### PR TITLE
Validator: allow "i-amphtml-ssr" attribute for amp-pixel

### DIFF
--- a/builtins/amp-pixel.md
+++ b/builtins/amp-pixel.md
@@ -59,6 +59,13 @@ This attribute is similar to the `referrerpolicy` attribute on `<img>`, however 
     layout="nodisplay"
     referrerpolicy="no-referrer"></amp-pixel>
 ```
+##### i-amphtml-ssr (optional)
+
+This attribute allows for Server Side Rendering optimization for AMP inabox
+creatives such that an img tag can be written directly within the amp-pixel
+tag as part of post-validation transformation.  This allows for the pixel
+to be sent in parallel with fetch/execution of the AMP runtime.
+
 ##### common attributes
 
 This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -3547,6 +3547,9 @@ tags: {  # <amp-pixel>
     value: "no-referrer"
   }
   attrs: {
+    name: "i-amphtml-ssr"
+  }
+  attrs: {
     name: "src"
     mandatory: true
     value_url: {
@@ -4455,4 +4458,3 @@ error_formats {
   format: "CSS syntax error in tag '%1' - the property '%2' is disallowed "
           "unless the enclosing rule is prefixed with the '%3' qualification."
 }
-


### PR DESCRIPTION
Add validator support for i-amphtml-ssr attribute added in #12017 Attribute's existence indicates that post-validation transformation for inabox creatives can inject a standard img tag within amp-pixel allowing for request to be sent in parallel with AMP runtime fetch/execution.  Resolves #12017 