### PR TITLE
Add demos to amp-fit-text doc

### DIFF
--- a/extensions/amp-fit-text/amp-fit-text.md
+++ b/extensions/amp-fit-text/amp-fit-text.md
@@ -31,7 +31,7 @@ limitations under the License.
   </tr>
   <tr>
     <td width="40%"><strong>Examples</strong></td>
-    <td><a href="https://ampbyexample.com/components/amp-fit-text/">Annotated code example that includes amp-fit</a></td>
+    <td>See AMP By Example's <a href="https://ampbyexample.com/components/amp-fit-text/">amp-fit-text example</a>.</td>
   </tr>
 </table>
 
@@ -39,37 +39,73 @@ limitations under the License.
 
 ## Behavior
 
-The `amp-fit-text` component expects its content to be text or other inline
-content, but it can also contain non-inline content. For the given content
-the `amp-fit-text` will try to find the best font size to fit all of the
-content within the available space.
+The `amp-fit-text` component allows you to manage the size and fit of text within a specified area. For content contained in an `amp-fit-text` element, the `amp-fit-text` component finds the best font size to fit all of the content within the available space. The expected content for `amp-fit-text` is text or other inline content, but it can also contain non-inline content. 
 
-If content of the `amp-fit-text` is overflowing the available space event with
-the minimum font size, the overflowing content will be cut off and hidden. The
-WebKit and Blink-based browsers will show ellipsis in this case.
 
-The `amp-fit-text` accepts one of the following `layout` values: `fixed`,
-`fixed-height`, `responsive` or `fill`.
+##### Example: Text scales to fit area
 
-For example:
-```html
-<amp-fit-text width="300" height="200" layout="responsive"
-    max-font-size="52">
-  Lorem ipsum dolor sit amet, has nisl nihil convenire et, vim at aeque
-  inermis reprehendunt.
-</amp-fit-text>
-```
+In the following example, the `<amp-fit-text>` element is nested within a 300x300 blue `div` block (class `fixedblock`). For the `<amp-fit-text>` element, we specified a `responsive` layout.  As a result, the text scales responsively per the aspect ratio provided by the width and height (200x200) of the `<amp-fit-text>` element, but the text does not exceed the size of its parent.
+
+<!--embedded example - displays in ampproject.org -->
+<div>
+<amp-iframe height="207"
+            layout="fixed-height"
+            sandbox="allow-scripts allow-forms allow-same-origin"
+            resizable
+            src="https://ampproject-b5f4c.firebaseapp.com/examples/ampfittext.base.embed.html">
+  <div overflow tabindex="0" role="button" aria-label="Show more">Show full code</div>
+  <div placeholder></div> 
+</amp-iframe>
+</div>
+
+##### Example: Text scales to fit area using a maximum font size
+
+The following example is similar to the one above, but in this example we specify a `max-font-size` of `22`, so the text is smaller but still fits the space:
+
+<!--embedded example - displays in ampproject.org -->
+<div>
+  <amp-iframe height="226"
+            layout="fixed-height"
+            sandbox="allow-scripts allow-forms allow-same-origin"
+            resizable
+            src="https://ampproject-b5f4c.firebaseapp.com/examples/ampfittext.max-font.embed.html">
+  <div overflow tabindex="0" role="button" aria-label="Show more">Show full code</div>
+  <div placeholder></div> 
+</amp-iframe>
+
+</div>
+
+### Overflowing content
+
+If the content of the `amp-fit-text` overflows the available space, even with a
+`min-font-size` specified, the overflowing content is cut off and hidden. WebKit and Blink-based browsers show ellipsis for overflowing content.
+
+##### Example: Text truncates when content overflows area 
+
+In the following example, we specified a `min-font-size` of `40`, which causes the content to exceed the size of its fixed block parent, so the text is truncated to fit the container.
+
+<!--embedded example - displays in ampproject.org -->
+<div>
+<amp-iframe height="226"
+            layout="fixed-height"
+            sandbox="allow-scripts allow-forms allow-same-origin"
+            resizable
+            src="https://ampproject-b5f4c.firebaseapp.com/examples/ampfittext.min-font.embed.html">
+  <div overflow tabindex="0" role="button" aria-label="Show more">Show full code</div>
+  <div placeholder></div> 
+</amp-iframe>
+</div>
 
 
 ## Attributes
 
 ##### min-font-size
 
-The minimum font size as an integer that the `amp-fit-text` can use.
+Specifies the minimum font size as an integer that the `amp-fit-text` can use.
 
 ##### max-font-size
 
-The maximum font size as an integer that the `amp-fit-text` can use.
+Specifies the maximum font size as an integer that the `amp-fit-text` can use.
 
 ##### common attributes
 
@@ -77,9 +113,7 @@ This element includes [common attributes](https://www.ampproject.org/docs/refere
 
 ## Styling
 
-The `amp-fit-text` component can be styled with standard CSS. In particular,
-it's possible to use `text-align`, `font-weight`, `color` and many other CSS
-properties with the main exception of `font-size`.
+You can style the `amp-fit-text` with standard CSS. In particular, you can use `text-align`, `font-weight`, `color` and many other CSS properties, with the main exception of `font-size`.
 
 ## Validation
 


### PR DESCRIPTION
Improved the amp-fit-text doc to:

- Include embedded demos that will render on ampproject.org
- Clarify and improve wording

Preview of what doc looks like [here](https://barb-ampdocs.firebaseapp.com/docs/reference/components/amp-fit-text.html)

cc: @jridgewell 