### PR TITLE
Update async image decoding attribute to updated standard.

### DIFF
--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -129,7 +129,7 @@ export class AmpImg extends BaseElement {
       this.img_ = scopedQuerySelector(this.element, 'img');
     }
     this.img_ = this.img_ || new Image();
-    this.img_.setAttribute('async', '');
+    this.img_.setAttribute('decoding', 'async');
     if (this.element.id) {
       this.img_.setAttribute('amp-img-id', this.element.id);
     }

--- a/extensions/amp-anim/0.1/amp-anim.js
+++ b/extensions/amp-anim/0.1/amp-anim.js
@@ -46,7 +46,7 @@ export class AmpAnim extends AMP.BaseElement {
   /** @override */
   buildCallback() {
     this.img_ = new Image();
-    this.img_.setAttribute('async', '');
+    this.img_.setAttribute('decoding', 'async');
     this.propagateAttributes(['alt', 'aria-label',
       'aria-describedby', 'aria-labelledby'], this.img_);
     this.applyFillContent(this.img_, true);

--- a/extensions/amp-anim/0.1/test/test-amp-anim.js
+++ b/extensions/amp-anim/0.1/test/test-amp-anim.js
@@ -39,6 +39,6 @@ describes.realWin('amp-anim', {
     expect(img.getAttribute('aria-label')).to.equal('Hello');
     expect(img.getAttribute('aria-labelledby')).to.equal('id2');
     expect(img.getAttribute('aria-describedby')).to.equal('id3');
-    expect(img.hasAttribute('async')).to.be.true;
+    expect(img.getAttribute('decoding')).to.equal('async');
   });
 });

--- a/test/functional/test-amp-img.js
+++ b/test/functional/test-amp-img.js
@@ -79,7 +79,7 @@ describe('amp-img', () => {
       expect(img.getAttribute('alt')).to.equal('An image');
       expect(img.getAttribute('title')).to.equal('Image title');
       expect(img.getAttribute('referrerpolicy')).to.equal('origin');
-      expect(img.hasAttribute('async')).to.be.true;
+      expect(img.getAttribute('decoding')).to.equal('async');
     });
   });
 


### PR DESCRIPTION
The new format is `<img decoding=async>`.

Fixes #12131
