### PR TITLE
Add support for analytics in amp-story

### DIFF
--- a/extensions/amp-story/0.1/analytics.js
+++ b/extensions/amp-story/0.1/analytics.js
@@ -64,12 +64,12 @@ export class AnalyticsTrigger {
    * @param {!./navigation-state.StateChangeEvent} stateChangeEvent
    */
   onStateChange(stateChangeEvent) {
-    switch(stateChangeEvent.type) {
+    switch (stateChangeEvent.type) {
       case StateChangeType.ACTIVE_PAGE:
         this.onActivePageChange_(
             dev().assertNumber(stateChangeEvent.value.pageIndex),
             dev().assertString(stateChangeEvent.value.pageId));
-      break;
+        break;
     }
   }
 

--- a/extensions/amp-story/0.1/analytics.js
+++ b/extensions/amp-story/0.1/analytics.js
@@ -1,0 +1,107 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {StateChangeType} from './navigation-state';
+import {dev} from '../../../src/log';
+import {hasOwn, map} from '../../../src/utils/object';
+import {triggerAnalyticsEvent} from '../../../src/analytics';
+
+
+const Events = {
+  PAGE_VISIBLE: 'story-page-visible',
+};
+
+
+let triggerAnalyticsEventImpl = triggerAnalyticsEvent;
+
+
+/**
+ * @param {!Function} fn
+ * @visibleForTesting
+ */
+export function setTriggerAnalyticsEventImplForTesting(fn) {
+  triggerAnalyticsEventImpl = fn;
+  return fn;
+}
+
+
+/**
+ * @visibleForTesting
+ */
+export function resetTriggerAnalyticsEventImplForTesting() {
+  triggerAnalyticsEventImpl = triggerAnalyticsEvent;
+}
+
+
+/**
+ * Intermediate handler for amp-story specific analytics.
+ * @implements {./navigation-state.ConsumerDef}
+ */
+export class AnalyticsTrigger {
+  /**
+   * @param {!Element} element
+   */
+  constructor(element) {
+    this.element_ = element;
+
+    /** @private @const {!Object<string, boolean>} */
+    this.pagesSeen_ = map();
+  }
+
+  /**
+   * @param {!./navigation-state.StateChangeEvent} stateChangeEvent
+   */
+  onStateChange(stateChangeEvent) {
+    switch(stateChangeEvent.type) {
+      case StateChangeType.ACTIVE_PAGE:
+        this.onActivePageChange_(
+            dev().assertNumber(stateChangeEvent.value.pageIndex),
+            dev().assertString(stateChangeEvent.value.pageId));
+      break;
+    }
+  }
+
+  /**
+   * @param {number} pageIndex
+   * @param {string} pageId
+   */
+  onActivePageChange_(pageIndex, pageId) {
+    if (this.shouldTriggerPageVisible_(pageIndex)) {
+      this.triggerEvent_(Events.PAGE_VISIBLE, {
+        'pageIndex': pageIndex.toString(),
+        'pageId': pageId,
+      });
+
+      this.pagesSeen_[pageIndex] = true;
+    }
+  }
+
+  /**
+   * @param {number} pageIndex
+   * @return {boolean}
+   */
+  shouldTriggerPageVisible_(pageIndex) {
+    return !hasOwn(this.pagesSeen_, pageIndex);
+  }
+
+  /**
+   * @param {string} eventType
+   * @param {!Object<string, string>=} opt_vars A map of vars and their values.
+   * @private
+   */
+  triggerEvent_(eventType, opt_vars) {
+    triggerAnalyticsEventImpl(this.element_, eventType, opt_vars);
+  }
+}

--- a/extensions/amp-story/0.1/navigation-state.js
+++ b/extensions/amp-story/0.1/navigation-state.js
@@ -26,7 +26,7 @@ export const StateChangeType = {
 };
 
 
-/** typedef {{type: !StateChangeType, value: *}} */
+/** @typedef {{type: !StateChangeType, value: *}} */
 export let StateChangeEventDef;
 
 

--- a/extensions/amp-story/0.1/navigation-state.js
+++ b/extensions/amp-story/0.1/navigation-state.js
@@ -1,0 +1,90 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {dev} from '../../../src/log';
+import {Observable} from '../../../src/observable';
+
+
+/**
+ * Types of state changes that can be consumed.
+ * @enum {number}
+ */
+export const StateChangeType = {
+  ACTIVE_PAGE: 0,
+};
+
+
+/** typedef {{type: !StateChangeType, value: *}} */
+export let StateChangeEventDef;
+
+
+/**
+ * Interface for navigation state consumers.
+ * @interface
+ */
+export class ConsumerDef {
+
+  /**
+   * @param {!StateChangeEventDef} unusedEvent
+   */
+  onStateChange(unusedEvent) {}
+}
+
+
+/**
+ * State store to decouple navigation changes from consumers.
+ */
+export class NavigationState {
+  constructor() {
+    /** @private {!Observable<StateChangeEventDef>} */
+    this.consumerObservable_ = new Observable();
+  }
+
+  /**
+   * @param {!ConsumerDef} consumer
+   */
+  installConsumer(consumer) {
+    this.consumerObservable_.add(changeEvent =>
+        consumer.onStateChange(changeEvent));
+  }
+
+  /**
+   * @param {number} index
+   * @param {string=} opt_pageId
+   */
+  // TODO(alanorozco): pass whether change was automatic or on user action
+  updateActivePage(index, opt_pageId) {
+    const changeValue = {
+      pageIndex: index,
+    };
+
+    if (opt_pageId) {
+      changeValue.pageId = dev().assertString(opt_pageId);
+    }
+
+    this.fire_(StateChangeType.ACTIVE_PAGE, changeValue);
+  }
+
+  /**
+   * @param {!StateChangeType}
+   * @param {*} changeValue
+   */
+  fire_(changeType, changeValue) {
+    this.consumerObservable_.fire({
+      type: changeType,
+      value: changeValue,
+    });
+  }
+}

--- a/extensions/amp-story/0.1/test/test-analytics.js
+++ b/extensions/amp-story/0.1/test/test-analytics.js
@@ -1,0 +1,89 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {StateChangeType} from '../navigation-state';
+import {
+  AnalyticsTrigger,
+  setTriggerAnalyticsEventImplForTesting,
+} from '../analytics';
+
+
+describes.fakeWin('amp-story analytics', {}, env => {
+  let win;
+  let analyticsTrigger;
+  let rootEl;
+
+  beforeEach(() => {
+    rootEl = env.win.document.createElement('div');
+    analyticsTrigger = new AnalyticsTrigger(rootEl);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('should trigger `story-page-visible` on change', () => {
+    const trigger = setTriggerAnalyticsEventImplForTesting(sandbox.spy());
+
+    analyticsTrigger.onStateChange({
+      type: StateChangeType.ACTIVE_PAGE,
+      value: {
+        pageIndex: 123,
+        pageId: 'my-page-id',
+      },
+    });
+
+    expect(trigger).to.have.been.calledWith(rootEl, 'story-page-visible',
+        sandbox.match(vars =>
+            vars.pageIndex === '123' &&
+            vars.pageId == 'my-page-id'));
+  });
+
+  it('should trigger `story-page-visible` only once per page', () => {
+    const trigger = setTriggerAnalyticsEventImplForTesting(sandbox.spy());
+
+    for (let i = 0; i < 10; i++) {
+      analyticsTrigger.onStateChange({
+        type: StateChangeType.ACTIVE_PAGE,
+        value: {
+          pageIndex: 123,
+          pageId: 'my-page-id',
+        },
+      });
+    }
+
+    expect(trigger).to.have.been.calledOnce;
+    expect(trigger).to.have.been.calledWith(rootEl, 'story-page-visible',
+        sandbox.match(vars =>
+            vars.pageIndex === '123' &&
+            vars.pageId == 'my-page-id'));
+
+    for (let i = 0; i < 10; i++) {
+      analyticsTrigger.onStateChange({
+        type: StateChangeType.ACTIVE_PAGE,
+        value: {
+          pageIndex: 6,
+          pageId: 'foo-page-id',
+        },
+      });
+    }
+
+    expect(trigger).to.have.been.calledTwice;
+    expect(trigger).to.have.been.calledWith(rootEl, 'story-page-visible',
+        sandbox.match(vars =>
+            vars.pageIndex === '6' &&
+            vars.pageId == 'foo-page-id'));
+  });
+});

--- a/extensions/amp-story/0.1/test/test-analytics.js
+++ b/extensions/amp-story/0.1/test/test-analytics.js
@@ -21,7 +21,6 @@ import {
 
 
 describes.fakeWin('amp-story analytics', {}, env => {
-  let win;
   let analyticsTrigger;
   let rootEl;
 

--- a/extensions/amp-story/0.1/test/test-navigation-state.js
+++ b/extensions/amp-story/0.1/test/test-navigation-state.js
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {NavigationState, StateChangeType} from '../navigation-state';
+
+
+describes.fakeWin('amp-story navigation state', {}, env => {
+  let win;
+  let navigationState;
+
+  function createConsumer() {
+    return {onStateChange: sandbox.spy()};
+  }
+
+  beforeEach(() => {
+    navigationState = new NavigationState();
+  });
+
+  it('should dispatch active page changes to all consumers', () => {
+    const consumers = Array(5).fill(undefined).map(createConsumer);
+
+    consumers.forEach(consumer => navigationState.installConsumer(consumer));
+
+    navigationState.updateActivePage(0, 'my-page-id-1');
+
+    consumers.forEach(consumer => {
+      expect(consumer.onStateChange).to.have.been.calledWith(sandbox.match(e =>
+          e.type == StateChangeType.ACTIVE_PAGE
+              && e.value.pageIndex === 0
+              && e.value.pageId == 'my-page-id-1'));
+    });
+
+    navigationState.updateActivePage(5);
+
+    consumers.forEach(consumer => {
+      expect(consumer.onStateChange).to.have.been.calledWith(sandbox.match(e =>
+          e.type == StateChangeType.ACTIVE_PAGE
+              && e.value.pageIndex === 5
+              && !('pageId' in e.value)));
+    });
+
+    navigationState.updateActivePage(2, 'one-two-three');
+
+    consumers.forEach(consumer => {
+      expect(consumer.onStateChange).to.have.been.calledWith(sandbox.match(e =>
+          e.type == StateChangeType.ACTIVE_PAGE
+              && e.value.pageIndex === 2
+              && e.value.pageId == 'one-two-three'));
+    });
+  });
+});

--- a/extensions/amp-story/0.1/test/test-navigation-state.js
+++ b/extensions/amp-story/0.1/test/test-navigation-state.js
@@ -16,8 +16,7 @@
 import {NavigationState, StateChangeType} from '../navigation-state';
 
 
-describes.fakeWin('amp-story navigation state', {}, env => {
-  let win;
+describes.fakeWin('amp-story navigation state', {}, () => {
   let navigationState;
 
   function createConsumer() {

--- a/extensions/amp-story/0.1/test/test-variable-service.js
+++ b/extensions/amp-story/0.1/test/test-variable-service.js
@@ -17,8 +17,7 @@ import {StateChangeType} from '../navigation-state';
 import {VariableService} from '../variable-service';
 
 
-describes.fakeWin('amp-story variable service', {}, env => {
-  let win;
+describes.fakeWin('amp-story variable service', {}, () => {
   let variableService;
 
   beforeEach(() => {

--- a/extensions/amp-story/0.1/test/test-variable-service.js
+++ b/extensions/amp-story/0.1/test/test-variable-service.js
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {StateChangeType} from '../navigation-state';
+import {VariableService} from '../variable-service';
+
+
+describes.fakeWin('amp-story variable service', {}, env => {
+  let win;
+  let variableService;
+
+  beforeEach(() => {
+    variableService = new VariableService();
+  });
+
+  it('should update pageIndex and pageId on change', () => {
+    variableService.onStateChange({
+      type: StateChangeType.ACTIVE_PAGE,
+      value: {
+        pageIndex: 123,
+        pageId: 'my-page-id',
+      },
+    });
+
+    expect(variableService.pageIndex).to.equal(123);
+    expect(variableService.pageId).to.equal('my-page-id');
+  });
+});

--- a/extensions/amp-story/0.1/variable-service.js
+++ b/extensions/amp-story/0.1/variable-service.js
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {StateChangeType} from './navigation-state';
+import {dev} from '../../../src/log';
+
+
+/**
+ * Variable service for amp-story.
+ * Used for URL replacement service. See usage in src/url-replacements-impl.
+ * @implements {./navigation-state.ConsumerDef}
+ */
+export class VariableService {
+  constructor() {
+    /** @private {?string} */
+    this.pageIndex_ = null;
+
+    /** @private {?number} */
+    this.pageId_ = null;
+  }
+
+  /**
+   * @param {!./navigation-state.StateChangeEvent} stateChangeEvent
+   */
+  onStateChange(stateChangeEvent) {
+    switch(stateChangeEvent.type) {
+      case StateChangeType.ACTIVE_PAGE:
+        this.pageIndex_ = stateChangeEvent.value.pageIndex;
+        this.pageId_ = stateChangeEvent.value.pageId;
+      break;
+    }
+  }
+
+  /**
+   * @return {number}
+   */
+  get pageIndex() {
+    return dev().assertNumber(this.pageIndex_);
+  }
+
+  /**
+   * @return {string}
+   */
+  get pageId() {
+    return dev().assertString(this.pageId_);
+  }
+}

--- a/extensions/amp-story/0.1/variable-service.js
+++ b/extensions/amp-story/0.1/variable-service.js
@@ -35,11 +35,11 @@ export class VariableService {
    * @param {!./navigation-state.StateChangeEvent} stateChangeEvent
    */
   onStateChange(stateChangeEvent) {
-    switch(stateChangeEvent.type) {
+    switch (stateChangeEvent.type) {
       case StateChangeType.ACTIVE_PAGE:
         this.pageIndex_ = stateChangeEvent.value.pageIndex;
         this.pageId_ = stateChangeEvent.value.pageId;
-      break;
+        break;
     }
   }
 

--- a/extensions/amp-story/0.1/variable-service.js
+++ b/extensions/amp-story/0.1/variable-service.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ export class VariableService {
   }
 
   /**
-   * @param {!./navigation-state.StateChangeEvent} stateChangeEvent
+   * @param {!./navigation-state.StateChangeEventDef} stateChangeEvent
    */
   onStateChange(stateChangeEvent) {
     switch (stateChangeEvent.type) {

--- a/src/analytics.js
+++ b/src/analytics.js
@@ -30,4 +30,4 @@ export function triggerAnalyticsEvent(target, eventType, opt_vars) {
     }
     analytics.triggerEventForTarget(target, eventType, opt_vars);
   });
-} 
+}

--- a/src/analytics.js
+++ b/src/analytics.js
@@ -30,4 +30,4 @@ export function triggerAnalyticsEvent(target, eventType, opt_vars) {
     }
     analytics.triggerEventForTarget(target, eventType, opt_vars);
   });
-}
+} 


### PR DESCRIPTION
This exposes hooks for triggering analytics pings on navigation in stories, with the ability to communicate two variables: the `id` and the index of the page to which the user has arrived.

/cc @alanorozco 
