### PR TITLE
Don't load full-width responsive ad if tag width is not 100vw

### DIFF
--- a/ads/google/adsense.js
+++ b/ads/google/adsense.js
@@ -31,13 +31,16 @@ export function adsense(global, data) {
       ['adClient', 'adSlot', 'adHost', 'adtest', 'tagOrigin', 'experimentId',
         'ampSlotIndex', 'adChannel', 'autoFormat', 'fullWidth']);
 
-  user().assert(
-      data['autoFormat'] !== 'rspv' ||
-        data['height'] == ADSENSE_RSPV_WHITELISTED_HEIGHT,
-      'Specified height ' + data['height'] +
-      ' in <amp-ad> tag is not equal to the required height of ' +
-      ADSENSE_RSPV_WHITELISTED_HEIGHT +
-      ' for responsive AdSense ad units.');
+  if (data['autoFormat'] == 'rspv') {
+    user().assert(data['height'] == ADSENSE_RSPV_WHITELISTED_HEIGHT,
+        `Specified height ${data['height']} in <amp-ad> tag is not equal to ` +
+        `the required height of ${ADSENSE_RSPV_WHITELISTED_HEIGHT} for ` +
+        'responsive AdSense ad units.');
+
+    user().assert(data['width'] == '100vw',
+        `Invalid width ${data['width']} for full-width responsive <amp-ad> ` +
+        'tag. Width must be 100vw.');
+  }
 
   if (global.context.clientId) {
     // Read by GPT for GA/GPT integration.

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -170,15 +170,22 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
      * to an amp-ad-adsense element. Thus, if we are an amp-ad, we can be sure
      * that it has been verified.
      */
-    const height = this.element.getAttribute('height');
-    if (this.isResponsive_() &&
-        height != ADSENSE_RSPV_WHITELISTED_HEIGHT) {
-      user().error(TAG,
-          'Specified height ' + height +
-          ' in <amp-ad> tag is not equal to the required height of ' +
-          ADSENSE_RSPV_WHITELISTED_HEIGHT +
-          ' for responsive AdSense ad units.');
-      return false;
+    if (this.isResponsive_()) {
+      const height = this.element.getAttribute('height');
+      const width = this.element.getAttribute('width');
+      if (height != ADSENSE_RSPV_WHITELISTED_HEIGHT) {
+        user().error(TAG,
+            `Specified height ${height} in <amp-ad> tag is not equal to the ` +
+            `required height of ${ADSENSE_RSPV_WHITELISTED_HEIGHT} for ` +
+            'responsive AdSense ad units.');
+        return false;
+      }
+      if (width != '100vw') {
+        user().error(TAG,
+            `Invalid width ${width} for full-width responsive <amp-ad> tag. ` +
+            'Width must be 100vw.');
+        return false;
+      }
     }
     return !!this.element.getAttribute('data-ad-client') &&
         this.isAmpAdElement();

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
@@ -116,11 +116,18 @@ describes.realWin('amp-ad-network-adsense-impl', {
     it('should be valid (responsive)', () => {
       isResponsiveStub.callsFake(() => true);
       element.setAttribute('height', '320');
+      element.setAttribute('width', '100vw');
       expect(impl.isValidElement()).to.be.true;
     });
     it('should NOT be valid (responsive with wrong height)', () => {
       isResponsiveStub.callsFake(() => true);
       element.setAttribute('height', '666');
+      expect(impl.isValidElement()).to.be.false;
+    });
+    it('should NOT be valid (responsive with wrong width)', () => {
+      isResponsiveStub.callsFake(() => true);
+      element.setAttribute('height', '320');
+      element.setAttribute('width', '666');
       expect(impl.isValidElement()).to.be.false;
     });
     it('should NOT be valid (impl tag name)', () => {


### PR DESCRIPTION
Prevent tampering with width attribute in AdSense full-width responsive ad tags.