### PR TITLE
Allow `<style amp-keyframes>` on AMP4ADS document formats.

### DIFF
--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -990,6 +990,7 @@ tags: {
 
 tags: {
   html_format: AMP
+  html_format: AMP4ADS
   tag_name: "STYLE"
   spec_name: "style[amp-keyframes]"
   unique: true


### PR DESCRIPTION
Addresses #12004
