### PR TITLE
Add a wrapper 'gulp pr-check' task for pr-check.js

### DIFF
--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -372,8 +372,10 @@ function runAllCommandsLocally() {
   command.testDocumentLinks();
 
   // Build if required.
-  command.cleanBuild();
-  command.buildRuntime();
+  if (!argv.nobuild) {
+    command.cleanBuild();
+    command.buildRuntime();
+  }
 
   // These tests need a build.
   command.runPresubmitTests();

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -271,21 +271,21 @@ const command = {
     timedExecOrDie('gulp dep-check');
     timedExecOrDie('gulp check-types');
   },
-  runUnitTests: function(saucelabs) {
+  runUnitTests: function() {
     // Unit tests with Travis' default chromium
     timedExecOrDie('gulp test --unit --nobuild');
-    if (saucelabs) {
+    if (!!process.env.SAUCE_USERNAME && !!process.env.SAUCE_ACCESS_KEY) {
       // A subset of unit tests on other browsers via sauce labs
       timedExecOrDie('gulp test --unit --nobuild --saucelabs_lite');
     }
   },
-  runIntegrationTests: function(compiled, saucelabs) {
-    // Integration tests on chrome, or on all saucelabs browsers if requested
+  runIntegrationTests: function(compiled) {
+    // Integration tests on chrome, or on all saucelabs browsers if set up
     let cmd = 'gulp test --nobuild --integration';
     if (compiled) {
       cmd += ' --compiled';
     }
-    if (saucelabs) {
+    if (!!process.env.SAUCE_USERNAME && !!process.env.SAUCE_ACCESS_KEY) {
       cmd += ' --saucelabs';
     }
     timedExecOrDie(cmd);
@@ -341,7 +341,7 @@ function runAllCommands() {
     command.runLintCheck();
     command.runJsonCheck();
     command.runDepAndTypeChecks();
-    command.runUnitTests(/* saucelabs */ true);
+    command.runUnitTests();
     command.verifyVisualDiffTests();
     // command.testDocumentLinks() is skipped during push builds.
     command.buildValidatorWebUI();
@@ -351,7 +351,7 @@ function runAllCommands() {
     command.cleanBuild();
     command.buildRuntimeMinified();
     command.runPresubmitTests();
-    command.runIntegrationTests(/* compiled */ true, /* saucelabs */ true);
+    command.runIntegrationTests(/* compiled */ true);
   }
 }
 
@@ -370,8 +370,8 @@ function runAllCommandsLocally() {
   // These tests need a build.
   command.runPresubmitTests();
   command.runVisualDiffTests();
-  command.runUnitTests(/* saucelabs */ false);
-  command.runIntegrationTests(/* compiled */ false, /* saucelabs */ false);
+  command.runUnitTests();
+  command.runIntegrationTests(/* compiled */ false);
   command.verifyVisualDiffTests();
 
   // Validator tests.
@@ -472,7 +472,7 @@ function main() {
       command.runDepAndTypeChecks();
       // Run unit tests only if the PR contains runtime changes.
       if (buildTargets.has('RUNTIME')) {
-        command.runUnitTests(/* saucelabs */ true);
+        command.runUnitTests();
       }
     }
   }
@@ -489,7 +489,7 @@ function main() {
       if (buildTargets.has('INTEGRATION_TEST') ||
           buildTargets.has('RUNTIME')) {
         command.runPresubmitTests();
-        command.runIntegrationTests(/* compiled */ false, /* saucelabs */ true);
+        command.runIntegrationTests(/* compiled */ false);
       }
       command.verifyVisualDiffTests();
     } else {

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -24,6 +24,7 @@
  * This script attempts to introduce some granularity for our
  * presubmit checking, via the determineBuildTargets method.
  */
+const argv = require('minimist')(process.argv.slice(2));
 const atob = require('atob');
 const execOrDie = require('./exec').execOrDie;
 const getStdout = require('./exec').getStdout;
@@ -272,16 +273,24 @@ const command = {
     timedExecOrDie('gulp check-types');
   },
   runUnitTests: function() {
+    let cmd = 'gulp test --unit --nobuild';
+    if (argv.files) {
+      cmd = cmd + ' --files ' + argv.files;
+    }
     // Unit tests with Travis' default chromium
-    timedExecOrDie('gulp test --unit --nobuild');
+    timedExecOrDie(cmd);
+    // A subset of unit tests on other browsers via sauce labs
     if (!!process.env.SAUCE_USERNAME && !!process.env.SAUCE_ACCESS_KEY) {
-      // A subset of unit tests on other browsers via sauce labs
-      timedExecOrDie('gulp test --unit --nobuild --saucelabs_lite');
+      cmd = cmd + ' --saucelabs_lite';
+      timedExecOrDie(cmd);
     }
   },
   runIntegrationTests: function(compiled) {
     // Integration tests on chrome, or on all saucelabs browsers if set up
     let cmd = 'gulp test --nobuild --integration';
+    if (argv.files) {
+      cmd = cmd + ' --files ' + argv.files;
+    }
     if (compiled) {
       cmd += ' --compiled';
     }

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -279,8 +279,8 @@ const command = {
     }
     // Unit tests with Travis' default chromium
     timedExecOrDie(cmd);
-    // A subset of unit tests on other browsers via sauce labs
     if (!!process.env.SAUCE_USERNAME && !!process.env.SAUCE_ACCESS_KEY) {
+      // A subset of unit tests on other browsers via sauce labs
       cmd = cmd + ' --saucelabs_lite';
       timedExecOrDie(cmd);
     }
@@ -306,8 +306,7 @@ const command = {
       console.log(
           '\n' + fileLogPrefix, 'Could not find environment variables',
           util.colors.cyan('PERCY_PROJECT'), 'and',
-          util.colors.cyan('PERCY_TOKEN') + '. Skipping visual diff tests.',
-          '\n');
+          util.colors.cyan('PERCY_TOKEN') + '. Skipping visual diff tests.');
       return;
     }
     let cmd = 'gulp visual-diff';
@@ -324,7 +323,7 @@ const command = {
           '\n' + fileLogPrefix, 'Could not find environment variables',
           util.colors.cyan('PERCY_PROJECT'), 'and',
           util.colors.cyan('PERCY_TOKEN') +
-          '. Skipping verification of visual diff tests.', '\n');
+          '. Skipping verification of visual diff tests.');
       return;
     }
     timedExecOrDie('gulp visual-diff --verify');

--- a/build-system/tasks/index.js
+++ b/build-system/tasks/index.js
@@ -29,6 +29,7 @@ require('./dep-check');
 require('./get-zindex');
 require('./gen-codeowners');
 require('./extension-generator');
+require('./pr-check');
 require('./process-github-issues');
 require('./json-check');
 require('./lint');

--- a/build-system/tasks/pr-check.js
+++ b/build-system/tasks/pr-check.js
@@ -15,6 +15,7 @@
  */
 'use strict';
 
+const argv = require('minimist')(process.argv.slice(2));
 const execOrDie = require('../exec').execOrDie;
 const gulp = require('gulp-help')(require('gulp'));
 
@@ -23,10 +24,20 @@ const gulp = require('gulp-help')(require('gulp'));
  * Simple wrapper around pr-check.js.
  */
 function prCheck() {
-  execOrDie('node build-system/pr-check.js');
+  let cmd = 'node build-system/pr-check.js';
+  if (argv.files) {
+    cmd = cmd + ' --files ' + argv.files;
+  }
+  execOrDie(cmd);
 }
 
 gulp.task(
     'pr-check',
     'Locally runs the PR checks that are run by Travis CI.',
-    prCheck);
+    prCheck,
+    {
+      options: {
+        'files': '  Restricts unit / integration tests to just these files'
+      },
+    }
+  );

--- a/build-system/tasks/pr-check.js
+++ b/build-system/tasks/pr-check.js
@@ -28,6 +28,9 @@ function prCheck() {
   if (argv.files) {
     cmd = cmd + ' --files ' + argv.files;
   }
+  if (argv.nobuild) {
+    cmd = cmd + ' --nobuild';
+  }
   execOrDie(cmd);
 }
 
@@ -38,6 +41,7 @@ gulp.task(
     {
       options: {
         'files': '  Restricts unit / integration tests to just these files',
+        'nobuild': '  Skips building the runtime via `gulp build`.',
       },
     }
 );

--- a/build-system/tasks/pr-check.js
+++ b/build-system/tasks/pr-check.js
@@ -37,7 +37,7 @@ gulp.task(
     prCheck,
     {
       options: {
-        'files': '  Restricts unit / integration tests to just these files'
+        'files': '  Restricts unit / integration tests to just these files',
       },
     }
-  );
+);

--- a/build-system/tasks/pr-check.js
+++ b/build-system/tasks/pr-check.js
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+const execOrDie = require('../exec').execOrDie;
+const gulp = require('gulp-help')(require('gulp'));
+
+
+/**
+ * Simple wrapper around pr-check.js.
+ */
+function prCheck() {
+  execOrDie('node build-system/pr-check.js');
+}
+
+gulp.task(
+    'pr-check',
+    'Locally runs the PR checks that are run by Travis CI.',
+    prCheck);

--- a/contributing/DEVELOPING.md
+++ b/contributing/DEVELOPING.md
@@ -47,6 +47,7 @@ The Quick Start Guide's  [One-time setup](getting-started-quick.md#one-time-setu
 | `gulp css`<sup>[[1]](#footnote-1)</sup>                                 | Recompiles css to build directory and builds the embedded css into js files for the AMP library. |
 | `gulp extensions`                                                       | Build AMP Extensions.                                                 |
 | `gulp watch`<sup>[[1]](#footnote-1)</sup>                               | Watches for changes in files, re-build.                               |
+| `gulp pr-check`<sup>[[1]](#footnote-1)</sup>                            | Runs all the Travis CI checks locally.         |
 | `gulp test`<sup>[[1]](#footnote-1)</sup>                                | Runs tests in Chrome.                                                 |
 | `gulp test --verbose`<sup>[[1]](#footnote-1)</sup>                      | Runs tests in Chrome with logging enabled.                            |
 | `gulp test --nobuild`                                                   | Runs tests without re-build.                                          |

--- a/contributing/DEVELOPING.md
+++ b/contributing/DEVELOPING.md
@@ -48,6 +48,7 @@ The Quick Start Guide's  [One-time setup](getting-started-quick.md#one-time-setu
 | `gulp extensions`                                                       | Build AMP Extensions.                                                 |
 | `gulp watch`<sup>[[1]](#footnote-1)</sup>                               | Watches for changes in files, re-build.                               |
 | `gulp pr-check`<sup>[[1]](#footnote-1)</sup>                            | Runs all the Travis CI checks locally.         |
+| `gulp pr-check --nobuild`<sup>[[1]](#footnote-1)</sup>                  | Runs all the Travis CI checks locally, but skips the `gulp build` step.         |
 | `gulp pr-check --files=<test-files-path-glob>`<sup>[[1]](#footnote-1)</sup>   | Runs all the Travis CI checks locally, and restricts tests to the files provided.  |
 | `gulp test`<sup>[[1]](#footnote-1)</sup>                                | Runs tests in Chrome.                                                 |
 | `gulp test --verbose`<sup>[[1]](#footnote-1)</sup>                      | Runs tests in Chrome with logging enabled.                            |

--- a/contributing/DEVELOPING.md
+++ b/contributing/DEVELOPING.md
@@ -48,6 +48,7 @@ The Quick Start Guide's  [One-time setup](getting-started-quick.md#one-time-setu
 | `gulp extensions`                                                       | Build AMP Extensions.                                                 |
 | `gulp watch`<sup>[[1]](#footnote-1)</sup>                               | Watches for changes in files, re-build.                               |
 | `gulp pr-check`<sup>[[1]](#footnote-1)</sup>                            | Runs all the Travis CI checks locally.         |
+| `gulp pr-check --files=<test-files-path-glob>`<sup>[[1]](#footnote-1)</sup>   | Runs all the Travis CI checks locally, and restricts tests to the files provided.  |
 | `gulp test`<sup>[[1]](#footnote-1)</sup>                                | Runs tests in Chrome.                                                 |
 | `gulp test --verbose`<sup>[[1]](#footnote-1)</sup>                      | Runs tests in Chrome with logging enabled.                            |
 | `gulp test --nobuild`                                                   | Runs tests without re-build.                                          |

--- a/contributing/getting-started-e2e.md
+++ b/contributing/getting-started-e2e.md
@@ -354,7 +354,13 @@ Sometimes, it can be useful to pre-emptively eliminate errors in your pull reque
 gulp pr-check
 ```
 
-To run all Travis CI checks, but restrict the unit tests and integration tests to just a subset of files, you can run:
+To run all Travis CI checks, but skip the `gulp build` step, you can run:
+
+```
+gulp pr-check --nobuild
+```
+
+To run all Travis CI checks, and restrict the unit tests and integration tests to just a subset of files, you can run:
 
 ```
 gulp pr-check --files=<test-files-path-glob>

--- a/contributing/getting-started-e2e.md
+++ b/contributing/getting-started-e2e.md
@@ -354,6 +354,12 @@ Sometimes, it can be useful to pre-emptively eliminate errors in your pull reque
 gulp pr-check
 ```
 
+To run all Travis CI checks, but restrict the unit tests and integration tests to just a subset of files, you can run:
+
+```
+gulp pr-check --files=<test-files-path-glob>
+```
+
 Notes:
 
 * This will force a clean build and run all the PR checks one by one.

--- a/contributing/getting-started-e2e.md
+++ b/contributing/getting-started-e2e.md
@@ -365,7 +365,7 @@ Notes:
 * This will force a clean build and run all the PR checks one by one.
 * Just like on Travis, a failing check will prevent subsequent checks from being run.
 * The `gulp visual-diff` check will be skipped unless you have set up a Percy account as described [here](https://github.com/ampproject/amphtml/blob/master/contributing/DEVELOPING.md#running-visual-diff-tests-locally).
-* The AMP unit and integration tests will be run on local Chrome unless you have set up a Sauce labs account as described [here](https://github.com/ampproject/amphtml/blob/master/contributing/DEVELOPING.md#testing-on-sauce-labs).
+* The AMP unit and integration tests will be run on local Chrome unless you have set up a Sauce Labs account as described [here](https://github.com/ampproject/amphtml/blob/master/contributing/DEVELOPING.md#testing-on-sauce-labs).
 
 ## Adding tests for your change
 

--- a/contributing/getting-started-e2e.md
+++ b/contributing/getting-started-e2e.md
@@ -37,6 +37,7 @@ If you do not yet have a specific code contribution project in mind as you go th
 - [Edit files and commit them](#edit-files-and-commit-them)
 - [Testing your changes](#testing-your-changes)
   * [Running tests locally](#running-tests-locally)
+  * [Running all the Travis CI checks locally](#running-all-the-travis-ci-checks-locally)
   * [Adding tests for your change](#adding-tests-for-your-change)
 - [Push your changes to your GitHub fork](#push-your-changes-to-your-github-fork)
 - [Send a Pull Request (i.e. request a code review)](#send-a-pull-request-ie-request-a-code-review)
@@ -331,7 +332,9 @@ Before sending your code changes for review, you will want to make sure that all
 
 Make sure you are in the branch that has your changes (`git checkout <branch name>`), pull in the latest changes from the remote amphtml repository and then simply run:
 
-`gulp test`
+```
+gulp test
+```
 
 You'll see some messages about stuff being compiled and then after a short time you will see a new Chrome window open up that says "Karma" at the top.  In the window where you ran `gulp test`, you'll see a bunch of tests scrolling by (`Executed NNNN of MMMM`) and hopefully a lot of `SUCCESS` messages.
 
@@ -342,6 +345,16 @@ If the tests have failed you will need to determine whether the failure is relat
 If the failing test looks completely unrelated to your change, it *might* be due to bad code/tests that have made it into the amphtml repository.  You can check the latest [amphtml test run on Travis](https://travis-ci.org/ampproject/amphtml/builds).  If it's green (meaning the tests pass) then it's more likely the failure is a problem with your change.  If it's red, you can click through to see if the failing tests are the same as the ones you see locally.
 
 Fixing the tests will depend heavily on the change you are making and what tests are failing.  If you need help to fix them you can ask on the GitHub issue you're working on or reach out to the community as described in [How to get help](#how-to-get-help).
+
+## Running all the Travis CI checks locally
+
+Sometimes, it can be useful to run all the Travis CI checks for a pull request on your local machine. You can do so by running:
+
+```
+gulp pr-check
+```
+
+Note that this will force a clean build and run all the PR checks one by one. Just like on Travis, a failing check will prevent subsequent checks from being run. This can be useful to pre-emptively eliminate errors in your PR before pushing your PR to your GitHub branch.
 
 ## Adding tests for your change
 

--- a/contributing/getting-started-e2e.md
+++ b/contributing/getting-started-e2e.md
@@ -348,13 +348,18 @@ Fixing the tests will depend heavily on the change you are making and what tests
 
 ## Running all the Travis CI checks locally
 
-Sometimes, it can be useful to run all the Travis CI checks for a pull request on your local machine. You can do so by running:
+Sometimes, it can be useful to pre-emptively eliminate errors in your pull request by running all the Travis CI checks on your local machine. You can do so by running:
 
 ```
 gulp pr-check
 ```
 
-Note that this will force a clean build and run all the PR checks one by one. Just like on Travis, a failing check will prevent subsequent checks from being run. This can be useful to pre-emptively eliminate errors in your PR before pushing your PR to your GitHub branch.
+Notes:
+
+* This will force a clean build and run all the PR checks one by one.
+* Just like on Travis, a failing check will prevent subsequent checks from being run.
+* The `gulp visual-diff` check will be skipped unless you have set up a Percy account as described [here](https://github.com/ampproject/amphtml/blob/master/contributing/DEVELOPING.md#running-visual-diff-tests-locally).
+* The AMP unit and integration tests will be run on local Chrome unless you have set up a Sauce labs account as described [here](https://github.com/ampproject/amphtml/blob/master/contributing/DEVELOPING.md#testing-on-sauce-labs).
 
 ## Adding tests for your change
 


### PR DESCRIPTION
This PR does the following:
- Adds `gulp pr-check`, which will run all PR checks locally.
- Adds support for optionally running the visual tests and sauce labs tests.
- Adds support for running selected tests via `--files`
- Adds support for skipping the `gulp build` step via `--nobuild`
- Updates the AMP development docs.

With this, a developer can use the following command to quickly run all Travis CI checks, and just the tests in `<test-file>` on their local machine. This is more reliable than running all the unit and integration tests locally.

```
gulp pr-check --nobuild --files <test-file>
```

Follow up to #12711
Fixes #5352
  
  
  