### PR TITLE
Add example + testing sections to CORs doc

### DIFF
--- a/spec/amp-cors-requests.md
+++ b/spec/amp-cors-requests.md
@@ -23,15 +23,26 @@ aspects of using CORS in AMP.  To learn about CORS itself, see the
 
 * [Why do I need CORS for my own origin?](#why-do-i-need-cors-for-my-own-origin)
 * [Utilizing cookies for CORS requests](#utilizing-cookies-for-cors-requests)
-  * [Third-party cookie restrictions](#third-party-cookie-restrictions)
+    * [Third-party cookie restrictions](#third-party-cookie-restrictions)
 * [CORS Security in AMP](#cors-security-in-amp)
-  * [Ensuring secure requests](#ensuring-secure-requests)
-    * [Verify the CORS Origin header](#verify-the-cors-origin-header)
-    * [Allow the AMP-Same-Origin header](#allow-the-amp-same-origin-header)
-    * [Restrict requests to source origins](#restrict-requests-to-source-origins)
-    * [Verify state changing requests](#verify-state-changing-requests)
-  * [Ensuring secure responses](#ensuring-secure-responses)
-
+    * [Ensuring secure requests](#ensuring-secure-requests)
+        * [Verify the CORS Origin header](#verify-the-cors-origin-header)
+        * [Allow the AMP-Same-Origin header](#allow-the-amp-same-origin-header)
+        * [Restrict requests to source origins](#restrict-requests-to-source-origins)
+    * [Ensuring secure responses](#ensuring-secure-responses)
+    * [Processing state changing requests](#processing-state-changing-requests)
+* [Example walkthrough: Handling CORS requests and responses](#example-walkthrough-handing-cors-requests-and-responses)
+    * [Allowed origins](#allowed-origins)
+    * [Response headers for allowed requests](#response-headers-for-allowed-requests)
+    * [Pseudo CORS logic](#pseudo-cors-logic)
+        * [CORS sample code](#cors-sample-code)
+    * [Scenario 1:  Get request from AMP page on same origin](#scenario-1--get-request-from-amp-page-on-same-origin)
+    * [Scenario 2:  Get request from cached AMP page](#scenario-2--get-request-from-cached-amp-page)
+* [Testing CORS in AMP](#testing-cors-in-amp)
+    * [Verify the page via the cache URL](#verify-the-page-via-the-cache-url)
+    * [Verify your server response headers](#verify-your-server-response-headers)
+        * [Test request from same origin](#test-request-from-same-origin)
+        * [Test request from cached AMP page](#test-request-from-cached-amp-page)
 
 ## Why do I need CORS for my own origin?
 
@@ -72,7 +83,7 @@ cross-origin requests, you need to handle CORS, otherwise, the request fails.
 **Okay, what should I do?**
  
 1.  For AMP pages that fetch dynamic data, make sure you test the cached version
-    of those pages; *don't just test on your own domain*.
+    of those pages; *don't just test on your own domain*. (See [Testing CORS in AMP](#testing-cors-in-amp) section below)
 2.  Follow the instructions in this document for handling CORS requests and
     responses.
 
@@ -121,6 +132,12 @@ The AMP CORS security protocol consists of three components:
 
 ### Ensuring secure requests
 
+When your endpoint receives a CORS request:
+
+1.  [Verify that the Origin header is an allowed origin (publisher's origin + AMP caches)](#verify-the-cors-origin-header).
+2.  [If there isn't an Origin header, check that the request is from the same origin](#allow-the-amp-same-origin-header). 
+3.  [If the request is a state change (e.g., POST), check that the origin is from the source origin](#restrict-requests-to-source-origins).
+
 #### Verify the CORS Origin header
 
 CORS endpoints receive the requesting origin via the `Origin` HTTP header.
@@ -158,8 +175,22 @@ parameter, which contains the value of the source origin (for example,
 To restrict requests to only source origins, check that the value of the
 `"__amp_source_origin"` parameter is within a set of the Publisher's own
 origins. 
+
+### Ensuring secure responses
+
+The resulting HTTP response to a CORS request must contain the following
+headers:
  
-#### Verify state changing requests
+<dl>
+  <dt><code>Access-Control-Allow-Origin: &lt;origin&gt;</code></dt>
+  <dd>This header is a <a href="https://www.w3.org/TR/cors/">W3 CORS Spec</a> requirement, where <code>origin</code> refers to the requesting origin that was allowed via the CORS <code>Origin</code> request header (for example, <code>"https://cdn.ampproject.org"</code>). Although the W3 CORS spec allows the value of <code>*</code> to be returned in the response, for improved security, you should validate and echo the value of the <code>"Origin"</code> header.</dd>
+  <dt><code>AMP-Access-Control-Allow-Source-Origin: &lt;source-origin&gt;</code></dt>
+  <dd>This header allows the specified <code>source-origin</code> to read the authorization response. The <code>source-origin</code> is the value specified and verified in the <code>"__amp_source_origin"</code> URL parameter (for example, <code>"https://publisher1.com"</code>).</dd>
+  <dt><code>Access-Control-Expose-Headers: AMP-Access-Control-Allow-Source-Origin</code></dt>
+  <dd>This header simply allows the CORS response to contain the <code>AMP-Access-Control-Allow-Source-Origin</code> header.</dd>
+</dl>
+
+#### Processing state changing requests
 
 **Important**: Perform these validation checks *before* you
 process the request. This validation helps to provide protection against CSRF
@@ -189,25 +220,230 @@ following:
     request does not contain this header, stop and return an error response.
 2.  Otherwise, process the request.
 
-### Ensuring secure responses
+## Example walkthrough: Handing CORS requests and responses
 
-The resulting HTTP response to a CORS request must contain the following
-headers:
- 
-* **`Access-Control-Allow-Origin: <origin>`**
-  * This header is a [W3 CORS Spec](https://www.w3.org/TR/cors/) requirement,
-    where `origin` refers to the requesting origin that was allowed via the CORS
-    `Origin` request header (for example, `"https://cdn.ampproject.org"`).
-    Although the W3 CORS spec allows the value of `*` to be returned in the
-    response, for improved security, you should validate and echo the value of
-    the `"Origin"` header.
+There are two scenarios to account for in CORS requests to your endpoint:
 
-* **`AMP-Access-Control-Allow-Source-Origin: <source-origin>`**
-  * This header allows the specified `source-origin` to read the authorization
-    response. The `source-origin` is the value specified and verified in the
-    `"__amp_source_origin"` URL parameter (for example,
-    `"https://publisher1.com"`).
-    
-* **`Access-Control-Expose-Headers: AMP-Access-Control-Allow-Source-Origin`**
-  * This header simply allows the CORS response to contain the
-    `AMP-Access-Control-Allow-Source-Origin` header.
+1.  A request from the same origin.
+2.  A request from a cached origin (from an AMP Cache).
+
+Let's walk though these scenarios with an example. In our example, we manage the `example.com` site that hosts an AMP page named `article-amp.html.`The AMP page contains an `amp-list` to retrieve dynamic data from a `data.json` file that is also hosted on `example.com`.  We want to process requests to our `data.json` file that come from our AMP page.  These requests could be from the AMP page on the same origin (non-cached) or from the AMP page on a different origin (cached).
+
+<amp-img alt="CORS example" layout="fixed" src="https://bpaduch.github.io/random-images/cors_example_walkthrough.png" width="629" height="433">
+  <noscript>
+    <img alt="CORS example" src="https://bpaduch.github.io/random-images/cors_example_walkthrough.png" />
+  </noscript>
+</amp-img>
+
+### Allowed origins
+
+Based on what we know about CORS and AMP (from [Ensuring secure requests](#ensuring-secure-requests) above), for our example we will allow requests from the following domains:
+
+* `example.com` ---  Publisher's domain
+* `example-com.cdn.ampproject.org` --- Google AMP Cache subdomain
+* `example.com.amp.cloudflare.com`--- Cloudflare AMP Cache subdomain
+* `cdn.ampproject.org` --- Google's legacy AMP Cache domain
+
+### Response headers for allowed requests
+
+For requests from the allowed origins, our response will contain the following headers:
+
+```text
+Access-Control-Allow-Origin: <origin>
+AMP-Access-Control-Allow-Source-Origin: <source-origin>
+Access-Control-Expose-Headers: AMP-Access-Control-Allow-Source-Origin
+```
+
+These are additional response headers we might include in our CORS response:
+
+```text
+Access-Control-Allow-Credentials: true
+Content-Type: application/json
+Access-Control-Max-Age: <delta-seconds>
+Cache-Control: private, no-cache
+```
+
+### Pseudo CORS logic
+
+Our logic for handling CORS requests and responses can be simplified into the following pseudo code:
+
+```text
+IF CORS header present
+   IF origin IN allowed-origins AND sourceOrigin = publisher
+      allow request & send response
+   ELSE
+      deny request
+ELSE
+   IF "AMP-Same-Origin: true"
+      allow request & send response
+   ELSE
+      deny request
+```
+
+#### CORS sample code
+
+Here's a sample JavaScript function that we could use to handle CORS requests and responses:
+
+```javascript
+function assertCors(req, res, opt_validMethods, opt_exposeHeaders) {
+  var unauthorized = 'Unauthorized Request';
+  var origin;
+  var allowedOrigins = [
+     "https://example.com",
+     "https://example-com.cdn.ampproject.org",
+     "https://example.com.amp.cloudflare.com",
+     "https://cdn.ampproject.org" ];
+  var allowedSourceOrigin = "https://example.com";  //publisher's origin
+  var sourceOrigin = req.query.__amp_source_origin;
+
+
+  // If same origin
+  if (req.headers['amp-same-origin'] == 'true') {
+      origin = sourceOrigin;
+  // If allowed CORS origin & allowed source origin
+  } else if (allowedOrigins.indexOf(req.headers.origin) == -1 &&
+      sourceOrigin == allowedSourceOrigin) {
+      origin = req.headers.origin;
+  } else {
+      res.statusCode = 401;
+      res.end(JSON.stringify({message: unauthorized}));
+      throw unauthorized;
+  }
+
+  res.setHeader('Access-Control-Allow-Credentials', 'true');
+  res.setHeader('Access-Control-Allow-Origin', origin);
+  res.setHeader('Access-Control-Expose-Headers',
+      ['AMP-Access-Control-Allow-Source-Origin']
+          .concat(opt_exposeHeaders || []).join(', '));
+  res.setHeader('AMP-Access-Control-Allow-Source-Origin', sourceOrigin);
+
+}
+```
+
+**Note**: For a working code sample, see [app.js](https://github.com/ampproject/amphtml/blob/master/build-system/app.js#L1129).
+
+### Scenario 1:  Get request from AMP page on same origin
+
+In the following scenario, the `article-amp.html` page requests the `data.json` file; the origins are the same.
+
+<amp-img alt="CORS example - scenario 1" layout="fixed" src="https://bpaduch.github.io/random-images/cors_example_walkthrough_ex1.png" width="657" height="155">
+  <noscript>
+    <img alt="CORS example" src="https://bpaduch.github.io/random-images/cors_example_walkthrough_ex1.png" />
+  </noscript>
+</amp-img>
+
+If we examine the request, we'll find:
+
+```text
+Request URL: https://example.com/data.json?__amp_source_origin=https%3A%2F%2Fexample.com
+Request Method: GET
+AMP-Same-Origin: true
+```
+
+As this request is from the same origin, there is no `Origin` header but the custom AMP request header of `AMP-Same-Origin: true` is present.  In the request URL, we can find the source origin through the `__amp_source_origin` query parameter.  We can allow this request as it's from the same origin.
+
+Our response headers would be:
+
+```text
+Access-Control-Allow-Credentials: true
+Access-Control-Allow-Origin: https://example.com
+Access-Control-Expose-Headers: AMP-Access-Control-Allow-Source-Origin
+AMP-Access-Control-Allow-Source-Origin: https://example.com
+```
+
+### Scenario 2:  Get request from cached AMP page
+
+In the following scenario, the `article-amp.html` page cached on the Google AMP Cache requests the `data.json` file; the origins differ.
+
+<amp-img alt="CORS example - scenario 2" layout="fixed" src="https://bpaduch.github.io/random-images/cors_example_walkthrough_ex2.png" width="657" height="155">
+  <noscript>
+    <img alt="CORS example" src="https://bpaduch.github.io/random-images/cors_example_walkthrough_ex2.png" />
+  </noscript>
+</amp-img>
+
+If we examine this request, we'll find:
+
+```text
+Request URL: https://example.com/data.json?__amp_source_origin=https%3A%2F%2Fexample.com
+origin: https://example-com.cdn.ampproject.org
+Request Method: GET
+```
+
+As this request contains an `Origin` header, we'll verify that it's from an allowed origin.  In the request URL, we can find the source origin through the `__amp_source_origin` query parameter.  We can allow this request as it's from an allowed origin.
+
+Our response headers would be:
+
+```text
+Access-Control-Allow-Credentials: true
+Access-Control-Allow-Origin: https://example-com.cdn.ampproject.org
+Access-Control-Expose-Headers: AMP-Access-Control-Allow-Source-Origin
+AMP-Access-Control-Allow-Source-Origin: https://example.com
+```
+
+## Testing CORS in AMP
+
+When you are testing your AMP pages, make sure to include tests from the cached versions of your AMP pages.
+
+### Verify the page via the cache URL
+
+To ensure your cached AMP page renders and functions correctly:
+
+1.  From your browser, open the URL that the AMP Cache would use to access your AMP page. You can determine the cache URL format from this [tool on AMP By Example](https://ampbyexample.com/advanced/using_the_google_amp_cache/).
+
+    For example:
+    * URL: `https://www.ampproject.org/docs/tutorials/create.html`
+    * AMP Cache URL format: `https://www-ampproject-org.cdn.ampproject.org/c/s/www.ampproject.org/docs/tutorials/create.html`
+
+1.  Open your browser's development tools and verify that there are no errors and that all resources loaded correctly.
+
+### Verify your server response headers
+
+You can use the `curl` command to verify that your server is sending the correct HTTP response headers.  In the `curl` command, provide the request URL and any custom headers you wish to add.
+
+**Syntax**:  `curl <request-url> -H <custom-header> - I`
+
+For CORS requests in AMP, be sure to add the  `__amp_source_origin=` query parameter to the request URL, which emulates what the AMP system does.
+
+#### Test request from same origin
+
+In a same-origin request, the AMP system adds the custom `AMP-Same-Origin:true` header.
+
+Here's our curl command for testing a request from `https://ampbyexample.com` to the `examples.json` file (on the same domain):
+
+```shell
+curl 'https://ampbyexample.com/json/examples.json?__amp_source_origin=https%3A%2F%2Fampbyexample.com' -H 'AMP-Same-Origin: true' -I
+```
+
+The results from the command show the correct response headers (note: extra information was trimmed):
+
+```text
+HTTP/2 200
+access-control-allow-headers: Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token
+access-control-allow-credentials: true
+access-control-allow-origin: https://ampbyexample.com
+amp-access-control-allow-source-origin: https://ampbyexample.com
+access-control-allow-methods: POST, GET, OPTIONS
+access-control-expose-headers: AMP-Access-Control-Allow-Source-Origin
+```
+
+#### Test request from cached AMP page
+
+In a CORS request not from the same domain (i.e., cache), the `origin` header is part of the request.
+
+Here's our curl command for testing a request from the cached AMP page on the Google AMP Cache to the `examples.json` file:
+
+```shell
+curl 'https://ampbyexample.com/json/examples.json?__amp_source_origin=https%3A%2F%2Fampbyexample.com' -H 'origin: https://ampbyexample-com.cdn.ampproject.org' -I
+```
+
+The results from the command show the correct response headers:
+
+```text
+HTTP/2 200
+access-control-allow-headers: Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token
+access-control-allow-credentials: true
+access-control-allow-origin: https://ampbyexample-com.cdn.ampproject.org
+amp-access-control-allow-source-origin: https://ampbyexample.com
+access-control-allow-methods: POST, GET, OPTIONS
+access-control-expose-headers: AMP-Access-Control-Allow-Source-Origin
+```


### PR DESCRIPTION
Improve CORS guide with Example walkthrough section + Testing section.

Fixes: https://github.com/ampproject/amphtml/issues/12089