### PR TITLE
Start gulp server after build is complete

### DIFF
--- a/build-system/tasks/runtime-test.js
+++ b/build-system/tasks/runtime-test.js
@@ -358,8 +358,8 @@ function runTests() {
   }).on('run_start', function() {
     if (argv.saucelabs || argv.saucelabs_lite) {
       console./* OK*/log(green(
-          'Running tests in parallel on', c.browsers.length,
-          'Sauce Labs browser(s)...'));
+          'Running tests in parallel on ' + c.browsers.length +
+          ' Sauce Labs browser(s)...'));
     } else {
       console./* OK*/log(green('Running tests locally...'));
     }

--- a/build-system/tasks/serve.js
+++ b/build-system/tasks/serve.js
@@ -59,15 +59,9 @@ function serve() {
       'SERVE_CACHING_HEADERS': sendCachingHeaders,
     },
     stdout: !quiet,
-  })
-      .once('quit', function() {
-        log(colors.green('Shutting down server'));
-      });
-  if (!quiet) {
-    log(colors.yellow('Run `gulp build` then go to '
-        + getHost() + '/examples/article.amp.html'
-    ));
-  }
+  }).once('quit', function() {
+    log(colors.green('Shutting down server'));
+  });
 }
 
 process.on('SIGINT', function() {

--- a/build-system/tasks/serve.js
+++ b/build-system/tasks/serve.js
@@ -94,3 +94,4 @@ function getHost() {
   return (useHttps ? 'https' : 'http') + '://' + host + ':' + port;
 }
 
+exports.serve = serve;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -403,9 +403,9 @@ function compile(watch, shouldMinify, opt_preventRemoveAndMakeDir,
 function compileCss() {
   // Print a message that could help speed up local development.
   if (!process.env.TRAVIS && argv['_'].indexOf('test') != -1) {
-    log(
-        green('To skip building during future test runs, use',
-        cyan('--nobuild'), 'with your', cyan('gulp test'), 'command.'));
+    log(green('To skip building during future test runs, use'),
+        cyan('--nobuild'), green('with your'), cyan('gulp test'),
+        green('command.'));
   }
   const startTime = Date.now();
   return jsifyCssAsync('css/amp.css')
@@ -582,14 +582,12 @@ function buildExtensionJs(path, name, version, options) {
  */
 function printConfigHelp(command) {
   if (!process.env.TRAVIS) {
-    log(
-        green('Building the runtime for local testing with the'),
+    log(green('Building the runtime for local testing with the'),
         cyan((argv.config === 'canary') ? 'canary' : 'prod'),
         green('AMP config'));
-    log(
-        green('To specify which config to apply, use',
-            cyan('--config={canary|prod}'), 'with your',
-            cyan(command), 'command'));
+    log(green('To specify which config to apply, use'),
+        cyan('--config={canary|prod}'), green('with your'),
+        cyan(command), green('command'));
   }
 }
 
@@ -846,8 +844,7 @@ function compileJs(srcDir, srcFilename, destDir, options) {
     if (argv.minimal_set
         && !(/integration|babel|amp-ad|lightbox|sidebar|analytics|app-banner/
             .test(srcFilename))) {
-      log(
-          'Skipping', cyan(srcFilename), 'because of --minimal_set');
+      log('Skipping', cyan(srcFilename), 'because of --minimal_set');
       return Promise.resolve();
     }
     const startTime = Date.now();

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -25,6 +25,7 @@ var cleanupBuildDir = require('./build-system/tasks/compile').cleanupBuildDir;
 var jsifyCssAsync = require('./build-system/tasks/jsify-css').jsifyCssAsync;
 var applyConfig = require('./build-system/tasks/prepend-global/index.js').applyConfig;
 var removeConfig = require('./build-system/tasks/prepend-global/index.js').removeConfig;
+var serve = require('./build-system/tasks/serve.js').serve;
 var fs = require('fs-extra');
 var gulp = $$.help(require('gulp'));
 var lazypipe = require('lazypipe');
@@ -1304,11 +1305,13 @@ gulp.task('build', 'Builds the AMP library', ['update-packages'], build, {
     config: '  Sets the runtime\'s AMP_CONFIG to one of "prod" or "canary"',
   }
 });
-gulp.task('check-all', 'Run through all presubmit checks', ['lint', 'dep-check', 'check-types', 'presubmit']);
+gulp.task('check-all', 'Run through all presubmit checks',
+    ['lint', 'dep-check', 'check-types', 'presubmit']);
 gulp.task('check-types', 'Check JS types', checkTypes);
 gulp.task('css', 'Recompile css to build directory', ['update-packages'],
     compileCss);
-gulp.task('default', 'Same as "watch"', ['update-packages', 'watch', 'serve']);
+gulp.task('default', 'Runs "watch" and then "serve"',
+    ['update-packages', 'watch'], serve);
 gulp.task('dist', 'Build production binaries', ['update-packages'], dist, {
   options: {
     pseudo_names: '  Compiles with readable names. ' +


### PR DESCRIPTION
When the default `gulp` task is invoked, we simultaneously start `gulp watch` and `gulp serve`. This is confusing because the server starts even before the binaries are built, due to which a partially built AMP runtime can be served. This might have worked in the past, but is in fact an invalid scenario that can have undefined results.

This PR runs `gulp serve` only after the AMP runtime is fully built for the first time. With this, we have deterministic results, and a properly built AMP runtime will be served. Subsequent edits to any source file should have the same effect as before.

Fixes #12860, #12852, #12868