### PR TITLE
Fix 3P ad frame for local development

### DIFF
--- a/src/3p-frame.js
+++ b/src/3p-frame.js
@@ -229,9 +229,6 @@ export function getDefaultBootstrapBaseUrl(parentWindow, opt_srcFileBasename) {
 }
 
 function getAdsLocalhost(win) {
-  if (urls.localDev) {
-    return `//${urls.thirdPartyFrameHost}`;
-  }
   return 'http://ads.localhost:'
       + (win.location.port || win.parent.location.port);
 }


### PR DESCRIPTION
Steps: Run 
```
gulp clean
gulp build
gulp serve
```
or
```
gulp clean
gulp dist --fortesting
gulp serve --compiled
```
and navigate to http://localhost:8000/examples/ads.amp.html

Earlier, you'd see several instances of the wrong 3P ad frame.
With this PR, you'll see the ads loading correctly.

Fixes #12439
Partial fix for #12054