### PR TITLE
VisibilityModel: Restart timeout when condition not met but visibility matched

### DIFF
--- a/extensions/amp-analytics/0.1/test/test-visibility-model.js
+++ b/extensions/amp-analytics/0.1/test/test-visibility-model.js
@@ -359,6 +359,7 @@ describes.sandboxed('VisibilityModel', {}, () => {
 
     it('conditions not met, schedule for total time', () => {
       vh.totalVisibleTime_ = 5;
+      vh.continuousTime_ = 2;
       visibilityValueForTesting = 0.1;
       vh.update_(visibilityValueForTesting);
       expect(vh.scheduledUpdateTimeoutId_).to.be.ok;
@@ -368,6 +369,8 @@ describes.sandboxed('VisibilityModel', {}, () => {
       expect(updateStub).to.not.be.called;
       clock.tick(1);
       expect(updateStub).to.be.calledOnce;
+      clock.tick(3);
+      expect(updateStub).to.be.calledTwice;
       expect(vh.scheduledUpdateTimeoutId_).to.be.null;
     });
 
@@ -381,6 +384,19 @@ describes.sandboxed('VisibilityModel', {}, () => {
       expect(updateStub).to.not.be.called;
       clock.tick(1);
       expect(updateStub).to.be.calledOnce;
+      expect(vh.scheduledUpdateTimeoutId_).to.be.null;
+    });
+
+    it('conditions not met, schedule timeout again', () => {
+      vh.spec_.totalTimeMin = 50;
+      vh.totalVisibleTime_ = 4;
+      vh.continuousTime_ = 4;
+      visibilityValueForTesting = 0.1;
+      vh.update_(visibilityValueForTesting);
+      clock.tick(6);
+      expect(updateStub).to.be.calledOnce;
+      clock.tick(40);
+      expect(updateStub).to.be.calledTwice;
       expect(vh.scheduledUpdateTimeoutId_).to.be.null;
     });
 

--- a/extensions/amp-analytics/0.1/visibility-model.js
+++ b/extensions/amp-analytics/0.1/visibility-model.js
@@ -349,8 +349,8 @@ export class VisibilityModel {
       const timeToWait = this.computeTimeToWait_();
       if (timeToWait > 0) {
         this.scheduledUpdateTimeoutId_ = setTimeout(() => {
-          this.update();
           this.scheduledUpdateTimeoutId_ = null;
+          this.update();
         }, timeToWait);
       }
     } else if (!this.matchesVisibility_ && this.scheduledUpdateTimeoutId_) {


### PR DESCRIPTION
This would affect many use cases. For example. 
```
"visibilitySpec": {
  "totalMinTime": 500,
   "continousMinTime": 200
}
```
We should patch the fix.