### PR TITLE
amp-youtube: Privacy-enhanced mode (#11956)

### DIFF
--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -356,7 +356,7 @@ const forbiddenTerms = {
       'src/service/cid-impl.js',
       'testing/fake-dom.js',
       'extensions/amp-analytics/0.1/vendors.js',
-      'extensions/amp-youtube/0.1/amp-youtube.js',  
+      'extensions/amp-youtube/0.1/amp-youtube.js',
     ],
   },
   'getCookie\\W': {

--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -356,6 +356,7 @@ const forbiddenTerms = {
       'src/service/cid-impl.js',
       'testing/fake-dom.js',
       'extensions/amp-analytics/0.1/vendors.js',
+      'extensions/amp-youtube/0.1/amp-youtube.js',  
     ],
   },
   'getCookie\\W': {

--- a/examples/youtube.amp.html
+++ b/examples/youtube.amp.html
@@ -21,6 +21,14 @@
             width="480" height="270">
     </amp-youtube>
 
+    <!-- YouTube video without cookies -->
+    <amp-youtube
+            data-videoid="mGENRKrdoGY"
+            credentials="omit"
+            data-param-controls=1
+            width="480" height="270">
+    </amp-youtube>
+
     <!-- YouTube video that doesn't have sddefault.jpg -->
     <amp-youtube
             data-videoid="oofSnsGkops"

--- a/extensions/amp-youtube/0.1/amp-youtube.js
+++ b/extensions/amp-youtube/0.1/amp-youtube.js
@@ -147,13 +147,25 @@ class AmpYoutube extends AMP.BaseElement {
     Services.videoManagerForDoc(this.element).register(this);
   }
 
+  /**
+   * @return {string}
+   * @private
+   */
+  getEmbedUrl_() {
+    let urlSuffix = '';
+    if (this.getCredentials_() === 'omit') {
+      urlSuffix = '-nocookie';
+    }
+    return `https://www.youtube${urlSuffix}.com/embed/${encodeURIComponent(this.videoid_ || '')}?enablejsapi=1`;
+  }
+
   /** @return {string} */
   getVideoIframeSrc_() {
     if (this.videoIframeSrc_) {
       return this.videoIframeSrc_;
     }
     dev().assert(this.videoid_);
-    let src = `https://www.youtube.com/embed/${encodeURIComponent(this.videoid_ || '')}?enablejsapi=1`;
+    let src = this.getEmbedUrl_();
 
     const params = getDataParamsFromAttributes(this.element);
     if ('autoplay' in params) {
@@ -266,6 +278,14 @@ class AmpYoutube extends AMP.BaseElement {
         this.element.getAttribute('data-videoid'),
         'The data-videoid attribute is required for <amp-youtube> %s',
         this.element);
+  }
+
+  /**
+   * @return {string}
+   * @private
+   */
+  getCredentials_() {
+    return this.element.getAttribute('credentials') || 'include';
   }
 
   /**

--- a/extensions/amp-youtube/0.1/test/test-amp-youtube.js
+++ b/extensions/amp-youtube/0.1/test/test-amp-youtube.js
@@ -72,6 +72,18 @@ describes.realWin('amp-youtube', {
     });
   });
 
+  it('uses privacy-enhanced mode', () => {
+    return getYt({'data-videoid': 'mGENRKrdoGY', 'credentials': 'omit'})
+        .then(yt => {
+          const iframe = yt.querySelector('iframe');
+          expect(iframe).to.not.be.null;
+          expect(iframe.tagName).to.equal('IFRAME');
+          expect(iframe.src).to.equal(
+              'https://www.youtube-nocookie.com/embed/mGENRKrdoGY?enablejsapi=1&playsinline=1'
+          );
+        });
+  });
+
   it('renders responsively', () => {
     return getYt({'data-videoid': 'mGENRKrdoGY'}, true).then(yt => {
       const iframe = yt.querySelector('iframe');

--- a/extensions/amp-youtube/amp-youtube.md
+++ b/extensions/amp-youtube/amp-youtube.md
@@ -76,6 +76,16 @@ Keys and values will be URI encoded. Keys will be camel cased.
 
 See [YouTube Embedded Player Parameters](https://developers.google.com/youtube/player_parameters) for more parameter options for YouTube.
 
+##### credentials (optional)
+
+Defines a `credentials` option as specified by the [Fetch API](https://fetch.spec.whatwg.org/).
+
+* Supported values: `omit`, `include`
+* Default: `include`
+
+If you want to use the [YouTube player in privacy-enhanced mode](http://www.google.com/support/youtube/bin/answer.py?answer=141046), pass the value of `omit`.  
+Usually YouTube sets its cookies when the player is loaded. In privacy-enhanced mode cookies are set when the user has clicked on the player.
+
 ##### common attributes
 
 This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.

--- a/extensions/amp-youtube/validator-amp-youtube.protoascii
+++ b/extensions/amp-youtube/validator-amp-youtube.protoascii
@@ -30,6 +30,10 @@ tags: {  # <amp-youtube>
   requires_extension: "amp-youtube"
   attrs: { name: "autoplay" }
   attrs: {
+    name: "credentials"
+    value_regex_casei: "(include|omit)"
+  }
+  attrs: {
     name: "data-videoid"
     mandatory: true
     value_regex: "[^=/?:]+"


### PR DESCRIPTION
# amp-youtube: Privacy-enhanced mode (#11956)

- Allows using the [privacy-enhanced mode](http://www.google.com/support/youtube/bin/answer.py?answer=141046) of the YouTube player 

Closes #11956