### PR TITLE
Pass the schedule time of an element to the element itself

### DIFF
--- a/src/base-element.js
+++ b/src/base-element.js
@@ -159,7 +159,10 @@ export class BaseElement {
 
     /**
      * The time at which this element was scheduled for layout relative to the
-     * epoch. This value will be set to 0 until the this element has been scheduled.
+     * epoch. This value will be set to 0 until the this element has been
+     * scheduled.
+     * Note that this value may change over time if the element is enqueued,
+     * then dequeued and re-enqueued by the scheduler.
      * @public {number}
      */
     this.layoutScheduleTime = 0;

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -156,6 +156,13 @@ export class BaseElement {
 
     /** @public {?Object} For use by sub classes */
     this.config = null;
+
+    /**
+     * The time at which this element was scheduled for layout relative to the
+     * epoch. This value will be set to 0 until the this element has been scheduled.
+     * @public {number}
+     */
+    this.layoutScheduleTime = 0;
   }
 
   /**

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -687,9 +687,11 @@ export class Resource {
 
   /**
    * Sets the resource's state to LAYOUT_SCHEDULED.
+   * @param {number} scheduleTime The time at which layout was scheduled.
    */
-  layoutScheduled() {
+  layoutScheduled(scheduleTime) {
     this.state_ = ResourceState.LAYOUT_SCHEDULED;
+    this.element.layoutScheduleTime = scheduleTime;
   }
 
   /**

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -1912,7 +1912,7 @@ export class Resources {
       this.queue_.enqueue(task);
       this.schedulePass(this.calcTaskTimeout_(task));
     }
-    task.resource.layoutScheduled();
+    task.resource.layoutScheduled(task.scheduleTime);
   }
 
   /**

--- a/test/functional/test-resource.js
+++ b/test/functional/test-resource.js
@@ -563,6 +563,26 @@ describes.realWin('Resource', {amp: true}, env => {
     });
   });
 
+  it('should record layout schedule time', () => {
+    resource.layoutScheduled(300);
+    expect(resource.element.layoutScheduleTime).to.equal(300);
+
+    // The time should be updated if scheduled multiple times.
+    resource.layoutScheduled(400);
+    expect(resource.element.layoutScheduleTime).to.equal(400);
+
+    expect(resource.getState()).to.equal(ResourceState.LAYOUT_SCHEDULED);
+  });
+
+  it('should not record layout schedule time in startLayout', () => {
+    resource.state_ = ResourceState.READY_FOR_LAYOUT;
+    resource.layoutBox_ = {left: 11, top: 12, width: 10, height: 10};
+    resource.startLayout();
+
+    expect(resource.element.layoutScheduleTime).to.be.undefined;
+    expect(resource.getState()).to.equal(ResourceState.LAYOUT_SCHEDULED);
+  });
+
   it('should change size and update state', () => {
     expect(resource.isMeasureRequested()).to.be.false;
     resource.state_ = ResourceState.READY_FOR_LAYOUT;

--- a/test/functional/test-resources.js
+++ b/test/functional/test-resources.js
@@ -1313,6 +1313,14 @@ describe('Resources discoverWork', () => {
     expect(resource1.getState()).to.equal(ResourceState.LAYOUT_SCHEDULED);
   });
 
+  it('should record layout schedule time on the resource element', () => {
+    resources.scheduleLayoutOrPreload_(resource1, true);
+
+    resources.work_();
+    expect(resource1.getState()).to.equal(ResourceState.LAYOUT_SCHEDULED);
+    expect(resource1.element.layoutScheduleTime).to.be.greaterThan(0);
+  });
+
   it('should not schedule resource execution outside viewport', () => {
     resources.scheduleLayoutOrPreload_(resource1, true);
     expect(resources.queue_.getSize()).to.equal(1);


### PR DESCRIPTION
Passes the time at which layout was scheduled for an element to the element itself. This will be used to measure the time between when layout was scheduled and when layout was completed.