### PR TITLE
Validator rollup

### DIFF
--- a/extensions/amp-timeago/0.1/test/validator-amp-timeago.html
+++ b/extensions/amp-timeago/0.1/test/validator-amp-timeago.html
@@ -32,6 +32,9 @@
     <!-- valid -->
     <amp-timeago layout="fixed" width="160" height="20" datetime="2017-04-11T00:37:33.809Z" locale="en" cutoff="8640000">Saturday 11 April 2017 00.37</amp-timeago>
 
+    <!-- valid, international locale -->
+    <amp-timeago layout="fixed" width="160" height="20" datetime="2017-08-11T18:58:58.000Z" locale="fr" cutoff="8640000">Lundi 14 août 2017</amp-timeago>
+
     <!-- valid, locale optional, cutoff optional -->
     <amp-timeago layout="fixed" width="160" height="20" datetime="2017-04-11T00:37:33.809Z">Saturday 11 April 2017 00.37</amp-timeago>
 

--- a/extensions/amp-timeago/0.1/test/validator-amp-timeago.out
+++ b/extensions/amp-timeago/0.1/test/validator-amp-timeago.out
@@ -1,3 +1,3 @@
 FAIL
-amp-timeago/0.1/test/validator-amp-timeago.html:39:4 The attribute 'datetime' in tag 'amp-timeago' is set to the invalid value '2017/04/11'. (see https://www.ampproject.org/docs/reference/components/amp-timeago) [AMP_TAG_PROBLEM]
-amp-timeago/0.1/test/validator-amp-timeago.html:42:4 The mandatory attribute 'datetime' is missing in tag 'amp-timeago'. (see https://www.ampproject.org/docs/reference/components/amp-timeago) [AMP_TAG_PROBLEM]
+amp-timeago/0.1/test/validator-amp-timeago.html:42:4 The attribute 'datetime' in tag 'amp-timeago' is set to the invalid value '2017/04/11'. (see https://www.ampproject.org/docs/reference/components/amp-timeago) [AMP_TAG_PROBLEM]
+amp-timeago/0.1/test/validator-amp-timeago.html:45:4 The mandatory attribute 'datetime' is missing in tag 'amp-timeago'. (see https://www.ampproject.org/docs/reference/components/amp-timeago) [AMP_TAG_PROBLEM]

--- a/extensions/amp-timeago/validator-amp-timeago.protoascii
+++ b/extensions/amp-timeago/validator-amp-timeago.protoascii
@@ -42,9 +42,11 @@ tags: {  # <amp-timeago>
   attrs: { name: "locale" }
   attr_lists: "extended-amp-global"
   cdata: {
-    # Regex: \s*[\w.,:/+-]+(\s*[\w.,:/+-]+)*\s*
+    # Regex: \s*[\w\p{L}\p{N}_.,:/+-]+(\s*[\w\p{L}\p{N}_.,:/+-]+)*\s*
     # CDATA such as: Saturday 11 April 2017 00.37
-    cdata_regex: "\\s*[\\w\\.,:/+-]+(\\s*[\\w\\.,:/+-]+)*\\s*"
+    # Note: Where Unicode characters may exist and a named group such as \w is
+    # used then it's necessary to also include \p{L}\p{N}_.
+    cdata_regex: "\\s*[\\w\\p{L}\\p{N}_\\.,:/+-]+(\\s*[\\w\\p{L}\\p{N}_\\.,:/+-]+)*\\s*"
   }
   spec_url: "https://www.ampproject.org/docs/reference/components/amp-timeago"
   amp_layout: {

--- a/validator/engine/validator_test.js
+++ b/validator/engine/validator_test.js
@@ -74,6 +74,18 @@ function isValidRegex(regex) {
 }
 
 /**
+ * Returns true if the regex has a group but is missing the corresponding
+ * Unicode group. For now this tests only for word character group (\\w) which
+ * must be followed by the Unicode equivalent group (\\p{L}\\p{N}_).
+ * @param {null|string} regex
+ * @return {boolean}
+ */
+function isMissingUnicodeGroup(regex) {
+  var wordGroupRegex = new RegExp("\\\\w(?!\\\\p{L}\\\\p{N}_)");
+  return wordGroupRegex.test(regex);
+}
+
+/**
  * Returns all html files underneath the testdata roots. This looks
  * both for feature_tests/*.html and for tests in extension directories.
  * E.g.: extensions/amp-accordion/0.1/test/*.html,
@@ -401,17 +413,29 @@ function attrRuleShouldMakeSense(attrSpec, rules) {
       const regex = rules.internedStrings[-1 - attrSpec.valueRegex];
       expect(isValidRegex(regex)).toBe(true);
     });
+    it('value_regex must have unicode named groups', () => {
+      const regex = rules.internedStrings[-1 - attrSpec.valueRegex];
+      expect(isMissingUnicodeGroup(regex)).toBe(false);
+    });
   }
   if (attrSpec.valueRegexCasei !== null) {
     it('value_regex_casei valid', () => {
       const regex = rules.internedStrings[-1 - attrSpec.valueRegexCasei];
       expect(isValidRegex(regex)).toBe(true);
     });
+    it('value_regex_casei must have unicode named groups', () => {
+      const regex = rules.internedStrings[-1 - attrSpec.valueRegexCasei];
+      expect(isMissingUnicodeGroup(regex)).toBe(false);
+    });
   }
   if (attrSpec.blacklistedValueRegex !== null) {
     it('blacklisted_value_regex valid', () => {
       const regex = rules.internedStrings[-1 - attrSpec.blacklistedValueRegex];
       expect(isValidRegex(regex)).toBe(true);
+    });
+    it('blacklisted_value_regex must have unicode named groups', () => {
+      const regex = rules.internedStrings[-1 - attrSpec.blacklistedValueRegex];
+      expect(isMissingUnicodeGroup(regex)).toBe(false);
     });
   }
   // value_url must have at least one allowed protocol.
@@ -664,15 +688,18 @@ describe('ValidatorRulesMakeSense', () => {
         });
       }
       // blacklisted_cdata_regex
-      it('blacklisted_cdata_regex valid and error_message defined', () => {
-        for (const blacklistedCdataRegex of
-                 tagSpec.cdata.blacklistedCdataRegex) {
+      for (const blacklistedCdataRegex of tagSpec.cdata.blacklistedCdataRegex) {
+        it('blacklisted_cdata_regex valid and error_message defined', () => {
           usefulCdataSpec = true;
           expect(blacklistedCdataRegex.regex).toBeDefined();
           expect(isValidRegex(blacklistedCdataRegex.regex)).toBe(true);
           expect(blacklistedCdataRegex.errorMessage).toBeDefined();
-        }
-      });
+        });
+        it('blacklisted_cdata_regex must have unicode named groups', () => {
+          const regex = rules.internedStrings[-1 - blacklistedCdataRegex.regex];
+          expect(isMissingUnicodeGroup(regex)).toBe(false);
+        });
+      }
 
       // css_spec
       if (tagSpec.cdata.cssSpec !== null) {
@@ -726,6 +753,10 @@ describe('ValidatorRulesMakeSense', () => {
       }
       it('a cdata spec must be defined', () => {
         expect(usefulCdataSpec).toBe(true);
+      });
+      it('cdata_regex must have unicode named groups', () => {
+        const regex = rules.internedStrings[-1 - tagSpec.cdata.cdataRegex];
+        expect(isMissingUnicodeGroup(regex)).toBe(false);
       });
 
       // reference_points

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -25,7 +25,7 @@ min_validator_revision_required: 246
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 473
+spec_file_revision: 474
 
 styles_spec_url: "https://www.ampproject.org/docs/guides/author-develop/responsive/style_pages"
 

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -25,7 +25,7 @@ min_validator_revision_required: 246
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 474
+spec_file_revision: 475
 
 styles_spec_url: "https://www.ampproject.org/docs/guides/author-develop/responsive/style_pages"
 
@@ -236,7 +236,7 @@ tags: {
                  "([0-9]+\\.?)+/css/font-awesome\\.min\\.css(\\?.*)?|"
                  "https://cloud\\.typography\\.com/"
                  "[0-9]*/[0-9]*/css/fonts\\.css|"
-                 "https://use\\.typekit\\.net/\\w+\\.css"
+                 "https://use\\.typekit\\.net/[\\w\\p{L}\\p{N}_]+\\.css"
   }
   attrs: {
     name: "rel"


### PR DESCRIPTION
- Use Unicode RegEx for amp-timeago cdata #11116 
- Revision bump, add global [hidden] attribute