### PR TITLE
Add amp-story URL replacement support

### DIFF
--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -503,6 +503,12 @@ export class GlobalVariableSource extends VariableSource {
           .getVideoAnalyticsDetails(video)
           .then(details => details ? details[property] : '');
     });
+
+    this.setAsync('STORY_PAGE_INDEX',
+        () => this.getStoryValue_(storyVariables => storyVariables.pageIndex));
+
+    this.setAsync('STORY_PAGE_ID',
+        () => this.getStoryValue_(storyVariables => storyVariables.pageId));
   }
 
   /**
@@ -592,6 +598,26 @@ export class GlobalVariableSource extends VariableSource {
           'amp-share-tracking should be configured',
           expr);
       return getter(/** @type {!ShareTrackingFragmentsDef} */ (fragments));
+    });
+  }
+
+  /**
+   * Resolves the value via amp-story's service.
+   * @param {function(!{pageIndex: number, pageId: string}):T} getter
+   * @param {string} expr
+   * @return {!Promise<T>}
+   * @template T
+   * @private
+   */
+  getStoryValue_(getter, expr) {
+    if (!this.storyVariables_) {
+      this.storyVariables_ = storyVariableServiceForOrNull(this.ampdoc.win);
+    }
+    return this.storyVariables_.then(storyVariables => {
+      user().assert(storyVariables,
+          'To use variable %s amp-story should be configured',
+          expr);
+      return getter(/** @type {{pageIndex: number}} */ (storyVariables));
     });
   }
 }

--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -504,11 +504,15 @@ export class GlobalVariableSource extends VariableSource {
           .then(details => details ? details[property] : '');
     });
 
-    this.setAsync('STORY_PAGE_INDEX',
-        () => this.getStoryValue_(storyVariables => storyVariables.pageIndex));
+    this.setAsync('STORY_PAGE_INDEX', () => {
+      return this.getStoryValue_(storyVariables => storyVariables.pageIndex,
+          'STORY_PAGE_INDEX');
+    });
 
-    this.setAsync('STORY_PAGE_ID',
-        () => this.getStoryValue_(storyVariables => storyVariables.pageId));
+    this.setAsync('STORY_PAGE_ID', () => {
+      return this.getStoryValue_(storyVariables => storyVariables.pageId,
+          'STORY_PAGE_ID');
+    });
   }
 
   /**

--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -82,6 +82,9 @@ export class GlobalVariableSource extends VariableSource {
 
     /** @private {?Promise<?ShareTrackingFragmentsDef>} */
     this.shareTrackingFragments_ = null;
+
+    /** @private {?Promise<?{pageIndex: number, pageId: string}>} */
+    this.storyVariables_ = null;
   }
 
   /**
@@ -622,7 +625,8 @@ export class GlobalVariableSource extends VariableSource {
       user().assert(storyVariables,
           'To use variable %s amp-story should be configured',
           expr);
-      return getter(/** @type {{pageIndex: number}} */ (storyVariables));
+      return getter(
+          /** @type {{pageIndex: number, pageId: string}} */ (storyVariables));
     });
   }
 }

--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -611,7 +611,8 @@ export class GlobalVariableSource extends VariableSource {
    */
   getStoryValue_(getter, expr) {
     if (!this.storyVariables_) {
-      this.storyVariables_ = storyVariableServiceForOrNull(this.ampdoc.win);
+      this.storyVariables_ =
+          Services.storyVariableServiceForOrNull(this.ampdoc.win);
     }
     return this.storyVariables_.then(storyVariables => {
       user().assert(storyVariables,

--- a/src/services.js
+++ b/src/services.js
@@ -260,6 +260,16 @@ export class Services {
   }
 
   /**
+   * @param {!Window} win
+   * @return {?Promise<?{pageIndex: number, pageId: string}>}
+   */
+  static storyVariableServiceForOrNull(win) {
+    return (/** @type {!Promise<?{pageIndex: number, pageId: string}>} */ (
+        getElementServiceIfAvailable(win, 'story-variable', 'amp-story',
+            true)));
+  }
+
+  /**
    * @param {!Node|!./service/ampdoc-impl.AmpDoc} nodeOrDoc
    * @return {!Promise<!./service/storage-impl.Storage>}
    */

--- a/test/functional/test-url-replacements.js
+++ b/test/functional/test-url-replacements.js
@@ -99,6 +99,15 @@ describes.sandboxed('UrlReplacements', {}, () => {
             });
           });
         }
+        if (opt_options.withStoryVariableService) {
+          markElementScheduledForTesting(iframe.win, 'amp-story');
+          registerServiceBuilder(iframe.win, 'story-variable', function() {
+            return Promise.resolve({
+              pageIndex: 546,
+              pageId: 'id-123',
+            });
+          });
+        }
       }
       viewerService = Services.viewerForDoc(iframe.ampdoc);
       replacements = Services.urlReplacementsForDoc(iframe.ampdoc);
@@ -419,6 +428,20 @@ describes.sandboxed('UrlReplacements', {}, () => {
     return expect(
         expandAsync('?in=SHARE_TRACKING_INCOMING&out=SHARE_TRACKING_OUTGOING'))
         .to.eventually.equal('?in=&out=');
+  });
+
+  it('should replace STORY_PAGE_INDEX and STORY_PAGE_ID', () => {
+    return expect(
+        expandAsync('?index=STORY_PAGE_INDEX&id=STORY_PAGE_ID',
+            /*opt_bindings*/ undefined, {withStoryVariableService: true}))
+        .to.eventually.equal('?index=546&id=id-123');
+  });
+
+  it('should replace STORY_PAGE_INDEX and STORY_PAGE_ID' +
+      ' with empty string if amp-story is not configured', () => {
+    return expect(
+        expandAsync('?index=STORY_PAGE_INDEX&id=STORY_PAGE_ID'))
+        .to.eventually.equal('?index=&id=');
   });
 
   it('should replace TIMESTAMP', () => {


### PR DESCRIPTION
This adds support for the rewriting the `STORY_PAGE_INDEX` and `STORY_PAGE_ID` variables for analytics.

/cc @alanorozco 

Depends on #11489