### PR TITLE
Add amp-analytics config to record CSI metrics for Doubleclick/AdSense impls.

### DIFF
--- a/ads/google/a4a/test/test-utils.js
+++ b/ads/google/a4a/test/test-utils.js
@@ -18,6 +18,7 @@ import {
   additionalDimensions,
   addCsiSignalsToAmpAnalyticsConfig,
   extractAmpAnalyticsConfig,
+  getCsiAmpAnalyticsVariables,
   EXPERIMENT_ATTRIBUTE,
   googleAdUrl,
   mergeExperimentIds,
@@ -591,6 +592,70 @@ describe('Google A4A utils', () => {
         {fetchJson: () => Promise.reject('some network failure')});
       return getIdentityToken(env.win, env.win.document)
           .then(result => expect(result).to.jsonEqual({}));
+    });
+  });
+
+  describe('variables for amp-analytics', () => {
+    let a4a;
+    let sandbox;
+
+    beforeEach(() => {
+      sandbox = sinon.sandbox.create();
+      return createIframePromise().then(fixture => {
+        setupForAdTesting(fixture);
+        const element = createElementWithAttributes(fixture.doc, 'amp-a4a', {
+          'width': '200',
+          'height': '50',
+          'type': 'adsense',
+          'data-amp-slot-index': '4',
+        });
+        element.getAmpDoc = () => fixture.doc;
+        a4a = new MockA4AImpl(element);
+      });
+    });
+
+    it('should include the correlator', () => {
+      const vars = getCsiAmpAnalyticsVariables('trigger', a4a, null);
+      expect(vars['correlator']).not.to.be.undefined;
+      expect(vars['correlator']).to.be.greaterThan(0);
+    });
+
+    it('should include the slot index', () => {
+      const vars = getCsiAmpAnalyticsVariables('trigger', a4a, null);
+      expect(vars['slotId']).to.equal('4');
+    });
+
+    it('should include the qqid when provided', () => {
+      const vars = getCsiAmpAnalyticsVariables('trigger', a4a, '<qqid>');
+      expect(vars['qqid']).to.equal('<qqid>');
+    });
+
+    it('should omit the qqid when null', () => {
+      const vars = getCsiAmpAnalyticsVariables('trigger', a4a, null);
+      expect(vars['qqid']).to.be.undefined;
+    });
+
+    it('should include scheduleTime for ad render start triggers', () => {
+      a4a.element.layoutScheduleTime = 200;
+      const vars = getCsiAmpAnalyticsVariables('ad-render-start', a4a, null);
+      expect(vars['scheduleTime']).to.be.a('number');
+      expect(vars['scheduleTime']).not.to.equal(0);
+    });
+
+    it('should omit scheduleTime by default', () => {
+      a4a.element.layoutScheduleTime = 200;
+      const vars = getCsiAmpAnalyticsVariables('trigger', a4a, null);
+      expect(vars['scheduleTime']).to.be.undefined;
+    });
+
+    it('should include viewer lastVisibleTime', () => {
+      const getLastVisibleTime = () => 300;
+      const viewerStub = sandbox.stub(Services, 'viewerForDoc');
+      viewerStub.returns({getLastVisibleTime});
+
+      const vars = getCsiAmpAnalyticsVariables('trigger', a4a, null);
+      expect(vars['viewerLastVisibleTime']).to.be.a('number');
+      expect(vars['viewerLastVisibleTime']).not.to.equal(0);
     });
   });
 });

--- a/ads/google/a4a/test/test-utils.js
+++ b/ads/google/a4a/test/test-utils.js
@@ -596,55 +596,56 @@ describe('Google A4A utils', () => {
   });
 
   describe('variables for amp-analytics', () => {
-    let element;
+    let a4a;
     let sandbox;
 
     beforeEach(() => {
       sandbox = sinon.sandbox.create();
       return createIframePromise().then(fixture => {
         setupForAdTesting(fixture);
-        element = createElementWithAttributes(fixture.doc, 'amp-a4a', {
+        const element = createElementWithAttributes(fixture.doc, 'amp-a4a', {
           'width': '200',
           'height': '50',
           'type': 'adsense',
           'data-amp-slot-index': '4',
         });
         element.getAmpDoc = () => fixture.doc;
+        a4a = new MockA4AImpl(element);
       });
     });
 
     it('should include the correlator', () => {
-      const vars = getCsiAmpAnalyticsVariables('trigger', element, null);
+      const vars = getCsiAmpAnalyticsVariables('trigger', a4a, null);
       expect(vars['correlator']).not.to.be.undefined;
       expect(vars['correlator']).to.be.greaterThan(0);
     });
 
     it('should include the slot index', () => {
-      const vars = getCsiAmpAnalyticsVariables('trigger', element, null);
+      const vars = getCsiAmpAnalyticsVariables('trigger', a4a, null);
       expect(vars['slotId']).to.equal('4');
     });
 
     it('should include the qqid when provided', () => {
-      const vars = getCsiAmpAnalyticsVariables('trigger', element, '<qqid>');
+      const vars = getCsiAmpAnalyticsVariables('trigger', a4a, '<qqid>');
       expect(vars['qqid']).to.equal('<qqid>');
     });
 
     it('should omit the qqid when null', () => {
-      const vars = getCsiAmpAnalyticsVariables('trigger', element, null);
+      const vars = getCsiAmpAnalyticsVariables('trigger', a4a, null);
       expect(vars['qqid']).to.be.undefined;
     });
 
     it('should include scheduleTime for ad render start triggers', () => {
-      element.layoutScheduleTime = 200;
+      a4a.element.layoutScheduleTime = 200;
       const vars = getCsiAmpAnalyticsVariables(
-          'ad-render-start', element, null);
+          'ad-render-start', a4a, null);
       expect(vars['scheduleTime']).to.be.a('number');
       expect(vars['scheduleTime']).not.to.equal(0);
     });
 
     it('should omit scheduleTime by default', () => {
-      element.layoutScheduleTime = 200;
-      const vars = getCsiAmpAnalyticsVariables('trigger', element, null);
+      a4a.element.layoutScheduleTime = 200;
+      const vars = getCsiAmpAnalyticsVariables('trigger', a4a, null);
       expect(vars['scheduleTime']).to.be.undefined;
     });
 
@@ -653,7 +654,7 @@ describe('Google A4A utils', () => {
       const viewerStub = sandbox.stub(Services, 'viewerForDoc');
       viewerStub.returns({getLastVisibleTime});
 
-      const vars = getCsiAmpAnalyticsVariables('trigger', element, null);
+      const vars = getCsiAmpAnalyticsVariables('trigger', a4a, null);
       expect(vars['viewerLastVisibleTime']).to.be.a('number');
       expect(vars['viewerLastVisibleTime']).not.to.equal(0);
     });

--- a/ads/google/a4a/test/test-utils.js
+++ b/ads/google/a4a/test/test-utils.js
@@ -614,6 +614,10 @@ describe('Google A4A utils', () => {
       });
     });
 
+    afterEach(() => {
+      sandbox.restore();
+    });
+
     it('should include the correlator', () => {
       const vars = getCsiAmpAnalyticsVariables('trigger', a4a, null);
       expect(vars['correlator']).not.to.be.undefined;

--- a/ads/google/a4a/test/test-utils.js
+++ b/ads/google/a4a/test/test-utils.js
@@ -596,55 +596,55 @@ describe('Google A4A utils', () => {
   });
 
   describe('variables for amp-analytics', () => {
-    let a4a;
+    let element;
     let sandbox;
 
     beforeEach(() => {
       sandbox = sinon.sandbox.create();
       return createIframePromise().then(fixture => {
         setupForAdTesting(fixture);
-        const element = createElementWithAttributes(fixture.doc, 'amp-a4a', {
+        element = createElementWithAttributes(fixture.doc, 'amp-a4a', {
           'width': '200',
           'height': '50',
           'type': 'adsense',
           'data-amp-slot-index': '4',
         });
         element.getAmpDoc = () => fixture.doc;
-        a4a = new MockA4AImpl(element);
       });
     });
 
     it('should include the correlator', () => {
-      const vars = getCsiAmpAnalyticsVariables('trigger', a4a, null);
+      const vars = getCsiAmpAnalyticsVariables('trigger', element, null);
       expect(vars['correlator']).not.to.be.undefined;
       expect(vars['correlator']).to.be.greaterThan(0);
     });
 
     it('should include the slot index', () => {
-      const vars = getCsiAmpAnalyticsVariables('trigger', a4a, null);
+      const vars = getCsiAmpAnalyticsVariables('trigger', element, null);
       expect(vars['slotId']).to.equal('4');
     });
 
     it('should include the qqid when provided', () => {
-      const vars = getCsiAmpAnalyticsVariables('trigger', a4a, '<qqid>');
+      const vars = getCsiAmpAnalyticsVariables('trigger', element, '<qqid>');
       expect(vars['qqid']).to.equal('<qqid>');
     });
 
     it('should omit the qqid when null', () => {
-      const vars = getCsiAmpAnalyticsVariables('trigger', a4a, null);
+      const vars = getCsiAmpAnalyticsVariables('trigger', element, null);
       expect(vars['qqid']).to.be.undefined;
     });
 
     it('should include scheduleTime for ad render start triggers', () => {
-      a4a.element.layoutScheduleTime = 200;
-      const vars = getCsiAmpAnalyticsVariables('ad-render-start', a4a, null);
+      element.layoutScheduleTime = 200;
+      const vars = getCsiAmpAnalyticsVariables(
+          'ad-render-start', element, null);
       expect(vars['scheduleTime']).to.be.a('number');
       expect(vars['scheduleTime']).not.to.equal(0);
     });
 
     it('should omit scheduleTime by default', () => {
-      a4a.element.layoutScheduleTime = 200;
-      const vars = getCsiAmpAnalyticsVariables('trigger', a4a, null);
+      element.layoutScheduleTime = 200;
+      const vars = getCsiAmpAnalyticsVariables('trigger', element, null);
       expect(vars['scheduleTime']).to.be.undefined;
     });
 
@@ -653,7 +653,7 @@ describe('Google A4A utils', () => {
       const viewerStub = sandbox.stub(Services, 'viewerForDoc');
       viewerStub.returns({getLastVisibleTime});
 
-      const vars = getCsiAmpAnalyticsVariables('trigger', a4a, null);
+      const vars = getCsiAmpAnalyticsVariables('trigger', element, null);
       expect(vars['viewerLastVisibleTime']).to.be.a('number');
       expect(vars['viewerLastVisibleTime']).not.to.equal(0);
     });

--- a/ads/google/a4a/utils.js
+++ b/ads/google/a4a/utils.js
@@ -29,7 +29,6 @@ import {
   isExperimentOn,
   toggleExperiment,
 } from '../../../src/experiments';
-import {AnalyticsTrigger} from '../../../extensions/amp-a4a/0.1/amp-a4a';
 
 /** @type {string}  */
 const AMP_ANALYTICS_HEADER = 'X-AmpAnalytics';
@@ -93,7 +92,7 @@ export const TRUNCATION_PARAM = {name: 'trunc', value: '1'};
  * Feature detection is used for safety on browsers that do not support the
  * performance API.
  * @param {!Window} win
- * @const {number}
+ * @return {number}
  */
 function getNavStart(win) {
   return win['performance'] && win['performance']['timing'] &&
@@ -458,21 +457,22 @@ export function getCsiAmpAnalyticsConfig() {
     },
     'transport': {'xhrpost': false},
     'triggers': {
-      'adRequestStart': csiTrigger(AnalyticsTrigger.AD_REQUEST_START, {
+      'adRequestStart': csiTrigger('ad-request-start', {
         // afs => ad fetch start
         'met.a4a': 'afs_lvt.${viewerLastVisibleTime}~afs.${time}',
       }),
-      'adResponseEnd': csiTrigger(AnalyticsTrigger.AD_RESPONSE_END, {
+      'adResponseEnd': csiTrigger('ad-response-end', {
         // afe => ad fetch end
         'met.a4a': 'afe.${time}',
       }),
-      'adRenderStart': csiTrigger(AnalyticsTrigger.AD_RENDER_START, {
+      'adRenderStart': csiTrigger('ad-render-start', {
         // ast => ad schedule time
         // ars => ad render start
         'met.a4a':
-            'ast.${scheduleTime}~ars_lvt.${viewerLastVisibleTime}.ars.${time}',
+            'ast.${scheduleTime}~ars_lvt.${viewerLastVisibleTime}~ars.${time}',
+        'qqid': '${qqid}',
       }),
-      'adIframeLoaded': csiTrigger(AnalyticsTrigger.AD_IFRAME_LOADED, {
+      'adIframeLoaded': csiTrigger('ad-iframe-loaded', {
         // ail => ad iframe loaded
         'met.a4a': 'ail.${time}',
       }),
@@ -492,9 +492,8 @@ export function getCsiAmpAnalyticsConfig() {
 
 /**
  * Returns variables to be included in the amp-analytics event for A4A.
- * @param {!AnalyticsTrigger} analyticsTrigger The analytics trigger to get
- *     variables for.
- * @param {!../../../extensions/amp-a4a/0.1/amp-a4a.A4A} a4a The A4A element.
+ * @param {string} analyticsTrigger The name of the analytics trigger.
+ * @param {!AMP.BaseElement} a4a The A4A element.
  * @param {?string} qqid The query ID or null if the query ID has not been set
  *     yet.
  */
@@ -509,7 +508,7 @@ export function getCsiAmpAnalyticsVariables(analyticsTrigger, a4a, qqid) {
   if (qqid) {
     vars['qqid'] = qqid;
   }
-  if (analyticsTrigger == AnalyticsTrigger.AD_RENDER_START) {
+  if (analyticsTrigger == 'ad-render-start') {
     vars['scheduleTime'] = a4a.element.layoutScheduleTime - navStart;
   }
   return vars;

--- a/ads/google/a4a/utils.js
+++ b/ads/google/a4a/utils.js
@@ -425,8 +425,9 @@ export function additionalDimensions(win, viewportSize) {
 };
 
 /**
- * Returns a new CSI trigger.
- * @param {!Object<string, string>} params
+ * Returns amp-analytics config for a new CSI trigger.
+ * @param {string} on The name of the analytics trigger.
+ * @param {!Object<string, string>} params Params to be included on the ping.
  * @return {!JsonObject}
  */
 function csiTrigger(on, params) {

--- a/ads/google/a4a/utils.js
+++ b/ads/google/a4a/utils.js
@@ -29,6 +29,7 @@ import {
   isExperimentOn,
   toggleExperiment,
 } from '../../../src/experiments';
+import {AnalyticsTrigger} from '../../../extensions/amp-a4a/0.1/amp-a4a';
 
 /** @type {string}  */
 const AMP_ANALYTICS_HEADER = 'X-AmpAnalytics';
@@ -85,6 +86,19 @@ export let AmpAnalyticsConfigDef;
  * @visibleForTesting
  */
 export const TRUNCATION_PARAM = {name: 'trunc', value: '1'};
+
+/**
+ * Returns the value of navigation start using the performance API or 0 if not
+ * supported by the browser.
+ * Feature detection is used for safety on browsers that do not support the
+ * performance API.
+ * @param {!Window} win
+ * @const {number}
+ */
+function getNavStart(win) {
+  return win['performance'] && win['performance']['timing'] &&
+      win['performance']['timing']['navigationStart'] || 0;
+}
 
 /**
  * Check whether Google Ads supports the A4A rendering pathway is valid for the
@@ -410,6 +424,96 @@ export function additionalDimensions(win, viewportSize) {
     innerWidth,
     innerHeight].join();
 };
+
+/**
+ * Returns a new CSI trigger.
+ * @param {!Object<string, string>} params
+ * @return {!JsonObject}
+ */
+function csiTrigger(on, params) {
+  return dict({
+    'on': on,
+    'request': 'csi',
+    'sampleSpec': {
+      // Pings are sampled on a per-pageview basis. A prefix is included in the
+      // sampleOn spec so that the hash is orthogonal to any other sampling in
+      // amp.
+      'sampleOn': 'a4a-csi-${pageViewId}',
+      'threshold': 1,  // 1% sample
+    },
+    'selector': 'amp-ad',
+    'selectionMethod': 'closest',
+    'extraUrlParams': params,
+  });
+}
+
+/**
+ * Returns amp-analytics config for Google ads network impls.
+ * @return {!JsonObject}
+ */
+export function getCsiAmpAnalyticsConfig() {
+  return dict({
+    'requests': {
+      'csi': 'https://csi.gstatic.com/csi?',
+    },
+    'transport': {'xhrpost': false},
+    'triggers': {
+      'adRequestStart': csiTrigger(AnalyticsTrigger.AD_REQUEST_START, {
+        // afs => ad fetch start
+        'met.a4a': 'afs_lvt.${viewerLastVisibleTime}~afs.${time}',
+      }),
+      'adResponseEnd': csiTrigger(AnalyticsTrigger.AD_RESPONSE_END, {
+        // afe => ad fetch end
+        'met.a4a': 'afe.${time}',
+      }),
+      'adRenderStart': csiTrigger(AnalyticsTrigger.AD_RENDER_START, {
+        // ast => ad schedule time
+        // ars => ad render start
+        'met.a4a':
+            'ast.${scheduleTime}~ars_lvt.${viewerLastVisibleTime}.ars.${time}',
+      }),
+      'adIframeLoaded': csiTrigger(AnalyticsTrigger.AD_IFRAME_LOADED, {
+        // ail => ad iframe loaded
+        'met.a4a': 'ail.${time}',
+      }),
+    },
+    'extraUrlParams': {
+      's': 'ampad',
+      'ctx': '2',
+      'c': '${correlator}',
+      'slotId': '${slotId}',
+      // Time that the beacon was actually sent. Note that there can be delays
+      // between the time at which the event is fired and when ${nowMs} is
+      // evaluated when the URL is built by amp-analytics.
+      'puid': '${requestCount}~${timestamp}',
+    },
+  });
+}
+
+/**
+ * Returns variables to be included in the amp-analytics event for A4A.
+ * @param {!AnalyticsTrigger} analyticsTrigger The analytics trigger to get
+ *     variables for.
+ * @param {!../../../extensions/amp-a4a/0.1/amp-a4a.A4A} a4a The A4A element.
+ * @param {?string} qqid The query ID or null if the query ID has not been set
+ *     yet.
+ */
+export function getCsiAmpAnalyticsVariables(analyticsTrigger, a4a, qqid) {
+  const viewer = Services.viewerForDoc(a4a.getAmpDoc());
+  const navStart = getNavStart(a4a.win);
+  const vars = {
+    'correlator': getCorrelator(a4a.win),
+    'slotId': a4a.element.getAttribute('data-amp-slot-index'),
+    'viewerLastVisibleTime': viewer.getLastVisibleTime() - navStart,
+  };
+  if (qqid) {
+    vars['qqid'] = qqid;
+  }
+  if (analyticsTrigger == AnalyticsTrigger.AD_RENDER_START) {
+    vars['scheduleTime'] = a4a.element.layoutScheduleTime - navStart;
+  }
+  return vars;
+}
 
 /**
  * Extracts configuration used to build amp-analytics element for active view.

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -380,6 +380,14 @@ export class AmpA4A extends AMP.BaseElement {
      * @private {?JsonObject}
      */
     this.a4aAnalyticsConfig_ = null;
+
+    /**
+     * The amp-analytics element that for this impl's analytics config. It will
+     * be null before buildCallback() executes or if the impl does not provide
+     * an analytice config.
+     * @private {?Element}
+     */
+    this.a4aAnalyticsElement_ = null;
   }
 
   /** @override */
@@ -428,7 +436,7 @@ export class AmpA4A extends AMP.BaseElement {
     if (this.a4aAnalyticsConfig_) {
       // TODO(warrengm): Consider having page-level singletons for networks that
       // use the same config for all ads.
-      insertAnalyticsElement(
+      this.a4aAnalyticsElement_ = insertAnalyticsElement(
           this.element, this.a4aAnalyticsConfig_, true /* loadAnalytics */);
     }
   }

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -31,6 +31,8 @@ import {
   isReportingEnabled,
   extractAmpAnalyticsConfig,
   addCsiSignalsToAmpAnalyticsConfig,
+  getCsiAmpAnalyticsConfig,
+  getCsiAmpAnalyticsVariables,
   QQID_HEADER,
   maybeAppendErrorParameter,
   getEnclosingContainerTypes,
@@ -455,6 +457,16 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
   /** @override */
   getPreconnectUrls() {
     return ['https://googleads.g.doubleclick.net'];
+  }
+
+  /** @override */
+  getA4aAnalyticsVars(analyticsTrigger) {
+    return getCsiAmpAnalyticsVariables(analyticsTrigger, this, this.qqid_);
+  }
+
+  /** @override */
+  getA4aAnalyticsConfig() {
+    return getCsiAmpAnalyticsConfig();
   }
 
   /**

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
@@ -691,7 +691,10 @@ describes.realWin('amp-ad-network-adsense-impl', {
           expect(impl.element.querySelector('div[placeholder]')).to.be.ok;
           expect(impl.element.querySelector('div[fallback]')).to.be.ok;
           expect(impl.element.querySelector('iframe')).to.be.null;
-          expect(impl.element.querySelector('amp-analytics')).to.be.null;
+          expect(impl.element.querySelectorAll('amp-analytics'))
+              .to.have.lengthOf(1);
+          expect(impl.element.querySelector('amp-analytics')).to.equal(
+              impl.a4aAnalyticsElement_);
           expect(impl.iframe).to.be.null;
           expect(impl.ampAnalyticsConfig_).to.be.null;
           expect(impl.ampAnalyticsElement_).to.be.null;

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -46,6 +46,8 @@ import {
   isReportingEnabled,
   AmpAnalyticsConfigDef,
   extractAmpAnalyticsConfig,
+  getCsiAmpAnalyticsConfig,
+  getCsiAmpAnalyticsVariables,
   groupAmpAdsByType,
   addCsiSignalsToAmpAnalyticsConfig,
   QQID_HEADER,
@@ -1314,8 +1316,17 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
       this.win.opener./*OK*/postMessage(payload, '*');
     });
   }
-}
 
+  /** @override */
+  getA4aAnalyticsVars(analyticsTrigger) {
+    return getCsiAmpAnalyticsVariables(analyticsTrigger, this, this.qqid_);
+  }
+
+  /** @override */
+  getA4aAnalyticsConfig() {
+    return getCsiAmpAnalyticsConfig();
+  }
+}
 
 AMP.extension(TAG, '0.1', AMP => {
   AMP.registerElement(TAG, AmpAdNetworkDoubleclickImpl);

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -727,6 +727,8 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
           expect(impl.element.querySelector('div[placeholder]')).to.be.ok;
           expect(impl.element.querySelector('div[fallback]')).to.be.ok;
           expect(impl.element.querySelector('iframe')).to.be.null;
+          expect(impl.element.querySelectorAll('amp-analytics'))
+              .to.have.lengthOf(1);
           expect(impl.element.querySelector('amp-analytics')).to.equal(
               impl.a4aAnalyticsElement_);
           expect(impl.iframe).to.be.null;

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -727,7 +727,8 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
           expect(impl.element.querySelector('div[placeholder]')).to.be.ok;
           expect(impl.element.querySelector('div[fallback]')).to.be.ok;
           expect(impl.element.querySelector('iframe')).to.be.null;
-          expect(impl.element.querySelector('amp-analytics')).to.be.null;
+          expect(impl.element.querySelector('amp-analytics')).to.equal(
+              impl.a4aAnalyticsElement_);
           expect(impl.iframe).to.be.null;
           expect(impl.ampAnalyticsConfig_).to.be.null;
           expect(impl.ampAnalyticsElement_).to.be.null;


### PR DESCRIPTION
This updates the Doubleclick and AdSense A4A impls to collect the triggers that were implemented in https://github.com/ampproject/amphtml/pull/11946.