### PR TITLE
Support trusted referrer for CORS impression

### DIFF
--- a/src/impression.js
+++ b/src/impression.js
@@ -62,10 +62,15 @@ export function maybeTrackImpression(win) {
         dev().warn('IMPRESSION', error);
       });
 
-  Services.viewerForDoc(win.document).isTrustedViewer().then(isTrusted => {
+  const viewer = Services.viewerForDoc(win.document);
+  const isTrustedViewerPromise = viewer.isTrustedViewer();
+  const isTrustedReferrerPromise = viewer.isTrustedReferrer();
+  Promise.all([isTrustedViewerPromise, isTrustedReferrerPromise]).then(results => {
+    const isTrustedViewer = results[0];
+    const isTrustedReferrer = results[1];
     // Currently this feature is launched for trusted viewer, but still
     // experiment guarded for all AMP docs.
-    if (!isTrusted && !isExperimentOn(win, 'alp')) {
+    if (!isTrustedViewer && !isTrustedReferrer && !isExperimentOn(win, 'alp')) {
       resolveImpression();
       return;
     }

--- a/src/impression.js
+++ b/src/impression.js
@@ -71,8 +71,8 @@ export function maybeTrackImpression(win) {
   ]).then(results => {
     const isTrustedViewer = results[0];
     const isTrustedReferrer = results[1];
-    // Currently this feature is launched for trusted viewer, but still
-    // experiment guarded for all AMP docs.
+    // Currently this feature is launched for trusted viewer and trusted referrer,
+    // but still experiment guarded for all AMP docs.
     if (!isTrustedViewer && !isTrustedReferrer && !isExperimentOn(win, 'alp')) {
       resolveImpression();
       return;

--- a/src/impression.js
+++ b/src/impression.js
@@ -65,7 +65,10 @@ export function maybeTrackImpression(win) {
   const viewer = Services.viewerForDoc(win.document);
   const isTrustedViewerPromise = viewer.isTrustedViewer();
   const isTrustedReferrerPromise = viewer.isTrustedReferrer();
-  Promise.all([isTrustedViewerPromise, isTrustedReferrerPromise]).then(results => {
+  Promise.all([
+    isTrustedViewerPromise,
+    isTrustedReferrerPromise,
+  ]).then(results => {
     const isTrustedViewer = results[0];
     const isTrustedReferrer = results[1];
     // Currently this feature is launched for trusted viewer, but still

--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -738,7 +738,7 @@ export class Viewer {
    * @return {!Promise<boolean>}
    */
   isTrustedReferrer() {
-    return this.referrerUrl_.then(referrer =>{
+    return this.referrerUrl_.then(referrer => {
       return this.isTrustedReferrer_(referrer);
     });
   }

--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -71,11 +71,19 @@ const TRUSTED_VIEWER_HOSTS = [
 ];
 
 /**
- * These domains are trusted for CORS impression requests
+ * These domains are trusted with more sensitive viewer operations such as
+ * sending impression requests. If you believe your domain should be here,
+ * file the issue on GitHub to discuss. The process will be similar
+ * (but somewhat more stringent) to the one described in the [3p/README.md](
+ * https://github.com/ampproject/amphtml/blob/master/3p/README.md)
  *
  * @export {!Array<!RegExp>}
  */
 const TRUSTED_REFERRER_HOSTS = [
+  /**
+   * Twitter's link wrapper domains:
+   * - t.co
+   */
   /^t.co$/,
 ];
 

--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -71,6 +71,15 @@ const TRUSTED_VIEWER_HOSTS = [
 ];
 
 /**
+ * These domains are trusted for CORS impression requests
+ *
+ * @export {!Array<!RegExp>}
+ */
+const TRUSTED_REFERRER_HOSTS = [
+  /^t.co$/,
+];
+
+/**
  * An AMP representation of the Viewer. This class doesn't do any work itself
  * but instead delegates everything to the actual viewer. This class and the
  * actual Viewer are connected via "AMP.viewer" using three methods:
@@ -683,6 +692,19 @@ export class Viewer {
   }
 
   /**
+   * @param {string} referrer
+   * @return {boolean}
+   * @private
+   */
+  isTrustedReferrer_(referrer) {
+    const url = parseUrl(referrer);
+    if (url.protocol != 'https:') {
+      return false;
+    }
+    return TRUSTED_REFERRER_HOSTS.some(th => th.test(url.hostname));
+  }
+
+  /**
    * Returns an unconfirmed "referrer" URL that can be optionally customized by
    * the viewer. Consider using `getReferrerUrl()` instead, which returns the
    * promise that will yield the confirmed "referrer" URL.
@@ -709,6 +731,16 @@ export class Viewer {
    */
   isTrustedViewer() {
     return this.isTrustedViewer_;
+  }
+
+  /**
+   * Whether the referrer has been whitelisted for CORS impression
+   * @return {!Promise<boolean>}
+   */
+  isTrustedReferrer() {
+    return this.referrerUrl_.then(referrer =>{
+      return this.isTrustedReferrer_(referrer);
+    });
   }
 
   /**

--- a/test/functional/test-viewer.js
+++ b/test/functional/test-viewer.js
@@ -1096,6 +1096,34 @@ describe('Viewer', () => {
   });
 
   describe('referrer', () => {
+    function test(referrer, toBeTrusted) {
+      it('testing ' + referrer, () => {
+        const viewer = new Viewer(ampdoc);
+        expect(viewer.isTrustedReferrer_(referrer)).to.equal(toBeTrusted);
+      });
+    }
+
+    describe('should not trust host as referrer with http', () => {
+      test('http://t.co/asdf', false);
+    });
+
+    describe('should trust whitelisted hosts', () => {
+      test('https://t.co/asdf', true);
+    });
+
+    describe('should not trust non-whitelisted hosts', () => {
+      test('https://www.t.co/asdf', false);
+      test('https://t.com/asdf', false);
+      test('https://t.cn/asdf', false);
+    });
+
+    it('should return true for whitelisted hosts', () => {
+      windowApi.document.referrer = 'https://t.co/docref';
+      const viewer = new Viewer(ampdoc);
+      return viewer.isTrustedReferrer().then(isTrusted => {
+        expect(isTrusted).to.equal(true);
+      });
+    });
 
     it('should return document referrer if not overriden', () => {
       windowApi.parent = {};

--- a/test/functional/test-viewer.js
+++ b/test/functional/test-viewer.js
@@ -1117,11 +1117,13 @@ describe('Viewer', () => {
       test('https://t.cn/asdf', false);
     });
 
-    it('should return true for whitelisted hosts', () => {
-      windowApi.document.referrer = 'https://t.co/docref';
-      const viewer = new Viewer(ampdoc);
-      return viewer.isTrustedReferrer().then(isTrusted => {
-        expect(isTrusted).to.equal(true);
+    describe('isTrustedReferrer', () => {
+      it('should return true for whitelisted hosts', () => {
+        windowApi.document.referrer = 'https://t.co/docref';
+        const viewer = new Viewer(ampdoc);
+        return viewer.isTrustedReferrer().then(isTrusted => {
+          expect(isTrusted).to.equal(true);
+        });
       });
     });
 


### PR DESCRIPTION
Support trusted referrer for CORS impression

- added isTrustedReferrer in viewer-impl, I didn't add the logic in isTrustedViewer because our current use case won't require the AMP page render in an iframe 
- updated impression.js to check for trusted referrer
- added unit tests
- verified locally with referrer from whitelisted domains