### PR TITLE
Fixes issue in handling SafeFrame message formats.

### DIFF
--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -66,7 +66,7 @@ const METADATA_STRINGS = [
 // acceptable solution to the 'Safari on iOS doesn't fetch iframe src from
 // cache' issue.  See https://github.com/ampproject/amphtml/issues/5614
 /** @type {string} */
-export const DEFAULT_SAFEFRAME_VERSION = '1-0-12';
+export const DEFAULT_SAFEFRAME_VERSION = '1-0-10';
 
 /** @const {string} */
 export const CREATIVE_SIZE_HEADER = 'X-CreativeSize';

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -66,7 +66,7 @@ const METADATA_STRINGS = [
 // acceptable solution to the 'Safari on iOS doesn't fetch iframe src from
 // cache' issue.  See https://github.com/ampproject/amphtml/issues/5614
 /** @type {string} */
-export const DEFAULT_SAFEFRAME_VERSION = '1-0-10';
+export const DEFAULT_SAFEFRAME_VERSION = '1-0-12';
 
 /** @const {string} */
 export const CREATIVE_SIZE_HEADER = 'X-CreativeSize';

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-fluid.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-fluid.js
@@ -167,14 +167,12 @@ describes.realWin('DoubleClick Fast Fetch Fluid', realWinConfig, env => {
         <script>
         parent./*OK*/postMessage(
             JSON.stringify(/** @type {!JsonObject} */ ({
-              s: 'init_done',
-              sentinel: 'sentinel',
+              e: 'sentinel',
             })), '*');
         parent./*OK*/postMessage(
             JSON.stringify(/** @type {!JsonObject} */ ({
               s: 'creative_geometry_update',
-              sentinel: 'sentinel',
-              p: '{"width":"1px","height":"1px"}',
+              p: '{"width":"1px","height":"1px","sentinel":"sentinel"}',
             })), '*');
         </script>`;
     const connectFluidMessagingChannelSpy =


### PR DESCRIPTION
SafeFrame's initial connect message is formatted slightly different than its subsequent messages (e.g., creative geometry update messages). In the initial message there is no payload object, so sentinel is present as a top level field in the message. Subsequent messages contain a stringified payload (containing the sentinel value) that needs to be parsed.