### PR TITLE
Move react-dates, etc. from devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "babel-polyfill": "6.26.0",
     "document-register-element": "1.5.0",
     "promise-pjs": "1.1.3",
+    "react-dates": "13.0.6",
     "web-animations-js": "2.3.1"
   },
   "devDependencies": {
@@ -128,7 +129,6 @@
     "prop-types": "15.6.0",
     "react": "16.2.0",
     "react-addons-shallow-compare": "15.6.2",
-    "react-dates": "16.0.1",
     "react-dom": "16.2.0",
     "react-externs": "0.13.6",
     "react-with-direction": "1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1959,6 +1959,10 @@ class-utils@^0.3.5:
     lazy-cache "^2.0.2"
     static-extend "^0.1.1"
 
+classnames@^2.2.5:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.5.tgz#fb3801d453467649ef3603c7d61a02bd129bde6d"
+
 clean-stack@^1.1.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-1.3.0.tgz#9e821501ae979986c46b1d66d2d432db2fd4ae31"
@@ -7924,27 +7928,27 @@ rc@^1.0.1, rc@^1.1.6, rc@^1.1.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-addons-shallow-compare@15.6.2, react-addons-shallow-compare@^15.5.2:
+react-addons-shallow-compare@15.6.2:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/react-addons-shallow-compare/-/react-addons-shallow-compare-15.6.2.tgz#198a00b91fc37623db64a28fd17b596ba362702f"
   dependencies:
     fbjs "^0.8.4"
     object-assign "^4.1.0"
 
-react-dates@16.0.1:
-  version "16.0.1"
-  resolved "https://registry.yarnpkg.com/react-dates/-/react-dates-16.0.1.tgz#0522e65c57b1a5dd685160127e29dff8bb41e573"
+react-dates@13.0.6:
+  version "13.0.6"
+  resolved "https://registry.yarnpkg.com/react-dates/-/react-dates-13.0.6.tgz#b1b98be7a2b886d1a2d47cc375dc38c10b68f539"
   dependencies:
     airbnb-prop-types "^2.8.1"
+    classnames "^2.2.5"
     consolidated-events "^1.1.0"
     is-touch-device "^1.0.1"
     lodash "^4.1.1"
     object.assign "^4.0.4"
     object.values "^1.0.4"
     prop-types "^15.5.10"
-    react-addons-shallow-compare "^15.5.2"
     react-moment-proptypes "^1.5.0"
-    react-portal "^4.1.0"
+    react-portal "^3.1.0"
     react-with-styles "^2.2.0"
     react-with-styles-interface-css "^3.0.0"
 
@@ -7967,9 +7971,9 @@ react-moment-proptypes@^1.5.0:
   dependencies:
     moment ">=1.6.0"
 
-react-portal@^4.1.0:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/react-portal/-/react-portal-4.1.2.tgz#7f28f3c8c2ed5c541907c0ed0f24e8996acf627f"
+react-portal@^3.1.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/react-portal/-/react-portal-3.2.0.tgz#4224e19b2b05d5cbe730a7ba0e34ec7585de0043"
   dependencies:
     prop-types "^15.5.8"
 


### PR DESCRIPTION
This is a follow up to the discussion in https://github.com/ampproject/amphtml/pull/12472#pullrequestreview-85124602

In #12016 and #12456, @cvializ added a bunch of packages to `devDependencies` while writing a new date picker component for the AMP runtime. It's possible that some of those should actually go into `dependencies`. See these diffs for the full list of packages that were added.

https://github.com/ampproject/amphtml/pull/12016/files#diff-b9cfc7f2cdf78a7f4b91a753d10865a2. 
https://github.com/ampproject/amphtml/pull/12456/files#diff-b9cfc7f2cdf78a7f4b91a753d10865a2

This PR moves the packages required by the date picker from `devDependencies` to `dependencies` and reverts them to their originally added versions.

Follows up #11368, #12016, #12456, and #12472