### PR TITLE
amp-video: propagate type to new sources

### DIFF
--- a/extensions/amp-video/0.1/amp-video.js
+++ b/extensions/amp-video/0.1/amp-video.js
@@ -294,10 +294,9 @@ class AmpVideo extends AMP.BaseElement {
     // if the `src` of `amp-video` itself is cached, move it to <source>
     if (this.element.hasAttribute('src') && this.isCachedByCDN_(this.element)) {
       const src = this.element.getAttribute('src');
+      const type = this.element.getAttribute('type');
+      const srcSource = this.createSourceElement_(src, type);
       const ampOrigSrc = this.element.getAttribute('amp-orig-src');
-      assertHttpsUrl(src, this.element);
-      const srcSource = this.element.ownerDocument.createElement('source');
-      srcSource.setAttribute('src', src);
       srcSource.setAttribute('amp-orig-src', ampOrigSrc);
       sources.unshift(srcSource);
     }
@@ -338,10 +337,9 @@ class AmpVideo extends AMP.BaseElement {
     // duplicate the `origin` Urls for cached sources and insert them after each
     const cached = toArray(this.video_.querySelectorAll('[amp-orig-src]'));
     cached.forEach(cachedSource => {
-      const origSource = this.element.ownerDocument.createElement('source');
-      const ampOrigSrc = cachedSource.getAttribute('amp-orig-src');
-      assertHttpsUrl(ampOrigSrc, cachedSource);
-      origSource.setAttribute('src', ampOrigSrc);
+      const origSrc = cachedSource.getAttribute('amp-orig-src');
+      const origType = cachedSource.getAttribute('type');
+      const origSource = this.createSourceElement_(origSrc, origType);
       insertAfterOrAtStart(dev().assertElement(this.video_),
           origSource, cachedSource);
     });
@@ -359,6 +357,22 @@ class AmpVideo extends AMP.BaseElement {
     const src = element.getAttribute('src');
     const hasOrigSrcAttr = element.hasAttribute('amp-orig-src');
     return hasOrigSrcAttr && isProxyOrigin(src);
+  }
+
+  /**
+   * @param {!string} src
+   * @param {?string} type
+   * @return {!Element} source element
+   * @private
+   */
+  createSourceElement_(src, type) {
+    assertHttpsUrl(src, this.element);
+    const source = this.element.ownerDocument.createElement('source');
+    source.setAttribute('src', src);
+    if (type) {
+      source.setAttribute('type', type);
+    }
+    return source;
   }
 
   /**

--- a/extensions/amp-video/0.1/test/test-amp-video.js
+++ b/extensions/amp-video/0.1/test/test-amp-video.js
@@ -594,6 +594,7 @@ describes.realWin('amp-video', {
       it('should move cached src to source during prerender', () => {
         return getVideo({
           'src': 'https://example-com.cdn.ampproject.org/m/s/video.mp4',
+          'type': 'video/mp4',
           'amp-orig-src': 'https://example.com/video.mp4',
         }).then(v => {
           video = v.querySelector('video');
@@ -602,6 +603,7 @@ describes.realWin('amp-video', {
           expect(sources.length).to.equal(1);
           const cachedSource = sources[0];
           expect(cachedSource.getAttribute('src')).to.equal('https://example-com.cdn.ampproject.org/m/s/video.mp4');
+          expect(cachedSource.getAttribute('type')).to.equal('video/mp4');
         });
       });
 
@@ -609,6 +611,7 @@ describes.realWin('amp-video', {
         const s1 = doc.createElement('source');
         s1.setAttribute('src', 'https://example-com.cdn.ampproject.org/m/s/video1.mp4');
         s1.setAttribute('amp-orig-src', 'https://example.com/video1.mp4');
+        s1.setAttribute('type', 'video/mp4');
 
         const s2 = doc.createElement('source');
         s2.setAttribute('src', 'https://example-com.cdn.ampproject.org/m/s/video2.mp4');
@@ -621,7 +624,9 @@ describes.realWin('amp-video', {
           const sources = video.querySelectorAll('source');
           expect(sources.length).to.equal(2);
           expect(sources[0].getAttribute('src')).to.equal('https://example-com.cdn.ampproject.org/m/s/video1.mp4');
+          expect(sources[0].getAttribute('type')).to.equal('video/mp4');
           expect(sources[1].getAttribute('src')).to.equal('https://example-com.cdn.ampproject.org/m/s/video2.mp4');
+          expect(sources[1].getAttribute('type')).to.be.null;
           expect(sources[0], s1);
           expect(sources[1], s2);
         });


### PR DESCRIPTION
Refactored source element creation into its own function and made sure `type` is preserved.