### PR TITLE
Patch web-animations-js during gulp dist

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -652,7 +652,7 @@ function dist() {
   if (argv.fortesting) {
     printConfigHelp('gulp dist --fortesting')
   }
-  return compileCss().then(() => {
+  return compileCss().then(patchWebAnimations).then(() => {
     return Promise.all([
       compile(false, true, true),
       // NOTE:


### PR DESCRIPTION
#13199 moved the call to `patchWebAnimations()` from the global scope in `gulpfile.js` to `performBuild()`. Turns out we need the call in `dist()` as well. 

Follow up to #13199
Fixes #13177
