### PR TITLE
add on tap listener for multiple advance

### DIFF
--- a/extensions/amp-story/0.1/page-advancement.js
+++ b/extensions/amp-story/0.1/page-advancement.js
@@ -207,6 +207,13 @@ class MultipleAdvancementConfig extends AdvancementConfig {
   }
 
   /** @override */
+  addOnTapNavigationListener(onTapNavigationListener) {
+    this.advancementModes_.forEach(advancementMode => {
+      advancementMode.addOnTapNavigationListener(onTapNavigationListener);
+    });
+  }
+
+  /** @override */
   addAdvanceListener(advanceListener) {
     this.advancementModes_.forEach(advancementMode => {
       advancementMode.addAdvanceListener(advanceListener);


### PR DESCRIPTION
#12671 
We did not add `onTapNavigationListener` for `MultipleAdvancementConfig`. Which prevents next/previous in media and time based navigation.

This fixes it.