### PR TITLE
Remove unnecessary server clean up message

### DIFF
--- a/build-system/server.js
+++ b/build-system/server.js
@@ -46,7 +46,6 @@ process.on('uncaughtException', function(err) {
 // Exit in the event of a crash in the parent gulp process.
 setInterval(function() {
   if (!isRunning(gulpProcess)) {
-    util.log(util.colors.red('Gulp process terminated, shutting down server'));
     process.exit(1);
   }
 }, 1000);


### PR DESCRIPTION
After #11069, it's no longer necessary to print a message when a server cleans up after itself. The message now gets printed as part of the next `gulp` task, which can be confusing in test logs.

Follow up to #11069
Fixes #11029