### PR TITLE
Initialize AmpDocService in Xhr service in tests

### DIFF
--- a/src/service/xhr-impl.js
+++ b/src/service/xhr-impl.js
@@ -91,14 +91,10 @@ export class Xhr {
     /** @const {!Window} */
     this.win = win;
 
+    const ampdocService = Services.ampdocServiceFor(win);
     /** @private {?./ampdoc-impl.AmpDoc} */
-    this.ampdocSingle_ = null;
-    if (!getMode().test) {
-      const ampdocService = Services.ampdocServiceFor(win);
-      this.ampdocSingle_ = ampdocService.isSingleDoc() ?
-          ampdocService.getAmpDoc() :
-          null;
-    }
+    this.ampdocSingle_ =
+        ampdocService.isSingleDoc() ? ampdocService.getAmpDoc() : null;
   }
 
   /**
@@ -111,7 +107,8 @@ export class Xhr {
    * @private
    */
   fetch_(input, init) {
-    if (this.ampdocSingle_ &&
+    if (!getMode().test &&
+        this.ampdocSingle_ &&
         Math.random() < 0.01 &&
         parseUrl(input).origin != this.win.location.origin &&
         !Services.viewerForDoc(this.ampdocSingle_).hasBeenVisible()) {

--- a/test/functional/test-batched-xhr.js
+++ b/test/functional/test-batched-xhr.js
@@ -14,21 +14,18 @@
  * limitations under the License.
  */
 
-import {FetchResponse, fetchPolyfill} from '../../src/service/xhr-impl';
+import {FetchResponse} from '../../src/service/xhr-impl';
+import {Services} from '../../src/services';
 import {batchedXhrServiceForTesting} from '../../src/service/batched-xhr-impl';
 
+describes.sandboxed('BatchedXhr', {}, env => {
+  beforeEach(() => {
+    env.sandbox.stub(Services, 'ampdocServiceFor').returns({
+      isSingleDoc: () => false,
+    });
+  });
 
-describes.sandboxed('BatchedXhr', {}, () => {
-  // Since if it's the Native fetch, it won't use the XHR object so
-  // mocking and testing the request becomes not doable.
-  function getPolyfillWin() {
-    return {
-      location: {href: 'https://acme.com/path'},
-      fetch: fetchPolyfill,
-    };
-  }
-
-  describes.fakeWin('#fetch', getPolyfillWin(), env => {
+  describes.fakeWin('#fetch', {}, env => {
     const TEST_OBJECT = {a: {b: [{c: 2}, {d: 4}]}};
     const TEST_RESPONSE = JSON.stringify(TEST_OBJECT);
     const mockXhr = {
@@ -87,7 +84,7 @@ describes.sandboxed('BatchedXhr', {}, () => {
     });
   });
 
-  describes.fakeWin('#fetchJson', getPolyfillWin(), env => {
+  describes.fakeWin('#fetchJson', {}, env => {
     const TEST_OBJECT = {a: {b: [{c: 2}, {d: 4}]}};
     const TEST_RESPONSE = JSON.stringify(TEST_OBJECT);
     const mockXhr = {
@@ -136,7 +133,7 @@ describes.sandboxed('BatchedXhr', {}, () => {
     });
   });
 
-  describes.realWin('#fetchDocument', getPolyfillWin(), env => {
+  describes.realWin('#fetchDocument', {}, env => {
     const TEST_CONTENT = '<b>Hello, world';
     const TEST_RESPONSE_TEXT = '<!doctype html><html><body>' + TEST_CONTENT;
     let xhr;
@@ -181,7 +178,7 @@ describes.sandboxed('BatchedXhr', {}, () => {
     });
   });
 
-  describes.fakeWin('#fetchText', getPolyfillWin(), env => {
+  describes.fakeWin('#fetchText', {}, env => {
     const TEST_RESPONSE = 'Hello, world!';
     const mockXhr = {
       status: 200,

--- a/test/functional/web-worker/test-amp-worker.js
+++ b/test/functional/web-worker/test-amp-worker.js
@@ -34,6 +34,9 @@ describe('invokeWebWorker', () => {
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
+    sandbox.stub(Services, 'ampdocServiceFor').returns({
+      isSingleDoc: () => false,
+    });
 
     postMessageStub = sandbox.stub();
 


### PR DESCRIPTION
This is a pre-requitesite for #11294.

Currently, AmpDocService is only initialized if not in test mode.
However, the about-to-be-added XHR interceptor feature also needs to
access AmpDocSerivce, and that feature requires extensive functional
testing. If AmpDocService is only initialized outside of test mode, the
XHR interceptor logic becomes untestable.

To prepare for testing XHR interceptor, AmpDocService needs to be always
initialized regardless of the mode (may initialize to null if doc is not
in single doc mode). Instead, the check for test mode is moved to the
call site.

@choumx I split this from #11314 as it's (locally) getting too large.