### PR TITLE
Split custom-element.js into registry, static layout and element class modules

### DIFF
--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -16,7 +16,7 @@
 
 import {BaseElement} from '../src/base-element';
 import {isLayoutSizeDefined} from '../src/layout';
-import {registerElement} from '../src/custom-element';
+import {registerElement} from '../src/service/custom-element-registry';
 import {srcsetFromElement} from '../src/srcset';
 
 /**

--- a/builtins/amp-pixel.js
+++ b/builtins/amp-pixel.js
@@ -17,7 +17,7 @@
 import {BaseElement} from '../src/base-element';
 import {dev, user} from '../src/log';
 import {dict} from '../src/utils/object';
-import {registerElement} from '../src/custom-element';
+import {registerElement} from '../src/service/custom-element-registry';
 import {Services} from '../src/services';
 import {createElementWithAttributes} from '../src/dom';
 

--- a/extensions/amp-a4a/0.1/test/test-a4a-integration.js
+++ b/extensions/amp-a4a/0.1/test/test-a4a-integration.js
@@ -29,7 +29,7 @@ import {signingServerURLs} from '../../../../ads/_a4a-config';
 import {
     resetScheduledElementForTesting,
     upgradeOrRegisterElement,
-} from '../../../../src/custom-element';
+} from '../../../../src/service/custom-element-registry';
 import '../../../amp-ad/0.1/amp-ad-xorigin-iframe-handler';
 import {loadPromise} from '../../../../src/event-helper';
 import * as sinon from 'sinon';

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -40,7 +40,9 @@ import {
   data as validCSSAmp,
 } from './testdata/valid_css_at_rules_amp.reserialized';
 import {data as testFragments} from './testdata/test_fragments';
-import {resetScheduledElementForTesting} from '../../../../src/custom-element';
+import {
+  resetScheduledElementForTesting,
+} from '../../../../src/service/custom-element-registry';
 import {Services} from '../../../../src/services';
 import {incrementLoadingAds} from '../../../amp-ad/0.1/concurrent-load';
 import '../../../../extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler';

--- a/src/amp-shadow.js
+++ b/src/amp-shadow.js
@@ -41,7 +41,7 @@ import {doNotTrackImpression} from './impression';
 import {cssText} from '../build/css';
 import {isExperimentOn} from './experiments';
 import {installPerformanceService} from './service/performance-impl';
-import {stubElementsForDoc} from './custom-element';
+import {stubElementsForDoc} from './service/custom-element-registry';
 
 // This feature doesn't make sense in shadow mode as it only applies to
 // background rendered iframes;

--- a/src/amp.js
+++ b/src/amp.js
@@ -28,7 +28,7 @@ import {installStylesForDoc, makeBodyVisible} from './style-installer';
 import {installErrorReporting} from './error';
 import {installDocService} from './service/ampdoc-impl';
 import {installCacheServiceWorker} from './service-worker/install';
-import {stubElementsForDoc} from './custom-element';
+import {stubElementsForDoc} from './service/custom-element-registry';
 import {
   installAmpdocServices,
   installBuiltins,

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -14,15 +14,20 @@
  * limitations under the License.
  */
 
+import {AmpEvents} from './amp-events';
 import {CommonSignals} from './common-signals';
-import {Layout, getLayoutClass, getLengthNumeral, getLengthUnits,
-    isInternalElement, isLayoutSizeDefined, isLoadingAllowed,
-    parseLayout, parseLength, getNaturalDimensions,
-    hasNaturalDimensions} from './layout';
-import {ElementStub, stubbedElements} from './element-stub';
+import {ElementStub} from './element-stub';
+import {
+  Layout,
+  applyStaticLayout,
+  isInternalElement,
+  isLayoutSizeDefined,
+  isLoadingAllowed,
+} from './layout';
+import {LayoutDelayMeter} from './layout-delay-meter';
+import {ResourceState} from './service/resource';
 import {Services} from './services';
 import {Signals} from './utils/signals';
-import {declareExtension} from './service/ampdoc-impl';
 import {createLoaderElement} from '../src/loader';
 import {dev, rethrowAsync, user} from './log';
 import {
@@ -31,13 +36,10 @@ import {
 import {getMode} from './mode';
 import {parseSizeList} from './size-list';
 import {reportError} from './error';
+import {setStyle} from './style';
 import * as dom from './dom';
-import {setStyle, setStyles} from './style';
-import {LayoutDelayMeter} from './layout-delay-meter';
-import {ResourceState} from './service/resource';
-import {AmpEvents} from './amp-events';
 
-const TAG_ = 'CustomElement';
+const TAG = 'CustomElement';
 
 /**
  * This is the minimum width of the element needed to trigger `loading`
@@ -46,7 +48,7 @@ const TAG_ = 'CustomElement';
  * is meaningless.
  * @private @const {number}
  */
-const MIN_WIDTH_FOR_LOADING_ = 100;
+const MIN_WIDTH_FOR_LOADING = 100;
 
 
 /**
@@ -55,7 +57,7 @@ const MIN_WIDTH_FOR_LOADING_ = 100;
  * render phase or scrolling.
  * @private @const {number}
  */
-const PREPARE_LOADING_THRESHOLD_ = 1000;
+const PREPARE_LOADING_THRESHOLD = 1000;
 
 
 /**
@@ -89,325 +91,13 @@ function isTemplateTagSupported() {
 
 
 /**
- * @param {!Window} win
- * @return {!Object<string, function(new:./base-element.BaseElement, !Element)>}
- */
-function getExtendedElements(win) {
-  if (!win.ampExtendedElements) {
-    win.ampExtendedElements = {};
-  }
-  return win.ampExtendedElements;
-}
-
-
-/**
- * Registers an element. Upgrades it if has previously been stubbed.
- * @param {!Window} win
- * @param {string} name
- * @param {function(new:./base-element.BaseElement, !Element)} toClass
- */
-export function upgradeOrRegisterElement(win, name, toClass) {
-  const knownElements = getExtendedElements(win);
-  if (!knownElements[name]) {
-    registerElement(win, name, /** @type {!Function} */ (toClass));
-    return;
-  }
-  if (knownElements[name] == toClass) {
-    // Already registered this instance.
-    return;
-  }
-  user().assert(knownElements[name] == ElementStub,
-      '%s is already registered. The script tag for ' +
-      '%s is likely included twice in the page.', name, name);
-  knownElements[name] = toClass;
-  for (let i = 0; i < stubbedElements.length; i++) {
-    const stub = stubbedElements[i];
-    // There are 3 possible states here:
-    // 1. We never made the stub because the extended impl. loaded first.
-    //    In that case the element won't be in the array.
-    // 2. We made a stub but the browser didn't attach it yet. In
-    //    that case we don't need to upgrade but simply switch to the new
-    //    implementation.
-    // 3. A stub was attached. We upgrade which means we replay the
-    //    implementation.
-    const element = stub.element;
-    if (element.tagName.toLowerCase() == name &&
-            element.ownerDocument.defaultView == win) {
-      tryUpgradeElementNoInline(element, toClass);
-      // Remove element from array.
-      stubbedElements.splice(i--, 1);
-    }
-  }
-}
-
-/**
- * This method should not be inlined to prevent TryCatch deoptimization.
- * NoInline keyword at the end of function name also prevents Closure compiler
- * from inlining the function.
- * @private
- */
-function tryUpgradeElementNoInline(element, toClass) {
-  try {
-    element.upgrade(toClass);
-  } catch (e) {
-    reportError(e, element);
-  }
-}
-
-/**
- * Stub extended elements missing an implementation. It can be called multiple
- * times and on partial document in order to start stubbing as early as
- * possible.
- * @param {!./service/ampdoc-impl.AmpDoc} ampdoc
- */
-export function stubElementsForDoc(ampdoc) {
-  const list = ampdoc.getHeadNode().querySelectorAll('script[custom-element]');
-  for (let i = 0; i < list.length; i++) {
-    const name = list[i].getAttribute('custom-element');
-    declareExtension(ampdoc, name);
-    stubElementIfNotKnown(ampdoc.win, name);
-  }
-}
-
-/**
- * Stub element if not yet known.
- * @param {!Window} win
- * @param {string} name
- */
-export function stubElementIfNotKnown(win, name) {
-  const knownElements = getExtendedElements(win);
-  if (!knownElements[name]) {
-    registerElement(win, name, ElementStub);
-  }
-}
-
-/**
- * Copies the specified element to child window (friendly iframe). This way
- * all implementations of the AMP elements are shared between all friendly
- * frames.
- * @param {!Window} parentWin
- * @param {!Window} childWin
- * @param {string} name
- */
-export function copyElementToChildWindow(parentWin, childWin, name) {
-  const toClass = getExtendedElements(parentWin)[name];
-  registerElement(childWin, name, toClass || ElementStub);
-}
-
-
-/**
- * Applies layout to the element. Visible for testing only.
- *
- * \   \  /  \  /   / /   \     |   _  \     |  \ |  | |  | |  \ |  |  / _____|
- *  \   \/    \/   / /  ^  \    |  |_)  |    |   \|  | |  | |   \|  | |  |  __
- *   \            / /  /_\  \   |      /     |  . `  | |  | |  . `  | |  | |_ |
- *    \    /\    / /  _____  \  |  |\  \----.|  |\   | |  | |  |\   | |  |__| |
- *     \__/  \__/ /__/     \__\ | _| `._____||__| \__| |__| |__| \__|  \______|
- *
- * The equivalent of this method is used for server-side rendering (SSR) and
- * any changes made to it must be made in coordination with caches that
- * implement SSR. For more information on SSR see bit.ly/amp-ssr.
- *
- * @param {!Element} element
- * @return {!Layout}
- */
-export function applyLayout_(element) {
-  // Check if the layout has already been done by server-side rendering. The
-  // document may be visible to the user if the boilerplate was removed so
-  // please take care in making changes here.
-  const completedLayoutAttr = element.getAttribute('i-amphtml-layout');
-  if (completedLayoutAttr) {
-    const layout = /** @type {!Layout} */ (dev().assert(
-        parseLayout(completedLayoutAttr)));
-    if (layout == Layout.RESPONSIVE && element.firstElementChild) {
-      // Find sizer, but assume that it might not have been parsed yet.
-      element.sizerElement_ =
-          element.querySelector('i-amphtml-sizer') || undefined;
-    } else if (layout == Layout.NODISPLAY) {
-      applyNoDisplayLayout_(element);
-    }
-    return layout;
-  }
-
-  // If the layout was already done by server-side rendering (SSR), then the code
-  // below will not run. Any changes below will necessitate a change to SSR and must
-  // be coordinated with caches that implement SSR. See bit.ly/amp-ssr.
-
-  // Parse layout from the element.
-  const layoutAttr = element.getAttribute('layout');
-  const widthAttr = element.getAttribute('width');
-  const heightAttr = element.getAttribute('height');
-  const sizesAttr = element.getAttribute('sizes');
-  const heightsAttr = element.getAttribute('heights');
-
-  // Input layout attributes.
-  const inputLayout = layoutAttr ? parseLayout(layoutAttr) : null;
-  user().assert(inputLayout !== undefined, 'Unknown layout: %s', layoutAttr);
-  const inputWidth = (widthAttr && widthAttr != 'auto') ?
-      parseLength(widthAttr) : widthAttr;
-  user().assert(inputWidth !== undefined, 'Invalid width value: %s', widthAttr);
-  const inputHeight = heightAttr ? parseLength(heightAttr) : null;
-  user().assert(inputHeight !== undefined, 'Invalid height value: %s',
-      heightAttr);
-
-  // Effective layout attributes. These are effectively constants.
-  let width;
-  let height;
-  let layout;
-
-  // Calculate effective width and height.
-  if ((!inputLayout || inputLayout == Layout.FIXED ||
-      inputLayout == Layout.FIXED_HEIGHT) &&
-      (!inputWidth || !inputHeight) && hasNaturalDimensions(element.tagName)) {
-    // Default width and height: handle elements that do not specify a
-    // width/height and are defined to have natural browser dimensions.
-    const dimensions = getNaturalDimensions(element);
-    width = (inputWidth || inputLayout == Layout.FIXED_HEIGHT) ? inputWidth :
-        dimensions.width;
-    height = inputHeight || dimensions.height;
-  } else {
-    width = inputWidth;
-    height = inputHeight;
-  }
-
-  // Calculate effective layout.
-  if (inputLayout) {
-    layout = inputLayout;
-  } else if (!width && !height) {
-    layout = Layout.CONTAINER;
-  } else if (height && (!width || width == 'auto')) {
-    layout = Layout.FIXED_HEIGHT;
-  } else if (height && width && (sizesAttr || heightsAttr)) {
-    layout = Layout.RESPONSIVE;
-  } else {
-    layout = Layout.FIXED;
-  }
-
-  // Verify layout attributes.
-  if (layout == Layout.FIXED || layout == Layout.FIXED_HEIGHT ||
-      layout == Layout.RESPONSIVE) {
-    user().assert(height, 'Expected height to be available: %s', heightAttr);
-  }
-  if (layout == Layout.FIXED_HEIGHT) {
-    user().assert(!width || width == 'auto',
-        'Expected width to be either absent or equal "auto" ' +
-        'for fixed-height layout: %s', widthAttr);
-  }
-  if (layout == Layout.FIXED || layout == Layout.RESPONSIVE) {
-    user().assert(width && width != 'auto',
-        'Expected width to be available and not equal to "auto": %s',
-        widthAttr);
-  }
-  if (layout == Layout.RESPONSIVE) {
-    user().assert(getLengthUnits(width) == getLengthUnits(height),
-        'Length units should be the same for width and height: %s, %s',
-        widthAttr, heightAttr);
-  } else {
-    user().assert(heightsAttr === null,
-        'Unexpected "heights" attribute for none-responsive layout');
-  }
-
-  // Apply UI.
-  element.classList.add(getLayoutClass(layout));
-  if (isLayoutSizeDefined(layout)) {
-    element.classList.add('i-amphtml-layout-size-defined');
-  }
-  if (layout == Layout.NODISPLAY) {
-    // CSS defines layout=nodisplay automatically with `display:none`. Thus
-    // no additional styling is needed.
-    applyNoDisplayLayout_(element);
-  } else if (layout == Layout.FIXED) {
-    setStyles(element, {
-      width: dev().assertString(width),
-      height: dev().assertString(height),
-    });
-  } else if (layout == Layout.FIXED_HEIGHT) {
-    setStyle(element, 'height', dev().assertString(height));
-  } else if (layout == Layout.RESPONSIVE) {
-    const sizer = element.ownerDocument.createElement('i-amphtml-sizer');
-    setStyles(sizer, {
-      display: 'block',
-      paddingTop:
-        ((getLengthNumeral(height) / getLengthNumeral(width)) * 100) + '%',
-    });
-    element.insertBefore(sizer, element.firstChild);
-    element.sizerElement_ = sizer;
-  } else if (layout == Layout.FILL) {
-    // Do nothing.
-  } else if (layout == Layout.CONTAINER) {
-    // Do nothing. Elements themselves will check whether the supplied
-    // layout value is acceptable. In particular container is only OK
-    // sometimes.
-  } else if (layout == Layout.FLEX_ITEM) {
-    // Set height and width to a flex item if they exist.
-    // The size set to a flex item could be overridden by `display: flex` later.
-    if (width) {
-      setStyle(element, 'width', width);
-    }
-    if (height) {
-      setStyle(element, 'height', height);
-    }
-  }
-  return layout;
-}
-
-
-/**
- * @param {!Element} element
- */
-function applyNoDisplayLayout_(element) {
-  // TODO(dvoytenko, #9353): once `toggleLayoutDisplay` API has been deployed
-  // everywhere, switch all relevant elements to this API. In the meantime,
-  // simply unblock display toggling via `style="display: ..."`.
-  setStyle(element, 'display', 'none');
-  element.classList.add('i-amphtml-display');
-}
-
-
-/**
- * Returns "true" for internal AMP nodes or for placeholder elements.
- * @param {!Node} node
- * @return {boolean}
- */
-function isInternalOrServiceNode(node) {
-  if (isInternalElement(node)) {
-    return true;
-  }
-  if (node.tagName && (node.hasAttribute('placeholder') ||
-      node.hasAttribute('fallback') ||
-      node.hasAttribute('overflow'))) {
-    return true;
-  }
-  return false;
-}
-
-/**
- * Creates a new custom element class prototype.
- *
- * Visible for testing only.
- *
- * @param {!Window} win The window in which to register the custom element.
- * @param {string} name The name of the custom element.
- * @param {function(new:./base-element.BaseElement, !Element)=} opt_implementationClass For
- *     testing only.
- * @return {!Object} Prototype of element.
- */
-export function createAmpElementProto(win, name, opt_implementationClass) {
-  const ElementProto = createCustomElementClass(win, name).prototype;
-  if (getMode().test && opt_implementationClass) {
-    ElementProto.implementationClassForTesting = opt_implementationClass;
-  }
-  return ElementProto;
-}
-
-/**
  * Creates a named custom element class.
  *
  * @param {!Window} win The window in which to register the custom element.
  * @param {string} name The name of the custom element.
  * @return {!Function} The custom element class.
  */
-function createCustomElementClass(win, name) {
+export function createCustomElementClass(win, name) {
   const baseCustomElement = createBaseCustomElementClass(win);
   /** @extends {HTMLElement} */
   class CustomAmpElement extends baseCustomElement {
@@ -423,6 +113,7 @@ function createCustomElementClass(win, name) {
   }
   return CustomAmpElement;
 }
+
 
 /**
  * Creates a base custom element class.
@@ -504,11 +195,11 @@ function createBaseCustomElementClass(win) {
       this.heightsList_ = undefined;
 
       /**
-       * This element can be assigned by the {@link applyLayout_} to a child
-       * element that will be used to size this element.
-       * @private {?Element|undefined}
+       * This element can be assigned by the {@link applyStaticLayout} to a
+       * child element that will be used to size this element.
+       * @package {?Element|undefined}
        */
-      this.sizerElement_ = undefined;
+      this.sizerElement = undefined;
 
       /** @private {boolean|undefined} */
       this.loadingDisabled_ = undefined;
@@ -526,8 +217,8 @@ function createBaseCustomElementClass(win) {
       this.overflowElement_ = undefined;
 
       // `opt_implementationClass` is only used for tests.
-      const knownElements = getExtendedElements(win);
-      let Ctor = knownElements[this.elementName()];
+      let Ctor = dev().assert(win.ampExtendedElements &&
+          win.ampExtendedElements[this.elementName()]);
       if (getMode().test && this.implementationClassForTesting) {
         Ctor = this.implementationClassForTesting;
       }
@@ -829,7 +520,7 @@ function createBaseCustomElementClass(win) {
         if (this.isInViewport_) {
           // Already in viewport - start showing loading.
           this.toggleLoading_(true);
-        } else if (layoutBox.top < PREPARE_LOADING_THRESHOLD_ &&
+        } else if (layoutBox.top < PREPARE_LOADING_THRESHOLD &&
           layoutBox.top >= 0) {
           // Few top elements will also be pre-initialized with a loading
           // element.
@@ -849,12 +540,12 @@ function createBaseCustomElementClass(win) {
      * @private
      */
     getSizer_() {
-      if (this.sizerElement_ === undefined &&
+      if (this.sizerElement === undefined &&
           this.layout_ === Layout.RESPONSIVE) {
         // Expect sizer to exist, just not yet discovered.
-        this.sizerElement_ = this.querySelector('i-amphtml-sizer');
+        this.sizerElement = this.querySelector('i-amphtml-sizer');
       }
-      return this.sizerElement_ || null;
+      return this.sizerElement || null;
     }
 
     /**
@@ -925,7 +616,7 @@ function createBaseCustomElementClass(win) {
         // From the moment height is changed the element becomes fully
         // responsible for managing its height. Aspect ratio is no longer
         // preserved.
-        this.sizerElement_ = null;
+        this.sizerElement = null;
         setStyle(sizer, 'paddingTop', '0');
         if (this.resources_) {
           this.resources_.deferMutate(this, () => {
@@ -1011,7 +702,7 @@ function createBaseCustomElementClass(win) {
         this.everAttached = true;
 
         try {
-          this.layout_ = applyLayout_(this);
+          this.layout_ = applyStaticLayout(this);
         } catch (e) {
           reportError(e, this);
         }
@@ -1664,7 +1355,7 @@ function createBaseCustomElementClass(win) {
         this.loadingDisabled_ = this.hasAttribute('noloading');
       }
       if (this.loadingDisabled_ || !isLoadingAllowed(this) ||
-        this.layoutWidth_ < MIN_WIDTH_FOR_LOADING_ ||
+        this.layoutWidth_ < MIN_WIDTH_FOR_LOADING ||
         this.layoutCount_ > 0 ||
         isInternalOrServiceNode(this) || !isLayoutSizeDefined(this.layout_)) {
         return false;
@@ -1806,7 +1497,7 @@ function createBaseCustomElementClass(win) {
       this.getOverflowElement();
       if (!this.overflowElement_) {
         if (overflown) {
-          user().warn(TAG_,
+          user().warn(TAG,
               'Cannot resize element and overflow is not available', this);
         }
       } else {
@@ -1831,88 +1522,12 @@ function createBaseCustomElementClass(win) {
   return win.BaseCustomElementClass;
 }
 
-/**
- * Registers a new custom element with its implementation class.
- * @param {!Window} win The window in which to register the elements.
- * @param {string} name Name of the custom element
- * @param {function(new:./base-element.BaseElement, !Element)} implementationClass
- */
-export function registerElement(win, name, implementationClass) {
-  const knownElements = getExtendedElements(win);
-  knownElements[name] = implementationClass;
-  const klass = createCustomElementClass(win, name);
-
-  const supportsCustomElementsV1 = 'customElements' in win;
-  if (supportsCustomElementsV1) {
-    win['customElements'].define(name, klass);
-  } else {
-    win.document.registerElement(name, {
-      prototype: klass.prototype,
-    });
-  }
-}
-
-/**
- * Registers a new alias for an existing custom element.
- * @param {!Window} win The window in which to register the elements.
- * @param {string} aliasName Additional name for an existing custom element.
- * @param {string} sourceName Name of an existing custom element
- */
-export function registerElementAlias(win, aliasName, sourceName) {
-  const knownElements = getExtendedElements(win);
-  const implementationClass = knownElements[sourceName];
-  if (implementationClass) {
-    // Update on the knownElements to prevent register again.
-    registerElement(win, aliasName, implementationClass);
-  } else {
-    throw new Error(`Element name is unknown: ${sourceName}.` +
-                     `Alias ${aliasName} was not registered.`);
-  }
-}
-
-/**
- * In order to provide better error messages we only allow to retrieve
- * services from other elements if those elements are loaded in the page.
- * This makes it possible to mark an element as loaded in a test.
- * @param {!Window} win
- * @param {string} elementName Name of an extended custom element.
- * @visibleForTesting
- */
-export function markElementScheduledForTesting(win, elementName) {
-  const knownElements = getExtendedElements(win);
-  if (!knownElements[elementName]) {
-    knownElements[elementName] = ElementStub;
-  }
-}
-
-/**
- * Resets our scheduled elements.
- * @param {!Window} win
- * @param {string} elementName Name of an extended custom element.
- * @visibleForTesting
- */
-export function resetScheduledElementForTesting(win, elementName) {
-  if (win.ampExtendedElements) {
-    delete win.ampExtendedElements[elementName];
-  }
-}
-
-/**
- * Returns a currently registered element class.
- * @param {!Window} win
- * @param {string} elementName Name of an extended custom element.
- * @return {?function()}
- * @visibleForTesting
- */
-export function getElementClassForTesting(win, elementName) {
-  const knownElements = win.ampExtendedElements;
-  return knownElements && knownElements[elementName] || null;
-}
 
 /** @param {!Element} element */
 function assertNotTemplate(element) {
   dev().assert(!element.isInTemplate_, 'Must never be called in template');
 }
+
 
 /**
  * @param {!Element} element
@@ -1922,7 +1537,8 @@ function getVsync(element) {
   // TODO(dvoytenko, #9177): consider removing this and always resolving via
   // `createCustomElementClass(win)` object.
   return Services.vsyncFor(element.ownerDocument.defaultView);
-};
+}
+
 
 /**
  * Whether the implementation is a stub.
@@ -1931,4 +1547,41 @@ function getVsync(element) {
  */
 function isStub(impl) {
   return (impl instanceof ElementStub);
-};
+}
+
+
+/**
+ * Returns "true" for internal AMP nodes or for placeholder elements.
+ * @param {!Node} node
+ * @return {boolean}
+ */
+function isInternalOrServiceNode(node) {
+  if (isInternalElement(node)) {
+    return true;
+  }
+  if (node.tagName && (node.hasAttribute('placeholder') ||
+      node.hasAttribute('fallback') ||
+      node.hasAttribute('overflow'))) {
+    return true;
+  }
+  return false;
+}
+
+
+/**
+ * Creates a new custom element class prototype.
+ *
+ * @param {!Window} win The window in which to register the custom element.
+ * @param {string} name The name of the custom element.
+ * @param {function(new:./base-element.BaseElement, !Element)=} opt_implementationClass For
+ *     testing only.
+ * @return {!Object} Prototype of element.
+ */
+export function createAmpElementProtoForTesting(
+    win, name, opt_implementationClass) {
+  const ElementProto = createCustomElementClass(win, name).prototype;
+  if (getMode().test && opt_implementationClass) {
+    ElementProto.implementationClassForTesting = opt_implementationClass;
+  }
+  return ElementProto;
+}

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -217,11 +217,12 @@ function createBaseCustomElementClass(win) {
       this.overflowElement_ = undefined;
 
       // `opt_implementationClass` is only used for tests.
-      let Ctor = dev().assert(win.ampExtendedElements &&
-          win.ampExtendedElements[this.elementName()]);
+      let Ctor = win.ampExtendedElements &&
+          win.ampExtendedElements[this.elementName()];
       if (getMode().test && this.implementationClassForTesting) {
         Ctor = this.implementationClassForTesting;
       }
+      dev().assert(Ctor);
       /** @private {!./base-element.BaseElement} */
       this.implementation_ = new Ctor(this);
 

--- a/src/inabox/amp-inabox.js
+++ b/src/inabox/amp-inabox.js
@@ -29,7 +29,7 @@ import {installStylesForDoc, makeBodyVisible} from '../style-installer';
 import {installErrorReporting} from '../error';
 import {installDocService} from '../service/ampdoc-impl';
 import {installCacheServiceWorker} from '../service-worker/install';
-import {stubElementsForDoc} from '../custom-element';
+import {stubElementsForDoc} from '../service/custom-element-registry';
 import {
     installAmpdocServices,
     installBuiltins,

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -79,7 +79,7 @@ import {
 } from './experiments';
 import {parseUrl} from './url';
 import {setStyle} from './style';
-import {stubElementsForDoc} from './custom-element';
+import {stubElementsForDoc} from './service/custom-element-registry';
 import {waitForBodyPromise} from './dom';
 import * as config from './config';
 

--- a/src/service/custom-element-registry.js
+++ b/src/service/custom-element-registry.js
@@ -1,0 +1,196 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {ElementStub, stubbedElements} from '../element-stub';
+import {createCustomElementClass} from '../custom-element';
+import {declareExtension} from './ampdoc-impl';
+import {user} from '../log';
+import {reportError} from '../error';
+
+
+/**
+ * @param {!Window} win
+ * @return {!Object<string, function(new:../base-element.BaseElement, !Element)>}
+ */
+function getExtendedElements(win) {
+  if (!win.ampExtendedElements) {
+    win.ampExtendedElements = {};
+  }
+  return win.ampExtendedElements;
+}
+
+
+/**
+ * Registers an element. Upgrades it if has previously been stubbed.
+ * @param {!Window} win
+ * @param {string} name
+ * @param {function(new:../base-element.BaseElement, !Element)} toClass
+ */
+export function upgradeOrRegisterElement(win, name, toClass) {
+  const knownElements = getExtendedElements(win);
+  if (!knownElements[name]) {
+    registerElement(win, name, /** @type {!Function} */ (toClass));
+    return;
+  }
+  if (knownElements[name] == toClass) {
+    // Already registered this instance.
+    return;
+  }
+  user().assert(knownElements[name] == ElementStub,
+      '%s is already registered. The script tag for ' +
+      '%s is likely included twice in the page.', name, name);
+  knownElements[name] = toClass;
+  for (let i = 0; i < stubbedElements.length; i++) {
+    const stub = stubbedElements[i];
+    // There are 3 possible states here:
+    // 1. We never made the stub because the extended impl. loaded first.
+    //    In that case the element won't be in the array.
+    // 2. We made a stub but the browser didn't attach it yet. In
+    //    that case we don't need to upgrade but simply switch to the new
+    //    implementation.
+    // 3. A stub was attached. We upgrade which means we replay the
+    //    implementation.
+    const element = stub.element;
+    if (element.tagName.toLowerCase() == name &&
+            element.ownerDocument.defaultView == win) {
+      tryUpgradeElementNoInline(element, toClass);
+      // Remove element from array.
+      stubbedElements.splice(i--, 1);
+    }
+  }
+}
+
+
+/**
+ * This method should not be inlined to prevent TryCatch deoptimization.
+ * NoInline keyword at the end of function name also prevents Closure compiler
+ * from inlining the function.
+ * @private
+ */
+function tryUpgradeElementNoInline(element, toClass) {
+  try {
+    element.upgrade(toClass);
+  } catch (e) {
+    reportError(e, element);
+  }
+}
+
+
+/**
+ * Stub extended elements missing an implementation. It can be called multiple
+ * times and on partial document in order to start stubbing as early as
+ * possible.
+ * @param {!./ampdoc-impl.AmpDoc} ampdoc
+ */
+export function stubElementsForDoc(ampdoc) {
+  const list = ampdoc.getHeadNode().querySelectorAll('script[custom-element]');
+  for (let i = 0; i < list.length; i++) {
+    const name = list[i].getAttribute('custom-element');
+    declareExtension(ampdoc, name);
+    stubElementIfNotKnown(ampdoc.win, name);
+  }
+}
+
+
+/**
+ * Stub element if not yet known.
+ * @param {!Window} win
+ * @param {string} name
+ */
+export function stubElementIfNotKnown(win, name) {
+  const knownElements = getExtendedElements(win);
+  if (!knownElements[name]) {
+    registerElement(win, name, ElementStub);
+  }
+}
+
+
+/**
+ * Copies the specified element to child window (friendly iframe). This way
+ * all implementations of the AMP elements are shared between all friendly
+ * frames.
+ * @param {!Window} parentWin
+ * @param {!Window} childWin
+ * @param {string} name
+ */
+export function copyElementToChildWindow(parentWin, childWin, name) {
+  const toClass = getExtendedElements(parentWin)[name];
+  registerElement(childWin, name, toClass || ElementStub);
+}
+
+
+/**
+ * Registers a new custom element with its implementation class.
+ * @param {!Window} win The window in which to register the elements.
+ * @param {string} name Name of the custom element
+ * @param {function(new:../base-element.BaseElement, !Element)} implementationClass
+ */
+export function registerElement(win, name, implementationClass) {
+  const knownElements = getExtendedElements(win);
+  knownElements[name] = implementationClass;
+  const klass = createCustomElementClass(win, name);
+
+  const supportsCustomElementsV1 = 'customElements' in win;
+  if (supportsCustomElementsV1) {
+    win['customElements'].define(name, klass);
+  } else {
+    win.document.registerElement(name, {
+      prototype: klass.prototype,
+    });
+  }
+}
+
+
+/**
+ * In order to provide better error messages we only allow to retrieve
+ * services from other elements if those elements are loaded in the page.
+ * This makes it possible to mark an element as loaded in a test.
+ * @param {!Window} win
+ * @param {string} elementName Name of an extended custom element.
+ * @visibleForTesting
+ */
+export function markElementScheduledForTesting(win, elementName) {
+  const knownElements = getExtendedElements(win);
+  if (!knownElements[elementName]) {
+    knownElements[elementName] = ElementStub;
+  }
+}
+
+
+/**
+ * Resets our scheduled elements.
+ * @param {!Window} win
+ * @param {string} elementName Name of an extended custom element.
+ * @visibleForTesting
+ */
+export function resetScheduledElementForTesting(win, elementName) {
+  if (win.ampExtendedElements) {
+    delete win.ampExtendedElements[elementName];
+  }
+}
+
+
+/**
+ * Returns a currently registered element class.
+ * @param {!Window} win
+ * @param {string} elementName Name of an extended custom element.
+ * @return {?function()}
+ * @visibleForTesting
+ */
+export function getElementClassForTesting(win, elementName) {
+  const knownElements = win.ampExtendedElements;
+  return knownElements && knownElements[elementName] || null;
+}

--- a/src/service/extensions-impl.js
+++ b/src/service/extensions-impl.js
@@ -27,7 +27,7 @@ import {
   copyElementToChildWindow,
   stubElementIfNotKnown,
   upgradeOrRegisterElement,
-} from '../custom-element';
+} from './custom-element-registry';
 import {cssText} from '../../build/css';
 import {dev, rethrowAsync} from '../log';
 import {getMode} from '../mode';

--- a/test/functional/test-activity.js
+++ b/test/functional/test-activity.js
@@ -26,7 +26,9 @@ import {installTimerService} from '../../src/service/timer-impl';
 import {
   installViewportServiceForDoc,
 } from '../../src/service/viewport/viewport-impl';
-import {markElementScheduledForTesting} from '../../src/custom-element';
+import {
+  markElementScheduledForTesting,
+} from '../../src/service/custom-element-registry';
 import {installVsyncService} from '../../src/service/vsync-impl';
 import {Observable} from '../../src/observable';
 import * as sinon from 'sinon';

--- a/test/functional/test-base-element.js
+++ b/test/functional/test-base-element.js
@@ -20,7 +20,6 @@ import {createAmpElementProtoForTesting} from '../../src/custom-element';
 import {layoutRectLtwh} from '../../src/layout-rect';
 import {listenOncePromise} from '../../src/event-helper';
 import {Services} from '../../src/services';
-import * as sinon from 'sinon';
 
 
 describes.realWin('BaseElement', {amp: true}, env => {

--- a/test/functional/test-base-element.js
+++ b/test/functional/test-base-element.js
@@ -16,35 +16,31 @@
 
 import {BaseElement} from '../../src/base-element';
 import {Resource} from '../../src/service/resource';
-import {createAmpElementProto} from '../../src/custom-element';
+import {createAmpElementProtoForTesting} from '../../src/custom-element';
 import {layoutRectLtwh} from '../../src/layout-rect';
 import {listenOncePromise} from '../../src/event-helper';
 import {Services} from '../../src/services';
 import * as sinon from 'sinon';
 
 
-describe('BaseElement', () => {
-
-  let sandbox;
+describes.realWin('BaseElement', {amp: true}, env => {
+  let win, doc;
   let customElement;
   let element;
 
-  document.registerElement('amp-test-element', {
-    prototype: createAmpElementProto(window, 'amp-test-element', BaseElement),
-  });
-
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
-    customElement = document.createElement('amp-test-element');
+    win = env.win;
+    doc = win.document;
+    doc.registerElement('amp-test-element', {
+      prototype: createAmpElementProtoForTesting(win,
+          'amp-test-element', BaseElement),
+    });
+    customElement = doc.createElement('amp-test-element');
     element = new BaseElement(customElement);
   });
 
-  afterEach(() => {
-    sandbox.restore();
-  });
-
   it('should delegate update priority to resources', () => {
-    const resources = window.services.resources.obj;
+    const resources = win.services.resources.obj;
     customElement.getResources = () => resources;
     const updatePriorityStub = sandbox.stub(resources, 'updatePriority');
     element.updatePriority(1);
@@ -52,7 +48,7 @@ describe('BaseElement', () => {
   });
 
   it('propagateAttributes - niente', () => {
-    const target = document.createElement('div');
+    const target = doc.createElement('div');
     expect(target.hasAttributes()).to.be.false;
 
     element.propagateAttributes(['data-test1'], target);
@@ -63,7 +59,7 @@ describe('BaseElement', () => {
   });
 
   it('propagateAttributes', () => {
-    const target = document.createElement('div');
+    const target = doc.createElement('div');
     expect(target.hasAttributes()).to.be.false;
 
     customElement.setAttribute('data-test1', 'abc');
@@ -149,7 +145,7 @@ describe('BaseElement', () => {
   });
 
   it('should return correct layoutBox', () => {
-    const resources = window.services.resources.obj;
+    const resources = win.services.resources.obj;
     customElement.getResources = () => resources;
     const resource = new Resource(1, customElement, resources);
     sandbox.stub(resources, 'getResourceForElement')
@@ -175,12 +171,12 @@ describe('BaseElement', () => {
 
     beforeEach(() => {
       const timer = Services.timerFor(element.win);
-      target = document.createElement('div');
+      target = doc.createElement('div');
 
-      event1 = document.createEvent('Event');
+      event1 = doc.createEvent('Event');
       event1.initEvent('event1', false, true);
 
-      event2 = document.createEvent('Event');
+      event2 = doc.createEvent('Event');
       event2.initEvent('event2', false, true);
 
       event1Promise = listenOncePromise(element.element, 'event1');

--- a/test/functional/test-custom-element-registry.js
+++ b/test/functional/test-custom-element-registry.js
@@ -1,0 +1,289 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {AmpDocSingle} from '../../src/service/ampdoc-impl';
+import {BaseElement} from '../../src/base-element';
+import {ElementStub} from '../../src/element-stub';
+import {
+  copyElementToChildWindow,
+  getElementClassForTesting,
+  registerElement,
+  resetScheduledElementForTesting,
+  stubElementIfNotKnown,
+  stubElementsForDoc,
+  upgradeOrRegisterElement,
+} from '../../src/service/custom-element-registry';
+import {createElementWithAttributes} from '../../src/dom';
+import {installDocumentStateService} from '../../src/service/document-state';
+
+
+describes.realWin('CustomElement register', {amp: true}, env => {
+
+  class ConcreteElement extends BaseElement {}
+
+  let win, doc, ampdoc, extensions;
+
+  beforeEach(() => {
+    win = env.win;
+    doc = win.document;
+    ampdoc = env.ampdoc;
+    extensions = env.extensions;
+    ampdoc.declareExtension_('amp-element1');
+  });
+
+  function insertElement(name) {
+    const testElement = createElementWithAttributes(doc, name, {
+      width: '300',
+      height: '250',
+      type: '_ping_',
+      'data-aax_size': '300*250',
+      'data-aax_pubname': 'abc123',
+      'data-aax_src': '302',
+    });
+    doc.body.appendChild(testElement);
+  }
+
+  it('should go through stub/upgrade cycle', () => {
+    registerElement(win, 'amp-element1', ElementStub);
+    expect(getElementClassForTesting(win, 'amp-element1'))
+        .to.equal(ElementStub);
+
+    // Pre-download elements are created as ElementStub.
+    const element1 = doc.createElement('amp-element1');
+    doc.body.appendChild(element1);
+    expect(element1.implementation_).to.be.instanceOf(ElementStub);
+
+    // Post-download, elements are upgraded.
+    upgradeOrRegisterElement(win, 'amp-element1', ConcreteElement);
+    expect(getElementClassForTesting(win, 'amp-element1'))
+        .to.equal(ConcreteElement);
+    expect(element1.implementation_).to.be.instanceOf(ConcreteElement);
+
+    // Elements created post-download and immediately upgraded.
+    const element2 = doc.createElement('amp-element1');
+    doc.body.appendChild(element1);
+    expect(element2.implementation_).to.be.instanceOf(ConcreteElement);
+  });
+
+  it('should mark stubbed element as declared', () => {
+    expect(ampdoc.declaresExtension('amp-element2')).to.be.false;
+
+    const head = document.createElement('fake-head');
+    const script = document.createElement('script');
+    script.setAttribute('custom-element', 'amp-element2');
+    head.appendChild(script);
+    sandbox.stub(ampdoc, 'getHeadNode', () => head);
+
+    stubElementsForDoc(ampdoc);
+    expect(ampdoc.declaresExtension('amp-element2')).to.be.true;
+    expect(win.ampExtendedElements['amp-element2']).to.equal(ElementStub);
+  });
+
+  it('should install pre-stubbed element extension', () => {
+    const stub = sandbox.stub(extensions, 'installExtensionForDoc');
+
+    stubElementIfNotKnown(win, 'amp-element2');
+    expect(win.ampExtendedElements['amp-element2']).to.equal(ElementStub);
+    expect(ampdoc.declaresExtension('amp-element2')).to.be.false;
+    expect(stub).to.not.be.called;
+
+    const element = doc.createElement('amp-element2');
+    doc.body.appendChild(element);
+    expect(stub).to.be.calledOnce;
+    expect(stub).to.be.calledWithExactly(ampdoc, 'amp-element2');
+  });
+
+  it('should not install declared pre-stubbed element extension', () => {
+    ampdoc.declareExtension_('amp-element2');
+    const stub = sandbox.stub(extensions, 'installExtensionForDoc');
+
+    stubElementIfNotKnown(win, 'amp-element2');
+    expect(win.ampExtendedElements['amp-element2']).to.equal(ElementStub);
+    expect(ampdoc.declaresExtension('amp-element2')).to.be.true;
+    expect(stub).to.not.be.called;
+
+    const element = doc.createElement('amp-element2');
+    doc.body.appendChild(element);
+    expect(stub).to.not.be.called;
+  });
+
+  it('should not install declared pre-installed element', () => {
+    const stub = sandbox.stub(extensions, 'installExtensionForDoc');
+
+    registerElement(win, 'amp-element1', ConcreteElement);
+    expect(win.ampExtendedElements['amp-element1']).to.equal(ConcreteElement);
+    expect(ampdoc.declaresExtension('amp-element1')).to.be.true;
+    expect(stub).to.not.be.called;
+
+    const element = doc.createElement('amp-element1');
+    doc.body.appendChild(element);
+    expect(stub).to.not.be.called;
+  });
+
+  it('insert script for amp-ad when script is not included', () => {
+    insertElement('amp-ad');
+    expect(doc.head.querySelectorAll('[custom-element="amp-ad"]'))
+        .to.have.length(1);
+  });
+
+  it('insert script for amp-embed when script is not included', () => {
+    insertElement('amp-embed');
+    expect(doc.head.querySelectorAll('[custom-element="amp-embed"]'))
+        .to.have.length(0);
+    expect(doc.head.querySelectorAll('[custom-element="amp-ad"]'))
+        .to.have.length(1);
+  });
+
+  it('insert script for amp-video when script is not included', () => {
+    insertElement('amp-video');
+    expect(doc.head.querySelectorAll('[custom-element="amp-video"]'))
+        .to.have.length(1);
+  });
+
+  describe('no body', () => {
+
+    let elements;
+    let doc;
+    let win;
+    let elem1;
+    let ampdoc;
+
+    beforeEach(() => {
+      elements = [];
+
+      doc = {
+        registerElement: sandbox.spy(),
+        documentElement: {
+          ownerDocument: doc,
+        },
+        head: {
+          nodeType: /* ELEMENT */ 1,
+          querySelectorAll: selector => {
+            if (selector == 'script[custom-element]') {
+              return elements;
+            }
+            return [];
+          },
+        },
+        body: {},
+      };
+
+      elem1 = {
+        getAttribute: name => {
+          if (name == 'custom-element') {
+            return 'amp-test1';
+          }
+        },
+        ownerDocument: doc,
+      };
+      elements.push(elem1);
+
+      win = {
+        document: doc,
+        Object: {
+          create: proto => Object.create(proto),
+        },
+        HTMLElement,
+        ampExtendedElements: {},
+      };
+      doc.defaultView = win;
+
+      ampdoc = new AmpDocSingle(win);
+
+      installDocumentStateService(win);
+    });
+
+    afterEach(() => {
+      resetScheduledElementForTesting(win, 'amp-test1');
+      resetScheduledElementForTesting(win, 'amp-test2');
+    });
+
+    it('should be stub elements when body available', () => {
+      stubElementsForDoc(ampdoc);
+
+      expect(win.ampExtendedElements).to.exist;
+      expect(win.ampExtendedElements['amp-test1']).to.equal(ElementStub);
+      expect(win.ampExtendedElements['amp-test2']).to.be.undefined;
+      expect(doc.registerElement).to.be.calledOnce;
+      expect(doc.registerElement.firstCall.args[0]).to.equal('amp-test1');
+    });
+
+    it('should repeat stubbing when body is not available', () => {
+      doc.body = null;  // Body not available
+
+      stubElementsForDoc(ampdoc);
+
+      expect(win.ampExtendedElements).to.exist;
+      expect(win.ampExtendedElements['amp-test1']).to.equal(ElementStub);
+      expect(win.ampExtendedElements['amp-test2']).to.be.undefined;
+      expect(doc.registerElement).to.be.calledOnce;
+      expect(doc.registerElement.firstCall.args[0]).to.equal('amp-test1');
+
+      // Add more elements
+      const elem2 = {
+        getAttribute: name => {
+          if (name == 'custom-element') {
+            return 'amp-test2';
+          }
+        },
+        ownerDocument: doc,
+      };
+      elements.push(elem2);
+
+      // Body available. Stub again.
+      doc.body = {};
+      stubElementsForDoc(ampdoc);
+      expect(win.ampExtendedElements['amp-test1']).to.equal(ElementStub);
+      expect(win.ampExtendedElements['amp-test2']).to.equal(ElementStub);
+      expect(doc.registerElement).to.have.callCount(2);
+      expect(doc.registerElement.getCall(1).args[0]).to.equal('amp-test2');
+    });
+
+    it('should stub element when not stubbed yet', () => {
+      // First stub is allowed.
+      stubElementIfNotKnown(win, 'amp-test1');
+
+      expect(win.ampExtendedElements).to.exist;
+      expect(win.ampExtendedElements['amp-test1']).to.equal(ElementStub);
+      expect(doc.registerElement).to.be.calledOnce;
+      expect(doc.registerElement.firstCall.args[0]).to.equal('amp-test1');
+
+      // Second stub is ignored.
+      stubElementIfNotKnown(win, 'amp-test1');
+      expect(doc.registerElement).to.be.calledOnce;
+    });
+
+    it('should copy or stub element definitions in a child window', () => {
+      stubElementIfNotKnown(win, 'amp-test1');
+
+      const registerElement = sandbox.spy();
+      const childWin = {Object, HTMLElement, document: {registerElement}};
+
+      copyElementToChildWindow(win, childWin, 'amp-test1');
+      expect(childWin.ampExtendedElements['amp-test1']).to.equal(ElementStub);
+      const firstCallCount = registerElement.callCount;
+      expect(firstCallCount).to.equal(1);
+      expect(registerElement.getCall(firstCallCount - 1).args[0])
+          .to.equal('amp-test1');
+
+      copyElementToChildWindow(win, childWin, 'amp-test2');
+      expect(childWin.ampExtendedElements['amp-test1']).to.equal(ElementStub);
+      expect(registerElement.callCount > firstCallCount).to.be.true;
+      expect(registerElement.getCall(registerElement.callCount - 1).args[0])
+          .to.equal('amp-test2');
+    });
+  });
+});

--- a/test/functional/test-custom-element.js
+++ b/test/functional/test-custom-element.js
@@ -14,152 +14,15 @@
  * limitations under the License.
  */
 
-import * as lolex from 'lolex';
-import {AmpDocSingle} from '../../src/service/ampdoc-impl';
 import {AmpEvents} from '../../src/amp-events';
 import {BaseElement} from '../../src/base-element';
 import {ElementStub} from '../../src/element-stub';
 import {LOADING_ELEMENTS_, Layout} from '../../src/layout';
-import {createElementWithAttributes} from '../../src/dom';
-import {installDocumentStateService} from '../../src/service/document-state';
-import {poll} from '../../testing/iframe';
 import {ResourceState} from '../../src/service/resource';
 import {Services} from '../../src/services';
-import {
-  copyElementToChildWindow,
-  createAmpElementProto,
-  getElementClassForTesting,
-  registerElement,
-  resetScheduledElementForTesting,
-  stubElementIfNotKnown,
-  stubElementsForDoc,
-  upgradeOrRegisterElement,
-} from '../../src/custom-element';
-
-
-describes.realWin('CustomElement register', {amp: true}, env => {
-
-  class ConcreteElement extends BaseElement {}
-
-  let win, doc, ampdoc, extensions;
-
-  beforeEach(() => {
-    win = env.win;
-    doc = win.document;
-    ampdoc = env.ampdoc;
-    extensions = env.extensions;
-    ampdoc.declareExtension_('amp-element1');
-  });
-
-  function insertElement(name) {
-    const testElement = createElementWithAttributes(doc, name, {
-      width: '300',
-      height: '250',
-      type: '_ping_',
-      'data-aax_size': '300*250',
-      'data-aax_pubname': 'abc123',
-      'data-aax_src': '302',
-    });
-    doc.body.appendChild(testElement);
-  }
-
-  it('should go through stub/upgrade cycle', () => {
-    registerElement(win, 'amp-element1', ElementStub);
-    expect(getElementClassForTesting(win, 'amp-element1'))
-        .to.equal(ElementStub);
-
-    // Pre-download elements are created as ElementStub.
-    const element1 = doc.createElement('amp-element1');
-    doc.body.appendChild(element1);
-    expect(element1.implementation_).to.be.instanceOf(ElementStub);
-
-    // Post-download, elements are upgraded.
-    upgradeOrRegisterElement(win, 'amp-element1', ConcreteElement);
-    expect(getElementClassForTesting(win, 'amp-element1'))
-        .to.equal(ConcreteElement);
-    expect(element1.implementation_).to.be.instanceOf(ConcreteElement);
-
-    // Elements created post-download and immediately upgraded.
-    const element2 = doc.createElement('amp-element1');
-    doc.body.appendChild(element1);
-    expect(element2.implementation_).to.be.instanceOf(ConcreteElement);
-  });
-
-  it('should mark stubbed element as declared', () => {
-    expect(ampdoc.declaresExtension('amp-element2')).to.be.false;
-
-    const head = document.createElement('fake-head');
-    const script = document.createElement('script');
-    script.setAttribute('custom-element', 'amp-element2');
-    head.appendChild(script);
-    sandbox.stub(ampdoc, 'getHeadNode', () => head);
-
-    stubElementsForDoc(ampdoc);
-    expect(ampdoc.declaresExtension('amp-element2')).to.be.true;
-    expect(win.ampExtendedElements['amp-element2']).to.equal(ElementStub);
-  });
-
-  it('should install pre-stubbed element extension', () => {
-    const stub = sandbox.stub(extensions, 'installExtensionForDoc');
-
-    stubElementIfNotKnown(win, 'amp-element2');
-    expect(win.ampExtendedElements['amp-element2']).to.equal(ElementStub);
-    expect(ampdoc.declaresExtension('amp-element2')).to.be.false;
-    expect(stub).to.not.be.called;
-
-    const element = doc.createElement('amp-element2');
-    doc.body.appendChild(element);
-    expect(stub).to.be.calledOnce;
-    expect(stub).to.be.calledWithExactly(ampdoc, 'amp-element2');
-  });
-
-  it('should not install declared pre-stubbed element extension', () => {
-    ampdoc.declareExtension_('amp-element2');
-    const stub = sandbox.stub(extensions, 'installExtensionForDoc');
-
-    stubElementIfNotKnown(win, 'amp-element2');
-    expect(win.ampExtendedElements['amp-element2']).to.equal(ElementStub);
-    expect(ampdoc.declaresExtension('amp-element2')).to.be.true;
-    expect(stub).to.not.be.called;
-
-    const element = doc.createElement('amp-element2');
-    doc.body.appendChild(element);
-    expect(stub).to.not.be.called;
-  });
-
-  it('should not install declared pre-installed element', () => {
-    const stub = sandbox.stub(extensions, 'installExtensionForDoc');
-
-    registerElement(win, 'amp-element1', ConcreteElement);
-    expect(win.ampExtendedElements['amp-element1']).to.equal(ConcreteElement);
-    expect(ampdoc.declaresExtension('amp-element1')).to.be.true;
-    expect(stub).to.not.be.called;
-
-    const element = doc.createElement('amp-element1');
-    doc.body.appendChild(element);
-    expect(stub).to.not.be.called;
-  });
-
-  it('insert script for amp-ad when script is not included', () => {
-    insertElement('amp-ad');
-    expect(doc.head.querySelectorAll('[custom-element="amp-ad"]'))
-        .to.have.length(1);
-  });
-
-  it('insert script for amp-embed when script is not included', () => {
-    insertElement('amp-embed');
-    expect(doc.head.querySelectorAll('[custom-element="amp-embed"]'))
-        .to.have.length(0);
-    expect(doc.head.querySelectorAll('[custom-element="amp-ad"]'))
-        .to.have.length(1);
-  });
-
-  it('insert script for amp-video when script is not included', () => {
-    insertElement('amp-video');
-    expect(doc.head.querySelectorAll('[custom-element="amp-video"]'))
-        .to.have.length(1);
-  });
-});
+import {createAmpElementProtoForTesting} from '../../src/custom-element';
+import {poll} from '../../testing/iframe';
+import * as lolex from 'lolex';
 
 
 describes.realWin('CustomElement', {amp: true}, env => {
@@ -249,11 +112,13 @@ describes.realWin('CustomElement', {amp: true}, env => {
     doc.body.appendChild(container);
 
     ElementClass = doc.registerElement('amp-test', {
-      prototype: createAmpElementProto(win, 'amp-test', TestElement),
+      prototype: createAmpElementProtoForTesting(win, 'amp-test', TestElement),
     });
     StubElementClass = doc.registerElement('amp-stub', {
-      prototype: createAmpElementProto(win, 'amp-stub', ElementStub),
+      prototype: createAmpElementProtoForTesting(win, 'amp-stub', ElementStub),
     });
+    win.ampExtendedElements['amp-test'] = TestElement;
+    win.ampExtendedElements['amp-stub'] = ElementStub;
     ampdoc.declareExtension_('amp-stub');
 
     testElementCreatedCallback = sandbox.spy();
@@ -1029,24 +894,24 @@ describes.realWin('CustomElement', {amp: true}, env => {
 
   it('should apply heights condition', () => {
     const element1 = new ElementClass();
-    element1.sizerElement_ = doc.createElement('div');
+    element1.sizerElement = doc.createElement('div');
     element1.setAttribute('layout', 'responsive');
     element1.setAttribute('width', '200px');
     element1.setAttribute('height', '200px');
     element1.setAttribute('heights', '(min-width: 1px) 99%, 1%');
     container.appendChild(element1);
     element1.applySizesAndMediaQuery();
-    expect(element1.sizerElement_.style.paddingTop).to.equal('99%');
+    expect(element1.sizerElement.style.paddingTop).to.equal('99%');
 
     const element2 = new ElementClass();
-    element2.sizerElement_ = doc.createElement('div');
+    element2.sizerElement = doc.createElement('div');
     element2.setAttribute('layout', 'responsive');
     element2.setAttribute('width', '200px');
     element2.setAttribute('height', '200px');
     element2.setAttribute('heights', '(min-width: 1111111px) 99%, 1%');
     container.appendChild(element2);
     element2.applySizesAndMediaQuery();
-    expect(element2.sizerElement_.style.paddingTop).to.equal('1%');
+    expect(element2.sizerElement.style.paddingTop).to.equal('1%');
   });
 
   it('should rediscover sizer to apply heights in SSR', () => {
@@ -1059,10 +924,10 @@ describes.realWin('CustomElement', {amp: true}, env => {
     container.appendChild(element1);
 
     const sizer = doc.createElement('i-amphtml-sizer');
-    expect(element1.sizerElement_).to.be.undefined;
+    expect(element1.sizerElement).to.be.undefined;
     element1.appendChild(sizer);
     element1.applySizesAndMediaQuery();
-    expect(element1.sizerElement_).to.equal(sizer);
+    expect(element1.sizerElement).to.equal(sizer);
     expect(sizer.style.paddingTop).to.equal('99%');
   });
 
@@ -1077,9 +942,9 @@ describes.realWin('CustomElement', {amp: true}, env => {
 
     const sizer = doc.createElement('i-amphtml-sizer');
     element1.appendChild(sizer);
-    element1.sizerElement_ = null;
+    element1.sizerElement = null;
     element1.applySizesAndMediaQuery();
-    expect(element1.sizerElement_).to.be.null;
+    expect(element1.sizerElement).to.be.null;
     expect(sizer.style.paddingTop).to.equal('');
   });
 
@@ -1150,10 +1015,10 @@ describes.realWin('CustomElement', {amp: true}, env => {
   it('should change size with sizer', () => {
     const element = new ElementClass();
     const sizer = doc.createElement('div');
-    element.sizerElement_ = sizer;
+    element.sizerElement = sizer;
     element.changeSize(111, 222, {top: 1, right: 2, bottom: 3, left: 4});
     expect(parseInt(sizer.style.paddingTop, 10)).to.equal(0);
-    expect(element.sizerElement_).to.be.null;
+    expect(element.sizerElement).to.be.null;
     expect(element.style.height).to.equal('111px');
     expect(element.style.width).to.equal('222px');
     expect(element.style.marginTop).to.equal('1px');
@@ -1420,7 +1285,7 @@ describes.realWin('CustomElement Service Elements', {amp: true}, env => {
     win = env.win;
     doc = win.document;
     StubElementClass = doc.registerElement('amp-stub2', {
-      prototype: createAmpElementProto(win, 'amp-stub2', ElementStub),
+      prototype: createAmpElementProtoForTesting(win, 'amp-stub2', ElementStub),
     });
     env.ampdoc.declareExtension_('amp-stub2');
     element = new StubElementClass();
@@ -1597,8 +1462,10 @@ describes.realWin('CustomElement Loading Indicator', {amp: true}, env => {
     doc = win.document;
     clock = lolex.install(win);
     ElementClass = doc.registerElement('amp-test-loader', {
-      prototype: createAmpElementProto(win, 'amp-test-loader', TestElement),
+      prototype: createAmpElementProtoForTesting(
+          win, 'amp-test-loader', TestElement),
     });
+    win.ampExtendedElements['amp-test-loader'] = TestElement;
     LOADING_ELEMENTS_['amp-test-loader'.toUpperCase()] = true;
     resources = Services.resourcesForDoc(doc);
     resources.isBuildOn_ = true;
@@ -1931,7 +1798,8 @@ describes.realWin('CustomElement Overflow Element', {amp: true}, env => {
     win = env.win;
     doc = win.document;
     ElementClass = doc.registerElement('amp-test-overflow', {
-      prototype: createAmpElementProto(win, 'amp-test-overflow', TestElement),
+      prototype: createAmpElementProtoForTesting(
+          win, 'amp-test-overflow', TestElement),
     });
     resources = Services.resourcesForDoc(doc);
     resourcesMock = sandbox.mock(resources);
@@ -2015,139 +1883,5 @@ describes.realWin('CustomElement Overflow Element', {amp: true}, env => {
 
     expect(overflowElement.onclick).to.not.exist;
     expect(overflowElement).to.not.have.class('amp-visible');
-  });
-
-  describe('no body', () => {
-
-    let elements;
-    let doc;
-    let win;
-    let elem1;
-    let ampdoc;
-
-    beforeEach(() => {
-      elements = [];
-
-      doc = {
-        registerElement: sandbox.spy(),
-        documentElement: {
-          ownerDocument: doc,
-        },
-        head: {
-          nodeType: /* ELEMENT */ 1,
-          querySelectorAll: selector => {
-            if (selector == 'script[custom-element]') {
-              return elements;
-            }
-            return [];
-          },
-        },
-        body: {},
-      };
-
-      elem1 = {
-        getAttribute: name => {
-          if (name == 'custom-element') {
-            return 'amp-test1';
-          }
-        },
-        ownerDocument: doc,
-      };
-      elements.push(elem1);
-
-      win = {
-        document: doc,
-        Object: {
-          create: proto => Object.create(proto),
-        },
-        HTMLElement,
-        ampExtendedElements: {},
-      };
-      doc.defaultView = win;
-
-      ampdoc = new AmpDocSingle(win);
-
-      installDocumentStateService(win);
-    });
-
-    afterEach(() => {
-      resetScheduledElementForTesting(win, 'amp-test1');
-      resetScheduledElementForTesting(win, 'amp-test2');
-    });
-
-    it('should be stub elements when body available', () => {
-      stubElementsForDoc(ampdoc);
-
-      expect(win.ampExtendedElements).to.exist;
-      expect(win.ampExtendedElements['amp-test1']).to.equal(ElementStub);
-      expect(win.ampExtendedElements['amp-test2']).to.be.undefined;
-      expect(doc.registerElement).to.be.calledOnce;
-      expect(doc.registerElement.firstCall.args[0]).to.equal('amp-test1');
-    });
-
-    it('should repeat stubbing when body is not available', () => {
-      doc.body = null;  // Body not available
-
-      stubElementsForDoc(ampdoc);
-
-      expect(win.ampExtendedElements).to.exist;
-      expect(win.ampExtendedElements['amp-test1']).to.equal(ElementStub);
-      expect(win.ampExtendedElements['amp-test2']).to.be.undefined;
-      expect(doc.registerElement).to.be.calledOnce;
-      expect(doc.registerElement.firstCall.args[0]).to.equal('amp-test1');
-
-      // Add more elements
-      const elem2 = {
-        getAttribute: name => {
-          if (name == 'custom-element') {
-            return 'amp-test2';
-          }
-        },
-        ownerDocument: doc,
-      };
-      elements.push(elem2);
-
-      // Body available. Stub again.
-      doc.body = {};
-      stubElementsForDoc(ampdoc);
-      expect(win.ampExtendedElements['amp-test1']).to.equal(ElementStub);
-      expect(win.ampExtendedElements['amp-test2']).to.equal(ElementStub);
-      expect(doc.registerElement).to.have.callCount(2);
-      expect(doc.registerElement.getCall(1).args[0]).to.equal('amp-test2');
-    });
-
-    it('should stub element when not stubbed yet', () => {
-      // First stub is allowed.
-      stubElementIfNotKnown(win, 'amp-test1');
-
-      expect(win.ampExtendedElements).to.exist;
-      expect(win.ampExtendedElements['amp-test1']).to.equal(ElementStub);
-      expect(doc.registerElement).to.be.calledOnce;
-      expect(doc.registerElement.firstCall.args[0]).to.equal('amp-test1');
-
-      // Second stub is ignored.
-      stubElementIfNotKnown(win, 'amp-test1');
-      expect(doc.registerElement).to.be.calledOnce;
-    });
-
-    it('should copy or stub element definitions in a child window', () => {
-      stubElementIfNotKnown(win, 'amp-test1');
-
-      const registerElement = sandbox.spy();
-      const childWin = {Object, HTMLElement, document: {registerElement}};
-
-      copyElementToChildWindow(win, childWin, 'amp-test1');
-      expect(childWin.ampExtendedElements['amp-test1']).to.equal(ElementStub);
-      const firstCallCount = registerElement.callCount;
-      expect(firstCallCount).to.equal(1);
-      expect(registerElement.getCall(firstCallCount - 1).args[0])
-          .to.equal('amp-test1');
-
-      copyElementToChildWindow(win, childWin, 'amp-test2');
-      expect(childWin.ampExtendedElements['amp-test1']).to.equal(ElementStub);
-      expect(registerElement.callCount > firstCallCount).to.be.true;
-      expect(registerElement.getCall(registerElement.callCount - 1).args[0])
-          .to.equal('amp-test2');
-    });
   });
 });

--- a/test/functional/test-dom.js
+++ b/test/functional/test-dom.js
@@ -18,7 +18,7 @@ import * as dom from '../../src/dom';
 import {loadPromise} from '../../src/event-helper';
 import {toArray} from '../../src/types';
 import {BaseElement} from '../../src/base-element';
-import {createAmpElementProto} from '../../src/custom-element';
+import {createAmpElementProtoForTesting} from '../../src/custom-element';
 
 
 describes.sandboxed('DOM', {}, env => {
@@ -962,7 +962,8 @@ describes.realWin('DOM', {
       doc.body.appendChild(element);
       env.win.setTimeout(() => {
         doc.registerElement('amp-test', {
-          prototype: createAmpElementProto(env.win, 'amp-test', TestElement),
+          prototype: createAmpElementProtoForTesting(
+              env.win, 'amp-test', TestElement),
         });
       }, 100);
       return dom.whenUpgradedToCustomElement(element).then(element => {

--- a/test/functional/test-element-service.js
+++ b/test/functional/test-element-service.js
@@ -18,7 +18,7 @@ import {FakeWindow} from '../../testing/fake-dom';
 import {
   markElementScheduledForTesting,
   resetScheduledElementForTesting,
-} from '../../src/custom-element';
+} from '../../src/service/custom-element-registry';
 import {
   getElementService,
   getElementServiceIfAvailable,

--- a/test/functional/test-extension-analytics.js
+++ b/test/functional/test-extension-analytics.js
@@ -24,7 +24,7 @@ import {
     useAnalyticsInSandbox,
     CustomEventReporterBuilder,
 } from '../../src/extension-analytics';
-import {createAmpElementProto} from '../../src/custom-element';
+import {createAmpElementProtoForTesting} from '../../src/custom-element';
 import {Services} from '../../src/services';
 import {BaseElement} from '../../src/base-element';
 import {macroTask} from '../../testing/yield';
@@ -184,7 +184,8 @@ describes.realWin('extension-analytics', {
       getServiceForDoc(ampdoc, 'amp-analytics-instrumentation');
 
       env.win.document.registerElement('amp-test', {
-        prototype: createAmpElementProto(env.win, 'amp-test', BaseElement),
+        prototype: createAmpElementProtoForTesting(
+            env.win, 'amp-test', BaseElement),
       });
       parentEle = env.win.document.createElement('amp-test');
       parentEle.setAttribute('layout', 'nodisplay');
@@ -266,7 +267,8 @@ describes.realWin('extension-analytics', {
           }
                 }
         env.win.document.registerElement('amp-test', {
-          prototype: createAmpElementProto(env.win, 'amp-test', TestElement),
+          prototype: createAmpElementProtoForTesting(
+              env.win, 'amp-test', TestElement),
         });
         parentEle = env.win.document.createElement('amp-test');
         parentEle.setAttribute('layout', 'nodisplay');
@@ -324,7 +326,8 @@ describes.realWin('extension-analytics', {
           }
                 }
         env.win.document.registerElement('amp-test', {
-          prototype: createAmpElementProto(env.win, 'amp-test', TestElement),
+          prototype: createAmpElementProtoForTesting(
+              env.win, 'amp-test', TestElement),
         });
         parentEle = env.win.document.createElement('amp-test');
         parentEle.setAttribute('layout', 'nodisplay');
@@ -358,7 +361,8 @@ describes.realWin('extension-analytics', {
           }
                 }
         env.win.document.registerElement('amp-test', {
-          prototype: createAmpElementProto(env.win, 'amp-test', TestElement),
+          prototype: createAmpElementProtoForTesting(
+              env.win, 'amp-test', TestElement),
         });
         parentEle = env.win.document.createElement('amp-test');
         parentEle.setAttribute('layout', 'nodisplay');
@@ -407,7 +411,8 @@ describes.realWin('extension-analytics', {
           }
                 }
         env.win.document.registerElement('amp-test', {
-          prototype: createAmpElementProto(env.win, 'amp-test', TestElement),
+          prototype: createAmpElementProtoForTesting(
+              env.win, 'amp-test', TestElement),
         });
         parentEle = env.win.document.createElement('amp-test');
         parentEle.setAttribute('layout', 'nodisplay');

--- a/test/functional/test-extension-analytics.js
+++ b/test/functional/test-extension-analytics.js
@@ -24,7 +24,7 @@ import {
     useAnalyticsInSandbox,
     CustomEventReporterBuilder,
 } from '../../src/extension-analytics';
-import {createAmpElementProtoForTesting} from '../../src/custom-element';
+import {registerElement} from '../../src/service/custom-element-registry';
 import {Services} from '../../src/services';
 import {BaseElement} from '../../src/base-element';
 import {macroTask} from '../../testing/yield';
@@ -172,7 +172,8 @@ describes.realWin('extension-analytics', {
       triggerEventForTarget(nodeOrDoc, eventType, opt_vars) {
         triggerEventSpy(nodeOrDoc, eventType, opt_vars);
       }
-        }
+    }
+
     beforeEach(() => {
       ampdoc = env.ampdoc;
       sandbox = sinon.sandbox.create();
@@ -183,10 +184,7 @@ describes.realWin('extension-analytics', {
             // Force instantiation
       getServiceForDoc(ampdoc, 'amp-analytics-instrumentation');
 
-      env.win.document.registerElement('amp-test', {
-        prototype: createAmpElementProtoForTesting(
-            env.win, 'amp-test', BaseElement),
-      });
+      registerElement(env.win, 'amp-test', BaseElement);
       parentEle = env.win.document.createElement('amp-test');
       parentEle.setAttribute('layout', 'nodisplay');
       env.win.document.body.appendChild(parentEle);
@@ -265,11 +263,8 @@ describes.realWin('extension-analytics', {
           buildCallback() {
             useAnalyticsInSandbox(this.element, promise);
           }
-                }
-        env.win.document.registerElement('amp-test', {
-          prototype: createAmpElementProtoForTesting(
-              env.win, 'amp-test', TestElement),
-        });
+        }
+        registerElement(env.win, 'amp-test', TestElement);
         parentEle = env.win.document.createElement('amp-test');
         parentEle.setAttribute('layout', 'nodisplay');
         env.win.document.body.appendChild(parentEle);
@@ -324,11 +319,8 @@ describes.realWin('extension-analytics', {
             useAnalyticsInSandbox(this.element, promise);
             return super.layoutCallback();
           }
-                }
-        env.win.document.registerElement('amp-test', {
-          prototype: createAmpElementProtoForTesting(
-              env.win, 'amp-test', TestElement),
-        });
+        }
+        registerElement(env.win, 'amp-test', TestElement);
         parentEle = env.win.document.createElement('amp-test');
         parentEle.setAttribute('layout', 'nodisplay');
         env.win.document.body.appendChild(parentEle);
@@ -359,11 +351,8 @@ describes.realWin('extension-analytics', {
           unlayoutCallback() {
             return true;
           }
-                }
-        env.win.document.registerElement('amp-test', {
-          prototype: createAmpElementProtoForTesting(
-              env.win, 'amp-test', TestElement),
-        });
+        }
+        registerElement(env.win, 'amp-test', TestElement);
         parentEle = env.win.document.createElement('amp-test');
         parentEle.setAttribute('layout', 'nodisplay');
         env.win.document.body.appendChild(parentEle);
@@ -409,11 +398,8 @@ describes.realWin('extension-analytics', {
           unlayoutCallback() {
             return true;
           }
-                }
-        env.win.document.registerElement('amp-test', {
-          prototype: createAmpElementProtoForTesting(
-              env.win, 'amp-test', TestElement),
-        });
+        }
+        registerElement(env.win, 'amp-test', TestElement);
         parentEle = env.win.document.createElement('amp-test');
         parentEle.setAttribute('layout', 'nodisplay');
         env.win.document.body.appendChild(parentEle);

--- a/test/functional/test-extensions.js
+++ b/test/functional/test-extensions.js
@@ -34,7 +34,9 @@ import {Services} from '../../src/services';
 import {getServiceForDoc} from '../../src/service';
 import {loadPromise} from '../../src/event-helper';
 import {registerServiceBuilder} from '../../src/service';
-import {resetScheduledElementForTesting} from '../../src/custom-element';
+import {
+  resetScheduledElementForTesting,
+} from '../../src/service/custom-element-registry';
 
 class AmpTest extends BaseElement {}
 class AmpTestSub extends BaseElement {}

--- a/test/functional/test-intersection-observer.js
+++ b/test/functional/test-intersection-observer.js
@@ -19,7 +19,7 @@ import {
   IntersectionObserver,
   getIntersectionChangeEntry,
 } from '../../src/intersection-observer';
-import {createAmpElementProto} from '../../src/custom-element';
+import {createAmpElementProtoForTesting} from '../../src/custom-element';
 import {layoutRectLtwh} from '../../src/layout-rect';
 import * as sinon from 'sinon';
 
@@ -325,7 +325,7 @@ describe('IntersectionObserver', () => {
   }
 
   const ElementClass = document.registerElement('amp-int', {
-    prototype: createAmpElementProto(window, 'amp-int', TestElement),
+    prototype: createAmpElementProtoForTesting(window, 'amp-int', TestElement),
   });
 
   const iframeSrc = 'http://iframe.localhost:' + location.port +

--- a/test/functional/test-layout.js
+++ b/test/functional/test-layout.js
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import {Layout, assertLength, getLengthNumeral, getLengthUnits, parseLength,
+import {Layout, applyStaticLayout,
+    assertLength, getLengthNumeral, getLengthUnits, parseLength,
     parseLayout, assertLengthOrPercent} from '../../src/layout';
-import {applyLayout_} from '../../src/custom-element';
 
 
 describe('Layout', () => {
@@ -155,7 +155,7 @@ describe('Layout', () => {
 
   it('layout=nodisplay', () => {
     div.setAttribute('layout', 'nodisplay');
-    expect(applyLayout_(div)).to.equal(Layout.NODISPLAY);
+    expect(applyStaticLayout(div)).to.equal(Layout.NODISPLAY);
     expect(div.style.width).to.equal('');
     expect(div.style.height).to.equal('');
     expect(div.style.display).to.equal('none');
@@ -169,7 +169,7 @@ describe('Layout', () => {
     div.setAttribute('layout', 'fixed');
     div.setAttribute('width', 100);
     div.setAttribute('height', 200);
-    expect(applyLayout_(div)).to.equal(Layout.FIXED);
+    expect(applyStaticLayout(div)).to.equal(Layout.FIXED);
     expect(div.style.width).to.equal('100px');
     expect(div.style.height).to.equal('200px');
     expect(div).to.have.class('i-amphtml-layout-fixed');
@@ -180,14 +180,14 @@ describe('Layout', () => {
   it('layout=fixed - default with width/height', () => {
     div.setAttribute('width', 100);
     div.setAttribute('height', 200);
-    expect(applyLayout_(div)).to.equal(Layout.FIXED);
+    expect(applyStaticLayout(div)).to.equal(Layout.FIXED);
     expect(div.style.width).to.equal('100px');
     expect(div.style.height).to.equal('200px');
   });
 
   it('layout=fixed - requires width/height', () => {
     div.setAttribute('layout', 'fixed');
-    expect(() => applyLayout_(div)).to.throw(
+    expect(() => applyStaticLayout(div)).to.throw(
         /Expected height to be available/);
   });
 
@@ -195,7 +195,7 @@ describe('Layout', () => {
   it('layout=fixed-height', () => {
     div.setAttribute('layout', 'fixed-height');
     div.setAttribute('height', 200);
-    expect(applyLayout_(div)).to.equal(Layout.FIXED_HEIGHT);
+    expect(applyStaticLayout(div)).to.equal(Layout.FIXED_HEIGHT);
     expect(div.style.width).to.equal('');
     expect(div.style.height).to.equal('200px');
     expect(div).to.have.class('i-amphtml-layout-fixed-height');
@@ -207,7 +207,7 @@ describe('Layout', () => {
     div.setAttribute('layout', 'fixed-height');
     div.setAttribute('height', 200);
     div.setAttribute('width', 'auto');
-    expect(applyLayout_(div)).to.equal(Layout.FIXED_HEIGHT);
+    expect(applyStaticLayout(div)).to.equal(Layout.FIXED_HEIGHT);
     expect(div.style.width).to.equal('');
     expect(div.style.height).to.equal('200px');
     expect(div).to.have.class('i-amphtml-layout-fixed-height');
@@ -220,13 +220,13 @@ describe('Layout', () => {
     div.setAttribute('height', 200);
     div.setAttribute('width', 300);
     expect(function() {
-      applyLayout_(div);
+      applyStaticLayout(div);
     }).to.throw(/Expected width to be either absent or equal "auto"/);
   });
 
   it('layout=fixed-height - default with height', () => {
     div.setAttribute('height', 200);
-    expect(applyLayout_(div)).to.equal(Layout.FIXED_HEIGHT);
+    expect(applyStaticLayout(div)).to.equal(Layout.FIXED_HEIGHT);
     expect(div.style.height).to.equal('200px');
     expect(div.style.width).to.equal('');
   });
@@ -234,14 +234,14 @@ describe('Layout', () => {
   it('layout=fixed-height - default with height and width=auto', () => {
     div.setAttribute('height', 200);
     div.setAttribute('width', 'auto');
-    expect(applyLayout_(div)).to.equal(Layout.FIXED_HEIGHT);
+    expect(applyStaticLayout(div)).to.equal(Layout.FIXED_HEIGHT);
     expect(div.style.height).to.equal('200px');
     expect(div.style.width).to.equal('');
   });
 
   it('layout=fixed-height - requires height', () => {
     div.setAttribute('layout', 'fixed-height');
-    expect(() => applyLayout_(div)).to.throw(
+    expect(() => applyStaticLayout(div)).to.throw(
         /Expected height to be available/);
   });
 
@@ -250,7 +250,7 @@ describe('Layout', () => {
     div.setAttribute('layout', 'responsive');
     div.setAttribute('width', 100);
     div.setAttribute('height', 200);
-    expect(applyLayout_(div)).to.equal(Layout.RESPONSIVE);
+    expect(applyStaticLayout(div)).to.equal(Layout.RESPONSIVE);
     expect(div.style.width).to.equal('');
     expect(div.style.height).to.equal('');
     expect(div).to.have.class('i-amphtml-layout-responsive');
@@ -264,7 +264,7 @@ describe('Layout', () => {
     div.setAttribute('sizes', '50vw');
     div.setAttribute('width', 100);
     div.setAttribute('height', 200);
-    expect(applyLayout_(div)).to.equal(Layout.RESPONSIVE);
+    expect(applyStaticLayout(div)).to.equal(Layout.RESPONSIVE);
     expect(div.style.width).to.equal('');
     expect(div.style.height).to.equal('');
     expect(div).to.have.class('i-amphtml-layout-responsive');
@@ -276,7 +276,7 @@ describe('Layout', () => {
 
   it('layout=fill', () => {
     div.setAttribute('layout', 'fill');
-    expect(applyLayout_(div)).to.equal(Layout.FILL);
+    expect(applyStaticLayout(div)).to.equal(Layout.FILL);
     expect(div.style.width).to.equal('');
     expect(div.style.height).to.equal('');
     expect(div).to.have.class('i-amphtml-layout-fill');
@@ -286,7 +286,7 @@ describe('Layout', () => {
 
   it('layout=container', () => {
     div.setAttribute('layout', 'container');
-    expect(applyLayout_(div)).to.equal(Layout.CONTAINER);
+    expect(applyStaticLayout(div)).to.equal(Layout.CONTAINER);
     expect(div.style.width).to.equal('');
     expect(div.style.height).to.equal('');
     expect(div).to.have.class('i-amphtml-layout-container');
@@ -298,7 +298,7 @@ describe('Layout', () => {
     div.setAttribute('layout', 'flex-item');
     div.setAttribute('width', 100);
     div.setAttribute('height', 200);
-    expect(applyLayout_(div)).to.equal(Layout.FLEX_ITEM);
+    expect(applyStaticLayout(div)).to.equal(Layout.FLEX_ITEM);
     expect(div.style.width).to.equal('100px');
     expect(div.style.height).to.equal('200px');
     expect(div).to.have.class('i-amphtml-layout-flex-item');
@@ -309,14 +309,14 @@ describe('Layout', () => {
   it('layout=unknown', () => {
     div.setAttribute('layout', 'foo');
     expect(function() {
-      applyLayout_(div);
+      applyStaticLayout(div);
     }).to.throw(/Unknown layout: foo/);
   });
 
 
   it('should configure natural dimensions; default layout', () => {
     const pixel = document.createElement('amp-pixel');
-    expect(applyLayout_(pixel)).to.equal(Layout.FIXED);
+    expect(applyStaticLayout(pixel)).to.equal(Layout.FIXED);
     expect(pixel.style.width).to.equal('0px');
     expect(pixel.style.height).to.equal('0px');
   });
@@ -324,7 +324,7 @@ describe('Layout', () => {
   it('should configure natural dimensions; default layout; with width', () => {
     const pixel = document.createElement('amp-pixel');
     pixel.setAttribute('width', '11');
-    expect(applyLayout_(pixel)).to.equal(Layout.FIXED);
+    expect(applyStaticLayout(pixel)).to.equal(Layout.FIXED);
     expect(pixel.style.width).to.equal('11px');
     expect(pixel.style.height).to.equal('0px');
   });
@@ -332,7 +332,7 @@ describe('Layout', () => {
   it('should configure natural dimensions; default layout; with height', () => {
     const pixel = document.createElement('amp-pixel');
     pixel.setAttribute('height', '11');
-    expect(applyLayout_(pixel)).to.equal(Layout.FIXED);
+    expect(applyStaticLayout(pixel)).to.equal(Layout.FIXED);
     expect(pixel.style.width).to.equal('0px');
     expect(pixel.style.height).to.equal('11px');
   });
@@ -340,7 +340,7 @@ describe('Layout', () => {
   it('should configure natural dimensions; layout=fixed', () => {
     const pixel = document.createElement('amp-pixel');
     pixel.setAttribute('layout', 'fixed');
-    expect(applyLayout_(pixel)).to.equal(Layout.FIXED);
+    expect(applyStaticLayout(pixel)).to.equal(Layout.FIXED);
     expect(pixel.style.width).to.equal('0px');
     expect(pixel.style.height).to.equal('0px');
   });
@@ -348,7 +348,7 @@ describe('Layout', () => {
   it('should configure natural dimensions; layout=fixed-height', () => {
     const pixel = document.createElement('amp-pixel');
     pixel.setAttribute('layout', 'fixed-height');
-    expect(applyLayout_(pixel)).to.equal(Layout.FIXED_HEIGHT);
+    expect(applyStaticLayout(pixel)).to.equal(Layout.FIXED_HEIGHT);
     expect(pixel.style.height).to.equal('0px');
     expect(pixel.style.width).to.equal('');
   });
@@ -360,26 +360,26 @@ describe('Layout', () => {
     pixel.setAttribute('width', '1px');
     pixel.setAttribute('height', '1px');
     expect(() => {
-      applyLayout_(pixel);
+      applyStaticLayout(pixel);
     }).to.not.throw();
 
     // Width=auto is also correct.
     pixel.setAttribute('width', 'auto');
     expect(() => {
-      applyLayout_(pixel);
+      applyStaticLayout(pixel);
     }).to.not.throw();
 
     // Width=X is invalid.
     pixel.setAttribute('width', 'X');
     expect(() => {
-      applyLayout_(pixel);
+      applyStaticLayout(pixel);
     }).to.throw(/Invalid width value/);
 
     // Height=X is invalid.
     pixel.setAttribute('height', 'X');
     pixel.setAttribute('width', '1px');
     expect(() => {
-      applyLayout_(pixel);
+      applyStaticLayout(pixel);
     }).to.throw(/Invalid height value/);
   });
 
@@ -391,7 +391,7 @@ describe('Layout', () => {
     div.className = 'other';
     div.style.width = '111px';
     div.style.height = '112px';
-    expect(applyLayout_(div)).to.equal(Layout.FLEX_ITEM);
+    expect(applyStaticLayout(div)).to.equal(Layout.FLEX_ITEM);
     // No other attributes are read or changed.
     expect(div.style.width).to.equal('111px');
     expect(div.style.height).to.equal('112px');
@@ -404,26 +404,26 @@ describe('Layout', () => {
     div.setAttribute('i-amphtml-layout', 'responsive');
     const sizer = document.createElement('i-amphtml-sizer');
     div.appendChild(sizer);
-    expect(applyLayout_(div)).to.equal(Layout.RESPONSIVE);
-    expect(div.sizerElement_).to.equal(sizer);
+    expect(applyStaticLayout(div)).to.equal(Layout.RESPONSIVE);
+    expect(div.sizerElement).to.equal(sizer);
   });
 
   it('should allow sizer to be missing', () => {
     div.setAttribute('i-amphtml-layout', 'responsive');
-    expect(applyLayout_(div)).to.equal(Layout.RESPONSIVE);
-    expect(div.sizerElement_).to.be.undefined;
+    expect(applyStaticLayout(div)).to.equal(Layout.RESPONSIVE);
+    expect(div.sizerElement).to.be.undefined;
   });
 
   it('should allow sizer to be missing even if other children there', () => {
     div.setAttribute('i-amphtml-layout', 'responsive');
     const other = document.createElement('div');
     div.appendChild(other);
-    expect(applyLayout_(div)).to.equal(Layout.RESPONSIVE);
-    expect(div.sizerElement_).to.be.undefined;
+    expect(applyStaticLayout(div)).to.equal(Layout.RESPONSIVE);
+    expect(div.sizerElement).to.be.undefined;
   });
 
   it('should fail when server generates invalid layout', () => {
     div.setAttribute('i-amphtml-layout', 'invalid');
-    expect(() => applyLayout_(div)).to.throw(/failed/);
+    expect(() => applyStaticLayout(div)).to.throw(/failed/);
   });
 });

--- a/test/functional/test-url-replacements.js
+++ b/test/functional/test-url-replacements.js
@@ -21,7 +21,7 @@ import {user} from '../../src/log';
 import {
   markElementScheduledForTesting,
   resetScheduledElementForTesting,
-} from '../../src/custom-element';
+} from '../../src/service/custom-element-registry';
 import {cidServiceForDocForTesting} from
     '../../src/service/cid-impl';
 import {installCryptoService} from '../../src/service/crypto-impl';

--- a/testing/describes.js
+++ b/testing/describes.js
@@ -103,14 +103,16 @@ import {createElementWithAttributes} from '../src/dom';
 import {addParamsToUrl} from '../src/url';
 import {cssText} from '../build/css';
 import {CSS} from '../build/amp-ad-0.1.css.js';
-import {createAmpElementProto} from '../src/custom-element';
+import {createAmpElementProtoForTesting} from '../src/custom-element';
 import {installDocService} from '../src/service/ampdoc-impl';
 import {
   installBuiltinElements,
   installExtensionsService,
   registerExtension,
 } from '../src/service/extensions-impl';
-import {resetScheduledElementForTesting} from '../src/custom-element';
+import {
+  resetScheduledElementForTesting,
+} from '../src/service/custom-element-registry';
 import {setStyles} from '../src/style';
 import * as sinon from 'sinon';
 
@@ -862,7 +864,7 @@ function installAmpAdStylesPromise(win) {
 function createAmpElement(win, opt_name, opt_implementationClass) {
   // Create prototype and constructor.
   const name = opt_name || 'amp-element';
-  const proto = createAmpElementProto(win, name);
+  const proto = createAmpElementProtoForTesting(win, name);
   const ctor = function() {
     const el = win.document.createElement(name);
     el.__proto__ = proto;


### PR DESCRIPTION
This is a straightforward split of the old `custom-element.js` into three modules: class definition, registry and static layout.

Partial for #10866.
