### PR TITLE
AdSense: Add implementation of AMP responsive

### DIFF
--- a/ads/google/adsense.js
+++ b/ads/google/adsense.js
@@ -27,7 +27,7 @@ export function adsense(global, data) {
   // TODO: check mandatory fields
   validateData(data, [],
       ['adClient', 'adSlot', 'adHost', 'adtest', 'tagOrigin', 'experimentId',
-        'ampSlotIndex', 'adChannel']);
+        'ampSlotIndex', 'adChannel', 'autoFormat']);
 
   if (global.context.clientId) {
     // Read by GPT for GA/GPT integration.

--- a/examples/a4a-fullwidth.amp.html
+++ b/examples/a4a-fullwidth.amp.html
@@ -1,0 +1,156 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>AdSense full-width ad examples</title>
+  <link rel="canonical" href="http://nonblocking.io/">
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
+  <script async custom-element="amp-ad" src="https://cdn.ampproject.org/v0/amp-ad-0.1.js"></script>
+  <style amp-custom>
+    body {
+      background-color: #DDDDDD;
+    }
+    /** Put all content in unusual margins for testing. */
+    .content {
+      margin-left: 15px;
+      margin-right: 12px;
+    }
+    .further-indent {
+      margin-left: 30px;
+      margin-right: 30px;
+    }
+    h1 {
+      padding: 12px 0;
+      margin: 0;
+    }
+    p {
+      margin: 0;
+      padding: 6px 2px;
+    }
+    h1, .everything {
+      background-color: #999999;
+    }
+    amp-ad div[placeholder] {
+      background-color: lightgray;
+    }
+    amp-ad div[fallback] {
+      background-color: black;
+    }
+    amp-ad div[placeholder]::after {
+      content: "loading ...";
+    }
+    amp-ad div[fallback]::after {
+      content: "No ad";
+      color: white;
+    }
+    amp-user-notification {
+      background-color: lightgray;
+      padding: 5px;
+    }
+    .header-img {
+      margin: 0 auto;
+      text-align: center;
+    }
+  </style>
+</head>
+<body>
+<h1>Content!</h1>
+<div class="content">
+
+  <div class="header-img">
+    <amp-img src="img/hero@1x.jpg"
+             width="289" height="216"></amp-img>
+  </div>
+
+  <p>
+    Canem ipsum dolor sit amet, consectetur adipiscing elit.
+    Curabitur ullamcorper turpis vel commodo scelerisque. Phasellus
+    luctus nunc ut elit cursus, et imperdiet diam vehicula.
+    Duis et nisi sed urna blandit bibendum et sit amet erat.
+    Suspendisse potenti. Curabitur consequat volutpat arcu nec
+    elementum. Etiam a turpis ac libero varius condimentum.
+    Maecenas sollicitudin felis aliquam tortor vulputate,
+    ac posuere velit semper.
+  </p>
+
+  <amp-ad width="100vw" height=150
+          type="adsense"
+          data-ad-client="ca-pub-2383777339857329"
+          data-ad-slot="4121425836"
+          data-adtest="on"
+          data-auto-format="rspv">
+    <div overflow></div>
+  </amp-ad>
+
+  <p>
+    Fusce pretium tempor justo, vitae consequat dolor maximus eget.
+    Aliquam iaculis tincidunt quam sed maximus. Suspendisse faucibus
+    ornare sodales. Nullam id dolor vitae arcu consequat ornare a
+    et lectus. Sed tempus eget enim eget lobortis.
+    Mauris sem est, accumsan sed tincidunt ut, sagittis vel arcu.
+    Nullam in libero nisi.
+  </p>
+
+
+  <div class="further-indent">
+    <amp-ad width="100vw" height=150
+            type="adsense"
+            data-ad-client="ca-pub-2383777339857329"
+            data-ad-slot="4121425836"
+            data-adtest="on"
+            data-auto-format="rspv">
+      <div overflow></div>
+    </amp-ad>
+
+
+    <p>
+      Sed pharetra semper fringilla. Nulla fringilla, neque eget
+      varius suscipit, mi turpis congue odio, quis dignissim nisi
+      nulla at erat. Duis non nibh vel erat vehicula hendrerit eget
+      vel velit. Donec congue augue magna, nec eleifend dui porttitor
+      sed. Cras orci quam, dignissim nec elementum ac, bibendum et purus.
+      Ut elementum mi eget felis ultrices tempus. Maecenas nec sodales
+      ex. Phasellus ultrices, purus non egestas ullamcorper, felis
+      lorem ultrices nibh, in tristique mauris justo sed ante.
+      Nunc commodo purus feugiat metus bibendum consequat. Duis
+      finibus urna ut ligula auctor, sed vehicula ex hecuba.
+      Sed sed augue auctor, porta turpis ultrices, cursus diam.
+      In venenatis aliquet porta. Sed volutpat fermentum quam,
+      ac molestie nulla porttitor ac. Donec porta risus ut enim
+      pellentesque, id placerat elit ornare.
+    </p>
+  </div>
+
+  <p id="section1">
+    Curabitur convallis, urna quis pulvinar feugiat, purus diam
+    posuere turpis, sit amet poodle purus justo et mi. Donec
+    sapien urna, aliquam ut lacinia quis, varius vitae ex.
+    Maecenas efficitur iaculis lorem, at imperdiet orci viverra
+    in. Nullam eu erat eu metus ultrices viverra a sit amet leo.
+    Pellentesque est felis, pulvinar mollis sollicitudin et,
+    suscipit eget massa. Nunc bibendum non nunc et consequat.
+    Quisque auctor est vel leo faucibus, non faucibus magna ultricies.
+    Vestibulum ante ipsum primis in faucibus orci luctus et ultrices
+    posuere cubilia Curae; Vestibulum tortor lacus, bibendum et
+    enim eu, vehicula placerat erat. Nullam gravida rhoncus accumsan.
+    Integer suscipit iaculis elit nec mollis. Vestibulum eget arcu
+    nec lectus finibus rutrum vel sed orci.
+  </p>
+
+  <amp-ad width="100vw" height=150
+          type="adsense"
+          data-ad-client="ca-pub-2383777339857329"
+          data-ad-slot="4121425836"
+          data-adtest="on"
+          data-auto-format="rspv">
+    <div placeholder></div>
+    <div fallback></div>
+    <div overflow></div>
+  </amp-ad>
+</div>
+
+</body>
+</html>

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -376,7 +376,7 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
         if (parentDirection == 'rtl') {
           setStyle(this.element, 'marginRight', layoutBox.left, 'px');
         } else {
-          setStyle(this.element, 'marginLeft', -1 * layoutBox.left, 'px');
+          setStyle(this.element, 'marginLeft', -layoutBox.left, 'px');
         }
       });
     }

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -48,8 +48,10 @@ import {stringHash32} from '../../../src/string';
 import {dev} from '../../../src/log';
 import {Services} from '../../../src/services';
 import {domFingerprintPlain} from '../../../src/utils/dom-fingerprint';
+import {clamp} from '../../../src/utils/math';
 import {
   computedStyle,
+  setStyle,
   setStyles,
 } from '../../../src/style';
 import {AdsenseSharedState} from './adsense-shared-state';
@@ -116,6 +118,28 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
 
     /** @private {?string} */
     this.qqid_ = null;
+
+    /**
+     * For full-width responsive ads: whether the element has already been
+     * aligned to the edges of the viewport.
+     * @private {boolean}
+     */
+    this.responsiveAligned_ = false;
+
+    /**
+     * The contents of the data-auto-format attribute, or empty string if the
+     * attribute was not set.
+     * @private {?string}
+     */
+    this.autoFormat_ = null;
+  }
+
+  /**
+   * @return {boolean}
+   * @private
+   */
+  isResponsive_() {
+    return this.autoFormat_ == 'rspv';
   }
 
   /** @override */
@@ -156,8 +180,11 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
     const height = Number(this.element.getAttribute('height'));
     // Need to ensure these are numbers since width can be set to 'auto'.
     // Checking height just in case.
-    this.size_ = isExperimentOn(this.win, 'as-use-attr-for-format')
-        && !isNaN(width) && width > 0 && !isNaN(height) && height > 0
+    const useDefinedSizes = isExperimentOn(this.win, 'as-use-attr-for-format')
+        && !this.isResponsive_()
+        && !isNaN(width) && width > 0
+        && !isNaN(height) && height > 0;
+    this.size_ = useDefinedSizes
         ? {width, height}
         : this.getIntersectionElementLayoutBox();
     const format = `${this.size_.width}x${this.size_.height}`;
@@ -193,6 +220,7 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
       'brdim': additionalDimensions(this.win, viewportSize),
       'ifi': this.win['ampAdGoogleIfiCounter']++,
       'rc': this.fromResumeCallback ? 1 : null,
+      'rafmt': this.isResponsive_() ? 13 : null,
     };
 
     const experimentIds = [];
@@ -313,8 +341,65 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
   }
 
   /** @override */
+  buildCallback() {
+    super.buildCallback();
+
+    this.autoFormat_ =
+        this.element.getAttribute('data-auto-format') || '';
+
+    if (this.isResponsive_()) {
+      // Attempt to resize to the correct height. The width should already be
+      // 100vw, but is fixed here so that future resizes of the viewport don't
+      // affect it.
+      const viewportSize = this.getViewport().getSize();
+      return this.attemptChangeSize(
+          AmpAdNetworkAdsenseImpl.getResponsiveHeightForContext_(
+              viewportSize),
+          viewportSize.width);
+    }
+  }
+
+  /** @override */
+  onLayoutMeasure() {
+    super.onLayoutMeasure();
+
+    if (this.isResponsive_() && !this.responsiveAligned_) {
+      this.responsiveAligned_ = true;
+
+      const layoutBox = this.getLayoutBox();
+
+      // Nudge into the correct horizontal position by changing side margin.
+      this.getVsync().measure(() => {
+        // TODO(charliereams): Is this the right way to get direction?
+        const parentDirection =
+            computedStyle(this.win, this.element)['direction'];
+        if (parentDirection == 'rtl') {
+          setStyle(this.element, 'marginRight', layoutBox.left, 'px');
+        } else {
+          setStyle(this.element, 'marginLeft', -1 * layoutBox.left, 'px');
+        }
+      });
+    }
+  }
+
+  /** @override */
   getPreconnectUrls() {
     return ['https://googleads.g.doubleclick.net'];
+  }
+
+  /**
+   * Calculates the appropriate height for a full-width responsive ad of the
+   * given width.
+   * @param {!{width: number, height: number}} viewportSize
+   * @return {number}
+   * @private
+   */
+  static getResponsiveHeightForContext_(viewportSize) {
+    const minHeight = 100;
+    const maxHeight = Math.min(300, viewportSize.height);
+    // We aim for a 6:5 aspect ratio.
+    const idealHeight = Math.round(viewportSize.width / 1.2);
+    return clamp(idealHeight, minHeight, maxHeight);
   }
 }
 

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
@@ -59,9 +59,10 @@ function createAdsenseImplElement(attributes, doc, opt_tag) {
 describes.realWin('amp-ad-network-adsense-impl', {
   amp: {
     extensions: ['amp-ad', 'amp-ad-network-adsense-impl'],
+    // runtimeOn: true,
   },
 }, env => {
-  let win, doc, ampdoc;
+  let win, doc, ampdoc, viewer;
   let impl;
   let element;
 
@@ -73,7 +74,7 @@ describes.realWin('amp-ad-network-adsense-impl', {
         () => {
           return ['google'];
         });
-    const viewer = win.services.viewer.obj;
+    viewer = win.services.viewer.obj;
     sandbox.stub(viewer, 'getReferrerUrl',
         () => Promise.resolve('https://acme.org/'));
     element = createAdsenseImplElement({
@@ -112,6 +113,10 @@ describes.realWin('amp-ad-network-adsense-impl', {
 
   describe('#isValidElement', () => {
     it('should be valid', () => {
+      expect(impl.isValidElement()).to.be.true;
+    });
+    it('should be valid (responsive)', () => {
+      element.setAttribute('data-auto-format', 'rspv');
       expect(impl.isValidElement()).to.be.true;
     });
     it('should NOT be valid (impl tag name)', () => {
@@ -452,13 +457,20 @@ describes.realWin('amp-ad-network-adsense-impl', {
           /(\?|&)dtd=\d+(&|$)/,
         ].forEach(regexp => expect(url).to.match(regexp));
       });
+      it('sets rafmt for responsive', () => {
+        element.setAttribute('data-ad-slot', 'some_slot');
+        element.setAttribute('data-auto-format', 'rspv');
+        return impl.getAdUrl().then(url => {
+          expect(url).to.match(/(\?|&)ramft=13(&|$)/);
+        });
+      });
     });
 
     // Not using arrow function here because otherwise the way closure behaves
     // prevents me from calling this.timeout(5000).
     it('with multiple slots', function() {
-      // When ran locally, this test tends to exceed 2000ms timeout.
-      this.timeout(5000);
+      // When run locally, this test tends to exceed 2000ms timeout.
+      this.timeout(10000);
       // Reset counter for purpose of this test.
       delete win['ampAdGoogleIfiCounter'];
       const elem1 = createAdsenseImplElement({
@@ -550,6 +562,172 @@ describes.realWin('amp-ad-network-adsense-impl', {
           expect(impl.element.getAttribute('data-amp-slot-index'))
               .to.equal('1');
         });
+  });
+
+  describe('#buildCallback', () => {
+
+    const VIEWPORT_WIDTH = 375;
+    const VIEWPORT_HEIGHT = 667;
+
+    let iframe;
+
+    function constructImpl(config) {
+      iframe = env.win.document.createElement('iframe');
+
+      config.type = 'adsense';
+      element = createElementWithAttributes(doc, 'amp-ad', config);
+      element.appendChild(iframe);
+      document.body.appendChild(element);
+      impl = new AmpAdNetworkAdsenseImpl(element);
+      impl.element.style.display = 'block';
+      impl.element.style.position = 'relative';
+      impl.element.style.top = '101vh';
+
+      // Fix the viewport to a consistent size to that the test doesn't depend
+      // on the actual browser window opened.
+      impl.getViewport().getSize =
+          () => ({width: VIEWPORT_WIDTH, height: VIEWPORT_HEIGHT});
+    }
+
+    it('should do nothing for non-responsive', () => {
+      constructImpl({
+        width: '320',
+        height: '150',
+      });
+      expect(impl.buildCallback()).to.be.undefined;
+    });
+
+    it('should schedule a resize for responsive', () => {
+      constructImpl({
+        width: '100vw',
+        height: '100',
+        'data-auto-format': 'rspv',
+      });
+
+      const callback = impl.buildCallback();
+      expect(callback).to.not.be.undefined;
+
+      // The returned promise fails for some reason.
+      return callback.then(() => {
+        expect(element.offsetHeight).to.equal(300);
+        expect(element.offsetWidth).to.equal(VIEWPORT_WIDTH);
+      });
+    });
+  });
+
+  describe('#onLayoutMeasure', () => {
+
+    const VIEWPORT_WIDTH = 375;
+    const VIEWPORT_HEIGHT = 667;
+
+    // Nested elements to contain the ad. (container contains the ad, and
+    // containerContainer contains that container.)
+    let containerContainer, container;
+    let iframe;
+
+    function buildImpl(config) {
+      // Create an element with horizontal margins for the ad to break out of.
+      containerContainer.style.marginLeft = '5px';
+      containerContainer.style.marginRight = '9px';
+
+      // Create an element with horizontal margins for the ad to break out of.
+      container.style.marginLeft = '19px';
+      container.style.marginRight = '25px';
+
+      config.type = 'adsense';
+      config['data-ad-client'] = 'ca-pub-1234';
+
+      element = createElementWithAttributes(doc, 'amp-ad', config);
+      iframe = doc.createElement('iframe');
+
+      element.appendChild(iframe);
+      container.appendChild(element);
+      containerContainer.appendChild(container);
+      doc.body.appendChild(containerContainer);
+
+      impl = new AmpAdNetworkAdsenseImpl(element);
+      impl.element.style.display = 'block';
+      impl.element.style.position = 'relative';
+      impl.element.style.top = '150vh';
+
+      // Stub out vsync measurements to occur immediately.
+      impl.getVsync().measure = callback => callback();
+
+      // Fix the viewport to a consistent size to that the test doesn't depend
+      // on the actual browser window opened.
+      impl.getViewport().getSize =
+          () => ({width: VIEWPORT_WIDTH, height: VIEWPORT_HEIGHT});
+
+      return impl.buildCallback();
+    }
+
+    beforeEach(() => {
+      viewer.toggleRuntime();  // Turn runtime on for these tests.
+    });
+
+    afterEach(() => {
+      viewer.toggleRuntime();  // Turn runtime off again.
+
+      if (containerContainer != null && containerContainer.parentNode != null) {
+        containerContainer.parentNode.removeChild(containerContainer);
+      }
+      doc.body.style.direction = '';
+    });
+
+    it('should change left margin for responsive', () => {
+      containerContainer = doc.createElement('div');
+      container = doc.createElement('div');
+      return buildImpl({
+        width: '100vw',
+        height: '150',
+        'data-auto-format': 'rspv',
+      }).then(() => {
+        impl.onLayoutMeasure();
+        // Left margin is 19px from container and 5px from body.
+        expect(element.style.marginLeft).to.be.equal('-24px');
+        expect(element.style.marginRight).to.be.equal('');
+      });
+    });
+
+    it('should change right margin for responsive in RTL', () => {
+      containerContainer = doc.createElement('div');
+      container = doc.createElement('div');
+      doc.body.style.direction = 'rtl'; // todo: revert
+
+      return buildImpl({
+        width: '100vw',
+        height: '150',
+        'data-auto-format': 'rspv',
+      }).then(() => {
+        impl.onLayoutMeasure();
+        // Right margin is 25px from container and 9px from body.
+        expect(element.style.marginRight).to.be.equal('-124px'); // seems to be out by 90?
+        expect(element.style.marginLeft).to.be.equal('');
+      });
+    });
+  });
+
+  describe('#getResponsiveHeightForContext', () => {
+    it('should request 100px height for very small viewports', () => {
+      expect(
+          AmpAdNetworkAdsenseImpl.getResponsiveHeightForContext_(
+              {width: 100, height: 667}))
+          .to.be.equal(100);
+    });
+
+    it('should request 6:5 aspect ratio for normal viewport (iPhone 5)', () => {
+      expect(
+          AmpAdNetworkAdsenseImpl.getResponsiveHeightForContext_(
+              {width: 320, height: 568}))
+          .to.be.equal(267);
+    });
+
+    it('should request 300px height for wide viewports', () => {
+      expect(
+          AmpAdNetworkAdsenseImpl.getResponsiveHeightForContext_(
+              {width: 500, height: 667}))
+          .to.be.equal(300);
+    });
   });
 
   describe('#delayAdRequestEnabled', () => {

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
@@ -650,8 +650,11 @@ describes.realWin('amp-ad-network-adsense-impl', {
       impl.element.style.position = 'relative';
       impl.element.style.top = '150vh';
 
-      // Stub out vsync measurements to occur immediately.
-      impl.getVsync().measure = callback => callback();
+      // Stub out vsync tasks to run immediately.
+      impl.getVsync().run = (vsyncTaskSpec, vsyncState) => {
+        vsyncTaskSpec.measure(vsyncState);
+        vsyncTaskSpec.mutate(vsyncState);
+      };
 
       // Fix the viewport to a consistent size to that the test doesn't depend
       // on the actual browser window opened.
@@ -700,8 +703,10 @@ describes.realWin('amp-ad-network-adsense-impl', {
         'data-auto-format': 'rspv',
       }).then(() => {
         impl.onLayoutMeasure();
-        // Right margin is 25px from container and 9px from body.
-        expect(element.style.marginRight).to.be.equal('-124px'); // seems to be out by 90?
+        // Right margin is 9px from containerContainer and 25px from container.
+        // TODO(charliereams): In the test harness it is also offset by 15px due
+        // to strange scrollbar behaviour. Figure out how to disable this.
+        expect(element.style.marginRight).to.be.equal('-49px');
         expect(element.style.marginLeft).to.be.equal('');
       });
     });


### PR DESCRIPTION
This introduces the new data-auto-format attribute to the component, and gives custom behavior to the value data-auto-format="rspv" for the AdSense implementation.

The custom behavior is twofold:

The element is aligned to the left-hand edge of the viewport. This is intended to combine with setting width="100vw" on the element, such that overall it covers the full width of the viewport. (See the new examples in a4a-fullwidth.amp.html for an example deployment.)
The original height of the element is overridden (on a best effort basis) with custom logic. Currently the custom logic just scales the height to be in a 5:6 ratio with the width and then applies some basic sanity limits. In a future version we may do something more interesting with this, such as different sizes above or below the fold.

The request is also modified to set the rafmt=13 parameter that AdSense expects for these requests.

Thanks!