### PR TITLE
Cherry-pick #11519, #11521 into amp-release-10-02-2017

### DIFF
--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -66,7 +66,7 @@ const METADATA_STRINGS = [
 // acceptable solution to the 'Safari on iOS doesn't fetch iframe src from
 // cache' issue.  See https://github.com/ampproject/amphtml/issues/5614
 /** @type {string} */
-export const DEFAULT_SAFEFRAME_VERSION = '1-0-10';
+export const DEFAULT_SAFEFRAME_VERSION = '1-0-13';
 
 /** @const {string} */
 export const CREATIVE_SIZE_HEADER = 'X-CreativeSize';


### PR DESCRIPTION
Testing using PRs to cherry-pick into amp-release branches to have proper visual test baseline. 

/to @rsimha-amp 