### PR TITLE
Remove maxDelay keyword

### DIFF
--- a/extensions/amp-analytics/0.1/test/test-amp-analytics.js
+++ b/extensions/amp-analytics/0.1/test/test-amp-analytics.js
@@ -532,7 +532,7 @@ describes.realWin('amp-analytics', {
       const analytics = getAnalyticsTag({
         'requests': {'foo': {
           'baseUrl': 'https://example.com/${bar}',
-          'maxDelay': 0,
+          'batchInterval': 0,
         }, 'bar': 'bar-i'},
         'triggers': [{'on': 'visible', 'request': 'foo'}],
       }, {'type': 'xyz'});
@@ -542,7 +542,7 @@ describes.realWin('amp-analytics', {
             'foo': 'foo',
             'bar': {
               'baseUrl': 'bar-v',
-              'maxDelay': 2,
+              'batchInterval': 2,
             }},
         },
       };
@@ -550,11 +550,11 @@ describes.realWin('amp-analytics', {
         expect(analytics.config_['requests']).to.jsonEqual({
           'foo': {
             'baseUrl': 'https://example.com/bar-i',
-            'maxDelay': 0,
+            'batchInterval': 0,
           },
           'bar': {
             'baseUrl': 'bar-i',
-            'maxDelay': 2,
+            'batchInterval': 2,
           },
         });
         expect(sendRequestSpy.calledOnce).to.be.true;
@@ -567,10 +567,10 @@ describes.realWin('amp-analytics', {
         'requests': {
           'foo': {
             'baseUrl': 'https://example.com/${bar}',
-            'maxDelay': 0,
+            'batchInterval': 0,
           },
           'bar': {
-            'maxDelay': 3,
+            'batchInterval': 3,
           },
         },
         'triggers': [{'on': 'visible', 'request': 'foo'}],
@@ -580,7 +580,7 @@ describes.realWin('amp-analytics', {
           'requests': {
             'foo': {
               'baseUrl': 'foo',
-              'maxDelay': 5,
+              'batchInterval': 5,
             },
             'bar': {
               'baseUrl': 'bar-v',
@@ -591,11 +591,11 @@ describes.realWin('amp-analytics', {
         expect(analytics.config_['requests']).to.jsonEqual({
           'foo': {
             'baseUrl': 'https://example.com/bar-v',
-            'maxDelay': 0,
+            'batchInterval': 0,
           },
           'bar': {
             'baseUrl': 'bar-v',
-            'maxDelay': 3,
+            'batchInterval': 3,
           },
         });
         expect(sendRequestSpy.calledOnce).to.be.true;

--- a/extensions/amp-analytics/amp-analytics.md
+++ b/extensions/amp-analytics/amp-analytics.md
@@ -185,7 +185,7 @@ In this example, all requests are valid.
   },
   "event": {
     "baseUrl": "${base}&type=event&eventId=${eventId}",
-    "maxDelay": 5
+    "batchInterval": 5
   }
 }
 ```
@@ -196,15 +196,15 @@ Some analytics providers have an already-provided configuration, which you use v
 To reduce the number of request pings, you can specify batching behaviors in the request configuration. Any [`extraUrlParams`](#extra-url-params) from `triggers` that use the same request are appended to the `baseUrl` of the request.
 
 The batching properties are:
-  - `maxDelay`: This property specifies the time to wait (in seconds) before sending out a request ping. `maxDelay` acts as a counter that starts upon the triggering of the first batched request.
+  - `batchInterval`: This property specifies the max time interval to wait (in seconds) before sending out a request ping. `batchInterval` can be a number or an array of numbers. Request will respect every item value in the array, and repeat the last interval value (or the single value) when reach the end of the array.
 
-For example, the following config sends out a single request ping after 3 seconds, with the final request ping looking like `https://example.com/analytics?rc=1&rc=2&rc=3` .
+For example, the following config sends out a single request ping every 3 seconds, with the first request ping looking like `https://example.com/analytics?rc=1&rc=2&rc=3` .
 
 ```javascript
 "requests": {
   "timer": {
     "baseUrl": "https://example.com/analytics?",
-    "maxDelay": 3,
+    "batchInterval": 3,
   }
 }
 "triggers": {

--- a/test/manual/analytics-batching.amp.html
+++ b/test/manual/analytics-batching.amp.html
@@ -48,11 +48,11 @@ Integer in felis at lacus mattis facilisis. Curabitur tincidunt, felis porttitor
       "old": "https://fake.com/analytics?timer",
       "batch": {
         "baseUrl": "https://fake.com/batch?",
-        "maxDelay": 5
+        "batchInterval": 5
       },
       "batchplugin": {
         "baseUrl": "https://fake.com/batchplugin?",
-        "maxDelay": 5,
+        "batchInterval": 5,
         "batchPlugin": "_ping_"
       },
       "batchInterval1": {


### PR DESCRIPTION
`maxDelay` and `batchInterval` are two very similar confusing concepts. To make our spec more clear, let's remove `maxDelay` at this point. We can always add this feature back upon further request. 

FYI: `maxDelay` is an experimental feature and safe to remove now. 