### PR TITLE
Add bookend section of amp-story component

### DIFF
--- a/extensions/amp-story/0.1/bookend-share.js
+++ b/extensions/amp-story/0.1/bookend-share.js
@@ -134,7 +134,7 @@ export class BookendShareWidget {
         return;
       }
 
-      user().warn(
+      user().warn('AMP-STORY',
           'Invalid amp-story bookend share configuration for %s. ' +
           'Value must be `true` or a params object.',
           type);

--- a/extensions/amp-story/0.1/bookend-share.js
+++ b/extensions/amp-story/0.1/bookend-share.js
@@ -1,0 +1,179 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {ICONS} from './icons';
+import {Services} from '../../../src/services';
+import {isObject} from '../../../src/types';
+import {createElementWithAttributes, escapeHtml} from '../../../src/dom';
+import {dev, user} from '../../../src/log';
+import {dict} from './../../../src/utils/object';
+
+
+const LINK_SHARE_TEMPLATE =
+    `<div class="i-amp-story-share-icon">
+      ${ICONS.link}
+    </div>
+    <span class="i-amp-story-share-name">Get link</span>`;
+
+
+/**
+ * Maps share provider type to visible name.
+ * If the name only needs to be capitalized (e.g. `facebook` to `Facebook`) it
+ * does not need to be included here.
+ * @const {!JsonObject}
+ */
+const SHARE_PROVIDER_NAME = dict({
+  'gplus': 'Google+',
+  'linkedin': 'LinkedIn',
+  'whatsapp': 'WhatsApp',
+});
+
+
+/**
+ * @param {string} type
+ * @param {!JsonObject=} opt_params
+ * @return {string}
+ */
+// TODO(alanorozco): article metadata
+function shareProviderHtml(type, opt_params) {
+  const params = !opt_params ? '' :
+      Object.keys(opt_params)
+          .map(field =>
+              `data-param-${escapeHtml(field)}=` +
+              `"${escapeHtml(opt_params[field])}"`)
+          .join(' ');
+
+  const name = SHARE_PROVIDER_NAME[type] || type;
+
+  // `email` should have an icon different than the default in amp-social-share,
+  // so it is special-cased
+  const icon = type == 'email' ? ICONS.mail : '';
+
+  return (
+      `<amp-social-share
+          type="${type}"
+          width="48"
+          height="48"
+          class="i-amp-story-share-icon"
+          ${params}>
+          ${icon}
+      </amp-social-share>
+      <span class="i-amp-story-share-name">${name}</span>`
+  );
+}
+
+
+export class BookendShareWidget {
+  /** @param {!Window} win */
+  constructor(win) {
+    /** @private {!Window} */
+    this.win_ = win;
+
+    /** @private {?Element} */
+    this.root_ = null;
+  }
+
+  /** @param {!Window} win */
+  static create(win) {
+    return new BookendShareWidget(win);
+  }
+
+  /** @return {!Element} */
+  build() {
+    dev().assert(!this.root_, 'Already built.');
+
+    this.root_ = createElementWithAttributes(this.win_.document, 'ul', {
+      'class': 'i-amp-story-share-list',
+    });
+
+    this.add_(this.buildItem_(LINK_SHARE_TEMPLATE));
+
+    this.maybeAddNativeShare_();
+
+    return this.root_;
+  }
+
+  /** @private */
+  maybeAddNativeShare_() {
+    // TODO(alanorozco): Implement
+  }
+
+  /**
+   * @param {!Array<!JsonObject>} providers
+   * @public
+   */
+  // TODO(alanorozco): Set story metadata in share config
+  setProviders(providers) {
+    const fragment = this.win_.document.createDocumentFragment();
+
+    this.loadRequiredExtensions_();
+
+    Object.keys(providers).forEach(type => {
+      if (isObject(providers[type])) {
+        fragment.appendChild(
+            this.buildProvider_(type,
+                /** @type {!JsonObject} */ (providers[type])));
+        return;
+      }
+
+      // Bookend config API requires real boolean, not just truthy
+      if (providers[type] === true) {
+        fragment.appendChild(this.buildProvider_(type));
+        return;
+      }
+
+      user().warn(
+          'Invalid amp-story bookend share configuration for %s. ' +
+          'Value must be `true` or a params object.',
+          type);
+    });
+
+    this.add_(fragment);
+  }
+
+  /** @private */
+  loadRequiredExtensions_() {
+    Services.extensionsFor(this.win_).loadExtension('amp-social-share');
+  }
+
+  /**
+   * @param {string} type
+   * @param {!JsonObject=} opt_params
+   * @return {!Element}
+   * @private
+   */
+  buildProvider_(type, opt_params) {
+    return this.buildItem_(shareProviderHtml(type, opt_params));
+  }
+
+  /**
+   * @param {string} html
+   * @return {!Element}
+   * @private
+   */
+  buildItem_(html) {
+    const el = this.win_.document.createElement('li');
+    el./*OK*/innerHTML = html;
+    return el;
+  }
+
+  /**
+   * @param {!Node} node
+   * @private
+   */
+  add_(node) {
+    dev().assert(this.root_).appendChild(node);
+  }
+}

--- a/extensions/amp-story/0.1/bookend-share.js
+++ b/extensions/amp-story/0.1/bookend-share.js
@@ -22,10 +22,10 @@ import {dict} from './../../../src/utils/object';
 
 
 const LINK_SHARE_TEMPLATE =
-    `<div class="i-amp-story-share-icon">
+    `<div class="i-amphtml-story-share-icon">
       ${ICONS.link}
     </div>
-    <span class="i-amp-story-share-name">Get link</span>`;
+    <span class="i-amphtml-story-share-name">Get link</span>`;
 
 
 /**
@@ -66,11 +66,11 @@ function shareProviderHtml(type, opt_params) {
           type="${type}"
           width="48"
           height="48"
-          class="i-amp-story-share-icon"
+          class="i-amphtml-story-share-icon"
           ${params}>
           ${icon}
       </amp-social-share>
-      <span class="i-amp-story-share-name">${name}</span>`
+      <span class="i-amphtml-story-share-name">${name}</span>`
   );
 }
 
@@ -95,7 +95,7 @@ export class BookendShareWidget {
     dev().assert(!this.root_, 'Already built.');
 
     this.root_ = createElementWithAttributes(this.win_.document, 'ul', {
-      'class': 'i-amp-story-share-list',
+      'class': 'i-amphtml-story-share-list',
     });
 
     this.add_(this.buildItem_(LINK_SHARE_TEMPLATE));

--- a/extensions/amp-story/0.1/bookend.js
+++ b/extensions/amp-story/0.1/bookend.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import {BookendShareWidget} from './bookend-share';
-import {EventType, dispatch} from './events';
 import {createElementWithAttributes, escapeHtml} from '../../../src/dom';
 import {dev} from '../../../src/log';
 

--- a/extensions/amp-story/0.1/bookend.js
+++ b/extensions/amp-story/0.1/bookend.js
@@ -20,7 +20,7 @@ import {dev} from '../../../src/log';
 
 /**
  * @typedef {{
- *   shareProviders: !JsonObject|undefined,
+ *   shareProviders: (!JsonObject|undefined),
  *   relatedArticles: !Array<!./related-articles.RelatedArticleSet>
  * }}
  */

--- a/extensions/amp-story/0.1/bookend.js
+++ b/extensions/amp-story/0.1/bookend.js
@@ -1,0 +1,202 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {BookendShareWidget} from './bookend-share';
+import {EventType, dispatch} from './events';
+import {createElementWithAttributes, escapeHtml} from '../../../src/dom';
+import {dev} from '../../../src/log';
+
+
+/**
+ * @typedef {{
+ *   shareProviders: !JsonObject|undefined,
+ *   relatedArticles: !Array<!./related-articles.RelatedArticleSet>
+ * }}
+ */
+export let BookendConfig;
+
+
+/**
+ * @param {!./related-articles.RelatedArticle} articleData
+ * @return {!string}
+ */
+// TODO(alanorozco): link
+// TODO(alanorozco): reading time
+// TODO(alanorozco): domain name
+function articleHtml(articleData) {
+  // TODO(alanorozco): Consider using amp-img and what we need to get it working
+  const imgHtml = articleData.image ? (
+      `<div class="i-amp-story-bookend-article-image">
+        <img src="${articleData.image}"
+            width="116"
+            height="116">
+        </img>
+      </div>`
+  ) : '';
+
+  return (
+      `${imgHtml}
+      <h2 class="i-amp-story-bookend-article-heading">
+        ${articleData.title}
+      </h2>
+      <div class="i-amp-story-bookend-article-meta">
+        example.com - 10 mins
+      </div>`
+  );
+}
+
+
+/**
+ * Bookend component for <amp-story>.
+ */
+export class Bookend {
+  /**
+   * @param {!Window} win
+   */
+  constructor(win) {
+    /** @private {!Window} */
+    this.win_ = win;
+
+    /** @private {boolean} */
+    this.isBuilt_ = false;
+
+    /** @private {?Element} */
+    this.root_ = null;
+
+    /** @private {!BookendShareWidget} */
+    this.shareWidget_ = BookendShareWidget.create(win);
+  }
+
+  /**
+   * @return {!Element}
+   */
+  build() {
+    if (this.isBuilt_) {
+      return this.getRoot();
+    }
+
+    this.isBuilt_ = true;
+
+    this.root_ = this.win_.document.createElement('section');
+    this.root_.classList.add('i-amp-story-bookend');
+
+    this.root_.appendChild(this.shareWidget_.build());
+
+    return this.getRoot();
+  }
+
+  /**
+   * @retun {boolean}
+   */
+  isBuilt() {
+    return this.isBuilt_;
+  }
+
+  /** @private */
+  assertBuilt_() {
+    dev().assert(this.isBuilt(), 'Bookend component needs to be built.');
+  }
+
+  /**
+   * @param {!BookendConfig} bookendConfig
+   */
+  setConfig(bookendConfig) {
+    this.assertBuilt_();
+
+    if (bookendConfig.shareProviders) {
+      this.shareWidget_.setProviders(
+          dev().assert(bookendConfig.shareProviders));
+    }
+
+    this.setRelatedArticles_(bookendConfig.relatedArticles);
+  }
+
+  /**
+   * @param {!Array<!./related-articles.RelatedArticleSet>} articleSets
+   * @private
+   */
+  setRelatedArticles_(articleSets) {
+    const fragment = this.win_.document.createDocumentFragment();
+
+    articleSets.forEach(articleSet =>
+        fragment.appendChild(this.buildArticleSet_(articleSet)));
+
+    this.getRoot().appendChild(fragment);
+  }
+
+  /**
+   * @param {!./related-articles.RelatedArticleSet} articleSet
+   * @return {!DocumentFragment}
+   */
+  // TODO(alanorozco): typing and format
+  buildArticleSet_(articleSet) {
+    const fragment = this.win_.document.createDocumentFragment();
+
+    if (articleSet.heading) {
+      fragment.appendChild(
+          this.buildArticleSetHeading_(articleSet.heading));
+    }
+
+    fragment.appendChild(this.buildArticleList_(articleSet.articles));
+
+    return fragment;
+  }
+
+  /**
+   * @param {!Array<!./related-articles.RelatedArticle>} articleList
+   * @return {!Element}
+   * @private
+   */
+  buildArticleList_(articleList) {
+    const container = createElementWithAttributes(this.win_.document, 'div', {
+      'class': 'i-amp-story-bookend-article-set',
+    });
+    articleList.forEach(article =>
+        container.appendChild(this.buildArticle_(article)));
+    return container;
+  }
+
+  /**
+   * @param {!string} heading
+   * @return {!Element}
+   */
+  buildArticleSetHeading_(heading) {
+    const headingEl = createElementWithAttributes(this.win_.document, 'h3', {
+      'class': 'i-amp-story-bookend-heading',
+    });
+    headingEl.innerText = escapeHtml(heading);
+    return headingEl;
+  }
+
+  /**
+   * @param {!./related-articles.RelatedArticle} article
+   * @return {!Element}
+   */
+  // TODO(alanorozco): typing and format
+  buildArticle_(article) {
+    const el = this.win_.document.createElement('article');
+    el./*OK*/innerHTML = articleHtml(article);
+    return el;
+  }
+
+  /**
+   * @return {!Element}
+   */
+  getRoot() {
+    this.assertBuilt_();
+    return dev().assertElement(this.root_);
+  }
+}
+

--- a/extensions/amp-story/0.1/bookend.js
+++ b/extensions/amp-story/0.1/bookend.js
@@ -37,7 +37,7 @@ export let BookendConfig;
 function articleHtml(articleData) {
   // TODO(alanorozco): Consider using amp-img and what we need to get it working
   const imgHtml = articleData.image ? (
-      `<div class="i-amp-story-bookend-article-image">
+      `<div class="i-amphtml-story-bookend-article-image">
         <img src="${articleData.image}"
             width="116"
             height="116">
@@ -47,10 +47,10 @@ function articleHtml(articleData) {
 
   return (
       `${imgHtml}
-      <h2 class="i-amp-story-bookend-article-heading">
+      <h2 class="i-amphtml-story-bookend-article-heading">
         ${articleData.title}
       </h2>
-      <div class="i-amp-story-bookend-article-meta">
+      <div class="i-amphtml-story-bookend-article-meta">
         example.com - 10 mins
       </div>`
   );
@@ -89,7 +89,7 @@ export class Bookend {
     this.isBuilt_ = true;
 
     this.root_ = this.win_.document.createElement('section');
-    this.root_.classList.add('i-amp-story-bookend');
+    this.root_.classList.add('i-amphtml-story-bookend');
 
     this.root_.appendChild(this.shareWidget_.build());
 
@@ -160,7 +160,7 @@ export class Bookend {
    */
   buildArticleList_(articleList) {
     const container = createElementWithAttributes(this.win_.document, 'div', {
-      'class': 'i-amp-story-bookend-article-set',
+      'class': 'i-amphtml-story-bookend-article-set',
     });
     articleList.forEach(article =>
         container.appendChild(this.buildArticle_(article)));
@@ -173,9 +173,9 @@ export class Bookend {
    */
   buildArticleSetHeading_(heading) {
     const headingEl = createElementWithAttributes(this.win_.document, 'h3', {
-      'class': 'i-amp-story-bookend-heading',
+      'class': 'i-amphtml-story-bookend-heading',
     });
-    headingEl.innerText = escapeHtml(heading);
+    headingEl./*OK*/innerText = escapeHtml(heading);
     return headingEl;
   }
 

--- a/extensions/amp-story/0.1/related-articles.js
+++ b/extensions/amp-story/0.1/related-articles.js
@@ -17,19 +17,19 @@ import {user} from '../../../src/log';
 
 
 /**
- * @typedef {{title: string, url: string, image: string|undefined}}
+ * @typedef {{title: string, url: string, image: (string|undefined)}}
  */
 export let RelatedArticle;
 
 
 /**
- * @typedef {{heading: string|undefined, articles: !Array<!RelatedArticle>}}
+ * @typedef {{heading: (string|undefined), articles: !Array<!RelatedArticle>}}
  */
 export let RelatedArticleSet;
 
 
 /**
- * @param {!JsonObject}
+ * @param {!JsonObject} articleJson
  * @return {!RelatedArticle}
  */
 function buildArticleFromJson_(articleJson) {

--- a/extensions/amp-story/0.1/related-articles.js
+++ b/extensions/amp-story/0.1/related-articles.js
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {user} from '../../../src/log';
+
+
+/**
+ * @typedef {{title: string, url: string, image: string|undefined}}
+ */
+export let RelatedArticle;
+
+
+/**
+ * @typedef {{heading: string|undefined, articles: !Array<!RelatedArticle>}}
+ */
+export let RelatedArticleSet;
+
+
+/**
+ * @param {!JsonObject}
+ * @return {!RelatedArticle}
+ */
+function buildArticleFromJson_(articleJson) {
+  const article = {
+    title: user().assert(articleJson.title),
+    url: user().assert(articleJson.url),
+  };
+
+  if (articleJson.image) {
+    article.image = articleJson.image;
+  }
+
+  return /** @type {!RelatedArticle} */ (article);
+}
+
+
+/**
+ * @param {!JsonObject} articleSetsResponse
+ * @return {!Array<!RelatedArticleSet>}
+ */
+// TODO(alanorozco): tighten externs
+// TODO(alanorozco): domain name
+export function buildFromJson(articleSetsResponse) {
+  return /** @type {!Array<!RelatedArticleSet>} */ (
+      Object.keys(articleSetsResponse).map(headingKey => {
+        const articleSet = {
+          articles: articleSetsResponse[headingKey].map(buildArticleFromJson_),
+        };
+
+        if (!!headingKey.trim().length) {
+          articleSet.heading = headingKey;
+        }
+
+        return /** @type {!RelatedArticleSet} */ (articleSet);
+      }));
+}


### PR DESCRIPTION
This PR adds the bookend section of the `amp-story` component, that handles parsing the JSON spec for sharing and related links and rendering them in the UI template.

/cc @alanorozco 

Depends on #11485 