### PR TITLE
Makes iframe transport work with SERP

### DIFF
--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -23,6 +23,7 @@ import {dict, hasOwn, map} from '../../../src/utils/object';
 import {sendRequest, sendRequestUsingIframe} from './transport';
 import {IframeTransport} from './iframe-transport';
 import {getAmpAdResourceId} from '../../../src/ad-helper';
+import {getTopWindow} from '../../../src/services';
 import {Services} from '../../../src/services';
 import {toggle} from '../../../src/style';
 import {isEnumValue} from '../../../src/types';
@@ -319,7 +320,7 @@ export class AmpAnalytics extends AMP.BaseElement {
     }
     const TAG = this.getName_();
     const ampAdResourceId = user().assertString(
-        getAmpAdResourceId(this.element, this.win.__AMP_TOP),
+        getAmpAdResourceId(this.element, getTopWindow(this.win)),
         `${TAG}: No friendly parent amp-ad element was found for ` +
         'amp-analytics tag with iframe transport.');
 

--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -23,7 +23,7 @@ import {dict, hasOwn, map} from '../../../src/utils/object';
 import {sendRequest, sendRequestUsingIframe} from './transport';
 import {IframeTransport} from './iframe-transport';
 import {getAmpAdResourceId} from '../../../src/ad-helper';
-import {getTopWindow} from '../../../src/services';
+import {getTopWindow} from '../../../src/service';
 import {Services} from '../../../src/services';
 import {toggle} from '../../../src/style';
 import {isEnumValue} from '../../../src/types';

--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -319,7 +319,7 @@ export class AmpAnalytics extends AMP.BaseElement {
     }
     const TAG = this.getName_();
     const ampAdResourceId = user().assertString(
-        getAmpAdResourceId(this.element, this.win.top),
+        getAmpAdResourceId(this.element, this.win.__AMP_TOP),
         `${TAG}: No friendly parent amp-ad element was found for ` +
         'amp-analytics tag with iframe transport.');
 


### PR DESCRIPTION
Was using this.win.top which refers to the absolute top window. __AMP_TOP refers to the page in the carousel instead.