### PR TITLE
Disambiguate Percy branch name

### DIFF
--- a/build-system/tasks/visual-diff.js
+++ b/build-system/tasks/visual-diff.js
@@ -17,6 +17,7 @@
 
 const argv = require('minimist')(process.argv.slice(2));
 const execOrDie = require('../exec').execOrDie;
+const getStdout = require('../exec').getStdout;
 const gulp = require('gulp-help')(require('gulp'));
 
 
@@ -24,6 +25,14 @@ const gulp = require('gulp-help')(require('gulp'));
  * Simple wrapper around the ruby based visual diff tests.
  */
 function visualDiff() {
+  if (!argv.master) {
+    let userName = getStdout(
+        'git config user.email').trim().split('\n');
+    let branchName = getStdout(
+        'git rev-parse --abbrev-ref HEAD').trim().split('\n');
+    process.env['PERCY_BRANCH'] = userName + '-' + branchName;
+  }
+
   let cmd = 'ruby build-system/tasks/visual-diff.rb';
   for (const arg in argv) {
     if (arg !== '_') {

--- a/build-system/tasks/visual-diff.js
+++ b/build-system/tasks/visual-diff.js
@@ -25,7 +25,7 @@ const gulp = require('gulp-help')(require('gulp'));
  * Simple wrapper around the ruby based visual diff tests.
  */
 function visualDiff() {
-  if (!argv.master) {
+  if (!argv.master || !process.env['TRAVIS']) {
     const userName = getStdout(
         'git log -1 --pretty=format:"%ae"').trim();
     const branchName = process.env['TRAVIS'] ?

--- a/build-system/tasks/visual-diff.js
+++ b/build-system/tasks/visual-diff.js
@@ -28,7 +28,9 @@ function visualDiff() {
   if (!argv.master) {
     const userName = getStdout(
         'git log -1 --pretty=format:"%ae"').trim();
-    const branchName = process.env['TRAVIS_PULL_REQUEST_BRANCH'];
+    const branchName = process.env['TRAVIS'] ?
+        process.env['TRAVIS_PULL_REQUEST_BRANCH'] :
+        getStdout('git rev-parse --abbrev-ref HEAD').trim();
     process.env['PERCY_BRANCH'] = userName + '-' + branchName;
   }
 

--- a/build-system/tasks/visual-diff.js
+++ b/build-system/tasks/visual-diff.js
@@ -26,10 +26,9 @@ const gulp = require('gulp-help')(require('gulp'));
  */
 function visualDiff() {
   if (!argv.master) {
-    let userName = getStdout(
-        'git config user.email').trim().split('\n');
-    let branchName = getStdout(
-        'git rev-parse --abbrev-ref HEAD').trim().split('\n');
+    const userName = getStdout(
+        'git log -1 --pretty=format:"%ae"').trim();
+    const branchName = process.env['TRAVIS_PULL_REQUEST_BRANCH'];
     process.env['PERCY_BRANCH'] = userName + '-' + branchName;
   }
 

--- a/build-system/tasks/visual-diff.js
+++ b/build-system/tasks/visual-diff.js
@@ -22,9 +22,11 @@ const gulp = require('gulp-help')(require('gulp'));
 
 
 /**
- * Simple wrapper around the ruby based visual diff tests.
+ * Disambiguates branch names by decorating them with the commit author name.
+ * We do this for all non-push builds in order to prevent them from being used
+ * as baselines for future builds.
  */
-function visualDiff() {
+function setPercyBranch() {
   if (!argv.master || !process.env['TRAVIS']) {
     const userName = getStdout(
         'git log -1 --pretty=format:"%ae"').trim();
@@ -33,7 +35,13 @@ function visualDiff() {
         getStdout('git rev-parse --abbrev-ref HEAD').trim();
     process.env['PERCY_BRANCH'] = userName + '-' + branchName;
   }
+}
 
+/**
+ * Simple wrapper around the ruby based visual diff tests.
+ */
+function visualDiff() {
+  setPercyBranch();
   let cmd = 'ruby build-system/tasks/visual-diff.rb';
   for (const arg in argv) {
     if (arg !== '_') {


### PR DESCRIPTION
If a developer inadvertently pushes a PR from their local `master` branch, and if that build contains visual diffs, those snapshots are used as the baseline for all subsequent Percy builds until a new commit is merged to the real `master`.

This PR disambiguates local `master` branches from the mainline `master` branch on `ampproject/amphtml`. It does not affect push builds on `master` or on release branches.

Partial fix for #11385
Mitigates https://github.com/percy/percy-client/issues/26