### PR TITLE
Force images to fit within viewer to handle long / wide images

### DIFF
--- a/src/image-viewer.js
+++ b/src/image-viewer.js
@@ -259,15 +259,17 @@ export class ImageViewer {
       this.viewerBox_ = layoutRectFromDomRect(this.viewer_
         ./*OK*/getBoundingClientRect());
 
-      const sf = Math.min(this.viewerBox_.width / this.sourceWidth_,
-          this.viewerBox_.height / this.sourceHeight_);
-      let width = Math.min(this.sourceWidth_ * sf, this.viewerBox_.width);
-      let height = Math.min(this.sourceHeight_ * sf, this.viewerBox_.height);
+      const sourceAspectRatio = this.sourceWidth_ / this.sourceHeight_;
+      let height = Math.min(this.viewerBox_.width / sourceAspectRatio,
+          this.viewerBox_.height);
+      let width = Math.min(this.viewerBox_.height * sourceAspectRatio,
+          this.viewerBox_.width);
 
       // TODO(dvoytenko): This is to reduce very small expansions that often
       // look like a stutter. To be evaluated if this is still the right
       // idea.
-      if (width - this.sourceWidth_ <= 16) {
+      if (width - this.sourceWidth_ <= 16
+          && height - this.sourceHeight_ <= 16) {
         width = this.sourceWidth_;
         height = this.sourceHeight_;
       }


### PR DESCRIPTION
Closes https://github.com/ampproject/amphtml/issues/12376. 
Using `object-fit: contain` causes the `imageBox` measurements to no longer match the image exactly. Since we use those for animations, it's better to have a precise heights / widths on initialization. 