### PR TITLE
amp-ad-exit layout validation

### DIFF
--- a/examples/amp-ad-exit.amp.html
+++ b/examples/amp-ad-exit.amp.html
@@ -37,7 +37,7 @@ h1 {
   <script async custom-element="amp-ad-exit" src="https://cdn.ampproject.org/v0/amp-ad-exit-0.1.js"></script>
 </head>
 <body>
-<amp-ad-exit id="exit-api">
+<amp-ad-exit id="exit-api" layout="nodisplay">
 <script type="application/json">
 {
   "targets": {
@@ -79,11 +79,11 @@ h1 {
 </script>
 </amp-ad-exit>
 <div id="ad">
-  <h1 on="tap:exit-api.exit(target='target1')">amp-ad-exit example</h1>
-  <div class="product" id="product1" on="tap:exit-api.exit(target='target1', _elem='Product 1')">
+  <h1 on="tap:exit-api.exit(target='target1')" role="button" tabindex="1">amp-ad-exit example</h1>
+  <div class="product" id="product1" on="tap:exit-api.exit(target='target1', _elem='Product 1')" role="button" tabindex="1">
     <p>product 1</p>
   </div>
-  <div class="product" id="product2" on="tap:exit-api.exit(target='target2', _elem='Product 2')">
+  <div class="product" id="product2" on="tap:exit-api.exit(target='target2', _elem='Product 2')" role="button" tabindex="1">
     <p>product 2</p>
   </div>
   <p><a href="https://www.google.com/" on="tap:exit-api.exit(target='target1', _elem='anchor')">&lt;A&gt; tags don't work well (try middle-clicking)</a>

--- a/extensions/amp-ad-exit/0.1/test/validator-amp4ads-amp-ad-exit.html
+++ b/extensions/amp-ad-exit/0.1/test/validator-amp4ads-amp-ad-exit.html
@@ -1,0 +1,68 @@
+<!doctype html>
+<html amp4ads>
+<head>
+  <title>amp-ad-exit example</title>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,minimum-scale=1">
+  <style amp4ads-boilerplate>body{visibility:hidden}</style>
+  <script async src="https://cdn.ampproject.org/amp4ads-v0.js"></script>
+  <script async custom-element="amp-ad-exit" src="https://cdn.ampproject.org/v0/amp-ad-exit-0.1.js"></script>
+</head>
+<body>
+<amp-ad-exit id="exit-api" layout="nodisplay">
+<script type="application/json">
+{
+  "targets": {
+    "target1": {
+      "finalUrl": "http://example.com/?x=CLICK_X&y=CLICK_Y&e=_elem",
+      "vars": {
+        "_elem": {"defaultValue": "headline"}
+      },
+      "filters": ["longDelay", "borderProtection"]
+    }
+  },
+  "filters": {
+    "longDelay": {
+      "type": "clickDelay",
+      "delay": 10000
+    },
+    "borderProtection": {
+      "type": "clickLocation",
+      "bottom": 10,
+      "left": 10,
+      "right": 10,
+      "relativeTo": "#ad"
+    }
+  },
+  "transport": {
+    "beacon": true,
+    "image": true
+  }
+}
+</script>
+</amp-ad-exit>
+<h1 on="tap:exit-api.exit(target='target1')" role="button" tabindex="1">amp-ad-exit example</h1>
+
+<amp-ad-exit id="exit-api-nolayout">
+<script type="application/json">
+{"targets": {"target1": {"finalUrl": "http://example.com/"}}}
+</script>
+</amp-ad-exit>
+
+<!-- Invalid: wrong layout -->
+<amp-ad-exit id="exit-api-layoutfill" layout="fill">
+<script type="application/json">
+{"targets": {"target1": {"finalUrl": "http://example.com/"}}}
+</script>
+
+<!-- Invalid: non-script children -->
+<amp-ad-exit id="exit-api-children">
+<script type="application/json">
+{"targets": {"target1": {"finalUrl": "http://example.com/"}}}
+</script>
+<p>p</p>
+</amp-ad-exit>
+
+</amp-ad-exit>
+</body>
+</html>

--- a/extensions/amp-ad-exit/0.1/test/validator-amp4ads-amp-ad-exit.out
+++ b/extensions/amp-ad-exit/0.1/test/validator-amp4ads-amp-ad-exit.out
@@ -1,0 +1,4 @@
+FAIL
+amp-ad-exit/0.1/test/validator-amp4ads-amp-ad-exit.html:53:0 The specified layout 'FILL' is not supported by tag 'amp-ad-exit'. (see https://www.ampproject.org/docs/reference/components/amp-ad-exit) [AMP_LAYOUT_PROBLEM]
+amp-ad-exit/0.1/test/validator-amp4ads-amp-ad-exit.html:59:0 Tag 'amp-ad-exit' must have 1 child tags - saw 2 child tags. (see https://www.ampproject.org/docs/reference/components/amp-ad-exit) [AMP_TAG_PROBLEM]
+amp-ad-exit/0.1/test/validator-amp4ads-amp-ad-exit.html:63:0 Tag 'p' is disallowed as child of tag 'amp-ad-exit'. Child tag must be one of ['script']. (see https://www.ampproject.org/docs/reference/components/amp-ad-exit) [AMP_TAG_PROBLEM]

--- a/extensions/amp-ad-exit/amp-ad-exit.md
+++ b/extensions/amp-ad-exit/amp-ad-exit.md
@@ -29,7 +29,7 @@ limitations under the License.
   </tr>
   <tr>
     <td><strong><a href="https://www.ampproject.org/docs/guides/responsive/control_layout.html">Supported Layouts</a></strong></td>
-    <td>`nodisplay`. The element is not presentational.</td>
+    <td>`nodisplay` or unspecified. The element is not presentational.</td>
   </tr>
 </table>
 

--- a/extensions/amp-ad-exit/amp-ad-exit.md
+++ b/extensions/amp-ad-exit/amp-ad-exit.md
@@ -29,7 +29,7 @@ limitations under the License.
   </tr>
   <tr>
     <td><strong><a href="https://www.ampproject.org/docs/guides/responsive/control_layout.html">Supported Layouts</a></strong></td>
-    <td>All. This element is hidden.</td>
+    <td>`nodisplay`. The element is not presentational.</td>
   </tr>
 </table>
 

--- a/extensions/amp-ad-exit/validator-amp-ad-exit.protoascii
+++ b/extensions/amp-ad-exit/validator-amp-ad-exit.protoascii
@@ -34,7 +34,15 @@ tags: {  # <amp-ad-exit>
     mandatory: true
   }
   attr_lists: "extended-amp-global"
+  child_tags: {
+    mandatory_num_child_tags: 1
+    child_tag_name_oneof: "SCRIPT"
+  }
   spec_url: "https://www.ampproject.org/docs/reference/components/amp-ad-exit"
+  amp_layout {
+    supported_layouts: NODISPLAY
+    supported_layouts: CONTAINER  # To allow an unspecified layout (container is default).
+  }
 }
 tags: {  # amp-ad-exit config JSON
   html_format: AMP4ADS


### PR DESCRIPTION
Allow "nodisplay" and unspecified ("container") for amp-ad-exit's layout. Fixes #12022.

Tested:
$ gulp validator
...
4049 specs, 0 failures
Finished in 1.477 seconds
[[build.py RunTests]] - ... success
[14:24:34] Finished 'validator' after 1.47 min