### PR TITLE
Add url REPLACE macro

### DIFF
--- a/extensions/amp-analytics/0.1/test/test-variables.js
+++ b/extensions/amp-analytics/0.1/test/test-variables.js
@@ -194,8 +194,28 @@ describe('amp-analytics.VariableService', function() {
           );
     });
 
-    it('replaces', () => {
-      return check('REPLACE(this-is-a-test, `-`, )', 'thisisatest');
+    it('replaces common use case', () => {
+      return check('REPLACE(this-is-a-test, `-`)', 'thisisatest');
+    });
+
+    it('replaces three args', () => {
+      return check('REPLACE(this-is-a-test, `-`, *)', 'this*is*a*test');
+    });
+
+    it('replaces backticks optional', () => {
+      return check('REPLACE(this-is-a-test, `-`, **)', 'this**is**a**test');
+    });
+
+    it('replaces not trimming spaces in backticks', () => {
+      return check('REPLACE(this-is-a-test, ` -`)', 'this-is-a-test');
+    });
+
+    it('replaces respecting space as arg', () => {
+      return check('REPLACE(this-is-a-test, `-`, ` `)', 'this%20is%20a%20test');
+    });
+
+    it('replaces respecting backticks', () => {
+      return check('REPLACE(`this-,is-,a-,test`, `-,`)', 'thisisatest');
     });
 
     it('replace with no third arg', () => {

--- a/extensions/amp-analytics/0.1/test/test-variables.js
+++ b/extensions/amp-analytics/0.1/test/test-variables.js
@@ -193,6 +193,14 @@ describe('amp-analytics.VariableService', function() {
                 'S7Uc5ZmODduHWdplzrZ7Jsnqx')
           );
     });
+
+    it('replaces', () => {
+      return check('REPLACE(this-is-a-test, `-`, )', 'thisisatest');
+    });
+
+    it('replace with no third arg', () => {
+      return check('REPLACE(thi@s-is-a-te@st, `-|@`)', 'thisisatest');
+    });
   });
 
   describe('getNameArgs:', () => {

--- a/extensions/amp-analytics/0.1/test/test-variables.js
+++ b/extensions/amp-analytics/0.1/test/test-variables.js
@@ -203,7 +203,7 @@ describe('amp-analytics.VariableService', function() {
     });
 
     it('replaces backticks optional', () => {
-      return check('REPLACE(this-is-a-test, `-`, **)', 'this**is**a**test');
+      return check('REPLACE(this-is-a-test, -, **)', 'this**is**a**test');
     });
 
     it('replaces not trimming spaces in backticks', () => {

--- a/extensions/amp-analytics/0.1/variables.js
+++ b/extensions/amp-analytics/0.1/variables.js
@@ -98,6 +98,17 @@ function defaultMacro(value, defaultValue) {
   return value;
 }
 
+function replaceFilter(string, matchPattern, newSubStr) {
+  if (!matchPattern) {
+    user().warn(TAG, 'Replace must have two or more arguments');
+  }
+  if (!newSubStr) {
+    newSubStr = '';
+  }
+  const regex = new RegExp(matchPattern, 'g');
+  return string.replace(regex, newSubStr);
+}
+
 
 /**
  * Provides support for processing of advanced variable syntax like nested
@@ -126,6 +137,7 @@ export class VariableService {
     this.register_('HASH', this.hashMacro_.bind(this));
     this.register_('IF',
         (value, thenValue, elseValue) => value ? thenValue : elseValue);
+    this.register_('REPLACE', replaceFilter);
   }
 
   /**

--- a/extensions/amp-analytics/0.1/variables.js
+++ b/extensions/amp-analytics/0.1/variables.js
@@ -98,15 +98,21 @@ function defaultMacro(value, defaultValue) {
   return value;
 }
 
-function replaceFilter(string, matchPattern, newSubStr) {
+/**
+ * @param {string} string input to be replaced
+ * @param {string} matchPattern string representation of regex pattern
+ * @param {string=} opt_newSubStr pattern to be substituted in
+ * @returns {string}
+ */
+function replaceMacro(string, matchPattern, opt_newSubStr) {
   if (!matchPattern) {
-    user().warn(TAG, 'Replace must have two or more arguments');
+    user().warn(TAG, 'REPLACE macro must have two or more arguments');
   }
-  if (!newSubStr) {
-    newSubStr = '';
+  if (!opt_newSubStr) {
+    opt_newSubStr = '';
   }
   const regex = new RegExp(matchPattern, 'g');
-  return string.replace(regex, newSubStr);
+  return string.replace(regex, opt_newSubStr);
 }
 
 
@@ -137,7 +143,7 @@ export class VariableService {
     this.register_('HASH', this.hashMacro_.bind(this));
     this.register_('IF',
         (value, thenValue, elseValue) => value ? thenValue : elseValue);
-    this.register_('REPLACE', replaceFilter);
+    this.register_('REPLACE', replaceMacro);
   }
 
   /**

--- a/src/service/url-expander/expander.js
+++ b/src/service/url-expander/expander.js
@@ -163,6 +163,7 @@ export class Expander {
           const binding = stack.pop();
           const nextArg = nextArgShouldBeRaw ? builder : builder.trim();
           results.push(nextArg);
+          nextArgShouldBeRaw = false;
           const value = this.evaluateBinding_(binding, results);
           return value;
         }

--- a/test/functional/url-expander/test-expander.js
+++ b/test/functional/url-expander/test-expander.js
@@ -174,6 +174,24 @@ describes.realWin('Expander', {
       return expect(expander.expand('TRIM(FAKE(aaaaa))', mockBindings))
           .to.eventually.equal('');
     });
+
+    it('ignores commas within backticks', () => {
+      const url = 'CONCAT(`he,llo`,UPPERCASE(world)';
+      return expect(expander.expand(url, mockBindings))
+          .to.eventually.equal('he,lloWORLD');
+    });
+
+    it('ignores left parentheses within backticks', () => {
+      const url = 'CONCAT(hello, `wo((rld`)';
+      return expect(expander.expand(url, mockBindings))
+          .to.eventually.equal('hellowo((rld');
+    });
+
+    it('ignores right parentheses within backticks', () => {
+      const url = 'CONCAT(`hello)`,UPPERCASE(world)';
+      return expect(expander.expand(url, mockBindings))
+          .to.eventually.equal('hello)WORLD');
+    });
   });
 });
 


### PR DESCRIPTION
Follow up to #12682. All the new macros should now be available behind the `url-replacement-v2` flag.  

This PR adds the `REPLACE` macro that can be used in url expansion. It also adds the `\`` character that tells the new parser to ignore the special characters that may remain inside.

Closes #2198
