### PR TITLE
Remove transitions for cropped and object-fit contain images from Lightbox

### DIFF
--- a/extensions/amp-image-viewer/0.1/amp-image-viewer.js
+++ b/extensions/amp-image-viewer/0.1/amp-image-viewer.js
@@ -209,7 +209,7 @@ export class AmpImageViewer extends AMP.BaseElement {
 
   /**
    * Returns the boundaries of the image element.
-   * @return {!Element}
+   * @return {?Element}
    */
   getImage() {
     return dev().assertElement(this.image_);

--- a/extensions/amp-image-viewer/0.1/amp-image-viewer.js
+++ b/extensions/amp-image-viewer/0.1/amp-image-viewer.js
@@ -212,7 +212,7 @@ export class AmpImageViewer extends AMP.BaseElement {
    * @return {?Element}
    */
   getImage() {
-    return dev().assertElement(this.image_);
+    return this.image_;
   }
 
   /**
@@ -286,11 +286,7 @@ export class AmpImageViewer extends AMP.BaseElement {
     } else {
       const img = elementByTag(dev().assertElement(this.sourceAmpImage_),
           'img');
-      if (img) {
-        return img.naturalWidth;
-      } else {
-        return this.sourceAmpImage_./*OK*/offsetWidth;
-      }
+      return img ? img.naturalWidth : this.sourceAmpImage_./*OK*/offsetWidth;
     }
   }
 
@@ -304,11 +300,7 @@ export class AmpImageViewer extends AMP.BaseElement {
     } else {
       const img = elementByTag(dev().assertElement(this.sourceAmpImage_),
           'img');
-      if (img) {
-        return img.naturalHeight;
-      } else {
-        return this.sourceAmpImage_./*OK*/offsetHeight;
-      }
+      return img ? img.naturalHeight : this.sourceAmpImage_./*OK*/offsetHeight;
     }
   }
 

--- a/extensions/amp-image-viewer/0.1/amp-image-viewer.js
+++ b/extensions/amp-image-viewer/0.1/amp-image-viewer.js
@@ -17,6 +17,7 @@
 import {CSS} from '../../../build/amp-image-viewer-0.1.css';
 import {Animation} from '../../../src/animation';
 import {bezierCurve} from '../../../src/curve';
+import {elementByTag} from '../../../src/dom';
 import {listen} from '../../../src/event-helper';
 import {Gestures} from '../../../src/gesture';
 import {dev, user} from '../../../src/log';
@@ -118,7 +119,7 @@ export class AmpImageViewer extends AMP.BaseElement {
     this.motion_ = null;
 
     /** @private {?Element} */
-    this.sourceElement_ = null;
+    this.sourceAmpImage_ = null;
   }
 
   /** @override */
@@ -130,16 +131,16 @@ export class AmpImageViewer extends AMP.BaseElement {
         children.length == 1 && children[0].tagName == 'AMP-IMG',
         'amp-image-viewer should have an amp-img as its one and only child'
     );
-    this.sourceElement_ = children[0];
-    this.setAsOwner(this.sourceElement_);
+    this.sourceAmpImage_ = children[0];
+    this.setAsOwner(this.sourceAmpImage_);
   }
 
   /** @override */
   layoutCallback() {
     let elementLayoutPromise = Promise.resolve();
-    if (this.sourceElement_) {
-      this.scheduleLayout(this.sourceElement_);
-      elementLayoutPromise = this.sourceElement_.signals()
+    if (this.sourceAmpImage_) {
+      this.scheduleLayout(this.sourceAmpImage_);
+      elementLayoutPromise = this.sourceAmpImage_.signals()
           .whenSignal(CommonSignals.LOAD_END);
     }
     return elementLayoutPromise
@@ -151,8 +152,8 @@ export class AmpImageViewer extends AMP.BaseElement {
 
               this.init_();
               this.element.appendChild(this.image_);
-              this.element.removeChild(this.sourceElement_);
-              this.sourceElement_ = null;
+              this.element.removeChild(this.sourceAmpImage_);
+              this.sourceAmpImage_ = null;
             }
           });
         }).then(() => {
@@ -276,18 +277,54 @@ export class AmpImageViewer extends AMP.BaseElement {
   }
 
   /**
+   * @return {number}
+   * @private
+   */
+  getSourceWidth_() {
+    if (this.sourceAmpImage_.hasAttribute('width')) {
+      return parseInt(this.sourceAmpImage_.getAttribute('width'), 10);
+    } else {
+      const img = elementByTag(dev().assertElement(this.sourceAmpImage_),
+          'img');
+      if (img) {
+        return img.naturalWidth;
+      } else {
+        return this.sourceAmpImage_./*OK*/offsetWidth;
+      }
+    }
+  }
+
+  /**
+   * @return {number}
+   * @private
+   */
+  getSourceHeight_() {
+    if (this.sourceAmpImage_.hasAttribute('height')) {
+      return parseInt(this.sourceAmpImage_.getAttribute('height'), 10);
+    } else {
+      const img = elementByTag(dev().assertElement(this.sourceAmpImage_),
+          'img');
+      if (img) {
+        return img.naturalHeight;
+      } else {
+        return this.sourceAmpImage_./*OK*/offsetHeight;
+      }
+    }
+  }
+
+  /**
    * Initializes the image viewer to the target image element such as
    * "amp-img". The target image element may or may not yet have the img
    * element initialized.
    */
   init_() {
-    this.sourceWidth_ = this.sourceElement_./*OK*/offsetWidth;
-    this.sourceHeight_ = this.sourceElement_./*OK*/offsetHeight;
-    this.srcset_ = srcsetFromElement(this.sourceElement_);
+    this.sourceWidth_ = this.getSourceWidth_();
+    this.sourceHeight_ = this.getSourceHeight_();
+    this.srcset_ = srcsetFromElement(dev().assertElement(this.sourceAmpImage_));
 
     ARIA_ATTRIBUTES.forEach(key => {
-      if (this.sourceElement_.hasAttribute(key)) {
-        this.image_.setAttribute(key, this.sourceElement_.getAttribute(key));
+      if (this.sourceAmpImage_.hasAttribute(key)) {
+        this.image_.setAttribute(key, this.sourceAmpImage_.getAttribute(key));
       }
     });
     st.setStyles(dev().assertElement(this.image_), {

--- a/extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.js
+++ b/extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.js
@@ -19,6 +19,7 @@ import {bezierCurve} from '../../../src/curve';
 import {CSS} from '../../../build/amp-lightbox-viewer-0.1.css';
 import {Gestures} from '../../../src/gesture';
 import {KeyCodes} from '../../../src/utils/key-codes';
+import {clamp} from '../../../src/utils/math';
 import {Services} from '../../../src/services';
 import {isExperimentOn} from '../../../src/experiments';
 import {isLoaded} from '../../../src/event-helper';
@@ -59,6 +60,7 @@ const MAX_TRANSITION_DURATION = 1000; // ms
 const MIN_TRANSITION_DURATION = 300; // ms
 const MAX_DISTANCE_APPROXIMATION = 250; // px
 const MOTION_DURATION_RATIO = 0.8; // fraction of animation
+const EPSILON = 0.001; // precision for approx equals
 
 /**
  * TODO(aghassemi): Make lightbox-manager into a doc-level service.
@@ -678,7 +680,7 @@ export class AmpLightboxViewer extends AMP.BaseElement {
     const elementHeight = ampImage./*OK*/offsetHeight;
     const elementWidth = ampImage./*OK*/offsetWidth;
     const ampImageAspectRatio = elementWidth / elementHeight;
-    return Math.abs(naturalAspectRatio - ampImageAspectRatio) > 0.001;
+    return Math.abs(naturalAspectRatio - ampImageAspectRatio) > EPSILON;
   }
 
   /**
@@ -867,10 +869,10 @@ export class AmpLightboxViewer extends AMP.BaseElement {
   getTransitionDuration_(dy) {
     const distanceAdjustedDuration =
       Math.abs(dy) / MAX_DISTANCE_APPROXIMATION * MAX_TRANSITION_DURATION;
-    // clamp duration to MIN and MAX duration constants
-    return Math.max(
-        Math.min(distanceAdjustedDuration, MAX_TRANSITION_DURATION),
-        MIN_TRANSITION_DURATION
+    return clamp(
+        distanceAdjustedDuration,
+        MIN_TRANSITION_DURATION,
+        MAX_TRANSITION_DURATION
     );
   }
   /**


### PR DESCRIPTION
Take these out because they look broken. Next step, actually implement a reasonable animation for them. 