### PR TITLE
amp-story: Workaround for broken "thirds" in Safari

### DIFF
--- a/examples/amp-story/grid-layer-templates.html
+++ b/examples/amp-story/grid-layer-templates.html
@@ -90,6 +90,14 @@
         </amp-story-grid-layer>
       </amp-story-page>
 
+      <amp-story-page id="vertical-template-thirds">
+        <amp-story-grid-layer template="thirds">
+          <div class="content" grid-area="upper-third">Paragraph 1</div>
+          <div class="content" grid-area="middle-third">Paragraph 2</div>
+          <div class="content" grid-area="lower-third">Paragraph 3</div>
+        </amp-story-grid-layer>
+      </amp-story-page>
+
       <amp-story-page id="horizontal-template-title">
         <amp-story-grid-layer template="vertical">
           <h1>horizontal</h1>

--- a/extensions/amp-story/0.1/amp-story.css
+++ b/extensions/amp-story/0.1/amp-story.css
@@ -312,7 +312,7 @@ amp-story-grid-layer * {
 }
 
 .i-amphtml-story-grid-template-thirds {
-  grid-template-rows: repeat(3, 1fr) !important;
+  grid-template-rows: 33% 33% 33% !important; /* `fr` is broken in Safari. */
   grid-template-areas: "upper-third"
                        "middle-third"
                        "lower-third" !important;


### PR DESCRIPTION
Fixes #11930.

/to @alanorozco @prateekbh 