### PR TITLE
Add event.valueAsNumber to change events

### DIFF
--- a/spec/amp-actions-and-events.md
+++ b/spec/amp-actions-and-events.md
@@ -112,10 +112,10 @@ For example, the following is possible in AMP.
     </td>
     <td><code>input</code>, <code>select</code></td>
     <td>
-      <code>event.min</code><br>
-      <code>event.max</code><br>
-      <code>event.value</code><br>
-      <code>event.valueAsNumber</code><br>
+      <pre>event.min
+event.max
+event.value
+event.valueAsNumber</pre>
     </td>
   </tr>
   <tr>
@@ -143,7 +143,8 @@ For example, the following is possible in AMP.
   <tr>
     <td><code>slideChange</code></td>
     <td>Fired when the user manually changes the carousel's current slide. Does not fire on autoplay or the <code>goToSlide</code> action.</td>
-    <td><code>// Slide number.<br>event.index</code></td>
+    <td><pre>// Slide number.
+event.index</pre></td>
   </tr>
 </table>
 
@@ -157,7 +158,8 @@ For example, the following is possible in AMP.
   <tr>
     <td><code>select</code></td>
     <td>Fired when the user manually selects an option.</td>
-    <td><code>// The `option` attribute value of the selected element.<br>event.targetOption</code></td>
+    <td><pre>// The `option` attribute value of the selected element.
+event.targetOption</pre></td>
   </tr>
 </table>
 
@@ -176,12 +178,14 @@ For example, the following is possible in AMP.
   <tr>
     <td><code>submit-success</code></td>
     <td>Fired when the form submission response is success.</td>
-    <td><code>// Response JSON.<br>event.response</code></td>
+    <td><pre>// Response JSON.
+event.response</pre></td>
   </tr>
   <tr>
     <td><code>submit-error</code></td>
     <td>Fired when the form submission response is an error.</td>
-    <td><code>// Response JSON.<br>event.response</code></td>
+    <td><pre>// Response JSON.
+event.response</pre></td>
   </tr>
 </table>
 

--- a/spec/amp-actions-and-events.md
+++ b/spec/amp-actions-and-events.md
@@ -104,25 +104,24 @@ For example, the following is possible in AMP.
   </tr>
   <!-- change -->
   <tr>
-    <td rowspan=3><code>change</code></td>
-    <td rowspan=3>Fired when the value of the element is changed and committed.</td>
-    <td>input[type="range"]</td>
+    <td rowspan=2><code>change</code></td>
+    <td rowspan=2>
+      Fired when the value of the element is changed and committed.
+      <br><br>
+      Data properties mirror those in <a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement#Properties">HTMLInputElement</a> and <a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLSelectElement#Properties">HTMLSelectElement</a>.
+    </td>
+    <td><code>input</code>, <code>select</code></td>
     <td>
-      <code>event.min</code> : The minimum value of the range<br>
-      <code>event.value</code> : The current value of the range<br>
-      <code>event.max</code> : The maximum value of the range<br>
+      <code>event.min</code><br>
+      <code>event.max</code><br>
+      <code>event.value</code><br>
+      <code>event.valueAsNumber</code><br>
     </td>
   </tr>
   <tr>
-    <td>input[type="radio"], input[type="checkbox"]</td>
+    <td><code>input[type="radio"]</code>, <code>input[type="checkbox"]</code></td>
     <td>
-      <code>event.checked</code> : If the element is checked
-    </td>
-  </tr>
-  <tr>
-    <td>input[type="text"], select</td>
-    <td>
-      <code>event.value</code> : String of the text or selected option
+      <code>event.checked</code>
     </td>
   </tr>
   <!-- input-debounced -->
@@ -130,7 +129,7 @@ For example, the following is possible in AMP.
     <td><code>input-debounced</code></td>
     <td>Fired when the value of the element is changed. This is similar to the standard <code>input</code> event, but it only fires when 300ms have passed after the value of the input has stopped changing.</td>
     <td>Elements that fire <code>input</code> event.</td>
-    <td>Same as above.</td>
+    <td>Same as <code>change</code> event data.</td>
   </tr>
 </table>
 
@@ -144,7 +143,7 @@ For example, the following is possible in AMP.
   <tr>
     <td><code>slideChange</code></td>
     <td>Fired when the user manually changes the carousel's current slide. Does not fire on autoplay or the <code>goToSlide</code> action.</td>
-    <td><code>event.index</code> : slide number</td>
+    <td><code>// Slide number.<br>event.index</code></td>
   </tr>
 </table>
 
@@ -158,7 +157,7 @@ For example, the following is possible in AMP.
   <tr>
     <td><code>select</code></td>
     <td>Fired when the user manually selects an option.</td>
-    <td><code>event.targetOption</code> : The <code>option</code> attribute value of the selected element</td>
+    <td><code>// The `option` attribute value of the selected element.<br>event.targetOption</code></td>
   </tr>
 </table>
 
@@ -177,12 +176,12 @@ For example, the following is possible in AMP.
   <tr>
     <td><code>submit-success</code></td>
     <td>Fired when the form submission response is success.</td>
-    <td><code>event.response</code> : JSON response</td>
+    <td><code>// Response JSON.<br>event.response</code></td>
   </tr>
   <tr>
     <td><code>submit-error</code></td>
     <td>Fired when the form submission response is an error.</td>
-    <td><code>event.response</code> : JSON response</td>
+    <td><code>// Response JSON.<br>event.response</code></td>
   </tr>
 </table>
 
@@ -293,20 +292,6 @@ For example, the following is possible in AMP.
   <tr>
     <td><code>toggle</code></td>
     <td>Toggles the state of the sidebar.</td>
-  </tr>
-</table>
-
-### amp-state
-<table>
-  <tr>
-    <th>Action</th>
-    <th>Description</th>
-  </tr>
-  <tr>
-    <td><code>(default)</code></td>
-    <td>Updates the amp-state's data with the data contained in the event. Requires
-      <a href="../extensions/amp-bind/amp-bind.md">amp-bind</a>.
-    </td>
   </tr>
 </table>
 

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -537,18 +537,18 @@ export class ActionService {
       const type = target.getAttribute('type');
 
       detail['value'] = target.value;
+
       detail['valueAsNumber'] = (target.valueAsNumber !== undefined)
           ? target.valueAsNumber
           : Number(target.value);
 
-      // Expose HTMLInputElement properties based on type.
-      if (tagName == 'INPUT') {
-        if (type == 'checkbox' || type == 'radio') {
-          detail['checked'] = target.checked;
-        } else if (type == 'range') {
-          detail['min'] = target.min;
-          detail['max'] = target.max;
-        }
+      if (type == 'checkbox' || type == 'radio') {
+        detail['checked'] = target.checked;
+      }
+
+      if (target.min !== undefined || target.max !== undefined) {
+        detail['min'] = target.min;
+        detail['max'] = target.max;
       }
     }
 

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -537,10 +537,8 @@ export class ActionService {
       const type = target.getAttribute('type');
 
       detail['value'] = target.value;
-
-      detail['valueAsNumber'] = (target.valueAsNumber !== undefined)
-          ? target.valueAsNumber
-          : Number(target.value);
+      // Natively supported on some browsers but convert anyways for consistency.
+      detail['valueAsNumber'] = Number(target.value);
 
       if (type == 'checkbox' || type == 'radio') {
         detail['checked'] = target.checked;

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -536,18 +536,18 @@ export class ActionService {
     if (tagName == 'INPUT' || tagName == 'SELECT') {
       const type = target.getAttribute('type');
 
-      // TODO(blueyedgeek, #10729): Provide valueAsNumber instead of casting.
-      detail['value'] = (type == 'range') ? Number(target.value) : target.value;
+      detail['value'] = target.value;
+      detail['valueAsNumber'] = (target.valueAsNumber !== undefined)
+          ? target.valueAsNumber
+          : Number(target.value);
 
       // Expose HTMLInputElement properties based on type.
       if (tagName == 'INPUT') {
         if (type == 'checkbox' || type == 'radio') {
           detail['checked'] = target.checked;
         } else if (type == 'range') {
-          // TODO(choumx): Perhaps we shouldn't cast since min/max is also
-          // available on input[type="date|time|number"].
-          detail['min'] = Number(target.min);
-          detail['max'] = Number(target.max);
+          detail['min'] = target.min;
+          detail['max'] = target.max;
         }
       }
     }
@@ -556,7 +556,6 @@ export class ActionService {
       event.detail = detail;
     }
   }
-
 }
 
 

--- a/test/functional/test-action.js
+++ b/test/functional/test-action.js
@@ -1090,8 +1090,9 @@ describes.fakeWin('Core events', {amp: true}, env => {
         element,
         'change',
         sinon.match(e => {
-          const detail = e.detail;
-          return detail.min == 0 && detail.max == 10 && detail.value == 5;
+          const {min, max, value, valueAsNumber} = e.detail;
+          return min === '0' && max === '10' && value === '5'
+              && valueAsNumber === 5;
         }));
   });
 


### PR DESCRIPTION
Fixes #10729.

- Stop casting `event.value` to Number and provide `event.valueAsNumber`.
- Stop casting `event.min` and `event.max` to Number since date ranges are a thing. 

`cookbook/492126` shows low usage of `event.value`. Developers can use unary `+` to convert to Number anyways.
