### PR TITLE
allow import statements to be longer than 80 chars

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -44,7 +44,7 @@
     "max-len": [2, 80, 4, {
       "ignoreComments": true,
       "ignoreUrls": true,
-      "ignorePattern": ""
+      "ignorePattern": "^import.*';$"
     }],
     "no-alert": 2,
     "no-array-destructuring": 2,

--- a/src/amp.js
+++ b/src/amp.js
@@ -30,12 +30,7 @@ import {installPlatformService} from './service/platform-impl';
 import {installDocService} from './service/ampdoc-impl';
 import {installCacheServiceWorker} from './service-worker/install';
 import {stubElementsForDoc} from './service/custom-element-registry';
-import {
-  installAmpdocServices,
-  installBuiltins,
-  installRuntimeServices,
-  adopt,
-} from './runtime';
+import {installAmpdocServices, installBuiltins, installRuntimeServices, adopt} from './runtime';
 import {cssText} from '../build/css';
 import {maybeValidate} from './validator-integration';
 import {maybeTrackImpression} from './impression';


### PR DESCRIPTION
Fixes https://github.com/ampproject/amphtml/issues/8750