### PR TITLE
Unbreak extensions with versions≠0.1 in ShadowDOM

### DIFF
--- a/src/runtime.js
+++ b/src/runtime.js
@@ -746,14 +746,20 @@ class MultidocManager {
                   src.indexOf('/v0.js') != -1;
               const customElement = n.getAttribute('custom-element');
               const customTemplate = n.getAttribute('custom-template');
+              const versionRe = /-(\d+.\d+)(.max)?\.js$/;
+              const match = versionRe.exec(src);
+              const version = match ? match[1] : '0.1';
               if (isRuntime) {
                 dev().fine(TAG, '- ignore runtime script: ', src);
               } else if (customElement || customTemplate) {
                 // This is an extension.
                 this.extensions_.installExtensionForDoc(
-                    ampdoc, customElement || customTemplate);
+                    ampdoc, customElement || customTemplate, version);
                 dev().fine(
-                    TAG, '- load extension: ', customElement || customTemplate);
+                    TAG, '- load extension: ',
+                    customElement || customTemplate,
+                    ' ',
+                    version);
                 if (customElement) {
                   extensionIds.push(customElement);
                 }

--- a/src/service-worker/shell.js
+++ b/src/service-worker/shell.js
@@ -26,5 +26,5 @@ installWorkerErrorReporting('sw');
  * thus, if a new SW must be installed) will be very fast.
  */
 const url = calculateExtensionScriptUrl(self.location, 'cache-service-worker',
-    getMode().localDev);
+    /*opt_extensionVersion*/ undefined, getMode().localDev);
 importScripts(url);

--- a/src/service/extension-location.js
+++ b/src/service/extension-location.js
@@ -20,11 +20,11 @@ import {getMode} from '../mode';
 /**
  * Calculate the base url for any scripts.
  * @param {!Location} location The window's location
- * @param {boolean=} isLocalDev
+ * @param {boolean=} opt_isLocalDev
  * @return {string}
  */
-function calculateScriptBaseUrl(location, isLocalDev) {
-  if (isLocalDev) {
+function calculateScriptBaseUrl(location, opt_isLocalDev) {
+  if (opt_isLocalDev) {
     return `${location.protocol}//${location.host}/dist`;
   }
   return urls.cdn;
@@ -34,12 +34,16 @@ function calculateScriptBaseUrl(location, isLocalDev) {
  * Calculate script url for an extension.
  * @param {!Location} location The window's location
  * @param {string} extensionId
- * @param {boolean=} isLocalDev
+ * @param {string=} opt_extensionVersion
+ * @param {boolean=} opt_isLocalDev
  * @return {string}
  */
-export function calculateExtensionScriptUrl(location, extensionId, isLocalDev) {
-  const base = calculateScriptBaseUrl(location, isLocalDev);
-  return `${base}/rtv/${getMode().rtvVersion}/v0/${extensionId}-0.1.js`;
+export function calculateExtensionScriptUrl(location, extensionId,
+    opt_extensionVersion, opt_isLocalDev) {
+  const base = calculateScriptBaseUrl(location, opt_isLocalDev);
+  const rtv = getMode().rtvVersion;
+  const extensionVersion = opt_extensionVersion || '0.1';
+  return `${base}/rtv/${rtv}/v0/${extensionId}-${extensionVersion}.js`;
 }
 
 /**

--- a/test/functional/test-extension-location.js
+++ b/test/functional/test-extension-location.js
@@ -40,7 +40,7 @@ describes.sandboxed('Extension Location', {}, () => {
         pathname: 'examples/ads.amp.html',
         host: 'localhost:8000',
         protocol: 'http:',
-      }, 'amp-ad', true);
+      }, 'amp-ad', /*opt_extensionVersion*/ undefined, true);
       expect(script).to.equal(
           'http://localhost:8000/dist/rtv/123/v0/amp-ad-0.1.js');
     });
@@ -51,7 +51,7 @@ describes.sandboxed('Extension Location', {}, () => {
         pathname: 'examples/ads.amp.html',
         host: 'localhost:8000',
         protocol: 'http:',
-      }, 'amp-ad', false);
+      }, 'amp-ad', /*opt_extensionVersion*/ undefined, false);
       expect(script).to.equal(
           'https://cdn.ampproject.org/rtv/123/v0/amp-ad-0.1.js');
     });

--- a/test/functional/test-extensions.js
+++ b/test/functional/test-extensions.js
@@ -581,6 +581,19 @@ describes.sandboxed('Extensions', {}, () => {
       expect(win.customElements.elements['amp-test']).to.be.undefined;
     });
 
+    it('should insert extension version correctly', () => {
+      expect(doc.head.querySelectorAll(
+          '[custom-element="amp-test"]')).to.have.length(0);
+      expect(extensions.extensions_['amp-test']).to.be.undefined;
+      extensions.preloadExtension('amp-test', '1.0');
+      expect(doc.head.querySelectorAll(
+          '[custom-element="amp-test"][src*="0.1"]')).to.have.length(0);
+      expect(doc.head.querySelectorAll(
+          '[custom-element="amp-test"][src*="1.0"]')).to.have.length(1);
+      expect(extensions.extensions_['amp-test'].scriptPresent).to.be.true;
+      expect(win.customElements.elements['amp-test']).to.be.undefined;
+    });
+
     it('should only insert script once', () => {
       expect(doc.head.querySelectorAll(
           '[custom-element="amp-test"]')).to.have.length(0);
@@ -641,6 +654,8 @@ describes.sandboxed('Extensions', {}, () => {
           .to.have.length(0);
       expect(extensions.extensions_['amp-embed']).to.be.undefined;
     });
+
+
   });
 
   describes.realWin('installExtensionForDoc', {

--- a/test/functional/test-extensions.js
+++ b/test/functional/test-extensions.js
@@ -663,7 +663,7 @@ describes.sandboxed('Extensions', {}, () => {
       expect(extensions.extensions_['amp-test']).to.be.undefined;
       extensions.installExtensionForDoc(ampdoc, 'amp-test');
       expect(loadSpy).to.be.calledOnce;
-      expect(loadSpy).to.be.calledWithExactly('amp-test');
+      expect(loadSpy).to.be.calledWithExactly('amp-test', undefined);
       expect(doc.head.querySelectorAll(
           '[custom-element="amp-test"]')).to.have.length(1);
       expect(extensions.extensions_['amp-test'].scriptPresent).to.be.true;

--- a/test/functional/test-runtime.js
+++ b/test/functional/test-runtime.js
@@ -1057,6 +1057,25 @@ describes.realWin('runtime multidoc', {
           .to.not.exist;
     });
 
+    it('should import extension element with version ≠ 0.1', () => {
+      extensionsMock.expects('preloadExtension')
+          .withExactArgs('amp-ext1', '1.0')
+          .returns(Promise.resolve({
+            elements: {
+              'amp-ext1': function() { },
+            },
+          }))
+          .once();
+
+      const scriptEl = win.document.createElement('script');
+      scriptEl.setAttribute('custom-element', 'amp-ext1');
+      scriptEl.setAttribute('src', 'https://cdn.ampproject.org/v0/amp-ext1-1.0.js');
+      importDoc.head.appendChild(scriptEl);
+      win.AMP.attachShadowDoc(hostElement, importDoc, docUrl);
+      expect(win.document.querySelector('script[custom-element="amp-ext1"]'))
+          .to.not.exist;
+    });
+
     it('should import extension template', () => {
       extensionsMock.expects('preloadExtension')
           .withExactArgs('amp-ext1', '0.1')

--- a/test/functional/test-runtime.js
+++ b/test/functional/test-runtime.js
@@ -1040,7 +1040,7 @@ describes.realWin('runtime multidoc', {
 
     it('should import extension element', () => {
       extensionsMock.expects('preloadExtension')
-          .withExactArgs('amp-ext1')
+          .withExactArgs('amp-ext1', '0.1')
           .returns(Promise.resolve({
             elements: {
               'amp-ext1': function() {},
@@ -1059,7 +1059,7 @@ describes.realWin('runtime multidoc', {
 
     it('should import extension template', () => {
       extensionsMock.expects('preloadExtension')
-          .withExactArgs('amp-ext1')
+          .withExactArgs('amp-ext1', '0.1')
           .returns(Promise.resolve({elements: {}}))
           .once();
 
@@ -1367,7 +1367,7 @@ describes.realWin('runtime multidoc', {
       shadowDoc = win.AMP.attachShadowDocAsStream(hostElement, docUrl);
       writer = shadowDoc.writer;
       extensionsMock.expects('preloadExtension')
-          .withExactArgs('amp-ext1')
+          .withExactArgs('amp-ext1', '0.1')
           .returns(Promise.resolve({
             elements: {
               'amp-ext1': function() {},
@@ -1387,7 +1387,7 @@ describes.realWin('runtime multidoc', {
       shadowDoc = win.AMP.attachShadowDocAsStream(hostElement, docUrl);
       writer = shadowDoc.writer;
       extensionsMock.expects('preloadExtension')
-          .withExactArgs('amp-ext1')
+          .withExactArgs('amp-ext1', '0.1')
           .returns(Promise.resolve({elements: {}}))
           .once();
       writer.write(


### PR DESCRIPTION
Fixes #12105 and Fixes #11939

This gets the version only when the extensions have been included as script tags in the document. For extensions included by configs, like for FriendlyIframeEmbeds, more work must be done. I opened a separate issue #12428 to track that effort.