### PR TITLE
Change randomization to use seedrandom

### DIFF
--- a/build-system/config.js
+++ b/build-system/config.js
@@ -56,11 +56,19 @@ var commonTestPaths = [
   },
 ];
 
-var testPaths = commonTestPaths.concat([
+var basicTestPaths = [
   'test/**/*.js',
   'ads/**/test/test-*.js',
   'extensions/**/test/**/*.js',
-]);
+];
+
+var testPaths = commonTestPaths.concat(basicTestPaths);
+
+var a4aTestPaths = [
+  'extensions/amp-a4a/**/test/**/*.js',
+  'extensions/amp-ad-network-*/**/test/**/*.js',
+  'ads/google/a4a/test/*.js'
+];
 
 var unitTestPaths = commonTestPaths.concat([
   'test/functional/**/*.js',
@@ -77,7 +85,9 @@ var integrationTestPaths = commonTestPaths.concat([
 /** @const  */
 module.exports = {
   commonTestPaths: commonTestPaths,
+  basicTestPaths: basicTestPaths,
   testPaths: testPaths,
+  a4aTestPaths: a4aTestPaths,
   unitTestPaths: unitTestPaths,
   integrationTestPaths: integrationTestPaths,
   lintGlobs: [

--- a/build-system/tasks/runtime-test.js
+++ b/build-system/tasks/runtime-test.js
@@ -135,9 +135,8 @@ function printArgvMessages() {
     unit: 'Running only the unit tests. Requires ' +
         cyan('gulp css') +  ' to have been run first.',
     randomize: 'Randomizing the order in which tests are run.',
-    a4a: 'Runs all A4A tests',
-    seed: 'Seeds the test order randomization. Use with --randomize ' +
-        'or --a4a',
+    a4a: 'Runing only A4A tests.',
+    seed: 'Randomizing test order with seed ' + cyan(argv.seed) + '.',
     compiled:  'Running tests against minified code.',
     grep: 'Only running tests that match the pattern "' +
         cyan(argv.grep) + '".'
@@ -204,7 +203,6 @@ gulp.task('test', 'Runs tests',
     const testPaths = argv.a4a ? config.a4aTestPaths : config.basicTestPaths;
 
     var testFiles = [];
-
     for (var index in testPaths) {
       testFiles = testFiles.concat(glob.sync(testPaths[index]));
     }
@@ -214,10 +212,11 @@ gulp.task('test', 'Runs tests',
       util.log(
           util.colors.yellow('Randomizing:'),
           util.colors.cyan('Seeding with value', seed));
-      util.log(util.colors.yellow('To rerun same ordering, append'),
-               util.colors.cyan(`--seed=${seed}`),
-               util.colors.yellow('to your invocation of'),
-               util.colors.cyan('gulp test'));
+      util.log(
+          util.colors.yellow('To rerun same ordering, append'),
+          util.colors.cyan(`--seed=${seed}`),
+          util.colors.yellow('to your invocation of'),
+          util.colors.cyan('gulp test'));
       testFiles = shuffleSeed.shuffle(testFiles, seed);
     }
 

--- a/build-system/tasks/runtime-test.js
+++ b/build-system/tasks/runtime-test.js
@@ -27,6 +27,7 @@ var util = require('gulp-util');
 var webserver = require('gulp-webserver');
 var app = require('../test-server').app;
 var karmaDefault = require('./karma.conf');
+var seedrandom = require('seedrandom');
 
 
 const green = util.colors.green;
@@ -219,21 +220,12 @@ gulp.task('test', 'Runs tests',
       testFiles = testFiles.concat(glob.sync(testPaths[index]));
     }
 
-    if (argv.randomize) {
-      testFiles = shuffleArray(testFiles);
+    if (argv.randomize || argv.a4a) {
+      testFiles = shuffleArray(testFiles, argv.seed);
     }
 
     testFiles.splice(testFiles.indexOf('test/_init_tests.js'),1);
     c.files = config.commonTestPaths.concat(testFiles);
-
-    util.log(util.colors.blue(JSON.stringify(c.files)));
-    util.log(yellow("Save the above files in a .json file to reuse"));
-
-  } else if (argv.testlist) {
-    var file = read.file(argv.testlist);
-    util.log(file);
-    c.files = file;
-
   } else {
     c.files = config.testPaths;
   }
@@ -334,20 +326,29 @@ gulp.task('test', 'Runs tests',
     'grep': '  Runs tests that match the pattern',
     'files': '  Runs tests for specific files',
     'randomize': '  Runs entire test suite in random order',
-    'testlist': '  Runs tests specified in JSON by supplied file',
+    'seed': '  Seeds the test order randomization. Use with --randomize ' +
+        'or --a4a',
     'glob': '  Explicitly expands test paths using glob before passing ' +
         'to Karma',
     'nohelp': '  Silence help messages that are printed prior to test run',
+    'a4a': '  Runs all A4A tests',
   }
 });
 
 
-function shuffleArray(array) {
-    for (var i = array.length - 1; i > 0; i--) {
-        var j = Math.floor(Math.random() * (i + 1));
-        var temp = array[i];
-        array[i] = array[j];
-        array[j] = temp;
-    }
-    return array;
+function shuffleArray(array, seed) {
+  seed = seed || Math.random();
+  util.log(
+      util.colors.red('Randomizing:'),
+      yellow('Seeding with value', seed));
+  util.log(util.colors.red('Randomizing:'),
+           yellow(`To rerun same ordering, append --seed=${seed}`));
+  const rng = seedrandom(seed);
+  for (var i = array.length - 1; i > 0; i--) {
+    var j = Math.floor(rng() * (i + 1));
+    var temp = array[i];
+    array[i] = array[j];
+    array[j] = temp;
+  }
+  return array;
 }

--- a/build-system/tasks/runtime-test.js
+++ b/build-system/tasks/runtime-test.js
@@ -135,7 +135,7 @@ function printArgvMessages() {
     unit: 'Running only the unit tests. Requires ' +
         cyan('gulp css') +  ' to have been run first.',
     randomize: 'Randomizing the order in which tests are run.',
-    a4a: 'Runing only A4A tests.',
+    a4a: 'Running only A4A tests.',
     seed: 'Randomizing test order with seed ' + cyan(argv.seed) + '.',
     compiled:  'Running tests against minified code.',
     grep: 'Only running tests that match the pattern "' +

--- a/build-system/tasks/runtime-test.js
+++ b/build-system/tasks/runtime-test.js
@@ -201,12 +201,7 @@ gulp.task('test', 'Runs tests',
   } else if (argv.unit) {
     c.files = config.unitTestPaths;
   } else if (argv.randomize || argv.glob || argv.a4a) {
-    var testPaths;
-    if (argv.a4a) {
-      testPaths = config.a4aTestPaths;
-    } else {
-      testPaths = config.basicTestPaths;
-    }
+    const testPaths = argv.a4a ? config.a4aTestPaths : config.basicTestPaths;
 
     var testFiles = [];
 
@@ -217,14 +212,16 @@ gulp.task('test', 'Runs tests',
     if (argv.randomize || argv.a4a) {
       const seed = argv.seed || Math.random();
       util.log(
-          util.colors.red('Randomizing:'),
-          yellow('Seeding with value', seed));
-      util.log(util.colors.red('Randomizing:'),
-               yellow(`To rerun same ordering, append --seed=${seed}`));
+          util.colors.yellow('Randomizing:'),
+          util.colors.cyan('Seeding with value', seed));
+      util.log(util.colors.yellow('To rerun same ordering, append'),
+               util.colors.cyan(`--seed=${seed}`),
+               util.colors.yellow('to your invocation of'),
+               util.colors.cyan('gulp test'));
       testFiles = shuffleSeed.shuffle(testFiles, seed);
     }
 
-    testFiles.splice(testFiles.indexOf('test/_init_tests.js'),1);
+    testFiles.splice(testFiles.indexOf('test/_init_tests.js'), 1);
     c.files = config.commonTestPaths.concat(testFiles);
   } else {
     c.files = config.testPaths;

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "pretty-bytes": "2.0.1",
     "request": "2.73.0",
     "rimraf": "2.5.1",
+    "seedrandom": "2.4.3",
     "sinon": "1.17.7",
     "sinon-chai": "2.8.0",
     "text-table": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "pretty-bytes": "2.0.1",
     "request": "2.73.0",
     "rimraf": "2.5.1",
-    "seedrandom": "2.4.3",
+    "shuffle-seed": "1.1.6",
     "sinon": "1.17.7",
     "sinon-chai": "2.8.0",
     "text-table": "0.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7698,6 +7698,12 @@ shelljs@^0.7.0, shelljs@^0.7.5:
     interpret "^1.0.0"
     rechoir "^0.6.2"
 
+shuffle-seed@1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/shuffle-seed/-/shuffle-seed-1.1.6.tgz#533c12683bab3b4fa3e8751fc4e562146744260b"
+  dependencies:
+    seedrandom "^2.4.2"
+
 sigmund@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/sigmund/-/sigmund-1.0.1.tgz#3ff21f198cad2175f9f3b781853fd94d0d19b590"


### PR DESCRIPTION
Fixes https://github.com/ampproject/amphtml/issues/10450
With this change, if a user runs 

```
gulp test --randomze
```

The test runner will output:

```
[10:51:02] Randomizing: Seeding with value 0.0710932902587813
[10:51:02] Randomizing: To rerun same ordering, append --seed=0.0710932902587813
```

Then to rerun the same ordering, they just run 

``` 
gulp test --randomize --seed=0.0710932902587813
```

This PR also fixes `gulp test --a4a` to automatically randomize each test run, which it was not doing.