### PR TITLE
Allow FF on canonical, non SSL pages

### DIFF
--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -691,7 +691,7 @@ export class AmpA4A extends AMP.BaseElement {
                   case VerificationStatus.UNVERIFIED:
                     return null;
                   case VerificationStatus.CRYPTO_UNAVAILABLE:
-                    return this.cryptoUnavailable(bytes);
+                    return this.ffWithoutCrypto() ? null : bytes;
                   // TODO(@taymonbeal, #9274): differentiate between these
                   case VerificationStatus.ERROR_KEY_NOT_FOUND:
                   case VerificationStatus.ERROR_SIGNATURE_MISMATCH:
@@ -1541,8 +1541,12 @@ export class AmpA4A extends AMP.BaseElement {
    */
   emitLifecycleEvent(unusedEventName, opt_extraVariables) {}
 
-  cryptoUnavailable(bytes) {
-    return null;
+  /**
+   * Whether Fast Fetch should still be utilized if web crypto is unavailable.
+   * @return {!boolean}
+   */
+  ffWithoutCrypto() {
+    return false;
   }
 }
 

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -691,7 +691,7 @@ export class AmpA4A extends AMP.BaseElement {
                   case VerificationStatus.UNVERIFIED:
                     return null;
                   case VerificationStatus.CRYPTO_UNAVAILABLE:
-                    return this.preferentialRenderWithoutCrypto() ?
+                    return this.shouldPreferentialRenderWithoutCrypto() ?
                       bytes : null;
                   // TODO(@taymonbeal, #9274): differentiate between these
                   case VerificationStatus.ERROR_KEY_NOT_FOUND:
@@ -1546,7 +1546,7 @@ export class AmpA4A extends AMP.BaseElement {
    * Whether preferential render should still be utilized if web crypto is unavailable.
    * @return {!boolean}
    */
-  preferentialRenderWithoutCrypto() {
+  shouldPreferentialRenderWithoutCrypto() {
     return false;
   }
 }

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -690,6 +690,8 @@ export class AmpA4A extends AMP.BaseElement {
                     return bytes;
                   case VerificationStatus.UNVERIFIED:
                     return null;
+                  case VerificationStatus.CRYPTO_UNAVAILABLE:
+                    return this.cryptoUnavailable(bytes);
                   // TODO(@taymonbeal, #9274): differentiate between these
                   case VerificationStatus.ERROR_KEY_NOT_FOUND:
                   case VerificationStatus.ERROR_SIGNATURE_MISMATCH:
@@ -1538,6 +1540,10 @@ export class AmpA4A extends AMP.BaseElement {
    * @param {!Object<string, string|number>=} opt_extraVariables
    */
   emitLifecycleEvent(unusedEventName, opt_extraVariables) {}
+
+  cryptoUnavailable(bytes) {
+    return null;
+  }
 }
 
 /**

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -692,7 +692,7 @@ export class AmpA4A extends AMP.BaseElement {
                     return null;
                   case VerificationStatus.CRYPTO_UNAVAILABLE:
                     return this.preferentialRenderWithoutCrypto() ?
-                      null : bytes;
+                      bytes : null;
                   // TODO(@taymonbeal, #9274): differentiate between these
                   case VerificationStatus.ERROR_KEY_NOT_FOUND:
                   case VerificationStatus.ERROR_SIGNATURE_MISMATCH:

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -1543,7 +1543,8 @@ export class AmpA4A extends AMP.BaseElement {
   emitLifecycleEvent(unusedEventName, opt_extraVariables) {}
 
   /**
-   * Whether preferential render should still be utilized if web crypto is unavailable.
+   * Whether preferential render should still be utilized if web crypto is unavailable,
+   * and crypto signature header is present.
    * @return {!boolean}
    */
   shouldPreferentialRenderWithoutCrypto() {

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -691,7 +691,8 @@ export class AmpA4A extends AMP.BaseElement {
                   case VerificationStatus.UNVERIFIED:
                     return null;
                   case VerificationStatus.CRYPTO_UNAVAILABLE:
-                    return this.ffWithoutCrypto() ? null : bytes;
+                    return this.preferentialRenderWithoutCrypto() ?
+                      null : bytes;
                   // TODO(@taymonbeal, #9274): differentiate between these
                   case VerificationStatus.ERROR_KEY_NOT_FOUND:
                   case VerificationStatus.ERROR_SIGNATURE_MISMATCH:
@@ -1542,10 +1543,10 @@ export class AmpA4A extends AMP.BaseElement {
   emitLifecycleEvent(unusedEventName, opt_extraVariables) {}
 
   /**
-   * Whether Fast Fetch should still be utilized if web crypto is unavailable.
+   * Whether preferential render should still be utilized if web crypto is unavailable.
    * @return {!boolean}
    */
-  ffWithoutCrypto() {
+  preferentialRenderWithoutCrypto() {
     return false;
   }
 }

--- a/extensions/amp-a4a/0.1/legacy-signature-verifier.js
+++ b/extensions/amp-a4a/0.1/legacy-signature-verifier.js
@@ -242,7 +242,7 @@ export class LegacySignatureVerifier {
    */
   verify(creative, headers, lifecycleCallback) {
     if (!this.isAvailable_()) {
-      return Promise.resolve(VerificationStatus.UNVERIFIED);
+      return Promise.resolve(VerificationStatus.CRYPTO_UNAVAILABLE);
     }
     const headerValue = headers.get(AMP_SIGNATURE_HEADER);
     if (!headerValue) {

--- a/extensions/amp-a4a/0.1/legacy-signature-verifier.js
+++ b/extensions/amp-a4a/0.1/legacy-signature-verifier.js
@@ -241,12 +241,12 @@ export class LegacySignatureVerifier {
    * @return {!Promise<!VerificationStatus>}
    */
   verify(creative, headers, lifecycleCallback) {
-    if (!this.isAvailable_()) {
-      return Promise.resolve(VerificationStatus.CRYPTO_UNAVAILABLE);
-    }
     const headerValue = headers.get(AMP_SIGNATURE_HEADER);
     if (!headerValue) {
       return Promise.resolve(VerificationStatus.UNVERIFIED);
+    }
+    if (!this.isAvailable_()) {
+      return Promise.resolve(VerificationStatus.CRYPTO_UNAVAILABLE);
     }
     let signature;
     try {

--- a/extensions/amp-a4a/0.1/signature-verifier.js
+++ b/extensions/amp-a4a/0.1/signature-verifier.js
@@ -50,6 +50,12 @@ export const VerificationStatus = {
    */
   ERROR_SIGNATURE_MISMATCH: 3,
 
+  /**
+   * Verificaiton failed because the page does not have web crypto available,
+   * i.e. is not SSL.
+   */
+  CRYPTO_UNAVAILABLE: 4,
+
 };
 
 /**
@@ -244,7 +250,7 @@ export class SignatureVerifier {
       signingServiceName, keypairId, signature, creative, lifecycleCallback) {
     if (!this.signers_) {
       // Web Cryptography isn't available.
-      return Promise.resolve(VerificationStatus.UNVERIFIED);
+      return Promise.resolve(VerificationStatus.CRYPTO_UNAVAILABLE);
     }
     const signer = this.signers_[signingServiceName];
     dev().assert(

--- a/extensions/amp-a4a/0.1/signature-verifier.js
+++ b/extensions/amp-a4a/0.1/signature-verifier.js
@@ -51,7 +51,7 @@ export const VerificationStatus = {
   ERROR_SIGNATURE_MISMATCH: 3,
 
   /**
-   * Verificaiton failed because the page does not have web crypto available,
+   * Verification failed because the page does not have web crypto available,
    * i.e. is not SSL.
    */
   CRYPTO_UNAVAILABLE: 4,

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -2033,6 +2033,18 @@ describe('amp-a4a', () => {
     });
   });
 
+  describe('shouldPreferentialRenderWithoutCrypto', () => {
+    it('returns false by default', () => {
+      return createIframePromise().then(fixture => {
+        setupForAdTesting(fixture);
+        const doc = fixture.doc;
+        a4aElement = createA4aElement(doc);
+        const a4a = new AmpA4A(a4aElement);
+        expect(a4a.shouldPreferentialRenderWithoutCrypto()).to.be.false;
+      });
+    });
+  });
+
   // TODO(tdrl): Other cases to handle for parsing JSON metadata:
   //   - Metadata tag(s) missing
   //   - JSON parse failure

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -2038,7 +2038,7 @@ describe('amp-a4a', () => {
       return createIframePromise().then(fixture => {
         setupForAdTesting(fixture);
         const doc = fixture.doc;
-        a4aElement = createA4aElement(doc);
+        const a4aElement = createA4aElement(doc);
         const a4a = new AmpA4A(a4aElement);
         expect(a4a.shouldPreferentialRenderWithoutCrypto()).to.be.false;
       });

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -2056,8 +2056,12 @@ describe('amp-a4a', () => {
                 .returns(false);
             a4a.buildCallback();
             a4a.onLayoutMeasure();
-            return a4a.adPromise_.then(() => {
-              expect(a4a.isVerifiedAmpCreative_).to.be.false;
+            return a4a.layoutCallback().then(() => {
+              // Force vsync system to run all queued tasks, so that DOM mutations
+              // are actually completed before testing.
+              a4a.vsync_.runScheduledTasks_();
+              expect(a4aElement.querySelector('iframe[src]')).to.be.ok;
+              expect(a4aElement.querySelector('iframe[srcdoc]')).to.not.be.ok;
             });
           });
 
@@ -2069,8 +2073,11 @@ describe('amp-a4a', () => {
             'shouldPreferentialRenderWithoutCrypto', () => true);
         a4a.buildCallback();
         a4a.onLayoutMeasure();
-        return a4a.adPromise_.then(() => {
-          expect(a4a.isVerifiedAmpCreative_).to.be.true;
+        return a4a.layoutCallback().then(() => {
+             // Force vsync system to run all queued tasks, so that DOM mutations
+             // are actually completed before testing.
+          a4a.vsync_.runScheduledTasks_();
+          verifyA4ARender(a4aElement);
         });
       });
 
@@ -2081,8 +2088,12 @@ describe('amp-a4a', () => {
             'shouldPreferentialRenderWithoutCrypto', () => true);
         a4a.buildCallback();
         a4a.onLayoutMeasure();
-        return a4a.adPromise_.then(() => {
-          expect(a4a.isVerifiedAmpCreative_).to.be.false;
+        return a4a.layoutCallback().then(() => {
+          // Force vsync system to run all queued tasks, so that DOM mutations
+          // are actually completed before testing.
+          a4a.vsync_.runScheduledTasks_();
+          expect(a4aElement.querySelector('iframe[src]')).to.be.ok;
+          expect(a4aElement.querySelector('iframe[srcdoc]')).to.not.be.ok;
         });
       });
     });

--- a/extensions/amp-a4a/0.1/test/test-signature-verifier.js
+++ b/extensions/amp-a4a/0.1/test/test-signature-verifier.js
@@ -451,6 +451,16 @@ describes.fakeWin('SignatureVerifier', {amp: true}, env => {
             .to.eventually.equal(VerificationStatus.UNVERIFIED);
       });
 
+      it('should return UNVERIFIED on no header when crypto unavailable',
+          () => {
+            env.sandbox.stub(env.win, 'crypto', undefined);
+            env.fetchMock.getOnce(
+                'https://signingservice1.net/keyset.json', jwkSet([key1]));
+            verifier.loadKeyset('service-1');
+            expect(verifier.verify(creative1, new Headers(), noop))
+                .to.eventually.equal(VerificationStatus.UNVERIFIED);
+          });
+
       it('should return ERROR_SIGNATURE_MISMATCH on malformed header', () => {
         env.fetchMock.getOnce(
             'https://signingservice1.net/keyset.json', jwkSet([key1]));

--- a/extensions/amp-a4a/0.1/test/test-signature-verifier.js
+++ b/extensions/amp-a4a/0.1/test/test-signature-verifier.js
@@ -55,7 +55,7 @@ describes.fakeWin('SignatureVerifier', {amp: true}, env => {
         .verifyCreativeAndSignature(
         'service-1', 'key-1', creative1, new Uint8Array(256), noop)
         .then(status => {
-          expect(status).to.equal(VerificationStatus.UNVERIFIED);
+          expect(status).to.equal(VerificationStatus.CRYPTO_UNAVAILABLE);
           expect(env.fetchMock.called()).to.be.false;
         });
   });

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -361,7 +361,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
   }
 
   /** @override */
-  ffWithoutCrypto() {
+  preferentialRenderWithoutCrypto() {
     return experimentFeatureEnabled(
         this.win, DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_HTTP_EXPERIMENT,
         DFP_CANONICAL_FF_EXPERIMENT_NAME);

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -359,6 +359,13 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     });
   }
 
+  /** @override */
+  cryptoUnavailable(bytes) {
+    return experimentFeatureEnabled(
+        this.win, DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_HTTP_EXPERIMENT,
+        DFP_CANONICAL_FF_EXPERIMENT_NAME) ? bytes : null;
+  }
+
   /**
    * @return {!{
    *  resolver: ?function(?../../../src/service/xhr-impl.FetchResponse),

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -31,6 +31,7 @@ import {VERIFIER_EXP_NAME} from '../../amp-a4a/0.1/legacy-signature-verifier';
 import {
   experimentFeatureEnabled,
   DOUBLECLICK_EXPERIMENT_FEATURE,
+  DFP_CANONICAL_FF_EXPERIMENT_NAME,
 } from './doubleclick-a4a-config';
 import {
   isInManualExperiment,
@@ -360,10 +361,10 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
   }
 
   /** @override */
-  cryptoUnavailable(bytes) {
+  ffWithoutCrypto() {
     return experimentFeatureEnabled(
         this.win, DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_HTTP_EXPERIMENT,
-        DFP_CANONICAL_FF_EXPERIMENT_NAME) ? bytes : null;
+        DFP_CANONICAL_FF_EXPERIMENT_NAME);
   }
 
   /**

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -361,7 +361,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
   }
 
   /** @override */
-  preferentialRenderWithoutCrypto() {
+  shouldPreferentialRenderWithoutCrypto() {
     return experimentFeatureEnabled(
         this.win, DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_HTTP_EXPERIMENT,
         DFP_CANONICAL_FF_EXPERIMENT_NAME);

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
@@ -135,7 +135,7 @@ export class DoubleclickA4aEligibility {
     if (!this.isCdnProxy(win)) {
       // Ensure that forcing FF via url is applied if test/localDev.
       if (urlExperimentId == -1 &&
-          (getMode(win).localDev ||	getMode(win).test)) {
+          (getMode(win).localDev || getMode(win).test)) {
         experimentId = MANUAL_EXPERIMENT_ID;
       } else if (!this.supportsCrypto(win)) {
         experimentId = this.maybeSelectExperiment(win, element, [

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
@@ -221,7 +221,7 @@ export function doubleclickIsA4AEnabled(win, element) {
 /**
  * @param {!Window} win
  * @param {!DOUBLECLICK_EXPERIMENT_FEATURE} feature
- * @param {?string} opt_experimentName
+ * @param {string=} opt_experimentName
  * @return {boolean} whether feature is enabled
  */
 export function experimentFeatureEnabled(win, feature, opt_experimentName) {

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
@@ -58,6 +58,8 @@ export const DOUBLECLICK_EXPERIMENT_FEATURE = {
   HOLDBACK_INTERNAL: '2092614',
   CANONICAL_CONTROL: '21060932',
   CANONICAL_EXPERIMENT: '21060933',
+  CANONICAL_HTTP_CONTROL: '21061030',
+  CANONICAL_HTTP_EXPERIMENT: '21061031',
   CACHE_EXTENSION_INJECTION_CONTROL: '21060955',
   CACHE_EXTENSION_INJECTION_EXP: '21060956',
 };
@@ -124,13 +126,21 @@ export class DoubleclickA4aEligibility {
   isA4aEnabled(win, element) {
     let experimentId;
     if ('useSameDomainRenderingUntilDeprecated' in element.dataset ||
-        element.hasAttribute('useSameDomainRenderingUntilDeprecated') ||
-        !this.supportsCrypto(win)) {
+        element.hasAttribute('useSameDomainRenderingUntilDeprecated')) {
       return false;
     }
     const urlExperimentId = extractUrlExperimentId(win, element);
     let experimentName = DFP_CANONICAL_FF_EXPERIMENT_NAME;
-    if (!this.isCdnProxy(win)) {
+
+    if (!this.supportsCrypto(win)) {
+      experimentId = this.maybeSelectExperiment(win, element, [
+            DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_HTTP_CONTROL,
+            DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_HTTP_EXPERIMENT,
+      ], DFP_CANONICAL_FF_EXPERIMENT_NAME);
+      if (!experimentId) {
+        return false;
+      }
+    } else if (!this.isCdnProxy(win)) {
       // Ensure that forcing FF via url is applied if test/localDev.
       experimentId = (urlExperimentId == -1 &&
           (getMode(win).localDev ||	getMode(win).test)) ?
@@ -172,6 +182,7 @@ export class DoubleclickA4aEligibility {
       DOUBLECLICK_EXPERIMENT_FEATURE.SFG_CONTROL_ID,
       DOUBLECLICK_EXPERIMENT_FEATURE.SFG_EXP_ID,
       DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_CONTROL,
+      DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_HTTP_CONTROL,
     ].includes(experimentId);
   }
 
@@ -210,8 +221,10 @@ export function doubleclickIsA4AEnabled(win, element) {
 /**
  * @param {!Window} win
  * @param {!DOUBLECLICK_EXPERIMENT_FEATURE} feature
+ * @param {?string} opt_experimentName
  * @return {boolean} whether feature is enabled
  */
-export function experimentFeatureEnabled(win, feature) {
-  return getExperimentBranch(win, DOUBLECLICK_A4A_EXPERIMENT_NAME) == feature;
+export function experimentFeatureEnabled(win, feature, opt_experimentName) {
+  const experimentName = opt_experimentName || DOUBLECLICK_A4A_EXPERIMENT_NAME;
+  return getExperimentBranch(win, experimentName) == feature;
 }

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
@@ -134,8 +134,8 @@ export class DoubleclickA4aEligibility {
 
     if (!this.supportsCrypto(win)) {
       experimentId = this.maybeSelectExperiment(win, element, [
-            DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_HTTP_CONTROL,
-            DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_HTTP_EXPERIMENT,
+        DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_HTTP_CONTROL,
+        DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_HTTP_EXPERIMENT,
       ], DFP_CANONICAL_FF_EXPERIMENT_NAME);
       if (!experimentId) {
         return false;

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
@@ -132,23 +132,23 @@ export class DoubleclickA4aEligibility {
     const urlExperimentId = extractUrlExperimentId(win, element);
     let experimentName = DFP_CANONICAL_FF_EXPERIMENT_NAME;
 
-    if (!this.supportsCrypto(win)) {
-      experimentId = this.maybeSelectExperiment(win, element, [
-        DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_HTTP_CONTROL,
-        DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_HTTP_EXPERIMENT,
-      ], DFP_CANONICAL_FF_EXPERIMENT_NAME);
-      if (!experimentId) {
-        return false;
-      }
-    } else if (!this.isCdnProxy(win)) {
+    if (!this.isCdnProxy(win)) {
       // Ensure that forcing FF via url is applied if test/localDev.
-      experimentId = (urlExperimentId == -1 &&
-          (getMode(win).localDev ||	getMode(win).test)) ?
-          MANUAL_EXPERIMENT_ID :
-          this.maybeSelectExperiment(win, element, [
-            DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_CONTROL,
-            DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_EXPERIMENT,
-          ], DFP_CANONICAL_FF_EXPERIMENT_NAME);
+      if (urlExperimentId == -1 &&
+          (getMode(win).localDev ||	getMode(win).test)) {
+        experimentId = MANUAL_EXPERIMENT_ID;
+      } else if (!this.supportsCrypto(win)) {
+        experimentId = this.maybeSelectExperiment(win, element, [
+          DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_HTTP_CONTROL,
+          DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_HTTP_EXPERIMENT,
+        ], DFP_CANONICAL_FF_EXPERIMENT_NAME);
+
+      } else {
+        experimentId = this.maybeSelectExperiment(win, element, [
+          DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_CONTROL,
+          DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_EXPERIMENT,
+        ], DFP_CANONICAL_FF_EXPERIMENT_NAME);
+      }
       // If no experiment selected, return false.
       if (!experimentId) {
         return false;

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
@@ -142,7 +142,6 @@ export class DoubleclickA4aEligibility {
           DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_HTTP_CONTROL,
           DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_HTTP_EXPERIMENT,
         ], DFP_CANONICAL_FF_EXPERIMENT_NAME);
-
       } else {
         experimentId = this.maybeSelectExperiment(win, element, [
           DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_CONTROL,

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -32,6 +32,7 @@ import {
   CORRELATOR_CLEAR_EXP_NAME,
 } from '../amp-ad-network-doubleclick-impl';
 import {
+  DFP_CANONICAL_FF_EXPERIMENT_NAME,
   DOUBLECLICK_A4A_EXPERIMENT_NAME,
   DOUBLECLICK_EXPERIMENT_FEATURE,
 } from '../doubleclick-a4a-config';
@@ -916,6 +917,30 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
       expect(onVisibilityChangedHandler).to.not.be.ok;
       expect(isInExperiment(elem2, CORRELATOR_CLEAR_EXP_BRANCHES.EXPERIMENT))
           .to.be.true;
+    });
+  });
+
+  describe('shouldPreferentialRenderWithoutCrypto', () => {
+    beforeEach(() => {
+      element = doc.createElement('amp-ad');
+      element.setAttribute('type', 'doubleclick');
+      element.setAttribute('data-ad-client', 'adsense');
+      doc.body.appendChild(element);
+      impl = new AmpAdNetworkDoubleclickImpl(element);
+    });
+
+    afterEach(() => {
+      doc.body.removeChild(element);
+    });
+
+    it('should return false when not in canonical non-SSL experiment', () => {
+      expect(impl.shouldPreferentialRenderWithoutCrypto()).to.be.false;
+    });
+
+    it('should return true when in canonical non-SSL experiment', () => {
+      forceExperimentBranch(impl.win, DFP_CANONICAL_FF_EXPERIMENT_NAME,
+          DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_HTTP_EXPERIMENT);
+      expect(impl.shouldPreferentialRenderWithoutCrypto()).to.be.true;
     });
   });
 });

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-a4a-config.js
@@ -100,19 +100,20 @@ describe('doubleclick-a4a-config', () => {
           DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_EXPERIMENT);
     });
 
-    it('should select into non-SSL canonical AMP experiment when not on CDN', () => {
-      forceExperimentBranch(mockWin, DFP_CANONICAL_FF_EXPERIMENT_NAME,
-          DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_HTTP_EXPERIMENT);
-      sandbox.stub(DoubleclickA4aEligibility.prototype,
-                   'isCdnProxy', () => false);
-      sandbox.stub(DoubleclickA4aEligibility.prototype,
-                   'supportsCrypto', () => false);
-      const elem = testFixture.doc.createElement('div');
-      testFixture.doc.body.appendChild(elem);
-      expect(doubleclickIsA4AEnabled(mockWin, elem)).to.be.true;
-      expect(elem.getAttribute(EXPERIMENT_ATTRIBUTE)).to.equal(
-          DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_HTTP_EXPERIMENT);
-    });
+    it('should select into non-SSL canonical AMP experiment when not on CDN',
+        () => {
+          forceExperimentBranch(mockWin, DFP_CANONICAL_FF_EXPERIMENT_NAME,
+              DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_HTTP_EXPERIMENT);
+          sandbox.stub(DoubleclickA4aEligibility.prototype,
+              'isCdnProxy', () => false);
+          sandbox.stub(DoubleclickA4aEligibility.prototype,
+              'supportsCrypto', () => false);
+          const elem = testFixture.doc.createElement('div');
+          testFixture.doc.body.appendChild(elem);
+          expect(doubleclickIsA4AEnabled(mockWin, elem)).to.be.true;
+          expect(elem.getAttribute(EXPERIMENT_ATTRIBUTE)).to.equal(
+              DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_HTTP_EXPERIMENT);
+        });
 
     it('should return false if no canonical AMP experiment branch', () => {
       forceExperimentBranch(mockWin, DFP_CANONICAL_FF_EXPERIMENT_NAME, null);

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-a4a-config.js
@@ -80,7 +80,6 @@ describe('doubleclick-a4a-config', () => {
     });
 
     it('should not enable a4a when native crypto is not supported', () => {
-      forceExperimentBranch(mockWin, DFP_CANONICAL_FF_EXPERIMENT_NAME, null);
       sandbox.stub(DoubleclickA4aEligibility.prototype,
           'supportsCrypto', () => false);
       const elem = testFixture.doc.createElement('div');
@@ -89,30 +88,35 @@ describe('doubleclick-a4a-config', () => {
     });
 
     it('should select into canonical AMP experiment when not on CDN', () => {
-      forceExperimentBranch(mockWin, DFP_CANONICAL_FF_EXPERIMENT_NAME,
-          DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_EXPERIMENT);
       sandbox.stub(DoubleclickA4aEligibility.prototype,
           'isCdnProxy', () => false);
+      const maybeSelectExperimentSpy = sandbox.spy(
+          DoubleclickA4aEligibility.prototype, 'maybeSelectExperiment');
       const elem = testFixture.doc.createElement('div');
       testFixture.doc.body.appendChild(elem);
-      expect(doubleclickIsA4AEnabled(mockWin, elem)).to.be.true;
-      expect(elem.getAttribute(EXPERIMENT_ATTRIBUTE)).to.equal(
-          DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_EXPERIMENT);
+      doubleclickIsA4AEnabled(mockWin, elem);
+      expect(maybeSelectExperimentSpy).to.be.calledWith(mockWin, elem, [
+        DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_CONTROL,
+        DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_EXPERIMENT,
+      ], DFP_CANONICAL_FF_EXPERIMENT_NAME) ;
+
     });
 
     it('should select into non-SSL canonical AMP experiment when not on CDN',
         () => {
-          forceExperimentBranch(mockWin, DFP_CANONICAL_FF_EXPERIMENT_NAME,
-              DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_HTTP_EXPERIMENT);
           sandbox.stub(DoubleclickA4aEligibility.prototype,
               'isCdnProxy', () => false);
           sandbox.stub(DoubleclickA4aEligibility.prototype,
               'supportsCrypto', () => false);
+          const maybeSelectExperimentSpy = sandbox.spy(
+              DoubleclickA4aEligibility.prototype, 'maybeSelectExperiment');
           const elem = testFixture.doc.createElement('div');
           testFixture.doc.body.appendChild(elem);
-          expect(doubleclickIsA4AEnabled(mockWin, elem)).to.be.true;
-          expect(elem.getAttribute(EXPERIMENT_ATTRIBUTE)).to.equal(
-              DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_HTTP_EXPERIMENT);
+          doubleclickIsA4AEnabled(mockWin, elem);
+          expect(maybeSelectExperimentSpy).to.be.calledWith(mockWin, elem, [
+            DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_HTTP_CONTROL,
+            DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_HTTP_EXPERIMENT,
+          ], DFP_CANONICAL_FF_EXPERIMENT_NAME) ;
         });
 
     it('should return false if no canonical AMP experiment branch', () => {

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-a4a-config.js
@@ -99,6 +99,7 @@ describe('doubleclick-a4a-config', () => {
         DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_CONTROL,
         DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_EXPERIMENT,
       ], DFP_CANONICAL_FF_EXPERIMENT_NAME) ;
+      expect(maybeSelectExperimentSpy.callCount).to.equal(1);
 
     });
 
@@ -117,6 +118,7 @@ describe('doubleclick-a4a-config', () => {
             DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_HTTP_CONTROL,
             DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_HTTP_EXPERIMENT,
           ], DFP_CANONICAL_FF_EXPERIMENT_NAME) ;
+          expect(maybeSelectExperimentSpy.callCount).to.equal(1);
         });
 
     it('should return false if no canonical AMP experiment branch', () => {

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-a4a-config.js
@@ -80,6 +80,7 @@ describe('doubleclick-a4a-config', () => {
     });
 
     it('should not enable a4a when native crypto is not supported', () => {
+      forceExperimentBranch(mockWin, DFP_CANONICAL_FF_EXPERIMENT_NAME, null);
       sandbox.stub(DoubleclickA4aEligibility.prototype,
           'supportsCrypto', () => false);
       const elem = testFixture.doc.createElement('div');
@@ -97,6 +98,20 @@ describe('doubleclick-a4a-config', () => {
       expect(doubleclickIsA4AEnabled(mockWin, elem)).to.be.true;
       expect(elem.getAttribute(EXPERIMENT_ATTRIBUTE)).to.equal(
           DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_EXPERIMENT);
+    });
+
+    it('should select into non-SSL canonical AMP experiment when not on CDN', () => {
+      forceExperimentBranch(mockWin, DFP_CANONICAL_FF_EXPERIMENT_NAME,
+          DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_HTTP_EXPERIMENT);
+      sandbox.stub(DoubleclickA4aEligibility.prototype,
+                   'isCdnProxy', () => false);
+      sandbox.stub(DoubleclickA4aEligibility.prototype,
+                   'supportsCrypto', () => false);
+      const elem = testFixture.doc.createElement('div');
+      testFixture.doc.body.appendChild(elem);
+      expect(doubleclickIsA4AEnabled(mockWin, elem)).to.be.true;
+      expect(elem.getAttribute(EXPERIMENT_ATTRIBUTE)).to.equal(
+          DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_HTTP_EXPERIMENT);
     });
 
     it('should return false if no canonical AMP experiment branch', () => {


### PR DESCRIPTION
Start experiment to allow FF for doubleclick on canonical, non-ssl AMP pages. 