### PR TITLE
Refactor myWidget ad extension

### DIFF
--- a/ads/_config.js
+++ b/ads/_config.js
@@ -505,7 +505,7 @@ export const adConfig = {
 
   mywidget: {
     preconnect: 'https://likemore-fe.go.mail.ru',
-    prefetch: 'https://likemore-go.imgsmail.ru/widget.amp.js',
+    prefetch: 'https://likemore-go.imgsmail.ru/widget_amp.js',
     renderStartImplemented: true,
   },
 

--- a/ads/mywidget.js
+++ b/ads/mywidget.js
@@ -22,57 +22,8 @@ import {loadScript, validateData} from '../3p/3p';
  */
 export function mywidget(global, data) {
   validateData(data, ['cid']);
-
-  let isReady = false;
-
-  /**
-   * `data.height` can be not a number (`undefined`, if attribute is not set,
-   * for example), that's why condition is not `data.height < 0`
-   */
-  if (!(data.height >= 0)) {
-    return;
-  }
-
-  global.myWidget = {
-    params: {
-      cid: data.cid,
-      container: 'c',
-    },
-
-    renderStart: global.context.renderStart,
-    noContentAvailable: global.context.noContentAvailable,
-
-    /**
-     * @param {{firstIntersectionCallback:function()}} opts
-     */
-    ready(opts) {
-      // Make sure ready() is called only once.
-      if (isReady) {
-        return;
-      } else {
-        isReady = true;
-      }
-
-      if (!opts || !opts.firstIntersectionCallback) {
-        return;
-      }
-
-      /**
-       * Widget want to be informed, when it gets into viewport, so we start
-       * to listen when it happens for the first time.
-       */
-      const unlisten = global.context.observeIntersection(changes => {
-        changes.forEach(c => {
-          if (c.intersectionRect.height) {
-            opts.firstIntersectionCallback();
-            unlisten();
-          }
-        });
-      });
-    },
-  };
+  global.myWidgetInit = data;
 
   // load the myWidget initializer asynchronously
-  loadScript(global, 'https://likemore-go.imgsmail.ru/widget.amp.js', () => {},
-      global.context.noContentAvailable);
+  loadScript(global, 'https://likemore-go.imgsmail.ru/widget_amp.js');
 }

--- a/ads/mywidget.md
+++ b/ads/mywidget.md
@@ -29,12 +29,14 @@ Please visit our [website](https://widget.my.com) for more information about us.
 ```html
 <amp-embed height="250"
       type="mywidget"
-      data-cid="your_campaign_id">
-  <div placeholder>Loading myWidget recommendations.</div>
-  <div fallback>No recommendations for you.</div>
+      data-cid="your-campaign-id">
 </amp-embed>
 ```
 
+## Configuration
+
+For semantics of configuration, please see [ad network documentation](https://widget.my.com/docs/dev/amp/).
+
 Required parameters:
 
-- `data-cid`
+- data-cid


### PR DESCRIPTION
# Refactor myWidget ad extension.

- Changes location of external script to `https://likemore-go.imgsmail.ru/widget_amp.js`.
- This new external script calls `renderStart`, `noContentAvailable` and `observeIntersections` inside itself, so ad extension only passes the data to it.
- Adds a link to myWidget AMP documentation in extension description.
- Removes `fallback` and `placeholder` from basic example, because they are advanced features and not needed by default.

Closes #11255
