### PR TITLE
amp-img: Ignore existing srcset during src mutation

### DIFF
--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -17,7 +17,7 @@
 import {BaseElement} from '../src/base-element';
 import {isLayoutSizeDefined} from '../src/layout';
 import {registerElement} from '../src/service/custom-element-registry';
-import {srcsetFromElement} from '../src/srcset';
+import {srcsetFromElement, srcsetFromSrc} from '../src/srcset';
 
 /**
  * Attributes to propagate to internal image when changed externally.
@@ -47,12 +47,21 @@ export class AmpImg extends BaseElement {
 
   /** @override */
   mutatedAttributesCallback(mutations) {
-    if (mutations['src'] !== undefined || mutations['srcset'] !== undefined) {
+    let mutated = false;
+    if (mutations['srcset'] !== undefined) {
+      // `srcset` mutations take precedence over `src` mutations.
       this.srcset_ = srcsetFromElement(this.element);
-      // This element may not have been laid out yet.
-      if (this.img_) {
-        this.updateImageSrc_();
-      }
+      mutated = true;
+    } else if (mutations['src'] !== undefined) {
+      // If only `src` is mutated, then ignore the existing `srcset` attribute
+      // value (may be set automatically as cache optimization).
+      this.srcset_ = srcsetFromSrc(this.element.getAttribute('src'));
+      mutated = true;
+    }
+
+    // This element may not have been laid out yet.
+    if (mutated && this.img_) {
+      this.updateImageSrc_();
     }
 
     if (this.img_) {

--- a/src/srcset.js
+++ b/src/srcset.js
@@ -44,9 +44,17 @@ export function srcsetFromElement(element) {
   const srcAttr = user().assert(element.getAttribute('src'),
       'Either non-empty "srcset" or "src" attribute must be specified: %s',
       element);
-  return new Srcset([{url: srcAttr, width: undefined, dpr: 1}]);
+  return srcsetFromSrc(srcAttr);
 }
 
+/**
+ * Creates a Srcset from a `src` attribute value.
+ * @param {string} src
+ * @return {!Srcset}
+ */
+export function srcsetFromSrc(src) {
+  return new Srcset([{url: src, width: undefined, dpr: 1}]);
+}
 
 /**
  * Parses the text representation of srcset into Srcset object.

--- a/test/functional/test-amp-img.js
+++ b/test/functional/test-amp-img.js
@@ -175,6 +175,30 @@ describe('amp-img', () => {
     });
   });
 
+  it('should handle attribute mutations', () => {
+    return getImg({
+      src: 'test.jpg',
+      srcset: 'large.jpg 2000w, small.jpg 1000w',
+      width: 300,
+      height: 200,
+    }).then(ampImg => {
+      const impl = ampImg.implementation_;
+
+      ampImg.setAttribute('srcset', 'mutated-srcset.jpg 500w');
+      ampImg.setAttribute('src', 'mutated-src.jpg');
+
+      // `srcset` mutation should take precedence over `src` mutation.
+      impl.mutatedAttributesCallback({
+        srcset: 'mutated-srcset.jpg 1000w',
+        src: 'mutated-src.jpg',
+      });
+      expect(impl.img_.getAttribute('src')).to.equal('mutated-srcset.jpg');
+
+      // `src` mutation should override existing `srcset` attribute.
+      impl.mutatedAttributesCallback({src: 'mutated-src.jpg'});
+      expect(impl.img_.getAttribute('src')).to.equal('mutated-src.jpg');
+    });
+  });
 
   describe('#fallback on initial load', () => {
     let el;
@@ -354,7 +378,6 @@ describe('amp-img', () => {
         });
       });
     });
-
   });
 
   it('should respect noprerender attribute', () => {

--- a/test/functional/test-srcset.js
+++ b/test/functional/test-srcset.js
@@ -14,7 +14,12 @@
  * limitations under the License.
  */
 
-import {Srcset, parseSrcset, srcsetFromElement} from '../../src/srcset';
+import {
+  Srcset,
+  parseSrcset,
+  srcsetFromElement,
+  srcsetFromSrc,
+} from '../../src/srcset';
 
 
 describe('Srcset parseSrcset', () => {
@@ -257,6 +262,19 @@ describe('Srcset srcsetFromElement', () => {
       srcsetFromElement(document.createElement('div'));
     }).to.throw(
         /Either non-empty "srcset" or "src" attribute must be specified/);
+  });
+});
+
+
+describe('Srcset srcsetFromSrc', () => {
+  it('should construct with undefined with and 1 dpi', () => {
+    const srcset = srcsetFromSrc('image-0.png');
+    expect(srcset.sources.length).to.equal(1);
+
+    const source = srcset.sources[0];
+    expect(source.url).to.equal('image-0.png');
+    expect(source.width).to.not.be.defined;
+    expect(source.dpi).to.equal(1);
   });
 });
 

--- a/test/functional/test-srcset.js
+++ b/test/functional/test-srcset.js
@@ -267,14 +267,14 @@ describe('Srcset srcsetFromElement', () => {
 
 
 describe('Srcset srcsetFromSrc', () => {
-  it('should construct with undefined with and 1 dpi', () => {
+  it('should construct with undefined width and 1 dpr', () => {
     const srcset = srcsetFromSrc('image-0.png');
-    expect(srcset.sources.length).to.equal(1);
+    expect(srcset.getSources().length).to.equal(1);
 
-    const source = srcset.sources[0];
+    const source = srcset.getSources()[0];
     expect(source.url).to.equal('image-0.png');
-    expect(source.width).to.not.be.defined;
-    expect(source.dpi).to.equal(1);
+    expect(source.width).to.be.undefined;
+    expect(source.dpr).to.equal(1);
   });
 });
 


### PR DESCRIPTION
Fixes #11470.