### PR TITLE
Add --extensions flag to only build listed extensions

### DIFF
--- a/contributing/DEVELOPING.md
+++ b/contributing/DEVELOPING.md
@@ -35,8 +35,8 @@ The Quick Start Guide's  [One-time setup](getting-started-quick.md#one-time-setu
 | Command                                                                 | Description                                                           |
 | ----------------------------------------------------------------------- | --------------------------------------------------------------------- |
 | **`gulp`**<sup>[[1]](#footnote-1)</sup>                                 | Runs "watch" and "serve". Use this for standard local dev.            |
-| `gulp --extensions=<amp-foo,amp-bar>`                                   | Runs "watch" and "serve" with only listed extension components.
-| `gulp --noextensions`                                                   | Runs "watch" and "serve" with no extensions.
+| `gulp --extensions=<amp-foo,amp-bar>`                                   | Runs "watch" and "serve", after building only the listed extensions.
+| `gulp --noextensions`                                                   | Runs "watch" and "serve" without building any extensions.
 | `gulp dist`<sup>[[1]](#footnote-1)</sup>                                | Builds production binaries.                                           |
 | `gulp dist --fortesting`<sup>[[1]](#footnote-1)</sup>                   | Builds production binaries for local testing. (Allows use cases like ads, tweets, etc. to work with minified sources. Overrides `TESTING_HOST` if specified. Uses the production `AMP_CONFIG` by default.) |
 | `gulp dist --fortesting --config=<config>`<sup>[[1]](#footnote-1)</sup> | Builds production binaries for local testing, with the specified `AMP_CONFIG`. `config` can be `prod` or `canary`. (Defaults to `prod`.) |
@@ -44,7 +44,7 @@ The Quick Start Guide's  [One-time setup](getting-started-quick.md#one-time-setu
 | `gulp lint --watch`                                                     | Watches for changes in files, Validates against Google Closure Linter.|
 | `gulp lint --fix`                                                       | Fixes simple lint warnings/errors automatically.                      |
 | `gulp build`<sup>[[1]](#footnote-1)</sup>                               | Builds the AMP library.                                               |
-| `gulp build --extensions=<amp-foo,amp-bar>`                         | Builds the AMP library, with only the listed extensions.
+| `gulp build --extensions=<amp-foo,amp-bar>`                             | Builds the AMP library, with only the listed extensions.
 | `gulp build --noextensions`                                             | Builds the AMP library with no extensions.
 | `gulp check-links --files foo.md,bar.md`                                | Reports dead links in `.md` files.                                                 |
 | `gulp clean`                                                            | Removes build output.                                                 |

--- a/contributing/DEVELOPING.md
+++ b/contributing/DEVELOPING.md
@@ -35,6 +35,8 @@ The Quick Start Guide's  [One-time setup](getting-started-quick.md#one-time-setu
 | Command                                                                 | Description                                                           |
 | ----------------------------------------------------------------------- | --------------------------------------------------------------------- |
 | **`gulp`**<sup>[[1]](#footnote-1)</sup>                                 | Runs "watch" and "serve". Use this for standard local dev.            |
+| `gulp --extensions=<amp-foo,amp-bar>`                                   | Runs "watch" and "serve" with only listed extension components.
+| `gulp --noextensions`                                                   | Runs "watch" and "serve" with no extensions.
 | `gulp dist`<sup>[[1]](#footnote-1)</sup>                                | Builds production binaries.                                           |
 | `gulp dist --fortesting`<sup>[[1]](#footnote-1)</sup>                   | Builds production binaries for local testing. (Allows use cases like ads, tweets, etc. to work with minified sources. Overrides `TESTING_HOST` if specified. Uses the production `AMP_CONFIG` by default.) |
 | `gulp dist --fortesting --config=<config>`<sup>[[1]](#footnote-1)</sup> | Builds production binaries for local testing, with the specified `AMP_CONFIG`. `config` can be `prod` or `canary`. (Defaults to `prod`.) |
@@ -42,14 +44,14 @@ The Quick Start Guide's  [One-time setup](getting-started-quick.md#one-time-setu
 | `gulp lint --watch`                                                     | Watches for changes in files, Validates against Google Closure Linter.|
 | `gulp lint --fix`                                                       | Fixes simple lint warnings/errors automatically.                      |
 | `gulp build`<sup>[[1]](#footnote-1)</sup>                               | Builds the AMP library.                                               |
-| `gulp build --extensions=<extension-name,extension-name>`               | Builds the AMP library with only listed extension components.
+| `gulp build --extensions=<amp-foo,amp-bar>`                         | Builds the AMP library, with only the listed extensions.
 | `gulp build --noextensions`                                             | Builds the AMP library with no extensions.
 | `gulp check-links --files foo.md,bar.md`                                | Reports dead links in `.md` files.                                                 |
 | `gulp clean`                                                            | Removes build output.                                                 |
 | `gulp css`<sup>[[1]](#footnote-1)</sup>                                 | Recompiles css to build directory and builds the embedded css into js files for the AMP library. |
-| `gulp watch`<sup>[[1]](#footnote-1)</sup>                               | Watches for changes in files, re-build.                               |
-| `gulp watch --extensions=<extension-name,extension-name>`               | Watch for changes in files, re-build with only listed extensions.
-| `gulp watch --noextensions`                                             | Watch for changes in files, re-build with no extensions.
+| `gulp watch`<sup>[[1]](#footnote-1)</sup>                               | Watches for changes in files, re-builds.                               |
+| `gulp watch --extensions=<amp-foo,amp-bar>`                             | Watches for changes in files, re-builds only the listed extensions.
+| `gulp watch --noextensions`                                             | Watches for changes in files, re-builds with no extensions.
 | `gulp pr-check`<sup>[[1]](#footnote-1)</sup>                            | Runs all the Travis CI checks locally.         |
 | `gulp pr-check --nobuild`<sup>[[1]](#footnote-1)</sup>                  | Runs all the Travis CI checks locally, but skips the `gulp build` step.         |
 | `gulp pr-check --files=<test-files-path-glob>`<sup>[[1]](#footnote-1)</sup>   | Runs all the Travis CI checks locally, and restricts tests to the files provided.  |

--- a/contributing/DEVELOPING.md
+++ b/contributing/DEVELOPING.md
@@ -42,11 +42,14 @@ The Quick Start Guide's  [One-time setup](getting-started-quick.md#one-time-setu
 | `gulp lint --watch`                                                     | Watches for changes in files, Validates against Google Closure Linter.|
 | `gulp lint --fix`                                                       | Fixes simple lint warnings/errors automatically.                      |
 | `gulp build`<sup>[[1]](#footnote-1)</sup>                               | Builds the AMP library.                                               |
+| `gulp build --extensions=<extension-name,extension-name>`               | Builds the AMP library with only listed extension components.
+| `gulp build --noextensions`                                             | Builds the AMP library with no extensions.
 | `gulp check-links --files foo.md,bar.md`                                | Reports dead links in `.md` files.                                                 |
 | `gulp clean`                                                            | Removes build output.                                                 |
 | `gulp css`<sup>[[1]](#footnote-1)</sup>                                 | Recompiles css to build directory and builds the embedded css into js files for the AMP library. |
-| `gulp extensions`                                                       | Build AMP Extensions.                                                 |
 | `gulp watch`<sup>[[1]](#footnote-1)</sup>                               | Watches for changes in files, re-build.                               |
+| `gulp watch --extensions=<extension-name,extension-name>`               | Watch for changes in files, re-build with only listed extensions.
+| `gulp watch --noextensions`                                             | Watch for changes in files, re-build with no extensions.
 | `gulp pr-check`<sup>[[1]](#footnote-1)</sup>                            | Runs all the Travis CI checks locally.         |
 | `gulp pr-check --nobuild`<sup>[[1]](#footnote-1)</sup>                  | Runs all the Travis CI checks locally, but skips the `gulp build` step.         |
 | `gulp pr-check --files=<test-files-path-glob>`<sup>[[1]](#footnote-1)</sup>   | Runs all the Travis CI checks locally, and restricts tests to the files provided.  |

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -240,8 +240,21 @@ function endBuildStep(stepName, targetName, startTime) {
  * @return {!Promise}
  */
 function buildExtensions(options) {
-  var results = [];
-  for (var key in extensions) {
+  const results = [];
+  let extensionToBuild = null;
+  if (argv.extension) {
+    let arg = argv.extension;
+    arg = arg.split(',');
+    extensionToBuild = Array.isArray(arg) ? arg : [arg];
+  }
+  for (const key in extensions) {
+    const extensionName = key.substring(0, key.length - 4);
+    if (argv.extension && extensionToBuild) {
+      if (extensionToBuild.indexOf(extensionName) < 0) {
+        // Skip this extension;
+        continue;
+      }
+    }
     var e = extensions[key];
     var o = Object.assign({}, options);
     o = Object.assign(o, e);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -240,24 +240,20 @@ function endBuildStep(stepName, targetName, startTime) {
  * @return {!Promise}
  */
 function buildExtensions(options) {
-  const results = [];
-  let extensionsToBuild = [];
-  // --noextensions flag skip building extensions
   if (!!argv.noextensions) {
-    return Promise.all(results);
+    return Promise.resolve();
   }
 
-  // --extensions flag: only build listed extensions
+  var extensionsToBuild = [];
   if (!!argv.extensions && argv.extensions !== true) {
     extensionsToBuild = argv.extensions.split(',');
   }
 
+  var results = [];
   for (var key in extensions) {
-    if (extensionsToBuild.length > 0 && extensionsToBuild) {
-      if (extensionsToBuild.indexOf(extensions[key].name) < 0) {
-        // Skip this extension;
-        continue;
-      }
+    if (extensionsToBuild.length > 0 &&
+        extensionsToBuild.indexOf(extensions[key].name) == -1) {
+      continue;
     }
     var e = extensions[key];
     var o = Object.assign({}, options);
@@ -1350,6 +1346,8 @@ gulp.task('build', 'Builds the AMP library',
     ['update-packages', 'patch-web-animations'], build, {
       options: {
         config: '  Sets the runtime\'s AMP_CONFIG to one of "prod" or "canary"',
+        extensions: '  Builds only the listed extensions.',
+        noextensions: ' Builds with no extensions.',
       }
     });
 gulp.task('check-all', 'Run through all presubmit checks',
@@ -1360,7 +1358,12 @@ gulp.task('patch-web-animations',
     ['update-packages'], patchWebAnimations);
 gulp.task('css', 'Recompile css to build directory', ['update-packages'], css);
 gulp.task('default', 'Runs "watch" and then "serve"',
-    ['update-packages', 'watch'], serve);
+    ['update-packages', 'watch'], serve, {
+      options: {
+        extensions: '  Watches and builds only the listed extensions.',
+        noextensions: '  Watches and builds with no extensions.',
+      }
+    });
 gulp.task('dist', 'Build production binaries',
     ['update-packages', 'patch-web-animations'], dist, {
       options: {
@@ -1376,6 +1379,8 @@ gulp.task('watch', 'Watches for changes in files, re-builds when detected',
       options: {
         with_inabox: '  Also watch and build the amp-inabox.js binary.',
         with_shadow: '  Also watch and build the amp-shadow.js binary.',
+        extensions: '  Watches and builds only the listed extensions.',
+        noextensions: '  Watches and builds with no extensions.',
       }
 });
 gulp.task('build-experiments', 'Builds experiments.html/js', buildExperiments);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1347,7 +1347,7 @@ gulp.task('build', 'Builds the AMP library',
       options: {
         config: '  Sets the runtime\'s AMP_CONFIG to one of "prod" or "canary"',
         extensions: '  Builds only the listed extensions.',
-        noextensions: ' Builds with no extensions.',
+        noextensions: '  Builds with no extensions.',
       }
     });
 gulp.task('check-all', 'Run through all presubmit checks',


### PR DESCRIPTION
The build time for local testing is getting so long with all these new extensions. 
I can't find a way to not build unrelated extensions to my change. Right now I would simply comment out extensions I don't want every time I start the gulp server. 

The idea is to introduce a new flag `--extension` and only build listed extensions.
For example `gulp --extension=amp-ad,amp-anim` will only build amp-ad and amp-anim extension. 
I tested the server only with the `gulp default` command, please let me know if I miss anything : )

Also I am thinking of the name `--only` vs `--extension`. Since we already have `--extensions`, might be confusing. Let me know, thanks!