### PR TITLE
Issue 10679 - Added recipient to email configuration

### DIFF
--- a/examples/social-share.amp.html
+++ b/examples/social-share.amp.html
@@ -38,6 +38,7 @@
       <amp-social-share type="email"
                         data-param-subject="Hello World"
                         data-param-body="What's up?"
+                        data-param-recipient="sample@xyz.com"
                         aria-label="Share by email">
       </amp-social-share>
       <amp-social-share type="whatsapp"

--- a/extensions/amp-social-share/0.1/amp-social-share-config.js
+++ b/extensions/amp-social-share/0.1/amp-social-share-config.js
@@ -63,10 +63,11 @@ const BUILTINS = dict({
     },
   },
   'email': {
-    'shareEndpoint': 'mailto:',
+    'shareEndpoint': 'mailto: ${recipient}',
     'defaultParams': {
       'subject': 'TITLE',
       'body': 'CANONICAL_URL',
+      'recipient': '',
     },
   },
   'tumblr': {

--- a/extensions/amp-social-share/0.1/amp-social-share-config.js
+++ b/extensions/amp-social-share/0.1/amp-social-share-config.js
@@ -63,7 +63,8 @@ const BUILTINS = dict({
     },
   },
   'email': {
-    'shareEndpoint': 'mailto: ${recipient}',
+    'bindings': ['recipient'],
+    'shareEndpoint': 'mailto:RECIPIENT',
     'defaultParams': {
       'subject': 'TITLE',
       'body': 'CANONICAL_URL',

--- a/extensions/amp-social-share/0.1/amp-social-share.js
+++ b/extensions/amp-social-share/0.1/amp-social-share.js
@@ -87,7 +87,17 @@ class AmpSocialShare extends AMP.BaseElement {
 
     const hrefWithVars = addParamsToUrl(this.shareEndpoint_, this.params_);
     const urlReplacements = Services.urlReplacementsForDoc(this.getAmpDoc());
-    urlReplacements.expandAsync(hrefWithVars).then(href => {
+    const bindingVars = typeConfig['bindings'];
+    let bindings;
+    if (bindingVars) {
+      bindings = {};
+      bindingVars.forEach(name => {
+        const bindingName = name.toUpperCase();
+        bindings[bindingName] = this.params_[name];
+      });
+    }
+
+    urlReplacements.expandAsync(hrefWithVars, bindings).then(href => {
       this.href_ = href;
       // mailto:, whatsapp: protocols breaks when opened in _blank on iOS Safari
       const protocol = parseUrl(href).protocol;

--- a/extensions/amp-social-share/0.1/amp-social-share.js
+++ b/extensions/amp-social-share/0.1/amp-social-share.js
@@ -88,9 +88,8 @@ class AmpSocialShare extends AMP.BaseElement {
     const hrefWithVars = addParamsToUrl(this.shareEndpoint_, this.params_);
     const urlReplacements = Services.urlReplacementsForDoc(this.getAmpDoc());
     const bindingVars = typeConfig['bindings'];
-    let bindings;
+    const bindings = {};
     if (bindingVars) {
-      bindings = {};
       bindingVars.forEach(name => {
         const bindingName = name.toUpperCase();
         bindings[bindingName] = this.params_[name];

--- a/extensions/amp-social-share/0.1/test/test-amp-social-share.js
+++ b/extensions/amp-social-share/0.1/test/test-amp-social-share.js
@@ -175,7 +175,7 @@ describes.realWin('amp-social-share', {
       el.implementation_.handleClick_();
       expect(el.implementation_.win.open).to.be.calledOnce;
       expect(el.implementation_.win.open).to.be.calledWith(
-          'mailto:?subject=doc%20title&' +
+          'mailto:sample%40xyz.com?subject=doc%20title&' +
             'body=https%3A%2F%2Fcanonicalexample.com%2F',
           '_top', 'resizable,scrollbars,width=640,height=480'
       );

--- a/extensions/amp-social-share/0.1/test/test-amp-social-share.js
+++ b/extensions/amp-social-share/0.1/test/test-amp-social-share.js
@@ -170,7 +170,7 @@ describes.realWin('amp-social-share', {
 
   it('opens mailto: window in _top on iOS Safari with recipient', () => {
     const params = {
-      'recipient': 'sample@xyz.com'
+      'recipient': 'sample@xyz.com',
     };
     isIos = true;
     isSafari = true;
@@ -179,7 +179,8 @@ describes.realWin('amp-social-share', {
       expect(el.implementation_.win.open).to.be.calledOnce;
       expect(el.implementation_.win.open).to.be.calledWith(
           'mailto:sample%40xyz.com?subject=doc%20title&' +
-            'body=https%3A%2F%2Fcanonicalexample.com%2F&recipient=sample%40xyz.com',
+            'body=https%3A%2F%2Fcanonicalexample.com%2F' +
+            '&recipient=sample%40xyz.com',
           '_top', 'resizable,scrollbars,width=640,height=480'
       );
     });

--- a/extensions/amp-social-share/0.1/test/test-amp-social-share.js
+++ b/extensions/amp-social-share/0.1/test/test-amp-social-share.js
@@ -176,7 +176,7 @@ describes.realWin('amp-social-share', {
       expect(el.implementation_.win.open).to.be.calledOnce;
       expect(el.implementation_.win.open).to.be.calledWith(
           'mailto:sample%40xyz.com?subject=doc%20title&' +
-            'body=https%3A%2F%2Fcanonicalexample.com%2F',
+            'body=https%3A%2F%2Fcanonicalexample.com%2F&recipient=',
           '_top', 'resizable,scrollbars,width=640,height=480'
       );
     });

--- a/extensions/amp-social-share/0.1/test/test-amp-social-share.js
+++ b/extensions/amp-social-share/0.1/test/test-amp-social-share.js
@@ -168,14 +168,31 @@ describes.realWin('amp-social-share', {
     });
   });
 
-  it('opens mailto: window in _top on iOS Safari', () => {
+  it('opens mailto: window in _top on iOS Safari with recipient', () => {
+    const params = {
+      'recipient': 'sample@xyz.com'
+    };
+    isIos = true;
+    isSafari = true;
+    return getShare('email', undefined, params).then(el => {
+      el.implementation_.handleClick_();
+      expect(el.implementation_.win.open).to.be.calledOnce;
+      expect(el.implementation_.win.open).to.be.calledWith(
+          'mailto:sample%40xyz.com?subject=doc%20title&' +
+            'body=https%3A%2F%2Fcanonicalexample.com%2F&recipient=sample%40xyz.com',
+          '_top', 'resizable,scrollbars,width=640,height=480'
+      );
+    });
+  });
+
+  it('opens mailto: window in _top on iOS Safari without recipient', () => {
     isIos = true;
     isSafari = true;
     return getShare('email').then(el => {
       el.implementation_.handleClick_();
       expect(el.implementation_.win.open).to.be.calledOnce;
       expect(el.implementation_.win.open).to.be.calledWith(
-          'mailto:sample%40xyz.com?subject=doc%20title&' +
+          'mailto:?subject=doc%20title&' +
             'body=https%3A%2F%2Fcanonicalexample.com%2F&recipient=',
           '_top', 'resizable,scrollbars,width=640,height=480'
       );

--- a/extensions/amp-social-share/amp-social-share.md
+++ b/extensions/amp-social-share/amp-social-share.md
@@ -96,7 +96,9 @@ The `amp-social-share` component provides [some pre-configured providers](0.1/am
     <td>
       <ul>
         <li><code>data-param-subject</code>: optional, defaults to: Current page title</li>
-        <li><code>data-param-body</code>: optional, defaults to: <code>rel=canonical</code> URL</li></ul>
+        <li><code>data-param-body</code>: optional, defaults to: <code>rel=canonical</code> URL</li>
+        <li><code>data-param-recipient</code>: optional, defaults to: '' (empty string)</li>
+      </ul>
     </td>
   </tr>
   <tr>


### PR DESCRIPTION
@cvializ , @jridgewell 
closes #10679. 

Added the following:
1. recipient 
2. created an example. 

Need help with the example. The ${recipient} in amp-social-share-config.js is not working fine with the created example. Can you please suggest? 