### PR TITLE
Transition show / hide for toggling controls

### DIFF
--- a/extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.css
+++ b/extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.css
@@ -65,7 +65,7 @@
 
 .i-amphtml-lbv-controls.fade-out
  {
-  opacity: 0;
+  opacity: 1;
   animation: fadeOut linear 0.4s 1 forwards;
 }
 
@@ -87,8 +87,6 @@
   color: #ffffff;
   z-index: 2;
   opacity: 0;
-  -webkit-animation: fadeIn ease-in 0.4s 1 forwards;
-  -moz-animation: fadeIn ease-in 0.4s 1 forwards;
   animation: fadeIn ease-in 0.4s 1 forwards;
 }
 
@@ -227,13 +225,16 @@
 
 @keyframes fadeIn {
   from { opacity: 0; }
-  to { opacity: 1; }
+  to {
+    opacity: 1;
+    visibility: visible;
+   }
 }
 
 @keyframes fadeOut {
   from { opacity: 1; }
   to {
     opacity: 0;
-    display: none;
+    visibility: hidden;
    }
 }

--- a/extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.css
+++ b/extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.css
@@ -55,8 +55,22 @@
   top: 0 !important;
   height: 50px !important;
   background: linear-gradient(rgba(0,0,0,0.3), rgba(0,0,0,0));
-  transition: opacity 1s;
   z-index: 2;
+}
+
+.i-amphtml-lbv-controls {
+  opacity: 0;
+  -webkit-animation: fadeIn ease-in 0.4s 1 forwards;
+  -moz-animation: fadeIn ease-in 0.4s 1 forwards;
+  animation: fadeIn ease-in 0.4s 1 forwards;
+}
+
+.i-amphtml-lbv-controls.fade-out
+ {
+  opacity: 0;
+  -webkit-animation: fadeOut linear 0.4s 1 forwards;
+  -moz-animation: fadeOut linear 0.4s 1 forwards;
+  animation: fadeOut linear 0.4s 1 forwards;
 }
 
 .i-amphtml-lbv-top-bar.fullscreen .i-amphtml-lbv-top-bar-top-gradient {
@@ -75,9 +89,11 @@
   bottom: 0 !important;
   overflow-x: hidden !important;
   color: #ffffff;
-  opacity: 1;
-  transition: opacity 1s;
   z-index: 2;
+  opacity: 0;
+  -webkit-animation: fadeIn ease-in 0.4s 1 forwards;
+  -moz-animation: fadeIn ease-in 0.4s 1 forwards;
+  animation: fadeIn ease-in 0.4s 1 forwards;
 }
 
 .i-amphtml-lbv-desc-box.standard {
@@ -211,4 +227,40 @@
   left: 0;
   bottom: 0;
   right: 0;
+}
+
+@-webkit-keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@-moz-keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@-webkit-keyframes fadeOut {
+  from { opacity: 1; }
+  to { opacity: 0; }
+}
+
+@-moz-keyframes fadeOut {
+  from { opacity: 1; }
+  to {
+    opacity: 0;
+    display: none;
+  }
+}
+
+@keyframes fadeOut {
+  from { opacity: 1; }
+  to {
+    opacity: 0;
+    display: none;
+   }
 }

--- a/extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.css
+++ b/extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.css
@@ -60,16 +60,12 @@
 
 .i-amphtml-lbv-controls {
   opacity: 0;
-  -webkit-animation: fadeIn ease-in 0.4s 1 forwards;
-  -moz-animation: fadeIn ease-in 0.4s 1 forwards;
   animation: fadeIn ease-in 0.4s 1 forwards;
 }
 
 .i-amphtml-lbv-controls.fade-out
  {
   opacity: 0;
-  -webkit-animation: fadeOut linear 0.4s 1 forwards;
-  -moz-animation: fadeOut linear 0.4s 1 forwards;
   animation: fadeOut linear 0.4s 1 forwards;
 }
 
@@ -229,32 +225,9 @@
   right: 0;
 }
 
-@-webkit-keyframes fadeIn {
-  from { opacity: 0; }
-  to { opacity: 1; }
-}
-
-@-moz-keyframes fadeIn {
-  from { opacity: 0; }
-  to { opacity: 1; }
-}
-
 @keyframes fadeIn {
   from { opacity: 0; }
   to { opacity: 1; }
-}
-
-@-webkit-keyframes fadeOut {
-  from { opacity: 1; }
-  to { opacity: 0; }
-}
-
-@-moz-keyframes fadeOut {
-  from { opacity: 1; }
-  to {
-    opacity: 0;
-    display: none;
-  }
 }
 
 @keyframes fadeOut {

--- a/extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.js
+++ b/extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.js
@@ -321,6 +321,8 @@ export class AmpLightboxViewer extends AMP.BaseElement {
   buildDescriptionBox_() {
     this.descriptionBox_ = this.win.document.createElement('div');
     this.descriptionBox_.classList.add('i-amphtml-lbv-desc-box');
+    this.descriptionBox_.classList.add('i-amphtml-lbv-controls');
+
     this.descriptionBox_.classList.add('standard');
 
     this.descriptionTextArea_ = this.win.document.createElement('div');
@@ -443,6 +445,7 @@ export class AmpLightboxViewer extends AMP.BaseElement {
     dev().assert(this.container_);
     this.topBar_ = this.win.document.createElement('div');
     this.topBar_.classList.add('i-amphtml-lbv-top-bar');
+    this.topBar_.classList.add('i-amphtml-lbv-controls');
 
     this.topGradient_ = this.win.document.createElement('div');
     this.topGradient_.classList.add('i-amphtml-lbv-top-bar-top-gradient');
@@ -504,12 +507,12 @@ export class AmpLightboxViewer extends AMP.BaseElement {
 
   /**
    * Toggle description box if it has text content
-   * @param {boolean} display
    * @private
    */
-  toggleDescriptionBox_(display) {
+  showDescriptionBox_() {
+    this.descriptionBox_.classList.remove('fade-out');
     this.updateDescriptionBox_();
-    toggle(dev().assertElement(this.descriptionBox_), display);
+    toggle(dev().assertElement(this.descriptionBox_), true);
   }
 
   /**
@@ -523,14 +526,15 @@ export class AmpLightboxViewer extends AMP.BaseElement {
     }
 
     if (this.controlsMode_ == LightboxControlsModes.CONTROLS_HIDDEN) {
+      this.topBar_.classList.remove('fade-out');
       toggle(dev().assertElement(this.topBar_), true);
       if (!this.container_.hasAttribute('gallery-view')) {
-        this.toggleDescriptionBox_(true);
+        this.showDescriptionBox_();
       }
       this.controlsMode_ = LightboxControlsModes.CONTROLS_DISPLAYED;
     } else {
-      this.toggleDescriptionBox_(false);
-      toggle(dev().assertElement(this.topBar_), false);
+      this.topBar_.classList.add('fade-out');
+      this.descriptionBox_.classList.add('fade-out');
       this.controlsMode_ = LightboxControlsModes.CONTROLS_HIDDEN;
     }
   }

--- a/extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.js
+++ b/extensions/amp-lightbox-viewer/0.1/amp-lightbox-viewer.js
@@ -506,16 +506,6 @@ export class AmpLightboxViewer extends AMP.BaseElement {
   }
 
   /**
-   * Toggle description box if it has text content
-   * @private
-   */
-  showDescriptionBox_() {
-    this.descriptionBox_.classList.remove('fade-out');
-    this.updateDescriptionBox_();
-    toggle(dev().assertElement(this.descriptionBox_), true);
-  }
-
-  /**
    * Toggle lightbox controls including topbar and description.
    * @param {!Event} e
    * @private
@@ -527,9 +517,9 @@ export class AmpLightboxViewer extends AMP.BaseElement {
 
     if (this.controlsMode_ == LightboxControlsModes.CONTROLS_HIDDEN) {
       this.topBar_.classList.remove('fade-out');
-      toggle(dev().assertElement(this.topBar_), true);
       if (!this.container_.hasAttribute('gallery-view')) {
-        this.showDescriptionBox_();
+        this.descriptionBox_.classList.remove('fade-out');
+        this.updateDescriptionBox_();
       }
       this.controlsMode_ = LightboxControlsModes.CONTROLS_DISPLAYED;
     } else {


### PR DESCRIPTION
I used animation instead of css transition here because css transition doesn't play nice with `display: none`, and we want to use `display: none` to make sure that we don't accidentally click on the button. The extra `keyframe` classes are for backwards compatibility. I've seen them elsewhere in the codebase, but I don't know if for example our build process handles them already. 