### PR TITLE
Deactivate font stylesheet timeout in Safari.

### DIFF
--- a/src/amp.js
+++ b/src/amp.js
@@ -26,6 +26,7 @@ import {installPerformanceService} from './service/performance-impl';
 import {installPullToRefreshBlocker} from './pull-to-refresh';
 import {installStylesForDoc, makeBodyVisible} from './style-installer';
 import {installErrorReporting} from './error';
+import {installPlatformService} from './service/platform-impl';
 import {installDocService} from './service/ampdoc-impl';
 import {installCacheServiceWorker} from './service-worker/install';
 import {stubElementsForDoc} from './service/custom-element-registry';
@@ -72,6 +73,7 @@ startupChunk(self.document, function initial() {
   if (self.document.documentElement.hasAttribute('i-amphtml-no-boilerplate')) {
     perf.addEnabledExperiment('no-boilerplate');
   }
+  installPlatformService(self);
   fontStylesheetTimeout(self);
   perf.tick('is');
   installStylesForDoc(ampdoc, cssText, () => {

--- a/src/font-stylesheet-timeout.js
+++ b/src/font-stylesheet-timeout.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {Services} from './services';
 import {onDocumentReady} from './document-ready';
 import {urls} from './config';
 import {isExperimentOn} from './experiments';
@@ -42,6 +43,13 @@ export function fontStylesheetTimeout(win) {
  */
 function maybeTimeoutFonts(win) {
   timeoutFontFaces(win);
+  const platform = Services.platformFor(win);
+  if (platform.isIos() || platform.isSafari()) {
+    // Deactivate on Safari and iOS (our current best way to estimate a non-
+    // blink WebKit) due to https://bugs.webkit.org/show_bug.cgi?id=180940
+    // TODO(#12520): Reinstate for fixed versions of WebKit.
+    return;
+  }
   let timeSinceResponseStart = 0;
   // If available, we start counting from the time the HTTP response
   // for the page started. The preload scanner should then quickly


### PR DESCRIPTION
Due to https://bugs.webkit.org/show_bug.cgi?id=180940

Mitigates #12520
