### PR TITLE
no hint layer on vertical swipe

### DIFF
--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -363,7 +363,7 @@ export class AmpStory extends AMP.BaseElement {
         return;
       }
 
-      if (!this.isSwipeLargeEnoughForHint_(e.data.deltaX, e.data.deltaY)) {
+      if (!this.isSwipeLargeEnoughForHint_(e.data.deltaX)) {
         return;
       }
 
@@ -389,9 +389,8 @@ export class AmpStory extends AMP.BaseElement {
   }
 
   /** @private */
-  isSwipeLargeEnoughForHint_(deltaX, deltaY) {
-    return (Math.sqrt(Math.pow(deltaX, 2) + Math.pow(deltaY, 2))
-      >= MIN_SWIPE_FOR_HINT_OVERLAY_PX);
+  isSwipeLargeEnoughForHint_(deltaX) {
+    return (Math.abs(deltaX) >= MIN_SWIPE_FOR_HINT_OVERLAY_PX);
   }
 
   /** @private */


### PR DESCRIPTION
Fixes: #12727 

Removing vertical swipe from triggering amp-story education hint layer
  