### PR TITLE
Fix comments from #11620

### DIFF
--- a/src/impression.js
+++ b/src/impression.js
@@ -115,7 +115,7 @@ function handleReplaceUrl(win) {
   }
 
   // request async replaceUrl is viewer support getReplaceUrl.
-  return viewer.sendMessageAwaitResponse('getReplaceUrl', undefined)
+  return viewer.sendMessageAwaitResponse('getReplaceUrl', /* data */ undefined)
       .then(response => {
         if (!response || typeof response != 'object') {
           dev().warn('IMPRESSION', 'get invalid replaceUrl response');

--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -970,7 +970,7 @@ export class Viewer {
   }
 
   /**
-   * Replace the
+   * Replace the document url with the viewer provided new replaceUrl.
    * @param {?string} newUrl
    */
   replaceUrl(newUrl) {


### PR DESCRIPTION
Follow up to comments from #11620 
Also want to make sure the messaging protocol looks good. 
(First check init param `replaceUrl` exist  =>  check viewer `cap['replaceUrl']` => `getReplaceUrl` or fallback to init param `replaceUrl`)