### PR TITLE
Enable amp-ad-exit to receive response from amp-analytics 3p vendor iframe

### DIFF
--- a/3p/iframe-transport-client.js
+++ b/3p/iframe-transport-client.js
@@ -61,7 +61,7 @@ export class IframeTransportClient {
           events.forEach(event => {
             try {
               this.listener_ &&
-                  this.listener_(event.message, event.transportId);
+                  this.listener_(event.message, event.creativeId);
             } catch (e) {
               user().error(TAG_,
                   'Exception in callback passed to onAnalyticsEvent: ' +

--- a/3p/iframe-transport-client.js
+++ b/3p/iframe-transport-client.js
@@ -24,7 +24,7 @@ const TAG_ = 'iframe-transport-client';
 
 /**
  * Receives event messages bound for this cross-domain iframe, from all
- * creatives
+ * creatives.
  */
 export class IframeTransportClient {
 
@@ -49,7 +49,7 @@ export class IframeTransportClient {
           const events =
               /**
                * @type
-               * {!Array<../src/3p-frame-messaging.IframeTransportEvent>}
+               *   {!Array<../src/3p-frame-messaging.IframeTransportEvent>}
                */
               (eventData['events']);
           user().assert(events,
@@ -83,7 +83,7 @@ export class IframeTransportClient {
   }
 
   /**
-   * Gets the IframeMessagingClient
+   * Gets the IframeMessagingClient.
    * @returns {!IframeMessagingClient}
    * @VisibleForTesting
    */

--- a/examples/analytics-iframe-transport.amp.html
+++ b/examples/analytics-iframe-transport.amp.html
@@ -13,7 +13,7 @@
 </head>
 <body>
   Here is some text above the ad.<br/>
-  <amp-ad width="300" height="400"
+  <amp-ad width="600" height="530"
           type="fake"
           src="fake_amp_ad_with_iframe_transport.html"
           data-use-a4a="true" fakesig="true">

--- a/extensions/amp-ad-exit/0.1/amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/amp-ad-exit.js
@@ -66,7 +66,7 @@ export class AmpAdExit extends AMP.BaseElement {
 
     this.registerAction('exit', this.exit.bind(this));
 
-    /** @private @const {!Object<string, Object<string, string>} */
+    /** @private @const {!Object<string, Object<string, string>>} */
     this.vendorResponses_ = {};
 
     try {
@@ -79,10 +79,10 @@ export class AmpAdExit extends AMP.BaseElement {
 
     this.unlisten_ = listen(this.getAmpDoc().win, 'message', event => {
       const responseMessage = deserializeMessage(getData(event));
-      if (!responseMessage || !responseMessage.type ||
-          responseMessage.type != MessageType.IFRAME_TRANSPORT_RESPONSE ||
-          !responseMessage.creativeId ||
-          responseMessage.creativeId != this.ampAdResourceId_) {
+      if (!responseMessage || !responseMessage['type'] ||
+          responseMessage['type'] != MessageType.IFRAME_TRANSPORT_RESPONSE ||
+          !responseMessage['creativeId'] ||
+          responseMessage['creativeId'] != this.ampAdResourceId_) {
         return;
       }
 
@@ -95,7 +95,7 @@ export class AmpAdExit extends AMP.BaseElement {
       assertOriginMatchesVendor(event.origin, vendor);
 
       this.vendorResponses_[vendor] = responseMessage['message'];
-    }, false);
+    });
   }
 
   /** @override */

--- a/extensions/amp-ad-exit/0.1/amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/amp-ad-exit.js
@@ -147,15 +147,15 @@ export class AmpAdExit extends AMP.BaseElement {
              */
             substitutionFunctions[customVarName] = () => {
               if ('iframeTransportSignal' in customVar) {
-                const vendorResponse = replacements.expandStringSync(
-                  customVar.iframeTransportSignal, {
-                    'IFRAME_TRANSPORT_SIGNAL': (vendor, responseKey) => {
-                      const vendorResponses = this.vendorResponses_[vendor];
-                      if (vendorResponses && responseKey in vendorResponses) {
-                        return vendorResponses[responseKey];
-                      }
-                    }
-                  });
+                const vendorResponse = replacements./*OK*/expandStringSync(
+                    customVar.iframeTransportSignal, {
+                      'IFRAME_TRANSPORT_SIGNAL': (vendor, responseKey) => {
+                        const vendorResponses = this.vendorResponses_[vendor];
+                        if (vendorResponses && responseKey in vendorResponses) {
+                          return vendorResponses[responseKey];
+                        }
+                      },
+                    });
                 if (vendorResponse != '') {
                   // Caveat: If the vendor's response *is* the empty string,
                   // then this will cause the arg/default value to be returned.

--- a/extensions/amp-ad-exit/0.1/amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/amp-ad-exit.js
@@ -122,7 +122,7 @@ export class AmpAdExit extends AMP.BaseElement {
       for (const customVarName in target.vars) {
         if (customVarName[0] == '_') {
           const customVar =
-              /** @type {./config.Variable} */ (target.vars[customVarName]);
+              /** @type {!./config.Variable} */ (target.vars[customVarName]);
           if (customVar) {
             /*
               Example:

--- a/extensions/amp-ad-exit/0.1/amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/amp-ad-exit.js
@@ -145,7 +145,7 @@ export class AmpAdExit extends AMP.BaseElement {
                which in this example will return "medium".
              */
             substitutionFunctions[customVarName] = () => {
-              if (customVar.hasOwnProperty('iframeTransportSignal')) {
+              if ('iframeTransportSignal' in customVar) {
                 const matches = customVar['iframeTransportSignal'].match(
                     /IFRAME_TRANSPORT_SIGNAL\(([\w-]+),\s*([\w-]+)\)/);
                 user().assert(matches && matches.length == 3,
@@ -162,14 +162,14 @@ export class AmpAdExit extends AMP.BaseElement {
                      that key.
                   */
                   const responseKey = matches[2];
-                  if (vendorResponses.hasOwnProperty(responseKey)) {
+                  if (responseKey in vendorResponses) {
                     return vendorResponses[responseKey];
                   }
                 }
               }
               // Either it's not a 3p analytics variable, or it is one but
               // no matching response has been received yet.
-              return (args && args.hasOwnProperty(customVarName)) ?
+              return (customVarName in args) ?
                   args[customVarName] : customVar.defaultValue;
             };
             whitelist[customVarName] = true;
@@ -254,7 +254,7 @@ export class AmpAdExit extends AMP.BaseElement {
       this.transport_.beacon = config.transport[TransportMode.BEACON] !== false;
       this.transport_.image = config.transport[TransportMode.IMAGE] !== false;
     } catch (e) {
-      this.user().error(TAG, 'Invalid JSON config', e);
+      user().error(TAG, 'Invalid JSON config', e);
       throw e;
     }
 
@@ -266,7 +266,7 @@ export class AmpAdExit extends AMP.BaseElement {
         ampAdResourceId = this.element.ownerDocument.defaultView
           .frameElement.parentElement.getResourceId();
       } catch (e) {
-        this.user().error(TAG,
+        user().error(TAG,
             'No friendly parent amp-ad element was found for amp-ad-exit tag.');
       }
 
@@ -281,7 +281,7 @@ export class AmpAdExit extends AMP.BaseElement {
           'Received empty response from 3p analytics frame');
       dev().assert(responseMessage && responseMessage['vendor'],
           'Received response from 3p analytics frame that does not indicate' +
-        ' vendor');
+          ' vendor');
       const vendor = responseMessage['vendor'];
       assertOriginMatchesVendor(event.origin, vendor);
 

--- a/extensions/amp-ad-exit/0.1/config.js
+++ b/extensions/amp-ad-exit/0.1/config.js
@@ -15,6 +15,7 @@
  */
 
 import {user} from '../../../src/log';
+import {ANALYTICS_CONFIG} from '../../amp-analytics/0.1/vendors';
 import {FilterType} from './filters/filter';
 
 /**
@@ -37,7 +38,16 @@ export let AmpAdExitConfig;
 export let NavigationTargetConfig;
 
 /**
- * @typedef {!Object<string, {defaultValue: (string|number|boolean)}>}
+ * @typedef {{
+ *   defaultValue: (string|number|boolean),
+ *   vendorAnalyticsSource: (string|undefined),
+ *   vendorAnalyticsResponseKey: (string|undefined)
+ * }}
+ */
+export let Variable;
+
+/**
+ * @typedef {!Object<string, !Variable>}
  */
 export let Variables;
 
@@ -135,6 +145,40 @@ function assertTarget(name, target, config) {
       user().assert(
           pattern.test(variable), '\'%s\' must match the pattern \'%s\'',
           variable, pattern);
+      const vendor = target.vars[variable]['vendorAnalyticsSource'];
+      if (vendor) {
+        assertVendor(vendor);
+        user().assert(
+            target.vars[variable]['vendorAnalyticsResponseKey'],
+            'Variable \'%s\': If vendorAnalyticsSource is defined then ' +
+            'vendorAnalyticsResponseKey must also be defined', variable);
+      }
     }
   }
+}
+
+/**
+ * Checks whether a vendor is valid (i.e. listed in vendors.js and has
+ * transport/iframe defined.
+ * @param {string} vendor The vendor name that should be listed in vendors.js
+ */
+function assertVendor(vendor) {
+  user().assert(ANALYTICS_CONFIG &&
+      ANALYTICS_CONFIG[vendor] !== undefined &&
+      ANALYTICS_CONFIG[vendor]['transport'] !== undefined &&
+      ANALYTICS_CONFIG[vendor]['transport']['iframe'] !== undefined,
+      'Unknown vendor: ' + vendor);
+}
+
+/**
+ * Ensures that a given origin matches that of an existing vendor's
+ * transport/iframe URL
+ * @param origin The origin to verify
+ * @param vendor The vendor whose origin to check against
+ */
+export function assertOriginMatchesVendor(origin, vendor) {
+  assertVendor(vendor);
+  const vendorURL = new URL(ANALYTICS_CONFIG[vendor]['transport']['iframe']);
+  user().assert(vendorURL && origin == vendorURL.origin,
+      'Invalid origin for vendor ' + vendor + ': ' + origin);
 }

--- a/extensions/amp-ad-exit/0.1/test/test-amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/test/test-amp-ad-exit.js
@@ -79,7 +79,7 @@ const EXIT_CONFIG = {
         _foo: {
           defaultValue: 'foo-default',
           iframeTransportSignal:
-            'IFRAME_TRANSPORT_SIGNAL(' + TEST_3P_VENDOR + ', collected-data)',
+            'IFRAME_TRANSPORT_SIGNAL(' + TEST_3P_VENDOR + ',collected-data)',
         },
         _bar: {
           defaultValue: 'bar-default',
@@ -400,7 +400,7 @@ describes.realWin('amp-ad-exit', {
     expect(sendBeacon).to.have.been.calledWith(trackingMatcher, '');
   });
 
-  it('should replace custom URL variables', () => {
+  it('should replace custom URL variables with vars', () => {
     const open = sandbox.stub(win, 'open', () => {
       return {name: 'fakeWin'};
     });

--- a/extensions/amp-ad-exit/0.1/test/test-amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/test/test-amp-ad-exit.js
@@ -155,6 +155,11 @@ describes.realWin('amp-ad-exit', {
     win = env.win;
     toggleExperiment(win, 'amp-ad-exit', true);
     addAdDiv();
+
+    // Ensure that getAmpAdResourceId() will return a value
+    win.__AMP_TOP = win.top;
+    win.top.document.body.getResourceId = function() { return '6789'; }
+
     // TEST_3P_VENDOR must be in ANALYTICS_CONFIG *before* makeElementWithConfig
     ANALYTICS_CONFIG[TEST_3P_VENDOR] = ANALYTICS_CONFIG[TEST_3P_VENDOR] || {
       transport: {

--- a/extensions/amp-ad-exit/0.1/test/test-amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/test/test-amp-ad-exit.js
@@ -408,7 +408,7 @@ describes.realWin('amp-ad-exit', {
     if (!win.navigator) {
       win.navigator = {sendBeacon: () => false};
     }
-    const sendBeacon = sandbox.stub(win.navigator, 'sendBeacon', () => true);
+    const sendBeacon = sandbox.stub(win.navigator, 'sendBeacon').returns(true);
 
     element.implementation_.executeAction({
       method: 'exit',
@@ -545,9 +545,7 @@ describes.realWin('amp-ad-exit', {
   });
 
   it('should replace custom URL variables with 3P Analytics defaults', () => {
-    const open = sandbox.stub(win, 'open', () => {
-      return {name: 'fakeWin'};
-    });
+    const open = sandbox.stub(win, 'open').returns({name: 'fakeWin'});
 
     element.implementation_.executeAction({
       method: 'exit',

--- a/extensions/amp-ad-exit/0.1/test/test-amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/test/test-amp-ad-exit.js
@@ -158,7 +158,7 @@ describes.realWin('amp-ad-exit', {
 
     // Ensure that getAmpAdResourceId() will return a value
     win.__AMP_TOP = win.top;
-    win.top.document.body.getResourceId = function() { return '6789'; }
+    win.top.document.body.getResourceId = function() { return '6789'; };
 
     // TEST_3P_VENDOR must be in ANALYTICS_CONFIG *before* makeElementWithConfig
     ANALYTICS_CONFIG[TEST_3P_VENDOR] = ANALYTICS_CONFIG[TEST_3P_VENDOR] || {

--- a/extensions/amp-ad-exit/amp-ad-exit.md
+++ b/extensions/amp-ad-exit/amp-ad-exit.md
@@ -212,18 +212,26 @@ applies to navigation URLs and click tracking URLs.
 
 ### Custom variables
 Custom variables must begin with an underscore. Define variables in the
-config alongside the navigation target. The default value can be overridden
-in the `exit` action invocation:
+config alongside the navigation target. Variables should have a `"defaultValue"`
+property. The default value can be overridden in the `exit` action invocation:
 
+Variable values can also come from 3P analytics.
+
+Example:
 ```html
 <amp-ad-exit id="exit-api"><script type="application/json">
 {
   "targets": {
     "product": {
-      "finalUrl": "http://example.com/?page=_productCategory",
+      "finalUrl": "http://example.com/?page=_productCategory"&verification=_3pAnalytics",
       "vars": {
         "_productCategory": {
           "defaultValue": "none"
+        },
+        "_3pAnalytics": {
+          "defaultValue": "no_response",
+          "vendorAnalyticsSource": "VendorXYZ",
+          "vendorAnalyticsResponseKey": "findings"
         }
       }
     }

--- a/extensions/amp-ad-network-fake-impl/0.1/data/fake_amp_ad_with_iframe_transport.html
+++ b/extensions/amp-ad-network-fake-impl/0.1/data/fake_amp_ad_with_iframe_transport.html
@@ -1,20 +1,25 @@
 <!doctype html>
 <html amp4ads>
   <head>
+    <title>Ad with 3p Analytics and amp-ad-exit</title>
     <meta charset=utf-8>
     <script async src='https://cdn.ampproject.org/v0.js'></script>
-    <script async custom-element=amp-analytics src='https://cdn.ampproject.org/v0/amp-analytics-0.1.js'></script>
+    <script async custom-element='amp-analytics' src='https://cdn.ampproject.org/v0/amp-analytics-0.1.js'></script>
+    <script async custom-element='amp-ad-exit' src='https://cdn.ampproject.org/v0/amp-ad-exit-0.1.js'></script>
     <style amp4ads-boilerplate>body{visibility:hidden}</style>
     <meta name=viewport content=width=device-width,minimum-scale=1>
   </head>
   <body>
-    <a href="/landing.html">
-      <amp-img id=img src='https://upload.wikimedia.org/wikipedia/commons/6/6e/Golde33443.jpg' width=256 height=300></amp-img>
-      <p class=frob>
-        By Golden Trvs Gol twister (Own work) [CC BY-SA 4.0 (http://creativecommons.org/licenses/by-sa/4.0)], via Wikimedia Commons
-      </p>
-    </a>
-    <amp-analytics type="testVendor">
+    Before using this example ad, please add the following to
+    extensions/amp-analytics/0.1/vendors.js:
+    <pre>
+      'example-3p-vendor': {
+        'transport': {
+          'iframe': 'http://localhost:8000/examples/analytics-iframe-transport-remote-frame.html',
+        },
+      },
+    </pre>
+    <amp-analytics type='example-3p-vendor'>
       <script type='application/json'>
         {
           "requests": {
@@ -34,13 +39,48 @@
               "selector": "img",
               "request": "sample_click_request"
             }
-          },
-          "transport": {
-            "iframe": "/examples/analytics-iframe-transport-remote-frame.html"
           }
         }
       </script>
     </amp-analytics>
+    <amp-ad-exit id='exit-api'>
+      <script type='application/json'>
+        {
+          "targets": {
+            "target1": {
+              "finalUrl": "/?product1&x=CLICK_X&y=CLICK_Y&e=_elem&foo=_bar&shouldNotBeReplaced=AMP_VERSION",
+              "vars": {
+                "_elem": {
+                  "defaultValue": "headline"
+                },
+                "_bar": {
+                  "defaultValue": "bar-default",
+                  "iframeTransportSignal": "IFRAME_TRANSPORT_SIGNAL(example-3p-vendor, collected-data)"
+                }
+              }
+            }
+          },
+          "filters": {
+            "longDelay": {
+              "type": "clickDelay",
+              "delay": 10000
+            }
+          },
+          "transport": {
+            "beacon": true,
+            "image": true
+          }
+        }
+      </script>
+    </amp-ad-exit>
+    <div id='ad'>
+      <div class='product' on='tap:exit-api.exit(target="target1", _elem="Product 1")'>
+        <amp-img id='img' src='https://upload.wikimedia.org/wikipedia/commons/6/6e/Golde33443.jpg' width=256 height=300></amp-img>
+        <p class='frob'>
+          By Golden Trvs Gol twister (Own work) [CC BY-SA 4.0 (http://creativecommons.org/licenses/by-sa/4.0)], via Wikimedia Commons
+        </p>
+      </div>
+    </div>
   </body>
 </html>
 

--- a/src/3p-frame-messaging.js
+++ b/src/3p-frame-messaging.js
@@ -51,6 +51,7 @@ export const MessageType = {
   // For amp-analytics' iframe-transport
   SEND_IFRAME_TRANSPORT_EVENTS: 'send-iframe-transport-events',
   IFRAME_TRANSPORT_EVENTS: 'iframe-transport-events',
+  IFRAME_TRANSPORT_RESPONSE: 'iframe-transport-response',
 
   // For user-error-in-iframe
   USER_ERROR_IN_IFRAME: 'user-error-in-iframe',
@@ -122,7 +123,7 @@ export function isAmpMessage(message) {
       message.indexOf('{') != -1);
 }
 
-/** @typedef {{transportId: string, message: string}} */
+/** @typedef {{creativeId: string, message: string}} */
 export let IframeTransportEvent;
 // An event, and the transport ID of the amp-analytics tags that
 // generated it. For instance if the creative with transport


### PR DESCRIPTION
Previous work implemented ability for amp-analytics to create a 3p vendor iframe.
Parallel PR #11306 enables the iframe to send a response to the pub page
This PR enables amp-ad-exit to receive those responses and substitute them into target URLs.