### PR TITLE
Add a new method, failAfterWarningOrError.

### DIFF
--- a/validator/gulpjs/README.md
+++ b/validator/gulpjs/README.md
@@ -28,6 +28,15 @@ gulp.task('amphtml:validate', () => {
 });
 ```
 
+To treat warnings as errors, replace the last line of the validation closure with:
+
+```js
+// Exit the process with error code (1) if an AMP validation warning or
+// error occurred.
+.pipe(gulpAmpValidator.failAfterWarningOrError());
+
+```
+
 ## Release Notes
 
 ### 1.0.1

--- a/validator/gulpjs/package.json
+++ b/validator/gulpjs/package.json
@@ -20,7 +20,7 @@
     "url": "https://github.com/ampproject/amphtml/tree/master/validator/gulpjs"
   },
   "dependencies": {
-    "amphtml-validator": "1.0.18",
+    "amphtml-validator": "1.0.21",
     "gulp-util": "^3.0.7",
     "through2": "^2.0.1"
   },


### PR DESCRIPTION
If used instead of failAfterError, gulp will effectively consider validator
warnings as errors. I've extracted a helper routine to avoid
duplicating too much code.