### PR TITLE
Improve amp-story prerender heuristic and prebuild quota usage

### DIFF
--- a/extensions/amp-story/0.1/amp-story-grid-layer.js
+++ b/extensions/amp-story/0.1/amp-story-grid-layer.js
@@ -27,6 +27,7 @@
  */
 
 import {Layout} from '../../../src/layout';
+import {matches} from '../../../src/dom';
 
 /**
  * A mapping of attribute names we support for grid layers to the CSS Grid
@@ -72,6 +73,16 @@ const TEMPLATE_CLASS_NAMES = {
 };
 
 export class AmpStoryGridLayer extends AMP.BaseElement {
+  /** @param {!AmpElement} element */
+  constructor(element) {
+    super(element);
+
+    /** @private @const {boolean} Only prerender if child of the first page. */
+    this.prerenderAllowed_ = matches(this.element,
+        'amp-story-page:first-of-type amp-story-grid-layer');
+  }
+
+
   /** @override */
   buildCallback() {
     this.applyTemplateClassName_();
@@ -82,7 +93,7 @@ export class AmpStoryGridLayer extends AMP.BaseElement {
 
   /** @override */
   prerenderAllowed() {
-    return true;
+    return this.prerenderAllowed_;
   }
 
 

--- a/extensions/amp-story/0.1/amp-story-page.js
+++ b/extensions/amp-story/0.1/amp-story-page.js
@@ -31,12 +31,11 @@ import {Layout} from '../../../src/layout';
 import {upgradeBackgroundAudio} from './audio';
 import {EventType, dispatch, dispatchCustom} from './events';
 import {AdvancementConfig} from './page-advancement';
-import {scopedQuerySelectorAll} from '../../../src/dom';
+import {matches, scopedQuerySelectorAll} from '../../../src/dom';
 import {getLogEntries} from './logging';
 import {getMode} from '../../../src/mode';
 import {CommonSignals} from '../../../src/common-signals';
 import {setImportantStyles} from '../../../src/style';
-
 
 
 /**
@@ -83,6 +82,10 @@ export class AmpStoryPage extends AMP.BaseElement {
             .catch(reject);
       };
     });
+
+    /** @private @const {boolean} Only prerender the first story page. */
+    this.prerenderAllowed_ = matches(this.element,
+        'amp-story-page:first-of-type');
   }
 
 
@@ -145,6 +148,7 @@ export class AmpStoryPage extends AMP.BaseElement {
     this.pageActiveCallback_();
   }
 
+
   /** @override */
   layoutCallback() {
     this.muteAllMedia();
@@ -155,10 +159,12 @@ export class AmpStoryPage extends AMP.BaseElement {
     ]);
   }
 
+
   /** @return {!Promise} */
   beforeVisible() {
     return this.maybeApplyFirstAnimationFrame();
   }
+
 
   /** @private */
   onPageVisible_() {
@@ -216,7 +222,7 @@ export class AmpStoryPage extends AMP.BaseElement {
 
   /** @override */
   prerenderAllowed() {
-    return true;
+    return this.prerenderAllowed_;
   }
 
 

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -524,7 +524,16 @@ export class Resources {
    */
   buildOrScheduleBuildForResource_(resource, checkForDupes = false,
       scheduleWhenBuilt = true) {
-    if (this.isRuntimeOn_ || this.isBuildOn_) {
+    const buildingEnabled = (this.isRuntimeOn_ || this.isBuildOn_);
+
+    // During prerender mode, don't build elements that aren't allowed to be
+    // prerendered. This avoids wasting our prerender build quota.
+    // See grantBuildPermission() for more details.
+    const shouldBuildResource =
+        this.viewer_.getVisibilityState() != VisibilityState.PRERENDER
+        || resource.prerenderAllowed();
+
+    if (buildingEnabled && shouldBuildResource) {
       if (this.documentReady_) {
         // Build resource immediately, the document has already been parsed.
         this.buildResourceUnsafe_(resource, scheduleWhenBuilt);

--- a/test/functional/test-resources.js
+++ b/test/functional/test-resources.js
@@ -1492,6 +1492,23 @@ describe('Resources discoverWork', () => {
     expect(schedulePassStub).to.not.be.called;
   });
 
+  it('should NOT build non-prerenderable resources in prerender', () => {
+    sandbox.stub(resources.viewer_, 'getVisibilityState')
+        .returns(VisibilityState.PRERENDER);
+    sandbox.stub(resources, 'schedule_');
+    resources.documentReady_ = true;
+
+    resource1.element.isBuilt = () => false;
+    resource1.prerenderAllowed = () => false;
+    resource1.state_ = ResourceState.NOT_BUILT;
+    resource1.build = sandbox.spy();
+    resource2.element.idleRenderOutsideViewport = () => false;
+
+    resources.discoverWork_();
+
+    expect(resource1.build).to.not.be.called;
+  });
+
   it('should layout resource if outside viewport but idle', () => {
     const schedulePassStub = sandbox.stub(resources, 'schedulePass');
     resources.documentReady_ = true;


### PR DESCRIPTION
Improves #11843.

- Only allow prerender of `amp-story-*` elements that are on the first story page
- Don't spend prerender build quota (20) on elements that can't be prerendered anyway

Note that non-story AMP elements that are on page 2+ will still get built -- will consider implementing that in a follow-up. Overall, I think our prerender system can use some love.

Let me know if you think this general approach works and I'll add tests.

/to @dvoytenko 