### PR TITLE
Fix lightbox controls toggle

### DIFF
--- a/extensions/amp-image-viewer/0.1/amp-image-viewer.js
+++ b/extensions/amp-image-viewer/0.1/amp-image-viewer.js
@@ -380,20 +380,21 @@ export class AmpImageViewer extends AMP.BaseElement {
 
   /** @private */
   setupGestures_() {
-    const gesturesWithoutPreventDefault = Gestures.get(
-        dev().assertElement(this.image_),
+    this.gestures_ = Gestures.get(
+        this.element,
         /* opt_shouldNotPreventDefault */true
     );
-    gesturesWithoutPreventDefault.onPointerDown(() => {
+
+    this.gestures_.onPointerDown(() => {
       if (this.motion_) {
         this.motion_.halt();
+        event.preventDefault();
       }
     });
 
-    this.gestures_ = Gestures.get(this.element);
-
     // Zoomable.
     this.gestures_.onGesture(DoubletapRecognizer, e => {
+      event.preventDefault();
       let newScale;
       if (this.scale_ == 1) {
         newScale = this.maxScale_;
@@ -408,6 +409,7 @@ export class AmpImageViewer extends AMP.BaseElement {
     });
 
     this.gestures_.onGesture(TapzoomRecognizer, e => {
+      event.preventDefault();
       this.onTapZoom_(e.data.centerClientX, e.data.centerClientY,
           e.data.deltaX, e.data.deltaY);
       if (e.data.last) {
@@ -417,6 +419,7 @@ export class AmpImageViewer extends AMP.BaseElement {
     });
 
     this.gestures_.onGesture(PinchRecognizer, e => {
+      event.preventDefault();
       this.onPinchZoom_(e.data.centerClientX, e.data.centerClientY,
           e.data.deltaX, e.data.deltaY, e.data.dir);
       if (e.data.last) {


### PR DESCRIPTION
Partially addresses https://github.com/ampproject/amphtml/issues/12362. 

Basically this has the non-ideal UX of causing controls to toggle when you double click, but it's a better UX than broken toggles. 

Other alternatives: 
1. Make gestures refire after pending gesture recognizers are all cancelled like so: https://github.com/ampproject/amphtml/pull/12957. 
2. Refactor gestures library to listen to `dblclick` event. This isn't ideal because `click` events will still get fired on `dblclick`, twice. 