### PR TITLE
Implementing full width responsive non fast-fetch path

### DIFF
--- a/ads/_config.js
+++ b/ads/_config.js
@@ -22,6 +22,7 @@
  *   clientIdScope: (string|undefined),
  *   clientIdCookieName: (string|undefined),
  *   remoteHTMLDisabled: (boolean|undefined),
+ *   fullWidthHeightRatio: (number|undefined),
  * }}
  */
 let AdNetworkConfigDef;
@@ -48,6 +49,11 @@ let AdNetworkConfigDef;
  *   // We highly recommend all networks to implement the API,
  *   // see details in the README.md
  *   renderStartImplemented: boolean
+ *
+ *   // The width / height ratio for full width ad units.
+ *   // If absent, it means the network does not support full width ad units.
+ *   // Example value: 1.2
+ *   fullWidthHeightRatio: number
  * }
  *
  * @const {!Object<string, !AdNetworkConfigDef>}}
@@ -132,6 +138,7 @@ export const adConfig = {
     clientIdCookieName: '_ga',
     remoteHTMLDisabled: true,
     masterFrameAccessibleType: 'google_network',
+    fullWidthHeightRatio: 1.2,
   },
 
   adsnative: {

--- a/ads/google/adsense.js
+++ b/ads/google/adsense.js
@@ -27,7 +27,7 @@ export function adsense(global, data) {
   // TODO: check mandatory fields
   validateData(data, [],
       ['adClient', 'adSlot', 'adHost', 'adtest', 'tagOrigin', 'experimentId',
-        'ampSlotIndex', 'adChannel', 'autoFormat']);
+        'ampSlotIndex', 'adChannel', 'autoFormat', 'fullWidth']);
 
   if (global.context.clientId) {
     // Read by GPT for GA/GPT integration.

--- a/examples/a4a-fullwidth.amp.html
+++ b/examples/a4a-fullwidth.amp.html
@@ -81,7 +81,8 @@
           data-ad-client="ca-pub-2383777339857329"
           data-ad-slot="4121425836"
           data-adtest="on"
-          data-auto-format="rspv">
+          data-auto-format="rspv"
+          data-full-width>
     <div overflow></div>
   </amp-ad>
 
@@ -101,7 +102,8 @@
             data-ad-client="ca-pub-2383777339857329"
             data-ad-slot="4121425836"
             data-adtest="on"
-            data-auto-format="rspv">
+            data-auto-format="rspv"
+            data-full-width>
       <div overflow></div>
     </amp-ad>
 
@@ -145,7 +147,8 @@
           data-ad-client="ca-pub-2383777339857329"
           data-ad-slot="4121425836"
           data-adtest="on"
-          data-auto-format="rspv">
+          data-auto-format="rspv"
+          data-full-width>
     <div placeholder></div>
     <div fallback></div>
     <div overflow></div>


### PR DESCRIPTION
This makes it possible for an ad network to specify an aspect ratio in the config, and if this is specified ad units with data-full-width set will then be expanded to 100% of the device width, aligned with the device edges and with she specified aspect ratio.

A default height needs to be provided for the ad unit in case changing the height to match the aspect ratio fails (for example if it's above the fold).

Tried to keep it reasonably close to the AdSense a4a path (https://github.com/ampproject/amphtml/pull/11231).
