### PR TITLE
Fix having multiple Criteo standalone ads on one page

### DIFF
--- a/ads/criteo.js
+++ b/ads/criteo.js
@@ -41,11 +41,9 @@ export function criteo(global, data) {
       }, () => {});
       setTargeting(global, data, null);
     } else if (data.tagtype === 'standalone') {
-      computeInMasterFrame(window, 'call-standalone', resultCallback => {
-        Criteo.PubTag.Adapters.AMP.Standalone(data, resultCallback, targ => {
-          setTargeting(global, data, targ);
-        });
-      }, () => {});
+      Criteo.PubTag.Adapters.AMP.Standalone(data, () => {}, targ => {
+        setTargeting(global, data, targ);
+      });
     } else if (!data.tagtype || data.tagtype === 'passback') {
       Criteo.DisplayAd({
         zoneid: data.zone,


### PR DESCRIPTION
# Ads: Fix having multiple Criteo standalone ads

The usage of `computeInMasterFrame` for Criteo standalone was removed.

Not only forcing the bidding to happen on the master frame was unnecessary, it also meant that only one standalone frame would get its bid request sent (and its display done, indirectly).