### PR TITLE
Swap win for ampdoc in amp-font to support shadowroot

### DIFF
--- a/extensions/amp-font/0.1/amp-font.js
+++ b/extensions/amp-font/0.1/amp-font.js
@@ -165,12 +165,20 @@ export class AmpFont extends AMP.BaseElement {
    * @private
    */
   onFontLoadFinish_(addClassName, removeClassName) {
-    const body = this.getAmpDoc().getBody();
+    const ampdoc = this.getAmpDoc();
+    const body = ampdoc.getBody();
+    const root = ampdoc.getRootNode().documentElement;
     if (addClassName) {
       body.classList.add(addClassName);
+      if (root) {
+        root.classList.add(addClassName);
+      }
     }
     if (removeClassName) {
       body.classList.remove(removeClassName);
+      if (root) {
+        root.classList.remove(removeClassName);
+      }
     };
     this.dispose_();
   }

--- a/extensions/amp-font/0.1/amp-font.js
+++ b/extensions/amp-font/0.1/amp-font.js
@@ -166,22 +166,14 @@ export class AmpFont extends AMP.BaseElement {
    */
   onFontLoadFinish_(addClassName, removeClassName) {
     const ampdoc = this.getAmpDoc();
-    const body = ampdoc.getBody();
-    const root = ampdoc.getRootNode().documentElement;
+    // Add the class to <html> unless in ShadowRoot, where we append to <body>
+    const root = ampdoc.getRootNode().documentElement || ampdoc.getBody();
     if (addClassName) {
-      if (root) {
-        root.classList.add(addClassName);
-      } else {
-        body.classList.add(addClassName);
-      }
+      root.classList.add(addClassName);
     }
     if (removeClassName) {
-      if (root) {
-        root.classList.remove(removeClassName);
-      } else {
-        body.classList.remove(removeClassName);
-      }
-    };
+      root.classList.remove(removeClassName);
+    }
     this.dispose_();
   }
 

--- a/extensions/amp-font/0.1/amp-font.js
+++ b/extensions/amp-font/0.1/amp-font.js
@@ -39,25 +39,18 @@ import {Services} from '../../../src/services';
 import {isFiniteNumber} from '../../../src/types';
 import {user} from '../../../src/log';
 
-/** @private @const {string} */
 const TAG = 'amp-font';
 
-/** @private @const {number} */
 const DEFAULT_TIMEOUT_ = 3000;
 
-/** @private @const {string} */
 const DEFAULT_WEIGHT_ = '400';
 
-/** @private @const {string} */
 const DEFAULT_VARIANT_ = 'normal';
 
-/** @private @const {string} */
 const DEFAULT_STYLE_ = 'normal';
 
-/** @private @const {string} */
 const DEFAULT_SIZE_ = 'medium';
 
-/** @private @const {number}*/
 /**
  * https://output.jsbin.com/badore - is js bin experiment to test timeouts on
  * various mobile devices. Loade the page and try refreshing it to serve the
@@ -83,18 +76,18 @@ export class AmpFont extends AMP.BaseElement {
   constructor(element) {
     super(element);
 
-    /** @private {string} */
+    /** @private */
     this.fontFamily_ = '';
-    /** @private {string} */
+
+    /** @private */
     this.fontWeight_ = '';
-    /** @private {string} */
+
+    /** @private */
     this.fontStyle_ = '';
-    /** @private {string} */
+
+    /** @private */
     this.fontVariant_ = '';
-    /** @private {?Document} */
-    this.document_ = null;
-    /** @private {?Element} */
-    this.documentElement_ = null;
+
     /** @private {?FontLoader} */
     this.fontLoader_ = null;
   }
@@ -116,9 +109,7 @@ export class AmpFont extends AMP.BaseElement {
         this.element.getAttribute('font-style') || DEFAULT_STYLE_;
     this.fontVariant_ =
         this.element.getAttribute('font-variant') || DEFAULT_VARIANT_;
-    this.document_ = this.win.document;
-    this.documentElement_ = this.document_.documentElement;
-    this.fontLoader_ = new FontLoader(this.win);
+    this.fontLoader_ = new FontLoader(this.getAmpDoc());
     this.startLoad_();
   }
 
@@ -174,12 +165,12 @@ export class AmpFont extends AMP.BaseElement {
    * @private
    */
   onFontLoadFinish_(addClassName, removeClassName) {
+    const body = this.getAmpDoc().getBody();
     if (addClassName) {
-      this.documentElement_.classList.add(addClassName);
+      body.classList.add(addClassName);
     }
     if (removeClassName) {
-      this.documentElement_.classList.remove(removeClassName);
-      this.document_.body.classList.remove(removeClassName);
+      body.classList.remove(removeClassName);
     };
     this.dispose_();
   }
@@ -200,10 +191,10 @@ export class AmpFont extends AMP.BaseElement {
    */
   getTimeout_() {
     let timeoutInMs = parseInt(this.element.getAttribute('timeout'), 10);
-    timeoutInMs = !isFiniteNumber(timeoutInMs) || timeoutInMs < 0 ?
-        DEFAULT_TIMEOUT_ : timeoutInMs;
+    timeoutInMs = !isFiniteNumber(timeoutInMs) ||
+        timeoutInMs < 0 ? DEFAULT_TIMEOUT_ : timeoutInMs;
     timeoutInMs = Math.max(
-      (timeoutInMs - Services.timerFor(this.win).timeSinceStart()),
+        (timeoutInMs - Services.timerFor(this.win).timeSinceStart()),
         CACHED_FONT_LOAD_TIME_
     );
     return timeoutInMs;

--- a/extensions/amp-font/0.1/amp-font.js
+++ b/extensions/amp-font/0.1/amp-font.js
@@ -169,15 +169,17 @@ export class AmpFont extends AMP.BaseElement {
     const body = ampdoc.getBody();
     const root = ampdoc.getRootNode().documentElement;
     if (addClassName) {
-      body.classList.add(addClassName);
       if (root) {
         root.classList.add(addClassName);
+      } else {
+        body.classList.add(addClassName);
       }
     }
     if (removeClassName) {
-      body.classList.remove(removeClassName);
       if (root) {
         root.classList.remove(removeClassName);
+      } else {
+        body.classList.remove(removeClassName);
       }
     };
     this.dispose_();

--- a/extensions/amp-font/0.1/fontloader.js
+++ b/extensions/amp-font/0.1/fontloader.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-/*eslint no-unused-vars: 0*/
 /**
  * @typedef {{
  *  style: string,
@@ -27,39 +26,41 @@
 let FontConfigDef;
 
 
-/** @private @const {Array.<string>} */
 const DEFAULT_FONTS_ = ['sans-serif', 'serif'];
 
-/** @private @const {string} */
 const TEST_STRING_ = 'MAxmTYklsjo190QW';
 
-/** @private @const {number} */
 const TOLERANCE_ = 2;
 
 
 import {removeElement} from '../../../src/dom';
 import {Services} from '../../../src/services';
-import * as style from '../../../src/style';
+import {setStyles} from '../../../src/style';
 
 
 export class FontLoader {
 
   /**
-   * @param {!Window} win
+   * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
    */
-  constructor(win) {
-    /** @private @const {!Window} */
-    this.win_ = win;
-    /** @private @const {!Document} */
-    this.document_ = win.document;
+  constructor(ampdoc) {
+    /** @private @const */
+    this.ampdoc_ = ampdoc;
+
+    /** @private @const */
+    this.document_ = ampdoc.win.document;
+
     /** @private {?Element} */
     this.container_ = null;
-    /** @private {boolean} */
-    this.fontLoadResolved_ = false;
-    /** @private {boolean} */
-    this.fontLoadRejected_ = false;
+
     /** @private {?FontConfigDef} */
     this.fontConfig_ = null;
+
+    /** @private */
+    this.fontLoadResolved_ = false;
+
+    /** @private */
+    this.fontLoadRejected_ = false;
   }
 
 
@@ -74,7 +75,7 @@ export class FontLoader {
    */
   load(fontConfig, timeout) {
     this.fontConfig_ = fontConfig;
-    return Services.timerFor(this.win_)
+    return Services.timerFor(this.ampdoc_.win)
         .timeoutPromise(timeout, this.load_())
         .then(() => {
           this.fontLoadResolved_ = true;
@@ -149,7 +150,7 @@ export class FontLoader {
    */
   loadWithPolyfill_() {
     return new Promise((resolve, reject) => {
-      const vsync = Services.vsyncFor(this.win_);
+      const vsync = Services.vsyncFor(this.ampdoc_.win);
       // Create font comparators
       const comparators = this.createFontComparators_();
       // Measure until timeout (or font load).
@@ -180,7 +181,7 @@ export class FontLoader {
   createFontComparators_() {
     const containerElement = this.container_ =
         this.document_.createElement('div');
-    style.setStyles(containerElement, {
+    setStyles(containerElement, {
       // Use larger font-size to better detect font load.
       fontSize: '40px',
       fontVariant: this.fontConfig_.variant,
@@ -197,7 +198,7 @@ export class FontLoader {
 
     const comparators = DEFAULT_FONTS_.map(defaultFont => new FontComparator(
         containerElement, this.fontConfig_.family, defaultFont));
-    this.document_.body.appendChild(containerElement);
+    this.ampdoc_.getBody().appendChild(containerElement);
     return comparators;
   }
 
@@ -246,7 +247,7 @@ class FontComparator {
   getFontElement_(doc, fontFamily) {
     const element = doc.createElement('div');
     element.textContent = TEST_STRING_;
-    style.setStyles(element, {
+    setStyles(element, {
       float: 'left',
       fontFamily,
       margin: 0,

--- a/extensions/amp-font/0.1/test/test-amp-font.js
+++ b/extensions/amp-font/0.1/test/test-amp-font.js
@@ -49,7 +49,7 @@ describes.realWin('amp-font', {
     sandbox.stub(FontLoader.prototype, 'load')
         .returns(Promise.reject('mock rejection'));
     return getAmpFont().then(() => {
-      expect(doc.documentElement)
+      expect(doc.body)
           .to.have.class('comic-amp-font-missing');
       expect(doc.body)
           .to.not.have.class('comic-amp-font-loading');
@@ -59,7 +59,7 @@ describes.realWin('amp-font', {
   it('should load custom font', function() {
     sandbox.stub(FontLoader.prototype, 'load').returns(Promise.resolve());
     return getAmpFont().then(() => {
-      expect(doc.documentElement)
+      expect(doc.body)
           .to.have.class('comic-amp-font-loaded');
       expect(doc.body)
           .to.not.have.class('comic-amp-font-loading');

--- a/extensions/amp-font/0.1/test/test-amp-font.js
+++ b/extensions/amp-font/0.1/test/test-amp-font.js
@@ -17,53 +17,58 @@
 import '../amp-font';
 import {FontLoader} from '../fontloader';
 
+describes.repeated('', {
+  'single ampdoc': {ampdoc: 'single'},
+  'shadow ampdoc': {ampdoc: 'shadow'},
+}, (name, variant) => {
 
-describes.realWin('amp-font', {
-  amp: {
-    extensions: ['amp-font'],
-  },
-}, function(env) {
-  let win, doc;
+  describes.realWin('amp-font', {
+    amp: {
+      ampdoc: variant.ampdoc,
+      extensions: ['amp-font'],
+    },
+  }, function(env) {
+    let ampdoc, doc, root, body;
 
-  beforeEach(() => {
-    win = env.win;
-    doc = win.document;
-  });
-
-  function getAmpFont() {
-    doc.body.classList.add('comic-amp-font-loading');
-    doc.documentElement.classList.add('comic-amp-font-loading');
-    const font = doc.createElement('amp-font');
-    font.setAttribute('layout', 'nodisplay');
-    font.setAttribute('font-family', 'Comic AMP');
-    font.setAttribute('timeout', '1000');
-    font.setAttribute('while-loading-class', '');
-    font.setAttribute('on-error-add-class', 'comic-amp-font-missing');
-    font.setAttribute('on-load-add-class', 'comic-amp-font-loaded');
-    font.setAttribute('on-error-remove-class', 'comic-amp-font-loading');
-    font.setAttribute('on-load-remove-class', 'comic-amp-font-loading');
-    doc.body.appendChild(font);
-    return font.build().then(() => font.layoutCallback()).then(() => font);
-  }
-
-  it('should timeout while loading custom font', function() {
-    sandbox.stub(FontLoader.prototype, 'load')
-        .returns(Promise.reject('mock rejection'));
-    return getAmpFont().then(() => {
-      expect(doc.body).to.have.class('comic-amp-font-missing');
-      expect(doc.body).to.not.have.class('comic-amp-font-loading');
-      expect(doc.documentElement).to.have.class('comic-amp-font-missing');
-      expect(doc.documentElement).to.not.have.class('comic-amp-font-loading');
+    beforeEach(() => {
+      ampdoc = env.ampdoc;
+      doc = env.win.document;
+      root = (variant.ampdoc === 'single' ?
+        doc.documentElement : ampdoc.getBody());
+      body = (variant.ampdoc === 'single' ?
+        doc.body : root);
     });
-  });
 
-  it('should load custom font', function() {
-    sandbox.stub(FontLoader.prototype, 'load').returns(Promise.resolve());
-    return getAmpFont().then(() => {
-      expect(doc.body).to.have.class('comic-amp-font-loaded');
-      expect(doc.body).to.not.have.class('comic-amp-font-loading');
-      expect(doc.documentElement).to.have.class('comic-amp-font-loaded');
-      expect(doc.documentElement).to.not.have.class('comic-amp-font-loading');
+    function getAmpFont() {
+      root.classList.add('comic-amp-font-loading');
+      const font = doc.createElement('amp-font');
+      font.setAttribute('layout', 'nodisplay');
+      font.setAttribute('font-family', 'Comic AMP');
+      font.setAttribute('timeout', '1000');
+      font.setAttribute('while-loading-class', '');
+      font.setAttribute('on-error-add-class', 'comic-amp-font-missing');
+      font.setAttribute('on-load-add-class', 'comic-amp-font-loaded');
+      font.setAttribute('on-error-remove-class', 'comic-amp-font-loading');
+      font.setAttribute('on-load-remove-class', 'comic-amp-font-loading');
+      body.appendChild(font);
+      return font.build().then(() => font.layoutCallback()).then(() => font);
+    }
+
+    it('should timeout while loading custom font', function() {
+      sandbox.stub(FontLoader.prototype, 'load')
+          .returns(Promise.reject('mock rejection'));
+      return getAmpFont().then(() => {
+        expect(root).to.have.class('comic-amp-font-missing');
+        expect(root).to.not.have.class('comic-amp-font-loading');
+      });
+    });
+
+    it('should load custom font', function() {
+      sandbox.stub(FontLoader.prototype, 'load').returns(Promise.resolve());
+      return getAmpFont().then(() => {
+        expect(root).to.have.class('comic-amp-font-loaded');
+        expect(root).to.not.have.class('comic-amp-font-loading');
+      });
     });
   });
 });

--- a/extensions/amp-font/0.1/test/test-amp-font.js
+++ b/extensions/amp-font/0.1/test/test-amp-font.js
@@ -32,6 +32,7 @@ describes.realWin('amp-font', {
 
   function getAmpFont() {
     doc.body.classList.add('comic-amp-font-loading');
+    doc.documentElement.classList.add('comic-amp-font-loading');
     const font = doc.createElement('amp-font');
     font.setAttribute('layout', 'nodisplay');
     font.setAttribute('font-family', 'Comic AMP');
@@ -49,20 +50,20 @@ describes.realWin('amp-font', {
     sandbox.stub(FontLoader.prototype, 'load')
         .returns(Promise.reject('mock rejection'));
     return getAmpFont().then(() => {
-      expect(doc.body)
-          .to.have.class('comic-amp-font-missing');
-      expect(doc.body)
-          .to.not.have.class('comic-amp-font-loading');
+      expect(doc.body).to.have.class('comic-amp-font-missing');
+      expect(doc.body).to.not.have.class('comic-amp-font-loading');
+      expect(doc.documentElement).to.have.class('comic-amp-font-missing');
+      expect(doc.documentElement).to.not.have.class('comic-amp-font-loading');
     });
   });
 
   it('should load custom font', function() {
     sandbox.stub(FontLoader.prototype, 'load').returns(Promise.resolve());
     return getAmpFont().then(() => {
-      expect(doc.body)
-          .to.have.class('comic-amp-font-loaded');
-      expect(doc.body)
-          .to.not.have.class('comic-amp-font-loading');
+      expect(doc.body).to.have.class('comic-amp-font-loaded');
+      expect(doc.body).to.not.have.class('comic-amp-font-loading');
+      expect(doc.documentElement).to.have.class('comic-amp-font-loaded');
+      expect(doc.documentElement).to.not.have.class('comic-amp-font-loading');
     });
   });
 });

--- a/extensions/amp-font/0.1/test/test-fontloader.js
+++ b/extensions/amp-font/0.1/test/test-fontloader.js
@@ -16,161 +16,185 @@
 
 import {FontLoader} from '../fontloader';
 
-/** @private @const {string} */
-const FONT_FACE_ = `
-  @font-face {
-    font-family: 'Comic AMP';
-    src: url(/examples/fonts/ComicAMP.ttf) format('truetype');
-  }
+describes.repeated('', {
+  'single ampdoc': {ampdoc: 'single'},
+  'shadow ampdoc': {ampdoc: 'shadow'},
+}, (name, variant) => {
+
+  const FONT_FACE_ = `
+@font-face {
+  font-family: 'Comic AMP';
+  src: url(/examples/fonts/ComicAMP.ttf) format('truetype');
+}
 `;
 
-const CSS_RULES_ = `
-  .comic-amp-font-loaded {
-    font-family: 'Comic AMP', serif, sans-serif;
-    color: #0f0;
-  }
+  const CSS_RULES_ = `
+.comic-amp-font-loaded {
+  font-family: 'Comic AMP', serif, sans-serif;
+  color: #0f0;
+}
 `;
 
-/** @private @const {!FontConfig} */
-const FONT_CONFIG = {
-  style: 'normal',
-  variant: 'normal',
-  weight: '400',
-  size: 'medium',
-  family: 'Comic AMP',
-};
+  /** @private @const {!FontConfig} */
+  const FONT_CONFIG = {
+    style: 'normal',
+    variant: 'normal',
+    weight: '400',
+    size: 'medium',
+    family: 'Comic AMP',
+  };
 
+  /** @private @const {!FontConfig} */
+  const FAILURE_FONT_CONFIG = {
+    style: 'normal',
+    variant: 'normal',
+    weight: '400',
+    size: 'medium',
+    family: 'Comic BLAH',
+  };
 
-/** @private @const {!FontConfig} */
-const FAILURE_FONT_CONFIG = {
-  style: 'normal',
-  variant: 'normal',
-  weight: '400',
-  size: 'medium',
-  family: 'Comic BLAH',
-};
+  describes.realWin('FontLoader', {
+    amp: {
+      ampdoc: variant.ampdoc,
+    },
+  }, env => {
+    let fontloader;
+    let setupFontCheckSpy;
+    let setupFontLoadSpy;
+    let setupLoadWithPolyfillSpy;
+    let setupDisposeSpy;
+    let setupCreateFontComparatorsSpy;
 
-describes.realWin('FontLoader', {amp: true}, env => {
-  let win, doc;
-  let fontloader;
-  let setupFontCheckSpy;
-  let setupFontLoadSpy;
-  let setupLoadWithPolyfillSpy;
-  let setupDisposeSpy;
-  let setupCreateFontComparatorsSpy;
+    let ampdoc, doc, root, body;
 
-  beforeEach(() => {
-    win = env.win;
-    doc = win.document;
-    setupLoadWithPolyfillSpy =
-        sandbox.spy(FontLoader.prototype, 'loadWithPolyfill_');
-    setupCreateFontComparatorsSpy =
-        sandbox.spy(FontLoader.prototype, 'createFontComparators_');
-    setupDisposeSpy = sandbox.spy(FontLoader.prototype, 'dispose_');
-
-    const style = doc.createElement('style');
-    style.textContent = FONT_FACE_ + CSS_RULES_;
-    doc.head.appendChild(style);
-    const textEl = doc.createElement('p');
-    textEl.textContent =
-        'Neque porro quisquam est qui dolorem ipsum quia dolor';
-    doc.body.appendChild(textEl);
-    setupFontCheckSpy = sandbox./*OK*/spy(doc.fonts, 'check');
-    setupFontLoadSpy = sandbox./*OK*/spy(doc.fonts, 'load');
-    fontloader = new FontLoader(env.ampdoc);
-  });
-
-  it('should check and load font via native api', () => {
-    fontloader.load(FONT_CONFIG, 3000).then(() => {
-      doc.documentElement.classList.add('comic-amp-font-loaded');
-      doc.body.classList.add('comic-amp-font-loaded');
-      expect(setupFontCheckSpy).to.be.calledOnce;
-      expect(setupFontLoadSpy).to.be.calledOnce;
-      expect(setupDisposeSpy).to.be.calledOnce;
-    }).catch(() => {
-      assert.fail('Font load failed');
+    beforeEach(() => {
+      ampdoc = env.ampdoc;
+      doc = env.win.document;
+      root = (variant.ampdoc === 'single' ?
+        doc.documentElement : ampdoc.getBody());
+      body = (variant.ampdoc === 'single' ?
+        doc.body : root);
     });
-  });
 
-  it('should check and load font via polyfill', () => {
-    sandbox.stub(FontLoader.prototype, 'canUseNativeApis_').returns(false);
-    fontloader.load(FONT_CONFIG, 3000).then(() => {
-      doc.documentElement.classList.add('comic-amp-font-loaded');
-      doc.body.classList.add('comic-amp-font-loaded');
-      expect(setupFontCheckSpy).to.have.not.been.called;
-      expect(setupFontLoadSpy).to.have.not.been.called;
-      expect(setupLoadWithPolyfillSpy).to.be.calledOnce;
-      expect(setupCreateFontComparatorsSpy).to.be.calledOnce;
-      expect(setupDisposeSpy).to.be.calledOnce;
-    }).catch(() => {
-      assert.fail('Font load failed');
+    beforeEach(() => {
+      ampdoc = env.ampdoc;
+      doc = env.win.document;
+      root = (variant.ampdoc === 'single' ?
+        doc.documentElement : ampdoc.getBody());
+      body = (variant.ampdoc === 'single' ?
+        doc.body : root);
+
+      setupLoadWithPolyfillSpy =
+          sandbox.spy(FontLoader.prototype, 'loadWithPolyfill_');
+      setupCreateFontComparatorsSpy =
+          sandbox.spy(FontLoader.prototype, 'createFontComparators_');
+      setupDisposeSpy = sandbox.spy(FontLoader.prototype, 'dispose_');
+
+      const style = doc.createElement('style');
+      style.textContent = FONT_FACE_ + CSS_RULES_;
+      doc.head.appendChild(style);
+      const textEl = doc.createElement('p');
+      textEl.textContent =
+          'Neque porro quisquam est qui dolorem ipsum quia dolor';
+      body.appendChild(textEl);
+      setupFontCheckSpy = sandbox./*OK*/spy(doc.fonts, 'check');
+      setupFontLoadSpy = sandbox./*OK*/spy(doc.fonts, 'load');
+      fontloader = new FontLoader(env.ampdoc);
     });
-  });
 
-  it('should error when font is not available', () => {
-    fontloader.load(FAILURE_FONT_CONFIG, 3000).then(() => {
-      assert.fail('Font loaded when it should have failed.');
-    }).catch(() => {
-      expect(setupFontCheckSpy).to.be.calledOnce;
-      expect(setupFontLoadSpy).to.be.calledOnce;
-      expect(setupDisposeSpy).to.be.calledOnce;
+    it('should check and load font via native api', () => {
+      fontloader.load(FONT_CONFIG, 3000).then(() => {
+        root.classList.add('comic-amp-font-loaded');
+        body.classList.add('comic-amp-font-loaded');
+        expect(setupFontCheckSpy).to.be.calledOnce;
+        expect(setupFontLoadSpy).to.be.calledOnce;
+        expect(setupDisposeSpy).to.be.calledOnce;
+      }).catch(() => {
+        assert.fail('Font load failed');
+      });
     });
-  });
 
-  it('should error when font is not available via polyfill', () => {
-    sandbox.stub(FontLoader.prototype, 'canUseNativeApis_').returns(false);
-    fontloader.load(FONT_CONFIG, 3000).then(() => {
-      doc.documentElement.classList.add('comic-amp-font-loaded');
-      doc.body.classList.add('comic-amp-font-loaded');
-      assert.fail('Font loaded when it should have failed.');
-    }).catch(() => {
-      expect(setupFontCheckSpy).to.have.not.been.called;
-      expect(setupFontLoadSpy).to.have.not.been.called;
-      expect(setupLoadWithPolyfillSpy).to.be.calledOnce;
-      expect(setupCreateFontComparatorsSpy).to.be.calledOnce;
-      expect(setupDisposeSpy).to.be.calledOnce;
+    it('should check and load font via polyfill', () => {
+      sandbox.stub(FontLoader.prototype, 'canUseNativeApis_').returns(false);
+      fontloader.load(FONT_CONFIG, 3000).then(() => {
+        root.classList.add('comic-amp-font-loaded');
+        body.classList.add('comic-amp-font-loaded');
+        expect(setupFontCheckSpy).to.have.not.been.called;
+        expect(setupFontLoadSpy).to.have.not.been.called;
+        expect(setupLoadWithPolyfillSpy).to.be.calledOnce;
+        expect(setupCreateFontComparatorsSpy).to.be.calledOnce;
+        expect(setupDisposeSpy).to.be.calledOnce;
+      }).catch(() => {
+        assert.fail('Font load failed');
+      });
     });
-  });
 
-  it('should check if elements are being created when using polyfill', () => {
-    sandbox.stub(FontLoader.prototype, 'canUseNativeApis_').returns(false);
-    setupDisposeSpy/*OK*/.restore();
-    setupDisposeSpy =
-        sandbox.stub(FontLoader.prototype, 'dispose_').returns(undefined);
-    const initialElementsCount = doc.getElementsByTagName('*').length;
-    fontloader.load(FONT_CONFIG, 3000).then(() => {
-      doc.documentElement.classList.add('comic-amp-font-loaded');
-      doc.body.classList.add('comic-amp-font-loaded');
-      const finalElementsCount = doc.getElementsByTagName('*').length;
-      expect(initialElementsCount).to.be.below(finalElementsCount);
-      const createdContainer = doc.querySelectorAll('body > div')[1];
-      expect(createdContainer.fontStyle).to.equal('normal');
-      expect(createdContainer.fontWeight).to.equal('400');
-      expect(createdContainer.fontVariant).to.equal('normal');
-    }).catch(() => {
-      assert.fail('Font load failed');
+    it('should error when font is not available', () => {
+      fontloader.load(FAILURE_FONT_CONFIG, 3000).then(() => {
+        assert.fail('Font loaded when it should have failed.');
+      }).catch(() => {
+        expect(setupFontCheckSpy).to.be.calledOnce;
+        expect(setupFontLoadSpy).to.be.calledOnce;
+        expect(setupDisposeSpy).to.be.calledOnce;
+      });
     });
-  });
 
-  it('should check if elements created using the polyfill are disposed', () => {
-    sandbox.stub(FontLoader.prototype, 'canUseNativeApis_').returns(false);
-    const initialElementsCount = doc.getElementsByTagName('*').length;
-    fontloader.load(FONT_CONFIG, 3000).then(() => {
-      doc.documentElement.classList.add('comic-amp-font-loaded');
-      doc.body.classList.add('comic-amp-font-loaded');
-      const finalElementsCount = doc.getElementsByTagName('*').length;
-      expect(initialElementsCount).to.equal(finalElementsCount);
-    }).catch(() => {
-      assert.fail('Font load failed');
+    it('should error when font is not available via polyfill', () => {
+      sandbox.stub(FontLoader.prototype, 'canUseNativeApis_').returns(false);
+      fontloader.load(FONT_CONFIG, 3000).then(() => {
+        root.classList.add('comic-amp-font-loaded');
+        body.classList.add('comic-amp-font-loaded');
+        assert.fail('Font loaded when it should have failed.');
+      }).catch(() => {
+        expect(setupFontCheckSpy).to.have.not.been.called;
+        expect(setupFontLoadSpy).to.have.not.been.called;
+        expect(setupLoadWithPolyfillSpy).to.be.calledOnce;
+        expect(setupCreateFontComparatorsSpy).to.be.calledOnce;
+        expect(setupDisposeSpy).to.be.calledOnce;
+      });
     });
-  });
 
-  it('should check compare elements', () => {
-    return fontloader.load(FONT_CONFIG, 3000).then(() => {
-      const comparators = fontloader.createFontComparators_();
-      expect(comparators.some(c => c.compare())).to.be.true;
-    }).catch(() => {
-      assert.fail('Font load failed');
+    it('should check if elements are being created when using polyfill', () => {
+      sandbox.stub(FontLoader.prototype, 'canUseNativeApis_').returns(false);
+      setupDisposeSpy/*OK*/.restore();
+      setupDisposeSpy =
+          sandbox.stub(FontLoader.prototype, 'dispose_').returns(undefined);
+      const initialElementsCount = doc.getElementsByTagName('*').length;
+      fontloader.load(FONT_CONFIG, 3000).then(() => {
+        root.classList.add('comic-amp-font-loaded');
+        body.classList.add('comic-amp-font-loaded');
+        const finalElementsCount = doc.getElementsByTagName('*').length;
+        expect(initialElementsCount).to.be.below(finalElementsCount);
+        const createdContainer = doc.querySelectorAll('body > div')[1];
+        expect(createdContainer.fontStyle).to.equal('normal');
+        expect(createdContainer.fontWeight).to.equal('400');
+        expect(createdContainer.fontVariant).to.equal('normal');
+      }).catch(() => {
+        assert.fail('Font load failed');
+      });
+    });
+
+    it('should check if elements created using the polyfill ' +
+        'are disposed', () => {
+      sandbox.stub(FontLoader.prototype, 'canUseNativeApis_').returns(false);
+      const initialElementsCount = doc.getElementsByTagName('*').length;
+      fontloader.load(FONT_CONFIG, 3000).then(() => {
+        root.classList.add('comic-amp-font-loaded');
+        body.classList.add('comic-amp-font-loaded');
+        const finalElementsCount = doc.getElementsByTagName('*').length;
+        expect(initialElementsCount).to.equal(finalElementsCount);
+      }).catch(() => {
+        assert.fail('Font load failed');
+      });
+    });
+
+    it('should check compare elements', () => {
+      return fontloader.load(FONT_CONFIG, 3000).then(() => {
+        const comparators = fontloader.createFontComparators_();
+        expect(comparators.some(c => c.compare())).to.be.true;
+      }).catch(() => {
+        assert.fail('Font load failed');
+      });
     });
   });
 });

--- a/extensions/amp-font/0.1/test/test-fontloader.js
+++ b/extensions/amp-font/0.1/test/test-fontloader.js
@@ -82,6 +82,7 @@ describes.realWin('FontLoader', {amp: true}, env => {
 
   it('should check and load font via native api', () => {
     fontloader.load(FONT_CONFIG, 3000).then(() => {
+      doc.documentElement.classList.add('comic-amp-font-loaded');
       doc.body.classList.add('comic-amp-font-loaded');
       expect(setupFontCheckSpy).to.be.calledOnce;
       expect(setupFontLoadSpy).to.be.calledOnce;
@@ -94,6 +95,7 @@ describes.realWin('FontLoader', {amp: true}, env => {
   it('should check and load font via polyfill', () => {
     sandbox.stub(FontLoader.prototype, 'canUseNativeApis_').returns(false);
     fontloader.load(FONT_CONFIG, 3000).then(() => {
+      doc.documentElement.classList.add('comic-amp-font-loaded');
       doc.body.classList.add('comic-amp-font-loaded');
       expect(setupFontCheckSpy).to.have.not.been.called;
       expect(setupFontLoadSpy).to.have.not.been.called;
@@ -118,6 +120,7 @@ describes.realWin('FontLoader', {amp: true}, env => {
   it('should error when font is not available via polyfill', () => {
     sandbox.stub(FontLoader.prototype, 'canUseNativeApis_').returns(false);
     fontloader.load(FONT_CONFIG, 3000).then(() => {
+      doc.documentElement.classList.add('comic-amp-font-loaded');
       doc.body.classList.add('comic-amp-font-loaded');
       assert.fail('Font loaded when it should have failed.');
     }).catch(() => {
@@ -136,6 +139,7 @@ describes.realWin('FontLoader', {amp: true}, env => {
         sandbox.stub(FontLoader.prototype, 'dispose_').returns(undefined);
     const initialElementsCount = doc.getElementsByTagName('*').length;
     fontloader.load(FONT_CONFIG, 3000).then(() => {
+      doc.documentElement.classList.add('comic-amp-font-loaded');
       doc.body.classList.add('comic-amp-font-loaded');
       const finalElementsCount = doc.getElementsByTagName('*').length;
       expect(initialElementsCount).to.be.below(finalElementsCount);
@@ -152,6 +156,7 @@ describes.realWin('FontLoader', {amp: true}, env => {
     sandbox.stub(FontLoader.prototype, 'canUseNativeApis_').returns(false);
     const initialElementsCount = doc.getElementsByTagName('*').length;
     fontloader.load(FONT_CONFIG, 3000).then(() => {
+      doc.documentElement.classList.add('comic-amp-font-loaded');
       doc.body.classList.add('comic-amp-font-loaded');
       const finalElementsCount = doc.getElementsByTagName('*').length;
       expect(initialElementsCount).to.equal(finalElementsCount);

--- a/extensions/amp-font/0.1/test/test-fontloader.js
+++ b/extensions/amp-font/0.1/test/test-fontloader.js
@@ -77,12 +77,12 @@ describes.realWin('FontLoader', {amp: true}, env => {
     doc.body.appendChild(textEl);
     setupFontCheckSpy = sandbox./*OK*/spy(doc.fonts, 'check');
     setupFontLoadSpy = sandbox./*OK*/spy(doc.fonts, 'load');
-    fontloader = new FontLoader(win);
+    fontloader = new FontLoader(env.ampdoc);
   });
 
   it('should check and load font via native api', () => {
     fontloader.load(FONT_CONFIG, 3000).then(() => {
-      doc.documentElement.classList.add('comic-amp-font-loaded');
+      doc.body.classList.add('comic-amp-font-loaded');
       expect(setupFontCheckSpy).to.be.calledOnce;
       expect(setupFontLoadSpy).to.be.calledOnce;
       expect(setupDisposeSpy).to.be.calledOnce;
@@ -94,7 +94,7 @@ describes.realWin('FontLoader', {amp: true}, env => {
   it('should check and load font via polyfill', () => {
     sandbox.stub(FontLoader.prototype, 'canUseNativeApis_').returns(false);
     fontloader.load(FONT_CONFIG, 3000).then(() => {
-      doc.documentElement.classList.add('comic-amp-font-loaded');
+      doc.body.classList.add('comic-amp-font-loaded');
       expect(setupFontCheckSpy).to.have.not.been.called;
       expect(setupFontLoadSpy).to.have.not.been.called;
       expect(setupLoadWithPolyfillSpy).to.be.calledOnce;
@@ -118,7 +118,7 @@ describes.realWin('FontLoader', {amp: true}, env => {
   it('should error when font is not available via polyfill', () => {
     sandbox.stub(FontLoader.prototype, 'canUseNativeApis_').returns(false);
     fontloader.load(FONT_CONFIG, 3000).then(() => {
-      doc.documentElement.classList.add('comic-amp-font-loaded');
+      doc.body.classList.add('comic-amp-font-loaded');
       assert.fail('Font loaded when it should have failed.');
     }).catch(() => {
       expect(setupFontCheckSpy).to.have.not.been.called;
@@ -136,7 +136,7 @@ describes.realWin('FontLoader', {amp: true}, env => {
         sandbox.stub(FontLoader.prototype, 'dispose_').returns(undefined);
     const initialElementsCount = doc.getElementsByTagName('*').length;
     fontloader.load(FONT_CONFIG, 3000).then(() => {
-      doc.documentElement.classList.add('comic-amp-font-loaded');
+      doc.body.classList.add('comic-amp-font-loaded');
       const finalElementsCount = doc.getElementsByTagName('*').length;
       expect(initialElementsCount).to.be.below(finalElementsCount);
       const createdContainer = doc.querySelectorAll('body > div')[1];
@@ -152,7 +152,7 @@ describes.realWin('FontLoader', {amp: true}, env => {
     sandbox.stub(FontLoader.prototype, 'canUseNativeApis_').returns(false);
     const initialElementsCount = doc.getElementsByTagName('*').length;
     fontloader.load(FONT_CONFIG, 3000).then(() => {
-      doc.documentElement.classList.add('comic-amp-font-loaded');
+      doc.body.classList.add('comic-amp-font-loaded');
       const finalElementsCount = doc.getElementsByTagName('*').length;
       expect(initialElementsCount).to.equal(finalElementsCount);
     }).catch(() => {

--- a/extensions/amp-font/amp-font.md
+++ b/extensions/amp-font/amp-font.md
@@ -41,7 +41,7 @@ limitations under the License.
 
 The `amp-font` extension should be used for controlling timeouts on font loading.
 
-The `amp-font` extension allows adding and removing CSS classes from `document.documentElement` based on whether a font was loaded or is in error-state.
+The `amp-font` extension allows adding and removing CSS classes from `document.body` based on whether a font was loaded or is in error-state.
 
 Example:
 ```html
@@ -82,19 +82,19 @@ Time in milliseconds after which the we don't wait for the custom font to be ava
 
 ##### on-load-add-class
 
-CSS class that would be added to the `document.documentElement`  after making sure that the custom font is available for display. This attribute is optional.
+CSS class that would be added to the `document.body` after making sure that the custom font is available for display. This attribute is optional.
 
 ##### on-load-remove-class
 
-CSS class that would be removed from the `document.documentElement` and `document.body` after making sure that the custom font is available for display. This attribute is optional.
+CSS class that would be removed from the `document.body` after making sure that the custom font is available for display. This attribute is optional.
 
 ##### on-error-add-class
 
-CSS class that would be added to the `document.documentElement`, if the timeout interval runs out before the font becomes available for use. This attribute is optional.
+CSS class that would be added to the `document.body`, if the timeout interval runs out before the font becomes available for use. This attribute is optional.
 
 **on-error-remove-class**
 
-CSS class that would be removed from the `document.documentElement` and `document.body` , if the timeout interval runs out before the font becomes available for use. This attribute is optional.
+CSS class that would be removed from the `document.body`, if the timeout interval runs out before the font becomes available for use. This attribute is optional.
 
 ##### font-weight, font-style, font-variant
 

--- a/extensions/amp-font/amp-font.md
+++ b/extensions/amp-font/amp-font.md
@@ -41,7 +41,8 @@ limitations under the License.
 
 The `amp-font` extension should be used for controlling timeouts on font loading.
 
-The `amp-font` extension allows adding and removing CSS classes from `document.body` based on whether a font was loaded or is in error-state.
+The `amp-font` extension allows adding and removing CSS classes from `document.documentElement`
+or `document.body` based on whether a font was loaded or is in error-state.
 
 Example:
 ```html
@@ -60,6 +61,8 @@ Example:
 ```
 
 The extension observes loading of a font and when it loads executes the optional attributes `on-load-add-class` and `on-load-remove-class` and when there is any error or timeout runs `on-error-remove-class` and `on-error-add-class`.
+These classes are toggled on the `documentElement` for standalone documents, and on `body` for documents
+without a `documentElement` i.e. inside a `ShadowRoot`.
 
 Using these classes authors can guard whether a font is displayed and get the following results:
 
@@ -82,19 +85,19 @@ Time in milliseconds after which the we don't wait for the custom font to be ava
 
 ##### on-load-add-class
 
-CSS class that would be added to the `document.body` after making sure that the custom font is available for display. This attribute is optional.
+CSS class that would be added to the document root after making sure that the custom font is available for display. This attribute is optional.
 
 ##### on-load-remove-class
 
-CSS class that would be removed from the `document.body` after making sure that the custom font is available for display. This attribute is optional.
+CSS class that would be removed from the document root after making sure that the custom font is available for display. This attribute is optional.
 
 ##### on-error-add-class
 
-CSS class that would be added to the `document.body`, if the timeout interval runs out before the font becomes available for use. This attribute is optional.
+CSS class that would be added to the document root if the timeout interval runs out before the font becomes available for use. This attribute is optional.
 
 **on-error-remove-class**
 
-CSS class that would be removed from the `document.body`, if the timeout interval runs out before the font becomes available for use. This attribute is optional.
+CSS class that would be removed from the document root if the timeout interval runs out before the font becomes available for use. This attribute is optional.
 
 ##### font-weight, font-style, font-variant
 


### PR DESCRIPTION
Fixes #12098 for Firefox and Safari.

The test-elements for the `FontLoader` were not being attached inside a ShadowRoot, they were being attached to the outer `window.document`. This PR passes the `ampdoc` instead of the `window` to the `FontLoader` to make it compatible with documents in a ShadowRoot.

I also cleaned up some superfluous annotations.