### PR TITLE
Introduce #Viewport.getClientRectAsync() function

### DIFF
--- a/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
@@ -456,7 +456,7 @@ export class AmpAdXOriginIframeHandler {
    * @private
    */
   getIframePositionPromise_() {
-    return this.viewport_.getBoundingRectAsync(
+    return this.viewport_.getClientRectAsync(
         dev().assertElement(this.iframe)).then(position => {
           const viewport = this.viewport_.getRect();
           return dict({

--- a/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
@@ -458,6 +458,8 @@ export class AmpAdXOriginIframeHandler {
   getIframePositionPromise_() {
     return this.viewport_.getClientRectAsync(
         dev().assertElement(this.iframe)).then(position => {
+          dev().assert(position,
+              'element clientRect should intersects with root clientRect');
           const viewport = this.viewport_.getRect();
           return dict({
             'targetRect': position,

--- a/extensions/amp-ad/0.1/test/test-amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-xorigin-iframe-handler.js
@@ -359,7 +359,7 @@ describe('amp-ad-xorigin-iframe-handler', () => {
       iframe.name = 'test_nomaster';
       iframeHandler.init(iframe);
       sandbox.stub/*OK*/(
-          iframeHandler.viewport_, 'getBoundingRectAsync', () => {
+          iframeHandler.viewport_, 'getClientRectAsync', () => {
             return Promise.resolve(layoutRectLtwh(1, 1, 1, 1));
           });
       sandbox.stub/*OK*/(iframeHandler.viewport_, 'getRect', () => {

--- a/src/inabox/inabox-viewport.js
+++ b/src/inabox/inabox-viewport.js
@@ -262,7 +262,7 @@ export class ViewportBindingInabox {
   }
 
   /** @override */
-  getRootClientRectAsyn() {
+  getRootClientRectAsync() {
     if (!this.requestPositionPromise_) {
       this.requestPositionPromise_ = new Promise(resolve => {
         this.iframeClient_.requestOnce(

--- a/src/inabox/inabox-viewport.js
+++ b/src/inabox/inabox-viewport.js
@@ -262,7 +262,7 @@ export class ViewportBindingInabox {
   }
 
   /** @override */
-  getGlobalClientRect() {
+  getRootClientRectAsyn() {
     if (!this.requestPositionPromise_) {
       this.requestPositionPromise_ = new Promise(resolve => {
         this.iframeClient_.requestOnce(

--- a/src/inabox/inabox-viewport.js
+++ b/src/inabox/inabox-viewport.js
@@ -262,34 +262,22 @@ export class ViewportBindingInabox {
   }
 
   /** @override */
-  getLayoutRectAsync(el) {
+  getGlobalClientRect() {
     if (!this.requestPositionPromise_) {
       this.requestPositionPromise_ = new Promise(resolve => {
         this.iframeClient_.requestOnce(
             MessageType.SEND_POSITIONS, MessageType.POSITION,
             data => {
               this.requestPositionPromise_ = null;
-              const parentLayoutRect = moveLayoutRect(
-                  data.targetRect,
-                  data.viewportRect.left,
-                  data.viewportRect.top);
-              resolve(parentLayoutRect);
+              dev().assert(data.targetRect, 'Host should send targetRect');
+              resolve(data.targetRect);
             }
         );
       });
     }
-
-    const elPosPromise = this.vsync_.measurePromise(() => {
-      return el./*OK*/getBoundingClientRect();
-    });
-
-    return Promise.all([elPosPromise, this.requestPositionPromise_]).then(
-        values => {
-          const box = values[0];
-          const iframeBox = values[1];
-          return moveLayoutRect(box, iframeBox.left, iframeBox.top);
-        });
+    return this.requestPositionPromise_;
   }
+
 
   /**
    * @return {!Promise}

--- a/src/service/viewport/viewport-binding-def.js
+++ b/src/service/viewport/viewport-binding-def.js
@@ -156,5 +156,5 @@ export class ViewportBindingDef {
    * Returns the client rect of the current window.
    * @return {Promise<null>|Promise<!../../layout-rect.LayoutRectDef>}
    */
-  getGlobalClientRect() {}
+  getRootClientRectAsyn() {}
 }

--- a/src/service/viewport/viewport-binding-def.js
+++ b/src/service/viewport/viewport-binding-def.js
@@ -156,5 +156,5 @@ export class ViewportBindingDef {
    * Returns the client rect of the current window.
    * @return {Promise<null>|Promise<!../../layout-rect.LayoutRectDef>}
    */
-  getRootClientRectAsyn() {}
+  getRootClientRectAsync() {}
 }

--- a/src/service/viewport/viewport-binding-def.js
+++ b/src/service/viewport/viewport-binding-def.js
@@ -153,11 +153,8 @@ export class ViewportBindingDef {
   getLayoutRect(unusedEl, unusedScrollLeft, unusedScrollTop) {}
 
   /**
-   * Returns a the rect of the element within the document asynchronously
-   * @param {!Element} unusedEl
-   * @param {number=} unusedScrollLeft
-   * @param {number=} unusedScrollTop
-   * @return {!Promise<!../../layout-rect.LayoutRectDef>}
+   * Returns the client rect of the current window.
+   * @return {Promise<null>|Promise<!../../layout-rect.LayoutRectDef>}
    */
-  getLayoutRectAsync(unusedEl, unusedScrollLeft, unusedScrollTop) {}
+  getGlobalClientRect() {}
 }

--- a/src/service/viewport/viewport-binding-ios-embed-wrapper.js
+++ b/src/service/viewport/viewport-binding-ios-embed-wrapper.js
@@ -232,7 +232,7 @@ export class ViewportBindingIosEmbedWrapper_ {
   }
 
   /** @override */
-  getRootClientRectAsyn() {
+  getRootClientRectAsync() {
     return Promise.resolve(null);
   }
 

--- a/src/service/viewport/viewport-binding-ios-embed-wrapper.js
+++ b/src/service/viewport/viewport-binding-ios-embed-wrapper.js
@@ -232,10 +232,8 @@ export class ViewportBindingIosEmbedWrapper_ {
   }
 
   /** @override */
-  getLayoutRectAsync(el, opt_scrollLeft, opt_scrollTop) {
-    return this.vsync_.measurePromise(() => {
-      return this.getLayoutRect(el, opt_scrollLeft, opt_scrollTop);
-    });
+  getGlobalClientRect() {
+    return Promise.resolve(null);
   }
 
   /** @override */

--- a/src/service/viewport/viewport-binding-ios-embed-wrapper.js
+++ b/src/service/viewport/viewport-binding-ios-embed-wrapper.js
@@ -232,7 +232,7 @@ export class ViewportBindingIosEmbedWrapper_ {
   }
 
   /** @override */
-  getGlobalClientRect() {
+  getRootClientRectAsyn() {
     return Promise.resolve(null);
   }
 

--- a/src/service/viewport/viewport-binding-natural-ios-embed.js
+++ b/src/service/viewport/viewport-binding-natural-ios-embed.js
@@ -321,7 +321,7 @@ export class ViewportBindingNaturalIosEmbed_ {
   }
 
   /** @override */
-  getRootClientRectAsyn() {
+  getRootClientRectAsync() {
     return Promise.resolve(null);
   }
 

--- a/src/service/viewport/viewport-binding-natural-ios-embed.js
+++ b/src/service/viewport/viewport-binding-natural-ios-embed.js
@@ -321,7 +321,7 @@ export class ViewportBindingNaturalIosEmbed_ {
   }
 
   /** @override */
-  getGlobalClientRect() {
+  getRootClientRectAsyn() {
     return Promise.resolve(null);
   }
 

--- a/src/service/viewport/viewport-binding-natural-ios-embed.js
+++ b/src/service/viewport/viewport-binding-natural-ios-embed.js
@@ -321,11 +321,10 @@ export class ViewportBindingNaturalIosEmbed_ {
   }
 
   /** @override */
-  getLayoutRectAsync(el, opt_scrollLeft, opt_scrollTop) {
-    return this.vsync_.measurePromise(() => {
-      return this.getLayoutRect(el, opt_scrollLeft, opt_scrollTop);
-    });
+  getGlobalClientRect() {
+    return Promise.resolve(null);
   }
+
 
   /** @override */
   setScrollTop(scrollTop) {

--- a/src/service/viewport/viewport-binding-natural.js
+++ b/src/service/viewport/viewport-binding-natural.js
@@ -203,10 +203,8 @@ export class ViewportBindingNatural_ {
   }
 
   /** @override */
-  getLayoutRectAsync(el, opt_scrollLeft, opt_scrollTop) {
-    return this.vsync_.measurePromise(() => {
-      return this.getLayoutRect(el, opt_scrollLeft, opt_scrollTop);
-    });
+  getGlobalClientRect() {
+    return Promise.resolve(null);
   }
 
   /** @override */

--- a/src/service/viewport/viewport-binding-natural.js
+++ b/src/service/viewport/viewport-binding-natural.js
@@ -203,7 +203,7 @@ export class ViewportBindingNatural_ {
   }
 
   /** @override */
-  getGlobalClientRect() {
+  getRootClientRectAsyn() {
     return Promise.resolve(null);
   }
 

--- a/src/service/viewport/viewport-binding-natural.js
+++ b/src/service/viewport/viewport-binding-natural.js
@@ -203,7 +203,7 @@ export class ViewportBindingNatural_ {
   }
 
   /** @override */
-  getRootClientRectAsyn() {
+  getRootClientRectAsync() {
     return Promise.resolve(null);
   }
 

--- a/src/service/viewport/viewport-impl.js
+++ b/src/service/viewport/viewport-impl.js
@@ -22,7 +22,12 @@ import {
   getParentWindowFrameElement,
   registerServiceBuilderForDoc,
 } from '../../service';
-import {layoutRectLtwh, moveLayoutRect} from '../../layout-rect';
+import {
+  layoutRectLtwh,
+  moveLayoutRect,
+  rectIntersection,
+  layoutRectFromDomRect,
+} from '../../layout-rect';
 import {dev} from '../../log';
 import {dict} from '../../utils/object';
 import {getFriendlyIframeEmbedOptional} from '../../friendly-iframe-embed';
@@ -374,7 +379,7 @@ export class Viewport {
    * Note that this function should be called in vsync measure. Please consider
    * using `getLayoutRectAsync` instead.
    * @param {!Element} el
-   * @return {!../../layout-rect.LayoutRectDef}}
+   * @return {!../../layout-rect.LayoutRectDef}
    */
   getLayoutRect(el) {
     const scrollLeft = this.getScrollLeft();
@@ -396,42 +401,50 @@ export class Viewport {
   }
 
   /**
-   * Returns a promise that resolves with latest rect of the element within the document.
+   * Returns the client rect of the element
+   * TODO(@zhouyx): Consider combine with #getClientRectInViewportAsync()
    * @param {!Element} el
    * @return {!Promise<!../../layout-rect.LayoutRectDef>}
    */
-  getLayoutRectAsync(el) {
-    const scrollLeft = this.getScrollLeft();
-    const scrollTop = this.getScrollTop();
+  getClientRectAsync(el) {
+    const local = this.vsync_.measurePromise(() => {
+      return el./*OK*/getBoundingClientRect();
+    });
+    const global = this.binding_.getGlobalClientRect();
 
-    // Go up the window hierarchy through friendly iframes.
-    const frameElement = getParentWindowFrameElement(el, this.ampdoc.win);
-    if (frameElement) {
-      const bPromise = this.binding_.getLayoutRectAsync(el, 0, 0);
-      const cPromise = this.binding_.getLayoutRectAsync(
-          frameElement, scrollLeft, scrollTop);
-      return Promise.all([bPromise, cPromise]).then(values => {
-        const b = values[0];
-        const c = values[1];
-        return layoutRectLtwh(Math.round(b.left + c.left),
-            Math.round(b.top + c.top),
-            Math.round(b.width),
-            Math.round(b.height));
-      });
-    }
-
-    return this.binding_.getLayoutRectAsync(el, scrollLeft, scrollTop);
+    return Promise.all([local, global]).then(values => {
+      const l = values[0];
+      const g = values[1];
+      if (!g) {
+        return l;
+      }
+      return moveLayoutRect(l, g.left, g.top);
+    });
   }
 
   /**
-   * Returns a promise that resolve with latest rect of the element within the viewport.
+   * Returns the client rect of the element if it intersects with viewport
    * @param {!Element} el
    * @return {!Promise<?../../layout-rect.LayoutRectDef>}}
    */
-  getBoundingRectAsync(el) {
-    const viewportRect = this.getRect();
-    return this.getLayoutRectAsync(el).then(rect => {
-      return moveLayoutRect(rect, -viewportRect.left, -viewportRect.top);
+  getClientRectInViewportAsync(el) {
+    const local = this.vsync_.measurePromise(() => {
+      return el./*OK*/getBoundingClientRect();
+    });
+    const global = this.binding_.getGlobalClientRect();
+
+    return Promise.all([local, global]).then(values => {
+      const l = values[0];
+      const g = values[1];
+      const size = this.getSize();
+      const viewport = layoutRectLtwh(0, 0, size.width, size.height);
+      if (!rectIntersection(l, g, viewport)) {
+        return null;
+      }
+      if (g) {
+        return moveLayoutRect(l, g.left, g.top);
+      }
+      return l;
     });
   }
 

--- a/src/service/viewport/viewport-impl.js
+++ b/src/service/viewport/viewport-impl.js
@@ -26,7 +26,6 @@ import {
   layoutRectLtwh,
   moveLayoutRect,
   rectIntersection,
-  layoutRectFromDomRect,
 } from '../../layout-rect';
 import {dev} from '../../log';
 import {dict} from '../../utils/object';
@@ -410,7 +409,7 @@ export class Viewport {
     const local = this.vsync_.measurePromise(() => {
       return el./*OK*/getBoundingClientRect();
     });
-    const global = this.binding_.getGlobalClientRect();
+    const global = this.binding_.getRootClientRectAsyn();
 
     return Promise.all([local, global]).then(values => {
       const l = values[0];
@@ -431,7 +430,7 @@ export class Viewport {
     const local = this.vsync_.measurePromise(() => {
       return el./*OK*/getBoundingClientRect();
     });
-    const global = this.binding_.getGlobalClientRect();
+    const global = this.binding_.getRootClientRectAsyn();
 
     return Promise.all([local, global]).then(values => {
       const l = values[0];

--- a/src/service/viewport/viewport-impl.js
+++ b/src/service/viewport/viewport-impl.js
@@ -25,7 +25,6 @@ import {
 import {
   layoutRectLtwh,
   moveLayoutRect,
-  rectIntersection,
 } from '../../layout-rect';
 import {dev} from '../../log';
 import {dict} from '../../utils/object';
@@ -401,11 +400,10 @@ export class Viewport {
 
   /**
    * Returns the clientRect of the element.
-   * If root is viewport: return the element clientRect
-   * If root is an iframe: return the element clientRect if element intersects with root
-   * TODO(@zhouyx): We should consider return null if root doesn't intersect with viewportRect as well.
+   * Note: This method does not taking intersection into account.
+   * TODO(@zhouyx): We may need to return info on the intersectionRect.
    * @param {!Element} el
-   * @return {!Promise<?../../layout-rect.LayoutRectDef>}
+   * @return {!Promise<!../../layout-rect.LayoutRectDef>}
    */
   getClientRectAsync(el) {
     const local = this.vsync_.measurePromise(() => {
@@ -419,11 +417,7 @@ export class Viewport {
       if (!r) {
         return l;
       }
-      const clientRect = moveLayoutRect(l, r.left, r.top);
-      if (!rectIntersection(clientRect, r)) {
-        return null;
-      }
-      return clientRect;
+      return moveLayoutRect(l, r.left, r.top);
     });
   }
 

--- a/test/functional/inabox/test-inabox-viewport.js
+++ b/test/functional/inabox/test-inabox-viewport.js
@@ -300,7 +300,7 @@ describes.fakeWin('inabox-viewport', {amp: {}}, env => {
           targetRect: layoutRectLtwh(10, 20, 100, 100),
           viewportRect: layoutRectLtwh(1, 1, 1, 1),
         }), undefined, true);
-    return binding.getGlobalClientRect().then(rect => {
+    return binding.getRootClientRectAsyn().then(rect => {
       expect(rect).to.jsonEqual(layoutRectLtwh(10, 20, 100, 100));
       expect(requestSpy).to.be.calledOnce;
     });

--- a/test/functional/inabox/test-inabox-viewport.js
+++ b/test/functional/inabox/test-inabox-viewport.js
@@ -300,7 +300,7 @@ describes.fakeWin('inabox-viewport', {amp: {}}, env => {
           targetRect: layoutRectLtwh(10, 20, 100, 100),
           viewportRect: layoutRectLtwh(1, 1, 1, 1),
         }), undefined, true);
-    return binding.getRootClientRectAsyn().then(rect => {
+    return binding.getRootClientRectAsync().then(rect => {
       expect(rect).to.jsonEqual(layoutRectLtwh(10, 20, 100, 100));
       expect(requestSpy).to.be.calledOnce;
     });

--- a/test/functional/inabox/test-inabox-viewport.js
+++ b/test/functional/inabox/test-inabox-viewport.js
@@ -293,10 +293,6 @@ describes.fakeWin('inabox-viewport', {amp: {}}, env => {
   });
 
   it('should request the position async from host', () => {
-    const el = document.createElement('div');
-    el.getBoundingClientRect = () => {return layoutRectLtwh(10, 20, 10, 10);};
-    const el2 = document.createElement('div');
-    el2.getBoundingClientRect = () => {return layoutRectLtwh(30, 40, 15, 15);};
     const requestSpy = stubIframeClientMakeRequest(
         'send-positions',
         'position',
@@ -304,15 +300,9 @@ describes.fakeWin('inabox-viewport', {amp: {}}, env => {
           targetRect: layoutRectLtwh(10, 20, 100, 100),
           viewportRect: layoutRectLtwh(1, 1, 1, 1),
         }), undefined, true);
-    let rect2 = null;
-    binding.getLayoutRectAsync(el2).then(rect => {
-      rect2 = rect;
-    });
-    return binding.getLayoutRectAsync(el).then(rect => {
-      expect(rect).to.jsonEqual(layoutRectLtwh(21, 41, 10, 10));
-      expect(rect2).to.jsonEqual(layoutRectLtwh(41, 61, 15, 15));
+    return binding.getGlobalClientRect().then(rect => {
+      expect(rect).to.jsonEqual(layoutRectLtwh(10, 20, 100, 100));
       expect(requestSpy).to.be.calledOnce;
     });
   });
-
 });

--- a/test/functional/test-viewport.js
+++ b/test/functional/test-viewport.js
@@ -831,7 +831,7 @@ describes.fakeWin('Viewport', {}, env => {
 
   it('should calculate client rect w/o global client rect', () => {
     const bindingMock = sandbox.mock(binding);
-    bindingMock.expects('getGlobalClientRect').returns(Promise.resolve(null));
+    bindingMock.expects('getRootClientRectAsyn').returns(Promise.resolve(null));
     const el = document.createElement('div');
     el.getBoundingClientRect = () => {return layoutRectLtwh(1, 2, 3, 4);};
     sandbox.stub(viewport.vsync_, 'measurePromise', cb => cb());
@@ -842,7 +842,7 @@ describes.fakeWin('Viewport', {}, env => {
 
   it('should calculate client rect w/ global client rect when ', () => {
     const bindingMock = sandbox.mock(binding);
-    bindingMock.expects('getGlobalClientRect')
+    bindingMock.expects('getRootClientRectAsyn')
         .returns(Promise.resolve(layoutRectLtwh(5, 5, 5, 5)));
     const el = document.createElement('div');
     el.getBoundingClientRect = () => {return layoutRectLtwh(1, 2, 3, 4);};

--- a/test/functional/test-viewport.js
+++ b/test/functional/test-viewport.js
@@ -42,6 +42,7 @@ import {installViewerServiceForDoc} from '../../src/service/viewer-impl';
 import {installVsyncService} from '../../src/service/vsync-impl';
 import {loadPromise} from '../../src/event-helper';
 import {setParentWindow} from '../../src/service';
+import {layoutRectLtwh} from '../../src/layout-rect';
 import * as sinon from 'sinon';
 
 
@@ -826,6 +827,29 @@ describes.fakeWin('Viewport', {}, env => {
     bindingMock.expects('getLayoutRect').withArgs(element, 222, 111)
         .returns('sentinel').once();
     expect(viewport.getLayoutRect(element)).to.equal('sentinel');
+  });
+
+  it('should calculate client rect w/o global client rect', () => {
+    const bindingMock = sandbox.mock(binding);
+    bindingMock.expects('getGlobalClientRect').returns(Promise.resolve(null));
+    const el = document.createElement('div');
+    el.getBoundingClientRect = () => {return layoutRectLtwh(1, 2, 3, 4);};
+    sandbox.stub(viewport.vsync_, 'measurePromise', cb => cb());
+    return viewport.getClientRectAsync(el).then(res => {
+      expect(res).to.deep.equal(layoutRectLtwh(1, 2, 3, 4));
+    });
+  });
+
+  it('should calculate client rect w/ global client rect when ', () => {
+    const bindingMock = sandbox.mock(binding);
+    bindingMock.expects('getGlobalClientRect')
+        .returns(Promise.resolve(layoutRectLtwh(5, 5, 5, 5)));
+    const el = document.createElement('div');
+    el.getBoundingClientRect = () => {return layoutRectLtwh(1, 2, 3, 4);};
+    sandbox.stub(viewport.vsync_, 'measurePromise', cb => cb());
+    return viewport.getClientRectAsync(el).then(res => {
+      expect(res).to.deep.equal(layoutRectLtwh(6, 7, 3, 4));
+    });
   });
 
   it('should deletegate scrollWidth', () => {

--- a/test/functional/test-viewport.js
+++ b/test/functional/test-viewport.js
@@ -846,15 +846,10 @@ describes.fakeWin('Viewport', {}, env => {
     bindingMock.expects('getRootClientRectAsync')
         .returns(Promise.resolve(layoutRectLtwh(5, 5, 5, 5))).twice();
     const el = document.createElement('div');
-    const el1 = document.createElement('div');
     el.getBoundingClientRect = () => {return layoutRectLtwh(1, 2, 3, 4);};
-    el1.getBoundingClientRect = () => {return layoutRectLtwh(5, 6, 3, 4);};
     sandbox.stub(viewport.vsync_, 'measurePromise', cb => cb());
     return viewport.getClientRectAsync(el).then(res => {
       expect(res).to.deep.equal(layoutRectLtwh(6, 7, 3, 4));
-      return viewport.getClientRectAsync(el1).then(res => {
-        expect(res).to.be.null;
-      });
     });
   });
 

--- a/test/functional/test-viewport.js
+++ b/test/functional/test-viewport.js
@@ -831,7 +831,8 @@ describes.fakeWin('Viewport', {}, env => {
 
   it('should calculate client rect w/o global client rect', () => {
     const bindingMock = sandbox.mock(binding);
-    bindingMock.expects('getRootClientRectAsyn').returns(Promise.resolve(null));
+    bindingMock.expects('getRootClientRectAsync')
+        .returns(Promise.resolve(null));
     const el = document.createElement('div');
     el.getBoundingClientRect = () => {return layoutRectLtwh(1, 2, 3, 4);};
     sandbox.stub(viewport.vsync_, 'measurePromise', cb => cb());
@@ -842,13 +843,18 @@ describes.fakeWin('Viewport', {}, env => {
 
   it('should calculate client rect w/ global client rect when ', () => {
     const bindingMock = sandbox.mock(binding);
-    bindingMock.expects('getRootClientRectAsyn')
-        .returns(Promise.resolve(layoutRectLtwh(5, 5, 5, 5)));
+    bindingMock.expects('getRootClientRectAsync')
+        .returns(Promise.resolve(layoutRectLtwh(5, 5, 5, 5))).twice();
     const el = document.createElement('div');
+    const el1 = document.createElement('div');
     el.getBoundingClientRect = () => {return layoutRectLtwh(1, 2, 3, 4);};
+    el1.getBoundingClientRect = () => {return layoutRectLtwh(5, 6, 3, 4);};
     sandbox.stub(viewport.vsync_, 'measurePromise', cb => cb());
     return viewport.getClientRectAsync(el).then(res => {
       expect(res).to.deep.equal(layoutRectLtwh(6, 7, 3, 4));
+      return viewport.getClientRectAsync(el1).then(res => {
+        expect(res).to.be.null;
+      });
     });
   });
 


### PR DESCRIPTION
To address the comment [here] (https://github.com/ampproject/amphtml/pull/10813#discussion_r135597709).

I can get rid of `+ scrollTop/scrollLeft` then `- scrollTop/scrollLeft` by using clientRect instead.

In this way, `scrollTop`/`scrollLeft` won't be calculated between two browser `scroll` event, but only `getBoundingClientRect()` will be calculated between `scroll` event for scroll bound animation. 

Note now both `layoutRect` and `clientRect` exist. We can later on switch to using clientRect instead of layoutRect for inabox case. But that's up to future decision. I want to get this in first to unblock #10813 : )