### PR TITLE
Make our custom element implementation directly consumable by CE V1

### DIFF
--- a/build-system/dep-check-config.js
+++ b/build-system/dep-check-config.js
@@ -235,6 +235,8 @@ exports.rules = [
     filesMatching: '**/*.js',
     mustNotDependOn: 'src/polyfills.js',
     whitelist: [
+      'src/custom-element.js->src/polyfills.js',
+      'src/service/custom-element-registry.js->src/polyfills.js',
       'src/amp.js->src/polyfills.js',
       'src/service.js->src/polyfills.js',
       'src/service/timer-impl.js->src/polyfills.js',

--- a/build-system/tasks/karma.conf.js
+++ b/build-system/tasks/karma.conf.js
@@ -66,7 +66,7 @@ module.exports = {
     suppressSkipped: true,
     suppressFailed: false,
     suppressErrorSummary: true,
-    maxLogLines: 10,
+    maxLogLines: 100,
   },
 
   mochaReporter: {

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -91,6 +91,7 @@ function isTemplateTagSupported() {
 }
 
 
+
 /**
  * Creates a named custom element class.
  *
@@ -99,154 +100,133 @@ function isTemplateTagSupported() {
  * @return {!Function} The custom element class.
  */
 export function createCustomElementClass(win, name) {
-  const baseCustomElement = createBaseCustomElementClass(win);
-  /** @extends {HTMLElement} */
-  class CustomAmpElement extends baseCustomElement {
-    /**
-     * @see https://github.com/WebReflection/document-register-element#v1-caveat
-     * @suppress {checkTypes}
-     */
-    constructor(self) {
-      return super(self);
-    }
-    elementName() {
-      return name;
-    }
+  // Polyfill for Reflect.construct.
+  const construct = typeof win.Reflect === 'object'
+    ? win.Reflect.construct
+    : function(Parent, args, Class) {
+      const a = [null];
+      a.push.apply(a, args);
+      const Constructor = Parent.bind.apply(Parent, a);
+      const object = new Constructor();
+      object.__proto__ = Class.prototype;
+      return object;
+    };
+
+  function CustomElementClass() {
+    const self = construct(win.HTMLElement, [], CustomElementClass);
+    self.createdCallback();
+    return self;
   }
-  return CustomAmpElement;
-}
+  CustomElementClass.prototype = win.Object.create(win.HTMLElement.prototype);
+  CustomElementClass.prototype.constructor = CustomElementClass;
 
-
-/**
- * Creates a base custom element class.
- *
- * @param {!Window} win The window in which to register the custom element.
- * @return {!Function}
- */
-function createBaseCustomElementClass(win) {
-  if (win.BaseCustomElementClass) {
-    return win.BaseCustomElementClass;
-  }
-  const htmlElement = win.HTMLElement;
-  /** @abstract @extends {HTMLElement} */
-  class BaseCustomElement extends htmlElement {
-    /**
-     * @see https://github.com/WebReflection/document-register-element#v1-caveat
-     * @suppress {checkTypes}
-     */
-    constructor(self) {
-      self = super(self);
-      self.createdCallback();
-      return self;
-    }
-
-    /**
+  /**
      * Called when elements is created. Sets instance vars since there is no
      * constructor.
      * @final @this {!Element}
      */
-    createdCallback() {
-      // Flag "notbuilt" is removed by Resource manager when the resource is
-      // considered to be built. See "setBuilt" method.
-      /** @private {boolean} */
-      this.built_ = false;
+  CustomElementClass.prototype.createdCallback = function() {
+    // Flag "notbuilt" is removed by Resource manager when the resource is
+    // considered to be built. See "setBuilt" method.
+    /** @private {boolean} */
+    this.built_ = false;
 
-      /** @private {?Promise} */
-      this.buildingPromise_ = null;
+    /** @private {?Promise} */
+    this.buildingPromise_ = null;
 
-      /** @type {string} */
-      this.readyState = 'loading';
+    /** @type {string} */
+    this.readyState = 'loading';
 
-      /** @type {boolean} */
-      this.everAttached = false;
+    /** @type {boolean} */
+    this.everAttached = false;
 
-      /**
+    /**
        * Ampdoc can only be looked up when an element is attached.
        * @private {?./service/ampdoc-impl.AmpDoc}
        */
-      this.ampdoc_ = null;
+    this.ampdoc_ = null;
 
-      /**
+    /**
        * Resources can only be looked up when an element is attached.
        * @private {?./service/resources-impl.Resources}
        */
-      this.resources_ = null;
+    this.resources_ = null;
 
-      /** @private {!Layout} */
-      this.layout_ = Layout.NODISPLAY;
+    /** @private {!Layout} */
+    this.layout_ = Layout.NODISPLAY;
 
-      /** @private {number} */
-      this.layoutWidth_ = -1;
+    /** @private {number} */
+    this.layoutWidth_ = -1;
 
-      /** @private {number} */
-      this.layoutCount_ = 0;
+    /** @private {number} */
+    this.layoutCount_ = 0;
 
-      /** @private {boolean} */
-      this.isFirstLayoutCompleted_ = false;
+    /** @private {boolean} */
+    this.isFirstLayoutCompleted_ = false;
 
-      /** @private {boolean} */
-      this.isInViewport_ = false;
+    /** @private {boolean} */
+    this.isInViewport_ = false;
 
-      /** @private {boolean} */
-      this.paused_ = false;
+    /** @private {boolean} */
+    this.paused_ = false;
 
-      /** @private {string|null|undefined} */
-      this.mediaQuery_ = undefined;
+    /** @private {string|null|undefined} */
+    this.mediaQuery_ = undefined;
 
-      /** @private {!./size-list.SizeList|null|undefined} */
-      this.sizeList_ = undefined;
+    /** @private {!./size-list.SizeList|null|undefined} */
+    this.sizeList_ = undefined;
 
-      /** @private {!./size-list.SizeList|null|undefined} */
-      this.heightsList_ = undefined;
+    /** @private {!./size-list.SizeList|null|undefined} */
+    this.heightsList_ = undefined;
 
-      /**
+    /**
        * This element can be assigned by the {@link applyStaticLayout} to a
        * child element that will be used to size this element.
        * @package {?Element|undefined}
        */
-      this.sizerElement = undefined;
+    this.sizerElement = undefined;
 
-      /** @private {boolean|undefined} */
-      this.loadingDisabled_ = undefined;
+    /** @private {boolean|undefined} */
+    this.loadingDisabled_ = undefined;
 
-      /** @private {boolean|undefined} */
-      this.loadingState_ = undefined;
+    /** @private {boolean|undefined} */
+    this.loadingState_ = undefined;
 
-      /** @private {?Element} */
-      this.loadingContainer_ = null;
+    /** @private {?Element} */
+    this.loadingContainer_ = null;
 
-      /** @private {?Element} */
-      this.loadingElement_ = null;
+    /** @private {?Element} */
+    this.loadingElement_ = null;
 
-      /** @private {?Element|undefined} */
-      this.overflowElement_ = undefined;
+    /** @private {?Element|undefined} */
+    this.overflowElement_ = undefined;
 
-      // `opt_implementationClass` is only used for tests.
-      let Ctor = win.ampExtendedElements &&
+    // `opt_implementationClass` is only used for tests.
+    let Ctor = win.ampExtendedElements &&
           win.ampExtendedElements[this.elementName()];
-      if (getMode().test && this.implementationClassForTesting) {
-        Ctor = this.implementationClassForTesting;
-      }
-      dev().assert(Ctor);
-      /** @private {!./base-element.BaseElement} */
-      this.implementation_ = new Ctor(this);
+    if (getMode().test && this.implementationClassForTesting) {
+      Ctor = this.implementationClassForTesting;
+    }
+    dev().assert(Ctor);
+    /** @private {!./base-element.BaseElement} */
+    this.implementation_ = new Ctor(this);
 
-      /**
+    /**
        * An element always starts in a unupgraded state until it's added to DOM
        * for the first time in which case it can be upgraded immediately or wait
        * for script download or `upgradeCallback`.
        * @private {!UpgradeState}
        */
-      this.upgradeState_ = UpgradeState.NOT_UPGRADED;
+    this.upgradeState_ = UpgradeState.NOT_UPGRADED;
 
-      /**
+    /**
        * Time delay imposed by baseElement upgradeCallback.  If no
        * upgradeCallback specified or not yet executed, delay is 0.
        * @private {number}
        */
-      this.upgradeDelayMs_ = 0;
+    this.upgradeDelayMs_ = 0;
 
-      /**
+    /**
        * Action queue is initially created and kept around until the element
        * is ready to send actions directly to the implementation.
        * - undefined initially
@@ -254,71 +234,71 @@ function createBaseCustomElementClass(win) {
        * - null after unspun
        * @private {?Array<!./service/action-impl.ActionInvocation>|undefined}
        */
-      this.actionQueue_ = undefined;
+    this.actionQueue_ = undefined;
 
-      /**
+    /**
        * Whether the element is in the template.
        * @private {boolean|undefined}
        */
-      this.isInTemplate_ = undefined;
+    this.isInTemplate_ = undefined;
 
-      /** @private @const */
-      this.signals_ = new Signals();
+    /** @private @const */
+    this.signals_ = new Signals();
 
-      const perf = Services.performanceForOrNull(win);
-      /** @private {boolean} */
-      this.perfOn_ = perf && perf.isPerformanceTrackingOn();
+    const perf = Services.performanceForOrNull(win);
+    /** @private {boolean} */
+    this.perfOn_ = perf && perf.isPerformanceTrackingOn();
 
-      /** @private {?./layout-delay-meter.LayoutDelayMeter} */
-      this.layoutDelayMeter_ = null;
+    /** @private {?./layout-delay-meter.LayoutDelayMeter} */
+    this.layoutDelayMeter_ = null;
 
-      if (this[dom.UPGRADE_TO_CUSTOMELEMENT_RESOLVER]) {
-        this[dom.UPGRADE_TO_CUSTOMELEMENT_RESOLVER](this);
-        delete this[dom.UPGRADE_TO_CUSTOMELEMENT_RESOLVER];
-        delete this[dom.UPGRADE_TO_CUSTOMELEMENT_PROMISE];
-      }
+    if (this[dom.UPGRADE_TO_CUSTOMELEMENT_RESOLVER]) {
+      this[dom.UPGRADE_TO_CUSTOMELEMENT_RESOLVER](this);
+      delete this[dom.UPGRADE_TO_CUSTOMELEMENT_RESOLVER];
+      delete this[dom.UPGRADE_TO_CUSTOMELEMENT_PROMISE];
     }
+  };
 
-    /**
+  /**
      * The name of the custom element.
-     * @abstract
      * @return {string}
      */
-    elementName() {
-    }
+  CustomElementClass.prototype.elementName = function() {
+    return name;
+  };
 
-    /** @return {!Signals} */
-    signals() {
-      return this.signals_;
-    }
+  /** @return {!Signals} */
+  CustomElementClass.prototype.signals = function() {
+    return this.signals_;
+  };
 
-    /**
+  /**
      * Returns the associated ampdoc. Only available after attachment. It throws
      * exception before the element is attached.
      * @return {!./service/ampdoc-impl.AmpDoc}
      * @final @this {!Element}
      * @package
      */
-    getAmpDoc() {
-      return /** @type {!./service/ampdoc-impl.AmpDoc} */ (
-        dev().assert(this.ampdoc_,
-            'no ampdoc yet, since element is not attached'));
-    }
+  CustomElementClass.prototype.getAmpDoc = function() {
+    return /** @type {!./service/ampdoc-impl.AmpDoc} */ (
+      dev().assert(this.ampdoc_,
+          'no ampdoc yet, since element is not attached'));
+  };
 
-    /**
+  /**
      * Returns Resources manager. Only available after attachment. It throws
      * exception before the element is attached.
      * @return {!./service/resources-impl.Resources}
      * @final @this {!Element}
      * @package
      */
-    getResources() {
-      return /** @type {!./service/resources-impl.Resources} */ (
-        dev().assert(this.resources_,
-            'no resources yet, since element is not attached'));
-    }
+  CustomElementClass.prototype.getResources = function() {
+    return /** @type {!./service/resources-impl.Resources} */ (
+      dev().assert(this.resources_,
+          'no resources yet, since element is not attached'));
+  };
 
-    /**
+  /**
      * Whether the element has been upgraded yet. Always returns false when
      * the element has not yet been added to DOM. After the element has been
      * added to DOM, the value depends on the `BaseElement` implementation and
@@ -326,110 +306,111 @@ function createBaseCustomElementClass(win) {
      * @return {boolean}
      * @final @this {!Element}
      */
-    isUpgraded() {
-      return this.upgradeState_ == UpgradeState.UPGRADED;
-    }
+  CustomElementClass.prototype.isUpgraded = function() {
+    return this.upgradeState_ == UpgradeState.UPGRADED;
+  };
 
-    /**
+  /**
      * Upgrades the element to the provided new implementation. If element
      * has already been attached, it's layout validation and attachment flows
      * are repeated for the new implementation.
      * @param {function(new:./base-element.BaseElement, !Element)} newImplClass
      * @final @package @this {!Element}
      */
-    upgrade(newImplClass) {
-      if (this.isInTemplate_) {
-        return;
-      }
-      if (this.upgradeState_ != UpgradeState.NOT_UPGRADED) {
-        // Already upgraded or in progress or failed.
-        return;
-      }
-      this.implementation_ = new newImplClass(this);
-      if (this.everAttached) {
-        // Usually, we do an implementation upgrade when the element is
-        // attached to the DOM. But, if it hadn't yet upgraded from
-        // ElementStub, we couldn't. Now that it's upgraded from a stub, go
-        // ahead and do the full upgrade.
-        this.tryUpgrade_();
-      }
+  CustomElementClass.prototype.upgrade = function(newImplClass) {
+    if (this.isInTemplate_) {
+      return;
     }
+    if (this.upgradeState_ != UpgradeState.NOT_UPGRADED) {
+      // Already upgraded or in progress or failed.
+      return;
+    }
+    this.implementation_ = new newImplClass(this);
+    if (this.everAttached) {
+      // Usually, we do an implementation upgrade when the element is
+      // attached to the DOM. But, if it hadn't yet upgraded from
+      // ElementStub, we couldn't. Now that it's upgraded from a stub, go
+      // ahead and do the full upgrade.
+      this.tryUpgrade_();
+    }
+  };
 
-    /**
+  /**
      * Time delay imposed by baseElement upgradeCallback.  If no
      * upgradeCallback specified or not yet executed, delay is 0.
      * @return {number}
      */
-    getUpgradeDelayMs() {
-      return this.upgradeDelayMs_;
-    }
+  CustomElementClass.prototype.getUpgradeDelayMs = function() {
+    return this.upgradeDelayMs_;
+  };
 
-    /**
+  /**
      * Completes the upgrade of the element with the provided implementation.
      * @param {!./base-element.BaseElement} newImpl
      * @param {number} upgradeStartTime
      * @final @private @this {!Element}
      */
-    completeUpgrade_(newImpl, upgradeStartTime) {
-      this.upgradeDelayMs_ = win.Date.now() - upgradeStartTime;
-      this.upgradeState_ = UpgradeState.UPGRADED;
-      this.implementation_ = newImpl;
-      this.classList.remove('amp-unresolved');
-      this.classList.remove('i-amphtml-unresolved');
-      this.implementation_.createdCallback();
-      this.assertLayout_();
-      this.implementation_.layout_ = this.layout_;
-      this.implementation_.layoutWidth_ = this.layoutWidth_;
-      this.implementation_.firstAttachedCallback();
-      this.dispatchCustomEventForTesting(AmpEvents.ATTACHED);
-      this.getResources().upgraded(this);
-    }
+  CustomElementClass.prototype.completeUpgrade_ =
+      function(newImpl, upgradeStartTime) {
+        this.upgradeDelayMs_ = win.Date.now() - upgradeStartTime;
+        this.upgradeState_ = UpgradeState.UPGRADED;
+        this.implementation_ = newImpl;
+        this.classList.remove('amp-unresolved');
+        this.classList.remove('i-amphtml-unresolved');
+        this.implementation_.createdCallback();
+        this.assertLayout_();
+        this.implementation_.layout_ = this.layout_;
+        this.implementation_.layoutWidth_ = this.layoutWidth_;
+        this.implementation_.firstAttachedCallback();
+        this.dispatchCustomEventForTesting(AmpEvents.ATTACHED);
+        this.getResources().upgraded(this);
+      };
 
-    /* @private */
-    assertLayout_() {
-      if (this.layout_ != Layout.NODISPLAY &&
+  /* @private */
+  CustomElementClass.prototype.assertLayout_ = function() {
+    if (this.layout_ != Layout.NODISPLAY &&
           !this.implementation_.isLayoutSupported(this.layout_)) {
-        let error = 'Layout not supported: ' + this.layout_;
-        if (!this.getAttribute('layout')) {
-          error += '. The element did not specify a layout attribute. ' +
+      let error = 'Layout not supported: ' + this.layout_;
+      if (!this.getAttribute('layout')) {
+        error += '. The element did not specify a layout attribute. ' +
               'Check https://www.ampproject.org/docs/guides/' +
               'responsive/control_layout and the respective element ' +
               'documentation for details.';
-        }
-        throw user().createError(error);
       }
+      throw user().createError(error);
     }
+  };
 
-    /**
+  /**
      * Whether the element has been built. A built element had its
      * {@link buildCallback} method successfully invoked.
      * @return {boolean}
      * @final @this {!Element}
      */
-    isBuilt() {
-      return this.built_;
-    }
+  CustomElementClass.prototype.isBuilt = function() {
+    return this.built_;
+  };
 
-    /**
+  /**
      * Returns the promise that's resolved when the element has been built. If
      * the build fails, the resulting promise is rejected.
      * @return {!Promise}
      */
-    whenBuilt() {
-      return this.signals_.whenSignal(CommonSignals.BUILT);
-    }
+  CustomElementClass.prototype.whenBuilt = function() {
+    return this.signals_.whenSignal(CommonSignals.BUILT);
+  };
 
-    /**
+  /**
      * Get the priority to load the element.
      * @return {number} @this {!Element}
      */
-    getPriority() {
-      dev().assert(
-          this.isUpgraded(), 'Cannot get priority of unupgraded element');
-      return this.implementation_.getPriority();
-    }
+  CustomElementClass.prototype.getPriority = function() {
+    dev().assert(
+        this.isUpgraded(), 'Cannot get priority of unupgraded element');
+    return this.implementation_.getPriority();
+  };
 
-    /**
+  /**
      * Requests or requires the element to be built. The build is done by
      * invoking {@link BaseElement.buildCallback} method.
      *
@@ -438,123 +419,123 @@ function createBaseCustomElementClass(win) {
      * @return {?Promise}
      * @final @this {!Element}
      */
-    build() {
-      assertNotTemplate(this);
-      dev().assert(this.isUpgraded(), 'Cannot build unupgraded element');
-      if (this.buildingPromise_) {
-        return this.buildingPromise_;
-      }
-      return this.buildingPromise_ = new Promise(resolve => {
-        resolve(this.implementation_.buildCallback());
-      }).then(() => {
-        this.preconnect(/* onLayout */false);
-        this.built_ = true;
-        this.classList.remove('i-amphtml-notbuilt');
-        this.classList.remove('amp-notbuilt');
-        this.signals_.signal(CommonSignals.BUILT);
-        if (this.isInViewport_) {
-          this.updateInViewport_(true);
-        }
-        if (this.actionQueue_) {
-          // Only schedule when the queue is not empty, which should be
-          // the case 99% of the time.
-          Services.timerFor(toWin(this.ownerDocument.defaultView))
-              .delay(this.dequeueActions_.bind(this), 1);
-        }
-        if (!this.getPlaceholder()) {
-          const placeholder = this.createPlaceholder();
-          if (placeholder) {
-            this.appendChild(placeholder);
-          }
-        }
-      }, reason => {
-        this.signals_.rejectSignal(CommonSignals.BUILT,
-            /** @type {!Error} */ (reason));
-        reportError(reason, this);
-        throw reason;
-      });
+  CustomElementClass.prototype.build = function() {
+    assertNotTemplate(this);
+    dev().assert(this.isUpgraded(), 'Cannot build unupgraded element');
+    if (this.buildingPromise_) {
+      return this.buildingPromise_;
     }
+    return this.buildingPromise_ = new Promise(resolve => {
+      resolve(this.implementation_.buildCallback());
+    }).then(() => {
+      this.preconnect(/* onLayout */false);
+      this.built_ = true;
+      this.classList.remove('i-amphtml-notbuilt');
+      this.classList.remove('amp-notbuilt');
+      this.signals_.signal(CommonSignals.BUILT);
+      if (this.isInViewport_) {
+        this.updateInViewport_(true);
+      }
+      if (this.actionQueue_) {
+        // Only schedule when the queue is not empty, which should be
+        // the case 99% of the time.
+        Services.timerFor(toWin(this.ownerDocument.defaultView))
+            .delay(this.dequeueActions_.bind(this), 1);
+      }
+      if (!this.getPlaceholder()) {
+        const placeholder = this.createPlaceholder();
+        if (placeholder) {
+          this.appendChild(placeholder);
+        }
+      }
+    }, reason => {
+      this.signals_.rejectSignal(CommonSignals.BUILT,
+          /** @type {!Error} */ (reason));
+      reportError(reason, this);
+      throw reason;
+    });
+  };
 
-    /**
+  /**
      * Called to instruct the element to preconnect to hosts it uses during
      * layout.
      * @param {boolean} onLayout Whether this was called after a layout.
      * @this {!Element}
      */
-    preconnect(onLayout) {
-      if (onLayout) {
+  CustomElementClass.prototype.preconnect = function(onLayout) {
+    if (onLayout) {
+      this.implementation_.preconnectCallback(onLayout);
+    } else {
+      // If we do early preconnects we delay them a bit. This is kind of
+      // an unfortunate trade off, but it seems faster, because the DOM
+      // operations themselves are not free and might delay
+      Services.timerFor(toWin(this.ownerDocument.defaultView)).delay(() => {
         this.implementation_.preconnectCallback(onLayout);
-      } else {
-        // If we do early preconnects we delay them a bit. This is kind of
-        // an unfortunate trade off, but it seems faster, because the DOM
-        // operations themselves are not free and might delay
-        Services.timerFor(toWin(this.ownerDocument.defaultView)).delay(() => {
-          this.implementation_.preconnectCallback(onLayout);
-        }, 1);
-      }
+      }, 1);
     }
+  };
 
-    /**
+  /**
      * Whether the custom element declares that it has to be fixed.
      * @return {boolean}
      * @this {!Element}
      */
-    isAlwaysFixed() {
-      return this.implementation_.isAlwaysFixed();
-    }
+  CustomElementClass.prototype.isAlwaysFixed = function() {
+    return this.implementation_.isAlwaysFixed();
+  };
 
-    /**
+  /**
      * Updates the layout box of the element.
      * See {@link BaseElement.getLayoutWidth} for details.
      * @param {!./layout-rect.LayoutRectDef} layoutBox
      * @this {!Element}
      */
-    updateLayoutBox(layoutBox) {
-      this.layoutWidth_ = layoutBox.width;
-      if (this.isUpgraded()) {
-        this.implementation_.layoutWidth_ = this.layoutWidth_;
-      }
-      if (this.isBuilt()) {
-        try {
-          this.implementation_.onLayoutMeasure();
-        } catch (e) {
-          reportError(e, this);
-        }
-      }
-
-      if (this.isLoadingEnabled_()) {
-        if (this.isInViewport_) {
-          // Already in viewport - start showing loading.
-          this.toggleLoading_(true);
-        } else if (layoutBox.top < PREPARE_LOADING_THRESHOLD &&
-          layoutBox.top >= 0) {
-          // Few top elements will also be pre-initialized with a loading
-          // element.
-          getVsync(this).mutate(() => {
-            // Repeat "loading enabled" check because it could have changed while
-            // waiting for vsync.
-            if (this.isLoadingEnabled_()) {
-              this.prepareLoading_();
-            }
-          });
-        }
+  CustomElementClass.prototype.updateLayoutBox = function(layoutBox) {
+    this.layoutWidth_ = layoutBox.width;
+    if (this.isUpgraded()) {
+      this.implementation_.layoutWidth_ = this.layoutWidth_;
+    }
+    if (this.isBuilt()) {
+      try {
+        this.implementation_.onLayoutMeasure();
+      } catch (e) {
+        reportError(e, this);
       }
     }
 
-    /**
+    if (this.isLoadingEnabled_()) {
+      if (this.isInViewport_) {
+        // Already in viewport - start showing loading.
+        this.toggleLoading_(true);
+      } else if (layoutBox.top < PREPARE_LOADING_THRESHOLD &&
+          layoutBox.top >= 0) {
+        // Few top elements will also be pre-initialized with a loading
+        // element.
+        getVsync(this).mutate(() => {
+          // Repeat "loading enabled" check because it could have changed while
+          // waiting for vsync.
+          if (this.isLoadingEnabled_()) {
+            this.prepareLoading_();
+          }
+        });
+      }
+    }
+  };
+
+  /**
      * @return {?Element}
      * @private
      */
-    getSizer_() {
-      if (this.sizerElement === undefined &&
+  CustomElementClass.prototype.getSizer_ = function() {
+    if (this.sizerElement === undefined &&
           this.layout_ === Layout.RESPONSIVE) {
-        // Expect sizer to exist, just not yet discovered.
-        this.sizerElement = this.querySelector('i-amphtml-sizer');
-      }
-      return this.sizerElement || null;
+      // Expect sizer to exist, just not yet discovered.
+      this.sizerElement = this.querySelector('i-amphtml-sizer');
     }
+    return this.sizerElement || null;
+  };
 
-    /**
+  /**
      * If the element has a media attribute, evaluates the value as a media
      * query and based on the result adds or removes the class
      * `i-amphtml-hidden-by-media-query`. The class adds display:none to the element
@@ -566,45 +547,45 @@ function createBaseCustomElementClass(win) {
      * @final
      * @package @this {!Element}
      */
-    applySizesAndMediaQuery() {
-      assertNotTemplate(this);
+  CustomElementClass.prototype.applySizesAndMediaQuery = function() {
+    assertNotTemplate(this);
 
-      // Media query.
-      if (this.mediaQuery_ === undefined) {
-        this.mediaQuery_ = this.getAttribute('media') || null;
-      }
-      if (this.mediaQuery_) {
-        const defaultView = this.ownerDocument.defaultView;
-        this.classList.toggle('i-amphtml-hidden-by-media-query',
-            !defaultView.matchMedia(this.mediaQuery_).matches);
-      }
-
-      // Sizes.
-      if (this.sizeList_ === undefined) {
-        const sizesAttr = this.getAttribute('sizes');
-        this.sizeList_ = sizesAttr ? parseSizeList(sizesAttr) : null;
-      }
-      if (this.sizeList_) {
-        setStyle(this, 'width', this.sizeList_.select(
-            toWin(this.ownerDocument.defaultView)));
-      }
-      // Heights.
-      if (this.heightsList_ === undefined &&
-          this.layout_ === Layout.RESPONSIVE) {
-        const heightsAttr = this.getAttribute('heights');
-        this.heightsList_ = heightsAttr ?
-          parseSizeList(heightsAttr, /* allowPercent */ true) : null;
-      }
-      if (this.heightsList_) {
-        const sizer = this.getSizer_();
-        if (sizer) {
-          setStyle(sizer, 'paddingTop',
-              this.heightsList_.select(toWin(this.ownerDocument.defaultView)));
-        }
-      }
+    // Media query.
+    if (this.mediaQuery_ === undefined) {
+      this.mediaQuery_ = this.getAttribute('media') || null;
+    }
+    if (this.mediaQuery_) {
+      const defaultView = this.ownerDocument.defaultView;
+      this.classList.toggle('i-amphtml-hidden-by-media-query',
+          !defaultView.matchMedia(this.mediaQuery_).matches);
     }
 
-    /**
+    // Sizes.
+    if (this.sizeList_ === undefined) {
+      const sizesAttr = this.getAttribute('sizes');
+      this.sizeList_ = sizesAttr ? parseSizeList(sizesAttr) : null;
+    }
+    if (this.sizeList_) {
+      setStyle(this, 'width', this.sizeList_.select(
+          toWin(this.ownerDocument.defaultView)));
+    }
+    // Heights.
+    if (this.heightsList_ === undefined &&
+          this.layout_ === Layout.RESPONSIVE) {
+      const heightsAttr = this.getAttribute('heights');
+      this.heightsList_ = heightsAttr ?
+        parseSizeList(heightsAttr, /* allowPercent */ true) : null;
+    }
+    if (this.heightsList_) {
+      const sizer = this.getSizer_();
+      if (sizer) {
+        setStyle(sizer, 'paddingTop',
+            this.heightsList_.select(toWin(this.ownerDocument.defaultView)));
+      }
+    }
+  };
+
+  /**
      * Changes the size of the element.
      *
      * This method is called by Resources and shouldn't be called by anyone else.
@@ -616,342 +597,344 @@ function createBaseCustomElementClass(win) {
      * @final
      * @package @this {!Element}
      */
-    changeSize(newHeight, newWidth, opt_newMargins) {
-      const sizer = this.getSizer_();
-      if (sizer) {
-        // From the moment height is changed the element becomes fully
-        // responsible for managing its height. Aspect ratio is no longer
-        // preserved.
-        this.sizerElement = null;
-        setStyle(sizer, 'paddingTop', '0');
-        if (this.resources_) {
-          this.resources_.deferMutate(this, () => {
-            dom.removeElement(sizer);
-          });
+  CustomElementClass.prototype.changeSize =
+      function(newHeight, newWidth, opt_newMargins) {
+        const sizer = this.getSizer_();
+        if (sizer) {
+          // From the moment height is changed the element becomes fully
+          // responsible for managing its height. Aspect ratio is no longer
+          // preserved.
+          this.sizerElement = null;
+          setStyle(sizer, 'paddingTop', '0');
+          if (this.resources_) {
+            this.resources_.deferMutate(this, () => {
+              dom.removeElement(sizer);
+            });
+          }
         }
-      }
-      if (newHeight !== undefined) {
-        setStyle(this, 'height', newHeight, 'px');
-      }
-      if (newWidth !== undefined) {
-        setStyle(this, 'width', newWidth, 'px');
-      }
-      if (opt_newMargins) {
-        if (opt_newMargins.top != null) {
-          setStyle(this, 'marginTop', opt_newMargins.top, 'px');
+        if (newHeight !== undefined) {
+          setStyle(this, 'height', newHeight, 'px');
         }
-        if (opt_newMargins.right != null) {
-          setStyle(this, 'marginRight', opt_newMargins.right, 'px');
+        if (newWidth !== undefined) {
+          setStyle(this, 'width', newWidth, 'px');
         }
-        if (opt_newMargins.bottom != null) {
-          setStyle(this, 'marginBottom', opt_newMargins.bottom, 'px');
+        if (opt_newMargins) {
+          if (opt_newMargins.top != null) {
+            setStyle(this, 'marginTop', opt_newMargins.top, 'px');
+          }
+          if (opt_newMargins.right != null) {
+            setStyle(this, 'marginRight', opt_newMargins.right, 'px');
+          }
+          if (opt_newMargins.bottom != null) {
+            setStyle(this, 'marginBottom', opt_newMargins.bottom, 'px');
+          }
+          if (opt_newMargins.left != null) {
+            setStyle(this, 'marginLeft', opt_newMargins.left, 'px');
+          }
         }
-        if (opt_newMargins.left != null) {
-          setStyle(this, 'marginLeft', opt_newMargins.left, 'px');
+        if (this.isAwaitingSize_()) {
+          this.sizeProvided_();
         }
-      }
-      if (this.isAwaitingSize_()) {
-        this.sizeProvided_();
-      }
-    }
+      };
 
-    /**
+  /**
      * Called when the element is first connected to the DOM. Calls
      * {@link firstAttachedCallback} if this is the first attachment.
      * @final @this {!Element}
      */
-    connectedCallback() {
-      if (!this.everAttached) {
-        this.classList.add('i-amphtml-element');
-        this.classList.add('i-amphtml-notbuilt');
-        this.classList.add('amp-notbuilt');
-      }
-
-      if (!isTemplateTagSupported() && this.isInTemplate_ === undefined) {
-        this.isInTemplate_ = !!dom.closestByTag(this, 'template');
-      }
-      if (this.isInTemplate_) {
-        return;
-      }
-      if (!this.ampdoc_) {
-        // Ampdoc can now be initialized.
-        const win = toWin(this.ownerDocument.defaultView);
-        const ampdocService = Services.ampdocServiceFor(win);
-        const ampdoc = ampdocService.getAmpDoc(this);
-        this.ampdoc_ = ampdoc;
-        // Load the pre-stubbed extension if needed.
-        const extensionId = this.tagName.toLowerCase();
-        if (isStub(this.implementation_) &&
-            !ampdoc.declaresExtension(extensionId)) {
-          Services.extensionsFor(win).installExtensionForDoc(
-              ampdoc, extensionId);
-        }
-      }
-      if (!this.resources_) {
-        // Resources can now be initialized since the ampdoc is now available.
-        this.resources_ = Services.resourcesForDoc(this.ampdoc_);
-      }
-      this.getResources().add(this);
-
-      if (this.everAttached) {
-        const reconstruct = this.reconstructWhenReparented();
-        if (reconstruct) {
-          this.reset_();
-        }
-        if (this.isUpgraded()) {
-          if (reconstruct) {
-            this.getResources().upgraded(this);
-          }
-          this.dispatchCustomEventForTesting(AmpEvents.ATTACHED);
-        }
-      } else {
-        this.everAttached = true;
-
-        try {
-          this.layout_ = applyStaticLayout(this);
-        } catch (e) {
-          reportError(e, this);
-        }
-        if (!isStub(this.implementation_)) {
-          this.tryUpgrade_();
-        }
-        if (!this.isUpgraded()) {
-          this.classList.add('amp-unresolved');
-          this.classList.add('i-amphtml-unresolved');
-          // amp:attached is dispatched from the ElementStub class when it
-          // replayed the firstAttachedCallback call.
-          this.dispatchCustomEventForTesting(AmpEvents.STUBBED);
-        }
-      }
+  CustomElementClass.prototype.connectedCallback = function() {
+    if (!this.everAttached) {
+      this.classList.add('i-amphtml-element');
+      this.classList.add('i-amphtml-notbuilt');
+      this.classList.add('amp-notbuilt');
     }
 
-    /**
+    if (!isTemplateTagSupported() && this.isInTemplate_ === undefined) {
+      this.isInTemplate_ = !!dom.closestByTag(this, 'template');
+    }
+    if (this.isInTemplate_) {
+      return;
+    }
+    if (!this.ampdoc_) {
+      // Ampdoc can now be initialized.
+      const win = toWin(this.ownerDocument.defaultView);
+      const ampdocService = Services.ampdocServiceFor(win);
+      const ampdoc = ampdocService.getAmpDoc(this);
+      this.ampdoc_ = ampdoc;
+      // Load the pre-stubbed extension if needed.
+      const extensionId = this.tagName.toLowerCase();
+      if (isStub(this.implementation_) &&
+            !ampdoc.declaresExtension(extensionId)) {
+        Services.extensionsFor(win).installExtensionForDoc(
+            ampdoc, extensionId);
+      }
+    }
+    if (!this.resources_) {
+      // Resources can now be initialized since the ampdoc is now available.
+      this.resources_ = Services.resourcesForDoc(this.ampdoc_);
+    }
+    this.getResources().add(this);
+
+    if (this.everAttached) {
+      const reconstruct = this.reconstructWhenReparented();
+      if (reconstruct) {
+        this.reset_();
+      }
+      if (this.isUpgraded()) {
+        if (reconstruct) {
+          this.getResources().upgraded(this);
+        }
+        this.dispatchCustomEventForTesting(AmpEvents.ATTACHED);
+      }
+    } else {
+      this.everAttached = true;
+
+      try {
+        this.layout_ = applyStaticLayout(this);
+      } catch (e) {
+        reportError(e, this);
+      }
+      if (!isStub(this.implementation_)) {
+        this.tryUpgrade_();
+      }
+      if (!this.isUpgraded()) {
+        this.classList.add('amp-unresolved');
+        this.classList.add('i-amphtml-unresolved');
+        // amp:attached is dispatched from the ElementStub class when it
+        // replayed the firstAttachedCallback call.
+        this.dispatchCustomEventForTesting(AmpEvents.STUBBED);
+      }
+    }
+  };
+
+  /**
      * @return {boolean}
      * @private
      */
-    isAwaitingSize_() {
-      return this.classList.contains('i-amphtml-layout-awaiting-size');
-    }
+  CustomElementClass.prototype.isAwaitingSize_ = function() {
+    return this.classList.contains('i-amphtml-layout-awaiting-size');
+  };
 
-    /**
+  /**
      * @private
      */
-    sizeProvided_() {
-      this.classList.remove('i-amphtml-layout-awaiting-size');
-    }
+  CustomElementClass.prototype.sizeProvided_ = function() {
+    this.classList.remove('i-amphtml-layout-awaiting-size');
+  };
 
-    /** The Custom Elements V0 sibling to `connectedCallback`. */
-    attachedCallback() {
-      this.connectedCallback();
-    }
+  /** The Custom Elements V0 sibling to `connectedCallback`. */
+  CustomElementClass.prototype.attachedCallback = function() {
+    this.connectedCallback();
+  };
 
-    /**
+  /**
      * Try to upgrade the element with the provided implementation.
      * @private @final @this {!Element}
      */
-    tryUpgrade_() {
-      const impl = this.implementation_;
-      dev().assert(!isStub(impl), 'Implementation must not be a stub');
-      if (this.upgradeState_ != UpgradeState.NOT_UPGRADED) {
-        // Already upgraded or in progress or failed.
-        return;
-      }
-
-      // The `upgradeCallback` only allows redirect once for the top-level
-      // non-stub class. We may allow nested upgrades later, but they will
-      // certainly be bad for performance.
-      this.upgradeState_ = UpgradeState.UPGRADE_IN_PROGRESS;
-      const startTime = win.Date.now();
-      const res = impl.upgradeCallback();
-      if (!res) {
-        // Nothing returned: the current object is the upgraded version.
-        this.completeUpgrade_(impl, startTime);
-      } else if (typeof res.then == 'function') {
-        // It's a promise: wait until it's done.
-        res.then(upgrade => {
-          this.completeUpgrade_(upgrade || impl, startTime);
-        }).catch(reason => {
-          this.upgradeState_ = UpgradeState.UPGRADE_FAILED;
-          rethrowAsync(reason);
-        });
-      } else {
-        // It's an actual instance: upgrade immediately.
-        this.completeUpgrade_(
-            /** @type {!./base-element.BaseElement} */(res), startTime);
-      }
+  CustomElementClass.prototype.tryUpgrade_ = function() {
+    const impl = this.implementation_;
+    dev().assert(!isStub(impl), 'Implementation must not be a stub');
+    if (this.upgradeState_ != UpgradeState.NOT_UPGRADED) {
+      // Already upgraded or in progress or failed.
+      return;
     }
 
-    /**
+    // The `upgradeCallback` only allows redirect once for the top-level
+    // non-stub class. We may allow nested upgrades later, but they will
+    // certainly be bad for performance.
+    this.upgradeState_ = UpgradeState.UPGRADE_IN_PROGRESS;
+    const startTime = win.Date.now();
+    const res = impl.upgradeCallback();
+    if (!res) {
+      // Nothing returned: the current object is the upgraded version.
+      this.completeUpgrade_(impl, startTime);
+    } else if (typeof res.then == 'function') {
+      // It's a promise: wait until it's done.
+      res.then(upgrade => {
+        this.completeUpgrade_(upgrade || impl, startTime);
+      }).catch(reason => {
+        this.upgradeState_ = UpgradeState.UPGRADE_FAILED;
+        rethrowAsync(reason);
+      });
+    } else {
+      // It's an actual instance: upgrade immediately.
+      this.completeUpgrade_(
+          /** @type {!./base-element.BaseElement} */(res), startTime);
+    }
+  };
+
+  /**
      * Called when the element is disconnected from the DOM.
      * @final @this {!Element}
      */
-    disconnectedCallback() {
-      if (this.isInTemplate_) {
-        return;
-      }
-      this.getResources().remove(this);
-      this.implementation_.detachedCallback();
+  CustomElementClass.prototype.disconnectedCallback = function() {
+    if (this.isInTemplate_) {
+      return;
     }
+    this.getResources().remove(this);
+    this.implementation_.detachedCallback();
+  };
 
-    /** The Custom Elements V0 sibling to `disconnectedCallback`. */
-    detachedCallback() {
-      this.disconnectedCallback();
-    }
+  /** The Custom Elements V0 sibling to `disconnectedCallback`. */
+  CustomElementClass.prototype.detachedCallback = function() {
+    this.disconnectedCallback();
+  };
 
-    /**
+  /**
      * Dispatches a custom event.
      *
      * @param {string} name
      * @param {!Object=} opt_data Event data.
      * @final @this {!Element}
      */
-    dispatchCustomEvent(name, opt_data) {
-      const data = opt_data || {};
-      // Constructors of events need to come from the correct window. Sigh.
-      const event = this.ownerDocument.createEvent('Event');
-      event.data = data;
-      event.initEvent(name, /* bubbles */ true, /* cancelable */ true);
-      this.dispatchEvent(event);
-    }
+  CustomElementClass.prototype.dispatchCustomEvent = function(name, opt_data) {
+    const data = opt_data || {};
+    // Constructors of events need to come from the correct window. Sigh.
+    const event = this.ownerDocument.createEvent('Event');
+    event.data = data;
+    event.initEvent(name, /* bubbles */ true, /* cancelable */ true);
+    this.dispatchEvent(event);
+  };
 
-    /**
+  /**
      * Dispatches a custom event only in testing environment.
      *
      * @param {string} name
      * @param {!Object=} opt_data Event data.
      * @final @this {!Element}
      */
-    dispatchCustomEventForTesting(name, opt_data) {
-      if (!getMode().test) {
-        return;
-      }
-      this.dispatchCustomEvent(name, opt_data);
-    }
+  CustomElementClass.prototype.dispatchCustomEventForTesting =
+      function(name, opt_data) {
+        if (!getMode().test) {
+          return;
+        }
+        this.dispatchCustomEvent(name, opt_data);
+      };
 
-    /**
+  /**
      * Whether the element can pre-render.
      * @return {boolean}
      * @final @this {!Element}
      */
-    prerenderAllowed() {
-      return this.implementation_.prerenderAllowed();
-    }
+  CustomElementClass.prototype.prerenderAllowed = function() {
+    return this.implementation_.prerenderAllowed();
+  };
 
-    /**
+  /**
      * Creates a placeholder for the element.
      * @returns {?Element}
      * @final @this {!Element}
      */
-    createPlaceholder() {
-      return this.implementation_.createPlaceholderCallback();
-    }
+  CustomElementClass.prototype.createPlaceholder = function() {
+    return this.implementation_.createPlaceholderCallback();
+  };
 
-    /**
+  /**
      * Whether the element should ever render when it is not in viewport.
      * @return {boolean|number}
      * @final @this {!Element}
      */
-    renderOutsideViewport() {
-      return this.implementation_.renderOutsideViewport();
-    }
+  CustomElementClass.prototype.renderOutsideViewport = function() {
+    return this.implementation_.renderOutsideViewport();
+  };
 
-    /**
+  /**
      * Whether the element should render outside of renderOutsideViewport when
      * the scheduler is idle.
      * @return {boolean|number}
      * @final @this {!Element}
      */
-    idleRenderOutsideViewport() {
-      return this.implementation_.idleRenderOutsideViewport();
-    }
+  CustomElementClass.prototype.idleRenderOutsideViewport = function() {
+    return this.implementation_.idleRenderOutsideViewport();
+  };
 
-    /**
+  /**
      * Returns a previously measured layout box adjusted to the viewport. This
      * mainly affects fixed-position elements that are adjusted to be always
      * relative to the document position in the viewport.
      * @return {!./layout-rect.LayoutRectDef}
      * @final @this {!Element}
      */
-    getLayoutBox() {
-      return this.getResources().getResourceForElement(this).getLayoutBox();
-    }
+  CustomElementClass.prototype.getLayoutBox = function() {
+    return this.getResources().getResourceForElement(this).getLayoutBox();
+  };
 
-    /**
+  /**
      * Returns a previously measured layout box relative to the page. The
      * fixed-position elements are relative to the top of the document.
      * @return {!./layout-rect.LayoutRectDef}
      * @final @this {!Element}
      */
-    getPageLayoutBox() {
-      return this.getResources().getResourceForElement(this).getPageLayoutBox();
-    }
+  CustomElementClass.prototype.getPageLayoutBox = function() {
+    return this.getResources().getResourceForElement(this).getPageLayoutBox();
+  };
 
-    /**
+  /**
      * @return {?Element}
      * @final @this {!Element}
      */
-    getOwner() {
-      return this.getResources().getResourceForElement(this).getOwner();
-    }
+  CustomElementClass.prototype.getOwner = function() {
+    return this.getResources().getResourceForElement(this).getOwner();
+  };
 
-    /**
+  /**
      * Returns a change entry for that should be compatible with
      * IntersectionObserverEntry.
      * @return {!IntersectionObserverEntry} A change entry.
      * @final @this {!Element}
      */
-    getIntersectionChangeEntry() {
-      const box = this.implementation_.getIntersectionElementLayoutBox();
-      const owner = this.getResources().getResourceForElement(this).getOwner();
-      const viewportBox = this.implementation_.getViewport().getRect();
-      // TODO(jridgewell, #4826): We may need to make this recursive.
-      const ownerBox = owner && owner.getLayoutBox();
-      return getIntersectionChangeEntry(box, ownerBox, viewportBox);
-    }
+  CustomElementClass.prototype.getIntersectionChangeEntry = function() {
+    const box = this.implementation_.getIntersectionElementLayoutBox();
+    const owner = this.getResources().getResourceForElement(this).getOwner();
+    const viewportBox = this.implementation_.getViewport().getRect();
+    // TODO(jridgewell, #4826): We may need to make this recursive.
+    const ownerBox = owner && owner.getLayoutBox();
+    return getIntersectionChangeEntry(box, ownerBox, viewportBox);
+  };
 
-    /**
+  /**
      * Returns the resource ID of the element.
      * @return {number}
      */
-    getResourceId() {
-      return this.getResources().getResourceForElement(this).getId();
-    }
+  CustomElementClass.prototype.getResourceId = function() {
+    return this.getResources().getResourceForElement(this).getId();
+  };
 
-    /**
+  /**
      * Returns the current resource state of the element.
      * @return {!ResourceState}
      */
-    getResourceState_() {
-      return this.getResources().getResourceForElement(this).getState();
-    }
+  CustomElementClass.prototype.getResourceState_ = function() {
+    return this.getResources().getResourceForElement(this).getState();
+  };
 
-    /**
+  /**
      * The runtime calls this method to determine if {@link layoutCallback}
      * should be called again when layout changes.
      * @return {boolean}
      * @package @final @this {!Element}
      */
-    isRelayoutNeeded() {
-      return this.implementation_.isRelayoutNeeded();
-    }
+  CustomElementClass.prototype.isRelayoutNeeded = function() {
+    return this.implementation_.isRelayoutNeeded();
+  };
 
-    /**
+  /**
      * Returns reference to implementation after it has been built.
      * @return {!Promise<!./base-element.BaseElement>}
      */
-    getImpl() {
-      return this.whenBuilt().then(() => this.implementation_);
-    }
+  CustomElementClass.prototype.getImpl = function() {
+    return this.whenBuilt().then(() => this.implementation_);
+  };
 
-    /**
+  /**
      * Returns the layout of the element.
      * @return {!Layout}
      */
-    getLayout() {
-      return this.layout_;
-    }
+  CustomElementClass.prototype.getLayout = function() {
+    return this.layout_;
+  };
 
-    /**
+  /**
      * Instructs the element to layout its content and load its resources if
      * necessary by calling the {@link BaseElement.layoutCallback} method that
      * should be implemented by BaseElement subclasses. Must return a promise
@@ -965,60 +948,60 @@ function createBaseCustomElementClass(win) {
      * @return {!Promise}
      * @package @final @this {!Element}
      */
-    layoutCallback() {
-      assertNotTemplate(this);
-      dev().assert(this.isBuilt(),
-          'Must be built to receive viewport events');
-      this.dispatchCustomEventForTesting(AmpEvents.LOAD_START);
-      const isLoadEvent = (this.layoutCount_ == 0); // First layout is "load".
-      this.signals_.reset(CommonSignals.UNLOAD);
-      if (isLoadEvent) {
-        this.signals_.signal(CommonSignals.LOAD_START);
-      }
-      if (this.perfOn_) {
-        this.getLayoutDelayMeter_().startLayout();
-      }
-      const promise = this.implementation_.layoutCallback();
-      this.preconnect(/* onLayout */true);
-      this.classList.add('i-amphtml-layout');
-      return promise.then(() => {
-        if (isLoadEvent) {
-          this.signals_.signal(CommonSignals.LOAD_END);
-        }
-        this.readyState = 'complete';
-        this.layoutCount_++;
-        this.toggleLoading_(false, /* cleanup */ true);
-        // Check if this is the first success layout that needs
-        // to call firstLayoutCompleted.
-        if (!this.isFirstLayoutCompleted_) {
-          this.implementation_.firstLayoutCompleted();
-          this.isFirstLayoutCompleted_ = true;
-          // TODO(dvoytenko, #7389): cleanup once amp-sticky-ad signals are
-          // in PROD.
-          this.dispatchCustomEvent(AmpEvents.LOAD_END);
-        }
-      }, reason => {
-        // add layoutCount_ by 1 despite load fails or not
-        if (isLoadEvent) {
-          this.signals_.rejectSignal(
-              CommonSignals.LOAD_END, /** @type {!Error} */ (reason));
-        }
-        this.layoutCount_++;
-        this.toggleLoading_(false, /* cleanup */ true);
-        throw reason;
-      });
+  CustomElementClass.prototype.layoutCallback = function() {
+    assertNotTemplate(this);
+    dev().assert(this.isBuilt(),
+        'Must be built to receive viewport events');
+    this.dispatchCustomEventForTesting(AmpEvents.LOAD_START);
+    const isLoadEvent = (this.layoutCount_ == 0); // First layout is "load".
+    this.signals_.reset(CommonSignals.UNLOAD);
+    if (isLoadEvent) {
+      this.signals_.signal(CommonSignals.LOAD_START);
     }
+    if (this.perfOn_) {
+      this.getLayoutDelayMeter_().startLayout();
+    }
+    const promise = this.implementation_.layoutCallback();
+    this.preconnect(/* onLayout */true);
+    this.classList.add('i-amphtml-layout');
+    return promise.then(() => {
+      if (isLoadEvent) {
+        this.signals_.signal(CommonSignals.LOAD_END);
+      }
+      this.readyState = 'complete';
+      this.layoutCount_++;
+      this.toggleLoading_(false, /* cleanup */ true);
+      // Check if this is the first success layout that needs
+      // to call firstLayoutCompleted.
+      if (!this.isFirstLayoutCompleted_) {
+        this.implementation_.firstLayoutCompleted();
+        this.isFirstLayoutCompleted_ = true;
+        // TODO(dvoytenko, #7389): cleanup once amp-sticky-ad signals are
+        // in PROD.
+        this.dispatchCustomEvent(AmpEvents.LOAD_END);
+      }
+    }, reason => {
+      // add layoutCount_ by 1 despite load fails or not
+      if (isLoadEvent) {
+        this.signals_.rejectSignal(
+            CommonSignals.LOAD_END, /** @type {!Error} */ (reason));
+      }
+      this.layoutCount_++;
+      this.toggleLoading_(false, /* cleanup */ true);
+      throw reason;
+    });
+  };
 
-    /**
+  /**
      * Whether the resource is currently visible in the viewport.
      * @return {boolean}
      * @final @package @this {!Element}
      */
-    isInViewport() {
-      return this.isInViewport_;
-    }
+  CustomElementClass.prototype.isInViewport = function() {
+    return this.isInViewport_;
+  };
 
-    /**
+  /**
      * Instructs the resource that it entered or exited the visible viewport.
      *
      * Can only be called on a upgraded and built element.
@@ -1027,100 +1010,100 @@ function createBaseCustomElementClass(win) {
      *   the visible viewport.
      * @final @package @this {!Element}
      */
-    viewportCallback(inViewport) {
-      assertNotTemplate(this);
-      if (inViewport == this.isInViewport_) {
-        return;
-      }
-      // TODO(dvoytenko, #9177): investigate/cleanup viewport signals for
-      // elements in dead iframes.
-      if (!this.ownerDocument ||
+  CustomElementClass.prototype.viewportCallback = function(inViewport) {
+    assertNotTemplate(this);
+    if (inViewport == this.isInViewport_) {
+      return;
+    }
+    // TODO(dvoytenko, #9177): investigate/cleanup viewport signals for
+    // elements in dead iframes.
+    if (!this.ownerDocument ||
           !this.ownerDocument.defaultView) {
-        return;
-      }
-      this.isInViewport_ = inViewport;
-      if (this.layoutCount_ == 0) {
-        if (!inViewport) {
-          this.toggleLoading_(false);
-        } else {
-          // Set a minimum delay in case the element loads very fast or if it
-          // leaves the viewport.
-          Services.timerFor(toWin(this.ownerDocument.defaultView)).delay(() => {
-            // TODO(dvoytenko, #9177): cleanup `this.ownerDocument.defaultView`
-            // once investigation is complete. It appears that we get a lot of
-            // errors here once the iframe is destroyed due to timer.
-            if (this.isInViewport_ &&
+      return;
+    }
+    this.isInViewport_ = inViewport;
+    if (this.layoutCount_ == 0) {
+      if (!inViewport) {
+        this.toggleLoading_(false);
+      } else {
+        // Set a minimum delay in case the element loads very fast or if it
+        // leaves the viewport.
+        Services.timerFor(toWin(this.ownerDocument.defaultView)).delay(() => {
+          // TODO(dvoytenko, #9177): cleanup `this.ownerDocument.defaultView`
+          // once investigation is complete. It appears that we get a lot of
+          // errors here once the iframe is destroyed due to timer.
+          if (this.isInViewport_ &&
                 this.ownerDocument &&
                 this.ownerDocument.defaultView) {
-              this.toggleLoading_(true);
-            }
-          }, 100);
-        }
-      }
-      if (this.isBuilt()) {
-        this.updateInViewport_(inViewport);
+            this.toggleLoading_(true);
+          }
+        }, 100);
       }
     }
+    if (this.isBuilt()) {
+      this.updateInViewport_(inViewport);
+    }
+  };
 
-    /**
+  /**
      * @param {boolean} inViewport
      * @private @this {!Element}
      */
-    updateInViewport_(inViewport) {
-      this.implementation_.inViewport_ = inViewport;
-      this.implementation_.viewportCallback(inViewport);
-      if (inViewport && this.perfOn_) {
-        this.getLayoutDelayMeter_().enterViewport();
-      }
+  CustomElementClass.prototype.updateInViewport_ = function(inViewport) {
+    this.implementation_.inViewport_ = inViewport;
+    this.implementation_.viewportCallback(inViewport);
+    if (inViewport && this.perfOn_) {
+      this.getLayoutDelayMeter_().enterViewport();
     }
+  };
 
-    /**
+  /**
      * Whether the resource is currently paused.
      * @return {boolean}
      * @final @package @this {!Element}
      */
-    isPaused() {
-      return this.paused_;
-    }
+  CustomElementClass.prototype.isPaused = function() {
+    return this.paused_;
+  };
 
-    /**
+  /**
      * Requests the resource to stop its activity when the document goes into
      * inactive state. The scope is up to the actual component. Among other
      * things the active playback of video or audio content must be stopped.
      *
      * @package @final @this {!Element}
      */
-    pauseCallback() {
-      assertNotTemplate(this);
-      if (this.paused_) {
-        return;
-      }
-      this.paused_ = true;
-      this.viewportCallback(false);
-      if (this.isBuilt()) {
-        this.implementation_.pauseCallback();
-      }
+  CustomElementClass.prototype.pauseCallback = function() {
+    assertNotTemplate(this);
+    if (this.paused_) {
+      return;
     }
+    this.paused_ = true;
+    this.viewportCallback(false);
+    if (this.isBuilt()) {
+      this.implementation_.pauseCallback();
+    }
+  };
 
-    /**
+  /**
      * Requests the resource to resume its activity when the document returns from
      * an inactive state. The scope is up to the actual component. Among other
      * things the active playback of video or audio content may be resumed.
      *
      * @package @final @this {!Element}
      */
-    resumeCallback() {
-      assertNotTemplate(this);
-      if (!this.paused_) {
-        return;
-      }
-      this.paused_ = false;
-      if (this.isBuilt()) {
-        this.implementation_.resumeCallback();
-      }
+  CustomElementClass.prototype.resumeCallback = function() {
+    assertNotTemplate(this);
+    if (!this.paused_) {
+      return;
     }
+    this.paused_ = false;
+    if (this.isBuilt()) {
+      this.implementation_.resumeCallback();
+    }
+  };
 
-    /**
+  /**
      * Requests the element to unload any expensive resources when the element
      * goes into non-visible state. The scope is up to the actual component.
      *
@@ -1129,30 +1112,30 @@ function createBaseCustomElementClass(win) {
      * @return {boolean}
      * @package @final @this {!Element}
      */
-    unlayoutCallback() {
-      assertNotTemplate(this);
-      if (!this.isBuilt()) {
-        return false;
-      }
-      this.signals_.signal(CommonSignals.UNLOAD);
-      const isReLayoutNeeded = this.implementation_.unlayoutCallback();
-      if (isReLayoutNeeded) {
-        this.reset_();
-      }
-      return isReLayoutNeeded;
+  CustomElementClass.prototype.unlayoutCallback = function() {
+    assertNotTemplate(this);
+    if (!this.isBuilt()) {
+      return false;
     }
-
-    /** @private */
-    reset_() {
-      this.layoutCount_ = 0;
-      this.isFirstLayoutCompleted_ = false;
-      this.signals_.reset(CommonSignals.RENDER_START);
-      this.signals_.reset(CommonSignals.LOAD_START);
-      this.signals_.reset(CommonSignals.LOAD_END);
-      this.signals_.reset(CommonSignals.INI_LOAD);
+    this.signals_.signal(CommonSignals.UNLOAD);
+    const isReLayoutNeeded = this.implementation_.unlayoutCallback();
+    if (isReLayoutNeeded) {
+      this.reset_();
     }
+    return isReLayoutNeeded;
+  };
 
-    /**
+  /** @private */
+  CustomElementClass.prototype.reset_ = function() {
+    this.layoutCount_ = 0;
+    this.isFirstLayoutCompleted_ = false;
+    this.signals_.reset(CommonSignals.RENDER_START);
+    this.signals_.reset(CommonSignals.LOAD_START);
+    this.signals_.reset(CommonSignals.LOAD_END);
+    this.signals_.reset(CommonSignals.INI_LOAD);
+  };
+
+  /**
      * Whether to call {@link unlayoutCallback} when pausing the element.
      * Certain elements cannot properly pause (like amp-iframes with unknown
      * video content), and so we must unlayout to stop playback.
@@ -1160,11 +1143,11 @@ function createBaseCustomElementClass(win) {
      * @return {boolean}
      * @package @final @this {!Element}
      */
-    unlayoutOnPause() {
-      return this.implementation_.unlayoutOnPause();
-    }
+  CustomElementClass.prototype.unlayoutOnPause = function() {
+    return this.implementation_.unlayoutOnPause();
+  };
 
-    /**
+  /**
      * Whether the element needs to be reconstructed after it has been
      * re-parented. Many elements cannot survive fully the reparenting and
      * are better to be reconstructed from scratch.
@@ -1172,43 +1155,43 @@ function createBaseCustomElementClass(win) {
      * @return {boolean}
      * @package @final @this {!Element}
      */
-    reconstructWhenReparented() {
-      return this.implementation_.reconstructWhenReparented();
-    }
+  CustomElementClass.prototype.reconstructWhenReparented = function() {
+    return this.implementation_.reconstructWhenReparented();
+  };
 
-    /**
+  /**
      * Collapses the element, and notifies its owner (if there is one) that the
      * element is no longer present.
      */
-    collapse() {
-      this.implementation_./*OK*/collapse();
-    }
+  CustomElementClass.prototype.collapse = function() {
+    this.implementation_./*OK*/collapse();
+  };
 
-    /**
+  /**
      * Called every time an owned AmpElement collapses itself.
      * @param {!AmpElement} element
      */
-    collapsedCallback(element) {
-      this.implementation_.collapsedCallback(element);
-    }
+  CustomElementClass.prototype.collapsedCallback = function(element) {
+    this.implementation_.collapsedCallback(element);
+  };
 
-    /**
+  /**
      * Expands the element, and notifies its owner (if there is one) that the
      * element is now present.
      */
-    expand() {
-      this.implementation_./*OK*/expand();
-    }
+  CustomElementClass.prototype.expand = function() {
+    this.implementation_./*OK*/expand();
+  };
 
-    /**
+  /**
      * Called every time an owned AmpElement expands itself.
      * @param {!AmpElement} element
      */
-    expandedCallback(element) {
-      this.implementation_.expandedCallback(element);
-    }
+  CustomElementClass.prototype.expandedCallback = function(element) {
+    this.implementation_.expandedCallback(element);
+  };
 
-    /**
+  /**
      * Called when one or more attributes are mutated.
      * @note Must be called inside a mutate context.
      * @note Boolean attributes have a value of `true` and `false` when
@@ -1217,11 +1200,11 @@ function createBaseCustomElementClass(win) {
      *   !JsonObject<string, (null|boolean|string|number|Array|Object)>
      * } mutations
      */
-    mutatedAttributesCallback(mutations) {
-      this.implementation_.mutatedAttributesCallback(mutations);
-    }
+  CustomElementClass.prototype.mutatedAttributesCallback = function(mutations) {
+    this.implementation_.mutatedAttributesCallback(mutations);
+  };
 
-    /**
+  /**
      * Enqueues the action with the element. If element has been upgraded and
      * built, the action is dispatched to the implementation right away.
      * Otherwise the invocation is enqueued until the implementation is ready
@@ -1229,320 +1212,321 @@ function createBaseCustomElementClass(win) {
      * @param {!./service/action-impl.ActionInvocation} invocation
      * @final @this {!Element}
      */
-    enqueAction(invocation) {
-      assertNotTemplate(this);
-      if (!this.isBuilt()) {
-        if (this.actionQueue_ === undefined) {
-          this.actionQueue_ = [];
-        }
-        dev().assert(this.actionQueue_).push(invocation);
-      } else {
-        this.executionAction_(invocation, false);
+  CustomElementClass.prototype.enqueAction = function(invocation) {
+    assertNotTemplate(this);
+    if (!this.isBuilt()) {
+      if (this.actionQueue_ === undefined) {
+        this.actionQueue_ = [];
       }
+      dev().assert(this.actionQueue_).push(invocation);
+    } else {
+      this.executionAction_(invocation, false);
     }
+  };
 
-    /**
+  /**
      * Dequeues events from the queue and dispatches them to the implementation
      * with "deferred" flag.
      * @private @this {!Element}
      */
-    dequeueActions_() {
-      if (!this.actionQueue_) {
-        return;
-      }
-
-      const actionQueue = dev().assert(this.actionQueue_);
-      this.actionQueue_ = null;
-
-      // Notice, the actions are currently not de-duped.
-      actionQueue.forEach(invocation => {
-        this.executionAction_(invocation, true);
-      });
+  CustomElementClass.prototype.dequeueActions_ = function() {
+    if (!this.actionQueue_) {
+      return;
     }
 
-    /**
+    const actionQueue = dev().assert(this.actionQueue_);
+    this.actionQueue_ = null;
+
+    // Notice, the actions are currently not de-duped.
+    actionQueue.forEach(invocation => {
+      this.executionAction_(invocation, true);
+    });
+  };
+
+  /**
      * Executes the action immediately. All errors are consumed and reported.
      * @param {!./service/action-impl.ActionInvocation} invocation
      * @param {boolean} deferred
      * @final
      * @private @this {!Element}
      */
-    executionAction_(invocation, deferred) {
-      try {
-        this.implementation_.executeAction(invocation, deferred);
-      } catch (e) {
-        rethrowAsync('Action execution failed:', e,
-            invocation.target.tagName, invocation.method);
-      }
-    }
+  CustomElementClass.prototype.executionAction_ =
+      function(invocation, deferred) {
+        try {
+          this.implementation_.executeAction(invocation, deferred);
+        } catch (e) {
+          rethrowAsync('Action execution failed:', e,
+              invocation.target.tagName, invocation.method);
+        }
+      };
 
-    /**
+  /**
      * Returns the original nodes of the custom element without any service nodes
      * that could have been added for markup. These nodes can include Text,
      * Comment and other child nodes.
      * @return {!Array<!Node>}
      * @package @final @this {!Element}
      */
-    getRealChildNodes() {
-      return dom.childNodes(this, node => !isInternalOrServiceNode(node));
-    }
+  CustomElementClass.prototype.getRealChildNodes = function() {
+    return dom.childNodes(this, node => !isInternalOrServiceNode(node));
+  };
 
-    /**
+  /**
      * Returns the original children of the custom element without any service
      * nodes that could have been added for markup.
      * @return {!Array<!Element>}
      * @package @final @this {!Element}
      */
-    getRealChildren() {
-      return dom.childElements(this, element =>
-        !isInternalOrServiceNode(element));
-    }
+  CustomElementClass.prototype.getRealChildren = function() {
+    return dom.childElements(this, element =>
+      !isInternalOrServiceNode(element));
+  };
 
-    /**
+  /**
      * Must be executed in the mutate context. Removes `display:none` from the
      * element set via `layout=nodisplay`.
      * @param {boolean} displayOn
      */
-    toggleLayoutDisplay(displayOn) {
-      this.classList.toggle('i-amphtml-display', displayOn);
-    }
+  CustomElementClass.prototype.toggleLayoutDisplay = function(displayOn) {
+    this.classList.toggle('i-amphtml-display', displayOn);
+  };
 
-    /**
+  /**
      * Returns an optional placeholder element for this custom element.
      * @return {?Element}
      * @package @final @this {!Element}
      */
-    getPlaceholder() {
-      return dom.lastChildElement(this, el => {
-        return el.hasAttribute('placeholder') &&
+  CustomElementClass.prototype.getPlaceholder = function() {
+    return dom.lastChildElement(this, el => {
+      return el.hasAttribute('placeholder') &&
           // Blacklist elements that has a native placeholder property
           // like input and textarea. These are not allowed to be AMP
           // placeholders.
           !('placeholder' in el);
-      });
-    }
+    });
+  };
 
-    /**
+  /**
      * Hides or shows the placeholder, if available.
      * @param {boolean} show
      * @package @final @this {!Element}
      */
-    togglePlaceholder(show) {
-      assertNotTemplate(this);
-      if (show) {
-        const placeholder = this.getPlaceholder();
-        if (placeholder) {
-          placeholder.classList.remove('amp-hidden');
-        }
-      } else {
-        const placeholders = dom.childElementsByAttr(this, 'placeholder');
-        for (let i = 0; i < placeholders.length; i++) {
-          placeholders[i].classList.add('amp-hidden');
-        }
+  CustomElementClass.prototype.togglePlaceholder = function(show) {
+    assertNotTemplate(this);
+    if (show) {
+      const placeholder = this.getPlaceholder();
+      if (placeholder) {
+        placeholder.classList.remove('amp-hidden');
+      }
+    } else {
+      const placeholders = dom.childElementsByAttr(this, 'placeholder');
+      for (let i = 0; i < placeholders.length; i++) {
+        placeholders[i].classList.add('amp-hidden');
       }
     }
+  };
 
-    /**
+  /**
      * Returns an optional fallback element for this custom element.
      * @return {?Element}
      * @package @final @this {!Element}
      */
-    getFallback() {
-      return dom.childElementByAttr(this, 'fallback');
-    }
+  CustomElementClass.prototype.getFallback = function() {
+    return dom.childElementByAttr(this, 'fallback');
+  };
 
-    /**
+  /**
      * Hides or shows the fallback, if available. This function must only
      * be called inside a mutate context.
      * @param {boolean} show
      * @package @final @this {!Element}
      */
-    toggleFallback(show) {
-      assertNotTemplate(this);
-      const resourceState = this.getResourceState_();
-      // Do not show fallback before layout
-      if (show && (resourceState == ResourceState.NOT_BUILT ||
+  CustomElementClass.prototype.toggleFallback = function(show) {
+    assertNotTemplate(this);
+    const resourceState = this.getResourceState_();
+    // Do not show fallback before layout
+    if (show && (resourceState == ResourceState.NOT_BUILT ||
           resourceState == ResourceState.NOT_LAID_OUT ||
           resourceState == ResourceState.READY_FOR_LAYOUT)) {
-        return;
-      }
-      // This implementation is notably less efficient then placeholder toggling.
-      // The reasons for this are: (a) "not supported" is the state of the whole
-      // element, (b) some relayout is expected and (c) fallback condition would
-      // be rare.
-      this.classList.toggle('amp-notsupported', show);
-      if (show == true) {
-        const fallbackElement = this.getFallback();
-        if (fallbackElement) {
-          this.getResources().scheduleLayout(this, fallbackElement);
-        }
+      return;
+    }
+    // This implementation is notably less efficient then placeholder toggling.
+    // The reasons for this are: (a) "not supported" is the state of the whole
+    // element, (b) some relayout is expected and (c) fallback condition would
+    // be rare.
+    this.classList.toggle('amp-notsupported', show);
+    if (show == true) {
+      const fallbackElement = this.getFallback();
+      if (fallbackElement) {
+        this.getResources().scheduleLayout(this, fallbackElement);
       }
     }
+  };
 
-    /**
+  /**
      * An implementation can call this method to signal to the element that
      * it has started rendering.
      * @package @final @this {!Element}
      */
-    renderStarted() {
-      this.signals_.signal(CommonSignals.RENDER_START);
-      this.togglePlaceholder(false);
-      this.toggleLoading_(false);
-    }
+  CustomElementClass.prototype.renderStarted = function() {
+    this.signals_.signal(CommonSignals.RENDER_START);
+    this.togglePlaceholder(false);
+    this.toggleLoading_(false);
+  };
 
-    /**
+  /**
      * Whether the loading can be shown for this element.
      * @return {boolean}
      * @private @this {!Element}
      */
-    isLoadingEnabled_() {
-      // No loading indicator will be shown if either one of these
-      // conditions true:
-      // 1. `noloading` attribute is specified;
-      // 2. The element has not been whitelisted;
-      // 3. The element is too small or has not yet been measured;
-      // 4. The element has already been laid out (include having loading error);
-      // 5. The element is a `placeholder` or a `fallback`;
-      // 6. The element's layout is not a size-defining layout.
-      // 7. The document is A4A.
-      if (this.isInA4A_()) {
-        return false;
-      }
-      if (this.loadingDisabled_ === undefined) {
-        this.loadingDisabled_ = this.hasAttribute('noloading');
-      }
-      if (this.loadingDisabled_ || !isLoadingAllowed(this) ||
+  CustomElementClass.prototype.isLoadingEnabled_ = function() {
+    // No loading indicator will be shown if either one of these
+    // conditions true:
+    // 1. `noloading` attribute is specified;
+    // 2. The element has not been whitelisted;
+    // 3. The element is too small or has not yet been measured;
+    // 4. The element has already been laid out (include having loading error);
+    // 5. The element is a `placeholder` or a `fallback`;
+    // 6. The element's layout is not a size-defining layout.
+    // 7. The document is A4A.
+    if (this.isInA4A_()) {
+      return false;
+    }
+    if (this.loadingDisabled_ === undefined) {
+      this.loadingDisabled_ = this.hasAttribute('noloading');
+    }
+    if (this.loadingDisabled_ || !isLoadingAllowed(this) ||
         this.layoutWidth_ < MIN_WIDTH_FOR_LOADING ||
         this.layoutCount_ > 0 ||
         isInternalOrServiceNode(this) || !isLayoutSizeDefined(this.layout_)) {
-        return false;
-      }
-      return true;
+      return false;
     }
+    return true;
+  };
 
-    /**
+  /**
      * @return {boolean}
      * @private
      */
-    isInA4A_() {
-      return (
+  CustomElementClass.prototype.isInA4A_ = function() {
+    return (
       // in FIE
-        this.ampdoc_ && this.ampdoc_.win != this.ownerDocument.defaultView ||
+      this.ampdoc_ && this.ampdoc_.win != this.ownerDocument.defaultView ||
 
           // in inabox
           getMode().runtime == 'inabox');
-    }
+  };
 
-    /**
+  /**
      * Creates a loading object. The caller must ensure that loading can
      * actually be shown. This method must also be called in the mutate
      * context.
      * @private @this {!Element}
      */
-    prepareLoading_() {
-      if (!this.loadingContainer_) {
-        const doc = this.ownerDocument;
+  CustomElementClass.prototype.prepareLoading_ = function() {
+    if (!this.loadingContainer_) {
+      const doc = this.ownerDocument;
 
-        const container = doc.createElement('div');
-        container.classList.add('i-amphtml-loading-container');
-        container.classList.add('i-amphtml-fill-content');
-        container.classList.add('amp-hidden');
+      const container = doc.createElement('div');
+      container.classList.add('i-amphtml-loading-container');
+      container.classList.add('i-amphtml-fill-content');
+      container.classList.add('amp-hidden');
 
-        const element = createLoaderElement(doc, this.elementName());
-        container.appendChild(element);
+      const element = createLoaderElement(doc, this.elementName());
+      container.appendChild(element);
 
-        this.appendChild(container);
-        this.loadingContainer_ = container;
-        this.loadingElement_ = element;
-      }
+      this.appendChild(container);
+      this.loadingContainer_ = container;
+      this.loadingElement_ = element;
     }
+  };
 
-    /**
+  /**
      * Turns the loading indicator on or off.
      * @param {boolean} state
      * @param {boolean=} opt_cleanup
      * @private @final @this {!Element}
      */
-    toggleLoading_(state, opt_cleanup) {
-      assertNotTemplate(this);
-      if (state &&
+  CustomElementClass.prototype.toggleLoading_ = function(state, opt_cleanup) {
+    assertNotTemplate(this);
+    if (state &&
           (this.layoutCount_ > 0 ||
               this.signals_.get(CommonSignals.RENDER_START))) {
-        // Loading has already been canceled. Ignore.
-        return;
-      }
-      this.loadingState_ = state;
-      if (!state && !this.loadingContainer_) {
-        return;
-      }
-
-      // Check if loading should be shown.
-      if (state && !this.isLoadingEnabled_()) {
-        this.loadingState_ = false;
-        return;
-      }
-
-      getVsync(this).mutate(() => {
-        let state = this.loadingState_;
-        // Repeat "loading enabled" check because it could have changed while
-        // waiting for vsync.
-        if (state && !this.isLoadingEnabled_()) {
-          state = false;
-        }
-        if (state) {
-          this.prepareLoading_();
-        }
-        if (!this.loadingContainer_) {
-          return;
-        }
-
-        this.loadingContainer_.classList.toggle('amp-hidden', !state);
-        this.loadingElement_.classList.toggle('amp-active', state);
-
-        if (!state && opt_cleanup) {
-          const loadingContainer = this.loadingContainer_;
-          this.loadingContainer_ = null;
-          this.loadingElement_ = null;
-          this.getResources().deferMutate(this, () => {
-            dom.removeElement(loadingContainer);
-          });
-        }
-      });
+      // Loading has already been canceled. Ignore.
+      return;
+    }
+    this.loadingState_ = state;
+    if (!state && !this.loadingContainer_) {
+      return;
     }
 
-    /**
+    // Check if loading should be shown.
+    if (state && !this.isLoadingEnabled_()) {
+      this.loadingState_ = false;
+      return;
+    }
+
+    getVsync(this).mutate(() => {
+      let state = this.loadingState_;
+      // Repeat "loading enabled" check because it could have changed while
+      // waiting for vsync.
+      if (state && !this.isLoadingEnabled_()) {
+        state = false;
+      }
+      if (state) {
+        this.prepareLoading_();
+      }
+      if (!this.loadingContainer_) {
+        return;
+      }
+
+      this.loadingContainer_.classList.toggle('amp-hidden', !state);
+      this.loadingElement_.classList.toggle('amp-active', state);
+
+      if (!state && opt_cleanup) {
+        const loadingContainer = this.loadingContainer_;
+        this.loadingContainer_ = null;
+        this.loadingElement_ = null;
+        this.getResources().deferMutate(this, () => {
+          dom.removeElement(loadingContainer);
+        });
+      }
+    });
+  };
+
+  /**
      * Returns an optional overflow element for this custom element.
      * @return {!./layout-delay-meter.LayoutDelayMeter}
      */
-    getLayoutDelayMeter_() {
-      if (!this.layoutDelayMeter_) {
-        this.layoutDelayMeter_ = new LayoutDelayMeter(
-            toWin(this.ownerDocument.defaultView), this.getPriority());
-      }
-      return this.layoutDelayMeter_;
+  CustomElementClass.prototype.getLayoutDelayMeter_ = function() {
+    if (!this.layoutDelayMeter_) {
+      this.layoutDelayMeter_ = new LayoutDelayMeter(
+          toWin(this.ownerDocument.defaultView), this.getPriority());
     }
+    return this.layoutDelayMeter_;
+  };
 
-    /**
+  /**
      * Returns an optional overflow element for this custom element.
      * @return {?Element}
      * @this {!Element}
      */
-    getOverflowElement() {
-      if (this.overflowElement_ === undefined) {
-        this.overflowElement_ = dom.childElementByAttr(this, 'overflow');
-        if (this.overflowElement_) {
-          if (!this.overflowElement_.hasAttribute('tabindex')) {
-            this.overflowElement_.setAttribute('tabindex', '0');
-          }
-          if (!this.overflowElement_.hasAttribute('role')) {
-            this.overflowElement_.setAttribute('role', 'button');
-          }
+  CustomElementClass.prototype.getOverflowElement = function() {
+    if (this.overflowElement_ === undefined) {
+      this.overflowElement_ = dom.childElementByAttr(this, 'overflow');
+      if (this.overflowElement_) {
+        if (!this.overflowElement_.hasAttribute('tabindex')) {
+          this.overflowElement_.setAttribute('tabindex', '0');
+        }
+        if (!this.overflowElement_.hasAttribute('role')) {
+          this.overflowElement_.setAttribute('role', 'button');
         }
       }
-      return this.overflowElement_;
     }
+    return this.overflowElement_;
+  };
 
-    /**
+  /**
      * Hides or shows the overflow, if available. This function must only
      * be called inside a mutate context.
      * @param {boolean} overflown
@@ -1550,33 +1534,32 @@ function createBaseCustomElementClass(win) {
      * @param {number|undefined} requestedWidth
      * @package @final @this {!Element}
      */
-    overflowCallback(overflown, requestedHeight, requestedWidth) {
-      this.getOverflowElement();
-      if (!this.overflowElement_) {
-        if (overflown) {
-          user().warn(TAG,
-              'Cannot resize element and overflow is not available', this);
-        }
-      } else {
-        this.overflowElement_.classList.toggle('amp-visible', overflown);
-
-        if (overflown) {
-          this.overflowElement_.onclick = () => {
-            this.getResources(). /*OK*/ changeSize(
-                this, requestedHeight, requestedWidth);
-            getVsync(this).mutate(() => {
-              this.overflowCallback(
-                  /* overflown */ false, requestedHeight, requestedWidth);
-            });
-          };
+  CustomElementClass.prototype.overflowCallback =
+      function(overflown, requestedHeight, requestedWidth) {
+        this.getOverflowElement();
+        if (!this.overflowElement_) {
+          if (overflown) {
+            user().warn(TAG,
+                'Cannot resize element and overflow is not available', this);
+          }
         } else {
-          this.overflowElement_.onclick = null;
+          this.overflowElement_.classList.toggle('amp-visible', overflown);
+
+          if (overflown) {
+            this.overflowElement_.onclick = () => {
+              this.getResources(). /*OK*/ changeSize(
+                  this, requestedHeight, requestedWidth);
+              getVsync(this).mutate(() => {
+                this.overflowCallback(
+                /* overflown */ false, requestedHeight, requestedWidth);
+              });
+            };
+          } else {
+            this.overflowElement_.onclick = null;
+          }
         }
-      }
-    }
-  };
-  win.BaseCustomElementClass = BaseCustomElement;
-  return win.BaseCustomElementClass;
+      };
+  return CustomElementClass;
 }
 
 

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -102,7 +102,7 @@ function isTemplateTagSupported() {
  */
 export function createCustomElementClass(win, name) {
   // Polyfill for Reflect.construct.
-  const construct = typeof win.Reflect === 'object'
+  const construct = win.Reflect
     ? win.Reflect.construct
     : function(Parent, args, Class) {
       const a = [null];

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import './polyfills';
 import {AmpEvents} from './amp-events';
 import {CommonSignals} from './common-signals';
 import {ElementStub} from './element-stub';

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -459,11 +459,15 @@ export function createCustomElementClass(win, name) {
         Services.timerFor(toWin(this.ownerDocument.defaultView))
             .delay(this.dequeueActions_.bind(this), 1);
       }
+      try {
       if (!this.getPlaceholder()) {
         const placeholder = this.createPlaceholder();
         if (placeholder) {
           this.appendChild(placeholder);
         }
+      }
+      } catch(e) {
+        reportError(e, this);
       }
     }, reason => {
       this.signals_.rejectSignal(CommonSignals.BUILT,

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -319,6 +319,7 @@ export function createCustomElementClass(win, name) {
      * @final @package @this {!Element}
      */
   CustomElementClass.prototype.upgrade = function(newImplClass) {
+    this.classList.add('upgrade-1')
     if (this.isInTemplate_) {
       return;
     }
@@ -326,12 +327,14 @@ export function createCustomElementClass(win, name) {
       // Already upgraded or in progress or failed.
       return;
     }
+    this.classList.add('upgrade-2')
     this.implementation_ = new newImplClass(this);
     if (this.everAttached) {
       // Usually, we do an implementation upgrade when the element is
       // attached to the DOM. But, if it hadn't yet upgraded from
       // ElementStub, we couldn't. Now that it's upgraded from a stub, go
       // ahead and do the full upgrade.
+      this.classList.add('upgrade-3')
       this.tryUpgrade_();
     }
   };
@@ -644,6 +647,7 @@ export function createCustomElementClass(win, name) {
      * @final @this {!Element}
      */
   CustomElementClass.prototype.connectedCallback = function() {
+    this.classList.add('connected-callback')
     if (!this.everAttached) {
       this.classList.add('i-amphtml-element');
       this.classList.add('i-amphtml-notbuilt');
@@ -733,9 +737,11 @@ export function createCustomElementClass(win, name) {
      * @private @final @this {!Element}
      */
   CustomElementClass.prototype.tryUpgrade_ = function() {
+    this.classList.add('try-upgrade')
     const impl = this.implementation_;
     dev().assert(!isStub(impl), 'Implementation must not be a stub');
     if (this.upgradeState_ != UpgradeState.NOT_UPGRADED) {
+      this.classList.add('try-upgrade-0-' + this.upgradeState_)
       // Already upgraded or in progress or failed.
       return;
     }
@@ -747,18 +753,23 @@ export function createCustomElementClass(win, name) {
     const startTime = win.Date.now();
     const res = impl.upgradeCallback();
     if (!res) {
+      this.classList.add('try-upgrade-1')
       // Nothing returned: the current object is the upgraded version.
       this.completeUpgrade_(impl, startTime);
     } else if (typeof res.then == 'function') {
+      this.classList.add('try-upgrade-2')
       // It's a promise: wait until it's done.
       res.then(upgrade => {
+        this.classList.add('try-upgrade-3')
         this.completeUpgrade_(upgrade || impl, startTime);
       }).catch(reason => {
+        this.classList.add('try-upgrade-4')
         this.upgradeState_ = UpgradeState.UPGRADE_FAILED;
         rethrowAsync(reason);
       });
     } else {
       // It's an actual instance: upgrade immediately.
+      this.classList.add('try-upgrade-5')
       this.completeUpgrade_(
           /** @type {!./base-element.BaseElement} */(res), startTime);
     }

--- a/src/error.js
+++ b/src/error.js
@@ -159,8 +159,9 @@ export function reportError(error, opt_associatedElement) {
       element.classList.add('i-amphtml-error');
       if (getMode().development) {
         element.classList.add('i-amphtml-element-error');
-        element.setAttribute('error-message', error.message);
+
       }
+      element.setAttribute('error-message', error.message);
     }
 
     // Report to console.

--- a/src/polyfills.js
+++ b/src/polyfills.js
@@ -16,8 +16,10 @@
 
 // Importing the document-register-element module has the side effect
 // of installing the custom elements polyfill if necessary.
+/*eslint-disable */
 import installCustomElements from
-  'document-register-element/build/document-register-element.node';
+  '../build/patched-module/document-register-element/build/document-register-element.patched';
+/*eslint-enable */
 import {
   install as installDOMTokenListToggle,
 } from './polyfills/domtokenlist-toggle';
@@ -26,16 +28,8 @@ import {install as installMathSign} from './polyfills/math-sign';
 import {install as installObjectAssign} from './polyfills/object-assign';
 import {install as installPromise} from './polyfills/promise';
 import {install as installArrayIncludes} from './polyfills/array-includes';
-import {getMode} from './mode';
 
-/**
-  Only install in closure binary and not in babel/browserify binary, since in
-  the closure binary we strip out the `document-register-element` install side
-  effect so we can tree shake the dependency correctly and we have to make
-  sure to not `install` it during dev since the `install` is done as a side
-  effect in importing the module.
-*/
-if (!getMode().localDev) {
+if (!self.customElements) {
   installCustomElements(self, 'auto');
 }
 installDOMTokenListToggle(self);

--- a/src/service/custom-element-registry.js
+++ b/src/service/custom-element-registry.js
@@ -144,14 +144,7 @@ export function registerElement(win, name, implementationClass) {
   knownElements[name] = implementationClass;
   const klass = createCustomElementClass(win, name);
 
-  const supportsCustomElementsV1 = 'customElements' in win;
-  if (supportsCustomElementsV1) {
-    win['customElements'].define(name, klass);
-  } else {
-    win.document.registerElement(name, {
-      prototype: klass.prototype,
-    });
-  }
+  win['customElements'].define(name, klass);
 }
 
 

--- a/src/service/custom-element-registry.js
+++ b/src/service/custom-element-registry.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import '../polyfills';
 import {ElementStub, stubbedElements} from '../element-stub';
 import {createCustomElementClass} from '../custom-element';
 import {declareExtension} from './ampdoc-impl';

--- a/src/service/extensions-impl.js
+++ b/src/service/extensions-impl.js
@@ -697,7 +697,9 @@ export function stubLegacyElements(win) {
 function installPolyfillsInChildWindow(childWin) {
   installDocContains(childWin);
   installDOMTokenListToggle(childWin);
-  installCustomElements(childWin, 'auto');
+  if (!childWin.customElements) {
+    installCustomElements(childWin, 'auto');
+  }
 }
 
 

--- a/src/service/extensions-impl.js
+++ b/src/service/extensions-impl.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import '../polyfills';
 import {Services} from '../services';
 import {declareExtension} from './ampdoc-impl';
 import {

--- a/src/service/extensions-impl.js
+++ b/src/service/extensions-impl.js
@@ -31,8 +31,10 @@ import {
 import {cssText} from '../../build/css';
 import {dev, rethrowAsync} from '../log';
 import {getMode} from '../mode';
+/*eslint-disable */
 import installCustomElements from
-  'document-register-element/build/document-register-element.node';
+  '../../build/patched-module/document-register-element/build/document-register-element.patched';
+/*eslint-enable */
 import {install as installDocContains} from '../polyfills/document-contains';
 import {
   install as installDOMTokenListToggle,

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -303,18 +303,23 @@ export class Resource {
    * @return {?Promise}
    */
   build() {
+    this.element.classList.add('build-1')
     if (this.isBuilding_ ||
         !this.element.isUpgraded() ||
         !this.resources_.grantBuildPermission()) {
       return null;
     }
+    this.element.classList.add('build-2')
     this.isBuilding_ = true;
     return this.element.build().then(() => {
+      this.element.classList.add('build-3')
       this.isBuilding_ = false;
       if (this.hasBeenMeasured()) {
+        this.element.classList.add('build-4')
         this.state_ = ResourceState.READY_FOR_LAYOUT;
         this.element.updateLayoutBox(this.layoutBox_);
       } else {
+        this.element.classList.add('build-5')
         this.state_ = ResourceState.NOT_LAID_OUT;
       }
       // TODO(dvoytenko): merge with the standard BUILT signal.
@@ -323,6 +328,7 @@ export class Resource {
       // in PROD.
       this.element.dispatchCustomEvent(AmpEvents.BUILT);
     }, reason => {
+      this.element.classList.add('build-6')
       dev().error(TAG, 'failed to build:', this.debugid, reason);
       this.isBuilding_ = false;
       this.element.signals().rejectSignal('res-built', reason);
@@ -725,6 +731,7 @@ export class Resource {
    * @package
    */
   startLayout() {
+    this.element.classList.add('r-layout-1')
     if (this.layoutPromise_) {
       return this.layoutPromise_;
     }
@@ -734,6 +741,7 @@ export class Resource {
     if (this.state_ == ResourceState.LAYOUT_FAILED) {
       return Promise.reject(this.lastLayoutError_);
     }
+    this.element.classList.add('r-layout-2')
 
     dev().assert(this.state_ != ResourceState.NOT_BUILT,
         'Not ready to start layout: %s (%s)', this.debugid, this.state_);
@@ -745,6 +753,7 @@ export class Resource {
       dev().fine(TAG, 'layout canceled since it wasn\'t requested:',
           this.debugid, this.state_);
       this.state_ = ResourceState.LAYOUT_COMPLETE;
+      this.element.classList.add('r-layout-3')
       return Promise.resolve();
     }
 
@@ -754,6 +763,7 @@ export class Resource {
 
     let promise;
     try {
+      this.element.classList.add('r-layout')
       promise = this.element.layoutCallback();
     } catch (e) {
       return Promise.reject(e);

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -1353,6 +1353,7 @@ export class Resources {
     for (let i = 0; i < this.resources_.length; i++) {
       const r = this.resources_[i];
       if (r.getState() == ResourceState.NOT_BUILT && !r.isBuilding()) {
+        r.element.classList.add('r-1')
         this.buildOrScheduleBuildForResource_(r, /* checkForDupes */ true);
       }
       if (relayoutAll ||
@@ -1383,6 +1384,7 @@ export class Resources {
                 r.isMeasureRequested() ||
                 relayoutTop != -1 && r.getLayoutBox().bottom >= relayoutTop) {
           const wasDisplayed = r.isDisplayed();
+          r.element.classList.add('r-2')
           r.measure();
           if (wasDisplayed && !r.isDisplayed()) {
             if (!toUnload) {
@@ -1427,6 +1429,7 @@ export class Resources {
     for (let i = 0; i < this.resources_.length; i++) {
       const r = this.resources_[i];
       if (r.getState() == ResourceState.NOT_BUILT || r.hasOwner()) {
+        r.element.classList.add('r-3')
         continue;
       }
       // Note that when the document is not visible, neither are any of its
@@ -1437,6 +1440,7 @@ export class Resources {
       const shouldBeInViewport = (this.visible_ && r.isDisplayed() &&
           r.overlaps(visibleRect));
       r.setInViewport(shouldBeInViewport);
+      r.element.classList.add('r-4')
     }
 
     // Phase 4: Schedule elements for layout within a reasonable distance from
@@ -1445,12 +1449,14 @@ export class Resources {
       for (let i = 0; i < this.resources_.length; i++) {
         const r = this.resources_[i];
         if (r.getState() != ResourceState.READY_FOR_LAYOUT || r.hasOwner()) {
+          r.element.classList.add('r-5')
           continue;
         }
         // TODO(dvoytenko, #3434): Reimplement the use of `isFixed` with
         // layers. This is currently a short-term fix to the problem that
         // the fixed elements get incorrect top coord.
         if (r.isDisplayed() && r.overlaps(loadRect)) {
+          r.element.classList.add('r-6')
           this.scheduleLayoutOrPreload_(r, /* layout */ true);
         }
       }
@@ -1469,6 +1475,7 @@ export class Resources {
         if (r.getState() == ResourceState.READY_FOR_LAYOUT &&
             !r.hasOwner() && r.isDisplayed() && r.idleRenderOutsideViewport()) {
           dev().fine(TAG_, 'idleRenderOutsideViewport layout:', r.debugid);
+          r.element.classList.add('r-7')
           this.scheduleLayoutOrPreload_(r, /* layout */ false);
           idleScheduledCount++;
         }
@@ -1481,6 +1488,7 @@ export class Resources {
         if (r.getState() == ResourceState.READY_FOR_LAYOUT &&
             !r.hasOwner() && r.isDisplayed()) {
           dev().fine(TAG_, 'idle layout:', r.debugid);
+          r.element.classList.add('r-8')
           this.scheduleLayoutOrPreload_(r, /* layout */ false);
           idleScheduledCount++;
         }
@@ -1796,6 +1804,7 @@ export class Resources {
     // Only built and displayed elements can be loaded.
     if (resource.getState() == ResourceState.NOT_BUILT ||
         !resource.isDisplayed()) {
+      resource.element.classList.add('allowed-1')
       return false;
     }
 
@@ -1804,6 +1813,7 @@ export class Resources {
     if (!this.visible_) {
       if (this.viewer_.getVisibilityState() != VisibilityState.PRERENDER ||
           !resource.prerenderAllowed()) {
+            resource.element.classList.add('allowed-2')
         return false;
       }
     }
@@ -1813,9 +1823,10 @@ export class Resources {
         !resource.isInViewport() &&
         !resource.renderOutsideViewport() &&
         !resource.idleRenderOutsideViewport()) {
+          resource.element.classList.add('allowed-3')
       return false;
     }
-
+    resource.element.classList.add('allowed-4')
     return true;
   }
 
@@ -1829,22 +1840,27 @@ export class Resources {
    */
   scheduleLayoutOrPreload_(resource, layout, opt_parentPriority,
     opt_forceOutsideViewport) {
+    resource.element.classList.add('r-s0')
     dev().assert(resource.getState() != ResourceState.NOT_BUILT &&
         resource.isDisplayed(),
     'Not ready for layout: %s (%s)',
     resource.debugid, resource.getState());
     const forceOutsideViewport = opt_forceOutsideViewport || false;
+    resource.element.classList.add('r-s1')
     if (!this.isLayoutAllowed_(resource, forceOutsideViewport)) {
+      resource.element.classList.add('r-s2')
       return;
     }
 
     if (layout) {
+      resource.element.classList.add('r-s3')
       this.schedule_(resource,
           LAYOUT_TASK_ID_, LAYOUT_TASK_OFFSET_,
           opt_parentPriority || 0,
           forceOutsideViewport,
           resource.startLayout.bind(resource));
     } else {
+      resource.element.classList.add('r-s4')
       this.schedule_(resource,
           PRELOAD_TASK_ID_, PRELOAD_TASK_OFFSET_,
           opt_parentPriority || 0,
@@ -1907,6 +1923,7 @@ export class Resources {
     forceOutsideViewport,
     callback) {
     const taskId = resource.getTaskId(localId);
+    resource.element.classList.add('r-schedule-1')
 
     const task = {
       id: taskId,
@@ -1929,8 +1946,10 @@ export class Resources {
         this.queue_.dequeue(queued);
       }
       this.queue_.enqueue(task);
+      resource.element.classList.add('r-schedule-2')
       this.schedulePass(this.calcTaskTimeout_(task));
     }
+    resource.element.classList.add('r-schedule-3')
     task.resource.layoutScheduled(task.scheduleTime);
   }
 

--- a/test/integration/test-amp-ad-3p.js
+++ b/test/integration/test-amp-ad-3p.js
@@ -34,7 +34,10 @@ function createIframeWithApis(fixture) {
   const platform = Services.platformFor(fixture.win);
   return poll('frame to be in DOM', () => {
     return fixture.doc.querySelector('amp-ad > iframe');
-  }, undefined, 5000).then(iframeElement => {
+  }, () => {
+    return new Error('Cannot find ad frame in : ' +
+        fixture.doc.querySelector('amp-ad')./*test*/outerHTML);
+  }, 5000).then(iframeElement => {
     iframe = iframeElement;
     return new Promise(resolve => {
       if (iframe.contentWindow.context) {

--- a/test/integration/test-released.js
+++ b/test/integration/test-released.js
@@ -31,7 +31,7 @@ describe.configure().retryOnSaucelabs().run(
     });
 
 function runTest(shouldKillPolyfillableApis) {
-  describe.configure().run('Rendering of released components', function() {
+  describe('Rendering of released components', function() {
     this.timeout(5000);
     let fixture;
     beforeEach(() => {
@@ -50,14 +50,14 @@ function runTest(shouldKillPolyfillableApis) {
     // It never renders the ad, even though it appears to work when looking
     // at the rendering. The test passes when running locally in FF.
     // TODO(lannka, #3561): unmute the test.
-    it.configure().skipFirefox().skipChrome()
+    it.configure().skipFirefox()
         .run('all components should get loaded', function() {
           this.timeout(15000);
-          return pollForLayout(fixture.win, 13, 10000).then(() => {
+          return pollForLayout(fixture.win, 12, 10000).then(() => {
             expect(fixture.doc.querySelectorAll('.i-amphtml-element'))
                 .to.have.length(17);
             expect(fixture.doc.querySelectorAll('.i-amphtml-layout'))
-                .to.have.length(13);
+                .to.have.length(12);
             expect(fixture.doc.querySelectorAll('.i-amphtml-error'))
                 .to.have.length(0);
             checkGlobalScope(fixture.win);

--- a/test/integration/test-released.js
+++ b/test/integration/test-released.js
@@ -53,11 +53,11 @@ function runTest(shouldKillPolyfillableApis) {
     it.configure().skipFirefox()
         .run('all components should get loaded', function() {
           this.timeout(15000);
-          return pollForLayout(fixture.win, 12, 10000).then(() => {
+          return pollForLayout(fixture.win, 13, 10000).then(() => {
             expect(fixture.doc.querySelectorAll('.i-amphtml-element'))
                 .to.have.length(17);
             expect(fixture.doc.querySelectorAll('.i-amphtml-layout'))
-                .to.have.length(12);
+                .to.have.length(13);
             expect(fixture.doc.querySelectorAll('.i-amphtml-error'))
                 .to.have.length(0);
             checkGlobalScope(fixture.win);

--- a/testing/iframe.js
+++ b/testing/iframe.js
@@ -447,7 +447,8 @@ export function pollForLayout(win, count, opt_timeout) {
         built.length + ' built) Elements without layout:\n' +
         Array.from(built)
             .filter(e => !e.classList.contains('i-amphtml-layout'))
-            .map(e => '  ' + e.tagName + '->' + e.className)
+            .map(e => '  ' + e.tagName + '->' + e.className + ': ' +
+                e./*test*/outerHTML)
             .join('\n '));
   }, opt_timeout);
 }

--- a/testing/iframe.js
+++ b/testing/iframe.js
@@ -230,7 +230,9 @@ export function createIframePromise(opt_runtimeOff, opt_beforeLayoutCallback) {
       const ampdoc = Services.ampdocServiceFor(iframe.contentWindow).getAmpDoc();
       installExtensionsService(iframe.contentWindow);
       installRuntimeServices(iframe.contentWindow);
-      installCustomElements(iframe.contentWindow);
+      if (!iframe.contentWindow.customElements) {
+        installCustomElements(iframe.contentWindow);
+      }
       installAmpdocServices(ampdoc);
       Services.resourcesForDoc(ampdoc).ampInitComplete();
       // Act like no other elements were loaded by default.
@@ -443,8 +445,8 @@ export function pollForLayout(win, count, opt_timeout) {
     return new Error('Failed to find elements with layout.' +
         ' Current count: ' + getCount() + '/' + count + ' (' +
         built.length + ' built) Elements:\n' +
-        Array.from(built).map(e => '  ' + e.tagName + '\t-> ' + e.className)
-        .join('\n'));
+        Array.from(built).map(e => '  ' + e.tagName + '->' + e.className)
+        .join('; '));
   }, opt_timeout);
 }
 

--- a/testing/iframe.js
+++ b/testing/iframe.js
@@ -139,9 +139,18 @@ export function createFixtureIframe(fixture, initialIframeHeight, opt_beforeLoad
             file + ':' + line + '\n' +
             (error ? error.stack : 'no stack')));
       };
+      win.errorMessages = '';
+      win.addEventListener('error', event => {
+        win.errorMessages += 'Error: ' + event.message + '\n';
+      });
+      win.addEventListener('unhandledrejection', event => {
+        win.errorMessages += 'Rejection: ' + event.reason.message + '\n';
+      });
       let errors = [];
       win.console.error = function() {
-        errors.push('Error: ' + [].slice.call(arguments).join(' '));
+        const message = [].slice.call(arguments).join(' ');
+        errors.push('Error: ' + message);
+        win.errorMessages += 'Message: ' + message + '\n';
         console.error.apply(console, arguments);
       };
       // Make time go 10x as fast
@@ -449,7 +458,8 @@ export function pollForLayout(win, count, opt_timeout) {
             .filter(e => !e.classList.contains('i-amphtml-layout'))
             .map(e => '  ' + e.tagName + '->' + e.className + ': ' +
                 e./*test*/outerHTML)
-            .join('\n '));
+            .join('\n ') +
+        '\nError messages ' + win.errorMessages);
   }, opt_timeout);
 }
 

--- a/testing/iframe.js
+++ b/testing/iframe.js
@@ -441,7 +441,7 @@ export function pollForLayout(win, count, opt_timeout) {
   return poll('Waiting for elements to layout: ' + count, () => {
     return getCount() >= count;
   }, () => {
-    const built = win.document.querySelectorAll('.i-amphtml-element');
+    const built = win.document.querySelectorAll('.i-amphtml-element,amp-img');
     return new Error('Failed to find elements with layout.' +
         ' Current count: ' + getCount() + '/' + count + ' (' +
         built.length + ' built) Elements without layout:\n' +

--- a/testing/iframe.js
+++ b/testing/iframe.js
@@ -444,9 +444,11 @@ export function pollForLayout(win, count, opt_timeout) {
     const built = win.document.querySelectorAll('.i-amphtml-element');
     return new Error('Failed to find elements with layout.' +
         ' Current count: ' + getCount() + '/' + count + ' (' +
-        built.length + ' built) Elements:\n' +
-        Array.from(built).map(e => '  ' + e.tagName + '->' + e.className)
-        .join('; '));
+        built.length + ' built) Elements without layout:\n' +
+        Array.from(built)
+            .filter(e => !e.classList.contains('i-amphtml-layout'))
+            .map(e => '  ' + e.tagName + '->' + e.className)
+            .join('\n '));
   }, opt_timeout);
 }
 

--- a/testing/iframe.js
+++ b/testing/iframe.js
@@ -439,9 +439,12 @@ export function pollForLayout(win, count, opt_timeout) {
   return poll('Waiting for elements to layout: ' + count, () => {
     return getCount() >= count;
   }, () => {
+    const built = win.document.querySelectorAll('.i-amphtml-element');
     return new Error('Failed to find elements with layout.' +
-        ' Current count: ' + getCount() + ' HTML:\n' +
-        win.document.documentElement./*TEST*/innerHTML);
+        ' Current count: ' + getCount() + '/' + count + ' (' +
+        built.length + ' built) Elements:\n' +
+        Array.from(built).map(e => '  ' + e.tagName + '\t-> ' + e.className)
+        .join('\n'));
   }, opt_timeout);
 }
 


### PR DESCRIPTION
The CustomElement V1 API is strictly coupled to ES6 classes inheriting from build-in `HTMLElement` or its subclasses. Alternatively, `Reflect.construct` can be used to make legacy constructors inherit from build-in classes.

Because we transpile ES6 classes, we never hit any of those 2 paths (Not an ES6 class and not using `Reflect.construct` in transpiled output). This is hidden by the polyfill by falling back to a V0 polyfill instead. As a consequence we depended on the polyfill even in browsers that implement custom elements.

This CL manually uses a legacy class with a `Reflect.construct` based constructor to make the resulting object directly consumable by `customElements.define`. Note, that while there is a way to make Babel produce similar code, there is no much way for closure compiler transpilation.

Additionally: The CE polyfill had a side effect and was included multiple times. Due to the polyfill's behavior this led to a forced CE V1 polyfill behavior (and it is also bad). We'll try to get this fixed upstream, but for now we always patch the polyfill (we had already done this for the prod build).
