### PR TITLE
Fix date picker sample with external src

### DIFF
--- a/examples/date-picker.json
+++ b/examples/date-picker.json
@@ -1,6 +1,6 @@
 {
   "templates": [{
-    "id": "low",
+    "id": "spooky",
     "dates": [
       "2017-11-01", "2017-11-03", "2017-11-05", "2017-11-06",
       "FREQ=WEEKLY;DTSTART=20171101T150000Z;COUNT=30;WKST=MO;BYDAY=TU,SA"


### PR DESCRIPTION
The id used in the `json` and the one used in the sample template should be the same in order to get the sample to work.
@cvializ FYI