### PR TITLE
Fix visibility trigger error

### DIFF
--- a/extensions/amp-analytics/0.1/visibility-model.js
+++ b/extensions/amp-analytics/0.1/visibility-model.js
@@ -350,10 +350,6 @@ export class VisibilityModel {
       if (timeToWait > 0) {
         this.scheduledUpdateTimeoutId_ = setTimeout(() => {
           this.update();
-          if (!this.eventResolver_) {
-            this.reset_();
-            this.setReady(true);
-          }
           this.scheduledUpdateTimeoutId_ = null;
         }, timeToWait);
       }

--- a/test/manual/amp-analytics-visible-repeat.amp.html
+++ b/test/manual/amp-analytics-visible-repeat.amp.html
@@ -68,6 +68,26 @@
             "on": "visible",
             "request": "base",
             "visibilitySpec": {
+              "visiblePercentageMin": "0",
+              "continuousTimeMin": 2000
+            }
+          }
+        }
+      }
+    </script>
+  </amp-analytics>
+  <amp-analytics>
+    <script type="application/json">
+      {
+        "transport": {"beacon": false, "xhrpost": false},
+        "requests": {
+          "base": "fake.com/ad1?repeat=true&continuousTimeMin=2000"
+        },
+        "triggers": {
+          "repeat": {
+            "on": "visible",
+            "request": "base",
+            "visibilitySpec": {
               "selector": "#ad1",
               "visiblePercentageMin": "0",
               "continuousTimeMin": 2000,


### PR DESCRIPTION
Fix #12304 and #12633 

With what we have before: 
```
 setTimeout(() => {
    this.update();
    if (!this.eventResolver_) {
      this.reset_();
       this.setReady(true);
     }
     this.scheduledUpdateTimeoutId_ = null;
 }, timeToWait);
```
When `this.update()` is called with all conditions met, `this.eventResolver_` will be set to null. Which will always lead to visibility model reset regardless of the `repeat` value. 

This is non issue for visibility tracking with selectosr. Because of the protection [here](https://github.com/ampproject/amphtml/blob/master/extensions/amp-analytics/0.1/visibility-manager.js#L540).  We remove trackedElement on `dispose()`, and the selected element's visibility will always be 0. However w/o selector, root visibility remains 1, and leads to infinite reset. I added the analytics config to repro the bug in #12304 