### PR TITLE
amp-bind: More functions, update docs

### DIFF
--- a/build-system/conformance-config.textproto
+++ b/build-system/conformance-config.textproto
@@ -71,6 +71,7 @@ requirement: {
   type: BANNED_NAME
   error_message: 'Object.values is not allowed'
   value: 'Object.values'
+  whitelist: 'extensions/amp-bind/0.1/bind-expression.js' # Polyfills IE case.
 }
 
 requirement: {

--- a/examples/bind/turing.amp.html
+++ b/examples/bind/turing.amp.html
@@ -69,7 +69,7 @@
           'state': T.instructions[T.state][ T.cells[T.head] ].state,
           'cells': T.instructions[T.state][ T.cells[T.head] ].write == null
               ? T.cells
-              : copyAndSplice(T.cells, T.head, 1, T.instructions[T.state][ T.cells[T.head] ].write)
+              : splice(T.cells, T.head, 1, T.instructions[T.state][ T.cells[T.head] ].write)
         },
         'count': T.state == 'return'
             ? T.cells[1] + 2*T.cells[2] + 4*T.cells[3] + 8*T.cells[4] + 16*T.cells[5] + 32*T.cells[6] + 64*T.cells[7] + 128*T.cells[8]

--- a/extensions/amp-bind/0.1/bind-expression.js
+++ b/extensions/amp-bind/0.1/bind-expression.js
@@ -299,7 +299,12 @@ export class BindExpression {
 
         if (validFunction) {
           if (Array.isArray(params)) {
-            return validFunction.apply(caller, params);
+            // Don't allow objects as parameters except for Object functions.
+            const invalidArgumentType = this.containsObject_(params)
+                && !this.isObjectMethod_(method);
+            if (!invalidArgumentType) {
+              return validFunction.apply(caller, params);
+            }
           } else if (typeof params == 'function') {
             // Special case: `params` may be an arrow function, which are only
             // supported as the sole argument to functions like Array#find.
@@ -468,5 +473,29 @@ export class BindExpression {
     const stringified = JSON.stringify(/** @type {!JsonObject} */ (member));
     user().warn(TAG, `Cannot read property ${stringified} of ` +
         `${stringified}; returning null.`);
+  }
+
+  /**
+   * Returns true iff method is
+   * @param {string} method
+   * @return {boolean}
+   */
+  isObjectMethod_(method) {
+    return method == 'keys' || method == 'values';
+  }
+
+  /**
+   * Returns true if input array contains a plain object.
+   * @param {!Array} array
+   * @return {boolean}
+   * @private
+   */
+  containsObject_(array) {
+    for (let i = 0; i < array.length; i++) {
+      if (isObject(array[i])) {
+        return true;
+      }
+    }
+    return false;
   }
 }

--- a/extensions/amp-bind/0.1/bind-expression.js
+++ b/extensions/amp-bind/0.1/bind-expression.js
@@ -39,9 +39,6 @@ const DEFAULT_MAX_AST_SIZE = 50;
 /** @const @private {string} */
 const BUILT_IN_FUNCTIONS = 'built-in-functions';
 
-/** @const {!Function} */
-const isEnumerable = Object.prototype.propertyIsEnumerable;
-
 /**
  * Map of object type to function name to whitelisted function.
  * @private {!Object<string, !Object<string, Function>>}
@@ -95,7 +92,7 @@ function generateFunctionWhitelist() {
   function values(object) {
     const v = [];
     for (const key in object) {
-      if (hasOwn(object, key) && isEnumerable.call(object, key)) {
+      if (hasOwn(object, key)) {
         v.push(object[key]);
       }
     }

--- a/extensions/amp-bind/0.1/bind-expression.js
+++ b/extensions/amp-bind/0.1/bind-expression.js
@@ -60,9 +60,9 @@ function generateFunctionWhitelist() {
    * @return {!Array}
    */
   /*eslint "no-unused-vars": 0*/
-  function copyAndSplice(array, start, deleteCount, items) {
+  function splice(array, start, deleteCount, items) {
     if (!isArray(array)) {
-      throw new Error(`copyAndSplice: ${array} is not an array.`);
+      throw new Error(`splice: ${array} is not an array.`);
     }
     const copy = Array.prototype.slice.call(array);
     const args = Array.prototype.slice.call(arguments, 1);
@@ -129,7 +129,8 @@ function generateFunctionWhitelist() {
 
   // Custom functions (non-js-built-ins) must be added manually as their names
   // will be minified at compile time.
-  out[BUILT_IN_FUNCTIONS]['copyAndSplice'] = copyAndSplice;
+  out[BUILT_IN_FUNCTIONS]['copyAndSplice'] = splice; // Legacy name.
+  out[BUILT_IN_FUNCTIONS]['splice'] = splice; // Legacy name.
 
   return out;
 }

--- a/extensions/amp-bind/0.1/bind-expression.js
+++ b/extensions/amp-bind/0.1/bind-expression.js
@@ -298,7 +298,7 @@ export class BindExpression {
         }
 
         if (validFunction) {
-          if (Array.isArray(params) && !this.containsObject_(params)) {
+          if (Array.isArray(params)) {
             return validFunction.apply(caller, params);
           } else if (typeof params == 'function') {
             // Special case: `params` may be an arrow function, which are only
@@ -468,20 +468,5 @@ export class BindExpression {
     const stringified = JSON.stringify(/** @type {!JsonObject} */ (member));
     user().warn(TAG, `Cannot read property ${stringified} of ` +
         `${stringified}; returning null.`);
-  }
-
-  /**
-   * Returns true if input array contains a plain object.
-   * @param {!Array} array
-   * @return {boolean}
-   * @private
-   */
-  containsObject_(array) {
-    for (let i = 0; i < array.length; i++) {
-      if (isObject(array[i])) {
-        return true;
-      }
-    }
-    return false;
   }
 }

--- a/extensions/amp-bind/0.1/bind-expression.js
+++ b/extensions/amp-bind/0.1/bind-expression.js
@@ -94,7 +94,7 @@ function generateFunctionWhitelist() {
    */
   function values(object) {
     const v = [];
-    for (var key in object) {
+    for (const key in object) {
       if (hasOwn(object, key) && isEnumerable.call(object, key)) {
         v.push(object[key]);
       }
@@ -174,8 +174,8 @@ function generateFunctionWhitelist() {
   out[BUILT_IN_FUNCTIONS]['copyAndSplice'] = splice; // Legacy name.
   out[BUILT_IN_FUNCTIONS]['sort'] = sort;
   out[BUILT_IN_FUNCTIONS]['splice'] = splice;
-  out[BUILT_IN_FUNCTIONS]['values'] = (typeof Object.values === 'function')
-      ? Object.values : values;
+  out[BUILT_IN_FUNCTIONS]['values'] =
+      (typeof Object.values == 'function') ? Object.values : values;
 
   return out;
 }

--- a/extensions/amp-bind/0.1/test/test-bind-expression.js
+++ b/extensions/amp-bind/0.1/test/test-bind-expression.js
@@ -349,17 +349,15 @@ describe('BindExpression', () => {
           .to.equal('http%3A%2F%2Fgoogle.com%2Ffoo%3Ffoo%3Dbar');
     });
 
-    it('copyAndSplice()', () => {
+    it('splice()', () => {
       const a = [1, 2, 3];
-      expect(() => evaluate('copyAndSplice()')).to.throw(/not an array/);
-      expect(() => evaluate('copyAndSplice(x)', {x: 8472}))
-          .to.throw(/not an array/);
-      expect(evaluate('copyAndSplice(a)', {a})).to.not.equal(a);
-      expect(evaluate('copyAndSplice(a)', {a})).to.deep.equal(a);
-      expect(evaluate('copyAndSplice(a, 1)', {a})).to.deep.equal([1]);
-      expect(evaluate('copyAndSplice(a, 1, 1)', {a})).to.deep.equal([1, 3]);
-      expect(evaluate('copyAndSplice(a, 1, 1, 47)', {a}))
-          .to.deep.equal([1, 47, 3]);
+      expect(() => evaluate('splice()')).to.throw(/not an array/);
+      expect(() => evaluate('splice(x)', {x: 8472})).to.throw(/not an array/);
+      expect(evaluate('splice(a)', {a})).to.not.equal(a);
+      expect(evaluate('splice(a)', {a})).to.deep.equal(a);
+      expect(evaluate('splice(a, 1)', {a})).to.deep.equal([1]);
+      expect(evaluate('splice(a, 1, 1)', {a})).to.deep.equal([1, 3]);
+      expect(evaluate('splice(a, 1, 1, 47)', {a})).to.deep.equal([1, 47, 3]);
     });
 
     it('return null when caller is null', () => {

--- a/extensions/amp-bind/0.1/test/test-bind-expression.js
+++ b/extensions/amp-bind/0.1/test/test-bind-expression.js
@@ -17,6 +17,7 @@
 import {BindExpression} from '../bind-expression';
 
 describe('BindExpression', () => {
+  const argumentTypeError = 'Unexpected argument type';
   const unsupportedFunctionError = 'not a supported function';
   const expressionSizeExceededError = 'exceeds max';
 
@@ -438,9 +439,13 @@ describe('BindExpression', () => {
       }).to.throw(Error, unsupportedFunctionError);
     });
 
-    it('gracefully handle invalid argument types', () => {
-      expect(evaluate('[1, 2, 3].indexOf({})')).to.equal(-1);
-      expect(() => { evaluate('"abc".substr({})'); }).to.throw(TypeError);
+    it('disallow: whitelisted functions with invalid argument types', () => {
+      expect(() => {
+        evaluate('[1, 2, 3].indexOf({})');
+      }).to.throw(Error, argumentTypeError);
+      expect(() => {
+        evaluate('"abc".substr({})');
+      }).to.throw(Error, argumentTypeError);
     });
   });
 

--- a/extensions/amp-bind/0.1/test/test-bind-expression.js
+++ b/extensions/amp-bind/0.1/test/test-bind-expression.js
@@ -577,7 +577,6 @@ describe('BindExpression', () => {
     });
   });
 
-
   describe('arrow functions', () => {
     it('Array#map()', () => {
       const a = [1, 2, 3];

--- a/extensions/amp-bind/amp-bind.md
+++ b/extensions/amp-bind/amp-bind.md
@@ -187,10 +187,10 @@ Expressions are similar to JavaScript with some important differences.
 
 - Expressions may only access the containing document's [state](#state).
 - Expressions **do not** have access to globals like `window` or `document`.
-- Only [white-listed functions](#white-listed-functions) are allowed.
-- Custom functions, classes and some control flow statements (e.g. `for`) are disallowed.
+- Only [white-listed functions](#white-listed-functions) and operators may be used.
+- Custom functions, classes and loops are generally disallowed. Arrow functions are allowed as parameters, e.g. `Array.prototype.map`.
 - Undefined variables and array-index-out-of-bounds return `null` instead of `undefined` or throwing errors.
-- A single expression is currently capped at 50 operands for performance reasons. Please [contact us](https://github.com/ampproject/amphtml/issues/new) if this is insufficient for your use case.
+- A single expression is currently capped at 50 operands for performance. Please [contact us](https://github.com/ampproject/amphtml/issues/new) if this is insufficient for your use case.
 
 The full expression grammar and implementation can be found in [bind-expr-impl.jison](./0.1/bind-expr-impl.jison) and [bind-expression.js](./0.1/bind-expression.js).
 
@@ -214,38 +214,123 @@ null || 'default' // 'default'
     <th>Example</th>
   </tr>
   <tr>
-    <td><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array#Methods"><code>Array</code></a></td>
-    <td class="col-thirty"><code>concat</code><br><code>includes</code><br><code>indexOf</code><br><code>join</code><br><code>lastIndexOf</code><br><code>slice</code></td>
-    <td><pre>// Returns true.
-[1, 2, 3].includes(1)</pre></td>
+    <td><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array#Methods"><code>Array</code><sup>2</sup></a></td>
+    <td class="col-thirty">
+      <code>concat</code><br>
+      <code>filter</code><br>
+      <code>includes</code><br>
+      <code>indexOf</code><br>
+      <code>join</code><br>
+      <code>lastIndexOf</code><br>
+      <code>map</code><br>
+      <code>reduce</code><br>
+      <code>slice</code><br>
+      <code>some</code><br>
+    </td>
+    <td>
+      <pre>// Returns true.
+[1, 2, 3].includes(1)</pre>
+      <pre>// Returns [2, 3].
+[1, 2, 3].filter(x => x >= 2)</pre>
+      <pre>// Returns [1, 3, 5].
+[1, 2, 3].map((x, i) => x + i)</pre>
+      <pre>// Returns 6.
+[1, 2, 3].reduce((x, y) => x + y)</pre>
+    </td>
+  </tr>
+  <tr>
+   <td><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number#Methods"><code>Number</code></a></td>
+    <td>
+      <code>toExponential</code><br>
+      <code>toFixed</code><br>
+      <code>toPrecision</code><br>
+      <code>toString</code>
+    <td>
+      <pre>// Returns 3.
+(3.14).toFixed()</pre>
+      <pre>// Returns '3.14'.
+(3.14).toString()</pre>
+    </td>
   </tr>
   <tr>
    <td><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#Methods"><code>String</code></a></td>
-    <td><code>charAt</code><br><code>charCodeAt</code><br><code>concat</code><br><code>indexOf</code><br><code>lastIndexOf</code><br><code>slice</code><br><code>split</code><br><code>substr</code><br><code>substring</code><br><code>toLowerCase</code><br><code>toUpperCase</code></td>
-    <td><pre>// Returns 'abcdef'.
-'abc'.concat('def')</pre></td>
+    <td>
+      <code>charAt</code><br>
+      <code>charCodeAt</code><br>
+      <code>concat</code><br>
+      <code>indexOf</code><br>
+      <code>lastIndexOf</code><br>
+      <code>slice</code><br>
+      <code>split</code><br>
+      <code>substr</code><br>
+      <code>substring</code><br>
+      <code>toLowerCase</code><br>
+      <code>toUpperCase</code></td>
+    <td>
+      <pre>// Returns 'abcdef'.
+'abc'.concat('def')</pre>
+    </td>
   </tr>
   <tr>
-    <td><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math"><code>Math</code></a><sup>2</sup></td>
-    <td><code>abs</code><br><code>ceil</code><br><code>floor</code><br><code>max</code><br><code>min</code><br><code>random</code><br><code>round</code><br><code>sign</code></td>
-    <td><pre>// Returns 1.
-abs(-1)</td>
+    <td><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math"><code>Math</code></a><sup>3</sup></td>
+    <td>
+      <code>abs</code><br>
+      <code>ceil</code><br>
+      <code>floor</code><br>
+      <code>max</code><br>
+      <code>min</code><br>
+      <code>random</code><br>
+      <code>round</code><br>
+      <code>sign</code></td>
+    <td>
+      <pre>// Returns 1.
+abs(-1)</pre>
+    </td>
   </tr>
   <tr>
-    <td><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects"><code>Global</code></a><sup>2</sup></td>
-    <td><code>encodeURI</code><br><code>encodeURIComponent</code></td>
-    <td><pre>// Returns 'hello%20world'
-encodeURIComponent('hello world')</pre></td>
+    <td><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object"><code>Object</code></a><sup>3</sup></td>
+    <td>
+      <code>keys</code><br>
+      <code>values</code>
+    <td>
+      <pre>// Returns ['a', 'b'].
+keys({a: 1, b: 2})</pre>
+      <pre>// Returns [1, 2].
+values({a: 1, b: 2}</pre>
+    </td>
   </tr>
   <tr>
-    <td><a href="#custom-built-in-functions">Custom built-ins</a><sup>2</sup></td>
-    <td><code>splice</code></td>
-    <td><pre>// Returns [1, 47 ,3].
-splice([1, 2, 3], 1, 1, 47)</pre></td>
+    <td>
+      <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects"><code>Global</code></a><sup>3</sup>
+    </td>
+    <td>
+      <code>encodeURI</code><br>
+      <code>encodeURIComponent</code>
+    </td>
+    <td>
+      <pre>// Returns 'Hello%20world'.
+encodeURIComponent('Hello world')</pre>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <a href="#custom-built-in-functions">Custom built-ins</a><sup>3</sup>
+    </td>
+    <td>
+      <code>splice</code><br>
+      <code>sort</code>
+    </td>
+    <td>
+      <pre>// Returns a new array [1, 47 ,3]. Does not splice in-place.
+splice([1, 2, 3], 1, 1, 47)</pre>
+      <pre>// Returns a new array: [1, 2, 3]. Does not sort in-place.
+sort([2, 1, 3])</pre>
+    </td>
   </tr>
 </table>
 
-<sup>2</sup>Functions are not namespaced, e.g. use `abs(-1)` instead of `Math.abs(-1)`.
+<sup>2</sup>Single-parameter arrow functions can't have parentheses, e.g. use `x => x + 1` instead of `(x) => x + 1`.<br>
+<sup>3</sup>Static functions are not namespaced, e.g. use `abs(-1)` instead of `Math.abs(-1)`.
 
 ### Bindings
 
@@ -519,36 +604,6 @@ Defines a `credentials` option as specified by the [Fetch API](https://fetch.spe
 * Default: `omit`
 
 To send credentials, pass the value of `include`. If this value is set, the response must follow the [AMP CORS security guidelines](../../spec/amp-cors-requests.md).
-
-
-### Non-standard built-in functions
-
-`amp-bind` supports the following non-standard functions:
-
-<table>
-  <tr>
-    <th>Name</th>
-    <th>Details</th>
-  </tr>
-  <tr>
-    <td><code>splice</code></td>
-    <td>Similar to <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/splice">Array#splice()</a> except a copy of the spliced array is returned.
-    <br><br>Arguments:
-    <ul>
-      <li><code>array</code>: An array.</li>
-      <li><code>start</code>: Index at which to start changing the array.</li>
-      <li><code>deleteCount</code>: The number of items to delete, starting at index <code>start</code>.</li>
-      <li><code>items...</code>: Items to add to the array, beginning at index <code>start</code></li>
-    </ul>
-    <br><br>Examples:
-    <pre>// Deleting an element. Returns [1, 3]
-splice([1, 2, 3], 1, 1)
-
-// Replacing an item. Returns ['Pizza', 'Cake', 'Ice Cream']
-splice(['Pizza', 'Cake', 'Soda'], 2, 1, 'Ice Cream')</pre>
-   </td>
-  </tr>
-</table>
 
 ### Deep-merge with `AMP.setState()`
 

--- a/extensions/amp-bind/amp-bind.md
+++ b/extensions/amp-bind/amp-bind.md
@@ -239,9 +239,9 @@ encodeURIComponent('hello world')</pre></td>
   </tr>
   <tr>
     <td><a href="#custom-built-in-functions">Custom built-ins</a><sup>2</sup></td>
-    <td><code>copyAndSplice</code></td>
+    <td><code>splice</code></td>
     <td><pre>// Returns [1, 47 ,3].
-copyAndSplice([1, 2, 3], 1, 1, 47)</pre></td>
+splice([1, 2, 3], 1, 1, 47)</pre></td>
   </tr>
 </table>
 
@@ -531,7 +531,7 @@ To send credentials, pass the value of `include`. If this value is set, the resp
     <th>Details</th>
   </tr>
   <tr>
-    <td><code>copyAndSplice</code></td>
+    <td><code>splice</code></td>
     <td>Similar to <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/splice">Array#splice()</a> except a copy of the spliced array is returned.
     <br><br>Arguments:
     <ul>
@@ -542,10 +542,10 @@ To send credentials, pass the value of `include`. If this value is set, the resp
     </ul>
     <br><br>Examples:
     <pre>// Deleting an element. Returns [1, 3]
-copyAndSplice([1, 2, 3], 1, 1)
+splice([1, 2, 3], 1, 1)
 
 // Replacing an item. Returns ['Pizza', 'Cake', 'Ice Cream']
-copyAndSplice(['Pizza', 'Cake', 'Soda'], 2, 1, 'Ice Cream')</pre>
+splice(['Pizza', 'Cake', 'Soda'], 2, 1, 'Ice Cream')</pre>
    </td>
   </tr>
 </table>


### PR DESCRIPTION
Fixes #11144 and #11136.

- Whitelist `Array#filter` and `Array#some`
- Whitelist a few `Number.prototype` functions like `toFixed`
- Adds custom, not-in-place `sort()` function
- Rename `copyAndSplice()` to `splice()` (keep the former for legacy)
- Update documentation