### PR TITLE
Implementing comScore amp-story page view analytics

### DIFF
--- a/extensions/amp-analytics/0.1/test/vendor-requests.json
+++ b/extensions/amp-analytics/0.1/test/vendor-requests.json
@@ -50,7 +50,8 @@
   "comscore": {
     "host": "https://sb.scorecardresearch.com",
     "base": "https://sb.scorecardresearch.com/b?",
-    "pageview": "https://sb.scorecardresearch.com/b?c1=2&c2=1000001&cs_pv=_page_view_id_&c12=_client_id_&rn=_random_&c8=_title_&c7=_canonical_url_&c9=_document_referrer_&cs_c7amp=_ampdoc_url_"
+    "pageview": "https://sb.scorecardresearch.com/b?c1=2&c2=1000001&cs_pv=_page_view_id_&c12=_client_id_&rn=_random_&c8=_title_&c7=_canonical_url_&c9=_document_referrer_&cs_c7amp=_ampdoc_url_",
+    "storyPageview": "https://sb.scorecardresearch.com/b?c1=2&c2=1000001&cs_pv=_page_view_id_&c12=_client_id_&ns_type=view&rn=_random_&c8=_title_&c7=_canonical_url_%23_story_page_id_&c9=_document_referrer_&cs_c7amp=_ampdoc_url_"
   },
   "cxense": {
     "host": "https://scomcluster.cxense.com",

--- a/extensions/amp-analytics/0.1/vendors.js
+++ b/extensions/amp-analytics/0.1/vendors.js
@@ -387,11 +387,25 @@ export const ANALYTICS_CONFIG = /** @type {!JsonObject} */ ({
         '&c7=${canonicalUrl}' +
         '&c9=${documentReferrer}' +
         '&cs_c7amp=${ampdocUrl}',
+      'storyPageview': '${base}c1=2' +
+        '&c2=${c2}' +
+        '&cs_pv=${pageViewId}' +
+        '&c12=${clientId(comScore)}' +
+        '&ns_type=view' +
+        '&rn=${random}' +
+        '&c8=${title}' +
+        '&c7=${canonicalUrl}%23${pageId}' +
+        '&c9=${documentReferrer}' +
+        '&cs_c7amp=${ampdocUrl}',
     },
     'triggers': {
       'defaultPageview': {
         'on': 'visible',
         'request': 'pageview',
+      },
+      'defaultStoryPageView': {
+        'on': 'story-page-visible',
+        'request': 'storyPageview',
       },
     },
     'transport': {


### PR DESCRIPTION
At comScore we're ready to implement the new amp-story page views analytics.

We submitted issue ampproject/amphtml#11924 asking about variable names, so we decided to use `_story_page_id_` in the test results at `vendor-requests.json`. Please advise otherwise if wrong, as we're uncertain on how to reproduce these tests.