### PR TITLE
Add missing option to buildExtensions() in gulp watch / gulp build

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -615,7 +615,7 @@ function performBuild(watch) {
       buildExaminer({watch: watch}),
       buildSw({watch: watch}),
       buildWebWorker({watch: watch}),
-      buildExtensions({bundleOnlyIfListedInFiles: watch}),
+      buildExtensions({bundleOnlyIfListedInFiles: !watch, watch: watch}),
       compile(watch),
     ]);
   });


### PR DESCRIPTION
Missed out an arg to `buildExtensions` in #12900

This should help when a single file is changed during `watch`

Follow up to #12900
Fixes #12895