### PR TITLE
Allow objects to be given as macro values in RTC config

### DIFF
--- a/examples/doubleclick-rtc.amp.html
+++ b/examples/doubleclick-rtc.amp.html
@@ -30,5 +30,17 @@
             rtc-config='{"urls": ["https://www.example.biz/?pvi=PAGEVIEWID&href=HREF&ds=ATTR(data-slot)&h=ATTR(height)&w=ATTR(width)&ovw=ATTR(data-override-width)&json=ATTR(data-json)&ovh=ATTR(data-override-height)"], "timeoutMillis": 500}'
             json='{"targeting":{"food":["burgers","chicken"]},"categoryExclusions":["health"],"tagForChildDirectedTreatment":0}'>
     </amp-ad>
+
+    <amp-ad width="320" height="50"
+            type="doubleclick"
+            data-slot="/4119129/mobile_ad_banner"
+            rtc-config='{
+            "vendors": {
+            "fakeVendor": {
+            "SLOT_ID": {"key":"param"}
+            }
+            }
+            }'>
+    </amp-ad>
 </body>
 </html>

--- a/extensions/amp-a4a/0.1/real-time-config-manager.js
+++ b/extensions/amp-a4a/0.1/real-time-config-manager.js
@@ -283,6 +283,12 @@ export function validateRtcConfig_(element) {
     return null;
   }
 
+  // The following loop is to allow vendor macros to be set as objects.
+  // We simply stringify the objects, or ignore if already a string.
+  // I.e. a valid rtcConfig could look like:
+  //   {"vendors": {"fakeVendor": {"MACRO1" : {"key": "value"}}}}
+  //   and then the macro MACRO1 would be replaced with the result of
+  //   stringifying {"key": "value"}.
   const vendors = rtcConfig['vendors'] || {};
   Object.keys(vendors).forEach(vendor => {
     Object.keys(vendors[vendor]).forEach(key => {

--- a/extensions/amp-a4a/0.1/real-time-config-manager.js
+++ b/extensions/amp-a4a/0.1/real-time-config-manager.js
@@ -108,7 +108,9 @@ export function maybeExecuteRealTimeConfig_(a4aElement, customMacros) {
     const validVendorMacros = {};
     Object.keys(rtcConfig['vendors'][vendor]).forEach(macro => {
       if (vendorObject.macros && vendorObject.macros.includes(macro)) {
-        validVendorMacros[macro] = rtcConfig['vendors'][vendor][macro];
+        const value = rtcConfig['vendors'][vendor][macro];
+        validVendorMacros[macro] = isObject(value) || isArray(value) ?
+          JSON.stringify(value) : value;
       } else {
         user().warn(TAG, `Unknown macro: ${macro} for vendor: ${vendor}`);
       }
@@ -282,22 +284,6 @@ export function validateRtcConfig_(element) {
     // This error would be due to the asserts above.
     return null;
   }
-
-  // The following loop is to allow vendor macros to be set as objects.
-  // We simply stringify the objects, or ignore if already a string.
-  // I.e. a valid rtcConfig could look like:
-  //   {"vendors": {"fakeVendor": {"MACRO1" : {"key": "value"}}}}
-  //   and then the macro MACRO1 would be replaced with the result of
-  //   stringifying {"key": "value"}.
-  const vendors = rtcConfig['vendors'] || {};
-  Object.keys(vendors).forEach(vendor => {
-    Object.keys(vendors[vendor]).forEach(key => {
-      if (isObject(vendors[vendor][key])) {
-        vendors[vendor][key] = JSON.stringify(vendors[vendor][key]);
-      }
-    });
-  });
-
   rtcConfig['timeoutMillis'] = timeout !== undefined ?
     timeout : defaultTimeoutMillis;
   return rtcConfig;

--- a/extensions/amp-a4a/0.1/real-time-config-manager.js
+++ b/extensions/amp-a4a/0.1/real-time-config-manager.js
@@ -283,6 +283,15 @@ export function validateRtcConfig_(element) {
     return null;
   }
 
+  const vendors = rtcConfig['vendors'] || {};
+  Object.keys(vendors).forEach(vendor => {
+    Object.keys(vendors[vendor]).forEach(key => {
+      if (isObject(vendors[vendor][key])) {
+        vendors[vendor][key] = JSON.stringify(vendors[vendor][key]);
+      }
+    });
+  });
+
   rtcConfig['timeoutMillis'] = timeout !== undefined ?
     timeout : defaultTimeoutMillis;
   return rtcConfig;

--- a/extensions/amp-a4a/0.1/test/test-real-time-config-manager.js
+++ b/extensions/amp-a4a/0.1/test/test-real-time-config-manager.js
@@ -416,6 +416,17 @@ describes.realWin('real-time-config-manager', {amp: true}, env => {
       expect(validatedRtcConfig).to.deep.equal(rtcConfig);
     });
 
+    it('should stringify objects given as macro values', () => {
+      const rtcConfig = {
+        'vendors': {'fakeVendor': {'SLOT_ID': {'key': 'value'}}}};
+      setRtcConfig(rtcConfig);
+      validatedRtcConfig = validateRtcConfig_(element);
+      expect(validatedRtcConfig).to.be.ok;
+      expect(validatedRtcConfig).to.not.deep.equal(rtcConfig);
+      expect(validatedRtcConfig['vendors']['fakeVendor']['SLOT_ID']
+      ).to.equal('{"key":"value"}');
+    });
+
     it('should allow timeout of 0', () => {
       const rtcConfig = {
         'vendors': {'fakeVendor': {'SLOT_ID': '1', 'PAGE_ID': '1'},

--- a/extensions/amp-a4a/0.1/test/test-real-time-config-manager.js
+++ b/extensions/amp-a4a/0.1/test/test-real-time-config-manager.js
@@ -233,6 +233,29 @@ describes.realWin('real-time-config-manager', {amp: true}, env => {
         vendors, customMacros, inflatedUrls, rtcCalloutResponses,
         calloutCount, expectedCalloutUrls: inflatedUrls, expectedRtcArray});
     });
+    it('should send callouts to vendor URLs with object/array macros', () => {
+      const vendors = {
+        'fAkeVeNdOR': {
+          SLOT_ID: {'key': 'value'},
+          PAGE_ID: [1,2,3],
+          FOO_ID: 'String',
+        },
+      };
+      const inflatedUrls = [
+        'https://localhost:8000/examples/rtcE1.json?slot_id=%7B%22key%22%3A%22' +
+            'value%22%7D&page_id=%5B1%2C2%2C3%5D&foo_id=String',
+      ];
+      const rtcCalloutResponses = [
+        {'response1': {'fooArray': ['foo']}},
+      ];
+      const calloutCount = 1;
+      const expectedRtcArray = [];
+      expectedRtcArray.push(rtcEntry(rtcCalloutResponses[0],
+          Object.keys(vendors)[0].toLowerCase()));
+      return executeTest({
+        vendors, inflatedUrls, rtcCalloutResponses,
+        calloutCount, expectedCalloutUrls: inflatedUrls, expectedRtcArray});
+    });
     it('should send RTC callouts to inflated publisher and vendor URLs', () => {
       const urls = generateUrls(2,2);
       const vendors = {
@@ -414,17 +437,6 @@ describes.realWin('real-time-config-manager', {amp: true}, env => {
       validatedRtcConfig = validateRtcConfig_(element);
       expect(validatedRtcConfig).to.be.ok;
       expect(validatedRtcConfig).to.deep.equal(rtcConfig);
-    });
-
-    it('should stringify objects given as macro values', () => {
-      const rtcConfig = {
-        'vendors': {'fakeVendor': {'SLOT_ID': {'key': 'value'}}}};
-      setRtcConfig(rtcConfig);
-      validatedRtcConfig = validateRtcConfig_(element);
-      expect(validatedRtcConfig).to.be.ok;
-      expect(validatedRtcConfig).to.not.deep.equal(rtcConfig);
-      expect(validatedRtcConfig['vendors']['fakeVendor']['SLOT_ID']
-      ).to.equal('{"key":"value"}');
     });
 
     it('should allow timeout of 0', () => {

--- a/extensions/amp-a4a/rtc-documentation.md
+++ b/extensions/amp-a4a/rtc-documentation.md
@@ -86,7 +86,7 @@ The value of rtc-config must conform to the following specification:
             *   Vendor to use must appear as a key in [callout-vendors.js ](https://github.com/ampproject/amphtml/blob/master/extensions/amp-a4a/0.1/callout-vendors.js)
         *   Value is a mapping of macros to values.
     *   Macros for a given vendor URL are specified by that particular vendor. 
-        *   E.g., in Example 1 above, VendorA has specified the macro SLOT_ID in their callout URL (see Vendor URL Specification below). The RTC config specifies the value "1" to substitute for SLOT_ID in the callout URL.
+        *   E.g., in Example 1 above, VendorA has specified the macro SLOT_ID in their callout URL (see Vendor URL Specification below). The RTC config specifies the value "1" to substitute for SLOT_ID in the callout URL. You may also set the value of a macro as a JSON object. This JSON object will be stringified automatically prior to replacement in the URL.
         *   Vendors can use the same macros as other vendors. 
 *   urls
     *   Optional parameter

--- a/extensions/amp-a4a/rtc-documentation.md
+++ b/extensions/amp-a4a/rtc-documentation.md
@@ -86,7 +86,7 @@ The value of rtc-config must conform to the following specification:
             *   Vendor to use must appear as a key in [callout-vendors.js ](https://github.com/ampproject/amphtml/blob/master/extensions/amp-a4a/0.1/callout-vendors.js)
         *   Value is a mapping of macros to values.
     *   Macros for a given vendor URL are specified by that particular vendor. 
-        *   E.g., in Example 1 above, VendorA has specified the macro SLOT_ID in their callout URL (see Vendor URL Specification below). The RTC config specifies the value "1" to substitute for SLOT_ID in the callout URL. You may also set the value of a macro as a JSON object. This JSON object will be stringified automatically prior to replacement in the URL.
+        *   E.g., in Example 1 above, VendorA has specified the macro SLOT_ID in their callout URL (see Vendor URL Specification below). The RTC config specifies the value "1" to substitute for SLOT_ID in the callout URL. You may also set the value of a macro as a JSON object or array. This JSON object will be stringified automatically prior to replacement in the URL.
         *   Vendors can use the same macros as other vendors. 
 *   urls
     *   Optional parameter


### PR DESCRIPTION
Simply stringify any objects. 

See https://github.com/ampproject/amphtml/issues/12801