### PR TITLE
Add support for analytics in amp-story

### DIFF
--- a/extensions/amp-story/0.1/analytics.js
+++ b/extensions/amp-story/0.1/analytics.js
@@ -15,7 +15,7 @@
  */
 import {StateChangeType} from './navigation-state';
 import {dev} from '../../../src/log';
-import {hasOwn, map} from '../../../src/utils/object';
+import {map} from '../../../src/utils/object';
 import {triggerAnalyticsEvent} from '../../../src/analytics';
 
 

--- a/extensions/amp-story/0.1/analytics.js
+++ b/extensions/amp-story/0.1/analytics.js
@@ -27,7 +27,7 @@ const Events = {
 /**
  * Intermediate handler for amp-story specific analytics.
  */
-export class AnalyticsTrigger {
+export class AmpStoryAnalytics {
   /**
    * @param {!Element} element
    */
@@ -35,7 +35,7 @@ export class AnalyticsTrigger {
     this.element_ = element;
 
     /** @private @const {!Object<string, boolean>} */
-    this.pagesSeen_ = map();
+    this.seenPagesIndices_ = map();
   }
 
   /**
@@ -44,9 +44,10 @@ export class AnalyticsTrigger {
   onStateChange(stateChangeEvent) {
     switch (stateChangeEvent.type) {
       case StateChangeType.ACTIVE_PAGE:
+        const {pageIndex, pageId} = stateChangeEvent.value;
         this.onActivePageChange_(
-            dev().assertNumber(stateChangeEvent.value.pageIndex),
-            dev().assertString(stateChangeEvent.value.pageId));
+            dev().assertNumber(pageIndex),
+            dev().assertString(pageId));
         break;
     }
   }
@@ -56,22 +57,14 @@ export class AnalyticsTrigger {
    * @param {string} pageId
    */
   onActivePageChange_(pageIndex, pageId) {
-    if (this.shouldTriggerPageVisible_(pageIndex)) {
+    if (!this.seenPagesIndices_[pageIndex]) {
       this.triggerEvent_(Events.PAGE_VISIBLE, {
         'pageIndex': pageIndex.toString(),
         'pageId': pageId,
       });
 
-      this.pagesSeen_[pageIndex] = true;
+      this.seenPagesIndices_[pageIndex] = true;
     }
-  }
-
-  /**
-   * @param {number} pageIndex
-   * @return {boolean}
-   */
-  shouldTriggerPageVisible_(pageIndex) {
-    return !hasOwn(this.pagesSeen_, pageIndex);
   }
 
   /**

--- a/extensions/amp-story/0.1/analytics.js
+++ b/extensions/amp-story/0.1/analytics.js
@@ -24,27 +24,6 @@ const Events = {
 };
 
 
-let triggerAnalyticsEventImpl = triggerAnalyticsEvent;
-
-
-/**
- * @param {!Function} fn
- * @visibleForTesting
- */
-export function setTriggerAnalyticsEventImplForTesting(fn) {
-  triggerAnalyticsEventImpl = fn;
-  return fn;
-}
-
-
-/**
- * @visibleForTesting
- */
-export function resetTriggerAnalyticsEventImplForTesting() {
-  triggerAnalyticsEventImpl = triggerAnalyticsEvent;
-}
-
-
 /**
  * Intermediate handler for amp-story specific analytics.
  */
@@ -101,6 +80,6 @@ export class AnalyticsTrigger {
    * @private
    */
   triggerEvent_(eventType, opt_vars) {
-    triggerAnalyticsEventImpl(this.element_, eventType, opt_vars);
+    triggerAnalyticsEvent(this.element_, eventType, opt_vars);
   }
 }

--- a/extensions/amp-story/0.1/analytics.js
+++ b/extensions/amp-story/0.1/analytics.js
@@ -47,7 +47,6 @@ export function resetTriggerAnalyticsEventImplForTesting() {
 
 /**
  * Intermediate handler for amp-story specific analytics.
- * @implements {./navigation-state.ConsumerDef}
  */
 export class AnalyticsTrigger {
   /**
@@ -61,7 +60,7 @@ export class AnalyticsTrigger {
   }
 
   /**
-   * @param {!./navigation-state.StateChangeEvent} stateChangeEvent
+   * @param {!./navigation-state.StateChangeEventDef} stateChangeEvent
    */
   onStateChange(stateChangeEvent) {
     switch (stateChangeEvent.type) {

--- a/extensions/amp-story/0.1/analytics.js
+++ b/extensions/amp-story/0.1/analytics.js
@@ -1,0 +1,107 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {StateChangeType} from './navigation-state';
+import {dev} from '../../../src/log';
+import {hasOwn, map} from '../../../src/utils/object';
+import {triggerAnalyticsEvent} from '../../../src/analytics';
+
+
+const Events = {
+  PAGE_VISIBLE: 'story-page-visible',
+};
+
+
+let triggerAnalyticsEventImpl = triggerAnalyticsEvent;
+
+
+/**
+ * @param {!Function} fn
+ * @visibleForTesting
+ */
+export function setTriggerAnalyticsEventImplForTesting(fn) {
+  triggerAnalyticsEventImpl = fn;
+  return fn;
+}
+
+
+/**
+ * @visibleForTesting
+ */
+export function resetTriggerAnalyticsEventImplForTesting() {
+  triggerAnalyticsEventImpl = triggerAnalyticsEvent;
+}
+
+
+/**
+ * Intermediate handler for amp-story specific analytics.
+ * @implements {./navigation-state.ConsumerDef}
+ */
+export class AnalyticsTrigger {
+  /**
+   * @param {!Element} element
+   */
+  constructor(element) {
+    this.element_ = element;
+
+    /** @private @const {!Object<string, boolean>} */
+    this.pagesSeen_ = map();
+  }
+
+  /**
+   * @param {!./navigation-state.StateChangeEvent} stateChangeEvent
+   */
+  onStateChange(stateChangeEvent) {
+    switch (stateChangeEvent.type) {
+      case StateChangeType.ACTIVE_PAGE:
+        this.onActivePageChange_(
+            dev().assertNumber(stateChangeEvent.value.pageIndex),
+            dev().assertString(stateChangeEvent.value.pageId));
+        break;
+    }
+  }
+
+  /**
+   * @param {number} pageIndex
+   * @param {string} pageId
+   */
+  onActivePageChange_(pageIndex, pageId) {
+    if (this.shouldTriggerPageVisible_(pageIndex)) {
+      this.triggerEvent_(Events.PAGE_VISIBLE, {
+        'pageIndex': pageIndex.toString(),
+        'pageId': pageId,
+      });
+
+      this.pagesSeen_[pageIndex] = true;
+    }
+  }
+
+  /**
+   * @param {number} pageIndex
+   * @return {boolean}
+   */
+  shouldTriggerPageVisible_(pageIndex) {
+    return !hasOwn(this.pagesSeen_, pageIndex);
+  }
+
+  /**
+   * @param {string} eventType
+   * @param {!Object<string, string>=} opt_vars A map of vars and their values.
+   * @private
+   */
+  triggerEvent_(eventType, opt_vars) {
+    triggerAnalyticsEventImpl(this.element_, eventType, opt_vars);
+  }
+}

--- a/extensions/amp-story/0.1/navigation-state.js
+++ b/extensions/amp-story/0.1/navigation-state.js
@@ -55,7 +55,7 @@ export class NavigationState {
     };
 
     if (opt_pageId) {
-      changeValue.pageId = dev().assertString(opt_pageId);
+      changeValue.pageId = opt_pageId;
     }
 
     this.fire_(StateChangeType.ACTIVE_PAGE, changeValue);

--- a/extensions/amp-story/0.1/navigation-state.js
+++ b/extensions/amp-story/0.1/navigation-state.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {dev} from '../../../src/log';
 import {Observable} from '../../../src/observable';
 
 

--- a/extensions/amp-story/0.1/navigation-state.js
+++ b/extensions/amp-story/0.1/navigation-state.js
@@ -31,33 +31,17 @@ export let StateChangeEventDef;
 
 
 /**
- * Interface for navigation state consumers.
- * @interface
- */
-export class ConsumerDef {
-
-  /**
-   * @param {!StateChangeEventDef} unusedEvent
-   */
-  onStateChange(unusedEvent) {}
-}
-
-
-/**
  * State store to decouple navigation changes from consumers.
  */
 export class NavigationState {
   constructor() {
     /** @private {!Observable<StateChangeEventDef>} */
-    this.consumerObservable_ = new Observable();
+    this.observable_ = new Observable();
   }
 
-  /**
-   * @param {!ConsumerDef} consumer
-   */
-  installConsumer(consumer) {
-    this.consumerObservable_.add(changeEvent =>
-        consumer.onStateChange(changeEvent));
+  /** @param {!function(!StateChangeEventDef):void} stateChangeFn */
+  observe(stateChangeFn) {
+    this.observable_.add(stateChangeFn);
   }
 
   /**
@@ -78,11 +62,11 @@ export class NavigationState {
   }
 
   /**
-   * @param {!StateChangeType}
+   * @param {!StateChangeType} changeType
    * @param {*} changeValue
    */
   fire_(changeType, changeValue) {
-    this.consumerObservable_.fire({
+    this.observable_.fire({
       type: changeType,
       value: changeValue,
     });

--- a/extensions/amp-story/0.1/navigation-state.js
+++ b/extensions/amp-story/0.1/navigation-state.js
@@ -1,0 +1,90 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {dev} from '../../../src/log';
+import {Observable} from '../../../src/observable';
+
+
+/**
+ * Types of state changes that can be consumed.
+ * @enum {number}
+ */
+export const StateChangeType = {
+  ACTIVE_PAGE: 0,
+};
+
+
+/** @typedef {{type: !StateChangeType, value: *}} */
+export let StateChangeEventDef;
+
+
+/**
+ * Interface for navigation state consumers.
+ * @interface
+ */
+export class ConsumerDef {
+
+  /**
+   * @param {!StateChangeEventDef} unusedEvent
+   */
+  onStateChange(unusedEvent) {}
+}
+
+
+/**
+ * State store to decouple navigation changes from consumers.
+ */
+export class NavigationState {
+  constructor() {
+    /** @private {!Observable<StateChangeEventDef>} */
+    this.consumerObservable_ = new Observable();
+  }
+
+  /**
+   * @param {!ConsumerDef} consumer
+   */
+  installConsumer(consumer) {
+    this.consumerObservable_.add(changeEvent =>
+        consumer.onStateChange(changeEvent));
+  }
+
+  /**
+   * @param {number} index
+   * @param {string=} opt_pageId
+   */
+  // TODO(alanorozco): pass whether change was automatic or on user action
+  updateActivePage(index, opt_pageId) {
+    const changeValue = {
+      pageIndex: index,
+    };
+
+    if (opt_pageId) {
+      changeValue.pageId = dev().assertString(opt_pageId);
+    }
+
+    this.fire_(StateChangeType.ACTIVE_PAGE, changeValue);
+  }
+
+  /**
+   * @param {!StateChangeType}
+   * @param {*} changeValue
+   */
+  fire_(changeType, changeValue) {
+    this.consumerObservable_.fire({
+      type: changeType,
+      value: changeValue,
+    });
+  }
+}

--- a/extensions/amp-story/0.1/test/test-analytics.js
+++ b/extensions/amp-story/0.1/test/test-analytics.js
@@ -1,0 +1,88 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {StateChangeType} from '../navigation-state';
+import {
+  AnalyticsTrigger,
+  setTriggerAnalyticsEventImplForTesting,
+} from '../analytics';
+
+
+describes.fakeWin('amp-story analytics', {}, env => {
+  let analyticsTrigger;
+  let rootEl;
+
+  beforeEach(() => {
+    rootEl = env.win.document.createElement('div');
+    analyticsTrigger = new AnalyticsTrigger(rootEl);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('should trigger `story-page-visible` on change', () => {
+    const trigger = setTriggerAnalyticsEventImplForTesting(sandbox.spy());
+
+    analyticsTrigger.onStateChange({
+      type: StateChangeType.ACTIVE_PAGE,
+      value: {
+        pageIndex: 123,
+        pageId: 'my-page-id',
+      },
+    });
+
+    expect(trigger).to.have.been.calledWith(rootEl, 'story-page-visible',
+        sandbox.match(vars =>
+            vars.pageIndex === '123' &&
+            vars.pageId == 'my-page-id'));
+  });
+
+  it('should trigger `story-page-visible` only once per page', () => {
+    const trigger = setTriggerAnalyticsEventImplForTesting(sandbox.spy());
+
+    for (let i = 0; i < 10; i++) {
+      analyticsTrigger.onStateChange({
+        type: StateChangeType.ACTIVE_PAGE,
+        value: {
+          pageIndex: 123,
+          pageId: 'my-page-id',
+        },
+      });
+    }
+
+    expect(trigger).to.have.been.calledOnce;
+    expect(trigger).to.have.been.calledWith(rootEl, 'story-page-visible',
+        sandbox.match(vars =>
+            vars.pageIndex === '123' &&
+            vars.pageId == 'my-page-id'));
+
+    for (let i = 0; i < 10; i++) {
+      analyticsTrigger.onStateChange({
+        type: StateChangeType.ACTIVE_PAGE,
+        value: {
+          pageIndex: 6,
+          pageId: 'foo-page-id',
+        },
+      });
+    }
+
+    expect(trigger).to.have.been.calledTwice;
+    expect(trigger).to.have.been.calledWith(rootEl, 'story-page-visible',
+        sandbox.match(vars =>
+            vars.pageIndex === '6' &&
+            vars.pageId == 'foo-page-id'));
+  });
+});

--- a/extensions/amp-story/0.1/test/test-analytics.js
+++ b/extensions/amp-story/0.1/test/test-analytics.js
@@ -14,10 +14,7 @@
  * limitations under the License.
  */
 import {StateChangeType} from '../navigation-state';
-import {
-  AnalyticsTrigger,
-  setTriggerAnalyticsEventImplForTesting,
-} from '../analytics';
+import {AnalyticsTrigger} from '../analytics';
 
 
 describes.fakeWin('amp-story analytics', {}, env => {
@@ -29,12 +26,8 @@ describes.fakeWin('amp-story analytics', {}, env => {
     analyticsTrigger = new AnalyticsTrigger(rootEl);
   });
 
-  afterEach(() => {
-    sandbox.restore();
-  });
-
   it('should trigger `story-page-visible` on change', () => {
-    const trigger = setTriggerAnalyticsEventImplForTesting(sandbox.spy());
+    const trigger = sandbox.stub(analyticsTrigger, 'triggerEvent_');
 
     analyticsTrigger.onStateChange({
       type: StateChangeType.ACTIVE_PAGE,
@@ -44,14 +37,14 @@ describes.fakeWin('amp-story analytics', {}, env => {
       },
     });
 
-    expect(trigger).to.have.been.calledWith(rootEl, 'story-page-visible',
+    expect(trigger).to.have.been.calledWith('story-page-visible',
         sandbox.match(vars =>
             vars.pageIndex === '123' &&
             vars.pageId == 'my-page-id'));
   });
 
   it('should trigger `story-page-visible` only once per page', () => {
-    const trigger = setTriggerAnalyticsEventImplForTesting(sandbox.spy());
+    const trigger = sandbox.stub(analyticsTrigger, 'triggerEvent_');
 
     for (let i = 0; i < 10; i++) {
       analyticsTrigger.onStateChange({
@@ -64,7 +57,7 @@ describes.fakeWin('amp-story analytics', {}, env => {
     }
 
     expect(trigger).to.have.been.calledOnce;
-    expect(trigger).to.have.been.calledWith(rootEl, 'story-page-visible',
+    expect(trigger).to.have.been.calledWith('story-page-visible',
         sandbox.match(vars =>
             vars.pageIndex === '123' &&
             vars.pageId == 'my-page-id'));
@@ -80,7 +73,7 @@ describes.fakeWin('amp-story analytics', {}, env => {
     }
 
     expect(trigger).to.have.been.calledTwice;
-    expect(trigger).to.have.been.calledWith(rootEl, 'story-page-visible',
+    expect(trigger).to.have.been.calledWith('story-page-visible',
         sandbox.match(vars =>
             vars.pageIndex === '6' &&
             vars.pageId == 'foo-page-id'));

--- a/extensions/amp-story/0.1/test/test-analytics.js
+++ b/extensions/amp-story/0.1/test/test-analytics.js
@@ -14,22 +14,22 @@
  * limitations under the License.
  */
 import {StateChangeType} from '../navigation-state';
-import {AnalyticsTrigger} from '../analytics';
+import {AmpStoryAnalytics} from '../analytics';
 
 
 describes.fakeWin('amp-story analytics', {}, env => {
-  let analyticsTrigger;
+  let analytics;
   let rootEl;
 
   beforeEach(() => {
     rootEl = env.win.document.createElement('div');
-    analyticsTrigger = new AnalyticsTrigger(rootEl);
+    analytics = new AmpStoryAnalytics(rootEl);
   });
 
   it('should trigger `story-page-visible` on change', () => {
-    const trigger = sandbox.stub(analyticsTrigger, 'triggerEvent_');
+    const trigger = sandbox.stub(analytics, 'triggerEvent_');
 
-    analyticsTrigger.onStateChange({
+    analytics.onStateChange({
       type: StateChangeType.ACTIVE_PAGE,
       value: {
         pageIndex: 123,
@@ -44,10 +44,10 @@ describes.fakeWin('amp-story analytics', {}, env => {
   });
 
   it('should trigger `story-page-visible` only once per page', () => {
-    const trigger = sandbox.stub(analyticsTrigger, 'triggerEvent_');
+    const trigger = sandbox.stub(analytics, 'triggerEvent_');
 
     for (let i = 0; i < 10; i++) {
-      analyticsTrigger.onStateChange({
+      analytics.onStateChange({
         type: StateChangeType.ACTIVE_PAGE,
         value: {
           pageIndex: 123,
@@ -63,7 +63,7 @@ describes.fakeWin('amp-story analytics', {}, env => {
             vars.pageId == 'my-page-id'));
 
     for (let i = 0; i < 10; i++) {
-      analyticsTrigger.onStateChange({
+      analytics.onStateChange({
         type: StateChangeType.ACTIVE_PAGE,
         value: {
           pageIndex: 6,

--- a/extensions/amp-story/0.1/test/test-navigation-state.js
+++ b/extensions/amp-story/0.1/test/test-navigation-state.js
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {NavigationState, StateChangeType} from '../navigation-state';
+
+
+describes.fakeWin('amp-story navigation state', {}, () => {
+  let navigationState;
+
+  function createConsumer() {
+    return {onStateChange: sandbox.spy()};
+  }
+
+  beforeEach(() => {
+    navigationState = new NavigationState();
+  });
+
+  it('should dispatch active page changes to all consumers', () => {
+    const consumers = Array(5).fill(undefined).map(createConsumer);
+
+    consumers.forEach(consumer => navigationState.installConsumer(consumer));
+
+    navigationState.updateActivePage(0, 'my-page-id-1');
+
+    consumers.forEach(consumer => {
+      expect(consumer.onStateChange).to.have.been.calledWith(sandbox.match(e =>
+          e.type == StateChangeType.ACTIVE_PAGE
+              && e.value.pageIndex === 0
+              && e.value.pageId == 'my-page-id-1'));
+    });
+
+    navigationState.updateActivePage(5);
+
+    consumers.forEach(consumer => {
+      expect(consumer.onStateChange).to.have.been.calledWith(sandbox.match(e =>
+          e.type == StateChangeType.ACTIVE_PAGE
+              && e.value.pageIndex === 5
+              && !('pageId' in e.value)));
+    });
+
+    navigationState.updateActivePage(2, 'one-two-three');
+
+    consumers.forEach(consumer => {
+      expect(consumer.onStateChange).to.have.been.calledWith(sandbox.match(e =>
+          e.type == StateChangeType.ACTIVE_PAGE
+              && e.value.pageIndex === 2
+              && e.value.pageId == 'one-two-three'));
+    });
+  });
+});

--- a/extensions/amp-story/0.1/test/test-navigation-state.js
+++ b/extensions/amp-story/0.1/test/test-navigation-state.js
@@ -19,23 +19,23 @@ import {NavigationState, StateChangeType} from '../navigation-state';
 describes.fakeWin('amp-story navigation state', {}, () => {
   let navigationState;
 
-  function createConsumer() {
-    return {onStateChange: sandbox.spy()};
+  function createObserver() {
+    return sandbox.spy();
   }
 
   beforeEach(() => {
     navigationState = new NavigationState();
   });
 
-  it('should dispatch active page changes to all consumers', () => {
-    const consumers = Array(5).fill(undefined).map(createConsumer);
+  it('should dispatch active page changes to all observers', () => {
+    const observers = Array(5).fill(undefined).map(createObserver);
 
-    consumers.forEach(consumer => navigationState.installConsumer(consumer));
+    observers.forEach(observer => navigationState.observe(observer));
 
     navigationState.updateActivePage(0, 'my-page-id-1');
 
-    consumers.forEach(consumer => {
-      expect(consumer.onStateChange).to.have.been.calledWith(sandbox.match(e =>
+    observers.forEach(observer => {
+      expect(observer).to.have.been.calledWith(sandbox.match(e =>
           e.type == StateChangeType.ACTIVE_PAGE
               && e.value.pageIndex === 0
               && e.value.pageId == 'my-page-id-1'));
@@ -43,8 +43,8 @@ describes.fakeWin('amp-story navigation state', {}, () => {
 
     navigationState.updateActivePage(5);
 
-    consumers.forEach(consumer => {
-      expect(consumer.onStateChange).to.have.been.calledWith(sandbox.match(e =>
+    observers.forEach(observer => {
+      expect(observer).to.have.been.calledWith(sandbox.match(e =>
           e.type == StateChangeType.ACTIVE_PAGE
               && e.value.pageIndex === 5
               && !('pageId' in e.value)));
@@ -52,8 +52,8 @@ describes.fakeWin('amp-story navigation state', {}, () => {
 
     navigationState.updateActivePage(2, 'one-two-three');
 
-    consumers.forEach(consumer => {
-      expect(consumer.onStateChange).to.have.been.calledWith(sandbox.match(e =>
+    observers.forEach(observer => {
+      expect(observer).to.have.been.calledWith(sandbox.match(e =>
           e.type == StateChangeType.ACTIVE_PAGE
               && e.value.pageIndex === 2
               && e.value.pageId == 'one-two-three'));

--- a/extensions/amp-story/0.1/test/test-variable-service.js
+++ b/extensions/amp-story/0.1/test/test-variable-service.js
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 import {StateChangeType} from '../navigation-state';
-import {VariableService} from '../variable-service';
+import {AmpStoryVariableService} from '../variable-service';
 
 
 describes.fakeWin('amp-story variable service', {}, () => {
   let variableService;
 
   beforeEach(() => {
-    variableService = new VariableService();
+    variableService = new AmpStoryVariableService();
   });
 
   it('should update pageIndex and pageId on change', () => {

--- a/extensions/amp-story/0.1/test/test-variable-service.js
+++ b/extensions/amp-story/0.1/test/test-variable-service.js
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {StateChangeType} from '../navigation-state';
+import {VariableService} from '../variable-service';
+
+
+describes.fakeWin('amp-story variable service', {}, () => {
+  let variableService;
+
+  beforeEach(() => {
+    variableService = new VariableService();
+  });
+
+  it('should update pageIndex and pageId on change', () => {
+    variableService.onStateChange({
+      type: StateChangeType.ACTIVE_PAGE,
+      value: {
+        pageIndex: 123,
+        pageId: 'my-page-id',
+      },
+    });
+
+    expect(variableService.pageIndex).to.equal(123);
+    expect(variableService.pageId).to.equal('my-page-id');
+  });
+});

--- a/extensions/amp-story/0.1/variable-service.js
+++ b/extensions/amp-story/0.1/variable-service.js
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {StateChangeType} from './navigation-state';
+import {dev} from '../../../src/log';
+
+
+/**
+ * Variable service for amp-story.
+ * Used for URL replacement service. See usage in src/url-replacements-impl.
+ * @implements {./navigation-state.ConsumerDef}
+ */
+export class VariableService {
+  constructor() {
+    /** @private {?string} */
+    this.pageIndex_ = null;
+
+    /** @private {?number} */
+    this.pageId_ = null;
+  }
+
+  /**
+   * @param {!./navigation-state.StateChangeEventDef} stateChangeEvent
+   */
+  onStateChange(stateChangeEvent) {
+    switch (stateChangeEvent.type) {
+      case StateChangeType.ACTIVE_PAGE:
+        this.pageIndex_ = stateChangeEvent.value.pageIndex;
+        this.pageId_ = stateChangeEvent.value.pageId;
+        break;
+    }
+  }
+
+  /**
+   * @return {number}
+   */
+  get pageIndex() {
+    return dev().assertNumber(this.pageIndex_);
+  }
+
+  /**
+   * @return {string}
+   */
+  get pageId() {
+    return dev().assertString(this.pageId_);
+  }
+}

--- a/extensions/amp-story/0.1/variable-service.js
+++ b/extensions/amp-story/0.1/variable-service.js
@@ -20,7 +20,6 @@ import {dev} from '../../../src/log';
 /**
  * Variable service for amp-story.
  * Used for URL replacement service. See usage in src/url-replacements-impl.
- * @implements {./navigation-state.ConsumerDef}
  */
 export class VariableService {
   constructor() {

--- a/extensions/amp-story/0.1/variable-service.js
+++ b/extensions/amp-story/0.1/variable-service.js
@@ -21,7 +21,7 @@ import {dev} from '../../../src/log';
  * Variable service for amp-story.
  * Used for URL replacement service. See usage in src/url-replacements-impl.
  */
-export class VariableService {
+export class AmpStoryVariableService {
   constructor() {
     /** @private {?string} */
     this.pageIndex_ = null;

--- a/extensions/amp-story/0.1/variable-service.js
+++ b/extensions/amp-story/0.1/variable-service.js
@@ -36,8 +36,9 @@ export class AmpStoryVariableService {
   onStateChange(stateChangeEvent) {
     switch (stateChangeEvent.type) {
       case StateChangeType.ACTIVE_PAGE:
-        this.pageIndex_ = stateChangeEvent.value.pageIndex;
-        this.pageId_ = stateChangeEvent.value.pageId;
+        const {pageIndex, pageId} = stateChangeEvent.value;
+        this.pageIndex_ = pageIndex;
+        this.pageId_ = pageId;
         break;
     }
   }


### PR DESCRIPTION
This exposes hooks for triggering analytics pings on navigation in stories, with the ability to communicate two variables: the id and the index of the page to which the user has arrived.

Follow-up of #11489

Additional changes:

- Cleaner stubbing per [this comment](https://github.com/ampproject/amphtml/pull/11489/files#r141907953).
- Removed `ConsumerDef` per [this comment](https://github.com/ampproject/amphtml/pull/11489/files#r141909722).
- Removed `sandbox.restore()` per [this comment](https://github.com/ampproject/amphtml/pull/11489/files#diff-bbc9bcd22c78d7462e049c9eda0c4473R33).

/cc @newmuis 