### PR TITLE
Fix flash when swapping backgrounds

### DIFF
--- a/extensions/amp-story/0.1/background.js
+++ b/extensions/amp-story/0.1/background.js
@@ -121,6 +121,8 @@ export class AmpStoryBackground {
 
     const hidden = this.hidden_;
 
+    setStyle(hidden, 'background-image', 'none');
+
     // Image will be swapped on load.
     whenFresh(imgLoad, () => {
       setStyle(hidden, 'background-image', url ? `url(${url})` : null);


### PR DESCRIPTION
This occurs when the image wait times out. The hidden layer will have a stale background image that will flash after the layer has been swapped, but before the correct image has been loaded.