### PR TITLE
Analytics: batchInterval support

### DIFF
--- a/extensions/amp-analytics/0.1/requests.js
+++ b/extensions/amp-analytics/0.1/requests.js
@@ -57,6 +57,9 @@ export class RequestHandler {
     this.batchInterval_ = request['batchInterval']; //unit is sec
 
     /** @private {?number} */
+    this.reportWindow_ = Number(request['reportWindow']) || null; // unit is sec
+
+    /** @private {?number} */
     this.batchIntervalPointer_ = null;
 
     /** @private @const {boolean} */
@@ -107,12 +110,19 @@ export class RequestHandler {
     /** @private {?number} */
     this.batchIntervalTimeoutId_ = null;
 
+    /** @private {?number} */
+    this.reportWindowTimeoutId_ = null;
+
+    /** @private {boolean} */
+    this.reportRequest_ = true;
+
     /** @private {?JsonObject} */
     this.lastTrigger_ = null;
 
     /** @private {number} */
     this.queueSize_ = 0;
 
+    this.initReportWindow_();
     this.initBatchInterval_();
   }
 
@@ -127,14 +137,23 @@ export class RequestHandler {
    *     return strings, promises, etc.
    */
   send(configParams, trigger, expansionOption, dynamicBindings) {
+    const isImportant = trigger['important'];
+
+    const isImmediate =
+        (trigger['important'] === true) || (!this.isBatched_);
+
+    if (!this.reportRequest_ && !isImportant) {
+      // Ignore non important trigger out reportWindow
+      return;
+    }
+
     this.queueSize_++;
     this.lastTrigger_ = trigger;
     const triggerParams = trigger['extraUrlParams'];
-    const isImmediate =
-        (trigger['immediate'] === true) || (!this.isBatched_);
 
     const macros = this.variableService_.getMacros();
     const bindings = Object.assign({}, dynamicBindings, macros);
+
     if (!this.baseUrlPromise_) {
       expansionOption.freezeVar('extraUrlParams');
       this.baseUrlTemplatePromise_ =
@@ -182,6 +201,11 @@ export class RequestHandler {
     if (this.batchIntervalTimeoutId_) {
       this.win.clearTimeout(this.batchIntervalTimeoutId_);
       this.batchIntervalTimeoutId_ = null;
+    }
+
+    if (this.reportWindowTimeoutId_) {
+      this.win.clearTimeout(this.reportWindowTimeoutId_);
+      this.reportWindowTimeoutId_ = null;
     }
   }
 
@@ -358,6 +382,7 @@ export class RequestHandler {
     }
 
     if (this.maxDelay_) {
+      // TODO: Remove maxDelay_ completely
       // Ignore maxDelay in presence of batchInterval
       // TODO: we can remove the restriction upon requests
       user().error(TAG,
@@ -365,50 +390,50 @@ export class RequestHandler {
       this.maxDelay_ = 0;
     }
 
-    if (isArray(this.batchInterval_)) {
-      // Support batchInterval in array with absolute time to send request
-      const batchInterval = [];
-      for (let i = 0; i < this.batchInterval_.length; i++) {
-        const current = this.batchInterval_[i];
-        const prev = (i > 0) ? this.batchInterval_[i - 1] : 0;
-        user().assert(isFiniteNumber(current) && Number(current) >= 0,
-            `Invalid batchInterval value: ${this.batchInterval_}, ` +
-            'interval must be number greater than 0.');
-        const interval = (current - prev) * 1000;
-        user().assert(i == 0 || interval > BATCH_INTERVAL_MIN,
-            `Invalid batchInterval value: ${this.batchInterval_}, ` +
-            `interval must be greater than ${BATCH_INTERVAL_MIN / 1000}s.`);
-        batchInterval[i] = interval;
-      }
-      this.batchInterval_ = batchInterval;
-      this.batchIntervalPointer_ = 0;
-    } else if (isFiniteNumber(Number(this.batchInterval_))) {
-      // Support batchInterval in number, send batched requests every interval
-      this.batchInterval_ = Number(this.batchInterval_) * 1000;
-      user().assert(this.batchInterval_ > BATCH_INTERVAL_MIN,
+    this.batchInterval_ = isArray(this.batchInterval_) ?
+      this.batchInterval_ : [this.batchInterval_];
+
+    for (let i = 0; i < this.batchInterval_.length; i++) {
+      let interval = this.batchInterval_[i];
+      user().assert(isFiniteNumber(interval),
+          `Invalid batchInterval value: ${this.batchInterval_}` +
+          'interval must be a number');
+      interval = Number(interval) * 1000;
+      user().assert(interval >= BATCH_INTERVAL_MIN,
           `Invalid batchInterval value: ${this.batchInterval_}, ` +
-          `interval must be greater than ${BATCH_INTERVAL_MIN / 1000}s.`);
-    } else {
-      user().assert(false,
-          `Invalid batchInterval value: ${this.batchInterval_}`);
+          `interval value must be greater than ${BATCH_INTERVAL_MIN}ms.`);
+      this.batchInterval_[i] = interval;
     }
 
+    this.batchIntervalPointer_ = 0;
+
     this.refreshBatchInterval_();
+  }
+
+  initReportWindow_() {
+    if (this.reportWindow_) {
+      this.reportWindowTimeoutId_ = this.win.setTimeout(() => {
+        // Flush batch queue;
+        this.trigger_(true);
+        this.reportRequest_ = false;
+        // Clear batchInterval timeout
+        if (this.batchIntervalTimeoutId_) {
+          this.win.clearTimeout(this.batchIntervalTimeoutId_);
+          this.batchIntervalTimeoutId_ = null;
+        }
+      }, this.reportWindow_ * 1000);
+    }
   }
 
   /**
    * Schedule sending request regarding to batchInterval
    */
   refreshBatchInterval_() {
-    let interval;
-    if (this.batchIntervalPointer_ != null) {
-      if (this.batchIntervalPointer_ >= this.batchInterval_.length) {
-        return;
-      }
-      interval = this.batchInterval_[this.batchIntervalPointer_++];
-    } else {
-      interval = this.batchInterval_;
-    }
+    dev().assert(this.batchIntervalPointer_ != null,
+        'Should not start batchInterval without pointer');
+    const interval = this.batchIntervalPointer_ < this.batchInterval_.length ?
+      this.batchInterval_[this.batchIntervalPointer_++] :
+      this.batchInterval_[this.batchInterval_.length - 1];
 
     this.batchIntervalTimeoutId_ = this.win.setTimeout(() => {
       this.trigger_(true);

--- a/extensions/amp-analytics/0.1/test/test-requests.js
+++ b/extensions/amp-analytics/0.1/test/test-requests.js
@@ -44,7 +44,34 @@ describes.realWin('Requests', {amp: 1}, env => {
   });
 
   describe('RequestHandler', () => {
-    describe('batch Delay', () => {
+    describe('batch', () => {
+      it('should batch multiple send', function* () {
+        const spy = sandbox.spy();
+        const r = {'baseUrl': 'r2', 'maxDelay': 1};
+        const handler = new RequestHandler(ampdoc, r, preconnect, spy, false);
+        const expansionOptions = new ExpansionOptions({});
+        handler.send({}, {}, expansionOptions, {});
+        handler.send({}, {}, expansionOptions, {});
+        clock.tick(500);
+        handler.send({}, {}, expansionOptions, {});
+        clock.tick(500);
+        yield macroTask();
+        expect(spy).to.be.calledOnce;
+      });
+
+      it('should preconnect', function* () {
+        const r = {'baseUrl': 'r2?cid=CLIENT_ID(scope)&var=${test}'};
+        const handler =
+            new RequestHandler(ampdoc, r, preconnect, sandbox.spy(), false);
+        const expansionOptions = new ExpansionOptions({'test': 'expanded'});
+        handler.send({}, {}, expansionOptions, {});
+        yield macroTask();
+        expect(preconnectSpy).to.be.calledWith(
+            'r2?cid=CLIENT_ID(scope)&var=expanded');
+      });
+    });
+
+    describe('batch with maxDelay', () => {
       it('maxDelay should  be a number', () => {
         const r1 = {'baseUrl': 'r1', 'maxDelay': 1};
         const r2 = {'baseUrl': 'r2', 'maxDelay': '2'};
@@ -120,32 +147,134 @@ describes.realWin('Requests', {amp: 1}, env => {
         expect(spy).to.be.calledOnce;
         expect(spy.args[0][0]).to.equal('r?e=4');
       });
+    });
 
-      it('should batch multiple send', function* () {
-        const spy = sandbox.spy();
-        const r = {'baseUrl': 'r2', 'maxDelay': 1};
+    describe('batch with batchInterval', () => {
+      let spy;
+      beforeEach(() => {
+        spy = sandbox.spy();
+      });
+
+      it('should support number', () => {
+        const r = {'baseUrl': 'r1', 'batchInterval': 5};
+        const handler = new RequestHandler(ampdoc, r, preconnect, spy, false);
+        expect(handler.batchIntervalPointer_).to.be.null;
+        expect(handler.batchInterval_).to.equal(5000);
+      });
+
+      it('should support array', () => {
+        const r = {'baseUrl': 'r1', 'batchInterval': [0, 2, 3]};
+        const handler = new RequestHandler(ampdoc, r, preconnect, spy, false);
+        expect(handler.batchIntervalPointer_).to.not.be.null;
+        expect(handler.batchInterval_).to.deep.equal([0, 2000, 1000]);
+      });
+
+      it('should check batchInterval is valid', () => {
+        //Should be number
+        const r1 = {'baseUrl': 'r', 'batchInterval': 'invalid'};
+        const r2 = {'baseUrl': 'r', 'batchInterval': ['invalid']};
+        try {
+          new RequestHandler(ampdoc, r1, preconnect, spy, false);
+          throw new Error('should never happen');
+        } catch (e) {
+          expect(e).to.match(/Invalid batchInterval value/);
+        }
+        try {
+          new RequestHandler(ampdoc, r2, preconnect, spy, false);
+          throw new Error('should never happen');
+        } catch (e) {
+          expect(e).to.match(/Invalid batchInterval value/);
+        }
+
+        //Should be greater than BATCH_INTERVAL_MIN
+        const r3 = {'baseUrl': 'r', 'batchInterval': 0.01};
+        const r4 = {'baseUrl': 'r', 'batchInterval': [-1, 5]};
+        const r5 = {'baseUrl': 'r', 'batchInterval': [1, 1.01]};
+        try {
+          new RequestHandler(ampdoc, r3, preconnect, spy, false);
+          throw new Error('should never happen');
+        } catch (e) {
+          expect(e).to.match(/Invalid batchInterval value/);
+        }
+        try {
+          new RequestHandler(ampdoc, r4, preconnect, spy, false);
+          throw new Error('should never happen');
+        } catch (e) {
+          expect(e).to.match(/Invalid batchInterval value/);
+        }
+        try {
+          new RequestHandler(ampdoc, r5, preconnect, spy, false);
+          throw new Error('should never happen');
+        } catch (e) {
+          expect(e).to.match(/Invalid batchInterval value/);
+        }
+      });
+
+      it('should overwrite maxDelay', () => {
+        const r = {'baseUrl': 'r', 'batchInterval': 1, 'maxDelay': 5};
+        const handler = new RequestHandler(ampdoc, r, preconnect, spy, false);
+        expect(handler.maxDelay_).to.equal(0);
+      });
+
+      it('should schedule send request', function* () {
+        const r = {'baseUrl': 'r', 'batchInterval': 1};
         const handler = new RequestHandler(ampdoc, r, preconnect, spy, false);
         const expansionOptions = new ExpansionOptions({});
+        clock.tick(998);
         handler.send({}, {}, expansionOptions, {});
+        yield macroTask();
+        expect(spy).to.not.be.called;
+        clock.tick(1);
         handler.send({}, {}, expansionOptions, {});
-        clock.tick(500);
-        handler.send({}, {}, expansionOptions, {});
-        clock.tick(500);
+        yield macroTask();
+        expect(spy).to.not.be.called;
+        clock.tick(2);
         yield macroTask();
         expect(spy).to.be.calledOnce;
       });
 
-      it('should preconnect', function* () {
-        const r = {'baseUrl': 'r2?cid=CLIENT_ID(scope)&var=${test}'};
-        const handler =
-            new RequestHandler(ampdoc, r, preconnect, sandbox.spy(), false);
-        const expansionOptions = new ExpansionOptions({'test': 'expanded'});
+      it('should schedule send request with interval array', function* () {
+        const r = {'baseUrl': 'r', 'batchInterval': [1, 3]};
+        const handler = new RequestHandler(ampdoc, r, preconnect, spy, false);
+        const expansionOptions = new ExpansionOptions({});
+        clock.tick(998);
         handler.send({}, {}, expansionOptions, {});
+        clock.tick(2);
         yield macroTask();
-        expect(preconnectSpy).to.be.calledWith(
-            'r2?cid=CLIENT_ID(scope)&var=expanded');
+        expect(spy).to.be.calledOnce;
+        spy.reset();
+        handler.send({}, {}, expansionOptions, {});
+        clock.tick(1000);
+        yield macroTask();
+        expect(spy).to.not.be.called;
+        handler.send({}, {}, expansionOptions, {});
+        clock.tick(1000);
+        yield macroTask();
+        expect(spy).to.be.calledOnce;
+      });
 
+      it('should not schedule send request w/o trigger', function* () {
+        const r = {'baseUrl': 'r', 'batchInterval': [1]};
+        new RequestHandler(ampdoc, r, preconnect, spy, false);
+        clock.tick(1000);
+        yield macroTask();
+        expect(spy).to.not.be.called;
+      });
 
+      it('should schedule send independent of trigger immediate', function* () {
+        const r = {'baseUrl': 'r', 'batchInterval': [1, 2]};
+        const handler = new RequestHandler(ampdoc, r, preconnect, spy, false);
+        const expansionOptions = new ExpansionOptions({});
+        handler.send({}, {}, expansionOptions, {});
+        clock.tick(999);
+        handler.send({}, {'immediate': true}, expansionOptions, {});
+        yield macroTask();
+        expect(spy).to.be.calledOnce;
+        spy.reset();
+        handler.send({}, {}, expansionOptions, {});
+        clock.tick(1);
+        yield macroTask();
+        expect(spy).to.be.calledOnce;
       });
     });
 

--- a/extensions/amp-analytics/amp-analytics.md
+++ b/extensions/amp-analytics/amp-analytics.md
@@ -260,7 +260,7 @@ The `triggers` configuration object describes when an analytics request should b
   - `on` (required) The event to listen for. Valid values are `render-start`, `ini-load`, `click`, `scroll`, `timer`, `visible`, `hidden`, `user-error`, [`access-*`](../amp-access/amp-access-analytics.md), and [`video-*`](./amp-video-analytics.md)
   - `request` (required) Name of the request to send (as specified in the `requests` section).
   - `vars` An object containing key-value pairs used to override `vars` defined in the top level config, or to specify vars unique to this trigger.
-  - `immediate` can be specified to work with request that support batching behavior. Setting `immediate` to `true` can help to flush batched request queue with some certain trigger. In this case, it's possible to reduce the request pings number without losing important trigger events.
+  - `important` can be specified to work with request that support batching behavior. Setting `important` to `true` can help to flush batched request queue with some certain trigger. In this case, it's possible to reduce the request pings number without losing important trigger events.
   - `selector` and `selectionMethod` can be specified for some triggers, such as `click` and `visible`. See [Element selector](#element-selector) for details.
   - `scrollSpec` (required when `on` is set to `scroll`) This configuration is used in conjunction with the `scroll` trigger. Please see below for details.
   - `timerSpec` (required when `on` is set to `timer`) This configuration is used in conjunction with the `timer` trigger. Please see below for details.

--- a/test/manual/analytics-batching.amp.html
+++ b/test/manual/analytics-batching.amp.html
@@ -47,56 +47,41 @@ Integer in felis at lacus mattis facilisis. Curabitur tincidunt, felis porttitor
     "requests": {
       "old": "https://fake.com/analytics?timer",
       "batch": {
-        "baseUrl": "https://fake.com/batch-analytics?",
+        "baseUrl": "https://fake.com/batch?",
         "maxDelay": 5
       },
       "batchplugin": {
-        "baseUrl": "https://fake.com/batch-analytics?",
+        "baseUrl": "https://fake.com/batchplugin?",
         "maxDelay": 5,
         "batchPlugin": "_ping_"
+      },
+      "batchInterval1": {
+        "baseUrl": "https://fake.com/batchinterval1?",
+        "batchInterval": [1, 2, 5, 10]
+      },
+      "batchInterval2": {
+        "baseUrl": "https://fake.com/batchinterval2?",
+        "batchInterval": 5
       }
     },
     "triggers": {
-      "timer": {
-        "on": "timer",
-        "request": "old",
-        "immediate": true,
-        "timerSpec": {
-          "interval": 2,
-          "maxTimerLength": 10
-        }
-      },
       "batch-time": {
         "on": "timer",
-        "request": "batch",
+        "request": ["batch", "batchInterval1", "batchInterval2"],
         "timerSpec": {
           "interval": 2,
           "maxTimerLength": 10
         },
-        "batchSegment": "&timer",
         "extraUrlParams": {
-          "extra": null,
-          "extra2": "&&${requestCount}"
-        }
-      },
-      "batch-plugin-timer": {
-        "on": "timer",
-        "request": "batchplugin",
-        "timerSpec": {
-          "interval": 2,
-          "maxTimerLength": 10
-        },
-        "batchSegment": "&timer",
-        "extraUrlParams": {
+          "event": "timer",
           "extra2": "${requestCount}"
         }
       },
       "click": {
         "on": "click",
         "selector": "#ele1",
-        "request": "batch",
+        "request": ["batch", "batchInterval1", "batchInterval2"],
         "immediate": true,
-        "batchSegment": "&timer",
         "extraUrlParams": {
           "extra": "immediate"
         }

--- a/test/manual/analytics-batching.amp.html
+++ b/test/manual/analytics-batching.amp.html
@@ -57,11 +57,13 @@ Integer in felis at lacus mattis facilisis. Curabitur tincidunt, felis porttitor
       },
       "batchInterval1": {
         "baseUrl": "https://fake.com/batchinterval1?",
-        "batchInterval": [1, 2, 5, 10]
+        "batchInterval": [1, 2, 5, 10],
+        "reportWindow": 30
       },
       "batchInterval2": {
         "baseUrl": "https://fake.com/batchinterval2?",
-        "batchInterval": 5
+        "batchInterval": 2,
+        "reportWindow": 10
       }
     },
     "triggers": {
@@ -81,9 +83,9 @@ Integer in felis at lacus mattis facilisis. Curabitur tincidunt, felis porttitor
         "on": "click",
         "selector": "#ele1",
         "request": ["batch", "batchInterval1", "batchInterval2"],
-        "immediate": true,
+        "important": true,
         "extraUrlParams": {
-          "extra": "immediate"
+          "extra": "important"
         }
       }
     },


### PR DESCRIPTION
This PR adds `batchInterval` support
`batchInterval` can be a single number that specify the interval. Or an array of numbers that specify the absolute time to flush batch queue. 

@pomeroyr please confirm this satisfy your use case. Thanks. We can add keywords like `exp` upon further requests. 