### PR TITLE
hasAudio() function in amp-story MediaElement Class returns true

### DIFF
--- a/extensions/amp-story/0.1/page-element.js
+++ b/extensions/amp-story/0.1/page-element.js
@@ -298,10 +298,7 @@ class MediaElement extends PageElement {
 
   /** @override */
   hasAudio() {
-    const mediaElement = this.getMediaElement_();
-    return mediaElement.mozHasAudio ||
-        Boolean(mediaElement['webkitAudioDecodedByteCount']) ||
-        Boolean(mediaElement.audioTracks && mediaElement.audioTracks.length);
+    return true;
   }
 }
 


### PR DESCRIPTION
hasAudio() function in amp-story MediaElement Class always returns true until it can more robustly return accurate value.

Since I'm attempting an issue that fixes the audio check on amp-story media elements #11857 I noticed this high-priority ticket.  As far as I can see this change should work for now.  I have tested manually and it seems to be ok.

Closes #12190 
