### PR TITLE
Ignore Vim swap files (*.swp, *.swo)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ build-system/runner/TESTS-TestSuites.xml
 /test/manual/amp-ad.adtech.html
 test/coverage
 package-lock.json
+*.swp
+*.swo


### PR DESCRIPTION
*.swp and *.swo files are temporary files generated when editing
buffers in Vim and should never be committed.

https://stackoverflow.com/questions/4824188/git-ignore-vim-temporary-files