### PR TITLE
Lightbox: fix various race conditions

### DIFF
--- a/extensions/amp-image-viewer/0.1/amp-image-viewer.js
+++ b/extensions/amp-image-viewer/0.1/amp-image-viewer.js
@@ -153,8 +153,7 @@ export class AmpImageViewer extends AMP.BaseElement {
 
               this.init_();
               this.element.appendChild(this.image_);
-              this.element.removeChild(this.sourceAmpImage_);
-              this.sourceAmpImage_ = null;
+              st.toggle(dev().assertElement(this.sourceAmpImage_), false);
             }
           });
         }).then(() => {
@@ -180,6 +179,7 @@ export class AmpImageViewer extends AMP.BaseElement {
 
   /** @override */
   resumeCallback() {
+    this.scheduleLayout(dev().assertElement(this.sourceAmpImage_));
     if (!this.loadPromise_) {
       return;
     }

--- a/extensions/amp-image-viewer/0.1/amp-image-viewer.js
+++ b/extensions/amp-image-viewer/0.1/amp-image-viewer.js
@@ -179,7 +179,9 @@ export class AmpImageViewer extends AMP.BaseElement {
 
   /** @override */
   resumeCallback() {
-    this.scheduleLayout(dev().assertElement(this.sourceAmpImage_));
+    if (this.sourceAmpImage_) {
+      this.scheduleLayout(this.sourceAmpImage_);
+    }
     if (!this.loadPromise_) {
       return;
     }

--- a/extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.js
+++ b/extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.js
@@ -286,23 +286,25 @@ export class AmpLightboxViewer extends AMP.BaseElement {
    * @private
    */
   buildCarousel_(lightboxGroupId) {
-    Services.extensionsFor(this.win).installExtensionForDoc(
-        this.getAmpDoc(), 'amp-carousel');
-    Services.extensionsFor(this.win).installExtensionForDoc(
-        this.getAmpDoc(), 'amp-image-viewer');
-    this.carousel_ = this.win.document.createElement('amp-carousel');
-    this.carousel_.setAttribute('type', 'slides');
-    this.carousel_.setAttribute('layout', 'fill');
-    this.carousel_.setAttribute('loop', '');
-    this.carousel_.setAttribute('amp-lightbox-group', lightboxGroupId);
-    return this.manager_.getElementsForLightboxGroup(lightboxGroupId)
-        .then(list => {
-          return this.vsync_.mutatePromise(() => {
-            this.buildCarouselSlides_(list);
-          });
-        }).then(() => {
-          this.container_.appendChild(this.carousel_);
-        });
+    return Promise.all([
+      Services.extensionsFor(this.win).installExtensionForDoc(
+          this.getAmpDoc(), 'amp-carousel'),
+      Services.extensionsFor(this.win).installExtensionForDoc(
+          this.getAmpDoc(), 'amp-image-viewer'),
+    ]).then(() => {
+      this.carousel_ = this.win.document.createElement('amp-carousel');
+      this.carousel_.setAttribute('type', 'slides');
+      this.carousel_.setAttribute('layout', 'fill');
+      this.carousel_.setAttribute('loop', '');
+      this.carousel_.setAttribute('amp-lightbox-group', lightboxGroupId);
+      return this.manager_.getElementsForLightboxGroup(lightboxGroupId);
+    }).then(list => {
+      return this.vsync_.mutatePromise(() => {
+        this.buildCarouselSlides_(list);
+      });
+    }).then(() => {
+      this.container_.appendChild(this.carousel_);
+    });
   }
 
   /**


### PR DESCRIPTION
Bug 1: we sometimes try to operate on `<amp-carousel>` and `<amp-image-viewer>` before these extensions load. The fix is to wait for these in a promise. 

Bug 2: image doesn't show bug. Under slow 3G / throttled internet, clicking on slide 7 causes slide 0 to go permanently black. This is because carousel tries to show slide 0, causing `<amp-image-viewer>` to try to lay out its child `<amp-img>`, but then it immediately jumps to slide 7, so when you wait for slide 0's `<amp-img>` to lay out, it is no longer in the viewport and never finishes laying out (hence layout callback for slide 0's `<amp-image-viewer>` never completes. The fix is to call scheduleLayout again on resume, so the wait for `LOAD_END` actually completes and then we finish the layout callback. 
