### PR TITLE
Don't prevent swipe gestures from triggering events

### DIFF
--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -328,7 +328,9 @@ export class AmpStory extends AMP.BaseElement {
       }
     }, true);
 
-    const gestures = Gestures.get(this.element);
+    const gestures = Gestures.get(this.element,
+        /* shouldNotPreventDefault */ true);
+
     gestures.onGesture(SwipeXYRecognizer, () => {
       this.ampStoryHint_.showNavigationOverlay();
     });


### PR DESCRIPTION
Context: Some elements (i.e. bookend) should be scrollable by swipe.