### PR TITLE
Remove noisy 3p error for user error reporting

### DIFF
--- a/3p/ampcontext.js
+++ b/3p/ampcontext.js
@@ -106,7 +106,6 @@ export class AbstractAmpContext {
     this.client_.setSentinel(dev().assertString(this.sentinel));
 
     this.listenForPageVisibility_();
-    this.report3pError_();
   }
 
   /**
@@ -316,17 +315,15 @@ export class AbstractAmpContext {
 
   /**
    * Send 3p error to parent iframe
-   * @private
+   * @param {!Error} e
    */
-  report3pError_() {
-    this.win_.onerror = message => {
-      if (message) {
-        this.client_.sendMessage(MessageType.USER_ERROR_IN_IFRAME, dict({
-          'message': message,
-        }));
-      }
-      return false;
-    };
+  report3pError(e) {
+    if (!e.message) {
+      return;
+    }
+    this.client_.sendMessage(MessageType.USER_ERROR_IN_IFRAME, dict({
+      'message': e.message,
+    }));
   }
 }
 

--- a/3p/integration.js
+++ b/3p/integration.js
@@ -48,11 +48,17 @@ import {urls} from '../src/config';
 import {endsWith} from '../src/string';
 import {parseJson} from '../src/json';
 import {parseUrl, getSourceUrl, isProxyOrigin} from '../src/url';
-import {initLogConstructor, setReportError, user} from '../src/log';
+import {
+  initLogConstructor,
+  setReportError,
+  user,
+  isUserErrorMessage,
+} from '../src/log';
 import {dict} from '../src/utils/object.js';
 import {getMode} from '../src/mode';
 import {startsWith} from '../src/string.js';
 import {AmpEvents} from '../src/amp-events';
+import {MessageType} from '../src/3p-frame-messaging';
 
 // 3P - please keep in alphabetic order
 import {facebook} from './facebook';
@@ -447,7 +453,6 @@ window.draw3p = function(opt_configCallback, opt_allowed3pTypes,
   try {
     const data = getAttributeData();
     const location = getLocation();
-
     ensureFramed(window);
     validateParentOrigin(window, location);
     validateAllowedTypes(window, getEmbedType(), opt_allowed3pTypes);
@@ -477,6 +482,14 @@ window.draw3p = function(opt_configCallback, opt_allowed3pTypes,
       nonSensitiveDataPostMessage('bootstrap-loaded');
     }
   } catch (e) {
+    if (window.context && window.context.report3pError) {
+      // window.context has initiated yet
+      if (e.message && isUserErrorMessage(e.message)) {
+        // report user error to parent window
+        window.context.report3pError(e);
+      }
+    }
+
     const c = window.context || {mode: {test: false}};
     if (!c.mode.test) {
       lightweightErrorReport(e, c.canary);
@@ -558,6 +571,8 @@ function installContextUsingStandardImpl(win, data) {
     renderStart: triggerRenderStart,
     reportRenderedEntityIdentifier,
     requestResize: triggerResizeRequest,
+    report3pError,
+
 
     // Using quotes due to bug related to imported variables in object property
     // shorthand + object shorthand lint rule.
@@ -724,6 +739,19 @@ function reportRenderedEntityIdentifier(entityId) {
       'entityId should be a string %s', entityId);
   nonSensitiveDataPostMessage('entity-id', dict({
     'id': entityId,
+  }));
+}
+
+/**
+ * Send 3p error to parent iframe
+ * @param {!Error} e
+ */
+function report3pError(e) {
+  if (!e.message) {
+    return;
+  }
+  nonSensitiveDataPostMessage(MessageType.USER_ERROR_IN_IFRAME, dict({
+    'message': e.message,
   }));
 }
 

--- a/3p/integration.js
+++ b/3p/integration.js
@@ -453,6 +453,7 @@ window.draw3p = function(opt_configCallback, opt_allowed3pTypes,
   try {
     const data = getAttributeData();
     const location = getLocation();
+
     ensureFramed(window);
     validateParentOrigin(window, location);
     validateAllowedTypes(window, getEmbedType(), opt_allowed3pTypes);

--- a/ads/_ping_.js
+++ b/ads/_ping_.js
@@ -15,7 +15,7 @@
  */
 
 import {validateData} from '../3p/3p';
-import {dev} from '../src/log';
+import {dev, user} from '../src/log';
 
 /**
  * A fake ad network integration that is mainly used for testing
@@ -28,7 +28,9 @@ export function _ping_(global, data) {
   // for testing only. see #10628
   global.networkIntegrationDataParamForTesting = data;
 
-  validateData(data, [], ['valid', 'adHeight', 'adWidth', 'enableIo', 'url']);
+  validateData(data, [],
+      ['valid', 'adHeight', 'adWidth', 'enableIo', 'url', 'error']);
+  user().assert(!data['error'], 'Fake user error!');
   global.document.getElementById('c').textContent = data.ping;
   global.ping = Object.create(null);
 

--- a/build-system/amp4test.js
+++ b/build-system/amp4test.js
@@ -56,6 +56,7 @@ app.use('/compose-doc', function(req, res) {
   </script>
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <script async src="/dist/${process.env.SERVE_MODE == 'compiled' ? 'v0' : 'amp'}.js"></script>
+  <meta name="amp-3p-iframe-src" content="http://localhost:9876/dist.3p/current/frame.max.html">
   ${extensionScripts}
   <style amp-custom>${req.query.css}</style>
 </head>

--- a/examples/analytics-error-reporting.amp.html
+++ b/examples/analytics-error-reporting.amp.html
@@ -75,22 +75,12 @@
 </amp-youtube>
 
 <h1>These create 3P error</h1>
-<h2>A9 fake 3p error</h2>
-<amp-ad width="300" height="250"
-        type="a9"
-        data-aax_size="300x250"
-        data-aax_pubname="test123"
-        data-aax_src="302"
-        data-a9-error="0">
-</amp-ad>
-
-<h2>Adblade fake 3p error</h2>
-<amp-ad width="300" height="250"
-        type="adblade"
-        data-width="300"
-        data-height="250"
-        data-cid="19626-3798936394"
-        data-blade-error="0">
+<h2>fake 3p error</h2>
+<amp-ad width=300 height=250
+    type="_ping_"
+    data-url='not-exist'
+    data-valid='false'
+    data-error='true'>
 </amp-ad>
 
 <amp-analytics>

--- a/test/functional/test-amp-context.js
+++ b/test/functional/test-amp-context.js
@@ -60,19 +60,19 @@ describe('3p ampcontext.js', () => {
     windowMessageHandler = undefined;
   });
 
-  it('should send error message with report3pError_', () => {
+  it('should send error message with report3pError', () => {
     win.name = generateSerializedAttributes();
     const context = new AmpContext(win);
     expect(context).to.be.ok;
 
     // Resetting since a message is sent on construction.
     windowPostMessageSpy.reset();
-    win.onerror('message');
+    context.report3pError(new Error('test'));
     expect(windowPostMessageSpy).to.be.called;
     expect(windowPostMessageSpy).to.be.calledWith(serializeMessage(
         'user-error-in-iframe',
         '1-291921',
-        {'message': 'message'},
+        {'message': 'test'},
         '$internalRuntimeVersion$'
       ));
   });

--- a/test/integration/test-user-error-reporting.js
+++ b/test/integration/test-user-error-reporting.js
@@ -83,4 +83,36 @@ describe.configure().run('user-error', function() {
       return expect(withdrawRequest(env.win, randomId)).to.be.ok;
     });
   });
+
+  describes.integration('3p user-error integration test', {
+    extensions: ['amp-analytics', 'amp-ad'],
+    hash: 'log=0',
+    experiments: ['user-error-reporting'],
+
+    body: () => `
+    <amp-ad width=300 height=250
+        type="_ping_"
+        data-url='not-exist'
+        data-valid='false'
+        data-error='true'>
+    </amp-ad>
+
+    <amp-analytics><script type="application/json">
+          {
+              "requests": {
+                  "error": "${depositRequestUrl(randomId)}"
+              },
+              "triggers": {
+                  "userError": {
+                      "on": "user-error",
+                      "request": "error"
+                  }
+              }
+          }
+    </script></amp-analytics>`,
+  }, env => {
+    it('should ping correct host with 3p error message', () => {
+      return expect(withdrawRequest(env.win, randomId)).to.eventually.be.ok;
+    });
+  });
 });

--- a/test/integration/test-user-error-reporting.js
+++ b/test/integration/test-user-error-reporting.js
@@ -49,7 +49,7 @@ describe.configure().run('user-error', function() {
                referrerpolicy="fail-referrer">`,
   }, env => {
     it('should ping correct host with amp-pixel user().assert err', () => {
-      return expect(withdrawRequest(env.win, randomId)).to.be.ok;
+      return withdrawRequest(env.win, randomId);
     });
   });
 
@@ -80,7 +80,7 @@ describe.configure().run('user-error', function() {
     </script></amp-analytics>`,
   }, env => {
     it('should ping correct host with amp-img user().error err', () => {
-      return expect(withdrawRequest(env.win, randomId)).to.be.ok;
+      return withdrawRequest(env.win, randomId);
     });
   });
 
@@ -112,7 +112,7 @@ describe.configure().run('user-error', function() {
     </script></amp-analytics>`,
   }, env => {
     it('should ping correct host with 3p error message', () => {
-      return expect(withdrawRequest(env.win, randomId)).to.eventually.be.ok;
+      return withdrawRequest(env.win, randomId);
     });
   });
 });

--- a/test/integration/test-user-error-reporting.js
+++ b/test/integration/test-user-error-reporting.js
@@ -98,17 +98,17 @@ describe.configure().run('user-error', function() {
     </amp-ad>
 
     <amp-analytics><script type="application/json">
-          {
-              "requests": {
-                  "error": "${depositRequestUrl(randomId)}"
-              },
-              "triggers": {
-                  "userError": {
-                      "on": "user-error",
-                      "request": "error"
-                  }
-              }
-          }
+    {
+      "requests": {
+        "error": "${depositRequestUrl(randomId)}"
+      },
+      "triggers": {
+        "userError": {
+          "on": "user-error",
+          "request": "error"
+        }
+      }
+    }
     </script></amp-analytics>`,
   }, env => {
     it('should ping correct host with 3p error message', () => {


### PR DESCRIPTION
Collecting every 3p iframe error can bring so much noise to error reporting. 
Earlier @cramforce mentioned that publisher can collect those errors and request ad networks to fix them. However this is not a good time to do this, as we are still promoting this new error reporting feature. 
I removed all noisy 3p errors. We can consider report them after publishers have widely adopted this feature. Or we can introduce a flag later so that one can specify if 3p errors reporting are wanted or not. 

Integration test also added. 

to @alanorozco since @lannka  is out : )
cc/ @cramforce 