### PR TITLE
Doubleclick Fast Fetch support downloaded impressions

### DIFF
--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -837,7 +837,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
 
   /**
    * @param {string} impressions
-   * @param {boolean} scrubReferer
+   * @param {boolean=} scrubReferer
    * @visibileForTesting
    */
   fireDelayedImpressions(impressions, scrubReferer) {

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -846,7 +846,10 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     }
     impressions.split(',').forEach(url => {
       try {
-        dev().assert(isSecureUrl(url));
+        if (!isSecureUrl(url)) {
+          dev().warn(TAG, `insecure impression url: ${url}`);
+          return;
+        }
         // Create amp-pixel and append to document to send impression.
         this.win.document.body.appendChild(
             createElementWithAttributes(

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -60,7 +60,7 @@ import {
   metaJsonCreativeGrouper,
 } from '../../../ads/google/a4a/line-delimited-response-handler';
 import {stringHash32} from '../../../src/string';
-import {removeElement} from '../../../src/dom';
+import {removeElement, createElementWithAttributes} from '../../../src/dom';
 import {tryParseJson} from '../../../src/json';
 import {dev, user} from '../../../src/log';
 import {getMode} from '../../../src/mode';
@@ -70,7 +70,7 @@ import {domFingerprintPlain} from '../../../src/utils/dom-fingerprint';
 import {insertAnalyticsElement} from '../../../src/extension-analytics';
 import {setStyles} from '../../../src/style';
 import {utf8Encode} from '../../../src/utils/bytes';
-import {deepMerge} from '../../../src/utils/object';
+import {deepMerge, dict} from '../../../src/utils/object';
 import {isCancellation} from '../../../src/error';
 import {isSecureUrl, parseUrl} from '../../../src/url';
 import {VisibilityState} from '../../../src/visibility-state';
@@ -490,6 +490,8 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
       this.extensions_./*OK*/installExtensionForDoc(
           this.getAmpDoc(), 'amp-analytics');
     }
+    this.fireDelayedImpressions(responseHeaders.get('X-AmpImps'));
+    this.fireDelayedImpressions(responseHeaders.get('X-AmpRSImps'), true);
     // If the server returned a size, use that, otherwise use the size that we
     // sent in the ad request.
     let size = super.extractSize(responseHeaders);
@@ -831,6 +833,29 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     // Null response indicates single slot should execute using non-SRA method.
     return this.sraResponsePromise_.then(
         response => response || super.sendXhrRequest(adUrl));
+  }
+
+  /**
+   * @param {string} impressions
+   * @param {boolean} scrubReferer
+   * @visibileForTesting
+   */
+  fireDelayedImpressions(impressions, scrubReferer) {
+    if (!impressions) return;
+    impressions.split(',').forEach(url => {
+      try {
+        dev().assert(isSecureUrl(url));
+        // Create amp-pixel and append to document to send impression.
+        this.win.document.body.appendChild(
+          createElementWithAttributes(
+            this.win.document,
+            'amp-pixel',
+            dict({
+              src: url,
+              referrerpolicy: scrubReferer ? 'no-referrer' : ''
+            })));
+      } catch (unusedError) {}
+    });
   }
 
   /**

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -841,19 +841,21 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
    * @visibileForTesting
    */
   fireDelayedImpressions(impressions, scrubReferer) {
-    if (!impressions) return;
+    if (!impressions) {
+      return;
+    }
     impressions.split(',').forEach(url => {
       try {
         dev().assert(isSecureUrl(url));
         // Create amp-pixel and append to document to send impression.
         this.win.document.body.appendChild(
-          createElementWithAttributes(
-            this.win.document,
-            'amp-pixel',
-            dict({
-              src: url,
-              referrerpolicy: scrubReferer ? 'no-referrer' : ''
-            })));
+            createElementWithAttributes(
+                this.win.document,
+                'amp-pixel',
+                dict({
+                  'src': url,
+                  'referrerpolicy': scrubReferer ? 'no-referrer' : '',
+                })));
       } catch (unusedError) {}
     });
   }

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -199,7 +199,6 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
     it('should load delayed impression amp-pixels', () => {
       const fireDelayedImpressionsSpy =
           sandbox.spy(impl, 'fireDelayedImpressions');
-      const url = ['https://foo.com?a=b', 'https://blah.com?lsk=sdk&sld=vj'];
       expect(impl.extractSize({
         get(name) {
           switch (name) {

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -195,6 +195,31 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
       // exact value of ampAnalyticsConfig covered in
       // ads/google/test/test-utils.js
     });
+
+    it('should load delayed impression amp-pixels', () => {
+      const fireDelayedImpressionsSpy =
+          sandbox.spy(impl, 'fireDelayedImpressions');
+      const url = ['https://foo.com?a=b', 'https://blah.com?lsk=sdk&sld=vj'];
+      expect(impl.extractSize({
+        get(name) {
+          switch (name) {
+            case 'X-AmpImps':
+              return 'https://a.com?a=b,https://b.com?c=d';
+            case 'X-AmpRSImps':
+              return 'https://c.com?e=f,https://d.com?g=h';
+            default:
+              return undefined;
+          }
+        },
+        has(name) {
+          return !!this.get(name);
+        },
+      })).to.deep.equal(size);
+      expect(fireDelayedImpressionsSpy.withArgs(
+          'https://a.com?a=b,https://b.com?c=d')).to.be.calledOnce;
+      expect(fireDelayedImpressionsSpy.withArgs(
+          'https://c.com?e=f,https://d.com?g=h', true)).to.be.calledOnce;
+    });
   });
 
   describe('#onCreativeRender', () => {
@@ -988,6 +1013,55 @@ describes.realWin('additional amp-ad-network-doubleclick-impl',
           expect(impl.element.getAttribute('width')).to.be.null;
           expect(impl.element.getAttribute('height')).to.equal('150');
           verifyCss(impl.iframe, size);
+        });
+      });
+
+      describe('#fireDelayedImpressions', () => {
+        beforeEach(() => {
+          element = createElementWithAttributes(doc, 'amp-ad', {
+            'width': '200',
+            'height': '50',
+            'type': 'doubleclick',
+          });
+          impl = new AmpAdNetworkDoubleclickImpl(element);
+        });
+
+        it('should handle null impressions', () => {
+          impl.fireDelayedImpressions(null);
+          expect(env.win.document.querySelectorAll('amp-pixel').length)
+              .to.equal(0);
+        });
+
+        it('should not include non-https', () => {
+          impl.fireDelayedImpressions('http://f.com?a=b,https://b.net?c=d');
+          expect(env.win.document.querySelectorAll('amp-pixel').length)
+              .to.equal(1);
+          expect(env.win.document.querySelector(
+              'amp-pixel[src="https://b.net?c=d"][referrerpolicy=""]'))
+              .to.be.ok;
+        });
+
+        it('should append amp-pixel w/o scrubReferer', () => {
+          impl.fireDelayedImpressions('https://f.com?a=b,https://b.net?c=d');
+          expect(env.win.document.querySelector(
+              'amp-pixel[src="https://f.com?a=b"][referrerpolicy=""]'))
+              .to.be.ok;
+          expect(env.win.document.querySelector(
+              'amp-pixel[src="https://b.net?c=d"][referrerpolicy=""]'))
+              .to.be.ok;
+        });
+
+        it('should append amp-pixel wwith scrubReferer', () => {
+          impl.fireDelayedImpressions(
+              'https://f.com?a=b,https://b.net?c=d', true);
+          expect(env.win.document.querySelector(
+              'amp-pixel[src="https://f.com?a=b"]' +
+              '[referrerpolicy="no-referrer"]'))
+              .to.be.ok;
+          expect(env.win.document.querySelector(
+              'amp-pixel[src="https://b.net?c=d"]' +
+              '[referrerpolicy="no-referrer"]'))
+              .to.be.ok;
         });
       });
     });


### PR DESCRIPTION
Doubleclick fast fetch triggers downloaded impressions on ad response.  Impressions are passed via headers.