### PR TITLE
Update comments for scheduleIframeLoad_ on delay time

### DIFF
--- a/extensions/amp-install-serviceworker/0.1/amp-install-serviceworker.js
+++ b/extensions/amp-install-serviceworker/0.1/amp-install-serviceworker.js
@@ -95,7 +95,7 @@ export class AmpInstallServiceWorker extends AMP.BaseElement {
   /** @private */
   scheduleIframeLoad_() {
     Services.viewerForDoc(this.getAmpDoc()).whenFirstVisible().then(() => {
-      // If the user is longer than 20 seconds on this page, load
+      // If the user is longer than 10 seconds on this page, load
       // the external iframe to install the ServiceWorker. The wait is
       // introduced to avoid installing SWs for content that the user
       // only engaged with superficially.


### PR DESCRIPTION
scheduleIframeLoad_ waits for 10000msec before loading iframe while the comment defines as "20 seconds". Should fix to "10 seconds" and might be worth documenting this spec. /** One of the hidden specs that not many people know **/
