### PR TITLE
amp-bind: Add class bindings support for SVG tags

### DIFF
--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -845,9 +845,9 @@ export class Bind {
           }
         }
         if (Array.isArray(newValue) || typeof newValue === 'string') {
-          element.className = ampClasses.concat(newValue).join(' ');
+          element.setAttribute('class', ampClasses.concat(newValue).join(' '));
         } else if (newValue === null) {
-          element.className = ampClasses.join(' ');
+          element.setAttribute('class', ampClasses.join(' '));
         } else {
           const err = user().createError(
               `${TAG}: "${newValue}" is not a valid result for [class].`);

--- a/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
@@ -379,6 +379,31 @@ describe.configure().ifNewChrome().run('Bind', function() {
       });
     });
 
+    it('should support binding to CSS classes with a null value', () => {
+      const element = createElement(env, container, '[class]="null"');
+      expect(toArray(element.classList)).to.deep.equal([]);
+      return onBindReadyAndSetState(env, bind, {}).then(() => {
+        expect(toArray(element.classList)).to.deep.equal([]);
+      });
+    });
+
+    it('should support binding to CSS classes for svg tags', () => {
+      const element = createElement(
+          env, container, '[class]="[\'abc\']"', 'svg');
+      expect(toArray(element.classList)).to.deep.equal([]);
+      return onBindReadyAndSetState(env, bind, {}).then(() => {
+        expect(toArray(element.classList)).to.deep.equal(['abc']);
+      });
+    });
+
+    it('supports binding to CSS classes for svg tags with a null value', () => {
+      const element = createElement(env, container, '[class]="null"', 'svg');
+      expect(toArray(element.classList)).to.deep.equal([]);
+      return onBindReadyAndSetState(env, bind, {}).then(() => {
+        expect(toArray(element.classList)).to.deep.equal([]);
+      });
+    });
+
     it('should support parsing exprs in setStateWithExpression()', () => {
       const element = createElement(env, container, '[text]="onePlusOne"');
       expect(element.textContent).to.equal('');


### PR DESCRIPTION
Addresses issue #12635.

 - The `className` property for `SVG` tags are different from the usual `className` property. Setting the className for `SVG`s did not change the actual class attribute.