### PR TITLE
amp-instagram: allow changeHeight unconditionally

### DIFF
--- a/extensions/amp-instagram/0.1/amp-instagram.js
+++ b/extensions/amp-instagram/0.1/amp-instagram.js
@@ -210,8 +210,7 @@ class AmpInstagram extends AMP.BaseElement {
         if (this.iframe_ && this.iframe_./*OK*/offsetHeight !== height) {
           // Height returned by Instagram includes header, so
           // subtract 48px top padding
-          this./*OK*/changeHeight(height - (PADDING_TOP + PADDING_BOTTOM))
-              .catch(() => {});
+          this./*OK*/changeHeight(height - (PADDING_TOP + PADDING_BOTTOM));
         }
       });
     }

--- a/extensions/amp-instagram/0.1/amp-instagram.js
+++ b/extensions/amp-instagram/0.1/amp-instagram.js
@@ -210,7 +210,7 @@ class AmpInstagram extends AMP.BaseElement {
         if (this.iframe_ && this.iframe_./*OK*/offsetHeight !== height) {
           // Height returned by Instagram includes header, so
           // subtract 48px top padding
-          this.attemptChangeHeight(height - (PADDING_TOP + PADDING_BOTTOM))
+          this./*OK*/changeHeight(height - (PADDING_TOP + PADDING_BOTTOM))
               .catch(() => {});
         }
       });

--- a/extensions/amp-instagram/0.1/test/test-amp-instagram.js
+++ b/extensions/amp-instagram/0.1/test/test-amp-instagram.js
@@ -161,7 +161,7 @@ describes.realWin('amp-instagram', {
     return getIns('fBwFP', true).then(ins => {
       const impl = ins.implementation_;
       const iframe = ins.querySelector('iframe');
-      const attemptChangeHeight = sandbox.spy(impl, 'attemptChangeHeight');
+      const changeHeight = sandbox.spy(impl, 'changeHeight');
       const newHeight = 977;
 
       expect(iframe).to.not.be.null;
@@ -170,9 +170,9 @@ describes.realWin('amp-instagram', {
         height: newHeight,
       });
 
-      expect(attemptChangeHeight).to.be.calledOnce;
+      expect(changeHeight).to.be.calledOnce;
       // Height minus padding
-      expect(attemptChangeHeight.firstCall.args[0]).to.equal(newHeight - 64);
+      expect(changeHeight.firstCall.args[0]).to.equal(newHeight - 64);
     });
   });
 


### PR DESCRIPTION
Closes https://github.com/ampproject/amphtml/issues/11777 Closes #12356

Most other embeds like `amp-twitter` , `amp-facebook` already allow `changeHeight` unconditionally. I don't see a reason Instagram should be different. Let's make them consistent to eliminate confusions like https://github.com/ampproject/amphtml/issues/11777 