### PR TITLE
Add ati param for remote.html usage

### DIFF
--- a/ads/google/doubleclick.js
+++ b/ads/google/doubleclick.js
@@ -43,6 +43,7 @@ export function doubleclick(global, data) {
     'overrideWidth', 'overrideHeight', 'loadingStrategy',
     'consentNotificationId', 'useSameDomainRenderingUntilDeprecated',
     'experimentId', 'multiSize', 'multiSizeValidation', 'ampSlotIndex',
+    'ati',
   ]);
 
   if (global.context.clientId) {

--- a/examples/doubleclick-remote-html.html
+++ b/examples/doubleclick-remote-html.html
@@ -1,0 +1,70 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>Doubleclick Example using custom remote.html on page</title>
+  <link rel="canonical" href="http://nonblocking.io/" >
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <style amp-custom>
+    .broken {
+      color: red;
+    }
+    amp-ad {
+      border: 1px solid #ccc;
+      max-width: 500px;
+    }
+    .red {
+      background-color: red;
+    }
+    .filterBar {
+      background: #eee;
+      padding: 3px;
+      font-size: 1.2em;
+    }
+    select {
+      border: 1px solid #999;
+    }
+    input[type=submit] {
+      font-size: 14px;
+      border: 1px solid #999;
+      border-radius: 3px;
+      margin-left: 10px;
+    }
+    amp-ad[type="revcontent"] {
+      width: 100%;
+      max-width: 1280px;
+      margin: 18px 0;
+      padding: 0;
+    }
+    amp-ad[type="nativo"] {
+      width: 100%;
+      max-width: 1280px;
+      margin: 18px 0;
+      padding: 0;
+      height:100px;
+    }
+  </style>
+  <script async custom-element="amp-ad" src="https://cdn.ampproject.org/v0/amp-ad-0.1.js"></script>
+  <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
+  <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.1.js"></script>
+  <script async custom-element="amp-form" src="https://cdn.ampproject.org/v0/amp-form-0.1.js"></script>
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <meta name="amp-3p-iframe-src" content="http://ads.localhost:8000/dist.3p/current/frame.max.html">
+</head>
+<body>
+
+  <h2>Doubleclick example, should use Glade.js</h2>
+  <amp-ad width="320" height="50"
+      type="doubleclick"
+      data-slot="/4119129/mobile_ad_banner">
+  </amp-ad>
+
+  <h2>Doubleclick example, should use GPT.js</h2>
+  <amp-ad width="320" height="50"
+      type="doubleclick"
+          data-slot="/4119129/mobile_ad_banner"
+          json='{"useSameDomainRenderingUntilDeprecated":1}'>
+  </amp-ad>
+</body>
+</html>

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
@@ -159,7 +159,7 @@ export class DoubleclickA4aEligibility {
     if (useRemoteHtml) {
       warnDeprecation('remote.html');
       if (!element.getAttribute('rtc-config')) {
-        element.setAttribute('ati', '1');
+        element.setAttribute('data-ati', '1');
         return false;
       }
     }

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
@@ -158,8 +158,12 @@ export class DoubleclickA4aEligibility {
     }
     if (useRemoteHtml) {
       warnDeprecation('remote.html');
+      if (!element.getAttribute('rtc-config')) {
+        element.setAttribute('ati', '1');
+        return false;
+      }
     }
-    if (hasUSDRD || (useRemoteHtml && !element.getAttribute('rtc-config'))) {
+    if (hasUSDRD) {
       return false;
     }
     let experimentId;

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-a4a-config.js
@@ -80,6 +80,7 @@ describe('doubleclick-a4a-config', () => {
       expect(
           doubleclickIsA4AEnabled(mockWin, elem, useRemoteHtml)).to.be.false;
       expect(elem.getAttribute(EXPERIMENT_ATTRIBUTE)).to.not.be.ok;
+      expect(elem.getAttribute('data-ati')).to.equal('1');
     });
 
     it('should use Fast Fetch if useRemoteHtml is true and RTC is set', () => {


### PR DESCRIPTION
When remote.html is being used on a doubleclick request, send a param on the request to indicate its usage. 