### PR TITLE
Add `source` and `caller` to ActionInvocation

### DIFF
--- a/extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.js
+++ b/extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.js
@@ -605,7 +605,7 @@ export class AmpLightboxViewer extends AMP.BaseElement {
    * @param {!../../../src/service/action-impl.ActionInvocation} invocation
    */
   activate(invocation) {
-    let target = invocation.source;
+    let target = invocation.caller;
     if (invocation.args && invocation.args['id']) {
       const targetId = invocation.args['id'];
       target = this.getAmpDoc().getElementById(targetId);

--- a/extensions/amp-sidebar/0.1/amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.js
@@ -275,7 +275,7 @@ export class AmpSidebar extends AMP.BaseElement {
       this.historyId_ = historyId;
     });
     if (opt_invocation) {
-      this.openerElement_ = opt_invocation.source;
+      this.openerElement_ = opt_invocation.caller;
       this.initialScrollTop_ = this.viewport_.getScrollTop();
     }
   }

--- a/src/document-submit.js
+++ b/src/document-submit.js
@@ -131,6 +131,7 @@ export function onDocumentFormSubmit_(e) {
     e.stopImmediatePropagation();
 
     const actions = Services.actionServiceForDoc(form);
-    actions.execute(form, 'submit', /*args*/ null, form, e, ActionTrust.HIGH);
+    actions.execute(
+        form, 'submit', /*args*/ null, form, form, e, ActionTrust.HIGH);
   }
 }

--- a/src/document-submit.js
+++ b/src/document-submit.js
@@ -132,6 +132,7 @@ export function onDocumentFormSubmit_(e) {
 
     const actions = Services.actionServiceForDoc(form);
     actions.execute(
-        form, 'submit', /*args*/ null, form, form, e, ActionTrust.HIGH);
+        form, 'submit', /*args*/ null, /*source*/ form, /*caller*/ form, e,
+        ActionTrust.HIGH);
   }
 }

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -122,10 +122,11 @@ export class ActionInvocation {
    * @param {string} method
    * @param {?JsonObject} args
    * @param {?Element} source
+   * @param {?Element} caller
    * @param {?ActionEventDef} event
    * @param {ActionTrust} trust
    */
-  constructor(target, method, args, source, event, trust) {
+  constructor(target, method, args, source, caller, event, trust) {
     /** @const {!Node} */
     this.target = target;
     /** @const {string} */
@@ -134,6 +135,8 @@ export class ActionInvocation {
     this.args = args;
     /** @const {?Element} */
     this.source = source;
+    /** @const {?Element} */
+    this.caller = caller;
     /** @const {?ActionEventDef} */
     this.event = event;
     /** @const {ActionTrust} */
@@ -319,12 +322,13 @@ export class ActionService {
    * @param {string} method
    * @param {?JsonObject} args
    * @param {?Element} source
+   * @param {?Element} caller
    * @param {?ActionEventDef} event
    * @param {ActionTrust} trust
    */
-  execute(target, method, args, source, event, trust) {
-    const invocation =
-        new ActionInvocation(target, method, args, source, event, trust);
+  execute(target, method, args, source, caller, event, trust) {
+    const invocation = new ActionInvocation(
+        target, method, args, source, caller, event, trust);
     this.invoke_(invocation, /* actionInfo */ null);
   }
 
@@ -398,7 +402,7 @@ export class ActionService {
         const globalTarget = this.globalTargets_[actionInfo.target];
         if (globalTarget) {
           const invocation = new ActionInvocation(this.root_, actionInfo.method,
-              args, action.node, event, trust);
+              args, source, action.node, event, trust);
           return globalTarget(invocation, i, action.actionInfos);
         }
 
@@ -406,7 +410,7 @@ export class ActionService {
         const target = this.root_.getElementById(actionInfo.target);
         if (target) {
           const invocation = new ActionInvocation(target, actionInfo.method,
-              args, action.node, event, trust);
+              args, source, action.node, event, trust);
           return this.invoke_(invocation, actionInfo);
         } else {
           this.actionInfoError_('target not found', actionInfo, target);

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -121,8 +121,8 @@ export class ActionInvocation {
    * @param {!Node} target
    * @param {string} method
    * @param {?JsonObject} args
-   * @param {?Element} source
-   * @param {?Element} caller
+   * @param {?Element} source Element where the action was triggered.
+   * @param {?Element} caller Element where the action is being handled.
    * @param {?ActionEventDef} event
    * @param {ActionTrust} trust
    */

--- a/test/functional/test-action.js
+++ b/test/functional/test-action.js
@@ -52,10 +52,12 @@ function createExecElement(id, enqueAction) {
 }
 
 
-function assertInvocation(inv, target, method, source, opt_event, opt_args) {
+function assertInvocation(inv, target, method, source, caller, opt_event,
+  child, opt_args) {
+
   expect(inv.target).to.equal(target);
   expect(inv.method).to.equal(method);
-  expect(inv.source).to.equal(source);
+  expect(inv.caller).to.equal(caller);
 
   if (opt_event !== undefined) {
     expect(inv.event).to.equal(opt_event);
@@ -622,24 +624,26 @@ describe('Action method', () => {
 
   it('should invoke on the AMP element', () => {
     action.invoke_(new ActionInvocation(execElement, 'method1', /* args */ null,
-        'source1', 'event1'));
+        'source1', 'caller1', 'event1'));
     expect(onEnqueue).to.be.calledOnce;
     const inv = onEnqueue.getCall(0).args[0];
     expect(inv.target).to.equal(execElement);
     expect(inv.method).to.equal('method1');
     expect(inv.source).to.equal('source1');
+    expect(inv.caller).to.equal('caller1');
     expect(inv.event).to.equal('event1');
     expect(inv.args).to.be.null;
   });
 
   it('should invoke on the AMP element with args', () => {
     action.invoke_(new ActionInvocation(execElement, 'method1', {'key1': 11},
-        'source1', 'event1'));
+        'source1', 'caller1', 'event1'));
     expect(onEnqueue).to.be.calledOnce;
     const inv = onEnqueue.getCall(0).args[0];
     expect(inv.target).to.equal(execElement);
     expect(inv.method).to.equal('method1');
     expect(inv.source).to.equal('source1');
+    expect(inv.caller).to.equal('caller1');
     expect(inv.event).to.equal('event1');
     expect(inv.args['key1']).to.equal(11);
   });
@@ -666,7 +670,8 @@ describe('Action method', () => {
     const inv = onEnqueue.getCall(0).args[0];
     expect(inv.target).to.equal(execElement);
     expect(inv.method).to.equal('method1');
-    expect(inv.source).to.equal(targetElement);
+    expect(inv.source).to.equal(child);
+    expect(inv.caller).to.equal(targetElement);
   });
 
   it('should execute method', () => {
@@ -698,13 +703,14 @@ describe('installActionHandler', () => {
     const target = document.createElement('form');
     action.installActionHandler(target, handlerSpy);
     action.invoke_(new ActionInvocation(target, 'submit', /* args */ null,
-        'button', 'tap', ActionTrust.HIGH));
+        'button', 'button', 'tap', ActionTrust.HIGH));
     expect(handlerSpy).to.be.calledOnce;
     const callArgs = handlerSpy.getCall(0).args[0];
     expect(callArgs.target).to.be.equal(target);
     expect(callArgs.method).to.be.equal('submit');
     expect(callArgs.args).to.be.equal(null);
     expect(callArgs.source).to.be.equal('button');
+    expect(callArgs.caller).to.be.equal('button');
     expect(callArgs.event).to.be.equal('tap');
   });
 
@@ -714,11 +720,11 @@ describe('installActionHandler', () => {
     action.installActionHandler(target, handlerSpy, ActionTrust.HIGH);
 
     action.invoke_(new ActionInvocation(target, 'submit', /* args */ null,
-        'button', 'tap', ActionTrust.LOW));
+        'button', 'button', 'tap', ActionTrust.LOW));
     expect(handlerSpy).to.not.be.called;
 
     action.invoke_(new ActionInvocation(target, 'submit', /* args */ null,
-        'button', 'tap', ActionTrust.HIGH));
+        'button', 'button', 'tap', ActionTrust.HIGH));
     expect(handlerSpy).to.be.calledOnce;
   });
 });
@@ -758,9 +764,9 @@ describe('Multiple handlers action method', () => {
     action.trigger(child, 'tap', null);
     expect(onEnqueue1).to.be.calledOnce;
     assertInvocation(onEnqueue1.getCall(0).args[0], execElement1, 'method1',
-        targetElement);
+        child, targetElement);
     assertInvocation(onEnqueue2.getCall(0).args[0], execElement2, 'method2',
-        targetElement);
+        child, targetElement);
   });
 
   it('should chain asynchronous actions', () => {
@@ -842,9 +848,9 @@ describe('Action interceptor', () => {
 
   it('should queue actions', () => {
     action.invoke_(new ActionInvocation(target, 'method1', /* args */ null,
-        'source1', 'event1'));
+        'source1', 'caller1', 'event1'));
     action.invoke_(new ActionInvocation(target, 'method2', /* args */ null,
-        'source2', 'event2'));
+        'source2', 'caller2', 'event2'));
 
     const queue = getQueue();
     expect(Array.isArray(queue)).to.be.true;
@@ -854,20 +860,22 @@ describe('Action interceptor', () => {
     expect(inv0.target).to.equal(target);
     expect(inv0.method).to.equal('method1');
     expect(inv0.source).to.equal('source1');
+    expect(inv0.caller).to.equal('caller1');
     expect(inv0.event).to.equal('event1');
 
     const inv1 = queue[1];
     expect(inv1.target).to.equal(target);
     expect(inv1.method).to.equal('method2');
     expect(inv1.source).to.equal('source2');
+    expect(inv1.caller).to.equal('caller2');
     expect(inv1.event).to.equal('event2');
   });
 
   it('should dequeue actions after handler set', () => {
     action.invoke_(new ActionInvocation(target, 'method1', /* args */ null,
-        'source1', 'event1', ActionTrust.HIGH));
+        'source1', 'caller1', 'event1', ActionTrust.HIGH));
     action.invoke_(new ActionInvocation(target, 'method2', /* args */ null,
-        'source2', 'event2', ActionTrust.HIGH));
+        'source2', 'caller2', 'event2', ActionTrust.HIGH));
 
     expect(Array.isArray(getQueue())).to.be.true;
     expect(getActionHandler()).to.be.undefined;
@@ -885,21 +893,24 @@ describe('Action interceptor', () => {
     expect(inv0.target).to.equal(target);
     expect(inv0.method).to.equal('method1');
     expect(inv0.source).to.equal('source1');
+    expect(inv0.caller).to.equal('caller1');
     expect(inv0.event).to.equal('event1');
 
     const inv1 = handler.getCall(1).args[0];
     expect(inv1.target).to.equal(target);
     expect(inv1.method).to.equal('method2');
     expect(inv1.source).to.equal('source2');
+    expect(inv1.caller).to.equal('caller2');
     expect(inv1.event).to.equal('event2');
 
     action.invoke_(new ActionInvocation(target, 'method3', /* args */ null,
-        'source3', 'event3', ActionTrust.HIGH));
+        'source3', 'caller3', 'event3', ActionTrust.HIGH));
     expect(handler).to.have.callCount(3);
     const inv2 = handler.getCall(2).args[0];
     expect(inv2.target).to.equal(target);
     expect(inv2.method).to.equal('method3');
     expect(inv2.source).to.equal('source3');
+    expect(inv2.caller).to.equal('caller3');
     expect(inv2.event).to.equal('event3');
   });
 });
@@ -930,12 +941,12 @@ describe('Action common handler', () => {
     action.addGlobalMethodHandler('action2', action2);
 
     action.invoke_(new ActionInvocation(target, 'action1', /* args */ null,
-        'source1', 'event1', ActionTrust.HIGH));
+        'source1', 'caller1', 'event1', ActionTrust.HIGH));
     expect(action1).to.be.calledOnce;
     expect(action2).to.have.not.been.called;
 
     action.invoke_(new ActionInvocation(target, 'action2', /* args */ null,
-        'source2', 'event2', ActionTrust.HIGH));
+        'source2', 'caller2', 'event2', ActionTrust.HIGH));
     expect(action2).to.be.calledOnce;
     expect(action1).to.be.calledOnce;
 
@@ -947,11 +958,11 @@ describe('Action common handler', () => {
     action.addGlobalMethodHandler('foo', handler, ActionTrust.HIGH);
 
     action.invoke_(new ActionInvocation(target, 'foo', /* args */ null,
-        'source1', 'event1', ActionTrust.LOW));
+        'source1', 'caller1', 'event1', ActionTrust.LOW));
     expect(handler).to.not.be.called;
 
     action.invoke_(new ActionInvocation(target, 'foo', /* args */ null,
-        'source1', 'event1', ActionTrust.HIGH));
+        'source1', 'caller1', 'event1', ActionTrust.HIGH));
     expect(handler).to.be.calledOnce;
   });
 });
@@ -976,8 +987,8 @@ describes.sandboxed('Action global target', {}, () => {
     action.trigger(element, 'tap', event);
     expect(target2).to.not.be.called;
     expect(target1).to.be.calledOnce;
-    assertInvocation(target1.args[0][0], document, 'action1', element, event,
-        {a: 'b'});
+    assertInvocation(target1.args[0][0], document, 'action1', element, element,
+        event, {a: 'b'});
 
     const element2 = document.createElement('div');
     element2.setAttribute('on', 'tap:target2.action1');
@@ -996,8 +1007,8 @@ describes.sandboxed('Action global target', {}, () => {
     action.trigger(element4, 'tap', event);
     expect(target2).to.be.calledThrice;
     expect(target1).to.be.calledThrice;
-    assertInvocation(target2.args[2][0], document, 'action2', element4, event,
-        {x: 'y'});
+    assertInvocation(target2.args[2][0], document, 'action2', element4,
+        element4, event, {x: 'y'});
   });
 });
 

--- a/test/functional/test-document-submit.js
+++ b/test/functional/test-document-submit.js
@@ -168,7 +168,7 @@ describe('test-document-submit onDocumentFormSubmit_', () => {
     onDocumentFormSubmit_(evt);
     expect(actionService.execute).to.have.been.calledOnce;
     expect(actionService.execute).to.have.been.calledWith(
-        tgt, 'submit', null, tgt, evt);
+        tgt, 'submit', null, tgt, tgt, evt);
     expect(preventDefaultSpy).to.have.been.calledOnce;
     expect(stopImmediatePropagationSpy).to.have.been.calledOnce;
   });


### PR DESCRIPTION
There's currently no way to determine the source of an action when the event was triggered by a descendant of the element where the invocation is defined.

Consider the following example, where the `source` field of the invocation object will always point to **carousel A** even when the event is triggered by carousel B.

```html
<amp-carousel id="carousel-A" on="slideChange:myAction">
  <amp-carousel id="carousel-B">
  <!-- ... -->
  </amp-carousel>
</amp-carousel>
```

This change adds a field named `caller`, which now stands for the previous value of `source`.

`source` now points to the actual element source.

The equivalents for `source` and `caller` in native `Event`s would be `target` and `currentTarget` respectively.

### If you're a component owner requested for review

Please confirm whether your use case requires `source` or `caller`. I updated all instances of `source` to `caller` since it's safer, but it's not necessarily the correct choice for your component.