### PR TITLE
amp-bind: TextArea needs special treatment for [text] binding

### DIFF
--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -791,6 +791,12 @@ export class Bind {
     switch (property) {
       case 'text':
         element.textContent = String(newValue);
+        // Setting `textContent` on TEXTAREA element only works if user
+        // has not interacted with the element, therefore `value` also needs
+        // to be set (but `value` is not an attribute on TEXTAREA)
+        if (element.tagName == 'TEXTAREA') {
+          element.value = String(newValue);
+        }
         break;
 
       case 'class':

--- a/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
@@ -352,6 +352,17 @@ describe.configure().ifNewChrome().run('Bind', function() {
       });
     });
 
+    it('should update value in addition to textContent for TextArea', () => {
+      const element = createElement(
+          env, container, '[text]="\'a\' + \'b\' + \'c\'"', 'textarea');
+      element.textContent = 'foo';
+      element.value = 'foo';
+      return onBindReadyAndSetState(env, bind, {}).then(() => {
+        expect(element.textContent).to.equal('abc');
+        expect(element.value).to.equal('abc');
+      });
+    });
+
     it('should support binding to CSS classes with strings', () => {
       const element = createElement(env, container, '[class]="[\'abc\']"');
       expect(toArray(element.classList)).to.deep.equal([]);


### PR DESCRIPTION
TextArea unlike other inputs does not have a `value` attribute so `[text]` binding is used to change its value. Normally setting `.textContent` - which `[text]` does - works UNLESS user has interacted with the component. We need to set both `value` and `textContent` in the case element is `textarea`

Closes https://github.com/ampproject/amphtml/issues/11693  and #11246 