### PR TITLE
Remove breaking width check in delayed-fetch path

### DIFF
--- a/ads/google/adsense.js
+++ b/ads/google/adsense.js
@@ -31,16 +31,12 @@ export function adsense(global, data) {
       ['adClient', 'adSlot', 'adHost', 'adtest', 'tagOrigin', 'experimentId',
         'ampSlotIndex', 'adChannel', 'autoFormat', 'fullWidth']);
 
-  if (data['autoFormat'] == 'rspv') {
-    user().assert(data['height'] == ADSENSE_RSPV_WHITELISTED_HEIGHT,
-        `Specified height ${data['height']} in <amp-ad> tag is not equal to ` +
-        `the required height of ${ADSENSE_RSPV_WHITELISTED_HEIGHT} for ` +
-        'responsive AdSense ad units.');
-
-    user().assert(data['width'] == '100vw',
-        `Invalid width ${data['width']} for full-width responsive <amp-ad> ` +
-        'tag. Width must be 100vw.');
-  }
+  user().assert(
+      data['autoFormat'] != 'rspv'
+        || data['height'] == ADSENSE_RSPV_WHITELISTED_HEIGHT,
+      `Specified height ${data['height']} in <amp-ad> tag is not equal to ` +
+      `the required height of ${ADSENSE_RSPV_WHITELISTED_HEIGHT} for ` +
+      'responsive AdSense ad units.');
 
   if (global.context.clientId) {
     // Read by GPT for GA/GPT integration.

--- a/ads/google/test/test-adsense.js
+++ b/ads/google/test/test-adsense.js
@@ -73,10 +73,9 @@ describes.realWin('adsenseDelayedFetch', {}, env => {
     });
   });
 
-  it('should not throw for valid responsive ad unit width and height', () => {
+  it('should not throw for valid responsive ad unit height', () => {
     data['autoFormat'] = 'rspv';
     data['height'] = '320';
-    data['width'] = '100vw';
     expect(() => adsense(env.win, data)).to.not.throw();
   });
 
@@ -85,13 +84,5 @@ describes.realWin('adsenseDelayedFetch', {}, env => {
     data['height'] = '666';
     expect(() => adsense(env.win, data)).to.throw(
         /Specified height 666 in <amp-ad> tag is not equal to the required/);
-  });
-
-  it('should throw on invalid responsive ad unit width', () => {
-    data['autoFormat'] = 'rspv';
-    data['height'] = '320';
-    data['width'] = '666';
-    expect(() => adsense(env.win, data)).to.throw(
-        /Invalid width/);
   });
 });


### PR DESCRIPTION
#Width check for AdSense full-width responsive implemented in [pull/12695](https://github.com/ampproject/amphtml/pull/12695) seems to break in delayed-fetch path. Reason being that in the data object being passed, the width is already stripped down from `"100vw"` to `100`.

The check turns out not to be necessary for delayed fetch anyway, since it's already performed in amp-ad-3p-impl.js.
  