### PR TITLE
Allow data-loading-strategy attribute in amp-ad.

### DIFF
--- a/3p/3p.js
+++ b/3p/3p.js
@@ -272,6 +272,7 @@ function validateAllowedFields(data, allowedFields) {
     consentNotificationId: true,
     ampSlotIndex: true,
     adHolderText: true,
+    loadingStrategy: true,
   };
 
   for (const field in data) {

--- a/ads/google/adsense.js
+++ b/ads/google/adsense.js
@@ -27,7 +27,7 @@ export function adsense(global, data) {
   // TODO: check mandatory fields
   validateData(data, [],
       ['adClient', 'adSlot', 'adHost', 'adtest', 'tagOrigin', 'experimentId',
-        'ampSlotIndex', 'adChannel', 'loadingStrategy']);
+        'ampSlotIndex', 'adChannel']);
 
   if (global.context.clientId) {
     // Read by GPT for GA/GPT integration.


### PR DESCRIPTION
Fixes #10817 

Since this attribute is for all ad networks.