### PR TITLE
Fix lightbox controls toggle

### DIFF
--- a/extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.js
+++ b/extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.js
@@ -316,7 +316,7 @@ export class AmpLightboxViewer extends AMP.BaseElement {
     }
     if (this.descriptionBox_.textContent) {
       this.descriptionBox_.classList.toggle('hide', !opt_display);
-    } else if (!this.descriptionBox_.classList.contains('hide')) {
+    } else {
       this.descriptionBox_.classList.add('hide');
     }
   }

--- a/extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.js
+++ b/extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.js
@@ -43,8 +43,8 @@ const TAG = 'amp-lightbox-viewer';
  * @enum {number}
  */
 const LightboxControlsModes = {
-  SHOW_CONTROLS: 1,
-  HIDE_CONTROLS: 0,
+  CONTROLS_DISPLAYED: 1,
+  CONTROLS_HIDDEN: 0,
 };
 
 const DESC_BOX_PADDING_TOP = 50;
@@ -131,7 +131,7 @@ export class AmpLightboxViewer extends AMP.BaseElement {
     this.topGradient_ = null;
 
     /** @private {!LightboxControlsModes} */
-    this.controlsMode_ = LightboxControlsModes.SHOW_CONTROLS;
+    this.controlsMode_ = LightboxControlsModes.CONTROLS_DISPLAYED;
 
     /** @private {?UnlistenDef} */
     this.unlistenResize_ = null;
@@ -315,8 +315,8 @@ export class AmpLightboxViewer extends AMP.BaseElement {
       opt_display = this.descriptionBox_.classList.contains('hide');
     }
     if (this.descriptionBox_.textContent) {
-      this.descriptionBox_.classList.toggle('hide', opt_display);
-    } else {
+      this.descriptionBox_.classList.toggle('hide', !opt_display);
+    } else if (!this.descriptionBox_.classList.contains('hide')) {
       this.descriptionBox_.classList.add('hide');
     }
   }
@@ -414,7 +414,7 @@ export class AmpLightboxViewer extends AMP.BaseElement {
     if (opt_display == undefined) {
       opt_display = this.topBar_.classList.contains('hide');
     }
-    this.topBar_.classList.toggle('hide', opt_display);
+    this.topBar_.classList.toggle('hide', !opt_display);
   }
 
   /**
@@ -469,14 +469,14 @@ export class AmpLightboxViewer extends AMP.BaseElement {
    * @private
    */
   toggleControls_() {
-    if (this.controlsMode_ == LightboxControlsModes.HIDE_CONTROLS) {
+    if (this.controlsMode_ == LightboxControlsModes.CONTROLS_HIDDEN) {
       this.toggleDescriptionBox_(/* opt_display */true);
       this.toggleTopBar_(/* opt_display */true);
-      this.controlsMode_ = LightboxControlsModes.SHOW_CONTROLS;
+      this.controlsMode_ = LightboxControlsModes.CONTROLS_DISPLAYED;
     } else {
       this.toggleDescriptionBox_(/* opt_display */false);
       this.toggleTopBar_(/* opt_display */false);
-      this.controlsMode_ = LightboxControlsModes.HIDE_CONTROLS;
+      this.controlsMode_ = LightboxControlsModes.CONTROLS_HIDDEN;
     }
   }
 
@@ -765,6 +765,7 @@ export class AmpLightboxViewer extends AMP.BaseElement {
     this.container_.setAttribute('gallery-view', '');
     this.topBar_.classList.add('fullscreen');
     toggle(dev().assertElement(this.carousel_), false);
+    this.toggleDescriptionBox_(false);
   }
 
   /**
@@ -777,6 +778,7 @@ export class AmpLightboxViewer extends AMP.BaseElement {
       this.topBar_.classList.remove('fullscreen');
     }
     toggle(dev().assertElement(this.carousel_), true);
+    this.toggleDescriptionBox_(true);
   }
 
   /**

--- a/src/image-viewer.js
+++ b/src/image-viewer.js
@@ -316,18 +316,18 @@ export class ImageViewer {
 
   /** @private */
   setupGestures_() {
-    this.gestures_ = Gestures.get(this.viewer_,
+    const gestures = Gestures.get(this.image_,
         /* opt_shouldNotPreventDefault */true);
-    this.gestures_.onPointerDown(() => {
+    gestures.onPointerDown(() => {
       if (this.motion_) {
-        event.preventDefault();
         this.motion_.halt();
       }
     });
 
+    this.gestures_ = Gestures.get(this.viewer_);
+
     // Zoomable.
     this.gestures_.onGesture(DoubletapRecognizer, e => {
-      event.preventDefault();
       let newScale;
       if (this.scale_ == 1) {
         newScale = this.maxScale_;
@@ -342,7 +342,6 @@ export class ImageViewer {
     });
 
     this.gestures_.onGesture(TapzoomRecognizer, e => {
-      event.preventDefault();
       this.onTapZoom_(e.data.centerClientX, e.data.centerClientY,
           e.data.deltaX, e.data.deltaY);
       if (e.data.last) {
@@ -352,8 +351,6 @@ export class ImageViewer {
     });
 
     this.gestures_.onGesture(PinchRecognizer, e => {
-      // To disable iOS 10 Safari default pinch zoom
-      event.preventDefault();
       this.onPinchZoom_(e.data.centerClientX, e.data.centerClientY,
           e.data.deltaX, e.data.deltaY, e.data.dir);
       if (e.data.last) {

--- a/src/image-viewer.js
+++ b/src/image-viewer.js
@@ -316,7 +316,7 @@ export class ImageViewer {
 
   /** @private */
   setupGestures_() {
-    this.gestures_ = Gestures.get(this.image_,
+    this.gestures_ = Gestures.get(this.viewer_,
         /* opt_shouldNotPreventDefault */true);
     this.gestures_.onPointerDown(() => {
       if (this.motion_) {

--- a/src/image-viewer.js
+++ b/src/image-viewer.js
@@ -316,15 +316,18 @@ export class ImageViewer {
 
   /** @private */
   setupGestures_() {
-    this.gestures_ = Gestures.get(this.image_);
+    this.gestures_ = Gestures.get(this.image_,
+        /* opt_shouldNotPreventDefault */true);
     this.gestures_.onPointerDown(() => {
       if (this.motion_) {
+        event.preventDefault();
         this.motion_.halt();
       }
     });
 
     // Zoomable.
     this.gestures_.onGesture(DoubletapRecognizer, e => {
+      event.preventDefault();
       let newScale;
       if (this.scale_ == 1) {
         newScale = this.maxScale_;
@@ -367,6 +370,7 @@ export class ImageViewer {
     // Movable.
     this.unlistenOnSwipePan_ = this.gestures_
       .onGesture(SwipeXYRecognizer, e => {
+        event.preventDefault();
         this.onMove_(e.data.deltaX, e.data.deltaY, false);
         if (e.data.last) {
           this.onMoveRelease_(e.data.velocityX, e.data.velocityY);

--- a/src/image-viewer.js
+++ b/src/image-viewer.js
@@ -316,9 +316,9 @@ export class ImageViewer {
 
   /** @private */
   setupGestures_() {
-    const gestures = Gestures.get(this.image_,
+    const gesturesWithoutPreventDefault = Gestures.get(this.image_,
         /* opt_shouldNotPreventDefault */true);
-    gestures.onPointerDown(() => {
+    gesturesWithoutPreventDefault.onPointerDown(() => {
       if (this.motion_) {
         this.motion_.halt();
       }
@@ -367,7 +367,6 @@ export class ImageViewer {
     // Movable.
     this.unlistenOnSwipePan_ = this.gestures_
       .onGesture(SwipeXYRecognizer, e => {
-        event.preventDefault();
         this.onMove_(e.data.deltaX, e.data.deltaY, false);
         if (e.data.last) {
           this.onMoveRelease_(e.data.velocityX, e.data.velocityY);


### PR DESCRIPTION
Address https://github.com/ampproject/amphtml/issues/12362, https://github.com/ampproject/amphtml/issues/12364

Bugs that were seen:
- When you tap on the image, toggle controls does not work. 
- On first tap, controls do not toggle. 
- Zoom too easily triggers browser zoom if one finger is on the black mask instead of the image. 

Fix: 
- Have the `ImageViewer` not prevent default for `onPointerDown`, since `lightbox-viewer` directly listens to click events. 
- Fixed behavior in `toggleDescription and` `toggleTopBar` to match naming. 
- Change the `ImageViewer` gesture recognizers to be on the `viewer_` div instead of the `image_` itself. 