### PR TITLE
Fix ads.amp.html

### DIFF
--- a/build-system/app.js
+++ b/build-system/app.js
@@ -751,13 +751,7 @@ app.get(['/examples/*.html', '/test/manual/*.html'], (req, res, next) => {
   });
 });
 
-function escapeRegExp(string) {
-  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
 function elementExtractor(tagName, type) {
-  tagName = escapeRegExp(tagName);
-  type = escapeRegExp(type);
   return new RegExp(
       `<${tagName} [^>]*['"]${type}['"][^>]*>([\\s\\S]+?)</${tagName}>`,
       'gm');

--- a/build-system/app.js
+++ b/build-system/app.js
@@ -751,7 +751,12 @@ app.get(['/examples/*.html', '/test/manual/*.html'], (req, res, next) => {
   });
 });
 
+function escapeRegExp(string) {
+  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 function elementExtractor(tagName, type) {
+  type = escapeRegExp(type);
   return new RegExp(
       `<${tagName} [^>]*['"]${type}['"][^>]*>([\\s\\S]+?)</${tagName}>`,
       'gm');


### PR DESCRIPTION
@rsimha-amp can you explain what was your change trying to do? It breaks the regex.

```
'(amp-ad|amp-embed)'.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
=> "\(amp-ad\|amp-embed\)"
```