### PR TITLE
Validator: meta name=amp-ad-doubleclick-sra

### DIFF
--- a/validator/testdata/feature_tests/ads.html
+++ b/validator/testdata/feature_tests/ads.html
@@ -20,6 +20,7 @@
   <title>Ad examples</title>
   <link rel="canonical" href="http://nonblocking.io/" >
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <meta name="amp-ad-doubleclick-sra">
   <style amp-custom>
     .broken {
       color: red;

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -503,6 +503,20 @@ tags: {
     mandatory: true
   }
 }
+# AMP metadata, name=amp-ad-doubleclick-sra
+# Enables SRA for amp-ad doubleclick Fast Fetch
+tags: {
+  html_format: AMP
+  tag_name: "META"
+  spec_name: "meta name=amp-ad-doubleclick-sra"
+  mandatory_parent: "HEAD"
+  attrs: {
+    name: "name"
+    mandatory: true
+    value_casei: "amp-ad-doubleclick-sra"
+    dispatch_key: NAME_VALUE_DISPATCH
+  }
+}
 # AMP4ADS metadata, name=amp4ads-id
 # https://github.com/ampproject/amphtml/issues/7730
 tags: {
@@ -4455,4 +4469,3 @@ error_formats {
   format: "CSS syntax error in tag '%1' - the property '%2' is disallowed "
           "unless the enclosing rule is prefixed with the '%3' qualification."
 }
-


### PR DESCRIPTION
Whitelist <meta name="amp-ad-doubleclick-sra"> in validator used to control if SRA is enabled for doubleclick Fast Fetch (added in #10160)