### PR TITLE
Strip `usqp` parameter from urls for analytics

### DIFF
--- a/src/url.js
+++ b/src/url.js
@@ -36,8 +36,11 @@ let a;
  */
 let cache;
 
-/** @private @const Matches amp_js_* paramters in query string. */
+/** @private @const Matches amp_js_* parameters in query string. */
 const AMP_JS_PARAMS_REGEX = /[?&]amp_js[^&]*/;
+
+/** @private @const Matches usqp parameters from goog experiment in query string. */
+const GOOGLE_EXPERIMENT_PARAMS_REGEX = /[?&]usqp[^&]*/;
 
 const INVALID_PROTOCOLS = [
   /*eslint no-script-url: 0*/ 'javascript:',
@@ -364,6 +367,7 @@ function removeAmpJsParams(urlSearch) {
   }
   const search = urlSearch
       .replace(AMP_JS_PARAMS_REGEX, '')
+      .replace(GOOGLE_EXPERIMENT_PARAMS_REGEX, '')
       .replace(/^[?&]/, '');  // Removes first ? or &.
   return search ? '?' + search : '';
 }

--- a/test/functional/test-url.js
+++ b/test/functional/test-url.js
@@ -638,6 +638,38 @@ describe('getSourceOrigin/Url', () => {
       'https://cdn.ampproject.org/c/o.com/foo/&amp_js_param=5&d=5',
       'http://o.com/foo/&amp_js_param=5&d=5');  // Treats &... as part of path.
 
+  // Removes google experimental queryString parameters.
+  testOrigin(
+      'https://cdn.ampproject.org/c/o.com/foo/?usqp=mq331AQCCAE',
+      'http://o.com/foo/');
+  testOrigin(
+      'https://cdn.ampproject.org/c/o.com/foo/?usqp=mq331AQCCAE&amp_js_param=5',
+      'http://o.com/foo/');
+  testOrigin(
+      'https://cdn.ampproject.org/c/o.com/foo/?amp_js_param=5&usqp=mq331AQCCAE',
+      'http://o.com/foo/');
+  testOrigin(
+      'https://cdn.ampproject.org/c/o.com/foo/?usqp=mq331AQCCAE&bar=1&amp_js_param=5',
+      'http://o.com/foo/?bar=1');
+  testOrigin(
+      'https://cdn.ampproject.org/c/o.com/foo/?f=0&usqp=mq331AQCCAE#something',
+      'http://o.com/foo/?f=0#something');
+  testOrigin(
+      'https://cdn.ampproject.org/c/o.com/foo/?usqp=mq331AQCCAE&f=0#bar',
+      'http://o.com/foo/?f=0#bar');
+  testOrigin(
+      'https://cdn.ampproject.org/c/o.com/foo/?f=0&usqp=mq331AQCCAE&d=5#baz',
+      'http://o.com/foo/?f=0&d=5#baz');
+  testOrigin(
+      'https://cdn.ampproject.org/c/o.com/foo/?f_usqp=mq331AQCCAE&d=5',
+      'http://o.com/foo/?f_usqp=mq331AQCCAE&d=5');
+  testOrigin(
+      'https://cdn.ampproject.org/c/o.com/foo/?usqp=mq331AQCCAE?d=5',
+      'http://o.com/foo/');  // Treats amp_js_param=5?d=5 as one param.
+  testOrigin(
+      'https://cdn.ampproject.org/c/o.com/foo/&usqp=mq331AQCCAE&d=5',
+      'http://o.com/foo/&usqp=mq331AQCCAE&d=5');  // Treats &... as part of path.
+
   // Non-CDN.
   testOrigin(
       'https://origin.com/foo/?f=0',


### PR DESCRIPTION
Adds logic to URL cleaning so that the `usqp` parameter used by experiments from google is no longer being sent with analytics

Closes #12137

@lannka 