### PR TITLE
Ad Fast Fetch: move anchor click listener to adsense/doubleclick impl

### DIFF
--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -25,9 +25,6 @@ import {
 import {createElementWithAttributes} from '../../../src/dom';
 import {cancellation, isCancellation} from '../../../src/error';
 import {
-  installAnchorClickInterceptor,
-} from '../../../src/anchor-click-interceptor';
-import {
   installFriendlyIframeEmbed,
   setFriendlyIframeEmbedVisible,
 } from '../../../src/friendly-iframe-embed';
@@ -1088,11 +1085,11 @@ export class AmpA4A extends AMP.BaseElement {
    * publisher page but prior to load (or ini-load for friendly frame AMP
    * creative render).  To be overridden by network implementations as needed.
    *
-   * @param {boolean} isVerifiedAmpCreative whether or not the creative was
-   *    verified as AMP and therefore given preferential treatment.
+   * @param {?CreativeMetaDataDef} creativeMetaData metadata if AMP creative,
+   *    null otherwise.
    */
-  onCreativeRender(isVerifiedAmpCreative) {
-    if (isVerifiedAmpCreative) {
+  onCreativeRender(creativeMetaData) {
+    if (creativeMetaData) {
       this.protectedEmitLifecycleEvent_('renderFriendlyEnd');
     }
   }
@@ -1260,9 +1257,6 @@ export class AmpA4A extends AMP.BaseElement {
           const frameDoc = friendlyIframeEmbed.iframe.contentDocument ||
               friendlyIframeEmbed.win.document;
           setStyle(frameDoc.body, 'visibility', 'visible');
-          // Capture phase click handlers on the ad.
-          installAnchorClickInterceptor(
-              this.getAmpDoc(), friendlyIframeEmbed.win);
           // Bubble phase click handlers on the ad.
           this.registerAlpHandler_(friendlyIframeEmbed.win);
           // Capture timing info for friendly iframe load completion.
@@ -1280,7 +1274,7 @@ export class AmpA4A extends AMP.BaseElement {
           protectFunctionWrapper(this.onCreativeRender, this, err => {
             dev().error(TAG, this.element.getAttribute('type'),
                 'Error executing onCreativeRender', err);
-          })(true);
+          })(creativeMetaData);
           // It's enough to wait for "ini-load" signal because in a FIE case
           // we know that the embed no longer consumes significant resources
           // after the initial load.
@@ -1321,7 +1315,7 @@ export class AmpA4A extends AMP.BaseElement {
     protectFunctionWrapper(this.onCreativeRender, this, err => {
       dev().error(TAG, this.element.getAttribute('type'),
           'Error executing onCreativeRender', err);
-    })(false);
+    })(null);
     return frameLoadPromise;
   }
 

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -270,7 +270,7 @@ describe('amp-a4a', () => {
         const child = a4aElement.querySelector('iframe[name]');
         expect(child).to.be.ok;
         expect(child).to.be.visible;
-        expect(onCreativeRenderSpy.withArgs(false)).to.be.called;
+        expect(onCreativeRenderSpy.withArgs(null)).to.be.called;
         expect(lifecycleEventStub).to.be.calledWith('renderSafeFrameStart',
             {'isAmpCreative': false, 'releaseType': '0'});
       });
@@ -296,7 +296,7 @@ describe('amp-a4a', () => {
         const child = a4aElement.querySelector('iframe[name]');
         expect(child).to.be.ok;
         expect(child).to.be.visible;
-        expect(onCreativeRenderSpy.withArgs(false)).to.be.called;
+        expect(onCreativeRenderSpy.withArgs(null)).to.be.called;
       });
     });
 
@@ -310,7 +310,7 @@ describe('amp-a4a', () => {
         const child = a4aElement.querySelector('iframe[src]');
         expect(child).to.be.ok;
         expect(child).to.be.visible;
-        expect(onCreativeRenderSpy.withArgs(false)).to.be.called;
+        expect(onCreativeRenderSpy.withArgs(null)).to.be.called;
       });
     });
 
@@ -429,7 +429,7 @@ describe('amp-a4a', () => {
         const child = a4aElement.querySelector('iframe[src]');
         expect(child).to.be.ok;
         expect(child).to.be.visible;
-        expect(onCreativeRenderSpy.withArgs(false)).to.be.called;
+        expect(onCreativeRenderSpy.withArgs(null)).to.be.called;
       });
     });
   });
@@ -940,7 +940,8 @@ describe('amp-a4a', () => {
                 'link[href="https://fonts.googleapis.com/css?family=Questrial"]'))
                 .to.be.ok;
             expect(doc.querySelector('script[src*="amp-font-0.1"]')).to.be.ok;
-            expect(onCreativeRenderSpy).to.be.calledOnce;
+            expect(onCreativeRenderSpy.withArgs(sinon.match.object))
+                .to.be.calledOnce;
             expect(updatePriorityStub).to.be.calledOnce;
             expect(updatePriorityStub.args[0][0]).to.equal(0);
             expect(lifecycleEventStub).to.be.calledWith(
@@ -1062,7 +1063,8 @@ describe('amp-a4a', () => {
             const iframe = a4aElement.getElementsByTagName('iframe')[0];
             if (isValidCreative && !opt_failAmpRender) {
               expect(iframe.getAttribute('src')).to.be.null;
-              expect(onCreativeRenderSpy.withArgs(true)).to.be.calledOnce;
+              expect(onCreativeRenderSpy.withArgs(sinon.match.object))
+                  .to.be.calledOnce;
               expect(updatePriorityStub).to.be.calledOnce;
               expect(updatePriorityStub.args[0][0]).to.equal(0);
             } else {
@@ -1070,7 +1072,7 @@ describe('amp-a4a', () => {
               expect(iframe.src, 'verify iframe src w/ origin').to
                   .equal(TEST_URL +
                          '&__amp_source_origin=about%3Asrcdoc');
-              expect(onCreativeRenderSpy.withArgs(false)).to.be.called;
+              expect(onCreativeRenderSpy.withArgs(null)).to.be.called;
               if (!opt_failAmpRender) {
                 expect(updatePriorityStub).to.not.be.called;
               }
@@ -1113,7 +1115,7 @@ describe('amp-a4a', () => {
           expect(iframe).to.be.ok;
           expect(iframe.src.indexOf(TEST_URL)).to.equal(0);
           expect(iframe).to.be.visible;
-          expect(onCreativeRenderSpy.withArgs(false)).to.be.called;
+          expect(onCreativeRenderSpy.withArgs(null)).to.be.called;
           expect(lifecycleEventStub).to.be.calledWith('networkError');
         });
       });
@@ -1146,7 +1148,7 @@ describe('amp-a4a', () => {
           expect(iframe.src.indexOf(TEST_URL)).to.equal(0);
           expect(/&err=true/.test(iframe.src), iframe.src).to.be.true;
           expect(iframe).to.be.visible;
-          expect(onCreativeRenderSpy.withArgs(false)).to.be.called;
+          expect(onCreativeRenderSpy.withArgs(null)).to.be.called;
           expect(lifecycleEventStub).to.be.calledWith('networkError');
         });
       });
@@ -1192,7 +1194,7 @@ describe('amp-a4a', () => {
           const iframe = a4aElement.querySelectorAll('iframe')[0];
           expect(iframe.src.indexOf(TEST_URL)).to.equal(0);
           expect(iframe).to.be.visible;
-          expect(onCreativeRenderSpy.withArgs(false)).to.be.called;
+          expect(onCreativeRenderSpy.withArgs(null)).to.be.called;
         }));
       });
     });
@@ -1219,7 +1221,7 @@ describe('amp-a4a', () => {
           const iframe = a4aElement.querySelectorAll('iframe')[0];
           expect(iframe.src.indexOf(TEST_URL)).to.equal(0);
           expect(iframe).to.be.visible;
-          expect(onCreativeRenderSpy.withArgs(false)).to.be.called;
+          expect(onCreativeRenderSpy.withArgs(null)).to.be.called;
         });
       });
     });
@@ -1615,47 +1617,6 @@ describe('amp-a4a', () => {
         expect(frameDoc.body.innerHTML.trim()).to.equal('<p>some text</p>');
         expect(Services.urlReplacementsForDoc(frameDoc))
             .to.not.equal(Services.urlReplacementsForDoc(a4aElement));
-      });
-    });
-
-    it('should handle click expansion correctly', () => {
-      return a4a.renderAmpCreative_(metaData).then(() => {
-        const adBody = a4aElement.querySelector('iframe')
-            .contentDocument.querySelector('body');
-        let clickHandlerCalled = 0;
-
-        adBody.onclick = function(e) {
-          expect(e.defaultPrevented).to.be.false;
-          e.preventDefault();  // Make the test not actually navigate.
-          clickHandlerCalled++;
-        };
-        adBody.innerHTML = '<a ' +
-            'href="https://f.co?CLICK_X,CLICK_Y,RANDOM">' +
-            '<button id="target"><button></div>';
-        const button = adBody.querySelector('#target');
-        const a = adBody.querySelector('a');
-        const ev1 = new Event('click', {bubbles: true});
-        ev1.pageX = 10;
-        ev1.pageY = 20;
-        button.dispatchEvent(ev1);
-        expect(a.href).to.equal('https://f.co/?10,20,RANDOM');
-        expect(clickHandlerCalled).to.equal(1);
-
-        const ev2 = new Event('click', {bubbles: true});
-        ev2.pageX = 111;
-        ev2.pageY = 222;
-        a.dispatchEvent(ev2);
-        expect(a.href).to.equal('https://f.co/?111,222,RANDOM');
-        expect(clickHandlerCalled).to.equal(2);
-
-        const ev3 = new Event('click', {bubbles: true});
-        ev3.pageX = 666;
-        ev3.pageY = 666;
-        // Click parent of a tag.
-        a.parentElement.dispatchEvent(ev3);
-        // Had no effect, because actual link wasn't clicked.
-        expect(a.href).to.equal('https://f.co/?111,222,RANDOM');
-        expect(clickHandlerCalled).to.equal(3);
       });
     });
   });

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -367,7 +367,7 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
           this.getAmpDoc(), this.iframe.contentWindow);
     }
     if (this.ampAnalyticsConfig_) {
-      dev().assert(!this.ampAnalyticsElement_);
+      dev().assertElement(!this.ampAnalyticsElement_);
       if (isReportingEnabled(this)) {
         addCsiSignalsToAmpAnalyticsConfig(
             this.win,

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -367,7 +367,7 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
           this.getAmpDoc(), this.iframe.contentWindow);
     }
     if (this.ampAnalyticsConfig_) {
-      dev().assertElement(!this.ampAnalyticsElement_);
+      dev().assert(!this.ampAnalyticsElement_);
       if (isReportingEnabled(this)) {
         addCsiSignalsToAmpAnalyticsConfig(
             this.win,
@@ -384,7 +384,7 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
 
     this.lifecycleReporter_.addPingsForVisibility(this.element);
 
-    setStyles(dev().assert(this.iframe), {
+    setStyles(dev().assertElement(this.iframe), {
       width: `${this.size_.width}px`,
       height: `${this.size_.height}px`,
     });

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
@@ -263,6 +263,68 @@ describes.realWin('amp-ad-network-adsense-impl', {
       // test/functional/test-analytics.js.
       // Just ensure extensions is loaded, and analytics element appended.
     });
+
+    it('should register click listener', () => {
+      impl.iframe = impl.win.document.createElement('iframe');
+      impl.win.document.body.appendChild(impl.iframe);
+      const adBody = impl.iframe.contentDocument.body;
+      let clickHandlerCalled = 0;
+
+      adBody.onclick = function(e) {
+        expect(e.defaultPrevented).to.be.false;
+        e.preventDefault();  // Make the test not actually navigate.
+        clickHandlerCalled++;
+      };
+      adBody.innerHTML = '<a ' +
+          'href="https://f.co?CLICK_X,CLICK_Y,RANDOM">' +
+          '<button id="target"><button></div>';
+      const button = adBody.querySelector('#target');
+      const a = adBody.querySelector('a');
+      const ev1 = new Event('click', {bubbles: true});
+      ev1.pageX = 10;
+      ev1.pageY = 20;
+      sinon.stub(impl, 'getResource').returns(
+          {
+            getUpgradeDelayMs: () => 1,
+          });
+      impl.buildCallback();
+      impl.size_ = {width: 123, height: 456};
+      impl.onCreativeRender({customElementExtensions: []});
+      button.dispatchEvent(ev1);
+      expect(a.href).to.equal('https://f.co/?10,20,RANDOM');
+      expect(clickHandlerCalled).to.equal(1);
+    });
+
+    it('should not register click listener is amp-ad-exit', () => {
+      impl.iframe = impl.win.document.createElement('iframe');
+      impl.win.document.body.appendChild(impl.iframe);
+      const adBody = impl.iframe.contentDocument.body;
+      let clickHandlerCalled = 0;
+
+      adBody.onclick = function(e) {
+        expect(e.defaultPrevented).to.be.false;
+        e.preventDefault();  // Make the test not actually navigate.
+        clickHandlerCalled++;
+      };
+      adBody.innerHTML = '<a ' +
+          'href="https://f.co?CLICK_X,CLICK_Y,RANDOM">' +
+          '<button id="target"><button></div>';
+      const button = adBody.querySelector('#target');
+      const a = adBody.querySelector('a');
+      const ev1 = new Event('click', {bubbles: true});
+      ev1.pageX = 10;
+      ev1.pageY = 20;
+      sinon.stub(impl, 'getResource').returns(
+          {
+            getUpgradeDelayMs: () => 1,
+          });
+      impl.buildCallback();
+      impl.size_ = {width: 123, height: 456};
+      impl.onCreativeRender({customElementExtensions: ['amp-ad-exit']});
+      button.dispatchEvent(ev1);
+      expect(a.href).to.equal('https://f.co/?CLICK_X,CLICK_Y,RANDOM');
+      expect(clickHandlerCalled).to.equal(1);
+    });
   });
 
   describe('centering', () => {

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
@@ -283,7 +283,7 @@ describes.realWin('amp-ad-network-adsense-impl', {
       const ev1 = new Event('click', {bubbles: true});
       ev1.pageX = 10;
       ev1.pageY = 20;
-      sinon.stub(impl, 'getResource').returns(
+      sandbox.stub(impl, 'getResource').returns(
           {
             getUpgradeDelayMs: () => 1,
           });
@@ -314,7 +314,7 @@ describes.realWin('amp-ad-network-adsense-impl', {
       const ev1 = new Event('click', {bubbles: true});
       ev1.pageX = 10;
       ev1.pageY = 20;
-      sinon.stub(impl, 'getResource').returns(
+      sandbox.stub(impl, 'getResource').returns(
           {
             getUpgradeDelayMs: () => 1,
           });

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -822,7 +822,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
           this.getAmpDoc(), this.iframe.contentWindow);
     }
     if (this.ampAnalyticsConfig_) {
-      dev().assertElement(!this.ampAnalyticsElement_);
+      dev().assert(!this.ampAnalyticsElement_);
       if (isReportingEnabled(this)) {
         addCsiSignalsToAmpAnalyticsConfig(
             this.win,
@@ -854,7 +854,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
         // the size header for fluid ads. Fluid size headers always come back as
         // 0x0.
         !(size.width == 0 && size.height == 0);
-    setStyles(dev().assert(this.iframe), {
+    setStyles(dev().assertElement(this.iframe), {
       width: `${size.width}px`,
       height: `${size.height}px`,
       position: isMultiSizeFluid ? 'relative' : null,

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -61,6 +61,9 @@ import {
   lineDelimitedStreamer,
   metaJsonCreativeGrouper,
 } from '../../../ads/google/a4a/line-delimited-response-handler';
+import {
+  installAnchorClickInterceptor,
+} from '../../../src/anchor-click-interceptor';
 import {stringHash32} from '../../../src/string';
 import {removeElement, createElementWithAttributes} from '../../../src/dom';
 import {getData} from '../../../src/event-helper';
@@ -808,8 +811,16 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
   }
 
   /** @override */
-  onCreativeRender(isVerifiedAmpCreative) {
-    super.onCreativeRender(isVerifiedAmpCreative);
+  onCreativeRender(creativeMetaData) {
+    super.onCreativeRender(creativeMetaData);
+    if (creativeMetaData &&
+        !creativeMetaData.customElementExtensions.includes('amp-ad-exit')) {
+      // Capture phase click handlers on the ad if amp-ad-exit not present
+      // (assume it will handle capture).
+      dev().assert(this.iframe);
+      installAnchorClickInterceptor(
+          this.getAmpDoc(), this.iframe.contentWindow);
+    }
     if (this.ampAnalyticsConfig_) {
       dev().assert(!this.ampAnalyticsElement_);
       if (isReportingEnabled(this)) {
@@ -818,7 +829,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
             this.element,
             this.ampAnalyticsConfig_,
             this.qqid_,
-            isVerifiedAmpCreative,
+            !!creativeMetaData,
             this.lifecycleReporter_.getDeltaTime(),
             this.lifecycleReporter_.getInitTime());
       }
@@ -843,7 +854,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
         // the size header for fluid ads. Fluid size headers always come back as
         // 0x0.
         !(size.width == 0 && size.height == 0);
-    setStyles(dev().assertElement(this.iframe), {
+    setStyles(dev().assert(this.iframe), {
       width: `${size.width}px`,
       height: `${size.height}px`,
       position: isMultiSizeFluid ? 'relative' : null,

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -822,7 +822,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
           this.getAmpDoc(), this.iframe.contentWindow);
     }
     if (this.ampAnalyticsConfig_) {
-      dev().assert(!this.ampAnalyticsElement_);
+      dev().assertElement(!this.ampAnalyticsElement_);
       if (isReportingEnabled(this)) {
         addCsiSignalsToAmpAnalyticsConfig(
             this.win,

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -337,6 +337,68 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
       // test/functional/test-analytics.js.
       // Just ensure extensions is loaded, and analytics element appended.
     });
+
+    it('should register click listener', () => {
+      impl.iframe = impl.win.document.createElement('iframe');
+      impl.win.document.body.appendChild(impl.iframe);
+      const adBody = impl.iframe.contentDocument.body;
+      let clickHandlerCalled = 0;
+
+      adBody.onclick = function(e) {
+        expect(e.defaultPrevented).to.be.false;
+        e.preventDefault();  // Make the test not actually navigate.
+        clickHandlerCalled++;
+      };
+      adBody.innerHTML = '<a ' +
+          'href="https://f.co?CLICK_X,CLICK_Y,RANDOM">' +
+          '<button id="target"><button></div>';
+      const button = adBody.querySelector('#target');
+      const a = adBody.querySelector('a');
+      const ev1 = new Event('click', {bubbles: true});
+      ev1.pageX = 10;
+      ev1.pageY = 20;
+      sinon.stub(impl, 'getResource').returns(
+          {
+            getUpgradeDelayMs: () => 1,
+          });
+      impl.buildCallback();
+      impl.size_ = {width: 123, height: 456};
+      impl.onCreativeRender({customElementExtensions: []});
+      button.dispatchEvent(ev1);
+      expect(a.href).to.equal('https://f.co/?10,20,RANDOM');
+      expect(clickHandlerCalled).to.equal(1);
+    });
+
+    it('should not register click listener is amp-ad-exit', () => {
+      impl.iframe = impl.win.document.createElement('iframe');
+      impl.win.document.body.appendChild(impl.iframe);
+      const adBody = impl.iframe.contentDocument.body;
+      let clickHandlerCalled = 0;
+
+      adBody.onclick = function(e) {
+        expect(e.defaultPrevented).to.be.false;
+        e.preventDefault();  // Make the test not actually navigate.
+        clickHandlerCalled++;
+      };
+      adBody.innerHTML = '<a ' +
+          'href="https://f.co?CLICK_X,CLICK_Y,RANDOM">' +
+          '<button id="target"><button></div>';
+      const button = adBody.querySelector('#target');
+      const a = adBody.querySelector('a');
+      const ev1 = new Event('click', {bubbles: true});
+      ev1.pageX = 10;
+      ev1.pageY = 20;
+      sinon.stub(impl, 'getResource').returns(
+          {
+            getUpgradeDelayMs: () => 1,
+          });
+      impl.buildCallback();
+      impl.size_ = {width: 123, height: 456};
+      impl.onCreativeRender({customElementExtensions: ['amp-ad-exit']});
+      button.dispatchEvent(ev1);
+      expect(a.href).to.equal('https://f.co/?CLICK_X,CLICK_Y,RANDOM');
+      expect(clickHandlerCalled).to.equal(1);
+    });
   });
 
   describe('#getAdUrl', () => {

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -357,7 +357,7 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
       const ev1 = new Event('click', {bubbles: true});
       ev1.pageX = 10;
       ev1.pageY = 20;
-      sinon.stub(impl, 'getResource').returns(
+      sandbox.stub(impl, 'getResource').returns(
           {
             getUpgradeDelayMs: () => 1,
           });
@@ -388,7 +388,7 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
       const ev1 = new Event('click', {bubbles: true});
       ev1.pageX = 10;
       ev1.pageY = 20;
-      sinon.stub(impl, 'getResource').returns(
+      sandbox.stub(impl, 'getResource').returns(
           {
             getUpgradeDelayMs: () => 1,
           });


### PR DESCRIPTION
Move document click listener for FIE which expands CLICK_X/CLICK_Y into AdSense/Doubleclick impls and do not install if amp-ad-exit extension exists in creative (assuming it will handle expansion).