### PR TITLE
Allows whitespace between URL params

### DIFF
--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -912,7 +912,7 @@ export class UrlReplacements {
     let replacement = url.replace(expr, (match, name, opt_strargs) => {
       let args = [];
       if (typeof opt_strargs == 'string') {
-        args = opt_strargs.split(',');
+        args = opt_strargs.split(/,\s*/);
       }
       if (opt_whiteList && !opt_whiteList[name]) {
         // Do not perform substitution and just return back the original

--- a/src/service/variable-source.js
+++ b/src/service/variable-source.js
@@ -243,6 +243,6 @@ export class VariableSource {
     // FOO_BAR(arg1,arg2)
     // FOO_BAR(arg1, arg2)
     return new RegExp('\\$?(' + all + ')' +
-        '(?:\\(([0-9a-zA-Z-_.]+(?:,\\s*[0-9a-zA-Z-_.]*)*)\\))?', 'g');
+        '(?:\\((\\s*(?!,)(?:\\s*,?\\s*[0-9a-zA-Z-_.]*)*)\\))?', 'g');
   }
 }

--- a/src/service/variable-source.js
+++ b/src/service/variable-source.js
@@ -236,11 +236,13 @@ export class VariableSource {
     keys.sort((s1, s2) => s2.length - s1.length);
     const all = keys.join('|');
     // Match the given replacement patterns, as well as optionally
-    // arguments to the replacement behind it in parantheses.
+    // arguments to the replacement behind it in parentheses.
     // Example string that match
     // FOO_BAR
     // FOO_BAR(arg1)
     // FOO_BAR(arg1,arg2)
-    return new RegExp('\\$?(' + all + ')(?:\\(([0-9a-zA-Z-_.,]+)\\))?', 'g');
+    // FOO_BAR(arg1, arg2)
+    return new RegExp('\\$?(' + all + ')' +
+        '(?:\\(([0-9a-zA-Z-_.]+(?:,\\s*[0-9a-zA-Z-_.]*)*)\\))?', 'g');
   }
 }

--- a/src/service/variable-source.js
+++ b/src/service/variable-source.js
@@ -243,6 +243,6 @@ export class VariableSource {
     // FOO_BAR(arg1,arg2)
     // FOO_BAR(arg1, arg2)
     return new RegExp('\\$?(' + all + ')' +
-        '(?:\\((\\s*(?!,)(?:\\s*,?\\s*[0-9a-zA-Z-_.]*)*)\\))?', 'g');
+        '(?:\\(((?:\\s*[0-9a-zA-Z-_.]*\\s*(?=,|\\)),?)*)\\s*\\))?', 'g');
   }
 }


### PR DESCRIPTION
Will fix https://github.com/ampproject/amphtml/issues/11616, i.e. will allow whitespace after a comma in parameter lists.
