### PR TITLE
Allow animation-timing-function for keyframes

### DIFF
--- a/validator/testdata/feature_tests/style_amp_keyframes_error.out
+++ b/validator/testdata/feature_tests/style_amp_keyframes_error.out
@@ -65,7 +65,7 @@ feature_tests/style_amp_keyframes_error.html:46:6 CSS syntax error in tag 'style
 |         * [opacity, transform, visibility, offset-distance] */
 |        100% {thisshouldfail: translateX(100%);}
 >>             ^~~~~~~~~
-feature_tests/style_amp_keyframes_error.html:51:12 CSS syntax error in tag 'style[amp-keyframes]' - invalid property 'thisshouldfail'. The only allowed properties are '['offset-distance', 'opacity', 'transform', 'visibility']'. [AUTHOR_STYLESHEET_PROBLEM]
+feature_tests/style_amp_keyframes_error.html:51:12 CSS syntax error in tag 'style[amp-keyframes]' - invalid property 'thisshouldfail'. The only allowed properties are '['animation-timing-function', 'offset-distance', 'opacity', 'transform', 'visibility']'. [AUTHOR_STYLESHEET_PROBLEM]
 |      }
 |      @keyframes anim2 {
 |        @keyframes anim1 {

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -1034,6 +1034,7 @@ tags: {
         type: PARSE_AS_ERROR
       }
       validate_keyframes: true
+      allowed_declarations: "animation-timing-function"
       allowed_declarations: "offset-distance"
       allowed_declarations: "opacity"
       allowed_declarations: "transform"


### PR DESCRIPTION
Fixes #12352.

Allow keyframe css declarations for `animation-timing-function`.
