### PR TITLE
Fix heroku deployment scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
     "dist": "gulp dist",
     "heroku-postbuild": "npm run test-env-var && gulp clean && gulp build --fortesting && gulp dist --fortesting && npm run prepend-amp && npm run prepend-v0",
     "test-env-var": "if [ -z \"${AMP_TESTING_HOST}\" ]; then echo \"ERROR: Please set the 'AMP_TESTING_HOST' environment variable. If you are in heroku this can be set by executing 'heroku config:set AMP_TESTING_HOST=my-heroku-subdomain.herokuapp.com' on the command line.\"; exit 1; fi",
-    "prepend-amp": "gulp prepend-global --prod node_modules/AMP_CONFIG.json --local --target dist/amp.js && gulp prepend-global --prod node_modules/AMP_CONFIG.json --local --target dist.3p/current/integration.js",
-    "prepend-v0": "gulp prepend-global --prod node_modules/AMP_CONFIG.json --local --target dist/v0.js && gulp prepend-global --prod node_modules/AMP_CONFIG.json --local --target dist.3p/current-min/f.js",
+    "prepend-amp": "gulp prepend-global --prod node_modules/AMP_CONFIG.json --local_branch --target dist/amp.js && gulp prepend-global --prod node_modules/AMP_CONFIG.json --local_branch --target dist.3p/current/integration.js",
+    "prepend-v0": "gulp prepend-global --prod node_modules/AMP_CONFIG.json --local_branch --target dist/v0.js && gulp prepend-global --prod node_modules/AMP_CONFIG.json --local_branch --target dist.3p/current-min/f.js",
     "preinstall": "node build-system/check-package-manager.js"
   },
   "dependencies": {


### PR DESCRIPTION
In #12152, the `--local` flag for `gulp prepend-loal` was renamed to `--local_branch` to disambiguate it from the other flag `--local_dev`.

This PR applies that change to the heroku deployment scripts in `package.json`.