### PR TITLE
Set progress bar for current page to full

### DIFF
--- a/extensions/amp-story/0.1/progress-bar.js
+++ b/extensions/amp-story/0.1/progress-bar.js
@@ -109,7 +109,7 @@ export class ProgressBar {
   setActivePageIndex(pageIndex) {
     this.assertValidPageIndex_(pageIndex);
     for (let i = 0; i < this.pageCount_; i++) {
-      if (i < pageIndex) {
+      if (i <= pageIndex) {
         this.updateProgress(i, 1.0);
       } else {
         this.updateProgress(i, 0.0);


### PR DESCRIPTION
The page you're on should have its progress bar segment as full by default.