### PR TITLE
Change how AMP inabox validates that the source of a postMessage is valid

### DIFF
--- a/ads/inabox/inabox-messaging-host.js
+++ b/ads/inabox/inabox-messaging-host.js
@@ -17,7 +17,6 @@
 import {FrameOverlayManager} from './frame-overlay-manager';
 import {PositionObserver} from './position-observer';
 import {
-  canInspectWindow,
   serializeMessage,
   deserializeMessage,
   MessageType,
@@ -225,27 +224,26 @@ export class InaboxMessagingHost {
       return this.iframeMap_[sentinel];
     }
 
-    // Walk up on the window tree and verify that there is no cross-domain
-    // frame in between the source of the postMessage and the host doc.
-    // If there is, the host doc will not be able to accurately measure
-    // the creative's positions in the page, so return null.
-    // Limit to 10 iterations.
-    let tempWin = source.parent;
-    for (let i = 0; i < 10; i++) {
-      if (tempWin == this.win_ || tempWin == this.win_.top) {
-        break;
-      }
-      if (!canInspectWindow(tempWin)) {
-        return null;
-      }
-      tempWin = tempWin.parent;
-    }
-
     // Verify that the source of the postMessage corresponds to one of
     // the iframes that was registered.
     for (let i = 0; i < this.iframes_.length; i++) {
       const iframe = this.iframes_[i];
       if (iframe.contentWindow === source) {
+	  // Walk up on the window tree and verify that there is no cross-domain
+	  // frame in between the source of the postMessage and the host doc.
+	  // If there is, the host doc will not be able to accurately measure
+	  // the creative's positions in the page, so return null.
+	  // Limit to 10 iterations.
+	  let tempWin = source.parent;
+	  for (let i = 0; i < 10; i++) {
+	      if (tempWin == this.win_ || tempWin == this.win_.top) {
+		  break;
+	      }
+	      if (!canInspectWindow(tempWin)) {
+		  return null;
+	      }
+	      tempWin = tempWin.parent;
+	  }
         // Cache the found iframe with its sentinel.
         this.iframeMap_[sentinel] = iframe;
         return iframe;
@@ -254,3 +252,34 @@ export class InaboxMessagingHost {
     return null;
   }
 }
+
+/**
+ * Returns true if win's properties can be accessed and win is defined.
+ * This functioned is used to determine if a window is cross-domained
+ * from the perspective of the current window.
+ * @param {Window} win
+ * @return {boolean}
+ */
+function canInspectWindow(win) {
+  try {
+    return !!win && win.location.href != null && canTouchProperty(win, 'test');
+  } catch (err) {
+    return false;
+  }
+}
+
+/**
+ * Returns whether we can touch the property prop on the object obj.
+ * @param {Object} obj
+ * @param {string} prop
+ * @return {boolean}
+ */
+function canTouchProperty(obj, prop) {
+  try {
+    const /* eslint no-unused-vars: 0 */ unused = obj[prop];
+    return true;
+  } catch (err) {
+    return false;
+  }
+}
+

--- a/ads/inabox/inabox-messaging-host.js
+++ b/ads/inabox/inabox-messaging-host.js
@@ -274,7 +274,7 @@ export class InaboxMessagingHost {
     let topXDomainWin;
     for (let j = 0, tempWin = win;
       j < 10 && tempWin != tempWin.top && !canInspectWindow_(tempWin);
-      j++, tempWin = tempWin.parent, topXDomainWin = tempWin) {}
+      j++, topXDomainWin = tempWin, tempWin = tempWin.parent) {}
     // If topXDomainWin exists, we know that the frame we want to measure
     // is a x-domain frame. Unfortunately, you can not access properties
     // on a x-domain window, so we can not do window.frameElement, and

--- a/ads/inabox/inabox-messaging-host.js
+++ b/ads/inabox/inabox-messaging-host.js
@@ -17,6 +17,7 @@
 import {FrameOverlayManager} from './frame-overlay-manager';
 import {PositionObserver} from './position-observer';
 import {
+  canInspectWindow,
   serializeMessage,
   deserializeMessage,
   MessageType,
@@ -228,9 +229,13 @@ export class InaboxMessagingHost {
     // frame in between the source of the postMessage and the host doc.
     // If there is, the host doc will not be able to accurately measure
     // the creative's positions in the page, so return null.
+    // Limit to 10 iterations.
     let tempWin = source.parent;
-    while (tempWin !== this.win_ && tempWin !== this.win_.top) {
-      if (tempWin.location.origin !== this.win_.location.origin) {
+    for (let i = 0; i < 10; i++) {
+      if (tempWin == this.win_ || tempWin == this.win_.top) {
+        break;
+      }
+      if (!canInspectWindow(tempWin)) {
         return null;
       }
       tempWin = tempWin.parent;

--- a/ads/inabox/inabox-messaging-host.js
+++ b/ads/inabox/inabox-messaging-host.js
@@ -261,24 +261,10 @@ export class InaboxMessagingHost {
  */
 function canInspectWindow(win) {
   try {
-    return win.location.href != null && canTouchProperty(win, 'test');
-  } catch (err) {
-    return false;
-  }
-}
-
-/**
- * Returns whether we can touch the property prop on the object obj.
- * @param {Object} obj
- * @param {string} prop
- * @return {boolean}
- */
-function canTouchProperty(obj, prop) {
-  try {
-    const /* eslint no-unused-vars: 0 */ unused = obj[prop];
+    const /* eslint no-unused-vars: 0 */ unused =
+      !!win.location.href && win['test'];
     return true;
-  } catch (err) {
+  } catch (unusedErr) {
     return false;
   }
 }
-

--- a/ads/inabox/inabox-messaging-host.js
+++ b/ads/inabox/inabox-messaging-host.js
@@ -261,17 +261,16 @@ export class InaboxMessagingHost {
    * For when win is friendly framed, returns the frame element for win.
    * @param {!Window} win
    * @return {?Element}
+   * @visibleForTesting
    */
   getMeasureableFrame(win) {
     let measureableWin;
-    let measureableFrame = win.frameElement;
-    for (let j = 0, tempWin = win; j < 5 && tempWin != tempWin.top;
+    for (let j = 0, tempWin = win; j < 10 && tempWin != tempWin.top;
       j++, tempWin = tempWin.parent) {
-      if (!canInspectWindow(tempWin)) {
-        measureableWin = tempWin;
-      } else {
+      if (canInspectWindow(tempWin)) {
         break;
       }
+      measureableWin = tempWin;
     }
     if (!!measureableWin) {
       const parent = measureableWin.parent;
@@ -279,11 +278,11 @@ export class InaboxMessagingHost {
       for (let k = 0, frame = iframes[k]; k < iframes.length;
         k++, frame = iframes[k]) {
         if (frame.contentWindow == measureableWin) {
-          measureableFrame = frame;
+          return frame;
         }
       }
     }
-    return measureableFrame;
+    return win.frameElement;
   }
 }
 
@@ -293,6 +292,7 @@ export class InaboxMessagingHost {
  * from the perspective of the current window.
  * @param {Window} win
  * @return {boolean}
+ * @private
  */
 function canInspectWindow(win) {
   try {

--- a/ads/inabox/inabox-messaging-host.js
+++ b/ads/inabox/inabox-messaging-host.js
@@ -230,7 +230,7 @@ export class InaboxMessagingHost {
    *
    * @param source {!Window}
    * @param sentinel {string}
-   * @returns {?HTMLIFrameElement}
+   * @return {?Element}
    * @private
    */
   getFrameElement_(source, sentinel) {
@@ -248,8 +248,8 @@ export class InaboxMessagingHost {
           return measureableFrame;
         }
       }
-      return null;
     }
+    return null;
   }
 
   /**
@@ -260,10 +260,11 @@ export class InaboxMessagingHost {
    * is found. Then, it returns the frame element for that window.
    * For when win is friendly framed, returns the frame element for win.
    * @param {!Window} win
-   * @returns {!HTMLIframeElement}
+   * @return {?Element}
    */
   getMeasureableFrame(win) {
-    let measureableWin, measureableFrame;
+    let measureableWin;
+    let measureableFrame = win.frameElement;
     for (let j = 0, tempWin = win; j < 5 && tempWin != tempWin.top;
       j++, tempWin = tempWin.parent) {
       if (!canInspectWindow(tempWin)) {
@@ -281,8 +282,6 @@ export class InaboxMessagingHost {
           measureableFrame = frame;
         }
       }
-    } else {
-      measureableFrame = win.frameElement;
     }
     return measureableFrame;
   }

--- a/ads/inabox/inabox-messaging-host.js
+++ b/ads/inabox/inabox-messaging-host.js
@@ -242,12 +242,12 @@ export class InaboxMessagingHost {
     for (let i = 0; i < this.iframes_.length; i++) {
       const iframe = this.iframes_[i];
       for (let j = 0, tempWin = measureableWin;
-           j < 10; j++, tempWin = tempWin.parent) {
-             if (iframe.contentWindow == tempWin) {
-               this.iframeMap_[sentinel] = measureableFrame;
-               return measureableFrame;
-             }
-           }
+        j < 10; j++, tempWin = tempWin.parent) {
+        if (iframe.contentWindow == tempWin) {
+          this.iframeMap_[sentinel] = measureableFrame;
+          return measureableFrame;
+        }
+      }
       return null;
     }
   }
@@ -264,23 +264,23 @@ export class InaboxMessagingHost {
    */
   getMeasureableFrame(win) {
     let measureableWin, measureableFrame;
-    for (let j = 0, tempWin = win; j < 10 && tempWin != tempWin.top;
-         j++, tempWin = tempWin.parent) {
-           if (!canInspectWindow(tempWin)) {
-               measureableWin = tempWin;
-           } else {
-             break;
-           }
-         }
+    for (let j = 0, tempWin = win; j < 5 && tempWin != tempWin.top;
+      j++, tempWin = tempWin.parent) {
+      if (!canInspectWindow(tempWin)) {
+        measureableWin = tempWin;
+      } else {
+        break;
+      }
+    }
     if (!!measureableWin) {
       const parent = measureableWin.parent;
       const iframes = parent.document.querySelectorAll('iframe');
       for (let k = 0, frame = iframes[k]; k < iframes.length;
-           k++, frame = iframes[k]) {
-             if (frame.contentWindow == measureableWin) {
-               measureableFrame = frame;
-             }
-           }
+        k++, frame = iframes[k]) {
+        if (frame.contentWindow == measureableWin) {
+          measureableFrame = frame;
+        }
+      }
     } else {
       measureableFrame = win.frameElement;
     }

--- a/ads/inabox/inabox-messaging-host.js
+++ b/ads/inabox/inabox-messaging-host.js
@@ -235,7 +235,7 @@ export class InaboxMessagingHost {
         // the creative's positions in the page, so return null.
         // Limit to 10 iterations.
         for (let i = 0, tempWin = source.parent;
-	     tempWin == this.win_ || tempWin == this.win_.top;
+	     tempWin != this.win_ && tempWin != this.win_.top;
 	     i++, tempWin = tempWin.parent) {
 	    if (i == 10 || !canInspectWindow(tempWin)) {
             dev().warn(

--- a/ads/inabox/inabox-messaging-host.js
+++ b/ads/inabox/inabox-messaging-host.js
@@ -247,6 +247,9 @@ export class InaboxMessagingHost {
           this.iframeMap_[sentinel] = measureableFrame;
           return measureableFrame;
         }
+        if (tempWin == window.top) {
+          break;
+        }
       }
     }
     return null;

--- a/src/3p-frame-messaging.js
+++ b/src/3p-frame-messaging.js
@@ -125,6 +125,32 @@ export function isAmpMessage(message) {
       message.indexOf('{') != -1);
 }
 
+
+/**
+ * Returns true if win's properties can be accessed and win is defined.
+ * This functioned is used to determine if a window is cross-domained
+ * from the perspective of the current window.
+ * @param {Window} win
+ * @return {boolean}
+ */
+export function canInspectWindow(win) {
+  try {
+    return !!win && win.location.href != null && canTouchProperty(win, 'test');
+  } catch (err) {
+    return false;
+  }
+}
+
+function canTouchProperty(obj, prop) {
+  try {
+    const /* eslint no-unused-vars: 0 */ unused = obj[prop];
+    return true;
+  } catch (err) {
+    return false;
+  }
+}
+
+
 /** @typedef {{creativeId: string, message: string}} */
 export let IframeTransportEvent;
 // An event, and the transport ID of the amp-analytics tags that

--- a/src/3p-frame-messaging.js
+++ b/src/3p-frame-messaging.js
@@ -141,6 +141,12 @@ export function canInspectWindow(win) {
   }
 }
 
+/**
+ * Returns whether we can touch the property prop on the object obj.
+ * @param {Object} obj
+ * @param {string} prop
+ * @return {boolean}
+ */
 function canTouchProperty(obj, prop) {
   try {
     const /* eslint no-unused-vars: 0 */ unused = obj[prop];

--- a/src/3p-frame-messaging.js
+++ b/src/3p-frame-messaging.js
@@ -125,38 +125,6 @@ export function isAmpMessage(message) {
       message.indexOf('{') != -1);
 }
 
-
-/**
- * Returns true if win's properties can be accessed and win is defined.
- * This functioned is used to determine if a window is cross-domained
- * from the perspective of the current window.
- * @param {Window} win
- * @return {boolean}
- */
-export function canInspectWindow(win) {
-  try {
-    return !!win && win.location.href != null && canTouchProperty(win, 'test');
-  } catch (err) {
-    return false;
-  }
-}
-
-/**
- * Returns whether we can touch the property prop on the object obj.
- * @param {Object} obj
- * @param {string} prop
- * @return {boolean}
- */
-function canTouchProperty(obj, prop) {
-  try {
-    const /* eslint no-unused-vars: 0 */ unused = obj[prop];
-    return true;
-  } catch (err) {
-    return false;
-  }
-}
-
-
 /** @typedef {{creativeId: string, message: string}} */
 export let IframeTransportEvent;
 // An event, and the transport ID of the amp-analytics tags that

--- a/test/functional/inabox/test-inabox-messaging-host.js
+++ b/test/functional/inabox/test-inabox-messaging-host.js
@@ -348,6 +348,20 @@ describes.realWin('inabox-host:messaging', {}, env => {
       ).to.deep.equal(expectedWin);
     });
 
+    it('should return correct frame when many frames registered', () => {
+      const iframeObj = createNestedIframeMocks(6);
+      const sourceMock = iframeObj.source;
+      const topWinMock = iframeObj.topWin;
+      const frameMockWrong1 = {};
+      const frameMockWrong2 = {};
+      const frameMock = topWinMock.document.querySelectorAll()[0];
+      const expectedWin = sourceMock;
+      host = new InaboxMessagingHost(
+          win, [frameMockWrong1, frameMockWrong2, frameMock]);
+      expect(host.getFrameElement_(sourceMock, sentinel).contentWindow
+      ).to.deep.equal(expectedWin);
+    });
+
     it('should return cached frame', () => {
       host.getMeasureableFrame = () => {
         throw new Error('Error!!');

--- a/test/functional/inabox/test-inabox-messaging-host.js
+++ b/test/functional/inabox/test-inabox-messaging-host.js
@@ -346,5 +346,26 @@ describes.realWin('inabox-host:messaging', {}, env => {
     it('should return null if frame is not registered', () => {
       expect(host.getFrameElement_(creativeWinMock, sentinel)).to.be.null;
     });
+
+    it('should return null if frame is more than 10 levels deep', () => {
+      const makeNestedFrame = parentFrame => {
+        return {
+	    parent: parentFrame,
+	    location: {
+            href: 'foo',
+	    },
+        };
+      };
+      const topFrame = {};
+      let source = topFrame;
+      for (let i = 0; i < 15 ; i++) {
+        source = makeNestedFrame(source);
+      }
+      creativeIframeMock = {
+        contentWindow: source,
+      };
+      host.iframes_.push(creativeIframeMock);
+      expect(host.getFrameElement_(source, sentinel)).to.be.null;
+    });
   });
 });

--- a/test/functional/inabox/test-inabox-messaging-host.js
+++ b/test/functional/inabox/test-inabox-messaging-host.js
@@ -303,6 +303,21 @@ describes.realWin('inabox-host:messaging', {}, env => {
   }
 
   describe('getMeasureableFrame', () => {
+    it('should return correct frame when many iframes at same level', () => {
+      const source = createNestedIframeMocks(6,3).source;
+      const expectedMeasureableWin = source.parent.parent;
+      const correctFrame =
+            expectedMeasureableWin.parent.document.querySelectorAll()[0];
+      expectedMeasureableWin.parent.document.querySelectorAll = () => {
+        const f1 = {};
+        const f2 = {};
+        const f3 = {};
+        return [f1, f2, correctFrame, f3];
+      };
+      expect(host.getMeasureableFrame(source).contentWindow).to.deep.equal(
+          expectedMeasureableWin);
+    });
+
     it('should return correct frame multiple level of xdomain', () => {
       const source = createNestedIframeMocks(6,3).source;
       const expectedMeasurableWin = source.parent.parent;

--- a/test/functional/inabox/test-inabox-messaging-host.js
+++ b/test/functional/inabox/test-inabox-messaging-host.js
@@ -273,13 +273,16 @@ describes.realWin('inabox-host:messaging', {}, env => {
       intermediateWinMock = {
         top: topWinMock,
         location: {
-          href: 'somesite.com',
+          href: 'intermediate.com',
         },
         parent: topWinMock,
       };
       creativeWinMock = {
         top: topWinMock,
         parent: intermediateWinMock,
+        location: {
+          href: 'creative.com',
+        },
       };
       creativeIframeMock = {
         contentWindow: creativeWinMock,
@@ -288,24 +291,20 @@ describes.realWin('inabox-host:messaging', {}, env => {
       sentinel = '123456789101112';
     });
 
-    it('should return null if there are intermediate xdomain frames', () => {
-      Object.defineProperty(intermediateWinMock['location'], 'href', {
-        get: () => {
-          throw new Error('Error!!');
-        },
-        set: () => {
-          throw new Error('Error!!');
-        },
+    function breakCanInspectWindowForWindow(win) {
+      Object.defineProperty(win['location'], 'href', {
+        get: () => throw new Error('Error!!'),
       });
+      Object.defineProperty(win, 'test', {
+        get: () => throw new Error('Error!!'),
+      });
+    }
 
-      Object.defineProperty(intermediateWinMock, 'test', {
-        get: () => {
-          throw new Error('Error!!');
-        },
-        set: () => {
-          throw new Error('Error!!');
-        },
-      });
+    it('should return null if there are intermediate xdomain frames', () => {
+      let hrefCalled = false;
+      let testCalled = false;
+      breakCanInspectWindowForWindow(intermediateWinMock);
+      breakCanInspectWindowForWindow(creativeWinMock);
       expect(host.getFrameElement_(creativeWinMock, sentinel)).to.be.null;
     });
 

--- a/test/functional/inabox/test-inabox-messaging-host.js
+++ b/test/functional/inabox/test-inabox-messaging-host.js
@@ -324,59 +324,13 @@ describes.realWin('inabox-host:messaging', {}, env => {
   });
 
   describe('getFrameElement', () => {
-    let topWinMock;
-    let intermediateWinMock;
-    let creativeWinMock;
-    let creativeIframeMock;
-    let sentinel;
+    const sentinel = '123456789101112';
 
-    beforeEach(() => {
-      topWinMock = {};
-      topWinMock['top'] = topWinMock;
-      intermediateWinMock = {
-        top: topWinMock,
-        location: {
-          href: 'intermediate.com',
-        },
-        parent: topWinMock,
-      };
-      creativeWinMock = {
-        top: topWinMock,
-        parent: intermediateWinMock,
-        location: {
-          href: 'creative.com',
-        },
-      };
-      creativeIframeMock = {
-        contentWindow: creativeWinMock,
-      };
-      host.win_ = topWinMock;
-      sentinel = '123456789101112';
+    it('should return correct frame when intermediate xdomain frames', () => {
+      const source = createNestedIframeMocks(6,3)
+      const expectedWin = source.parent.parent;
+      expect(host.getFrameElement_(creativeWinMock, sentinel).win).to.deep.equal(expectedWin);
     });
-
-
-
-    it('should return null if there are intermediate xdomain frames', () => {
-      let hrefCalled = false;
-      let testCalled = false;
-      breakCanInspectWindowForWindow(intermediateWinMock);
-      breakCanInspectWindowForWindow(creativeWinMock);
-      expect(host.getFrameElement_(creativeWinMock, sentinel)).to.be.null;
-    });
-
-    it('should return null if there are intermediate xdomain frames - safari',
-        () => {
-          intermediateWinMock['location']['href'] = undefined;
-          Object.defineProperty(intermediateWinMock, 'test', {
-            get: () => {
-              throw new Error('Error!!');
-            },
-            set: () => {
-              throw new Error('Error!!');
-            },
-          });
-          expect(host.getFrameElement_(creativeWinMock, sentinel)).to.be.null;
-        });
 
     it('should return correct frame', () => {
       host.iframes_.push(creativeIframeMock);


### PR DESCRIPTION
This PR separates out how amp inabox 1. validates that the source of a post message is valid and 2. returns which iframe on the page should be measured. Before, it always looked to measure the direct child frame of the window level at which the host script runs. After this change, it now:
1. Checks that the source of the postMessage contains one of the registered amp inabox iframes in its parent chain
2. Either returns the source iframe if it is measureable, or returns whichever xdomain frame of the source's parent hierarchy is measureable. 