### PR TITLE
Fix syntax error reporting in compileJs

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -912,7 +912,7 @@ function compileJs(srcDir, srcFilename, destDir, options) {
     return toPromise(bundler.bundle()
       .on('error', function(err) {
         if (err instanceof SyntaxError) {
-          console.error(red('Syntax error:', err.message));
+          console.error(red('Syntax error: ' + err.message));
         } else {
           console.error(red(err.message));
         }


### PR DESCRIPTION
This was due to an API change between `gulp-util.colors` and `ansi-colors.colors`.

Follow up to #12825