### PR TITLE
Add this.isInabox_ field in amp-analytics

### DIFF
--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -118,7 +118,7 @@ export class AmpAnalytics extends AMP.BaseElement {
     this.iframeTransport_ = null;
 
     /** @private {!boolean} */
-    this.isInabox_ = getMode().runtime == 'inabox' ? true : false;
+    this.isInabox_ = getMode().runtime == 'inabox';
   }
 
   /** @override */

--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -116,12 +116,15 @@ export class AmpAnalytics extends AMP.BaseElement {
 
     /** @private {?IframeTransport} */
     this.iframeTransport_ = null;
+
+    /** @private {!boolean} */
+    this.isInabox_ = getMode().runtime == 'inabox' ? true : false;
   }
 
   /** @override */
   getPriority() {
     // Load immediately if inabox, otherwise after other content.
-    return getMode().runtime == 'inabox' ? 0 : 1;
+    return this.isInabox_ ? 0 : 1;
   }
 
   /** @override */

--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -80,7 +80,7 @@ export class AmpAnalytics extends AMP.BaseElement {
      */
     this.type_ = null;
 
-    /** @private {!boolean} */
+    /** @private {boolean} */
     this.isSandbox_ = false;
 
     /**
@@ -117,7 +117,7 @@ export class AmpAnalytics extends AMP.BaseElement {
     /** @private {?IframeTransport} */
     this.iframeTransport_ = null;
 
-    /** @private {!boolean} */
+    /** @private {boolean} */
     this.isInabox_ = getMode().runtime == 'inabox';
   }
 


### PR DESCRIPTION
This CL adds isInabox_ field to cache the isInabox result so that it can be used later for special handing the case of amp-analytics for inabox.