### PR TITLE
amp-form doc - add clarifying info on http response header

### DIFF
--- a/extensions/amp-form/amp-form.md
+++ b/extensions/amp-form/amp-form.md
@@ -22,10 +22,6 @@ limitations under the License.
     <td>Allow usage of <code>form</code> and <code>input</code> tags.</td>
   </tr>
   <tr>
-    <td width="40%"><strong>Availability</strong></td>
-    <td>Stable</td>
-  </tr>
-  <tr>
     <td width="40%"><strong>Required Script</strong></td>
     <td><code>&lt;script async custom-element="amp-form" src="https://cdn.ampproject.org/v0/amp-form-0.1.js">&lt;/script></code></td>
   </tr>
@@ -60,40 +56,46 @@ The `amp-form` extension **MUST** be loaded if you're using `<form>`, otherwise 
 
 ## Attributes
 
-**target**
+##### target
 
-The value for the `target` attribute must be either `_blank` or `_top`.
+Indicates where to display the form response after submitting the form. The value must be `_blank` or `_top`.
 
-**action** (optional for GET, invalid for POST)
+##### action
 
-For GET submissions, at least one of `action` or `action-xhr` must be provided.
+Specifies a server endpoint to handle the form input. The value must be an `https` URL and must not be a link to a CDN.
 
-This attribute is required for `method=GET`. The value must be an `https` URL and must not be a link to a CDN (does **NOT** link to `https://cdn.ampproject.org`). For `method=POST`, the `action` attribute is invalid, use  `action-xhr` instead.
+This attribute is required for `method=GET`. For `method=POST`, the `action` attribute is invalid, use `action-xhr` instead.
+
+For GET submissions, provide at least one of `action` or `action-xhr`.
 
 
 {% call callout('Note', type='note') %}
-The `target` and `action` attributes will only be used for non-xhr GET requests. The AMP runtime will use `action-xhr` to make the request and will ignore `action` and `target`. When `action-xhr` is not provided, AMP makes a GET request to the `action` endpoint and uses `target` to open a new window (if `_blank`). The AMP runtime might also fallback to using action and target in cases where `amp-form` extension fails to load.
+The `target` and `action` attributes are only used for non-xhr GET requests. The AMP runtime will use `action-xhr` to make the request and will ignore `action` and `target`. When `action-xhr` is not provided, AMP makes a GET request to the `action` endpoint and uses `target` to open a new window (if `_blank`). The AMP runtime might also fallback to using `action` and `target` in cases where the `amp-form` extension fails to load.
 {% endcall %}
 
-**action-xhr**
+##### action-xhr
 
-This attribute is required for `method=POST`, and is optional for `method=GET`. If provided, the form will be submitted in an XHR fashion.
+Specifies a server endpoint to handle the form input and submit the form via XMLHttpRequest (XHR).
 
-An XHR request (sometimes called an AJAX request) is where the browser would make the request without a full load of the page or opening a new page. Browsers will send the request in the background using [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) when available and fallback to [XMLHttpRequest API](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest) for older browsers.
+An XHR request (sometimes called an AJAX request) is where the browser would make the request without a full load of the page or opening a new page. Browsers will send the request in the background using the [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) when available and fallback to [XMLHttpRequest API](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest) for older browsers.
 
-The value for `action-xhr` can be the same or a different endpoint than `action` and has the same action requirements above.
+This attribute is required for `method=POST`, and is optional for `method=GET`.
+
+The value for `action-xhr` can be the same or a different endpoint than `action` and has the same `action` requirements above.
+
+To learn about redirecting the user after successfully submitting the form, see the [Redirecting after a submission](#redirecting-after-a-submission) section below.
 
 {% call callout('Important', type='caution') %}
 See the [Security Considerations](#security-considerations) section below for notes on how to secure your forms endpoints.
 {% endcall %}
 
-**other form attributes**
+##### other form attributes
 
 All other [form attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form) are optional.
 
-**custom-validation-reporting** (optional)
+##### custom-validation-reporting
 
-Enables and selects a custom validation reporting strategy, valid values are one of: `show-first-on-submit`, `show-all-on-submit` or `as-you-go`.
+This is an optional attribute that enables and selects a custom validation reporting strategy. Valid values are one of: `show-first-on-submit`, `show-all-on-submit` or `as-you-go`.
 
 See the [Custom Validation](#custom-validations) section for more details.
 
@@ -256,18 +258,21 @@ Publishers can render these in a template inside their forms as follows.
 See the [full example here](../../examples/forms.amp.html).
 
 ### Redirecting after a submission
-`amp-form` also allows publishers to redirect users to a new page after a submission happens through `AMP-Redirect-To` response header.
 
-Note that you'd also have to update your `Access-Control-Expose-Headers` response header to include `AMP-Redirect-To` to the list of allowed headers.
+You can redirect users to a new page after a successful `amp-form` submission by setting the `AMP-Redirect-To` response header and specifying a redirect URL. The redirect URL must be a HTTPS URL, otherwise AMP will throw an error and redirection won't occur.  HTTP response headers are configured via your server. 
 
-The redirect URL must be absolute HTTPS URL otherwise AMP will throw an error and redirection won't happen.
+Make sure to update your `Access-Control-Expose-Headers` response header to include `AMP-Redirect-To` to the list of allowed headers.  Learn more about these headers in [CORS Security in AMP](https://github.com/ampproject/amphtml/blob/master/spec/amp-cors-requests.md#cors-security-in-amp).
 
-**Known Issue**: Due to an [issue in Safari iOS](https://bugs.webkit.org/show_bug.cgi?id=165627) redirecting to deep linked URLs (URLs that would actually end up opening a native app) might fail when the AMP document is embedded. This is [tracked in this issue](https://github.com/ampproject/amphtml/issues/6953).
+*Example response headers:*
 
 ```text
 AMP-Redirect-To: https://example.com/forms/thank-you
 Access-Control-Expose-Headers: AMP-Redirect-To, Another-Header, And-Some-More
 ```
+
+
+Check out AMP By Example's [Form Submission with Update](https://ampbyexample.com/components/amp-form/#form-submission-with-page-update) and [Product Page](https://ampbyexample.com/samples_templates/product_page/#product-page) that demonstrate using redirection after a form submission.
+
 
 ## Polyfills
 `amp-form` provide polyfills for behaviors and functionality missing from some browsers or being implemented in the next version of CSS.


### PR DESCRIPTION
Fixes: https://github.com/ampproject/docs/issues/689

- Added info for `action-xhr` on specifying HTTP response header, including pointing to examples
- Performed some miscellaneous formatting and wording cleanup