### PR TITLE
Layers: Scoring Algorithm

### DIFF
--- a/src/log.js
+++ b/src/log.js
@@ -380,6 +380,21 @@ export class Log {
   }
 
   /**
+   * Throws an error if the first argument isn't a boolean.
+   *
+   * For more details see `assert`.
+   *
+   * @param {*} shouldBeBoolean
+   * @param {string=} opt_message The assertion message
+   * @return {boolean} The boolean value.
+   */
+  assertBoolean(shouldBeBoolean, opt_message) {
+    this.assert(!!shouldBeBoolean === shouldBeBoolean,
+        (opt_message || 'Boolean expected') + ': %s', shouldBeBoolean);
+    return /** @type {boolean} */ (shouldBeBoolean);
+  }
+
+  /**
    * Asserts and returns the enum value. If the enum doesn't contain such a value,
    * the error is thrown.
    *

--- a/src/service/layers-impl.js
+++ b/src/service/layers-impl.js
@@ -211,7 +211,6 @@ export class LayoutLayers {
       parent.remove(layout);
     }
 
-    // TODO(jridgewell) child elements will disappear into the ether.
     layout.undeclareLayer();
   }
 
@@ -663,9 +662,19 @@ export class LayoutElement {
       return;
     }
 
+    const element = this.element_;
+    const win = element.ownerDocument.defaultView;
+    // If it remains fixed, it will still be a layer.
+    if (computedStyle(win, element).position === 'fixed') {
+      return;
+    }
+
     this.isLayer_ = false;
-    this.transfer_(/** @type {!LayoutElement} */ (dev().assert(
-        this.getParentLayer())));
+    // Handle if this was a fixed position layer (and therefore had null parent
+    // layer).
+    const parent = this.getParentLayer() ||
+        LayoutElement.getParentLayer(this.element_, true);
+    this.transfer_(/** @type {!LayoutElement} */ (dev().assert(parent)));
   }
 
   /**

--- a/src/service/layers-impl.js
+++ b/src/service/layers-impl.js
@@ -265,11 +265,15 @@ export class LayoutLayers {
    * #buildCallback, #layoutCallback, viewport changes size).
    *
    * @param {!Element} element A regular or AMP Element
+   * @param {boolean=} opt_force
    */
-  remeasure(element) {
+  remeasure(element, opt_force) {
     const layout = this.add(element);
-    layout.requestRemeasure();
-    layout.remeasure();
+    const from = layout.getParentLayer() || layout;
+    if (opt_force) {
+      from.requestRemeasure();
+    }
+    from.remeasure();
   }
 
   /**

--- a/src/service/layers-impl.js
+++ b/src/service/layers-impl.js
@@ -267,10 +267,9 @@ export class LayoutLayers {
    * @param {!Element} element A regular or AMP Element
    */
   remeasure(element) {
-    const layer = LayoutElement.getParentLayer(element);
-    if (layer) {
-      layer.remeasure();
-    }
+    const layout = this.add(element);
+    layout.requestRemeasure();
+    layout.remeasure();
   }
 
   /**

--- a/src/service/layers-impl.js
+++ b/src/service/layers-impl.js
@@ -652,9 +652,7 @@ export class LayoutElement {
    * @return {!SizeDef}
    */
   getSize() {
-    if (this.needsRemeasure_) {
-      this.remeasure();
-    }
+    this.remeasure();
     return this.size_;
   }
 
@@ -665,9 +663,7 @@ export class LayoutElement {
    * @return {!PositionDef}
    */
   getOffsetFromParent() {
-    if (this.needsRemeasure_) {
-      this.remeasure();
-    }
+    this.remeasure();
     return this.position_;
   }
 
@@ -795,7 +791,9 @@ export class LayoutElement {
       }
     }
 
-    layer.remeasure_();
+    if (layer.needsRemeasure_) {
+      layer.remeasure_();
+    }
   }
 
   /**

--- a/src/service/layers-impl.js
+++ b/src/service/layers-impl.js
@@ -666,7 +666,8 @@ export class LayoutElement {
     }
 
     const element = this.element_;
-    const win = element.ownerDocument.defaultView;
+    const win = /** @type {!Window } */ (dev().assert(
+        element.ownerDocument.defaultView));
     // If it remains fixed, it will still be a layer.
     if (computedStyle(win, element).position === 'fixed') {
       return;
@@ -1006,7 +1007,7 @@ export class LayoutElement {
         positionLt(0, 0);
     }
 
-    this.size_ = sizeWh(element.clientWidth, element.clientHeight);
+    this.size_ = sizeWh(element./*OK*/clientWidth, element./*OK*/clientHeight);
 
     let {left, top} = element./*OK*/getBoundingClientRect();
     // Root layers are really screwed up. Their positions will **double** count

--- a/src/service/layers-impl.js
+++ b/src/service/layers-impl.js
@@ -989,8 +989,8 @@ export class LayoutElement {
   remeasure_(opt_relativeTo) {
     this.updateScrollPosition_();
     this.needsRemeasure_ = false;
+    const element = this.element_;
 
-    const box = this.element_./*OK*/getBoundingClientRect();
     // We need a relative box to measure our offset. Importantly, this box must
     // be negatively offset by it's scroll position, to account for the fact
     // that getBoundingClientRect() will only return scrolled positions.
@@ -1002,9 +1002,9 @@ export class LayoutElement {
         positionLt(0, 0);
     }
 
-    this.size_ = sizeWh(box.width, box.height);
+    this.size_ = sizeWh(element.clientWidth, element.clientHeight);
 
-    let {left, top} = box;
+    let {left, top} = element./*OK*/getBoundingClientRect();
     // Root layers are really screwed up. Their positions will **double** count
     // their scroll position (left === -scrollLeft, top === -scrollTop), which
     // breaks with every other scroll box on the page.

--- a/src/service/layers-impl.js
+++ b/src/service/layers-impl.js
@@ -320,11 +320,11 @@ export class LayoutLayers {
    * @param {!Element} element
    */
   scrolled_(element) {
-    const layer = LayoutElement.forOptional(element);
+    let layer = LayoutElement.forOptional(element);
     if (layer && layer.isLayer()) {
       layer.requestScrollRemeasure();
     } else {
-      this.declareLayer_(element, false);
+      layer = this.declareLayer_(element, false);
     }
 
     this.activeLayer_ = layer;
@@ -384,8 +384,8 @@ export class LayoutElement {
     /** @const @private {!Element} */
     this.element_ = element;
 
-    /** @const private {number} */
-    this.id_ = layoutId++;
+    /** @const private {string} */
+    this.id_ = `${element.tagName}-${layoutId++}`;
 
     /**
      * The parent layer of the current element. Note that even if _this_
@@ -570,7 +570,7 @@ export class LayoutElement {
   /**
    * Returns the unique identifier for each layout.
    *
-   * @return {number}
+   * @return {string}
    */
   getId() {
     return this.id_;

--- a/src/service/layers-impl.js
+++ b/src/service/layers-impl.js
@@ -80,8 +80,9 @@ function positionLt(left, top) {
 }
 
 /**
- * Stores an LayoutElement's parent layer ancestry (temporarily).
- * See {@link LayoutElement#ancestry}.
+ * Stores an LayoutElement's parent layer ancestry (temporarily), reusing the
+ * same array instance to avoid heavy GCs.
+ * See {@link LayoutElement#iterateAncestry}.
  * @const {!Array<!LayoutElement>}
  */
 const ANCESTRY_CACHE = [];
@@ -481,9 +482,6 @@ export class LayoutElement {
      * @private {number}
      */
     this.scrollTop_ = 0;
-
-    /**
-     *
 
     /**
      * The child LayoutElements of this layer. Only a layer (which means it
@@ -977,6 +975,7 @@ export class LayoutElement {
     // Gather, and update whether the layers are descendants of the active
     // layer.
     let isActive = activeLayer === this || activeLayer.contains(this);
+    dev().assert(ANCESTRY_CACHE.length === 0, 'ancestry cache must be empty');
 
     let layer = this;
     while (layer) {

--- a/src/service/layers-impl.js
+++ b/src/service/layers-impl.js
@@ -92,8 +92,8 @@ export class LayoutLayers {
 
     /**
      * An Event handler, which will be called when a layer (any layer) scrolls.
-     * A later PR will refine this to send an array of elements who have
-     * changed position due to the scroll.
+     * TODO(jridgewell, #12556): send an array of elements who have changed
+     * position due to the scroll.
      * @type {function()|null}
      */
     this.onScroll_ = null;
@@ -450,6 +450,8 @@ export class LayoutElement {
    * If the element is itself a layer, it still looks in the element's ancestry
    * for a parent layer.
    *
+   * TODO(jridgewell, #12554): Needs to traverse FIE/Shadow boundary.
+   *
    * @param {!Element} node
    * @param {boolean=} opt_force Whether to force a re-lookup
    * @return {?LayoutElement}
@@ -484,6 +486,8 @@ export class LayoutElement {
           // If the op is fixed-position, it defines a new layer. But, if the
           // node is the op, we can't return the node as its own parent layer.
           // In that case, it doesn't have a parent layer.
+          // TODO(jridgewell, #12554): Fixed position's parent is the FIE
+          // element, what about Shadows?
           return op === node ? null : LayoutElement.for(op);
         }
         op = op./*OK*/offsetParent;
@@ -498,6 +502,9 @@ export class LayoutElement {
   /**
    * A check that the LayoutElement is contained by this layer, and the element
    * is not the layer's element.
+   *
+   * TODO(jridgewell, #12554): This needs to account for FIE/Shadow's root,
+   * since it will be a child layout of the host element.
    *
    * @param {!LayoutElement} layout
    * @return {boolean}

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -483,7 +483,18 @@ export class Resource {
   measureViaLayers_() {
     const {element} = this;
     const layers = element.getLayers();
-    layers.remeasure(element);
+    /**
+     * TODO(jridgewell): This force remeasure shouldn't be necessary. We
+     * essentially have 3 phases of measurements:
+     * 1. Initial measurements during page load, where we're not mutating
+     * 2. Remeasurements after page load, where we might have mutated (but
+     *    really shouldn't, it's a bug we haven't fixed yet)
+     * 3. Mutation remeasurements
+     *
+     * We can optimize the initial measurements by not forcing remeasure. But
+     * for both 2 and 3, we need for force it.
+     */
+    layers.remeasure(element, /* opt_force */ true);
   }
 
   /**

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -682,6 +682,8 @@ export class Resource {
     let scrollPenalty = 1;
     let distance = 0;
 
+    // TODO
+
     if (this.useLayers_) {
       distance += Math.max(0,
           layoutBox.left - viewportBox.right,

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -693,7 +693,8 @@ export class Resource {
     let scrollPenalty = 1;
     let distance = 0;
 
-    // TODO
+    // TODO(jridgewell): Switch all viewport distance calculations to use
+    // Layer's definition of ancestry layer viewports.
 
     if (this.useLayers_) {
       distance += Math.max(0,

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -176,9 +176,9 @@ export class Resources {
 
     let boundScorer;
     if (this.useLayers_) {
-      boundScorer = this.calcTaskScore_.bind(this);
-    } else {
       boundScorer = this.calcTaskScoreLayers_.bind(this);
+    } else {
+      boundScorer = this.calcTaskScore_.bind(this);
     }
     /** @const {!function(./task-queue.TaskDef, !Object<string, *>):number} */
     this.boundTaskScorer_ = boundScorer;
@@ -1682,7 +1682,7 @@ export class Resources {
    * @return {number}
    */
   calcLayoutScore_(currentScore, layout, depth, cache) {
-    const id = String(layout.getId());
+    const id = layout.getId();
     if (hasOwn(cache, id)) {
       return dev().assertNumber(cache[id]);
     }
@@ -1692,7 +1692,7 @@ export class Resources {
     const nonActivePenalty = layout.isActive() ? 1 : 2;
     const distance = layout.getHorizontalDistanceFromParent() +
         layout.getVerticalDistanceFromParent();
-    return score * nonActivePenalty * depthPenalty * distance;
+    return cache[id] = score + nonActivePenalty * depthPenalty * distance;
   }
 
   /**

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -245,7 +245,7 @@ export class Resources {
         this.schedulePass();
       });
 
-      /** @const */
+      /** @private @const {function(number, !./layers-impl.LayoutElement, number, !Object<string, *>):number} */
       this.boundCalcLayoutScore_ = this.calcLayoutScore_.bind(this);
     }
 
@@ -1667,13 +1667,14 @@ export class Resources {
    * @private
    */
   calcTaskScoreLayers_(task, cache) {
-    const layerScore = this.layers_.ancestry(task.resource.element,
+    const layerScore = this.layers_.iterateAncestry(task.resource.element,
         this.boundCalcLayoutScore_, cache);
     return task.priority * PRIORITY_BASE_ + layerScore;
   }
 
   /**
-   * Calculates the ancestry score... todo description trololololol.
+   * Calculates the layout's distance from viewport score, using an iterative
+   * (and cacheable) calculation based on tree depth and distance.
    *
    * @param {number} currentScore
    * @param {!./layers-impl.LayoutElement} layout

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -29,7 +29,7 @@ import {loadPromise} from '../event-helper';
 import {registerServiceBuilderForDoc} from '../service';
 import {isArray} from '../types';
 import {dev} from '../log';
-import {dict} from '../utils/object';
+import {dict, hasOwn} from '../utils/object';
 import {reportError} from '../error';
 import {filterSplice} from '../utils/array';
 import {getSourceUrl} from '../url';
@@ -171,8 +171,17 @@ export class Resources {
     /** @const {!TaskQueue} */
     this.queue_ = new TaskQueue();
 
-    /** @const {!function(./task-queue.TaskDef):number} */
-    this.boundTaskScorer_ = task => this.calcTaskScore_(task);
+    /** @private @const {boolean} */
+    this.useLayers_ = isExperimentOn(this.win, 'layers');
+
+    let boundScorer;
+    if (this.useLayers_) {
+      boundScorer = this.calcTaskScore_.bind(this);
+    } else {
+      boundScorer = this.calcTaskScoreLayers_.bind(this);
+    }
+    /** @const {!function(./task-queue.TaskDef, !Object<string, *>):number} */
+    this.boundTaskScorer_ = boundScorer;
 
     /**
     * @private {!Array<!ChangeSizeRequestDef>}
@@ -206,9 +215,6 @@ export class Resources {
     /** @private {boolean} */
     this.maybeChangeHeight_ = false;
 
-    /** @private @const {boolean} */
-    this.useLayers_ = isExperimentOn(this.win, 'layers');
-
     /** @private @const {!FiniteStateMachine<!VisibilityState>} */
     this.visibilityStateMachine_ = new FiniteStateMachine(
         this.viewer_.getVisibilityState()
@@ -230,9 +236,17 @@ export class Resources {
     });
 
     if (this.useLayers_) {
-      Services.layersForDoc(this.ampdoc).onScroll((/* elements */) => {
+      const layers = Services.layersForDoc(this.ampdoc);
+
+      /** @private @const {!./layers-impl.LayoutLayers} */
+      this.layers_ = layers;
+
+      layers.onScroll((/* elements */) => {
         this.schedulePass();
       });
+
+      /** @const */
+      this.boundCalcLayoutScore_ = this.calcLayoutScore_.bind(this);
     }
 
     // When document becomes visible, e.g. from "prerender" mode, do a
@@ -1155,6 +1169,8 @@ export class Resources {
       }
       this.maybeChangeHeight_ = true;
     }
+
+    // TODO(jridgewell, #12780): Update resize rules to account for layers.
     if (this.requestsChangeSize_.length > 0) {
       dev().fine(TAG_, 'change size requests:',
           this.requestsChangeSize_.length);
@@ -1538,12 +1554,13 @@ export class Resources {
     const now = Date.now();
 
     let timeout = -1;
-    let task = this.queue_.peek(this.boundTaskScorer_);
+    const state = Object.create(null);
+    let task = this.queue_.peek(this.boundTaskScorer_, state);
     while (task) {
       timeout = this.calcTaskTimeout_(task);
       dev().fine(TAG_, 'peek from queue:', task.id,
           'sched at', task.scheduleTime,
-          'score', this.boundTaskScorer_(task),
+          'score', this.boundTaskScorer_(task, state),
           'timeout', timeout);
       if (timeout > 16) {
         break;
@@ -1575,7 +1592,7 @@ export class Resources {
         }
       }
 
-      task = this.queue_.peek(this.boundTaskScorer_);
+      task = this.queue_.peek(this.boundTaskScorer_, state);
       timeout = -1;
     }
 
@@ -1615,10 +1632,11 @@ export class Resources {
    * this element or away from it.
    *
    * @param {!./task-queue.TaskDef} task
+   * @param {!Object<string, *>} unusedCache
    * @return {number}
    * @private
    */
-  calcTaskScore_(task) {
+  calcTaskScore_(task, unusedCache) {
     // TODO(jridgewell): these should be taking into account the active
     // scroller, which may not be the root scroller. Maybe a weighted average
     // of "scroller scrolls necessary" to see the element.
@@ -1631,6 +1649,50 @@ export class Resources {
     }
     posPriority = Math.abs(posPriority);
     return task.priority * PRIORITY_BASE_ + posPriority;
+  }
+
+  /**
+   * Calculates the task's score using the Layers service. A task with the
+   * lowest score will be dequeued from the queue the first.
+   *
+   * Refer to {@link calcTaskScore_} for basic explanation.
+   *
+   * Viewport priority is a function of the distance of the element from the
+   * currently visible viewports. The elements in the visible viewport get
+   * higher priority and further away from the viewport get lower priority.
+   *
+   * @param {!./task-queue.TaskDef} task
+   * @param {!Object<string, *>} cache
+   * @return {number}
+   * @private
+   */
+  calcTaskScoreLayers_(task, cache) {
+    const layerScore = this.layers_.ancestry(task.resource.element,
+        this.boundCalcLayoutScore_, cache);
+    return task.priority * PRIORITY_BASE_ + layerScore;
+  }
+
+  /**
+   * Calculates the ancestry score... todo description trololololol.
+   *
+   * @param {number} currentScore
+   * @param {!./layers-impl.LayoutElement} layout
+   * @param {number} depth
+   * @param {!Object<string, *>} cache
+   * @return {number}
+   */
+  calcLayoutScore_(currentScore, layout, depth, cache) {
+    const id = String(layout.getId());
+    if (hasOwn(cache, id)) {
+      return dev().assertNumber(cache[id]);
+    }
+
+    const score = currentScore || 0;
+    const depthPenalty = 1 + (depth / 10);
+    const nonActivePenalty = layout.isActive() ? 1 : 2;
+    const distance = layout.getHorizontalDistanceFromParent() +
+        layout.getVerticalDistanceFromParent();
+    return score * nonActivePenalty * depthPenalty * distance;
   }
 
   /**

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -143,7 +143,11 @@ export class Resources {
     /** @private {boolean} */
     this.relayoutAll_ = true;
 
-    /** @private {number} */
+    /**
+     * TODO(jridgewell): relayoutTop should be replaced with parent layer
+     * dirtying.
+     * @private {number}
+     */
     this.relayoutTop_ = -1;
 
     /** @private {time} */
@@ -915,6 +919,7 @@ export class Resources {
       mutate: () => {
         mutator();
 
+        // TODO(jridgewell): Mark parent layer as dirty, skip the rest of this.
         // Mark itself and children for re-measurement.
         if (element.classList.contains('i-amphtml-element')) {
           const r = Resource.forElement(element);
@@ -976,6 +981,7 @@ export class Resources {
     const box = this.viewport_.getLayoutRect(element);
     const resource = Resource.forElement(element);
     if (box.width != 0 && box.height != 0) {
+      // TODO setRelayoutTop_ is being deprecated.
       this.setRelayoutTop_(box.top);
     }
     resource.completeCollapse();

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -1690,7 +1690,7 @@ export class Resources {
 
     const score = currentScore || 0;
     const depthPenalty = 1 + (depth / 10);
-    const nonActivePenalty = layout.isActive() ? 1 : 2;
+    const nonActivePenalty = layout.isActiveUnsafe() ? 1 : 2;
     const distance = layout.getHorizontalDistanceFromParent() +
         layout.getVerticalDistanceFromParent();
     return cache[id] = score + nonActivePenalty * depthPenalty * distance;

--- a/src/service/task-queue.js
+++ b/src/service/task-queue.js
@@ -32,6 +32,12 @@ import {dev} from '../log';
  */
 export let TaskDef;
 
+/**
+ * @typedef {Object<string, *>}
+ */
+let PeekStateDef;
+
+
 
 /**
  * A scheduling queue for Resources.
@@ -119,15 +125,16 @@ export class TaskQueue {
   /**
    * Returns the task with the minimal score based on the provided scoring
    * callback.
-   * @param {function(!TaskDef):number} scorer
+   * @param {function(!TaskDef, !PeekStateDef):number} scorer
+   * @param {!PeekStateDef} state
    * @return {?TaskDef}
    */
-  peek(scorer) {
+  peek(scorer, state) {
     let minScore = 1e6;
     let minTask = null;
     for (let i = 0; i < this.tasks_.length; i++) {
       const task = this.tasks_[i];
-      const score = scorer(task);
+      const score = scorer(task, state);
       if (score < minScore) {
         minScore = score;
         minTask = task;

--- a/test/functional/test-layers.js
+++ b/test/functional/test-layers.js
@@ -21,7 +21,7 @@ import {
   installLayersServiceForDoc,
 } from '../../src/service/layers-impl';
 
-describes.realWin('Layers', {amp: false}, env => {
+describes.realWin.only('Layers', {amp: false}, env => {
   let win;
   let root;
 
@@ -123,14 +123,14 @@ describes.realWin('Layers', {amp: false}, env => {
         });
 
         div.style.top = '10px';
-        rootLayout.remeasure();
+        rootLayout.requestRemeasure();
         expect(layout.getScrolledPosition()).to.deep.equal({
           left: 0,
           top: 10,
         });
 
         div.style.left = '10px';
-        rootLayout.remeasure();
+        rootLayout.requestRemeasure();
         expect(layout.getScrolledPosition()).to.deep.equal({
           left: 10,
           top: 10,
@@ -144,14 +144,14 @@ describes.realWin('Layers', {amp: false}, env => {
         });
 
         parent.style.top = '10px';
-        rootLayout.remeasure();
+        rootLayout.requestRemeasure();
         expect(layout.getScrolledPosition()).to.deep.equal({
           left: 0,
           top: 10,
         });
 
         parent.style.left = '10px';
-        rootLayout.remeasure();
+        rootLayout.requestRemeasure();
         expect(layout.getScrolledPosition()).to.deep.equal({
           left: 10,
           top: 10,
@@ -166,7 +166,7 @@ describes.realWin('Layers', {amp: false}, env => {
 
         parent.style.top = '10px';
         div.style.left = '10px';
-        rootLayout.remeasure();
+        rootLayout.requestRemeasure();
         expect(layout.getScrolledPosition()).to.deep.equal({
           left: 10,
           top: 10,
@@ -174,7 +174,7 @@ describes.realWin('Layers', {amp: false}, env => {
 
         parent.style.left = '10px';
         div.style.top = '10px';
-        rootLayout.remeasure();
+        rootLayout.requestRemeasure();
         expect(layout.getScrolledPosition()).to.deep.equal({
           left: 20,
           top: 20,
@@ -188,7 +188,7 @@ describes.realWin('Layers', {amp: false}, env => {
           left: 0,
           top: 0,
         });
-        rootLayout.remeasure();
+        rootLayout.requestRemeasure();
         expect(parentLayout.getScrolledPosition()).to.deep.equal({
           left: 0,
           top: 0,
@@ -200,7 +200,7 @@ describes.realWin('Layers', {amp: false}, env => {
           left: 0,
           top: 0,
         });
-        rootLayout.remeasure();
+        rootLayout.requestRemeasure();
         expect(rootLayout.getScrolledPosition()).to.deep.equal({
           left: 0,
           top: 0,
@@ -214,7 +214,7 @@ describes.realWin('Layers', {amp: false}, env => {
           left: -5,
           top: -10,
         });
-        rootLayout.remeasure();
+        rootLayout.requestRemeasure();
         expect(layout.getScrolledPosition()).to.deep.equal({
           left: -5,
           top: -10,
@@ -226,7 +226,7 @@ describes.realWin('Layers', {amp: false}, env => {
           left: -10,
           top: -20,
         });
-        rootLayout.remeasure();
+        rootLayout.requestRemeasure();
         expect(layout.getScrolledPosition()).to.deep.equal({
           left: -10,
           top: -20,
@@ -274,14 +274,14 @@ describes.realWin('Layers', {amp: false}, env => {
         });
 
         div.style.top = '10px';
-        rootLayout.remeasure();
+        rootLayout.requestRemeasure();
         expect(layout.getOffsetPosition()).to.deep.equal({
           left: 0,
           top: 10,
         });
 
         div.style.left = '10px';
-        rootLayout.remeasure();
+        rootLayout.requestRemeasure();
         expect(layout.getOffsetPosition()).to.deep.equal({
           left: 10,
           top: 10,
@@ -295,14 +295,14 @@ describes.realWin('Layers', {amp: false}, env => {
         });
 
         parent.style.top = '10px';
-        rootLayout.remeasure();
+        rootLayout.requestRemeasure();
         expect(layout.getOffsetPosition()).to.deep.equal({
           left: 0,
           top: 10,
         });
 
         parent.style.left = '10px';
-        rootLayout.remeasure();
+        rootLayout.requestRemeasure();
         expect(layout.getOffsetPosition()).to.deep.equal({
           left: 10,
           top: 10,
@@ -317,7 +317,7 @@ describes.realWin('Layers', {amp: false}, env => {
 
         parent.style.top = '10px';
         div.style.left = '10px';
-        rootLayout.remeasure();
+        rootLayout.requestRemeasure();
         expect(layout.getOffsetPosition()).to.deep.equal({
           left: 10,
           top: 10,
@@ -325,7 +325,7 @@ describes.realWin('Layers', {amp: false}, env => {
 
         parent.style.left = '10px';
         div.style.top = '10px';
-        rootLayout.remeasure();
+        rootLayout.requestRemeasure();
         expect(layout.getOffsetPosition()).to.deep.equal({
           left: 20,
           top: 20,
@@ -339,7 +339,7 @@ describes.realWin('Layers', {amp: false}, env => {
           left: 0,
           top: 0,
         });
-        rootLayout.remeasure();
+        rootLayout.requestRemeasure();
         expect(parentLayout.getOffsetPosition()).to.deep.equal({
           left: 0,
           top: 0,
@@ -351,7 +351,7 @@ describes.realWin('Layers', {amp: false}, env => {
           left: 0,
           top: 0,
         });
-        rootLayout.remeasure();
+        rootLayout.requestRemeasure();
         expect(rootLayout.getOffsetPosition()).to.deep.equal({
           left: 0,
           top: 0,
@@ -365,7 +365,7 @@ describes.realWin('Layers', {amp: false}, env => {
           left: 0,
           top: 0,
         });
-        rootLayout.remeasure();
+        rootLayout.requestRemeasure();
         expect(layout.getOffsetPosition()).to.deep.equal({
           left: 0,
           top: 0,
@@ -377,7 +377,7 @@ describes.realWin('Layers', {amp: false}, env => {
           left: 0,
           top: 0,
         });
-        rootLayout.remeasure();
+        rootLayout.requestRemeasure();
         expect(layout.getOffsetPosition()).to.deep.equal({
           left: 0,
           top: 0,

--- a/test/functional/test-layers.js
+++ b/test/functional/test-layers.js
@@ -21,7 +21,7 @@ import {
   installLayersServiceForDoc,
 } from '../../src/service/layers-impl';
 
-describes.realWin.only('Layers', {amp: false}, env => {
+describes.realWin('Layers', {amp: false}, env => {
   let win;
   let root;
 

--- a/test/functional/test-layers.js
+++ b/test/functional/test-layers.js
@@ -45,7 +45,7 @@ describes.realWin('Layers', {amp: false}, env => {
     element.scrollTop = top;
     element.scrollLeft = left;
     const layout = LayoutElement.for(element);
-    layout.requestScrollRemeasure();
+    layout.dirtyScrollMeasurements();
   }
 
   describe('LayoutElement', () => {
@@ -123,14 +123,14 @@ describes.realWin('Layers', {amp: false}, env => {
         });
 
         div.style.top = '10px';
-        rootLayout.requestRemeasure();
+        rootLayout.dirtyMeasurements();
         expect(layout.getScrolledPosition()).to.deep.equal({
           left: 0,
           top: 10,
         });
 
         div.style.left = '10px';
-        rootLayout.requestRemeasure();
+        rootLayout.dirtyMeasurements();
         expect(layout.getScrolledPosition()).to.deep.equal({
           left: 10,
           top: 10,
@@ -144,14 +144,14 @@ describes.realWin('Layers', {amp: false}, env => {
         });
 
         parent.style.top = '10px';
-        rootLayout.requestRemeasure();
+        rootLayout.dirtyMeasurements();
         expect(layout.getScrolledPosition()).to.deep.equal({
           left: 0,
           top: 10,
         });
 
         parent.style.left = '10px';
-        rootLayout.requestRemeasure();
+        rootLayout.dirtyMeasurements();
         expect(layout.getScrolledPosition()).to.deep.equal({
           left: 10,
           top: 10,
@@ -166,7 +166,7 @@ describes.realWin('Layers', {amp: false}, env => {
 
         parent.style.top = '10px';
         div.style.left = '10px';
-        rootLayout.requestRemeasure();
+        rootLayout.dirtyMeasurements();
         expect(layout.getScrolledPosition()).to.deep.equal({
           left: 10,
           top: 10,
@@ -174,7 +174,7 @@ describes.realWin('Layers', {amp: false}, env => {
 
         parent.style.left = '10px';
         div.style.top = '10px';
-        rootLayout.requestRemeasure();
+        rootLayout.dirtyMeasurements();
         expect(layout.getScrolledPosition()).to.deep.equal({
           left: 20,
           top: 20,
@@ -188,7 +188,7 @@ describes.realWin('Layers', {amp: false}, env => {
           left: 0,
           top: 0,
         });
-        rootLayout.requestRemeasure();
+        rootLayout.dirtyMeasurements();
         expect(parentLayout.getScrolledPosition()).to.deep.equal({
           left: 0,
           top: 0,
@@ -200,7 +200,7 @@ describes.realWin('Layers', {amp: false}, env => {
           left: 0,
           top: 0,
         });
-        rootLayout.requestRemeasure();
+        rootLayout.dirtyMeasurements();
         expect(rootLayout.getScrolledPosition()).to.deep.equal({
           left: 0,
           top: 0,
@@ -214,7 +214,7 @@ describes.realWin('Layers', {amp: false}, env => {
           left: -5,
           top: -10,
         });
-        rootLayout.requestRemeasure();
+        rootLayout.dirtyMeasurements();
         expect(layout.getScrolledPosition()).to.deep.equal({
           left: -5,
           top: -10,
@@ -226,7 +226,7 @@ describes.realWin('Layers', {amp: false}, env => {
           left: -10,
           top: -20,
         });
-        rootLayout.requestRemeasure();
+        rootLayout.dirtyMeasurements();
         expect(layout.getScrolledPosition()).to.deep.equal({
           left: -10,
           top: -20,
@@ -274,14 +274,14 @@ describes.realWin('Layers', {amp: false}, env => {
         });
 
         div.style.top = '10px';
-        rootLayout.requestRemeasure();
+        rootLayout.dirtyMeasurements();
         expect(layout.getOffsetPosition()).to.deep.equal({
           left: 0,
           top: 10,
         });
 
         div.style.left = '10px';
-        rootLayout.requestRemeasure();
+        rootLayout.dirtyMeasurements();
         expect(layout.getOffsetPosition()).to.deep.equal({
           left: 10,
           top: 10,
@@ -295,14 +295,14 @@ describes.realWin('Layers', {amp: false}, env => {
         });
 
         parent.style.top = '10px';
-        rootLayout.requestRemeasure();
+        rootLayout.dirtyMeasurements();
         expect(layout.getOffsetPosition()).to.deep.equal({
           left: 0,
           top: 10,
         });
 
         parent.style.left = '10px';
-        rootLayout.requestRemeasure();
+        rootLayout.dirtyMeasurements();
         expect(layout.getOffsetPosition()).to.deep.equal({
           left: 10,
           top: 10,
@@ -317,7 +317,7 @@ describes.realWin('Layers', {amp: false}, env => {
 
         parent.style.top = '10px';
         div.style.left = '10px';
-        rootLayout.requestRemeasure();
+        rootLayout.dirtyMeasurements();
         expect(layout.getOffsetPosition()).to.deep.equal({
           left: 10,
           top: 10,
@@ -325,7 +325,7 @@ describes.realWin('Layers', {amp: false}, env => {
 
         parent.style.left = '10px';
         div.style.top = '10px';
-        rootLayout.requestRemeasure();
+        rootLayout.dirtyMeasurements();
         expect(layout.getOffsetPosition()).to.deep.equal({
           left: 20,
           top: 20,
@@ -339,7 +339,7 @@ describes.realWin('Layers', {amp: false}, env => {
           left: 0,
           top: 0,
         });
-        rootLayout.requestRemeasure();
+        rootLayout.dirtyMeasurements();
         expect(parentLayout.getOffsetPosition()).to.deep.equal({
           left: 0,
           top: 0,
@@ -351,7 +351,7 @@ describes.realWin('Layers', {amp: false}, env => {
           left: 0,
           top: 0,
         });
-        rootLayout.requestRemeasure();
+        rootLayout.dirtyMeasurements();
         expect(rootLayout.getOffsetPosition()).to.deep.equal({
           left: 0,
           top: 0,
@@ -365,7 +365,7 @@ describes.realWin('Layers', {amp: false}, env => {
           left: 0,
           top: 0,
         });
-        rootLayout.requestRemeasure();
+        rootLayout.dirtyMeasurements();
         expect(layout.getOffsetPosition()).to.deep.equal({
           left: 0,
           top: 0,
@@ -377,7 +377,7 @@ describes.realWin('Layers', {amp: false}, env => {
           left: 0,
           top: 0,
         });
-        rootLayout.requestRemeasure();
+        rootLayout.dirtyMeasurements();
         expect(layout.getOffsetPosition()).to.deep.equal({
           left: 0,
           top: 0,


### PR DESCRIPTION
This implements the scoring algorithm for Layers. It does not change how viewport distance is calculated yet, which prevents them from being scored far-out of viewport.

/cc @dvoytenko on the `#ancestry` iteration. I ended up waffling, and allow direct access to the `LayoutElement` during iteration, instead of forcing the caller to do the calculations (with a bunch of parameters to the iterator).

Fixes #12650.