### PR TITLE
amp-iframe: Two-way message passing with actions

### DIFF
--- a/extensions/amp-iframe/0.1/amp-iframe.js
+++ b/extensions/amp-iframe/0.1/amp-iframe.js
@@ -611,8 +611,16 @@ export class AmpIframe extends AMP.BaseElement {
           }
           return;
         }
+        const data = getData(e);
+        let sanitizedData;
+        try {
+          sanitizedData = JSON.parse(JSON.stringify(data));
+        } catch (e) {
+          user().error(TAG_, 'Message may only contain JSON data.');
+          return;
+        }
         const event =
-            createCustomEvent(this.win, 'amp-iframe:message', getData(e));
+            createCustomEvent(this.win, 'amp-iframe:message', sanitizedData);
         const actionService = Services.actionServiceForDoc(this.getAmpDoc());
         actionService.trigger(this.element, 'message', event, ActionTrust.HIGH);
       };

--- a/extensions/amp-iframe/0.1/amp-iframe.js
+++ b/extensions/amp-iframe/0.1/amp-iframe.js
@@ -22,7 +22,7 @@ import {LayoutPriority} from '../../../src/layout';
 import {Services} from '../../../src/services';
 import {base64EncodeFromBytes} from '../../../src/utils/base64.js';
 import {closestBySelector, removeElement} from '../../../src/dom';
-import {createCustomEvent} from '../../../src/event-helper';
+import {createCustomEvent, getData} from '../../../src/event-helper';
 import {dev, user} from '../../../src/log';
 import {endsWith} from '../../../src/string';
 import {isAdPositionAllowed} from '../../../src/ad-helper';
@@ -127,7 +127,7 @@ export class AmpIframe extends AMP.BaseElement {
 
     /**
      * The origin of URL at `src` attr, if available. Otherwise, null.
-     * @private {string}
+     * @private {?string}
      */
     this.targetOrigin_ = null;
   }
@@ -611,7 +611,8 @@ export class AmpIframe extends AMP.BaseElement {
           }
           return;
         }
-        const event = createCustomEvent(this.win, 'amp-iframe:message', e.data);
+        const event =
+            createCustomEvent(this.win, 'amp-iframe:message', getData(e));
         const actionService = Services.actionServiceForDoc(this.getAmpDoc());
         actionService.trigger(this.element, 'message', event, ActionTrust.HIGH);
       };

--- a/extensions/amp-iframe/0.1/amp-iframe.js
+++ b/extensions/amp-iframe/0.1/amp-iframe.js
@@ -583,8 +583,8 @@ export class AmpIframe extends AMP.BaseElement {
         this.iframe_.contentWindow./*OK*/postMessage(
             invocation.args, this.targetOrigin_);
       } else {
-        user().error(TAG_, '"postMessage" action is only allowed only ' +
-            'amp-iframe src with an origin.');
+        user().error(TAG_, '"postMessage" action is only allowed with "src"' +
+            'attribute with an origin.');
       }
     }, ActionTrust.HIGH);
 
@@ -637,6 +637,7 @@ export class AmpIframe extends AMP.BaseElement {
    * Returns true if a user gesture was recently performed.
    * @return {boolean}
    * @private
+   * @visibleForTesting
    */
   isUserGesture_() {
     // Best effort polyfill until native support is available: check that
@@ -650,6 +651,14 @@ export class AmpIframe extends AMP.BaseElement {
       return false;
     }
     return true;
+  }
+
+  /**
+   * @param {string} value
+   * @visibleForTesting
+   */
+  setTargetOriginForTesting(value) {
+    this.targetOrigin_ = value;
   }
 }
 
@@ -718,7 +727,6 @@ export function isAdLike(element) {
 export function setTrackingIframeTimeoutForTesting(ms) {
   trackingIframeTimeout = ms;
 }
-
 
 AMP.extension(TAG_, '0.1', AMP => {
   AMP.registerElement(TAG_, AmpIframe);

--- a/extensions/amp-iframe/0.1/amp-iframe.js
+++ b/extensions/amp-iframe/0.1/amp-iframe.js
@@ -259,9 +259,7 @@ export class AmpIframe extends AMP.BaseElement {
 
     this.container_ = makeIOsScrollable(this.element);
 
-    if (isExperimentOn(this.win, 'iframe-messaging')) {
-      this.registerIframeMessaging_();
-    }
+    this.registerIframeMessaging_();
   }
 
   /**
@@ -571,6 +569,10 @@ export class AmpIframe extends AMP.BaseElement {
    * @private
    */
   registerIframeMessaging_() {
+    if (!isExperimentOn(this.win, 'iframe-messaging')) {
+      return;
+    }
+
     const src = this.element.getAttribute('src');
     if (src) {
       this.targetOrigin_ = parseUrl(src).origin;
@@ -612,6 +614,8 @@ export class AmpIframe extends AMP.BaseElement {
             'from a user gesture.');
         // Disable the 'message' event if the iframe is behaving badly.
         if (unexpectedMessages >= maxUnexpectedMessages) {
+          user().error(TAG_, 'Too many non-gesture-triggered "message" ' +
+              'events; detaching event listener.');
           this.win.removeEventListener('message', listener);
         }
         return;

--- a/extensions/amp-iframe/0.1/amp-iframe.js
+++ b/extensions/amp-iframe/0.1/amp-iframe.js
@@ -30,12 +30,7 @@ import {isLayoutSizeDefined} from '../../../src/layout';
 import {isSecureUrl, parseUrl, removeFragment} from '../../../src/url';
 import {listenFor} from '../../../src/iframe-helper';
 import {moveLayoutRect} from '../../../src/layout-rect';
-import {removeElement, closestBySelector} from '../../../src/dom';
-import {removeFragment, parseUrl, isSecureUrl} from '../../../src/url';
-import {Services} from '../../../src/services';
-import {user, dev} from '../../../src/log';
-import {utf8EncodeSync} from '../../../src/utils/bytes';
-import {urls} from '../../../src/config';
+import {parseJson} from '../../../src/json';
 import {setStyle} from '../../../src/style';
 import {urls} from '../../../src/config';
 import {utf8Encode} from '../../../src/utils/bytes.js';
@@ -614,7 +609,7 @@ export class AmpIframe extends AMP.BaseElement {
         const data = getData(e);
         let sanitizedData;
         try {
-          sanitizedData = JSON.parse(JSON.stringify(data));
+          sanitizedData = parseJson(JSON.stringify(data));
         } catch (e) {
           user().error(TAG_, 'Message may only contain JSON data.');
           return;

--- a/extensions/amp-iframe/0.1/test/test-amp-iframe.js
+++ b/extensions/amp-iframe/0.1/test/test-amp-iframe.js
@@ -78,10 +78,10 @@ describes.realWin('amp-iframe', {
       setTrackingIframeTimeoutForTesting(20);
     });
 
-    function waitForJsInIframe(opt_ranJs = 1) {
+    function waitForJsInIframe(opt_ranJs = 1, opt_timeout = 300) {
       return poll('waiting for JS to run', () => {
         return ranJs >= opt_ranJs;
-      }, undefined, IFRAME_MESSAGE_TIMEOUT * 6);
+      }, undefined, opt_timeout);
     }
 
     function waitForAmpIframeLayoutPromise(doc, ampIframe) {
@@ -755,7 +755,7 @@ describes.realWin('amp-iframe', {
           satisfiesTrust: () => true,
         });
 
-        yield waitForJsInIframe();
+        yield waitForJsInIframe(1, 500);
         expect(content).to.equal('foo-123');
       });
 
@@ -809,7 +809,7 @@ describes.realWin('amp-iframe', {
           satisfiesTrust: () => true,
         });
 
-        yield waitForJsInIframe(1);
+        yield waitForJsInIframe(1, 500);
         expect(actions.trigger).to.not.be.called;
         expect(userError).calledWithMatch('amp-iframe',
             /may only be triggered from a user gesture/);
@@ -821,7 +821,7 @@ describes.realWin('amp-iframe', {
           satisfiesTrust: () => true,
         });
 
-        yield waitForJsInIframe(2);
+        yield waitForJsInIframe(2, 500);
         // Once for 'loaded-iframe' and once for 'content-iframe'.
         expect(actions.trigger).to.be.calledTwice;
         const eventMatcher = sinon.match({

--- a/extensions/amp-iframe/0.1/test/test-amp-iframe.js
+++ b/extensions/amp-iframe/0.1/test/test-amp-iframe.js
@@ -755,7 +755,7 @@ describes.realWin('amp-iframe', {
           satisfiesTrust: () => true,
         });
 
-        yield waitForJsInIframe(1, 500);
+        yield waitForJsInIframe(1);
         expect(content).to.equal('foo-123');
       });
 
@@ -809,7 +809,7 @@ describes.realWin('amp-iframe', {
           satisfiesTrust: () => true,
         });
 
-        yield waitForJsInIframe(1, 500);
+        yield waitForJsInIframe(1);
         expect(actions.trigger).to.not.be.called;
         expect(userError).calledWithMatch('amp-iframe',
             /may only be triggered from a user gesture/);
@@ -821,7 +821,7 @@ describes.realWin('amp-iframe', {
           satisfiesTrust: () => true,
         });
 
-        yield waitForJsInIframe(2, 500);
+        yield waitForJsInIframe(2);
         // Once for 'loaded-iframe' and once for 'content-iframe'.
         expect(actions.trigger).to.be.calledTwice;
         const eventMatcher = sinon.match({

--- a/extensions/amp-iframe/0.1/test/test-amp-iframe.js
+++ b/extensions/amp-iframe/0.1/test/test-amp-iframe.js
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+import * as sinon from 'sinon';
+
+import {ActionTrust} from '../../../../src/action-trust';
 import {
   AmpIframe,
   isAdLike,
@@ -27,7 +30,11 @@ import {
   whenUpgradedToCustomElement,
 } from '../../../../src/dom';
 import {poll} from '../../../../testing/iframe';
+import {toggleExperiment} from '../../../../src/experiments';
+import {user} from '../../../../src/log';
 
+/** @const {number} */
+const IFRAME_MESSAGE_TIMEOUT = 50;
 
 describes.realWin('amp-iframe', {
   allowExternalResources: true,
@@ -64,7 +71,6 @@ describes.realWin('amp-iframe', {
         if (message.data == 'loaded-iframe') {
           ranJs++;
         }
-
         if (message.data.indexOf('content-iframe:') == 0) {
           content = message.data.replace('content-iframe:', '');
         }
@@ -72,10 +78,10 @@ describes.realWin('amp-iframe', {
       setTrackingIframeTimeoutForTesting(20);
     });
 
-    function waitForJsInIframe() {
+    function waitForJsInIframe(opt_ranJs = 1) {
       return poll('waiting for JS to run', () => {
-        return ranJs > 0;
-      }, undefined, 300);
+        return ranJs >= opt_ranJs;
+      }, undefined, IFRAME_MESSAGE_TIMEOUT * 6);
     }
 
     function waitForAmpIframeLayoutPromise(doc, ampIframe) {
@@ -165,9 +171,8 @@ describes.realWin('amp-iframe', {
       expect(iframe.parentNode).to.equal(scrollWrapper);
       expect(impl.looksLikeTrackingIframe_()).to.be.false;
       expect(impl.getLayoutPriority()).to.equal(LayoutPriority.CONTENT);
-      return timer.promise(50).then(() => {
-        expect(ranJs).to.equal(0);
-      });
+      yield timer.promise(IFRAME_MESSAGE_TIMEOUT);
+      expect(ranJs).to.equal(0);
     });
 
     it('should only propagate supported attributes', function* () {
@@ -304,9 +309,8 @@ describes.realWin('amp-iframe', {
       const scrollWrapper =
           ampIframe.querySelector('i-amphtml-scroll-container');
       expect(iframe.parentNode).to.equal(scrollWrapper);
-      return timer.promise(50).then(() => {
-        expect(ranJs).to.equal(0);
-      });
+      yield timer.promise(IFRAME_MESSAGE_TIMEOUT);
+      expect(ranJs).to.equal(0);
     });
 
     it('should support srcdoc', function* () {
@@ -550,10 +554,9 @@ describes.realWin('amp-iframe', {
       });
       yield waitForAmpIframeLayoutPromise(doc, ampIframe);
       const iframe = ampIframe.querySelector('iframe');
-      return timer.promise(100).then(() => {
-        expect(iframe.style.zIndex).to.equal('0');
-        expect(activateIframeSpy_).to.have.callCount(2);
-      });
+      yield timer.promise(100);
+      expect(iframe.style.zIndex).to.equal('0');
+      expect(activateIframeSpy_).to.have.callCount(2);
     });
 
     it('should detect non-tracking iframe', function* () {
@@ -723,5 +726,111 @@ describes.realWin('amp-iframe', {
           expect(impl.iframeSrc).to.contain(newSrc);
           expect(iframe.getAttribute('src')).to.contain(newSrc);
         });
+
+    describe('two-way messaging', function() {
+      let messagingSrc;
+
+      beforeEach(() => {
+        messagingSrc = 'http://iframe.localhost:' + location.port +
+            '/test/fixtures/served/iframe-messaging.html';
+        toggleExperiment(win, 'iframe-messaging', true, true);
+      });
+
+      afterEach(() => {
+        toggleExperiment(win, 'iframe-messaging', false, true);
+      });
+
+      it('should support "postMessage" action', function*() {
+        const ampIframe = createAmpIframe(env, {
+          src: messagingSrc,
+          sandbox: 'allow-scripts allow-same-origin',
+          width: 100,
+          height: 100});
+        yield waitForAmpIframeLayoutPromise(doc, ampIframe);
+
+        const impl = ampIframe.implementation_;
+        impl.executeAction({
+          method: 'postMessage',
+          args: 'foo-123',
+          satisfiesTrust: () => true,
+        });
+
+        yield waitForJsInIframe();
+        expect(content).to.equal('foo-123');
+      });
+
+      it('should not allow "postMessage" on srcdoc amp-iframe', function*() {
+        const ampIframe = createAmpIframe(env, {
+          srcdoc: '<script>addEventListener("message", e => {' +
+            '  parent./*OK*/postMessage("content-iframe:" + e.data, "*");' +
+            '  parent./*OK*/postMessage("loaded-iframe", "*");' +
+            '});</script>',
+          sandbox: 'allow-scripts',
+          width: 100,
+          height: 100});
+        yield waitForAmpIframeLayoutPromise(doc, ampIframe);
+
+        const userError = sandbox.stub(user(), 'error');
+        const addEventListener = sandbox.stub(win, 'addEventListener');
+        ampIframe.implementation_.executeAction({
+          method: 'postMessage',
+          args: 'foo-123',
+          satisfiesTrust: () => true,
+        });
+        expect(userError).to.be.calledOnce;
+        expect(userError).to.be.calledWithMatch('amp-iframe',
+            /"postMessage" action is only allowed with "src"/);
+
+        yield timer.promise(IFRAME_MESSAGE_TIMEOUT);
+        // The iframe's <script> will only post 'loaded-frame' on receipt of
+        // a message from the parent, which should be disallowed above.
+        expect(ranJs).to.equal(0);
+        // Normally, amp-iframe sets up a listener for "message" events
+        // for iframe -> host messaging, but not if targetOrigin_ is invalid.
+        expect(addEventListener).to.not.be.called;
+      });
+
+      it('should receive "message" events from <iframe>', function*() {
+        const ampIframe = createAmpIframe(env, {
+          src: messagingSrc,
+          sandbox: 'allow-scripts allow-same-origin',
+          width: 100,
+          height: 100});
+        yield waitForAmpIframeLayoutPromise(doc, ampIframe);
+
+        const userError = sandbox.stub(user(), 'error');
+        const actions = {trigger: sandbox.spy()};
+        sandbox.stub(Services, 'actionServiceForDoc').returns(actions);
+
+        const impl = ampIframe.implementation_;
+        impl.executeAction({
+          method: 'postMessage',
+          args: 'foo-123',
+          satisfiesTrust: () => true,
+        });
+
+        yield waitForJsInIframe(1);
+        expect(actions.trigger).to.not.be.called;
+        expect(userError).calledWithMatch('amp-iframe',
+            /may only be triggered from a user gesture/);
+
+        sandbox.stub(impl, 'isUserGesture_').returns(true);
+        impl.executeAction({
+          method: 'postMessage',
+          args: 'bar-456',
+          satisfiesTrust: () => true,
+        });
+
+        yield waitForJsInIframe(2);
+        // Once for 'loaded-iframe' and once for 'content-iframe'.
+        expect(actions.trigger).to.be.calledTwice;
+        const eventMatcher = sinon.match({
+          type: 'amp-iframe:message',
+          detail: 'content-iframe:bar-456',
+        });
+        expect(actions.trigger).to.be.calledWith(ampIframe, 'message',
+            eventMatcher, ActionTrust.HIGH);
+      });
+    });
   });
 });

--- a/src/event-helper.js
+++ b/src/event-helper.js
@@ -24,7 +24,7 @@ const LOAD_FAILURE_PREFIX = 'Failed to load:';
  * Returns a CustomEvent with a given type and detail; supports fallback for IE.
  * @param {!Window} win
  * @param {string} type
- * @param {Object} detail
+ * @param {Object|string|undefined} detail
  * @param {EventInit=} opt_eventInit
  * @return {!Event}
  */

--- a/test/fixtures/served/iframe-messaging.html
+++ b/test/fixtures/served/iframe-messaging.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<body style="background-color:red">
+<script>
+addEventListener("message", function(e) {
+  parent./*OK*/postMessage("content-iframe:" + e.data, "*");
+  parent./*OK*/postMessage("loaded-iframe", "*");
+});
+</script>
+</body>
+</html>

--- a/tools/experiments/experiments.js
+++ b/tools/experiments/experiments.js
@@ -282,6 +282,12 @@ const EXPERIMENTS = [
     spec: 'https://github.com/ampproject/amphtml/issues/13674',
     cleanupIssue: 'https://github.com/ampproject/amphtml/issues/13955',
   },
+  {
+    id: 'iframe-messaging',
+    name: 'Enables "postMessage" action on amp-iframe.',
+    spec: 'https://github.com/ampproject/amphtml/issues/9074',
+    cleanupissue: 'https://github.com/ampproject/amphtml/issues/14263',
+  },
 ];
 
 if (getMode().localDev) {


### PR DESCRIPTION
Partial for #9074.

- Support message passing with `postMessage` from/to iframes with AMP action system
- Uses [targetOrigin](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage#Syntax), extracted from initial value of `src` attribute
- Constrain child -> parent messaging by requiring user gesture (polyfilled)

A simple example:
```html
<!-- On tap, invokes postMessage() with targetOrigin == "https://must.use". -->
<button on="tap:my-iframe.postMessage(foo='bar')">
  Send message {foo: 'bar'} to iframe
</button>

<!-- On message from iframe, invokes AMP.setState(). -->
<amp-iframe 
    id="my-iframe" 
    on="message:AMP.setState({foo: event.foo})" 
    src="https://must.use/src_attribute.html" 
    sandbox="allow-scripts">
</amp-iframe>
```