### PR TITLE
Lightbox: do not allow panning to go past image boundaries

### DIFF
--- a/extensions/amp-image-viewer/0.1/amp-image-viewer.js
+++ b/extensions/amp-image-viewer/0.1/amp-image-viewer.js
@@ -611,8 +611,8 @@ export class AmpImageViewer extends AMP.BaseElement {
    * @private
    */
   onMove_(deltaX, deltaY, animate) {
-    const newPosX = this.boundX_(this.startX_ + deltaX, true);
-    const newPosY = this.boundY_(this.startY_ + deltaY, true);
+    const newPosX = this.boundX_(this.startX_ + deltaX, false);
+    const newPosY = this.boundY_(this.startY_ + deltaY, false);
     this.set_(this.scale_, newPosX, newPosY, animate);
   }
 
@@ -628,8 +628,8 @@ export class AmpImageViewer extends AMP.BaseElement {
     this.motion_ = continueMotion(dev().assertElement(this.image_),
         this.posX_, this.posY_, veloX, veloY,
         (x, y) => {
-          const newPosX = this.boundX_(x, true);
-          const newPosY = this.boundY_(y, true);
+          const newPosX = this.boundX_(x, false);
+          const newPosY = this.boundY_(y, false);
           if (Math.abs(newPosX - this.posX_) < 1 &&
                 Math.abs(newPosY - this.posY_) < 1) {
             // Hit the wall: stop motion.


### PR DESCRIPTION
We want zoom to still have the overzoom + shrink effect, but make sure that panning does not exceed the boundaries of the image itself. 