### PR TITLE
Add yarn to PATH before installing greenkeeper-lockfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ before_install:
   - sh -e /etc/init.d/xvfb start
   - wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
   - sudo dpkg -i google-chrome*.deb
-  - yarn global add greenkeeper-lockfile@1
   - export PATH=$PATH:`yarn global bin`
+  - yarn global add greenkeeper-lockfile@1
 before_script:
   - pip install --user protobuf
   - gem install percy-capybara phantomjs poltergeist


### PR DESCRIPTION
Based on https://github.com/travis-ci/travis-ci/issues/8870#issuecomment-351395853, it appears we have to add `yarn` to `$PATH`*before* installing `greenkeeper-lockfile`.

Also see: greenkeeperio/greenkeeper-lockfile#62
Follow up to #12683 #12720 #12732 #12789
Unblocks #12766
Partial fix for #12181