### PR TITLE
Intercept XHR for trusted capable viewers

### DIFF
--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -318,6 +318,7 @@ const forbiddenTerms = {
   '\\.sendMessageAwaitResponse\\(': {
     message: 'Usages must be reviewed.',
     whitelist: [
+      'src/service/xhr-impl.js',
       'src/service/viewer-impl.js',
       'src/service/viewer-cid-api.js',
       'src/service/storage-impl.js',
@@ -382,6 +383,7 @@ const forbiddenTerms = {
   'isTrustedViewer': {
     message: requiresReviewPrivacy,
     whitelist: [
+      'src/service/xhr-impl.js',
       'src/service/viewer-impl.js',
       'src/service/viewer-cid-api.js',
       'src/inabox/inabox-viewer.js',

--- a/extensions/amp-a4a/0.1/test/test-signature-verifier.js
+++ b/extensions/amp-a4a/0.1/test/test-signature-verifier.js
@@ -432,7 +432,7 @@ describes.fakeWin('SignatureVerifier', {amp: true}, env => {
             env.fetchMock.getOnce(
                 'https://signingservice1.net/keyset.json', jwkSet([key1]));
             verifier.loadKeyset('service-1');
-            expect(
+            return expect(
                 verifier.verify(
                     creative1,
                     new Headers({
@@ -447,7 +447,7 @@ describes.fakeWin('SignatureVerifier', {amp: true}, env => {
         env.fetchMock.getOnce(
             'https://signingservice1.net/keyset.json', jwkSet([key1]));
         verifier.loadKeyset('service-1');
-        expect(verifier.verify(creative1, new Headers(), noop))
+        return expect(verifier.verify(creative1, new Headers(), noop))
             .to.eventually.equal(VerificationStatus.UNVERIFIED);
       });
 
@@ -457,7 +457,7 @@ describes.fakeWin('SignatureVerifier', {amp: true}, env => {
             env.fetchMock.getOnce(
                 'https://signingservice1.net/keyset.json', jwkSet([key1]));
             verifier.loadKeyset('service-1');
-            expect(verifier.verify(creative1, new Headers(), noop))
+            return expect(verifier.verify(creative1, new Headers(), noop))
                 .to.eventually.equal(VerificationStatus.UNVERIFIED);
           });
 
@@ -466,7 +466,7 @@ describes.fakeWin('SignatureVerifier', {amp: true}, env => {
             'https://signingservice1.net/keyset.json', jwkSet([key1]));
         env.sandbox.stub(user(), 'error');
         verifier.loadKeyset('service-1');
-        expect(
+        return expect(
             verifier.verify(
                 creative1,
                 new Headers({

--- a/src/service/xhr-impl.js
+++ b/src/service/xhr-impl.js
@@ -29,6 +29,8 @@ import {parseJson} from '../json';
 import {isArray, isObject} from '../types';
 import {utf8EncodeSync} from '../utils/bytes';
 import {getMode} from '../mode';
+import {dict, map} from '../utils/object';
+import {fromIterator} from '../utils/array';
 
 /**
  * The "init" argument of the Fetch API. Currently, only "credentials: include"
@@ -61,6 +63,20 @@ export let FetchInitDef;
  * }}
  */
 export let FetchInitJsonDef;
+
+/**
+ * A record version of `XMLHttpRequest` that has all the necessary properties
+ * and methods of `XMLHttpRequest` to construct a `FetchResponse` from a
+ * serialized response returned by the viewer.
+ * @typedef {{
+ *   status: number,
+ *   statusText: string,
+ *   responseText: string,
+ *   responseXML: ?Document,
+ *   getResponseHeader: function(this:XhrDef, string): string,
+ * }}
+ */
+let XhrDef;
 
 /** @private @const {!Array<string>} */
 const allowedMethods_ = ['GET', 'POST'];
@@ -126,20 +142,218 @@ export class Xhr {
         creds === undefined || creds == 'include' || creds == 'omit',
         'Only credentials=include|omit support: %s', creds);
 
-    // After this point, both the native `fetch` and the `fetch` polyfill will
-    // expect a native `FormData` object in the `body` property, so the native
-    // `FormData` object needs to be unwrapped.
-    if (init.body instanceof FormDataWrapper) {
-      init.body = init.body.getFormData();
+    return this.maybeIntercept_(input, init).then(interceptorResponse => {
+      if (interceptorResponse) {
+        return interceptorResponse;
+      }
+
+      // After this point, both the native `fetch` and the `fetch` polyfill will
+      // expect a native `FormData` object in the `body` property, so the native
+      // `FormData` object needs to be unwrapped.
+      if (init.body instanceof FormDataWrapper) {
+        init.body = init.body.getFormData();
+      }
+      // Fallback to xhr polyfill since `fetch` api does not support
+      // responseType = 'document'. We do this so we don't have to do any
+      // parsing and document construction on the UI thread which would be
+      // expensive.
+      if (init.responseType == 'document') {
+        return fetchPolyfill(input, init);
+      }
+      return (this.win.fetch || fetchPolyfill).apply(null, arguments);
+    });
+  }
+
+  /**
+   * Intercepts the XHR and proxies it through the viewer if necessary.
+   *
+   * XHRs are intercepted if all of the following are true:
+   * - The AMP doc is in single doc mode
+   * - The viewer has the `xhrInterceptor` capability
+   * - The Viewer is a trusted viewer or AMP is currently in developement mode
+   * - The AMP doc is opted-in for XHR interception (`<html>` tag has
+   *   `allow-xhr-interception` attribute)
+   *
+   * @param {string} input The URL of the XHR which may get intercepted.
+   * @param {!FetchInitDef} init The options of the XHR which may get
+   *     intercepted.
+   * @return {!Promise<!FetchResponse|!Response|undefined>}
+   *     A response returned by the interceptor if XHR is intercepted or
+   *     `Promise<undefined>` otherwise.
+   * @private
+   */
+  maybeIntercept_(input, init) {
+    if (!this.ampdocSingle_) {
+      return Promise.resolve();
     }
 
-    // Fallback to xhr polyfill since `fetch` api does not support
-    // responseType = 'document'. We do this so we don't have to do any parsing
-    // and document construction on the UI thread which would be expensive.
-    if (init.responseType == 'document') {
-      return fetchPolyfill(input, init);
+    const docOptedIn = this.win.document.documentElement.hasAttribute(
+        'allow-xhr-interception');
+    if (!docOptedIn) {
+      return Promise.resolve();
     }
-    return (this.win.fetch || fetchPolyfill).apply(null, arguments);
+
+    const viewer = Services.viewerForDoc(this.ampdocSingle_);
+    if (!viewer.hasCapability('xhrInterceptor')) {
+      return Promise.resolve();
+    }
+
+    return viewer.isTrustedViewer().then(viewerTrusted => {
+      if (!viewerTrusted && !getMode(this.win).development) {
+        return;
+      }
+
+      const messagePayload = dict({
+        'originalRequest': this.toStructuredCloneable_(input, init),
+      });
+
+      return viewer.sendMessageAwaitResponse('xhr', messagePayload)
+          .then(response =>
+              this.fromStructuredCloneable_(response, init.responseType));
+    });
+  }
+
+  /**
+   * Serializes a fetch request so that it can be passed to `postMessage()`,
+   * i.e., can be cloned using the
+   * [structured clone algorithm](http://mdn.io/Structured_clone_algorithm).
+   *
+   * The request is serialized in the following way:
+   *
+   * 1. If the `init.body` is a `FormData`, set content-type header to
+   * `multipart/form-data` and transform `init.body` into an
+   * `!Array<!Array<string>>` holding the list of form entries, where each
+   * element in the array is a form entry (key-value pair) represented as a
+   * 2-element array.
+   *
+   * 2. Return a new object having properties `input` and the transformed
+   * `init`.
+   *
+   * The serialized request is assumed to be de-serialized in the following way:
+   *
+   * 1.If content-type header starts with `multipart/form-data`
+   * (case-insensitive), transform the entry array in `init.body` into a
+   * `FormData` object.
+   *
+   * 2. Pass `input` and transformed `init` to `fetch` (or the constructor of
+   * `Request`).
+   *
+   * Currently only `FormData` used in `init.body` is handled as it's the only
+   * type being used in AMP runtime that needs serialization. The `Headers` type
+   * also needs serialization, but callers should not be passing `Headers`
+   * object in `init`, as that fails `fetchPolyfill` on browsers that don't
+   * support fetch. Some serialization-needing types for `init.body` such as
+   * `ArrayBuffer` and `Blob` are already supported by the structured clone
+   * algorithm. Other serialization-needing types such as `URLSearchParams`
+   * (which is not supported in IE and Safari) and `FederatedCredentials` are
+   * not used in AMP runtime.
+   *
+   * @param {string} input The URL of the XHR to convert to structured
+   *     cloneable.
+   * @param {!FetchInitDef} init The options of the XHR to convert to structured
+   *     cloneable.
+   * @return {{input: string, init: !FetchInitDef}} The serialized structurally-
+   *     cloneable request.
+   * @private
+   */
+  toStructuredCloneable_(input, init) {
+    const newInit = Object.assign({}, init);
+    if (init.body instanceof FormDataWrapper) {
+      newInit.headers = newInit.headers || {};
+      newInit.headers['Content-Type'] = 'multipart/form-data;charset=utf-8';
+      newInit.body = fromIterator(init.body.entries());
+    }
+    return {input, init: newInit};
+  }
+
+  /**
+   * De-serializes a fetch response that was made possible to be passed to
+   * `postMessage()`, i.e., can be cloned using the
+   * [structured clone algorithm](http://mdn.io/Structured_clone_algorithm).
+   *
+   * The response is assumed to be serialized in the following way:
+   *
+   * 1. Transform the entries in the headers of the response into an
+   * `!Array<!Array<string>>` holding the list of header entries, where each
+   * element in the array is a header entry (key-value pair) represented as a
+   * 2-element array. The header key is case-insensitive.
+   *
+   * 2. Include the header entry list and `status` and `statusText` properties
+   * of the response in as `headers`, `status` and `statusText` properties of
+   * `init`.
+   *
+   * 3. Include the body of the response serialized as string in `body`.
+   *
+   * 4. Return a new object having properties `body` and `init`.
+   *
+   * The response is de-serialized in the following way:
+   *
+   * 1. If the `Response` type is supported and `responseType` is not
+   * document, pass `body` and `init` directly to the constructor of `Response`.
+   *
+   * 2. Otherwise, populate a fake XHR object to pass to `FetchResponse` as if
+   * the response is returned by the fetch polyfill.
+   *
+   * 3. If `responseType` is `document`, also parse the body and populate
+   * `responseXML` as a `Document` type.
+   *
+   * @param {JsonObject|string|undefined} response The structurally-cloneable
+   *     response to convert back to a regular Response.
+   * @param {string|undefined} responseType The original response type used to
+   *     initiate the XHR.
+   * @return {!FetchResponse|!Response} The deserialized regular response.
+   * @private
+   */
+  fromStructuredCloneable_(response, responseType) {
+    user().assert(isObject(response), 'Object expected: %s', response);
+
+    const isDocumentType = responseType == 'document';
+    if (typeof this.win.Response === 'function' && !isDocumentType) {
+      // Use native `Response` type if available for performance. If response
+      // type is `document`, we must fall back to `FetchResponse` polyfill
+      // because callers would then rely on the `responseXML` property being
+      // present, which is not supported by the Response type.
+      return new this.win.Response(response['body'], response['init']);
+    }
+
+    const lowercasedHeaders = map();
+    const xhr = {
+      status: 200,
+      statusText: 'OK',
+      responseText: (response['body'] ? String(response['body']) : ''),
+      /**
+       * @param {string} name
+       * @return {string}
+       */
+      getResponseHeader(name) {
+        return lowercasedHeaders[String(name).toLowerCase()] || null;
+      },
+    };
+
+    if (response['init']) {
+      const init = response['init'];
+      if (isArray(init.headers)) {
+        init.headers.forEach(entry => {
+          const headerName = entry[0];
+          const headerValue = entry[1];
+          lowercasedHeaders[String(headerName).toLowerCase()] =
+              String(headerValue);
+        });
+      }
+      if (init.status) {
+        xhr.status = parseInt(init.status, 10);
+      }
+      if (init.statusText) {
+        xhr.statusText = String(init.statusText);
+      }
+    }
+
+    if (isDocumentType) {
+      xhr.responseXML =
+          new DOMParser().parseFromString(xhr.responseText, 'text/html');
+    }
+
+    return new FetchResponse(xhr);
   }
 
   /**
@@ -480,10 +694,10 @@ export function assertSuccess(response) {
  */
 export class FetchResponse {
   /**
-   * @param {!XMLHttpRequest|!XDomainRequest} xhr
+   * @param {!XMLHttpRequest|!XDomainRequest|!XhrDef} xhr
    */
   constructor(xhr) {
-    /** @private @const {!XMLHttpRequest|!XDomainRequest} */
+    /** @private @const {!XMLHttpRequest|!XDomainRequest|!XhrDef} */
     this.xhr_ = xhr;
 
     /** @const {number} */
@@ -573,10 +787,10 @@ export class FetchResponse {
  */
 export class FetchResponseHeaders {
   /**
-   * @param {!XMLHttpRequest|!XDomainRequest} xhr
+   * @param {!XMLHttpRequest|!XDomainRequest|!XhrDef} xhr
    */
   constructor(xhr) {
-    /** @private @const {!XMLHttpRequest|!XDomainRequest} */
+    /** @private @const {!XMLHttpRequest|!XDomainRequest|!XhrDef} */
     this.xhr_ = xhr;
   }
 
@@ -600,7 +814,7 @@ export class FetchResponseHeaders {
 
 /**
  * @param {!Window} window
- * @return {!Xhr}
+ * @return {!XhrDef}
  */
 export function xhrServiceForTesting(window) {
   installXhrService(window);

--- a/src/service/xhr-impl.js
+++ b/src/service/xhr-impl.js
@@ -73,10 +73,10 @@ export let FetchInitJsonDef;
  *   statusText: string,
  *   responseText: string,
  *   responseXML: ?Document,
- *   getResponseHeader: function(this:XhrDef, string): string,
+ *   getResponseHeader: function(this:XMLHttpRequestDef, string): string,
  * }}
  */
-let XhrDef;
+let XMLHttpRequestDef;
 
 /** @private @const {!Array<string>} */
 const allowedMethods_ = ['GET', 'POST'];
@@ -187,8 +187,8 @@ export class Xhr {
       return Promise.resolve();
     }
 
-    const docOptedIn = this.win.document.documentElement.hasAttribute(
-        'allow-xhr-interception');
+    const htmlElement = this.ampdocSingle_.getRootNode().documentElement;
+    const docOptedIn = htmlElement.hasAttribute('allow-xhr-interception');
     if (!docOptedIn) {
       return Promise.resolve();
     }
@@ -317,7 +317,7 @@ export class Xhr {
     }
 
     const lowercasedHeaders = map();
-    const xhr = {
+    const data = {
       status: 200,
       statusText: 'OK',
       responseText: (response['body'] ? String(response['body']) : ''),
@@ -341,19 +341,19 @@ export class Xhr {
         });
       }
       if (init.status) {
-        xhr.status = parseInt(init.status, 10);
+        data.status = parseInt(init.status, 10);
       }
       if (init.statusText) {
-        xhr.statusText = String(init.statusText);
+        data.statusText = String(init.statusText);
       }
     }
 
     if (isDocumentType) {
-      xhr.responseXML =
-          new DOMParser().parseFromString(xhr.responseText, 'text/html');
+      data.responseXML =
+          new DOMParser().parseFromString(data.responseText, 'text/html');
     }
 
-    return new FetchResponse(xhr);
+    return new FetchResponse(data);
   }
 
   /**
@@ -694,10 +694,10 @@ export function assertSuccess(response) {
  */
 export class FetchResponse {
   /**
-   * @param {!XMLHttpRequest|!XDomainRequest|!XhrDef} xhr
+   * @param {!XMLHttpRequest|!XDomainRequest|!XMLHttpRequestDef} xhr
    */
   constructor(xhr) {
-    /** @private @const {!XMLHttpRequest|!XDomainRequest|!XhrDef} */
+    /** @private @const {!XMLHttpRequest|!XDomainRequest|!XMLHttpRequestDef} */
     this.xhr_ = xhr;
 
     /** @const {number} */
@@ -787,10 +787,10 @@ export class FetchResponse {
  */
 export class FetchResponseHeaders {
   /**
-   * @param {!XMLHttpRequest|!XDomainRequest|!XhrDef} xhr
+   * @param {!XMLHttpRequest|!XDomainRequest|!XMLHttpRequestDef} xhr
    */
   constructor(xhr) {
-    /** @private @const {!XMLHttpRequest|!XDomainRequest|!XhrDef} */
+    /** @private @const {!XMLHttpRequest|!XDomainRequest|!XMLHttpRequestDef} */
     this.xhr_ = xhr;
   }
 
@@ -814,7 +814,7 @@ export class FetchResponseHeaders {
 
 /**
  * @param {!Window} window
- * @return {!XhrDef}
+ * @return {!Xhr}
  */
 export function xhrServiceForTesting(window) {
   installXhrService(window);

--- a/test/functional/test-xhr.js
+++ b/test/functional/test-xhr.js
@@ -29,7 +29,9 @@ import {Services} from '../../src/services';
 // TODO(jridgewell, #11827): Make this test work on Safari.
 describe.configure().skipSafari().run('XHR', function() {
   let sandbox;
-  let requests;
+  let ampdocServiceForStub;
+  let xhrCreated;
+
   const location = {href: 'https://acme.com/path'};
   const nativeWin = {
     location,
@@ -56,10 +58,7 @@ describe.configure().skipSafari().run('XHR', function() {
 
   function setupMockXhr() {
     const mockXhr = sandbox.useFakeXMLHttpRequest();
-    requests = [];
-    mockXhr.onCreate = function(xhr) {
-      requests.push(xhr);
-    };
+    xhrCreated = new Promise(resolve => mockXhr.onCreate = resolve);
   }
 
   function noOrigin(url) {
@@ -73,9 +72,8 @@ describe.configure().skipSafari().run('XHR', function() {
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
-    sandbox.stub(Services, 'ampdocServiceFor').returns({
-      isSingleDoc: () => false,
-    });
+    ampdocServiceForStub = sandbox.stub(Services, 'ampdocServiceFor');
+    ampdocServiceForStub.returns({isSingleDoc: () => false});
     location.href = 'https://acme.com/path';
   });
 
@@ -145,31 +143,36 @@ describe.configure().skipSafari().run('XHR', function() {
 
         it('should do `GET` as default method', () => {
           xhr.fetchJson('/get?k=v1');
-          expect(requests[0].method).to.equal('GET');
+          return xhrCreated.then(xhr => expect(xhr.method).to.equal('GET'));
         });
 
-        it('should normalize method names to uppercase', () => {
+        it('should normalize GET method name to uppercase', () => {
           xhr.fetchJson('/abc');
+          return xhrCreated.then(xhr => expect(xhr.method).to.equal('GET'));
+        });
+
+        it('should normalize POST method name to uppercase', () => {
           xhr.fetchJson('/abc', {
             method: 'post',
             body: {
               hello: 'world',
             },
           });
-          expect(requests[0].method).to.equal('GET');
-          expect(requests[1].method).to.equal('POST');
+          return xhrCreated.then(xhr => expect(xhr.method).to.equal('POST'));
         });
 
         it('should inject source origin query parameter', () => {
           xhr.fetchJson('/get?k=v1#h1');
-          expect(noOrigin(requests[0].url)).to.equal(
-              '/get?k=v1&__amp_source_origin=https%3A%2F%2Facme.com#h1');
+          return xhrCreated.then(xhr =>
+              expect(noOrigin(xhr.url)).to.equal(
+                  '/get?k=v1&__amp_source_origin=https%3A%2F%2Facme.com#h1'));
         });
 
         it('should inject source origin query parameter w/o query', () => {
           xhr.fetchJson('/get');
-          expect(noOrigin(requests[0].url)).to.equal(
-              '/get?__amp_source_origin=https%3A%2F%2Facme.com');
+          return xhrCreated.then(xhr =>
+              expect(noOrigin(xhr.url)).to.equal(
+                  '/get?__amp_source_origin=https%3A%2F%2Facme.com'));
         });
 
         it('should defend against invalid source origin query ' +
@@ -194,28 +197,37 @@ describe.configure().skipSafari().run('XHR', function() {
         it('should not include __amp_source_origin if ampCors ' +
             'set to false', () => {
           xhr.fetchJson('/get', {ampCors: false});
-          expect(noOrigin(requests[0].url)).to.equal('/get');
+          return xhrCreated.then(
+              xhr => expect(noOrigin(xhr.url)).to.equal('/get'));
         });
 
         it('should accept AMP origin when received in response', () => {
           const promise = xhr.fetchJson('/get');
-          requests[0].respond(200, {
-            'Content-Type': 'application/json',
-            'Access-Control-Expose-Headers':
-                'AMP-Access-Control-Allow-Source-Origin',
-            'AMP-Access-Control-Allow-Source-Origin': 'https://acme.com',
-          }, '{}');
+          xhrCreated.then(
+              xhr => xhr.respond(
+                  200, {
+                    'Content-Type': 'application/json',
+                    'Access-Control-Expose-Headers':
+                        'AMP-Access-Control-Allow-Source-Origin',
+                    'AMP-Access-Control-Allow-Source-Origin':
+                        'https://acme.com',
+                  },
+                  '{}'));
           return promise;
         });
 
         it('should deny AMP origin for different origin in response', () => {
           const promise = xhr.fetchJson('/get');
-          requests[0].respond(200, {
-            'Content-Type': 'application/json',
-            'Access-Control-Expose-Headers':
-                'AMP-Access-Control-Allow-Source-Origin',
-            'AMP-Access-Control-Allow-Source-Origin': 'https://other.com',
-          }, '{}');
+          xhrCreated.then(
+              xhr => xhr.respond(
+                  200, {
+                    'Content-Type': 'application/json',
+                    'Access-Control-Expose-Headers':
+                        'AMP-Access-Control-Allow-Source-Origin',
+                    'AMP-Access-Control-Allow-Source-Origin':
+                        'https://other.com',
+                  },
+                  '{}'));
           return promise.then(() => {
             throw new Error('UNREACHABLE');
           }, res => {
@@ -225,9 +237,12 @@ describe.configure().skipSafari().run('XHR', function() {
 
         it('should require AMP origin in response for when request', () => {
           const promise = xhr.fetchJson('/get');
-          requests[0].respond(200, {
-            'Content-Type': 'application/json',
-          }, '{}');
+          xhrCreated.then(
+              xhr => xhr.respond(
+                  200, {
+                    'Content-Type': 'application/json',
+                  },
+                  '{}'));
           return promise.then(() => {
             throw new Error('UNREACHABLE');
           }, error => {
@@ -424,28 +439,33 @@ describe.configure().skipSafari().run('XHR', function() {
 
       it('should be able to fetch a document', () => {
         setupMockXhr();
-        expect(requests[0]).to.be.undefined;
         const promise = xhr.fetchDocument('/index.html').then(doc => {
           expect(doc.nodeType).to.equal(9);
         });
-        expect(requests[0].requestHeaders['Accept']).to.equal('text/html');
-        requests[0].respond(200, {
-          'Content-Type': 'text/xml',
-          'Access-Control-Expose-Headers':
-              'AMP-Access-Control-Allow-Source-Origin',
-          'AMP-Access-Control-Allow-Source-Origin': 'https://acme.com',
-        }, '<html></html>');
-        expect(requests[0].responseType).to.equal('document');
+        xhrCreated.then(xhr => {
+          expect(xhr.requestHeaders['Accept']).to.equal('text/html');
+          xhr.respond(
+              200, {
+                'Content-Type': 'text/xml',
+                'Access-Control-Expose-Headers':
+                    'AMP-Access-Control-Allow-Source-Origin',
+                'AMP-Access-Control-Allow-Source-Origin': 'https://acme.com',
+              },
+              '<html></html>');
+          expect(xhr.responseType).to.equal('document');
+        });
         return promise;
       });
 
       it('should mark 400 as not retriable', () => {
         setupMockXhr();
-        expect(requests[0]).to.be.undefined;
         const promise = xhr.fetchDocument('/index.html');
-        requests[0].respond(400, {
-          'Content-Type': 'text/xml',
-        }, '<html></html>');
+        xhrCreated.then(
+            xhr => xhr.respond(
+                400, {
+                  'Content-Type': 'text/xml',
+                },
+                '<html></html>'));
         return promise.catch(e => {
           expect(e.retriable).to.be.undefined;
           expect(e.retriable === true).to.be.false;
@@ -454,14 +474,16 @@ describe.configure().skipSafari().run('XHR', function() {
 
       it('should mark 415 as retriable', () => {
         setupMockXhr();
-        expect(requests[0]).to.be.undefined;
         const promise = xhr.fetchDocument('/index.html');
-        requests[0].respond(415, {
-          'Content-Type': 'text/xml',
-          'Access-Control-Expose-Headers':
-              'AMP-Access-Control-Allow-Source-Origin',
-          'AMP-Access-Control-Allow-Source-Origin': 'https://acme.com',
-        }, '<html></html>');
+        xhrCreated.then(
+            xhr => xhr.respond(
+                415, {
+                  'Content-Type': 'text/xml',
+                  'Access-Control-Expose-Headers':
+                      'AMP-Access-Control-Allow-Source-Origin',
+                  'AMP-Access-Control-Allow-Source-Origin': 'https://acme.com',
+                },
+                '<html></html>'));
         return promise.catch(e => {
           expect(e.retriable).to.exist;
           expect(e.retriable === true).to.be.true;
@@ -470,14 +492,16 @@ describe.configure().skipSafari().run('XHR', function() {
 
       it('should mark 500 as retriable', () => {
         setupMockXhr();
-        expect(requests[0]).to.be.undefined;
         const promise = xhr.fetchDocument('/index.html');
-        requests[0].respond(415, {
-          'Content-Type': 'text/xml',
-          'Access-Control-Expose-Headers':
-              'AMP-Access-Control-Allow-Source-Origin',
-          'AMP-Access-Control-Allow-Source-Origin': 'https://acme.com',
-        }, '<html></html>');
+        xhrCreated.then(
+            xhr => xhr.respond(
+                415, {
+                  'Content-Type': 'text/xml',
+                  'Access-Control-Expose-Headers':
+                      'AMP-Access-Control-Allow-Source-Origin',
+                  'AMP-Access-Control-Allow-Source-Origin': 'https://acme.com',
+                },
+                '<html></html>'));
         return promise.catch(e => {
           expect(e.retriable).to.exist;
           expect(e.retriable === true).to.be.true;
@@ -486,14 +510,16 @@ describe.configure().skipSafari().run('XHR', function() {
 
       it('should error on non truthy responseXML', () => {
         setupMockXhr();
-        expect(requests[0]).to.be.undefined;
         const promise = xhr.fetchDocument('/index.html');
-        requests[0].respond(200, {
-          'Content-Type': 'application/json',
-          'Access-Control-Expose-Headers':
-              'AMP-Access-Control-Allow-Source-Origin',
-          'AMP-Access-Control-Allow-Source-Origin': 'https://acme.com',
-        }, '{"hello": "world"}');
+        xhrCreated.then(
+            xhr => xhr.respond(
+                200, {
+                  'Content-Type': 'application/json',
+                  'Access-Control-Expose-Headers':
+                      'AMP-Access-Control-Allow-Source-Origin',
+                  'AMP-Access-Control-Allow-Source-Origin': 'https://acme.com',
+                },
+                '{"hello": "world"}'));
         return promise.catch(e => {
           expect(e.message)
               .to.contain('responseXML should exist');
@@ -541,7 +567,6 @@ describe.configure().skipSafari().run('XHR', function() {
       if (test.desc != 'Native') {
         it('should be able to fetch a response', () => {
           setupMockXhr();
-          expect(requests[0]).to.be.undefined;
           const promise = xhr.fetch(
               '/index.html').then(response => {
                 expect(response.headers.get('X-foo-header')).to
@@ -553,14 +578,18 @@ describe.configure().skipSafari().run('XHR', function() {
                       expect(text).to.equal(creative);
                     });
               });
-          requests[0].respond(200, {
-            'Content-Type': 'text/xml',
-            'Access-Control-Expose-Headers':
-                'AMP-Access-Control-Allow-Source-Origin',
-            'AMP-Access-Control-Allow-Source-Origin': 'https://acme.com',
-            'X-foo-header': 'foo data',
-            'X-bar-header': 'bar data',
-          }, creative);
+          xhrCreated.then(
+              xhr => xhr.respond(
+                  200, {
+                    'Content-Type': 'text/xml',
+                    'Access-Control-Expose-Headers':
+                        'AMP-Access-Control-Allow-Source-Origin',
+                    'AMP-Access-Control-Allow-Source-Origin':
+                        'https://acme.com',
+                    'X-foo-header': 'foo data',
+                    'X-bar-header': 'bar data',
+                  },
+                  creative));
           return promise;
         });
       }
@@ -587,11 +616,12 @@ describe.configure().skipSafari().run('XHR', function() {
               'Other': 'another',
             },
           });
-          expect(requests[0].requestHeaders).to.deep.equal({
-            'Accept': 'application/json',
-            'Content-Type': 'text/plain;charset=utf-8',
-            'Other': 'another',  // Not removed when other headers set.
-          });
+          return xhrCreated.then(
+              xhr => expect(xhr.requestHeaders).to.deep.equal({
+                'Accept': 'application/json',
+                'Content-Type': 'text/plain;charset=utf-8',
+                'Other': 'another',  // Not removed when other headers set.
+              }));
         });
       }
 
@@ -707,7 +737,6 @@ describe.configure().skipSafari().run('XHR', function() {
           });
 
           it('should return text from a full XHR request', () => {
-            expect(requests[0]).to.be.undefined;
             const promise = xhr.fetchAmpCors_('http://nowhere.org').then(
                 response => {
                   expect(response).to.be.instanceof(FetchResponse);
@@ -715,16 +744,423 @@ describe.configure().skipSafari().run('XHR', function() {
                     expect(result).to.equal(TEST_TEXT);
                   });
                 });
-            requests[0].respond(200, {
-              'Content-Type': 'text/plain',
-              'Access-Control-Expose-Headers':
-                  'AMP-Access-Control-Allow-Source-Origin',
-              'AMP-Access-Control-Allow-Source-Origin': 'https://acme.com',
-            }, TEST_TEXT);
+            xhrCreated.then(
+                xhr => xhr.respond(
+                    200, {
+                      'Content-Type': 'text/plain',
+                      'Access-Control-Expose-Headers':
+                          'AMP-Access-Control-Allow-Source-Origin',
+                      'AMP-Access-Control-Allow-Source-Origin':
+                          'https://acme.com',
+                    },
+                    TEST_TEXT));
             return promise;
           });
         });
       }
+    });
+  });
+
+  describe('interceptor', () => {
+    const origin = 'https://acme.com';
+
+    let interceptionEnabledWin;
+    let viewer;
+    let sendMessageStub;
+
+    function getDefaultResponseOptions() {
+      return {
+        headers: [
+          ['AMP-Access-Control-Allow-Source-Origin', origin],
+        ],
+      };
+    }
+
+    function getDefaultResponsePromise() {
+      return Promise.resolve({init: getDefaultResponseOptions()});
+    }
+
+    beforeEach(() => {
+      ampdocServiceForStub.returns({
+        isSingleDoc: () => true,
+        getAmpDoc: () => ({}),
+      });
+
+      viewer = {
+        hasCapability: () => true,
+        isTrustedViewer: () => Promise.resolve(true),
+        sendMessageAwaitResponse: getDefaultResponsePromise,
+      };
+      sendMessageStub = sandbox.stub(viewer, 'sendMessageAwaitResponse');
+      sendMessageStub.returns(getDefaultResponsePromise());
+      sandbox.stub(Services, 'viewerForDoc').returns(viewer);
+
+      const optedInDoc = window.document.implementation.createHTMLDocument('');
+      optedInDoc.documentElement.setAttribute('allow-xhr-interception', '');
+
+      interceptionEnabledWin = {
+        location: {
+          href: `${origin}/path`,
+        },
+        fetch: () =>
+            Promise.resolve(new Response('', getDefaultResponseOptions())),
+        document: optedInDoc,
+      };
+    });
+
+    it('should not intercept if AMP doc is not single', () => {
+      ampdocServiceForStub.returns({isSingleDoc: () => false});
+      const xhr = xhrServiceForTesting(interceptionEnabledWin);
+
+      return xhr.fetch('https://cdn.ampproject.org')
+          .then(() => expect(sendMessageStub).to.not.have.been.called);
+    });
+
+    it('should not intercept if AMP doc does not opt in', () => {
+      const nonOptedInDoc =
+          window.document.implementation.createHTMLDocument('');
+      interceptionEnabledWin.document = nonOptedInDoc;
+
+      const xhr = xhrServiceForTesting(interceptionEnabledWin);
+
+      return xhr.fetch('https://cdn.ampproject.org')
+          .then(() => expect(sendMessageStub).to.not.have.been.called);
+    });
+
+    it('should not intercept if viewer is not capable', () => {
+      sandbox.stub(viewer, 'hasCapability').withArgs('xhrInterceptor')
+          .returns(false);
+      const xhr = xhrServiceForTesting(interceptionEnabledWin);
+
+      return xhr.fetch('https://cdn.ampproject.org')
+          .then(() => expect(sendMessageStub).to.not.have.been.called);
+    });
+
+    it('should not intercept if viewer untrusted and non-dev mode', () => {
+      sandbox.stub(viewer, 'isTrustedViewer').returns(Promise.resolve(false));
+      interceptionEnabledWin.AMP_DEV_MODE = false;
+
+      const xhr = xhrServiceForTesting(interceptionEnabledWin);
+
+      return xhr.fetch('https://cdn.ampproject.org')
+          .then(() => expect(sendMessageStub).to.not.have.been.called);
+    });
+
+    it('should intercept if viewer untrusted but dev mode', () => {
+      sandbox.stub(viewer, 'isTrustedViewer').returns(Promise.resolve(false));
+      interceptionEnabledWin.AMP_DEV_MODE = true;
+
+      const xhr = xhrServiceForTesting(interceptionEnabledWin);
+
+      return xhr.fetch('https://cdn.ampproject.org')
+          .then(() => expect(sendMessageStub).to.have.been.called);
+    });
+
+    it('should intercept if non-dev mode but viewer trusted', () => {
+      sandbox.stub(viewer, 'isTrustedViewer').returns(Promise.resolve(true));
+      interceptionEnabledWin.AMP_DEV_MODE = false;
+
+      const xhr = xhrServiceForTesting(interceptionEnabledWin);
+
+      return xhr.fetch('https://cdn.ampproject.org')
+          .then(() => expect(sendMessageStub).to.have.been.called);
+    });
+
+    it('should send viewer message named `xhr`', () => {
+      const xhr = xhrServiceForTesting(interceptionEnabledWin);
+
+      return xhr.fetch('https://cdn.ampproject.org')
+          .then(() =>
+              expect(sendMessageStub).to.have.been.calledWithMatch(
+                  'xhr', sinon.match.any));
+    });
+
+    it('should post correct structurally-cloneable GET request', () => {
+      const xhr = xhrServiceForTesting(interceptionEnabledWin);
+
+      return xhr.fetch('https://cdn.ampproject.org')
+          .then(() =>
+              expect(sendMessageStub).to.have.been.calledWithMatch(
+                  sinon.match.any, {
+                    originalRequest: {
+                      input: 'https://cdn.ampproject.org' +
+                          '?__amp_source_origin=https%3A%2F%2Facme.com',
+                      init: {
+                        headers: {},
+                        method: 'GET',
+                        requireAmpResponseSourceOrigin: true,
+                      },
+                    },
+                  }));
+    });
+
+    it('should post correct structurally-cloneable JSON request', () => {
+      const xhr = xhrServiceForTesting(interceptionEnabledWin);
+
+      return xhr
+          .fetch('https://cdn.ampproject.org', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json;charset=utf-8'},
+            body: JSON.stringify({a: 42, b: [24, true]}),
+          })
+          .then(() =>
+              expect(sendMessageStub).to.have.been.calledWithMatch(
+                  sinon.match.any, {
+                    originalRequest: {
+                      input: 'https://cdn.ampproject.org' +
+                          '?__amp_source_origin=https%3A%2F%2Facme.com',
+                      init: {
+                        headers: {
+                          'Content-Type':
+                              'application/json;charset=utf-8',
+                        },
+                        body: '{"a":42,"b":[24,true]}',
+                        method: 'POST',
+                        requireAmpResponseSourceOrigin: true,
+                      },
+                    },
+                  }));
+    });
+
+    it('should post correct structurally-cloneable FormData request', () => {
+      const xhr = xhrServiceForTesting(interceptionEnabledWin);
+
+      const formData = new FormDataWrapper();
+      formData.append('a', 42);
+      formData.append('b', '24');
+      formData.append('b', true);
+
+      return xhr
+          .fetch('https://cdn.ampproject.org', {
+            method: 'POST',
+            body: formData,
+          })
+          .then(() =>
+              expect(sendMessageStub).to.have.been.calledWithMatch(
+                  sinon.match.any, {
+                    originalRequest: {
+                      input: 'https://cdn.ampproject.org' +
+                          '?__amp_source_origin=https%3A%2F%2Facme.com',
+                      init: {
+                        headers: {
+                          'Content-Type':
+                              'multipart/form-data;charset=utf-8',
+                        },
+                        body: [['a', '42'], ['b', '24'], ['b', 'true']],
+                        method: 'POST',
+                        requireAmpResponseSourceOrigin: true,
+                      },
+                    },
+                  }));
+    });
+
+    it('should be rejected when response undefined', () => {
+      sendMessageStub.returns(Promise.resolve());
+      const xhr = xhrServiceForTesting(interceptionEnabledWin);
+
+      return expect(xhr.fetch('https://cdn.ampproject.org'))
+          .to.eventually.be.rejectedWith(Error, 'Object expected: undefined');
+    });
+
+    it('should be rejected when response null', () => {
+      sendMessageStub.returns(Promise.resolve(null));
+      const xhr = xhrServiceForTesting(interceptionEnabledWin);
+
+      return expect(xhr.fetch('https://cdn.ampproject.org'))
+          .to.eventually.be.rejectedWith(Error, 'Object expected: null');
+    });
+
+    it('should be rejected when response is string', () => {
+      sendMessageStub.returns(Promise.resolve('response text'));
+      const xhr = xhrServiceForTesting(interceptionEnabledWin);
+
+      return expect(xhr.fetch('https://cdn.ampproject.org')).to.eventually
+          .be.rejectedWith(Error, 'Object expected: response text');
+    });
+
+    describe('when native Response type is available', () => {
+      beforeEach(() => interceptionEnabledWin.Response = window.Response);
+
+      it('should return correct non-document response', () => {
+        sendMessageStub.returns(
+            Promise.resolve({
+              body: '{"content":32}',
+              init: {
+                status: 242,
+                statusText: 'Magic status',
+                headers: [
+                  ['a', 2],
+                  ['b', false],
+                  ['AMP-Access-Control-Allow-Source-Origin', origin],
+                ],
+              },
+            }));
+        const xhr = xhrServiceForTesting(interceptionEnabledWin);
+
+        return xhr.fetch('https://cdn.ampproject.org').then(response => {
+          expect(response.headers.get('a')).to.equal('2');
+          expect(response.headers.get('b')).to.equal('false');
+          expect(response.headers.get('Amp-Access-Control-Allow-source-origin'))
+              .to.equal(origin);
+          expect(response).to.have.property('ok').that.is.true;
+          expect(response).to.have.property('status').that.equals(242);
+          expect(response).to.have.property('statusText')
+              .that.equals('Magic status');
+          return expect(response.text()).to.eventually.equal('{"content":32}');
+          return expect(response.json()).to.eventually.deep.equal({
+            content: 32,
+          });
+        });
+      });
+
+      it('should return correct document response', () => {
+        sendMessageStub.returns(
+            Promise.resolve({
+              body: '<html><body>Foo</body></html>',
+              init: {
+                headers: [['AMP-Access-Control-Allow-Source-Origin', origin]],
+              },
+            }));
+        const xhr = xhrServiceForTesting(interceptionEnabledWin);
+
+        return xhr.fetchDocument('https://cdn.ampproject.org').then(doc => {
+          expect(doc).to.have.nested.property('body.textContent')
+              .that.equals('Foo');
+        });
+      });
+    });
+
+    describe('when native Response type is unavailable', () => {
+      beforeEach(() => interceptionEnabledWin.Response = undefined);
+
+      it('should return correct non-document response', () => {
+        sendMessageStub.returns(
+            Promise.resolve({
+              body: '{"content":32}',
+              init: {
+                status: 242,
+                statusText: 'Magic status',
+                headers: [
+                  ['a', 2],
+                  ['b', false],
+                  ['AMP-Access-Control-Allow-Source-Origin', origin],
+                ],
+              },
+            }));
+        const xhr = xhrServiceForTesting(interceptionEnabledWin);
+
+        return xhr.fetch('https://cdn.ampproject.org').then(response => {
+          expect(response.headers.get('a')).to.equal('2');
+          expect(response.headers.get('b')).to.equal('false');
+          expect(response.headers.get('Amp-Access-Control-Allow-Source-Origin'))
+              .to.equal(origin);
+          expect(response).to.have.property('ok').that.is.true;
+          expect(response).to.have.property('status').that.equals(242);
+          return expect(response.json()).to.eventually.deep.equal({
+            content: 32,
+          });
+        });
+      });
+
+      it('should return correct document response', () => {
+        sendMessageStub.returns(
+            Promise.resolve({
+              body: '<html><body>Foo</body></html>',
+              init: {
+                headers: [['AMP-Access-Control-Allow-Source-Origin', origin]],
+              },
+            }));
+        const xhr = xhrServiceForTesting(interceptionEnabledWin);
+
+        return xhr.fetchDocument('https://cdn.ampproject.org')
+            .then(doc => expect(doc.body.textContent).to.equal('Foo'));
+      });
+
+      it('should return default response when body/init missing', () => {
+        sendMessageStub.returns(Promise.resolve({}));
+        const xhr = xhrServiceForTesting(interceptionEnabledWin);
+
+        return xhr.fetch('https://cdn.ampproject.org', {ampCors: false})
+            .then(response => {
+              expect(response.headers.get('a')).to.be.null;
+              expect(response.headers.has('a')).to.be.false;
+              expect(response).to.have.property('ok').that.is.true;
+              expect(response).to.have.property('status').that.equals(200);
+              return expect(response.text()).to.eventually.be.empty;
+            });
+      });
+
+      it('should return default response when status/headers missing', () => {
+        sendMessageStub.returns(Promise.resolve({body: '', init: {}}));
+        const xhr = xhrServiceForTesting(interceptionEnabledWin);
+
+        return xhr.fetch('https://cdn.ampproject.org', {ampCors: false})
+            .then(response => {
+              expect(response.headers.get('a')).to.be.null;
+              expect(response.headers.has('a')).to.be.false;
+              expect(response).to.have.property('status').that.equals(200);
+            });
+      });
+
+      it('should convert body to string', () => {
+        sendMessageStub.returns(Promise.resolve({body: 32}));
+        const xhr = xhrServiceForTesting(interceptionEnabledWin);
+
+        return xhr.fetch('https://cdn.ampproject.org', {ampCors: false})
+            .then(response => {
+              return expect(response.text()).to.eventually.equal('32');
+            });
+      });
+
+      it('should convert status to int', () => {
+        sendMessageStub.returns(Promise.resolve({init: {status: '209.6'}}));
+        const xhr = xhrServiceForTesting(interceptionEnabledWin);
+
+        return xhr.fetch('https://cdn.ampproject.org', {ampCors: false})
+            .then(response => {
+              return expect(response).to.have.property('status')
+                  .that.equals(209);
+            });
+      });
+
+      it('should convert headers to string', () => {
+        sendMessageStub.returns(
+            Promise.resolve({
+              init: {
+                headers: [[1, true], [false, NaN], [undefined, null]],
+              },
+            }));
+        const xhr = xhrServiceForTesting(interceptionEnabledWin);
+
+        return xhr.fetch('https://cdn.ampproject.org', {ampCors: false})
+            .then(response => {
+              expect(response.headers.get(1)).to.equal('true');
+              expect(response.headers.get('false')).to.equal('NaN');
+              expect(response.headers.get('undefined')).to.equal('null');
+            });
+      });
+
+      it('should support case-insensitive header search', () => {
+        sendMessageStub.returns(
+            Promise.resolve({
+              init: {
+                headers: [
+                  ['Content-Type', 'text/plain'],
+                  ['ACCEPT', 'text/plain'],
+                  ['x-amp-custom', 'foo'],
+                ],
+              },
+            }));
+        const xhr = xhrServiceForTesting(interceptionEnabledWin);
+
+        return xhr.fetch('https://cdn.ampproject.org', {ampCors: false})
+            .then(response => {
+              expect(response.headers.get('content-type'))
+                  .to.equal('text/plain');
+              expect(response.headers.get('Accept')).to.equal('text/plain');
+              expect(response.headers.get('X-AMP-CUSTOM')).to.equal('foo');
+            });
+      });
     });
   });
 });


### PR DESCRIPTION
Some trusted custom AMP Viewers require the runtime to delegate all XHRs
triggered from the AMP document to the viewer to handle.

Instead of sending the XHRs directly from the AMP document, the AMP
runtime delegates the task of sending the XHR to the viewer and waits
for the viewer to return the XHR response.

This includes a polyfill for FormData#entries, as the XHR service needs
to be able to read the entries in FormData if it is passed to `body` in
order to make it a strucured cloneable.

This resolves #11294.

@choumx for some early feedback (hence not including tests yet).