### PR TITLE
Add built-in vendor configuration for ShinyStat analytics

### DIFF
--- a/examples/analytics-vendors.amp.html
+++ b/examples/analytics-vendors.amp.html
@@ -76,6 +76,7 @@
       <option>quantcast</option>
       <option>rakam</option>
       <option>segment</option>
+      <option>shinystat</option>
       <option>simplereach</option>
       <option>snowplow</option>
       <option>top100</option>
@@ -722,6 +723,19 @@ For complete documentation and additional examples please see: https://marketing
 }
 </script>
 </amp-analytics>
+
+<!-- Shinystat example -->
+<amp-analytics type="shinystat" id="shinystat">
+<script type="application/json">
+  {
+    "vars": {
+      "account": "ampshinystat",
+      "page": "Home page"
+    }
+  }
+</script>
+</amp-analytics>
+<!-- End Shinystat Example -->
 
 <!-- SimpleReach Tracking -->
 <amp-analytics type="simplereach" id="simplereach">

--- a/extensions/amp-analytics/0.1/test/vendor-requests.json
+++ b/extensions/amp-analytics/0.1/test/vendor-requests.json
@@ -204,6 +204,16 @@
     "page": "https://api.segment.io/v1/pixel/page?writeKey=$writeKey&context.library.name=amp&anonymousId=_client_id_&context.locale=_browser_language_&context.page.path=_canonical_path_&context.page.url=_canonical_url_&context.page.referrer=_document_referrer_&context.page.title=_title_&context.screen.width=_screen_width_&context.screen.height=_screen_height_&name=$name",
     "track": "https://api.segment.io/v1/pixel/track?writeKey=$writeKey&context.library.name=amp&anonymousId=_client_id_&context.locale=_browser_language_&context.page.path=_canonical_path_&context.page.url=_canonical_url_&context.page.referrer=_document_referrer_&context.page.title=_title_&context.screen.width=_screen_width_&context.screen.height=_screen_height_&event=$event"
   },
+  "shinystat": {
+    "base": "https://amp.shinystat.com/cgi-bin/shinyamp.cgi",
+    "commpar": "AMP=1&RM=_random_&USER=$account&PAG=$page&HR=_canonical_url_&REFER=_document_referrer_&RES=_screen_width_X_screen_height_&COLOR=_screen_color_depth_&CID=_client_id_&PAGID=_page_view_id_&TITL=_title_&RQC=2",
+    "pagepar": "&VIE=_viewer_&PLT=_page_load_time_",
+    "eventpar": "&SSXL=1",
+    "linkpar": "&LINK=$outboundLink",
+    "pageview": "https://amp.shinystat.com/cgi-bin/shinyamp.cgi?AMP=1&RM=_random_&USER=$account&PAG=$page&HR=_canonical_url_&REFER=_document_referrer_&RES=_screen_width_X_screen_height_&COLOR=_screen_color_depth_&CID=_client_id_&PAGID=_page_view_id_&TITL=_title_&RQC=2&VIE=_viewer_&PLT=_page_load_time_",
+    "event": "https://amp.shinystat.com/cgi-bin/shinyamp.cgi?AMP=1&RM=_random_&USER=$account&PAG=$page&HR=_canonical_url_&REFER=_document_referrer_&RES=_screen_width_X_screen_height_&COLOR=_screen_color_depth_&CID=_client_id_&PAGID=_page_view_id_&TITL=_title_&RQC=2&SSXL=1",
+    "link": "https://amp.shinystat.com/cgi-bin/shinyamp.cgi?AMP=1&RM=_random_&USER=$account&PAG=$page&HR=_canonical_url_&REFER=_document_referrer_&RES=_screen_width_X_screen_height_&COLOR=_screen_color_depth_&CID=_client_id_&PAGID=_page_view_id_&TITL=_title_&RQC=2&LINK=$outboundLink"
+  },
   "snowplow": {
     "aaVersion": "amp-0.2",
     "basePrefix": "https://$collectorHost/i?url=_canonical_url_&page=_title_&res=_screen_width_x_screen_height_&stm=_timestamp_&tz=_timezone_&aid=$appId&p=web&tv=amp-0.2&cd=_screen_color_depth_&cs=_document_charset_&duid=_client_id_&lang=_browser_language_&refr=_document_referrer_&stm=_timezone_&vp=_viewport_width_x_viewport_height_",

--- a/extensions/amp-analytics/0.1/vendors.js
+++ b/extensions/amp-analytics/0.1/vendors.js
@@ -1274,6 +1274,41 @@ export const ANALYTICS_CONFIG = /** @type {!JsonObject} */ ({
     },
   },
 
+  'shinystat': {
+    'transport': {
+      'beacon': false,
+      'xhrpost': false,
+      'image': true,
+    },
+    'requests': {
+      'base': 'https://amp.shinystat.com/cgi-bin/shinyamp.cgi',
+      'commpar': 'AMP=1&RM=${random}' +
+                 '&USER=${account}' +
+                 '&PAG=${page}' +
+                 '&HR=${canonicalUrl}' +
+                 '&REFER=${documentReferrer}' +
+                 '&RES=${screenWidth}X${screenHeight}' +
+                 '&COLOR=${screenColorDepth}' +
+                 '&CID=${clientId(AMP_CID)}' +
+                 '&PAGID=${pageViewId}' +
+                 '&TITL=${title}' +
+                 '&RQC=${requestCount}',
+      'pagepar': '&VIE=${viewer}' +
+                 '&PLT=${pageLoadTime}',
+      'eventpar': '&SSXL=1',
+      'linkpar': '&LINK=${outboundLink}',
+      'pageview': '${base}?${commpar}${pagepar}',
+      'event': '${base}?${commpar}${eventpar}',
+      'link': '${base}?${commpar}${linkpar}',
+    },
+    'triggers': {
+      'pageview': {
+        'on': 'visible',
+        'request': 'pageview',
+      },
+    },
+  },
+
   'snowplow': {
     'vars': {
       'duid': 'CLIENT_ID(_sp_id)',


### PR DESCRIPTION
This is our second attempt to add vendor configuration for ShinyStat analytics. The first one stalled due to the use of the temporary "iframePing" flag which is not required anymore.
This new pull request is a single patch. At the time of writing it applies cleanly to the upstream repository.

For reference, previous discussions are #2556 and #2557.
