### PR TITLE
Add amp-story URL replacement support

### DIFF
--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -84,7 +84,7 @@ export class GlobalVariableSource extends VariableSource {
     this.shareTrackingFragments_ = null;
 
     /** @private {?Promise<?{pageIndex: number, pageId: string}>} */
-    this.storyVariables_ = null;
+    this.storyVariablesPromise_ = null;
   }
 
   /**
@@ -617,11 +617,11 @@ export class GlobalVariableSource extends VariableSource {
    * @private
    */
   getStoryValue_(getter, expr) {
-    if (!this.storyVariables_) {
-      this.storyVariables_ =
+    if (!this.storyVariablesPromise_) {
+      this.storyVariablesPromise_ =
           Services.storyVariableServiceForOrNull(this.ampdoc.win);
     }
-    return this.storyVariables_.then(storyVariables => {
+    return this.storyVariablesPromise_.then(storyVariables => {
       user().assert(storyVariables,
           'To use variable %s amp-story should be configured',
           expr);

--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -82,6 +82,9 @@ export class GlobalVariableSource extends VariableSource {
 
     /** @private {?Promise<?ShareTrackingFragmentsDef>} */
     this.shareTrackingFragments_ = null;
+
+    /** @private {?Promise<?{pageIndex: number, pageId: string}>} */
+    this.storyVariables_ = null;
   }
 
   /**
@@ -503,6 +506,16 @@ export class GlobalVariableSource extends VariableSource {
           .getVideoAnalyticsDetails(video)
           .then(details => details ? details[property] : '');
     });
+
+    this.setAsync('STORY_PAGE_INDEX', () => {
+      return this.getStoryValue_(storyVariables => storyVariables.pageIndex,
+          'STORY_PAGE_INDEX');
+    });
+
+    this.setAsync('STORY_PAGE_ID', () => {
+      return this.getStoryValue_(storyVariables => storyVariables.pageId,
+          'STORY_PAGE_ID');
+    });
   }
 
   /**
@@ -592,6 +605,28 @@ export class GlobalVariableSource extends VariableSource {
           'amp-share-tracking should be configured',
           expr);
       return getter(/** @type {!ShareTrackingFragmentsDef} */ (fragments));
+    });
+  }
+
+  /**
+   * Resolves the value via amp-story's service.
+   * @param {function(!{pageIndex: number, pageId: string}):T} getter
+   * @param {string} expr
+   * @return {!Promise<T>}
+   * @template T
+   * @private
+   */
+  getStoryValue_(getter, expr) {
+    if (!this.storyVariables_) {
+      this.storyVariables_ =
+          Services.storyVariableServiceForOrNull(this.ampdoc.win);
+    }
+    return this.storyVariables_.then(storyVariables => {
+      user().assert(storyVariables,
+          'To use variable %s amp-story should be configured',
+          expr);
+      return getter(
+          /** @type {{pageIndex: number, pageId: string}} */ (storyVariables));
     });
   }
 }

--- a/src/services.js
+++ b/src/services.js
@@ -260,6 +260,16 @@ export class Services {
   }
 
   /**
+   * @param {!Window} win
+   * @return {?Promise<?{pageIndex: number, pageId: string}>}
+   */
+  static storyVariableServiceForOrNull(win) {
+    return (/** @type {!Promise<?{pageIndex: number, pageId: string}>} */ (
+        getElementServiceIfAvailable(win, 'story-variable', 'amp-story',
+            true)));
+  }
+
+  /**
    * @param {!Node|!./service/ampdoc-impl.AmpDoc} nodeOrDoc
    * @return {!Promise<!../extensions/amp-animation/0.1/web-animation-service.WebAnimationService>}
    */

--- a/test/functional/test-url-replacements.js
+++ b/test/functional/test-url-replacements.js
@@ -99,6 +99,15 @@ describes.sandboxed('UrlReplacements', {}, () => {
             });
           });
         }
+        if (opt_options.withStoryVariableService) {
+          markElementScheduledForTesting(iframe.win, 'amp-story');
+          registerServiceBuilder(iframe.win, 'story-variable', function() {
+            return Promise.resolve({
+              pageIndex: 546,
+              pageId: 'id-123',
+            });
+          });
+        }
       }
       viewerService = Services.viewerForDoc(iframe.ampdoc);
       replacements = Services.urlReplacementsForDoc(iframe.ampdoc);
@@ -419,6 +428,20 @@ describes.sandboxed('UrlReplacements', {}, () => {
     return expect(
         expandAsync('?in=SHARE_TRACKING_INCOMING&out=SHARE_TRACKING_OUTGOING'))
         .to.eventually.equal('?in=&out=');
+  });
+
+  it('should replace STORY_PAGE_INDEX and STORY_PAGE_ID', () => {
+    return expect(
+        expandAsync('?index=STORY_PAGE_INDEX&id=STORY_PAGE_ID',
+            /*opt_bindings*/ undefined, {withStoryVariableService: true}))
+        .to.eventually.equal('?index=546&id=id-123');
+  });
+
+  it('should replace STORY_PAGE_INDEX and STORY_PAGE_ID' +
+      ' with empty string if amp-story is not configured', () => {
+    return expect(
+        expandAsync('?index=STORY_PAGE_INDEX&id=STORY_PAGE_ID'))
+        .to.eventually.equal('?index=&id=');
   });
 
   it('should replace TIMESTAMP', () => {


### PR DESCRIPTION
This adds support for the rewriting the `STORY_PAGE_INDEX` and `STORY_PAGE_ID` variables for analytics.

/cc @newmuis 