### PR TITLE
Render on idle experiment for doubleclick fast fetch

### DIFF
--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -129,9 +129,6 @@ export const CORRELATOR_CLEAR_EXP_BRANCHES = {
   EXPERIMENT: '22302765',
 };
 
-/** @const {string} */
-const RENDER_ON_IDLE_EXP_NAME = 'a4a-render-idle';
-
 /**
  * @const {string}
  * @visibileForTesting

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -129,6 +129,9 @@ export const CORRELATOR_CLEAR_EXP_BRANCHES = {
   EXPERIMENT: '22302765',
 };
 
+/** @const {string} */
+const RENDER_ON_IDLE_EXP_NAME = 'a4a-render-idle';
+
 /**
  * @const {string}
  * @visibileForTesting
@@ -356,6 +359,12 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
   }
 
   /** @override */
+  renderOnIdleOutsideViewport() {
+    return getExperimentBranch(
+        this.win, RENDER_ON_IDLE_EXP_NAME) == '21061138' ? 5 : false;
+  }
+
+  /** @override */
   isLayoutSupported(layout) {
     this.isFluid_ = layout == Layout.FLUID;
     return this.isFluid_ || isLayoutSizeDefined(layout);
@@ -408,13 +417,26 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     this.win['dbclk_a4a_viz_change'] = true;
 
     const sfPreloadExpName = 'a4a-safeframe-preloading-off';
-    const experimentInfoMap =
+    let experimentInfoMap =
         /** @type {!Object<string, !ExperimentInfo>} */ ({});
     experimentInfoMap[sfPreloadExpName] = {
       isTrafficEligible: () => true,
       branches: ['21061135', '21061136'],
     };
     randomlySelectUnsetExperiments(this.win, experimentInfoMap);
+    experimentInfoMap =
+        /** @type {!Object<string, !ExperimentInfo>} */ ({});
+    experimentInfoMap[RENDER_ON_IDLE_EXP_NAME] = {
+      isTrafficEligible: () => true,
+      // TODO: allocate actual ids!!!
+      branches: ['21061137', '21061138'],
+    };
+    randomlySelectUnsetExperiments(this.win, experimentInfoMap);
+    const renderIdleExpId =
+        getExperimentBranch(this.win, RENDER_ON_IDLE_EXP_NAME);
+    if (renderIdleExpId) {
+      addExperimentIdToElement(renderIdleExpId, this.element);
+    }
     const sfPreloadExpId = getExperimentBranch(this.win, sfPreloadExpName);
     if (sfPreloadExpId) {
       addExperimentIdToElement(sfPreloadExpId, this.element);

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -359,11 +359,8 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
   idleRenderOutsideViewport() {
     const vpRange =
         parseInt(this.postAdResponseExperimentFeatures['render-idle-vp'], 10);
-    // Disable if publisher has indicated a non-default loading strategy or
-    // renderOutsideViewport returns false (indicating concurrent load of
-    // non-AMP creative).
-    if (isNaN(vpRange) || this.element.getAttribute('data-loading-strategy') ||
-        !this.renderOutsideViewport()) {
+    // Disable if publisher has indicated a non-default loading strategy.
+    if (isNaN(vpRange) || this.element.getAttribute('data-loading-strategy')) {
       return false;
     }
     return vpRange;
@@ -798,6 +795,8 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     if (this.isFluid_) {
       this.registerListenerForFluid_();
     }
+    // TODO(keithwrightbos): consider enforcing concurrent load throttle for
+    // non-AMP creatives loaded via idleRenderOutsideViewport.
     return super.layoutCallback();
   }
 

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -359,9 +359,17 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
   }
 
   /** @override */
-  renderOnIdleOutsideViewport() {
-    return getExperimentBranch(
-        this.win, RENDER_ON_IDLE_EXP_NAME) == '21061138' ? 5 : false;
+  idleRenderOutsideViewport() {
+    const vpRange =
+        parseInt(this.postAdResponseExperimentFeatures['render-idle-vp'], 10);
+    // Disable if publisher has indicated a non-default loading strategy or
+    // renderOutsideViewport returns false (indicating concurrent load of
+    // non-AMP creative).
+    if (isNaN(vpRange) || this.element.getAttribute('data-loading-strategy') ||
+        !this.renderOutsideViewport()) {
+      return false;
+    }
+    return vpRange;
   }
 
   /** @override */
@@ -417,26 +425,13 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     this.win['dbclk_a4a_viz_change'] = true;
 
     const sfPreloadExpName = 'a4a-safeframe-preloading-off';
-    let experimentInfoMap =
+    const experimentInfoMap =
         /** @type {!Object<string, !ExperimentInfo>} */ ({});
     experimentInfoMap[sfPreloadExpName] = {
       isTrafficEligible: () => true,
       branches: ['21061135', '21061136'],
     };
     randomlySelectUnsetExperiments(this.win, experimentInfoMap);
-    experimentInfoMap =
-        /** @type {!Object<string, !ExperimentInfo>} */ ({});
-    experimentInfoMap[RENDER_ON_IDLE_EXP_NAME] = {
-      isTrafficEligible: () => true,
-      // TODO: allocate actual ids!!!
-      branches: ['21061137', '21061138'],
-    };
-    randomlySelectUnsetExperiments(this.win, experimentInfoMap);
-    const renderIdleExpId =
-        getExperimentBranch(this.win, RENDER_ON_IDLE_EXP_NAME);
-    if (renderIdleExpId) {
-      addExperimentIdToElement(renderIdleExpId, this.element);
-    }
     const sfPreloadExpId = getExperimentBranch(this.win, sfPreloadExpName);
     if (sfPreloadExpId) {
       addExperimentIdToElement(sfPreloadExpId, this.element);

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -1212,4 +1212,41 @@ describes.realWin('additional amp-ad-network-doubleclick-impl',
               .to.be.ok;
         });
       });
+
+      describe('#idleRenderOutsideViewport', () => {
+        beforeEach(() => {
+          element = createElementWithAttributes(doc, 'amp-ad', {
+            'width': '200',
+            'height': '50',
+            'type': 'doubleclick',
+          });
+          impl = new AmpAdNetworkDoubleclickImpl(element);
+        });
+
+        it('should use experiment value', () => {
+          impl.postAdResponseExperimentFeatures['render-idle-vp'] = '4';
+          sandbox.stub(impl, 'renderOutsideViewport', () => 3);
+          expect(impl.idleRenderOutsideViewport()).to.equal(4);
+        });
+
+        it('should return false if renderOutsideViewport returns false', () => {
+          impl.postAdResponseExperimentFeatures['render-idle-vp'] = '4';
+          sandbox.stub(impl, 'renderOutsideViewport', () => false);
+          expect(impl.idleRenderOutsideViewport()).to.be.false;
+        });
+
+        it('should return false if using loading strategy', () => {
+          impl.postAdResponseExperimentFeatures['render-idle-vp'] = '4';
+          impl.element.setAttribute('data-loading-strategy',
+              'prefer-viewability-over-views');
+          sandbox.stub(impl, 'renderOutsideViewport', () => 3);
+          expect(impl.idleRenderOutsideViewport()).to.be.false;
+        });
+
+        it('should return false if invalid experiment value', () => {
+          impl.postAdResponseExperimentFeatures['render-idle-vp'] = 'abc';
+          sandbox.stub(impl, 'renderOutsideViewport', () => 3);
+          expect(impl.idleRenderOutsideViewport()).to.be.false;
+        });
+      });
     });

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -1225,27 +1225,18 @@ describes.realWin('additional amp-ad-network-doubleclick-impl',
 
         it('should use experiment value', () => {
           impl.postAdResponseExperimentFeatures['render-idle-vp'] = '4';
-          sandbox.stub(impl, 'renderOutsideViewport', () => 3);
           expect(impl.idleRenderOutsideViewport()).to.equal(4);
-        });
-
-        it('should return false if renderOutsideViewport returns false', () => {
-          impl.postAdResponseExperimentFeatures['render-idle-vp'] = '4';
-          sandbox.stub(impl, 'renderOutsideViewport', () => false);
-          expect(impl.idleRenderOutsideViewport()).to.be.false;
         });
 
         it('should return false if using loading strategy', () => {
           impl.postAdResponseExperimentFeatures['render-idle-vp'] = '4';
           impl.element.setAttribute('data-loading-strategy',
               'prefer-viewability-over-views');
-          sandbox.stub(impl, 'renderOutsideViewport', () => 3);
           expect(impl.idleRenderOutsideViewport()).to.be.false;
         });
 
         it('should return false if invalid experiment value', () => {
           impl.postAdResponseExperimentFeatures['render-idle-vp'] = 'abc';
-          sandbox.stub(impl, 'renderOutsideViewport', () => 3);
           expect(impl.idleRenderOutsideViewport()).to.be.false;
         });
       });

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -394,12 +394,12 @@ export class BaseElement {
 
   /**
    * Allows for rendering outside of the constraint set by renderOutsideViewport
-   * so long task scheduler is idle.  Values should be greater than
-   * renderOutsideViewport and indicates outer range at which elements are
-   * are considered.  Subclasses can override (default is disabled).
+   * so long task scheduler is idle.  Integer values less than those returned
+   * by renderOutsideViewport have no effect.  Subclasses can override (default
+   * is disabled).
    * @return {boolean|number}
    */
-  renderOnIdleOutsideViewport() {
+  idleRenderOutsideViewport() {
     return false;
   }
 

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -393,6 +393,17 @@ export class BaseElement {
   }
 
   /**
+   * Allows for rendering outside of the constraint set by renderOutsideViewport
+   * so long task scheduler is idle.  Values should be greater than
+   * renderOutsideViewport and indicates outer range at which elements are
+   * are considered.  Subclasses can override (default is disabled).
+   * @return {boolean|number}
+   */
+  renderOnIdleOutsideViewport() {
+    return false;
+  }
+
+  /**
    * Subclasses can override this method to opt-in into receiving additional
    * {@link layoutCallback} calls. Note that this method is not consulted for
    * the first layout given that each element must be laid out at least once.

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -861,8 +861,8 @@ function createBaseCustomElementClass(win) {
      * @return {boolean|number}
      * @final @this {!Element}
      */
-    renderOnIdleOutsideViewport() {
-      return this.implementation_.renderOnIdleOutsideViewport();
+    idleRenderOutsideViewport() {
+      return this.implementation_.idleRenderOutsideViewport();
     }
 
     /**

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -856,6 +856,16 @@ function createBaseCustomElementClass(win) {
     }
 
     /**
+     * Whether the element should render outside of renderOutsideViewport when
+     * the scheduler is idle.
+     * @return {boolean|number}
+     * @final @this {!Element}
+     */
+    renderOnIdleOutsideViewport() {
+      return this.implementation_.renderOnIdleOutsideViewport();
+    }
+
+    /**
      * Returns a previously measured layout box adjusted to the viewport. This
      * mainly affects fixed-position elements that are adjusted to be always
      * relative to the document position in the viewport.

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -635,7 +635,7 @@ export class Resource {
     const viewportBox = this.resources_.getViewport().getRect();
     const layoutBox = this.getLayoutBox();
     const scrollDirection = this.resources_.getScrollDirection();
-    multipler = Math.max(multiplier, 0);
+    multiplier = Math.max(multiplier, 0);
     let scrollPenalty = 1;
     let distance;
     if (viewportBox.right < layoutBox.left ||
@@ -663,7 +663,7 @@ export class Resource {
       // Element is in viewport
       return true;
     }
-    return distance < viewportBox.height * multipler / scrollPenalty;
+    return distance < viewportBox.height * multiplier / scrollPenalty;
   }
 
   /**
@@ -677,8 +677,11 @@ export class Resource {
     // prerender this resource, so that it can avoid expensive elements wayyy
     // outside of viewport. For now, blindly trust that owner knows what it's
     // doing.
-    if (this.hasOwner() ||
-        this.withinViewportMultiplier_(this.element.renderOutsideViewport())) {
+    if (this.hasOwner()) {
+      this.resolveRenderOutsideViewport_();
+      return true;
+    }
+    if (this.withinViewportMultiplier_(this.element.renderOutsideViewport())) {
       this.resolveRenderOutsideViewport_();
       return true;
     }
@@ -690,9 +693,9 @@ export class Resource {
    * viewport.
    * @return {boolean}
    */
-  renderOnIdleOutsideViewport() {
-    return this.hasOwner() || this.withinViewportMultiplier_(
-        this.element.renderOnIdleOutsideViewport());
+  idleRenderOutsideViewport() {
+    return this.withinViewportMultiplier_(
+        this.element.idleRenderOutsideViewport());
   }
 
   /**

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -623,9 +623,9 @@ export class Resource {
    * @param {number|boolean} multiplier
    * @return {boolean} whether resource is within provider multiplier of
    *    viewports from current visible viewport.
-   * @private
+   * @visibleForTesting
    */
-  withinViewportMultiplier_(multiplier) {
+  withinViewportMultiplier(multiplier) {
     // Boolean interface controls explicit result.
     if (multiplier === true || multiplier === false) {
       return multiplier;
@@ -681,7 +681,7 @@ export class Resource {
       this.resolveRenderOutsideViewport_();
       return true;
     }
-    if (this.withinViewportMultiplier_(this.element.renderOutsideViewport())) {
+    if (this.withinViewportMultiplier(this.element.renderOutsideViewport())) {
       this.resolveRenderOutsideViewport_();
       return true;
     }
@@ -694,7 +694,7 @@ export class Resource {
    * @return {boolean}
    */
   idleRenderOutsideViewport() {
-    return this.withinViewportMultiplier_(
+    return this.withinViewportMultiplier(
         this.element.idleRenderOutsideViewport());
   }
 

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -620,36 +620,22 @@ export class Resource {
   }
 
   /**
-   * Whether this is allowed to render when not in viewport.
-   * @return {boolean}
+   * @param {number|boolean} multiplier
+   * @return {boolean} whether resource is within provider multiplier of
+   *    viewports from current visible viewport.
+   * @private
    */
-  renderOutsideViewport() {
-    // The exception is for owned resources, since they only attempt to
-    // render outside viewport when the owner has explicitly allowed it.
-    // TODO(jridgewell, #5803): Resources should be asking owner if it can
-    // prerender this resource, so that it can avoid expensive elements wayyy
-    // outside of viewport. For now, blindly trust that owner knows what it's
-    // doing.
-    if (this.hasOwner()) {
-      this.resolveRenderOutsideViewport_();
-      return true;
-    }
-
-    const renders = this.element.renderOutsideViewport();
-    // Boolean interface, element is either always allowed or never allowed to
-    // render outside viewport.
-    if (renders === true || renders === false) {
-      if (renders === true) {
-        this.resolveRenderOutsideViewport_();
-      }
-      return renders;
+  withinViewportMultiplier_(multiplier) {
+    // Boolean interface controls explicit result.
+    if (multiplier === true || multiplier === false) {
+      return multiplier;
     }
     // Numeric interface, element is allowed to render outside viewport when it
     // is within X times the viewport height of the current viewport.
     const viewportBox = this.resources_.getViewport().getRect();
     const layoutBox = this.getLayoutBox();
     const scrollDirection = this.resources_.getScrollDirection();
-    const multipler = Math.max(renders, 0);
+    multipler = Math.max(multiplier, 0);
     let scrollPenalty = 1;
     let distance;
     if (viewportBox.right < layoutBox.left ||
@@ -675,14 +661,38 @@ export class Resource {
       }
     } else {
       // Element is in viewport
+      return true;
+    }
+    return distance < viewportBox.height * multipler / scrollPenalty;
+  }
+
+  /**
+   * Whether this is allowed to render when not in viewport.
+   * @return {boolean}
+   */
+  renderOutsideViewport() {
+    // The exception is for owned resources, since they only attempt to
+    // render outside viewport when the owner has explicitly allowed it.
+    // TODO(jridgewell, #5803): Resources should be asking owner if it can
+    // prerender this resource, so that it can avoid expensive elements wayyy
+    // outside of viewport. For now, blindly trust that owner knows what it's
+    // doing.
+    if (this.hasOwner() ||
+        this.withinViewportMultiplier_(this.element.renderOutsideViewport())) {
       this.resolveRenderOutsideViewport_();
       return true;
     }
-    const result = distance < viewportBox.height * multipler / scrollPenalty;
-    if (result) {
-      this.resolveRenderOutsideViewport_();
-    }
-    return result;
+    return false;
+  }
+
+  /**
+   * Whether this is allowed to render when scheduler is idle but not in
+   * viewport.
+   * @return {boolean}
+   */
+  renderOnIdleOutsideViewport() {
+    return this.hasOwner() || this.withinViewportMultiplier_(
+        this.element.renderOnIdleOutsideViewport());
   }
 
   /**

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -1463,7 +1463,7 @@ export class Resources {
           const idleLayout = r.idleRenderOutsideViewport();
           if ((idleLayout && idleScheduledLayoutCount++ < 4) ||
             (!idleLayout && idleScheduledPreloadCount++ < 4)) {
-            dev().fine(TAG_, 'idle layout:', r.debugid);
+            dev().fine(TAG_, 'idle layout:', r.debugid, idleLayout);
             this.scheduleLayoutOrPreload_(r, /* layout */ idleLayout);
           }
           if (idleScheduledPreloadCount >= 4 && idleScheduledLayoutCount >= 4) {

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -1460,17 +1460,10 @@ export class Resources {
         const r = this.resources_[i];
         if (r.getState() == ResourceState.READY_FOR_LAYOUT &&
                 !r.hasOwner() && r.isDisplayed()) {
-          const idleLayout = r.renderOnIdleOutsideViewport();
-          this.scheduleLayoutOrPreload_(
-              r, /* layout */ idleLayout);
-          if (idleLayout) {
-            if (idleScheduledLayoutCount++ < 4) {
-              this.scheduleLayoutOrPreload_(r, /* layout */true);
-            }
-          } else  {
-            if (idleScheduledPreloadCount++ < 4) {
-              this.scheduleLayoutOrPreload_(r, /* layout */false);
-            }
+          const idleLayout = r.idleRenderOutsideViewport();
+          if ((idleLayout && idleScheduledLayoutCount++ < 4) ||
+            (!idleLayout && idleScheduledPreloadCount++ < 4)) {
+            this.scheduleLayoutOrPreload_(r, /* layout */ idleLayout);
           }
           if (idleScheduledPreloadCount >= 4 && idleScheduledLayoutCount >= 4) {
             break;
@@ -1804,7 +1797,7 @@ export class Resources {
     if (!forceOutsideViewport &&
         !resource.isInViewport() &&
         !resource.renderOutsideViewport() &&
-        !resource.renderOnIdleOutsideViewport()) {
+        !resource.idleRenderOutsideViewport()) {
       return false;
     }
 

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -1452,7 +1452,7 @@ export class Resources {
           this.exec_.getSize() == 0 &&
           this.queue_.getSize() == 0 &&
           now > this.exec_.getLastDequeueTime() + 5000) {
-      // Phase 5: Idle Render Outside Viewport layout: layout up to 3 items
+      // Phase 5: Idle Render Outside Viewport layout: layout up to 4 items
       // with idleRenderOutsideViewport true
       let idleScheduledCount = 0;
       for (let i = 0; i < this.resources_.length && idleScheduledCount < 4;

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -1463,6 +1463,7 @@ export class Resources {
           const idleLayout = r.idleRenderOutsideViewport();
           if ((idleLayout && idleScheduledLayoutCount++ < 4) ||
             (!idleLayout && idleScheduledPreloadCount++ < 4)) {
+            dev().fine(TAG_, 'idle layout:', r.debugid);
             this.scheduleLayoutOrPreload_(r, /* layout */ idleLayout);
           }
           if (idleScheduledPreloadCount >= 4 && idleScheduledLayoutCount >= 4) {

--- a/test/functional/test-resource.js
+++ b/test/functional/test-resource.js
@@ -823,6 +823,63 @@ describes.realWin('Resource', {amp: true}, env => {
   });
 });
 
+describe('Resource idleRenderOutsideViewport', () => {
+  let sandbox;
+  let element;
+  let resources;
+  let resource;
+  let idleRenderOutsideViewport;
+  let withinViewportMultiplier;
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox.create();
+    idleRenderOutsideViewport = sandbox.stub();
+    element = {
+      idleRenderOutsideViewport,
+      ownerDocument: {defaultView: window},
+      tagName: 'AMP-AD',
+      hasAttribute: () => false,
+      isBuilt: () => false,
+      isUpgraded: () => false,
+      prerenderAllowed: () => false,
+      renderOutsideViewport: () => true,
+      build: () => false,
+      getBoundingClientRect: () => null,
+      updateLayoutBox: () => {},
+      isRelayoutNeeded: () => false,
+      layoutCallback: () => {},
+      changeSize: () => {},
+      unlayoutOnPause: () => false,
+      unlayoutCallback: () => true,
+      pauseCallback: () => false,
+      resumeCallback: () => false,
+      viewportCallback: () => {},
+      getPriority: () => 0,
+    };
+    resources = new Resources(new AmpDocSingle(window));
+    resource = new Resource(1, element, resources);
+    withinViewportMultiplier =
+        sandbox.stub(resource, 'withinViewportMultiplier');
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('should return true if withinViewportMultiplier', () => {
+    idleRenderOutsideViewport.returns(5);
+    withinViewportMultiplier.withArgs(5).returns(true);
+    expect(resource.idleRenderOutsideViewport()).to.equal(true);
+  });
+
+  it('should return false for false element idleRenderOutsideViewport', () => {
+    idleRenderOutsideViewport.returns(false);
+    withinViewportMultiplier.withArgs(false).returns(false);
+    expect(resource.idleRenderOutsideViewport()).to.equal(false);
+  });
+});
+
 describe('Resource renderOutsideViewport', () => {
   let sandbox;
   let element;


### PR DESCRIPTION
Experiment for doubleclick fast fetch allowing creative render when beyond renderOutsideViewport so long as scheduler is idle and pub is not using data loading strategy.  Throttling of concurrent non-AMP creative layout is still enforced.