### PR TITLE
Be flexible in value of `as` attribute after assignment of invalid value.

### DIFF
--- a/test/functional/test-preconnect.js
+++ b/test/functional/test-preconnect.js
@@ -293,7 +293,7 @@ describe('preconnect', () => {
         expect(as == '' || as == 'fetch').to.be.ok;
         preloads[0].as = 'not-valid';
         if (preloads[0].as != 'not-valid') {
-          expect(as).to.equal('fetch');
+          expect(as == '' || as == 'fetch').to.be.ok;
         }
       });
     });


### PR DESCRIPTION
The behavior changed in Chrome 61 from returning `fetch` to ``. Both just meand `default` and so we accept both.