### PR TITLE
Add Fast Fetch support to canonical AMP pages for DoubleClick

### DIFF
--- a/ads/google/a4a/utils.js
+++ b/ads/google/a4a/utils.js
@@ -78,7 +78,7 @@ export const TRUNCATION_PARAM = {name: 'trunc', value: '1'};
 /**
  * Check whether Google Ads supports the A4A rendering pathway is valid for the
  * environment by ensuring native crypto support and page originated in the
- * the {@code cdn.ampproject.org} CDN <em>or</em> we must be running in local
+ * {@code cdn.ampproject.org} CDN <em>or</em> we must be running in local
  * dev mode.
  *
  * @param {!Window} win  Host window for the ad.
@@ -86,6 +86,19 @@ export const TRUNCATION_PARAM = {name: 'trunc', value: '1'};
  *   pathway.
  */
 export function isGoogleAdsA4AValidEnvironment(win) {
+  const googleCdnProxyRegex =
+      /^https:\/\/([a-zA-Z0-9_-]+\.)?cdn\.ampproject\.org/;
+  return supportsNativeCrypto(win) && (
+      !!googleCdnProxyRegex.test(win.location.origin) ||
+        getMode(win).localDev || getMode(win).test);
+}
+
+/**
+ * Checks whether native crypto is supported for win.
+ * @param {!Window} win  Host window for the ad.
+ * @returns {boolean} Whether native crypto is supported.
+ */
+export function supportsNativeCrypto(win) {
   return win.crypto && (win.crypto.subtle || win.crypto.webkitSubtle);
 }
 

--- a/ads/google/a4a/utils.js
+++ b/ads/google/a4a/utils.js
@@ -87,7 +87,7 @@ export const TRUNCATION_PARAM = {name: 'trunc', value: '1'};
  */
 export function isGoogleAdsA4AValidEnvironment(win) {
   const googleCdnProxyRegex =
-      /^https:\/\/([a-zA-Z0-9_-]+\.)?cdn\.ampproject\.org/;
+        /^https:\/\/([a-zA-Z0-9_-]+\.)?cdn\.ampproject\.org((\/.*)|($))+/;
   return supportsNativeCrypto(win) && (
       !!googleCdnProxyRegex.test(win.location.origin) ||
         getMode(win).localDev || getMode(win).test);

--- a/ads/google/a4a/utils.js
+++ b/ads/google/a4a/utils.js
@@ -86,13 +86,7 @@ export const TRUNCATION_PARAM = {name: 'trunc', value: '1'};
  *   pathway.
  */
 export function isGoogleAdsA4AValidEnvironment(win) {
-  const supportsNativeCrypto = win.crypto &&
-      (win.crypto.subtle || win.crypto.webkitSubtle);
-  const googleCdnProxyRegex =
-      /^https:\/\/([a-zA-Z0-9_-]+\.)?cdn\.ampproject\.org/;
-  return supportsNativeCrypto &&
-      (googleCdnProxyRegex.test(win.location.origin) || getMode(win).localDev ||
-       getMode(win).test);
+  return win.crypto && (win.crypto.subtle || win.crypto.webkitSubtle);
 }
 
 /**

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
@@ -124,7 +124,7 @@ export class DoubleclickA4aEligibility {
     }
     let experimentName = DFP_CANONICAL_FF_EXPERIMENT_NAME;
     if (!this.isCdnProxy(win)) {
-      experimentId = this.maybeSelectExperiment(win, element, [
+      experimentId = this.maybeSelectExperiment_(win, element, [
         DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_CONTROL,
         DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_EXPERIMENT,
       ], DFP_CANONICAL_FF_EXPERIMENT_NAME);
@@ -143,7 +143,7 @@ export class DoubleclickA4aEligibility {
             TAG,
             `url experiment selection ${urlExperimentId}: ${experimentId}.`);
       } else {
-        experimentId = this.maybeSelectExperiment(win, element, [
+        experimentId = this.maybeSelectExperiment_(win, element, [
           DOUBLECLICK_EXPERIMENT_FEATURE.HOLDBACK_INTERNAL_CONTROL,
           DOUBLECLICK_EXPERIMENT_FEATURE.HOLDBACK_INTERNAL],
             DOUBLECLICK_A4A_EXPERIMENT_NAME);
@@ -164,12 +164,12 @@ export class DoubleclickA4aEligibility {
   /**
    * @param {!Window} win
    * @param {!Element} element
-   * @param {!Array} selectionBranches
+   * @param {!Array<string>} selectionBranches
    * @param {!string} experimentName}
    * @return {?string} Experiment branch ID or null if not selected.
    * @private
    */
-  maybeSelectExperiment(win, element, selectionBranches, experimentName) {
+  maybeSelectExperiment_(win, element, selectionBranches, experimentName) {
     const experimentInfoMap =
         /** @type {!Object<string, !ExperimentInfo>} */ ({});
     experimentInfoMap[experimentName] = {

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
@@ -51,6 +51,8 @@ export const DOUBLECLICK_EXPERIMENT_FEATURE = {
   SRA: '117152667',
   HOLDBACK_INTERNAL_CONTROL: '2092613',
   HOLDBACK_INTERNAL: '2092614',
+  CANONICAL_CONTROL: '21060932',
+  CANONICAL_EXPERIMENT: '21060933'
 };
 
 /** @const @type {!Object<string,?string>} */
@@ -107,7 +109,10 @@ export function doubleclickIsA4AEnabled(win, element) {
     experimentInfoMap[DOUBLECLICK_A4A_EXPERIMENT_NAME] = {
       isTrafficEligible: () => true,
       branches: [DOUBLECLICK_EXPERIMENT_FEATURE.HOLDBACK_INTERNAL_CONTROL,
-        DOUBLECLICK_EXPERIMENT_FEATURE.HOLDBACK_INTERNAL],
+                 DOUBLECLICK_EXPERIMENT_FEATURE.HOLDBACK_INTERNAL,
+                 DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_CONTROL,
+                 DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_EXPERIMENT
+                ],
     };
     // Note: Because the same experimentName is being used everywhere here,
     // randomlySelectUnsetExperiments won't add new IDs if
@@ -123,9 +128,11 @@ export function doubleclickIsA4AEnabled(win, element) {
     forceExperimentBranch(win, DOUBLECLICK_A4A_EXPERIMENT_NAME, experimentId);
   }
   return ![DOUBLECLICK_EXPERIMENT_FEATURE.HOLDBACK_EXTERNAL,
-    DOUBLECLICK_EXPERIMENT_FEATURE.HOLDBACK_INTERNAL,
-    DOUBLECLICK_EXPERIMENT_FEATURE.SFG_CONTROL_ID,
-    DOUBLECLICK_EXPERIMENT_FEATURE.SFG_EXP_ID].includes(experimentId);
+           DOUBLECLICK_EXPERIMENT_FEATURE.HOLDBACK_INTERNAL,
+           DOUBLECLICK_EXPERIMENT_FEATURE.SFG_CONTROL_ID,
+           DOUBLECLICK_EXPERIMENT_FEATURE.SFG_EXP_ID,
+           DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_EXPERIMENT
+          ].includes(experimentId);
 }
 
 /**

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
@@ -161,7 +161,8 @@ export class DoubleclickA4aEligibility {
    * @param {!Array} validBranches
    * @param {!string} experimentName}
    */
-  addAndForceExperiment(win, element, experimentId, validBranches, experimentName) {
+  addAndForceExperiment(win, element, experimentId, validBranches,
+                        experimentName) {
     if (experimentId) {
       addExperimentIdToElement(experimentId, element);
       forceExperimentBranch(win, experimentName, experimentId);
@@ -169,7 +170,8 @@ export class DoubleclickA4aEligibility {
     return experimentId ? !!validBranches.includes(experimentId) : true;
   }
 
-  selectExperiment(win, element, selectionBranches, validBranches, experimentName) {
+  selectExperiment(win, element, selectionBranches, validBranches,
+                   experimentName) {
     const experimentInfoMap =
         /** @type {!Object<string, !ExperimentInfo>} */ ({});
     experimentInfoMap[experimentName] = {

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-a4a-config.js
@@ -59,6 +59,8 @@ describe('doubleclick-a4a-config', () => {
 
   describe('#doubleclickIsA4AEnabled', () => {
     it('should enable a4a when native crypto is supported', () => {
+      forceExperimentBranch(mockWin, DFP_CANONICAL_FF_EXPERIMENT_NAME,
+          DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_EXPERIMENT);
       const elem = testFixture.doc.createElement('div');
       testFixture.doc.body.appendChild(elem);
       expect(doubleclickIsA4AEnabled(mockWin, elem)).to.be.true;

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-a4a-config.js
@@ -67,8 +67,8 @@ describe('doubleclick-a4a-config', () => {
     });
 
     it('should not enable a4a when native crypto is not supported', () => {
-      const instance = new DoubleclickA4aEligibility();
-      sandbox.stub(instance, 'supportsCrypto', () => false);
+      sandbox.stub(DoubleclickA4aEligibility.prototype,
+          'supportsCrypto', () => false);
       const elem = testFixture.doc.createElement('div');
       testFixture.doc.body.appendChild(elem);
       expect(doubleclickIsA4AEnabled(mockWin, elem)).to.be.false;
@@ -77,8 +77,8 @@ describe('doubleclick-a4a-config', () => {
     it('should select into canonical AMP experiment when not on CDN', () => {
       forceExperimentBranch(mockWin, DFP_CANONICAL_FF_EXPERIMENT_NAME,
           DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_EXPERIMENT);
-      const instance = new DoubleclickA4aEligibility();
-      sandbox.stub(instance, 'isCdnProxy', () => false);
+      sandbox.stub(DoubleclickA4aEligibility.prototype,
+          'isCdnProxy', () => false);
       const elem = testFixture.doc.createElement('div');
       testFixture.doc.body.appendChild(elem);
       expect(doubleclickIsA4AEnabled(mockWin, elem)).to.be.true;

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-a4a-config.js
@@ -18,9 +18,11 @@ import {
   doubleclickIsA4AEnabled,
   BETA_ATTRIBUTE,
   BETA_EXPERIMENT_ID,
+  DFP_CANONICAL_FF_EXPERIMENT_NAME,
   DOUBLECLICK_A4A_EXPERIMENT_NAME,
   DOUBLECLICK_EXPERIMENT_FEATURE,
   URL_EXPERIMENT_MAPPING,
+  DoubleclickA4aEligibility,
 } from '../doubleclick-a4a-config';
 import {
   isInExperiment,
@@ -56,33 +58,30 @@ describe('doubleclick-a4a-config', () => {
   });
 
   describe('#doubleclickIsA4AEnabled', () => {
-    it('should enable a4a when requested and on CDN', () => {
-      mockWin.location = parseUrl(
-          'https://cdn.ampproject.org/some/path/to/content.html');
+    it('should enable a4a when native crypto is supported', () => {
       const elem = testFixture.doc.createElement('div');
-      elem.setAttribute(BETA_ATTRIBUTE, 'true');
       testFixture.doc.body.appendChild(elem);
       expect(doubleclickIsA4AEnabled(mockWin, elem)).to.be.true;
-      expect(elem.getAttribute(EXPERIMENT_ATTRIBUTE)).to.equal(
-          BETA_EXPERIMENT_ID);
     });
 
-    it('should enable a4a when requested and in local dev', () => {
+    it('should not enable a4a when native crypto is not supported', () => {
+      const instance = new DoubleclickA4aEligibility();
+      sandbox.stub(instance, 'supportsCrypto', () => false);
       const elem = testFixture.doc.createElement('div');
-      elem.setAttribute(BETA_ATTRIBUTE, 'true');
-      mockWin.AMP_MODE = {localDev: true};
-      testFixture.doc.body.appendChild(elem);
-      expect(doubleclickIsA4AEnabled(mockWin, elem)).to.be.true;
-      expect(elem.getAttribute(EXPERIMENT_ATTRIBUTE)).to.equal(
-          BETA_EXPERIMENT_ID);
-    });
-
-    it('should not enable a4a, even if requested, when on bad origin', () => {
-      const elem = testFixture.doc.createElement('div');
-      elem.setAttribute(BETA_ATTRIBUTE, 'true');
       testFixture.doc.body.appendChild(elem);
       expect(doubleclickIsA4AEnabled(mockWin, elem)).to.be.false;
-      expect(elem.getAttribute(EXPERIMENT_ATTRIBUTE)).to.not.be.ok;
+    });
+
+    it('should select into canonical AMP experiment when not on CDN', () => {
+      forceExperimentBranch(mockWin, DFP_CANONICAL_FF_EXPERIMENT_NAME,
+          DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_EXPERIMENT);
+      const instance = new DoubleclickA4aEligibility();
+      sandbox.stub(instance, 'isCdnProxy', () => false);
+      const elem = testFixture.doc.createElement('div');
+      testFixture.doc.body.appendChild(elem);
+      expect(doubleclickIsA4AEnabled(mockWin, elem)).to.be.true;
+      expect(elem.getAttribute(EXPERIMENT_ATTRIBUTE)).to.equal(
+          DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_EXPERIMENT);
     });
 
     it('should not enable if data-use-same-domain-rendering-until-deprecated',


### PR DESCRIPTION
This change will start an experiment to add Fast Fetch support for Canonical AMP pages with DRX