### PR TITLE
Launch AdSense Fast Fetch Delay Request

### DIFF
--- a/extensions/amp-ad-network-adsense-impl/0.1/adsense-a4a-config.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/adsense-a4a-config.js
@@ -37,24 +37,12 @@ import {dev} from '../../../src/log';
 /** @const {!string} @visibleForTesting */
 export const ADSENSE_A4A_EXPERIMENT_NAME = 'expAdsenseA4A';
 
-/**
- * Unconditioned, client-side diverted experiment across all AdSense traffic.
- * @const {!string} @visibleForTesting
- */
-export const FF_DR_EXP_NAME = 'expAdSenseFFDR';
-
-/** @const @enum{string} @visibleForTesting */
-export const INTERNAL_FAST_FETCH_DELAY_REQUEST_EXP = {
-  CONTROL: '21060901',
-  EXPERIMENT: '21060902',
-};
-
 /** @const @enum{string} @visibleForTesting */
 export const ADSENSE_EXPERIMENT_FEATURE = {
   HOLDBACK_EXTERNAL_CONTROL: '21060732',
   HOLDBACK_EXTERNAL: '21060733',
-  DELAYED_REQUEST_EXTERNAL_CONTROL: '21060734',
-  DELAYED_REQUEST_EXTERNAL: '21060735',
+  DELAYED_REQUEST_HOLDBACK_CONTROL: '21061056',
+  DELAYED_REQUEST_HOLDBACK_EXTERNAL: '21061057',
   HOLDBACK_INTERNAL_CONTROL: '2092615',
   HOLDBACK_INTERNAL: '2092616',
   CACHE_EXTENSION_INJECTION_CONTROL: '21060953',
@@ -72,8 +60,8 @@ export const URL_EXPERIMENT_MAPPING = {
   '1': ADSENSE_EXPERIMENT_FEATURE.HOLDBACK_EXTERNAL_CONTROL,
   '2': ADSENSE_EXPERIMENT_FEATURE.HOLDBACK_EXTERNAL,
   // Delay Request
-  '3': ADSENSE_EXPERIMENT_FEATURE.DELAYED_REQUEST_EXTERNAL_CONTROL,
-  '4': ADSENSE_EXPERIMENT_FEATURE.DELAYED_REQUEST_EXTERNAL,
+  '3': ADSENSE_EXPERIMENT_FEATURE.DELAYED_REQUEST_HOLDBACK_CONTROL,
+  '4': ADSENSE_EXPERIMENT_FEATURE.DELAYED_REQUEST_HOLDBACK_EXTERNAL,
   // AMP Cache extension injection
   '5': ADSENSE_EXPERIMENT_FEATURE.CACHE_EXTENSION_INJECTION_CONTROL,
   '6': ADSENSE_EXPERIMENT_FEATURE.CACHE_EXTENSION_INJECTION_EXP,
@@ -85,23 +73,6 @@ export const URL_EXPERIMENT_MAPPING = {
  * @returns {boolean}
  */
 export function adsenseIsA4AEnabled(win, element) {
-  // Select Fast fetch, delayed request across all traffic as its unconditioned.
-  // Note that this will "pollute" the SERP triggered control/experiments and
-  // will have no effect on delayed fetch.
-  const ffDrExperimentInfoMap =
-      /** @type {!Object<string, !ExperimentInfo>} */ ({});
-  ffDrExperimentInfoMap[FF_DR_EXP_NAME] = {
-    isTrafficEligible: () => true,
-    branches: [
-      INTERNAL_FAST_FETCH_DELAY_REQUEST_EXP.CONTROL,
-      INTERNAL_FAST_FETCH_DELAY_REQUEST_EXP.EXPERIMENT,
-    ],
-  };
-  randomlySelectUnsetExperiments(win, ffDrExperimentInfoMap);
-  const delayedFetchExperimentId = getExperimentBranch(win, FF_DR_EXP_NAME);
-  if (delayedFetchExperimentId) {
-    addExperimentIdToElement(delayedFetchExperimentId, element);
-  }
   if (!isGoogleAdsA4AValidEnvironment(win) ||
       !element.getAttribute('data-ad-client')) {
     return false;
@@ -147,9 +118,6 @@ export function adsenseIsA4AEnabled(win, element) {
  * @return {boolean} whether fast fetch delayed request experiment is enabled.
  */
 export function fastFetchDelayedRequestEnabled(win) {
-  return !!(
-      getExperimentBranch(win, ADSENSE_A4A_EXPERIMENT_NAME) ==
-        ADSENSE_EXPERIMENT_FEATURE.DELAYED_REQUEST_EXTERNAL ||
-      getExperimentBranch(win, FF_DR_EXP_NAME) ==
-        INTERNAL_FAST_FETCH_DELAY_REQUEST_EXP.EXPERIMENT);
+  return getExperimentBranch(win, ADSENSE_A4A_EXPERIMENT_NAME) !=
+      ADSENSE_EXPERIMENT_FEATURE.DELAYED_REQUEST_HOLDBACK_EXTERNAL;
 }

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-adsense-a4a-config.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-adsense-a4a-config.js
@@ -17,9 +17,7 @@
 import {
   adsenseIsA4AEnabled,
   ADSENSE_A4A_EXPERIMENT_NAME,
-  FF_DR_EXP_NAME,
   ADSENSE_EXPERIMENT_FEATURE,
-  INTERNAL_FAST_FETCH_DELAY_REQUEST_EXP,
   URL_EXPERIMENT_MAPPING,
   fastFetchDelayedRequestEnabled,
 } from '../adsense-a4a-config';
@@ -129,21 +127,13 @@ describe('adsense-a4a-config', () => {
 
   describe('#fastFetchDelayedRequestEnabled', () => {
     [
-      [ADSENSE_EXPERIMENT_FEATURE.DELAYED_REQUEST_EXTERNAL_CONTROL, {
-        layer: ADSENSE_A4A_EXPERIMENT_NAME,
-        result: false,
-      }],
-      [ADSENSE_EXPERIMENT_FEATURE.DELAYED_REQUEST_EXTERNAL, {
+      [ADSENSE_EXPERIMENT_FEATURE.DELAYED_REQUEST_HOLDBACK_CONTROL, {
         layer: ADSENSE_A4A_EXPERIMENT_NAME,
         result: true,
       }],
-      [INTERNAL_FAST_FETCH_DELAY_REQUEST_EXP.CONTROL, {
-        layer: FF_DR_EXP_NAME,
+      [ADSENSE_EXPERIMENT_FEATURE.DELAYED_REQUEST_HOLDBACK_EXTERNAL, {
+        layer: ADSENSE_A4A_EXPERIMENT_NAME,
         result: false,
-      }],
-      [INTERNAL_FAST_FETCH_DELAY_REQUEST_EXP.EXPERIMENT, {
-        layer: FF_DR_EXP_NAME,
-        result: true,
       }],
     ].forEach(item => {
       it(`should return ${item[1].result} if in ${item[0]} experiment`, () => {
@@ -153,8 +143,8 @@ describe('adsense-a4a-config', () => {
       });
     });
 
-    it('should return false if not in any experiments', () => {
-      expect(fastFetchDelayedRequestEnabled(mockWin)).to.be.false;
+    it('should return true if not in any experiments', () => {
+      expect(fastFetchDelayedRequestEnabled(mockWin)).to.be.true;
     });
   });
 });

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
@@ -21,9 +21,7 @@ import {
 } from '../amp-ad-network-adsense-impl';
 import {
   ADSENSE_A4A_EXPERIMENT_NAME,
-  FF_DR_EXP_NAME,
   ADSENSE_EXPERIMENT_FEATURE,
-  INTERNAL_FAST_FETCH_DELAY_REQUEST_EXP,
 } from '../adsense-a4a-config';
 import {Services} from '../../../../src/services';
 import {AmpAdUIHandler} from '../../../amp-ad/0.1/amp-ad-ui'; // eslint-disable-line no-unused-vars
@@ -745,21 +743,13 @@ describes.realWin('amp-ad-network-adsense-impl', {
     });
 
     [
-      [ADSENSE_EXPERIMENT_FEATURE.DELAYED_REQUEST_EXTERNAL_CONTROL, {
-        layer: ADSENSE_A4A_EXPERIMENT_NAME,
-        result: false,
-      }],
-      [ADSENSE_EXPERIMENT_FEATURE.DELAYED_REQUEST_EXTERNAL, {
+      [ADSENSE_EXPERIMENT_FEATURE.DELAYED_REQUEST_HOLDBACK_CONTROL, {
         layer: ADSENSE_A4A_EXPERIMENT_NAME,
         result: true,
       }],
-      [INTERNAL_FAST_FETCH_DELAY_REQUEST_EXP.CONTROL, {
-        layer: FF_DR_EXP_NAME,
+      [ADSENSE_EXPERIMENT_FEATURE.DELAYED_REQUEST_HOLDBACK_EXTERNAL, {
+        layer: ADSENSE_A4A_EXPERIMENT_NAME,
         result: false,
-      }],
-      [INTERNAL_FAST_FETCH_DELAY_REQUEST_EXP.EXPERIMENT, {
-        layer: FF_DR_EXP_NAME,
-        result: true,
       }],
     ].forEach(item => {
       it(`should return ${item[1].result} if in ${item[0]} experiment`, () => {
@@ -768,8 +758,8 @@ describes.realWin('amp-ad-network-adsense-impl', {
       });
     });
 
-    it('should return false if not in any experiments', () => {
-      expect(impl.delayAdRequestEnabled()).to.be.false;
+    it('should return true if not in any experiments', () => {
+      expect(impl.delayAdRequestEnabled()).to.be.true;
     });
   });
 });


### PR DESCRIPTION
Launch default behavior for AdSense Fast Fetch is to not send ad request until renderOutsideViewport is met (default being 3 viewports but can be tuned by publisher to lower value via prefer-viewability-over-views option).