### PR TITLE
Reduce racy-ness with window destruction

### DIFF
--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -808,8 +808,7 @@ function createBaseCustomElementClass(win) {
     dispatchCustomEvent(name, opt_data) {
       const data = opt_data || {};
       // Constructors of events need to come from the correct window. Sigh.
-      const win = this.ownerDocument.defaultView;
-      const event = win.document.createEvent('Event');
+      const event = this.ownerDocument.createEvent('Event');
       event.data = data;
       event.initEvent(name, /* bubbles */ true, /* cancelable */ true);
       this.dispatchEvent(event);


### PR DESCRIPTION
Closes #11339.
Closes #9870.

This should reduce the chance of #11339 happening. Typically the window is destroyed very fast, but the `ownerDocument` sticks around until all elements are gc'd.