### PR TITLE
Produce only one default bootstrap base URL per window.

### DIFF
--- a/src/3p-frame.js
+++ b/src/3p-frame.js
@@ -202,6 +202,7 @@ export function setDefaultBootstrapBaseUrlForTesting(url) {
 
 export function resetBootstrapBaseUrlForTesting(win) {
   win.bootstrapBaseUrl = undefined;
+  win.defaultBootstrapBaseUrl = undefined;
 }
 
 /**
@@ -211,18 +212,22 @@ export function resetBootstrapBaseUrlForTesting(win) {
  * @return {string}
  */
 export function getDefaultBootstrapBaseUrl(parentWindow, opt_srcFileBasename) {
+  if (parentWindow.defaultBootstrapBaseUrl) {
+    return parentWindow.defaultBootstrapBaseUrl;
+  }
   const srcFileBasename = opt_srcFileBasename || 'frame';
   if (getMode().localDev || getMode().test) {
     if (overrideBootstrapBaseUrl) {
-      return overrideBootstrapBaseUrl;
+      return parentWindow.defaultBootstrapBaseUrl = overrideBootstrapBaseUrl;
     }
-    return getAdsLocalhost(parentWindow)
+    return parentWindow.defaultBootstrapBaseUrl = getAdsLocalhost(parentWindow)
         + '/dist.3p/'
         + (getMode().minified ? `$internalRuntimeVersion$/${srcFileBasename}`
             : `current/${srcFileBasename}.max`)
         + '.html';
   }
-  return 'https://' + getSubDomain(parentWindow) +
+  return parentWindow.defaultBootstrapBaseUrl = 'https://' +
+      getSubDomain(parentWindow) +
       `.${urls.thirdPartyFrameHost}/$internalRuntimeVersion$/` +
       `${srcFileBasename}.html`;
 }

--- a/test/integration/test-3p-frame.js
+++ b/test/integration/test-3p-frame.js
@@ -18,6 +18,7 @@ import {
   addDataAndJsonAttributes_,
   getIframe,
   getBootstrapBaseUrl,
+  getDefaultBootstrapBaseUrl,
   getSubDomain,
   preloadBootstrap,
   resetCountForTesting,
@@ -268,6 +269,17 @@ describe.configure().ifNewChrome().run('3p-frame', () => {
     window.AMP_MODE = {};
     expect(getBootstrapBaseUrl(window)).to.match(
         /^https:\/\/d-\d+\.ampproject\.net\/\$\internal\w+\$\/frame\.html$/);
+  });
+
+  it('should return a stable URL in getBootstrapBaseUrl', () => {
+    window.AMP_MODE = {};
+    expect(getBootstrapBaseUrl(window)).to.equal(getBootstrapBaseUrl(window));
+  });
+
+  it('should return a stable URL in getDefaultBootstrapBaseUrl', () => {
+    window.AMP_MODE = {};
+    expect(getDefaultBootstrapBaseUrl(window)).to.equal(
+        getDefaultBootstrapBaseUrl(window));
   });
 
   it('should pick the right bootstrap url (custom)', () => {


### PR DESCRIPTION
This function needs to produce the same value for all calls in a window. It was originally not exported and its caller ensured the invariant.