### PR TITLE
Implement new signature verifier

### DIFF
--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -568,7 +568,7 @@ export class AmpA4A extends AMP.BaseElement {
     //   - Rendering fails => return false
     //   - Chain cancelled => don't return; drop error
     //   - Uncaught error otherwise => don't return; percolate error up
-    this.adPromise_ = this.keysetPromise_
+    this.adPromise_ = Services.viewerForDoc(this.getAmpDoc()).whenFirstVisible()
         .then(() => {
           checkStillCurrent();
           // See if experiment that delays request until slot is within
@@ -672,10 +672,12 @@ export class AmpA4A extends AMP.BaseElement {
             this.creativeBody_ = bytes;
           }
           this.protectedEmitLifecycleEvent_('adResponseValidateStart');
-          return signatureVerifierFor(this.win)
-              .verify(bytes, headers, (eventName, extraVariables) => {
-                this.protectedEmitLifecycleEvent_(eventName, extraVariables);
-              })
+          return this.keysetPromise_
+              .then(() => signatureVerifierFor(this.win)
+                  .verify(bytes, headers, (eventName, extraVariables) => {
+                    this.protectedEmitLifecycleEvent_(
+                        eventName, extraVariables);
+                  }))
               .then(status => {
                 if (getMode().localDev &&
                     this.element.getAttribute('type') == 'fake') {

--- a/extensions/amp-a4a/0.1/signature-verifier.js
+++ b/extensions/amp-a4a/0.1/signature-verifier.js
@@ -14,6 +14,11 @@
  * limitations under the License.
  */
 
+import {dev, user} from '../../../src/log';
+import {Services} from '../../../src/services';
+import {isArray} from '../../../src/types';
+import {base64DecodeToBytes} from '../../../src/utils/base64';
+
 /**
  * The result of an attempt to verify a Fast Fetch signature. The different
  * error statuses are used for reporting errors to the ad network.
@@ -22,7 +27,7 @@
  */
 export const VerificationStatus = {
 
-  /** Verification succeeded. */
+  /** The ad was successfully verified as AMP. */
   OK: 0,
 
   /**
@@ -65,10 +70,8 @@ export class ISignatureVerifier {
    * Fetches and imports the public keyset for the named signing service.
    *
    * @param {string} unusedSigningServiceName
-   * @param {!Promise<undefined>} unusedWaitFor a promise that must resolve
-   *     before the keys are fetched
    */
-  loadKeyset(unusedSigningServiceName, unusedWaitFor) {}
+  loadKeyset(unusedSigningServiceName) {}
 
   /**
    * Extracts a cryptographic signature from `headers` and attempts to verify
@@ -84,4 +87,344 @@ export class ISignatureVerifier {
    * @return {!Promise<!VerificationStatus>}
    */
   verify(unusedCreative, unusedHeaders, unusedLifecycleCallback) {}
+}
+
+/**
+ * A window-level object that encapsulates the logic for obtaining public keys
+ * from Fast Fetch signing services and cryptographically verifying signatures
+ * of AMP creatives.
+ *
+ * Unlike an AMP service, a signature verifier is **stateful**. It maintains a
+ * cache of all public keys that it has previously downloaded and imported, and
+ * also keeps track of which keys and signing services have already had failed
+ * download or import attempts and should not be attempted again.
+ *
+ * This entire class is currently dead code in production, but will soon be
+ * introduced as an experiment.
+ */
+export class SignatureVerifier {
+
+  /**
+   * @param {!Window} win
+   * @param {!Object<string, string>} signingServerURLs a map from the name of
+   *    each trusted signing service to the URL of its public key endpoint
+   */
+  constructor(win, signingServerURLs) {
+    /** @private @const {!Window} */
+    this.win_ = win;
+
+    /** @private @const {!Object<string, string>} */
+    this.signingServerURLs_ = signingServerURLs;
+
+    /**
+     * The cache where all the public keys are stored.
+     *
+     * This field has a lot of internal structure and its type's a little hairy,
+     * so here's a rundown of what each piece means:
+     *  - If Web Cryptography isn't available in the current browsing context,
+     *    then the entire field is null. Since the keys are of no use, we don't
+     *    fetch them.
+     *  - Otherwise, it's a map-like `Object` from signing service names (as
+     *    defined in the Fast Fetch config registry) to "signer" objects.
+     *  - The `promise` property of each signer resolves to a boolean indicating
+     *    whether the most recent attempt to fetch and import that signing
+     *    service's public keys was successful. If the promise is still pending,
+     *    then an attempt is currently in progress. This property is mutable;
+     *    its value is replaced with a new promise when a new attempt is made.
+     *    Invariant: only one attempt may be in progress at a time, so this
+     *    property may not be mutated while the current promise is pending.
+     *  - The `keys` property of each signer is a map-like `Object` from keypair
+     *    IDs to nullable key promises. (This means that a property access on
+     *    this object may evaluate to `undefined`, `null`, or a `Promise`
+     *    object.) The `keys` object is internally mutable; new keys are added
+     *    to it as they are fetched. Invariant: the `keys` object may be mutated
+     *    only while the corresponding `promise` object is pending; this ensures
+     *    that callbacks chained to `promise` may observe `keys` without being
+     *    subject to race conditions.
+     *  - If a key promise (i.e., the value of a property access on the `keys`
+     *    object) is absent (i.e., `undefined`), then no key with that keypair
+     *    ID is present (but this could be because of a stale cache). If it's
+     *    null, then no key with that keypair ID could be found even after
+     *    cachebusting. If it's a `Promise` that resolves to `null`, then key
+     *    data for that keypair ID was found but could not be imported
+     *    successfully; this most likely indicates signing service misbehavior.
+     *    The success case is a `Promise` that resolves to a `CryptoKey`.
+     *
+     * @private @const {?Object<string, {promise: !Promise<boolean>, keys: !Object<string, ?Promise<?webCrypto.CryptoKey>>}>}
+     */
+    this.signers_ = Services.cryptoFor(win).isPkcsAvailable() ? {} : null;
+
+    /**
+     * Gets a notion of current time, in ms.  The value is not necessarily
+     * absolute, so should be used only for computing deltas.  When available,
+     * the performance system will be used; otherwise Date.now() will be
+     * returned.
+     *
+     * @private @const {function(): number}
+     */
+    this.getNow_ = (win.performance && win.performance.now) ?
+        win.performance.now.bind(win.performance) : Date.now;
+  }
+
+  /**
+   * Fetches and imports the public keyset for the named signing service,
+   * without any cachebusting. Hopefully, this will hit cache in many cases
+   * and not make an actual network round-trip. This method should be called
+   * as early as possible, once it's known which signing service is likely to
+   * be used, so that the network request and key imports can execute in
+   * parallel with other operations.
+   *
+   * @param {string} signingServiceName
+   */
+  loadKeyset(signingServiceName) {
+    if (this.signers_ && !this.signers_[signingServiceName]) {
+      const keys = {};
+      const promise = this.fetchAndAddKeys_(keys, signingServiceName, null);
+      this.signers_[signingServiceName] = {promise, keys};
+    }
+  }
+
+  /**
+   * Extracts a cryptographic signature from `headers` and attempts to verify
+   * that it's the correct cryptographic signature for `creative`.
+   *
+   * As a precondition, `loadKeyset(signingServiceName)` must have already been
+   * called.
+   *
+   * @param {!ArrayBuffer} creative
+   * @param {!Headers} headers
+   * @param {function(string, !Object)} lifecycleCallback called for each AMP
+   *     lifecycle event triggered during verification
+   * @return {!Promise<!VerificationStatus>}
+   */
+  verify(creative, headers, lifecycleCallback) {
+    const signatureHeader = 'AMP-Fast-Fetch-Signature';
+    const signatureFormat =
+        /^([A-Za-z0-9._-]+):([A-Za-z0-9._-]+):([A-Za-z0-9+/]{341}[AQgw]==)$/;
+    if (!headers.has(signatureHeader)) {
+      return Promise.resolve(VerificationStatus.UNVERIFIED);
+    }
+    const headerValue = headers.get(signatureHeader);
+    const match = signatureFormat.exec(headerValue);
+    if (!match) {
+      // TODO(@taymonbeal, #9274): replace this with real error reporting
+      user().error('AMP-A4A', `Invalid signature header: ${headerValue}`);
+      return Promise.resolve(VerificationStatus.ERROR_SIGNATURE_MISMATCH);
+    }
+    return this.verifyCreativeAndSignature(
+        match[1], match[2], base64DecodeToBytes(match[3]), creative,
+        lifecycleCallback);
+  }
+
+  /**
+   * Verifies that `signature` is the correct cryptographic signature for
+   * `creative`, with the public key from the named signing service identified
+   * by `keypairId`.
+   *
+   * As a precondition, `loadKeyset(signingServiceName)` must have already been
+   * called.
+   *
+   * If the keyset for the named signing service was imported successfully but
+   * did not include a key for `keypairId`, this may be the result of a stale
+   * browser cache. To work around this, `keypairId` is added to the public key
+   * endpoint URL as a query parameter and the keyset is re-fetched. Other kinds
+   * of failures, including network connectivity failures, are not retried.
+   *
+   * @param {string} signingServiceName
+   * @param {string} keypairId
+   * @param {!Uint8Array} signature
+   * @param {!ArrayBuffer} creative
+   * @param {function(string, !Object)} lifecycleCallback called for each AMP
+   *     lifecycle event triggered during verification
+   * @return {!Promise<!VerificationStatus>}
+   * @visibleForTesting
+   */
+  verifyCreativeAndSignature(
+      signingServiceName, keypairId, signature, creative, lifecycleCallback) {
+    if (!this.signers_) {
+      // Web Cryptography isn't available.
+      return Promise.resolve(VerificationStatus.UNVERIFIED);
+    }
+    const signer = this.signers_[signingServiceName];
+    return signer.promise.then(success => {
+      if (!success) {
+        // The public keyset couldn't be fetched and imported. Probably a
+        // network connectivity failure.
+        return VerificationStatus.UNVERIFIED;
+      }
+      const keyPromise = signer.keys[keypairId];
+      if (keyPromise === undefined) {
+        // We don't have this key, but maybe the cache is stale; try
+        // cachebusting.
+        signer.promise =
+            this.fetchAndAddKeys_(signer.keys, signingServiceName, keypairId)
+                .then(success => {
+                  if (signer.keys[keypairId] === undefined) {
+                    // We still don't have this key; make sure we never try
+                    // again.
+                    signer.keys[keypairId] = null;
+                  }
+                  return success;
+                });
+        // This "recursive" call can recurse at most once.
+        return this.verifyCreativeAndSignature(
+            signingServiceName, keypairId, signature, creative,
+            lifecycleCallback);
+      } else if (keyPromise === null) {
+        // We don't have this key and we already tried cachebusting.
+        return VerificationStatus.ERROR_KEY_NOT_FOUND;
+      } else {
+        return keyPromise.then(key => {
+          if (!key) {
+            // This particular public key couldn't be imported. Probably the
+            // signing service's fault.
+            return VerificationStatus.UNVERIFIED;
+          }
+          const crypto = Services.cryptoFor(this.win_);
+          const startTime = this.getNow_();
+          return crypto.verifyPkcs(key, signature, creative).then(
+              result => {
+                const endTime = this.getNow_();
+                if (result) {
+                  lifecycleCallback('signatureVerifySuccess', {
+                    'met.delta.AD_SLOT_ID': endTime - startTime,
+                    'signingServiceName.AD_SLOT_ID': signingServiceName,
+                  });
+                  return VerificationStatus.OK;
+                } else {
+                  return VerificationStatus.ERROR_SIGNATURE_MISMATCH;
+                }
+              },
+              err => {
+                // Web Cryptography rejected the verification attempt. This
+                // hopefully won't happen in the wild, but browsers can be weird
+                // about this, so we need to guard against the possibility.
+                // Phone home to the AMP Project so that we can understand why
+                // this occurred.
+                const message = err && err.message;
+                dev().error(
+                    'AMP-A4A', `Failed to verify signature: ${message}`);
+                return VerificationStatus.UNVERIFIED;
+              });
+        });
+      }
+    });
+  }
+
+  /**
+   * Try to download the keyset for the named signing service and add a promise
+   * for each key to the `keys` object.
+   *
+   * @param {!Object<string, ?Promise<?webCrypto.CryptoKey>>} keys the object to
+   *     add each key promise to. This is mutated while the returned promise is
+   *     pending.
+   * @param {string} signingServiceName
+   * @param {?string} keypairId the keypair ID to include in the query string
+   *     for cachebusting purposes, or `null` if no cachebusting is needed
+   * @return {!Promise<boolean>} resolves after the mutation of `keys` is
+   *     complete, to `true` if the keyset was downloaded and parsed
+   *     successfully (even if some keys were malformed), or `false` if a
+   *     keyset-level failure occurred
+   * @private
+   */
+  fetchAndAddKeys_(keys, signingServiceName, keypairId) {
+    // TODO(@erwinmombay, #11081): eslint-disable-line needed due to linter bug
+    let url = this.signingServerURLs_[signingServiceName];
+    if (keypairId != null) {
+      url += '?kid=' + encodeURIComponent(keypairId);
+    }
+    return Services.xhrFor(this.win_)
+        .fetchJson(
+            url, // eslint-disable-line indent
+            {mode: 'cors', method: 'GET', ampCors: false, credentials: 'omit'})
+        .then(
+            response => { // eslint-disable-line indent
+              // These are assertions on signing service behavior required by
+              // the spec. However, nothing terrible happens if they aren't met
+              // and there's no meaningful error recovery to be done if they
+              // fail, so we don't need to do them at runtime in production.
+              // They're included in dev mode as a debugging aid.
+              dev().assert(
+                  response.status === 200,
+                  'Fast Fetch keyset spec requires status code 200');
+              dev().assert(
+                  response.headers.get('Content-Type') ==
+                      'application/jwk-set+json',
+                  'Fast Fetch keyset spec requires Content-Type: ' +
+                      'application/jwk-set+json');
+              return response.json().then(
+                  jwkSet => {
+                    // This is supposed to be a JSON Web Key Set, as defined in
+                    // Section 5 of RFC 7517. However, the signing service could
+                    // misbehave and send an arbitrary JSON value, so we have to
+                    // type-check at runtime.
+                    if (!jwkSet || !isArray(jwkSet['keys'])) {
+                      signingServiceError(
+                          signingServiceName,
+                          `Key set (${JSON.stringify(jwkSet)}) has no "keys"`);
+                      return false;
+                    }
+                    jwkSet['keys'].forEach(jwk => {
+                      if (!jwk || typeof jwk['kid'] != 'string') {
+                        signingServiceError(
+                            signingServiceName,
+                            `Key (${JSON.stringify(jwk)}) has no "kid"`);
+                      } else if (keys[jwk['kid']] === undefined) {
+                        // We haven't seen this keypair ID before.
+                        keys[jwk['kid']] =
+                            Services.cryptoFor(this.win_).importPkcsKey(jwk)
+                                .catch(err => {
+                                  // Web Cryptography rejected the key
+                                  // import attempt. Either the signing
+                                  // service sent a malformed key or the
+                                  // browser is doing something weird.
+                                  const jwkData = JSON.stringify(jwk);
+                                  const message = err && err.message;
+                                  signingServiceError(
+                                      signingServiceName,
+                                      `Failed to import key (${
+                                        jwkData
+                                      }): ${message}`);
+                                  return null;
+                                });
+                      }
+                    });
+                    return true;
+                  },
+                  err => {
+                    // The signing service didn't send valid JSON.
+                    signingServiceError(
+                        signingServiceName,
+                        `Failed to parse JSON: ${err && err.response}`);
+                    return false;
+                  });
+            },
+            err => { // eslint-disable-line indent
+              // Some kind of error occurred during the XHR. This could be a lot
+              // of things (and we have no type information), but if there's no
+              // `response` it's probably a network connectivity failure, so we
+              // ignore it. Unfortunately, we can't distinguish this from a CORS
+              // problem.
+              if (err && err.response) {
+                // This probably indicates a non-2xx HTTP status code.
+                signingServiceError(
+                    signingServiceName, `Status code ${err.response.status}`);
+              }
+              return false;
+            });
+  }
+}
+
+/**
+ * Report an error caused by a signing service. Since signing services currently
+ * don't have their own error logging URLs, we just send everything to the AMP
+ * Project.
+ *
+ * @param {string} signingServiceName
+ * @param {string} message
+ * @private
+ */
+function signingServiceError(signingServiceName, message) {
+  dev().error(
+      'AMP-A4A', `Signing service error for ${signingServiceName}: ${message}`);
 }

--- a/extensions/amp-a4a/0.1/signature-verifier.js
+++ b/extensions/amp-a4a/0.1/signature-verifier.js
@@ -96,8 +96,8 @@ export class ISignatureVerifier {
  *
  * Unlike an AMP service, a signature verifier is **stateful**. It maintains a
  * cache of all public keys that it has previously downloaded and imported, and
- * also keeps track of which keys and signing services have already had failed
- * download or import attempts and should not be attempted again.
+ * also keeps track of which keys and signing services have already had
+ * unsuccessful download or import attempts and should not be attempted again.
  *
  * This entire class is currently dead code in production, but will soon be
  * introduced as an experiment.

--- a/extensions/amp-a4a/0.1/test/fetch-mock.js
+++ b/extensions/amp-a4a/0.1/test/fetch-mock.js
@@ -15,6 +15,13 @@
  */
 
 /**
+ * @fileoverview
+ * @deprecated Do not use this in new code. Use env.fetchMock instead. Its API
+ *     is a superset of this one. TODO(@taymonbeal, #11066): Migrate all
+ *     existing users and then delete this file.
+ */
+
+/**
  * @typedef {(?string|{
  *     body: ?string,
  *     status: (number|undefined),

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -914,6 +914,7 @@ describe('amp-a4a', () => {
         const a4aElement = createA4aElement(doc, rect);
         const a4a = new MockA4AImpl(a4aElement);
         // test 0 height
+        a4a.buildCallback();
         a4a.onLayoutMeasure();
         expect(a4a.adPromise_).to.not.be.ok;
         // test 0 width
@@ -1268,11 +1269,13 @@ describe('amp-a4a', () => {
       it('should not delay request when in viewport', () => {
         getResourceStub.returns(
             {
+              getUpgradeDelayMs: () => 1,
               renderOutsideViewport: () => true,
               whenWithinRenderOutsideViewport: () => {
                 throw new Error('failure!');
               },
             });
+        a4a.buildCallback();
         a4a.onLayoutMeasure();
         expect(a4a.adPromise_);
         return a4a.adPromise_.then(() => {
@@ -1283,11 +1286,13 @@ describe('amp-a4a', () => {
         let whenWithinRenderOutsideViewportResolve;
         getResourceStub.returns(
             {
+              getUpgradeDelayMs: () => 1,
               renderOutsideViewport: () => false,
               whenWithinRenderOutsideViewport: () => new Promise(resolve => {
                 whenWithinRenderOutsideViewportResolve = resolve;
               }),
             });
+        a4a.buildCallback();
         a4a.onLayoutMeasure();
         expect(a4a.adPromise_);
         // Delay to all getAdUrl to potentially execute.

--- a/extensions/amp-a4a/0.1/test/test-legacy-signature-verifier.js
+++ b/extensions/amp-a4a/0.1/test/test-legacy-signature-verifier.js
@@ -51,7 +51,7 @@ describes.realWin('LegacySignatureVerifier', {amp: true}, env => {
 
   it('should fetch a single key', () => {
     expect(result).to.be.empty;
-    verifier.loadKeyset('google', Promise.resolve());
+    verifier.loadKeyset('google');
     expect(result).to.be.instanceof(Array);
     expect(result).to.have.lengthOf(1);
     return Promise.all(result).then(serviceInfos => {
@@ -69,26 +69,13 @@ describes.realWin('LegacySignatureVerifier', {amp: true}, env => {
     });
   });
 
-  it('should wait for promise', () => {
-    expect(result).to.be.empty;
-    let resolveWaitFor;
-    verifier.loadKeyset('google', new Promise(resolve => {
-      resolveWaitFor = resolve;
-    }));
-    expect(fetchMock.called('keyset')).to.be.false;
-    resolveWaitFor();
-    return Promise.all(result).then(() => {
-      expect(fetchMock.called('keyset')).to.be.true;
-    });
-  });
-
   it('should fetch multiple keys', () => {
     // For our purposes, re-using the same key is fine.
     keysetBody =
         `{"keys":[${validCSSAmp.publicKey},${
             validCSSAmp.publicKey},${validCSSAmp.publicKey}]}`;
     expect(result).to.be.empty;
-    verifier.loadKeyset('google', Promise.resolve());
+    verifier.loadKeyset('google');
     expect(result).to.be.instanceof(Array);
     expect(result).to.have.lengthOf(1);  // Only one service.
     return Promise.all(result).then(serviceInfos => {
@@ -110,8 +97,8 @@ describes.realWin('LegacySignatureVerifier', {amp: true}, env => {
         'https://cdn.ampproject.org/amp-ad-verifying-keyset-dev.json',
         keysetBody, {name: 'dev-keyset'});
     expect(result).to.be.empty;
-    verifier.loadKeyset('google', Promise.resolve());
-    verifier.loadKeyset('google-dev', Promise.resolve());
+    verifier.loadKeyset('google');
+    verifier.loadKeyset('google-dev');
     expect(result).to.be.instanceof(Array);
     expect(result).to.have.lengthOf(2);  // Two services.
     return Promise.all(result).then(serviceInfos => {
@@ -134,7 +121,7 @@ describes.realWin('LegacySignatureVerifier', {amp: true}, env => {
   it('Should gracefully handle malformed key responses', () => {
     keysetBody = '{"keys":["invalid key data"]}';
     expect(result).to.be.empty;
-    verifier.loadKeyset('google', Promise.resolve());
+    verifier.loadKeyset('google');
     expect(result).to.be.instanceof(Array);
     expect(result).to.have.lengthOf(1);  // Only one service.
     return Promise.all(result).then(serviceInfos => {
@@ -149,7 +136,7 @@ describes.realWin('LegacySignatureVerifier', {amp: true}, env => {
   it('should gracefully handle network errors in a single service', () => {
     keysetBody = Promise.reject(networkFailure());
     expect(result).to.be.empty;
-    verifier.loadKeyset('google', Promise.resolve());
+    verifier.loadKeyset('google');
     expect(result).to.be.instanceof(Array);
     expect(result).to.have.lengthOf(1);  // Only one service.
     return result[0].then(serviceInfo => {
@@ -165,8 +152,8 @@ describes.realWin('LegacySignatureVerifier', {amp: true}, env => {
         'https://cdn.ampproject.org/amp-ad-verifying-keyset-dev.json',
         Promise.reject(networkFailure()), {name: 'dev-keyset'});
     expect(result).to.be.empty;
-    verifier.loadKeyset('google', Promise.resolve());
-    verifier.loadKeyset('google-dev', Promise.resolve());
+    verifier.loadKeyset('google');
+    verifier.loadKeyset('google-dev');
     expect(result).to.be.instanceof(Array);
     expect(result).to.have.lengthOf(2);  // Two services.
     return Promise.all(result.map(  // For each service...
@@ -196,7 +183,7 @@ describes.realWin('LegacySignatureVerifier', {amp: true}, env => {
 
   it('should return valid object on invalid service name', () => {
     expect(result).to.be.empty;
-    verifier.loadKeyset('fnord', Promise.resolve());
+    verifier.loadKeyset('fnord');
     expect(fetchMock.called('keyset')).to.be.false;
     expect(result).to.be.instanceof(Array);
     expect(result).to.have.lengthOf(1);

--- a/extensions/amp-a4a/0.1/test/test-signature-verifier.js
+++ b/extensions/amp-a4a/0.1/test/test-signature-verifier.js
@@ -1,0 +1,479 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// TODO(@erwinmombay, #11081): eslint-disable-next-line needed due to linter bug
+
+import * as sinon from 'sinon';
+
+import {dev, user} from '../../../../src/log';
+import {base64EncodeFromBytes} from '../../../../src/utils/base64';
+import {utf8EncodeSync} from '../../../../src/utils/bytes';
+import {SignatureVerifier, VerificationStatus} from '../signature-verifier';
+
+const networkFailure = {throws: new TypeError('Failed to fetch')};
+const noop = () => {};
+
+describes.fakeWin('SignatureVerifier', {amp: true}, env => {
+
+  let mockDevError;
+  beforeEach(() => {
+    mockDevError = env.sandbox.mock(dev()).expects('error');
+    mockDevError.never();
+  });
+  afterEach(() => {
+    mockDevError.verify();
+  });
+
+  /** @param {string} signingServiceName */
+  const expectSigningServiceError = signingServiceName => {
+    mockDevError.withExactArgs('AMP-A4A', sinon.match(signingServiceName))
+        .once();
+  };
+
+  const creative1 = utf8EncodeSync('Hello world!');
+  const creative2 = utf8EncodeSync('This is a <em>test</em> creative.');
+
+  it('should make no network requests when crypto is unavailable', () => {
+    env.sandbox.stub(env.win, 'crypto', undefined);
+    env.expectFetch('*', {throws: new Error('no network requests allowed')});
+    const verifier = new SignatureVerifier(env.win);
+    verifier.loadKeyset('service-1');
+    return verifier
+        .verifyCreativeAndSignature(
+            // eslint-disable-next-line indent
+            'service-1', 'key-1', creative1, new Uint8Array(256), noop)
+        .then(status => {
+          expect(status).to.equal(VerificationStatus.UNVERIFIED);
+          expect(env.fetchMock.called()).to.be.false;
+        });
+  });
+
+  const crypto = window.crypto || window.msCrypto;
+  if (!crypto) {
+    return;
+  }
+  const subtle = crypto.subtle || crypto.webkitSubtle;
+  if (!subtle) {
+    return;
+  }
+
+  describe('when crypto is available', () => {
+    const Keypair = class {
+      /** @param {string} kid */
+      constructor(kid) {
+        /** @const {string} */
+        this.kid = kid;
+        /** @const {!Promise<{privateKey: !webCrypto.CryptoKey, publicKey: !webCrypto.CryptoKey}>} */
+        this.keysPromise = subtle.generateKey(
+            {
+              name: 'RSASSA-PKCS1-v1_5',
+              modulusLength: 2048,
+              publicExponent: Uint8Array.of(1, 0, 1),
+              hash: {name: 'SHA-256'},
+            },
+            true, ['sign', 'verify']);
+      }
+
+      /**
+       * @param {!Uint8Array} data
+       * @return {!Promise<!Uint8Array>}
+       */
+      sign(data) {
+        return this.keysPromise
+            .then(({privateKey}) => subtle.sign(
+                {name: 'RSASSA-PKCS1-v1_5', hash: {name: 'SHA-256'}},
+                privateKey, data))
+            .then(signature => new Uint8Array(signature));
+      }
+
+      /** @return {!Promise<!JsonObject>} */
+      jwk() {
+        return this.keysPromise
+            .then(({publicKey}) => subtle.exportKey('jwk', publicKey))
+            .then(jwk => {
+              jwk['kid'] = this.kid;
+              return jwk;
+            });
+      }
+    };
+
+    const headers = {'Content-Type': 'application/jwk-set+json'};
+
+    /**
+     * @param {!Array<!Keypair>} keys
+     * @param {!Promise<!JsonObject>}
+     */
+    const jwkSet = keys =>
+        Promise.all(keys.map(key => key.jwk()))
+            .then(jwks => ({body: {'keys': jwks}, headers}));
+
+    const key1 = new Keypair('key-1');
+    const key2 = new Keypair('key-2');
+
+    let verifier;
+
+    beforeEach(() => {
+      verifier = new SignatureVerifier(env.win, {
+        'service-1': 'https://signingservice1.net/keyset.json',
+        'service-2': 'https://signingservice2.net/keyset.json',
+      });
+    });
+
+    afterEach(() => {
+      expect(env.fetchMock.done()).to.be.true;
+    });
+
+    it('should verify a signature',
+        () => key1.sign(creative1).then(signature => {
+          env.fetchMock.getOnce(
+              'https://signingservice1.net/keyset.json', jwkSet([key1]));
+          verifier.loadKeyset('service-1');
+          return expect(
+              verifier.verifyCreativeAndSignature(
+                  'service-1', 'key-1', signature, creative1, noop))
+              .to.eventually.equal(VerificationStatus.OK);
+        }));
+
+    it('should call the lifecycle callback',
+        () => key1.sign(creative1).then(signature => {
+          env.fetchMock.getOnce(
+              'https://signingservice1.net/keyset.json', jwkSet([key1]));
+          verifier.loadKeyset('service-1');
+          const lifecycleSpy = env.sandbox.spy();
+          return verifier
+              .verifyCreativeAndSignature(
+                  // eslint-disable-next-line indent
+                  'service-1', 'key-1', signature, creative1, lifecycleSpy)
+              .then(status => {
+                expect(status).to.equal(VerificationStatus.OK);
+                expect(lifecycleSpy).to.be.calledOnce;
+                expect(lifecycleSpy).to.be.calledWithExactly(
+                    'signatureVerifySuccess',
+                    sinon.match({
+                      'met.delta.AD_SLOT_ID': sinon.match.number,
+                      'signingServiceName.AD_SLOT_ID': 'service-1',
+                    }));
+              });
+        }));
+
+    it('should verify multiple signatures with only one network request',
+        () => key1.sign(creative1).then(
+            signature1 => key1.sign(creative2).then(signature2 => {
+              env.fetchMock.getOnce(
+                  'https://signingservice1.net/keyset.json', jwkSet([key1]));
+              verifier.loadKeyset('service-1');
+              return verifier
+                  .verifyCreativeAndSignature(
+                      // eslint-disable-next-line indent
+                      'service-1', 'key-1', signature1, creative1, noop)
+                  .then(status => {
+                    expect(status).to.equal(VerificationStatus.OK);
+                    verifier.loadKeyset('service-1');
+                    return expect(
+                        verifier.verifyCreativeAndSignature(
+                            'service-1', 'key-1', signature2, creative2, noop))
+                        .to.eventually.equal(VerificationStatus.OK);
+                  });
+            })));
+
+    it('should verify signatures from multiple signing services',
+        () => key1.sign(creative1).then(
+            signature1 => key2.sign(creative2).then(signature2 => {
+              env.fetchMock.getOnce(
+                  'https://signingservice1.net/keyset.json', jwkSet([key1]));
+              verifier.loadKeyset('service-1');
+              return verifier
+                  .verifyCreativeAndSignature(
+                      // eslint-disable-next-line indent
+                      'service-1', 'key-1', signature1, creative1, noop)
+                  .then(status => {
+                    expect(status).to.equal(VerificationStatus.OK);
+                    env.fetchMock.getOnce(
+                        'https://signingservice2.net/keyset.json',
+                        jwkSet([key2]));
+                    verifier.loadKeyset('service-2');
+                    return expect(
+                        verifier.verifyCreativeAndSignature(
+                            'service-2', 'key-2', signature2, creative2, noop))
+                        .to.eventually.equal(VerificationStatus.OK);
+                  });
+            })));
+
+    it('should verify signatures when different signing services share a kid',
+        () => key1.sign(creative1).then(signature1 => {
+          const key1FromService2 = new Keypair('key-1');
+          return key1FromService2.sign(creative2).then(signature2 => {
+            env.fetchMock.getOnce(
+                'https://signingservice1.net/keyset.json', jwkSet([key1]));
+            verifier.loadKeyset('service-1');
+            return verifier
+                .verifyCreativeAndSignature(
+                    // eslint-disable-next-line indent
+                    'service-1', 'key-1', signature1, creative1, noop)
+                .then(status => {
+                  expect(status).to.equal(VerificationStatus.OK);
+                  env.fetchMock.getOnce(
+                      'https://signingservice2.net/keyset.json',
+                      jwkSet([key1FromService2]));
+                  verifier.loadKeyset('service-2');
+                  return expect(
+                      verifier.verifyCreativeAndSignature(
+                          'service-2', 'key-1', signature2, creative2, noop))
+                      .to.eventually.equal(VerificationStatus.OK);
+                });
+          });
+        }));
+
+    it('should verify a signature from a newly added key',
+        () => key2.sign(creative1).then(signature => {
+          env.fetchMock.getOnce(
+              'https://signingservice1.net/keyset.json', () => {
+                env.fetchMock.getOnce(
+                    'https://signingservice1.net/keyset.json?kid=key-2',
+                    jwkSet([key2]));
+                return jwkSet([key1]);
+              });
+          verifier.loadKeyset('service-1');
+          return expect(
+              verifier.verifyCreativeAndSignature(
+                  'service-1', 'key-2', signature, creative1, noop))
+              .to.eventually.equal(VerificationStatus.OK);
+        }));
+
+    it('should return ERROR_KEY_NOT_FOUND for a nonexistent kid',
+        () => key1.sign(creative1).then(signature => {
+          env.fetchMock.getOnce(
+              'https://signingservice1.net/keyset.json', () => {
+                env.fetchMock.getOnce(
+                    'https://signingservice1.net/keyset.json?kid=key-1',
+                    jwkSet([]));
+                return jwkSet([]);
+              });
+          verifier.loadKeyset('service-1');
+          return expect(
+              verifier.verifyCreativeAndSignature(
+                  'service-1', 'key-1', signature, creative1, noop))
+              .to.eventually.equal(VerificationStatus.ERROR_KEY_NOT_FOUND);
+        }));
+
+    it('should not make more network requests retrying a nonexistent kid',
+        () => key1.sign(creative1).then(
+            signature1 => key1.sign(creative2).then(signature2 => {
+              env.fetchMock.getOnce(
+                  'https://signingservice1.net/keyset.json', () => {
+                    env.fetchMock.getOnce(
+                        'https://signingservice1.net/keyset.json?kid=key-1',
+                        jwkSet([]));
+                    return jwkSet([]);
+                  });
+              verifier.loadKeyset('service-1');
+              return verifier
+                  .verifyCreativeAndSignature(
+                  'service-1', 'key-1', signature1, creative1, noop)
+                  .then(status => {
+                    expect(status).to.equal(
+                        VerificationStatus.ERROR_KEY_NOT_FOUND);
+                    verifier.loadKeyset('service-1');
+                    return expect(
+                        verifier.verifyCreativeAndSignature(
+                            'service-1', 'key-1', signature2, creative2, noop))
+                        .to.eventually.equal(
+                        VerificationStatus.ERROR_KEY_NOT_FOUND);
+                  });
+            })));
+
+    it('should return ERROR_SIGNATURE_MISMATCH for a wrong signature',
+        () => key2.sign(creative1).then(signature => {
+          env.fetchMock.getOnce(
+              'https://signingservice1.net/keyset.json', jwkSet([key1]));
+          verifier.loadKeyset('service-1');
+          return expect(
+              verifier.verifyCreativeAndSignature(
+                  'service-1', 'key-1', signature, creative1, noop))
+              .to.eventually.equal(VerificationStatus.ERROR_SIGNATURE_MISMATCH);
+        }));
+
+    it('should return UNVERIFIED and report on Web Cryptography error',
+        () => key1.sign(creative1).then(signature => {
+          env.fetchMock.getOnce(
+              'https://signingservice1.net/keyset.json', jwkSet([key1]));
+          const errorMessage = 'Web Cryptography failed';
+          env.stubService('crypto', 'verifyPkcs')
+              .returns(Promise.reject(new Error(errorMessage)));
+          mockDevError.withExactArgs('AMP-A4A', sinon.match(errorMessage))
+              .once();
+          verifier.loadKeyset('service-1');
+          return expect(
+              verifier.verifyCreativeAndSignature(
+                  'service-1', 'key-1', signature, creative1, noop))
+              .to.eventually.equal(VerificationStatus.UNVERIFIED);
+        }));
+
+    it('should return UNVERIFIED on network connectivity error',
+        () => key1.sign(creative1).then(signature => {
+          env.fetchMock.getOnce(
+              'https://signingservice1.net/keyset.json', networkFailure);
+          verifier.loadKeyset('service-1');
+          return expect(
+              verifier.verifyCreativeAndSignature(
+                  'service-1', 'key-1', signature, creative1, noop))
+              .to.eventually.equal(VerificationStatus.UNVERIFIED);
+        }));
+
+    it('should not retry for same service on network connectivity error',
+        () => key1.sign(creative1).then(
+            signature1 => key1.sign(creative2).then(signature2 => {
+              env.fetchMock.getOnce(
+                  'https://signingservice1.net/keyset.json', networkFailure);
+              verifier.loadKeyset('service-1');
+              return verifier
+                  .verifyCreativeAndSignature(
+                      // eslint-disable-next-line indent
+                      'service-1', 'key-1', signature1, creative1, noop)
+                  .then(status => {
+                    expect(status).to.equal(VerificationStatus.UNVERIFIED);
+                    verifier.loadKeyset('service-1');
+                    return expect(
+                        verifier.verifyCreativeAndSignature(
+                            'service-1', 'key-1', signature2, creative2, noop))
+                        .to.eventually.equal(VerificationStatus.UNVERIFIED);
+                  });
+            })));
+
+    it('should return UNVERIFIED, report, and not retry on malformed JSON',
+        () => key1.sign(creative1).then(
+            signature1 => key1.sign(creative2).then(signature2 => {
+              env.fetchMock.getOnce(
+                  'https://signingservice1.net/keyset.json',
+                 {body: '{"keys":', headers});
+              expectSigningServiceError('service-1');
+              verifier.loadKeyset('service-1');
+              return verifier
+                  .verifyCreativeAndSignature(
+                      // eslint-disable-next-line indent
+                      'service-1', 'key-1', signature1, creative1, noop)
+                  .then(status => {
+                    expect(status).to.equal(VerificationStatus.UNVERIFIED);
+                    verifier.loadKeyset('service-1');
+                    return expect(
+                        verifier.verifyCreativeAndSignature(
+                            'service-1', 'key-1', signature2, creative2, noop))
+                        .to.eventually.equal(VerificationStatus.UNVERIFIED);
+                  });
+            })));
+
+    it('should return UNVERIFIED, report, and not retry on non-JWK Set JSON',
+        () => key1.sign(creative1).then(
+            signature1 => key1.sign(creative2).then(signature2 => {
+              env.fetchMock.getOnce(
+                  'https://signingservice1.net/keyset.json',
+                 {body: '{"foo":"bar"}', headers});
+              expectSigningServiceError('service-1');
+              verifier.loadKeyset('service-1');
+              return verifier
+                  .verifyCreativeAndSignature(
+                      // eslint-disable-next-line indent
+                      'service-1', 'key-1', signature1, creative1, noop)
+                  .then(status => {
+                    expect(status).to.equal(VerificationStatus.UNVERIFIED);
+                    verifier.loadKeyset('service-1');
+                    return expect(
+                        verifier.verifyCreativeAndSignature(
+                            'service-1', 'key-1', signature2, creative2, noop))
+                        .to.eventually.equal(VerificationStatus.UNVERIFIED);
+                  });
+            })));
+
+    it('should report on extraneous malformed data',
+        () => key1.sign(creative1).then(signature => {
+          env.fetchMock.getOnce(
+              'https://signingservice1.net/keyset.json',
+              jwkSet([key1]).then(keyset => {
+                keyset.body['keys'].push({'foo': 'bar'});
+                return keyset;
+              }));
+          expectSigningServiceError('service-1');
+          verifier.loadKeyset('service-1');
+          return expect(
+              verifier.verifyCreativeAndSignature(
+                  'service-1', 'key-1', signature, creative1, noop))
+              .to.eventually.equal(VerificationStatus.OK);
+        }));
+
+    it('should return UNVERIFIED, report, and not retry on malformed key',
+        () => key1.sign(creative1).then(
+            signature1 => key1.sign(creative2).then(signature2 => {
+              env.fetchMock.getOnce(
+                  'https://signingservice1.net/keyset.json',
+                 {body: {'keys': [{'kid': 'key-1', 'foo': 'bar'}]}, headers});
+              expectSigningServiceError('service-1');
+              verifier.loadKeyset('service-1');
+              return verifier
+                  .verifyCreativeAndSignature(
+                      // eslint-disable-next-line indent
+                      'service-1', 'key-1', signature1, creative1, noop)
+                  .then(status => {
+                    expect(status).to.equal(VerificationStatus.UNVERIFIED);
+                    verifier.loadKeyset('service-1');
+                    return expect(
+                        verifier.verifyCreativeAndSignature(
+                            'service-1', 'key-1', signature2, creative2, noop))
+                        .to.eventually.equal(VerificationStatus.UNVERIFIED);
+                  });
+            })));
+
+    describe('#verify', () => {
+      it('should verify a signature header',
+          () => key1.sign(creative1).then(signature => {
+            env.fetchMock.getOnce(
+                'https://signingservice1.net/keyset.json', jwkSet([key1]));
+            verifier.loadKeyset('service-1');
+            expect(
+                verifier.verify(
+                    creative1,
+                    new Headers({
+                      'AMP-Fast-Fetch-Signature':
+                         `service-1:key-1:${base64EncodeFromBytes(signature)}`,
+                    }),
+                    noop))
+                .to.eventually.equal(VerificationStatus.OK);
+          }));
+
+      it('should return UNVERIFIED on no header', () => {
+        env.fetchMock.getOnce(
+            'https://signingservice1.net/keyset.json', jwkSet([key1]));
+        verifier.loadKeyset('service-1');
+        expect(verifier.verify(creative1, new Headers(), noop))
+            .to.eventually.equal(VerificationStatus.UNVERIFIED);
+      });
+
+      it('should return ERROR_SIGNATURE_MISMATCH on malformed header', () => {
+        env.fetchMock.getOnce(
+            'https://signingservice1.net/keyset.json', jwkSet([key1]));
+        env.sandbox.stub(user(), 'error');
+        verifier.loadKeyset('service-1');
+        expect(
+            verifier.verify(
+                creative1,
+                new Headers({
+                  'AMP-Fast-Fetch-Signature': 'service-1:key-1:Invalid base64!',
+                }),
+                noop))
+            .to.eventually.equal(VerificationStatus.ERROR_SIGNATURE_MISMATCH);
+      });
+    });
+  });
+});

--- a/extensions/amp-a4a/0.1/test/test-signature-verifier.js
+++ b/extensions/amp-a4a/0.1/test/test-signature-verifier.js
@@ -114,7 +114,7 @@ describes.fakeWin('SignatureVerifier', {amp: true}, env => {
 
     /**
      * @param {!Array<!Keypair>} keys
-     * @param {!Promise<!JsonObject>}
+     * @return {!Promise<!JsonObject>}
      */
     const jwkSet = keys =>
         Promise.all(keys.map(key => key.jwk()))
@@ -282,7 +282,8 @@ describes.fakeWin('SignatureVerifier', {amp: true}, env => {
               verifier.loadKeyset('service-1');
               return verifier
                   .verifyCreativeAndSignature(
-                  'service-1', 'key-1', signature1, creative1, noop)
+                      // eslint-disable-next-line indent
+                      'service-1', 'key-1', signature1, creative1, noop)
                   .then(status => {
                     expect(status).to.equal(
                         VerificationStatus.ERROR_KEY_NOT_FOUND);

--- a/extensions/amp-a4a/0.1/test/test-signature-verifier.js
+++ b/extensions/amp-a4a/0.1/test/test-signature-verifier.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-// TODO(@erwinmombay, #11081): eslint-disable-next-line needed due to linter bug
+// TODO(@jridgewell, #11081): fix linter to allow fixing weird indentation
 
 import * as sinon from 'sinon';
 
@@ -53,8 +53,7 @@ describes.fakeWin('SignatureVerifier', {amp: true}, env => {
     verifier.loadKeyset('service-1');
     return verifier
         .verifyCreativeAndSignature(
-            // eslint-disable-next-line indent
-            'service-1', 'key-1', creative1, new Uint8Array(256), noop)
+        'service-1', 'key-1', creative1, new Uint8Array(256), noop)
         .then(status => {
           expect(status).to.equal(VerificationStatus.UNVERIFIED);
           expect(env.fetchMock.called()).to.be.false;
@@ -155,8 +154,7 @@ describes.fakeWin('SignatureVerifier', {amp: true}, env => {
           const lifecycleSpy = env.sandbox.spy();
           return verifier
               .verifyCreativeAndSignature(
-                  // eslint-disable-next-line indent
-                  'service-1', 'key-1', signature, creative1, lifecycleSpy)
+              'service-1', 'key-1', signature, creative1, lifecycleSpy)
               .then(status => {
                 expect(status).to.equal(VerificationStatus.OK);
                 expect(lifecycleSpy).to.be.calledOnce;
@@ -177,8 +175,7 @@ describes.fakeWin('SignatureVerifier', {amp: true}, env => {
               verifier.loadKeyset('service-1');
               return verifier
                   .verifyCreativeAndSignature(
-                      // eslint-disable-next-line indent
-                      'service-1', 'key-1', signature1, creative1, noop)
+                  'service-1', 'key-1', signature1, creative1, noop)
                   .then(status => {
                     expect(status).to.equal(VerificationStatus.OK);
                     verifier.loadKeyset('service-1');
@@ -197,8 +194,7 @@ describes.fakeWin('SignatureVerifier', {amp: true}, env => {
               verifier.loadKeyset('service-1');
               return verifier
                   .verifyCreativeAndSignature(
-                      // eslint-disable-next-line indent
-                      'service-1', 'key-1', signature1, creative1, noop)
+                  'service-1', 'key-1', signature1, creative1, noop)
                   .then(status => {
                     expect(status).to.equal(VerificationStatus.OK);
                     env.fetchMock.getOnce(
@@ -221,8 +217,7 @@ describes.fakeWin('SignatureVerifier', {amp: true}, env => {
             verifier.loadKeyset('service-1');
             return verifier
                 .verifyCreativeAndSignature(
-                    // eslint-disable-next-line indent
-                    'service-1', 'key-1', signature1, creative1, noop)
+                'service-1', 'key-1', signature1, creative1, noop)
                 .then(status => {
                   expect(status).to.equal(VerificationStatus.OK);
                   env.fetchMock.getOnce(
@@ -282,8 +277,7 @@ describes.fakeWin('SignatureVerifier', {amp: true}, env => {
               verifier.loadKeyset('service-1');
               return verifier
                   .verifyCreativeAndSignature(
-                      // eslint-disable-next-line indent
-                      'service-1', 'key-1', signature1, creative1, noop)
+                  'service-1', 'key-1', signature1, creative1, noop)
                   .then(status => {
                     expect(status).to.equal(
                         VerificationStatus.ERROR_KEY_NOT_FOUND);
@@ -292,8 +286,7 @@ describes.fakeWin('SignatureVerifier', {amp: true}, env => {
                         verifier.verifyCreativeAndSignature(
                             'service-1', 'key-1', signature2, creative2, noop))
                         .to.eventually.equal(
-                            // eslint-disable-next-line indent
-                            VerificationStatus.ERROR_KEY_NOT_FOUND);
+                        VerificationStatus.ERROR_KEY_NOT_FOUND);
                   });
             })));
 
@@ -343,8 +336,7 @@ describes.fakeWin('SignatureVerifier', {amp: true}, env => {
               verifier.loadKeyset('service-1');
               return verifier
                   .verifyCreativeAndSignature(
-                      // eslint-disable-next-line indent
-                      'service-1', 'key-1', signature1, creative1, noop)
+                  'service-1', 'key-1', signature1, creative1, noop)
                   .then(status => {
                     expect(status).to.equal(VerificationStatus.UNVERIFIED);
                     verifier.loadKeyset('service-1');
@@ -365,8 +357,7 @@ describes.fakeWin('SignatureVerifier', {amp: true}, env => {
               verifier.loadKeyset('service-1');
               return verifier
                   .verifyCreativeAndSignature(
-                      // eslint-disable-next-line indent
-                      'service-1', 'key-1', signature1, creative1, noop)
+                  'service-1', 'key-1', signature1, creative1, noop)
                   .then(status => {
                     expect(status).to.equal(VerificationStatus.UNVERIFIED);
                     verifier.loadKeyset('service-1');
@@ -387,8 +378,7 @@ describes.fakeWin('SignatureVerifier', {amp: true}, env => {
               verifier.loadKeyset('service-1');
               return verifier
                   .verifyCreativeAndSignature(
-                      // eslint-disable-next-line indent
-                      'service-1', 'key-1', signature1, creative1, noop)
+                  'service-1', 'key-1', signature1, creative1, noop)
                   .then(status => {
                     expect(status).to.equal(VerificationStatus.UNVERIFIED);
                     verifier.loadKeyset('service-1');
@@ -425,8 +415,7 @@ describes.fakeWin('SignatureVerifier', {amp: true}, env => {
               verifier.loadKeyset('service-1');
               return verifier
                   .verifyCreativeAndSignature(
-                      // eslint-disable-next-line indent
-                      'service-1', 'key-1', signature1, creative1, noop)
+                  'service-1', 'key-1', signature1, creative1, noop)
                   .then(status => {
                     expect(status).to.equal(VerificationStatus.UNVERIFIED);
                     verifier.loadKeyset('service-1');

--- a/extensions/amp-a4a/0.1/test/test-signature-verifier.js
+++ b/extensions/amp-a4a/0.1/test/test-signature-verifier.js
@@ -292,7 +292,8 @@ describes.fakeWin('SignatureVerifier', {amp: true}, env => {
                         verifier.verifyCreativeAndSignature(
                             'service-1', 'key-1', signature2, creative2, noop))
                         .to.eventually.equal(
-                        VerificationStatus.ERROR_KEY_NOT_FOUND);
+                            // eslint-disable-next-line indent
+                            VerificationStatus.ERROR_KEY_NOT_FOUND);
                   });
             })));
 

--- a/testing/describes.js
+++ b/testing/describes.js
@@ -89,6 +89,7 @@ import {
   FakeWindow,
   interceptEventListeners,
 } from './fake-dom';
+import {stubService} from './test-helper';
 import {installFriendlyIframeEmbed} from '../src/friendly-iframe-embed';
 import {doNotLoadExternalResourcesInTest} from './iframe';
 import {Services} from '../src/services';
@@ -285,8 +286,10 @@ export const repeated = (function() {
 
 
 /**
- * Mocks Window.fetch in the given environment and exposes fetch-mock's mock()
- * function as `env.expectFetch(matcher, response)`.
+ * Mocks Window.fetch in the given environment and exposes `env.fetchMock`. For
+ * convenience, also exposes fetch-mock's mock() function as
+ * `env.expectFetch(matcher, response)`.
+ *
  * @param {!Object} env
  * @see http://www.wheresrhys.co.uk/fetch-mock/quickstart
  */
@@ -294,6 +297,7 @@ function attachFetchMock(env) {
   fetchMock.constructor.global = env.win;
   fetchMock._mock();
 
+  env.fetchMock = fetchMock;
   env.expectFetch = fetchMock.mock.bind(fetchMock);
 }
 
@@ -692,6 +696,17 @@ class AmpFixture {
         }
       });
     }
+
+    /**
+     * Stubs a method of a service object using Sinon.
+     *
+     * @param {string} serviceId
+     * @param {string} method
+     * @return {!sinon.stub}
+     */
+    env.stubService = (serviceId, method) => {
+      return stubService(env.sandbox, env.win, serviceId, method);
+    };
 
     /**
      * Installs the specified extension.

--- a/testing/fake-dom.js
+++ b/testing/fake-dom.js
@@ -65,6 +65,9 @@ export class FakeWindow {
     /** @const */
     this.Math = window.Math;
 
+    /** @const */
+    this.crypto = window.crypto || window.msCrypto;
+
     // Parent Window points to itself if spec.parent was not passed.
     /** @const @type {!Window} */
     this.parent = spec.parent ? new FakeWindow(spec.parent) : this;


### PR DESCRIPTION
At long last, the new verifier arrives!

...sort of. This change introduces the code for the new verifier into the repo, but does not cause it to be compiled into the Fast Fetch extensions in production. The actual SignatureVerifier class is dead code and should be optimized out by the compiler. It is just here so that unit tests can be run against it, and to facilitate the next PR which links it into the Fast Fetch extensions for real, as an experiment.

Replaces #9040 (the core logic from that PR is in here). Related to #7618. Follow-up to #10674.