### PR TITLE
Fix LGTM error in gulpfile.js

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1029,7 +1029,7 @@ function buildWebPushPublisherFilesVersion(version, options) {
     var copy = Object.create(options);
     copy.watch = false;
     $$.watch(path + '/*', function() {
-      buildWebPushPublisherFiles(version, copy);
+      buildWebPushPublisherFiles(version);
     });
   }
 


### PR DESCRIPTION
Fixes the following LGTM error:

- [gulpfile.js#L1032](https://lgtm.com/projects/g/ampproject/amphtml/snapshot/a4d5dedaa4349a630d64ac4ffa41ed08b90f7efe/files/gulpfile.js?sort=name&dir=ASC&mode=heatmap&excluded=false#L1032)

Partial fix for #12597