### PR TITLE
Build all CSS files in compileCss

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -412,7 +412,7 @@ function compileCss() {
   })
   .then(() => {
     return buildExtensions({
-      bundleOnlyIfListedInFiles: true,
+      bundleOnlyIfListedInFiles: false,
       compileOnlyCss: true
     });
   });


### PR DESCRIPTION
Due to a css dependency that was recently added to `testing/describes.js`, we now need to do a full css compile before running any tests, even if `gulp test` was invoked only on a single file via `--files`. This re-enables the running of `gulp test --unit --files <file>` from a clean state.

There is barely any time cost to doing this, since a `gulp css` build takes less than a second to execute.

Fixes #11613