### PR TITLE
Enable 1% experiment fraction for AdSense Fast Fetch, Delayed Request

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -5,6 +5,7 @@
   "canary": 1,
   "expAdsenseA4A": 0.01,
   "expDoubleclickA4A": 0.01,
+  "expAdSenseFFDR": 0.01,
   "a4aProfilingRate": 1,
   "dbclk_a4a_viz_change": 0.02,
   "ad-type-custom": 1,

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -5,6 +5,7 @@
   "canary": 0,
   "expAdsenseA4A": 0.01,
   "expDoubleclickA4A": 0.01,
+  "expAdSenseFFDR": 0.01,
   "dbclk_a4a_viz_change": 0.02,
   "a4aProfilingRate": 0.1,
   "ad-type-custom": 1,


### PR DESCRIPTION
Set to 1% of canary and production (See #11021)