### PR TITLE
Implement new font-load-timeout scheme

### DIFF
--- a/test/functional/test-font-stylesheet-timeout.js
+++ b/test/functional/test-font-stylesheet-timeout.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import {Services} from '../../src/services';
 import {
   fontStylesheetTimeout,
 } from '../../src/font-stylesheet-timeout';
@@ -44,7 +43,6 @@ describes.realWin('font-stylesheet-timeout', {
         return responseStart;
       },
     });
-    const platform = Services.platformFor(win);
   });
 
   function addLink(opt_content, opt_href) {
@@ -66,6 +64,8 @@ describes.realWin('font-stylesheet-timeout', {
     clock.tick(10000);
     expect(win.document.querySelectorAll(
         'link[rel="stylesheet"]')).to.have.length(1);
+    expect(win.document.querySelector(
+        'link[rel="stylesheet"]')).to.equal(link);
     expect(win.document.querySelectorAll(
         'link[rel="stylesheet"][i-amphtml-timeout]')).to.have.length(0);
   });

--- a/test/functional/test-font-stylesheet-timeout.js
+++ b/test/functional/test-font-stylesheet-timeout.js
@@ -27,10 +27,8 @@ describes.realWin('font-stylesheet-timeout', {
   let win;
   let readyState;
   let responseStart;
-  let isSafariIsh;
 
   beforeEach(() => {
-    isSafariIsh = false;
     clock = env.sandbox.useFakeTimers();
     win = env.win;
     win.setTimeout = self.setTimeout;
@@ -47,8 +45,6 @@ describes.realWin('font-stylesheet-timeout', {
       },
     });
     const platform = Services.platformFor(win);
-    env.sandbox.stub(platform, 'isIos').callsFake(() => isSafariIsh);
-    env.sandbox.stub(platform, 'isSafari').callsFake(() => isSafariIsh);
   });
 
   function addLink(opt_content, opt_href) {
@@ -63,29 +59,15 @@ describes.realWin('font-stylesheet-timeout', {
     return 'data:text/css;charset=utf-8,' + (opt_content || '');
   }
 
-  it('should skip in safari', () => {
-    isSafariIsh = true;
-    const link = addLink();
-    expect(win.document.querySelector(
-        'link[rel="stylesheet"]')).to.equal(link);
-    fontStylesheetTimeout(win);
-    clock.tick(2000);
-    expect(win.document.querySelectorAll(
-        'link[rel="stylesheet"][i-amphtml-timeout]')).to.have.length(0);
-    expect(win.document.querySelector(
-        'link[rel="stylesheet"]')).to.equal(link);
-  });
-
-  // TODO(cramforce, #11827): Make this test work on Safari.
-  it.configure().skipSafari().run('should not time out for immediately ' +
+  it('should not time out for immediately ' +
       'loading style sheets', () => {
     const link = addLink();
     fontStylesheetTimeout(win);
     clock.tick(10000);
     expect(win.document.querySelectorAll(
         'link[rel="stylesheet"]')).to.have.length(1);
-    expect(win.document.querySelector(
-        'link[rel="stylesheet"]')).to.equal(link);
+    expect(win.document.querySelectorAll(
+        'link[rel="stylesheet"][i-amphtml-timeout]')).to.have.length(0);
   });
 
   it('should time out if style sheets do not load', () => {
@@ -99,7 +81,7 @@ describes.realWin('font-stylesheet-timeout', {
         'link[rel="stylesheet"][i-amphtml-timeout]')).to.have.length(1);
     const after = win.document.querySelector(
         'link[rel="stylesheet"]');
-    expect(after).to.not.equal(link);
+    expect(after).to.equal(link);
     expect(after.href).to.equal(link.href);
     expect(after.media).to.equal('not-matching');
     after.href = immediatelyLoadingHref('/* make-it-load */');
@@ -124,7 +106,7 @@ describes.realWin('font-stylesheet-timeout', {
     expect(win.document.querySelectorAll(
         'link[rel="stylesheet"][i-amphtml-timeout]')).to.have.length(1);
     expect(win.document.querySelector(
-        'link[rel="stylesheet"]')).to.not.equal(link);
+        'link[rel="stylesheet"]')).to.equal(link);
     expect(win.document.querySelector(
         'link[rel="stylesheet"]').href).to.equal(link.href);
   });
@@ -142,12 +124,10 @@ describes.realWin('font-stylesheet-timeout', {
     clock.tick(1);
     expect(win.document.querySelectorAll(
         'link[rel="stylesheet"][i-amphtml-timeout]')).to.have.length(2);
-    expect(win.document.querySelector(
-        'link[rel="stylesheet"]')).to.not.equal(link0);
     expect(win.document.querySelectorAll(
-        'link[rel="stylesheet"]')[0].href).to.equal(link0.href);
+        'link[rel="stylesheet"][i-amphtml-timeout]')[0]).to.equal(link0);
     expect(win.document.querySelectorAll(
-        'link[rel="stylesheet"]')[1].href).to.equal(link1.href);
+        'link[rel="stylesheet"][i-amphtml-timeout]')[1]).to.equal(link1);
     expect(win.document.querySelectorAll(
         'link[rel="stylesheet"]')[2]).to.equal(cdnLink);
   });

--- a/test/functional/test-font-stylesheet-timeout.js
+++ b/test/functional/test-font-stylesheet-timeout.js
@@ -57,7 +57,8 @@ describes.realWin('font-stylesheet-timeout', {
     return 'data:text/css;charset=utf-8,' + (opt_content || '');
   }
 
-  it('should not time out for immediately ' +
+  // TODO(cramforce, #11827): Make this test work on Safari.
+  it.configure().skipSafari().run('should not time out for immediately ' +
       'loading style sheets', () => {
     const link = addLink();
     fontStylesheetTimeout(win);


### PR DESCRIPTION
**With downloading stylesheet:**

| Browser | Remove Link/Add NewLink | Media Swap |
| --- | --- | --- |
| iOS 9.3 | blocks ❌ | blocks ❌ |
| iOS 10.3 | unblocks | unblocks |
| iOS 11 | unblocks | unblocks |
| OS X Safari 11 | unblocks | unblocks |
| Chrome 45 | unblocks | unblocks |
| Chrome 51 | unblocks | unblocks |
| Chrome 63 | unblocks | unblocks |

**With downloading `@import`:**

| Browser | Remove Link/Add NewLink | Media Swap |
| --- | --- | --- |
| iOS 9.3 | blocks ❌ | blocks ❌ |
| iOS 10.3 | blank ❌❌❌ | unblocks |
| iOS 11 | blank ❌❌❌ | unblocks |
| OS X Safari 11 | blank ❌❌❌ | unblocks |
| Chrome 45 | blank ❌❌❌ | unblocks |
| Chrome 51 | blank ❌❌❌ | blocks ❌ |
| Chrome 63 | unblocks | unblocks |

Fixes #12520.