### PR TITLE
Enable `greenkeeper-lockfile` to correctly find `yarn` on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ before_install:
   - wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
   - sudo dpkg -i google-chrome*.deb
   - yarn global add greenkeeper-lockfile@1
+  - export PATH=$PATH:`yarn global bin`
 before_script:
   - pip install --user protobuf
   - gem install percy-capybara phantomjs poltergeist


### PR DESCRIPTION
This PR fixes `greenkeeper-lockfile` on Travis by implementing the workaround described in https://github.com/greenkeeperio/greenkeeper-lockfile/issues/98#issuecomment-352087908

Also see: https://github.com/greenkeeperio/greenkeeper-lockfile/issues/62
Follow up to #12683 #12720 #12732 
Unblocks #12766
Partial fix for #12181 

