### PR TITLE
Added link to animation example

### DIFF
--- a/extensions/amp-animation/amp-animation.md
+++ b/extensions/amp-animation/amp-animation.md
@@ -19,7 +19,7 @@ limitations under the License.
 <table>
   <tr>
     <td width="40%"><strong>Description</strong></td>
-    <td>Animation component</td>
+    <td>Defines and runs animations.</td>
   </tr>
   <tr>
     <td width="40%"><strong>Required Script</strong></td>
@@ -28,6 +28,10 @@ limitations under the License.
   <tr>
     <td class="col-fourty"><strong><a href="https://www.ampproject.org/docs/guides/responsive/control_layout.html">Supported Layouts</a></strong></td>
     <td>nodisplay</td>
+  </tr>
+  <tr>
+    <td class="col-fourty"><strong>Examples</strong></td>
+    <td><a href="https://github.com/ampproject/amphtml/blob/master/examples/animations.amp.html">animations.amp.html</a></td>
   </tr>
 </table>
 


### PR DESCRIPTION
Added link to an example for amp-animation.  Will replace with ABE link, when there's an example.
