### PR TITLE
Merge canonical SSL and non-SSL into single experiment

### DIFF
--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -459,7 +459,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
   /** @override */
   shouldPreferentialRenderWithoutCrypto() {
     return experimentFeatureEnabled(
-        this.win, DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_HTTP_EXPERIMENT,
+        this.win, DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_EXPERIMENT,
         DFP_CANONICAL_FF_EXPERIMENT_NAME);
   }
 

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
@@ -56,8 +56,6 @@ export const DOUBLECLICK_EXPERIMENT_FEATURE = {
   HOLDBACK_INTERNAL: '2092614',
   CANONICAL_CONTROL: '21060932',
   CANONICAL_EXPERIMENT: '21060933',
-  CANONICAL_HTTP_CONTROL: '21061030',
-  CANONICAL_HTTP_EXPERIMENT: '21061031',
   CACHE_EXTENSION_INJECTION_CONTROL: '21060955',
   CACHE_EXTENSION_INJECTION_EXP: '21060956',
   IDENTITY_CONTROL: '21060937',
@@ -137,11 +135,6 @@ export class DoubleclickA4aEligibility {
       if (urlExperimentId == -1 &&
           (getMode(win).localDev || getMode(win).test)) {
         experimentId = MANUAL_EXPERIMENT_ID;
-      } else if (!this.supportsCrypto(win)) {
-        experimentId = this.maybeSelectExperiment(win, element, [
-          DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_HTTP_CONTROL,
-          DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_HTTP_EXPERIMENT,
-        ], DFP_CANONICAL_FF_EXPERIMENT_NAME);
       } else {
         experimentId = this.maybeSelectExperiment(win, element, [
           DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_CONTROL,
@@ -179,7 +172,6 @@ export class DoubleclickA4aEligibility {
     return ![DOUBLECLICK_EXPERIMENT_FEATURE.HOLDBACK_EXTERNAL,
       DOUBLECLICK_EXPERIMENT_FEATURE.HOLDBACK_INTERNAL,
       DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_CONTROL,
-      DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_HTTP_CONTROL,
     ].includes(experimentId);
   }
 

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -946,7 +946,7 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
 
     it('should return true when in canonical non-SSL experiment', () => {
       forceExperimentBranch(impl.win, DFP_CANONICAL_FF_EXPERIMENT_NAME,
-          DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_HTTP_EXPERIMENT);
+          DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_EXPERIMENT);
       expect(impl.shouldPreferentialRenderWithoutCrypto()).to.be.true;
     });
   });

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-a4a-config.js
@@ -103,24 +103,6 @@ describe('doubleclick-a4a-config', () => {
 
     });
 
-    it('should select into non-SSL canonical AMP experiment when not on CDN',
-        () => {
-          sandbox.stub(DoubleclickA4aEligibility.prototype,
-              'isCdnProxy', () => false);
-          sandbox.stub(DoubleclickA4aEligibility.prototype,
-              'supportsCrypto', () => false);
-          const maybeSelectExperimentSpy = sandbox.spy(
-              DoubleclickA4aEligibility.prototype, 'maybeSelectExperiment');
-          const elem = testFixture.doc.createElement('div');
-          testFixture.doc.body.appendChild(elem);
-          doubleclickIsA4AEnabled(mockWin, elem);
-          expect(maybeSelectExperimentSpy).to.be.calledWith(mockWin, elem, [
-            DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_HTTP_CONTROL,
-            DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_HTTP_EXPERIMENT,
-          ], DFP_CANONICAL_FF_EXPERIMENT_NAME) ;
-          expect(maybeSelectExperimentSpy.callCount).to.equal(1);
-        });
-
     it('should return false if no canonical AMP experiment branch', () => {
       forceExperimentBranch(mockWin, DFP_CANONICAL_FF_EXPERIMENT_NAME, null);
       sandbox.stub(DoubleclickA4aEligibility.prototype,


### PR DESCRIPTION
Native crypto has been showing as available on safari pages on non-ssl pages, whereas that is not the case for non-ios traffic. For ease of development/debugging etc, merging into a single experiment for SSL and non-SSL traffic. 