### PR TITLE
Simplify isLocalDev logic in mode.js

### DIFF
--- a/extensions/amp-a4a/0.1/real-time-config-manager.js
+++ b/extensions/amp-a4a/0.1/real-time-config-manager.js
@@ -19,7 +19,6 @@ import {dev, user} from '../../../src/log';
 import {Services} from '../../../src/services';
 import {isArray, isObject} from '../../../src/types';
 import {isSecureUrl} from '../../../src/url';
-import {getMode} from '../../../src/mode';
 
 /** @type {string} */
 const TAG = 'real-time-config';
@@ -151,7 +150,7 @@ function inflateAndSendRtc_(a4aElement, url, seenUrls, promiseArray,
     url = urlReplacements.expandUrlSync(
         url, macros, /** opt_collectVars */undefined, whitelist);
   }
-  if (!isSecureUrl(url) && !(getMode(win).localDev || getMode(win).test)) {
+  if (!isSecureUrl(url)) {
     return logAndAddErrorResponse_(promiseArray, RTC_ERROR_ENUM.INSECURE_URL,
         opt_vendor || url);
   }

--- a/extensions/amp-a4a/0.1/test/test-real-time-config-manager.js
+++ b/extensions/amp-a4a/0.1/test/test-real-time-config-manager.js
@@ -334,8 +334,6 @@ describes.realWin('real-time-config-manager', {amp: true}, env => {
     });
 
     it('should not send an RTC callout to an insecure url', () => {
-      env.win.AMP_MODE.test = false;
-      env.win.AMP_MODE.localdev = false;
       const urls = [
         'https://www.1.com/',
         'https://www.2.com',

--- a/src/mode.js
+++ b/src/mode.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import {startsWith} from './string';
 import {parseQueryString_} from './url-parse-query-string';
 
 /**
@@ -43,12 +42,6 @@ const version = '$internalRuntimeVersion$';
 let rtvVersion = '';
 
 /**
- * A #querySelector query to see if we have any scripts with development paths.
- * @type {string}
- */
-const developmentScriptQuery = 'script[src*="/dist/"],script[src*="/base/"]';
-
-/**
  * Provides info about the current app.
  * @param {?Window=} opt_win
  * @return {!ModeDef}
@@ -73,11 +66,9 @@ function getMode_(win) {
   // --fortesting flag.
   const IS_DEV = true;
   const IS_MINIFIED = false;
-  const LOCALDEV_ENABLED = !!(self.AMP_CONFIG && self.AMP_CONFIG.localDev);
-  const AMP_CONFIG_3P_FRAME_HOST = self.AMP_CONFIG &&
-      self.AMP_CONFIG.thirdPartyFrameHost;
 
-  const isLocalDev = IS_DEV && LOCALDEV_ENABLED;
+  const localDevEnabled = !!(self.AMP_CONFIG && self.AMP_CONFIG.localDev);
+  const isLocalDev = IS_DEV && localDevEnabled;
   const hashQuery = parseQueryString_(
       // location.originalHash is set by the viewer when it removes the fragment
       // from the URL.

--- a/src/mode.js
+++ b/src/mode.js
@@ -68,7 +68,8 @@ function getMode_(win) {
   const IS_MINIFIED = false;
 
   const localDevEnabled = !!(self.AMP_CONFIG && self.AMP_CONFIG.localDev);
-  const isLocalDev = IS_DEV && localDevEnabled;
+  const runningTests = IS_DEV && !!(win.AMP_TEST || win.__karma__);
+  const isLocalDev = IS_DEV && (localDevEnabled || runningTests);
   const hashQuery = parseQueryString_(
       // location.originalHash is set by the viewer when it removes the fragment
       // from the URL.
@@ -87,8 +88,7 @@ function getMode_(win) {
   return {
     localDev: isLocalDev,
     // Triggers validation
-    development: !!(hashQuery['development'] == '1' ||
-        win.AMP_DEV_MODE),
+    development: !!(hashQuery['development'] == '1' || win.AMP_DEV_MODE),
     examiner: hashQuery['development'] == '2',
     // Allows filtering validation errors by error category. For the
     // available categories, see ErrorCategory in validator/validator.proto.
@@ -97,7 +97,7 @@ function getMode_(win) {
     // Whether document is in an amp-lite viewer. It signal that the user
     // would prefer to use less bandwidth.
     lite: searchQuery['amp_lite'] != undefined,
-    test: IS_DEV && !!(win.AMP_TEST || win.__karma__),
+    test: runningTests,
     log: hashQuery['log'],
     version,
     rtvVersion,

--- a/src/mode.js
+++ b/src/mode.js
@@ -69,22 +69,15 @@ export function getMode(opt_win) {
 function getMode_(win) {
   // Magic constants that are replaced by closure compiler.
   // IS_MINIFIED is always replaced with true when closure compiler is used
-  // while IS_DEV is only replaced when the --fortesting flag is NOT used.
+  // while IS_DEV is only replaced when `gulp dist` is called without the
+  // --fortesting flag.
   const IS_DEV = true;
   const IS_MINIFIED = false;
-  const FORCE_LOCALDEV = !!(self.AMP_CONFIG && self.AMP_CONFIG.localDev);
+  const LOCALDEV_ENABLED = !!(self.AMP_CONFIG && self.AMP_CONFIG.localDev);
   const AMP_CONFIG_3P_FRAME_HOST = self.AMP_CONFIG &&
       self.AMP_CONFIG.thirdPartyFrameHost;
 
-  const isLocalDev = IS_DEV && !!(win.location.hostname == 'localhost' ||
-      (FORCE_LOCALDEV && win.location.hostname == AMP_CONFIG_3P_FRAME_HOST) ||
-      (win.location.ancestorOrigins && win.location.ancestorOrigins[0] &&
-        startsWith(win.location.ancestorOrigins[0], 'http://localhost:'))) &&
-      // Filter out localhost running against a prod script.
-      // Because all allowed scripts are ours, we know that these can only
-      // occur during local dev.
-      (!win.document || !!win.document.querySelector(developmentScriptQuery));
-
+  const isLocalDev = IS_DEV && LOCALDEV_ENABLED;
   const hashQuery = parseQueryString_(
       // location.originalHash is set by the viewer when it removes the fragment
       // from the URL.


### PR DESCRIPTION
Now that `gulp`, `gulp watch`, `gulp build`, and `gulp dist --fortesting` all enable `localDev` by default, this PR simplifies the logic behind `isLocalDev` in `src/mode.js` based on the suggestion presented in https://github.com/ampproject/amphtml/issues/12054#issuecomment-355133769.

Tested by making sure that `localDev` is set to true in the locally served `AMP_CONFIG` after each of the following:
- [x] `gulp`
- [x] `gulp watch`
- [x] `gulp build && gulp serve`
- [x] `export AMP_TESTING_HOST=<hostname> && gulp build && gulp serve --host=<hostname>`
- [x] `gulp dist --fortesting && gulp serve --compiled`
- [x] `export AMP_TESTING_HOST=<hostname> && gulp dist --fortesting && gulp serve  --compiled --host=<hostname>`

Partial fix for #12054
  