### PR TITLE
add `bt` (binary type) query param to error reporting query string

### DIFF
--- a/src/error.js
+++ b/src/error.js
@@ -28,7 +28,7 @@ import {
   dev,
 } from './log';
 import {isProxyOrigin} from './url';
-import {isCanary, experimentTogglesOrNull} from './experiments';
+import {isCanary, experimentTogglesOrNull, getBinaryType} from './experiments';
 import {makeBodyVisible} from './style-installer';
 import {startsWith} from './string';
 import {urls} from './config';
@@ -358,9 +358,14 @@ export function getErrorReportUrl(message, filename, line, col, error,
   }
   url += '&rt=' + runtime;
 
+  // TODO(erwinm): Remove ca when all systems read `bt` instead of `ca` to
+  // identify js binary type.
   if (isCanary(self)) {
     url += '&ca=1';
   }
+  // Pass binary type.
+  url += '&bt=' + getBinaryType(self);
+
   if (self.location.ancestorOrigins && self.location.ancestorOrigins[0]) {
     url += '&or=' + encodeURIComponent(self.location.ancestorOrigins[0]);
   }

--- a/test/functional/test-error.js
+++ b/test/functional/test-error.js
@@ -260,6 +260,39 @@ describe('reportErrorToServer', () => {
     expect(query['vs']).to.equal('some-state');
   });
 
+  it('reportError marks binary type', () => {
+    window.AMP_CONFIG = {
+      type: 'canary',
+    };
+    const e = new Error('XYZ');
+    const url = parseUrl(
+        getErrorReportUrl(undefined, undefined, undefined, undefined, e));
+    const query = parseQueryString(url.search);
+
+    expect(query.m).to.equal('XYZ');
+    expect(query['bt']).to.equal('canary');
+
+    window.AMP_CONFIG = {
+      type: 'control',
+    };
+    const e1 = new Error('XYZ');
+    const url1 = parseUrl(
+        getErrorReportUrl(undefined, undefined, undefined, undefined, e1));
+    const query1 = parseQueryString(url1.search);
+
+    expect(query1.m).to.equal('XYZ');
+    expect(query1['bt']).to.equal('control');
+
+    window.AMP_CONFIG = {};
+    const e2 = new Error('ABC');
+    const url2 = parseUrl(
+        getErrorReportUrl(undefined, undefined, undefined, undefined, e2));
+    const query2 = parseQueryString(url2.search);
+
+    expect(query2.m).to.equal('ABC');
+    expect(query2['bt']).to.equal('unknown');
+  });
+
   it('reportError without error object', () => {
     const url = parseUrl(
         getErrorReportUrl('foo bar', 'foo.js', '11', '22', undefined));


### PR DESCRIPTION
this allows us to identify `control` bucket