### PR TITLE
Fix LGTM error in validator/chromeextension/popup-validator.html

### DIFF
--- a/validator/chromeextension/popup-validator.html
+++ b/validator/chromeextension/popup-validator.html
@@ -113,9 +113,11 @@ limitations under the License.
               <div class="column">{{ item.col }}</div>
               <div class="issue">
                 {{ getIssue(item) }}
-                <a href="{{ item.webuiUrl }}" target="_blank">Debug</a>.
+                <a href="{{ item.webuiUrl }}" target="_blank"
+                    rel="noopener noreferrer">Debug</a>.
                 <template is="dom-if" if="{{ item.specUrl }}">
-                  <a href="{{ item.specUrl }}" target="_blank">Learn more</a>.
+                  <a href="{{ item.specUrl }}" target="_blank"
+                      rel="noopener noreferrer">Learn more</a>.
                 </template>
               </div>
             </paper-item>


### PR DESCRIPTION
Fixes the following LGTM errors:

- [validator/chromeextension/popup-validator.html#L116](https://lgtm.com/projects/g/ampproject/amphtml/snapshot/a4d5dedaa4349a630d64ac4ffa41ed08b90f7efe/files/validator/chromeextension/popup-validator.html?sort=name&dir=ASC&mode=heatmap&excluded=false#L116)

Partial fix for #12597