### PR TITLE
Properly retreives AmpDocShell when native getRootNode is not available

### DIFF
--- a/src/service/ampdoc-impl.js
+++ b/src/service/ampdoc-impl.js
@@ -189,6 +189,10 @@ export class AmpDocService {
       // Shadow doc.
       const shadowRoot = getShadowRootNode(n);
       if (!shadowRoot) {
+        // If not inside a shadow root, it may belong to AmpDocShell
+        if (this.shellShadowDoc_) {
+          return this.shellShadowDoc_;
+        }
         break;
       }
 


### PR DESCRIPTION
When native method `Node.getRootNode` is not available, `AmpDocService.getAmpDoc` is unable to find the AmpDocShell for components that are not inside a shadow root. This PR fixes this.


