### PR TITLE
Ensure transition is reset _after_ measurements

### DIFF
--- a/src/service/fixed-layer.js
+++ b/src/service/fixed-layer.js
@@ -289,10 +289,7 @@ export class FixedLayer {
         }
         // 3. Cleanup the `style.bottom`.
         for (let i = 0; i < elements.length; i++) {
-          setStyles(elements[i].element, {
-            bottom: '',
-            transition: '',
-          });
+          setStyle(elements[i].element, 'bottom', '');
         }
 
         for (let i = 0; i < elements.length; i++) {
@@ -372,12 +369,21 @@ export class FixedLayer {
             transferLayer.className = this.ampdoc.getBody().className;
           }
         }
-        this.elements_.forEach((fe, i) => {
+        const elements = this.elements_;
+        for (let i = 0; i < elements.length; i++) {
+          const fe = elements[i];
           const feState = state[fe.id];
+
+          // Note: This MUST be done after measurements are taken.
+          // Transitions will mess up everything and, depending on when paints
+          // happen, mutates of transition and bottom at the same time may be
+          // make the transition active.
+          setStyle(fe.element, 'transition', '');
+
           if (feState) {
             this.mutateElement_(fe, i, feState);
           }
-        });
+        }
       },
     }, {}).catch(error => {
       // Fail silently.

--- a/test/functional/test-fixed-layer.js
+++ b/test/functional/test-fixed-layer.js
@@ -746,9 +746,15 @@ describe('FixedLayer', () => {
 
       expect(state['F0'].fixed).to.be.true;
       expect(state['F0'].top).to.equal('0px');
+      expect(element1.style.transition).to.equal('none');
 
       expect(state['F4'].sticky).to.be.true;
       expect(state['F4'].top).to.equal('0px');
+      expect(element5.style.transition).to.equal('none');
+
+      vsyncTasks[0].mutate({});
+      expect(element1.style.transition).to.equal('');
+      expect(element5.style.transition).to.equal('');
     });
 
     it('should mutate element to fixed without top', () => {


### PR DESCRIPTION
Depending on paints, the transition can be applied _before_ the element
is moved (from resetting `bottom` to the stylesheet's value). If that
happens, all measurements are messed up.

Now, we take all measurements then reset `transition` afterwards.

Fixes #11132.