### PR TITLE
Fix several amp-list/amp-bind interaction bugs

### DIFF
--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -253,28 +253,29 @@ export class Bind {
   }
 
   /**
-   * Rescans elements for bindings, evaluates corresponding expressions
-   * and applies the results to only those elements. Does _not_ mutate other
-   * elements in the document.
+   * Removes bindings from `removed` elements and scans `added` for bindings.
+   * Then, evaluates all expressions and applies results to `added` elements.
+   * Does _not_ mutate any other elements.
    *
-   * Returned promise is resolved when rescan and evaluation complete.
-   * If it doesn't complete within `timeout` ms, the promise is rejected.
+   * Returned promise is resolved when all operations complete.
+   * If they don't complete within `timeout` ms, the promise is rejected.
    *
-   * @param {!Array<!Element>} elements
+   * @param {!Array<!Element>} added
+   * @param {!Array<!Element>} removed
    * @param {number} timeout Timeout in milliseconds.
    * @return {!Promise}
    */
-  rescanAndEvaluate(elements, timeout = 2000) {
-    const rescan = this.removeBindingsForNodes_(elements)
-        .then(() => this.addBindingsForNodes_(elements))
+  scanAndApply(added, removed, timeout = 2000) {
+    const promise = this.removeBindingsForNodes_(removed)
+        .then(() => this.addBindingsForNodes_(added))
         .then(numberOfBindingsAdded => {
           // Don't reevaluate/apply if there are no bindings.
           if (numberOfBindingsAdded > 0) {
             return this.evaluate_().then(results =>
-              this.applyElements_(results, elements));
+                this.applyElements_(results, added));
           }
         });
-    return this.timer_.timeoutPromise(timeout, rescan,
+    return this.timer_.timeoutPromise(timeout, promise,
         'Timed out waiting for amp-bind to process rendered template.');
   }
 
@@ -389,9 +390,6 @@ export class Bind {
         this.boundElements_ = this.boundElements_.concat(boundElements);
         Object.assign(this.expressionToElements_, expressionToElements);
 
-        dev().fine(TAG, `Scanned ${bindings.length} bindings from ` +
-            `${boundElements.length} elements.`);
-
         if (limitExceeded) {
           user().error(TAG, 'Maximum number of bindings reached ' +
               `(${this.maxNumberOfBindings_}). Additional elements with ` +
@@ -408,6 +406,8 @@ export class Bind {
       // `results` is a 2D array where results[i] is an array of bindings.
       // Flatten this into a 1D array of bindings via concat.
       const bindings = Array.prototype.concat.apply([], results);
+      dev().fine(TAG, `Scanned ${bindings.length} bindings from ` +
+          `${nodes.length} elements and their descendants.`);
       if (bindings.length == 0) {
         return bindings.length;
       } else {
@@ -444,6 +444,7 @@ export class Bind {
    * @visibleForTesting
    */
   removeBindingsForNodes_(nodes) {
+    const before = this.numberOfBindings();
     // Eliminate bound elements that are descendants of `nodes`.
     filterSplice(this.boundElements_, boundElement => {
       for (let i = 0; i < nodes.length; i++) {
@@ -453,7 +454,11 @@ export class Bind {
       }
       return true;
     });
-
+    const after = this.numberOfBindings();
+    if (after < before) {
+      dev().fine(TAG, `Removed ${before - after} bindings from ${nodes.length} `
+          + `elements and their descendants.`);
+    }
     // Eliminate elements from the expression to elements map that
     // have node as an ancestor. Delete expressions that are no longer
     // bound to elements.
@@ -993,9 +998,17 @@ export class Bind {
    * @param {!Event} event
    */
   onDomUpdate_(event) {
-    const templateContainer = dev().assertElement(event.target);
-    this.removeBindingsForNodes_([templateContainer]).then(() => {
-      return this.addBindingsForNodes_([templateContainer]);
+    const target = dev().assertElement(event.target);
+
+    // Skip amp-list since there's already a custom integration for it.
+    const parent = target.parentNode;
+    if (parent && parent.tagName == 'AMP-LIST') {
+      dev().info(TAG, 'Skipping DOM_UPDATE rescan of:', target);
+      return;
+    }
+
+    this.removeBindingsForNodes_([target]).then(() => {
+      return this.addBindingsForNodes_([target]);
     }).then(() => {
       this.dispatchEventForTesting_(BindEvents.RESCAN_TEMPLATE);
     });

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -272,7 +272,7 @@ export class Bind {
           // Don't reevaluate/apply if there are no bindings.
           if (numberOfBindingsAdded > 0) {
             return this.evaluate_().then(results =>
-                this.applyElements_(results, added));
+              this.applyElements_(results, added));
           }
         });
     return this.timer_.timeoutPromise(timeout, promise,
@@ -457,7 +457,7 @@ export class Bind {
     const after = this.numberOfBindings();
     if (after < before) {
       dev().fine(TAG, `Removed ${before - after} bindings from ${nodes.length} `
-          + `elements and their descendants.`);
+          + 'elements and their descendants.');
     }
     // Eliminate elements from the expression to elements map that
     // have node as an ancestor. Delete expressions that are no longer

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -444,7 +444,7 @@ export class Bind {
    * @visibleForTesting
    */
   removeBindingsForNodes_(nodes) {
-    const before = this.numberOfBindings();
+    const before = (getMode().development) ? this.numberOfBindings() : 0;
     // Eliminate bound elements that are descendants of `nodes`.
     filterSplice(this.boundElements_, boundElement => {
       for (let i = 0; i < nodes.length; i++) {
@@ -454,7 +454,7 @@ export class Bind {
       }
       return true;
     });
-    const after = this.numberOfBindings();
+    const after = (getMode().development) ? this.numberOfBindings() : 0;
     if (after < before) {
       dev().fine(TAG, `Removed ${before - after} bindings from ${nodes.length} `
           + 'elements and their descendants.');

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -36,12 +36,6 @@ export class AmpList extends AMP.BaseElement {
   constructor(element) {
     super(element);
 
-    /** @const {!function(!Array<!Element>)} */
-    this.boundRendered_ = this.rendered_.bind(this);
-
-    /** @const {!function(!Array<!Element>):!Promise<!Array<!Element>>} */
-    this.boundUpdateBindings_ = this.updateBindings_.bind(this);
-
     /** @private {?Element} */
     this.container_ = null;
 
@@ -179,8 +173,8 @@ export class AmpList extends AMP.BaseElement {
    */
   renderItems_(items) {
     return this.templates_.findAndRenderTemplateArray(this.element, items)
-        .then(this.boundUpdateBindings_)
-        .then(this.boundRendered_);
+        .then(elements => this.updateBindings_(elements))
+        .then(elements => this.rendered_(elements));
   }
 
   /**

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -153,7 +153,7 @@ export class AmpList extends AMP.BaseElement {
     return this.fetch_(itemsExpr).then(items => {
       if (this.element.hasAttribute('single-item')) {
         user().assert(typeof items !== 'undefined' ,
-            'Response must contain an arrary or object at "%s". %s',
+            'Response must contain an array or object at "%s". %s',
             itemsExpr, this.element);
         if (!isArray(items)) {
           items = [items];

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -191,6 +191,9 @@ describes.realWin('amp-list component', {
     const foo = doc.createElement('div');
     const rendered = expectFetchAndRender(items, [foo]);
 
+    // Return zero width to simulate pre-layout behavior.
+    listMock.expects('getLayoutWidth').returns(0);
+
     return list.layoutCallback().then(() => rendered).then(() => {
       expect(list.container_.contains(foo)).to.be.true;
 
@@ -207,8 +210,7 @@ describes.realWin('amp-list component', {
     const foo = doc.createElement('div');
     const rendered = expectFetchAndRender(items, [foo]);
 
-    // mutatedAttributesCallback() checks layout width to determine whether
-    // the element has been laid out yet.
+    // Return non-zero width to simulate post-layout behavior.
     listMock.expects('getLayoutWidth').returns(100);
 
     return list.layoutCallback().then(() => rendered).then(() => {

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -29,7 +29,7 @@ describes.realWin('amp-list component', {
   let element;
   let list;
   let listMock;
-  let bindStub;
+  let bindForDocOrNull;
 
   beforeEach(() => {
     win = env.win;
@@ -44,7 +44,7 @@ describes.realWin('amp-list component', {
     element.getAmpDoc = () => ampdoc;
     element.getFallback = () => null;
 
-    bindStub = sandbox.stub(Services, 'bindForDocOrNull')
+    bindForDocOrNull = sandbox.stub(Services, 'bindForDocOrNull')
         .returns(Promise.resolve(null));
 
     list = new AmpList(element);
@@ -60,31 +60,65 @@ describes.realWin('amp-list component', {
     listMock.verify();
   });
 
+  /**
+   * @param {!Array|!Object} fetched
+   * @param {!Array<!Element>} rendered
+   * @param {Object=} opts
+   * @return {!Promise}
+   */
+  function expectFetchAndRender(fetched, rendered,
+      opts = {expr: 'items', maxItems: 0, singleItem: false}) {
+    const fetch = Promise.resolve(fetched);
+    listMock.expects('fetch_').withExactArgs(opts.expr).returns(fetch).once();
+
+    let itemsToRender = fetched;
+    if (opts.singleItem) {
+      expect(fetched).to.be.a('object');
+      itemsToRender = [fetched];
+    } else if (opts.maxItems > 0) {
+      itemsToRender = fetched.slice(0, opts.maxItems);
+    }
+    const render = Promise.resolve(rendered);
+    templatesMock.expects('findAndRenderTemplateArray')
+        .withExactArgs(element, itemsToRender)
+        .returns(render)
+        .once();
+
+    return Promise.all([fetch, render]);
+  }
+
   it('should load and render', () => {
     const items = [
       {title: 'Title1'},
     ];
-    const newHeight = 127;
     const itemElement = doc.createElement('div');
-    itemElement.style.height = newHeight + 'px';
-    const fetchPromise = Promise.resolve(items);
-    const renderPromise = Promise.resolve([itemElement]);
-    listMock.expects('fetch_').withExactArgs('items')
-        .returns(fetchPromise).once();
-    templatesMock.expects('findAndRenderTemplateArray').withExactArgs(
-        element, items)
-        .returns(renderPromise).once();
+    const rendered = expectFetchAndRender(items, [itemElement]);
+    return list.layoutCallback().then(() => rendered).then(() => {
+      expect(list.container_.contains(itemElement)).to.be.true;
+    });
+  });
+
+  it('should attemptChangeHeight after render', () => {
+    const items = [
+      {title: 'Title1'},
+    ];
+    const itemElement = doc.createElement('div');
+    itemElement.style.height = '1337px';
+
+    const rendered = expectFetchAndRender(items, [itemElement]);
+
     let measureFunc;
     listMock.expects('getVsync').returns({
       measure: func => {
         measureFunc = func;
       },
     }).once();
-    listMock.expects('attemptChangeHeight').withExactArgs(newHeight).returns(
-        Promise.resolve());
-    return list.layoutCallback().then(() => {
-      return Promise.all([fetchPromise, renderPromise]);
-    }).then(() => {
+
+    listMock.expects('attemptChangeHeight')
+        .withExactArgs(1337)
+        .returns(Promise.resolve());
+
+    return list.layoutCallback().then(() => rendered).then(() => {
       expect(list.container_.contains(itemElement)).to.be.true;
       expect(measureFunc).to.exist;
       measureFunc();
@@ -93,31 +127,14 @@ describes.realWin('amp-list component', {
 
   it('should load and render non-array if single-item is set', () => {
     const items = {title: 'Title1'};
-    const newHeight = 127;
     const itemElement = doc.createElement('div');
-    itemElement.style.height = newHeight + 'px';
     element.setAttribute('single-item', 'true');
-    const fetchPromise = Promise.resolve(items);
-    const renderPromise = Promise.resolve([itemElement]);
-    listMock.expects('fetch_').withExactArgs('items')
-        .returns(fetchPromise).once();
-    templatesMock.expects('findAndRenderTemplateArray').withExactArgs(
-        element, [items])
-        .returns(renderPromise).once();
-    let measureFunc;
-    listMock.expects('getVsync').returns({
-      measure: func => {
-        measureFunc = func;
-      },
-    }).once();
-    listMock.expects('attemptChangeHeight').withExactArgs(newHeight).returns(
-        Promise.resolve());
-    return list.layoutCallback().then(() => {
-      return Promise.all([fetchPromise, renderPromise]);
-    }).then(() => {
+
+    const rendered = expectFetchAndRender(
+        items, [itemElement], {expr: 'items', singleItem: true});
+
+    return list.layoutCallback().then(() => rendered).then(() => {
       expect(list.container_.contains(itemElement)).to.be.true;
-      expect(measureFunc).to.exist;
-      measureFunc();
     });
   });
 
@@ -127,47 +144,25 @@ describes.realWin('amp-list component', {
       {title: 'Title2'},
       {title: 'Title3'},
     ];
-    const newHeight = 127;
     const itemElement = doc.createElement('div');
-    itemElement.style.height = newHeight + 'px';
     element.setAttribute('max-items', '2');
-    const fetchPromise = Promise.resolve(items);
-    const renderPromise = Promise.resolve([itemElement]);
-    listMock.expects('fetch_').withExactArgs('items')
-        .returns(fetchPromise).once();
-    templatesMock.expects('findAndRenderTemplateArray').withExactArgs(
-        element, items.slice(0,2))
-        .returns(renderPromise).once();
-    let measureFunc;
-    listMock.expects('getVsync').returns({
-      measure: func => {
-        measureFunc = func;
-      },
-    }).once();
-    listMock.expects('attemptChangeHeight').withExactArgs(newHeight).returns(
-        Promise.resolve());
-    return list.layoutCallback().then(() => {
-      return Promise.all([fetchPromise, renderPromise]);
-    }).then(() => {
+
+    const rendered = expectFetchAndRender(
+        items, [itemElement], {expr: 'items', maxItems: 2});
+
+    return list.layoutCallback().then(() => rendered).then(() => {
       expect(list.container_.contains(itemElement)).to.be.true;
-      expect(measureFunc).to.exist;
-      measureFunc();
     });
   });
 
-  it('should dispatch "amp:template-rendered" event after render', () => {
+  it('should dispatch DOM_UPDATE event after render', () => {
+    const spy = sandbox.spy(list.container_, 'dispatchEvent');
+
     const items = [{title: 'Title1'}];
     const itemElement = doc.createElement('div');
-    const fetchPromise = Promise.resolve(items);
-    const renderPromise = Promise.resolve([itemElement]);
-    listMock.expects('fetch_').withExactArgs('items')
-        .returns(fetchPromise).once();
-    templatesMock.expects('findAndRenderTemplateArray').withArgs()
-        .returns(renderPromise).once();
-    const spy = sandbox.spy(list.container_, 'dispatchEvent');
-    return list.layoutCallback().then(() => {
-      return Promise.all([fetchPromise, renderPromise]);
-    }).then(() => {
+    const rendered = expectFetchAndRender(items, [itemElement]);
+
+    return list.layoutCallback().then(() => rendered).then(() => {
       expect(spy).to.have.been.calledOnce;
       expect(spy).calledWithMatch({
         type: AmpEvents.DOM_UPDATE,
@@ -176,68 +171,58 @@ describes.realWin('amp-list component', {
     });
   });
 
-  it('should call scanAndApply() if Bind is available', () => {
-    const fakeBind = {scanAndApply: sandbox.spy()};
-    bindStub.returns(Promise.resolve(fakeBind));
+  it('should call scanAndApply() if amp-bind is available', () => {
+    const bind = {scanAndApply: sandbox.spy()};
+    bindForDocOrNull.returns(Promise.resolve(bind));
 
     const items = [{title: 'Title1'}];
-    const itemElement = doc.createElement('div');
-    const fetchPromise = Promise.resolve(items);
-    const rendered = [itemElement];
-    const renderPromise = Promise.resolve(rendered);
-    listMock.expects('fetch_').withExactArgs('items')
-        .returns(fetchPromise).once();
-    templatesMock.expects('findAndRenderTemplateArray').withArgs()
-        .returns(renderPromise).once();
-    return list.layoutCallback().then(() => {
-      return Promise.all([fetchPromise, renderPromise]);
-    }).then(() => {
-      expect(fakeBind.scanAndApply).to.have.been.calledOnce;
-      expect(fakeBind.scanAndApply).calledWithExactly(rendered);
+    const output = [doc.createElement('div')];
+    const rendered = expectFetchAndRender(items, output);
+
+    return list.layoutCallback().then(() => rendered).then(() => {
+      expect(bind.scanAndApply).to.have.been.calledOnce;
+      expect(bind.scanAndApply).calledWithExactly(output, [list.container_]);
     });
   });
 
-  it('should reload data if the src attribute changes', () => {
-    const initialItems = [
-      {title: 'Title1'},
-    ];
-    const newItems = [
-      {title: 'Title2'}, {title: 'Title3'},
-    ];
-    const itemElement = doc.createElement('div');
-    const itemElement2 = doc.createElement('div');
-    const itemElement3 = doc.createElement('div');
-    const fetchPromise = Promise.resolve(initialItems);
-    const renderPromise = Promise.resolve([itemElement]);
-    listMock.expects('fetch_').withExactArgs('items')
-        .returns(fetchPromise).once();
-    templatesMock.expects('findAndRenderTemplateArray').withExactArgs(
-        element, initialItems)
-        .returns(renderPromise);
-    listMock.expects('getVsync').returns({
-      measure: () => {},
-    }).twice();
-    return list.layoutCallback().then(() => {
-      return Promise.all([fetchPromise, renderPromise]);
-    }).then(() => {
-      expect(list.container_.contains(itemElement)).to.be.true;
-      const newFetchPromise = Promise.resolve(newItems);
-      const newRenderPromise = Promise.resolve([itemElement2, itemElement3]);
-      listMock.expects('fetch_').withExactArgs('items')
-          .returns(newFetchPromise).once();
-      templatesMock.expects('findAndRenderTemplateArray').withExactArgs(
-          element, newItems)
-          .returns(newRenderPromise).once();
-      const spy = sandbox.spy(list, 'fetchList_');
-      element.setAttribute('src', 'https://data2.com/list.json');
-      list.mutatedAttributesCallback({'src': 'https://data2.com/list.json'});
-      expect(spy).to.be.calledOnce;
+  it('should _not_ reload if [src] attribute changes (before layout)', () => {
+    const items = [{title: 'foo'}];
+    const foo = doc.createElement('div');
+    const rendered = expectFetchAndRender(items, [foo]);
+
+    return list.layoutCallback().then(() => rendered).then(() => {
+      expect(list.container_.contains(foo)).to.be.true;
+
+      // Not allowed before layout.
+      listMock.expects('fetchList_').never();
+
+      element.setAttribute('src', 'https://new.com/list.json');
+      list.mutatedAttributesCallback({'src': 'https://new.com/list.json'});
+    });
+  });
+
+  it('should reload if [src] attribute changes (after layout)', () => {
+    const items = [{title: 'foo'}];
+    const foo = doc.createElement('div');
+    const rendered = expectFetchAndRender(items, [foo]);
+
+    // mutatedAttributesCallback() checks layout width to determine whether
+    // the element has been laid out yet.
+    listMock.expects('getLayoutWidth').returns(100);
+
+    return list.layoutCallback().then(() => rendered).then(() => {
+      expect(list.container_.contains(foo)).to.be.true;
+
+      // Allowed post-layout.
+      listMock.expects('fetchList_').once();
+
+      element.setAttribute('src', 'https://new.com/list.json');
+      list.mutatedAttributesCallback({'src': 'https://new.com/list.json'});
     });
   });
 
   it('should fail to load b/c data array is absent', () => {
-    listMock.expects('fetch_')
-        .returns(Promise.resolve({})).once();
+    listMock.expects('fetch_').returns(Promise.resolve({})).once();
     templatesMock.expects('findAndRenderTemplateArray').never();
     return expect(list.layoutCallback()).to.eventually.be
         .rejectedWith(/Response must contain an array/);
@@ -245,68 +230,44 @@ describes.realWin('amp-list component', {
 
   it('should fail to load b/c data single-item object is absent', () => {
     element.setAttribute('single-item', 'true');
-    listMock.expects('fetch_')
-        .returns(Promise.resolve()).once();
+    listMock.expects('fetch_').returns(Promise.resolve()).once();
     templatesMock.expects('findAndRenderTemplateArray').never();
     return expect(list.layoutCallback()).to.eventually.be
-        .rejectedWith(/Response must contain an arrary or object/);
+        .rejectedWith(/Response must contain an array or object/);
   });
 
   it('should load and render with a different root', () => {
-    const different = [
-      {title: 'Title1'},
-    ];
-    element.setAttribute('items', 'different');
+    const items = [{title: 'Title1'}];
     const itemElement = doc.createElement('div');
-    listMock.expects('fetch_')
-        .returns(Promise.resolve(different)).once();
-    templatesMock.expects('findAndRenderTemplateArray')
-        .withExactArgs(element, different)
-        .returns(Promise.resolve([itemElement])).once();
+    element.setAttribute('items', 'different');
+    expectFetchAndRender(items, [itemElement], {expr: 'different'});
+
     return list.layoutCallback().then(() => {
       expect(list.container_.contains(itemElement)).to.be.true;
     });
   });
 
   it('should set accessibility roles', () => {
-    const items = [
-      {title: 'Title1'},
-    ];
+    const items = [{title: 'Title1'}];
     const itemElement = doc.createElement('div');
-    const fetchPromise = Promise.resolve(items);
-    const renderPromise = Promise.resolve([itemElement]);
-    listMock.expects('fetch_').withExactArgs('items')
-        .returns(fetchPromise).once();
-    templatesMock.expects('findAndRenderTemplateArray').withExactArgs(
-        element, items)
-        .returns(renderPromise).once();
-    return list.layoutCallback().then(() => {
-      return Promise.all([fetchPromise, renderPromise]).then(() => {
-        expect(list.container_.getAttribute('role')).to.equal('list');
-        expect(itemElement.getAttribute('role')).to.equal('listitem');
-      });
+    const rendered = expectFetchAndRender(items, [itemElement]);
+
+    return list.layoutCallback().then(() => rendered).then(() => {
+      expect(list.container_.getAttribute('role')).to.equal('list');
+      expect(itemElement.getAttribute('role')).to.equal('listitem');
     });
   });
 
   it('should preserve accessibility roles', () => {
-    const items = [
-      {title: 'Title1'},
-    ];
+    const items = [{title: 'Title1'}];
     element.setAttribute('role', 'list1');
     const itemElement = doc.createElement('div');
     itemElement.setAttribute('role', 'listitem1');
-    const fetchPromise = Promise.resolve(items);
-    const renderPromise = Promise.resolve([itemElement]);
-    listMock.expects('fetch_').withExactArgs('items')
-        .returns(fetchPromise).once();
-    templatesMock.expects('findAndRenderTemplateArray').withExactArgs(
-        element, items)
-        .returns(renderPromise).once();
-    return list.layoutCallback().then(() => {
-      return Promise.all([fetchPromise, renderPromise]).then(() => {
-        expect(list.element.getAttribute('role')).to.equal('list1');
-        expect(itemElement.getAttribute('role')).to.equal('listitem1');
-      });
+    const rendered = expectFetchAndRender(items, [itemElement]);
+
+    return list.layoutCallback().then(() => rendered).then(() => {
+      expect(list.element.getAttribute('role')).to.equal('list1');
+      expect(itemElement.getAttribute('role')).to.equal('listitem1');
     });
   });
 

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -176,8 +176,8 @@ describes.realWin('amp-list component', {
     });
   });
 
-  it('should call rescanAndEvaluate() if Bind is available', () => {
-    const fakeBind = {rescanAndEvaluate: sandbox.spy()};
+  it('should call scanAndApply() if Bind is available', () => {
+    const fakeBind = {scanAndApply: sandbox.spy()};
     bindStub.returns(Promise.resolve(fakeBind));
 
     const items = [{title: 'Title1'}];
@@ -192,8 +192,8 @@ describes.realWin('amp-list component', {
     return list.layoutCallback().then(() => {
       return Promise.all([fetchPromise, renderPromise]);
     }).then(() => {
-      expect(fakeBind.rescanAndEvaluate).to.have.been.calledOnce;
-      expect(fakeBind.rescanAndEvaluate).calledWithExactly(rendered);
+      expect(fakeBind.scanAndApply).to.have.been.calledOnce;
+      expect(fakeBind.scanAndApply).calledWithExactly(rendered);
     });
   });
 

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -60,14 +60,15 @@ describes.realWin('amp-list component', {
     listMock.verify();
   });
 
+  const DEFAULT_LIST_OPTS = {expr: 'items', maxItems: 0, singleItem: false};
+
   /**
    * @param {!Array|!Object} fetched
    * @param {!Array<!Element>} rendered
    * @param {Object=} opts
    * @return {!Promise}
    */
-  function expectFetchAndRender(fetched, rendered,
-      opts = {expr: 'items', maxItems: 0, singleItem: false}) {
+  function expectFetchAndRender(fetched, rendered, opts = DEFAULT_LIST_OPTS) {
     const fetch = Promise.resolve(fetched);
     listMock.expects('fetch_').withExactArgs(opts.expr).returns(fetch).once();
 

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -187,22 +187,13 @@ describes.realWin('amp-list component', {
   });
 
   it('should _not_ reload if [src] attribute changes (before layout)', () => {
-    const items = [{title: 'foo'}];
-    const foo = doc.createElement('div');
-    const rendered = expectFetchAndRender(items, [foo]);
-
     // Return zero width to simulate pre-layout behavior.
     listMock.expects('getLayoutWidth').returns(0);
+    // Not allowed before layout.
+    listMock.expects('fetchList_').never();
 
-    return list.layoutCallback().then(() => rendered).then(() => {
-      expect(list.container_.contains(foo)).to.be.true;
-
-      // Not allowed before layout.
-      listMock.expects('fetchList_').never();
-
-      element.setAttribute('src', 'https://new.com/list.json');
-      list.mutatedAttributesCallback({'src': 'https://new.com/list.json'});
-    });
+    element.setAttribute('src', 'https://new.com/list.json');
+    list.mutatedAttributesCallback({'src': 'https://new.com/list.json'});
   });
 
   it('should reload if [src] attribute changes (after layout)', () => {


### PR DESCRIPTION
Fixes #12517.

- Properly dispose of bindings from discarded previous renders of `amp-list` (prevent inevitable hitting of 2000 binding limit)
- Don't rescan bindings from `AmpEvents.DOM_UPDATE` if sent from an `amp-list` (ugly, I know)
- Defer to `layoutCallback` before fetching amp-list data due to mutation
- Clean up test-amp-list.js a lot
  