### PR TITLE
Fix animation bugs related to page activation

### DIFF
--- a/extensions/amp-story/0.1/amp-story-page.js
+++ b/extensions/amp-story/0.1/amp-story-page.js
@@ -224,14 +224,23 @@ export class AmpStoryPage extends AMP.BaseElement {
     this.pageActiveCallback_();
   }
 
+  /** @override */
+  layoutCallback() {
+    return this.beforeVisible();
+  }
+
+  /** @return {!Promise} */
+  beforeVisible() {
+    return this.maybeApplyFirstAnimationFrame();
+  }
 
   /** @private */
   onPageVisible_() {
     this.markPageAsLoaded_();
-    this.maybeApplyFirstAnimationFrame();
     this.updateAudioIcon_();
     this.playAllMedia_();
     this.advancement_.start();
+    this.maybeStartAnimations();
     this.reportDevModeErrors_();
   }
 

--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -506,20 +506,6 @@ export class AmpStory extends AMP.BaseElement {
   }
 
   /**
-   * @param {!./amp-story-page.AmpStoryPage} page
-   */
-  maybeApplyFirstAnimationFrame_(page) {
-    page.maybeApplyFirstAnimationFrame();
-  }
-
-  /**
-   * @param {!./amp-story-page.AmpStoryPage} page
-   */
-  maybeStartAnimations_(page) {
-    page.maybeStartAnimations();
-  }
-
-  /**
    * Switches to a particular page.
    * @param {string} targetPageId
    * @return {!Promise}
@@ -558,16 +544,14 @@ export class AmpStory extends AMP.BaseElement {
     const previousActivePriorSibling = scopedQuerySelector(
         this.element, `[${PRE_ACTIVE_PAGE_ATTRIBUTE_NAME}]`);
 
-    this.maybeApplyFirstAnimationFrame_(targetPage);
-
     return this.mutateElement(() => {
       this.activePage_ = targetPage;
       this.triggerActiveEventForPage_();
       this.systemLayer_.resetDeveloperLogs();
       this.systemLayer_.setDeveloperLogContextString(
           this.activePage_.element.id);
-      this.maybeStartAnimations_(targetPage);
     })
+        .then(() => targetPage.beforeVisible())
         .then(() => {
           if (oldPage) {
             oldPage.setActive(false);

--- a/extensions/amp-story/0.1/animation.js
+++ b/extensions/amp-story/0.1/animation.js
@@ -311,6 +311,11 @@ class AnimationRunner {
   cancel() {
     this.scheduledActivity_ = null;
     this.scheduledWait_ = null;
+
+    if (this.hasStarted()) {
+      dev().assert(this.runner_).cancel();
+      this.runnerReset_ = true;
+    }
   }
 
   /**


### PR DESCRIPTION
Moving page activation logic to `AmpStoryPage` caused some animation regressions.

1. First frame was being applied twice, which made elements disappear after animation ended when using certain presets.

2. First frame could "jump" since it's being applied when the page is already visible.

3. Previously unknown bug related to animations not being cancelled properly.