### PR TITLE
Add warnings for use of useSameDomainRenderingUntilDeprecated or remote.html with fast fetch.

### DIFF
--- a/ads/google/doubleclick.js
+++ b/ads/google/doubleclick.js
@@ -16,12 +16,9 @@
 
 import {makeCorrelator} from './correlator';
 import {validateData, loadScript} from '../../3p/3p';
-import {dev, user} from '../../src/log';
+import {dev} from '../../src/log';
 import {setStyles} from '../../src/style';
 import {getMultiSizeDimensions} from './utils';
-
-/** @type {string} */
-const TAG = 'DoubleClick';
 
 /**
  * @enum {number}

--- a/ads/google/doubleclick.js
+++ b/ads/google/doubleclick.js
@@ -280,14 +280,7 @@ export function selectGptExperiment(data) {
  */
 export function writeAdScript(global, data, gptFilename) {
   const url =
-        `https://www.googletagservices.com/tag/js/${gptFilename || 'gpt.js'}`;
-  const hasUSDRD = data.useSameDomainRenderingUntilDeprecated != undefined;
-  if (hasUSDRD) {
-    user().warn(TAG, 'useSameDomainRenderingUntilDeprecated will no longer ' +
-                'be supported starting on March 29, 2018. Please refer to ' +
-                'https://github.com/ampproject/amphtml/issues/11834 ' +
-                'for morch information');
-  }
+  `https://www.googletagservices.com/tag/js/${gptFilename || 'gpt.js'}`;
   if (gptFilename || data.useSameDomainRenderingUntilDeprecated != undefined
     || data.multiSize) {
     doubleClickWithGpt(global, data, GladeExperiment.GLADE_OPT_OUT, url);

--- a/ads/google/doubleclick.js
+++ b/ads/google/doubleclick.js
@@ -16,9 +16,12 @@
 
 import {makeCorrelator} from './correlator';
 import {validateData, loadScript} from '../../3p/3p';
-import {dev} from '../../src/log';
+import {dev, user} from '../../src/log';
 import {setStyles} from '../../src/style';
 import {getMultiSizeDimensions} from './utils';
+
+/** @type {string} */
+const TAG = 'DoubleClick';
 
 /**
  * @enum {number}
@@ -277,7 +280,14 @@ export function selectGptExperiment(data) {
  */
 export function writeAdScript(global, data, gptFilename) {
   const url =
-  `https://www.googletagservices.com/tag/js/${gptFilename || 'gpt.js'}`;
+        `https://www.googletagservices.com/tag/js/${gptFilename || 'gpt.js'}`;
+  const hasUSDRD = data.useSameDomainRenderingUntilDeprecated != undefined;
+  if (hasUSDRD) {
+    user().warn(TAG, 'useSameDomainRenderingUntilDeprecated will no longer ' +
+                'be supported starting on March 29, 2018. Please refer to ' +
+                'https://github.com/ampproject/amphtml/issues/11834 ' +
+                'for morch information');
+  }
   if (gptFilename || data.useSameDomainRenderingUntilDeprecated != undefined
     || data.multiSize) {
     doubleClickWithGpt(global, data, GladeExperiment.GLADE_OPT_OUT, url);

--- a/ads/google/doubleclick.md
+++ b/ads/google/doubleclick.md
@@ -104,8 +104,9 @@ Supported via `json` attribute:
 - `targeting`
 - `useSameDomainRenderingUntilDeprecated`
 
-### Temporary use of useSameDomainRenderingUntilDeprecated
-An experiment to use the higher performance GPT Light tag in place of the DoubleClick GPT tag causes the ad to render in a second cross domain iframe within the outer AMP iframe. This prevents ads from accessing the iframe sandbox information and methods which are provided by the AMP runtime. Until this API is available to work in the second level iframe, publishers can opt out of this experiment by including "useSameDomainRenderingUntilDeprecated": 1 as a json attribute. This attribute will be deprecated once the [new window.context implementation](https://github.com/ampproject/amphtml/issues/6829) is complete. After that point, the GPT Light tag will become the default and all eligible ads will always be rendered inside a second cross domain iframe.
+### Temporary use of useSameDomainRenderingUntilDeprecated until March 29, 2018
+Support for this attribute will be dropped on March 29, 2018. 
+An experiment to use the higher performance GPT Light tag in place of the DoubleClick GPT tag causes the ad to render in a second cross domain iframe within the outer AMP iframe. This prevents ads from accessing the iframe sandbox information and methods which are provided by the AMP runtime. Until this API is available to work in the second level iframe, publishers can opt out of this experiment by including "useSameDomainRenderingUntilDeprecated": 1 as a json attribute. This attribute will be deprecated on March 29, 2018. After that point, the GPT Light tag will become the default and all eligible ads will always be rendered inside a second cross domain iframe. For more information, please refer to https://github.com/ampproject/amphtml/issues/11834;
 
 Example:
 ```html

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
@@ -162,20 +162,18 @@ export class DoubleclickA4aEligibility {
    */
   isA4aEnabled(win, element, useRemoteHtml) {
     this.unconditionedExperimentSelection(win, element);
-    const hasUSDRD =
-          'useSameDomainRenderingUntilDeprecated' in element.dataset ||
-          element.hasAttribute('useSameDomainRenderingUntilDeprecated');
+    const warnDeprecation = feature => user.warn(
+        TAG, `${feature} will no longer ` +
+          'be supported starting on March 29, 2018. Please refer to ' +
+          'https://github.com/ampproject/amphtml/issues/11834 ' +
+          'for more information');
+    const usdrd = 'useSameDomainRenderingUntilDeprecated';
+    const hasUSDRD = usdrd in element.dataset || element.hasAttribute(usdrd);
     if (hasUSDRD) {
-      user().warn(TAG, 'useSameDomainRenderingUntilDeprecated will no longer ' +
-                  'be supported starting on March 29, 2018. Please refer to ' +
-                  'https://github.com/ampproject/amphtml/issues/11834 ' +
-                  'for morch information');
+      warnDeprecation(usdrd);
     }
     if (useRemoteHtml) {
-      user().warn(TAG, 'The use of remote.html will no longer ' +
-                  'be supported starting on March 29, 2018. Please refer to ' +
-                  'https://github.com/ampproject/amphtml/issues/11834 ' +
-                  'for morch information');
+      warnDeprecation('remote.html');
     }
     if (hasUSDRD || (useRemoteHtml && !element.getAttribute('rtc-config'))) {
       return false;

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
@@ -162,7 +162,7 @@ export class DoubleclickA4aEligibility {
    */
   isA4aEnabled(win, element, useRemoteHtml) {
     this.unconditionedExperimentSelection(win, element);
-    const warnDeprecation = feature => user.warn(
+    const warnDeprecation = feature => user().warn(
         TAG, `${feature} will no longer ` +
           'be supported starting on March 29, 2018. Please refer to ' +
           'https://github.com/ampproject/amphtml/issues/11834 ' +

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
@@ -33,7 +33,7 @@ import {
   randomlySelectUnsetExperiments,
 } from '../../../src/experiments';
 import {getMode} from '../../../src/mode';
-import {dev} from '../../../src/log';
+import {dev, user} from '../../../src/log';
 
 /** @const {string} */
 export const DOUBLECLICK_A4A_EXPERIMENT_NAME = 'expDoubleclickA4A';
@@ -162,9 +162,15 @@ export class DoubleclickA4aEligibility {
    */
   isA4aEnabled(win, element, useRemoteHtml) {
     this.unconditionedExperimentSelection(win, element);
-    if ((useRemoteHtml && !element.getAttribute('rtc-config')) ||
-        'useSameDomainRenderingUntilDeprecated' in element.dataset ||
+    if ('useSameDomainRenderingUntilDeprecated' in element.dataset ||
         element.hasAttribute('useSameDomainRenderingUntilDeprecated')) {
+      user().warn(TAG, 'useSameDomainRenderingUntilDeprecated will no longer ' +
+                  'be supported starting on March 29, 2018. Please refer to ' +
+                  'https://github.com/ampproject/amphtml/issues/11834 ' +
+                  'for morch information');
+      return false;
+    }
+    if (useRemoteHtml && !element.getAttribute('rtc-config')) {
       return false;
     }
     let experimentId;

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
@@ -162,15 +162,22 @@ export class DoubleclickA4aEligibility {
    */
   isA4aEnabled(win, element, useRemoteHtml) {
     this.unconditionedExperimentSelection(win, element);
-    if ('useSameDomainRenderingUntilDeprecated' in element.dataset ||
-        element.hasAttribute('useSameDomainRenderingUntilDeprecated')) {
+    const hasUSDRD =
+          'useSameDomainRenderingUntilDeprecated' in element.dataset ||
+          element.hasAttribute('useSameDomainRenderingUntilDeprecated');
+    if (hasUSDRD) {
       user().warn(TAG, 'useSameDomainRenderingUntilDeprecated will no longer ' +
                   'be supported starting on March 29, 2018. Please refer to ' +
                   'https://github.com/ampproject/amphtml/issues/11834 ' +
                   'for morch information');
-      return false;
     }
-    if (useRemoteHtml && !element.getAttribute('rtc-config')) {
+    if (useRemoteHtml) {
+      user().warn(TAG, 'The use of remote.html will no longer ' +
+                  'be supported starting on March 29, 2018. Please refer to ' +
+                  'https://github.com/ampproject/amphtml/issues/11834 ' +
+                  'for morch information');
+    }
+    if (hasUSDRD || (useRemoteHtml && !element.getAttribute('rtc-config'))) {
       return false;
     }
     let experimentId;


### PR DESCRIPTION
See https://github.com/ampproject/amphtml/issues/11834