### PR TITLE
Updates expected Adzerk URL format.

### DIFF
--- a/examples/adzerk.amp.html
+++ b/examples/adzerk.amp.html
@@ -11,10 +11,10 @@
   <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.1.js"></script>
 </head>
 <body>
+  <!-- Note that the below data-r attributes are not formatted for production.
+       They will only work in local dev mode. --->
   <amp-ad width=300 height=250
       type="adzerk"
-      <!-- Note that the below data-r attributes are not formatted for production.
-        They will only work in local dev mode.-->
       data-r="0">
     <div placeholder></div>
     <div fallback></div>
@@ -33,6 +33,5 @@
     <div placeholder></div>
     <div fallback></div>
   </amp-ad>
-
 </body>
 </html>

--- a/examples/adzerk.amp.html
+++ b/examples/adzerk.amp.html
@@ -13,9 +13,24 @@
 <body>
   <amp-ad width=300 height=250
       type="adzerk"
-      src="https://engine.adzerk.net/amp?id=0">
+      data-template-id="0">
     <div placeholder></div>
     <div fallback></div>
   </amp-ad>
+
+  <amp-ad width=300 height=250
+      type="adzerk"
+      data-template-id="101">
+    <div placeholder></div>
+    <div fallback></div>
+  </amp-ad>
+
+  <amp-ad width=300 height=250
+      type="adzerk"
+      data-template-id="102">
+    <div placeholder></div>
+    <div fallback></div>
+  </amp-ad>
+
 </body>
 </html>

--- a/examples/adzerk.amp.html
+++ b/examples/adzerk.amp.html
@@ -13,21 +13,23 @@
 <body>
   <amp-ad width=300 height=250
       type="adzerk"
-      data-template-id="0">
+      <!-- Note that the below data-r attributes are not formatted for production.
+        They will only work in local dev mode.-->
+      data-r="0">
     <div placeholder></div>
     <div fallback></div>
   </amp-ad>
 
   <amp-ad width=300 height=250
       type="adzerk"
-      data-template-id="101">
+      data-r="101">
     <div placeholder></div>
     <div fallback></div>
   </amp-ad>
 
   <amp-ad width=300 height=250
       type="adzerk"
-      data-template-id="102">
+      data-r="102">
     <div placeholder></div>
     <div fallback></div>
   </amp-ad>

--- a/examples/adzerk.amp.html
+++ b/examples/adzerk.amp.html
@@ -11,13 +11,11 @@
   <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.1.js"></script>
 </head>
 <body>
-
   <amp-ad width=300 height=250
       type="adzerk"
-      src="https://adzerk.com?id=0">
+      src="https://engine.adzerk.net/amp?id=0">
     <div placeholder></div>
     <div fallback></div>
   </amp-ad>
-  
 </body>
 </html>

--- a/extensions/amp-ad-network-adzerk-impl/0.1/amp-ad-network-adzerk-impl.js
+++ b/extensions/amp-ad-network-adzerk-impl/0.1/amp-ad-network-adzerk-impl.js
@@ -94,11 +94,12 @@ export class AmpAdNetworkAdzerkImpl extends AmpA4A {
   /** @override */
   getAdUrl() {
     const data = this.element.getAttribute('data-r');
+    dev().assert(data, 'Expected data-r attribte on amp-ad tag');
     if (getMode(this.win).localDev) {
       return `http://ads.localhost:${this.win.location.port}` +
           '/adzerk/' + data;
     }
-    return 'https://engine.adzerk.net/amp' + (data ? `/r=${data}` : '');
+    return `https://engine.adzerk.net/amp?r='${data}'`;
   }
 
   /** @override */

--- a/extensions/amp-ad-network-adzerk-impl/0.1/amp-ad-network-adzerk-impl.js
+++ b/extensions/amp-ad-network-adzerk-impl/0.1/amp-ad-network-adzerk-impl.js
@@ -99,8 +99,7 @@ export class AmpAdNetworkAdzerkImpl extends AmpA4A {
       return `http://ads.localhost:${this.win.location.port}` +
           '/adzerk/' + data;
     }
-    const encodedQueryParam = encodeURIComponent(`'${data}'`);
-    return `https://engine.adzerk.net/amp?r=${encodedQueryParam}`;
+    return `https://engine.adzerk.net/amp?r=${encodeURIComponent(data)}`;
   }
 
   /** @override */

--- a/extensions/amp-ad-network-adzerk-impl/0.1/amp-ad-network-adzerk-impl.js
+++ b/extensions/amp-ad-network-adzerk-impl/0.1/amp-ad-network-adzerk-impl.js
@@ -93,17 +93,14 @@ export class AmpAdNetworkAdzerkImpl extends AmpA4A {
 
   /** @override */
   getAdUrl() {
-    const src = this.element.getAttribute('src');
-    if (!/^https:\/\/engine.adzerk.net\/amp/i.test(src)) {
-      return '';
-    }
     if (getMode(this.win).localDev) {
-      return `http://ads.localhost:${this.win.location.port}` +
-        '/adzerk/' + /^https:\/\/engine.adzerk.net\/amp\?id=(\d+)/
-        .exec(src)[1];
+      const localTemplateId = this.element.getAttribute('data-template-id');
+      if (localTemplateId) {
+        return `http://ads.localhost:${this.win.location.port}` +
+          '/adzerk/' + localTemplateId;
+      }
     }
-    // TODO(adzerk): specify expected src path.
-    return /^https:\/\/engine.adzerk.net\/amp/i.test(src) ? src : '';
+    return 'https://engine.adzerk.net/amp';
   }
 
   /** @override */

--- a/extensions/amp-ad-network-adzerk-impl/0.1/amp-ad-network-adzerk-impl.js
+++ b/extensions/amp-ad-network-adzerk-impl/0.1/amp-ad-network-adzerk-impl.js
@@ -93,14 +93,12 @@ export class AmpAdNetworkAdzerkImpl extends AmpA4A {
 
   /** @override */
   getAdUrl() {
+    const data = this.element.getAttribute('data-r');
     if (getMode(this.win).localDev) {
-      const localTemplateId = this.element.getAttribute('data-template-id');
-      if (localTemplateId) {
-        return `http://ads.localhost:${this.win.location.port}` +
-          '/adzerk/' + localTemplateId;
-      }
+      return `http://ads.localhost:${this.win.location.port}` +
+          '/adzerk/' + data;
     }
-    return 'https://engine.adzerk.net/amp';
+    return 'https://engine.adzerk.net/amp' + (data ? `/r=${data}` : '');
   }
 
   /** @override */

--- a/extensions/amp-ad-network-adzerk-impl/0.1/amp-ad-network-adzerk-impl.js
+++ b/extensions/amp-ad-network-adzerk-impl/0.1/amp-ad-network-adzerk-impl.js
@@ -99,7 +99,8 @@ export class AmpAdNetworkAdzerkImpl extends AmpA4A {
       return `http://ads.localhost:${this.win.location.port}` +
           '/adzerk/' + data;
     }
-    return `https://engine.adzerk.net/amp?r='${encodeURIComponent(data)}'`;
+    const encodedQueryParam = encodeURIComponent(`'${data}'`);
+    return `https://engine.adzerk.net/amp?r=${encodedQueryParam}`;
   }
 
   /** @override */

--- a/extensions/amp-ad-network-adzerk-impl/0.1/amp-ad-network-adzerk-impl.js
+++ b/extensions/amp-ad-network-adzerk-impl/0.1/amp-ad-network-adzerk-impl.js
@@ -99,7 +99,7 @@ export class AmpAdNetworkAdzerkImpl extends AmpA4A {
       return `http://ads.localhost:${this.win.location.port}` +
           '/adzerk/' + data;
     }
-    return `https://engine.adzerk.net/amp?r='${data}'`;
+    return `https://engine.adzerk.net/amp?r='${encodeURIComponent(data)}'`;
   }
 
   /** @override */

--- a/extensions/amp-ad-network-adzerk-impl/0.1/amp-ad-network-adzerk-impl.js
+++ b/extensions/amp-ad-network-adzerk-impl/0.1/amp-ad-network-adzerk-impl.js
@@ -94,15 +94,16 @@ export class AmpAdNetworkAdzerkImpl extends AmpA4A {
   /** @override */
   getAdUrl() {
     const src = this.element.getAttribute('src');
-    if (!/^https:\/\/adzerk.com\?id=\d+$/i.test(src)) {
+    if (!/^https:\/\/engine.adzerk.net\/amp/i.test(src)) {
       return '';
     }
     if (getMode(this.win).localDev) {
       return `http://ads.localhost:${this.win.location.port}` +
-        '/adzerk/' + /^https:\/\/adzerk.com\?id=(\d+)/.exec(src)[1];
+        '/adzerk/' + /^https:\/\/engine.adzerk.net\/amp\?id=(\d+)/
+        .exec(src)[1];
     }
     // TODO(adzerk): specify expected src path.
-    return /^https:\/\/adzerk.com\?id=\d+$/i.test(src) ? src : '';
+    return /^https:\/\/engine.adzerk.net\/amp/i.test(src) ? src : '';
   }
 
   /** @override */

--- a/extensions/amp-ad-network-adzerk-impl/0.1/test/test-amp-ad-network-adzerk-impl.js
+++ b/extensions/amp-ad-network-adzerk-impl/0.1/test/test-amp-ad-network-adzerk-impl.js
@@ -41,7 +41,6 @@ describes.fakeWin('amp-ad-network-adzerk-impl', {amp: true}, env => {
     fetchTextMock = sandbox.stub(Xhr.prototype, 'fetchText');
     element = createElementWithAttributes(doc, 'amp-ad', {
       'type': 'adzerk',
-      'src': 'https://engine.adzerk.net/amp?id=1234',
       'width': '320',
       'height': '50',
     });

--- a/extensions/amp-ad-network-adzerk-impl/0.1/test/test-amp-ad-network-adzerk-impl.js
+++ b/extensions/amp-ad-network-adzerk-impl/0.1/test/test-amp-ad-network-adzerk-impl.js
@@ -58,10 +58,7 @@ describes.fakeWin('amp-ad-network-adzerk-impl', {amp: true}, env => {
     });
 
     it('should be invalid', () => {
-      try {
-        impl.getAdUrl();
-        expect(false).to.be.true;
-      } catch (err) {}
+      expect(() => impl.getAdUrl()).to.throw(/Expected data-r attribte/);
     });
   });
 

--- a/extensions/amp-ad-network-adzerk-impl/0.1/test/test-amp-ad-network-adzerk-impl.js
+++ b/extensions/amp-ad-network-adzerk-impl/0.1/test/test-amp-ad-network-adzerk-impl.js
@@ -51,23 +51,16 @@ describes.fakeWin('amp-ad-network-adzerk-impl', {amp: true}, env => {
 
   describe('#getAdUrl', () => {
     it('should be valid', () => {
-      ['https://engine.adzerk.net/amp?id=1234',
-        'https://engine.aDzErK.net/amp'].forEach(src => {
-        element.setAttribute('src', src);
-        expect(impl.isValidElement()).to.be.true;
-        expect(impl.getAdUrl()).to.equal(src);
-      });
+      const r = '{"p":[{"n":1234,"t":[5],"s":677496}]}';
+      element.setAttribute('data-r', r);
+      expect(impl.getAdUrl()).to.equal(`https://engine.adzerk.net/amp?r='${r}'`);
     });
 
-    it('should not be valid', () => {
-      ['http://engine.adzerk.com/amp',
-        'https://engine.adzerk.net?id=a',
-        'https://www.adzerk.net/amp?id=1234',
-        'foohttps://engine.adzerk.net/amp'].forEach(src => {
-        element.setAttribute('src', src);
-        expect(impl.isValidElement()).to.be.false;
-        expect(impl.getAdUrl()).to.equal('');
-      });
+    it('should be invalid', () => {
+      try {
+        impl.getAdUrl();
+        expect(false).to.be.true;
+      } catch (err) {}
     });
   });
 

--- a/extensions/amp-ad-network-adzerk-impl/0.1/test/test-amp-ad-network-adzerk-impl.js
+++ b/extensions/amp-ad-network-adzerk-impl/0.1/test/test-amp-ad-network-adzerk-impl.js
@@ -52,7 +52,8 @@ describes.fakeWin('amp-ad-network-adzerk-impl', {amp: true}, env => {
     it('should be valid', () => {
       const r = '{"p":[{"n":1234,"t":[5],"s":677496}]}';
       element.setAttribute('data-r', r);
-      expect(impl.getAdUrl()).to.equal(`https://engine.adzerk.net/amp?r='${r}'`);
+      expect(impl.getAdUrl()).to.equal(
+          `https://engine.adzerk.net/amp?r='${encodeURIComponent(r)}'`);
     });
 
     it('should be invalid', () => {

--- a/extensions/amp-ad-network-adzerk-impl/0.1/test/test-amp-ad-network-adzerk-impl.js
+++ b/extensions/amp-ad-network-adzerk-impl/0.1/test/test-amp-ad-network-adzerk-impl.js
@@ -52,9 +52,17 @@ describes.fakeWin('amp-ad-network-adzerk-impl', {amp: true}, env => {
     it('should be valid', () => {
       const r = '{"p":[{"n":1234,"t":[5],"s":677496}]}';
       element.setAttribute('data-r', r);
-      const encodedQueryParam = encodeURIComponent(`'${r}'`);
       expect(impl.getAdUrl()).to.equal(
-          `https://engine.adzerk.net/amp?r=${encodedQueryParam}`);
+          `https://engine.adzerk.net/amp?r=${encodeURIComponent(r)}`);
+    });
+
+    it('should be valid #2', () => {
+      element.setAttribute('data-r',
+          '{"p":[{"t":[5],"s":333999,"a":5603000}]}');
+      expect(impl.getAdUrl()).to.equal(
+          'https://engine.adzerk.net' +
+          '/amp?r=%7B%22p%22%3A%5B%7B%22t%22%3A%5B5%5D%2C%22s%22%3A333999' +
+          '%2C%22a%22%3A5603000%7D%5D%7D');
     });
 
     it('should be invalid', () => {

--- a/extensions/amp-ad-network-adzerk-impl/0.1/test/test-amp-ad-network-adzerk-impl.js
+++ b/extensions/amp-ad-network-adzerk-impl/0.1/test/test-amp-ad-network-adzerk-impl.js
@@ -41,7 +41,7 @@ describes.fakeWin('amp-ad-network-adzerk-impl', {amp: true}, env => {
     fetchTextMock = sandbox.stub(Xhr.prototype, 'fetchText');
     element = createElementWithAttributes(doc, 'amp-ad', {
       'type': 'adzerk',
-      'src': 'https://adzerk.com?id=1234',
+      'src': 'https://engine.adzerk.net/amp?id=1234',
       'width': '320',
       'height': '50',
     });
@@ -51,9 +51,8 @@ describes.fakeWin('amp-ad-network-adzerk-impl', {amp: true}, env => {
 
   describe('#getAdUrl', () => {
     it('should be valid', () => {
-      ['https://adzerk.com?id=1234',
-        'https://aDzErK.com?id=1234',
-        'https://adzerk.com?id=9'].forEach(src => {
+      ['https://engine.adzerk.net/amp?id=1234',
+        'https://engine.aDzErK.net/amp'].forEach(src => {
         element.setAttribute('src', src);
         expect(impl.isValidElement()).to.be.true;
         expect(impl.getAdUrl()).to.equal(src);
@@ -61,11 +60,10 @@ describes.fakeWin('amp-ad-network-adzerk-impl', {amp: true}, env => {
     });
 
     it('should not be valid', () => {
-      ['http://adzerk.com?id=1234',
-        'https://adzerk.com?id=a',
-        'https://www.adzerk.com?id=1234',
-        'https://adzerk.com?id=1234&a=b',
-        'foohttps://adzer.com?id=1234'].forEach(src => {
+      ['http://engine.adzerk.com/amp',
+        'https://engine.adzerk.net?id=a',
+        'https://www.adzerk.net/amp?id=1234',
+        'foohttps://engine.adzerk.net/amp'].forEach(src => {
         element.setAttribute('src', src);
         expect(impl.isValidElement()).to.be.false;
         expect(impl.getAdUrl()).to.equal('');

--- a/extensions/amp-ad-network-adzerk-impl/0.1/test/test-amp-ad-network-adzerk-impl.js
+++ b/extensions/amp-ad-network-adzerk-impl/0.1/test/test-amp-ad-network-adzerk-impl.js
@@ -52,8 +52,9 @@ describes.fakeWin('amp-ad-network-adzerk-impl', {amp: true}, env => {
     it('should be valid', () => {
       const r = '{"p":[{"n":1234,"t":[5],"s":677496}]}';
       element.setAttribute('data-r', r);
+      const encodedQueryParam = encodeURIComponent(`'${r}'`);
       expect(impl.getAdUrl()).to.equal(
-          `https://engine.adzerk.net/amp?r='${encodeURIComponent(r)}'`);
+          `https://engine.adzerk.net/amp?r=${encodedQueryParam}`);
     });
 
     it('should be invalid', () => {


### PR DESCRIPTION
Ensures that ad requests can only be sent to: `https://engine.adzerk.net/amp`. Note that query params may be appended to the end of the URL; this is especially the case for local testing, which relies on some appended id to differentiate between different templates in the /data/ directory.