### PR TITLE
Validator Rollup

### DIFF
--- a/extensions/amp-audio/validator-amp-audio.protoascii
+++ b/extensions/amp-audio/validator-amp-audio.protoascii
@@ -30,7 +30,6 @@ attr_lists: { # amp-audio attributes that are common to both AMP and A4A format.
   attrs: { name: "artist" }
   attrs: { name: "artwork" }
   attrs: { name: "controls" }
-  attrs: { name: "controlslist" }
   attrs: { name: "loop"  value: "" }
   attrs: { name: "muted" value: "" }
   attrs: {

--- a/extensions/amp-audio/validator-amp-audio.protoascii
+++ b/extensions/amp-audio/validator-amp-audio.protoascii
@@ -30,6 +30,7 @@ attr_lists: { # amp-audio attributes that are common to both AMP and A4A format.
   attrs: { name: "artist" }
   attrs: { name: "artwork" }
   attrs: { name: "controls" }
+  attrs: { name: "controlslist" }
   attrs: { name: "loop"  value: "" }
   attrs: { name: "muted" value: "" }
   attrs: {

--- a/extensions/amp-position-observer/0.1/test/validator-amp-position-observer.html
+++ b/extensions/amp-position-observer/0.1/test/validator-amp-position-observer.html
@@ -70,3 +70,4 @@
   <amp-position-observer viewport-margins="100fx 100vh" layout="nodisplay"></amp-position-observer>
   <amp-position-observer viewport-margins="100vx 100px" layout="nodisplay"></amp-position-observer>
 </body>
+</html>

--- a/extensions/amp-position-observer/0.1/test/validator-amp-position-observer.html
+++ b/extensions/amp-position-observer/0.1/test/validator-amp-position-observer.html
@@ -70,4 +70,3 @@
   <amp-position-observer viewport-margins="100fx 100vh" layout="nodisplay"></amp-position-observer>
   <amp-position-observer viewport-margins="100vx 100px" layout="nodisplay"></amp-position-observer>
 </body>
-</html>

--- a/extensions/amp-video/validator-amp-video.protoascii
+++ b/extensions/amp-video/validator-amp-video.protoascii
@@ -79,10 +79,10 @@ tags: {  # <amp-video>
   attrs: { name: "[attribution]" }
   attrs: { name: "[controls]" }
   attrs: { name: "[loop]" }
-  attrs: { name: "[title]" }
   attrs: { name: "[poster]" }
   attrs: { name: "[preload]" }
   attrs: { name: "[src]" }
+  attrs: { name: "[title]" }
   attr_lists: "extended-amp-global"
   spec_url: "https://www.ampproject.org/docs/reference/components/amp-video"
   amp_layout: {

--- a/extensions/amp-video/validator-amp-video.protoascii
+++ b/extensions/amp-video/validator-amp-video.protoascii
@@ -79,7 +79,6 @@ tags: {  # <amp-video>
   attrs: { name: "[attribution]" }
   attrs: { name: "[controls]" }
   attrs: { name: "[loop]" }
-  attrs: { name: "[title]" }
   attrs: { name: "[poster]" }
   attrs: { name: "[preload]" }
   attrs: { name: "[src]" }

--- a/extensions/amp-video/validator-amp-video.protoascii
+++ b/extensions/amp-video/validator-amp-video.protoascii
@@ -79,6 +79,7 @@ tags: {  # <amp-video>
   attrs: { name: "[attribution]" }
   attrs: { name: "[controls]" }
   attrs: { name: "[loop]" }
+  attrs: { name: "[title]" }
   attrs: { name: "[poster]" }
   attrs: { name: "[preload]" }
   attrs: { name: "[src]" }

--- a/validator/engine/validator.js
+++ b/validator/engine/validator.js
@@ -3174,18 +3174,27 @@ function validateNoSiblingsAllowedTags(
   const tagStack = context.getTagStack();
 
   if (spec.siblingsDisallowed && context.numOfSiblings() > 0) {
-    context.addError(
+    if (amp.validator.LIGHT) {
+      validationResult.status = amp.validator.ValidationResult.Status.FAIL;
+      return;
+    } else {
+      context.addError(
         amp.validator.ValidationError.Severity.ERROR,
         amp.validator.ValidationError.Code.TAG_NOT_ALLOWED_TO_HAVE_SIBLINGS,
         context.getDocLocator(),
         /* params */
         [spec.tagName.toLowerCase(), tagStack.getParent().toLowerCase()],
         getTagSpecUrl(spec), validationResult);
+    }
   }
 
   if (tagStack.parentHasChildWithNoSiblingRule() &&
       context.numOfSiblings() > 0) {
-    context.addError(
+    if (amp.validator.LIGHT) {
+      validationResult.status = amp.validator.ValidationResult.Status.FAIL;
+      return;
+    } else {
+      context.addError(
         amp.validator.ValidationError.Severity.ERROR,
         amp.validator.ValidationError.Code.TAG_NOT_ALLOWED_TO_HAVE_SIBLINGS,
         tagStack.parentOnlyChildErrorLineCol(),
@@ -3195,6 +3204,7 @@ function validateNoSiblingsAllowedTags(
           tagStack.getParent().toLowerCase()
         ],
         getTagSpecUrl(spec), validationResult);
+    }
   }
 
   if (spec.siblingsDisallowed) {

--- a/validator/engine/validator.js
+++ b/validator/engine/validator.js
@@ -1178,8 +1178,7 @@ let DescendantConstraints;
  * @typedef {{ tagName: string,
  *             hasDescendantConstraintLists: boolean,
  *             childTagMatcher: ?ChildTagMatcher,
- *             referencePointMatcher: ?ReferencePointMatcher,
- *             dataAmpReportTestValue: ?string }}
+ *             referencePointMatcher: ?ReferencePointMatcher }}
  */
 let TagStackEntry;
 
@@ -1232,23 +1231,11 @@ class TagStack {
    * @param {!Array<string>} encounteredAttrs Alternating key/value pairs.
    */
   enterTag(tagName, context, result, encounteredAttrs) {
-    let maybeDataAmpReportTestValue = null;
-    if (!amp.validator.LIGHT) {
-      for (let i = 0; i < encounteredAttrs.length; i += 2) {
-        const attrName = encounteredAttrs[i];
-        const attrValue = encounteredAttrs[i + 1];
-        if (attrName === 'data-amp-report-test') {
-          maybeDataAmpReportTestValue = attrValue;
-          break;
-        }
-      }
-    }
     this.stack_.push({
       tagName: tagName,
       hasDescendantConstraintLists: false,
       childTagMatcher: null,
       referencePointMatcher: null,
-      dataAmpReportTestValue: maybeDataAmpReportTestValue
     });
   }
 
@@ -1356,17 +1343,6 @@ class TagStack {
   getCurrent() {
     goog.asserts.assert(this.stack_.length > 0, 'Empty tag stack.');
     return this.stack_[this.stack_.length - 1].tagName;
-  };
-
-  /**
-   * The value of the data-amp-report-test attribute for the current tag,
-   * which may be null.
-   * @return {?string}
-   */
-  getReportTestValue() {
-    if (this.stack_.length > 0)
-      return this.stack_[this.stack_.length - 1].dataAmpReportTestValue;
-    return null;
   };
 
   /**
@@ -2108,9 +2084,6 @@ class Context {
     error.line = lineCol.getLine();
     error.col = lineCol.getCol();
     error.specUrl = (specUrl === null ? '' : specUrl);
-    const reportTestValue = this.tagStack_.getReportTestValue();
-    if (reportTestValue !== null)
-      error.dataAmpReportTestValue = reportTestValue;
 
     this.addBuiltError(error, validationResult);
   }

--- a/validator/engine/validator.js
+++ b/validator/engine/validator.js
@@ -1177,6 +1177,9 @@ let DescendantConstraints;
 /**
  * @typedef {{ tagName: string,
  *             hasDescendantConstraintLists: boolean,
+ *             numOfChildren: number,
+ *             onlyChildTagName: string,
+ *             onlyChildErrorLineCol: LineCol,
  *             childTagMatcher: ?ChildTagMatcher,
  *             referencePointMatcher: ?ReferencePointMatcher }}
  */
@@ -1221,6 +1224,22 @@ class TagStack {
   }
 
   /**
+   * @param {string} tagName
+   * @return {TagStackEntry} a new TagStackEntry.
+   */
+  createNewTagStackEntry(tagName) {
+    return {
+      tagName: tagName,
+      hasDescendantConstraintLists: false,
+      numOfChildren: 0,
+      onlyChildTagName: '',
+      onlyChildErrorLineCol: null,
+      childTagMatcher: null,
+      referencePointMatcher: null
+    };
+  }
+
+  /**
    * Enter a tag, opening a scope for child tags. Reason |context| and
    * |result| are provided is that entering a tag can close the previous
    * tag, which can trigger validation (e.g., the previous tag may be
@@ -1231,12 +1250,8 @@ class TagStack {
    * @param {!Array<string>} encounteredAttrs Alternating key/value pairs.
    */
   enterTag(tagName, context, result, encounteredAttrs) {
-    this.stack_.push({
-      tagName: tagName,
-      hasDescendantConstraintLists: false,
-      childTagMatcher: null,
-      referencePointMatcher: null,
-    });
+    this.stack_.push(this.createNewTagStackEntry(tagName));
+    this.increaseChildCounterForParent();
   }
 
   /**
@@ -1346,14 +1361,86 @@ class TagStack {
   };
 
   /**
+   * The parent of the current stack entry.
+   * @return {?TagStackEntry}
+   */
+  getParentStackEntry() {
+    if (this.stack_.length >= 2) {
+      return this.stack_[this.stack_.length - 2];
+    }
+    return null;
+  }
+
+  /**
    * The name of the parent of the current tag.
    * @return {string}
    */
   getParent() {
-    if (this.stack_.length >= 2) {
-      return this.stack_[this.stack_.length - 2].tagName;
+    const parent = this.getParentStackEntry();
+    return (parent === null) ? '$ROOT' : parent.tagName;
+  }
+
+  /**
+   * The number of siblings that have been discovered up to now by traversing
+   * the stack.
+   * @return {number}
+   */
+  numOfSiblings() {
+    const parent = this.getParentStackEntry();
+    if (parent !== null) return parent.numOfChildren - 1;
+    return 0;
+  }
+
+  /**
+   * Increases the Parent tag's child count.
+   */
+  increaseChildCounterForParent() {
+    const parent = this.getParentStackEntry();
+    if (parent !== null) ++parent.numOfChildren;
+  }
+
+  /**
+   * Tells the parent of the current stack entry that it can only have 1 child
+   * and that child must be me (the current stack entry).
+   * @param {string} tagName The current stack entry's tag name.
+   * @param {amp.htmlparser.DocLocator} docLocator The line and col of where the
+   *  current stack entry appears.
+   */
+  tellParentNoSiblingsAllowed(tagName, docLocator) {
+    const parent = this.getParentStackEntry();
+    if (parent !== null) {
+      parent.onlyChildTagName = tagName;
+      parent.onlyChildErrorLineCol =
+          new LineCol(docLocator.getLine(), docLocator.getCol());
     }
-    return '$ROOT';
+  }
+
+  /**
+   * @return {LineCol} The LineCol of the tag that set the 'no siblings allowed'
+   * rule.
+   */
+  parentOnlyChildErrorLineCol() {
+    const parent = this.getParentStackEntry();
+    if (parent !== null) return parent.onlyChildErrorLineCol;
+    return null;
+  }
+
+  /**
+   * @return {string} The name of the tag that set the 'no siblings allowed'
+   * rule.
+   */
+  parentOnlyChildTagName() {
+    const parent = this.getParentStackEntry();
+    if (parent !== null) return parent.onlyChildTagName;
+    return '';
+  }
+
+  /**
+   * @return {boolean} true if this tag's parent has a child with 'no siblings
+   * allowed' rule. Else false.
+   */
+  parentHasChildWithNoSiblingRule() {
+    return this.parentOnlyChildTagName().length > 0;
   }
 
   /**
@@ -1788,7 +1875,7 @@ class ExtensionsContext {
     // AMP-AD is grandfathered in to not require the respective extension
     // javascript file for historical reasons. We still need to mark that
     // the extension is used if we see the tags.
-    this.extensionsLoaded_["amp-ad"] = true;
+    this.extensionsLoaded_['amp-ad'] = true;
 
     /**
      * @type {!Array<string>}
@@ -2252,6 +2339,26 @@ class Context {
    */
   allowedDescendantsList() {
     return this.tagStack_.allowedDescendantsList();
+  }
+
+  /**
+   * The number of siblings that have been discovered up to now by traversing
+   * the stack.
+   * @return {number}
+   */
+  numOfSiblings() {
+    return this.tagStack_.numOfSiblings();
+  }
+
+  /**
+   * Tells the parent of the current stack entry that it can only have 1 child
+   * and that child must be me (the current stack entry).
+   * @param {string} tagName The current stack entry's tag name.
+   * @param {amp.htmlparser.DocLocator} docLocator The line and col of where the
+   *  current stack entry appears.
+   */
+  tellParentNoSiblingsAllowed(tagName, docLocator) {
+    this.tagStack_.tellParentNoSiblingsAllowed(tagName, docLocator);
   }
 }
 
@@ -3052,6 +3159,46 @@ function validateDescendantTags(
         return;
       }
     }
+  }
+}
+
+/**
+ * Validates if the 'no siblings allowed' rule if it exists.
+ * @param {!ParsedTagSpec} parsedTagSpec
+ * @param {!Context} context
+ * @param {!amp.validator.ValidationResult} validationResult
+ */
+function validateNoSiblingsAllowedTags(
+    parsedTagSpec, context, validationResult) {
+  const spec = parsedTagSpec.getSpec();
+  const tagStack = context.getTagStack();
+
+  if (spec.siblingsDisallowed && context.numOfSiblings() > 0) {
+    context.addError(
+        amp.validator.ValidationError.Severity.ERROR,
+        amp.validator.ValidationError.Code.TAG_NOT_ALLOWED_TO_HAVE_SIBLINGS,
+        context.getDocLocator(),
+        /* params */
+        [spec.tagName.toLowerCase(), tagStack.getParent().toLowerCase()],
+        getTagSpecUrl(spec), validationResult);
+  }
+
+  if (tagStack.parentHasChildWithNoSiblingRule() &&
+      context.numOfSiblings() > 0) {
+    context.addError(
+        amp.validator.ValidationError.Severity.ERROR,
+        amp.validator.ValidationError.Code.TAG_NOT_ALLOWED_TO_HAVE_SIBLINGS,
+        tagStack.parentOnlyChildErrorLineCol(),
+        /* params */
+        [
+          tagStack.parentOnlyChildTagName().toLowerCase(),
+          tagStack.getParent().toLowerCase()
+        ],
+        getTagSpecUrl(spec), validationResult);
+  }
+
+  if (spec.siblingsDisallowed) {
+    context.tellParentNoSiblingsAllowed(spec.tagName, context.getDocLocator());
   }
 }
 
@@ -3919,6 +4066,7 @@ function validateTagAgainstSpec(
   validateParentTag(parsedSpec, context, resultForAttempt);
   validateAncestorTags(parsedSpec, context, resultForAttempt);
   validateDescendantTags(parsedSpec, context, resultForAttempt, parsedRules);
+  validateNoSiblingsAllowedTags(parsedSpec, context, resultForAttempt);
 
   // Set Descendent Constraint rules.
   const descendantTagLists = parsedRules.getDescendantTagLists();
@@ -5291,7 +5439,9 @@ amp.validator.categorizeError = function(error) {
       error.code ===
           amp.validator.ValidationError.Code.DUPLICATE_REFERENCE_POINT ||
       error.code ===
-          amp.validator.ValidationError.Code.TAG_REFERENCE_POINT_CONFLICT) {
+          amp.validator.ValidationError.Code.TAG_REFERENCE_POINT_CONFLICT ||
+      error.code ===
+          amp.validator.ValidationError.Code.TAG_NOT_ALLOWED_TO_HAVE_SIBLINGS) {
     return amp.validator.ErrorCategory.Code.AMP_TAG_PROBLEM;
   }
   // E.g. "The tag 'picture' is disallowed."

--- a/validator/engine/validator_test.js
+++ b/validator/engine/validator_test.js
@@ -170,16 +170,6 @@ ValidatorTestCase.prototype.run = function() {
   assert.fail('', '', message, '');
 };
 
-describe('ValidatorTestdata', () => {
-  it('reports data-amp-report-test values', () => {
-    const result = amp.validator.validateString(
-        '<!doctype lemur data-amp-report-test="foo">');
-    assertStrictEqual(
-        result.status, amp.validator.ValidationResult.Status.FAIL);
-    assertStrictEqual('foo', result.errors[0].dataAmpReportTestValue);
-  });
-});
-
 /**
  * A strict comparison between two values.
  * Note: Unfortunately assert.strictEqual has some drawbacks, including that

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -25,7 +25,7 @@ min_validator_revision_required: 246
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 471
+spec_file_revision: 472
 
 styles_spec_url: "https://www.ampproject.org/docs/guides/author-develop/responsive/style_pages"
 

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -25,7 +25,7 @@ min_validator_revision_required: 246
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 470
+spec_file_revision: 471
 
 styles_spec_url: "https://www.ampproject.org/docs/guides/author-develop/responsive/style_pages"
 

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -25,7 +25,7 @@ min_validator_revision_required: 238
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 467
+spec_file_revision: 468
 
 styles_spec_url: "https://www.ampproject.org/docs/guides/author-develop/responsive/style_pages"
 

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -25,7 +25,7 @@ min_validator_revision_required: 246
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 472
+spec_file_revision: 473
 
 styles_spec_url: "https://www.ampproject.org/docs/guides/author-develop/responsive/style_pages"
 

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -25,7 +25,7 @@ min_validator_revision_required: 238
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 468
+spec_file_revision: 469
 
 styles_spec_url: "https://www.ampproject.org/docs/guides/author-develop/responsive/style_pages"
 

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -25,7 +25,7 @@ min_validator_revision_required: 238
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 466
+spec_file_revision: 467
 
 styles_spec_url: "https://www.ampproject.org/docs/guides/author-develop/responsive/style_pages"
 

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -20,12 +20,12 @@
 # in production from crashing. This id is not relevant to validator.js
 # because thus far, engine (validator.js) and spec file
 # (validator-main.protoascii) are always released together.
-min_validator_revision_required: 238
+min_validator_revision_required: 246
 # The spec file revision allows the validator engine to distinguish
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 469
+spec_file_revision: 470
 
 styles_spec_url: "https://www.ampproject.org/docs/guides/author-develop/responsive/style_pages"
 
@@ -3771,6 +3771,7 @@ error_specificity { code: DEPRECATED_TAG specificity: 102 }
 error_specificity { code: DISALLOWED_MANUFACTURED_BODY specificity: 104 }
 error_specificity { code: DOCUMENT_TOO_COMPLEX specificity: 105 }
 error_specificity { code: INCORRECT_MIN_NUM_CHILD_TAGS specificity: 106 }
+error_specificity { code: TAG_NOT_ALLOWED_TO_HAVE_SIBLINGS specificity: 107 }
 # Error formats
 error_formats {
   code: UNKNOWN_CODE
@@ -3994,6 +3995,11 @@ error_formats {
 error_formats {
   code: INCORRECT_MIN_NUM_CHILD_TAGS
   format: "Tag '%1' must have a minimum of %2 child tags - saw %3 child tags."
+}
+error_formats {
+  code: TAG_NOT_ALLOWED_TO_HAVE_SIBLINGS
+  format: "Tag '%1' is not allowed to have any sibling tags ('%2' should only"
+  " have 1 child)."
 }
 error_formats {
   code: DISALLOWED_CHILD_TAG_NAME

--- a/validator/validator.proto
+++ b/validator/validator.proto
@@ -356,7 +356,7 @@ message ExtensionSpec {
 // Some tags are mandatory. Note that the tag name is not unique, that is,
 // there can be multiple tag specs covering the same name, e.g., for
 // multiple meta tags (with different attributes).
-// NEXT AVAILABLE TAG: 30
+// NEXT AVAILABLE TAG: 31
 message TagSpec {
   // The HtmlFormat field tells the validator which html formats
   // (ie: (<html ⚡> vs <html a4⚡>) this HTML TagSpec is relevant for.)
@@ -456,6 +456,9 @@ message TagSpec {
   // of this tag in the document.
   optional ChildTagSpec child_tags = 19;
 
+  // If set to true, this tag cannot have any siblings.
+  optional bool siblings_disallowed = 30;
+
   // The reference_points defined by this TagSpec instance determine how
   // specific child tags are identified. Please see the comment for the
   // ReferencePoint message.
@@ -554,7 +557,7 @@ message ValidationError {
     // DO NOT REASSIGN the previously used values 2, 3.
   }
   optional Severity severity = 6 [ default = ERROR ];
-  // NEXT AVAILABLE TAG: 87
+  // NEXT AVAILABLE TAG: 88
   enum Code {
     UNKNOWN_CODE = 0;
     MANDATORY_TAG_MISSING = 1;
@@ -612,6 +615,7 @@ message ValidationError {
     CHILD_TAG_DOES_NOT_SATISFY_REFERENCE_POINT = 66;
     MANDATORY_REFERENCE_POINT_MISSING = 67;
     DUPLICATE_REFERENCE_POINT = 68;
+    TAG_NOT_ALLOWED_TO_HAVE_SIBLINGS = 87;
     TAG_REFERENCE_POINT_CONFLICT = 69;
     CHILD_TAG_DOES_NOT_SATISFY_REFERENCE_POINT_SINGULAR = 70;
     BASE_TAG_MUST_PRECEED_ALL_URLS = 78;


### PR DESCRIPTION
 - Revision bump, amp-position-observer
 - Revision bump, amp-audio/amp-video
 - Remove no longer used data-amp-report-test attribute handling
 - Revision bump
 - New validator rules to disallow sibling tags
 - Revision bump for #10965 and #10976
 - Adding lite to new validator rules for disallowing siblings
 - Revision bump from minor clean-up