### PR TITLE
Add validator test for XHR interceptor

### DIFF
--- a/validator/testdata/feature_tests/root_element_attributes.html
+++ b/validator/testdata/feature_tests/root_element_attributes.html
@@ -1,0 +1,28 @@
+<!--
+  Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS-IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the license.
+-->
+<!--
+  Test Description:
+  This demonstrates that certain attributes are not allowed on the root <html> element.
+-->
+<!doctype html>
+<html ⚡ allow-xhr-interception>
+<head>
+  <meta charset="utf-8">
+  <link rel="canonical" href="./regular-html-version.html">
+  <meta name="viewport" content="width=device-width,minimum-scale=1">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+</body>
+</html>

--- a/validator/testdata/feature_tests/root_element_attributes.out
+++ b/validator/testdata/feature_tests/root_element_attributes.out
@@ -1,0 +1,3 @@
+FAIL
+feature_tests/root_element_attributes.html:18:0 The attribute 'allow-xhr-interception' may not appear in tag 'html ⚡ for top-level html'. (see https://www.ampproject.org/docs/reference/spec#required-markup) [DISALLOWED_HTML]
+feature_tests/root_element_attributes.html:28:7 The mandatory tag 'html ⚡ for top-level html' is missing or incorrect. (see https://www.ampproject.org/docs/reference/spec#required-markup) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]


### PR DESCRIPTION
This is for #11294.

The XHR interceptor checks whether the root element <html> has an
attribute called `allow-xhr-interception`. This attribute must be not
allowed by the validator so that only the viewer who also has control
of the document can add it, after validation.

@choumx @jridgewell 