### PR TITLE
Doubleclick FF: fix issue where forcing via url for development no longer applying on non-cache

### DIFF
--- a/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
@@ -127,8 +127,8 @@ export class DoubleclickA4aEligibility {
     let experimentName = DFP_CANONICAL_FF_EXPERIMENT_NAME;
     if (!this.isCdnProxy(win)) {
       // Ensure that forcing FF via url is applied if test/localDev.
-      experimentId = urlExperimentId == -1 &&
-          (getMode(win).localDev ||	getMode(win).test) ?
+      experimentId = (urlExperimentId == -1 &&
+          (getMode(win).localDev ||	getMode(win).test)) ?
           MANUAL_EXPERIMENT_ID :
           this.maybeSelectExperiment(win, element, [
             DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_CONTROL,

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
@@ -122,12 +122,15 @@ export class DoubleclickA4aEligibility {
         !this.supportsCrypto(win)) {
       return false;
     }
+    const urlExperimentId = extractUrlExperimentId(win, element);
     let experimentName = DFP_CANONICAL_FF_EXPERIMENT_NAME;
     if (!this.isCdnProxy(win)) {
-      experimentId = this.maybeSelectExperiment_(win, element, [
-        DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_CONTROL,
-        DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_EXPERIMENT,
-      ], DFP_CANONICAL_FF_EXPERIMENT_NAME);
+      // Ensure that forcing FF via url is applied.
+      experimentId = urlExperimentId == -1 ? MANUAL_EXPERIMENT_ID :
+          this.maybeSelectExperiment_(win, element, [
+            DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_CONTROL,
+            DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_EXPERIMENT,
+          ], DFP_CANONICAL_FF_EXPERIMENT_NAME);
     } else {
       if (element.hasAttribute(BETA_ATTRIBUTE)) {
         addExperimentIdToElement(BETA_EXPERIMENT_ID, element);
@@ -136,7 +139,6 @@ export class DoubleclickA4aEligibility {
       }
       experimentName = DOUBLECLICK_A4A_EXPERIMENT_NAME;
       // See if in holdback control/experiment.
-      const urlExperimentId = extractUrlExperimentId(win, element);
       if (urlExperimentId != undefined) {
         experimentId = URL_EXPERIMENT_MAPPING[urlExperimentId];
         dev().info(

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
@@ -32,6 +32,7 @@ import {
   forceExperimentBranch,
   randomlySelectUnsetExperiments,
 } from '../../../src/experiments';
+import {getMode} from '../../../src/mode';
 import {dev} from '../../../src/log';
 
 /** @const {string} */
@@ -125,12 +126,18 @@ export class DoubleclickA4aEligibility {
     const urlExperimentId = extractUrlExperimentId(win, element);
     let experimentName = DFP_CANONICAL_FF_EXPERIMENT_NAME;
     if (!this.isCdnProxy(win)) {
-      // Ensure that forcing FF via url is applied.
-      experimentId = urlExperimentId == -1 ? MANUAL_EXPERIMENT_ID :
-          this.maybeSelectExperiment_(win, element, [
+      // Ensure that forcing FF via url is applied if test/localDev.
+      experimentId = urlExperimentId == -1 &&
+          (getMode(win).localDev ||	getMode(win).test) ?
+          MANUAL_EXPERIMENT_ID :
+          this.maybeSelectExperiment(win, element, [
             DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_CONTROL,
             DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_EXPERIMENT,
           ], DFP_CANONICAL_FF_EXPERIMENT_NAME);
+      // If no experiment selected, return false.
+      if (!experimentId) {
+        return false;
+      }
     } else {
       if (element.hasAttribute(BETA_ATTRIBUTE)) {
         addExperimentIdToElement(BETA_EXPERIMENT_ID, element);
@@ -145,7 +152,7 @@ export class DoubleclickA4aEligibility {
             TAG,
             `url experiment selection ${urlExperimentId}: ${experimentId}.`);
       } else {
-        experimentId = this.maybeSelectExperiment_(win, element, [
+        experimentId = this.maybeSelectExperiment(win, element, [
           DOUBLECLICK_EXPERIMENT_FEATURE.HOLDBACK_INTERNAL_CONTROL,
           DOUBLECLICK_EXPERIMENT_FEATURE.HOLDBACK_INTERNAL],
             DOUBLECLICK_A4A_EXPERIMENT_NAME);
@@ -169,9 +176,9 @@ export class DoubleclickA4aEligibility {
    * @param {!Array<string>} selectionBranches
    * @param {!string} experimentName}
    * @return {?string} Experiment branch ID or null if not selected.
-   * @private
+   * @visibileForTesting
    */
-  maybeSelectExperiment_(win, element, selectionBranches, experimentName) {
+  maybeSelectExperiment(win, element, selectionBranches, experimentName) {
     const experimentInfoMap =
         /** @type {!Object<string, !ExperimentInfo>} */ ({});
     experimentInfoMap[experimentName] = {

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-a4a-config.js
@@ -26,6 +26,7 @@ import {
 } from '../doubleclick-a4a-config';
 import {
   isInExperiment,
+  MANUAL_EXPERIMENT_ID,
 } from '../../../../ads/google/a4a/traffic-experiments';
 import {EXPERIMENT_ATTRIBUTE} from '../../../../ads/google/a4a/utils';
 import {forceExperimentBranch} from '../../../../src/experiments';
@@ -84,6 +85,18 @@ describe('doubleclick-a4a-config', () => {
       expect(doubleclickIsA4AEnabled(mockWin, elem)).to.be.true;
       expect(elem.getAttribute(EXPERIMENT_ATTRIBUTE)).to.equal(
           DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_EXPERIMENT);
+    });
+
+    it('should honor url forced FF on non-CDN', () => {
+      mockWin.location = parseUrl(
+          'https://foo.com/some/path/to/content.html?exp=a4a:-1');
+      sandbox.stub(DoubleclickA4aEligibility.prototype,
+          'isCdnProxy', () => false);
+      const elem = testFixture.doc.createElement('div');
+      testFixture.doc.body.appendChild(elem);
+      expect(doubleclickIsA4AEnabled(mockWin, elem)).to.be.true;
+      expect(elem.getAttribute(EXPERIMENT_ATTRIBUTE)).to.equal(
+          MANUAL_EXPERIMENT_ID);
     });
 
     it('should not enable if data-use-same-domain-rendering-until-deprecated',

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-a4a-config.js
@@ -59,6 +59,18 @@ describe('doubleclick-a4a-config', () => {
   });
 
   describe('#doubleclickIsA4AEnabled', () => {
+    it('should enable a4a on AMP cache w/o experiments selected', () => {
+      // Ensure no selection in order to very experiment attribute.
+      sandbox.stub(DoubleclickA4aEligibility.prototype, 'maybeSelectExperiment')
+          .returns(null);
+      mockWin.location = parseUrl(
+          'https://cdn.ampproject.org/some/path/to/content.html');
+      const elem = testFixture.doc.createElement('div');
+      testFixture.doc.body.appendChild(elem);
+      expect(doubleclickIsA4AEnabled(mockWin, elem)).to.be.true;
+      expect(elem.getAttribute(EXPERIMENT_ATTRIBUTE)).to.not.be.ok;
+    });
+
     it('should enable a4a when native crypto is supported', () => {
       forceExperimentBranch(mockWin, DFP_CANONICAL_FF_EXPERIMENT_NAME,
           DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_EXPERIMENT);
@@ -87,7 +99,18 @@ describe('doubleclick-a4a-config', () => {
           DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_EXPERIMENT);
     });
 
+    it('should return false if no canonical AMP experiment branch', () => {
+      forceExperimentBranch(mockWin, DFP_CANONICAL_FF_EXPERIMENT_NAME, null);
+      sandbox.stub(DoubleclickA4aEligibility.prototype,
+          'isCdnProxy', () => false);
+      const elem = testFixture.doc.createElement('div');
+      testFixture.doc.body.appendChild(elem);
+      expect(doubleclickIsA4AEnabled(mockWin, elem)).to.be.false;
+      expect(elem.getAttribute(EXPERIMENT_ATTRIBUTE)).to.not.be.ok;
+    });
+
     it('should honor url forced FF on non-CDN', () => {
+      mockWin.AMP_MODE = {test: false, localDev: true};
       mockWin.location = parseUrl(
           'https://foo.com/some/path/to/content.html?exp=a4a:-1');
       sandbox.stub(DoubleclickA4aEligibility.prototype,
@@ -97,6 +120,21 @@ describe('doubleclick-a4a-config', () => {
       expect(doubleclickIsA4AEnabled(mockWin, elem)).to.be.true;
       expect(elem.getAttribute(EXPERIMENT_ATTRIBUTE)).to.equal(
           MANUAL_EXPERIMENT_ID);
+    });
+
+    it('should not honor url forced FF on non-CDN if prod', () => {
+      // Ensure no selection in order to very experiment attribute.
+      const maybeSelectExperimentStub = sandbox.stub(
+          DoubleclickA4aEligibility.prototype, 'maybeSelectExperiment')
+          .returns(undefined);
+      mockWin.AMP_MODE = {test: false, localDev: false};
+      mockWin.location = parseUrl(
+          'https://somepub.com/some/path/to/content.html?exp=a4a:-1');
+      const elem = testFixture.doc.createElement('div');
+      testFixture.doc.body.appendChild(elem);
+      expect(doubleclickIsA4AEnabled(mockWin, elem)).to.be.false;
+      expect(elem.getAttribute(EXPERIMENT_ATTRIBUTE)).to.not.be.ok;
+      expect(maybeSelectExperimentStub).to.be.calledOnce;
     });
 
     it('should not enable if data-use-same-domain-rendering-until-deprecated',


### PR DESCRIPTION
Fixes issue from #11063 which caused forced fast fetch via url parameter to no longer be honored on non-AMP pages.