### PR TITLE
Chrome Ext: Use tab's UA in the Validator's requests

### DIFF
--- a/validator/chromeextension/amp-validator.html
+++ b/validator/chromeextension/amp-validator.html
@@ -259,7 +259,7 @@ limitations under the License.
           },
         });
         function processTab(tabs, toolbar, content) {
-          var url = tabs[0].url;
+          var url = tabs[0].url.split('#')[0];
           var validationResult;
           chrome.runtime.getBackgroundPage(function(backgroundPage) {
             validationResult =

--- a/validator/chromeextension/background.js
+++ b/validator/chromeextension/background.js
@@ -242,8 +242,10 @@ function updateTabStatus(tabId, iconPrefix, title, text, color) {
  * @param {userAgent} string Tab's current user agent
  */
 function validateUrlFromTab(tab, userAgent) {
-  var xhr = new XMLHttpRequest();
-  xhr.open('GET', tab.url, true);
+  var xhr = new XMLHttpRequest(),
+    url = tab.url.split('#')[0];
+
+  xhr.open('GET', url, true);
   // We can't set the User-Agent header directly, but we can set this header
   //   and let the onBeforeSendHeaders handler rename it for us
   // Add the listener now. It'll be removed after the request is made.
@@ -252,7 +254,7 @@ function validateUrlFromTab(tab, userAgent) {
   //   99.9% of requests which aren't for AMP validation.
   chrome.webRequest.onBeforeSendHeaders.addListener(
     updateSendHeadersUserAgent,
-    {urls: [tab.url], types: ["xmlhttprequest"], tabId: -1},
+    {urls: [url], types: ["xmlhttprequest"], tabId: -1},
     ["requestHeaders", "blocking"]
   );
 
@@ -268,7 +270,7 @@ function validateUrlFromTab(tab, userAgent) {
 
       const doc = xhr.responseText;
       const validationResult = amp.validator.validateString(doc);
-      window.sessionStorage.setItem(tab.url, JSON.stringify(validationResult));
+      window.sessionStorage.setItem(url, JSON.stringify(validationResult));
       if (validationResult.status == 'PASS') {
         handleAmpPass(tab.id, validationResult);
       } else {

--- a/validator/chromeextension/content_script.js
+++ b/validator/chromeextension/content_script.js
@@ -111,6 +111,8 @@ function isAmpDocument() {
  * - fromAmpCache: Is the page from an AMP Cache.
  * - ampHref: the href to an AMP page if the page is not an AMP page but there
  *   is an <link rel="amphtml"> or if the page is from an AMP Cache.
+ * - userAgent: Tab's current userAgent, which may have been modified by device
+ *   emulation
  *
  * Requests for loadAmp and has ampHref, then redirects the browser to ampHref.
  */
@@ -123,6 +125,7 @@ chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
     if (fromAmpCache) ampHref = getAmpCacheHref();
     sendResponse({
       'isAmp': isAmp, 'fromAmpCache': fromAmpCache, 'ampHref': ampHref,
+      'userAgent': navigator.userAgent,
     });
   }
   if (request.loadAmp && request.ampHref) {

--- a/validator/chromeextension/manifest.json
+++ b/validator/chromeextension/manifest.json
@@ -29,6 +29,8 @@
   "content_security_policy": "script-src 'self' https://cdn.ampproject.org; object-src 'self'",
   "homepage_url": "https://www.ampproject.org",
   "permissions": [
+    "webRequest",
+    "webRequestBlocking",
     "tabs",
     "<all_urls>"
   ]


### PR DESCRIPTION
Currently the validator's XHR requests use the browser's "default" UA, which may be different from the tab's UA (if, e.g., it's in mobile emulation mode). If the server responds differently to different UA's this causes problems.

Fixes https://github.com/ampproject/amphtml/issues/11741

* Tab's content_script.js sends the UA with the Validation request
* Background sets this UA in its XHR request via a listener

