### PR TITLE
Progress bar styling fixes

### DIFF
--- a/extensions/amp-story/0.1/amp-story.css
+++ b/extensions/amp-story/0.1/amp-story.css
@@ -144,6 +144,9 @@ amp-story[standalone]:fullscreen {
   margin: 0 2px!important;
   overflow: hidden!important;
   width: 100% !important;
+
+  /* An empty image works around Safari not clipping rounded corners. */
+  -webkit-mask-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAA5JREFUeNpiYGBgAAgwAAAEAAGbA+oJAAAAAElFTkSuQmCC) !important;
 }
 
 .i-amphtml-story-page-progress-value {

--- a/extensions/amp-story/0.1/amp-story.css
+++ b/extensions/amp-story/0.1/amp-story.css
@@ -145,7 +145,8 @@ amp-story[standalone]:fullscreen {
   overflow: hidden!important;
   width: 100% !important;
 
-  /* An empty image works around Safari not clipping rounded corners. */
+  /* An empty mask image works around Safari not clipping rounded corners.
+   * https://stackoverflow.com/questions/5736503/how-to-make-css3-rounded-corners-hide-overflow-in-chrome-opera/10296258#10296258 */
   -webkit-mask-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAA5JREFUeNpiYGBgAAgwAAAEAAGbA+oJAAAAAElFTkSuQmCC) !important;
 }
 
@@ -157,7 +158,7 @@ amp-story[standalone]:fullscreen {
   width: 100% !important;
   transform: translateZ(0) scaleX(0) !important; /* 0-width by default */
   transform-origin: left !important;
-  will-change: transform !important;
+  will-change: transform, transition !important;
 }
 
 [dir=rtl] .i-amphtml-story-progress-value {

--- a/extensions/amp-story/0.1/amp-story.css
+++ b/extensions/amp-story/0.1/amp-story.css
@@ -156,7 +156,6 @@ amp-story[standalone]:fullscreen {
   height: 100% !important;
   width: 100% !important;
   transform: translateZ(0) scaleX(0) !important; /* 0-width by default */
-  transition: transform 0.2s ease !important;
   transform-origin: left !important;
   will-change: transform !important;
 }

--- a/extensions/amp-story/0.1/progress-bar.js
+++ b/extensions/amp-story/0.1/progress-bar.js
@@ -19,6 +19,10 @@ import {scopedQuerySelector} from '../../../src/dom';
 import {Services} from '../../../src/services';
 
 
+/** @const {string} */
+const TRANSITION = 'transform 0.2s ease';
+
+
 /**
  * Progress bar for <amp-story>.
  */
@@ -110,13 +114,11 @@ export class ProgressBar {
     this.assertValidPageIndex_(pageIndex);
     for (let i = 0; i < this.pageCount_; i++) {
       if (i < pageIndex) {
-        this.updateProgress(i, 1.0);
-      } else if (i > pageIndex) {
-        this.updateProgress(i, 0.0);
+        this.updateProgress(i, 1.0, /* transition */ i == pageIndex - 1);
       } else {
         // The active page manages its own progress by firing PAGE_PROGRESS
         // events to amp-story.
-        this.updateProgress(i, 0.0);
+        this.updateProgress(i, 0.0, /* transition */ pageIndex != 0);
       }
     }
   }
@@ -128,7 +130,9 @@ export class ProgressBar {
    *     progress of the current page.
    * @public
    */
-  updateProgress(pageIndex, progress) {
+  updateProgress(pageIndex, progress, transition = true) {
+    this.activePageIndex_ = pageIndex;
+
     this.assertValidPageIndex_(pageIndex);
     // Offset the index by 1, since nth-child indices start at 1 while
     // JavaScript indices start at 0.
@@ -139,6 +143,7 @@ export class ProgressBar {
     this.vsync_.mutate(() => {
       setImportantStyles(dev().assertElement(progressEl), {
         'transform': scale(`${progress},1`),
+        'transition': transition ? TRANSITION : 'none',
       });
     });
   }

--- a/extensions/amp-story/0.1/progress-bar.js
+++ b/extensions/amp-story/0.1/progress-bar.js
@@ -43,6 +43,9 @@ export class ProgressBar {
     /** @private {number} */
     this.pageCount_ = 0;
 
+    /** @private {number} */
+    this.activePageIndex_ = 0;
+
     /** @private @const {!../../../src/service/vsync-impl.Vsync} */
     this.vsync_ = Services.vsyncFor(this.win_);
   }
@@ -111,12 +114,12 @@ export class ProgressBar {
     this.assertValidPageIndex_(pageIndex);
     for (let i = 0; i < this.pageCount_; i++) {
       if (i < pageIndex) {
-        this.updateProgress(i, 1.0, /* transition */ i == pageIndex - 1);
+        this.updateProgress(i, 1.0, /* withTransition */ i == pageIndex - 1);
       } else {
         // The active page manages its own progress by firing PAGE_PROGRESS
         // events to amp-story.
-        this.updateProgress(i, 0.0, /* transition */ (
-            pageIndex != 0 && this.activePageIndex_ != 1));
+        this.updateProgress(i, 0.0, /* withTransition */ (
+          pageIndex != 0 && this.activePageIndex_ != 1));
       }
     }
   }
@@ -126,9 +129,10 @@ export class ProgressBar {
    *     changed.
    * @param {number} progress A number from 0.0 to 1.0, representing the
    *     progress of the current page.
+   * @param {boolean=} withTransition
    * @public
    */
-  updateProgress(pageIndex, progress, transition = true) {
+  updateProgress(pageIndex, progress, withTransition = true) {
     this.assertValidPageIndex_(pageIndex);
 
     this.activePageIndex_ = pageIndex;
@@ -142,7 +146,7 @@ export class ProgressBar {
     this.vsync_.mutate(() => {
       setImportantStyles(dev().assertElement(progressEl), {
         'transform': scale(`${progress},1`),
-        'transition': transition ? TRANSITION : 'none',
+        'transition': withTransition ? TRANSITION : 'none',
       });
     });
   }

--- a/extensions/amp-story/0.1/progress-bar.js
+++ b/extensions/amp-story/0.1/progress-bar.js
@@ -41,9 +41,6 @@ export class ProgressBar {
     this.root_ = null;
 
     /** @private {number} */
-    this.activePageIndex_ = -1;
-
-    /** @private {number} */
     this.pageCount_ = 0;
 
     /** @private @const {!../../../src/service/vsync-impl.Vsync} */
@@ -118,7 +115,8 @@ export class ProgressBar {
       } else {
         // The active page manages its own progress by firing PAGE_PROGRESS
         // events to amp-story.
-        this.updateProgress(i, 0.0, /* transition */ pageIndex != 0);
+        this.updateProgress(i, 0.0, /* transition */ (
+            pageIndex != 0 && this.activePageIndex_ != 1));
       }
     }
   }
@@ -131,9 +129,10 @@ export class ProgressBar {
    * @public
    */
   updateProgress(pageIndex, progress, transition = true) {
+    this.assertValidPageIndex_(pageIndex);
+
     this.activePageIndex_ = pageIndex;
 
-    this.assertValidPageIndex_(pageIndex);
     // Offset the index by 1, since nth-child indices start at 1 while
     // JavaScript indices start at 0.
     const nthChildIndex = pageIndex + 1;


### PR DESCRIPTION
1. Disables transition when skipping or advancing before transition is over. This fixes cases where more than one bar would be animated at a time.

2. Works around an issue in which Safari would not clip the rounded corners for the contained bar element.