### PR TITLE
Add missing quotes for key sourceType in .babelrc

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -6,7 +6,7 @@
         "browsers": ["Last 2 versions"]
       },
       "modules": "commonjs",
-      sourceType: "module"
+      "sourceType": "module"
     }]
   ],
   "sourceType": "module",


### PR DESCRIPTION
Babel uses JSON5 format for `.babelrc` configuration files. This change makes keys uniformly quoted.
