### PR TITLE
Unbreak rendering {{.}} as strings in templates

### DIFF
--- a/extensions/amp-mustache/0.1/amp-mustache.js
+++ b/extensions/amp-mustache/0.1/amp-mustache.js
@@ -58,8 +58,10 @@ export class AmpMustache extends AMP.BaseTemplate {
 
   /** @override */
   render(data) {
-    const html = mustacheRender(this.template_,
-        Object.assign({}, data, this.nestedTemplates_));
+    if (typeof data !== 'string') {
+      data = Object.assign({}, data, this.nestedTemplates_);
+    }
+    const html = mustacheRender(this.template_, data);
     const sanitized = sanitizeHtml(html);
     const root = this.win.document.createElement('div');
     root./*OK*/innerHTML = sanitized;

--- a/extensions/amp-mustache/0.1/amp-mustache.js
+++ b/extensions/amp-mustache/0.1/amp-mustache.js
@@ -59,7 +59,7 @@ export class AmpMustache extends AMP.BaseTemplate {
   /** @override */
   render(data) {
     let mustacheData = data;
-    if (typeof mustacheData === 'object') {
+    if (typeof data === 'object') {
       mustacheData = Object.assign({}, data, this.nestedTemplates_);
     }
     const html = mustacheRender(this.template_, mustacheData);

--- a/extensions/amp-mustache/0.1/amp-mustache.js
+++ b/extensions/amp-mustache/0.1/amp-mustache.js
@@ -58,10 +58,11 @@ export class AmpMustache extends AMP.BaseTemplate {
 
   /** @override */
   render(data) {
-    if (typeof data !== 'string') {
-      data = Object.assign({}, data, this.nestedTemplates_);
+    let mustacheData = data;
+    if (typeof mustacheData === 'object') {
+      mustacheData = Object.assign({}, data, this.nestedTemplates_);
     }
-    const html = mustacheRender(this.template_, data);
+    const html = mustacheRender(this.template_, mustacheData);
     const sanitized = sanitizeHtml(html);
     const root = this.win.document.createElement('div');
     root./*OK*/innerHTML = sanitized;

--- a/extensions/amp-mustache/0.1/test/test-amp-mustache.js
+++ b/extensions/amp-mustache/0.1/test/test-amp-mustache.js
@@ -29,6 +29,15 @@ describe('amp-mustache template', () => {
     expect(result./*OK*/innerHTML).to.equal('value = abc');
   });
 
+  it('should render {{.}} from string', () => {
+    const templateElement = document.createElement('template');
+    templateElement.content.textContent = 'value = {{.}}';
+    const template = new AmpMustache(templateElement);
+    template.compileCallback();
+    const result = template.render('abc');
+    expect(result./*OK*/innerHTML).to.equal('value = abc');
+  });
+
   it('should sanitize output', () => {
     const templateElement = document.createElement('template');
     templateElement./*OK*/innerHTML =

--- a/src/service/template-impl.js
+++ b/src/service/template-impl.js
@@ -67,7 +67,7 @@ export class BaseTemplate {
 
   /**
    * To be implemented by subclasses.
-   * @param {!JsonObject} unusedData
+   * @param {!JsonObject|string} unusedData
    * @return {!Element}
    */
   render(unusedData) {


### PR DESCRIPTION
PR #12853 broke the rendering of `{{.}}` in templates where the passed data is a string (instead of an object.) This PR fixes it and adds a unit test to prevent future regressions