### PR TITLE
Add amp-state to variable substitution table

### DIFF
--- a/spec/amp-var-substitutions.md
+++ b/spec/amp-var-substitutions.md
@@ -58,6 +58,12 @@ The following table lists the features that enable variable substitutions, as we
     <td width="25%">None</td>
   </tr>
   <tr>
+    <td width="25%"><code>amp-state</code><br><a href="https://github.com/ampproject/amphtml/blob/master/extensions/amp-bind/amp-bind.md#attributes">Detailed documentation</a></td>
+    <td width="25%">Requests must be HTTPS URLs (not a requirement specific to variable substitutions)</td>
+    <td width="25%">No</td>
+    <td width="25%">None</td>
+  </tr>
+  <tr>
     <td width="25%">Links (<code>&lt;a&gt;</code>)</td>
     <td width="25%">
       HTTPS URL and URL matching either:


### PR DESCRIPTION
According to the amp-state documentation:

"The src attribute allows all standard URL variable substitutions."

https://github.com/ampproject/amphtml/blob/master/extensions/amp-bind/amp-bind.md#attributes