### PR TITLE
Fix type checker errors

### DIFF
--- a/src/form-data-wrapper.js
+++ b/src/form-data-wrapper.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {dev} from './log';
 import {getFormAsObject} from './form';
 import {map} from './utils/object';
 
@@ -47,13 +48,13 @@ export class FormDataWrapper {
    *     input content.
    */
   constructor(opt_form = undefined) {
-    /** @private @const {FormData} */
+    /** @private @const {!FormData} */
     this.formData_ = new FormData(opt_form);
 
-    /** @private @const {!Object|undefined} */
+    /** @private @const {?Object<string, !Array<string>>} */
     this.fieldValues_ =
-        this.formData_.entries ?
-            undefined :
+        this.formData_['entries'] ?
+            null :
             (opt_form ? getFormAsObject(opt_form) : map());
   }
 
@@ -76,7 +77,7 @@ export class FormDataWrapper {
    * @param {string} value The field's value.
    */
   append(name, value) {
-    if (!this.formData_.entries) {
+    if (!this.formData_['entries']) {
       const nameString = String(name);
       this.fieldValues_[nameString] = this.fieldValues_[nameString] || [];
       this.fieldValues_[name].push(String(value));
@@ -93,13 +94,15 @@ export class FormDataWrapper {
    * @return {!Iterator<!Array<string>>}
    */
   entries() {
-    if (this.formData_.entries) {
-      return this.formData_.entries();
+    if (this.formData_['entries']) {
+      return this.formData_['entries']();
     }
 
     const fieldEntries = [];
-    Object.keys(this.fieldValues_).forEach(name => {
-      const values = this.fieldValues_[name];
+    const fieldValues = /** @type {!Object<string, !Array<string>>} */ (
+        dev().assert(this.fieldValues_));
+    Object.keys(fieldValues).forEach(name => {
+      const values = fieldValues[name];
       values.forEach(value => fieldEntries.push([name, value]));
     });
 
@@ -118,7 +121,7 @@ export class FormDataWrapper {
   /**
    * Returns the wrapped native `FormData` object.
    *
-   * @return {FormData}
+   * @return {!FormData}
    */
   getFormData() {
     return this.formData_;


### PR DESCRIPTION
This fix the following errors thrown by the type checker when the
FormDataWrapper class starts to be used:

src/form-data-wrapper.js:79: ERROR - Property entries never defined on FormData
    if (!this.formData_.entries) {
                        ^^^^^^^

src/form-data-wrapper.js:101: ERROR - actual parameter 1 of Object.keys does not match formal parameter
found   : (Object|undefined)
required: Object
    Object.keys(this.fieldValues_).forEach(name => {
                ^^^^^^^^^^^^^^^^^

As well as fixing the nullability of the return value of `getFormData`.
It should really be non-nullable so that callers don't need to check
for null.

@choumx @jridgewell I have some pending PR for #11294 that depend on this.