### PR TITLE
Change RTC to use a macro whitelist for vendors

### DIFF
--- a/extensions/amp-a4a/0.1/callout-vendors.js
+++ b/extensions/amp-a4a/0.1/callout-vendors.js
@@ -20,7 +20,14 @@
 //       otherwise the vendor endpoint will not be used.        //
 //                                                              //
 //////////////////////////////////////////////////////////////////
-/** @const {!Object<string, string>} */
+/** @typedef {{
+    url: string,
+    macros: Array<string>}} */
+let RtcVendorDef;
+/** @const {!Object<string, RtcVendorDef>} */
 export const RTC_VENDORS = {
-  'fakevendor': 'https://www.fake.qqq/?slot_id=SLOT_ID&page_id=PAGE_ID&foo_id=FOO_ID',
+  'fakevendor': {
+    url: 'https://www.fake.qqq/?slot_id=SLOT_ID&page_id=PAGE_ID&foo_id=FOO_ID',
+    macros: ['SLOT_ID', 'PAGE_ID', 'FOO_ID'],
+  },
 };

--- a/extensions/amp-a4a/0.1/real-time-config-manager.js
+++ b/extensions/amp-a4a/0.1/real-time-config-manager.js
@@ -107,7 +107,7 @@ export function maybeExecuteRealTimeConfig_(a4aElement, customMacros) {
       if (vendorObject.macros && vendorObject.macros.includes(macro)) {
         validVendorMacros[macro] = rtcConfig['vendors'][vendor][macro];
       } else {
-        user().warn(TAG, `Invalid macro: ${macro} for vendor: ${vendor}`);
+        user().warn(TAG, `Unknown macro: ${macro} for vendor: ${vendor}`);
       }
     });
     // The ad network defined macros override vendor defined/pub specifed.

--- a/extensions/amp-a4a/0.1/real-time-config-manager.js
+++ b/extensions/amp-a4a/0.1/real-time-config-manager.js
@@ -97,15 +97,14 @@ export function maybeExecuteRealTimeConfig_(a4aElement, customMacros) {
   // url if it exists, and send the RTC request.
   Object.keys(rtcConfig['vendors'] || []).forEach(vendor => {
     const vendorObject = RTC_VENDORS[vendor.toLowerCase()];
-    const url = vendorObject ?
-          RTC_VENDORS[vendor.toLowerCase()].url : undefined;
+    const url = vendorObject ? vendorObject.url : '';
     if (!url) {
       return logAndAddErrorResponse_(promiseArray,
           RTC_ERROR_ENUM.UNKNOWN_VENDOR, vendor);
     }
     const validVendorMacros = {};
     Object.keys(rtcConfig['vendors'][vendor]).forEach(macro => {
-      if (vendorObject.macros.includes(macro)) {
+      if (vendorObject.macros && vendorObject.macros.includes(macro)) {
         validVendorMacros[macro] = rtcConfig['vendors'][vendor][macro];
       } else {
         user().warn(TAG, `Invalid macro: ${macro} for vendor: ${vendor}`);

--- a/extensions/amp-a4a/0.1/real-time-config-manager.js
+++ b/extensions/amp-a4a/0.1/real-time-config-manager.js
@@ -96,14 +96,23 @@ export function maybeExecuteRealTimeConfig_(a4aElement, customMacros) {
   // For each vendor the publisher has specified, inflate the vendor
   // url if it exists, and send the RTC request.
   Object.keys(rtcConfig['vendors'] || []).forEach(vendor => {
-    const url = RTC_VENDORS[vendor.toLowerCase()];
+    const vendorObject = RTC_VENDORS[vendor.toLowerCase()];
+    const url = vendorObject ?
+          RTC_VENDORS[vendor.toLowerCase()].url : undefined;
     if (!url) {
       return logAndAddErrorResponse_(promiseArray,
           RTC_ERROR_ENUM.UNKNOWN_VENDOR, vendor);
     }
+    const validVendorMacros = {};
+    Object.keys(rtcConfig['vendors'][vendor]).forEach(macro => {
+      if (vendorObject.macros.includes(macro)) {
+        validVendorMacros[macro] = rtcConfig['vendors'][vendor][macro];
+      } else {
+        user().warn(TAG, `Invalid macro: ${macro} for vendor: ${vendor}`);
+      }
+    });
     // The ad network defined macros override vendor defined/pub specifed.
-    const macros = Object.assign(
-        rtcConfig['vendors'][vendor] || {}, customMacros);
+    const macros = Object.assign(validVendorMacros, customMacros);
     inflateAndSendRtc_(a4aElement, url, seenUrls, promiseArray, rtcStartTime,
         macros, rtcConfig['timeoutMillis'],
         vendor.toLowerCase());

--- a/extensions/amp-a4a/0.1/test/test-real-time-config-manager.js
+++ b/extensions/amp-a4a/0.1/test/test-real-time-config-manager.js
@@ -249,6 +249,25 @@ describes.realWin('real-time-config-manager', {amp: true}, env => {
         urls, vendors, customMacros, inflatedUrls, rtcCalloutResponses,
         calloutCount, expectedCalloutUrls: inflatedUrls, expectedRtcArray});
     });
+    it('should ignore bad macros for vendor urls', () => {
+      const vendors = {
+        'fAkeVeNdOR': {'slot_id=SLOT_ID': 0, PAGE_ID: 1},
+      };
+      const inflatedUrls = [
+        'https://www.fake.qqq/?slot_id=SLOT_ID&page_id=1&foo_id=FOO_ID',
+      ];
+      const rtcCalloutResponses = generateCalloutResponses(1);
+      const expectedRtcArray = [];
+      for (let i = 0; i < 1; i++) {
+        expectedRtcArray.push(
+            rtcEntry(rtcCalloutResponses[i],
+                Object.keys(vendors)[0].toLowerCase()));
+      }
+      const calloutCount = 1;
+      return executeTest({
+        vendors, inflatedUrls, rtcCalloutResponses,
+        calloutCount, expectedCalloutUrls: inflatedUrls, expectedRtcArray});
+    });
     it('should favor publisher URLs over vendor URLs', () => {
       const urls = generateUrls(3,2);
       const vendors = {


### PR DESCRIPTION
Previously, a publisher could specify anything as the macro value to substitute into a vendor url. I.e. if the vendor url was:

```
https://www.foo.com
```

The publisher could specify in their rtc-config:
```
'vendorfoo': {'w': 'z'}
```
And the resulting url would be 
```
https://zzz.foo.com
```

This fixes that by adding an explicit whitelist for each vendor's url.