### PR TITLE
Fix amp-web-push crashing in unsupported environment

### DIFF
--- a/extensions/amp-web-push/0.1/amp-web-push-config.js
+++ b/extensions/amp-web-push/0.1/amp-web-push-config.js
@@ -139,7 +139,7 @@ export class WebPushConfig extends AMP.BaseElement {
     this.validate();
     const config = this.parseConfig();
     const webPushService = getServiceForDoc(this.getAmpDoc(), SERVICE_TAG);
-    webPushService.start(config);
+    webPushService.start(config).catch(() => {});
 
     this.registerAction(WebPushWidgetActions.SUBSCRIBE,
         this.onSubscribe_.bind(this));

--- a/extensions/amp-web-push/0.1/test/test-web-push-service.js
+++ b/extensions/amp-web-push/0.1/test/test-web-push-service.js
@@ -67,6 +67,19 @@ describes.realWin('web-push-service environment support', {
     });
     expect(webPush.environmentSupportsWebPush()).to.eq(false);
   });
+
+  it('an unsupported environment should prevent initializing', () => {
+    // Cause push to not be supported on this environment
+    Object.defineProperty(env.win, 'PushManager', {
+      enumerable: false,
+      configurable: false,
+      writable: false,
+      value: undefined,
+    });
+    // Should not error out
+    return webPush.start().should.eventually.be
+        .rejectedWith(/Web push is not supported/);
+  });
 });
 
 

--- a/extensions/amp-web-push/0.1/web-push-service.js
+++ b/extensions/amp-web-push/0.1/web-push-service.js
@@ -145,6 +145,14 @@ export class WebPushService {
    * @returns {!Promise}
    */
   start(configJson) {
+    dev().fine(TAG, 'amp-web-push extension starting up.');
+
+    // Exit early if web push isn't supported
+    if (!this.environmentSupportsWebPush()) {
+      dev().fine(TAG, 'Web push is not supported.');
+      return Promise.reject('Web push is not supported');
+    }
+
     this.initializeConfig(configJson);
 
     // Add the IFrame
@@ -172,14 +180,6 @@ export class WebPushService {
    * @param {!AmpWebPushConfig} configJson
    */
   initializeConfig(configJson) {
-    dev().fine(TAG, 'amp-web-push extension starting up.');
-
-    // Exit early if web push isn't supported
-    if (!this.environmentSupportsWebPush()) {
-      dev().fine(TAG, 'Web push is not supported.');
-      return;
-    }
-
     // Read amp-web-push configuration
     this.config_ = configJson;
     if (!this.config_) {
@@ -187,6 +187,8 @@ export class WebPushService {
       return;
     }
   }
+
+  /**
 
   /**
    * Installs the helper IFrame onto the AMP page and returns a Promise for when


### PR DESCRIPTION
When amp-web-push starts up, it checks whether the browser environment
supports web push notifications. If the environment doesn't support web
push notifications, the code incorrectly returns ... into the next
method and just continues running. Eventually, configuration variables
that were supposed to be set in the initialization method we just quit
out of, are accessed, but are null, and the whole thing errors out.

The web push service now exits immediately when starting to run if the
environment is unsupported. This will cause any web push widgets for
subscription or unsubscription to remain hidden, since they're not shown
until the service determines the user's subscription state, and the
service is now stopped.