### PR TITLE
 Use FormDataWrapper instead of native FormData

### DIFF
--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -580,6 +580,13 @@ const forbiddenTerms = {
       'src/event-helper.js',
     ],
   },
+  'new FormData\\(': {
+    message: 'Use new FormDataWrapper() instead and call ' +
+        'formDataWrapper.getFormData() to get the native FormData object.',
+    whitelist: [
+      'src/form-data-wrapper.js',
+    ],
+  },
   '([eE]xit|[eE]nter|[cC]ancel|[rR]equest)Full[Ss]creen\\(': {
     message: 'Use fullscreenEnter() and fullscreenExit() from dom.js instead.',
     whitelist: [

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -28,6 +28,7 @@ import {
   setFormForElement,
   getFormAsObject,
 } from '../../../src/form';
+import {FormDataWrapper} from '../../../src/form-data-wrapper';
 import {
   assertAbsoluteHttpOrHttpsUrl,
   assertHttpsUrl,
@@ -487,7 +488,7 @@ export class AmpForm {
       xhrUrl = addParamsToUrl(url, values);
     } else {
       xhrUrl = url;
-      body = new FormData(this.form_);
+      body = new FormDataWrapper(this.form_);
       for (const key in opt_extraFields) {
         body.append(key, opt_extraFields[key]);
       }

--- a/extensions/amp-form/0.1/test/test-amp-form.js
+++ b/extensions/amp-form/0.1/test/test-amp-form.js
@@ -36,6 +36,8 @@ import '../../../amp-selector/0.1/amp-selector';
 import {user} from '../../../../src/log';
 import {whenCalled} from '../../../../testing/test-helper.js';
 import {AmpEvents} from '../../../../src/amp-events';
+import {FormDataWrapper} from '../../../../src/form-data-wrapper';
+import {fromIterator} from '../../../../src/utils/array';
 
 describes.repeated('', {
   'single ampdoc': {ampdoc: 'single'},
@@ -678,7 +680,11 @@ describes.repeated('', {
 
           const xhrCall = ampForm.xhr_.fetch.getCall(0);
           const config = xhrCall.args[1];
-          expect(config.body).to.not.be.null;
+          expect(config.body).to.be.an.instanceof(FormDataWrapper);
+          const entriesInForm =
+              fromIterator(new FormDataWrapper(getForm()).entries());
+          expect(fromIterator(config.body.entries())).to.have.deep.members(
+              entriesInForm);
           expect(config.method).to.equal('POST');
           expect(config.credentials).to.equal('include');
         });

--- a/src/types.js
+++ b/src/types.js
@@ -73,15 +73,6 @@ export function isFiniteNumber(value) {
 }
 
 /**
- * Determines if value is of FormData type.
- * @param {*} value
- * @return {boolean}
- */
-export function isFormData(value) {
-  return toString(value) === '[object FormData]';
-}
-
-/**
  * Checks whether `s` is a valid value of `enumObj`.
  *
  * @param {!Object<T>} enumObj

--- a/test/functional/test-xhr.js
+++ b/test/functional/test-xhr.js
@@ -22,6 +22,7 @@ import {
   FetchResponse,
   assertSuccess,
 } from '../../src/service/xhr-impl';
+import {FormDataWrapper} from '../../src/form-data-wrapper';
 import {getCookie} from '../../src/cookies';
 import {Services} from '../../src/services';
 
@@ -130,7 +131,7 @@ describe.configure().skipSafari().run('XHR', function() {
         });
 
         it('should allow FormData as body', () => {
-          const formData = new FormData();
+          const formData = new FormDataWrapper();
           sandbox.stub(JSON, 'stringify');
           formData.append('name', 'John Miller');
           formData.append('age', 56);


### PR DESCRIPTION
Formdata#entries is not supported by IE, Edge and Safari, but is useful
for accessing content of the a FormData object. On IE, Edge and
Safari, the only available method on FormData is append, which means
that client code can't read from a FormData. Reading entries in a
FormData will be required by #11294 to serialize a FormData object
into a plain old JavaScript object so that it can be passed to
postMessage() (i.e., can be cloned using the structured clone
algorithm).

Since polyfilling FormData#entries requires patching both the constructor
and the append method and can be ugly to implement, a new unified API
FormDataWrapper is added to provide a consistent way to deal with
FormData. Callers will be banned from calling new FormData(), and
will have to use new FormDataWrapper(). When a native FormData is
needed to be passed to the native fetch or XMLHttpRequest API, callers
would need to call formDataWrapper.getFormData().

@choumx @jridgewell