### PR TITLE
Fix mis-aligned close butter for amp-app-banner.

### DIFF
--- a/extensions/amp-app-banner/0.1/amp-app-banner.css
+++ b/extensions/amp-app-banner/0.1/amp-app-banner.css
@@ -49,9 +49,9 @@ i-amphtml-app-banner-top-padding {
   background-color: #fff;
   background-repeat: no-repeat;
   z-index: 14;
-  box-shadow: 0 0 5px 0 rgba(0,0,0, 0.2);
+  box-shadow: 0 -1px 1px 0 rgba(0,0,0, 0.2);
   border: none;
-  border-top-left-radius: 12px;
+  border-radius: 12px 0 0 0;
 }
 
 /* Increase tapping area of the dismiss button */

--- a/extensions/amp-sticky-ad/1.0/amp-sticky-ad.css
+++ b/extensions/amp-sticky-ad/1.0/amp-sticky-ad.css
@@ -71,9 +71,9 @@ amp-sticky-ad[visible] {
   background-position: 9px center;
   background-color: #fff;
   background-repeat: no-repeat;
-  box-shadow: 0 0 5px 0 rgba(0,0,0, 0.2);
+  box-shadow: 0 -1px 1px 0 rgba(0,0,0, 0.2);
   border: none;
-  border-top-left-radius: 12px;
+  border-radius: 12px 0 0 0;
 }
 
 amp-sticky-ad[visible] > .amp-sticky-ad-close-button {


### PR DESCRIPTION
Fixes #12441 

**Before:**

<img width="427" alt="screen shot 2017-12-12 at 7 49 04 pm" src="https://user-images.githubusercontent.com/8496897/33920922-8ef2e2b2-df75-11e7-83b5-9f6156b5c146.png">

**After:**

<img width="424" alt="screen shot 2017-12-12 at 7 48 03 pm" src="https://user-images.githubusercontent.com/8496897/33920921-8ec9c24c-df75-11e7-8552-7f4cd099650e.png">
