### PR TITLE
Allow document level opt-in for url-replacement-v2

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -1,5 +1,5 @@
 {
-  "allow-doc-opt-in": ["visibility-v3", "amp-animation", "ampdoc-shell", "amp-ima-video"],
+  "allow-doc-opt-in": ["visibility-v3", "amp-animation", "ampdoc-shell", "amp-ima-video", "url-replacement-v2"],
   "allow-url-opt-in": ["pump-early-frame"],
 
   "canary": 1,

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -1,5 +1,5 @@
 {
-  "allow-doc-opt-in": ["visibility-v3", "amp-animation", "ampdoc-shell", "amp-ima-video"],
+  "allow-doc-opt-in": ["visibility-v3", "amp-animation", "ampdoc-shell", "amp-ima-video", "url-replacement-v2"],
   "allow-url-opt-in": ["pump-early-frame"],
 
   "canary": 0,


### PR DESCRIPTION
This is so we can test on ampproject.org as well as letting some of the content providers anxious to use this feature get started

Related to: #2198