### PR TITLE
amp-animation: remove mandatory body as parent

### DIFF
--- a/extensions/amp-animation/0.1/test/validator-amp-animation.html
+++ b/extensions/amp-animation/0.1/test/validator-amp-animation.html
@@ -39,7 +39,6 @@
     </script>
   </amp-animation>
 
-  <!-- Invalid: not direct child of body -->
   <span>
     <amp-animation layout="nodisplay">
       <script type="application/json">

--- a/extensions/amp-animation/0.1/test/validator-amp-animation.out
+++ b/extensions/amp-animation/0.1/test/validator-amp-animation.out
@@ -1,4 +1,3 @@
 FAIL
-amp-animation/0.1/test/validator-amp-animation.html:44:4 The parent tag of tag 'amp-animation' is 'span', but it can only be 'body'. (see https://www.ampproject.org/docs/reference/components/amp-animation) [AMP_TAG_PROBLEM]
-amp-animation/0.1/test/validator-amp-animation.html:56:2 The attribute 'trigger' in tag 'amp-animation' is set to the invalid value 'display'. (see https://www.ampproject.org/docs/reference/components/amp-animation) [AMP_TAG_PROBLEM]
-amp-animation/0.1/test/validator-amp-animation.html:67:2 Tag 'amp-animation' must have 1 child tags - saw 0 child tags. (see https://www.ampproject.org/docs/reference/components/amp-animation) [AMP_TAG_PROBLEM]
+amp-animation/0.1/test/validator-amp-animation.html:55:2 The attribute 'trigger' in tag 'amp-animation' is set to the invalid value 'display'. (see https://www.ampproject.org/docs/reference/components/amp-animation) [AMP_TAG_PROBLEM]
+amp-animation/0.1/test/validator-amp-animation.html:66:2 Tag 'amp-animation' must have 1 child tags - saw 0 child tags. (see https://www.ampproject.org/docs/reference/components/amp-animation) [AMP_TAG_PROBLEM]

--- a/extensions/amp-animation/validator-amp-animation.protoascii
+++ b/extensions/amp-animation/validator-amp-animation.protoascii
@@ -49,7 +49,6 @@ tags: {  # <amp-animation>
   html_format: AMP
   html_format: AMP4ADS
   tag_name: "AMP-ANIMATION"
-  mandatory_parent: "BODY"
   requires_extension: "amp-animation"
   requires: "amp-animation extension .json script"
   attrs: {


### PR DESCRIPTION
`amp-animation` does not need to be in `body` if `trigger` is not `visibility`. We relaxed this rule in #11826 for runtime but validation rule changes were missed.

