### PR TITLE
Fix ads served from non-localhost servers

### DIFF
--- a/build-system/tasks/prepend-global/index.js
+++ b/build-system/tasks/prepend-global/index.js
@@ -169,6 +169,7 @@ function enableLocalDev(config, target, configJson) {
   const TESTING_HOST = process.env.AMP_TESTING_HOST;
   if (typeof TESTING_HOST == 'string') {
     LOCAL_DEV_AMP_CONFIG = Object.assign(LOCAL_DEV_AMP_CONFIG, {
+      thirdPartyUrl: 'http://' + TESTING_HOST,
       thirdPartyFrameHost: TESTING_HOST,
       thirdPartyFrameRegex: TESTING_HOST,
     });

--- a/src/3p-frame.js
+++ b/src/3p-frame.js
@@ -229,8 +229,8 @@ export function getDefaultBootstrapBaseUrl(parentWindow, opt_srcFileBasename) {
 }
 
 function getAdsLocalhost(win) {
-  const hostname = getMode().thirdPartyFrameHost ?
-    getMode().thirdPartyFrameHost : 'ads.localhost';
+  const hostname = self.AMP_CONFIG['thirdPartyFrameHost'] ?
+    self.AMP_CONFIG['thirdPartyFrameHost'] : 'ads.localhost';
   return 'http://' + hostname + ':' +
       (win.location.port || win.parent.location.port);
 }

--- a/src/3p-frame.js
+++ b/src/3p-frame.js
@@ -229,8 +229,11 @@ export function getDefaultBootstrapBaseUrl(parentWindow, opt_srcFileBasename) {
 }
 
 function getAdsLocalhost(win) {
-  return (getMode().thirdPartyUrl || 'http://ads.localhost') + ':' +
-      (win.location.port || win.parent.location.port);
+  let adsUrl = urls.thirdParty;
+  if (adsUrl == 'https://3p.ampproject.net') {
+    adsUrl = 'http://ads.localhost';
+  }
+  return adsUrl + ':' + (win.location.port || win.parent.location.port);
 }
 
 /**

--- a/src/3p-frame.js
+++ b/src/3p-frame.js
@@ -229,8 +229,10 @@ export function getDefaultBootstrapBaseUrl(parentWindow, opt_srcFileBasename) {
 }
 
 function getAdsLocalhost(win) {
-  return 'http://ads.localhost:'
-      + (win.location.port || win.parent.location.port);
+  const hostname = getMode().thirdPartyFrameHost ?
+    getMode().thirdPartyFrameHost : 'ads.localhost';
+  return 'http://' + hostname + ':' +
+      (win.location.port || win.parent.location.port);
 }
 
 /**

--- a/src/3p-frame.js
+++ b/src/3p-frame.js
@@ -229,9 +229,9 @@ export function getDefaultBootstrapBaseUrl(parentWindow, opt_srcFileBasename) {
 }
 
 function getAdsLocalhost(win) {
-  let adsUrl = urls.thirdParty;
-  if (adsUrl == 'https://3p.ampproject.net') {
-    adsUrl = 'http://ads.localhost';
+  let adsUrl = urls.thirdParty; // local dev with a non-localhost server
+  if (adsUrl.indexOf('ampproject.net') > -1) {
+    adsUrl = 'http://ads.localhost'; // local dev with a localhost server
   }
   return adsUrl + ':' + (win.location.port || win.parent.location.port);
 }

--- a/src/3p-frame.js
+++ b/src/3p-frame.js
@@ -229,9 +229,7 @@ export function getDefaultBootstrapBaseUrl(parentWindow, opt_srcFileBasename) {
 }
 
 function getAdsLocalhost(win) {
-  const hostname = self.AMP_CONFIG['thirdPartyFrameHost'] ?
-    self.AMP_CONFIG['thirdPartyFrameHost'] : 'ads.localhost';
-  return 'http://' + hostname + ':' +
+  return (self.AMP_CONFIG['thirdPartyUrl'] || 'http://ads.localhost') + ':' +
       (win.location.port || win.parent.location.port);
 }
 

--- a/src/3p-frame.js
+++ b/src/3p-frame.js
@@ -229,7 +229,7 @@ export function getDefaultBootstrapBaseUrl(parentWindow, opt_srcFileBasename) {
 }
 
 function getAdsLocalhost(win) {
-  return (self.AMP_CONFIG['thirdPartyUrl'] || 'http://ads.localhost') + ':' +
+  return (getMode().thirdPartyUrl || 'http://ads.localhost') + ':' +
       (win.location.port || win.parent.location.port);
 }
 


### PR DESCRIPTION
When you run...
```
export AMP_TESTING_HOST=<hostname>
gulp --host=<hostname>
```
... and navigate to `http://<hostname>:8000/examples/ads.amp.html`, the ads don't load because the page is trying to fetch them from `http://ads.localhost:8000/dist.3p/current` and not `http://<hostname>:8000/dist.3p/current`.

This PR replaces `ads.localhost` in `src/3p-frame.js` with `<hostname>` when they are being served from a non-localhost server.

See https://github.com/ampproject/amphtml/issues/12054#issuecomment-355443905 for more details. 

Fixes #12054
  