### PR TITLE
Use the proper getAttribute function for propagating image viewer aria attributes

### DIFF
--- a/extensions/amp-image-viewer/0.1/amp-image-viewer.js
+++ b/extensions/amp-image-viewer/0.1/amp-image-viewer.js
@@ -271,7 +271,7 @@ export class AmpImageViewer extends AMP.BaseElement {
 
     ARIA_ATTRIBUTES.forEach(key => {
       if (this.sourceElement_.hasAttribute(key)) {
-        this.image_.setAttribute(key, this.sourceElement_[key]);
+        this.image_.setAttribute(key, this.sourceElement_.getAttribute(key));
       }
     });
     st.setStyles(dev().assertElement(this.image_), {


### PR DESCRIPTION
Fixing a bug from the previous PR that merged too quickly. 