### PR TITLE
Add Sidebar to FixedLayer after displaying

### DIFF
--- a/extensions/amp-sidebar/0.1/amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.js
@@ -113,8 +113,6 @@ export class AmpSidebar extends AMP.BaseElement {
 
     this.action_ = Services.actionServiceForDoc(this.element);
 
-    this.viewport_.addToFixedLayer(this.element, /* forceTransfer */ true);
-
     if (this.side_ != 'left' && this.side_ != 'right') {
       this.side_ = isRTL(this.document_) ? 'right' : 'left';
       this.element.setAttribute('side', this.side_);
@@ -259,6 +257,8 @@ export class AmpSidebar extends AMP.BaseElement {
     this.viewport_.enterOverlayMode();
     this.vsync_.mutate(() => {
       toggle(this.element, /* display */true);
+      this.viewport_.addToFixedLayer(this.element, /* forceTransfer */ true);
+
       if (this.isIos_ && this.isSafari_) {
         this.compensateIosBottombar_();
       }

--- a/src/service/fixed-layer.js
+++ b/src/service/fixed-layer.js
@@ -192,6 +192,12 @@ export class FixedLayer {
    * @return {!Promise}
    */
   addElement(element, opt_forceTransfer) {
+    const win = this.ampdoc.win;
+    if (!element./*OK*/offsetParent &&
+        computedStyle(win, element).display === 'none') {
+      dev().error(TAG, 'Tried to add display:none element to FixedLayer',
+          element.tagName);
+    }
     this.setupElement_(
         element,
         /* selector */ '*',
@@ -479,8 +485,10 @@ export class FixedLayer {
     }
     const isFixed = position == 'fixed';
     if (fe) {
-      // Already seen.
-      fe.selectors.push(selector);
+      if (!fe.selectors.includes(selector)) {
+        // Already seen.
+        fe.selectors.push(selector);
+      }
     } else {
       // A new entry.
       const id = 'F' + (this.counter_++);


### PR DESCRIPTION
Fixes #12891.

Also ensures we don't try adding another `display:none` element to FixedLayer, it _has_ to be displayed before adding so proper measurements are taken.