### PR TITLE
Deobfuscate string cleanup while expanding URLs

### DIFF
--- a/src/service/url-expander/expander.js
+++ b/src/service/url-expander/expander.js
@@ -135,7 +135,7 @@ export class Expander {
             ignoringChars = true;
             nextArgShouldBeRaw = true;
             user().assert(builder.trim() === '',
-                `The substring "${builder}" was lost during url-replacement.` +
+                `The substring "${builder}" was lost during url-replacement. ` +
                 'Please ensure the url syntax is correct');
             builder = '';
           } else {

--- a/src/service/url-expander/expander.js
+++ b/src/service/url-expander/expander.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {rethrowAsync} from '../../log';
+import {rethrowAsync, user} from '../../log';
 
 export const PARSER_IGNORE_FLAG = '`';
 
@@ -134,6 +134,9 @@ export class Expander {
           if (!ignoringChars) {
             ignoringChars = true;
             nextArgShouldBeRaw = true;
+            user().assert(builder === '' || builder === ' ',
+                `The substring "${builder}" was lost during url-replacement.` +
+                'Please ensure the url syntax is correct');
             builder = '';
           } else {
             ignoringChars = false;

--- a/src/service/url-expander/expander.js
+++ b/src/service/url-expander/expander.js
@@ -134,7 +134,7 @@ export class Expander {
           if (!ignoringChars) {
             ignoringChars = true;
             nextArgShouldBeRaw = true;
-            user().assert(builder === '' || builder === ' ',
+            user().assert(builder.trim() === '',
                 `The substring "${builder}" was lost during url-replacement.` +
                 'Please ensure the url syntax is correct');
             builder = '';

--- a/test/functional/url-expander/test-expander.js
+++ b/test/functional/url-expander/test-expander.js
@@ -195,9 +195,9 @@ describes.realWin('Expander', {
 
     it('throws on bad input with back ticks', () => {
       const url = 'CONCAT(bad`hello`, world)';
-      return expect(expander.expand(url, mockBindings))
-          // .to.throw('The substring "bad" was lost during url-replacement. Please ensure the url syntax is correct');
-          .to.throw(Error);
+      expect(() => {
+        expander.expand(url, mockBindings);
+      }).to.throw(/bad/);
     });
   });
 });

--- a/test/functional/url-expander/test-expander.js
+++ b/test/functional/url-expander/test-expander.js
@@ -192,6 +192,13 @@ describes.realWin('Expander', {
       return expect(expander.expand(url, mockBindings))
           .to.eventually.equal('hello)WORLD');
     });
+
+    it('throws on bad input with back ticks', () => {
+      const url = 'CONCAT(bad`hello`, world)';
+      return expect(expander.expand(url, mockBindings))
+          // .to.throw('The substring "bad" was lost during url-replacement. Please ensure the url syntax is correct');
+          .to.throw(Error);
+    });
   });
 });
 


### PR DESCRIPTION
If a user gives a bad input like ``REPLACE(vanishing`hello-word`, `-`)`` the string `vanishing` will get removed. Instead of swallowing the error we should tell the user.

Open to bike-shedding about the actual warning sentence.
