### PR TITLE
Set up Greenkeeper GH_TOKEN for PR builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,11 @@ before_install:
   - sh -e /etc/init.d/xvfb start
   - wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
   - sudo dpkg -i google-chrome*.deb
-  - export PATH=$PATH:`yarn global bin`
+  # Set up Greenkeeper token
+  - yarn global add btoa-atob
+  - export GH_TOKEN=`echo $GREENKEEPER_TOKEN_ENCODED | atob`
+  # Required due to https://github.com/greenkeeperio/greenkeeper-lockfile/issues/98#issuecomment-352087908
+  - export PATH="`yarn global bin`:$PATH"
   - yarn global add greenkeeper-lockfile@1
 before_script:
   - pip install --user protobuf
@@ -42,8 +46,6 @@ addons:
   jwt:
     # SAUCE_ACCESS_KEY for sauce_connect
     - secure: "Wze0F0vGL0UcxryOx1n/vcuD5LIMGyR+69Nc6IWLoRvZBbbIpFwVFhDE6rE9ranIXiA2Hc684N4sV8ASfNDF8RRSB+jyLov159qwgji2rBxIfQ/4kuDV2vYoAJvYMz8m42kwx5FV2VV9awqMMt8mwU3wYIrKIaVCxB34uV86KIlDlbrHxt17Bm5EIiUmwi9r1AAnW/63vVRUN264D77oB4j9UQ759PfD6BDwEt54O87KurNIaLseNCr1IvzfL8veEsZ3uTbLC1GtgHfR4IGgkS2YyN2QIk06VZWeRDEOalS3RcY0nDkbCmBywxIGObnrpEMzOpjBiOb2fxLoLvvpjlla5W84zJGfWE6q4T9IvkyHuDJE+sft5B+arjMIeA6PIeUhKdV27+6qqDEf7fILZ/U/Ekn9ds4zSV8hekAZPUyyPncOeyWppCIJ8sOeCrsebkRjH1BoX/d+FE+nP0bN/XkBpIi/nManx5FyS/kqjQWGKmvsFQfEWlSUaZi7XtEQEjvBizRkzvpJanSDaoiTDS2Keulmwii3XRId51FuGtnfDZFeggLaMTKGfBX9DlPkccwYAZe6vPNfYk1pNgEj6AtnifEhYVEO+aAuWhEnJ86od+1wDOL/h+a2XY6h8/gFBywsD95p7sXPfdVDCKgwagiBo+Hw5MNjztVF7lszg1A="
-    # GH_TOKEN for greenkeeper
-    - secure: "Y+eN4irwUJ3xo+9sRx4TMjdKVW/IuGuB69UreCwp7GaisfJ7MZrI2FZqDeLRsdxJFK1heNV+lCJHxTNI+5DHtWgoLVVVsS+Z+KZU0ZR6bfrla4Y0mgj5SuDRRBAAXc/Ld/3yR2UOtOyz3a6zuikuejj8ppBYS14koE4NRS0e0v4qh5hohb1ZkxxXBFokQ5NnvrlKD4YXul/9iHBqR5I8WjOgdZBE9oK0iyj5C+jIfTbP8MM2+Bh+BvBjXxuPp7vPLF0aHYSK2AuZCsO/Lw6O1n8ukQccKyuwsW6olGJsHVZxff0vsmyjPUag6M+XQfVxqRegxf4zwoctRNAHjIwLvYauSv0R4ld/hMr3yTeYbJpjBdz2qJdScmhTo7FdZaSbM8yLqXYGL2Hzw0bB3/W3X657ZWTi1kGAc33Db0IZFRNm17cheoOP4QNHfkX0y3law87qkKFWi4+VgoHEZkUaBQUj07ZSTRkS0M7Lhc0zMQntRtyHc0StkwEEsd+3ZzYbloqLCL1/AgxXNZ9QbivKVPESU53mIjGqinsTS/h0vo3z6O/xUb9px1HLn7iJEhqobtNb/49SGi4YnUbFDyv1hc7aurpL3STS0zd3S6IXcvuXNKhXCQlAJoXb+AMfqzeqwsnTGQs3gb4q3+oC1q/SXiTFuV6YMDQv24u7GxuI2eQ="
   hosts:
     - ads.localhost
     - iframe.localhost

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,6 @@ before_install:
   - sh -e /etc/init.d/xvfb start
   - wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
   - sudo dpkg -i google-chrome*.deb
-  # Set up Greenkeeper token
-  - yarn global add btoa-atob
-  - export GH_TOKEN=`echo $GREENKEEPER_TOKEN_ENCODED | atob`
   # Required due to https://github.com/greenkeeperio/greenkeeper-lockfile/issues/98#issuecomment-352087908
   - export PATH="`yarn global bin`:$PATH"
   - yarn global add greenkeeper-lockfile@1
@@ -26,6 +23,8 @@ before_script:
   - gem install percy-capybara phantomjs poltergeist
   # Poltergeist requires an absolute path to find phantomjs. See #10305.
   - export PATH="`pwd`/node_modules/.bin:$PATH"
+  # Set up a token for Greenkeeper and update the yarn lock file
+  - export GH_TOKEN=`node -e "console.log(require('atob')(process.env.GREENKEEPER_TOKEN_ENCODED))"`
   - greenkeeper-lockfile-update
 script: node build-system/pr-check.js
 after_script: greenkeeper-lockfile-upload


### PR DESCRIPTION
The JWT token we were using earlier does not work for PR builds. Therefore, we were seeing a permission error: https://travis-ci.org/ampproject/amphtml/jobs/327380341#L808

This PR decodes a previously set GH token with just the `public_repo` permission, for use by `greenkeeper-lockfile-upload`.

Follow up to #12683 #12720 #12732 #12789 #12791
Unblocks #12766
Partial fix for #1218
