### PR TITLE
Add SMI2 amp-embed

### DIFF
--- a/3p/integration.js
+++ b/3p/integration.js
@@ -166,6 +166,7 @@ import {sklik} from '../ads/sklik';
 import {slimcutmedia} from '../ads/slimcutmedia';
 import {smartadserver} from '../ads/smartadserver';
 import {smartclip} from '../ads/smartclip';
+import {smi2} from '../ads/smi2';
 import {sortable} from '../ads/sortable';
 import {sogouad} from '../ads/sogouad';
 import {sovrn} from '../ads/sovrn';
@@ -206,6 +207,7 @@ const AMP_EMBED_ALLOWED = {
   outbrain: true,
   plista: true,
   smartclip: true,
+  smi2: true,
   taboola: true,
   zergnet: true,
 };
@@ -333,6 +335,7 @@ register('sklik', sklik);
 register('slimcutmedia', slimcutmedia);
 register('smartadserver', smartadserver);
 register('smartclip', smartclip);
+register('smi2', smi2);
 register('sortable', sortable);
 register('sogouad', sogouad);
 register('sovrn', sovrn);

--- a/ads/_config.js
+++ b/ads/_config.js
@@ -641,10 +641,6 @@ export const adConfig = {
   },
 
   smi2: {
-    preconnect: [
-      'https://smi2.ru',
-      'https://amp.smi2.ru',
-    ],
     renderStartImplemented: true,
   },
 

--- a/ads/_config.js
+++ b/ads/_config.js
@@ -640,16 +640,16 @@ export const adConfig = {
     renderStartImplemented: true,
   },
 
-  sogouad: {
-    prefetch: 'https://theta.sogoucdn.com/wap/js/aw.js',
-    renderStartImplemented: true,
-  },
-
   smi2: {
     preconnect: [
       'https://smi2.ru',
       'https://amp.smi2.ru',
     ],
+    renderStartImplemented: true,
+  },
+
+  sogouad: {
+    prefetch: 'https://theta.sogoucdn.com/wap/js/aw.js',
     renderStartImplemented: true,
   },
 

--- a/ads/_config.js
+++ b/ads/_config.js
@@ -645,6 +645,14 @@ export const adConfig = {
     renderStartImplemented: true,
   },
 
+  smi2: {
+    preconnect: [
+      'https://smi2.ru',
+      'https://amp.smi2.ru',
+    ],
+    renderStartImplemented: true,
+  },
+
   sortable: {
     prefetch: 'https://www.googletagservices.com/tag/js/gpt.js',
     preconnect: [

--- a/ads/smi2.js
+++ b/ads/smi2.js
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {loadScript, validateData} from '../3p/3p';
+
+/**
+ * @param {!Window} global
+ * @param {!Object} data
+ */
+
+export function smi2(global, data) {
+  validateData(data, ['blockid']);
+  (global._smi2 = global._smi2 || {
+    viewId: global.context.pageViewId,
+    blockId: data['blockid'],
+    htmlURL: data['canonical'] || global.context.canonicalUrl,
+    ampURL: data['ampurl'] || global.context.sourceUrl,
+    testMode: data['testmode'] || 'false',
+    referrer: data['referrer'] || global.context.referrer,
+    hostname: global.window.context.location.hostname,
+    clientId: window.context.clientId,
+    domFingerprint: window.context.domFingerprint,
+    location: window.context.location,
+    startTime: window.context.startTime,
+
+  });
+  global._smi2.AMPCallbacks = {
+    renderStart: global.context.renderStart,
+    noContentAvailable: global.context.noContentAvailable,
+  };
+  // load the smi2  AMP JS file script asynchronously
+  const rand = Math.round(Math.random() * 100000000);
+  loadScript(global, 'https://amp.smi2.ru/ampclient/ampfecth.js?rand=' + rand, () => {},
+      global.context.noContentAvailable);
+}

--- a/ads/smi2.md
+++ b/ads/smi2.md
@@ -1,0 +1,39 @@
+<!---
+Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS-IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Smi2
+
+SMI2 is a service for personalizing content network.
+
+Please visit our [website](https://smi2.net) for more information about us.
+
+## Examples
+
+```html
+  <amp-embed height="284"
+          type="smi2"
+          data-blockid="90223">
+  </amp-embed>
+
+```
+
+## Configuration
+
+height and
+
+Required parameters:
+
+- `data-blockid` - insert your block_id 

--- a/examples/ads.amp.html
+++ b/examples/ads.amp.html
@@ -164,8 +164,8 @@
         <option>slimcutmedia</option>
         <option>smartadserver</option>
         <option>smartclip</option>
-        <option>sogouad</option>
         <option>smi2</option>
+        <option>sogouad</option>
         <option>sortable</option>
         <option>sovrn</option>
         <option>spotx</option>
@@ -1214,6 +1214,12 @@
       data-sz="400x320">
   </amp-ad>
 
+  <h2>SMI2</h2>
+  <amp-embed height="284"
+             type="smi2"
+             data-blockid="90223">
+  </amp-embed>
+
   <h2>sogou ad</h2>
   <amp-ad width="20" height="3"
       type="sogouad"
@@ -1230,12 +1236,6 @@
       data-w="100%"
       data-h="69">
   </amp-ad>
-
-  <h2>SMI2</h2>
-  <amp-embed height="284"
-          type="smi2"
-          data-blockid="90223">
-  </amp-embed>
 
   <h2>Sortable ad</h2>
   <amp-ad width="300" height="250"

--- a/examples/ads.amp.html
+++ b/examples/ads.amp.html
@@ -165,6 +165,7 @@
         <option>smartadserver</option>
         <option>smartclip</option>
         <option>sogouad</option>
+        <option>smi2</option>
         <option>sortable</option>
         <option>sovrn</option>
         <option>spotx</option>
@@ -1229,6 +1230,12 @@
       data-w="100%"
       data-h="69">
   </amp-ad>
+
+  <h2>SMI2</h2>
+  <amp-embed height="284"
+          type="smi2"
+          data-blockid="90223">
+  </amp-embed>
 
   <h2>Sortable ad</h2>
   <amp-ad width="300" height="250"

--- a/extensions/amp-ad/amp-ad.md
+++ b/extensions/amp-ad/amp-ad.md
@@ -317,5 +317,6 @@ See [amp-ad rules](https://github.com/ampproject/amphtml/blob/master/extensions/
 - [Dable](../../ads/dable.md)
 - [Engageya](../../ads/engageya.md)
 - [Outbrain](../../ads/outbrain.md)
+- [Smi2](../../ads/smi2.md)
 - [Taboola](../../ads/taboola.md)
 - [ZergNet](../../ads/zergnet.md)


### PR DESCRIPTION
# Overview
Provides support for amp-embed  type=smi2
It will be widget with content recommendations for User.
Project site https://smi2.net/

Smi2 is a service for personalizing content and increasing user metrics in Russian network.
Smi2 is a free platform used by web publishers to improve metrics and audience loyalty.
Our network like Outbrain & Taboola in Russia.

# Example horizontal block

![ampblocksmi2](https://user-images.githubusercontent.com/1861412/30261605-1ff50e4a-96d6-11e7-8b1d-eb6c6bc9fbf9.png)


# Usage

``` 
<amp-embed height="284"
       type="smi2"
        data-blockid="90223">
</amp-embed>
```
