### PR TITLE
Wait for viewer visible before requesting cid

### DIFF
--- a/src/service/cid-impl.js
+++ b/src/service/cid-impl.js
@@ -131,9 +131,10 @@ export class Cid {
         'The CID scope and cookie name must only use the characters ' +
         '[a-zA-Z0-9-_.]+\nInstead found: %s',
         getCidStruct.scope);
+    const viewer = Services.viewerForDoc(this.ampdoc);
 
     return consent.then(() => {
-      return Services.viewerForDoc(this.ampdoc).whenFirstVisible();
+      return viewer.whenFirstVisible();
     }).then(() => {
       // Check if user has globally opted out of CID, we do this after
       // consent check since user can optout during consent process.
@@ -142,15 +143,17 @@ export class Cid {
       if (optedOut) {
         return '';
       }
-      const cidPromise = this.getExternalCid_(
-          getCidStruct, opt_persistenceConsent || consent);
-      // Getting the CID might involve an HTTP request. We timeout after 10s.
-      return Services.timerFor(this.ampdoc.win)
-          .timeoutPromise(10000, cidPromise,
-          `Getting cid for "${getCidStruct.scope}" timed out`)
-          .catch(error => {
-            rethrowAsync(error);
-          });
+      return viewer.nextVisiblePromise().then(() => {
+        const cidPromise = this.getExternalCid_(
+            getCidStruct, opt_persistenceConsent || consent);
+        // Getting the CID might involve an HTTP request. We timeout after 10s.
+        return Services.timerFor(this.ampdoc.win)
+            .timeoutPromise(10000, cidPromise,
+            `Getting cid for "${getCidStruct.scope}" timed out`)
+            .catch(error => {
+              rethrowAsync(error);
+            });
+      });
     });
   }
 

--- a/src/service/cid-impl.js
+++ b/src/service/cid-impl.js
@@ -143,7 +143,7 @@ export class Cid {
       if (optedOut) {
         return '';
       }
-      return viewer.nextVisiblePromise().then(() => {
+      return viewer.whenNextVisible().then(() => {
         const cidPromise = this.getExternalCid_(
             getCidStruct, opt_persistenceConsent || consent);
         // Getting the CID might involve an HTTP request. We timeout after 10s.

--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -149,6 +149,12 @@ export class Viewer {
     /** @private {?function()} */
     this.whenFirstVisibleResolve_ = null;
 
+    /** @private {?Promise} */
+    this.nextVisiblePromise_ = null;
+
+    /** @private {?function()} */
+    this.nextVisibleResolve_ = null;
+
     /** @private {?time} */
     this.firstVisibleTime_ = null;
 
@@ -426,6 +432,10 @@ export class Viewer {
       this.lastVisibleTime_ = now;
       this.hasBeenVisible_ = true;
       this.whenFirstVisibleResolve_();
+      if (this.nextVisibleResolve_) {
+        this.nextVisibleResolve_();
+        this.nextVisibleResolve_ = null;
+      }
     }
     this.visibilityObservable_.fire();
   }
@@ -603,11 +613,29 @@ export class Viewer {
 
   /**
    * Returns a Promise that only ever resolved when the current
-   * AMP document becomes visible.
+   * AMP document first becomes visible.
    * @return {!Promise}
    */
   whenFirstVisible() {
     return this.whenFirstVisiblePromise_;
+  }
+
+  /**
+   * Returns a Promise that resolve when current doc becomes visible
+   * @return {!Promise}
+   */
+  nextVisiblePromise() {
+    if (this.isVisible()) {
+      return Promise.resolve();
+    }
+
+    if (this.nextVisiblePromise_) {
+      return this.nextVisiblePromise_;
+    }
+
+    return this.nextVisiblePromise_ = new Promise(resolve => {
+      this.nextVisibleResolve_ = resolve;
+    });
   }
 
   /**

--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -432,10 +432,7 @@ export class Viewer {
       this.lastVisibleTime_ = now;
       this.hasBeenVisible_ = true;
       this.whenFirstVisibleResolve_();
-      if (this.nextVisibleResolve_) {
-        this.nextVisibleResolve_();
-        this.nextVisibleResolve_ = null;
-      }
+      this.whenNextVisibleResolve_();
     }
     this.visibilityObservable_.fire();
   }
@@ -621,10 +618,11 @@ export class Viewer {
   }
 
   /**
-   * Returns a Promise that resolve when current doc becomes visible
+   * Returns a Promise that resolve when current doc becomes visible.
+   * The promise resolves immediately if doc is already visible.
    * @return {!Promise}
    */
-  nextVisiblePromise() {
+  whenNextVisible() {
     if (this.isVisible()) {
       return Promise.resolve();
     }
@@ -636,6 +634,18 @@ export class Viewer {
     return this.nextVisiblePromise_ = new Promise(resolve => {
       this.nextVisibleResolve_ = resolve;
     });
+  }
+
+  /**
+   * Helper method to be called on visiblity change
+   * @private
+   */
+  whenNextVisibleResolve_() {
+    if (this.nextVisibleResolve_) {
+      this.nextVisibleResolve_();
+      this.nextVisibleResolve_ = null;
+      this.nextVisiblePromise_ = null;
+    }
   }
 
   /**

--- a/test/functional/test-viewer.js
+++ b/test/functional/test-viewer.js
@@ -173,12 +173,12 @@ describe('Viewer', () => {
   it('should return promise that resolve on visible', function* () {
     const viewer = new Viewer(ampdoc);
     expect(viewer.isVisible()).to.be.true;
-    let promise = viewer.nextVisiblePromise();
+    let promise = viewer.whenNextVisible();
     yield promise;
     viewer.receiveMessage('visibilitychange', {
       state: 'hidden',
     });
-    promise = viewer.nextVisiblePromise();
+    promise = viewer.whenNextVisible();
     expect(viewer.isVisible()).to.be.false;
     viewer.receiveMessage('visibilitychange', {
       state: 'visible',

--- a/test/functional/test-viewer.js
+++ b/test/functional/test-viewer.js
@@ -170,6 +170,22 @@ describe('Viewer', () => {
     expect(viewer.getLastVisibleTime()).to.equal(0);
   });
 
+  it('should return promise that resolve on visible', function* () {
+    const viewer = new Viewer(ampdoc);
+    expect(viewer.isVisible()).to.be.true;
+    let promise = viewer.nextVisiblePromise();
+    yield promise;
+    viewer.receiveMessage('visibilitychange', {
+      state: 'hidden',
+    });
+    promise = viewer.nextVisiblePromise();
+    expect(viewer.isVisible()).to.be.false;
+    viewer.receiveMessage('visibilitychange', {
+      state: 'visible',
+    });
+    return promise;
+  });
+
   it('should initialize firstVisibleTime for initially visible doc', () => {
     clock.tick(1);
     const viewer = new Viewer(ampdoc);


### PR DESCRIPTION
fix #11628 

Please note I did NOT bounce multiple cid request to one, as it needs a map from `getCidStruct` to each promise, which I think does not worth it. Service who call `Cid.get()` should be responsible to only call `#get()` once with each `getCidStruct`. But I am glad to store cid result if requested : )

One thing to note is that: Do we TIMEOUT if doc does not become visible after a certain amount of time. I feel we should not do in `Cid.get()` function, but whoever is calling that function should handle timeout. 