### PR TITLE
Fix animation goes into corner on resize bug

### DIFF
--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -293,6 +293,7 @@ export class AmpSlideScroll extends BaseSlides {
 
   /** @override */
   unlayoutCallback() {
+    this.scheduleUnlayout(this.slides_[dev().assertNumber(this.slideIndex_)]);
     this.slideIndex_ = null;
     return super.unlayoutCallback();
   }

--- a/extensions/amp-image-viewer/0.1/amp-image-viewer.js
+++ b/extensions/amp-image-viewer/0.1/amp-image-viewer.js
@@ -171,7 +171,8 @@ export class AmpImageViewer extends AMP.BaseElement {
       return;
     }
     this.loadPromise_.then(() => {
-      this.measure();
+      return this.measure();
+    }).then(() => {
       this.cleanupGestures_();
       this.cleanupOnResizeHandler_();
     });
@@ -186,12 +187,10 @@ export class AmpImageViewer extends AMP.BaseElement {
       return;
     }
     this.loadPromise_.then(() => {
-      if (!this.gestures_) {
-        this.setupGestures_();
-      }
-      if (!this.cleanupOnResizeHandler_) {
-        this.registerOnResizeHandler_();
-      }
+      return this.measure();
+    }).then(() => {
+      this.setupGestures_();
+      this.registerOnResizeHandler_();
     });
   }
 
@@ -253,6 +252,8 @@ export class AmpImageViewer extends AMP.BaseElement {
    */
   // TODO (cathyxz): test on mobile and verify this works.
   registerOnResizeHandler_() {
+    this.cleanupOnResizeHandler_();
+
     const platform = Services.platformFor(this.win);
 
     // Special case for iOS browsers due to Webkit bug #170595
@@ -283,10 +284,12 @@ export class AmpImageViewer extends AMP.BaseElement {
   cleanupOnResizeHandler_() {
     if (this.unlistenResize_) {
       this.unlistenResize_();
+      this.unlistenResize_ = null;
     }
 
     if (this.unlistenOrientationChange_) {
       this.unlistenOrientationChange_();
+      this.unlistenOrientationChange_ = null;
     }
   }
 
@@ -435,6 +438,7 @@ export class AmpImageViewer extends AMP.BaseElement {
     // is a temporary solution to #12362. We should revisit this problem after
     // resolving #12881 or change the use of window.event to the specific event
     // triggering the gesture.
+    this.cleanupGestures_();
     this.gestures_ = Gestures.get(
         this.element,
         /* opt_shouldNotPreventDefault */true


### PR DESCRIPTION
Fixes this bug: Resizing the window causes entrance animation to zoom to (0,0,0,0) upper left corner on next lightbox open. 

Code changes: 

1. Carousel does an unlayout on resize. Since it does a scheduleLayout on the slide after an unlayout, the current slide should also be scheduled for unlayout on unlayout. /to @camelburrito 

2. Cleaned up setup and cleanup logic for `<amp-image-viewer>`'s onResize handler to guarantee that cleanup and initialization happens on pause / resume, unlayout / layout. /to @aghassemi @cvializ 