### PR TITLE
Thumbnails in lightbox gallery should be object fit cover

### DIFF
--- a/extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.css
+++ b/extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.css
@@ -136,6 +136,7 @@
   height: 100%;
   position: absolute;
   top: 0;
+  object-fit: cover;
 }
 
 /* Controls */


### PR DESCRIPTION
to unstretch thumbnail images. 