### PR TITLE
Refactor media blessing to work cross-browser

### DIFF
--- a/extensions/amp-story/0.1/amp-story-page.js
+++ b/extensions/amp-story/0.1/amp-story-page.js
@@ -158,8 +158,7 @@ export class AmpStoryPage extends AMP.BaseElement {
     storyEl.getImpl()
         .then(storyImpl => {
           this.mediaPoolResolveFn_(MediaPool.for(storyImpl));
-        })
-        .catch(reason => this.mediaPoolRejectFn_(reason));
+        }, reason => this.mediaPoolRejectFn_(reason));
   }
 
 

--- a/extensions/amp-story/0.1/amp-story-page.js
+++ b/extensions/amp-story/0.1/amp-story-page.js
@@ -44,7 +44,6 @@ import {LoadingSpinner} from './loading-spinner';
 import {listen} from '../../../src/event-helper';
 import {debounce} from '../../../src/utils/rate-limit';
 import {MediaPool} from './media-pool';
-import {dev} from '../../../src/log';
 
 
 /**

--- a/extensions/amp-story/0.1/amp-story-page.js
+++ b/extensions/amp-story/0.1/amp-story-page.js
@@ -91,11 +91,19 @@ export class AmpStoryPage extends AMP.BaseElement {
       this.markPageAsLoaded_();
     });
 
+    let mediaPoolResolveFn, mediaPoolRejectFn;
+
     /** @private @const {!Promise<!MediaPool>} */
     this.mediaPoolPromise_ = new Promise((resolve, reject) => {
-      this.mediaPoolResolveFn_ = resolve;
-      this.mediaPoolRejectFn_ = reject;
+      mediaPoolResolveFn = resolve;
+      mediaPoolRejectFn = reject;
     });
+
+    /** @private @const {!function(!MediaPool)} */
+    this.mediaPoolResolveFn_ = mediaPoolResolveFn;
+
+    /** @private @const {!function(*)} */
+    this.mediaPoolRejectFn_ = mediaPoolRejectFn;
 
     /** @private @const {boolean} Only prerender the first story page. */
     this.prerenderAllowed_ = matches(this.element,

--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -377,9 +377,11 @@ export class AmpStory extends AMP.BaseElement {
     this.element.addEventListener(EventType.TAP_NAVIGATION, e => {
       const {direction} = e.detail;
 
-      this.mediaPool_.blessAll()
-          .then(() => this.performTapNavigation_(direction),
-              () => this.performTapNavigation_(direction));
+      this.performTapNavigation_(direction);
+
+      // We bless after the navigation so as not to slow down the navigation
+      // interaction.
+      this.mediaPool_.blessAll();
     });
 
     const gestures = Gestures.get(this.element,

--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -169,6 +169,9 @@ const HIDE_ON_BOOKEND_SELECTOR =
     'amp-story-page, .i-amphtml-story-system-layer';
 
 
+/**
+ * @implements {./media-pool.MediaPoolRoot}
+ */
 export class AmpStory extends AMP.BaseElement {
   /** @param {!AmpElement} element */
   constructor(element) {
@@ -238,7 +241,7 @@ export class AmpStory extends AMP.BaseElement {
     this.ampStoryHint_ = new AmpStoryHint(this.win);
 
     /** @private {!Promise<!MediaPool>} */
-    this.mediaPoolPromise_ = MediaPool.forStory(this.element);
+    this.mediaPool_ = MediaPool.for(this);
 
     /** @private @const {!../../../src/service/timer-impl.Timer} */
     this.timer_ = Services.timerFor(this.win);
@@ -374,8 +377,7 @@ export class AmpStory extends AMP.BaseElement {
     this.element.addEventListener(EventType.TAP_NAVIGATION, e => {
       const {direction} = e.detail;
 
-      this.mediaPoolPromise_
-          .then(mediaPool => mediaPool.blessAll())
+      this.mediaPool_.blessAll()
           .then(() => this.performTapNavigation_(direction),
               () => this.performTapNavigation_(direction));
     });
@@ -586,6 +588,12 @@ export class AmpStory extends AMP.BaseElement {
    */
   hashOrigin_(domain) {
     return stringHash32(domain.toLowerCase());
+  }
+
+
+  /** @override */
+  getWindow() {
+    return this.win;
   }
 
 
@@ -1264,21 +1272,14 @@ export class AmpStory extends AMP.BaseElement {
   }
 
 
-  /**
-   * @param {!Element} element The element whose distance should be retrieved.
-   * @return {number} The number of pages the specified element is from the
-   *     currently active page.
-   */
-  getElementDistanceFromActivePage(element) {
+  /** @override */
+  getElementDistance(element) {
     const page = this.getPageContainingElement_(element);
     return page.getDistance();
   }
 
 
-  /**
-   * @return {!Object<!MediaType, number>} The maximum amount of each media
-   *     type to allow within this story.
-   */
+  /** @override */
   getMaxMediaElementCounts() {
     return MAX_MEDIA_ELEMENT_COUNTS;
   }
@@ -1300,8 +1301,7 @@ export class AmpStory extends AMP.BaseElement {
    * @private
    */
   unmute_() {
-    this.mediaPoolPromise_
-        .then(mediaPool => mediaPool.blessAll())
+    this.mediaPool_.blessAll()
         .then(() => this.activePage_.unmuteAllMedia(),
             () => this.activePage_.unmuteAllMedia());
     this.toggleMutedAttribute_(false);

--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -240,7 +240,7 @@ export class AmpStory extends AMP.BaseElement {
     /** @private {!AmpStoryHint} */
     this.ampStoryHint_ = new AmpStoryHint(this.win);
 
-    /** @private {!Promise<!MediaPool>} */
+    /** @private {!MediaPool} */
     this.mediaPool_ = MediaPool.for(this);
 
     /** @private @const {!../../../src/service/timer-impl.Timer} */
@@ -588,12 +588,6 @@ export class AmpStory extends AMP.BaseElement {
    */
   hashOrigin_(domain) {
     return stringHash32(domain.toLowerCase());
-  }
-
-
-  /** @override */
-  getWindow() {
-    return this.win;
   }
 
 
@@ -1282,6 +1276,12 @@ export class AmpStory extends AMP.BaseElement {
   /** @override */
   getMaxMediaElementCounts() {
     return MAX_MEDIA_ELEMENT_COUNTS;
+  }
+
+
+  /** @override */
+  getElement() {
+    return this.element;
   }
 
 

--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -1303,9 +1303,9 @@ export class AmpStory extends AMP.BaseElement {
    * @private
    */
   unmute_() {
+    const unmuteAllMedia = () => this.activePage_.unmuteAllMedia();
     this.mediaPool_.blessAll()
-        .then(() => this.activePage_.unmuteAllMedia(),
-            () => this.activePage_.unmuteAllMedia());
+        .then(unmuteAllMedia, unmuteAllMedia);
     this.toggleMutedAttribute_(false);
   }
 

--- a/extensions/amp-story/0.1/media-pool.js
+++ b/extensions/amp-story/0.1/media-pool.js
@@ -22,6 +22,7 @@ import {
 } from '../../../src/dom';
 import {dev} from '../../../src/log';
 import {findIndex} from '../../../src/utils/array';
+import {toWin} from '../../../src/types';
 import {BLANK_AUDIO_SRC, BLANK_VIDEO_SRC} from './default-media';
 
 
@@ -778,17 +779,20 @@ export class MediaPool {
    * @return {!MediaPool}
    */
   static for(root) {
-    const existingId = root.element.getAttribute(POOL_MEDIA_ELEMENT_ATTRIBUTE);
+    const element = root.getElement();
+    const existingId = element.getAttribute(POOL_MEDIA_ELEMENT_ATTRIBUTE);
     const hasInstanceAllocated = existingId && instances[existingId];
 
     if (hasInstanceAllocated) {
       return instances[existingId];
     }
 
-    const newId = nextInstanceId++;
-    root.element.setAttribute(POOL_MEDIA_ELEMENT_ATTRIBUTE, newId);
-    instances[newId] = new MediaPool(root.win,
-        root.getMaxMediaElementCounts(), root.getElementDistance);
+    const newId = String(nextInstanceId++);
+    element.setAttribute(POOL_MEDIA_ELEMENT_ATTRIBUTE, newId);
+    instances[newId] = new MediaPool(
+        toWin(root.getElement().ownerDocument.defaultView),
+        root.getMaxMediaElementCounts(),
+        root.getElementDistance);
 
     return instances[newId];
   }
@@ -852,15 +856,19 @@ class Sources {
 
 
 /**
- * Defines a common interface for elements that contain a MediaPool.  Components
- * implementing this interface must also extend
- * {@link ./base-element.BaseElement}.
+ * Defines a common interface for elements that contain a MediaPool.
  *
  * @interface
  */
 export class MediaPoolRoot {
   /**
-   * @param {!Element} element The element whose distance should be retrieved.
+   * @return {!Element} The root element of this media pool.
+   */
+  getElement() {};
+
+  /**
+   * @param {!Element} unusedElement The element whose distance should be
+   *    retrieved.
    * @return {number} A numerical distance representing how far the specified
    *     element is from the user's current position in the document.  The
    *     absolute magnitude of this number is irrelevant; the relative magnitude
@@ -868,16 +876,12 @@ export class MediaPoolRoot {
    *     furthest from the user's current position in the document are evicted
    *     from the MediaPool first).
    */
-  getElementDistance() {
-    return 0;
-  };
+  getElementDistance(unusedElement) {};
 
 
   /**
    * @return {!Object<!MediaType, number>} The maximum amount of each media
    *     type to allow within this element.
    */
-  getMaxMediaElementCounts() {
-    return {};
-  };
+  getMaxMediaElementCounts() {};
 }

--- a/extensions/amp-story/0.1/media-pool.js
+++ b/extensions/amp-story/0.1/media-pool.js
@@ -57,7 +57,7 @@ const DOM_MEDIA_ELEMENT_ID_PREFIX = 'i-amphtml-media-';
 /**
  * @const {string}
  */
-const POOL_MEDIA_ELEMENT_ATTRIBUTE = 'i-amphtml-media-pool';
+const POOL_MEDIA_ELEMENT_PROPERTY_NAME = 'i-amphtml-media-pool';
 
 
 /**
@@ -788,7 +788,7 @@ export class MediaPool {
    */
   static for(root) {
     const element = root.getElement();
-    const existingId = element.getAttribute(POOL_MEDIA_ELEMENT_ATTRIBUTE);
+    const existingId = element[POOL_MEDIA_ELEMENT_PROPERTY_NAME];
     const hasInstanceAllocated = existingId && instances[existingId];
 
     if (hasInstanceAllocated) {
@@ -796,7 +796,7 @@ export class MediaPool {
     }
 
     const newId = String(nextInstanceId++);
-    element.setAttribute(POOL_MEDIA_ELEMENT_ATTRIBUTE, newId);
+    element[POOL_MEDIA_ELEMENT_PROPERTY_NAME] = newId;
     instances[newId] = new MediaPool(
         toWin(root.getElement().ownerDocument.defaultView),
         root.getMaxMediaElementCounts(),

--- a/extensions/amp-story/0.1/media-pool.js
+++ b/extensions/amp-story/0.1/media-pool.js
@@ -594,7 +594,15 @@ export class MediaPool {
     const isMuted = mediaEl.muted;
     const currentTime = mediaEl.currentTime;
 
-    return Promise.resolve(mediaEl.play()).then(() => {
+    // If the video is already playing, we do not want to call play again, as it
+    // can interrupt the video playback.  Instead, we do a no-op.
+    const playFn = () => {
+      if (isPaused) {
+        mediaEl.play();
+      }
+    };
+
+    return Promise.resolve(playFn()).then(() => {
       mediaEl.muted = false;
 
       if (isPaused) {

--- a/extensions/amp-story/0.1/media-pool.js
+++ b/extensions/amp-story/0.1/media-pool.js
@@ -57,7 +57,7 @@ const DOM_MEDIA_ELEMENT_ID_PREFIX = 'i-amphtml-media-';
 /**
  * @const {string}
  */
-const POOL_MEDIA_ELEMENT_PROPERTY_NAME = 'i-amphtml-media-pool';
+const POOL_MEDIA_ELEMENT_PROPERTY_NAME = '__AMP_MEDIA_POOL_ID__';
 
 
 /**
@@ -602,7 +602,7 @@ export class MediaPool {
       }
     };
 
-    return Promise.resolve(playFn()).then(() => {
+    return Promise.resolve().then(() => playFn()).then(() => {
       mediaEl.muted = false;
 
       if (isPaused) {


### PR DESCRIPTION
The most important change here is to move unmuting the media *after* playing the media in `MediaPool#bless_`.

Fixes #12976 due to the reordering.
Fixes #13033 due to performing the navigation after `blessAll()` has completed.