### PR TITLE
AdSense/Doubleclick Fast Fetch unlayoutCallback experiment setup

### DIFF
--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -972,19 +972,8 @@ export class AmpA4A extends AMP.BaseElement {
     return super.attemptChangeSize(newHeight, newWidth).catch(() => {});
   }
 
-  /**
-   * @return {boolean} where AMP creatives rendered via FIE should
-   *    be removed as part of unlayoutCallback.  By default they remain.
-   */
-  shouldUnlayoutAmpCreatives() {
-    return false;
-  }
-
   /** @override  */
   unlayoutCallback() {
-    if (this.friendlyIframeEmbed_ && !this.shouldUnlayoutAmpCreatives()) {
-      return false;
-    }
     this.tearDownSlot();
     return true;
   }

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -794,7 +794,7 @@ describe('amp-a4a', () => {
         return a4a.layoutCallback().then(() => {
           expect(renderAmpCreativeSpy.calledOnce,
               'renderAmpCreative_ called exactly once').to.be.true;
-          a4a.unlayoutCallback();
+          sandbox.stub(a4a, 'unlayoutCallback', () => false);
           const onLayoutMeasureSpy = sandbox.spy(a4a, 'onLayoutMeasure');
           a4a.resumeCallback();
           expect(onLayoutMeasureSpy).to.not.be.called;

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -402,33 +402,6 @@ describe('amp-a4a', () => {
       });
     });
 
-    it('should reset state to null on non-FIE unlayoutCallback', () => {
-      // Make sure there's no signature, so that we go down the 3p iframe path.
-      delete adResponse.headers['AMP-Fast-Fetch-Signature'];
-      delete adResponse.headers[AMP_SIGNATURE_HEADER];
-      a4a.buildCallback();
-      a4a.onLayoutMeasure();
-      return a4a.layoutCallback().then(() => {
-        expect(a4aElement.querySelector('iframe[src]')).to.be.ok;
-        expect(a4a.unlayoutCallback()).to.be.true;
-        expect(a4aElement.querySelector('iframe[src]')).to.not.be.ok;
-      });
-    });
-
-    it('should not reset state to null on FIE unlayoutCallback', () => {
-      a4a.buildCallback();
-      a4a.onLayoutMeasure();
-      return a4a.layoutCallback().then(() => {
-        a4a.vsync_.runScheduledTasks_();
-        expect(a4a.friendlyIframeEmbed_).to.exist;
-        const destroySpy = sandbox.spy();
-        a4a.friendlyIframeEmbed_.destroy = destroySpy;
-        expect(a4a.unlayoutCallback()).to.be.false;
-        expect(a4a.friendlyIframeEmbed_).to.exist;
-        expect(destroySpy).to.not.be.called;
-      });
-    });
-
     it('should update embed visibility', () => {
       sandbox.stub(a4a, 'isInViewport', () => false);
       a4a.buildCallback();

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -364,33 +364,6 @@ describe('amp-a4a', () => {
       });
     });
 
-    it('should reset state to null on non-FIE unlayoutCallback', () => {
-      // Make sure there's no signature, so that we go down the 3p iframe path.
-      delete adResponse.headers['AMP-Fast-Fetch-Signature'];
-      delete adResponse.headers[AMP_SIGNATURE_HEADER];
-      a4a.buildCallback();
-      a4a.onLayoutMeasure();
-      return a4a.layoutCallback().then(() => {
-        expect(a4aElement.querySelector('iframe[src]')).to.be.ok;
-        expect(a4a.unlayoutCallback()).to.be.true;
-        expect(a4aElement.querySelector('iframe[src]')).to.not.be.ok;
-      });
-    });
-
-    it('should not reset state to null on FIE unlayoutCallback', () => {
-      a4a.buildCallback();
-      a4a.onLayoutMeasure();
-      return a4a.layoutCallback().then(() => {
-        a4a.vsync_.runScheduledTasks_();
-        expect(a4a.friendlyIframeEmbed_).to.exist;
-        const destroySpy = sandbox.spy();
-        a4a.friendlyIframeEmbed_.destroy = destroySpy;
-        expect(a4a.unlayoutCallback()).to.be.false;
-        expect(a4a.friendlyIframeEmbed_).to.exist;
-        expect(destroySpy).to.not.be.called;
-      });
-    });
-
     it('should update embed visibility', () => {
       sandbox.stub(a4a, 'isInViewport', () => false);
       a4a.buildCallback();

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
@@ -623,32 +623,94 @@ describes.realWin('amp-ad-network-adsense-impl', {
   });
 
   describe('#unlayoutCallback', () => {
+    beforeEach(() => {
+      createImplTag({
+        width: '300',
+        height: '150',
+      });
+      impl.win.ampAdSlotIdCounter = 1;
+      expect(impl.element.getAttribute('data-amp-slot-index')).to.not.be.ok;
+      impl.layoutMeasureExecuted_ = true;
+      impl.uiHandler = {applyUnlayoutUI: () => {}};
+      const placeholder = doc.createElement('div');
+      placeholder.setAttribute('placeholder', '');
+      const fallback = doc.createElement('div');
+      fallback.setAttribute('fallback', '');
+      impl.element.appendChild(placeholder);
+      impl.element.appendChild(fallback);
+      impl.size_ = {width: 123, height: 456};
+    });
+
+    it('should reset state to null on non-FIE unlayoutCallback', () => {
+      impl.onCreativeRender();
+      expect(impl.unlayoutCallback()).to.be.true;
+      expect(impl.iframe).is.not.ok;
+    });
+
+    it('should not reset state to null on FIE unlayoutCallback', () => {
+      impl.onCreativeRender({customElementExtensions: []});
+      expect(impl.unlayoutCallback()).to.be.false;
+      expect(impl.iframe).is.ok;
+    });
+
+    it('should remove FIE if in all exp', () => {
+      impl.onCreativeRender({customElementExtensions: []});
+      impl.postAdResponseExperimentFeatures['unlayout_exp'] = 'all';
+      expect(impl.unlayoutCallback()).to.be.true;
+      expect(impl.iframe).is.not.ok;
+      expect(impl.isAmpCreative_).to.be.null;
+    });
+
+    it('should remove non-FIE if in all exp', () => {
+      impl.onCreativeRender();
+      impl.postAdResponseExperimentFeatures['unlayout_exp'] = 'all';
+      expect(impl.unlayoutCallback()).to.be.true;
+      expect(impl.iframe).is.not.ok;
+      expect(impl.isAmpCreative_).to.be.null;
+    });
+
+    it('should not remove FIE if in remain exp', () => {
+      impl.onCreativeRender({customElementExtensions: []});
+      impl.postAdResponseExperimentFeatures['unlayout_exp'] = 'remain';
+      expect(impl.unlayoutCallback()).to.be.false;
+      expect(impl.iframe).is.ok;
+    });
+
+    it('should remove rendered non-FIE if in remain exp', () => {
+      impl.onCreativeRender();
+      impl.postAdResponseExperimentFeatures['unlayout_exp'] = 'remain';
+      expect(impl.unlayoutCallback()).to.be.true;
+      expect(impl.iframe).is.not.ok;
+      expect(impl.isAmpCreative_).to.be.null;
+    });
+
+    it('should not destroy ad promise for unrendered if in remain exp', () => {
+      impl.onCreativeRender();
+      impl.qqid_ = 'abcdef';
+      impl.isAmpCreative_ = null;
+      impl.postAdResponseExperimentFeatures['unlayout_exp'] = 'remain';
+      expect(impl.unlayoutCallback()).to.be.false;
+      expect(impl.isAmpCreative_).to.be.null;
+    });
+
+    it('should destroy ad promise if ad response not yet received and in ' +
+        'remain exp', () => {
+      impl.onCreativeRender();
+      impl.qqid_ = null;
+      impl.isAmpCreative_ = null;
+      impl.postAdResponseExperimentFeatures['unlayout_exp'] = 'remain';
+      expect(impl.unlayoutCallback()).to.be.true;
+      expect(impl.isAmpCreative_).to.be.null;
+    });
+
     it('should call #resetSlot, remove child iframe, but keep other children',
         () => {
-          createImplTag({
-            width: '300',
-            height: '150',
-          });
-          impl.win.ampAdSlotIdCounter = 1;
-          expect(impl.element.getAttribute('data-amp-slot-index')).to.not.be.ok;
-
-          impl.layoutMeasureExecuted_ = true;
-          impl.uiHandler = {applyUnlayoutUI: () => {}};
-          const placeholder = doc.createElement('div');
-          placeholder.setAttribute('placeholder', '');
-          const fallback = doc.createElement('div');
-          fallback.setAttribute('fallback', '');
-          impl.element.appendChild(placeholder);
-          impl.element.appendChild(fallback);
           impl.ampAnalyticsConfig_ = {};
           impl.ampAnalyticsElement_ =
-              doc.createElement('amp-analytics');
+             doc.createElement('amp-analytics');
           impl.element.appendChild(impl.ampAnalyticsElement_);
-
           expect(impl.iframe).to.be.ok;
-          expect(impl.ampAnalyticsConfig_).to.be.ok;
           expect(impl.element.querySelector('iframe')).to.be.ok;
-          expect(impl.element.querySelector('amp-analytics')).to.be.ok;
           impl.unlayoutCallback();
           expect(impl.element.querySelector('div[placeholder]')).to.be.ok;
           expect(impl.element.querySelector('div[fallback]')).to.be.ok;

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -649,37 +649,98 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
   });
 
   describe('#unlayoutCallback', () => {
+    beforeEach(() => {
+      const setup = createImplTag({
+        width: '300',
+        height: '150',
+      }, element, impl, env);
+      element = setup[0];
+      impl = setup[1];
+      env = setup[2];
+      impl.buildCallback();
+      impl.win.ampAdSlotIdCounter = 1;
+      expect(impl.element.getAttribute('data-amp-slot-index')).to.not.be.ok;
+      impl.layoutMeasureExecuted_ = true;
+      impl.uiHandler = {applyUnlayoutUI: () => {}};
+      const placeholder = doc.createElement('div');
+      placeholder.setAttribute('placeholder', '');
+      const fallback = doc.createElement('div');
+      fallback.setAttribute('fallback', '');
+      impl.element.appendChild(placeholder);
+      impl.element.appendChild(fallback);
+      impl.size_ = {width: 123, height: 456};
+    });
+
+    it('should reset state to null on non-FIE unlayoutCallback', () => {
+      impl.onCreativeRender();
+      expect(impl.unlayoutCallback()).to.be.true;
+      expect(impl.iframe).is.not.ok;
+    });
+
+    it('should not reset state to null on FIE unlayoutCallback', () => {
+      impl.onCreativeRender({customElementExtensions: []});
+      expect(impl.unlayoutCallback()).to.be.false;
+      expect(impl.iframe).is.ok;
+    });
+
+    it('should remove FIE if in all exp', () => {
+      impl.onCreativeRender({customElementExtensions: []});
+      impl.postAdResponseExperimentFeatures['unlayout_exp'] = 'all';
+      expect(impl.unlayoutCallback()).to.be.true;
+      expect(impl.iframe).is.not.ok;
+      expect(impl.isAmpCreative_).to.be.null;
+    });
+
+    it('should remove non-FIE if in all exp', () => {
+      impl.onCreativeRender();
+      impl.postAdResponseExperimentFeatures['unlayout_exp'] = 'all';
+      expect(impl.unlayoutCallback()).to.be.true;
+      expect(impl.iframe).is.not.ok;
+      expect(impl.isAmpCreative_).to.be.null;
+    });
+
+    it('should not remove FIE if in remain exp', () => {
+      impl.onCreativeRender({customElementExtensions: []});
+      impl.postAdResponseExperimentFeatures['unlayout_exp'] = 'remain';
+      expect(impl.unlayoutCallback()).to.be.false;
+      expect(impl.iframe).is.ok;
+    });
+
+    it('should remove rendered non-FIE if in remain exp', () => {
+      impl.onCreativeRender();
+      impl.postAdResponseExperimentFeatures['unlayout_exp'] = 'remain';
+      expect(impl.unlayoutCallback()).to.be.true;
+      expect(impl.iframe).is.not.ok;
+      expect(impl.isAmpCreative_).to.be.null;
+    });
+
+    it('should not destroy ad promise for unrendered if in remain exp', () => {
+      impl.onCreativeRender();
+      impl.qqid_ = 'abcdef';
+      impl.isAmpCreative_ = null;
+      impl.postAdResponseExperimentFeatures['unlayout_exp'] = 'remain';
+      expect(impl.unlayoutCallback()).to.be.false;
+      expect(impl.isAmpCreative_).to.be.null;
+    });
+
+    it('should destroy ad promise if ad response not yet received and in ' +
+        'remain exp', () => {
+      impl.onCreativeRender();
+      impl.qqid_ = null;
+      impl.isAmpCreative_ = null;
+      impl.postAdResponseExperimentFeatures['unlayout_exp'] = 'remain';
+      expect(impl.unlayoutCallback()).to.be.true;
+      expect(impl.isAmpCreative_).to.be.null;
+    });
+
     it('should call #resetSlot, remove child iframe, but keep other children',
         () => {
-          const setup = createImplTag({
-            width: '300',
-            height: '150',
-          }, element, impl, env);
-          element = setup[0];
-          impl = setup[1];
-          env = setup[2];
-          impl.buildCallback();
-          impl.win.ampAdSlotIdCounter = 1;
-          const slotIdBefore = impl.element.getAttribute(
-              'data-amp-slot-index');
-
-          impl.layoutMeasureExecuted_ = true;
-          impl.uiHandler = {applyUnlayoutUI: () => {}};
-          const placeholder = doc.createElement('div');
-          placeholder.setAttribute('placeholder', '');
-          const fallback = doc.createElement('div');
-          fallback.setAttribute('fallback', '');
-          impl.element.appendChild(placeholder);
-          impl.element.appendChild(fallback);
           impl.ampAnalyticsConfig_ = {};
           impl.ampAnalyticsElement_ =
              doc.createElement('amp-analytics');
           impl.element.appendChild(impl.ampAnalyticsElement_);
-
           expect(impl.iframe).to.be.ok;
-          expect(impl.ampAnalyticsConfig_).to.be.ok;
           expect(impl.element.querySelector('iframe')).to.be.ok;
-          expect(impl.element.querySelector('amp-analytics')).to.be.ok;
           impl.unlayoutCallback();
           expect(impl.element.querySelector('div[placeholder]')).to.be.ok;
           expect(impl.element.querySelector('div[fallback]')).to.be.ok;
@@ -688,8 +749,8 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
           expect(impl.iframe).to.be.null;
           expect(impl.ampAnalyticsConfig_).to.be.null;
           expect(impl.ampAnalyticsElement_).to.be.null;
-          expect(impl.element.getAttribute('data-amp-slot-index')).to
-              .equal(String(Number(slotIdBefore) + 1));
+          expect(impl.element.getAttribute('data-amp-slot-index'))
+              .to.equal('1');
         });
   });
 

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-sra.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-sra.js
@@ -106,15 +106,17 @@ describes.realWin('amp-ad-network-doubleclick-impl', config , env => {
             width: 50,
           }, 'iframe', element);
       impl = new AmpAdNetworkDoubleclickImpl(element);
+      impl.buildCallback();
+      impl.isAmpCreative_ = true;
     });
 
     it('should not remove if not SRA', () => {
-      expect(impl.shouldUnlayoutAmpCreatives()).to.be.false;
+      expect(impl.unlayoutCallback()).to.be.false;
     });
 
     it('should remove if SRA and has frame', () => {
       impl.useSra = true;
-      expect(impl.shouldUnlayoutAmpCreatives()).to.be.true;
+      expect(impl.unlayoutCallback()).to.be.true;
     });
   });
 


### PR DESCRIPTION
For AdSense/Doubleclick Fast Fetch, setup infrastructure to experiment with what state is cleared as part of unlayoutCallback.  Current behavior allows for AMP creatives to remain such that they remain visible to the user upon resumeCallback from SERP viewer.  Experiment with two new behaviors:

- clear all including AMP creatives.  This allows for measuring the uplift given by allowing AMP creatives to remain
- do not destroy ad promise for unrendered creatives (did not call layoutCallback as they did not get within 3 viewports).  This will allow for their usage should the user swipe back and scroll.