### PR TITLE
Add additional CSS grid properties that can be specified as attributes on children of amp-story-grid-layer

### DIFF
--- a/extensions/amp-story/0.1/amp-story-grid-layer.js
+++ b/extensions/amp-story/0.1/amp-story-grid-layer.js
@@ -34,7 +34,13 @@ import {Layout} from '../../../src/layout';
  * @private @const {!Object<string, string>}
  */
 const SUPPORTED_CSS_GRID_ATTRIBUTES = {
+  'align-content': 'alignContent',
+  'align-items': 'alignItems',
+  'align-self': 'alignSelf',
   'grid-area': 'gridArea',
+  'justify-content': 'justifyContent',
+  'justify-items': 'justifyItems',
+  'justify-self': 'justifySelf',
 };
 
 /**

--- a/extensions/amp-story/0.1/progress-bar.js
+++ b/extensions/amp-story/0.1/progress-bar.js
@@ -109,10 +109,13 @@ export class ProgressBar {
   setActivePageIndex(pageIndex) {
     this.assertValidPageIndex_(pageIndex);
     for (let i = 0; i < this.pageCount_; i++) {
-      if (i <= pageIndex) {
+      if (i < pageIndex) {
         this.updateProgress(i, 1.0);
-      } else {
+      } else if (i > pageIndex) {
         this.updateProgress(i, 0.0);
+      } else {
+        // The active page manages its own progress by firing PAGE_PROGRESS
+        // events to amp-story.  As such, its progress is not set here.
       }
     }
   }

--- a/extensions/amp-story/0.1/progress-bar.js
+++ b/extensions/amp-story/0.1/progress-bar.js
@@ -109,13 +109,10 @@ export class ProgressBar {
   setActivePageIndex(pageIndex) {
     this.assertValidPageIndex_(pageIndex);
     for (let i = 0; i < this.pageCount_; i++) {
-      if (i < pageIndex) {
+      if (i <= pageIndex) {
         this.updateProgress(i, 1.0);
-      } else if (i > pageIndex) {
-        this.updateProgress(i, 0.0);
       } else {
-        // The active page manages its own progress by firing PAGE_PROGRESS
-        // events to amp-story.  As such, its progress is not set here.
+        this.updateProgress(i, 0.0);
       }
     }
   }


### PR DESCRIPTION
These properties can be specified as attributes on direct children of amp-story-grid-layer.  This is a convenience function, but will also allow us to fix layout on browsers that do not support CSS grid.