### PR TITLE
Doubleclick Fast Fetch idle render fix throttle behavior for non-AMP creative

### DIFF
--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -942,7 +942,6 @@ export class AmpA4A extends AMP.BaseElement {
     if (this.isRefreshing) {
       this.destroyFrame(true);
     }
-    user().info(TAG, `layoutCallback ${Date.now()}`);
     return this.attemptToRenderCreative();
   }
 
@@ -1267,7 +1266,6 @@ export class AmpA4A extends AMP.BaseElement {
    * @return {Promise<boolean>} Whether the creative was successfully rendered.
    */
   renderNonAmpCreative(throttleApplied) {
-    user().info(TAG, `renderNonAmpCreative start ${Date.now()}`);
     if (this.element.getAttribute('disable3pfallback') == 'true') {
       user().warn(TAG, this.element.getAttribute('type'),
           'fallback to 3p disabled');

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -495,7 +495,7 @@ describe('amp-a4a', () => {
       const layoutCallbackPromise = a4a.layoutCallback();
       a4a.unlayoutCallback();
       const renderNonAmpCreativeSpy = sandbox.spy(
-          AmpA4A.prototype, 'renderNonAmpCreative_');
+          AmpA4A.prototype, 'renderNonAmpCreative');
       promiseResolver();
       layoutCallbackPromise.then(() => {
         // We should never get in here.
@@ -827,13 +827,13 @@ describe('amp-a4a', () => {
         doc.head.appendChild(s);
         const a4a = new MockA4AImpl(a4aElement);
         const renderNonAmpCreativeSpy =
-          sandbox.spy(a4a, 'renderNonAmpCreative_');
+          sandbox.spy(a4a, 'renderNonAmpCreative');
         a4a.buildCallback();
         a4a.onLayoutMeasure();
         expect(a4a.adPromise_).to.be.ok;
         return a4a.layoutCallback().then(() => {
           expect(renderNonAmpCreativeSpy.calledOnce,
-              'renderNonAmpCreative_ called exactly once').to.be.true;
+              'renderNonAmpCreative called exactly once').to.be.true;
           a4a.unlayoutCallback();
           getResourceStub.returns({
             'hasBeenMeasured': () => true,
@@ -888,13 +888,13 @@ describe('amp-a4a', () => {
         doc.head.appendChild(s);
         const a4a = new MockA4AImpl(a4aElement);
         const renderNonAmpCreativeSpy =
-          sandbox.spy(a4a, 'renderNonAmpCreative_');
+          sandbox.spy(a4a, 'renderNonAmpCreative');
         a4a.buildCallback();
         a4a.onLayoutMeasure();
         expect(a4a.adPromise_).to.be.ok;
         return a4a.layoutCallback().then(() => {
           expect(renderNonAmpCreativeSpy.calledOnce,
-              'renderNonAmpCreative_ called exactly once').to.be.true;
+              'renderNonAmpCreative called exactly once').to.be.true;
           a4a.unlayoutCallback();
           const onLayoutMeasureSpy = sandbox.spy(a4a, 'onLayoutMeasure');
           getResourceStub.returns({'hasBeenMeasured': () => false});

--- a/extensions/amp-ad/0.1/concurrent-load.js
+++ b/extensions/amp-ad/0.1/concurrent-load.js
@@ -23,12 +23,22 @@ import {user} from '../../../src/log';
  */
 const LOADING_ADS_WIN_ID_ = '3pla';
 
+/** @private {?Promise} resolves when no 3p throttle */
+let throttlePromise_ = null;
+/** @private {?Function} resolver for throttle promise */
+let throttlePromiseResolver_ = null;
+
 /**
  * @param {!Window} win
  * @return {boolean} Whether 3p is currently throttled.
  */
 export function is3pThrottled(win) {
   return !!win[LOADING_ADS_WIN_ID_];
+}
+
+/** @return {!Promise} resolves when no 3p throttle */
+export function waitFor3pThrottle() {
+  return throttlePromise_ || Promise.resolve();
 }
 
 /**
@@ -65,10 +75,16 @@ export function incrementLoadingAds(win, opt_loadingPromise) {
     win[LOADING_ADS_WIN_ID_] = 0;
   }
   win[LOADING_ADS_WIN_ID_]++;
+  throttlePromise_ = throttlePromise_ ||
+      new Promise(resolver => throttlePromiseResolver_ = resolver);
   Services.timerFor(win)
       .timeoutPromise(1000, opt_loadingPromise)
       .catch(() => {})
       .then(() => {
-        win[LOADING_ADS_WIN_ID_]--;
+        if (!--win[LOADING_ADS_WIN_ID_]) {
+          throttlePromiseResolver_();
+          throttlePromise_ = null;
+          throttlePromiseResolver_ = null;
+        }
       });
 }

--- a/extensions/amp-ad/0.1/test/test-concurrent-load.js
+++ b/extensions/amp-ad/0.1/test/test-concurrent-load.js
@@ -18,6 +18,7 @@ import {
   getAmpAdRenderOutsideViewport,
   is3pThrottled,
   incrementLoadingAds,
+  waitFor3pThrottle,
 } from '../concurrent-load';
 import {createElementWithAttributes} from '../../../../src/dom';
 import {installTimerService} from '../../../../src/service/timer-impl';
@@ -103,6 +104,25 @@ describes.realWin('concurrent-load', {}, env => {
       resolver();
       yield macroTask();
       expect(is3pThrottled(win)).to.be.false;
+    });
+  });
+
+  describe('waitFor3pThrottle', () => {
+    beforeEach(() => {
+      installTimerService(env.win);
+    });
+
+    it('should block if incremented', () => {
+      incrementLoadingAds(env.win);
+      const start = Date.now();
+      return waitFor3pThrottle(env.win).then(
+          () => expect(Date.now() - start >= 1000));
+    });
+
+    it('should not block if never incremented', () => {
+      const start = Date.now();
+      return waitFor3pThrottle(env.win).then(
+          () => expect(Date.now() - start <= 50));
     });
   });
 });


### PR DESCRIPTION
Render on idle with throttling should impose 1 second delay between non-AMP creatives however this was not applied given increment is set as part of layoutCallback as opposed to in advance.  Modified to enforce throttle during renderNonAmpCreative flow with test coverage (also tested locally).