### PR TITLE
Add missing prefix to example .amp-live-list-item-new CSS rule

### DIFF
--- a/extensions/amp-live-list/amp-live-list.md
+++ b/extensions/amp-live-list/amp-live-list.md
@@ -280,7 +280,7 @@ added, and will be removed once the next set of new items are inserted on a subs
 highlighting effect like the css below.
 
 ```css
-.live-list-item-new {
+.amp-live-list-item-new {
   animation: amp-live-list-item-highlight 2s;
 }
 


### PR DESCRIPTION
The class name added to newly-inserted `amp-live-list` items is `amp-live-list-item-new` but the example CSS is missing the `amp-` prefix, so it is incorrectly shown as `.live-list-item-new`.