### PR TITLE
Check that :scope selector behaves correctly.

### DIFF
--- a/src/dom.js
+++ b/src/dom.js
@@ -418,6 +418,8 @@ function isScopeSelectorSupported(parent) {
     const testElement = doc.createElement('div');
     const testChild = doc.createElement('div');
     testElement.appendChild(testChild);
+    // NOTE(cvializ, #12383): Firefox's implementation is incomplete,
+    // therefore we test actual functionality of`:scope` as well.
     return testElement./*OK*/querySelector(':scope div') === testChild;
   } catch (e) {
     return false;

--- a/src/dom.js
+++ b/src/dom.js
@@ -408,13 +408,17 @@ export function setScopeSelectorSupportedForTesting(val) {
 }
 
 /**
+ * Test that the :scope selector is supported and behaves correctly.
  * @param {!Element} parent
  * @return {boolean}
  */
 function isScopeSelectorSupported(parent) {
+  const doc = parent.ownerDocument;
   try {
-    parent.ownerDocument.querySelector(':scope');
-    return true;
+    const testElement = doc.createElement('div');
+    const testChild = doc.createElement('div');
+    testElement.appendChild(testChild);
+    return testElement./*OK*/querySelector(':scope div') === testChild;
   } catch (e) {
     return false;
   }


### PR DESCRIPTION
Fixes #12151

Firefox does not throw when the `:scope` pseudoclass is used, but in some contexts it returns `null` incorrectly even when it should match a child element.

| Firefox (normal) | Firefox (ShadowDOM?) |
|---|---|
|<img width="712" alt="screen shot 2017-12-08 at 1 16 08 pm" src="https://user-images.githubusercontent.com/2363700/33785546-5cdd910e-dc1a-11e7-9f8d-dfa489ddb613.png">|<img width="723" alt="screen shot 2017-12-08 at 1 16 16 pm" src="https://user-images.githubusercontent.com/2363700/33785529-49f11b7e-dc1a-11e7-8ff5-398baa9098d2.png">|

/cc @kul3r4 