### PR TITLE
Implement lightbox attribute for carousels

### DIFF
--- a/extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.js
+++ b/extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.js
@@ -34,6 +34,8 @@ import * as st from '../../../src/style';
 import * as tr from '../../../src/transition';
 import {SwipeYRecognizer} from '../../../src/gesture-recognizers';
 import {debounce} from '../../../src/utils/rate-limit';
+import {CommonSignals} from '../../../src/common-signals';
+
 
 /** @const */
 const TAG = 'amp-lightbox-viewer';
@@ -81,9 +83,6 @@ export class AmpLightboxViewer extends AMP.BaseElement {
   /** @param {!AmpElement} element */
   constructor(element) {
     super(element);
-
-    /** @private {?../../../src/service/resources-impl.Resources} */
-    this.resources_ = null;
 
     /** @private {!boolean} */
     this.active_ = false;
@@ -160,7 +159,6 @@ export class AmpLightboxViewer extends AMP.BaseElement {
         `Experiment ${TAG} disabled`);
     this.manager_ = dev().assert(manager_);
     this.vsync_ = this.getVsync();
-    this.resources_ = Services.resourcesForDoc(this.getAmpDoc());
     const viewer = Services.viewerForDoc(this.getAmpDoc());
     viewer.whenFirstVisible().then(() => {
       this.container_ = this.win.document.createElement('div');
@@ -638,7 +636,7 @@ export class AmpLightboxViewer extends AMP.BaseElement {
       this.setupGestures_();
       this.setupEventListeners_();
 
-      return this.resources_.requireLayout(dev().assertElement(this.carousel_));
+      return this.carousel_.signals().whenSignal(CommonSignals.LOAD_END);
     }).then(() => this.openLightboxForElement_(element));
   }
 

--- a/extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.js
+++ b/extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.js
@@ -160,11 +160,14 @@ export class AmpLightboxViewer extends AMP.BaseElement {
         `Experiment ${TAG} disabled`);
     this.manager_ = dev().assert(manager_);
     this.vsync_ = this.getVsync();
-    this.container_ = this.win.document.createElement('div');
-    this.container_.classList.add('i-amphtml-lbv');
     this.resources_ = Services.resourcesForDoc(this.getAmpDoc());
-    this.buildMask_();
-    this.element.appendChild(this.container_);
+    this.vsync_.mutate(() => {
+      this.container_ = this.win.document.createElement('div');
+      this.container_.classList.add('i-amphtml-lbv');
+      this.element.appendChild(this.container_);
+      this.manager_.maybeInit();
+      this.buildMask_();
+    });
   }
 
   /** @override */
@@ -226,6 +229,7 @@ export class AmpLightboxViewer extends AMP.BaseElement {
       if (clonedNode.tagName === 'AMP-IMG') {
         const container = this.element.ownerDocument.createElement('div');
         container.classList.add('i-amphtml-image-lightbox-container');
+        // TODO: make image viewer an amp component to deal with lazy images
         const imageViewer = new ImageViewer(this, this.win,
             this.loadPromise.bind(this));
         imageViewer.init(element, elementByTag(element, 'img'));

--- a/extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.js
+++ b/extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.js
@@ -161,7 +161,8 @@ export class AmpLightboxViewer extends AMP.BaseElement {
     this.manager_ = dev().assert(manager_);
     this.vsync_ = this.getVsync();
     this.resources_ = Services.resourcesForDoc(this.getAmpDoc());
-    this.vsync_.mutate(() => {
+    const viewer = Services.viewerForDoc(this.getAmpDoc());
+    viewer.whenFirstVisible().then(() => {
       this.container_ = this.win.document.createElement('div');
       this.container_.classList.add('i-amphtml-lbv');
       this.element.appendChild(this.container_);

--- a/extensions/amp-lightbox-viewer/0.1/service/lightbox-manager-impl.js
+++ b/extensions/amp-lightbox-viewer/0.1/service/lightbox-manager-impl.js
@@ -16,11 +16,7 @@
 
 import {isExperimentOn} from '../../../../src/experiments';
 import {dev} from '../../../../src/log';
-import {
-  elementByTag,
-  iterateCursor,
-  scopedQuerySelectorAll,
-} from '../../../../src/dom';
+import {elementByTag, iterateCursor} from '../../../../src/dom';
 import {toArray} from '../../../../src/types';
 import {CommonSignals} from '../../../../src/common-signals';
 
@@ -171,7 +167,7 @@ export class LightboxManager {
    */
   getSlidesFromCarousel_(element) {
     return element.signals().whenSignal(CommonSignals.LOAD_END).then(() => {
-      return toArray(scopedQuerySelectorAll(element, SLIDE_SELECTOR));
+      return toArray(element./*OK*/querySelectorAll(SLIDE_SELECTOR));
     });
   }
 

--- a/extensions/amp-lightbox-viewer/0.1/service/lightbox-manager-impl.js
+++ b/extensions/amp-lightbox-viewer/0.1/service/lightbox-manager-impl.js
@@ -17,13 +17,13 @@
 import {isExperimentOn} from '../../../../src/experiments';
 import {dev} from '../../../../src/log';
 import {
-  childElement,
-  childElements,
   elementByTag,
   iterateCursor,
-  scopedQuerySelector,
   scopedQuerySelectorAll,
 } from '../../../../src/dom';
+import {toArray} from '../../../../src/types';
+import {CommonSignals} from '../../../../src/common-signals';
+
 
 const ELIGIBLE_TAP_TAGS = {
   'amp-img': true,
@@ -32,8 +32,7 @@ const ELIGIBLE_TAP_TAGS = {
 
 const VIEWER_TAG = 'amp-lightbox-viewer';
 const CAROUSEL_TAG = 'amp-carousel';
-const SLIDE_ITEM_SELECTOR = '.i-amphtml-slide-item';
-const CAROUSEL_CONTAINER_SELECTOR = '.i-amphtml-scrollable-carousel-container';
+const SLIDE_SELECTOR = '.amp-carousel-slide';
 
 /** @typedef {{
  *  url: string,
@@ -79,7 +78,7 @@ export class LightboxManager {
 
     /**
      * Counter tracking number of carousels without ids
-     * @private {!number}
+     * @private {number}
      */
     this.counter_ = 0;
   }
@@ -136,17 +135,16 @@ export class LightboxManager {
    */
   processLightboxElement_(element) {
     if (element.tagName.toLowerCase() == CAROUSEL_TAG) {
-      let lightboxGroupId = element.getAttribute('lightbox');
-      if (!lightboxGroupId) {
-        lightboxGroupId = 'carousel'
-          + (element.getAttribute('id') || this.counter_++);
-      }
-      this.getSlidesFromCarousel_(element).forEach(slide => {
-        // TODO: review naming conventions for component attributes
-        if (!slide.hasAttribute('lightbox-exclude')) {
-          slide.setAttribute('lightbox', lightboxGroupId);
-          this.processBaseLightboxElement_(slide, lightboxGroupId);
-        }
+      const lightboxGroupId = element.getAttribute('lightbox') ||
+       'carousel' + (element.getAttribute('id') || this.counter_++);
+      this.getSlidesFromCarousel_(element).then(slides => {
+        slides.forEach(slide => {
+          // TODO: review naming conventions for component attributes
+          if (!slide.hasAttribute('lightbox-exclude')) {
+            slide.setAttribute('lightbox', lightboxGroupId);
+            this.processBaseLightboxElement_(slide, lightboxGroupId);
+          }
+        });
       });
     } else {
       const lightboxGroupId = element.getAttribute('lightbox') || 'default';
@@ -162,30 +160,19 @@ export class LightboxManager {
         .push(dev().assertElement(element));
     if (this.meetsHeuristicsForTap_(element)) {
       const viewer = elementByTag(this.ampdoc_.getRootNode(), VIEWER_TAG);
-      element.setAttribute('on', 'tap:' + viewer.id + '.activate');
+      element.setAttribute('on', `tap:${viewer.id}.activate`);
     }
   }
 
   /**
    * @param {!Element} element
-   * @return {!Array<!Element>}
+   * @return {!Promise<!Array<!Element>>}
    * @private
    */
   getSlidesFromCarousel_(element) {
-    const type = element.getAttribute('type');
-    let carouselSlides = [];
-    if (type == 'slides') {
-      iterateCursor(
-          scopedQuerySelectorAll(element, SLIDE_ITEM_SELECTOR),
-          slide => carouselSlides.push(childElement(slide, () => true))
-      );
-    } else if (type == 'carousel') {
-      const container = dev().assertElement(
-          scopedQuerySelector(element, CAROUSEL_CONTAINER_SELECTOR)
-      );
-      carouselSlides = childElements(container, () => true);
-    }
-    return carouselSlides;
+    return element.signals().whenSignal(CommonSignals.LOAD_END).then(() => {
+      return toArray(scopedQuerySelectorAll(element, SLIDE_SELECTOR));
+    });
   }
 
   /**

--- a/test/manual/amp-lightbox-carousel-demo.amp.html
+++ b/test/manual/amp-lightbox-carousel-demo.amp.html
@@ -47,77 +47,170 @@
 
   <h1>Lightbox Carousel Demo</h1>
 
+  <h2>Lightbox on Carousel Children</h2>
   <amp-carousel height="300"
   layout="fixed-height"
-  type="carousel">
+  type="carousel"
+  >
     <amp-img src="https://picsum.photos/300/200/?image=10"
       width="300"
       height="200"
       alt="a sample image"
-      lightbox
-      on="tap:myLightboxViewer.activate"></amp-img>
+      lightbox></amp-img>
     <amp-img src="https://picsum.photos/300/200/?image=11"
       width="300"
       height="200"
       alt="another sample image"
-      lightbox="evens"
-      on="tap:myLightboxViewer.activate"></amp-img>
+      lightbox="evens"></amp-img>
     <amp-img src="https://picsum.photos/300/200/?image=12"
       width="300"
       height="200"
       alt="and another sample image"
-      lightbox
-      on="tap:myLightboxViewer.activate"></amp-img>
+      lightbox></amp-img>
     <amp-img src="https://picsum.photos/300/200/?image=13"
       width="300"
       height="200"
       alt="and another sample image"
-      lightbox="evens"
-      on="tap:myLightboxViewer.activate"></amp-img>
+      lightbox="evens"></amp-img>
     <amp-img src="https://picsum.photos/300/200/?image=14"
       width="300"
       height="200"
       alt="and another sample image"
-      lightbox="evens"
-      on="tap:myLightboxViewer.activate"></amp-img>
+      lightbox="evens"></amp-img>
     <amp-img src="https://picsum.photos/300/200/?image=15"
       width="300"
       height="200"
       alt="and another sample image"
-      lightbox
-      on="tap:myLightboxViewer.activate"></amp-img>
+      lightbox></amp-img>
     <amp-img src="https://picsum.photos/300/200/?image=16"
       width="300"
       height="200"
       alt="and another sample image"
-      lightbox
-      on="tap:myLightboxViewer.activate"></amp-img>
+      lightbox></amp-img>
     <amp-img src="https://picsum.photos/300/200/?image=17"
       width="300"
       height="200"
       alt="and another sample image"
-      lightbox
-      on="tap:myLightboxViewer.activate"></amp-img>
+      lightbox></amp-img>
     <amp-img src="https://picsum.photos/300/200/?image=18"
       width="300"
       height="200"
       alt="and another sample image"
-      lightbox
-      on="tap:myLightboxViewer.activate"></amp-img>
+      lightbox></amp-img>
     <amp-img src="https://picsum.photos/300/200/?image=19"
       width="300"
       height="200"
       alt="and another sample image"
-      lightbox
-      on="tap:myLightboxViewer.activate"></amp-img>
+      lightbox></amp-img>
     <amp-img src="https://picsum.photos/300/200/?image=20"
       width="300"
       height="200"
       alt="and another sample image"
-      lightbox
-      on="tap:myLightboxViewer.activate"></amp-img>
+      lightbox></amp-img>
   </amp-carousel>
 
+  <h2>Directly Lightboxed</h2>
+
+  <!-- TODO: make slides work after componentizing ImageViewer -->
+  <amp-carousel height="300"
+  layout="fixed-height"
+  type="slides"
+  lightbox>
+    <amp-img src="https://picsum.photos/300/200/?image=10"
+      width="300"
+      height="200"
+      alt="a sample image"></amp-img>
+    <amp-img src="https://picsum.photos/300/200/?image=11"
+      width="300"
+      height="200"
+      alt="another sample image"></amp-img>
+    <amp-img src="https://picsum.photos/300/200/?image=12"
+      width="300"
+      height="200"
+      alt="and another sample image"></amp-img>
+    <amp-img src="https://picsum.photos/300/200/?image=13"
+      width="300"
+      height="200"
+      alt="and another sample image"></amp-img>
+    <amp-img src="https://picsum.photos/300/200/?image=14"
+      width="300"
+      height="200"
+      alt="and another sample image"></amp-img>
+    <amp-img src="https://picsum.photos/300/200/?image=15"
+      width="300"
+      height="200"
+      alt="and another sample image"></amp-img>
+    <amp-img src="https://picsum.photos/300/200/?image=16"
+      width="300"
+      height="200"
+      alt="and another sample image"></amp-img>
+    <amp-img src="https://picsum.photos/300/200/?image=17"
+      width="300"
+      height="200"
+      alt="and another sample image"></amp-img>
+    <amp-img src="https://picsum.photos/300/200/?image=18"
+      width="300"
+      height="200"
+      alt="and another sample image"></amp-img>
+    <amp-img src="https://picsum.photos/300/200/?image=19"
+      width="300"
+      height="200"
+      alt="and another sample image"></amp-img>
+    <amp-img src="https://picsum.photos/300/200/?image=20"
+      width="300"
+      height="200"
+      alt="and another sample image"></amp-img>
+  </amp-carousel>
+
+  <amp-carousel height="300"
+  layout="fixed-height"
+  type="carousel"
+  lightbox>
+    <amp-img src="https://picsum.photos/300/200/?image=30"
+      width="300"
+      height="200"
+      alt="a sample image"></amp-img>
+    <amp-img src="https://picsum.photos/300/200/?image=31"
+      width="300"
+      height="200"
+      alt="another sample image"></amp-img>
+    <amp-img src="https://picsum.photos/300/200/?image=32"
+      width="300"
+      height="200"
+      alt="and another sample image"></amp-img>
+    <amp-img src="https://picsum.photos/300/200/?image=33"
+      width="300"
+      height="200"
+      alt="and another sample image"></amp-img>
+    <amp-img src="https://picsum.photos/300/200/?image=34"
+      width="300"
+      height="200"
+      alt="and another sample image"></amp-img>
+    <amp-img src="https://picsum.photos/300/200/?image=35"
+      width="300"
+      height="200"
+      alt="and another sample image"></amp-img>
+    <amp-img src="https://picsum.photos/300/200/?image=36"
+      width="300"
+      height="200"
+      alt="and another sample image"></amp-img>
+    <amp-img src="https://picsum.photos/300/200/?image=37"
+      width="300"
+      height="200"
+      alt="and another sample image"></amp-img>
+    <amp-img src="https://picsum.photos/300/200/?image=38"
+      width="300"
+      height="200"
+      alt="and another sample image"></amp-img>
+    <amp-img src="https://picsum.photos/300/200/?image=39"
+      width="300"
+      height="200"
+      alt="and another sample image"></amp-img>
+    <amp-img src="https://picsum.photos/300/200/?image=40"
+      width="300"
+      height="200"
+      alt="and another sample image"></amp-img>
+  </amp-carousel>
   <amp-lightbox-viewer id="myLightboxViewer" layout="nodisplay"></amp-lightbox-viewer>
 
 </body>


### PR DESCRIPTION
Partially addresses https://github.com/ampproject/amphtml/issues/12583. Enables lightboxing carousels and installs on-tap handlers. 
Basically implements a special case if the tag name is `amp-carousel` to lightbox all its children instead. Finding the children has different logic depending on whether the type of the `amp-carousel` is `carousel` or `slides`. 

Known Bugs: 
- There's a known issue with rendering the third image onwards for carousels with `type='slides'`. This is due to us initializing the image viewer on buildCarousel, and expecting the `amp-img` to be laid out when it isn't. The intended fix is to promote `ImageViewer` to its own standalone component and to call its layout callback when we are one slide away and ready to lay out that slide in the lightbox. 