### PR TITLE
AppNexus added flag indicated renderStart implemented

### DIFF
--- a/ads/_config.js
+++ b/ads/_config.js
@@ -232,6 +232,7 @@ export const adConfig = {
   appnexus: {
     prefetch: 'https://acdn.adnxs.com/ast/ast.js',
     preconnect: 'https://ib.adnxs.com',
+    renderStartImplemented: true,
   },
 
   atomx: {


### PR DESCRIPTION
# AppNexus added flag indicated renderStart implemented

AppNexus adapter [previously](https://github.com/ampproject/amphtml/pull/10021) added support for the renderStart event. This just adds it into the config object. 