### PR TITLE
Wrote Test For Toggling amp-img's place holder on failure to load.

### DIFF
--- a/test/functional/test-amp-img.js
+++ b/test/functional/test-amp-img.js
@@ -241,6 +241,27 @@ describe('amp-img', () => {
       });
     });
 
+    it('should hide child placeholder elements if loading fails', () => {
+      sandbox.stub(impl, 'loadPromise').returns(Promise.reject());
+      const errorSpy = sandbox.spy(impl, 'onImgLoadingError_');
+      const toggleSpy = sandbox.spy(impl, 'toggleFallback');
+      const togglePlaceholderSpy = sandbox.spy(impl, 'togglePlaceholder');
+      impl.buildCallback();
+      expect(errorSpy).to.have.not.been.called;
+      expect(toggleSpy).to.have.not.been.called;
+      expect(togglePlaceholderSpy).to.have.not.been.called;
+      expect(toggleElSpy).to.have.not.been.called;
+
+      return impl.layoutCallback().catch(() => {
+        expect(errorSpy).to.be.calledOnce;
+        expect(toggleSpy).to.be.calledOnce;
+        expect(toggleSpy.firstCall.args[0]).to.be.true;
+        expect(togglePlaceholderSpy).to.be.calledOnce;
+        expect(togglePlaceholderSpy.firstCall.args[0]).to.be.false; 
+        expect(toggleElSpy.firstCall.args[0]).to.be.true;
+      });
+    });
+
     it('should fallback only once', () => {
       const loadStub = sandbox.stub(impl, 'loadPromise');
       loadStub

--- a/test/functional/test-amp-img.js
+++ b/test/functional/test-amp-img.js
@@ -257,7 +257,7 @@ describe('amp-img', () => {
         expect(toggleSpy).to.be.calledOnce;
         expect(toggleSpy.firstCall.args[0]).to.be.true;
         expect(togglePlaceholderSpy).to.be.calledOnce;
-        expect(togglePlaceholderSpy.firstCall.args[0]).to.be.false; 
+        expect(togglePlaceholderSpy.firstCall.args[0]).to.be.false;
         expect(toggleElSpy.firstCall.args[0]).to.be.true;
       });
     });


### PR DESCRIPTION
As promised!

Closes #10707 . This is in relation to the PR #10701 that I fixed a little while ago.

# Tests Passing

<img width="633" alt="screen shot 2017-08-18 at 11 34 13 pm" src="https://user-images.githubusercontent.com/1448289/29484178-01b9d3cc-846e-11e7-91f6-e96c38746f42.png">
