### PR TITLE
Edge case for visiblePercentageMin and Max = 0

### DIFF
--- a/extensions/amp-analytics/0.1/test/test-visibility-model.js
+++ b/extensions/amp-analytics/0.1/test/test-visibility-model.js
@@ -995,6 +995,28 @@ describes.sandboxed('VisibilityModel', {}, () => {
       vh.update();
       expect(eventSpy).to.be.calledOnce;
     });
+
+    it('should fire for visiblePercentageMin=visiblePercentageMax=0', () => {
+      const vh = new VisibilityModel({
+        visiblePercentageMin: 0,
+        visiblePercentageMax: 0,
+      }, calcVisibility);
+      const eventSpy = vh.eventResolver_ = sandbox.spy();
+      visibility = 0;
+      clock.tick(200);
+      expect(eventSpy).to.not.be.called;
+      vh.update();
+
+      visibility = 0.1;
+      clock.tick(200);
+      expect(eventSpy).to.not.be.called;
+      vh.update();
+
+      visibility = 0;
+      clock.tick(200);
+      vh.update();
+      expect(eventSpy).to.be.calledOnce;
+    });
   });
 
   describe('end to end event repeat', () => {

--- a/extensions/amp-analytics/0.1/test/test-visibility-model.js
+++ b/extensions/amp-analytics/0.1/test/test-visibility-model.js
@@ -1000,6 +1000,7 @@ describes.sandboxed('VisibilityModel', {}, () => {
       const vh = new VisibilityModel({
         visiblePercentageMin: 0,
         visiblePercentageMax: 0,
+        repeat: true,
       }, calcVisibility);
       const eventSpy = vh.eventResolver_ = sandbox.spy();
       visibility = 0;
@@ -1007,7 +1008,18 @@ describes.sandboxed('VisibilityModel', {}, () => {
       expect(eventSpy).to.not.be.called;
       vh.update();
 
-      visibility = 0.1;
+      visibility = 1;
+      clock.tick(200);
+      expect(eventSpy).to.not.be.called;
+      vh.update();
+
+      visibility = 0;
+      clock.tick(200);
+      vh.update();
+      expect(eventSpy).to.be.calledOnce;
+
+      eventSpy.reset();
+      visibility = 1;
       clock.tick(200);
       expect(eventSpy).to.not.be.called;
       vh.update();

--- a/extensions/amp-analytics/0.1/test/test-visibility-model.js
+++ b/extensions/amp-analytics/0.1/test/test-visibility-model.js
@@ -1003,8 +1003,8 @@ describes.sandboxed('VisibilityModel', {}, () => {
         repeat: true,
       }, calcVisibility);
       const eventSpy = vh.eventResolver_ = sandbox.spy();
-      const updateStub = sandbox.stub(vh, 'reset_').callsFake(() => {
-        vh.eventPromise_ = new Promise(resolve => {
+      sandbox.stub(vh, 'reset_').callsFake(() => {
+        vh.eventPromise_ = new Promise(unused => {
           vh.eventResolver_ = eventSpy;
         });
         vh.eventPromise_.then(() => {

--- a/extensions/amp-analytics/0.1/test/test-visibility-model.js
+++ b/extensions/amp-analytics/0.1/test/test-visibility-model.js
@@ -67,9 +67,9 @@ describes.sandboxed('VisibilityModel', {}, () => {
       expect(config({visiblePercentageMax: ''}).visiblePercentageMax)
           .to.equal(1);
       expect(config({visiblePercentageMax: 0}).visiblePercentageMax)
-          .to.equal(1);
+          .to.equal(0);
       expect(config({visiblePercentageMax: '0'}).visiblePercentageMax)
-          .to.equal(1);
+          .to.equal(0);
       expect(config({visiblePercentageMax: 50}).visiblePercentageMax)
           .to.equal(0.5);
       expect(config({visiblePercentageMax: '50'}).visiblePercentageMax)
@@ -988,8 +988,8 @@ describes.sandboxed('VisibilityModel', {}, () => {
       const eventSpy = vh.eventResolver_ = sandbox.spy();
       visibility = 0.99;
       clock.tick(200);
-      expect(eventSpy).to.not.be.called;
       vh.update();
+      expect(eventSpy).to.not.be.called;
       visibility = 1.0;
       clock.tick(200);
       vh.update();
@@ -1003,15 +1003,38 @@ describes.sandboxed('VisibilityModel', {}, () => {
         repeat: true,
       }, calcVisibility);
       const eventSpy = vh.eventResolver_ = sandbox.spy();
+      const updateStub = sandbox.stub(vh, 'reset_').callsFake(() => {
+        vh.eventPromise_ = new Promise(resolve => {
+          vh.eventResolver_ = eventSpy;
+        });
+        vh.eventPromise_.then(() => {
+          vh.onTriggerObservable_.fire();
+        });
+        vh.scheduleRepeatId_ = null;
+        vh.everMatchedVisibility_ = false;
+        vh.matchesVisibility_ = false;
+        vh.continuousTime_ = 0;
+        vh.maxContinuousVisibleTime_ = 0;
+        vh.totalVisibleTime_ = 0;
+        vh.firstVisibleTime_ = 0;
+        vh.firstSeenTime_ = 0;
+        vh.lastSeenTime_ = 0;
+        vh.lastVisibleTime_ = 0;
+        vh.minVisiblePercentage_ = 0;
+        vh.maxVisiblePercentage_ = 0;
+        vh.lastVisibleUpdateTime_ = 0;
+        vh.waitToReset_ = false;
+      });
+
       visibility = 0;
       clock.tick(200);
-      expect(eventSpy).to.not.be.called;
       vh.update();
+      expect(eventSpy).to.not.be.called;
 
       visibility = 1;
       clock.tick(200);
-      expect(eventSpy).to.not.be.called;
       vh.update();
+      expect(eventSpy).to.not.be.called;
 
       visibility = 0;
       clock.tick(200);
@@ -1021,8 +1044,8 @@ describes.sandboxed('VisibilityModel', {}, () => {
       eventSpy.reset();
       visibility = 1;
       clock.tick(200);
-      expect(eventSpy).to.not.be.called;
       vh.update();
+      expect(eventSpy).to.not.be.called;
 
       visibility = 0;
       clock.tick(200);

--- a/extensions/amp-analytics/0.1/test/test-visibility-model.js
+++ b/extensions/amp-analytics/0.1/test/test-visibility-model.js
@@ -1025,17 +1025,6 @@ describes.sandboxed('VisibilityModel', {}, () => {
         vh.lastVisibleUpdateTime_ = 0;
         vh.waitToReset_ = false;
       });
-
-      visibility = 0;
-      clock.tick(200);
-      vh.update();
-      expect(eventSpy).to.not.be.called;
-
-      visibility = 1;
-      clock.tick(200);
-      vh.update();
-      expect(eventSpy).to.not.be.called;
-
       visibility = 0;
       clock.tick(200);
       vh.update();

--- a/extensions/amp-analytics/0.1/visibility-model.js
+++ b/extensions/amp-analytics/0.1/visibility-model.js
@@ -358,10 +358,9 @@ export class VisibilityModel {
     if (this.spec_.visiblePercentageMin == 1) {
       return visibility == 1;
     }
-    // Special case: If visiblePercentageMin and Max are both 0, then we
+    // Special case: If visiblePercentageMax is 0%, then we
     // want to ping when the creative becomes not visible.
-    if (this.spec_.visiblePercentageMin == 0 &&
-        this.spec_.visiblePercentageMax == 0) {
+    if (this.spec_.visiblePercentageMax == 0) {
       return visibility == 0;
     }
     return visibility > this.spec_.visiblePercentageMin &&

--- a/extensions/amp-analytics/0.1/visibility-model.js
+++ b/extensions/amp-analytics/0.1/visibility-model.js
@@ -359,8 +359,7 @@ export class VisibilityModel {
       return visibility == 1;
     }
     // Special case: If visiblePercentageMin and Max are both 0, then we
-    // want to ping when the creative becomes not visible after having
-    // previously been visible.
+    // want to ping when the creative becomes not visible.
     if (this.spec_.visiblePercentageMin == 0 &&
         this.spec_.visiblePercentageMax == 0) {
       return visibility == 0;

--- a/extensions/amp-analytics/0.1/visibility-model.js
+++ b/extensions/amp-analytics/0.1/visibility-model.js
@@ -44,18 +44,16 @@ export class VisibilityModel {
      */
     this.spec_ = {
       visiblePercentageMin: Number(spec['visiblePercentageMin']) / 100 || 0,
-      visiblePercentageMax: Number(spec['visiblePercentageMax']) / 100,
+      visiblePercentageMax: Number(spec['visiblePercentageMax']) / 100 || 1,
       totalTimeMin: Number(spec['totalTimeMin']) || 0,
       totalTimeMax: Number(spec['totalTimeMax']) || Infinity,
       continuousTimeMin: Number(spec['continuousTimeMin']) || 0,
       continuousTimeMax: Number(spec['continuousTimeMax']) || Infinity,
     };
-    // If visiblePercentageMax was not specified, assume 100% (but do allow
-    // 0% to have been specified)
-    if (spec['visiblePercentageMax'] === null ||
-        spec['visiblePercentageMax'] === '' ||
-        isNaN(spec['visiblePercentageMax'])) {
-      this.spec_.visiblePercentageMax = 1;
+    // Above, if visiblePercentageMax was not specified, assume 100%.
+    // Here, do allow 0% to be the value if that is what was specified.
+    if (String(spec['visiblePercentageMax']).trim() === '0') {
+      this.spec_.visiblePercentageMax = 0;
     }
 
     /** @private {boolean} */
@@ -133,12 +131,8 @@ export class VisibilityModel {
     /** @private {time} milliseconds since epoch */
     this.lastVisibleUpdateTime_ = 0;
 
-    /**
-     * Want to fire when visibility becomes zero, *after* having been
-     * non-zero. So, set up the state as though it needs to wait to fire.
-     * @private {boolean} */
-    this.waitToReset_ = this.spec_.visiblePercentageMin == 0 &&
-        this.spec_.visiblePercentageMax == 0;
+    /** @private {boolean} */
+    this.waitToReset_ = false;
 
     /** @private {?number} */
     this.scheduleRepeatId_ = null;


### PR DESCRIPTION
If the config sets visiblePercentageMin and visiblePercentageMax both to 0, then we want to ping when the creative *stops* being visible. Do not ping right away if it's invisible at page load time.