### PR TITLE
Handle no-content response from clickUrl

### DIFF
--- a/build-system/app.js
+++ b/build-system/app.js
@@ -542,6 +542,8 @@ app.use('/impression-proxy/', (req, res) => {
     'gclid': '1234',
   };
   res.send(body);
+
+  // Or fake response with status 204 if viewer replaceUrl is provided
 });
 
 // Proxy with local JS.

--- a/src/impression.js
+++ b/src/impression.js
@@ -147,6 +147,7 @@ function handleClickUrl(win) {
   /** @const {string|undefined} */
   const clickUrl = viewer.getParam('click');
 
+
   if (!clickUrl) {
     return Promise.resolve();
   }
@@ -170,6 +171,8 @@ function handleClickUrl(win) {
     return invoke(win, dev().assertString(clickUrl));
   }).then(response => {
     applyResponse(win, response);
+  }).catch(err => {
+    user().warn('Error on request clickUrl: ', err);
   });
 }
 
@@ -187,7 +190,13 @@ function invoke(win, clickUrl) {
     credentials: 'include',
     // All origins are allows to send these requests.
     requireAmpResponseSourceOrigin: false,
-  }).then(res => res.json());
+  }).then(res => {
+    // Treat 204 no content response specially
+    if (res.status == 204) {
+      return null;
+    }
+    return res.json();
+  });
 }
 
 /**

--- a/src/impression.js
+++ b/src/impression.js
@@ -172,7 +172,7 @@ function handleClickUrl(win) {
   }).then(response => {
     applyResponse(win, response);
   }).catch(err => {
-    user().warn('Error on request clickUrl: ', err);
+    user().warn('IMPRESSION', 'Error on request clickUrl: ', err);
   });
 }
 
@@ -180,7 +180,7 @@ function handleClickUrl(win) {
  * Send the url to ad server and wait for its response
  * @param {!Window} win
  * @param {string} clickUrl
- * @return {!Promise<!JsonObject>}
+ * @return {!Promise<?JsonObject>}
  */
 function invoke(win, clickUrl) {
   if (getMode().localDev && !getMode().test) {
@@ -203,9 +203,13 @@ function invoke(win, clickUrl) {
  * parse the response back from ad server
  * Set for analytics purposes
  * @param {!Window} win
- * @param {!JsonObject} response
+ * @param {?JsonObject} response
  */
 function applyResponse(win, response) {
+  if (!response) {
+    return;
+  }
+
   const adLocation = response['location'];
   const adTracking = response['tracking_url'];
 


### PR DESCRIPTION
close #11790 

Please note that 204 response is only expected when `replaceUrl` is present. However I feel even without `replaceUrl`, a no-content response should still be handled without throwing an error/warning. Let me know if anyone thinks that I should check the existence of `replaceUrl` specifically. 

cc @sucharithav

