### PR TITLE
Add amp-analytics triggers for A4A lifecycle stages.

### DIFF
--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -376,9 +376,10 @@ export class AmpA4A extends AMP.BaseElement {
     /**
      * The configuration for amp-analytics. If null, no amp-analytics element
      * will be inserted and no analytics events will be fired.
+     * This will be initialized inside of buildCallback.
      * @private {?JsonObject}
      */
-    this.a4aAnalyticsConfig_ = this.getA4aAnalyticsConfig();
+    this.a4aAnalyticsConfig_ = null;
   }
 
   /** @override */
@@ -423,6 +424,7 @@ export class AmpA4A extends AMP.BaseElement {
           });
         });
 
+    this.a4aAnalyticsConfig_ = this.getA4aAnalyticsConfig();
     if (this.a4aAnalyticsConfig_) {
       // TODO(warrengm): Consider having page-level singletons for networks that
       // use the same config for all ads.

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -1667,16 +1667,16 @@ export class AmpA4A extends AMP.BaseElement {
   /**
    * Checks if the given lifecycle event has a corresponding amp-analytics event
    * and fires the analytics trigger if so.
-   * @param {string} lifeycleStage
+   * @param {string} lifecycleStage
    * @private
    */
-  maybeTriggerAnalyticsEvent_(lifeycleStage) {
+  maybeTriggerAnalyticsEvent_(lifecycleStage) {
     if (!this.a4aAnalyticsConfig_) {
       // No config exists that will listen to this event.
       return;
     }
     const analyticsEvent =
-        LIFECYCLE_STAGE_TO_ANALYTICS_TRIGGER[lifeycleStage];
+        LIFECYCLE_STAGE_TO_ANALYTICS_TRIGGER[lifecycleStage];
     if (!analyticsEvent) {
       // No analytics event is defined for this lifecycle stage.
       return;

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -184,6 +184,7 @@ const LIFECYCLE_STAGE_TO_ANALYTICS_TRIGGER = {
   'adRequestEnd': AnalyticsTrigger.AD_RESPONSE_END,
   'renderFriendlyStart': AnalyticsTrigger.AD_RENDER_START,
   'renderCrossDomainStart': AnalyticsTrigger.AD_RENDER_START,
+  'renderSafeFrameStart': AnalyticsTrigger.AD_RENDER_START,
   'renderFriendlyEnd': AnalyticsTrigger.AD_RENDER_END,
   'renderCrossDomainEnd': AnalyticsTrigger.AD_RENDER_END,
   'friendlyIframeIniLoad': AnalyticsTrigger.AD_IFRAME_LOADED,

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -426,7 +426,8 @@ export class AmpA4A extends AMP.BaseElement {
     if (this.ampAnalyticsConfig_) {
       // TODO(warrengm): Consider having page-level singletons for networks that
       // use the same config for all ads.
-      insertAnalyticsElement(this.element, this.ampAnalyticsConfig_, true);
+      insertAnalyticsElement(
+          this.element, this.ampAnalyticsConfig_, true /* loadAnalytics */);
     }
   }
 
@@ -1312,7 +1313,7 @@ export class AmpA4A extends AMP.BaseElement {
     }
     incrementLoadingAds(this.win, renderPromise);
     return renderPromise.then(
-        (result) => {
+        result => {
           this.handleLifecycleStage_('crossDomainIframeLoaded');
           // Pass on the result to the next value in the promise change.
           return result;

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -301,9 +301,14 @@ export class AmpA4A extends AMP.BaseElement {
     /**
      * Protected version of emitLifecycleEvent that ensures error does not
      * cause promise chain to reject.
-     * @private {?function(string, !Object=)}
+     * @private {function(string, !Object=)}
      */
-    this.protectedEmitLifecycleEvent_ = null;
+    this.protectedEmitLifecycleEvent_ = protectFunctionWrapper(
+        this.emitLifecycleEvent, this,
+        (err, varArgs) => {
+          dev().error(TAG, this.element.getAttribute('type'),
+              'Error on emitLifecycleEvent', err, varArgs) ;
+        });
 
     /** @const {string} */
     this.sentinel = generateSentinel(window);
@@ -392,12 +397,6 @@ export class AmpA4A extends AMP.BaseElement {
       width: this.element.getAttribute('width'),
       height: this.element.getAttribute('height'),
     };
-    this.protectedEmitLifecycleEvent_ = protectFunctionWrapper(
-        this.emitLifecycleEvent, this,
-        (err, varArgs) => {
-          dev().error(TAG, this.element.getAttribute('type'),
-              'Error on emitLifecycleEvent', err, varArgs) ;
-        });
     const upgradeDelayMs = Math.round(this.getResource().getUpgradeDelayMs());
     dev().info(TAG,
         `upgradeDelay ${this.element.getAttribute('type')}: ${upgradeDelayMs}`);

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -1673,6 +1673,8 @@ export class AmpA4A extends AMP.BaseElement {
   /**
    * Returns variables to be included on an analytics event. This can be
    * overridden by specific network implementations.
+   * Note that this function is called for each time an analytics event is
+   * fired.
    * @param {string} unusedAnalyticsEvent The name of the analytics event.
    * @return {!Object<string, string>}
    */
@@ -1680,8 +1682,9 @@ export class AmpA4A extends AMP.BaseElement {
 
   /**
    * Returns network-specific config for amp-analytics. It should overridden
-   * with network-specific configurations. If the network has no amp-analytics
-   * config, it should return null;
+   * with network-specific configurations.
+   * This function may return null. If so, no amp-analytics element will be
+   * added to this A4A element and no A4A triggers will be fired.
    * @return {?JsonObject}
    */
   getAmpAnalyticsConfig() { return null; }

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -168,11 +168,11 @@ export const LIFECYCLE_STAGES = {
  * @enum {string}
  */
 export const AnalyticsTrigger = {
-  AD_REQUEST_START: 'adRequestStart',
-  AD_RESPONSE_END: 'adResponseEnd',
-  AD_RENDER_START: 'adRenderStart',
-  AD_RENDER_END: 'adRenderEnd',
-  AD_IFRAME_LOADED: 'adIframeLoaded',
+  AD_REQUEST_START: 'ad-request-start',
+  AD_RESPONSE_END: 'ad-response-end',
+  AD_RENDER_START: 'ad-render-start',
+  AD_RENDER_END: 'ad-render-end',
+  AD_IFRAME_LOADED: 'ad-iframe-loaded',
 };
 
 /**
@@ -378,7 +378,7 @@ export class AmpA4A extends AMP.BaseElement {
      * will be inserted and no analytics events will be fired.
      * @private {?JsonObject}
      */
-    this.ampAnalyticsConfig_ = this.getAmpAnalyticsConfig();
+    this.a4aAnalyticsConfig_ = this.getA4aAnalyticsConfig();
   }
 
   /** @override */
@@ -423,11 +423,11 @@ export class AmpA4A extends AMP.BaseElement {
           });
         });
 
-    if (this.ampAnalyticsConfig_) {
+    if (this.a4aAnalyticsConfig_) {
       // TODO(warrengm): Consider having page-level singletons for networks that
       // use the same config for all ads.
       insertAnalyticsElement(
-          this.element, this.ampAnalyticsConfig_, true /* loadAnalytics */);
+          this.element, this.a4aAnalyticsConfig_, true /* loadAnalytics */);
     }
   }
 
@@ -1671,7 +1671,7 @@ export class AmpA4A extends AMP.BaseElement {
    * @private
    */
   maybeTriggerAnalyticsEvent_(lifeycleStage) {
-    if (!this.ampAnalyticsConfig_) {
+    if (!this.a4aAnalyticsConfig_) {
       // No config exists that will listen to this event.
       return;
     }
@@ -1683,7 +1683,7 @@ export class AmpA4A extends AMP.BaseElement {
     }
     const analyticsVars = Object.assign(
         {'time': Math.round(this.getNow_())},
-        this.getAmpAnalyticsVars(analyticsEvent));
+        this.getA4aAnalyticsVars(analyticsEvent));
     triggerAnalyticsEvent(this.element, analyticsEvent, analyticsVars);
   }
 
@@ -1695,7 +1695,7 @@ export class AmpA4A extends AMP.BaseElement {
    * @param {string} unusedAnalyticsEvent The name of the analytics event.
    * @return {!Object<string, string>}
    */
-  getAmpAnalyticsVars(unusedAnalyticsEvent) { return {}; }
+  getA4aAnalyticsVars(unusedAnalyticsEvent) { return {}; }
 
   /**
    * Returns network-specific config for amp-analytics. It should overridden
@@ -1704,7 +1704,7 @@ export class AmpA4A extends AMP.BaseElement {
    * added to this A4A element and no A4A triggers will be fired.
    * @return {?JsonObject}
    */
-  getAmpAnalyticsConfig() { return null; }
+  getA4aAnalyticsConfig() { return null; }
 
   /**
    * To be overriden by network specific implementation.

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -30,7 +30,7 @@ import {
 import {isLayoutSizeDefined, Layout} from '../../../src/layout';
 import {isAdPositionAllowed} from '../../../src/ad-helper';
 import {dev, user, duplicateErrorIfNecessary} from '../../../src/log';
-import {deepMerge, dict} from '../../../src/utils/object';
+import {dict} from '../../../src/utils/object';
 import {getMode} from '../../../src/mode';
 import {isArray, isObject, isEnumValue} from '../../../src/types';
 import {utf8Decode} from '../../../src/utils/bytes';
@@ -1666,19 +1666,18 @@ export class AmpA4A extends AMP.BaseElement {
       return;
     }
     const analyticsVars = Object.assign(
-        { 'time': Math.round(this.getNow_()) },
+        {'time': Math.round(this.getNow_())},
         this.getAmpAnalyticsVars(analyticsEvent));
-    triggerAnalyticsEvent(
-      this.element, analyticsEvent, analyticsVars);
+    triggerAnalyticsEvent(this.element, analyticsEvent, analyticsVars);
   }
 
   /**
    * Returns variables to be included on an analytics event. This can be
    * overridden by specific network implementations.
-   * @param {string} analyticsEvent The name of the analytics event.
+   * @param {string} unusedAnalyticsEvent The name of the analytics event.
    * @return {!Object<string, string>}
    */
-  getAmpAnalyticsVars(analyticsEvent) { return {}; }
+  getAmpAnalyticsVars(unusedAnalyticsEvent) { return {}; }
 
   /**
    * Returns network-specific config for amp-analytics. It should overridden

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -1917,9 +1917,10 @@ describe('amp-a4a', function() {
     });
 
     it('should emit upgradeDelay lifecycle ping', () => {
+      const emitLifecycleEventSpy =
+          sandbox.spy(MockA4AImpl.prototype, 'emitLifecycleEvent');
       return createIframePromise().then(fixture => {
         const a4a = new MockA4AImpl(createA4aElement(fixture.doc));
-        const emitLifecycleEventSpy = sandbox.spy(a4a, 'emitLifecycleEvent');
         a4a.buildCallback();
         expect(emitLifecycleEventSpy.withArgs('upgradeDelay', {
           'forced_delta': 12345,

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -55,7 +55,7 @@ import * as sinon from 'sinon';
 // AmpAd is not loaded already, so we need to load it separately.
 import '../../../amp-ad/0.1/amp-ad';
 
-describe('amp-a4a', function() {
+describe('amp-a4a', () => {
   let sandbox;
   let fetchMock;
   let getSigningServiceNamesMock;

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -235,7 +235,7 @@ describe('amp-a4a', () => {
     verifyContext(attributes._context);
   }
 
-  function verifyAmpAnalyticsTriggersWereFired(a4a, triggerAnalyticsEventSpy) {
+  function verifyA4aAnalyticsTriggersWereFired(a4a, triggerAnalyticsEventSpy) {
     expect(triggerAnalyticsEventSpy).to.be.calledWith(
         a4a.element, 'adRequestStart', {'time': sinon.match.number});
     expect(triggerAnalyticsEventSpy).to.be.calledWith(
@@ -398,7 +398,7 @@ describe('amp-a4a', () => {
         iniLoadResolver();
         return layoutPromise;
       }).then(() => {
-        verifyAmpAnalyticsTriggersWereFired(a4a, triggerAnalyticsEventSpy);
+        verifyA4aAnalyticsTriggersWereFired(a4a, triggerAnalyticsEventSpy);
       });
     });
 
@@ -468,12 +468,12 @@ describe('amp-a4a', () => {
       a4a.buildCallback();
       a4a.onLayoutMeasure();
       return a4a.layoutCallback().then(() => {
-        verifyAmpAnalyticsTriggersWereFired(a4a, triggerAnalyticsEventSpy);
+        verifyA4aAnalyticsTriggersWereFired(a4a, triggerAnalyticsEventSpy);
       });
     });
 
     it('should not fire amp-analytics triggers without config', () => {
-      sandbox.stub(MockA4AImpl.prototype, 'getAmpAnalyticsConfig', () => null);
+      sandbox.stub(MockA4AImpl.prototype, 'getA4aAnalyticsConfig', () => null);
       a4a = new MockA4AImpl(a4aElement);
       const triggerAnalyticsEventSpy =
           sandbox.spy(analytics, 'triggerAnalyticsEvent');
@@ -486,7 +486,7 @@ describe('amp-a4a', () => {
 
     it('should insert an amp-analytics element', () => {
       sandbox.stub(
-          MockA4AImpl.prototype, 'getAmpAnalyticsConfig',
+          MockA4AImpl.prototype, 'getA4aAnalyticsConfig',
           () => ({'foo': 'bar'}));
       a4a = new MockA4AImpl(a4aElement);
       const insertAnalyticsElementSpy =
@@ -497,7 +497,7 @@ describe('amp-a4a', () => {
     });
 
     it('should not insert an amp-analytics element if config is null', () => {
-      sandbox.stub(MockA4AImpl.prototype, 'getAmpAnalyticsConfig', () => null);
+      sandbox.stub(MockA4AImpl.prototype, 'getA4aAnalyticsConfig', () => null);
       a4a = new MockA4AImpl(a4aElement);
       const insertAnalyticsElementSpy =
           sandbox.spy(analyticsExtension, 'insertAnalyticsElement');
@@ -618,7 +618,7 @@ describe('amp-a4a', () => {
         const triggerAnalyticsEventSpy =
             sandbox.spy(analytics, 'triggerAnalyticsEvent');
         return a4a.layoutCallback().then(() => {
-          verifyAmpAnalyticsTriggersWereFired(a4a, triggerAnalyticsEventSpy);
+          verifyA4aAnalyticsTriggersWereFired(a4a, triggerAnalyticsEventSpy);
           expect(lifecycleEventStub).to.be.calledWith(
               'crossDomainIframeLoaded');
         });
@@ -690,7 +690,7 @@ describe('amp-a4a', () => {
         const triggerAnalyticsEventSpy =
             sandbox.spy(analytics, 'triggerAnalyticsEvent');
         return a4a.layoutCallback().then(() => {
-          verifyAmpAnalyticsTriggersWereFired(a4a, triggerAnalyticsEventSpy);
+          verifyA4aAnalyticsTriggersWereFired(a4a, triggerAnalyticsEventSpy);
           expect(lifecycleEventStub).to.be.calledWith(
               'crossDomainIframeLoaded');
         });
@@ -789,7 +789,7 @@ describe('amp-a4a', () => {
         const triggerAnalyticsEventSpy =
             sandbox.spy(analytics, 'triggerAnalyticsEvent');
         return a4a.layoutCallback().then(() => {
-          verifyAmpAnalyticsTriggersWereFired(a4a, triggerAnalyticsEventSpy);
+          verifyA4aAnalyticsTriggersWereFired(a4a, triggerAnalyticsEventSpy);
           expect(lifecycleEventStub).to.be.calledWith(
               'crossDomainIframeLoaded');
         });

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -393,11 +393,9 @@ describe('amp-a4a', () => {
           sandbox.spy(analytics, 'triggerAnalyticsEvent');
       a4a.onLayoutMeasure();
       const layoutPromise = a4a.layoutCallback();
-      return Promise.resolve().then(() => {
-        expect(whenIniLoadedStub).to.not.be.called;
-        iniLoadResolver();
-        return layoutPromise;
-      }).then(() => {
+      expect(whenIniLoadedStub).to.not.be.called;
+      iniLoadResolver();
+      layoutPromise.then(() => {
         verifyA4aAnalyticsTriggersWereFired(a4a, triggerAnalyticsEventSpy);
       });
     });

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -47,9 +47,11 @@ import {dev, user} from '../../../../src/log';
 import {createElementWithAttributes} from '../../../../src/dom';
 import {layoutRectLtwh} from '../../../../src/layout-rect';
 import {installDocService} from '../../../../src/service/ampdoc-impl';
+import * as sinon from 'sinon';
+// The following namespaces are imported so that we can stub and spy on certain
+// methods in tests.
 import * as analytics from '../../../../src/analytics';
 import * as analyticsExtension from '../../../../src/extension-analytics';
-import * as sinon from 'sinon';
 // Need the following side-effect import because in actual production code,
 // Fast Fetch impls are always loaded via an AmpAd tag, which means AmpAd is
 // always available for them. However, when we test an impl in isolation,

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -2025,20 +2025,20 @@ describe('amp-a4a', function() {
     });
 
     it('should trigger amp-analytics events for friendly iframe rendering',
-      () => {
-        a4a.buildCallback();
-        a4a.onLayoutMeasure();
-        return a4a.layoutCallback().then(() => {
-          expect(triggerAnalyticsEventSpy).to.be.calledWith(
-              element, 'adRequestStart', {'time': sinon.match.number});
-          expect(triggerAnalyticsEventSpy).to.be.calledWith(
-              element, 'adResponseEnd', {'time': sinon.match.number});
-          expect(triggerAnalyticsEventSpy).to.be.calledWith(
-              element, 'adRenderStart', {'time': sinon.match.number});
-          expect(triggerAnalyticsEventSpy).to.be.calledWith(
-              element, 'adRenderEnd', {'time': sinon.match.number});
+        () => {
+          a4a.buildCallback();
+          a4a.onLayoutMeasure();
+          return a4a.layoutCallback().then(() => {
+            expect(triggerAnalyticsEventSpy).to.be.calledWith(
+                element, 'adRequestStart', {'time': sinon.match.number});
+            expect(triggerAnalyticsEventSpy).to.be.calledWith(
+                element, 'adResponseEnd', {'time': sinon.match.number});
+            expect(triggerAnalyticsEventSpy).to.be.calledWith(
+                element, 'adRenderStart', {'time': sinon.match.number});
+            expect(triggerAnalyticsEventSpy).to.be.calledWith(
+                element, 'adRenderEnd', {'time': sinon.match.number});
+          });
         });
-      });
 
     it('should trigger amp-analytics for SafeFrame rendering', () => {
       // Make sure there's no signature, so that we go down the 3p iframe path.

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -237,15 +237,15 @@ describe('amp-a4a', () => {
 
   function verifyA4aAnalyticsTriggersWereFired(a4a, triggerAnalyticsEventSpy) {
     expect(triggerAnalyticsEventSpy).to.be.calledWith(
-        a4a.element, 'adRequestStart', {'time': sinon.match.number});
+        a4a.element, 'ad-request-start', {'time': sinon.match.number});
     expect(triggerAnalyticsEventSpy).to.be.calledWith(
-        a4a.element, 'adResponseEnd', {'time': sinon.match.number});
+        a4a.element, 'ad-response-end', {'time': sinon.match.number});
     expect(triggerAnalyticsEventSpy).to.be.calledWith(
-        a4a.element, 'adRenderStart', {'time': sinon.match.number});
+        a4a.element, 'ad-render-start', {'time': sinon.match.number});
     expect(triggerAnalyticsEventSpy).to.be.calledWith(
-        a4a.element, 'adRenderEnd', {'time': sinon.match.number});
+        a4a.element, 'ad-render-end', {'time': sinon.match.number});
     expect(triggerAnalyticsEventSpy).to.be.calledWith(
-        a4a.element, 'adIframeLoaded', {'time': sinon.match.number});
+        a4a.element, 'ad-iframe-loaded', {'time': sinon.match.number});
   }
 
   describe('ads are visible', () => {

--- a/extensions/amp-a4a/0.1/test/utils.js
+++ b/extensions/amp-a4a/0.1/test/utils.js
@@ -15,6 +15,7 @@
  */
 
 import {AmpA4A} from '../amp-a4a';
+import {dict} from '../../../../src/utils/object';
 
 /** @type {string} @private */
 export const TEST_URL = 'http://iframe.localhost:' + location.port +
@@ -44,5 +45,10 @@ export class MockA4AImpl extends AmpA4A {
   /** @override */
   getPreconnectUrls() {
     return ['https://googleads.g.doubleclick.net'];
+  }
+
+  /** @override */
+  getAmpAnalyticsConfig() {
+    return dict();
   }
 }

--- a/extensions/amp-a4a/0.1/test/utils.js
+++ b/extensions/amp-a4a/0.1/test/utils.js
@@ -48,7 +48,7 @@ export class MockA4AImpl extends AmpA4A {
   }
 
   /** @override */
-  getAmpAnalyticsConfig() {
+  getA4aAnalyticsConfig() {
     return dict();
   }
 }


### PR DESCRIPTION
Adds amp-analytics triggers to A4A for select lifecycle stages.

This PR (optionally) adds an amp-analytics element to each A4A element. A4A network implementations will be able to override two methods for interacting with amp-analytics:

- **getAmpAnalyticsConfig():** Returns the config for amp-analytics. If it returns null, no analytics element will be added and no triggers will be fired.
-  **getAmpAnalyticsVars(triggerName):** Returns variables to be included in the amp-analytics event for that trigger. This function will be called for each trigger that is fired.

Analytics triggers are fired for a select few A4A lifecycle stages. We may want to add additional analytics triggers for other lifecycle stages in the future (such as network errors). Note that triggers are fired to the analytics element within the A4A element.