### PR TITLE
fix typos in amp-form extension error messages

### DIFF
--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -547,7 +547,7 @@ export class AmpForm {
   handleNonXhrPost_() {
     // non-XHR POST requests are not supported.
     user().assert(false,
-        'Only XHR based (via action-xhr attribute) submissions are support ' +
+        'Only XHR based (via action-xhr attribute) submissions are supported ' +
         'for POST requests. %s',
         this.form_);
   }

--- a/extensions/amp-form/0.1/test/test-amp-form.js
+++ b/extensions/amp-form/0.1/test/test-amp-form.js
@@ -228,7 +228,7 @@ describes.repeated('', {
       sandbox.stub(ampForm, 'analyticsEvent_');
       sandbox.spy(form, 'checkValidity');
       const errorRe =
-          /Only XHR based \(via action-xhr attribute\) submissions are support/;
+          /Only XHR based \(via action-xhr attribute\) submissions are supported/;
       expect(() => ampForm.handleSubmitEvent_(event)).to.throw(errorRe);
       expect(event.preventDefault).to.be.called;
       expect(ampForm.analyticsEvent_).to.have.not.been.called;
@@ -288,7 +288,7 @@ describes.repeated('', {
       sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
       sandbox.spy(form, 'checkValidity');
       const submitErrorRe =
-          /Only XHR based \(via action-xhr attribute\) submissions are support/;
+          /Only XHR based \(via action-xhr attribute\) submissions are supported/;
       expect(() => ampForm.handleSubmitEvent_(event)).to.throw(submitErrorRe);
       expect(event.preventDefault).to.be.called;
       document.body.removeChild(form);

--- a/extensions/amp-form/0.1/test/test-amp-form.js
+++ b/extensions/amp-form/0.1/test/test-amp-form.js
@@ -228,7 +228,7 @@ describes.repeated('', {
       sandbox.stub(ampForm, 'analyticsEvent_');
       sandbox.spy(form, 'checkValidity');
       const errorRe =
-          /Only XHR based \(via action-xhr attribute\) submissions are supported/;
+        /Only XHR based \(via action-xhr attribute\) submissions are supported/;
       expect(() => ampForm.handleSubmitEvent_(event)).to.throw(errorRe);
       expect(event.preventDefault).to.be.called;
       expect(ampForm.analyticsEvent_).to.have.not.been.called;
@@ -288,7 +288,7 @@ describes.repeated('', {
       sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
       sandbox.spy(form, 'checkValidity');
       const submitErrorRe =
-          /Only XHR based \(via action-xhr attribute\) submissions are supported/;
+        /Only XHR based \(via action-xhr attribute\) submissions are supported/;
       expect(() => ampForm.handleSubmitEvent_(event)).to.throw(submitErrorRe);
       expect(event.preventDefault).to.be.called;
       document.body.removeChild(form);


### PR DESCRIPTION
# fix typos in amp-form extension error messages

I noticed there was a typo in the error messages.  This is my first pull request, please let me know if I've missed anything. 