### PR TITLE
Enable experiments before Percy build

### DIFF
--- a/build-system/tasks/prepend-global/index.js
+++ b/build-system/tasks/prepend-global/index.js
@@ -157,7 +157,9 @@ function removeConfig(target) {
       .then(file => {
         let contents = file.toString();
         if (numConfigs(contents) == 0) {
-          util.log('No configs found in', util.colors.cyan(target));
+          if (!process.env.TRAVIS) {
+            util.log('No configs found in', util.colors.cyan(target));
+          }
           return Promise.resolve();
         }
         sanityCheck(contents);

--- a/build-system/tasks/visual-diff.rb
+++ b/build-system/tasks/visual-diff.rb
@@ -284,10 +284,16 @@ def generate_snapshots(page, webpages)
       forbidden_css = webpage['forbidden_css']
       loading_incomplete_css = webpage['loading_incomplete_css']
       loading_complete_css = webpage['loading_complete_css']
+      enable_experiments(page, webpage['experiments'])
       page.visit(url)
-      verify_css_elements(page, url,
-                          forbidden_css, loading_incomplete_css, loading_complete_css)
+      verify_css_elements(
+          page,
+          url,
+          forbidden_css,
+          loading_incomplete_css,
+          loading_complete_css)
       Percy::Capybara.snapshot(page, name: name)
+      clear_experiments(page)
     end
   end
 end
@@ -333,6 +339,30 @@ def verify_css_elements(
       end
     end
   end
+end
+
+
+# Enables the given AMP experiments.
+#
+# Args:
+# - page: Page object used by Percy for snapshotting.
+# - experiments: List of experiments to enable.
+def enable_experiments(page, experiments)
+  if experiments
+    page.driver.set_cookie(
+        'AMP_EXP',
+        experiments.join('%2C'),
+        { :path => '/', :domain => 'localhost' })
+  end
+end
+
+
+# Clears all AMP experiment cookies.
+#
+# Args:
+# - page: Page object used by Percy for snapshotting.
+def clear_experiments(page)
+  page.driver.clear_cookies
 end
 
 

--- a/build-system/tasks/visual-diff.rb
+++ b/build-system/tasks/visual-diff.rb
@@ -353,6 +353,7 @@ def enable_experiments(page, experiments)
         'AMP_EXP',
         experiments.join('%2C'),
         { :path => '/', :domain => 'localhost' })
+    log('verbose', 'Setting AMP experiments ' + cyan(experiments.join(', ')))
   end
 end
 
@@ -363,6 +364,7 @@ end
 # - page: Page object used by Percy for snapshotting.
 def clear_experiments(page)
   page.driver.clear_cookies
+  log('verbose', 'Cleared all AMP experiment cookies')
 end
 
 

--- a/test/visual-diff/visual-tests.json
+++ b/test/visual-diff/visual-tests.json
@@ -63,6 +63,12 @@
    *   "loading_complete_css": [
    *     ".loading-complete-css-class",
    *     ".another-loading-complete-css-class"
+   *   ],
+   *
+   *   // Experiments that must be enabled via cookies.
+   *   "experiments": [
+   *     "amp-feature-one",
+   *     "amp-feature-two"
    *   ]
    * },
    */


### PR DESCRIPTION
This PR allows the selective enabling of AMP experiments before snapshotting a page. It also fixes a bug where we weren't cleaning up the cookies that might be set by a given test page.

Fixes #11804, #11854