### PR TITLE
Have pause and resume callback respect layout order

### DIFF
--- a/extensions/amp-image-viewer/0.1/amp-image-viewer.js
+++ b/extensions/amp-image-viewer/0.1/amp-image-viewer.js
@@ -143,14 +143,10 @@ export class AmpImageViewer extends AMP.BaseElement {
     if (this.layoutPromise_) {
       return this.layoutPromise_;
     }
-    this.layoutPromise_ = Promise.resolve();
-    if (this.sourceAmpImage_) {
-      this.scheduleLayout(this.sourceAmpImage_);
-      this.layoutPromise_ = this.sourceAmpImage_.signals()
-          .whenSignal(CommonSignals.LOAD_END);
-    }
-    return this.layoutPromise_
-        .then(() => {
+    dev().assertElement(this.sourceAmpImage_);
+    this.scheduleLayout(this.sourceAmpImage_);
+    this.layoutPromise_ = this.sourceAmpImage_.signals()
+        .whenSignal(CommonSignals.LOAD_END).then(() => {
           return this.vsync_.mutatePromise(() => {
             if (!this.image_) {
               this.image_ = this.element.ownerDocument.createElement('img');
@@ -168,6 +164,7 @@ export class AmpImageViewer extends AMP.BaseElement {
           this.setupGestures_();
           this.registerOnResizeHandler_();
         });
+    return this.layoutPromise_;
   }
 
   /** @override */

--- a/extensions/amp-image-viewer/0.1/amp-image-viewer.js
+++ b/extensions/amp-image-viewer/0.1/amp-image-viewer.js
@@ -122,7 +122,7 @@ export class AmpImageViewer extends AMP.BaseElement {
     this.sourceAmpImage_ = null;
 
     /** @private {?Promise} */
-    this.layoutPromise_ = null;
+    this.loadPromise_ = null;
   }
 
   /** @override */
@@ -140,12 +140,11 @@ export class AmpImageViewer extends AMP.BaseElement {
 
   /** @override */
   layoutCallback() {
-    if (this.layoutPromise_) {
-      return this.layoutPromise_;
+    if (this.loadPromise_) {
+      return this.loadPromise_;
     }
-    dev().assertElement(this.sourceAmpImage_);
-    this.scheduleLayout(this.sourceAmpImage_);
-    this.layoutPromise_ = this.sourceAmpImage_.signals()
+    this.scheduleLayout(dev().assertElement(this.sourceAmpImage_));
+    this.loadPromise_ = this.sourceAmpImage_.signals()
         .whenSignal(CommonSignals.LOAD_END).then(() => {
           return this.vsync_.mutatePromise(() => {
             if (!this.image_) {
@@ -164,15 +163,15 @@ export class AmpImageViewer extends AMP.BaseElement {
           this.setupGestures_();
           this.registerOnResizeHandler_();
         });
-    return this.layoutPromise_;
+    return this.loadPromise_;
   }
 
   /** @override */
   pauseCallback() {
-    if (!this.layoutPromise_) {
+    if (!this.loadPromise_) {
       return;
     }
-    this.layoutPromise_.then(() => {
+    this.loadPromise_.then(() => {
       this.measure();
       this.cleanupGestures_();
       this.cleanupOnResizeHandler_();
@@ -181,10 +180,10 @@ export class AmpImageViewer extends AMP.BaseElement {
 
   /** @override */
   resumeCallback() {
-    if (!this.layoutPromise_) {
+    if (!this.loadPromise_) {
       return;
     }
-    this.layoutPromise_.then(() => {
+    this.loadPromise_.then(() => {
       if (!this.gestures_) {
         this.setupGestures_();
       }
@@ -198,7 +197,7 @@ export class AmpImageViewer extends AMP.BaseElement {
   unlayoutCallback() {
     this.cleanupGestures_();
     this.cleanupOnResizeHandler_();
-    this.layoutPromise_ = null;
+    this.loadPromise_ = null;
     return true;
   }
 


### PR DESCRIPTION
This is a code logic change based on a revised interpretation of `pause` and `resume` callback. Basically if these get called before layout callback, we should ensure that they are noops. If they get called while layout callback is happening, they should wait for layout callback to finish. Layout callback instead of behaving incorrectly when there is no AmpImage present, or pre-setting itself to a resolved promise (this causes a race bug), should just assert that the `sourceAmpImage` has been initialized (this happens in buildcallback) and set itself to the actual layout promise. I think this resolves the bug where some images show up as black because `measure` was called at the wrong time. 