### PR TITLE
CSP for AMP creative render

### DIFF
--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -74,6 +74,12 @@ export const RENDERING_TYPE_HEADER = 'X-AmpAdRender';
 /** @type {string} @visibleForTesting */
 export const SAFEFRAME_VERSION_HEADER = 'X-AmpSafeFrameVersion';
 
+/** @type {string} @visibleForTesting */
+export const EXPERIMENT_FEATURE_HEADER_NAME = 'amp-ff-exps';
+
+/** @type {string} @visibleForTesting */
+export const CSP_ENABLED_EXP_NAME = 'csp_enabled';
+
 /** @type {string} */
 const TAG = 'amp-a4a';
 
@@ -309,6 +315,16 @@ export class AmpA4A extends AMP.BaseElement {
      */
     this.releaseType_ = getBinaryTypeNumericalCode(getBinaryType(this.win)) ||
         '-1';
+
+    /**
+     * Mapping of feature name to value extracted from ad response header
+     * amp-ff-exps with comma separated pairs of '=' separated key/value.
+     * @type {!Object<string,string>}
+     */
+    this.postAdResponseExperimentFeatures = {};
+
+    /** @private {boolean} whether CSP for FIE is enabled */
+    this.cspEnabled_ = false;
   }
 
   /** @override */
@@ -602,6 +618,21 @@ export class AmpA4A extends AMP.BaseElement {
           // assuming ad url or creative exist.
           if (!fetchResponse) {
             return null;
+          }
+          if (fetchResponse.headers && fetchResponse.headers.has(
+              EXPERIMENT_FEATURE_HEADER_NAME)) {
+            fetchResponse.headers.get(EXPERIMENT_FEATURE_HEADER_NAME).split(',')
+              .forEach(pair => {
+                const parts = pair.split('=');
+                if (parts.length == 2 && parts[0]) {
+                  this.postAdResponseExperimentFeatures[parts[0]] = parts[1];
+                } else {
+                  dev().warn(TAG, `invalid experiment feature ${pair}`);
+                }
+              });
+            this.cspEnabled_ =
+              this.postAdResponseExperimentFeatures[CSP_ENABLED_EXP_NAME] ==
+                'true';
           }
           // If the response has response code 204, or arrayBuffer is null,
           // collapse it.
@@ -960,6 +991,8 @@ export class AmpA4A extends AMP.BaseElement {
     this.fromResumeCallback = false;
     this.experimentalNonAmpCreativeRenderMethod_ =
         this.getNonAmpCreativeRenderingMethod();
+    this.postAdResponseExperimentFeatures = {};
+    this.cspEnabled_ = false;
   }
 
   /**
@@ -1245,6 +1278,7 @@ export class AmpA4A extends AMP.BaseElement {
           html: creativeMetaData.minifiedCreative,
           extensionIds: creativeMetaData.customElementExtensions || [],
           fonts: fontsArray,
+          cspEnabled: this.cspEnabled_,
         }, embedWin => {
           installUrlReplacementsForEmbed(this.getAmpDoc(), embedWin,
               new A4AVariableSource(this.getAmpDoc(), embedWin));

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -77,7 +77,10 @@ export const SAFEFRAME_VERSION_HEADER = 'X-AmpSafeFrameVersion';
 /** @type {string} @visibleForTesting */
 export const EXPERIMENT_FEATURE_HEADER_NAME = 'amp-ff-exps';
 
-/** @type {string} @visibleForTesting */
+/**
+ * Controls if Content Security Policy is enabled for FIE render.
+ * @type {string} @visibleForTesting
+ */
 export const CSP_ENABLED_EXP_NAME = 'csp_enabled';
 
 /** @type {string} */
@@ -624,11 +627,11 @@ export class AmpA4A extends AMP.BaseElement {
             fetchResponse.headers.get(EXPERIMENT_FEATURE_HEADER_NAME).split(',')
               .forEach(pair => {
                 const parts = pair.split('=');
-                if (parts.length == 2 && parts[0]) {
-                  this.postAdResponseExperimentFeatures[parts[0]] = parts[1];
-                } else {
+                if (parts.length != 2 || !parts[0]) {
                   dev().warn(TAG, `invalid experiment feature ${pair}`);
+                  return;
                 }
+                this.postAdResponseExperimentFeatures[parts[0]] = parts[1];
               });
             this.cspEnabled_ =
               this.postAdResponseExperimentFeatures[CSP_ENABLED_EXP_NAME] ==

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -24,6 +24,8 @@ import {
   SAFEFRAME_VERSION_HEADER,
   protectFunctionWrapper,
   assignAdUrlToError,
+  EXPERIMENT_FEATURE_HEADER_NAME,
+  CSP_ENABLED_EXP_NAME,
 } from '../amp-a4a';
 import {
   AMP_SIGNATURE_HEADER,
@@ -311,6 +313,22 @@ describe('amp-a4a', () => {
         expect(child).to.be.ok;
         expect(child).to.be.visible;
         expect(onCreativeRenderSpy.withArgs(null)).to.be.called;
+      });
+    });
+
+    it('populate postAdResponseExperimentFeatures', () => {
+      adResponse.headers[EXPERIMENT_FEATURE_HEADER_NAME] =
+          `foo=bar,bad,${CSP_ENABLED_EXP_NAME}=true`;
+      a4a.buildCallback();
+      a4a.onLayoutMeasure();
+      return a4a.layoutCallback().then(() => {
+        const child = a4aElement.querySelector('iframe[srcdoc]');
+        expect(child).to.be.ok;
+        expect(child.srcdoc.indexOf('meta http-equiv=Content-Security-Policy'))
+            .to.not.equal(-1);
+        expect(a4a.postAdResponseExperimentFeatures).to.jsonEqual({
+          foo: 'bar', [CSP_ENABLED_EXP_NAME]: 'true',
+        });
       });
     });
 

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -316,7 +316,7 @@ describe('amp-a4a', () => {
       });
     });
 
-    it('populate postAdResponseExperimentFeatures', () => {
+    it('populates postAdResponseExperimentFeatures', () => {
       adResponse.headers[EXPERIMENT_FEATURE_HEADER_NAME] =
           `foo=bar,bad,${CSP_ENABLED_EXP_NAME}=true`;
       a4a.buildCallback();

--- a/src/friendly-iframe-embed.js
+++ b/src/friendly-iframe-embed.js
@@ -56,6 +56,7 @@ const EXCLUDE_INI_LOAD = ['AMP-AD', 'AMP-ANALYTICS', 'AMP-PIXEL'];
  *   html: string,
  *   extensionIds: (?Array<string>|undefined),
  *   fonts: (?Array<string>|undefined),
+ *   cspEnabled: boolean,
  * }}
  */
 export let FriendlyIframeSpec;
@@ -265,6 +266,12 @@ function mergeHtml(spec) {
       result.push(
           `<link href="${escapeHtml(font)}" rel="stylesheet" type="text/css">`);
     });
+  }
+
+  // Load CSP
+  if (spec.cspEnabled) {
+    result.push('<meta http-equiv=Content-Security-Policy ' +
+      'content="script-src "none";object-src "none";child-src "none">');
   }
 
   // Postambule.

--- a/src/friendly-iframe-embed.js
+++ b/src/friendly-iframe-embed.js
@@ -155,6 +155,11 @@ export function installFriendlyIframeEmbed(iframe, container, spec,
     iframe.src = 'about:blank';
     container.appendChild(iframe);
     const childDoc = iframe.contentWindow.document;
+    if (spec.cspEnabled) {
+      childDoc.addEventListener('securitypolicyviolation', violationEvent => {
+        dev().warn('FIE', 'security policy violation', violationEvent);
+      });
+    }
     childDoc.open();
     childDoc.write(html);
     // With document.write, `iframe.onload` arrives almost immediately, thus
@@ -271,7 +276,7 @@ function mergeHtml(spec) {
   // Load CSP
   if (spec.cspEnabled) {
     result.push('<meta http-equiv=Content-Security-Policy ' +
-      'content="script-src "none";object-src "none";child-src "none">');
+      'content="script-src \'none\';object-src \'none\';child-src \'none\'">');
   }
 
   // Postambule.

--- a/src/friendly-iframe-embed.js
+++ b/src/friendly-iframe-embed.js
@@ -154,7 +154,7 @@ export function installFriendlyIframeEmbed(iframe, container, spec,
         violationEvent => {
           dev().warn('FIE', 'security policy violation', violationEvent);
         });
-  }
+  };
   let loadedPromise;
   if (isSrcdocSupported()) {
     iframe.srcdoc = html;

--- a/test/functional/test-friendly-iframe-embed.js
+++ b/test/functional/test-friendly-iframe-embed.js
@@ -434,6 +434,18 @@ describe('friendly-iframe-embed', () => {
           + '<base href="https://acme.org/embed1">'
           + 'content');
     });
+
+    it('should insert CSP', () => {
+      spec.html = '<html><head></head><body></body></html>';
+      spec.cspEnabled = true;
+      const html = mergeHtmlForTesting(spec);
+      expect(html).to.equal(
+          '<html><head><base href="https://acme.org/embed1">' +
+          '<meta http-equiv=Content-Security-Policy ' +
+          'content="script-src \'none\';object-src \'none\';' +
+          'child-src \'none\'">' +
+          '</head><body></body></html>');
+    });
   });
 
   describe('child document ready and loaded states', () => {

--- a/test/functional/test-friendly-iframe-embed.js
+++ b/test/functional/test-friendly-iframe-embed.js
@@ -438,13 +438,24 @@ describe('friendly-iframe-embed', () => {
     it('should insert CSP', () => {
       spec.html = '<html><head></head><body></body></html>';
       spec.cspEnabled = true;
-      const html = mergeHtmlForTesting(spec);
-      expect(html).to.equal(
+      expect(mergeHtmlForTesting(spec)).to.equal(
           '<html><head><base href="https://acme.org/embed1">' +
           '<meta http-equiv=Content-Security-Policy ' +
           'content="script-src \'none\';object-src \'none\';' +
           'child-src \'none\'">' +
           '</head><body></body></html>');
+      spec.html = '<html>foo';
+      expect(mergeHtmlForTesting(spec)).to.equal(
+          '<html><base href="https://acme.org/embed1">' +
+          '<meta http-equiv=Content-Security-Policy ' +
+          'content="script-src \'none\';object-src \'none\';' +
+          'child-src \'none\'">foo');
+      spec.html = '<body>foo';
+      expect(mergeHtmlForTesting(spec)).to.equal(
+          '<base href="https://acme.org/embed1">' +
+          '<meta http-equiv=Content-Security-Policy ' +
+          'content="script-src \'none\';object-src \'none\';' +
+          'child-src \'none\'"><body>foo');
     });
   });
 


### PR DESCRIPTION
Create framework to start experiment which will measure the effect of enforcing a CSP for AMP creative FIE render.  Also allows for using single header to control post ad response behaviors (comma separate, '=' delimited pairs)