### PR TITLE
Allow vector-effect for SVGs

### DIFF
--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -1797,6 +1797,7 @@ attr_lists: {
   attrs: { name: "text-decoration" }
   attrs: { name: "text-rendering" }
   attrs: { name: "unicode-bidi" }
+  attrs: { name: "vector-effect" }
   attrs: { name: "visibility" }
   attrs: { name: "word-spacing" }
   attrs: { name: "writing-mode" }


### PR DESCRIPTION
Addresses #11128

The (vector-effect)[https://www.w3.org/TR/SVGTiny12/painting.html#NonScalingStroke] attribute  is being added to the `attr_lists`: `svg-presentation-attributes` so that it's available to SVG tags such as `circle` and `ellipse`.
