### PR TITLE
Story video loading spinner.

### DIFF
--- a/extensions/amp-story/0.1/amp-story-page.js
+++ b/extensions/amp-story/0.1/amp-story-page.js
@@ -642,7 +642,7 @@ export class AmpStoryPage extends AMP.BaseElement {
    */
   stopListeningToVideoEvents_() {
     this.unlisteners_.forEach(unlisten => unlisten());
-    this.unlisteners_.length = 0;
+    this.unlisteners_ = [];
   }
 
 

--- a/extensions/amp-story/0.1/amp-story-page.js
+++ b/extensions/amp-story/0.1/amp-story-page.js
@@ -628,12 +628,12 @@ export class AmpStoryPage extends AMP.BaseElement {
     }
 
     this.debounceToggleLoadingSpinner_(true);
-    for (let videoEl of videos) {
+    Array.prototype.forEach.call(videos, videoEl => {
       this.unlisteners_.push(listen(
           videoEl, 'playing', () => this.debounceToggleLoadingSpinner_(false)));
       this.unlisteners_.push(listen(
           videoEl, 'waiting', () => this.debounceToggleLoadingSpinner_(true)));
-    }
+    });
   }
 
 

--- a/extensions/amp-story/0.1/amp-story-page.js
+++ b/extensions/amp-story/0.1/amp-story-page.js
@@ -98,7 +98,7 @@ export class AmpStoryPage extends AMP.BaseElement {
 
     /** @const @private {!function()} */
     this.debounceToggleLoadingSpinner_ = debounce(
-        this.win, isActive => this.toggleLoadingSpinner_(isActive), 100);
+        this.win, isActive => this.toggleLoadingSpinner_(!!isActive), 100);
 
     /** @const @private {!Array<function()>} */
     this.unlisteners_ = [];
@@ -628,12 +628,12 @@ export class AmpStoryPage extends AMP.BaseElement {
     }
 
     this.debounceToggleLoadingSpinner_(true);
-    videos.forEach(videoEl => {
+    for (let videoEl of videos) {
       this.unlisteners_.push(listen(
           videoEl, 'playing', () => this.debounceToggleLoadingSpinner_(false)));
       this.unlisteners_.push(listen(
           videoEl, 'waiting', () => this.debounceToggleLoadingSpinner_(true)));
-    });
+    }
   }
 
 
@@ -649,9 +649,9 @@ export class AmpStoryPage extends AMP.BaseElement {
   /**
    * @private
    */
-  buildAndAttachLoadingSpinner_() {
+  buildAndAppendLoadingSpinner_() {
     this.loadingSpinner_ = new LoadingSpinner(this.win.document);
-    this.loadingSpinner_.attach(this.element);
+    this.element.appendChild(this.loadingSpinner_.build());
   }
 
 
@@ -664,9 +664,9 @@ export class AmpStoryPage extends AMP.BaseElement {
    * @private
    */
   toggleLoadingSpinner_(isActive) {
-    this.getVsync(this).mutate(() => {
+    this.getVsync().mutate(() => {
       if (!this.loadingSpinner_) {
-        this.buildAndAttachLoadingSpinner_();
+        this.buildAndAppendLoadingSpinner_();
       }
 
       this.loadingSpinner_.toggle(isActive);

--- a/extensions/amp-story/0.1/amp-story-page.js
+++ b/extensions/amp-story/0.1/amp-story-page.js
@@ -34,6 +34,9 @@ import {AdvancementConfig} from './page-advancement';
 import {matches, scopedQuerySelectorAll} from '../../../src/dom';
 import {getLogEntries} from './logging';
 import {getMode} from '../../../src/mode';
+import {LoadingSpinner} from './loading-spinner';
+import {listen} from '../../../src/event-helper';
+import {debounce} from '../../../src/utils/rate-limit';
 
 
 /**
@@ -69,6 +72,9 @@ export class AmpStoryPage extends AMP.BaseElement {
     /** @private @const {!AdvancementConfig} */
     this.advancement_ = AdvancementConfig.forPage(this);
 
+    /** @private {?Element} */
+    this.loadingSpinner_ = null;
+
     /** @private @const {!Promise} */
     this.mediaLayoutPromise_ = this.waitForMediaLayout_();
 
@@ -89,6 +95,13 @@ export class AmpStoryPage extends AMP.BaseElement {
     /** @private @const {boolean} Only prerender the first story page. */
     this.prerenderAllowed_ = matches(this.element,
         'amp-story-page:first-of-type');
+
+    /** @const @private {!function()} */
+    this.debounceToggleLoadingSpinner_ = debounce(
+        this.win, isActive => this.toggleLoadingSpinner_(isActive), 100);
+
+    /** @const @private {!Array<function()>} */
+    this.unlisteners_ = [];
   }
 
 
@@ -146,6 +159,7 @@ export class AmpStoryPage extends AMP.BaseElement {
   pauseCallback() {
     this.advancement_.stop();
 
+    this.stopListeningToVideoEvents_();
     this.pauseAllMedia_(/* opt_rewindToBeginning */ false);
 
     if (this.animationManager_) {
@@ -161,7 +175,9 @@ export class AmpStoryPage extends AMP.BaseElement {
     if (this.isActive()) {
       this.advancement_.start();
       this.maybeStartAnimations();
-      this.playAllMedia_();
+      this.preloadAllMedia_()
+          .then(() => this.startListeningToVideoEvents_())
+          .then(() => this.playAllMedia_());
     }
 
     this.reportDevModeErrors_();
@@ -256,15 +272,26 @@ export class AmpStoryPage extends AMP.BaseElement {
   }
 
 
+   /**
+   * Gets all video elements on this page.
+   * @return {!NodeList<!Element>}
+   * @private
+   */
+  getAllVideos_() {
+    return scopedQuerySelectorAll(this.element, 'video');
+  }
+
+
   /**
    * Applies the specified callback to each media element on the page, after the
    * media element is loaded.
    * @param {!function(!./media-pool.MediaPool, !Element)} callbackFn The
    *     callback to be applied to each media element.
+   * @return {!Promise} Promise that resolves after the callbacks are called.
    */
   forEachMediaElement_(callbackFn) {
     const mediaSet = this.getAllMedia_();
-    this.mediaPoolPromise_.then(mediaPool => {
+    return this.mediaPoolPromise_.then(mediaPool => {
       Array.prototype.forEach.call(mediaSet, mediaEl => {
         callbackFn(mediaPool, mediaEl);
       });
@@ -276,10 +303,11 @@ export class AmpStoryPage extends AMP.BaseElement {
    * Pauses all media on this page.
    * @param {boolean=} opt_rewindToBeginning Whether to rewind the currentTime
    *     of media items to the beginning.
+   * @return {!Promise} Promise that resolves after the callbacks are called.
    * @private
    */
   pauseAllMedia_(opt_rewindToBeginning) {
-    this.forEachMediaElement_((mediaPool, mediaEl) => {
+    return this.forEachMediaElement_((mediaPool, mediaEl) => {
       mediaPool.pause(/** @type {!HTMLMediaElement} */ (mediaEl),
           opt_rewindToBeginning);
     });
@@ -287,29 +315,35 @@ export class AmpStoryPage extends AMP.BaseElement {
 
 
   /**
-   * Pauses all media on this page.
+   * Plays all media on this page.
+   * @return {!Promise} Promise that resolves after the callbacks are called.
    * @private
    */
   playAllMedia_() {
-    this.forEachMediaElement_((mediaPool, mediaEl) => {
+    return this.forEachMediaElement_((mediaPool, mediaEl) => {
       mediaPool.play(/** @type {!HTMLMediaElement} */ (mediaEl));
     });
   }
 
 
   /**
-   * Pauses all media on this page.
+   * Preloads all media on this page.
+   * @return {!Promise} Promise that resolves after the callbacks are called.
    * @private
    */
   preloadAllMedia_() {
-    this.forEachMediaElement_((mediaPool, mediaEl) => {
+    return this.forEachMediaElement_((mediaPool, mediaEl) => {
       mediaPool.preload(/** @type {!HTMLMediaElement} */ (mediaEl));
     });
   }
 
-  /** @private */
+
+  /**
+   * @return {!Promise} Promise that resolves after the callbacks are called.
+   * @private
+   */
   rewindAllMediaToBeginning_() {
-    this.forEachMediaElement_((mediaPool, mediaEl) => {
+    return this.forEachMediaElement_((mediaPool, mediaEl) => {
       mediaPool.rewindToBeginning(/** @type {!HTMLMediaElement} */ (mediaEl));
     });
   }
@@ -317,9 +351,10 @@ export class AmpStoryPage extends AMP.BaseElement {
 
   /**
    * Mutes all media on this page.
+   * @return {!Promise} Promise that resolves after the callbacks are called.
    */
   muteAllMedia() {
-    this.forEachMediaElement_((mediaPool, mediaEl) => {
+    return this.forEachMediaElement_((mediaPool, mediaEl) => {
       mediaPool.mute(/** @type {!HTMLMediaElement} */ (mediaEl));
     });
   }
@@ -327,9 +362,10 @@ export class AmpStoryPage extends AMP.BaseElement {
 
   /**
    * Unmutes all media on this page.
+   * @return {!Promise} Promise that resolves after the callbacks are called.
    */
   unmuteAllMedia() {
-    this.forEachMediaElement_((mediaPool, mediaEl) => {
+    return this.forEachMediaElement_((mediaPool, mediaEl) => {
       mediaPool.unmute(/** @type {!HTMLMediaElement} */ (mediaEl));
     });
   }
@@ -337,10 +373,11 @@ export class AmpStoryPage extends AMP.BaseElement {
 
   /**
    * Registers all media on this page
+   * @return {!Promise} Promise that resolves after the callbacks are called.
    * @private
    */
   registerAllMedia_() {
-    this.forEachMediaElement_((mediaPool, mediaEl) => {
+    return this.forEachMediaElement_((mediaPool, mediaEl) => {
       mediaPool.register(/** @type {!HTMLMediaElement} */ (mediaEl));
     });
   }
@@ -573,6 +610,66 @@ export class AmpStoryPage extends AMP.BaseElement {
     getLogEntries(this.element).then(logEntries => {
       dispatchCustom(this.win, this.element,
           EventType.DEV_LOG_ENTRIES_AVAILABLE, logEntries, {bubbles: true});
+    });
+  }
+
+
+  /**
+   * Displays a loading spinner whenever the video is buffering.
+   * Has to be called after the mediaPool preload method, that swaps the video
+   * elements with new amp elements.
+   * @private
+   */
+  startListeningToVideoEvents_() {
+    const videos = this.getAllVideos_();
+
+    if (videos.length === 0) {
+      return;
+    }
+
+    this.debounceToggleLoadingSpinner_(true);
+    videos.forEach((videoEl) => {
+      this.unlisteners_.push(listen(
+          videoEl, 'playing', () => this.debounceToggleLoadingSpinner_(false)));
+      this.unlisteners_.push(listen(
+          videoEl, 'waiting', () => this.debounceToggleLoadingSpinner_(true)));
+    });
+  }
+
+
+  /**
+   * @private
+   */
+  stopListeningToVideoEvents_() {
+    this.unlisteners_.forEach(unlisten => unlisten());
+    this.unlisteners_.length = 0;
+  }
+
+
+  /**
+   * @private
+   */
+  buildAndAttachLoadingSpinner_() {
+    this.loadingSpinner_ = new LoadingSpinner(this.win.document);
+    this.loadingSpinner_.attach(this.element);
+  }
+
+
+  /**
+   * Has to be called through the `debounceToggleLoadingSpinner_` method, to
+   * avoid the spinner flashing on the screen when the video loops, or during
+   * navigation transitions.
+   * Builds the loading spinner and attaches it to the DOM on first call.
+   * @param {boolean} isActive
+   * @private
+   */
+  toggleLoadingSpinner_(isActive) {
+    this.getVsync(this).mutate(() => {
+      if (!this.loadingSpinner_) {
+        this.buildAndAttachLoadingSpinner_();
+      }
+
+      this.loadingSpinner_.toggle(isActive);
     });
   }
 }

--- a/extensions/amp-story/0.1/amp-story-page.js
+++ b/extensions/amp-story/0.1/amp-story-page.js
@@ -100,7 +100,7 @@ export class AmpStoryPage extends AMP.BaseElement {
     this.debounceToggleLoadingSpinner_ = debounce(
         this.win, isActive => this.toggleLoadingSpinner_(!!isActive), 100);
 
-    /** @const @private {!Array<function()>} */
+    /** @private {!Array<function()>} */
     this.unlisteners_ = [];
   }
 

--- a/extensions/amp-story/0.1/amp-story-page.js
+++ b/extensions/amp-story/0.1/amp-story-page.js
@@ -272,7 +272,7 @@ export class AmpStoryPage extends AMP.BaseElement {
   }
 
 
-   /**
+  /**
    * Gets all video elements on this page.
    * @return {!NodeList<!Element>}
    * @private
@@ -628,7 +628,7 @@ export class AmpStoryPage extends AMP.BaseElement {
     }
 
     this.debounceToggleLoadingSpinner_(true);
-    videos.forEach((videoEl) => {
+    videos.forEach(videoEl => {
       this.unlisteners_.push(listen(
           videoEl, 'playing', () => this.debounceToggleLoadingSpinner_(false)));
       this.unlisteners_.push(listen(

--- a/extensions/amp-story/0.1/amp-story.css
+++ b/extensions/amp-story/0.1/amp-story.css
@@ -926,3 +926,126 @@ amp-story[standalone].i-amphtml-story-landscape .i-amphtml-story-no-rotation-ove
 .i-amphtml-story-button-container {
   display: none !important;
 }
+
+/* Default loading spinner */
+
+.i-amphtml-story-spinner {
+  display: inline-block;
+  position: absolute;
+  top: calc(100% - 36px);
+  right: 12px;
+  width: 24px;
+  height: 24px;
+  z-index: 10;
+}
+
+.i-amphtml-story-spinner-container {
+  width: 100%;
+  height: 100%;
+  direction: ltr;
+}
+
+.i-amphtml-story-spinner[active] .i-amphtml-story-spinner-container {
+  animation: container-rotate 1294ms linear infinite;
+}
+
+@keyframes container-rotate {
+  to { transform: rotate(360deg) }
+}
+
+.i-amphtml-story-spinner-layer {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+  white-space: nowrap;
+  color: white;
+}
+
+.i-amphtml-story-spinner[active] .i-amphtml-story-spinner-layer {
+  animation-name: fill-unfill-rotate;
+  animation-duration: 4400ms;
+  animation-timing-function: cubic-bezier(0.4, 0.0, 0.2, 1);
+  animation-iteration-count: infinite;
+  opacity: 1;
+}
+
+@keyframes fill-unfill-rotate {
+  12.5% { transform: rotate(135deg) }
+  25%   { transform: rotate(270deg) }
+  37.5% { transform: rotate(405deg) }
+  50%   { transform: rotate(540deg) }
+  62.5% { transform: rotate(675deg) }
+  75%   { transform: rotate(810deg) }
+  87.5% { transform: rotate(945deg) }
+  to    { transform: rotate(1080deg) }
+}
+
+.i-amphtml-story-spinner-circle-clipper {
+  display: inline-block;
+  position: relative;
+  width: 50%;
+  height: 100%;
+  overflow: hidden;
+}
+
+.i-amphtml-story-spinner-layer::after {
+  left: 45%;
+  width: 10%;
+  border-top-style: solid;
+}
+
+.i-amphtml-story-spinner-layer::after,
+.i-amphtml-story-spinner-circle-clipper::after {
+  content: '';
+  box-sizing: border-box;
+  position: absolute;
+  top: 0;
+  border-width: 3px;
+  border-radius: 50%;
+}
+
+.i-amphtml-story-spinner-circle-clipper::after {
+  bottom: 0;
+  width: 200%;
+  border-style: solid;
+  border-bottom-color: transparent !important;
+}
+
+.i-amphtml-story-spinner-circle-clipper.left::after {
+  left: 0;
+  border-right-color: transparent !important;
+  transform: rotate(129deg);
+}
+
+.i-amphtml-story-spinner-circle-clipper.right::after {
+  left: -100%;
+  border-left-color: transparent !important;
+  transform: rotate(-129deg);
+}
+
+.i-amphtml-story-spinner[active] .i-amphtml-story-spinner-circle-clipper::after {
+  animation-duration: 1100ms;
+  animation-timing-function: cubic-bezier(0.4, 0.0, 0.2, 1);
+  animation-iteration-count: infinite;
+}
+
+.i-amphtml-story-spinner[active] .i-amphtml-story-spinner-circle-clipper.left::after {
+  animation-name: left-spin;
+}
+
+.i-amphtml-story-spinner[active] .i-amphtml-story-spinner-circle-clipper.right::after {
+  animation-name: right-spin;
+}
+
+@keyframes left-spin {
+  0% { transform: rotate(130deg) }
+  50% { transform: rotate(-5deg) }
+  to { transform: rotate(130deg) }
+}
+
+@keyframes right-spin {
+  0% { transform: rotate(-130deg) }
+  50% { transform: rotate(5deg) }
+  to { transform: rotate(-130deg) }
+}

--- a/extensions/amp-story/0.1/amp-story.css
+++ b/extensions/amp-story/0.1/amp-story.css
@@ -930,23 +930,23 @@ amp-story[standalone].i-amphtml-story-landscape .i-amphtml-story-no-rotation-ove
 /* Default loading spinner */
 
 .i-amphtml-story-spinner {
-  display: inline-block;
-  position: absolute;
-  top: calc(100% - 36px);
-  right: 12px;
-  width: 24px;
-  height: 24px;
-  z-index: 10;
+  display: inline-block !important;
+  position: absolute !important;
+  top: calc(100% - 36px) !important;
+  right: 12px !important;
+  width: 24px !important;
+  height: 24px !important;
+  z-index: 10 !important;
 }
 
 .i-amphtml-story-spinner-container {
-  width: 100%;
-  height: 100%;
-  direction: ltr;
+  width: 100% !important;
+  height: 100% !important;
+  direction: ltr !important;
 }
 
 .i-amphtml-story-spinner[active] .i-amphtml-story-spinner-container {
-  animation: container-rotate 1294ms linear infinite;
+  animation: container-rotate 1294ms linear infinite !important;
 }
 
 @keyframes container-rotate {
@@ -954,20 +954,20 @@ amp-story[standalone].i-amphtml-story-landscape .i-amphtml-story-no-rotation-ove
 }
 
 .i-amphtml-story-spinner-layer {
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  opacity: 0;
-  white-space: nowrap;
-  color: white;
+  position: absolute !important;
+  width: 100% !important;
+  height: 100% !important;
+  opacity: 0 !important;
+  white-space: nowrap !important;
+  color: white !important;
 }
 
 .i-amphtml-story-spinner[active] .i-amphtml-story-spinner-layer {
-  animation-name: fill-unfill-rotate;
-  animation-duration: 4400ms;
-  animation-timing-function: cubic-bezier(0.4, 0.0, 0.2, 1);
-  animation-iteration-count: infinite;
-  opacity: 1;
+  animation-name: fill-unfill-rotate !important;
+  animation-duration: 4400ms !important;
+  animation-timing-function: cubic-bezier(0.4, 0.0, 0.2, 1) !important;
+  animation-iteration-count: infinite !important;
+  opacity: 1 !important;
 }
 
 @keyframes fill-unfill-rotate {
@@ -982,60 +982,60 @@ amp-story[standalone].i-amphtml-story-landscape .i-amphtml-story-no-rotation-ove
 }
 
 .i-amphtml-story-spinner-circle-clipper {
-  display: inline-block;
-  position: relative;
-  width: 50%;
-  height: 100%;
-  overflow: hidden;
+  display: inline-block !important;
+  position: relative !important;
+  width: 50% !important;
+  height: 100% !important;
+  overflow: hidden !important;
 }
 
 .i-amphtml-story-spinner-layer::after {
-  left: 45%;
-  width: 10%;
-  border-top-style: solid;
+  left: 45% !important;
+  width: 10% !important;
+  border-top-style: solid !important;
 }
 
 .i-amphtml-story-spinner-layer::after,
 .i-amphtml-story-spinner-circle-clipper::after {
-  content: '';
-  box-sizing: border-box;
-  position: absolute;
-  top: 0;
-  border-width: 3px;
-  border-radius: 50%;
+  content: '' !important;
+  box-sizing: border-box !important;
+  position: absolute !important;
+  top: 0 !important;
+  border-width: 3px !important;
+  border-radius: 50% !important;
 }
 
 .i-amphtml-story-spinner-circle-clipper::after {
-  bottom: 0;
-  width: 200%;
-  border-style: solid;
+  bottom: 0 !important;
+  width: 200% !important;
+  border-style: solid !important;
   border-bottom-color: transparent !important;
 }
 
 .i-amphtml-story-spinner-circle-clipper.left::after {
-  left: 0;
+  left: 0 !important;
   border-right-color: transparent !important;
-  transform: rotate(129deg);
+  transform: rotate(129deg) !important;
 }
 
 .i-amphtml-story-spinner-circle-clipper.right::after {
-  left: -100%;
+  left: -100% !important;
   border-left-color: transparent !important;
-  transform: rotate(-129deg);
+  transform: rotate(-129deg) !important;
 }
 
 .i-amphtml-story-spinner[active] .i-amphtml-story-spinner-circle-clipper::after {
-  animation-duration: 1100ms;
-  animation-timing-function: cubic-bezier(0.4, 0.0, 0.2, 1);
-  animation-iteration-count: infinite;
+  animation-duration: 1100ms !important;
+  animation-timing-function: cubic-bezier(0.4, 0.0, 0.2, 1) !important;
+  animation-iteration-count: infinite !important;
 }
 
 .i-amphtml-story-spinner[active] .i-amphtml-story-spinner-circle-clipper.left::after {
-  animation-name: left-spin;
+  animation-name: left-spin !important;
 }
 
 .i-amphtml-story-spinner[active] .i-amphtml-story-spinner-circle-clipper.right::after {
-  animation-name: right-spin;
+  animation-name: right-spin !important;
 }
 
 @keyframes left-spin {

--- a/extensions/amp-story/0.1/loading-spinner.js
+++ b/extensions/amp-story/0.1/loading-spinner.js
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import {dev} from '../../../src/log';
 import {dict} from './../../../src/utils/object';
 import {renderAsElement} from './simple-template';
 
@@ -66,29 +67,42 @@ export class LoadingSpinner {
    * @param {!Document} doc
    */
   constructor(doc) {
-    /** @public @const {!Element} */
-    this.element_ = renderAsElement(doc, SPINNER);
+    /** @private @const {!Document} */
+    this.doc_ = doc;
+
+    /** @public {?Element} */
+    this.root_ = null;
 
     /** @private {boolean} */
     this.isActive_ = false;
   }
 
-  /** @param {!Element} element */
-  attach(element) {
-    element.appendChild(this.element_);
+  build() {
+    if (this.root_) {
+      return this.root_;
+    }
+
+    this.root_ = renderAsElement(this.doc_, SPINNER);
+
+    return this.getRoot();
   }
 
-  /** @param {boolean} state */
+  /** @return {!Element} */
+  getRoot() {
+    return dev().assertElement(this.root_);
+  }
+
+  /** @param {boolean} isActive */
   toggle(isActive) {
     if (isActive === this.isActive_) {
       return;
     }
     if (isActive) {
-      this.element_.setAttribute(SPINNER_ACTIVE_ATTRIBUTE, '');
-      this.element_.setAttribute('aria-hidden', 'false');
+      this.root_.setAttribute(SPINNER_ACTIVE_ATTRIBUTE, '');
+      this.root_.setAttribute('aria-hidden', 'false');
     } else {
-      this.element_.removeAttribute(SPINNER_ACTIVE_ATTRIBUTE);
-      this.element_.setAttribute('aria-hidden', 'true');
+      this.root_.removeAttribute(SPINNER_ACTIVE_ATTRIBUTE);
+      this.root_.setAttribute('aria-hidden', 'true');
     }
     this.isActive_ = isActive;
   }

--- a/extensions/amp-story/0.1/loading-spinner.js
+++ b/extensions/amp-story/0.1/loading-spinner.js
@@ -61,7 +61,6 @@ const SPINNER =  {
   ],
 };
 
-
 export class LoadingSpinner {
   /**
    * @param {!Document} doc
@@ -74,12 +73,10 @@ export class LoadingSpinner {
     this.isActive_ = false;
   }
 
-
   /** @param {!Element} element */
   attach(element) {
     element.appendChild(this.element_);
   }
-
 
   /** @param {boolean} state */
   toggle(isActive) {
@@ -87,10 +84,10 @@ export class LoadingSpinner {
       return;
     }
     if (isActive) {
-      this.element_.setAttribute('active', '');
+      this.element_.setAttribute(SPINNER_ACTIVE_ATTRIBUTE, '');
       this.element_.setAttribute('aria-hidden', 'false');
     } else {
-      this.element_.removeAttribute('active');
+      this.element_.removeAttribute(SPINNER_ACTIVE_ATTRIBUTE);
       this.element_.setAttribute('aria-hidden', 'true');
     }
     this.isActive_ = isActive;

--- a/extensions/amp-story/0.1/loading-spinner.js
+++ b/extensions/amp-story/0.1/loading-spinner.js
@@ -1,0 +1,98 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {dict} from './../../../src/utils/object';
+import {renderAsElement} from './simple-template';
+
+
+/** @const {string} */
+const SPINNER_ACTIVE_ATTRIBUTE = 'active';
+
+
+/** @private @const {!./simple-template.ElementDef} */
+const SPINNER =  {
+  tag: 'div',
+  attrs: dict({
+    'class': 'i-amphtml-story-spinner',
+    'aria-hidden': 'true',
+    'aria-label': 'Loading video',
+  }),
+  children: [
+    {
+      tag: 'div',
+      attrs: dict({
+        'class': 'i-amphtml-story-spinner-container',
+      }),
+      children: [
+        {
+          tag: 'div',
+          attrs: dict({
+            'class': 'i-amphtml-story-spinner-layer',
+          }),
+          children: [
+            {
+              tag: 'div',
+              attrs: dict({
+                'class': 'i-amphtml-story-spinner-circle-clipper left',
+              }),
+            },
+            {
+              tag: 'div',
+              attrs: dict({
+                'class': 'i-amphtml-story-spinner-circle-clipper right',
+              }),
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+
+export class LoadingSpinner {
+  /**
+   * @param {!Document} doc
+   */
+  constructor(doc) {
+    /** @public @const {!Element} */
+    this.element_ = renderAsElement(doc, SPINNER);
+
+    /** @private {boolean} */
+    this.isActive_ = false;
+  }
+
+
+  /** @param {!Element} element */
+  attach(element) {
+    element.appendChild(this.element_);
+  }
+
+
+  /** @param {boolean} state */
+  toggle(isActive) {
+    if (isActive === this.isActive_) {
+      return;
+    }
+    if (isActive) {
+      this.element_.setAttribute('active', '');
+      this.element_.setAttribute('aria-hidden', 'false');
+    } else {
+      this.element_.removeAttribute('active');
+      this.element_.setAttribute('aria-hidden', 'true');
+    }
+    this.isActive_ = isActive;
+  }
+}

--- a/extensions/amp-story/0.1/loading-spinner.js
+++ b/extensions/amp-story/0.1/loading-spinner.js
@@ -22,7 +22,7 @@ const SPINNER_ACTIVE_ATTRIBUTE = 'active';
 
 
 /** @private @const {!./simple-template.ElementDef} */
-const SPINNER =  {
+const SPINNER = {
   tag: 'div',
   attrs: dict({
     'class': 'i-amphtml-story-spinner',

--- a/extensions/amp-story/0.1/test/test-loading-spinner.js
+++ b/extensions/amp-story/0.1/test/test-loading-spinner.js
@@ -24,31 +24,23 @@ describes.realWin('loading-spinner', {}, env => {
     loadingSpinner = new LoadingSpinner(win.document);
   });
 
-  it('should attach the loading spinner', () => {
-    const container = win.document.createElement('div');
-    loadingSpinner.attach(container);
-
-    expect(container.children).to.have.length(1);
-    expect(container.children[0].className)
-        .to.contain('i-amphtml-story-spinner');
+  it('should build the loading spinner', () => {
+    const loadingSpinnerEl = loadingSpinner.build();
+    expect(loadingSpinnerEl.className).to.contain('i-amphtml-story-spinner');
   });
 
   it('should be hidden by default', () => {
-    const container = win.document.createElement('div');
-    loadingSpinner.attach(container);
+    const loadingSpinnerEl = loadingSpinner.build();
 
-    const loadingSpinnerEl = container.children[0];
     expect(loadingSpinnerEl).not.to.have.attribute('active');
     expect(loadingSpinnerEl).to.have.attribute('aria-hidden');
     expect(loadingSpinnerEl.getAttribute('aria-hidden')).to.equal('true');
   });
 
   it('should toggle the loading spinner', () => {
-    const container = win.document.createElement('div');
-    loadingSpinner.attach(container);
+    const loadingSpinnerEl = loadingSpinner.build();
     loadingSpinner.toggle(true);
 
-    const loadingSpinnerEl = container.children[0];
     expect(loadingSpinnerEl).to.have.attribute('active');
     expect(loadingSpinnerEl).to.have.attribute('aria-hidden');
     expect(loadingSpinnerEl.getAttribute('aria-hidden')).to.equal('false');

--- a/extensions/amp-story/0.1/test/test-loading-spinner.js
+++ b/extensions/amp-story/0.1/test/test-loading-spinner.js
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {LoadingSpinner} from '../loading-spinner';
+
+describes.realWin('loading-spinner', {}, env => {
+  let win;
+  let loadingSpinner;
+
+  beforeEach(() => {
+    win = env.win;
+    loadingSpinner = new LoadingSpinner(win.document);
+  });
+
+  it('should attach the loading spinner', () => {
+    const container = win.document.createElement('div');
+    loadingSpinner.attach(container);
+
+    expect(container.children).to.have.length(1);
+    expect(container.children[0].className)
+        .to.contain('i-amphtml-story-spinner');
+  });
+
+  it('should be hidden by default', () => {
+    const container = win.document.createElement('div');
+    loadingSpinner.attach(container);
+
+    const loadingSpinnerEl = container.children[0];
+    expect(loadingSpinnerEl).not.to.have.attribute('active');
+    expect(loadingSpinnerEl).to.have.attribute('aria-hidden');
+    expect(loadingSpinnerEl.getAttribute('aria-hidden')).to.equal('true');
+  });
+
+  it('should toggle the loading spinner', () => {
+    const container = win.document.createElement('div');
+    loadingSpinner.attach(container);
+    loadingSpinner.toggle(true);
+
+    const loadingSpinnerEl = container.children[0];
+    expect(loadingSpinnerEl).to.have.attribute('active');
+    expect(loadingSpinnerEl).to.have.attribute('aria-hidden');
+    expect(loadingSpinnerEl.getAttribute('aria-hidden')).to.equal('false');
+  });
+});


### PR DESCRIPTION
Displays a loading spinner whenever a video is buffering, whether it is before the video starts playing, or if it is stuttering because the network is not fast enough.

We make sure we retrieve the elements from the DOM after they have been swapped by the media pool, which is why we are now making sure the preload method is called before we start listening to video events.

A follow up PR should add a 8 seconds timeout, or look at the video networkState / readyState for some errors.

Closes #12775 
