### PR TITLE
Fix gray border on image for alt with no src bug on lightbox

### DIFF
--- a/extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.js
+++ b/extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.js
@@ -29,6 +29,7 @@ import {toggle, setStyle} from '../../../src/style';
 import {getData, listen} from '../../../src/event-helper';
 import {LightboxManager} from './service/lightbox-manager-impl';
 import {layoutRectFromDomRect} from '../../../src/layout-rect';
+import {elementByTag} from '../../../src/dom';
 import * as st from '../../../src/style';
 import * as tr from '../../../src/transition';
 import {SwipeYRecognizer} from '../../../src/gesture-recognizers';
@@ -220,7 +221,7 @@ export class AmpLightboxViewer extends AMP.BaseElement {
         container.classList.add('i-amphtml-image-lightbox-container');
         const imageViewer = new ImageViewer(this, this.win,
           this.loadPromise.bind(this));
-        imageViewer.init(element);
+        imageViewer.init(element, elementByTag(element, 'img'));
         container.appendChild(imageViewer.getElement());
         slide = container;
         metadata.imageViewer = imageViewer;

--- a/src/image-viewer.js
+++ b/src/image-viewer.js
@@ -240,11 +240,14 @@ export class ImageViewer {
       // Set src provisionally to the known loaded value for fast display.
       // It will be updated later.
       this.image_.setAttribute('src', sourceImage.src);
-    } else {
-      // Most browsers show a gray border for images with alt but no src
-      // If we did not set the src, remove the alt attribute
-      this.image_.removeAttribute('alt');
     }
+
+    st.setStyles(this.image_, {
+      top: st.px(0),
+      left: st.px(0),
+      width: st.px(0),
+      height: st.px(0),
+    });
   }
 
   /**
@@ -314,11 +317,6 @@ export class ImageViewer {
     // and then naturally upgrade to a higher quality image.
     return Services.timerFor(this.win).promise(1).then(() => {
       this.image_.setAttribute('src', src);
-      if (this.ariaAttributes_.hasOwnProperty('alt')) {
-        // Most browsers show a gray border for images with alt but no src
-        // Set alt only after we set the src attribute
-        this.image_.setAttribute('alt', this.ariaAttributes_['alt']);
-      }
       return this.loadPromise_(this.image_);
     });
   }

--- a/src/image-viewer.js
+++ b/src/image-viewer.js
@@ -236,12 +236,13 @@ export class ImageViewer {
       }
     });
 
+    const platform = Services.platformFor(this.win);
     if (sourceImage && isLoaded(sourceImage) && sourceImage.src) {
       // Set src provisionally to the known loaded value for fast display.
       // It will be updated later.
       this.image_.setAttribute('src', sourceImage.src);
-    } else if (Services.platformFor(this.win).isSafari()) {
-      // Safari shows a gray border for images with alt but no src
+    } else if (platform.isSafari() || platform.isIos()) {
+      // iOS/Safari shows a gray border for images with alt but no src
       // If we did not set the src, remove the alt attribute
       this.image_.removeAttribute('alt');
     }
@@ -315,8 +316,9 @@ export class ImageViewer {
     return Services.timerFor(this.win).promise(1).then(() => {
       this.image_.setAttribute('src', src);
       const platform = Services.platformFor(this.win);
-      if (platform.isSafari() && this.ariaAttributes_.hasOwnProperty('alt')) {
-        // Safari shows a gray border for images with alt but no src
+      if ((platform.isSafari() || platform.isIos())
+        && this.ariaAttributes_.hasOwnProperty('alt')) {
+        // iOS/Safari shows a gray border for images with alt but no src
         // Set alt only after we set the src attribute
         this.image_.setAttribute('alt', this.ariaAttributes_['alt']);
       }

--- a/src/image-viewer.js
+++ b/src/image-viewer.js
@@ -240,6 +240,10 @@ export class ImageViewer {
       // Set src provisionally to the known loaded value for fast display.
       // It will be updated later.
       this.image_.setAttribute('src', sourceImage.src);
+    } else if (Services.platformFor(this.win).isSafari()) {
+      // Safari shows a gray border for images with alt but no src
+      // If we did not set the src, remove the alt attribute
+      this.image_.removeAttribute('alt');
     }
   }
 
@@ -310,6 +314,12 @@ export class ImageViewer {
     // and then naturally upgrade to a higher quality image.
     return Services.timerFor(this.win).promise(1).then(() => {
       this.image_.setAttribute('src', src);
+      const platform = Services.platformFor(this.win);
+      if (platform.isSafari() && this.ariaAttributes_.hasOwnProperty('alt')) {
+        // Safari shows a gray border for images with alt but no src
+        // Set alt only after we set the src attribute
+        this.image_.setAttribute('alt', this.ariaAttributes_['alt']);
+      }
       return this.loadPromise_(this.image_);
     });
   }

--- a/src/image-viewer.js
+++ b/src/image-viewer.js
@@ -236,13 +236,12 @@ export class ImageViewer {
       }
     });
 
-    const platform = Services.platformFor(this.win);
     if (sourceImage && isLoaded(sourceImage) && sourceImage.src) {
       // Set src provisionally to the known loaded value for fast display.
       // It will be updated later.
       this.image_.setAttribute('src', sourceImage.src);
-    } else if (platform.isSafari() || platform.isIos()) {
-      // iOS/Safari shows a gray border for images with alt but no src
+    } else {
+      // Most browsers show a gray border for images with alt but no src
       // If we did not set the src, remove the alt attribute
       this.image_.removeAttribute('alt');
     }
@@ -315,10 +314,8 @@ export class ImageViewer {
     // and then naturally upgrade to a higher quality image.
     return Services.timerFor(this.win).promise(1).then(() => {
       this.image_.setAttribute('src', src);
-      const platform = Services.platformFor(this.win);
-      if ((platform.isSafari() || platform.isIos())
-        && this.ariaAttributes_.hasOwnProperty('alt')) {
-        // iOS/Safari shows a gray border for images with alt but no src
+      if (this.ariaAttributes_.hasOwnProperty('alt')) {
+        // Most browsers show a gray border for images with alt but no src
         // Set alt only after we set the src attribute
         this.image_.setAttribute('alt', this.ariaAttributes_['alt']);
       }


### PR DESCRIPTION
Fixes https://github.com/ampproject/amphtml/issues/12366. 
Problem: 
Multiple browsers gives images with `alt` but not `src` attribute a gray border. On `ImageViewer` initialization, we set all the aria attributes including `alt`, but not the `src` attribute unless the image has loaded. Therefore when we open the lightbox for the first time, before the image loads, safari shows an ugly gray border. This happens every time we scroll to a new image for the first time. Applies to: mobile safari, mobile chrome, mobile firefox, desktop safari. 

Proposed solution: 
Special case safari to not set the `alt` attribute until after we set `src`. 

There are multiple hack solutions to this problem, including setting opacity to 0 until we set src, setting a tiny transparent src, but nothing elegant comes to mind. If an immediate better solution comes to mind, I'm very open to suggestions. I think we could also revisit this after reviewing Lightbox for performance because depending on how we refactor the order of doing things, this bug might no longer be applicable by then. 

Testing: 
- [x] ios safari
- [x] ios chrome
- [x] ios firefox
- [x] desktop chrome
- [x] desktop safari
- [x] android chrome
- [x] android firefox