### PR TITLE
Always call performance.mark at the pre-render complete time.

### DIFF
--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -257,6 +257,8 @@ export class Performance {
           this.tickDelta('pc', userPerceivedVisualCompletenesssTime);
         });
         this.prerenderComplete_(userPerceivedVisualCompletenesssTime);
+        // Mark this instance in the browser timeline.
+        this.mark('pc');
       } else {
         // If it didnt start in prerender, no need to calculate anything
         // and we just need to tick `pc`. (it will give us the relative
@@ -307,8 +309,20 @@ export class Performance {
     } else {
       this.queueTick_(data);
     }
-    // Add browser performance timeline entries for simple ticks.
-    // These are for example exposed in WPT.
+    // Mark the event on the browser timeline, but only if there was
+    // no delta (in which case it would not make sense).
+    if (arguments.length == 1) {
+      this.mark(label);
+    }
+  }
+
+  /**
+   * Add browser performance timeline entries for simple ticks.
+   * These are for example exposed in WPT.
+   * See https://developer.mozilla.org/en-US/docs/Web/API/Performance/mark
+   * @param {string} label
+   */
+  mark(label) {
     if (this.win.performance
         && this.win.performance.mark
         && arguments.length == 1) {

--- a/test/functional/test-performance.js
+++ b/test/functional/test-performance.js
@@ -490,6 +490,10 @@ describes.realWin('performance', {amp: true}, env => {
           .returns(visibility);
     }
 
+    function getPerformanceMarks() {
+      return win.performance.getEntriesByType('mark').map(entry => entry.name);
+    }
+
     beforeEach(() => {
       viewer = Services.viewerForDoc(ampdoc);
       sandbox.stub(viewer, 'whenMessagingReady')
@@ -533,6 +537,9 @@ describes.realWin('performance', {amp: true}, env => {
           return perf.whenViewportLayoutComplete_().then(() => {
             expect(viewerSendMessageStub.withArgs(
                 'prerenderComplete').firstCall.args[1].value).to.equal(400);
+
+            expect(getPerformanceMarks()).to.deep.equal(
+                ['ol', 'ofv', 'pc']);
           });
         });
       });
@@ -584,6 +591,8 @@ describes.realWin('performance', {amp: true}, env => {
           return whenFirstVisiblePromise.then(() => {
             expect(tickSpy.withArgs('pc')).to.be.calledOnce;
             expect(Number(tickSpy.withArgs('pc').args[0][1])).to.equal(0);
+            expect(getPerformanceMarks()).to.deep.equal(
+                ['ol', 'pc', 'ofv']);
           });
         });
       });
@@ -604,6 +613,7 @@ describes.realWin('performance', {amp: true}, env => {
         return perf.whenViewportLayoutComplete_().then(() => {
           expect(viewerSendMessageStub.withArgs(
               'prerenderComplete').firstCall.args[1].value).to.equal(300);
+          expect(getPerformanceMarks()).to.deep.equal(['ol', 'pc']);
         });
       });
 
@@ -615,6 +625,7 @@ describes.realWin('performance', {amp: true}, env => {
           expect(tickSpy.withArgs('ol')).to.be.calledOnce;
           expect(tickSpy.withArgs('pc')).to.be.calledOnce;
           expect(tickSpy.withArgs('pc').args[0][2]).to.be.undefined;
+          expect(getPerformanceMarks()).to.deep.equal(['ol', 'pc']);
         });
       });
     });


### PR DESCRIPTION
We'd previously not call it when we calculate the delta manually (to make the visible time the time-origin). But for the browser performance timeline it makes sense to always mark the instance. 

We additionally mark the `visible` time, so that timeline analysis can also produce the relative metric.