### PR TITLE
Fix cloned node dupe id causing activation to fail on non images

### DIFF
--- a/extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.js
+++ b/extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.js
@@ -198,6 +198,7 @@ export class AmpLightboxViewer extends AMP.BaseElement {
                 'i-amphtml-element');
             const clonedNode = element.cloneNode(deepClone);
             clonedNode.removeAttribute('on');
+            clonedNode.removeAttribute('id');
             const descText = this.manager_.getDescription(element);
             const metadata = {
               descriptionText: descText,


### PR DESCRIPTION
`cloneNode` results in duplicate ids. This causes activate with the id argument to break, which means that the open video in lightbox by clicking on button, open tweet in lightbox by clicking on button functionality doesn't work. Removing the id attribute fixes this. The clonedNodes are managed separately by the carousel and do not need an id attribute. 