### PR TITLE
Fix merging of categoryExclusions for DoubleClick RTC

### DIFF
--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -659,18 +659,23 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
               rewrittenResponse;
         }
         if (rtcResponse.response['categoryExclusions']) {
-          exclusions = exclusions || {};
-          [this.jsonTargeting_['categoryExclusions'],
-            rtcResponse.response['categoryExclusions']].forEach(
-              categoryExclusions => {
-                (categoryExclusions || []).forEach(exclusion => {
-                  exclusions[exclusion] = true;
-                });
+          if (!exclusions) {
+            exclusions = {};
+            if (this.jsonTargeting_['categoryExclusions']) {
+              this.jsonTargeting_['categoryExclusions'].forEach(exclusion => {
+                exclusions[exclusion] = true;
               });
+            }
+          }
+          rtcResponse.response['categoryExclusions'].forEach(exclusion => {
+            exclusions[exclusion] = true;
+          });
         }
       }
     });
-    this.jsonTargeting_['categoryExclusions'] = Object.keys(exclusions);
+    if (exclusions) {
+      this.jsonTargeting_['categoryExclusions'] = Object.keys(exclusions);
+    }
     return {'artc': artc.join() || null, 'ati': ati.join(), 'ard': ard.join()};
   }
 

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -658,12 +658,16 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
               rewrittenResponse;
         }
         if (rtcResponse.response['categoryExclusions']) {
+          const exclusions = {};
           this.jsonTargeting_['categoryExclusions'] =
               this.jsonTargeting_['categoryExclusions'] || [];
+          this.jsonTargeting_['categoryExclusions'].forEach(exclusion => {
+            exclusions[exclusion] = true;
+          });
           rtcResponse.response['categoryExclusions'].forEach(exclusion => {
-            if (this.jsonTargeting_['categoryExclusions'].indexOf(exclusion)
-                == -1) {
+            if (!exclusions[exclusion]) {
               this.jsonTargeting_['categoryExclusions'].push(exclusion);
+              exclusions[exclusion] = true;
             }
           });
         }

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -662,8 +662,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
           [this.jsonTargeting_['categoryExclusions'],
             rtcResponse.response['categoryExclusions']].forEach(
               categoryExclusions => {
-                categoryExclusions = categoryExclusions || [];
-                categoryExclusions.forEach(exclusion => {
+                (categoryExclusions || []).forEach(exclusion => {
                   exclusions[exclusion] = true;
                 });
               });

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -646,7 +646,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
       ati.push(!rtcResponse.error ? RTC_ATI_ENUM.RTC_SUCCESS :
                RTC_ATI_ENUM.RTC_FAILURE);
       ard.push(rtcResponse.callout);
-      if (rtcResponse) {
+      if (rtcResponse.response) {
         if (rtcResponse.response['targeting']) {
           const rewrittenResponse = this.rewriteRtcKeys_(
               rtcResponse.response['targeting'],
@@ -654,13 +654,18 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
           this.jsonTargeting_['targeting'] =
               !!this.jsonTargeting_['targeting'] ?
               deepMerge(this.jsonTargeting_['targeting'],
-                        rewrittenResponse) :
+                  rewrittenResponse) :
               rewrittenResponse;
         }
         if (rtcResponse.response['categoryExclusions']) {
           this.jsonTargeting_['categoryExclusions'] =
-              rtcResponse.response['categoryExclusions'].concat(
-                  this.jsonTargeting_['categoryExclusions'] || []);
+              this.jsonTargeting_['categoryExclusions'] || [];
+          rtcResponse.response['categoryExclusions'].forEach(exclusion => {
+            if (this.jsonTargeting_['categoryExclusions'].indexOf(exclusion)
+                == -1) {
+              this.jsonTargeting_['categoryExclusions'].push(exclusion);
+            }
+          });
         }
       }
     });

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -660,7 +660,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
         if (rtcResponse.response['categoryExclusions']) {
           this.jsonTargeting_['categoryExclusions'] =
               rtcResponse.response['categoryExclusions'].concat(
-                  this.jsonTargeting_['categoryExclusions'] || {});
+                  this.jsonTargeting_['categoryExclusions'] || []);
         }
       }
     });

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -659,17 +659,15 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
         }
         if (rtcResponse.response['categoryExclusions']) {
           const exclusions = {};
-          this.jsonTargeting_['categoryExclusions'] =
-              this.jsonTargeting_['categoryExclusions'] || [];
-          this.jsonTargeting_['categoryExclusions'].forEach(exclusion => {
-            exclusions[exclusion] = true;
-          });
-          rtcResponse.response['categoryExclusions'].forEach(exclusion => {
-            if (!exclusions[exclusion]) {
-              this.jsonTargeting_['categoryExclusions'].push(exclusion);
-              exclusions[exclusion] = true;
-            }
-          });
+          [this.jsonTargeting_['categoryExclusions'],
+            rtcResponse.response['categoryExclusions']].forEach(
+              categoryExclusions => {
+                categoryExclusions = categoryExclusions || [];
+                categoryExclusions.forEach(exclusion => {
+                  exclusions[exclusion] = true;
+                });
+              });
+          this.jsonTargeting_['categoryExclusions'] = Object.keys(exclusions);
         }
       }
     });

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -646,20 +646,22 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
       ati.push(!rtcResponse.error ? RTC_ATI_ENUM.RTC_SUCCESS :
                RTC_ATI_ENUM.RTC_FAILURE);
       ard.push(rtcResponse.callout);
-      if (rtcResponse.response['targeting']) {
-        const rewrittenResponse = this.rewriteRtcKeys_(
-            rtcResponse.response['targeting'],
-            rtcResponse.callout);
-        this.jsonTargeting_['targeting'] =
-            !!this.jsonTargeting_['targeting'] ?
-            deepMerge(this.jsonTargeting_['targeting'],
-                rewrittenResponse) :
-            rewrittenResponse;
-      }
-      if (rtcResponse.response['categoryExclusions']) {
-        this.jsonTargeting_['categoryExclusions'] =
-            rtcResponse.response['categoryExclusions'].concat(
-                this.jsonTargeting_['categoryExclusions'] || {});
+      if (rtcResponse) {
+        if (rtcResponse.response['targeting']) {
+          const rewrittenResponse = this.rewriteRtcKeys_(
+              rtcResponse.response['targeting'],
+              rtcResponse.callout);
+          this.jsonTargeting_['targeting'] =
+              !!this.jsonTargeting_['targeting'] ?
+              deepMerge(this.jsonTargeting_['targeting'],
+                        rewrittenResponse) :
+              rewrittenResponse;
+        }
+        if (rtcResponse.response['categoryExclusions']) {
+          this.jsonTargeting_['categoryExclusions'] =
+              rtcResponse.response['categoryExclusions'].concat(
+                  this.jsonTargeting_['categoryExclusions'] || {});
+        }
       }
     });
     return {'artc': artc.join() || null, 'ati': ati.join(), 'ard': ard.join()};

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -634,6 +634,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     const artc = [];
     const ati = [];
     const ard = [];
+    const exclusions = {};
     rtcResponseArray.forEach(rtcResponse => {
       // Only want to send errors for requests we actually sent.
       if (rtcResponse.error &&
@@ -658,7 +659,6 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
               rewrittenResponse;
         }
         if (rtcResponse.response['categoryExclusions']) {
-          const exclusions = {};
           [this.jsonTargeting_['categoryExclusions'],
             rtcResponse.response['categoryExclusions']].forEach(
               categoryExclusions => {

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -646,19 +646,20 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
       ati.push(!rtcResponse.error ? RTC_ATI_ENUM.RTC_SUCCESS :
                RTC_ATI_ENUM.RTC_FAILURE);
       ard.push(rtcResponse.callout);
-      if (rtcResponse.response) {
-        ['targeting', 'categoryExclusions'].forEach(key => {
-          if (rtcResponse.response[key]) {
-            const rewrittenResponse = this.rewriteRtcKeys_(
-                rtcResponse.response[key],
-                rtcResponse.callout);
-            this.jsonTargeting_[key] =
-                !!this.jsonTargeting_[key] ?
-                deepMerge(this.jsonTargeting_[key],
-                    rewrittenResponse) :
-                rewrittenResponse;
-          }
-        });
+      if (rtcResponse.response['targeting']) {
+        const rewrittenResponse = this.rewriteRtcKeys_(
+            rtcResponse.response['targeting'],
+            rtcResponse.callout);
+        this.jsonTargeting_['targeting'] =
+            !!this.jsonTargeting_['targeting'] ?
+            deepMerge(this.jsonTargeting_['targeting'],
+                rewrittenResponse) :
+            rewrittenResponse;
+      }
+      if (rtcResponse.response['categoryExclusions']) {
+        this.jsonTargeting_['categoryExclusions'] =
+            rtcResponse.response['categoryExclusions'].concat(
+                this.jsonTargeting_['categoryExclusions'] || {});
       }
     });
     return {'artc': artc.join() || null, 'ati': ati.join(), 'ard': ard.join()};

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -634,7 +634,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     const artc = [];
     const ati = [];
     const ard = [];
-    const exclusions = {};
+    let exclusions;
     rtcResponseArray.forEach(rtcResponse => {
       // Only want to send errors for requests we actually sent.
       if (rtcResponse.error &&
@@ -659,6 +659,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
               rewrittenResponse;
         }
         if (rtcResponse.response['categoryExclusions']) {
+          exclusions = exclusions || {};
           [this.jsonTargeting_['categoryExclusions'],
             rtcResponse.response['categoryExclusions']].forEach(
               categoryExclusions => {
@@ -666,10 +667,10 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
                   exclusions[exclusion] = true;
                 });
               });
-          this.jsonTargeting_['categoryExclusions'] = Object.keys(exclusions);
         }
       }
     });
+    this.jsonTargeting_['categoryExclusions'] = Object.keys(exclusions);
     return {'artc': artc.join() || null, 'ati': ati.join(), 'ard': ard.join()};
   }
 


### PR DESCRIPTION
CategoryExclusions was getting treated the same as targeting, but they are different. Targeting is an object, cE is an array. Need to merge separately. 