### PR TITLE
Add new amp-analytics vendor: Alexa Internet

### DIFF
--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -355,6 +355,7 @@ const forbiddenTerms = {
       'src/cookies.js',
       'src/service/cid-impl.js',
       'testing/fake-dom.js',
+      'extensions/amp-analytics/0.1/vendors.js',
     ],
   },
   'getCookie\\W': {

--- a/examples/analytics-vendors.amp.html
+++ b/examples/analytics-vendors.amp.html
@@ -47,6 +47,7 @@
       <option>acquialift</option>
       <option>adobeanalytics</option>
       <option>adobeanalytics_nativeConfig</option>
+      <option>alexametrics</option>
       <option>atinternet</option>
       <option>afsanalytics</option>
       <option>baiduanalytics</option>
@@ -182,6 +183,19 @@ For complete documentation and additional examples please see: https://marketing
 </script>
 </amp-analytics>
 <!-- End Adobe Analytics example -->
+
+<!-- Alexa tracking -->
+<amp-analytics type="alexametrics">
+<script type="application/json">
+  {
+    "vars": {
+      "atrk_acct": "YOURACCOUNT",
+      "domain": "YOURDOMAIN"
+    }
+  }
+</script>
+</amp-analytics>
+<!-- End Alexa tracking -->
 
 <!-- AT Internet tracking -->
 <amp-analytics type="atinternet" id="atinternet">

--- a/extensions/amp-analytics/0.1/test/vendor-requests.json
+++ b/extensions/amp-analytics/0.1/test/vendor-requests.json
@@ -12,8 +12,8 @@
    "click":   "//www.afsanalytics.com/cgi_bin/click.cgi?usr=xxxxxxxx&event=click&exit=clicked%20from%20AMP%20page"
   },
   "alexametrics": {
-    "base": "https://certify-amp.alexametrics.com/atrk.gif?account=xxxxxxxx&domain=xxxxxxxx",
-    "pageview": "https://certify-amp.alexametrics.com/atrk.gif?account=xxxxxxxx&domain=xxxxxxxx&jsv=amp-_amp_version_&frame_height=_viewport_height_&frame_width=_viewport_width_&title=_title_&time=_timestamp_&time_zone_offset=_timezone_&screen_params=_screen_width_x_screen_height_x_screen_color_depth_&ref_url=_document_referrer_&host_url=_source_url_&random_number=_random_&user_cookie=_client_id_&user_cookie_flag=0&user_lang=_browser_language_&amp_doc_url=_ampdoc_url_"
+    "base": "https://certify-amp.alexametrics.com/atrk.gif?account=$atrk_acct&domain=$domain",
+    "pageview": "https://certify-amp.alexametrics.com/atrk.gif?account=$atrk_acct&domain=$domain&jsv=amp-_amp_version_&frame_height=_viewport_height_&frame_width=_viewport_width_&title=_title_&time=_timestamp_&time_zone_offset=_timezone_&screen_params=_screen_width_x_screen_height_x_screen_color_depth_&ref_url=_document_referrer_&host_url=_source_url_&random_number=_random_&user_cookie=_client_id_&user_cookie_flag=0&user_lang=_browser_language_&amp_doc_url=_ampdoc_url_"
   },
   "atinternet": {
     "base": "https://$log$domain/hit.xiti?s=$site&ts=_timestamp_&r=_screen_width_x_screen_height_x_screen_color_depth_&re=_available_screen_width_x_available_screen_height_",

--- a/extensions/amp-analytics/0.1/test/vendor-requests.json
+++ b/extensions/amp-analytics/0.1/test/vendor-requests.json
@@ -11,6 +11,10 @@
    "pageview": "//www.afsanalytics.com/cgi_bin/connect.cgi?usr=xxxxxxxxPauto&js=1&amp=1&title=_title_&url=_canonical_url_&refer=_document_referrer_&resolution=_screen_width_x_screen_height_&color=_screen_color_depth_&Tips=_random_",
    "click":   "//www.afsanalytics.com/cgi_bin/click.cgi?usr=xxxxxxxx&event=click&exit=clicked%20from%20AMP%20page"
   },
+  "alexametrics": {
+    "base": "https://certify-amp.alexametrics.com/atrk.gif?account=xxxxxxxx&domain=xxxxxxxx",
+    "pageview": "https://certify-amp.alexametrics.com/atrk.gif?account=xxxxxxxx&domain=xxxxxxxx&jsv=amp-_amp_version_&frame_height=_viewport_height_&frame_width=_viewport_width_&title=_title_&time=_timestamp_&time_zone_offset=_timezone_&screen_params=_screen_width_x_screen_height_x_screen_color_depth_&ref_url=_document_referrer_&host_url=_source_url_&random_number=_random_&user_cookie=_client_id_&user_cookie_flag=0&user_lang=_browser_language_&amp_doc_url=_ampdoc_url_"
+  },
   "atinternet": {
     "base": "https://$log$domain/hit.xiti?s=$site&ts=_timestamp_&r=_screen_width_x_screen_height_x_screen_color_depth_&re=_available_screen_width_x_available_screen_height_",
     "suffix": "&medium=amp&&ref=_document_referrer_",

--- a/extensions/amp-analytics/0.1/vendors.js
+++ b/extensions/amp-analytics/0.1/vendors.js
@@ -143,31 +143,32 @@ export const ANALYTICS_CONFIG = /** @type {!JsonObject} */ ({
 
   'alexametrics': {
     'requests': {
-      'base': 'https://${ampAtrkHost}/atrk.gif?account=${atrk_acct}&domain=${domain}', 
-      'pageview': '${base}&jsv=amp-${ampVersion}' + 
-        '&frame_height=${viewportHeight}&frame_width=${viewportWidth}' + 
-        '&title=${title}&time=${timestamp}&time_zone_offset=${timezone}' + 
-        '&screen_params=${screenWidth}x${screenHeight}x${screenColorDepth}' + 
-        '&ref_url=${documentReferrer}&host_url=${sourceUrl}&random_number=${random}' + 
-        '&user_cookie=${clientId(__auc)}&user_cookie_flag=0' + 
-        '&user_lang=${browserLanguage}&amp_doc_url=${ampdocUrl}'
+      'base': 'https://${ampAtrkHost}/atrk.gif?account=${atrk_acct}&domain=${domain}',
+      'pageview': '${base}&jsv=amp-${ampVersion}' +
+        '&frame_height=${viewportHeight}&frame_width=${viewportWidth}' +
+        '&title=${title}&time=${timestamp}&time_zone_offset=${timezone}' +
+        '&screen_params=${screenWidth}x${screenHeight}x${screenColorDepth}' +
+        '&ref_url=${documentReferrer}&host_url=${sourceUrl}' +
+        '&random_number=${random}&user_cookie=${clientId(__auc)}' +
+        '&user_cookie_flag=0&user_lang=${browserLanguage}' +
+        '&amp_doc_url=${ampdocUrl}',
     },
     'vars': {
       'atrk_acct': '',
       'domain': '',
-      'ampAtrkHost': 'certify-amp.alexametrics.com'
+      'ampAtrkHost': 'certify-amp.alexametrics.com',
     },
     'triggers': {
       'trackPageview': {
         'on': 'visible',
-        'request': 'pageview'
-      }
+        'request': 'pageview',
+      },
     },
-    'transport' : {
-      'xhrpost': false, 
-      'beacon' : false,
-      'image' : true
-    }
+    'transport': {
+      'xhrpost': false,
+      'beacon': false,
+      'image': true,
+    },
   },
 
   'atinternet': {

--- a/extensions/amp-analytics/0.1/vendors.js
+++ b/extensions/amp-analytics/0.1/vendors.js
@@ -153,20 +153,20 @@ export const ANALYTICS_CONFIG = /** @type {!JsonObject} */ ({
         '&user_lang=${browserLanguage}&amp_doc_url=${ampdocUrl}'
     },
     'vars': {
-        'atrk_acct': 'xxxxxxxx'
-      , 'domain': 'xxxxxxxx'
-      , 'ampAtrkHost': 'certify-amp.alexametrics.com'
+      'atrk_acct': '',
+      'domain': '',
+      'ampAtrkHost': 'certify-amp.alexametrics.com'
     },
     'triggers': {
       'trackPageview': {
-          'on': 'visible'
-        , 'request': 'pageview'
+        'on': 'visible',
+        'request': 'pageview'
       }
     },
     'transport' : {
-        'xhrpost': false
-      , 'beacon' : false
-      , 'image' : true
+      'xhrpost': false, 
+      'beacon' : false,
+      'image' : true
     }
   },
 

--- a/extensions/amp-analytics/0.1/vendors.js
+++ b/extensions/amp-analytics/0.1/vendors.js
@@ -141,6 +141,35 @@ export const ANALYTICS_CONFIG = /** @type {!JsonObject} */ ({
     },
   },
 
+  'alexametrics': {
+    'requests': {
+      'base': 'https://${ampAtrkHost}/atrk.gif?account=${atrk_acct}&domain=${domain}', 
+      'pageview': '${base}&jsv=amp-${ampVersion}' + 
+        '&frame_height=${viewportHeight}&frame_width=${viewportWidth}' + 
+        '&title=${title}&time=${timestamp}&time_zone_offset=${timezone}' + 
+        '&screen_params=${screenWidth}x${screenHeight}x${screenColorDepth}' + 
+        '&ref_url=${documentReferrer}&host_url=${sourceUrl}&random_number=${random}' + 
+        '&user_cookie=${clientId(__auc)}&user_cookie_flag=0' + 
+        '&user_lang=${browserLanguage}&amp_doc_url=${ampdocUrl}'
+    },
+    'vars': {
+        'atrk_acct': 'xxxxxxxx'
+      , 'domain': 'xxxxxxxx'
+      , 'ampAtrkHost': 'certify-amp.alexametrics.com'
+    },
+    'triggers': {
+      'trackPageview': {
+          'on': 'visible'
+        , 'request': 'pageview'
+      }
+    },
+    'transport' : {
+        'xhrpost': false
+      , 'beacon' : false
+      , 'image' : true
+    }
+  },
+
   'atinternet': {
     'transport': {'beacon': false, 'xhrpost': false, 'image': true},
     'requests': {


### PR DESCRIPTION
This adds Alexa Internet to the amp-analytics provider list.

Fixes [#11966](https://github.com/ampproject/amphtml/issues/11966)