### PR TITLE
Ensure experiment is passed in ad request from PR #11021

### DIFF
--- a/extensions/amp-ad-network-adsense-impl/0.1/adsense-a4a-config.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/adsense-a4a-config.js
@@ -94,7 +94,7 @@ export function adsenseIsA4AEnabled(win, element) {
   };
   randomlySelectUnsetExperiments(win, ffDrExperimentInfoMap);
   addExperimentIdToElement(experimentId, element);
-  let delayedFetchExperimentId = getExperimentBranch(win, FF_DR_EXP_NAME);
+  const delayedFetchExperimentId = getExperimentBranch(win, FF_DR_EXP_NAME);
   if (delayedFetchExperimentId) {
     addExperimentIdToElement(delayedFetchExperimentId, element);
   }

--- a/extensions/amp-ad-network-adsense-impl/0.1/adsense-a4a-config.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/adsense-a4a-config.js
@@ -93,6 +93,11 @@ export function adsenseIsA4AEnabled(win, element) {
     ],
   };
   randomlySelectUnsetExperiments(win, ffDrExperimentInfoMap);
+  addExperimentIdToElement(experimentId, element);
+  let delayedFetchExperimentId = getExperimentBranch(win, FF_DR_EXP_NAME);
+  if (delayedFetchExperimentId) {
+    addExperimentIdToElement(delayedFetchExperimentId, element);
+  }
   if (!isGoogleAdsA4AValidEnvironment(win) ||
       !element.getAttribute('data-ad-client')) {
     return false;

--- a/extensions/amp-ad-network-adsense-impl/0.1/adsense-a4a-config.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/adsense-a4a-config.js
@@ -93,7 +93,6 @@ export function adsenseIsA4AEnabled(win, element) {
     ],
   };
   randomlySelectUnsetExperiments(win, ffDrExperimentInfoMap);
-  addExperimentIdToElement(experimentId, element);
   const delayedFetchExperimentId = getExperimentBranch(win, FF_DR_EXP_NAME);
   if (delayedFetchExperimentId) {
     addExperimentIdToElement(delayedFetchExperimentId, element);


### PR DESCRIPTION
Fix to PR #11021 which did not set experiment id attribute on amp-ad element causing experiment id to not be included in the ad request.