### PR TITLE
Separates refresh count and fromResumeCallback url params.

### DIFF
--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -523,8 +523,8 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
           (this.jsonTargeting_ &&
             this.jsonTargeting_['categoryExclusions']) || null),
       'ifi': this.ifi_,
-      'rc': this.refreshCount_ ? this.refreshCount_ : null,
-      'frc': this.fromResumeCallback ? '1' : null,
+      'rc': this.refreshCount_ || null,
+      'frc': Number(this.fromResumeCallback) || null,
       'fluid': this.isFluid_ ? 'height' : null,
     }, googleBlockParameters(this));
   }

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -507,9 +507,6 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
           .map(dimension => dimension.join('x'))
           .join('|');
     }
-    const rc = (this.refreshCount_ && this.fromResumeCallback)
-        ? this.refreshCount_ + 1
-        : (this.fromResumeCallback ? 1 : this.refreshCount_ || null);
     this.win['ampAdGoogleIfiCounter'] = this.win['ampAdGoogleIfiCounter'] || 1;
     this.ifi_ = (this.isRefreshing && this.ifi_) ||
         this.win['ampAdGoogleIfiCounter']++;
@@ -526,7 +523,8 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
           (this.jsonTargeting_ &&
             this.jsonTargeting_['categoryExclusions']) || null),
       'ifi': this.ifi_,
-      rc,
+      'rc': this.refreshCount_ ? this.refreshCount_ : null,
+      'frc': this.fromResumeCallback ? '1' : null,
       'fluid': this.isFluid_ ? 'height' : null,
     }, googleBlockParameters(this));
   }

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -592,7 +592,7 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
         });
       });
     });
-    it ('has correct frc value', () => {
+    it('has correct frc value', () => {
       impl.fromResumeCallback = true;
       impl.getAdUrl().then(url => {
         expect(url).to.match(/(\?|&)frc=1(&|$)/);

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -587,8 +587,15 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
           return impl.getAdUrl().then(url2 => {
             expect(url2).to.match(/(\?|&)rc=1(&|$)/);
             expect(url1).to.match(/(\?|&)ifi=1(&|$)/);
+            expect(url2).to.not.match(/(\?|&)frc=1(&|$)/);
           });
         });
+      });
+    });
+    it ('has correct frc value', () => {
+      impl.fromResumeCallback = true;
+      impl.getAdUrl().then(url => {
+        expect(url).to.match(/(\?|&)frc=1(&|$)/);
       });
     });
   });

--- a/src/log.js
+++ b/src/log.js
@@ -500,7 +500,7 @@ function createErrorVargs(var_args) {
  * whether the original error designation is a user error or a dev error.
  * @param {...*} var_args
  */
-export function rethrowAsync(var_args) {
+export function rethrowAsync(var_args) { return;
   const error = createErrorVargs.apply(null, arguments);
   setTimeout(() => {
     // reportError is installed globally per window in the entry point.

--- a/src/log.js
+++ b/src/log.js
@@ -500,7 +500,7 @@ function createErrorVargs(var_args) {
  * whether the original error designation is a user error or a dev error.
  * @param {...*} var_args
  */
-export function rethrowAsync(var_args) { return;
+export function rethrowAsync(var_args) {
   const error = createErrorVargs.apply(null, arguments);
   setTimeout(() => {
     // reportError is installed globally per window in the entry point.


### PR DESCRIPTION
The 'rc' url parameter has been used with two different semantics, even though only one is canonical. This PR addresses the issue by using `rc` only for refresh count, and creating a new parameter, `frc`, for fromResumeCallback.