### PR TITLE
Pass the doc to the getCorrelator function

### DIFF
--- a/ads/google/a4a/utils.js
+++ b/ads/google/a4a/utils.js
@@ -198,7 +198,7 @@ export function googlePageParameters(win, doc, startTime, output = 'html') {
           'is_amp': AmpAdImplementation.AMP_AD_XHR_TO_IFRAME_OR_AMP,
           'amp_v': '$internalRuntimeVersion$',
           'd_imp': '1',
-          'c': getCorrelator(win, clientId),
+          'c': getCorrelator(win, clientId, doc),
           'dt': startTime,
           output,
           'biw': viewportRect.width,

--- a/ads/google/a4a/utils.js
+++ b/ads/google/a4a/utils.js
@@ -177,28 +177,29 @@ export function groupAmpAdsByType(win, type, groupFn) {
 
 /**
  * @param {!Window} win
- * @param {!Node|!../../../src/service/ampdoc-impl.AmpDoc} doc
+ * @param {!Node|!../../../src/service/ampdoc-impl.AmpDoc} nodeOrDoc
  * @param {number} startTime
  * @param {string=} output default is 'html'
  * @return {!Promise<!Object<string,null|number|string>>}
  */
-export function googlePageParameters(win, doc, startTime, output = 'html') {
-  const referrerPromise = Services.viewerForDoc(doc).getReferrerUrl();
-  return getOrCreateAdCid(doc, 'AMP_ECID_GOOGLE', '_ga')
+export function googlePageParameters(
+    win, nodeOrDoc, startTime, output = 'html') {
+  const referrerPromise = Services.viewerForDoc(nodeOrDoc).getReferrerUrl();
+  return getOrCreateAdCid(nodeOrDoc, 'AMP_ECID_GOOGLE', '_ga')
       .then(clientId => referrerPromise.then(referrer => {
-        const documentInfo = Services.documentInfoForDoc(doc);
+        const documentInfo = Services.documentInfoForDoc(nodeOrDoc);
         // Read by GPT for GA/GPT integration.
         win.gaGlobal = win.gaGlobal ||
         {cid: clientId, hid: documentInfo.pageViewId};
         const screen = win.screen;
-        const viewport = Services.viewportForDoc(doc);
+        const viewport = Services.viewportForDoc(nodeOrDoc);
         const viewportRect = viewport.getRect();
         const viewportSize = viewport.getSize();
         return {
           'is_amp': AmpAdImplementation.AMP_AD_XHR_TO_IFRAME_OR_AMP,
           'amp_v': '$internalRuntimeVersion$',
           'd_imp': '1',
-          'c': getCorrelator(win, clientId, doc),
+          'c': getCorrelator(win, clientId, nodeOrDoc),
           'dt': startTime,
           output,
           'biw': viewportRect.width,


### PR DESCRIPTION
Fixes this error which breaks A4A in PWAs:
<img width="782" alt="screen shot 2017-08-23 at 4 07 29 pm" src="https://user-images.githubusercontent.com/2363700/29642367-4169d924-881d-11e7-835d-e1d77b47d2e9.png">

Still investigating why it is happening at this time, and how to implement a test to detect this particular failure.

As PWA usage increases, we will need to more carefully pass arguments to functions that accept an ampdoc and make sure that they will work whether they are running in single or shadow ampdocs.
