### PR TITLE
Prevent locking orientation from blocking rendering on error

### DIFF
--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -450,7 +450,7 @@ export class AmpStory extends AMP.BaseElement {
     try {
       lockOrientation('portrait');
     } catch (e) {
-      dev().warn(TAG, 'Could not lock screen orientation:', e.message);
+      dev().warn(TAG, 'Failed to lock screen orientation:', e.message);
     }
   }
 

--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -447,7 +447,11 @@ export class AmpStory extends AMP.BaseElement {
         screen.mozLockOrientation || screen.msLockOrientation ||
         (unusedOrientation => {});
 
-    lockOrientation('portrait');
+    try {
+      lockOrientation('portrait');
+    } catch(e) {
+      dev().info(TAG, 'Could not lock screen orientation:', e.message);
+    }
   }
 
   /** @private */

--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -449,8 +449,8 @@ export class AmpStory extends AMP.BaseElement {
 
     try {
       lockOrientation('portrait');
-    } catch(e) {
-      dev().info(TAG, 'Could not lock screen orientation:', e.message);
+    } catch (e) {
+      dev().warn(TAG, 'Could not lock screen orientation:', e.message);
     }
   }
 


### PR DESCRIPTION
Firefox Quantum blocks page rendering when `mozLockOrientation` fails :(