### PR TITLE
Add a Ctrl+C handler for `gulp watch | build | dist`

### DIFF
--- a/build-system/exec.js
+++ b/build-system/exec.js
@@ -45,6 +45,16 @@ exports.exec = function(cmd) {
 };
 
 /**
+ * Executes the provided command in an asynchronous process.
+ *
+ * @param {string} cmd
+ * @param {<Object>} options
+ */
+exports.execAsync = function(cmd, options) {
+  return childProcess.spawn(shellCmd, [shellFlag, cmd], options);
+};
+
+/**
  * Executes the provided command, and terminates the program in case of failure.
  *
  * @param {string} cmd Command line to execute.


### PR DESCRIPTION
Trying to cancel `gulp watch | build | dist` using `Ctrl + C` sometimes takes upwards of 30 seconds when the closure compiler is busy. This PR adds an async `SIGINT` handler that runs in the background during these tasks, that will immediately exit `gulp` when `Ctrl + C` is pressed during an ongoing build. The handler is cleaned up soon after the build is complete. Other `gulp` tasks remain unaffected by this change.

Fixes #13227