### PR TITLE
Gestures: Fix double tap centering bug

### DIFF
--- a/src/gesture-recognizers.js
+++ b/src/gesture-recognizers.js
@@ -141,6 +141,8 @@ export class DoubletapRecognizer extends GestureRecognizer {
     }
     this.startX_ = touches[0].clientX;
     this.startY_ = touches[0].clientY;
+    this.lastX_ = touches[0].clientX;
+    this.lastY_ = touches[0].clientY;
     return true;
   }
 


### PR DESCRIPTION
Bug: double-tap does not register `clientX` or `clientY` if the tap did not move. It is actually possible to tap without registering a `onTouchMove` if your tap didn't move. 

Proposed fix: set the `clientX` and `clientY` in `onTouchStart`, and updating it in `onTouchMove`. 

Example repro with `amp-image-lightbox`: 
No matter where you double tap, you always zoom to the left. This is because `clientX` and `clientY` are unregistered and default to 0. 
![bug](https://user-images.githubusercontent.com/1528181/33102891-caa7ca28-ced3-11e7-81b7-84d458c8efec.gif)

Post fix: 
Zoom is now centered at double tap location. 
![fix](https://user-images.githubusercontent.com/1528181/33102898-d07dcaec-ced3-11e7-9950-debb174c3a4b.gif)



