### PR TITLE
amp-facebook: Center align suport for facebook extenstion

### DIFF
--- a/3p/facebook.js
+++ b/3p/facebook.js
@@ -46,7 +46,7 @@ function getPostContainer(global, data) {
   const c = global.document.getElementById('c');
   const shouldAlignCenter = data.alignCenter || false;
   if (shouldAlignCenter) {
-    setStyle(global.document.getElementById('c'), 'text-align', 'center');
+    setStyle(c, 'text-align', 'center');
   }
   const container = global.document.createElement('div');
   const embedAs = data.embedAs || 'post';

--- a/3p/facebook.js
+++ b/3p/facebook.js
@@ -17,6 +17,7 @@
 import {loadScript} from './3p';
 import {user} from '../src/log';
 import {dashToUnderline} from '../src/string';
+import {setStyle} from '../src/style';
 
 /**
  * Produces the Facebook SDK object for the passed in callback.
@@ -42,6 +43,11 @@ function getFacebookSdk(global, cb) {
  * @return {!Element} div
  */
 function getPostContainer(global, data) {
+  const c = global.document.getElementById('c');
+  const shouldAlignCenter = data.alignCenter || false;
+  if (shouldAlignCenter) {
+    setStyle(global.document.getElementById('c'), 'text-align', 'center');
+  }
   const container = global.document.createElement('div');
   const embedAs = data.embedAs || 'post';
   user().assert(['post', 'video'].indexOf(embedAs) !== -1,

--- a/examples/facebook.amp.html
+++ b/examples/facebook.amp.html
@@ -27,7 +27,8 @@
 
 <amp-facebook width=552 height=350
     layout="responsive"
-    data-href="https://www.facebook.com/notes/facebook-engineering/under-the-hood-the-javascript-sdk-truly-asynchronous-loading/10151176218703920/">
+    data-href="https://www.facebook.com/notes/facebook-engineering/under-the-hood-the-javascript-sdk-truly-asynchronous-loading/10151176218703920/"
+    data-align-center="true">
 </amp-facebook>
 
 <amp-facebook width=552 height=579

--- a/extensions/amp-facebook/amp-facebook.md
+++ b/extensions/amp-facebook/amp-facebook.md
@@ -88,6 +88,12 @@ Both posts and videos can be embedded as a post. Setting `data-embed-as="video"`
 
 Check out the documentation for differences between [post embeds](https://developers.facebook.com/docs/plugins/embedded-posts) and [video embeds](https://developers.facebook.com/docs/plugins/embedded-video-player).
 
+##### data-align-center
+
+The value is either `true` or `false`.  The default is `false`.
+
+Having this attribute set to true would align the post/video container to center.
+
 ##### common attributes
 
 This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.


### PR DESCRIPTION
Solves #12093 
Exposes
`data-align-center` attribute (true/false), which aligns the contained to center.

@aghassemi 