### PR TITLE
Fix layout bug for non-prerendered AMP elements in first viewport  

### DIFF
--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -1353,8 +1353,7 @@ export class Resources {
     for (let i = 0; i < this.resources_.length; i++) {
       const r = this.resources_[i];
       if (r.getState() == ResourceState.NOT_BUILT && !r.isBuilding()) {
-        this.buildOrScheduleBuildForResource_(r, /* checkForDupes */ true,
-            /* scheduleWhenBuilt */ false);
+        this.buildOrScheduleBuildForResource_(r, /* checkForDupes */ true);
       }
       if (relayoutAll ||
               !r.hasBeenMeasured() ||

--- a/test/functional/test-resources.js
+++ b/test/functional/test-resources.js
@@ -1468,12 +1468,15 @@ describe('Resources discoverWork', () => {
     resource1.element.isBuilt = () => false;
     resource2.element.idleRenderOutsideViewport = () => false;
     resource1.state_ = ResourceState.NOT_BUILT;
-    resource1.build = sandbox.spy();
+    resource1.build = sandbox.stub().returns(Promise.resolve());
 
     resources.discoverWork_();
 
     expect(resource1.build).to.be.calledOnce;
-    expect(schedulePassStub).to.not.be.called;
+    return resource1.build().then(() => {
+      // Pass should be scheduled after successful resource build.
+      expect(schedulePassStub).to.be.calledWithExactly();
+    });
   });
 
   it('should build resource when not built and before doc ready', () => {
@@ -1484,12 +1487,15 @@ describe('Resources discoverWork', () => {
     resource1.element.isBuilt = () => false;
     resource2.element.idleRenderOutsideViewport = () => false;
     resource1.state_ = ResourceState.NOT_BUILT;
-    resource1.build = sandbox.spy();
+    resource1.build = sandbox.stub().returns(Promise.resolve());
 
     resources.discoverWork_();
 
     expect(resource1.build).to.be.calledOnce;
-    expect(schedulePassStub).to.not.be.called;
+    return resource1.build().then(() => {
+      // Pass should be scheduled after successful resource build.
+      expect(schedulePassStub).to.be.calledWithExactly();
+    });
   });
 
   it('should NOT build non-prerenderable resources in prerender', () => {

--- a/test/functional/test-resources.js
+++ b/test/functional/test-resources.js
@@ -1462,40 +1462,36 @@ describe('Resources discoverWork', () => {
   });
 
   it('should build resource when not built', () => {
-    const schedulePassStub = sandbox.stub(resources, 'schedulePass');
+    const buildResourceSpy = sandbox.spy(resources, 'buildResourceUnsafe_');
     sandbox.stub(resources, 'schedule_');
     resources.documentReady_ = true;
     resource1.element.isBuilt = () => false;
     resource2.element.idleRenderOutsideViewport = () => false;
     resource1.state_ = ResourceState.NOT_BUILT;
-    resource1.build = sandbox.stub().returns(Promise.resolve());
+    resource1.build = sandbox.spy();
 
     resources.discoverWork_();
 
     expect(resource1.build).to.be.calledOnce;
-    return resource1.build().then(() => {
-      // Pass should be scheduled after successful resource build.
-      expect(schedulePassStub).to.be.calledWithExactly();
-    });
+    expect(buildResourceSpy).calledWithExactly(
+        resource1, /* schedulePass */ true);
   });
 
   it('should build resource when not built and before doc ready', () => {
-    const schedulePassStub = sandbox.stub(resources, 'schedulePass');
+    const buildResourceSpy = sandbox.spy(resources, 'buildResourceUnsafe_');
     sandbox.stub(resources, 'schedule_');
     resources.documentReady_ = false;
     resource1.element.nextSibling = {};
     resource1.element.isBuilt = () => false;
     resource2.element.idleRenderOutsideViewport = () => false;
     resource1.state_ = ResourceState.NOT_BUILT;
-    resource1.build = sandbox.stub().returns(Promise.resolve());
+    resource1.build = sandbox.spy();
 
     resources.discoverWork_();
 
     expect(resource1.build).to.be.calledOnce;
-    return resource1.build().then(() => {
-      // Pass should be scheduled after successful resource build.
-      expect(schedulePassStub).to.be.calledWithExactly();
-    });
+    expect(buildResourceSpy).calledWithExactly(
+        resource1, /* schedulePass */ true);
   });
 
   it('should NOT build non-prerenderable resources in prerender', () => {


### PR DESCRIPTION
Fixes #11843.

Non-prerendered AMP elements in first viewport won't get laid out when transitioning from "prerender" to "visible".

This check was [originally added in this PR](https://github.com/ampproject/amphtml/pull/5181/files#diff-80b9cea934a00a64f15d14cb656dfad4R984) to fix a bug where there are infinite passes when element build fails. 

I don't think this fix will reintroduce the bug since a pass is now [only scheduled on *successful* build](https://github.com/ampproject/amphtml/blob/8355bc6c21e7543634f62aa628c4cd63b3436fe2/src/service/resources-impl.js#L587-L597) (which wasn't the case in the PR above). I could be missing something though.

Let me know if you think this is okay and I'll add a unit test.

/to @dvoytenko /cc @jridgewell 
