### PR TITLE
amp-gwd-animation: Fix timeline-event-prefix attribute validator rule

### DIFF
--- a/extensions/amp-gwd-animation/validator-amp-gwd-animation.protoascii
+++ b/extensions/amp-gwd-animation/validator-amp-gwd-animation.protoascii
@@ -28,10 +28,7 @@ tags: {  # <amp-gwd-animation>
   html_format: AMP4ADS
   tag_name: "AMP-GWD-ANIMATION"
   requires_extension: "amp-gwd-animation"
-  attrs: {
-    name: "timeline-event-prefix"
-    value: ""
-  }
+  attrs: { name: "timeline-event-prefix" }
   attr_lists: "extended-amp-global"
   amp_layout: {
     supported_layouts: NODISPLAY


### PR DESCRIPTION
amp-gwd-animation: Remove the incorrect `value: ""` field from the `timeline-event-prefix` attribute validator rule. The attribute should accept any string.