### PR TITLE
Handle figure elements in lightboxed carousel with descriptions from aria

### DIFF
--- a/extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.js
+++ b/extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.js
@@ -336,7 +336,7 @@ export class AmpLightboxViewer extends AMP.BaseElement {
    */
   updateDescriptionBox_() {
     const descText = this.getCurrentElement_().descriptionText;
-    this.descriptionTextArea_.textContent = descText;
+    this.descriptionTextArea_.innerText = descText;
     if (!descText) {
       this.descriptionBox_.classList.add('hide');
     }

--- a/extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.js
+++ b/extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.js
@@ -332,7 +332,7 @@ export class AmpLightboxViewer extends AMP.BaseElement {
    */
   updateDescriptionBox_() {
     const descText = this.getCurrentElement_().descriptionText;
-    // The problem with setting this attribute is that it not only removes
+    // The problem with setting innerText is that it not only removes
     // child nodes from the element, but also permanently destroys all
     // descendant text nodes. It is okay in this case because the description
     // text area is a div that does not contain descendant elements.

--- a/extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.js
+++ b/extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.js
@@ -336,7 +336,11 @@ export class AmpLightboxViewer extends AMP.BaseElement {
    */
   updateDescriptionBox_() {
     const descText = this.getCurrentElement_().descriptionText;
-    this.descriptionTextArea_.innerText = descText;
+    // The problem with setting innerText is that it not only removes child
+    // nodes from the element, but also permanently destroys all descendant
+    // text nodes. It is okay in this case because the description text
+    // area is a div that does not contain descendant elements.
+    this.descriptionTextArea_./*OK*/innerText = descText;
     if (!descText) {
       this.descriptionBox_.classList.add('hide');
     }

--- a/extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.js
+++ b/extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.js
@@ -203,6 +203,24 @@ export class AmpLightboxViewer extends AMP.BaseElement {
   }
 
   /**
+   * Return a cleaned clone of the given element for building
+   * carousel slides with.
+   * @param {!Element} element
+   * @private
+   */
+  cloneLightboxableElement_(element) {
+    const deepClone = !element.classList.contains(
+        'i-amphtml-element');
+    let clonedNode = element.cloneNode(deepClone);
+    if (element.tagName == 'FIGURE') {
+      clonedNode = element.getElementsByTagName('amp-img')[0]
+          .cloneNode(deepClone);
+    }
+    clonedNode.removeAttribute('on');
+    clonedNode.removeAttribute('id');
+    return clonedNode;
+  }
+  /**
    * Given a list of lightboxable elements, build the internal carousel slides
    * @param {!Array<!Element>} lightboxableElements
    * @private
@@ -212,11 +230,7 @@ export class AmpLightboxViewer extends AMP.BaseElement {
     this.elementsMetadata_[this.currentLightboxGroupId_] = [];
     lightboxableElements.forEach(element => {
       element.lightboxItemId = index++;
-      const deepClone = !element.classList.contains(
-          'i-amphtml-element');
-      const clonedNode = element.cloneNode(deepClone);
-      clonedNode.removeAttribute('on');
-      clonedNode.removeAttribute('id');
+      const clonedNode = this.cloneLightboxableElement_(element);
       const descText = this.manager_.getDescription(element);
       const metadata = {
         descriptionText: descText,

--- a/extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.js
+++ b/extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.js
@@ -211,13 +211,7 @@ export class AmpLightboxViewer extends AMP.BaseElement {
   cloneLightboxableElement_(element) {
     const deepClone = !element.classList.contains(
         'i-amphtml-element');
-    let clonedNode = element.cloneNode(deepClone);
-    if (element.tagName == 'FIGURE') {
-      const ampImg = element.getElementsByTagName('amp-img');
-      user().assert(ampImg.length == 1,
-          'You must have exactly one amp-img in a figure');
-      clonedNode = ampImg[0].cloneNode(deepClone);
-    }
+    const clonedNode = element.cloneNode(deepClone);
     clonedNode.removeAttribute('on');
     clonedNode.removeAttribute('id');
     return clonedNode;
@@ -338,10 +332,10 @@ export class AmpLightboxViewer extends AMP.BaseElement {
    */
   updateDescriptionBox_() {
     const descText = this.getCurrentElement_().descriptionText;
-    // The problem with setting innerText is that it not only removes child
-    // nodes from the element, but also permanently destroys all descendant
-    // text nodes. It is okay in this case because the description text
-    // area is a div that does not contain descendant elements.
+    // The problem with setting this attribute is that it not only removes
+    // child nodes from the element, but also permanently destroys all
+    // descendant text nodes. It is okay in this case because the description
+    // text area is a div that does not contain descendant elements.
     this.descriptionTextArea_./*OK*/innerText = descText;
     if (!descText) {
       this.descriptionBox_.classList.add('hide');

--- a/extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.js
+++ b/extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.js
@@ -213,8 +213,17 @@ export class AmpLightboxViewer extends AMP.BaseElement {
         'i-amphtml-element');
     let clonedNode = element.cloneNode(deepClone);
     if (element.tagName == 'FIGURE') {
-      clonedNode = element.getElementsByTagName('amp-img')[0]
-          .cloneNode(deepClone);
+      const ampImg = element.getElementsByTagName('amp-img');
+      user().assert(ampImg.length <= 1,
+          'You cannot have more than one amp-img in a figure');
+      if (ampImg.length == 1) {
+        clonedNode = ampImg[0].cloneNode(deepClone);
+      } else {
+        const img = element.getElementsByTagName('img');
+        user().assert(img.length == 1,
+            'You must have exactly one img or amp-img in a figure');
+        clonedNode = img[0].cloneNode(deepClone);
+      }
     }
     clonedNode.removeAttribute('on');
     clonedNode.removeAttribute('id');

--- a/extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.js
+++ b/extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.js
@@ -214,16 +214,9 @@ export class AmpLightboxViewer extends AMP.BaseElement {
     let clonedNode = element.cloneNode(deepClone);
     if (element.tagName == 'FIGURE') {
       const ampImg = element.getElementsByTagName('amp-img');
-      user().assert(ampImg.length <= 1,
-          'You cannot have more than one amp-img in a figure');
-      if (ampImg.length == 1) {
-        clonedNode = ampImg[0].cloneNode(deepClone);
-      } else {
-        const img = element.getElementsByTagName('img');
-        user().assert(img.length == 1,
-            'You must have exactly one img or amp-img in a figure');
-        clonedNode = img[0].cloneNode(deepClone);
-      }
+      user().assert(ampImg.length == 1,
+          'You must have exactly one amp-img in a figure');
+      clonedNode = ampImg[0].cloneNode(deepClone);
     }
     clonedNode.removeAttribute('on');
     clonedNode.removeAttribute('id');

--- a/extensions/amp-lightbox-viewer/0.1/service/lightbox-manager-impl.js
+++ b/extensions/amp-lightbox-viewer/0.1/service/lightbox-manager-impl.js
@@ -284,7 +284,7 @@ export class LightboxManager {
       const descriptionElement = element.ownerDocument
           .getElementById(ariaLabelledBy);
       if (descriptionElement) {
-        return descriptionElement.innerText;
+        return descriptionElement./*OK*/innerText;
       }
     }
 

--- a/extensions/amp-lightbox-viewer/0.1/service/lightbox-manager-impl.js
+++ b/extensions/amp-lightbox-viewer/0.1/service/lightbox-manager-impl.js
@@ -27,6 +27,7 @@ const ELIGIBLE_TAP_TAGS = {
 
 const VIEWER_TAG = 'amp-lightbox-viewer';
 const CAROUSEL_TAG = 'amp-carousel';
+const FIGURE_TAG = 'figure';
 const SLIDE_SELECTOR = '.amp-carousel-slide';
 
 /** @typedef {{
@@ -134,7 +135,6 @@ export class LightboxManager {
        'carousel' + (element.getAttribute('id') || this.counter_++);
       this.getSlidesFromCarousel_(element).then(slides => {
         slides.forEach(slide => {
-          // TODO: review naming conventions for component attributes
           if (!slide.hasAttribute('lightbox-exclude')) {
             slide.setAttribute('lightbox', lightboxGroupId);
             this.processBaseLightboxElement_(slide, lightboxGroupId);
@@ -148,6 +148,10 @@ export class LightboxManager {
   }
 
   processBaseLightboxElement_(element, lightboxGroupId) {
+    if (element.tagName.toLowerCase() == FIGURE_TAG) {
+      element = elementByTag(element, 'amp-img');
+      element.setAttribute('lightbox', lightboxGroupId);
+    }
     if (!this.lightboxGroups_[lightboxGroupId]) {
       this.lightboxGroups_[lightboxGroupId] = [];
     }
@@ -186,8 +190,8 @@ export class LightboxManager {
    * @return {?string}
    */
   getDescription(element) {
-    if (element.tagName == 'FIGURE') {
-      const figCaption = element.getElementsByTagName('figcaption')[0];
+    if (element.parentElement.tagName == 'FIGURE') {
+      const figCaption = elementByTag(element.parentElement, 'figcaption');
       if (figCaption) {
         return figCaption./*OK*/innerText;
       }

--- a/extensions/amp-lightbox-viewer/0.1/service/lightbox-manager-impl.js
+++ b/extensions/amp-lightbox-viewer/0.1/service/lightbox-manager-impl.js
@@ -189,7 +189,7 @@ export class LightboxManager {
     if (element.tagName == 'FIGURE') {
       const figCaption = element.getElementsByTagName('figcaption')[0];
       if (figCaption) {
-        return figCaption.innerText;
+        return figCaption./*OK*/innerText;
       }
     }
     const alt = element.getAttribute('alt');
@@ -201,7 +201,7 @@ export class LightboxManager {
       const descriptionElement = element.ownerDocument
           .getElementById(ariaDescribedBy);
       if (descriptionElement) {
-        return descriptionElement.innerText;
+        return descriptionElement./*OK*/innerText;
       }
     }
     const ariaLabel = element.getAttribute('aria-label');

--- a/extensions/amp-lightbox-viewer/0.1/service/lightbox-manager-impl.js
+++ b/extensions/amp-lightbox-viewer/0.1/service/lightbox-manager-impl.js
@@ -181,7 +181,6 @@ export class LightboxManager {
   }
 
   /**
-   * The function is simplified for testing now.
    * Get the description for single lightboxed item.
    * @param {!Element} element
    * @return {?string}
@@ -197,9 +196,22 @@ export class LightboxManager {
     if (alt) {
       return alt;
     }
-    const aria = element.getAttribute('aria-describedby');
-    if (aria) {
-      const descriptionElement = element.ownerDocument.getElementById(aria);
+    const ariaDescribedBy = element.getAttribute('aria-describedby');
+    if (ariaDescribedBy) {
+      const descriptionElement = element.ownerDocument
+          .getElementById(ariaDescribedBy);
+      if (descriptionElement) {
+        return descriptionElement.textContent;
+      }
+    }
+    const ariaLabel = element.getAttribute('aria-label');
+    if (ariaLabel) {
+      return ariaLabel;
+    }
+    const ariaLabelledBy = element.getAttribute('aria-labelledby');
+    if (ariaLabelledBy) {
+      const descriptionElement = element.ownerDocument
+          .getElementById(ariaLabelledBy);
       if (descriptionElement) {
         return descriptionElement.textContent;
       }

--- a/extensions/amp-lightbox-viewer/0.1/service/lightbox-manager-impl.js
+++ b/extensions/amp-lightbox-viewer/0.1/service/lightbox-manager-impl.js
@@ -15,20 +15,32 @@
  */
 
 import {isExperimentOn} from '../../../../src/experiments';
-import {dev} from '../../../../src/log';
-import {elementByTag, iterateCursor} from '../../../../src/dom';
+import {dev, user} from '../../../../src/log';
+import {
+  childElement,
+  closestByTag,
+  elementByTag,
+  iterateCursor,
+} from '../../../../src/dom';
 import {toArray} from '../../../../src/types';
 import {CommonSignals} from '../../../../src/common-signals';
 
+const LIGHTBOX_ELIGIBLE_TAGS = {
+  'amp-img': true,
+};
+
 const ELIGIBLE_TAP_TAGS = {
   'amp-img': true,
-  'amp-anim': true,
 };
 
 const VIEWER_TAG = 'amp-lightbox-viewer';
 const CAROUSEL_TAG = 'amp-carousel';
 const FIGURE_TAG = 'figure';
 const SLIDE_SELECTOR = '.amp-carousel-slide';
+
+const VALIDATION_ERROR_MSG = `lightbox attribute is only supported for the
+  <amp-img> tag and <figure> and <amp-carousel> tags containing the <amp-img>
+  tag right now.`;
 
 /** @typedef {{
  *  url: string,
@@ -125,36 +137,88 @@ export class LightboxManager {
   }
 
   /**
+   * Checks to see if a root element is supported.
+   * @param {Element} element
+   * @return {boolean}
+   * @private
+   */
+  baseElementIsSupported_(element) {
+    return LIGHTBOX_ELIGIBLE_TAGS[element.tagName.toLowerCase()];
+  }
+
+  /**
+   * Process an amp-carousel element for lightbox, assigns a lightbox
+   * group id, installs the lightbox attribute and tap handlers to open
+   * the lightbox on the eligible slide elements.
+   * @param {!Element} carousel
+   */
+  processLightboxCarousel_(carousel) {
+    const lightboxGroupId = carousel.getAttribute('lightbox') ||
+    'carousel' + (carousel.getAttribute('id') || this.counter_++);
+    this.getSlidesFromCarousel_(carousel).then(slides => {
+      slides.forEach(slide => {
+        if (!slide.hasAttribute('lightbox-exclude')) {
+          slide.setAttribute('lightbox', lightboxGroupId);
+          this.processBaseLightboxElement_(slide, lightboxGroupId);
+        }
+      });
+    });
+  }
+  /**
    * Adds element to correct lightbox group, installs tap handler.
    * @param {!Element} element
    * @private
    */
   processLightboxElement_(element) {
     if (element.tagName.toLowerCase() == CAROUSEL_TAG) {
-      const lightboxGroupId = element.getAttribute('lightbox') ||
-       'carousel' + (element.getAttribute('id') || this.counter_++);
-      this.getSlidesFromCarousel_(element).then(slides => {
-        slides.forEach(slide => {
-          if (!slide.hasAttribute('lightbox-exclude')) {
-            slide.setAttribute('lightbox', lightboxGroupId);
-            this.processBaseLightboxElement_(slide, lightboxGroupId);
-          }
-        });
-      });
+      this.processLightboxCarousel_(element);
     } else {
       const lightboxGroupId = element.getAttribute('lightbox') || 'default';
       this.processBaseLightboxElement_(element, lightboxGroupId);
     }
   }
 
-  processBaseLightboxElement_(element, lightboxGroupId) {
-    if (element.tagName.toLowerCase() == FIGURE_TAG) {
-      element = elementByTag(element, 'amp-img');
+  /**
+   * Unwraps a figure element and lightboxes the
+   * @param {!Element} figure
+   * @param {string} lightboxGroupId
+   * @return {?Element}
+   * @private
+   */
+  unwrapLightboxedFigure_(figure, lightboxGroupId) {
+    // Assume that the lightbox target is whichever element inside the figure
+    // that is not the figcaption.
+    const element = childElement(figure,
+        child => child.tagName !== 'FIGCAPTION');
+    if (element) {
       element.setAttribute('lightbox', lightboxGroupId);
     }
+    return element;
+  }
+
+  /**
+   * Assigns each lightboxed element to a lightbox group and adds
+   * the on tap activate attribute.
+   * @param {!Element} element
+   * @param {string} lightboxGroupId
+   */
+  processBaseLightboxElement_(element, lightboxGroupId) {
+    if (element.tagName.toLowerCase() == FIGURE_TAG) {
+      const unwrappedFigureElement = this.unwrapLightboxedFigure_(element,
+          lightboxGroupId);
+      if (!unwrappedFigureElement) {
+        return;
+      } else {
+        element = unwrappedFigureElement;
+      }
+    }
+
+    user().assert(this.baseElementIsSupported_(element), VALIDATION_ERROR_MSG);
+
     if (!this.lightboxGroups_[lightboxGroupId]) {
       this.lightboxGroups_[lightboxGroupId] = [];
     }
+
     this.lightboxGroups_[lightboxGroupId]
         .push(dev().assertElement(element));
     if (this.meetsHeuristicsForTap_(element)) {
@@ -187,11 +251,14 @@ export class LightboxManager {
   /**
    * Get the description for single lightboxed item.
    * @param {!Element} element
-   * @return {?string}
+   * @return {string|null}
    */
   getDescription(element) {
-    if (element.parentElement.tagName == 'FIGURE') {
-      const figCaption = elementByTag(element.parentElement, 'figcaption');
+    // If the element in question is the descendant of a figure element
+    // try using the figure caption as the lightbox description.
+    const figureParent = closestByTag(element, 'figure');
+    if (figureParent) {
+      const figCaption = elementByTag(figureParent, 'figcaption');
       if (figCaption) {
         return figCaption./*OK*/innerText;
       }

--- a/extensions/amp-lightbox-viewer/0.1/service/lightbox-manager-impl.js
+++ b/extensions/amp-lightbox-viewer/0.1/service/lightbox-manager-impl.js
@@ -187,6 +187,16 @@ export class LightboxManager {
    * @return {?string}
    */
   getDescription(element) {
+    if (element.tagName == 'FIGURE') {
+      const figCaption = element.getElementsByTagName('figcaption')[0];
+      if (figCaption) {
+        return figCaption.textContent;
+      }
+    }
+    const alt = element.getAttribute('alt');
+    if (alt) {
+      return alt;
+    }
     const aria = element.getAttribute('aria-describedby');
     if (aria) {
       const descriptionElement = element.ownerDocument.getElementById(aria);
@@ -194,10 +204,7 @@ export class LightboxManager {
         return descriptionElement.textContent;
       }
     }
-    const alt = element.getAttribute('alt');
-    if (alt) {
-      return alt;
-    }
+
     return null;
   }
 

--- a/extensions/amp-lightbox-viewer/0.1/service/lightbox-manager-impl.js
+++ b/extensions/amp-lightbox-viewer/0.1/service/lightbox-manager-impl.js
@@ -189,7 +189,7 @@ export class LightboxManager {
     if (element.tagName == 'FIGURE') {
       const figCaption = element.getElementsByTagName('figcaption')[0];
       if (figCaption) {
-        return figCaption.textContent;
+        return figCaption.innerText;
       }
     }
     const alt = element.getAttribute('alt');
@@ -201,7 +201,7 @@ export class LightboxManager {
       const descriptionElement = element.ownerDocument
           .getElementById(ariaDescribedBy);
       if (descriptionElement) {
-        return descriptionElement.textContent;
+        return descriptionElement.innerText;
       }
     }
     const ariaLabel = element.getAttribute('aria-label');
@@ -213,7 +213,7 @@ export class LightboxManager {
       const descriptionElement = element.ownerDocument
           .getElementById(ariaLabelledBy);
       if (descriptionElement) {
-        return descriptionElement.textContent;
+        return descriptionElement.innerText;
       }
     }
 

--- a/test/manual/amp-lightbox-carousel-demo.amp.html
+++ b/test/manual/amp-lightbox-carousel-demo.amp.html
@@ -209,11 +209,6 @@
       width="300"
       height="200"
       alt="and another sample image"></amp-img>
-    <amp-youtube
-      lightbox-thumbnail-src="https://i.ytimg.com/vi/lBTCB7yLs8Y/maxresdefault.jpg"
-      data-videoid="lBTCB7yLs8Y"
-      layout="responsive"
-      width="480" height="270"></amp-youtube>
   </amp-carousel>
   <div id='my-aria-describe'>
     This is an aria described by a div. <br/>

--- a/test/manual/amp-lightbox-carousel-demo.amp.html
+++ b/test/manual/amp-lightbox-carousel-demo.amp.html
@@ -180,15 +180,15 @@
     <amp-img src="https://picsum.photos/300/200/?image=32"
       width="300"
       height="200"
-      alt="and another sample image"></amp-img>
+      aria-label="Aria labels are cool."></amp-img>
     <amp-img src="https://picsum.photos/300/200/?image=33"
       width="300"
       height="200"
-      alt="and another sample image"></amp-img>
+      aria-describedby="my-aria-describe"></amp-img>
     <amp-img src="https://picsum.photos/300/200/?image=34"
       width="300"
       height="200"
-      alt="and another sample image"></amp-img>
+      aria-labelledby="my-aria-label"></amp-img>
     <amp-img src="https://picsum.photos/300/200/?image=35"
       width="300"
       height="200"
@@ -215,6 +215,11 @@
       layout="responsive"
       width="480" height="270"></amp-youtube>
   </amp-carousel>
-
+  <div id='my-aria-describe'>
+    This is an aria described by a div.
+  </div>
+  <div id='my-aria-label'>
+    This is an aria labelled by a div.
+  </div>
 </body>
 </html>

--- a/test/manual/amp-lightbox-carousel-demo.amp.html
+++ b/test/manual/amp-lightbox-carousel-demo.amp.html
@@ -216,10 +216,12 @@
       width="480" height="270"></amp-youtube>
   </amp-carousel>
   <div id='my-aria-describe'>
-    This is an aria described by a div.
+    This is an aria described by a div. <br/>
+    I have a linebreak.
   </div>
   <div id='my-aria-label'>
-    This is an aria labelled by a div.
+    This is an aria labelled by a div. <br/>
+    I also have a newline.
   </div>
 </body>
 </html>

--- a/test/manual/amp-lightbox-carousel-demo.amp.html
+++ b/test/manual/amp-lightbox-carousel-demo.amp.html
@@ -170,10 +170,13 @@
       width="300"
       height="200"
       alt="a sample image"></amp-img>
-    <amp-img src="https://picsum.photos/300/200/?image=31"
-      width="300"
-      height="200"
-      alt="another sample image"></amp-img>
+    <figure>
+        <amp-img src="https://picsum.photos/300/200/?image=31"
+        width="300"
+        height="200"
+        alt="another sample image"></amp-img>
+        <figcaption>This is a figure with a figcaption.</figcaption>
+    </figure>
     <amp-img src="https://picsum.photos/300/200/?image=32"
       width="300"
       height="200"
@@ -209,7 +212,7 @@
     <amp-youtube
       lightbox-thumbnail-src="https://i.ytimg.com/vi/lBTCB7yLs8Y/maxresdefault.jpg"
       data-videoid="lBTCB7yLs8Y"
-      layout="container"
+      layout="responsive"
       width="480" height="270"></amp-youtube>
   </amp-carousel>
 


### PR DESCRIPTION
Addresses https://github.com/ampproject/amphtml/issues/12960, https://github.com/ampproject/amphtml/issues/12959. 

- [x] Do some research on `innerText` support on IE 11 before marking `/* OK */` or find alternative. 

On the subject of `innerText`, this is [the best article I could find](http://perfectionkills.com/the-poor-misunderstood-innerText/). It sounds like from the [standards](https://html.spec.whatwg.org/multipage/dom.html#the-innertext-idl-attribute), that we have pretty good browser support for it. The main downside is a very non-trivial [perf regression](https://jsperf.com/innerhtml-vs-innertext/17). However, for this particular use case, it isn't terrible. Basically you have a get and a set every time you have a slide change, which amongst other things that are happening, isn't going to be the perf bottleneck. 
