### PR TITLE
Making sure the spinning loader is only visible on the active page on desktop.

### DIFF
--- a/extensions/amp-story/0.1/amp-story-page.js
+++ b/extensions/amp-story/0.1/amp-story-page.js
@@ -642,6 +642,7 @@ export class AmpStoryPage extends AMP.BaseElement {
    * @private
    */
   stopListeningToVideoEvents_() {
+    this.debounceToggleLoadingSpinner_(false);
     this.unlisteners_.forEach(unlisten => unlisten());
     this.unlisteners_ = [];
   }


### PR DESCRIPTION
Making sure the spinning loader is only visible on the active page on desktop.

Fixes #13024