### PR TITLE
Wrap shadow-v0.js in an IIFE to prevent global name collisions

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -325,7 +325,6 @@ function compile(watch, shouldMinify, opt_preventRemoveAndMakeDir,
           watch: watch,
           preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
           minify: shouldMinify,
-          wrapper: '<%= contents %>'
         })
       );
     }


### PR DESCRIPTION
Fixes #10799

Google Analytics would overwrite one of the `shadow-v0.js`'s minified functions with its own function of the same minified name, causing a strange bug. If we wrap `shadow-v0.js` in an IIFE then its variables won't be on the global object and won't be easily overwritten.