### PR TITLE
amp-analytics set priority 0 for inabox

### DIFF
--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -27,6 +27,7 @@ import {Services} from '../../../src/services';
 import {toggle} from '../../../src/style';
 import {isEnumValue} from '../../../src/types';
 import {parseJson} from '../../../src/json';
+import {getMode} from '../../../src/mode';
 import {Activity} from './activity-impl';
 import {
     InstrumentationService,
@@ -118,8 +119,8 @@ export class AmpAnalytics extends AMP.BaseElement {
 
   /** @override */
   getPriority() {
-    // Loads after other content.
-    return 1;
+    // Load immediately if inabox, otherwise after other content.
+    return getMode().runtime == 'inabox' ? 0 : 1;
   }
 
   /** @override */

--- a/extensions/amp-analytics/0.1/test/test-amp-analytics.js
+++ b/extensions/amp-analytics/0.1/test/test-amp-analytics.js
@@ -1614,4 +1614,31 @@ describes.realWin('amp-analytics', {
       });
     });
   });
+
+  describe('getPriority', () => {
+    function getConfig() {
+      return {
+        'requests': {
+          'pageview1': '/test1=${requestCount}',
+        },
+        'triggers': {
+          'conditional': {
+            'on': 'visible',
+            'request': 'pageview1',
+            'vars': {},
+          },
+        },
+        'vars': {},
+      };
+    }
+
+    it('is 1 for non-inabox', () => {
+      expect(getAnalyticsTag(getConfig()).getPriority()).to.equal(1);
+    });
+
+    it('is 0 for inabox', () => {
+      env.win.AMP_MODE = 'inabox';
+      expect(getAnalyticsTag(getConfig()).getPriority()).to.equal(1);
+    });
+  });
 });


### PR DESCRIPTION
To ensure that amp-analytics executes immediately for inabox ad creatives, set priority to 0.