### PR TITLE
FIX install on Linux with NPM 5 (#10854).

### DIFF
--- a/validator/nodejs/package.json
+++ b/validator/nodejs/package.json
@@ -24,6 +24,6 @@
     "jasmine": "2.3.2"
   },
   "scripts": {
-    "postinstall": "node postinstall-windows.js"
+    "postinstall": "$NODE postinstall-windows.js"
   }
 }

--- a/validator/nodejs/package.json
+++ b/validator/nodejs/package.json
@@ -24,6 +24,6 @@
     "jasmine": "2.3.2"
   },
   "scripts": {
-    "postinstall": "/bin/sh -c \"exit 0\" 2> postinstall.DELETEME && rm postinstall.DELETEME || node postinstall-windows.js"
+    "postinstall": "node postinstall-windows.js"
   }
 }

--- a/validator/nodejs/postinstall-windows.js
+++ b/validator/nodejs/postinstall-windows.js
@@ -20,18 +20,10 @@
 var path = require('path');
 var fs = require('fs');
 
-// The postinstall invocation in package.json creates this temp file and on
-// Windows installations, it won't delete it. We used to redirect to NUL
-// but that doesn't work in Linux if the underlying filesystem is SMB
-// (since in Windows NUL is special). So now we clean it up best-effort here.
-if (fs.existsSync('postinstall.DELETEME')) {
-  fs.unlinkSync('postinstall.DELETEME');
-}
-
 if (process.env.OS !== 'Windows_NT') {
-  console./*OK*/ error(
+  console./*OK*/ log(
       'postinstall-windows.js: This script is for Windows only.');
-  process.exit(1);
+  process.exit(0);
 }
 
 // We only want to modify the .cmd shim - this is what would run on a


### PR DESCRIPTION
Rationale here: https://github.com/ampproject/amphtml/issues/10854#issuecomment-343422944

Tested using:

```
# /usr/bin/npm install --global
/usr/bin/amphtml-validator -> /usr/lib/node_modules/amphtml-validator/index.sh

> amphtml-validator@1.0.21 postinstall /usr/lib/node_modules/amphtml-validator
> node postinstall-windows.js

postinstall-windows.js: This script is for Windows only.
+ amphtml-validator@1.0.21
added 6 packages in 0.6s
```

Yes, running node for nothing adds 0.06s on each install (~8% of 0.8s on my machine: executing `node` for nothing costs way more than executing `sh` for nothing) but it does less I/O (Do not creates a file for nothing on a filesystem we don't know, which may be networked and slow) and uses less code so it's probably less error prone.


Closes #10854 
