### PR TITLE
Fix iOS relayout bug with debounce and onorientationchange

### DIFF
--- a/extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.js
+++ b/extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.js
@@ -501,6 +501,10 @@ export class AmpLightboxViewer extends AMP.BaseElement {
         'click', toggleControls);
   }
 
+  /**
+   * Clean up event listeners.
+   * @private
+   */
   cleanupEventListeners_() {
     if (this.unlistenResize_) {
       this.unlistenResize_();
@@ -729,10 +733,10 @@ export class AmpLightboxViewer extends AMP.BaseElement {
 
     // Register an onResize handler to resize the image viewer
     this.unlistenResize_ = this.getViewport().onResize(() => {
-      if (!platform.isIos()) {
-        onResize();
-      } else if (platform.isSafari()) {
+      if (platform.isIos() && platform.isSafari()) {
         debouncedOnResize();
+      } else {
+        onResize();
       }
     });
 

--- a/extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.js
+++ b/extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.js
@@ -273,7 +273,7 @@ export class AmpLightboxViewer extends AMP.BaseElement {
     const tagName = this.elementsMetadata_[this.currentElemId_]
         .tagName;
     if (tagName === 'AMP-IMG') {
-      this.onResize_();
+      this.resizeCurrentImageViewer_();
       this.registerOnResizeHandler_();
     }
     this.updateDescriptionBox_();
@@ -607,7 +607,7 @@ export class AmpLightboxViewer extends AMP.BaseElement {
         .tagName;
     if (tagName === 'AMP-IMG') {
       this.registerOnResizeHandler_();
-      this.onResize_().then(() => this.enter_(element));
+      this.resizeCurrentImageViewer_().then(() => this.enter_(element));
     }
     this.updateDescriptionBox_();
   }
@@ -695,7 +695,7 @@ export class AmpLightboxViewer extends AMP.BaseElement {
    * @return {!Promise}
    * @private
    */
-  onResize_() {
+  resizeCurrentImageViewer_() {
     const imgViewer = this.elementsMetadata_[this.currentElemId_].imageViewer;
     return imgViewer.measure();
   }
@@ -720,17 +720,17 @@ export class AmpLightboxViewer extends AMP.BaseElement {
    */
   registerOnResizeHandler_() {
     const platform = Services.platformFor(this.win);
-    const boundOnResize = this.onResize_.bind(this);
+    const onResize = this.resizeCurrentImageViewer_.bind(this);
 
     // Special case for iOS browsers due to Webkit bug #170595
     // https://bugs.webkit.org/show_bug.cgi?id=170595
     // Delay the onResize by 500 ms to ensure correct height and width
-    const debouncedOnResize = debounce(this.win, boundOnResize, 500);
+    const debouncedOnResize = debounce(this.win, onResize, 500);
 
     // Register an onResize handler to resize the image viewer
     this.unlistenResize_ = this.getViewport().onResize(() => {
       if (!platform.isIos()) {
-        boundOnResize();
+        onResize();
       } else if (platform.isSafari()) {
         debouncedOnResize();
       }
@@ -901,7 +901,7 @@ export class AmpLightboxViewer extends AMP.BaseElement {
       // type checking to work.
       /**@type {?}*/ (this.carousel_).implementation_.showSlideWhenReady(
           this.currentElemId_);
-      this.onResize_();
+      this.resizeCurrentImageViewer_();
       this.registerOnResizeHandler_();
       this.updateDescriptionBox_();
       event.stopPropagation();

--- a/src/service/viewport/viewport-impl.js
+++ b/src/service/viewport/viewport-impl.js
@@ -533,6 +533,11 @@ export class Viewport {
    * @param {!function(!ViewportResizedEventDef)} handler
    * @return {!UnlistenDef}
    */
+
+  // Note that there is a known bug in Webkit that causes window.innerWidth
+  // and window.innerHeight values to be incorrect after resize. A temporary
+  // fix is to add a 500 ms delay before computing these values.
+  // Link: https://bugs.webkit.org/show_bug.cgi?id=170595
   onResize(handler) {
     return this.resizeObservable_.add(handler);
   }


### PR DESCRIPTION
Closes https://github.com/ampproject/amphtml/issues/12363

Two separate issues here: 
1. [Webkit bug #170595](https://bugs.webkit.org/show_bug.cgi?id=170595) means we need to introduce a 500ms delay to the onResize event for all browsers running on iOS. 
2. `onResize` doesn't fire reliably on iOS Chrome and Firefox, hence we need to listen to `orientationchange` instead. 

I lightly refactored the setup and cleanup of event listeners into their own separate functions. 
