### PR TITLE
Support 'geo:' URL scheme for anchor href attributes.

### DIFF
--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -1206,10 +1206,10 @@ tags: {
   attrs: {
     name: "href"
     value_url: {
-      # Maintain the same whitelist of protocols here as for the <CITE> tag.
       allow_empty: true
       allow_relative: true
       allowed_protocol: "ftp"
+      allowed_protocol: "geo"
       allowed_protocol: "http"
       allowed_protocol: "https"
       allowed_protocol: "mailto"


### PR DESCRIPTION
Reference: https://en.wikipedia.org/wiki/Geo_URI_scheme

Fixes: https://github.com/ampproject/amphtml/issues/12888


Also removed comment about `CITE` tag which seems to be old. The `CITE` tag doesn't support URLs as an attribute. I suspect this comment intends to refer to the `cite` attribute, but non http/https schemes don't make much sense for the `cite` attribute.