### PR TITLE
reverting eq CSS changes

### DIFF
--- a/css/amp.css
+++ b/css/amp.css
@@ -604,14 +604,13 @@ i-amphtml-video-mask, i-amp-video-mask {
 }
 .amp-video-eq {
   align-items: flex-end;
-  border: transparent solid 7px;
-  bottom: 0;
+  bottom: 7px;
   display: flex;
   height: 12px;
   opacity: 0.8;
   overflow: hidden;
   position: absolute;
-  right: 0;
+  right: 7px;
   width: 20px;
   z-index: 1;
 }


### PR DESCRIPTION
reverting the css part of https://github.com/ampproject/amphtml/pull/10960/files, based on some canary testing, new rule does not play nice with some author-specified rules around box-sizing.

