### PR TITLE
amp-animation: remove ticker warning

### DIFF
--- a/extensions/amp-animation/0.1/web-animations.js
+++ b/extensions/amp-animation/0.1/web-animations.js
@@ -594,14 +594,6 @@ export class MeasureScanner extends Scanner {
   onKeyframeAnimation(spec) {
     this.with_(spec, () => {
       const target = user().assertElement(this.target_, 'No target specified');
-      //TODO(aghassemi,#10911): Remove this warning later.
-      if (spec && spec.ticker) {
-        user().error(TAG, 'Experimental `ticker` property has been removed. ' +
-          'For scroll-bound animations, please see the new approach at ' +
-          'https://github.com/ampproject/amphtml/blob/master/extensions/' +
-          'amp-position-observer/amp-position-observer.md'
-        );
-      }
       const keyframes = this.createKeyframes_(target, spec);
       this.requests_.push({
         target,


### PR DESCRIPTION
Enough time has passed for the warning, removing it.

Closes https://github.com/ampproject/amphtml/issues/10911