### PR TITLE
Warn that use of Doubleclick.js will no longer be possible coming march 29 2018

### DIFF
--- a/ads/criteo.js
+++ b/ads/criteo.js
@@ -17,6 +17,7 @@
 import {computeInMasterFrame, loadScript} from '../3p/3p';
 import {doubleclick} from '../ads/google/doubleclick';
 import {tryParseJson} from '../src/json';
+import {user} from '../src/log';
 
 /* global Criteo: false */
 
@@ -77,6 +78,12 @@ function setTargeting(global, data, targeting) {
       dblParams['targeting'][i] = targeting[i];
     }
 
+    user().warn(
+        'DOUBLECLICK', 'Delayed Fetch for DoubleClick will be' +
+        'removed by March 29, 2018. Any use of this file will cease' +
+        'to work at that time. Please refer to ' +
+        'https://github.com/ampproject/amphtml/issues/11834 ' +
+        'for more information');
     doubleclick(global, dblParams);
   }
 }

--- a/ads/google/doubleclick.js
+++ b/ads/google/doubleclick.js
@@ -16,7 +16,7 @@
 
 import {makeCorrelator} from './correlator';
 import {validateData, loadScript} from '../../3p/3p';
-import {dev} from '../../src/log';
+import {dev, user} from '../../src/log';
 import {setStyles} from '../../src/style';
 import {getMultiSizeDimensions} from './utils';
 
@@ -36,6 +36,12 @@ const GladeExperiment = {
  * @param {!Object} data
  */
 export function doubleclick(global, data) {
+  user().warn(
+      'DOUBLECLICK', 'Delayed Fetch for DoubleClick will be' +
+      'removed by March 29, 2018. Any use of this file will cease' +
+      'to work at that time. Please refer to ' +
+      'https://github.com/ampproject/amphtml/issues/11834 ' +
+      'for more information');
   // TODO: check mandatory fields
   validateData(data, [], [
     'slot', 'targeting', 'categoryExclusions',

--- a/ads/google/doubleclick.js
+++ b/ads/google/doubleclick.js
@@ -16,7 +16,7 @@
 
 import {makeCorrelator} from './correlator';
 import {validateData, loadScript} from '../../3p/3p';
-import {dev, user} from '../../src/log';
+import {dev} from '../../src/log';
 import {setStyles} from '../../src/style';
 import {getMultiSizeDimensions} from './utils';
 
@@ -36,12 +36,6 @@ const GladeExperiment = {
  * @param {!Object} data
  */
 export function doubleclick(global, data) {
-  user().warn(
-      'DOUBLECLICK', 'Delayed Fetch for DoubleClick will be' +
-      'removed by March 29, 2018. Any use of this file will cease' +
-      'to work at that time. Please refer to ' +
-      'https://github.com/ampproject/amphtml/issues/11834 ' +
-      'for more information');
   // TODO: check mandatory fields
   validateData(data, [], [
     'slot', 'targeting', 'categoryExclusions',

--- a/ads/medianet.js
+++ b/ads/medianet.js
@@ -17,6 +17,7 @@
 import {writeScript, validateData, computeInMasterFrame} from '../3p/3p';
 import {getSourceUrl} from '../src/url';
 import {doubleclick} from '../ads/google/doubleclick';
+import {user} from '../src/log';
 
 const mandatoryParams = ['tagtype', 'cid'],
     optionalParams = [
@@ -160,6 +161,12 @@ function loadHBTag(global, data, publisherUrl, referrerUrl) {
       global.advBidxc.setAmpTargeting(global, data);
     }
     deleteUnexpectedDoubleclickParams();
+    user().warn(
+        'DOUBLECLICK', 'Delayed Fetch for DoubleClick will be' +
+        'removed by March 29, 2018. Any use of this file will cease' +
+        'to work at that time. Please refer to ' +
+        'https://github.com/ampproject/amphtml/issues/11834 ' +
+        'for more information');
     doubleclick(global, data);
   }
 

--- a/ads/navegg.js
+++ b/ads/navegg.js
@@ -16,6 +16,7 @@
 
 import {loadScript, validateData} from '../3p/3p';
 import {doubleclick} from '../ads/google/doubleclick';
+import {user} from '../src/log';
 
 /**
  * @param {!Window} global
@@ -36,6 +37,12 @@ export function navegg(global, data) {
       for (seg in nvgTargeting) {
         data.targeting[seg] = nvgTargeting[seg];
       };
+      user().warn(
+          'DOUBLECLICK', 'Delayed Fetch for DoubleClick will be' +
+          'removed by March 29, 2018. Any use of this file will cease' +
+          'to work at that time. Please refer to ' +
+          'https://github.com/ampproject/amphtml/issues/11834 ' +
+          'for more information');
       doubleclick(global, data);
     });
   });

--- a/ads/openx.js
+++ b/ads/openx.js
@@ -17,6 +17,7 @@
 import {loadScript, writeScript, validateData} from '../3p/3p';
 import {doubleclick} from '../ads/google/doubleclick';
 import {startsWith} from '../src/string';
+import {user} from '../src/log';
 
 const hasOwnProperty = Object.prototype.hasOwnProperty;
 
@@ -103,6 +104,12 @@ export function openx(global, data) {
       loadScript(global, jssdk);
     }
   } else if (data.dfpSlot) { // Fall back to a DFP ad.
+    user().warn(
+        'DOUBLECLICK', 'Delayed Fetch for DoubleClick will be' +
+        'removed by March 29, 2018. Any use of this file will cease' +
+        'to work at that time. Please refer to ' +
+        'https://github.com/ampproject/amphtml/issues/11834 ' +
+        'for more information');
     doubleclick(global, dfpData);
   }
 }

--- a/ads/pulsepoint.js
+++ b/ads/pulsepoint.js
@@ -16,6 +16,7 @@
 
 import {writeScript, loadScript, validateData} from '../3p/3p';
 import {doubleclick} from '../ads/google/doubleclick';
+import {user} from '../src/log';
 
 /**
  * @param {!Window} global
@@ -60,6 +61,12 @@ function headerBidding(global, data) {
         elementId: 'c',
       }],
       done(targeting) {
+        user().warn(
+            'DOUBLECLICK', 'Delayed Fetch for DoubleClick will be' +
+            'removed by March 29, 2018. Any use of this file will cease' +
+            'to work at that time. Please refer to ' +
+            'https://github.com/ampproject/amphtml/issues/11834 ' +
+            'for more information');
         doubleclick(global, {
           width: data.width,
           height: data.height,

--- a/ads/rubicon.js
+++ b/ads/rubicon.js
@@ -17,6 +17,7 @@
 import {writeScript, loadScript, validateData} from '../3p/3p';
 import {getSourceUrl} from '../src/url';
 import {doubleclick} from '../ads/google/doubleclick';
+import {user} from '../src/log';
 
 /* global rubicontag: false */
 
@@ -92,6 +93,12 @@ function fastLane(global, data) {
     if (data['kw']) { delete data['kw']; }
     if (data['visitor']) { delete data['visitor']; }
     if (data['inventory']) { delete data['inventory']; }
+    user().warn(
+        'DOUBLECLICK', 'Delayed Fetch for DoubleClick will be' +
+        'removed by March 29, 2018. Any use of this file will cease' +
+        'to work at that time. Please refer to ' +
+        'https://github.com/ampproject/amphtml/issues/11834 ' +
+        'for more information');
     doubleclick(global, data);
   }
 

--- a/ads/yieldbot.js
+++ b/ads/yieldbot.js
@@ -17,7 +17,7 @@
 import {validateData, loadScript} from '../3p/3p';
 import {doubleclick} from '../ads/google/doubleclick';
 import {getMultiSizeDimensions} from '../ads/google/utils';
-import {rethrowAsync} from '../src/log';
+import {rethrowAsync, user} from '../src/log';
 
 /**
  * @param {!Window} global
@@ -73,6 +73,12 @@ export function yieldbot(global, data) {
       }
       delete data['ybSlot'];
       delete data['psn'];
+      user().warn(
+          'DOUBLECLICK', 'Delayed Fetch for DoubleClick will be' +
+          'removed by March 29, 2018. Any use of this file will cease' +
+          'to work at that time. Please refer to ' +
+          'https://github.com/ampproject/amphtml/issues/11834 ' +
+          'for more information');
       doubleclick(global, data);
     });
   });

--- a/build-system/dep-check-config.js
+++ b/build-system/dep-check-config.js
@@ -259,4 +259,19 @@ exports.rules = [
       'extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js',
     ],
   },
+
+  {
+    mustNotDependOn: 'ads/google/doubleclick.js',
+    whitelist: [
+      'ads/criteo.js->ads/google/doubleclick.js',
+      'ads/ix.js->ads/google/doubleclick.js',
+      'ads/medianet.js->ads/google/doubleclick.js',
+      'ads/navegg.js->ads/google/doubleclick.js',
+      'ads/openx.js->ads/google/doubleclick.js',
+      'ads/pulsepoint.js->ads/google/doubleclick.js',
+      'ads/rubicon.js->ads/google/doubleclick.js',
+      'ads/yieldbot.js->ads/google/doubleclick.js',
+      '3p/integration.js->ads/google/doubleclick.js',
+    ],
+  },
 ];


### PR DESCRIPTION
Delayed Fetch for Doubleclick is being removed in the coming months. Add warning to make this clear to anyone who is importing and using doubleclick.js 