### PR TITLE
Speculative fix for unit tests

### DIFF
--- a/test/functional/test-resources.js
+++ b/test/functional/test-resources.js
@@ -1112,8 +1112,8 @@ describe('Resources discoverWork', () => {
   });
 
   afterEach(() => {
-    viewportMock.verify();
     sandbox.restore();
+    viewportMock.verify();
   });
 
   it('should set ready-scan signal on first ready pass after amp init', () => {
@@ -1781,8 +1781,8 @@ describe('Resources changeSize', () => {
   });
 
   afterEach(() => {
-    viewportMock.verify();
     sandbox.restore();
+    viewportMock.verify();
   });
 
   it('should schedule separate requests', () => {
@@ -2558,8 +2558,8 @@ describe('Resources mutateElement and collapse', () => {
   });
 
   afterEach(() => {
-    viewportMock.verify();
     sandbox.restore();
+    viewportMock.verify();
   });
 
   it('should mutate from visible to invisible', () => {


### PR DESCRIPTION
`test/functional/test-resources.js` sometimes complains that the sandbox hasn't been cleaned up during `viewportMock.verify()`.

See https://travis-ci.org/ampproject/amphtml/jobs/319896846#L765 for example. 

This PR moves the sandbox clean up in `afterEach()` to before `viewportMock.verify()`.