### PR TITLE
Support the data-language attribute for AdSense

### DIFF
--- a/ads/google/adsense.md
+++ b/ads/google/adsense.md
@@ -37,3 +37,4 @@ Supported parameters:
 - data-ad-host
 - data-adtest
 - data-tag-origin
+- data-language

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -252,6 +252,7 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
       'bc': global.SVGElement && global.document.createElementNS ? '1' : null,
       'ctypes': this.getCtypes_(),
       'host': this.element.getAttribute('data-ad-host'),
+      'hl': this.element.getAttribute('data-language') || null,
       'to': this.element.getAttribute('data-tag-origin'),
       'pv': sharedStateParams.pv,
       'channel': this.element.getAttribute('data-ad-channel'),

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -252,7 +252,7 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
       'bc': global.SVGElement && global.document.createElementNS ? '1' : null,
       'ctypes': this.getCtypes_(),
       'host': this.element.getAttribute('data-ad-host'),
-      'hl': this.element.getAttribute('data-language') || null,
+      'hl': this.element.getAttribute('data-language'),
       'to': this.element.getAttribute('data-tag-origin'),
       'pv': sharedStateParams.pv,
       'channel': this.element.getAttribute('data-ad-channel'),

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
@@ -477,6 +477,7 @@ describes.realWin('amp-ad-network-adsense-impl', {
     });
     it('returns the right URL', () => {
       element.setAttribute('data-ad-slot', 'some_slot');
+      element.setAttribute('data-language', 'lxz');
       return impl.getAdUrl().then(url => {
         [
           /^https:\/\/googleads\.g\.doubleclick\.net\/pagead\/ads/,
@@ -509,6 +510,7 @@ describes.realWin('amp-ad-network-adsense-impl', {
           /(\?|&)isw=\d+(&|$)/,
           /(\?|&)ish=\d+(&|$)/,
           /(\?|&)pfx=(1|0)(&|$)/,
+          /(\?|&)hl=lxz(&|$)/,
           /(\?|&)url=https?%3A%2F%2F[a-zA-Z0-9.:%]+(&|$)/,
           /(\?|&)top=localhost(&|$)/,
           /(\?|&)ref=https%3A%2F%2Facme.org%2F(&|$)/,


### PR DESCRIPTION
Allow the "data-language" attribute to appear in the <amp-ad> element for type="adsense". When present, the attribute value maps into the value of the "hl" parameter in the resulting ad request.

Fixes #12238