### PR TITLE
Enable adding analytics to template ad

### DIFF
--- a/extensions/amp-a4a/0.1/amp-ad-templates.js
+++ b/extensions/amp-a4a/0.1/amp-ad-templates.js
@@ -20,6 +20,8 @@ import {getMode} from '../../../src/mode';
 import {urls} from '../../../src/config';
 import {parseUrl} from '../../../src/url';
 import {LRUCache} from '../../../src/utils/lru-cache';
+import {isArray} from '../../../src/types';
+import {createElementWithAttributes} from '../../../src/dom';
 
 /** @private {!Object<string, string|boolean>} */
 const TEMPLATE_CORS_CONFIG = {
@@ -75,7 +77,45 @@ export class AmpAdTemplates {
    */
   render(templateValues, element) {
     return Services.templatesFor(this.win_)
-        .findAndRenderTemplate(element, templateValues);
+        .findAndRenderTemplate(element, templateValues)
+        .then(renderedElement => {
+          return renderedElement;
+        });
+  }
+
+  /**
+   * @param {!Element} element
+   * @param {!JsonObject|undefined} analyticsValue
+   */
+  insertAnalytics(element, analyticsValue) {
+    if (!analyticsValue) {
+      return;
+    }
+
+    analyticsValue =
+        isArray(analyticsValue) ? analyticsValue : [analyticsValue];
+    for (let i = 0; i < analyticsValue.length; i++) {
+      console.log('i is ', i);
+      const config = analyticsValue[i];
+      const analyticsEle = document.createElement('amp-analytics');
+      if (config['config']) {
+        analyticsEle.setAttribute('config', config['config']);
+      }
+      if (config['type']) {
+        analyticsEle.setAttribute('type', config['type']);
+      }
+      if (config['json']) {
+        const scriptElem = createElementWithAttributes(
+            document,
+            'script', {
+              'type': 'application/json',
+            });
+        scriptElem.textContent = JSON.stringify(config['json']);
+        analyticsEle.appendChild(scriptElem);
+      }
+      console.log('new', analyticsEle);
+      element.appendChild(analyticsEle);
+    }
   }
 
   /**

--- a/extensions/amp-a4a/0.1/amp-ad-templates.js
+++ b/extensions/amp-a4a/0.1/amp-ad-templates.js
@@ -94,19 +94,19 @@ export class AmpAdTemplates {
     for (let i = 0; i < analyticsValue.length; i++) {
       const config = analyticsValue[i];
       const analyticsEle = document.createElement('amp-analytics');
-      if (config['config']) {
-        analyticsEle.setAttribute('config', config['config']);
+      if (config['remote']) {
+        analyticsEle.setAttribute('config', config['remote']);
       }
       if (config['type']) {
         analyticsEle.setAttribute('type', config['type']);
       }
-      if (config['json']) {
+      if (config['inline']) {
         const scriptElem = createElementWithAttributes(
             document,
             'script', dict({
               'type': 'application/json',
             }));
-        scriptElem.textContent = JSON.stringify(config['json']);
+        scriptElem.textContent = JSON.stringify(config['inline']);
         analyticsEle.appendChild(scriptElem);
       }
       element.appendChild(analyticsEle);

--- a/extensions/amp-a4a/0.1/amp-ad-templates.js
+++ b/extensions/amp-a4a/0.1/amp-ad-templates.js
@@ -22,6 +22,7 @@ import {parseUrl} from '../../../src/url';
 import {LRUCache} from '../../../src/utils/lru-cache';
 import {isArray} from '../../../src/types';
 import {createElementWithAttributes} from '../../../src/dom';
+import {dict} from '../../../src/utils/object';
 
 /** @private {!Object<string, string|boolean>} */
 const TEMPLATE_CORS_CONFIG = {
@@ -85,17 +86,12 @@ export class AmpAdTemplates {
 
   /**
    * @param {!Element} element
-   * @param {!JsonObject|undefined} analyticsValue
+   * @param {!Array|!JsonObject} analyticsValue
    */
   insertAnalytics(element, analyticsValue) {
-    if (!analyticsValue) {
-      return;
-    }
-
-    analyticsValue =
-        isArray(analyticsValue) ? analyticsValue : [analyticsValue];
+    analyticsValue = /**@type {!Array}*/
+        (isArray(analyticsValue) ? analyticsValue : [analyticsValue]);
     for (let i = 0; i < analyticsValue.length; i++) {
-      console.log('i is ', i);
       const config = analyticsValue[i];
       const analyticsEle = document.createElement('amp-analytics');
       if (config['config']) {
@@ -107,13 +103,12 @@ export class AmpAdTemplates {
       if (config['json']) {
         const scriptElem = createElementWithAttributes(
             document,
-            'script', {
+            'script', dict({
               'type': 'application/json',
-            });
+            }));
         scriptElem.textContent = JSON.stringify(config['json']);
         analyticsEle.appendChild(scriptElem);
       }
-      console.log('new', analyticsEle);
       element.appendChild(analyticsEle);
     }
   }

--- a/extensions/amp-a4a/0.1/amp-ad-templates.js
+++ b/extensions/amp-a4a/0.1/amp-ad-templates.js
@@ -78,10 +78,7 @@ export class AmpAdTemplates {
    */
   render(templateValues, element) {
     return Services.templatesFor(this.win_)
-        .findAndRenderTemplate(element, templateValues)
-        .then(renderedElement => {
-          return renderedElement;
-        });
+        .findAndRenderTemplate(element, templateValues);
   }
 
   /**
@@ -93,7 +90,7 @@ export class AmpAdTemplates {
         (isArray(analyticsValue) ? analyticsValue : [analyticsValue]);
     for (let i = 0; i < analyticsValue.length; i++) {
       const config = analyticsValue[i];
-      const analyticsEle = document.createElement('amp-analytics');
+      const analyticsEle = element.ownerDocument.createElement('amp-analytics');
       if (config['remote']) {
         analyticsEle.setAttribute('config', config['remote']);
       }
@@ -102,7 +99,7 @@ export class AmpAdTemplates {
       }
       if (config['inline']) {
         const scriptElem = createElementWithAttributes(
-            document,
+            element.ownerDocument,
             'script', dict({
               'type': 'application/json',
             }));

--- a/extensions/amp-a4a/0.1/test/test-amp-ad-templates.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-ad-templates.js
@@ -68,6 +68,18 @@ describes.fakeWin('amp-ad-templates', {amp: true}, env => {
     win.AMP.registerTemplate('amp-mustache', AmpMustache);
   });
 
+  it('should render a template with correct values', () => {
+    win.AMP.registerTemplate('amp-mustache', AmpMustache);
+    const parentDiv = doc.createElement('div');
+    parentDiv./*OK*/innerHTML =
+        '<template type="amp-mustache"><p>{{foo}}</p></template>';
+    doc.body.appendChild(parentDiv);
+    return ampAdTemplates.render({foo: 'bar'}, parentDiv).then(result => {
+      expect(result).to.not.be.null;
+      expect(result./*OK*/innerHTML).to.equal('bar');
+    });
+  });
+
   it('should insert analytics component', () => {
     const parentDiv = doc.createElement('div');
     parentDiv./*OK*/innerHTML =
@@ -81,7 +93,6 @@ describes.fakeWin('amp-ad-templates', {amp: true}, env => {
     }, {
       'type': 'googleanalytics',
     }];
-    console.log(parentDiv);
     ampAdTemplates.insertAnalytics(parentDiv, analytics);
     expect(parentDiv.childNodes.length).to.equal(3);
     expect(parentDiv.innerHTML).to.equal('<p>123</p>' +

--- a/extensions/amp-a4a/0.1/test/test-amp-ad-templates.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-ad-templates.js
@@ -86,8 +86,8 @@ describes.fakeWin('amp-ad-templates', {amp: true}, env => {
         '<p>123</p>';
     doc.body.appendChild(parentDiv);
     const analytics = [{
-      'config': 'remoteUrl',
-      'json': {
+      'remote': 'remoteUrl',
+      'inline': {
         'requests': 'r',
       },
     }, {

--- a/extensions/amp-a4a/0.1/test/test-amp-ad-templates.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-ad-templates.js
@@ -66,15 +66,29 @@ describes.fakeWin('amp-ad-templates', {amp: true}, env => {
 
   it('should render a template with correct values', () => {
     win.AMP.registerTemplate('amp-mustache', AmpMustache);
-    const parentDiv = doc.createElement('div');
-    parentDiv./*OK*/innerHTML =
-        '<template type="amp-mustache"><p>{{foo}}</p></template>';
-    doc.body.appendChild(parentDiv);
-    return ampAdTemplates.render({foo: 'bar'}, parentDiv).then(result => {
-      expect(result).to.not.be.null;
-      expect(result./*OK*/innerHTML).to.equal('bar');
-    });
   });
 
+  it('should insert analytics component', () => {
+    const parentDiv = doc.createElement('div');
+    parentDiv./*OK*/innerHTML =
+        '<p>123</p>';
+    doc.body.appendChild(parentDiv);
+    const analytics = [{
+      'config': 'remoteUrl',
+      'json': {
+        'requests': 'r',
+      },
+    }, {
+      'type': 'googleanalytics',
+    }];
+    console.log(parentDiv);
+    ampAdTemplates.insertAnalytics(parentDiv, analytics);
+    expect(parentDiv.childNodes.length).to.equal(3);
+    expect(parentDiv.innerHTML).to.equal('<p>123</p>' +
+        '<amp-analytics config="remoteUrl">' +
+        '<script type="application/json">{"requests":"r"}</script>' +
+        '</amp-analytics>' +
+        '<amp-analytics type="googleanalytics"></amp-analytics>');
+  });
 });
 

--- a/extensions/amp-ad-network-adzerk-impl/0.1/amp-ad-network-adzerk-impl.js
+++ b/extensions/amp-ad-network-adzerk-impl/0.1/amp-ad-network-adzerk-impl.js
@@ -151,6 +151,18 @@ export class AmpAdNetworkAdzerkImpl extends AmpA4A {
 
   /** @override */
   getAmpAdMetadata(unusedCreative) {
+    if (this.ampCreativeJson_.analytics) {
+      if (!this.creativeMetadata_) {
+        this.creativeMetadata_ = /**@type {?CreativeMetaDataDef}*/ {};
+      }
+      if (!this.creativeMetadata_['customElementExtensions']) {
+        this.creativeMetadata_['customElementExtensions'] = [];
+      }
+      if (this.creativeMetadata_['customElementExtensions'].indexOf(
+          'amp-analytics') < 0) {
+        this.creativeMetadata_['customElementExtensions'].push('amp-analytics');
+      }
+    }
     return /**@type {?CreativeMetaDataDef}*/(this.creativeMetadata_);
   }
 
@@ -161,6 +173,8 @@ export class AmpAdNetworkAdzerkImpl extends AmpA4A {
           this.ampCreativeJson_.data,
           this.iframe.contentWindow.document.body)
           .then(renderedElement => {
+            ampAdTemplates.insertAnalytics(
+                renderedElement, this.ampCreativeJson_.analytics);
             this.iframe.contentWindow.document.body./*OK*/innerHTML =
                 renderedElement./*OK*/innerHTML;
           });

--- a/extensions/amp-ad-network-adzerk-impl/0.1/amp-ad-network-adzerk-impl.js
+++ b/extensions/amp-ad-network-adzerk-impl/0.1/amp-ad-network-adzerk-impl.js
@@ -153,7 +153,7 @@ export class AmpAdNetworkAdzerkImpl extends AmpA4A {
   getAmpAdMetadata(unusedCreative) {
     if (this.ampCreativeJson_.analytics) {
       if (!this.creativeMetadata_) {
-        this.creativeMetadata_ = /**@type {?CreativeMetaDataDef}*/ {};
+        this.creativeMetadata_ = /**@type {?CreativeMetaDataDef}*/ ({});
       }
       if (!this.creativeMetadata_['customElementExtensions']) {
         this.creativeMetadata_['customElementExtensions'] = [];
@@ -173,8 +173,10 @@ export class AmpAdNetworkAdzerkImpl extends AmpA4A {
           this.ampCreativeJson_.data,
           this.iframe.contentWindow.document.body)
           .then(renderedElement => {
-            ampAdTemplates.insertAnalytics(
-                renderedElement, this.ampCreativeJson_.analytics);
+            if (this.ampCreativeJson_.analytics) {
+              ampAdTemplates.insertAnalytics(
+                  renderedElement, this.ampCreativeJson_.analytics);
+            }
             this.iframe.contentWindow.document.body./*OK*/innerHTML =
                 renderedElement./*OK*/innerHTML;
           });

--- a/extensions/amp-ad-network-adzerk-impl/0.1/data/0
+++ b/extensions/amp-ad-network-adzerk-impl/0.1/data/0
@@ -9,7 +9,7 @@
     "height": "92px"
   },
   "analytics": [{
-    "json": {
+    "inline": {
       "requests": {
           "a": "https://www.fake.com"
         },

--- a/extensions/amp-ad-network-adzerk-impl/0.1/data/0
+++ b/extensions/amp-ad-network-adzerk-impl/0.1/data/0
@@ -7,5 +7,20 @@
     "title": "Adzerk Demo",
     "width": "272px",
     "height": "92px"
-  }
+  },
+  "analytics": [{
+    "json": {
+      "requests": {
+          "a": "https://www.fake.com"
+        },
+        "triggers": {
+          "visible": {
+            "on": "visible",
+            "request": "a"
+          }
+        }
+    }
+  }, {
+    "type": "googleanalytics"
+  }]
 }

--- a/extensions/amp-ad-network-adzerk-impl/0.1/test/test-amp-ad-network-adzerk-impl.js
+++ b/extensions/amp-ad-network-adzerk-impl/0.1/test/test-amp-ad-network-adzerk-impl.js
@@ -142,29 +142,16 @@ describes.fakeWin('amp-ad-network-adzerk-impl', {amp: true}, env => {
     let template;
 
     beforeEach(() => {
-      template = '<!doctype html><html ⚡4ads><head>' +
-          '<meta charset="utf-8">' +
-          '<meta name="viewport" content="width=device-width, ' +
-          'minimum-scale=1"><style amp4ads-boilerplate>body{visibility:' +
-          'hidden}</style><style amp-custom>amp-fit-text: {border: 1px;}' +
-          '</style><script async src="https://cdn.ampproject.org/' +
-          'amp4ads-v0.js"></script><script async custom-element=' +
-          '"amp-fit-text" src="https://cdn.ampproject.org/v0/' +
-          'amp-fit-text-0.1.js"></script><link rel="stylesheet" ' +
-          'type="text/css" href="https://fonts.googleapis.com/css?' +
-          'family=Raleway"></head><body>' +
-          '<amp-fit-text width="300" height="200" ' +
-          '[text]="\'hello \' + USER_NAME + \'!\' + USER_NUM ">' +
-          '</amp-fit-text><p [text]="\'Expect encoding \' + HTML_CONTENT">' +
-          '</p><amp-img [src]="IMG_SRC" [srcset]="IMG_SRC"/>' +
-          '<p [text]="\'Missing \' + UNKNOWN + \' item\'"></p>' +
-          '<script amp-ad-metadata type=application/json>' +
-          '{ "ampRuntimeUtf16CharOffsets" : [ 235, 414 ], ' +
-          '"customElementExtensions": [ "amp-bind" ], ' +
-          '"extensions": [ { ' +
-          '"custom-element": "amp-bind",' +
-          '"src": "https://cdn.ampproject.org/v0/amp-fit-text-0.1.js" } ] }' +
-          '</script></body></html>';
+      template = `<!doctype html><html ⚡><head>
+          <script async src="https://cdn.ampproject.org/v0.js"></script>
+          <script async custom-template="amp-mustache"
+            src="https://cdn.ampproject.org/v0/amp-mustache-0.1.js"></script>
+          </head>
+          <body>
+            <template type="amp-mustache">
+            <p>{{foo}}</p>
+            </template>
+          </body></html>`;
       fetchTextMock.withArgs(
           'https://www-adzerk-com.cdn.ampproject.org/c/s/www.adzerk.com/456',
           {
@@ -197,12 +184,14 @@ describes.fakeWin('amp-ad-network-adzerk-impl', {amp: true}, env => {
           .then(creative => {
             expect(impl.getAmpAdMetadata()).to.jsonEqual({
               minifiedCreative: creative,
-              customElementExtensions: ['amp-bind', 'amp-analytics'],
+              customElementExtensions: ['amp-analytics'],
+              extensions: [],
             });
             // Won't insert duplicate
             expect(impl.getAmpAdMetadata()).to.jsonEqual({
               minifiedCreative: creative,
-              customElementExtensions: ['amp-bind', 'amp-analytics'],
+              customElementExtensions: ['amp-analytics'],
+              extensions: [],
             });
           });
     });
@@ -225,7 +214,8 @@ describes.fakeWin('amp-ad-network-adzerk-impl', {amp: true}, env => {
           .then(creative => {
             expect(impl.getAmpAdMetadata()).to.jsonEqual({
               minifiedCreative: creative,
-              customElementExtensions: ['amp-bind'],
+              customElementExtensions: [],
+              extensions: [],
             });
           });
     });

--- a/extensions/amp-ad-network-adzerk-impl/0.1/test/test-amp-ad-network-adzerk-impl.js
+++ b/extensions/amp-ad-network-adzerk-impl/0.1/test/test-amp-ad-network-adzerk-impl.js
@@ -185,7 +185,7 @@ describes.fakeWin('amp-ad-network-adzerk-impl', {amp: true}, env => {
         analytics: {'type': 'googleanalytics'},
       };
       return impl.maybeValidateAmpCreative(
-          utf8EncodeSync(JSON.stringify(adResponseBody)).buffer,
+          utf8Encode(JSON.stringify(adResponseBody)).buffer,
           {
             get: name => {
               expect(name).to.equal(AMP_TEMPLATED_CREATIVE_HEADER_NAME);
@@ -213,7 +213,7 @@ describes.fakeWin('amp-ad-network-adzerk-impl', {amp: true}, env => {
         analytics: undefined,
       };
       return impl.maybeValidateAmpCreative(
-          utf8EncodeSync(JSON.stringify(adResponseBody)).buffer,
+          utf8Encode(JSON.stringify(adResponseBody)).buffer,
           {
             get: name => {
               expect(name).to.equal(AMP_TEMPLATED_CREATIVE_HEADER_NAME);


### PR DESCRIPTION
Insert `<amp-analytics>` component to template ad.

creativeJson should be defined like
```
{
  "templateUrl": ...
  "data": {}
  "analytics": {
     "remote": // define remote config url
     "type": // type attribute
     "inline": // inline config valeu
   } // Can also be an array of jsonObject
}
```