### PR TITLE
amp-bind: Throw user error when replacing non-whitelisted URL vars

### DIFF
--- a/extensions/amp-bind/0.1/amp-state.js
+++ b/extensions/amp-bind/0.1/amp-state.js
@@ -130,13 +130,14 @@ export class AmpState extends AMP.BaseElement {
    * @return {!Promise}
    * @visibleForTesting
    */
-  fetch_(ampdoc, element) {
+  fetch_(ampdoc, element, isInit) {
     // Require opt-in for URL variable replacements on fetches triggered
     // by [src] mutation. @see spec/amp-var-substitutions.md
     const policy = isInit
       ? UrlReplacementPolicy.ALL
       : UrlReplacementPolicy.OPT_IN;
-    return batchFetchJsonFor(ampdoc, element, /* opt_expr */ null, policy);
+    return batchFetchJsonFor(
+        ampdoc, element, /* opt_expr */ undefined, policy);
   }
 
   /**

--- a/extensions/amp-bind/0.1/amp-state.js
+++ b/extensions/amp-bind/0.1/amp-state.js
@@ -130,7 +130,8 @@ export class AmpState extends AMP.BaseElement {
    * @visibleForTesting
    */
   batchFetchJsonFor_(ampdoc, element) {
-    return batchFetchJsonFor(ampdoc, element, undefined, UrlReplacementPolicy.OPT_IN);
+    return batchFetchJsonFor(
+        ampdoc, element, undefined, UrlReplacementPolicy.OPT_IN);
   }
 
   /**

--- a/extensions/amp-bind/0.1/amp-state.js
+++ b/extensions/amp-bind/0.1/amp-state.js
@@ -15,7 +15,11 @@
  */
 
 import {Services} from '../../../src/services';
-import {UrlReplacementPolicy, batchFetchJsonFor} from '../../../src/batched-json';
+import {
+  UrlReplacementPolicy,
+  batchFetchJsonFor,
+} from '../../../src/batched-json';
+import {getSourceOrigin} from '../../../src/url';
 import {map} from '../../../src/utils/object';
 import {isJsonScriptTag} from '../../../src/dom';
 import {toggle} from '../../../src/style';
@@ -131,11 +135,15 @@ export class AmpState extends AMP.BaseElement {
    * @visibleForTesting
    */
   fetch_(ampdoc, element, isInit) {
-    // Require opt-in for URL variable replacements on fetches triggered
+    const src = element.getAttribute('src');
+
+    // Require opt-in for URL variable replacements on CORS fetches triggered
     // by [src] mutation. @see spec/amp-var-substitutions.md
-    const policy = isInit
-      ? UrlReplacementPolicy.ALL
-      : UrlReplacementPolicy.OPT_IN;
+    let policy = UrlReplacementPolicy.OPT_IN;
+    if (isInit ||
+      (getSourceOrigin(src) == getSourceOrigin(ampdoc.win.location))) {
+      policy = UrlReplacementPolicy.ALL;
+    }
     return batchFetchJsonFor(
         ampdoc, element, /* opt_expr */ undefined, policy);
   }

--- a/extensions/amp-bind/0.1/amp-state.js
+++ b/extensions/amp-bind/0.1/amp-state.js
@@ -68,7 +68,7 @@ export class AmpState extends AMP.BaseElement {
     }
     const src = mutations['src'];
     if (src !== undefined) {
-      this.fetchSrcAndUpdateState_(/* isInit */ false);
+      this.fetchAndUpdate_(/* isInit */ false);
     }
   }
 
@@ -93,7 +93,7 @@ export class AmpState extends AMP.BaseElement {
       this.parseChildAndUpdateState_();
     }
     if (this.element.hasAttribute('src')) {
-      this.fetchSrcAndUpdateState_(/* isInit */ true);
+      this.fetchAndUpdate_(/* isInit */ true);
     }
   }
 
@@ -126,12 +126,17 @@ export class AmpState extends AMP.BaseElement {
    * Wrapper to stub during testing.
    * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
    * @param {!Element} element
+   * @param {boolean} isInit
    * @return {!Promise}
    * @visibleForTesting
    */
-  batchFetchJsonFor_(ampdoc, element) {
-    return batchFetchJsonFor(
-        ampdoc, element, undefined, UrlReplacementPolicy.OPT_IN);
+  fetch_(ampdoc, element) {
+    // Require opt-in for URL variable replacements on fetches triggered
+    // by [src] mutation. @see spec/amp-var-substitutions.md
+    const policy = isInit
+      ? UrlReplacementPolicy.ALL
+      : UrlReplacementPolicy.OPT_IN;
+    return batchFetchJsonFor(ampdoc, element, /* opt_expr */ null, policy);
   }
 
   /**
@@ -139,9 +144,9 @@ export class AmpState extends AMP.BaseElement {
    * @returm {!Promise}
    * @private
    */
-  fetchSrcAndUpdateState_(isInit) {
+  fetchAndUpdate_(isInit) {
     const ampdoc = this.getAmpDoc();
-    return this.batchFetchJsonFor_(ampdoc, this.element).then(json => {
+    return this.fetch_(ampdoc, this.element, isInit).then(json => {
       this.updateState_(json, isInit);
     });
   }

--- a/extensions/amp-bind/0.1/amp-state.js
+++ b/extensions/amp-bind/0.1/amp-state.js
@@ -15,7 +15,7 @@
  */
 
 import {Services} from '../../../src/services';
-import {batchFetchJsonFor} from '../../../src/batched-json';
+import {UrlReplacementPolicy, batchFetchJsonFor} from '../../../src/batched-json';
 import {map} from '../../../src/utils/object';
 import {isJsonScriptTag} from '../../../src/dom';
 import {toggle} from '../../../src/style';
@@ -130,7 +130,7 @@ export class AmpState extends AMP.BaseElement {
    * @visibleForTesting
    */
   batchFetchJsonFor_(ampdoc, element) {
-    return batchFetchJsonFor(ampdoc, element);
+    return batchFetchJsonFor(ampdoc, element, undefined, UrlReplacementPolicy.OPT_IN);
   }
 
   /**

--- a/extensions/amp-bind/0.1/amp-state.js
+++ b/extensions/amp-bind/0.1/amp-state.js
@@ -15,8 +15,8 @@
  */
 
 import {Services} from '../../../src/services';
+import {batchFetchJsonFor} from '../../../src/batched-json';
 import {map} from '../../../src/utils/object';
-import {fetchBatchedJsonFor} from '../../../src/batched-json';
 import {isJsonScriptTag} from '../../../src/dom';
 import {toggle} from '../../../src/style';
 import {tryParseJson} from '../../../src/json';
@@ -129,8 +129,8 @@ export class AmpState extends AMP.BaseElement {
    * @return {!Promise}
    * @visibleForTesting
    */
-  fetchBatchedJsonFor_(ampdoc, element) {
-    return fetchBatchedJsonFor(ampdoc, element);
+  batchFetchJsonFor_(ampdoc, element) {
+    return batchFetchJsonFor(ampdoc, element);
   }
 
   /**
@@ -140,7 +140,7 @@ export class AmpState extends AMP.BaseElement {
    */
   fetchSrcAndUpdateState_(isInit) {
     const ampdoc = this.getAmpDoc();
-    return this.fetchBatchedJsonFor_(ampdoc, this.element).then(json => {
+    return this.batchFetchJsonFor_(ampdoc, this.element).then(json => {
       this.updateState_(json, isInit);
     });
   }

--- a/extensions/amp-bind/0.1/test/test-amp-state.js
+++ b/extensions/amp-bind/0.1/test/test-amp-state.js
@@ -25,7 +25,7 @@ describes.realWin('AmpState', {
 }, env => {
   let ampState;
   let fetchSpy;
-  let batchedJsonStub;
+  let batchFetchStub;
   let updateStub;
 
   let stubFetchPromise;
@@ -57,8 +57,8 @@ describes.realWin('AmpState', {
 
     fetchSpy = env.sandbox.spy(impl, 'fetchSrcAndUpdateState_');
     updateStub = env.sandbox.stub(impl, 'updateState_');
-    batchedJsonStub = env.sandbox.stub(impl, 'fetchBatchedJsonFor_');
-    batchedJsonStub.returns(stubFetchPromise);
+    batchFetchStub = env.sandbox.stub(impl, 'batchFetchJsonFor_');
+    batchFetchStub.returns(stubFetchPromise);
   });
 
   it('should fetch json if `src` attribute exists', () => {
@@ -67,7 +67,7 @@ describes.realWin('AmpState', {
 
     // IMPORTANT: No CORS fetch should happen until viewer is visible.
     expect(fetchSpy).to.not.have.been.called;
-    expect(batchedJsonStub).to.not.have.been.called;
+    expect(batchFetchStub).to.not.have.been.called;
     expect(updateStub).to.not.have.been.called;
 
     whenFirstVisiblePromiseResolve();
@@ -86,7 +86,7 @@ describes.realWin('AmpState', {
 
     // IMPORTANT: No parsing should happen until viewer is visible.
     expect(fetchSpy).to.not.have.been.called;
-    expect(batchedJsonStub).to.not.have.been.called;
+    expect(batchFetchStub).to.not.have.been.called;
     expect(updateStub).to.not.have.been.called;
 
     whenFirstVisiblePromiseResolve();
@@ -104,7 +104,7 @@ describes.realWin('AmpState', {
 
     // IMPORTANT: No fetching or parsing should happen until viewer is visible.
     expect(fetchSpy).to.not.have.been.called;
-    expect(batchedJsonStub).to.not.have.been.called;
+    expect(batchFetchStub).to.not.have.been.called;
     expect(updateStub).to.not.have.been.called;
 
     whenFirstVisiblePromiseResolve();
@@ -126,7 +126,7 @@ describes.realWin('AmpState', {
     isVisibleStub.returns(false);
     ampState.mutatedAttributesCallback({src: 'https://foo.com/bar?baz=1'});
     expect(fetchSpy).to.not.have.been.called;
-    expect(batchedJsonStub).to.not.have.been.called;
+    expect(batchFetchStub).to.not.have.been.called;
 
     isVisibleStub.returns(true);
     ampState.mutatedAttributesCallback({src: 'https://foo.com/bar?baz=1'});

--- a/extensions/amp-bind/0.1/test/test-amp-state.js
+++ b/extensions/amp-bind/0.1/test/test-amp-state.js
@@ -23,12 +23,11 @@ describes.realWin('AmpState', {
     extensions: ['amp-bind:0.1'],
   },
 }, env => {
-  let ampState;
-  let fetchSpy;
-  let batchFetchStub;
-  let updateStub;
+  let win;
+  let sandbox;
 
-  let stubFetchPromise;
+  let element;
+  let ampState;
 
   // Viewer-related vars.
   let viewer;
@@ -36,103 +35,102 @@ describes.realWin('AmpState', {
   let whenFirstVisiblePromiseResolve;
 
   function getAmpState() {
-    const el = env.win.document.createElement('amp-state');
+    const el = win.document.createElement('amp-state');
     el.setAttribute('id', 'myAmpState');
-    env.win.document.body.appendChild(el);
+    win.document.body.appendChild(el);
     return el;
   }
 
   beforeEach(() => {
-    viewer = Services.viewerForDoc(env.win.document);
+    ({win, sandbox} = env);
+    viewer = Services.viewerForDoc(win.document);
     whenFirstVisiblePromise = new Promise(resolve => {
       whenFirstVisiblePromiseResolve = resolve;
     });
-    env.sandbox.stub(viewer, 'whenFirstVisible').callsFake(
-        () => whenFirstVisiblePromise);
+    sandbox.stub(viewer, 'whenFirstVisible')
+        .callsFake(() => whenFirstVisiblePromise);
 
-    ampState = getAmpState();
-    const impl = ampState.implementation_;
+    element = getAmpState();
+    ampState = element.implementation_;
 
-    stubFetchPromise = Promise.resolve({baz: 'qux'});
-
-    fetchSpy = env.sandbox.spy(impl, 'fetchSrcAndUpdateState_');
-    updateStub = env.sandbox.stub(impl, 'updateState_');
-    batchFetchStub = env.sandbox.stub(impl, 'batchFetchJsonFor_');
-    batchFetchStub.returns(stubFetchPromise);
+    sandbox.spy(ampState, 'fetchAndUpdate_');
+    sandbox.stub(ampState, 'updateState_');
+    sandbox.stub(ampState, 'fetch_')
+        .returns(Promise.resolve({baz: 'qux'}));
   });
 
   it('should fetch json if `src` attribute exists', () => {
-    ampState.setAttribute('src', 'https://foo.com/bar?baz=1');
-    ampState.build();
+    element.setAttribute('src', 'https://foo.com/bar?baz=1');
+    element.build();
 
     // IMPORTANT: No CORS fetch should happen until viewer is visible.
-    expect(fetchSpy).to.not.have.been.called;
-    expect(batchFetchStub).to.not.have.been.called;
-    expect(updateStub).to.not.have.been.called;
+    expect(ampState.fetchAndUpdate_).to.not.have.been.called;
+    expect(ampState.fetch_).to.not.have.been.called;
+    expect(ampState.updateState_).to.not.have.been.called;
 
     whenFirstVisiblePromiseResolve();
     return whenFirstVisiblePromise.then(() => {
-      expect(fetchSpy).calledWithExactly(/* isInit */ true);
-      return stubFetchPromise;
+      expect(ampState.fetchAndUpdate_).calledWithExactly(/* isInit */ true);
+      return ampState.fetch_();
     }).then(() => {
-      expect(updateStub).calledWithMatch({baz: 'qux'});
+      expect(ampState.updateState_).calledWithMatch({baz: 'qux'});
     });
   });
 
   it('should parse its child script', () => {
-    ampState.innerHTML = '<script type="application/json">' +
+    element.innerHTML = '<script type="application/json">' +
         '{"foo": "bar"}</script>';
-    ampState.build();
+    element.build();
 
     // IMPORTANT: No parsing should happen until viewer is visible.
-    expect(fetchSpy).to.not.have.been.called;
-    expect(batchFetchStub).to.not.have.been.called;
-    expect(updateStub).to.not.have.been.called;
+    expect(ampState.fetchAndUpdate_).to.not.have.been.called;
+    expect(ampState.fetch_).to.not.have.been.called;
+    expect(ampState.updateState_).to.not.have.been.called;
 
     whenFirstVisiblePromiseResolve();
     return whenFirstVisiblePromise.then(() => {
-      expect(fetchSpy).to.not.have.been.called;
-      expect(updateStub).calledWithMatch({foo: 'bar'});
+      expect(ampState.fetchAndUpdate_).to.not.have.been.called;
+      expect(ampState.updateState_).calledWithMatch({foo: 'bar'});
     });
   });
 
   it('should parse child and fetch `src` if both provided', () => {
-    ampState.innerHTML = '<script type="application/json">' +
+    element.innerHTML = '<script type="application/json">' +
         '{"foo": "bar"}</script>';
-    ampState.setAttribute('src', 'https://foo.com/bar?baz=1');
-    ampState.build();
+    element.setAttribute('src', 'https://foo.com/bar?baz=1');
+    element.build();
 
     // IMPORTANT: No fetching or parsing should happen until viewer is visible.
-    expect(fetchSpy).to.not.have.been.called;
-    expect(batchFetchStub).to.not.have.been.called;
-    expect(updateStub).to.not.have.been.called;
+    expect(ampState.fetchAndUpdate_).to.not.have.been.called;
+    expect(ampState.fetch_).to.not.have.been.called;
+    expect(ampState.updateState_).to.not.have.been.called;
 
     whenFirstVisiblePromiseResolve();
     return whenFirstVisiblePromise.then(() => {
-      expect(updateStub).calledWithMatch({foo: 'bar'});
-      expect(fetchSpy).calledWithExactly(/* isInit */ true);
-      return stubFetchPromise;
+      expect(ampState.updateState_).calledWithMatch({foo: 'bar'});
+      expect(ampState.fetchAndUpdate_).calledWithExactly(/* isInit */ true);
+      return ampState.fetch_();
     }).then(() => {
-      expect(updateStub).calledWithMatch({baz: 'qux'});
+      expect(ampState.updateState_).calledWithMatch({baz: 'qux'});
     });
   });
 
   it('should fetch json if `src` is mutated', () => {
-    ampState.setAttribute('src', 'https://foo.com/bar?baz=1');
-    ampState.build();
+    element.setAttribute('src', 'https://foo.com/bar?baz=1');
+    element.build();
 
     // IMPORTANT: No CORS fetch should happen until viewer is visible.
-    const isVisibleStub = env.sandbox.stub(viewer, 'isVisible');
+    const isVisibleStub = sandbox.stub(viewer, 'isVisible');
     isVisibleStub.returns(false);
-    ampState.mutatedAttributesCallback({src: 'https://foo.com/bar?baz=1'});
-    expect(fetchSpy).to.not.have.been.called;
-    expect(batchFetchStub).to.not.have.been.called;
+    element.mutatedAttributesCallback({src: 'https://foo.com/bar?baz=1'});
+    expect(ampState.fetchAndUpdate_).to.not.have.been.called;
+    expect(ampState.fetch_).to.not.have.been.called;
 
     isVisibleStub.returns(true);
-    ampState.mutatedAttributesCallback({src: 'https://foo.com/bar?baz=1'});
-    expect(fetchSpy).calledWithExactly(/* isInit */ false);
-    return stubFetchPromise.then(() => {
-      expect(updateStub).calledWithMatch({baz: 'qux'});
+    element.mutatedAttributesCallback({src: 'https://foo.com/bar?baz=1'});
+    expect(ampState.fetchAndUpdate_).calledWithExactly(/* isInit */ false);
+    return ampState.fetch_().then(() => {
+      expect(ampState.updateState_).calledWithMatch({baz: 'qux'});
     });
   });
 });

--- a/extensions/amp-date-picker/0.1/amp-date-picker.js
+++ b/extensions/amp-date-picker/0.1/amp-date-picker.js
@@ -21,13 +21,13 @@ import {DEFAULT_LOCALE, DEFAULT_FORMAT, FORMAT_STRINGS} from './constants';
 import {DatesList} from './dates-list';
 import {Layout} from '../../../src/layout';
 import {Services} from '../../../src/services';
+import {batchFetchJsonFor} from '../../../src/batched-json';
 import {childElementByAttr, isRTL, removeElement} from '../../../src/dom';
 import {createCustomEvent} from '../../../src/event-helper';
 import {createDateRangePicker} from './date-range-picker';
 import {createDeferred} from './react-utils';
 import {createSingleDatePicker} from './single-date-picker';
 import {dashToCamelCase} from '../../../src/string';
-import {fetchBatchedJsonFor} from '../../../src/batched-json';
 import {isExperimentOn} from '../../../src/experiments';
 import {map} from '../../../src/utils/object';
 import {requireExternal} from '../../../src/module';
@@ -239,7 +239,7 @@ class AmpDatePicker extends AMP.BaseElement {
    */
   fetchSrcTemplates_() {
     if (this.element.getAttribute('src')) {
-      return fetchBatchedJsonFor(this.ampdoc_, this.element);
+      return batchFetchJsonFor(this.ampdoc_, this.element);
     } else {
       return null;
     }

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -15,8 +15,8 @@
  */
 
 import {AmpEvents} from '../../../src/amp-events';
+import {batchFetchJsonFor} from '../../../src/batched-json';
 import {createCustomEvent} from '../../../src/event-helper';
-import {fetchBatchedJsonFor} from '../../../src/batched-json';
 import {isArray} from '../../../src/types';
 import {isLayoutSizeDefined} from '../../../src/layout';
 import {removeChildren} from '../../../src/dom';
@@ -237,7 +237,7 @@ export class AmpList extends AMP.BaseElement {
    * @private
    */
   fetch_(itemsExpr) {
-    return fetchBatchedJsonFor(this.getAmpDoc(), this.element, itemsExpr);
+    return batchFetchJsonFor(this.getAmpDoc(), this.element, itemsExpr);
   }
 }
 

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -50,6 +50,9 @@ export class AmpList extends AMP.BaseElement {
      * @private {boolean}
      */
     this.layoutCompleted_ = false;
+
+    /** @const @private {string} */
+    this.initialSrc_ = element.getAttribute('src');
   }
 
   /** @override */
@@ -237,8 +240,12 @@ export class AmpList extends AMP.BaseElement {
    * @private
    */
   fetch_(itemsExpr) {
-    return batchFetchJsonFor(this.getAmpDoc(), this.element, itemsExpr,
-        UrlReplacementPolicy.OPT_IN);
+    // Require opt-in for URL variable replacements on fetches triggered
+    // by [src] mutation. @see spec/amp-var-substitutions.md
+    const policy = (this.element.getAttribute('src') == this.initialSrc_)
+      ? UrlReplacementPolicy.ALL
+      : UrlReplacementPolicy.OPT_IN;
+    return batchFetchJsonFor(this.getAmpDoc(), this.element, itemsExpr, policy);
   }
 }
 

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -237,7 +237,8 @@ export class AmpList extends AMP.BaseElement {
    * @private
    */
   fetch_(itemsExpr) {
-    return batchFetchJsonFor(this.getAmpDoc(), this.element, itemsExpr, UrlReplacementPolicy.OPT_IN);
+    return batchFetchJsonFor(this.getAmpDoc(), this.element, itemsExpr,
+        UrlReplacementPolicy.OPT_IN);
   }
 }
 

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -15,10 +15,14 @@
  */
 
 import {AmpEvents} from '../../../src/amp-events';
-import {UrlReplacementPolicy, batchFetchJsonFor} from '../../../src/batched-json';
+import {
+  UrlReplacementPolicy,
+  batchFetchJsonFor,
+} from '../../../src/batched-json';
 import {createCustomEvent} from '../../../src/event-helper';
 import {isArray} from '../../../src/types';
 import {isLayoutSizeDefined} from '../../../src/layout';
+import {getSourceOrigin} from '../../../src/url';
 import {removeChildren} from '../../../src/dom';
 import {Services} from '../../../src/services';
 import {dev, user} from '../../../src/log';
@@ -240,12 +244,17 @@ export class AmpList extends AMP.BaseElement {
    * @private
    */
   fetch_(itemsExpr) {
-    // Require opt-in for URL variable replacements on fetches triggered
+    const ampdoc = this.getAmpDoc();
+    const src = this.element.getAttribute('src');
+
+    // Require opt-in for URL variable replacements on CORS fetches triggered
     // by [src] mutation. @see spec/amp-var-substitutions.md
-    const policy = (this.element.getAttribute('src') == this.initialSrc_)
-      ? UrlReplacementPolicy.ALL
-      : UrlReplacementPolicy.OPT_IN;
-    return batchFetchJsonFor(this.getAmpDoc(), this.element, itemsExpr, policy);
+    let policy = UrlReplacementPolicy.OPT_IN;
+    if (src == this.initialSrc_ ||
+      (getSourceOrigin(src) == getSourceOrigin(ampdoc.win.location))) {
+      policy = UrlReplacementPolicy.ALL;
+    }
+    return batchFetchJsonFor(ampdoc, this.element, itemsExpr, policy);
   }
 }
 

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -15,7 +15,7 @@
  */
 
 import {AmpEvents} from '../../../src/amp-events';
-import {batchFetchJsonFor} from '../../../src/batched-json';
+import {UrlReplacementPolicy, batchFetchJsonFor} from '../../../src/batched-json';
 import {createCustomEvent} from '../../../src/event-helper';
 import {isArray} from '../../../src/types';
 import {isLayoutSizeDefined} from '../../../src/layout';
@@ -237,7 +237,7 @@ export class AmpList extends AMP.BaseElement {
    * @private
    */
   fetch_(itemsExpr) {
-    return batchFetchJsonFor(this.getAmpDoc(), this.element, itemsExpr);
+    return batchFetchJsonFor(this.getAmpDoc(), this.element, itemsExpr, UrlReplacementPolicy.OPT_IN);
   }
 }
 

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -88,7 +88,7 @@ describes.realWin('amp-list component', {
     return Promise.all([fetch, render]);
   }
 
-  it('should load and render', () => {
+  it('should fetch and render', () => {
     const items = [
       {title: 'Title1'},
     ];
@@ -126,7 +126,7 @@ describes.realWin('amp-list component', {
     });
   });
 
-  it('should load and render non-array if single-item is set', () => {
+  it('should fetch and render non-array if single-item is set', () => {
     const items = {title: 'Title1'};
     const itemElement = doc.createElement('div');
     element.setAttribute('single-item', 'true');
@@ -186,7 +186,7 @@ describes.realWin('amp-list component', {
     });
   });
 
-  it('should _not_ reload if [src] attribute changes (before layout)', () => {
+  it('should _not_ refetch if [src] attribute changes (before layout)', () => {
     // Not allowed before layout.
     listMock.expects('fetchList_').never();
 
@@ -211,7 +211,7 @@ describes.realWin('amp-list component', {
     });
   });
 
-  it('should reload if [src] attribute changes (after layout)', () => {
+  it('should refetch if [src] attribute changes (after layout)', () => {
     const items = [{title: 'foo'}];
     const foo = doc.createElement('div');
     const rendered = expectFetchAndRender(items, [foo]);

--- a/spec/amp-var-substitutions.md
+++ b/spec/amp-var-substitutions.md
@@ -48,7 +48,7 @@ The following table lists the features that enable variable substitutions, as we
   <tr>
     <td width="25%"><code>amp-list</code><br><a href="https://github.com/ampproject/amphtml/blob/master/extensions/amp-list/amp-list.md#substitutions">Detailed documentation</a></td>
     <td width="25%">Requests must be HTTPS URLs (not a requirement specific to variable substitutions)</td>
-    <td width="25%">Yes, if using <code>[src]</code> <a href="https://www.ampproject.org/docs/reference/components/amp-bind#element-specific-attributes">attribute binding</a>. Otherwise, no. Read more about <a href="#per-use-opt-in">per-use opt-in</a></td>
+    <td width="25%">Yes, if fetching cross-origin resources via <code>[src]</code> <a href="https://www.ampproject.org/docs/reference/components/amp-bind#element-specific-attributes">attribute binding</a>. Otherwise, no. Read more about <a href="#per-use-opt-in">per-use opt-in</a></td>
     <td width="25%">None</td>
   </tr>
   <tr>
@@ -60,7 +60,7 @@ The following table lists the features that enable variable substitutions, as we
   <tr>
     <td width="25%"><code>amp-state</code><br><a href="https://github.com/ampproject/amphtml/blob/master/extensions/amp-bind/amp-bind.md#attributes">Detailed documentation</a></td>
     <td width="25%">Requests must be HTTPS URLs (not a requirement specific to variable substitutions)</td>
-    <td width="25%">Yes, if using <code>[src]</code> <a href="https://www.ampproject.org/docs/reference/components/amp-bind#element-specific-attributes">attribute binding</a>. Otherwise, no. Read more about <a href="#per-use-opt-in">per-use opt-in</a></td>
+    <td width="25%">Yes, if fetching cross-origin resources via <code>[src]</code> <a href="https://www.ampproject.org/docs/reference/components/amp-bind#element-specific-attributes">attribute binding</a>. Otherwise, no. Read more about <a href="#per-use-opt-in">per-use opt-in</a></td>
     <td width="25%">None</td>
   </tr>
   <tr>

--- a/spec/amp-var-substitutions.md
+++ b/spec/amp-var-substitutions.md
@@ -48,7 +48,7 @@ The following table lists the features that enable variable substitutions, as we
   <tr>
     <td width="25%"><code>amp-list</code><br><a href="https://github.com/ampproject/amphtml/blob/master/extensions/amp-list/amp-list.md#substitutions">Detailed documentation</a></td>
     <td width="25%">Requests must be HTTPS URLs (not a requirement specific to variable substitutions)</td>
-    <td width="25%">Yes, if using <code>[src]</code> <a href="https://www.ampproject.org/docs/reference/components/amp-bind#element-specific-attributes">attribute binding</a>. Otherwise, no</td>
+    <td width="25%">Yes, if using <code>[src]</code> <a href="https://www.ampproject.org/docs/reference/components/amp-bind#element-specific-attributes">attribute binding</a>. Otherwise, no. Read more about <a href="#per-use-opt-in">per-use opt-in</a></td>
     <td width="25%">None</td>
   </tr>
   <tr>
@@ -60,7 +60,7 @@ The following table lists the features that enable variable substitutions, as we
   <tr>
     <td width="25%"><code>amp-state</code><br><a href="https://github.com/ampproject/amphtml/blob/master/extensions/amp-bind/amp-bind.md#attributes">Detailed documentation</a></td>
     <td width="25%">Requests must be HTTPS URLs (not a requirement specific to variable substitutions)</td>
-    <td width="25%">Yes, if using <code>[src]</code> <a href="https://www.ampproject.org/docs/reference/components/amp-bind#element-specific-attributes">attribute binding</a>. Otherwise, no</td>
+    <td width="25%">Yes, if using <code>[src]</code> <a href="https://www.ampproject.org/docs/reference/components/amp-bind#element-specific-attributes">attribute binding</a>. Otherwise, no. Read more about <a href="#per-use-opt-in">per-use opt-in</a></td>
     <td width="25%">None</td>
   </tr>
   <tr>

--- a/spec/amp-var-substitutions.md
+++ b/spec/amp-var-substitutions.md
@@ -36,7 +36,7 @@ The following table lists the features that enable variable substitutions, as we
   <tr>
     <th width="25%"><strong>AMP Feature</strong></th>
     <th width="25%"><strong>URL limitations</strong></th>
-    <th width="25%"><strong>Requires per-use opt-in?</strong></th>
+    <th width="25%"><strong>Requires <a href="#per-use-opt-in">per-use opt-in</a>?</strong></th>
     <th width="25%"><strong>Restrictions</strong></th>
   </tr>
   <tr>
@@ -48,7 +48,7 @@ The following table lists the features that enable variable substitutions, as we
   <tr>
     <td width="25%"><code>amp-list</code><br><a href="https://github.com/ampproject/amphtml/blob/master/extensions/amp-list/amp-list.md#substitutions">Detailed documentation</a></td>
     <td width="25%">Requests must be HTTPS URLs (not a requirement specific to variable substitutions)</td>
-    <td width="25%">No</td>
+    <td width="25%">Yes, if using <code>[src]</code> <a href="https://www.ampproject.org/docs/reference/components/amp-bind#element-specific-attributes">attribute binding</a>. Otherwise, no</td>
     <td width="25%">None</td>
   </tr>
   <tr>
@@ -60,7 +60,7 @@ The following table lists the features that enable variable substitutions, as we
   <tr>
     <td width="25%"><code>amp-state</code><br><a href="https://github.com/ampproject/amphtml/blob/master/extensions/amp-bind/amp-bind.md#attributes">Detailed documentation</a></td>
     <td width="25%">Requests must be HTTPS URLs (not a requirement specific to variable substitutions)</td>
-    <td width="25%">No</td>
+    <td width="25%">Yes, if using <code>[src]</code> <a href="https://www.ampproject.org/docs/reference/components/amp-bind#element-specific-attributes">attribute binding</a>. Otherwise, no</td>
     <td width="25%">None</td>
   </tr>
   <tr>
@@ -74,13 +74,13 @@ The following table lists the features that enable variable substitutions, as we
       </ul>
     </td>
     <td width="25%">Yes, via space-delimited attribute <code>data-amp-replace</code>. Read more about <a href="#per-use-opt-in">per-use opt-in</a></td>
-    <td width="25%">Only these variables are supported: <code>CLIENT_ID</code> and <code>QUERY_PARAM</code>.<br>See the section on <a href="#substitution-timing">"substitution timing"</a> for further notes.</td>
+    <td width="25%">Only these variables are supported: <code>CLIENT_ID</code> and <code>QUERY_PARAM</code>.<br>See the section on <a href="#substitution-timing">"substitution timing"</a> for further notes</td>
   </tr>
   <tr>
     <td width="25%">Form inputs<br><a href="https://github.com/ampproject/amphtml/blob/master/extensions/amp-form/amp-form.md#variable-substitutions">Detailed documentation</a></td>
     <td width="25%">Requests must be HTTPS URLs (not a requirement specific to variable substitutions)</td>
     <td width="25%">Yes, via space-delimited attribute <code>data-amp-replace</code>. Read more about <a href="#per-use-opt-in">per-use opt-in</a></td>
-    <td width="25%">See the section on <a href="#substitution-timing">"substitution timing"</a> for further notes.</td>
+    <td width="25%">See the section on <a href="#substitution-timing">"substitution timing"</a> for further notes</td>
   </tr>
 </table>
 
@@ -582,7 +582,7 @@ Provides the name of the error that triggered an user error event. This variable
 #### External Referrer
 
 Provides the referrer where the user came from. Similar to [Document Referrer](#document_referrer), but the value is empty if user is navigated from same domain or the corresponding CDN proxy domain.
-Analytics vendor might prefer this value to Document Referrer for better session stitching, depending on the server side implementation. 
+Analytics vendor might prefer this value to Document Referrer for better session stitching, depending on the server side implementation.
 
 * **platform variable**: `EXTERNAL_REFERRER`
   *  Example: <br>
@@ -624,7 +624,7 @@ Provides the horizontal scroll boundary that triggered a scroll event. This vari
 #### Intersection Ratio
 
 Provides the fraction of the selected element that is visible. The value will be between 0.0 and 1.0, inclusive. For more information, please see the [IntersectionObserverEntry.intersectionRatio](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserverEntry/intersectionRatio) API documentation.
- 
+
 * **platform variable**: N/A
 * **amp-analytics variable**: `${intersectionRatio}`
 

--- a/src/batched-json.js
+++ b/src/batched-json.js
@@ -60,13 +60,14 @@ export function batchFetchJsonFor(
     // Throw user error if this element is performing URL substitutions
     // without the soon-to-be-required opt-in (#12498).
     if (opt_urlReplacement == UrlReplacementPolicy.OPT_IN) {
-      const unwhitelisted = urlReplacements.collectUnwhitelistedVars(element);
-      if (unwhitelisted.length > 0) {
-        const TAG = element.tagName;
-        user().error(TAG, 'Variable substitutions will soon require opt-in. ' +
-            `Please add data-amp-replace="${unwhitelisted.join(' ')}" to ` +
-            `the <${TAG}> element. This will stop working soon!`);
-      }
+      urlReplacements.collectUnwhitelistedVars(element).then(unwhitelisted => {
+        if (unwhitelisted.length > 0) {
+          const TAG = element.tagName;
+          user().error(TAG, 'Variable substitutions will soon require opt-in. ' +
+              `Please add data-amp-replace="${unwhitelisted.join(' ')}" to ` +
+              `the <${TAG}> element. This will stop working soon!`);
+        }
+      });
     }
     const opts = {};
     if (element.hasAttribute('credentials')) {

--- a/src/batched-json.js
+++ b/src/batched-json.js
@@ -63,9 +63,10 @@ export function batchFetchJsonFor(
       urlReplacements.collectUnwhitelistedVars(element).then(unwhitelisted => {
         if (unwhitelisted.length > 0) {
           const TAG = element.tagName;
-          user().error(TAG, 'URL variable substitutions will soon require ' +
-              `opt-in. Add data-amp-replace="${unwhitelisted.join(' ')}" to ` +
-              `the <${TAG}> element. This will stop working soon!`);
+          user().error(TAG, 'URL variable substitutions in CORS fetches ' +
+              'triggered by amp-bind will soon require opt-in. Please add ' +
+              `data-amp-replace="${unwhitelisted.join(' ')}" to the ` +
+              '<${TAG}> element. See "bit.ly/amp-var-subs" for details.';
         }
       });
     }

--- a/src/batched-json.js
+++ b/src/batched-json.js
@@ -66,7 +66,7 @@ export function batchFetchJsonFor(
           user().error(TAG, 'URL variable substitutions in CORS fetches ' +
               'triggered by amp-bind will soon require opt-in. Please add ' +
               `data-amp-replace="${unwhitelisted.join(' ')}" to the ` +
-              '<${TAG}> element. See "bit.ly/amp-var-subs" for details.';
+              `<${TAG}> element. See "bit.ly/amp-var-subs" for details.`);
         }
       });
     }

--- a/src/batched-json.js
+++ b/src/batched-json.js
@@ -33,13 +33,14 @@ import {user} from './log';
  * @return {!Promise<!JsonObject|!Array<JsonObject>>} Resolved with JSON
  *     result or rejected if response is invalid.
  */
-export function fetchBatchedJsonFor(
+export function batchFetchJsonFor(
   ampdoc, element, opt_expr = '.', opt_expandUrl = 'none')
 {
   const url = assertHttpsUrl(element.getAttribute('src'), element);
 
+  // Replace vars in URL if desired.
   const urlReplacements = Services.urlReplacementsForDoc(ampdoc);
-  const srcPromise = (opt_expandUrl in ['all', 'opt'])
+  const srcPromise = (['all', 'opt'].includes(opt_expandUrl))
     ? urlReplacements.expandUrlAsync(url)
     : Promise.resolve(url);
 
@@ -66,6 +67,6 @@ export function fetchBatchedJsonFor(
     if (data == null) {
       throw new Error('Response is undefined.');
     }
-    return getValueForExpr(data, opt_expr);
+    return getValueForExpr(data, opt_expr || '.');
   });
 }

--- a/src/batched-json.js
+++ b/src/batched-json.js
@@ -63,8 +63,8 @@ export function batchFetchJsonFor(
       urlReplacements.collectUnwhitelistedVars(element).then(unwhitelisted => {
         if (unwhitelisted.length > 0) {
           const TAG = element.tagName;
-          user().error(TAG, 'Variable substitutions will soon require opt-in. ' +
-              `Please add data-amp-replace="${unwhitelisted.join(' ')}" to ` +
+          user().error(TAG, 'URL variable substitutions will soon require ' +
+              `opt-in. Add data-amp-replace="${unwhitelisted.join(' ')}" to ` +
               `the <${TAG}> element. This will stop working soon!`);
         }
       });

--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -1024,7 +1024,13 @@ export class UrlReplacements {
     const url = element.getAttribute('src');
     return this.collectVars(url).then(vars => {
       const whitelist = this.getWhitelistForElement_(element);
-      return Object.keys(vars).filter(v => !whitelist[v]);
+      const varNames = Object.keys(vars);
+      if (whitelist) {
+        return varNames.filter(v => !whitelist[v]);
+      } else {
+        // All vars are unwhitelisted if the element has no whitelist.
+        return varNames;
+      }
     });
   }
 

--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -1001,7 +1001,6 @@ export class UrlReplacements {
     return replacementPromise || Promise.resolve(replacement);
   }
 
-
   /**
    * Collects all substitutions in the provided URL and expands them to the
    * values for known variables. Optional `opt_bindings` can be used to add
@@ -1014,7 +1013,6 @@ export class UrlReplacements {
     const vars = Object.create(null);
     return this.expand_(url, opt_bindings, vars).then(() => vars);
   }
-
 
   /**
    * Collects substitutions in the `src` attribute of the given element
@@ -1029,7 +1027,6 @@ export class UrlReplacements {
       return Object.keys(vars).filter(v => !whitelist[v]);
     });
   }
-
 
   /**
    * Ensures that the protocol of the original url matches the protocol of the

--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -1001,6 +1001,7 @@ export class UrlReplacements {
     return replacementPromise || Promise.resolve(replacement);
   }
 
+
   /**
    * Collects all substitutions in the provided URL and expands them to the
    * values for known variables. Optional `opt_bindings` can be used to add
@@ -1012,6 +1013,21 @@ export class UrlReplacements {
   collectVars(url, opt_bindings) {
     const vars = Object.create(null);
     return this.expand_(url, opt_bindings, vars).then(() => vars);
+  }
+
+
+  /**
+   * Collects substitutions in the `src` attribute of the given element
+   * that are _not_ whitelisted via `data-amp-replace` opt-in attribute.
+   * @param {!Element} element
+   * @return {!Promise<!Array<string>>}
+   */
+  collectUnwhitelistedVars(element) {
+    const url = element.getAttribute('src');
+    return this.collectVars(url).then(vars => {
+      const whitelist = this.getWhitelistForElement_(element);
+      return Object.keys(vars).filter(v => !whitelist[v]);
+    });
   }
 
 

--- a/test/functional/test-batched-json.js
+++ b/test/functional/test-batched-json.js
@@ -1,0 +1,108 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Services} from '../../src/services';
+import {batchFetchJsonFor} from '../../src/batched-json';
+import {user} from '../../src/log';
+
+describe('batchFetchJsonFor', () => {
+  let sandbox;
+  // Fakes.
+  let ampdoc = {win: null};
+  // Service fakes.
+  let urlReplacements;
+  let batchedXhr;
+  // Mutable return variables.
+  let data = {'foo': 'bar'};
+
+  /**
+   * @param {string} src
+   * @return {!Element}
+   */
+  function element(src) {
+    // Doesn't matter that it's amp-list. Could be anything with a src attr.
+    const el = document.createElement('AMP-LIST');
+    el.setAttribute('src', src);
+    return el;
+  }
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+
+    urlReplacements = {
+      expandUrlAsync: sandbox.stub(),
+      collectUnwhitelistedVars: sandbox.stub(),
+    };
+    sandbox.stub(Services, 'urlReplacementsForDoc').returns(urlReplacements);
+
+    batchedXhr = {
+      fetchJson: sandbox.stub().returns(Promise.resolve({
+        json: () => Promise.resolve(data)
+      })
+    )};
+    sandbox.stub(Services, 'batchedXhrFor').returns(batchedXhr);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('URL replacement', () => {
+    it('should not replace URL vars if opt_expand is not passed', () => {
+      const el = element('https://data.com?x=FOO&y=BAR');
+
+      return batchFetchJsonFor(ampdoc, el).then(() => {
+        expect(batchedXhr.fetchJson).to.be.calledWith('https://data.com?x=FOO&y=BAR');
+        expect(urlReplacements.expandUrlAsync).to.not.be.called;
+        expect(urlReplacements.collectUnwhitelistedVars).to.not.be.called;
+      });
+    });
+
+    it('should throw user error if expanding non-whitelisted vars and opt_expand is `opt`', () => {
+      const el = element('https://data.com?x=FOO&y=BAR');
+
+      urlReplacements.expandUrlAsync
+          .withArgs('https://data.com?x=FOO&y=BAR')
+          .returns(Promise.resolve('https://data.com?x=expandedFoo&y=BAR'));
+      urlReplacements.collectUnwhitelistedVars
+          .withArgs(el)
+          .returns(['BAR']);
+      const userError = sandbox.stub(user(), 'error');
+
+      return batchFetchJsonFor(ampdoc, el, /* opt_expr */ null, 'opt').then(() => {
+        expect(batchedXhr.fetchJson).to.be.calledWith('https://data.com?x=expandedFoo&y=BAR');
+        expect(userError).calledWithMatch('AMP-LIST', /data-amp-replace="BAR"/);
+      });
+    });
+
+    it('should replace all URL vars if opt_expand is `all`', () => {
+      const el = element('https://data.com?x=FOO&y=BAR');
+
+      urlReplacements.expandUrlAsync
+          .withArgs('https://data.com?x=FOO&y=BAR')
+          .returns(Promise.resolve('https://data.com?x=expandedFoo&y=BAR'));
+      const userError = sandbox.stub(user(), 'error');
+
+      return batchFetchJsonFor(ampdoc, el, /* opt_expr */ null, 'all').then(() => {
+        expect(batchedXhr.fetchJson).to.be.calledWith('https://data.com?x=expandedFoo&y=BAR');
+        expect(urlReplacements.collectUnwhitelistedVars).to.not.be.called;
+        expect(userError).to.not.be.called;
+      });
+    });
+  });
+
+  // TODO(choumx): Add tests for normal fetch functionality.
+});

--- a/test/functional/test-batched-json.js
+++ b/test/functional/test-batched-json.js
@@ -81,7 +81,7 @@ describe('batchFetchJsonFor', () => {
           .returns(Promise.resolve('https://data.com?x=abc&y=BAR'));
       urlReplacements.collectUnwhitelistedVars
           .withArgs(el)
-          .returns(['BAR']);
+          .returns(Promise.resolve(['BAR']));
       const userError = sandbox.stub(user(), 'error');
 
       const optIn = UrlReplacementPolicy.OPT_IN;

--- a/test/functional/test-url-replacements.js
+++ b/test/functional/test-url-replacements.js
@@ -1045,6 +1045,18 @@ describes.sandboxed('UrlReplacements', {}, () => {
         });
   });
 
+  it('should collect unwhitelisted vars', () => {
+    const win = getFakeWindow();
+    const element = document.createElement('amp-foo');
+    element.setAttribute('src', '?SOURCE_HOST&QUERY_PARAM(p1)&COUNTER');
+    element.setAttribute('data-amp-replace', 'QUERY_PARAM(p1)');
+    return Services.urlReplacementsForDoc(win.ampdoc)
+        .collectUnwhitelistedVars(element)
+        .then(res => {
+          expect(res).to.deep.equal(['SOURCE_HOST', 'COUNTER']);
+        });
+  });
+
   it('should reject javascript protocol', () => {
     const win = getFakeWindow();
     const urlReplacements = Services.urlReplacementsForDoc(win.ampdoc);


### PR DESCRIPTION
Step 1 for #12498.

- Throw user error when performing non-whitelisted URL var replacement via amp-bind
- Default to no replacement with new optional param `opt_urlReplacement`
- Add test-batched-json.js file
- Rename `fetchBatchedJsonFor` to `batchFetchJsonFor`

Aside: I think we should merge batched-json.js into batched-xhr.js. It'll also make stubbing the function possible.