### PR TITLE
Ignore display:none fixed elements

### DIFF
--- a/src/service/fixed-layer.js
+++ b/src/service/fixed-layer.js
@@ -301,6 +301,7 @@ export class FixedLayer {
           const {offsetWidth, offsetHeight, offsetTop} = element;
           const {
             position = '',
+            display = '',
             bottom,
             zIndex,
           } = style;
@@ -315,8 +316,9 @@ export class FixedLayer {
               (fe.forceTransfer || (offsetWidth > 0 && offsetHeight > 0)));
           // Element is indeed sticky.
           const isSticky = endsWith(position, 'sticky');
+          const isDisplayed = display !== 'none';
 
-          if (!isFixed && !isSticky) {
+          if (!isDisplayed || !(isFixed || isSticky)) {
             state[fe.id] = {
               fixed: false,
               sticky: false,

--- a/test/functional/test-fixed-layer.js
+++ b/test/functional/test-fixed-layer.js
@@ -567,7 +567,7 @@ describe('FixedLayer', () => {
       element5.computedStyle['position'] = 'sticky';
       element5.offsetWidth = 10;
       element5.offsetHeight = 10;
-      element1.computedStyle['display'] = 'none';
+      element5.computedStyle['display'] = 'none';
 
       expect(vsyncTasks).to.have.length(1);
       const state = {};

--- a/test/functional/test-fixed-layer.js
+++ b/test/functional/test-fixed-layer.js
@@ -559,6 +559,25 @@ describe('FixedLayer', () => {
       expect(state['F4'].sticky).to.be.true;
     });
 
+    it('should disregard display:none element', () => {
+      element1.computedStyle['position'] = 'fixed';
+      element1.offsetWidth = 10;
+      element1.offsetHeight = 10;
+      element1.computedStyle['display'] = 'none';
+      element5.computedStyle['position'] = 'sticky';
+      element5.offsetWidth = 10;
+      element5.offsetHeight = 10;
+      element1.computedStyle['display'] = 'none';
+
+      expect(vsyncTasks).to.have.length(1);
+      const state = {};
+      vsyncTasks[0].measure(state);
+
+      expect(state['F0'].fixed).to.be.false;
+      expect(state['F1'].fixed).to.be.false;
+      expect(state['F4'].sticky).to.be.false;
+    });
+
     it('should tolerate getComputedStyle = null', () => {
       // See #3096 and https://bugzilla.mozilla.org/show_bug.cgi?id=548397
       documentApi.defaultView.getComputedStyle = () => null;


### PR DESCRIPTION
`display:none` fixed elements have an `offsetTop` of `0`, which was throwing off [this calculation](https://github.com/ampproject/amphtml/pull/12449/files#diff-a244d3899d7cb3930087a9d566a46af9R334).

Fixes #12306.
