### PR TITLE
Update amp-image-lightbox default object-fit and zoom upper bound for extreme aspect ratios

### DIFF
--- a/extensions/amp-image-lightbox/0.1/amp-image-lightbox.js
+++ b/extensions/amp-image-lightbox/0.1/amp-image-lightbox.js
@@ -58,7 +58,7 @@ const EXIT_CURVE_ = bezierCurve(0.4, 0, 0.2, 1);
 /** @private @const {!../../../src/curve.CurveDef} */
 const PAN_ZOOM_CURVE_ = bezierCurve(0.4, 0, 0.2, 1.4);
 
-/** @private @const {!number} */
+/** @private @const {number} */
 const DEFAULT_MAX_SCALE = 2;
 
 /**

--- a/extensions/amp-image-lightbox/0.1/amp-image-lightbox.js
+++ b/extensions/amp-image-lightbox/0.1/amp-image-lightbox.js
@@ -259,16 +259,21 @@ export class ImageViewer {
   measure() {
     this.viewerBox_ = layoutRectFromDomRect(this.viewer_
         ./*OK*/getBoundingClientRect());
-
-    const sf = Math.min(this.viewerBox_.width / this.sourceWidth_,
-        this.viewerBox_.height / this.sourceHeight_);
-    let width = Math.min(this.sourceWidth_ * sf, this.viewerBox_.width);
-    let height = Math.min(this.sourceHeight_ * sf, this.viewerBox_.height);
+    const sourceAspectRatio = this.sourceWidth_ / this.sourceHeight_;
+    let height = Math.min(
+        this.viewerBox_.width / sourceAspectRatio,
+        this.viewerBox_.height
+    );
+    let width = Math.min(
+        this.viewerBox_.height * sourceAspectRatio,
+        this.viewerBox_.width
+    );
 
     // TODO(dvoytenko): This is to reduce very small expansions that often
     // look like a stutter. To be evaluated if this is still the right
     // idea.
-    if (width - this.sourceWidth_ <= 16) {
+    if (Math.abs(width - this.sourceWidth_) <= 16
+        && Math.abs(height - this.sourceHeight_) <= 16) {
       width = this.sourceWidth_;
       height = this.sourceHeight_;
     }

--- a/extensions/amp-image-lightbox/0.1/amp-image-lightbox.js
+++ b/extensions/amp-image-lightbox/0.1/amp-image-lightbox.js
@@ -58,6 +58,8 @@ const EXIT_CURVE_ = bezierCurve(0.4, 0, 0.2, 1);
 /** @private @const {!../../../src/curve.CurveDef} */
 const PAN_ZOOM_CURVE_ = bezierCurve(0.4, 0, 0.2, 1.4);
 
+/** @private @const {!number} */
+const DEFAULT_MAX_SCALE = 2;
 
 /**
  * This class is responsible providing all operations necessary for viewing
@@ -122,7 +124,7 @@ export class ImageViewer {
     /** @private {number} */
     this.minScale_ = 1;
     /** @private {number} */
-    this.maxScale_ = 2;
+    this.maxScale_ = DEFAULT_MAX_SCALE;
 
     /** @private {number} */
     this.startX_ = 0;
@@ -290,6 +292,14 @@ export class ImageViewer {
       width: st.px(this.imageBox_.width),
       height: st.px(this.imageBox_.height),
     });
+
+    // If aspect ratio is off by too much, adjust max scale
+    const viewerBoxRatio = this.viewerBox_.width / this.viewerBox_.height;
+    const maxScale = Math.max(
+        viewerBoxRatio / sourceAspectRatio,
+        sourceAspectRatio / viewerBoxRatio
+    );
+    this.maxScale_ = Math.max(DEFAULT_MAX_SCALE, maxScale);
 
     // Reset zoom and pan.
     this.startScale_ = this.scale_ = 1;

--- a/test/manual/amp-image-lightbox.amp.html
+++ b/test/manual/amp-image-lightbox.amp.html
@@ -120,6 +120,20 @@
     Iisque rationibus consetetur in cum, quo unum nulla legere ut. Simul numquam saperet no sit.
   </div>
 
+  <div>
+      <amp-img id="wide_image"
+      src="https://picsum.photos/4000/300"
+      width=4000 height=300 layout="responsive"
+      aria-describedby="img1-desc" role="button" tabindex="0"
+      on="tap:image-lightbox1"></amp-img>
+
+      <amp-img id="long_image"
+      src="https://picsum.photos/300/4000"
+      width=300 height=4000 layout="responsive"
+      aria-describedby="img1-desc" role="button" tabindex="0"
+      on="tap:image-lightbox1"></amp-img>
+  </div>
+
   <p>
     Lorem ipsum dolor sit amet, has nisl nihil convenire et, vim at aeque inermis reprehendunt. Propriae tincidunt id nec, elit nusquam te mea, ius noster platonem in. Mea an idque minim, sit sale deleniti apeirian et. Omnium legendos tractatos cu mea. Vix in stet dolorem accusamus. Iisque rationibus consetetur in cum, quo unum nulla legere ut. Simul numquam saperet no sit.
   </p>


### PR DESCRIPTION
Addresses #12580 (partial fix for #12519). From issue: 

1. Port #12440 to amp-image-lightbox, which opens lightbox images in object fit.
2. Re-adjust the Zoom upper bound so that it is the max of our current default constant and whatever zoom factor necessary to achieve object-fit: cover.