### PR TITLE
Eliminate the use of Object.values()

### DIFF
--- a/ads/google/a4a/test/test-utils.js
+++ b/ads/google/a4a/test/test-utils.js
@@ -479,8 +479,12 @@ describe('Google A4A utils', () => {
       });
       const ampAdElem = env.win.document.createElement('amp-ad');
       prevContainer.appendChild(ampAdElem);
+      const ValidAdContainerTypeValues =
+          Object.keys(ValidAdContainerTypes).map(function(key) {
+            return ValidAdContainerTypes[key];
+          });
       expect(getEnclosingContainerTypes(ampAdElem).sort())
-          .to.deep.equal(Object.values(ValidAdContainerTypes).sort());
+          .to.deep.equal(ValidAdContainerTypeValues.sort());
     });
   });
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -699,7 +699,10 @@ function checkTypes() {
     './src/service-worker/kill.js',
     './src/web-worker/web-worker.js',
   ];
-  var extensionSrcs = Object.values(extensions).filter(function(extension) {
+  var extensionValues = Object.keys(extensions).map(function(key) {
+    return extensions[key];
+  });
+  var extensionSrcs = extensionValues.filter(function(extension) {
     return !extension.noTypeCheck;
   }).map(function(extension) {
     return './extensions/' + extension.name + '/' +


### PR DESCRIPTION
Fixes the error seen in the Travis jobs from #12679

```
TypeError: Object.values is not a function
    at Gulp.checkTypes (/home/travis/build/ampproject/amphtml/gulpfile.js:702:30)
```

See https://travis-ci.org/ampproject/amphtml/jobs/325672590#L730