### PR TITLE
Fix broken system social share in Webviews and Opera UA detection

### DIFF
--- a/src/service/platform-impl.js
+++ b/src/service/platform-impl.js
@@ -80,7 +80,10 @@ export class Platform {
    * @return {boolean}
    */
   isOpera() {
-    return /OPR|Opera|OPiOS/i.test(this.navigator_.userAgent);
+    // Chrome mobile UA includes OPR<v> stating with Chrome 60, however real
+    // Opera puts put a / after OPR and that's the only tell, so
+    // we check for OPR/ instead of OPR
+    return /OPR\/|Opera|OPiOS/i.test(this.navigator_.userAgent);
   }
 
   /**

--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -486,6 +486,14 @@ export class Viewer {
   }
 
   /**
+   * Whether the document is embedded in a webview.
+   * @return {boolean}
+   */
+  isWebviewEmbedded() {
+    return this.isWebviewEmbedded_;
+  }
+
+  /**
    * @return {boolean}
    */
   isRuntimeOn() {

--- a/test/functional/test-platform.js
+++ b/test/functional/test-platform.js
@@ -198,6 +198,18 @@ describe('Platform', () => {
     testStandalone(userAgent, isStandalone);
   });
 
+  it('Pixel Chrome 61', () => {
+    isAndroid = true;
+    isChrome = true;
+    isWebKit = true;
+    majorVersion = 61;
+    userAgent = 'Mozilla/5.0 (Linux; Android 8.0.0; Pixel XL Build/OPR6.' +
+        '170623.011) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163' +
+        '.98 Mobile Safari/537.36';
+    testUserAgent(userAgent);
+    testStandalone(userAgent, isStandalone);
+  });
+
   it('Firefox', () => {
     isFirefox = true;
     majorVersion = 40;

--- a/test/functional/test-viewer.js
+++ b/test/functional/test-viewer.js
@@ -780,6 +780,32 @@ describe('Viewer', () => {
     });
   });
 
+  describe('isWebviewEmbedded', () => {
+    it('should be webview w/ "webview=1"', () => {
+      windowApi.parent = windowApi;
+      windowApi.location.hash = '#webview=1';
+      expect(new Viewer(ampdoc).isWebviewEmbedded()).to.be.true;
+    });
+
+    it('should NOT be webview w/o "webview=1"', () => {
+      windowApi.parent = windowApi;
+      windowApi.location.hash = '#foo=1';
+      expect(new Viewer(ampdoc).isWebviewEmbedded()).to.be.false;
+    });
+
+    it('should NOT be webview w/ "webview=0"', () => {
+      windowApi.parent = windowApi;
+      windowApi.location.hash = '#webview=0';
+      expect(new Viewer(ampdoc).isWebviewEmbedded()).to.be.false;
+    });
+
+    it('should NOT be webview if iframed regardless of "webview=1"', () => {
+      windowApi.parent = {};
+      windowApi.location.hash = '#webview=1';
+      expect(new Viewer(ampdoc).isEmbedded()).to.be.false;
+    });
+  });
+
   describe('isTrustedViewer', () => {
 
     it('should consider non-trusted when not iframed', () => {


### PR DESCRIPTION
Fixes https://github.com/ampproject/amphtml/issues/11473 

Chrome does not implement System Share in WebViews (See https://bugs.chromium.org/p/chromium/issues/detail?id=765923 ) but exposes `navigator.share` API (throws exception on call) so we now we have to use some UA detection to see if system share is supported or not.

Chrome 60+ also started sending `OPR` (opera) as part of user agent string, this PR also fixes that.