### PR TITLE
Add a check to make sure yarn.lock was properly updated

### DIFF
--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -475,8 +475,9 @@ function main() {
   const yarnLockfileCheck = getStdout('git -c color.ui=always diff').trim();
   if (yarnLockfileCheck.includes('yarn.lock')) {
     console.error(fileLogPrefix, colors.red('ERROR:'),
-        'This PR did not properly update', colors.cyan('yarn.lock') +
-        '. To fix this, sync your branch to', colors.cyan('upstream/master'),
+        'This PR did not properly update', colors.cyan('yarn.lock') + '.');
+    console.error(fileLogPrefix, colors.yellow('NOTE:'),
+        'To fix this, sync your branch to', colors.cyan('upstream/master') +
         ', run', colors.cyan('gulp update-packages') +
         ', and push a new commit containing the changes.');
     console.error(fileLogPrefix, 'Expected changes:');

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -452,7 +452,8 @@ function main() {
     process.exit(1);
   }
 
-  // Make sure package.json and yarn.lock are in sync.
+  // Make sure package.json and yarn.lock are in sync, and that yarn.lock was
+  // properly updated.
   if (files.indexOf('package.json') != -1 || files.indexOf('yarn.lock') != -1) {
     const yarnIntegrityCheck = getStderr('yarn check --integrity').trim();
     if (yarnIntegrityCheck.includes('error')) {
@@ -469,6 +470,17 @@ function main() {
           '"' + colors.cyan('yarn install') + '"',
           'and include the updated', colors.cyan('yarn.lock'),
           'in your PR.');
+      process.exit(1);
+    }
+    const yarnLockfileCheck = getStdout('git diff').trim();
+    if (yarnLockfileCheck.includes('yarn.lock')) {
+      console.error(fileLogPrefix, colors.red('ERROR:'),
+          'This PR did not properly update', colors.cyan('yarn.lock') +
+          '. To fix this, sync your branch to', colors.cyan('upstream/master'),
+          'run', colors.cyan('gulp update-packages') +
+          ', and push a new commit.');
+      console.error(fileLogPrefix, colors.yellow('Diffs found:'));
+      console.log(yarnLockfileCheck);
       process.exit(1);
     }
   }

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -390,12 +390,57 @@ function runAllCommandsLocally() {
 }
 
 /**
+ * Makes sure package.json and yarn.lock are in sync.
+ */
+function runYarnIntegrityCheck() {
+  const yarnIntegrityCheck = getStderr('yarn check --integrity').trim();
+  if (yarnIntegrityCheck.includes('error')) {
+    console.error(fileLogPrefix, colors.red('ERROR:'),
+        'Found the following', colors.cyan('yarn'), 'errors:\n' +
+        colors.cyan(yarnIntegrityCheck));
+    console.error(fileLogPrefix, colors.red('ERROR:'),
+        'Updates to', colors.cyan('package.json'),
+        'must be accompanied by a corresponding update to',
+        colors.cyan('yarn.lock'));
+    console.error(fileLogPrefix, colors.yellow('NOTE:'),
+        'To update', colors.cyan('yarn.lock'), 'after changing',
+        colors.cyan('package.json') + ',', 'run',
+        '"' + colors.cyan('yarn install') + '"',
+        'and include the updated', colors.cyan('yarn.lock'),
+        'in your PR.');
+    process.exit(1);
+  }
+}
+
+/**
+ * Makes sure that yarn.lock was properly updated.
+ */
+function runYarnLockfileCheck() {
+  const yarnLockfileCheck = getStdout('git -c color.ui=always diff').trim();
+  if (yarnLockfileCheck.includes('yarn.lock')) {
+    console.error(fileLogPrefix, colors.red('ERROR:'),
+        'This PR did not properly update', colors.cyan('yarn.lock') + '.');
+    console.error(fileLogPrefix, colors.yellow('NOTE:'),
+        'To fix this, sync your branch to', colors.cyan('upstream/master') +
+        ', run', colors.cyan('gulp update-packages') +
+        ', and push a new commit containing the changes.');
+    console.error(fileLogPrefix, 'Expected changes:');
+    console.log(yarnLockfileCheck);
+    process.exit(1);
+  }
+}
+
+/**
  * The main method for the script execution which much like a C main function
  * receives the command line arguments and returns an exit status.
  * @returns {number}
  */
 function main() {
   const startTime = startTimer('pr-check.js');
+
+  // Make sure package.json and yarn.lock are in sync and up-to-date.
+  runYarnIntegrityCheck();
+  runYarnLockfileCheck();
 
   // Run the local version of all tests.
   if (!process.env.TRAVIS) {
@@ -449,39 +494,6 @@ function main() {
         'Please move these files to a separate PR:',
         colors.cyan(nonFlagConfigFiles.join(', ')));
     stopTimer('pr-check.js', startTime);
-    process.exit(1);
-  }
-
-  // Make sure package.json and yarn.lock are in sync.
-  const yarnIntegrityCheck = getStderr('yarn check --integrity').trim();
-  if (yarnIntegrityCheck.includes('error')) {
-    console.error(fileLogPrefix, colors.red('ERROR:'),
-        'Found the following', colors.cyan('yarn'), 'errors:\n' +
-        colors.cyan(yarnIntegrityCheck));
-    console.error(fileLogPrefix, colors.red('ERROR:'),
-        'Updates to', colors.cyan('package.json'),
-        'must be accompanied by a corresponding update to',
-        colors.cyan('yarn.lock'));
-    console.error(fileLogPrefix, colors.yellow('NOTE:'),
-        'To update', colors.cyan('yarn.lock'), 'after changing',
-        colors.cyan('package.json') + ',', 'run',
-        '"' + colors.cyan('yarn install') + '"',
-        'and include the updated', colors.cyan('yarn.lock'),
-        'in your PR.');
-    process.exit(1);
-  }
-
-  // Make sure that yarn.lock was properly updated.
-  const yarnLockfileCheck = getStdout('git -c color.ui=always diff').trim();
-  if (yarnLockfileCheck.includes('yarn.lock')) {
-    console.error(fileLogPrefix, colors.red('ERROR:'),
-        'This PR did not properly update', colors.cyan('yarn.lock') + '.');
-    console.error(fileLogPrefix, colors.yellow('NOTE:'),
-        'To fix this, sync your branch to', colors.cyan('upstream/master') +
-        ', run', colors.cyan('gulp update-packages') +
-        ', and push a new commit containing the changes.');
-    console.error(fileLogPrefix, 'Expected changes:');
-    console.log(yarnLockfileCheck);
     process.exit(1);
   }
 

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -472,14 +472,14 @@ function main() {
   }
 
   // Make sure that yarn.lock was properly updated.
-  const yarnLockfileCheck = getStdout('git diff').trim();
+  const yarnLockfileCheck = getStdout('git -c color.ui=always diff').trim();
   if (yarnLockfileCheck.includes('yarn.lock')) {
     console.error(fileLogPrefix, colors.red('ERROR:'),
         'This PR did not properly update', colors.cyan('yarn.lock') +
         '. To fix this, sync your branch to', colors.cyan('upstream/master'),
-        'run', colors.cyan('gulp update-packages') +
-        ', and push a new commit.');
-    console.error(fileLogPrefix, colors.yellow('Diffs found:'));
+        ', run', colors.cyan('gulp update-packages') +
+        ', and push a new commit containing the changes.');
+    console.error(fileLogPrefix, 'Expected changes:');
     console.log(yarnLockfileCheck);
     process.exit(1);
   }

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -452,37 +452,36 @@ function main() {
     process.exit(1);
   }
 
-  // Make sure package.json and yarn.lock are in sync, and that yarn.lock was
-  // properly updated.
-  if (files.indexOf('package.json') != -1 || files.indexOf('yarn.lock') != -1) {
-    const yarnIntegrityCheck = getStderr('yarn check --integrity').trim();
-    if (yarnIntegrityCheck.includes('error')) {
-      console.error(fileLogPrefix, colors.red('ERROR:'),
-          'Found the following', colors.cyan('yarn'), 'errors:\n' +
-          colors.cyan(yarnIntegrityCheck));
-      console.error(fileLogPrefix, colors.red('ERROR:'),
-          'Updates to', colors.cyan('package.json'),
-          'must be accompanied by a corresponding update to',
-          colors.cyan('yarn.lock'));
-      console.error(fileLogPrefix, colors.yellow('NOTE:'),
-          'To update', colors.cyan('yarn.lock'), 'after changing',
-          colors.cyan('package.json') + ',', 'run',
-          '"' + colors.cyan('yarn install') + '"',
-          'and include the updated', colors.cyan('yarn.lock'),
-          'in your PR.');
-      process.exit(1);
-    }
-    const yarnLockfileCheck = getStdout('git diff').trim();
-    if (yarnLockfileCheck.includes('yarn.lock')) {
-      console.error(fileLogPrefix, colors.red('ERROR:'),
-          'This PR did not properly update', colors.cyan('yarn.lock') +
-          '. To fix this, sync your branch to', colors.cyan('upstream/master'),
-          'run', colors.cyan('gulp update-packages') +
-          ', and push a new commit.');
-      console.error(fileLogPrefix, colors.yellow('Diffs found:'));
-      console.log(yarnLockfileCheck);
-      process.exit(1);
-    }
+  // Make sure package.json and yarn.lock are in sync.
+  const yarnIntegrityCheck = getStderr('yarn check --integrity').trim();
+  if (yarnIntegrityCheck.includes('error')) {
+    console.error(fileLogPrefix, colors.red('ERROR:'),
+        'Found the following', colors.cyan('yarn'), 'errors:\n' +
+        colors.cyan(yarnIntegrityCheck));
+    console.error(fileLogPrefix, colors.red('ERROR:'),
+        'Updates to', colors.cyan('package.json'),
+        'must be accompanied by a corresponding update to',
+        colors.cyan('yarn.lock'));
+    console.error(fileLogPrefix, colors.yellow('NOTE:'),
+        'To update', colors.cyan('yarn.lock'), 'after changing',
+        colors.cyan('package.json') + ',', 'run',
+        '"' + colors.cyan('yarn install') + '"',
+        'and include the updated', colors.cyan('yarn.lock'),
+        'in your PR.');
+    process.exit(1);
+  }
+
+  // Make sure that yarn.lock was properly updated.
+  const yarnLockfileCheck = getStdout('git diff').trim();
+  if (yarnLockfileCheck.includes('yarn.lock')) {
+    console.error(fileLogPrefix, colors.red('ERROR:'),
+        'This PR did not properly update', colors.cyan('yarn.lock') +
+        '. To fix this, sync your branch to', colors.cyan('upstream/master'),
+        'run', colors.cyan('gulp update-packages') +
+        ', and push a new commit.');
+    console.error(fileLogPrefix, colors.yellow('Diffs found:'));
+    console.log(yarnLockfileCheck);
+    process.exit(1);
   }
 
   console.log(

--- a/yarn.lock
+++ b/yarn.lock
@@ -247,11 +247,10 @@ ajv-keywords@2.1.1, ajv-keywords@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-2.1.1.tgz#617997fc5f60576894c435f940d819e135b80762"
 
-ajv@5.5.2, ajv@^5.1.0, ajv@^5.2.3, ajv@^5.3.0:
-  version "5.5.2"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.2.tgz#73b5eeca3fab653e3d3f9422b341ad42205dc965"
+ajv@6.1.1:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.1.1.tgz#978d597fbc2b7d0e5a5c3ddeb149a682f2abfa0e"
   dependencies:
-    co "^4.6.0"
     fast-deep-equal "^1.0.0"
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.3.0"
@@ -262,6 +261,15 @@ ajv@^4.9.1:
   dependencies:
     co "^4.6.0"
     json-stable-stringify "^1.0.1"
+
+ajv@^5.1.0, ajv@^5.2.3, ajv@^5.3.0:
+  version "5.5.2"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.2.tgz#73b5eeca3fab653e3d3f9422b341ad42205dc965"
+  dependencies:
+    co "^4.6.0"
+    fast-deep-equal "^1.0.0"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.3.0"
 
 align-text@^0.1.1, align-text@^0.1.3:
   version "0.1.4"
@@ -1600,10 +1608,6 @@ braces@^2.3.0:
     split-string "^3.0.2"
     to-regex "^3.0.1"
 
-brcast@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/brcast/-/brcast-2.0.2.tgz#2db16de44140e418dc37fab10beec0369e78dcef"
-
 brorand@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
@@ -2910,7 +2914,7 @@ deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
 
-deepmerge@^1.5.1, deepmerge@^1.5.2:
+deepmerge@^1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-1.5.2.tgz#10499d868844cdad4fee0842df8c7f6f0c95a753"
 
@@ -5793,9 +5797,9 @@ jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
 
-jsdom@11.6.1:
-  version "11.6.1"
-  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-11.6.1.tgz#43fffc10072597a8ee9680cba46900d9e4dbeba2"
+jsdom@11.6.2:
+  version "11.6.2"
+  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-11.6.2.tgz#25d1ef332d48adf77fc5221fe2619967923f16bb"
   dependencies:
     abab "^1.0.4"
     acorn "^5.3.0"
@@ -5810,7 +5814,7 @@ jsdom@11.6.1:
     html-encoding-sniffer "^1.0.2"
     left-pad "^1.2.0"
     nwmatcher "^1.4.3"
-    parse5 "^4.0.0"
+    parse5 "4.0.0"
     pn "^1.1.0"
     request "^2.83.0"
     request-promise-native "^1.0.5"
@@ -7633,7 +7637,7 @@ parse-passwd@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/parse-passwd/-/parse-passwd-1.0.0.tgz#6d5b934a456993b23d37f40a382d6f1666a8e5c6"
 
-parse5@^4.0.0:
+parse5@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-4.0.0.tgz#6d78656e3da8d78b4ec0b906f7c08ef1dfe3f608"
 


### PR DESCRIPTION
This PR adds a new check to safeguard against merge conflicts in `yarn.lock` like the one in https://github.com/ampproject/amphtml/pull/13067#issuecomment-362022629.

It also fixes the out-of-sync `yarn.lock` on `master`.