### PR TITLE
Update A4A analytics instances to be singletons by ad network

### DIFF
--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -186,6 +186,22 @@ const LIFECYCLE_STAGE_TO_ANALYTICS_TRIGGER = {
 };
 
 /**
+ * A map of ad network types to the page-level singleton amp-analytics instance
+ * for A4A. If an ad network does not provide an analytics config, the instance
+ * will be null. Keys will be absent until an A4A element has been created for
+ * the ad network.
+ * @const {!Object<string, ?Element>}
+ */
+const perNetworkAnalyticsElements = {};
+
+/** @visibleForTesting */
+export function resetA4aAnalyticsState() {
+  for (const type in perNetworkAnalyticsElements) {
+    delete perNetworkAnalyticsElements[type];
+  }
+}
+
+/**
  * Utility function that ensures any error thrown is handled by optional
  * onError handler (if none provided or handler throws, error is swallowed and
  * undefined is returned).
@@ -359,20 +375,10 @@ export class AmpA4A extends AMP.BaseElement {
     this.postAdResponseExperimentFeatures = {};
 
     /**
-     * The configuration for amp-analytics. If null, no amp-analytics element
-     * will be inserted and no analytics events will be fired.
-     * This will be initialized inside of buildCallback.
-     * @private {?JsonObject}
+     * Whether this ad network has an amp-analytics element on the page.
+     * @type {boolean}
      */
-    this.a4aAnalyticsConfig_ = null;
-
-    /**
-     * The amp-analytics element that for this impl's analytics config. It will
-     * be null before buildCallback() executes or if the impl does not provide
-     * an analytice config.
-     * @private {?Element}
-     */
-    this.a4aAnalyticsElement_ = null;
+    this.hasA4aAnalyticsElement_ = false;
   }
 
   /** @override */
@@ -425,12 +431,18 @@ export class AmpA4A extends AMP.BaseElement {
           });
         });
 
-    this.a4aAnalyticsConfig_ = this.getA4aAnalyticsConfig();
-    if (this.a4aAnalyticsConfig_) {
-      // TODO(warrengm): Consider having page-level singletons for networks that
-      // use the same config for all ads.
-      this.a4aAnalyticsElement_ = insertAnalyticsElement(
-          this.element, this.a4aAnalyticsConfig_, true /* loadAnalytics */);
+    const networkType = this.element.getAttribute('type');
+    if (!(networkType in perNetworkAnalyticsElements)) {
+      const analyticsConfig = this.getA4aAnalyticsNetworkConfig();
+      if (analyticsConfig) {
+        this.hasA4aAnalyticsElement_ = true;
+        // NOTE(warrengm): We trigger the event to body because the analytics
+        // instrumentation service is scoped by ampdoc.
+        perNetworkAnalyticsElements[networkType] = insertAnalyticsElement(
+            this.win.document.body, analyticsConfig, true /* loadAnalytics */);
+      } else {
+        perNetworkAnalyticsElements[networkType] = null;
+      }
     }
   }
 
@@ -1658,7 +1670,9 @@ export class AmpA4A extends AMP.BaseElement {
    * @private
    */
   maybeTriggerAnalyticsEvent_(lifecycleStage) {
-    if (!this.a4aAnalyticsConfig_) {
+    const analyticsElement =
+        perNetworkAnalyticsElements[this.element.getAttribute('type')];
+    if (!analyticsElement) {
       // No config exists that will listen to this event.
       return;
     }
@@ -1671,12 +1685,20 @@ export class AmpA4A extends AMP.BaseElement {
     const analyticsVars = Object.assign(
         {'time': Math.round(this.getNow_())},
         this.getA4aAnalyticsVars(analyticsEvent));
-    triggerAnalyticsEvent(this.element, analyticsEvent, analyticsVars);
+    if (this.win.document == analyticsElement.ownerDocument) {
+      // Check if the amp-analytics is still attached to the document before
+      // firing the trigger.
+      // Note that this happens in tests when promise chains continue executing
+      // after the DOM has been cleaned up. I don't expect such scenarios to
+      // occur in practice.
+      triggerAnalyticsEvent(analyticsElement, analyticsEvent, analyticsVars);
+    }
   }
 
   /**
    * Returns variables to be included on an analytics event. This can be
-   * overridden by specific network implementations.
+   * overridden by specific network implementations to provide dynamic variables
+   * for amp-analytics triggers.
    * Note that this function is called for each time an analytics event is
    * fired.
    * @param {string} unusedAnalyticsEvent The name of the analytics event.
@@ -1691,7 +1713,12 @@ export class AmpA4A extends AMP.BaseElement {
    * added to this A4A element and no A4A triggers will be fired.
    * @return {?JsonObject}
    */
-  getA4aAnalyticsConfig() { return null; }
+  getA4aAnalyticsNetworkConfig() { return null; }
+
+  /**
+   * Returns the a4a-analytics singleton instance for this ad network. It will
+   * return null if
+   */
 
   /**
    * To be overriden by network specific implementation.
@@ -1721,7 +1748,7 @@ export class AmpA4A extends AMP.BaseElement {
       }
     } else if (this.element.getAttribute('rtc-config')) {
       user().error(TAG, 'RTC not supported for ad network ' +
-                   `${this.element.getAttribute('type')}`);
+                   this.element.getAttribute('type'));
     }
   }
 

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -441,6 +441,9 @@ export class AmpA4A extends AMP.BaseElement {
         perNetworkAnalyticsElements[networkType] = insertAnalyticsElement(
             this.win.document.body, analyticsConfig, true /* loadAnalytics */);
       } else {
+        // We want to call getA4aAnalyticsNetworkConfig only once per page so
+        // we set the value to null here. Later slots will exit early since the
+        // key is present in the map.
         perNetworkAnalyticsElements[networkType] = null;
       }
     }
@@ -1692,6 +1695,10 @@ export class AmpA4A extends AMP.BaseElement {
       // after the DOM has been cleaned up. I don't expect such scenarios to
       // occur in practice.
       triggerAnalyticsEvent(analyticsElement, analyticsEvent, analyticsVars);
+    } else {
+      dev().warn(
+          'AMP-A4A',
+          'The owner document for amp-analytics mismatches this.win.document.');
     }
   }
 

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -1697,7 +1697,7 @@ export class AmpA4A extends AMP.BaseElement {
       triggerAnalyticsEvent(analyticsElement, analyticsEvent, analyticsVars);
     } else {
       dev().warn(
-          'AMP-A4A',
+          TAG,
           'The owner document for amp-analytics mismatches this.win.document.');
     }
   }

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -489,6 +489,36 @@ describe('amp-a4a', () => {
       a4a.buildCallback();
       expect(a4a.win.document.querySelector('amp-analytics')).to.be.null;
     });
+
+    it('should call getA4aAnalyticsNetworkConfig once when not null', () => {
+      // Note that a4a1 and a4a2 are on the same ad network.
+      const a4a1 = new MockA4AImpl(createA4aElement(fixture.doc));
+      const a4a2 = new MockA4AImpl(createA4aElement(fixture.doc));
+
+      const getA4aAnalyticsNetworkConfigSpy =
+          sandbox.stub(MockA4AImpl.prototype, 'getA4aAnalyticsNetworkConfig')
+              .returns({'foo': 1});
+
+      a4a1.buildCallback();
+      a4a2.buildCallback();
+
+      expect(getA4aAnalyticsNetworkConfigSpy).to.be.calledOnce;
+    });
+
+    it('should call getA4aAnalyticsNetworkConfig once when null', () => {
+      // Note that a4a1 and a4a2 are on the same ad network.
+      const a4a1 = new MockA4AImpl(createA4aElement(fixture.doc));
+      const a4a2 = new MockA4AImpl(createA4aElement(fixture.doc));
+
+      const getA4aAnalyticsNetworkConfigSpy =
+          sandbox.stub(MockA4AImpl.prototype, 'getA4aAnalyticsNetworkConfig')
+              .returns(null);
+
+      a4a1.buildCallback();
+      a4a2.buildCallback();
+
+      expect(getA4aAnalyticsNetworkConfigSpy).to.be.calledOnce;
+    });
   });
 
   describe('layoutCallback cancels properly', () => {

--- a/extensions/amp-a4a/0.1/test/utils.js
+++ b/extensions/amp-a4a/0.1/test/utils.js
@@ -48,7 +48,7 @@ export class MockA4AImpl extends AmpA4A {
   }
 
   /** @override */
-  getA4aAnalyticsConfig() {
+  getA4aAnalyticsNetworkConfig() {
     return dict();
   }
 }

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -466,7 +466,7 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
   }
 
   /** @override */
-  getA4aAnalyticsConfig() {
+  getA4aAnalyticsNetworkConfig() {
     return getCsiAmpAnalyticsConfig();
   }
 

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
@@ -694,10 +694,7 @@ describes.realWin('amp-ad-network-adsense-impl', {
           expect(impl.element.querySelector('div[placeholder]')).to.be.ok;
           expect(impl.element.querySelector('div[fallback]')).to.be.ok;
           expect(impl.element.querySelector('iframe')).to.be.null;
-          expect(impl.element.querySelectorAll('amp-analytics'))
-              .to.have.lengthOf(1);
-          expect(impl.element.querySelector('amp-analytics')).to.equal(
-              impl.a4aAnalyticsElement_);
+          expect(impl.element.querySelector('amp-analytics')).to.be.null;
           expect(impl.iframe).to.be.null;
           expect(impl.ampAnalyticsConfig_).to.be.null;
           expect(impl.ampAnalyticsElement_).to.be.null;

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -1346,7 +1346,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
   }
 
   /** @override */
-  getA4aAnalyticsConfig() {
+  getA4aAnalyticsNetworkConfig() {
     return getCsiAmpAnalyticsConfig();
   }
 }

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -726,10 +726,7 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
           expect(impl.element.querySelector('div[placeholder]')).to.be.ok;
           expect(impl.element.querySelector('div[fallback]')).to.be.ok;
           expect(impl.element.querySelector('iframe')).to.be.null;
-          expect(impl.element.querySelectorAll('amp-analytics'))
-              .to.have.lengthOf(1);
-          expect(impl.element.querySelector('amp-analytics')).to.equal(
-              impl.a4aAnalyticsElement_);
+          expect(impl.element.querySelector('amp-analytics')).to.be.null;
           expect(impl.iframe).to.be.null;
           expect(impl.ampAnalyticsConfig_).to.be.null;
           expect(impl.ampAnalyticsElement_).to.be.null;


### PR DESCRIPTION
This PR updates A4A so that ad slots on the page from the same ad network will share the same
amp-analytics element and config.
