### PR TITLE
Fix Dead Link In Documentation

### DIFF
--- a/ads/google/a4a/docs/a4a-readme.md
+++ b/ads/google/a4a/docs/a4a-readme.md
@@ -4,7 +4,7 @@ AMP Ads applies AMP’s core philosophy of reliable fast performance and  great 
 
 # AMP Ads 
 
-AMP Ads are written in AMP format - [A4A HTML](https://github.com/google/amphtml/blob/master/extensions/amp-a4a/amp-a4a-format.md) (A variant of AMP HTML) + CSS. This means that ads can no longer have the ability to run arbitrary JavaScript - which is traditionally the number one cause of poor ad performance. Therefore, just like core AMP, the core ads JavaScript use-cases are built right into the AMP Open Source project which guarantees good behavior from ads. 
+AMP Ads are written in AMP format - [A4A HTML](https://github.com/ampproject/amphtml/blob/master/extensions/amp-a4a/amp-a4a-format.md) (A variant of AMP HTML) + CSS. This means that ads can no longer have the ability to run arbitrary JavaScript - which is traditionally the number one cause of poor ad performance. Therefore, just like core AMP, the core ads JavaScript use-cases are built right into the AMP Open Source project which guarantees good behavior from ads. 
 
 # Why are AMP Ads better than regular ads?
 

--- a/ads/google/a4a/docs/a4a-readme.md
+++ b/ads/google/a4a/docs/a4a-readme.md
@@ -28,13 +28,13 @@ AMP Ads are designed to work on both AMP and Non-AMP webpages,  including deskto
 
 # Current status
 
-The AMP Ads format spec has been [released](https://github.com/google/amphtml/blob/master/extensions/amp-a4a/amp-a4a-format.md) and any creative developer can create AMP Ads. A number of ad providers are working on automatically converting ads to AMP Ads whenever possible. e.g. AdSense.
+The AMP Ads format spec has been [released](https://github.com/ampproject/amphtml/blob/master/extensions/amp-a4a/amp-a4a-format.md) and any creative developer can create AMP Ads. A number of ad providers are working on automatically converting ads to AMP Ads whenever possible. e.g. AdSense.
 
 Here is how you can participate. If you are:
 
 ## Publishers
 
-If publishers want to serve their direct-sold ad formats they must create the ads in[ A4A format](https://github.com/google/amphtml/blob/master/extensions/amp-a4a/amp-a4a-format.md) (or use a creative agency), and deliver them using an AMP Ad supported ad server.
+If publishers want to serve their direct-sold ad formats they must create the ads in [A4A format](https://github.com/ampproject/amphtml/blob/master/extensions/amp-a4a/amp-a4a-format.md) (or use a creative agency), and deliver them using an AMP Ad supported ad server.
 
 The following adservers support serving AMP Ads at the moment:
 1. DoubleClick for Publishers


### PR DESCRIPTION
- Used to link here:
https://github.com/google/amphtml/blob/master/extensions/amp-a4a/amp-a4a-format.md

- Assumed it should point here:
https://github.com/ampproject/amphtml/blob/master/extensions/amp-a4a/amp-a4a-format.md
