### PR TITLE
Pass publisher domain in the medianet ad url

### DIFF
--- a/ads/medianet.js
+++ b/ads/medianet.js
@@ -188,7 +188,7 @@ function loadHBTag(global, data, publisherUrl, referrerUrl) {
       setAmpTargeting: () => {},
       renderAmpAd: () => {},
     };
-    writeScript(global, 'https://contextual.media.net/bidexchange.js?https=1&amp=1&cid=' + encodeURIComponent(data.cid), () => {
+    writeScript(global, 'https://contextual.media.net/bidexchange.js?https=1&amp=1&cid=' + encodeURIComponent(data.cid) + '&dn=' + encodeURIComponent(global.context.location.hostname), () => {
       done(null);
     });
   }, mnetHBHandle);


### PR DESCRIPTION
Retrieve publisher domain for Media.net AMP publishers in order to apply domain specific rules.