### PR TITLE
POC: Adzerk Fast Fetch with template based preferential render

### DIFF
--- a/ads/_a4a-config.js
+++ b/ads/_a4a-config.js
@@ -62,6 +62,7 @@ export function getA4ARegistry() {
   if (!a4aRegistry) {
     a4aRegistry = map({
       'adsense': adsenseIsA4AEnabled,
+      'adzerk': () => true,
       'doubleclick': doubleclickIsA4AEnabled,
       'triplelift': tripleliftIsA4AEnabled,
       'cloudflare': cloudflareIsA4AEnabled,

--- a/build-system/app.js
+++ b/build-system/app.js
@@ -569,6 +569,26 @@ app.get('/iframe/*', (req, res) => {
           </html>`);
 });
 
+app.get('/a4a_template/*', (req, res) => {
+  assertCors(req, res, ['GET'], undefined, true);
+  const match = /^\/a4a_template\/([a-z-]+)\/(\d+)$/.exec(req.path);
+  if (!match) {
+    res.status(404);
+    res.end('Invalid path: ' + req.path);
+    return;
+  }
+  const filePath = `${pc.cwd()}/extensions/amp-ad-network-${match[1]}-impl/` +
+      `0.1/data/${match[2]}.template`;
+  fs.readFileAsync(filePath).then(file => {
+    res.setHeader('Content-Type', 'application/json');
+    res.setHeader('AMP-template-amp-creative', 'true');
+    res.end(file);
+  }).error(() => {
+    res.status(404);
+    res.end('Not found: ' + filePath);
+  });
+});
+
 // Returns a document that echoes any post messages received from parent.
 // An optional `message` query param can be appended for an initial post
 // message sent on document load.
@@ -873,6 +893,27 @@ app.get([fakeAdNetworkDataDir + '/*', cloudflareDataDir + '/*'], (req, res) => {
   });
 });
 
+// Simulated adzerk ad server and AMP cache CDN.
+app.get('/adzerk/*', (req, res) => {
+  assertCors(req, res, ['GET'], ['AMP-template-amp-creative']);
+  const match = /\/(\d+)/.exec(req.path);
+  if (!match || !match[1]) {
+    res.status(404);
+    res.end('Invalid path: ' + req.path);
+    return;
+  }
+  const filePath =
+      pc.cwd() + '/extensions/amp-ad-network-adzerk-impl/0.1/data/' + match[1];
+  fs.readFileAsync(filePath).then(file => {
+    res.setHeader('Content-Type', 'application/json');
+    res.setHeader('AMP-template-amp-creative', 'true');
+    res.end(file);
+  }).error(() => {
+    res.status(404);
+    res.end('Not found: ' + filePath);
+  });
+});
+
 /*
  * Serve extension script url
  */
@@ -1122,11 +1163,14 @@ function enableCors(req, res, origin, opt_exposeHeaders) {
   res.setHeader('Access-Control-Expose-Headers',
       ['AMP-Access-Control-Allow-Source-Origin']
           .concat(opt_exposeHeaders || []).join(', '));
-  res.setHeader('AMP-Access-Control-Allow-Source-Origin',
-      req.query.__amp_source_origin);
+  if (req.query.__amp_source_origin) {
+    res.setHeader('AMP-Access-Control-Allow-Source-Origin',
+        req.query.__amp_source_origin);
+  }
 }
 
-function assertCors(req, res, opt_validMethods, opt_exposeHeaders) {
+function assertCors(req, res, opt_validMethods, opt_exposeHeaders,
+  opt_ignoreMissingSourceOrigin) {
   // Allow disable CORS check (iframe fixtures have origin 'about:srcdoc').
   if (req.query.cors == '0') {
     return;
@@ -1153,7 +1197,8 @@ function assertCors(req, res, opt_validMethods, opt_exposeHeaders) {
       throw invalidOrigin;
     }
 
-    if (!SOURCE_ORIGIN_REGEX.test(req.query.__amp_source_origin)) {
+    if (!opt_ignoreMissingSourceOrigin &&
+        !SOURCE_ORIGIN_REGEX.test(req.query.__amp_source_origin)) {
       res.statusCode = 500;
       res.end(JSON.stringify({message: invalidSourceOrigin}));
       throw invalidSourceOrigin;

--- a/build-system/dep-check-config.js
+++ b/build-system/dep-check-config.js
@@ -42,6 +42,8 @@ exports.rules = [
     mustNotDependOn: 'src/sanitizer.js',
     whitelist: [
       'extensions/amp-mustache/0.1/amp-mustache.js->src/sanitizer.js',
+      'extensions/amp-ad-network-adzerk-impl/0.1/' +
+          'amp-ad-network-adzerk-impl.js->src/sanitizer.js',
       'extensions/amp-bind/0.1/bind-impl.js->src/sanitizer.js',
       'extensions/amp-date-picker/0.1/amp-date-picker.js->src/sanitizer.js',
     ],
@@ -61,6 +63,8 @@ exports.rules = [
           'third_party/closure-library/sha384-generated.js',
       'extensions/amp-mustache/0.1/amp-mustache.js->' +
           'third_party/mustache/mustache.js',
+      'extensions/amp-ad-network-adzerk-impl/0.1/' +
+          'amp-ad-network-adzerk-impl.js->third_party/mustache/mustache.js',
       'extensions/amp-timeago/0.1/amp-timeago.js->' +
           'third_party/timeagojs/timeago.js',
       '3p/polyfills.js->third_party/babel/custom-babel-helpers.js',

--- a/examples/adzerk.amp.html
+++ b/examples/adzerk.amp.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>Adzerk examples</title>
+  <link rel="canonical" href="http://nonblocking.io/" >
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-ad" src="https://cdn.ampproject.org/v0/amp-ad-0.1.js"></script>
+</head>
+<body>
+
+  <amp-ad width=300 height=250
+      type="adzerk"
+      src="https://adzerk.com?id=1234">
+    <div placeholder></div>
+    <div fallback></div>
+  </amp-ad>
+
+  <amp-ad width=300 height=250
+      type="adzerk"
+      src="https://adzerk.com?id=101">
+    <div placeholder></div>
+    <div fallback></div>
+  </amp-ad>
+
+  <amp-ad width=300 height=250
+      type="adzerk"
+      src="https://adzerk.com?id=102">
+    <div placeholder></div>
+    <div fallback></div>
+  </amp-ad>
+
+</body>
+</html>

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -998,8 +998,8 @@ describe('amp-a4a', () => {
         const doc = fixture.doc;
         const a4aElement = createA4aElement(doc);
         const a4a = new MockA4AImpl(a4aElement);
-        sandbox.stub(a4a, 'getAmpAdMetadata_').callsFake(creative => {
-          const metaData = AmpA4A.prototype.getAmpAdMetadata_(creative);
+        sandbox.stub(a4a, 'getAmpAdMetadata').callsFake(creative => {
+          const metaData = AmpA4A.prototype.getAmpAdMetadata(creative);
           metaData.images = ['https://prefetch.me.com?a=b', 'http://do.not.prefetch.me.com?c=d',
             'https://prefetch.metoo.com?e=f'];
           return metaData;
@@ -1491,7 +1491,7 @@ describe('amp-a4a', () => {
     });
   });
 
-  describe('#getAmpAdMetadata_', () => {
+  describe('#getAmpAdMetadata', () => {
     let a4a;
     let metaData;
     beforeEach(() => {
@@ -1510,7 +1510,7 @@ describe('amp-a4a', () => {
       });
     });
     it('should parse metadata', () => {
-      const actual = a4a.getAmpAdMetadata_(buildCreativeString(metaData));
+      const actual = a4a.getAmpAdMetadata(buildCreativeString(metaData));
       const expected = Object.assign(metaData, {
         minifiedCreative: testFragments.minimalDocOneStyleSrcDoc,
       });
@@ -1522,7 +1522,7 @@ describe('amp-a4a', () => {
       const creative = buildCreativeString(metaData).replace(
           '<script type="application/json" amp-ad-metadata>',
           '<script type=application/json amp-ad-metadata>');
-      const actual = a4a.getAmpAdMetadata_(creative);
+      const actual = a4a.getAmpAdMetadata(creative);
       const expected = Object.assign({
         minifiedCreative: testFragments.minimalDocOneStyleSrcDoc,
       }, metaData);
@@ -1532,35 +1532,35 @@ describe('amp-a4a', () => {
       const creative = buildCreativeString(metaData).replace(
           '<script type="application/json" amp-ad-metadata>',
           '<script type=application/json" amp-ad-metadata>');
-      expect(a4a.getAmpAdMetadata_(creative)).to.be.null;
+      expect(a4a.getAmpAdMetadata(creative)).to.be.null;
     });
 
     it('should return null if missing ampRuntimeUtf16CharOffsets', () => {
       const baseTestDoc = testFragments.minimalDocOneStyle;
       const splicePoint = baseTestDoc.indexOf('</body>');
-      expect(a4a.getAmpAdMetadata_(
+      expect(a4a.getAmpAdMetadata(
           baseTestDoc.slice(0, splicePoint) +
         '<script type="application/json" amp-ad-metadata></script>' +
         baseTestDoc.slice(splicePoint))).to.be.null;
     });
     it('should return null if invalid extensions', () => {
       metaData.customElementExtensions = 'amp-vine';
-      expect(a4a.getAmpAdMetadata_(buildCreativeString(metaData))).to.be.null;
+      expect(a4a.getAmpAdMetadata(buildCreativeString(metaData))).to.be.null;
     });
     it('should return null if non-array stylesheets', () => {
       metaData.customStylesheets = 'https://fonts.googleapis.com/css?foobar';
-      expect(a4a.getAmpAdMetadata_(buildCreativeString(metaData))).to.be.null;
+      expect(a4a.getAmpAdMetadata(buildCreativeString(metaData))).to.be.null;
     });
     it('should return null if invalid stylesheet object', () => {
       metaData.customStylesheets = [
         {href: 'https://fonts.googleapis.com/css?foobar'},
         {foo: 'https://fonts.com/css?helloworld'},
       ];
-      expect(a4a.getAmpAdMetadata_(buildCreativeString(metaData))).to.be.null;
+      expect(a4a.getAmpAdMetadata(buildCreativeString(metaData))).to.be.null;
     });
     it('should not include amp images if not an array', () => {
       metaData.images = 'https://foo.com';
-      const actual = a4a.getAmpAdMetadata_(buildCreativeString(metaData));
+      const actual = a4a.getAmpAdMetadata(buildCreativeString(metaData));
       const expected = Object.assign({
         minifiedCreative: testFragments.minimalDocOneStyleSrcDoc,
       }, metaData);
@@ -1569,7 +1569,7 @@ describe('amp-a4a', () => {
     });
     it('should tolerate missing images', () => {
       delete metaData.images;
-      const actual = a4a.getAmpAdMetadata_(buildCreativeString(metaData));
+      const actual = a4a.getAmpAdMetadata(buildCreativeString(metaData));
       const expected = Object.assign({
         minifiedCreative: testFragments.minimalDocOneStyleSrcDoc,
       }, metaData);
@@ -1580,7 +1580,7 @@ describe('amp-a4a', () => {
       while (metaData.images.length < 10) {
         metaData.images.push('https://another.image.com?abc=def');
       }
-      expect(a4a.getAmpAdMetadata_(buildCreativeString(metaData)).images.length)
+      expect(a4a.getAmpAdMetadata(buildCreativeString(metaData)).images.length)
           .to.equal(5);
     });
     // FAILURE cases here
@@ -1619,7 +1619,7 @@ describe('amp-a4a', () => {
   });
 
   describe('#renderAmpCreative_', () => {
-    const metaData = AmpA4A.prototype.getAmpAdMetadata_(buildCreativeString());
+    const metaData = AmpA4A.prototype.getAmpAdMetadata(buildCreativeString());
     let a4aElement;
     let a4a;
     beforeEach(() => {

--- a/extensions/amp-ad-network-adzerk-impl/0.1/amp-ad-network-adzerk-impl.js
+++ b/extensions/amp-ad-network-adzerk-impl/0.1/amp-ad-network-adzerk-impl.js
@@ -1,0 +1,272 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  AmpA4A,
+  NO_CONTENT_RESPONSE,
+  CreativeMetaDataDef,
+} from '../../amp-a4a/0.1/amp-a4a';
+import {parse as mustacheParse, render as mustacheRender,
+  setUnescapedSanitizier} from '../../../third_party/mustache/mustache';
+import {urls} from '../../../src/config';
+import {tryParseJson} from '../../../src/json';
+import {dev} from '../../../src/log';
+import {getMode} from '../../../src/mode';
+import {sanitizeHtml, sanitizeFormattingHtml} from '../../../src/sanitizer';
+import {Services} from '../../../src/services';
+import {utf8Decode, utf8Encode} from '../../../src/utils/bytes';
+
+/** @type {string} */
+const TAG = 'amp-ad-network-adzerk-impl';
+
+/** @visibleForTesting @type {string} */
+export const AMP_TEMPLATED_CREATIVE_HEADER_NAME = 'AMP-template-amp-creative';
+
+/** @typedef {{
+      ampCreativeTemplateId: number,
+      templateMacroValues: (JsonObject|undefined),
+    }} */
+let AmpTemplateCreativeDef;
+
+/** @typedef {{
+      doc: !Document,
+      metadata: !CreativeMetaDataDef,
+      access: number
+    }} */
+let CachedTemplateDef;
+
+/** @private {!Object<number, !Promise<!CachedTemplateDef>>} */
+const TemplateCache = {};
+
+/** @private {!Object<string, string|boolean>} */
+const TEMPLATE_CORS_CONFIG = {
+  mode: 'cors',
+  method: 'GET',
+  // This should be cached across publisher domains, so don't append
+  // __amp_source_origin to the URL.
+  ampCors: false,
+  credentials: 'omit',
+};
+
+// Configure inline sanitizer for unescaped values.
+setUnescapedSanitizier(sanitizeFormattingHtml);
+
+/**
+ * Fast Fetch implementation for AdZerk network that allows AMP creative
+ * preferential render via AMP cache stored template expansion using
+ * amp-mustache.  AMP creative response will consist of the following JSON
+ * object with two fields:
+ *
+ * - ampCreativeTemplateId: number value for template ID.  Template must already
+ *    have been stored in the AMP cache.
+ * - templateMacroValues: optional JSON object mapping of macro name to its
+ *    string value used to dynamically update the template
+ *
+ * Additionally, ad response must include header indicating AMP creative
+ * template response: AMP-template-amp-creative: true
+ *
+ * Failure to properly fetch or expand template will result in slot collapsing.
+ * Non-AMP creatives (defined as those not including AMP-template-amp-creative)
+ * will be rendered via cross domain frame.
+ */
+export class AmpAdNetworkAdzerkImpl extends AmpA4A {
+
+  /**
+   * @param {!Element} element
+   */
+  constructor(element) {
+    super(element);
+
+    /** @private {?CreativeMetaDataDef} */
+    this.creativeMetaData_ = null;
+  };
+
+  /**
+   * Validate the tag parameters.  If invalid, ad ad will not be displayed.
+   * @override
+   */
+  isValidElement() {
+    if (!this.win['DOMParser']) {
+      dev().error(TAG, 'Missing DOM Parser');
+      return false;
+    }
+    return !!this.getAdUrl();
+  }
+
+  /** @override */
+  getSigningServiceNames() {
+    // Does not utilize crypto signature based AMP creative validation.
+    // TODO(keithwrightbos): move import of crypto validation into
+    // implementations, reducing adzerk binary size.
+    return [];
+  }
+
+  /** @override */
+  getAdUrl() {
+    const src = this.element.getAttribute('src');
+    if (!/^https:\/\/adzerk.com\?id=\d+$/i.test(src)) {
+      return '';
+    }
+    if (getMode(this.win).localDev) {
+      return `http://ads.localhost:${this.win.location.port}` +
+        '/adzerk/' + /^https:\/\/adzerk.com\?id=(\d+)/.exec(src)[1];
+    }
+    // TODO(adzerk): specify expected src path.
+    return /^https:\/\/adzerk.com\?id=\d+$/i.test(src) ? src : '';
+  }
+
+  /**
+   * Fetch and parse template from AMP cache.  Result is stored in global in
+   * order to reduce overhead when template is used multiple times.
+   * @param {number} templateId
+   * @return {!Promise<!CachedTemplateDef>}
+   * @private
+   */
+  retrieveTemplate_(templateId) {
+    // Retrieve template from AMP cache.
+    TemplateCache[templateId] = TemplateCache[templateId] ||
+        Services.xhrFor(this.win)
+            .fetchText(getMode(this.win).localDev ?
+              `http://ads.localhost:${this.win.location.port}` +
+                `/a4a_template/adzerk/${templateId}` :
+              `${urls.cdn}/c/s/adzerk/${templateId}`,
+            TEMPLATE_CORS_CONFIG)
+            .then(response => response.text())
+            .then(template => this.parseTemplate_(template));
+    TemplateCache[templateId].access = Date.now();
+    const cacheKeys = /**@type {!Array<number>}*/(Object.keys(TemplateCache));
+    if (cacheKeys.length > 5) {
+      dev().warn(TAG, 'Trimming template cache');
+      // Evict oldest entry to ensure memory usage is minimized.
+      cacheKeys.sort((a, b) =>
+        TemplateCache[b].access - TemplateCache[a].access);
+      delete TemplateCache[cacheKeys[cacheKeys.length - 1]];
+    }
+    dev().assert(TemplateCache[templateId]);
+    return TemplateCache[templateId];
+  }
+
+  /**
+   * Extracts metadata from template head used for preferential render.
+   * @param {string} template
+   * @return {!CachedTemplateDef}
+   * @private
+   */
+  parseTemplate_(template) {
+    mustacheParse(template);
+    // TODO(keithwrightbos): this is temporary until AMP cache can be modified
+    // to parse and supply this information as opposed to requiring client
+    // side parsing.  For now build metadata and remove portions of template.
+    // Only the body will be used for mustache expansion.
+    const doc = new DOMParser().parseFromString(template, 'text/html');
+    if (!doc) {
+      throw new Error('Unable to parse template');
+    }
+    const parsedTemplate = {
+      doc,
+      metadata: {
+        // minifiedCreative will be populated using mustache and macro values.
+        minifiedCreative: '',
+        customElementExtensions: [],
+        customStylesheets: [],
+      },
+      access: Date.now(),
+    };
+    Array.prototype.forEach.call(
+        // Scripts can be present within the body as configurations so only
+        // look for those with src attribute for removal (extensions and
+        // runtime).
+        doc.querySelectorAll('script[src]'),
+        element => {
+          const customElement = element.getAttribute('custom-element');
+          if (customElement) {
+            parsedTemplate.metadata.customElementExtensions.push(customElement);
+          }
+          element.parentElement.removeChild(element);
+        });
+    Array.prototype.forEach.call(
+        doc.querySelectorAll('link[rel=stylesheet][href]'),
+        element => {
+          parsedTemplate.metadata.customStylesheets.push({
+            href: element.getAttribute('href'),
+          });
+          element.parentElement.removeChild(element);
+        });
+    Array.prototype.forEach.call(
+        doc.querySelectorAll('style[amp4ads-boilerplate]'),
+        element => element.parentElement.removeChild(element));
+    // TODO(keithwrightbos): support dynamic creation of amp-pixel and
+    // amp-analytics.
+    return parsedTemplate;
+  }
+
+  /** @override */
+  maybeValidateAmpCreative(bytes, headers) {
+    if (headers.get(AMP_TEMPLATED_CREATIVE_HEADER_NAME) !== 'true') {
+      return /**@type {!Promise<(ArrayBuffer|null)>}*/ (Promise.resolve(null));
+    }
+    // Shorthand for: reject promise if current promise chain is out of date.
+    const checkStillCurrent = this.verifyStillCurrent();
+    return utf8Decode(bytes).then(body => {
+      checkStillCurrent();
+      const ampCreativeJson =
+          /** @type {!AmpTemplateCreativeDef} */(tryParseJson(body) || {});
+      if (isNaN(parseInt(ampCreativeJson.ampCreativeTemplateId, 10))) {
+        dev().warn(TAG, 'AMP creative missing/invalid template path',
+            ampCreativeJson);
+        this.forceCollapse();
+        return Promise.reject(NO_CONTENT_RESPONSE);
+      }
+      // TODO(keithwrightbos): macro value validation?  E.g. http invalid?
+      return this.retrieveTemplate_(ampCreativeJson.ampCreativeTemplateId)
+          .then(parsedTemplate => {
+            // Assign copy of cached metadata to local and then build
+            // minifiedCreative by temporarily modifying cached document's
+            // body ensuring that it is reset so that other consumers can
+            // macro.
+            // TODO(keithwrightbos): sanitizeHtml strips out ALL script elements
+            // including those used within extensions (e.g. amp-analytics &
+            // amp-animation).
+            this.creativeMetaData_ = Object.assign({}, parsedTemplate.metadata);
+            const origDocBody = parsedTemplate.doc.body./*OK*/innerHTML;
+            parsedTemplate.doc.body./*OK*/innerHTML =
+                sanitizeHtml(mustacheRender(
+                    parsedTemplate.doc.body./*OK*/innerHTML,
+                    ampCreativeJson.templateMacroValues || {}));
+            this.creativeMetaData_.minifiedCreative =
+                parsedTemplate.doc.documentElement./*OK*/outerHTML;
+            parsedTemplate.doc.body./*OK*/innerHTML = origDocBody;
+            return utf8Encode(this.creativeMetaData_.minifiedCreative);
+          })
+          .catch(error => {
+            dev().warn(TAG, 'Error fetching/expanding template',
+                ampCreativeJson, error);
+            this.forceCollapse();
+            return Promise.reject(NO_CONTENT_RESPONSE);
+          });
+    });
+  }
+
+  /** @override */
+  getAmpAdMetadata(unusedCreative) {
+    return /**@type {?CreativeMetaDataDef}*/(this.creativeMetaData_);
+  }
+}
+
+
+AMP.extension('amp-ad-network-adzerk-impl', '0.1', AMP => {
+  AMP.registerElement('amp-ad-network-adzerk-impl', AmpAdNetworkAdzerkImpl);
+});

--- a/extensions/amp-ad-network-adzerk-impl/0.1/data/101
+++ b/extensions/amp-ad-network-adzerk-impl/0.1/data/101
@@ -1,0 +1,9 @@
+{
+  "ampCreativeTemplateId": 456,
+  "templateMacroValues": {
+    "USER_NAME": "bar",
+    "USER_NUM": 1234,
+    "HTML_CONTENT": "<img src=https://img.com/>",
+    "IMG_SRC": "https://image.slidesharecdn.com/nativeadsguide-161205215856/95/a-native-ads-guide-for-publishers-38-638.jpg?cb=1480975246"
+  }
+}

--- a/extensions/amp-ad-network-adzerk-impl/0.1/data/102
+++ b/extensions/amp-ad-network-adzerk-impl/0.1/data/102
@@ -1,0 +1,6 @@
+{
+  "ampCreativeTemplateId": 789,
+  "templateMacroValues": {
+    "CLOCK_IMG": "../examples/img/clock.jpg"
+  }
+}

--- a/extensions/amp-ad-network-adzerk-impl/0.1/data/1234
+++ b/extensions/amp-ad-network-adzerk-impl/0.1/data/1234
@@ -1,0 +1,9 @@
+{
+  "ampCreativeTemplateId": 456,
+  "templateMacroValues": {
+    "USER_NAME": "foo",
+    "USER_NUM": 9876,
+    "HTML_CONTENT": "<img src=https://img.com/>",
+    "IMG_SRC": "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRESOzSW5espRF3Peen04hLpWZUVL5KY5ig9SYSdI19jN6ty0XB"
+  }
+}

--- a/extensions/amp-ad-network-adzerk-impl/0.1/data/456.template
+++ b/extensions/amp-ad-network-adzerk-impl/0.1/data/456.template
@@ -1,0 +1,18 @@
+<!doctype html>
+<html ⚡4ads>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,minimum-scale=1">
+    <style amp4ads-boilerplate>body{visibility:hidden}</style>
+    <style amp-custom>amp-fit-text {border: solid 1px;font: 500 11px/13px "Raleway";}</style>
+    <script async src="https://cdn.ampproject.org/amp4ads-v0.js"></script>
+    <script async custom-element="amp-fit-text" src="https://cdn.ampproject.org/v0/amp-fit-text-0.1.js"></script>
+    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Raleway">
+  </head>
+  <body>
+    <amp-fit-text width="200" height="40">hello {{USER_NAME}}! {{USER_NUM}}</amp-fit-text><br>
+    Expect encoding {{HTML_CONTENT}}<br>
+    <amp-img src={{IMG_SRC}} height=159 width=318></amp-img><br>
+    Missing {{UNKNOWN}} item
+  </body>
+</html>

--- a/extensions/amp-ad-network-adzerk-impl/0.1/data/789.template
+++ b/extensions/amp-ad-network-adzerk-impl/0.1/data/789.template
@@ -1,0 +1,65 @@
+<!doctype html>
+<html ⚡4ads>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,minimum-scale=1">
+    <style amp4ads-boilerplate>body{visibility:hidden}</style>
+    <script async src="https://cdn.ampproject.org/amp4ads-v0.js"></script>
+    <script async custom-element="amp-animation" src="https://cdn.ampproject.org/v0/amp-animation-0.1.js"></script>
+    <script async custom-element="amp-position-observer" src="https://cdn.ampproject.org/v0/amp-position-observer-0.1.js"></script>
+    <style amp-custom>
+      amp-img img {
+        object-fit: cover;
+      }
+
+      .container {
+        position: relative;
+        height: 100vh;
+        width: 100vw;
+      }
+
+      .clock-hand {
+        position: absolute;
+        width: 2vw;
+        height: 20vw;
+        top: 50%;
+        left: 50%;
+        z-index: 2;
+        background: #FAFAFA;
+        transform-origin: 50% 0%;
+        border-radius: 10px;
+        transform: rotate(-180deg)
+      }
+    </style>
+  </head>
+  <body>
+    <amp-animation id="clockAnim" layout="nodisplay">
+      <script type="application/json">
+      {
+        "duration": "6s",
+        "fill": "both",
+        "direction": "alternate",
+        "animations": [
+          {
+            "target": "clockHand",
+            "keyframes": [
+              { "transform": "rotate(-180deg)" },
+              { "transform": "rotate(0deg)" }
+            ]
+          }
+        ]
+      }
+      </script>
+    </amp-animation>
+    <div class="container">
+      <amp-position-observer
+        intersection-ratios="1"
+        viewport-margins="5vh"
+        on="scroll:clockAnim.seekTo(percent=event.percent)"
+        layout="nodisplay"></amp-position-observer>
+      <amp-img id="clock-bg" layout="fill" src="{{CLOCK_IMG}}">
+      </amp-img>
+      <div id="clockHand" class="clock-hand"></div>
+    </div>
+  </body>
+</html>

--- a/extensions/amp-ad-network-adzerk-impl/0.1/test/test-amp-ad-network-adzerk-impl.js
+++ b/extensions/amp-ad-network-adzerk-impl/0.1/test/test-amp-ad-network-adzerk-impl.js
@@ -1,0 +1,163 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Need the following side-effect import because in actual production code,
+// Fast Fetch impls are always loaded via an AmpAd tag, which means AmpAd is
+// always available for them. However, when we test an impl in isolation,
+// AmpAd is not loaded already, so we need to load it separately.
+import '../../../amp-ad/0.1/amp-ad';
+import {
+  AmpAdNetworkAdzerkImpl,
+  AMP_TEMPLATED_CREATIVE_HEADER_NAME,
+} from '../amp-ad-network-adzerk-impl';
+import {createElementWithAttributes} from '../../../../src/dom';
+import {Xhr} from '../../../../src/service/xhr-impl';
+import {utf8EncodeSync, utf8Decode} from '../../../../src/utils/bytes';
+
+describes.fakeWin('amp-ad-network-adzerk-impl', {amp: true}, env => {
+  let win, doc;
+  let element, impl;
+  let fetchTextMock;
+
+  beforeEach(() => {
+    win = env.win;
+    doc = win.document;
+    fetchTextMock = sandbox.stub(Xhr.prototype, 'fetchText');
+    element = createElementWithAttributes(doc, 'amp-ad', {
+      'type': 'adzerk',
+      'src': 'https://adzerk.com?id=1234',
+      'width': '320',
+      'height': '50',
+    });
+    doc.body.appendChild(element);
+    impl = new AmpAdNetworkAdzerkImpl(element);
+  });
+
+  describe('#getAdUrl', () => {
+    it('should be valid', () => {
+      win['DOMParser'] = true;
+      win.AMP_MODE = {localDev: false};
+      ['https://adzerk.com?id=1234',
+        'https://aDzErK.com?id=1234',
+        'https://adzerk.com?id=9'].forEach(src => {
+        element.setAttribute('src', src);
+        expect(impl.isValidElement()).to.be.true;
+        expect(impl.getAdUrl()).to.equal(src);
+      });
+    });
+
+    it('should not be valid', () => {
+      win['DOMParser'] = true;
+      win.AMP_MODE = {localDev: false};
+      ['http://adzerk.com?id=1234',
+        'https://adzerk.com?id=a',
+        'https://www.adzerk.com?id=1234',
+        'https://adzerk.com?id=1234&a=b',
+        'foohttps://adzer.com?id=1234'].forEach(src => {
+        element.setAttribute('src', src);
+        expect(impl.isValidElement()).to.be.false;
+        expect(impl.getAdUrl()).to.equal('');
+      });
+    });
+
+    it('should not be valid if missing DOMParser', () => {
+      win['DOMParser'] = false;
+      win.AMP_MODE = {localDev: false};
+      expect(impl.isValidElement()).to.be.false;
+    });
+  });
+
+  describe('#getSigningServiceNames', () => {
+    it('should be empty array', () => {
+      expect(impl.getSigningServiceNames()).to.deep.equal([]);
+    });
+  });
+
+  describe('#maybeValidateAmpCreative', () => {
+    it('should properly inflate template', () => {
+      const adResponseBody = {
+        ampCreativeTemplateId: 456,
+        templateMacroValues: {
+          USER_NAME: 'some_user',
+          USER_NUM: 9876,
+          HTML_CONTENT: '<img src=https://img.com/>',
+          IMG_SRC: 'https://some.img.com?a=b',
+        },
+      };
+      const template = '<!doctype html>' +
+          '<html ⚡4ads><head>' +
+          '<meta charset="utf-8">' +
+          '<meta name="viewport" content="width=device-width,' +
+          'minimum-scale=1">' +
+          '<style amp4ads-boilerplate>body{visibility:hidden}</style>' +
+          '<style amp-custom>amp-fit-text: {border: 1px;}</style>' +
+          '<script async src="https://cdn.ampproject.org/amp4ads-v0.js">' +
+          '</script>' +
+          '<script async custom-element="amp-fit-text" ' +
+          'src="https://cdn.ampproject.org/v0/amp-fit-text-0.1.js"></script>' +
+          '<link rel="stylesheet" type="text/css" ' +
+          'href="https://fonts.googleapis.com/css?family=Raleway">' +
+        '</head>' +
+        '<body>' +
+          '<amp-fit-text width="300" height="200">hello {{USER_NAME}}! ' +
+          '{{USER_NUM}}</amp-fit-text>' +
+          'Expect encoding {{HTML_CONTENT}}' +
+          '<amp-img src={{IMG_SRC}}/>' +
+          'Missing {{UNKNOWN}} item' +
+        '</body>' +
+        '</html>';
+      fetchTextMock.withArgs(
+          'https://cdn.ampproject.org/c/s/adzerk/456',
+          {
+            mode: 'cors',
+            method: 'GET',
+            ampCors: false,
+            credentials: 'omit',
+          }).returns(Promise.resolve(
+          {
+            headers: {},
+            text: () => template,
+          }));
+      return impl.maybeValidateAmpCreative(
+          utf8EncodeSync(JSON.stringify(adResponseBody)).buffer,
+          {
+            get: name => {
+              expect(name).to.equal(AMP_TEMPLATED_CREATIVE_HEADER_NAME);
+              return 'true';
+            },
+          },
+          () => {})
+          .then(buffer => utf8Decode(buffer))
+          .then(creative => {
+            expect(creative).to.equal(
+                '<html ⚡4ads=""><head><meta charset="utf-8">' +
+              '<meta name="viewport" content="width=device-width,' +
+              'minimum-scale=1"><style amp-custom="">amp-fit-text: ' +
+              '{border: 1px;}</style></head><body><amp-fit-text ' +
+              'width="300" height="200">hello some_user! 9876</amp-fit-text>' +
+              'Expect encoding &lt;img src=https://img.com/&gt;<amp-img ' +
+              'src="https://some.img.com/?a=b/">Missing  item</amp-img>' +
+              '</body></html>');
+            expect(impl.getAmpAdMetadata()).to.jsonEqual({
+              minifiedCreative: creative,
+              customElementExtensions: ['amp-fit-text'],
+              customStylesheets: [
+                {'href': 'https://fonts.googleapis.com/css?family=Raleway'}],
+            });
+          });
+    });
+  });
+});

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -859,7 +859,7 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
         impl.element.setAttribute('width', width);
         return Promise.resolve();
       });
-      sandbox.stub(impl, 'getAmpAdMetadata_').callsFake(() => {
+      sandbox.stub(impl, 'getAmpAdMetadata').callsFake(() => {
         return {
           customElementExtensions: [],
           minifiedCreative: '<html><body>Hello, World!</body></html>',

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -59,6 +59,7 @@ declareExtension('amp-access-laterpay', '0.1', true);
 declareExtension('amp-accordion', '0.1', false);
 declareExtension('amp-ad', '0.1', true);
 declareExtension('amp-ad-network-adsense-impl', 0.1, false);
+declareExtension('amp-ad-network-adzerk-impl', 0.1, false);
 declareExtension('amp-ad-network-doubleclick-impl', 0.1, false);
 declareExtension('amp-ad-network-fake-impl', 0.1, false);
 declareExtension('amp-ad-network-triplelift-impl', 0.1, false);


### PR DESCRIPTION
Proof of concept in order to determine feasibility of template based AMP creatives for adzerk.  AMP cache portions TBD.

AMP ad Fast Fetch implementation for adzerk network allowing for preferential render via mustache template.   Template must have previously been pushed to AMP cache (yet to be implemented) in order to guarantee it is A4A valid.

Items to be addressed:
- Consult with Adzerk to determine expected publisher tag implementation and resulting ad request url.  Currently assumes single attribute named "src" whose format matches: https://adzerk.com\?id=#
- Does not yet allow for automatic creation of amp-pixel and amp-analytics from known macro template values
- sanitizeHtml strips out all <script> tags within body causing extensions that utilize script for configuration to not work properly (e.g. amp-animations & amp-analytics)
- Does not leverage template service.  This was intentional design decision but could be altered.
- AMP template is "consumed" by the client for preferential render using DOMParser in order to determine fonts/extensions and remove unnecessary portions of head (scripts, boilerplate).  This could be moved server side as part of AMP cache integration.
- Additional test coverage.

/cc @ampproject/a4a 