### PR TITLE
Allow vendors to disable key appending on RTC responses merged for Doubleclick 

### DIFF
--- a/extensions/amp-a4a/0.1/callout-vendors.js
+++ b/extensions/amp-a4a/0.1/callout-vendors.js
@@ -30,4 +30,8 @@ export const RTC_VENDORS = {
     url: 'https://localhost:8000/examples/rtcE1.json?slot_id=SLOT_ID&page_id=PAGE_ID&foo_id=FOO_ID',
     macros: ['SLOT_ID', 'PAGE_ID', 'FOO_ID'],
   },
+  'fakevendor2': {
+    url: 'https://localhost:8000/examples/rtcE1.json?slot_id=SLOT_ID&page_id=PAGE_ID&foo_id=FOO_ID',
+    disableKeyAppend: true,
+  },
 };

--- a/extensions/amp-a4a/0.1/callout-vendors.js
+++ b/extensions/amp-a4a/0.1/callout-vendors.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import {getMode} from '../../../src/mode';
 
 //////////////////////////////////////////////////////////////////
 //                                                              //
@@ -20,19 +21,31 @@
 //       otherwise the vendor endpoint will not be used.        //
 //                                                              //
 //////////////////////////////////////////////////////////////////
+
+// Note: disableKeyAppend is an option specifically for DoubleClick's
+// implementation of RTC. It prevents the vendor ID from being
+// appended onto each key of the RTC response, for each vendor.
+// This appending is done to prevent a collision case during merge
+// that would cause one RTC response to overwrite another if they
+// share key names.
 /** @typedef {{
     url: string,
     macros: Array<string>,
     disableKeyAppend: boolean}} */
 let RtcVendorDef;
+
 /** @const {!Object<string, RtcVendorDef>} */
 export const RTC_VENDORS = {
-  'fakevendor': {
+  // Add vendors here
+};
+
+if (getMode().localDev || getMode().test) {
+  RTC_VENDORS['fakevendor'] = {
     url: 'https://localhost:8000/examples/rtcE1.json?slot_id=SLOT_ID&page_id=PAGE_ID&foo_id=FOO_ID',
     macros: ['SLOT_ID', 'PAGE_ID', 'FOO_ID'],
-  },
-  'fakevendor2': {
+  };
+  RTC_VENDORS['fakevendor2'] = {
     url: 'https://localhost:8000/examples/rtcE1.json?slot_id=SLOT_ID&page_id=PAGE_ID&foo_id=FOO_ID',
     disableKeyAppend: true,
-  },
+  };
 };

--- a/extensions/amp-a4a/0.1/callout-vendors.js
+++ b/extensions/amp-a4a/0.1/callout-vendors.js
@@ -39,13 +39,14 @@ export const RTC_VENDORS = {
   // Add vendors here
 };
 
+// DO NOT MODIFY: Setup for tests
 if (getMode().localDev || getMode().test) {
-  RTC_VENDORS['fakevendor'] = {
+  RTC_VENDORS['fakevendor'] = /** @type {RtcVendorDef} */({
     url: 'https://localhost:8000/examples/rtcE1.json?slot_id=SLOT_ID&page_id=PAGE_ID&foo_id=FOO_ID',
     macros: ['SLOT_ID', 'PAGE_ID', 'FOO_ID'],
-  };
-  RTC_VENDORS['fakevendor2'] = {
+  });
+  RTC_VENDORS['fakevendor2'] = /** @type {RtcVendorDef} */({
     url: 'https://localhost:8000/examples/rtcE1.json?slot_id=SLOT_ID&page_id=PAGE_ID&foo_id=FOO_ID',
     disableKeyAppend: true,
-  };
+  });
 };

--- a/extensions/amp-a4a/0.1/callout-vendors.js
+++ b/extensions/amp-a4a/0.1/callout-vendors.js
@@ -22,7 +22,8 @@
 //////////////////////////////////////////////////////////////////
 /** @typedef {{
     url: string,
-    macros: Array<string>}} */
+    macros: Array<string>,
+    disableKeyAppend: boolean}} */
 let RtcVendorDef;
 /** @const {!Object<string, RtcVendorDef>} */
 export const RTC_VENDORS = {

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -725,7 +725,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
    */
   rewriteRtcKeys_(response, callout) {
     // Only perform this substitution for vendor-defined URLs.
-    if (!RTC_VENDORS[callout]) {
+    if (!RTC_VENDORS[callout] || RTC_VENDORS[callout].disableKeyAppend) {
       return response;
     }
     const newResponse = {};

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-rtc.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-rtc.js
@@ -252,6 +252,16 @@ describes.realWin('DoubleClick Fast Fetch RTC', {amp: true}, env => {
           .to.deep.equal(rewrittenResponse);
     });
 
+    it('should not rewrite key names if vendor has disableKeyAppend', () => {
+      const response = {
+        'a': '1',
+        'b': '2',
+      };
+      // fakevendor2 has disableKeyAppend set to true, see callout-vendors.js
+      expect(impl.rewriteRtcKeys_(response, 'fakevendor2'))
+          .to.deep.equal(response);
+    });
+
     it('should not rewrite key names if custom url callout', () => {
       const response = {
         'a': '1',

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-rtc.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-rtc.js
@@ -86,7 +86,7 @@ describes.realWin('DoubleClick Fast Fetch RTC', {amp: true}, env => {
     });
 
     it('should properly merge RTC responses from vendors', () => {
-      RTC_VENDORS['fakevendor2'] = {
+      RTC_VENDORS['TEMP_VENDOR'] = {
         'url': 'https://fakevendor2.biz',
       };
       const rtcResponseArray = [
@@ -95,17 +95,17 @@ describes.realWin('DoubleClick Fast Fetch RTC', {amp: true}, env => {
         {response: {targeting: {'a': 'foo', 'b': {e: 'f'}}},
           callout: 'www.exampleB.com', rtcTime: 500},
         {response: {targeting: {'a': 'bar'}},
-          callout: 'fakevendor2', rtcTime: 100},
+          callout: 'TEMP_VENDOR', rtcTime: 100},
       ];
       const expectedParams = {
         ati: '2,2,2',
         artc: '100,500,100',
-        ard: 'fakevendor,www.exampleB.com,fakevendor2',
+        ard: 'fakevendor,www.exampleB.com,TEMP_VENDOR',
       };
       const expectedJsonTargeting = {
         targeting: {
           'a': 'foo', 'b': {e: 'f'}, 'a_fakevendor': [1,2,3],
-          'b_fakevendor': {c: 'd'}, 'a_fakevendor2': 'bar'},
+          'b_fakevendor': {c: 'd'}, 'a_TEMP_VENDOR': 'bar'},
       };
       testMergeRtcResponses(
           rtcResponseArray, expectedParams, expectedJsonTargeting);


### PR DESCRIPTION
Doubleclick's Fast Fetch impl merges RTC responses by appending vendor names onto their keys, to disallow collisions. Allow vendors to opt out of this collision protection. 