### PR TITLE
Launch new Fast Fetch crypto verifier

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -24,7 +24,7 @@
   "a4aFastFetchDoubleclickLaunched": 0,
   "a4aFastFetchAdSenseLaunched": 0,
   "a4a-measure-get-ad-urls": 1,
-  "a4a-new-signature-verifier": 0.1,
+  "a4a-new-signature-verifier": 1,
   "ad-loader-v2": 1,
   "3p-use-ampcontext": 0,
   "amp-animation": 1,

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -21,7 +21,7 @@
   "visibility-v3": 1,
   "a4aFastFetchDoubleclickLaunched": 0,
   "a4aFastFetchAdSenseLaunched": 0,
-  "a4a-new-signature-verifier": 0.1,
+  "a4a-new-signature-verifier": 1,
   "pump-early-frame": 1,
   "a4a-measure-get-ad-urls": 0,
   "ad-loader-v2": 1,


### PR DESCRIPTION
At long last, we're ready to start using the new verifier for all Fast Fetch traffic.

CC @ampproject/cloudflare, so that you're ready to expect the change.

Related to #7618. Follow-up to #11447.