### PR TITLE
Run `gulp ava` for the `RUNTIME` build target

### DIFF
--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -396,7 +396,8 @@ function main() {
 
   // Run different sets of independent tasks in parallel to reduce build time.
   if (process.env.BUILD_SHARD == 'unit_tests') {
-    if (buildTargets.has('BUILD_SYSTEM')) {
+    if (buildTargets.has('BUILD_SYSTEM') ||
+        buildTargets.has('RUNTIME')) {
       command.testBuildSystem();
     }
     if (buildTargets.has('BUILD_SYSTEM') ||


### PR DESCRIPTION
`gulp ava` started failing when version upgrades were made to `devDependencies`. This wasn't caught by PR check because it skips `gulp ava` for the `RUNTIME` build target.

This PR runs `gulp ava` when the `RUNTIME` build target is detected by `pr-check.js`.

Follow up to #12574