### PR TITLE
Amp-ad Fast Fetch: preload fonts for valid AMP creatives

### DIFF
--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -735,6 +735,9 @@ export class AmpA4A extends AMP.BaseElement {
           const extensions = Services.extensionsFor(this.win);
           creativeMetaDataDef.customElementExtensions.forEach(
               extensionId => extensions.preloadExtension(extensionId));
+          // Preload any fonts.
+          (creativeMetaDataDef.customStylesheets || []).forEach(font =>
+              this.preconnect.preload(font.href));
           return creativeMetaDataDef;
         })
         .catch(error => {

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -885,7 +885,7 @@ describe('amp-a4a', () => {
           expect(preloadExtensionSpy.withArgs('amp-font')).to.be.calledOnce;
           expect(doc.querySelector('link[rel=preload]' +
             '[href="https://fonts.googleapis.com/css?family=Questrial"]'))
-            .to.be.ok;
+              .to.be.ok;
           return a4a.layoutCallback().then(() => {
             expect(renderAmpCreativeSpy.calledOnce,
                 'renderAmpCreative_ called exactly once').to.be.true;

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -883,6 +883,9 @@ describe('amp-a4a', () => {
               .to.be.true;
           expect(fetchMock.called('ad')).to.be.true;
           expect(preloadExtensionSpy.withArgs('amp-font')).to.be.calledOnce;
+          expect(doc.querySelector('link[rel=preload]' +
+            '[href="https://fonts.googleapis.com/css?family=Questrial"]'))
+            .to.be.ok;
           return a4a.layoutCallback().then(() => {
             expect(renderAmpCreativeSpy.calledOnce,
                 'renderAmpCreative_ called exactly once').to.be.true;


### PR DESCRIPTION
Post creative AMP validation, preload any fonts to ensure they are available as soon as possible.  This is already done for any creative AMP extensions.

/cc @ampproject/a4a 