### PR TITLE
Don't load responsive ad if tag height is not AdSense whitelisted height

### DIFF
--- a/ads/google/adsense.js
+++ b/ads/google/adsense.js
@@ -15,8 +15,10 @@
  */
 
 import {validateData} from '../../3p/3p';
+import {user} from '../../src/log';
 import {setStyles} from '../../src/style';
 import {camelCaseToDash} from '../../src/string';
+import {ADSENSE_RSPV_WHITELISTED_HEIGHT} from './utils';
 
 /**
  * Make an adsense iframe.
@@ -28,6 +30,14 @@ export function adsense(global, data) {
   validateData(data, [],
       ['adClient', 'adSlot', 'adHost', 'adtest', 'tagOrigin', 'experimentId',
         'ampSlotIndex', 'adChannel', 'autoFormat', 'fullWidth']);
+
+  user().assert(
+      data['autoFormat'] !== 'rspv' ||
+        data['height'] == ADSENSE_RSPV_WHITELISTED_HEIGHT,
+      'Specified height ' + data['height'] +
+      ' in <amp-ad> tag is not equal to the required height of ' +
+      ADSENSE_RSPV_WHITELISTED_HEIGHT +
+      ' for responsive AdSense ad units.');
 
   if (global.context.clientId) {
     // Read by GPT for GA/GPT integration.

--- a/ads/google/test/test-adsense.js
+++ b/ads/google/test/test-adsense.js
@@ -71,4 +71,10 @@ describes.realWin('adsenseDelayedFetch', {}, env => {
       hid: pageViewId,
     });
   });
+
+  it('throws on invalid responsive ad unit height', () => {
+    const data = {'autoFormat': 'rspv', 'height': '666'};
+    expect(() => adsense(env.win, data)).to.throw(
+        /Specified height 666 in <amp-ad> tag is not equal to the required/);
+  });
 });

--- a/ads/google/utils.js
+++ b/ads/google/utils.js
@@ -17,6 +17,12 @@
 import {user} from '../../src/log';
 
 /**
+ * Approved height for AdSense full-width responsive ads.
+ * @const {number}
+ */
+export const ADSENSE_RSPV_WHITELISTED_HEIGHT = 320;
+
+/**
  * Given the amp-ad data attribute containing the multi-size dimensions, and a
  * set of primary dimensions, this function will return all valid multi-size
  * [width, height] pairs in an array.

--- a/examples/a4a-fullwidth.amp.html
+++ b/examples/a4a-fullwidth.amp.html
@@ -76,7 +76,7 @@
     ac posuere velit semper.
   </p>
 
-  <amp-ad width="100vw" height=150
+  <amp-ad width="100vw" height=320
           type="adsense"
           data-ad-client="ca-pub-2383777339857329"
           data-ad-slot="4121425836"
@@ -97,7 +97,7 @@
 
 
   <div class="further-indent">
-    <amp-ad width="100vw" height=150
+    <amp-ad width="100vw" height=320
             type="adsense"
             data-ad-client="ca-pub-2383777339857329"
             data-ad-slot="4121425836"
@@ -142,7 +142,7 @@
     nec lectus finibus rutrum vel sed orci.
   </p>
 
-  <amp-ad width="100vw" height=150
+  <amp-ad width="100vw" height=320
           type="adsense"
           data-ad-client="ca-pub-2383777339857329"
           data-ad-slot="4121425836"

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -49,7 +49,7 @@ import {
 import {removeElement} from '../../../src/dom';
 import {getMode} from '../../../src/mode';
 import {stringHash32} from '../../../src/string';
-import {dev} from '../../../src/log';
+import {dev, user} from '../../../src/log';
 import {Services} from '../../../src/services';
 import {domFingerprintPlain} from '../../../src/utils/dom-fingerprint';
 import {clamp} from '../../../src/utils/math';
@@ -63,6 +63,7 @@ import {insertAnalyticsElement} from '../../../src/extension-analytics';
 import {
   getAdSenseAmpAutoAdsExpBranch,
 } from '../../../ads/google/adsense-amp-auto-ads';
+import {ADSENSE_RSPV_WHITELISTED_HEIGHT} from '../../../ads/google/utils';
 
 /** @const {string} */
 const ADSENSE_BASE_URL = 'https://googleads.g.doubleclick.net/pagead/ads';
@@ -154,6 +155,7 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
   /**
    * @return {boolean}
    * @private
+   * @visibleForTesting
    */
   isResponsive_() {
     return this.autoFormat_ == 'rspv';
@@ -168,6 +170,16 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
      * to an amp-ad-adsense element. Thus, if we are an amp-ad, we can be sure
      * that it has been verified.
      */
+    const height = this.element.getAttribute('height');
+    if (this.isResponsive_() &&
+        height != ADSENSE_RSPV_WHITELISTED_HEIGHT) {
+      user().error(TAG,
+          'Specified height ' + height +
+          ' in <amp-ad> tag is not equal to the required height of ' +
+          ADSENSE_RSPV_WHITELISTED_HEIGHT +
+          ' for responsive AdSense ad units.');
+      return false;
+    }
     return !!this.element.getAttribute('data-ad-client') &&
         this.isAmpAdElement();
   }

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
@@ -59,6 +59,7 @@ describes.realWin('amp-ad-network-adsense-impl', {
   let win, doc, ampdoc, viewer;
   let impl;
   let element;
+  let isResponsiveStub;
 
   beforeEach(() => {
     win = env.win;
@@ -82,6 +83,7 @@ describes.realWin('amp-ad-network-adsense-impl', {
     doc.body.appendChild(element);
     impl = new AmpAdNetworkAdsenseImpl(element);
     impl.win['goog_identity_prom'] = Promise.resolve({});
+    isResponsiveStub = sandbox.stub(impl, 'isResponsive_');
   });
 
   /**
@@ -112,8 +114,14 @@ describes.realWin('amp-ad-network-adsense-impl', {
       expect(impl.isValidElement()).to.be.true;
     });
     it('should be valid (responsive)', () => {
-      element.setAttribute('data-auto-format', 'rspv');
+      isResponsiveStub.callsFake(() => true);
+      element.setAttribute('height', '320');
       expect(impl.isValidElement()).to.be.true;
+    });
+    it('should NOT be valid (responsive with wrong height)', () => {
+      isResponsiveStub.callsFake(() => true);
+      element.setAttribute('height', '666');
+      expect(impl.isValidElement()).to.be.false;
     });
     it('should NOT be valid (impl tag name)', () => {
       element = createAdsenseImplElement({'data-ad-client': 'ca-adsense'},
@@ -121,7 +129,7 @@ describes.realWin('amp-ad-network-adsense-impl', {
       impl = new AmpAdNetworkAdsenseImpl(element);
       expect(impl.isValidElement()).to.be.false;
     });
-    it('should be NOT valid (missing ad client)', () => {
+    it('should NOT be valid (missing ad client)', () => {
       element.setAttribute('data-ad-client', '');
       element.setAttribute('type', 'adsense');
       expect(impl.isValidElement()).to.be.false;


### PR DESCRIPTION
Prevent tampering with height attribute in AdSense responsive ad tags