### PR TITLE
Render validator test case output inline.

### DIFF
--- a/extensions/amp-3q-player/0.1/test/validator-amp-3q-player.out
+++ b/extensions/amp-3q-player/0.1/test/validator-amp-3q-player.out
@@ -1,2 +1,50 @@
 FAIL
+|  <!--
+|    Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests for the amp-3q-player tag. See the inline comments.
+|  -->
+|  <!DOCTYPE html>
+|  <html amp lang="en">
+|    <head>
+|      <meta charset="utf-8">
+|      <link rel="canonical" href="./regular-html-version.html">
+|      <meta name="viewport" content="width=device-width,minimum-scale=1">
+|      <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|      <script async custom-element="amp-3q-player" src="https://cdn.ampproject.org/v0/amp-3q-player-latest.js"></script>
+|      <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    </head>
+|    <body>
+|  
+|      <!-- valid -->
+|      <amp-3q-player
+|        data-id="c8dbe7f4-7f7f-11e6-a407-0cc47a188158"
+|        height=360
+|        width=640
+|        layout="responsive">
+|      </amp-3q-player>
+|  
+|      <!-- invalid, needs data-id -->
+|      <amp-3q-player
+>>     ^~~~~~~~~
 amp-3q-player/0.1/test/validator-amp-3q-player.html:41:4 The mandatory attribute 'data-id' is missing in tag 'amp-3q-player'. (see https://www.ampproject.org/docs/reference/components/amp-3q-player) [AMP_TAG_PROBLEM]
+|        height=360
+|        width=640
+|        layout="responsive">
+|      </amp-3q-player>
+|    </body>
+|  </html>

--- a/extensions/amp-access-laterpay/0.1/test/validator-amp-access-laterpay.out
+++ b/extensions/amp-access-laterpay/0.1/test/validator-amp-access-laterpay.out
@@ -1,1 +1,70 @@
 PASS
+|  <!--
+|    Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    This tests for amp-access syntax.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <script async custom-element="amp-access" src="https://cdn.ampproject.org/v0/amp-access-0.1.js"></script>
+|    <script async custom-element="amp-access-laterpay" src="https://cdn.ampproject.org/v0/amp-access-laterpay-0.1.js"></script>
+|    <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
+|    <script async custom-element="amp-youtube" src="https://cdn.ampproject.org/v0/amp-youtube-0.1.js"></script>
+|    <script id="amp-access" type="application/json">
+|      {
+|        "contents": "currently untested",
+|        "laterpay": {},
+|      }
+|    </script>
+|  </head>
+|  <body>
+|  Hello, world.
+|  
+|  <!-- amp-access attributes should be allowed on both valid amp elements
+|       as well as valid html elements -->
+|  <amp-youtube
+|      width="480" height="270"
+|      data-videoid="dQw4w9WgXcQ"
+|      amp-access="lemur">
+|  </amp-youtube>
+|  <p amp-access="lemur"></p>
+|  <noscript>
+|    <img src="https://example.com/" amp-access="lemur" />
+|  </noscript>
+|  
+|  <!-- test some other attributes -->
+|  <div amp-access="lemur"
+|       amp-access-loading="lemur"
+|       amp-access-loader="lemur"
+|       amp-access-template="lemur"
+|       amp-access-off="lemur"
+|       amp-access-on="lemur"
+|       amp-access-show="lemur"
+|       amp-access-hide="lemur"
+|       amp-access-style="lemur"
+|       amp-access-behavior="lemur"
+|       amp-access-id="lemur">
+|  </div>
+|  
+|  </body>
+|  </html>

--- a/extensions/amp-access/0.1/test/validator-amp-access-missing-extension.out
+++ b/extensions/amp-access/0.1/test/validator-amp-access-missing-extension.out
@@ -1,2 +1,44 @@
 FAIL
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    amp-access is unusual in that it's extension can actually be present in
+|    the document below the usage, since the usage can be in the head. Here
+|    we test that we are verifying that the extension is present.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
+|    <script async custom-element="amp-youtube" src="https://cdn.ampproject.org/v0/amp-youtube-0.1.js"></script>
+|    <script id="amp-access" type="application/json">
+>>   ^~~~~~~~~
 amp-access/0.1/test/validator-amp-access-missing-extension.html:32:2 The tag 'amp-access extension .json script' requires including the 'amp-access' extension JavaScript. (see https://www.ampproject.org/docs/reference/components/amp-access) [AMP_TAG_PROBLEM]
+|      {
+|        "contents": "currently untested"
+|      }
+|    </script>
+|  </head>
+|  <body>
+|  Hello, world.
+|  </body>
+|  </html>

--- a/extensions/amp-access/0.1/test/validator-amp-access.out
+++ b/extensions/amp-access/0.1/test/validator-amp-access.out
@@ -1,1 +1,68 @@
 PASS
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    This tests for amp-access syntax.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <script async custom-element="amp-access" src="https://cdn.ampproject.org/v0/amp-access-0.1.js"></script>
+|    <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
+|    <script async custom-element="amp-youtube" src="https://cdn.ampproject.org/v0/amp-youtube-0.1.js"></script>
+|    <script id="amp-access" type="application/json">
+|      {
+|        "contents": "currently untested"
+|      }
+|    </script>
+|  </head>
+|  <body>
+|  Hello, world.
+|  
+|  <!-- amp-access attributes should be allowed on both valid amp elements
+|       as well as valid html elements -->
+|  <amp-youtube
+|      width="480" height="270"
+|      data-videoid="dQw4w9WgXcQ"
+|      amp-access="lemur">
+|  </amp-youtube>
+|  <p amp-access="lemur"></p>
+|  <noscript>
+|    <img src="https://example.com/" amp-access="lemur" />
+|  </noscript>
+|  
+|  <!-- test some other attributes -->
+|  <span amp-access="lemur"
+|       amp-access-loading="lemur"
+|       amp-access-loader="lemur"
+|       amp-access-template="lemur"
+|       amp-access-off="lemur"
+|       amp-access-on="lemur"
+|       amp-access-show="lemur"
+|       amp-access-hide="lemur"
+|       amp-access-style="lemur"
+|       amp-access-behavior="lemur"
+|       amp-access-id="lemur">
+|  </span>
+|  
+|  </body>
+|  </html>

--- a/extensions/amp-accordion/0.1/test/validator-amp-accordion.out
+++ b/extensions/amp-accordion/0.1/test/validator-amp-accordion.out
@@ -1,5 +1,81 @@
 FAIL
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests amp-accordion.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <script async custom-element="amp-accordion" src="https://cdn.ampproject.org/v0/amp-accordion-0.1.js"></script>
+|  </head>
+|  <body>
+|    <!-- a valid example -->
+|    <amp-accordion>
+|      <section>
+|        <h2>Section 1</h2>
+|        <p>Bunch of awesome content</p>
+|      </section>
+|      <section expanded>
+|        <h2>Section 2</h2>
+|        <div>Bunch of awesome content</div>
+|      </section>
+|      <section expanded>
+|        <h2>Section 3</h2>
+|        <amp-img src="/awesome.png" width="300" height="300"></amp-img>
+|      </section>
+|      <section>
+|        <h2>Properly nested amp-accordion</h2>
+|        <amp-accordion>
+|          <section>
+|            <h2>Nested section</h2>
+|            <p>It's possible to nest amp-accordions.</p>
+|          </section>
+|        </amp-accordion>
+|      </section>
+|      <section>
+|        <header>The header tag is supported as well.</header>
+|        <p>Even more awesome.</p>
+|      </section>
+|    </amp-accordion>
+|  
+|    <!-- invalid example -->
+|    <amp-accordion>
+|      <amp-accordion> <!-- can't nest amp-accordion -->
+>>     ^~~~~~~~~
 amp-accordion/0.1/test/validator-amp-accordion.html:62:4 Tag 'amp-accordion' is disallowed as child of tag 'amp-accordion'. Child tag must be one of ['section']. (see https://www.ampproject.org/docs/reference/components/amp-accordion) [AMP_TAG_PROBLEM]
+|      </amp-accordion>
+|      <p>Some paragraph of text that doesn't belong here.</p>
+>>     ^~~~~~~~~
 amp-accordion/0.1/test/validator-amp-accordion.html:64:4 Tag 'p' is disallowed as child of tag 'amp-accordion'. Child tag must be one of ['section']. (see https://www.ampproject.org/docs/reference/components/amp-accordion) [AMP_TAG_PROBLEM]
+|      <section>
+>>     ^~~~~~~~~
 amp-accordion/0.1/test/validator-amp-accordion.html:65:4 Tag 'amp-accordion > section' must have 2 child tags - saw 3 child tags. [AMP_TAG_PROBLEM]
+|        <div>header which isn't h1-h6.</div>
+>>       ^~~~~~~~~
 amp-accordion/0.1/test/validator-amp-accordion.html:66:6 Tag 'div' is disallowed as first child of tag 'amp-accordion > section'. First child tag must be one of ['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'header']. [AMP_TAG_PROBLEM]
+|        <div>a second child</div>
+|        <div>a third child</div>
+|      </section>
+|    </amp-accordion>
+|  </body>
+|  </html>

--- a/extensions/amp-ad/0.1/test/validator-amp-ad.out
+++ b/extensions/amp-ad/0.1/test/validator-amp-ad.out
@@ -1,4 +1,63 @@
 FAIL
+|  <!--
+|    Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests support for the amp-ad tag.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <script async custom-element="amp-ad" src="https://cdn.ampproject.org/v0/amp-ad-0.1.js"></script>
+|    <script async custom-element="amp-fx-flying-carpet" src="https://cdn.ampproject.org/v0/amp-fx-flying-carpet-0.1.js"></script>
+|  </head>
+|  <body>
+|    <!-- Valid -->
+|    <amp-ad width=300 height=250
+|            type="a9"
+|            data-aax_size="300x250"
+|            data-aax_pubname="test123"
+|            data-aax_src="302">
+|    </amp-ad>
+|    <!-- Valid -->
+|    <amp-fx-flying-carpet height="300">
+|      <amp-ad height="300" type="foo"></amp-ad>
+|    </amp-fx-flying-carpet>
+|    <!-- Valid -->
+|    <amp-ad type=doubleclick width="100" height="fluid" layout="fluid"></amp-ad>
+|    <!-- Invalid: amp-ad in an amp ad container with data-multi-size attr -->
+|    <amp-fx-flying-carpet height="300">
+|      <amp-ad data-multi-size="" height="300" type="foo"></amp-ad>
+>>     ^~~~~~~~~
 amp-ad/0.1/test/validator-amp-ad.html:47:4 The tag 'amp-ad with data-multi-size attribute' may not appear as a descendant of tag 'amp-fx-flying-carpet'. (see https://www.ampproject.org/docs/reference/components/amp-ad) [AMP_TAG_PROBLEM]
+|    </amp-fx-flying-carpet>
+|    <!-- Invalid: amp-ad in an amp ad container with data-multi-size attr -->
+|    <amp-fx-flying-carpet height="300">
+|      <amp-embed data-multi-size="" height="300" type="foo"></amp-ad>
+>>     ^~~~~~~~~
 amp-ad/0.1/test/validator-amp-ad.html:51:4 The tag 'amp-embed with data-multi-size attribute' may not appear as a descendant of tag 'amp-fx-flying-carpet'. (see https://www.ampproject.org/docs/reference/components/amp-ad) [AMP_TAG_PROBLEM]
+|    </amp-fx-flying-carpet>
+|    <!-- Invalid: amp-ad missing layout=fluid for fluid ad -->
+|    <amp-ad type=doubleclick width="100" height="fluid"></amp-ad>
+>>   ^~~~~~~~~
 amp-ad/0.1/test/validator-amp-ad.html:54:2 The attribute 'height' in tag 'amp-ad' is set to the invalid value 'fluid'. (see https://www.ampproject.org/docs/reference/components/amp-ad) [AMP_LAYOUT_PROBLEM]
+|  </body>
+|  </html>

--- a/extensions/amp-analytics/0.1/test/validator-analytics-notification.out
+++ b/extensions/amp-analytics/0.1/test/validator-analytics-notification.out
@@ -1,1 +1,111 @@
 PASS
+|  <!--
+|    Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <title>Lorem Ipsum | PublisherName</title>
+|    <link rel="canonical" href="amps.html" >
+|    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+|    <link href='https://fonts.googleapis.com/css?family=Georgia|Open+Sans|Roboto' rel='stylesheet' type='text/css'>
+|    <style amp-custom>
+|      amp-user-notification {
+|        min-height: 30px;
+|        font-family: 'Roboto';
+|        font-weight: 500;
+|        line-height: 30px;
+|        padding: 8px;
+|        background: #46b6ac;
+|      }
+|  
+|      amp-user-notification .btn {
+|        border: none;
+|        border-radius: 2px;
+|  
+|        color: #fafafa;
+|        height: 26px;
+|        min-width: 32px;
+|        padding: 0 16px;
+|        margin: 0 16px;
+|        text-transform: uppercase;
+|        letter-spacing: 0;
+|        cursor: pointer;
+|        vertical-align: middle;
+|        line-height: 26px;
+|        text-align: center;
+|        background: #3f51b5;
+|      }
+|  
+|      @-webkit-keyframes fadeIn {
+|        from { opacity: 0; }
+|        to { opacity: 1; }
+|      }
+|  
+|      @-moz-keyframes fadeIn {
+|        from { opacity: 0; }
+|        to { opacity: 1; }
+|      }
+|  
+|      @keyframes fadeIn {
+|        from { opacity: 0; }
+|        to { opacity: 1; }
+|      }
+|  
+|      amp-user-notification.amp-active {
+|        opacity: 0;
+|        -webkit-animation: fadeIn ease-in 1s 1 forwards;
+|        -moz-animation: fadeIn ease-in 1s 1 forwards;
+|        animation: fadeIn ease-in 1s 1 forwards;
+|      }
+|    </style>
+|    <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
+|    <script async custom-element="amp-user-notification" src="https://cdn.ampproject.org/v0/amp-user-notification-0.1.js"></script>
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|  <body>
+|  
+|    <amp-user-notification
+|        layout=nodisplay
+|        id="amp-user-notification1"
+|        data-show-if-href="https://example.com/api/show?timestamp=TIMESTAMP"
+|        data-dismiss-href="https://example.com/api/echo/post">
+|        This site uses cookies to personalize content.
+|       <a class="btn" on="tap:amp-user-notification1.dismiss">I accept</a>
+|    </amp-user-notification>
+|  
+|    <amp-analytics data-consent-notification-id="amp-user-notification1">
+|      <script type="application/json">
+|      {
+|        "requests": {
+|          "test-ping": "https://my-analytics.com/ping?title=${title}&acct=${account}"
+|        },
+|        "vars": {
+|          "title": "A page that sends a ping",
+|          "account": "12345"
+|        },
+|        "triggers": {
+|          "page-view": {
+|            "on": "visible",
+|            "request": "test-ping"
+|          }
+|        }
+|      }
+|      </script>
+|    </amp-analytics>
+|  </body>
+|  </html>

--- a/extensions/amp-analytics/0.1/test/validator-analytics.out
+++ b/extensions/amp-analytics/0.1/test/validator-analytics.out
@@ -1,1 +1,246 @@
 PASS
+|  <!--
+|    Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <title>AMP Analytics</title>
+|    <link rel="canonical" href="analytics.amp.html" >
+|    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+|    <style amp-custom>
+|      .box {
+|        background: #ccc;
+|        border: 1px solid #aaa;
+|        padding: 10px;
+|        margin: 10px;
+|      }
+|      #container {
+|        position: absolute;
+|        top: 10000px;
+|        height: 10px;
+|      }
+|    </style>
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <script async custom-element="amp-anim" src="https://cdn.ampproject.org/v0/amp-anim-0.1.js"></script>
+|    <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
+|  </head>
+|  <body>
+|  <div id="container">
+|  Container for analytics tags. Positioned far away from top to make sure that doesn't matter.
+|  
+|  <amp-analytics id="analytics1">
+|  <script type="application/json">
+|  {
+|    "transport": {"beacon": false, "xhrpost": false},
+|    "requests": {
+|      "endpoint": "https://raw.githubusercontent.com/ampproject/amphtml/master/examples/img/ampicon.png",
+|      "base": "${endpoint}?${type|default:foo}&path=${canonicalPath}",
+|      "event": "${base}&scrollY=${scrollTop}&scrollX=${scrollLeft}&height=${availableScreenHeight}&width=${availableScreenWidth}&scrollBoundV=${verticalScrollBoundary}&scrollBoundH=${horizontalScrollBoundary}",
+|      "visibility": "${base}&a=${maxContinuousVisibleTime}&b=${totalVisibleTime}&c=${firstSeenTime}&d=${lastSeenTime}&e=${firstVisibleTime}&f=${lastVisibleTime}&g=${minVisiblePercentage}&h=${maxVisiblePercentage}&i=${elementX}&j=${elementY}&k=${elementWidth}&l=${elementHeight}&m=${totalTime}&n=${loadTimeVisibility}&o=${backgroundedAtStart}&p=${backgrounded}&subTitle=${subTitle}",
+|      "timer": "${base}&backgroundState=${backgroundState}&duration=${timerDuration}&startTime=${timerStart}"
+|    },
+|    "vars": {
+|      "title": "Example Request"
+|    },
+|    "extraUrlParams": {
+|      "param1": "${random}",
+|      "platform": "AMP"
+|    },
+|    "extraUrlParamsReplaceMap": {
+|      "param": "p"
+|    },
+|    "triggers": {
+|      "defaultPageview": {
+|        "on": "visible",
+|        "request": "base",
+|        "vars": {
+|          "type": "pageLoad"
+|        },
+|        "extraUrlParams": {
+|          "param1": "Another value"
+|        }
+|      },
+|      "pageview": {
+|        "on": "visible",
+|        "request": "base",
+|        "vars": {
+|          "type": "${random}${title}"
+|        }
+|      },
+|      "visibility": {
+|        "on": "visible",
+|        "request": "visibility",
+|        "selector": "#anim-id",
+|        "visibilitySpec": {
+|          "visiblePercentageMin": 20,
+|          "visiblePercentageMax": 80,
+|          "totalTimeMin": 5000,
+|          "continuousTimeMin": 2000,
+|          "waitFor": "ini-load"
+|        },
+|        "vars": {
+|          "type": "visibility"
+|        }
+|      },
+|      "hidden": {
+|        "on": "hidden",
+|        "request": "visibility",
+|        "visibilitySpec": {
+|          "selector": "#anim-id",
+|          "visiblePercentageMin": 20,
+|          "visiblePercentageMin": 1000,
+|          "continuousTimeMax": 5000
+|        },
+|        "vars": {
+|          "type": "hidden"
+|        }
+|      },
+|      "scrollPings": {
+|        "on": "scroll",
+|        "request": "event",
+|        "scrollSpec": {
+|          "verticalBoundaries" : [1, 50, 90],
+|          "horizontalBoundaries": [100]
+|        },
+|        "vars": {
+|          "type": "scroll"
+|        }
+|      },
+|      "clickPings": {
+|        "on": "click",
+|        "selector": "${img}",
+|        "request": ["endpoint", "base"],
+|        "vars": {
+|          "type": "click",
+|          "img": "#anim-id, #container"
+|        }
+|      },
+|      "timer": {
+|        "on": "timer",
+|        "timerSpec": {
+|          "interval": 5,
+|          "maxTimerLength": 20
+|        },
+|        "request": "timer",
+|        "vars": {
+|          "type": "timer"
+|        }
+|      }
+|    }
+|  }
+|  </script>
+|  </amp-analytics>
+|  
+|  <amp-analytics id="analytics3" config="./analytics.config.json"></amp-analytics>
+|  
+|  <div class="logo"></div>
+|  <h1 id="top">AMP Analytics</h1>
+|  <span id="test1" class="box" data-vars-title="Example request with element level overrides">
+|    Click here to generate an event
+|  </span>
+|  <p>
+|  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam pellentesque augue quis elementum tempus. Pellentesque sit amet neque bibendum, sagittis purus vitae, pellentesque magna. Vestibulum non viverra metus, eget feugiat lacus. Nulla in maximus orci. Maecenas id turpis vel ipsum vestibulum bibendum ut sit amet magna. Nullam hendrerit ex at est eleifend, nec dignissim nibh rutrum. Aliquam quis tellus et nibh faucibus laoreet in eget turpis. Nam quam nisl, porttitor vel ex eget, dapibus placerat dui. Mauris commodo pellentesque leo, eu tempus quam. In hac habitasse platea dictumst. Suspendisse non ante finibus, luctus augue non, luctus orci. Vestibulum ornare lacinia aliquam. In sollicitudin vehicula vulputate. Sed mi elit, commodo nec sapien nec, pretium bibendum leo. Donec id justo tortor. Ut in mauris dapibus, laoreet metus vitae, dictum nisi.
+|  </p>
+|  <p>
+|  Integer dapibus egestas arcu. Nunc vitae velit congue, placerat augue quis, suscipit nisi. Donec suscipit imperdiet turpis pharetra feugiat. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Phasellus aliquam eleifend dolor, at lacinia orci semper vel. Nunc semper sem vel tincidunt posuere. Nunc lobortis velit vitae condimentum mollis. Morbi eu ullamcorper mauris. Pellentesque ac eros maximus, pulvinar sapien vitae, semper nisi. Curabitur imperdiet non mauris vitae sollicitudin.
+|  </p>
+|  <p>
+|  Nam posuere velit euismod risus pulvinar, in sollicitudin sapien consectetur. Vestibulum nec ex odio. Quisque at elit nec nunc ultricies lacinia nec non lorem. Maecenas porttitor consequat mauris, vitae porttitor ligula pellentesque ut. Pellentesque rhoncus diam vel lacus lobortis imperdiet. Sed maximus dictum hendrerit. Vivamus ornare, purus in laoreet sagittis, est ante pretium mauris, vel vulputate arcu erat eget mauris. Suspendisse eu lorem metus. Aliquam tempus aliquet urna, vitae mollis lacus pretium vitae. Etiam semper gravida commodo. Maecenas at pulvinar quam. Nullam dolor ipsum, ornare a sollicitudin et, sodales porttitor neque.
+|  </p>
+|  <p>
+|  Integer in felis at lacus mattis facilisis. Curabitur tincidunt, felis porttitor mollis finibus, tortor elit elementum dolor, vel vulputate lorem dui id ante. Vivamus in velit at lectus blandit gravida vitae quis arcu. Nam et magna magna. Fusce condimentum diam lacus, ac ullamcorper purus malesuada eu. Mauris ullamcorper elit et venenatis faucibus. Nullam lobortis molestie purus quis pellentesque. Sed at libero id nisi rhoncus tincidunt. Praesent vestibulum vehicula tristique. Etiam rutrum, nunc id porta interdum, nulla nisi molestie leo, at fermentum justo dolor at lorem. Duis in egestas sapien.
+|  </p>
+|  <p>
+|  Donec pharetra molestie sollicitudin. Duis mattis eleifend rutrum. Quisque luctus tincidunt lacus, vitae lobortis nisi malesuada ac. Aliquam mattis leo vel elit rutrum, nec consequat massa vestibulum. Maecenas bibendum metus nec ante feugiat, eu faucibus orci mattis. Cras tristique sem non elit congue malesuada. Proin ornare, lacus et porttitor consequat, sapien urna rutrum diam, ac pellentesque ligula est eget nisi. Interdum et malesuada fames ac ante ipsum primis in faucibus. Donec ultrices sollicitudin eros a placerat. Proin eget pulvinar est. Donec posuere ultrices odio at ultrices. Suspendisse potenti. Phasellus id orci id purus porttitor consectetur a at erat. Nullam volutpat ultricies nisl id maximus. Morbi porta ex ante, et egestas odio ultricies consequat.
+|  </p>
+|  <p>
+|  <ul>
+|  <li>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</li>
+|  <li>Aliquam in ex porta, imperdiet elit sit amet, condimentum diam.</li>
+|  <li>Etiam fermentum nisi at porta pulvinar.</li>
+|  </ul>
+|  </p>
+|  <p>
+|  <ul>
+|  <li>Proin mattis neque vel elit posuere molestie.</li>
+|  <li>Integer tincidunt sem sed nunc auctor elementum.</li>
+|  <li>Integer a felis in ipsum aliquet auctor sit amet a neque.</li>
+|  </ul>
+|  </p>
+|  <p>
+|  <ul>
+|  <li>Sed suscipit dolor molestie, rhoncus quam ac, lacinia ex.</li>
+|  <li>Curabitur et tellus vel justo ultrices aliquet sed id turpis.</li>
+|  <li>Nam finibus risus at justo elementum bibendum.</li>
+|  <li>In non lacus non urna congue feugiat at vel diam.</li>
+|  </ul>
+|  </p>
+|  <p>
+|  <ul>
+|  <li>Integer hendrerit augue interdum dui venenatis, sit amet tristique mauris cursus.</li>
+|  <li>Etiam quis eros viverra, tincidunt justo in, facilisis nunc.</li>
+|  <li>Aliquam at lacus faucibus, congue lorem interdum, semper mauris.</li>
+|  <li>Ut vulputate erat vel feugiat pharetra.</li>
+|  <li>Morbi id augue id orci sagittis tempus.</li>
+|  <li>Vestibulum varius libero ac dignissim sodales.</li>
+|  </ul>
+|  </p>
+|  <p>
+|  <ul>
+|  <li>Aenean ac sem eget libero varius viverra sit amet vitae nunc.</li>
+|  </ul>
+|  
+|  </p>
+|  <amp-anim src="https://www.google.com/logos/doodles/2016/2016-doodle-fruit-games-day-14-5645577527230464-hp.gif" id="anim-id" width="665" height="220" layout="responsive">
+|    <amp-img placeholder src="https://www.google.com/logos/doodles/2016/2016-doodle-fruit-games-day-14-5645577527230464.2-scta.png" width="665" height="220" layout="responsive"></amp-img>
+|    <amp-analytics id="nestedAnalytics">
+|      <script type="application/json">
+|      {
+|        "transport": {"beacon": false, "xhrpost": false},
+|        "requests": {
+|          "visibility": "https://raw.githubusercontent.com/ampproject/amphtml/master/examples/img/ampicon.png?${type}&RANDOM"
+|        },
+|        "triggers": {
+|          "visibilityScope": {
+|            "on": "visible",
+|            "request": "visibility",
+|            "visibilitySpec": {
+|              "selector": "amp-img",
+|              "selectionMethod": "scope",
+|              "visiblePercentageMin": 10
+|            },
+|            "vars": { "type": "scope" }
+|          },
+|          "visibilityClosest": {
+|            "on": "visible",
+|            "request": "visibility",
+|            "visibilitySpec": {
+|              "selector": "amp-anim",
+|              "selectionMethod": "closest",
+|              "visiblePercentageMin": 20
+|            },
+|            "vars": { "type": "closest" }
+|          }
+|        }
+|      }
+|      </script>
+|    </amp-analytics>
+|  </amp-anim>
+|  </div>
+|  </body>
+|  </html>

--- a/extensions/amp-animation/0.1/test/validator-amp-animation.out
+++ b/extensions/amp-animation/0.1/test/validator-amp-animation.out
@@ -1,3 +1,74 @@
 FAIL
+|  <!--
+|    Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests for the amp-animation tag.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async custom-element="amp-animation" src="https://cdn.ampproject.org/v0/amp-animation-latest.js"></script>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|  <body>
+|    <!-- Valid: Example of amp-animation -->
+|    <amp-animation layout="nodisplay">
+|      <script type="application/json">
+|      {
+|        "target": "target1",
+|        "duration": 1000,
+|        "keyframes": {"opacity": 1}
+|      }
+|      </script>
+|    </amp-animation>
+|  
+|    <span>
+|      <amp-animation layout="nodisplay">
+|        <script type="application/json">
+|        {
+|          "target": "target1",
+|          "duration": 1000,
+|          "keyframes": {"opacity": 1}
+|        }
+|        </script>
+|      </amp-animation>
+|    </span>
+|  
+|    <!-- Invalid: trigger value is not visibility -->
+|    <amp-animation layout="nodisplay" trigger="display">
+>>   ^~~~~~~~~
 amp-animation/0.1/test/validator-amp-animation.html:55:2 The attribute 'trigger' in tag 'amp-animation' is set to the invalid value 'display'. (see https://www.ampproject.org/docs/reference/components/amp-animation) [AMP_TAG_PROBLEM]
+|      <script type="application/json">
+|      {
+|        "target": "target1",
+|        "duration": 1000,
+|        "keyframes": {"opacity": 1}
+|      }
+|      </script>
+|    </amp-animation>
+|  
+|    <!-- Invalid: no child json tag -->
+|    <amp-animation layout="nodisplay">
+>>   ^~~~~~~~~
 amp-animation/0.1/test/validator-amp-animation.html:66:2 Tag 'amp-animation' must have 1 child tags - saw 0 child tags. (see https://www.ampproject.org/docs/reference/components/amp-animation) [AMP_TAG_PROBLEM]
+|    </amp-animation>
+|  </body>
+|  </html>

--- a/extensions/amp-apester-media/0.1/test/validator-amp-apester-media.out
+++ b/extensions/amp-apester-media/0.1/test/validator-amp-apester-media.out
@@ -1,1 +1,63 @@
 PASS
+|  <!--
+|    Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests for the amp-apester-media tag. See the inline comments.
+|  -->
+|  
+|  <!doctype html>
+|  <html ⚡>
+|  
+|  <head>
+|      <meta charset="utf-8">
+|      <title>Apester Media Smart Unit</title>
+|      <link rel="canonical" href="./regular-html-version.html">
+|      <meta name="viewport" content="width=device-width,minimum-scale=1">
+|      <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|      <script async custom-element="amp-apester-media" src="https://cdn.ampproject.org/v0/amp-apester-media-0.1.js"></script>
+|      <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|  <body>
+|  
+|  <!-- Valid: simplest possible example -->
+|  <amp-apester-media
+|          height="444"
+|          data-apester-media-id="57a336dba187a2ca3005e826">
+|  </amp-apester-media>
+|  
+|  <!-- Valid: a simple example with explicit fixed layout -->
+|  <amp-apester-media
+|          height="444"
+|          layout="fixed-height"
+|          data-apester-media-id="57a336dba187a2ca3005e826">
+|  </amp-apester-media>
+|  
+|  <!-- Valid: playlist example -->
+|  <amp-apester-media
+|          height="444"
+|          data-apester-channel-token="57a36e1e96cd505a7f01ed12">
+|  </amp-apester-media>
+|  
+|  <!-- Valid: a simple playlist example with explicit fixed layout -->
+|  <amp-apester-media
+|          height="444"
+|          layout="fixed-height"
+|          data-apester-channel-token="57a36e1e96cd505a7f01ed12">
+|  </amp-apester-media>
+|  
+|  </body>
+|  </html>

--- a/extensions/amp-app-banner/0.1/test/validator-amp-app-banner-missing-meta.out
+++ b/extensions/amp-app-banner/0.1/test/validator-amp-app-banner-missing-meta.out
@@ -1,2 +1,49 @@
 FAIL
-amp-app-banner/0.1/test/validator-amp-app-banner-missing-meta.html:46:7 The tag 'amp-app-banner data source' is missing or incorrect, but required by 'amp-app-banner'. (see https://www.ampproject.org/docs/reference/components/amp-app-banner) [AMP_TAG_PROBLEM]
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests support for the amp-app-banner tag. This test case demonstrates
+|    a valid <amp-app-banner> tag with missing metadata in the head.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <script async custom-element="amp-app-banner" src="https://cdn.ampproject.org/v0/amp-app-banner-0.1.js"></script>
+|  
+|  </head>
+|  <body>
+|  
+|    <!-- Valid other than missing <head> metadata -->
+|    <amp-app-banner layout="nodisplay" id="demo-app-banner-2134">
+|      <amp-img src="https://example.com/icon.png" width="60" height="51">
+|      </amp-img>
+|      <h3>App Name</h3>
+|      <p>Experience a richer experience on our mobile app!</p>
+|      <div class="actions">
+|        <button open-button>Get the app</button>
+|      </div>
+|    </amp-app-banner>
+|  
+|  </body>
+|  </html>
+>>       ^~~~~~~~~
+amp-app-banner/0.1/test/validator-amp-app-banner-missing-meta.html:46:6 The tag 'amp-app-banner data source' is missing or incorrect, but required by 'amp-app-banner'. (see https://www.ampproject.org/docs/reference/components/amp-app-banner) [AMP_TAG_PROBLEM]

--- a/extensions/amp-app-banner/0.1/test/validator-amp-app-banner-only-one-meta.out
+++ b/extensions/amp-app-banner/0.1/test/validator-amp-app-banner-only-one-meta.out
@@ -1,1 +1,51 @@
 PASS
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests support for the amp-app-banner tag and required <head> metatdata.
+|    In this test, we only have the <link rel=manifest> tag, and not the
+|    <meta name=apple-itunes-app> tag, but it's still valid.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <script async custom-element="amp-app-banner" src="https://cdn.ampproject.org/v0/amp-app-banner-0.1.js"></script>
+|  
+|    <!-- Valid -->
+|    <link rel="manifest" href="https://link/to/manifest.json">
+|  
+|  </head>
+|  <body>
+|  
+|    <!-- Valid -->
+|    <amp-app-banner layout="nodisplay" id="demo-app-banner-2134">
+|      <amp-img src="https://example.com/icon.png" width="60" height="51">
+|      </amp-img>
+|      <h3>App Name</h3>
+|      <p>Experience a richer experience on our mobile app!</p>
+|      <div class="actions">
+|        <button open-button>Get the app</button>
+|      </div>
+|    </amp-app-banner>
+|  
+|  </body>
+|  </html>

--- a/extensions/amp-app-banner/0.1/test/validator-amp-app-banner.out
+++ b/extensions/amp-app-banner/0.1/test/validator-amp-app-banner.out
@@ -1,1 +1,51 @@
 PASS
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests support for the amp-app-banner tag and required <head> metatdata.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <script async custom-element="amp-app-banner" src="https://cdn.ampproject.org/v0/amp-app-banner-0.1.js"></script>
+|  
+|    <!-- Valid -->
+|    <meta name="apple-itunes-app"
+|          content="app-id=123456789, app-argument=app-name://link/to/app-content">
+|    <link rel="manifest" href="https://link/to/manifest.json">
+|  
+|  </head>
+|  <body>
+|  
+|    <!-- Valid -->
+|    <amp-app-banner layout="nodisplay" id="demo-app-banner-2134">
+|      <amp-img src="https://example.com/icon.png" width="60" height="51">
+|      </amp-img>
+|      <h3>App Name</h3>
+|      <p>Experience a richer experience on our mobile app!</p>
+|      <div class="actions">
+|        <button open-button>Get the app</button>
+|      </div>
+|    </amp-app-banner>
+|  
+|  </body>
+|  </html>

--- a/extensions/amp-audio/0.1/test/validator-amp-audio.out
+++ b/extensions/amp-audio/0.1/test/validator-amp-audio.out
@@ -1,1 +1,45 @@
 PASS
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests the example from the markdown file, autoplay enabled.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <script async custom-element="amp-audio" src="https://cdn.ampproject.org/v0/amp-audio-0.1.js"></script>
+|  </head>
+|  <body>
+|    <amp-audio width="400" height="300" autoplay src="https://yourhost.com/audios/myaudio.mp3">
+|      <div fallback>
+|        <p>Your browser doesn’t support HTML5 audio</p>
+|      </div>
+|      <source type="audio/mpeg" src="foo.mp3">
+|        <source type="audio/ogg" src="foo.ogg">
+|    </amp-audio>
+|  
+|    <!-- test controlslist attr, which is often provided in camelCase -->
+|    <amp-audio width="400" height="300"
+|               controlsList="nofullscreen nodownload noremoteplayback foobar">
+|    </amp-audio>
+|  </body>
+|  </html>

--- a/extensions/amp-audio/0.1/test/validator-amp4ads-amp-audio.out
+++ b/extensions/amp-audio/0.1/test/validator-amp4ads-amp-audio.out
@@ -1,2 +1,52 @@
 FAIL
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests the example from the markdown file with and without autoplay.
+|    Format is set to A4A.
+|  -->
+|  <!doctype html>
+|  <html ⚡4ads>
+|  <head>
+|    <meta charset="utf-8">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp4ads-boilerplate>body{visibility:hidden}</style>
+|    <script async src="https://cdn.ampproject.org/amp4ads-v0.js"></script>
+|    <script async custom-element="amp-audio" src="https://cdn.ampproject.org/v0/amp-audio-0.1.js"></script>
+|  </head>
+|  <body>
+|    <!-- Valid: autoplay not present. -->
+|    <amp-audio width="400" height="300" src="https://yourhost.com/audios/myaudio.mp3">
+|      <div fallback>
+|        <p>Your browser doesn’t support HTML5 audio</p>
+|      </div>
+|      <source type="audio/mpeg" src="foo.mp3">
+|        <source type="audio/ogg" src="foo.ogg">
+|    </amp-audio>
+|  
+|    <!-- Invalid: autoplay present. -->
+|    <amp-audio width="400" height="300" autoplay src="https://yourhost.com/audios/myaudio.mp3">
+>>   ^~~~~~~~~
 amp-audio/0.1/test/validator-amp4ads-amp-audio.html:41:2 The attribute 'autoplay' may not appear in tag 'amp-audio (A4A)'. (see https://www.ampproject.org/docs/reference/components/amp-audio) [AMP_TAG_PROBLEM]
+|      <div fallback>
+|        <p>Your browser doesn’t support HTML5 audio</p>
+|      </div>
+|      <source type="audio/mpeg" src="foo.mp3">
+|        <source type="audio/ogg" src="foo.ogg">
+|    </amp-audio>
+|  </body>
+|  </html>

--- a/extensions/amp-auto-ads/0.1/test/validator-amp-auto-ads.out
+++ b/extensions/amp-auto-ads/0.1/test/validator-amp-auto-ads.out
@@ -1,1 +1,33 @@
 PASS
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description: Basic test for amp-auto-ad.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <script async custom-element="amp-auto-ads" src="https://cdn.ampproject.org/v0/amp-auto-ads-0.1.js"></script>
+|  </head>
+|  <body>
+|    <amp-auto-ads type="adsense" data-ad-client="ca-pub-2005682797531342"></amp-auto-ads>
+|  </body>
+|  </html>

--- a/extensions/amp-bind/0.1/test/validator-amp-bind.out
+++ b/extensions/amp-bind/0.1/test/validator-amp-bind.out
@@ -1,1 +1,79 @@
 PASS
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description: Basic test for amp-bind.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <title>amp-bind: Basic</title>
+|    <link rel="canonical" href="amps.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+|    <link href="https://fonts.googleapis.com/css?family=Questrial" rel="stylesheet" type="text/css">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script>
+|  </head>
+|  
+|  <body>
+|    <!-- VALID BINDINGS -->
+|    <p [text]="foo.bar" [class]="foo.bar">p</p>
+|    <a [href]="foo.bar">a</a>
+|    <amp-img src="http://pictures.com/image.jpg" alt="pic" width=10 height=10
+|        [src]="foo.bar" [alt]="foo.bar" [width]="foo.bar" [height]="foo.bar">
+|    </amp-img>
+|    <button [disabled]="foo.bar" [type]="foo.bar" [value]="foo.bar">
+|      button
+|    </button>
+|  
+|    <amp-bind-macro id="macroWithArgs" arguments="arg1, arg2" expression="arg1 + arg2"></amp-bind-macro>
+|    <amp-bind-macro id="macroWithoutArgs" expression="foo.bar + 'baz'"></amp-bind-macro>
+|  
+|    <!-- AMP-STATE -->
+|    <!-- amp-state with child script -->
+|    <amp-state id="withChildScript">
+|      <script type="application/json">
+|        {
+|          "foo": "bar"
+|        }
+|      </script>
+|    </amp-state>
+|    <!-- amp-state with `src` attr -->
+|    <amp-state id="withSrc" src="https://www.foo.com/data.json">
+|    </amp-state>
+|    <!-- amp-state with `src` and `credentials` attrs -->
+|    <amp-state id="withSrcPlusCredentials" src="https://www.foo.com/data.json" credentials="omit">
+|    </amp-state>
+|    <!-- amp-state with child script and `src` attr -->
+|    <amp-state id="withChildScriptAndSrc" src="https://www.foo.com/data.json">
+|      <script type="application/json">
+|        {
+|          "foo": "bar"
+|        }
+|      </script>
+|    </amp-state>
+|    <!-- amp-state with child script and `src` and `credentials` attrs -->
+|    <amp-state id="withChildScriptAndSrcPlusCredentials" src="https://www.foo.com/data.json" credentials="include">
+|      <script type="application/json">
+|        {
+|          "foo": "bar"
+|        }
+|      </script>
+|    </amp-state>
+|  </body>
+|  </html>

--- a/extensions/amp-bind/0.1/test/validator-autosuggest.out
+++ b/extensions/amp-bind/0.1/test/validator-autosuggest.out
@@ -1,1 +1,156 @@
 PASS
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description: Another test of amp-bind with an autosuggest box.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <title>AMP autosuggest Demo</title>
+|    <link rel="canonical" href="amps.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+|    <link href="https://fonts.googleapis.com/css?family=Questrial" rel="stylesheet" type="text/css">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script>
+|    <script async custom-element="amp-form" src="https://cdn.ampproject.org/v0/amp-form-0.1.js"></script>
+|    <script async custom-element="amp-list" src="https://cdn.ampproject.org/v0/amp-list-0.1.js"></script>
+|    <script async custom-element="amp-selector" src="https://cdn.ampproject.org/v0/amp-selector-0.1.js"></script>
+|    <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.1.js"></script>
+|    <style amp-custom>
+|    body {
+|      padding: 10px;
+|    }
+|    .search-container {
+|      display: flex;
+|      flex-flow: row nowrap;
+|    }
+|    .search-box, .search-submit, .select-option {
+|      font-size: 1.25em;
+|    }
+|    .autosuggest-box {
+|      box-shadow: 0px 2px 6px rgba(0,0,0,.3);
+|    }
+|    .search-box {
+|      flex: 4 0 0;
+|      padding: 5px;
+|      border-radius: 4px 0 0 4px;
+|      border: 2px solid lightgray;
+|      border-right: 0;
+|    }
+|    .search-submit {
+|      flex: 1 0 0;
+|      padding: 5px;
+|      border-radius: 0 4px 4px 0;
+|      border: 2px solid #4b68ff;
+|      background: #4b68ff;
+|      color: #fff;
+|    }
+|    .select-option {
+|      display: block;
+|      box-sizing: border-box;
+|      height: 30px;
+|      line-height: 30px;
+|      padding-left: 10px;
+|      background: #ddd;
+|    }
+|    amp-selector .select-option.no-outline.no-outline[option] {
+|      outline: none;
+|    }
+|    .select-option:focus {
+|      box-shadow: inset rgb(94, 158, 215) 0px 0px 45px;
+|    }
+|    .select-option:focus {
+|      background: #fff;
+|    }
+|    .select-option:nth-child(2n) {
+|      background: #eee;
+|    }
+|    </style>
+|  </head>
+|  <body>
+|    <h1>Programming language search</h1>
+|    <form
+|      method="post"
+|      action-xhr="/form/autosuggest/search"
+|      target="_blank"
+|      id="search-form"
+|      on="submit:autosuggest-list.hide;submit-success:results.show"
+|    >
+|      <div class="search-container">
+|        <input
+|          id="query"
+|          name="query"
+|          type="text"
+|          class="search-box"
+|          on="input-debounced:AMP.setState({
+|              query: event.value,
+|              autosuggest: event.value
+|            }),
+|            autosuggest-list.show,
+|            results.hide"
+|          [value]="query || ''"
+|        />
+|        <button class="search-submit" type="submit">Search</button>
+|      </div>
+|      <amp-list
+|        class="autosuggest-box"
+|        layout="fixed-height"
+|        height="120"
+|        src="/form/autosuggest/query"
+|        [src]="'/form/autosuggest/query?q=' + (autosuggest || '')"
+|        id="autosuggest-list"
+|        hidden
+|      >
+|        <template type="amp-mustache">
+|          <amp-selector
+|            keyboard-select-mode="focus"
+|            layout="container"
+|            on="select:AMP.setState({
+|                query: event.targetOption
+|              }),
+|              autosuggest-list.hide,
+|              results.hide"
+|          >
+|            {{#results}}
+|              <div
+|                class="select-option no-outline"
+|                role="option"
+|                tabindex="0"
+|                on="tap:autosuggest-list.hide"
+|                option="{{.}}"
+|              >{{.}}</div>
+|            {{/results}}
+|            {{^results.3}}<div class="select-option"></div>{{/results.3}}
+|            {{^results.2}}<div class="select-option"></div>{{/results.2}}
+|            {{^results.1}}<div class="select-option"></div>{{/results.1}}
+|            {{^results.0}}<div class="select-option"></div>{{/results.0}}
+|          </amp-selector>
+|        </template>
+|      </amp-list>
+|      <div submit-success id="results">
+|        <template type="amp-mustache">
+|          <p>Here are the results for the search "{{query}}":</p>
+|          <ul>
+|              {{#results}}<li>{{title}}</li>{{/results}}
+|          </ul>
+|        </template>
+|      </div>
+|    </form>
+|  </body>
+|  </html>

--- a/extensions/amp-brid-player/0.1/test/validator-amp-brid-player.out
+++ b/extensions/amp-brid-player/0.1/test/validator-amp-brid-player.out
@@ -1,3 +1,75 @@
 FAIL
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests support for the amp-brid-player tag.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <script async custom-element="amp-brid-player" src="https://cdn.ampproject.org/v0/amp-brid-player-0.1.js"></script>
+|  </head>
+|  <body>
+|    <!-- Example of a valid amp-brid-player. -->
+|    <amp-brid-player
+|        data-partner="264"
+|        data-player="4144"
+|        data-video="13663"
+|        layout="responsive"
+|        width="480" height="270">
+|    </amp-brid-player>
+|    <!-- Alternate valid example using a playlist. -->
+|    <amp-brid-player
+|        data-partner="264"
+|        data-player="4144"
+|        data-playlist="13663"
+|        layout="responsive"
+|        width="480" height="270">
+|    </amp-brid-player>
+|    <!-- Alternate valid example using a outstream. -->
+|    <amp-brid-player
+|        data-partner="6205"
+|        data-player="0"
+|        data-outstream="3828"
+|        layout="responsive"
+|        width="480" height="270">
+|    </amp-brid-player>
+|    <!-- Invalid example missing a player id. -->
+|    <amp-brid-player
+>>   ^~~~~~~~~
 amp-brid-player/0.1/test/validator-amp-brid-player.html:56:2 The mandatory attribute 'data-player' is missing in tag 'amp-brid-player'. (see https://www.ampproject.org/docs/reference/components/amp-brid-player) [AMP_TAG_PROBLEM]
+|        data-partner="264"
+|        data-video="13663"
+|        layout="responsive"
+|        width="480" height="270">
+|    </amp-brid-player>
+|    <!-- Invalid example missing video, playlist and outstream. -->
+|    <amp-brid-player
+>>   ^~~~~~~~~
 amp-brid-player/0.1/test/validator-amp-brid-player.html:63:2 The tag 'amp-brid-player' is missing a mandatory attribute - pick one of ['data-outstream', 'data-playlist', 'data-video']. (see https://www.ampproject.org/docs/reference/components/amp-brid-player) [AMP_TAG_PROBLEM]
+|        data-partner="264"
+|        data-player="4144"
+|        layout="responsive"
+|        width="480" height="270">
+|    </amp-brid-player>
+|  </body>
+|  </html>

--- a/extensions/amp-brightcove/0.1/test/validator-amp-brightcove.out
+++ b/extensions/amp-brightcove/0.1/test/validator-amp-brightcove.out
@@ -1,2 +1,61 @@
 FAIL
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests support for the amp-brightcove tag.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <script async custom-element="amp-brightcove" src="https://cdn.ampproject.org/v0/amp-brightcove-0.1.js"></script>
+|  </head>
+|  <body>
+|    <!-- Valid: Example of a valid amp-brightcove. -->
+|    <amp-brightcove
+|        data-account="906043040001"
+|        data-video-id="1401169490001"
+|        data-player-id="180a5658-8be8-4f33-8eba-d562ab41b40c"
+|        layout="responsive" width="480" height="270">
+|    </amp-brightcove>
+|    <!-- Valid: data-video-id, data-player-id are optional;
+|         leaving them out results in the default config. -->
+|    <amp-brightcove
+|        data-account="906043040001"
+|        layout="responsive" width="480" height="270">
+|    </amp-brightcove>
+|    <!-- Valid: most "data-*" attributes are bindable. -->
+|    <amp-brightcove
+|        data-account="906043040001"
+|        layout="responsive" width="480" height="270"
+|        [data-account]="foo.bar" [data-embed]="foo.bar" [data-player]="foo.bar"
+|        [data-player-id]="foo.bar" [data-playlist-id]="foo.bar"
+|        [data-video-id]="foo.bar">
+|    </amp-brightcove>
+|    <!-- Invalid: data-account is mandatory;
+|         leaving them out results in an error. -->
+|    <amp-brightcove
+>>   ^~~~~~~~~
 amp-brightcove/0.1/test/validator-amp-brightcove.html:54:2 The mandatory attribute 'data-account' is missing in tag 'amp-brightcove'. (see https://www.ampproject.org/docs/reference/components/amp-brightcove) [AMP_TAG_PROBLEM]
+|        layout="responsive" width="480" height="270">
+|    </amp-brightcove>
+|  </body>
+|  </html>

--- a/extensions/amp-call-tracking/0.1/test/validator-amp-call-tracking.out
+++ b/extensions/amp-call-tracking/0.1/test/validator-amp-call-tracking.out
@@ -1,5 +1,65 @@
 FAIL
+|  <!--
+|    Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests for the amp-call-tracking tag.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async custom-element="amp-call-tracking" src="https://cdn.ampproject.org/v0/amp-call-tracking-latest.js"></script>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|  <body>
+|    <!-- Valid: Example of amp-call-tracking usage -->
+|    <amp-call-tracking config="https://example.com/calltracking.json">
+|      <a href="tel:12345678">+1 (23) 45-678</a>
+|    </amp-call-tracking>
+|  
+|    <!-- Invalid: no <A> tag -->
+|    <amp-call-tracking config="https://example.com/calltracking.json">
+>>   ^~~~~~~~~
 amp-call-tracking/0.1/test/validator-amp-call-tracking.html:37:2 Tag 'amp-call-tracking' must have 1 child tags - saw 0 child tags. (see https://www.ampproject.org/docs/reference/components/amp-call-tracking) [AMP_TAG_PROBLEM]
+|    </amp-call-tracking>
+|  
+|    <!-- Invalid: more than one <A> tag -->
+|    <amp-call-tracking config="https://example.com/calltracking.json">
+>>   ^~~~~~~~~
 amp-call-tracking/0.1/test/validator-amp-call-tracking.html:41:2 Tag 'amp-call-tracking' must have 1 child tags - saw 2 child tags. (see https://www.ampproject.org/docs/reference/components/amp-call-tracking) [AMP_TAG_PROBLEM]
+|      <a href="tel:12345678">+1 (23) 45-678</a>
+|      <a href="tel:98765432">(987) 654-321</a>
+|    </amp-call-tracking>
+|  
+|    <!-- Invalid: no "config" attribute -->
+|    <amp-call-tracking>
+>>   ^~~~~~~~~
 amp-call-tracking/0.1/test/validator-amp-call-tracking.html:47:2 The mandatory attribute 'config' is missing in tag 'amp-call-tracking'. (see https://www.ampproject.org/docs/reference/components/amp-call-tracking) [AMP_TAG_PROBLEM]
+|      <a href="tel:12345678">+1 (23) 45-678</a>
+|    </amp-call-tracking>
+|  
+|    <!-- Invalid: Something other than an <A> child -->
+|    <amp-call-tracking config="https://example.com/calltracking.json">
+|      <div></div>
+>>     ^~~~~~~~~
 amp-call-tracking/0.1/test/validator-amp-call-tracking.html:53:4 Tag 'div' is disallowed as child of tag 'amp-call-tracking'. Child tag must be one of ['a']. (see https://www.ampproject.org/docs/reference/components/amp-call-tracking) [AMP_TAG_PROBLEM]
+|    </amp-call-tracking>
+|  </body>
+|  </html>

--- a/extensions/amp-carousel/0.1/test/validator-amp-carousel.out
+++ b/extensions/amp-carousel/0.1/test/validator-amp-carousel.out
@@ -1,2 +1,48 @@
 FAIL
+|  <!--
+|    Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests for the amp-carousel tag. See the inline comments.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <script async custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.1.js"></script>
+|  </head>
+|  <body>
+|    <!-- Invalid: Wrong delay attribute usage -->
+|    <amp-carousel layout="fixed" width=500 height=500 autoplay delay>
+>>   ^~~~~~~~~
 amp-carousel/0.1/test/validator-amp-carousel.html:32:2 The attribute 'delay' in tag 'amp-carousel' is set to the invalid value ''. (see https://www.ampproject.org/docs/reference/components/amp-carousel) [AMP_TAG_PROBLEM]
+|    </amp-carousel>
+|    <!-- Valid: Correct delay attribute usage -->
+|    <amp-carousel layout="fixed" width=500 height=500 autoplay delay=5000>
+|    </amp-carousel>
+|    <!-- Valid: default carousel autoplay usage w/o delay -->
+|    <amp-carousel layout="fixed" width=500 height=500 autoplay>
+|    </amp-carousel>
+|    <!-- Valid: amp-carousel with bindable [slide] attr -->
+|    <amp-carousel type="slides" layout="fixed" width=500 height=500
+|        [slide]="foo.bar">
+|    </amp-carousel>
+|  </body>
+|  </html>

--- a/extensions/amp-dailymotion/0.1/test/validator-amp-dailymotion.out
+++ b/extensions/amp-dailymotion/0.1/test/validator-amp-dailymotion.out
@@ -1,4 +1,71 @@
 FAIL
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    This tests validation for the amp-dailymotion tag.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|      <meta charset="utf-8">
+|      <title>Dailymotion examples</title>
+|      <link rel="canonical" href="amps.html">
+|      <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+|      <link href="https://fonts.googleapis.com/css?family=Questrial" rel="stylesheet" type="text/css">
+|      <script async custom-element="amp-dailymotion" src="https://cdn.ampproject.org/v0/amp-dailymotion-0.1.js"></script>
+|       <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|      <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|  <body>
+|  <!-- valid -->
+|  <amp-dailymotion data-videoid="x2m8jpp" width="500" height="281"></amp-dailymotion>
+|  
+|  <!-- valid -->
+|  <amp-dailymotion data-videoid="jx2m8pp" width="500" height="281" layout="responsive">
+|  </amp-dailymotion>
+|  
+|  <!-- valid: all optional attrs set -->
+|  <amp-dailymotion data-videoid="jx2m8pp" width="500" height="281" layout="responsive"
+|             data-mute="true" data-endscreen-enable="false"
+|             data-sharing-enable="true" data-start="42" data-ui-highlight="ef0122"
+|             data-ui-logo="false" data-info="true">
+|  </amp-dailymotion>
+|  
+|  <!-- invalid: videoid bad -->
+|  <amp-dailymotion data-videoid="i don't think so" width="500" height="281"
+>> ^~~~~~~~~
 amp-dailymotion/0.1/test/validator-amp-dailymotion.html:48:0 The attribute 'data-videoid' in tag 'amp-dailymotion' is set to the invalid value 'i don't think so'. (see https://www.ampproject.org/docs/reference/components/amp-dailymotion) [AMP_TAG_PROBLEM]
+|          layout="responsive"></amp-dailymotion>
+|  
+|  <!-- invalid: videoid missing -->
+|  <amp-dailymotion width="500" height="281" layout="responsive"></amp-dailymotion>
+>> ^~~~~~~~~
 amp-dailymotion/0.1/test/validator-amp-dailymotion.html:52:0 The mandatory attribute 'data-videoid' is missing in tag 'amp-dailymotion'. (see https://www.ampproject.org/docs/reference/components/amp-dailymotion) [AMP_TAG_PROBLEM]
+|  
+|  <!-- invalid: bad attr value -->
+|  <amp-dailymotion data-videoid="jx2m8pp" width="500" height="281" layout="responsive"
+>> ^~~~~~~~~
 amp-dailymotion/0.1/test/validator-amp-dailymotion.html:55:0 The attribute 'data-ui-highlight' in tag 'amp-dailymotion' is set to the invalid value 'blue'. (see https://www.ampproject.org/docs/reference/components/amp-dailymotion) [AMP_TAG_PROBLEM]
+|                   data-ui-highlight="blue">
+|  </amp-dailymotion>
+|  
+|  <!-- valid: three letter color -->
+|  <amp-dailymotion data-videoid="jx2m8pp" width="500" height="281"
+|                   data-ui-highlight="fff">
+|  </amp-dailymotion>
+|  </body>
+|  </html>

--- a/extensions/amp-experiment/0.1/test/validator-amp-experiment.out
+++ b/extensions/amp-experiment/0.1/test/validator-amp-experiment.out
@@ -1,3 +1,56 @@
 FAIL
+|  <!--
+|    Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    This tests validation for the amp-experiment tag.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|      <meta charset="utf-8">
+|      <title>Experiment examples</title>
+|      <link rel="canonical" href="amps.html">
+|      <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+|      <link href="https://fonts.googleapis.com/css?family=Questrial" rel="stylesheet" type="text/css">
+|      <script async custom-element="amp-experiment" src="https://cdn.ampproject.org/v0/amp-experiment-0.1.js"></script>
+|       <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|      <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|  <body>
+|  
+|  <amp-experiment>
+|      <script type="application/json">
+|          {
+|              "background-color-test": {
+|                  "variants": {
+|                      "yellow": 50,
+|                      "green": 50
+|                  }
+|              }
+|          }
+|      </script>
+|  </amp-experiment>
+|  
+|  <amp-experiment>
+>> ^~~~~~~~~
 amp-experiment/0.1/test/validator-amp-experiment.html:47:0 The tag 'amp-experiment' appears more than once in the document. (see https://www.ampproject.org/docs/reference/components/amp-experiment) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
+|      <script type="invalidtype"></script>
+>>     ^~~~~~~~~
 amp-experiment/0.1/test/validator-amp-experiment.html:48:4 Only AMP runtime 'script' tags are allowed, and only in the document head. (see https://www.ampproject.org/docs/reference/spec#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
+|  </amp-experiment>
+|  </body>
+|  </html>

--- a/extensions/amp-facebook-comments/0.1/test/validator-amp-facebook-comments.out
+++ b/extensions/amp-facebook-comments/0.1/test/validator-amp-facebook-comments.out
@@ -1,1 +1,40 @@
 PASS
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests support for the amp-facebook-comments tag.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <script async custom-element="amp-facebook-comments" src="https://cdn.ampproject.org/v0/amp-facebook-comments-0.1.js"></script>
+|  </head>
+|  <body>
+|    <!-- Example of a valid amp-facebook-comments -->
+|    <amp-facebook-comments
+|        width=486
+|        height=657
+|        layout="responsive"
+|        data-href="http://www.directlyrics.com/adele-25-complete-album-lyrics-news.html">
+|    </amp-facebook>
+|  </body>
+|  </html>

--- a/extensions/amp-facebook-like/0.1/test/validator-amp-facebook-like.out
+++ b/extensions/amp-facebook-like/0.1/test/validator-amp-facebook-like.out
@@ -1,1 +1,40 @@
 PASS
+|  <!--
+|    Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests support for the amp-facebook-like tag.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <script async custom-element="amp-facebook-like" src="https://cdn.ampproject.org/v0/amp-facebook-like-0.1.js"></script>
+|  </head>
+|  <body>
+|      <amp-facebook-like width=225 height=80
+|          layout="fixed"
+|          data-layout="standard"
+|          data-size="large"
+|          data-show-faces="true"
+|          data-href="https://www.facebook.com/testesmegadivertidos/">
+|      </amp-facebook-like>
+|  </body>
+|  </html>

--- a/extensions/amp-facebook/0.1/test/validator-amp-facebook.out
+++ b/extensions/amp-facebook/0.1/test/validator-amp-facebook.out
@@ -1,1 +1,55 @@
 PASS
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests support for the amp-facebook tag.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <script async custom-element="amp-facebook" src="https://cdn.ampproject.org/v0/amp-facebook-0.1.js"></script>
+|  </head>
+|  <body>
+|    <!-- Example of a valid amp-facebook (embedded post) -->
+|    <amp-facebook
+|        width=486
+|        height=657
+|        layout="responsive"
+|        data-href="https://www.facebook.com/zuck/posts/10102593740125791">
+|    </amp-facebook>
+|    <!-- Example of a valid amp-facebook (embedded video) -->
+|    <amp-facebook
+|        width=552
+|        height=574
+|        layout="responsive"
+|        data-embed-as="video"
+|        data-href="https://www.facebook.com/zuck/videos/10102509264909801/">
+|    </amp-facebook>
+|    <!-- Example of a valid amp-facebook (embedded video) -->
+|    <amp-facebook
+|        width=552
+|        height=574
+|        layout="responsive"
+|        data-href="https://www.facebook.com/zuck/videos/10102509264909801/">
+|    </amp-facebook>
+|  </body>
+|  </html>

--- a/extensions/amp-font/0.1/test/validator-amp-font.out
+++ b/extensions/amp-font/0.1/test/validator-amp-font.out
@@ -1,1 +1,45 @@
 PASS
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <script async custom-element="amp-font" src="https://cdn.ampproject.org/v0/amp-font-0.1.js"></script>
+|  </head>
+|  <body>
+|    <!--
+|      Test Description:
+|      Tests support for the amp-font tag.
+|    -->
+|    <amp-font
+|        layout="nodisplay"
+|        font-family="My Font"
+|        timeout="3000"
+|        on-error-remove-class="my-font-loading"
+|        on-error-add-class="my-font-missing"></amp-font>
+|    <amp-font
+|        layout="nodisplay"
+|        font-family="My Other Font"
+|        timeout="1000"
+|        on-load-add-class="my-other-font-loaded"
+|        on-load-remove-class="my-other-font-loading"></amp-font>
+|  </body>
+|  </html>

--- a/extensions/amp-fx-flying-carpet/0.1/test/validator-amp-flying-carpet.out
+++ b/extensions/amp-fx-flying-carpet/0.1/test/validator-amp-flying-carpet.out
@@ -1,1 +1,36 @@
 PASS
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests amp-fx-flying-carpet.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <script async custom-element="amp-fx-flying-carpet" src="https://cdn.ampproject.org/v0/amp-fx-flying-carpet-0.1.js"></script>
+|  </head>
+|  <body>
+|    <amp-fx-flying-carpet height="300px">
+|      <amp-img src="fullscreen.png" width="100vw" height="100vh"></amp-img>
+|    </amp-fx-flying-carpet>
+|  </body>
+|  </html>

--- a/extensions/amp-gfycat/0.1/test/validator-amp-gfycat.out
+++ b/extensions/amp-gfycat/0.1/test/validator-amp-gfycat.out
@@ -1,1 +1,61 @@
 PASS
+|  <!--
+|    Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|      <meta charset="utf-8">
+|      <title>Gfycat examples</title>
+|      <link rel="canonical" href="amps.html">
+|      <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+|      <link href="https://fonts.googleapis.com/css?family=Questrial" rel="stylesheet" type="text/css">
+|      <script async custom-element="amp-gfycat" data-amp-report-test="amp-gfycat" src="https://cdn.ampproject.org/v0/amp-gfycat-0.1.js"></script>
+|      <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|      <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|  <body>
+|      <h2>Gfycat</h2>
+|      <h3>Responsive layout</h3>
+|      <amp-gfycat
+|              data-gfyid="TautWhoppingCougar"
+|              width="640"
+|              height="360"
+|              layout="responsive">
+|      </amp-gfycat>
+|  
+|      <h3>Fixed layout</h3>
+|      <amp-gfycat
+|              data-gfyid="BareSecondaryFlamingo"
+|              width="225"
+|              height="400">
+|      </amp-gfycat>
+|  
+|      <h3>Autoplaying video is paused when out of view</h3>
+|      <amp-gfycat
+|              data-gfyid="LeanMediocreBeardeddragon"
+|              width="640"
+|              height="360">
+|      </amp-gfycat>
+|  
+|      <h3>Autoplay disabled</h3>
+|      <amp-gfycat
+|              data-gfyid="LeanMediocreBeardeddragon"
+|              width="640"
+|              height="360"
+|              noautoplay>
+|      </amp-gfycat>
+|  </body>
+|  </html>

--- a/extensions/amp-iframe/0.1/test/validator-amp-iframe.out
+++ b/extensions/amp-iframe/0.1/test/validator-amp-iframe.out
@@ -1,2 +1,59 @@
 FAIL
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests for the amp-iframe tag. See the inline comments.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async custom-element="amp-iframe" src="https://cdn.ampproject.org/v0/amp-iframe-latest.js"></script>
+|    <!-- Also include amp-bind to test special case interactions -->
+|    <script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-latest.js"></script>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|  <body>
+|    <!-- Valid: Basic tests -->
+|    <amp-iframe width="200" height="200" src="https://example.com"></amp-iframe>
+|    <amp-iframe width="200" height="200" srcdoc="<p>Hello World</p>"></amp-iframe>
+|  
+|    <!-- Valid: Allowed attributes tests -->
+|    <amp-iframe width="200" height="200" src="https://example.com" allow="geolocation; microphone" allowfullscreen allowpaymentrequest allowtransparency frameborder="0" referrerpolicy="origin" resizable sandbox="allow-same-origin allow-scripts" scrolling="no" ></amp-iframe>
+|  
+|    <!-- Valid: We allow the src attribute to be bindable -->
+|    <amp-iframe width="200" height="200" src="https://example.com" [src]="iframeurl"></amp-iframe>
+|  
+|    <!-- Invalid: We do not allow to bind to the src attribute, and also specify a srcdoc value -->
+|    <amp-iframe width="200" height="200" srcdoc="<p>Hello World</p>" [src]="iframeurl"></amp-iframe>
+>>   ^~~~~~~~~
 amp-iframe/0.1/test/validator-amp-iframe.html:44:2 The attribute 'src' in tag 'amp-iframe' is missing or incorrect, but required by attribute '[src]'. (see https://www.ampproject.org/docs/reference/components/amp-iframe) [DISALLOWED_HTML]
+|  
+|  
+|    <!-- Mandatory amp-state to avoid amp-bind validator errors -->
+|    <amp-state id=myState>
+|      <script type="application/json">
+|        {"iframeurl": "https://example.com"}
+|      </script>
+|    </amp-state>
+|  
+|  
+|  </body>
+|  </html>

--- a/extensions/amp-ima-video/0.1/test/validator-amp-ima-video.out
+++ b/extensions/amp-ima-video/0.1/test/validator-amp-ima-video.out
@@ -1,1 +1,39 @@
 PASS
+|  <!--
+|    Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Basic test for amp-ima-video.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <script async custom-element="amp-ima-video" src="https://cdn.ampproject.org/v0/amp-ima-video-0.1.js"></script>
+|  </head>
+|  <body>
+|    <amp-ima-video
+|        width=640 height=360 layout="responsive"
+|        data-src="https://s0.2mdn.net/4253510/google_ddm_animation_480P.mp4"
+|        data-tag="https://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/124319096/external/ad_rule_samples&ciu_szs=300x250&ad_rule=1&impl=s&gdfp_req=1&env=vp&output=vmap&unviewed_position_start=1&cust_params=deployment%3Ddevsite%26sample_ar%3Dpremidpost&cmsid=496&vid=short_onecue&correlator="
+|        data-poster="path/to/poster.png">
+|    </amp-ima-video>
+|  </body>
+|  </html>

--- a/extensions/amp-imgur/0.1/test/validator-amp-imgur.out
+++ b/extensions/amp-imgur/0.1/test/validator-amp-imgur.out
@@ -1,2 +1,39 @@
 FAIL
+|  <!--
+|    Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests for amp-imgur tag.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <script async custom-element="amp-imgur" src="https://cdn.ampproject.org/v0/amp-imgur-latest.js"></script>
+|  </head>
+|  <body>
+|    <!-- Valid: Example of amp-imgur usage -->
+|    <amp-imgur data-imgur-id="2CnX7" height="480" width="640" layout="responsive"></amp-imgur>
+|    <!-- Invalid: Missing mandatory data-imgur-id attribute -->
+|    <amp-imgur height="480" width="640" layout="responsive"></amp-imgur>
+>>   ^~~~~~~~~
 amp-imgur/0.1/test/validator-amp-imgur.html:34:2 The mandatory attribute 'data-imgur-id' is missing in tag 'amp-imgur'. (see https://www.ampproject.org/docs/reference/components/amp-imgur) [AMP_TAG_PROBLEM]
+|  </body>
+|  </html>

--- a/extensions/amp-instagram/0.1/test/validator-amp-instagram.out
+++ b/extensions/amp-instagram/0.1/test/validator-amp-instagram.out
@@ -1,1 +1,92 @@
 PASS
+|  <!--
+|    Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <title>Instagram examples</title>
+|    <link rel="canonical" href="amps.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+|    <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
+|    <script async custom-element="amp-instagram" src="https://cdn.ampproject.org/v0/amp-instagram-0.1.js"></script>
+|    <style amp-custom>
+|      body {
+|        background-color: white;
+|        padding: 20px;
+|      }
+|  
+|      amp-instagram [overflow] {
+|        position: absolute;
+|        bottom: 0;
+|        text-align: center;
+|        background: #444;
+|        color: white;
+|        padding: 5px;
+|      }
+|    </style>
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|  <body>
+|  
+|  
+|  
+|    <h2>Instagram</h2>
+|  
+|    <amp-instagram
+|        data-shortcode="fBwFP"
+|        width="381"
+|        height="381"
+|        layout="responsive">
+|    </amp-instagram>
+|  
+|    <h2>Instagram with Frame</h2>
+|    <amp-instagram
+|        data-shortcode="BR3g5NDBvBu"
+|        data-default-framing
+|        width="500"
+|        height="500"
+|        layout="responsive">
+|    </amp-instagram>
+|  
+|    <h2>Instagram with Frame, Caption and Overflow Element</h2>
+|    <amp-instagram
+|        data-shortcode="BR3g5NDBvBu"
+|        data-captioned
+|        data-default-framing
+|        width="500"
+|        height="500"
+|        layout="responsive">
+|        <div overflow>Show Caption</div>
+|    </amp-instagram>
+|  
+|    <h2>Instagram Default Layout</h2>
+|    <amp-instagram
+|        data-shortcode="fBwFP"
+|        width="381"
+|        height="381">
+|    </amp-instagram>
+|  
+|    <h3>Instagram Video</h3>
+|    <amp-instagram data-shortcode="ftMW4rmDM_"
+|                   width="300"
+|                   height="300"
+|                   layout="responsive">
+|    </amp-instagram>
+|  
+|  </body>
+|  </html>

--- a/extensions/amp-izlesene/0.1/test/validator-amp-izlesene.out
+++ b/extensions/amp-izlesene/0.1/test/validator-amp-izlesene.out
@@ -1,3 +1,52 @@
 FAIL
+|  <!--
+|    Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    This tests validation for the amp-izlesene tag.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|      <meta charset="utf-8">
+|      <title>İzlesene examples</title>
+|      <link rel="canonical" href="amps.html">
+|      <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+|      <link href="https://fonts.googleapis.com/css?family=Questrial" rel="stylesheet" type="text/css">
+|      <script async custom-element="amp-izlesene" src="https://cdn.ampproject.org/v0/amp-izlesene-0.1.js"></script>
+|       <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|      <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|  <body>
+|    <h2>İzlesene</h2>
+|  
+|    <!-- Valid -->
+|    <amp-izlesene data-videoid="7221390" width="480" height="270"></amp-izlesene>
+|  
+|    <!-- Valid -->
+|    <amp-izlesene data-videoid="7221390" width="480" height="270" layout="responsive"></amp-izlesene>
+|  
+|    <!-- Invalid: bad data-videoid. -->
+|    <amp-izlesene data-videoid="something else" width="480" height="270" layout="responsive"></amp-izlesene>
+>>   ^~~~~~~~~
 amp-izlesene/0.1/test/validator-amp-izlesene.html:42:2 The attribute 'data-videoid' in tag 'amp-izlesene' is set to the invalid value 'something else'. (see https://www.ampproject.org/docs/reference/components/amp-izlesene) [AMP_TAG_PROBLEM]
+|  
+|    <!-- Invalid: data-videoid missing. -->
+|    <amp-izlesene width="480" height="270" layout="responsive"></amp-izlesene>
+>>   ^~~~~~~~~
 amp-izlesene/0.1/test/validator-amp-izlesene.html:45:2 The mandatory attribute 'data-videoid' is missing in tag 'amp-izlesene'. (see https://www.ampproject.org/docs/reference/components/amp-izlesene) [AMP_TAG_PROBLEM]
+|  </body>
+|  </html>

--- a/extensions/amp-jwplayer/0.1/test/validator-amp-jwplayer.out
+++ b/extensions/amp-jwplayer/0.1/test/validator-amp-jwplayer.out
@@ -1,4 +1,59 @@
 FAIL
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests support for the amp-jwplayer tag.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <script async custom-element="amp-jwplayer" src="https://cdn.ampproject.org/v0/amp-jwplayer-0.1.js"></script>
+|  </head>
+|  <body>
+|    <!-- Example of a valid amp-jwplayer. -->
+|    <amp-jwplayer
+|        data-player-id="aBcD1234"
+|        data-media-id="5678WxYz"
+|        layout="responsive"
+|        width="160" height="90">
+|    </amp-jwplayer>
+|    <!-- Alternate valid example using a playlist rather than video. -->
+|    <amp-jwplayer
+|        data-player-id="aBcD1234"
+|        data-playlist-id="5678WxYz"
+|        width="160" height="90">
+|    <!-- Invalid example missing a player id. -->
+|    <amp-jwplayer
+>>   ^~~~~~~~~
 amp-jwplayer/0.1/test/validator-amp-jwplayer.html:44:2 The tag 'amp-jwplayer' is missing a mandatory attribute - pick one of data-media-id or data-playlist-id. (see https://www.ampproject.org/docs/reference/components/amp-jwplayer) [AMP_TAG_PROBLEM]
+>>   ^~~~~~~~~
 amp-jwplayer/0.1/test/validator-amp-jwplayer.html:44:2 The mandatory attribute 'data-player-id' is missing in tag 'amp-jwplayer'. (see https://www.ampproject.org/docs/reference/components/amp-jwplayer) [AMP_TAG_PROBLEM]
+|        data-playerlist-id="5678WxYz"
+|        width="160" height="90">
+|    <!-- Invalid example missing playlist id or media-id. -->
+|    <amp-jwplayer
+>>   ^~~~~~~~~
 amp-jwplayer/0.1/test/validator-amp-jwplayer.html:48:2 The tag 'amp-jwplayer' is missing a mandatory attribute - pick one of data-media-id or data-playlist-id. (see https://www.ampproject.org/docs/reference/components/amp-jwplayer) [AMP_TAG_PROBLEM]
+|        data-player-id="aBcD1234"
+|        width="160" height="90">
+|  </body>
+|  </html>

--- a/extensions/amp-kaltura-player/0.1/test/validator-amp-kaltura-player.out
+++ b/extensions/amp-kaltura-player/0.1/test/validator-amp-kaltura-player.out
@@ -1,2 +1,46 @@
 FAIL
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests for the amp-youtube tag. See the inline comments.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async custom-element="amp-kaltura-player" src="https://cdn.ampproject.org/v0/amp-kaltura-player-latest.js"></script>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|  <body>
+|    <!-- valid example from the documentation -->
+|    <amp-kaltura-player
+|       data-uiconf="33502051"
+|       data-partner="1281471"
+|       data-entryid="1_3ts1ms9c"
+|       data-param-streamerType = "auto"
+|       layout="responsive" width="480" height="270">
+|    </amp-kaltura-player>
+|  
+|    <!-- invalid example: data-partner is missing -->
+|    <amp-kaltura-player width="480" height="270"></amp-kaltura-player>
+>>   ^~~~~~~~~
 amp-kaltura-player/0.1/test/validator-amp-kaltura-player.html:41:2 The mandatory attribute 'data-partner' is missing in tag 'amp-kaltura-player'. (see https://www.ampproject.org/docs/reference/components/amp-kaltura-player) [AMP_TAG_PROBLEM]
+|  </body>
+|  </html>

--- a/extensions/amp-list/0.1/test/validator-amp-list.out
+++ b/extensions/amp-list/0.1/test/validator-amp-list.out
@@ -1,4 +1,65 @@
 FAIL
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests for the amp-list tag.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <script async custom-element="amp-list"
+|      src="https://cdn.ampproject.org/v0/amp-list-0.1.js"></script>
+|  </head>
+|  <body>
+|    <!-- Example of a valid amp-list -->
+|    <amp-list width=10 height=10
+|              src="https://data.com/articles.json?ref=CANONICAL_URL">
+|      <div></div>
+|    </amp-list>
+|    <!-- Valid amp-list with amp-bind attributes -->
+|    <amp-list width=10 height=10
+|              src="https://data.com/articles.json?ref=CANONICAL_URL"
+|              [src]="foo.bar" [state]="baz.qux">
+|      <div></div>
+|    </amp-list>
+|    <!-- Invalid: width is mistyped. -->
+|    <amp-list src="https://data.com/articles.json?ref=CANONICAL_URL"
+>>   ^~~~~~~~~
 amp-list/0.1/test/validator-amp-list.html:44:2 The attribute 'wdith' may not appear in tag 'amp-list'. (see https://www.ampproject.org/docs/reference/components/amp-list) [AMP_TAG_PROBLEM]
+|              wdith=10 height=10>
+|      <div></div>
+|    </amp-list>
+|    <!-- Invalid: src is missing. -->
+|    <amp-list width=10 height=10>
+>>   ^~~~~~~~~
 amp-list/0.1/test/validator-amp-list.html:49:2 The mandatory attribute 'src' is missing in tag 'amp-list'. (see https://www.ampproject.org/docs/reference/components/amp-list) [AMP_TAG_PROBLEM]
+|      <div></div>
+|    </amp-list>
+|    <!-- also invalid: width/height missing, so it's container layout
+|         which isn't supported. -->
+|    <amp-list src="https://data.com/articles.json?ref=CANONICAL_URL">
+>>   ^~~~~~~~~
 amp-list/0.1/test/validator-amp-list.html:54:2 The implied layout 'CONTAINER' is not supported by tag 'amp-list'. (see https://www.ampproject.org/docs/reference/components/amp-list) [AMP_LAYOUT_PROBLEM]
+|      <div></div>
+|    </amp-list>
+|  </body>
+|  </html>

--- a/extensions/amp-live-list/0.1/test/validator-amp-live-list.out
+++ b/extensions/amp-live-list/0.1/test/validator-amp-live-list.out
@@ -1,17 +1,157 @@
 FAIL
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests amp-live-list.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <script async custom-element="amp-live-list" src="https://cdn.ampproject.org/v0/amp-live-list-0.1.js"></script>
+|  </head>
+|  <body>
+|  
+|    <!-- Minimal valid example of an amp-live-list. -->
+|    <amp-live-list id="my-live-list" data-max-items-per-page="20">
+|      <button update on="tap:my-live-list.update">You have updates!</button>
+|      <div items></div>
+|      <!-- pagination is optional -->
+|      <div pagination></div>
+|    </amp-live-list>
+|  
+|    <!-- Example with items non-empty -->
+|    <amp-live-list id="my-live-list-1" data-poll-interval="15000" data-max-items-per-page="20">
+|      <button update>You have updates!</button>
+|      <ul items>
+|        <li id="1" data-sort-time="42" data-update-time="42">1</li>
+|        <li id="2" data-sort-time="43" data-update-time="44">2</li>
+|        <li id="3" data-sort-time="44" data-update-time="46">3</li>
+|      </ul>
+|      <div pagination></div>
+|    </amp-live-list>
+|  
+|    <!-- Example triggering CHILD_TAG_DOES_NOT_SATISFY_REFERENCE_POINT
+|         This example has the mandatory reference points, but also a couple
+|         extra child tags that don't have any reference point. -->
+|    <amp-live-list id="my-live-list-2" data-poll-interval="15000" data-max-items-per-page="20">
+|      <ul><li>a</li></ul>
+>>     ^~~~~~~~~
 amp-live-list/0.1/test/validator-amp-live-list.html:55:4 The tag 'ul', a child tag of 'amp-live-list', does not satisfy one of the acceptable reference points: AMP-LIVE-LIST [update], AMP-LIVE-LIST [items], AMP-LIVE-LIST [pagination]. (see https://www.ampproject.org/docs/reference/components/amp-live-list) [AMP_TAG_PROBLEM]
+|      <button>Update</button>
+>>     ^~~~~~~~~
 amp-live-list/0.1/test/validator-amp-live-list.html:56:4 The tag 'button', a child tag of 'amp-live-list', does not satisfy one of the acceptable reference points: AMP-LIVE-LIST [update], AMP-LIVE-LIST [items], AMP-LIVE-LIST [pagination]. (see https://www.ampproject.org/docs/reference/components/amp-live-list) [AMP_TAG_PROBLEM]
+|      <button update>You have updates!</button>
+|      <div items></div>
+|    </amp-live-list>
+|  
+|    <!-- Example triggering MANDATORY_REFERENCE_POINT_MISSING. In this
+|         case, one of the mandatory reference points (items) isn't
+|         present. -->
+|    <amp-live-list id="my-live-list-2" data-poll-interval="15000" data-max-items-per-page="20">
+>>   ^~~~~~~~~
 amp-live-list/0.1/test/validator-amp-live-list.html:64:2 The mandatory reference point 'AMP-LIVE-LIST [items]' for 'amp-live-list' is missing. (see https://www.ampproject.org/docs/reference/components/amp-live-list) [AMP_TAG_PROBLEM]
+|      <button update>You have updates!</button>
+|    </amp-live-list>
+|  
+|    <!-- Example of DUPLICATE_REFERENCE_POINT: update and pagination are
+|         present twice. -->
+|    <amp-live-list id="my-live-list-3" data-poll-interval="15000" data-max-items-per-page="20">
+>>   ^~~~~~~~~
 amp-live-list/0.1/test/validator-amp-live-list.html:70:2 The reference point 'AMP-LIVE-LIST [update]' for 'amp-live-list' must be unique but a duplicate was encountered. (see https://www.ampproject.org/docs/reference/components/amp-live-list) [AMP_TAG_PROBLEM]
+>>   ^~~~~~~~~
 amp-live-list/0.1/test/validator-amp-live-list.html:70:2 The reference point 'AMP-LIVE-LIST [pagination]' for 'amp-live-list' must be unique but a duplicate was encountered. (see https://www.ampproject.org/docs/reference/components/amp-live-list) [AMP_TAG_PROBLEM]
+|      <button update on="tap:my-live-list.update">You have updates!</button>
+|      <button update on="tap:my-live-list.update">You have updates!</button>
+|      <div items></div>
+|      <div pagination></div>
+|      <div pagination></div>
+|    </amp-live-list>
+|  
+|    <!-- Example showing disallowed tags. In this case the reference points are
+|         OK but the tags that attach to them are not: Reference point validation
+|         and regular tag validation are orthogonal. -->
+|    <amp-live-list id="my-live-list-4" data-poll-interval="15000" data-max-items-per-page="20">
+|      <img update src="button.gif" onclick="javascript:alert('u have updates!')">
+>>     ^~~~~~~~~
 amp-live-list/0.1/test/validator-amp-live-list.html:82:4 The tag 'img' may only appear as a descendant of tag 'noscript'. Did you mean 'amp-img'? (see https://www.ampproject.org/docs/reference/components/amp-img) [DISALLOWED_HTML_WITH_AMP_EQUIVALENT]
+|      <script items>
+>>     ^~~~~~~~~
 amp-live-list/0.1/test/validator-amp-live-list.html:83:4 Only AMP runtime 'script' tags are allowed, and only in the document head. (see https://www.ampproject.org/docs/reference/spec#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
+|        document.writeln('1, 2, 3');
+|      </script>
+|    </amp-live-list>
+|  
+|    <!-- Example with individual items not matching the reference point
+|         "AMP-LIVE-LIST [items] item" -->
+|    <amp-live-list id="my-live-list-5" data-poll-interval="15000" data-max-items-per-page="20">
+|      <button update>You have updates!</button>
+|      <ul items>
+|        <li id="1" data-update-time="42">1</li>  <!-- data-sort-time missing -->
+>>       ^~~~~~~~~
 amp-live-list/0.1/test/validator-amp-live-list.html:93:6 The mandatory attribute 'data-sort-time' is missing in tag 'AMP-LIVE-LIST [items] item'. (see https://www.ampproject.org/docs/reference/components/amp-live-list#items) [DISALLOWED_HTML]
+>>       ^~~~~~~~~
 amp-live-list/0.1/test/validator-amp-live-list.html:93:6 The tag 'li', a child tag of 'AMP-LIVE-LIST [items]', does not satisfy the reference point 'AMP-LIVE-LIST [items] item'. (see https://www.ampproject.org/docs/reference/components/amp-live-list#items) [AMP_TAG_PROBLEM]
+|        <li id="2" data-sort-time="43" data-update-time="44">2</li>
+|        <li data-update-time="44">3</li> <!-- id and data-sort-time missing -->
+>>       ^~~~~~~~~
 amp-live-list/0.1/test/validator-amp-live-list.html:95:6 The mandatory attribute 'id' is missing in tag 'AMP-LIVE-LIST [items] item'. (see https://www.ampproject.org/docs/reference/components/amp-live-list#items) [DISALLOWED_HTML]
+>>       ^~~~~~~~~
 amp-live-list/0.1/test/validator-amp-live-list.html:95:6 The mandatory attribute 'data-sort-time' is missing in tag 'AMP-LIVE-LIST [items] item'. (see https://www.ampproject.org/docs/reference/components/amp-live-list#items) [DISALLOWED_HTML]
+>>       ^~~~~~~~~
 amp-live-list/0.1/test/validator-amp-live-list.html:95:6 The tag 'li', a child tag of 'AMP-LIVE-LIST [items]', does not satisfy the reference point 'AMP-LIVE-LIST [items] item'. (see https://www.ampproject.org/docs/reference/components/amp-live-list#items) [AMP_TAG_PROBLEM]
+|        <p>junk</p> <!-- id, data-sort-time missing -->
+>>       ^~~~~~~~~
 amp-live-list/0.1/test/validator-amp-live-list.html:96:6 The mandatory attribute 'id' is missing in tag 'AMP-LIVE-LIST [items] item'. (see https://www.ampproject.org/docs/reference/components/amp-live-list#items) [DISALLOWED_HTML]
+>>       ^~~~~~~~~
 amp-live-list/0.1/test/validator-amp-live-list.html:96:6 The mandatory attribute 'data-sort-time' is missing in tag 'AMP-LIVE-LIST [items] item'. (see https://www.ampproject.org/docs/reference/components/amp-live-list#items) [DISALLOWED_HTML]
+>>       ^~~~~~~~~
 amp-live-list/0.1/test/validator-amp-live-list.html:96:6 The tag 'p', a child tag of 'AMP-LIVE-LIST [items]', does not satisfy the reference point 'AMP-LIVE-LIST [items] item'. (see https://www.ampproject.org/docs/reference/components/amp-live-list#items) [AMP_TAG_PROBLEM]
+|      </ul>
+|      <div pagination></div>
+|    </amp-live-list>
+|  
+|    <!-- amp-live-list can't be used for a reference point that defines reference
+|         points since it also defines reference points -->
+|    <amp-live-list id="my-live-list-6" data-poll-interval="15000" data-max-items-per-page="20">
+|      <button update on="tap:my-live-list-6.update">You have updates!</button>
+|      <amp-live-list items id="my-live-list-7" data-poll-interval="15000" data-max-items-per-page="20">
+>>     ^~~~~~~~~
 amp-live-list/0.1/test/validator-amp-live-list.html:105:4 The tag 'amp-live-list' conflicts with reference point 'AMP-LIVE-LIST [items]' because both define reference points. (see https://www.ampproject.org/docs/reference/components/amp-live-list#items) [AMP_TAG_PROBLEM]
+|        <button update on="tap:my-live-list-7.update">You have updates!</button>
+|        <div items></div>
+|      </amp-live-list>
+|    </amp-live-list>
+|  
+|    <!-- While the previous example showed how amp-live-list can't be used as the
+|         items reference point, it *can* be one of the items. -->
+|    <amp-live-list id="my-live-list-8" data-poll-interval="15000" data-max-items-per-page="20">
+|      <button update on="tap:my-live-list-8.update">You have updates!</button>
+|      <div items>
+|        <amp-live-list id="my-live-list-9" data-sort-time="43" data-update-time="44" data-poll-interval="15000" data-max-items-per-page="20">
+|          <button update on="tap:my-live-list-9.update">You have updates!</button>
+|          <div items></div>
+|        </amp-live-list>
+|      </div>
+|    </amp-live-list>
+|  
+|  </body>
+|  </html>

--- a/extensions/amp-mustache/0.1/test/validator-amp-mustache.out
+++ b/extensions/amp-mustache/0.1/test/validator-amp-mustache.out
@@ -1,72 +1,269 @@
 FAIL
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    This tests the logic for <template> tags and mustache variable replacements.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|  <body>
+|  
+|  <template type="amp-mustache">
+>> ^~~~~~~~~
 amp-mustache/0.1/test/validator-amp-mustache.html:31:0 The tag 'template' requires including the 'amp-mustache' extension JavaScript. (see https://www.ampproject.org/docs/reference/components/amp-mustache) [AMP_TAG_PROBLEM]
+|    <{{not-actually-parsed-as-an-html-tag-so-allowed}}>
+|    <p title="{{allowed}}">{{allowed}}</p>
+|    <p {{notallowed}}></p>
+>>   ^~~~~~~~~
 amp-mustache/0.1/test/validator-amp-mustache.html:34:2 Mustache template syntax in attribute name '{{notallowed}}' in tag 'p'. (see https://www.ampproject.org/docs/reference/components/dynamic/amp-mustache) [AMP_HTML_TEMPLATE_PROBLEM]
+|    <p {{notallowed}}=0></p>
+>>   ^~~~~~~~~
 amp-mustache/0.1/test/validator-amp-mustache.html:35:2 Mustache template syntax in attribute name '{{notallowed}}' in tag 'p'. (see https://www.ampproject.org/docs/reference/components/dynamic/amp-mustache) [AMP_HTML_TEMPLATE_PROBLEM]
+|    <p [{{notallowed}}]=0></p>
+>>   ^~~~~~~~~
 amp-mustache/0.1/test/validator-amp-mustache.html:36:2 Mustache template syntax in attribute name '[{{notallowed}}]' in tag 'p'. (see https://www.ampproject.org/docs/reference/components/dynamic/amp-mustache) [AMP_HTML_TEMPLATE_PROBLEM]
+|    <p data-{notallowed}=0></p>
+>>   ^~~~~~~~~
 amp-mustache/0.1/test/validator-amp-mustache.html:37:2 The attribute 'data-{notallowed}' may not appear in tag 'p'. [DISALLOWED_HTML]
+|    <p data-{{notallowed}}=0></p>
+>>   ^~~~~~~~~
 amp-mustache/0.1/test/validator-amp-mustache.html:38:2 Mustache template syntax in attribute name 'data-{{notallowed}}' in tag 'p'. (see https://www.ampproject.org/docs/reference/components/dynamic/amp-mustache) [AMP_HTML_TEMPLATE_PROBLEM]
+|    <p data-[{{notallowed}}]=0></p>
+>>   ^~~~~~~~~
 amp-mustache/0.1/test/validator-amp-mustache.html:39:2 Mustache template syntax in attribute name 'data-[{{notallowed}}]' in tag 'p'. (see https://www.ampproject.org/docs/reference/components/dynamic/amp-mustache) [AMP_HTML_TEMPLATE_PROBLEM]
+|    <p data-{{{notallowed}}}=0></p>
+>>   ^~~~~~~~~
 amp-mustache/0.1/test/validator-amp-mustache.html:40:2 Mustache template syntax in attribute name 'data-{{{notallowed}}}' in tag 'p'. (see https://www.ampproject.org/docs/reference/components/dynamic/amp-mustache) [AMP_HTML_TEMPLATE_PROBLEM]
+|    <p data-{{&notallowed}}=0></p>
+>>   ^~~~~~~~~
 amp-mustache/0.1/test/validator-amp-mustache.html:41:2 Mustache template syntax in attribute name 'data-{{&notallowed}}' in tag 'p'. (see https://www.ampproject.org/docs/reference/components/dynamic/amp-mustache) [AMP_HTML_TEMPLATE_PROBLEM]
+|    <p data-{{#notallowed}}=0></p>
+>>   ^~~~~~~~~
 amp-mustache/0.1/test/validator-amp-mustache.html:42:2 Mustache template syntax in attribute name 'data-{{#notallowed}}' in tag 'p'. (see https://www.ampproject.org/docs/reference/components/dynamic/amp-mustache) [AMP_HTML_TEMPLATE_PROBLEM]
+|    <p data-{{/notallowed}}=0></p>
+>>   ^~~~~~~~~
 amp-mustache/0.1/test/validator-amp-mustache.html:43:2 Mustache template syntax in attribute name 'data-{{/notallowed}}' in tag 'p'. (see https://www.ampproject.org/docs/reference/components/dynamic/amp-mustache) [AMP_HTML_TEMPLATE_PROBLEM]
+|    <p data-{{^notallowed}}=0></p>
+>>   ^~~~~~~~~
 amp-mustache/0.1/test/validator-amp-mustache.html:44:2 Mustache template syntax in attribute name 'data-{{^notallowed}}' in tag 'p'. (see https://www.ampproject.org/docs/reference/components/dynamic/amp-mustache) [AMP_HTML_TEMPLATE_PROBLEM]
+|    <p data-{{>notallowed}}=0></p>
+>>   ^~~~~~~~~
 amp-mustache/0.1/test/validator-amp-mustache.html:45:2 Mustache template syntax in attribute name 'data-{{' in tag 'p'. (see https://www.ampproject.org/docs/reference/components/dynamic/amp-mustache) [AMP_HTML_TEMPLATE_PROBLEM]
+|    <p {{#notallowed}}class=foo{{/notallowed}}>
+>>   ^~~~~~~~~
 amp-mustache/0.1/test/validator-amp-mustache.html:46:2 Mustache template syntax in attribute name '{{#notallowed}}class' in tag 'p'. (see https://www.ampproject.org/docs/reference/components/dynamic/amp-mustache) [AMP_HTML_TEMPLATE_PROBLEM]
+|    <p {{#notallowed}}class{{/notallowed}}>
+>>   ^~~~~~~~~
 amp-mustache/0.1/test/validator-amp-mustache.html:47:2 Mustache template syntax in attribute name '{{#notallowed}}class{{/notallowed}}' in tag 'p'. (see https://www.ampproject.org/docs/reference/components/dynamic/amp-mustache) [AMP_HTML_TEMPLATE_PROBLEM]
+|    <p title="{{{notallowed}}}"></p>
+>>   ^~~~~~~~~
 amp-mustache/0.1/test/validator-amp-mustache.html:48:2 The attribute 'title' in tag 'p' is set to '{{{notallowed}}}', which contains unescaped Mustache template syntax. (see https://www.ampproject.org/docs/reference/components/dynamic/amp-mustache) [AMP_HTML_TEMPLATE_PROBLEM]
+|    <p title="{{&notallowed}}"></p>
+>>   ^~~~~~~~~
 amp-mustache/0.1/test/validator-amp-mustache.html:49:2 The attribute 'title' in tag 'p' is set to '{{&notallowed}}', which contains unescaped Mustache template syntax. (see https://www.ampproject.org/docs/reference/components/dynamic/amp-mustache) [AMP_HTML_TEMPLATE_PROBLEM]
+|    <p title="{{>notallowed}}"></p>
+>>   ^~~~~~~~~
 amp-mustache/0.1/test/validator-amp-mustache.html:50:2 The attribute 'title' in tag 'p' is set to '{{>notallowed}}', which contains a Mustache template partial. (see https://www.ampproject.org/docs/reference/components/dynamic/amp-mustache) [AMP_HTML_TEMPLATE_PROBLEM]
+|    <p data-title="{{{notallowed}}}"></p>
+>>   ^~~~~~~~~
 amp-mustache/0.1/test/validator-amp-mustache.html:51:2 The attribute 'data-title' in tag 'p' is set to '{{{notallowed}}}', which contains unescaped Mustache template syntax. (see https://www.ampproject.org/docs/reference/components/dynamic/amp-mustache) [AMP_HTML_TEMPLATE_PROBLEM]
+|    <p data-title="{{&notallowed}}"></p>
+>>   ^~~~~~~~~
 amp-mustache/0.1/test/validator-amp-mustache.html:52:2 The attribute 'data-title' in tag 'p' is set to '{{&notallowed}}', which contains unescaped Mustache template syntax. (see https://www.ampproject.org/docs/reference/components/dynamic/amp-mustache) [AMP_HTML_TEMPLATE_PROBLEM]
+|    <p data-title="{{>notallowed}}"></p>
+>>   ^~~~~~~~~
 amp-mustache/0.1/test/validator-amp-mustache.html:53:2 The attribute 'data-title' in tag 'p' is set to '{{>notallowed}}', which contains a Mustache template partial. (see https://www.ampproject.org/docs/reference/components/dynamic/amp-mustache) [AMP_HTML_TEMPLATE_PROBLEM]
+|  
+|    <!-- now with some whitespace inside the mustache tags -->
+|    <{{ not-actually-parsed-as-an-html-tag-so-allowed }}>
+|    <p title="{{ allowed }}">{{ allowed }}</p>
+|    <p {{ notallowed }}></p>
+>>   ^~~~~~~~~
 amp-mustache/0.1/test/validator-amp-mustache.html:58:2 The attribute 'notallowed' may not appear in tag 'p'. [DISALLOWED_HTML]
+>>   ^~~~~~~~~
 amp-mustache/0.1/test/validator-amp-mustache.html:58:2 Mustache template syntax in attribute name '{{' in tag 'p'. (see https://www.ampproject.org/docs/reference/components/dynamic/amp-mustache) [AMP_HTML_TEMPLATE_PROBLEM]
+>>   ^~~~~~~~~
 amp-mustache/0.1/test/validator-amp-mustache.html:58:2 The attribute '}}' may not appear in tag 'p'. [DISALLOWED_HTML]
+|    <p {{ notallowed }}=0></p>
+>>   ^~~~~~~~~
 amp-mustache/0.1/test/validator-amp-mustache.html:59:2 The attribute 'notallowed' may not appear in tag 'p'. [DISALLOWED_HTML]
+>>   ^~~~~~~~~
 amp-mustache/0.1/test/validator-amp-mustache.html:59:2 Mustache template syntax in attribute name '{{' in tag 'p'. (see https://www.ampproject.org/docs/reference/components/dynamic/amp-mustache) [AMP_HTML_TEMPLATE_PROBLEM]
+>>   ^~~~~~~~~
 amp-mustache/0.1/test/validator-amp-mustache.html:59:2 The attribute '}}' may not appear in tag 'p'. [DISALLOWED_HTML]
+|    <p data-{{ notallowed }}=0></p>
+>>   ^~~~~~~~~
 amp-mustache/0.1/test/validator-amp-mustache.html:60:2 Mustache template syntax in attribute name 'data-{{' in tag 'p'. (see https://www.ampproject.org/docs/reference/components/dynamic/amp-mustache) [AMP_HTML_TEMPLATE_PROBLEM]
+>>   ^~~~~~~~~
 amp-mustache/0.1/test/validator-amp-mustache.html:60:2 The attribute 'notallowed' may not appear in tag 'p'. [DISALLOWED_HTML]
+>>   ^~~~~~~~~
 amp-mustache/0.1/test/validator-amp-mustache.html:60:2 The attribute '}}' may not appear in tag 'p'. [DISALLOWED_HTML]
+|    <p data-{{{ notallowed }}}=0></p>
+>>   ^~~~~~~~~
 amp-mustache/0.1/test/validator-amp-mustache.html:61:2 Mustache template syntax in attribute name 'data-{{{' in tag 'p'. (see https://www.ampproject.org/docs/reference/components/dynamic/amp-mustache) [AMP_HTML_TEMPLATE_PROBLEM]
+>>   ^~~~~~~~~
 amp-mustache/0.1/test/validator-amp-mustache.html:61:2 The attribute 'notallowed' may not appear in tag 'p'. [DISALLOWED_HTML]
+>>   ^~~~~~~~~
 amp-mustache/0.1/test/validator-amp-mustache.html:61:2 The attribute '}}}' may not appear in tag 'p'. [DISALLOWED_HTML]
+|    <p data-{{ &notallowed }}=0></p>
+>>   ^~~~~~~~~
 amp-mustache/0.1/test/validator-amp-mustache.html:62:2 The attribute '&notallowed' may not appear in tag 'p'. [DISALLOWED_HTML]
+>>   ^~~~~~~~~
 amp-mustache/0.1/test/validator-amp-mustache.html:62:2 Mustache template syntax in attribute name 'data-{{' in tag 'p'. (see https://www.ampproject.org/docs/reference/components/dynamic/amp-mustache) [AMP_HTML_TEMPLATE_PROBLEM]
+>>   ^~~~~~~~~
 amp-mustache/0.1/test/validator-amp-mustache.html:62:2 The attribute '}}' may not appear in tag 'p'. [DISALLOWED_HTML]
+|    <p data-{{ #notallowed }}=0></p>
+>>   ^~~~~~~~~
 amp-mustache/0.1/test/validator-amp-mustache.html:63:2 The attribute '#notallowed' may not appear in tag 'p'. [DISALLOWED_HTML]
+>>   ^~~~~~~~~
 amp-mustache/0.1/test/validator-amp-mustache.html:63:2 Mustache template syntax in attribute name 'data-{{' in tag 'p'. (see https://www.ampproject.org/docs/reference/components/dynamic/amp-mustache) [AMP_HTML_TEMPLATE_PROBLEM]
+>>   ^~~~~~~~~
 amp-mustache/0.1/test/validator-amp-mustache.html:63:2 The attribute '}}' may not appear in tag 'p'. [DISALLOWED_HTML]
+|    <p data-{{ /notallowed }}=0></p>
+>>   ^~~~~~~~~
 amp-mustache/0.1/test/validator-amp-mustache.html:64:2 The attribute '/notallowed' may not appear in tag 'p'. [DISALLOWED_HTML]
+>>   ^~~~~~~~~
 amp-mustache/0.1/test/validator-amp-mustache.html:64:2 Mustache template syntax in attribute name 'data-{{' in tag 'p'. (see https://www.ampproject.org/docs/reference/components/dynamic/amp-mustache) [AMP_HTML_TEMPLATE_PROBLEM]
+>>   ^~~~~~~~~
 amp-mustache/0.1/test/validator-amp-mustache.html:64:2 The attribute '}}' may not appear in tag 'p'. [DISALLOWED_HTML]
+|    <p data-{{ ^notallowed }}=0></p>
+>>   ^~~~~~~~~
 amp-mustache/0.1/test/validator-amp-mustache.html:65:2 The attribute '^notallowed' may not appear in tag 'p'. [DISALLOWED_HTML]
+>>   ^~~~~~~~~
 amp-mustache/0.1/test/validator-amp-mustache.html:65:2 Mustache template syntax in attribute name 'data-{{' in tag 'p'. (see https://www.ampproject.org/docs/reference/components/dynamic/amp-mustache) [AMP_HTML_TEMPLATE_PROBLEM]
+>>   ^~~~~~~~~
 amp-mustache/0.1/test/validator-amp-mustache.html:65:2 The attribute '}}' may not appear in tag 'p'. [DISALLOWED_HTML]
+|    <p data-{{ >notallowed }}=0></p>
+>>   ^~~~~~~~~
 amp-mustache/0.1/test/validator-amp-mustache.html:66:2 Mustache template syntax in attribute name 'data-{{' in tag 'p'. (see https://www.ampproject.org/docs/reference/components/dynamic/amp-mustache) [AMP_HTML_TEMPLATE_PROBLEM]
+|    <p {{ #notallowed }}class=foo{{ /notallowed }}>
+>>   ^~~~~~~~~
 amp-mustache/0.1/test/validator-amp-mustache.html:67:2 The attribute '#notallowed' may not appear in tag 'p'. [DISALLOWED_HTML]
+>>   ^~~~~~~~~
 amp-mustache/0.1/test/validator-amp-mustache.html:67:2 The attribute '/notallowed' may not appear in tag 'p'. [DISALLOWED_HTML]
+>>   ^~~~~~~~~
 amp-mustache/0.1/test/validator-amp-mustache.html:67:2 Mustache template syntax in attribute name '{{' in tag 'p'. (see https://www.ampproject.org/docs/reference/components/dynamic/amp-mustache) [AMP_HTML_TEMPLATE_PROBLEM]
+>>   ^~~~~~~~~
 amp-mustache/0.1/test/validator-amp-mustache.html:67:2 The attribute '}}' may not appear in tag 'p'. [DISALLOWED_HTML]
+>>   ^~~~~~~~~
 amp-mustache/0.1/test/validator-amp-mustache.html:67:2 The attribute '}}class' may not appear in tag 'p'. [DISALLOWED_HTML]
+|    <p {{ #notallowed }}class{{ /notallowed }}>
+>>   ^~~~~~~~~
 amp-mustache/0.1/test/validator-amp-mustache.html:68:2 The attribute '#notallowed' may not appear in tag 'p'. [DISALLOWED_HTML]
+>>   ^~~~~~~~~
 amp-mustache/0.1/test/validator-amp-mustache.html:68:2 The attribute '/notallowed' may not appear in tag 'p'. [DISALLOWED_HTML]
+>>   ^~~~~~~~~
 amp-mustache/0.1/test/validator-amp-mustache.html:68:2 Mustache template syntax in attribute name '{{' in tag 'p'. (see https://www.ampproject.org/docs/reference/components/dynamic/amp-mustache) [AMP_HTML_TEMPLATE_PROBLEM]
+>>   ^~~~~~~~~
 amp-mustache/0.1/test/validator-amp-mustache.html:68:2 The attribute '}}' may not appear in tag 'p'. [DISALLOWED_HTML]
+>>   ^~~~~~~~~
 amp-mustache/0.1/test/validator-amp-mustache.html:68:2 Mustache template syntax in attribute name '}}class{{' in tag 'p'. (see https://www.ampproject.org/docs/reference/components/dynamic/amp-mustache) [AMP_HTML_TEMPLATE_PROBLEM]
+|    <p title="{{{ notallowed }}}"></p>
+>>   ^~~~~~~~~
 amp-mustache/0.1/test/validator-amp-mustache.html:69:2 The attribute 'title' in tag 'p' is set to '{{{ notallowed }}}', which contains unescaped Mustache template syntax. (see https://www.ampproject.org/docs/reference/components/dynamic/amp-mustache) [AMP_HTML_TEMPLATE_PROBLEM]
+|    <p title="{{ &notallowed }}"></p>
+>>   ^~~~~~~~~
 amp-mustache/0.1/test/validator-amp-mustache.html:70:2 The attribute 'title' in tag 'p' is set to '{{ &notallowed }}', which contains unescaped Mustache template syntax. (see https://www.ampproject.org/docs/reference/components/dynamic/amp-mustache) [AMP_HTML_TEMPLATE_PROBLEM]
+|    <p title="{{ >notallowed }}"></p>
+>>   ^~~~~~~~~
 amp-mustache/0.1/test/validator-amp-mustache.html:71:2 The attribute 'title' in tag 'p' is set to '{{ >notallowed }}', which contains a Mustache template partial. (see https://www.ampproject.org/docs/reference/components/dynamic/amp-mustache) [AMP_HTML_TEMPLATE_PROBLEM]
+|    <p title="{{& notallowed }}"></p>
+>>   ^~~~~~~~~
 amp-mustache/0.1/test/validator-amp-mustache.html:72:2 The attribute 'title' in tag 'p' is set to '{{& notallowed }}', which contains unescaped Mustache template syntax. (see https://www.ampproject.org/docs/reference/components/dynamic/amp-mustache) [AMP_HTML_TEMPLATE_PROBLEM]
+|    <p title="{{> notallowed }}"></p>
+>>   ^~~~~~~~~
 amp-mustache/0.1/test/validator-amp-mustache.html:73:2 The attribute 'title' in tag 'p' is set to '{{> notallowed }}', which contains a Mustache template partial. (see https://www.ampproject.org/docs/reference/components/dynamic/amp-mustache) [AMP_HTML_TEMPLATE_PROBLEM]
+|    <p title="{{ & notallowed }}"></p>
+>>   ^~~~~~~~~
 amp-mustache/0.1/test/validator-amp-mustache.html:74:2 The attribute 'title' in tag 'p' is set to '{{ & notallowed }}', which contains unescaped Mustache template syntax. (see https://www.ampproject.org/docs/reference/components/dynamic/amp-mustache) [AMP_HTML_TEMPLATE_PROBLEM]
+|    <p title="{{ > notallowed }}"></p>
+>>   ^~~~~~~~~
 amp-mustache/0.1/test/validator-amp-mustache.html:75:2 The attribute 'title' in tag 'p' is set to '{{ > notallowed }}', which contains a Mustache template partial. (see https://www.ampproject.org/docs/reference/components/dynamic/amp-mustache) [AMP_HTML_TEMPLATE_PROBLEM]
+|  
+|    <!-- Note, this is allowed by the validator, but it is critical that it
+|         be sanitized by the runtime. If the runtime allowed this, then after
+|         rendering (assuming #off was null) we would have:
+|        <a href="javascript:alert('foo')"></a>
+|     -->
+|    <a href="{{#off}}"></a>
+|      {{/off}}javascript:alert('foo'){{#off}}
+|    <a href="{{/off}"></a>
+|  
+|    <!-- Allowed by the validator, but could lead to script execution
+|         depending on the value. -->
+|    <a href="{{foo}}"></a>
+|    <a href="java{{foo}}script:alert('foo')"></a>
+|  
+|    <!-- Really tricky example that the validator allows, but the runtime
+|         must handle. Essentially if {{foo}} is an empty string, this becomes
+|         a <script> tag, otherwise, it's just a harmless comment -->
+|    <!-- comment --{{foo}}><script><!-- -->
+|  
+|  </template>
+|  
+|  <template type="amp-mustache">
+>> ^~~~~~~~~
 amp-mustache/0.1/test/validator-amp-mustache.html:98:0 The tag 'template' requires including the 'amp-mustache' extension JavaScript. (see https://www.ampproject.org/docs/reference/components/amp-mustache) [AMP_TAG_PROBLEM]
+|    <div>
+|      <template type="amp-mustache">
+>>     ^~~~~~~~~
 amp-mustache/0.1/test/validator-amp-mustache.html:100:4 The tag 'template' may not appear as a descendant of tag 'template'. (see https://www.ampproject.org/docs/reference/components/amp-mustache) [AMP_HTML_TEMPLATE_PROBLEM]
+>>     ^~~~~~~~~
 amp-mustache/0.1/test/validator-amp-mustache.html:100:4 The tag 'template' requires including the 'amp-mustache' extension JavaScript. (see https://www.ampproject.org/docs/reference/components/amp-mustache) [AMP_TAG_PROBLEM]
+|        Nested Template tags are not allowed.
+|      </template>
+|    </div>
+|  </template>
+|  
+|  <!-- Not descendant from a template, so mustache attribute values are OK -->
+|  <p title="{{{allowed }}}"></p>
+|  <p title="{{&allowed }}"></p>
+|  <p title="{{>allowed }}"></p>
+|  
+|  <!-- Inside a template, attribute value restrictions are relaxed. -->
+|  <amp-audio src="https://example.com/audio" layout="fixed" autoplay="{{invalid}}">
+>> ^~~~~~~~~
 amp-mustache/0.1/test/validator-amp-mustache.html:112:0 The attribute 'autoplay' in tag 'amp-audio' is set to the invalid value '{{invalid}}'. (see https://www.ampproject.org/docs/reference/components/amp-audio) [AMP_TAG_PROBLEM]
+>> ^~~~~~~~~
 amp-mustache/0.1/test/validator-amp-mustache.html:112:0 The tag 'amp-audio' requires including the 'amp-audio' extension JavaScript. (see https://www.ampproject.org/docs/reference/components/amp-audio) [AMP_TAG_PROBLEM]
+|  <template type="amp-mustache">
+>> ^~~~~~~~~
 amp-mustache/0.1/test/validator-amp-mustache.html:113:0 The tag 'template' requires including the 'amp-mustache' extension JavaScript. (see https://www.ampproject.org/docs/reference/components/amp-mustache) [AMP_TAG_PROBLEM]
+|  <amp-audio src="https://example.com/audio" layout="fixed" autoplay="{{valid}}">
+>> ^~~~~~~~~
 amp-mustache/0.1/test/validator-amp-mustache.html:114:0 The tag 'amp-audio' requires including the 'amp-audio' extension JavaScript. (see https://www.ampproject.org/docs/reference/components/amp-audio) [AMP_TAG_PROBLEM]
+|  </template>
+|  
+|  <!-- Since layout calculations follow a different code path, test that layouts
+|       validate. -->
+|  <!-- See https://github.com/ampproject/amphtml/issues/2670 -->
+|  <template type="amp-mustache">
+>> ^~~~~~~~~
 amp-mustache/0.1/test/validator-amp-mustache.html:120:0 The tag 'template' requires including the 'amp-mustache' extension JavaScript. (see https://www.ampproject.org/docs/reference/components/amp-mustache) [AMP_TAG_PROBLEM]
+|  <amp-img src="{{image.url}}" width={{image.width}} height={{image.height}}></amp-img>
+|  </template>
+|  
+|  
+|  </body>
+|  </html>

--- a/extensions/amp-nexxtv-player/0.1/test/validator-amp-nexxtv-player.out
+++ b/extensions/amp-nexxtv-player/0.1/test/validator-amp-nexxtv-player.out
@@ -1,3 +1,75 @@
 FAIL
+|  <!--
+|    Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests for the amp-nexxtv-player tag.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|      <meta charset="utf-8">
+|      <link rel="canonical" href="./regular-html-version.html">
+|      <meta name="viewport" content="width=device-width,minimum-scale=1">
+|      <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|  
+|      <!-- <script async custom-element="amp-nexxtv-player" src="/dist/v0/amp-nexxtv-player-0.1.max.js"></script>
+|      <script async src="/dist/amp.js"></script> -->
+|      <script async custom-element="amp-nexxtv-player" src="https://cdn.ampproject.org/v0/amp-nexxtv-player-latest.js"></script>
+|      <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|  <body>
+|  
+|      <!-- valid -->
+|      <amp-nexxtv-player
+|          data-mediaid="71QQG852413DU7J"
+|          data-client="761"
+|          data-streamtype="video"
+|          layout="responsive"
+|          width="480" height="270"
+|      ></amp-nexxtv-player>
+|  
+|      <!-- valid, with optional data -->
+|      <amp-nexxtv-player
+|              data-mediaid="71QQG852413DU7J"
+|              data-client="761"
+|              data-streamtype="video"
+|              data-seek-to="0"
+|              data-mode="api"
+|              data-origin="https://embed.nexx.cloud/"
+|              data-disable-ads="1"
+|              data-streaming-filter="nxp-bitrate-2500"
+|              layout="responsive"
+|              width="480" height="270"
+|      ></amp-nexxtv-player>
+|  
+|      <!-- invalid, needs data-mediaid -->
+|      <amp-nexxtv-player
+>>     ^~~~~~~~~
 amp-nexxtv-player/0.1/test/validator-amp-nexxtv-player.html:59:4 The mandatory attribute 'data-mediaid' is missing in tag 'amp-nexxtv-player'. (see https://www.ampproject.org/docs/reference/components/amp-nexxtv-player) [AMP_TAG_PROBLEM]
+|              data-client="761"
+|              width="480" height="270"
+|      ></amp-nexxtv-player>
+|  
+|      <!-- invalid, needs data-client -->
+|      <amp-nexxtv-player
+>>     ^~~~~~~~~
 amp-nexxtv-player/0.1/test/validator-amp-nexxtv-player.html:65:4 The mandatory attribute 'data-client' is missing in tag 'amp-nexxtv-player'. (see https://www.ampproject.org/docs/reference/components/amp-nexxtv-player) [AMP_TAG_PROBLEM]
+|              data-mediaid="71QQG852413DU7J"
+|              width="480" height="270"
+|      ></amp-nexxtv-player>
+|  </body>
+|  </html>

--- a/extensions/amp-o2-player/0.1/test/validator-amp-o2-player.out
+++ b/extensions/amp-o2-player/0.1/test/validator-amp-o2-player.out
@@ -1,3 +1,66 @@
 FAIL
+|  <!--
+|    Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests support for the amp-o2-player tag.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async custom-element="amp-o2-player" src="https://cdn.ampproject.org/v0/amp-o2-player-latest.js"></script>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|  <body>
+|    <!-- Example of a valid amp-o2-player -->
+|    <amp-o2-player
+|        data-pid="573d9bf1e4b02a3388f42c36"
+|        data-bcid="50d595ec0364e95588c77bd2"
+|        layout="responsive" width="480" height="270">
+|    </amp-o2-player>
+|  
+|    <!-- Valid: data-vid is optional -->
+|    <amp-o2-player
+|        data-pid="573d9bf1e4b02a3388f42c36"
+|        data-bcid="50d595ec0364e95588c77bd2"
+|        data-bid="573d9bd3e4b00df34e4325ed"
+|        data-macros="m.playertype=HTML5"
+|        layout="responsive" width="480" height="270">
+|    </amp-o2-player>
+|  
+|    <!-- Invalid: bcid is needed;
+|         leaving it out results in an error. -->
+|    <amp-o2-player
+>>   ^~~~~~~~~
 amp-o2-player/0.1/test/validator-amp-o2-player.html:49:2 The mandatory attribute 'data-bcid' is missing in tag 'amp-o2-player'. (see https://www.ampproject.org/docs/reference/components/amp-o2-player) [AMP_TAG_PROBLEM]
+|        data-pid="573d9bf1e4b02a3388f42c36"
+|        layout="responsive" width="480" height="270">
+|    </amp-o2-player>
+|  
+|    <!-- Invalid: pid is needed;
+|           leaving it out results in an error. -->
+|    <amp-o2-player
+>>   ^~~~~~~~~
 amp-o2-player/0.1/test/validator-amp-o2-player.html:56:2 The mandatory attribute 'data-pid' is missing in tag 'amp-o2-player'. (see https://www.ampproject.org/docs/reference/components/amp-o2-player) [AMP_TAG_PROBLEM]
+|        data-bcid="50d595ec0364e95588c77bd2"
+|        layout="responsive" width="480" height="270">
+|    </amp-o2-player>
+|  </body>
+|  </html>

--- a/extensions/amp-ooyala-player/0.1/test/validator-amp-ooyala.out
+++ b/extensions/amp-ooyala-player/0.1/test/validator-amp-ooyala.out
@@ -1,4 +1,81 @@
 FAIL
+|  <!--
+|    Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests for the amp-ooyala-player tag. See the inline comments.
+|  -->
+|  <!doctype html>
+|  <html amp lang="en">
+|    <head>
+|      <meta charset="utf-8">
+|      <link rel="canonical" href="./regular-html-version.html">
+|      <meta name="viewport" content="width=device-width,minimum-scale=1">
+|      <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|      <script async custom-element="amp-ooyala-player" src="https://cdn.ampproject.org/v0/amp-ooyala-player-latest.js"></script>
+|      <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    </head>
+|    <body>
+|      <!-- valid -->
+|      <amp-ooyala-player
+|        height=400
+|        width=400
+|        data-embedcode="xkeHRiMjE6ls2aXoPoiqmPO6IU8HtXsg"
+|        data-pcode="5zb2wxOlZcNCe_HVT3a6cawW298X"
+|        data-playerid="26e2e3c1049c4e70ae08a242638b5c40"
+|        data-playerversion="v4">
+|      </amp-ooyala-player>
+|  
+|      <!-- valid, uses V3 player by default -->
+|      <amp-ooyala-player
+|        height=400
+|        width=400
+|        data-embedcode="xkeHRiMjE6ls2aXoPoiqmPO6IU8HtXsg"
+|        data-pcode="5zb2wxOlZcNCe_HVT3a6cawW298X"
+|        data-playerid="26e2e3c1049c4e70ae08a242638b5c40">
+|      </amp-ooyala-player>
+|  
+|      <!-- invalid, needs data-pcode -->
+|      <amp-ooyala-player
+>>     ^~~~~~~~~
 amp-ooyala-player/0.1/test/validator-amp-ooyala.html:51:4 The mandatory attribute 'data-pcode' is missing in tag 'amp-ooyala-player'. (see https://www.ampproject.org/docs/reference/components/amp-ooyala-player) [AMP_TAG_PROBLEM]
+|        height=400
+|        width=400
+|        data-embedcode="xkeHRiMjE6ls2aXoPoiqmPO6IU8HtXsg"
+|        data-playerid="26e2e3c1049c4e70ae08a242638b5c40">
+|      </amp-ooyala-player>
+|  
+|      <!-- invalid, needs data-embedcode -->
+|      <amp-ooyala-player
+>>     ^~~~~~~~~
 amp-ooyala-player/0.1/test/validator-amp-ooyala.html:59:4 The mandatory attribute 'data-embedcode' is missing in tag 'amp-ooyala-player'. (see https://www.ampproject.org/docs/reference/components/amp-ooyala-player) [AMP_TAG_PROBLEM]
+|        height=400
+|        width=400
+|        data-pcode="5zb2wxOlZcNCe_HVT3a6cawW298X"
+|        data-playerid="26e2e3c1049c4e70ae08a242638b5c40">
+|      </amp-ooyala-player>
+|  
+|      <!-- invalid, needs data-playerid -->
+|      <amp-ooyala-player
+>>     ^~~~~~~~~
 amp-ooyala-player/0.1/test/validator-amp-ooyala.html:67:4 The mandatory attribute 'data-playerid' is missing in tag 'amp-ooyala-player'. (see https://www.ampproject.org/docs/reference/components/amp-ooyala-player) [AMP_TAG_PROBLEM]
+|        height=400
+|        width=400
+|        data-embedcode="xkeHRiMjE6ls2aXoPoiqmPO6IU8HtXsg"
+|        data-pcode="5zb2wxOlZcNCe_HVT3a6cawW298X">
+|      </amp-ooyala-player>
+|    </body>
+|  </html>

--- a/extensions/amp-pinterest/0.1/test/validator-amp-pinterest.out
+++ b/extensions/amp-pinterest/0.1/test/validator-amp-pinterest.out
@@ -1,1 +1,57 @@
 PASS
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests support for the amp-pinterest tag.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <script async custom-element="amp-pinterest" src="https://cdn.ampproject.org/v0/amp-pinterest-0.1.js"></script>
+|  </head>
+|  <body>
+|    <!-- Example of a valid amp-pinterest (pin it button) -->
+|    <amp-pinterest
+|        height=20
+|        width=40
+|        data-do="buttonPin"
+|        data-url="http://www.flickr.com/photos/kentbrew/6851755809/"
+|        data-media="http://farm8.staticflickr.com/7027/6851755809_df5b2051c9_z.jpg"
+|        data-description="Next stop: Pinterest">
+|    </amp-pinterest>
+|    <!-- Example of a valid amp-pinterest (follow button) -->
+|    <amp-pinterest
+|        height=20
+|        width=94
+|        data-do="buttonFollow"
+|        data-href="https://www.pinterest.com/kentbrew/"
+|        data-label="Kent Brewster">
+|    </amp-pinterest>
+|    <!-- Example of a valid amp-pinterest (embedded pin widget) -->
+|    <amp-pinterest
+|        width=245
+|        height=330
+|        data-do="embedPin"
+|        data-url="https://www.pinterest.com/pin/99360735500167749">
+|    </amp-pinterest>
+|  </body>
+|  </html>

--- a/extensions/amp-playbuzz/0.1/test/validator-amp-playbuzz.out
+++ b/extensions/amp-playbuzz/0.1/test/validator-amp-playbuzz.out
@@ -1,1 +1,92 @@
 PASS
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests amp-playbuzz
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <title>playbuzz examples</title>
+|    <link rel="canonical" href="amps.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+|    <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
+|    <script async custom-element="amp-playbuzz" src="https://cdn.ampproject.org/v0/amp-playbuzz-latest.js"></script>
+|  
+|    <style amp-custom>
+|      body {
+|        background-color: auto;
+|      }
+|    </style>
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|  <body>
+|  
+|  
+|     <div>
+|  
+|    <h1>Times.com</h1>
+|    <h2>Some Article</h2>
+|  
+|  
+|    <p>orem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus felis arcu, vehicula sed pretium eget, pulvinar eu elit. Ut nibh nulla, pharetra at tristique at, pharetra et mi. Ut elementum quam eu feugiat varius. Vestibulum dui ligula, dapibus at suscipit venenatis, elementum vitae libero. Vivamus efficitur nibh et tortor semper, sit amet interdum augue tempor. Nulla vitae tempus dolor, ac molestie odio. Cras cursus, lectus ac consectetur scelerisque, mi arcu egestas velit, ac ultricies est mi aliquam enim. Aenean ac neque in arcu euismod ornare. Fusce sodales massa ac lectus finibus rutrum. Nunc laoreet nunc id rutrum vehicula. Sed tempor turpis posuere, auctor elit quis, ultricies ligula. Maecenas posuere pulvinar mi, ac congue nulla placerat nec.</p>
+|       <amp-playbuzz
+|              src="https://www.playbuzz.com/wespeakmusic10/can-you-name-these-debut-albums"
+|              layout="responsive"
+|              height="300"
+|              width="300"
+|              data-item-info="false"
+|              data-share-buttons="false"
+|              data-comments="false">
+|          </amp-playbuzz>
+|  
+|    <p>orem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus felis arcu, vehicula sed pretium eget, pulvinar eu elit. Ut nibh nulla, pharetra at tristique at, pharetra et mi. Ut elementum quam eu feugiat varius. Vestibulum dui ligula, dapibus at suscipit venenatis, elementum vitae libero. Vivamus efficitur nibh et tortor semper, sit amet interdum augue tempor. Nulla vitae tempus dolor, ac molestie odio. Cras cursus, lectus ac consectetur scelerisque, mi arcu egestas velit, ac ultricies est mi aliquam enim. Aenean ac neque in arcu euismod ornare. Fusce sodales massa ac lectus finibus rutrum. Nunc laoreet nunc id rutrum vehicula. Sed tempor turpis posuere, auctor elit quis, ultricies ligula. Maecenas posuere pulvinar mi, ac congue nulla placerat nec.</p>
+|  
+|        <amp-playbuzz
+|              src="https://www.playbuzz.com/HistoryUK/10-classic-christmas-movies"
+|              layout="responsive"
+|              height="300"
+|              width="300"
+|              data-item-info="false"
+|              data-share-buttons="false"
+|              data-comments="false">
+|          </amp-playbuzz>
+|  
+|    <p>orem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus felis arcu, vehicula sed pretium eget, pulvinar eu elit. Ut nibh nulla, pharetra at tristique at, pharetra et mi. Ut elementum quam eu feugiat varius. Vestibulum dui ligula, dapibus at suscipit venenatis, elementum vitae libero. Vivamus efficitur nibh et tortor semper, sit amet interdum augue tempor. Nulla vitae tempus dolor, ac molestie odio. Cras cursus, lectus ac consectetur scelerisque, mi arcu egestas velit, ac ultricies est mi aliquam enim. Aenean ac neque in arcu euismod ornare. Fusce sodales massa ac lectus finibus rutrum. Nunc laoreet nunc id rutrum vehicula. Sed tempor turpis posuere, auctor elit quis, ultricies ligula. Maecenas posuere pulvinar mi, ac congue nulla placerat nec.</p>
+|  
+|  
+|           <amp-playbuzz
+|              src="http://www.playbuzz.com/perezhilton/vote-for-the-worst-dressed-at-the-2016-american-music-awards-here"
+|              layout="responsive"
+|              height="300"
+|              width="300"
+|              data-item-info="true"
+|              data-share-buttons="true"
+|              data-comments="true">
+|          </amp-playbuzz>
+|  
+|          <p>orem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus felis arcu, vehicula sed pretium eget, pulvinar eu elit. Ut nibh nulla, pharetra at tristique at, pharetra et mi. Ut elementum quam eu feugiat varius. Vestibulum dui ligula, dapibus at suscipit venenatis, elementum vitae libero. Vivamus efficitur nibh et tortor semper, sit amet interdum augue tempor. Nulla vitae tempus dolor, ac molestie odio. Cras cursus, lectus ac consectetur scelerisque, mi arcu egestas velit, ac ultricies est mi aliquam enim. Aenean ac neque in arcu euismod ornare. Fusce sodales massa ac lectus finibus rutrum. Nunc laoreet nunc id rutrum vehicula. Sed tempor turpis posuere, auctor elit quis, ultricies ligula. Maecenas posuere pulvinar mi, ac congue nulla placerat nec.</p>
+|  
+|  
+|      </div>
+|  
+|  <footer>Footer</footer>
+|  
+|  </body>
+|  </html>

--- a/extensions/amp-position-observer/0.1/test/validator-amp-position-observer.out
+++ b/extensions/amp-position-observer/0.1/test/validator-amp-position-observer.out
@@ -1,22 +1,116 @@
 FAIL
+|  <!--
+|    Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests amp-position-observer.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <script async custom-element="amp-position-observer" src="https://cdn.ampproject.org/v0/amp-position-observer-0.1.js"></script>
+|  </head>
+|  <body>
+|    <!-- Valid -->
+|    <amp-position-observer layout="nodisplay"></amp-position-observer>
+|    <amp-position-observer layout="nodisplay" on="enter:foo;exit:bar;scroll:baz(percent=event.percent)"></amp-position-observer>
+|    <amp-position-observer target="#id" layout="nodisplay"></amp-position-observer>
+|    <amp-position-observer intersection-ratios="0" layout="nodisplay"></amp-position-observer>
+|    <amp-position-observer intersection-ratios="1" layout="nodisplay"></amp-position-observer>
+|    <amp-position-observer intersection-ratios="0.5" layout="nodisplay"></amp-position-observer>
+|    <amp-position-observer intersection-ratios="0.5 0" layout="nodisplay"></amp-position-observer>
+|    <amp-position-observer intersection-ratios="1 0.5" layout="nodisplay"></amp-position-observer>
+|    <amp-position-observer viewport-margins="100" layout="nodisplay"></amp-position-observer>
+|    <amp-position-observer viewport-margins="100 200" layout="nodisplay"></amp-position-observer>
+|    <amp-position-observer viewport-margins="100vh" layout="nodisplay"></amp-position-observer>
+|    <amp-position-observer viewport-margins="100px" layout="nodisplay"></amp-position-observer>
+|    <amp-position-observer viewport-margins="100px 200" layout="nodisplay"></amp-position-observer>
+|    <amp-position-observer viewport-margins="100px 200vh" layout="nodisplay"></amp-position-observer>
+|    <amp-position-observer viewport-margins="100vh 200px" layout="nodisplay"></amp-position-observer>
+|    <amp-position-observer viewport-margins="100 200vh" layout="nodisplay"></amp-position-observer>
+|    <!-- Invalid: missing required layout value -->
+|    <amp-position-observer></amp-position-observer>
+>>   ^~~~~~~~~
 amp-position-observer/0.1/test/validator-amp-position-observer.html:49:2 The implied layout 'CONTAINER' is not supported by tag 'amp-position-observer'. (see https://www.ampproject.org/docs/reference/components/amp-position-observer) [AMP_LAYOUT_PROBLEM]
+|    <!-- Invalid: interesection-ratios not valid entries -->
+|    <amp-position-observer intersection-ratios="" layout="nodisplay"></amp-position-observer>
+>>   ^~~~~~~~~
 amp-position-observer/0.1/test/validator-amp-position-observer.html:51:2 The attribute 'intersection-ratios' in tag 'amp-position-observer' is set to the invalid value ''. (see https://www.ampproject.org/docs/reference/components/amp-position-observer) [AMP_TAG_PROBLEM]
+|    <amp-position-observer intersection-ratios="1.1" layout="nodisplay"></amp-position-observer>
+>>   ^~~~~~~~~
 amp-position-observer/0.1/test/validator-amp-position-observer.html:52:2 The attribute 'intersection-ratios' in tag 'amp-position-observer' is set to the invalid value '1.1'. (see https://www.ampproject.org/docs/reference/components/amp-position-observer) [AMP_TAG_PROBLEM]
+|    <amp-position-observer intersection-ratios="0.b" layout="nodisplay"></amp-position-observer>
+>>   ^~~~~~~~~
 amp-position-observer/0.1/test/validator-amp-position-observer.html:53:2 The attribute 'intersection-ratios' in tag 'amp-position-observer' is set to the invalid value '0.b'. (see https://www.ampproject.org/docs/reference/components/amp-position-observer) [AMP_TAG_PROBLEM]
+|    <amp-position-observer intersection-ratios="foo" layout="nodisplay"></amp-position-observer>
+>>   ^~~~~~~~~
 amp-position-observer/0.1/test/validator-amp-position-observer.html:54:2 The attribute 'intersection-ratios' in tag 'amp-position-observer' is set to the invalid value 'foo'. (see https://www.ampproject.org/docs/reference/components/amp-position-observer) [AMP_TAG_PROBLEM]
+|    <amp-position-observer intersection-ratios="3" layout="nodisplay"></amp-position-observer>
+>>   ^~~~~~~~~
 amp-position-observer/0.1/test/validator-amp-position-observer.html:55:2 The attribute 'intersection-ratios' in tag 'amp-position-observer' is set to the invalid value '3'. (see https://www.ampproject.org/docs/reference/components/amp-position-observer) [AMP_TAG_PROBLEM]
+|    <amp-position-observer intersection-ratios="0.a 0.b" layout="nodisplay"></amp-position-observer>
+>>   ^~~~~~~~~
 amp-position-observer/0.1/test/validator-amp-position-observer.html:56:2 The attribute 'intersection-ratios' in tag 'amp-position-observer' is set to the invalid value '0.a 0.b'. (see https://www.ampproject.org/docs/reference/components/amp-position-observer) [AMP_TAG_PROBLEM]
+|    <amp-position-observer intersection-ratios="0.5 foo" layout="nodisplay"></amp-position-observer>
+>>   ^~~~~~~~~
 amp-position-observer/0.1/test/validator-amp-position-observer.html:57:2 The attribute 'intersection-ratios' in tag 'amp-position-observer' is set to the invalid value '0.5 foo'. (see https://www.ampproject.org/docs/reference/components/amp-position-observer) [AMP_TAG_PROBLEM]
+|    <amp-position-observer intersection-ratios="0.5 1.1" layout="nodisplay"></amp-position-observer>
+>>   ^~~~~~~~~
 amp-position-observer/0.1/test/validator-amp-position-observer.html:58:2 The attribute 'intersection-ratios' in tag 'amp-position-observer' is set to the invalid value '0.5 1.1'. (see https://www.ampproject.org/docs/reference/components/amp-position-observer) [AMP_TAG_PROBLEM]
+|    <amp-position-observer intersection-ratios="0.5 4" layout="nodisplay"></amp-position-observer>
+>>   ^~~~~~~~~
 amp-position-observer/0.1/test/validator-amp-position-observer.html:59:2 The attribute 'intersection-ratios' in tag 'amp-position-observer' is set to the invalid value '0.5 4'. (see https://www.ampproject.org/docs/reference/components/amp-position-observer) [AMP_TAG_PROBLEM]
+|    <amp-position-observer intersection-ratios="foo 0.5" layout="nodisplay"></amp-position-observer>
+>>   ^~~~~~~~~
 amp-position-observer/0.1/test/validator-amp-position-observer.html:60:2 The attribute 'intersection-ratios' in tag 'amp-position-observer' is set to the invalid value 'foo 0.5'. (see https://www.ampproject.org/docs/reference/components/amp-position-observer) [AMP_TAG_PROBLEM]
+|    <amp-position-observer intersection-ratios="1.1 0.5" layout="nodisplay"></amp-position-observer>
+>>   ^~~~~~~~~
 amp-position-observer/0.1/test/validator-amp-position-observer.html:61:2 The attribute 'intersection-ratios' in tag 'amp-position-observer' is set to the invalid value '1.1 0.5'. (see https://www.ampproject.org/docs/reference/components/amp-position-observer) [AMP_TAG_PROBLEM]
+|    <amp-position-observer intersection-ratios="4 0.5" layout="nodisplay"></amp-position-observer>
+>>   ^~~~~~~~~
 amp-position-observer/0.1/test/validator-amp-position-observer.html:62:2 The attribute 'intersection-ratios' in tag 'amp-position-observer' is set to the invalid value '4 0.5'. (see https://www.ampproject.org/docs/reference/components/amp-position-observer) [AMP_TAG_PROBLEM]
+|    <!-- Invalid: viewport-margins not valid entries -->
+|    <amp-position-observer viewport-margins="" layout="nodisplay"></amp-position-observer>
+>>   ^~~~~~~~~
 amp-position-observer/0.1/test/validator-amp-position-observer.html:64:2 The attribute 'viewport-margins' in tag 'amp-position-observer' is set to the invalid value ''. (see https://www.ampproject.org/docs/reference/components/amp-position-observer) [AMP_TAG_PROBLEM]
+|    <amp-position-observer viewport-margins="foo" layout="nodisplay"></amp-position-observer>
+>>   ^~~~~~~~~
 amp-position-observer/0.1/test/validator-amp-position-observer.html:65:2 The attribute 'viewport-margins' in tag 'amp-position-observer' is set to the invalid value 'foo'. (see https://www.ampproject.org/docs/reference/components/amp-position-observer) [AMP_TAG_PROBLEM]
+|    <amp-position-observer viewport-margins="100fx" layout="nodisplay"></amp-position-observer>
+>>   ^~~~~~~~~
 amp-position-observer/0.1/test/validator-amp-position-observer.html:66:2 The attribute 'viewport-margins' in tag 'amp-position-observer' is set to the invalid value '100fx'. (see https://www.ampproject.org/docs/reference/components/amp-position-observer) [AMP_TAG_PROBLEM]
+|    <amp-position-observer viewport-margins="100vx" layout="nodisplay"></amp-position-observer>
+>>   ^~~~~~~~~
 amp-position-observer/0.1/test/validator-amp-position-observer.html:67:2 The attribute 'viewport-margins' in tag 'amp-position-observer' is set to the invalid value '100vx'. (see https://www.ampproject.org/docs/reference/components/amp-position-observer) [AMP_TAG_PROBLEM]
+|    <amp-position-observer viewport-margins="100 100vx" layout="nodisplay"></amp-position-observer>
+>>   ^~~~~~~~~
 amp-position-observer/0.1/test/validator-amp-position-observer.html:68:2 The attribute 'viewport-margins' in tag 'amp-position-observer' is set to the invalid value '100 100vx'. (see https://www.ampproject.org/docs/reference/components/amp-position-observer) [AMP_TAG_PROBLEM]
+|    <amp-position-observer viewport-margins="100vh 100vx" layout="nodisplay"></amp-position-observer>
+>>   ^~~~~~~~~
 amp-position-observer/0.1/test/validator-amp-position-observer.html:69:2 The attribute 'viewport-margins' in tag 'amp-position-observer' is set to the invalid value '100vh 100vx'. (see https://www.ampproject.org/docs/reference/components/amp-position-observer) [AMP_TAG_PROBLEM]
+|    <amp-position-observer viewport-margins="100fx 100vh" layout="nodisplay"></amp-position-observer>
+>>   ^~~~~~~~~
 amp-position-observer/0.1/test/validator-amp-position-observer.html:70:2 The attribute 'viewport-margins' in tag 'amp-position-observer' is set to the invalid value '100fx 100vh'. (see https://www.ampproject.org/docs/reference/components/amp-position-observer) [AMP_TAG_PROBLEM]
+|    <amp-position-observer viewport-margins="100vx 100px" layout="nodisplay"></amp-position-observer>
+>>   ^~~~~~~~~
 amp-position-observer/0.1/test/validator-amp-position-observer.html:71:2 The attribute 'viewport-margins' in tag 'amp-position-observer' is set to the invalid value '100vx 100px'. (see https://www.ampproject.org/docs/reference/components/amp-position-observer) [AMP_TAG_PROBLEM]
+|  </body>
+|  </html>

--- a/extensions/amp-reach-player/0.1/test/validator-amp-reach-player.out
+++ b/extensions/amp-reach-player/0.1/test/validator-amp-reach-player.out
@@ -1,2 +1,45 @@
 FAIL
+|  <!--
+|    Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests support for the amp-reach-player tag.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async custom-element="amp-reach-player" src="https://cdn.ampproject.org/v0/amp-reach-player-0.1.js"></script>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|  <body>
+|    <!-- Example of a valid amp-reach-player -->
+|    <amp-reach-player
+|            data-embed-id="a95a73fe-384b-4abc-beab-3ec719aacfcf"
+|            layout="responsive" width="560" height="315">
+|    </amp-reach-player>
+|    <!-- Invalid: data-embedId is required;
+|         missing value results in an error. -->
+|    <amp-reach-player
+>>   ^~~~~~~~~
 amp-reach-player/0.1/test/validator-amp-reach-player.html:38:2 The mandatory attribute 'data-embed-id' is missing in tag 'amp-reach-player'. (see https://www.ampproject.org/docs/reference/components/amp-reach-player) [AMP_TAG_PROBLEM]
+|        layout="responsive" width="480" height="270">
+|    </amp-reach-player>
+|  </body>
+|  </html>

--- a/extensions/amp-riddle-quiz/0.1/test/validator-amp-riddle-quiz.out
+++ b/extensions/amp-riddle-quiz/0.1/test/validator-amp-riddle-quiz.out
@@ -1,1 +1,34 @@
 PASS
+|  <!--
+|    Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|        http://www.apache.org/licenses/LICENSE-2.0
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests amp-riddle-quiz
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <title>amp-riddle-quiz example</title>
+|    <link rel="canonical" href="amps.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+|    <script async custom-element="amp-riddle-quiz" src="https://cdn.ampproject.org/v0/amp-riddle-quiz-0.1.js"></script>
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|  <body>
+|    <article>
+|      <amp-riddle-quiz layout="responsive" width="600" height="400" data-riddle-id="25799"></amp-riddle-quiz>
+|    </article>
+|  </body>
+|  </html>

--- a/extensions/amp-selector/0.1/test/validator-amp-selector.out
+++ b/extensions/amp-selector/0.1/test/validator-amp-selector.out
@@ -1,1 +1,103 @@
 PASS
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests amp-live-list.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <script async custom-element="amp-selector" src="https://cdn.ampproject.org/v0/amp-selector-0.1.js"></script>
+|    <script async custom-element="amp-form" src="https://cdn.ampproject.org/v0/amp-form-0.1.js"></script>
+|    <script async custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.1.js"></script>
+|    <script async custom-element="amp-live-list" src="https://cdn.ampproject.org/v0/amp-live-list-0.1.js"></script>
+|  </head>
+|  <body>
+|    <!-- Valid -->
+|    <form action="/" method="get" target="_blank" id="form1">
+|    <!-- <amp-selector> with the options as list elements -->
+|    <amp-selector layout="container" name="single_image_select">
+|      <ul>
+|        <li><amp-img src="/img1.png" width=50 height=50 option="1"></amp-img></li>
+|        <li><amp-img src="/img2.png" width=50 height=50 option="2"></amp-img></li>
+|        <li option="na" selected>None of the Above</li>
+|      </ul>
+|    </amp-selector>
+|    <!-- <amp-selector> with the options as images -->
+|    <amp-selector layout="container" name="multi_image_select" multiple>
+|      <amp-img src="/img1.png" width=50 height=50 option="1"></amp-img>
+|      <amp-img src="/img2.png" width=50 height=50 option="2"></amp-img>
+|      <amp-img src="/img3.png" width=50 height=50 option="3"></amp-img>
+|    </amp-selector>
+|    <!-- <amp-selector> with the options as carousel images -->
+|    <amp-selector layout="container" name="multi_image_select_1" multiple>
+|      <amp-carousel id="carousel-1" width=200 height=60 controls>
+|        <amp-img src="/img1.png" width=80 height=60 option="a"></amp-img>
+|        <amp-img src="/img2.png" width=80 height=60 option="b" selected></amp-img>
+|        <amp-img src="/img3.png" width=80 height=60 option="c"></amp-img>
+|        <amp-img src="/img4.png" width=80 height=60 option="d" disabled></amp-img>
+|      </amp-carousel>
+|    </amp-selector>
+|    <!-- <amp-selector> with bindable [selected] attribute -->
+|    <amp-selector layout="container" name="with_binding" [selected]="foo.bar">
+|    </amp-selector>
+|  </form>
+|  
+|  <!-- <amp-selector> with the options as carousel images, outside a form -->
+|  <amp-selector layout="container" name="multi_image_select_2" multiple form="form1">
+|    <amp-carousel id="carousel-1" width=400 height=300 type=slides controls>
+|      <amp-img src="/img1.png" width=80 height=60 option="a"></amp-img>
+|      <amp-img src="/img2.png" width=80 height=60 option="b" selected></amp-img>
+|      <amp-img src="/img3.png" width=80 height=60 option="c"></amp-img>
+|      <amp-img src="/img4.png" width=80 height=60 option="d"></amp-img>
+|    </amp-carousel>
+|  </amp-selector>
+|  
+|  <!-- Let's also try embedding an <amp-selector> inside an <amp-live-list>
+|       and vice versa. These should both be valid even though they are
+|       nonsensical. -->
+|  <amp-live-list id="my-live-list" data-max-items-per-page="20">
+|    <button update on="tap:my-live-list.update">
+|      <amp-selector layout="container" name="multi_image_select" multiple>
+|        <amp-img src="/img1.png" width=50 height=50 option="1"></amp-img>
+|        <amp-img src="/img2.png" width=50 height=50 option="2"></amp-img>
+|        <amp-img src="/img3.png" width=50 height=50 option="3"></amp-img>
+|      </amp-selector>
+|    </button>
+|    <div items></div>
+|    <!-- pagination is optional -->
+|    <div pagination></div>
+|  </amp-live-list>
+|  
+|  <amp-selector layout="container" name="multi_image_select" multiple>
+|    <div option="1">
+|      <amp-live-list id="my-live-list" data-max-items-per-page="20">
+|        <button update on="tap:my-live-list.update">You have updates!</button>
+|        <div items></div>
+|        <!-- pagination is optional -->
+|        <div pagination></div>
+|      </amp-live-list>
+|    </div>
+|    <div option="2">Non-live-list option</div>
+|  </amp-selector>
+|  
+|  </body>

--- a/extensions/amp-sidebar/0.1/test/validator-amp-sidebar.out
+++ b/extensions/amp-sidebar/0.1/test/validator-amp-sidebar.out
@@ -1,3 +1,79 @@
 FAIL
+|  <!--
+|    Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests support for the amp-sidebar tag.
+|    TODO(honeybadgerdontcare): Include spec url once publicly available.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <script async custom-element="amp-accordion" src="https://cdn.ampproject.org/v0/amp-accordion-0.1.js"></script>
+|    <script async custom-element="amp-sidebar" src="https://cdn.ampproject.org/v0/amp-sidebar-0.1.js"></script>
+|  </head>
+|  <body>
+|    <!-- Valid: Example of amp-sidebar usage -->
+|    <amp-sidebar side="left" layout="nodisplay">
+|      <amp-accordion>
+|        <section>
+|          <h2>Section 1</h2>
+|          <p>Content</p>
+|        </section>
+|        <section>
+|          <h2>Section 2</h2>
+|          <p>Content</p>
+|        </section>
+|      </amp-accordion>
+|      <amp-img layout="fill" src="img"></amp-img>
+|    </amp-sidebar>
+|    <!-- Valid: Example of amp-sidebar with toolbar usage -->
+|    <amp-sidebar layout="nodisplay">
+|      <nav toolbar="(min-width: 0px) and (max-width: 768px)" toolbar-target="id">
+|        <ul>
+|          <li>Nav item 1</li>
+|          <li>Nav item 2</li>
+|          <li>Nav item 3</li>
+|        </ul>
+|      </nav>
+|      <amp-img layout="fill" src="img"></amp-img>
+|    </amp-sidebar>
+|    <!-- Invalid: more than one <ul> tag -->
+|    <amp-sidebar layout="nodisplay">
+|      <nav toolbar="(min-width: 0px) and (max-width: 768px)" toolbar-target="id">
+>>     ^~~~~~~~~
 amp-sidebar/0.1/test/validator-amp-sidebar.html:60:4 Tag 'amp-sidebar > nav' must have 1 child tags - saw 2 child tags. [AMP_TAG_PROBLEM]
+|        <ul>
+|          <li>Nav item 1</li>
+|        </ul>
+|        <ul>
+|          <li>Nav item 2</li>
+|          <li>Nav item 3</li>
+|        </ul>
+|      </nav>
+|      <amp-img layout="fill" src="img"></amp-img>
+|    </amp-sidebar>
+|    <!-- Invalid: incorrect side value -->
+|    <amp-sidebar side="center" layout="nodisplay"></amp-sidebar>
+>>   ^~~~~~~~~
 amp-sidebar/0.1/test/validator-amp-sidebar.html:72:2 The attribute 'side' in tag 'amp-sidebar' is set to the invalid value 'center'. (see https://www.ampproject.org/docs/reference/components/amp-sidebar) [AMP_TAG_PROBLEM]
+|  </body>
+|  </html>

--- a/extensions/amp-social-share/0.1/test/validator-amp-social-share.out
+++ b/extensions/amp-social-share/0.1/test/validator-amp-social-share.out
@@ -1,3 +1,99 @@
 FAIL
+|  <!--
+|    Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests for the amp-social-share tag. See the inline comments.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <script async custom-element="amp-sidebar" src="https://cdn.ampproject.org/v0/amp-sidebar-0.1.js"></script>
+|    <script async custom-element="amp-social-share" src="https://cdn.ampproject.org/v0/amp-social-share-0.1.js"></script>
+|  </head>
+|  <body>
+|    <!-- Valid: simplest possible example -->
+|    <amp-social-share type="twitter"></amp-social-share>
+|  
+|    <!-- Valid: a simple example with params -->
+|    <amp-social-share type="linkedin" width="60" height="44"
+|                      data-param-text="Hello world"
+|                      data-param-url="https://example.com/">
+|    </amp-social-share>
+|  
+|    <!-- Valid: A share endpoint that's a URL with whitelisted app protocol -->
+|    <amp-social-share type="whatsapp"
+|                      layout="container"
+|                      data-share-endpoint="whatsapp://send"
+|                      data-param-text="Check this out: TITLE - CANONICAL_URL">
+|      Share on Whatsapp
+|    </amp-social-share>
+|  
+|    <!-- Valid: A share endpoint that's a URL with the whitelisted https protocol
+|      -->
+|    <amp-social-share type="vote-this-up"
+|                      layout="container"
+|                      data-share-endpoint="https://example.com/vote-this-up"
+|                      data-param-text="Check this out: TITLE - CANONICAL_URL">
+|      Share on Whatsapp
+|    </amp-social-share>
+|  
+|    <!-- Valid: A share endpoint that's within an amp-sidebar -->
+|    <amp-sidebar layout="nodisplay">
+|    <amp-social-share type="vote-this-up"
+|                      layout="container"
+|                      data-share-endpoint="https://example.com/vote-this-up"
+|                      data-param-text="Check this out: TITLE - CANONICAL_URL">
+|      Share on Whatsapp
+|    </amp-social-share>
+|    </amp-sidebar>
+|  
+|    <!-- Valid: unknown type, no endpoint given
+|         Note: It would be good to consider this invalid, but given the choices
+|         around required / optional parameters for this tag, we don't have a
+|         convenient way to do that. This will probablly yield a runtime error.
+|      -->
+|    <amp-social-share type="unknown" width="60" height="44"
+|                      data-param-text="Hello world"
+|                      data-param-url="https://example.com/">
+|    </amp-social-share>
+|  
+|    <!-- Invalid: Endpoint given with a protocol that doesn't fit the whitelist -->
+|    <amp-social-share type="vote-this-up"
+>>   ^~~~~~~~~
 amp-social-share/0.1/test/validator-amp-social-share.html:79:2 Invalid URL protocol 'votethisup:' for attribute 'data-share-endpoint' in tag 'amp-social-share'. (see https://www.ampproject.org/docs/reference/components/amp-social-share) [AMP_TAG_PROBLEM]
+|                      layout="container"
+|                      data-share-endpoint="votethisup://vote"
+|                      data-param-text="Check this out: TITLE - CANONICAL_URL">
+|      Share on Whatsapp
+|    </amp-social-share>
+|  
+|    <!-- Invalid: Endpoint given with a protocol that doesn't fit the whitelist -->
+|    <amp-social-share type="uhm-no-hahaha"
+>>   ^~~~~~~~~
 amp-social-share/0.1/test/validator-amp-social-share.html:87:2 Invalid URL protocol 'j a v a s c r i p t :' for attribute 'data-share-endpoint' in tag 'amp-social-share'. (see https://www.ampproject.org/docs/reference/components/amp-social-share) [AMP_TAG_PROBLEM]
+|                      layout="container"
+|                      data-share-endpoint="j a v a s c r i p t : alert('oh hi')"
+|                      data-param-text="Check this out: TITLE - CANONICAL_URL">
+|      Share on Whatsapp
+|    </amp-social-share>
+|  </body>
+|  </html>

--- a/extensions/amp-soundcloud/0.1/test/validator-amp-soundcloud.out
+++ b/extensions/amp-soundcloud/0.1/test/validator-amp-soundcloud.out
@@ -1,4 +1,63 @@
 FAIL
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    This tests validation for the amp-soundcloud tag.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|      <meta charset="utf-8">
+|      <link rel="canonical" href="amps.html">
+|      <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+|      <link href="https://fonts.googleapis.com/css?family=Questrial" rel="stylesheet" type="text/css">
+|      <script async custom-element="amp-soundcloud" src="https://cdn.ampproject.org/v0/amp-soundcloud-0.1.js"></script>
+|       <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|      <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|  <body>
+|    <!-- valid: classic mode -->
+|    <amp-soundcloud height=166 data-trackid="243169232" data-color="ff5500"
+|                    layout="fixed-height"></amp-soundcloud>
+|    <!-- valid: visual mode -->
+|    <amp-soundcloud height=166 data-trackid="243169232" data-visual="true"
+|                    layout="fixed-height"></amp-soundcloud>
+|    <!-- invalid: visual mode must be 'true' or 'false'-->
+|    <amp-soundcloud height=166 data-trackid="243169232" data-visual
+>>   ^~~~~~~~~
 amp-soundcloud/0.1/test/validator-amp-soundcloud.html:39:2 The attribute 'data-visual' in tag 'amp-soundcloud' is set to the invalid value ''. (see https://www.ampproject.org/docs/reference/components/amp-soundcloud) [AMP_TAG_PROBLEM]
+|                    layout="fixed-height"></amp-soundcloud>
+|    <!-- invalid: bad trackid-->
+|    <amp-soundcloud height=166 data-trackid="mahler_number_6.ogg" data-visual="false"
+>>   ^~~~~~~~~
 amp-soundcloud/0.1/test/validator-amp-soundcloud.html:42:2 The attribute 'data-trackid' in tag 'amp-soundcloud' is set to the invalid value 'mahler_number_6.ogg'. (see https://www.ampproject.org/docs/reference/components/amp-soundcloud) [AMP_TAG_PROBLEM]
+|                    layout="fixed-height"></amp-soundcloud>
+|    <!-- invalid: bad layout -->
+|    <amp-soundcloud height=166 width=42 data-trackid="243169232" data-visual="true"
+>>   ^~~~~~~~~
 amp-soundcloud/0.1/test/validator-amp-soundcloud.html:45:2 The specified layout 'RESPONSIVE' is not supported by tag 'amp-soundcloud'. (see https://www.ampproject.org/docs/reference/components/amp-soundcloud) [AMP_LAYOUT_PROBLEM]
+|                    layout="responsive"></amp-soundcloud>
+|    <!-- valid: classic mode with three letter color -->
+|    <amp-soundcloud height=166 data-trackid="243169232" data-color="fff"
+|                    layout="fixed-height"></amp-soundcloud>
+|    <!-- valid: classic mode with secret token -->
+|    <amp-soundcloud height=166 data-trackid="243169232" data-color="fff"
+|                    data-secret-token="s-CYqsZ"
+|                    layout="fixed-height"></amp-soundcloud>
+|  
+|  </body>
+|  </html>

--- a/extensions/amp-springboard-player/0.1/test/validator-amp-springboard-player.out
+++ b/extensions/amp-springboard-player/0.1/test/validator-amp-springboard-player.out
@@ -1,10 +1,101 @@
 FAIL
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    This tests validation for the amp-springboard-player tag.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|      <meta charset="utf-8">
+|      <link rel="canonical" href="amps.html">
+|      <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+|      <link href="https://fonts.googleapis.com/css?family=Questrial" rel="stylesheet" type="text/css">
+|      <script async custom-element="amp-springboard-player" src="https://cdn.ampproject.org/v0/amp-springboard-player-0.1.js"></script>
+|       <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|      <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|  <body>
+|    <!-- valid -->
+|    <amp-springboard-player data-site-id="261" data-mode="video"
+|        data-content-id="1578473" data-player-id="test401"
+|        data-domain="test.com" data-items="10"
+|        layout="fixed" width="480" height="270"></amp-springboard-player>
+|    <!-- invalid: data-site-id must be numeric -->
+|    <amp-springboard-player data-site-id="a261" data-mode="video"
+>>   ^~~~~~~~~
 amp-springboard-player/0.1/test/validator-amp-springboard-player.html:38:2 The attribute 'data-site-id' in tag 'amp-springboard-player' is set to the invalid value 'a261'. (see https://www.ampproject.org/docs/reference/components/amp-springboard-player) [AMP_TAG_PROBLEM]
+|        data-content-id="1578473" data-player-id="test401"
+|        data-domain="test.com" data-items="10"
+|        layout="fixed"width="480" height="270"></amp-springboard-player>
+|    <!-- invalid: data-player-id must be alphanumeric -->
+|    <amp-springboard-player data-site-id="261" data-mode="playlist"
+>>   ^~~~~~~~~
 amp-springboard-player/0.1/test/validator-amp-springboard-player.html:43:2 The attribute 'data-player-id' in tag 'amp-springboard-player' is set to the invalid value 'test 401'. (see https://www.ampproject.org/docs/reference/components/amp-springboard-player) [AMP_TAG_PROBLEM]
+|        data-content-id="1578473" data-player-id="test 401"
+|        data-domain="test.com" data-items="10"
+|        layout="fixed" width="480" height="270"></amp-springboard-player>
+|    <!-- invalid: data-content-id required -->
+|    <amp-springboard-player data-site-id="261" data-mode="video"
+>>   ^~~~~~~~~
 amp-springboard-player/0.1/test/validator-amp-springboard-player.html:48:2 The mandatory attribute 'data-content-id' is missing in tag 'amp-springboard-player'. (see https://www.ampproject.org/docs/reference/components/amp-springboard-player) [AMP_TAG_PROBLEM]
+|        data-player-id="test401"
+|        data-domain="test.com" data-items="10"
+|        layout="fixed" width="480" height="270"></amp-springboard-player>
+|    <!-- invalid: data-domain required -->
+|    <amp-springboard-player data-site-id="261" data-mode="video"
+>>   ^~~~~~~~~
 amp-springboard-player/0.1/test/validator-amp-springboard-player.html:53:2 The mandatory attribute 'data-domain' is missing in tag 'amp-springboard-player'. (see https://www.ampproject.org/docs/reference/components/amp-springboard-player) [AMP_TAG_PROBLEM]
+|        data-content-id="1578473" data-player-id="test401"
+|        data-items="10"
+|        layout="fixed" width="480" height="270"></amp-springboard-player>
+|    <!-- invalid: data-items required -->
+|    <amp-springboard-player data-site-id="261" data-mode="video"
+>>   ^~~~~~~~~
 amp-springboard-player/0.1/test/validator-amp-springboard-player.html:58:2 The mandatory attribute 'data-items' is missing in tag 'amp-springboard-player'. (see https://www.ampproject.org/docs/reference/components/amp-springboard-player) [AMP_TAG_PROBLEM]
+|        data-content-id="1578473" data-player-id="test401"
+|        data-domain="test.com"
+|        layout="fixed" width="480" height="270"></amp-springboard-player>
+|    <!-- invalid: data-mode required -->
+|    <amp-springboard-player data-site-id="261"
+>>   ^~~~~~~~~
 amp-springboard-player/0.1/test/validator-amp-springboard-player.html:63:2 The mandatory attribute 'data-mode' is missing in tag 'amp-springboard-player'. (see https://www.ampproject.org/docs/reference/components/amp-springboard-player) [AMP_TAG_PROBLEM]
+|        data-content-id="1578473" data-player-id="test401"
+|        data-domain="test.com" data-items="10"
+|        layout="fixed" width="480" height="270"></amp-springboard-player>
+|    <!-- invalid: data-player-id required -->
+|    <amp-springboard-player data-site-id="261" data-mode="video"
+>>   ^~~~~~~~~
 amp-springboard-player/0.1/test/validator-amp-springboard-player.html:68:2 The mandatory attribute 'data-player-id' is missing in tag 'amp-springboard-player'. (see https://www.ampproject.org/docs/reference/components/amp-springboard-player) [AMP_TAG_PROBLEM]
+|        data-content-id="1578473"
+|        data-domain="test.com" data-items="10"
+|        layout="fixed" width="480" height="270"></amp-springboard-player>
+|    <!-- invalid: data-site-id required -->
+|    <amp-springboard-player data-mode="video"
+>>   ^~~~~~~~~
 amp-springboard-player/0.1/test/validator-amp-springboard-player.html:73:2 The mandatory attribute 'data-site-id' is missing in tag 'amp-springboard-player'. (see https://www.ampproject.org/docs/reference/components/amp-springboard-player) [AMP_TAG_PROBLEM]
+|        data-content-id="1578473" data-player-id="test401"
+|        data-domain="test.com" data-items="10"
+|        layout="fixed" width="480" height="270"></amp-springboard-player>
+|    <!-- invalid: bad layout -->
+|    <amp-springboard-player data-site-id="261" data-mode="playlist"
+>>   ^~~~~~~~~
 amp-springboard-player/0.1/test/validator-amp-springboard-player.html:78:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-springboard-player'. (see https://www.ampproject.org/docs/reference/components/amp-springboard-player) [AMP_LAYOUT_PROBLEM]
+|        data-player-id="test401"
+|        layout="fixed-height" width="480" height="270"></amp-springboard-player>
+|  </body>
+|  </html>

--- a/extensions/amp-sticky-ad/0.1/test/validator-amp-sticky-ad.out
+++ b/extensions/amp-sticky-ad/0.1/test/validator-amp-sticky-ad.out
@@ -1,3 +1,45 @@
 PASS
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests amp-sticky-ad.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <script async custom-element="amp-sticky-ad" src="https://cdn.ampproject.org/v0/amp-sticky-ad-0.1.js"></script>
+>>   ^~~~~~~~~
 amp-sticky-ad/0.1/test/validator-amp-sticky-ad.html:28:2 The extension 'amp-sticky-ad' is referenced at version '0.1' which is a deprecated version. Please use a more recent version of this extension. This may become an error in the future. (see https://www.ampproject.org/docs/reference/components/amp-sticky-ad) [DEPRECATION]
-amp-sticky-ad/0.1/test/validator-amp-sticky-ad.html:40:7 The tag 'amp-ad extension .js script' is missing or incorrect, but required by 'amp-ad'. This will soon be an error. (see https://www.ampproject.org/docs/reference/components/amp-ad) [DEPRECATION]
+|  </head>
+|  <body>
+|    <amp-sticky-ad layout=nodisplay>
+|      <amp-ad width=300 height=250
+|          type="a9"
+|          data-aax_size="300x250"
+|          data-aax_pubname="test123"
+|          data-aax_src="302">
+|      </amp-ad>
+|    </amp-sticky-ad>
+|  </body>
+|  </html>
+>>       ^~~~~~~~~
+amp-sticky-ad/0.1/test/validator-amp-sticky-ad.html:40:6 The tag 'amp-ad extension .js script' is missing or incorrect, but required by 'amp-ad'. This will soon be an error. (see https://www.ampproject.org/docs/reference/components/amp-ad) [DEPRECATION]

--- a/extensions/amp-sticky-ad/1.0/test/validator-amp-sticky-ad.out
+++ b/extensions/amp-sticky-ad/1.0/test/validator-amp-sticky-ad.out
@@ -1,2 +1,43 @@
 PASS
-amp-sticky-ad/1.0/test/validator-amp-sticky-ad.html:40:7 The tag 'amp-ad extension .js script' is missing or incorrect, but required by 'amp-ad'. This will soon be an error. (see https://www.ampproject.org/docs/reference/components/amp-ad) [DEPRECATION]
+|  <!--
+|    Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests amp-sticky-ad.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <script async custom-element="amp-sticky-ad" src="https://cdn.ampproject.org/v0/amp-sticky-ad-1.0.js"></script>
+|  </head>
+|  <body>
+|    <amp-sticky-ad layout=nodisplay>
+|      <amp-ad width=300 height=250
+|          type="a9"
+|          data-aax_size="300x250"
+|          data-aax_pubname="test123"
+|          data-aax_src="302">
+|      </amp-ad>
+|    </amp-sticky-ad>
+|  </body>
+|  </html>
+>>       ^~~~~~~~~
+amp-sticky-ad/1.0/test/validator-amp-sticky-ad.html:40:6 The tag 'amp-ad extension .js script' is missing or incorrect, but required by 'amp-ad'. This will soon be an error. (see https://www.ampproject.org/docs/reference/components/amp-ad) [DEPRECATION]

--- a/extensions/amp-story/0.1/test/validator-amp-story-error.out
+++ b/extensions/amp-story/0.1/test/validator-amp-story-error.out
@@ -1,7 +1,57 @@
 FAIL
+|  <!--
+|    Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests for the amp-story tag.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <title>STAMP examples</title>
+|    <link rel="canonical" href="http://nonblocking.io/" >
+|    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|  <body>
+|    <amp-story> <!-- error because the 'standalone' attribute isn't set -->
+>>   ^~~~~~~~~
 amp-story/0.1/test/validator-amp-story-error.html:31:2 The mandatory attribute 'standalone' is missing in tag 'amp-story'. (see https://www.ampproject.org/docs/reference/components/amp-story) [AMP_TAG_PROBLEM]
+>>   ^~~~~~~~~
 amp-story/0.1/test/validator-amp-story-error.html:31:2 The tag 'amp-story' requires including the 'amp-story' extension JavaScript. (see https://www.ampproject.org/docs/reference/components/amp-story) [AMP_TAG_PROBLEM]
+|      <amp-story-page> <!-- error because the 'id' attribute isn't set -->
+>>     ^~~~~~~~~
 amp-story/0.1/test/validator-amp-story-error.html:32:4 The mandatory attribute 'id' is missing in tag 'amp-story-page'. (see https://www.ampproject.org/docs/reference/components/amp-story) [AMP_TAG_PROBLEM]
+>>     ^~~~~~~~~
 amp-story/0.1/test/validator-amp-story-error.html:32:4 The tag 'amp-story-page' requires including the 'amp-story' extension JavaScript. (see https://www.ampproject.org/docs/reference/components/amp-story) [AMP_TAG_PROBLEM]
+|        <amp-story-grid-layer> <!-- error because one of 'fill', 'horizontal', 'vertical', 'thirds' should be set. -->
+>>       ^~~~~~~~~
 amp-story/0.1/test/validator-amp-story-error.html:33:6 The mandatory attribute 'template' is missing in tag 'amp-story-grid-layer'. [AMP_TAG_PROBLEM]
+|          <h5>
+|            <h1>
+|              <h4 height="50px"></h4> <!-- error because 'height' is not an allowed attribute. -->
+>>             ^~~~~~~~~
 amp-story/0.1/test/validator-amp-story-error.html:36:12 The attribute 'height' may not appear in tag 'h4'. [DISALLOWED_HTML]
+|            </h1>
+|          </h5>
+|        </amp-story-grid-layer>
+|      </amp-story-page>
+|    </amp-story>
+|    <div></div> <!-- this should create an error for the 'no siblings allowed' rule on <amp-story> -->
+|  </body>
+|  </html>

--- a/extensions/amp-story/0.1/test/validator-amp-story-reference-point.out
+++ b/extensions/amp-story/0.1/test/validator-amp-story-reference-point.out
@@ -1,4 +1,47 @@
 FAIL
+|  <!--
+|    Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests for the amp-story tag.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <title>STAMP examples</title>
+|    <link rel="canonical" href="http://nonblocking.io/" >
+|    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-0.1.js"></script>
+|  </head>
+|  <body>
+|    <amp-story standalone bookend-config-src="./related.json" background-audio="path/to/my.mp3">
+|      <amp-story-page id="1" background-audio="path/to/my.mp3" auto-advance-after="any-value">
+|        <amp-story-grid-layer template="horizontal">
+|          <img class="footer-logo" src="img/foot-logo.svg" width="40" height="40" /> <!-- The real error here is that <img/> tag is not allowed. But this is a weird use case where the validator error will comment about reference points. This needs to be fixed in the near future. -->
+>>         ^~~~~~~~~
 amp-story/0.1/test/validator-amp-story-reference-point.html:35:8 The tag 'img', a child tag of 'amp-story-grid-layer', does not satisfy one of the acceptable reference points: AMP-STORY-GRID-LAYER default, AMP-STORY-GRID-LAYER animate-in. [AMP_TAG_PROBLEM]
+>>         ^~~~~~~~~
 amp-story/0.1/test/validator-amp-story-reference-point.html:35:8 The tag 'img' may only appear as a descendant of tag 'noscript'. Did you mean 'amp-img'? (see https://www.ampproject.org/docs/reference/components/amp-img) [DISALLOWED_HTML_WITH_AMP_EQUIVALENT]
+>>         ^~~~~~~~~
 amp-story/0.1/test/validator-amp-story-reference-point.html:35:8 The tag 'img' may not appear as a descendant of tag 'amp-story-grid-layer'. (see https://www.ampproject.org/docs/reference/components/amp-img) [AMP_TAG_PROBLEM]
+|        </amp-story-grid-layer>
+|      </amp-story-page>
+|    </amp-story>
+|  </body>
+|  </html>

--- a/extensions/amp-story/0.1/test/validator-amp-story-video-error.out
+++ b/extensions/amp-story/0.1/test/validator-amp-story-video-error.out
@@ -1,2 +1,56 @@
 FAIL
+|  <!--
+|    Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Test to make sure amp-video under amp-story gets an error if it doesn't have the "poster"
+|    attribute set.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <title>STAMP examples</title>
+|    <link rel="canonical" href="http://nonblocking.io/" >
+|    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-0.1.js"></script>
+|    <script async custom-element="amp-video" src="https://cdn.ampproject.org/v0/amp-video-0.1.js"></script>
+|  </head>
+|  <body>
+|    <amp-story standalone bookend-config-src="./related.json" background-audio="path/to/my.mp3">
+|      <amp-story-page id="1" background-audio="path/to/my.mp3" auto-advance-after="any-value">
+|        <amp-story-grid-layer template="horizontal">
+|          <!-- This should fail because amp-video doesn't have the [poster] attribute. -->
+|          <amp-video width="480"
+>>         ^~~~~~~~~
 amp-story/0.1/test/validator-amp-story-video-error.html:38:8 The tag 'amp-video' may not appear as a descendant of tag 'amp-story'. (see https://www.ampproject.org/docs/reference/components/amp-video) [AMP_TAG_PROBLEM]
+|                     height="270"
+|                     src="/video/tokyo.mp4"
+|                     layout="responsive"
+|                     controls>
+|               <div fallback>
+|                 <p>Your browser doesn't support HTML5 video.</p>
+|               </div>
+|               <source type="video/mp4" src="/video/tokyo.mp4">
+|               <source type="video/webm" src="/video/tokyo.webm">
+|           </amp-video>
+|        </amp-story-grid-layer>
+|      </amp-story-page>
+|    </amp-story>
+|  </body>
+|  </html>

--- a/extensions/amp-story/0.1/test/validator-amp-story.out
+++ b/extensions/amp-story/0.1/test/validator-amp-story.out
@@ -1,1 +1,55 @@
 PASS
+|  <!--
+|    Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests for the amp-story tag.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <title>STAMP examples</title>
+|    <link rel="canonical" href="http://nonblocking.io/" >
+|    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-0.1.js"></script>
+|  </head>
+|  <body>
+|    <amp-story standalone bookend-config-src="./bookend-config-src.json" background-audio="path/to/my.mp3">
+|      <amp-story-page id="1" background-audio="path/to/my.mp3" auto-advance-after="any-value">
+|        <amp-story-grid-layer template="horizontal">
+|          <h5 animate-in="drop">
+|            <h1>
+|              <h4 animate-in-delay="anything"></h4>
+|            </h1>
+|            <h2></h2>
+|          </h5>
+|          <h3 grid-area="any value">
+|            <h6 animate-in-after="whatever-value"></h6>
+|          </h3>
+|          <h3 align-content="center"></h3>
+|          <h3 align-items="stretch"></h3>
+|          <h3 align-self="start"></h3>
+|        </amp-story-grid-layer>
+|        <amp-story-grid-layer template="horizontal">
+|          <h1></h1>
+|        </amp-story-grid-layer>
+|      </amp-story-page>
+|    </amp-story>
+|  </body>
+|  </html>

--- a/extensions/amp-story/0.1/test/validator-empty-story.out
+++ b/extensions/amp-story/0.1/test/validator-empty-story.out
@@ -1,2 +1,40 @@
 FAIL
-amp-story/0.1/test/validator-empty-story.html:37:7 The tag 'amp-story-page' is missing or incorrect, but required by 'amp-story'. (see https://www.ampproject.org/docs/reference/components/amp-story) [AMP_TAG_PROBLEM]
+|  <!--
+|    Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    This tests that every amp-story standalone must have at least one
+|    amp-story-page child, not just one child of any kind.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <title>STAMP examples</title>
+|    <link rel="canonical" href="http://nonblocking.io/" >
+|    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-0.1.js"></script>
+|  </head>
+|  <body>
+|    <amp-story standalone>
+|      <amp-pixel src=""></amp-pixel>
+|    </amp-story>
+|  </body>
+|  </html>
+>>       ^~~~~~~~~
+amp-story/0.1/test/validator-empty-story.html:37:6 The tag 'amp-story-page' is missing or incorrect, but required by 'amp-story'. (see https://www.ampproject.org/docs/reference/components/amp-story) [AMP_TAG_PROBLEM]

--- a/extensions/amp-timeago/0.1/test/validator-amp-timeago.out
+++ b/extensions/amp-timeago/0.1/test/validator-amp-timeago.out
@@ -1,3 +1,53 @@
 FAIL
+|  <!--
+|    Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests for the amp-timeago tag.
+|  -->
+|  <!DOCTYPE html>
+|  <html amp lang="en">
+|    <head>
+|      <meta charset="utf-8">
+|      <link rel="canonical" href="./regular-html-version.html">
+|      <meta name="viewport" content="width=device-width,minimum-scale=1">
+|      <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|      <script async custom-element="amp-timeago" src="https://cdn.ampproject.org/v0/amp-timeago-latest.js"></script>
+|      <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    </head>
+|    <body>
+|  
+|      <!-- valid -->
+|      <amp-timeago layout="fixed" width="160" height="20" datetime="2017-04-11T00:37:33.809Z" locale="en" cutoff="8640000">Saturday 11 April 2017 00.37</amp-timeago>
+|  
+|      <!-- valid, international locale -->
+|      <amp-timeago layout="fixed" width="160" height="20" datetime="2017-08-11T18:58:58.000Z" locale="fr" cutoff="8640000">Lundi 14 août 2017</amp-timeago>
+|  
+|      <!-- valid, locale optional, cutoff optional -->
+|      <amp-timeago layout="fixed" width="160" height="20" datetime="2017-04-11T00:37:33.809Z">Saturday 11 April 2017 00.37</amp-timeago>
+|  
+|      <!-- invalid, datetime is not ISO date format -->
+|      <amp-timeago layout="fixed" width="160" height="20" datetime="2017/04/11">Saturday 11 April 2017 00.37</amp-timeago>
+>>     ^~~~~~~~~
 amp-timeago/0.1/test/validator-amp-timeago.html:42:4 The attribute 'datetime' in tag 'amp-timeago' is set to the invalid value '2017/04/11'. (see https://www.ampproject.org/docs/reference/components/amp-timeago) [AMP_TAG_PROBLEM]
+|  
+|      <!-- invalid, needs datetime -->
+|      <amp-timeago layout="fixed" width="160" height="20">Saturday 11 April 2017 00.37</amp-timeago>
+>>     ^~~~~~~~~
 amp-timeago/0.1/test/validator-amp-timeago.html:45:4 The mandatory attribute 'datetime' is missing in tag 'amp-timeago'. (see https://www.ampproject.org/docs/reference/components/amp-timeago) [AMP_TAG_PROBLEM]
+|  
+|    </body>
+|  </html>

--- a/extensions/amp-twitter/0.1/test/validator-amp-twitter.out
+++ b/extensions/amp-twitter/0.1/test/validator-amp-twitter.out
@@ -1,1 +1,74 @@
 PASS
+|  <!--
+|    Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <title>Twitter examples</title>
+|    <link rel="canonical" href="amps.html" >
+|    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+|    <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
+|    <script async custom-element="amp-twitter" src="https://cdn.ampproject.org/v0/amp-twitter-0.1.js"></script>
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|  <body>
+|  
+|  
+|  
+|    <h2>Twitter</h2>
+|  
+|    <amp-twitter width=375 height=472
+|        layout="responsive"
+|        data-tweetid="638793490521001985">
+|        <blockquote placeholder class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">I only needed to change some CSS. <a href="http://t.co/LvjLbjgY9F">pic.twitter.com/LvjLbjgY9F</a></p>&mdash; Malte Ubl (@cramforce) <a href="https://twitter.com/cramforce/status/638793490521001985">September 1, 2015</a></blockquote>
+|    </amp-twitter>
+|  
+|    <amp-twitter width=390 height=330
+|        data-tweetid="585110598171631616"
+|        data-cards="hidden">
+|    </amp-twitter>
+|  
+|    <amp-twitter width=390 height=330
+|        layout="responsive"
+|        data-tweetid="585110598171631616"
+|        data-cards="hidden">
+|    </amp-twitter>
+|  
+|    <amp-twitter width=390 height=330
+|        layout="responsive"
+|        data-tweetid="641653602164060160"
+|        data-conversation="none"
+|        data-cards="hidden">
+|    </amp-twitter>
+|  
+|    <amp-twitter width=390 height=330
+|        layout="responsive"
+|        data-tweetid="641653602164060160"
+|        data-cards="hidden">
+|    </amp-twitter>
+|  
+|    <h2>Intentionally non-existing-tweet</h2>
+|    <amp-twitter width=390 height=330
+|        layout="responsive"
+|        data-tweetid="1111111111111641653602164060160"
+|        data-cards="hidden">
+|        <blockquote placeholder class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">A new approach to web performance.<br><br>Today we are starting the AMP Project to make mobile web content fast again.<a href="https://t.co/b091YOzo5s">https://t.co/b091YOzo5s</a></p>&mdash; Malte Ubl (@cramforce) <a href="https://twitter.com/cramforce/status/651762967147483136">October 7, 2015</a></blockquote>
+|    </amp-twitter>
+|  
+|  </body>
+|  </html>

--- a/extensions/amp-user-notification/0.1/test/validator-amp-user-notification.out
+++ b/extensions/amp-user-notification/0.1/test/validator-amp-user-notification.out
@@ -1,2 +1,83 @@
 FAIL
+|  <!--
+|    Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests for the amp-youtube tag. See the inline comments.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <script async custom-element="amp-user-notification" src="https://cdn.ampproject.org/v0/amp-user-notification-0.1.js"></script>
+|  </head>
+|  <body>
+|    <!-- Example of valid amp-user-notification -->
+|    <amp-user-notification
+|        layout=nodisplay
+|        id="amp-user-notification1"
+|        data-show-if-href="https://example.com/api/show?timestamp=TIMESTAMP"
+|        data-dismiss-href="https://example.com/api/echo/post">
+|        This site uses cookies to personalize content.
+|        <a href="#learn-more">Learn more.</a>
+|       <button on="tap:amp-user-notification1.dismiss">I accept</button>
+|    </amp-user-notification>
+|    <!-- Example of missing data-show-if-href (that's OK, still valid) -->
+|    <amp-user-notification
+|        layout=nodisplay
+|        id="amp-user-notification2"
+|        data-dismiss-href="https://example.com/api/echo/post">
+|        This site uses cookies to personalize content.
+|        <a href="#learn-more">Learn more.</a>
+|       <button on="tap:amp-user-notification1.dismiss">I accept</button>
+|    </amp-user-notification>
+|    <!-- Example of missing data-dismiss-href (that's OK, still valid)-->
+|    <amp-user-notification
+|        layout=nodisplay
+|        id="amp-user-notification3"
+|        data-show-if-href="https://example.com/api/show?timestamp=TIMESTAMP">
+|        This site uses cookies to personalize content.
+|        <a href="#learn-more">Learn more.</a>
+|       <button on="tap:amp-user-notification1.dismiss">I accept</button>
+|    </amp-user-notification>
+|    <!-- Example of missing data-show-if-href and data-dismiss-href
+|         (that's OK, still valid)
+|      -->
+|    <amp-user-notification
+|        layout=nodisplay
+|        id="amp-user-notification4">
+|        This site uses cookies to personalize content.
+|        <a href="#learn-more">Learn more.</a>
+|       <button on="tap:amp-user-notification1.dismiss">I accept</button>
+|    </amp-user-notification>
+|    <!-- Example of non nodisplay layout type -->
+|    <amp-user-notification
+>>   ^~~~~~~~~
 amp-user-notification/0.1/test/validator-amp-user-notification.html:70:2 The specified layout 'CONTAINER' is not supported by tag 'amp-user-notification'. (see https://www.ampproject.org/docs/reference/components/amp-user-notification) [AMP_LAYOUT_PROBLEM]
+|        layout=container
+|        id="amp-user-notification1"
+|        data-show-if-href="https://example.com/api/show?timestamp=TIMESTAMP"
+|        data-dismiss-href="https://example.com/api/echo/post">
+|        This site uses cookies to personalize content.
+|        <a href="#learn-more">Learn more.</a>
+|       <button on="tap:amp-user-notification1.dismiss">I accept</button>
+|    </amp-user-notification>
+|  </body>
+|  </html>

--- a/extensions/amp-vimeo/0.1/test/validator-amp-vimeo.out
+++ b/extensions/amp-vimeo/0.1/test/validator-amp-vimeo.out
@@ -1,4 +1,60 @@
 FAIL
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    This tests validation for the amp-vimeo tag.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|      <meta charset="utf-8">
+|      <title>Vimeo examples</title>
+|      <link rel="canonical" href="amps.html">
+|      <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+|      <link href="https://fonts.googleapis.com/css?family=Questrial" rel="stylesheet" type="text/css">
+|      <script async custom-element="amp-vimeo" src="https://cdn.ampproject.org/v0/amp-vimeo-0.1.js"></script>
+|       <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|      <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|  <body>
+|  <h2>Vimeo</h2>
+|  
+|  <!-- valid -->
+|  <amp-vimeo data-videoid="27246366" width="500" height="281"></amp-vimeo>
+|  
+|  <!-- valid -->
+|  <amp-vimeo data-videoid="27246366" width="500" height="281" layout="responsive" noloading></amp-vimeo>
+|  
+|  <!-- valid -->
+|  <amp-vimeo data-videoid="27246366" width="500" height="281" layout="responsive" noloading="noloading"></amp-vimeo>
+|  
+|  <!-- invalid videoid -->
+|  <amp-vimeo data-videoid="i don't think so" width="500" height="281" layout="responsive"></amp-vimeo>
+>> ^~~~~~~~~
 amp-vimeo/0.1/test/validator-amp-vimeo.html:45:0 The attribute 'data-videoid' in tag 'amp-vimeo' is set to the invalid value 'i don't think so'. (see https://www.ampproject.org/docs/reference/components/amp-vimeo) [AMP_TAG_PROBLEM]
+|  
+|  <!-- videoid missing -->
+|  <amp-vimeo width="500" height="281" layout="responsive"></amp-vimeo>
+>> ^~~~~~~~~
 amp-vimeo/0.1/test/validator-amp-vimeo.html:48:0 The mandatory attribute 'data-videoid' is missing in tag 'amp-vimeo'. (see https://www.ampproject.org/docs/reference/components/amp-vimeo) [AMP_TAG_PROBLEM]
+|  
+|  <!-- noloading must not have a value other than "" or noloading-->
+|  <amp-vimeo width="500" height="281" layout="responsive" noloading="foo"></amp-vimeo>
+>> ^~~~~~~~~
 amp-vimeo/0.1/test/validator-amp-vimeo.html:51:0 The attribute 'noloading' in tag 'amp-vimeo' is set to the invalid value 'foo'. (see https://www.ampproject.org/docs/reference/components/amp-vimeo) [AMP_TAG_PROBLEM]
+|  </body>
+|  </html>

--- a/extensions/amp-vine/0.1/test/validator-amp-vine.out
+++ b/extensions/amp-vine/0.1/test/validator-amp-vine.out
@@ -1,1 +1,46 @@
 PASS
+|  <!--
+|    Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <title>Vine examples</title>
+|    <link rel="canonical" href="amps.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+|    <link href="https://fonts.googleapis.com/css?family=Questrial" rel="stylesheet" type="text/css">
+|    <script async custom-element="amp-vine" src="https://cdn.ampproject.org/v0/amp-vine-0.1.js"></script>
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|  <body>
+|    <h2>Vine</h2>
+|  
+|    <amp-vine
+|      data-vineid="MdKjXez002d"
+|      width="381"
+|      height="381"
+|      layout="responsive">
+|    </amp-vine>
+|  
+|    <amp-vine
+|      data-vineid="e2eTlxAYvqO"
+|      width="400"
+|      height="400"
+|      layout="responsive">
+|    </amp-vine>
+|  </body>
+|  </html>

--- a/extensions/amp-vk/0.1/test/validator-amp-vk.out
+++ b/extensions/amp-vk/0.1/test/validator-amp-vk.out
@@ -1,1 +1,52 @@
 PASS
+|  <!--
+|    Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <title>VK examples</title>
+|    <link rel="canonical" href="amps.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+|    <link href="https://fonts.googleapis.com/css?family=Questrial" rel="stylesheet" type="text/css">
+|    <script async custom-element="amp-vk" src="https://cdn.ampproject.org/v0/amp-vk-0.1.js"></script>
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|  <body>
+|    <h2>VK</h2>
+|    <!-- Valid: Example of amp-vk Post embed usage -->
+|    <amp-vk
+|        width="500"
+|        height="300"
+|        layout="responsive"
+|        data-embedtype="post"
+|        data-owner-id="1"
+|        data-post-id="45616"
+|        data-hash="Yc8_Z9pnpg8aKMZbVcD-jK45eAk">
+|    </amp-vk>
+|  
+|    <!-- Valid: Example of amp-vk Poll embed usage -->
+|    <amp-vk
+|        width="400"
+|        height="300"
+|        layout="responsive"
+|        data-embedtype="poll"
+|        data-api-id="6183531"
+|        data-poll-id="274086843_1a2a465f60fff4699f">
+|    </amp-vk>
+|  </body>
+|  </html>

--- a/extensions/amp-web-push/0.1/test/validator-amp-web-push.out
+++ b/extensions/amp-web-push/0.1/test/validator-amp-web-push.out
@@ -1,1 +1,50 @@
 PASS
+|  <!--
+|    Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests for the amp-web-push tag.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html" />
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <script async custom-element="amp-web-push" src="https://cdn.ampproject.org/v0/amp-web-push-0.1.js"></script>
+|  </head>
+|  <body>
+|    <!-- Valid: Example of amp-web-push usage -->
+|    <amp-web-push
+|      id="amp-web-push"
+|      layout="nodisplay"
+|      helper-iframe-url="https://example.com/helper-iframe.html"
+|      permission-dialog-url="https://example.com/permission-dialog.html"
+|      service-worker-url="https://example.com/service-worker.js">
+|    </amp-web-push>
+|    <amp-web-push-widget visibility="unsubscribed" layout="fixed" width="250" height="80">
+|      <button on="tap:amp-web-push.subscribe">Subscribe to Notifications</button>
+|    </amp-web-push-widget>
+|    <amp-web-push-widget visibility="subscribed" layout="fixed" width="250" height="80">
+|      <button on="tap:amp-web-push.unsubscribe">Unsubscribe from Notifications</button>
+|    </amp-web-push-widget>
+|    <amp-web-push-widget visibility="blocked" layout="fixed" width="250" height="80">
+|      Looks like you've blocked notifications!
+|    </amp-web-push-widget>
+|  </body>
+|  </html>

--- a/extensions/amp-youtube/0.1/test/validator-amp-youtube.out
+++ b/extensions/amp-youtube/0.1/test/validator-amp-youtube.out
@@ -1,5 +1,68 @@
 FAIL
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests for the amp-youtube tag. See the inline comments.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async custom-element="amp-youtube" src="https://cdn.ampproject.org/v0/amp-youtube-latest.js"></script>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|  <body>
+|    <!-- Valid -->
+|    <amp-youtube width="480" height="270"
+|                 data-videoid="dQw4w9WgXcQ">
+|    </amp-youtube>
+|    <!-- Valid: with bindable [data-videoid] attribute -->
+|    <amp-youtube width="480" height="270"
+|                 data-videoid="dQw4w9WgXcQ" [data-videoid]="foo.bar">
+|    </amp-youtube>
+|    <!-- Valid: with data-live-channelid attribute -->
+|    <amp-youtube width="480" height="270"
+|      data-live-channelid="UCB8Kb4pxYzsDsHxzBfnid4Q">
+|    </amp-youtube>
+|  
+|    <!-- Invalid: data-videoid and data-live-channelid both missing. -->
+|    <amp-youtube width="480" height="270"></amp-youtube>
+>>   ^~~~~~~~~
 amp-youtube/0.1/test/validator-amp-youtube.html:45:2 The tag 'amp-youtube' is missing a mandatory attribute - pick one of ['data-live-channelid', 'data-videoid']. (see https://www.ampproject.org/docs/reference/components/amp-youtube) [AMP_TAG_PROBLEM]
+|    <!-- Invalid: dimensions are missing. -->
+|    <amp-youtube data-videoid="dQw4w9WgXcQ">
+>>   ^~~~~~~~~
 amp-youtube/0.1/test/validator-amp-youtube.html:47:2 The implied layout 'CONTAINER' is not supported by tag 'amp-youtube'. (see https://www.ampproject.org/docs/reference/components/amp-youtube) [AMP_LAYOUT_PROBLEM]
+|    </amp-youtube>
+|    <!-- Invalid: the attr value must be a video id -->
+|    <amp-youtube width="480" height="270"
+>>   ^~~~~~~~~
 amp-youtube/0.1/test/validator-amp-youtube.html:50:2 The attribute 'data-videoid' in tag 'amp-youtube' is set to the invalid value 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'. (see https://www.ampproject.org/docs/reference/components/amp-youtube) [AMP_TAG_PROBLEM]
+|                 data-videoid="https://www.youtube.com/watch?v=dQw4w9WgXcQ">
+|    </amp-youtube>
+|    <!-- Invalid: cannot have both data-videoid and data-live-channelid -->
+|    <amp-youtube width="480" height="270"
+>>   ^~~~~~~~~
 amp-youtube/0.1/test/validator-amp-youtube.html:54:2 Mutually exclusive attributes encountered in tag 'amp-youtube' - pick one of ['data-live-channelid', 'data-videoid']. (see https://www.ampproject.org/docs/reference/components/amp-youtube) [AMP_TAG_PROBLEM]
+|      data-live-channelid="UCB8Kb4pxYzsDsHxzBfnid4Q"
+|      data-videoid="dQw4w9WgXcQ">
+|    </amp-youtube>
+|  </body>
+|  </html>

--- a/validator/engine/validator_test.js
+++ b/validator/engine/validator_test.js
@@ -21,8 +21,10 @@ goog.require('amp.validator.TagSpec');
 goog.require('amp.validator.ValidationError');
 goog.require('amp.validator.annotateWithErrorCategories');
 goog.require('amp.validator.createRules');
+goog.require('amp.validator.renderErrorMessage');
 goog.require('amp.validator.renderValidationResult');
 goog.require('amp.validator.validateString');
+goog.require('goog.uri.utils');
 
 /**
  * Returns the absolute path for a given test file, that is, a file
@@ -152,6 +154,12 @@ const ValidatorTestCase = function(ampHtmlFile, opt_ampUrl) {
     this.htmlFormat = 'AMP4ADS';
   }
   /**
+   * If set to false, output will be generated without inlining the input
+   * document.
+   * @type {boolean}
+   */
+  this.inlineOutput = true;
+  /**
    * This field can be null, indicating that the expectedOutput did not
    * come from a file.
    * @type {?string}
@@ -160,11 +168,66 @@ const ValidatorTestCase = function(ampHtmlFile, opt_ampUrl) {
       path.dirname(ampHtmlFile), path.basename(ampHtmlFile, '.html') + '.out');
   /** @type {string} */
   this.ampHtmlFileContents =
-      fs.readFileSync(absolutePathFor(this.ampHtmlFile), 'utf8');
+      fs.readFileSync(absolutePathFor(this.ampHtmlFile), 'utf8').trim();
   /** @type {string} */
   this.expectedOutput =
       fs.readFileSync(absolutePathFor(this.expectedOutputFile), 'utf8').trim();
 };
+
+/**
+ * Renders one line of error output.
+ * @param {string} filenameOrUrl
+ * @param {!amp.validator.ValidationError} error
+ * @return {string}
+ */
+function renderErrorWithPosition(filenameOrUrl, error) {
+  const line = error.line || 1;
+  const col = error.col || 0;
+
+  let errorLine = goog.uri.utils.removeFragment(filenameOrUrl) + ':' + line +
+      ':' + col + ' ';
+  errorLine += amp.validator.renderErrorMessage(error);
+  if (error.specUrl) {
+    errorLine += ' (see ' + error.specUrl + ')';
+  }
+  if (error.category !== null) {
+    errorLine += ' [' + error.category + ']';
+  }
+  return errorLine;
+}
+
+/**
+ * Like amp.validator.renderValidationResult, except inlines any error messages
+ * into the input document.
+ * @param {!Object} validationResult
+ * @param {string} filename to use in rendering error messages.
+ * @param {string} filecontents
+ * @return {string}
+ */
+function renderInlineResult(validationResult, filename, filecontents) {
+  let rendered = '';
+  rendered += validationResult.status;
+
+  const lines = filecontents.split('\n');
+  let linesEmitted = 0;
+  for (const error of validationResult.errors) {
+    // Emit all input lines up to and including the line containing the error,
+    // prefixed with '|  '.
+    while (linesEmitted < error.line && linesEmitted < lines.length) {
+      rendered += '\n|  ' + lines[linesEmitted++];
+    }
+    // Emit a carat showing the column of the following error.
+    rendered += '\n>>';
+    for (let i = 0; i < error.col + 1; ++i)
+      rendered += ' ';
+    rendered += '^~~~~~~~~\n';
+    rendered += renderErrorWithPosition(filename, error);
+  }
+  while (linesEmitted < lines.length) {
+    rendered += '\n|  '+ lines[linesEmitted++];
+  }
+  return rendered;
+}
 
 /**
  * Runs the test, by executing the AMP Validator, then comparing its output
@@ -174,8 +237,10 @@ ValidatorTestCase.prototype.run = function() {
   const results =
       amp.validator.validateString(this.ampHtmlFileContents, this.htmlFormat);
   amp.validator.annotateWithErrorCategories(results);
-  const observed =
+  const observed = this.inlineOutput ?
+      renderInlineResult(results, this.ampUrl, this.ampHtmlFileContents) :
       amp.validator.renderValidationResult(results, this.ampUrl).join('\n');
+
   if (observed === this.expectedOutput) {
     return;
   }
@@ -214,8 +279,12 @@ describe('ValidatorOutput', () => {
     const test = new ValidatorTestCase(
         'feature_tests/no_custom_js.html',
         'http://google.com/foo.html#development=1');
-    test.expectedOutputFile = null;
-    test.expectedOutput = 'FAIL\n' +
+    const results =
+        amp.validator.validateString(test.ampHtmlFileContents, test.htmlFormat);
+    amp.validator.annotateWithErrorCategories(results);
+    const observed =
+        amp.validator.renderValidationResult(results, test.ampUrl).join('\n');
+    const expectedOutput = 'FAIL\n' +
         'http://google.com/foo.html:28:3 Only AMP runtime \'script\' tags ' +
         'are allowed, and only in the document head. (see ' +
         'https://www.ampproject.org/docs/reference/spec#html-tags) ' +
@@ -224,7 +293,9 @@ describe('ValidatorOutput', () => {
         'are allowed, and only in the document head. (see ' +
         'https://www.ampproject.org/docs/reference/spec#html-tags) ' +
         '[CUSTOM_JAVASCRIPT_DISALLOWED]';
-    test.run();
+    if (observed !== expectedOutput)
+      assert.fail(
+          '', '', 'expected:\n' + expectedOutput + '\nsaw:\n' + observed, '');
   });
 });
 
@@ -244,8 +315,10 @@ describe('ValidatorCssLengthValidation', () => {
     assertStrictEqual(50000, maxBytes.length);
 
     const test = new ValidatorTestCase('feature_tests/css_length.html');
+    test.inlineOutput = false;
     test.ampHtmlFileContents =
         test.ampHtmlFileContents.replace('.replaceme {}', maxBytes);
+    test.expectedOutput = 'PASS';
     test.run();
   });
 
@@ -253,6 +326,7 @@ describe('ValidatorCssLengthValidation', () => {
     const oneTooMany = Array(5001).join(validStyleBlob) + ' ';
     assertStrictEqual(50001, oneTooMany.length);
     const test = new ValidatorTestCase('feature_tests/css_length.html');
+    test.inlineOutput = false;
     test.ampHtmlFileContents =
         test.ampHtmlFileContents.replace('.replaceme {}', oneTooMany);
     test.expectedOutputFile = null;
@@ -269,6 +343,7 @@ describe('ValidatorCssLengthValidation', () => {
     const multiByteSheet = Array(5000).join(validStyleBlob) + 'h {a: 😺}';
     assertStrictEqual(49999, multiByteSheet.length);  // character length
     const test = new ValidatorTestCase('feature_tests/css_length.html');
+    test.inlineOutput = false;
     test.ampHtmlFileContents =
         test.ampHtmlFileContents.replace('.replaceme {}', multiByteSheet);
     test.expectedOutputFile = null;

--- a/validator/nodejs/index.js
+++ b/validator/nodejs/index.js
@@ -63,7 +63,7 @@ function readFromFile(name) {
       if (err) {
         reject(err);
       } else {
-        resolve(data);
+        resolve(data.trim());
       }
     });
   });

--- a/validator/nodejs/index_test.js
+++ b/validator/nodejs/index_test.js
@@ -64,8 +64,8 @@ it('built validator rejects the empty file', function(done) {
 
 it('accepts the minimum valid AMP file', function(done) {
   // Note: This will use the validator that was built with build.py.
-  var mini =
-      fs.readFileSync('../testdata/feature_tests/minimum_valid_amp.html', 'utf-8');
+  var mini = fs.readFileSync(
+      '../testdata/feature_tests/minimum_valid_amp.html', 'utf-8').trim();
   ampValidator.getInstance(/*validatorJs*/ '../dist/validator_minified.js')
       .then(function(instance) {
         var validationResult = instance.validateString(mini);
@@ -81,7 +81,8 @@ it('accepts the minimum valid AMP file', function(done) {
 it('accepts the minimum valid AMP4ADS file', function(done) {
   // Note: This will use the validator that was built with build.py.
   var mini = fs.readFileSync(
-      '../testdata/amp4ads_feature_tests/min_valid_amp4ads.html', 'utf-8');
+      '../testdata/amp4ads_feature_tests/min_valid_amp4ads.html', 'utf-8')
+      .trim();
   ampValidator.getInstance(/*validatorJs*/ '../dist/validator_minified.js')
       .then(function(instance) {
         var validationResult = instance.validateString(mini, 'AMP4ADS');
@@ -94,12 +95,27 @@ it('accepts the minimum valid AMP4ADS file', function(done) {
       });
 });
 
+/**
+ * Given a line read from a test .out file, returns true iff the line is an
+ * actual error, instead of the input file inlined.
+ * @param {string} line
+ * @return {boolean}
+ */
+function isErrorLine(line) {
+  return !(line.startsWith('|') || line.startsWith('>>'));
+}
+
 it('rejects a specific file that is known to have errors', function(done) {
   // Note: This will use the validator that was built with build.py.
   var severalErrorsHtml =
-      fs.readFileSync('../testdata/feature_tests/several_errors.html', 'utf-8');
+      fs.readFileSync('../testdata/feature_tests/several_errors.html', 'utf-8')
+          .trim();
   var severalErrorsOut =
-      fs.readFileSync('../testdata/feature_tests/several_errors.out', 'utf-8');
+      fs.readFileSync('../testdata/feature_tests/several_errors.out', 'utf-8')
+          .split('\n')
+          .filter(isErrorLine)
+          .join('\n');
+
   ampValidator.getInstance(/*validatorJs*/ '../dist/validator_minified.js')
       .then(function(instance) {
         var validationResult = instance.validateString(severalErrorsHtml);
@@ -142,7 +158,7 @@ it('handles syntax errors in validator file', function(done) {
 
 it('also works with newInstance', function() {
   var mini = fs.readFileSync(
-      '../testdata/feature_tests/minimum_valid_amp.html', 'utf-8');
+      '../testdata/feature_tests/minimum_valid_amp.html', 'utf-8').trim();
   var validatorJsContents =
       fs.readFileSync('../dist/validator_minified.js', 'utf-8');
   var resultForMini =
@@ -150,7 +166,8 @@ it('also works with newInstance', function() {
   expect(resultForMini.status).toBe('PASS');
 
   var severalErrorsHtml =
-      fs.readFileSync('../testdata/feature_tests/several_errors.html', 'utf-8');
+      fs.readFileSync('../testdata/feature_tests/several_errors.html', 'utf-8')
+          .trim();
   var resultForSeveralErrors = ampValidator.newInstance(validatorJsContents)
                                    .validateString(severalErrorsHtml);
   expect(resultForSeveralErrors.status).toBe('FAIL');
@@ -160,6 +177,7 @@ it('emits text if --format=text is specified on command line', function(done) {
   var severalErrorsOut =
       fs.readFileSync('../testdata/feature_tests/several_errors.out', 'utf-8')
           .split('\n')
+          .filter(isErrorLine)
           .splice(1)  // trim 1st line
           .join('\n')
           .replace(/ \[[A-Z_]+\]/g, '');  // trim error categories
@@ -215,6 +233,7 @@ it('supports AMP4ADS with --html_format command line option', function(done) {
             '../testdata/amp4ads_feature_tests/style-amp-custom.out',
             'utf-8')
           .split('\n')
+          .filter(isErrorLine)
           .splice(1)  // trim 1st line
           .join('\n')
           .replace(/ \[[A-Z_]+\]/g, '');  // trim error categories

--- a/validator/testdata/amp4ads_feature_tests/amp_pixel_ssr.out
+++ b/validator/testdata/amp4ads_feature_tests/amp_pixel_ssr.out
@@ -1,1 +1,33 @@
 PASS
+|  <!--
+|    Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Verify amp-pixel indicating SSR support is valid.
+|  -->
+|  <!doctype html>
+|  <html ⚡4ads>
+|  <head>
+|    <meta charset="utf-8">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp4ads-boilerplate>body{visibility:hidden}</style>
+|    <script async src="https://cdn.ampproject.org/amp4ads-v0.js"></script>
+|  </head>
+|  <body>
+|    Hello, world.
+|    <amp-pixel src="https://pixel.me?yes=please" allow-ssr-img></amp-pixel>
+|  </body>
+|  </html>

--- a/validator/testdata/amp4ads_feature_tests/extensions.out
+++ b/validator/testdata/amp4ads_feature_tests/extensions.out
@@ -1,33 +1,186 @@
 FAIL
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    This test illustrates which AMP extensions are allowed in A4A and which
+|    are not. It is likely that this test will not keep up with added extensions
+|    over time, and so it should not be used as a definitive list. For that,
+|    see the AMP and A4A documentation.
+|  
+|    Note that the test will generate a bunch of warnings/errors suggesting that
+|    the extensions are unnecessary since corresponding tags are not present.
+|  -->
+|  <!doctype html>
+|  <html ⚡4ads>
+|  <head>
+|    <meta charset="utf-8">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp4ads-boilerplate>body{visibility:hidden}</style>
+|    <script async src="https://cdn.ampproject.org/amp4ads-v0.js"></script>
+|  
+|    <!-- So many AMP extensions! -->
+|    <script async custom-element="amp-access"
+>>   ^~~~~~~~~
 amp4ads_feature_tests/extensions.html:35:2 Only AMP runtime 'script' tags are allowed, and only in the document head. (see https://www.ampproject.org/docs/reference/spec#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
+|       src="https://cdn.ampproject.org/v0/amp-access-0.1.js"></script>
+|    <script async custom-element="amp-accordion"
+|       src="https://cdn.ampproject.org/v0/amp-accordion-0.1.js"></script>
+|    <script async custom-element="amp-ad"
+>>   ^~~~~~~~~
 amp4ads_feature_tests/extensions.html:39:2 Only AMP runtime 'script' tags are allowed, and only in the document head. (see https://www.ampproject.org/docs/reference/spec#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
+|       src="https://cdn.ampproject.org/v0/amp-ad-0.1.js"></script>
+|    <script async custom-element="amp-analytics"
+|       src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
+|    <script async custom-element="amp-anim"
+|       src="https://cdn.ampproject.org/v0/amp-anim-0.1.js"></script>
+|    <script async custom-element="amp-animation"
+|       src="https://cdn.ampproject.org/v0/amp-animation-0.1.js"></script>
+|    <script async custom-element="amp-audio"
+|       src="https://cdn.ampproject.org/v0/amp-audio-0.1.js"></script>
+|    <script async custom-element="amp-brid-player"
+>>   ^~~~~~~~~
 amp4ads_feature_tests/extensions.html:49:2 Only AMP runtime 'script' tags are allowed, and only in the document head. (see https://www.ampproject.org/docs/reference/spec#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
+|       src="https://cdn.ampproject.org/v0/amp-brid-player-0.1.js"></script>
+|    <script async custom-element="amp-brightcove"
+>>   ^~~~~~~~~
 amp4ads_feature_tests/extensions.html:51:2 Only AMP runtime 'script' tags are allowed, and only in the document head. (see https://www.ampproject.org/docs/reference/spec#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
+|       src="https://cdn.ampproject.org/v0/amp-brightcove-0.1.js"></script>
+|    <script async custom-element="amp-carousel"
+|       src="https://cdn.ampproject.org/v0/amp-carousel-0.1.js"></script>
+|    <script async custom-element="amp-dailymotion"
+>>   ^~~~~~~~~
 amp4ads_feature_tests/extensions.html:55:2 Only AMP runtime 'script' tags are allowed, and only in the document head. (see https://www.ampproject.org/docs/reference/spec#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
+|       src="https://cdn.ampproject.org/v0/amp-dailymotion-0.1.js"></script>
+|    <script async custom-element="amp-dynamic-css-classes"
+>>   ^~~~~~~~~
 amp4ads_feature_tests/extensions.html:57:2 Only AMP runtime 'script' tags are allowed, and only in the document head. (see https://www.ampproject.org/docs/reference/spec#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
+|       src="https://cdn.ampproject.org/v0/amp-dynamic-css-classes-0.1.js"></script>
+|    <script async custom-element="amp-experiment"
+>>   ^~~~~~~~~
 amp4ads_feature_tests/extensions.html:59:2 Only AMP runtime 'script' tags are allowed, and only in the document head. (see https://www.ampproject.org/docs/reference/spec#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
+|       src="https://cdn.ampproject.org/v0/amp-experiment-0.1.js"></script>
+|    <script async custom-element="amp-facebook"
+>>   ^~~~~~~~~
 amp4ads_feature_tests/extensions.html:61:2 Only AMP runtime 'script' tags are allowed, and only in the document head. (see https://www.ampproject.org/docs/reference/spec#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
+|       src="https://cdn.ampproject.org/v0/amp-facebook-0.1.js"></script>
+|    <script async custom-element="amp-fit-text"
+|       src="https://cdn.ampproject.org/v0/amp-fit-text-0.1.js"></script>
+|    <script async custom-element="amp-font"
+|       src="https://cdn.ampproject.org/v0/amp-font-0.1.js"></script>
+|    <script async custom-element="amp-form"
+|       src="https://cdn.ampproject.org/v0/amp-form-0.1.js"></script>
+|    <script async custom-element="amp-fx-flying-carpet"
+>>   ^~~~~~~~~
 amp4ads_feature_tests/extensions.html:69:2 Only AMP runtime 'script' tags are allowed, and only in the document head. (see https://www.ampproject.org/docs/reference/spec#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
+|       src="https://cdn.ampproject.org/v0/amp-fx-flying-carpet-0.1.js"></script>
+|    <script async custom-element="amp-iframe"
+>>   ^~~~~~~~~
 amp4ads_feature_tests/extensions.html:71:2 Only AMP runtime 'script' tags are allowed, and only in the document head. (see https://www.ampproject.org/docs/reference/spec#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
+|       src="https://cdn.ampproject.org/v0/amp-iframe-0.1.js"></script>
+|    <script async custom-element="amp-image-lightbox"
+>>   ^~~~~~~~~
 amp4ads_feature_tests/extensions.html:73:2 Only AMP runtime 'script' tags are allowed, and only in the document head. (see https://www.ampproject.org/docs/reference/spec#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
+|       src="https://cdn.ampproject.org/v0/amp-image-lightbox-0.1.js"></script>
+|    <script async custom-element="amp-instagram"
+>>   ^~~~~~~~~
 amp4ads_feature_tests/extensions.html:75:2 Only AMP runtime 'script' tags are allowed, and only in the document head. (see https://www.ampproject.org/docs/reference/spec#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
+|       src="https://cdn.ampproject.org/v0/amp-instagram-0.1.js"></script>
+|    <script async custom-element="amp-install-serviceworker"
+>>   ^~~~~~~~~
 amp4ads_feature_tests/extensions.html:77:2 Only AMP runtime 'script' tags are allowed, and only in the document head. (see https://www.ampproject.org/docs/reference/spec#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
+|       src="https://cdn.ampproject.org/v0/amp-install-serviceworker-0.1.js"></script>
+|    <script async custom-element="amp-jwplayer"
+>>   ^~~~~~~~~
 amp4ads_feature_tests/extensions.html:79:2 Only AMP runtime 'script' tags are allowed, and only in the document head. (see https://www.ampproject.org/docs/reference/spec#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
+|       src="https://cdn.ampproject.org/v0/amp-jwplayer-0.1.js"></script>
+|    <script async custom-element="amp-kaltura-player"
+>>   ^~~~~~~~~
 amp4ads_feature_tests/extensions.html:81:2 Only AMP runtime 'script' tags are allowed, and only in the document head. (see https://www.ampproject.org/docs/reference/spec#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
+|       src="https://cdn.ampproject.org/v0/amp-kaltura-player-0.1.js"></script>
+|    <script async custom-element="amp-lightbox"
+>>   ^~~~~~~~~
 amp4ads_feature_tests/extensions.html:83:2 Only AMP runtime 'script' tags are allowed, and only in the document head. (see https://www.ampproject.org/docs/reference/spec#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
+|       src="https://cdn.ampproject.org/v0/amp-lightbox-0.1.js"></script>
+|    <script async custom-element="amp-list"
+>>   ^~~~~~~~~
 amp4ads_feature_tests/extensions.html:85:2 Only AMP runtime 'script' tags are allowed, and only in the document head. (see https://www.ampproject.org/docs/reference/spec#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
+|       src="https://cdn.ampproject.org/v0/amp-list-0.1.js"></script>
+|    <script async custom-element="amp-live-list"
+>>   ^~~~~~~~~
 amp4ads_feature_tests/extensions.html:87:2 Only AMP runtime 'script' tags are allowed, and only in the document head. (see https://www.ampproject.org/docs/reference/spec#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
+|       src="https://cdn.ampproject.org/v0/amp-live-list-0.1.js"></script>
+|    <script async custom-element="amp-o2-player"
+>>   ^~~~~~~~~
 amp4ads_feature_tests/extensions.html:89:2 Only AMP runtime 'script' tags are allowed, and only in the document head. (see https://www.ampproject.org/docs/reference/spec#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
+|       src="https://cdn.ampproject.org/v0/amp-o2-player-0.1.js"></script>
+|    <script async custom-element="amp-pinterest"
+>>   ^~~~~~~~~
 amp4ads_feature_tests/extensions.html:91:2 Only AMP runtime 'script' tags are allowed, and only in the document head. (see https://www.ampproject.org/docs/reference/spec#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
+|       src="https://cdn.ampproject.org/v0/amp-pinterest-0.1.js"></script>
+|    <script async custom-element="amp-reach-player"
+>>   ^~~~~~~~~
 amp4ads_feature_tests/extensions.html:93:2 Only AMP runtime 'script' tags are allowed, and only in the document head. (see https://www.ampproject.org/docs/reference/spec#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
+|       src="https://cdn.ampproject.org/v0/amp-reach-player-0.1.js"></script>
+|    <script async custom-element="amp-sidebar"
+>>   ^~~~~~~~~
 amp4ads_feature_tests/extensions.html:95:2 Only AMP runtime 'script' tags are allowed, and only in the document head. (see https://www.ampproject.org/docs/reference/spec#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
+|       src="https://cdn.ampproject.org/v0/amp-sidebar-0.1.js"></script>
+|    <script async custom-element="amp-slides"
+>>   ^~~~~~~~~
 amp4ads_feature_tests/extensions.html:97:2 Only AMP runtime 'script' tags are allowed, and only in the document head. (see https://www.ampproject.org/docs/reference/spec#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
+|       src="https://cdn.ampproject.org/v0/amp-slides-0.1.js"></script>
+|    <script async custom-element="amp-social-share"
+|       src="https://cdn.ampproject.org/v0/amp-social-share-0.1.js"></script>
+|    <script async custom-element="amp-soundcloud"
+>>   ^~~~~~~~~
 amp4ads_feature_tests/extensions.html:101:2 Only AMP runtime 'script' tags are allowed, and only in the document head. (see https://www.ampproject.org/docs/reference/spec#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
+|       src="https://cdn.ampproject.org/v0/amp-soundcloud-0.1.js"></script>
+|    <script async custom-element="amp-springboard-player"
+>>   ^~~~~~~~~
 amp4ads_feature_tests/extensions.html:103:2 Only AMP runtime 'script' tags are allowed, and only in the document head. (see https://www.ampproject.org/docs/reference/spec#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
+|       src="https://cdn.ampproject.org/v0/amp-springboard-player-0.1.js"></script>
+|    <script async custom-element="amp-sticky-ad"
+>>   ^~~~~~~~~
 amp4ads_feature_tests/extensions.html:105:2 Only AMP runtime 'script' tags are allowed, and only in the document head. (see https://www.ampproject.org/docs/reference/spec#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
+|       src="https://cdn.ampproject.org/v0/amp-sticky-ad-0.1.js"></script>
+|    <script async custom-element="amp-twitter"
+>>   ^~~~~~~~~
 amp4ads_feature_tests/extensions.html:107:2 Only AMP runtime 'script' tags are allowed, and only in the document head. (see https://www.ampproject.org/docs/reference/spec#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
+|       src="https://cdn.ampproject.org/v0/amp-twitter-0.1.js"></script>
+|    <script async custom-element="amp-user-notification"
+>>   ^~~~~~~~~
 amp4ads_feature_tests/extensions.html:109:2 Only AMP runtime 'script' tags are allowed, and only in the document head. (see https://www.ampproject.org/docs/reference/spec#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
+|       src="https://cdn.ampproject.org/v0/amp-user-notification-0.1.js"></script>
+|    <script async custom-element="amp-vimeo"
+>>   ^~~~~~~~~
 amp4ads_feature_tests/extensions.html:111:2 Only AMP runtime 'script' tags are allowed, and only in the document head. (see https://www.ampproject.org/docs/reference/spec#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
+|       src="https://cdn.ampproject.org/v0/amp-vimeo-0.1.js"></script>
+|    <script async custom-element="amp-vine"
+>>   ^~~~~~~~~
 amp4ads_feature_tests/extensions.html:113:2 Only AMP runtime 'script' tags are allowed, and only in the document head. (see https://www.ampproject.org/docs/reference/spec#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
+|       src="https://cdn.ampproject.org/v0/amp-vine-0.1.js"></script>
+|    <script async custom-element="amp-youtube"
+|       src="https://cdn.ampproject.org/v0/amp-youtube-0.1.js"></script>
+|  
+|    <script async custom-template="amp-mustache"
+>>   ^~~~~~~~~
 amp4ads_feature_tests/extensions.html:118:2 Only AMP runtime 'script' tags are allowed, and only in the document head. (see https://www.ampproject.org/docs/reference/spec#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
-amp4ads_feature_tests/extensions.html:121:20 The extension 'amp-animation' was found on this page, but is unused. Please remove this extension. [AMP_TAG_PROBLEM]
+|       src="https://cdn.ampproject.org/v0/amp-mustache-0.1.js"></script>
+|  </head>
+|  <body></body></html>
+>>                    ^~~~~~~~~
+amp4ads_feature_tests/extensions.html:121:19 The extension 'amp-animation' was found on this page, but is unused. Please remove this extension. [AMP_TAG_PROBLEM]

--- a/validator/testdata/amp4ads_feature_tests/min_valid_amp4ads.out
+++ b/validator/testdata/amp4ads_feature_tests/min_valid_amp4ads.out
@@ -1,1 +1,31 @@
 PASS
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    This is the minimum valid A4A document; it includes all of the required
+|    fields from the spec, but nothing else.
+|  -->
+|  <!doctype html>
+|  <html ⚡4ads>
+|  <head>
+|    <meta charset="utf-8">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp4ads-boilerplate>body{visibility:hidden}</style>
+|    <script async src="https://cdn.ampproject.org/amp4ads-v0.js"></script>
+|  </head>
+|  <body>Hello, world.</body>
+|  </html>

--- a/validator/testdata/amp4ads_feature_tests/noscript.out
+++ b/validator/testdata/amp4ads_feature_tests/noscript.out
@@ -1,8 +1,57 @@
 FAIL
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    This tests that <noscript> tags are disallowed in A4A, which differs from AMP.
+|  -->
+|  <!doctype html>
+|  <html ⚡4ads>
+|  <head>
+|    <meta charset="utf-8">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp4ads-boilerplate>body{visibility:hidden}</style>
+|    <script async src="https://cdn.ampproject.org/amp4ads-v0.js"></script>
+|  </head>
+|  <body>
+|    <!-- Invalid -->
+|    <noscript></noscript>
+>>   ^~~~~~~~~
 amp4ads_feature_tests/noscript.html:30:2 The tag 'noscript' is disallowed. [DISALLOWED_HTML]
+|    <!-- Invalid -->
+|    <img src="https://example.com/">
+>>   ^~~~~~~~~
 amp4ads_feature_tests/noscript.html:32:2 The tag 'img' is disallowed. [DISALLOWED_HTML]
+|    <!-- Invalid -->
+|    <noscript>
+>>   ^~~~~~~~~
 amp4ads_feature_tests/noscript.html:34:2 The tag 'noscript' is disallowed. [DISALLOWED_HTML]
+|      <img src="https://example.com/">
+>>     ^~~~~~~~~
 amp4ads_feature_tests/noscript.html:35:4 The tag 'img' is disallowed. [DISALLOWED_HTML]
+|    </noscript>
+|    <noscript>
+>>   ^~~~~~~~~
 amp4ads_feature_tests/noscript.html:37:2 The tag 'noscript' is disallowed. [DISALLOWED_HTML]
+|      <video></video>
+>>     ^~~~~~~~~
 amp4ads_feature_tests/noscript.html:38:4 The tag 'video' is disallowed. [DISALLOWED_HTML]
+|      <audio></audio>
+>>     ^~~~~~~~~
 amp4ads_feature_tests/noscript.html:39:4 The tag 'audio' is disallowed. [DISALLOWED_HTML]
+|    </noscript>
+|  </body>
+|  </html>

--- a/validator/testdata/amp4ads_feature_tests/obsolete_tags.out
+++ b/validator/testdata/amp4ads_feature_tests/obsolete_tags.out
@@ -1,15 +1,77 @@
 FAIL
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    This tests that A4A does not allow obsolete non-conforming tags, which AMP
+|    does.
+|  -->
+|  <!doctype html>
+|  <html ⚡4ads>
+|  <head>
+|    <meta charset="utf-8">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp4ads-boilerplate>body{visibility:hidden}</style>
+|    <script async src="https://cdn.ampproject.org/amp4ads-v0.js"></script>
+|  </head>
+|  <body>
+|  These tags are not allowed:
+|  <ACRONYM></ACRONYM>
+>> ^~~~~~~~~
 amp4ads_feature_tests/obsolete_tags.html:31:0 The tag 'acronym' is disallowed. [DISALLOWED_HTML]
+|  <BIG></BIG>
+>> ^~~~~~~~~
 amp4ads_feature_tests/obsolete_tags.html:32:0 The tag 'big' is disallowed. [DISALLOWED_HTML]
+|  <CENTER></CENTER>
+>> ^~~~~~~~~
 amp4ads_feature_tests/obsolete_tags.html:33:0 The tag 'center' is disallowed. [DISALLOWED_HTML]
+|  <DIR></DIR>
+>> ^~~~~~~~~
 amp4ads_feature_tests/obsolete_tags.html:34:0 The tag 'dir' is disallowed. [DISALLOWED_HTML]
+|  <HGROUP></HGROUP>
+>> ^~~~~~~~~
 amp4ads_feature_tests/obsolete_tags.html:35:0 The tag 'hgroup' is disallowed. [DISALLOWED_HTML]
+|  <LISTING></LISTING>
+>> ^~~~~~~~~
 amp4ads_feature_tests/obsolete_tags.html:36:0 The tag 'listing' is disallowed. [DISALLOWED_HTML]
+|  <MULTICOL></MULTICOL>
+>> ^~~~~~~~~
 amp4ads_feature_tests/obsolete_tags.html:37:0 The tag 'multicol' is disallowed. [DISALLOWED_HTML]
+|  <NEXTID></NEXTID>
+>> ^~~~~~~~~
 amp4ads_feature_tests/obsolete_tags.html:38:0 The tag 'nextid' is disallowed. [DISALLOWED_HTML]
+|  <NOBR></NOBR>
+>> ^~~~~~~~~
 amp4ads_feature_tests/obsolete_tags.html:39:0 The tag 'nobr' is disallowed. [DISALLOWED_HTML]
+|  <SPACER></SPACER>
+>> ^~~~~~~~~
 amp4ads_feature_tests/obsolete_tags.html:40:0 The tag 'spacer' is disallowed. [DISALLOWED_HTML]
+|  <STRIKE></STRIKE>
+>> ^~~~~~~~~
 amp4ads_feature_tests/obsolete_tags.html:41:0 The tag 'strike' is disallowed. [DISALLOWED_HTML]
+|  <TT></TT>
+>> ^~~~~~~~~
 amp4ads_feature_tests/obsolete_tags.html:42:0 The tag 'tt' is disallowed. [DISALLOWED_HTML]
+|  <XMP></XMP>
+>> ^~~~~~~~~
 amp4ads_feature_tests/obsolete_tags.html:43:0 The tag 'xmp' is disallowed. [DISALLOWED_HTML]
+|  <o:p></o:p>
+>> ^~~~~~~~~
 amp4ads_feature_tests/obsolete_tags.html:44:0 The tag 'o:p' is disallowed. [DISALLOWED_HTML]
+|  
+|  
+|  </body>
+|  </html>

--- a/validator/testdata/amp4ads_feature_tests/style-amp-custom.out
+++ b/validator/testdata/amp4ads_feature_tests/style-amp-custom.out
@@ -1,13 +1,166 @@
 FAIL
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    This tests CSS style rules specific to A4A which differ from AMP.
+|  -->
+|  <!doctype html>
+|  <html ⚡4ads>
+|  <head>
+|    <meta charset="utf-8">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp4ads-boilerplate>body{visibility:hidden}</style>
+|    <script async src="https://cdn.ampproject.org/amp4ads-v0.js"></script>
+|    </style>
+|    <style amp-custom>
+|      /* Valid. */
+|      .amp-animate .box {
+|        transform: rotate(180deg);
+|        transition: transform 2s;
+|      }
+|  
+|      /* Invalid: non-animation property (color) invalid in animation selector */
+|      .amp-animate .box {
+|        color: red;
+>>       ^~~~~~~~~
 amp4ads_feature_tests/style-amp-custom.html:37:6 CSS syntax error in tag 'style amp-custom (AMP4ADS)' - the property 'color' is disallowed together with 'transition'. Allowed properties: ['animation', 'opacity', 'transform', 'transition', 'visibility']. [AUTHOR_STYLESHEET_PROBLEM]
+|        transform: rotate(180deg);
+|        transition: transform 2s;
+|      }
+|  
+|      /* Invalid: Missing context class .amp-animate */
+|      .box {
+|        transform: rotate(180deg);
+|        transition: transform 2s;
+|      }
+|  
+|      /* Valid. */
+|      .amp-animate .box {
+|        transition: transform 2s;
+|      }
+|  
+|      /* Invalid: The only properties that may be transitioned are opacity
+|         and transform. */
+|      .amp-animate .box {
+|        transition: background-color 2s;
+>>       ^~~~~~~~~
 amp4ads_feature_tests/style-amp-custom.html:56:6 CSS syntax error in tag 'style amp-custom (AMP4ADS)' - the property 'transition' is set to the disallowed value 'background-color'. Allowed values: ['opacity', 'transform']. [AUTHOR_STYLESHEET_PROBLEM]
+|      }
+|  
+|      /* Valid. */
+|      @keyframes turn {
+|        from {
+|          transform: rotate(180deg);
+|        }
+|  
+|        to {
+|          transform: rotate(90deg);
+|        }
+|      }
+|  
+|      /* Invalid: only opacity and transform may be transitioned. */
+|      @keyframes slidein {
+|        from {
+|          margin-left:100%;
+>>         ^~~~~~~~~
 amp4ads_feature_tests/style-amp-custom.html:73:8 CSS syntax error in tag 'style amp-custom (AMP4ADS)' - the property 'margin-left' is disallowed within @keyframes. Allowed properties: ['animation-timing-function', 'opacity', 'transform']. [AUTHOR_STYLESHEET_PROBLEM]
+|          width:300%
+>>         ^~~~~~~~~
 amp4ads_feature_tests/style-amp-custom.html:74:8 CSS syntax error in tag 'style amp-custom (AMP4ADS)' - the property 'width' is disallowed within @keyframes. Allowed properties: ['animation-timing-function', 'opacity', 'transform']. [AUTHOR_STYLESHEET_PROBLEM]
+|        }
+|  
+|        to {
+|          margin-left:0%;
+>>         ^~~~~~~~~
 amp4ads_feature_tests/style-amp-custom.html:78:8 CSS syntax error in tag 'style amp-custom (AMP4ADS)' - the property 'margin-left' is disallowed within @keyframes. Allowed properties: ['animation-timing-function', 'opacity', 'transform']. [AUTHOR_STYLESHEET_PROBLEM]
+|          width:100%;
+>>         ^~~~~~~~~
 amp4ads_feature_tests/style-amp-custom.html:79:8 CSS syntax error in tag 'style amp-custom (AMP4ADS)' - the property 'width' is disallowed within @keyframes. Allowed properties: ['animation-timing-function', 'opacity', 'transform']. [AUTHOR_STYLESHEET_PROBLEM]
+|        }
+|      }
+|  
+|      /* Now with vendor prefixes */
+|  
+|      /* Valid. */
+|      .amp-animate .box {
+|        -moz-transform: rotate(180deg);
+|        -webkit-transition: transform 2s;
+|      }
+|  
+|      /* Invalid: non-animation property (color) invalid in animation selector */
+|      .amp-animate .box {
+|        color: red;
+>>       ^~~~~~~~~
 amp4ads_feature_tests/style-amp-custom.html:93:6 CSS syntax error in tag 'style amp-custom (AMP4ADS)' - the property 'color' is disallowed together with '-o-transition'. Allowed properties: ['animation', 'opacity', 'transform', 'transition', 'visibility']. [AUTHOR_STYLESHEET_PROBLEM]
+|        -webkit-transform: rotate(180deg);
+|        -o-transition: -o-transform 2s;
+|      }
+|  
+|      /* Invalid: Missing context class .amp-animate */
+|      .box {
+|        -webkit-transform: rotate(180deg);
+|        -o-transition: -o-transform 2s;
+|      }
+|  
+|      /* Valid. */
+|      .amp-animate .box {
+|        -o-transition: -o-transform 2s;
+|      }
+|  
+|      /* Invalid: The only properties that may be transitioned are opacity
+|         and transform. */
+|      .amp-animate .box {
+|        -moz-transition: background-color 2s;
+>>       ^~~~~~~~~
 amp4ads_feature_tests/style-amp-custom.html:112:6 CSS syntax error in tag 'style amp-custom (AMP4ADS)' - the property 'transition' is set to the disallowed value 'background-color'. Allowed values: ['opacity', 'transform']. [AUTHOR_STYLESHEET_PROBLEM]
+|      }
+|  
+|      /* Valid. */
+|      @-moz-keyframes turn {
+|        from {
+|          -webkit-transform: rotate(180deg);
+|        }
+|  
+|        to {
+|          -webkit-transform: rotate(90deg);
+|        }
+|      }
+|  
+|      /* Invalid: only opacity and transform may be transitioned. */
+|      @-o-keyframes slidein {
+|        from {
+|          margin-left:100%;
+>>         ^~~~~~~~~
 amp4ads_feature_tests/style-amp-custom.html:129:8 CSS syntax error in tag 'style amp-custom (AMP4ADS)' - the property 'margin-left' is disallowed within @-o-keyframes. Allowed properties: ['animation-timing-function', 'opacity', 'transform']. [AUTHOR_STYLESHEET_PROBLEM]
+|          width:300%
+>>         ^~~~~~~~~
 amp4ads_feature_tests/style-amp-custom.html:130:8 CSS syntax error in tag 'style amp-custom (AMP4ADS)' - the property 'width' is disallowed within @-o-keyframes. Allowed properties: ['animation-timing-function', 'opacity', 'transform']. [AUTHOR_STYLESHEET_PROBLEM]
+|        }
+|  
+|        to {
+|          margin-left:0%;
+>>         ^~~~~~~~~
 amp4ads_feature_tests/style-amp-custom.html:134:8 CSS syntax error in tag 'style amp-custom (AMP4ADS)' - the property 'margin-left' is disallowed within @-o-keyframes. Allowed properties: ['animation-timing-function', 'opacity', 'transform']. [AUTHOR_STYLESHEET_PROBLEM]
+|          width:100%;
+>>         ^~~~~~~~~
 amp4ads_feature_tests/style-amp-custom.html:135:8 CSS syntax error in tag 'style amp-custom (AMP4ADS)' - the property 'width' is disallowed within @-o-keyframes. Allowed properties: ['animation-timing-function', 'opacity', 'transform']. [AUTHOR_STYLESHEET_PROBLEM]
+|        }
+|      }
+|    </style>
+|  </head>
+|  <body>Hello, world.</body>
+|  </html>

--- a/validator/testdata/feature_tests/ads.out
+++ b/validator/testdata/feature_tests/ads.out
@@ -1,1 +1,1337 @@
 PASS
+|  <!--
+|    Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <title>Ad examples</title>
+|    <link rel="canonical" href="http://nonblocking.io/" >
+|    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+|    <meta name="amp-ad-enable-refresh" content="doubleclick=30">
+|    <meta name="amp-ad-doubleclick-sra">
+|    <style amp-custom>
+|      .broken {
+|        color: red;
+|      }
+|      amp-ad {
+|        border: 1px solid #ccc;
+|        max-width: 500px;
+|      }
+|      .red {
+|        background-color: red;
+|      }
+|      .filterBar {
+|        background: #eee;
+|        padding: 3px;
+|        font-size: 1.2em;
+|      }
+|      select {
+|        border: 1px solid #999;
+|      }
+|      input[type=submit] {
+|        font-size: 14px;
+|        border: 1px solid #999;
+|        border-radius: 3px;
+|        margin-left: 10px;
+|      }
+|      amp-ad[type="revcontent"] {
+|        width: 100%;
+|        max-width: 1280px;
+|        margin: 18px 0;
+|        padding: 0;
+|      }
+|      amp-ad[type="nativo"] {
+|        width: 100%;
+|        max-width: 1280px;
+|        margin: 18px 0;
+|        padding: 0;
+|        height:100px;
+|      }
+|    </style>
+|    <script async custom-element="amp-ad" src="https://cdn.ampproject.org/v0/amp-ad-0.1.js"></script>
+|    <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
+|    <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.1.js"></script>
+|    <script async custom-element="amp-form" src="https://cdn.ampproject.org/v0/amp-form-0.1.js"></script>
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|  <body>
+|    <div class="filterBar">
+|      <form action="ads.amp.html" method="get" target="_top">
+|        <label for="filter">Ad network filter</label>
+|        <select id="filter" name="type">
+|          <option>[Select an ad network]</option>
+|          <!--
+|            When adding new ad network to the list, please
+|            1) verify that the ad slot loads ad. Check DEVELOPMENT.md for how to
+|               run a local server.
+|            2) keep the list in alphabetic order
+|          -->
+|          <option>a8</option>
+|          <option>a9</option>
+|          <option>accesstrade</option>
+|          <option>adblade</option>
+|          <option>adbutler</option>
+|          <option>adfox</option>
+|          <option>adition</option>
+|          <option>adgeneration</option>
+|          <option>adhese</option>
+|          <option>adman</option>
+|          <option>admanmedia</option>
+|          <option>adreactor</option>
+|          <option>adsense</option>
+|          <option>adsnative</option>
+|          <option>adspeed</option>
+|          <option>adspirit</option>
+|          <option>adstir</option>
+|          <option>adtech</option>
+|          <option>adthrive</option>
+|          <option>aduptech</option>
+|          <option>adverline</option>
+|          <option>adverticum</option>
+|          <option>advertserve</option>
+|          <option>affiliateb</option>
+|          <option>amoad</option>
+|          <option>appnexus</option>
+|          <option>atomx</option>
+|          <option>bidtellect</option>
+|          <option>brainy</option>
+|          <option>bringhub</option>
+|          <option>caajainfeed</option>
+|          <option>caprofitx</option>
+|          <option>chargeads</option>
+|          <option>contentad</option>
+|          <option>criteo</option>
+|          <option>csa</option>
+|          <option>custom</option>
+|          <option>eas</option>
+|          <option>distroscale</option>
+|          <option>dotandads</option>
+|          <option>doubleclick</option>
+|          <option>eplanning</option>
+|          <option>ezoic</option>
+|          <option>f1e</option>
+|          <option>f1h</option>
+|          <option>felmat</option>
+|          <option>flite</option>
+|          <option>fluct</option>
+|          <option>fusion</option>
+|          <option>genieessp</option>
+|          <option>gmossp</option>
+|          <option>gumgum</option>
+|          <option>holder</option>
+|          <option>ibillboard</option>
+|          <option>imobile</option>
+|          <option>imedia</option>
+|          <option>industrybrains</option>
+|          <option>inmobi</option>
+|          <option>ix</option>
+|          <option>kiosked</option>
+|          <option>kargo</option>
+|          <option>kixer</option>
+|          <option>ligatus</option>
+|          <option>loka</option>
+|          <option>mads</option>
+|          <option>mantis-display</option>
+|          <option>mediaimpact</option>
+|          <option>medianet</option>
+|          <option>mediavine</option>
+|          <option>meg</option>
+|          <option>microad</option>
+|          <option>mixpo</option>
+|          <option>mywidget</option>
+|          <option>nativo</option>
+|          <option>navegg</option>
+|          <option>nend</option>
+|          <option>netletix</option>
+|          <option>nokta</option>
+|          <option>openadstream</option>
+|          <option>openx</option>
+|          <option>outbrain</option>
+|          <option>plista</option>
+|          <option>polymorphicads</option>
+|          <option>popin</option>
+|          <option>pubmine</option>
+|          <option>pulsepoint</option>
+|          <option>purch</option>
+|          <option>capirs</option>
+|          <option>relap</option>
+|          <option>revcontent</option>
+|          <option>rubicon</option>
+|          <option>sharethrough</option>
+|          <option>sklik</option>
+|          <option>slimcutmedia</option>
+|          <option>smartadserver</option>
+|          <option>smartclip</option>
+|          <option>sortable</option>
+|          <option>sovrn</option>
+|          <option>spotx</option>
+|          <option>sunmedia</option>
+|          <option>swoop</option>
+|          <option>taboola</option>
+|          <option>teads</option>
+|          <option>triplelift</option>
+|          <option>valuecommerce</option>
+|          <option>webediads</option>
+|          <option>weborama</option>
+|          <option>widespace</option>
+|          <option>xlift</option>
+|          <option>yahoo</option>
+|          <option>yahoojp</option>
+|          <option>yandex</option>
+|          <option>yieldbot</option>
+|          <option>yieldone</option>
+|          <option>yieldmo</option>
+|          <option>zedo</option>
+|          <option>zergnet</option>
+|          <option>zucks</option>
+|        </select>
+|        <input type="submit" value="Go">
+|      </form>
+|    </div>
+|  
+|    <h2>A8</h2>
+|    <amp-ad width="300" height="250"
+|        type="a8"
+|        data-aid="170223075073"
+|        data-wid="001"
+|        data-eno="01"
+|        data-mid="s00000016751001031000"
+|        data-mat="2TCGYR-17GNXU-3L92-64Z8X"
+|        data-type="static">
+|    </amp-ad>
+|  
+|    <h2>A9</h2>
+|    <amp-ad width="300" height="250"
+|        type="a9"
+|        data-aax_size="300x250"
+|        data-aax_pubname="test123"
+|        data-aax_src="302">
+|    </amp-ad>
+|  
+|    <h2>AccessTrade</h2>
+|    <amp-ad width="300" height="250"
+|        type="accesstrade"
+|        data-atops="r"
+|        data-atrotid="00000000000008c06y">
+|    </amp-ad>
+|  
+|    <h2>Adblade</h2>
+|    <amp-ad width="300" height="250"
+|        type="adblade"
+|        data-width="300"
+|        data-height="250"
+|        data-cid="19626-3798936394">
+|    </amp-ad>
+|  
+|    <h2>AdButler</h2>
+|    <amp-ad width="300" height="250"
+|        type="adbutler"
+|        data-account="167283"
+|        data-zone="212491">
+|    </amp-ad>
+|  
+|    <h2>ADITION</h2>
+|    <amp-ad width="300" height="250"
+|        type="adition"
+|        data-version="1"
+|        data-wp_id="3470234">
+|    </amp-ad>
+|  
+|    <h2>Ad Generation</h2>
+|    <amp-ad width="320" height="50"
+|        type="adgeneration"
+|        data-id="10722">
+|    </amp-ad>
+|  
+|    <h2>Adhese</h2>
+|    <amp-ad width=300 height=250
+|        type="adhese"
+|        data-location="_sdk_amp_"
+|        data-position=""
+|        data-format="amprectangle"
+|        data-account="demo"
+|        data-request-type="ad">
+|      <div placeholder></div>
+|      <div fallback></div>
+|    </amp-ad>
+|  
+|    <amp-ad width=300 height=250
+|        type="adhese"
+|        data-location="_sdk_amp_"
+|        data-position=""
+|        data-format="amprectangle"
+|        data-account="demo"
+|        data-request-type="ad"
+|        json='{"targeting":{"br": ["sport", "info"],"dt": ["desktop"]}}'>
+|      <div placeholder></div>
+|      <div fallback></div>
+|    </amp-ad>
+|  
+|    <h2 id="adfox">AdFox</h2>
+|    <amp-ad width="248" height="408"
+|        type="adfox"
+|        data-owner-id="208087"
+|        data-adfox-params='{"pt": "b","p1": "bsoji","p2": "feil","pct": "a","pfc": "bbhfo","pfb": "cwrtv"}'>
+|    </amp-ad>
+|  
+|    <h2>Adman</h2>
+|    <amp-ad width="300" height="250"
+|        type="adman"
+|        data-ws="17342"
+|        data-s="300x250"
+|        data-host="talos.adman.gr">
+|    </amp-ad>
+|  
+|    <h2>AdmanMedia</h2>
+|    <amp-ad width="300" height="250"
+|        type="admanmedia"
+|        data-id="8e916419">
+|    </amp-ad>
+|  
+|    <h2>AdReactor</h2>
+|    <amp-ad width="728" height="90"
+|        type="adreactor"
+|        data-pid=790
+|        data-zid=9
+|        data-custom3="No Type">
+|    </amp-ad>
+|  
+|    <h2>AdSense</h2>
+|    <amp-ad width="300" height="250"
+|        type="adsense"
+|        data-ad-client="ca-pub-2005682797531342"
+|        data-ad-slot="7046626912">
+|    </amp-ad>
+|  
+|    <h2>AdsNative</h2>
+|    <amp-ad width="300" height="250"
+|        type="adsnative"
+|        data-anapiid="t8AjW-y8rudFGzKft_YQcBZG1-aGZ5otj5QdsKaP"
+|        data-ancat="IAB1,IAB2"
+|        data-antid="abc"
+|        data-ankv="key:val,key:val2">
+|    </amp-ad>
+|  
+|    <h2>AdSpeed</h2>
+|    <amp-ad width="300" height="250"
+|        type="adspeed"
+|        data-zone="82441"
+|        data-client="3">
+|    <div placeholder></div>
+|    <div fallback></div>
+|    </amp-ad>
+|  
+|    <h2>AdSpirit</h2>
+|    <amp-ad width="300" height="250"
+|        type="adspirit"
+|        data-asm-params="&amp;pid=4"
+|        data-asm-host="help.adspirit.de">
+|    </amp-ad>
+|  
+|    <h2>AdStir 320x50 banner</h2>
+|    <amp-ad width="320" height="50"
+|        type="adstir"
+|        data-app-id="MEDIA-343ded3e"
+|        data-ad-spot="1">
+|    </amp-ad>
+|  
+|    <h2>AdTech (1x1 fake image ad)</h2>
+|    <amp-ad width="300" height="250"
+|        type="adtech"
+|        src="https://adserver.adtechus.com/addyn/3.0/5280.1/2274008/0/-1/ADTECH;size=300x250;key=plumber;alias=careerbear-ros-middle1;loc=300;;target=_blank;grp=27980912;misc=3767074">
+|    </amp-ad>
+|  
+|    <h2>AdThrive 320x50 banner</h2>
+|    <amp-ad width="320" height="50"
+|        type="adthrive"
+|        data-site-id="test"
+|        data-ad-unit="AdThrive_Content_1"
+|        data-sizes="320x50">
+|    </amp-ad>
+|  
+|    <h2>AdThrive 300x250 banner</h2>
+|    <amp-ad width="300" height="250"
+|        type="adthrive"
+|        data-site-id="test"
+|        data-ad-unit="AdThrive_Content_2"
+|        data-sizes="300x250">
+|    </amp-ad>
+|  
+|    <h2>Ad Up Technology</h2>
+|    <amp-ad width="500" height="250"
+|        type="aduptech"
+|        layout="fixed"
+|        data-placementkey="ae7906d535ce47fbb29fc5f45ef910b4"
+|        data-query="reisen;mallorca;spanien"
+|        data-adtest="1">
+|    </amp-ad>
+|  
+|    <h2>Adverline</h2>
+|    <amp-ad width="300" height="250"
+|        type="adverline"
+|        data-id=13625
+|        data-plc=3>
+|    </amp-ad>
+|  
+|    <h2>Adverticum</h2>
+|    <amp-ad width="285" height="350"
+|       type="adverticum"
+|       data-goa3zone="4316734"
+|       data-costumeTargetString="bWFsYWM=">
+|    </amp-ad>
+|  
+|    <h2>AdvertServe</h2>
+|    <amp-ad width="300" height="250"
+|        type="advertserve"
+|        data-client="tester"
+|        data-pid=0
+|        data-zid=68>
+|    </amp-ad>
+|  
+|    <h2>Affiliate-B</h2>
+|    <amp-ad width="300" height="250"
+|        type="affiliateb"
+|        data-afb_a="l44x-y174897c"
+|        data-afb_p="g2m"
+|        data-afb_t="i">
+|    </amp-ad>
+|  
+|    <h2>AMoAd banner</h2>
+|    <amp-ad width="300" height="250"
+|        type="amoad"
+|        data-ad-type="banner"
+|        data-sid="62056d310111552c951d19c06bfa71e16e615e39493eceff667912488bc576a6">
+|    </amp-ad>
+|  
+|    <h2>AMoAd native</h2>
+|    <amp-ad width="320" height="100"
+|        type="amoad"
+|        data-ad-type="native"
+|        data-sid="62056d310111552c951d19c06bfa71e1bc19eea7e94d0a6e73e46a9402dbee47">
+|    </amp-ad>
+|  
+|    <h2>AppNexus with JSON based configuration multi ad</h2>
+|    <amp-ad width="300" height="250"
+|        type="appnexus"
+|        data-target="apn_ad_1"
+|        json='{"pageOpts":{"member": 958}, "adUnits": [{"disablePsa": true, "tagId": 6063968,"sizes": [300,250],"targetId": "apn_ad_1"}, {"tagId": 6063968,"sizes": [728,90],"targetId":"apn_ad_2"}]}'>
+|    </amp-ad>
+|  
+|    <amp-ad width="728" height="90"
+|        type="appnexus"
+|        data-target="apn_ad_2"
+|        json='{"pageOpts":{"member": 958}, "adUnits": [{"disablePsa": true, "tagId": 6063968,"sizes": [300,250],"targetId": "apn_ad_1"}, {"tagId": 6063968,"sizes": [728,90],"targetId":"apn_ad_2"}]}'>
+|    </amp-ad>
+|  
+|    <h2>Atomx</h2>
+|    <amp-ad width="300" height="250"
+|        type="atomx"
+|        data-id="1234">
+|    </amp-ad>
+|  
+|    <h2 id="bidtellect">Bidtellect</h2>
+|    <amp-ad width=320 height=200
+|        type="bidtellect"
+|        data-t="20bc0442-8bec-43f8-9992-08be6e6a3591"
+|        data-pid="925847381"
+|        data-sid="216072">
+|    </amp-ad>
+|  
+|    <h2>brainy</h2>
+|    <amp-ad width="300" height="250"
+|        type="brainy"
+|        data-aid="10"
+|        data-slot-id="3347">
+|    </amp-ad>
+|  
+|    <h2>Bringhub Mini-Storefront</h2>
+|    <amp-embed width="600" height="320"
+|        type="bringhub"
+|        layout="responsive"
+|        heights="(max-width: 270px) 1280px, (max-width:553px) 640px, 338px">
+|    </amp-embed>
+|  
+|    <h2>CA A.J.A. Infeed</h2>
+|    <amp-ad width="320" height="120"
+|        type="caajainfeed"
+|        data-ad-spot="jqeto4eMJqk"
+|        data-test="true">
+|    </amp-ad>
+|  
+|    <h2>CA ProFit-X</h2>
+|    <amp-ad width="320" height="50"
+|        type="caprofitx"
+|        data-tagid="17359">
+|    </amp-ad>
+|  
+|    <h2>Chargeads</h2>
+|    <amp-ad width="320" height="50"
+|        type="chargeads"
+|        src="https://www.chargeplatform.com/ads/?id=1288491435">
+|    </amp-ad>
+|  
+|    <h2>Content.ad Banner 320x50</h2>
+|    <amp-ad width="320" height="50"
+|        type="contentad"
+|        data-id="80a26f7c-277a-4c9a-b541-1ae7304d8b06"
+|        data-d="bm9uYmxvY2tpbmcuaW8="
+|        data-wid="218710"
+|        data-url="nonblocking.io">
+|    </amp-ad>
+|  
+|    <h2>Content.ad Banner 300x250</h2>
+|    <amp-ad width="300" height="250"
+|        type="contentad"
+|        data-id="09a8809f-9e98-4c24-b076-3dc28c8a7f32"
+|        data-d="bm9uYmxvY2tpbmcuaW8="
+|        data-wid="218706"
+|        data-url="nonblocking.io">
+|    </amp-ad>
+|  
+|    <h2>Content.ad Banner 300x250 2x2</h2>
+|    <amp-ad width="300" height="250"
+|        type="contentad"
+|        data-id="7902c314-4cad-466e-9264-ecd333a2c757"
+|        data-d="bm9uYmxvY2tpbmcuaW8="
+|        data-wid="218705"
+|        data-url="nonblocking.io">
+|    </amp-ad>
+|  
+|    <h2>Content.ad Banner 300x600</h2>
+|    <amp-ad width="300" height="600"
+|        type="contentad"
+|        data-id="54115175-cb71-4905-9781-970c868059c1"
+|        data-d="bm9uYmxvY2tpbmcuaW8="
+|        data-wid="218708"
+|        data-url="nonblocking.io">
+|    </amp-ad>
+|  
+|    <h2>Content.ad Banner 300x600 5x2</h2>
+|    <amp-ad width="300" height="600"
+|        type="contentad"
+|        data-id="d5979da1-3686-4b8d-8bbc-9a94eb2d6a76"
+|        data-d="bm9uYmxvY2tpbmcuaW8="
+|        data-wid="218709"
+|        data-url="nonblocking.io">
+|    </amp-ad>
+|  
+|    <h2>Criteo Passback</h2>
+|    <p>Due to ad targeting, the slot might not load ad.</p>
+|  
+|    <amp-ad width="300" height="250"
+|        type="criteo"
+|        data-tagtype="passback"
+|        data-zone="314159">
+|    </amp-ad>
+|  
+|    <h2>Criteo RTA</h2>
+|    <p>Due to ad targeting, the slot might not load ad.</p>
+|  
+|    <amp-ad width="300" height="250"
+|        type="criteo"
+|        data-tagtype="rta"
+|        data-slot="/2729856/iframe_test_new_tag"
+|        data-adserver="DFP"
+|        data-networkid="1976">
+|    </amp-ad>
+|  
+|    <h2>CSA</h2>
+|    <amp-ad width="auto" height="300"
+|        type="csa"
+|        layout="fixed-height"
+|        data-afs-page-options='{"pubId": "partner-pub-9616389000213823", "query": "flowers"}'
+|        data-afs-adblock-options='{"width": "auto", "number": 1}'>
+|    </amp-ad>
+|  
+|    <h2 id="custom">Custom leaderboard</h2>
+|    <amp-ad width="500" height="60"
+|        type="custom"
+|        data-slot="1"
+|        data-url="/examples/custom.ad.example.json">
+|      <template type="amp-mustache" id="amp-template-id-leader">
+|        <a href="{{href}}" target='_blank'>
+|          <amp-img layout='fixed' width="500" height="60" src="{{src}}" data-info="{{info}}"></amp-img>
+|        </a>
+|      </template>
+|    </amp-ad>
+|  
+|    <h2>Custom square</h2>
+|    <amp-ad width="200" height="200"
+|        type="custom"
+|        data-slot="2"
+|        data-url="/examples/custom.ad.example.json">
+|      <template type="amp-mustache">
+|        <a href="{{href}}" target="_blank">
+|          <amp-img layout='fixed' height="200" width="200" src="{{src}}" data-info="{{info}}"></amp-img>
+|        </a>
+|      </template>
+|    </amp-ad>
+|  
+|    <h2>Custom leaderboard with no slot specified</h2>
+|    <amp-ad width="500" height="60"
+|        type="custom"
+|        data-url="/examples/custom.ad.example.single.json">
+|      <template type="amp-mustache" id="amp-template-id-no-slot">
+|        <a href="{{href}}" target="_blank">
+|          <amp-img layout='fixed' height="60" width="500" src="{{src}}" data-info="{{info}}"></amp-img>
+|        </a>
+|      </template>
+|    </amp-ad>
+|  
+|    <h2>Cxense Display</h2>
+|    <amp-ad width="240" height="65"
+|        type="eas"
+|        data-eas-domain="stage.emediate.eu"
+|        data-eas-cu="3255">
+|    </amp-ad>
+|  
+|    <h2>DistroScale</h2>
+|    <amp-ad width="300" height="600"
+|        type="distroscale"
+|        data-pid="1"
+|        data-zid="8710"
+|        layout="responsive">
+|    </amp-ad>
+|  
+|    <h2>DotAndAds masthead</h2>
+|    <amp-ad width="980" height="250"
+|        type="dotandads"
+|        data-cid="11"
+|        data-mpo="ampTest"
+|        data-mpt="amp-amp-all-all"
+|        data-sp='sn-u'>
+|    </amp-ad>
+|  
+|    <h2>DotAndAds 300x250 box</h2>
+|    <amp-ad width="300" height="250"
+|        type="dotandads"
+|        data-sp='300x250-u'
+|        data-cid="11"
+|        data-mpo="ampTest"
+|        data-mpt="amp-amp-all-all">
+|    </amp-ad>
+|  
+|    <h2>Doubleclick</h2>
+|    <amp-ad width="320" height="50"
+|        type="doubleclick"
+|        data-slot="/4119129/mobile_ad_banner">
+|    </amp-ad>
+|  
+|    <h2>Doubleclick with JSON based parameters</h2>
+|    <amp-ad width="320" height="50"
+|        type="doubleclick"
+|        data-slot="/4119129/mobile_ad_banner"
+|        json='{"targeting":{"sport":["rugby","cricket"]},"categoryExclusions":["health"],"tagForChildDirectedTreatment":0}'>
+|    </amp-ad>
+|  
+|    <h2>Doubleclick no ad</h2>
+|    <amp-ad width="300" height="200"
+|        type="doubleclick"
+|        data-slot="/4119129/doesnt-exist">
+|    </amp-ad>
+|  
+|    <h2>Doubleclick with overriden size</h2>
+|    <amp-ad width="420" height="100"
+|        data-override-width="320" data-override-height="50"
+|        type="doubleclick"
+|        data-slot="/4119129/mobile_ad_banner"
+|        class="red">
+|    </amp-ad>
+|  
+|    <h2>Doubleclick challenging ad</h2>
+|    <amp-ad width="414" height="457"
+|        type="doubleclick"
+|        layout="fixed"
+|        data-slot="/35096353/amptesting/badvideoad">
+|    </amp-ad>
+|  
+|    <h2>E-Planning 320x50</h2>
+|    <amp-ad width="320" height="50"
+|        type="eplanning"
+|        layout=responsive
+|        data-epl_si="af2"
+|        data-epl_sv="https://ads.eu.e-planning.net"
+|        data-epl_isv="https://us.img.e-planning.net"
+|        data-epl_sec="AMP_TEST"
+|        data-epl_kvs='{"target1":"food", "target2":"cars"}'
+|        data-epl_e="AMP_TEST">
+|    </amp-ad>
+|  
+|    <h2>Ezoic</h2>
+|    <amp-ad width="300" height="250"
+|        type="ezoic"
+|        data-slot="/1254144/28607874"
+|        json='{"targeting": {"iid15":"1479509","t":"134","d":"1317","t1":"134","pvc":"0","ap":"1144","sap":"1144","a":"|0|","as":"revenue","plat":"1","bra":"mod1","ic":"1","at":"mbf","adr":"400","reft":"tf","ga":"2497208","rid":"99998","pt":"0","al":"2022","compid":"1","tap":"28607874-1479509","br1":"0","br2":"0"}}'>
+|    </amp-ad>
+|  
+|    <h2>FlexOneELEPHANT</h2>
+|    <amp-ad width="300" height="250"
+|        type="f1e"
+|        data-url="https://demo.impact-ad.jp"
+|        data-target="/SITE=AMPSITE/AREA=AMPAREA/AAMSZ=300X250/OENCJP=UTF8" >
+|    </amp-ad>
+|  
+|    <h2>FlexOneHARRIER</h2>
+|    <amp-ad width="300" height="250"
+|        type="f1h"
+|        data-section-id="2267"
+|        data-slot="2843">
+|    </amp-ad>
+|  
+|    <h2>Felmat</h2>
+|    <amp-ad width="300" height="250"
+|        type="felmat"
+|        data-host="felmat.net"
+|        data-fmt="banner"
+|        data-fmk="U12473_n2cJD"
+|        data-fmp="0">
+|    </amp-ad>
+|  
+|    <h2>Flite</h2>
+|    <amp-ad width="320" height="568"
+|        type="flite"
+|        data-guid="aa7bf589-6d51-4194-91f4-d22eef8e3688"
+|        data-mixins="">
+|    </amp-ad>
+|  
+|    <h2>fluct</h2>
+|    <amp-ad width="300" height="250"
+|        type="fluct"
+|        data-g="1000067784"
+|        data-u="1000101409">
+|    </amp-ad>
+|  
+|    <h2>Fusion</h2>
+|    <amp-ad width="600" height="100"
+|        type="fusion"
+|        data-ad-server="bn-01d.adtomafusion.com"
+|        data-media-zone="adtomatest.apica"
+|        data-layout="apicaping"
+|        data-space="apicaAd"
+|        data-parameters="age=99&isMobile&gender=male">
+|    </amp-ad>
+|  
+|    <h2>Geniee SSP</h2>
+|    <amp-ad width="300" height="250"
+|        type="genieessp"
+|        data-vid="3"
+|        data-zid="1077330">
+|    </amp-ad>
+|  
+|    <h2 class="broken">GMOSSP 320x50 banner</h2>
+|    <amp-ad width="320" height="50"
+|        type="gmossp"
+|        data-id="10014">
+|    </amp-ad>
+|  
+|    <h2>GumGum 300x100 banner</h2>
+|    <amp-ad width=300 height=100
+|        type="gumgum"
+|        data-zone="ggumtest"
+|        data-slot="3883">
+|    </amp-ad>
+|  
+|    <h2>Holder 300x250 banner</h2>
+|    <amp-ad width="300" height="250"
+|        type="holder"
+|        data-block="7163">
+|    </amp-ad>
+|  
+|    <h2>iBillboard 300x250 banner</h2>
+|    <amp-ad width="300" height="250"
+|        type="ibillboard"
+|        src="https://go.eu.bbelements.com/please/code?j-21414.1.5.6.0.0._blank">
+|    </amp-ad>
+|  
+|    <h2>I-Mobile 320x50 banner</h2>
+|    <amp-ad width="320" height="50"
+|        type="imobile"
+|        data-pid="1847"
+|        data-adtype="banner"
+|        data-asid="813689">
+|    </amp-ad>
+|  
+|    <h2>Imedia</h2>
+|    <amp-ad width="300" height="250"
+|        type="imedia"
+|        data-id="p1"
+|        data-positions='[{"id":"p1", "zoneId":"seznam.novinky.ikona2"}, {"id":"p2", "zoneId":"seznam.novinky.ikona"}]'>
+|    </amp-ad>
+|  
+|    <amp-ad width="300" height="100"
+|        type="imedia"
+|        data-id="p2"
+|        data-positions='[{"id":"p1", "zoneId":"seznam.novinky.ikona2"}, {"id":"p2", "zoneId":"seznam.novinky.ikona"}]'>
+|    </amp-ad>
+|  
+|    <h2>Industrybrains</h2>
+|    <amp-ad width="300" height="250"
+|        type="industrybrains"
+|        data-width="300"
+|        data-height="250"
+|        data-cid="19626-3798936394">
+|    </amp-ad>
+|  
+|    <h2>InMobi</h2>
+|    <amp-ad width="320" height="50"
+|        type="inmobi"
+|        data-siteid="a0078c4ae5a54199a8689d49f3b46d4b"
+|        data-slotid="15">
+|    </amp-ad>
+|  
+|    <h2>Index Exchange Header Tag</h2>
+|    <amp-ad width="300" height="250"
+|        type="ix"
+|        data-ix-id="1"
+|        data-slot="/62650033/AMP_Example_Ad_Unit">
+|    </amp-ad>
+|  
+|  
+|    <h2>Kargo</h2>
+|    <amp-ad width="300" height="250"
+|        type="kargo"
+|        data-site="_tt9gZ3qxCc2RCg6CADfLAAFR"
+|        data-slot="_vypM8bkVCf"
+|        data-options='{"targetParams":{"AD_ID":"test-middle","ad_id":"test-middle"}}'>
+|    </amp-ad>
+|  
+|    <h2>Kiosked</h2>
+|    <amp-ad width="300" height="250"
+|        type="kiosked"
+|        data-scriptid="91">
+|    </amp-ad>
+|  
+|    <h2>Kixer</h2>
+|    <amp-ad width="300" height="250"
+|        type="kixer"
+|        data-adslot="6812">
+|    </amp-ad>
+|  
+|    <h2>Ligatus</h2>
+|    <amp-ad width="300" height="250"
+|        type="ligatus"
+|        src="https://a-ssl.ligatus.com/?ids=88443&t=js&s=1&bc=2">
+|    </amp-ad>
+|  
+|    <h2>LOKA</h2>
+|    <amp-ad width="300" height="250"
+|        type="loka"
+|        data-unit-params='{"unit":"mvbanner","id":"YdzhBxTvKwZlLeeQ"}'>
+|    </amp-ad>
+|  
+|    <h2>MADS</h2>
+|    <amp-ad width="320" height="50"
+|        type="mads"
+|        data-adrequest='{"pid":"6252122059"}'>
+|    </amp-ad>
+|  
+|    <h2>MANTIS</h2>
+|    <amp-ad width="300" height="250"
+|        type="mantis-display"
+|        data-property = "demo"
+|        data-zone="medium-rectangle">
+|    </amp-ad>
+|  
+|    <amp-embed width="100" height="283"
+|        type="mantis-recommend"
+|        layout=responsive
+|        heights="(min-width:1907px) 56%, (min-width:1100px) 64%, (min-width:780px) 75%, (min-width:480px) 105%, 200%"
+|        data-property="demo">
+|    </amp-embed>
+|  
+|    <h2>Media Impact</h2>
+|    <amp-ad width="320" height="250"
+|        type="mediaimpact"
+|        data-site="67767"
+|        data-page="amp"
+|        data-format="4459"
+|        data-target=""
+|        data-slot="4459">
+|    </amp-ad>
+|  
+|    <h2>Media.Net Header Bidder Tag</h2>
+|    <amp-ad width="300" height="250"
+|        type="medianet"
+|        data-tagtype="headerbidder"
+|        data-cid="8CU852274"
+|        data-slot="/45361917/AMP_Header_Bidder"
+|        json='{"targeting":{"mnetAmpTest":"1","pos":"mnetSlot1"}}'>
+|    </amp-ad>
+|  
+|    <h2>Media.Net Contextual Monetization Tag</h2>
+|    <amp-ad width="300" height="250"
+|        type="medianet"
+|        data-tagtype="cm"
+|        data-cid="8CUS8O7EX"
+|        data-crid="112682482">
+|    </amp-ad>
+|  
+|    <h2>Mediavine</h2>
+|    <amp-ad width="300" height="250"
+|        type="mediavine"
+|        data-site="amp-project"
+|        data-sizes="300x250,320x50">
+|        <div placeholder></div>
+|        <div fallback></div>
+|    </amp-ad>
+|  
+|    <h2>Meg</h2>
+|    <amp-ad width="320" height="250"
+|        type="meg"
+|        data-code="6rc0ERhN75">
+|    </amp-ad>
+|  
+|    <h2>MicroAd 320x50 banner</h2>
+|    <amp-ad width="320" height="50"
+|        type="microad"
+|        data-spot="b4bf837c5ddd69758d5ac924d04cf502"
+|        data-url="${COMPASS_EXT_URL}"
+|        data-referrer="${COMPASS_EXT_REF}"
+|        data-ifa="${COMPASS_EXT_IFA}"
+|        data-appid="${COMPASS_EXT_APPID}"
+|        data-geo="${COMPASS_EXT_GEO}">
+|    </amp-ad>
+|  
+|    <h2>Mixpo</h2>
+|    <amp-ad width="300" height="250"
+|        type = "mixpo"
+|        data-guid = "b0caf856-fd92-4adb-aaec-e91948c9ffc8"
+|        data-subdomain = "www">
+|    </amp-ad>
+|  
+|    <h2>myWidget</h2>
+|    <amp-embed width="300" height="250"
+|        type="mywidget"
+|        data-cid="ed1538fc077cfeae6ea558f6e7404541">
+|    </amp-embed>
+|  
+|    <h2>Nativo</h2>
+|    <amp-ad width="350" height="150"
+|        type="nativo"
+|        layout="responsive"
+|        data-premium
+|        data-request-url="http://localhost:9876">
+|    </amp-ad>
+|  
+|    <h2>Navegg</h2>
+|    <div>It is common to see a no-fill ad in this example.</div>
+|    <amp-ad width=320 height=50
+|        type="navegg"
+|        data-acc="10"
+|        data-slot="/4119129/mobile_ad_banner"
+|        json='{"targeting":{"sport":["rugby","cricket"]}}'>
+|    </amp-ad>
+|  
+|    <h2>Nend</h2>
+|    <amp-ad width="320" height="50"
+|        type="nend"
+|        data-nend_params='{"media":82,"site":58536,"spot":127513,"type":1,"oriented":1}'>
+|    </amp-ad>
+|  
+|    <h2>NETLETIX</h2>
+|    <amp-ad width='300' height='250'
+|        type='netletix'
+|        data-nxkey='b5f0c5d4-c2b8-4989-a7b9-130ad4417102'
+|        data-nxunit='/60343726/netzathleten_.de'
+|        data-nxwidth='300'
+|        data-nxheight='250'>
+|    </amp-ad>
+|  
+|    <h2>Nokta</h2>
+|    <amp-ad width="300" height="250"
+|        type="nokta"
+|        data-category="izlesene_anasayfa"
+|        data-site="izlesene:anasayfa"
+|        data-zone="152541">
+|    </amp-ad>
+|  
+|    <h2>Open AdStream single ad</h2>
+|    <amp-ad width="300" height="250"
+|        type="openadstream"
+|        data-adhost="oasc-training7.247realmedia.com"
+|        data-sitepage="dx_tag_pvt_site"
+|        data-pos="x04"
+|        data-query="keyword=keyvalue&key2=value2" >
+|    </amp-ad>
+|  
+|    <h2>OpenX</h2>
+|    <amp-ad width="728" height="90"
+|        type="openx"
+|        data-auid="538289845"
+|        data-host="sademo-d.openx.net"
+|        data-nc="90577858-BidderTest">
+|    </amp-ad>
+|    <div>
+|      <a href="openx.amp.html">See all OpenX examples</a>
+|    </div>
+|  
+|    <h2>Outbrain widget</h2>
+|    <amp-embed width="100" height="100"
+|        type="outbrain"
+|        layout="responsive"
+|        data-widgetIds="SB_14,SB_13"
+|        data-htmlURL="http%3A%2F%2Fedition.cnn.com%2F2015%2F11%2F08%2Fmiddleeast%2Frussian-plane-crash-egypt-sinai%2Findex.html"
+|        data-referrer="http%3A%2F%2Fedition.cnn.com"
+|        data-ampURL="http%3A%2F%2Famp.cnn.com%2Fpage.html"
+|        data-styleFile="http://localhost/style.css"
+|        data-testMode="true">
+|    </amp-embed>
+|  
+|    <h2>Plista responsive widget</h2>
+|    <amp-embed width="300" height="300"
+|        type="plista"
+|        layout=responsive
+|        data-countrycode="de"
+|        data-publickey="e6a75b42216ffc96b7ea7ad0c94d64946aedaac4"
+|        data-widgetname="iAMP_2"
+|        data-geo="de"
+|        data-urlprefix=""
+|        data-categories="politik">
+|    </amp-embed>
+|  
+|    <h2>polymorphicAds</h2>
+|    <amp-ad width=320 height=50
+|        type="polymorphicads"
+|        data-adunit="7c0b3ae742beccf94f7726ea832277a2"
+|        data-params='{"testMode": "true"}'>
+|    </amp-ad>
+|  
+|    <h2>popIn native ad</h2>
+|    <amp-ad width="300" height="568"
+|        type="popin"
+|        layout=responsive
+|        heights="(min-width:1907px) 39%, (min-width:1200px) 46%, (min-width:780px) 64%, (min-width:480px) 98%, (min-width:460px) 167%, 196%"
+|        data-mediaid="popin_amp">
+|    </amp-ad>
+|  
+|    <h2>Pubmine 300x250</h2>
+|    <amp-ad width="300" height="250"
+|        type="pubmine"
+|        data-adsafe="1"
+|        data-section="1"
+|        data-siteid="37790885"
+|        data-wordads="1">
+|    </amp-ad>
+|  
+|    <h2 class="broken">PulsePoint Header Bidding 300x250</h2>
+|    <amp-ad width="300" height="250"
+|        type="pulsepoint"
+|        data-pid="521732"
+|        data-tagid="76835"
+|        data-tagtype="hb"
+|        data-timeout="1000"
+|        data-slot="/1066621/ExchangeTech_Prebid_AdUnit">
+|    </amp-ad>
+|  
+|    <h2>PulsePoint 300x250</h2>
+|    <amp-ad width="300" height="250"
+|        type="pulsepoint"
+|        data-pid="512379"
+|        data-tagid="472988">
+|    </amp-ad>
+|  
+|    <h2>Purch 300x250</h2>
+|    <amp-ad width="300" height="250"
+|        type="purch"
+|        data-pid="2882"
+|        data-divid="rightcol_top">
+|    </amp-ad>
+|  
+|    <h2>Rambler&Co</h2>
+|    <amp-ad width="500" height="250"
+|        type="capirs"
+|        layout="responsive"
+|        data-begun-auto-pad="434906118"
+|        data-begun-block-id="434908944"
+|        data-custom-css="div[id^=begun_block] iframe{margin:0 auto;}"
+|        json='{"params":{"p1":"bvpkq","p2":"y","pct":"a"}}'>
+|    </amp-ad>
+|  
+|    <h2>Relap</h2>
+|    <amp-ad width="auto" height="750"
+|        type="relap"
+|        layout="fixed-height"
+|        data-token="D3UMgQWBqleq1tPW"
+|        data-url="http://bigpicture.ru"
+|        data-anchorid="i0xMMY1MoliiZWVl">
+|    </amp-ad>
+|  
+|    <h2>Revcontent Responsive Tag</h2>
+|    <amp-ad width="320" height="240"
+|        type="revcontent"
+|        layout="responsive"
+|        heights="(max-width: 320px) 933px,
+|          (max-width: 360px) 1087px,
+|          (max-width: 375px) 1138px,
+|          (max-width: 412px) 1189px,
+|          (max-width: 414px) 1072px,
+|          (max-width: 568px) 1151px,
+|          (max-width: 640px) 1128px,
+|          (max-width: 667px) 1151px,
+|          (max-width: 732px) 1211px,
+|          (max-width: 736px) 1151px,
+|          (max-width: 768px) 633px,
+|          (max-width: 1024px) 711px,
+|          86vw"
+|        data-wrapper="rcjsload_2ff711"
+|        data-id="203">
+|    </amp-ad>
+|  
+|    <h2>Rubicon Project Smart Tag</h2>
+|    <amp-ad width="320" height="50"
+|        type="rubicon"
+|        data-method="smartTag"
+|        data-account="14062"
+|        data-site="70608"
+|        data-zone="335918"
+|        data-size="43"
+|        data-kw="amp-test, test"
+|        json='{"visitor":{"age":"18-24","gender":"male"},"inventory":{"section":"amp"}}'>
+|    </amp-ad>
+|  
+|    <h2>Rubicon Project FastLane Single Slot</h2>
+|    <amp-ad width="320" height="50"
+|        type="rubicon"
+|        data-slot="/5300653/amp_test"
+|        data-method="fastLane"
+|        data-account="14062"
+|        data-pos="atf"
+|        data-kw="amp-test"
+|        json='{"targeting":{"kw":"amp-test","age":"18-24","gender":"male","section":"amp"},"visitor":{"age":"18-24","gender":"male"},"inventory":{"section":"amp"}}'>
+|    </amp-ad>
+|  
+|    <h2>Sharethrough</h2>
+|    <amp-ad width="300" height="150"
+|        type="sharethrough"
+|        layout="responsive"
+|        data-pkey="c0fa8367">
+|    </amp-ad>
+|  
+|    <h2>Sklik</h2>
+|    <amp-ad width="970" height="310"
+|        type="sklik"
+|        json='{"zoneId":0, "w": 970, "h": 310}'>
+|    </amp-ad>
+|  
+|    <h2>SlimCut Media</h2>
+|    <amp-ad width="400" height="225"
+|        type="slimcutmedia"
+|        data-pid="amp-3"
+|        data-ffc="SCMPROMO">
+|    </amp-ad>
+|  
+|    <h2>SmartAdServer ad</h2>
+|    <amp-ad width="320" height="50"
+|        type="smartadserver"
+|        data-site="94612"
+|        data-page="629154"
+|        data-format="38952"
+|        data-target="foo=bar">
+|    </amp-ad>
+|  
+|    <h2>smartclip</h2>
+|    <amp-ad width="400" height="225"
+|        type="smartclip"
+|        data-plc="84555"
+|        data-sz="400x320">
+|    </amp-ad>
+|  
+|    <h2>Sortable ad</h2>
+|    <amp-ad width="300" height="250"
+|        type="sortable"
+|        data-name="medrec"
+|        data-site="ampproject.org">
+|    </amp-ad>
+|  
+|    <h2>SOVRN</h2>
+|    <amp-ad width="300" height="250"
+|        type="sovrn"
+|        data-width="300"
+|        data-height="600"
+|        data-u="sduggan"
+|        data-iid="informerIDgoeshere"
+|        data-aid="affiliateIDgoeshere"
+|        data-testFlag="true"
+|        data-z="393900"><!-- this ID is only whitelisted for localhost:8000 and http://amphtml-nightly.herokuapp.com-->
+|    </amp-ad>
+|  
+|    <h2>SpotX</h2>
+|    <amp-ad width="300" height="250"
+|        type="spotx"
+|        data-spotx_channel_id="85394"
+|        data-spotx_autoplay="1">
+|    </amp-ad>
+|  
+|    <h2>SunMedia</h2>
+|    <amp-ad width="300" height="1"
+|        type="sunmedia"
+|        layout="responsive"
+|        data-cskp="1"
+|        data-cid="sunmedia_test"
+|        data-crst="1">
+|    </amp-ad>
+|  
+|    <h2>Swoop</h2>
+|    <amp-ad width=250 height=35
+|        type="swoop"
+|        data-layout="auto"
+|        data-publisher="SW-11122234-1AMP"
+|        data-placement="page/inline"
+|        data-slot="amp/test">
+|    </amp-ad>
+|  
+|    <h2>Taboola responsive widget</h2>
+|    <amp-embed width="100" height="283"
+|        type="taboola"
+|        layout="responsive"
+|        heights="(min-width:1907px) 39%, (min-width:1200px) 46%, (min-width:780px) 64%, (min-width:480px) 98%, (min-width:460px) 167%, 196%"
+|        data-publisher="amp-demo"
+|        data-mode="thumbnails-a"
+|        data-placement="Ads Example"
+|        data-article="auto">
+|    </amp-embed>
+|  
+|    <h2>Teads</h2>
+|    <amp-ad width="300" height="220"
+|        type="teads"
+|        data-pid="42266"
+|        layout="responsive">
+|    </amp-ad>
+|  
+|    <h2>TripleLift</h2>
+|    <amp-ad width="297" height="410"
+|        type="triplelift"
+|        layout="responsive"
+|        src="https://ib.3lift.com/dtj/amptest_main_feed/335430">
+|    </amp-ad>
+|  
+|    <h2>Weborama</h2>
+|    <amp-ad width="300" height="250"
+|        type="weborama-display"
+|        data-wbo_account_id=51
+|        data-wbo_tracking_element_id=137
+|        data-wbo_fullhost="certification.solution.weborama.fr"
+|        data-wbo_random="[RANDOM]"
+|        data-wbo_publisherclick="[PUBLISHER_TRACKING_URL]">
+|    </amp-ad>
+|  
+|    <h2>Widespace Panorama Ad</h2>
+|    <amp-ad width="300" height="50"
+|        type="widespace"
+|        data-sid="93f1a996-52f5-46b4-8dc8-ccd8886a8fbf"
+|        layout="responsive">
+|    </amp-ad>
+|  
+|    <h2>Widespace Takeover Ad</h2>
+|    <amp-ad width="300" height="300"
+|        type="widespace"
+|        data-sid="fc5a6f59-d45e-4cf1-acac-67bf5ab4862a"
+|        layout="responsive">
+|    </amp-ad>
+|  
+|    <h2>Xlift native ad</h2>
+|    <amp-ad width="300" height="300"
+|        type="xlift"
+|        data-mediaid="mamastar">
+|    </amp-ad>
+|  
+|    <h2>Yahoo Display</h2>
+|    <amp-ad width="316" height="264"
+|        type="yahoo"
+|        data-sid="954014446"
+|        data-site="news"
+|        data-sa='{"LREC":"300x250","secure":"true","content":"no_expandable;"}'>
+|    </amp-ad>
+|  
+|    <h2>YahooJP YDN</h2>
+|    <amp-ad width="300" height="250"
+|        type="yahoojp"
+|        data-yadsid="79712_113431">
+|    </amp-ad>
+|  
+|    <h2 id="yandex">Yandex</h2>
+|    <amp-ad width="240" height="400"
+|        type="yandex"
+|        data-block-id="R-I-106712-3">
+|    </amp-ad>
+|  
+|    <h2>Yieldbot 300x250</h2>
+|    <amp-ad width="300" height="250"
+|        type="yieldbot"
+|        data-psn="1234"
+|        data-yb-slot="medrec"
+|        data-slot="/2476204/medium-rectangle"
+|        json='{"targeting":{"category":["food","lifestyle"]},"categoryExclusions":["health"]}'>
+|    </amp-ad>
+|  
+|    <h2>YIELD ONE</h2>
+|    <amp-ad width="320" height="50"
+|        type="yieldone"
+|        data-pubid="0001"
+|        data-pid="032478_4">
+|    </amp-ad>
+|  
+|    <h2>Yieldmo</h2>
+|    <amp-ad width="300" height="168"
+|        type="yieldmo"
+|        data-ymid="1349317029731662884">
+|    </amp-ad>
+|  
+|    <h2>ValueCommerce</h2>
+|    <amp-ad width="300" height="250"
+|        type="valuecommerce"
+|        data-sid="3008"
+|        data-pid="884466614">
+|    </amp-ad>
+|  
+|    <h2>Webediads</h2>
+|    <div>It's a private ad network with strict ad targeting, hence very common to see a no-fill.</div>
+|    <amp-ad width="300" height="250"
+|        type="webediads"
+|        data-site="site_test"
+|        data-page="amp"
+|        data-position="middle"
+|        data-query="amptest=1">
+|    </amp-ad>
+|  
+|    <h2>ZEDO</h2>
+|    <amp-ad width="300" height="250"
+|        type="zedo"
+|        data-super-id="364489"
+|        data-network="2500"
+|        data-placement-id="364489_1"
+|        data-channel="727"
+|        data-publisher="0"
+|        data-dim="9">
+|    </amp-ad>
+|  
+|    <h2>ZergNet</h2>
+|    <amp-embed width="780" height="100"
+|        type="zergnet"
+|        heights="(max-width:645px) 100%, (max-width:845px) 31%, 23%"
+|        layout="responsive"
+|        data-zergid="42658">
+|    </amp-embed>
+|  
+|    <h2>Zucks</h2>
+|    <amp-ad width="320" height="50"
+|        type="zucks"
+|        data-frame-id="_bda46cf5ac">
+|    </amp-ad>
+|  </body>
+|  </html>

--- a/validator/testdata/feature_tests/amp_gist.out
+++ b/validator/testdata/feature_tests/amp_gist.out
@@ -1,1 +1,25 @@
 PASS
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <title>amp-gist example</title>
+|    <link rel="canonical" href="amps.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <style amp-custom>
+|      amp-gist {
+|        color: red;
+|      }
+|    </style>
+|    <script async custom-element="amp-gist" src="https://cdn.ampproject.org/v0/amp-gist-0.1.js"></script>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|  <body>
+|    <amp-gist
+|       data-gistid="a19e811dcd7df10c4da0931641538497"
+|       layout="fixed-height"
+|       height="1613">
+|    </amp-gist>
+|  </body>
+|  </html>

--- a/validator/testdata/feature_tests/amp_identification_missing.out
+++ b/validator/testdata/feature_tests/amp_identification_missing.out
@@ -1,2 +1,36 @@
 FAIL
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    The only thing that's wrong with this AMP doc is that it is not identifying
+|    itself as AMP.
+|  -->
+|  <!doctype html>
+|  <html>
+>> ^~~~~~~~~
 feature_tests/amp_identification_missing.html:22:0 The mandatory attribute '⚡' is missing in tag 'html ⚡ for top-level html'. (see https://www.ampproject.org/docs/reference/spec#required-markup) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|  <body>
+|  Hello, world.
+|  </body>
+|  </html>

--- a/validator/testdata/feature_tests/amp_layouts.out
+++ b/validator/testdata/feature_tests/amp_layouts.out
@@ -1,12 +1,179 @@
 FAIL
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    This is a (partial) transcription from test/functional/test-layout.js.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|  <body>
+|    <!-- valid: layout=nodisplay -->
+|    <amp-img layout="nodisplay" src="itshappening.gif"></amp-img>
+|  
+|    <!-- valid: layout=fixed -->
+|    <amp-img layout="fixed" width="100" height="200"
+|             src="itshappening.gif"></amp-img>
+|  
+|    <!-- valid: layout=fixed default width/height -->
+|    <amp-img width="100" height="200" src="itshappening.gif"></amp-img>
+|  
+|    <!-- invalid: layout=fixed - requires width/height -->
+|    <amp-img layout="fixed"  src="itshappening.gif"></amp-img>
+>>   ^~~~~~~~~
 feature_tests/amp_layouts.html:41:2 The mandatory attribute 'height' is missing in tag 'amp-img'. (see https://www.ampproject.org/docs/reference/components/amp-img) [AMP_LAYOUT_PROBLEM]
+|  
+|    <!-- valid: layout=fixed-height -->
+|    <amp-img layout="fixed-height" height="200"  src="itshappening.gif"></amp-img>
+|  
+|    <!-- valid: layout=fixed-height, with width=auto -->
+|    <amp-img layout="fixed-height" height="200" width="auto"
+|             src="itshappening.gif"></amp-img>
+|  
+|    <!-- invalid: layout=fixed-height, prohibit width!=auto -->
+|    <amp-img layout="fixed-height" height="200" width="300"
+>>   ^~~~~~~~~
 feature_tests/amp_layouts.html:51:2 Invalid value '300' for attribute 'width' in tag 'amp-img' - for layout 'FIXED_HEIGHT', set the attribute 'width' to value 'auto'. (see https://www.ampproject.org/docs/reference/components/amp-img) [AMP_LAYOUT_PROBLEM]
+|             src="itshappening.gif"></amp-img>
+|  
+|    <!-- valid: layout=fixed-height - default with height -->
+|    <amp-img height="200" src="itshappening.gif"></amp-img>
+|  
+|    <!-- valid: layout=fixed-height - default with height and width=auto -->
+|    <amp-img height="200" width="auto" src="itshappening.gif"></amp-img>
+|  
+|    <!-- invalid: layout=fixed-height - requires height -->
+|    <amp-img layout="fixed-height" src="itshappening.gif"></amp-img>
+>>   ^~~~~~~~~
 feature_tests/amp_layouts.html:61:2 The mandatory attribute 'height' is missing in tag 'amp-img'. (see https://www.ampproject.org/docs/reference/components/amp-img) [AMP_LAYOUT_PROBLEM]
+|  
+|    <!-- valid: layout=responsive -->
+|    <amp-img layout="responsive" width="100" height="200"
+|             src="itshappening.gif"></amp-img>
+|  
+|    <!-- valid: layout=responsive with sizes -->
+|    <amp-img layout="responsive" width="100" height="200" sizes="50vw"
+|             src="itshappening.gif"></amp-img>
+|  
+|    <!-- valid: layout=fill -->
+|    <amp-img layout="fill" src="itshappening.gif"></amp-img>
+|  
+|    <!-- invalid: layout=fill with height=auto; height=auto is only allowed
+|         for flex-item -->
+|    <amp-img layout="fill" width="50" height="auto"></amp-img>
+>>   ^~~~~~~~~
 feature_tests/amp_layouts.html:76:2 The attribute 'height' in tag 'amp-img' is set to the invalid value 'auto'. (see https://www.ampproject.org/docs/reference/components/amp-img) [AMP_LAYOUT_PROBLEM]
+|  
+|    <!-- valid: layout=flex-item -->
+|    <amp-img layout="flex-item" src="itshappening.gif"></amp-img>
+|    <!-- valid: layout=flex-item with width="auto" -->
+|    <amp-img layout="flex-item" width="auto" height="50"
+|             src="itshappening.gif"></amp-img>
+|    <!-- valid: layout=flex-item with height=auto -->
+|    <amp-img layout="flex-item" width="50" height="auto"
+|             src="itshappening.gif"></amp-img>
+|    <!-- valid: layout=flex-item with width and height -->
+|    <amp-img layout="flex-item" width="50" height="50"
+|             src="itshappening.gif"></amp-img>
+|  
+|    <!-- invalid: layout=container
+|         Note that this would be valid if amp-img allowed container.
+|         It doesn't and there is no other element that does.
+|         TODO(johannes): Long run we should get rid of container or use it.
+|         https://github.com/ampproject/amphtml/issues/1109
+|      -->
+|    <amp-img layout="container" src="itshappening.gif"></amp-img>
+>>   ^~~~~~~~~
 feature_tests/amp_layouts.html:96:2 The specified layout 'CONTAINER' is not supported by tag 'amp-img'. (see https://www.ampproject.org/docs/reference/components/amp-img) [AMP_LAYOUT_PROBLEM]
+|  
+|    <!-- invalid: layout=unknown -->
+|    <amp-img layout="unknown" src="itshappening.gif"></amp-img>
+>>   ^~~~~~~~~
 feature_tests/amp_layouts.html:99:2 The attribute 'layout' in tag 'amp-img' is set to the invalid value 'unknown'. (see https://www.ampproject.org/docs/reference/components/amp-img) [AMP_LAYOUT_PROBLEM]
+|  
+|    <!-- valid: should configure natural dimensions; default layout -->
+|    <amp-pixel src="https://www.example.com/make-my-visit-count"></amp-pixel>
+|  
+|    <!-- valid: should configure natural dimensions; default layout;
+|         with width -->
+|    <amp-pixel src="https://www.example.com/make-my-visit-count" width="11">
+|    </amp-pixel>
+|  
+|    <!-- valid: should configure natural dimensions; default layout;
+|         with height -->
+|    <amp-pixel src="https://www.example.com/make-my-visit-count" height="11">
+|    </amp-pixel>
+|  
+|    <!-- valid: should configure natural dimensions; layout=fixed -->
+|    <amp-pixel src="https://www.example.com/make-my-visit-count" layout="fixed">
+|    </amp-pixel>
+|  
+|    <!-- valid: should configure natural dimensions; layout=fixed -->
+|    <amp-pixel src="https://www.example.com/make-my-visit-count"
+|               layout="fixed">
+|    </amp-pixel>
+|  
+|    <!-- valid: width and hight set with valid css lengths -->
+|    <amp-pixel src="https://www.example.com/make-my-visit-count"
+|               width="1px" height="1px"></amp-pixel>
+|  
+|    <!-- invalid: width=auto won't work because amp-pixel doesn't
+|         support fixed-height layout. -->
+|    <amp-pixel src="https://www.example.com/make-my-visit-count"
+>>   ^~~~~~~~~
 feature_tests/amp_layouts.html:129:2 The implied layout 'FIXED_HEIGHT' is not supported by tag 'amp-pixel'. (see https://www.ampproject.org/docs/reference/components/amp-pixel) [AMP_LAYOUT_PROBLEM]
+|               width="auto" height="1px"></amp-pixel>
+|  
+|    <!-- invalid: width=X. -->
+|    <amp-pixel src="https://www.example.com/make-my-visit-count"
+>>   ^~~~~~~~~
 feature_tests/amp_layouts.html:133:2 The attribute 'width' in tag 'amp-pixel' is set to the invalid value 'X'. (see https://www.ampproject.org/docs/reference/components/amp-pixel) [AMP_LAYOUT_PROBLEM]
+|               width="X" height="1px"></amp-pixel>
+|  
+|    <!-- invalid: height=X. -->
+|    <amp-pixel src="https://www.example.com/make-my-visit-count"
+>>   ^~~~~~~~~
 feature_tests/amp_layouts.html:137:2 The attribute 'height' in tag 'amp-pixel' is set to the invalid value 'X'. (see https://www.ampproject.org/docs/reference/components/amp-pixel) [AMP_LAYOUT_PROBLEM]
+|               height="X" width="1px"></amp-pixel>
+|  
+|    <!-- valid responsive layout with heights -->
+|    <amp-img src="https://lh3.googleusercontent.com/5rcQ32ml8E5ONp9f9-Rf78IofLb9QjS5_0mqsY1zEFc=w400-h300-no-n" width=400 height=300 layout=responsive
+|             heights="(min-width:760px)  33%, (min-width:500px) 75%, 125%" ></amp-img>
+|  
+|    <!-- valid implied responsive layout with heights -->
+|    <amp-img src="https://lh3.googleusercontent.com/5rcQ32ml8E5ONp9f9-Rf78IofLb9QjS5_0mqsY1zEFc=w400-h300-no-n" width=400 height=300
+|             heights="(min-width:760px)  33%, (min-width:500px) 75%, 125%" ></amp-img>
+|  
+|    <!-- invalid: can't have heights with specified layout fixed -->
+|    <amp-img src="https://lh3.googleusercontent.com/5rcQ32ml8E5ONp9f9-Rf78IofLb9QjS5_0mqsY1zEFc=w400-h300-no-n" width=400 height=300 layout="fixed"
+>>   ^~~~~~~~~
 feature_tests/amp_layouts.html:149:2 The attribute 'heights' in tag 'amp-img' is disallowed by specified layout 'FIXED'. (see https://www.ampproject.org/docs/reference/components/amp-img) [AMP_LAYOUT_PROBLEM]
+|             heights="(min-width:760px)  33%, (min-width:500px) 75%, 125%" ></amp-img>
+|  
+|    <!-- invalid: can't have heights with implied layout fixed_height -->
+|    <amp-img src="https://lh3.googleusercontent.com/5rcQ32ml8E5ONp9f9-Rf78IofLb9QjS5_0mqsY1zEFc=w400-h300-no-n" height=300
+>>   ^~~~~~~~~
 feature_tests/amp_layouts.html:153:2 The attribute 'heights' in tag 'amp-img' is disallowed by implied layout 'FIXED_HEIGHT'. (see https://www.ampproject.org/docs/reference/components/amp-img) [AMP_LAYOUT_PROBLEM]
+|             heights="(min-width:760px)  33%, (min-width:500px) 75%, 125%" ></amp-img>
+|  </body>
+|  </html>

--- a/validator/testdata/feature_tests/amp_meta_tags.out
+++ b/validator/testdata/feature_tests/amp_meta_tags.out
@@ -1,2 +1,47 @@
 FAIL
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    This tests various meta tags related to AMP.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html" />
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  
+|    <!-- Allowed -->
+|    <meta name=amp-experiment-token content="...">
+|    <meta name=amp-experiments-opt-in content="...">
+|    <meta name=amp-3p-iframe-src content="https://example.com/">
+|    <meta name=amp-link-variable-allowed-origin content="...">
+|    <meta name=amp-google-client-id-api content="...">
+|  
+|    <!-- Test that the rule is not amp-* so that these remain reserved in
+|         AMP documents. This should produce an error. -->
+|    <meta name=amp-tag-does-not-exist content="...">
+>>   ^~~~~~~~~
 feature_tests/amp_meta_tags.html:38:2 The attribute 'name' in tag 'meta name= and content=' is set to the invalid value 'amp-tag-does-not-exist'. [DISALLOWED_HTML]
+|  
+|  </head>
+|  <body>
+|  Hello, world.
+|  </body>
+|  </html>

--- a/validator/testdata/feature_tests/amp_rtc.out
+++ b/validator/testdata/feature_tests/amp_rtc.out
@@ -1,2 +1,60 @@
 FAIL
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Test of the amp-rtc script tag.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <!-- Valid: correctly formatted, present in head -->
+|    <script type="application/json" id="amp-rtc">
+|    {
+|      "doubleclick": {
+|        "url": "https://pub.com/rtc-endpoint",
+|        "sendAdRequestOnFailure": true
+|      },
+|      "fake-network": {
+|        "url": "https://pub.com/rtc-endpoint-fake-network",
+|        "sendAdRequestOnFailure": false
+|      }
+|    }
+|    </script>
+|  </head>
+|  <body>
+|    <!-- Invalid: found in body, duplicate -->
+|    <script type="application/json" id="amp-rtc">
+>>   ^~~~~~~~~
 feature_tests/amp_rtc.html:44:2 The parent tag of tag 'script id=amp-rtc' is 'body', but it can only be 'head'. [DISALLOWED_HTML]
+|    {
+|      "doubleclick": {
+|        "url": "https://pub.com/rtc-endpoint",
+|        "sendAdRequestOnFailure": true
+|      },
+|      "fake-network": {
+|        "url": "https://pub.com/rtc-endpoint-fake-network",
+|        "sendAdRequestOnFailure": false
+|      }
+|    }
+|    </script>
+|  </body>
+|  </html>

--- a/validator/testdata/feature_tests/aria.out
+++ b/validator/testdata/feature_tests/aria.out
@@ -1,5 +1,52 @@
 FAIL
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|      This tests looks at specific errors related to ARIA rules.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1,user-scalable=no,minimal-ui">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script src="https://cdn.ampproject.org/v0.js" async></script>
+|  </head>
+|  <body>
+|    <!-- valid -->
+|    <amp-img on="tap:lightbox" role="button" tabindex="1" layout="fill" src="img"></amp-img>
+|    <!-- valid -->
+|    <a href="#" on="tap:amp-access.login">Login</a>
+|    <!-- valid -->
+|    <button on="tap:amp-user-notification.dismiss">Dismiss</button>
+|    <!-- invalid: missing role -->
+|    <amp-img on="tap:lightbox" tabindex="1" layout="fill" src="img"></amp-img>
+>>   ^~~~~~~~~
 feature_tests/aria.html:37:2 The attribute 'role' in tag 'amp-img' is missing or incorrect, but required by attribute 'on'. (see https://www.ampproject.org/docs/reference/components/amp-img) [DISALLOWED_HTML]
+|    <!-- invalid: missing tabindex -->
+|    <amp-img on="tap:lightbox" role="button" layout="fill" src="img"></amp-img>
+>>   ^~~~~~~~~
 feature_tests/aria.html:39:2 The attribute 'tabindex' in tag 'amp-img' is missing or incorrect, but required by attribute 'on'. (see https://www.ampproject.org/docs/reference/components/amp-img) [DISALLOWED_HTML]
+|    <!-- invalid: missing both role and tabindex -->
+|    <amp-img on="tap:lightbox" layout="fill" src="img"></amp-img>
+>>   ^~~~~~~~~
 feature_tests/aria.html:41:2 The attribute 'role' in tag 'amp-img' is missing or incorrect, but required by attribute 'on'. (see https://www.ampproject.org/docs/reference/components/amp-img) [DISALLOWED_HTML]
+>>   ^~~~~~~~~
 feature_tests/aria.html:41:2 The attribute 'tabindex' in tag 'amp-img' is missing or incorrect, but required by attribute 'on'. (see https://www.ampproject.org/docs/reference/components/amp-img) [DISALLOWED_HTML]
+|  </body>
+|  </html>

--- a/validator/testdata/feature_tests/article-json-ld.out
+++ b/validator/testdata/feature_tests/article-json-ld.out
@@ -1,1 +1,148 @@
 PASS
+|  <!--
+|    Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!doctype html>
+|  <!--
+|        This sample AMP HTML file aims to be a minimalist document that
+|        follows best practices and guidances for publishers to mark up
+|        content for inclusion in various platforms.
+|  -->
+|  <html AMP lang="en">
+|    <!-- you can use "amp" or "AMP" or "⚡" -->
+|    <head>
+|      <meta charset="utf-8">
+|      <title>Lorem Ipsum</title>
+|      <link rel="canonical" href="http://example.ampproject.org/article-metadata.html">
+|      <!--
+|          The canonical document for this article should be linked, as above.
+|  
+|          The canonical document should also have a corresponding <link> tag
+|          within pointing at this AMP HTML file:
+|  
+|            <link rel="amphtml" href="http://example.ampproject.org/article-json-ld.amp.html">
+|  
+|          It is possible that this AMP HTML document is the canonical document
+|          for this article, in which case, the canonical URL should point to this
+|          document, and no "amphtml" link is required.
+|      -->
+|      <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+|      <!-- only one style tag is allowed, and it must have an "amp-custom" attribute -->
+|      <style amp-custom>
+|        body {
+|          background-color: white;
+|        }
+|        amp-img {
+|          background-color: gray;
+|        }
+|      </style>
+|      <script type="application/ld+json">
+|          //
+|          // The document referenced in mainEntityOfPage should be the same as the
+|          // canonical link above.
+|          //
+|          // Also, please be aware that some platforms that use AMP HTML have
+|          // further restrictions with regards to some schema components.
+|          //
+|          // For example:
+|          //
+|          //   * The leader "image" referenced in the markup below must appear
+|          //   somewhere on the AMP HTML document itself.
+|          //
+|          //   * The URL for that "image" must precisely match the src of the
+|          //   amp-img tag.
+|          //
+|          //   * All marked-up URLs should be absolute.
+|          //
+|          //   * The "logo" dimensions must not exceed 600x60.
+|          //
+|        {
+|          "@context": "http://schema.org",
+|          "@type": "NewsArticle",
+|          "mainEntityOfPage": "http://example.ampproject.org/article-metadata.html",
+|          "headline": "Lorem Ipsum",
+|          "datePublished": "1907-05-05T12:02:41Z",
+|          "dateModified": "1907-05-05T12:02:41Z",
+|          "description": "The Catiline Orations continue to begule engineers and designers alike -- but can it stand the test of time?",
+|          "author": {
+|            "@type": "Person",
+|            "name": "Jordan M Adler"
+|          },
+|          "publisher": {
+|            "@type": "Organization",
+|            "name": "Google",
+|            "logo": {
+|              "@type": "ImageObject",
+|              "url": "http://cdn.ampproject.org/logo.jpg",
+|              "width": 600,
+|              "height": 60
+|            }
+|          },
+|          "image": {
+|            "@type": "ImageObject",
+|            "url": "http://cdn.ampproject.org/leader.jpg",
+|            "height": 2000,
+|            "width": 800
+|          }
+|        }
+|      </script>
+|      <!-- this style tag is required -->
+|      <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|      <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    </head>
+|    <body>
+|      <h1>Lorem Ipsum</h1>
+|      <amp-img src="http://cdn.ampproject.org/leader.jpg" alt="Lorem Ipsum?" height="2000" width="800"></amp-img>
+|      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer nec
+|         odio. Praesent libero. Sed cursus ante dapibus diam. Sed nisi. Nulla
+|         quis sem at nibh elementum imperdiet. Duis sagittis ipsum. Praesent
+|         mauris. Fusce nec tellus sed augue semper porta. Mauris massa.
+|         Vestibulum lacinia arcu eget nulla. Class aptent taciti sociosqu ad
+|         litora torquent per conubia nostra, per inceptos himenaeos.</p>
+|      <p>Curabitur sodales ligula in libero. Sed dignissim lacinia nunc.
+|         Curabitur tortor. Pellentesque nibh. Aenean quam. In scelerisque sem at
+|         dolor.  Maecenas mattis. Sed convallis tristique sem. Proin ut ligula vel nunc
+|         egestas porttitor. Morbi lectus risus, iaculis vel, suscipit quis, luctus non,
+|         massa.  Fusce ac turpis quis ligula lacinia aliquet. Mauris ipsum.</p>
+|      <p>Nulla metus metus, ullamcorper vel, tincidunt sed, euismod in, nibh.
+|         Quisque volutpat condimentum velit. Class aptent taciti sociosqu ad
+|         litora torquent per conubia nostra, per inceptos himenaeos. Nam nec
+|         ante. Sed lacinia, urna non tincidunt mattis, tortor neque adipiscing
+|         diam, a cursus ipsum ante quis turpis. Nulla facilisi. Ut fringilla.
+|         Suspendisse potenti. Nunc feugiat mi a tellus consequat imperdiet.
+|         Vestibulum sapien. Proin quam.</p>
+|      <blockquote>
+|        <p>Quo usque tandem abutere, Catilina, patientia nostra? Quam diu etiam
+|           furor iste tuus nos eludet? Quem ad finem sese effrenata iactabit
+|           audacia?</p>
+|        <p>CICERO</p>
+|      </blockquote>
+|      <p>Etiam ultrices. Suspendisse in justo eu magna luctus suscipit. Sed
+|         lectus. Integer euismod lacus luctus magna. Quisque cursus, metus vitae
+|         pharetra auctor, sem massa mattis sem, at interdum magna augue eget diam.
+|         Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere
+|         cubilia Curae; Morbi lacinia molestie dui. Praesent blandit dolor. Sed
+|         non quam. In vel mi sit amet augue congue elementum. Morbi in ipsum sit
+|         amet pede facilisis laoreet. Donec lacus nunc, viverra nec, blandit vel,
+|         egestas et, augue. Vestibulum tincidunt malesuada tellus. Ut ultrices
+|         ultrices enim.</p>
+|      <p>Curabitur sit amet mauris. Morbi in dui quis est pulvinar ullamcorper.
+|         Nulla facilisi. Integer lacinia sollicitudin massa. Cras metus. Sed
+|         aliquet risus a tortor. Integer id quam. Morbi mi. Quisque nisl felis,
+|         venenatis tristique, dignissim in, ultrices sit amet, augue. Proin
+|         sodales libero eget ante. Nulla quam. Aenean laoreet. Vestibulum nisi
+|         lectus, commodo ac, facilisis ac, ultricies eu, pede.</p>
+|    </body>
+|  </html>

--- a/validator/testdata/feature_tests/article-microdata.out
+++ b/validator/testdata/feature_tests/article-microdata.out
@@ -1,1 +1,126 @@
 PASS
+|  <!--
+|    Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!doctype html>
+|  <!--
+|        This sample AMP HTML file aims to be a minimalist document that
+|        follows best practices and guidances for publishers to mark up
+|        content for inclusion in various platforms.
+|  -->
+|  <html AMP lang="en" itemscope itemtype="http://schema.org/NewsArticle">
+|    <!-- you can use "amp" or "AMP" or "⚡" -->
+|    <head>
+|      <meta charset="utf-8">
+|      <title>Lorem Ipsum</title>
+|      <link itemprop="mainEntityOfPage" rel="canonical" href="http://example.ampproject.org/article-metadata.html">
+|      <!--
+|          The canonical document for this article should be linked, as above.
+|  
+|          The canonical document should also have a corresponding <link> tag
+|          within pointing at this AMP HTML file:
+|  
+|            <link rel="amphtml" href="http://example.ampproject.org/article-microdata.amp.html">
+|  
+|          It is possible that this AMP HTML document is the canonical document
+|          for this article, in which case, the canonical URL should point to this
+|          document, and no "amphtml" link is required.
+|  
+|          Also, please be aware that some platforms that use AMP HTML have
+|          further restrictions with regards to some schema components.
+|  
+|           For example:
+|  
+|             * All marked-up URL's should be absolute.
+|             * The "logo" dimensions must not exceed 600x60.
+|      -->
+|      <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+|      <!-- only one style tag is allowed, and it must have an "amp-custom" attribute -->
+|      <style amp-custom>
+|        body {
+|          background-color: white;
+|        }
+|        amp-img {
+|          background-color: gray;
+|        }
+|      </style>
+|      <!-- this style tag is required -->
+|      <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|      <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    </head>
+|    <body>
+|      <h1 itemprop="headline">Lorem Ipsum</h1>
+|      <h2 itemprop="author" itemscope itemtype="https://schema.org/Person">
+|        <span itemprop="name">Jordan M Adler</span>
+|      </h2>
+|      <time itemprop="datePublished" datetime="1907-05-05T12:02:41Z">Sunday, May 5th 1907</time>
+|      <time itemprop="dateModified" datetime="1907-05-05T12:02:41Z"></time>
+|      <meta itemprop="description" content="The Catiline Orations continue to begule engineers and designers alike -- but can it stand the test of time?"></meta>
+|      <div itemprop="publisher" itemscope itemtype="https://schema.org/Organization">
+|        <div itemprop="logo" itemscope itemtype="https://schema.org/ImageObject">
+|          <amp-img width="600" height="60" src="http://cdn.ampproject.org/logo.jpg"></amp-img>
+|          <meta itemprop="url" content="http://cdn.ampproject.org/logo.jpg"></meta>
+|          <meta itemprop="width" content="600"></meta>
+|          <meta itemprop="height" content="60"></meta>
+|        </div>
+|        <meta itemprop="name" content="Google"></meta>
+|      </div>
+|      <div itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+|        <amp-img src="http://cdn.ampproject.org/leader.jpg" alt="Lorem Ipsum?" height="2000" width="800"></amp-img>
+|        <meta itemprop="url" content="http://cdn.ampproject.org/leader.jpg"></meta>
+|        <meta itemprop="width" content="2000"></meta>
+|        <meta itemprop="height" content="800"></meta>
+|      </div>
+|      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer nec
+|         odio. Praesent libero. Sed cursus ante dapibus diam. Sed nisi. Nulla
+|         quis sem at nibh elementum imperdiet. Duis sagittis ipsum. Praesent
+|         mauris. Fusce nec tellus sed augue semper porta. Mauris massa.
+|         Vestibulum lacinia arcu eget nulla. Class aptent taciti sociosqu ad
+|         litora torquent per conubia nostra, per inceptos himenaeos.</p>
+|      <p>Curabitur sodales ligula in libero. Sed dignissim lacinia nunc.
+|         Curabitur tortor. Pellentesque nibh. Aenean quam. In scelerisque sem at
+|         dolor.  Maecenas mattis. Sed convallis tristique sem. Proin ut ligula vel nunc
+|         egestas porttitor. Morbi lectus risus, iaculis vel, suscipit quis, luctus non,
+|         massa.  Fusce ac turpis quis ligula lacinia aliquet. Mauris ipsum.</p>
+|      <p>Nulla metus metus, ullamcorper vel, tincidunt sed, euismod in, nibh.
+|         Quisque volutpat condimentum velit. Class aptent taciti sociosqu ad
+|         litora torquent per conubia nostra, per inceptos himenaeos. Nam nec
+|         ante. Sed lacinia, urna non tincidunt mattis, tortor neque adipiscing
+|         diam, a cursus ipsum ante quis turpis. Nulla facilisi. Ut fringilla.
+|         Suspendisse potenti. Nunc feugiat mi a tellus consequat imperdiet.
+|         Vestibulum sapien. Proin quam.</p>
+|      <blockquote>
+|        <p>Quo usque tandem abutere, Catilina, patientia nostra? Quam diu etiam
+|           furor iste tuus nos eludet? Quem ad finem sese effrenata iactabit
+|           audacia?</p>
+|        <p>CICERO</p>
+|      </blockquote>
+|      <p>Etiam ultrices. Suspendisse in justo eu magna luctus suscipit. Sed
+|         lectus. Integer euismod lacus luctus magna. Quisque cursus, metus vitae
+|         pharetra auctor, sem massa mattis sem, at interdum magna augue eget diam.
+|         Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere
+|         cubilia Curae; Morbi lacinia molestie dui. Praesent blandit dolor. Sed
+|         non quam. In vel mi sit amet augue congue elementum. Morbi in ipsum sit
+|         amet pede facilisis laoreet. Donec lacus nunc, viverra nec, blandit vel,
+|         egestas et, augue. Vestibulum tincidunt malesuada tellus. Ut ultrices
+|         ultrices enim.</p>
+|      <p>Curabitur sit amet mauris. Morbi in dui quis est pulvinar ullamcorper.
+|         Nulla facilisi. Integer lacinia sollicitudin massa. Cras metus. Sed
+|         aliquet risus a tortor. Integer id quam. Morbi mi. Quisque nisl felis,
+|         venenatis tristique, dignissim in, ultrices sit amet, augue. Proin
+|         sodales libero eget ante. Nulla quam. Aenean laoreet. Vestibulum nisi
+|         lectus, commodo ac, facilisis ac, ultricies eu, pede.</p>
+|    </body>
+|  </html>

--- a/validator/testdata/feature_tests/article.out
+++ b/validator/testdata/feature_tests/article.out
@@ -1,3 +1,503 @@
 FAIL
+|  <!--
+|    Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <title>Lorem Ipsum | PublisherName</title>
+|    <link rel="canonical" href="https://medium.com/p/cb7f223fad86" >
+|    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  
+|    <style amp-custom>
+|      body {
+|        margin: 0;
+|        font-family: 'Georgia', Serif;
+|      }
+|  
+|      .brand-logo {
+|        font-family: 'Open Sans';
+|      }
+|  
+|      .ad-container {
+|        display: flex;
+|        justify-content: center;
+|      }
+|  
+|      .content-container p {
+|        line-height: 24px;
+|      }
+|  
+|      header,
+|      .article-body {
+|        padding: 15px;
+|      }
+|  
+|      /* In the shadow-doc mode, the parent shell already has header and nav. */
+|      .amp-shadow header {
+|        display: none;
+|      }
+|  
+|      .lightbox {
+|        background: #222;
+|      }
+|  
+|      .full-bleed {
+|        margin: 0 -15px;
+|      }
+|  
+|      .lightbox-content {
+|        position: absolute;
+|        top: 0;
+|        left: 0;
+|        right: 0;
+|        bottom: 0;
+|  
+|        display: flex;
+|        flex-direction: column;
+|        flex-wrap: nowrap;
+|        justify-content: center;
+|        align-items: center;
+|      }
+|  
+|      .lightbox-content p {
+|        color: #fff;
+|        padding: 15px;
+|      }
+|  
+|      .lightbox amp-img {
+|        width: 100%;
+|      }
+|  
+|      figure {
+|        margin: 0;
+|      }
+|  
+|      figcaption {
+|        color: #6f757a;
+|        padding: 15px 0;
+|        font-size: .9em;
+|      }
+|  
+|      .author {
+|        display: flex;
+|        align-items: center;
+|  
+|        background: #f4f4f4;
+|        padding: 0 15px;
+|  
+|        font-size: .8em;
+|  
+|        border: solid #dcdcdc;
+|        border-width: 1px 0;
+|      }
+|  
+|      .header-time {
+|        color: #a8a3ae;
+|        font-family: 'Roboto';
+|        font-size: 12px;
+|      }
+|  
+|      .author p {
+|        margin: 5px;
+|      }
+|  
+|      .byline {
+|        font-family: 'Roboto';
+|        display: inline-block;
+|      }
+|  
+|      .byline p {
+|        line-height: normal;
+|      }
+|  
+|      .byline .brand {
+|        color: #6f757a;
+|      }
+|  
+|      .standfirst {
+|        color: #6f757a;
+|      }
+|  
+|      .mailto {
+|        text-decoration: none;
+|      }
+|  
+|      #author-avatar {
+|        margin: 10px;
+|        border: 5px solid #fff;
+|        width: 50px;
+|        height: 50px;
+|        border-radius: 50%;
+|      }
+|  
+|      h1 {
+|        margin: 5px 0;
+|        font-weight: normal;
+|      }
+|  
+|      footer {
+|        display: flex;
+|        align-items: center;
+|        justify-content: center;
+|        height: 226px;
+|        background: #f4f4f4;
+|        margin-bottom: 20px;
+|      }
+|  
+|      hr {
+|        margin: 0;
+|      }
+|  
+|      amp-app-banner {
+|        padding: 10px;
+|      }
+|  
+|      amp-app-banner .content {
+|        display: flex;
+|        align-items: center;
+|        justify-content: center;
+|      }
+|  
+|      amp-img {
+|        background-color: #f4f4f4;
+|      }
+|  
+|      .slot-fallback {
+|        padding: 16px;
+|        background: yellow;
+|      }
+|  
+|      amp-app-banner amp-img {
+|        background-color: transparent;
+|        margin-right: 15px
+|      }
+|  
+|      amp-app-banner .description {
+|        margin-right: 20px;
+|      }
+|  
+|      amp-app-banner h5 {
+|        margin: 0;
+|      }
+|  
+|      amp-app-banner p {
+|        font-size: 10px;
+|        margin: 3px 0;
+|      }
+|  
+|      amp-app-banner .actions button {
+|        padding: 5px;
+|        width: 70px;
+|        border: 1px solid #aaa;
+|        font-size: 8px;
+|        background: #fff;
+|      }
+|  
+|      amp-app-banner .actions {
+|        text-align: right;
+|        font-size: 14px;
+|      }
+|  
+|      amp-sidebar {
+|        width: 150px;
+|      }
+|  
+|      nav li {
+|        list-style: none;
+|        margin-bottom: 10px;
+|      }
+|  
+|      nav li a {
+|        text-decoration: none;
+|        color: #666666;
+|      }
+|  
+|    </style>
+|    <link href='https://fonts.googleapis.com/css?family=Georgia|Open+Sans|Roboto' rel='stylesheet' type='text/css'>
+|    <script async custom-element="amp-ad" src="https://cdn.ampproject.org/v0/amp-ad-0.1.js"></script>
+|    <script async custom-element="amp-lightbox" src="https://cdn.ampproject.org/v0/amp-lightbox-0.1.js"></script>
+|    <script async custom-element="amp-sidebar" src="https://cdn.ampproject.org/v0/amp-sidebar-0.1.js"></script>
+|    <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
+|    <script async custom-element="amp-app-banner" src="https://cdn.ampproject.org/v0/amp-app-banner-0.1.js" data-amp-report-test="amp-app-banner.js"></script>
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <meta name="apple-itunes-app" content="app-id=828256236, app-argument=medium://p/cb7f223fad86">
+|    <link rel="manifest" href="medium-manifest.json">
+|  </head>
+|  <body>
+|    <amp-sidebar id="sidebar" layout="nodisplay">
+|      <nav>
+|        <ul>
+|          <li>
+|            <a href="#">
+|              Home
+|              <amp-img src="img/ampicon.png" width="15" height="15"></amp-img>
+|            </a>
+|          </li>
+|          <li><a href="#">Link 1</a></li>
+|          <li><a href="#">Link 2</a></li>
+|          <li><a href="#">Link 3</a></li>
+|          <li><a href="#">Link 4</a></li>
+|          <li><a href="#section1">Section 1</a></li>
+|          <li><a href="#section2">Section 2</a></li>
+|          <li><a href="#section3">Section 3</a></li>
+|        </ul>
+|      </nav>
+|    </amp-sidebar>
+|    <amp-app-banner layout="nodisplay" id="demo-app-banner-2134">
+|      <div class="content">
+|        <amp-img src="https://cdn-images-1.medium.com/max/800/1*JLegdtjFMNgqHgnxdd04fg.png"
+|                 width="40" height="34"></amp-img>
+|        <div class="description">
+|          <h5>Medium App</h5>
+|          <p>Experience a richer experience on our mobile app!</p>
+|        </div>
+|        <div class="actions">
+|          <button open-button>Open In App</button>
+|        </div>
+|      </div>
+|    </amp-app-banner>
+|  
+|    <header>
+|      <button on="tap:sidebar.toggle" class="menu" title="Toggle Sidebar" >
+|        ☰
+|      </button>
+|      <span class="brand-logo">
+|        PublisherLogo
+|      </span>
+|    </header>
+|  
+|    <!--
+|    Slots spec is not implemented yet by any browser. Will use an older version via `<content>` tag.
+|    <slot name="slot1"></slot>
+|    -->
+|    <content>
+>>   ^~~~~~~~~
 feature_tests/article.html:287:2 The tag 'content' is disallowed. [DISALLOWED_HTML]
-feature_tests/article.html:498:7 The tag 'amp-video extension .js script' is missing or incorrect, but required by 'amp-video'. This will soon be an error. (see https://www.ampproject.org/docs/reference/components/amp-video) [DEPRECATION]
+|      <div class="slot-fallback">
+|        This is a slot fallback.
+|      </div>
+|    </content>
+|  
+|    <main role="main">
+|      <article>
+|        <figure>
+|          <amp-img id="hero-img"
+|              src="img/hero@1x.jpg"
+|              srcset="img/hero@1x.jpg 1x, img/hero@2x.jpg 2x"
+|              layout="responsive" width="360" placeholder
+|              alt="Picture of two chairs on a lake shore with big pine trees"
+|              title="Opens image in a lightbox"
+|              role="button" on="tap:headline-img-lightbox"
+|              height="216" tabindex="0">
+|          </amp-img>
+|        </figure>
+|  
+|        <amp-lightbox id="headline-img-lightbox" class="lightbox"
+|            layout="nodisplay">
+|  
+|          <div class="lightbox-content">
+|            <amp-img id="floating-headline-img"
+|                src="img/hero@1x.jpg"
+|                srcset="img/hero@1x.jpg 1x, img/hero@2x.jpg 2x"
+|                alt="Two chairs on a lake shore with big pine trees"
+|                placeholder
+|                width="360" height="216" layout="responsive">
+|            </amp-img>
+|            <p>
+|              Fusce pretium tempor justo, vitae consequat dolor maximus eget.
+|            </p>
+|          </div>
+|        </amp-lightbox>
+|  
+|        <div class="content-container">
+|          <ul>
+|            <li><a href="#section1">Section 1</a></li>
+|            <li><a href="#section2">Section 2</a></li>
+|          </ul>
+|          <header>
+|            <h1 itemprop="headline">Lorem Ipsum</h1>
+|            <time class="header-time" itemprop="datePublished"
+|                datetime="2015-09-14 13:00">September 14, 2015</time>
+|            <p class="standfirst">
+|              Fusce pretium tempor justo, vitae consequat dolor maximus eget.
+|            </p>
+|          </header>
+|  
+|          <div class="author">
+|            <amp-img src="img/sample.jpg" id="author-avatar" placeholder
+|                height="50" width="50">
+|            </amp-img>
+|            <div class="byline">
+|              <p>
+|                by <span itemscope itemtype="http://schema.org/Person"
+|                itemprop="author"><b>Lorem Ipsum</b>
+|                <a class="mailto" href="mailto:lorem.ipsum@">
+|                lorem.ipsum@</a></span>
+|              </p>
+|              <p class="brand">PublisherName News Reporter<p>
+|            </div>
+|          </div>
+|          <div class="article-body" itemprop="articleBody">
+|            <p>
+|              Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+|              Curabitur ullamcorper turpis vel commodo scelerisque. Phasellus
+|              luctus nunc ut elit cursus, et imperdiet diam vehicula.
+|              Duis et nisi sed urna blandit bibendum et sit amet erat.
+|              Suspendisse potenti. Curabitur consequat volutpat arcu nec
+|              elementum. Etiam a turpis ac libero varius condimentum.
+|              Maecenas sollicitudin felis aliquam tortor vulputate,
+|              ac posuere velit semper.
+|            </p>
+|            <p>
+|              Fusce pretium tempor justo, vitae consequat dolor maximus eget.
+|              Aliquam iaculis tincidunt quam sed maximus. Suspendisse faucibus
+|              ornare sodales. Nullam id dolor vitae arcu consequat ornare a
+|              et lectus. Sed tempus eget enim eget lobortis.
+|              Mauris sem est, accumsan sed tincidunt ut, sagittis vel arcu.
+|              Nullam in libero nisi.
+|            </p>
+|  
+|            <div class="ad-container">
+|              <amp-ad width=300 height=250
+|                  type="a9"
+|                  data-aax_size="300x250"
+|                  data-aax_pubname="abc123"
+|                  data-aax_src="302">
+|              </amp-ad>
+|            </div>
+|  
+|            <p>
+|              Sed pharetra semper fringilla. Nulla fringilla, neque eget
+|              varius suscipit, mi turpis congue odio, quis dignissim nisi
+|              nulla at erat. Duis non nibh vel erat vehicula hendrerit eget
+|              vel velit. Donec congue augue magna, nec eleifend dui porttitor
+|              sed. Cras orci quam, dignissim nec elementum ac, bibendum et purus.
+|              Ut elementum mi eget felis ultrices tempus. Maecenas nec sodales
+|              ex. Phasellus ultrices, purus non egestas ullamcorper, felis
+|              lorem ultrices nibh, in tristique mauris justo sed ante.
+|              Nunc commodo purus feugiat metus bibendum consequat. Duis
+|              finibus urna ut ligula auctor, sed vehicula ex aliquam.
+|              Sed sed augue auctor, porta turpis ultrices, cursus diam.
+|              In venenatis aliquet porta. Sed volutpat fermentum quam,
+|              ac molestie nulla porttitor ac. Donec porta risus ut enim
+|              pellentesque, id placerat elit ornare.
+|            </p>
+|  
+|            <figure>
+|              <amp-video
+|                autoplay
+|                src="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4"
+|                width="720"
+|                height="405"
+|                layout="responsive"
+|                controls>
+|              </amp-video>
+|              <figcaption>
+|                Fusce pretium tempor justo, vitae consequat dolor maximus eget.
+|              </figcaption>
+|            </figure>
+|  
+|            <p>
+|              Sed pharetra semper fringilla. Nulla fringilla, neque eget
+|              varius suscipit, mi turpis congue odio, quis dignissim nisi
+|              nulla at erat. Duis non nibh vel erat vehicula hendrerit eget
+|              vel velit. Donec congue augue magna, nec eleifend dui porttitor
+|              sed. Cras orci quam, dignissim nec elementum ac, bibendum et purus.
+|              Ut elementum mi eget felis ultrices tempus. Maecenas nec sodales
+|              ex. Phasellus ultrices, purus non egestas ullamcorper, felis
+|              lorem ultrices nibh, in tristique mauris justo sed ante.
+|              Nunc commodo purus feugiat metus bibendum consequat. Duis
+|              finibus urna ut ligula auctor, sed vehicula ex aliquam.
+|              Sed sed augue auctor, porta turpis ultrices, cursus diam.
+|              In venenatis aliquet porta. Sed volutpat fermentum quam,
+|              ac molestie nulla porttitor ac. Donec porta risus ut enim
+|              pellentesque, id placerat elit ornare.
+|            </p>
+|  
+|            <p id="section1">
+|              Curabitur convallis, urna quis pulvinar feugiat, purus diam
+|              posuere turpis, sit amet tincidunt purus justo et mi. Donec
+|              sapien urna, aliquam ut lacinia quis, varius vitae ex.
+|              Maecenas efficitur iaculis lorem, at imperdiet orci viverra
+|              in. Nullam eu erat eu metus ultrices viverra a sit amet leo.
+|              Pellentesque est felis, pulvinar mollis sollicitudin et,
+|              suscipit eget massa. Nunc bibendum non nunc et consequat.
+|              Quisque auctor est vel leo faucibus, non faucibus magna ultricies.
+|              Vestibulum ante ipsum primis in faucibus orci luctus et ultrices
+|              posuere cubilia Curae; Vestibulum tortor lacus, bibendum et
+|              enim eu, vehicula placerat erat. Nullam gravida rhoncus accumsan.
+|              Integer suscipit iaculis elit nec mollis. Vestibulum eget arcu
+|              nec lectus finibus rutrum vel sed orci.
+|            </p>
+|  
+|            <figure>
+|              <amp-img class="full-bleed" placeholder
+|                  src="img/sea@1x.jpg"
+|                  srcset="img/sea@1x.jpg 1x, img/sea@2x.jpg 2x"
+|                  layout="responsive" width="320"
+|                  alt="Fusce pretium tempor justo, vitae consequat dolor maximus eget."
+|                  height="180">
+|              </amp-img>
+|              <figcaption>
+|                Fusce pretium tempor justo, vitae consequat dolor maximus eget.
+|              </figcaption>
+|            </figure>
+|            <hr>
+|  
+|            <p>
+|              Cum sociis natoque penatibus et magnis dis parturient montes,
+|              nascetur ridiculus mus. Nulla et viverra turpis. Fusce
+|              viverra enim eget elit blandit, in finibus enim blandit. Integer
+|              fermentum eleifend felis non posuere. In vulputate et metus at
+|              aliquam. Praesent a varius est. Quisque et tincidunt nisi.
+|              Nam porta urna at turpis lacinia, sit amet mattis eros elementum.
+|              Etiam vel mauris mattis, dignissim tortor in, pulvinar arcu.
+|              In molestie sem elit, tincidunt venenatis tortor aliquet sodales.
+|              Ut elementum velit fermentum felis volutpat sodales in non libero.
+|              Aliquam erat volutpat.
+|            </p>
+|  
+|            <div class="ad-container">
+|              <amp-ad width=300 height=200
+|                  type="adsense"
+|                  data-ad-client="ca-pub-9350112648257122">
+|              </amp-ad>
+|            </div>
+|  
+|            <p id="section2">
+|              Morbi at velit vitae eros congue congue venenatis non dui.
+|              Sed lacus sem, feugiat sed elementum sed, maximus sed lacus.
+|              Integer accumsan magna in sagittis pharetra. Class aptent taciti
+|              sociosqu ad litora torquent per conubia nostra, per inceptos
+|              himenaeos. Suspendisse ac nisl efficitur ligula aliquam lacinia
+|              eu in magna. Vestibulum non felis odio. Ut consectetur venenatis
+|              felis aliquet maximus. Class aptent taciti sociosqu ad litora
+|              torquent per conubia nostra, per inceptos himenaeos.
+|            </p>
+|          </div>
+|        </div>
+|      </article>
+|    </main>
+|  
+|    <footer>
+|      <div class="brand-logo">PublisherLogo</div>
+|    </footer>
+|  </body>
+|  </html>
+>>       ^~~~~~~~~
+feature_tests/article.html:498:6 The tag 'amp-video extension .js script' is missing or incorrect, but required by 'amp-video'. This will soon be an error. (see https://www.ampproject.org/docs/reference/components/amp-video) [DEPRECATION]

--- a/validator/testdata/feature_tests/bad_viewport.out
+++ b/validator/testdata/feature_tests/bad_viewport.out
@@ -1,4 +1,39 @@
 FAIL
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <!--
+|      Test Description:
+|      Tests what happens when bad viewport properties are specified.
+|    -->
+|    <meta name="viewport" content="minimum-scale=not-a-number,foo=bar">
+>>   ^~~~~~~~~
 feature_tests/bad_viewport.html:25:2 The property 'foo' in attribute 'content' in tag 'meta name=viewport' is disallowed. (see https://www.ampproject.org/docs/reference/spec#required-markup) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
+>>   ^~~~~~~~~
 feature_tests/bad_viewport.html:25:2 The property 'minimum-scale' in attribute 'content' in tag 'meta name=viewport' is set to 'not-a-number', which is invalid. (see https://www.ampproject.org/docs/reference/spec#required-markup) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
+>>   ^~~~~~~~~
 feature_tests/bad_viewport.html:25:2 The property 'width' is missing from attribute 'content' in tag 'meta name=viewport'. (see https://www.ampproject.org/docs/reference/spec#required-markup) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|  <body>
+|  Hello, world.
+|  </body>
+|  </html>

--- a/validator/testdata/feature_tests/base_href.out
+++ b/validator/testdata/feature_tests/base_href.out
@@ -1,2 +1,37 @@
 FAIL
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    This tests that a <base href> tag must be present before any URLs in the
+|    document.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <base href="https://example.com/">
+>>   ^~~~~~~~~
 feature_tests/base_href.html:26:2 The attribute 'href' in tag 'base' is set to the invalid value 'https://example.com/'. [DISALLOWED_HTML]
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|  <body>
+|  Hello, world.
+|  </body>
+|  </html>

--- a/validator/testdata/feature_tests/css_errors.out
+++ b/validator/testdata/feature_tests/css_errors.out
@@ -1,7 +1,56 @@
 FAIL
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests syntax errors in the author stylesheet.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <style amp-custom>
+|      a {
+|          two: 2;
+|          b {
+>>         ^~~~~~~~~
 feature_tests/css_errors.html:31:8 CSS syntax error in tag 'style amp-custom' - incomplete declaration. [AUTHOR_STYLESHEET_PROBLEM]
+|              three: 3;
+|          }
+>>         ^~~~~~~~~
 feature_tests/css_errors.html:33:8 CSS syntax error in tag 'style amp-custom' - invalid declaration. [AUTHOR_STYLESHEET_PROBLEM]
+|      }
+|      url("an unterminated string)
+>>     ^~~~~~~~~
 feature_tests/css_errors.html:35:4 CSS syntax error in tag 'style amp-custom' - end of stylesheet encountered in prelude of a qualified rule. [AUTHOR_STYLESHEET_PROBLEM]
+>>         ^~~~~~~~~
 feature_tests/css_errors.html:35:8 CSS syntax error in tag 'style amp-custom' - unterminated string. [AUTHOR_STYLESHEET_PROBLEM]
+|      A trailing backslash \
+>>                          ^~~~~~~~~
 feature_tests/css_errors.html:36:25 CSS syntax error in tag 'style amp-custom' - stray trailing backslash. [AUTHOR_STYLESHEET_PROBLEM]
+|      url(foo"bar)
+>>     ^~~~~~~~~
 feature_tests/css_errors.html:37:4 CSS syntax error in tag 'style amp-custom' - bad url. [AUTHOR_STYLESHEET_PROBLEM]
+|    </style>
+|  </head>
+|  <body>
+|  Hello, world.
+|  </body>
+|  </html>

--- a/validator/testdata/feature_tests/css_length.out
+++ b/validator/testdata/feature_tests/css_length.out
@@ -1,1 +1,36 @@
 PASS
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <!--
+|      Test Description:
+|      This testcase isn't run verbatim. The template string below is replaced by
+|      the test harnesses with various lenghts of valid CSS stylesheets. We use
+|      this test to verify the max_byte_length rules for CSS author stylesheets.
+|    -->
+|    <style amp-custom>.replaceme {}</style>
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|  <body>
+|  Hello, world.
+|  </body>
+|  </html>

--- a/validator/testdata/feature_tests/custom_element_case.out
+++ b/validator/testdata/feature_tests/custom_element_case.out
@@ -1,2 +1,40 @@
 FAIL
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    This tests that the custom-element value must be matched case-sensitively.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  
+|    <!-- Invalid: custom-element value is case-sensitive -->
+|    <script async custom-element='Amp-Analytics'
+>>   ^~~~~~~~~
 feature_tests/custom_element_case.html:30:2 The attribute 'custom-element' may not appear in tag 'amp-analytics extension .js script'. (see https://www.ampproject.org/docs/reference/components/amp-analytics) [AMP_TAG_PROBLEM]
+|       src='https://cdn.ampproject.org/v0/amp-analytics-0.1.js'></script>
+|  
+|  </runhead>
+|  <body>
+|  Hello, world.
+|  </body>
+|  </html>

--- a/validator/testdata/feature_tests/data_attrs.out
+++ b/validator/testdata/feature_tests/data_attrs.out
@@ -1,8 +1,60 @@
 FAIL
+|  <!--
+|    Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    This demonstrates the allowed set of data-* attributes.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|  <body>
+|    <div data->allowed</div>
+|    <div data>not allowed</div>
+>>   ^~~~~~~~~
 feature_tests/data_attrs.html:31:2 The attribute 'data' may not appear in tag 'div'. [DISALLOWED_HTML]
+|    <div data-foo>allowed</div>
+|    <div data_foo>not allowed</div>
+>>   ^~~~~~~~~
 feature_tests/data_attrs.html:33:2 The attribute 'data_foo' may not appear in tag 'div'. [DISALLOWED_HTML]
+|    <div data-foo_bar>allowed</div>
+|    <div data-foo:bar>allowed</div>
+|    <div data-foo.bar>allowed</div>
+|    <div data-123>allowed</div>
+|    <div data-UPPER>allowed</div>
+|    <div data-foo&bar>not allowed</div>
+>>   ^~~~~~~~~
 feature_tests/data_attrs.html:39:2 The attribute 'data-foo&bar' may not appear in tag 'div'. [DISALLOWED_HTML]
+|    <div data-foo?bar>not allowed</div>
+>>   ^~~~~~~~~
 feature_tests/data_attrs.html:40:2 The attribute 'data-foo?bar' may not appear in tag 'div'. [DISALLOWED_HTML]
+|    <div data-foo;bar>not allowed</div>
+>>   ^~~~~~~~~
 feature_tests/data_attrs.html:41:2 The attribute 'data-foo;bar' may not appear in tag 'div'. [DISALLOWED_HTML]
+|    <div data-foo"bar>not allowed</div>
+>>   ^~~~~~~~~
 feature_tests/data_attrs.html:42:2 The attribute 'data-foo"bar' may not appear in tag 'div'. [DISALLOWED_HTML]
+|    <div data-foo<bar>not allowed</div>
+>>   ^~~~~~~~~
 feature_tests/data_attrs.html:43:2 The attribute 'data-foo<bar' may not appear in tag 'div'. [DISALLOWED_HTML]
+|  </body>
+|  </html>

--- a/validator/testdata/feature_tests/deprecation_warnings_and_errors.out
+++ b/validator/testdata/feature_tests/deprecation_warnings_and_errors.out
@@ -1,4 +1,43 @@
 FAIL
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    This test contains the old, opacity-based boilerplate and an invalid tag.
+|    It is used for testing deprecation warnings and errors.
+|    Please don't use the old boilerplate at this point - if you need
+|    a starting point use minimum_valid_amp.html, *NOT* this file.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style>body {opacity: 0}</style>
+>>   ^~~~~~~~~
 feature_tests/deprecation_warnings_and_errors.html:29:2 The tag 'head > style[amp-boilerplate] - old variant' is deprecated - use 'head > style[amp-boilerplate]' instead. (see https://github.com/ampproject/amphtml/blob/master/spec/amp-boilerplate.md) [DEPRECATION]
+|    <noscript><style>body {opacity: 1}</style></noscript>
+>>             ^~~~~~~~~
 feature_tests/deprecation_warnings_and_errors.html:30:12 The tag 'noscript > style[amp-boilerplate] - old variant' is deprecated - use 'noscript > style[amp-boilerplate]' instead. (see https://github.com/ampproject/amphtml/blob/master/spec/amp-boilerplate.md) [DEPRECATION]
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|  <body>
+|  <disallowed-tag>This tag is disallowed.</disallowed-tag>
+>> ^~~~~~~~~
 feature_tests/deprecation_warnings_and_errors.html:34:0 The tag 'disallowed-tag' is disallowed. [DISALLOWED_HTML]
+|  </body>
+|  </html>

--- a/validator/testdata/feature_tests/dog_doc_type.out
+++ b/validator/testdata/feature_tests/dog_doc_type.out
@@ -1,3 +1,40 @@
 FAIL
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    On the internet, nobody knows you're a dog - except for the AMP Validator...
+|    Instead of the AMP identification, this document has the dog Unicode character
+|    in its dogtype. We don't allow that. This test generates two errors (one for
+|    the dog, one for the missing amp attribute).
+|  -->
+|  <!doctype html 🐶>
+>> ^~~~~~~~~
 feature_tests/dog_doc_type.html:23:0 The attribute '🐶' may not appear in tag 'html doctype'. (see https://www.ampproject.org/docs/reference/spec#required-markup) [DISALLOWED_HTML]
+|  <html>
+>> ^~~~~~~~~
 feature_tests/dog_doc_type.html:24:0 The mandatory attribute '⚡' is missing in tag 'html ⚡ for top-level html'. (see https://www.ampproject.org/docs/reference/spec#required-markup) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|  <body>
+|  Hello this is dog.
+|  </body>
+|  </html>

--- a/validator/testdata/feature_tests/duplicate_attribute.out
+++ b/validator/testdata/feature_tests/duplicate_attribute.out
@@ -1,10 +1,64 @@
 FAIL
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    This is the minimum valid AMP document; it includes all of the required
+|    fields from the spec, but nothing else.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <!-- These two duplicate a custom-element attribute used as a dispatch key -->
+|    <script async custom-element="amp-image-lightbox" custom-element="duplicate" src="https://cdn.ampproject.org/v0/amp-image-lightbox-0.1.js"></script>
+>>   ^~~~~~~~~
 feature_tests/duplicate_attribute.html:30:2 The tag 'script' contains the attribute 'custom-element' repeated multiple times. [DISALLOWED_HTML]
+|    <script async custom-element="duplicate" custom-element="amp-youtube" src="https://cdn.ampproject.org/v0/amp-youtube-0.1.js"></script>
+>>   ^~~~~~~~~
 feature_tests/duplicate_attribute.html:31:2 The tag 'script' contains the attribute 'custom-element' repeated multiple times. [DISALLOWED_HTML]
+>>   ^~~~~~~~~
 feature_tests/duplicate_attribute.html:31:2 Only AMP runtime 'script' tags are allowed, and only in the document head. (see https://www.ampproject.org/docs/reference/spec#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
+|  
+|  </head>
+|  <body>
+|  
+|     <!-- 600 width is legal given the implied layout, but 100% is not -->
+|     <amp-img src="a.png" width='100%' width=600 height=800></amp-img>
+>>    ^~~~~~~~~
 feature_tests/duplicate_attribute.html:37:3 The tag 'amp-img' contains the attribute 'width' repeated multiple times. [DISALLOWED_HTML]
+>>    ^~~~~~~~~
 feature_tests/duplicate_attribute.html:37:3 The attribute 'width' in tag 'amp-img' is set to the invalid value '100%'. (see https://www.ampproject.org/docs/reference/components/amp-img) [AMP_LAYOUT_PROBLEM]
+|     <amp-img src="a.png" width=600 width='100%' height=800></amp-img>
+>>    ^~~~~~~~~
 feature_tests/duplicate_attribute.html:38:3 The tag 'amp-img' contains the attribute 'width' repeated multiple times. [DISALLOWED_HTML]
+|  
+|     <!-- Let's make sure the script type can't be overridden -->
+|     <script type="application/ld+json" type="text/javascript"></script>
+>>    ^~~~~~~~~
 feature_tests/duplicate_attribute.html:41:3 The tag 'script' contains the attribute 'type' repeated multiple times. [DISALLOWED_HTML]
+|     <script type="text/javascript" type="application/ld+json"></script>
+>>    ^~~~~~~~~
 feature_tests/duplicate_attribute.html:42:3 The tag 'script' contains the attribute 'type' repeated multiple times. [DISALLOWED_HTML]
+>>    ^~~~~~~~~
 feature_tests/duplicate_attribute.html:42:3 Only AMP runtime 'script' tags are allowed, and only in the document head. (see https://www.ampproject.org/docs/reference/spec#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
+|  
+|  </body>
+|  </html>

--- a/validator/testdata/feature_tests/duplicate_unique_tags_and_wrong_parents.out
+++ b/validator/testdata/feature_tests/duplicate_unique_tags_and_wrong_parents.out
@@ -1,3 +1,42 @@
 FAIL
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    This example exercises tag spec rules that allow only one instance of a tag
+|    per doc, and rules that require specific parent tags.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <style amp-custom>a.style {}</style>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1,user-scalable=no,minimal-ui">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <!-- This tag is duplicate, but must be unique. -->
+|    <style amp-custom>a { second: style; }</style>
+>>   ^~~~~~~~~
 feature_tests/duplicate_unique_tags_and_wrong_parents.html:31:2 The tag 'style amp-custom' appears more than once in the document. (see https://www.ampproject.org/docs/reference/spec#stylesheets) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
+|  </head>
+|  <body>
+|  <!-- Style isn't allowed inside body -->
+|  <style amp-custom>Wrong parent tag.</style>
+>> ^~~~~~~~~
 feature_tests/duplicate_unique_tags_and_wrong_parents.html:35:0 The parent tag of tag 'style amp-custom' is 'body', but it can only be 'head'. (see https://www.ampproject.org/docs/reference/spec#stylesheets) [DISALLOWED_HTML]
+|  </body>
+|  </html>

--- a/validator/testdata/feature_tests/empty.out
+++ b/validator/testdata/feature_tests/empty.out
@@ -1,12 +1,24 @@
 FAIL
+|  
+>> ^~~~~~~~~
 feature_tests/empty.html:1:0 The mandatory tag 'html doctype' is missing or incorrect. (see https://www.ampproject.org/docs/reference/spec#required-markup) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
+>> ^~~~~~~~~
 feature_tests/empty.html:1:0 The mandatory tag 'html ⚡ for top-level html' is missing or incorrect. (see https://www.ampproject.org/docs/reference/spec#required-markup) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
+>> ^~~~~~~~~
 feature_tests/empty.html:1:0 The mandatory tag 'head' is missing or incorrect. (see https://www.ampproject.org/docs/reference/spec#required-markup) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
+>> ^~~~~~~~~
 feature_tests/empty.html:1:0 The mandatory tag 'link rel=canonical' is missing or incorrect. (see https://www.ampproject.org/docs/reference/spec#required-markup) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
+>> ^~~~~~~~~
 feature_tests/empty.html:1:0 The mandatory tag 'meta charset=utf-8' is missing or incorrect. (see https://www.ampproject.org/docs/reference/spec#required-markup) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
+>> ^~~~~~~~~
 feature_tests/empty.html:1:0 The mandatory tag 'meta name=viewport' is missing or incorrect. (see https://www.ampproject.org/docs/reference/spec#required-markup) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
+>> ^~~~~~~~~
 feature_tests/empty.html:1:0 The mandatory tag 'body' is missing or incorrect. (see https://www.ampproject.org/docs/reference/spec#required-markup) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
+>> ^~~~~~~~~
 feature_tests/empty.html:1:0 The mandatory tag 'amphtml engine v0.js script' is missing or incorrect. (see https://www.ampproject.org/docs/reference/spec#required-markup) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
+>> ^~~~~~~~~
 feature_tests/empty.html:1:0 The mandatory tag 'noscript enclosure for boilerplate' is missing or incorrect. (see https://github.com/ampproject/amphtml/blob/master/spec/amp-boilerplate.md) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
+>> ^~~~~~~~~
 feature_tests/empty.html:1:0 The mandatory tag 'head > style[amp-boilerplate]' is missing or incorrect. (see https://github.com/ampproject/amphtml/blob/master/spec/amp-boilerplate.md) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
+>> ^~~~~~~~~
 feature_tests/empty.html:1:0 The mandatory tag 'noscript > style[amp-boilerplate]' is missing or incorrect. (see https://github.com/ampproject/amphtml/blob/master/spec/amp-boilerplate.md) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]

--- a/validator/testdata/feature_tests/empty_stylesheet.out
+++ b/validator/testdata/feature_tests/empty_stylesheet.out
@@ -1,1 +1,34 @@
 PASS
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <!--
+|      Test Description:
+|      This tests an empty user-defined stylesheet. The validator is happy with it.
+|    -->
+|    <style amp-custom></style>
+|  </head>
+|  <body>
+|  Hello, world.
+|  </body>
+|  </html>

--- a/validator/testdata/feature_tests/everything.out
+++ b/validator/testdata/feature_tests/everything.out
@@ -1,1 +1,469 @@
 PASS
+|  <!--
+|    Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <title>AMP #0</title>
+|    <link rel="canonical" href="amps.html" >
+|    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+|    <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
+|    <style amp-custom>
+|      body {
+|        font-family: 'Questrial', Arial;
+|      }
+|      article {
+|        display: block;
+|        max-width: 736px;
+|        margin: 8px;
+|      }
+|  
+|      amp-lightbox {
+|        background-color: rgba(0, 0, 0, 0.9);
+|      }
+|  
+|      .bordered {
+|        border: 1px solid black;
+|      }
+|  
+|      .box1 {
+|        border: 1px solid black;
+|        margin: 8px 0;
+|      }
+|  
+|      .logo {
+|        background: yellow;
+|        border: 5px solid black;
+|        border-radius: 50%;
+|        opacity: 0.7;
+|        position: fixed;
+|        z-index: 1000;
+|        top: 100px;
+|        right: 10px;
+|        width: 40px;
+|        height: 40px;
+|      }
+|  
+|      .ear {
+|        background: lime;
+|        border: 5px solid black;
+|        opacity: 0.7;
+|        position: absolute;
+|        z-index: 999;
+|        top: 0;
+|        right: 0;
+|        width: 20px;
+|        height: 20px;
+|      }
+|  
+|      @media screen and (min-width: 380px) {
+|        .logo {
+|          top: auto;
+|        }
+|      }
+|  
+|      @media screen and (min-width: 420px) {
+|        .logo {
+|          position: static;
+|          top: auto;
+|        }
+|      }
+|  
+|      .goto {
+|        display: block;
+|        margin: 16px;
+|      }
+|      @font-face {
+|        font-family: 'Comic AMP';
+|        font-style: bold;
+|        font-weight: 700;
+|        src: url(fonts/ComicAMP.ttf) format('truetype');
+|      }
+|      .comic-amp-font-loaded .comic-amp {
+|        font-family: 'Comic AMP', serif, sans-serif;
+|      }
+|  
+|      .comic-amp-font-loading .comic-amp {
+|        color: #0ff;
+|      }
+|  
+|      .comic-amp-font-missing .comic-amp {
+|        color: #f00;
+|      }
+|  
+|      .lightbox-close-button {
+|        background: white;
+|      }
+|  
+|      .lightbox-text {
+|        color: white;
+|      }
+|  
+|      #amp-iframe:target {
+|        border: 1px solid green;
+|      }
+|  
+|      #breaker {
+|        height: 100px;
+|        background: green;
+|      }
+|  
+|      #breaking {
+|        height: 200px;
+|        width: 200vw;
+|        background: rgba(0, 0, 0, 0.5);
+|      }
+|  
+|  
+|    </style>
+|    <script async custom-element="amp-dynamic-css-classes" src="https://cdn.ampproject.org/v0/amp-dynamic-css-classes-0.1.js"></script>
+|    <script async custom-element="amp-ad" src="https://cdn.ampproject.org/v0/amp-ad-0.1.js"></script>
+|    <script async custom-element="amp-anim" src="https://cdn.ampproject.org/v0/amp-anim-0.1.js"></script>
+|    <script async custom-element="amp-audio" src="https://cdn.ampproject.org/v0/amp-audio-0.1.js"></script>
+|    <script async custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.1.js"></script>
+|    <script async custom-element="amp-fit-text" src="https://cdn.ampproject.org/v0/amp-fit-text-0.1.js"></script>
+|    <script async custom-element="amp-font" src="https://cdn.ampproject.org/v0/amp-font-0.1.js"></script>
+|    <script async custom-element="amp-iframe" src="https://cdn.ampproject.org/v0/amp-iframe-0.1.js"></script>
+|    <script async custom-element="amp-instagram" src="https://cdn.ampproject.org/v0/amp-instagram-0.1.js"></script>
+|    <script async custom-element="amp-image-lightbox" src="https://cdn.ampproject.org/v0/amp-image-lightbox-0.1.js"></script>
+|    <script async custom-element="amp-lightbox" src="https://cdn.ampproject.org/v0/amp-lightbox-0.1.js"></script>
+|    <script async custom-element="amp-twitter" src="https://cdn.ampproject.org/v0/amp-twitter-0.1.js"></script>
+|    <script async custom-element="amp-youtube" src="https://cdn.ampproject.org/v0/amp-youtube-0.1.js"></script>
+|    <script async custom-element="amp-video" src="https://cdn.ampproject.org/v0/amp-video-0.1.js"></script>
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|  <body class="comic-amp-font-loading">
+|  <div class="logo"></div>
+|  <div class="ear"></div>
+|  
+|  <article>
+|  
+|  <h1 id="top">AMP #0</h1>
+|  <a href="#amp-iframe">Go to iframe</a>
+|    <p class="comic-amp">
+|      Quisque ultricies id augue a convallis. Vivamus euismod est quis tellus laoreet lacinia. In quam tellus, mollis nec porta eget, volutpat sit amet nibh. Duis ac odio sem. Sed consequat, ante gravida fringilla suscipit, libero libero ullamcorper metus, nec porta est elit at est. Curabitur vel diam ligula. Nulla bibendum malesuada odio.
+|    </p>
+|    <p>
+|      <amp-fit-text width="300" height="200" layout="responsive" class="box1">
+|        Lorem ipsum dolor sit amet, has nisl nihil convenire et, vim at aeque inermis reprehendunt.
+|      </amp-fit-text>
+|    </p>
+|    <p>
+|      <div class="box1">
+|        Lorem ipsum dolor sit amet, has nisl nihil convenire et, vim at aeque inermis reprehendunt.
+|      </div>
+|    </p>
+|  
+|    <p>
+|      <a class="goto" href="#top">Top</a>
+|      <a class="goto" href="#img0">Image0</a>
+|      <a class="goto" href="#footer">Footer</a>
+|    </p>
+|  
+|    <p>
+|      <amp-carousel width=400 height=300 layout=responsive type=slides>
+|        <amp-img src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w400-h300-no-n" layout=fill></amp-img>
+|        <amp-img src="https://lh3.googleusercontent.com/5rcQ32ml8E5ONp9f9-Rf78IofLb9QjS5_0mqsY1zEFc=w400-h300-no-n" width=400 height=300 layout=responsive></amp-img>
+|        <amp-img src="https://lh3.googleusercontent.com/Z4gtm5Bkxyv21Z2PtbTf95Clb9AE4VTR6olbBKYrenM=w400-h300-no-n" width=400 height=300 layout=responsive></amp-img>
+|        <amp-anim
+|            src="https://lh3.googleusercontent.com/qNn8GDz8Jfd-s9lt3Nc4lJeLjVyEaqGJTk1vuCUWazCmAeOBVjSWDD0SMTU7x0zhVe5UzOTKR0n-kN4SXx7yElvpKYvCMaRyS_g-jydhJ_cEVYmYPiZ_j1Y9de43mlKxU6s06uK1NAlpbSkL_046amEKOdgIACICkuWfOBwlw2hUDfjPOWskeyMrcTu8XOEerCLuVqXugG31QC345hz3lUyOlkdT9fMYVUynSERGNzHba7bXMOxKRe3izS5DIWUgJs3oeKYqA-V8iqgCvneD1jj0Ff68V_ajm4BDchQubBJU0ytXVkoWh27ngeEHubpnApOS6fcGsjPxeuMjnzAUtoTsiXz2FZi1mMrxrblJ-kZoAq1DJ95cnoqoa2CYq3BTgq2E8BRe2paNxLJ5GXBCTpNdXMpVJc6eD7ceijQyn-2qanilX-iK3ChbOq0uBHMvsdoC_LsFOu5KzbbNH71vM3DPkvDGmHJmF67Vj8sQ6uBrLnzpYlCyN4-Y9frR8zugDcqX5Q=w400-h300-no"
+|            width="400" height="300">
+|          <amp-img placeholder
+|              src="https://lh3.googleusercontent.com/qNn8GDz8Jfd-s9lt3Nc4lJeLjVyEaqGJTk1vuCUWazCmAeOBVjSWDD0SMTU7x0zhVe5UzOTKR0n-kN4SXx7yElvpKYvCMaRyS_g-jydhJ_cEVYmYPiZ_j1Y9de43mlKxU6s06uK1NAlpbSkL_046amEKOdgIACICkuWfOBwlw2hUDfjPOWskeyMrcTu8XOEerCLuVqXugG31QC345hz3lUyOlkdT9fMYVUynSERGNzHba7bXMOxKRe3izS5DIWUgJs3oeKYqA-V8iqgCvneD1jj0Ff68V_ajm4BDchQubBJU0ytXVkoWh27ngeEHubpnApOS6fcGsjPxeuMjnzAUtoTsiXz2FZi1mMrxrblJ-kZoAq1DJ95cnoqoa2CYq3BTgq2E8BRe2paNxLJ5GXBCTpNdXMpVJc6eD7ceijQyn-2qanilX-iK3ChbOq0uBHMvsdoC_LsFOu5KzbbNH71vM3DPkvDGmHJmF67Vj8sQ6uBrLnzpYlCyN4-Y9frR8zugDcqX5Q=w400-h300-no-k"
+|              width="400" height="300"></amp-img>
+|        </amp-anim>
+|      </amp-carousel>
+|    </p>
+|    <p>
+|      <amp-carousel width=auto height=200>
+|        <amp-img src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w300-h200-no-n" width=300 height=200></amp-img>
+|        <amp-img src="https://lh3.googleusercontent.com/5rcQ32ml8E5ONp9f9-Rf78IofLb9QjS5_0mqsY1zEFc=w300-h200-no-n" width=300 height=200></amp-img>
+|        <amp-img src="https://lh3.googleusercontent.com/Z4gtm5Bkxyv21Z2PtbTf95Clb9AE4VTR6olbBKYrenM=w300-h200-no-n" width=300 height=200></amp-img>
+|        <amp-anim
+|            src="https://lh3.googleusercontent.com/qNn8GDz8Jfd-s9lt3Nc4lJeLjVyEaqGJTk1vuCUWazCmAeOBVjSWDD0SMTU7x0zhVe5UzOTKR0n-kN4SXx7yElvpKYvCMaRyS_g-jydhJ_cEVYmYPiZ_j1Y9de43mlKxU6s06uK1NAlpbSkL_046amEKOdgIACICkuWfOBwlw2hUDfjPOWskeyMrcTu8XOEerCLuVqXugG31QC345hz3lUyOlkdT9fMYVUynSERGNzHba7bXMOxKRe3izS5DIWUgJs3oeKYqA-V8iqgCvneD1jj0Ff68V_ajm4BDchQubBJU0ytXVkoWh27ngeEHubpnApOS6fcGsjPxeuMjnzAUtoTsiXz2FZi1mMrxrblJ-kZoAq1DJ95cnoqoa2CYq3BTgq2E8BRe2paNxLJ5GXBCTpNdXMpVJc6eD7ceijQyn-2qanilX-iK3ChbOq0uBHMvsdoC_LsFOu5KzbbNH71vM3DPkvDGmHJmF67Vj8sQ6uBrLnzpYlCyN4-Y9frR8zugDcqX5Q=w300-h200-no"
+|            width="300" height="200">
+|          <amp-img placeholder
+|              src="https://lh3.googleusercontent.com/qNn8GDz8Jfd-s9lt3Nc4lJeLjVyEaqGJTk1vuCUWazCmAeOBVjSWDD0SMTU7x0zhVe5UzOTKR0n-kN4SXx7yElvpKYvCMaRyS_g-jydhJ_cEVYmYPiZ_j1Y9de43mlKxU6s06uK1NAlpbSkL_046amEKOdgIACICkuWfOBwlw2hUDfjPOWskeyMrcTu8XOEerCLuVqXugG31QC345hz3lUyOlkdT9fMYVUynSERGNzHba7bXMOxKRe3izS5DIWUgJs3oeKYqA-V8iqgCvneD1jj0Ff68V_ajm4BDchQubBJU0ytXVkoWh27ngeEHubpnApOS6fcGsjPxeuMjnzAUtoTsiXz2FZi1mMrxrblJ-kZoAq1DJ95cnoqoa2CYq3BTgq2E8BRe2paNxLJ5GXBCTpNdXMpVJc6eD7ceijQyn-2qanilX-iK3ChbOq0uBHMvsdoC_LsFOu5KzbbNH71vM3DPkvDGmHJmF67Vj8sQ6uBrLnzpYlCyN4-Y9frR8zugDcqX5Q=w300-h200-no-k"
+|              width="300" height="200"></amp-img>
+|        </amp-anim>
+|      </amp-carousel>
+|    </p>
+|    <p>
+|      <amp-anim
+|          src="https://lh3.googleusercontent.com/qNn8GDz8Jfd-s9lt3Nc4lJeLjVyEaqGJTk1vuCUWazCmAeOBVjSWDD0SMTU7x0zhVe5UzOTKR0n-kN4SXx7yElvpKYvCMaRyS_g-jydhJ_cEVYmYPiZ_j1Y9de43mlKxU6s06uK1NAlpbSkL_046amEKOdgIACICkuWfOBwlw2hUDfjPOWskeyMrcTu8XOEerCLuVqXugG31QC345hz3lUyOlkdT9fMYVUynSERGNzHba7bXMOxKRe3izS5DIWUgJs3oeKYqA-V8iqgCvneD1jj0Ff68V_ajm4BDchQubBJU0ytXVkoWh27ngeEHubpnApOS6fcGsjPxeuMjnzAUtoTsiXz2FZi1mMrxrblJ-kZoAq1DJ95cnoqoa2CYq3BTgq2E8BRe2paNxLJ5GXBCTpNdXMpVJc6eD7ceijQyn-2qanilX-iK3ChbOq0uBHMvsdoC_LsFOu5KzbbNH71vM3DPkvDGmHJmF67Vj8sQ6uBrLnzpYlCyN4-Y9frR8zugDcqX5Q=w400-h225-no"
+|          width="400" height="225" layout="responsive">
+|        <amp-img placeholder
+|            src="https://lh3.googleusercontent.com/qNn8GDz8Jfd-s9lt3Nc4lJeLjVyEaqGJTk1vuCUWazCmAeOBVjSWDD0SMTU7x0zhVe5UzOTKR0n-kN4SXx7yElvpKYvCMaRyS_g-jydhJ_cEVYmYPiZ_j1Y9de43mlKxU6s06uK1NAlpbSkL_046amEKOdgIACICkuWfOBwlw2hUDfjPOWskeyMrcTu8XOEerCLuVqXugG31QC345hz3lUyOlkdT9fMYVUynSERGNzHba7bXMOxKRe3izS5DIWUgJs3oeKYqA-V8iqgCvneD1jj0Ff68V_ajm4BDchQubBJU0ytXVkoWh27ngeEHubpnApOS6fcGsjPxeuMjnzAUtoTsiXz2FZi1mMrxrblJ-kZoAq1DJ95cnoqoa2CYq3BTgq2E8BRe2paNxLJ5GXBCTpNdXMpVJc6eD7ceijQyn-2qanilX-iK3ChbOq0uBHMvsdoC_LsFOu5KzbbNH71vM3DPkvDGmHJmF67Vj8sQ6uBrLnzpYlCyN4-Y9frR8zugDcqX5Q=w400-h225-no-k"
+|            width="400" height="225" layout="responsive"></amp-img>
+|      </amp-anim>
+|    </p>
+|  
+|    <h2>Video</h2>
+|    <amp-video
+|        src="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4"
+|        width="358"
+|        height="204"
+|        layout="responsive"
+|        controls></amp-video>
+|  
+|    <h2>Youtube</h2>
+|    <amp-youtube
+|        data-videoid="mGENRKrdoGY"
+|        width="480" height="270"></amp-youtube>
+|  
+|    <amp-youtube
+|        data-videoid="mGENRKrdoGY"
+|        layout="responsive"
+|        width="480" height="270"></amp-youtube>
+|  
+|  
+|    <h2>Audio</h2>
+|      <amp-audio src="/examples/av/audio.mp3"></amp-audio>
+|  
+|    <h2>Lightbox</h2>
+|    <amp-lightbox id="lightbox" layout="nodisplay">
+|      <p>
+|        <button on="tap:lightbox.close" class="lightbox-close-button">
+|            Close Lightbox
+|        </button>
+|      </p>
+|      <p>
+|        <amp-img src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w300-h200-no" width=300 height=200></amp-img>
+|      </p>
+|      <p class="lightbox-text">
+|        Lorem ipsum dolor sit amet, has nisl nihil convenire et, vim at aeque inermis reprehendunt. Propriae tincidunt id nec, elit nusquam te mea, ius noster platonem in. Mea an idque minim, sit sale deleniti apeirian et. Omnium legendos tractatos cu mea. Vix in stet dolorem accusamus. Iisque rationibus consetetur in cum, quo unum nulla legere ut. Simul numquam saperet no sit.
+|      </p>
+|    </amp-lightbox>
+|  
+|    <button on="tap:lightbox">
+|        Open Lightbox
+|    </button>
+|  
+|    <h2>Scrollable Lightbox</h2>
+|    <amp-lightbox scrollable id="lightbox-scrollable" layout="nodisplay">
+|      <button on="tap:lightbox-scrollable.close" class="lightbox-close-button">
+|        Close Scrollable Lightbox
+|      </button>
+|      <p>
+|        <amp-img src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w300-h200-no" width=300 height=200></amp-img>
+|      </p>
+|      <p class="lightbox-text">
+|        Lorem ipsum dolor sit amet, has nisl nihil convenire et, vim at aeque inermis reprehendunt. Propriae tincidunt id nec, elit nusquam te mea, ius noster platonem in. Mea an idque minim, sit sale deleniti apeirian et. Omnium legendos tractatos cu mea. Vix in stet dolorem accusamus. Iisque rationibus consetetur in cum, quo unum nulla legere ut. Simul numquam saperet no sit.
+|      </p>
+|      <p>
+|        <amp-img src="https://lh3.googleusercontent.com/5rcQ32ml8E5ONp9f9-Rf78IofLb9QjS5_0mqsY1zEFc=w300-h200-no" width=300 height=200></amp-img>
+|      </p>
+|      <p class="lightbox-text">
+|        Lorem ipsum dolor sit amet, has nisl nihil convenire et, vim at aeque inermis reprehendunt. Propriae tincidunt id nec, elit nusquam te mea, ius noster platonem in. Mea an idque minim, sit sale deleniti apeirian et. Omnium legendos tractatos cu mea. Vix in stet dolorem accusamus. Iisque rationibus consetetur in cum, quo unum nulla legere ut. Simul numquam saperet no sit.
+|      </p>
+|      <p>
+|        <amp-img src="https://lh3.googleusercontent.com/Z4gtm5Bkxyv21Z2PtbTf95Clb9AE4VTR6olbBKYrenM=w300-h200-no" width=300 height=200></amp-img>
+|      </p>
+|      <p class="lightbox-text">
+|        Lorem ipsum dolor sit amet, has nisl nihil convenire et, vim at aeque inermis reprehendunt. Propriae tincidunt id nec, elit nusquam te mea, ius noster platonem in. Mea an idque minim, sit sale deleniti apeirian et. Omnium legendos tractatos cu mea. Vix in stet dolorem accusamus. Iisque rationibus consetetur in cum, quo unum nulla legere ut. Simul numquam saperet no sit.
+|      </p>
+|      <amp-twitter width=486 height=657
+|                   media="(min-width: 401px)"
+|                   layout="responsive"
+|                   data-tweetID="585110598171631616"></amp-twitter>
+|      <amp-youtube
+|          data-videoid="mGENRKrdoGY"
+|          layout="responsive"
+|          width="480" height="270"></amp-youtube>
+|      <p class="lightbox-text">
+|        Lorem ipsum dolor sit amet, has nisl nihil convenire et, vim at aeque inermis reprehendunt. Propriae tincidunt id nec, elit nusquam te mea, ius noster platonem in. Mea an idque minim, sit sale deleniti apeirian et. Omnium legendos tractatos cu mea. Vix in stet dolorem accusamus. Iisque rationibus consetetur in cum, quo unum nulla legere ut. Simul numquam saperet no sit.
+|        Lorem ipsum dolor sit amet, has nisl nihil convenire et, vim at aeque inermis reprehendunt. Propriae tincidunt id nec, elit nusquam te mea, ius noster platonem in. Mea an idque minim, sit sale deleniti apeirian et. Omnium legendos tractatos cu mea. Vix in stet dolorem accusamus. Iisque rationibus consetetur in cum, quo unum nulla legere ut. Simul numquam saperet no sit.
+|        Lorem ipsum dolor sit amet, has nisl nihil convenire et, vim at aeque inermis reprehendunt. Propriae tincidunt id nec, elit nusquam te mea, ius noster platonem in. Mea an idque minim, sit sale deleniti apeirian et. Omnium legendos tractatos cu mea. Vix in stet dolorem accusamus. Iisque rationibus consetetur in cum, quo unum nulla legere ut. Simul numquam saperet no sit.
+|      </p>
+|    </amp-lightbox>
+|  
+|    <button on="tap:lightbox-scrollable">
+|      Open Scrollable Lightbox
+|    </button>
+|  
+|    <h2>Images</h2>
+|    <p>
+|    Responsive (w/srcset, w/image-lightbox)
+|    <p>
+|      <amp-image-lightbox id="imagelightbox1" layout="nodisplay"></amp-image-lightbox>
+|      <amp-img id="img0"
+|          srcset="
+|              https://lh4.googleusercontent.com/-okOlNNHeoOc/VbYyrlFYFII/AAAAAAABYdA/La-3j3c-QQI/w2004-h734-no/PANO_20150726_171347%257E2.jpg 2004w,
+|              https://lh4.googleusercontent.com/-okOlNNHeoOc/VbYyrlFYFII/AAAAAAABYdA/La-3j3c-QQI/w1002-h367-no/PANO_20150726_171347%257E2.jpg 1002w"
+|          width=527 height=193 layout="responsive"
+|          on="tap:imagelightbox1" role="button" tabindex="0"></amp-img>
+|    </p>
+|  
+|    <p>
+|    Fixed
+|    <p>
+|      <amp-img id="img1" src="https://lh4.googleusercontent.com/-okOlNNHeoOc/VbYyrlFYFII/AAAAAAABYdA/La-3j3c-QQI/w2004-h734-no/PANO_20150726_171347%257E2.jpg" width=264 height=96></amp-img>
+|    </p>
+|  
+|    <p>
+|    None
+|    <p class="bordered">
+|      <amp-img id="img2" src="https://lh4.googleusercontent.com/-okOlNNHeoOc/VbYyrlFYFII/AAAAAAABYdA/La-3j3c-QQI/w2004-h734-no/PANO_20150726_171347%257E2.jpg" width=527 height=193 layout="nodisplay"></amp-img>
+|    </p>
+|    <p>
+|      Lorem ipsum dolor sit amet.
+|    </p>
+|    <amp-ad width=300 height=250
+|        type="a9"
+|        data-aax_size="300x250"
+|        data-aax_pubname="abc123"
+|        data-aax_src="302">
+|    </amp-ad>
+|    <p>
+|      Lorem ipsum dolor sit amet, has nisl nihil convenire et, vim at aeque inermis reprehendunt. Propriae tincidunt id nec, elit nusquam te mea, ius noster platonem in. Mea an idque minim, sit sale deleniti apeirian et. Omnium legendos tractatos cu mea. Vix in stet dolorem accusamus. Iisque rationibus consetetur in cum, quo unum nulla legere ut. Simul numquam saperet no sit.
+|    </p>
+|  
+|    <p>
+|      Lorem ipsum dolor sit amet, has nisl nihil convenire et, vim at aeque inermis reprehendunt. Propriae tincidunt id nec, elit nusquam te mea, ius noster platonem in. Mea an idque minim, sit sale deleniti apeirian et. Omnium legendos tractatos cu mea. Vix in stet dolorem accusamus. Iisque rationibus consetetur in cum, quo unum nulla legere ut. Simul numquam saperet no sit.
+|    </p>
+|    <p>
+|      <amp-img id="img3" src="https://lh4.googleusercontent.com/-okOlNNHeoOc/VbYyrlFYFII/AAAAAAABYdA/La-3j3c-QQI/w2004-h734-no/PANO_20150726_171347%257E2.jpg" width=527 height=193 layout="responsive" ></amp-img>
+|    </p>
+|    <p>
+|      <amp-img id="img4" src="https://lh4.googleusercontent.com/-okOlNNHeoOc/VbYyrlFYFII/AAAAAAABYdA/La-3j3c-QQI/w2004-h734-no/PANO_20150726_171347%257E2.jpg" width=527 height=193 layout="responsive" ></amp-img>
+|    </p>
+|    <p>
+|      <amp-img id="img5" src="https://lh4.googleusercontent.com/-okOlNNHeoOc/VbYyrlFYFII/AAAAAAABYdA/La-3j3c-QQI/w2004-h734-no/PANO_20150726_171347%257E2.jpg" width=527 height=193 layout="responsive" ></amp-img>
+|    </p>
+|    <p>
+|      Lorem ipsum dolor sit amet, has nisl nihil convenire et, vim at aeque inermis reprehendunt. Propriae tincidunt id nec, elit nusquam te mea, ius noster platonem in. Mea an idque minim, sit sale deleniti apeirian et. Omnium legendos tractatos cu mea. Vix in stet dolorem accusamus. Iisque rationibus consetetur in cum, quo unum nulla legere ut. Simul numquam saperet no sit.
+|    </p>
+|    <section>
+|      <h1>Media query selection<h1>
+|      <amp-img
+|          media="(min-width: 650px)"
+|          id="img6" src="https://lh5.googleusercontent.com/-vmSp-YN10lA/VcH6S35gAWI/AAAAAAABYqk/6wuA5T3ApSk/w1832-h1376-no/IMG_20150805_131745-ANIMATION.gif"
+|          width=466
+|          height=355 layout="responsive" ></amp-img>
+|      <amp-img
+|          media="(max-width: 649px)"
+|          id="img7" src="https://lh4.googleusercontent.com/-okOlNNHeoOc/VbYyrlFYFII/AAAAAAABYdA/La-3j3c-QQI/w2004-h734-no/PANO_20150726_171347%257E2.jpg"
+|          width=527
+|          height=193 layout="responsive" ></amp-img>
+|    </section>
+|    <p>
+|      <amp-img src="https://lh4.googleusercontent.com/-okOlNNHeoOc/VbYyrlFYFII/AAAAAAABYdA/La-3j3c-QQI/w2004-h734-no/PANO_20150726_171347%257E2.jpg" width=527 height=193 layout="responsive" ></amp-img>
+|    </p>
+|    <p>
+|      <amp-img src="https://lh4.googleusercontent.com/-okOlNNHeoOc/VbYyrlFYFII/AAAAAAABYdA/La-3j3c-QQI/w2004-h734-no/PANO_20150726_171347%257E2.jpg" width=527 height=193 layout="responsive" ></amp-img>
+|    </p>
+|    <p>
+|      <amp-img src="https://lh4.googleusercontent.com/-okOlNNHeoOc/VbYyrlFYFII/AAAAAAABYdA/La-3j3c-QQI/w2004-h734-no/PANO_20150726_171347%257E2.jpg" width=527 height=193 layout="responsive" ></amp-img>
+|    </p>
+|    <p>
+|      Lorem ipsum dolor sit amet, has nisl nihil convenire et, vim at aeque inermis reprehendunt. Propriae tincidunt id nec, elit nusquam te mea, ius noster platonem in. Mea an idque minim, sit sale deleniti apeirian et. Omnium legendos tractatos cu mea. Vix in stet dolorem accusamus. Iisque rationibus consetetur in cum, quo unum nulla legere ut. Simul numquam saperet no sit.
+|    </p>
+|    <p>
+|      <amp-img src="https://lh4.googleusercontent.com/-okOlNNHeoOc/VbYyrlFYFII/AAAAAAABYdA/La-3j3c-QQI/w2004-h734-no/PANO_20150726_171347%257E2.jpg" width=527 height=193 layout="responsive" ></amp-img>
+|    </p>
+|    <p>
+|      <amp-img src="https://lh4.googleusercontent.com/-okOlNNHeoOc/VbYyrlFYFII/AAAAAAABYdA/La-3j3c-QQI/w2004-h734-no/PANO_20150726_171347%257E2.jpg" width=527 height=193 layout="responsive" ></amp-img>
+|    </p>
+|    <p>
+|      <amp-img src="https://lh4.googleusercontent.com/-okOlNNHeoOc/VbYyrlFYFII/AAAAAAABYdA/La-3j3c-QQI/w2004-h734-no/PANO_20150726_171347%257E2.jpg" width=527 height=193 layout="responsive" ></amp-img>
+|    </p>
+|    <h2>Twitter</h2>
+|    <amp-twitter width=486 height=657
+|        media="(min-width: 401px)"
+|        layout="responsive"
+|        data-tweetID="585110598171631616">
+|    </amp-twitter>
+|    <amp-twitter width=306 height=525
+|        media="(max-width: 400px)"
+|        layout="responsive"
+|        data-tweetID="585110598171631616">
+|    </amp-twitter>
+|    <!-- no cards -->
+|    <amp-twitter width=486 height=256
+|        layout="responsive"
+|        data-tweetID="585110598171631616"
+|        data-cards="hidden">
+|    </amp-twitter>
+|    <p>
+|      <amp-img src="https://lh4.googleusercontent.com/-okOlNNHeoOc/VbYyrlFYFII/AAAAAAABYdA/La-3j3c-QQI/w2004-h734-no/PANO_20150726_171347%257E2.jpg" width=527 height=193 layout="responsive" ></amp-img>
+|    </p>
+|    <p>
+|      Lorem ipsum dolor sit amet, has nisl nihil convenire et, vim at aeque inermis reprehendunt. Propriae tincidunt id nec, elit nusquam te mea, ius noster platonem in. Mea an idque minim, sit sale deleniti apeirian et. Omnium legendos tractatos cu mea. Vix in stet dolorem accusamus. Iisque rationibus consetetur in cum, quo unum nulla legere ut. Simul numquam saperet no sit.
+|    </p>
+|    <h2>Instagram</h2>
+|    <amp-instagram
+|      data-shortcode="fBwFP"
+|      width="320"
+|      height="320"
+|      layout="responsive">
+|    </amp-instagram>
+|  
+|    <h2 id="amp-iframe">IFrame</h2>
+|    <amp-iframe width=300 height=300
+|        sandbox="allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox"
+|        layout="responsive"
+|        frameborder="0"
+|        src="https://www.google.com/maps/embed/v1/place?key=AIzaSyDG9YXIhKBhqclZizcSzJ0ROiE0qgVfwzI&q=Alameda,%20CA">
+|    </amp-iframe>
+|    <div>
+|      <a on="tap:AMP.goBack">Go back</a>
+|    </div>
+|    </p>
+|    <amp-ad width=300 height=200
+|        type="adsense"
+|        data-ad-client="ca-pub-9350112648257122">
+|    </amp-ad>
+|  
+|    <h2>SVG</h2>
+|    <svg width="400" height="296" viewBox="1400 500 3000 2500">
+|      <path d="m 3766.9354,1578.1181 c 58.2769,-756.81944 -408.1876,-717.21057 -510.4769,-701.02201 -79.902,12.64545 -239.2559,90.53098 -313.8601,318.92831 -82.3686,252.1683 143.3895,461.6098 259.4436,801.3231 172.8182,640.8523 -882.0196,923.1062 -1227.7959,798.7381 -69.3048,-30.0286 -182.3973,-108.7232 -158.8806,-186.5382 8.5153,-72.4218 -105.5719,-107.3077 -82.4098,-11.1024 95.373,379.694 618.3608,323.5968 1066.1849,144.2115 250.0432,-100.16 489.5859,-347.2474 489.7608,-633.164 -50.7024,-386.8592 -391.2774,-599.5297 -282.7825,-917.5279 173.2946,-330.57664 355.7612,-318.24308 596.6594,-169.4657 82.8022,96.8444 115.4521,181.225 119.5309,313.0092 2.5525,82.4609 -36.2889,260.8703 44.6262,242.61 z" fill="#669900"/>
+|      <path d="m 4416.0026,1455.3672 c 77.2745,23.6811 73.5053,107.3467 75.9575,166.8979 15.3869,149.8221 -6.2292,300.1828 4.2896,450.1688 -8.5601,219.3654 0.7438,438.9849 -1.682,658.4723 -9.842,56.6077 34.5512,148.3936 -55.7836,165.4604 -81.0177,12.4369 -163.7234,-0.9781 -245.5127,3.3739 -248.997,-1.7285 -498.1326,1.9053 -747.01,-2.3009 -86.3231,6.2887 -77.5196,-71.1333 -75.8856,-133.0733 43.1106,-461.6582 -55.107,-895.0067 58.8105,-1302.5316 173.2754,-4.339 702.7558,-6.7657 986.8163,-6.4675 z" fill="#6699ff"/>
+|      <path d="m 3534.2772,1717.8648 c 221.2517,21.2119 572.0499,-17.0571 851.7094,28.1009 -21.0892,135.2035 -26.2108,343.7127 -18.8464,481.1314 0.6629,160.8137 -8.6026,320.1194 -0.3032,497.6322 -118.3583,29.6629 -269.1727,23.1546 -403.9033,17.3782 -156.4796,-6.7087 -363.7832,20.958 -488.8767,-22.9287 16.6915,-141.6537 14.7827,-372.2907 21.3755,-514.5289 7.5082,-162.6119 26.4066,-324.4933 38.8447,-486.7851 z" fill="#3366cc"/>
+|      <path d="m 3889.2766,1650.5266 c 27.7364,23.6886 72.1445,20.4506 101.2331,1.0458 22.3604,-17.6131 19.1236,-56.6446 -8.0767,-68.5575 -51.3171,-39.4426 -125.0811,27.5752 -93.1564,67.5117 z" fill="#ff6600"/>
+|      <path d="m 3985.4115,1806.5993 c -54.1134,86.3413 -120.9065,155.5988 -208.7186,279.6705 -98.9752,111.8484 -122.1792,163.717 136.357,69.2462 175.8375,-36.4294 35.4891,130.704 -15.9848,267.0009 -45.1026,119.4263 -83.2501,196.2986 -92.2725,256.8308 139.8358,-155.934 233.9965,-339.5471 357.0405,-505.614 167.1182,-233.0853 -225.0018,-15.3832 -266.0121,-102.9119 38.3338,-115.9788 97.6167,-173.7877 89.7826,-252.6178 l -0.1926,-11.6047 0,0 z" fill="#ffcc00"/>
+|      <path d="m 4099.9162,1659.9255 c 27.7366,23.6887 72.1447,20.4507 101.2333,1.046 22.3604,-17.6133 19.1235,-56.6446 -8.0768,-68.5575 -51.3168,-39.4426 -125.0812,27.5752 -93.1565,67.5115 z" fill="#ff6600"/>
+|      <path d="m 3681.6605,1651.4038 c 27.7364,23.6888 72.1445,20.4506 101.2332,1.046 22.3603,-17.6132 19.1234,-56.6448 -8.0769,-68.5575 -51.3169,-39.4428 -125.0811,27.5751 -93.1563,67.5115 z" fill="#ff6600"/>
+|      <path d="m 2575.0536,1072.0944 c -41.7949,-215.28999 -198.1073,64.4153 -379.7157,193.092 -133.7465,94.7647 -234.5954,11.3165 -570.0903,133.4228 -401.8972,146.2742 -388.2427,684.9442 -224.4598,986.8548 366.0107,674.6879 1103.0419,131.271 1216.6407,-55.3662 104.6211,-171.8874 330.8926,-138.9279 453.9675,-237.6837 59.7216,-47.9209 -5.9599,-359.9096 -105.7909,-337.7945 -648.2816,143.6118 -380.3137,-629.7889 -390.5515,-682.5252 z" fill="#ffcc00"/>
+|      <path d="m 2058.3207,1381.3517 c -555.3851,-61.9665 -825.72,463.8013 -645.5204,442.4364 185.0637,-21.9416 158.9799,-504.669 310.9149,49.8713 57.2299,208.8816 401.8092,439.7925 494.821,638.6355 11.6767,57.5407 75.9987,46.3975 104.7889,25.124 31.5505,-23.313 18.9107,-80.0105 6.3288,-117.0635 -83.6721,-143.0048 -274.9312,-272.5734 -377.898,-377.9464 -120.8368,-136.4516 -208.1109,-334.9469 -151.0128,-495.0356 34.8137,-61.4683 63.3834,-80.7131 124.7882,-78.1048 55.22,9.7787 202.4079,237.5436 211.6533,157.296 6.1561,-44.3048 11.1555,-235.1689 -78.8639,-245.2129 z" fill="#ff6600"/>
+|      <path d="m 4005.3105,689.39563 c -132.1157,120.32132 -1412.0359,816.95107 -1555.1646,911.30147 160.4961,184.2922 15.234,-12.8488 95.6898,137.9579 550.1675,-329.2476 954.2058,-586.1938 1528.6046,-873.93017 75.1515,-104.89315 -12.1136,-113.30773 -69.1298,-175.3292 z" fill="#3366cc"/>
+|      <path d="m 2194.3681,1352.5268 c 9.2935,-33.3595 115.3351,-96.1488 116.2957,-60.9354 14.1803,519.7676 226.8596,740.1443 346.5092,899.2496 -9.1403,53.8137 -95.4967,108.843 -112.5912,76.6163 -104.516,-105.815 -172.0892,-466.006 -263.1765,-522.0611 -35.4594,-21.8216 12.7645,157.4396 -44.8138,184.0385 -77.4149,35.7627 -124.043,-138.0522 -229.1002,-113.7727 -18.3195,211.0153 555.9431,443.0665 505.2979,529.8185 -23.9237,43.5892 -81.9643,131.8588 -116.5557,78.0317 -146.1854,-207.6808 -213.2253,-245.8824 -420.072,-434.4752 -155.6003,-141.8688 -136.5394,-403.4861 -68.1091,-424.1442 116.1363,-27.4812 191.9444,245.9541 275.2956,188.1784 65.7711,-140.9662 -10.6629,-310.5452 11.0201,-400.5444 z" fill="#669900"/>
+|      <path d="m 1640.1413,1783.8678 c -1.2739,288.86 586.9469,664.0874 521.3165,807.9936 -69.3201,51.7542 -264.7475,48.6232 -223.0496,-59.7663 40.7522,-117.7527 -130.0456,-272.4627 -303.3394,-291.2684 -296.5803,-32.1851 105.9828,212.4171 191.594,291.2294 36.2581,33.3788 125.7201,137.2209 -60.6765,119.5389 -142.0502,-35.061 -243.6721,-174.3502 -325.3694,-295.8032 -78.4159,-116.5746 -186.0507,-483.4195 -48.246,-480.286 125.3372,6.1146 22.5452,202.8366 86.2367,275.034 41.4944,47.0359 443.4581,128.9297 80.3823,-189.183 -157.9532,-138.3924 81.516,-260.2092 81.1514,-177.489 z" fill="#3366cc"/>
+|      <path d="m 4079.5806,868.74488 c -18.4503,-3.3062 -24.5591,-6.34261 -33.5316,-16.66736 -4.696,-5.40376 -13.8197,-14.12548 -20.2749,-19.38163 -15.4956,-12.61776 -67.3382,-71.44012 -79.5473,-90.25706 -5.3049,-8.17621 -11.2871,-16.48111 -13.2935,-18.45531 -3.2617,-3.20909 -2.0572,-6.35995 11.3672,-29.73174 8.2588,-14.37823 17.879,-28.42525 21.3781,-31.21559 5.1887,-4.13699 12.0245,-5.80701 37.0394,-9.04885 16.8723,-2.18653 54.8305,-8.80671 84.352,-14.71151 29.5216,-5.90476 65.0265,-12.78154 78.8997,-15.28165 l 25.2242,-4.54567 23.7713,9.77618 c 62.8275,25.83824 111.7721,65.33019 111.7721,90.18546 1e-4,5.06675 -4.6709,12.80857 -17.366,28.78381 -52.1377,65.60993 -108.3882,110.96089 -146.1569,117.83656 -19.9034,3.62333 -69.5666,5.23515 -83.6338,2.71436 z" fill="#ff6600"/>
+|      <path d="m 2377.3238,1269.2624 c -26.787,279.7212 111.0044,672.201 309.1165,843.6212 80.8729,69.9767 240.8138,-4.026 318.9086,-41.6454 45.2094,-35.9724 35.0313,-101.296 26.1997,-150.9873 -17.4339,-69.7557 -49.832,-121.797 -100.685,-116.1204 -45.4057,5.0682 -68.5356,8.8251 -64.9322,120.9642 1.3601,42.327 -40.4759,93.1741 -89.0657,90.4079 -52.9357,4.327 -75.8994,-38.881 -101.1012,-69.9814 -212.4085,-262.1247 -233.2146,-599.5762 -162.849,-813.093 10.758,-32.6441 5.6189,-86.0919 -34.34,-65.3213 -75.6217,39.3078 -93.8408,124.7689 -101.2517,202.1555 z" fill="#ff6600"/>
+|    </svg>
+|  
+|    <div id="footer">The end. <a href="#top">Back to top.</a></div>
+|  
+|    <amp-pixel src="https://pubads.g.doubleclick.net/activity;dc_iu=/12344/pixel;ord=$RANDOM?"></amp-pixel>
+|  
+|    <amp-font
+|      layout="nodisplay"
+|      font-family="Comic Amp"
+|      timeout="3000"
+|      on-load-remove-class="comic-amp-font-loading"
+|      on-error-remove-class="comic-amp-font-loading"
+|      on-error-add-class="comic-amp-font-missing"
+|      on-load-add-class="comic-amp-font-loaded">
+|    </amp-font>
+|  
+|    <div id="breaker">
+|      <div id="breaking"></div>
+|    </div>
+|  </article>
+|  </body>
+|  </html>

--- a/validator/testdata/feature_tests/extensions.out
+++ b/validator/testdata/feature_tests/extensions.out
@@ -1,4 +1,55 @@
 FAIL
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    This test demonstrates the error message for various extension-related errors.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  
+|    <!-- Extension is included, unused. Produces warning. -->
+|    <script async custom-element='amp-ad'
+|       src='https://cdn.ampproject.org/v0/amp-ad-0.1.js'></script>
+|    <!-- Extension is included, unused. Produces error. -->
+|    <script async custom-element='amp-timeago'
+|       src='https://cdn.ampproject.org/v0/amp-timeago-0.1.js'></script>
+|    <!-- Extension is included, unused. No error or warning -->
+|    <script async custom-element='amp-dynamic-css-classes'
+|       src='https://cdn.ampproject.org/v0/amp-dynamic-css-classes-0.1.js'></script>
+|  </head>
+|  <body>
+|  
+|    <!-- Extension missing. Produces error. -->
+|    <amp-analytics type="googleanalytics">
+>>   ^~~~~~~~~
 feature_tests/extensions.html:42:2 The tag 'amp-analytics' requires including the 'amp-analytics' extension JavaScript. (see https://www.ampproject.org/docs/reference/components/amp-analytics) [AMP_TAG_PROBLEM]
+|      <script type="application/json"></script>
+>>     ^~~~~~~~~
 feature_tests/extensions.html:43:4 The tag 'amp-analytics extension .json script' requires including the 'amp-analytics' extension JavaScript. (see https://www.ampproject.org/docs/reference/components/amp-analytics) [AMP_TAG_PROBLEM]
-feature_tests/extensions.html:48:7 The extension 'amp-timeago' was found on this page, but is unused. Please remove this extension. [AMP_TAG_PROBLEM]
+|    </amp-analytics>
+|  
+|  Hello, world.
+|  </body>
+|  </html>
+>>       ^~~~~~~~~
+feature_tests/extensions.html:48:6 The extension 'amp-timeago' was found on this page, but is unused. Please remove this extension. [AMP_TAG_PROBLEM]

--- a/validator/testdata/feature_tests/forms.out
+++ b/validator/testdata/feature_tests/forms.out
@@ -1,13 +1,164 @@
 FAIL
+|  <!--
+|    Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    This tests looks at specific errors related to forms.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <script async custom-element="amp-form" src="https://cdn.ampproject.org/v0/amp-form-0.1.js"></script>
+|    <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.1.js"></script>
+|  </head>
+|  <body>
+|    <!-- Valid form -->
+|    <form method="post" action-xhr="https://example.com/subscribe" target="_blank"
+|      custom-validation-reporting="as-you-go">
+|      <fieldset>
+|        <label>
+|          <span>Your name</span>
+|          <input id="name" type="text" name="name" required>
+|          <span visible-when-invalid="valueMissing" validation-for="name"></span>
+|        </label>
+|        <label>
+|          <span>Your email</span>
+|          <input type="email" name="email" required>
+|        </label>
+|        <input type="submit" value="Subscribe">
+|      </fieldset>
+|      <div submit-success><template type="amp-mustache">Success</template></div>
+|      <div submit-error>Error</div>
+|    </form>
+|    <!-- More valid tags (datalist and optgroup) -->
+|    <form method="post" action-xhr="https://example.com/subscribe" target="_blank">
+|      <label>Choose a browser from this list:
+|      <input list="browsers" name="myBrowser" /></label>
+|      <datalist id="browsers">
+|        <option value="Chrome">
+|        <option value="Firefox">
+|        <option value="Internet Explorer">
+|        <option value="Opera">
+|        <option value="Safari">
+|        <option value="Microsoft Edge">
+|      </datalist>
+|      <select>
+|        <optgroup label="Group 1">
+|          <option>Option 1.1</option>
+|        </optgroup>
+|        <optgroup label="Group 2">
+|          <option>Option 2.1</option>
+|          <option>Option 2.2</option>
+|        </optgroup>
+|        <optgroup label="Group 3" disabled>
+|          <option>Option 3.1</option>
+|          <option>Option 3.2</option>
+|          <option>Option 3.3</option>
+|        </optgroup>
+|      </select>
+|    </form>
+|    <!-- Invalid form action must not be a relative url -->
+|    <form method="post" action-xhr="/subscribe" target="_blank">
+|      <input type="submit" value="Subscribe">
+|    </form>
+|    <!-- Invalid: form action must be https. -->
+|    <form method="post" action-xhr="http://example.com/subscribe" target="_blank">
+>>   ^~~~~~~~~
 feature_tests/forms.html:82:2 Invalid URL protocol 'http:' for attribute 'action-xhr' in tag 'FORM [method=POST]'. (see https://www.ampproject.org/docs/reference/components/amp-form) [DISALLOWED_HTML]
+|      <input type="submit" value="Subscribe">
+|    </form>
+|    <!-- Invalid: form action must be a non-cdn link. -->
+|    <form method="post" action-xhr="https://cdn.ampproject.org/subscribe" target="_blank">
+|      <input type="submit" value="Subscribe">
+|    </form>
+|    <!-- Invalid: form action must be a non-cdn link -->
+|    <form method="post" action-xhr="https://example-com.cdn.ampproject.org/subscribe" target="_blank">
+|      <input type="submit" value="Subscribe">
+|    </form>
+|    <!-- Invalid: form action must be a non-cdn link -->
+|    <form method="post" action-xhr="https://example-com.amp.cloudflare.com/subscribe" target="_blank">
+|      <input type="submit" value="Subscribe">
+|    </form>
+|    <!-- Valid: disallowed domain checks subdomains, not suffix -->
+|    <form method="post" action-xhr="https://example-cdn.ampproject.org/subscribe" target="_blank">
+|      <input type="submit" value="Subscribe">
+|    </form>
+|    <!-- Invalid: form target must be _blank or _top -->
+|    <form method="post" action-xhr="https://example/subscribe" target="_new">
+>>   ^~~~~~~~~
 feature_tests/forms.html:102:2 The attribute 'target' in tag 'FORM [method=POST]' is set to the invalid value '_new'. (see https://www.ampproject.org/docs/reference/components/amp-form) [DISALLOWED_HTML]
+|      <input type="submit" value="Subscribe">
+|    </form>
+|    <!-- Invalid: input, select, option and textarea must be children of form. -->
+|    <input type="text" name="name">
+|    <select name="language">
+|      <option value="1">English</option>
+|    </select>
+|    <textarea name="comment"></textarea>
+|    <!-- Invalid: input can not be type="button|file|image|password". -->
+|    <form method="post" action-xhr="https://example.com/subscribe" target="_blank">
+|      <input type="button" name="button">
+>>     ^~~~~~~~~
 feature_tests/forms.html:113:4 The attribute 'type' in tag 'input' is set to the invalid value 'button'. (see https://www.ampproject.org/docs/reference/components/amp-form) [DISALLOWED_HTML]
+|      <input type="file" name="file">
+>>     ^~~~~~~~~
 feature_tests/forms.html:114:4 The attribute 'type' in tag 'input' is set to the invalid value 'file'. (see https://www.ampproject.org/docs/reference/components/amp-form) [DISALLOWED_HTML]
+|      <input type="image" name="image">
+>>     ^~~~~~~~~
 feature_tests/forms.html:115:4 The attribute 'type' in tag 'input' is set to the invalid value 'image'. (see https://www.ampproject.org/docs/reference/components/amp-form) [DISALLOWED_HTML]
+|      <input type="password" name="password">
+>>     ^~~~~~~~~
 feature_tests/forms.html:116:4 The attribute 'type' in tag 'input' is set to the invalid value 'password'. (see https://www.ampproject.org/docs/reference/components/amp-form) [DISALLOWED_HTML]
+|    </form>
+|    <!-- Invalid: if validation-for is set on an element, then -->
+|    <!-- visible-when-invalid must also be set and vice versa. -->
+|    <form action="/foo" target="_blank">
+|      <div validation-for="bar"></div>
+>>     ^~~~~~~~~
 feature_tests/forms.html:121:4 The attribute 'visible-when-invalid' in tag 'div' is missing or incorrect, but required by attribute 'validation-for'. [DISALLOWED_HTML]
+|      <div visibile-when-invalid="valueMissing"></div>
+>>     ^~~~~~~~~
 feature_tests/forms.html:122:4 The attribute 'visibile-when-invalid' may not appear in tag 'div'. [DISALLOWED_HTML]
+|    </form>
+|    <!-- Invalid: submit-success must be a div -->
+|    <form method="post" action-xhr="https://example.com/subscribe" target="_blank"
+|      custom-validation-reporting="as-you-go">
+|      <span submit-success><template type="amp-mustache">Success</template></span>
+>>     ^~~~~~~~~
 feature_tests/forms.html:127:4 The attribute 'submit-success' may not appear in tag 'span'. [DISALLOWED_HTML]
+|    </form>
+|    <!-- Invalid: post implies action-xhr -->
+|    <form method="post" action="https://example.com/subscribe" target="_top">
+>>   ^~~~~~~~~
 feature_tests/forms.html:130:2 The attribute 'action' may not appear in tag 'FORM [method=POST]'. (see https://www.ampproject.org/docs/reference/components/amp-form) [DISALLOWED_HTML]
+|    </form>
+|    <!-- Invalid: get implies action -->
+|    <form method="get" action-xhr="https://example.com/subscribe" target="_top">
+>>   ^~~~~~~~~
 feature_tests/forms.html:133:2 The mandatory attribute 'action' is missing in tag 'FORM [method=GET]'. (see https://www.ampproject.org/docs/reference/components/amp-form) [DISALLOWED_HTML]
+|    </form>
+|    <!-- Invalid: get implies action, default method is get -->
+|    <form action-xhr="https://example.com/subscribe" target="_top">
+>>   ^~~~~~~~~
 feature_tests/forms.html:136:2 The mandatory attribute 'action' is missing in tag 'FORM [method=GET]'. (see https://www.ampproject.org/docs/reference/components/amp-form) [DISALLOWED_HTML]
+|    </form>
+|  </body>
+|  </html>

--- a/validator/testdata/feature_tests/incorrect_custom_style.out
+++ b/validator/testdata/feature_tests/incorrect_custom_style.out
@@ -1,8 +1,74 @@
 FAIL
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests what happens when the custom style made by the author
+|    of the document contains things that we disallow.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1,user-scalable=no,minimal-ui">
+|    <style amp-custom>
+>>   ^~~~~~~~~
 feature_tests/incorrect_custom_style.html:27:2 The text (CDATA) inside tag 'style amp-custom' contains 'CSS !important', which is disallowed. (see https://www.ampproject.org/docs/reference/spec#stylesheets) [AUTHOR_STYLESHEET_PROBLEM]
+|      /* These CSS Rules violate essential CSS validation */
+|      @import url("http://somewhere/on/the/internet.css");
+>>     ^~~~~~~~~
 feature_tests/incorrect_custom_style.html:29:4 CSS syntax error in tag 'style amp-custom' - saw invalid at rule '@import'. [AUTHOR_STYLESHEET_PROBLEM]
+|      foo.i-amp-class {}
+|      foo.amp-class {}
+|      foo { b: red !important; }
+|      @viewport (mumble mumble) { }
+>>     ^~~~~~~~~
 feature_tests/incorrect_custom_style.html:33:4 CSS syntax error in tag 'style amp-custom' - saw invalid at rule '@viewport'. [AUTHOR_STYLESHEET_PROBLEM]
+|      @media (whatever) { @notallowednested }
+>>                         ^~~~~~~~~
 feature_tests/incorrect_custom_style.html:34:24 CSS syntax error in tag 'style amp-custom' - saw invalid at rule '@notallowednested'. [AUTHOR_STYLESHEET_PROBLEM]
+|  
+|      /* some tests for url verification - images */
+|      foo { background-image: url('') }  /* allowed for now */
+|      foo { background-image: url('invalid://invalid.com/1.jpg') }
+>>                             ^~~~~~~~~
 feature_tests/incorrect_custom_style.html:38:28 CSS syntax error in tag 'style amp-custom' - invalid url protocol 'invalid:'. (see https://www.ampproject.org/docs/reference/spec#stylesheets) [AUTHOR_STYLESHEET_PROBLEM]
+|      foo { background-image: url('https://valid.com/1.jpg') }
+|      foo { background-image: url('http://valid.com/1.jpg') }
+|      foo { background-image: url('absolute://disallow.com/soon.jpg') }
+|      foo { background-image: url('://valid.jpg') }
+|      foo { background-image: url('valid.jpg') }
+|  
+|      /* some tests for url verification - fonts */
+|      @font-face { src: url(''); } /* allowed for now */
+|      @font-face { src: url('invalid://invalid.com/1.ttf') }
+>>                       ^~~~~~~~~
 feature_tests/incorrect_custom_style.html:47:22 CSS syntax error in tag 'style amp-custom' - invalid url protocol 'invalid:'. (see https://www.ampproject.org/docs/reference/spec#stylesheets) [AUTHOR_STYLESHEET_PROBLEM]
+|      @font-face { src: url('https://valid.com/1.ttf') }
+|      @font-face { src: url('http://valid.com/1.ttf') }
+|      @font-face { src: url('absolute://invalid.com/1.ttf') }
+>>                       ^~~~~~~~~
 feature_tests/incorrect_custom_style.html:50:22 CSS syntax error in tag 'style amp-custom' - invalid url protocol 'absolute:'. (see https://www.ampproject.org/docs/reference/spec#stylesheets) [AUTHOR_STYLESHEET_PROBLEM]
+|      @font-face { src: url('://valid.ttf') }
+|      @font-face { src: url('valid.ttf') }
+|    </style>
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script src="https://cdn.ampproject.org/v0.js" async></script>
+|  </head>
+|  <body>
+|  </body>
+|  </html>

--- a/validator/testdata/feature_tests/incorrect_mandatory_style.out
+++ b/validator/testdata/feature_tests/incorrect_mandatory_style.out
@@ -1,3 +1,38 @@
 FAIL
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests what happens when the contents of the mandatory style tags
+|    are specified incorrectly - as in, wrong cdata content which
+|    doesn't match the spec.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1,user-scalable=no,minimal-ui">
+|    <style amp-boilerplate>incorrect cdata</style><noscript><style amp-boilerplate>incorrect cdata</style></noscript>
+>>   ^~~~~~~~~
 feature_tests/incorrect_mandatory_style.html:28:2 The mandatory text (CDATA) inside tag 'head > style[amp-boilerplate]' is missing or incorrect. (see https://github.com/ampproject/amphtml/blob/master/spec/amp-boilerplate.md) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
+>>                                                           ^~~~~~~~~
 feature_tests/incorrect_mandatory_style.html:28:58 The mandatory text (CDATA) inside tag 'noscript > style[amp-boilerplate]' is missing or incorrect. (see https://github.com/ampproject/amphtml/blob/master/spec/amp-boilerplate.md) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|  <body>
+|  </body>
+|  </html>

--- a/validator/testdata/feature_tests/javascript_xss.out
+++ b/validator/testdata/feature_tests/javascript_xss.out
@@ -1,5 +1,41 @@
 FAIL
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1,user-scalable=no,minimal-ui">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script src="https://cdn.ampproject.org/v0.js" async></script>
+|  </head>
+|  <body>
+|    <a href="javascript:alert('boo')">Click here to see an important message.</a>
+>>   ^~~~~~~~~
 feature_tests/javascript_xss.html:27:2 Invalid URL protocol 'javascript:' for attribute 'href' in tag 'a'. (see https://www.ampproject.org/docs/reference/spec#links) [DISALLOWED_HTML]
+|    <a href="JavaScript:alert('boo')">It's CAse inSenSitive.</a>
+>>   ^~~~~~~~~
 feature_tests/javascript_xss.html:28:2 Invalid URL protocol 'javascript:' for attribute 'href' in tag 'a'. (see https://www.ampproject.org/docs/reference/spec#links) [DISALLOWED_HTML]
+|    <a href="vbscript:bar">vbscript is also dangerous</a>
+>>   ^~~~~~~~~
 feature_tests/javascript_xss.html:29:2 Invalid URL protocol 'vbscript:' for attribute 'href' in tag 'a'. (see https://www.ampproject.org/docs/reference/spec#links) [DISALLOWED_HTML]
+|    <a href="data:baz">data urls have some risks</a>
+>>   ^~~~~~~~~
 feature_tests/javascript_xss.html:30:2 Invalid URL protocol 'data:' for attribute 'href' in tag 'a'. (see https://www.ampproject.org/docs/reference/spec#links) [DISALLOWED_HTML]
+|  </body>
+|  </html>

--- a/validator/testdata/feature_tests/lang_attr.out
+++ b/validator/testdata/feature_tests/lang_attr.out
@@ -1,1 +1,33 @@
 PASS
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!doctype html>
+|  <!--
+|    Test Description:
+|    Tests that we allow the lang attr to be set on the document.
+|  -->
+|  <html ⚡ lang="fr">
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|  <body>
+|  Hello, world.
+|  </body>
+|  </html>

--- a/validator/testdata/feature_tests/link_meta_values.out
+++ b/validator/testdata/feature_tests/link_meta_values.out
@@ -1,6 +1,66 @@
 FAIL
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1,user-scalable=no,minimal-ui">
+|    <!--
+|      Test Description:
+|      Tests that various link and meta tags are blacklisted/whitelisted as expected.
+|    -->
+|    <meta name="foo" content="bar">
+|    <meta property="foo" content="bar">
+|    <meta name="amp-experiment-token" content="HfmyLgNLmblRg3Alqy164Vywr">
+|    <link rel="manifest" href="foo">
+|    <link rel="manifest foo" href="foo">
+>>   ^~~~~~~~~
 feature_tests/link_meta_values.html:30:2 The attribute 'rel' in tag 'link rel=' is set to the invalid value 'manifest foo'. (see https://www.ampproject.org/docs/reference/spec#html-tags) [DISALLOWED_HTML]
+|    <link rel="shortcut icon" type="a" href="b" sizes="c">
+|    <link rel="author" href="me">
+|    <link rel="DCTERMS.any" href="foo">
+|  
+|    <meta name="content-disposition" content="any">
+>>   ^~~~~~~~~
 feature_tests/link_meta_values.html:35:2 The attribute 'name' in tag 'meta name= and content=' is set to the invalid value 'content-disposition'. [DISALLOWED_HTML]
+|    <meta name=viewport content=invalid>
+>>   ^~~~~~~~~
 feature_tests/link_meta_values.html:36:2 The property 'minimum-scale' is missing from attribute 'content' in tag 'meta name=viewport'. (see https://www.ampproject.org/docs/reference/spec#required-markup) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
+>>   ^~~~~~~~~
 feature_tests/link_meta_values.html:36:2 The property 'width' is missing from attribute 'content' in tag 'meta name=viewport'. (see https://www.ampproject.org/docs/reference/spec#required-markup) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
+|    <link rel="unknown" href="foo">
+|  
+|    <link rel="comment cite map" href="foo">
+|  
+|    <link itemprop="foo" href="bar">
+|  
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  
+|    <!-- Invalid as we need some additional attributes e.g. "rel=canonical" -->
+|    <link href="foo">
+>>   ^~~~~~~~~
 feature_tests/link_meta_values.html:47:2 The mandatory attribute 'rel' is missing in tag 'link rel='. (see https://www.ampproject.org/docs/reference/spec#html-tags) [DISALLOWED_HTML]
+|  </head>
+|  <body>
+|  Hello, world.
+|  
+|    <a href="http://example.com/" rel="canonical">OK</a>
+|  
+|  </body>
+|  </html>

--- a/validator/testdata/feature_tests/mandatory_dimensions.out
+++ b/validator/testdata/feature_tests/mandatory_dimensions.out
@@ -1,52 +1,253 @@
 FAIL
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    This test validates the complex rules around mandatory dimensions for
+|    responsive amp custom elements. See
+|    https://github.com/ampproject/amphtml/blob/master/spec/amp-html-layout.md.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1,user-scalable=no,minimal-ui">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|  <body>
+|  
+|    <!-- Valid Examples -->
+|      <!-- Layout of responsive/fixed with width/height -->
+|      <amp-img src="img" layout="responsive" width="42" height="42"></amp-img>
+|      <amp-img src="img" layout="fixed" width="42" height="42"></amp-img>
+|  
+|      <!-- Layout of nodisplay/fill with/without width/height -->
+|      <amp-img src="img" layout="nodisplay" width="42" height="42"></amp-img>
+|      <amp-img src="img" layout="fill" width="42" height="42"></amp-img>
+|      <amp-img src="img" layout="nodisplay"></amp-img>
+|      <amp-img src="img" layout="fill"></amp-img>
+|  
+|      <!-- Layout of nodisplay/fill with partial width/height.
+|           These should not validate, but currently do. -->
+|      <amp-img src="img" layout="nodisplay" width="42"></amp-img>
+|      <amp-img src="img" layout="fill" height="42"></amp-img>
+|  
+|      <!-- Missing layout implies layout="fixed" when width and height are set. -->
+|      <amp-img src="img" width="42" height="42"></amp-img>
+|  
+|      <!-- fixed-height layout allows width=auto. -->
+|      <amp-img layout="fixed-height" src="img" width="auto" height="42"></amp-img>
+|      <amp-img layout="fixed-height" src="img" height="42"></amp-img>
+|  
+|      <!-- Missing layout implies layout="fixed-height" when height is set. -->
+|      <amp-img src="img" width="auto" height="42"></amp-img>
+|      <amp-img src="img" height="42"></amp-img>
+|  
+|      <!-- It's OK to have inconsistent units for layout="fixed" -->
+|      <amp-img src="img" layout="fixed" width="42px" height="42rem">
+|  
+|  
+|      <!-- throw in some fully optional attrs -->
+|      <amp-img src="img" width=42 height=42 placeholder=""></amp-img>
+|      <amp-img src="img" layout="nodisplay" alt="" attribution=""></amp-img>
+|      <amp-img src="img" layout="fixed" width="42" height="42" on="" media="">
+|      </amp-img>
+|  
+|      <!-- amp-audio/pixel/lightbox have relaxed width/heigh constraints -->
+|      <amp-audio src="https://example.com/audio" layout="fixed" width="42"></amp-audio>
+>>     ^~~~~~~~~
 feature_tests/mandatory_dimensions.html:71:4 The tag 'amp-audio' requires including the 'amp-audio' extension JavaScript. (see https://www.ampproject.org/docs/reference/components/amp-audio) [AMP_TAG_PROBLEM]
+|      <amp-audio src="https://example.com/audio" layout="fixed"></amp-audio>
+>>     ^~~~~~~~~
 feature_tests/mandatory_dimensions.html:72:4 The tag 'amp-audio' requires including the 'amp-audio' extension JavaScript. (see https://www.ampproject.org/docs/reference/components/amp-audio) [AMP_TAG_PROBLEM]
+|      <amp-pixel src="https://example.com/pixel" layout="fixed" width="42"></amp-pixel>
+|      <amp-pixel src="https://example.com/pixel" layout="fixed"></amp-pixel>
+|      <amp-lightbox layout="nodisplay" width="42"></amp-lightbox>
+>>     ^~~~~~~~~
 feature_tests/mandatory_dimensions.html:75:4 The tag 'amp-lightbox' requires including the 'amp-lightbox' extension JavaScript. (see https://www.ampproject.org/docs/reference/components/amp-lightbox) [AMP_TAG_PROBLEM]
+|      <amp-lightbox layout="nodisplay"></amp-lightbox>
+>>     ^~~~~~~~~
 feature_tests/mandatory_dimensions.html:76:4 The tag 'amp-lightbox' requires including the 'amp-lightbox' extension JavaScript. (see https://www.ampproject.org/docs/reference/components/amp-lightbox) [AMP_TAG_PROBLEM]
+|  
+|      <!-- src or srcset or both are all valid -->
+|      <amp-img width="42" height="42" src="img"></amp-img>
+|      <amp-img width="42" height="42" srcset="img 1x, img2 2x"></amp-img>
+|      <amp-img width="42" height="42" src="img" srcset="img 1x, img2 2x"></amp-img>
+|      <amp-anim width="42" height="42" src="anim"></amp-anim>
+>>     ^~~~~~~~~
 feature_tests/mandatory_dimensions.html:82:4 The tag 'amp-anim' requires including the 'amp-anim' extension JavaScript. (see https://www.ampproject.org/docs/reference/components/amp-anim) [AMP_TAG_PROBLEM]
+|      <amp-anim width="42" height="42" srcset="img 1x, img2 2x"></amp-anim>
+>>     ^~~~~~~~~
 feature_tests/mandatory_dimensions.html:83:4 The tag 'amp-anim' requires including the 'amp-anim' extension JavaScript. (see https://www.ampproject.org/docs/reference/components/amp-anim) [AMP_TAG_PROBLEM]
+|      <amp-anim width="42" height="42" src="anim" srcset="img 1x, img2 2x"></amp-anim>
+>>     ^~~~~~~~~
 feature_tests/mandatory_dimensions.html:84:4 The tag 'amp-anim' requires including the 'amp-anim' extension JavaScript. (see https://www.ampproject.org/docs/reference/components/amp-anim) [AMP_TAG_PROBLEM]
+|  
+|      <!-- src optional -->
+|      <amp-audio src="https://example.com/audio"></amp-audio>
+>>     ^~~~~~~~~
 feature_tests/mandatory_dimensions.html:87:4 The tag 'amp-audio' requires including the 'amp-audio' extension JavaScript. (see https://www.ampproject.org/docs/reference/components/amp-audio) [AMP_TAG_PROBLEM]
+|      <amp-audio></amp-audio>
+>>     ^~~~~~~~~
 feature_tests/mandatory_dimensions.html:88:4 The tag 'amp-audio' requires including the 'amp-audio' extension JavaScript. (see https://www.ampproject.org/docs/reference/components/amp-audio) [AMP_TAG_PROBLEM]
+|      <amp-video width="42" height="42" src="https://example.com/video"></amp-video>
+|      <amp-video width="42" height="42"></amp-video>
+|      <amp-ad width="42" height="42" type="" src="https://example.com/ad"></amp-ad>
+|      <amp-ad width="42" height="42" type=""></amp-ad>
+|  
+|      <!-- src or srcdoc required -->
+|      <amp-iframe width="42" height="42" src="https://example.com/iframe"></amp-iframe>
+>>     ^~~~~~~~~
 feature_tests/mandatory_dimensions.html:95:4 The tag 'amp-iframe' requires including the 'amp-iframe' extension JavaScript. (see https://www.ampproject.org/docs/reference/components/amp-iframe) [AMP_TAG_PROBLEM]
+|      <amp-iframe width="42" height="42" srcdoc="<p>Hello, world!</p>"></amp-iframe>
+>>     ^~~~~~~~~
 feature_tests/mandatory_dimensions.html:96:4 The tag 'amp-iframe' requires including the 'amp-iframe' extension JavaScript. (see https://www.ampproject.org/docs/reference/components/amp-iframe) [AMP_TAG_PROBLEM]
+|      <amp-pixel src="https://example.com/pixel"></amp-pixel>
+|  
+|      <!-- disallow a src or srcset -->
+|      <amp-fit-text height="42"></amp-fit-text>
+>>     ^~~~~~~~~
 feature_tests/mandatory_dimensions.html:100:4 The tag 'amp-fit-text' requires including the 'amp-fit-text' extension JavaScript. (see https://www.ampproject.org/docs/reference/components/amp-fit-text) [AMP_TAG_PROBLEM]
+|      <amp-carousel height="42"></amp-carousel>
+>>     ^~~~~~~~~
 feature_tests/mandatory_dimensions.html:101:4 The tag 'amp-carousel' requires including the 'amp-carousel' extension JavaScript. (see https://www.ampproject.org/docs/reference/components/amp-carousel) [AMP_TAG_PROBLEM]
+|      <amp-youtube data-videoid="dQw4w9WgXcQ" height="42"></amp-youtube>
+>>     ^~~~~~~~~
 feature_tests/mandatory_dimensions.html:102:4 The tag 'amp-youtube' requires including the 'amp-youtube' extension JavaScript. (see https://www.ampproject.org/docs/reference/components/amp-youtube) [AMP_TAG_PROBLEM]
+|      <amp-twitter data-tweetid="" height="42"></amp-twitter>
+>>     ^~~~~~~~~
 feature_tests/mandatory_dimensions.html:103:4 The tag 'amp-twitter' requires including the 'amp-twitter' extension JavaScript. (see https://www.ampproject.org/docs/reference/components/amp-twitter) [AMP_TAG_PROBLEM]
+|      <amp-instagram data-shortcode="" height="42"></amp-instagram>
+>>     ^~~~~~~~~
 feature_tests/mandatory_dimensions.html:104:4 The tag 'amp-instagram' requires including the 'amp-instagram' extension JavaScript. (see https://www.ampproject.org/docs/reference/components/amp-instagram) [AMP_TAG_PROBLEM]
+|      <amp-lightbox layout="nodisplay"></amp-lightbox>
+>>     ^~~~~~~~~
 feature_tests/mandatory_dimensions.html:105:4 The tag 'amp-lightbox' requires including the 'amp-lightbox' extension JavaScript. (see https://www.ampproject.org/docs/reference/components/amp-lightbox) [AMP_TAG_PROBLEM]
+|    <!-- /Valid Examples -->
+|  
+|    <!-- Invalid Examples -->
+|      <!-- Container layout isn't supported by amp-img. -->
+|      <amp-img src="img" layout="container">
+>>     ^~~~~~~~~
 feature_tests/mandatory_dimensions.html:110:4 The specified layout 'CONTAINER' is not supported by tag 'amp-img'. (see https://www.ampproject.org/docs/reference/components/amp-img) [AMP_LAYOUT_PROBLEM]
+|      <amp-img src="img" layout="container" width="42" height="42">
+>>     ^~~~~~~~~
 feature_tests/mandatory_dimensions.html:111:4 The specified layout 'CONTAINER' is not supported by tag 'amp-img'. (see https://www.ampproject.org/docs/reference/components/amp-img) [AMP_LAYOUT_PROBLEM]
+|      <amp-img src="img">
+>>     ^~~~~~~~~
 feature_tests/mandatory_dimensions.html:112:4 The implied layout 'CONTAINER' is not supported by tag 'amp-img'. (see https://www.ampproject.org/docs/reference/components/amp-img) [AMP_LAYOUT_PROBLEM]
+|  
+|      <!-- Layout of responsive/fixed without width/height -->
+|      <amp-img src="img" layout="responsive">
+>>     ^~~~~~~~~
 feature_tests/mandatory_dimensions.html:115:4 The mandatory attribute 'height' is missing in tag 'amp-img'. (see https://www.ampproject.org/docs/reference/components/amp-img) [AMP_LAYOUT_PROBLEM]
+|      <amp-img src="img" layout="fixed">
+>>     ^~~~~~~~~
 feature_tests/mandatory_dimensions.html:116:4 The mandatory attribute 'height' is missing in tag 'amp-img'. (see https://www.ampproject.org/docs/reference/components/amp-img) [AMP_LAYOUT_PROBLEM]
+|      <amp-img src="img" layout="responsive" width="42">
+>>     ^~~~~~~~~
 feature_tests/mandatory_dimensions.html:117:4 The mandatory attribute 'height' is missing in tag 'amp-img'. (see https://www.ampproject.org/docs/reference/components/amp-img) [AMP_LAYOUT_PROBLEM]
+|      <amp-img src="img" layout="fixed" height="42">
+>>     ^~~~~~~~~
 feature_tests/mandatory_dimensions.html:118:4 The mandatory attribute 'width' is missing in tag 'amp-img'. (see https://www.ampproject.org/docs/reference/components/amp-img) [AMP_LAYOUT_PROBLEM]
+|      <amp-img src="img" layout="fixed" height="auto">
+>>     ^~~~~~~~~
 feature_tests/mandatory_dimensions.html:119:4 The attribute 'height' in tag 'amp-img' is set to the invalid value 'auto'. (see https://www.ampproject.org/docs/reference/components/amp-img) [AMP_LAYOUT_PROBLEM]
+|      <amp-img src="img" layout="fixed" width="auto" height="42">
+>>     ^~~~~~~~~
 feature_tests/mandatory_dimensions.html:120:4 The attribute 'width' in tag 'amp-img' is set to the invalid value 'auto'. (see https://www.ampproject.org/docs/reference/components/amp-img) [AMP_LAYOUT_PROBLEM]
+|  
+|      <!-- Inconsistent units -->
+|      <amp-img src="img" layout="responsive" width="42px" height="42rem">
+>>     ^~~~~~~~~
 feature_tests/mandatory_dimensions.html:123:4 Inconsistent units for width and height in tag 'amp-img' - width is specified in 'px' whereas height is specified in 'rem'. (see https://www.ampproject.org/docs/reference/components/amp-img) [AMP_LAYOUT_PROBLEM]
+|  
+|      <!-- src or srcset or both are all valid -->
+|      <amp-img width="42" height="42"></amp-img>
+>>     ^~~~~~~~~
 feature_tests/mandatory_dimensions.html:126:4 The mandatory attribute 'src' is missing in tag 'amp-img'. (see https://www.ampproject.org/docs/reference/components/amp-img) [AMP_TAG_PROBLEM]
+|      <amp-anim width="42" height="42"></amp-anim>
+>>     ^~~~~~~~~
 feature_tests/mandatory_dimensions.html:127:4 The mandatory attribute 'src' is missing in tag 'amp-anim'. (see https://www.ampproject.org/docs/reference/components/amp-anim) [AMP_TAG_PROBLEM]
+>>     ^~~~~~~~~
 feature_tests/mandatory_dimensions.html:127:4 The tag 'amp-anim' requires including the 'amp-anim' extension JavaScript. (see https://www.ampproject.org/docs/reference/components/amp-anim) [AMP_TAG_PROBLEM]
+|  
+|      <!-- src optional -->
+|      <amp-audio srcset="img 1x, img2 2x"></amp-audio>
+>>     ^~~~~~~~~
 feature_tests/mandatory_dimensions.html:130:4 The attribute 'srcset' may not appear in tag 'amp-audio'. (see https://www.ampproject.org/docs/reference/components/amp-audio) [AMP_TAG_PROBLEM]
+>>     ^~~~~~~~~
 feature_tests/mandatory_dimensions.html:130:4 The tag 'amp-audio' requires including the 'amp-audio' extension JavaScript. (see https://www.ampproject.org/docs/reference/components/amp-audio) [AMP_TAG_PROBLEM]
+|      <amp-ad height="42" type="" srcset="img 1x, img2 2x"></amp-ad>
+>>     ^~~~~~~~~
 feature_tests/mandatory_dimensions.html:131:4 The attribute 'srcset' may not appear in tag 'amp-ad'. (see https://www.ampproject.org/docs/reference/components/amp-ad) [AMP_TAG_PROBLEM]
+|  
+|      <!-- src or srcdoc required -->
+|      <amp-iframe height="42"></amp-iframe>
+>>     ^~~~~~~~~
 feature_tests/mandatory_dimensions.html:134:4 The tag 'amp-iframe' is missing a mandatory attribute - pick one of ['src', 'srcdoc']. (see https://www.ampproject.org/docs/reference/components/amp-iframe) [AMP_TAG_PROBLEM]
+>>     ^~~~~~~~~
 feature_tests/mandatory_dimensions.html:134:4 The tag 'amp-iframe' requires including the 'amp-iframe' extension JavaScript. (see https://www.ampproject.org/docs/reference/components/amp-iframe) [AMP_TAG_PROBLEM]
+|      <amp-pixel></amp-pixel>
+>>     ^~~~~~~~~
 feature_tests/mandatory_dimensions.html:135:4 The mandatory attribute 'src' is missing in tag 'amp-pixel'. (see https://www.ampproject.org/docs/reference/components/amp-pixel) [AMP_TAG_PROBLEM]
+|  
+|      <!-- disallow a src or srcset -->
+|      <amp-fit-text height="42" src="fit-text"></amp-fit-text>
+>>     ^~~~~~~~~
 feature_tests/mandatory_dimensions.html:138:4 The attribute 'src' may not appear in tag 'amp-fit-text'. (see https://www.ampproject.org/docs/reference/components/amp-fit-text) [AMP_TAG_PROBLEM]
+>>     ^~~~~~~~~
 feature_tests/mandatory_dimensions.html:138:4 The tag 'amp-fit-text' requires including the 'amp-fit-text' extension JavaScript. (see https://www.ampproject.org/docs/reference/components/amp-fit-text) [AMP_TAG_PROBLEM]
+|      <amp-carousel height="42" src="carousel"></amp-carousel>
+>>     ^~~~~~~~~
 feature_tests/mandatory_dimensions.html:139:4 The attribute 'src' may not appear in tag 'amp-carousel'. (see https://www.ampproject.org/docs/reference/components/amp-carousel) [AMP_TAG_PROBLEM]
+>>     ^~~~~~~~~
 feature_tests/mandatory_dimensions.html:139:4 The tag 'amp-carousel' requires including the 'amp-carousel' extension JavaScript. (see https://www.ampproject.org/docs/reference/components/amp-carousel) [AMP_TAG_PROBLEM]
+|      <amp-youtube height="42" data-videoid="dQw4w9WgXcQ" srcset="img 1x, img2 2x"></amp-youtube>
+>>     ^~~~~~~~~
 feature_tests/mandatory_dimensions.html:140:4 The attribute 'srcset' may not appear in tag 'amp-youtube'. (see https://www.ampproject.org/docs/reference/components/amp-youtube) [AMP_TAG_PROBLEM]
+>>     ^~~~~~~~~
 feature_tests/mandatory_dimensions.html:140:4 The tag 'amp-youtube' requires including the 'amp-youtube' extension JavaScript. (see https://www.ampproject.org/docs/reference/components/amp-youtube) [AMP_TAG_PROBLEM]
+|      <amp-twitter height="42" data-tweetid="" srcset="img 1x, img2 2x"></amp-twitter>
+>>     ^~~~~~~~~
 feature_tests/mandatory_dimensions.html:141:4 The attribute 'srcset' may not appear in tag 'amp-twitter'. (see https://www.ampproject.org/docs/reference/components/amp-twitter) [AMP_TAG_PROBLEM]
+>>     ^~~~~~~~~
 feature_tests/mandatory_dimensions.html:141:4 The tag 'amp-twitter' requires including the 'amp-twitter' extension JavaScript. (see https://www.ampproject.org/docs/reference/components/amp-twitter) [AMP_TAG_PROBLEM]
+|      <amp-instagram height="42" data-shortcode="" srcset="img 1x, img2 2x"></amp-instagram>
+>>     ^~~~~~~~~
 feature_tests/mandatory_dimensions.html:142:4 The attribute 'srcset' may not appear in tag 'amp-instagram'. (see https://www.ampproject.org/docs/reference/components/amp-instagram) [AMP_TAG_PROBLEM]
+>>     ^~~~~~~~~
 feature_tests/mandatory_dimensions.html:142:4 The tag 'amp-instagram' requires including the 'amp-instagram' extension JavaScript. (see https://www.ampproject.org/docs/reference/components/amp-instagram) [AMP_TAG_PROBLEM]
+|      <amp-lightbox layout="nodisplay" src="lightbox"></amp-lightbox>
+>>     ^~~~~~~~~
 feature_tests/mandatory_dimensions.html:143:4 The attribute 'src' may not appear in tag 'amp-lightbox'. (see https://www.ampproject.org/docs/reference/components/amp-lightbox) [AMP_TAG_PROBLEM]
+>>     ^~~~~~~~~
 feature_tests/mandatory_dimensions.html:143:4 The tag 'amp-lightbox' requires including the 'amp-lightbox' extension JavaScript. (see https://www.ampproject.org/docs/reference/components/amp-lightbox) [AMP_TAG_PROBLEM]
+|  
+|      <!-- Not-whitelisted attributes -->
+|      <amp-img height="42" src="img" foo="bar"></amp-img>
+>>     ^~~~~~~~~
 feature_tests/mandatory_dimensions.html:146:4 The attribute 'foo' may not appear in tag 'amp-img'. (see https://www.ampproject.org/docs/reference/components/amp-img) [AMP_TAG_PROBLEM]
-feature_tests/mandatory_dimensions.html:150:7 The tag 'amp-ad extension .js script' is missing or incorrect, but required by 'amp-ad'. This will soon be an error. (see https://www.ampproject.org/docs/reference/components/amp-ad) [DEPRECATION]
-feature_tests/mandatory_dimensions.html:150:7 The tag 'amp-video extension .js script' is missing or incorrect, but required by 'amp-video'. This will soon be an error. (see https://www.ampproject.org/docs/reference/components/amp-video) [DEPRECATION]
+|    <!-- /Invalid Examples -->
+|  
+|  </body>
+|  </html>
+>>       ^~~~~~~~~
+feature_tests/mandatory_dimensions.html:150:6 The tag 'amp-ad extension .js script' is missing or incorrect, but required by 'amp-ad'. This will soon be an error. (see https://www.ampproject.org/docs/reference/components/amp-ad) [DEPRECATION]
+>>       ^~~~~~~~~
+feature_tests/mandatory_dimensions.html:150:6 The tag 'amp-video extension .js script' is missing or incorrect, but required by 'amp-video'. This will soon be an error. (see https://www.ampproject.org/docs/reference/components/amp-video) [DEPRECATION]

--- a/validator/testdata/feature_tests/manufactured_body.out
+++ b/validator/testdata/feature_tests/manufactured_body.out
@@ -1,2 +1,36 @@
 FAIL
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    This test shows what happens if elements allowed only in the body are placed
+|    before the body tag.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <script async custom-element="amp-analytics"
+|        src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
+|  </head>
+|  <amp-analytics></amp-analytics>
+>> ^~~~~~~~~
 feature_tests/manufactured_body.html:32:0 Tag or text which is only allowed inside the body section found outside of the body section. [DISALLOWED_HTML]
+|  </html>

--- a/validator/testdata/feature_tests/mask-icon.out
+++ b/validator/testdata/feature_tests/mask-icon.out
@@ -1,1 +1,37 @@
 PASS
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Test for `link rel="mask-icon` tagsepc, due to the non-standard color attr.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  
+|    <link rel="mask-icon" href="https://example.com/website_icon.svg" color="red">
+|    <link rel="mask-icon" href="https://example.com/website_icon.svg">
+|  
+|  </head>
+|  <body>
+|  Hello, world.
+|  </body>
+|  </html>

--- a/validator/testdata/feature_tests/minimum_valid_amp.out
+++ b/validator/testdata/feature_tests/minimum_valid_amp.out
@@ -1,1 +1,34 @@
 PASS
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    This is the minimum valid AMP document; it includes all of the required
+|    fields from the spec, but nothing else.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|  <body>
+|  Hello, world.
+|  </body>
+|  </html>

--- a/validator/testdata/feature_tests/multiple_body_tags.out
+++ b/validator/testdata/feature_tests/multiple_body_tags.out
@@ -1,2 +1,37 @@
 FAIL
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests errors generated for multiple body tags. This is useful because
+|    body tags are treated special - the attributes from all of them are merged
+|    into the first one. However, for AMPHTML only a single BODY tag is allowed.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|  <body class="foo">
+>> ^~~~~~~~~
 feature_tests/multiple_body_tags.html:31:0 The tag 'BODY' appears more than once in the document. [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
+|    <body class="bar" style="background-color:red"></body>
+|  </body>
+|  </html>

--- a/validator/testdata/feature_tests/multiple_body_tags_2.out
+++ b/validator/testdata/feature_tests/multiple_body_tags_2.out
@@ -1,2 +1,39 @@
 FAIL
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests errors generated for multiple body tags. This is useful because
+|    body tags are treated special - the attributes from all of them are merged
+|    into the first one. However, for AMPHTML only a single BODY tag is allowed.
+|    In this second variant for the test we show that the error is emitted
+|    even if the attribute names and values of the two body tags agree.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|  <body class="foo">
+>> ^~~~~~~~~
 feature_tests/multiple_body_tags_2.html:33:0 The tag 'BODY' appears more than once in the document. [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
+|    <body class="foo"></body>
+|  </body>
+|  </html>

--- a/validator/testdata/feature_tests/multiple_body_tags_3.out
+++ b/validator/testdata/feature_tests/multiple_body_tags_3.out
@@ -1,9 +1,58 @@
 FAIL
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests errors generated for multiple body tags. This is useful because
+|    body tags are treated special - the attributes from all of them are merged
+|    into the first one. However, for AMPHTML only a single BODY tag is allowed.
+|    In this second variant for the test we show that multiple BODY tags are
+|    detected when the body is started by stray text in the head.
+|    In which case, the manufactured boy tag message also appears.
+|    This is important because otherwise the user might be confused.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport"
+|          content="width=device-width,minimum-scale=1">some stray text
+>>                                                      ^~~~~~~~~
 feature_tests/multiple_body_tags_3.html:32:53 Tag or text which is only allowed inside the body section found outside of the body section. [DISALLOWED_HTML]
+>>                                                      ^~~~~~~~~
 feature_tests/multiple_body_tags_3.html:32:53 The tag 'BODY' appears more than once in the document. [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+>>   ^~~~~~~~~
 feature_tests/multiple_body_tags_3.html:33:2 The parent tag of tag 'style amp-custom' is 'body', but it can only be 'head'. (see https://www.ampproject.org/docs/reference/spec#stylesheets) [DISALLOWED_HTML]
+>>                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  ^~~~~~~~~
 feature_tests/multiple_body_tags_3.html:33:641 The tag 'noscript > style[amp-boilerplate]' may only appear as a descendant of tag 'head'. (see https://github.com/ampproject/amphtml/blob/master/spec/amp-boilerplate.md) [DISALLOWED_HTML]
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+>>   ^~~~~~~~~
 feature_tests/multiple_body_tags_3.html:34:2 The parent tag of tag 'amphtml engine v0.js script' is 'body', but it can only be 'head'. (see https://www.ampproject.org/docs/reference/spec#required-markup) [DISALLOWED_HTML]
-feature_tests/multiple_body_tags_3.html:41:7 The mandatory tag 'noscript enclosure for boilerplate' is missing or incorrect. (see https://github.com/ampproject/amphtml/blob/master/spec/amp-boilerplate.md) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
-feature_tests/multiple_body_tags_3.html:41:7 The tag 'head > style[amp-boilerplate]' is missing or incorrect, but required by 'noscript > style[amp-boilerplate]'. (see https://github.com/ampproject/amphtml/blob/master/spec/amp-boilerplate.md) [GENERIC]
-feature_tests/multiple_body_tags_3.html:41:7 The mandatory tag 'head > style[amp-boilerplate]' is missing or incorrect. (see https://github.com/ampproject/amphtml/blob/master/spec/amp-boilerplate.md) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
+|  </head>
+|  <body class="foo">
+|    <!-- You might think there's only one body in this doc, but this is
+|         the body because "some stray text" above started the actual
+|         body so that counts as the first body tag. -->
+|  </body>
+|  </html>
+>>       ^~~~~~~~~
+feature_tests/multiple_body_tags_3.html:41:6 The mandatory tag 'noscript enclosure for boilerplate' is missing or incorrect. (see https://github.com/ampproject/amphtml/blob/master/spec/amp-boilerplate.md) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
+>>       ^~~~~~~~~
+feature_tests/multiple_body_tags_3.html:41:6 The tag 'head > style[amp-boilerplate]' is missing or incorrect, but required by 'noscript > style[amp-boilerplate]'. (see https://github.com/ampproject/amphtml/blob/master/spec/amp-boilerplate.md) [GENERIC]
+>>       ^~~~~~~~~
+feature_tests/multiple_body_tags_3.html:41:6 The mandatory tag 'head > style[amp-boilerplate]' is missing or incorrect. (see https://github.com/ampproject/amphtml/blob/master/spec/amp-boilerplate.md) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]

--- a/validator/testdata/feature_tests/new_and_old_boilerplate_mixed.out
+++ b/validator/testdata/feature_tests/new_and_old_boilerplate_mixed.out
@@ -1,3 +1,39 @@
 FAIL
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    This test contains the new boilerplate in the javascript-enabled version
+|    but the old, opacity-based one inside noscript. This is not allowed.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style>
+|    <noscript><style>body {opacity: 1}</style></noscript>
+>>             ^~~~~~~~~
 feature_tests/new_and_old_boilerplate_mixed.html:28:12 The tag 'noscript > style[amp-boilerplate] - old variant' is deprecated - use 'noscript > style[amp-boilerplate]' instead. (see https://github.com/ampproject/amphtml/blob/master/spec/amp-boilerplate.md) [DEPRECATION]
-feature_tests/new_and_old_boilerplate_mixed.html:34:7 The tag 'noscript > style[amp-boilerplate]' is missing or incorrect, but required by 'head > style[amp-boilerplate]'. (see https://github.com/ampproject/amphtml/blob/master/spec/amp-boilerplate.md) [GENERIC]
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|  <body>
+|  Hello, world.
+|  </body>
+|  </html>
+>>       ^~~~~~~~~
+feature_tests/new_and_old_boilerplate_mixed.html:34:6 The tag 'noscript > style[amp-boilerplate]' is missing or incorrect, but required by 'head > style[amp-boilerplate]'. (see https://github.com/ampproject/amphtml/blob/master/spec/amp-boilerplate.md) [GENERIC]

--- a/validator/testdata/feature_tests/new_and_old_boilerplate_mixed2.out
+++ b/validator/testdata/feature_tests/new_and_old_boilerplate_mixed2.out
@@ -1,3 +1,40 @@
 FAIL
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    This test contains the old, opacity-based boilerplate in the
+|    javascript-enabled version, but the new one inside noscript. This is
+|    not allowed.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style>body {opacity: 0}</style>
+>>   ^~~~~~~~~
 feature_tests/new_and_old_boilerplate_mixed2.html:28:2 The tag 'head > style[amp-boilerplate] - old variant' is deprecated - use 'head > style[amp-boilerplate]' instead. (see https://github.com/ampproject/amphtml/blob/master/spec/amp-boilerplate.md) [DEPRECATION]
-feature_tests/new_and_old_boilerplate_mixed2.html:35:7 The tag 'head > style[amp-boilerplate]' is missing or incorrect, but required by 'noscript > style[amp-boilerplate]'. (see https://github.com/ampproject/amphtml/blob/master/spec/amp-boilerplate.md) [GENERIC]
+|    <noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|  <body>
+|  Hello, world.
+|  </body>
+|  </html>
+>>       ^~~~~~~~~
+feature_tests/new_and_old_boilerplate_mixed2.html:35:6 The tag 'head > style[amp-boilerplate]' is missing or incorrect, but required by 'noscript > style[amp-boilerplate]'. (see https://github.com/ampproject/amphtml/blob/master/spec/amp-boilerplate.md) [GENERIC]

--- a/validator/testdata/feature_tests/new_boilerplate.out
+++ b/validator/testdata/feature_tests/new_boilerplate.out
@@ -1,1 +1,35 @@
 PASS
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    This is the minimum valid AMP document; it includes all of the required
+|    fields from the spec, but nothing else. This test exercises the new
+|    amp boilerplate.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|  <body>
+|  Hello, world.
+|  </body>
+|  </html>

--- a/validator/testdata/feature_tests/no_custom_js.out
+++ b/validator/testdata/feature_tests/no_custom_js.out
@@ -1,3 +1,37 @@
 FAIL
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Custom Javascript (other than whitelisted script locations) is rejected.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|   <head>
+|     <meta charset="utf-8">
+|     <link rel=canonical href=http://output.jsbin.com/mumifuyewi/hello-world.html>
+|     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1"><meta name="robots" content="noindex">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|     <script async src="https://cdn.ampproject.org/v0.js"></script>
+|     <script async src="https://example.com/v0-not-allowed.js"></script>
+>>    ^~~~~~~~~
 feature_tests/no_custom_js.html:28:3 Only AMP runtime 'script' tags are allowed, and only in the document head. (see https://www.ampproject.org/docs/reference/spec#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
+|     <script async custom-element="amp-foo" src="https://example.com/v0/not-allowed.js"></script>
+>>    ^~~~~~~~~
 feature_tests/no_custom_js.html:29:3 Only AMP runtime 'script' tags are allowed, and only in the document head. (see https://www.ampproject.org/docs/reference/spec#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
+|   </head>
+|   <body>Hello World!</body>
+|  </html>

--- a/validator/testdata/feature_tests/noscript.out
+++ b/validator/testdata/feature_tests/noscript.out
@@ -1,7 +1,76 @@
 FAIL
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    This tests the logic for <noscript> tags and it's child tags.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|  <body>
+|    <!-- Example of a valid noscript -->
+|    <noscript>
+|      <audio controls>
+|        <source src="https://example.com/howl-of-the-lemur.mp3" type="audio/mpeg">
+|      </audio>
+|      <img alt="Iconic Lemurs" height="200" src="https://example.com/lemurs.png" width="80">
+|      <video controls height="480" width="640">
+|        <source src="https://example.com/island-of-lemurs.mp4" type="video/mp4">
+|      </video>
+|    </noscript>
+|    <!-- Invalid: audio's source must have src and type; controls are optional -->
+|    <noscript>
+|      <audio>
+|        <source>
+>>       ^~~~~~~~~
 feature_tests/noscript.html:43:6 The parent tag of tag 'amp-video > source' is 'audio', but it can only be 'amp-video'. (see https://www.ampproject.org/docs/reference/components/amp-video) [AMP_TAG_PROBLEM]
+|      </audio>
+|    </noscript>
+|    <!-- Invalid: img must have src; alt, height and width are optional -->
+|    <noscript>
+|      <img alt="Iconic Lemurs">
+>>     ^~~~~~~~~
 feature_tests/noscript.html:48:4 The mandatory attribute 'src' is missing in tag 'img'. (see https://www.ampproject.org/docs/reference/components/amp-img) [DISALLOWED_HTML]
+|    </noscript>
+|    <!-- Invalid: audio must be in a noscript tag -->
+|    <audio controls>
+>>   ^~~~~~~~~
 feature_tests/noscript.html:51:2 The tag 'audio' may only appear as a descendant of tag 'noscript'. Did you mean 'amp-audio'? (see https://www.ampproject.org/docs/reference/components/amp-audio) [DISALLOWED_HTML_WITH_AMP_EQUIVALENT]
+|      <source src="https://example.com/howl-of-the-lemur.mp3" type="audio/mpeg">
+|    </audio>
+|    <!-- Invalid: img must be in a noscript tag -->
+|    <img alt="Iconic Lemurs" height="200" src="https://example.com/lemurs.png" width="80">
+>>   ^~~~~~~~~
 feature_tests/noscript.html:55:2 The tag 'img' may only appear as a descendant of tag 'noscript'. Did you mean 'amp-img'? (see https://www.ampproject.org/docs/reference/components/amp-img) [DISALLOWED_HTML_WITH_AMP_EQUIVALENT]
+|    <!-- Invalid: video must be in a noscript tag -->
+|    <video controls height="480" width="640">
+>>   ^~~~~~~~~
 feature_tests/noscript.html:57:2 The tag 'video' may only appear as a descendant of tag 'noscript'. Did you mean 'amp-video'? (see https://www.ampproject.org/docs/reference/components/amp-video) [DISALLOWED_HTML_WITH_AMP_EQUIVALENT]
+|      <source src="https://example.com/island-of-lemurs.mp4" type="video/mp4">
+|    </video>
+|    <!-- Invalid: nested noscript tags don't correctly parse. -->
+|    <noscript> <noscript> </noscript> </noscript>
+>>              ^~~~~~~~~
 feature_tests/noscript.html:61:13 The tag 'noscript' may not appear as a descendant of tag 'noscript'. [GENERIC]
+|  </body>
+|  </html>

--- a/validator/testdata/feature_tests/old-boilerplate.out
+++ b/validator/testdata/feature_tests/old-boilerplate.out
@@ -1,3 +1,40 @@
 PASS
+|  <!--
+|    Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <title>Twitter examples</title>
+|    <link rel="canonical" href="amps.html" >
+|    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+|    <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
+|    <style>body {opacity: 0}</style><noscript><style>body {opacity: 1}</style></noscript>
+>>   ^~~~~~~~~
 feature_tests/old-boilerplate.html:24:2 The tag 'head > style[amp-boilerplate] - old variant' is deprecated - use 'head > style[amp-boilerplate]' instead. (see https://github.com/ampproject/amphtml/blob/master/spec/amp-boilerplate.md) [DEPRECATION]
+>>                                             ^~~~~~~~~
 feature_tests/old-boilerplate.html:24:44 The tag 'noscript > style[amp-boilerplate] - old variant' is deprecated - use 'noscript > style[amp-boilerplate]' instead. (see https://github.com/ampproject/amphtml/blob/master/spec/amp-boilerplate.md) [DEPRECATION]
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|  <body>
+|    <h1>AMP boilerplate</h1>
+|    <h2>Testing if the old validator is still accepted.</h2>
+|    <p>
+|      "Neque porro quisquam est qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit..."
+|      "There is no one who loves pain itself, who seeks after it and wants to have it, simply because it is pain..."
+|    </p>
+|  </body>
+|  </html>

--- a/validator/testdata/feature_tests/parser.out
+++ b/validator/testdata/feature_tests/parser.out
@@ -1,25 +1,119 @@
 FAIL
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    This runs some tests which exercise our HTML parser.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content=width=device-width,minimum-scale=1>
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|  <body>
+|  
+|    <!-- Strangely quoted attributes: -->
+|    <a href="foo.html""></a>
+>>   ^~~~~~~~~
 feature_tests/parser.html:32:2 The attribute '"' may not appear in tag 'a'. (see https://www.ampproject.org/docs/reference/spec#links) [DISALLOWED_HTML]
+|    <a href='foo.html''></a>
+>>   ^~~~~~~~~
 feature_tests/parser.html:33:2 The attribute ''' may not appear in tag 'a'. (see https://www.ampproject.org/docs/reference/spec#links) [DISALLOWED_HTML]
+|    <a href=""foo.html"></a>
+>>   ^~~~~~~~~
 feature_tests/parser.html:34:2 The attribute 'foo.html"' may not appear in tag 'a'. (see https://www.ampproject.org/docs/reference/spec#links) [DISALLOWED_HTML]
+|    <a href=''foo.html'></a>
+>>   ^~~~~~~~~
 feature_tests/parser.html:35:2 The attribute 'foo.html'' may not appear in tag 'a'. (see https://www.ampproject.org/docs/reference/spec#links) [DISALLOWED_HTML]
+|    <a href=""foo.html""></a>
+>>   ^~~~~~~~~
 feature_tests/parser.html:36:2 The attribute 'foo.html""' may not appear in tag 'a'. (see https://www.ampproject.org/docs/reference/spec#links) [DISALLOWED_HTML]
+|    <a href=''foo.html''></a>
+>>   ^~~~~~~~~
 feature_tests/parser.html:37:2 The attribute 'foo.html''' may not appear in tag 'a'. (see https://www.ampproject.org/docs/reference/spec#links) [DISALLOWED_HTML]
+|    <a '></a>
+>>   ^~~~~~~~~
 feature_tests/parser.html:38:2 The attribute ''' may not appear in tag 'a'. (see https://www.ampproject.org/docs/reference/spec#links) [DISALLOWED_HTML]
+|    <a "></a>
+>>   ^~~~~~~~~
 feature_tests/parser.html:39:2 The attribute '"' may not appear in tag 'a'. (see https://www.ampproject.org/docs/reference/spec#links) [DISALLOWED_HTML]
+|    <a href"foo.html"></a>
+>>   ^~~~~~~~~
 feature_tests/parser.html:40:2 The attribute 'href"foo.html"' may not appear in tag 'a'. (see https://www.ampproject.org/docs/reference/spec#links) [DISALLOWED_HTML]
+|    <a href'foo.html'></a>
+>>   ^~~~~~~~~
 feature_tests/parser.html:41:2 The attribute 'href'foo.html'' may not appear in tag 'a'. (see https://www.ampproject.org/docs/reference/spec#links) [DISALLOWED_HTML]
+|    <a href"foo.html""></a>
+>>   ^~~~~~~~~
 feature_tests/parser.html:42:2 The attribute 'href"foo.html""' may not appear in tag 'a'. (see https://www.ampproject.org/docs/reference/spec#links) [DISALLOWED_HTML]
+|    <a href'foo.html''></a>
+>>   ^~~~~~~~~
 feature_tests/parser.html:43:2 The attribute 'href'foo.html''' may not appear in tag 'a'. (see https://www.ampproject.org/docs/reference/spec#links) [DISALLOWED_HTML]
+|    <a href""foo.html"></a>
+>>   ^~~~~~~~~
 feature_tests/parser.html:44:2 The attribute 'href""foo.html"' may not appear in tag 'a'. (see https://www.ampproject.org/docs/reference/spec#links) [DISALLOWED_HTML]
+|    <a href''foo.html'></a>
+>>   ^~~~~~~~~
 feature_tests/parser.html:45:2 The attribute 'href''foo.html'' may not appear in tag 'a'. (see https://www.ampproject.org/docs/reference/spec#links) [DISALLOWED_HTML]
+|    <a href""foo.html""></a>
+>>   ^~~~~~~~~
 feature_tests/parser.html:46:2 The attribute 'href""foo.html""' may not appear in tag 'a'. (see https://www.ampproject.org/docs/reference/spec#links) [DISALLOWED_HTML]
+|    <a href''foo.html''></a>
+>>   ^~~~~~~~~
 feature_tests/parser.html:47:2 The attribute 'href''foo.html''' may not appear in tag 'a'. (see https://www.ampproject.org/docs/reference/spec#links) [DISALLOWED_HTML]
+|  
+|    <!-- Attributes in closing tags: -->
+|    <a></a foo>
+|    <a></a href>
+|    <a></a foo="foo.html">
+|    <a></a href="foo.html">
+|  
+|    <!-- <, / as attributes: -->
+|    <a < ></a>
+>>   ^~~~~~~~~
 feature_tests/parser.html:56:2 The attribute '<' may not appear in tag 'a'. (see https://www.ampproject.org/docs/reference/spec#links) [DISALLOWED_HTML]
+|    <a / ></a>
+>>   ^~~~~~~~~
 feature_tests/parser.html:57:2 The attribute '/' may not appear in tag 'a'. (see https://www.ampproject.org/docs/reference/spec#links) [DISALLOWED_HTML]
+|    <a /a></a>
+>>   ^~~~~~~~~
 feature_tests/parser.html:58:2 The attribute '/a' may not appear in tag 'a'. (see https://www.ampproject.org/docs/reference/spec#links) [DISALLOWED_HTML]
+|    <a /a ></a>
+>>   ^~~~~~~~~
 feature_tests/parser.html:59:2 The attribute '/a' may not appear in tag 'a'. (see https://www.ampproject.org/docs/reference/spec#links) [DISALLOWED_HTML]
+|  
+|    <!-- Tags that may be processing instructions: -->
+|    <?php ?>
+>>   ^~~~~~~~~
 feature_tests/parser.html:62:2 The tag '?php' is disallowed. [DISALLOWED_HTML]
+|    < ?php ?>
+|    <?php echo 'Hello, World'; ?>
+>>   ^~~~~~~~~
 feature_tests/parser.html:64:2 The tag '?php' is disallowed. [DISALLOWED_HTML]
+|    <?php <span>Content</span> ?>
+>>   ^~~~~~~~~
 feature_tests/parser.html:65:2 The tag '?php' is disallowed. [DISALLOWED_HTML]
+|    <?xml:namespace prefix = o ns = "urn:schemas-microsoft-com:office:office" />
+>>   ^~~~~~~~~
 feature_tests/parser.html:66:2 The tag '?xml:namespace' is disallowed. [DISALLOWED_HTML]
+|    < ?xml:namespace ?>
+|  
+|  </body>
+|  </html>

--- a/validator/testdata/feature_tests/partial_comment.out
+++ b/validator/testdata/feature_tests/partial_comment.out
@@ -1,1 +1,35 @@
 PASS
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    This test is valid, but contains a corner-case of an HTML comment that
+|    ends at EOF.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|  <body>
+|  Hello, world.
+|  </body>
+|  </html>
+|  <!-- This is a comment that ends at the document end.

--- a/validator/testdata/feature_tests/property_parsing.out
+++ b/validator/testdata/feature_tests/property_parsing.out
@@ -1,1 +1,34 @@
 PASS
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    This tests that properties in meta viewport can be separated by a semicolon.
+|    See https://github.com/ampproject/amphtml/issues/4577 for history.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width;minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|  <body>
+|  Hello, world.
+|  </body>
+|  </html>

--- a/validator/testdata/feature_tests/rdfa.out
+++ b/validator/testdata/feature_tests/rdfa.out
@@ -1,1 +1,97 @@
 PASS
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!doctype html>
+|  <!--
+|    Test Description:
+|    Tests that we allow the global RDFa attributes (as used in schema.org).
+|  -->
+|  <html ⚡ prefix="dc: http://purl.org/dc/terms/ schema: http://schema.org/">
+|  <head>
+|    <meta charset="utf-8">
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <meta property="dc:title" content="RDFa Example Page">
+|    <meta property="dc:creator" content="AMP HTML Authors">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|  </head>
+|  <body>
+|  
+|    <div typeof="schema:TVSeries" about="Buffy-the-Vampire-Slayer">
+|      <h1 property="schema:name">Buffy the Vampire Slayer</h1>
+|      <ul>
+|        <li><a property="schema:url" href="https://en.wikipedia.org/wiki/Buffy_the_Vampire_Slayer">Wikipedia Page</a></li>
+|        <li>Start Date: <span property="schema:startDate" content="1997-03-10">March 10, 1997</span></li>
+|        <li>End Date: <span property="schema:endDate" content="2003-05-20">May 20, 2003</span></li>
+|        <li>Seasons: <span property="schema:numberOfSeasons">7</span></li>
+|      </ul>
+|  
+|  
+|      <h2>Cast</h2>
+|      <ul>
+|        <li rel="schema:actor" typeof="schema:PerformanceRole">
+|          <span rel="schema:actor" resource="https://en.wikipedia.org/wiki/Nicholas_Brendon">Nicholas Brendon</span>
+|          as <span property="schema:characterName">Xander Harris</span>
+|        </li>
+|        <li rel="schema:actor" typeof="schema:PerformanceRole">
+|          <span rel="schema:actor" resource="https://en.wikipedia.org/wiki/Sarah_Michelle_Gellar">Sarah Michelle Gellar</span>
+|          as <span property="schema:characterName">Buffy Summers</span>
+|        </li>
+|      </ul>
+|    </div>
+|  
+|  
+|    <h2>Actors</h2>
+|    <div typeof="schema:Person" about="https://en.wikipedia.org/wiki/Sarah_Michelle_Gellar">
+|      <span property="schema:givenName">Sarah Michelle</span>
+|      <span property="schema:familyName">Gellar</span>
+|      <link property="schema:url" href="https://en.wikipedia.org/wiki/Sarah_Michelle_Gellar">
+|      <meta property="schema:alternateName" content="Sarah Michelle Prinze">
+|      <meta rev="schema:creator" resource="https://example.org/Gellar.jpg">
+|    </div>
+|    <div typeof="schema:Person" about="https://en.wikipedia.org/wiki/Nicholas_Brendon">
+|      <span property="schema:givenName">Nicholas</span>
+|      <span property="schema:familyName">Brendon</span>
+|      <link property="schema:url" href="https://en.wikipedia.org/wiki/Nicholas_Brendon">
+|      <meta property="schema:alternateName" content="Nicholas Brendon Schultz">
+|      <meta rev="schema:creator" resource="https://example.org/Brendon.jpg">
+|    </div>
+|  
+|  
+|    <h2>Photos</h2>
+|    <div
+|        typeof="schema:ImageObject" about="https://example.org/Gellar.jpg"
+|        rev="schema:image" resource="https://en.wikipedia.org/wiki/Sarah_Michelle_Gellar">
+|      <amp-img
+|          src="https://example.org/Gellar.jpg"
+|          property="schema:contentUrl"
+|          alt="Self Portrait by Sarah" layout="fixed" height="320" width="200"></amp-img>
+|      <span property="schema:name">Self Portrait</span>
+|    </div>
+|  
+|    <div
+|        typeof="schema:ImageObject" about="https://example.org/Brendon.jpg"
+|        rev="schema:image" resource="https://en.wikipedia.org/wiki/Nicholas_Brendon">
+|      <amp-img
+|          src="https://example.org/Brendon.jpg"
+|          property="schema:contentUrl"
+|          alt="Self Portrait by Nicholas" layout="fixed" height="320" width="200"></amp-img>
+|      <span property="schema:name">Self Portrait</span>
+|    </div>
+|  
+|  </body>
+|  </html>

--- a/validator/testdata/feature_tests/recipe-json-ld.out
+++ b/validator/testdata/feature_tests/recipe-json-ld.out
@@ -1,1 +1,161 @@
 PASS
+|  <!--
+|    Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!doctype html>
+|  <!--
+|        This sample AMP HTML file aims to be a minimalist document that
+|        follows best practices and guidances for publishers to mark up
+|        content for inclusion in various platforms.
+|  -->
+|  <html AMP lang="en">
+|    <!-- you can use "amp" or "AMP" or "⚡" -->
+|    <head>
+|      <meta charset="utf-8">
+|      <title>Lorem Ipsum</title>
+|      <link rel="canonical" href="http://example.ampproject.org/recipe-metadata.html">
+|      <!--
+|          The canonical document for this article should be linked, as above.
+|  
+|          The canonical document should also have a corresponding <link> tag
+|          within pointing at this AMP HTML file:
+|  
+|            <link rel="amphtml" href="http://example.ampproject.org/recipe-json-ld.amp.html">
+|  
+|          It is possible that this AMP HTML document is the canonical document
+|          for this article, in which case, the canonical URL should point to this
+|          document, and no "amphtml" link is required.
+|  
+|          Also, please be aware that some platforms that use AMP HTML have
+|          further restrictions with regards to some schema components.
+|  
+|           For example:
+|  
+|             * All marked-up URL's should be absolute.
+|             * The "logo" dimensions must not exceed 600x60.
+|      -->
+|      <meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1,user-scalable=no,minimal-ui">
+|      </script>
+|      <!-- only one style tag is allowed, and it must have an "amp-custom" attribute -->
+|      <style amp-custom>
+|        body {
+|          background-color: white;
+|        }
+|        amp-img {
+|          background-color: gray;
+|        }
+|      </style>
+|      <script type="application/ld+json">
+|          //
+|          // The document referenced in mainEntityOfPage should be the same as the
+|          // canonical link above.
+|          //
+|          // Also, please be aware that some platforms that use AMP HTML have
+|          // further restrictions with regards to some schema components.
+|          //
+|          // For example:
+|          //
+|          //   * The leader "image" referenced in the markup below must appear
+|          //   somewhere on the AMP HTML document itself.
+|          //
+|          //   * The URL for that "image" must precisely match the src of the
+|          //   amp-img tag.
+|          //
+|          //   * All marked-up URLs should be absolute.
+|          //
+|          //   * The "logo" dimensions must not exceed 600x60.
+|        {
+|          "@context": "http://schema.org/",
+|          "@type": "Recipe",
+|          "mainEntityOfPage": "http://example.ampproject.org/recipe-metadata.html",
+|          "name": "Grandma's Holiday Apple Pie",
+|          "image": {
+|            "@type": "ImageObject",
+|            "url": "http://cdn.ampproject.org/leader.jpg",
+|            "height": 200,
+|            "width": 200
+|          },
+|          "author": {
+|            "@type":"Person",
+|            "name":"Carol Smith"
+|          },
+|          "datePublished": "2009-11-05",
+|          "dateModified": "2009-11-05",
+|          "description": "This is my grandmother's apple pie recipe. I like to add a dash of nutmeg.",
+|          "aggregateRating": {
+|            "@type": "AggregateRating",
+|            "ratingValue": "4.0",
+|            "reviewCount": "35"
+|          },
+|          "prepTime": "PT30M",
+|          "cookTime": "PT1H",
+|          "totalTime": "PT1H30M",
+|          "recipeYield": "1 9\" pie (8 servings)",
+|          "nutrition": {
+|            "@type": "NutritionInformation",
+|            "servingSize": "1 medium slice",
+|            "calories": "250 cal",
+|            "fatContent": "12 g"
+|          },
+|          "recipeIngredient": [
+|            "apples",
+|            "White sugar"
+|          ],
+|          "recipeInstructions": "1. Cut and peel apples\n 2. Mix sugar and cinnamon. Use additional sugar for tart apples.\n...",
+|          "publisher": {
+|            "@type": "Organization",
+|            "name": "Google",
+|            "logo": {
+|              "@type": "ImageObject",
+|              "url": "http://cdn.ampproject.org/logo.jpg",
+|              "width": 600,
+|              "height": 60
+|            }
+|          }
+|        }
+|      </script>
+|      <!-- this style tag is required -->
+|      <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|      <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    </head>
+|    <body>
+|        <h1>Grandma's Holiday Apple Pie</h1>
+|        <amp-img src="http://cdn.ampproject.org/leader.jpg" height="200" width="200"/></amp-img><br>
+|        By Carol Smith <br>
+|        Published: November 5, 2009
+|        <p>This is my grandmother's apple pie recipe. I like to add a
+|          dash of nutmeg. </p>
+|        <p>4.0 stars based on 35 reviews</p>
+|        <p>Prep time: 30 min</p>
+|        <p>Cook time: 1 hour</p>
+|        <p>Total time: 1 hour 30 min</p>
+|        <p>Yield: 1 9" pie (8 servings) <br>
+|          Serving size: 1 medium slice <br>
+|          Calories per serving: 250 cal <br>
+|          Fat per serving: 12 <br>
+|        </p>
+|        <p>Ingredients: <br>
+|            Thinly-sliced apples:  6 cups <br>
+|            White sugar: 3/4 cup <br>
+|        ... <br>
+|        </p>
+|        <p>
+|        Directions: <br>
+|            1. Cut and peel apples <br>
+|            2. Mix sugar and cinnamon. Use additional sugar for tart apples. <br>
+|            ... <br>
+|          </p>
+|    </body>
+|  </html>

--- a/validator/testdata/feature_tests/recipe-microdata.out
+++ b/validator/testdata/feature_tests/recipe-microdata.out
@@ -1,1 +1,117 @@
 PASS
+|  <!--
+|    Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!doctype html>
+|  <!--
+|        This sample AMP HTML file aims to be a minimalist document that
+|        follows best practices and guidances for publishers to mark up
+|        content for inclusion in various platforms.
+|  -->
+|  <html AMP lang="en" itemscope itemtype="http://schema.org/Recipe">
+|    <!-- you can use "amp" or "AMP" or "⚡" -->
+|    <head>
+|      <meta charset="utf-8">
+|      <title>Lorem Ipsum</title>
+|      <link itemprop="mainEntityOfPage" rel="canonical" href="http://example.ampproject.org/recipe-metadata.html">
+|      <!--
+|          The canonical document for this article should be linked, as above.
+|  
+|          The canonical document should also have a corresponding <link> tag
+|          within pointing at this AMP HTML file:
+|  
+|            <link rel="amphtml" href="http://example.ampproject.org/recipe-json-ld.amp.html">
+|  
+|          It is possible that this AMP HTML document is the canonical document
+|          for this article, in which case, the canonical URL should point to this
+|          document, and no "amphtml" link is required.
+|  
+|          Also, please be aware that some platforms that use AMP HTML have
+|          further restrictions with regards to some schema components.
+|  
+|           For example:
+|  
+|             * All marked-up URL's should be absolute.
+|             * The "logo" dimensions must not exceed 600x60.
+|      -->
+|      <meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1,user-scalable=no,minimal-ui">
+|      <!-- only one style tag is allowed, and it must have an "amp-custom" attribute -->
+|      <style amp-custom>
+|        body {
+|          background-color: white;
+|        }
+|        amp-img {
+|          background-color: gray;
+|        }
+|      </style>
+|      <!-- this style tag is required -->
+|      <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|      <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    </head>
+|    <body>
+|        <h1 itemprop="name">Grandma's Holiday Apple Pie</h1>
+|        <div itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+|          <amp-img src="http://cdn.ampproject.org/leader.jpg" height="200" width="200"></amp-img>
+|          <meta itemprop="url" content="http://cdn.ampproject.org/leader.jpg"></meta>
+|          <meta itemprop="width" content="200"></meta>
+|          <meta itemprop="height" content="200"></meta>
+|        </div>
+|        <amp-img itemprop="image" src="http://cdn.ampproject.org/leader.jpg" height="200" width="200"/></amp-img><br>
+|        By <span itemprop="author" itemscope itemtype="http://schema.org/Person">
+|             <span itemprop="name">Carol Smith</span>
+|           </span>
+|        Published: <time datetime="2009-11-05" itemprop="datePublished">
+|          November 5, 2009</time>
+|        <time datetime="2009-11-05" itemprop="dateModified"></time>
+|        <p itemprop="description">This is my grandmother's apple pie recipe. I like to add a dash of nutmeg.</p>
+|        <p itemprop="aggregateRating" itemscope itemtype="http://schema.org/AggregateRating">
+|          <span itemprop="ratingValue">4.0</span> stars based on
+|          <span itemprop="reviewCount">35</span> reviews </p>
+|        <p>Prep time: <time datetime="PT30M" itemprop="prepTime">30 min</time></p>
+|        <p>Cook time: <time datetime="PT1H" itemprop="cookTime">1 hour</time></p>
+|        <p>Total time: <time datetime="PT1H30M" itemprop="totalTime">1 hour 30 min</time></p>
+|        <p>Yield: <span itemprop="recipeYield">1 9" pie (8 servings)</span></p>
+|        <p><span itemprop="nutrition" itemscope itemtype="http://schema.org/NutritionInformation">
+|          Serving size: <span itemprop="servingSize">1 medium slice</span><br>
+|          Calories per serving: <span itemprop="calories">250 cal</span><br>
+|          Fat per serving: <span itemprop="fatContent">12 g</span><br>
+|        </span></p>
+|        <p>Ingredients:<br>
+|          Thinly-sliced <span itemprop="ingredients">apples</span>:
+|           6 cups<br>
+|            <span itemprop="ingredients">White sugar</span>:
+|            3/4 cup<br>
+|        ...<br>
+|      </p>
+|      <p>
+|        Directions:<br>
+|          <div itemprop="recipeInstructions">
+|            1. Cut and peel apples<br>
+|            2. Mix sugar and cinnamon. Use additional sugar for tart apples.<br>
+|            ...<br>
+|          </div>
+|        </p>
+|      </div>
+|      <div itemprop="publisher" itemscope itemtype="https://schema.org/Organization">
+|        <div itemprop="logo" itemscope itemtype="https://schema.org/ImageObject">
+|          <amp-img width="600" height="60" src="http://cdn.ampproject.org/logo.jpg"></amp-img>
+|          <meta itemprop="url" content="http://cdn.ampproject.org/logo.jpg"></meta>
+|          <meta itemprop="width" content="600"></meta>
+|          <meta itemprop="height" content="60"></meta>
+|        </div>
+|        <meta itemprop="name" content="Google"></meta>
+|      </div>
+|    </body>
+|  </html>

--- a/validator/testdata/feature_tests/regexps.out
+++ b/validator/testdata/feature_tests/regexps.out
@@ -1,25 +1,192 @@
 FAIL
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|      This tests looks at specific errors related to positive and negative
+|      regexps used inside the validator.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style>invalid body</style>
+>>   ^~~~~~~~~
 feature_tests/regexps.html:27:2 The tag 'head > style[amp-boilerplate] - old variant' is deprecated - use 'head > style[amp-boilerplate]' instead. (see https://github.com/ampproject/amphtml/blob/master/spec/amp-boilerplate.md) [DEPRECATION]
+>>   ^~~~~~~~~
 feature_tests/regexps.html:27:2 The mandatory text (CDATA) inside tag 'head > style[amp-boilerplate] - old variant' is missing or incorrect. (see https://github.com/ampproject/amphtml/blob/master/spec/amp-boilerplate.md) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
+|    <noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  
+|    <!--
+|    src value_regex: "https://cdn\\.ampproject\\.org/v0/amp-vine-(latest|0\\.1).js"
+|    The first example is valid. The latter three examples are invalid.
+|    -->
+|    <script async custom-element="amp-vine" src="https://cdn.ampproject.org/v0/amp-vine-latest.js"> </script>
+|    <script async custom-element="amp-vine" src="https://cdn.ampproject.org/v0/amp-vine-0.1.js?foobar"></script>
+>>   ^~~~~~~~~
 feature_tests/regexps.html:36:2 The attribute 'src' in tag 'amp-vine extension .js script' is set to the invalid value 'https://cdn.ampproject.org/v0/amp-vine-0.1.js?foobar'. (see https://www.ampproject.org/docs/reference/components/amp-vine) [CUSTOM_JAVASCRIPT_DISALLOWED]
+|    <script async custom-element="amp-vine" src="http://xss.com/https://cdn.ampproject.org/v0/amp-vine-0.1.js?foobar"></script>
+>>   ^~~~~~~~~
 feature_tests/regexps.html:37:2 The attribute 'src' in tag 'amp-vine extension .js script' is set to the invalid value 'http://xss.com/https://cdn.ampproject.org/v0/amp-vine-0.1.js?foobar'. (see https://www.ampproject.org/docs/reference/components/amp-vine) [CUSTOM_JAVASCRIPT_DISALLOWED]
+|    <script async custom-element="amp-hulu" src="https://cdn.ampproject.org/v0/amp-hulu-latest.js"> Only whitespace is allowed here. </script>
+>>   ^~~~~~~~~
 feature_tests/regexps.html:38:2 The tag 'amp-hulu extension .js script' contains text (CDATA), which is disallowed. (see https://www.ampproject.org/docs/reference/components/amp-hulu) [DISALLOWED_HTML]
+|  
+|    <!--
+|    href value_regex: "https://cdn\\.materialdesignicons\\.com/([0-9]+\\.?)+/css/materialdesignicons\\.min\\.css"
+|    The first example is valid, the second example is invalid.
+|    -->
+|    <link rel="stylesheet" type="text/css"
+|          href="https://cdn.materialdesignicons.com/2.0.46/css/materialdesignicons.min.css">
+|    <link rel="stylesheet" type="text/css"
+>>   ^~~~~~~~~
 feature_tests/regexps.html:46:2 The attribute 'href' in tag 'link rel=stylesheet for fonts' is set to the invalid value 'https://cdn.materialdesignicons.com/2.0.46/css/.../materialdesignicons.min.css'. (see https://www.ampproject.org/docs/reference/spec#custom-fonts) [AUTHOR_STYLESHEET_PROBLEM]
+|          href="https://cdn.materialdesignicons.com/2.0.46/css/.../materialdesignicons.min.css">
+|  
+|    <!--
+|    href value_regex: "https://fonts\\.googleapis\\.com/css\\?.*|https://fast\\.fonts\\.net/.*"
+|    The first two examples are valid, the third example is invalid.
+|    -->
+|    <link rel="stylesheet" type="text/css"
+|          href="https://fonts.googleapis.com/css?foobar">
+|    <link rel="stylesheet" type="text/css"
+|          href="https://cloud.typography.com/6256354/724768/css/fonts.css">
+|    <link rel="stylesheet" type="text/css"
+>>   ^~~~~~~~~
 feature_tests/regexps.html:57:2 The attribute 'href' in tag 'link rel=stylesheet for fonts' is set to the invalid value 'http://xss.com/https://fonts.googleapis.com/css?foobar'. (see https://www.ampproject.org/docs/reference/spec#custom-fonts) [AUTHOR_STYLESHEET_PROBLEM]
+|          href="http://xss.com/https://fonts.googleapis.com/css?foobar">
+|  
+|    <!--
+|      Regexp to allow typekit fonts.
+|      href value_regex: "https://use\\.typekit\\.net/\\w+\\.css"
+|      The first example is valid, the second example is invalid.
+|    -->
+|    <link rel="stylesheet" type="text/css"
+|          href="https://use.typekit.net/oeg4hgb.css">
+|    <link rel="stylesheet" type="text/css"
+>>   ^~~~~~~~~
 feature_tests/regexps.html:67:2 The attribute 'href' in tag 'link rel=stylesheet for fonts' is set to the invalid value 'https://use.typekit.net/css/oeg4hgb.css'. (see https://www.ampproject.org/docs/reference/spec#custom-fonts) [AUTHOR_STYLESHEET_PROBLEM]
+|          href="https://use.typekit.net/css/oeg4hgb.css">
+|  
+|    <!--
+|      Regexp to allow font-awesome css, but not path traversal.
+|      The first example is valid, the second is not.
+|    -->
+|    <link rel="stylesheet" type="text/css"
+|          href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
+|    <link rel="stylesheet" type="text/css"
+>>   ^~~~~~~~~
 feature_tests/regexps.html:76:2 The attribute 'href' in tag 'link rel=stylesheet for fonts' is set to the invalid value 'https://maxcdn.bootstrapcdn.com/font-awesome/../bootstrap/3.3.7/css/bootstrap.min.class'. (see https://www.ampproject.org/docs/reference/spec#custom-fonts) [AUTHOR_STYLESHEET_PROBLEM]
+|          href="https://maxcdn.bootstrapcdn.com/font-awesome/../bootstrap/3.3.7/css/bootstrap.min.class">
+|  
+|    <!--
+|    rel value_regex: lengthy, see protoascii
+|    The first three examples are valid. The latter three examples are invalid.
+|    -->
+|    <link rel="accessibility">
+|    <link rel="accessibility alternate">
+|    <link rel="accessibility alternate archives">
+|    <link rel="import">
+>>   ^~~~~~~~~
 feature_tests/regexps.html:86:2 The attribute 'rel' in tag 'link rel=' is set to the invalid value 'import'. (see https://www.ampproject.org/docs/reference/spec#html-tags) [DISALLOWED_HTML]
+|    <link rel="accessibility subresource">
+>>   ^~~~~~~~~
 feature_tests/regexps.html:87:2 The attribute 'rel' in tag 'link rel=' is set to the invalid value 'accessibility subresource'. (see https://www.ampproject.org/docs/reference/spec#html-tags) [DISALLOWED_HTML]
+|    <link rel="manifest accessibility">
+>>   ^~~~~~~~~
 feature_tests/regexps.html:88:2 The attribute 'rel' in tag 'link rel=' is set to the invalid value 'manifest accessibility'. (see https://www.ampproject.org/docs/reference/spec#html-tags) [DISALLOWED_HTML]
+|  
+|    <!--
+|    name blacklisted_value_regex: "(^|\\s)(viewport|content-disposition|revisit-after)($|\\s)"
+|    The first two examples are valid. The latter two examples are invalid.
+|    -->
+|    <meta name="valid" content="">
+|    <meta name="validcontent-disposition" content="">
+|    <meta name="content-disposition" content="">
+>>   ^~~~~~~~~
 feature_tests/regexps.html:96:2 The attribute 'name' in tag 'meta name= and content=' is set to the invalid value 'content-disposition'. [DISALLOWED_HTML]
+|    <meta name="invalid content-disposition" content="">
+>>   ^~~~~~~~~
 feature_tests/regexps.html:97:2 The attribute 'name' in tag 'meta name= and content=' is set to the invalid value 'invalid content-disposition'. [DISALLOWED_HTML]
+|  
+|    <!--
+|    css selector blacklisted_value_regex: "(^|\\W)i-amphtml-"
+|    The first example is valid. The latter four are invalid.
+|    -->
+|    <style amp-custom>
+>>   ^~~~~~~~~
 feature_tests/regexps.html:103:2 The text (CDATA) inside tag 'style amp-custom' contains 'CSS i-amphtml- name prefix', which is disallowed. (see https://www.ampproject.org/docs/reference/spec#stylesheets) [AUTHOR_STYLESHEET_PROBLEM]
+|      .comic-amp-font-loaded .comic-amp {
+|        font-family: 'Comic AMP', serif, sans-serif;
+|      }
+|      .i-amphtml-hidden {}
+|      #i-amphtml-wrapper {}
+|      i-amphtml-sizer {}
+|      [i-amphtml-section] {}
+|    </style>
+|  
+|  </head>
+|  <body>
+|  
+|    <!--
+|    class blacklisted_value_regex: "(^|\\W)i-amphtml-"
+|    The first example is valid. The latter two are invalid.
+|    -->
+|    <div class="example-amp-font"></div>
+|    <div class="example-amp-font i-amphtml-hidden"></div>
+>>   ^~~~~~~~~
 feature_tests/regexps.html:121:2 The attribute 'class' in tag 'div' is set to the invalid value 'example-amp-font i-amphtml-hidden'. [DISALLOWED_HTML]
+|    <div class="i-amphtml-hidden example-amp-font"></div>
+>>   ^~~~~~~~~
 feature_tests/regexps.html:122:2 The attribute 'class' in tag 'div' is set to the invalid value 'i-amphtml-hidden example-amp-font'. [DISALLOWED_HTML]
+|  
+|    <!--
+|    id blacklisted_value_regex: lengthy, see protoascii
+|    The first example is valid. The latter two are invalid.
+|    -->
+|    <div id="exampe-amp-font"></div>
+|    <div id="i-amphtml-abc"></div>
+>>   ^~~~~~~~~
 feature_tests/regexps.html:129:2 The attribute 'id' in tag 'div' is set to the invalid value 'i-amphtml-abc'. [DISALLOWED_HTML]
+|    <div id="AMP"></div>
+>>   ^~~~~~~~~
 feature_tests/regexps.html:130:2 The attribute 'id' in tag 'div' is set to the invalid value 'AMP'. [DISALLOWED_HTML]
+|  
+|    <!--
+|    name blacklisted_value_regex: lengthy, see protoascii
+|    The first two examples are valid. The latter three are invalid.
+|    -->
+|    <input name="" />
+|    <input name="email" />
+|    <input name="innerHTML" />
+>>   ^~~~~~~~~
 feature_tests/regexps.html:138:2 The attribute 'name' in tag 'input' is set to the invalid value 'innerHTML'. (see https://www.ampproject.org/docs/reference/components/amp-form) [DISALLOWED_HTML]
+|    <input name="__amp_source_origin" />
+>>   ^~~~~~~~~
 feature_tests/regexps.html:139:2 The attribute 'name' in tag 'input' is set to the invalid value '__amp_source_origin'. (see https://www.ampproject.org/docs/reference/components/amp-form) [DISALLOWED_HTML]
+|    <input name="webkitRequestFullscreen" />
+>>   ^~~~~~~~~
 feature_tests/regexps.html:140:2 The attribute 'name' in tag 'input' is set to the invalid value 'webkitRequestFullscreen'. (see https://www.ampproject.org/docs/reference/components/amp-form) [DISALLOWED_HTML]
-feature_tests/regexps.html:143:7 The tag 'head > style[amp-boilerplate]' is missing or incorrect, but required by 'noscript > style[amp-boilerplate]'. (see https://github.com/ampproject/amphtml/blob/master/spec/amp-boilerplate.md) [GENERIC]
-feature_tests/regexps.html:143:7 The extension 'amp-hulu' was found on this page, but is unused. Please remove this extension. [AMP_TAG_PROBLEM]
+|  
+|  </body>
+|  </html>
+>>       ^~~~~~~~~
+feature_tests/regexps.html:143:6 The tag 'head > style[amp-boilerplate]' is missing or incorrect, but required by 'noscript > style[amp-boilerplate]'. (see https://github.com/ampproject/amphtml/blob/master/spec/amp-boilerplate.md) [GENERIC]
+>>       ^~~~~~~~~
+feature_tests/regexps.html:143:6 The extension 'amp-hulu' was found on this page, but is unused. Please remove this extension. [AMP_TAG_PROBLEM]

--- a/validator/testdata/feature_tests/review-json-ld.out
+++ b/validator/testdata/feature_tests/review-json-ld.out
@@ -1,1 +1,121 @@
 PASS
+|  <!--
+|    Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!doctype html>
+|  <!--
+|        This sample AMP HTML file aims to be a minimalist document that
+|        follows best practices and guidances for publishers to mark up
+|        content for inclusion in various platforms.
+|  -->
+|  <html AMP lang="en">
+|    <!-- you can use "amp" or "AMP" or "⚡" -->
+|    <head>
+|      <meta charset="utf-8">
+|      <title>Lorem Ipsum</title>
+|      <link rel="canonical" href="http://example.ampproject.org/review-metadata.html">
+|      <!--
+|          The canonical document for this article should be linked, as above.
+|  
+|          The canonical document should also have a corresponding <link> tag
+|          within pointing at this AMP HTML file:
+|  
+|            <link rel="amphtml" href="http://example.ampproject.org/review-json-ld.amp.html">
+|  
+|          It is possible that this AMP HTML document is the canonical document
+|          for this article, in which case, the canonical URL should point to this
+|          document, and no "amphtml" link is required.
+|  
+|          Also, please be aware that some platforms that use AMP HTML have
+|          further restrictions with regards to some schema components.
+|  
+|           For example:
+|  
+|             * All marked-up URL's should be absolute.
+|             * The "logo" dimensions must not exceed 600x60.
+|      -->
+|      <meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1,user-scalable=no,minimal-ui">
+|      </script>
+|      <!-- only one style tag is allowed, and it must have an "amp-custom" attribute -->
+|      <style amp-custom>
+|        body {
+|          background-color: white;
+|        }
+|        amp-img {
+|          background-color: gray;
+|        }
+|      </style>
+|      <script type="application/ld+json">
+|          //
+|          // The document referenced in mainEntityOfPage should be the same as the
+|          // canonical link above.
+|          //
+|          // Also, please be aware that some platforms that use AMP HTML have
+|          // further restrictions with regards to some schema components.
+|          //
+|          // For example:
+|          //
+|          //   * The leader "image" referenced in the markup below must appear
+|          //   somewhere on the AMP HTML document itself.
+|          //
+|          //   * The URL for that "image" must precisely match the src of the
+|          //   amp-img tag.
+|          //
+|          //   * All marked-up URLs should be absolute.
+|          //
+|          //   * The "logo" dimensions must not exceed 600x60.
+|          //
+|        {
+|          "@context": "http://schema.org/",
+|          "@type": "Review",
+|          "mainEntityOfPage": "http://example.ampproject.org/review-metadata.html",
+|          "itemReviewed": {
+|            "@type": "Restaurant",
+|            "name": "Legal Seafood"
+|          },
+|          "reviewRating": {
+|            "@type": "Rating",
+|            "ratingValue": "4"
+|          },
+|          "name": "A good seafood place.",
+|          "author": {
+|            "@type": "Person",
+|            "name": "Bob Smith"
+|          },
+|          "reviewBody": "The seafood is great.",
+|          "publisher": {
+|            "@type": "Organization",
+|            "name": "Google",
+|            "logo": {
+|              "@type": "ImageObject",
+|              "url": "http://cdn.ampproject.org/logo.jpg",
+|              "width": 600,
+|              "height": 60
+|            }
+|          }
+|        }
+|      </script>
+|      <!-- this style tag is required -->
+|      <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|      <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    </head>
+|    <body>
+|        <h1>Legal Seafood</h1>
+|        <p>A good seafood place</p>
+|        <p>The Seafood is great</p>
+|        <p>4.0 out of 5</p>
+|        <p>By Bob Smith from Google</p>
+|    </body>
+|  </html>

--- a/validator/testdata/feature_tests/review-microdata.out
+++ b/validator/testdata/feature_tests/review-microdata.out
@@ -1,1 +1,69 @@
 PASS
+|  <!doctype html>
+|  <!--
+|        This sample AMP HTML file aims to be a minimalist document that
+|        follows best practices and guidances for publishers to mark up
+|        content for inclusion in various platforms.
+|  -->
+|  <html AMP lang="en" itemscope itemtype="http://schema.org/Review">
+|    <!-- you can use "amp" or "AMP" or "⚡" -->
+|    <head>
+|      <meta charset="utf-8">
+|      <title>Lorem Ipsum</title>
+|      <link itemprop="mainEntityOfPage" rel="canonical" href="http://example.ampproject.org/review-metadata.html">
+|      <!--
+|          The canonical document for this article should be linked, as above.
+|  
+|          The canonical document should also have a corresponding <link> tag
+|          within pointing at this AMP HTML file:
+|  
+|            <link rel="amphtml" href="http://example.ampproject.org/review-microdata.amp.html">
+|  
+|          It is possible that this AMP HTML document is the canonical document
+|          for this article, in which case, the canonical URL should point to this
+|          document, and no "amphtml" link is required.
+|  
+|          Also, please be aware that some platforms that use AMP HTML have
+|          further restrictions with regards to some schema components.
+|  
+|           For example:
+|  
+|             * All marked-up URL's should be absolute.
+|             * The "logo" dimensions must not exceed 600x60.
+|      -->
+|      <meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1,user-scalable=no,minimal-ui">
+|      <!-- only one style tag is allowed, and it must have an "amp-custom" attribute -->
+|      <style amp-custom>
+|        body {
+|          background-color: white;
+|        }
+|        amp-img {
+|          background-color: gray;
+|        }
+|      </style>
+|      <!-- this style tag is required -->
+|      <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|      <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    </head>
+|    <body>
+|      <div itemprop="itemReviewed" itemscope itemtype="http://schema.org/Restaurant">
+|        <h1 itemprop="name">Legal Seafood</h1>
+|      </div>
+|      <p itemprop="name">A good seafood place</p>
+|      <p itemprop="reviewBody">The Seafood is great</p>
+|      <div itemprop="reviewRating" itemscope itemtype="http://schema.org/Rating">
+|        <p><span itemprop="ratingValue">4.0</span> out of 5</p>
+|      </div>
+|      <p>By <span itemprop="author" itemscope itemtype="http://schema.org/Person">
+|      <span itemprop="name">Bob Smith</span></span> from Google</p>
+|      <div itemprop="publisher" itemscope itemtype="https://schema.org/Organization">
+|        <div itemprop="logo" itemscope itemtype="https://schema.org/ImageObject">
+|          <amp-img width="600" height="60" src="http://cdn.ampproject.org/logo.jpg"></amp-img>
+|          <meta itemprop="url" content="http://cdn.ampproject.org/logo.jpg"></meta>
+|          <meta itemprop="width" content="600"></meta>
+|          <meta itemprop="height" content="60"></meta>
+|        </div>
+|        <meta itemprop="name" content="Google"></meta>
+|      </div>
+|    </body>
+|  </html>

--- a/validator/testdata/feature_tests/root_element_attributes.out
+++ b/validator/testdata/feature_tests/root_element_attributes.out
@@ -1,2 +1,31 @@
 FAIL
+|  <!--
+|    Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|        http://www.apache.org/licenses/LICENSE-2.0
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    This demonstrates that certain attributes are not allowed on the root <html> element.
+|  -->
+|  <!doctype html>
+|  <html ⚡ allow-xhr-interception>
+>> ^~~~~~~~~
 feature_tests/root_element_attributes.html:18:0 The attribute 'allow-xhr-interception' may not appear in tag 'html ⚡ for top-level html'. (see https://www.ampproject.org/docs/reference/spec#required-markup) [DISALLOWED_HTML]
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|  <body>
+|  </body>
+|  </html>

--- a/validator/testdata/feature_tests/runtime_in_body.out
+++ b/validator/testdata/feature_tests/runtime_in_body.out
@@ -1,2 +1,46 @@
 FAIL
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|  
+|    This test demonstrates an error message selected via dispatch_key rules.
+|  
+|    The <script> tag in the body is invalid only in it's location in the document.
+|    Other forms of <script> tags are allowed in the body, but not the runtime tag.
+|    We want to verify that the error message generated suggests a different
+|    parent, not different attribute values.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|  </head>
+|  <body>
+|  
+|    <!-- This is a valid runtime script tag ag, but it's invalid because it is
+|         found outside the <head>. The test demonstrates that the error message
+|         is useful, suggesting placement in the document head. -->
+|  
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+>>   ^~~~~~~~~
 feature_tests/runtime_in_body.html:40:2 The parent tag of tag 'amphtml engine v0.js script' is 'body', but it can only be 'head'. (see https://www.ampproject.org/docs/reference/spec#required-markup) [DISALLOWED_HTML]
+|  
+|  </body>
+|  </html>

--- a/validator/testdata/feature_tests/several_errors.out
+++ b/validator/testdata/feature_tests/several_errors.out
@@ -1,10 +1,62 @@
 FAIL
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    This example has several problems - see the .out file.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset='pick-a-key'>
+>>   ^~~~~~~~~
 feature_tests/several_errors.html:23:2 The attribute 'charset' in tag 'meta charset=utf-8' is set to the invalid value 'pick-a-key'. (see https://www.ampproject.org/docs/reference/spec#required-markup) [DISALLOWED_HTML]
+|    <link rel='canonical' href='./regular-html-version.html'>
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script type='javascript'>
+>>   ^~~~~~~~~
 feature_tests/several_errors.html:26:2 Only AMP runtime 'script' tags are allowed, and only in the document head. (see https://www.ampproject.org/docs/reference/spec#html-tags) [CUSTOM_JAVASCRIPT_DISALLOWED]
+|    // Let's go crazy. Uhm, no, hahaha.
+|    </script>
+|  </head>
+|  <body>
+|    <table><tr><td>Tables are allowed</td></tr></table>
+|    <amp-img src=dimensions_are_missing.jpg layout="fixed"/>
+>>   ^~~~~~~~~
 feature_tests/several_errors.html:32:2 The mandatory attribute 'height' is missing in tag 'amp-img'. (see https://www.ampproject.org/docs/reference/components/amp-img) [AMP_LAYOUT_PROBLEM]
+|    <!-- We don't allow percent as a size unit either. -->
+|    <amp-ad width=100% height=300>
+>>   ^~~~~~~~~
 feature_tests/several_errors.html:34:2 The attribute 'width' in tag 'amp-ad' is set to the invalid value '100%'. (see https://www.ampproject.org/docs/reference/components/amp-ad) [AMP_LAYOUT_PROBLEM]
+|      <!-- <script>document.write(…)</script> -->
+|    </amp-ad>
+|    <amp-ad width="42" height="42" made_up_attribute="oh hi"></amp-ad>
+>>   ^~~~~~~~~
 feature_tests/several_errors.html:37:2 The attribute 'made_up_attribute' may not appear in tag 'amp-ad'. (see https://www.ampproject.org/docs/reference/components/amp-ad) [AMP_TAG_PROBLEM]
+|    <!-- When rendering errors for attribute values, we collapse whitespace -
+|         even whitespace that is originally encoded.-->
+|    <amp-ad width="42" height="foo&#13;&#10;bar  baz">
+>>   ^~~~~~~~~
 feature_tests/several_errors.html:40:2 The attribute 'height' in tag 'amp-ad' is set to the invalid value 'foo bar baz'. (see https://www.ampproject.org/docs/reference/components/amp-ad) [AMP_LAYOUT_PROBLEM]
-feature_tests/several_errors.html:43:7 The mandatory tag 'meta name=viewport' is missing or incorrect. (see https://www.ampproject.org/docs/reference/spec#required-markup) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
-feature_tests/several_errors.html:43:7 The mandatory tag 'amphtml engine v0.js script' is missing or incorrect. (see https://www.ampproject.org/docs/reference/spec#required-markup) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
-feature_tests/several_errors.html:43:7 The tag 'amp-ad extension .js script' is missing or incorrect, but required by 'amp-ad'. This will soon be an error. (see https://www.ampproject.org/docs/reference/components/amp-ad) [DEPRECATION]
+|    </amp-ad>
+|  </body>
+|  </html>
+>>       ^~~~~~~~~
+feature_tests/several_errors.html:43:6 The mandatory tag 'meta name=viewport' is missing or incorrect. (see https://www.ampproject.org/docs/reference/spec#required-markup) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
+>>       ^~~~~~~~~
+feature_tests/several_errors.html:43:6 The mandatory tag 'amphtml engine v0.js script' is missing or incorrect. (see https://www.ampproject.org/docs/reference/spec#required-markup) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
+>>       ^~~~~~~~~
+feature_tests/several_errors.html:43:6 The tag 'amp-ad extension .js script' is missing or incorrect, but required by 'amp-ad'. This will soon be an error. (see https://www.ampproject.org/docs/reference/components/amp-ad) [DEPRECATION]

--- a/validator/testdata/feature_tests/slash_attrs.out
+++ b/validator/testdata/feature_tests/slash_attrs.out
@@ -1,5 +1,48 @@
 FAIL
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    This is the minimum valid AMP document; it includes all of the required
+|    fields from the spec, but nothing else.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|  <body>
+|  
+|    <p data-this-is-fine="">
+|    <p data-\this-is-not="">
+>>   ^~~~~~~~~
 feature_tests/slash_attrs.html:33:2 The attribute 'data-\this-is-not' may not appear in tag 'p'. [DISALLOWED_HTML]
+|    <p data-/this-is-not="">
+>>   ^~~~~~~~~
 feature_tests/slash_attrs.html:34:2 The attribute 'data-/this-is-not' may not appear in tag 'p'. [DISALLOWED_HTML]
+|    <p data-\this-is-not>
+>>   ^~~~~~~~~
 feature_tests/slash_attrs.html:35:2 The attribute 'data-\this-is-not' may not appear in tag 'p'. [DISALLOWED_HTML]
+|    <p data-/this-is-not>
+>>   ^~~~~~~~~
 feature_tests/slash_attrs.html:36:2 The attribute 'data-/this-is-not' may not appear in tag 'p'. [DISALLOWED_HTML]
+|  
+|  </body>
+|  </html>

--- a/validator/testdata/feature_tests/slot.out
+++ b/validator/testdata/feature_tests/slot.out
@@ -1,1 +1,38 @@
 PASS
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests the slot element.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|  <body>
+|    <slot name="slot1"> <!-- slot is allowed -->
+|      <div class="slot-fallback">
+|        This is a slot fallback.
+|      </div>
+|    </slot>
+|    <slot>The name attribute is optional.</slot>
+|  </body>
+|  </html>

--- a/validator/testdata/feature_tests/spec_example.out
+++ b/validator/testdata/feature_tests/spec_example.out
@@ -1,2 +1,62 @@
 PASS
-feature_tests/spec_example.html:59:7 The tag 'amp-ad extension .js script' is missing or incorrect, but required by 'amp-ad'. This will soon be an error. (see https://www.ampproject.org/docs/reference/components/amp-ad) [DEPRECATION]
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    This is the sample document from the AMP spec.
+|    https://github.com/ampproject/amphtml/blob/master/spec/amp-html-format.md
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|    <head>
+|      <meta charset="utf-8">
+|      <title>Sample document</title>
+|      <link rel="canonical" href="./regular-html-version.html">
+|      <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+|      <style amp-custom>
+|        h1 {color: red}
+|      </style>
+|      <script type="application/ld+json">
+|      {
+|        "@context": "http://schema.org",
+|        "@type": "NewsArticle",
+|        "headline": "Article headline",
+|        "image": [
+|          "thumbnail1.jpg"
+|        ],
+|        "datePublished": "2015-02-05T08:00:00+08:00"
+|      }
+|      </script>
+|      <script async custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.1.js"></script>
+|      <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|      <script async nonce="cryptographic-nonce" src="https://cdn.ampproject.org/v0.js"></script>
+|    </head>
+|    <body>
+|      <h1>Sample document</h1>
+|      <p>
+|        Some text
+|        <amp-img src=sample.jpg width=300 height=300></amp-img>
+|      </p>
+|      <amp-ad width=300 height=250
+|          type="a9"
+|          data-aax_size="300x250"
+|          data-aax_pubname="test123"
+|          data-aax_src="302">
+|      </amp-ad>
+|    </body>
+|  </html>
+>>       ^~~~~~~~~
+feature_tests/spec_example.html:59:6 The tag 'amp-ad extension .js script' is missing or incorrect, but required by 'amp-ad'. This will soon be an error. (see https://www.ampproject.org/docs/reference/components/amp-ad) [DEPRECATION]

--- a/validator/testdata/feature_tests/style_amp_keyframes_error.out
+++ b/validator/testdata/feature_tests/style_amp_keyframes_error.out
@@ -1,12 +1,90 @@
 FAIL
+|  <!--
+|    Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|      This tests a <style> tag in body and should fail.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <title>STAMP examples</title>
+|    <link rel="canonical" href="http://nonblocking.io/" >
+|    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|  <body>
+|    <div></div>
+|    <style amp-keyframes>
+|      amp-img { opacity: 0 } /* this should fail because it's not an @rule */
+>>     ^~~~~~~~~
 feature_tests/style_amp_keyframes_error.html:33:4 CSS syntax error in tag 'style[amp-keyframes]' - qualified rule 'amp-img' must be located inside of a keyframe. [AUTHOR_STYLESHEET_PROBLEM]
+|      a.underlined {} /* selector is not @rule and should fail */
+>>     ^~~~~~~~~
 feature_tests/style_amp_keyframes_error.html:34:4 CSS syntax error in tag 'style[amp-keyframes]' - qualified rule 'a.underlined' must be located inside of a keyframe. [AUTHOR_STYLESHEET_PROBLEM]
+|      @font-face {} /* this should fail because it's not an allowed @rule */
+>>     ^~~~~~~~~
 feature_tests/style_amp_keyframes_error.html:35:4 CSS syntax error in tag 'style[amp-keyframes]' - saw invalid at rule '@font-face'. [AUTHOR_STYLESHEET_PROBLEM]
+|      @supports (offset-distance: 0) {
+|        amp-carousel {} /* this should fail because it's not allowed content inside the @supports */
+>>       ^~~~~~~~~
 feature_tests/style_amp_keyframes_error.html:37:6 CSS syntax error in tag 'style[amp-keyframes]' - qualified rule 'amp-carousel' must be located inside of a keyframe. [AUTHOR_STYLESHEET_PROBLEM]
+|      }
+|      @media (min-width: 300px) {
+|        /* this should fail because css style rules are only allowed inside keyframes */
+|        from {transform: translateX(-100%);}
+>>       ^~~~~~~~~
 feature_tests/style_amp_keyframes_error.html:41:6 CSS syntax error in tag 'style[amp-keyframes]' - qualified rule 'from' must be located inside of a keyframe. [AUTHOR_STYLESHEET_PROBLEM]
+|        to {transform: translateX(100%);} /* this should fail because it's a css style rule */
+>>       ^~~~~~~~~
 feature_tests/style_amp_keyframes_error.html:42:6 CSS syntax error in tag 'style[amp-keyframes]' - qualified rule 'to' must be located inside of a keyframe. [AUTHOR_STYLESHEET_PROBLEM]
+|      }
+|      @media (min-width: 300px) {
+|        /* this should fail because css style rules are only allowed inside keyframes */
+|        100% {transform: translateX(-100%);}
+>>       ^~~~~~~~~
 feature_tests/style_amp_keyframes_error.html:46:6 CSS syntax error in tag 'style[amp-keyframes]' - qualified rule '100' must be located inside of a keyframe. [AUTHOR_STYLESHEET_PROBLEM]
+|      }
+|      @keyframes anim1 {
+|        /* this should fail because the only allowed properties are
+|         * [opacity, transform, visibility, offset-distance] */
+|        100% {thisshouldfail: translateX(100%);}
+>>             ^~~~~~~~~
 feature_tests/style_amp_keyframes_error.html:51:12 CSS syntax error in tag 'style[amp-keyframes]' - invalid property 'thisshouldfail'. The only allowed properties are '['offset-distance', 'opacity', 'transform', 'visibility']'. [AUTHOR_STYLESHEET_PROBLEM]
+|      }
+|      @keyframes anim2 {
+|        @keyframes anim1 {
+>>       ^~~~~~~~~
 feature_tests/style_amp_keyframes_error.html:54:6 CSS syntax error in tag 'style[amp-keyframes]' - keyframe inside keyframe is not allowed. [AUTHOR_STYLESHEET_PROBLEM]
+|          /* this should fail because you cannot have a keyframe inside of another keyframe */
+|          100% {visibility: visible}
+|        }
+|      }
+|      @keyframes anim1 {
+|        100% {} /* this should fail because it makes no sense */
+>>       ^~~~~~~~~
 feature_tests/style_amp_keyframes_error.html:60:6 CSS syntax error in tag 'style[amp-keyframes]' - qualified rule '100' has no declarations. [AUTHOR_STYLESHEET_PROBLEM]
+|      }
+|      @keyframes anim1 {
+|        a {} /* this should fail because it makes no sense */
+>>       ^~~~~~~~~
 feature_tests/style_amp_keyframes_error.html:63:6 CSS syntax error in tag 'style[amp-keyframes]' - qualified rule 'a' has no declarations. [AUTHOR_STYLESHEET_PROBLEM]
+|      }
+|    </style>
+|  </body>
+|  </html>

--- a/validator/testdata/feature_tests/style_amp_keyframes_passing.out
+++ b/validator/testdata/feature_tests/style_amp_keyframes_passing.out
@@ -1,1 +1,98 @@
 PASS
+|  <!--
+|    Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|      This tests a <style> tag in body and should pass.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <title>STAMP examples</title>
+|    <link rel="canonical" href="http://nonblocking.io/" >
+|    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|  <body>
+|    <div></div>
+|    <style amp-keyframes>
+|      @keyframes anim1 {
+|        0% {transform: translateX(-100%);}
+|        100% {transform: translateX(100%);}
+|      }
+|      @-webkit-keyframes anim1 {
+|        0% {transform: translateX(-100%);}
+|        100% {transform: translateX(100%);}
+|      }
+|      @-moz-keyframes anim1 {
+|        0% {transform: translateX(-100%);}
+|        100% {transform: translateX(100%);}
+|      }
+|      @-o-keyframes anim1 {
+|        0% {transform: translateX(-100%);}
+|        100% {transform: translateX(100%);}
+|      }
+|      @media (min-width: 300px) {
+|        @keyframes anim1 {
+|          0% {transform: translateX(-200%);}
+|          100% {transform: translateX(200%);}
+|        }
+|      }
+|      @supports (offset-distance: 0) {
+|        @keyframes anim1 {
+|          0% {offset-distance: 0}
+|          100% {offset-distance: 100%}
+|        }
+|      }
+|      @media (min-width: 300px) {
+|        @supports (offset-distance: 0) {
+|          @keyframes anim1 {
+|            0% {offset-distance: 0}
+|            100% {offset-distance: 100%}
+|          }
+|        }
+|      }
+|      @supports (offset-distance: 0) {
+|        @media (min-width: 300px) {
+|          @keyframes anim1 {
+|            from {transform: translateX(-200%); opacity: 0.5; visibility: hidden;} /* from is 0% */
+|            to {transform: translateX(200%); opacity: 1; visibility: visible;} /* to is 100% */
+|          }
+|        }
+|      }
+|      @supports (offset-distance: 0) {
+|        @media (min-width: 300px) {
+|          @keyframes anim1 {
+|            100% {opacity: 0.5;}
+|          }
+|        }
+|      }
+|      @supports (offset-distance: 0) {
+|        @media (min-width: 300px) {
+|          @keyframes anim1 {
+|            100% {visibility: visible;}
+|          }
+|        }
+|      }
+|      @keyframes anim1 {
+|        from {transform: translateX(-200%); opacity: 0.5; visibility: hidden;} /* from is 0% */
+|        to {transform: translateX(200%); opacity: 1; visibility: visible;} /* to is 100% */
+|      }
+|    </style>
+|  </body>
+|  </html>

--- a/validator/testdata/feature_tests/style_in_body_error.out
+++ b/validator/testdata/feature_tests/style_in_body_error.out
@@ -1,2 +1,37 @@
 FAIL
+|  <!--
+|    Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|      This tests a <style> tag in body and should fail.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <title>STAMP examples</title>
+|    <link rel="canonical" href="http://nonblocking.io/" >
+|    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|  <body>
+|    <style amp-keyframes></style> <!-- this should error because it isn't the last child of body -->
+>>   ^~~~~~~~~
 feature_tests/style_in_body_error.html:31:2 Tag 'style[amp-keyframes]', if present, must be the last child of tag 'body'. [AMP_TAG_PROBLEM]
+|    <div></div>
+|  </body>
+|  </html>

--- a/validator/testdata/feature_tests/style_in_body_passing.out
+++ b/validator/testdata/feature_tests/style_in_body_passing.out
@@ -1,1 +1,35 @@
 PASS
+|  <!--
+|    Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|      This tests a <style> tag in body and should pass.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <title>STAMP examples</title>
+|    <link rel="canonical" href="http://nonblocking.io/" >
+|    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|  <body>
+|    <div></div>
+|    <style amp-keyframes></style>
+|  </body>
+|  </html>

--- a/validator/testdata/feature_tests/stylesheet_in_body.out
+++ b/validator/testdata/feature_tests/stylesheet_in_body.out
@@ -1,2 +1,47 @@
 FAIL
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|  
+|    This test demonstrates an error message selected via dispatch_key rules.
+|  
+|    The <link> tag in the body is invalid only in it's location in the document.
+|    Other forms of <link> tags are allowed in the body, but not rel="stylesheet"
+|    <link> tags. We want to verify that the error message generated suggests
+|    a different parent, not different attribute values.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|  <body>
+|  
+|    <!-- This is a valid font stylesheet tag, but it's invalid because it is
+|         found outside the <head>. The test demonstrates that the error message
+|         is useful, suggesting placement in the document head. -->
+|  
+|    <link href="https://fonts.googleapis.com/css?family=Lato" rel="stylesheet">
+>>   ^~~~~~~~~
 feature_tests/stylesheet_in_body.html:41:2 The parent tag of tag 'link rel=stylesheet for fonts' is 'body', but it can only be 'head'. (see https://www.ampproject.org/docs/reference/spec#custom-fonts) [DISALLOWED_HTML]
+|  
+|  </body>
+|  </html>

--- a/validator/testdata/feature_tests/svg.out
+++ b/validator/testdata/feature_tests/svg.out
@@ -1,6 +1,102 @@
 FAIL
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests SVG tags and attrs.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1,user-scalable=no,minimal-ui">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|  <body>
+|    <h2>SVG</h2>
+|    <!-- same svg pic as the one in valid_examples_from_github/everything.amp.html -->
+|    <!-- "unofficial amphtml logo" -->
+|    <svg width="400" height="296" viewBox="1400 500 3000 2500">
+|      <path d="m 3766.9354,1578.1181 c 58.2769,-756.81944 -408.1876,-717.21057 -510.4769,-701.02201 -79.902,12.64545 -239.2559,90.53098 -313.8601,318.92831 -82.3686,252.1683 143.3895,461.6098 259.4436,801.3231 172.8182,640.8523 -882.0196,923.1062 -1227.7959,798.7381 -69.3048,-30.0286 -182.3973,-108.7232 -158.8806,-186.5382 8.5153,-72.4218 -105.5719,-107.3077 -82.4098,-11.1024 95.373,379.694 618.3608,323.5968 1066.1849,144.2115 250.0432,-100.16 489.5859,-347.2474 489.7608,-633.164 -50.7024,-386.8592 -391.2774,-599.5297 -282.7825,-917.5279 173.2946,-330.57664 355.7612,-318.24308 596.6594,-169.4657 82.8022,96.8444 115.4521,181.225 119.5309,313.0092 2.5525,82.4609 -36.2889,260.8703 44.6262,242.61 z" fill="#669900"/>
+|      <path d="m 4416.0026,1455.3672 c 77.2745,23.6811 73.5053,107.3467 75.9575,166.8979 15.3869,149.8221 -6.2292,300.1828 4.2896,450.1688 -8.5601,219.3654 0.7438,438.9849 -1.682,658.4723 -9.842,56.6077 34.5512,148.3936 -55.7836,165.4604 -81.0177,12.4369 -163.7234,-0.9781 -245.5127,3.3739 -248.997,-1.7285 -498.1326,1.9053 -747.01,-2.3009 -86.3231,6.2887 -77.5196,-71.1333 -75.8856,-133.0733 43.1106,-461.6582 -55.107,-895.0067 58.8105,-1302.5316 173.2754,-4.339 702.7558,-6.7657 986.8163,-6.4675 z" fill="#6699ff"/>
+|      <path d="m 3534.2772,1717.8648 c 221.2517,21.2119 572.0499,-17.0571 851.7094,28.1009 -21.0892,135.2035 -26.2108,343.7127 -18.8464,481.1314 0.6629,160.8137 -8.6026,320.1194 -0.3032,497.6322 -118.3583,29.6629 -269.1727,23.1546 -403.9033,17.3782 -156.4796,-6.7087 -363.7832,20.958 -488.8767,-22.9287 16.6915,-141.6537 14.7827,-372.2907 21.3755,-514.5289 7.5082,-162.6119 26.4066,-324.4933 38.8447,-486.7851 z" fill="#3366cc"/>
+|      <path d="m 3889.2766,1650.5266 c 27.7364,23.6886 72.1445,20.4506 101.2331,1.0458 22.3604,-17.6131 19.1236,-56.6446 -8.0767,-68.5575 -51.3171,-39.4426 -125.0811,27.5752 -93.1564,67.5117 z" fill="#ff6600"/>
+|      <path d="m 3985.4115,1806.5993 c -54.1134,86.3413 -120.9065,155.5988 -208.7186,279.6705 -98.9752,111.8484 -122.1792,163.717 136.357,69.2462 175.8375,-36.4294 35.4891,130.704 -15.9848,267.0009 -45.1026,119.4263 -83.2501,196.2986 -92.2725,256.8308 139.8358,-155.934 233.9965,-339.5471 357.0405,-505.614 167.1182,-233.0853 -225.0018,-15.3832 -266.0121,-102.9119 38.3338,-115.9788 97.6167,-173.7877 89.7826,-252.6178 l -0.1926,-11.6047 0,0 z" fill="#ffcc00"/>
+|      <path d="m 4099.9162,1659.9255 c 27.7366,23.6887 72.1447,20.4507 101.2333,1.046 22.3604,-17.6133 19.1235,-56.6446 -8.0768,-68.5575 -51.3168,-39.4426 -125.0812,27.5752 -93.1565,67.5115 z" fill="#ff6600"/>
+|      <path d="m 3681.6605,1651.4038 c 27.7364,23.6888 72.1445,20.4506 101.2332,1.046 22.3603,-17.6132 19.1234,-56.6448 -8.0769,-68.5575 -51.3169,-39.4428 -125.0811,27.5751 -93.1563,67.5115 z" fill="#ff6600"/>
+|      <path d="m 2575.0536,1072.0944 c -41.7949,-215.28999 -198.1073,64.4153 -379.7157,193.092 -133.7465,94.7647 -234.5954,11.3165 -570.0903,133.4228 -401.8972,146.2742 -388.2427,684.9442 -224.4598,986.8548 366.0107,674.6879 1103.0419,131.271 1216.6407,-55.3662 104.6211,-171.8874 330.8926,-138.9279 453.9675,-237.6837 59.7216,-47.9209 -5.9599,-359.9096 -105.7909,-337.7945 -648.2816,143.6118 -380.3137,-629.7889 -390.5515,-682.5252 z" fill="#ffcc00"/>
+|      <path d="m 2058.3207,1381.3517 c -555.3851,-61.9665 -825.72,463.8013 -645.5204,442.4364 185.0637,-21.9416 158.9799,-504.669 310.9149,49.8713 57.2299,208.8816 401.8092,439.7925 494.821,638.6355 11.6767,57.5407 75.9987,46.3975 104.7889,25.124 31.5505,-23.313 18.9107,-80.0105 6.3288,-117.0635 -83.6721,-143.0048 -274.9312,-272.5734 -377.898,-377.9464 -120.8368,-136.4516 -208.1109,-334.9469 -151.0128,-495.0356 34.8137,-61.4683 63.3834,-80.7131 124.7882,-78.1048 55.22,9.7787 202.4079,237.5436 211.6533,157.296 6.1561,-44.3048 11.1555,-235.1689 -78.8639,-245.2129 z" fill="#ff6600"/>
+|      <path d="m 4005.3105,689.39563 c -132.1157,120.32132 -1412.0359,816.95107 -1555.1646,911.30147 160.4961,184.2922 15.234,-12.8488 95.6898,137.9579 550.1675,-329.2476 954.2058,-586.1938 1528.6046,-873.93017 75.1515,-104.89315 -12.1136,-113.30773 -69.1298,-175.3292 z" fill="#3366cc"/>
+|      <path d="m 2194.3681,1352.5268 c 9.2935,-33.3595 115.3351,-96.1488 116.2957,-60.9354 14.1803,519.7676 226.8596,740.1443 346.5092,899.2496 -9.1403,53.8137 -95.4967,108.843 -112.5912,76.6163 -104.516,-105.815 -172.0892,-466.006 -263.1765,-522.0611 -35.4594,-21.8216 12.7645,157.4396 -44.8138,184.0385 -77.4149,35.7627 -124.043,-138.0522 -229.1002,-113.7727 -18.3195,211.0153 555.9431,443.0665 505.2979,529.8185 -23.9237,43.5892 -81.9643,131.8588 -116.5557,78.0317 -146.1854,-207.6808 -213.2253,-245.8824 -420.072,-434.4752 -155.6003,-141.8688 -136.5394,-403.4861 -68.1091,-424.1442 116.1363,-27.4812 191.9444,245.9541 275.2956,188.1784 65.7711,-140.9662 -10.6629,-310.5452 11.0201,-400.5444 z" fill="#669900"/>
+|      <path d="m 1640.1413,1783.8678 c -1.2739,288.86 586.9469,664.0874 521.3165,807.9936 -69.3201,51.7542 -264.7475,48.6232 -223.0496,-59.7663 40.7522,-117.7527 -130.0456,-272.4627 -303.3394,-291.2684 -296.5803,-32.1851 105.9828,212.4171 191.594,291.2294 36.2581,33.3788 125.7201,137.2209 -60.6765,119.5389 -142.0502,-35.061 -243.6721,-174.3502 -325.3694,-295.8032 -78.4159,-116.5746 -186.0507,-483.4195 -48.246,-480.286 125.3372,6.1146 22.5452,202.8366 86.2367,275.034 41.4944,47.0359 443.4581,128.9297 80.3823,-189.183 -157.9532,-138.3924 81.516,-260.2092 81.1514,-177.489 z" fill="#3366cc"/>
+|      <path d="m 4079.5806,868.74488 c -18.4503,-3.3062 -24.5591,-6.34261 -33.5316,-16.66736 -4.696,-5.40376 -13.8197,-14.12548 -20.2749,-19.38163 -15.4956,-12.61776 -67.3382,-71.44012 -79.5473,-90.25706 -5.3049,-8.17621 -11.2871,-16.48111 -13.2935,-18.45531 -3.2617,-3.20909 -2.0572,-6.35995 11.3672,-29.73174 8.2588,-14.37823 17.879,-28.42525 21.3781,-31.21559 5.1887,-4.13699 12.0245,-5.80701 37.0394,-9.04885 16.8723,-2.18653 54.8305,-8.80671 84.352,-14.71151 29.5216,-5.90476 65.0265,-12.78154 78.8997,-15.28165 l 25.2242,-4.54567 23.7713,9.77618 c 62.8275,25.83824 111.7721,65.33019 111.7721,90.18546 1e-4,5.06675 -4.6709,12.80857 -17.366,28.78381 -52.1377,65.60993 -108.3882,110.96089 -146.1569,117.83656 -19.9034,3.62333 -69.5666,5.23515 -83.6338,2.71436 z" fill="#ff6600"/>
+|      <path d="m 2377.3238,1269.2624 c -26.787,279.7212 111.0044,672.201 309.1165,843.6212 80.8729,69.9767 240.8138,-4.026 318.9086,-41.6454 45.2094,-35.9724 35.0313,-101.296 26.1997,-150.9873 -17.4339,-69.7557 -49.832,-121.797 -100.685,-116.1204 -45.4057,5.0682 -68.5356,8.8251 -64.9322,120.9642 1.3601,42.327 -40.4759,93.1741 -89.0657,90.4079 -52.9357,4.327 -75.8994,-38.881 -101.1012,-69.9814 -212.4085,-262.1247 -233.2146,-599.5762 -162.849,-813.093 10.758,-32.6441 5.6189,-86.0919 -34.34,-65.3213 -75.6217,39.3078 -93.8408,124.7689 -101.2517,202.1555 z" fill="#ff6600"/>
+|    </svg>
+|  
+|  <!-- This has some text saying "Oh HI I'm an SVG." and three geometric shapes
+|       in red, green, and blue underneath. -->
+|  <svg width="640" height="480" xmlns="http://www.w3.org/2000/svg">
+|   <!-- Created with SVG-edit - http://svg-edit.googlecode.com/ -->
+|   <g>
+|    <title>Layer 1</title>
+|    <text xml:space="preserve" text-anchor="middle" font-family="serif" font-size="24" id="svg_1" y="148" x="314" stroke-width="0" stroke="#000000" fill="#000000">Oh Hi I'm an SVG.</text>
+|    <rect id="svg_2" height="169" width="185" y="193" x="25" stroke-width="0" stroke="#000000" fill="#ff0000"/>
+|    <circle id="svg_3" r="89.560036" cy="275" cx="315" stroke-linecap="null" stroke-linejoin="null" stroke-width="0" stroke="#000000" fill="#007f00"/>
+|    <path id="svg_4" d="m515,195l-96,165l198,-4" stroke-linecap="null" stroke-linejoin="null" stroke-width="0" stroke="#000000" fill="#0000ff"/>
+|   </g>
+|  </svg>
+|  
+|  <!-- This is what Dima described in http://b/24416359 to be common
+|       output from graphics tools. While it's a bit weird to have this namespace
+|       stuff in HTML5, we allow it just like browsers would do in practice.
+|   -->
+|  <svg version="1.0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="640" height="480">
+|    <circle id="svg_3_2" r="89.560036" cy="275" cx="315" stroke-linecap="null" stroke-linejoin="null" stroke-width="0" stroke="#000000" fill="#007f00"/>
+|  </svg>
+|  
+|  <!-- Allow version to be 1.1 and stop tags for lineargradient and
+|    radialgradient -->
+|    <svg version = "1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+|      <lineargradient x1="30%" y1="-55%" x2="58%" y2="94%">
+|        <stop offset="0%" stop-color="#fff" offset="0%" />
+|        <stop offset="0%" stop-color="#aaa" offset="67.36%" />
+>>       ^~~~~~~~~
 feature_tests/svg.html:76:6 The tag 'stop' contains the attribute 'offset' repeated multiple times. [DISALLOWED_HTML]
+|        <stop offset="0%" stop-color="#333" offset="100%" />
+>>       ^~~~~~~~~
 feature_tests/svg.html:77:6 The tag 'stop' contains the attribute 'offset' repeated multiple times. [DISALLOWED_HTML]
+|      </lineargradient>
+|      <radialgradient cx="50%" cy="50%" r="50%" fx="50%" fy="50%">
+|        <stop offset="0%" stop-color="#fff" offset="0%" />
+|        <stop offset="0%" stop-color="#aaa" offset="67.36%" />
+>>       ^~~~~~~~~
 feature_tests/svg.html:81:6 The tag 'stop' contains the attribute 'offset' repeated multiple times. [DISALLOWED_HTML]
+|        <stop offset="0%" stop-color="#333" offset="100%" />
+>>       ^~~~~~~~~
 feature_tests/svg.html:82:6 The tag 'stop' contains the attribute 'offset' repeated multiple times. [DISALLOWED_HTML]
+|      </radialgradient>
+|    </svg>
+|  
+|    <!-- Invalid xml:base present -->
+|    <svg xml:base="javascript:alert('hello world')">
+>>   ^~~~~~~~~
 feature_tests/svg.html:87:2 The attribute 'xml:base' may not appear in tag 'svg'. (see https://www.ampproject.org/docs/reference/spec#svg) [DISALLOWED_HTML]
+|      <a href="#"><circle r="10"></a>
+|    </svg>
+|  </body>
+|  </html>

--- a/validator/testdata/feature_tests/track_tag.out
+++ b/validator/testdata/feature_tests/track_tag.out
@@ -1,7 +1,76 @@
 FAIL
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    This is a test for the rules surrounding the <track> tag:
+|     - Must be a child of <audio>, <video>, <amp-audio>, or <amp-video>
+|     - If attribute kind has value 'subtitles', attribute srcland must
+|       be specified.
+|     - 'src' attribute must be https.
+|    This is the minimum valid AMP document; it includes all of the required
+|    fields from the spec, but nothing else.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <script async custom-element="amp-audio" src="https://cdn.ampproject.org/v0/amp-audio-latest.js"></script>
+|  </head>
+|  <body>
+|  
+|    <amp-audio src="https://example.com/audio" layout="fixed">
+|      <!-- Valid examples -->
+|      <track src="https://example.com/track"></track>
+|      <track src="https://example.com/track" kind="captions"></track>
+|      <track src="https://example.com/track" kind="descriptions"></track>
+|      <track src="https://example.com/track"
+|             kind="subtitles"
+|             srclang="en"></track>
+|  
+|      <!-- Invalid: http URL -->
+|      <track src="http://example.com/track"></track>
+>>     ^~~~~~~~~
 feature_tests/track_tag.html:48:4 Invalid URL protocol 'http:' for attribute 'src' in tag 'amp-audio > track'. [AMP_TAG_PROBLEM]
+|      <!-- Invalid: subtitles but no srclang -->
+|      <track src="https://example.com/track" kind="subtitles"></track>
+>>     ^~~~~~~~~
 feature_tests/track_tag.html:50:4 The mandatory attribute 'srclang' is missing in tag 'amp-audio > track[kind=subtitles]'. [AMP_TAG_PROBLEM]
+|    </amp-audio>
+|  
+|    <!-- Invalid examples to make sure the error messages look right -->
+|    <noscript>
+|      <audio><track src="https://a.com/" kind="subtitles"></track></audio>
+>>            ^~~~~~~~~
 feature_tests/track_tag.html:55:11 The mandatory attribute 'srclang' is missing in tag 'audio > track[kind=subtitles]'. [DISALLOWED_HTML]
+|      <video><track src="https://a.com/" kind="subtitles"></track></video>
+>>            ^~~~~~~~~
 feature_tests/track_tag.html:56:11 The mandatory attribute 'srclang' is missing in tag 'video > track[kind=subtitles]'. [DISALLOWED_HTML]
+|    </noscript>
+|    <amp-video src="https://example.com/audio" layout="fixed" height=42 width=42>
+|      <track src="https://a.com/" kind="subtitles"></track>
+>>     ^~~~~~~~~
 feature_tests/track_tag.html:59:4 The mandatory attribute 'srclang' is missing in tag 'amp-video > track[kind=subtitles]'. [AMP_TAG_PROBLEM]
-feature_tests/track_tag.html:63:7 The tag 'amp-video extension .js script' is missing or incorrect, but required by 'amp-video'. This will soon be an error. (see https://www.ampproject.org/docs/reference/components/amp-video) [DEPRECATION]
+|    </amp-video>
+|  
+|  </body>
+|  </html>
+>>       ^~~~~~~~~
+feature_tests/track_tag.html:63:6 The tag 'amp-video extension .js script' is missing or incorrect, but required by 'amp-video'. This will soon be an error. (see https://www.ampproject.org/docs/reference/components/amp-video) [DEPRECATION]

--- a/validator/testdata/feature_tests/urls.out
+++ b/validator/testdata/feature_tests/urls.out
@@ -1,54 +1,224 @@
 FAIL
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|      This tests looks at specific errors related to URLs in href and src
+|      attributes.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="javascript://llamas">
+>>   ^~~~~~~~~
 feature_tests/urls.html:25:2 Invalid URL protocol 'javascript:' for attribute 'href' in tag 'link rel=canonical'. (see https://www.ampproject.org/docs/reference/spec#required-markup) [DISALLOWED_HTML]
+|    <meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1,user-scalable=no,minimal-ui">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script src="https://cdn.ampproject.org/v0.js" async></script>
+|  </head>
+|  <body>
+|    <a href="https://google.com/">Valid URL</a>
+|    <a href=" http://google.com/ ">Valid URL</a>
+|    <a href="foo">Valid URL</a>
+|    <a href="/bar">Valid URL</a>
+|    <a href="#foobar">Valid URL</a>
+|    <a href="https://⚡">Valid URL</a>
+|    <a href="https://">Valid URL</a>
+>>   ^~~~~~~~~
 feature_tests/urls.html:37:2 Malformed URL 'https://' for attribute 'href' in tag 'a'. (see https://www.ampproject.org/docs/reference/spec#links) [DISALLOWED_HTML]
+|    <a href="HtTpS://Google.com/">Valid URL</a>
+|    <a href="javascript:alert('boo')">Invalid protocol</a>
+>>   ^~~~~~~~~
 feature_tests/urls.html:39:2 Invalid URL protocol 'javascript:' for attribute 'href' in tag 'a'. (see https://www.ampproject.org/docs/reference/spec#links) [DISALLOWED_HTML]
+|    <a href="JavaScript:alert('boo')">Invalid protocol</a>
+>>   ^~~~~~~~~
 feature_tests/urls.html:40:2 Invalid URL protocol 'javascript:' for attribute 'href' in tag 'a'. (see https://www.ampproject.org/docs/reference/spec#links) [DISALLOWED_HTML]
+|    <a href="javascript&colon;alert(1)">Invalid protocol</a>
+>>   ^~~~~~~~~
 feature_tests/urls.html:41:2 Invalid URL protocol 'javascript:' for attribute 'href' in tag 'a'. (see https://www.ampproject.org/docs/reference/spec#links) [DISALLOWED_HTML]
+|    <a href="vbscript:bar">Invalid protocol</a>
+>>   ^~~~~~~~~
 feature_tests/urls.html:42:2 Invalid URL protocol 'vbscript:' for attribute 'href' in tag 'a'. (see https://www.ampproject.org/docs/reference/spec#links) [DISALLOWED_HTML]
+|    <a href="data:baz">Invalid protocol</a>
+>>   ^~~~~~~~~
 feature_tests/urls.html:43:2 Invalid URL protocol 'data:' for attribute 'href' in tag 'a'. (see https://www.ampproject.org/docs/reference/spec#links) [DISALLOWED_HTML]
+|    <a href="ftp://google.com/">Valid protocol</a>
+|    <!-- invalid (javascript is not an allowed protocol: singluar src element) -->
+|    <amp-img srcset="javascript:alert(1)" layout="fill"></amp-img>
+>>   ^~~~~~~~~
 feature_tests/urls.html:46:2 Invalid URL protocol 'javascript:' for attribute 'srcset' in tag 'amp-img'. (see https://www.ampproject.org/docs/reference/components/amp-img) [AMP_TAG_PROBLEM]
+|    <!-- invalid (javascript is not an allwoed protocol: second src element) -->
+|    <amp-img srcset="image-1.png 1x, javascript:alert(1)" layout="fill"></amp-img>
+>>   ^~~~~~~~~
 feature_tests/urls.html:48:2 Multiple image candidates with the same width or pixel density found in attribute 'srcset' in tag 'amp-img'. (see https://www.ampproject.org/docs/reference/components/amp-img) [DISALLOWED_HTML]
+|    <!-- valid -->
+|    <amp-img srcset="image-1x.png 1x, image-2x.png 2x" layout="fill"></amp-img>
+|    <!-- valid -->
+|    <amp-img srcset="image-1x.png 1x, image-2x.png 2x," layout="fill"></amp-img>
+|    <!-- valid (commas are valid in URLs) -->
+|    <amp-img srcset="image-1,x.png 1x, image-2,x.png 2x" layout="fill"></amp-img>
+|    <!-- invalid (javascript is not an allowed protocol: multi src element) -->
+|    <amp-img srcset="javascript:alert('boo') 1x, foo 2x" layout="fill"></amp-img>
+>>   ^~~~~~~~~
 feature_tests/urls.html:56:2 Invalid URL protocol 'javascript:' for attribute 'srcset' in tag 'amp-img'. (see https://www.ampproject.org/docs/reference/components/amp-img) [AMP_TAG_PROBLEM]
+|    <!-- invalid (javascript is not an allowed protocol: case insensitive) -->
+|    <amp-img srcset="image-1x.png 1x, JavaScript:baz 2x" layout="fill"></amp-img>
+>>   ^~~~~~~~~
 feature_tests/urls.html:58:2 Invalid URL protocol 'javascript:' for attribute 'srcset' in tag 'amp-img'. (see https://www.ampproject.org/docs/reference/components/amp-img) [AMP_TAG_PROBLEM]
+|    <!-- invalid (empty) -->
+|    <amp-img srcset="" layout="fill"></amp-img>
+>>   ^~~~~~~~~
 feature_tests/urls.html:60:2 Missing URL for attribute 'srcset' in tag 'amp-img'. (see https://www.ampproject.org/docs/reference/components/amp-img) [AMP_TAG_PROBLEM]
+|    <!-- invalid (duplicate pixel density) -->
+|    <amp-img srcset="image-1x.png 1x, image-2x.png 1x" layout="fill"></amp-img>
+>>   ^~~~~~~~~
 feature_tests/urls.html:62:2 Multiple image candidates with the same width or pixel density found in attribute 'srcset' in tag 'amp-img'. (see https://www.ampproject.org/docs/reference/components/amp-img) [DISALLOWED_HTML]
+|    <!-- invalid (URL has spaces that are not encoded) -->
+|    <amp-img srcset="image 1x.png 1x, image 2x.png 2x" layout="fill"></amp-img>
+>>   ^~~~~~~~~
 feature_tests/urls.html:64:2 The attribute 'srcset' in tag 'amp-img' is set to the invalid value 'image 1x.png 1x, image 2x.png 2x'. (see https://www.ampproject.org/docs/reference/components/amp-img) [AMP_TAG_PROBLEM]
+|    <!-- valid (URL has encoded spaces) -->
+|    <amp-img srcset=", image%201x.png 1x, image%202x.png 2x" layout="fill"></amp-img>
+|    <a href="http://foobarbazexample.com\x10.com/">Interesting Case</a>
+|  
+|    <!-- Missing src -->
+|    <amp-ad src="" width="42" height="42" type=""></amp-ad>
+>>   ^~~~~~~~~
 feature_tests/urls.html:70:2 Missing URL for attribute 'src' in tag 'amp-ad'. (see https://www.ampproject.org/docs/reference/components/amp-ad) [AMP_TAG_PROBLEM]
+|    <amp-anim src="" width="42" height="42"></amp-anim>
+>>   ^~~~~~~~~
 feature_tests/urls.html:71:2 Missing URL for attribute 'src' in tag 'amp-anim'. (see https://www.ampproject.org/docs/reference/components/amp-anim) [AMP_TAG_PROBLEM]
+>>   ^~~~~~~~~
 feature_tests/urls.html:71:2 The tag 'amp-anim' requires including the 'amp-anim' extension JavaScript. (see https://www.ampproject.org/docs/reference/components/amp-anim) [AMP_TAG_PROBLEM]
+|    <amp-audio src="" layout="fixed" width="42"></amp-audio>
+>>   ^~~~~~~~~
 feature_tests/urls.html:72:2 Missing URL for attribute 'src' in tag 'amp-audio'. (see https://www.ampproject.org/docs/reference/components/amp-audio) [AMP_TAG_PROBLEM]
+>>   ^~~~~~~~~
 feature_tests/urls.html:72:2 The tag 'amp-audio' requires including the 'amp-audio' extension JavaScript. (see https://www.ampproject.org/docs/reference/components/amp-audio) [AMP_TAG_PROBLEM]
+|    <amp-iframe src="" width="42" height="42"></amp-iframe>
+>>   ^~~~~~~~~
 feature_tests/urls.html:73:2 Missing URL for attribute 'src' in tag 'amp-iframe'. (see https://www.ampproject.org/docs/reference/components/amp-iframe) [AMP_TAG_PROBLEM]
+>>   ^~~~~~~~~
 feature_tests/urls.html:73:2 The tag 'amp-iframe' requires including the 'amp-iframe' extension JavaScript. (see https://www.ampproject.org/docs/reference/components/amp-iframe) [AMP_TAG_PROBLEM]
+|    <amp-img src="" layout="responsive" width="42" height="42"></amp-img>
+>>   ^~~~~~~~~
 feature_tests/urls.html:74:2 Missing URL for attribute 'src' in tag 'amp-img'. (see https://www.ampproject.org/docs/reference/components/amp-img) [AMP_TAG_PROBLEM]
+|    <amp-pixel src="" layout="fixed" width="42"></amp-pixel>
+|    <amp-video src="" width="42" height="42"></amp-video>
+>>   ^~~~~~~~~
 feature_tests/urls.html:76:2 Missing URL for attribute 'src' in tag 'amp-video'. (see https://www.ampproject.org/docs/reference/components/amp-video) [AMP_TAG_PROBLEM]
+|    <!-- src contains only whitespace: regular space followed by non-breaking
+|         space followed by tab. -->
+|    <amp-ad src="  	" width="42" height="42" type=""></amp-ad>
+>>   ^~~~~~~~~
 feature_tests/urls.html:79:2 Missing URL for attribute 'src' in tag 'amp-ad'. (see https://www.ampproject.org/docs/reference/components/amp-ad) [AMP_TAG_PROBLEM]
+|    <!-- Invalid protocol -->
+|    <amp-ad src="http://amp-ad" width="42" height="42" type=""></amp-ad>
+>>   ^~~~~~~~~
 feature_tests/urls.html:81:2 Invalid URL protocol 'http:' for attribute 'src' in tag 'amp-ad'. (see https://www.ampproject.org/docs/reference/components/amp-ad) [AMP_TAG_PROBLEM]
+|    <amp-iframe src="http://amp-iframe" width="42" height="42"></amp-iframe>
+>>   ^~~~~~~~~
 feature_tests/urls.html:82:2 Invalid URL protocol 'http:' for attribute 'src' in tag 'amp-iframe'. (see https://www.ampproject.org/docs/reference/components/amp-iframe) [AMP_TAG_PROBLEM]
+>>   ^~~~~~~~~
 feature_tests/urls.html:82:2 The tag 'amp-iframe' requires including the 'amp-iframe' extension JavaScript. (see https://www.ampproject.org/docs/reference/components/amp-iframe) [AMP_TAG_PROBLEM]
+|    <amp-pixel src="http://amp-pixel" layout="fixed" width="42"></amp-pixel>
+>>   ^~~~~~~~~
 feature_tests/urls.html:83:2 Invalid URL protocol 'http:' for attribute 'src' in tag 'amp-pixel'. (see https://www.ampproject.org/docs/reference/components/amp-pixel) [AMP_TAG_PROBLEM]
+|    <amp-video src="http://amp-video" width="42" height="42"></amp-video>
+>>   ^~~~~~~~~
 feature_tests/urls.html:84:2 Invalid URL protocol 'http:' for attribute 'src' in tag 'amp-video'. (see https://www.ampproject.org/docs/reference/components/amp-video) [AMP_TAG_PROBLEM]
+|    <a href=" j a v a s c r i p t :alert(1)">Invalid protocol</a>
+>>   ^~~~~~~~~
 feature_tests/urls.html:85:2 Invalid URL protocol 'j a v a s c r i p t :' for attribute 'href' in tag 'a'. (see https://www.ampproject.org/docs/reference/spec#links) [DISALLOWED_HTML]
+|  
+|    <!-- Valid ipv6 addresses -->
+|    <a href="https://[2001:0db8::85a3]/">Valid</a>
+|    <a href="https://[::1]/">Valid</a>
+|    <a href="https://[0:0:0:0:0:0:0:1]/">Valid</a>
+|    <a href="https://[0:0:0:0:0:0:8.8.8.8]/">Valid</a>
+|    <a href="https://[0:0:0:0:0:0:8.124.8.8]/">Valid</a>
+|    <a href="https://[0:0:0:0:0:0:8.8.8.22]/">Valid</a>
+|    <a href="https://[::8.8.8.8]/">Valid</a>
+|    <!-- Invalid ipv6 addresses -->
+|    <a href="https://[2001:0db8:85a3]/">Invalid</a>
+>>   ^~~~~~~~~
 feature_tests/urls.html:96:2 Malformed URL 'https://[2001:0db8:85a3]/' for attribute 'href' in tag 'a'. (see https://www.ampproject.org/docs/reference/spec#links) [DISALLOWED_HTML]
+|    <a href="https://[20012:0db8::85a3]/">Invalid</a>
+>>   ^~~~~~~~~
 feature_tests/urls.html:97:2 Malformed URL 'https://[20012:0db8::85a3]/' for attribute 'href' in tag 'a'. (see https://www.ampproject.org/docs/reference/spec#links) [DISALLOWED_HTML]
+|    <a href="https://[200g:0db8:85a3]/">Invalid</a>
+>>   ^~~~~~~~~
 feature_tests/urls.html:98:2 Malformed URL 'https://[200g:0db8:85a3]/' for attribute 'href' in tag 'a'. (see https://www.ampproject.org/docs/reference/spec#links) [DISALLOWED_HTML]
+|    <a href="https://[:::1]/">Invalid</a>
+>>   ^~~~~~~~~
 feature_tests/urls.html:99:2 Malformed URL 'https://[:::1]/' for attribute 'href' in tag 'a'. (see https://www.ampproject.org/docs/reference/spec#links) [DISALLOWED_HTML]
+|    <a href="https://[0:0:0:0:0:0:1]/">Invalid</a>
+>>   ^~~~~~~~~
 feature_tests/urls.html:100:2 Malformed URL 'https://[0:0:0:0:0:0:1]/' for attribute 'href' in tag 'a'. (see https://www.ampproject.org/docs/reference/spec#links) [DISALLOWED_HTML]
+|    <a href="https://[0:0:0:0:0:0:0:0:1]/">Invalid</a>
+>>   ^~~~~~~~~
 feature_tests/urls.html:101:2 Malformed URL 'https://[0:0:0:0:0:0:0:0:1]/' for attribute 'href' in tag 'a'. (see https://www.ampproject.org/docs/reference/spec#links) [DISALLOWED_HTML]
+|    <a href="https://[0:0:0:0:0:0:0:8.8.8.8]/">Invalid</a>
+>>   ^~~~~~~~~
 feature_tests/urls.html:102:2 Malformed URL 'https://[0:0:0:0:0:0:0:8.8.8.8]/' for attribute 'href' in tag 'a'. (see https://www.ampproject.org/docs/reference/spec#links) [DISALLOWED_HTML]
+|    <a href="https://[0:0:0:0:0:8.8.8.8]/">Invalid</a>
+>>   ^~~~~~~~~
 feature_tests/urls.html:103:2 Malformed URL 'https://[0:0:0:0:0:8.8.8.8]/' for attribute 'href' in tag 'a'. (see https://www.ampproject.org/docs/reference/spec#links) [DISALLOWED_HTML]
+|    <a href="https://[0:0:0:0:0:8.8.8.8:1]/">Invalid</a>
+>>   ^~~~~~~~~
 feature_tests/urls.html:104:2 Malformed URL 'https://[0:0:0:0:0:8.8.8.8:1]/' for attribute 'href' in tag 'a'. (see https://www.ampproject.org/docs/reference/spec#links) [DISALLOWED_HTML]
+|  
+|    <!-- __amp_source_origin is not an allowed value for URLs. -->
+|    <a href="__amp_source_origin">uhm, no</a>
+>>   ^~~~~~~~~
 feature_tests/urls.html:107:2 The attribute 'href' in tag 'a' is set to the invalid value '__amp_source_origin'. (see https://www.ampproject.org/docs/reference/spec#links) [DISALLOWED_HTML]
+|    <amp-ad src="__amp_source_origin" width="42" height="42" type=""></amp-ad>
+>>   ^~~~~~~~~
 feature_tests/urls.html:108:2 The attribute 'src' in tag 'amp-ad' is set to the invalid value '__amp_source_origin'. (see https://www.ampproject.org/docs/reference/components/amp-ad) [AMP_TAG_PROBLEM]
+|    <amp-anim src="__amp_source_origin" width="42" height="42"></amp-anim>
+>>   ^~~~~~~~~
 feature_tests/urls.html:109:2 The attribute 'src' in tag 'amp-anim' is set to the invalid value '__amp_source_origin'. (see https://www.ampproject.org/docs/reference/components/amp-anim) [AMP_TAG_PROBLEM]
+>>   ^~~~~~~~~
 feature_tests/urls.html:109:2 The tag 'amp-anim' requires including the 'amp-anim' extension JavaScript. (see https://www.ampproject.org/docs/reference/components/amp-anim) [AMP_TAG_PROBLEM]
+|    <amp-audio src="__amp_source_origin" layout="fixed" width="42"></amp-audio>
+>>   ^~~~~~~~~
 feature_tests/urls.html:110:2 The attribute 'src' in tag 'amp-audio' is set to the invalid value '__amp_source_origin'. (see https://www.ampproject.org/docs/reference/components/amp-audio) [AMP_TAG_PROBLEM]
+>>   ^~~~~~~~~
 feature_tests/urls.html:110:2 The tag 'amp-audio' requires including the 'amp-audio' extension JavaScript. (see https://www.ampproject.org/docs/reference/components/amp-audio) [AMP_TAG_PROBLEM]
+|    <amp-iframe src="__amp_source_origin" width="42" height="42"></amp-iframe>
+>>   ^~~~~~~~~
 feature_tests/urls.html:111:2 The attribute 'src' in tag 'amp-iframe' is set to the invalid value '__amp_source_origin'. (see https://www.ampproject.org/docs/reference/components/amp-iframe) [AMP_TAG_PROBLEM]
+>>   ^~~~~~~~~
 feature_tests/urls.html:111:2 The tag 'amp-iframe' requires including the 'amp-iframe' extension JavaScript. (see https://www.ampproject.org/docs/reference/components/amp-iframe) [AMP_TAG_PROBLEM]
+|    <amp-img src="__amp_source_origin" layout="responsive" width="42" height="42"></amp-img>
+>>   ^~~~~~~~~
 feature_tests/urls.html:112:2 The attribute 'src' in tag 'amp-img' is set to the invalid value '__amp_source_origin'. (see https://www.ampproject.org/docs/reference/components/amp-img) [AMP_TAG_PROBLEM]
+|    <amp-pixel src="__amp_source_origin" layout="fixed" width="42"></amp-pixel>
+>>   ^~~~~~~~~
 feature_tests/urls.html:113:2 The attribute 'src' in tag 'amp-pixel' is set to the invalid value '__amp_source_origin'. (see https://www.ampproject.org/docs/reference/components/amp-pixel) [AMP_TAG_PROBLEM]
+|    <amp-video src="__amp_source_origin" width="42" height="42"></amp-video>
+>>   ^~~~~~~~~
 feature_tests/urls.html:114:2 The attribute 'src' in tag 'amp-video' is set to the invalid value '__amp_source_origin'. (see https://www.ampproject.org/docs/reference/components/amp-video) [AMP_TAG_PROBLEM]
+|    <amp-video src="%5f_amp_source%5forigin" width="42" height="42"></amp-video>
+>>   ^~~~~~~~~
 feature_tests/urls.html:115:2 The attribute 'src' in tag 'amp-video' is set to the invalid value '%5f_amp_source%5forigin'. (see https://www.ampproject.org/docs/reference/components/amp-video) [AMP_TAG_PROBLEM]
-feature_tests/urls.html:117:7 The tag 'amp-ad extension .js script' is missing or incorrect, but required by 'amp-ad'. This will soon be an error. (see https://www.ampproject.org/docs/reference/components/amp-ad) [DEPRECATION]
-feature_tests/urls.html:117:7 The tag 'amp-video extension .js script' is missing or incorrect, but required by 'amp-video'. This will soon be an error. (see https://www.ampproject.org/docs/reference/components/amp-video) [DEPRECATION]
+|  </body>
+|  </html>
+>>       ^~~~~~~~~
+feature_tests/urls.html:117:6 The tag 'amp-ad extension .js script' is missing or incorrect, but required by 'amp-ad'. This will soon be an error. (see https://www.ampproject.org/docs/reference/components/amp-ad) [DEPRECATION]
+>>       ^~~~~~~~~
+feature_tests/urls.html:117:6 The tag 'amp-video extension .js script' is missing or incorrect, but required by 'amp-video'. This will soon be an error. (see https://www.ampproject.org/docs/reference/components/amp-video) [DEPRECATION]

--- a/validator/testdata/feature_tests/urls_in_css.out
+++ b/validator/testdata/feature_tests/urls_in_css.out
@@ -1,2 +1,42 @@
 FAIL
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|      Shows an example of a url(...) function within a stylesheet which
+|      has invalid paramters.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <style amp-custom>
+|      @font-face {
+|        font-family: 'Roboto', sans-serif;
+|        src: url('<link href='https://fonts.googleapis.com/css?family=Roboto:300,400,500,700' rel='stylesheet' type='text/css'>');
+>>            ^~~~~~~~~
 feature_tests/urls_in_css.html:32:11 CSS syntax error in tag 'style amp-custom' - bad url. [AUTHOR_STYLESHEET_PROBLEM]
+|      }
+|    </style>
+|  </head>
+|  <body>
+|  Hello, world.
+|  </body>
+|  </html>

--- a/validator/testdata/feature_tests/valid_css_at_rules_amp.out
+++ b/validator/testdata/feature_tests/valid_css_at_rules_amp.out
@@ -1,1 +1,67 @@
 PASS
+|  <!--
+|    Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    This is the minimum valid AMP document; it includes all of the required
+|    fields from the spec, but nothing else.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <style amp-custom>
+|      @supports (animation-name) {
+|      }
+|  
+|      @-webkit-keyframes fadeIn {
+|        from { opacity: 0; }
+|        to { opacity: 1; }
+|      }
+|  
+|      @-moz-keyframes fadeIn {
+|        from { opacity: 0; }
+|        to { opacity: 1; }
+|      }
+|  
+|      @-o-keyframes fadeIn {
+|        from { opacity: 0; }
+|        to { opacity: 1; }
+|      }
+|  
+|      @keyframes fadeIn {
+|        from { opacity: 0; }
+|        to { opacity: 1; }
+|      }
+|  
+|      amp-user-notification.amp-active {
+|        opacity: 0;
+|        -webkit-animation: fadeIn ease-in 1s 1 forwards;
+|        -moz-animation: fadeIn ease-in 1s 1 forwards;
+|        -ms-animation: fadeIn ease-in 1s 1 forwards;
+|        -o-animation: fadeIn ease-in 1s 1 forwards;
+|        animation: fadeIn ease-in 1s 1 forwards;
+|      }
+|    </style>
+|  </head>
+|  <body>
+|  Hello, world.
+|  </body>
+|  </html>

--- a/validator/testdata/feature_tests/video-json-ld.out
+++ b/validator/testdata/feature_tests/video-json-ld.out
@@ -1,1 +1,109 @@
 PASS
+|  <!--
+|    Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!doctype html>
+|  <!--
+|        This sample AMP HTML file aims to be a minimalist document that
+|        follows best practices and guidances for publishers to mark up Video
+|        content for inclusion in various platforms.
+|  -->
+|  <html AMP lang="en">
+|    <!-- you can use "amp" or "AMP" or "⚡" -->
+|    <head>
+|      <meta charset="utf-8">
+|      <title>Lorem Ipsum</title>
+|      <link rel="canonical" href="http://example.ampproject.org/video-metadata.html">
+|      <!--
+|          The canonical document for this article should be linked, as above.
+|  
+|          The canonical document should also have a corresponding <link> tag
+|          within pointing at this AMP HTML file:
+|  
+|            <link rel="amphtml" href="http://example.ampproject.org/video-json-ld.amp.html">
+|  
+|          It is possible that this AMP HTML document is the canonical document
+|          for this article, in which case, the canonical URL should point to this
+|          document, and no "amphtml" link is required.
+|      -->
+|      <meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1,user-scalable=no,minimal-ui">
+|      <!-- only one style tag is allowed, and it must have an "amp-custom" attribute -->
+|      <style amp-custom>
+|        body {
+|          background-color: white;
+|        }
+|        amp-img {
+|          background-color: gray;
+|        }
+|      </style>
+|      <script type="application/ld+json">
+|          //
+|          // The document referenced in mainEntityOfPage should be the same as the
+|          // canonical link above.
+|          //
+|          // Also, please be aware that some platforms that use AMP HTML have
+|          // further restrictions with regards to some schema components.
+|          //
+|          // For example:
+|          //
+|          //   * The leader "image" referenced in the markup below must appear
+|          //   somewhere on the AMP HTML document itself.
+|          //
+|          //   * The URL for that "image" must precisely match the src of the
+|          //   amp-img tag.
+|          //
+|          //   * All marked-up URLs should be absolute.
+|          //
+|          //   * The "logo" dimensions must not exceed 600x60.
+|          //
+|        {
+|          "@context": "http://schema.org",
+|          "@type": "VideoObject",
+|          "mainEntityOfPage": "http://example.ampproject.org/video-metadata.html",
+|          "name": "The Audience is programing",
+|          "description": "A programming audience",
+|          "thumbnailUrl": "http://cdn.ampproject.org/leader.jpg",
+|          "uploadDate": "2015-02-05T08:00:00+08:00",
+|          "duration": "PT1M33S",
+|          "contentUrl": "https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4",
+|          "interactionCount": "2347",
+|          "publisher": {
+|            "@type": "Organization",
+|            "name": "Google",
+|            "logo": {
+|              "@type": "ImageObject",
+|              "url": "http://cdn.ampproject.org/logo.jpg",
+|              "width": 600,
+|              "height": 60
+|            }
+|          }
+|        }
+|      </script>
+|      <!-- this style tag is required -->
+|      <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|      <script async src="https://cdn.ampproject.org/v0.js"></script>
+|      <script async custom-element="amp-video" src="https://cdn.ampproject.org/v0/amp-video-0.1.js"></script>
+|    </head>
+|    <body>
+|      <h2>The Audience is programing</h2>
+|      <p>A programming audience</p>
+|      <amp-video
+|          src="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4"
+|          width="358"
+|          height="204"
+|          layout="responsive"
+|          controls></amp-video>
+|    </body>
+|  </html>

--- a/validator/testdata/feature_tests/video-microdata.out
+++ b/validator/testdata/feature_tests/video-microdata.out
@@ -1,1 +1,88 @@
 PASS
+|  <!--
+|    Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!doctype html>
+|  <!--
+|        This sample AMP HTML file aims to be a minimalist document that
+|        follows best practices and guidances for publishers to mark up
+|        content for inclusion in various platforms.
+|  -->
+|  <html AMP lang="en" itemscope itemtype="http://schema.org/VideoObject">
+|    <!-- you can use "amp" or "AMP" or "⚡" -->
+|    <head>
+|      <meta charset="utf-8">
+|      <title>Lorem Ipsum</title>
+|      <link itemprop="mainEntityOfPage" rel="canonical" href="http://example.ampproject.org/video-metadata.html">
+|      <!--
+|          The canonical document for this article should be linked, as above.
+|  
+|          The canonical document should also have a corresponding <link> tag
+|          within pointing at this AMP HTML file:
+|  
+|            <link rel="amphtml" href="http://example.ampproject.org/video-microdata.amp.html">
+|  
+|          It is possible that this AMP HTML document is the canonical document
+|          for this article, in which case, the canonical URL should point to this
+|          document, and no "amphtml" link is required.
+|  
+|          Also, please be aware that some platforms that use AMP HTML have
+|          further restrictions with regards to some schema components.
+|  
+|           For example:
+|  
+|             * All marked-up URL's should be absolute.
+|             * The "logo" dimensions must not exceed 600x60.
+|      -->
+|      <meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1,user-scalable=no,minimal-ui">
+|      <!-- only one style tag is allowed, and it must have an "amp-custom" attribute -->
+|      <style amp-custom>
+|        body {
+|          background-color: white;
+|        }
+|        amp-img {
+|          background-color: gray;
+|        }
+|      </style>
+|      <!-- this style tag is required -->
+|      <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|      <script async src="https://cdn.ampproject.org/v0.js"></script>
+|      <script async custom-element="amp-video" src="https://cdn.ampproject.org/v0/amp-video-0.1.js"></script>
+|    </head>
+|    <body>
+|      <h2 itemprop="name">The Audience is programing</h2>
+|      <p itemprop="description">A programming audience</p>
+|      <meta itemprop="thumbnailUrl" content="http://cdn.ampproject.org/leader.jpg"></meta>
+|      <meta itemprop="uploadDate" content="2015-02-05T08:00:00+08:00"></meta>
+|      <meta itemprop="duration" content="PT1M33S"></meta>
+|      <meta itemprop="contentUrl" content="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4"></meta>
+|      <meta itemprop="interactionCount" content="2347"></meta>
+|      <amp-video
+|          src="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4"
+|          width="358"
+|          height="204"
+|          layout="responsive"
+|          controls></amp-video>
+|      <div itemprop="publisher" itemscope itemtype="https://schema.org/Organization">
+|        <div itemprop="logo" itemscope itemtype="https://schema.org/ImageObject">
+|          <amp-img width="600" height="60" src="http://cdn.ampproject.org/logo.jpg"></amp-img>
+|          <meta itemprop="url" content="http://cdn.ampproject.org/logo.jpg"></meta>
+|          <meta itemprop="width" content="600"></meta>
+|          <meta itemprop="height" content="60"></meta>
+|        </div>
+|        <meta itemprop="name" content="Google"></meta>
+|      </div>
+|    </body>
+|  </html>

--- a/validator/testdata/feature_tests/xlinkhref.out
+++ b/validator/testdata/feature_tests/xlinkhref.out
@@ -1,2 +1,67 @@
 FAIL
+|  <!--
+|    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|      Tests xlink:href attributes in SVG tags.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1,user-scalable=no,minimal-ui">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|  <body>
+|  
+|  <!-- Invalid image/svg+xml in a data: url inside an svg image tag.
+|       See https://github.com/ampproject/amphtml/issues/4567
+|   -->
+|  <svg version="1.0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="640" height="480">
+|    <image x=0 y=0 width=14 height=10 xlink:href="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+Cjxzdmcgd2lkdGg9IjE0cHgiIGhlaWdodD0iMTRweCIgdmlld0JveD0iMCAwIDE0IDE0IiB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiPgogICAgPCEtLSBHZW5lcmF0b3I6IFNrZXRjaCAzLjYuMSAoMjYzMTMpIC0gaHR0cDovL3d3dy5ib2hlbWlhbmNvZGluZy5jb20vc2tldGNoIC0tPgogICAgPHRpdGxlPkFNUCBMb2dvPC90aXRsZT4KICAgIDxkZXNjPkNyZWF0ZWQgd2l0aCBTa2V0Y2guPC9kZXNjPgogICAgPGRlZnM+PC9kZWZzPgogICAgPGcgaWQ9IlBhZ2UtMSIgc3Ryb2tlPSJub25lIiBzdHJva2Utd2lkdGg9IjEiIGZpbGw9Im5vbmUiIGZpbGwtcnVsZT0iZXZlbm9kZCI+CiAgICAgICAgPGcgaWQ9IkFNUC1Mb2dvIiBmaWxsPSIjMDM3OUM0Ij4KICAgICAgICAgICAgPHBhdGggZD0iTTguNjU3ODE3LDAuMjE2MDYyIEw3LjY0NzI5Nyw1LjU4OTk2MiBMMTAuMDg1MzI3LDUuNTg5OTYyIEMxMC4xODg3ODcsNS41ODk5NjIgMTAuMjU2NDc3LDUuNjk4MzIyIDEwLjIxMTExNyw1Ljc5MTI4MiBMNi4yMzAyMTcsMTMuOTU4NTMyIEM2LjQ4MDQ2NywxMy45ODU2MjIgNi43MzQ1NjcsMTMuOTk5OTcyIDYuOTkyMDk3LDEzLjk5OTk3MiBDMTAuODUzNzE3LDEzLjk5OTk3MiAxMy45ODQxMTcsMTAuODY5NTcyIDEzLjk4NDExNyw3LjAwNzk1MiBDMTMuOTg0MTE3LDMuNzIwNDAyIDExLjcxNTA2NywwLjk2MzMxMiA4LjY1NzgxNywwLjIxNjA2MiIgaWQ9IkZpbGwtNCI+PC9wYXRoPgogICAgICAgICAgICA8cGF0aCBkPSJNNi40MjUzOTgsOC41Mjk5NDggTDMuOTg3MTU4LDguNTI5OTQ4IEMzLjg4MzY5OCw4LjUyOTk0OCAzLjgxNTkzOCw4LjQyMTU4OCAzLjg2MTI5OCw4LjMyODYyOCBMNy44ODU4MDgsMC4wNzI0NzggQzcuNTkxODA4LDAuMDM0OTU4IDcuMjkyMTM4LDAuMDE1NzA4IDYuOTg3ODQ4LDAuMDE1ODQ4IEMzLjE2ODIyOCwwLjAxODA4OCAwLjAyODAyOCwzLjEzNjMwOCAwLjAwMDE2OCw2Ljk1NTg1OCBDLTAuMDI0MTkyLDEwLjMwMzMyOCAyLjMwNDA3OCwxMy4xMTExNjggNS40Mjk3MTgsMTMuODI0NjA4IEw2LjQyNTM5OCw4LjUyOTk0OCBaIiBpZD0iRmlsbC0xIj48L3BhdGg+CiAgICAgICAgPC9nPgogICAgPC9nPgo8L3N2Zz4K"/>
+>>   ^~~~~~~~~
 feature_tests/xlinkhref.html:35:2 The attribute 'xlink:href' in tag 'image' is set to the invalid value 'data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+Cjxzdmcgd2lkdGg9IjE0cHgiIGhlaWdodD0iMTRweCIgdmlld0JveD0iMCAwIDE0IDE0IiB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiPgogICAgPCEtLSBHZW5lcmF0b3I6IFNrZXRjaCAzLjYuMSAoMjYzMTMpIC0gaHR0cDovL3d3dy5ib2hlbWlhbmNvZGluZy5jb20vc2tldGNoIC0tPgogICAgPHRpdGxlPkFNUCBMb2dvPC90aXRsZT4KICAgIDxkZXNjPkNyZWF0ZWQgd2l0aCBTa2V0Y2guPC9kZXNjPgogICAgPGRlZnM+PC9kZWZzPgogICAgPGcgaWQ9IlBhZ2UtMSIgc3Ryb2tlPSJub25lIiBzdHJva2Utd2lkdGg9IjEiIGZpbGw9Im5vbmUiIGZpbGwtcnVsZT0iZXZlbm9kZCI+CiAgICAgICAgPGcgaWQ9IkFNUC1Mb2dvIiBmaWxsPSIjMDM3OUM0Ij4KICAgICAgICAgICAgPHBhdGggZD0iTTguNjU3ODE3LDAuMjE2MDYyIEw3LjY0NzI5Nyw1LjU4OTk2MiBMMTAuMDg1MzI3LDUuNTg5OTYyIEMxMC4xODg3ODcsNS41ODk5NjIgMTAuMjU2NDc3LDUuNjk4MzIyIDEwLjIxMTExNyw1Ljc5MTI4MiBMNi4yMzAyMTcsMTMuOTU4NTMyIEM2LjQ4MDQ2NywxMy45ODU2MjIgNi43MzQ1NjcsMTMuOTk5OTcyIDYuOTkyMDk3LDEzLjk5OTk3MiBDMTAuODUzNzE3LDEzLjk5OTk3MiAxMy45ODQxMTcsMTAuODY5NTcyIDEzLjk4NDExNyw3LjAwNzk1MiBDMTMuOTg0MTE3LDMuNzIwNDAyIDExLjcxNTA2NywwLjk2MzMxMiA4LjY1NzgxNywwLjIxNjA2MiIgaWQ9IkZpbGwtNCI+PC9wYXRoPgogICAgICAgICAgICA8cGF0aCBkPSJNNi40MjUzOTgsOC41Mjk5NDggTDMuOTg3MTU4LDguNTI5OTQ4IEMzLjg4MzY5OCw4LjUyOTk0OCAzLjgxNTkzOCw4LjQyMTU4OCAzLjg2MTI5OCw4LjMyODYyOCBMNy44ODU4MDgsMC4wNzI0NzggQzcuNTkxODA4LDAuMDM0OTU4IDcuMjkyMTM4LDAuMDE1NzA4IDYuOTg3ODQ4LDAuMDE1ODQ4IEMzLjE2ODIyOCwwLjAxODA4OCAwLjAyODAyOCwzLjEzNjMwOCAwLjAwMDE2OCw2Ljk1NTg1OCBDLTAuMDI0MTkyLDEwLjMwMzMyOCAyLjMwNDA3OCwxMy4xMTExNjggNS40Mjk3MTgsMTMuODI0NjA4IEw2LjQyNTM5OCw4LjUyOTk0OCBaIiBpZD0iRmlsbC0xIj48L3BhdGg+CiAgICAgICAgPC9nPgogICAgPC9nPgo8L3N2Zz4K'. (see https://www.ampproject.org/docs/reference/spec#svg) [DISALLOWED_HTML]
+|  </svg>
+|  
+|  <!-- Valid image/png in a data: url inside an svg image tag.
+|       See https://github.com/ampproject/amphtml/issues/4567
+|   -->
+|  <svg version="1.0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="640" height="480">
+|    <image x=0 y=0 width=16 height=16 xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAjpJREFUOBFlU01oE1EQnnnZbmJVEFQiCsaLigepYA9tglgQf9BDwZOggmCpF+2h1IPbBPbQEqQUBL1I8dCDInoRBC9BhLL5OSgIFqkiHuLNmz9gk+x748w2u31pBnZ35vvm+97vImyJdDE4qo26CWTOEcBBRPzkKOdGaPS1jEuP//qFn7YE42LMJydo1e4T0hQQODEOSl1OgXG1geeMtVDhYmcuX2Rj9gdQ8toQV18T0LQt5qbVcG70lQE4IX0caTLkOV5tWTQCRAZBq7rAdhcEsIPJ+Wgkkxh0aboedOolKZRbrB9j8R1bKDmv7avn5l9Iznw8AymjIKKZQT/Yr4w2E4ykunjyQVTzvo9mu9fIMrgvIeKEaLDdxmmeJZ2PMev7veCOPpMaXU0K1IQ8XD21ejils5jygj88xx02oQAnO+XCko1J7njVFZ76qU0cfykWJ0cZEQg/jqR3LW82bWTOvdrpXrHgZBTvcrOnmXDlS/g77xTrYzv993sSDina9aTmhEduKnZ9a4PsepW0fifPug5zwg3MNka470xvX1RVlJvOLLDVeh+JEOb27l4VnIzuG51hzRv7RP3zh5uI8GCrAQKufZs63BooNU7yDb3YxyM+apfza9FNPJTN+oD40m7iy/NRal5K0cYl5wErQ7n0XckjAxmp5Oav8IYu8nLCqIkN3FLtOBGMS90NzeqHQ7nMpQ+3hjuC9R4hA9tmaweYmeS/7g3f0tt8zOMIJCdVUeAstcsjn0UYx3/zRM/F1CZLnQAAAABJRU5ErkJggg=="/>
+|  </svg>
+|  
+|  <!-- Valid image URL iside an svg image tag.
+|       See https://github.com/ampproject/amphtml/issues/9243
+|   -->
+|  <svg version="1.0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="640" height="480">
+|    <image x=0 y=0 width=16 height=16 xlink:href="https://www.ampproject.org/static/img/logo-blue.svg"/>
+|  </svg>
+|  
+|  <!-- Valid [use xlink:href] example.
+|       See https://github.com/ampproject/amphtml/issues/9243
+|   -->
+|  <svg class="icon" xmlns:xlink="http://www.w3.org/1999/xlink">
+|    <use xlink:href="https://localhost.test/icons/below.svg#icon-telegram"></use>
+|  </svg>
+|  
+|  <svg class="icon" xmlns:xlink="http://www.w3.org/1999/xlink">
+|    <use xlink:href="https://localhost.test/icons/below.svg#icon-whatsapp"></use>
+|  </svg>
+|  
+|  </body>
+|  </html>


### PR DESCRIPTION
Render validator test case output inline, so that it's clearer how the input relates to the output. The new output looks like an ascii-art version of what you see on validator.ampproject.org with validation output inlined in place into the original document.

Note that we actually changed behavior of the validator w.r.t. end of document output. Previously, we would point to a column past the end of the document, now we point to the last character in the document. This change is caused by trimming the input.