### PR TITLE
Remove the flash on story pages transitions.

### DIFF
--- a/extensions/amp-story/0.1/amp-story.css
+++ b/extensions/amp-story/0.1/amp-story.css
@@ -39,6 +39,9 @@ html.i-amphtml-story-standalone body {
   margin: 0 !important;
   padding: 0 !important;
   width: 100% !important;
+  /** Remove the cursor: pointer; style set by the runtime, to avoid wrong
+      touch feedback on mobile, like a flashing overlay on page transitions. */
+  cursor: auto !important;
 }
 
 html.i-amphtml-story-standalone body {

--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -285,10 +285,6 @@ export class AmpStory extends AMP.BaseElement {
         () => this.variableService_);
 
     this.buildLandscapeOrientationOverlay_();
-
-    // Remove the cursor: pointer; style set by the runtime, to avoid wrong
-    // touch feedback on mobile, like a flashing overlay on page transitions.
-    resetStyles(this.win.document.documentElement, ['cursor']);
   }
 
 

--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -285,6 +285,10 @@ export class AmpStory extends AMP.BaseElement {
         () => this.variableService_);
 
     this.buildLandscapeOrientationOverlay_();
+
+    // Remove the cursor: pointer; style set by the runtime, to avoid wrong
+    // touch feedback on mobile, like a flashing overlay on page transitions.
+    resetStyles(this.win.document.documentElement, ['cursor']);
   }
 
 


### PR DESCRIPTION
Removes the flash on story pages transitions.

[From this](https://giphy.com/gifs/26DN0yJwkIsX2KJFe), [to this](https://giphy.com/gifs/l4pT26uVYGrOKvPnW).

There's another [known hack](https://css-tricks.com/snippets/css/remove-gray-highlight-when-tapping-links-in-mobile-safari/) to get rid of this overlay, but it'd break tap feedback on all the elements, including links or forms if we ever support it.