### PR TITLE
Use experiments META tag in AmpDocShell example

### DIFF
--- a/examples/pwa/pwa-ampdoc-shell.html
+++ b/examples/pwa/pwa-ampdoc-shell.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <title>PWA</title>
   <meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1,user-scalable=no,minimal-ui">
+  <meta name="amp-experiments-opt-in" content="ampdoc-shell">
   <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Georgia|Open+Sans|Roboto">
 
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
@@ -14,9 +15,12 @@
     if (window.location.pathname.indexOf('/examples') == 0) {
       window.location.assign('/pwa/ampdoc-shell');
     } else {
-      window.AMP_CONFIG = {
-        'ampdoc-shell': 1
-      }
+      // TODO: Remove this once AMP_CONFIG is available in dev builds
+      // In a production environment amppdoc-shell experiment should be
+      // enabled using only the experiments META tag.
+      // See https://github.com/ampproject/amphtml/tree/master/tools/experiments#enable-an-experiment-for-a-particular-document
+      window.AMP_CONFIG = window.AMP_CONFIG || {};
+      window.AMP_CONFIG['ampdoc-shell'] = 1;
     }
   </script>
 


### PR DESCRIPTION
Added the experiments META tag in AmpDocShell example, and an explanation of how activate this experiment in production environments.
