### PR TITLE
eslint: remove deprecated rulePaths

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,5 @@
 {
   "parser": "babel-eslint",
-  "rulePaths": ["build-system/eslint-rules/"],
   "plugins": ["eslint-plugin-google-camelcase"],
   "ecmaFeatures": {
     "modules": true,


### PR DESCRIPTION
`rulePaths` had been deprecated in favor of `--rulesdir` and in eslint >4 - which we recently upgrade to - it is now an error, I am removing it since it is breaking eslint plugins for editors like Visual Studio code.

Note that this does not impact `gulp lint` since our `lint.js` manually sets this path an as option on `gulp-eslint` and I verified that custom rules continue to work with `gulp lint`.
