### PR TITLE
Revert changes from PR

### DIFF
--- a/ads/google/doubleclick.js
+++ b/ads/google/doubleclick.js
@@ -43,7 +43,6 @@ export function doubleclick(global, data) {
     'overrideWidth', 'overrideHeight', 'loadingStrategy',
     'consentNotificationId', 'useSameDomainRenderingUntilDeprecated',
     'experimentId', 'multiSize', 'multiSizeValidation', 'ampSlotIndex',
-    'ati',
   ]);
 
   if (global.context.clientId) {

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
@@ -138,12 +138,8 @@ export class DoubleclickA4aEligibility {
     }
     if (useRemoteHtml) {
       warnDeprecation('remote.html');
-      if (!element.getAttribute('rtc-config')) {
-        element.setAttribute('data-ati', '1');
-        return false;
-      }
     }
-    if (hasUSDRD) {
+    if (hasUSDRD || (useRemoteHtml && !element.getAttribute('rtc-config'))) {
       return false;
     }
     let experimentId;

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-a4a-config.js
@@ -80,7 +80,6 @@ describe('doubleclick-a4a-config', () => {
       expect(
           doubleclickIsA4AEnabled(mockWin, elem, useRemoteHtml)).to.be.false;
       expect(elem.getAttribute(EXPERIMENT_ATTRIBUTE)).to.not.be.ok;
-      expect(elem.getAttribute('data-ati')).to.equal('1');
     });
 
     it('should use Fast Fetch if useRemoteHtml is true and RTC is set', () => {


### PR DESCRIPTION
revert main changes in: https://github.com/ampproject/amphtml/pull/12090
Leaving the new example

gpt.js and glade.js add the ati parameter already, that PR actually didn't do anything