### PR TITLE
Write prod config and enable local dev for gulp watch

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -441,6 +441,7 @@ function copyCss() {
  * @return {!Promise}
  */
 function watch() {
+  printConfigHelp('gulp watch', 'dist/amp.js');
   $$.watch('css/**/*.css', function() {
     compileCss();
   });
@@ -451,7 +452,9 @@ function watch() {
     buildExaminer({watch: true}),
     buildExtensions({watch: true}),
     compile(true),
-  ]);
+  ]).then(() => {
+    return enableLocalTesting('dist/amp.js');
+  });
 }
 
 /**
@@ -608,7 +611,7 @@ function enableLocalTesting(targetFile) {
  */
 function build() {
   process.env.NODE_ENV = 'development';
-  printConfigHelp('gulp build', 'dist/amp.js')
+  printConfigHelp('gulp build', 'dist/amp.js');
   return compileCss().then(() => {
     return Promise.all([
       polyfillsForTests(),
@@ -1304,11 +1307,12 @@ gulp.task('dist', 'Build production binaries', ['update-packages'], dist, {
   }
 });
 gulp.task('extensions', 'Build AMP Extensions', buildExtensions);
-gulp.task('watch', 'Watches for changes in files, re-build', watch, {
-  options: {
-    with_inabox: '  Also watch and build the amp-inabox.js binary.',
-    with_shadow: '  Also watch and build the amp-shadow.js binary.',
-  }
+gulp.task('watch', 'Watches for changes in files, re-builds when detected',
+    ['update-packages'], watch, {
+      options: {
+        with_inabox: '  Also watch and build the amp-inabox.js binary.',
+        with_shadow: '  Also watch and build the amp-shadow.js binary.',
+      }
 });
 gulp.task('build-experiments', 'Builds experiments.html/js', buildExperiments);
 gulp.task('build-login-done', 'Builds login-done.html/js', buildLoginDone);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -52,6 +52,9 @@ var yellow = $$.util.colors.yellow;
 var red = $$.util.colors.red;
 var cyan = $$.util.colors.cyan;
 
+var minifiedRuntimeTarget = 'dist/v0.js';
+var unminifiedRuntimeTarget = 'dist/amp.js';
+
 // Each extension and version must be listed individually here.
 declareExtension('amp-3q-player', '0.1', false);
 declareExtension('amp-access', '0.1', true);
@@ -441,7 +444,7 @@ function copyCss() {
  * @return {!Promise}
  */
 function watch() {
-  printConfigHelp('gulp watch', 'dist/amp.js');
+  printConfigHelp('gulp watch', unminifiedRuntimeTarget);
   $$.watch('css/**/*.css', function() {
     compileCss();
   });
@@ -453,7 +456,7 @@ function watch() {
     buildExtensions({watch: true}),
     compile(true),
   ]).then(() => {
-    return enableLocalTesting('dist/amp.js');
+    return enableLocalTesting(unminifiedRuntimeTarget);
   });
 }
 
@@ -611,7 +614,7 @@ function enableLocalTesting(targetFile) {
  */
 function build() {
   process.env.NODE_ENV = 'development';
-  printConfigHelp('gulp build', 'dist/amp.js');
+  printConfigHelp('gulp build', unminifiedRuntimeTarget);
   return compileCss().then(() => {
     return Promise.all([
       polyfillsForTests(),
@@ -623,7 +626,7 @@ function build() {
       compile(),
     ]);
   }).then(() => {
-    return enableLocalTesting('dist/amp.js');
+    return enableLocalTesting(unminifiedRuntimeTarget);
   });
 }
 
@@ -635,7 +638,7 @@ function dist() {
   process.env.NODE_ENV = 'production';
   cleanupBuildDir();
   if (argv.fortesting) {
-    printConfigHelp('gulp dist --fortesting', 'dist/v0.js')
+    printConfigHelp('gulp dist --fortesting', minifiedRuntimeTarget)
   }
   return compileCss().then(() => {
     return Promise.all([
@@ -657,7 +660,7 @@ function dist() {
     copyAliasExtensions();
   }).then(() => {
     if (argv.fortesting) {
-      return enableLocalTesting('dist/v0.js');
+      return enableLocalTesting(minifiedRuntimeTarget);
     }
   });
 }


### PR DESCRIPTION
Running `gulp build [--config=canary]` or `gulp dist --fortesting [--config=canary]` sets `localDev` to true and causes the `prod [canary]` config to be written to the locally built AMP runtime.

With this PR, we run the same steps for `gulp` and `gulp watch`.

**To build and enable `localDev` with the `prod` config, run one of these commands:**

```
gulp
gulp watch
gulp build
gulp dist --fortesting
```

**To build and enable `localDev` with the `canary` config, run one of these commands:**

```
gulp --config canary
gulp watch --config canary
gulp build --config canary
gulp dist --fortesting --config canary
```

This fixes the issue raised in https://github.com/ampproject/amphtml/issues/12054#issuecomment-355357528
Partial fix for #12054
  
  
  