### PR TITLE
Disable navigation hint when bookend is open

### DIFF
--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -330,6 +330,9 @@ export class AmpStory extends AMP.BaseElement {
 
     const gestures = Gestures.get(this.element);
     gestures.onGesture(SwipeXYRecognizer, () => {
+      if (this.bookend_.isActive()) {
+        return;
+      }
       this.ampStoryHint_.showNavigationOverlay();
     });
 


### PR DESCRIPTION
The bookend has x/y scrolling, so it doesn't make sense to display the navigation hint in this case.