### PR TITLE
amp-ima-video: Adding additional video analytics.

### DIFF
--- a/ads/google/ima-player-data.js
+++ b/ads/google/ima-player-data.js
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export class ImaPlayerData {
+
+  /**
+   * Create a new ImaPlayerData object.
+   */
+  constructor() {
+    /* {!Number} */
+    this.currentTime = 0;
+
+    /* {!Number} */
+    this.duration = 1;
+
+    /* {!Array} */
+    this.playedRanges = [];
+  }
+
+  /**
+   * Update from the provided video player.
+   *
+   * @param {!Element} videoPlayer
+   */
+  update(videoPlayer) {
+    this.currentTime = videoPlayer.currentTime;
+    this.duration = videoPlayer.duration;
+
+    // Adapt videoPlayer.played for the playedRanges format AMP wants.
+    const played = videoPlayer.played;
+    const length = played.length;
+    this.playedRanges = [];
+    for (let i = 0; i < length; i++) {
+      this.playedRanges.push([played.start(i), played.end(i)]);
+    }
+  }
+}
+
+/**
+ * Unique identifier for messages from the implementation iframe with data
+ * about the player.
+ * @const
+ */
+ImaPlayerData.IMA_PLAYER_DATA = 'imaPlayerData';

--- a/ads/google/imaVideo.js
+++ b/ads/google/imaVideo.js
@@ -15,6 +15,9 @@
  */
 
 import {camelCaseToTitleCase, setStyle} from '../../src/style';
+import {
+  ImaPlayerData
+} from '../../extensions/amp-ima-video/0.1/ima-player-data';
 import {isObject} from '../../src/types';
 import {loadScript} from '../../3p/3p';
 import {tryParseJson} from '../../src/json';
@@ -167,6 +170,9 @@ let videoWidth, videoHeight;
 
 // IMASettings provided via <script> tag in parent element.
 let imaSettings;
+
+// Player data used for video analytics.
+let playerData = new ImaPlayerData();
 
 /**
  * Loads the IMA SDK library.
@@ -477,6 +483,7 @@ function changeIcon(element, name, fill = '#FFFFFF') {
 export function onClick(global) {
   playbackStarted = true;
   uiTicker = setInterval(uiTickerClick, 500);
+  playerDataTicker = setInterval(playerDataTick, 1000);
   bigPlayDiv.removeEventListener(interactEvent, onClick);
   setStyle(bigPlayDiv, 'display', 'none');
   adDisplayContainer.initialize();
@@ -628,6 +635,25 @@ export function onContentResumeRequested() {
 function uiTickerClick() {
   updateUi(videoPlayer.currentTime, videoPlayer.duration);
 }
+
+/**
+ *  Called when our player data timer goes off. Sends a message to the parent
+ *  iframe to update the player data.
+ */
+function playerDataTick() {
+  // Skip while ads are active in case of custom playback. No harm done for
+  // non-custom playback because content won't be progressing while ads are
+  // playing.
+  if (videoPlayer && !adsActive) {
+    playerData.update(videoPlayer);
+    window.parent./*OK*/postMessage({
+      event: ImaPlayerData.IMA_PLAYER_DATA,
+      data: playerData
+    }, '*');
+  }
+}
+
+
 
 /**
  * Updates the video player UI.

--- a/ads/google/imaVideo.js
+++ b/ads/google/imaVideo.js
@@ -16,8 +16,8 @@
 
 import {camelCaseToTitleCase, setStyle} from '../../src/style';
 import {
-  ImaPlayerData
-} from '../../extensions/amp-ima-video/0.1/ima-player-data';
+  ImaPlayerData,
+} from './ima-player-data';
 import {isObject} from '../../src/types';
 import {loadScript} from '../../3p/3p';
 import {tryParseJson} from '../../src/json';
@@ -172,7 +172,7 @@ let videoWidth, videoHeight;
 let imaSettings;
 
 // Player data used for video analytics.
-let playerData = new ImaPlayerData();
+const playerData = new ImaPlayerData();
 
 /**
  * Loads the IMA SDK library.
@@ -483,7 +483,7 @@ function changeIcon(element, name, fill = '#FFFFFF') {
 export function onClick(global) {
   playbackStarted = true;
   uiTicker = setInterval(uiTickerClick, 500);
-  playerDataTicker = setInterval(playerDataTick, 1000);
+  setInterval(playerDataTick, 1000);
   bigPlayDiv.removeEventListener(interactEvent, onClick);
   setStyle(bigPlayDiv, 'display', 'none');
   adDisplayContainer.initialize();
@@ -648,12 +648,10 @@ function playerDataTick() {
     playerData.update(videoPlayer);
     window.parent./*OK*/postMessage({
       event: ImaPlayerData.IMA_PLAYER_DATA,
-      data: playerData
+      data: playerData,
     }, '*');
   }
 }
-
-
 
 /**
  * Updates the video player UI.

--- a/extensions/amp-ima-video/0.1/amp-ima-video.js
+++ b/extensions/amp-ima-video/0.1/amp-ima-video.js
@@ -16,6 +16,7 @@
 
 import {assertHttpsUrl} from '../../../src/url';
 import {getIframe, preloadBootstrap} from '../../../src/3p-frame';
+import {ImaPlayerData} from './ima-player-data';
 import {
   installVideoManagerForDoc,
 } from '../../../src/service/video-manager-impl';
@@ -73,6 +74,9 @@ class AmpImaVideo extends AMP.BaseElement {
 
     /** @private {?String} */
     this.preconnectTrack_ = null;
+
+    /** @private {!ImaPlayerData} */
+    this.playerData_ = new ImaPlayerData();
   }
 
   /** @override */
@@ -198,7 +202,7 @@ class AmpImaVideo extends AMP.BaseElement {
    * @param {string} command
    * @param {Object=} opt_args
    * @private
-   * */
+   */
   sendCommand_(command, opt_args) {
     if (this.iframe_ && this.iframe_.contentWindow)
     {
@@ -226,6 +230,8 @@ class AmpImaVideo extends AMP.BaseElement {
           this.playerReadyResolver_(this.iframe_);
         }
         this.element.dispatchCustomEvent(videoEvent);
+      } else if (videoEvent == ImaPlayerData.IMA_PLAYER_DATA) {
+          this.playerData_ = /** {ImaPlayerData} */eventData['data'];
       }
     }
   }
@@ -330,20 +336,17 @@ class AmpImaVideo extends AMP.BaseElement {
 
   /** @override */
   getCurrentTime() {
-    // Not supported.
-    return 0;
+    return this.playerData_.currentTime;
   }
 
   /** @override */
   getDuration() {
-    // Not supported.
-    return 1;
+    return this.playerData_.duration;
   }
 
   /** @override */
   getPlayedRanges() {
-    // Not supported.
-    return [];
+    return this.playerData_.playedRanges;
   }
 }
 

--- a/extensions/amp-ima-video/0.1/amp-ima-video.js
+++ b/extensions/amp-ima-video/0.1/amp-ima-video.js
@@ -16,7 +16,7 @@
 
 import {assertHttpsUrl} from '../../../src/url';
 import {getIframe, preloadBootstrap} from '../../../src/3p-frame';
-import {ImaPlayerData} from './ima-player-data';
+import {ImaPlayerData} from '../../../ads/google/ima-player-data';
 import {
   installVideoManagerForDoc,
 } from '../../../src/service/video-manager-impl';
@@ -231,7 +231,7 @@ class AmpImaVideo extends AMP.BaseElement {
         }
         this.element.dispatchCustomEvent(videoEvent);
       } else if (videoEvent == ImaPlayerData.IMA_PLAYER_DATA) {
-          this.playerData_ = /** {ImaPlayerData} */eventData['data'];
+        this.playerData_ = /** @type {!ImaPlayerData} */(eventData['data']);
       }
     }
   }

--- a/extensions/amp-ima-video/0.1/ima-player-data.js
+++ b/extensions/amp-ima-video/0.1/ima-player-data.js
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export class ImaPlayerData {
+
+  /**
+   * Create a new ImaPlayerData object.
+   *
+   * @param {!Number} curentTime
+   * @param {!Number} duration
+   * @param {!Array} playedRanges
+   */
+  constructor(currentTime = 0, duration = 1, playedRanges = []) {
+    /* {!Number} */
+    this.currentTime = currentTime;
+
+    /* {!Number} */
+    this.duration = duration;
+
+    /* {!Array} */
+    this.playedRanges = playedRanges;
+  }
+
+  /**
+   * Update from the provided video player.
+   *
+   * @param {!Element} videoPlayer
+   */
+  update(videoPlayer) {
+    this.currentTime = videoPlayer.currentTime;
+    this.duration = videoPlayer.duration;
+
+    // Adapt videoPlayer.played for the playedRanges format AMP wants.
+    const played = videoPlayer.played;
+    const length = played.length;
+    this.playedRanges = [];
+    for (let i = 0; i < length; i++) {
+      this.playedRanges.push([played.start(i), played.end(i)]);
+    }
+  }
+}
+
+/**
+ * Unique identifier for messages from the implementation iframe with data
+ * about the player.
+ * @const
+ */
+ImaPlayerData.IMA_PLAYER_DATA = 'imaPlayerData';

--- a/package.json
+++ b/package.json
@@ -30,8 +30,7 @@
     "babel-polyfill": "6.26.0",
     "document-register-element": "1.5.0",
     "promise-pjs": "1.1.3",
-    "web-animations-js": "2.3.1",
-    "yarn": "^1.2.1"
+    "web-animations-js": "2.3.1"
   },
   "devDependencies": {
     "ajv": "5.2.2",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "babel-polyfill": "6.26.0",
     "document-register-element": "1.5.0",
     "promise-pjs": "1.1.3",
-    "web-animations-js": "2.3.1"
+    "web-animations-js": "2.3.1",
+    "yarn": "^1.2.1"
   },
   "devDependencies": {
     "ajv": "5.2.2",


### PR DESCRIPTION
This adds currentTime, duration, and playedRanges.

I could use some quick help organizing/compiling this. Specifically imaVideo.js is not allowed to depend on ima-player-data because it's in the extensions/ folder, so I'd like to know how to handle that (move the file, move the code into an existing file, whatever works).

Resolves #11356 

/to @aghassemi 
