### PR TITLE
Remove unnecessary check for A4A validity, thereby fixing bug in canonical experiment

### DIFF
--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -31,7 +31,6 @@ import {getExperimentBranch, isExperimentOn} from '../../../src/experiments';
 import {
   additionalDimensions,
   googleAdUrl,
-  isGoogleAdsA4AValidEnvironment,
   isReportingEnabled,
   extractAmpAnalyticsConfig,
   addCsiSignalsToAmpAnalyticsConfig,
@@ -144,8 +143,15 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
 
   /** @override */
   isValidElement() {
+    /**
+     * isValidElement used to also check that we are in a valid A4A environment,
+     * however this is not necessary as that is checked by adsenseIsA4AEnabled,
+     * which is always called as part of the upgrade path from an amp-ad element
+     * to an amp-ad-adsense element. Thus, if we are an amp-ad, we can be sure
+     * that it has been verified.
+     */
     return !!this.element.getAttribute('data-ad-client') &&
-        isGoogleAdsA4AValidEnvironment(this.win) && this.isAmpAdElement();
+        this.isAmpAdElement();
   }
 
   /** @override */

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -293,7 +293,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
   }
 
   /** @override */
-  isValidElement(opt_doc) {
+  isValidElement() {
     /**
      * isValidElement used to also check that we are in a valid A4A environment,
      * however this is not necessary as that is checked by doubleclickIsA4AEnabled,

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -292,8 +292,11 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     this.ifi_ = 0;
   }
 
-  /** @override */
-  isValidElement() {
+  /**
+   * @param {Document=} opt_doc Optional document to pass in for testing.
+   * @override
+   */
+  isValidElement(opt_doc) {
     /**
      * isValidElement used to also check that we are in a valid A4A environment,
      * however this is not necessary as that is checked by doubleclickIsA4AEnabled,
@@ -301,9 +304,10 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
      * to an amp-ad-doubleclick element. Thus, if we are an amp-ad, we can be sure
      * that it has been verified.
      */
+    const doc = opt_doc || document;
     return this.isAmpAdElement() &&
       // Ensure not within remote.html iframe.
-      !document.querySelector('meta[name=amp-3p-iframe-src]');
+      !doc.querySelector('meta[name=amp-3p-iframe-src]');
   }
 
   /** @override */

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -292,10 +292,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     this.ifi_ = 0;
   }
 
-  /**
-   * @param {Document=} opt_doc Optional document to pass in for testing.
-   * @override
-   */
+  /** @override */
   isValidElement(opt_doc) {
     /**
      * isValidElement used to also check that we are in a valid A4A environment,
@@ -304,10 +301,9 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
      * to an amp-ad-doubleclick element. Thus, if we are an amp-ad, we can be sure
      * that it has been verified.
      */
-    const doc = opt_doc || document;
     return this.isAmpAdElement() &&
       // Ensure not within remote.html iframe.
-      !doc.querySelector('meta[name=amp-3p-iframe-src]');
+      !this.win.document.querySelector('meta[name=amp-3p-iframe-src]');
   }
 
   /** @override */

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -41,7 +41,6 @@ import {
   truncAndTimeUrl,
   googleBlockParameters,
   googlePageParameters,
-  isGoogleAdsA4AValidEnvironment,
   isReportingEnabled,
   AmpAnalyticsConfigDef,
   extractAmpAnalyticsConfig,
@@ -295,8 +294,14 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
 
   /** @override */
   isValidElement() {
-    return isGoogleAdsA4AValidEnvironment(this.win) &&
-      this.isAmpAdElement() &&
+    /**
+     * isValidElement used to also check that we are in a valid A4A environment,
+     * however this is not necessary as that is checked by doubleclickIsA4AEnabled,
+     * which is always called as part of the upgrade path from an amp-ad element
+     * to an amp-ad-doubleclick element. Thus, if we are an amp-ad, we can be sure
+     * that it has been verified.
+     */
+    return this.isAmpAdElement() &&
       // Ensure not within remote.html iframe.
       !document.querySelector('meta[name=amp-3p-iframe-src]');
   }

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -151,7 +151,7 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
       meta.setAttribute('name', 'amp-3p-iframe-src');
       doc.head.appendChild(meta);
       impl = new AmpAdNetworkDoubleclickImpl(element);
-      expect(impl.isValidElement(doc)).to.be.false;
+      expect(impl.isValidElement()).to.be.false;
     });
   });
 

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -146,6 +146,13 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
       impl = new AmpAdNetworkDoubleclickImpl(element);
       expect(impl.isValidElement()).to.be.true;
     });
+    it('should not be valid if remote.html present', () => {
+      const meta = doc.createElement('meta');
+      meta.setAttribute('name', 'amp-3p-iframe-src');
+      doc.head.appendChild(meta);
+      impl = new AmpAdNetworkDoubleclickImpl(element);
+      expect(impl.isValidElement(doc)).to.be.false;
+    });
   });
 
 


### PR DESCRIPTION
We were unnecessarily checking that the doubleclick and adsense impls were in a valid a4a environment, when just checking that it was an amp-ad element would suffice (due to environment validity already being checked as part of the upgrade path). In the case of doubleclick, this was breaking the canonical fast fetch support experiments. 