### PR TITLE
Update amp-cache-modifications.md

### DIFF
--- a/spec/amp-cache-modifications.md
+++ b/spec/amp-cache-modifications.md
@@ -288,6 +288,7 @@ Any `<link>` tag present with attribute `rel` equal to any of the following:
 
 *Condition*:
 Remove any `<meta>` tags except for those that:
+ - have attribute `charset`
  - do not have attributes `content`, `itemprop`, `name` and `property`
  - have attribute `http-equiv`
  - have attribute `name` with case-insensitive prefix `amp-`


### PR DESCRIPTION
Do not strip `<meta>` tags that have attribute `charset`.

Why is this necessary? Because some sites may set a `<meta charset>` with other attributes that are valid attributes but don't pass the other conditions listed here (e.g. has attribute `itemprop`).
