### PR TITLE
Fix broken initLogConstructor issue

### DIFF
--- a/src/log.js
+++ b/src/log.js
@@ -583,7 +583,11 @@ export function user(opt_element) {
  */
 function getUserLogger(suffix) {
   if (!logConstructor) {
-    throw new Error('failed to call initLogConstructor');
+    if (getMode().test || getMode().localDev) {
+      initLogConstructor();
+    } else {
+      throw new Error('failed to call initLogConstructor');
+    }
   }
   return new logConstructor(self, mode => {
     const logNum = parseInt(mode.log, 10);
@@ -609,7 +613,11 @@ export function dev() {
     return logs.dev;
   }
   if (!logConstructor) {
-    throw new Error('failed to call initLogConstructor');
+    if (getMode().test || getMode().localDev) {
+      initLogConstructor();
+    } else {
+      throw new Error('failed to call initLogConstructor');
+    }
   }
   return logs.dev = new logConstructor(self, mode => {
     const logNum = parseInt(mode.log, 10);


### PR DESCRIPTION
### Issue
If you run 
``` gulp test --a4a ```
you will see a bunch of test failures that say "failed to call initLogConstructor".
`gulp test --a4a-` runs all A4A related tests in a randomized ordering. When the tests are not in random order, everything passes. This is presumably because initLogConstructor is getting called early and causes the log constructor to exist for future calls to user() or dev(). However, in random order, the "early" code does not execute early, and so future calls to user() or dev() fail.

Not sure what is the best way to fix this.

DO NOT SUBMIT the solution I've done here. This just initializes the log constructor automatically at call-time if in a test or localdev. This seems like a bad idea, but not sure what the 'good' idea would be. Tried to initialize from the tests themselves, and that didn't work. 