### PR TITLE
Add a screen that explains that the amp-story experiment is disabled

### DIFF
--- a/extensions/amp-story/0.1/amp-story.css
+++ b/extensions/amp-story/0.1/amp-story.css
@@ -470,3 +470,35 @@ amp-social-share.i-amphtml-story-share-icon[type=email] {
   font-size: 10px;
   padding: 8px 0 0;
 }
+
+/** Experiment disabled  */
+.i-amphtml-story-experiment-error {
+  align-content: center;
+  background-color: #222 !important;
+  bottom: 0 !important;
+  color: #f0f0f0 !important;
+  display: flex;
+  flex-direction: column;
+  font-family: 'Roboto', sans-serif !important;
+  font-size: 20px;
+  justify-content: center;
+  left: 0 !important;
+  padding: 32px;
+  position: absolute !important;
+  right: 0 !important;
+  top: 0 !important;
+  z-index: 999999;
+}
+
+.i-amphtml-story-experiment-error-icon {
+  background-image: url('data:image/svg+xml;charset=utf8,<svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" viewBox="0 0 24 24" fill="#FFFFFF"><path d="M0 0h24v24H0z" fill="none"/><path d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z"/></svg>');
+  background-repeat: no-repeat;
+  background-size: cover;
+  height: 64px;
+  margin: 0 auto;
+  width: 64px;
+}
+
+.i-amphtml-story-experiment-error a {
+  color: #f0f0f0 !important;
+}

--- a/extensions/amp-story/0.1/amp-story.css
+++ b/extensions/amp-story/0.1/amp-story.css
@@ -495,7 +495,7 @@ amp-social-share.i-amphtml-story-share-icon[type=email] {
   background-repeat: no-repeat;
   background-size: cover;
   height: 64px;
-  margin: 0 auto;
+  margin: 0 auto 16px;
   width: 64px;
 }
 

--- a/extensions/amp-story/0.1/amp-story.css
+++ b/extensions/amp-story/0.1/amp-story.css
@@ -491,7 +491,7 @@ amp-social-share.i-amphtml-story-share-icon[type=email] {
 }
 
 .i-amphtml-story-experiment-error-icon {
-  background-image: url('data:image/svg+xml;charset=utf8,<svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" viewBox="0 0 24 24" fill="#FFFFFF"><path d="M0 0h24v24H0z" fill="none"/><path d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z"/></svg>');
+  background-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" viewBox="0 0 24 24" fill="#FFFFFF"><path d="M0 0h24v24H0z" fill="none"/><path d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z"/></svg>');
   background-repeat: no-repeat;
   background-size: cover;
   height: 64px;

--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -261,13 +261,14 @@ export class AmpStory extends AMP.BaseElement {
       const errorIconEl = this.win.document.createElement('div');
       errorIconEl.classList.add('i-amphtml-story-experiment-error-icon');
 
-      const errorMsgEl = this.win.document.createElement('p');
+      const errorMsgEl = this.win.document.createElement('span');
       errorMsgEl.textContent = 'You must enable the amp-story experiment to ' +
-          'view this content. Enable or disable your AMP experiments:';
+          'view this content.';
 
       const experimentsLinkEl = this.win.document.createElement('a');
       experimentsLinkEl.href = `${urls.cdn}/experiments.html`;
-      experimentsLinkEl.textContent = 'AMP Experiments Dashboard';
+      experimentsLinkEl.textContent = 'Enable or disable your experiments on ' +
+          'the experiments dashboard.';
 
       const errorEl = this.win.document.createElement('div');
       errorEl.classList.add('i-amphtml-story-experiment-error');

--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -53,6 +53,7 @@ import {AudioManager, upgradeBackgroundAudio} from './audio';
 import {setStyle, setStyles} from '../../../src/style';
 import {findIndex} from '../../../src/utils/array';
 import {ActionTrust} from '../../../src/action-trust';
+import {urls} from '../../../src/config';
 
 
 /** @private @const {number} */
@@ -69,9 +70,6 @@ const AMP_STORY_STANDALONE_ATTRIBUTE = 'standalone';
 
 /** @private @const {number} */
 const FULLSCREEN_THRESHOLD = 1024;
-
-/** @private @const {string} */
-const AMP_EXPERIMENTS_PAGE_URL = 'https://cdn.ampproject.org/experiments.html';
 
 /** @type {string} */
 const TAG = 'amp-story';
@@ -268,7 +266,7 @@ export class AmpStory extends AMP.BaseElement {
           'view this content. Enable or disable your AMP experiments:';
 
       const experimentsLinkEl = this.win.document.createElement('a');
-      experimentsLinkEl.href = AMP_EXPERIMENTS_PAGE_URL;
+      experimentsLinkEl.href = `${urls.cdn}/experiments.html`;
       experimentsLinkEl.textContent = 'AMP Experiments Dashboard';
 
       const errorEl = this.win.document.createElement('div');

--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -70,6 +70,9 @@ const AMP_STORY_STANDALONE_ATTRIBUTE = 'standalone';
 /** @private @const {number} */
 const FULLSCREEN_THRESHOLD = 1024;
 
+/** @private @const {string} */
+const AMP_EXPERIMENTS_PAGE_URL = 'https://cdn.ampproject.org/experiments.html';
+
 /** @type {string} */
 const TAG = 'amp-story';
 
@@ -133,7 +136,7 @@ export class AmpStory extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
-    user().assert(isExperimentOn(this.win, TAG), 'enable amp-story experiment');
+    this.assertAmpStoryExperiment_();
 
     if (this.element.hasAttribute(AMP_STORY_STANDALONE_ATTRIBUTE)) {
       this.getAmpDoc().win.document.documentElement.classList
@@ -251,6 +254,32 @@ export class AmpStory extends AMP.BaseElement {
   /** @override */
   prerenderAllowed() {
     return true;
+  }
+
+
+  /** @private */
+  assertAmpStoryExperiment_() {
+    if (!isExperimentOn(this.win, TAG)) {
+      const errorIconEl = this.win.document.createElement('div');
+      errorIconEl.classList.add('i-amphtml-story-experiment-error-icon');
+
+      const errorMsgEl = this.win.document.createElement('p');
+      errorMsgEl.textContent = 'You must enable the amp-story experiment to ' +
+          'view this content. Enable or disable your AMP experiments:';
+
+      const experimentsLinkEl = this.win.document.createElement('a');
+      experimentsLinkEl.href = AMP_EXPERIMENTS_PAGE_URL;
+      experimentsLinkEl.textContent = 'AMP Experiments Dashboard';
+
+      const errorEl = this.win.document.createElement('div');
+      errorEl.classList.add('i-amphtml-story-experiment-error');
+      errorEl.appendChild(errorIconEl);
+      errorEl.appendChild(errorMsgEl);
+      errorEl.appendChild(experimentsLinkEl);
+      this.element.appendChild(errorEl);
+
+      user().error(TAG, 'enable amp-story experiment');
+    }
   }
 
 


### PR DESCRIPTION
Since the format is highly visual, we offer a visual affordance that the experiment is disabled, with a link to enable it.

![screen shot 2017-10-06 at 8 30 26 am](https://user-images.githubusercontent.com/1651960/31277887-05d3596e-aa71-11e7-8d2f-a79e88059570.png)
