### PR TITLE
Fix carousel arrow disappearing on desktop without controls attr

### DIFF
--- a/examples/carousel.amp.html
+++ b/examples/carousel.amp.html
@@ -27,7 +27,7 @@
   <script async src="https://cdn.ampproject.org/v0.js"></script>
 </head>
 <body>
-  <amp-carousel width=400 height=300 layout=responsive type=slides controls>
+  <amp-carousel width=400 height=300 layout=responsive type=slides>
 
     <div>hello world</div>
 

--- a/extensions/amp-carousel/0.1/base-carousel.js
+++ b/extensions/amp-carousel/0.1/base-carousel.js
@@ -37,7 +37,9 @@ export class BaseCarousel extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
-    this.showControls_ = this.element.hasAttribute('controls');
+    const input = Services.inputFor(this.win);
+    this.showControls_ = input.isMouseDetected() ||
+        this.element.hasAttribute('controls');
 
     if (this.showControls_) {
       this.element.classList.add('i-amphtml-carousel-has-controls');

--- a/extensions/amp-carousel/0.1/test/test-base-slide.js
+++ b/extensions/amp-carousel/0.1/test/test-base-slide.js
@@ -31,6 +31,7 @@
  */
 
 import {BaseSlides} from '../base-slides';
+import {installInputService} from '../../../../src/input';
 
 
 describes.fakeWin('BaseSlides', {amp: true}, env => {
@@ -53,6 +54,7 @@ describes.fakeWin('BaseSlides', {amp: true}, env => {
   beforeEach(() => {
     win = env.win;
     doc = win.document;
+    installInputService(win);
     buildSlidesSpy = sandbox.spy();
     onViewportCallbackSpy = sandbox.spy();
     hasPrevSpy = sandbox.spy();


### PR DESCRIPTION
Fixes #12887

The code that adds the a11y CSS class assumed that `this.showControls_` was the source of truth for whether or not the arrow buttons should be shown, but there was some CSS controlling that as well using `.amp-mouse-mode`. This PR makes the `this.showControls_` value correspond when `.amp-mouse-mode` is applied.

/to @aghassemi @cathyxz 
/cc @erwinmombay 