### PR TITLE
Address edge case of minVisible = 100%

### DIFF
--- a/extensions/amp-analytics/0.1/test/test-visibility-model.js
+++ b/extensions/amp-analytics/0.1/test/test-visibility-model.js
@@ -982,16 +982,12 @@ describes.sandboxed('VisibilityModel', {}, () => {
 
     it('should fire for 100 percent min and max visibility', () => {
       const vh = new VisibilityModel({
-        continuousTimeMin: 1000,
         visiblePercentageMin: 100,
         visiblePercentageMax: 100,
       }, calcVisibility);
       const eventSpy = vh.eventResolver_ = sandbox.spy();
       visibility = 1.0;
       clock.tick(200);
-      vh.update();
-      expect(eventSpy).to.not.be.called;
-      clock.tick(1100);
       vh.update();
       expect(eventSpy).to.be.calledOnce;
     });

--- a/extensions/amp-analytics/0.1/test/test-visibility-model.js
+++ b/extensions/amp-analytics/0.1/test/test-visibility-model.js
@@ -979,6 +979,22 @@ describes.sandboxed('VisibilityModel', {}, () => {
         totalVisibleTime: 1000,
       });
     });
+
+    it('should fire for 100 percent min and max visibility', () => {
+      const vh = new VisibilityModel({
+        continuousTimeMin: 1000,
+        visiblePercentageMin: 100,
+        visiblePercentageMax: 100,
+      }, calcVisibility);
+      const eventSpy = vh.eventResolver_ = sandbox.spy();
+      visibility = 1.0;
+      clock.tick(200);
+      vh.update();
+      expect(eventSpy).to.not.be.called;
+      clock.tick(1100);
+      vh.update();
+      expect(eventSpy).to.be.calledOnce;
+    });
   });
 
   describe('end to end event repeat', () => {

--- a/extensions/amp-analytics/0.1/test/test-visibility-model.js
+++ b/extensions/amp-analytics/0.1/test/test-visibility-model.js
@@ -980,7 +980,7 @@ describes.sandboxed('VisibilityModel', {}, () => {
       });
     });
 
-    it('should fire for 100 percent min and max visibility', () => {
+    it('should fire for visiblePercentageMin=visiblePercentageMax=100', () => {
       const vh = new VisibilityModel({
         visiblePercentageMin: 100,
         visiblePercentageMax: 100,

--- a/extensions/amp-analytics/0.1/test/test-visibility-model.js
+++ b/extensions/amp-analytics/0.1/test/test-visibility-model.js
@@ -986,6 +986,10 @@ describes.sandboxed('VisibilityModel', {}, () => {
         visiblePercentageMax: 100,
       }, calcVisibility);
       const eventSpy = vh.eventResolver_ = sandbox.spy();
+      visibility = 0.99;
+      clock.tick(200);
+      expect(eventSpy).to.not.be.called;
+      vh.update();
       visibility = 1.0;
       clock.tick(200);
       vh.update();

--- a/extensions/amp-analytics/0.1/visibility-model.js
+++ b/extensions/amp-analytics/0.1/visibility-model.js
@@ -348,11 +348,9 @@ export class VisibilityModel {
   isVisibilityMatch_(visibility) {
     dev().assert(visibility >= 0 && visibility <= 1,
         'invalid visibility value: %s', visibility);
-    // TODO(jonkeller): Currently don't allow min=100%.
-    // One possible approach is:
-    // if (this.spec_.visiblePercentageMin == 1) {
-    //   return visibility == 1;
-    // }
+    if (this.spec_.visiblePercentageMin == 1) {
+      return visibility == 1;
+    }
     return visibility > this.spec_.visiblePercentageMin &&
         visibility <= this.spec_.visiblePercentageMax;
   }

--- a/extensions/amp-analytics/0.1/visibility-model.js
+++ b/extensions/amp-analytics/0.1/visibility-model.js
@@ -348,9 +348,11 @@ export class VisibilityModel {
   isVisibilityMatch_(visibility) {
     dev().assert(visibility >= 0 && visibility <= 1,
         'invalid visibility value: %s', visibility);
-    if (this.spec_.visiblePercentageMin == 1) {
-      return visibility == 1;
-    }
+    // TODO(jonkeller): Currently don't allow min=100%.
+    // One possible approach is:
+    // if (this.spec_.visiblePercentageMin == 1) {
+    //   return visibility == 1;
+    // }
     return visibility > this.spec_.visiblePercentageMin &&
         visibility <= this.spec_.visiblePercentageMax;
   }


### PR DESCRIPTION
Spec allows you to give min, max visible percentage to trigger the event.
But it's defined as triggering on (min, max].
So if you want the event only when 100% of the creative is visible...you can't. If you say min=max=100 then the event will never fire, because the percent of the creative that is visible will never be > 100.
