### PR TITLE
Adds getBinaryType to experiments.js

### DIFF
--- a/src/experiments.js
+++ b/src/experiments.js
@@ -72,8 +72,8 @@ export function isCanary(win) {
  * @return {string}
  */
 export function getBinaryType(win) {
-  return win.AMP_CONFIG && win.AMP_CONFIG.type
-      ? win.AMP_CONFIG.type : 'unknown';
+  return win.AMP_CONFIG && win.AMP_CONFIG.type ?
+      win.AMP_CONFIG.type : 'unknown';
 }
 
 

--- a/src/experiments.js
+++ b/src/experiments.js
@@ -72,7 +72,8 @@ export function isCanary(win) {
  * @return {string}
  */
 export function getBinaryType(win) {
-  return (win.AMP_CONFIG && win.AMP_CONFIG.type) || 'unknown';
+  return win.AMP_CONFIG && win.AMP_CONFIG.type
+      ? win.AMP_CONFIG.type : 'unknown';
 }
 
 

--- a/src/experiments.js
+++ b/src/experiments.js
@@ -66,6 +66,15 @@ export function isCanary(win) {
   return !!(win.AMP_CONFIG && win.AMP_CONFIG.canary);
 }
 
+/**
+ * Returns runtime type, e.g., canary, control, or production.
+ * @param {!Window} win
+ * @return {string}
+ */
+export function getRuntimeType(win) {
+  return (win.AMP_CONFIG && win.AMP_CONFIG.type) || 'unknown';
+}
+
 
 /**
  * Enable experiments detailed in an origin trials token iff the token is

--- a/src/experiments.js
+++ b/src/experiments.js
@@ -67,11 +67,11 @@ export function isCanary(win) {
 }
 
 /**
- * Returns runtime type, e.g., canary, control, or production.
+ * Returns binary type, e.g., canary, control, or production.
  * @param {!Window} win
  * @return {string}
  */
-export function getRuntimeType(win) {
+export function getBinaryType(win) {
   return (win.AMP_CONFIG && win.AMP_CONFIG.type) || 'unknown';
 }
 

--- a/test/functional/test-experiments.js
+++ b/test/functional/test-experiments.js
@@ -588,6 +588,8 @@ describe('getBinaryType', () => {
     expect(getBinaryType(win)).to.equal('production');
     win.AMP_CONFIG.type = 'canary';
     expect(getBinaryType(win)).to.equal('canary');
+    delete win.AMP_CONFIG.type;
+    expect(getBinaryType(win)).to.equal('unknown');
   });
   it('should return "unknown"', () => {
     expect(getBinaryType({})).to.equal('unknown');

--- a/test/functional/test-experiments.js
+++ b/test/functional/test-experiments.js
@@ -36,7 +36,7 @@ import {
   RANDOM_NUMBER_GENERATORS,
   getExperimentBranch,
   randomlySelectUnsetExperiments,
-  getRuntimeType,
+  getBinaryType,
 } from '../../src/experiments';
 import {createElementWithAttributes} from '../../src/dom';
 import {user} from '../../src/log';
@@ -578,19 +578,19 @@ describe('isCanary', () => {
   });
 });
 
-describe('getRuntimeType', () => {
+describe('getBinaryType', () => {
   it('should return correct type', () => {
     const win = {
       AMP_CONFIG: {
         type: 'production',
       },
     };
-    expect(getRuntimeType(win)).to.equal('production');
+    expect(getBinaryType(win)).to.equal('production');
     win.AMP_CONFIG.type = 'canary';
-    expect(getRuntimeType(win)).to.equal('canary');
+    expect(getBinaryType(win)).to.equal('canary');
   });
   it('should return "unknown"', () => {
-    expect(getRuntimeType({})).to.equal('unknown');
+    expect(getBinaryType({})).to.equal('unknown');
   });
 });
 

--- a/test/functional/test-experiments.js
+++ b/test/functional/test-experiments.js
@@ -36,6 +36,7 @@ import {
   RANDOM_NUMBER_GENERATORS,
   getExperimentBranch,
   randomlySelectUnsetExperiments,
+  getRuntimeType,
 } from '../../src/experiments';
 import {createElementWithAttributes} from '../../src/dom';
 import {user} from '../../src/log';
@@ -574,6 +575,22 @@ describe('isCanary', () => {
     expect(isCanary(win)).to.be.false;
     win.AMP_CONFIG.canary = 1;
     expect(isCanary(win)).to.be.true;
+  });
+});
+
+describe('getRuntimeType', () => {
+  it('should return correct type', () => {
+    const win = {
+      AMP_CONFIG: {
+        type: 'production',
+      },
+    };
+    expect(getRuntimeType(win)).to.equal('production');
+    win.AMP_CONFIG.type = 'canary';
+    expect(getRuntimeType(win)).to.equal('canary');
+  });
+  it('should return "unknown"', () => {
+    expect(getRuntimeType({})).to.equal('unknown');
   });
 });
 


### PR DESCRIPTION
Adds getBinaryType to experiments.js, which just returns win.AMP_CONFIG.type, if set, or "unknown" otherwise.