### PR TITLE
Make all images in AMP have the `async` attribute.

### DIFF
--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -114,6 +114,7 @@ export class AmpImg extends BaseElement {
     }
 
     this.img_ = new Image();
+    this.img_.setAttribute('async', '');
     if (this.element.id) {
       this.img_.setAttribute('amp-img-id', this.element.id);
     }

--- a/extensions/amp-anim/0.1/amp-anim.js
+++ b/extensions/amp-anim/0.1/amp-anim.js
@@ -123,9 +123,9 @@ export class AmpAnim extends AMP.BaseElement {
       return Promise.resolve();
     }
     const src = this.srcset_.select(
-      // The width should never be 0, but we fall back to the screen width
-      // just in case.
-      this.getViewport().getWidth() || this.win.screen.width).url;
+        // The width should never be 0, but we fall back to the screen width
+        // just in case.
+        this.getViewport().getWidth() || this.win.screen.width).url;
     if (src == this.img_.getAttribute('src')) {
       return Promise.resolve();
     }

--- a/extensions/amp-anim/0.1/amp-anim.js
+++ b/extensions/amp-anim/0.1/amp-anim.js
@@ -125,7 +125,8 @@ export class AmpAnim extends AMP.BaseElement {
     const src = this.srcset_.select(
         // The width should never be 0, but we fall back to the screen width
         // just in case.
-        this.getViewport().getWidth() || this.win.screen.width).url;
+        this.getViewport().getWidth() || this.win.screen.width,
+        this.getDpr()).url;
     if (src == this.img_.getAttribute('src')) {
       return Promise.resolve();
     }

--- a/extensions/amp-anim/0.1/amp-anim.js
+++ b/extensions/amp-anim/0.1/amp-anim.js
@@ -46,6 +46,7 @@ export class AmpAnim extends AMP.BaseElement {
   /** @override */
   buildCallback() {
     this.img_ = new Image();
+    this.img_.setAttribute('async', '');
     this.propagateAttributes(['alt', 'aria-label',
       'aria-describedby', 'aria-labelledby'], this.img_);
     this.applyFillContent(this.img_, true);
@@ -121,8 +122,10 @@ export class AmpAnim extends AMP.BaseElement {
     if (this.getLayoutWidth() <= 0) {
       return Promise.resolve();
     }
-    const src = this.srcset_.select(this.getLayoutWidth(),
-        this.getDpr()).url;
+    const src = this.srcset_.select(
+      // The width should never be 0, but we fall back to the screen width
+      // just in case.
+      this.getViewport().getWidth() || this.win.screen.width).url;
     if (src == this.img_.getAttribute('src')) {
       return Promise.resolve();
     }

--- a/extensions/amp-anim/0.1/test/test-amp-anim.js
+++ b/extensions/amp-anim/0.1/test/test-amp-anim.js
@@ -39,5 +39,6 @@ describes.realWin('amp-anim', {
     expect(img.getAttribute('aria-label')).to.equal('Hello');
     expect(img.getAttribute('aria-labelledby')).to.equal('id2');
     expect(img.getAttribute('aria-describedby')).to.equal('id3');
+    expect(img.hasAttribute('async')).to.be.true;
   });
 });

--- a/test/functional/test-amp-img.js
+++ b/test/functional/test-amp-img.js
@@ -79,6 +79,7 @@ describe('amp-img', () => {
       expect(img.getAttribute('alt')).to.equal('An image');
       expect(img.getAttribute('title')).to.equal('Image title');
       expect(img.getAttribute('referrerpolicy')).to.equal('origin');
+      expect(img.hasAttribute('async')).to.be.true;
     });
   });
 


### PR DESCRIPTION
With this adding the image to the DOM should never trigger a sync decode.

This was just added to Safari Tech preview
https://webkit.org/blog/7922/release-notes-for-safari-technology-preview-40/
