### PR TITLE
Fix for disabling SF preload experiment.

### DIFF
--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -348,6 +348,9 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
 
     /** @type {?../../../ads/google/a4a/utils.IdentityToken} */
     this.identityToken = null;
+
+    /** @private {boolean} */
+    this.preloadSafeframe_ = true;
   }
 
   /** @override */
@@ -401,9 +404,14 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
       return;
     }
     this.win['dbclk_a4a_viz_change'] = true;
-    addExperimentIdToElement(
-        isExperimentOn(this.win, 'a4a-safeframe-preloading-off') ?
-        '21061136' : '21061135', this.element);
+    if (isExperimentOn(this.win, 'a4a-safeframe-preloading-off')) {
+      if (Math.random() < 0.5) {
+        this.preloadSafeframe_ = false;
+        addExperimentIdToElement('21061136', this.element);
+      } else {
+        addExperimentIdToElement('21061135', this.element);
+      }
+    }
     const viewer = Services.viewerForDoc(this.getAmpDoc());
     viewer.onVisibilityChanged(() => {
       if (viewer.getVisibilityState() != VisibilityState.PAUSED ||
@@ -1086,7 +1094,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
 
   getPreconnectUrls() {
     const urls = ['https://partner.googleadservices.com'];
-    if (!isExperimentOn(this.win, 'a4a-safeframe-preloading-off')) {
+    if (this.preloadSafeframe_) {
       urls.push(SAFEFRAME_ORIGIN);
     }
     return urls;

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -404,14 +404,21 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
       return;
     }
     this.win['dbclk_a4a_viz_change'] = true;
-    if (isExperimentOn(this.win, 'a4a-safeframe-preloading-off')) {
-      if (Math.random() < 0.5) {
-        this.preloadSafeframe_ = false;
-        addExperimentIdToElement('21061136', this.element);
-      } else {
-        addExperimentIdToElement('21061135', this.element);
-      }
+
+    const sfPreloadExpName = 'a4a-safeframe-preloading-off';
+    const experimentInfoMap =
+        /** @type {!Object<string, !ExperimentInfo>} */ ({});
+    experimentInfoMap[sfPreloadExpName] = {
+      isTrafficEligible: () => true,
+      branches: ['21061135', '21061136'],
+    };
+    randomlySelectUnsetExperiments(this.win, experimentInfoMap);
+    const sfPreloadExpId = getExperimentBranch(this.win, sfPreloadExpName);
+    if (sfPreloadExpId) {
+      addExperimentIdToElement(sfPreloadExpId, this.element);
+      this.preloadSafeframe_ = sfPreloadExpId == '21061135';
     }
+
     const viewer = Services.viewerForDoc(this.getAmpDoc());
     viewer.onVisibilityChanged(() => {
       if (viewer.getVisibilityState() != VisibilityState.PAUSED ||

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -31,6 +31,7 @@ import {
   getNetworkId,
   CORRELATOR_CLEAR_EXP_BRANCHES,
   CORRELATOR_CLEAR_EXP_NAME,
+  SAFEFRAME_ORIGIN,
 } from '../amp-ad-network-doubleclick-impl';
 import {
   DFP_CANONICAL_FF_EXPERIMENT_NAME,
@@ -1010,6 +1011,39 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
       forceExperimentBranch(impl.win, DFP_CANONICAL_FF_EXPERIMENT_NAME,
           DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_EXPERIMENT);
       expect(impl.shouldPreferentialRenderWithoutCrypto()).to.be.true;
+    });
+  });
+
+  describe('#disable safeframe preload experiment', () => {
+
+    const sfPreloadExpName = 'a4a-safeframe-preloading-off';
+
+    beforeEach(() => {
+      element = createElementWithAttributes(doc, 'amp-ad', {
+        type: 'doubleclick',
+        height: '250',
+        width: '320',
+      });
+      doc.body.appendChild(element);
+      impl = new AmpAdNetworkDoubleclickImpl(element);
+    });
+
+    it('should not preload SafeFrame', () => {
+      forceExperimentBranch(impl.win, sfPreloadExpName, '21061136');
+      impl.buildCallback();
+      expect(isInExperiment(element, '21061135')).to.be.false;
+      expect(isInExperiment(element, '21061136')).to.be.true;
+      expect(impl.getPreconnectUrls()).to.deep.equal(
+          ['https://partner.googleadservices.com']);
+    });
+
+    it('should preload SafeFrame', () => {
+      forceExperimentBranch(impl.win, sfPreloadExpName, '21061135');
+      impl.buildCallback();
+      expect(isInExperiment(element, '21061135')).to.be.true;
+      expect(isInExperiment(element, '21061136')).to.be.false
+      expect(impl.getPreconnectUrls()).to.deep.equal(
+          ['https://partner.googleadservices.com', SAFEFRAME_ORIGIN]);
     });
   });
 });

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -1041,7 +1041,7 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
       forceExperimentBranch(impl.win, sfPreloadExpName, '21061135');
       impl.buildCallback();
       expect(isInExperiment(element, '21061135')).to.be.true;
-      expect(isInExperiment(element, '21061136')).to.be.false
+      expect(isInExperiment(element, '21061136')).to.be.false;
       expect(impl.getPreconnectUrls()).to.deep.equal(
           ['https://partner.googleadservices.com', SAFEFRAME_ORIGIN]);
     });

--- a/src/log.js
+++ b/src/log.js
@@ -500,7 +500,7 @@ function createErrorVargs(var_args) {
  * whether the original error designation is a user error or a dev error.
  * @param {...*} var_args
  */
-export function rethrowAsync(var_args) {
+export function rethrowAsync(var_args) { return;
   const error = createErrorVargs.apply(null, arguments);
   setTimeout(() => {
     // reportError is installed globally per window in the entry point.

--- a/src/log.js
+++ b/src/log.js
@@ -500,7 +500,7 @@ function createErrorVargs(var_args) {
  * whether the original error designation is a user error or a dev error.
  * @param {...*} var_args
  */
-export function rethrowAsync(var_args) { return;
+export function rethrowAsync(var_args) {
   const error = createErrorVargs.apply(null, arguments);
   setTimeout(() => {
     // reportError is installed globally per window in the entry point.


### PR DESCRIPTION
Disabling SF Preload experiment now divides 1% of traffic evenly between control and experiment.