### PR TITLE
amp-ima-video: Added data-delay-ad-request.

### DIFF
--- a/ads/google/imaVideo.js
+++ b/ads/google/imaVideo.js
@@ -125,6 +125,9 @@ let adRequestFailed;
 // IMA SDK AdDisplayContainer object.
 let adDisplayContainer;
 
+// IMA SDK AdsRequest object.
+let adsRequest;
+
 // IMA SDK AdsLoader object.
 let adsLoader;
 
@@ -173,6 +176,9 @@ let imaSettings;
 
 // Player data used for video analytics.
 const playerData = new ImaPlayerData();
+
+// Flag used to track if ads have been requested or not.
+let adsRequested;
 
 /**
  * Loads the IMA SDK library.
@@ -436,15 +442,19 @@ export function imaVideo(global, data) {
 
     videoPlayer.addEventListener('ended', onContentEnded);
 
-    const adsRequest = new global.google.ima.AdsRequest();
+    adsRequest = new global.google.ima.AdsRequest();
     adsRequest.adTagUrl = data.tag;
     adsRequest.linearAdSlotWidth = videoWidth;
     adsRequest.linearAdSlotHeight = videoHeight;
     adsRequest.nonLinearAdSlotWidth = videoWidth;
     adsRequest.nonLinearAdSlotHeight = videoHeight / 3;
 
-    adRequestFailed = false;
-    adsLoader.requestAds(adsRequest);
+    if (!data['delayAdRequest']) {
+      requestAds();
+    } else {
+      // Let amp-ima-video know that we are done set-up.
+      window.parent./*OK*/postMessage({event: VideoEvents.LOAD}, '*');
+    }
   });
 }
 
@@ -491,6 +501,13 @@ export function onClick(global) {
   playAds(global);
 }
 
+
+export function requestAds() {
+  adsRequested = true;
+  adRequestFailed = false;
+  adsLoader.requestAds(adsRequest);
+}
+
 /**
  * Starts ad playback. If the ad request has not yte resolved, calls itself
  * again after 250ms.
@@ -498,7 +515,11 @@ export function onClick(global) {
  * @visibleForTesting
  */
 export function playAds(global) {
-  if (adsManager) {
+  if (!adsRequested) {
+    requestAds();
+    playAds(global);
+    return;
+  } else if (adsManager) {
     // Ad request resolved.
     try {
       adsManager.init(
@@ -970,6 +991,12 @@ function onMessage(global, event) {
             adsManagerWidthOnLoad = msg.args.width;
             adsManagerHeightOnLoad = msg.args.height;
           }
+        }
+        break;
+      case 'onScroll':
+      case 'onAdRequestTimeout':
+        if (!adsRequested) {
+          requestAds();
         }
         break;
     }

--- a/ads/google/imaVideo.js
+++ b/ads/google/imaVideo.js
@@ -993,8 +993,8 @@ function onMessage(global, event) {
           }
         }
         break;
-      case 'onScroll':
-      case 'onAdRequestTimeout':
+      case 'onFirstScroll':
+      case 'onAdRequestDelayTimeout':
         if (!adsRequested) {
           requestAds();
         }

--- a/extensions/amp-ima-video/0.1/test/test-amp-ima-video.js
+++ b/extensions/amp-ima-video/0.1/test/test-amp-ima-video.js
@@ -88,6 +88,8 @@ describes.realWin('amp-ima-video', {
     const initSpy = sandbox.spy(adDisplayContainerMock, 'initialize');
     const videoPlayerMock = {load() {}};
     const loadSpy = sandbox.spy(videoPlayerMock, 'load');
+    const mockAdsLoader = {requestAds() {}};
+    imaVideoObj.setAdsLoaderForTesting(mockAdsLoader);
     //const playAdsSpy = sandbox.spy(imaVideoObj, 'playAds');
     //const playAdsFunc = imaVideoObj.playAds;
     //const playAdsSpy = sandbox.spy(playAdsFunc);

--- a/extensions/amp-ima-video/amp-ima-video.md
+++ b/extensions/amp-ima-video/amp-ima-video.md
@@ -90,6 +90,10 @@ The URL of your video content. A relative URL or a URL that uses https protocol.
 An image for the frame to be displayed before video playback has started. By
 default, the first frame is displayed.
 
+##### data-delay-ad-request
+
+If true, delay the ad request until either the user scrolls the page, or for 3 seconds, whichever occurs first. Defaults to false.
+
 ##### common attributes
 
 This element includes


### PR DESCRIPTION
Adds data-delay-ad-request. If set to true, the ad request will be delayed until either a) the user scrolls the page, or b) 3 seconds has elapsed, whichever comes first. If set to false (default), the ad request will be sent on page load.

Resolves #11916 