### PR TITLE
Fix font visual test

### DIFF
--- a/examples/visual-tests/font.amp/font.amp.html
+++ b/examples/visual-tests/font.amp/font.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ class="comic-amp-font-loading comic-amp-bold-font-loading">
 <head>
   <meta charset="utf-8">
   <title>Font example</title>
@@ -56,7 +56,7 @@
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
 </head>
-<body class="comic-amp-font-loading comic-amp-bold-font-loading">
+<body>
 
  <h1> Lorem Ipsum </h1>
 

--- a/test/visual-diff/visual-tests.json
+++ b/test/visual-diff/visual-tests.json
@@ -100,12 +100,12 @@
       "url": "examples/visual-tests/font.amp/font.amp.html",
       "name": "Fonts",
       "loading_incomplete_css": [
-        ".comic-amp-font-loading",
-        ".comic-amp-bold-font-loading"
+        "html.comic-amp-font-loading",
+        "html.comic-amp-bold-font-loading"
       ],
       "loading_complete_css": [
-        ".comic-amp-font-loaded",
-        ".comic-amp-bold-font-loaded"
+        "html.comic-amp-font-loaded",
+        "html.comic-amp-bold-font-loaded"
       ]
     },
     {


### PR DESCRIPTION
Fixes visual test failure that started with https://travis-ci.org/ampproject/amphtml/jobs/318914052

```
pr-check.js: Running gulp visual-diff --master...
[01:50:49] Using gulpfile ~/build/ampproject/amphtml/gulpfile.js
[01:50:49] Starting 'visual-diff'...
INFO: Started Percy build 451419...
ERROR: examples/visual-tests/font.amp/font.amp.html still has CSS element .comic-amp-font-loading
build-system/tasks/visual-diff.rb:329:in `block in verify_css_elements': Invalid CSS element (RuntimeError)
	from build-system/tasks/visual-diff.rb:325:in `each'
	from build-system/tasks/visual-diff.rb:325:in `verify_css_elements'
	from build-system/tasks/visual-diff.rb:289:in `block (2 levels) in generate_snapshots'
	from build-system/tasks/visual-diff.rb:281:in `each'
	from build-system/tasks/visual-diff.rb:281:in `block in generate_snapshots'
	from build-system/tasks/visual-diff.rb:275:in `each'
	from build-system/tasks/visual-diff.rb:275:in `generate_snapshots'
	from build-system/tasks/visual-diff.rb:250:in `run_visual_tests'
	from build-system/tasks/visual-diff.rb:433:in `main'
	from build-system/tasks/visual-diff.rb:441:in `<main>'

Command failed: ruby build-system/tasks/visual-diff.rb --master

Command failed: gulp visual-diff --master
```