### PR TITLE
Add lightbox-thumbnail-src attribute

### DIFF
--- a/extensions/amp-lightbox-viewer/0.1/service/lightbox-manager-impl.js
+++ b/extensions/amp-lightbox-viewer/0.1/service/lightbox-manager-impl.js
@@ -218,7 +218,6 @@ export class LightboxManager {
   }
 
   /**
-   * The function is not implemented yet. Fake for testing.
    * Get thumbnail url for single element.
    * @param {!Element} element
    * @param {number=} index fake it for testing only, will delete later
@@ -226,7 +225,9 @@ export class LightboxManager {
    * @private
    */
   getThumbnailUrl_(element, index) {
-    if (element.tagName == 'AMP-IMG') {
+    if (element.hasAttribute('lightbox-thumbnail-src')) {
+      return element.getAttribute('lightbox-thumbnail-src');
+    } else if (element.tagName == 'AMP-IMG') {
       return element.getAttribute('src');
     } else {
       // TODO(#12713): implement default thumbnails

--- a/test/manual/amp-lightbox-carousel-demo.amp.html
+++ b/test/manual/amp-lightbox-carousel-demo.amp.html
@@ -206,10 +206,11 @@
       width="300"
       height="200"
       alt="and another sample image"></amp-img>
-    <amp-img src="https://picsum.photos/300/200/?image=40"
-      width="300"
-      height="200"
-      alt="and another sample image"></amp-img>
+    <amp-youtube
+      lightbox-thumbnail-src="https://i.ytimg.com/vi/lBTCB7yLs8Y/maxresdefault.jpg"
+      data-videoid="lBTCB7yLs8Y"
+      layout="container"
+      width="480" height="270"></amp-youtube>
   </amp-carousel>
   <amp-lightbox-viewer id="myLightboxViewer" layout="nodisplay"></amp-lightbox-viewer>
 


### PR DESCRIPTION
Adds a `lightbox-thumbnail-src` attribute. Default thumbnails pending icons from design. 
Closes https://github.com/ampproject/amphtml/issues/12856. 