### PR TITLE
Remove pfx parameter from Doubleclick Fast Fetch requests

### DIFF
--- a/ads/google/a4a/test/test-utils.js
+++ b/ads/google/a4a/test/test-utils.js
@@ -23,6 +23,8 @@ import {
   mergeExperimentIds,
   maybeAppendErrorParameter,
   TRUNCATION_PARAM,
+  getEnclosingContainerTypes,
+  ValidAdContainerTypes,
 } from '../utils';
 import {buildUrl} from '../url-builder';
 import {createElementWithAttributes} from '../../../../src/dom';
@@ -401,6 +403,37 @@ describe('Google A4A utils', () => {
           'https://foo.com/bar', {hello: 'world'}, 15, TRUNCATION_PARAM);
       expect(truncUrl.indexOf(TRUNCATION_PARAM.name) != -1);
       expect(maybeAppendErrorParameter(truncUrl, 'n')).to.not.be.ok;
+    });
+  });
+
+  describes.realWin('#getEnclosingContainerTypes', {}, env => {
+    it('should return empty if no containers', () => {
+      expect(getEnclosingContainerTypes(
+          env.win.document.createElement('amp-ad')).length).to.equal(0);
+    });
+
+    Object.keys(ValidAdContainerTypes).forEach(container => {
+      it(`should return container: ${container}`, () => {
+        const containerElem = env.win.document.createElement(container);
+        env.win.document.body.appendChild(containerElem);
+        const ampAdElem = env.win.document.createElement('amp-ad');
+        containerElem.appendChild(ampAdElem);
+        expect(getEnclosingContainerTypes(ampAdElem))
+            .to.deep.equal([ValidAdContainerTypes[container]]);
+      });
+    });
+
+    it('should include ALL containers', () => {
+      let prevContainer;
+      Object.keys(ValidAdContainerTypes).forEach(container => {
+        const containerElem = env.win.document.createElement(container);
+        (prevContainer || env.win.document.body).appendChild(containerElem);
+        prevContainer = containerElem;
+      });
+      const ampAdElem = env.win.document.createElement('amp-ad');
+      prevContainer.appendChild(ampAdElem);
+      expect(getEnclosingContainerTypes(ampAdElem).sort())
+          .to.deep.equal(Object.values(ValidAdContainerTypes).sort());
     });
   });
 });

--- a/ads/google/a4a/utils.js
+++ b/ads/google/a4a/utils.js
@@ -154,9 +154,6 @@ export function googleBlockParameters(a4a, opt_experimentIds) {
   const slotRect = a4a.getPageLayoutBox();
   const iframeDepth = iframeNestingDepth(win);
   const enclosingContainers = getEnclosingContainerTypes(adElement);
-  const pfx = enclosingContainers.includes(
-      ValidAdContainerTypes['AMP-FX-FLYING-CARPET']) ||
-      enclosingContainers.includes(ValidAdContainerTypes['AMP-STICKY-AD']);
   let eids = adElement.getAttribute('data-experiment-id');
   if (opt_experimentIds) {
     eids = mergeExperimentIds(opt_experimentIds, eids);
@@ -168,7 +165,6 @@ export function googleBlockParameters(a4a, opt_experimentIds) {
     'adx': slotRect.left,
     'ady': slotRect.top,
     'oid': '2',
-    'pfx': pfx ? '1' : '0',
     'act': enclosingContainers.length ? enclosingContainers.join() : null,
   };
 }

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -36,6 +36,8 @@ import {
   addCsiSignalsToAmpAnalyticsConfig,
   QQID_HEADER,
   maybeAppendErrorParameter,
+  getEnclosingContainerTypes,
+  ValidAdContainerTypes,
 } from '../../../ads/google/a4a/utils';
 import {
   googleLifecycleReporterFactory,
@@ -220,6 +222,10 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
         format, this.uniqueSlotId_, adClientId);
     const viewportSize = this.getViewport().getSize();
     this.win['ampAdGoogleIfiCounter'] = this.win['ampAdGoogleIfiCounter'] || 1;
+    const enclosingContainers = getEnclosingContainerTypes(this.element);
+    const pfx = enclosingContainers.includes(
+        ValidAdContainerTypes['AMP-FX-FLYING-CARPET']) ||
+        enclosingContainers.includes(ValidAdContainerTypes['AMP-STICKY-AD']);
     const parameters = {
       'client': adClientId,
       format,
@@ -242,6 +248,7 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
       'ifi': this.win['ampAdGoogleIfiCounter']++,
       'rc': this.fromResumeCallback ? 1 : null,
       'rafmt': this.isResponsive_() ? 13 : null,
+      'pfx': pfx ? '1' : '0',
     };
 
     const experimentIds = [];

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -413,7 +413,6 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
           /(\?|&)oid=2(&|$)/,
           /(\?|&)isw=[0-9]+(&|$)/,
           /(\?|&)ish=[0-9]+(&|$)/,
-          /(\?|&)pfx=(1|0)(&|$)/,
           /(\?|&)eid=([^&]+%2c)*12345678(%2c[^&]+)*(&|$)/,
           /(\?|&)url=https?%3A%2F%2F[a-zA-Z0-9.:%-]+(&|$)/,
           /(\?|&)top=localhost(&|$)/,


### PR DESCRIPTION
Remove pfx parameter indicating position fixed from Doubleclick Fast Fetch requests (can already be determined from 'act' containers type parameter).