### PR TITLE
Again, cut the time we wait for a font stylesheet to load in half.

### DIFF
--- a/src/font-stylesheet-timeout.js
+++ b/src/font-stylesheet-timeout.js
@@ -27,14 +27,9 @@ import {isExperimentOn} from './experiments';
  * even though all they do is reference fonts.
  *
  * For that reasons this function identifies (or rather infers) font
- * stylesheets that have not downloaded within 1 second of the page
+ * stylesheets that have not downloaded within timeout period of the page
  * response starting and reinserts equivalent link tags  dynamically. This
  * removes their page-render-blocking nature and lets the doc render.
- *
- * 1 second was picked, because the font-stylesheets are typically
- * tiny. If a connection wasn't able to deliver them within 1s
- * of page load start, then it is unlikely that it will be able
- * to download the font itself within 3s.
  *
  * @param {!Window} win
  */

--- a/src/font-stylesheet-timeout.js
+++ b/src/font-stylesheet-timeout.js
@@ -55,7 +55,7 @@ function maybeTimeoutFonts(win) {
   if (perf && perf.timing && perf.timing.responseStart) {
     timeSinceResponseStart = Date.now() - perf.timing.responseStart;
   }
-  const timeout = Math.max(1, 500 - timeSinceResponseStart);
+  const timeout = Math.max(1, 250 - timeSinceResponseStart);
 
   // Avoid timer dependency since this runs very early in execution.
   win.setTimeout(() => {

--- a/test/functional/test-font-stylesheet-timeout.js
+++ b/test/functional/test-font-stylesheet-timeout.js
@@ -71,7 +71,7 @@ describes.realWin('font-stylesheet-timeout', {
   it('should time out if style sheets do not load', () => {
     const link = addLink(undefined, '/does-not-exist.css');
     fontStylesheetTimeout(win);
-    clock.tick(499);
+    clock.tick(249);
     expect(win.document.querySelectorAll(
         'link[rel="stylesheet"][i-amphtml-timeout]')).to.have.length(0);
     clock.tick(1);
@@ -94,7 +94,7 @@ describes.realWin('font-stylesheet-timeout', {
 
   it('should time out from response start', () => {
     responseStart = 200;
-    clock.tick(500);
+    clock.tick(250);
     const link = addLink(undefined, '/does-not-exist.css');
     fontStylesheetTimeout(win);
     clock.tick(199);


### PR DESCRIPTION
With this change timeouts may become more common, with faster loads for more people.

See also #11163