### PR TITLE
Fixes amp-ad-exit handling of responses for different instance

### DIFF
--- a/extensions/amp-ad-exit/0.1/amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/amp-ad-exit.js
@@ -334,7 +334,9 @@ export class AmpAdExit extends AMP.BaseElement {
           }
           const responseMsg = deserializeMessage(getData(event));
           if (!responseMsg ||
-              responseMsg['type'] != MessageType.IFRAME_TRANSPORT_RESPONSE) {
+              responseMsg['type'] != MessageType.IFRAME_TRANSPORT_RESPONSE ||
+              responseMsg['creativeId'] != this.ampAdResourceId_) {
+
             return;
           }
           this.assertValidResponseMessage_(responseMsg, event.origin);
@@ -353,10 +355,6 @@ export class AmpAdExit extends AMP.BaseElement {
   assertValidResponseMessage_(responseMessage, eventOrigin) {
     user().assert(responseMessage['message'],
         'Received empty response from 3p analytics frame');
-    user().assert(
-        responseMessage['creativeId'] == this.ampAdResourceId_,
-        'Received malformed message from 3p analytics frame: ' +
-        'creativeId missing or invalid');
     user().assert(responseMessage['vendor'],
         'Received malformed message from 3p analytics frame: ' +
         'vendor missing');

--- a/extensions/amp-ad-exit/0.1/amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/amp-ad-exit.js
@@ -336,7 +336,6 @@ export class AmpAdExit extends AMP.BaseElement {
           if (!responseMsg ||
               responseMsg['type'] != MessageType.IFRAME_TRANSPORT_RESPONSE ||
               responseMsg['creativeId'] != this.ampAdResourceId_) {
-
             return;
           }
           this.assertValidResponseMessage_(responseMsg, event.origin);


### PR DESCRIPTION
amp-ad-exit listens for response messages from creatives.
There was a bug where if one amp-ad-exit instance receives a response meant for another instance, it would cause a failed assert(). Instead, the non-recipient instance should just ignore the response.