### PR TITLE
Don't allow postmessages to send if postMessage is undefined

### DIFF
--- a/ads/inabox/inabox-messaging-host.js
+++ b/ads/inabox/inabox-messaging-host.js
@@ -154,10 +154,14 @@ export class InaboxMessagingHost {
    * @param {JsonObject} data
    */
   sendPosition_(request, source, origin, data) {
-    dev().fine(TAG, `Sent position data to [${request.sentinel}]`, data);
-    source./*OK*/postMessage(
-        serializeMessage(MessageType.POSITION, request.sentinel, data),
-        origin);
+    if (source./*OK*/postMessage) {
+      dev().fine(TAG, `Sent position data to [${request.sentinel}]`, data);
+      source./*OK*/postMessage(
+          serializeMessage(MessageType.POSITION, request.sentinel, data),
+          origin);
+    } else {
+      dev().warn(TAG, 'postMessage is undefined');
+    }
   }
 
   /**
@@ -172,15 +176,19 @@ export class InaboxMessagingHost {
   // 2. Disable zoom and scroll on parent doc
   handleEnterFullOverlay_(iframe, request, source, origin) {
     this.frameOverlayManager_.expandFrame(iframe, boxRect => {
-      source./*OK*/postMessage(
-          serializeMessage(
-              MessageType.FULL_OVERLAY_FRAME_RESPONSE,
-              request.sentinel,
-              dict({
-                'success': true,
-                'boxRect': boxRect,
-              })),
-          origin);
+      if (source./*OK*/postMessage) {
+        source./*OK*/postMessage(
+            serializeMessage(
+                MessageType.FULL_OVERLAY_FRAME_RESPONSE,
+                request.sentinel,
+                dict({
+                  'success': true,
+                  'boxRect': boxRect,
+                })),
+            origin);
+      } else {
+        dev().warn(TAG, 'postMessage is undefined');
+      }
     });
 
     return true;
@@ -195,15 +203,19 @@ export class InaboxMessagingHost {
    */
   handleCancelFullOverlay_(iframe, request, source, origin) {
     this.frameOverlayManager_.collapseFrame(iframe, boxRect => {
-      source./*OK*/postMessage(
-          serializeMessage(
-              MessageType.CANCEL_FULL_OVERLAY_FRAME_RESPONSE,
-              request.sentinel,
-              dict({
-                'success': true,
-                'boxRect': boxRect,
-              })),
-          origin);
+      if (source./*OK*/postMessage) {
+        source./*OK*/postMessage(
+            serializeMessage(
+                MessageType.CANCEL_FULL_OVERLAY_FRAME_RESPONSE,
+                request.sentinel,
+                dict({
+                  'success': true,
+                  'boxRect': boxRect,
+                })),
+            origin);
+      } else {
+        dev().warn(TAG, 'postMessage is undefined');
+      }
     });
 
     return true;

--- a/test/functional/inabox/test-inabox-messaging-host.js
+++ b/test/functional/inabox/test-inabox-messaging-host.js
@@ -127,6 +127,18 @@ describes.realWin('inabox-host:messaging', {}, env => {
       });
       expect(targetOrigin).to.equal('www.example.com');
     });
+
+    it('should not throw error if postMessage undefined', () => {
+      iframe1.contentWindow.postMessage = undefined;
+      host.processMessage({
+        source: iframe1.contentWindow,
+        origin: 'www.example.com',
+        data: 'amp-' + JSON.stringify({
+          sentinel: '0-123',
+          type: 'send-positions',
+        }),
+      });
+    });
   });
 
   describe('send-positions position observer callback', () => {
@@ -254,6 +266,30 @@ describes.realWin('inabox-host:messaging', {}, env => {
       expect(message.type).to.equal('cancel-full-overlay-frame-response');
       expect(message.success).to.be.true;
       expect(message.boxRect).to.deep.equal(boxRect);
+    });
+
+    it('should not error if postMessage undefined', () => {
+      iframe1.contentWindow.postMessage = undefined;
+      host.processMessage({
+        source: iframe1.contentWindow,
+        origin: 'www.example.com',
+        data: 'amp-' + JSON.stringify({
+          sentinel: '0-123',
+          type: 'full-overlay-frame',
+        }),
+      });
+    });
+
+    it('should not error if postMessage undefined, cancel msg', () => {
+      iframe1.contentWindow.postMessage = undefined;
+      host.processMessage({
+        source: iframe1.contentWindow,
+        origin: 'www.example.com',
+        data: 'amp-' + JSON.stringify({
+          sentinel: '0-123',
+          type: 'cancel-full-overlay-frame',
+        }),
+      });
     });
 
   });


### PR DESCRIPTION
There's no protection verifying that postMessage is actually defined on the source before sending. This fixes that. 