### PR TITLE
Consolidate gulp watch and gulp build

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -618,10 +618,6 @@ function performBuild(watch) {
       buildExtensions({bundleOnlyIfListedInFiles: watch}),
       compile(watch),
     ]);
-  }).then(() => {
-    return enableLocalTesting(unminifiedRuntimeTarget);
-  }).then(() => {
-    return enableLocalTesting(unminified3pTarget);
   });
 }
 
@@ -928,6 +924,18 @@ function compileJs(srcDir, srcFilename, destDir, options) {
         appendToCompiledFile(srcFilename, destDir + '/' + destFilename);
       })).then(() => {
         endBuildStep('Compiled', srcFilename, startTime);
+      }).then(() => {
+        if (process.env.NODE_ENV === 'development') {
+          if (srcFilename === 'amp-babel.js') {
+            return enableLocalTesting(unminifiedRuntimeTarget);
+          } else if (srcFilename === 'integration.js') {
+            return enableLocalTesting(unminified3pTarget);
+          } else {
+            return Promise.resolve();
+          }
+        } else {
+          return Promise.resolve();
+        }
       });
   }
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -606,9 +606,7 @@ function enableLocalTesting(targetFile) {
  * @return {!Promise}
  */
 function performBuild(watch) {
-  if (!watch) {
-    process.env.NODE_ENV = 'development';
-  }
+  process.env.NODE_ENV = 'development';
   printConfigHelp(watch ? 'gulp watch' : 'gulp build');
   return compileCss(watch).then(() => {
     return Promise.all([

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -397,16 +397,32 @@ function compile(watch, shouldMinify, opt_preventRemoveAndMakeDir,
 }
 
 /**
- * Compile all the css and drop in the build folder
+ * Entry point for 'gulp css'
  * @return {!Promise}
  */
-function compileCss() {
+function css() {
+  return compileCss();
+}
+
+/**
+ * Compile all the css and drop in the build folder
+ * @param {boolean} watch
+ * @return {!Promise}
+ */
+function compileCss(watch) {
   // Print a message that could help speed up local development.
   if (!process.env.TRAVIS && argv['_'].indexOf('test') != -1) {
     log(green('To skip building during future test runs, use'),
         cyan('--nobuild'), green('with your'), cyan('gulp test'),
         green('command.'));
   }
+
+  if (watch) {
+    $$.watch('css/**/*.css', function() {
+      compileCss();
+    });
+  }
+
   const startTime = Date.now();
   return jsifyCssAsync('css/amp.css')
   .then(function(css) {
@@ -443,29 +459,6 @@ function copyCss() {
       .then(() => {
         endBuildStep('Copied', 'build/css/v0.css to dist/v0.css', startTime);
       });
-}
-
-/**
- * Enables watching for file changes in css, extensions.
- * @return {!Promise}
- */
-function watch() {
-  printConfigHelp('gulp watch');
-  $$.watch('css/**/*.css', function() {
-    compileCss();
-  });
-
-  return Promise.all([
-    compileCss(),
-    buildAlp({watch: true}),
-    buildExaminer({watch: true}),
-    buildExtensions({watch: true}),
-    compile(true),
-  ]).then(() => {
-    return enableLocalTesting(unminifiedRuntimeTarget);
-  }).then(() => {
-    return enableLocalTesting(unminified3pTarget);
-  });
 }
 
 /**
@@ -608,27 +601,46 @@ function enableLocalTesting(targetFile) {
 }
 
 /**
- * Main build
+ * Performs the build steps for gulp build and gulp watch
+ * @param {boolean} watch
  * @return {!Promise}
  */
-function build() {
-  process.env.NODE_ENV = 'development';
-  printConfigHelp('gulp build');
-  return compileCss().then(() => {
+function performBuild(watch) {
+  if (!watch) {
+    process.env.NODE_ENV = 'development';
+  }
+  printConfigHelp(watch ? 'gulp watch' : 'gulp build');
+  return compileCss(watch).then(() => {
     return Promise.all([
       polyfillsForTests(),
-      buildAlp(),
-      buildExaminer(),
-      buildSw(),
-      buildWebWorker(),
-      buildExtensions({bundleOnlyIfListedInFiles: true}),
-      compile(),
+      buildAlp({watch: watch}),
+      buildExaminer({watch: watch}),
+      buildSw({watch: watch}),
+      buildWebWorker({watch: watch}),
+      buildExtensions({bundleOnlyIfListedInFiles: watch}),
+      compile(watch),
     ]);
   }).then(() => {
     return enableLocalTesting(unminifiedRuntimeTarget);
   }).then(() => {
     return enableLocalTesting(unminified3pTarget);
   });
+}
+
+/**
+ * Enables watching for file changes in css, extensions.
+ * @return {!Promise}
+ */
+function watch() {
+  return performBuild(true);
+}
+
+/**
+ * Main build
+ * @return {!Promise}
+ */
+function build() {
+  return performBuild();
 }
 
 /**
@@ -1305,8 +1317,7 @@ gulp.task('build', 'Builds the AMP library', ['update-packages'], build, {
 gulp.task('check-all', 'Run through all presubmit checks',
     ['lint', 'dep-check', 'check-types', 'presubmit']);
 gulp.task('check-types', 'Check JS types', checkTypes);
-gulp.task('css', 'Recompile css to build directory', ['update-packages'],
-    compileCss);
+gulp.task('css', 'Recompile css to build directory', ['update-packages'], css);
 gulp.task('default', 'Runs "watch" and then "serve"',
     ['update-packages', 'watch'], serve);
 gulp.task('dist', 'Build production binaries', ['update-packages'], dist, {


### PR DESCRIPTION
It turns out that `gulp watch` and `gulp build` had diverged over time in the build steps they would run. This was due to new build steps that were added to `build()` but not to `watch()` in PRs like #7436 ([here](https://github.com/ampproject/amphtml/pull/7436/files#diff-b9e12334e9eafd8341a6107dd98510c9R478)) and #4037 ([here](https://github.com/ampproject/amphtml/pull/4037/files#diff-b9e12334e9eafd8341a6107dd98510c9R318)).

This PR consolidates the build steps in `watch` and `build`. Now, there is no need to run `gulp build` before `gulp`. Running `gulp` will do a full build, and then wait for files to be changed.

Fixes #12895 
Fixes #12860 
Fixes #12747 
Fixes #12868
Fixes #12852