### PR TITLE
Write AMP_CONFIG to 3p frame to enable local development

### DIFF
--- a/3p/integration.js
+++ b/3p/integration.js
@@ -813,7 +813,7 @@ export function validateAllowedTypes(window, type, allowedTypes) {
   if (urls.thirdPartyFrameRegex.test(window.location.hostname)) {
     return;
   }
-  if (window.location.hostname == 'ads.localhost' || getMode().localDev) {
+  if (window.location.hostname == 'ads.localhost') {
     return;
   }
   if (defaultAllowedTypesInCustomFrame.indexOf(type) != -1) {

--- a/3p/integration.js
+++ b/3p/integration.js
@@ -813,7 +813,7 @@ export function validateAllowedTypes(window, type, allowedTypes) {
   if (urls.thirdPartyFrameRegex.test(window.location.hostname)) {
     return;
   }
-  if (window.location.hostname == 'ads.localhost') {
+  if (window.location.hostname == 'ads.localhost' || getMode().localDev) {
     return;
   }
   if (defaultAllowedTypesInCustomFrame.indexOf(type) != -1) {

--- a/build-system/tasks/prepend-global/index.js
+++ b/build-system/tasks/prepend-global/index.js
@@ -178,14 +178,7 @@ function enableLocalDev(config, target, configJson) {
           'in', cyan(target));
     }
   }
-  LOCAL_DEV_AMP_CONFIG = Object.assign(LOCAL_DEV_AMP_CONFIG, configJson);
-  const herokuConfigFile = 'node_modules/AMP_CONFIG.json';
-  fs.writeFileSync(herokuConfigFile, JSON.stringify(LOCAL_DEV_AMP_CONFIG));
-  if (!process.env.TRAVIS) {
-    util.log('Wrote', cyan(config), 'AMP config to', cyan(herokuConfigFile),
-        'for use with Heroku');
-  }
-  return LOCAL_DEV_AMP_CONFIG;
+  return Object.assign(LOCAL_DEV_AMP_CONFIG, configJson);
 }
 
 /**

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -53,7 +53,9 @@ var red = $$.util.colors.red;
 var cyan = $$.util.colors.cyan;
 
 var minifiedRuntimeTarget = 'dist/v0.js';
+var minified3pTarget = 'dist.3p/current-min/f.js';
 var unminifiedRuntimeTarget = 'dist/amp.js';
+var unminified3pTarget = 'dist.3p/current/integration.js';
 
 // Each extension and version must be listed individually here.
 declareExtension('amp-3q-player', '0.1', false);
@@ -444,7 +446,7 @@ function copyCss() {
  * @return {!Promise}
  */
 function watch() {
-  printConfigHelp('gulp watch', unminifiedRuntimeTarget);
+  printConfigHelp('gulp watch');
   $$.watch('css/**/*.css', function() {
     compileCss();
   });
@@ -457,6 +459,8 @@ function watch() {
     compile(true),
   ]).then(() => {
     return enableLocalTesting(unminifiedRuntimeTarget);
+  }).then(() => {
+    return enableLocalTesting(unminified3pTarget);
   });
 }
 
@@ -571,24 +575,17 @@ function buildExtensionJs(path, name, version, options) {
 /**
  * Prints a helpful message that lets the developer know how to switch configs.
  * @param {string} command Command being run.
- * @param {string} targetFile File to which the config is to be written.
  */
-function printConfigHelp(command, targetFile) {
+function printConfigHelp(command) {
   if (!process.env.TRAVIS) {
     $$.util.log(
         green('Building the runtime for local testing with the'),
         cyan((argv.config === 'canary') ? 'canary' : 'prod'),
         green('AMP config'));
     $$.util.log(
-        green('- To specify which config to apply:'),
-        cyan(command), cyan('--config={canary|prod}'));
-    $$.util.log(
-        green('- To switch configs after building:'),
-        cyan('gulp prepend-global {--canary|--prod} --local_dev --target ' +
-            targetFile));
-    $$.util.log(
-        green('- To remove any existing config:'),
-        cyan('gulp prepend-global --remove --target ' + targetFile));
+        green('To specify which config to apply, use',
+            cyan('--config={canary|prod}'), 'with your',
+            cyan(command), 'command'));
   }
 }
 
@@ -614,7 +611,7 @@ function enableLocalTesting(targetFile) {
  */
 function build() {
   process.env.NODE_ENV = 'development';
-  printConfigHelp('gulp build', unminifiedRuntimeTarget);
+  printConfigHelp('gulp build');
   return compileCss().then(() => {
     return Promise.all([
       polyfillsForTests(),
@@ -627,6 +624,8 @@ function build() {
     ]);
   }).then(() => {
     return enableLocalTesting(unminifiedRuntimeTarget);
+  }).then(() => {
+    return enableLocalTesting(unminified3pTarget);
   });
 }
 
@@ -638,7 +637,7 @@ function dist() {
   process.env.NODE_ENV = 'production';
   cleanupBuildDir();
   if (argv.fortesting) {
-    printConfigHelp('gulp dist --fortesting', minifiedRuntimeTarget)
+    printConfigHelp('gulp dist --fortesting')
   }
   return compileCss().then(() => {
     return Promise.all([
@@ -661,6 +660,10 @@ function dist() {
   }).then(() => {
     if (argv.fortesting) {
       return enableLocalTesting(minifiedRuntimeTarget);
+    }
+  }).then(() => {
+    if (argv.fortesting) {
+      return enableLocalTesting(minified3pTarget);
     }
   });
 }

--- a/package.json
+++ b/package.json
@@ -20,10 +20,8 @@
     "lint": "gulp lint",
     "build": "gulp build",
     "dist": "gulp dist",
-    "heroku-postbuild": "npm run test-env-var && gulp clean && gulp build --fortesting && gulp dist --fortesting && npm run prepend-amp && npm run prepend-v0",
+    "heroku-postbuild": "npm run test-env-var && gulp clean && gulp build && gulp dist --fortesting",
     "test-env-var": "if [ -z \"${AMP_TESTING_HOST}\" ]; then echo \"ERROR: Please set the 'AMP_TESTING_HOST' environment variable. If you are in heroku this can be set by executing 'heroku config:set AMP_TESTING_HOST=my-heroku-subdomain.herokuapp.com' on the command line.\"; exit 1; fi",
-    "prepend-amp": "gulp prepend-global --prod node_modules/AMP_CONFIG.json --local_branch --target dist/amp.js && gulp prepend-global --prod node_modules/AMP_CONFIG.json --local_branch --target dist.3p/current/integration.js",
-    "prepend-v0": "gulp prepend-global --prod node_modules/AMP_CONFIG.json --local_branch --target dist/v0.js && gulp prepend-global --prod node_modules/AMP_CONFIG.json --local_branch --target dist.3p/current-min/f.js",
     "preinstall": "node build-system/check-package-manager.js"
   },
   "dependencies": {


### PR DESCRIPTION
This PR causes `gulp | gulp watch | gulp build | gulp dist --fortesting` to write `AMP_CONFIG` to the 3p frame target file in addition to the AMP runtime file. This enables testing with non-localhost servers.

In addition, now that we're writing `AMP_CONFIG` by default to the runtime file and the 3p frame file, we can simplify the heroku setup scripts to no longer have to invoke `gulp prepend-global`.

For context, see https://github.com/ampproject/amphtml/issues/12054#issuecomment-356041685

Follow up to #12673
Unblocks #12666
Fixes #12054
  
  
  
  