### PR TITLE
Fix Safari's broken transition !important unset

### DIFF
--- a/src/service/fixed-layer.js
+++ b/src/service/fixed-layer.js
@@ -375,6 +375,10 @@ export class FixedLayer {
           const fe = elements[i];
           const feState = state[fe.id];
 
+          // Fix a bug with Safari. For some reason, you cannot unset
+          // transition when it's important. You can, however, set it to a valid
+          // non-important value, then unset it.
+          setStyle(fe.element, 'transition', 'none');
           // Note: This MUST be done after measurements are taken.
           // Transitions will mess up everything and, depending on when paints
           // happen, mutates of transition and bottom at the same time may be

--- a/test/functional/test-fixed-layer.js
+++ b/test/functional/test-fixed-layer.js
@@ -229,9 +229,15 @@ describe('FixedLayer', () => {
             elem.style[privProp] = `${value} !${priority}`;
           } else if (elem.style[privProp] ||
               !endsWith(elem.computedStyle[prop], '!important')) {
-            // If element style is already set, we can override
-            // Or, if computed style is not important priority
-            elem.style[privProp] = value;
+            if (prop === 'transition' && !value &&
+                endsWith(elem.style[privProp] || '', '!important')) {
+              // Emulate a stupid Safari bug.
+              // noop.
+            } else {
+              // If element style is already set, we can override
+              // Or, if computed style is not important priority
+              elem.style[privProp] = value;
+            }
           }
         },
       },


### PR DESCRIPTION
Safari won't let you unset an inline `transition: none !important` by
setting it to `''`. Instead, you have to first set it to a valid
non-important value, then set it to `''`.

Fixes https://github.com/ampproject/amphtml/issues/11453.