### PR TITLE
Ignore yarn-error.log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ test/coverage
 package-lock.json
 *.swp
 *.swo
+yarn-error.log


### PR DESCRIPTION
This file is generated by `yarn check --integrity`, and should not be tracked by git.