### PR TITLE
Add svg > use xlink:href rewrite

### DIFF
--- a/spec/amp-cache-modifications.md
+++ b/spec/amp-cache-modifications.md
@@ -153,6 +153,7 @@ The AMP Cache rewrites URLs found in the AMP HTML for two purposes. One is to re
 | `<amp-img srcset="https://example.com/bar.png 1080w, https://example.com/bar-400.png 400w">`| `<amp-img src="/i/s/example.com/bar.png 1080w, /i/s/example.com/bar-400.png 400w">` |
 | `<amp-anim src=foo.gif></amp-anim>` | `<amp-anim src=/i/s/example.com/foo.gif></amp-anim>` |
 | `<amp-video poster=bar.png>` | `<amp-video poster=/i/s/example.com/bar.png>` |
+| `<svg class="icon" xmlns:xlink="http://www.w3.org/1999/xlink"><use xlink:href="https://example.com/icon.svg#icon"></use></svg>` | `<svg class=icon xmlns:xlink="http://www.w3.org/1999/xlink"><use xlink:href="/i/s/example.com/icon.svg#icon"></use></svg>` |
 
 </details>
 


### PR DESCRIPTION
#10055 got stuck in percy and I haven't been able to kick things hard enough to get it to re-run. Creating a new PR for it instead.

Add svg image url example.

<svg class="icon" xmlns:xlink="http://www.w3.org/1999/xlink"><use xlink:href="https://example.com/test.svg#icon"></use></svg> should be rewritten to AMP cache URLs