### PR TITLE
Fixes 3p URL calculation

### DIFF
--- a/extensions/amp-analytics/0.1/iframe-transport.js
+++ b/extensions/amp-analytics/0.1/iframe-transport.js
@@ -14,12 +14,9 @@
  * limitations under the License.
  */
 
+import {urls} from '../../../src/config';
 import {createElementWithAttributes} from '../../../src/dom';
 import {dev} from '../../../src/log';
-import {getMode} from '../../../src/mode';
-import {
-  calculateEntryPointScriptUrl,
-} from '../../../src/service/extension-location';
 import {setStyles} from '../../../src/style';
 import {hasOwn} from '../../../src/utils/object';
 import {IframeTransportMessageQueue} from './iframe-transport-message-queue';
@@ -106,11 +103,12 @@ export class IframeTransport {
     // iframeTransport.getCreativeId() -> sentinel relationship is *not*
     // many-to-many.
     const sentinel = IframeTransport.createUniqueId_();
-    const useLocal = getMode().localDev || getMode().test;
-    const useRtvVersion = !useLocal;
-    const scriptSrc = calculateEntryPointScriptUrl(
-        this.ampWin_.parent.location, 'iframe-transport-client-lib',
-        useLocal, useRtvVersion);
+    const useLocal = false;//getMode().localDev || getMode().test;
+    const loc = this.ampWin_.parent.location;
+    const scriptSrc = useLocal ?
+        `${loc.protocol}//${loc.host}/dist/iframe-transport-client-lib.js` :
+        urls.thirdParty +
+        '/$internalRuntimeVersion$/iframe-transport-client-v0.js';
     const frameName = JSON.stringify(/** @type {JsonObject} */ ({
       scriptSrc,
       sentinel,

--- a/extensions/amp-analytics/0.1/iframe-transport.js
+++ b/extensions/amp-analytics/0.1/iframe-transport.js
@@ -31,7 +31,7 @@ import {IframeTransportMessageQueue} from './iframe-transport-message-queue';
 export let FrameData;
 
 /**
- * @visibleForTesting
+ * @VisibleForTesting
  */
 export class IframeTransport {
   /**
@@ -104,14 +104,8 @@ export class IframeTransport {
     // iframeTransport.getCreativeId() -> sentinel relationship is *not*
     // many-to-many.
     const sentinel = IframeTransport.createUniqueId_();
-    const useLocal = getMode().localDev || getMode().test;
-    const loc = this.ampWin_.parent.location;
-    const scriptSrc = useLocal ?
-        `${loc.protocol}//${loc.host}/dist/iframe-transport-client-lib.js` :
-        urls.thirdParty +
-        '/$internalRuntimeVersion$/iframe-transport-client-v0.js';
     const frameName = JSON.stringify(/** @type {JsonObject} */ ({
-      scriptSrc,
+      scriptSrc: this.getLibScriptUrl(),
       sentinel,
       type: this.type_,
     }));
@@ -135,6 +129,22 @@ export class IframeTransport {
     });
     IframeTransport.crossDomainIframes_[this.type_] = frameData;
     return frameData;
+  }
+
+  /**
+   * Calculates the URL of the client lib
+   * @param {boolean=} opt_forceProdUrl If true, prod URL will be returned even
+   *     in local/test modes.
+   * @return {string}
+   * @VisibleForTesting
+   */
+  getLibScriptUrl(opt_forceProdUrl) {
+    if ((getMode().localDev || getMode().test) && !opt_forceProdUrl) {
+      const loc = this.ampWin_.parent.location;
+      return `${loc.protocol}//${loc.host}/dist/iframe-transport-client-lib.js`;
+    }
+    return urls.thirdParty +
+        '/$internalRuntimeVersion$/iframe-transport-client-v0.js';
   }
 
   /**

--- a/extensions/amp-analytics/0.1/iframe-transport.js
+++ b/extensions/amp-analytics/0.1/iframe-transport.js
@@ -17,6 +17,7 @@
 import {urls} from '../../../src/config';
 import {createElementWithAttributes} from '../../../src/dom';
 import {dev} from '../../../src/log';
+import {getMode} from '../../../src/mode';
 import {setStyles} from '../../../src/style';
 import {hasOwn} from '../../../src/utils/object';
 import {IframeTransportMessageQueue} from './iframe-transport-message-queue';

--- a/extensions/amp-analytics/0.1/iframe-transport.js
+++ b/extensions/amp-analytics/0.1/iframe-transport.js
@@ -103,7 +103,7 @@ export class IframeTransport {
     // iframeTransport.getCreativeId() -> sentinel relationship is *not*
     // many-to-many.
     const sentinel = IframeTransport.createUniqueId_();
-    const useLocal = false;//getMode().localDev || getMode().test;
+    const useLocal = getMode().localDev || getMode().test;
     const loc = this.ampWin_.parent.location;
     const scriptSrc = useLocal ?
         `${loc.protocol}//${loc.host}/dist/iframe-transport-client-lib.js` :

--- a/extensions/amp-analytics/0.1/test/test-iframe-transport.js
+++ b/extensions/amp-analytics/0.1/test/test-iframe-transport.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {urls} from '../../../../src/config';
 import {IframeTransport} from '../iframe-transport';
 
 describes.realWin('amp-analytics.iframe-transport', {amp: true}, env => {
@@ -115,5 +116,17 @@ describes.realWin('amp-analytics.iframe-transport', {amp: true}, env => {
     expect(frame2.usageCount).to.equal(0);
     expect(env.win.document.getElementsByTagName('IFRAME')).to.have.lengthOf(0);
   });
-});
 
+  it('gets correct client lib URL in local/test mode', () => {
+    const url = iframeTransport.getLibScriptUrl();
+    expect(url).to.contain(env.win.location.host);
+    expect(url).to.contain('/dist/iframe-transport-client-lib.js');
+  });
+
+  it('gets correct client lib URL in prod mode', () => {
+    const url = iframeTransport.getLibScriptUrl(true);
+    expect(url).to.contain(urls.thirdParty);
+    expect(url).to.contain('/iframe-transport-client-v0.js');
+    expect(url).to.match(/https:\/\/3p\.ampproject\.net\/\$internalRuntimeVersion\$\/iframe-transport-client-v0\.js/); // eslint-disable-line max-len
+  });
+});

--- a/extensions/amp-analytics/0.1/test/test-iframe-transport.js
+++ b/extensions/amp-analytics/0.1/test/test-iframe-transport.js
@@ -127,6 +127,7 @@ describes.realWin('amp-analytics.iframe-transport', {amp: true}, env => {
     const url = iframeTransport.getLibScriptUrl(true);
     expect(url).to.contain(urls.thirdParty);
     expect(url).to.contain('/iframe-transport-client-v0.js');
-    expect(url).to.match(/https:\/\/3p\.ampproject\.net\/\$internalRuntimeVersion\$\/iframe-transport-client-v0\.js/); // eslint-disable-line max-len
+    expect(url).to.equal('https://3p.ampproject.net/$internalRuntimeVersion$/' +
+        'iframe-transport-client-v0.js');
   });
 });


### PR DESCRIPTION
Need https://3p.ampproject.net/1508896929494/iframe-transport-client-v0.js
It was giving us https://cdn.ampproject.org/rtv/001508896929494/iframe-transport-client-lib.js
