### PR TITLE
Changes how adzerk impl produces metadata object from ad template.

### DIFF
--- a/examples/adzerk.amp.html
+++ b/examples/adzerk.amp.html
@@ -18,20 +18,6 @@
     <div placeholder></div>
     <div fallback></div>
   </amp-ad>
-
-  <amp-ad width=300 height=250
-      type="adzerk"
-      src="https://adzerk.com?id=101">
-    <div placeholder></div>
-    <div fallback></div>
-  </amp-ad>
-
-  <amp-ad width=300 height=250
-      type="adzerk"
-      src="https://adzerk.com?id=102">
-    <div placeholder></div>
-    <div fallback></div>
-  </amp-ad>
-
+  
 </body>
 </html>

--- a/extensions/amp-ad-network-adzerk-impl/0.1/amp-ad-network-adzerk-impl.js
+++ b/extensions/amp-ad-network-adzerk-impl/0.1/amp-ad-network-adzerk-impl.js
@@ -120,10 +120,7 @@ export class AmpAdNetworkAdzerkImpl extends AmpA4A {
       return ampAdTemplates
           .fetch(this.ampCreativeJson_.templateUrl)
           .then(parsedTemplate => {
-            this.creativeMetadata_ = /** @type {!CreativeMetaDataDef} */
-                (super.getAmpAdMetadata(parsedTemplate));
-            return Promise.resolve(
-                utf8Encode(this.creativeMetadata_.minifiedCreative));
+            return utf8Encode(this.parseMetadataFromCreative(parsedTemplate));
           })
           .catch(error => {
             dev().warn(TAG, 'Error fetching/expanding template',
@@ -132,6 +129,33 @@ export class AmpAdNetworkAdzerkImpl extends AmpA4A {
             return Promise.reject(NO_CONTENT_RESPONSE);
           });
     });
+  }
+
+  /**
+   * Parses out required extensions and returns a minified version of the
+   * creative.
+   * @param {string} creative
+   * @return {string} A minified version of the creative, suitable to be
+   *   rendered as an amp4ads ad.
+   */
+  parseMetadataFromCreative(creative) {
+    // TODO(levitzky) The following minification is for demo purposes only. Once
+    // launched this will either be performed server-side, or will be replaced
+    // by more sophisticated logic.
+    const minifiedCreative = creative
+        .split(
+            '<script async src="https://cdn.ampproject.org/v0.js"></script>')
+        .join('')
+        .split(
+            '<script async custom-template="amp-mustache" src=' +
+            '"https://cdn.ampproject.org/v0/amp-mustache-0.1.js"></script>')
+        .join('');
+    this.creativeMetadata_ = /** @type {?CreativeMetaDataDef} */ ({
+      minifiedCreative,
+      customElementExtensions: [],
+      extensions: [],
+    });
+    return minifiedCreative;
   }
 
   /** @override */

--- a/extensions/amp-ad-network-adzerk-impl/0.1/amp-ad-network-adzerk-impl.js
+++ b/extensions/amp-ad-network-adzerk-impl/0.1/amp-ad-network-adzerk-impl.js
@@ -142,15 +142,9 @@ export class AmpAdNetworkAdzerkImpl extends AmpA4A {
     // TODO(levitzky) The following minification is for demo purposes only. Once
     // launched this will either be performed server-side, or will be replaced
     // by more sophisticated logic.
-    const minifiedCreative = creative
-        .split(
-            '<script async src="https://cdn.ampproject.org/v0.js"></script>')
-        .join('')
-        .split(
-            '<script async custom-template="amp-mustache" src=' +
-            '"https://cdn.ampproject.org/v0/amp-mustache-0.1.js"></script>')
-        .join('');
-    this.creativeMetadata_ = /** @type {?CreativeMetaDataDef} */ ({
+    const minifiedCreative = creative.replace(
+        /<script async.+?<\/script>/g, '');
+      this.creativeMetadata_ = /** @type {?CreativeMetaDataDef} */ ({
       minifiedCreative,
       customElementExtensions: [],
       extensions: [],

--- a/extensions/amp-ad-network-adzerk-impl/0.1/amp-ad-network-adzerk-impl.js
+++ b/extensions/amp-ad-network-adzerk-impl/0.1/amp-ad-network-adzerk-impl.js
@@ -144,7 +144,7 @@ export class AmpAdNetworkAdzerkImpl extends AmpA4A {
     // by more sophisticated logic.
     const minifiedCreative = creative.replace(
         /<script async.+?<\/script>/g, '');
-      this.creativeMetadata_ = /** @type {?CreativeMetaDataDef} */ ({
+    this.creativeMetadata_ = /** @type {?CreativeMetaDataDef} */ ({
       minifiedCreative,
       customElementExtensions: [],
       extensions: [],

--- a/extensions/amp-ad-network-adzerk-impl/0.1/data/0
+++ b/extensions/amp-ad-network-adzerk-impl/0.1/data/0
@@ -1,7 +1,11 @@
 {
   "templateUrl": "0",
   "data": {
-     "url": "https://www.google.com",
-    "externalUrl": "https://www.google.com/images/branding/googlelogo/1x/googlelogo_color_272x92dp.png"
+    "impressionUrl": "https://www.google.com",
+    "url": "https://www.google.com",
+    "externalUrl": "https://www.google.com/images/branding/googlelogo/1x/googlelogo_color_272x92dp.png",
+    "title": "Adzerk Demo",
+    "width": "272px",
+    "height": "92px"
   }
 }

--- a/extensions/amp-ad-network-adzerk-impl/0.1/data/0.template
+++ b/extensions/amp-ad-network-adzerk-impl/0.1/data/0.template
@@ -1,24 +1,19 @@
-<!doctype html><html amp4ads><head><meta charset="utf-8"><script async src="https://cdn.ampproject.org/amp4ads-v0.js"></script>
-    <style amp4ads-boilerplate>body{visibility:hidden}</style>
+<!doctype html>
+<html ⚡>
+  <head>
+    <meta charset="utf-8">
+    <link rel="canonical" href="self.html" />
     <meta name="viewport" content="width=device-width,minimum-scale=1">
+    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+    <script async src="https://cdn.ampproject.org/v0.js"></script>
+    <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.1.js"></script>
   </head>
-  <body><template type="amp-mustache">
-    <a href={{url}} rel="nofollow" target="_blank">
-      <amp-img src={{externalUrl}} width="250px" height="150px" layout="responsive"></amp-img>
-    </a>
-    <script amp-ad-metadata type=application/json>
-    {
-      "ampRuntimeUtf16CharOffsets" : [ 57, 127 ],
-      "customElementExtensions": [
-        "amp-bind"
-      ],
-      "extensions": [
-        {
-          "custom-element": "amp-bind",
-          "src": "https://cdn.ampproject.org/v0/amp-bind-0.1.js"
-        }
-      ]
-    }
-    </script>
-    </template></body>
+  <body>
+    <template type="amp-mustache">
+      <a href="{{url}}" rel="nofollow" target="_blank" title="{{title}}">
+        <amp-img src="{{externalUrl}}" title="{{title}}" alt="{{title}}" width="{{width}}" height="{{height}}"></amp-img>
+      </a>
+      <amp-pixel src="{{impressionUrl}}"></amp-pixel>
+    </template>
+  </body>
 </html>

--- a/extensions/amp-ad-network-adzerk-impl/0.1/test/test-amp-ad-network-adzerk-impl.js
+++ b/extensions/amp-ad-network-adzerk-impl/0.1/test/test-amp-ad-network-adzerk-impl.js
@@ -90,29 +90,16 @@ describes.fakeWin('amp-ad-network-adzerk-impl', {amp: true}, env => {
           IMG_SRC: 'https://some.img.com?a=b',
         },
       };
-      const template = '<!doctype html><html ⚡4ads><head>' +
-          '<meta charset="utf-8">' +
-          '<meta name="viewport" content="width=device-width, ' +
-          'minimum-scale=1"><style amp4ads-boilerplate>body{visibility:' +
-          'hidden}</style><style amp-custom>amp-fit-text: {border: 1px;}' +
-          '</style><script async src="https://cdn.ampproject.org/' +
-          'amp4ads-v0.js"></script><script async custom-element=' +
-          '"amp-fit-text" src="https://cdn.ampproject.org/v0/' +
-          'amp-fit-text-0.1.js"></script><link rel="stylesheet" ' +
-          'type="text/css" href="https://fonts.googleapis.com/css?' +
-          'family=Raleway"></head><body>' +
-          '<amp-fit-text width="300" height="200" ' +
-          '[text]="\'hello \' + USER_NAME + \'!\' + USER_NUM ">' +
-          '</amp-fit-text><p [text]="\'Expect encoding \' + HTML_CONTENT">' +
-          '</p><amp-img [src]="IMG_SRC" [srcset]="IMG_SRC"/>' +
-          '<p [text]="\'Missing \' + UNKNOWN + \' item\'"></p>' +
-          '<script amp-ad-metadata type=application/json>' +
-          '{ "ampRuntimeUtf16CharOffsets" : [ 235, 414 ], ' +
-          '"customElementExtensions": [ "amp-bind" ], ' +
-          '"extensions": [ { ' +
-          '"custom-element": "amp-fit-text",' +
-          '"src": "https://cdn.ampproject.org/v0/amp-fit-text-0.1.js" } ] }' +
-          '</script></body></html>';
+      const template = `<!doctype html><html ⚡><head>
+          <script async src="https://cdn.ampproject.org/v0.js"></script>
+          <script async custom-template="amp-mustache"
+            src="https://cdn.ampproject.org/v0/amp-mustache-0.1.js"></script>
+          </head>
+          <body>
+            <template type="amp-mustache">
+            <p>{{foo}}</p>
+            </template>
+          </body></html>`;
       fetchTextMock.withArgs(
           'https://www-adzerk-com.cdn.ampproject.org/c/s/www.adzerk.com/456',
           {
@@ -136,9 +123,19 @@ describes.fakeWin('amp-ad-network-adzerk-impl', {amp: true}, env => {
           () => {})
           .then(buffer => Promise.resolve(utf8Decode(buffer)))
           .then(creative => {
+            expect(creative
+                .indexOf(
+                    '<script async src="https://cdn.ampproject.org/v0.js">' +
+                    '</script>') == -1).to.be.true;
+            expect(creative
+                .indexOf(
+                    '<script async custom-template="amp-mustache" src=' +
+                    '"https://cdn.ampproject.org/v0/amp-mustache-0.1.js">' +
+                    '</script>') == -1).to.be.true;
             expect(impl.getAmpAdMetadata()).to.jsonEqual({
               minifiedCreative: creative,
-              customElementExtensions: ['amp-bind'],
+              customElementExtensions: [],
+              extensions: [],
             });
           });
     });


### PR DESCRIPTION
For the purposes of the Adzerk demo, we will use a simple template that does not need heavy parsing to extract metadata. The metadata parsing introduced here will simply remove the runtime script and amp-mustache template script, and otherwise leave the creative the same.

0.template contains the AMPed version of Adzerk's template.