### PR TITLE
Fix bug that useRemoteHtml wasn't being used in Doubleclick-a4a-config

### DIFF
--- a/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
@@ -130,7 +130,8 @@ export class DoubleclickA4aEligibility {
           win, DFP_CANONICAL_FF_EXPERIMENT_NAME, experimentId);
     }
 
-    if ('useSameDomainRenderingUntilDeprecated' in element.dataset ||
+    if (useRemoteHtml ||
+        'useSameDomainRenderingUntilDeprecated' in element.dataset ||
         element.hasAttribute('useSameDomainRenderingUntilDeprecated')) {
       return false;
     }

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
@@ -130,7 +130,7 @@ export class DoubleclickA4aEligibility {
           win, DFP_CANONICAL_FF_EXPERIMENT_NAME, experimentId);
     }
 
-    if (useRemoteHtml ||
+    if ((useRemoteHtml && !element.getAttribute('rtc-config')) ||
         'useSameDomainRenderingUntilDeprecated' in element.dataset ||
         element.hasAttribute('useSameDomainRenderingUntilDeprecated')) {
       return false;

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-a4a-config.js
@@ -70,6 +70,20 @@ describe('doubleclick-a4a-config', () => {
       expect(elem.getAttribute(EXPERIMENT_ATTRIBUTE)).to.not.be.ok;
     });
 
+    it('should disable Fast Fetch if useRemoteHtml is true', () => {
+      // Ensure no selection in order to very experiment attribute.
+      sandbox.stub(DoubleclickA4aEligibility.prototype, 'maybeSelectExperiment')
+          .returns(null);
+      mockWin.location = parseUrl(
+          'https://cdn.ampproject.org/some/path/to/content.html');
+      const elem = testFixture.doc.createElement('div');
+      testFixture.doc.body.appendChild(elem);
+      const useRemoteHtml = true;
+      expect(
+          doubleclickIsA4AEnabled(mockWin, elem, useRemoteHtml)).to.be.false;
+      expect(elem.getAttribute(EXPERIMENT_ATTRIBUTE)).to.not.be.ok;
+    });
+
     it('should enable a4a when native crypto is supported', () => {
       forceExperimentBranch(mockWin, DFP_CANONICAL_FF_EXPERIMENT_NAME,
           DOUBLECLICK_EXPERIMENT_FEATURE.CANONICAL_EXPERIMENT);

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-a4a-config.js
@@ -70,7 +70,7 @@ describe('doubleclick-a4a-config', () => {
       expect(elem.getAttribute(EXPERIMENT_ATTRIBUTE)).to.not.be.ok;
     });
 
-    it('should disable Fast Fetch if useRemoteHtml is true', () => {
+    it('should disable Fast Fetch if useRemoteHtml is true and no RTC', () => {
       // Ensure no selection in order to very experiment attribute.
       sandbox.stub(DoubleclickA4aEligibility.prototype, 'maybeSelectExperiment')
           .returns(null);
@@ -81,6 +81,21 @@ describe('doubleclick-a4a-config', () => {
       const useRemoteHtml = true;
       expect(
           doubleclickIsA4AEnabled(mockWin, elem, useRemoteHtml)).to.be.false;
+      expect(elem.getAttribute(EXPERIMENT_ATTRIBUTE)).to.not.be.ok;
+    });
+
+    it('should use Fast Fetch if useRemoteHtml is true and RTC is set', () => {
+      // Ensure no selection in order to very experiment attribute.
+      sandbox.stub(DoubleclickA4aEligibility.prototype, 'maybeSelectExperiment')
+          .returns(null);
+      mockWin.location = parseUrl(
+          'https://cdn.ampproject.org/some/path/to/content.html');
+      const elem = testFixture.doc.createElement('div');
+      elem.setAttribute('rtc-config', '{"urls": ["https://www.foo.com/"]}');
+      testFixture.doc.body.appendChild(elem);
+      const useRemoteHtml = true;
+      expect(
+          doubleclickIsA4AEnabled(mockWin, elem, useRemoteHtml)).to.be.true;
       expect(elem.getAttribute(EXPERIMENT_ATTRIBUTE)).to.not.be.ok;
     });
 


### PR DESCRIPTION
Breakage due to https://github.com/ampproject/amphtml/pull/11704/files

Was incorrectly ignoring useRemoteHtml Param. The useRemoteHtml param was introduced so we could do unconditioned experiment selection. However, when useRemoteHtml is true and we are not in the unconditioned experiment, we should not select into Fast Fetch. The current behavior means that Delayed Fetch won't occur in the situation where publisher is using remote HTML to force into Delayed Fetch. This PR fixes that 
