### PR TITLE
Closes #11175: Add input-throttled action event

### DIFF
--- a/examples/amp-rate-limited.amp.html
+++ b/examples/amp-rate-limited.amp.html
@@ -13,37 +13,58 @@
 <body>
     <h4>On Change Slider</h4>
     <p>This slider's value should update on mouse up, after the user finishes dragging the slider.</p>
-    <form
+    <form method="post"
+      action-xhr="/form/echo-json/post"
       id="change-slider"
       target="_blank">
         <fieldset>
             <label>
-                <input type="range" min="0" max="100" value="0" on="change:AMP.setState({rangeValueOnChange: event.value})" id="range">
-                <p id="changeText" [text]="rangeValueOnChange">0</p>
+                <input
+                  type="range"
+                  min="0"
+                  max="100"
+                  value="0"
+                  on="change:AMP.setState({rangeValueOnChange: event.value})"
+                  id="range-change">
+                <p id="changeText" [text]="rangeValueOnChange || 0">0</p>
             </label>
         </fieldset>
     </form>
   <h4>Throttled Slider</h4>
   <p>This slider's value should update at a throttled rate of once every 100ms, while the user is dragging the slider.</p>
-  <form
+  <form method="post"
+    action-xhr="/form/echo-json/post"
     id="throttled-slider"
     target="_blank">
       <fieldset>
           <label>
-              <input type="range" min="0" max="100" value="0" on="input-throttled:AMP.setState({rangeValueThrottled: event.value})" id="range">
-              <p id="throttledText" [text]="rangeValueThrottled">0</p>
+              <input
+                type="range"
+                required="required"
+                min="0" max="100"
+                value="0"
+                on="input-throttled:AMP.setState({rangeValueThrottled: event.value})"
+                id="range-throttled">
+              <p id="throttledText" [text]="rangeValueThrottled || 0">0</p>
           </label>
       </fieldset>
   </form>
   <h4>Debounced Slider</h4>
   <p>This slider's value should update 300ms after the user stops moving the slider, but not necessarily after mouse up.</p>
-  <form
+  <form method="post"
+    action-xhr="/form/echo-json/post"
     id="debounced-slider"
     target="_blank">
       <fieldset>
           <label>
-              <input type="range" min="0" max="100" value="0" on="input-debounced:AMP.setState({rangeValueDebounced: event.value})" id="range">
-              <p id="debouncedText" [text]="rangeValueDebounced">0</p>
+              <input
+                type="range"
+                min="0"
+                max="100"
+                value="0"
+                on="input-debounced:AMP.setState({rangeValueDebounced: event.value})"
+                id="range-debounced">
+              <p id="debouncedText" [text]="rangeValueDebounced || 0">0</p>
           </label>
       </fieldset>
   </form>

--- a/examples/amp-rate-limited.amp.html
+++ b/examples/amp-rate-limited.amp.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html ⚡>
+<head>
+    <meta charset="utf-8">
+    <title>Rate Limited Input Examples in AMP</title>
+    <link rel="canonical" href="amps.html" >
+    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+    <script async src="https://cdn.ampproject.org/v0.js"></script>
+    <script async custom-element="amp-form" src="https://cdn.ampproject.org/v0/amp-form-0.1.js"></script>
+    <script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script>
+</head>
+<body>
+    <h4>On Change Slider</h4>
+    <p>This slider's value should update on mouse up, after the user finishes dragging the slider.</p>
+    <form
+      id="change-slider"
+      target="_blank">
+        <fieldset>
+            <label>
+                <input type="range" min="0" max="100" value="0" on="change:AMP.setState({rangeValueOnChange: event.value})" id="range">
+                <p id="changeText" [text]="rangeValueOnChange">0</p>
+            </label>
+        </fieldset>
+    </form>
+  <h4>Throttled Slider</h4>
+  <p>This slider's value should update at a throttled rate of once every 100ms, while the user is dragging the slider.</p>
+  <form
+    id="throttled-slider"
+    target="_blank">
+      <fieldset>
+          <label>
+              <input type="range" min="0" max="100" value="0" on="input-throttled:AMP.setState({rangeValueThrottled: event.value})" id="range">
+              <p id="throttledText" [text]="rangeValueThrottled">0</p>
+          </label>
+      </fieldset>
+  </form>
+  <h4>Debounced Slider</h4>
+  <p>This slider's value should update 300ms after the user stops moving the slider, but not necessarily after mouse up.</p>
+  <form
+    id="debounced-slider"
+    target="_blank">
+      <fieldset>
+          <label>
+              <input type="range" min="0" max="100" value="0" on="input-debounced:AMP.setState({rangeValueDebounced: event.value})" id="range">
+              <p id="debouncedText" [text]="rangeValueDebounced">0</p>
+          </label>
+      </fieldset>
+  </form>
+</body>
+</html>

--- a/spec/amp-actions-and-events.md
+++ b/spec/amp-actions-and-events.md
@@ -158,6 +158,13 @@ event.value</pre>
     <td>Elements that fire <code>input</code> event.</td>
     <td>Same as <code>change</code> event data.</td>
   </tr>
+    <!-- input-throttled -->
+  <tr>
+    <td><code>input-throttled</code></td>
+    <td>Fired when the value of the element is changed. This is similar to the standard <code>change</code> event, but it is throttled to firing at most once every 100ms while the value of the input is changing.</td>
+    <td>Elements that fire <code>input</code> event.</td>
+    <td>Same as <code>change</code> event data.</td>
+  </tr>
 </table>
 
 ### amp-carousel[type="slides"]

--- a/test/functional/test-action.js
+++ b/test/functional/test-action.js
@@ -1188,6 +1188,28 @@ describes.fakeWin('Core events', {amp: true}, env => {
     });
   });
 
+  it('should trigger input-throttled event on input', () => {
+    sandbox.stub(action, 'invoke_');
+    const handler = window.document.addEventListener.getCall(5).args[1];
+    const element = document.createElement('input');
+    element.id = 'test';
+    element.setAttribute('on', 'input-throttled:test.hide');
+    element.value = 'foo bar baz';
+    const event = {target: element};
+    document.body.appendChild(element);
+    handler(event);
+
+    return triggerPromise.then(() => {
+      expect(action.trigger).to.have.been.calledWith(
+          element,
+          'input-throttled',
+          sinon.match(event => {
+            const value = event.target.value;
+            return value == 'foo bar baz';
+          }));
+    });
+  });
+
   describe('DeferredEvent', () => {
     it('should copy the properties of an event object', () => {
       const event = createCustomEvent(window, 'MyEvent', {foo: 'bar'});


### PR DESCRIPTION
Disclaimer: new person onboarding, please feel free to closely review. =) 

Closes #11175

- Implements an input-throttled action event. 
- Adds an example rate-limiting slider page to demonstrate rate-limiting related action events. 
- Leaves out explicit testing for whether the input is actually throttled (following the example set by input-debounced), as we unit test the throttle function. But I actually thought this was a bit weird. I wouldn't mind adding functionality tests for input-debounced and input-throttled to test that they are actually debounced and throttled. 

Feedback welcome on: the choice of 100ms as a throttling interval. This is based on the heuristic of "respond to user input within 100ms" from https://developers.google.com/web/fundamentals/performance/rail. 

Two tests fail on my laptop locally, but they also fail on master, so I don't think they are related to my changes and hence not blocking this PR. 

```
DESCRIBE => amp-ad-network-adsense-impl
  DESCRIBE =>  
    DESCRIBE => #onLayoutMeasure
      IT => should change right margin for responsive in RTL
        ✗ AssertionError: expected '-34px' to equal '-49px'
            at /var/folders/rf/d9hrbkbj1g93pqtqzlj0z3jc00glry/T/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js:807:48 <- /var/folders/rf/d9hrbkbj1g93pqtqzlj0z3jc00glry/T/2bea2323ddcad37f6008b5c157268e5d.browserify:38684:49
            at <anonymous>
●●●●●●●●●●●●●●●●○●●●●●●●●●●●●●●●●●●●●
DESCRIBE => amp-ad-network-doubleclick-impl
  DESCRIBE =>  
    DESCRIBE => #getAdUrl
      IT => has correct rc and ifi after refresh
        ✗ Error: timeout of 2000ms exceeded. Ensure the done() callback is being called in this test.
```
