### PR TITLE
Enable ampdoc-shell experiment via amp-experiments-opt-in meta tag

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -1,5 +1,5 @@
 {
-  "allow-doc-opt-in": ["visibility-v3", "amp-animation"],
+  "allow-doc-opt-in": ["visibility-v3", "amp-animation", "ampdoc-shell"],
   "allow-url-opt-in": ["pump-early-frame"],
 
   "canary": 1,

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -1,5 +1,5 @@
 {
-  "allow-doc-opt-in": ["visibility-v3", "amp-animation"],
+  "allow-doc-opt-in": ["visibility-v3", "amp-animation", "ampdoc-shell"],
   "allow-url-opt-in": ["pump-early-frame"],
 
   "canary": 0,


### PR DESCRIPTION
For production environments, allows enabling `ampdoc-shell` experiment via meta tag