### PR TITLE
AMP creative inabox Server Side Rendering image inclusion

### DIFF
--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -124,7 +124,9 @@ export class AmpImg extends BaseElement {
 
     // For inabox SSR, image will have been written directly to DOM so no need
     // to recreate.  Calling appendChild again will have no effect.
-    this.img_ = this.element.querySelector('img');
+    if (this.element.hasAttribute('i-amphtml-ssr')) {
+      this.img_ = this.element.querySelector('img');
+    }
     this.img_ = this.img_ || new Image();
     this.img_.setAttribute('async', '');
     if (this.element.id) {

--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -122,7 +122,10 @@ export class AmpImg extends BaseElement {
       this.allowImgLoadFallback_ = false;
     }
 
-    this.img_ = new Image();
+    // For inabox SSR, image will have been written directly to DOM so no need
+    // to recreate.  Calling appendChild again will have no effect.
+    this.img_ = this.element.querySelector('img');
+    this.img_ = this.img_ || new Image();
     this.img_.setAttribute('async', '');
     if (this.element.id) {
       this.img_.setAttribute('amp-img-id', this.element.id);

--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -15,6 +15,7 @@
  */
 
 import {BaseElement} from '../src/base-element';
+import {scopedQuerySelector} from '../src/dom';
 import {isLayoutSizeDefined} from '../src/layout';
 import {registerElement} from '../src/service/custom-element-registry';
 import {srcsetFromElement, srcsetFromSrc} from '../src/srcset';
@@ -125,7 +126,7 @@ export class AmpImg extends BaseElement {
     // For inabox SSR, image will have been written directly to DOM so no need
     // to recreate.  Calling appendChild again will have no effect.
     if (this.element.hasAttribute('i-amphtml-ssr')) {
-      this.img_ = this.element.querySelector('img');
+      this.img_ = scopedQuerySelector(this.element, 'img');
     }
     this.img_ = this.img_ || new Image();
     this.img_.setAttribute('async', '');

--- a/builtins/amp-pixel.js
+++ b/builtins/amp-pixel.js
@@ -59,7 +59,8 @@ export class AmpPixel extends BaseElement {
           `${TAG}: invalid "referrerpolicy" value "${this.referrerPolicy_}".`
           + ' Only "no-referrer" is supported');
     }
-    if (this.element.querySelector('img')) {
+    if (this.element.hasAttribute('i-amphtml-ssr') &&
+        this.element.querySelector('img')) {
       dev().info(TAG, 'inabox img already present');
       return;
     }

--- a/builtins/amp-pixel.js
+++ b/builtins/amp-pixel.js
@@ -59,6 +59,10 @@ export class AmpPixel extends BaseElement {
           `${TAG}: invalid "referrerpolicy" value "${this.referrerPolicy_}".`
           + ' Only "no-referrer" is supported');
     }
+    if (this.element.querySelector('img')) {
+      dev().info(TAG, 'inabox img already present');
+      return;
+    }
     // Trigger, but only when visible.
     const viewer = Services.viewerForDoc(this.getAmpDoc());
     viewer.whenFirstVisible().then(this.trigger_.bind(this));

--- a/builtins/amp-pixel.js
+++ b/builtins/amp-pixel.js
@@ -15,6 +15,7 @@
  */
 
 import {BaseElement} from '../src/base-element';
+import {scopedQuerySelector} from '../src/dom';
 import {dev, user} from '../src/log';
 import {dict} from '../src/utils/object';
 import {registerElement} from '../src/service/custom-element-registry';
@@ -60,7 +61,7 @@ export class AmpPixel extends BaseElement {
           + ' Only "no-referrer" is supported');
     }
     if (this.element.hasAttribute('i-amphtml-ssr') &&
-        this.element.querySelector('img')) {
+        scopedQuerySelector(this.element, 'img')) {
       dev().info(TAG, 'inabox img already present');
       return;
     }

--- a/examples/adsense.amp.html
+++ b/examples/adsense.amp.html
@@ -5,19 +5,92 @@
   <title>Adsense examples</title>
   <link rel="canonical" href="http://nonblocking.io/" >
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <style amp-custom>
+    amp-ad {
+      max-width: 500px;
+    }
+    .red {
+      background-color: red;
+    }
+    .talldiv {
+      height: 2000px;
+    }
+    amp-ad div[placeholder] {
+      background-color: lightgray;
+    }
+    amp-ad div[fallback] {
+      background-color: black;
+    }
+    amp-ad div[placeholder]::after {
+      content: "loading ...";
+    }
+    amp-ad div[fallback]::after {
+      content: "No ad";
+      color: white;
+    }
+    amp-ad div[placeholder]::after,
+    amp-ad div[fallback]::after {
+      font-size: 20px;
+      line-height: 30px;
+      text-align: center;
+      position: absolute;
+      left: 0;
+      right: 0;
+      top: calc(50% - 15px);
+    }
+    amp-user-notification {
+      background-color: lightgray;
+      padding: 5px;
+    }
+  </style>
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
+  <script async custom-element="amp-user-notification" src="https://cdn.ampproject.org/v0/amp-user-notification-0.1.js"></script>
+  <script async custom-element="amp-ad" src="https://cdn.ampproject.org/v0/amp-ad-0.1.js"></script>
 </head>
 <body>
-  <amp-img height=250 width=300 src="https://www-wikihow-com.cdn.ampproject.org/i/s/www.wikihow.com/images/thumb/a/a9/Delete-Messages-on-Facebook-Messenger-Step-1.jpg/v4-460px-Delete-Messages-on-Facebook-Messenger-Step-1.jpg">
-    <i-amphtml-sizer style="display: block; padding-top: 75%;"></i-amphtml-sizer>
-    <img async class="i-amphtml-fill-content i-amphtml-replaced-content" src="https://www-wikihow-com.cdn.ampproject.org/i/s/www.wikihow.com/images/a/a9/Delete-Messages-on-Facebook-Messenger-Step-1.jpg">
-  </amp-img>
-  <amp-pixel src="https://tpc.googlesyndication.com/pagead/images/adchoices/icon.png">
-    <img asyc src="https://tpc.googlesyndication.com/pagead/images/adchoices/icon.png"/>
-  </amp-pixel>
+
+  <amp-user-notification
+      layout=nodisplay
+      id="amp-user-notification">
+    This site uses cookies to personalize content.
+    <a href="#learn-more">Learn more.</a>
+    <button on="tap:amp-user-notification.dismiss" role="button" tabindex="0">I accept</button>
+  </amp-user-notification>
 
   <h2>AdSense</h2>
+  <amp-ad width=300 height=250
+      type="adsense"
+      data-ad-client="ca-pub-2005682797531342"
+      data-ad-slot="7046626912">
+    <div placeholder></div>
+    <div fallback></div>
+  </amp-ad>
+
+  <amp-ad width=300 height=250
+          type="adsense"
+          data-ad-client="ca-pub-2005682797531342"
+          data-ad-slot="7046626912"
+          data-consent-notification-id="amp-user-notification">
+    <div placeholder>should only show ad after notification get dismissed</div>
+    <div fallback></div>
+  </amp-ad>
+
+  <div class=talldiv>
+    <!-- Make the second ad below the fold. -->
+  </div>
+
+  <h2>AdSense ad 2</h2>
+
+  <amp-ad width=300 height=250
+      type="adsense"
+      data-ad-client="ca-pub-2005682797531342"
+      data-ad-slot="7046626912"
+      data-adtest="on">
+    <div placeholder></div>
+    <div fallback></div>
+  </amp-ad>
 
 </body>
 </html>

--- a/examples/adsense.amp.html
+++ b/examples/adsense.amp.html
@@ -5,92 +5,19 @@
   <title>Adsense examples</title>
   <link rel="canonical" href="http://nonblocking.io/" >
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
-  <style amp-custom>
-    amp-ad {
-      max-width: 500px;
-    }
-    .red {
-      background-color: red;
-    }
-    .talldiv {
-      height: 2000px;
-    }
-    amp-ad div[placeholder] {
-      background-color: lightgray;
-    }
-    amp-ad div[fallback] {
-      background-color: black;
-    }
-    amp-ad div[placeholder]::after {
-      content: "loading ...";
-    }
-    amp-ad div[fallback]::after {
-      content: "No ad";
-      color: white;
-    }
-    amp-ad div[placeholder]::after,
-    amp-ad div[fallback]::after {
-      font-size: 20px;
-      line-height: 30px;
-      text-align: center;
-      position: absolute;
-      left: 0;
-      right: 0;
-      top: calc(50% - 15px);
-    }
-    amp-user-notification {
-      background-color: lightgray;
-      padding: 5px;
-    }
-  </style>
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
-  <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
-  <script async custom-element="amp-user-notification" src="https://cdn.ampproject.org/v0/amp-user-notification-0.1.js"></script>
-  <script async custom-element="amp-ad" src="https://cdn.ampproject.org/v0/amp-ad-0.1.js"></script>
 </head>
 <body>
-
-  <amp-user-notification
-      layout=nodisplay
-      id="amp-user-notification">
-    This site uses cookies to personalize content.
-    <a href="#learn-more">Learn more.</a>
-    <button on="tap:amp-user-notification.dismiss" role="button" tabindex="0">I accept</button>
-  </amp-user-notification>
+  <amp-img height=250 width=300 src="https://www-wikihow-com.cdn.ampproject.org/i/s/www.wikihow.com/images/thumb/a/a9/Delete-Messages-on-Facebook-Messenger-Step-1.jpg/v4-460px-Delete-Messages-on-Facebook-Messenger-Step-1.jpg">
+    <i-amphtml-sizer style="display: block; padding-top: 75%;"></i-amphtml-sizer>
+    <img async class="i-amphtml-fill-content i-amphtml-replaced-content" src="https://www-wikihow-com.cdn.ampproject.org/i/s/www.wikihow.com/images/a/a9/Delete-Messages-on-Facebook-Messenger-Step-1.jpg">
+  </amp-img>
+  <amp-pixel src="https://tpc.googlesyndication.com/pagead/images/adchoices/icon.png">
+    <img asyc src="https://tpc.googlesyndication.com/pagead/images/adchoices/icon.png"/>
+  </amp-pixel>
 
   <h2>AdSense</h2>
-  <amp-ad width=300 height=250
-      type="adsense"
-      data-ad-client="ca-pub-2005682797531342"
-      data-ad-slot="7046626912">
-    <div placeholder></div>
-    <div fallback></div>
-  </amp-ad>
-
-  <amp-ad width=300 height=250
-          type="adsense"
-          data-ad-client="ca-pub-2005682797531342"
-          data-ad-slot="7046626912"
-          data-consent-notification-id="amp-user-notification">
-    <div placeholder>should only show ad after notification get dismissed</div>
-    <div fallback></div>
-  </amp-ad>
-
-  <div class=talldiv>
-    <!-- Make the second ad below the fold. -->
-  </div>
-
-  <h2>AdSense ad 2</h2>
-
-  <amp-ad width=300 height=250
-      type="adsense"
-      data-ad-client="ca-pub-2005682797531342"
-      data-ad-slot="7046626912"
-      data-adtest="on">
-    <div placeholder></div>
-    <div fallback></div>
-  </amp-ad>
 
 </body>
 </html>

--- a/test/fixtures/images.html
+++ b/test/fixtures/images.html
@@ -110,6 +110,11 @@
   <p>
     Lorem ipsum dolor sit amet, has nisl nihil convenire et, vim at aeque inermis reprehendunt. Propriae tincidunt id nec, elit nusquam te mea, ius noster platonem in. Mea an idque minim, sit sale deleniti apeirian et. Omnium legendos tractatos cu mea. Vix in stet dolorem accusamus. Iisque rationibus consetetur in cum, quo unum nulla legere ut. Simul numquam saperet no sit.
   </p>
+  <p>
+    In a box case
+    <amp-img id="img8" src="/examples/img/sample.jpg" width=527 height=193 layout="responsive">
+      <img src="/examples/img/sample.jpg" width=527 height=193/>
+    </amp-img>
   </p>
   <amp-ad width=300 height=250
       type="a9"

--- a/test/fixtures/images.html
+++ b/test/fixtures/images.html
@@ -112,7 +112,7 @@
   </p>
   <p>
     In a box case
-    <amp-img id="img8" src="/examples/img/sample.jpg" width=527 height=193 layout="responsive">
+    <amp-img id="img8" i-amphtml-ssr src="/examples/img/sample.jpg" width=527 height=193 layout="responsive">
       <img src="/examples/img/sample.jpg" width=527 height=193/>
     </amp-img>
   </p>

--- a/test/integration/test-amp-img.js
+++ b/test/integration/test-amp-img.js
@@ -20,7 +20,7 @@ import {
 } from '../../testing/iframe.js';
 import {AmpEvents} from '../../src/amp-events';
 
-describe.configure().retryOnSaucelabs().run('Rendering of amp-img', function() {
+describe.configure().retryOnSaucelabs().run('Rendering of amp-img', () => {
   const timeout = window.ampTestRuntimeConfig.mochaTimeout;
 
   let fixture;
@@ -35,23 +35,25 @@ describe.configure().retryOnSaucelabs().run('Rendering of amp-img', function() {
   });
 
   it('should be present', () => {
-    expect(fixture.doc.querySelectorAll('amp-img')).to.have.length(15);
-    // 5 image visible in 500 pixel height.
+    expect(fixture.doc.querySelectorAll('amp-img')).to.have.length(16);
+    // 5 image visible in 500 pixel height. Note that there will be no load
+    // event for the inabox image.
     return fixture.awaitEvent(AmpEvents.LOAD_START, 3).then(function() {
       expect(fixture.doc.querySelectorAll('amp-img img[src]')).to
-          .have.length(3);
+          .have.length(4);
     });
   });
 
   it('should resize and load more elements', () => {
+    // Note that there will be no load event for the inabox image.
     const p = fixture.awaitEvent(AmpEvents.LOAD_START, 11).then(function() {
       expect(fixture.doc.querySelectorAll('amp-img img[src]'))
-          .to.have.length(11);
+          .to.have.length(12);
       fixture.iframe.height = 2000;
       fixture.win.dispatchEvent(new fixture.win.Event('resize'));
       return fixture.awaitEvent(AmpEvents.LOAD_START, 13).then(function() {
         expect(fixture.doc.querySelectorAll('amp-img img[src]'))
-            .to.have.length(13);
+            .to.have.length(14);
       });
     });
     fixture.iframe.height = 1500;
@@ -78,6 +80,14 @@ describe.configure().retryOnSaucelabs().run('Rendering of amp-img', function() {
         expect(smallScreen.offsetHeight).to.equal(0);
         expect(largeScreen.offsetHeight).to.not.equal(0);
       });
+    });
+  });
+
+  it('should not load image if already present (inabox)', () => {
+    return fixture.awaitEvent(AmpEvents.LOAD_START, 3).then(function() {
+      const ampImage = fixture.doc.getElementById('img8');
+      expect(ampImage).is.ok;
+      expect(ampImage.querySelectorAll('img').length).to.equal(1);
     });
   });
 });

--- a/test/integration/test-amp-pixel.js
+++ b/test/integration/test-amp-pixel.js
@@ -51,7 +51,8 @@ describes.fakeWin('amp-pixel with img (inabox)', {amp: true}, env => {
   it('should not write image', () => {
     const src = 'https://foo.com/tracker/foo';
     const pixelElem =
-        createElementWithAttributes(env.win.document, 'amp-pixel', {src});
+        createElementWithAttributes(env.win.document, 'amp-pixel',
+        {src, 'i-amphtml-ssr': ''});
     pixelElem.appendChild(
         createElementWithAttributes(env.win.document, 'img', {src}));
     env.win.document.body.appendChild(pixelElem);

--- a/test/integration/test-amp-pixel.js
+++ b/test/integration/test-amp-pixel.js
@@ -18,6 +18,9 @@ import {
   depositRequestUrl,
   withdrawRequest,
 } from '../../testing/test-helper';
+import {createElementWithAttributes} from '../../src/dom';
+import {Services} from '../../src/services';
+import {AmpPixel} from '../../builtins/amp-pixel';
 
 describe.configure().run('amp-pixel', function() {
   this.timeout(15000);
@@ -41,5 +44,23 @@ describe.configure().run('amp-pixel', function() {
         expect(request.headers.referer).to.not.be.ok;
       });
     });
+  });
+});
+
+describes.fakeWin('amp-pixel with img (inabox)', {amp: true}, env => {
+  it('should not write image', () => {
+    const src = 'https://foo.com/tracker/foo';
+    const pixelElem =
+        createElementWithAttributes(env.win.document, 'amp-pixel', {src});
+    pixelElem.appendChild(
+        createElementWithAttributes(env.win.document, 'img', {src}));
+    env.win.document.body.appendChild(pixelElem);
+    const viewer = Services.viewerForDoc(env.win.document);
+    env.sandbox.stub(viewer, 'whenFirstVisible', () => {
+      return Promise.resolve();
+    });
+    const pixel = new AmpPixel(pixelElem);
+    pixel.buildCallback();
+    expect(pixelElem.querySelectorAll('img').length).to.equal(1);
   });
 });


### PR DESCRIPTION
As part of Server Side Rendering for inabox AMP creatives, the creative will be transformed to include the image directly within amp-image/amp-pixel tags to ensure immediate fetch/render by the browser.  This PR ensures that the existence of the img tag prevents duplicate image fetch.