### PR TITLE
amp-sidebar, expose open and close events

### DIFF
--- a/extensions/amp-sidebar/0.1/amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.js
@@ -391,7 +391,6 @@ export class AmpSidebar extends AMP.BaseElement {
   }
 
   /**
-   * Get called when animation/transition end when open/close sidebar
    * @private
    */
   triggerEvent_(name) {

--- a/extensions/amp-sidebar/0.1/amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.js
@@ -15,6 +15,7 @@
  */
 
 import {CSS} from '../../../build/amp-sidebar-0.1.css';
+import {ActionTrust} from '../../../src/action-trust';
 import {KeyCodes} from '../../../src/utils/key-codes';
 import {Layout} from '../../../src/layout';
 import {Services} from '../../../src/services';
@@ -23,6 +24,7 @@ import {closestByTag, tryFocus, isRTL} from '../../../src/dom';
 import {dev} from '../../../src/log';
 import {isExperimentOn} from '../../../src/experiments';
 import {setStyles, toggle} from '../../../src/style';
+import {createCustomEvent} from '../../../src/event-helper';
 import {debounce} from '../../../src/utils/rate-limit';
 import {removeFragment, parseUrl} from '../../../src/url';
 import {toArray} from '../../../src/types';
@@ -36,6 +38,12 @@ const ANIMATION_TIMEOUT = 350;
 /** @const */
 const IOS_SAFARI_BOTTOMBAR_HEIGHT = '10vh';
 
+/**  @enum {string} */
+const SidebarEvents = {
+  OPEN: 'sidebarOpen',
+  CLOSE: 'sidebarClose',
+};
+
 export class AmpSidebar extends AMP.BaseElement {
   /** @param {!AmpElement} element */
   constructor(element) {
@@ -46,6 +54,9 @@ export class AmpSidebar extends AMP.BaseElement {
 
     /** @const @private {!../../../src/service/vsync-impl.Vsync} */
     this.vsync_ = Services.vsyncFor(this.win);
+
+    /** @const @private {?../../../src/service/action-impl.ActionService} */
+    this.action_ = Services.actionServiceForDoc(this.element);
 
     /** @private {?Element} */
     this.maskElement_ = null;
@@ -368,13 +379,24 @@ export class AmpSidebar extends AMP.BaseElement {
       this.scheduleLayout(children);
       this.scheduleResume(children);
       tryFocus(this.element);
+      this.triggerEvent_(SidebarEvents.OPEN);
     } else {
       // On close sidebar
       this.vsync_.mutate(() => {
         toggle(this.element, /* display */false);
         this.schedulePause(this.getRealChildren());
+        this.triggerEvent_(SidebarEvents.CLOSE);
       });
     }
+  }
+
+  /**
+   * Get called when animation/transition end when open/close sidebar
+   * @private
+   */
+  triggerEvent_(name) {
+    const event = createCustomEvent(this.win, `${TAG}.${name}`, {});
+    this.action_.trigger(this.element, name, event, ActionTrust.HIGH);
   }
 }
 

--- a/extensions/amp-sidebar/0.1/amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.js
@@ -55,8 +55,8 @@ export class AmpSidebar extends AMP.BaseElement {
     /** @const @private {!../../../src/service/vsync-impl.Vsync} */
     this.vsync_ = Services.vsyncFor(this.win);
 
-    /** @const @private {?../../../src/service/action-impl.ActionService} */
-    this.action_ = Services.actionServiceForDoc(this.element);
+    /** @private {?../../../src/service/action-impl.ActionService} */
+    this.action_ = null;
 
     /** @private {?Element} */
     this.maskElement_ = null;
@@ -110,6 +110,8 @@ export class AmpSidebar extends AMP.BaseElement {
     this.side_ = this.element.getAttribute('side');
 
     this.viewport_ = this.getViewport();
+
+    this.action_ = Services.actionServiceForDoc(this.element);
 
     this.viewport_.addToFixedLayer(this.element, /* forceTransfer */ true);
 

--- a/spec/amp-actions-and-events.md
+++ b/spec/amp-actions-and-events.md
@@ -182,7 +182,7 @@ event.index</pre></td>
   </tr>
 </table>
 
-### amp-selector
+### amp-sidebar
 <table>
   <tr>
     <th width="25%">Event</th>
@@ -190,12 +190,29 @@ event.index</pre></td>
     <th width="40%">Data</th>
   </tr>
   <tr>
-    <td><code>select</code></td>
-    <td>Fired when the user manually selects an option.</td>
-    <td><pre>// The option attribute
-// value of
-// the selected element.
-event.targetOption</pre></td>
+    <td><code>sidebarOpen</code></td>
+    <td>Fired when sidebar is fully opened after transition has ended.</td>
+    <td>None</td>
+  </tr>
+  <tr>
+    <td><code>sidebarClose</code></td>
+    <td>Fired when sidebar is fully closed after transition has ended.</td>
+    <td>None</td>
+  </tr>
+</table>
+
+### amp-carousel[type="slides"]
+<table>
+  <tr>
+    <th width="25%">Event</th>
+    <th width="35%">Description</th>
+    <th width="40%">Data</th>
+  </tr>
+  <tr>
+    <td><code>slideChange</code></td>
+    <td>Fired when the user manually changes the carousel's current slide. Does not fire on autoplay or the <code>goToSlide</code> action.</td>
+    <td><pre>// Slide number.
+event.index</pre></td>
   </tr>
 </table>
 

--- a/test/manual/amp-sidebar.amp.html
+++ b/test/manual/amp-sidebar.amp.html
@@ -182,7 +182,7 @@
     }
 
     body#mybody > amp-sidebar {
-      background: blue;
+      background: grey;
     }
   </style>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
@@ -196,13 +196,14 @@
 
 </head>
 <body id="mybody">
-  <amp-sidebar id="sidebar1" layout="nodisplay">
+  <amp-sidebar id="sidebar1" layout="nodisplay" on="sidebarOpen:focusOnMe.focus">
     <div>
       <amp-social-share width="57" type="twitter"></amp-social-share>
       <amp-social-share width="57" type="linkedin"></amp-social-share>
       <amp-social-share width="57" type="facebook"></amp-social-share>
     </div>
     <ul>
+      <li><a id="focusOnMe" href="https://google.com">This gets focused on open</a></li>
       <li> Nav item 1</li>
       <li> Nav item 2</li>
       <li> Nav item 3</li>


### PR DESCRIPTION
This PR exposes `sidebarOpen` and `sidebarClose` events.

These events fire after sidebar has finished transition and are needed for cases such as focusing on an element in the sidebar (as browsers refuse to focus on invisible items) or running an animation in the sidebar (which only makes sense to start when sidebar is fully visible).

Fixes https://github.com/ampproject/amphtml/issues/12240 