### PR TITLE
Inabox array clear

### DIFF
--- a/ads/inabox/inabox-host.js
+++ b/ads/inabox/inabox-host.js
@@ -64,7 +64,7 @@ export class InaboxHost {
           try {
             host.processMessage(message);
           } catch (err) {
-            dev().info(TAG, 'Error processing inabox message', message, err);
+            dev().error(TAG, 'Error processing inabox message', message, err);
           }
         });
       } else {

--- a/ads/inabox/inabox-host.js
+++ b/ads/inabox/inabox-host.js
@@ -21,30 +21,54 @@
 
 import {dev, initLogConstructor, setReportError} from '../../src/log';
 import {reportError} from '../../src/error';
+import {isArray} from '../../src/types';
 import {InaboxMessagingHost} from './inabox-messaging-host';
 
 const TAG = 'inabox-host';
-run(self);
+const INITIALIZED_WIN_VAR_NAME = 'ampInaboxInitialized';
+const PENDING_MESSAGES_WIN_VAR_NAME = 'ampInaboxPendingMessages';
+const INABOX_AD_IFRAMES_IN_VAR_NAME= 'ampInaboxIframes';
 
 /**
- * @param win {!Window}
+ * Class for initializing host script and consuming queued messages.
+ * @visibleForTesting
  */
-function run(win) {
-  // Prevent double initialization
-  if (win['ampInaboxInitialized']) {
-    dev().info(TAG, 'Skip a 2nd attempt of initializing AMP inabox host.');
-    return;
+export class InaboxHost {
+  /** @param win {!Window}  */
+  constructor(win) {
+    // Prevent double initialization
+    if (win[INITIALIZED_WIN_VAR_NAME]) {
+      dev().info(TAG, 'Skip a 2nd attempt of initializing AMP inabox host.');
+      return;
+    }
+
+    // Assume we cannot recover from state initialization errors.
+    win[INITIALIZED_WIN_VAR_NAME] = true;
+    initLogConstructor();
+    setReportError(reportError);
+
+    const host = new InaboxMessagingHost(
+      win, win[INABOX_AD_IFRAMES_IN_VAR_NAME]);
+
+    const queuedMsgs = win[PENDING_MESSAGES_WIN_VAR_NAME];
+    if (queuedMsgs) {
+      if (isArray(queuedMsgs)) {
+        queuedMsgs.forEach(message => {
+          try {
+            host.processMessage(message);
+          } catch (err) {
+            dev().info('Error processing inabox message', message, err);
+          }
+        });
+      } else {
+        dev().info(TAG, `Invalid ${PENDING_MESSAGES_WIN_VAR_NAME}`, queuedMsgs);
+      }
+    }
+    // Empty and ensure that future messages are no longer stored in the array.
+    win[PENDING_MESSAGES_WIN_VAR_NAME] = [];
+    win[PENDING_MESSAGES_WIN_VAR_NAME]['push'] = () => {};
+    win.addEventListener('message', host.processMessage.bind(host));
   }
-
-  win['ampInaboxInitialized'] = true;
-  initLogConstructor();
-  setReportError(reportError);
-
-  const host = new InaboxMessagingHost(win, win['ampInaboxIframes']);
-
-  win['ampInaboxPendingMessages'].forEach(message => {
-    host.processMessage(message);
-  });
-
-  win.addEventListener('message', host.processMessage.bind(host));
 }
+
+new InaboxHost(self);

--- a/ads/inabox/inabox-host.js
+++ b/ads/inabox/inabox-host.js
@@ -27,7 +27,7 @@ import {InaboxMessagingHost} from './inabox-messaging-host';
 const TAG = 'inabox-host';
 const INITIALIZED_WIN_VAR_NAME = 'ampInaboxInitialized';
 const PENDING_MESSAGES_WIN_VAR_NAME = 'ampInaboxPendingMessages';
-const INABOX_AD_IFRAMES_IN_VAR_NAME= 'ampInaboxIframes';
+const INABOX_AD_IFRAMES_IN_VAR_NAME = 'ampInaboxIframes';
 
 /**
  * Class for initializing host script and consuming queued messages.
@@ -49,12 +49,12 @@ export class InaboxHost {
 
     if (win[INABOX_AD_IFRAMES_IN_VAR_NAME] &&
         !isArray(win[INABOX_AD_IFRAMES_IN_VAR_NAME])) {
-      dev().info(`Invalid ${INABOX_AD_IFRAMES_IN_VAR_NAME}`,
-        win[INABOX_AD_IFRAMES_IN_VAR_NAME]);
+      dev().info(TAG, `Invalid ${INABOX_AD_IFRAMES_IN_VAR_NAME}`,
+          win[INABOX_AD_IFRAMES_IN_VAR_NAME]);
       win[INABOX_AD_IFRAMES_IN_VAR_NAME] = [];
     }
     const host = new InaboxMessagingHost(
-      win, win[INABOX_AD_IFRAMES_IN_VAR_NAME]);
+        win, win[INABOX_AD_IFRAMES_IN_VAR_NAME]);
 
     const queuedMsgs = win[PENDING_MESSAGES_WIN_VAR_NAME];
     if (queuedMsgs) {
@@ -63,7 +63,7 @@ export class InaboxHost {
           try {
             host.processMessage(message);
           } catch (err) {
-            dev().info('Error processing inabox message', message, err);
+            dev().info(TAG, 'Error processing inabox message', message, err);
           }
         });
       } else {

--- a/ads/inabox/inabox-host.js
+++ b/ads/inabox/inabox-host.js
@@ -47,6 +47,12 @@ export class InaboxHost {
     initLogConstructor();
     setReportError(reportError);
 
+    if (win[INABOX_AD_IFRAMES_IN_VAR_NAME] &&
+        !isArray(win[INABOX_AD_IFRAMES_IN_VAR_NAME])) {
+      dev().info(`Invalid ${INABOX_AD_IFRAMES_IN_VAR_NAME}`,
+        win[INABOX_AD_IFRAMES_IN_VAR_NAME]);
+      win[INABOX_AD_IFRAMES_IN_VAR_NAME] = [];
+    }
     const host = new InaboxMessagingHost(
       win, win[INABOX_AD_IFRAMES_IN_VAR_NAME]);
 

--- a/test/functional/inabox/test-inabox-host.js
+++ b/test/functional/inabox/test-inabox-host.js
@@ -22,7 +22,7 @@ describes.fakeWin('inabox-host', {}, env => {
   let processMessageSpy;
   beforeEach(() => {
     processMessageSpy = env.sandbox.spy(
-      InaboxMessagingHost.prototype, 'processMessage');
+        InaboxMessagingHost.prototype, 'processMessage');
   });
 
   it('should process queue', () => {

--- a/test/functional/inabox/test-inabox-host.js
+++ b/test/functional/inabox/test-inabox-host.js
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {InaboxHost} from '../../../ads/inabox/inabox-host';
+import {InaboxMessagingHost} from '../../../ads/inabox/inabox-messaging-host';
+
+describes.fakeWin('inabox-host', {}, env => {
+
+  let processMessageSpy;
+  beforeEach(() => {
+    processMessageSpy = env.sandbox.spy(
+      InaboxMessagingHost.prototype, 'processMessage');
+  });
+
+  it('should process queue', () => {
+    const messages = [{}, {}, {}];
+    env.win['ampInaboxPendingMessages'] = messages;
+    new InaboxHost(env.win);
+    expect(processMessageSpy.callCount).to.equal(3);
+    messages.forEach(e => expect(processMessageSpy.withArgs(e)).to.be.called);
+    // Calling push should have no effect
+    expect(env.win['ampInaboxPendingMessages'].length).to.equal(0);
+    env.win['ampInaboxPendingMessages'].push({});
+    expect(env.win['ampInaboxPendingMessages'].length).to.equal(0);
+  });
+
+  it('should handle no queue', () => {
+    new InaboxHost(env.win);
+    expect(processMessageSpy).to.not.be.called;
+  });
+
+  it('should handle non-array queue', () => {
+    env.win['ampInaboxPendingMessages'] = 1234;
+    new InaboxHost(env.win);
+    expect(processMessageSpy).to.not.be.called;
+  });
+
+  it('should handle duplicate executions', () => {
+    // Does not throw.
+    new InaboxHost(env.win);
+    new InaboxHost(env.win);
+    // Calling push should have no effect
+    expect(env.win['ampInaboxPendingMessages'].length).to.equal(0);
+    env.win['ampInaboxPendingMessages'].push({});
+    expect(env.win['ampInaboxPendingMessages'].length).to.equal(0);
+  });
+
+});


### PR DESCRIPTION
As part of inabox host script load, verify inbound window objects and clear array after load and ensure it can no longer be populated (free memory).  Added test coverage.