### PR TITLE
Skip testing for PR builds and non-lockfile push builds on greenkeeper branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ python:
 notifications:
   webhooks:
     - http://savage.nonblocking.io:8080/savage/travis
-# Skip greenkeeper PR builds
-if: NOT ((branch = ^greenkeeper/.*$) AND (type = pull_request))
 before_install:
   - export CHROME_BIN=google-chrome
   - export DISPLAY=:99.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ python:
 notifications:
   webhooks:
     - http://savage.nonblocking.io:8080/savage/travis
+# Skip greenkeeper PR builds
+if: NOT ((branch = ^greenkeeper/.*$) AND (type = pull_request))
 before_install:
   - export CHROME_BIN=google-chrome
   - export DISPLAY=:99.0

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -410,6 +410,24 @@ function main() {
       colors.cyan(process.env.BUILD_SHARD),
       '\n');
 
+  // Eliminate unnecessary testing on greenkeeper branches by running tests only
+  // on the push build that contains the lockfile update.
+  const isGreenkeeperPushBuild =
+      ((process.env.TRAVIS_EVENT_TYPE == 'push') &&
+       (process.env.TRAVIS_BRANCH.indexOf('greenkeeper/') != -1));
+  const isGreenkeeperPrBuild =
+      ((process.env.TRAVIS_EVENT_TYPE == 'pull_request') &&
+       (process.env.TRAVIS_PULL_REQUEST_BRANCH.indexOf('greenkeeper/') != -1));
+  if (isGreenkeeperPrBuild ||
+      (isGreenkeeperPushBuild &&
+       process.env.TRAVIS_COMMIT_MESSAGE.indexOf('update lockfile') == -1)) {
+    console.log(fileLogPrefix,
+        'Skipping unnecessary testing on greenkeeper branches. ' +
+        'Tests will only be run for the push build with the lockfile update.');
+    stopTimer('pr-check.js', startTime);
+    return 0;
+  }
+
   // If $TRAVIS_PULL_REQUEST_SHA is empty then it is a push build and not a PR.
   if (!process.env.TRAVIS_PULL_REQUEST_SHA) {
     console.log(fileLogPrefix, 'Running all commands on push build.');

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -410,20 +410,13 @@ function main() {
       colors.cyan(process.env.BUILD_SHARD),
       '\n');
 
+  // If $TRAVIS_PULL_REQUEST_SHA is empty then it is a push build and not a PR.
   if (!process.env.TRAVIS_PULL_REQUEST_SHA) {
-    // If $TRAVIS_PULL_REQUEST_SHA is empty, it's a push build. Run all tests.
     console.log(fileLogPrefix, 'Running all commands on push build.');
     runAllCommands();
     stopTimer('pr-check.js', startTime);
     return 0;
-  } else if (process.env.TRAVIS_BRANCH.indexOf('greenkeeper/') != -1) {
-    // If it's a PR build on a greenkeeper branch, there's nothing to do.
-    console.log(fileLogPrefix, 'Skipping tests for greenkeeper PR builds.');
-    stopTimer('pr-check.js', startTime);
-    return 0;
   }
-
-  // Determine which tests to run based on the files being touched by the PR.
   const files = filesInPr();
   const buildTargets = determineBuildTargets(files);
 

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -410,13 +410,20 @@ function main() {
       colors.cyan(process.env.BUILD_SHARD),
       '\n');
 
-  // If $TRAVIS_PULL_REQUEST_SHA is empty then it is a push build and not a PR.
   if (!process.env.TRAVIS_PULL_REQUEST_SHA) {
+    // If $TRAVIS_PULL_REQUEST_SHA is empty, it's a push build. Run all tests.
     console.log(fileLogPrefix, 'Running all commands on push build.');
     runAllCommands();
     stopTimer('pr-check.js', startTime);
     return 0;
+  } else if (process.env.TRAVIS_BRANCH.indexOf('greenkeeper/') != -1) {
+    // If it's a PR build on a greenkeeper branch, there's nothing to do.
+    console.log(fileLogPrefix, 'Skipping tests for greenkeeper PR builds.');
+    stopTimer('pr-check.js', startTime);
+    return 0;
   }
+
+  // Determine which tests to run based on the files being touched by the PR.
   const files = filesInPr();
   const buildTargets = determineBuildTargets(files);
 


### PR DESCRIPTION
`greenkeeper` branches are currently tested on Travis four times.

1. PR build for `package.json` update
2. Push build for `package.json` update
3. PR build for `yarn.lock` update
4. Push build for `yarn.lock` update

The only case in which we need to run all the AMP tests is case 4 above.

This PR skips testing in cases 1, 2, and 3. The pre and post script steps that actually update the lockfile will be run normally.

This will reduce test time from ~20 min to ~1 min in cases 1, 2, and 3, , thereby reducing the overall Travis CPU usage