### PR TITLE
Fast Fetch: change logging of non-AMP render from error to dev warn

### DIFF
--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -1282,6 +1282,7 @@ export class AmpA4A extends AMP.BaseElement {
           'fallback to 3p disabled');
       return Promise.resolve(false);
     }
+    // TODO(keithwrightbos): remove when no longer needed.
     dev().warn(TAG, 'fallback to 3p');
     // Haven't rendered yet, so try rendering via one of our
     // cross-domain iframe solutions.

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -1282,9 +1282,7 @@ export class AmpA4A extends AMP.BaseElement {
           'fallback to 3p disabled');
       return Promise.resolve(false);
     }
-    this.promiseErrorHandler_(
-        new Error('fallback to 3p'),
-        /* ignoreStack */ true);
+    dev().warn(TAG, 'fallback to 3p');
     // Haven't rendered yet, so try rendering via one of our
     // cross-domain iframe solutions.
     const method = this.experimentalNonAmpCreativeRenderMethod_;


### PR DESCRIPTION
Current message is available in console leading to confusion around incorrect page tagging.