### PR TITLE
For sauce labs runs, print a message indicating that tests will be run in parallel

### DIFF
--- a/build-system/tasks/karma.conf.js
+++ b/build-system/tasks/karma.conf.js
@@ -48,6 +48,7 @@ module.exports = {
   reporters: ['super-dots', 'karmaSimpleReporter'],
 
   superDotsReporter: {
+    nbDotsPerLine: 10000,
     color: {
       success: 'green',
       failure: 'red',

--- a/build-system/tasks/runtime-test.js
+++ b/build-system/tasks/runtime-test.js
@@ -312,6 +312,11 @@ gulp.task('test', 'Runs tests', preTestTasks, function(done) {
     } else {
       done();
     }
+  }).on('run_start', function() {
+    if (argv.saucelabs) {
+      console./* OK*/log(green(
+          'Running tests in parallel on', c.browsers.length, 'browsers...'));
+    }
   }).on('browser_complete', function(browser) {
     if (argv.saucelabs) {
       const result = browser.lastResult;


### PR DESCRIPTION
This should make it clear that tests are being run in parallel, and that errors printed on the screen are from one of the browsers currently being run.

Follow up to #11444