### PR TITLE
AdSense delayed fetch add loadingStrategy to validateData attributes

### DIFF
--- a/ads/google/adsense.js
+++ b/ads/google/adsense.js
@@ -27,7 +27,7 @@ export function adsense(global, data) {
   // TODO: check mandatory fields
   validateData(data, [],
       ['adClient', 'adSlot', 'adHost', 'adtest', 'tagOrigin', 'experimentId',
-        'ampSlotIndex', 'adChannel']);
+        'ampSlotIndex', 'adChannel', 'loadingStrategy']);
 
   if (global.context.clientId) {
     // Read by GPT for GA/GPT integration.


### PR DESCRIPTION
Addresses issue #10817 where amp-ad type=adsense usage of data-loading-strategy triggers error within 3p frame.  Fix is to add to array of validateData attributes.