### PR TITLE
Integrate `fetch-mock` into describes.js

### DIFF
--- a/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
@@ -110,6 +110,7 @@ describe.configure().ifNewChrome().run('Bind', function() {
         ampdoc: 'fie',
         runtimeOn: false,
       },
+      mockFetches: false,
     }, env => {
       let bind;
       let container;
@@ -175,6 +176,7 @@ describe.configure().ifNewChrome().run('Bind', function() {
       ampdoc: 'shadow',
       runtimeOn: false,
     },
+    mockFetches: false,
   }, env => {
     let bind;
     let container;
@@ -201,6 +203,7 @@ describe.configure().ifNewChrome().run('Bind', function() {
       ampdoc: 'single',
       runtimeOn: false,
     },
+    mockFetches: false,
   }, env => {
     let bind;
     let container;

--- a/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
@@ -110,7 +110,7 @@ describe.configure().ifNewChrome().run('Bind', function() {
         ampdoc: 'fie',
         runtimeOn: false,
       },
-      mockFetches: false,
+      mockFetch: false,
     }, env => {
       let bind;
       let container;
@@ -176,7 +176,7 @@ describe.configure().ifNewChrome().run('Bind', function() {
       ampdoc: 'shadow',
       runtimeOn: false,
     },
-    mockFetches: false,
+    mockFetch: false,
   }, env => {
     let bind;
     let container;
@@ -203,7 +203,7 @@ describe.configure().ifNewChrome().run('Bind', function() {
       ampdoc: 'single',
       runtimeOn: false,
     },
-    mockFetches: false,
+    mockFetch: false,
   }, env => {
     let bind;
     let container;

--- a/extensions/amp-form/0.1/test/integration/test-integration-form.js
+++ b/extensions/amp-form/0.1/test/integration/test-integration-form.js
@@ -30,6 +30,7 @@ describes.realWin('AmpForm Integration', {
     runtimeOn: true,
     ampdoc: 'single',
   },
+  mockFetch: false,
 }, env => {
   const baseUrl = 'http://localhost:31862';
   let doc;

--- a/extensions/amp-form/0.1/test/integration/test-integration-form.js
+++ b/extensions/amp-form/0.1/test/integration/test-integration-form.js
@@ -29,7 +29,6 @@ describes.realWin('AmpForm Integration', {
   amp: {
     runtimeOn: true,
     ampdoc: 'single',
-    mockFetches: false,
   },
 }, env => {
   const baseUrl = 'http://localhost:31862';

--- a/extensions/amp-form/0.1/test/integration/test-integration-form.js
+++ b/extensions/amp-form/0.1/test/integration/test-integration-form.js
@@ -29,6 +29,7 @@ describes.realWin('AmpForm Integration', {
   amp: {
     runtimeOn: true,
     ampdoc: 'single',
+    mockFetches: false,
   },
 }, env => {
   const baseUrl = 'http://localhost:31862';

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "eslint": "3.18.0",
     "eslint-plugin-google-camelcase": "0.0.2",
     "express": "4.14.0",
-    "fetch-mock": "^5.12.2",
+    "fetch-mock": "5.12.2",
     "file-reader": "1.1.1",
     "formidable": "1.0.17",
     "fs-extra": "0.27.0",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "eslint": "3.18.0",
     "eslint-plugin-google-camelcase": "0.0.2",
     "express": "4.14.0",
+    "fetch-mock": "^5.12.2",
     "file-reader": "1.1.1",
     "formidable": "1.0.17",
     "fs-extra": "0.27.0",

--- a/test/functional/test-describes.js
+++ b/test/functional/test-describes.js
@@ -14,10 +14,7 @@
  * limitations under the License.
  */
 
-/**
- * @fileoverview Tests `fetch-mock` integration in describes.js.
- */
-
+// Test `fetch-mock` integration in describes.
 describe('fetch-mock', () => {
   describes.realWin('on realWin', {
     mockFetches: true,

--- a/test/functional/test-describes.js
+++ b/test/functional/test-describes.js
@@ -16,9 +16,8 @@
 
 // Test `fetch-mock` integration in describes.
 describe('fetch-mock', () => {
-  describes.realWin('on realWin', {
-    mockFetches: true,
-  }, env => {
+  /** @param {!Object} env */
+  function runTests(env) {
     it('should mock fetches', () => {
       const mock = env.expectFetch('fake.com', {payload: 'foo'});
 
@@ -29,20 +28,17 @@ describe('fetch-mock', () => {
         expect(mock.called('fake.com')).to.be.true;
       });
     });
+  }
+
+  describes.realWin('on realWin', {
+    mockFetches: true,
+  }, env => {
+    runTests(env);
   });
 
   describes.fakeWin('on fakeWin', {
     mockFetches: true,
   }, env => {
-    it('should mock fetches', () => {
-      env.expectFetch('fake.com', {payload: 'foo'});
-
-      return env.win.fetch('fake.com').then(response => {
-        return response.json();
-      }).then(data => {
-        expect(data.payload).to.equal('foo');
-        expect(mock.called('fake.com')).to.be.true;
-      });
-    });
+    runTests(env);
   });
 });

--- a/test/functional/test-describes.js
+++ b/test/functional/test-describes.js
@@ -31,13 +31,13 @@ describe('fetch-mock', () => {
   }
 
   describes.realWin('on realWin', {
-    mockFetches: true,
+    mockFetch: true,
   }, env => {
     runTests(env);
   });
 
   describes.fakeWin('on fakeWin', {
-    mockFetches: true,
+    mockFetch: true,
   }, env => {
     runTests(env);
   });

--- a/test/functional/test-fetch-mock-in-describes.js
+++ b/test/functional/test-fetch-mock-in-describes.js
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Tests `fetch-mock` integration in describes.js.
+ */
+
+describe('fetch-mock', () => {
+  describes.realWin('on realWin', {
+    mockFetches: true,
+  }, env => {
+    it('should mock fetches', () => {
+      const mock = env.expectFetch('fake.com', {payload: 'foo'});
+
+      return env.win.fetch('fake.com').then(response => {
+        return response.json();
+      }).then(data => {
+        expect(data.payload).to.equal('foo');
+        expect(mock.called('fake.com')).to.be.true;
+      });
+    });
+  });
+
+  describes.fakeWin('on fakeWin', {
+    mockFetches: true,
+  }, env => {
+    it('should mock fetches', () => {
+      env.expectFetch('fake.com', {payload: 'foo'});
+
+      return env.win.fetch('fake.com').then(response => {
+        return response.json();
+      }).then(data => {
+        expect(data.payload).to.equal('foo');
+        expect(mock.called('fake.com')).to.be.true;
+      });
+    });
+  });
+});

--- a/testing/describes.js
+++ b/testing/describes.js
@@ -285,10 +285,16 @@ export const repeated = (function() {
 })();
 
 
-/** @param {!Object} env */
+/**
+ * Mocks Window.fetch in the given environment and exposes fetch-mock's mock()
+ * function as `env.expectFetch(matcher, response)`.
+ * @param {!Object} env
+ * @see http://www.wheresrhys.co.uk/fetch-mock/quickstart
+ */
 function attachFetchMock(env) {
   fetchMock.constructor.global = env.win;
   fetchMock._mock();
+
   env.expectFetch = fetchMock.mock.bind(fetchMock);
 }
 
@@ -505,14 +511,14 @@ class FakeWinFixture {
   setup(env) {
     env.win = new FakeWindow(this.spec.win || {});
 
-    if (this.spec.mockFetches !== false) {
+    if (this.spec.mockFetch !== false) {
       attachFetchMock(env);
     }
   }
 
   /** @override */
   teardown(env) {
-    if (this.spec.mockFetches !== false) {
+    if (this.spec.mockFetch !== false) {
       fetchMock./*OK*/restore();
     }
   }
@@ -590,7 +596,7 @@ class RealWinFixture {
         interceptEventListeners(win.document.body);
         env.interceptEventListeners = interceptEventListeners;
 
-        if (spec.mockFetches !== false) {
+        if (spec.mockFetch !== false) {
           attachFetchMock(env);
         }
 
@@ -607,7 +613,7 @@ class RealWinFixture {
     if (env.iframe.parentNode) {
       env.iframe.parentNode.removeChild(env.iframe);
     }
-    if (this.spec.mockFetches !== false) {
+    if (this.spec.mockFetch !== false) {
       fetchMock./*OK*/restore();
     }
   }

--- a/testing/describes.js
+++ b/testing/describes.js
@@ -505,14 +505,14 @@ class FakeWinFixture {
   setup(env) {
     env.win = new FakeWindow(this.spec.win || {});
 
-    if (!!this.spec.mockFetches) {
+    if (this.spec.mockFetches !== false) {
       attachFetchMock(env);
     }
   }
 
   /** @override */
   teardown(env) {
-    if (!!this.spec.mockFetches) {
+    if (this.spec.mockFetches !== false) {
       fetchMock./*OK*/restore();
     }
   }
@@ -590,7 +590,7 @@ class RealWinFixture {
         interceptEventListeners(win.document.body);
         env.interceptEventListeners = interceptEventListeners;
 
-        if (!!spec.mockFetches) {
+        if (spec.mockFetches !== false) {
           attachFetchMock(env);
         }
 
@@ -607,7 +607,7 @@ class RealWinFixture {
     if (env.iframe.parentNode) {
       env.iframe.parentNode.removeChild(env.iframe);
     }
-    if (!!this.spec.mockFetches) {
+    if (this.spec.mockFetches !== false) {
       fetchMock./*OK*/restore();
     }
   }

--- a/testing/describes.js
+++ b/testing/describes.js
@@ -513,7 +513,7 @@ class FakeWinFixture {
   /** @override */
   teardown(env) {
     if (!!this.spec.mockFetches) {
-      fetchMock.restore();
+      fetchMock./*OK*/restore();
     }
   }
 }
@@ -608,7 +608,7 @@ class RealWinFixture {
       env.iframe.parentNode.removeChild(env.iframe);
     }
     if (!!this.spec.mockFetches) {
-      fetchMock.restore();
+      fetchMock./*OK*/restore();
     }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2793,6 +2793,12 @@ encodeurl@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.1.tgz#79e3d58655346909fe6f0f45a5de68103b294d20"
 
+encoding@^0.1.11:
+  version "0.1.12"
+  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
+  dependencies:
+    iconv-lite "~0.4.13"
+
 end-of-stream@1.0.0, end-of-stream@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.0.0.tgz#d4596e702734a93e40e9af864319eabd99ff2f0e"
@@ -3272,6 +3278,14 @@ fd-slicer@~1.0.1:
   dependencies:
     pend "~1.2.0"
 
+fetch-mock@^5.12.2:
+  version "5.12.2"
+  resolved "https://registry.yarnpkg.com/fetch-mock/-/fetch-mock-5.12.2.tgz#07fde6b71f718328b4ce9b81c82a7c11c05d9748"
+  dependencies:
+    glob-to-regexp "^0.3.0"
+    node-fetch "^1.3.3"
+    path-to-regexp "^1.7.0"
+
 figures@^1.3.5, figures@^1.4.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
@@ -3627,6 +3641,10 @@ glob-stream@^3.1.5:
     ordered-read-streams "^0.1.0"
     through2 "^0.6.1"
     unique-stream "^1.0.0"
+
+glob-to-regexp@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
 
 glob-watcher@^0.0.6:
   version "0.0.6"
@@ -4322,6 +4340,10 @@ iconv-lite@0.4.15, iconv-lite@^0.4.5:
 iconv-lite@0.4.4:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.4.tgz#e95f2e41db0735fc21652f7827a5ee32e63c83a8"
+
+iconv-lite@~0.4.13:
+  version "0.4.18"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.18.tgz#23d8656b16aae6742ac29732ea8f0336a4789cf2"
 
 ieee754@^1.1.4:
   version "1.1.8"
@@ -5937,6 +5959,13 @@ nested-error-stacks@^1.0.0:
   dependencies:
     inherits "~2.0.1"
 
+node-fetch@^1.3.3:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.2.tgz#c54e9aac57e432875233525f3c891c4159ffefd7"
+  dependencies:
+    encoding "^0.1.11"
+    is-stream "^1.0.1"
+
 node-pre-gyp@^0.6.29:
   version "0.6.32"
   resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.6.32.tgz#fc452b376e7319b3d255f5f34853ef6fd8fe1fd5"
@@ -6414,6 +6443,12 @@ path-root@^0.1.1:
 path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
+
+path-to-regexp@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
+  dependencies:
+    isarray "0.0.1"
 
 path-type@^1.0.0:
   version "1.1.0"


### PR DESCRIPTION
Fixes #10477. Forked from #10776.

- Adds new `fetch-mock` dev dependency: https://github.com/wheresrhys/fetch-mock
- Integrates it into `describes.fakeWin` and `describes.realWin` and **enabled by default!**

```js
describes.realWin('fetch-mock', {}, env => {
  it('should mock fetches', function() {
    const mock = env.expectFetch('fake.com');

    return env.win.fetch('fake.com').then(response => {
      expect(mock.called('fake.com')).to.be.true;
    });
  });
});
```

See `test-describes.js` and [this documentation](http://www.wheresrhys.co.uk/fetch-mock/quickstart) for example usage and details. To disable, add `fetchMock: false` to `spec` object.
