### PR TITLE
Update 'yarn add' instructions

### DIFF
--- a/build-system/check-package-manager.js
+++ b/build-system/check-package-manager.js
@@ -39,8 +39,12 @@ function main() {
         '*** The AMP project uses yarn for package management ***'), '\n');
     console/*OK*/.log(yellow('To install all packages:'));
     console/*OK*/.log(cyan('$'), 'yarn', '\n');
-    console/*OK*/.log(yellow(
-        'To install a new package (and update package.json and yarn.lock):'));
+    console/*OK*/.log(
+        yellow('To install a new (runtime) package to "dependencies":'));
+    console/*OK*/.log(cyan('$'),
+        'yarn add --exact [package_name@version]', '\n');
+    console/*OK*/.log(
+        yellow('To install a new (toolset) package to "devDependencies":'));
     console/*OK*/.log(cyan('$'),
         'yarn add --dev --exact [package_name@version]', '\n');
     console/*OK*/.log(yellow('To upgrade a package:'));

--- a/contributing/getting-started-quick.md
+++ b/contributing/getting-started-quick.md
@@ -27,7 +27,7 @@ This Quick Start guide is the TL;DR version of the longer [end-to-end guide](get
 
 * Install [NodeJS](https://nodejs.org/) version >= 6 (which includes npm)
 
-* Install [Yarn](https://yarnpkg.com/) version >= 1.0.2 (instructions [here](https://yarnpkg.com/en/docs/install), this may require elevated privileges using `sudo` on some platforms)
+* Install [Yarn](https://yarnpkg.com/) version >= 1.2.0 (instructions [here](https://yarnpkg.com/en/docs/install), this may require elevated privileges using `sudo` on some platforms)
 
 * Install Gulp by running `yarn global add gulp` (this may require elevated privileges using `sudo` on some platforms)
 


### PR DESCRIPTION
This helps distinguish between adding a package to `dependencies` vs. `devDependencies`

Follow up to https://github.com/ampproject/amphtml/pull/12472#pullrequestreview-85124602