### PR TITLE
amp-ad: add type=adagio ad network implementation

### DIFF
--- a/3p/integration.js
+++ b/3p/integration.js
@@ -71,6 +71,7 @@ import {_ping_} from '../ads/_ping_';
 import {a8} from '../ads/a8';
 import {a9} from '../ads/a9';
 import {accesstrade} from '../ads/accesstrade';
+import {adagio} from '../ads/adagio';
 import {adblade, industrybrains} from '../ads/adblade';
 import {adbutler} from '../ads/adbutler';
 import {adform} from '../ads/adform';
@@ -241,6 +242,7 @@ if (getMode().test || getMode().localDev) {
 register('a8', a8);
 register('a9', a9);
 register('accesstrade', accesstrade);
+register('adagio', adagio);
 register('adblade', adblade);
 register('adbutler', adbutler);
 register('adform', adform);

--- a/ads/_config.js
+++ b/ads/_config.js
@@ -77,6 +77,7 @@ export const adConfig = {
       'https://ad-aws-it.neodatagroup.com',
       'https://tracker.neodatagroup.com',
     ],
+    renderStartImplemented: true,
   },
 
   adblade: {

--- a/ads/_config.js
+++ b/ads/_config.js
@@ -71,6 +71,14 @@ export const adConfig = {
     prefetch: 'https://h.accesstrade.net/js/amp/amp.js',
   },
 
+  adagio: {
+    prefetch: 'https://js-ssl.neodatagroup.com/adagio_amp.js',
+    preconnect: [
+      'https://ad-aws-it.neodatagroup.com',
+      'https://tracker.neodatagroup.com',
+    ],
+  },
+
   adblade: {
     prefetch: 'https://web.adblade.com/js/ads/async/show.js',
     preconnect: [

--- a/ads/adagio.js
+++ b/ads/adagio.js
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {loadScript, validateData} from '../3p/3p';
+
+/**
+ * @param {!Window} global
+ * @param {!Object} data
+ */
+export function adagio(global, data) {
+
+  validateData(data, ['sid', 'loc']);
+
+  const $neodata = global;
+
+  $neodata._adagio = {};
+  $neodata._adagio.amp = data;
+
+  loadScript($neodata, 'https://js-ssl.neodatagroup.com/adagio_amp.js');
+}

--- a/ads/adagio.md
+++ b/ads/adagio.md
@@ -1,0 +1,41 @@
+<!---
+Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS-IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Ad.Agio - Neodata Group
+
+## Example
+
+```html
+<amp-ad width=320 height=250
+    type="adagio"
+    data-sid="39"
+    data-loc="amp_ampw_amps_ampp_300x250"
+    data-keywords=""
+    data-uservars="">
+</amp-ad>
+```
+
+## Configuration
+
+For semantics of configuration, please see ad network documentation.
+
+Supported parameters:
+
+- data-sid
+- data-loc
+- data-keywords
+- data-uservars
+

--- a/examples/ads-legacy.amp.html
+++ b/examples/ads-legacy.amp.html
@@ -64,6 +64,15 @@
     </amp-ad>
   </div>
 
+  <h2>Ad.Agio</h2>
+  <amp-ad width=320 height=250
+      type="adagio"
+      data-sid="39"
+      data-loc="amp_ampw_amps_ampp_300x250"
+      data-keywords=""
+      data-uservars="">
+  </amp-ad>
+
   <h2>Adblade</h2>
   <amp-ad width=300 height=250
       type="adblade"

--- a/examples/ads.amp.html
+++ b/examples/ads.amp.html
@@ -66,6 +66,7 @@
         <option>a8</option>
         <option>a9</option>
         <option>accesstrade</option>
+        <option>adagio</option>
         <option>adblade</option>
         <option>adbutler</option>
         <option>adfox</option>
@@ -222,6 +223,15 @@
       type="accesstrade"
       data-atops="r"
       data-atrotid="00000000000008c06y">
+  </amp-ad>
+
+  <h2>Ad.Agio</h2>
+  <amp-ad width=300 height=250
+      type="adagio"
+      data-sid="39"
+      data-loc="amp_ampw_amps_ampp_300x250"
+      data-keywords=""
+      data-uservars="">
   </amp-ad>
 
   <h2>Adblade</h2>


### PR DESCRIPTION
The PR implements support to delivery ad.agio advertising ad.agio is an adserver developed by Neodata (www.neodatagroup.com)