### PR TITLE
Remove the soon-to-be-deprecated gulp-util

### DIFF
--- a/build-system/check-package-manager.js
+++ b/build-system/check-package-manager.js
@@ -18,7 +18,7 @@
 const getStdout = require('./exec').getStdout;
 const setupInstructionsUrl = 'https://github.com/ampproject/amphtml/blob/master/contributing/getting-started-quick.md#one-time-setup';
 
-// Color formatting may not yet be available via gulp-util.
+// Color formatting libraries may not be available when this script is run.
 function red(text) {return '\x1b[31m' + text + '\x1b[0m';}
 function cyan(text) {return '\x1b[36m' + text + '\x1b[0m';}
 function green(text) {return '\x1b[32m' + text + '\x1b[0m';}

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -30,7 +30,6 @@ const execOrDie = require('./exec').execOrDie;
 const getStdout = require('./exec').getStdout;
 const getStderr = require('./exec').getStderr;
 const path = require('path');
-const util = require('gulp-util');
 const colors = require('ansi-colors');
 
 const fileLogPrefix = colors.yellow.bold('pr-check.js:');

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -32,7 +32,7 @@ const getStderr = require('./exec').getStderr;
 const path = require('path');
 const colors = require('ansi-colors');
 
-const fileLogPrefix = colors.yellow.bold('pr-check.js:');
+const fileLogPrefix = colors.bold(colors.yellow('pr-check.js:'));
 
 /**
  * Starts a timer to measure the execution time of the given function.

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -31,8 +31,9 @@ const getStdout = require('./exec').getStdout;
 const getStderr = require('./exec').getStderr;
 const path = require('path');
 const util = require('gulp-util');
+const colors = require('ansi-colors');
 
-const fileLogPrefix = util.colors.yellow.bold('pr-check.js:');
+const fileLogPrefix = colors.yellow.bold('pr-check.js:');
 
 /**
  * Starts a timer to measure the execution time of the given function.
@@ -42,7 +43,7 @@ const fileLogPrefix = util.colors.yellow.bold('pr-check.js:');
 function startTimer(functionName) {
   const startTime = Date.now();
   console.log(
-      '\n' + fileLogPrefix, 'Running', util.colors.cyan(functionName) + '...');
+      '\n' + fileLogPrefix, 'Running', colors.cyan(functionName) + '...');
   return startTime;
 }
 
@@ -57,8 +58,8 @@ function stopTimer(functionName, startTime) {
   const mins = executionTime.getMinutes();
   const secs = executionTime.getSeconds();
   console.log(
-      fileLogPrefix, 'Done running', util.colors.cyan(functionName),
-      'Total time:', util.colors.green(mins + 'm ' + secs + 's'));
+      fileLogPrefix, 'Done running', colors.cyan(functionName),
+      'Total time:', colors.green(mins + 'm ' + secs + 's'));
 }
 
 /**
@@ -84,7 +85,7 @@ function filesInPr() {
       getStdout('git -c color.ui=always diff --stat master...HEAD');
   console.log(fileLogPrefix,
       'Testing the following changes at commit',
-      util.colors.cyan(process.env.TRAVIS_PULL_REQUEST_SHA));
+      colors.cyan(process.env.TRAVIS_PULL_REQUEST_SHA));
   console.log(changeSummary);
   return files;
 }
@@ -305,8 +306,8 @@ const command = {
     } else if (!process.env.PERCY_PROJECT || !process.env.PERCY_TOKEN) {
       console.log(
           '\n' + fileLogPrefix, 'Could not find environment variables',
-          util.colors.cyan('PERCY_PROJECT'), 'and',
-          util.colors.cyan('PERCY_TOKEN') + '. Skipping visual diff tests.');
+          colors.cyan('PERCY_PROJECT'), 'and',
+          colors.cyan('PERCY_TOKEN') + '. Skipping visual diff tests.');
       return;
     }
     let cmd = 'gulp visual-diff';
@@ -321,8 +322,8 @@ const command = {
     if (!process.env.PERCY_PROJECT || !process.env.PERCY_TOKEN) {
       console.log(
           '\n' + fileLogPrefix, 'Could not find environment variables',
-          util.colors.cyan('PERCY_PROJECT'), 'and',
-          util.colors.cyan('PERCY_TOKEN') +
+          colors.cyan('PERCY_PROJECT'), 'and',
+          colors.cyan('PERCY_TOKEN') +
           '. Skipping verification of visual diff tests.');
       return;
     }
@@ -407,7 +408,7 @@ function main() {
 
   console.log(
       fileLogPrefix, 'Running build shard',
-      util.colors.cyan(process.env.BUILD_SHARD),
+      colors.cyan(process.env.BUILD_SHARD),
       '\n');
 
   // If $TRAVIS_PULL_REQUEST_SHA is empty then it is a push build and not a PR.
@@ -422,14 +423,14 @@ function main() {
 
   // Exit early if flag-config files are mixed with non-flag-config files.
   if (buildTargets.has('FLAG_CONFIG') && buildTargets.size !== 1) {
-    console.log(fileLogPrefix, util.colors.red('ERROR:'),
+    console.log(fileLogPrefix, colors.red('ERROR:'),
         'Looks like your PR contains',
-        util.colors.cyan('{prod|canary}-config.json'),
+        colors.cyan('{prod|canary}-config.json'),
         'in addition to some other files');
     const nonFlagConfigFiles = files.filter(file => !isFlagConfig(file));
-    console.log(fileLogPrefix, util.colors.red('ERROR:'),
+    console.log(fileLogPrefix, colors.red('ERROR:'),
         'Please move these files to a separate PR:',
-        util.colors.cyan(nonFlagConfigFiles.join(', ')));
+        colors.cyan(nonFlagConfigFiles.join(', ')));
     stopTimer('pr-check.js', startTime);
     process.exit(1);
   }
@@ -438,18 +439,18 @@ function main() {
   if (files.indexOf('package.json') != -1 || files.indexOf('yarn.lock') != -1) {
     const yarnIntegrityCheck = getStderr('yarn check --integrity').trim();
     if (yarnIntegrityCheck.includes('error')) {
-      console.error(fileLogPrefix, util.colors.red('ERROR:'),
-          'Found the following', util.colors.cyan('yarn'), 'errors:\n' +
-          util.colors.cyan(yarnIntegrityCheck));
-      console.error(fileLogPrefix, util.colors.red('ERROR:'),
-          'Updates to', util.colors.cyan('package.json'),
+      console.error(fileLogPrefix, colors.red('ERROR:'),
+          'Found the following', colors.cyan('yarn'), 'errors:\n' +
+          colors.cyan(yarnIntegrityCheck));
+      console.error(fileLogPrefix, colors.red('ERROR:'),
+          'Updates to', colors.cyan('package.json'),
           'must be accompanied by a corresponding update to',
-          util.colors.cyan('yarn.lock'));
-      console.error(fileLogPrefix, util.colors.yellow('NOTE:'),
-          'To update', util.colors.cyan('yarn.lock'), 'after changing',
-          util.colors.cyan('package.json') + ',', 'run',
-          '"' + util.colors.cyan('yarn install') + '"',
-          'and include the updated', util.colors.cyan('yarn.lock'),
+          colors.cyan('yarn.lock'));
+      console.error(fileLogPrefix, colors.yellow('NOTE:'),
+          'To update', colors.cyan('yarn.lock'), 'after changing',
+          colors.cyan('package.json') + ',', 'run',
+          '"' + colors.cyan('yarn install') + '"',
+          'and include the updated', colors.cyan('yarn.lock'),
           'in your PR.');
       process.exit(1);
     }
@@ -457,7 +458,7 @@ function main() {
 
   console.log(
       fileLogPrefix, 'Detected build targets:',
-      util.colors.cyan(Array.from(buildTargets).sort().join(', ')));
+      colors.cyan(Array.from(buildTargets).sort().join(', ')));
 
   // Run different sets of independent tasks in parallel to reduce build time.
   if (process.env.BUILD_SHARD == 'unit_tests') {

--- a/build-system/scope-require.js
+++ b/build-system/scope-require.js
@@ -23,7 +23,6 @@ const rocambole = require('rocambole');
 const fs = require('fs');
 const program = require('commander');
 const es = require('event-stream');
-const util = require('gulp-util');
 const colors = require('ansi-colors');
 
 /**

--- a/build-system/scope-require.js
+++ b/build-system/scope-require.js
@@ -24,6 +24,7 @@ const fs = require('fs');
 const program = require('commander');
 const es = require('event-stream');
 const util = require('gulp-util');
+const colors = require('ansi-colors');
 
 /**
  * Changes global `require` calls to be referenced from a given global namespace.
@@ -116,14 +117,14 @@ const inputStream = (program.infile && program.infile !== '-' ?
   fs.createReadStream(program.infile) :
   process.stdin);
 inputStream.on('error', err => {
-  console./*OK*/error(util.colors.red('\nError reading file: ' + err.path));
+  console./*OK*/error(colors.red('\nError reading file: ' + err.path));
 });
 
 const outputStream = (program.outfile && program.outfile !== '-' ?
   fs.createWriteStream(program.outfile) :
   process.stdout);
 outputStream.on('error', err => {
-  console./*OK*/error(util.colors.red('\nError writing file: ' + err.path));
+  console./*OK*/error(colors.red('\nError writing file: ' + err.path));
 });
 
 const scopeRequireStream = es.map((inputFile, cb) =>

--- a/build-system/server.js
+++ b/build-system/server.js
@@ -23,7 +23,6 @@ const app = require(require.resolve('./app.js'));
 const isRunning = require('is-running');
 const gulp = require('gulp-help')(require('gulp'));
 const morgan = require('morgan');
-const util = require('gulp-util');
 const webserver = require('gulp-webserver');
 const colors = require('ansi-colors');
 const log = require('fancy-log');

--- a/build-system/server.js
+++ b/build-system/server.js
@@ -26,6 +26,7 @@ const morgan = require('morgan');
 const util = require('gulp-util');
 const webserver = require('gulp-webserver');
 const colors = require('ansi-colors');
+const log = require('fancy-log');
 
 const host = process.env.SERVE_HOST;
 const port = process.env.SERVE_PORT;
@@ -38,9 +39,9 @@ const header = require('connect-header');
 // Exit if the port is in use.
 process.on('uncaughtException', function(err) {
   if (err.errno === 'EADDRINUSE') {
-    util.log(colors.red('Port', port, 'in use, shutting down server'));
+    log(colors.red('Port', port, 'in use, shutting down server'));
   } else {
-    util.log(colors.red(err));
+    log(colors.red(err));
   }
   process.kill(gulpProcess, 'SIGINT');
   process.exit(1);

--- a/build-system/server.js
+++ b/build-system/server.js
@@ -25,6 +25,7 @@ const gulp = require('gulp-help')(require('gulp'));
 const morgan = require('morgan');
 const util = require('gulp-util');
 const webserver = require('gulp-webserver');
+const colors = require('ansi-colors');
 
 const host = process.env.SERVE_HOST;
 const port = process.env.SERVE_PORT;
@@ -37,9 +38,9 @@ const header = require('connect-header');
 // Exit if the port is in use.
 process.on('uncaughtException', function(err) {
   if (err.errno === 'EADDRINUSE') {
-    util.log(util.colors.red('Port', port, 'in use, shutting down server'));
+    util.log(colors.red('Port', port, 'in use, shutting down server'));
   } else {
-    util.log(util.colors.red(err));
+    util.log(colors.red(err));
   }
   process.kill(gulpProcess, 'SIGINT');
   process.exit(1);

--- a/build-system/tasks/changelog.js
+++ b/build-system/tasks/changelog.js
@@ -31,7 +31,6 @@ const extend = require('util')._extend;
 const git = require('gulp-git');
 const gulp = require('gulp-help')(require('gulp'));
 const request = BBPromise.promisify(require('request'));
-const util = require('gulp-util');
 const colors = require('ansi-colors');
 const log = require('fancy-log');
 

--- a/build-system/tasks/changelog.js
+++ b/build-system/tasks/changelog.js
@@ -33,6 +33,7 @@ const gulp = require('gulp-help')(require('gulp'));
 const request = BBPromise.promisify(require('request'));
 const util = require('gulp-util');
 const colors = require('ansi-colors');
+const log = require('fancy-log');
 
 const GITHUB_ACCESS_TOKEN = process.env.GITHUB_ACCESS_TOKEN;
 const exec = BBPromise.promisify(childProcess.exec);
@@ -101,9 +102,9 @@ let PrMetadataDef;
 
 function changelog() {
   if (!GITHUB_ACCESS_TOKEN) {
-    util.log(colors.red('Warning! You have not set the ' +
+    log(colors.red('Warning! You have not set the ' +
         'GITHUB_ACCESS_TOKEN env var. Aborting "changelog" task.'));
-    util.log(colors.green('See https://help.github.com/articles/' +
+    log(colors.green('See https://help.github.com/articles/' +
         'creating-an-access-token-for-command-line-use/ ' +
         'for instructions on how to create a github access token. We only ' +
         'need `public_repo` scope.'));
@@ -129,7 +130,7 @@ function getGitMetadata() {
       .then(getBaseCanaryVersion)
       .then(buildChangelog)
       .then(function(gitMetadata) {
-        util.log(colors.blue('\n' + gitMetadata.changelog));
+        log(colors.blue('\n' + gitMetadata.changelog));
         if (isDryrun) {
           return;
         }
@@ -206,7 +207,7 @@ function submitReleaseNotes(version, changelog, sha) {
   }
 
   return request(options).then(function() {
-    util.log(colors.green('Release Notes submitted'));
+    log(colors.green('Release Notes submitted'));
   });
 }
 
@@ -486,7 +487,7 @@ function errHandler(err) {
   if (err.message) {
     msg = err.message;
   }
-  util.log(colors.red(msg));
+  log(colors.red(msg));
 }
 
 /**
@@ -544,16 +545,16 @@ function buildPrMetadata(pr) {
 
 function changelogUpdate() {
   if (!GITHUB_ACCESS_TOKEN) {
-    util.log(colors.red('Warning! You have not set the ' +
+    log(colors.red('Warning! You have not set the ' +
         'GITHUB_ACCESS_TOKEN env var. Aborting "changelog" task.'));
-    util.log(colors.green('See https://help.github.com/articles/' +
+    log(colors.green('See https://help.github.com/articles/' +
         'creating-an-access-token-for-command-line-use/ ' +
         'for instructions on how to create a github access token. We only ' +
         'need `public_repo` scope.'));
     return;
   }
   if (!argv.message) {
-    util.log(colors.red('--message flag must be set.'));
+    log(colors.red('--message flag must be set.'));
   }
   return update();
 }
@@ -603,10 +604,10 @@ function update() {
       releasesOptions.body.body = argv.message + release.body;
     }
     return request(releasesOptions).then(() => {
-      util.log(colors.green('Update Successful.'));
+      log(colors.green('Update Successful.'));
     })
         .catch(e => {
-          util.log(colors.red('Update Failed. ' + e.message));
+          log(colors.red('Update Failed. ' + e.message));
         });
   });
 }

--- a/build-system/tasks/changelog.js
+++ b/build-system/tasks/changelog.js
@@ -32,6 +32,7 @@ const git = require('gulp-git');
 const gulp = require('gulp-help')(require('gulp'));
 const request = BBPromise.promisify(require('request'));
 const util = require('gulp-util');
+const colors = require('ansi-colors');
 
 const GITHUB_ACCESS_TOKEN = process.env.GITHUB_ACCESS_TOKEN;
 const exec = BBPromise.promisify(childProcess.exec);
@@ -100,9 +101,9 @@ let PrMetadataDef;
 
 function changelog() {
   if (!GITHUB_ACCESS_TOKEN) {
-    util.log(util.colors.red('Warning! You have not set the ' +
+    util.log(colors.red('Warning! You have not set the ' +
         'GITHUB_ACCESS_TOKEN env var. Aborting "changelog" task.'));
-    util.log(util.colors.green('See https://help.github.com/articles/' +
+    util.log(colors.green('See https://help.github.com/articles/' +
         'creating-an-access-token-for-command-line-use/ ' +
         'for instructions on how to create a github access token. We only ' +
         'need `public_repo` scope.'));
@@ -128,7 +129,7 @@ function getGitMetadata() {
       .then(getBaseCanaryVersion)
       .then(buildChangelog)
       .then(function(gitMetadata) {
-        util.log(util.colors.blue('\n' + gitMetadata.changelog));
+        util.log(colors.blue('\n' + gitMetadata.changelog));
         if (isDryrun) {
           return;
         }
@@ -205,7 +206,7 @@ function submitReleaseNotes(version, changelog, sha) {
   }
 
   return request(options).then(function() {
-    util.log(util.colors.green('Release Notes submitted'));
+    util.log(colors.green('Release Notes submitted'));
   });
 }
 
@@ -485,7 +486,7 @@ function errHandler(err) {
   if (err.message) {
     msg = err.message;
   }
-  util.log(util.colors.red(msg));
+  util.log(colors.red(msg));
 }
 
 /**
@@ -543,16 +544,16 @@ function buildPrMetadata(pr) {
 
 function changelogUpdate() {
   if (!GITHUB_ACCESS_TOKEN) {
-    util.log(util.colors.red('Warning! You have not set the ' +
+    util.log(colors.red('Warning! You have not set the ' +
         'GITHUB_ACCESS_TOKEN env var. Aborting "changelog" task.'));
-    util.log(util.colors.green('See https://help.github.com/articles/' +
+    util.log(colors.green('See https://help.github.com/articles/' +
         'creating-an-access-token-for-command-line-use/ ' +
         'for instructions on how to create a github access token. We only ' +
         'need `public_repo` scope.'));
     return;
   }
   if (!argv.message) {
-    util.log(util.colors.red('--message flag must be set.'));
+    util.log(colors.red('--message flag must be set.'));
   }
   return update();
 }
@@ -602,10 +603,10 @@ function update() {
       releasesOptions.body.body = argv.message + release.body;
     }
     return request(releasesOptions).then(() => {
-      util.log(util.colors.green('Update Successful.'));
+      util.log(colors.green('Update Successful.'));
     })
         .catch(e => {
-          util.log(util.colors.red('Update Failed. ' + e.message));
+          util.log(colors.red('Update Failed. ' + e.message));
         });
   });
 }

--- a/build-system/tasks/check-links.js
+++ b/build-system/tasks/check-links.js
@@ -23,7 +23,6 @@ const fs = require('fs-extra');
 const getStdout = require('../exec').getStdout;
 const gulp = require('gulp-help')(require('gulp'));
 const markdownLinkCheck = BBPromise.promisify(require('markdown-link-check'));
-const util = require('gulp-util');
 const colors = require('ansi-colors');
 const log = require('fancy-log');
 

--- a/build-system/tasks/check-links.js
+++ b/build-system/tasks/check-links.js
@@ -24,6 +24,7 @@ const getStdout = require('../exec').getStdout;
 const gulp = require('gulp-help')(require('gulp'));
 const markdownLinkCheck = BBPromise.promisify(require('markdown-link-check'));
 const util = require('gulp-util');
+const colors = require('ansi-colors');
 
 
 /**
@@ -78,31 +79,31 @@ function checkLinks() {
           if (deadLinksFoundInFile) {
             filesWithDeadLinks.push(markdownFiles[index]);
             util.log(
-                util.colors.red('ERROR'),
+                colors.red('ERROR'),
                 'Possible dead link(s) found in',
-                util.colors.magenta(markdownFiles[index]));
+                colors.magenta(markdownFiles[index]));
           } else {
             util.log(
-                util.colors.green('SUCCESS'),
+                colors.green('SUCCESS'),
                 'All links in',
-                util.colors.magenta(markdownFiles[index]), 'are alive.');
+                colors.magenta(markdownFiles[index]), 'are alive.');
           }
         });
         if (deadLinksFound) {
           util.log(
-              util.colors.red('ERROR'),
+              colors.red('ERROR'),
               'Please update dead link(s) in',
-              util.colors.magenta(filesWithDeadLinks.join(',')),
+              colors.magenta(filesWithDeadLinks.join(',')),
               'or whitelist them in build-system/tasks/check-links.js');
           util.log(
-              util.colors.yellow('NOTE'),
+              colors.yellow('NOTE'),
               'If the link(s) above are not meant to resolve to a real webpage',
               'surrounding them with backticks will exempt them from the link',
               'checker.');
           process.exit(1);
         } else {
           util.log(
-              util.colors.green('SUCCESS'),
+              colors.green('SUCCESS'),
               'All links in all markdown files in this branch are alive.');
         }
       });

--- a/build-system/tasks/check-links.js
+++ b/build-system/tasks/check-links.js
@@ -25,6 +25,7 @@ const gulp = require('gulp-help')(require('gulp'));
 const markdownLinkCheck = BBPromise.promisify(require('markdown-link-check'));
 const util = require('gulp-util');
 const colors = require('ansi-colors');
+const log = require('fancy-log');
 
 
 /**
@@ -71,38 +72,38 @@ function checkLinks() {
             if (result.status === 'dead') {
               deadLinksFound = true;
               deadLinksFoundInFile = true;
-              util.log('[%s] %s', chalk.red('✖'), result.link);
+              log('[%s] %s', chalk.red('✖'), result.link);
             } else if (!process.env.TRAVIS) {
-              util.log('[%s] %s', chalk.green('✔'), result.link);
+              log('[%s] %s', chalk.green('✔'), result.link);
             }
           });
           if (deadLinksFoundInFile) {
             filesWithDeadLinks.push(markdownFiles[index]);
-            util.log(
+            log(
                 colors.red('ERROR'),
                 'Possible dead link(s) found in',
                 colors.magenta(markdownFiles[index]));
           } else {
-            util.log(
+            log(
                 colors.green('SUCCESS'),
                 'All links in',
                 colors.magenta(markdownFiles[index]), 'are alive.');
           }
         });
         if (deadLinksFound) {
-          util.log(
+          log(
               colors.red('ERROR'),
               'Please update dead link(s) in',
               colors.magenta(filesWithDeadLinks.join(',')),
               'or whitelist them in build-system/tasks/check-links.js');
-          util.log(
+          log(
               colors.yellow('NOTE'),
               'If the link(s) above are not meant to resolve to a real webpage',
               'surrounding them with backticks will exempt them from the link',
               'checker.');
           process.exit(1);
         } else {
-          util.log(
+          log(
               colors.green('SUCCESS'),
               'All links in all markdown files in this branch are alive.');
         }

--- a/build-system/tasks/compile.js
+++ b/build-system/tasks/compile.js
@@ -26,6 +26,7 @@ const internalRuntimeVersion = require('../internal-version').VERSION;
 const internalRuntimeToken = require('../internal-version').TOKEN;
 const shortenLicense = require('../shorten-license');
 const rimraf = require('rimraf');
+const colors = require('ansi-colors');
 
 const isProdBuild = !!argv.type;
 const queue = [];
@@ -52,7 +53,7 @@ exports.closureCompile = function(entryModuleFilename, outputDir,
             next();
             resolve();
           }, function(e) {
-            console./* OK*/error(util.colors.red('Compilation error',
+            console./* OK*/error(colors.red('Compilation error',
                 e.message));
             process.exit(1);
           });
@@ -340,9 +341,9 @@ function compile(entryModuleFilenames, outputDir,
     let stream = gulp.src(srcs)
         .pipe(closureCompiler(compilerOptions))
         .on('error', function(err) {
-          console./* OK*/error(util.colors.red('Error compiling',
+          console./* OK*/error(colors.red('Error compiling',
               entryModuleFilenames));
-          console./* OK*/error(util.colors.red(err.message));
+          console./* OK*/error(colors.red(err.message));
           process.exit(1);
         });
 

--- a/build-system/tasks/compile.js
+++ b/build-system/tasks/compile.js
@@ -21,7 +21,6 @@ const closureCompiler = require('gulp-closure-compiler');
 const gulp = require('gulp');
 const rename = require('gulp-rename');
 const replace = require('gulp-replace');
-const util = require('gulp-util');
 const internalRuntimeVersion = require('../internal-version').VERSION;
 const internalRuntimeToken = require('../internal-version').TOKEN;
 const shortenLicense = require('../shorten-license');

--- a/build-system/tasks/csvify-size/index.js
+++ b/build-system/tasks/csvify-size/index.js
@@ -22,6 +22,7 @@ const exec = BBPromise.promisify(childProcess.exec);
 const fs = BBPromise.promisifyAll(require('fs'));
 const gulp = require('gulp-help')(require('gulp'));
 const util = require('gulp-util');
+const colors = require('ansi-colors');
 
 
 const prettyBytesUnits = ['B', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
@@ -235,7 +236,7 @@ function serializeCheckout(logs) {
           tables.push([]);
           return tables;
         }
-        util.log(util.colors.red(e.message));
+        util.log(colors.red(e.message));
       });
     });
   }, Promise.resolve(tables));

--- a/build-system/tasks/csvify-size/index.js
+++ b/build-system/tasks/csvify-size/index.js
@@ -23,6 +23,7 @@ const fs = BBPromise.promisifyAll(require('fs'));
 const gulp = require('gulp-help')(require('gulp'));
 const util = require('gulp-util');
 const colors = require('ansi-colors');
+const log = require('fancy-log');
 
 
 const prettyBytesUnits = ['B', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
@@ -236,7 +237,7 @@ function serializeCheckout(logs) {
           tables.push([]);
           return tables;
         }
-        util.log(colors.red(e.message));
+        log(colors.red(e.message));
       });
     });
   }, Promise.resolve(tables));

--- a/build-system/tasks/csvify-size/index.js
+++ b/build-system/tasks/csvify-size/index.js
@@ -21,7 +21,6 @@ const childProcess = require('child_process');
 const exec = BBPromise.promisify(childProcess.exec);
 const fs = BBPromise.promisifyAll(require('fs'));
 const gulp = require('gulp-help')(require('gulp'));
-const util = require('gulp-util');
 const colors = require('ansi-colors');
 const log = require('fancy-log');
 

--- a/build-system/tasks/dep-check.js
+++ b/build-system/tasks/dep-check.js
@@ -27,11 +27,12 @@ const path = require('path');
 const source = require('vinyl-source-stream');
 const through = require('through2');
 const util = require('gulp-util');
+const colors = require('ansi-colors');
 
 
 const root = process.cwd();
 const absPathRegExp = new RegExp(`^${root}/`);
-const red = msg => util.log(util.colors.red(msg));
+const red = msg => util.log(colors.red(msg));
 
 
 /**

--- a/build-system/tasks/dep-check.js
+++ b/build-system/tasks/dep-check.js
@@ -28,11 +28,12 @@ const source = require('vinyl-source-stream');
 const through = require('through2');
 const util = require('gulp-util');
 const colors = require('ansi-colors');
+const log = require('fancy-log');
 
 
 const root = process.cwd();
 const absPathRegExp = new RegExp(`^${root}/`);
-const red = msg => util.log(colors.red(msg));
+const red = msg => log(colors.red(msg));
 
 
 /**

--- a/build-system/tasks/dep-check.js
+++ b/build-system/tasks/dep-check.js
@@ -26,7 +26,6 @@ const minimatch = require('minimatch');
 const path = require('path');
 const source = require('vinyl-source-stream');
 const through = require('through2');
-const util = require('gulp-util');
 const colors = require('ansi-colors');
 const log = require('fancy-log');
 

--- a/build-system/tasks/extension-generator/index.js
+++ b/build-system/tasks/extension-generator/index.js
@@ -18,7 +18,6 @@
 const argv = require('minimist')(process.argv.slice(2));
 const fs = require('fs-extra');
 const gulp = require('gulp-help')(require('gulp'));
-const util = require('gulp-util');
 const colors = require('ansi-colors');
 const log = require('fancy-log');
 

--- a/build-system/tasks/extension-generator/index.js
+++ b/build-system/tasks/extension-generator/index.js
@@ -19,7 +19,7 @@ const argv = require('minimist')(process.argv.slice(2));
 const fs = require('fs-extra');
 const gulp = require('gulp-help')(require('gulp'));
 const util = require('gulp-util');
-
+const colors = require('ansi-colors');
 
 const year = new Date().getFullYear();
 
@@ -273,7 +273,7 @@ function getExamplesFile(name) {
 
 function makeExtension() {
   if (!argv.name) {
-    util.log(util.colors.red(
+    util.log(colors.red(
         'Error! Please pass in the "--name" flag with a value'));
   }
   const name = argv.name;

--- a/build-system/tasks/extension-generator/index.js
+++ b/build-system/tasks/extension-generator/index.js
@@ -20,6 +20,7 @@ const fs = require('fs-extra');
 const gulp = require('gulp-help')(require('gulp'));
 const util = require('gulp-util');
 const colors = require('ansi-colors');
+const log = require('fancy-log');
 
 const year = new Date().getFullYear();
 
@@ -273,7 +274,7 @@ function getExamplesFile(name) {
 
 function makeExtension() {
   if (!argv.name) {
-    util.log(colors.red(
+    log(colors.red(
         'Error! Please pass in the "--name" flag with a value'));
   }
   const name = argv.name;

--- a/build-system/tasks/gen-codeowners/index.js
+++ b/build-system/tasks/gen-codeowners/index.js
@@ -22,6 +22,7 @@ const intercept = require('gulp-intercept');
 const path = require('path');
 const minimist = require('minimist');
 const util = require('gulp-util');
+const log = require('fancy-log');
 
 const argv = minimist(process.argv.slice(2));
 
@@ -98,7 +99,7 @@ function generate(root, target, writeToDisk) {
           fs.writeFileSync(target, codeowners);
         } else {
           const codeowners = buildCodeownersFile(dirs);
-          util.log(codeowners);
+          log(codeowners);
         }
       });
 }

--- a/build-system/tasks/gen-codeowners/index.js
+++ b/build-system/tasks/gen-codeowners/index.js
@@ -21,7 +21,6 @@ const gulp = require('gulp-help')(require('gulp'));
 const intercept = require('gulp-intercept');
 const path = require('path');
 const minimist = require('minimist');
-const util = require('gulp-util');
 const log = require('fancy-log');
 
 const argv = minimist(process.argv.slice(2));

--- a/build-system/tasks/gen-codeowners/test.js
+++ b/build-system/tasks/gen-codeowners/test.js
@@ -22,6 +22,7 @@ const fs = BBPromise.promisifyAll(require('fs-extra'));
 const exec = require('child_process').execSync;
 const util = require('gulp-util');
 const colors = require('ansi-colors');
+const log = require('fancy-log');
 
 test('sync - build out correct CODEOWNERS', t => {
   const owners = {
@@ -60,7 +61,7 @@ test.skip('CODEOWNERS must be in sync with OWNERS.yaml', t => {
       'CODEOWNERS is out of sync. Please re-generate CODEOWNERS by ' +
       'running `gulp gen-codeowners`');
   if (!isInSync) {
-    util.log(colors.red('CODEOWNERS is out of sync. Please re-generate ' +
+    log(colors.red('CODEOWNERS is out of sync. Please re-generate ' +
         'CODEOWNERS by running `gulp gen-codeowners`'));
   }
   fs.removeSync(tmppath);

--- a/build-system/tasks/gen-codeowners/test.js
+++ b/build-system/tasks/gen-codeowners/test.js
@@ -20,7 +20,6 @@ const m = require('./');
 const BBPromise = require('bluebird');
 const fs = BBPromise.promisifyAll(require('fs-extra'));
 const exec = require('child_process').execSync;
-const util = require('gulp-util');
 const colors = require('ansi-colors');
 const log = require('fancy-log');
 

--- a/build-system/tasks/gen-codeowners/test.js
+++ b/build-system/tasks/gen-codeowners/test.js
@@ -21,6 +21,7 @@ const BBPromise = require('bluebird');
 const fs = BBPromise.promisifyAll(require('fs-extra'));
 const exec = require('child_process').execSync;
 const util = require('gulp-util');
+const colors = require('ansi-colors');
 
 test('sync - build out correct CODEOWNERS', t => {
   const owners = {
@@ -59,7 +60,7 @@ test.skip('CODEOWNERS must be in sync with OWNERS.yaml', t => {
       'CODEOWNERS is out of sync. Please re-generate CODEOWNERS by ' +
       'running `gulp gen-codeowners`');
   if (!isInSync) {
-    util.log(util.colors.red('CODEOWNERS is out of sync. Please re-generate ' +
+    util.log(colors.red('CODEOWNERS is out of sync. Please re-generate ' +
         'CODEOWNERS by running `gulp gen-codeowners`'));
   }
   fs.removeSync(tmppath);

--- a/build-system/tasks/get-zindex/index.js
+++ b/build-system/tasks/get-zindex/index.js
@@ -21,6 +21,7 @@ const gulp = require('gulp-help')(require('gulp'));
 const postcss = require('postcss');
 const table = require('text-table');
 const through = require('through2');
+const PluginError = require('plugin-error');
 
 const tableHeaders = [
   ['selector', 'z-index', 'file'],
@@ -66,7 +67,7 @@ function onFileThrough(file, enc, cb) {
   }
 
   if (file.isStream()) {
-    cb(new util.PluginError('size', 'Stream not supported'));
+    cb(new PluginError('size', 'Stream not supported'));
     return;
   }
 

--- a/build-system/tasks/get-zindex/index.js
+++ b/build-system/tasks/get-zindex/index.js
@@ -21,7 +21,6 @@ const gulp = require('gulp-help')(require('gulp'));
 const postcss = require('postcss');
 const table = require('text-table');
 const through = require('through2');
-const util = require('gulp-util');
 
 const tableHeaders = [
   ['selector', 'z-index', 'file'],

--- a/build-system/tasks/jsify-css.js
+++ b/build-system/tasks/jsify-css.js
@@ -22,6 +22,7 @@ const cssnano = require('cssnano');
 const fs = require('fs-extra');
 const postcss = require('postcss');
 const postcssImport = require('postcss-import');
+const colors = require('ansi-colors');
 
 // NOTE: see https://github.com/ai/browserslist#queries for `browsers` list
 const cssprefixer = autoprefixer({
@@ -86,7 +87,7 @@ const transformCss = exports.transformCss = function(filename, opt_cssnano) {
 exports.jsifyCssAsync = function(filename) {
   return transformCss(filename).then(function(result) {
     result.warnings().forEach(function(warn) {
-      $$.util.log($$.util.colors.red(warn.toString()));
+      $$.util.log(colors.red(warn.toString()));
     });
     const css = result.css;
     return css + '\n/*# sourceURL=/' + filename + '*/';

--- a/build-system/tasks/jsify-css.js
+++ b/build-system/tasks/jsify-css.js
@@ -23,6 +23,7 @@ const fs = require('fs-extra');
 const postcss = require('postcss');
 const postcssImport = require('postcss-import');
 const colors = require('ansi-colors');
+const log = require('fancy-log');
 
 // NOTE: see https://github.com/ai/browserslist#queries for `browsers` list
 const cssprefixer = autoprefixer({
@@ -87,7 +88,7 @@ const transformCss = exports.transformCss = function(filename, opt_cssnano) {
 exports.jsifyCssAsync = function(filename) {
   return transformCss(filename).then(function(result) {
     result.warnings().forEach(function(warn) {
-      $$.util.log(colors.red(warn.toString()));
+      log(colors.red(warn.toString()));
     });
     const css = result.css;
     return css + '\n/*# sourceURL=/' + filename + '*/';

--- a/build-system/tasks/jsify-css.js
+++ b/build-system/tasks/jsify-css.js
@@ -16,7 +16,6 @@
 'use strict';
 
 
-const $$ = require('gulp-load-plugins')();
 const autoprefixer = require('autoprefixer');
 const cssnano = require('cssnano');
 const fs = require('fs-extra');

--- a/build-system/tasks/json-check.js
+++ b/build-system/tasks/json-check.js
@@ -17,7 +17,6 @@
 
 const gulp = require('gulp-help')(require('gulp'));
 const jsonGlobs = require('../config').jsonGlobs;
-const util = require('gulp-util');
 const through2 = require('through2');
 const colors = require('ansi-colors');
 const log = require('fancy-log');

--- a/build-system/tasks/json-check.js
+++ b/build-system/tasks/json-check.js
@@ -19,6 +19,7 @@ const gulp = require('gulp-help')(require('gulp'));
 const jsonGlobs = require('../config').jsonGlobs;
 const util = require('gulp-util');
 const through2 = require('through2');
+const colors = require('ansi-colors');
 
 /**
  * Fail if JSON files are valid.
@@ -30,7 +31,7 @@ function checkValidJson() {
         try {
           JSON.parse(file.contents.toString());
         } catch (e) {
-          util.log(util.colors.red('Invalid JSON in '
+          util.log(colors.red('Invalid JSON in '
               + file.relative + ': ' + e.message));
           hasError = true;
         }

--- a/build-system/tasks/json-check.js
+++ b/build-system/tasks/json-check.js
@@ -20,6 +20,7 @@ const jsonGlobs = require('../config').jsonGlobs;
 const util = require('gulp-util');
 const through2 = require('through2');
 const colors = require('ansi-colors');
+const log = require('fancy-log');
 
 /**
  * Fail if JSON files are valid.
@@ -31,7 +32,7 @@ function checkValidJson() {
         try {
           JSON.parse(file.contents.toString());
         } catch (e) {
-          util.log(colors.red('Invalid JSON in '
+          log(colors.red('Invalid JSON in '
               + file.relative + ': ' + e.message));
           hasError = true;
         }

--- a/build-system/tasks/lint.js
+++ b/build-system/tasks/lint.js
@@ -22,7 +22,6 @@ const eslint = require('gulp-eslint');
 const gulp = require('gulp-help')(require('gulp'));
 const gulpIf = require('gulp-if');
 const lazypipe = require('lazypipe');
-const util = require('gulp-util');
 const watch = require('gulp-watch');
 const colors = require('ansi-colors');
 const log = require('fancy-log');

--- a/build-system/tasks/lint.js
+++ b/build-system/tasks/lint.js
@@ -25,6 +25,7 @@ const lazypipe = require('lazypipe');
 const util = require('gulp-util');
 const watch = require('gulp-watch');
 const colors = require('ansi-colors');
+const log = require('fancy-log');
 
 const isWatching = (argv.watch || argv.w) || false;
 
@@ -71,18 +72,18 @@ function runLinter(path, stream, options) {
   return stream.pipe(eslint(options))
       .pipe(eslint.formatEach('stylish', function(msg) {
         errorsFound = true;
-        util.log(msg);
+        log(msg);
       }))
       .pipe(gulpIf(isFixed, gulp.dest(path)))
       .pipe(eslint.failAfterError())
       .on('error', function() {
         if (errorsFound && !options.fix) {
-          util.log(colors.red('ERROR:'),
+          log(colors.red('ERROR:'),
               'Lint errors found.');
-          util.log(colors.yellow('NOTE:'),
+          log(colors.yellow('NOTE:'),
               'You can run', colors.cyan('gulp lint --fix'),
               'to automatically fix some of these lint errors.');
-          util.log(colors.yellow('WARNING:'),
+          log(colors.yellow('WARNING:'),
               'Since this is a destructive operation (operates on the file',
               'system), make sure you commit before running the command.');
         }

--- a/build-system/tasks/lint.js
+++ b/build-system/tasks/lint.js
@@ -24,6 +24,7 @@ const gulpIf = require('gulp-if');
 const lazypipe = require('lazypipe');
 const util = require('gulp-util');
 const watch = require('gulp-watch');
+const colors = require('ansi-colors');
 
 const isWatching = (argv.watch || argv.w) || false;
 
@@ -76,12 +77,12 @@ function runLinter(path, stream, options) {
       .pipe(eslint.failAfterError())
       .on('error', function() {
         if (errorsFound && !options.fix) {
-          util.log(util.colors.red('ERROR:'),
+          util.log(colors.red('ERROR:'),
               'Lint errors found.');
-          util.log(util.colors.yellow('NOTE:'),
-              'You can run', util.colors.cyan('gulp lint --fix'),
+          util.log(colors.yellow('NOTE:'),
+              'You can run', colors.cyan('gulp lint --fix'),
               'to automatically fix some of these lint errors.');
-          util.log(util.colors.yellow('WARNING:'),
+          util.log(colors.yellow('WARNING:'),
               'Since this is a destructive operation (operates on the file',
               'system), make sure you commit before running the command.');
         }

--- a/build-system/tasks/make-golden.js
+++ b/build-system/tasks/make-golden.js
@@ -23,7 +23,6 @@ const gulp = require('gulp');
 // imageDiff is currently a bad dependency as it has a fixed node 0.8 engine
 // requirement.
 const imageDiff = require('gulp-image-diff');
-const util = require('gulp-util');
 const colors = require('ansi-colors');
 const log = require('fancy-log');
 

--- a/build-system/tasks/make-golden.js
+++ b/build-system/tasks/make-golden.js
@@ -25,7 +25,7 @@ const gulp = require('gulp');
 const imageDiff = require('gulp-image-diff');
 const util = require('gulp-util');
 const colors = require('ansi-colors');
-
+const log = require('fancy-log');
 
 /**
  * Use phantomjs to take a screenshot of a page at the given url and save it
@@ -41,7 +41,7 @@ const colors = require('ansi-colors');
 function doScreenshot(host, path, output, device, verbose, cb) {
   fs.mkdirpSync(dirname(output));
   if (verbose) {
-    util.log('Output to: ', output);
+    log('Output to: ', output);
   }
   exec('phantomjs --ssl-protocol=any --ignore-ssl-errors=true ' +
        '--load-images=true ' +
@@ -52,13 +52,13 @@ function doScreenshot(host, path, output, device, verbose, cb) {
       '"' + device + '" ',
   function(err, stdout, stderr) {
     if (verbose) {
-      util.log(colors.gray('stdout: ', stdout));
+      log(colors.gray('stdout: ', stdout));
       if (stderr.length) {
-        util.log(colors.red('stderr: ', stderr));
+        log(colors.red('stderr: ', stderr));
       }
     }
     if (err != null) {
-      util.log(colors.red('exec error: ', err));
+      log(colors.red('exec error: ', err));
     }
     cb();
   });
@@ -140,26 +140,26 @@ function testScreenshots(cb) {
 
   let todo = goldenFiles.length;
   if (verbose) {
-    util.log('Diffs to be done: ', todo, goldenFiles);
+    log('Diffs to be done: ', todo, goldenFiles);
   }
   goldenFiles.forEach(function(file) {
     diffScreenshot_(file, dir, host, verbose, function(res) {
       reportRecord(reportFile, file, dir, res);
       if (res.error || res.disparity > 0) {
         errorCount++;
-        util.log(colors.red('Screenshot diff failed: ', file,
+        log(colors.red('Screenshot diff failed: ', file,
             JSON.stringify(res)));
       } else if (verbose) {
-        util.log(colors.green('Screenshot diff successful: ', file));
+        log(colors.green('Screenshot diff successful: ', file));
       }
 
       todo--;
       if (todo == 0) {
         reportPostambule(reportFile);
         if (errorCount == 0) {
-          util.log(colors.green('Screenshots tests successful'));
+          log(colors.green('Screenshots tests successful'));
         } else {
-          util.log(colors.red('Screenshots tests failed: ', errorCount,
+          log(colors.red('Screenshots tests failed: ', errorCount,
               reportFile));
           process.exit(1);
         }
@@ -180,7 +180,7 @@ function testScreenshots(cb) {
  */
 function diffScreenshot_(file, dir, host, verbose, cb) {
   if (verbose) {
-    util.log('Screenshot diff for ', file);
+    log('Screenshot diff for ', file);
   }
 
   const goldenFile = 'screenshots/' + file;
@@ -202,7 +202,7 @@ function diffScreenshot_(file, dir, host, verbose, cb) {
         .pipe(imageDiff.jsonReporter())
         .pipe(gulp.dest(diffFile + '.json'))
         .on('error', function(error) {
-          util.log(colors.red('Screenshot diff failed: ', file, error));
+          log(colors.red('Screenshot diff failed: ', file, error));
           cb({error});
         })
         .on('end', function() {

--- a/build-system/tasks/make-golden.js
+++ b/build-system/tasks/make-golden.js
@@ -24,6 +24,7 @@ const gulp = require('gulp');
 // requirement.
 const imageDiff = require('gulp-image-diff');
 const util = require('gulp-util');
+const colors = require('ansi-colors');
 
 
 /**
@@ -51,13 +52,13 @@ function doScreenshot(host, path, output, device, verbose, cb) {
       '"' + device + '" ',
   function(err, stdout, stderr) {
     if (verbose) {
-      util.log(util.colors.gray('stdout: ', stdout));
+      util.log(colors.gray('stdout: ', stdout));
       if (stderr.length) {
-        util.log(util.colors.red('stderr: ', stderr));
+        util.log(colors.red('stderr: ', stderr));
       }
     }
     if (err != null) {
-      util.log(util.colors.red('exec error: ', err));
+      util.log(colors.red('exec error: ', err));
     }
     cb();
   });
@@ -146,19 +147,19 @@ function testScreenshots(cb) {
       reportRecord(reportFile, file, dir, res);
       if (res.error || res.disparity > 0) {
         errorCount++;
-        util.log(util.colors.red('Screenshot diff failed: ', file,
+        util.log(colors.red('Screenshot diff failed: ', file,
             JSON.stringify(res)));
       } else if (verbose) {
-        util.log(util.colors.green('Screenshot diff successful: ', file));
+        util.log(colors.green('Screenshot diff successful: ', file));
       }
 
       todo--;
       if (todo == 0) {
         reportPostambule(reportFile);
         if (errorCount == 0) {
-          util.log(util.colors.green('Screenshots tests successful'));
+          util.log(colors.green('Screenshots tests successful'));
         } else {
-          util.log(util.colors.red('Screenshots tests failed: ', errorCount,
+          util.log(colors.red('Screenshots tests failed: ', errorCount,
               reportFile));
           process.exit(1);
         }
@@ -201,7 +202,7 @@ function diffScreenshot_(file, dir, host, verbose, cb) {
         .pipe(imageDiff.jsonReporter())
         .pipe(gulp.dest(diffFile + '.json'))
         .on('error', function(error) {
-          util.log(util.colors.red('Screenshot diff failed: ', file, error));
+          util.log(colors.red('Screenshot diff failed: ', file, error));
           cb({error});
         })
         .on('end', function() {

--- a/build-system/tasks/prepend-global/index.js
+++ b/build-system/tasks/prepend-global/index.js
@@ -22,9 +22,10 @@ const exec = BBPromise.promisify(childProcess.exec);
 const fs = BBPromise.promisifyAll(require('fs'));
 const gulp = require('gulp-help')(require('gulp'));
 const util = require('gulp-util');
+const colors = require('ansi-colors');
 
-const red = util.colors.red;
-const cyan = util.colors.cyan;
+const red = colors.red;
+const cyan = colors.cyan;
 
 /**
  * Returns the number of AMP_CONFIG matches in the given config string.

--- a/build-system/tasks/prepend-global/index.js
+++ b/build-system/tasks/prepend-global/index.js
@@ -23,6 +23,7 @@ const fs = BBPromise.promisifyAll(require('fs'));
 const gulp = require('gulp-help')(require('gulp'));
 const util = require('gulp-util');
 const colors = require('ansi-colors');
+const log = require('fancy-log');
 
 const red = colors.red;
 const cyan = colors.cyan;
@@ -93,8 +94,8 @@ function prependConfig(configString, fileString) {
  */
 function writeTarget(filename, fileString, opt_dryrun) {
   if (opt_dryrun) {
-    util.log(cyan(`overwriting: ${filename}`));
-    util.log(fileString);
+    log(cyan(`overwriting: ${filename}`));
+    log(fileString);
     return Promise.resolve();
   }
   return fs.writeFileAsync(filename, fileString);
@@ -135,7 +136,7 @@ function applyConfig(
         try {
           configJson = JSON.parse(files[0].toString());
         } catch (e) {
-          util.log(red(`Error parsing config file: ${filename}`));
+          log(red(`Error parsing config file: ${filename}`));
           throw e;
         }
         if (opt_localDev) {
@@ -151,7 +152,7 @@ function applyConfig(
       })
       .then(() => {
         if (!process.env.TRAVIS) {
-          util.log('Wrote', cyan(config), 'AMP config to', cyan(target));
+          log('Wrote', cyan(config), 'AMP config to', cyan(target));
         }
       });
 }
@@ -165,7 +166,7 @@ function applyConfig(
 function enableLocalDev(config, target, configJson) {
   let LOCAL_DEV_AMP_CONFIG = {localDev: true};
   if (!process.env.TRAVIS) {
-    util.log('Enabled local development mode in', cyan(target));
+    log('Enabled local development mode in', cyan(target));
   }
   const TESTING_HOST = process.env.AMP_TESTING_HOST;
   if (typeof TESTING_HOST == 'string') {
@@ -175,7 +176,7 @@ function enableLocalDev(config, target, configJson) {
       thirdPartyFrameRegex: TESTING_HOST,
     });
     if (!process.env.TRAVIS) {
-      util.log('Set', cyan('TESTING_HOST'), 'to', cyan(TESTING_HOST),
+      log('Set', cyan('TESTING_HOST'), 'to', cyan(TESTING_HOST),
           'in', cyan(target));
     }
   }
@@ -192,7 +193,7 @@ function removeConfig(target) {
         let contents = file.toString();
         if (numConfigs(contents) == 0) {
           if (!process.env.TRAVIS) {
-            util.log('No configs found in', cyan(target));
+            log('No configs found in', cyan(target));
           }
           return Promise.resolve();
         }
@@ -202,7 +203,7 @@ function removeConfig(target) {
         contents = contents.replace(config, '');
         return writeTarget(target, contents, argv.dryrun).then(() => {
           if (!process.env.TRAVIS) {
-            util.log('Removed existing config from', cyan(target));
+            log('Removed existing config from', cyan(target));
           }
         });
       });
@@ -213,7 +214,7 @@ function main() {
   const target = argv.target || TESTING_HOST;
 
   if (!target) {
-    util.log(red('Missing --target.'));
+    log(red('Missing --target.'));
     return;
   }
 
@@ -222,7 +223,7 @@ function main() {
   }
 
   if (!(argv.prod || argv.canary)) {
-    util.log(red('One of --prod or --canary should be provided.'));
+    log(red('One of --prod or --canary should be provided.'));
     return;
   }
 

--- a/build-system/tasks/prepend-global/index.js
+++ b/build-system/tasks/prepend-global/index.js
@@ -21,7 +21,6 @@ const childProcess = require('child_process');
 const exec = BBPromise.promisify(childProcess.exec);
 const fs = BBPromise.promisifyAll(require('fs'));
 const gulp = require('gulp-help')(require('gulp'));
-const util = require('gulp-util');
 const colors = require('ansi-colors');
 const log = require('fancy-log');
 

--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -18,7 +18,6 @@
 const gulp = require('gulp-help')(require('gulp'));
 const path = require('path');
 const srcGlobs = require('../config').presubmitGlobs;
-const util = require('gulp-util');
 const through2 = require('through2');
 const colors = require('ansi-colors');
 const log = require('fancy-log');

--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -70,6 +70,11 @@ const forbiddenTerms = {
   'describes.*\\.only': '',
   'it\\.only': '',
   'Math\.random[^;()]*=': 'Use Sinon to stub!!!',
+  'gulp-util': {
+    message: '`gulp-util` will be deprecated soon. See ' +
+        'https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5 ' +
+        'for a list of alternatives.',
+  },
   'sinon\\.(spy|stub|mock)\\(': {
     message: 'Use a sandbox instead to avoid repeated `#restore` calls',
   },

--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -21,6 +21,7 @@ const srcGlobs = require('../config').presubmitGlobs;
 const util = require('gulp-util');
 const through2 = require('through2');
 const colors = require('ansi-colors');
+const log = require('fancy-log');
 
 const dedicatedCopyrightNoteSources = /(\.js|\.css|\.go)$/;
 
@@ -947,7 +948,7 @@ function matchTerms(file, terms) {
         }
       }
 
-      util.log(colors.red('Found forbidden: "' + match[0] +
+      log(colors.red('Found forbidden: "' + match[0] +
           '" in ' + relative + ':' + line + ':' + column));
       if (typeof terms[term] === 'string') {
         fix = terms[term];
@@ -957,9 +958,9 @@ function matchTerms(file, terms) {
 
       // log the possible fix information if provided for the term.
       if (fix) {
-        util.log(colors.blue(fix));
+        log(colors.blue(fix));
       }
-      util.log(colors.blue('=========='));
+      log(colors.blue('=========='));
     }
 
     return hasTerm;
@@ -1022,9 +1023,9 @@ function isMissingTerms(file) {
 
     const matches = contents.match(new RegExp(term));
     if (!matches) {
-      util.log(colors.red('Did not find required: "' + term +
+      log(colors.red('Did not find required: "' + term +
           '" in ' + file.relative));
-      util.log(colors.blue('=========='));
+      log(colors.blue('=========='));
       return true;
     }
     return false;
@@ -1048,11 +1049,11 @@ function checkForbiddenAndRequiredTerms() {
       }))
       .on('end', function() {
         if (forbiddenFound) {
-          util.log(colors.blue(
+          log(colors.blue(
               'Please remove these usages or consult with the AMP team.'));
         }
         if (missingRequirements) {
-          util.log(colors.blue(
+          log(colors.blue(
               'Adding these terms (e.g. by adding a required LICENSE ' +
             'to the file)'));
         }

--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -20,6 +20,7 @@ const path = require('path');
 const srcGlobs = require('../config').presubmitGlobs;
 const util = require('gulp-util');
 const through2 = require('through2');
+const colors = require('ansi-colors');
 
 const dedicatedCopyrightNoteSources = /(\.js|\.css|\.go)$/;
 
@@ -946,7 +947,7 @@ function matchTerms(file, terms) {
         }
       }
 
-      util.log(util.colors.red('Found forbidden: "' + match[0] +
+      util.log(colors.red('Found forbidden: "' + match[0] +
           '" in ' + relative + ':' + line + ':' + column));
       if (typeof terms[term] === 'string') {
         fix = terms[term];
@@ -956,9 +957,9 @@ function matchTerms(file, terms) {
 
       // log the possible fix information if provided for the term.
       if (fix) {
-        util.log(util.colors.blue(fix));
+        util.log(colors.blue(fix));
       }
-      util.log(util.colors.blue('=========='));
+      util.log(colors.blue('=========='));
     }
 
     return hasTerm;
@@ -1021,9 +1022,9 @@ function isMissingTerms(file) {
 
     const matches = contents.match(new RegExp(term));
     if (!matches) {
-      util.log(util.colors.red('Did not find required: "' + term +
+      util.log(colors.red('Did not find required: "' + term +
           '" in ' + file.relative));
-      util.log(util.colors.blue('=========='));
+      util.log(colors.blue('=========='));
       return true;
     }
     return false;
@@ -1047,11 +1048,11 @@ function checkForbiddenAndRequiredTerms() {
       }))
       .on('end', function() {
         if (forbiddenFound) {
-          util.log(util.colors.blue(
+          util.log(colors.blue(
               'Please remove these usages or consult with the AMP team.'));
         }
         if (missingRequirements) {
-          util.log(util.colors.blue(
+          util.log(colors.blue(
               'Adding these terms (e.g. by adding a required LICENSE ' +
             'to the file)'));
         }

--- a/build-system/tasks/process-github-issues.js
+++ b/build-system/tasks/process-github-issues.js
@@ -20,7 +20,6 @@ const assert = require('assert');
 const extend = require('util')._extend;
 const gulp = require('gulp-help')(require('gulp'));
 const request = BBPromise.promisify(require('request'));
-const util = require('gulp-util');
 const colors = require('ansi-colors');
 const log = require('fancy-log');
 

--- a/build-system/tasks/process-github-issues.js
+++ b/build-system/tasks/process-github-issues.js
@@ -21,6 +21,7 @@ const extend = require('util')._extend;
 const gulp = require('gulp-help')(require('gulp'));
 const request = BBPromise.promisify(require('request'));
 const util = require('gulp-util');
+const colors = require('ansi-colors');
 
 const GITHUB_ACCESS_TOKEN = process.env.GITHUB_ACCESS_TOKEN;
 
@@ -72,16 +73,16 @@ const NUM_BATCHES = 14;
 // We start processing the issues by checking token first
 function processIssues() {
   if (!GITHUB_ACCESS_TOKEN) {
-    util.log(util.colors.red('You have not set the ' +
+    util.log(colors.red('You have not set the ' +
         'GITHUB_ACCESS_TOKEN env var.'));
-    util.log(util.colors.green('See https://help.github.com/articles/' +
+    util.log(colors.green('See https://help.github.com/articles/' +
         'creating-an-access-token-for-command-line-use/ ' +
         'for instructions on how to create a github access token. We only ' +
         'need `public_repo` scope.'));
     return;
   }
   return updateGitHubIssues().then(function() {
-    util.log(util.colors.blue('automation applied'));
+    util.log(colors.blue('automation applied'));
   });
 }
 /**
@@ -139,7 +140,7 @@ function updateGitHubIssues() {
           // if an issue is a pull request, we'll skip it
           if (pullRequest) {
             if (isDryrun) {
-              util.log(util.colors.red(issue.number + ' is a pull request'));
+              util.log(colors.red(issue.number + ' is a pull request'));
             }
             return;
           }
@@ -261,7 +262,7 @@ function updateGitHubIssues() {
                   issueNewMilestone == null ||
                   issueNewMilestone === MILESTONE_GREAT_ISSUES) {
                 if (isDryrun) {
-                  util.log(util.colors.green('No comment needed '
+                  util.log(colors.green('No comment needed '
                       + ' for #' + issue.number));
                 }
               } else {
@@ -293,7 +294,7 @@ function applyMilestone(issue, milestoneNumber) {
 
   issue.milestone = milestoneNumber;
   if (isDryrun) {
-    util.log(util.colors.green('Milestone applied ' + milestoneNumber +
+    util.log(colors.green('Milestone applied ' + milestoneNumber +
         ' for #' + issue.number));
     return;
   } else {
@@ -315,7 +316,7 @@ function applyLabel(issue, label) {
     'access_token': GITHUB_ACCESS_TOKEN,
   };
   if (isDryrun) {
-    util.log(util.colors.green('Label applied ' +
+    util.log(colors.green('Label applied ' +
         label + ' for #' + issue.number));
     return;
   } else {
@@ -341,8 +342,8 @@ function applyComment(issue, comment) {
   const promise = new Promise(resolve => setTimeout(resolve, 120000));
   return promise.then(function() {
     if (isDryrun) {
-      util.log(util.colors.blue('waited 2 minutes to avoid gh rate limits'));
-      util.log(util.colors.green('Comment applied after ' +
+      util.log(colors.blue('waited 2 minutes to avoid gh rate limits'));
+      util.log(colors.green('Comment applied after ' +
           'waiting 2 minutes to avoid github rate limits: ' + comment +
           ' for #' + issue.number));
       return;

--- a/build-system/tasks/process-github-issues.js
+++ b/build-system/tasks/process-github-issues.js
@@ -22,6 +22,7 @@ const gulp = require('gulp-help')(require('gulp'));
 const request = BBPromise.promisify(require('request'));
 const util = require('gulp-util');
 const colors = require('ansi-colors');
+const log = require('fancy-log');
 
 const GITHUB_ACCESS_TOKEN = process.env.GITHUB_ACCESS_TOKEN;
 
@@ -73,16 +74,16 @@ const NUM_BATCHES = 14;
 // We start processing the issues by checking token first
 function processIssues() {
   if (!GITHUB_ACCESS_TOKEN) {
-    util.log(colors.red('You have not set the ' +
+    log(colors.red('You have not set the ' +
         'GITHUB_ACCESS_TOKEN env var.'));
-    util.log(colors.green('See https://help.github.com/articles/' +
+    log(colors.green('See https://help.github.com/articles/' +
         'creating-an-access-token-for-command-line-use/ ' +
         'for instructions on how to create a github access token. We only ' +
         'need `public_repo` scope.'));
     return;
   }
   return updateGitHubIssues().then(function() {
-    util.log(colors.blue('automation applied'));
+    log(colors.blue('automation applied'));
   });
 }
 /**
@@ -140,7 +141,7 @@ function updateGitHubIssues() {
           // if an issue is a pull request, we'll skip it
           if (pullRequest) {
             if (isDryrun) {
-              util.log(colors.red(issue.number + ' is a pull request'));
+              log(colors.red(issue.number + ' is a pull request'));
             }
             return;
           }
@@ -162,7 +163,7 @@ function updateGitHubIssues() {
           }
           // promise starts
           promise = promise.then(function() {
-            util.log('Update ' + issue.number);
+            log('Update ' + issue.number);
             const updates = [];
             // Get the labels we want to check
             labels.forEach(function(label) {
@@ -262,7 +263,7 @@ function updateGitHubIssues() {
                   issueNewMilestone == null ||
                   issueNewMilestone === MILESTONE_GREAT_ISSUES) {
                 if (isDryrun) {
-                  util.log(colors.green('No comment needed '
+                  log(colors.green('No comment needed '
                       + ' for #' + issue.number));
                 }
               } else {
@@ -294,7 +295,7 @@ function applyMilestone(issue, milestoneNumber) {
 
   issue.milestone = milestoneNumber;
   if (isDryrun) {
-    util.log(colors.green('Milestone applied ' + milestoneNumber +
+    log(colors.green('Milestone applied ' + milestoneNumber +
         ' for #' + issue.number));
     return;
   } else {
@@ -316,7 +317,7 @@ function applyLabel(issue, label) {
     'access_token': GITHUB_ACCESS_TOKEN,
   };
   if (isDryrun) {
-    util.log(colors.green('Label applied ' +
+    log(colors.green('Label applied ' +
         label + ' for #' + issue.number));
     return;
   } else {
@@ -342,8 +343,8 @@ function applyComment(issue, comment) {
   const promise = new Promise(resolve => setTimeout(resolve, 120000));
   return promise.then(function() {
     if (isDryrun) {
-      util.log(colors.blue('waited 2 minutes to avoid gh rate limits'));
-      util.log(colors.green('Comment applied after ' +
+      log(colors.blue('waited 2 minutes to avoid gh rate limits'));
+      log(colors.green('Comment applied after ' +
           'waiting 2 minutes to avoid github rate limits: ' + comment +
           ' for #' + issue.number));
       return;

--- a/build-system/tasks/release-tagging.js
+++ b/build-system/tasks/release-tagging.js
@@ -23,6 +23,7 @@ const gulp = require('gulp-help')(require('gulp'));
 const request = BBPromise.promisify(require('request'));
 const util = require('gulp-util');
 const colors = require('ansi-colors');
+const log = require('fancy-log');
 
 const GITHUB_ACCESS_TOKEN = process.env.GITHUB_ACCESS_TOKEN;
 const gitExec = BBPromise.promisify(git.exec);
@@ -42,7 +43,7 @@ const LABELS = {
  * @return {!Promise}
  */
 function releaseTagFor(type, dir) {
-  util.log('Tag release for: ', type);
+  log('Tag release for: ', type);
   let promise = Promise.resolve();
   const ampDir = dir + '/amphtml';
 
@@ -64,7 +65,7 @@ function releaseTagFor(type, dir) {
 
   // Checkout tag.
   promise = promise.then(function() {
-    util.log('Git tag: ', tag);
+    log('Git tag: ', tag);
     return gitExec({
       cwd: ampDir,
       args: 'checkout ' + tag,
@@ -100,7 +101,7 @@ function releaseTagFor(type, dir) {
   // Update.
   const label = LABELS[type];
   promise = promise.then(function() {
-    util.log('Update ' + pullRequests.length + ' pull requests');
+    log('Update ' + pullRequests.length + ' pull requests');
     const updates = [];
     pullRequests.forEach(function(pullRequest) {
       updates.push(applyLabel(pullRequest, label));
@@ -109,7 +110,7 @@ function releaseTagFor(type, dir) {
   });
 
   return promise.then(function() {
-    util.log(colors.green('Tag release for ' + type + ' done.'));
+    log(colors.green('Tag release for ' + type + ' done.'));
   });
 }
 
@@ -120,7 +121,7 @@ function releaseTagFor(type, dir) {
  */
 function applyLabel(pullRequest, label) {
   if (verbose && isDryrun) {
-    util.log('Apply label ' + label + ' for #' + pullRequest);
+    log('Apply label ' + label + ' for #' + pullRequest);
   }
   if (isDryrun) {
     return Promise.resolve();
@@ -130,7 +131,7 @@ function applyLabel(pullRequest, label) {
       'POST',
       [label]).then(function() {
     if (verbose) {
-      util.log(colors.green(
+      log(colors.green(
           'Label applied ' + label + ' for #' + pullRequest));
     }
   });
@@ -193,7 +194,7 @@ function releaseTag() {
   let promise = Promise.resolve();
 
   const dir = 'build/tagging';
-  util.log('Work dir: ', dir);
+  log('Work dir: ', dir);
   fs.mkdirpSync(dir);
   promise = promise.then(function() {
     return gitFetch(dir);

--- a/build-system/tasks/release-tagging.js
+++ b/build-system/tasks/release-tagging.js
@@ -21,7 +21,6 @@ const fs = require('fs-extra');
 const git = require('gulp-git');
 const gulp = require('gulp-help')(require('gulp'));
 const request = BBPromise.promisify(require('request'));
-const util = require('gulp-util');
 const colors = require('ansi-colors');
 const log = require('fancy-log');
 

--- a/build-system/tasks/release-tagging.js
+++ b/build-system/tasks/release-tagging.js
@@ -22,6 +22,7 @@ const git = require('gulp-git');
 const gulp = require('gulp-help')(require('gulp'));
 const request = BBPromise.promisify(require('request'));
 const util = require('gulp-util');
+const colors = require('ansi-colors');
 
 const GITHUB_ACCESS_TOKEN = process.env.GITHUB_ACCESS_TOKEN;
 const gitExec = BBPromise.promisify(git.exec);
@@ -108,7 +109,7 @@ function releaseTagFor(type, dir) {
   });
 
   return promise.then(function() {
-    util.log(util.colors.green('Tag release for ' + type + ' done.'));
+    util.log(colors.green('Tag release for ' + type + ' done.'));
   });
 }
 
@@ -129,7 +130,7 @@ function applyLabel(pullRequest, label) {
       'POST',
       [label]).then(function() {
     if (verbose) {
-      util.log(util.colors.green(
+      util.log(colors.green(
           'Label applied ' + label + ' for #' + pullRequest));
     }
   });

--- a/build-system/tasks/runtime-test.js
+++ b/build-system/tasks/runtime-test.js
@@ -154,13 +154,13 @@ function printArgvMessages() {
         cyan(argv.grep) + '".',
   };
   if (!process.env.TRAVIS) {
-    log(green('Run', cyan('gulp help'),
-        'to see a list of all test flags. (Use', cyan('--nohelp'),
-        'to silence these messages.)'));
+    log(green('Run'), cyan('gulp help'),
+        green('to see a list of all test flags. (Use'), cyan('--nohelp'),
+        green('to silence these messages.)'));
     if (!argv.unit && !argv.integration && !argv.files) {
-      log(green('Running all tests. Use',
-          cyan('--unit'), 'or', cyan('--integration'),
-          'to run just the unit tests or integration tests.'));
+      log(green('Running all tests. Use'),
+          cyan('--unit'), green('or'), cyan('--integration'),
+          green('to run just the unit tests or integration tests.'));
     }
     if (!argv.compiled) {
       log(green('Running tests against unminified code.'));

--- a/build-system/tasks/runtime-test.js
+++ b/build-system/tasks/runtime-test.js
@@ -30,6 +30,7 @@ const app = require('../test-server').app;
 const karmaDefault = require('./karma.conf');
 const shuffleSeed = require('shuffle-seed');
 const colors = require('ansi-colors');
+const log = require('fancy-log');
 
 
 const green = colors.green;
@@ -154,22 +155,22 @@ function printArgvMessages() {
         cyan(argv.grep) + '".',
   };
   if (!process.env.TRAVIS) {
-    util.log(green('Run', cyan('gulp help'),
+    log(green('Run', cyan('gulp help'),
         'to see a list of all test flags. (Use', cyan('--nohelp'),
         'to silence these messages.)'));
     if (!argv.unit && !argv.integration && !argv.files) {
-      util.log(green('Running all tests. Use',
+      log(green('Running all tests. Use',
           cyan('--unit'), 'or', cyan('--integration'),
           'to run just the unit tests or integration tests.'));
     }
     if (!argv.compiled) {
-      util.log(green('Running tests against unminified code.'));
+      log(green('Running tests against unminified code.'));
     }
-    util.log(green('Setting the runtime\'s AMP config to'), cyan(ampConfig));
+    log(green('Setting the runtime\'s AMP config to'), cyan(ampConfig));
     Object.keys(argv).forEach(arg => {
       const message = argvMessages[arg];
       if (message) {
-        util.log(yellow('--' + arg + ':'), green(message));
+        log(yellow('--' + arg + ':'), green(message));
       }
     });
   }
@@ -218,9 +219,9 @@ function runTests() {
   }
 
   if (argv.saucelabs && !argv.integration) {
-    util.log(red('Only integration tests may be run on the full set of ' +
+    log(red('Only integration tests may be run on the full set of ' +
         'Sauce Labs browsers'));
-    util.log(
+    log(
         red('Use'), cyan('--saucelabs'), red('with'), cyan('--integration'));
     process.exit();
   }
@@ -253,10 +254,10 @@ function runTests() {
 
     if (argv.randomize || argv.a4a) {
       const seed = argv.seed || Math.random();
-      util.log(
+      log(
           yellow('Randomizing:'),
           cyan('Seeding with value', seed));
-      util.log(
+      log(
           yellow('To rerun same ordering, append'),
           cyan(`--seed=${seed}`),
           yellow('to your invocation of'),
@@ -297,7 +298,7 @@ function runTests() {
   }
 
   if (argv.coverage) {
-    util.log(cyan('Including code coverage tests'));
+    log(cyan('Including code coverage tests'));
     c.browserify.transform.push(
         ['browserify-istanbul', {instrumenterConfig: {embedSource: true}}]);
     c.reporters = c.reporters.concat(['progress', 'coverage']);
@@ -334,13 +335,13 @@ function runTests() {
         middleware: [app],
       })
           .on('kill', function() {
-            util.log(yellow(
+            log(yellow(
                 'Shutting down test responses server on localhost:31862'));
             process.nextTick(function() {
               process.exit();
             });
           }));
-  util.log(yellow(
+  log(yellow(
       'Started test responses server on localhost:31862'));
 
   let resolver;
@@ -348,7 +349,7 @@ function runTests() {
   new Karma(c, function(exitCode) {
     server.emit('kill');
     if (exitCode) {
-      util.log(
+      log(
           red('ERROR:'),
           yellow('Karma test failed with exit code', exitCode));
       process.exit(exitCode);

--- a/build-system/tasks/runtime-test.js
+++ b/build-system/tasks/runtime-test.js
@@ -29,12 +29,13 @@ const webserver = require('gulp-webserver');
 const app = require('../test-server').app;
 const karmaDefault = require('./karma.conf');
 const shuffleSeed = require('shuffle-seed');
+const colors = require('ansi-colors');
 
 
-const green = util.colors.green;
-const yellow = util.colors.yellow;
-const cyan = util.colors.cyan;
-const red = util.colors.red;
+const green = colors.green;
+const yellow = colors.yellow;
+const cyan = colors.cyan;
+const red = colors.red;
 
 const preTestTasks = argv.nobuild ? [] : (argv.unit ? ['css'] : ['build']);
 const ampConfig = (argv.config === 'canary') ? 'canary' : 'prod';

--- a/build-system/tasks/runtime-test.js
+++ b/build-system/tasks/runtime-test.js
@@ -24,7 +24,6 @@ const applyConfig = require('./prepend-global/index.js').applyConfig;
 const removeConfig = require('./prepend-global/index.js').removeConfig;
 const fs = require('fs');
 const path = require('path');
-const util = require('gulp-util');
 const webserver = require('gulp-webserver');
 const app = require('../test-server').app;
 const karmaDefault = require('./karma.conf');

--- a/build-system/tasks/serve.js
+++ b/build-system/tasks/serve.js
@@ -20,6 +20,7 @@ const gulp = require('gulp-help')(require('gulp'));
 const util = require('gulp-util');
 const nodemon = require('nodemon');
 const colors = require('ansi-colors');
+const log = require('fancy-log');
 
 const host = argv.host || 'localhost';
 const port = argv.port || process.env.PORT || 8000;
@@ -34,13 +35,13 @@ function serve() {
   // Get the serve mode
   if (argv.compiled) {
     process.env.SERVE_MODE = 'compiled';
-    util.log(colors.green('Serving minified js'));
+    log(colors.green('Serving minified js'));
   } else if (argv.cdn) {
     process.env.SERVE_MODE = 'cdn';
-    util.log(colors.green('Serving current prod js'));
+    log(colors.green('Serving current prod js'));
   } else {
     process.env.SERVE_MODE = 'default';
-    util.log(colors.green('Serving unminified js'));
+    log(colors.green('Serving unminified js'));
   }
 
   nodemon({
@@ -61,10 +62,10 @@ function serve() {
     stdout: !quiet,
   })
       .once('quit', function() {
-        util.log(colors.green('Shutting down server'));
+        log(colors.green('Shutting down server'));
       });
   if (!quiet) {
-    util.log(colors.yellow('Run `gulp build` then go to '
+    log(colors.yellow('Run `gulp build` then go to '
         + getHost() + '/examples/article.amp.html'
     ));
   }

--- a/build-system/tasks/serve.js
+++ b/build-system/tasks/serve.js
@@ -19,6 +19,7 @@ const argv = require('minimist')(process.argv.slice(2));
 const gulp = require('gulp-help')(require('gulp'));
 const util = require('gulp-util');
 const nodemon = require('nodemon');
+const colors = require('ansi-colors');
 
 const host = argv.host || 'localhost';
 const port = argv.port || process.env.PORT || 8000;
@@ -33,13 +34,13 @@ function serve() {
   // Get the serve mode
   if (argv.compiled) {
     process.env.SERVE_MODE = 'compiled';
-    util.log(util.colors.green('Serving minified js'));
+    util.log(colors.green('Serving minified js'));
   } else if (argv.cdn) {
     process.env.SERVE_MODE = 'cdn';
-    util.log(util.colors.green('Serving current prod js'));
+    util.log(colors.green('Serving current prod js'));
   } else {
     process.env.SERVE_MODE = 'default';
-    util.log(util.colors.green('Serving unminified js'));
+    util.log(colors.green('Serving unminified js'));
   }
 
   nodemon({
@@ -60,10 +61,10 @@ function serve() {
     stdout: !quiet,
   })
       .once('quit', function() {
-        util.log(util.colors.green('Shutting down server'));
+        util.log(colors.green('Shutting down server'));
       });
   if (!quiet) {
-    util.log(util.colors.yellow('Run `gulp build` then go to '
+    util.log(colors.yellow('Run `gulp build` then go to '
         + getHost() + '/examples/article.amp.html'
     ));
   }

--- a/build-system/tasks/serve.js
+++ b/build-system/tasks/serve.js
@@ -17,7 +17,6 @@
 
 const argv = require('minimist')(process.argv.slice(2));
 const gulp = require('gulp-help')(require('gulp'));
-const util = require('gulp-util');
 const nodemon = require('nodemon');
 const colors = require('ansi-colors');
 const log = require('fancy-log');

--- a/build-system/tasks/size.js
+++ b/build-system/tasks/size.js
@@ -22,6 +22,7 @@ const gzipSize = require('gzip-size');
 const prettyBytes = require('pretty-bytes');
 const table = require('text-table');
 const through = require('through2');
+const PluginError = require('plugin-error');
 
 
 const tempFolderName = '__size-temp';
@@ -172,7 +173,7 @@ function onFileThrough(rows, file, enc, cb) {
   }
 
   if (file.isStream()) {
-    cb(new util.PluginError('size', 'Stream not supported'));
+    cb(new PluginError('size', 'Stream not supported'));
     return;
   }
 

--- a/build-system/tasks/size.js
+++ b/build-system/tasks/size.js
@@ -22,7 +22,6 @@ const gzipSize = require('gzip-size');
 const prettyBytes = require('pretty-bytes');
 const table = require('text-table');
 const through = require('through2');
-const util = require('gulp-util');
 
 
 const tempFolderName = '__size-temp';

--- a/build-system/tasks/todos.js
+++ b/build-system/tasks/todos.js
@@ -18,7 +18,6 @@
 const BBPromise = require('bluebird');
 const gulp = require('gulp-help')(require('gulp'));
 const srcGlobs = require('../config').presubmitGlobs;
-const util = require('gulp-util');
 const through2 = require('through2');
 const request = BBPromise.promisify(require('request'));
 const colors = require('ansi-colors');

--- a/build-system/tasks/todos.js
+++ b/build-system/tasks/todos.js
@@ -21,6 +21,7 @@ const srcGlobs = require('../config').presubmitGlobs;
 const util = require('gulp-util');
 const through2 = require('through2');
 const request = BBPromise.promisify(require('request'));
+const colors = require('ansi-colors');
 
 const GITHUB_ACCESS_TOKEN = process.env.GITHUB_ACCESS_TOKEN;
 
@@ -60,7 +61,7 @@ function findClosedTodosInFile(file) {
       return acc + v;
     }, 0);
   }).catch(function(error) {
-    util.log(util.colors.red('Failed in', file.path, error, error.stack));
+    util.log(colors.red('Failed in', file.path, error, error.stack));
     return 0;
   });
 }
@@ -81,7 +82,7 @@ function reportClosedIssue(file, issueId, todo) {
         const issue = JSON.parse(response.body);
         const value = issue.state == 'closed' ? 1 : 0;
         if (value) {
-          util.log(util.colors.red(todo, 'in', file.path));
+          util.log(colors.red(todo, 'in', file.path));
         }
         return value;
       });
@@ -130,7 +131,7 @@ function findClosedTodosTask() {
       }))
       .on('end', function() {
         if (foundCount > 0) {
-          util.log(util.colors.red('Found closed TODOs: ', foundCount));
+          util.log(colors.red('Found closed TODOs: ', foundCount));
           process.exit(1);
         }
       });

--- a/build-system/tasks/todos.js
+++ b/build-system/tasks/todos.js
@@ -22,6 +22,7 @@ const util = require('gulp-util');
 const through2 = require('through2');
 const request = BBPromise.promisify(require('request'));
 const colors = require('ansi-colors');
+const log = require('fancy-log');
 
 const GITHUB_ACCESS_TOKEN = process.env.GITHUB_ACCESS_TOKEN;
 
@@ -61,7 +62,7 @@ function findClosedTodosInFile(file) {
       return acc + v;
     }, 0);
   }).catch(function(error) {
-    util.log(colors.red('Failed in', file.path, error, error.stack));
+    log(colors.red('Failed in', file.path, error, error.stack));
     return 0;
   });
 }
@@ -82,7 +83,7 @@ function reportClosedIssue(file, issueId, todo) {
         const issue = JSON.parse(response.body);
         const value = issue.state == 'closed' ? 1 : 0;
         if (value) {
-          util.log(colors.red(todo, 'in', file.path));
+          log(colors.red(todo, 'in', file.path));
         }
         return value;
       });
@@ -131,7 +132,7 @@ function findClosedTodosTask() {
       }))
       .on('end', function() {
         if (foundCount > 0) {
-          util.log(colors.red('Found closed TODOs: ', foundCount));
+          log(colors.red('Found closed TODOs: ', foundCount));
           process.exit(1);
         }
       });

--- a/build-system/tasks/update-packages.js
+++ b/build-system/tasks/update-packages.js
@@ -20,6 +20,7 @@ const getStderr = require('../exec').getStderr;
 const gulp = require('gulp-help')(require('gulp'));
 const util = require('gulp-util');
 const colors = require('ansi-colors');
+const log = require('fancy-log');
 
 
 /**
@@ -28,17 +29,17 @@ const colors = require('ansi-colors');
 function updatePackages() {
   const integrityCmd = 'yarn check --integrity';
   if (getStderr(integrityCmd).trim() != '') {
-    util.log(colors.yellow('WARNING:'), 'The packages in',
+    log(colors.yellow('WARNING:'), 'The packages in',
         colors.cyan('node_modules'), 'do not match',
         colors.cyan('package.json.'));
     const verifyTreeCmd = 'yarn check --verify-tree';
     exec(verifyTreeCmd);
-    util.log('Running', colors.cyan('yarn'), 'to update packages...');
+    log('Running', colors.cyan('yarn'), 'to update packages...');
     const yarnCmd = 'yarn';
     exec(yarnCmd);
   } else {
     if (!process.env.TRAVIS) {
-      util.log(colors.green('All packages in',
+      log(colors.green('All packages in',
           colors.cyan('node_modules'), 'are up to date.'));
     }
   }

--- a/build-system/tasks/update-packages.js
+++ b/build-system/tasks/update-packages.js
@@ -38,8 +38,8 @@ function updatePackages() {
     exec(yarnCmd);
   } else {
     if (!process.env.TRAVIS) {
-      log(colors.green('All packages in',
-          colors.cyan('node_modules'), 'are up to date.'));
+      log(colors.green('All packages in'),
+          colors.cyan('node_modules'), colors.green('are up to date.'));
     }
   }
 }

--- a/build-system/tasks/update-packages.js
+++ b/build-system/tasks/update-packages.js
@@ -18,7 +18,6 @@
 const exec = require('../exec').exec;
 const getStderr = require('../exec').getStderr;
 const gulp = require('gulp-help')(require('gulp'));
-const util = require('gulp-util');
 const colors = require('ansi-colors');
 const log = require('fancy-log');
 

--- a/build-system/tasks/update-packages.js
+++ b/build-system/tasks/update-packages.js
@@ -19,6 +19,7 @@ const exec = require('../exec').exec;
 const getStderr = require('../exec').getStderr;
 const gulp = require('gulp-help')(require('gulp'));
 const util = require('gulp-util');
+const colors = require('ansi-colors');
 
 
 /**
@@ -27,18 +28,18 @@ const util = require('gulp-util');
 function updatePackages() {
   const integrityCmd = 'yarn check --integrity';
   if (getStderr(integrityCmd).trim() != '') {
-    util.log(util.colors.yellow('WARNING:'), 'The packages in',
-        util.colors.cyan('node_modules'), 'do not match',
-        util.colors.cyan('package.json.'));
+    util.log(colors.yellow('WARNING:'), 'The packages in',
+        colors.cyan('node_modules'), 'do not match',
+        colors.cyan('package.json.'));
     const verifyTreeCmd = 'yarn check --verify-tree';
     exec(verifyTreeCmd);
-    util.log('Running', util.colors.cyan('yarn'), 'to update packages...');
+    util.log('Running', colors.cyan('yarn'), 'to update packages...');
     const yarnCmd = 'yarn';
     exec(yarnCmd);
   } else {
     if (!process.env.TRAVIS) {
-      util.log(util.colors.green('All packages in',
-          util.colors.cyan('node_modules'), 'are up to date.'));
+      util.log(colors.green('All packages in',
+          colors.cyan('node_modules'), 'are up to date.'));
     }
   }
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -36,6 +36,7 @@ var watchify = require('watchify');
 var internalRuntimeVersion = require('./build-system/internal-version').VERSION;
 var internalRuntimeToken = require('./build-system/internal-version').TOKEN;
 var colors = require('ansi-colors');
+var log = require('fancy-log');
 
 var argv = minimist(process.argv.slice(2), {boolean: ['strictBabelTransform']});
 
@@ -217,7 +218,7 @@ function endBuildStep(stepName, targetName, startTime) {
     timeString += secs + '.' + ms + ' s)';
   }
   if (!process.env.TRAVIS) {
-    $$.util.log(stepName, cyan(targetName), green(timeString));
+    log(stepName, cyan(targetName), green(timeString));
   }
 }
 
@@ -400,7 +401,7 @@ function compile(watch, shouldMinify, opt_preventRemoveAndMakeDir,
 function compileCss() {
   // Print a message that could help speed up local development.
   if (!process.env.TRAVIS && argv['_'].indexOf('test') != -1) {
-    $$.util.log(
+    log(
         green('To skip building during future test runs, use',
         cyan('--nobuild'), 'with your', cyan('gulp test'), 'command.'));
   }
@@ -579,11 +580,11 @@ function buildExtensionJs(path, name, version, options) {
  */
 function printConfigHelp(command) {
   if (!process.env.TRAVIS) {
-    $$.util.log(
+    log(
         green('Building the runtime for local testing with the'),
         cyan((argv.config === 'canary') ? 'canary' : 'prod'),
         green('AMP config'));
-    $$.util.log(
+    log(
         green('To specify which config to apply, use',
             cyan('--config={canary|prod}'), 'with your',
             cyan(command), 'command'));
@@ -843,7 +844,7 @@ function compileJs(srcDir, srcFilename, destDir, options) {
     if (argv.minimal_set
         && !(/integration|babel|amp-ad|lightbox|sidebar|analytics|app-banner/
             .test(srcFilename))) {
-      $$.util.log(
+      log(
           'Skipping', cyan(srcFilename), 'because of --minimal_set');
       return Promise.resolve();
     }
@@ -1251,8 +1252,8 @@ function buildWebWorker(options) {
 function checkMinVersion() {
   var majorVersion = Number(process.version.replace(/v/, '').split('.')[0]);
   if (majorVersion < 4) {
-    $$.util.log('Please run AMP with node.js version 4 or newer.');
-    $$.util.log('Your version is', process.version);
+    log('Please run AMP with node.js version 4 or newer.');
+    log('Your version is', process.version);
     process.exit(1);
   }
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -35,6 +35,7 @@ var touch = require('touch');
 var watchify = require('watchify');
 var internalRuntimeVersion = require('./build-system/internal-version').VERSION;
 var internalRuntimeToken = require('./build-system/internal-version').TOKEN;
+var colors = require('ansi-colors');
 
 var argv = minimist(process.argv.slice(2), {boolean: ['strictBabelTransform']});
 
@@ -47,10 +48,10 @@ var hostname3p = argv.hostname3p || '3p.ampproject.net';
 var extensions = {};
 var extensionAliasFilePath = {};
 
-var green = $$.util.colors.green;
-var yellow = $$.util.colors.yellow;
-var red = $$.util.colors.red;
-var cyan = $$.util.colors.cyan;
+var green = colors.green;
+var yellow = colors.yellow;
+var red = colors.red;
+var cyan = colors.cyan;
 
 var minifiedRuntimeTarget = 'dist/v0.js';
 var minified3pTarget = 'dist.3p/current-min/f.js';

--- a/package.json
+++ b/package.json
@@ -93,7 +93,6 @@
     "gulp-replace": "0.6.1",
     "gulp-sourcemaps": "2.6.3",
     "gulp-uglify": "3.0.0",
-    "gulp-util": "3.0.8",
     "gulp-watch": "4.3.11",
     "gulp-webserver": "0.9.1",
     "gulp-wrap": "0.13.0",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "eslint-plugin-google-camelcase": "0.0.2",
     "esprima": "4.0.0",
     "express": "4.16.2",
+    "fancy-log": "1.3.2",
     "fetch-mock": "5.13.1",
     "file-reader": "1.1.1",
     "formidable": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -131,6 +131,7 @@
     "morgan": "1.9.0",
     "nodemon": "1.14.7",
     "path": "0.12.7",
+    "plugin-error": "0.1.2",
     "postcss": "6.0.15",
     "postcss-import": "11.0.0",
     "preact": "8.2.7",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "acorn-globals": "4.1.0",
     "ajv": "5.5.2",
     "ajv-keywords": "2.1.1",
+    "ansi-colors": "1.0.1",
     "ast-replace": "1.1.3",
     "atob": "2.0.3",
     "autoprefixer": "7.2.4",

--- a/validator/gulpjs/index.js
+++ b/validator/gulpjs/index.js
@@ -18,11 +18,12 @@
 'use strict';
 
 const through = require('through2');
-const gutil = require('gulp-util');
 const amphtmlValidator = require('amphtml-validator');
+const colors = require('ansi-colors');
+const log = require('fancy-log');
 
 const PLUGIN_NAME = 'gulp-amphtml-validator';
-const PluginError = gutil.PluginError;
+const PluginError = require('plugin-error');
 
 const STATUS_FAIL = 'FAIL';
 const STATUS_PASS = 'PASS';
@@ -60,7 +61,7 @@ module.exports.validate = function(validator) {
           // build, but map the exception to an validation error instead. This
           // makes it possible to configure via failAfterError whether this
           // should fail the build or not.
-          gutil.log(gutil.colors.red(err.message));
+          log(colors.red(err.message));
           file.ampValidationResult = {
             status: STATUS_UNKNOWN,
           };
@@ -81,7 +82,7 @@ module.exports.format = function(logger) {
 
   const results = [];
   if (!logger) {
-    logger = gutil;
+    logger = log;
   }
 
   function collectResults(file, encoding, callback) {
@@ -100,15 +101,15 @@ module.exports.format = function(logger) {
     const validationResult = file.ampValidationResult;
     let report = file.relative + ': ';
     if (validationResult.status === STATUS_PASS) {
-      report += gutil.colors.green(validationResult.status);
+      report += colors.green(validationResult.status);
     } else if (validationResult.status === STATUS_UNKNOWN) {
-      report += gutil.colors.red(validationResult.status);
+      report += colors.red(validationResult.status);
     } else {
-      report += gutil.colors.red(validationResult.status);
+      report += colors.red(validationResult.status);
       for (let ii = 0; ii < validationResult.errors.length; ii++) {
         const error = validationResult.errors[ii];
         let msg = file.relative + ':' + error.line + ':' + error.col + ' ' +
-          gutil.colors.red(error.message);
+          colors.red(error.message);
         if (error.specUrl) {
           msg += ' (see ' + error.specUrl + ')';
         }

--- a/validator/gulpjs/package.json
+++ b/validator/gulpjs/package.json
@@ -21,7 +21,6 @@
   },
   "dependencies": {
     "amphtml-validator": "1.0.21",
-    "gulp-util": "^3.0.7",
     "through2": "^2.0.1"
   },
   "devDependencies": {

--- a/validator/gulpjs/test/validate.js
+++ b/validator/gulpjs/test/validate.js
@@ -19,7 +19,6 @@
 
 const assert = require('assert');
 const es = require('event-stream');
-const gutil = require('gulp-util');
 const File = require('vinyl');
 const fs = require('fs');
 const gulpAmpHtmlValidator = require('../');
@@ -120,7 +119,7 @@ describe('gulp-amphtml-validator', function() {
       format.end();
       format.once('finish', function() {
         assert.equal(logger.logged, 'AMP Validation results:\n\n' +
-          INVALID_FILE + ': \u001b[31mFAIL\u001b[39m\n' + INVALID_FILE + 
+          INVALID_FILE + ': \u001b[31mFAIL\u001b[39m\n' + INVALID_FILE +
           ':24:4 ' + '\u001b[31merrorMessage\u001b[39m (see specUrl)');
         done();
       });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4654,7 +4654,20 @@ gulp-uglify@3.0.0:
     uglify-js "^3.0.5"
     vinyl-sourcemaps-apply "^0.2.0"
 
-gulp-util@3.0.8, gulp-util@^3.0.0, gulp-util@^3.0.3, gulp-util@^3.0.6, gulp-util@^3.0.7:
+gulp-util@^2.2.19:
+  version "2.2.20"
+  resolved "https://registry.yarnpkg.com/gulp-util/-/gulp-util-2.2.20.tgz#d7146e5728910bd8f047a6b0b1e549bc22dbd64c"
+  dependencies:
+    chalk "^0.5.0"
+    dateformat "^1.0.7-1.2.3"
+    lodash._reinterpolate "^2.4.1"
+    lodash.template "^2.4.1"
+    minimist "^0.2.0"
+    multipipe "^0.1.0"
+    through2 "^0.5.0"
+    vinyl "^0.2.1"
+
+gulp-util@^3.0.0, gulp-util@^3.0.3, gulp-util@^3.0.6, gulp-util@^3.0.7:
   version "3.0.8"
   resolved "https://registry.yarnpkg.com/gulp-util/-/gulp-util-3.0.8.tgz#0054e1e744502e27c04c187c3ecc505dd54bbb4f"
   dependencies:
@@ -4676,19 +4689,6 @@ gulp-util@3.0.8, gulp-util@^3.0.0, gulp-util@^3.0.3, gulp-util@^3.0.6, gulp-util
     replace-ext "0.0.1"
     through2 "^2.0.0"
     vinyl "^0.5.0"
-
-gulp-util@^2.2.19:
-  version "2.2.20"
-  resolved "https://registry.yarnpkg.com/gulp-util/-/gulp-util-2.2.20.tgz#d7146e5728910bd8f047a6b0b1e549bc22dbd64c"
-  dependencies:
-    chalk "^0.5.0"
-    dateformat "^1.0.7-1.2.3"
-    lodash._reinterpolate "^2.4.1"
-    lodash.template "^2.4.1"
-    minimist "^0.2.0"
-    multipipe "^0.1.0"
-    through2 "^0.5.0"
-    vinyl "^0.2.1"
 
 gulp-watch@4.3.11:
   version "4.3.11"

--- a/yarn.lock
+++ b/yarn.lock
@@ -280,6 +280,12 @@ ansi-align@^2.0.0:
   dependencies:
     string-width "^2.0.0"
 
+ansi-colors@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-1.0.1.tgz#e94c6c306005af8b482240241e2f3dea4b855ff3"
+  dependencies:
+    ansi-wrap "^0.1.0"
+
 ansi-cyan@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/ansi-cyan/-/ansi-cyan-0.1.1.tgz#538ae528af8982f28ae30d86f2f17456d2609873"
@@ -336,7 +342,7 @@ ansi-styles@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-1.0.0.tgz#cb102df1c56f5123eab8b67cd7b98027a0279178"
 
-ansi-wrap@0.1.0:
+ansi-wrap@0.1.0, ansi-wrap@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/ansi-wrap/-/ansi-wrap-0.1.0.tgz#a82250ddb0015e9a27ca82e82ea603bbfa45efaf"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3825,7 +3825,7 @@ extsprintf@^1.2.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
 
-fancy-log@^1.1.0, fancy-log@^1.2.0, fancy-log@^1.3.2:
+fancy-log@1.3.2, fancy-log@^1.1.0, fancy-log@^1.2.0, fancy-log@^1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/fancy-log/-/fancy-log-1.3.2.tgz#f41125e3d84f2e7d89a43d06d958c8f78be16be1"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -7818,7 +7818,7 @@ pkginfo@0.3.x:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/pkginfo/-/pkginfo-0.3.1.tgz#5b29f6a81f70717142e09e765bbeab97b4f81e21"
 
-plugin-error@^0.1.2:
+plugin-error@0.1.2, plugin-error@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/plugin-error/-/plugin-error-0.1.2.tgz#3b9bb3335ccf00f425e07437e19276967da47ace"
   dependencies:


### PR DESCRIPTION
This PR does the following:
- Removes the soon-to-be-deprecated `gulp-util` package from AMP's `devDependencies`. 
- Replaces `gulp-util.colors` with `ansi-colors.colors` (https://www.npmjs.com/package/ansi-colors)
- Replaces `gulp-util.log` with `fancy-log.log` (https://www.npmjs.com/package/fancy-log)
- Replaces `gulp-util.PluginError` with `plugin-error.PluginError` (https://www.npmjs.com/package/plugin-error)

See https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5 for a detailed write up on why this is a good idea.

Fixes #12719
