### PR TITLE
Lightbox 2.0: add basic pinch zoom

### DIFF
--- a/src/gesture-recognizers.js
+++ b/src/gesture-recognizers.js
@@ -640,6 +640,17 @@ export class TapzoomRecognizer extends GestureRecognizer {
  */
 let PinchDef;
 
+/**
+ * Threshold in pixels for how much two touches move away from
+ * each other before we recognize the gesture as a pinch.
+ */
+const PINCH_ACCEPT_THRESHOLD = 4;
+
+/**
+ * Threshold in pixels for how much two touches move in the same
+ * direction before we reject the gesture as a pinch.
+ */
+const PINCH_REJECT_THRESHOLD = 10;
 
 /**
  * Recognizes a "pinch" gesture.
@@ -738,10 +749,12 @@ export class PinchRecognizer extends GestureRecognizer {
         const dy2 = this.lastY2_ - this.startY2_;
         // Fingers should move in opposite directions and go over the threshold.
         if (dx1 * dx2 <= 0 && dy1 * dy2 <= 0) {
-          if (Math.abs(dx1 - dx2) >= 4 || Math.abs(dy1 - dy2) >= 4) {
+          if (Math.abs(dx1 - dx2) >= PINCH_ACCEPT_THRESHOLD
+            || Math.abs(dy1 - dy2) >= PINCH_ACCEPT_THRESHOLD) {
             this.signalReady(0);
           }
-        } else if (Math.abs(dx1 + dx2) >= 10 || Math.abs(dy1 + dy2) >= 10) {
+        } else if (Math.abs(dx1 + dx2) >= PINCH_REJECT_THRESHOLD
+          || Math.abs(dy1 + dy2) >= PINCH_REJECT_THRESHOLD) {
           // Moving in the same direction over a threshold.
           return false;
         }

--- a/src/gesture-recognizers.js
+++ b/src/gesture-recognizers.js
@@ -148,8 +148,10 @@ export class DoubletapRecognizer extends GestureRecognizer {
 
   /** @override */
   onTouchMove(e) {
-    const touches = e.changedTouches || e.touches;
-    if (touches && touches.length == 1) {
+    const touches = e.touches;
+    if (!touches || touches.length != 1) {
+      return false;
+    } else {
       this.lastX_ = touches[0].clientX;
       this.lastY_ = touches[0].clientY;
       const dx = Math.abs(this.lastX_ - this.startX_) >= 8;
@@ -158,8 +160,8 @@ export class DoubletapRecognizer extends GestureRecognizer {
         this.acceptCancel();
         return false;
       }
+      return true;
     }
-    return true;
   }
 
   /** @override */
@@ -271,8 +273,10 @@ class SwipeRecognizer extends GestureRecognizer {
 
   /** @override */
   onTouchMove(e) {
-    const touches = e.changedTouches || e.touches;
-    if (touches && touches.length == 1) {
+    const touches = e.touches;
+    if (!touches || touches.length != 1) {
+      return false;
+    } else {
       const x = touches[0].clientX;
       const y = touches[0].clientY;
       this.lastX_ = x;
@@ -304,8 +308,8 @@ class SwipeRecognizer extends GestureRecognizer {
           return false;
         }
       }
+      return true;
     }
-    return true;
   }
 
   /** @override */
@@ -512,7 +516,9 @@ export class TapzoomRecognizer extends GestureRecognizer {
   /** @override */
   onTouchMove(e) {
     const touches = e.changedTouches || e.touches;
-    if (touches && touches.length == 1) {
+    if (!touches || touches.length != 1) {
+      return false;
+    } else {
       this.lastX_ = touches[0].clientX;
       this.lastY_ = touches[0].clientY;
       if (this.eventing_) {
@@ -529,8 +535,8 @@ export class TapzoomRecognizer extends GestureRecognizer {
           }
         }
       }
+      return true;
     }
-    return true;
   }
 
   /** @override */
@@ -691,42 +697,48 @@ export class PinchRecognizer extends GestureRecognizer {
   /** @override */
   onTouchStart(e) {
     const touches = e.touches;
-    if (!touches || touches.length != 2) {
+    if (!touches || touches.length > 2) {
       return false;
+    } else if (touches.length == 1) {
+      return true;
+    } else {
+      this.startTime_ = Date.now();
+      this.startX1_ = touches[0].clientX;
+      this.startY1_ = touches[0].clientY;
+      this.startX2_ = touches[1].clientX;
+      this.startY2_ = touches[1].clientY;
+      return true;
     }
-    this.startTime_ = Date.now();
-    this.startX1_ = touches[0].clientX;
-    this.startY1_ = touches[0].clientY;
-    this.startX2_ = touches[1].clientX;
-    this.startY2_ = touches[1].clientY;
-    return true;
   }
 
   /** @override */
   onTouchMove(e) {
     const touches = e.touches;
-    if (!touches || touches.length != 2) {
+    if (!touches || touches.length > 2) {
       return false;
-    }
-    this.lastX1_ = touches[0].clientX;
-    this.lastY1_ = touches[0].clientY;
-    this.lastX2_ = touches[1].clientX;
-    this.lastY2_ = touches[1].clientY;
-    if (this.eventing_) {
-      this.emit_(false, false, e);
+    } else if (touches.length == 1) {
+      return true;
     } else {
-      const dx1 = this.lastX1_ - this.startX1_;
-      const dy1 = this.lastY1_ - this.startY1_;
-      const dx2 = this.lastX2_ - this.startX2_;
-      const dy2 = this.lastY2_ - this.startY2_;
-      // Fingers should move in opposite directions and go over the threshold.
-      if (dx1 * dx2 <= 0 && dy1 * dy2 <= 0) {
-        if (Math.abs(dx1 - dx2) >= 8 || Math.abs(dy1 - dy2) >= 8) {
-          this.signalReady(0);
+      this.lastX1_ = touches[0].clientX;
+      this.lastY1_ = touches[0].clientY;
+      this.lastX2_ = touches[1].clientX;
+      this.lastY2_ = touches[1].clientY;
+      if (this.eventing_) {
+        this.emit_(false, false, e);
+      } else {
+        const dx1 = this.lastX1_ - this.startX1_;
+        const dy1 = this.lastY1_ - this.startY1_;
+        const dx2 = this.lastX2_ - this.startX2_;
+        const dy2 = this.lastY2_ - this.startY2_;
+        // Fingers should move in opposite directions and go over the threshold.
+        if (dx1 * dx2 <= 0 && dy1 * dy2 <= 0) {
+          if (Math.abs(dx1 - dx2) >= 4 || Math.abs(dy1 - dy2) >= 4) {
+            this.signalReady(0);
+          }
+        } else if (Math.abs(dx1 + dx2) >= 10 || Math.abs(dy1 + dy2) >= 10) {
+          // Moving in the same direction over a threshold.
+          return false;
         }
-      } else if (Math.abs(dx1 + dx2) >= 8 || Math.abs(dy1 + dy2) >= 8) {
-        // Moving in the same direction over a threshold.
-        return false;
       }
     }
     return true;

--- a/src/gesture-recognizers.js
+++ b/src/gesture-recognizers.js
@@ -55,12 +55,13 @@ export class TapRecognizer extends GestureRecognizer {
   /** @override */
   onTouchStart(e) {
     const touches = e.touches;
-    if (!touches || touches.length != 1) {
+    if (touches && touches.length == 1) {
+      this.startX_ = touches[0].clientX;
+      this.startY_ = touches[0].clientY;
+      return true;
+    } else {
       return false;
     }
-    this.startX_ = touches[0].clientX;
-    this.startY_ = touches[0].clientY;
-    return true;
   }
 
   /** @override */
@@ -136,22 +137,21 @@ export class DoubletapRecognizer extends GestureRecognizer {
       return false;
     }
     const touches = e.touches;
-    if (!touches || touches.length != 1) {
+    if (touches && touches.length == 1) {
+      this.startX_ = touches[0].clientX;
+      this.startY_ = touches[0].clientY;
+      this.lastX_ = touches[0].clientX;
+      this.lastY_ = touches[0].clientY;
+      return true;
+    } else {
       return false;
     }
-    this.startX_ = touches[0].clientX;
-    this.startY_ = touches[0].clientY;
-    this.lastX_ = touches[0].clientX;
-    this.lastY_ = touches[0].clientY;
-    return true;
   }
 
   /** @override */
   onTouchMove(e) {
     const touches = e.touches;
-    if (!touches || touches.length != 1) {
-      return false;
-    } else {
+    if (touches && touches.length == 1) {
       this.lastX_ = touches[0].clientX;
       this.lastY_ = touches[0].clientY;
       const dx = Math.abs(this.lastX_ - this.startX_) >= 8;
@@ -161,6 +161,8 @@ export class DoubletapRecognizer extends GestureRecognizer {
         return false;
       }
       return true;
+    } else {
+      return false;
     }
   }
 
@@ -262,21 +264,20 @@ class SwipeRecognizer extends GestureRecognizer {
   /** @override */
   onTouchStart(e) {
     const touches = e.touches;
-    if (!touches || touches.length != 1) {
+    if (touches && touches.length == 1) {
+      this.startTime_ = Date.now();
+      this.startX_ = touches[0].clientX;
+      this.startY_ = touches[0].clientY;
+      return true;
+    } else {
       return false;
     }
-    this.startTime_ = Date.now();
-    this.startX_ = touches[0].clientX;
-    this.startY_ = touches[0].clientY;
-    return true;
   }
 
   /** @override */
   onTouchMove(e) {
     const touches = e.touches;
-    if (!touches || touches.length != 1) {
-      return false;
-    } else {
+    if (touches && touches.length == 1) {
       const x = touches[0].clientX;
       const y = touches[0].clientY;
       this.lastX_ = x;
@@ -309,6 +310,8 @@ class SwipeRecognizer extends GestureRecognizer {
         }
       }
       return true;
+    } else {
+      return false;
     }
   }
 
@@ -505,20 +508,19 @@ export class TapzoomRecognizer extends GestureRecognizer {
       return false;
     }
     const touches = e.touches;
-    if (!touches || touches.length != 1) {
+    if (touches && touches.length == 1) {
+      this.startX_ = touches[0].clientX;
+      this.startY_ = touches[0].clientY;
+      return true;
+    } else {
       return false;
     }
-    this.startX_ = touches[0].clientX;
-    this.startY_ = touches[0].clientY;
-    return true;
   }
 
   /** @override */
   onTouchMove(e) {
-    const touches = e.changedTouches || e.touches;
-    if (!touches || touches.length != 1) {
-      return false;
-    } else {
+    const touches = e.touches;
+    if (touches && touches.length == 1) {
       this.lastX_ = touches[0].clientX;
       this.lastY_ = touches[0].clientY;
       if (this.eventing_) {
@@ -536,6 +538,8 @@ export class TapzoomRecognizer extends GestureRecognizer {
         }
       }
       return true;
+    } else {
+      return false;
     }
   }
 
@@ -697,28 +701,30 @@ export class PinchRecognizer extends GestureRecognizer {
   /** @override */
   onTouchStart(e) {
     const touches = e.touches;
-    if (!touches || touches.length > 2) {
-      return false;
-    } else if (touches.length == 1) {
+    // Pinch touches are not always simultaneous, continue to listen
+    // for second touch.
+    if (touches && touches.length == 1) {
       return true;
-    } else {
+    } else if (touches && touches.length == 2) {
       this.startTime_ = Date.now();
       this.startX1_ = touches[0].clientX;
       this.startY1_ = touches[0].clientY;
       this.startX2_ = touches[1].clientX;
       this.startY2_ = touches[1].clientY;
       return true;
+    } else {
+      return false;
     }
   }
 
   /** @override */
   onTouchMove(e) {
     const touches = e.touches;
-    if (!touches || touches.length > 2) {
-      return false;
-    } else if (touches.length == 1) {
+    // Pinch touches are not always simultaneous, continue to listen
+    // for second touch.
+    if (touches && touches.length == 1) {
       return true;
-    } else {
+    } else if (touches && touches.length == 2) {
       this.lastX1_ = touches[0].clientX;
       this.lastY1_ = touches[0].clientY;
       this.lastX2_ = touches[1].clientX;
@@ -740,8 +746,10 @@ export class PinchRecognizer extends GestureRecognizer {
           return false;
         }
       }
+      return true;
+    } else {
+      return false;
     }
-    return true;
   }
 
   /** @override */

--- a/src/image-viewer.js
+++ b/src/image-viewer.js
@@ -26,6 +26,7 @@ import {
   DoubletapRecognizer,
   SwipeXYRecognizer,
   TapzoomRecognizer,
+  PinchRecognizer,
 } from './gesture-recognizers';
 import {bezierCurve} from './curve';
 import {isLoaded} from './event-helper';
@@ -339,15 +340,25 @@ export class ImageViewer {
       const deltaX = this.viewerBox_.width / 2 - e.data.clientX;
       const deltaY = this.viewerBox_.height / 2 - e.data.clientY;
       this.onZoom_(newScale, deltaX, deltaY, true).then(() => {
-        return this.onZoomRelease_(0, 0, 0, 0, 0, 0);
+        return this.onZoomRelease_();
       });
     });
     gestures.onGesture(TapzoomRecognizer, e => {
-      this.onZoomInc_(e.data.centerClientX, e.data.centerClientY,
+      event.preventDefault();
+      this.onTapZoom_(e.data.centerClientX, e.data.centerClientY,
           e.data.deltaX, e.data.deltaY);
       if (e.data.last) {
-        this.onZoomRelease_(e.data.centerClientX, e.data.centerClientY,
+        this.onTapZoomRelease_(e.data.centerClientX, e.data.centerClientY,
             e.data.deltaX, e.data.deltaY, e.data.velocityY, e.data.velocityY);
+      }
+    });
+    gestures.onGesture(PinchRecognizer, e => {
+      // To disable iOS 10 Safari default pinch zoom
+      event.preventDefault();
+      this.onPinchZoom_(e.data.centerClientX, e.data.centerClientY,
+          e.data.deltaX, e.data.deltaY, e.data.dir);
+      if (e.data.last) {
+        this.onZoomRelease_();
       }
     });
   }
@@ -490,23 +501,49 @@ export class ImageViewer {
   }
 
   /**
-   * Performs a one-step zoom action.
+ * Performs a one-step pinch zoom action.
+ * @param {number} centerClientX
+ * @param {number} centerClientY
+ * @param {number} deltaX
+ * @param {number} deltaY
+ *  @param {number} dir
+ * @private
+ */
+  onPinchZoom_(centerClientX, centerClientY, deltaX, deltaY, dir) {
+    this.onZoomInc_(centerClientX, centerClientY, deltaX, deltaY, dir);
+  }
+
+/**
+   * Performs a one-step tap zoom action.
    * @param {number} centerClientX
    * @param {number} centerClientY
    * @param {number} deltaX
    * @param {number} deltaY
    * @private
    */
-  onZoomInc_(centerClientX, centerClientY, deltaX, deltaY) {
-    const dist = Math.sqrt(deltaX * deltaX + deltaY * deltaY);
 
-    const zoomSign = Math.abs(deltaY) > Math.abs(deltaX) ?
-        Math.sign(deltaY) : Math.sign(-deltaX);
-    if (zoomSign == 0) {
+  onTapZoom_(centerClientX, centerClientY, deltaX, deltaY) {
+    const dir = Math.abs(deltaY) > Math.abs(deltaX) ?
+      Math.sign(deltaY) : Math.sign(-deltaX);
+    this.onZoomInc_(centerClientX, centerClientY, deltaX, deltaY, dir);
+  }
+
+  /**
+   * Given center position, zoom delta, and zoom position, computes
+   * and updates a zoom action on the image.
+   * @param {number} centerClientX
+   * @param {number} centerClientY
+   * @param {number} deltaX
+   * @param {number} deltaY
+   * @param {number} dir
+   * @private
+   */
+  onZoomInc_(centerClientX, centerClientY, deltaX, deltaY, dir) {
+    if (dir == 0) {
       return;
     }
-
-    const newScale = this.startScale_ * (1 + zoomSign * dist / 100);
+    const dist = Math.sqrt(deltaX * deltaX + deltaY * deltaY);
+    const newScale = this.startScale_ * (1 + dir * dist / 100);
     const deltaCenterX = this.viewerBox_.width / 2 - centerClientX;
     const deltaCenterY = this.viewerBox_.height / 2 - centerClientY;
     deltaX = Math.min(deltaCenterX, deltaCenterX * (dist / 100));
@@ -549,7 +586,8 @@ export class ImageViewer {
    * @return {!Promise}
    * @private
    */
-  onZoomRelease_(centerClientX, centerClientY, deltaX, deltaY, veloX, veloY) {
+  onTapZoomRelease_(centerClientX, centerClientY,
+    deltaX, deltaY, veloX, veloY) {
     let promise;
     if (veloX == 0 && veloY == 0) {
       promise = Promise.resolve();
@@ -557,15 +595,24 @@ export class ImageViewer {
       promise = continueMotion(this.image_,
           deltaX, deltaY, veloX, veloY,
           (x, y) => {
-            this.onZoomInc_(centerClientX, centerClientY, x, y);
+            this.onTapZoom_(centerClientX, centerClientY, x, y);
             return true;
           }).thenAlways();
     }
-
-    const relayout = this.scale_ > this.startScale_;
     return promise.then(() => {
-      return this.release_();
-    }).then(() => {
+      this.onZoomRelease_();
+    });
+  }
+
+  /**
+   * Performs actions after the gesture that was performing zooming has been
+   * released.
+   * @return {!Promise}
+   * @private
+   */
+  onZoomRelease_() {
+    const relayout = this.scale_ > this.startScale_;
+    return this.release_().then(() => {
       if (relayout) {
         this.updateSrc_();
       }

--- a/src/image-viewer.js
+++ b/src/image-viewer.js
@@ -501,19 +501,19 @@ export class ImageViewer {
   }
 
   /**
- * Performs a one-step pinch zoom action.
- * @param {number} centerClientX
- * @param {number} centerClientY
- * @param {number} deltaX
- * @param {number} deltaY
- *  @param {number} dir
- * @private
- */
+   * Performs a one-step pinch zoom action.
+   * @param {number} centerClientX
+   * @param {number} centerClientY
+   * @param {number} deltaX
+   * @param {number} deltaY
+   *  @param {number} dir
+   * @private
+   */
   onPinchZoom_(centerClientX, centerClientY, deltaX, deltaY, dir) {
-    this.onZoomInc_(centerClientX, centerClientY, deltaX, deltaY, dir);
+    this.zoomToPoint_(centerClientX, centerClientY, deltaX, deltaY, dir);
   }
 
-/**
+  /**
    * Performs a one-step tap zoom action.
    * @param {number} centerClientX
    * @param {number} centerClientY
@@ -521,11 +521,10 @@ export class ImageViewer {
    * @param {number} deltaY
    * @private
    */
-
   onTapZoom_(centerClientX, centerClientY, deltaX, deltaY) {
     const dir = Math.abs(deltaY) > Math.abs(deltaX) ?
       Math.sign(deltaY) : Math.sign(-deltaX);
-    this.onZoomInc_(centerClientX, centerClientY, deltaX, deltaY, dir);
+    this.zoomToPoint_(centerClientX, centerClientY, deltaX, deltaY, dir);
   }
 
   /**
@@ -538,7 +537,7 @@ export class ImageViewer {
    * @param {number} dir
    * @private
    */
-  onZoomInc_(centerClientX, centerClientY, deltaX, deltaY, dir) {
+  zoomToPoint_(centerClientX, centerClientY, deltaX, deltaY, dir) {
     if (dir == 0) {
       return;
     }

--- a/test/functional/test-gesture-recognizers.js
+++ b/test/functional/test-gesture-recognizers.js
@@ -622,10 +622,11 @@ describe('PinchRecognizer', () => {
   }
 
 
-  it('should deny single-point touchstart', () => {
+  it('should wait and listen on single-point touchstart', () => {
+    gesturesMock.expects('signalReady_').never();
     const res = recognizer.onTouchStart({touches:
         [{clientX: 101, clientY: 201}]});
-    expect(res).to.equal(false);
+    expect(res).to.equal(true);
     expect(recognizer.startX1_).to.equal(0);
     expect(recognizer.startY1_).to.equal(0);
     expect(recognizer.startX2_).to.equal(0);
@@ -656,11 +657,11 @@ describe('PinchRecognizer', () => {
     expect(recognizer.startY2_).to.equal(120);
 
     res = recognizer.onTouchMove({touches:
-    [{clientX: 88, clientY: 78},
+    [{clientX: 89, clientY: 79},
          {clientX: 112, clientY: 122}]});
     expect(res).to.equal(true);
-    expect(recognizer.lastX1_).to.equal(88);
-    expect(recognizer.lastY1_).to.equal(78);
+    expect(recognizer.lastX1_).to.equal(89);
+    expect(recognizer.lastY1_).to.equal(79);
     expect(recognizer.lastX2_).to.equal(112);
     expect(recognizer.lastY2_).to.equal(122);
   });


### PR DESCRIPTION
This PR adds basic pinch zoom to `amp-lightbox-viewer` via `image-viewer`, tested on Android/Chrome (iOS testing in progress). 

Some small tweaks were made to the behavior of `PinchRecognizer` and `SwipeXYRecognizer` because the default implementation keeps causing pinches to be miscategorized as swipes. Comments inline. 

TODOs: 
- [x] iOS testing. 
- [x] fix tests. (Forgot that `GestureRecognizers` have lovely and elaborate tests).

Added a `event.preventDefault()` for iOS safari. The pinch zoom is now pretty smooth. =) 