### PR TITLE
Fail travis on master when there are visual diffs

### DIFF
--- a/build-system/tasks/visual-diff.rb
+++ b/build-system/tasks/visual-diff.rb
@@ -167,18 +167,22 @@ def verifyBuildStatus(status, buildId)
     raise "Percy build not processed after #{BUILD_PROCESSING_TIMEOUT_SECS}s"
   end
   if status['total_comparisons_diff'] != 0
-    branches = ['release', 'canary', 'amp-release']
+    branches = ['master', 'release', 'canary', 'amp-release']
     if branches.any? { |branch| status['branch'].include? branch }
-      # If there are visual diffs on a release branch, fail Travis.
+      # If there are visual diffs on master or a release branch, fail Travis.
       raise "Found visual diffs in branch #{status['branch']}."
     else
-      # For master and PR branches, just print a warning, since the diff may be
-      # intentional.
+      # For PR branches, just print a warning since the diff may be intentional,
+      # with instructions for how to approve the new snapshots so they are used
+      # as the baseline for future visual diff builds.
       log('warning',
           'Percy build ' + cyan("#{buildId}") + ' contains visual diffs.')
       log('warning',
-          'If the diffs are intentional, you must approve the snapshots at ' +
-          cyan("#{PERCY_BUILD_URL}/#{buildId}"))
+          'If they are intentional, you must first approve the build at' +
+          cyan("#{PERCY_BUILD_URL}/#{buildId}") +
+          ' to allow your PR to be merged, and then approve the build at ' +
+          cyan("#{PERCY_BUILD_URL}") +
+          ' from when your PR is merged to the master branch.')
     end
   else
     log('info',

--- a/build-system/tasks/visual-diff.rb
+++ b/build-system/tasks/visual-diff.rb
@@ -178,11 +178,13 @@ def verifyBuildStatus(status, buildId)
       log('warning',
           'Percy build ' + cyan("#{buildId}") + ' contains visual diffs.')
       log('warning',
-          'If they are intentional, you must first approve the build at' +
+          'If they are intentional, you must first approve the build at ' +
           cyan("#{PERCY_BUILD_URL}/#{buildId}") +
-          ' to allow your PR to be merged, and then approve the build at ' +
-          cyan("#{PERCY_BUILD_URL}") +
-          ' from when your PR is merged to the master branch.')
+          ' to allow your PR to be merged.')
+      log('warning',
+          'You must then wait for your merged PR to be tested on master, and ' +
+          'approve the next "master" build at ' + cyan("#{PERCY_BUILD_URL}") +
+          ' in order to update the visual diff baseline snapshots.')
     end
   else
     log('info',

--- a/examples/visual-tests/amp-by-example/amp-by-example.html
+++ b/examples/visual-tests/amp-by-example/amp-by-example.html
@@ -314,7 +314,7 @@
   <!-- End Sidebar -->
   <!-- End Navbar -->
         <header class="www-header">
-      <h1 class="mb4 px2 col-12 sm-col-8 mx-auto">Lean AMP by Example</h1>
+      <h1 class="mb4 px2 col-12 sm-col-8 mx-auto">Learn AMP by Example</h1>
       <span class="h3 block mb4 px2 col-12 sm-col-8 mx-auto">AMP by Example gives a hands-on introduction to Accelerated Mobile Pages based on code and live samples. <span class="xs-hide sm-hide">Learn how to create web pages with AMP and how to effectively use AMP components.</span></span>
     </header>
   <amp-selector layout="container">

--- a/examples/visual-tests/amp-by-example/amp-by-example.html
+++ b/examples/visual-tests/amp-by-example/amp-by-example.html
@@ -314,7 +314,7 @@
   <!-- End Sidebar -->
   <!-- End Navbar -->
         <header class="www-header">
-      <h1 class="mb4 px2 col-12 sm-col-8 mx-auto">Learn AMP by Example</h1>
+      <h1 class="mb4 px2 col-12 sm-col-8 mx-auto">Lean AMP by Example</h1>
       <span class="h3 block mb4 px2 col-12 sm-col-8 mx-auto">AMP by Example gives a hands-on introduction to Accelerated Mobile Pages based on code and live samples. <span class="xs-hide sm-hide">Learn how to create web pages with AMP and how to effectively use AMP components.</span></span>
     </header>
   <amp-selector layout="container">


### PR DESCRIPTION
This will alert us to the fact that there are new visual changes that must be manually approved on Percy so that the diff baselines are updated.

Fixes #10536