### PR TITLE
Replace Element#matches() in amp-story component with helper in dom.js

### DIFF
--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -855,6 +855,7 @@ const forbiddenTermsSrcInclusive = {
       'validator/engine/validator.js',
     ],
   },
+  '\\.matches(?!_)': 'please use matches() helper in src/dom.js',  
 };
 
 // Terms that must appear in a source file.

--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -855,7 +855,7 @@ const forbiddenTermsSrcInclusive = {
       'validator/engine/validator.js',
     ],
   },
-  '\\.matches(?!_)': 'please use matches() helper in src/dom.js',  
+  '\\.matches(?!_)': 'please use matches() helper in src/dom.js',
 };
 
 // Terms that must appear in a source file.

--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -855,7 +855,7 @@ const forbiddenTermsSrcInclusive = {
       'validator/engine/validator.js',
     ],
   },
-  '\\.matches(?!_)': 'please use matches() helper in src/dom.js',
+  '\\.matches\\(': 'Please use matches() helper in src/dom.js',
 };
 
 // Terms that must appear in a source file.

--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -44,10 +44,10 @@ import {
   fullscreenEnter,
   fullscreenExit,
   isFullscreenElement,
+  matches,
+  removeElement,
   scopedQuerySelector,
   scopedQuerySelectorAll,
-  removeElement,
-  matches,
 } from '../../../src/dom';
 import {dev, user} from '../../../src/log';
 import {once} from '../../../src/utils/function';

--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -47,6 +47,7 @@ import {
   scopedQuerySelector,
   scopedQuerySelectorAll,
   removeElement,
+  matches,
 } from '../../../src/dom';
 import {dev, user} from '../../../src/log';
 import {once} from '../../../src/utils/function';
@@ -646,7 +647,7 @@ export class AmpStory extends AMP.BaseElement {
           targetPage.setActive(true);
 
           if (activePriorSibling &&
-              activePriorSibling.matches('amp-story-page')) {
+              matches(activePriorSibling, 'amp-story-page')) {
             activePriorSibling.setAttribute(PRE_ACTIVE_PAGE_ATTRIBUTE_NAME, '');
           }
           if (previousActivePriorSibling) {

--- a/extensions/amp-story/0.1/system-layer.js
+++ b/extensions/amp-story/0.1/system-layer.js
@@ -214,10 +214,10 @@ export class SystemLayer {
       const target = dev().assertElement(e.target);
 
       if (matches(
-        target, `.${EXIT_FULLSCREEN_CLASS}, .${EXIT_FULLSCREEN_CLASS} *`)) {
+          target, `.${EXIT_FULLSCREEN_CLASS}, .${EXIT_FULLSCREEN_CLASS} *`)) {
         this.onExitFullScreenClick_(e);
       } else if (matches(
-        target, `.${ENTER_FULLSCREEN_CLASS}, .${ENTER_FULLSCREEN_CLASS} *`)) {
+          target, `.${ENTER_FULLSCREEN_CLASS}, .${ENTER_FULLSCREEN_CLASS} *`)) {
         this.onEnterFullScreenClick_(e);
       } else if (matches(target, `.${MUTE_CLASS}, .${MUTE_CLASS} *`)) {
         this.onMuteAudioClick_(e);

--- a/extensions/amp-story/0.1/system-layer.js
+++ b/extensions/amp-story/0.1/system-layer.js
@@ -214,10 +214,12 @@ export class SystemLayer {
       const target = dev().assertElement(e.target);
 
       if (matches(
-          target, `.${EXIT_FULLSCREEN_CLASS}, .${EXIT_FULLSCREEN_CLASS} *`)) {
+          target,
+          `.${EXIT_FULLSCREEN_CLASS}, .${EXIT_FULLSCREEN_CLASS} *`)) {
         this.onExitFullScreenClick_(e);
       } else if (matches(
-          target, `.${ENTER_FULLSCREEN_CLASS}, .${ENTER_FULLSCREEN_CLASS} *`)) {
+          target,
+          `.${ENTER_FULLSCREEN_CLASS}, .${ENTER_FULLSCREEN_CLASS} *`)) {
         this.onEnterFullScreenClick_(e);
       } else if (matches(target, `.${MUTE_CLASS}, .${MUTE_CLASS} *`)) {
         this.onMuteAudioClick_(e);

--- a/extensions/amp-story/0.1/system-layer.js
+++ b/extensions/amp-story/0.1/system-layer.js
@@ -20,7 +20,7 @@ import {dev} from '../../../src/log';
 import {Services} from '../../../src/services';
 import {ProgressBar} from './progress-bar';
 import {getMode} from '../../../src/mode';
-import {dom} from '../../../src/dom';
+import {matches} from '../../../src/dom';
 import {DevelopmentModeLog, DevelopmentModeLogButtonSet} from './development-ui'; // eslint-disable-line max-len
 
 

--- a/extensions/amp-story/0.1/system-layer.js
+++ b/extensions/amp-story/0.1/system-layer.js
@@ -20,6 +20,7 @@ import {dev} from '../../../src/log';
 import {Services} from '../../../src/services';
 import {ProgressBar} from './progress-bar';
 import {getMode} from '../../../src/mode';
+import {dom} from '../../../src/dom';
 import {DevelopmentModeLog, DevelopmentModeLogButtonSet} from './development-ui'; // eslint-disable-line max-len
 
 
@@ -212,15 +213,13 @@ export class SystemLayer {
     this.root_.addEventListener('click', e => {
       const target = dev().assertElement(e.target);
 
-      if (target.matches(
-          `.${EXIT_FULLSCREEN_CLASS}, .${EXIT_FULLSCREEN_CLASS} *`)) {
+      if (dom.matches(target, `.${EXIT_FULLSCREEN_CLASS}, .${EXIT_FULLSCREEN_CLASS} *`)) {
         this.onExitFullScreenClick_(e);
-      } else if (target.matches(
-          `.${ENTER_FULLSCREEN_CLASS}, .${ENTER_FULLSCREEN_CLASS} *`)) {
+      } else if (dom.matches(target, `.${ENTER_FULLSCREEN_CLASS}, .${ENTER_FULLSCREEN_CLASS} *`)) {
         this.onEnterFullScreenClick_(e);
-      } else if (target.matches(`.${MUTE_CLASS}, .${MUTE_CLASS} *`)) {
+      } else if (dom.matches(target, `.${MUTE_CLASS}, .${MUTE_CLASS} *`)) {
         this.onMuteAudioClick_(e);
-      } else if (target.matches(`.${UNMUTE_CLASS}, .${UNMUTE_CLASS} *`)) {
+      } else if (dom.matches(target, `.${UNMUTE_CLASS}, .${UNMUTE_CLASS} *`)) {
         this.onUnmuteAudioClick_(e);
       }
     });

--- a/extensions/amp-story/0.1/system-layer.js
+++ b/extensions/amp-story/0.1/system-layer.js
@@ -213,9 +213,11 @@ export class SystemLayer {
     this.root_.addEventListener('click', e => {
       const target = dev().assertElement(e.target);
 
-      if (matches(target, `.${EXIT_FULLSCREEN_CLASS}, .${EXIT_FULLSCREEN_CLASS} *`)) {
+      if (matches(
+        target, `.${EXIT_FULLSCREEN_CLASS}, .${EXIT_FULLSCREEN_CLASS} *`)) {
         this.onExitFullScreenClick_(e);
-      } else if (matches(target, `.${ENTER_FULLSCREEN_CLASS}, .${ENTER_FULLSCREEN_CLASS} *`)) {
+      } else if (matches(
+        target, `.${ENTER_FULLSCREEN_CLASS}, .${ENTER_FULLSCREEN_CLASS} *`)) {
         this.onEnterFullScreenClick_(e);
       } else if (matches(target, `.${MUTE_CLASS}, .${MUTE_CLASS} *`)) {
         this.onMuteAudioClick_(e);

--- a/extensions/amp-story/0.1/system-layer.js
+++ b/extensions/amp-story/0.1/system-layer.js
@@ -213,13 +213,13 @@ export class SystemLayer {
     this.root_.addEventListener('click', e => {
       const target = dev().assertElement(e.target);
 
-      if (dom.matches(target, `.${EXIT_FULLSCREEN_CLASS}, .${EXIT_FULLSCREEN_CLASS} *`)) {
+      if (matches(target, `.${EXIT_FULLSCREEN_CLASS}, .${EXIT_FULLSCREEN_CLASS} *`)) {
         this.onExitFullScreenClick_(e);
-      } else if (dom.matches(target, `.${ENTER_FULLSCREEN_CLASS}, .${ENTER_FULLSCREEN_CLASS} *`)) {
+      } else if (matches(target, `.${ENTER_FULLSCREEN_CLASS}, .${ENTER_FULLSCREEN_CLASS} *`)) {
         this.onEnterFullScreenClick_(e);
-      } else if (dom.matches(target, `.${MUTE_CLASS}, .${MUTE_CLASS} *`)) {
+      } else if (matches(target, `.${MUTE_CLASS}, .${MUTE_CLASS} *`)) {
         this.onMuteAudioClick_(e);
-      } else if (dom.matches(target, `.${UNMUTE_CLASS}, .${UNMUTE_CLASS} *`)) {
+      } else if (matches(target, `.${UNMUTE_CLASS}, .${UNMUTE_CLASS} *`)) {
         this.onUnmuteAudioClick_(e);
       }
     });

--- a/extensions/amp-story/0.1/system-layer.js
+++ b/extensions/amp-story/0.1/system-layer.js
@@ -213,12 +213,10 @@ export class SystemLayer {
     this.root_.addEventListener('click', e => {
       const target = dev().assertElement(e.target);
 
-      if (matches(
-          target,
+      if (matches(target,
           `.${EXIT_FULLSCREEN_CLASS}, .${EXIT_FULLSCREEN_CLASS} *`)) {
         this.onExitFullScreenClick_(e);
-      } else if (matches(
-          target,
+      } else if (matches(target,
           `.${ENTER_FULLSCREEN_CLASS}, .${ENTER_FULLSCREEN_CLASS} *`)) {
         this.onEnterFullScreenClick_(e);
       } else if (matches(target, `.${MUTE_CLASS}, .${MUTE_CLASS} *`)) {


### PR DESCRIPTION
Uses of native `.matches()` in the amp-story component refactored to use `matches()` helper from src/dom.js

?: Unclear if the request is for it to be done in all instances or just in amp-story.

Have had a go at implementing a presubmit-check for `.matches()`, need to have another look at the first bonus.

Closes #11816 
