### PR TITLE
amp-bind: Warn during verify instead of error

### DIFF
--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -1024,11 +1024,11 @@ export class Bind {
     }
 
     if (!match) {
-      user().warn(`${TAG}: ` +
-        `Default value for <${tagName} [${property}]="${expressionString}"> ` +
-        `does not match first result (${expectedValue}). We recommend ` +
-        'writing expressions with matching default values, but this can be ' +
-        'safely ignored if intentional.');
+      user().warn(TAG,
+          `Default value for <${tagName} [${property}]="${expressionString}"> `
+          + `does not match first result (${expectedValue}). We recommend `
+          + 'writing expressions with matching default values, but this can be '
+          + 'safely ignored if intentional.');
     }
   }
 

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -962,11 +962,12 @@ export class Bind {
    * @private
    */
   verifyBinding_(boundProperty, element, expectedValue) {
-    const property = boundProperty.property;
+    const {property, expressionString} = boundProperty;
+    const tagName = element.tagName;
 
     // Don't show a warning for bind-only attributes,
     // like 'slide' on amp-carousel.
-    const bindOnlyAttrs = BIND_ONLY_ATTRIBUTES[element.tagName];
+    const bindOnlyAttrs = BIND_ONLY_ATTRIBUTES[tagName];
     if (bindOnlyAttrs && bindOnlyAttrs.includes(property)) {
       return;
     }
@@ -1023,11 +1024,11 @@ export class Bind {
     }
 
     if (!match) {
-      const err = user().createError(`${TAG}: ` +
-        `Default value for [${property}] does not match first expression ` +
-        `result (${expectedValue}). This can result in unexpected behavior ` +
-        'after the next state change.');
-      reportError(err, element);
+      user().warn(`${TAG}: ` +
+        `Default value for <${tagName} [${property}]="${expressionString}"> ` +
+        `does not match first result (${expectedValue}). We recommend ` +
+        'writing expressions with matching default values, but this can be ' +
+        'safely ignored if intentional.');
     }
   }
 

--- a/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
@@ -287,10 +287,10 @@ describe.configure().ifNewChrome().run('Bind', function() {
       createElement(env, container, '[class]="\'foo\'" class=" foo "');
       createElement(env, container, '[class]="\'\'"');
       createElement(env, container, '[class]="\'bar\'" class="qux"'); // Error
-      const errorSpy = env.sandbox.spy(user(), 'createError');
+      const warnSpy = env.sandbox.spy(user(), 'warn');
       return onBindReady(env, bind).then(() => {
-        expect(errorSpy).to.be.calledOnce;
-        expect(errorSpy).calledWithMatch(/bar/);
+        expect(warnSpy).to.be.calledOnce;
+        expect(warnSpy).calledWithMatch(/bar/);
       });
     });
 
@@ -298,9 +298,9 @@ describe.configure().ifNewChrome().run('Bind', function() {
       window.AMP_MODE = {development: true, test: true};
       // Only the initial value for [a] binding does not match.
       createElement(env, container, '[text]="\'a\'" [class]="\'b\'" class="b"');
-      const errorSpy = env.sandbox.spy(user(), 'createError');
+      const warnSpy = env.sandbox.spy(user(), 'warn');
       return onBindReady(env, bind).then(() => {
-        expect(errorSpy).to.be.calledOnce;
+        expect(warnSpy).to.be.calledOnce;
       });
     });
 
@@ -309,9 +309,9 @@ describe.configure().ifNewChrome().run('Bind', function() {
       createElement(env, container, '[disabled]="true" disabled', 'button');
       createElement(env, container, '[disabled]="false"', 'button');
       createElement(env, container, '[disabled]="true"', 'button'); // Mismatch.
-      const errorSpy = env.sandbox.spy(user(), 'createError');
+      const warnSpy = env.sandbox.spy(user(), 'warn');
       return onBindReady(env, bind).then(() => {
-        expect(errorSpy).to.be.calledOnce;
+        expect(warnSpy).to.be.calledOnce;
       });
     });
 

--- a/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
@@ -290,7 +290,7 @@ describe.configure().ifNewChrome().run('Bind', function() {
       const warnSpy = env.sandbox.spy(user(), 'warn');
       return onBindReady(env, bind).then(() => {
         expect(warnSpy).to.be.calledOnce;
-        expect(warnSpy).calledWithMatch(/bar/);
+        expect(warnSpy).calledWithMatch('amp-bind', /\[class\]/);
       });
     });
 
@@ -301,6 +301,7 @@ describe.configure().ifNewChrome().run('Bind', function() {
       const warnSpy = env.sandbox.spy(user(), 'warn');
       return onBindReady(env, bind).then(() => {
         expect(warnSpy).to.be.calledOnce;
+        expect(warnSpy).calledWithMatch('amp-bind', /\[text\]/);
       });
     });
 
@@ -312,6 +313,7 @@ describe.configure().ifNewChrome().run('Bind', function() {
       const warnSpy = env.sandbox.spy(user(), 'warn');
       return onBindReady(env, bind).then(() => {
         expect(warnSpy).to.be.calledOnce;
+        expect(warnSpy).calledWithMatch('amp-bind', /\[disabled\]/);
       });
     });
 


### PR DESCRIPTION
Also update the warning message to be less scary sounding. We've gotten a lot confused users due to this e.g. https://github.com/ampproject/amphtml/issues/9862#issuecomment-362627812.

/to @jridgewell @alabiaga 