### PR TITLE
Fix amp-story incorrect measurements in prerender

### DIFF
--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -243,21 +243,23 @@ export class AmpStory extends AMP.BaseElement {
 
     /** @private @const {!../../../src/service/timer-impl.Timer} */
     this.timer_ = Services.timerFor(this.win);
-
-    // This must be done before buildCallback() so the body CSS can be applied
-    // before measure. This avoids incorrect measurements in prerender.
-    if (this.element.hasAttribute(AMP_STORY_STANDALONE_ATTRIBUTE)) {
-      this.win.document.documentElement.classList
-          .add('i-amphtml-story-standalone');
-      // Lock body to prevent overflow.
-      this.lockBody_();
-    }
   }
 
 
   /** @override */
   buildCallback() {
     this.assertAmpStoryExperiment_();
+
+    if (this.element.hasAttribute(AMP_STORY_STANDALONE_ATTRIBUTE)) {
+      const html = this.win.document.documentElement;
+      this.mutateElement(() => {
+        html.classList.add('i-amphtml-story-standalone');
+        // Lock body to prevent overflow.
+        this.lockBody_();
+        // Standalone CSS affects sizing of the entire page.
+        this.onResize();
+      }, html);
+    }
 
     this.initializeListeners_();
     this.initializeListenersForDev_();
@@ -405,7 +407,6 @@ export class AmpStory extends AMP.BaseElement {
 
     this.boundOnResize_ = debounce(this.win, () => this.onResize(), 300);
     this.getViewport().onResize(this.boundOnResize_);
-    this.onResize();
   }
 
   /** @private */

--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -243,20 +243,21 @@ export class AmpStory extends AMP.BaseElement {
 
     /** @private @const {!../../../src/service/timer-impl.Timer} */
     this.timer_ = Services.timerFor(this.win);
+
+    // This must be done before buildCallback() so the body CSS can be applied
+    // before measure. This avoids incorrect measurements in prerender.
+    if (this.element.hasAttribute(AMP_STORY_STANDALONE_ATTRIBUTE)) {
+      this.win.document.documentElement.classList
+          .add('i-amphtml-story-standalone');
+      // Lock body to prevent overflow.
+      this.lockBody_();
+    }
   }
 
 
   /** @override */
   buildCallback() {
     this.assertAmpStoryExperiment_();
-
-    if (this.element.hasAttribute(AMP_STORY_STANDALONE_ATTRIBUTE)) {
-      this.getAmpDoc().win.document.documentElement.classList
-          .add('i-amphtml-story-standalone');
-
-      // Lock body to prevent overflow.
-      this.lockBody_();
-    }
 
     this.initializeListeners_();
     this.initializeListenersForDev_();


### PR DESCRIPTION
Fixes #11843.

Context: https://github.com/ampproject/amphtml/issues/11843#issuecomment-359959049

I also changed `getAmpdoc()` to `win.document`. We'll have to fix this and a lot more to get stories working in PWA anyways, so might as well access it directly for now. Filed #12988 to track.

Unit test coming soon.

/to @newmuis @jridgewell 