### PR TITLE
Style unresolved elements

### DIFF
--- a/css/amp.css
+++ b/css/amp.css
@@ -144,31 +144,47 @@ html.i-amphtml-ios-embed.i-amphtml-ios-overscroll > #i-amphtml-wrapper {
   display: inline-block;
 }
 
-.i-amphtml-layout-nodisplay {
+.i-amphtml-layout-nodisplay,
+[layout=nodisplay]:not(.i-amphtml-layout-nodisplay)
+{
   /* Display is set/reset in JS */
 }
 
-.i-amphtml-layout-fixed {
+.i-amphtml-layout-fixed,
+/*, [width][height]:not([layout=fixed]) */
+[layout=fixed][width][height]:not(.i-amphtml-layout-fixed)
+{
   display: inline-block;
   position: relative;
 }
 
-.i-amphtml-layout-responsive {
+.i-amphtml-layout-responsive,
+[layout=responsive][width][height]:not(.i-amphtml-layout-responsive),
+[width][height][sizes]:not(.i-amphtml-layout-responsive)
+{
   display: block;
   position: relative;
 }
 
-.i-amphtml-layout-fixed-height {
+.i-amphtml-layout-fixed-height,
+[layout=fixed-height][height],
+/* [height]:not([width]), */
+/* [height][width=auto], */
+{
   display: block;
   position: relative;
 }
 
-.i-amphtml-layout-container {
+.i-amphtml-layout-container,
+[layout=container]
+{
   display: block;
   position: relative;
 }
 
-.i-amphtml-layout-fill {
+.i-amphtml-layout-fill,
+[layout=fill]:not(.i-amphtml-layout-fill)
+{
   display: block;
   overflow: hidden !important;
   position: absolute;
@@ -178,7 +194,9 @@ html.i-amphtml-ios-embed.i-amphtml-ios-overscroll > #i-amphtml-wrapper {
   right: 0;
 }
 
-.i-amphtml-layout-flex-item {
+.i-amphtml-layout-flex-item,
+[layout=flex-item]:not(.i-amphtml-layout-flex-item)
+{
   display: block;
   position: relative;
   flex: 1 1 auto;

--- a/css/amp.css
+++ b/css/amp.css
@@ -335,7 +335,8 @@ i-amphtml-sizer {
   display: none !important;
 }
 
-.i-amphtml-element > [placeholder] {
+.i-amphtml-element > [placeholder],
+[layout]:not(.i-amphtml-element) > [placeholder] {
   display: block;
 }
 

--- a/css/amp.css
+++ b/css/amp.css
@@ -151,7 +151,6 @@ html.i-amphtml-ios-embed.i-amphtml-ios-overscroll > #i-amphtml-wrapper {
 }
 
 .i-amphtml-layout-fixed,
-/*, [width][height]:not([layout=fixed]) */
 [layout=fixed][width][height]:not(.i-amphtml-layout-fixed)
 {
   display: inline-block;
@@ -167,9 +166,7 @@ html.i-amphtml-ios-embed.i-amphtml-ios-overscroll > #i-amphtml-wrapper {
 }
 
 .i-amphtml-layout-fixed-height,
-[layout=fixed-height][height],
-/* [height]:not([width]), */
-/* [height][width=auto], */
+[layout=fixed-height][height]
 {
   display: block;
   position: relative;

--- a/css/amp.css
+++ b/css/amp.css
@@ -300,8 +300,7 @@ i-amphtml-sizer {
 }
 
 .i-amphtml-notbuilt,
-[layout]:not(.i-amphtml-element),
-.-amp-element:not(.i-amphtml-element)
+[layout]:not(.i-amphtml-element)
 {
   position: relative;
   overflow: hidden !important;
@@ -309,8 +308,7 @@ i-amphtml-sizer {
 }
 
 .i-amphtml-notbuilt:not(.i-amphtml-layout-container) > * ,
-[layout]:not(.i-amphtml-element):not(.i-amphtml-layout-container) > *,
-.-amp-element:not(.i-amphtml-element):not(.i-amphtml-layout-container) > *
+[layout]:not([layout=container]):not(.i-amphtml-element) > *
 {
   display: none;
 }

--- a/css/amp.css
+++ b/css/amp.css
@@ -284,13 +284,19 @@ i-amphtml-sizer {
   /* For author styling. */
 }
 
-.i-amphtml-notbuilt {
+.i-amphtml-notbuilt,
+[layout]:not(.i-amphtml-element),
+.-amp-element:not(.i-amphtml-element)
+{
   position: relative;
   overflow: hidden !important;
   color: transparent !important;
 }
 
-.i-amphtml-notbuilt:not(.i-amphtml-layout-container) > * {
+.i-amphtml-notbuilt:not(.i-amphtml-layout-container) > * ,
+[layout]:not(.i-amphtml-element):not(.i-amphtml-layout-container) > *,
+.-amp-element:not(.i-amphtml-element):not(.i-amphtml-layout-container) > *
+{
   display: none;
 }
 


### PR DESCRIPTION
This applies initial layouts to still unresolved AMP elements.

The changes to `layout=nodisplay`, `layout=responsive`, `layout=fixed-height`, `layout=container`, `layout=fill`, and `layout=flex-item` just apply while the element is unresolved (doesn't have a `.i-amphtml-layout-X` class). Once it is resolved, the class will be added and selector will fail to apply, so everything keeps the same specificity as before.

The other changes to unresolved elements with any layout (`[layout]:not(.i-amphtml-element)`) prevent the children of unresolved elements from being displayed, since the parent needs to resolve before we can figure out the measurements for the children. This fixes https://github.com/ampproject/amphtml/issues/11929.

/cc @brandondiamond