### PR TITLE
AdSense Fast Fetch, Delayed Request Unconditioned Experiment

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -3,7 +3,7 @@
   "allow-url-opt-in": ["pump-early-frame"],
 
   "canary": 1,
-  "expAdsenseA4A": 0.02,
+  "expAdsenseA4A": 0.01,
   "expDoubleclickA4A": 0.01,
   "a4aProfilingRate": 1,
   "dbclk_a4a_viz_change": 0.02,

--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -3,7 +3,7 @@
   "allow-url-opt-in": ["pump-early-frame"],
 
   "canary": 1,
-  "expAdsenseA4A": 0.01,
+  "expAdsenseA4A": 0.02,
   "expDoubleclickA4A": 0.01,
   "a4aProfilingRate": 1,
   "dbclk_a4a_viz_change": 0.02,

--- a/extensions/amp-ad-network-adsense-impl/0.1/adsense-a4a-config.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/adsense-a4a-config.js
@@ -34,7 +34,7 @@ import {
 } from '../../../src/experiments';
 import {dev} from '../../../src/log';
 
-/** @const {!string}  @private */
+/** @const {!string} */
 export const ADSENSE_A4A_EXPERIMENT_NAME = 'expAdsenseA4A';
 
 /** @type {string} */
@@ -44,10 +44,12 @@ const TAG = 'amp-ad-network-adsense-impl';
 export const ADSENSE_EXPERIMENT_FEATURE = {
   HOLDBACK_EXTERNAL_CONTROL: '21060732',
   HOLDBACK_EXTERNAL: '21060733',
-  DELAYED_REQUEST_CONTROL: '21060734',
-  DELAYED_REQUEST: '21060735',
+  DELAYED_REQUEST_EXTERNAL_CONTROL: '21060734',
+  DELAYED_REQUEST_EXTERNAL: '21060735',
   HOLDBACK_INTERNAL_CONTROL: '2092615',
   HOLDBACK_INTERNAL: '2092616',
+  DELAYED_REQUEST_INTERNAL_CONTROL: '21060901',
+  DELAYED_REQUEST_INTERNAL: '21060902',
 };
 
 /** @const @type {!Object<string,?string>} */
@@ -58,8 +60,8 @@ export const URL_EXPERIMENT_MAPPING = {
   '1': ADSENSE_EXPERIMENT_FEATURE.HOLDBACK_EXTERNAL_CONTROL,
   '2': ADSENSE_EXPERIMENT_FEATURE.HOLDBACK_EXTERNAL,
   // Delay Request
-  '3': ADSENSE_EXPERIMENT_FEATURE.DELAYED_REQUEST_CONTROL,
-  '4': ADSENSE_EXPERIMENT_FEATURE.DELAYED_REQUEST,
+  '3': ADSENSE_EXPERIMENT_FEATURE.DELAYED_REQUEST_EXTERNAL_CONTROL,
+  '4': ADSENSE_EXPERIMENT_FEATURE.DELAYED_REQUEST_EXTERNAL,
 };
 
 /**
@@ -80,13 +82,18 @@ export function adsenseIsA4AEnabled(win, element) {
     dev().info(
         TAG, `url experiment selection ${urlExperimentId}: ${experimentId}.`);
   } else {
-    // Not set via url so randomly set.
+    // Not set via url so randomly set.  Delayed request experiment run in
+    // same layer as client-side holdback to ensure mutual exclusion.
     const experimentInfoMap =
         /** @type {!Object<string, !ExperimentInfo>} */ ({});
     experimentInfoMap[ADSENSE_A4A_EXPERIMENT_NAME] = {
       isTrafficEligible: () => true,
-      branches: [ADSENSE_EXPERIMENT_FEATURE.HOLDBACK_INTERNAL_CONTROL,
-        ADSENSE_EXPERIMENT_FEATURE.HOLDBACK_INTERNAL],
+      branches: [
+        ADSENSE_EXPERIMENT_FEATURE.HOLDBACK_INTERNAL_CONTROL,
+        ADSENSE_EXPERIMENT_FEATURE.HOLDBACK_INTERNAL,
+        ADSENSE_EXPERIMENT_FEATURE.DELAYED_REQUEST_INTERNAL_CONTROL,
+        ADSENSE_EXPERIMENT_FEATURE.DELAYED_REQUEST_INTERNAL,
+      ],
     };
     // Note: Because the same experimentName is being used everywhere here,
     // randomlySelectUnsetExperiments won't add new IDs if
@@ -96,6 +103,7 @@ export function adsenseIsA4AEnabled(win, element) {
     experimentId = getExperimentBranch(win, ADSENSE_A4A_EXPERIMENT_NAME);
     dev().info(
         TAG, `random experiment selection ${urlExperimentId}: ${experimentId}`);
+
   }
   if (experimentId) {
     addExperimentIdToElement(experimentId, element);

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -21,10 +21,7 @@
 // extensions/amp-ad-network-${NETWORK_NAME}-impl directory.
 
 import {AmpA4A} from '../../amp-a4a/0.1/amp-a4a';
-import {
-  experimentFeatureEnabled,
-  ADSENSE_EXPERIMENT_FEATURE,
-} from './adsense-a4a-config';
+import {fastFetchDelayedRequestEnabled} from './adsense-a4a-config';
 import {
   isInManualExperiment,
 } from '../../../ads/google/a4a/traffic-experiments';
@@ -138,10 +135,7 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
 
   /** @override */
   delayAdRequestEnabled() {
-    return experimentFeatureEnabled(
-        this.win, ADSENSE_EXPERIMENT_FEATURE.DELAYED_REQUEST_EXTERNAL) ||
-        experimentFeatureEnabled(
-            this.win, ADSENSE_EXPERIMENT_FEATURE.DELAYED_REQUEST_INTERNAL);
+    return fastFetchDelayedRequestEnabled(this.win);
   }
 
   /** @override */

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -139,7 +139,9 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
   /** @override */
   delayAdRequestEnabled() {
     return experimentFeatureEnabled(
-        this.win, ADSENSE_EXPERIMENT_FEATURE.DELAYED_REQUEST);
+        this.win, ADSENSE_EXPERIMENT_FEATURE.DELAYED_REQUEST_EXTERNAL) ||
+        experimentFeatureEnabled(
+            this.win, ADSENSE_EXPERIMENT_FEATURE.DELAYED_REQUEST_INTERNAL);
   }
 
   /** @override */

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-adsense-a4a-config.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-adsense-a4a-config.js
@@ -17,8 +17,11 @@
 import {
   adsenseIsA4AEnabled,
   ADSENSE_A4A_EXPERIMENT_NAME,
+  FF_DR_EXP_NAME,
   ADSENSE_EXPERIMENT_FEATURE,
+  INTERNAL_FAST_FETCH_DELAY_REQUEST_EXP,
   URL_EXPERIMENT_MAPPING,
+  fastFetchDelayedRequestEnabled,
 } from '../adsense-a4a-config';
 import {
   isInExperiment,
@@ -121,6 +124,37 @@ describe('adsense-a4a-config', () => {
       testFixture.doc.body.appendChild(elem);
       expect(adsenseIsA4AEnabled(mockWin, elem)).to.be.true;
       expect(elem.getAttribute(EXPERIMENT_ATTRIBUTE)).to.equal('2092615');
+    });
+  });
+
+  describe('#fastFetchDelayedRequestEnabled', () => {
+    Object.entries({
+      [ADSENSE_EXPERIMENT_FEATURE.DELAYED_REQUEST_EXTERNAL_CONTROL]: {
+        layer: ADSENSE_A4A_EXPERIMENT_NAME,
+        result: false,
+      },
+      [ADSENSE_EXPERIMENT_FEATURE.DELAYED_REQUEST_EXTERNAL]: {
+        layer: ADSENSE_A4A_EXPERIMENT_NAME,
+        result: true,
+      },
+      [INTERNAL_FAST_FETCH_DELAY_REQUEST_EXP.CONTROL]: {
+        layer: FF_DR_EXP_NAME,
+        result: false,
+      },
+      [INTERNAL_FAST_FETCH_DELAY_REQUEST_EXP.EXPERIMENT]: {
+        layer: FF_DR_EXP_NAME,
+        result: true,
+      },
+    }).forEach(item => {
+      it(`should return ${item[1].result} if in ${item[0]} experiment`, () => {
+        forceExperimentBranch(mockWin, item[1].layer, item[0]);
+        expect(fastFetchDelayedRequestEnabled(mockWin)).to.equal(
+            item[1].result);
+      });
+    });
+
+    it('should return false if not in any experiments', () => {
+      expect(fastFetchDelayedRequestEnabled(mockWin)).to.be.false;
     });
   });
 });

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
@@ -21,7 +21,9 @@ import {
 } from '../amp-ad-network-adsense-impl';
 import {
   ADSENSE_A4A_EXPERIMENT_NAME,
+  FF_DR_EXP_NAME,
   ADSENSE_EXPERIMENT_FEATURE,
+  INTERNAL_FAST_FETCH_DELAY_REQUEST_EXP,
 } from '../adsense-a4a-config';
 import {
   installExtensionsService,
@@ -564,14 +566,26 @@ describes.realWin('amp-ad-network-adsense-impl', {
     });
 
     Object.entries({
-      [ADSENSE_EXPERIMENT_FEATURE.DELAYED_REQUEST_EXTERNAL_CONTROL]: false,
-      [ADSENSE_EXPERIMENT_FEATURE.DELAYED_REQUEST_EXTERNAL]: true,
-      [ADSENSE_EXPERIMENT_FEATURE.DELAYED_REQUEST_INTERNAL_CONTROL]: false,
-      [ADSENSE_EXPERIMENT_FEATURE.DELAYED_REQUEST_INTERNAL]: true,
+      [ADSENSE_EXPERIMENT_FEATURE.DELAYED_REQUEST_EXTERNAL_CONTROL]: {
+        layer: ADSENSE_A4A_EXPERIMENT_NAME,
+        result: false,
+      },
+      [ADSENSE_EXPERIMENT_FEATURE.DELAYED_REQUEST_EXTERNAL]: {
+        layer: ADSENSE_A4A_EXPERIMENT_NAME,
+        result: true,
+      },
+      [INTERNAL_FAST_FETCH_DELAY_REQUEST_EXP.CONTROL]: {
+        layer: FF_DR_EXP_NAME,
+        result: false,
+      },
+      [INTERNAL_FAST_FETCH_DELAY_REQUEST_EXP.EXPERIMENT]: {
+        layer: FF_DR_EXP_NAME,
+        result: true,
+      },
     }).forEach(item => {
-      it(`should return ${item[1]} if in ${item[0]} experiment`, () => {
-        forceExperimentBranch(impl.win, ADSENSE_A4A_EXPERIMENT_NAME, item[0]);
-        expect(impl.delayAdRequestEnabled()).to.equal(item[1]);
+      it(`should return ${item[1].result} if in ${item[0]} experiment`, () => {
+        forceExperimentBranch(impl.win, item[1].layer, item[0]);
+        expect(impl.delayAdRequestEnabled()).to.equal(item[1].result);
       });
     });
 

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
@@ -563,13 +563,19 @@ describes.realWin('amp-ad-network-adsense-impl', {
         }));
     });
 
-    it('should return true if in experiment', () => {
-      forceExperimentBranch(impl.win, ADSENSE_A4A_EXPERIMENT_NAME,
-          ADSENSE_EXPERIMENT_FEATURE.DELAYED_REQUEST);
-      expect(impl.delayAdRequestEnabled()).to.be.true;
+    Object.entries({
+      [ADSENSE_EXPERIMENT_FEATURE.DELAYED_REQUEST_EXTERNAL_CONTROL]: false,
+      [ADSENSE_EXPERIMENT_FEATURE.DELAYED_REQUEST_EXTERNAL]: true,
+      [ADSENSE_EXPERIMENT_FEATURE.DELAYED_REQUEST_INTERNAL_CONTROL]: false,
+      [ADSENSE_EXPERIMENT_FEATURE.DELAYED_REQUEST_INTERNAL]: true,
+    }).forEach(item => {
+      it(`should return ${item[1]} if in ${item[0]} experiment`, () => {
+        forceExperimentBranch(impl.win, ADSENSE_A4A_EXPERIMENT_NAME, item[0]);
+        expect(impl.delayAdRequestEnabled()).to.equal(item[1]);
+      });
     });
 
-    it('should return false if not in experiment', () => {
+    it('should return false if not in any experiments', () => {
       expect(impl.delayAdRequestEnabled()).to.be.false;
     });
   });

--- a/src/experiments.js
+++ b/src/experiments.js
@@ -461,7 +461,7 @@ export function randomlySelectUnsetExperiments(win, experiments) {
  *     null if experimentName has been tested but no branch was enabled).
  */
 export function getExperimentBranch(win, experimentName) {
-  return win.experimentBranches[experimentName];
+  return win.experimentBranches ? win.experimentBranches[experimentName] : null;
 }
 
 /**


### PR DESCRIPTION
To track impact across all AdSense traffic (in addition to existing SERP diverted experiment).  This will include delayed fetch traffic and be selected prior to url based diversion causing some pollution of other experiments.