### PR TITLE
Refactor experiment selection for doubleclick A4A, add unconditioned experiment selection for canonical FF

### DIFF
--- a/extensions/amp-ad-network-adsense-impl/0.1/adsense-a4a-config.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/adsense-a4a-config.js
@@ -75,9 +75,13 @@ export const URL_EXPERIMENT_MAPPING = {
 /**
  * @param {!Window} win
  * @param {!Element} element
+ * @param {!boolean} useRemoteHtml
  * @returns {boolean}
  */
-export function adsenseIsA4AEnabled(win, element) {
+export function adsenseIsA4AEnabled(win, element, useRemoteHtml) {
+  if (useRemoteHtml) {
+    return false;
+  }
   if (!isGoogleAdsA4AValidEnvironment(win) ||
       !element.getAttribute('data-ad-client')) {
     return false;

--- a/extensions/amp-ad-network-adsense-impl/0.1/adsense-a4a-config.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/adsense-a4a-config.js
@@ -79,11 +79,9 @@ export const URL_EXPERIMENT_MAPPING = {
  * @returns {boolean}
  */
 export function adsenseIsA4AEnabled(win, element, useRemoteHtml) {
-  if (useRemoteHtml) {
-    return false;
-  }
+  dev().assert(!useRemoteHtml, 'Adsense should never use remote.html');
   if (!isGoogleAdsA4AValidEnvironment(win) ||
-      !element.getAttribute('data-ad-client')) {
+      !element.getAttribute('data-ad-client') || useRemoteHtml) {
     return false;
   }
   // See if in holdback control/experiment.

--- a/extensions/amp-ad-network-cloudflare-impl/0.1/cloudflare-a4a-config.js
+++ b/extensions/amp-ad-network-cloudflare-impl/0.1/cloudflare-a4a-config.js
@@ -16,11 +16,13 @@
 
 /**
  * Determines which tags desire A4A handling
- *
+ * @param {!Window} win
+ * @param {!Element} element
+ * @param {!boolean} useRemoteHtml
  * @returns {boolean}
  */
-export function cloudflareIsA4AEnabled() {
+export function cloudflareIsA4AEnabled(win, element, useRemoteHtml) {
   // We assume fast fetch for all content, but this will gracefully degrade,
   // when non-a4a content is delivered
-  return true;
+  return useRemoteHtml;
 }

--- a/extensions/amp-ad-network-cloudflare-impl/0.1/test/test-amp-ad-network-cloudflare-impl.js
+++ b/extensions/amp-ad-network-cloudflare-impl/0.1/test/test-amp-ad-network-cloudflare-impl.js
@@ -41,7 +41,7 @@ describes.realWin('cloudflare-a4a-config', {
       src: '/ad.html',
       'data-cf-a4a': 'true',
     });
-    expect(cloudflareIsA4AEnabled(win, el)).to.be.true;
+    expect(cloudflareIsA4AEnabled(win, el, true)).to.be.true;
   });
 });
 

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
@@ -154,6 +154,9 @@ export class DoubleclickA4aEligibility {
       return experimentId ==
           DOUBLECLICK_EXPERIMENT_FEATURE.UNCONDITIONED_FF_EXPERIMENT;
     }
+    if (useRemoteHtml && !element.getAttribute('rtc-config')) {
+      return false;
+    }
     if ('useSameDomainRenderingUntilDeprecated' in element.dataset ||
         element.hasAttribute('useSameDomainRenderingUntilDeprecated')) {
       return false;

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
@@ -60,6 +60,8 @@ export const DOUBLECLICK_EXPERIMENT_FEATURE = {
   CACHE_EXTENSION_INJECTION_EXP: '21060956',
   IDENTITY_CONTROL: '21060937',
   IDENTITY_EXPERIMENT: '21060938',
+  UNCONDITIONED_FF_CONTROL: 'foo',
+  UNCONDITIONED_FF_EXPERIMENT: 'bar'
 };
 
 /** @const @type {!Object<string,?string>} */
@@ -116,6 +118,18 @@ export class DoubleclickA4aEligibility {
     return googleCdnProxyRegex.test(win.location.origin);
   }
 
+  /**
+   * Attempts to select into Fast Fetch
+   */
+  unconditionedSelection_() {
+    const experimentId = this.maybeSelectExperiment(win, element, [
+      DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_CONTROL,
+      DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_EXPERIMENT,
+    ], DFP_CANONICAL_FF_EXPERIMENT_NAME)
+    addExperimentIdToElement(experimentId, element);
+      forceExperimentBranch(win, DOUBLECLICK_A4A_EXPERIMENT_NAME, experimentId);
+  }
+
   /** Whether Fast Fetch is enabled
    * @param {!Window} win
    * @param {!Element} element
@@ -123,6 +137,9 @@ export class DoubleclickA4aEligibility {
    * @return {boolean}
    */
   isA4aEnabled(win, element, useRemoteHtml) {
+    if (this.unconditionedSelection_()) {
+      return true;
+    }
     let experimentId;
     if ('useSameDomainRenderingUntilDeprecated' in element.dataset ||
         element.hasAttribute('useSameDomainRenderingUntilDeprecated')) {
@@ -202,6 +219,7 @@ const singleton = new DoubleclickA4aEligibility();
 /**
  * @param {!Window} win
  * @param {!Element} element
+ * @param {!boolean} useRemoteHtml
  * @returns {boolean}
  */
 export function doubleclickIsA4AEnabled(win, element, useRemoteHtml) {

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
@@ -180,8 +180,8 @@ export class DoubleclickA4aEligibility {
                              DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_EXPERIMENT],
        experimentName: DFP_CANONICAL_FF_EXPERIMENT_NAME,
        diversionCriteria: () => {
-         return isFastFetchEligible && !isCdnProxy && !urlExperimentId == -1
-             || !isDevMode;
+         return isFastFetchEligible && !isCdnProxy && (urlExperimentId != -1
+                                                       || !isDevMode);
        }},
       /******************* HOLDBACK INTERNAL EXPERIMENT ***********************/
       {experimentBranchIds: [DOUBLECLICK_EXPERIMENT_FEATURE.HOLDBACK_INTERNAL_CONTROL,
@@ -248,7 +248,7 @@ export class DoubleclickA4aEligibility {
       }
     });
     console.log(this.activeExperiments_);
-    return isFastFetchEligible;
+    return isFastFetchEligible && this.isCdnProxy(win);
   }
 
   /** Whether Fast Fetch is enabled

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
@@ -41,6 +41,10 @@ export const DOUBLECLICK_A4A_EXPERIMENT_NAME = 'expDoubleclickA4A';
 /** @const {string} */
 export const DFP_CANONICAL_FF_EXPERIMENT_NAME = 'expDfpCanonicalFf';
 
+/** @const {string} */
+export const DOUBLECLICK_UNCONDITIONED_EXPERIMENT_NAME =
+    'expUnconditionedDoubleclick';
+
 /** @type {string} */
 const TAG = 'amp-ad-network-doubleclick-impl';
 
@@ -60,8 +64,8 @@ export const DOUBLECLICK_EXPERIMENT_FEATURE = {
   CACHE_EXTENSION_INJECTION_EXP: '21060956',
   IDENTITY_CONTROL: '21060937',
   IDENTITY_EXPERIMENT: '21060938',
-  UNCONDITIONED_FF_CONTROL: 'foo',
-  UNCONDITIONED_FF_EXPERIMENT: 'bar'
+  UNCONDITIONED_FF_CONTROL: '21061145',
+  UNCONDITIONED_FF_EXPERIMENT: '21061146',
 };
 
 /** @const @type {!Object<string,?string>} */
@@ -120,14 +124,22 @@ export class DoubleclickA4aEligibility {
 
   /**
    * Attempts to select into Fast Fetch
+   * @param {!Window} win
+   * @param {!Element} element
+   * @private
+   * @return {?string}
    */
-  unconditionedSelection_() {
+  unconditionedSelection_(win, element) {
     const experimentId = this.maybeSelectExperiment(win, element, [
-      DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_CONTROL,
-      DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_EXPERIMENT,
-    ], DFP_CANONICAL_FF_EXPERIMENT_NAME)
-    addExperimentIdToElement(experimentId, element);
-      forceExperimentBranch(win, DOUBLECLICK_A4A_EXPERIMENT_NAME, experimentId);
+      DOUBLECLICK_EXPERIMENT_FEATURE.UNCONDITIONED_FF_CONTROL,
+      DOUBLECLICK_EXPERIMENT_FEATURE.UNCONDITIONED_FF_EXPERIMENT,
+    ], DOUBLECLICK_UNCONDITIONED_EXPERIMENT_NAME);
+    if (experimentId) {
+      addExperimentIdToElement(experimentId, element);
+      forceExperimentBranch(
+          win, DOUBLECLICK_UNCONDITIONED_EXPERIMENT_NAME, experimentId);
+    }
+    return experimentId;
   }
 
   /** Whether Fast Fetch is enabled
@@ -137,10 +149,11 @@ export class DoubleclickA4aEligibility {
    * @return {boolean}
    */
   isA4aEnabled(win, element, useRemoteHtml) {
-    if (this.unconditionedSelection_()) {
-      return true;
+    let experimentId = this.unconditionedSelection_(win, element);
+    if (experimentId != null) {
+      return experimentId ==
+          DOUBLECLICK_EXPERIMENT_FEATURE.UNCONDITIONED_FF_EXPERIMENT;
     }
-    let experimentId;
     if ('useSameDomainRenderingUntilDeprecated' in element.dataset ||
         element.hasAttribute('useSameDomainRenderingUntilDeprecated')) {
       return false;
@@ -199,7 +212,7 @@ export class DoubleclickA4aEligibility {
    * @param {!Array<string>} selectionBranches
    * @param {!string} experimentName}
    * @return {?string} Experiment branch ID or null if not selected.
-   * @visibileForTesting
+   * @visibleForTesting
    */
   maybeSelectExperiment(win, element, selectionBranches, experimentName) {
     const experimentInfoMap =

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
@@ -147,8 +147,8 @@ export class DoubleclickA4aEligibility {
       addExperimentIdToElement(experimentId, element);
       forceExperimentBranch(
           win, DOUBLECLICK_UNCONDITIONED_EXPERIMENT_NAME, experimentId);
+      this.activeExperiments_[experimentId] = true;
     }
-    this.activeExperiments_[experimentId] = true;
   }
 
   selectA4aExperiments(win, element, useRemoteHtml) {
@@ -213,7 +213,7 @@ export class DoubleclickA4aEligibility {
       if (experiment.diversionCriteria()) {
         experimentId = experiment.forceExperimentId || this.maybeSelectExperiment(
             win, element, experiment.experimentBranchIds, experiment.experimentName)
-        if (experimentId) {
+        if (!!experimentId) {
           addExperimentIdToElement(experimentId, element);
           forceExperimentBranch(win, DOUBLECLICK_A4A_EXPERIMENT_NAME, experimentId);
           this.activeExperiments_[experimentId] = true;
@@ -247,6 +247,7 @@ export class DoubleclickA4aEligibility {
         return false;
       }
     });
+    console.log(this.activeExperiments_);
     return isFastFetchEligible;
   }
 

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
@@ -119,9 +119,10 @@ export class DoubleclickA4aEligibility {
   /** Whether Fast Fetch is enabled
    * @param {!Window} win
    * @param {!Element} element
+   * @param {!boolean} useRemoteHtml
    * @return {boolean}
    */
-  isA4aEnabled(win, element) {
+  isA4aEnabled(win, element, useRemoteHtml) {
     let experimentId;
     if ('useSameDomainRenderingUntilDeprecated' in element.dataset ||
         element.hasAttribute('useSameDomainRenderingUntilDeprecated')) {
@@ -203,8 +204,8 @@ const singleton = new DoubleclickA4aEligibility();
  * @param {!Element} element
  * @returns {boolean}
  */
-export function doubleclickIsA4AEnabled(win, element) {
-  return singleton.isA4aEnabled(win, element);
+export function doubleclickIsA4AEnabled(win, element, useRemoteHtml) {
+  return singleton.isA4aEnabled(win, element, useRemoteHtml);
 }
 
 /**

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
@@ -69,7 +69,7 @@ export const DOUBLECLICK_EXPERIMENT_FEATURE = {
 export const DOUBLECLICK_UNCONDITIONED_EXPERIMENTS = {
   FF_CANONICAL_CTL: '21061145',
   FF_CANONICAL_EXP: '21061146',
-}
+};
 
 /** @const @type {!Object<string,?string>} */
 export const URL_EXPERIMENT_MAPPING = {
@@ -98,16 +98,21 @@ export const BETA_ATTRIBUTE = 'data-use-beta-a4a-implementation';
 /** @const {string} */
 export const BETA_EXPERIMENT_ID = '2077831';
 
+/** @typedef {{
+    forceExperimentId: (string|undefined),
+    experimentName: !string,
+    diversionCriteria: (Function|undefined),
+    experimentBranchIds: (!Array<string>|undefined)}} */
+let A4A_EXPERIMENT_TYPE;
+
 /**
  * Class for checking whether a page/element is eligible for Fast Fetch.
  * Singleton class.
  * @visibleForTesting
  */
 export class DoubleclickA4aEligibility {
-
   constructor() {
-    this.unconditionedExperiments_ = {};
-    this.experiment;
+    this.activeExperiments_ = {};
   }
   /**
    * Returns whether win supports native crypto. Is just a wrapper around
@@ -131,31 +136,12 @@ export class DoubleclickA4aEligibility {
   }
 
   /**
-   * Attempts to select into Fast Fetch
+   * Attempts to select into all A4A experiments as defined in the two arrays
+   * of experiments: unconditionedExperiments and conditionedExperiments.
    * @param {!Window} win
    * @param {!Element} element
-   * @private
-   * @return {?string}
+   * @param {!boolean} useRemoteHtml
    */
-  unconditionedSelection_(win, element) {
-    const unconditionedExperiments = [
-      {branches: [DOUBLECLICK_UNCONDITIONED_EXPERIMENTS.FF_CANONICAL_CTL,
-                  DOUBLECLICK_UNCONDITIONED_EXPERIMENTS.FF_CANONICAL_EXP],
-       name: DOUBLECLICK_UNCONDITIONED_EXPERIMENT_NAME},
-    ];
-    let experimentId;
-    unconditionedExperiments.forEach(experiment => {
-      experimentId = this.maybeSelectExperiment(
-          win, element, experiment.branches, experiment.name);
-      if (experimentId) {
-        addExperimentIdToElement(experimentId, element);
-        forceExperimentBranch(
-            win, DOUBLECLICK_UNCONDITIONED_EXPERIMENT_NAME, experimentId);
-        this.unconditionedExperiments_[experimentId] = true;
-      }
-    });
-  }
-
   selectA4aExperiments(win, element, useRemoteHtml) {
     const urlExperimentId = extractUrlExperimentId(win, element);
     const isFastFetchEligible =
@@ -165,84 +151,121 @@ export class DoubleclickA4aEligibility {
     const isCdnProxy = this.isCdnProxy(win);
     const isDevMode = (getMode(win).localDev || getMode(win).test);
     const hasBetaAttribute = element.hasAttribute(BETA_ATTRIBUTE);
+
+    /**
+     * Definition of unconditioned A4A experiments. For a given experiment, we will
+     * attempt to select into the experiment unconditionally.
+     */
+    /** @type {!Array<A4A_EXPERIMENT_TYPE>} */
+    const unconditionedExperiments = [
+      /****** CANONICAL FAST FETCH UNCONDITIONED EXPERIMENT *******************/
+      {experimentBranchIds: [
+        DOUBLECLICK_UNCONDITIONED_EXPERIMENTS.FF_CANONICAL_CTL,
+        DOUBLECLICK_UNCONDITIONED_EXPERIMENTS.FF_CANONICAL_EXP],
+        experimentName: DOUBLECLICK_UNCONDITIONED_EXPERIMENT_NAME},
+    ];
     /**
      * Definition of A4A experiments. For each experiment, if forceExperimentBranch is
      * provided, then if the diversion criteria passes, we force on that experiment.
      * If experimentBranchIds is provided, then if the diversionCriteria passes, we
      * attempt to randomly select into one of the provided experiment branch IDs.
      */
+    /** @type {!Array<A4A_EXPERIMENT_TYPE>} */
     const conditionedExperiments = [
       /************************** MANUAL EXPERIMENT ***************************/
       {forceExperimentId: MANUAL_EXPERIMENT_ID,
-       experimentName: DOUBLECLICK_A4A_EXPERIMENT_NAME,
-       diversionCriteria: () => {
-         return isFastFetchEligible && !isCdnProxy && urlExperimentId == -1
+        experimentName: DOUBLECLICK_A4A_EXPERIMENT_NAME,
+        diversionCriteria: () => {
+          return isFastFetchEligible && !isCdnProxy && urlExperimentId == -1
              && isDevMode;
-       }},
+        }},
       /****************** CANONICAL FAST FETCH EXPERIMENT *********************/
       {experimentBranchIds: [DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_CONTROL,
-                             DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_EXPERIMENT],
-       experimentName: DFP_CANONICAL_FF_EXPERIMENT_NAME,
-       diversionCriteria: () => {
-         return isFastFetchEligible && !isCdnProxy &&
+        DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_EXPERIMENT],
+        experimentName: DFP_CANONICAL_FF_EXPERIMENT_NAME,
+        diversionCriteria: () => {
+          return isFastFetchEligible && !isCdnProxy &&
              (urlExperimentId != -1 || !isDevMode) &&
-             !this.unconditionedExperiments_[
-               DOUBLECLICK_UNCONDITIONED_EXPERIMENTS.CANONICAL_CONTROL] &&
-             !this.unconditionedExperiments_[
-               DOUBLECLICK_UNCONDITIONED_EXPERIMENTS.CANONICAL_EXPERIMENT];
-       }},
+             !this.activeExperiments_[
+                 DOUBLECLICK_UNCONDITIONED_EXPERIMENTS.FF_CANONICAL_CTL] &&
+             !this.activeExperiments_[
+                 DOUBLECLICK_UNCONDITIONED_EXPERIMENTS.FF_CANONICAL_EXP];
+        }},
       /******************* HOLDBACK INTERNAL EXPERIMENT ***********************/
-      {experimentBranchIds: [DOUBLECLICK_EXPERIMENT_FEATURE.HOLDBACK_INTERNAL_CONTROL,
-                             DOUBLECLICK_EXPERIMENT_FEATURE.HOLDBACK_INTERNAL],
-       experimentName: DOUBLECLICK_A4A_EXPERIMENT_NAME,
-       diversionCriteria: () => {
-         return isFastFetchEligible && isCdnProxy && urlExperimentId == undefined &&
-             !hasBetaAttribute;
-       }
+      {experimentBranchIds: [
+        DOUBLECLICK_EXPERIMENT_FEATURE.HOLDBACK_INTERNAL_CONTROL,
+        DOUBLECLICK_EXPERIMENT_FEATURE.HOLDBACK_INTERNAL,
+      ],
+        experimentName: DOUBLECLICK_A4A_EXPERIMENT_NAME,
+        diversionCriteria: () => {
+          return isFastFetchEligible && isCdnProxy &&
+             urlExperimentId == undefined && !hasBetaAttribute;
+        },
       },
       /****************** URL EXPERIMENT SELECTION ****************************/
-      {forceExperimentId: urlExperimentId ? URL_EXPERIMENT_MAPPING[urlExperimentId] : null,
-       experimentName: DOUBLECLICK_A4A_EXPERIMENT_NAME,
-       diversionCriteria: () => {
-         return isFastFetchEligible && isCdnProxy && urlExperimentId != undefined &&
-             !hasBetaAttribute;
-       }
+      {forceExperimentId: urlExperimentId ?
+       URL_EXPERIMENT_MAPPING[urlExperimentId] : null,
+        experimentName: DOUBLECLICK_A4A_EXPERIMENT_NAME,
+        diversionCriteria: () => {
+          return isFastFetchEligible && isCdnProxy &&
+              urlExperimentId != undefined && !hasBetaAttribute;
+        },
       },
       /***************** BETA EXPERIMENT SELECTION ****************************/
       {forceExperimentId: BETA_EXPERIMENT_ID,
-       experimentName: DOUBLECLICK_A4A_EXPERIMENT_NAME,
-       diversionCriteria: () => {
-         return isFastFetchEligible && isCdnProxy && hasBetaAttribute;
-       }
+        experimentName: DOUBLECLICK_A4A_EXPERIMENT_NAME,
+        diversionCriteria: () => {
+          return isFastFetchEligible && isCdnProxy && hasBetaAttribute;
+        },
       },
     ];
-    this.unconditionedSelection_(win, element);
+    /********* Unconditioned Experiment Selection *******************************/
+    this.experimentSelection(win, element, unconditionedExperiments);
     /********** Conditioned Experiment Selection *******************************/
-    this.conditionedExperimentSelection(win, element, conditionedExperiments);
+    this.experimentSelection(win, element, conditionedExperiments);
   }
 
-  conditionedExperimentSelection(win, element, experiments) {
+  /**
+   * Attempts to select into all A4A experiments as defined in the two arrays
+   * of experiments: unconditionedExperiments and conditionedExperiments.
+   * @param {!Window} win
+   * @param {!Element} element
+   * @param {!Array<A4A_EXPERIMENT_TYPE>} experiments
+   */
+  experimentSelection(win, element, experiments) {
     let experimentId;
     experiments.forEach(experiment => {
-      if (experiment.diversionCriteria()) {
-        experimentId = experiment.forceExperimentId || this.maybeSelectExperiment(
-            win, element, experiment.experimentBranchIds, experiment.experimentName)
+      // If diversionCriteria is undefined, then it is an unconditioned experiment.
+      if ((experiment.diversionCriteria && experiment.diversionCriteria()) ||
+          experiment.diversionCriteria == undefined) {
+        experimentId = experiment.forceExperimentId ||
+            this.maybeSelectExperiment(
+                win, element,
+                /** @type {!Array<string>}*/(experiment.experimentBranchIds),
+                experiment.experimentName);
         if (!!experimentId) {
           addExperimentIdToElement(experimentId, element);
-          forceExperimentBranch(win, DOUBLECLICK_A4A_EXPERIMENT_NAME, experimentId);
-          this.experiment = experimentId;
+          forceExperimentBranch(win, experiment.experimentName, experimentId);
+          this.activeExperiments_[experimentId] = true;
         }
       }
     });
   }
 
-  shouldUseFastFetch(win, element, useRemoteHtml) {
+  /**
+   * @param {!Window} win
+   * @param {!Element} element
+   * @param {!boolean} useRemoteHtml
+   * @return {boolean}
+   */
+  fastFetchSelection(win, element, useRemoteHtml) {
     const urlExperimentId = extractUrlExperimentId(win, element);
+    const isDevMode = (getMode(win).localDev || getMode(win).test);
     /************ FF Selection Criteria for Unconditioned Exp *************/
     const fastFetchExperimentConditions = {};
     fastFetchExperimentConditions[
       DOUBLECLICK_UNCONDITIONED_EXPERIMENTS.FF_CANONICAL_EXP] = () => {
-      return !((useRemoteHtml && !element.getAttribute('rtc-config')) ||
+        return !((useRemoteHtml && !element.getAttribute('rtc-config')) ||
                'useSameDomainRenderingUntilDeprecated' in element.dataset ||
                element.hasAttribute('useSameDomainRenderingUntilDeprecated')) &&
             !this.isCdnProxy(win) && (urlExperimentId != -1 || !isDevMode);
@@ -268,21 +291,25 @@ export class DoubleclickA4aEligibility {
       exp.HOLDBACK_EXTERNAL,
       exp.HOLDBACK_INTERNAL,
       exp.CANONICAL_CONTROL,
-      DOUBLECLICK_UNCONDITIONED_EXPERIMENTS.FF_CANONICAL_CTL
+      DOUBLECLICK_UNCONDITIONED_EXPERIMENTS.FF_CANONICAL_CTL,
     ];
 
-    /***************** Attempt to select into Fast Fetch *******************/
-    const unconditionedExpIds = Object.keys(this.unconditionedExperiments_);
-    for (let i in unconditionedExpIds) {
-      let expId = unconditionedExpIds[i];
+    /**** For unconditioned experiments, attempt to select into Fast Fetch */
+    const activeExpIds = Object.keys(this.activeExperiments_);
+    for (const expId in this.activeExperiments_) {
       if (fastFetchExperimentConditions[expId]) {
         return fastFetchExperimentConditions[expId]();
       }
     }
-    /************** If in FF/DF experiment, select accordingly  ************/
-    if (this.experiment && (fastFetchBranches.includes(this.experiment) ||
-                            delayedFetchBranches.includes(this.experiment))) {
-      return fastFetchBranches.includes(this.experiment);
+    /**
+     *  If in a conditioned experiment, select based on whether the branch is
+     *  designated as a Fast Fetch or Delayed Fetch branch.
+     */
+    for (const expId in this.activeExperiments_) {
+      if (fastFetchBranches.includes(expId) ||
+          delayedFetchBranches.includes(expId)) {
+        return fastFetchBranches.includes(expId);
+      }
     }
     /************** Default Fast Fetch Selection ***************************/
     return !(useRemoteHtml && !element.getAttribute('rtc-config')) &&
@@ -299,7 +326,7 @@ export class DoubleclickA4aEligibility {
    */
   isA4aEnabled(win, element, useRemoteHtml) {
     this.selectA4aExperiments(win, element, useRemoteHtml);
-    return this.shouldUseFastFetch(win, element, useRemoteHtml);
+    return this.fastFetchSelection(win, element, useRemoteHtml);
   }
 
   /**
@@ -322,7 +349,7 @@ export class DoubleclickA4aEligibility {
   }
 }
 
-/** @const {!DoubleclickA4aEligibility} */
+/** @type {!DoubleclickA4aEligibility} */
 let singleton = new DoubleclickA4aEligibility();
 
 /**
@@ -335,6 +362,9 @@ export function doubleclickIsA4AEnabled(win, element, useRemoteHtml) {
   return singleton.isA4aEnabled(win, element, useRemoteHtml);
 }
 
+/**
+ * Resets state of singleton.
+ */
 export function resetForTesting() {
   singleton = new DoubleclickA4aEligibility();
 }

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-a4a-config.js
@@ -79,14 +79,6 @@ describe('doubleclick-a4a-config', () => {
       expect(doubleclickIsA4AEnabled(mockWin, elem)).to.be.true;
     });
 
-    it('should not enable a4a when native crypto is not supported', () => {
-      sandbox.stub(DoubleclickA4aEligibility.prototype,
-          'supportsCrypto', () => false);
-      const elem = testFixture.doc.createElement('div');
-      testFixture.doc.body.appendChild(elem);
-      expect(doubleclickIsA4AEnabled(mockWin, elem)).to.be.false;
-    });
-
     it('should select into canonical AMP experiment when not on CDN', () => {
       sandbox.stub(DoubleclickA4aEligibility.prototype,
           'isCdnProxy', () => false);

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-a4a-config.js
@@ -21,6 +21,8 @@ import {
   DFP_CANONICAL_FF_EXPERIMENT_NAME,
   DOUBLECLICK_A4A_EXPERIMENT_NAME,
   DOUBLECLICK_EXPERIMENT_FEATURE,
+  DOUBLECLICK_UNCONDITIONED_EXPERIMENT_NAME,
+  DOUBLECLICK_UNCONDITIONED_EXPERIMENTS,
   URL_EXPERIMENT_MAPPING,
   DoubleclickA4aEligibility,
   resetForTesting,
@@ -93,7 +95,7 @@ describe('doubleclick-a4a-config', () => {
         DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_CONTROL,
         DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_EXPERIMENT,
       ], DFP_CANONICAL_FF_EXPERIMENT_NAME) ;
-      expect(maybeSelectExperimentSpy.callCount).to.equal(1);
+      expect(maybeSelectExperimentSpy.callCount).to.equal(2);
     });
 
     it('should return false if no canonical AMP experiment branch', () => {
@@ -131,7 +133,7 @@ describe('doubleclick-a4a-config', () => {
       testFixture.doc.body.appendChild(elem);
       expect(doubleclickIsA4AEnabled(mockWin, elem)).to.be.false;
       expect(elem.getAttribute(EXPERIMENT_ATTRIBUTE)).to.not.be.ok;
-      expect(maybeSelectExperimentStub).to.be.calledOnce;
+      expect(maybeSelectExperimentStub).to.be.calledTwice;
     });
 
     it('should not enable if data-use-same-domain-rendering-until-deprecated',
@@ -201,25 +203,37 @@ describe('doubleclick-a4a-config', () => {
     });
 
     it('should only select once if put into unconditioned exp', () => {
-      const maybeSelectExperimentStub = sandbox.stub(
-          DoubleclickA4aEligibility.prototype, 'maybeSelectExperiment')
-          .returns(DOUBLECLICK_EXPERIMENT_FEATURE.UNCONDITIONED_FF_EXPERIMENT);
+      sandbox.stub(DoubleclickA4aEligibility.prototype,
+          'isCdnProxy', () => false);
       const elem = testFixture.doc.createElement('div');
       testFixture.doc.body.appendChild(elem);
+      const maybeSelectExperimentStub = sandbox.stub(
+          DoubleclickA4aEligibility.prototype, 'maybeSelectExperiment').withArgs(
+              mockWin, elem, [
+                DOUBLECLICK_UNCONDITIONED_EXPERIMENTS.FF_CANONICAL_CTL,
+                DOUBLECLICK_UNCONDITIONED_EXPERIMENTS.FF_CANONICAL_EXP],
+              DOUBLECLICK_UNCONDITIONED_EXPERIMENT_NAME)
+          .returns(DOUBLECLICK_UNCONDITIONED_EXPERIMENTS.FF_CANONICAL_EXP);
       expect(doubleclickIsA4AEnabled(mockWin, elem)).to.be.true;
       expect(elem.getAttribute(EXPERIMENT_ATTRIBUTE)).to.equal(
-          DOUBLECLICK_EXPERIMENT_FEATURE.UNCONDITIONED_FF_EXPERIMENT);
+          DOUBLECLICK_UNCONDITIONED_EXPERIMENTS.FF_CANONICAL_EXP);
       expect(maybeSelectExperimentStub).to.be.calledOnce;
     });
     it('should only select once if put into unconditioned control', () => {
-      const maybeSelectExperimentStub = sandbox.stub(
-          DoubleclickA4aEligibility.prototype, 'maybeSelectExperiment')
-          .returns(DOUBLECLICK_EXPERIMENT_FEATURE.UNCONDITIONED_FF_CONTROL);
+      sandbox.stub(DoubleclickA4aEligibility.prototype,
+          'isCdnProxy', () => false);
       const elem = testFixture.doc.createElement('div');
       testFixture.doc.body.appendChild(elem);
+      const maybeSelectExperimentStub = sandbox.stub(
+          DoubleclickA4aEligibility.prototype, 'maybeSelectExperiment').withArgs(
+              mockWin, elem, [
+                DOUBLECLICK_UNCONDITIONED_EXPERIMENTS.FF_CANONICAL_CTL,
+                DOUBLECLICK_UNCONDITIONED_EXPERIMENTS.FF_CANONICAL_EXP],
+              DOUBLECLICK_UNCONDITIONED_EXPERIMENT_NAME)
+          .returns(DOUBLECLICK_UNCONDITIONED_EXPERIMENTS.FF_CANONICAL_CTL);
       expect(doubleclickIsA4AEnabled(mockWin, elem)).to.be.false;
       expect(elem.getAttribute(EXPERIMENT_ATTRIBUTE)).to.equal(
-          DOUBLECLICK_EXPERIMENT_FEATURE.UNCONDITIONED_FF_CONTROL);
+          DOUBLECLICK_UNCONDITIONED_EXPERIMENTS.FF_CANONICAL_CTL);
       expect(maybeSelectExperimentStub).to.be.calledOnce;
     });
   });

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-a4a-config.js
@@ -23,6 +23,7 @@ import {
   DOUBLECLICK_EXPERIMENT_FEATURE,
   URL_EXPERIMENT_MAPPING,
   DoubleclickA4aEligibility,
+  resetForTesting,
 } from '../doubleclick-a4a-config';
 import {
   isInExperiment,
@@ -41,6 +42,7 @@ describe('doubleclick-a4a-config', () => {
   let testFixture;
 
   beforeEach(() => {
+    resetForTesting();
     sandbox = sinon.sandbox.create();
     mockWin = {
       location: parseUrl('https://nowhere.org/a/place/page.html?s=foo&q=bar'),
@@ -91,8 +93,7 @@ describe('doubleclick-a4a-config', () => {
         DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_CONTROL,
         DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_EXPERIMENT,
       ], DFP_CANONICAL_FF_EXPERIMENT_NAME) ;
-      expect(maybeSelectExperimentSpy.callCount).to.equal(2);
-
+      expect(maybeSelectExperimentSpy.callCount).to.equal(1);
     });
 
     it('should return false if no canonical AMP experiment branch', () => {
@@ -130,14 +131,14 @@ describe('doubleclick-a4a-config', () => {
       testFixture.doc.body.appendChild(elem);
       expect(doubleclickIsA4AEnabled(mockWin, elem)).to.be.false;
       expect(elem.getAttribute(EXPERIMENT_ATTRIBUTE)).to.not.be.ok;
-      expect(maybeSelectExperimentStub).to.be.calledTwice;
+      expect(maybeSelectExperimentStub).to.be.calledOnce;
     });
 
     it('should not enable if data-use-same-domain-rendering-until-deprecated',
         () => {
           const elem = testFixture.doc.createElement('div');
           elem.setAttribute(
-              'data-use-same-domain-rendering-until-deprecated', '');
+              'useSameDomainRenderingUntilDeprecated', '');
           testFixture.doc.body.appendChild(elem);
           expect(doubleclickIsA4AEnabled(mockWin, elem)).to.be.false;
           expect(elem.getAttribute(EXPERIMENT_ATTRIBUTE)).to.not.be.ok;

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-a4a-config.js
@@ -208,12 +208,13 @@ describe('doubleclick-a4a-config', () => {
       const elem = testFixture.doc.createElement('div');
       testFixture.doc.body.appendChild(elem);
       const maybeSelectExperimentStub = sandbox.stub(
-          DoubleclickA4aEligibility.prototype, 'maybeSelectExperiment').withArgs(
-              mockWin, elem, [
-                DOUBLECLICK_UNCONDITIONED_EXPERIMENTS.FF_CANONICAL_CTL,
-                DOUBLECLICK_UNCONDITIONED_EXPERIMENTS.FF_CANONICAL_EXP],
-              DOUBLECLICK_UNCONDITIONED_EXPERIMENT_NAME)
-          .returns(DOUBLECLICK_UNCONDITIONED_EXPERIMENTS.FF_CANONICAL_EXP);
+          DoubleclickA4aEligibility.prototype,
+          'maybeSelectExperiment').withArgs(
+          mockWin, elem, [
+            DOUBLECLICK_UNCONDITIONED_EXPERIMENTS.FF_CANONICAL_CTL,
+            DOUBLECLICK_UNCONDITIONED_EXPERIMENTS.FF_CANONICAL_EXP],
+          DOUBLECLICK_UNCONDITIONED_EXPERIMENT_NAME)
+            .returns(DOUBLECLICK_UNCONDITIONED_EXPERIMENTS.FF_CANONICAL_EXP);
       expect(doubleclickIsA4AEnabled(mockWin, elem)).to.be.true;
       expect(elem.getAttribute(EXPERIMENT_ATTRIBUTE)).to.equal(
           DOUBLECLICK_UNCONDITIONED_EXPERIMENTS.FF_CANONICAL_EXP);
@@ -225,12 +226,13 @@ describe('doubleclick-a4a-config', () => {
       const elem = testFixture.doc.createElement('div');
       testFixture.doc.body.appendChild(elem);
       const maybeSelectExperimentStub = sandbox.stub(
-          DoubleclickA4aEligibility.prototype, 'maybeSelectExperiment').withArgs(
-              mockWin, elem, [
-                DOUBLECLICK_UNCONDITIONED_EXPERIMENTS.FF_CANONICAL_CTL,
-                DOUBLECLICK_UNCONDITIONED_EXPERIMENTS.FF_CANONICAL_EXP],
-              DOUBLECLICK_UNCONDITIONED_EXPERIMENT_NAME)
-          .returns(DOUBLECLICK_UNCONDITIONED_EXPERIMENTS.FF_CANONICAL_CTL);
+          DoubleclickA4aEligibility.prototype,
+          'maybeSelectExperiment').withArgs(
+          mockWin, elem, [
+            DOUBLECLICK_UNCONDITIONED_EXPERIMENTS.FF_CANONICAL_CTL,
+            DOUBLECLICK_UNCONDITIONED_EXPERIMENTS.FF_CANONICAL_EXP],
+          DOUBLECLICK_UNCONDITIONED_EXPERIMENT_NAME)
+            .returns(DOUBLECLICK_UNCONDITIONED_EXPERIMENTS.FF_CANONICAL_CTL);
       expect(doubleclickIsA4AEnabled(mockWin, elem)).to.be.false;
       expect(elem.getAttribute(EXPERIMENT_ATTRIBUTE)).to.equal(
           DOUBLECLICK_UNCONDITIONED_EXPERIMENTS.FF_CANONICAL_CTL);

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-a4a-config.js
@@ -99,7 +99,7 @@ describe('doubleclick-a4a-config', () => {
         DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_CONTROL,
         DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_EXPERIMENT,
       ], DFP_CANONICAL_FF_EXPERIMENT_NAME) ;
-      expect(maybeSelectExperimentSpy.callCount).to.equal(1);
+      expect(maybeSelectExperimentSpy.callCount).to.equal(2);
 
     });
 
@@ -138,7 +138,7 @@ describe('doubleclick-a4a-config', () => {
       testFixture.doc.body.appendChild(elem);
       expect(doubleclickIsA4AEnabled(mockWin, elem)).to.be.false;
       expect(elem.getAttribute(EXPERIMENT_ATTRIBUTE)).to.not.be.ok;
-      expect(maybeSelectExperimentStub).to.be.calledOnce;
+      expect(maybeSelectExperimentStub).to.be.calledTwice;
     });
 
     it('should not enable if data-use-same-domain-rendering-until-deprecated',
@@ -205,6 +205,29 @@ describe('doubleclick-a4a-config', () => {
       testFixture.doc.body.appendChild(elem);
       expect(doubleclickIsA4AEnabled(mockWin, elem)).to.be.true;
       expect(elem.getAttribute(EXPERIMENT_ATTRIBUTE)).to.equal('2092613');
+    });
+
+    it('should only select once if put into unconditioned exp', () => {
+      const maybeSelectExperimentStub = sandbox.stub(
+          DoubleclickA4aEligibility.prototype, 'maybeSelectExperiment')
+          .returns(DOUBLECLICK_EXPERIMENT_FEATURE.UNCONDITIONED_FF_EXPERIMENT);
+      const elem = testFixture.doc.createElement('div');
+      testFixture.doc.body.appendChild(elem);
+      expect(doubleclickIsA4AEnabled(mockWin, elem)).to.be.true;
+      expect(elem.getAttribute(EXPERIMENT_ATTRIBUTE)).to.equal(
+          DOUBLECLICK_EXPERIMENT_FEATURE.UNCONDITIONED_FF_EXPERIMENT);
+      expect(maybeSelectExperimentStub).to.be.calledOnce;
+    });
+    it('should only select once if put into unconditioned control', () => {
+      const maybeSelectExperimentStub = sandbox.stub(
+          DoubleclickA4aEligibility.prototype, 'maybeSelectExperiment')
+          .returns(DOUBLECLICK_EXPERIMENT_FEATURE.UNCONDITIONED_FF_CONTROL);
+      const elem = testFixture.doc.createElement('div');
+      testFixture.doc.body.appendChild(elem);
+      expect(doubleclickIsA4AEnabled(mockWin, elem)).to.be.false;
+      expect(elem.getAttribute(EXPERIMENT_ATTRIBUTE)).to.equal(
+          DOUBLECLICK_EXPERIMENT_FEATURE.UNCONDITIONED_FF_CONTROL);
+      expect(maybeSelectExperimentStub).to.be.calledOnce;
     });
   });
 });

--- a/extensions/amp-ad-network-gmossp-impl/0.1/gmossp-a4a-config.js
+++ b/extensions/amp-ad-network-gmossp-impl/0.1/gmossp-a4a-config.js
@@ -25,9 +25,13 @@ const GMOSSP_SRC_A4A_PREFIX_ = 'https://amp.sp.gmossp-sp.jp/_a4a/';
 /**
  * @param {!Window} win
  * @param {!Element} element
+ * @param {!boolean} useRemoteHtml
  * @returns {boolean}
  */
-export function gmosspIsA4AEnabled(win, element) {
+export function gmosspIsA4AEnabled(win, element, useRemoteHtml) {
+  if (useRemoteHtml) {
+    return false;
+  }
   const src = element.getAttribute('src');
   return !!element.getAttribute('data-use-a4a') && !!src &&
       (startsWith(src, GMOSSP_SRC_PREFIX_) ||

--- a/extensions/amp-ad-network-triplelift-impl/0.1/triplelift-a4a-config.js
+++ b/extensions/amp-ad-network-triplelift-impl/0.1/triplelift-a4a-config.js
@@ -19,9 +19,13 @@ const SRC_PREFIX_ = 'https://ib.3lift.com/';
 /**
  * @param {!Window} win
  * @param {!Element} element
+ * @param {!boolean} useRemoteHtml
  * @returns {boolean}
  */
-export function tripleliftIsA4AEnabled(win, element) {
+export function tripleliftIsA4AEnabled(win, element, useRemoteHtml) {
+  if (useRemoteHtml) {
+    return false;
+  }
   let src;
   return !!element.getAttribute('data-use-a4a') && !!(src =
     element.getAttribute('src')) && src.indexOf(SRC_PREFIX_) == 0;

--- a/extensions/amp-ad/0.1/amp-ad.js
+++ b/extensions/amp-ad/0.1/amp-ad.js
@@ -76,8 +76,7 @@ export class AmpAd extends AMP.BaseElement {
 
       const useRemoteHtml = (
           !(adConfig[type] || {}).remoteHTMLDisabled &&
-            this.win.document.querySelector('meta[name=amp-3p-iframe-src]') &&
-            !this.element.getAttribute('rtc-config'));
+            this.win.document.querySelector('meta[name=amp-3p-iframe-src]'));
       // TODO(tdrl): Check amp-ad registry to see if they have this already.
       // TODO(a4a-cam): Shorten this predicate.
       if (!a4aRegistry[type] ||

--- a/extensions/amp-ad/0.1/amp-ad.js
+++ b/extensions/amp-ad/0.1/amp-ad.js
@@ -74,14 +74,15 @@ export class AmpAd extends AMP.BaseElement {
       const slotId = this.win.ampAdSlotIdCounter++;
       this.element.setAttribute('data-amp-slot-index', slotId);
 
+      const useRemoteHtml = (
+          !(adConfig[type] || {}).remoteHTMLDisabled &&
+            this.win.document.querySelector('meta[name=amp-3p-iframe-src]') &&
+            !this.element.getAttribute('rtc-config'));
       // TODO(tdrl): Check amp-ad registry to see if they have this already.
       // TODO(a4a-cam): Shorten this predicate.
       if (!a4aRegistry[type] ||
-          (!(adConfig[type] || {}).remoteHTMLDisabled &&
-          this.win.document.querySelector('meta[name=amp-3p-iframe-src]') &&
-          !this.element.getAttribute('rtc-config')) ||
           // Note that predicate execution may have side effects.
-          !a4aRegistry[type](this.win, this.element)) {
+          !a4aRegistry[type](this.win, this.element, useRemoteHtml)) {
         // Either this ad network doesn't support Fast Fetch, its Fast Fetch
         // implementation has explicitly opted not to handle this tag, or this
         // page uses remote.html which is inherently incompatible with Fast

--- a/extensions/amp-ad/0.1/test/test-amp-ad.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad.js
@@ -137,7 +137,7 @@ describes.realWin('Ad loader', {amp: true}, env => {
         meta.setAttribute('content', 'https://example.com/remote.html');
         doc.head.appendChild(meta);
         a4aRegistry['zort'] = (win, element, useRemoteHtml) => {
-          return useRemoteHtml;
+          return !useRemoteHtml;
         };
         ampAdElement.setAttribute('type', 'zort');
         const upgraded = new AmpAd(ampAdElement).upgradeCallback();

--- a/extensions/amp-ad/0.1/test/test-amp-ad.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad.js
@@ -136,8 +136,8 @@ describes.realWin('Ad loader', {amp: true}, env => {
         meta.setAttribute('name', 'amp-3p-iframe-src');
         meta.setAttribute('content', 'https://example.com/remote.html');
         doc.head.appendChild(meta);
-        a4aRegistry['zort'] = () => {
-          throw new Error('predicate should not execute if remote.html!');
+        a4aRegistry['zort'] = (win, element, useRemoteHtml) => {
+          return useRemoteHtml;
         };
         ampAdElement.setAttribute('type', 'zort');
         const upgraded = new AmpAd(ampAdElement).upgradeCallback();

--- a/extensions/amp-ad/0.1/test/test-amp-ad.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad.js
@@ -136,9 +136,7 @@ describes.realWin('Ad loader', {amp: true}, env => {
         meta.setAttribute('name', 'amp-3p-iframe-src');
         meta.setAttribute('content', 'https://example.com/remote.html');
         doc.head.appendChild(meta);
-        a4aRegistry['zort'] = (win, element, useRemoteHtml) => {
-          return !useRemoteHtml;
-        };
+        a4aRegistry['zort'] = (win, element, useRemoteHtml) => !useRemoteHtml;
         ampAdElement.setAttribute('type', 'zort');
         const upgraded = new AmpAd(ampAdElement).upgradeCallback();
         return expect(upgraded).to.eventually.be.instanceof(AmpAd3PImpl);


### PR DESCRIPTION
Refactor how experiment selection works for Doubleclick A4A experiments.
Add ability to have unconditioned experiments.