### PR TITLE
Adds "Fluid" layout.

### DIFF
--- a/src/layout.js
+++ b/src/layout.js
@@ -36,6 +36,7 @@ export const Layout = {
   CONTAINER: 'container',
   FILL: 'fill',
   FLEX_ITEM: 'flex-item',
+  FLUID: 'fluid',
 };
 
 
@@ -130,7 +131,8 @@ export function isLayoutSizeDefined(layout) {
       layout == Layout.FIXED_HEIGHT ||
       layout == Layout.RESPONSIVE ||
       layout == Layout.FILL ||
-      layout == Layout.FLEX_ITEM);
+      layout == Layout.FLEX_ITEM ||
+      layout == Layout.FLUID);
 }
 
 
@@ -333,7 +335,8 @@ export function applyStaticLayout(element) {
   const inputWidth = (widthAttr && widthAttr != 'auto') ?
       parseLength(widthAttr) : widthAttr;
   user().assert(inputWidth !== undefined, 'Invalid width value: %s', widthAttr);
-  const inputHeight = heightAttr ? parseLength(heightAttr) : null;
+  const inputHeight = (heightAttr && heightAttr != 'fluid') ?
+      parseLength(heightAttr) : heightAttr;
   user().assert(inputHeight !== undefined, 'Invalid height value: %s',
       heightAttr);
 
@@ -362,6 +365,8 @@ export function applyStaticLayout(element) {
     layout = inputLayout;
   } else if (!width && !height) {
     layout = Layout.CONTAINER;
+  } else if (height == 'fluid') {
+    layout = Layout.FLUID;
   } else if (height && (!width || width == 'auto')) {
     layout = Layout.FIXED_HEIGHT;
   } else if (height && width && (sizesAttr || heightsAttr)) {
@@ -434,6 +439,9 @@ export function applyStaticLayout(element) {
     if (height) {
       setStyle(element, 'height', height);
     }
+  } else if (layout == Layout.FLUID) {
+    element.classList.add('i-amphtml-layout-awaiting-size');
+    setStyle(element, 'width', width ? width : '100%');
   }
   return layout;
 }

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -562,7 +562,7 @@ export class Resource {
    * @return {boolean}
    */
   isDisplayed() {
-    return (this.layoutBox_.height > 0 && this.layoutBox_.width > 0 &&
+    return (this.layoutBox_.height > 0 || this.layoutBox_.width > 0 &&
         !!this.element.ownerDocument &&
         !!this.element.ownerDocument.defaultView);
   }

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -562,9 +562,9 @@ export class Resource {
    * @return {boolean}
    */
   isDisplayed() {
-    return (this.layoutBox_.height > 0 || this.layoutBox_.width > 0 &&
+    return (this.layoutBox_.height > 0 || this.layoutBox_.width > 0) &&
         !!this.element.ownerDocument &&
-        !!this.element.ownerDocument.defaultView);
+        !!this.element.ownerDocument.defaultView;
   }
 
   /**

--- a/test/functional/test-layout.js
+++ b/test/functional/test-layout.js
@@ -33,6 +33,7 @@ describe('Layout', () => {
     expect(parseLayout('responsive')).to.equal('responsive');
     expect(parseLayout('container')).to.equal('container');
     expect(parseLayout('fill')).to.equal('fill');
+    expect(parseLayout('fluid')).to.equal('fluid');
   });
 
   it('parseLayout - failure', () => {
@@ -303,6 +304,23 @@ describe('Layout', () => {
     expect(div.style.height).to.equal('200px');
     expect(div).to.have.class('i-amphtml-layout-flex-item');
     expect(div).to.have.class('i-amphtml-layout-size-defined');
+    expect(div.children.length).to.equal(0);
+  });
+
+  it('layout=fluid - default', () => {
+    div.setAttribute('height', 'fluid');
+    expect(applyStaticLayout(div)).to.equal(Layout.FLUID);
+    expect(div).to.have.class('i-amphtml-layout-awaiting-size');
+    expect(div.style.width).to.equal('100%');
+    expect(div.children.length).to.equal(0);
+  });
+
+  it('layout=fluid - default with width', () => {
+    div.setAttribute('height', 'fluid');
+    div.setAttribute('width', 300);
+    expect(applyStaticLayout(div)).to.equal(Layout.FLUID);
+    expect(div).to.have.class('i-amphtml-layout-awaiting-size');
+    expect(div.style.width).to.equal('300px');
     expect(div.children.length).to.equal(0);
   });
 

--- a/test/functional/test-resource.js
+++ b/test/functional/test-resource.js
@@ -549,6 +549,23 @@ describe('Resource', () => {
     });
   });
 
+  it('should complete startLayout with height == 0', () => {
+    elementMock.expects('layoutCallback').returns(Promise.resolve()).once();
+
+    resource.state_ = ResourceState.READY_FOR_LAYOUT;
+    resource.layoutBox_ = {left: 11, top: 12, width: 10, height: 0};
+    const loaded = resource.loadedOnce();
+    const promise = resource.startLayout();
+    expect(resource.layoutPromise_).to.not.equal(null);
+    expect(resource.getState()).to.equal(ResourceState.LAYOUT_SCHEDULED);
+
+    return promise.then(() => {
+      expect(resource.getState()).to.equal(ResourceState.LAYOUT_COMPLETE);
+      expect(resource.layoutPromise_).to.equal(null);
+      return loaded;
+    });
+  });
+
   it('should fail startLayout', () => {
     const error = new Error('intentional');
     elementMock.expects('layoutCallback')


### PR DESCRIPTION
Element must have height="fluid" in order for this layout to be inferred.  This change is required to support AMP Fluid ads (issue #11198).

One thing to consider (up to reviewers):
- Should applyStaticLayout enforce the restriction that only amp-ad elements can have a Fluid layout?