### PR TITLE
Make ima experiment a doc-level opt-in

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -1,5 +1,5 @@
 {
-  "allow-doc-opt-in": ["visibility-v3", "amp-animation", "ampdoc-shell"],
+  "allow-doc-opt-in": ["visibility-v3", "amp-animation", "ampdoc-shell", "amp-ima-video"],
   "allow-url-opt-in": ["pump-early-frame"],
 
   "canary": 1,

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -1,5 +1,5 @@
 {
-  "allow-doc-opt-in": ["visibility-v3", "amp-animation", "ampdoc-shell"],
+  "allow-doc-opt-in": ["visibility-v3", "amp-animation", "ampdoc-shell", "amp-ima-video"],
   "allow-url-opt-in": ["pump-early-frame"],
 
   "canary": 0,


### PR DESCRIPTION
/cc @shawnbuso @jasti 

After this is in, publisher can enable it by adding

```
<meta name="amp-experiments-opt-in" content="amp-ima-video">
```

to their AMP page.