### PR TITLE
Prevent waiting for elements hidden by media query

### DIFF
--- a/extensions/amp-story/0.1/amp-story-page.js
+++ b/extensions/amp-story/0.1/amp-story-page.js
@@ -288,20 +288,28 @@ export class AmpStoryPage extends AMP.BaseElement {
    * @public
    */
   calculateLoadStatus() {
-    const visiblePageElements = this.pageElements_.filter(pageElement =>
-      !pageElement.isHiddenByMediaQuery());
-
-    if (this.isLoaded_ || visiblePageElements.length == 0) {
+    if (this.isLoaded_) {
       return true;
     }
 
-    visiblePageElements.forEach(pageElement => pageElement.updateState());
+    const visiblePageElements = this.pageElements_.filter(pageElement =>
+      !pageElement.isHiddenByMediaQuery());
 
-    const isPageLoaded = !visiblePageElements.some(pageElement =>
-      !pageElement.isLoaded && !pageElement.hasFailed);
+    if (visiblePageElements.length == 0) {
+      return true;
+    }
 
-    const canPageBeShown = visiblePageElements.some(pageElement =>
-      pageElement.canBeShown);
+    let isPageLoaded = true;
+    let canPageBeShown = false;
+
+    visiblePageElements.forEach(pageElement => {
+      pageElement.updateState();
+
+      isPageLoaded =
+          isPageLoaded && (pageElement.isLoaded || pageElement.hasFailed);
+
+      canPageBeShown = canPageBeShown || pageElement.canBeShown;
+    });
 
     if (isPageLoaded) {
       this.markPageAsLoaded_();

--- a/extensions/amp-story/0.1/amp-story-page.js
+++ b/extensions/amp-story/0.1/amp-story-page.js
@@ -288,24 +288,20 @@ export class AmpStoryPage extends AMP.BaseElement {
    * @public
    */
   calculateLoadStatus() {
-    if (this.isLoaded_ || this.pageElements_.length == 0) {
+    const visiblePageElements = this.pageElements_.filter(pageElement =>
+      !pageElement.isHiddenByMediaQuery());
+
+    if (this.isLoaded_ || visiblePageElements.length == 0) {
       return true;
     }
 
-    let isPageLoaded = true;
-    let canPageBeShown = false;
+    visiblePageElements.forEach(pageElement => pageElement.updateState());
 
-    this.pageElements_.forEach(pageElement => {
-      pageElement.updateState();
+    const isPageLoaded = !visiblePageElements.some(pageElement =>
+      !pageElement.isLoaded && !pageElement.hasFailed);
 
-      if (isPageLoaded) {
-        isPageLoaded = pageElement.isLoaded || pageElement.hasFailed;
-      }
-
-      if (!canPageBeShown) {
-        canPageBeShown = pageElement.canBeShown;
-      }
-    });
+    const canPageBeShown = visiblePageElements.some(pageElement =>
+      pageElement.canBeShown);
 
     if (isPageLoaded) {
       this.markPageAsLoaded_();

--- a/extensions/amp-story/0.1/page-element.js
+++ b/extensions/amp-story/0.1/page-element.js
@@ -67,8 +67,8 @@ const ELEMENT_FAILED_CLASS_NAME = 'i-amphtml-story-page-element-failed';
 
 
 /**
- * CSS class for an element on an amp-story-page that indicates the element has
- * failed to load.
+ * CSS class for an element on an amp-story-page that indicates the element was
+ * hidden by a media query rule.
  * @const {string}
  */
 const HIDDEN_BY_MEDIA_QUERY_CLASS_NAME = 'i-amphtml-hidden-by-media-query';

--- a/extensions/amp-story/0.1/page-element.js
+++ b/extensions/amp-story/0.1/page-element.js
@@ -67,6 +67,14 @@ const ELEMENT_FAILED_CLASS_NAME = 'i-amphtml-story-page-element-failed';
 
 
 /**
+ * CSS class for an element on an amp-story-page that indicates the element has
+ * failed to load.
+ * @const {string}
+ */
+const HIDDEN_BY_MEDIA_QUERY_CLASS_NAME = 'i-amphtml-hidden-by-media-query';
+
+
+/**
  * The minimum amount of a media item (by percentage) that must be loaded in
  * order for that element to be considered "loaded".  Note that if the total
  * size cannot be determined, this criteria is simply ignored.
@@ -154,6 +162,13 @@ export class PageElement {
       this.element.classList
           .toggle(ELEMENT_SHOW_CLASS_NAME, /* force */ this.canBeShown);
     }
+  }
+
+  /**
+   * @return {boolean}
+   */
+  isHiddenByMediaQuery() {
+    return this.element.classList.contains(HIDDEN_BY_MEDIA_QUERY_CLASS_NAME);
   }
 
   /**


### PR DESCRIPTION
`PageElements.forPage` will gather all elements on `buildCallback`. We won't know if the element is hidden until layout, so we filter then.

Fixes #12501