### PR TITLE
Receives response message from vendor frame

### DIFF
--- a/extensions/amp-ad-exit/0.1/amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/amp-ad-exit.js
@@ -164,7 +164,7 @@ export class AmpAdExit extends AMP.BaseElement {
                 `IFRAME_TRANSPORT_SIGNAL${vendorResponse}`) {
               // No substitution occurred, so format string in amp-ad-exit
               // config was invalid
-              dev().error('Invalid IFRAME_TRANSPORT_SIGNAL format:' +
+              dev().error(TAG, 'Invalid IFRAME_TRANSPORT_SIGNAL format:' +
                   vendorResponse +
                   ' (perhaps there is a space after a comma?)');
             } else if (vendorResponse != '') {

--- a/extensions/amp-ad-exit/0.1/amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/amp-ad-exit.js
@@ -18,7 +18,7 @@ import {makeClickDelaySpec} from './filters/click-delay';
 import {assertConfig, assertVendor, TransportMode} from './config';
 import {createFilter} from './filters/factory';
 import {isJsonScriptTag, openWindowDialog} from '../../../src/dom';
-import {getAmpAdResourceId} from '../../../src/service';
+import {getAmpAdResourceId} from '../../../src/ad-helper';
 import {Services} from '../../../src/services';
 import {user} from '../../../src/log';
 import {parseJson} from '../../../src/json';

--- a/extensions/amp-ad-exit/0.1/amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/amp-ad-exit.js
@@ -16,7 +16,6 @@
 
 import {makeClickDelaySpec} from './filters/click-delay';
 import {assertConfig, assertVendor, TransportMode} from './config';
-import {ANALYTICS_CONFIG} from '../../amp-analytics/0.1/vendors';
 import {createFilter} from './filters/factory';
 import {isJsonScriptTag, openWindowDialog} from '../../../src/dom';
 import {getAmpAdResourceId} from '../../../src/service';
@@ -256,9 +255,7 @@ export class AmpAdExit extends AMP.BaseElement {
 
     this.unlisten_ = listen(this.getAmpDoc().win, 'message', event => {
       const responseMessage = deserializeMessage(getData(event));
-
       this.assertValidResponseMessage_(responseMessage, event.origin);
-
       this.vendorResponses_[responseMessage['vendor']] =
           responseMessage['message'];
     });
@@ -270,6 +267,8 @@ export class AmpAdExit extends AMP.BaseElement {
    * the one in service.js isn't stubbable for testing, since only object
    * methods are stubbable.
    * @returns {?string}
+   * @private
+   * @VisibleForTesting
    */
   getAmpAdResourceId_() {
     return getAmpAdResourceId(this.element, this.win.top);
@@ -313,8 +312,8 @@ export class AmpAdExit extends AMP.BaseElement {
    * @private
    */
   assertOriginMatchesVendor_(origin, vendor) {
-    assertVendor(vendor);
-    const vendorURL = new URL(ANALYTICS_CONFIG[vendor]['transport']['iframe']);
+    const vendorConfig = assertVendor(vendor);
+    const vendorURL = new URL(vendorConfig['transport']['iframe']);
     user().assert(vendorURL && origin == vendorURL.origin,
         `Invalid origin for vendor ${vendor}: ${origin}`);
   }

--- a/extensions/amp-ad-exit/0.1/amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/amp-ad-exit.js
@@ -255,11 +255,11 @@ export class AmpAdExit extends AMP.BaseElement {
     this.unlisten_ = listen(this.getAmpDoc().win, 'message', event => {
       const responseMessage = deserializeMessage(getData(event));
 
-      this.assertValidResponseMessage(responseMessage, ampAdResourceId,
-          event.origin);
+      this.assertValidResponseMessage(responseMessage,
+          /** @type {string} */ (ampAdResourceId), event.origin);
 
       this.vendorResponses_[responseMessage['vendor']] =
-        responseMessage['message'];
+          responseMessage['message'];
     });
   }
 
@@ -272,10 +272,10 @@ export class AmpAdExit extends AMP.BaseElement {
 
   /**
    *
-   * @param responseMessage The response object to validate.
-   * @param expectedCreativeId The resource ID of the enclosing AMP ad (which
+   * @param {?JsonObject|undefined} responseMessage The response object to validate.
+   * @param {string} expectedCreativeId The resource ID of the enclosing AMP ad (which
    *     responseMessage['creativeId'] should match.
-   * @param expectedVendor The 3p analytics vendor, which
+   * @param {string} expectedVendor The 3p analytics vendor, which
    *     responseMesssage['vendor'] should match.
    */
   assertValidResponseMessage(responseMessage, expectedCreativeId,
@@ -294,7 +294,7 @@ export class AmpAdExit extends AMP.BaseElement {
     dev().assert(responseMessage['creativeId'] &&
       responseMessage['creativeId'] == expectedCreativeId,
         'Received malformed message from 3p analytics frame: ' +
-      'creativeId missing');
+        'creativeId missing');
     dev().assert(responseMessage['vendor'],
         'Received malformed message from 3p analytics frame: ' +
       'vendor missing');

--- a/extensions/amp-ad-exit/0.1/amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/amp-ad-exit.js
@@ -20,7 +20,7 @@ import {createFilter} from './filters/factory';
 import {isJsonScriptTag, openWindowDialog} from '../../../src/dom';
 import {getAmpAdResourceId} from '../../../src/ad-helper';
 import {Services} from '../../../src/services';
-import {user} from '../../../src/log';
+import {user, dev} from '../../../src/log';
 import {parseJson} from '../../../src/json';
 import {
   listen,
@@ -151,13 +151,23 @@ export class AmpAdExit extends AMP.BaseElement {
             const vendorResponse = replacements./*OK*/expandStringSync(
                 customVar.iframeTransportSignal, {
                   'IFRAME_TRANSPORT_SIGNAL': (vendor, responseKey) => {
+                    if (!(vendor && responseKey)) {
+                      return '';
+                    }
                     const vendorResponses = this.vendorResponses_[vendor];
                     if (vendorResponses && responseKey in vendorResponses) {
                       return vendorResponses[responseKey];
                     }
                   },
                 });
-            if (vendorResponse != '') {
+            if (customVar.iframeTransportSignal ==
+                `IFRAME_TRANSPORT_SIGNAL${vendorResponse}`) {
+              // No substitution occurred, so format string in amp-ad-exit
+              // config was invalid
+              dev().error('Invalid IFRAME_TRANSPORT_SIGNAL format:' +
+                  vendorResponse +
+                  ' (perhaps there is a space after a comma?)');
+            } else if (vendorResponse != '') {
               // Caveat: If the vendor's response *is* the empty string, then
               // this will cause the arg/default value to be returned.
               return vendorResponse;

--- a/extensions/amp-ad-exit/0.1/amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/amp-ad-exit.js
@@ -22,6 +22,7 @@ import {getAmpAdResourceId} from '../../../src/ad-helper';
 import {Services} from '../../../src/services';
 import {user, dev} from '../../../src/log';
 import {parseJson} from '../../../src/json';
+import {parseUrl} from '../../../src/url';
 import {
   listen,
   deserializeMessage,
@@ -120,10 +121,12 @@ export class AmpAdExit extends AMP.BaseElement {
     };
     if (target.vars) {
       for (const customVarName in target.vars) {
-        let customVar;
-        if (customVarName[0] != '_' ||
-            !(customVar = /** @type {!./config.VariableDef} */
-            (target.vars[customVarName]))) {
+        if (customVarName[0] != '_') {
+          continue;
+        }
+        const customVar =
+            /** @type {!./config.VariableDef} */ (target.vars[customVarName]);
+        if (!customVar) {
           continue;
         }
         /*
@@ -347,7 +350,7 @@ export class AmpAdExit extends AMP.BaseElement {
    * @private
    */
   assertOriginMatchesVendor_(origin, vendor) {
-    const vendorURL = new URL(assertVendor(vendor));
+    const vendorURL = parseUrl(assertVendor(vendor));
     if (this.vendorOrigins_[vendor]) {
       user().assert(this.vendorOrigins_[vendor] == origin,
           `Invalid origin for vendor ${vendor}: ${origin}`);

--- a/extensions/amp-ad-exit/0.1/amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/amp-ad-exit.js
@@ -280,12 +280,6 @@ export class AmpAdExit extends AMP.BaseElement {
    */
   assertValidResponseMessage(responseMessage, expectedCreativeId,
                              expectedVendor) {
-    if (!responseMessage || !responseMessage['type'] ||
-      responseMessage['type'] != MessageType.IFRAME_TRANSPORT_RESPONSE ||
-      !responseMessage['creativeId'] ||
-      responseMessage['creativeId'] != expectedCreativeId) {
-      return;
-    }
     dev().assert(responseMessage && responseMessage['message'],
         'Received empty response from 3p analytics frame');
     dev().assert(responseMessage['type'] &&
@@ -297,7 +291,7 @@ export class AmpAdExit extends AMP.BaseElement {
         'creativeId missing');
     dev().assert(responseMessage['vendor'],
         'Received malformed message from 3p analytics frame: ' +
-      'vendor missing');
+        'vendor missing');
     assertOriginMatchesVendor(expectedVendor, responseMessage['vendor']);
   }
 

--- a/extensions/amp-ad-exit/0.1/amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/amp-ad-exit.js
@@ -251,7 +251,7 @@ export class AmpAdExit extends AMP.BaseElement {
     }
 
     this.ampAdResourceId_ = user().assert(
-        getAmpAdResourceId(this.element, this.win.top),
+        this.getAmpAdResourceId_(),
         `${TAG}: No friendly parent amp-ad element was found for amp-ad-exit.`);
 
     this.unlisten_ = listen(this.getAmpDoc().win, 'message', event => {
@@ -262,6 +262,17 @@ export class AmpAdExit extends AMP.BaseElement {
       this.vendorResponses_[responseMessage['vendor']] =
           responseMessage['message'];
     });
+  }
+
+  /**
+   * Gets the resource ID of the amp-ad element containing this amp-ad-exit tag.
+   * This is a pass-through for the version in service.js, solely because
+   * the one in service.js isn't stubbable for testing, since only object
+   * methods are stubbable.
+   * @returns {?string}
+   */
+  getAmpAdResourceId_() {
+    return getAmpAdResourceId(this.element, this.win.top);
   }
 
   /** @override */

--- a/extensions/amp-ad-exit/0.1/amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/amp-ad-exit.js
@@ -263,7 +263,7 @@ export class AmpAdExit extends AMP.BaseElement {
             continue;
           }
           const matches = target.vars[customVar].iframeTransportSignal.match(
-              /IFRAME_TRANSPORT_SIGNAL\(([^,]*)/);
+              /IFRAME_TRANSPORT_SIGNAL\(([^,]+)/);
           if (!matches || matches.length < 2) {
             continue;
           }

--- a/extensions/amp-ad-exit/0.1/config.js
+++ b/extensions/amp-ad-exit/0.1/config.js
@@ -169,4 +169,5 @@ export function assertVendor(vendor) {
       ANALYTICS_CONFIG[vendor]['transport'] &&
       ANALYTICS_CONFIG[vendor]['transport']['iframe'],
       'Unknown vendor: ' + vendor);
+  return ANALYTICS_CONFIG[vendor];
 }

--- a/extensions/amp-ad-exit/0.1/config.js
+++ b/extensions/amp-ad-exit/0.1/config.js
@@ -170,3 +170,16 @@ function assertVendor(vendor) {
       ANALYTICS_CONFIG[vendor]['transport']['iframe'] !== undefined,
       'Unknown vendor: ' + vendor);
 }
+
+/**
+ * Ensures that a given origin matches that of an existing vendor's
+ * transport/iframe URL
+ * @param origin The origin to verify
+ * @param vendor The vendor whose origin to check against
+ */
+export function assertOriginMatchesVendor(origin, vendor) {
+  assertVendor(vendor);
+  const vendorURL = new URL(ANALYTICS_CONFIG[vendor]['transport']['iframe']);
+  user().assert(vendorURL && origin == vendorURL.origin,
+      'Invalid origin for vendor ' + vendor + ': ' + origin);
+}

--- a/extensions/amp-ad-exit/0.1/config.js
+++ b/extensions/amp-ad-exit/0.1/config.js
@@ -165,7 +165,7 @@ function assertTarget(name, target, config) {
  */
 function assertVendor(vendor) {
   user().assert(ANALYTICS_CONFIG &&
-      ANALYTICS_CONFIG[vendor] !== undefined &&
+      ANALYTICS_CONFIG[vendor] &&
       ANALYTICS_CONFIG[vendor]['transport'] !== undefined &&
       ANALYTICS_CONFIG[vendor]['transport']['iframe'] !== undefined,
       'Unknown vendor: ' + vendor);

--- a/extensions/amp-ad-exit/0.1/config.js
+++ b/extensions/amp-ad-exit/0.1/config.js
@@ -162,6 +162,7 @@ function assertTarget(name, target, config) {
  * Checks whether a vendor is valid (i.e. listed in vendors.js and has
  * transport/iframe defined.
  * @param {string} vendor The vendor name that should be listed in vendors.js
+ * @return {string} The vendor's iframe URL
  */
 export function assertVendor(vendor) {
   user().assert(ANALYTICS_CONFIG &&
@@ -169,5 +170,5 @@ export function assertVendor(vendor) {
       ANALYTICS_CONFIG[vendor]['transport'] &&
       ANALYTICS_CONFIG[vendor]['transport']['iframe'],
       'Unknown vendor: ' + vendor);
-  return ANALYTICS_CONFIG[vendor];
+  return ANALYTICS_CONFIG[vendor]['transport']['iframe'];
 }

--- a/extensions/amp-ad-exit/0.1/config.js
+++ b/extensions/amp-ad-exit/0.1/config.js
@@ -174,8 +174,8 @@ function assertVendor(vendor) {
 /**
  * Ensures that a given origin matches that of an existing vendor's
  * transport/iframe URL
- * @param origin The origin to verify
- * @param vendor The vendor whose origin to check against
+ * @param {string} origin The origin to verify
+ * @param {string} vendor The vendor whose origin to check against
  */
 export function assertOriginMatchesVendor(origin, vendor) {
   assertVendor(vendor);

--- a/extensions/amp-ad-exit/0.1/config.js
+++ b/extensions/amp-ad-exit/0.1/config.js
@@ -40,8 +40,7 @@ export let NavigationTargetConfig;
 /**
  * @typedef {{
  *   defaultValue: (string|number|boolean),
- *   vendorAnalyticsSource: (string|undefined),
- *   vendorAnalyticsResponseKey: (string|undefined)
+ *   iframeTransportSignal: (string|undefined)
  * }}
  */
 export let VariableDef;
@@ -145,15 +144,6 @@ function assertTarget(name, target, config) {
       user().assert(
           pattern.test(variable), '\'%s\' must match the pattern \'%s\'',
           variable, pattern);
-      const vendor = target.vars[variable]['vendorAnalyticsSource'];
-      if (vendor) {
-        assertVendor(vendor);
-        user().assert(
-            target.vars[variable]['vendorAnalyticsResponseKey'],
-            'Variable \'%s\': If vendorAnalyticsSource is defined then ' +
-            'vendorAnalyticsResponseKey must also be defined', variable);
-
-      }
     }
   }
 }

--- a/extensions/amp-ad-exit/0.1/config.js
+++ b/extensions/amp-ad-exit/0.1/config.js
@@ -163,23 +163,10 @@ function assertTarget(name, target, config) {
  * transport/iframe defined.
  * @param {string} vendor The vendor name that should be listed in vendors.js
  */
-function assertVendor(vendor) {
+export function assertVendor(vendor) {
   user().assert(ANALYTICS_CONFIG &&
       ANALYTICS_CONFIG[vendor] &&
-      ANALYTICS_CONFIG[vendor]['transport'] !== undefined &&
-      ANALYTICS_CONFIG[vendor]['transport']['iframe'] !== undefined,
+      ANALYTICS_CONFIG[vendor]['transport'] &&
+      ANALYTICS_CONFIG[vendor]['transport']['iframe'],
       'Unknown vendor: ' + vendor);
-}
-
-/**
- * Ensures that a given origin matches that of an existing vendor's
- * transport/iframe URL
- * @param {string} origin The origin to verify
- * @param {string} vendor The vendor whose origin to check against
- */
-export function assertOriginMatchesVendor(origin, vendor) {
-  assertVendor(vendor);
-  const vendorURL = new URL(ANALYTICS_CONFIG[vendor]['transport']['iframe']);
-  user().assert(vendorURL && origin == vendorURL.origin,
-      'Invalid origin for vendor ' + vendor + ': ' + origin);
 }

--- a/extensions/amp-ad-exit/0.1/test/test-amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/test/test-amp-ad-exit.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import '../amp-ad-exit';
+import {AmpAdExit} from '../amp-ad-exit';
 import * as sinon from 'sinon';
 import {ANALYTICS_CONFIG} from '../../../amp-analytics/0.1/vendors';
 import {toggleExperiment} from '../../../../src/experiments';
@@ -148,6 +148,8 @@ describes.realWin('amp-ad-exit', {
     adDiv.style.width = '200px';
     adDiv.style.height = '200px';
     win.document.body.appendChild(adDiv);
+    sandbox.stub(AmpAdExit.prototype, 'getAmpAdResourceId_',
+        () => String(Math.round(Math.random()*10000)));
   }
 
   beforeEach(() => {

--- a/extensions/amp-ad-exit/0.1/test/test-amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/test/test-amp-ad-exit.js
@@ -148,6 +148,8 @@ describes.realWin('amp-ad-exit', {
     adDiv.style.width = '200px';
     adDiv.style.height = '200px';
     win.document.body.appendChild(adDiv);
+    // TODO(jonkeller): Long-term, test with amp-ad-exit enclosed inside amp-ad,
+    // so we don't have to do this hack.
     sandbox.stub(AmpAdExit.prototype, 'getAmpAdResourceId_',
         () => String(Math.round(Math.random() * 10000)));
   }

--- a/extensions/amp-ad-exit/0.1/test/test-amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/test/test-amp-ad-exit.js
@@ -149,7 +149,7 @@ describes.realWin('amp-ad-exit', {
     adDiv.style.height = '200px';
     win.document.body.appendChild(adDiv);
     sandbox.stub(AmpAdExit.prototype, 'getAmpAdResourceId_',
-        () => String(Math.round(Math.random()*10000)));
+        () => String(Math.round(Math.random() * 10000)));
   }
 
   beforeEach(() => {

--- a/extensions/amp-ad-network-fake-impl/0.1/data/fake_amp_ad_with_iframe_transport.html
+++ b/extensions/amp-ad-network-fake-impl/0.1/data/fake_amp_ad_with_iframe_transport.html
@@ -1,20 +1,25 @@
 <!doctype html>
 <html amp4ads>
   <head>
+    <title>Ad with 3p Analytics and amp-ad-exit</title>
     <meta charset=utf-8>
     <script async src='https://cdn.ampproject.org/v0.js'></script>
-    <script async custom-element=amp-analytics src='https://cdn.ampproject.org/v0/amp-analytics-0.1.js'></script>
+    <script async custom-element='amp-analytics' src='https://cdn.ampproject.org/v0/amp-analytics-0.1.js'></script>
+    <script async custom-element='amp-ad-exit' src='https://cdn.ampproject.org/v0/amp-ad-exit-0.1.js'></script>
     <style amp4ads-boilerplate>body{visibility:hidden}</style>
     <meta name=viewport content=width=device-width,minimum-scale=1>
   </head>
   <body>
-    <a href="/landing.html">
-      <amp-img id=img src='https://upload.wikimedia.org/wikipedia/commons/6/6e/Golde33443.jpg' width=256 height=300></amp-img>
-      <p class=frob>
-        By Golden Trvs Gol twister (Own work) [CC BY-SA 4.0 (http://creativecommons.org/licenses/by-sa/4.0)], via Wikimedia Commons
-      </p>
-    </a>
-    <amp-analytics type="testVendor">
+    Before using this example ad, please add the following to
+    extensions/amp-analytics/0.1/vendors.js:
+    <pre>
+      'example-3p-vendor': {
+        'transport': {
+          'iframe': 'http://localhost:8000/examples/analytics-iframe-transport-remote-frame.html',
+        },
+      },
+    </pre>
+    <amp-analytics type='example-3p-vendor'>
       <script type='application/json'>
         {
           "requests": {
@@ -34,13 +39,48 @@
               "selector": "img",
               "request": "sample_click_request"
             }
-          },
-          "transport": {
-            "iframe": "/examples/analytics-iframe-transport-remote-frame.html"
           }
         }
       </script>
     </amp-analytics>
+    <amp-ad-exit id='exit-api'>
+      <script type='application/json'>
+        {
+          "targets": {
+            "target1": {
+              "finalUrl": "/?product1&x=CLICK_X&y=CLICK_Y&e=_elem&foo=_bar&shouldNotBeReplaced=AMP_VERSION",
+              "vars": {
+                "_elem": {
+                  "defaultValue": "headline"
+                },
+                "_bar": {
+                  "defaultValue": "bar-default",
+                  "iframeTransportSignal": "IFRAME_TRANSPORT_SIGNAL(example-3p-vendor, collected-data)"
+                }
+              }
+            }
+          },
+          "filters": {
+            "longDelay": {
+              "type": "clickDelay",
+              "delay": 10000
+            }
+          },
+          "transport": {
+            "beacon": true,
+            "image": true
+          }
+        }
+      </script>
+    </amp-ad-exit>
+    <div id='ad'>
+      <div class='product' on='tap:exit-api.exit(target="target1", _elem="Product 1")'>
+        <amp-img id='img' src='https://upload.wikimedia.org/wikipedia/commons/6/6e/Golde33443.jpg' width=256 height=300></amp-img>
+        <p class='frob'>
+          By Golden Trvs Gol twister (Own work) [CC BY-SA 4.0 (http://creativecommons.org/licenses/by-sa/4.0)], via Wikimedia Commons
+        </p>
+      </div>
+    </div>
   </body>
 </html>
 

--- a/extensions/amp-ad-network-fake-impl/0.1/data/fake_amp_ad_with_iframe_transport.html
+++ b/extensions/amp-ad-network-fake-impl/0.1/data/fake_amp_ad_with_iframe_transport.html
@@ -55,7 +55,7 @@
                 },
                 "_bar": {
                   "defaultValue": "bar-default",
-                  "iframeTransportSignal": "IFRAME_TRANSPORT_SIGNAL(example-3p-vendor, collected-data)"
+                  "iframeTransportSignal": "IFRAME_TRANSPORT_SIGNAL(example-3p-vendor,collected-data)"
                 }
               }
             }

--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -170,7 +170,9 @@ export class AmpAnalytics extends AMP.BaseElement {
 
   /** @override */
   resumeCallback() {
-    this.initIframeTransport_();
+    if (this.config_['transport'] && this.config_['transport']['iframe']) {
+      this.initIframeTransport_();
+    }
   }
 
   /** @override */

--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -790,7 +790,7 @@ export class AmpAnalytics extends AMP.BaseElement {
       sendRequestUsingIframe(this.win, request);
     } else if (this.config_['transport'] &&
         this.config_['transport']['iframe']) {
-      this.iframeTransport_.sendRequest(request);
+      this.iframeTransport_ && this.iframeTransport_.sendRequest(request);
     } else {
       sendRequest(this.win, request, this.config_['transport'] || {});
     }

--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -168,22 +168,6 @@ export class AmpAnalytics extends AMP.BaseElement {
     }
   }
 
-  /** @override */
-  resumeCallback() {
-    if (this.config_['transport'] && this.config_['transport']['iframe']) {
-      this.initIframeTransport_();
-    }
-  }
-
-  /** @override */
-  unlayoutCallback() {
-    if (this.iframeTransport_) {
-      this.iframeTransport_.detach();
-      this.iframeTransport_ = null;
-    }
-    return super.unlayoutCallback();
-  }
-
   /**
    * @return {!Promise}
    * @private

--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -225,14 +225,14 @@ export class AmpAnalytics extends AMP.BaseElement {
         this.instrumentation_.createAnalyticsGroup(this.element);
 
     if (this.config_['transport'] && this.config_['transport']['iframe']) {
-      const ampAdResourceId = user().assert(
+      const ampAdResourceId = user().assertString(
           getAmpAdResourceId(this.element, this.win.top),
           `${TAG}: No friendly parent amp-ad element was found for ` +
           'amp-analytics.');
 
       this.iframeTransport_ = new IframeTransport(this.getAmpDoc().win,
         this.element.getAttribute('type'),
-        this.config_['transport'], /** @type {string} */ (ampAdResourceId));
+        this.config_['transport'], ampAdResourceId);
     }
 
     const promises = [];

--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -166,6 +166,7 @@ export class AmpAnalytics extends AMP.BaseElement {
       this.analyticsGroup_.dispose();
       this.analyticsGroup_ = null;
     }
+    this.iframeTransport_ = null;
   }
 
   /**

--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -228,7 +228,7 @@ export class AmpAnalytics extends AMP.BaseElement {
       const ampAdResourceId = user().assertString(
           getAmpAdResourceId(this.element, this.win.top),
           `${TAG}: No friendly parent amp-ad element was found for ` +
-          'amp-analytics.');
+          'amp-analytics tag with iframe transport.');
 
       this.iframeTransport_ = new IframeTransport(this.getAmpDoc().win,
         this.element.getAttribute('type'),

--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -166,7 +166,22 @@ export class AmpAnalytics extends AMP.BaseElement {
       this.analyticsGroup_.dispose();
       this.analyticsGroup_ = null;
     }
-    this.iframeTransport_ = null;
+  }
+
+  /** @override */
+  resumeCallback() {
+    if (this.config_['transport'] && this.config_['transport']['iframe']) {
+      this.initIframeTransport_();
+    }
+  }
+
+  /** @override */
+  unlayoutCallback() {
+    if (this.iframeTransport_) {
+      this.iframeTransport_.detach();
+      this.iframeTransport_ = null;
+    }
+    return super.unlayoutCallback();
   }
 
   /**
@@ -775,7 +790,9 @@ export class AmpAnalytics extends AMP.BaseElement {
       sendRequestUsingIframe(this.win, request);
     } else if (this.config_['transport'] &&
         this.config_['transport']['iframe']) {
-      this.iframeTransport_ && this.iframeTransport_.sendRequest(request);
+      user().assert(this.iframeTransport_,
+          'iframe transport was inadvertently deleted');
+      this.iframeTransport_.sendRequest(request);
     } else {
       sendRequest(this.win, request, this.config_['transport'] || {});
     }

--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -22,7 +22,7 @@ import {isArray, isObject} from '../../../src/types';
 import {dict, hasOwn, map} from '../../../src/utils/object';
 import {sendRequest, sendRequestUsingIframe} from './transport';
 import {IframeTransport} from './iframe-transport';
-import {getAmpAdResourceId} from '../../../src/service';
+import {getAmpAdResourceId} from '../../../src/ad-helper';
 import {Services} from '../../../src/services';
 import {toggle} from '../../../src/style';
 import {isEnumValue} from '../../../src/types';

--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -225,11 +225,10 @@ export class AmpAnalytics extends AMP.BaseElement {
         this.instrumentation_.createAnalyticsGroup(this.element);
 
     if (this.config_['transport'] && this.config_['transport']['iframe']) {
-      const ampAdResourceId = getAmpAdResourceId(this.element, this.win.top);
-      if (!ampAdResourceId) {
-        this.user().error(TAG, 'No friendly parent amp-ad element was found' +
-          ' for amp-ad-exit tag.');
-      }
+      const ampAdResourceId = user().assert(
+          getAmpAdResourceId(this.element, this.win.top),
+          `${TAG}: No friendly parent amp-ad element was found for ` +
+          'amp-analytics.');
 
       this.iframeTransport_ = new IframeTransport(this.getAmpDoc().win,
         this.element.getAttribute('type'),

--- a/src/ad-helper.js
+++ b/src/ad-helper.js
@@ -16,6 +16,7 @@
 
 import {dev} from './log';
 import {computedStyle} from './style';
+import {getParentWindowFrameElement} from './service';
 
 const AD_CONTAINER_PROP = '__AMP__AD_CONTAINER';
 
@@ -91,3 +92,25 @@ export function getAdContainer(element) {
   }
   return element[AD_CONTAINER_PROP];
 }
+
+/**
+ * Gets the resource ID of the amp-ad element containing the passed node.
+ * If there is no containing amp-ad tag, then null will be returned.
+ * TODO(jonkeller): Investigate whether non-A4A use case is needed. Issue 11436
+ * @return {?string}
+ */
+export function getAmpAdResourceId(node, topWin) {
+  try {
+    const frameParent = getParentWindowFrameElement(node, topWin).parentElement;
+    if (frameParent.nodeName == 'AMP-AD') {
+      return frameParent.getResourceId();
+    }
+  } catch (e) {
+  }
+  // Whether we entered the catch above (e.g. due to attempt to access
+  // across xdomain boundary), or failed to enter the if further above, the
+  // node is not within a friendly amp-ad tag. So, there is no amp-ad
+  // resource ID. How to handle that is up to the caller, but see TODO above.
+  return null;
+}
+

--- a/src/ad-helper.js
+++ b/src/ad-helper.js
@@ -103,7 +103,7 @@ export function getAmpAdResourceId(node, topWin) {
   try {
     const frameParent = getParentWindowFrameElement(node, topWin).parentElement;
     if (frameParent.nodeName == 'AMP-AD') {
-      return frameParent.getResourceId();
+      return String(frameParent.getResourceId());
     }
   } catch (e) {
   }

--- a/src/service.js
+++ b/src/service.js
@@ -348,28 +348,6 @@ export function getParentWindowFrameElement(node, topWin) {
 
 
 /**
- * Gets the resource ID of the amp-ad element containing the passed node.
- * If there is no containing amp-ad tag, then null will be returned.
- * TODO(jonkeller): Investigate whether non-A4A use case is needed. Issue 11436
- * @return {?string}
- */
-export function getAmpAdResourceId(node, topWin) {
-  try {
-    const frameParent = getParentWindowFrameElement(node, topWin).parentElement;
-    if (frameParent.nodeName == 'AMP-AD') {
-      return frameParent.getResourceId();
-    }
-  } catch (e) {
-  }
-  // Whether we entered the catch above (e.g. due to attempt to access
-  // across xdomain boundary), or failed to enter the if further above, the
-  // node is not within a friendly amp-ad tag. So, there is no amp-ad
-  // resource ID. How to handle that is up to the caller, but see TODO above.
-  return null;
-}
-
-
-/**
  * @param {!Node|!./service/ampdoc-impl.AmpDoc} nodeOrDoc
  * @return {!./service/ampdoc-impl.AmpDoc}
  */

--- a/src/service.js
+++ b/src/service.js
@@ -351,7 +351,7 @@ export function getParentWindowFrameElement(node, topWin) {
  * Gets the resource ID of the amp-ad element containing the passed node.
  * If there is no containing amp-ad tag, then null will be returned.
  * TODO(jonkeller): Investigate whether non-A4A use case is needed. Issue 11436
- * @return {string|null}
+ * @return {?string}
  */
 export function getAmpAdResourceId(node, topWin) {
   try {
@@ -361,6 +361,10 @@ export function getAmpAdResourceId(node, topWin) {
     }
   } catch (e) {
   }
+  // Whether we entered the catch above, or failed to enter the if further
+  // above, the node is not within a friendly amp-ad tag. So, there is no
+  // amp-ad resource ID. How to handle that is up to the caller, but
+  // see TODO above.
   return null;
 }
 

--- a/src/service.js
+++ b/src/service.js
@@ -348,6 +348,24 @@ export function getParentWindowFrameElement(node, topWin) {
 
 
 /**
+ * Gets the resource ID of the amp-ad element containing the passed node.
+ * If there is no containing amp-ad tag, then null will be returned.
+ * TODO(jonkeller): Investigate whether non-A4A use case is needed. Issue 11436
+ * @return {string|null}
+ */
+export function getAmpAdResourceId(node, topWin) {
+  try {
+    const frameParent = getParentWindowFrameElement(node, topWin).parentElement;
+    if (frameParent.nodeName == 'AMP-AD') {
+      return frameParent.getResourceId();
+    }
+  } catch (e) {
+  }
+  return null;
+}
+
+
+/**
  * @param {!Node|!./service/ampdoc-impl.AmpDoc} nodeOrDoc
  * @return {!./service/ampdoc-impl.AmpDoc}
  */

--- a/src/service.js
+++ b/src/service.js
@@ -361,10 +361,10 @@ export function getAmpAdResourceId(node, topWin) {
     }
   } catch (e) {
   }
-  // Whether we entered the catch above, or failed to enter the if further
-  // above, the node is not within a friendly amp-ad tag. So, there is no
-  // amp-ad resource ID. How to handle that is up to the caller, but
-  // see TODO above.
+  // Whether we entered the catch above (e.g. due to attempt to access
+  // across xdomain boundary), or failed to enter the if further above, the
+  // node is not within a friendly amp-ad tag. So, there is no amp-ad
+  // resource ID. How to handle that is up to the caller, but see TODO above.
   return null;
 }
 


### PR DESCRIPTION
Previous work implemented ability for amp-analytics to create a 3p vendor iframe.
PR #11306 enables the iframe to send a response to the pub page
This PR enables amp-ad-exit to receive those responses.
PR #11462 enables amp-ad-exit to substitute them into target URLs.