### PR TITLE
The linter complains about long "import" lines

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -53,7 +53,7 @@
     "max-len": [2, 80, 4, {
       "ignoreComments": true,
       "ignoreUrls": true,
-      "ignorePattern": ""
+      "ignorePattern": "^\\s*import\\s+{[^}]+}\\s+from\\s+'[^']+'\\s*;$"
     }],
     "no-alert": 2,
     "no-array-destructuring": 2,


### PR DESCRIPTION
For issue #8750, I added an ignore pattern to the "max-len" rule to ignore the import statements. 