### PR TITLE
Pass analytics filters as bindings to core

### DIFF
--- a/build-system/dep-check-config.js
+++ b/build-system/dep-check-config.js
@@ -214,6 +214,9 @@ exports.rules = [
           'src/service/position-observer/position-observer-worker.js',
       'extensions/amp-analytics/0.1/amp-analytics.js->' +
           'src/service/cid-impl.js',
+      // TODO(calebcordry) remove this once experiment is launched
+      'extensions/amp-analytics/0.1/variables.js->' +
+          'src/service/url-replacements-impl.js',
     ],
   },
   {

--- a/extensions/amp-analytics/0.1/requests.js
+++ b/extensions/amp-analytics/0.1/requests.js
@@ -28,6 +28,7 @@ import {Services} from '../../../src/services';
 import {batchSegmentDef, BatchingPluginFunctions} from './batching-plugins';
 import {parseQueryString} from '../../../src/url';
 import {dict} from '../../../src/utils/object';
+import {isExperimentOn} from '../../../src/experiments';
 
 const TAG = 'AMP-ANALYTICS';
 
@@ -117,8 +118,15 @@ export class RequestHandler {
     const isImmediate =
         (trigger['immediate'] === true) || (this.maxDelay_ == 0);
 
-    const filters = this.variableService_.getFilters();
-    const bindings = Object.assign({}, dynamicBindings, filters);
+    const isV2ExpansionON = isExperimentOn(this.ampdoc.win,
+        'url-replacement-v2');
+    let bindings;
+    if (isV2ExpansionON) {
+      const filters = this.variableService_.getFilters();
+      bindings = Object.assign({}, dynamicBindings, filters);
+    } else {
+      bindings = dynamicBindings;
+    }
 
     if (!this.baseUrlPromise_) {
       expansionOption.freezeVar('extraUrlParams');

--- a/extensions/amp-analytics/0.1/requests.js
+++ b/extensions/amp-analytics/0.1/requests.js
@@ -28,7 +28,6 @@ import {Services} from '../../../src/services';
 import {batchSegmentDef, BatchingPluginFunctions} from './batching-plugins';
 import {parseQueryString} from '../../../src/url';
 import {dict} from '../../../src/utils/object';
-import {isExperimentOn} from '../../../src/experiments';
 
 const TAG = 'AMP-ANALYTICS';
 
@@ -118,16 +117,8 @@ export class RequestHandler {
     const isImmediate =
         (trigger['immediate'] === true) || (this.maxDelay_ == 0);
 
-    const isV2ExpansionON = this.ampdoc && isExperimentOn(this.ampdoc.win,
-        'url-replacement-v2');
-    let bindings;
-    if (isV2ExpansionON) {
-      const macros = this.variableService_.getMacros();
-      bindings = Object.assign({}, dynamicBindings, macros);
-    } else {
-      bindings = dynamicBindings;
-    }
-
+    const macros = this.variableService_.getMacros();
+    const bindings = Object.assign({}, dynamicBindings, macros);
     if (!this.baseUrlPromise_) {
       expansionOption.freezeVar('extraUrlParams');
       this.baseUrlTemplatePromise_ =

--- a/extensions/amp-analytics/0.1/requests.js
+++ b/extensions/amp-analytics/0.1/requests.js
@@ -116,13 +116,17 @@ export class RequestHandler {
     const triggerParams = trigger['extraUrlParams'];
     const isImmediate =
         (trigger['immediate'] === true) || (this.maxDelay_ == 0);
+
+    const filters = this.variableService_.getFilters();
+    const bindings = {...dynamicBindings, ...filters};
+
     if (!this.baseUrlPromise_) {
       expansionOption.freezeVar('extraUrlParams');
       this.baseUrlTemplatePromise_ =
           this.variableService_.expandTemplate(this.baseUrl, expansionOption);
       this.baseUrlPromise_ = this.baseUrlTemplatePromise_.then(baseUrl => {
-        return this.urlReplacementService_.expandUrlAsync(
-            baseUrl, dynamicBindings, this.whiteList_);
+        return this.urlReplacementService_.expandAsync(
+            baseUrl, bindings, this.whiteList_);
       });
     };
 
@@ -132,8 +136,8 @@ export class RequestHandler {
           // Construct the extraUrlParamsString: Remove null param and encode component
           const expandedExtraUrlParamsStr =
               this.getExtraUrlParamsString_(expandExtraUrlParams);
-          return this.urlReplacementService_.expandUrlAsync(
-              expandedExtraUrlParamsStr, dynamicBindings, this.whiteList_);
+          return this.urlReplacementService_.expandAsync(
+              expandedExtraUrlParamsStr, bindings, this.whiteList_);
         });
 
     if (this.batchingPlugin_) {

--- a/extensions/amp-analytics/0.1/requests.js
+++ b/extensions/amp-analytics/0.1/requests.js
@@ -122,8 +122,8 @@ export class RequestHandler {
         'url-replacement-v2');
     let bindings;
     if (isV2ExpansionON) {
-      const filters = this.variableService_.getFilters();
-      bindings = Object.assign({}, dynamicBindings, filters);
+      const macros = this.variableService_.getMacros();
+      bindings = Object.assign({}, dynamicBindings, macros);
     } else {
       bindings = dynamicBindings;
     }
@@ -133,7 +133,7 @@ export class RequestHandler {
       this.baseUrlTemplatePromise_ =
           this.variableService_.expandTemplate(this.baseUrl, expansionOption);
       this.baseUrlPromise_ = this.baseUrlTemplatePromise_.then(baseUrl => {
-        return this.urlReplacementService_.expandAsync(
+        return this.urlReplacementService_.expandUrlAsync(
             baseUrl, bindings, this.whiteList_);
       });
     };
@@ -144,7 +144,7 @@ export class RequestHandler {
           // Construct the extraUrlParamsString: Remove null param and encode component
           const expandedExtraUrlParamsStr =
               this.getExtraUrlParamsString_(expandExtraUrlParams);
-          return this.urlReplacementService_.expandAsync(
+          return this.urlReplacementService_.expandUrlAsync(
               expandedExtraUrlParamsStr, bindings, this.whiteList_);
         });
 

--- a/extensions/amp-analytics/0.1/requests.js
+++ b/extensions/amp-analytics/0.1/requests.js
@@ -118,7 +118,7 @@ export class RequestHandler {
     const isImmediate =
         (trigger['immediate'] === true) || (this.maxDelay_ == 0);
 
-    const isV2ExpansionON = isExperimentOn(this.ampdoc.win,
+    const isV2ExpansionON = this.ampdoc && isExperimentOn(this.ampdoc.win,
         'url-replacement-v2');
     let bindings;
     if (isV2ExpansionON) {

--- a/extensions/amp-analytics/0.1/requests.js
+++ b/extensions/amp-analytics/0.1/requests.js
@@ -118,7 +118,7 @@ export class RequestHandler {
         (trigger['immediate'] === true) || (this.maxDelay_ == 0);
 
     const filters = this.variableService_.getFilters();
-    const bindings = {...dynamicBindings, ...filters};
+    const bindings = Object.assign({}, dynamicBindings, filters);
 
     if (!this.baseUrlPromise_) {
       expansionOption.freezeVar('extraUrlParams');

--- a/extensions/amp-analytics/0.1/test/test-variables.js
+++ b/extensions/amp-analytics/0.1/test/test-variables.js
@@ -125,11 +125,6 @@ describe('amp-analytics.VariableService', function() {
     });
   });
 
-  it('default filterdoesn\'t work when experiment is off' , () =>
-    variables.expandTemplate('${bar|default:baz}',
-        new ExpansionOptions({'foo': ' Hello world! '}))
-        .then(actual => expect(actual).to.equal('')));
-
   describes.fakeWin('macros', {amp: true}, env => {
     let win;
     let ampdoc;

--- a/extensions/amp-analytics/0.1/test/test-variables.js
+++ b/extensions/amp-analytics/0.1/test/test-variables.js
@@ -142,7 +142,7 @@ describe('amp-analytics.VariableService', function() {
     afterEach(() => {
       toggleExperiment(env.win, 'url-replacement-v2');
     });
-    
+
     function check(input, output) {
       const filters = variables.getFilters();
       const expanded = urlReplacementService.expandAsync(input, filters);

--- a/extensions/amp-analytics/0.1/test/test-variables.js
+++ b/extensions/amp-analytics/0.1/test/test-variables.js
@@ -137,7 +137,6 @@ describe('amp-analytics.VariableService', function() {
       toggleExperiment(env.win, 'url-replacement-v2', true);
       ampdoc = env.ampdoc;
       urlReplacementService = Services.urlReplacementsForDoc(ampdoc);
-      sandbox.stub(variables, 'isFilterExperimentOn_').callsFake(() => true);
     });
 
     function check(input, output) {

--- a/extensions/amp-analytics/0.1/test/test-variables.js
+++ b/extensions/amp-analytics/0.1/test/test-variables.js
@@ -139,6 +139,10 @@ describe('amp-analytics.VariableService', function() {
       urlReplacementService = Services.urlReplacementsForDoc(ampdoc);
     });
 
+    afterEach(() => {
+      toggleExperiment(env.win, 'url-replacement-v2');
+    });
+    
     function check(input, output) {
       const filters = variables.getFilters();
       const expanded = urlReplacementService.expandAsync(input, filters);

--- a/extensions/amp-analytics/0.1/test/test-variables.js
+++ b/extensions/amp-analytics/0.1/test/test-variables.js
@@ -129,7 +129,7 @@ describe('amp-analytics.VariableService', function() {
         new ExpansionOptions({'foo': ' Hello world! '}))
         .then(actual => expect(actual).to.equal('')));
 
-  describes.fakeWin('filters', {amp: true}, env => {
+  describes.fakeWin('macros', {amp: true}, env => {
     let ampdoc;
     let urlReplacementService;
 
@@ -144,8 +144,8 @@ describe('amp-analytics.VariableService', function() {
     });
 
     function check(input, output) {
-      const filters = variables.getFilters();
-      const expanded = urlReplacementService.expandAsync(input, filters);
+      const macros = variables.getMacros();
+      const expanded = urlReplacementService.expandUrlAsync(input, macros);
       return expect(expanded).to.eventually.equal(output);
     }
 

--- a/extensions/amp-analytics/0.1/test/test-variables.js
+++ b/extensions/amp-analytics/0.1/test/test-variables.js
@@ -23,6 +23,7 @@ import {
 import {adopt} from '../../../../src/runtime';
 import * as sinon from 'sinon';
 import {Services} from '../../../../src/services';
+import {toggleExperiment} from '../../../../src/experiments';
 
 adopt(window);
 
@@ -133,6 +134,7 @@ describe('amp-analytics.VariableService', function() {
     let urlReplacementService;
 
     beforeEach(() => {
+      toggleExperiment(env.win, 'url-replacement-v2', true);
       ampdoc = env.ampdoc;
       urlReplacementService = Services.urlReplacementsForDoc(ampdoc);
       sandbox.stub(variables, 'isFilterExperimentOn_').callsFake(() => true);
@@ -140,7 +142,6 @@ describe('amp-analytics.VariableService', function() {
 
     function check(input, output) {
       const filters = variables.getFilters();
-      debugger;
       const expanded = urlReplacementService.expandAsync(input, filters);
       return expect(expanded).to.eventually.equal(output);
     }

--- a/extensions/amp-analytics/0.1/test/test-variables.js
+++ b/extensions/amp-analytics/0.1/test/test-variables.js
@@ -22,6 +22,7 @@ import {
 } from '../variables';
 import {adopt} from '../../../../src/runtime';
 import * as sinon from 'sinon';
+import {Services} from '../../../../src/services';
 
 adopt(window);
 
@@ -127,56 +128,63 @@ describe('amp-analytics.VariableService', function() {
         new ExpansionOptions({'foo': ' Hello world! '}))
         .then(actual => expect(actual).to.equal('')));
 
-  describe('filter:', () => {
-    const vars = new ExpansionOptions({'foo': ' Hello world! '});
+  describes.fakeWin('filters', {amp: true}, env => {
+    let ampdoc;
+    let urlReplacementService;
 
     beforeEach(() => {
+      ampdoc = env.ampdoc;
+      urlReplacementService = Services.urlReplacementsForDoc(ampdoc);
       sandbox.stub(variables, 'isFilterExperimentOn_').callsFake(() => true);
     });
 
     function check(input, output) {
-      return variables.expandTemplate(input, vars).then(actual =>
-        expect(actual).to.equal(output));
+      const filters = variables.getFilters();
+      debugger;
+      const expanded = urlReplacementService.expandAsync(input, filters);
+      return expect(expanded).to.eventually.equal(output);
     }
 
-    it('default works', () => check('${bar|default:baz}', 'baz'));
+    it('default works', () => check('DEFAULT(one,two)', 'one'));
+    it('default works without first arg', () => check('DEFAULT(,two)', 'two'));
 
-    it('hash works', () => check('${foo|hash}',
-        '8R9LfzzIKtjQOwqNEUN5Tw3-oUTgU2UvtufGxDh4wRiiacsW5yga9nqHSYBoBkkp'));
+    it('hash works', () => check('HASH(test)',
+        'doQSMg97CqWBL85CjcRwazyuUOAqZMqhangiSb_o78S37xzLEmJV0ZYEff7fF6Cp'));
 
-    it('substr works', () => check('${foo|substr:2:4}', 'ello'));
+    it('substr works', () => check('SUBSTR(Hello world!, 1, 4)', 'ello'));
 
-    it('trim works', () => check('${foo|trim}', 'Hello%20world!'));
+    it('trim works', () => check('TRIM(hello      )', 'hello'));
 
     it('json works', () =>
       // " Hello world! "
-      check('${foo|json}', '%22%20Hello%20world!%20%22'));
+      check('JSON(Hello world!)', '%22Hello%20world!%22'));
 
     it('toLowerCase works', () =>
-      check('${foo|toLowerCase}', '%20hello%20world!%20'));
+      check('TOLOWERCASE(HeLLO WOrld!)', 'hello%20world!'));
 
     it('toUpperCase works', () => {
-      return check('${foo|toUpperCase}', '%20HELLO%20WORLD!%20');
+      return check('TOUPPERCASE(HeLLO WOrld!)', 'HELLO%20WORLD!');
     });
 
-    it('not works (truth-y value)', () => check('${foo|not}', 'false'));
+    it('not works (truth-y value)', () => check('NOT(hello)', 'false'));
 
-    it('not works (false-y value)', () => check('${bar|not}', 'true'));
+    it('not works (false-y value)', () => check('NOT()', 'true'));
 
     it('base64 works', () => {
-      return check('${foo|base64}', 'IEhlbGxvIHdvcmxkISA%3D');
+      return check('BASE64(Hello World!)', 'SGVsbG8gV29ybGQh');
     });
 
-    it('if works', () => check('${foo|if:yey:boo}', 'yey'));
+    it('if works', () => check('IF(hey, truthy, falsey)', 'truthy'));
 
     it('chaining works', () => {
-      return check('${foo|substr:6}', '%20world!%20').then(() =>
-        check('${foo|substr:6|trim}', 'world!')).then(() =>
-        check('${foo|substr:6|trim|toUpperCase}', 'WORLD!')).then(() =>
-        check('${foo|substr:6|trim|toUpperCase|base64}', 'V09STEQh')).then(() =>
-        check('${foo|substr:6|trim|toUpperCase|base64|hash}',
-            'OPTTt2IGW8-R31MrIF_cRUwLTZ9jLDOXEuhNz_QS7Uc5ZmODduHWdplzrZ7Jsnqx')
-      );
+      return check('SUBSTR(Hello world!, 6)', 'world!').then(() =>
+        check('TOUPPERCASE(SUBSTR(Hello world!, 6))', 'WORLD!')).then(() =>
+        check('BASE64(TOUPPERCASE(SUBSTR(Hello world!, 6)))', 'V09STEQh'))
+          .then(() =>
+            check('HASH(BASE64(TOUPPERCASE(SUBSTR(Hello world!, 6))))',
+                'OPTTt2IGW8-R31MrIF_cRUwLTZ9jLDOXEuhNz_Q' +
+                'S7Uc5ZmODduHWdplzrZ7Jsnqx')
+          );
     });
   });
 

--- a/extensions/amp-analytics/0.1/variables.js
+++ b/extensions/amp-analytics/0.1/variables.js
@@ -243,10 +243,6 @@ export class VariableService {
   hashMacro_(value) {
     return Services.cryptoFor(this.win_).sha384Base64(value);
   }
-
-  isMacroExperimentOn_() {
-    return isExperimentOn(this.win_, 'variable-macros');
-  }
 }
 
 

--- a/extensions/amp-analytics/0.1/variables.js
+++ b/extensions/amp-analytics/0.1/variables.js
@@ -19,6 +19,8 @@ import {Services} from '../../../src/services';
 import {dev, user} from '../../../src/log';
 import {getService, registerServiceBuilder} from '../../../src/service';
 import {isArray, isFiniteNumber} from '../../../src/types';
+// TODO(calebcordry) remove this once experiment is launched
+// also remove from dep-check-config whitelist;
 import {REPLACEMENT_EXP_NAME} from '../../../src/service/url-replacements-impl';
 
 /** @const {string} */

--- a/extensions/amp-analytics/0.1/variables.js
+++ b/extensions/amp-analytics/0.1/variables.js
@@ -19,6 +19,7 @@ import {Services} from '../../../src/services';
 import {dev, user} from '../../../src/log';
 import {getService, registerServiceBuilder} from '../../../src/service';
 import {isArray, isFiniteNumber} from '../../../src/types';
+import {REPLACEMENT_EXP_NAME} from '../../../src/service/url-replacements-impl';
 
 /** @const {string} */
 const TAG = 'Analytics.Variables';
@@ -129,7 +130,9 @@ export class VariableService {
    * @return {!Object} contains all registered macros
    */
   getMacros() {
-    return this.macros_;
+    const isV2ExpansionOn = this.win_ && isExperimentOn(this.win_,
+        REPLACEMENT_EXP_NAME);
+    return isV2ExpansionOn ? this.macros_ : {};
   }
 
   /**

--- a/extensions/amp-analytics/0.1/variables.js
+++ b/extensions/amp-analytics/0.1/variables.js
@@ -69,15 +69,15 @@ export class ExpansionOptions {
  * @param {string=} opt_l
  * @return {string}
  */
-function substrFilter(str, s, opt_l) {
+function substrMacro(str, s, opt_l) {
   const start = Number(s);
   let length = str.length;
   user().assert(isFiniteNumber(start),
-      'Start index ' + start + 'in substr filter should be a number');
+      'Start index ' + start + 'in substr macro should be a number');
   if (opt_l) {
     length = Number(opt_l);
     user().assert(isFiniteNumber(length),
-        'Length ' + length + ' in substr filter should be a number');
+        'Length ' + length + ' in substr macro should be a number');
   }
 
   return str.substr(start, length);
@@ -88,7 +88,7 @@ function substrFilter(str, s, opt_l) {
  * @param {string} defaultValue
  * @return {string}
  */
-function defaultFilter(value, defaultValue) {
+function defaultMacro(value, defaultValue) {
   if (!value || !value.length) {
     return user().assertString(defaultValue);
   }
@@ -98,7 +98,7 @@ function defaultFilter(value, defaultValue) {
 
 /**
  * Provides support for processing of advanced variable syntax like nested
- * expansions filters etc.
+ * expansions macros etc.
  */
 export class VariableService {
   /**
@@ -110,36 +110,36 @@ export class VariableService {
     this.win_ = window;
 
     /** @private {!Object<string, *>} */
-    this.filters_ = {};
+    this.macros_ = {};
 
-    this.register_('DEFAULT', defaultFilter);
-    this.register_('SUBSTR', substrFilter);
+    this.register_('DEFAULT', defaultMacro);
+    this.register_('SUBSTR', substrMacro);
     this.register_('TRIM', value => value.trim());
     this.register_('JSON', value => JSON.stringify(value));
     this.register_('TOLOWERCASE', value => value.toLowerCase());
     this.register_('TOUPPERCASE', value => value.toUpperCase());
     this.register_('NOT', value => String(!value));
     this.register_('BASE64', value => btoa(value));
-    this.register_('HASH', this.hashFilter_.bind(this));
+    this.register_('HASH', this.hashMacro_.bind(this));
     this.register_('IF',
         (value, thenValue, elseValue) => value ? thenValue : elseValue);
   }
 
   /**
-   * @return {!Object} contains all registered filters
+   * @return {!Object} contains all registered macros
    */
-  getFilters() {
-    return this.filters_;
+  getMacros() {
+    return this.macros_;
   }
 
   /**
    * @param {string} name
-   * @param {*} filter
+   * @param {*} macro
    */
-  register_(name, filter) {
-    dev().assert(!this.filters_[name], 'Filter "' + name
+  register_(name, macro) {
+    dev().assert(!this.macros_[name], 'Macro "' + name
         + '" already registered.');
-    this.filters_[name] = filter;
+    this.macros_[name] = macro;
   }
 
   /**
@@ -240,12 +240,12 @@ export class VariableService {
    * @param {string} value
    * @return {!Promise<string>}
    */
-  hashFilter_(value) {
+  hashMacro_(value) {
     return Services.cryptoFor(this.win_).sha384Base64(value);
   }
 
-  isFilterExperimentOn_() {
-    return isExperimentOn(this.win_, 'variable-filters');
+  isMacroExperimentOn_() {
+    return isExperimentOn(this.win_, 'variable-macros');
   }
 }
 

--- a/extensions/amp-analytics/0.1/variables.js
+++ b/extensions/amp-analytics/0.1/variables.js
@@ -109,7 +109,7 @@ export class VariableService {
     /** @private {!Window} */
     this.win_ = window;
 
-    /** @private {!Object<string, !Filter>} */
+    /** @private {!Object<string, *>} */
     this.filters_ = {};
 
     this.register_('DEFAULT', defaultFilter);
@@ -134,7 +134,7 @@ export class VariableService {
 
   /**
    * @param {string} name
-   * @param {!Filter} filter
+   * @param {*} filter
    */
   register_(name, filter) {
     dev().assert(!this.filters_[name], 'Filter "' + name

--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -917,7 +917,6 @@ export class UrlReplacements {
    * @private
    */
   expand_(url, opt_bindings, opt_collectVars, opt_sync, opt_whiteList) {
-    debugger;
     const isV2ExperimentOn = isExperimentOn(this.ampdoc.win,
         REPLACEMENT_EXP_NAME);
     if (isV2ExperimentOn && !opt_collectVars && !opt_sync) {

--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -49,6 +49,9 @@ const VARIANT_DELIMITER = '.';
 const ORIGINAL_HREF_PROPERTY = 'amp-original-href';
 const ORIGINAL_VALUE_PROPERTY = 'amp-original-value';
 
+/** @const {string} */
+export const REPLACEMENT_EXP_NAME = 'url-replacement-v2';
+
 /**
  * Returns a encoded URI Component, or an empty string if the value is nullish.
  * @param {*} val
@@ -914,8 +917,9 @@ export class UrlReplacements {
    * @private
    */
   expand_(url, opt_bindings, opt_collectVars, opt_sync, opt_whiteList) {
+    debugger;
     const isV2ExperimentOn = isExperimentOn(this.ampdoc.win,
-        'url-replacement-v2');
+        REPLACEMENT_EXP_NAME);
     if (isV2ExperimentOn && !opt_collectVars && !opt_sync) {
       // not supporting syncronous version (yet) or collect_vars with this new structure
       return this.expander_./*OK*/expand(url, opt_bindings, opt_whiteList);

--- a/tools/experiments/experiments.js
+++ b/tools/experiments/experiments.js
@@ -191,11 +191,6 @@ const EXPERIMENTS = [
     cleanupIssue: 'https://github.com/ampproject/amphtml/issues/5888',
   },
   {
-    id: 'variable-filters',
-    name: 'Format to apply filters to analytics variables',
-    cleanupIssue: 'https://github.com/ampproject/amphtml/issues/2198',
-  },
-  {
     id: 'pump-early-frame',
     name: 'Force all extensions to have the same release ' +
         'as the main JS binary',


### PR DESCRIPTION
This is a continuation of the work started in #12682 

The analytics level filters will now be passed as `opt_bindings` to be resolved at the platform level. Some dead code deleted from the original implementation that would try to resolve filters all at the analytics level. This should solve the mixpanel use case. 

The `replace` filter will be implemented in a separate PR

Related-to #2198

