### PR TITLE
Reduce verbosity of visual diff logs on Travis

### DIFF
--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -298,7 +298,7 @@ const command = {
   },
   runVisualDiffTests: function(opt_mode) {
     process.env['PERCY_TOKEN'] = atob(process.env.PERCY_TOKEN_ENCODED);
-    let cmd = 'ruby build-system/tasks/visual-diff.rb';
+    let cmd = `${gulp} visual-diff`;
     if (opt_mode === 'skip') {
       cmd += ' --skip';
     } else if (opt_mode === 'master') {
@@ -307,7 +307,7 @@ const command = {
     timedExecOrDie(cmd);
   },
   verifyVisualDiffTests: function() {
-    timedExecOrDie('ruby build-system/tasks/visual-diff.rb --verify');
+    timedExecOrDie(`${gulp} visual-diff --verify`);
   },
   runPresubmitTests: function() {
     timedExecOrDie(`${gulp} presubmit`);

--- a/build-system/server.js
+++ b/build-system/server.js
@@ -28,9 +28,9 @@ const webserver = require('gulp-webserver');
 
 const host = process.env.SERVE_HOST;
 const port = process.env.SERVE_PORT;
-const useHttps = process.env.SERVE_USEHTTPS == 'true' ? true : false;
+const useHttps = process.env.SERVE_USEHTTPS == 'true';
 const gulpProcess = process.env.SERVE_PROCESS_ID;
-const quiet = process.env.SERVE_QUIET == 'true' ? true : false;
+const quiet = process.env.SERVE_QUIET == 'true';
 
 // Exit if the port is in use.
 process.on('uncaughtException', function(err) {
@@ -57,6 +57,6 @@ gulp.src(process.cwd())
     host,
     directoryListing: true,
     https: useHttps,
-    middleware: quiet ? [app] : [morgan('dev'), app]
+    middleware: quiet ? [] : [morgan('dev'), app]
   }));
 

--- a/build-system/tasks/index.js
+++ b/build-system/tasks/index.js
@@ -39,3 +39,4 @@ require('./serve');
 require('./size');
 require('./todos');
 require('./validator');
+require('./visual-diff');

--- a/build-system/tasks/serve.js
+++ b/build-system/tasks/serve.js
@@ -55,6 +55,7 @@ function serve() {
       'SERVE_PROCESS_ID': process.pid,
       'SERVE_QUIET': quiet
     },
+    stdout: !quiet,
   })
   .once('quit', function () {
     util.log(util.colors.green('Shutting down server'));

--- a/build-system/tasks/visual-diff.js
+++ b/build-system/tasks/visual-diff.js
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+var argv = require('minimist')(process.argv.slice(2));
+var execOrDie = require('../exec.js').execOrDie;
+var gulp = require('gulp-help')(require('gulp'));
+
+
+/**
+ * Simple wrapper around the ruby based visual diff tests.
+ */
+function visualDiff() {
+  var cmd = 'ruby build-system/tasks/visual-diff.rb';
+  for (var arg in argv) {
+    if (arg !== '_') {
+      cmd = cmd + ' --' + arg;
+    }
+  }
+  execOrDie(cmd);
+}
+
+gulp.task(
+    'visual-diff',
+    'Runs the AMP visual diff tests.',
+    visualDiff,
+    {
+      options: {
+        'master': '  Includes a blank snapshot (baseline for skipped builds)',
+        'verify': '  Verifies the status of the build ID in ./PERCY_BUILD_ID',
+        'skip': '  Creates a dummy Percy build with only a blank snapshot',
+        'percy_debug': '  Prints debug info from Percy libraries',
+        'phantomjs_debug': '  Prints debug info from PhantomJS libraries',
+        'webserver_debug': '  Prints debug info from the local gulp webserver',
+        'debug': '  Prints all the above debug info',
+      }
+    }
+);

--- a/build-system/tasks/visual-diff.rb
+++ b/build-system/tasks/visual-diff.rb
@@ -42,6 +42,8 @@ BUILD_STATUS_URL = 'https://amphtml-percy-status-checker.appspot.com/status'
 BUILD_PROCESSING_POLLING_INTERVAL_SECS = 5
 BUILD_PROCESSING_TIMEOUT_SECS = 60
 PERCY_BUILD_URL = 'https://percy.io/ampproject/amphtml/builds'
+OUT = ENV['TRAVIS'] ? "/dev/null" : :out
+
 
 # Colorize logs.
 def red(text); "\e[31m#{text}\e[0m"; end
@@ -56,7 +58,7 @@ def green(text); "\e[32m#{text}\e[0m"; end
 def launchWebServer()
   webserverCmd =
       "gulp serve --host #{HOST} --port #{PORT} #{ENV['WEBSERVER_QUIET']}"
-  spawn(webserverCmd)
+  spawn(webserverCmd, :out=>OUT)
 end
 
 
@@ -235,7 +237,8 @@ def generateSnapshots(page, webpages)
   end
   for config in CONFIGS
     puts green('Switching to the ') + cyan("#{config}") + green(' AMP config')
-    system("gulp prepend-global --target #{AMP_RUNTIME_FILE} --#{config}")
+    configCmd = "gulp prepend-global --target #{AMP_RUNTIME_FILE} --#{config}"
+    system(configCmd, :out=>OUT)
     puts green('Generating snapshots using the ') + cyan("#{config}") +
         green(' AMP config')
     webpages.each do |webpage|
@@ -250,7 +253,8 @@ def generateSnapshots(page, webpages)
       Percy::Capybara.snapshot(page, name: name)
     end
     puts green('Switching back to the default AMP config')
-    system("gulp prepend-global --target #{AMP_RUNTIME_FILE} --remove")
+    removeCmd = "gulp prepend-global --target #{AMP_RUNTIME_FILE} --remove"
+    system(removeCmd, :out=>OUT)
   end
 end
 

--- a/build-system/tasks/visual-diff.rb
+++ b/build-system/tasks/visual-diff.rb
@@ -236,11 +236,15 @@ def generateSnapshots(page, webpages)
     Percy::Capybara.snapshot(page, name: 'Blank page')
   end
   for config in CONFIGS
-    puts green('Switching to the ') + cyan("#{config}") + green(' AMP config')
+    if not ENV['TRAVIS']
+      puts green('Switching to the ') + cyan("#{config}") + green(' AMP config')
+    end
     configCmd = "gulp prepend-global --target #{AMP_RUNTIME_FILE} --#{config}"
     system(configCmd, :out=>OUT)
-    puts green('Generating snapshots using the ') + cyan("#{config}") +
-        green(' AMP config')
+    if not ENV['TRAVIS']
+      puts green('Generating snapshots using the ') + cyan("#{config}") +
+          green(' AMP config')
+    end
     webpages.each do |webpage|
       url = webpage["url"]
       name = "#{webpage["name"]} (#{config})"
@@ -252,7 +256,9 @@ def generateSnapshots(page, webpages)
           page, forbidden_css, loading_incomplete_css, loading_complete_css)
       Percy::Capybara.snapshot(page, name: name)
     end
-    puts green('Switching back to the default AMP config')
+    if not ENV['TRAVIS']
+      puts green('Switching back to the default AMP config')
+    end
     removeCmd = "gulp prepend-global --target #{AMP_RUNTIME_FILE} --remove"
     system(removeCmd, :out=>OUT)
   end

--- a/build-system/tasks/visual-diff.rb
+++ b/build-system/tasks/visual-diff.rb
@@ -42,7 +42,7 @@ BUILD_STATUS_URL = 'https://amphtml-percy-status-checker.appspot.com/status'
 BUILD_PROCESSING_POLLING_INTERVAL_SECS = 5
 BUILD_PROCESSING_TIMEOUT_SECS = 60
 PERCY_BUILD_URL = 'https://percy.io/ampproject/amphtml/builds'
-OUT = ENV['TRAVIS'] ? "/dev/null" : :out
+OUT = ENV['TRAVIS'] ? '/dev/null' : :out
 
 
 # Colorize logs.
@@ -182,7 +182,7 @@ def verifyBuildStatus(status, buildId)
     end
   else
     log('info',
-        'Percy build ' + cyan("#{buildId}") + ' contained no visual diffs.')
+        'Percy build ' + cyan("#{buildId}") + ' contains no visual diffs.')
   end
 end
 

--- a/build-system/tasks/visual-diff.rb
+++ b/build-system/tasks/visual-diff.rb
@@ -212,6 +212,7 @@ def runVisualTests(visualTestsConfig)
   page.driver.options[:js_errors] = true
   page.driver.options[:phantomjs_options] =
       ["--debug=#{ENV['PHANTOMJS_DEBUG']}"]
+  page.driver.options[:phantomjs_logger] = ENV['TRAVIS'] ? '/dev/null' : STDOUT
   generateSnapshots(page, visualTestsConfig['webpages'])
   result = Percy::Capybara.finalize_build
   if (result['success'])

--- a/contributing/DEVELOPING.md
+++ b/contributing/DEVELOPING.md
@@ -67,8 +67,8 @@ The Quick Start Guide's  [One-time setup](getting-started-quick.md#one-time-setu
 | `node build-system/pr-check.js`                                         | Runs all tests that will be run upon pushing a CL.                     |
 | `gulp ava`<sup>[[1]](#footnote-1)</sup>                                 | Run node tests for tasks and offline/node code using [ava](https://github.com/avajs/ava). |
 | `gulp todos:find-closed`                                                | Find `TODO`s in code for issues that have been closed. |
-| `ruby build-system/tasks/visual-diff.rb`                                | Runs all visual diff tests locally. Requires `gulp build` to have been run. Also requires `PERCY_PROJECT` and `PERCY_TOKEN` to be set as environment variables. |
-| `ruby build-system/tasks/visual-diff.rb --percy_debug --phantomjs_debug --webserver_debug`  | Same as above, with additional logging. Debug flags can be used independently.  |
+| `gulp visual-diff`                                                      | Runs all visual diff tests locally. Requires `gulp build` to have been run. Also requires `PERCY_PROJECT` and `PERCY_TOKEN` to be set as environment variables. |
+| `gulp visual-diff --percy_debug --phantomjs_debug --webserver_debug`    | Same as above, with additional logging. Debug flags can be used independently.  |
 
 <a id="footnote-1">[1]</a> On Windows, this command must be run as administrator.
 
@@ -212,22 +212,22 @@ First, make sure you have [Ruby](https://www.ruby-lang.org/en/documentation/inst
 ```
 gem install percy-capybara poltergeist phantomjs
 ```
-Next, build the AMP runtime and invoke the visual diff script:
+Next, build the AMP runtime and run the gulp task that invokes the visual diff script:
 ```
 gulp build
-ruby build-system/tasks/visual-diff.rb
+gulp visual-diff
 ```
 The build will use the Percy credentials set via environment variables in the previous step, and you can see the results at `https://percy.io/<org>/<project>`.
 
 To see debugging info during Percy runs, you can run:
 ```
- ruby build-system/tasks/visual-diff.rb --percy_debug --phantomjs_debug --webserver_debug
+ gulp visual-diff --percy_debug --phantomjs_debug --webserver_debug
 ```
 The debug flags `--percy_debug`, `--phantomjs_debug`, and `--webserver_debug` can be used independently. To enable all three debug flags, you can also run:
 ```
- ruby build-system/tasks/visual-diff.rb --debug
+ gulp visual-diff --debug
 ```
-After each run, a new set of results will be available at `https://percy.io/<org>/<project>/settings`.
+After each run, a new set of results will be available at `https://percy.io/<org>/<project>`.
 
 ## Testing on devices
 


### PR DESCRIPTION
This PR contains various logging fixes that greatly reduce the verbosity of visual diff logs on Travis. It also adds a wrapper `gulp` task to the ruby based script, so that the tests are documented in `gulp help`.

Fixes #11212