### PR TITLE
Forward all errors to JS Error Reporting Service

### DIFF
--- a/tools/errortracker/errortracker.go
+++ b/tools/errortracker/errortracker.go
@@ -86,6 +86,23 @@ func cloudAuthContext(r *http.Request) (context.Context, error) {
 }
 
 func handle(w http.ResponseWriter, r *http.Request) {
+	// We're temporarily forwarding 100% of traffic to the JS error tracker.
+	if rand.Float64() < 1 {
+		urlString := strings.Replace(r.URL.String(), "amp-error-reporting", "amp-error-reporting-js", 1)
+		client := urlfetch.Client(c)
+		req, err := http.NewRequest("GET", urlString, nil)
+		if err == nil {
+			req.Header.Set("User-Agent", r.UserAgent())
+			req.Header.Set("Referer", r.Referer())
+			_, err := client.Do(req)
+			if err != nil {
+				log.Errorf(c, "Error forwarding report: %v", err)
+			}
+		} else {
+			log.Errorf(c, "Error making forwarding request: %v", err)
+		}
+	}
+
 	c, _ := cloudAuthContext(r)
 	logc, err := logging.NewClient(c, appengine.AppID(c), "javascript.errors")
 	if err != nil {
@@ -171,22 +188,6 @@ func handle(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprintln(w, "THROTTLED\n")
 		return
-	}
-	// We're temporarily forwarding 100% of traffic to the JS error tracker.
-	if rand.Float64() < 1 {
-		urlString := strings.Replace(r.URL.String(), "amp-error-reporting", "amp-error-reporting-js", 1)
-		client := urlfetch.Client(c)
-		req, err := http.NewRequest("GET", urlString, nil)
-		if err == nil {
-			req.Header.Set("User-Agent", r.UserAgent())
-			req.Header.Set("Referer", r.Referer())
-			_, err := client.Do(req)
-			if err != nil {
-				log.Errorf(c, "Error forwarding report: %v", err)
-			}
-		} else {
-			log.Errorf(c, "Error making forwarding request: %v", err)
-		}
 	}
 
 	exception := r.URL.Query().Get("s")


### PR DESCRIPTION
This now forwards before throttling, so we can see how it really performs.