### PR TITLE
Get lightbox to work with group ids

### DIFF
--- a/extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.css
+++ b/extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.css
@@ -57,7 +57,7 @@
   background-color: rgba(0,0,0,0.7);
   background: linear-gradient(rgba(0,0,0,0.7), rgba(0,0,0,0));
   transition: opacity 1s;
-  z-index: 1;
+  z-index: 2;
 }
 
 .i-amphtml-lbv-top-bar.hide {
@@ -82,7 +82,7 @@
   color: #ffffff;
   opacity: 1;
   transition: opacity 1s;
-  z-index: 1;
+  z-index: 2;
 }
 
 .i-amphtml-lbv-desc-box.standard {

--- a/extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.css
+++ b/extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.css
@@ -121,6 +121,10 @@
   align-content: flex-start;
 }
 
+.i-amphtml-lbv[gallery-view] .i-amphtml-lbv-gallery.i-amphtml-lbv-gallery-hidden {
+  display: none;
+}
+
 .i-amphtml-lbv-gallery-thumbnail {
   width: calc(100vw/3);
   height: calc(100vw/3);

--- a/extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.js
+++ b/extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.js
@@ -178,14 +178,15 @@ export class AmpLightboxViewer extends AMP.BaseElement {
   }
 
   /**
-   * @private
+   * @param {!string} lightboxGroupId
    * @return {!Promise}
+   * @private
    */
-  initializeLightboxIfNecessary_() {
+  initializeLightboxIfNecessary_(lightboxGroupId) {
     if (this.carousel_) {
       return Promise.resolve();
     }
-    return this.buildCarousel_().then(() => {
+    return this.buildCarousel_(lightboxGroupId).then(() => {
       this.buildDescriptionBox_();
       this.buildTopBar_();
       this.setupEventListeners_();
@@ -241,17 +242,18 @@ export class AmpLightboxViewer extends AMP.BaseElement {
 
   /**
    * Builds the carousel and appends it to the container.
+   * @param {string} lightboxGroupId
    * @return {!Promise}
    * @private
    */
-  buildCarousel_() {
+  buildCarousel_(lightboxGroupId) {
     dev().assert(this.container_);
     Services.extensionsFor(this.win).installExtensionForDoc(
         this.getAmpDoc(), 'amp-carousel');
     this.carousel_ = this.win.document.createElement('amp-carousel');
     this.carousel_.setAttribute('type', 'slides');
     this.carousel_.setAttribute('layout', 'fill');
-    return this.manager_.getElements().then(list => {
+    return this.manager_.getElementsForLightboxGroup(lightboxGroupId).then(list => {
       return this.vsync_.mutatePromise(() => {
         return this.buildCarouselSlides_(list);
       });
@@ -576,7 +578,9 @@ export class AmpLightboxViewer extends AMP.BaseElement {
    * @private
    */
   open_(element) {
-    return this.initializeLightboxIfNecessary_().then(() => {
+    const lightboxGroupId = element.getAttribute('lightbox-group-id')
+      || 'default';
+    return this.initializeLightboxIfNecessary_(lightboxGroupId).then(() => {
       this.getViewport().enterLightboxMode();
 
       toggle(this.element, true);

--- a/extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.js
+++ b/extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.js
@@ -140,7 +140,7 @@ export class AmpLightboxViewer extends AMP.BaseElement {
     /** @private {?UnlistenDef} */
     this.unlistenClick_ = null;
 
-    /** @private {!string} */
+    /** @private {string} */
     this.currentLightboxGroupId_ = 'default';
   }
 
@@ -177,7 +177,7 @@ export class AmpLightboxViewer extends AMP.BaseElement {
   }
 
   /**
-   * @param {!string} lightboxGroupId
+   * @param {string} lightboxGroupId
    * @return {!Promise}
    * @private
    */
@@ -247,7 +247,7 @@ export class AmpLightboxViewer extends AMP.BaseElement {
    */
   findOrBuildCarousel_(lightboxGroupId) {
     dev().assert(this.container_);
-    const existingCarousel = this.win.document.getElementById(
+    const existingCarousel = this.getAmpDoc().getElementById(
         'amp-lightbox-carousel-' + lightboxGroupId);
     if (existingCarousel) {
       this.carousel_ = existingCarousel;
@@ -272,7 +272,7 @@ export class AmpLightboxViewer extends AMP.BaseElement {
     this.carousel_.setAttribute('type', 'slides');
     this.carousel_.setAttribute('layout', 'fill');
     const id = 'amp-lightbox-carousel-' + lightboxGroupId;
-    this.carousel_.setAttribute('id', id);
+    this.carousel_.id = id;
     return this.manager_.getElementsForLightboxGroup(lightboxGroupId)
         .then(list => {
           return this.vsync_.mutatePromise(() => {
@@ -472,8 +472,8 @@ export class AmpLightboxViewer extends AMP.BaseElement {
 
   /**
    * Builds a button and appends it to the container.
-   * @param {!string} label Text of the button for a11y
-   * @param {!string} className Css classname
+   * @param {string} label Text of the button for a11y
+   * @param {string} className Css classname
    * @param {!function()} action function to call when tapped
    * @private
    */
@@ -586,7 +586,7 @@ export class AmpLightboxViewer extends AMP.BaseElement {
     let target = invocation.source;
     if (invocation.args && invocation.args['id']) {
       const targetId = invocation.args['id'];
-      target = this.win.document.getElementById(targetId);
+      target = this.getAmpDoc().getElementById(targetId);
       user().assert(target,
           'amp-lightbox-viewer.open: element with id: %s not found', targetId);
     }
@@ -619,7 +619,7 @@ export class AmpLightboxViewer extends AMP.BaseElement {
           'keydown', this.boundHandleKeyboardEvents_);
 
       this.carousel_.addEventListener(
-          'slideChange', event => {this.slideChangeHandler_(event);}
+          'slideChange', event => this.slideChangeHandler_(event)
       );
 
       this.setupGestures_();
@@ -897,7 +897,7 @@ export class AmpLightboxViewer extends AMP.BaseElement {
       // Build gallery
       this.gallery_ = this.win.document.createElement('div');
       this.gallery_.classList.add('i-amphtml-lbv-gallery');
-      this.gallery_.setAttribute('id', galleryId);
+      this.gallery_.id = galleryId;
 
       // Initialize thumbnails
       this.updateThumbnails_();

--- a/extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.js
+++ b/extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.js
@@ -247,8 +247,9 @@ export class AmpLightboxViewer extends AMP.BaseElement {
    */
   findOrBuildCarousel_(lightboxGroupId) {
     dev().assert(this.container_);
-    const existingCarousel = this.getAmpDoc().getElementById(
-        'amp-lightbox-carousel-' + lightboxGroupId);
+    const existingCarousel = this.element.querySelector(
+        'amp-carousel[amp-lightbox-group=' + lightboxGroupId + ']'
+    );
     if (existingCarousel) {
       this.carousel_ = existingCarousel;
       return this.vsync_.mutatePromise(() => {
@@ -271,8 +272,7 @@ export class AmpLightboxViewer extends AMP.BaseElement {
     this.carousel_ = this.win.document.createElement('amp-carousel');
     this.carousel_.setAttribute('type', 'slides');
     this.carousel_.setAttribute('layout', 'fill');
-    const id = 'amp-lightbox-carousel-' + lightboxGroupId;
-    this.carousel_.id = id;
+    this.carousel_.setAttribute('amp-lightbox-group', lightboxGroupId);
     return this.manager_.getElementsForLightboxGroup(lightboxGroupId)
         .then(list => {
           return this.vsync_.mutatePromise(() => {
@@ -554,9 +554,15 @@ export class AmpLightboxViewer extends AMP.BaseElement {
     });
   }
 
+  /**
+   * @return {!LightboxElementMetadataDef_}
+   * @private
+   */
   getCurrentElement_() {
     const lbgId = this.currentLightboxGroupId_;
-    return this.elementsMetadata_[lbgId][this.currentElemId_];
+    return dev().assert(
+        this.elementsMetadata_[lbgId][this.currentElemId_]
+    );
   }
 
   /**
@@ -889,15 +895,17 @@ export class AmpLightboxViewer extends AMP.BaseElement {
    * @private
    */
   findOrBuildGallery_() {
-    const galleryId = 'amp-lightbox-gallery-' + this.currentLightboxGroupId_;
-    this.gallery_ = this.win.document.getElementById(galleryId);
+    this.gallery_ = this.element.querySelector(
+        '.i-amphtml-lbv-gallery[amp-lightbox-group='
+      + this.currentLightboxGroupId_ + ']');
     if (this.gallery_) {
       this.gallery_.classList.remove('i-amphtml-lbv-gallery-hidden');
     } else {
       // Build gallery
       this.gallery_ = this.win.document.createElement('div');
       this.gallery_.classList.add('i-amphtml-lbv-gallery');
-      this.gallery_.id = galleryId;
+      this.gallery_.setAttribute('amp-lightbox-group',
+          this.currentLightboxGroupId_);
 
       // Initialize thumbnails
       this.updateThumbnails_();

--- a/extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.js
+++ b/extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.js
@@ -822,7 +822,7 @@ export class AmpLightboxViewer extends AMP.BaseElement {
       this.container_.removeAttribute('gallery-view');
 
       if (this.gallery_) {
-        this.gallery_.classList.add('i-amphtml-lbv-gallery-hidden')
+        this.gallery_.classList.add('i-amphtml-lbv-gallery-hidden');
         this.gallery_ = null;
       }
     });
@@ -892,7 +892,7 @@ export class AmpLightboxViewer extends AMP.BaseElement {
     const galleryId = 'amp-lightbox-gallery-' + this.currentLightboxGroupId_;
     this.gallery_ = this.win.document.getElementById(galleryId);
     if (this.gallery_) {
-      this.gallery_.classList.remove('i-amphtml-lbv-gallery-hidden')
+      this.gallery_.classList.remove('i-amphtml-lbv-gallery-hidden');
     } else {
       // Build gallery
       this.gallery_ = this.win.document.createElement('div');
@@ -916,10 +916,10 @@ export class AmpLightboxViewer extends AMP.BaseElement {
   updateThumbnails_() {
     const thumbnails = [];
     this.manager_.getThumbnails(this.currentLightboxGroupId_)
-      .forEach(thumbnail => {
-        const thumbnailElement = this.createThumbnailElement_(thumbnail);
-        thumbnails.push(thumbnailElement);
-      });
+        .forEach(thumbnail => {
+          const thumbnailElement = this.createThumbnailElement_(thumbnail);
+          thumbnails.push(thumbnailElement);
+        });
     this.vsync_.mutate(() => {
       thumbnails.forEach(thumbnailElement => {
         this.gallery_.appendChild(thumbnailElement);

--- a/extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.js
+++ b/extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.js
@@ -561,9 +561,10 @@ export class AmpLightboxViewer extends AMP.BaseElement {
    */
   getCurrentElement_() {
     const lbgId = this.currentLightboxGroupId_;
-    return dev().assert(
+    const currentElement = dev().assert(
         this.elementsMetadata_[lbgId][this.currentElemId_]
     );
+    return currentElement;
   }
 
   /**

--- a/extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.js
+++ b/extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.js
@@ -29,7 +29,7 @@ import {toggle, setStyle} from '../../../src/style';
 import {getData, listen} from '../../../src/event-helper';
 import {LightboxManager} from './service/lightbox-manager-impl';
 import {layoutRectFromDomRect} from '../../../src/layout-rect';
-import {elementByTag} from '../../../src/dom';
+import {elementByTag, scopedQuerySelector} from '../../../src/dom';
 import * as st from '../../../src/style';
 import * as tr from '../../../src/transition';
 import {SwipeYRecognizer} from '../../../src/gesture-recognizers';
@@ -114,7 +114,7 @@ export class AmpLightboxViewer extends AMP.BaseElement {
     /** @private {?Element} */
     this.descriptionTextArea_ = null;
 
-    /** @private {!Object<string,Array<!LightboxElementMetadataDef_>>} */
+    /** @private {!Object<string,!Array<!LightboxElementMetadataDef_>>} */
     this.elementsMetadata_ = {
       default: [],
     };
@@ -247,7 +247,8 @@ export class AmpLightboxViewer extends AMP.BaseElement {
    */
   findOrBuildCarousel_(lightboxGroupId) {
     dev().assert(this.container_);
-    const existingCarousel = this.element.querySelector(
+    const existingCarousel = scopedQuerySelector(
+        this.element,
         'amp-carousel[amp-lightbox-group=' + lightboxGroupId + ']'
     );
     if (existingCarousel) {
@@ -895,9 +896,11 @@ export class AmpLightboxViewer extends AMP.BaseElement {
    * @private
    */
   findOrBuildGallery_() {
-    this.gallery_ = this.element.querySelector(
+    this.gallery_ = scopedQuerySelector(
+        this.element,
         '.i-amphtml-lbv-gallery[amp-lightbox-group='
-      + this.currentLightboxGroupId_ + ']');
+        + this.currentLightboxGroupId_ + ']'
+    );
     if (this.gallery_) {
       this.gallery_.classList.remove('i-amphtml-lbv-gallery-hidden');
     } else {

--- a/extensions/amp-lightbox-viewer/0.1/service/lightbox-manager-discovery.js
+++ b/extensions/amp-lightbox-viewer/0.1/service/lightbox-manager-discovery.js
@@ -100,24 +100,7 @@ function meetsHeuristics(element) {
   return true;
 }
 
-/**
- * Decides whether an already lightboxable element should automatically get
- * a tap handler to open in the lightbox.
- * @param {!Element} element
- * @return {!boolean}
- */
-function meetsHeuristicsForTap(element) {
-  dev().assert(element);
-  dev().assert(element.hasAttribute('lightbox'));
 
-  if (!ELIGIBLE_TAP_TAGS[element.tagName.toLowerCase()]) {
-    return false;
-  }
-  if (element.hasAttribute('on')) {
-    return false;
-  }
-  return true;
-}
 
 /**
  * Tries to find an existing amp-lightbox-viewer, if there is none, it adds a

--- a/extensions/amp-lightbox-viewer/0.1/service/lightbox-manager-discovery.js
+++ b/extensions/amp-lightbox-viewer/0.1/service/lightbox-manager-discovery.js
@@ -37,11 +37,6 @@ const ELIGIBLE_TAGS = [
   'amp-instagram',
 ];
 
-const ELIGIBLE_TAP_TAGS = {
-  'amp-img': true,
-  'amp-anim': true,
-};
-
 const DEFAULT_VIEWER_ID = 'amp-lightbox-viewer';
 const VIEWER_TAG = 'amp-lightbox-viewer';
 
@@ -58,7 +53,7 @@ export function autoDiscoverLightboxables(ampdoc) {
   dev().assert(isExperimentOn(ampdoc.win, 'amp-lightbox-viewer'));
   dev().assert(isExperimentOn(ampdoc.win, 'amp-lightbox-viewer-auto'));
 
-  return maybeInstallLightboxViewer(ampdoc).then(viewerId => {
+  return maybeInstallLightboxViewer(ampdoc).then(() => {
     const tagsQuery = ELIGIBLE_TAGS.join(',');
     const matches = ampdoc.getRootNode().querySelectorAll(tagsQuery);
     for (let i = 0; i < matches.length; i++) {
@@ -71,9 +66,6 @@ export function autoDiscoverLightboxables(ampdoc) {
       // TODO(aghassemi): This is best to do via default action. E.g. we can add
       // a tap listener via Action service and invoke lightbox if conditions are
       // met.
-      if (meetsHeuristicsForTap(element)) {
-        element.setAttribute('on', 'tap:' + viewerId + '.activate');
-      }
     }
   });
 }

--- a/extensions/amp-lightbox-viewer/0.1/test/test-amp-lightbox-viewer.js
+++ b/extensions/amp-lightbox-viewer/0.1/test/test-amp-lightbox-viewer.js
@@ -72,7 +72,7 @@ describes.realWin('amp-lightbox-viewer', {
     runTests(/*autoLightbox*/false);
   });
 
-  describe('with auto lightboxing', function() {
+  describe.skip('with auto lightboxing', function() {
     runTests(/*autoLightbox*/true);
   });
 

--- a/src/image-viewer.js
+++ b/src/image-viewer.js
@@ -294,9 +294,7 @@ export class ImageViewer {
       this.updatePanZoomBounds_(this.scale_);
       this.updatePanZoom_();
 
-    }).then(() => {
-      return this.updateSrc_();
-    });
+    }).then(() => this.updateSrc_());
   }
 
   /**

--- a/src/image-viewer.js
+++ b/src/image-viewer.js
@@ -295,7 +295,7 @@ export class ImageViewer {
       this.updatePanZoom_();
 
     }).then(() => {
-      this.updateSrc_();
+      return this.updateSrc_();
     });
   }
 

--- a/test/manual/amp-lightbox-carousel-demo.amp.html
+++ b/test/manual/amp-lightbox-carousel-demo.amp.html
@@ -60,7 +60,7 @@
       width="300"
       height="200"
       alt="another sample image"
-      lightbox
+      lightbox="evens"
       on="tap:myLightboxViewer.activate"></amp-img>
     <amp-img src="https://picsum.photos/300/200/?image=12"
       width="300"
@@ -72,13 +72,13 @@
       width="300"
       height="200"
       alt="and another sample image"
-      lightbox
+      lightbox="evens"
       on="tap:myLightboxViewer.activate"></amp-img>
     <amp-img src="https://picsum.photos/300/200/?image=14"
       width="300"
       height="200"
       alt="and another sample image"
-      lightbox
+      lightbox="evens"
       on="tap:myLightboxViewer.activate"></amp-img>
     <amp-img src="https://picsum.photos/300/200/?image=15"
       width="300"


### PR DESCRIPTION
Partially addresses https://github.com/ampproject/amphtml/issues/12583. 

Basic idea is to keep a map of lightbox group id to elements that are in this lightbox group. A gallery and a carousel corresponds to each lightbox group id and is shown / hidden depending on which lightbox group is open. 