### PR TITLE
Pass useSameDomainRenderingUntilDeprecated parameter into window.context

### DIFF
--- a/3p/frame-metadata.js
+++ b/3p/frame-metadata.js
@@ -54,13 +54,14 @@ const FALLBACK = dict({
   }),
 });
 
+let winForTesting;
 
 /**
  * Gets metadata encoded in iframe name attribute.
  * @return {!JsonObject}
  */
 const allMetadata = once(() => {
-  const iframeName = window.name;
+  const iframeName = (winForTesting || window).name;
 
   try {
     // TODO(bradfrizzell@): Change the data structure of the attributes
@@ -131,9 +132,11 @@ export function getLocation() {
 
 
 /**
+ * @param {?Window} opt_win
  * @return {!ContextStateDef}
  */
-export function getContextState() {
+export function getContextState(opt_win) {
+  winForTesting = opt_win;
   const attributes = allMetadata()['attributes'];
   const rawContext = attributes['_context'];
 

--- a/3p/frame-metadata.js
+++ b/3p/frame-metadata.js
@@ -134,9 +134,10 @@ export function getLocation() {
  * @return {!ContextStateDef}
  */
 export function getContextState() {
+  //const allMetadata =  allMetadata();
   const rawContext = allMetadata()['attributes']['_context'];
 
-  return {
+  const context = {
     ampcontextFilepath: rawContext['ampcontextFilepath'],
     ampcontextVersion: rawContext['ampcontextVersion'],
     canary: rawContext['canary'],
@@ -155,6 +156,11 @@ export function getContextState() {
     startTime: rawContext['startTime'],
     tagName: rawContext['tagName'],
   };
+  if (allMetadata['useSameDomainRenderingUntilDeprecated']) {
+    context['useSameDomainRenderingUntilDeprecated'] =
+      allMetadata['useSameDomainRenderingUntilDeprecated'];
+  }
+  return context;
 };
 
 

--- a/3p/frame-metadata.js
+++ b/3p/frame-metadata.js
@@ -132,7 +132,7 @@ export function getLocation() {
 
 
 /**
- * @param {?Window} opt_win
+ * @param {Window=} opt_win
  * @return {!ContextStateDef}
  */
 export function getContextState(opt_win) {

--- a/3p/frame-metadata.js
+++ b/3p/frame-metadata.js
@@ -134,8 +134,8 @@ export function getLocation() {
  * @return {!ContextStateDef}
  */
 export function getContextState() {
-  const metadata = allMetadata();
-  const rawContext = metadata['attributes']['_context'];
+  const attributes = allMetadata()['attributes'];
+  const rawContext = attributes['_context'];
 
   const context = {
     ampcontextFilepath: rawContext['ampcontextFilepath'],
@@ -156,9 +156,9 @@ export function getContextState() {
     startTime: rawContext['startTime'],
     tagName: rawContext['tagName'],
   };
-  if (metadata['attributes']['useSameDomainRenderingUntilDeprecated']) {
+  if (attributes['useSameDomainRenderingUntilDeprecated']) {
     context['useSameDomainRenderingUntilDeprecated'] =
-      metadata['attributes']['useSameDomainRenderingUntilDeprecated'];
+      attributes['useSameDomainRenderingUntilDeprecated'];
   }
   return context;
 };

--- a/3p/frame-metadata.js
+++ b/3p/frame-metadata.js
@@ -134,8 +134,8 @@ export function getLocation() {
  * @return {!ContextStateDef}
  */
 export function getContextState() {
-  //const allMetadata =  allMetadata();
-  const rawContext = allMetadata()['attributes']['_context'];
+  const metadata = allMetadata();
+  const rawContext = metadata['attributes']['_context'];
 
   const context = {
     ampcontextFilepath: rawContext['ampcontextFilepath'],
@@ -156,9 +156,9 @@ export function getContextState() {
     startTime: rawContext['startTime'],
     tagName: rawContext['tagName'],
   };
-  if (allMetadata['useSameDomainRenderingUntilDeprecated']) {
+  if (metadata['attributes']['useSameDomainRenderingUntilDeprecated']) {
     context['useSameDomainRenderingUntilDeprecated'] =
-      allMetadata['useSameDomainRenderingUntilDeprecated'];
+      metadata['attributes']['useSameDomainRenderingUntilDeprecated'];
   }
   return context;
 };

--- a/3p/integration.js
+++ b/3p/integration.js
@@ -590,6 +590,10 @@ function installContextUsingStandardImpl(win, data) {
     'computeInMasterFrame': computeInMasterFrame,
   };
 
+  if (contextState.useSameDomainRenderingUntilDeprecated) {
+    win.context['useSameDomainRenderingUntilDeprecated'] = true;
+  }
+
   // Define master related properties to be lazily read.
   Object.defineProperties(win.context, {
     master: {

--- a/examples/doubleclick-remote-html.html
+++ b/examples/doubleclick-remote-html.html
@@ -54,11 +54,11 @@
 </head>
 <body>
 
-  <h2>Doubleclick example, should use Glade.js</h2>
+<!--  <h2>Doubleclick example, should use Glade.js</h2>
   <amp-ad width="320" height="50"
       type="doubleclick"
       data-slot="/4119129/mobile_ad_banner">
-  </amp-ad>
+  </amp-ad> -->
 
   <h2>Doubleclick example, should use GPT.js</h2>
   <amp-ad width="320" height="50"

--- a/examples/doubleclick-remote-html.html
+++ b/examples/doubleclick-remote-html.html
@@ -54,11 +54,11 @@
 </head>
 <body>
 
-<!--  <h2>Doubleclick example, should use Glade.js</h2>
+  <h2>Doubleclick example, should use Glade.js</h2>
   <amp-ad width="320" height="50"
       type="doubleclick"
       data-slot="/4119129/mobile_ad_banner">
-  </amp-ad> -->
+  </amp-ad>
 
   <h2>Doubleclick example, should use GPT.js</h2>
   <amp-ad width="320" height="50"

--- a/test/functional/test-frame-metadata.js
+++ b/test/functional/test-frame-metadata.js
@@ -1,0 +1,77 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  getContextState,
+} from '../../3p/frame-metadata';
+
+const realWinConfigAmpAd = {
+  amp: {ampdoc: 'amp-ad'},
+  ampAdCss: true,
+  allowExternalResources: true,
+};
+
+describes.realWin('frame-metadata', realWinConfigAmpAd, env => {
+  let context;
+  let name;
+
+  beforeEach(() => {
+    context = {
+      referrer: 'http://acme.org/',
+      ampcontextVersion: '$internalRuntimeVersion$',
+      ampcontextFilepath: 'https://3p.ampproject.net' +
+        '/$internalRuntimeVersion$/ampcontext-v0.js',
+      canonicalUrl: 'https://foo.com',
+      sourceUrl: 'https://foo.bar.com',
+      pageViewId: '1234',
+      clientId: '5678',
+      mode: {'localDev': true,'development': false,'minified': false,
+        'test': false,'version': '$internalRuntimeVersion$'},
+      canary: true,
+      hidden: false,
+      // Note that DOM fingerprint will change if the document DOM changes
+      // Note also that running it using --files uses different DOM.
+      domFingerprint: '1725030182',
+      startTime: 1234567888,
+      sentinel: '010101010',
+      container: undefined,
+      initialIntersection: undefined,
+      initialLayoutRect: undefined,
+      tagName: undefined,
+    };
+    name = {
+      attributes: {
+        _context: context,
+      }};
+    window.name = JSON.stringify(name);
+  });
+
+  afterEach(() => {
+    window.name = undefined;
+  });
+
+  describe('getContextState', () => {
+    it('should return context with usdrd', () => {
+      name.attributes['useSameDomainRenderingUntilDeprecated'] = '1';
+      window.name = JSON.stringify(name);
+      const contextState = getContextState();
+      context['useSameDomainRenderingUntilDeprecated'] = '1';
+      expect(contextState).to.deep.equal(context);
+    });
+  });
+
+
+});

--- a/test/functional/test-frame-metadata.js
+++ b/test/functional/test-frame-metadata.js
@@ -27,8 +27,10 @@ const realWinConfigAmpAd = {
 describes.realWin('frame-metadata', realWinConfigAmpAd, env => {
   let context;
   let name;
+  let win;
 
   beforeEach(() => {
+    win = env.win;
     context = {
       referrer: 'http://acme.org/',
       ampcontextVersion: '$internalRuntimeVersion$',
@@ -66,8 +68,8 @@ describes.realWin('frame-metadata', realWinConfigAmpAd, env => {
   describe('getContextState', () => {
     it('should return context with usdrd', () => {
       name.attributes['useSameDomainRenderingUntilDeprecated'] = '1';
-      window.name = JSON.stringify(name);
-      const contextState = getContextState();
+      win.name = JSON.stringify(name);
+      const contextState = getContextState(win);
       context['useSameDomainRenderingUntilDeprecated'] = '1';
       expect(contextState).to.deep.equal(context);
     });


### PR DESCRIPTION
Need signal available on window.context, so we can detect from within the ad iframe that usdrd is being used. 