### PR TITLE
Make credentialed preconnect in polyfill.

### DIFF
--- a/src/preconnect.js
+++ b/src/preconnect.js
@@ -285,10 +285,10 @@ class PreconnectService {
       const url = origin +
           '/amp_preconnect_polyfill_404_or_other_error_expected.' +
           '_Do_not_worry_about_it?' + cacheBust;
-      // We use an XHR without withCredentials(true), so we do not send cookies
-      // to the host and the host cannot set cookies.
       const xhr = new XMLHttpRequest();
       xhr.open('HEAD', url, true);
+      // We only support credentialed preconnect for now.
+      xhr.withCredentials = true;
 
       xhr.send();
     });

--- a/test/functional/test-preconnect.js
+++ b/test/functional/test-preconnect.js
@@ -20,7 +20,7 @@ import {preconnectForElement, setPreconnectFeaturesForTesting} from
 import * as sinon from 'sinon';
 import * as lolex from 'lolex';
 
-describe('preconnect', () => {
+describe.only('preconnect', () => {
 
   let sandbox;
   let iframeClock;

--- a/test/functional/test-preconnect.js
+++ b/test/functional/test-preconnect.js
@@ -20,7 +20,7 @@ import {preconnectForElement, setPreconnectFeaturesForTesting} from
 import * as sinon from 'sinon';
 import * as lolex from 'lolex';
 
-describe.only('preconnect', () => {
+describe('preconnect', () => {
 
   let sandbox;
   let iframeClock;


### PR DESCRIPTION
That way the browser can actually use the connection for the default request type.

The requests are guarded with the doc being visible.