### PR TITLE
Doubleclick render idle throttle

### DIFF
--- a/build-system/dep-check-config.js
+++ b/build-system/dep-check-config.js
@@ -248,7 +248,6 @@ exports.rules = [
     filesMatching: 'extensions/**/*-ad-network-*.js',
     mustNotDependOn: [
       'extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js',
-      'extensions/amp-ad/0.1/concurrent-load.js',
       'src/3p-frame.js',
       'src/iframe-helper.js',
     ],

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -252,9 +252,6 @@ export class AmpA4A extends AMP.BaseElement {
      */
     this.promiseId_ = 0;
 
-    /** {?Object} */
-    this.config = null;
-
     /** @private {?string} */
     this.adUrl_ = null;
 
@@ -266,9 +263,6 @@ export class AmpA4A extends AMP.BaseElement {
 
     /** @private {?AMP.AmpAdXOriginIframeHandler} */
     this.xOriginIframeHandler_ = null;
-
-    /** @const @private {!../../../src/service/vsync-impl.Vsync} */
-    this.vsync_ = this.getVsync();
 
     /** @private {boolean} whether creative has been verified as AMP */
     this.isVerifiedAmpCreative_ = false;
@@ -407,6 +401,16 @@ export class AmpA4A extends AMP.BaseElement {
   /** @override */
   isRelayoutNeeded() {
     return this.isRelayoutNeededFlag;
+  }
+
+  /**
+   * @return {!Promise<boolean>} promise blocked on ad promise whose result is
+   *    whether creative returned is validated as AMP.
+   */
+  isVerifiedAmpCreativePromise() {
+    this.verifyStillCurrent();
+    return this.adPromise_.then(
+        () => this.verifyStillCurrent() && this.isVerifiedAmpCreative_);
   }
 
   /** @override */

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -408,9 +408,7 @@ export class AmpA4A extends AMP.BaseElement {
    *    whether creative returned is validated as AMP.
    */
   isVerifiedAmpCreativePromise() {
-    this.verifyStillCurrent();
-    return this.adPromise_.then(
-        () => this.verifyStillCurrent() && this.isVerifiedAmpCreative_);
+    return this.adPromise_.then(() => this.isVerifiedAmpCreative_);
   }
 
   /** @override */

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -300,9 +300,6 @@ describe('amp-a4a', () => {
       a4a.buildCallback();
       a4a.onLayoutMeasure();
       return a4a.layoutCallback().then(() => {
-        // Force vsync system to run all queued tasks, so that DOM mutations
-        // are actually completed before testing.
-        a4a.vsync_.runScheduledTasks_();
         const child = a4aElement.querySelector('iframe[name]');
         expect(child).to.be.ok;
         expect(child).to.be.visible;
@@ -407,7 +404,6 @@ describe('amp-a4a', () => {
       a4a.buildCallback();
       a4a.onLayoutMeasure();
       return a4a.layoutCallback().then(() => {
-        a4a.vsync_.runScheduledTasks_();
         expect(a4a.friendlyIframeEmbed_).to.exist;
         expect(a4a.friendlyIframeEmbed_.isVisible()).to.be.false;
 
@@ -607,9 +603,6 @@ describe('amp-a4a', () => {
 
       it('should attach a NameFrame when header is set', () => {
         return a4a.layoutCallback().then(() => {
-          // Force vsync system to run all queued tasks, so that DOM mutations
-          // are actually completed before testing.
-          a4a.vsync_.runScheduledTasks_();
           verifyNameFrameRender(a4aElement);
           expect(fetchMock.called('ad')).to.be.true;
         });
@@ -622,9 +615,6 @@ describe('amp-a4a', () => {
         a4a.onLayoutMeasure();
         a4a.onLayoutMeasure();
         return a4a.layoutCallback().then(() => {
-          // Force vsync system to run all queued tasks, so that DOM mutations
-          // are actually completed before testing.
-          a4a.vsync_.runScheduledTasks_();
           verifyNameFrameRender(a4aElement);
           expect(fetchMock.called('ad')).to.be.true;
         });
@@ -642,9 +632,6 @@ describe('amp-a4a', () => {
                   adResponse.headers[RENDERING_TYPE_HEADER] = headerVal;
                   a4a.onLayoutMeasure();
                   return a4a.layoutCallback().then(() => {
-                    // Force vsync system to run all queued tasks, so that
-                    // DOM mutations are actually completed before testing.
-                    a4a.vsync_.runScheduledTasks_();
                     const nameChild = a4aElement.querySelector(
                         'iframe[src^="nameframe"]');
                     expect(nameChild).to.not.be.ok;
@@ -679,9 +666,6 @@ describe('amp-a4a', () => {
 
       it('should attach a SafeFrame when header is set', () => {
         return a4a.layoutCallback().then(() => {
-          // Force vsync system to run all queued tasks, so that DOM mutations
-          // are actually completed before testing.
-          a4a.vsync_.runScheduledTasks_();
           verifySafeFrameRender(a4aElement, DEFAULT_SAFEFRAME_VERSION);
           expect(fetchMock.called('ad')).to.be.true;
         });
@@ -690,9 +674,6 @@ describe('amp-a4a', () => {
       it('should use safeframe version header value', () => {
         a4a.safeframeVersion = '1-2-3';
         return a4a.layoutCallback().then(() => {
-          // Force vsync system to run all queued tasks, so that DOM mutations
-          // are actually completed before testing.
-          a4a.vsync_.runScheduledTasks_();
           verifySafeFrameRender(a4aElement, '1-2-3');
           expect(fetchMock.called('ad')).to.be.true;
         });
@@ -705,9 +686,6 @@ describe('amp-a4a', () => {
         a4a.onLayoutMeasure();
         a4a.onLayoutMeasure();
         return a4a.layoutCallback().then(() => {
-          // Force vsync system to run all queued tasks, so that DOM mutations
-          // are actually completed before testing.
-          a4a.vsync_.runScheduledTasks_();
           verifySafeFrameRender(a4aElement, DEFAULT_SAFEFRAME_VERSION);
           expect(fetchMock.called('ad')).to.be.true;
         });
@@ -722,9 +700,6 @@ describe('amp-a4a', () => {
                   adResponse.headers[RENDERING_TYPE_HEADER] = headerVal;
                   a4a.onLayoutMeasure();
                   return a4a.layoutCallback().then(() => {
-                    // Force vsync system to run all queued tasks, so that
-                    // DOM mutations are actually completed before testing.
-                    a4a.vsync_.runScheduledTasks_();
                     const safeframeUrl = 'https://tpc.googlesyndication.com/safeframe/' +
                       DEFAULT_SAFEFRAME_VERSION + '/html/container.html';
                     const safeChild = a4aElement.querySelector(
@@ -743,16 +718,9 @@ describe('amp-a4a', () => {
 
       it('should reset state to null on unlayoutCallback', () => {
         return a4a.layoutCallback().then(() => {
-          // Force vsync system to run all queued tasks, so that DOM mutations
-          // are actually completed before testing.
-          a4a.vsync_.runScheduledTasks_();
           expect(a4a.experimentalNonAmpCreativeRenderMethod_)
               .to.equal('safeframe');
           a4a.unlayoutCallback();
-          // QUESTION TO REVIEWERS: Do we really need the vsync.mutate in
-          // AmpA4A.unlayoutCallback?  We have an open question there about
-          // whether it's necessary or perhaps hazardous.  Feedback welcome.
-          a4a.vsync_.runScheduledTasks_();
           expect(a4a.experimentalNonAmpCreativeRenderMethod_).to.be.null;
           expect(fetchMock.called('ad')).to.be.true;
         });
@@ -792,9 +760,6 @@ describe('amp-a4a', () => {
         a4a.buildCallback();
         a4a.onLayoutMeasure();
         return a4a.layoutCallback().then(() => {
-          // Force vsync system to run all queued tasks, so that DOM mutations
-          // are actually completed before testing.
-          a4a.vsync_.runScheduledTasks_();
           verifyA4ARender(a4aElement);
         });
       });
@@ -842,9 +807,6 @@ describe('amp-a4a', () => {
       a4a.onLayoutMeasure();
       const renderPromise = a4a.layoutCallback();
       return renderPromise.then(() => {
-        // Force vsync system to run all queued tasks, so that DOM mutations
-        // are actually completed before testing.
-        a4a.vsync_.runScheduledTasks_();
         const child = a4aElement.querySelector('iframe[name]');
         expect(child).to.be.ok;
         expect(child.getAttribute('width')).to.equal('320');
@@ -1763,9 +1725,6 @@ describe('amp-a4a', () => {
         // This is to prevent `applyUnlayoutUI` to be called;
         a4a.uiHandler.state = 0;
         a4a.unlayoutCallback();
-        // Force vsync system to run all queued tasks, so that DOM mutations
-        // are actually completed before testing.
-        a4a.vsync_.runScheduledTasks_();
         whenFirstVisibleResolve();
         return adPromise.then(unusedError => {
           assert.fail('cancelled ad promise should not succeed');
@@ -2037,9 +1996,6 @@ describe('amp-a4a', () => {
             a4a.buildCallback();
             a4a.onLayoutMeasure();
             return a4a.layoutCallback().then(() => {
-              // Force vsync system to run all queued tasks, so that DOM mutations
-              // are actually completed before testing.
-              a4a.vsync_.runScheduledTasks_();
               expect(a4aElement.querySelector('iframe[src]')).to.be.ok;
               expect(a4aElement.querySelector('iframe[srcdoc]')).to.not.be.ok;
             });
@@ -2054,9 +2010,6 @@ describe('amp-a4a', () => {
         a4a.buildCallback();
         a4a.onLayoutMeasure();
         return a4a.layoutCallback().then(() => {
-             // Force vsync system to run all queued tasks, so that DOM mutations
-             // are actually completed before testing.
-          a4a.vsync_.runScheduledTasks_();
           verifyA4ARender(a4aElement);
         });
       });
@@ -2069,9 +2022,6 @@ describe('amp-a4a', () => {
         a4a.buildCallback();
         a4a.onLayoutMeasure();
         return a4a.layoutCallback().then(() => {
-          // Force vsync system to run all queued tasks, so that DOM mutations
-          // are actually completed before testing.
-          a4a.vsync_.runScheduledTasks_();
           expect(a4aElement.querySelector('iframe[src]')).to.be.ok;
           expect(a4aElement.querySelector('iframe[srcdoc]')).to.not.be.ok;
         });

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -27,6 +27,7 @@ import {
   DEFAULT_SAFEFRAME_VERSION,
   assignAdUrlToError,
 } from '../../amp-a4a/0.1/amp-a4a';
+import {is3pThrottled} from '../../amp-ad/0.1/concurrent-load';
 import {RTC_VENDORS} from '../../amp-a4a/0.1/callout-vendors';
 import {
   experimentFeatureEnabled,
@@ -374,6 +375,9 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
      * indicates no creative render.
      */
     this.isAmpCreative_ = null;
+
+    /** @private {boolean} */
+    this.isIdleRender_ = false;
   }
 
   /** @override */
@@ -384,6 +388,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     if (isNaN(vpRange) || this.element.getAttribute('data-loading-strategy')) {
       return false;
     }
+    this.isIdleRender_ = true;
     return vpRange;
   }
 
@@ -809,6 +814,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     this.ampAnalyticsConfig_ = null;
     this.jsonTargeting_ = null;
     this.isAmpCreative_ = null;
+    this.isIdleRender_ = false;
     // Reset SRA requests to allow for resumeCallback to re-fetch
     // ad requests.  Assumes that unlayoutCallback will be called for all slots
     // in rapid succession (meaning onLayoutMeasure initiated promise chain
@@ -823,12 +829,26 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
 
   /** @override */
   layoutCallback() {
-    if (this.isFluid_) {
-      this.registerListenerForFluid_();
+    const registerFluidAndExec = () => {
+      if (this.isFluid_) {
+        this.registerListenerForFluid_();
+      }
+      return super.layoutCallback();
+    };
+    if (this.postAdResponseExperimentFeatures['render-idle-throttle'] &&
+        this.isIdleRender_) {
+      return this.isVerifiedAmpCreativePromise().then(verified => {
+        // Control concurrent loading of non-AMP creatives executed via
+        // idleRenderOutsideViewport as doing so within
+        // idleRenderOutsideViewport would impose at least 5 second delay due to
+        // scheduler constraints.
+        const throttleFn = () => !verified && is3pThrottled(this.win) ?
+            Services.timerFor(this.win).delay(throttleFn, 1000) :
+            registerFluidAndExec();
+        return throttleFn();
+      });
     }
-    // TODO(keithwrightbos): consider enforcing concurrent load throttle for
-    // non-AMP creatives loaded via idleRenderOutsideViewport.
-    return super.layoutCallback();
+    return registerFluidAndExec();
   }
 
   /** @override  */

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -26,6 +26,7 @@ import {
   VerificationStatus,
 } from '../../../amp-a4a/0.1/signature-verifier';
 import {Services} from '../../../../src/services';
+import {Timer} from '../../../../src/service/timer-impl';
 import {
   AmpAdNetworkDoubleclickImpl,
   getNetworkId,
@@ -101,7 +102,6 @@ function createImplTag(config, element, impl, env) {
   impl.win['goog_identity_prom'] = Promise.resolve({});
   return [element, impl, env];
 }
-
 
 describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
   let win, doc, ampdoc;
@@ -1347,6 +1347,7 @@ describes.realWin('additional amp-ad-network-doubleclick-impl',
         it('should use experiment value', () => {
           impl.postAdResponseExperimentFeatures['render-idle-vp'] = '4';
           expect(impl.idleRenderOutsideViewport()).to.equal(4);
+          expect(impl.isIdleRender_).to.be.true;
         });
 
         it('should return false if using loading strategy', () => {
@@ -1354,11 +1355,83 @@ describes.realWin('additional amp-ad-network-doubleclick-impl',
           impl.element.setAttribute('data-loading-strategy',
               'prefer-viewability-over-views');
           expect(impl.idleRenderOutsideViewport()).to.be.false;
+          expect(impl.isIdleRender_).to.be.false;
         });
 
         it('should return false if invalid experiment value', () => {
           impl.postAdResponseExperimentFeatures['render-idle-vp'] = 'abc';
           expect(impl.idleRenderOutsideViewport()).to.be.false;
+          expect(impl.isIdleRender_).to.be.false;
+        });
+      });
+
+      describe('idle render layoutCallback', () => {
+        let attemptToRenderCreativeStub;
+        let isVerifiedAmpCreativePromiseStub;
+
+        beforeEach(() => {
+          element = createElementWithAttributes(doc, 'amp-ad', {
+            'width': '200',
+            'height': '50',
+            'type': 'doubleclick',
+          });
+          impl = new AmpAdNetworkDoubleclickImpl(element);
+          impl.postAdResponseExperimentFeatures['render-idle-vp'] = '4';
+          impl.postAdResponseExperimentFeatures['render-idle-throttle'] =
+              'true';
+          attemptToRenderCreativeStub =
+              sandbox.stub(impl, 'attemptToRenderCreative')
+              .returns(Promise.resolve());
+          isVerifiedAmpCreativePromiseStub =
+              sandbox.stub(impl, 'isVerifiedAmpCreativePromise');
+          sandbox.stub(Timer.prototype, 'delay')
+              .callsFake((fn, timeout) => {
+                expect(timeout).to.equal(1000);
+                impl.win['3pla']--;
+                return fn();
+              });
+        });
+
+        it('should throttle if idle render and non-AMP creative', () => {
+          isVerifiedAmpCreativePromiseStub.returns(Promise.resolve(false));
+          impl.win['3pla'] = 1;
+          expect(impl.idleRenderOutsideViewport()).to.equal(4);
+          return impl.layoutCallback().then(() => {
+            expect(impl.win['3pla']).to.equal(0);
+            expect(attemptToRenderCreativeStub).to.be.calledOnce;
+          });
+        });
+
+        it('should NOT throttle if idle experiment not enabled', () => {
+          isVerifiedAmpCreativePromiseStub.returns(Promise.resolve(false));
+          delete impl.postAdResponseExperimentFeatures['render-idle-vp'];
+          impl.win['3pla'] = 1;
+          expect(impl.idleRenderOutsideViewport()).to.be.false;
+          return impl.layoutCallback().then(() => {
+            expect(impl.win['3pla']).to.equal(1);
+            expect(attemptToRenderCreativeStub).to.be.calledOnce;
+          });
+        });
+
+        it('should NOT throttle if experiment throttle not enabled', () => {
+          isVerifiedAmpCreativePromiseStub.returns(Promise.resolve(false));
+          delete impl.postAdResponseExperimentFeatures['render-idle-throttle'];
+          impl.win['3pla'] = 1;
+          expect(impl.idleRenderOutsideViewport()).to.equal(4);
+          return impl.layoutCallback().then(() => {
+            expect(impl.win['3pla']).to.equal(1);
+            expect(attemptToRenderCreativeStub).to.be.calledOnce;
+          });
+        });
+
+        it('should NOT throttle if idle render and AMP creative', () => {
+          isVerifiedAmpCreativePromiseStub.returns(Promise.resolve(true));
+          impl.win['3pla'] = 1;
+          expect(impl.idleRenderOutsideViewport()).to.equal(4);
+          return impl.layoutCallback().then(() => {
+            expect(impl.win['3pla']).to.equal(1);
+            expect(attemptToRenderCreativeStub).to.be.calledOnce;
+          });
         });
       });
     });


### PR DESCRIPTION
For doubleclick Fast Fetch experiment allowing render beyond 3 viewports when scheduler is idle.  Currently up to 4 amp-ad slots call layoutCallback simultaneously despite the possible render of multiple non-AMP validated creatives.  This PR addresses this inconsistency by enforcing same 1 second throttle if experiment is enabled (controlled via header on response).