### PR TITLE
Remove vendors.js from 'cookie' whitelist

### DIFF
--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -354,7 +354,6 @@ const forbiddenTerms = {
       'build-system/test-server.js',
       'src/cookies.js',
       'src/service/cid-impl.js',
-      'extensions/amp-analytics/0.1/vendors.js',
       'testing/fake-dom.js',
     ],
   },


### PR DESCRIPTION
No longer necessary so let's remove and keep the whitelist clean. Added in: https://github.com/ampproject/amphtml/pull/8317/files#diff-43075fef96144a4f898edb8d18aae69aR559

/to @lannka