### PR TITLE
video-manager: honour VideoEvents.VISIBILITY event

### DIFF
--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -838,8 +838,6 @@ class VideoEntry {
       // Only muted videos are allowed to autoplay
       this.video.mute();
 
-      //
-
       if (this.video.isInteractive()) {
         this.autoplayInteractiveVideoBuilt_();
       }

--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -18,7 +18,7 @@
 import {ActionTrust} from '../action-trust';
 import {VideoSessionManager} from './video-session-manager';
 import {removeElement, scopedQuerySelector, isRTL} from '../dom';
-import {listen, listenOncePromise} from '../event-helper';
+import {listen, listenOncePromise, getData} from '../event-helper';
 import {dev} from '../log';
 import {getMode} from '../mode';
 import {registerServiceBuilderForDoc, getServiceForDoc} from '../service';
@@ -239,7 +239,8 @@ export class VideoManager {
    */
   maybeInstallVisibilityObserver_(entry) {
     listen(entry.video.element, VideoEvents.VISIBILITY, details => {
-      if (details && details.data && details.data.visible) {
+      const data = getData(details);
+      if (data && data['visible'] == true) {
         entry.updateVisibility(/* opt_forceVisible */ true);
       } else {
         entry.updateVisibility();
@@ -1761,7 +1762,7 @@ class VideoEntry {
   /**
    * Called by all possible events that might change the visibility of the video
    * such as scrolling or {@link ../video-interface.VideoEvents#VISIBILITY}.
-   * @param {boolean} opt_forceVisible
+   * @param {?boolean=} opt_forceVisible
    * @package
    */
   updateVisibility(opt_forceVisible) {
@@ -1769,7 +1770,7 @@ class VideoEntry {
 
     // Measure if video is now in viewport and what percentage of it is visible.
     const measure = () => {
-      if (opt_forceVisible) {
+      if (opt_forceVisible == true) {
         this.isVisible_ = true;
       } else {
         // Calculate what percentage of the video is in viewport.

--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -18,7 +18,7 @@
 import {ActionTrust} from '../action-trust';
 import {VideoSessionManager} from './video-session-manager';
 import {removeElement, scopedQuerySelector, isRTL} from '../dom';
-import {listen, listenOncePromise, getData} from '../event-helper';
+import {getData, listen, listenOncePromise} from '../event-helper';
 import {dev} from '../log';
 import {getMode} from '../mode';
 import {registerServiceBuilderForDoc, getServiceForDoc} from '../service';


### PR DESCRIPTION
Closes https://github.com/ampproject/amphtml/issues/8681

Value of `getIntersectionChangeEntry` is not always accurate in cases like Carousel. If `VideoEvents.VISIBILITY` says video is visible, honour it regardless of value of `getIntersectionChangeEntry`.

Something that might be fixed by `layers`, but this is a low-risk small fix for now.
