### PR TITLE
Remove @suppress from events now that closure compiler is upgraded

### DIFF
--- a/src/event-helper-listen.js
+++ b/src/event-helper-listen.js
@@ -78,7 +78,6 @@
  * or not.
  *
  * @return {boolean}
- * @suppress {checkTypes}
  */
  export function detectEvtListenerOptsSupport() {
    // Only run the test once


### PR DESCRIPTION
New closure compiler has updated externs for the new eventListener API (object as third param), no need for `@supress` anymore.

Closes https://github.com/ampproject/amphtml/issues/5105