### PR TITLE
Adds presubmit rule to avoid Promise.defer()

### DIFF
--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -586,6 +586,9 @@ const forbiddenTerms = {
       'dist.3p/current/integration.js',
     ],
   },
+  '\\.defer\\(\\)': {
+    message: 'Promise.defer() is deprecated and should not be used.',
+  },
 };
 
 const ThreePTermsMessage = 'The 3p bootstrap iframe has no polyfills loaded' +


### PR DESCRIPTION
Adds presubmit rule to avoid Promise.defer() since that is deprecated.
Fixes #11801 