### PR TITLE
Fix all remaining LGTM warnings in AMP code

### DIFF
--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -935,7 +935,7 @@ export class Bind {
     }
 
     let initialValue;
-    let match = true;
+    let match;
 
     switch (property) {
       case 'text':

--- a/extensions/amp-image-lightbox/0.1/amp-image-lightbox.js
+++ b/extensions/amp-image-lightbox/0.1/amp-image-lightbox.js
@@ -905,11 +905,9 @@ class AmpImageLightbox extends AMP.BaseElement {
     let caption = null;
 
     // 1. Check <figure> and <figcaption>.
-    if (!caption) {
-      const figure = dom.closestByTag(sourceElement, 'figure');
-      if (figure) {
-        caption = dom.elementByTag(figure, 'figcaption');
-      }
+    const figure = dom.closestByTag(sourceElement, 'figure');
+    if (figure) {
+      caption = dom.elementByTag(figure, 'figcaption');
     }
 
     // 2. Check "aria-describedby".

--- a/extensions/amp-lightbox-viewer/0.1/service/lightbox-manager-impl.js
+++ b/extensions/amp-lightbox-viewer/0.1/service/lightbox-manager-impl.js
@@ -215,7 +215,6 @@ export class LightboxManager {
           url: this.getThumbnailUrl_(dev().assertElement(element), i),
           element,
         }));
-    ;
   }
 
   /**

--- a/extensions/amp-story/0.1/share.js
+++ b/extensions/amp-story/0.1/share.js
@@ -103,7 +103,7 @@ function buildProviderParams(opt_params) {
   const attrs = dict();
 
   if (opt_params) {
-    Object.keys(opt_params || {}).forEach(field => {
+    Object.keys(opt_params).forEach(field => {
       attrs[`data-param-${field}`] = opt_params[field];
     });
   }

--- a/extensions/amp-web-push/0.1/amp-web-push.service-worker.js
+++ b/extensions/amp-web-push/0.1/amp-web-push.service-worker.js
@@ -71,13 +71,13 @@ self.addEventListener('message', event => {
 
   switch (command) {
     case WorkerMessengerCommand.AMP_SUBSCRIPION_STATE:
-      onMessageReceivedSubscriptionState(payload);
+      onMessageReceivedSubscriptionState();
       break;
     case WorkerMessengerCommand.AMP_SUBSCRIBE:
-      onMessageReceivedSubscribe(payload);
+      onMessageReceivedSubscribe();
       break;
     case WorkerMessengerCommand.AMP_UNSUBSCRIBE:
-      onMessageReceivedUnsubscribe(payload);
+      onMessageReceivedUnsubscribe();
       break;
   }
 });

--- a/extensions/amp-web-push/0.1/amp-web-push.service-worker.js
+++ b/extensions/amp-web-push/0.1/amp-web-push.service-worker.js
@@ -67,7 +67,7 @@ self.addEventListener('message', event => {
     - payload: An optional JavaScript object containing extra data relevant to
       the command.
    */
-  const {command, payload} = event.data;
+  const {command, payload} = event.data; // eslint-disable-line no-unused-vars
 
   switch (command) {
     case WorkerMessengerCommand.AMP_SUBSCRIPION_STATE:

--- a/extensions/amp-web-push/0.1/amp-web-push.service-worker.js
+++ b/extensions/amp-web-push/0.1/amp-web-push.service-worker.js
@@ -67,7 +67,7 @@ self.addEventListener('message', event => {
     - payload: An optional JavaScript object containing extra data relevant to
       the command.
    */
-  const {command, payload} = event.data; // eslint-disable-line no-unused-vars
+  const {command} = event.data;
 
   switch (command) {
     case WorkerMessengerCommand.AMP_SUBSCRIPION_STATE:


### PR DESCRIPTION
Fixes the following LGTM warnings:

- [extensions/amp-lightbox-viewer/0.1/service/lightbox-manager-impl.js#L218](https://lgtm.com/projects/g/ampproject/amphtml/snapshot/279db9d5a15d63c53a4de7a24efc58f9a0729a0b/files/extensions/amp-lightbox-viewer/0.1/service/lightbox-manager-impl.js?sort=name&dir=ASC&mode=heatmap&excluded=false#L218)
- [extensions/amp-web-push/0.1/amp-web-push.service-worker.js#L74](https://lgtm.com/projects/g/ampproject/amphtml/snapshot/279db9d5a15d63c53a4de7a24efc58f9a0729a0b/files/extensions/amp-web-push/0.1/amp-web-push.service-worker.js#L74)
- [extensions/amp-story/0.1/share.js#L106](https://lgtm.com/projects/g/ampproject/amphtml/snapshot/279db9d5a15d63c53a4de7a24efc58f9a0729a0b/files/extensions/amp-story/0.1/share.js?sort=name&dir=ASC&mode=heatmap&excluded=false#L106)
- [extensions/amp-bind/0.1/bind-impl.js#L938](https://lgtm.com/projects/g/ampproject/amphtml/snapshot/279db9d5a15d63c53a4de7a24efc58f9a0729a0b/files/extensions/amp-bind/0.1/bind-impl.js?sort=name&dir=ASC&mode=heatmap&excluded=false#L938)
- [extensions/amp-image-lightbox/0.1/amp-image-lightbox.js#L908](https://lgtm.com/projects/g/ampproject/amphtml/snapshot/279db9d5a15d63c53a4de7a24efc58f9a0729a0b/files/extensions/amp-image-lightbox/0.1/amp-image-lightbox.js?sort=name&dir=ASC&mode=heatmap&excluded=false#L908)

With this, there should be zero remaining [LGTM warnings and errors](https://lgtm.com/projects/g/ampproject/amphtml/alerts/?mode=list) in the AMP code (until new ones are checked in :/)

Partial fix for #12597