### PR TITLE
Revert "amp-layout: enable visual tests"

### DIFF
--- a/test/visual-diff/visual-tests.json
+++ b/test/visual-diff/visual-tests.json
@@ -107,10 +107,6 @@
         ".comic-amp-font-loaded",
         ".comic-amp-bold-font-loaded"
       ]
-    },
-    {
-      "url": "examples/visual-tests/amp-layout/amp-layout.amp.html",
-      "name": "AMP Layout"
     }
   ],
 


### PR DESCRIPTION
Reverts ampproject/amphtml#12158

screenshots are wrong.