### PR TITLE
Correct attribute name used for naming an amp-bind-macro

### DIFF
--- a/extensions/amp-bind/amp-bind.md
+++ b/extensions/amp-bind/amp-bind.md
@@ -349,7 +349,7 @@ sort([2, 1, 3])</pre>
 references the current state as well as zero or more arguments. Then, this `amp-bind-macro` can be called by its name from anywhere in your doc.
 
 ```html
-<amp-bind-macro name="circleArea" arguments="radius" expression="3.14 * radius * radius" />
+<amp-bind-macro id="circleArea" arguments="radius" expression="3.14 * radius * radius" />
 
 <div>
   The circle has an area of <span [text]="circleArea(myCircle.radius)">0</span>.


### PR DESCRIPTION
Correct docs to make it use the appropriate attribute name 'id' for naming an amp-bind-macro

The existing doc incorrectly uses the attribute name "name" for the name of a macro but it must be "id"