### PR TITLE
Doubleclick Fast Fetch gct parameter

### DIFF
--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -599,7 +599,6 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
       'rc': this.refreshCount_ || null,
       'frc': Number(this.fromResumeCallback) || null,
       'fluid': this.isFluid_ ? 'height' : null,
-      'gct': this.getLocationQueryParameterValue('google_preview') || null,
     }, googleBlockParameters(this));
   }
 

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -116,13 +116,6 @@ const RTC_ATI_ENUM = {
   RTC_FAILURE: 3,
 };
 
-/** @private @const {!Object<string,string>} */
-const PAGE_LEVEL_PARAMS_ = {
-  'gdfp_req': '1',
-  'sfv': DEFAULT_SAFEFRAME_VERSION,
-  'u_sd': window.devicePixelRatio,
-};
-
 /** @visibleForTesting @const {string} */
 export const CORRELATOR_CLEAR_EXP_NAME = 'dbclk-correlator-clear';
 
@@ -540,9 +533,12 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
 
   /** @return {!Object<string,string|boolean|number>} */
   getPageParameters_() {
-    return Object.assign(PAGE_LEVEL_PARAMS_, {
+    return {
+      'gdfp_req': '1',
+      'sfv': DEFAULT_SAFEFRAME_VERSION,
+      'u_sd': this.win.devicePixelRatio,
       'gct': this.getLocationQueryParameterValue('google_preview') || null,
-    });
+    };
   }
 
   /**
@@ -1379,9 +1375,14 @@ AMP.extension(TAG, '0.1', AMP => {
 });
 
 
-/** @visibileForTesting */
+/** @visibleForTesting */
 export function resetSraStateForTesting() {
   sraRequests = null;
+}
+
+/** @visibleForTesting */
+export function resetLocationQueryParametersForTesting() {
+  windowLocationQueryParameters = null;
 }
 
 /**
@@ -1403,15 +1404,15 @@ export function getNetworkId(element) {
  * @param {!Array<!AmpAdNetworkDoubleclickImpl>} instances
  * @return {!Promise<string>} SRA request URL
  */
-function constructSRARequest_(win, doc, instances) {
+export function constructSRARequest_(win, doc, instances) {
   // TODO(bradfrizzell): Need to add support for RTC.
   dev().assert(instances && instances.length);
   const startTime = Date.now();
   return googlePageParameters(win, doc, startTime)
-      .then(pageLevelParameters => {
+      .then(googPageLevelParameters => {
         const blockParameters = constructSRABlockParameters(instances);
         return truncAndTimeUrl(DOUBLECLICK_BASE_URL,
-            Object.assign(blockParameters, pageLevelParameters,
+            Object.assign(blockParameters, googPageLevelParameters,
                 instances[0].getPageParameters_()),
             startTime);
       });

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -574,6 +574,18 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
         });
       });
     });
+    it('should have google_preview parameter', () => {
+      sandbox.stub(impl, 'getLocationQueryParameterValue')
+          .withArgs('google_preview').returns({'google_preview': 'abcdef'});
+      new AmpAd(element).upgradeCallback();
+      expect(impl.getAdUrl()).to.eventually.contain('&gct=abcdef&');
+    });
+    it('should cache getLocationQueryParameterValue', () => {
+      impl.win = {location: {search: '?foo=bar'}};
+      expect(impl.getLocationQueryParameterValue('foo')).to.equal('bar');
+      impl.win.location.search = '?foo=bar2';
+      expect(impl.getLocationQueryParameterValue('foo')).to.equal('bar');
+    });
     // TODO(bradfrizzell, #12476): Make this test work with sinon 4.0.
     it.skip('has correct rc and ifi after refresh', () => {
       // We don't really care about the behavior of the following methods, so

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -33,6 +33,7 @@ import {
   CORRELATOR_CLEAR_EXP_BRANCHES,
   CORRELATOR_CLEAR_EXP_NAME,
   SAFEFRAME_ORIGIN,
+  resetLocationQueryParametersForTesting,
 } from '../amp-ad-network-doubleclick-impl';
 import {
   DOUBLECLICK_A4A_EXPERIMENT_NAME,
@@ -109,11 +110,13 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
   let impl;
 
   beforeEach(() => {
+    resetLocationQueryParametersForTesting();
     win = env.win;
     doc = win.document;
     ampdoc = env.ampdoc;
   });
 
+  afterEach(() => resetLocationQueryParametersForTesting);
 
   describe('#isValidElement', () => {
     beforeEach(() => {
@@ -576,9 +579,9 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
     });
     it('should have google_preview parameter', () => {
       sandbox.stub(impl, 'getLocationQueryParameterValue')
-          .withArgs('google_preview').returns({'google_preview': 'abcdef'});
+          .withArgs('google_preview').returns('abcdef');
       new AmpAd(element).upgradeCallback();
-      expect(impl.getAdUrl()).to.eventually.contain('&gct=abcdef&');
+      expect(impl.getAdUrl()).to.eventually.contain('&gct=abcdef');
     });
     it('should cache getLocationQueryParameterValue', () => {
       impl.win = {location: {search: '?foo=bar'}};

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-sra.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-sra.js
@@ -213,11 +213,13 @@ describes.realWin('amp-ad-network-doubleclick-impl', config , env => {
       const iuParts = encodeURIComponent(
           validInstances[0].element.getAttribute('data-slot').split(/\//)
               .splice(1).join());
+      sandbox.stub(validInstances[0], 'getLocationQueryParameterValue')
+          .withArgs('google_preview').returns('abcdef');
       const xhrWithArgs = xhrMock.withArgs(
-          sinon.match(
-              new RegExp('^https:\/\/securepubads\\.g\\.doubleclick\\.net' +
-            '\/gampad\/ads\\?output=ldjh&impl=fifs&iu_parts=' +
-            `${iuParts}&enc_prev_ius=`)),
+          sinon.match(new RegExp(
+              '^https:\/\/securepubads\\.g\\.doubleclick\\.net' +
+              '\/gampad\/ads\\?output=ldjh&impl=fifs&iu_parts=' +
+              `${iuParts}&enc_prev_ius=.*&gct=abcdef`)),
           {
             mode: 'cors',
             method: 'GET',


### PR DESCRIPTION
For Doubleclick Fast Fetch, populate gct parameter used as part of DFP UI preview.