### PR TITLE
Fix primitive wrappers in Closure type tags

### DIFF
--- a/ads/adgeneration.js
+++ b/ads/adgeneration.js
@@ -50,7 +50,7 @@ export function adgeneration(global, data) {
 
 /**
  * URL encoding of query string
- * @param {!String} str
+ * @param {string} str
  */
 function encodeQueryValue(str) {
   return str.split('&').map(v => {

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -49,7 +49,7 @@ function startTimer(functionName) {
 /**
  * Stops the timer for the given function and prints the execution time.
  * @param {string} functionName
- * @return {Number}
+ * @return {number}
  */
 function stopTimer(functionName, startTime) {
   const endTime = Date.now();

--- a/extensions/amp-apester-media/0.1/utils.js
+++ b/extensions/amp-apester-media/0.1/utils.js
@@ -57,7 +57,7 @@ function extractElementTags(element) {
 /**
  * Extracts tags from a given element and document.
  * @param element
- * @return {Array<String>}
+ * @return {Array<string>}
  */
 export function extractTags(element) {
   const extractags = extractElementTags(element);

--- a/extensions/amp-ima-video/0.1/amp-ima-video.js
+++ b/extensions/amp-ima-video/0.1/amp-ima-video.js
@@ -72,10 +72,10 @@ class AmpImaVideo extends AMP.BaseElement {
     /** @private {?Function} */
     this.unlistenMessage_ = null;
 
-    /** @private {?String} */
+    /** @private {?string} */
     this.preconnectSource_ = null;
 
-    /** @private {?String} */
+    /** @private {?string} */
     this.preconnectTrack_ = null;
 
     /**

--- a/extensions/amp-ima-video/0.1/ima-player-data.js
+++ b/extensions/amp-ima-video/0.1/ima-player-data.js
@@ -19,8 +19,8 @@ export class ImaPlayerData {
   /**
    * Create a new ImaPlayerData object.
    *
-   * @param {!Number} curentTime
-   * @param {!Number} duration
+   * @param {number} curentTime
+   * @param {number} duration
    * @param {!Array} playedRanges
    */
   constructor(currentTime = 0, duration = 1, playedRanges = []) {


### PR DESCRIPTION
[go/es6-style#disallowed-features-wrapper-objects](https://engdoc.corp.google.com/eng/doc/devguide/js/styleguide.md#disallowed-features-wrapper-objects)

> Never use new on the primitive object wrappers (`Boolean`, `Number`, `String`, `Symbol`), nor include them in type annotations.

This change forbids and fixes primitive wrappers in Closure Compiler type tags. If the wrapper is explicitly non-nullable, the `!` will be removed as well.

```js
/** @type {!Boolean} */ (x) // incorrect, converted to:
/** @type {boolean} */ (x) // correct
```

This concludes my diversion into linting Closure types 🤓