### PR TITLE
Request re-measure before build is complete

### DIFF
--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -351,10 +351,8 @@ export class Resource {
   changeSize(newHeight, newWidth, opt_newMargins) {
     this.element./*OK*/changeSize(newHeight, newWidth, opt_newMargins);
 
-    // Schedule for re-layout.
-    if (this.state_ != ResourceState.NOT_BUILT) {
-      this.state_ = ResourceState.NOT_LAID_OUT;
-    }
+    // Schedule for re-measure and possible re-layout.
+    this.requestMeasure();
   }
 
   /**
@@ -520,10 +518,6 @@ export class Resource {
    * Requests the element to be remeasured on the next pass.
    */
   requestMeasure() {
-    if (this.state_ == ResourceState.NOT_BUILT) {
-      // Can't measure unbuilt element.
-      return;
-    }
     this.isMeasureRequested_ = true;
   }
 

--- a/test/functional/test-resource.js
+++ b/test/functional/test-resource.js
@@ -255,11 +255,11 @@ describe('Resource', () => {
     });
   });
 
-  it('should noop request measure when not built', () => {
+  it('should request measure even when not built', () => {
     expect(resource.isMeasureRequested()).to.be.false;
     elementMock.expects('getBoundingClientRect').never();
     resource.requestMeasure();
-    expect(resource.isMeasureRequested()).to.be.false;
+    expect(resource.isMeasureRequested()).to.be.true;
   });
 
   it('should request measure when built', () => {
@@ -579,11 +579,12 @@ describe('Resource', () => {
   });
 
   it('should change size and update state', () => {
+    expect(resource.isMeasureRequested()).to.be.false;
     resource.state_ = ResourceState.READY_FOR_LAYOUT;
     elementMock.expects('changeSize').withExactArgs(111, 222,
         {top: 1, right: 2, bottom: 3, left: 4}).once();
     resource.changeSize(111, 222, {top: 1, right: 2, bottom: 3, left: 4});
-    expect(resource.getState()).to.equal(ResourceState.NOT_LAID_OUT);
+    expect(resource.isMeasureRequested()).to.be.true;
   });
 
   it('should change size but not state', () => {


### PR DESCRIPTION
Measures have been extended to pre-built elements long time ago. These are holdover bugs.


Partial for #10866.