### PR TITLE
Tweak the Git instructions

### DIFF
--- a/contributing/getting-started-e2e.md
+++ b/contributing/getting-started-e2e.md
@@ -148,14 +148,21 @@ git remote add upstream git@github.com:ampproject/amphtml.git
 
 Now run `git remote -v` again and notice that you have set up your upstream alias.
 
+Each branch of your local Git repository can track a branch of a remote repository.  Right now, your local `master` branch is tracking `origin/master`, which corresponds to the `master` branch of your GitHub fork.  You don't actually want this, though; the upstream `master` branch is constantly being updated, and your fork's `master` branch will rapidly become outdated.  Instead, it's best to make your local `master` branch track the upstream `master` branch.  You can do this like so:
+
+```
+git branch -u upstream/master master
+```
+
 # Building AMP and starting a local server
 
 Now that you have all of the files copied locally you can actually build the code and run a local server to try things out.
 
 amphtml uses Node.js, the Yarn package manager and the Gulp build system to build amphtml and start up a local server that lets you try out your changes.  Installing these and getting amphtml built is straightforward:
 
-* Install [NodeJS](https://nodejs.org/) version >= 6 (which includes npm)
+* Install [Node.js](https://nodejs.org/) version >= 6 (which includes npm).
 
+  [NVM](https://github.com/creationix/nvm) is a convenient way to do this on Mac and Linux, especially if you have other projects that require different versions of Node.
 
 * Install [Yarn](https://yarnpkg.com/) version >= 1.2.0 (instructions [here](https://yarnpkg.com/en/docs/install), this may require elevated privileges using `sudo` on some platforms)
 
@@ -169,7 +176,9 @@ amphtml uses Node.js, the Yarn package manager and the Gulp build system to buil
 
    You can do this by adding this line to your hosts file (`/etc/hosts` on Mac or Linux, `%SystemRoot%\System32\drivers\etc\hosts` on Windows):
 
-    ```127.0.0.1               ads.localhost iframe.localhost```
+    ```
+    127.0.0.1 ads.localhost iframe.localhost
+    ```
 
 * The AMP Project uses Gulp as our build system.   Gulp uses a configuration file ([gulpfile.js](https://github.com/ampproject/amphtml/blob/master/gulpfile.js)) to build amphtml (including the amphtml javascript) and to start up the Node.js server with the proper settings.  You don't really have to understand exactly what it is doing at this point--you just have to install it and use it.
 
@@ -220,10 +229,14 @@ By default you'll have a branch named _master_.  You can see this if you run the
 Although you could do work on the master branch, most people choose to leave the master branch unchanged and create other branches to actually do work in.  Creating a branch is easy; simply run:
 
 ```
-git branch --track <branch_name> origin/master
+git checkout -b <branch_name> master
 ```
 
-Whenever you want to do work in this branch, run the checkout command:
+This will move you to the new branch, which uses `master` as its start point, meaning that it will start out containing the same files as `master`.  You can then start working in the new branch.
+
+(You can use a different branch as a start point, like if you want to make one branch based on another.  Generally, though, you want `master` as your start point.  If you omit the start point, Git will use whichever branch you're currently on.)
+
+Whenever you want to move to a different branch, run the checkout command:
 
 ```
 git checkout <branch_name>
@@ -235,22 +248,20 @@ You can see a list of your branches and which one you're currently in by running
 git branch
 ```
 
-When you created the branch the `--track` flag and `origin/master` part are a convenience for telling Git the default place you want to sync with in the future.  Remember _origin_ is the alias that was set up for your GitHub fork remote repository. _origin/master_ is "the master branch of the origin repository."
-
 Note that currently the branch you just created only exists in your local repository.  If you check the list of branches that exist on your GitHub fork at `https://github.com/<your username>/amphtml/branches/yours`, you won't see this new branch listed.  Later on when we want to make the changes in your branch visible to others (e.g. so you can do a pull request) we'll push this branch to your GitHub fork.
 
 # Pull the latest changes from the amphtml repository
 
 Since your local repository is just a copy of the amphtml repository it can quickly become out of date if other people make changes to the amphtml repository.  Before you start making changes you'll want to make sure you have the latest version of the code; you'll also want to do this periodically during development, before sending your code for review, etc.
 
-In the workflow we will be using you'll go to the master branch on your local repository and pull the latest changes in from the remote amphtml repository's master branch.  (Remember that you set up the alias _upstream_ to refer to the remote amphtml repository.)
+In the workflow we will be using you'll go to the master branch on your local repository and pull the latest changes in from the remote amphtml repository's master branch.  (Remember that you set up the alias _upstream_ to refer to the remote amphtml repository, and you set your local `master` branch to track `upstream/master`.)
 
 ```
 # make sure you are in your local repo's master branch
 git checkout master
 
 # pull in the latest changes from the remote amphtml repository
-git pull upstream master
+git pull
 ```
 If there have been any changes you'll see the details of what changed, otherwise you'll see a message like `Already up-to-date`.
 
@@ -399,15 +410,21 @@ Before pushing your changes, make sure you have the latest changes in the amphtm
 
 ```
 git checkout master
-git pull upstream master
+git pull
 git checkout <branch name>
 git rebase master
 ```
 
-Now push your changes to origin (the alias for your GitHub fork):
+Now push your changes to `origin` (the alias for your GitHub fork):
 
 ```
-git push origin <branch name>
+git push -u origin <branch name>
+```
+
+`-u origin <branch name>` tells Git to create a remote branch with the specified name in `origin` and to make your local branch track that remote branch from now on.  You only have to do this the first time you push each branch.  For subsequent pushes on the same branch, you can use a shorter command:
+
+```
+git push
 ```
 
 The changes you've made are now visible on GitHub!  Go to your fork on GitHub:
@@ -485,7 +502,7 @@ git checkout master
 git branch -D <branch name>
 
 # delete the branch in your GitHub fork (if you didn't use the UI)
-git push origin --delete <branch name>
+git push -d origin <branch name>
 ```
 
 # See your changes in production

--- a/contributing/getting-started-quick.md
+++ b/contributing/getting-started-quick.md
@@ -25,7 +25,7 @@ This Quick Start guide is the TL;DR version of the longer [end-to-end guide](get
 
 * [Install and set up Git](https://help.github.com/articles/set-up-git/); in the "Authenticating" step of that page use SSH instead of HTTPS
 
-* Install [NodeJS](https://nodejs.org/) version >= 6 (which includes npm)
+* Install [Node.js](https://nodejs.org/) version >= 6 (which includes npm); [NVM](https://github.com/creationix/nvm) is a convenient way to do this on Mac and Linux
 
 * Install [Yarn](https://yarnpkg.com/) version >= 1.2.0 (instructions [here](https://yarnpkg.com/en/docs/install), this may require elevated privileges using `sudo` on some platforms)
 
@@ -34,18 +34,17 @@ This Quick Start guide is the TL;DR version of the longer [end-to-end guide](get
 * Add this line to your hosts file (`/etc/hosts` on Mac or Linux, `%SystemRoot%\System32\drivers\etc\hosts` on Windows):
 
     ```
-    127.0.0.1               ads.localhost iframe.localhost
+    127.0.0.1 ads.localhost iframe.localhost
     ```
 
 * Fork the [amphtml repository](https://github.com/ampproject/amphtml) by clicking "Fork" in the Web UI.
 
 * Create your local repository: `git clone git@github.com:<your username>/amphtml.git`
-* Add an alias:  Go to the newly created local repository directory and run `git remote add upstream git@github.com:ampproject/amphtml.git`
+* Add an alias:  Go to the newly created local repository directory and run `git remote add upstream git@github.com:ampproject/amphtml.git` and then `git branch -u upstream/master master`
 
 # Branch (do this each time you want a new branch)
 
-* Create the branch: `git branch --track <branch name> origin/master`
-* Go to the branch: `git checkout <branch name>`
+* Create and go to the branch: `git checkout -b <branch name> master`
 
 # Build AMP & run a local server
 
@@ -73,7 +72,7 @@ This Quick Start guide is the TL;DR version of the longer [end-to-end guide](get
 # Pull the latest changes
 
 * `git checkout master`
-* `git pull upstream master`
+* `git pull`
 * `git checkout <branch name>`
 * `git rebase master`
 * Note that you may need to resolve conflicting changes at this point
@@ -82,10 +81,11 @@ This Quick Start guide is the TL;DR version of the longer [end-to-end guide](get
 
 * Pull the latest changes as described above
 * `git checkout <branch name>`
-* `git push origin <branch name>`
+* `git push -u origin <branch name>`
 * Go to [https://github.com/ampproject/amphtml](https://github.com/ampproject/amphtml) and in the banner indicating you've recently pushed a branch, click the "Compare & pull request"  (if this banner does not appear, go to your fork at `https://github.com/<your username>/amphtml`, choose your branch from the "Branch" dropdown and click "New pull request")
 * Make sure you've signed the CLA (using the same email address as your git config indicates)
 * If your reviewer requests changes make them locally and then repeat the steps in this section to push the changes to your branch back up to GitHub again
+* For pushes after the first, just use `git push`
 * If you don't get a new review within 2 business days, feel free to ping the pull request by adding a comment
 * Once approved your changes are merged into the amphtml repository by a core committer (you don't do this merge)
 
@@ -93,7 +93,7 @@ This Quick Start guide is the TL;DR version of the longer [end-to-end guide](get
 
 * Go to the master branch: `git checkout master`
 * Delete your local branch: `git branch -D <branch name>`
-* Delete the GitHub fork branch: `git push origin --delete <branch name>`
+* Delete the GitHub fork branch: `git push -d origin <branch name>`
 
 # See your changes in production
 


### PR DESCRIPTION
There are easier ways to handle a few of the tasks in the contributing instructions. In particular, it's best to have master track upstream, since otherwise you have two separate remote masters to keep track of. Additionally, a few instructions (like the first git push) don't quite work as currently specified; this fixes them.