### PR TITLE
Set !important to media-query display

### DIFF
--- a/css/amp.css
+++ b/css/amp.css
@@ -334,7 +334,7 @@ i-amphtml-sizer {
 }
 
 .i-amphtml-hidden-by-media-query {
-  display: none;
+  display: none !important;
 }
 
 .i-amphtml-element-error {


### PR DESCRIPTION
fix #8961

media-query-display applies before `buildCallback`. `#toggle()` element in `#buildCallback` will override the value. 

Not sure if this is the correct approach though. PTAL : )
