### PR TITLE
Write local testing config values to AMP runtime

### DIFF
--- a/build-system/tasks/prepend-global/index.js
+++ b/build-system/tasks/prepend-global/index.js
@@ -23,8 +23,8 @@ const fs = BBPromise.promisifyAll(require('fs'));
 const gulp = require('gulp-help')(require('gulp'));
 const util = require('gulp-util');
 
-var red = util.colors.red;
-var cyan = util.colors.cyan;
+const red = util.colors.red;
+const cyan = util.colors.cyan;
 
 /**
  * Returns the number of AMP_CONFIG matches in the given config string.
@@ -166,7 +166,7 @@ function enableLocalDev(config, target, configJson) {
   if (!process.env.TRAVIS) {
     util.log('Enabled local development mode in', cyan(target));
   }
-  let TESTING_HOST = process.env.AMP_TESTING_HOST;
+  const TESTING_HOST = process.env.AMP_TESTING_HOST;
   if (typeof TESTING_HOST == 'string') {
     LOCAL_DEV_AMP_CONFIG = Object.assign(LOCAL_DEV_AMP_CONFIG, {
       thirdPartyFrameHost: TESTING_HOST,
@@ -178,7 +178,7 @@ function enableLocalDev(config, target, configJson) {
     }
   }
   LOCAL_DEV_AMP_CONFIG = Object.assign(LOCAL_DEV_AMP_CONFIG, configJson);
-  let herokuConfigFile = 'node_modules/AMP_CONFIG.json';
+  const herokuConfigFile = 'node_modules/AMP_CONFIG.json';
   fs.writeFileSync(herokuConfigFile, JSON.stringify(LOCAL_DEV_AMP_CONFIG));
   if (!process.env.TRAVIS) {
     util.log('Wrote', cyan(config), 'AMP config to', cyan(herokuConfigFile),

--- a/build-system/tasks/prepend-global/index.js
+++ b/build-system/tasks/prepend-global/index.js
@@ -53,7 +53,7 @@ function sanityCheck(str) {
 
 /**
  * @param {string} filename File containing the config
- * @param {string} opt_localBranch Whether to use the local branch version
+ * @param {string=} opt_localBranch Whether to use the local branch version
  * @param {string=} opt_branch If not the local branch, which branch to use
  * @return {!Promise}
  */
@@ -115,9 +115,9 @@ function valueOrDefault(value, defaultValue) {
  * @param {string} config Prod or canary
  * @param {string} target File containing the AMP runtime (amp.js or v0.js)
  * @param {string} filename File containing the (prod or canary) config
- * @param {boolean} opt_localDev Whether to enable local development
- * @param {boolean} opt_localBranch Whether to use the local branch version
- * @param {string} opt_branch If not the local branch, which branch to use
+ * @param {boolean=} opt_localDev Whether to enable local development
+ * @param {boolean=} opt_localBranch Whether to use the local branch version
+ * @param {string=} opt_branch If not the local branch, which branch to use
  * @return {!Promise}
  */
 function applyConfig(

--- a/build-system/tasks/prepend-global/index.js
+++ b/build-system/tasks/prepend-global/index.js
@@ -23,6 +23,8 @@ const fs = BBPromise.promisifyAll(require('fs'));
 const gulp = require('gulp-help')(require('gulp'));
 const util = require('gulp-util');
 
+var red = util.colors.red;
+var cyan = util.colors.cyan;
 
 /**
  * Returns the number of AMP_CONFIG matches in the given config string.
@@ -50,13 +52,13 @@ function sanityCheck(str) {
 }
 
 /**
- * @param {string} filename
- * @param {string} opt_local
- * @param {string=} opt_branch
+ * @param {string} filename File containing the config
+ * @param {string} opt_localBranch Whether to use the local branch version
+ * @param {string=} opt_branch If not the local branch, which branch to use
  * @return {!Promise}
  */
-function checkoutBranchConfigs(filename, opt_local, opt_branch) {
-  if (opt_local) {
+function checkoutBranchConfigs(filename, opt_localBranch, opt_branch) {
+  if (opt_localBranch) {
     return Promise.resolve();
   }
   const branch = opt_branch || 'origin/master';
@@ -73,8 +75,8 @@ function checkoutBranchConfigs(filename, opt_local, opt_branch) {
 }
 
 /**
- * @param {string} configString
- * @param {string} fileString
+ * @param {string} configString String containing the AMP config
+ * @param {string} fileString String containing the AMP runtime
  * @return {string}
  */
 function prependConfig(configString, fileString) {
@@ -83,14 +85,14 @@ function prependConfig(configString, fileString) {
 }
 
 /**
- * @param {string} filename
- * @param {string} fileString
- * @param {boolean=} opt_dryrun
+ * @param {string} filename Destination filename
+ * @param {string} fileString String to write
+ * @param {boolean=} opt_dryrun If true, print the contents without writing them
  * @return {!Promise}
  */
 function writeTarget(filename, fileString, opt_dryrun) {
   if (opt_dryrun) {
-    util.log(util.colors.blue(`overwriting: ${filename}`));
+    util.log(cyan(`overwriting: ${filename}`));
     util.log(fileString);
     return Promise.resolve();
   }
@@ -110,15 +112,17 @@ function valueOrDefault(value, defaultValue) {
 }
 
 /**
- * @param {string} config
- * @param {string} target
- * @param {string} filename
- * @param {string} opt_local
- * @param {string} opt_branch
+ * @param {string} config Prod or canary
+ * @param {string} target File containing the AMP runtime (amp.js or v0.js)
+ * @param {string} filename File containing the (prod or canary) config
+ * @param {boolean} opt_localDev Whether to enable local development
+ * @param {boolean} opt_localBranch Whether to use the local branch version
+ * @param {string} opt_branch If not the local branch, which branch to use
  * @return {!Promise}
  */
-function applyConfig(config, target, filename, opt_local, opt_branch) {
-  return checkoutBranchConfigs(filename, opt_local, opt_branch)
+function applyConfig(
+    config, target, filename, opt_localDev, opt_localBranch, opt_branch) {
+  return checkoutBranchConfigs(filename, opt_localBranch, opt_branch)
       .then(() => {
         return Promise.all([
           fs.readFileAsync(filename),
@@ -126,15 +130,19 @@ function applyConfig(config, target, filename, opt_local, opt_branch) {
         ]);
       })
       .then(files => {
-        let configFile;
+        let configJson;
         try {
-          configFile = JSON.stringify(JSON.parse(files[0].toString()));
+          configJson = JSON.parse(files[0].toString());
         } catch (e) {
-          util.log(util.colors.red(`Error parsing config file: ${filename}`));
+          util.log(red(`Error parsing config file: ${filename}`));
           throw e;
         }
-        const targetFile = files[1].toString();
-        return prependConfig(configFile, targetFile);
+        if (opt_localDev) {
+          configJson = enableLocalDev(config, target, configJson);
+        }
+        const targetString = files[1].toString();
+        const configString = JSON.stringify(configJson);
+        return prependConfig(configString, targetString);
       })
       .then(fileString => {
         sanityCheck(fileString);
@@ -142,14 +150,45 @@ function applyConfig(config, target, filename, opt_local, opt_branch) {
       })
       .then(() => {
         if (!process.env.TRAVIS) {
-          util.log('Wrote', util.colors.cyan(config), 'AMP config to',
-              util.colors.cyan(target));
+          util.log('Wrote', cyan(config), 'AMP config to', cyan(target));
         }
       });
 }
 
 /**
- * @param {string} target
+ * @param {string} config Prod or canary
+ * @param {string} target File containing the AMP runtime (amp.js or v0.js)
+ * @param {string} configJson The json object in which to enable local dev
+ * @return {string}
+ */
+function enableLocalDev(config, target, configJson) {
+  let LOCAL_DEV_AMP_CONFIG = {localDev: true};
+  if (!process.env.TRAVIS) {
+    util.log('Enabled local development mode in', cyan(target));
+  }
+  let TESTING_HOST = process.env.AMP_TESTING_HOST;
+  if (typeof TESTING_HOST == 'string') {
+    LOCAL_DEV_AMP_CONFIG = Object.assign(LOCAL_DEV_AMP_CONFIG, {
+      thirdPartyFrameHost: TESTING_HOST,
+      thirdPartyFrameRegex: TESTING_HOST,
+    });
+    if (!process.env.TRAVIS) {
+      util.log('Set', cyan('TESTING_HOST'), 'to', cyan(TESTING_HOST),
+          'in', cyan(target));
+    }
+  }
+  LOCAL_DEV_AMP_CONFIG = Object.assign(LOCAL_DEV_AMP_CONFIG, configJson);
+  let herokuConfigFile = 'node_modules/AMP_CONFIG.json';
+  fs.writeFileSync(herokuConfigFile, JSON.stringify(LOCAL_DEV_AMP_CONFIG));
+  if (!process.env.TRAVIS) {
+    util.log('Wrote', cyan(config), 'AMP config to', cyan(herokuConfigFile),
+        'for use with Heroku');
+  }
+  return LOCAL_DEV_AMP_CONFIG;
+}
+
+/**
+ * @param {string} target Target file from which to remove the AMP config
  * @return {!Promise}
  */
 function removeConfig(target) {
@@ -158,7 +197,7 @@ function removeConfig(target) {
         let contents = file.toString();
         if (numConfigs(contents) == 0) {
           if (!process.env.TRAVIS) {
-            util.log('No configs found in', util.colors.cyan(target));
+            util.log('No configs found in', cyan(target));
           }
           return Promise.resolve();
         }
@@ -168,7 +207,7 @@ function removeConfig(target) {
         contents = contents.replace(config, '');
         return writeTarget(target, contents, argv.dryrun).then(() => {
           if (!process.env.TRAVIS) {
-            util.log('Removed existing config from', util.colors.cyan(target));
+            util.log('Removed existing config from', cyan(target));
           }
         });
       });
@@ -179,7 +218,7 @@ function main() {
   const target = argv.target || TESTING_HOST;
 
   if (!target) {
-    util.log(util.colors.red('Missing --target.'));
+    util.log(red('Missing --target.'));
     return;
   }
 
@@ -188,11 +227,10 @@ function main() {
   }
 
   if (!(argv.prod || argv.canary)) {
-    util.log(util.colors.red('One of --prod or --canary should be provided.'));
+    util.log(red('One of --prod or --canary should be provided.'));
     return;
   }
 
-  const branch = argv.branch;
   let filename = '';
 
   // Prod by default.
@@ -205,7 +243,9 @@ function main() {
         'build-system/global-configs/prod-config.json');
   }
   return removeConfig(target).then(() => {
-    return applyConfig(config, target, filename, argv.local, branch);
+    return applyConfig(
+        config, target, filename,
+        argv.local_dev, argv.local_branch, argv.branch);
   });
 }
 
@@ -216,9 +256,11 @@ gulp.task('prepend-global', 'Prepends a json config to a target file', main, {
         'Takes in an optional value for a custom canary config source.',
     'prod': '  Prepend the default prod config. ' +
         'Takes in an optional value for a custom prod config source.',
+    'local_dev': '  Enables runtime to be used for local development.',
     'branch': '  Switch to a git branch to get config source from. ' +
         'Uses master by default.',
-    'local': '  Don\'t switch branches and use local config',
+    'local_branch': '  Don\'t switch branches and use the config from the ' +
+        'local branch.',
     'remove': '  Removes previously prepended json config from the target ' +
         'file (if present).',
   },

--- a/build-system/tasks/runtime-test.js
+++ b/build-system/tasks/runtime-test.js
@@ -186,7 +186,8 @@ function applyAmpConfig(targetFile) {
   if (fs.existsSync(targetFile)) {
     return removeConfig(targetFile).then(() => {
       return applyConfig(
-          ampConfig, targetFile, configFile, /* opt_local */ true);
+          ampConfig, targetFile, configFile,
+          /* opt_localDev */ true, /* opt_localBranch */ true);
     });
   } else {
     return Promise.resolve();

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -577,7 +577,8 @@ function printConfigHelp(command, targetFile) {
         cyan(command), cyan('--config={canary|prod}'));
     $$.util.log(
         green('- To switch configs after building:'),
-        cyan('gulp prepend-global {--canary|--prod} --target ' + targetFile));
+        cyan('gulp prepend-global {--canary|--prod} --local_dev --target ' +
+            targetFile));
     $$.util.log(
         green('- To remove any existing config:'),
         cyan('gulp prepend-global --remove --target ' + targetFile));
@@ -592,28 +593,11 @@ function printConfigHelp(command, targetFile) {
 function enableLocalTesting(targetFile) {
   let config = (argv.config === 'canary') ? 'canary' : 'prod';
   let baseConfigFile = 'build-system/global-configs/' + config + '-config.json';
-  let localTestingConfigFile = 'node_modules/AMP_CONFIG.json';
 
   return removeConfig(targetFile).then(() => {
-    let AMP_CONFIG = {localDev: true};
-    let TESTING_HOST = process.env.AMP_TESTING_HOST;
-    if (typeof TESTING_HOST == 'string') {
-      AMP_CONFIG = Object.assign(AMP_CONFIG, {
-        thirdPartyFrameHost: TESTING_HOST,
-        thirdPartyFrameRegex: TESTING_HOST,
-      });
-    }
-    AMP_CONFIG = Object.assign(
-        AMP_CONFIG, JSON.parse(fs.readFileSync(baseConfigFile).toString()));
-    fs.writeFileSync(localTestingConfigFile, JSON.stringify(AMP_CONFIG));
-    if (!process.env.TRAVIS) {
-      $$.util.log('Wrote', cyan(config), 'AMP config to',
-          cyan(localTestingConfigFile), 'for use with Heroku');
-    }
-    return Promise.resolve();
-  }).then(() => {
     return applyConfig(
-        config, targetFile, localTestingConfigFile, /* opt_local */ true);
+        config, targetFile, baseConfigFile,
+        /* opt_localDev */ true, /* opt_localBranch */ true);
   });
 }
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -591,13 +591,11 @@ function printConfigHelp(command, targetFile) {
  */
 function enableLocalTesting(targetFile) {
   let config = (argv.config === 'canary') ? 'canary' : 'prod';
-  let configFile = 'build-system/global-configs/' + config + '-config.json';
+  let baseConfigFile = 'build-system/global-configs/' + config + '-config.json';
+  let localTestingConfigFile = 'node_modules/AMP_CONFIG.json';
 
   return removeConfig(targetFile).then(() => {
-    return applyConfig(config, targetFile, configFile, /* opt_local */ true);
-  }).then(() => {
     let AMP_CONFIG = {localDev: true};
-    let herokuConfigFile = 'node_modules/AMP_CONFIG.json';
     let TESTING_HOST = process.env.AMP_TESTING_HOST;
     if (typeof TESTING_HOST == 'string') {
       AMP_CONFIG = Object.assign(AMP_CONFIG, {
@@ -606,12 +604,16 @@ function enableLocalTesting(targetFile) {
       });
     }
     AMP_CONFIG = Object.assign(
-        AMP_CONFIG, JSON.parse(fs.readFileSync(configFile).toString()));
-    fs.writeFileSync(herokuConfigFile, JSON.stringify(AMP_CONFIG));
+        AMP_CONFIG, JSON.parse(fs.readFileSync(baseConfigFile).toString()));
+    fs.writeFileSync(localTestingConfigFile, JSON.stringify(AMP_CONFIG));
     if (!process.env.TRAVIS) {
       $$.util.log('Wrote', cyan(config), 'AMP config to',
-          cyan(herokuConfigFile), 'for use with Heroku');
+          cyan(localTestingConfigFile), 'for use with Heroku');
     }
+    return Promise.resolve();
+  }).then(() => {
+    return applyConfig(
+        config, targetFile, localTestingConfigFile, /* opt_local */ true);
   });
 }
 


### PR DESCRIPTION
This PR does the following:
1. Makes sure that the values of `localDev: true`, `thirdPartyFrameHost`, and `thirdPartyFrameRegex` are written to the local AMP config to enable local testing with `gulp build` and `gulp dist --fortesting`.
2. Adds a new parameter `--local_dev` to `gulp prepend-global`, which will ensure that the AMP runtime is set up for local development and testing. 

With this, `localDev` will be set to true when the runtime is built and served on `localhost` via `gulp`, or via the following commands:
```
gulp clean
gulp build
gulp serve
```

In addition, `localDev` will be set to true and `thirdPartyFrameHost` and `thirdPartyFrameRegex` will point to `AMP_TESTING_HOST` when the runtime is built and served from a non-localhost server, via the following commands.

```
gulp clean
export AMP_TESTING_HOST=<hostname.domain.com>
gulp build
gulp serve --host=<hostname.domain.com>
```

Partial fix for #12054