### PR TITLE
Substitutes variables into URL

### DIFF
--- a/extensions/amp-ad-exit/0.1/amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/amp-ad-exit.js
@@ -107,7 +107,7 @@ export class AmpAdExit extends AMP.BaseElement {
       for (const customVarName in target.vars) {
         if (customVarName[0] == '_') {
           const customVar =
-            /** @type {!./config.Variable} */ (target.vars[customVarName]);
+              /** @type {!./config.Variable} */ (target.vars[customVarName]);
           if (customVar) {
             /*
              Example:
@@ -128,7 +128,7 @@ export class AmpAdExit extends AMP.BaseElement {
              be any strings.
              The code below will create substitutionFunctions['_pty'],
              which in this example will return "medium".
-             */
+            */
             substitutionFunctions[customVarName] = () => {
               if ('iframeTransportSignal' in customVar) {
                 const vendorResponse = replacements./*OK*/expandStringSync(
@@ -150,7 +150,7 @@ export class AmpAdExit extends AMP.BaseElement {
               // Either it's not a 3p analytics variable, or it is one
               // but no matching response has been received yet.
               return (customVarName in args) ?
-                args[customVarName] : customVar.defaultValue;
+                  args[customVarName] : customVar.defaultValue;
             };
             whitelist[customVarName] = true;
           }

--- a/extensions/amp-ad-exit/0.1/amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/amp-ad-exit.js
@@ -105,56 +105,56 @@ export class AmpAdExit extends AMP.BaseElement {
     };
     if (target.vars) {
       for (const customVarName in target.vars) {
-        if (customVarName[0] == '_') {
-          const customVar =
-              /** @type {!./config.Variable} */ (target.vars[customVarName]);
-          if (customVar) {
-            /*
-             Example:
-             The amp-ad-exit target has a variable representing the
-             priority of something, which is defined as follows:
-             "vars": {
-             "_pty": {
+        let customVar;
+        if (customVarName[0] != '_' ||
+            !(customVar = /** @type {!./config.Variable} */
+            (target.vars[customVarName]))) {
+          continue;
+        }
+        /*
+         Example:
+         The amp-ad-exit target has a variable representing the priority of
+         something, which is defined as follows:
+         "vars": {
+           "_pty": {
              "defaultValue": "unknown",
              "iframeTransportSignal":
-             "IFRAME_TRANSPORT_SIGNAL(vendorXYZ,priority)"
-             },
-             ...
-             }
-             The cross-domain iframe of vendorXYZ has sent the
-             following response for the creative:
-             { priority: medium, category: W }
-             This is just example data. The keys/values in that object can
-             be any strings.
-             The code below will create substitutionFunctions['_pty'],
-             which in this example will return "medium".
-            */
-            substitutionFunctions[customVarName] = () => {
-              if ('iframeTransportSignal' in customVar) {
-                const vendorResponse = replacements./*OK*/expandStringSync(
-                    customVar.iframeTransportSignal, {
-                      'IFRAME_TRANSPORT_SIGNAL': (vendor, responseKey) => {
-                        const vendorResponses = this.vendorResponses_[vendor];
-                        if (vendorResponses && responseKey in vendorResponses) {
-                          return vendorResponses[responseKey];
-                        }
-                      },
-                    });
-                if (vendorResponse != '') {
-                  // Caveat: If the vendor's response *is* the empty string,
-                  // then this will cause the arg/default value to be returned.
-                  return vendorResponse;
-                }
-              }
-
-              // Either it's not a 3p analytics variable, or it is one
-              // but no matching response has been received yet.
-              return (customVarName in args) ?
-                  args[customVarName] : customVar.defaultValue;
-            };
-            whitelist[customVarName] = true;
+                 "IFRAME_TRANSPORT_SIGNAL(vendorXYZ,priority)"
+           },
+           ...
+         }
+         The cross-domain iframe of vendorXYZ has sent the following
+         response for the creative:
+         { priority: medium, category: W }
+         This is just example data. The keys/values in that object can be
+         any strings.
+         The code below will create substitutionFunctions['_pty'], which in
+         this example will return "medium".
+        */
+        substitutionFunctions[customVarName] = () => {
+          if ('iframeTransportSignal' in customVar) {
+            const vendorResponse = replacements./*OK*/expandStringSync(
+                customVar.iframeTransportSignal, {
+                  'IFRAME_TRANSPORT_SIGNAL': (vendor, responseKey) => {
+                    const vendorResponses = this.vendorResponses_[vendor];
+                    if (vendorResponses && responseKey in vendorResponses) {
+                      return vendorResponses[responseKey];
+                    }
+                  },
+                });
+            if (vendorResponse != '') {
+              // Caveat: If the vendor's response *is* the empty string, then
+              // this will cause the arg/default value to be returned.
+              return vendorResponse;
+            }
           }
-        }
+
+          // Either it's not a 3p analytics variable, or it is one
+          // but no matching response has been received yet.
+          return (customVarName in args) ?
+              args[customVarName] : customVar.defaultValue;
+        };
+        whitelist[customVarName] = true;
       }
     }
     return url => replacements.expandUrlSync(

--- a/extensions/amp-ad-exit/0.1/amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/amp-ad-exit.js
@@ -28,7 +28,7 @@ const TAG = 'amp-ad-exit';
  * @typedef {{
  *   finalUrl: string,
  *   trackingUrls: !Array<string>,
- *   vars: !./config.Variables,
+ *   vars: !./config.VariablesDef,
  *   filters: !Array<!./filters/filter.Filter>
  * }}
  */
@@ -107,7 +107,7 @@ export class AmpAdExit extends AMP.BaseElement {
       for (const customVarName in target.vars) {
         let customVar;
         if (customVarName[0] != '_' ||
-            !(customVar = /** @type {!./config.Variable} */
+            !(customVar = /** @type {!./config.VariableDef} */
             (target.vars[customVarName]))) {
           continue;
         }

--- a/extensions/amp-ad-exit/0.1/amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/amp-ad-exit.js
@@ -59,6 +59,9 @@ export class AmpAdExit extends AMP.BaseElement {
     this.userFilters_ = {};
 
     this.registerAction('exit', this.exit.bind(this));
+
+    /** @private @const {!Object<string, Object<string, string>>} */
+    this.vendorResponses_ = {};
   }
 
   /**
@@ -90,28 +93,72 @@ export class AmpAdExit extends AMP.BaseElement {
    * @return {function(string): string}
    */
   getUrlVariableRewriter_(args, event, target) {
-    const vars = {
+    const substitutionFunctions = {
       'CLICK_X': () => event.clientX,
       'CLICK_Y': () => event.clientY,
     };
+    const replacements = Services.urlReplacementsForDoc(this.getAmpDoc());
     const whitelist = {
       'RANDOM': true,
       'CLICK_X': true,
       'CLICK_Y': true,
     };
     if (target.vars) {
-      for (const customVar in target.vars) {
-        if (customVar[0] == '_') {
-          vars[customVar] = () =>
-              args[customVar] == undefined ?
-                target.vars[customVar].defaultValue : args[customVar];
-          whitelist[customVar] = true;
+      for (const customVarName in target.vars) {
+        if (customVarName[0] == '_') {
+          const customVar =
+            /** @type {!./config.Variable} */ (target.vars[customVarName]);
+          if (customVar) {
+            /*
+             Example:
+             The amp-ad-exit target has a variable representing the
+             priority of something, which is defined as follows:
+             "vars": {
+             "_pty": {
+             "defaultValue": "unknown",
+             "iframeTransportSignal":
+             "IFRAME_TRANSPORT_SIGNAL(vendorXYZ,priority)"
+             },
+             ...
+             }
+             The cross-domain iframe of vendorXYZ has sent the
+             following response for the creative:
+             { priority: medium, category: W }
+             This is just example data. The keys/values in that object can
+             be any strings.
+             The code below will create substitutionFunctions['_pty'],
+             which in this example will return "medium".
+             */
+            substitutionFunctions[customVarName] = () => {
+              if ('iframeTransportSignal' in customVar) {
+                const vendorResponse = replacements./*OK*/expandStringSync(
+                    customVar.iframeTransportSignal, {
+                      'IFRAME_TRANSPORT_SIGNAL': (vendor, responseKey) => {
+                        const vendorResponses = this.vendorResponses_[vendor];
+                        if (vendorResponses && responseKey in vendorResponses) {
+                          return vendorResponses[responseKey];
+                        }
+                      },
+                    });
+                if (vendorResponse != '') {
+                  // Caveat: If the vendor's response *is* the empty string,
+                  // then this will cause the arg/default value to be returned.
+                  return vendorResponse;
+                }
+              }
+
+              // Either it's not a 3p analytics variable, or it is one
+              // but no matching response has been received yet.
+              return (customVarName in args) ?
+                args[customVarName] : customVar.defaultValue;
+            };
+            whitelist[customVarName] = true;
+          }
         }
       }
     }
-    const replacements = Services.urlReplacementsForDoc(this.getAmpDoc());
     return url => replacements.expandUrlSync(
-        url, vars, undefined /* opt_collectVars */, whitelist);
+        url, substitutionFunctions, undefined /* opt_collectVars */, whitelist);
   }
 
   /**

--- a/extensions/amp-ad-exit/0.1/config.js
+++ b/extensions/amp-ad-exit/0.1/config.js
@@ -15,6 +15,7 @@
  */
 
 import {user} from '../../../src/log';
+import {ANALYTICS_CONFIG} from '../../amp-analytics/0.1/vendors';
 import {FilterType} from './filters/filter';
 
 /**
@@ -37,7 +38,16 @@ export let AmpAdExitConfig;
 export let NavigationTargetConfig;
 
 /**
- * @typedef {!Object<string, {defaultValue: (string|number|boolean)}>}
+ * @typedef {{
+ *   defaultValue: (string|number|boolean),
+ *   vendorAnalyticsSource: (string|undefined),
+ *   vendorAnalyticsResponseKey: (string|undefined)
+ * }}
+ */
+export let Variable;
+
+/**
+ * @typedef {!Object<string, !Variable>}
  */
 export let Variables;
 
@@ -135,6 +145,28 @@ function assertTarget(name, target, config) {
       user().assert(
           pattern.test(variable), '\'%s\' must match the pattern \'%s\'',
           variable, pattern);
+      const vendor = target.vars[variable]['vendorAnalyticsSource'];
+      if (vendor) {
+        assertVendor(vendor);
+        user().assert(
+            target.vars[variable]['vendorAnalyticsResponseKey'],
+            'Variable \'%s\': If vendorAnalyticsSource is defined then ' +
+            'vendorAnalyticsResponseKey must also be defined', variable);
+
+      }
     }
   }
+}
+
+/**
+ * Checks whether a vendor is valid (i.e. listed in vendors.js and has
+ * transport/iframe defined.
+ * @param {string} vendor The vendor name that should be listed in vendors.js
+ */
+function assertVendor(vendor) {
+  user().assert(ANALYTICS_CONFIG &&
+    ANALYTICS_CONFIG[vendor] !== undefined &&
+    ANALYTICS_CONFIG[vendor]['transport'] !== undefined &&
+    ANALYTICS_CONFIG[vendor]['transport']['iframe'] !== undefined,
+      'Unknown vendor: ' + vendor);
 }

--- a/extensions/amp-ad-exit/0.1/config.js
+++ b/extensions/amp-ad-exit/0.1/config.js
@@ -165,8 +165,8 @@ function assertTarget(name, target, config) {
  */
 function assertVendor(vendor) {
   user().assert(ANALYTICS_CONFIG &&
-    ANALYTICS_CONFIG[vendor] !== undefined &&
-    ANALYTICS_CONFIG[vendor]['transport'] !== undefined &&
-    ANALYTICS_CONFIG[vendor]['transport']['iframe'] !== undefined,
+      ANALYTICS_CONFIG[vendor] !== undefined &&
+      ANALYTICS_CONFIG[vendor]['transport'] !== undefined &&
+      ANALYTICS_CONFIG[vendor]['transport']['iframe'] !== undefined,
       'Unknown vendor: ' + vendor);
 }

--- a/extensions/amp-ad-exit/0.1/config.js
+++ b/extensions/amp-ad-exit/0.1/config.js
@@ -31,7 +31,7 @@ export let AmpAdExitConfig;
  * @typedef {{
  *   finalUrl: string,
  *   trackingUrls: (!Array<string>|undefined),
- *   vars: (Variables|undefined),
+ *   vars: (VariablesDef|undefined),
  *   filters: (!Array<string>|undefined)
  * }}
  */
@@ -44,12 +44,12 @@ export let NavigationTargetConfig;
  *   vendorAnalyticsResponseKey: (string|undefined)
  * }}
  */
-export let Variable;
+export let VariableDef;
 
 /**
- * @typedef {!Object<string, !Variable>}
+ * @typedef {!Object<string, !VariableDef>}
  */
-export let Variables;
+export let VariablesDef;
 
 /**
  * @typedef {{

--- a/extensions/amp-ad-exit/0.1/test/test-amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/test/test-amp-ad-exit.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {AmpAdExit} from '../amp-ad-exit';
+import '../amp-ad-exit';
 import * as sinon from 'sinon';
 import {ANALYTICS_CONFIG} from '../../../amp-analytics/0.1/vendors';
 import {toggleExperiment} from '../../../../src/experiments';
@@ -79,7 +79,7 @@ const EXIT_CONFIG = {
         _foo: {
           defaultValue: 'foo-default',
           iframeTransportSignal:
-              `IFRAME_TRANSPORT_SIGNAL(${TEST_3P_VENDOR}, collected-data)`,
+              `IFRAME_TRANSPORT_SIGNAL(${TEST_3P_VENDOR},collected-data)`,
         },
         _bar: {
           defaultValue: 'bar-default',
@@ -147,10 +147,6 @@ describes.realWin('amp-ad-exit', {
     adDiv.style.top = '200px';
     adDiv.style.width = '200px';
     adDiv.style.height = '200px';
-    // TODO(jonkeller): Long-term, test with amp-ad-exit enclosed inside amp-ad,
-    // so we don't have to do this hack.
-    sandbox.stub(AmpAdExit.prototype, 'getAmpAdResourceId_',
-        () => String(Math.round(Math.random() * 10000)));
     win.document.body.appendChild(adDiv);
   }
 
@@ -159,6 +155,8 @@ describes.realWin('amp-ad-exit', {
     win = env.win;
     toggleExperiment(win, 'amp-ad-exit', true);
     addAdDiv();
+    // TODO(jonkeller): Remove after rebase
+    win.top.document.body.getResourceId = () => '6789';
     // TEST_3P_VENDOR must be in ANALYTICS_CONFIG *before* makeElementWithConfig
     ANALYTICS_CONFIG[TEST_3P_VENDOR] = ANALYTICS_CONFIG[TEST_3P_VENDOR] || {
       transport: {

--- a/extensions/amp-ad-exit/0.1/test/test-amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/test/test-amp-ad-exit.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import '../amp-ad-exit';
+import {AmpAdExit} from '../amp-ad-exit';
 import * as sinon from 'sinon';
 import {ANALYTICS_CONFIG} from '../../../amp-analytics/0.1/vendors';
 import {toggleExperiment} from '../../../../src/experiments';
@@ -79,8 +79,7 @@ const EXIT_CONFIG = {
         _foo: {
           defaultValue: 'foo-default',
           iframeTransportSignal:
-              'IFRAME_TRANSPORT_SIGNAL(' + TEST_3P_VENDOR +
-              ',collected-data)',
+              `IFRAME_TRANSPORT_SIGNAL(${TEST_3P_VENDOR}, collected-data)`,
         },
         _bar: {
           defaultValue: 'bar-default',
@@ -148,6 +147,10 @@ describes.realWin('amp-ad-exit', {
     adDiv.style.top = '200px';
     adDiv.style.width = '200px';
     adDiv.style.height = '200px';
+    // TODO(jonkeller): Long-term, test with amp-ad-exit enclosed inside amp-ad,
+    // so we don't have to do this hack.
+    sandbox.stub(AmpAdExit.prototype, 'getAmpAdResourceId_',
+        () => String(Math.round(Math.random() * 10000)));
     win.document.body.appendChild(adDiv);
   }
 
@@ -156,7 +159,6 @@ describes.realWin('amp-ad-exit', {
     win = env.win;
     toggleExperiment(win, 'amp-ad-exit', true);
     addAdDiv();
-    win.top.document.body.getResourceId = () => '6789';
     // TEST_3P_VENDOR must be in ANALYTICS_CONFIG *before* makeElementWithConfig
     ANALYTICS_CONFIG[TEST_3P_VENDOR] = ANALYTICS_CONFIG[TEST_3P_VENDOR] || {
       transport: {

--- a/extensions/amp-ad-exit/0.1/test/test-amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/test/test-amp-ad-exit.js
@@ -156,7 +156,7 @@ describes.realWin('amp-ad-exit', {
     win = env.win;
     toggleExperiment(win, 'amp-ad-exit', true);
     addAdDiv();
-    win.top.document.body.getResourceId = function() { return '6789'; };
+    win.top.document.body.getResourceId = () => '6789';
     // TEST_3P_VENDOR must be in ANALYTICS_CONFIG *before* makeElementWithConfig
     ANALYTICS_CONFIG[TEST_3P_VENDOR] = ANALYTICS_CONFIG[TEST_3P_VENDOR] || {
       transport: {

--- a/extensions/amp-ad-exit/0.1/test/test-amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/test/test-amp-ad-exit.js
@@ -79,7 +79,8 @@ const EXIT_CONFIG = {
         _foo: {
           defaultValue: 'foo-default',
           iframeTransportSignal:
-          'IFRAME_TRANSPORT_SIGNAL(' + TEST_3P_VENDOR + ',collected-data)',
+              'IFRAME_TRANSPORT_SIGNAL(' + TEST_3P_VENDOR +
+              ',collected-data)',
         },
         _bar: {
           defaultValue: 'bar-default',

--- a/extensions/amp-ad-exit/0.1/test/test-amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/test/test-amp-ad-exit.js
@@ -16,7 +16,10 @@
 
 import '../amp-ad-exit';
 import * as sinon from 'sinon';
+import {ANALYTICS_CONFIG} from '../../../amp-analytics/0.1/vendors';
 import {toggleExperiment} from '../../../../src/experiments';
+
+const TEST_3P_VENDOR = '3p-vendor';
 
 const EXIT_CONFIG = {
   targets: {
@@ -67,6 +70,19 @@ const EXIT_CONFIG = {
         },
         _boolVar: {
           defaultValue: true,
+        },
+      },
+    },
+    variableFrom3pAnalytics: {
+      'finalUrl': 'http://localhost:8000/vars?foo=_foo',
+      vars: {
+        _foo: {
+          defaultValue: 'foo-default',
+          iframeTransportSignal:
+          'IFRAME_TRANSPORT_SIGNAL(' + TEST_3P_VENDOR + ',collected-data)',
+        },
+        _bar: {
+          defaultValue: 'bar-default',
         },
       },
     },
@@ -139,6 +155,13 @@ describes.realWin('amp-ad-exit', {
     win = env.win;
     toggleExperiment(win, 'amp-ad-exit', true);
     addAdDiv();
+    win.top.document.body.getResourceId = function() { return '6789'; };
+    // TEST_3P_VENDOR must be in ANALYTICS_CONFIG *before* makeElementWithConfig
+    ANALYTICS_CONFIG[TEST_3P_VENDOR] = ANALYTICS_CONFIG[TEST_3P_VENDOR] || {
+      transport: {
+        iframe: '/nowhere.html',
+      },
+    };
     return makeElementWithConfig(EXIT_CONFIG).then(el => {
       element = el;
     });
@@ -358,8 +381,7 @@ describes.realWin('amp-ad-exit', {
     if (!win.navigator) {
       win.navigator = {sendBeacon: () => false};
     }
-    const sendBeacon =
-        sandbox.stub(win.navigator, 'sendBeacon', () => true);
+    const sendBeacon = sandbox.stub(win.navigator, 'sendBeacon', () => true);
 
     element.implementation_.executeAction({
       method: 'exit',
@@ -378,7 +400,7 @@ describes.realWin('amp-ad-exit', {
     expect(sendBeacon).to.have.been.calledWith(trackingMatcher, '');
   });
 
-  it('should replace custom URL variables', () => {
+  it('should replace custom URL variables with vars', () => {
     const open = sandbox.stub(win, 'open', () => {
       return {name: 'fakeWin'};
     });
@@ -386,8 +408,7 @@ describes.realWin('amp-ad-exit', {
     if (!win.navigator) {
       win.navigator = {sendBeacon: () => false};
     }
-    const sendBeacon =
-        sandbox.stub(win.navigator, 'sendBeacon', () => true);
+    const sendBeacon = sandbox.stub(win.navigator, 'sendBeacon', () => true);
 
     element.implementation_.executeAction({
       method: 'exit',
@@ -521,6 +542,50 @@ describes.realWin('amp-ad-exit', {
     expect(open).to.have.been.calledTwice;
     expect(open).to.have.been.calledWith(
         EXIT_CONFIG.targets.borderProtection.finalUrl, '_blank');
+  });
+
+  it('should replace custom URL variables with 3P Analytics defaults', () => {
+    const open = sandbox.stub(win, 'open').returns({name: 'fakeWin'});
+
+    element.implementation_.executeAction({
+      method: 'exit',
+      args: {target: 'variableFrom3pAnalytics'},
+      event: makeClickEvent(1004),
+      satisfiesTrust: () => true,
+    });
+
+    expect(open).to.have.been.calledWith(
+        'http://localhost:8000/vars?foo=foo-default', '_blank');
+  });
+
+  it('should replace custom URL variables with 3P Analytics signals', () => {
+    const open = sandbox.stub(win, 'open', () => {
+      return {name: 'fakeWin'};
+    });
+
+    element.implementation_.vendorResponses_[TEST_3P_VENDOR] = {
+      'unused': 'unused',
+      'collected-data': 'abc123',
+    };
+
+    element.implementation_.executeAction({
+      method: 'exit',
+      args: {target: 'variableFrom3pAnalytics'},
+      event: makeClickEvent(1005),
+      satisfiesTrust: () => true,
+    });
+
+    expect(open).to.have.been.calledWith(
+        'http://localhost:8000/vars?foo=abc123', '_blank');
+  });
+
+  it('should reject unrecognized 3P Analytics vendors', () => {
+    const unkVendor = JSON.parse(JSON.stringify(EXIT_CONFIG));
+    unkVendor.targets.variableFrom3pAnalytics.vars._foo.vendorAnalyticsSource =
+        'nonexistent_vendor';
+
+    expect(makeElementWithConfig(unkVendor))
+        .to.eventually.be.rejectedWith(/Unknown vendor/);
   });
 });
 

--- a/extensions/amp-ad-exit/amp-ad-exit.md
+++ b/extensions/amp-ad-exit/amp-ad-exit.md
@@ -212,19 +212,27 @@ applies to navigation URLs and click tracking URLs.
 
 ### Custom variables
 Custom variables must begin with an underscore. Define variables in the
-config alongside the navigation target. The default value can be overridden
-in the `exit` action invocation:
+config alongside the navigation target. Variables should have a `"defaultValue"`
+property. The default value can be overridden in the `exit` action invocation:
 
+Variable values can also come from 3P analytics.
+
+Example:
 ```html
 <amp-ad-exit id="exit-api"><script type="application/json">
 {
   "targets": {
     "product": {
-      "finalUrl": "http://example.com/?page=_productCategory",
+      "finalUrl": "http://example.com/?page=_productCategory&verification=_3pAnalytics",
       "vars": {
         "_productCategory": {
           "defaultValue": "none"
-        }
+        },
+        "_3pAnalytics": {
+          "defaultValue": "no_response",
+          "vendorAnalyticsSource": "VendorXYZ",
+          "vendorAnalyticsResponseKey": "findings"
+         }
       }
     }
   }


### PR DESCRIPTION
Previous work implemented ability for amp-analytics to create a 3p vendor iframe.
PR #11306 enables the iframe to send a response to the pub page
PR #11461 enables amp-ad-exit to receive those responses.
This PR enables amp-ad-exit to substitute them into target URLs.