### PR TITLE
Fix bug in domain whitelist check

### DIFF
--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -82,11 +82,6 @@ const DESKTOP_THRESHOLD = 768;
 /** @type {string} */
 const TAG = 'amp-story';
 
-/** @type {!Array<string>} */
-const WHITELISTED_ORIGINS = [
-  
-];
-
 
 /**
  * @param {!Element} el
@@ -358,12 +353,6 @@ export class AmpStory extends AMP.BaseElement {
 
 
   /** @private */
-  getOriginWhitelist_() {
-    return ;
-  }
-
-
-  /** @private */
   isAmpStoryEnabled_() {
     if (isExperimentOn(this.win, TAG) || getMode().test || getMode().localDev) {
       return true;
@@ -384,7 +373,12 @@ export class AmpStory extends AMP.BaseElement {
   }
 
 
-  /** @private */
+  /**
+   * @param {string} origin The origin to check.
+   * @return {boolean} Whether the specified origin is whitelisted to use the
+   *     amp-story extension.
+   * @private
+   */
   isOriginWhitelisted_(origin) {
     const hostName = parseUrl(origin).hostname;
     const domains = hostName.split('.');

--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -377,7 +377,7 @@ export class AmpStory extends AMP.BaseElement {
     // (e.g. .co.uk) the third level may be whitelisted.  Additionally, this
     // allows subdomains to be whitelisted individually.
     return domains.some((unusedDomain, index) => {
-      const domain = domains.slice(0, index + 1).join('.');
+      const domain = domains.slice(index, domains.length).join('.');
       const domainHash = stringHash32(domain.toLowerCase());
       return WHITELISTED_ORIGINS.includes(domainHash);
     });

--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -84,9 +84,7 @@ const TAG = 'amp-story';
 
 /** @type {!Array<string>} */
 const WHITELISTED_ORIGINS = [
-  '3451824873', '834917366', '4273375831', '750731789', '3322156041',
-  '878041739', '2199838184', '708478954', '142793127', '2414533450',
-  '212690086',
+  
 ];
 
 
@@ -167,6 +165,13 @@ export class AmpStory extends AMP.BaseElement {
 
     /** @private {?function()} */
     this.boundOnResize_ = null;
+
+    /** @private @const {!Array<string>} */
+    this.originWhitelist_ = [
+      '3451824873', '834917366', '4273375831', '750731789', '3322156041',
+      '878041739', '2199838184', '708478954', '142793127', '2414533450',
+      '212690086',
+    ];
   }
 
 
@@ -353,12 +358,34 @@ export class AmpStory extends AMP.BaseElement {
 
 
   /** @private */
+  getOriginWhitelist_() {
+    return ;
+  }
+
+
+  /** @private */
   isAmpStoryEnabled_() {
     if (isExperimentOn(this.win, TAG) || getMode().test || getMode().localDev) {
       return true;
     }
 
     const origin = getSourceOrigin(this.win.location);
+    return this.isOriginWhitelisted_(origin);
+  }
+
+
+  /**
+   * @param {string} domain The domain part of the origin, to be hashed.
+   * @return {string} The hashed origin.
+   * @private
+   */
+  hashOrigin_(domain) {
+    return stringHash32(domain.toLowerCase());
+  }
+
+
+  /** @private */
+  isOriginWhitelisted_(origin) {
     const hostName = parseUrl(origin).hostname;
     const domains = hostName.split('.');
 
@@ -378,8 +405,8 @@ export class AmpStory extends AMP.BaseElement {
     // allows subdomains to be whitelisted individually.
     return domains.some((unusedDomain, index) => {
       const domain = domains.slice(index, domains.length).join('.');
-      const domainHash = stringHash32(domain.toLowerCase());
-      return WHITELISTED_ORIGINS.includes(domainHash);
+      const domainHash = this.hashOrigin_(domain);
+      return this.originWhitelist_.includes(domainHash);
     });
   }
 

--- a/extensions/amp-story/0.1/progress-bar.js
+++ b/extensions/amp-story/0.1/progress-bar.js
@@ -109,10 +109,13 @@ export class ProgressBar {
   setActivePageIndex(pageIndex) {
     this.assertValidPageIndex_(pageIndex);
     for (let i = 0; i < this.pageCount_; i++) {
-      if (i <= pageIndex) {
+      if (i < pageIndex) {
         this.updateProgress(i, 1.0);
-      } else {
+      } else if (i > pageIndex) {
         this.updateProgress(i, 0.0);
+      } else {
+        // The active page manages its own progress by firing PAGE_PROGRESS
+        // events to amp-story.  As such, its progress is not set here.
       }
     }
   }

--- a/extensions/amp-story/0.1/progress-bar.js
+++ b/extensions/amp-story/0.1/progress-bar.js
@@ -109,13 +109,10 @@ export class ProgressBar {
   setActivePageIndex(pageIndex) {
     this.assertValidPageIndex_(pageIndex);
     for (let i = 0; i < this.pageCount_; i++) {
-      if (i < pageIndex) {
+      if (i <= pageIndex) {
         this.updateProgress(i, 1.0);
-      } else if (i > pageIndex) {
-        this.updateProgress(i, 0.0);
       } else {
-        // The active page manages its own progress by firing PAGE_PROGRESS
-        // events to amp-story.  As such, its progress is not set here.
+        this.updateProgress(i, 0.0);
       }
     }
   }

--- a/extensions/amp-story/0.1/test/test-amp-story.js
+++ b/extensions/amp-story/0.1/test/test-amp-story.js
@@ -14,12 +14,15 @@
  * limitations under the License.
  */
 import {AnalyticsTrigger} from '../analytics';
+import {AmpStory} from '../amp-story';
 import {EventType} from '../events';
 import {KeyCodes} from '../../../../src/utils/key-codes';
 import {VariableService} from '../variable-service';
+import {stringHash32} from '../../../../src/string';
 
 
 const NOOP = () => {};
+const IDENTITY_FN = x => x;
 
 
 describes.realWin('amp-story', {
@@ -313,5 +316,60 @@ describes.realWin('amp-story', {
 
     expect(pages[0].hasAttribute('active')).to.be.false;
     expect(pages[1].hasAttribute('active')).to.be.true;
+  });
+});
+
+
+describes.realWin('amp-story origin whitelist', {
+  amp: {
+    extensions: ['amp-story'],
+  },
+}, env => {
+  let win;
+  let element;
+  let story;
+
+  beforeEach(() => {
+    win = env.win;
+    element = win.document.createElement('amp-story');
+    win.document.body.appendChild(element);
+
+    story = new AmpStory(element);
+    story.hashOrigin_ = IDENTITY_FN;
+  });
+
+  it('should allow exact whitelisted origin with https scheme', () => {
+    story.originWhitelist_ = [ 'example.com' ];
+    expect(story.isOriginWhitelisted_('https://example.com')).to.be.true;
+  });
+
+  it('should allow exact whitelisted origin with http scheme', () => {
+    story.originWhitelist_ = [ 'example.com' ];
+    expect(story.isOriginWhitelisted_('http://example.com')).to.be.true;
+  });
+
+  it('should allow www subdomain of origin', () => {
+    story.originWhitelist_ = [ 'example.com' ];
+    expect(story.isOriginWhitelisted_('https://www.example.com')).to.be.true;
+  });
+
+  it('should allow subdomain of origin', () => {
+    story.originWhitelist_ = [ 'example.com' ];
+    expect(story.isOriginWhitelisted_('https://foobar.example.com')).to.be.true;
+  });
+
+  it('should not allow exact whitelisted domain under different tld', () => {
+    story.originWhitelist_ = [ 'example.com' ];
+    expect(story.isOriginWhitelisted_('https://example.co.uk')).to.be.false;
+  });
+
+  it('should not allow exact whitelisted domain infixed in another tld', () => {
+    story.originWhitelist_ = [ 'example.co.uk' ];
+    expect(story.isOriginWhitelisted_('https://example.co')).to.be.false;
+  });
+
+  it('should not allow domain that contains whitelisted domain', () => {
+    story.originWhitelist_ = [ 'example.co' ];
+    expect(story.isOriginWhitelisted_('https://example.co.uk')).to.be.false;
   });
 });

--- a/extensions/amp-story/0.1/test/test-amp-story.js
+++ b/extensions/amp-story/0.1/test/test-amp-story.js
@@ -18,7 +18,6 @@ import {AmpStory} from '../amp-story';
 import {EventType} from '../events';
 import {KeyCodes} from '../../../../src/utils/key-codes';
 import {VariableService} from '../variable-service';
-import {stringHash32} from '../../../../src/string';
 
 
 const NOOP = () => {};
@@ -339,37 +338,37 @@ describes.realWin('amp-story origin whitelist', {
   });
 
   it('should allow exact whitelisted origin with https scheme', () => {
-    story.originWhitelist_ = [ 'example.com' ];
+    story.originWhitelist_ = ['example.com'];
     expect(story.isOriginWhitelisted_('https://example.com')).to.be.true;
   });
 
   it('should allow exact whitelisted origin with http scheme', () => {
-    story.originWhitelist_ = [ 'example.com' ];
+    story.originWhitelist_ = ['example.com'];
     expect(story.isOriginWhitelisted_('http://example.com')).to.be.true;
   });
 
   it('should allow www subdomain of origin', () => {
-    story.originWhitelist_ = [ 'example.com' ];
+    story.originWhitelist_ = ['example.com'];
     expect(story.isOriginWhitelisted_('https://www.example.com')).to.be.true;
   });
 
   it('should allow subdomain of origin', () => {
-    story.originWhitelist_ = [ 'example.com' ];
+    story.originWhitelist_ = ['example.com'];
     expect(story.isOriginWhitelisted_('https://foobar.example.com')).to.be.true;
   });
 
   it('should not allow exact whitelisted domain under different tld', () => {
-    story.originWhitelist_ = [ 'example.com' ];
+    story.originWhitelist_ = ['example.com'];
     expect(story.isOriginWhitelisted_('https://example.co.uk')).to.be.false;
   });
 
   it('should not allow exact whitelisted domain infixed in another tld', () => {
-    story.originWhitelist_ = [ 'example.co.uk' ];
+    story.originWhitelist_ = ['example.co.uk'];
     expect(story.isOriginWhitelisted_('https://example.co')).to.be.false;
   });
 
   it('should not allow domain that contains whitelisted domain', () => {
-    story.originWhitelist_ = [ 'example.co' ];
+    story.originWhitelist_ = ['example.co'];
     expect(story.isOriginWhitelisted_('https://example.co.uk')).to.be.false;
   });
 });


### PR DESCRIPTION
The old code was using domains from the beginning of the array to the current index, while iterating, rather than from the current index to the end of the array.

In other words, given www.example.com, the old way would give:

- www
- www.example
- www.example.com

The new (correct) way will give:

- www.example.com
- example.com
- com