### PR TITLE
Exclude generated dirs in validator/webui from presubmit checks

### DIFF
--- a/build-system/config.js
+++ b/build-system/config.js
@@ -141,6 +141,8 @@ module.exports = {
     '!validator/dist/**/*.*',
     '!validator/node_modules/**/*.*',
     '!validator/nodejs/node_modules/**/*.*',
+    '!validator/webui/dist/**/*.*',
+    '!validator/webui/node_modules/**/*.*',
     '!build-system/tasks/presubmit-checks.js',
     '!build/polyfills.js',
     '!build/polyfills/*.js',


### PR DESCRIPTION
Running validator tests locally will break `gulp presubmit` because it picks up the stuff in `validator/webui/{node_modules|dist}`. This PR excludes those directories from the presubmit check.