### PR TITLE
Enables vendor iframe to send response to creative

### DIFF
--- a/3p/iframe-transport-client-lib.js
+++ b/3p/iframe-transport-client-lib.js
@@ -23,15 +23,11 @@ initLogConstructor();
 setReportError(() => {});
 
 /**
- *  If window.iframeTransportClient does not exist, we must instantiate and
- *  assign it to window.iframeTransportClient, to provide the creative with
+ *  Instantiate IframeTransportClient, to provide the creative with
  *  all the required functionality.
  */
 try {
-  const iframeTransportClientCreated =
-      new Event('amp-iframeTransportClientCreated');
-  window.iframeTransportClient = new IframeTransportClient(window);
-  window.dispatchEvent(iframeTransportClientCreated);
+  new IframeTransportClient(window);
 } catch (err) {
   // do nothing with error
 }

--- a/3p/iframe-transport-client.js
+++ b/3p/iframe-transport-client.js
@@ -42,7 +42,10 @@ export class IframeTransportClient {
     this.vendor_ = dev().assertString(parsedFrameName['type'],
         'Parent frame must supply vendor name as type in ' +
         this.win_.location.href);
-    dev().assert(this.vendor_.length > 0, 'Vendor name cannot be empty in ' +
+    // Note: amp-ad-exit will validate the vendor name before performing
+    // variable substitution, so if the vendor name is not a valid one from
+    // vendors.js, then its response messages will have no effect.
+    dev().assert(this.vendor_.length, 'Vendor name cannot be empty in ' +
         this.win_.location.href);
 
     /** @protected {!IframeMessagingClient} */
@@ -124,9 +127,9 @@ class IframeTransportContext {
     /** @private {?function(string)} */
     this.listener_ = null;
 
-    user().assert(win['onNewAmpAnalyticsInstance'],
-        'Must implement onNewAmpAnalyticsInstance in ' +
-        win.location.href);
+    user().assert(win['onNewAmpAnalyticsInstance'] &&
+        typeof win['onNewAmpAnalyticsInstance'] == 'function',
+        'Must implement onNewAmpAnalyticsInstance in ' + win.location.href);
     win['onNewAmpAnalyticsInstance'](this);
   }
 
@@ -135,7 +138,7 @@ class IframeTransportContext {
    * is received.
    * Note that calling this a second time will result in the first listener
    * being removed - the events will not be sent to both callbacks.
-   * @param {function(string)} listener
+   * @param {!function(string)} listener
    */
   onAnalyticsEvent(listener) {
     this.listener_ = listener;

--- a/3p/iframe-transport-client.js
+++ b/3p/iframe-transport-client.js
@@ -61,7 +61,7 @@ export class IframeTransportClient {
           events.forEach(event => {
             try {
               this.listener_ &&
-                  this.listener_(event.message, event.transportId);
+                  this.listener_(event.message, event.creativeId);
             } catch (e) {
               user().error(TAG_,
                   'Exception in callback passed to onAnalyticsEvent: ' +
@@ -80,6 +80,19 @@ export class IframeTransportClient {
    */
   onAnalyticsEvent(callback) {
     this.listener_ = callback;
+  }
+
+  /**
+   * Sends a message back to the creative
+   * @param {string} vendor The name of the 3p vendor used in the
+   * <amp-analytics> tag
+   * @param {string} creativeId An ID uniquely identifying which creative
+   * shall receive the event
+   * @param {!Object<string,string>} response
+   */
+  sendMessageToCreative(vendor, creativeId, response) {
+    this.client_./*OK*/sendMessage(MessageType.IFRAME_TRANSPORT_RESPONSE,
+        /** @type {JsonObject} */({creativeId, vendor, message: response}));
   }
 
   /**

--- a/3p/iframe-transport-client.js
+++ b/3p/iframe-transport-client.js
@@ -33,7 +33,7 @@ export class IframeTransportClient {
     /** @private {!Window} */
     this.win_ = win;
 
-    /** @private {Object<string, IframeTransportContext>} */
+    /** @private {!Object<string, IframeTransportContext>} */
     this.creativeIdToContext_ = {};
 
     const parsedFrameName = tryParseJson(this.win_.name);
@@ -127,10 +127,10 @@ class IframeTransportContext {
     /** @private {?function(string)} */
     this.listener_ = null;
 
-    user().assert(win['onNewAmpAnalyticsInstance'] &&
-        typeof win['onNewAmpAnalyticsInstance'] == 'function',
-        'Must implement onNewAmpAnalyticsInstance in ' + win.location.href);
-    win['onNewAmpAnalyticsInstance'](this);
+    user().assert(win['onNewContextInstance'] &&
+        typeof win['onNewContextInstance'] == 'function',
+        'Must implement onNewContextInstance in ' + win.location.href);
+    win['onNewContextInstance'](this);
   }
 
   /**
@@ -155,12 +155,12 @@ class IframeTransportContext {
 
   /**
    * Sends a response message back to the creative.
-   * @param {!Object<string,string>} message
+   * @param {!Object<string, string>} data
    */
-  sendResponseToCreative(message) {
+  sendResponseToCreative(data) {
     this.iframeMessagingClient_./*OK*/sendMessage(
         MessageType.IFRAME_TRANSPORT_RESPONSE,
         /** @type {!JsonObject} */
-        (Object.assign({}, message, this.baseMessage_)));
+        (Object.assign({}, message: data, this.baseMessage_)));
   }
 }

--- a/3p/iframe-transport-client.js
+++ b/3p/iframe-transport-client.js
@@ -72,7 +72,7 @@ export class IframeTransportClient {
             try {
               dev().assert(event.creativeId,
                   'Received malformed event in ' + this.win_.location.href);
-              this.contextFor_(event.creativeId).dispatch(event.message);
+              this.contextFor_(event.creativeId).dispatch(event);
             } catch (e) {
               user().error(TAG_,
                   'Exception in callback passed to onAnalyticsEvent',
@@ -124,7 +124,7 @@ export class IframeTransportContext {
     /** @private @const {!Object} */
     this.baseMessage_ = {creativeId, vendor};
 
-    /** @private {?function(string)} */
+    /** @private {?function(!Object)} */
     this.listener_ = null;
 
     user().assert(win['onNewContextInstance'] &&
@@ -138,7 +138,7 @@ export class IframeTransportContext {
    * is received.
    * Note that calling this a second time will result in the first listener
    * being removed - the events will not be sent to both callbacks.
-   * @param {!function(string)} listener
+   * @param {!function(!Object)} listener
    */
   onAnalyticsEvent(listener) {
     this.listener_ = listener;
@@ -147,7 +147,7 @@ export class IframeTransportContext {
   /**
    * Receives an event from IframeTransportClient, and passes it along to
    * the creative that this context represents.
-   * @param {string} event
+   * @param {!Object} event
    */
   dispatch(event) {
     this.listener_ && this.listener_(event);

--- a/3p/iframe-transport-client.js
+++ b/3p/iframe-transport-client.js
@@ -33,7 +33,7 @@ export class IframeTransportClient {
     /** @private {!Window} */
     this.win_ = win;
 
-    /** @private {Object<string,IframeTransportContext>} */
+    /** @private {Object<string, IframeTransportContext>} */
     this.creativeIdToContext_ = {};
 
     const parsedFrameName = tryParseJson(this.win_.name);
@@ -75,7 +75,7 @@ export class IframeTransportClient {
               this.contextFor_(event.creativeId).dispatch(event.message);
             } catch (e) {
               user().error(TAG_,
-                  'Exception in callback passed to onAnalyticsEvent: ' +
+                  'Exception in callback passed to onAnalyticsEvent',
                   e);
             }
           });

--- a/3p/iframe-transport-client.js
+++ b/3p/iframe-transport-client.js
@@ -109,7 +109,7 @@ export class IframeTransportClient {
 /**
  * A context object to be passed along with event data.
  */
-class IframeTransportContext {
+export class IframeTransportContext {
   /**
    * @param {!Window} win
    * @param {!IframeMessagingClient} iframeMessagingClient
@@ -161,6 +161,6 @@ class IframeTransportContext {
     this.iframeMessagingClient_./*OK*/sendMessage(
         MessageType.IFRAME_TRANSPORT_RESPONSE,
         /** @type {!JsonObject} */
-        (Object.assign({}, message: data, this.baseMessage_)));
+        (Object.assign({message: data}, this.baseMessage_)));
   }
 }

--- a/3p/iframe-transport-client.js
+++ b/3p/iframe-transport-client.js
@@ -72,8 +72,7 @@ export class IframeTransportClient {
             try {
               dev().assert(event.creativeId,
                   'Received malformed event in ' + this.win_.location.href);
-              event.type = MessageType.IFRAME_TRANSPORT_EVENTS;
-              this.contextFor_(event.creativeId).dispatch(event);
+              this.contextFor_(event.creativeId).dispatch(event.message);
             } catch (e) {
               user().error(TAG_,
                   'Exception in callback passed to onAnalyticsEvent',
@@ -125,7 +124,7 @@ export class IframeTransportContext {
     /** @private @const {!Object} */
     this.baseMessage_ = {creativeId, vendor};
 
-    /** @private {?function(!Object)} */
+    /** @private {?function(string)} */
     this.listener_ = null;
 
     user().assert(win['onNewContextInstance'] &&
@@ -139,7 +138,7 @@ export class IframeTransportContext {
    * is received.
    * Note that calling this a second time will result in the first listener
    * being removed - the events will not be sent to both callbacks.
-   * @param {!function(!Object)} listener
+   * @param {!function(string)} listener
    */
   onAnalyticsEvent(listener) {
     this.listener_ = listener;
@@ -148,7 +147,7 @@ export class IframeTransportContext {
   /**
    * Receives an event from IframeTransportClient, and passes it along to
    * the creative that this context represents.
-   * @param {!Object} event
+   * @param {string} event
    */
   dispatch(event) {
     this.listener_ && this.listener_(event);

--- a/3p/iframe-transport-client.js
+++ b/3p/iframe-transport-client.js
@@ -24,7 +24,7 @@ const TAG_ = 'iframe-transport-client';
 
 /**
  * Receives event messages bound for this cross-domain iframe, from all
- * creatives
+ * creatives.
  */
 export class IframeTransportClient {
 
@@ -49,7 +49,7 @@ export class IframeTransportClient {
           const events =
               /**
                * @type
-               * {!Array<../src/3p-frame-messaging.IframeTransportEvent>}
+               *   {!Array<../src/3p-frame-messaging.IframeTransportEvent>}
                */
               (eventData['events']);
           user().assert(events,
@@ -83,20 +83,20 @@ export class IframeTransportClient {
   }
 
   /**
-   * Sends a message back to the creative
+   * Sends a message back to the creative.
    * @param {string} vendor The name of the 3p vendor used in the
-   * <amp-analytics> tag
+   *   <amp-analytics> tag
    * @param {string} creativeId An ID uniquely identifying which creative
    * shall receive the event
    * @param {!Object<string,string>} response
    */
   sendMessageToCreative(vendor, creativeId, response) {
     this.client_./*OK*/sendMessage(MessageType.IFRAME_TRANSPORT_RESPONSE,
-        /** @type {JsonObject} */({creativeId, vendor, message: response}));
+        /** @type {!JsonObject} */({creativeId, vendor, message: response}));
   }
 
   /**
-   * Gets the IframeMessagingClient
+   * Gets the IframeMessagingClient.
    * @returns {!IframeMessagingClient}
    * @VisibleForTesting
    */

--- a/3p/iframe-transport-client.js
+++ b/3p/iframe-transport-client.js
@@ -72,6 +72,7 @@ export class IframeTransportClient {
             try {
               dev().assert(event.creativeId,
                   'Received malformed event in ' + this.win_.location.href);
+              event.type = MessageType.IFRAME_TRANSPORT_EVENTS;
               this.contextFor_(event.creativeId).dispatch(event);
             } catch (e) {
               user().error(TAG_,

--- a/build-system/amp.extern.js
+++ b/build-system/amp.extern.js
@@ -146,6 +146,11 @@ AmpViewerMessage.prototype.error;
 // AMP-Analytics Cross-domain iframes
 let IframeTransportEvent;
 
+/** @constructor @struct */
+function IframeTransportContext() {}
+IframeTransportContext.onAnalyticsEvent;
+IframeTransportContext.sendResponseToCreative;
+
 // amp-viz-vega related externs.
 /**
  * @typedef {{spec: function(!JsonObject, function())}}

--- a/examples/analytics-iframe-transport-remote-frame.html
+++ b/examples/analytics-iframe-transport-remote-frame.html
@@ -4,26 +4,26 @@
     <meta charset="UTF-8">
     <title>Requests Frame</title>
     <script>
-      window.addEventListener('amp-iframeTransportClientCreated', () => {
-        /**
-         * To receive AMP analytics events in a third-party frame, you must
-         * pass a callback function to this method. The callback will be called
-         * when an event is received, and will be passed two parameters:
-         * @param {string} event A string of the format specified in the
-         * requests block of the amp-analytics JSON config
-         * @param {string} transportId An ID uniquely identifying which creative
-         * generated the event
-         */
-        window.iframeTransportClient.onAnalyticsEvent(
-            (event, transportId) => {
-              // Now, do something meaningful with the AMP Analytics event
-              console.log('The page at: ' + window.location.href +
-                  ' has received an event: ' + event +
-                  ' from the creative with transport ID: ' + transportId);
-              window.iframeTransportClient.sendMessageToCreative(
-                'example-3p-vendor', transportId, {'collected-data': 'abc'});
-            });
-      });
+      /**
+       * To receive analytics events in a third-party frame, you must
+       * implement this method, with this signature. Within that method, you
+       * must create a function which processes an event, and
+       * pass that function to the onAnalyticsEvent() method of the object
+       * which is passed as a parameter to onNewAmpAnalyticsInstance().
+       * @param ampAnalytics  Call onAnalyticsEvent() on this, passing your
+       * function which will receive the analytics events.
+       */
+      window.onNewAmpAnalyticsInstance = ampAnalytics => {
+        ampAnalytics.onAnalyticsEvent(event => {
+          // Now, do something meaningful with the AMP Analytics event
+          console.log('The page at: ' + window.location.href +
+              ' has received an event: ' + event);
+          // Optionally, you may send a response containing key/value pairs, to
+          // be used by the amp-ad-exit of the creative which generated the
+          // event.
+          ampAnalytics.sendResponseToCreative({'collected-data': 'abc'});
+        });
+      };
 
       // Load the script specified in the iframe’s name attribute:
       const url = JSON.parse(window.name).scriptSrc;

--- a/examples/analytics-iframe-transport-remote-frame.html
+++ b/examples/analytics-iframe-transport-remote-frame.html
@@ -15,12 +15,12 @@
          * Within the window.onNewContextInstance method, you
          * must create a function which processes an event, and
          * pass that function to context.onAnalyticsEvent().
-         * @param {string} event The event message received from AMP Analytics
+         * @param {Object} event The event received from AMP Analytics
          */
         context.onAnalyticsEvent(event => {
           // Now, do something meaningful with the AMP Analytics event
           console.log('The page at: ' + window.location.href +
-              ' has received an event: ' + event);
+              ' has received an event: ' + event.message);
 
           // Optionally, you may send a response containing key/value pairs, to
           // be used by the amp-ad-exit of the creative which generated the

--- a/examples/analytics-iframe-transport-remote-frame.html
+++ b/examples/analytics-iframe-transport-remote-frame.html
@@ -6,22 +6,26 @@
     <script>
       /**
        * To receive analytics events in a third-party frame, you must
-       * implement this method, with this signature. Within that method, you
-       * must create a function which processes an event, and
-       * pass that function to the onAnalyticsEvent() method of the object
-       * which is passed as a parameter to onNewAmpAnalyticsInstance().
-       * @param ampAnalytics  Call onAnalyticsEvent() on this, passing your
+       * implement window.onNewContextInstance, with this signature.
+       * @param context  Call onAnalyticsEvent() on this, passing your
        * function which will receive the analytics events.
        */
-      window.onNewAmpAnalyticsInstance = ampAnalytics => {
-        ampAnalytics.onAnalyticsEvent(event => {
+      window.onNewContextInstance = context => {
+        /**
+         * Within the window.onNewContextInstance method, you
+         * must create a function which processes an event, and
+         * pass that function to context.onAnalyticsEvent().
+         * @param {string} event The event message received from AMP Analytics
+         */
+        context.onAnalyticsEvent(event => {
           // Now, do something meaningful with the AMP Analytics event
           console.log('The page at: ' + window.location.href +
               ' has received an event: ' + event);
+
           // Optionally, you may send a response containing key/value pairs, to
           // be used by the amp-ad-exit of the creative which generated the
           // event.
-          ampAnalytics.sendResponseToCreative({'collected-data': 'abc'});
+          context.sendResponseToCreative({'collected-data': 'abc'});
         });
       };
 
@@ -31,7 +35,7 @@
         script = document.createElement('script');
         script.src = url;
         document.head.appendChild(script);
-        // The script will be loaded, and will call onNewAmpAnalyticsInstance()
+        // The script will be loaded, and will call onNewContextInstance()
       } else {
         console.warn('Received invalid URL - risk of XSS! ' + url);
       }

--- a/examples/analytics-iframe-transport-remote-frame.html
+++ b/examples/analytics-iframe-transport-remote-frame.html
@@ -15,21 +15,17 @@
          * Within the window.onNewContextInstance method, you
          * must create a function which processes an event, and
          * pass that function to context.onAnalyticsEvent().
-         * @param {Object} event The event received from AMP Analytics
+         * @param {string} event The event message received from AMP Analytics
          */
         context.onAnalyticsEvent(event => {
-          if (event.type == 'iframe-transport-events') {
-            // Currently, this is the only event type, but others may exist in
-            // the future.
-            // Now, do something meaningful with the AMP Analytics event.
-            console.log('The page at: ' + window.location.href +
-                ' has received an event: ' + event.message);
+          // Now, do something meaningful with the AMP Analytics event
+          console.log('The page at: ' + window.location.href +
+              ' has received an event: ' + event);
 
-            // Optionally, you may send a response containing key/value pairs,
-            // to be used by the amp-ad-exit of the creative which generated the
-            // event.
-            context.sendResponseToCreative({'collected-data': 'abc'});
-          }
+          // Optionally, you may send a response containing key/value pairs, to
+          // be used by the amp-ad-exit of the creative which generated the
+          // event.
+          context.sendResponseToCreative({'collected-data': 'abc'});
         });
       };
 

--- a/examples/analytics-iframe-transport-remote-frame.html
+++ b/examples/analytics-iframe-transport-remote-frame.html
@@ -20,6 +20,8 @@
               console.log('The page at: ' + window.location.href +
                   ' has received an event: ' + event +
                   ' from the creative with transport ID: ' + transportId);
+              window.iframeTransportClient.sendMessageToCreative(
+                'example-3p-vendor', transportId, {'collected-data': 'abc'});
             });
       });
 

--- a/examples/analytics-iframe-transport-remote-frame.html
+++ b/examples/analytics-iframe-transport-remote-frame.html
@@ -18,14 +18,18 @@
          * @param {Object} event The event received from AMP Analytics
          */
         context.onAnalyticsEvent(event => {
-          // Now, do something meaningful with the AMP Analytics event
-          console.log('The page at: ' + window.location.href +
-              ' has received an event: ' + event.message);
+          if (event.type == 'iframe-transport-events') {
+            // Currently, this is the only event type, but others may exist in
+            // the future.
+            // Now, do something meaningful with the AMP Analytics event.
+            console.log('The page at: ' + window.location.href +
+                ' has received an event: ' + event.message);
 
-          // Optionally, you may send a response containing key/value pairs, to
-          // be used by the amp-ad-exit of the creative which generated the
-          // event.
-          context.sendResponseToCreative({'collected-data': 'abc'});
+            // Optionally, you may send a response containing key/value pairs,
+            // to be used by the amp-ad-exit of the creative which generated the
+            // event.
+            context.sendResponseToCreative({'collected-data': 'abc'});
+          }
         });
       };
 

--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -224,9 +224,17 @@ export class AmpAnalytics extends AMP.BaseElement {
         this.instrumentation_.createAnalyticsGroup(this.element);
 
     if (this.config_['transport'] && this.config_['transport']['iframe']) {
+      let ampAdResourceId;
+      try {
+        ampAdResourceId = this.element.ownerDocument.defaultView
+            .frameElement.parentElement.getResourceId();
+      } catch (e) {
+        this.user().error(TAG, 'No friendly parent amp-ad element was found' +
+            ' for amp-analytics tag.');
+      }
       this.iframeTransport_ = new IframeTransport(this.getAmpDoc().win,
-        this.element.getAttribute('type'),
-        this.config_['transport']);
+        this.win, this.element.getAttribute('type'),
+        this.config_['transport'], ampAdResourceId);
     }
 
     const promises = [];
@@ -832,7 +840,6 @@ export class AmpAnalytics extends AMP.BaseElement {
     return new ExpansionOptions(vars, opt_iterations, opt_noEncode);
   }
 }
-
 
 AMP.extension(TAG, '0.1', AMP => {
   // Register doc-service factory.

--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -290,8 +290,8 @@ export class AmpAnalytics extends AMP.BaseElement {
  /**
   * Gets the resource ID of the amp-ad element containing this AmpAnalytics
   * instance.
-  * If there is no containing amp-ad tag, then the resource ID of this
-  * amp-analytics tag is used instead.
+  * If there is no containing amp-ad tag, then an exception will be thrown,
+  * although that use case may be enabled in the future.
   * @return {string}
   */
   getAmpAdResourceId() {
@@ -301,7 +301,7 @@ export class AmpAnalytics extends AMP.BaseElement {
     } catch (e) {
       this.user().error(TAG, 'No friendly parent amp-ad element was found' +
           ' for amp-analytics tag.');
-      return this.element.getResourceId();
+      throw e;
     }
   }
 

--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -292,6 +292,7 @@ export class AmpAnalytics extends AMP.BaseElement {
   * instance.
   * If there is no containing amp-ad tag, then an exception will be thrown,
   * although that use case may be enabled in the future.
+  * TODO(jonkeller): Investigate whether non-A4A use case is needed. Issue 11436
   * @return {string}
   */
   getAmpAdResourceId() {

--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -233,7 +233,7 @@ export class AmpAnalytics extends AMP.BaseElement {
             ' for amp-analytics tag.');
       }
       this.iframeTransport_ = new IframeTransport(this.getAmpDoc().win,
-        this.win, this.element.getAttribute('type'),
+        this.element.getAttribute('type'),
         this.config_['transport'], ampAdResourceId);
     }
 

--- a/extensions/amp-analytics/0.1/iframe-transport.js
+++ b/extensions/amp-analytics/0.1/iframe-transport.js
@@ -38,18 +38,13 @@ export let FrameData;
 export class IframeTransport {
   /**
    * @param {!Window} ampWin The window object of the AMP document
-   * @param {!Window} win The window object of the innermost document
-   * containing the amp-analytics tag (e.g. a creative iframe)
    * @param {!string} type The value of the amp-analytics tag's type attribute
    * @param {!JsonObject} config
    * @param {!string} ampAdResourceId The resourceID of the enclosing amp-ad tag
    */
-  constructor(ampWin, win, type, config, ampAdResourceId) {
-    /** @private @const {!Window} win */
+  constructor(ampWin, type, config, ampAdResourceId) {
+    /** @private @const {!Window} */
     this.ampWin_ = ampWin;
-
-    /** @private @const {!Window} win */
-    this.win_ = win;
 
     /** @private @const {string} */
     this.type_ = type;

--- a/extensions/amp-analytics/0.1/iframe-transport.js
+++ b/extensions/amp-analytics/0.1/iframe-transport.js
@@ -37,11 +37,17 @@ export let FrameData;
  */
 export class IframeTransport {
   /**
-   * @param {!Window} win
+   * @param {!Window} ampWin The window object of the AMP document
+   * @param {!Window} win The window object of the innermost document
+   * containing the amp-analytics tag (e.g. a creative iframe)
    * @param {!string} type The value of the amp-analytics tag's type attribute
    * @param {!JsonObject} config
+   * @param {!string} ampAdResourceId The resourceID of the enclosing amp-ad tag
    */
-  constructor(win, type, config) {
+  constructor(ampWin, win, type, config, ampAdResourceId) {
+    /** @private @const {!Window} win */
+    this.ampWin_ = ampWin;
+
     /** @private @const {!Window} win */
     this.win_ = win;
 
@@ -49,11 +55,12 @@ export class IframeTransport {
     this.type_ = type;
 
     /** @private @const {string} */
-    this.id_ = IframeTransport.createUniqueId_();
+    this.creativeId_ = ampAdResourceId;
 
     dev().assert(config && config['iframe'],
         'Must supply iframe URL to constructor!');
     this.frameUrl_ = config['iframe'];
+
     this.processCrossDomainIframe();
   }
 
@@ -61,7 +68,8 @@ export class IframeTransport {
    * Called when a Transport instance is being removed from the DOM
    */
   detach() {
-    IframeTransport.markCrossDomainIframeAsDone(this.win_.document, this.type_);
+    IframeTransport.markCrossDomainIframeAsDone(this.ampWin_.document,
+        this.type_);
   }
 
   /**
@@ -75,40 +83,41 @@ export class IframeTransport {
       ++(frameData.usageCount);
     } else {
       frameData = this.createCrossDomainIframe();
-      this.win_.document.body.appendChild(frameData.frame);
+      this.ampWin_.document.body.appendChild(frameData.frame);
     }
     dev().assert(frameData, 'Trying to use non-existent frame');
   }
 
   /**
-   * Create a cross-domain iframe for third-party vendor anaytlics
+   * Create a cross-domain iframe for third-party vendor analytics
    * @return {!FrameData}
    * @VisibleForTesting
    */
   createCrossDomainIframe() {
     // Explanation of IDs:
     // Each instance of IframeTransport (owned by a specific amp-analytics
-    // tag, in turn owned by a specific creative) has an ID in this._id.
+    // tag, in turn owned by a specific creative) has an ID
+    // (this.getCreativeId()).
     // Each cross-domain iframe also has an ID, stored here in sentinel.
-    // These two types of IDs are drawn from the same pool of numbers, and
-    // are thus mutually unique.
+    // These two types of IDs have different formats.
     // There is a many-to-one relationship, in that several creatives may
-    // utilize the same analytics vendor, so perhaps creatives #1 & #2 might
-    // both use xframe #3.
+    // utilize the same analytics vendor, so perhaps two creatives might
+    // both use the same vendor iframe.
     // Of course, a given creative may use multiple analytics vendors, but
     // in that case it would use multiple amp-analytics tags, so the
-    // iframeTransport.id_ -> sentinel relationship is *not* many-to-many.
+    // iframeTransport.getCreativeId() -> sentinel relationship is *not*
+    // many-to-many.
     const sentinel = IframeTransport.createUniqueId_();
     const useLocal = getMode().localDev || getMode().test;
     const useRtvVersion = !useLocal;
     const scriptSrc = calculateEntryPointScriptUrl(
-        this.win_.parent.location, 'iframe-transport-client-lib',
+        this.ampWin_.parent.location, 'iframe-transport-client-lib',
         useLocal, useRtvVersion);
     const frameName = JSON.stringify(/** @type {JsonObject} */ ({
       scriptSrc,
       sentinel,
     }));
-    const frame = createElementWithAttributes(this.win_.document, 'iframe',
+    const frame = createElementWithAttributes(this.ampWin_.document, 'iframe',
         /** @type {!JsonObject} */ ({
           sandbox: 'allow-scripts allow-same-origin',
           name: frameName,
@@ -122,7 +131,7 @@ export class IframeTransport {
     const frameData = /** @const {FrameData} */ ({
       frame,
       usageCount: 1,
-      queue: new IframeTransportMessageQueue(this.win_,
+      queue: new IframeTransportMessageQueue(this.ampWin_,
           /** @type {!HTMLIFrameElement} */
           (frame)),
     });
@@ -180,12 +189,13 @@ export class IframeTransport {
   sendRequest(event) {
     const frameData = IframeTransport.getFrameData(this.type_);
     dev().assert(frameData, 'Trying to send message to non-existent frame');
-    dev().assert(frameData.queue, 'Event queue is missing for ' + this.id_);
+    dev().assert(frameData.queue,
+        'Event queue is missing for ' + this.getCreativeId());
     frameData.queue.enqueue(
         /**
          * @type {!../../../src/3p-frame-messaging.IframeTransportEvent}
          */
-        ({transportId: this.id_, message: event}));
+        ({creativeId: this.getCreativeId(), message: event}));
   }
 
   /**
@@ -211,8 +221,8 @@ export class IframeTransport {
    * @returns {!string} Unique ID of this instance of IframeTransport
    * @VisibleForTesting
    */
-  getId() {
-    return this.id_;
+  getCreativeId() {
+    return this.creativeId_;
   }
 
   /**

--- a/extensions/amp-analytics/0.1/iframe-transport.js
+++ b/extensions/amp-analytics/0.1/iframe-transport.js
@@ -189,12 +189,13 @@ export class IframeTransport {
     const frameData = IframeTransport.getFrameData(this.type_);
     dev().assert(frameData, 'Trying to send message to non-existent frame');
     dev().assert(frameData.queue,
-        'Event queue is missing for ' + this.getCreativeId());
+        'Event queue is missing for messages from ' + this.type_ +
+        ' to creative ID ' + this.creativeId_);
     frameData.queue.enqueue(
         /**
          * @type {!../../../src/3p-frame-messaging.IframeTransportEvent}
          */
-        ({creativeId: this.getCreativeId(), message: event}));
+        ({creativeId: this.creativeId_, message: event}));
   }
 
   /**

--- a/extensions/amp-analytics/0.1/iframe-transport.js
+++ b/extensions/amp-analytics/0.1/iframe-transport.js
@@ -40,9 +40,12 @@ export class IframeTransport {
    * @param {!Window} ampWin The window object of the AMP document
    * @param {!string} type The value of the amp-analytics tag's type attribute
    * @param {!JsonObject} config
-   * @param {!string} ampAdResourceId The resourceID of the enclosing amp-ad tag
+   * @param {!string} id A unique ID for this instance. If (potentially) using
+   *     sendResponseToCreative(), it should be something that the recipient
+   *     can use to identify the context of the message, e.g. the resourceID
+   *     of a DOM element.
    */
-  constructor(ampWin, type, config, ampAdResourceId) {
+  constructor(ampWin, type, config, id) {
     /** @private @const {!Window} */
     this.ampWin_ = ampWin;
 
@@ -50,7 +53,7 @@ export class IframeTransport {
     this.type_ = type;
 
     /** @private @const {string} */
-    this.creativeId_ = ampAdResourceId;
+    this.creativeId_ = id;
 
     dev().assert(config && config['iframe'],
         'Must supply iframe URL to constructor!');
@@ -111,6 +114,7 @@ export class IframeTransport {
     const frameName = JSON.stringify(/** @type {JsonObject} */ ({
       scriptSrc,
       sentinel,
+      type: this.type_
     }));
     const frame = createElementWithAttributes(this.ampWin_.document, 'iframe',
         /** @type {!JsonObject} */ ({

--- a/extensions/amp-analytics/0.1/iframe-transport.js
+++ b/extensions/amp-analytics/0.1/iframe-transport.js
@@ -114,7 +114,7 @@ export class IframeTransport {
     const frameName = JSON.stringify(/** @type {JsonObject} */ ({
       scriptSrc,
       sentinel,
-      type: this.type_
+      type: this.type_,
     }));
     const frame = createElementWithAttributes(this.ampWin_.document, 'iframe',
         /** @type {!JsonObject} */ ({

--- a/extensions/amp-analytics/0.1/test/test-iframe-transport-client.js
+++ b/extensions/amp-analytics/0.1/test/test-iframe-transport-client.js
@@ -153,7 +153,7 @@ describe('iframe-transport-client', () => {
       'my_creative', 'my_vendor');
     const listener = sandbox.spy();
     ctx.onAnalyticsEvent(listener);
-    const event = 'Something important happened';
+    const event = {message: 'Something important happened'};
     ctx.dispatch(event);
     expect(listener).to.be.calledOnce;
     expect(listener).to.be.calledWith(event);

--- a/extensions/amp-analytics/0.1/test/test-iframe-transport-client.js
+++ b/extensions/amp-analytics/0.1/test/test-iframe-transport-client.js
@@ -116,7 +116,7 @@ describe('iframe-transport-client', () => {
   });
 
   it('calls onNewContextInstance', () => {
-    const onNewContextInstanceSpy = sinon.spy();
+    const onNewContextInstanceSpy = sandbox.spy();
     window.onNewContextInstance = ctx => onNewContextInstanceSpy(ctx);
     const ctx = new IframeTransportContext(window,
       iframeTransportClient.iframeMessagingClient_,
@@ -127,7 +127,7 @@ describe('iframe-transport-client', () => {
   });
 
   it('Sets listener and baseMessage properly', () => {
-    const onNewContextInstanceSpy = sinon.spy();
+    const onNewContextInstanceSpy = sandbox.spy();
     window.onNewContextInstance = ctx => onNewContextInstanceSpy(ctx);
     const ctx = new IframeTransportContext(window,
       iframeTransportClient.iframeMessagingClient_,
@@ -136,8 +136,8 @@ describe('iframe-transport-client', () => {
     expect(ctx.baseMessage_).to.not.be.null;
     expect(ctx.baseMessage_.creativeId).to.equal('my_creative');
     expect(ctx.baseMessage_.vendor).to.equal('my_vendor');
-    const listener1 = sinon.spy();
-    const listener2 = sinon.spy();
+    const listener1 = sandbox.spy();
+    const listener2 = sandbox.spy();
     ctx.onAnalyticsEvent(listener1);
     expect(ctx.listener_).to.equal(listener1);
     ctx.onAnalyticsEvent(listener2);
@@ -146,12 +146,12 @@ describe('iframe-transport-client', () => {
   });
 
   it('dispatches event', () => {
-    const onNewContextInstanceSpy = sinon.spy();
+    const onNewContextInstanceSpy = sandbox.spy();
     window.onNewContextInstance = ctx => onNewContextInstanceSpy(ctx);
     const ctx = new IframeTransportContext(window,
       iframeTransportClient.iframeMessagingClient_,
       'my_creative', 'my_vendor');
-    const listener = sinon.spy();
+    const listener = sandbox.spy();
     ctx.onAnalyticsEvent(listener);
     const event = 'Something important happened';
     ctx.dispatch(event);
@@ -161,21 +161,22 @@ describe('iframe-transport-client', () => {
   });
 
   it('sends response', () => {
-    const onNewContextInstanceSpy = sinon.spy();
+    const onNewContextInstanceSpy = sandbox.spy();
     window.onNewContextInstance = ctx => onNewContextInstanceSpy(ctx);
-    const ctx = new IframeTransportContext(window,
-      iframeTransportClient.iframeMessagingClient_,
+    // This const exists solely to avoid triggering a false positive on the
+    // presubmit rule that says you can't call stub() on a cross-domain iframe.
+    const imc = iframeTransportClient.iframeMessagingClient_;
+    const ctx = new IframeTransportContext(window, imc,
       'my_creative', 'my_vendor');
     const response = {foo: 'bar', answer: '42'};
-    sandbox.stub(iframeTransportClient.iframeMessagingClient_, 'sendMessage',
-        (type, opt_payload) => {
-          expect(type).to.equal(MessageType.IFRAME_TRANSPORT_RESPONSE);
-          expect(opt_payload).to.not.be.null;
-          expect(opt_payload.creativeId).to.equal('my_creative');
-          expect(opt_payload.vendor).to.equal('my_vendor');
-          expect(opt_payload.message).to.not.be.null;
-          expect(opt_payload.message).to.equal(response);
-        });
+    sandbox.stub(imc, 'sendMessage', (type, opt_payload) => {
+      expect(type).to.equal(MessageType.IFRAME_TRANSPORT_RESPONSE);
+      expect(opt_payload).to.not.be.null;
+      expect(opt_payload.creativeId).to.equal('my_creative');
+      expect(opt_payload.vendor).to.equal('my_vendor');
+      expect(opt_payload.message).to.not.be.null;
+      expect(opt_payload.message).to.equal(response);
+    });
     ctx.sendResponseToCreative(response);
     window.onNewContextInstance = undefined;
   });

--- a/extensions/amp-analytics/0.1/test/test-iframe-transport-client.js
+++ b/extensions/amp-analytics/0.1/test/test-iframe-transport-client.js
@@ -85,7 +85,8 @@ describe('iframe-transport-client', () => {
   });
 
   it('sets sentinel from window.name.sentinel ', () => {
-    expect(iframeTransportClient.getClient().sentinel_).to.equal(sentinel);
+    const client = iframeTransportClient.getIframeMessagingClient();
+    expect(client.sentinel_).to.equal(sentinel);
   });
 
   it('receives an event message ', () => {

--- a/extensions/amp-analytics/0.1/test/test-iframe-transport-client.js
+++ b/extensions/amp-analytics/0.1/test/test-iframe-transport-client.js
@@ -153,7 +153,7 @@ describe('iframe-transport-client', () => {
       'my_creative', 'my_vendor');
     const listener = sandbox.spy();
     ctx.onAnalyticsEvent(listener);
-    const event = {message: 'Something important happened'};
+    const event = 'Something important happened';
     ctx.dispatch(event);
     expect(listener).to.be.calledOnce;
     expect(listener).to.be.calledWith(event);

--- a/extensions/amp-analytics/0.1/test/test-iframe-transport.js
+++ b/extensions/amp-analytics/0.1/test/test-iframe-transport.js
@@ -24,8 +24,8 @@ describes.realWin('amp-analytics.iframe-transport', {amp: true}, env => {
 
   beforeEach(() => {
     sandbox = env.sandbox;
-    iframeTransport = new IframeTransport(env.win, 'some_vendor_type',
-        {iframe: frameUrl});
+    iframeTransport = new IframeTransport(env.ampdoc.win, env.win,
+        'some_vendor_type', {iframe: frameUrl}, frameUrl + '-1');
   });
 
   afterEach(() => {
@@ -61,8 +61,9 @@ describes.realWin('amp-analytics.iframe-transport', {amp: true}, env => {
   });
 
   it('does not cause sentinel collisions', () => {
-    const iframeTransport2 = new IframeTransport(env.win,
-        'some_other_vendor_type', {iframe: 'https://example.com/test2'});
+    const iframeTransport2 = new IframeTransport(env.ampdoc.win, env.win,
+        'some_other_vendor_type', {iframe: 'https://example.com/test2'},
+        'https://example.com/test2-2');
 
     const frame1 = IframeTransport.getFrameData(iframeTransport.getType());
     const frame2 = IframeTransport.getFrameData(iframeTransport2.getType());
@@ -72,8 +73,8 @@ describes.realWin('amp-analytics.iframe-transport', {amp: true}, env => {
 
   it('correctly tracks usageCount and destroys iframes', () => {
     const frameUrl2 = 'https://example.com/test2';
-    const iframeTransport2 = new IframeTransport(env.win,
-        'some_other_vendor_type', {iframe: frameUrl2});
+    const iframeTransport2 = new IframeTransport(env.ampdoc.win, env.win,
+        'some_other_vendor_type', {iframe: frameUrl2}, frameUrl2 + '-3');
 
     const frame1 = IframeTransport.getFrameData(iframeTransport.getType());
     const frame2 = IframeTransport.getFrameData(iframeTransport2.getType());

--- a/extensions/amp-analytics/0.1/test/test-iframe-transport.js
+++ b/extensions/amp-analytics/0.1/test/test-iframe-transport.js
@@ -68,8 +68,8 @@ describes.realWin('amp-analytics.iframe-transport', {amp: true}, env => {
     const frame1 = IframeTransport.getFrameData(iframeTransport.getType());
     const frame2 = IframeTransport.getFrameData(iframeTransport2.getType());
     expectAllUnique([iframeTransport.getCreativeId(),
-        iframeTransport2.getCreativeId(),
-        frame1.frame.sentinel, frame2.frame.sentinel]);
+      iframeTransport2.getCreativeId(),
+      frame1.frame.sentinel, frame2.frame.sentinel]);
   });
 
   it('correctly tracks usageCount and destroys iframes', () => {

--- a/extensions/amp-analytics/0.1/test/test-iframe-transport.js
+++ b/extensions/amp-analytics/0.1/test/test-iframe-transport.js
@@ -24,7 +24,7 @@ describes.realWin('amp-analytics.iframe-transport', {amp: true}, env => {
 
   beforeEach(() => {
     sandbox = env.sandbox;
-    iframeTransport = new IframeTransport(env.ampdoc.win, env.win,
+    iframeTransport = new IframeTransport(env.ampdoc.win,
         'some_vendor_type', {iframe: frameUrl}, frameUrl + '-1');
   });
 
@@ -61,19 +61,20 @@ describes.realWin('amp-analytics.iframe-transport', {amp: true}, env => {
   });
 
   it('does not cause sentinel collisions', () => {
-    const iframeTransport2 = new IframeTransport(env.ampdoc.win, env.win,
+    const iframeTransport2 = new IframeTransport(env.ampdoc.win,
         'some_other_vendor_type', {iframe: 'https://example.com/test2'},
         'https://example.com/test2-2');
 
     const frame1 = IframeTransport.getFrameData(iframeTransport.getType());
     const frame2 = IframeTransport.getFrameData(iframeTransport2.getType());
-    expectAllUnique([iframeTransport.getId(), iframeTransport2.getId(),
-      frame1.frame.sentinel, frame2.frame.sentinel]);
+    expectAllUnique([iframeTransport.getCreativeId(),
+        iframeTransport2.getCreativeId(),
+        frame1.frame.sentinel, frame2.frame.sentinel]);
   });
 
   it('correctly tracks usageCount and destroys iframes', () => {
     const frameUrl2 = 'https://example.com/test2';
-    const iframeTransport2 = new IframeTransport(env.ampdoc.win, env.win,
+    const iframeTransport2 = new IframeTransport(env.ampdoc.win,
         'some_other_vendor_type', {iframe: frameUrl2}, frameUrl2 + '-3');
 
     const frame1 = IframeTransport.getFrameData(iframeTransport.getType());

--- a/src/3p-frame-messaging.js
+++ b/src/3p-frame-messaging.js
@@ -51,6 +51,7 @@ export const MessageType = {
   // For amp-analytics' iframe-transport
   SEND_IFRAME_TRANSPORT_EVENTS: 'send-iframe-transport-events',
   IFRAME_TRANSPORT_EVENTS: 'iframe-transport-events',
+  IFRAME_TRANSPORT_RESPONSE: 'iframe-transport-response',
 
   // For user-error-in-iframe
   USER_ERROR_IN_IFRAME: 'user-error-in-iframe',
@@ -122,7 +123,7 @@ export function isAmpMessage(message) {
       message.indexOf('{') != -1);
 }
 
-/** @typedef {{transportId: string, message: string}} */
+/** @typedef {{creativeId: string, message: string}} */
 export let IframeTransportEvent;
 // An event, and the transport ID of the amp-analytics tags that
 // generated it. For instance if the creative with transport


### PR DESCRIPTION
Previous work implemented ability for amp-analytics to create a 3p vendor iframe.
This PR enables the iframe to send a response to the pub page
Parallel PR #11305 enables amp-ad-exit to receive those responses and substitute them into target URLs.