### PR TITLE
Change default user logging level of AMP runtime from `OFF` to `WARN`

### DIFF
--- a/src/log.js
+++ b/src/log.js
@@ -159,7 +159,7 @@ export class Log {
       } else if (level == 'WARN') {
         fn = this.win.console.warn || fn;
       }
-      messages.unshift(Date.now() - start, '[' + tag + ']');
+      messages.unshift('[' + tag + ']');
       fn.apply(this.win.console, messages);
     }
   }

--- a/src/log.js
+++ b/src/log.js
@@ -156,7 +156,9 @@ export class Log {
       } else if (level == 'WARN') {
         fn = this.win.console.warn || fn;
       }
-      messages.unshift('[' + tag + ']');
+      if (getMode().localDev) {
+        messages.unshift('[' + tag + ']');
+      }
       fn.apply(this.win.console, messages);
     }
   }

--- a/src/log.js
+++ b/src/log.js
@@ -18,9 +18,6 @@ import {getMode} from './mode';
 import {getModeObject} from './mode-object';
 import {isEnumValue} from './types';
 
-/** @const Time when this JS loaded.  */
-const start = Date.now();
-
 /**
  * Triple zero width space.
  *

--- a/src/log.js
+++ b/src/log.js
@@ -590,7 +590,7 @@ function getUserLogger(suffix) {
     if (mode.development || logNum >= 1) {
       return LogLevel.FINE;
     }
-    return LogLevel.OFF;
+    return LogLevel.WARN;
   }, suffix);
 }
 

--- a/test/functional/test-log.js
+++ b/test/functional/test-log.js
@@ -106,16 +106,16 @@ describe('Logging', () => {
       const log = new Log(win, RETURNS_FINE);
       expect(log.level_).to.equal(LogLevel.FINE);
 
-      log.fine('fine');
-      log.info('info');
-      log.warn('warn');
-      log.error('error');
+      log.fine('test-log', 'fine');
+      log.info('test-log', 'info');
+      log.warn('test-log', 'warn');
+      log.error('test-log', 'error');
 
       expect(logSpy).to.have.callCount(4);
-      expect(logSpy.args[0][0]).to.equal('[fine]');
-      expect(logSpy.args[1][0]).to.equal('[info]');
-      expect(logSpy.args[2][0]).to.equal('[warn]');
-      expect(logSpy.args[3][0]).to.equal('[error]');
+      expect(logSpy.args[0][0]).to.equal('fine');
+      expect(logSpy.args[1][0]).to.equal('info');
+      expect(logSpy.args[2][0]).to.equal('warn');
+      expect(logSpy.args[3][0]).to.equal('error');
       expect(timeoutSpy).to.have.not.been.called;
     });
 
@@ -123,15 +123,15 @@ describe('Logging', () => {
       const log = new Log(win, RETURNS_INFO);
       expect(log.level_).to.equal(LogLevel.INFO);
 
-      log.fine('fine');
-      log.info('info');
-      log.warn('warn');
-      log.error('error');
+      log.fine('test-log', 'fine');
+      log.info('test-log', 'info');
+      log.warn('test-log', 'warn');
+      log.error('test-log', 'error');
 
       expect(logSpy).to.have.callCount(3);
-      expect(logSpy.args[0][0]).to.equal('[info]');
-      expect(logSpy.args[1][0]).to.equal('[warn]');
-      expect(logSpy.args[2][0]).to.equal('[error]');
+      expect(logSpy.args[0][0]).to.equal('info');
+      expect(logSpy.args[1][0]).to.equal('warn');
+      expect(logSpy.args[2][0]).to.equal('error');
       expect(timeoutSpy).to.have.not.been.called;
     });
 
@@ -139,14 +139,14 @@ describe('Logging', () => {
       const log = new Log(win, RETURNS_WARN);
       expect(log.level_).to.equal(LogLevel.WARN);
 
-      log.fine('fine');
-      log.info('info');
-      log.warn('warn');
-      log.error('error');
+      log.fine('test-log', 'fine');
+      log.info('test-log', 'info');
+      log.warn('test-log', 'warn');
+      log.error('test-log', 'error');
 
       expect(logSpy).to.have.callCount(2);
-      expect(logSpy.args[0][0]).to.equal('[warn]');
-      expect(logSpy.args[1][0]).to.equal('[error]');
+      expect(logSpy.args[0][0]).to.equal('warn');
+      expect(logSpy.args[1][0]).to.equal('error');
       expect(timeoutSpy).to.have.not.been.called;
     });
 
@@ -154,13 +154,13 @@ describe('Logging', () => {
       const log = new Log(win, RETURNS_ERROR);
       expect(log.level_).to.equal(LogLevel.ERROR);
 
-      log.fine('fine');
-      log.info('info');
-      log.warn('warn');
-      log.error('error');
+      log.fine('test-log', 'fine');
+      log.info('test-log', 'info');
+      log.warn('test-log', 'warn');
+      log.error('test-log', 'error');
 
       expect(logSpy).to.be.calledOnce;
-      expect(logSpy.args[0][0]).to.equal('[error]');
+      expect(logSpy.args[0][0]).to.equal('error');
       expect(timeoutSpy).to.have.not.been.called;
     });
 

--- a/test/functional/test-log.js
+++ b/test/functional/test-log.js
@@ -112,10 +112,10 @@ describe('Logging', () => {
       log.error('error');
 
       expect(logSpy).to.have.callCount(4);
-      expect(logSpy.args[0][1]).to.equal('[fine]');
-      expect(logSpy.args[1][1]).to.equal('[info]');
-      expect(logSpy.args[2][1]).to.equal('[warn]');
-      expect(logSpy.args[3][1]).to.equal('[error]');
+      expect(logSpy.args[0][0]).to.equal('[fine]');
+      expect(logSpy.args[1][0]).to.equal('[info]');
+      expect(logSpy.args[2][0]).to.equal('[warn]');
+      expect(logSpy.args[3][0]).to.equal('[error]');
       expect(timeoutSpy).to.have.not.been.called;
     });
 
@@ -129,9 +129,9 @@ describe('Logging', () => {
       log.error('error');
 
       expect(logSpy).to.have.callCount(3);
-      expect(logSpy.args[0][1]).to.equal('[info]');
-      expect(logSpy.args[1][1]).to.equal('[warn]');
-      expect(logSpy.args[2][1]).to.equal('[error]');
+      expect(logSpy.args[0][0]).to.equal('[info]');
+      expect(logSpy.args[1][0]).to.equal('[warn]');
+      expect(logSpy.args[2][0]).to.equal('[error]');
       expect(timeoutSpy).to.have.not.been.called;
     });
 
@@ -145,8 +145,8 @@ describe('Logging', () => {
       log.error('error');
 
       expect(logSpy).to.have.callCount(2);
-      expect(logSpy.args[0][1]).to.equal('[warn]');
-      expect(logSpy.args[1][1]).to.equal('[error]');
+      expect(logSpy.args[0][0]).to.equal('[warn]');
+      expect(logSpy.args[1][0]).to.equal('[error]');
       expect(timeoutSpy).to.have.not.been.called;
     });
 
@@ -160,7 +160,7 @@ describe('Logging', () => {
       log.error('error');
 
       expect(logSpy).to.be.calledOnce;
-      expect(logSpy.args[0][1]).to.equal('[error]');
+      expect(logSpy.args[0][0]).to.equal('[error]');
       expect(timeoutSpy).to.have.not.been.called;
     });
 
@@ -228,8 +228,8 @@ describe('Logging', () => {
 
   describe('UserLog', () => {
 
-    it('should be disabled by default', () => {
-      expect(user().levelFunc_(mode)).to.equal(LogLevel.OFF);
+    it('should be WARN by default', () => {
+      expect(user().levelFunc_(mode)).to.equal(LogLevel.WARN);
     });
 
     it('should be enabled in development mode', () => {


### PR DESCRIPTION
With this PR, the default user logging level will be changed from `OFF` to `WARN`. In addition, the `tag` argument to `user.log.*` is only printed when `localDev` is `true`.

**Before:**
- `user.log.error()`: No output
- `user.log.warn()`: No output
- `user.log.info()`: No output
- `user.log.fine()`: No output

**After:**
- `user.log.error()`: Prints message
- `user.log.warn()`: Prints message
- `user.log.info()`: No output
- `user.log.fine()`: No output

**Here is what the logs will look like for local development:**

![image](https://user-images.githubusercontent.com/26553114/34574454-72e2c4c0-f145-11e7-8603-9ba473186957.png)


**Here is what the logs will look like in production:**

![image](https://user-images.githubusercontent.com/26553114/34574247-d69b5ece-f144-11e7-8627-dc5e184da4d8.png)

**Notes:**
- Adding `#development=1` to the URL will set the logging level to `FINE`
- Adding `#log=<N>` to the URL will set the logging level to `<N>` 

Fixes #11662
  
  