### PR TITLE
Fix square aspect ratios on desktop

### DIFF
--- a/extensions/amp-story/0.1/amp-story-desktop.css
+++ b/extensions/amp-story/0.1/amp-story-desktop.css
@@ -153,10 +153,10 @@ amp-story-page.i-amphtml-story-page-shown {
   right: auto!important;
   margin: auto!important;
   max-height: 70vh!important;
-  max-width: calc(9/16 * 70vh);
+  max-width: calc(9/16 * 70vh) !important;
   box-shadow: 0 0 15px rgba(0, 0, 0, .4)!important;
   min-width: 348px !important;
-  max-width: 619px !important;
+  min-height: 619px !important;
 }
 
 /* Navigation buttons */
@@ -394,6 +394,12 @@ amp-story-page.i-amphtml-story-page-shown {
   top: auto!important;
   bottom: 0!important;
   height: 72px!important;
+}
+
+@media (max-height: 768px) {
+  [desktop] .i-amphtml-story-system-layer {
+    height: 32px !important;
+  }
 }
 
 [desktop] .i-amphtml-story-progress-bar {


### PR DESCRIPTION
Fix for a regression caused by #12265

Bonus: progress bar has smaller gaps so it won't overlap/be off-center