### PR TITLE
Removes the check for custom-template declaration

### DIFF
--- a/src/service/template-impl.js
+++ b/src/service/template-impl.js
@@ -289,7 +289,6 @@ export class Templates {
       return this.templateClassMap_[type];
     }
 
-    this.checkTemplateDeclared_(element, type);
     let aResolve;
     const promise = new Promise((resolve, unusedReject) => {
       aResolve = resolve;
@@ -297,29 +296,6 @@ export class Templates {
     this.templateClassMap_[type] = promise;
     this.templateClassResolvers_[type] = aResolve;
     return promise;
-  }
-
-
-  /**
-   * Checks that the template type has actually been declared by a
-   * `<script custom-template=$type>` tag in the head.
-   * @param {!Element} element
-   * @param {string} type
-   * @private
-   */
-  checkTemplateDeclared_(element, type) {
-    if (!this.declaredTemplates_) {
-      this.declaredTemplates_ = this.win_.Object.create(null);
-      const scriptTags = this.win_.document.querySelectorAll(
-          'script[custom-template]');
-      for (let i = 0; i < scriptTags.length; i++) {
-        this.declaredTemplates_[scriptTags[i].getAttribute(
-            'custom-template')] = true;
-      }
-    }
-    user().assert(this.declaredTemplates_[type],
-        'Template must be declared for %s as <script custom-template=%s>',
-        element, type);
   }
 
   /**

--- a/test/functional/test-template.js
+++ b/test/functional/test-template.js
@@ -87,13 +87,6 @@ describes.fakeWin('Template', {}, env => {
     }).to.throw(/Duplicate template type/);
   });
 
-  it('should fail render if template is not declared', () => {
-    const templateElement = createTemplateElement();
-    expect(() => {
-      templates.renderTemplate(templateElement, {value: 0});
-    }).to.throw(/Template must be declared/);
-  });
-
   it('should block render until template registered', () => {
     templates.declaredTemplates_ = undefined;
     const templateElement = createTemplateElement();


### PR DESCRIPTION
This sanity check would potentially break dynamically loaded custom-template, for example from an FIE ad.

Like custom-element, we should just rely on validator to do the job.