### PR TITLE
Only asserts resource ID if NOT inabox

### DIFF
--- a/extensions/amp-ad-exit/0.1/amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/amp-ad-exit.js
@@ -322,6 +322,7 @@ export class AmpAdExit extends AMP.BaseElement {
    */
   init3pResponseListener_() {
     if (getMode().runtime == 'inabox') {
+      // TODO(jonkeller): Remove this once #11436 is resolved.
       return;
     }
     this.ampAdResourceId_ = this.ampAdResourceId_ ||

--- a/extensions/amp-ad-exit/0.1/amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/amp-ad-exit.js
@@ -20,6 +20,7 @@ import {createFilter} from './filters/factory';
 import {isJsonScriptTag, openWindowDialog} from '../../../src/dom';
 import {getAmpAdResourceId} from '../../../src/ad-helper';
 import {Services} from '../../../src/services';
+import {getMode} from '../../../src/mode';
 import {user, dev} from '../../../src/log';
 import {parseJson} from '../../../src/json';
 import {parseUrl} from '../../../src/url';
@@ -280,10 +281,6 @@ export class AmpAdExit extends AMP.BaseElement {
       throw e;
     }
 
-    this.ampAdResourceId_ = user().assert(
-        this.getAmpAdResourceId_(),
-        `${TAG}: No friendly parent amp-ad element was found for amp-ad-exit.`);
-
     this.init3pResponseListener_();
   }
 
@@ -324,6 +321,13 @@ export class AmpAdExit extends AMP.BaseElement {
    * @private
    */
   init3pResponseListener_() {
+    if (getMode().runtime == 'inabox') {
+      return;
+    }
+    this.ampAdResourceId_ = this.ampAdResourceId_ ||
+        user().assert(this.getAmpAdResourceId_(),
+            `${TAG}: No friendly parent amp-ad element was found for ` +
+            'amp-ad-exit; not in inabox case.');
     dev().assert(!this.unlisten_, 'Unlistener should not already exist.');
     this.unlisten_ = listen(this.getAmpDoc().win, 'message',
         event => {


### PR DESCRIPTION
amp-ad-exit won't be inside amp-ad, if using inabox.

This PR effectively disables listening for messages from vendor frame iff inabox.