### PR TITLE
Test, add example, and document referenced templates in a form's submit-[success|error]

### DIFF
--- a/examples/forms.amp.html
+++ b/examples/forms.amp.html
@@ -756,3 +756,26 @@
 
 </body>
 </html>
+
+<h4>Using a submit-success template referenced by id</h4>
+
+<template type="amp-mustache" id="submit_success_template">
+    <h1>You searched for: {{term}}</h1>
+</template>
+
+<form method="get"
+      action="https://httpbin.org/response-headers?AMP-Access-Control-Allow-Source-Origin=http%3A%2F%2Flocalhost%3A8000&access-control-expose-headers=AMP-Access-Control-Allow-Source-Origin"
+      action-xhr="https://httpbin.org/response-headers?AMP-Access-Control-Allow-Source-Origin=http%3A%2F%2Flocalhost%3A8000&access-control-expose-headers=AMP-Access-Control-Allow-Source-Origin"
+      target="_blank">
+    <fieldset>
+        <input name="clientId" type="hidden" value="CLIENT_ID(poll)" data-amp-replace="CLIENT_ID">
+        <input name="canonicalUrl" type="hidden" value="RANDOM and CANONICAL_URL" data-amp-replace="CANONICAL_URL RANDOM">
+        <label>
+            <span>Search for</span>
+            <input type="search" name="term" required>
+        </label>
+        <input type="submit" value="Search">
+    </fieldset>
+
+    <div submit-success template="submit_success_template"></div>
+</form>

--- a/extensions/amp-form/amp-form.md
+++ b/extensions/amp-form/amp-form.md
@@ -211,7 +211,7 @@ When the `amp-form-submit` event fires, it generates the following variables con
 ## Success/Error Response Rendering
 `amp-form` allows publishers to render the responses using [Extended Templates](../../spec/amp-html-format.md#extended-templates).
 
-Using `submit-success` and `submit-error` special marker attributes, publishers can mark any **direct child element of form** and include a `<template></template>` tag inside it to render the response in it.
+Using `submit-success` and `submit-error` special marker attributes, publishers can mark any **direct child element of form** and include a `<template></template>` tag inside it, or a `template="id_of_other_template"` attribute, to render the response in it.
 
 The response is expected to be a valid JSON Object. For example, if the publisher's `action-xhr` endpoint returns the following responses:
 
@@ -234,7 +234,7 @@ The response is expected to be a valid JSON Object. For example, if the publishe
 
 Both success and error responses should have a `Content-Type: application/json` header. `submit-success` will render for all responses that has a status of `2XX`, all other statuses will render `submit-error`.
 
-Publishers can render these in a template inside their forms as follows.
+Publishers can render these in a nested template inside their forms as follows.
 
 ```html
 <form ...>
@@ -252,6 +252,26 @@ Publishers can render these in a template inside their forms as follows.
       Oops! {{name}}, {{message}}.
     </template>
   </div>
+</form>
+```
+
+Publishers can render the responses in a referenced template defined earlier in the document by using the template's id as the value of the `template` attribute, set on the elements with the `submit-success` and `submit-error` attributes.
+
+```html
+<template type="amp-mustache" id="submit_success_template">
+  Success! Thanks {{name}} for subscribing! Please make sure to check your email {{email}}
+  to confirm! After that we'll start sending you weekly articles on {{#interests}}<b>{{name}}</b> {{/interests}}.
+</template>
+<template type="amp-mustache" id="submit_error_template">
+  Oops! {{name}}, {{message}}.
+</template>
+
+<form ...>
+  <fieldset>
+  ...
+  </fieldset>
+  <div submit-success template="submit_success_template"></div>
+  <div submit-error template="submit_error_template"></div>
 </form>
 ```
 

--- a/extensions/amp-form/amp-form.md
+++ b/extensions/amp-form/amp-form.md
@@ -234,7 +234,7 @@ The response is expected to be a valid JSON Object. For example, if the publishe
 
 Both success and error responses should have a `Content-Type: application/json` header. `submit-success` will render for all responses that has a status of `2XX`, all other statuses will render `submit-error`.
 
-Publishers can render these in a nested template inside their forms as follows.
+Publishers can render these in a inlined template inside their forms as follows.
 
 ```html
 <form ...>
@@ -255,7 +255,7 @@ Publishers can render these in a nested template inside their forms as follows.
 </form>
 ```
 
-Publishers can render the responses in a referenced template defined earlier in the document by using the template's id as the value of the `template` attribute, set on the elements with the `submit-success` and `submit-error` attributes.
+  Publishers can render the responses in a referenced template defined earlier in the document by using the template's id as the value of the `template` attribute, set on the elements with the `submit-success` and `submit-error` attributes.
 
 ```html
 <template type="amp-mustache" id="submit_success_template">

--- a/src/service/template-impl.js
+++ b/src/service/template-impl.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {childElementByTag, scopedQuerySelector} from '../dom';
+import {childElementByTag, rootNodeFor, scopedQuerySelector} from '../dom';
 import {dev, user} from '../log';
 import {getService, registerServiceBuilder} from '../service';
 
@@ -237,7 +237,7 @@ export class Templates {
   maybeFindTemplate_(parent, opt_querySelector) {
     const templateId = parent.getAttribute('template');
     if (templateId) {
-      return parent.ownerDocument.getElementById(templateId);
+      return rootNodeFor(parent).getElementById(templateId);
     } else if (opt_querySelector) {
       return scopedQuerySelector(parent, opt_querySelector);
     } else {

--- a/test/functional/test-template.js
+++ b/test/functional/test-template.js
@@ -152,6 +152,7 @@ describes.fakeWin('Template', {}, env => {
 
     const parentElement = doc.createElement('div');
     parentElement.setAttribute('template', id);
+    doc.body.appendChild(parentElement);
     return templates.findAndRenderTemplate(parentElement, {value: 1}).then(
         res => {
           expect(res.textContent).to.equal('abc1');
@@ -166,6 +167,7 @@ describes.fakeWin('Template', {}, env => {
 
     const parentElement = doc.createElement('div');
     parentElement.setAttribute('template', id);
+    doc.body.appendChild(parentElement);
     expect(() => {
       templates.findAndRenderTemplate(parentElement, {value: 0});
     }).to.throw(/Template element must be a "template" tag/);
@@ -186,6 +188,7 @@ describes.fakeWin('Template', {}, env => {
 
   it('should fail when template not found', () => {
     const parentElement = doc.createElement('div');
+    doc.body.appendChild(parentElement);
     expect(() => {
       templates.findAndRenderTemplate(parentElement, {value: 0});
     }).to.throw(/Template not found/);
@@ -198,6 +201,7 @@ describes.fakeWin('Template', {}, env => {
 
   it('should detect if a template is present in a container', () => {
     const parentElement = doc.createElement('div');
+    doc.body.appendChild(parentElement);
     expect(templates.hasTemplate(parentElement)).to.be.false;
 
     parentElement.setAttribute('template', 'notemplate' + Math.random());
@@ -226,24 +230,7 @@ describes.fakeWin('Template', {}, env => {
 
     const parentElement = doc.createElement('div');
     parentElement.setAttribute('template', id);
-    return templates.findAndRenderTemplateArray(parentElement,
-        [{value: 1}, {value: 2}]).then(res => {
-      expect(res).to.have.length.of(2);
-      expect(res[0].textContent).to.equal('abc1');
-      expect(res[1].textContent).to.equal('abc2');
-    });
-  });
-
-  it('should discover and render template for an array', () => {
-    const templateElement = createTemplateElement();
-    const type = templateElement.getAttribute('type');
-    const id = type + Math.random();
-    templateElement.setAttribute('id', id);
-    doc.body.appendChild(templateElement);
-    registerExtendedTemplate(win, type, TemplateImpl);
-
-    const parentElement = doc.createElement('div');
-    parentElement.setAttribute('template', id);
+    doc.body.appendChild(parentElement);
     return templates.findAndRenderTemplateArray(parentElement,
         [{value: 1}, {value: 2}]).then(res => {
       expect(res).to.have.length.of(2);

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -3265,7 +3265,6 @@ tags {
     name: "template"
     mandatory: true
   }
-  attrs: { name: "template" }
 }
 tags {
   tag_name: "DIV"
@@ -3290,7 +3289,6 @@ tags {
     name: "template"
     mandatory: true
   }
-  attrs: { name: "template" }
 }
 attr_lists: {
   name: "input-name-attr"

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -3247,6 +3247,7 @@ tags {
   spec_name: "FORM > DIV [submit-success]"
   mandatory_parent: "FORM"
   attrs: { name: "align" }
+  attrs: { name: "template" }
   attrs: {
     name: "submit-success"
     mandatory: true
@@ -3271,6 +3272,7 @@ tags {
   spec_name: "FORM > DIV [submit-error]"
   mandatory_parent: "FORM"
   attrs: { name: "align" }
+  attrs: { name: "template" }
   attrs: {
     name: "submit-error"
     mandatory: true

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -3247,7 +3247,6 @@ tags {
   spec_name: "FORM > DIV [submit-success]"
   mandatory_parent: "FORM"
   attrs: { name: "align" }
-  attrs: { name: "template" }
   attrs: {
     name: "submit-success"
     mandatory: true
@@ -3266,13 +3265,13 @@ tags {
     name: "template"
     mandatory: true
   }
+  attrs: { name: "template" }
 }
 tags {
   tag_name: "DIV"
   spec_name: "FORM > DIV [submit-error]"
   mandatory_parent: "FORM"
   attrs: { name: "align" }
-  attrs: { name: "template" }
   attrs: {
     name: "submit-error"
     mandatory: true
@@ -3291,6 +3290,7 @@ tags {
     name: "template"
     mandatory: true
   }
+  attrs: { name: "template" }
 }
 attr_lists: {
   name: "input-name-attr"


### PR DESCRIPTION
Fixes #7118

Turns out this feature is already implemented! Just needed documentation/test/examples