### PR TITLE
Add a function to remove a registered gesture recognizer in gestures

### DIFF
--- a/src/gesture.js
+++ b/src/gesture.js
@@ -18,6 +18,8 @@ import {Observable} from './observable';
 import {Pass} from './pass';
 import {dev} from './log';
 import {toWin} from './types';
+import {findIndex} from './utils/array';
+
 
 const PROP_ = '__AMP_Gestures';
 
@@ -171,6 +173,35 @@ export class Gestures {
       this.overservers_[type] = overserver;
     }
     return overserver.add(handler);
+  }
+
+  /**
+   * Unsubscribes all handlers from the given gesture recognizer. Returns
+   * true if anything was done. Returns false if there were no handlers
+   * registered on the given gesture recognizer in first place.
+   *
+   * @param {function(new:GestureRecognizer<DATA>, !Gestures)} recognizerConstr
+   * @return {boolean}
+   */
+  removeGesture(recognizerConstr) {
+    const type = new recognizerConstr(this).getType();
+    const overserver = this.overservers_[type];
+    if (overserver) {
+      overserver.removeAll();
+      const index = findIndex(this.recognizers_, e => e.getType() == type);
+      if (index < 0) {
+        return false;
+      }
+      // Remove the recognizer as well as all associated tracking state
+      this.recognizers_.splice(index, 1);
+      this.ready_.splice(index, 1);
+      this.pending_.splice(index, 1);
+      this.tracking_.splice(index, 1);
+      delete this.overservers_[type];
+      return true;
+    } else {
+      return false;
+    }
   }
 
   /**

--- a/test/functional/test-gesture.js
+++ b/test/functional/test-gesture.js
@@ -355,6 +355,16 @@ describe('Gestures', () => {
     expect(event.stopPropagation).to.have.not.been.called;
   });
 
+  it('should gesture recognizer on removeGesture', () => {
+    expect(gestures.recognizers_.length).to.equal(1);
+    expect(gestures.removeGesture(TestRecognizer)).to.equal(true);
+    expect(gestures.removeGesture(Test2Recognizer)).to.equal(false);
+    expect(gestures.recognizers_.length).to.equal(0);
+    expect(gestures.ready_.length).to.equal(0);
+    expect(gestures.tracking_.length).to.equal(0);
+    expect(gestures.pending_.length).to.equal(0);
+  });
+
   it('should remove listeners and shared cache instance on cleanup', () => {
     const eventNames = ['touchstart', 'touchend', 'touchmove', 'touchcancel'];
     const prop = '__AMP_Gestures';


### PR DESCRIPTION
Closes https://github.com/ampproject/amphtml/issues/12112. 

This is a small PR. Please review the API for this new function and give feedback on whether it seems reasonable. The reason I'm proposing this function is because using `SwipeXY` to pan on `image-viewer` conflicts with using `SwipeY` to swipe-to-close on `amp-lightbox-viewer`. We want to deregister the `SwipeXY` on `image-viewer` when the image isn't scaled. 

This PR enables swipe up to close lightbox, prototype on [feature branch](https://github.com/cathyxz/amphtml/tree/feature/lightbox-swipe-to-close), deployment in progress on [heroku](https://amp-cathyxz.herokuapp.com/test/manual/amp-lightbox-viewer-optin.amp.html) for iOS testing. The actual lightbox swipe to close feature will be in a separate PR that is based off of https://github.com/ampproject/amphtml/pull/12256. 