### PR TITLE
Add realistic example of non-provider

### DIFF
--- a/extensions/amp-social-share/amp-social-share.md
+++ b/extensions/amp-social-share/amp-social-share.md
@@ -195,22 +195,22 @@ The `amp-social-share` component provides [some pre-configured providers](0.1/am
 </table>
 
 
-### Non-configured Providers
+## Non-configured providers
 
 In addition to pre-configured providers, you can use non-configured providers by specifying additional attributes in the `amp-social-share` component.
 
 **Example: Creating a share button for a non-configured provider**
 
-The following example creates a share button through WhatsApp by setting the `data-share-endpoint` attribute to the correct endpoint for the WhatsApp custom protocol.
+The following example creates a share button through Facebook Messenger by setting the `data-share-endpoint` attribute to the correct endpoint for the Facebook Messenger custom protocol.
 
 ```html
-<amp-social-share type="whatsapp"
-    layout="container"
-    data-share-endpoint="whatsapp://send"
+<amp-social-share type="facebookmessenger"
+    data-share-endpoint="fb-messenger://share"
     data-param-text="Check out this article: TITLE - CANONICAL_URL">
-    Share on Whatsapp
 </amp-social-share>
 ```
+
+As these providers are not pre-configured, you'll need to create the appropriate button image and styles for the provider.
 
 ## Styles
 
@@ -237,10 +237,7 @@ You can use [global AMP variables substitution](https://github.com/ampproject/am
 
 ```html
 <amp-social-share type="whatsapp"
-    layout="container"
-    data-share-endpoint="whatsapp://send"
     data-param-text="Check out this article: TITLE - CANONICAL_URL">
-    Share on Whatsapp
 </amp-social-share>
 ```
 


### PR DESCRIPTION
The existing example for a non-provider was actually a pre-configured provider.  I stumbled upon someone using "facebookmessenger", which is a non-configured provider, so I thought it would be a good example.