### PR TITLE
amp-ima-video: Ignore tap-and-drag to start video. Only start on tap without drag

### DIFF
--- a/ads/google/imaVideo.js
+++ b/ads/google/imaVideo.js
@@ -372,7 +372,7 @@ export function imaVideo(global, data) {
     playbackStarted = false;
     nativeFullscreen = false;
 
-    var mobileBrowser = false;
+    let mobileBrowser = false;
     interactEvent = 'click';
     mouseDownEvent = 'mousedown';
     mouseMoveEvent = 'mousemove';
@@ -522,7 +522,7 @@ function onBigPlayTouchEnd() {
     // Reset state and ignore this tap.
     userTappedAndDragged = false;
   } else {
-    var tapWithoutDragEvent = new Event('tapwithoutdrag');
+    const tapWithoutDragEvent = new Event('tapwithoutdrag');
     bigPlayDiv.dispatchEvent(tapWithoutDragEvent);
   }
 }

--- a/ads/google/imaVideo.js
+++ b/ads/google/imaVideo.js
@@ -180,6 +180,9 @@ const playerData = new ImaPlayerData();
 // Flag used to track if ads have been requested or not.
 let adsRequested;
 
+// Flag that tracks if the user tapped and dragged on the big play button.
+let userTappedAndDragged;
+
 /**
  * Loads the IMA SDK library.
  */
@@ -369,6 +372,7 @@ export function imaVideo(global, data) {
     playbackStarted = false;
     nativeFullscreen = false;
 
+    var mobileBrowser = false;
     interactEvent = 'click';
     mouseDownEvent = 'mousedown';
     mouseMoveEvent = 'mousemove';
@@ -376,12 +380,20 @@ export function imaVideo(global, data) {
     if (navigator.userAgent.match(/iPhone/i) ||
         navigator.userAgent.match(/iPad/i) ||
         navigator.userAgent.match(/Android/i)) {
+      mobileBrowser = true;
       interactEvent = 'touchend';
       mouseDownEvent = 'touchstart';
       mouseMoveEvent = 'touchmove';
       mouseUpEvent = 'touchend';
     }
-    bigPlayDiv.addEventListener(interactEvent, onClick.bind(null, global));
+    if (mobileBrowser) {
+      // Create our own tap listener that ignores tap and drag.
+      bigPlayDiv.addEventListener(mouseMoveEvent, onBigPlayTouchMove);
+      bigPlayDiv.addEventListener(mouseUpEvent, onBigPlayTouchEnd);
+      bigPlayDiv.addEventListener('tapwithoutdrag', onClick.bind(null, global));
+    } else {
+      bigPlayDiv.addEventListener(interactEvent, onClick.bind(null, global));
+    }
     playPauseDiv.addEventListener(interactEvent, onPlayPauseClick);
     progressBarWrapperDiv.addEventListener(mouseDownEvent, onProgressClick);
     fullscreenDiv.addEventListener(interactEvent,
@@ -499,6 +511,28 @@ export function onClick(global) {
   adDisplayContainer.initialize();
   videoPlayer.load();
   playAds(global);
+}
+
+
+/**
+ * Triggered when the user ends a tap on the big play button.
+ */
+function onBigPlayTouchEnd() {
+  if (userTappedAndDragged) {
+    // Reset state and ignore this tap.
+    userTappedAndDragged = false;
+  } else {
+    var tapWithoutDragEvent = new Event('tapwithoutdrag');
+    bigPlayDiv.dispatchEvent(tapWithoutDragEvent);
+  }
+}
+
+
+/**
+ * Triggered when the user moves a tap on the big play button.
+ */
+function onBigPlayTouchMove() {
+  userTappedAndDragged = true;
 }
 
 


### PR DESCRIPTION
Currently the amp-ima-video player will start with any tap action on the player. This changes that so it only starts when the user taps and does not drag. When we start via tap and drag it causes a rejected promise on the video player and the player freezes.

Fixes #12666