### PR TITLE
Do not require AMP-CORS for impression tracking.

### DIFF
--- a/src/impression.js
+++ b/src/impression.js
@@ -132,6 +132,8 @@ function invoke(win, clickUrl) {
   }
   return Services.xhrFor(win).fetchJson(clickUrl, {
     credentials: 'include',
+    // All origins are allows to send these requests.
+    requireAmpResponseSourceOrigin: false,
   }).then(res => res.json());
 }
 

--- a/test/functional/test-impression.js
+++ b/test/functional/test-impression.js
@@ -90,6 +90,7 @@ describe('impression', () => {
       expect(url).to.equal('https://www.example.com');
       expect(params).to.jsonEqual({
         credentials: 'include',
+        requireAmpResponseSourceOrigin: false,
       });
     });
   });
@@ -107,6 +108,7 @@ describe('impression', () => {
       expect(url).to.equal('https://www.example.com');
       expect(params).to.jsonEqual({
         credentials: 'include',
+        requireAmpResponseSourceOrigin: false,
       });
     });
   });


### PR DESCRIPTION
There is not need to check that the correct origin is issuing the requests.