### PR TITLE
Implement the error reporting logic through the AMP Viewer

### DIFF
--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -309,6 +309,7 @@ const forbiddenTerms = {
     message: 'Usages must be reviewed.',
     whitelist: [
       // viewer-impl.sendMessage
+      'src/error.js',
       'src/service/viewer-impl.js',
       'src/service/viewport/viewport-impl.js',
       'src/service/performance-impl.js',
@@ -390,6 +391,7 @@ const forbiddenTerms = {
   'isTrustedViewer': {
     message: requiresReviewPrivacy,
     whitelist: [
+      'src/error.js',
       'src/service/xhr-impl.js',
       'src/service/viewer-impl.js',
       'src/service/viewer-cid-api.js',

--- a/src/error.js
+++ b/src/error.js
@@ -298,27 +298,23 @@ function reportErrorToServer(message, filename, line, col, error) {
  * - The viewer is a trusted viewer
  * - The viewer has the `errorReporter` capability
  * - The AMP doc is in single doc mode
- * - The AMP doc is opted-in for error interception (`<html>` tag has the 
+ * - The AMP doc is opted-in for error interception (`<html>` tag has the
  *   `allow-error-reporting-to-viewer` attribute)
  *
- * @param {!JsonObject} error Data from `getErrorReportData`.
+ * @param {!JsonObject} data Data from `getErrorReportData`.
  * @return {!Promise<boolean|undefined>} True if the error was sent to the
  *     viewer, `Promise<undefined>` otherwise.
- * @this {!Window|undefined}
  * @visibleForTesting
  */
 export function maybeReportErrorToViewer(data) {
-  if (!this) {
-    return Promise.resolve();
-  }
-
   const ampdocService = Services.ampdocServiceFor(self);
   if (!ampdocService.isSingleDoc()) {
     return Promise.resolve();
   }
   const ampdocSingle = ampdocService.getAmpDoc();
   const htmlElement = ampdocSingle.getRootNode().documentElement;
-  const docOptedIn = htmlElement.hasAttribute('allow-error-reporting-to-viewer');
+  const docOptedIn =
+      htmlElement.hasAttribute('allow-error-reporting-to-viewer');
   if (!docOptedIn) {
     return Promise.resolve();
   }

--- a/src/error.js
+++ b/src/error.js
@@ -282,10 +282,29 @@ function reportErrorToServer(message, filename, line, col, error) {
       hasNonAmpJs);
   if (data) {
     reportingBackoff(() => {
+      // Report the error to viewer if it has the capability. The data passed
+      // to the viewer is exactly the same as the data passed to the server
+      // below.
+      if (self.AMP && self.AMP.viewer) {
+        maybeReportErrorToViewer(self.AMP.viewer, data);
+      }
       const xhr = new XMLHttpRequest();
       xhr.open('POST', urls.errorReporting, true);
       xhr.send(JSON.stringify(data));
     });
+  }
+}
+
+/**
+ * Reports the given error to the viewer if it has the 'errorReporting'
+ * capability. The error data can be obtained by calling #getErrorReportData.
+ * @param {!Viewer} viewer
+ * @param {!JsonObject} error data from #getErrorReportData
+ * visibleForTesting
+ */
+export function maybeReportErrorToViewer(viewer, data) {
+  if (viewer.hasCapability('errorReporting')) {
+    viewer.sendMessage('error', data);
   }
 }
 

--- a/test/functional/test-error.js
+++ b/test/functional/test-error.js
@@ -96,7 +96,6 @@ describe('maybeReportErrorToViewer', () => {
   let viewer;
   let sandbox;
   let ampdocServiceForStub;
-  let viewerForDocStub;
   let sendMessageStub;
 
   const data = getErrorReportData(undefined, undefined, undefined, undefined,
@@ -106,7 +105,8 @@ describe('maybeReportErrorToViewer', () => {
     sandbox = sinon.sandbox.create();
 
     const optedInDoc = window.document.implementation.createHTMLDocument('');
-    optedInDoc.documentElement.setAttribute('allow-error-reporting-to-viewer', '');
+    optedInDoc.documentElement.setAttribute(
+        'allow-error-reporting-to-viewer', '');
 
     ampdocServiceForStub = sandbox.stub(Services, 'ampdocServiceFor');
     ampdocServiceForStub.returns({
@@ -121,7 +121,7 @@ describe('maybeReportErrorToViewer', () => {
     };
     sendMessageStub = sandbox.stub(viewer, 'sendMessage');
 
-    viewerForDocStub = sandbox.stub(Services, 'viewerForDoc').returns(viewer);
+    sandbox.stub(Services, 'viewerForDoc').returns(viewer);
   });
 
   afterEach(() => {
@@ -147,7 +147,7 @@ describe('maybeReportErrorToViewer', () => {
 
   it('should not report if viewer is not capable', () => {
     sandbox.stub(viewer, 'hasCapability').withArgs('errorReporting')
-          .returns(false);
+        .returns(false);
     return maybeReportErrorToViewer(data)
         .then(() => expect(sendMessageStub).to.not.have.been.called);
   });
@@ -162,7 +162,7 @@ describe('maybeReportErrorToViewer', () => {
     return maybeReportErrorToViewer(data)
         .then(() => expect(sendMessageStub).to.have.been
             .calledWith('error', data));
-  });  
+  });
 });
 
 describe('reportErrorToServer', () => {

--- a/test/functional/test-error.js
+++ b/test/functional/test-error.js
@@ -148,7 +148,6 @@ describe('maybeReportErrorToViewer', () => {
   it('should not report if viewer is not capable', () => {
     sandbox.stub(viewer, 'hasCapability').withArgs('errorReporting')
           .returns(false);
-    viewer.hasCapability = () => false;
     return maybeReportErrorToViewer(data)
         .then(() => expect(sendMessageStub).to.not.have.been.called);
   });

--- a/test/functional/test-error.js
+++ b/test/functional/test-error.js
@@ -106,7 +106,7 @@ describe('maybeReportErrorToViewer', () => {
     sandbox = sinon.sandbox.create();
 
     const optedInDoc = window.document.implementation.createHTMLDocument('');
-    optedInDoc.documentElement.setAttribute('allow-error-interception', '');
+    optedInDoc.documentElement.setAttribute('allow-error-reporting-to-viewer', '');
 
     ampdocServiceForStub = sandbox.stub(Services, 'ampdocServiceFor');
     ampdocServiceForStub.returns({
@@ -128,13 +128,13 @@ describe('maybeReportErrorToViewer', () => {
     sandbox.restore();
   });
 
-  it('should not intercept if AMP doc is not single', () => {
+  it('should not report if AMP doc is not single', () => {
     ampdocServiceForStub.returns({isSingleDoc: () => false});
     return maybeReportErrorToViewer(data)
         .then(() => expect(sendMessageStub).to.not.have.been.called);
   });
 
-  it('should not intercept if AMP doc is not opted in', () => {
+  it('should not report if AMP doc is not opted in', () => {
     const nonOptedInDoc =
           window.document.implementation.createHTMLDocument('');
     ampdocServiceForStub.returns({
@@ -145,7 +145,7 @@ describe('maybeReportErrorToViewer', () => {
         .then(() => expect(sendMessageStub).to.not.have.been.called);
   });
 
-  it('should not intercept if viewer is not capable', () => {
+  it('should not report if viewer is not capable', () => {
     sandbox.stub(viewer, 'hasCapability').withArgs('errorReporting')
           .returns(false);
     viewer.hasCapability = () => false;
@@ -153,7 +153,7 @@ describe('maybeReportErrorToViewer', () => {
         .then(() => expect(sendMessageStub).to.not.have.been.called);
   });
 
-  it('should not intercept if viewer is not trusted', () => {
+  it('should not report if viewer is not trusted', () => {
     sandbox.stub(viewer, 'isTrustedViewer').returns(Promise.resolve(false));
     return maybeReportErrorToViewer(data)
         .then(() => expect(sendMessageStub).to.not.have.been.called);

--- a/test/functional/test-error.js
+++ b/test/functional/test-error.js
@@ -93,6 +93,7 @@ describes.fakeWin('installErrorReporting', {}, env => {
 });
 
 describe('maybeReportErrorToViewer', () => {
+  let win;
   let viewer;
   let sandbox;
   let ampdocServiceForStub;
@@ -105,8 +106,7 @@ describe('maybeReportErrorToViewer', () => {
     sandbox = sinon.sandbox.create();
 
     const optedInDoc = window.document.implementation.createHTMLDocument('');
-    optedInDoc.documentElement.setAttribute(
-        'allow-error-reporting-to-viewer', '');
+    optedInDoc.documentElement.setAttribute('report-errors-to-viewer', '');
 
     ampdocServiceForStub = sandbox.stub(Services, 'ampdocServiceFor');
     ampdocServiceForStub.returns({
@@ -130,7 +130,7 @@ describe('maybeReportErrorToViewer', () => {
 
   it('should not report if AMP doc is not single', () => {
     ampdocServiceForStub.returns({isSingleDoc: () => false});
-    return maybeReportErrorToViewer(data)
+    return maybeReportErrorToViewer(win, data)
         .then(() => expect(sendMessageStub).to.not.have.been.called);
   });
 
@@ -141,25 +141,25 @@ describe('maybeReportErrorToViewer', () => {
       isSingleDoc: () => true,
       getAmpDoc: () => ({getRootNode: () => nonOptedInDoc}),
     });
-    return maybeReportErrorToViewer(data)
+    return maybeReportErrorToViewer(win, data)
         .then(() => expect(sendMessageStub).to.not.have.been.called);
   });
 
   it('should not report if viewer is not capable', () => {
     sandbox.stub(viewer, 'hasCapability').withArgs('errorReporting')
         .returns(false);
-    return maybeReportErrorToViewer(data)
+    return maybeReportErrorToViewer(win, data)
         .then(() => expect(sendMessageStub).to.not.have.been.called);
   });
 
   it('should not report if viewer is not trusted', () => {
     sandbox.stub(viewer, 'isTrustedViewer').returns(Promise.resolve(false));
-    return maybeReportErrorToViewer(data)
+    return maybeReportErrorToViewer(win, data)
         .then(() => expect(sendMessageStub).to.not.have.been.called);
   });
 
   it('should send viewer message named `error`', () => {
-    return maybeReportErrorToViewer(data)
+    return maybeReportErrorToViewer(win, data)
         .then(() => expect(sendMessageStub).to.have.been
             .calledWith('error', data));
   });

--- a/validator/testdata/feature_tests/root_element_attributes.html
+++ b/validator/testdata/feature_tests/root_element_attributes.html
@@ -15,7 +15,7 @@
   This demonstrates that certain attributes are not allowed on the root <html> element.
 -->
 <!doctype html>
-<html ⚡ allow-xhr-interception>
+<html ⚡ allow-xhr-interception allow-error-reporting-to-viewer>
 <head>
   <meta charset="utf-8">
   <link rel="canonical" href="./regular-html-version.html">

--- a/validator/testdata/feature_tests/root_element_attributes.html
+++ b/validator/testdata/feature_tests/root_element_attributes.html
@@ -15,7 +15,7 @@
   This demonstrates that certain attributes are not allowed on the root <html> element.
 -->
 <!doctype html>
-<html ⚡ allow-xhr-interception allow-error-reporting-to-viewer>
+<html ⚡ allow-xhr-interception report-errors-to-viewer>
 <head>
   <meta charset="utf-8">
   <link rel="canonical" href="./regular-html-version.html">

--- a/validator/testdata/feature_tests/root_element_attributes.out
+++ b/validator/testdata/feature_tests/root_element_attributes.out
@@ -16,11 +16,11 @@ FAIL
 |    This demonstrates that certain attributes are not allowed on the root <html> element.
 |  -->
 |  <!doctype html>
-|  <html ⚡ allow-xhr-interception allow-error-reporting-to-viewer>
->> ^~~~~~~~~
-feature_tests/root_element_attributes.html:18:0 The attribute 'allow-error-reporting-to-viewer' may not appear in tag 'html ⚡ for top-level html'. (see https://www.ampproject.org/docs/reference/spec#required-markup) [DISALLOWED_HTML]
+|  <html ⚡ allow-xhr-interception report-errors-to-viewer>
 >> ^~~~~~~~~
 feature_tests/root_element_attributes.html:18:0 The attribute 'allow-xhr-interception' may not appear in tag 'html ⚡ for top-level html'. (see https://www.ampproject.org/docs/reference/spec#required-markup) [DISALLOWED_HTML]
+>> ^~~~~~~~~
+feature_tests/root_element_attributes.html:18:0 The attribute 'report-errors-to-viewer' may not appear in tag 'html ⚡ for top-level html'. (see https://www.ampproject.org/docs/reference/spec#required-markup) [DISALLOWED_HTML]
 |  <head>
 |    <meta charset="utf-8">
 |    <link rel="canonical" href="./regular-html-version.html">

--- a/validator/testdata/feature_tests/root_element_attributes.out
+++ b/validator/testdata/feature_tests/root_element_attributes.out
@@ -16,7 +16,9 @@ FAIL
 |    This demonstrates that certain attributes are not allowed on the root <html> element.
 |  -->
 |  <!doctype html>
-|  <html ⚡ allow-xhr-interception>
+|  <html ⚡ allow-xhr-interception allow-error-reporting-to-viewer>
+>> ^~~~~~~~~
+feature_tests/root_element_attributes.html:18:0 The attribute 'allow-error-reporting-to-viewer' may not appear in tag 'html ⚡ for top-level html'. (see https://www.ampproject.org/docs/reference/spec#required-markup) [DISALLOWED_HTML]
 >> ^~~~~~~~~
 feature_tests/root_element_attributes.html:18:0 The attribute 'allow-xhr-interception' may not appear in tag 'html ⚡ for top-level html'. (see https://www.ampproject.org/docs/reference/spec#required-markup) [DISALLOWED_HTML]
 |  <head>


### PR DESCRIPTION
# Implement the error reporting logic through the AMP Viewer

Fixes #12950.

Passes errors to the AMP Viewer if the following is true:
-The viewer is in single document mode
-The viewer is trusted
-The viewer has the `errorReporter` capability
-The document is opted-in for error interception, this can be done by adding an additional attribute called `allow-error-reporting-to-viewer` in the `<html>` tag.

The client embedding the AMP viewer can then use these errors for their own monitoring or reporting.

The error passed to the viewer is the same as the error passed to the AMP error server.
