### PR TITLE
Eliminate the use of String.padStart()

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -206,7 +206,7 @@ function endBuildStep(stepName, targetName, startTime) {
   const endTime = Date.now();
   const executionTime = new Date(endTime - startTime);
   const secs = executionTime.getSeconds();
-  const ms = executionTime.getMilliseconds().toString().padStart(3, '0');
+  const ms = ('000' + executionTime.getMilliseconds().toString()).slice(-3);
   var timeString = '(';
   if (secs === 0) {
     timeString += ms + ' ms)';


### PR DESCRIPTION
Fixes the error seen in the Travis jobs from #12679

```
TypeError: executionTime.getMilliseconds(...).toString(...).padStart is not a function
    at endBuildStep (/home/travis/build/ampproject/amphtml/gulpfile.js:209:57)
    at jsifyCssAsync.then.then (/home/travis/build/ampproject/amphtml/gulpfile.js:418:5)
```

See https://travis-ci.org/ampproject/amphtml/jobs/325647986#L691