### PR TITLE
Add warning for unsupported older yarn versions

### DIFF
--- a/build-system/check-package-manager.js
+++ b/build-system/check-package-manager.js
@@ -55,7 +55,8 @@ function main() {
 
   // If yarn is being run, perform a version check and proceed with the install.
   const yarnVersion = getStdout('yarn --version').trim();
-  const [major, minor] = yarnVersion.split('.');
+  const major = yarnVersion.split('.')[0];
+  const minor = yarnVersion.split('.')[1];
   if ((major < 1) || (minor < 2)) {
     console/*OK*/.log(yellow('WARNING: Detected yarn version'),
         cyan(yarnVersion) + yellow('. Minimum recommended version is'),

--- a/build-system/check-package-manager.js
+++ b/build-system/check-package-manager.js
@@ -15,6 +15,7 @@
  */
 'use strict';
 
+const getStdout = require('./exec').getStdout;
 const setupInstructionsUrl = 'https://github.com/ampproject/amphtml/blob/master/contributing/getting-started-quick.md#one-time-setup';
 
 // Color formatting may not yet be available via gulp-util.
@@ -52,8 +53,22 @@ function main() {
     return 1;
   }
 
-  // If yarn is being run, proceed with the install.
-  console/*OK*/.log(green('Detected yarn. Installing packages...'));
+  // If yarn is being run, perform a version check and proceed with the install.
+  const yarnVersion = getStdout('yarn --version').trim();
+  const [major, minor] = yarnVersion.split('.');
+  if ((major < 1) || (minor < 2)) {
+    console/*OK*/.log(yellow('WARNING: Detected yarn version'),
+        cyan(yarnVersion) + yellow('. Minimum recommended version is'),
+        cyan('1.2.0') + yellow('.'));
+    console/*OK*/.log(yellow('To upgrade, run'),
+        cyan('"curl -o- -L https://yarnpkg.com/install.sh | bash"'),
+        yellow('or see'), cyan('https://yarnpkg.com/docs/install'),
+        yellow('for instructions.'));
+    console/*OK*/.log(yellow('Attempting to install packages...'));
+  } else {
+    console/*OK*/.log(green('Detected yarn version'), cyan(yarnVersion) +
+        green('. Installing packages...'));
+  };
   return 0;
 }
 

--- a/build-system/exec.js
+++ b/build-system/exec.js
@@ -20,7 +20,6 @@
  */
 
 const childProcess = require('child_process');
-const util = require('gulp-util');
 
 /**
  * Spawns the given command in a child process with the given options.
@@ -41,7 +40,7 @@ function spawnProcess(cmd, options) {
 exports.exec = function(cmd) {
   const p = spawnProcess(cmd, {'stdio': 'inherit'});
   if (p.status != 0) {
-    console/*OK*/.log(util.colors.yellow('\nCommand failed: ' + cmd));
+    console/*OK*/.log('\nCommand failed: ' + cmd);
   }
 };
 
@@ -53,7 +52,7 @@ exports.exec = function(cmd) {
 exports.execOrDie = function(cmd) {
   const p = spawnProcess(cmd, {'stdio': 'inherit'});
   if (p.status != 0) {
-    console/*OK*/.error(util.colors.red('\nCommand failed: ' + cmd));
+    console/*OK*/.error('\nCommand failed: ' + cmd);
     process.exit(p.status);
   }
 };

--- a/contributing/getting-started-e2e.md
+++ b/contributing/getting-started-e2e.md
@@ -156,7 +156,7 @@ amphtml uses Node.js, the Yarn package manager and the Gulp build system to buil
 * Install [NodeJS](https://nodejs.org/) version >= 6 (which includes npm)
 
 
-* Install [Yarn](https://yarnpkg.com/) version >= 1.0.2 (instructions [here](https://yarnpkg.com/en/docs/install), this may require elevated privileges using `sudo` on some platforms)
+* Install [Yarn](https://yarnpkg.com/) version >= 1.2.0 (instructions [here](https://yarnpkg.com/en/docs/install), this may require elevated privileges using `sudo` on some platforms)
 
 * In your local repository directory (e.g. `~/src/ampproject/amphtml`), install the packages that AMP uses by running
    ```


### PR DESCRIPTION
Installing packages with older versions of yarn is broken. This PR adds a version check and prints a warning with upgrade instructions.

Fixes #12534