### PR TITLE
Add web animation service to allow creating animation builders from other extensions

### DIFF
--- a/build-system/tasks/compile.js
+++ b/build-system/tasks/compile.js
@@ -145,6 +145,8 @@ function compile(entryModuleFilenames, outputDir,
       // Currently needed for crypto.js and visibility.js.
       // Should consider refactoring.
       'extensions/amp-analytics/**/*.js',
+      // Needed for WebAnimationService
+      'extensions/amp-animation/**/*.js',
       // For amp-bind in the web worker (ww.js).
       'extensions/amp-bind/**/*.js',
       // Needed to access form impl from other extensions

--- a/extensions/amp-animation/0.1/amp-animation.js
+++ b/extensions/amp-animation/0.1/amp-animation.js
@@ -31,6 +31,7 @@ import {user} from '../../../src/log';
 import {Services} from '../../../src/services';
 import {isFiniteNumber} from '../../../src/types';
 import {clamp} from '../../../src/utils/math';
+import {WebAnimationService} from './web-animation-service';
 
 const TAG = 'amp-animation';
 const POLYFILLED = '__AMP_WA';
@@ -510,4 +511,5 @@ function ensurePolyfillInstalled(win) {
 
 AMP.extension(TAG, '0.1', function(AMP) {
   AMP.registerElement(TAG, AmpAnimation);
+  AMP.registerServiceForDoc('web-animation', WebAnimationService);
 });

--- a/extensions/amp-animation/0.1/test/test-web-animations.js
+++ b/extensions/amp-animation/0.1/test/test-web-animations.js
@@ -1659,6 +1659,18 @@ describes.sandboxed('WebAnimationRunner', {}, () => {
     anim2Mock.expects('play').once();
     runner.resume();
     expect(runner.getPlayState()).to.equal(WebAnimationPlayState.RUNNING);
+
+    anim1.onfinish();
+    expect(runner.getPlayState()).to.equal(WebAnimationPlayState.RUNNING);
+
+    anim2.onfinish();
+    expect(runner.getPlayState()).to.equal(WebAnimationPlayState.FINISHED);
+
+    expect(playStateSpy.callCount).to.equal(4);
+    expect(playStateSpy.args[0][0]).to.equal(WebAnimationPlayState.RUNNING);
+    expect(playStateSpy.args[1][0]).to.equal(WebAnimationPlayState.PAUSED);
+    expect(playStateSpy.args[2][0]).to.equal(WebAnimationPlayState.RUNNING);
+    expect(playStateSpy.args[3][0]).to.equal(WebAnimationPlayState.FINISHED);
   });
 
   it('should only allow resume when started', () => {

--- a/extensions/amp-animation/0.1/web-animation-service.js
+++ b/extensions/amp-animation/0.1/web-animation-service.js
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {Builder} from './web-animations';
+import {Services} from '../../../src/services';
+
+
+export class WebAnimationService {
+  /**
+   * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
+   */
+  constructor(ampdoc) {
+    /** @private @const */
+    this.ampdoc_ = ampdoc;
+
+    /** @private @const */
+    this.vsync_ = Services.vsyncFor(ampdoc.win);
+
+    /** @private @const */
+    this.resources_ = Services.resourcesForDoc(ampdoc);
+  }
+
+
+  /**
+   * @return {!Builder}
+   */
+  createBuilder() {
+    return new Builder(
+        this.ampdoc_.win,
+        this.ampdoc_.getRootNode(),
+        this.ampdoc_.getUrl(),
+        this.vsync_,
+        this.resources_);
+  }
+}

--- a/extensions/amp-animation/0.1/web-animations.js
+++ b/extensions/amp-animation/0.1/web-animations.js
@@ -174,6 +174,7 @@ export class WebAnimationRunner {
       return;
     }
     this.setPlayState_(WebAnimationPlayState.RUNNING);
+    this.runningCount_ = this.players_.length;
     this.players_.forEach(player => {
       player.play();
     });

--- a/src/services.js
+++ b/src/services.js
@@ -261,6 +261,17 @@ export class Services {
 
   /**
    * @param {!Node|!./service/ampdoc-impl.AmpDoc} nodeOrDoc
+   * @return {!Promise<!../extensions/amp-animation/0.1/web-animation-service.WebAnimationService>}
+   */
+  static webAnimationServiceFor(nodeOrDoc) {
+    return (/** @type {
+        !Promise<!../extensions/amp-animation/0.1/web-animation-service.WebAnimationService>} */ (
+           getElementServiceForDoc(
+              nodeOrDoc, 'web-animation', 'amp-animation')));
+  }
+
+  /**
+   * @param {!Node|!./service/ampdoc-impl.AmpDoc} nodeOrDoc
    * @return {!Promise<!./service/storage-impl.Storage>}
    */
   static storageForDoc(nodeOrDoc) {

--- a/src/services.js
+++ b/src/services.js
@@ -265,9 +265,8 @@ export class Services {
    */
   static webAnimationServiceFor(nodeOrDoc) {
     return (/** @type {
-        !Promise<!../extensions/amp-animation/0.1/web-animation-service.WebAnimationService>} */ (
-           getElementServiceForDoc(
-              nodeOrDoc, 'web-animation', 'amp-animation')));
+        !Promise<!../extensions/amp-animation/0.1/web-animation-service.WebAnimationService>} */
+        (getElementServiceForDoc(nodeOrDoc, 'web-animation', 'amp-animation')));
   }
 
   /**


### PR DESCRIPTION
From newmuis/amphtml-story#114, newmuis/amphtml-story#151, and newmuis/amphtml-story#152

Follow-up of #11320 (already approved).

Additional changes:

- Added `extensions/amp-animation` to compile rules to pass type check.
- Fixed types for `src/services.webAnimationServiceFor`

/cc @dvoytenko @newmuis 