### PR TITLE
Implement amp-macro element in amp-bind to allow reuse of expressions

### DIFF
--- a/extensions/amp-bind/0.1/amp-bind-macro.js
+++ b/extensions/amp-bind/0.1/amp-bind-macro.js
@@ -16,14 +16,18 @@
 
 /**
  * @typedef {{
- *   name: string,
+ *   id: string,
  *   argumentNames: Array<string>,
  *   expressionString: string
  * }}
  */
 export let AmpMacroDef;
 
-export class AmpMacro extends AMP.BaseElement {
+/**
+ * The amp-bind-macro element is used to define an expression macro that can be
+ * called from other amp-bind expressions within the document.
+ */
+export class AmpBindMacro extends AMP.BaseElement {
   /** @override */
   getPriority() {
     // Loads after other content.
@@ -52,7 +56,7 @@ export class AmpMacro extends AMP.BaseElement {
    * @private
    */
   getName_() {
-    return '<amp-macro> ' +
-        (this.element.getAttribute('name') || '<unknown id>');
+    return '<amp-bind-macro> ' +
+        (this.element.getAttribute('id') || '<unknown id>');
   }
 }

--- a/extensions/amp-bind/0.1/amp-bind.js
+++ b/extensions/amp-bind/0.1/amp-bind.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {AmpMacro} from './amp-macro';
+import {AmpBindMacro} from './amp-bind-macro';
 import {AmpState} from './amp-state';
 import {Bind} from './bind-impl';
 
@@ -24,5 +24,5 @@ const TAG = 'amp-bind';
 AMP.extension(TAG, '0.1', function(AMP) {
   AMP.registerServiceForDoc('bind', Bind);
   AMP.registerElement('amp-state', AmpState);
-  AMP.registerElement('amp-macro', AmpMacro);
+  AMP.registerElement('amp-bind-macro', AmpBindMacro);
 });

--- a/extensions/amp-bind/0.1/amp-bind.js
+++ b/extensions/amp-bind/0.1/amp-bind.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {AmpMacro} from './amp-macro';
 import {AmpState} from './amp-state';
 import {Bind} from './bind-impl';
 
@@ -23,4 +24,5 @@ const TAG = 'amp-bind';
 AMP.extension(TAG, '0.1', function(AMP) {
   AMP.registerServiceForDoc('bind', Bind);
   AMP.registerElement('amp-state', AmpState);
+  AMP.registerElement('amp-macro', AmpMacro);
 });

--- a/extensions/amp-bind/0.1/amp-macro.js
+++ b/extensions/amp-bind/0.1/amp-macro.js
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @typedef {{
+ *   name: string,
+ *   argumentNames: Array<string>,
+ *   expressionString: string
+ * }}
+ */
+export let AmpMacroDef;
+
+export class AmpMacro extends AMP.BaseElement {
+  /** @override */
+  getPriority() {
+    // Loads after other content.
+    return 1;
+  }
+
+  /** @override */
+  isAlwaysFixed() {
+    return true;
+  }
+
+  /** @override */
+  isLayoutSupported(unusedLayout) {
+    return true;
+  }
+
+  /** @override */
+  renderOutsideViewport() {
+    // We want the macro to be available wherever it is in the document.
+    return true;
+  }
+
+  /**
+   * @return {string} Returns a string to identify this tag. May not be unique
+   *     if the element name is not unique.
+   * @private
+   */
+  getName_() {
+    return '<amp-macro> ' +
+        (this.element.getAttribute('name') || '<unknown id>');
+  }
+}

--- a/extensions/amp-bind/0.1/bind-evaluator.js
+++ b/extensions/amp-bind/0.1/bind-evaluator.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {BindMacro} from './bind-macro';
 import {BindExpression} from './bind-expression';
 import {BindValidator} from './bind-validator';
 import {filterSplice} from '../../../src/utils/array';
@@ -43,6 +44,12 @@ export class BindEvaluator {
   constructor() {
     /** @const @private {!Array<BindingDef>} */
     this.bindings_ = [];
+
+    /**
+     * The map of name to macro for all macros on the page
+     * @private @const {!Object<string, !./bind-macro.BindMacro>}
+     */
+    this.macros_ = Object.create(null);
 
     /** @const @private {!./bind-validator.BindValidator} */
     this.validator_ = new BindValidator();
@@ -85,6 +92,26 @@ export class BindEvaluator {
 
     filterSplice(this.bindings_, binding =>
         !expressionsToRemove[binding.expressionString]);
+  }
+
+  /**
+   * Parses and stores the given macros and returns map
+   * of macro name to parse errors.
+   * @param {!Array<./amp-macro.AmpMacroDef>} ampMacroDefs
+   * @return {?Object<string, EvaluatorErrorDef>},
+   */
+  addMacros(ampMacroDefs) {
+    const errors = Object.create(null);
+    // Create BindMacro objects from AmpMacroDefs.
+    ampMacroDefs.forEach(ampMacroDef => {
+      try {
+        this.macros_[ampMacroDef.name] =
+          new BindMacro(ampMacroDef, this.macros_);
+      } catch (e) {
+        errors[ampMacroDef.name] = {message: e.message, stack: e.stack};
+      }
+    });
+    return errors;
   }
 
   /**
@@ -183,7 +210,7 @@ export class BindEvaluator {
     let error = null;
     if (!expression) {
       try {
-        expression = new BindExpression(expressionString);
+        expression = new BindExpression(expressionString, this.macros_);
         this.expressions_[expressionString] = expression;
       } catch (e) {
         error = {message: e.message, stack: e.stack};

--- a/extensions/amp-bind/0.1/bind-evaluator.js
+++ b/extensions/amp-bind/0.1/bind-evaluator.js
@@ -98,7 +98,7 @@ export class BindEvaluator {
    * Parses and stores the given macros and returns map
    * of macro name to parse errors.
    * @param {!Array<./amp-bind-macro.AmpMacroDef>} ampMacroDefs
-   * @return {?Object<string, EvaluatorErrorDef>},
+   * @return {!Object<string, EvaluatorErrorDef>},
    */
   addMacros(ampMacroDefs) {
     const errors = Object.create(null);

--- a/extensions/amp-bind/0.1/bind-evaluator.js
+++ b/extensions/amp-bind/0.1/bind-evaluator.js
@@ -97,7 +97,7 @@ export class BindEvaluator {
   /**
    * Parses and stores the given macros and returns map
    * of macro name to parse errors.
-   * @param {!Array<./amp-macro.AmpMacroDef>} ampMacroDefs
+   * @param {!Array<./amp-bind-macro.AmpMacroDef>} ampMacroDefs
    * @return {?Object<string, EvaluatorErrorDef>},
    */
   addMacros(ampMacroDefs) {
@@ -105,10 +105,10 @@ export class BindEvaluator {
     // Create BindMacro objects from AmpMacroDefs.
     ampMacroDefs.forEach(ampMacroDef => {
       try {
-        this.macros_[ampMacroDef.name] =
+        this.macros_[ampMacroDef.id] =
           new BindMacro(ampMacroDef, this.macros_);
       } catch (e) {
-        errors[ampMacroDef.name] = {message: e.message, stack: e.stack};
+        errors[ampMacroDef.id] = {message: e.message, stack: e.stack};
       }
     });
     return errors;

--- a/extensions/amp-bind/0.1/bind-expression.js
+++ b/extensions/amp-bind/0.1/bind-expression.js
@@ -183,6 +183,7 @@ function generateFunctionWhitelist() {
 export class BindExpression {
   /**
    * @param {string} expressionString
+   * @param {!Object<string, !./bind-macro.BindMacro>} macros
    * @param {number=} opt_maxAstSize
    * @throws {Error} On malformed expressions.
    */
@@ -195,7 +196,7 @@ export class BindExpression {
     this.expressionString = expressionString;
 
     /** @const {!Object<string, !./bind-macro.BindMacro>} */
-    this.macros = macros || {};
+    this.macros = macros;
 
     /** @const @private {!./bind-expr-defines.AstNode} */
     this.ast_ = parser.parse(this.expressionString);

--- a/extensions/amp-bind/0.1/bind-expression.js
+++ b/extensions/amp-bind/0.1/bind-expression.js
@@ -256,15 +256,15 @@ export class BindExpression {
    * @private
    */
   isMacroInvocationNode_(ast) {
-    return ast.type === AstNodeType.INVOCATION && !ast.args[0] &&
-        this.macros_[String(ast.value)];
+    return !!(ast.type === AstNodeType.INVOCATION && !ast.args[0] &&
+        this.macros_[String(ast.value)]);
   }
 
   /**
    * Gets the array of nodes for the arguments of the provided INVOCATION
    * node, without the wrapping ARGS node and ARRAY node.
    * @param {!./bind-expr-defines.AstNode} ast
-   * @return {!Array<!./bind-expr-defines.AstNode>}
+   * @return {!Array<./bind-expr-defines.AstNode>}
    * @private
    */
   getInvocationArgNodes_(ast) {
@@ -275,11 +275,10 @@ export class BindExpression {
       } else if (argsNode.args.length === 1 &&
         argsNode.args[0].type === AstNodeType.ARRAY) {
         const arrayNode = argsNode.args[0];
-        return arrayNode.args;
+        return arrayNode.args || [];
       }
-    } else {
-      return ast.args;
     }
+    return ast.args || [];
   }
 
   /**

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -338,7 +338,7 @@ export class Bind {
    * @private
    */
   addMacros_() {
-    const elements = 
+    const elements =
         this.localWin_.document.getElementsByTagName('AMP-MACRO');
     const ampMacroDefs = [];
     for (let i = 0; i < elements.length; i++) {

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -34,7 +34,7 @@ import {parseJson, recursiveEquals} from '../../../src/json';
 import {reportError} from '../../../src/error';
 import {rewriteAttributeValue} from '../../../src/sanitizer';
 import {
-  childElementsByTag, iterateCursor, waitForBodyPromise,
+  iterateCursor, scopedQuerySelectorAll, waitForBodyPromise,
 } from '../../../src/dom';
 
 const TAG = 'amp-bind';
@@ -341,7 +341,7 @@ export class Bind {
    */
   addMacros_() {
     const elements =
-        childElementsByTag(this.ampdoc.getBody(), 'AMP-BIND-MACRO');
+        scopedQuerySelectorAll(this.ampdoc.getBody(), 'AMP-BIND-MACRO');
     const macros = /** @type {!Array<!AmpMacroDef>} */ [];
     iterateCursor(elements, element => {
       const argumentNames = (element.getAttribute('arguments') || '')

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -284,7 +284,9 @@ export class Bind {
    */
   initialize_(rootNode) {
     dev().fine(TAG, 'Scanning DOM for bindings...');
-    let promise = this.addBindingsForNodes_([rootNode]).then(() => {
+    let promise = this.addMacros_().then(() => {
+      return this.addBindingsForNodes_([rootNode]);
+    }).then(() => {
       // Listen for DOM updates (e.g. template render) to rescan for bindings.
       rootNode.addEventListener(AmpEvents.DOM_UPDATE, this.boundOnDomUpdate_);
     });
@@ -325,6 +327,36 @@ export class Bind {
   /** @return {!../../../src/service/history-impl.History} */
   historyForTesting() {
     return this.history_;
+  }
+
+  /**
+   * Scans the document for <amp-macro> elements, and adds them to the bind-evaluator.
+   *
+   * Returns a promise that resolves after macros have been added.
+   *
+   * @return {!Promise<number>}
+   * @private
+   */
+  addMacros_() {
+    const elements = 
+        this.localWin_.document.getElementsByTagName('AMP-MACRO');
+    const ampMacroDefs = [];
+    for (let i = 0; i < elements.length; i++) {
+      const element = elements[i];
+      ampMacroDefs.push({
+        name: element.getAttribute('name'),
+        argumentNames: (element.getAttribute('arguments') || '')
+            .split(',')
+            .map(s => s.trim()),
+        expressionString: element.getAttribute('expression'),
+      });
+    }
+    if (ampMacroDefs.length == 0) {
+      return Promise.resolve(0);
+    } else {
+      return this.ww_('bind.addMacros', [ampMacroDefs])
+          .then(() => ampMacroDefs.length);
+    }
   }
 
   /**

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -342,7 +342,7 @@ export class Bind {
   addMacros_() {
     const elements =
         scopedQuerySelectorAll(this.ampdoc.getBody(), 'AMP-BIND-MACRO');
-    const macros = /** @type {!Array<!AmpMacroDef>} */ [];
+    const macros = /** @type {!Array<!./amp-bind-macro.AmpMacroDef>} */ ([]);
     iterateCursor(elements, element => {
       const argumentNames = (element.getAttribute('arguments') || '')
           .split(',')

--- a/extensions/amp-bind/0.1/bind-macro.js
+++ b/extensions/amp-bind/0.1/bind-macro.js
@@ -21,14 +21,24 @@ import {BindExpression} from './bind-expression';
  */
 export class BindMacro {
 
+  /**
+   * @param {!./amp-bind-macro.AmpMacroDef} ampMacro
+   * @param {Object<string, BindMacro} otherMacros
+   */
   constructor(ampMacro, otherMacros) {
-    /** @const @private {Array<string>} */
+    /** @const @private {!Array<string>} */
     this.argumentNames_ = ampMacro.argumentNames || [];
-    /** @const @private {BindExpression} */
+    /** @const @private {!BindExpression} */
     this.expression_ =
-      new BindExpression(ampMacro.expressionString, otherMacros);
+        new BindExpression(ampMacro.expressionString, otherMacros);
   }
 
+  /**
+   * @param {!Object} state
+   * @param {!Array} args
+   * @throws {Error} On illegal function invocation.
+   * @return {BindExpressionResultDef}
+   */
   evaluate(state, args) {
     const scope = Object.assign({}, state);
     for (let i = 0; i < this.argumentNames_.length; i++) {
@@ -37,6 +47,9 @@ export class BindMacro {
     return this.expression_.evaluate(scope);
   }
 
+  /**
+   * @return {number}
+   */
   getExpressionSize() {
     return this.expression_.expressionSize;
   }

--- a/extensions/amp-bind/0.1/bind-macro.js
+++ b/extensions/amp-bind/0.1/bind-macro.js
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {BindExpression} from './bind-expression';
+
+/**
+ * A single parsed Bind macro.
+ */
+export class BindMacro {
+
+  constructor(ampMacro, otherMacros) {
+    /** @const @private {Array<string>} */
+    this.argumentNames_ = ampMacro.argumentNames || [];
+    /** @const @private {BindExpression} */
+    this.expression_ =
+      new BindExpression(ampMacro.expressionString, otherMacros);
+  }
+
+  evaluate(state, args) {
+    const scope = Object.assign({}, state);
+    for (let i = 0; i < this.argumentNames_.length; i++) {
+      scope[this.argumentNames_[i]] = args[i];
+    }
+    return this.expression_.evaluate(scope);
+  }
+
+  getExpressionSize() {
+    return this.expression_.expressionSize;
+  }
+
+}

--- a/extensions/amp-bind/0.1/bind-macro.js
+++ b/extensions/amp-bind/0.1/bind-macro.js
@@ -23,7 +23,7 @@ export class BindMacro {
 
   /**
    * @param {!./amp-bind-macro.AmpMacroDef} ampMacro
-   * @param {Object<string, BindMacro} otherMacros
+   * @param {!Object<string, !BindMacro>} otherMacros
    */
   constructor(ampMacro, otherMacros) {
     /** @const @private {!Array<string>} */
@@ -37,7 +37,7 @@ export class BindMacro {
    * @param {!Object} state
    * @param {!Array} args
    * @throws {Error} On illegal function invocation.
-   * @return {BindExpressionResultDef}
+   * @return {./bind-expression.BindExpressionResultDef}
    */
   evaluate(state, args) {
     const scope = Object.assign({}, state);

--- a/extensions/amp-bind/0.1/test/test-bind-evaluator.js
+++ b/extensions/amp-bind/0.1/test/test-bind-evaluator.js
@@ -157,4 +157,46 @@ describe('BindEvaluator', () => {
     expect(results[string]).to.be.undefined;
     expect(errors[string].message).to.match(/not a valid result/);
   });
+
+  it('should evaluate expressions with macros', () => {
+    expect(numberOfBindings()).to.equal(0);
+    evaluator.addMacros([{
+      name: 'add',
+      argumentNames: ['a', 'b'],
+      expressionString: 'a + b',
+    }]);
+    evaluator.addBindings([{
+      tagName: 'P',
+      property: 'text',
+      expressionString: 'add(oneplusone, 2)',
+    }]);
+    expect(numberOfBindings()).to.equal(1);
+    const {results, errors} = evaluator.evaluateBindings({oneplusone: 2});
+    expect(results['add(oneplusone, 2)']).to.equal(4);
+    expect(errors['add(oneplusone, 2)']).to.be.undefined;
+  });
+
+  it('should evaluate expressions with nested macros', () => {
+    expect(numberOfBindings()).to.equal(0);
+    evaluator.addMacros([{
+      name: 'add',
+      argumentNames: ['a', 'b'],
+      expressionString: 'a + b',
+    }, {
+      name: 'addThree',
+      argumentNames: ['a', 'b', 'c'],
+      expressionString: 'add(add(a, b), c)',
+    }]);
+    evaluator.addBindings([{
+      tagName: 'P',
+      property: 'text',
+      expressionString: 'addThree(oneplusone, 2, 2)',
+    }]);
+    expect(numberOfBindings()).to.equal(1);
+    const {results, errors} = evaluator.evaluateBindings({oneplusone: 2});
+    expect(results['addThree(oneplusone, 2, 2)']).to.equal(6);
+    expect(errors['addThree(oneplusone, 2, 2)']).to.be.undefined;
+  });
+
+
 });

--- a/extensions/amp-bind/0.1/test/test-bind-evaluator.js
+++ b/extensions/amp-bind/0.1/test/test-bind-evaluator.js
@@ -161,7 +161,7 @@ describe('BindEvaluator', () => {
   it('should evaluate expressions with macros', () => {
     expect(numberOfBindings()).to.equal(0);
     evaluator.addMacros([{
-      name: 'add',
+      id: 'add',
       argumentNames: ['a', 'b'],
       expressionString: 'a + b',
     }]);
@@ -179,11 +179,11 @@ describe('BindEvaluator', () => {
   it('should evaluate expressions with nested macros', () => {
     expect(numberOfBindings()).to.equal(0);
     evaluator.addMacros([{
-      name: 'add',
+      id: 'add',
       argumentNames: ['a', 'b'],
       expressionString: 'a + b',
     }, {
-      name: 'addThree',
+      id: 'addThree',
       argumentNames: ['a', 'b', 'c'],
       expressionString: 'add(add(a, b), c)',
     }]);

--- a/extensions/amp-bind/0.1/test/test-bind-expression.js
+++ b/extensions/amp-bind/0.1/test/test-bind-expression.js
@@ -15,6 +15,7 @@
  */
 
 import {BindExpression} from '../bind-expression';
+import {BindMacro} from '../bind-macro';
 
 describe('BindExpression', () => {
   const argumentTypeError = 'Unexpected argument type';
@@ -589,13 +590,43 @@ describe('BindExpression', () => {
     });
 
     it('disallow: exceeding maximum AST size', () => {
-      expect(new BindExpression('1 + 1', /* maxAstSize */ 3)).to.not.be.null;
+      expect(new BindExpression('1 + 1', {}, /* maxAstSize */ 3))
+          .to.not.be.null;
 
       // The expression '1 + 1' should have an AST size of 3 -- one for each
       // literal, and a PLUS expression wrapping them.
       expect(() => {
-        new BindExpression('1 + 1', /* maxAstSize */ 2);
+        new BindExpression('1 + 1', {}, /* maxAstSize */ 2);
       }).to.throw(expressionSizeExceededError);
+
+      const addMacro = new BindMacro({
+        name: 'add',
+        argumentNames: ['x', 'y'],
+        expressionString: 'x + y',
+      });
+      expect(addMacro.getExpressionSize()).to.equal(3);
+
+      // The expression add(1, 1) should have an AST size of 3
+      expect(
+          new BindExpression(
+          'add(1, 1)', {add: addMacro}, /* maxAstSize */ 3)
+        ).to.not.be.null;
+
+      expect(() => {
+        new BindExpression('add(1, 1)', {add: addMacro}, /* maxAstSize */ 2);
+      }).to.throw(expressionSizeExceededError);
+
+      // The expression add(1, 1 + 1) should have an AST size of 5
+      expect(
+          new BindExpression(
+          'add(1, 1 + 1)', {add: addMacro}, /* maxAstSize */ 5)
+        ).to.not.be.null;
+      expect(() => {
+        new BindExpression(
+          'add(1, 1 + 1)', {add: addMacro}, /* maxAstSize */ 4);
+      }).to.throw(expressionSizeExceededError);
+
+
     });
   });
 

--- a/extensions/amp-bind/0.1/test/test-bind-expression.js
+++ b/extensions/amp-bind/0.1/test/test-bind-expression.js
@@ -28,7 +28,7 @@ describe('BindExpression', () => {
    * @return {*}
    */
   function evaluate(expression, opt_scope) {
-    return new BindExpression(expression).evaluate(opt_scope || {});
+    return new BindExpression(expression, {}).evaluate(opt_scope || {});
   }
 
   describe('operations', () => {

--- a/extensions/amp-bind/0.1/test/validator-amp-bind.html
+++ b/extensions/amp-bind/0.1/test/validator-amp-bind.html
@@ -40,6 +40,9 @@
     button
   </button>
 
+  <amp-bind-macro id="macroWithArgs" arguments="arg1, arg2" expression="arg1 + arg2"></amp-bind-macro>
+  <amp-bind-macro id="macroWithoutArgs" expression="foo.bar + 'baz'"></amp-bind-macro>
+
   <!-- AMP-STATE -->
   <!-- amp-state with child script -->
   <amp-state id="withChildScript">

--- a/extensions/amp-bind/amp-bind.md
+++ b/extensions/amp-bind/amp-bind.md
@@ -343,6 +343,22 @@ sort([2, 1, 3])</pre>
 <sup>2</sup>Single-parameter arrow functions can't have parentheses, e.g. use `x => x + 1` instead of `(x) => x + 1`.<br>
 <sup>3</sup>Static functions are not namespaced, e.g. use `abs(-1)` instead of `Math.abs(-1)`.
 
+#### Defining macros with `amp-macro`
+
+`amp-bind` expression fragments can be reused by defining an `amp-macro`. The `amp-macro` element allows you to define an expression that
+references the current state as well as zero or more arguments. Then, this `amp-macro` can be called by its name from anywhere in your doc.
+
+```html
+<amp-macro name="circleArea" arguments="radius" expression="3.14 * radius * radius" />
+
+<div>
+  The circle has an area of <span [text]="circleArea(myCircle.radius)">0</span>.
+</div>
+```
+
+`amp-macro`s can also call other `amp-macro`s but only if the callee is defined before the caller in the document. `amp-macro`s cannot call
+themselves recursively.
+
 ### Bindings
 
 A **binding** is a special attribute of the form `[property]` that links an element's property to an [expression](#expressions).

--- a/extensions/amp-bind/amp-bind.md
+++ b/extensions/amp-bind/amp-bind.md
@@ -343,20 +343,20 @@ sort([2, 1, 3])</pre>
 <sup>2</sup>Single-parameter arrow functions can't have parentheses, e.g. use `x => x + 1` instead of `(x) => x + 1`.<br>
 <sup>3</sup>Static functions are not namespaced, e.g. use `abs(-1)` instead of `Math.abs(-1)`.
 
-#### Defining macros with `amp-macro`
+#### Defining macros with `amp-bind-macro`
 
-`amp-bind` expression fragments can be reused by defining an `amp-macro`. The `amp-macro` element allows you to define an expression that
-references the current state as well as zero or more arguments. Then, this `amp-macro` can be called by its name from anywhere in your doc.
+`amp-bind` expression fragments can be reused by defining an `amp-bind-macro`. The `amp-bind-macro` element allows you to define an expression that
+references the current state as well as zero or more arguments. Then, this `amp-bind-macro` can be called by its name from anywhere in your doc.
 
 ```html
-<amp-macro name="circleArea" arguments="radius" expression="3.14 * radius * radius" />
+<amp-bind-macro name="circleArea" arguments="radius" expression="3.14 * radius * radius" />
 
 <div>
   The circle has an area of <span [text]="circleArea(myCircle.radius)">0</span>.
 </div>
 ```
 
-`amp-macro`s can also call other `amp-macro`s but only if the callee is defined before the caller in the document. `amp-macro`s cannot call
+`amp-bind-macro`s can also call other `amp-bind-macro`s but only if the callee is defined before the caller in the document. `amp-bind-macro`s cannot call
 themselves recursively.
 
 ### Bindings

--- a/extensions/amp-bind/validator-amp-bind.protoascii
+++ b/extensions/amp-bind/validator-amp-bind.protoascii
@@ -78,3 +78,26 @@ tags: {  # <amp-state>
   }
   spec_url: "https://www.ampproject.org/docs/reference/components/amp-bind"
 }
+tags: {  # <amp-bind-macro>
+  html_format: AMP
+  tag_name: "AMP-BIND-MACRO"
+  spec_name: "amp-bind-macro"
+  requires_extension: "amp-bind"
+  attrs: {
+    name: "id"
+    mandatory: true
+  }
+  attrs: {
+    name: "arguments"
+  }
+  attrs: {
+    name: "expression"
+    mandatory: true
+  }
+  # <amp-bind>
+  attrs: { name: "[src]" }
+  child_tags: {
+    first_child_tag_name_oneof: "SCRIPT"
+  }
+  spec_url: "https://www.ampproject.org/docs/reference/components/amp-bind"
+}

--- a/extensions/amp-bind/validator-amp-bind.protoascii
+++ b/extensions/amp-bind/validator-amp-bind.protoascii
@@ -81,7 +81,6 @@ tags: {  # <amp-state>
 tags: {  # <amp-bind-macro>
   html_format: AMP
   tag_name: "AMP-BIND-MACRO"
-  spec_name: "amp-bind-macro"
   requires_extension: "amp-bind"
   attrs: {
     name: "id"
@@ -93,11 +92,6 @@ tags: {  # <amp-bind-macro>
   attrs: {
     name: "expression"
     mandatory: true
-  }
-  # <amp-bind>
-  attrs: { name: "[src]" }
-  child_tags: {
-    first_child_tag_name_oneof: "SCRIPT"
   }
   spec_url: "https://www.ampproject.org/docs/reference/components/amp-bind"
 }

--- a/extensions/amp-bind/validator-amp-bind.protoascii
+++ b/extensions/amp-bind/validator-amp-bind.protoascii
@@ -83,14 +83,14 @@ tags: {  # <amp-bind-macro>
   tag_name: "AMP-BIND-MACRO"
   requires_extension: "amp-bind"
   attrs: {
-    name: "id"
-    mandatory: true
-  }
-  attrs: {
     name: "arguments"
   }
   attrs: {
     name: "expression"
+    mandatory: true
+  }
+  attrs: {
+    name: "id"
     mandatory: true
   }
   spec_url: "https://www.ampproject.org/docs/reference/components/amp-bind"

--- a/src/web-worker/web-worker.js
+++ b/src/web-worker/web-worker.js
@@ -55,6 +55,9 @@ self.addEventListener('message', function(event) {
       const removeBindings = evaluator.removeBindingsWithExpressionStrings;
       returnValue = removeBindings.apply(evaluator, args);
       break;
+    case 'bind.addMacros':
+      returnValue = evaluator.addMacros.apply(evaluator, args);
+      break;
     case 'bind.evaluateBindings':
       returnValue = evaluator.evaluateBindings.apply(evaluator, args);
       break;


### PR DESCRIPTION
Allows developers to re-use expressions throughout the page by defining an <amp-macro> element and calling that macro by name in other parts of the page

- Macros can take in arguments
- Macros can reference parts of the state
- Macros can call other macros previously defined in the page (i.e. defined above the caller macro), but cannot call themselves (no recursion)
- When counting the size of an expression, the size of any called macros is counted in the size of the caller expression

Fixes #12218
