### PR TITLE
Fix boilerplate test Firefox failure on animation css api update

### DIFF
--- a/test/integration/test-boilerplates.js
+++ b/test/integration/test-boilerplates.js
@@ -54,7 +54,7 @@ describe.configure().run('New Visibility Boilerplate', () => {
       expect(getStyle(
           fixture.win.document.body, 'visibility')).to.equal('visible');
       // Firefox spells out the values when assigning none.
-      const ffValue = '0s ease 0s normal none 1 running none';
+      const ffValue = '0s ease 0s 1 normal none running none';
       const animation = getStyle(fixture.win.document.body, 'animation');
       if (animation == ffValue) {
         expect(animation).to.equal(ffValue);


### PR DESCRIPTION
The original test failure: 
```
New Visibility Boilerplate
IT => should show the body in boilerplate test
✗ expected '0s ease 0s 1 normal none running none' to equal 'none'
```
The test fails because we're expecting firefox to have this value: 
`0s ease 0s normal none 1 running none`
However, the animation css api expects a new order, where the `iteration-count` comes before the `animation-direction`. 

Source: code example from [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/animation)