### PR TITLE
Revert - #11482

### DIFF
--- a/src/url.js
+++ b/src/url.js
@@ -54,10 +54,7 @@ export const SOURCE_ORIGIN_PARAM = '__amp_source_origin';
  * @return {string} origin
  */
 export function getWinOrigin(win) {
-  if (win.origin && win.origin !== 'null') {
-    return win.origin;
-  }
-  return parseUrl(win.location.href).origin;
+  return win.origin || parseUrl(win.location.href).origin;
 }
 
 /**

--- a/test/functional/test-url.js
+++ b/test/functional/test-url.js
@@ -58,8 +58,8 @@ describe('getWinOrigin', () => {
 
   it('should return origin from href when win.origin is empty', () => {
     expect(getWinOrigin({
+      'origin': '',
       'location': {
-        'origin': '',
         'href': 'https://foo1.com/abc?123#foo',
       },
     })).to.equal('https://foo1.com');
@@ -67,20 +67,20 @@ describe('getWinOrigin', () => {
 
   it('should return origin from href when win.origin is null', () => {
     expect(getWinOrigin({
+      'origin': null,
       'location': {
-        'origin': null,
         'href': 'https://foo1.com/abc?123#foo',
       },
     })).to.equal('https://foo1.com');
   });
 
-  it('should return origin from href when win.origin is \"null\"', () => {
+  it('should return \"null\" when win.origin is \"null\"', () => {
     expect(getWinOrigin({
+      'origin': 'null',
       'location': {
-        'origin': 'null',
         'href': 'https://foo1.com/abc?123#foo',
       },
-    })).to.equal('https://foo1.com');
+    })).to.equal('null');
   });
 
 


### PR DESCRIPTION
#11482 - was wrong - "null" as an origin is still useful for CORS