### PR TITLE
Change priority of ads in PWA

### DIFF
--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -381,7 +381,7 @@ export class AmpA4A extends AMP.BaseElement {
     // AMP creatives will be injected as part of the promise chain created
     // within onLayoutMeasure, this is only relevant to non-AMP creatives
     // therefore we want this to match the 3p priority.
-    const isPWA = !this.element.ampdoc_.isSingleDoc();
+    const isPWA = !this.element.getAmpDoc().isSingleDoc();
     // give the ad higher priority if it is inside a PWA
     return isPWA ? 1 : 2;
   }

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -381,7 +381,9 @@ export class AmpA4A extends AMP.BaseElement {
     // AMP creatives will be injected as part of the promise chain created
     // within onLayoutMeasure, this is only relevant to non-AMP creatives
     // therefore we want this to match the 3p priority.
-    return 2;
+    const isPWA = !this.element.ampdoc_.isSingleDoc();
+    // give the ad higher priority if it is inside a PWA
+    return isPWA ? 1 : 2;
   }
 
   /** @override */

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -118,7 +118,7 @@ describe('amp-a4a', () => {
     doc.head.appendChild(ampStyle);
   }
 
-  function createA4aElement(doc, opt_rect) {
+  function createA4aElement(doc, opt_rect, body) {
     const element = createElementWithAttributes(doc, 'amp-a4a', {
       'width': opt_rect ? String(opt_rect.width) : '200',
       'height': opt_rect ? String(opt_rect.height) : '50',
@@ -141,7 +141,8 @@ describe('amp-a4a', () => {
     element.renderStarted = () => {
       signals.signal('render-start');
     };
-    doc.body.appendChild(element);
+    body = body || doc.body;
+    body.appendChild(element);
     return element;
   }
 
@@ -1655,8 +1656,30 @@ describe('amp-a4a', () => {
   });
 
   describe('#getPriority', () => {
-    it('validate priority', () => {
-      expect(AmpA4A.prototype.getPriority()).to.equal(2);
+    describes.realWin('with shadow AmpDoc', {
+      amp: {
+        ampdoc: 'shadow',
+      },
+    }, env => {
+      it('should return priority of 1', () => {
+        const body = env.ampdoc.getBody();
+        const a4aElement = createA4aElement(env.win.document, null, body);
+        const a4a = new MockA4AImpl(a4aElement);
+        expect(a4a.getPriority()).to.equal(1);
+      });
+    });
+
+    describes.realWin('with single AmpDoc', {
+      amp: {
+        ampdoc: 'single',
+      },
+    }, env => {
+      it('should return priority of 2', () => {
+        const body = env.ampdoc.getBody();
+        const a4aElement = createA4aElement(env.win.document, null, body);
+        const a4a = new MockA4AImpl(a4aElement);
+        expect(a4a.getPriority()).to.equal(2);
+      });
     });
   });
 

--- a/extensions/amp-ad/0.1/amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/amp-ad-3p-impl.js
@@ -122,8 +122,10 @@ export class AmpAd3PImpl extends AMP.BaseElement {
 
   /** @override */
   getPriority() {
-    // Loads ads after other content.
-    return 2;
+    // Loads ads after other content,
+    const isPWA = !this.element.ampdoc_.isSingleDoc();
+    // give the ad higher priority if it is inside a PWA
+    return isPWA ? 1 : 2;;
   }
 
   renderOutsideViewport() {

--- a/extensions/amp-ad/0.1/amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/amp-ad-3p-impl.js
@@ -123,7 +123,7 @@ export class AmpAd3PImpl extends AMP.BaseElement {
   /** @override */
   getPriority() {
     // Loads ads after other content,
-    const isPWA = !this.element.ampdoc_.isSingleDoc();
+    const isPWA = !this.element.getAmpDoc().isSingleDoc();
     // give the ad higher priority if it is inside a PWA
     return isPWA ? 1 : 2;;
   }

--- a/extensions/amp-ad/0.1/amp-ad-custom.js
+++ b/extensions/amp-ad/0.1/amp-ad-custom.js
@@ -54,7 +54,7 @@ export class AmpAdCustom extends AMP.BaseElement {
   /** @override */
   getPriority() {
     // Loads ads after other content
-    const isPWA = !this.element.ampdoc_.isSingleDoc();
+    const isPWA = !this.element.getAmpDoc().isSingleDoc();
     // give the ad higher priority if it is inside a PWA
     return isPWA ? 1 : 2;
   }

--- a/extensions/amp-ad/0.1/amp-ad-custom.js
+++ b/extensions/amp-ad/0.1/amp-ad-custom.js
@@ -53,8 +53,10 @@ export class AmpAdCustom extends AMP.BaseElement {
 
   /** @override */
   getPriority() {
-    // Loads ads after other content.
-    return 2;
+    // Loads ads after other content
+    const isPWA = !this.element.ampdoc_.isSingleDoc();
+    // give the ad higher priority if it is inside a PWA
+    return isPWA ? 1 : 2;
   }
 
   /** @override **/

--- a/extensions/amp-ad/0.1/test/test-amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-3p-impl.js
@@ -525,7 +525,7 @@ describes.realWin('amp-ad-3p-impl', {
   });
 });
 
-describe.only('#getPriority', () => {
+describe('#getPriority', () => {
   describes.realWin('with shadow AmpDoc', {
     amp: {
       ampdoc: 'shadow',

--- a/extensions/amp-ad/0.1/test/test-amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-3p-impl.js
@@ -24,7 +24,7 @@ import '../../../amp-sticky-ad/1.0/amp-sticky-ad';
 import {macroTask} from '../../../../testing/yield';
 import * as lolex from 'lolex';
 
-function createAmpAd(win) {
+function createAmpAd(win, attachToAmpdoc = false, ampdoc) {
   const ampAdElement = createElementWithAttributes(win.document, 'amp-ad', {
     type: '_ping_',
     width: 300,
@@ -33,6 +33,11 @@ function createAmpAd(win) {
     'data-valid': 'true',
     'data-width': '6666',
   });
+
+  if (attachToAmpdoc) {
+    ampdoc.getBody().appendChild(ampAdElement);
+  }
+
   ampAdElement.isBuilt = () => {return true;};
 
   return new AmpAd3PImpl(ampAdElement);
@@ -516,6 +521,30 @@ describes.realWin('amp-ad-3p-impl', {
           expect(element.style.marginRight).to.be.equal('-49px');
         });
       });
+    });
+  });
+});
+
+describe.only('#getPriority', () => {
+  describes.realWin('with shadow AmpDoc', {
+    amp: {
+      ampdoc: 'shadow',
+    },
+  }, env => {
+    it('should return priority of 1', () => {
+      const ad3p = createAmpAd(env.ampdoc.win, /*attach*/ true, env.ampdoc);
+      expect(ad3p.getPriority()).to.equal(1);
+    });
+  });
+
+  describes.realWin('with single AmpDoc', {
+    amp: {
+      ampdoc: 'single',
+    },
+  }, env => {
+    it('should return priority of 2', () => {
+      const ad3p = createAmpAd(env.ampdoc.win, /*attach*/ true, env.ampdoc);
+      expect(ad3p.getPriority()).to.equal(2);
     });
   });
 });

--- a/extensions/amp-ad/0.1/test/test-amp-ad-custom.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-custom.js
@@ -39,7 +39,7 @@ describe('Amp custom ad', () => {
    * @returns {Element} The completed amp-ad element, which has been added to
    *    the current document body.
    */
-  function getCustomAd(url, slot) {
+  function getCustomAd(url, slot, body = document.body) {
     const ampAdElement = createElementWithAttributes(document, 'amp-ad', {
       type: 'custom',
       width: '500',
@@ -51,7 +51,7 @@ describe('Amp custom ad', () => {
     }
     const template = document.createElement('template');
     ampAdElement.appendChild(template);
-    document.body.appendChild(ampAdElement);
+    body.appendChild(ampAdElement);
     return ampAdElement;
   }
 
@@ -97,4 +97,34 @@ describe('Amp custom ad', () => {
     expect(ad3.getFullUrl_()).to.equal(expected34);
     expect(ad4.getFullUrl_()).to.equal(expected34);
   });
+
+  describe('#getPriority', () => {
+    const url = '/examples/custom.ad.example.json';
+    const slot = 'myslot';
+    
+    describes.realWin('with shadow AmpDoc', {
+      amp: {
+        ampdoc: 'shadow',
+      },
+    }, env => {
+      it('should return priority of 1', () => {
+        const adElement = getCustomAd(url, slot, /*body*/env.ampdoc.getBody());
+        const customAd = new AmpAdCustom(adElement);
+        expect(customAd.getPriority()).to.equal(1);
+      });
+    });
+  
+    describes.realWin('with single AmpDoc', {
+      amp: {
+        ampdoc: 'single',
+      },
+    }, env => {
+      it('should return priority of 2', () => {
+        const adElement = getCustomAd(url, slot, /*body*/env.ampdoc.getBody());
+        const customAd = new AmpAdCustom(adElement);
+        expect(customAd.getPriority()).to.equal(2);
+      });
+    });
+  });
 });
+

--- a/extensions/amp-ad/0.1/test/test-amp-ad-custom.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-custom.js
@@ -101,7 +101,7 @@ describe('Amp custom ad', () => {
   describe('#getPriority', () => {
     const url = '/examples/custom.ad.example.json';
     const slot = 'myslot';
-    
+
     describes.realWin('with shadow AmpDoc', {
       amp: {
         ampdoc: 'shadow',
@@ -113,7 +113,7 @@ describe('Amp custom ad', () => {
         expect(customAd.getPriority()).to.equal(1);
       });
     });
-  
+
     describes.realWin('with single AmpDoc', {
       amp: {
         ampdoc: 'single',


### PR DESCRIPTION
Change ads to higher priority in PWA context for faster loading. This is accomplished by checking to see if amp is loaded with shadow binary.

Closes #12232
