### PR TITLE
Add a new gulp task for patchWebAnimations

### DIFF
--- a/build-system/ctrlcHandler.js
+++ b/build-system/ctrlcHandler.js
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const colors = require('ansi-colors');
+const log = require('fancy-log');
+const execAsync = require('./exec').execAsync;
+
+const green = colors.green;
+const cyan = colors.cyan;
+
+/**
+ * Creates an async child process that handles Ctrl + C and immediately cancels
+ * the ongoing `gulp watch | build | dist` task.
+ *
+ * @param {string} command
+ */
+exports.createCtrlcHandler = function(command) {
+  if (!process.env.TRAVIS) {
+    log(green('Running'), cyan(command) + green('. Press'), cyan('Ctrl + C'),
+        green('to cancel...'));
+  }
+  const killCmd =
+      (process.platform == 'win32') ? 'taskkill /pid' : 'kill -KILL';
+  const killMessage = green('\nDetected ') + cyan('Ctrl + C') +
+      green('. Canceling ') + cyan(command) + green('.');
+  const listenerCmd = `
+    #!/bin/sh
+    ctrlcHandler() {
+      echo -e "${killMessage}"
+      ${killCmd} ${process.pid}
+      exit 1
+    }
+    trap 'ctrlcHandler' INT
+    read _ # Waits until the process is terminated
+  `;
+  return execAsync(
+      listenerCmd, {'stdio': [null, process.stdout, process.stderr]}).pid;
+};
+
+/**
+ * Exits the Ctrl C handler process.
+ *
+ * @param {string} handlerProcess
+ */
+exports.exitCtrlcHandler = function(handlerProcess) {
+  process.kill(handlerProcess, 'SIGKILL');
+};

--- a/build-system/tasks/dep-check.js
+++ b/build-system/tasks/dep-check.js
@@ -28,6 +28,8 @@ const source = require('vinyl-source-stream');
 const through = require('through2');
 const colors = require('ansi-colors');
 const log = require('fancy-log');
+const createCtrlcHandler = require('../ctrlcHandler').createCtrlcHandler;
+const exitCtrlcHandler = require('../ctrlcHandler').exitCtrlcHandler;
 
 
 const root = process.cwd();
@@ -253,19 +255,17 @@ function runRules(modules) {
 }
 
 function depCheck() {
+  const handlerProcess = createCtrlcHandler('dep-check');
   return getSrcs().then(entryPoints => {
     // This check is for extension folders that actually dont have
     // an extension entry point module yet.
     entryPoints = entryPoints.filter(x => fs.existsSync(x));
     return BBPromise.all(entryPoints.map(getGraph));
-  })
-      .then(flattenGraph)
-      .then(runRules)
-      .then(errorsFound => {
-        if (errorsFound) {
-          process.exit(1);
-        }
-      });
+  }).then(flattenGraph).then(runRules).then(errorsFound => {
+    if (errorsFound) {
+      process.exit(1);
+    }
+  }).then(() => exitCtrlcHandler(handlerProcess));
 }
 
 /**
@@ -297,5 +297,6 @@ function flatten(arr) {
 gulp.task(
     'dep-check',
     'Runs a dependency check on each module',
-    ['css'], // Defined in gulpfile.js, and must be run before dep-check.
+    // Defined in gulpfile.js, and must be run before dep-check.
+    ['update-packages', 'patch-web-animations', 'css'],
     depCheck);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -455,7 +455,8 @@ function compileCss(watch) {
       bundleOnlyIfListedInFiles: false,
       compileOnlyCss: true
     });
-  });
+  })
+  .then(patchWebAnimations);
 }
 
 /**
@@ -619,7 +620,7 @@ function enableLocalTesting(targetFile) {
 function performBuild(watch) {
   process.env.NODE_ENV = 'development';
   printConfigHelp(watch ? 'gulp watch' : 'gulp build');
-  return compileCss(watch).then(patchWebAnimations).then(() => {
+  return compileCss(watch).then(() => {
     return Promise.all([
       polyfillsForTests(),
       buildAlp({watch: watch}),
@@ -661,7 +662,7 @@ function dist() {
   if (argv.fortesting) {
     printConfigHelp('gulp dist --fortesting')
   }
-  return compileCss().then(patchWebAnimations).then(() => {
+  return compileCss().then(() => {
     return Promise.all([
       compile(false, true, true),
       // NOTE:

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -38,10 +38,8 @@ var internalRuntimeVersion = require('./build-system/internal-version').VERSION;
 var internalRuntimeToken = require('./build-system/internal-version').TOKEN;
 var colors = require('ansi-colors');
 var log = require('fancy-log');
-var BBPromise = require('bluebird');
-var writeFileAsync = BBPromise.promisify(require('fs-extra').writeFile);
-var execAsync = require('./build-system/exec').execAsync;
-
+var createCtrlcHandler = require('./build-system/ctrlcHandler').createCtrlcHandler;
+var exitCtrlcHandler = require('./build-system/ctrlcHandler').exitCtrlcHandler;
 var argv = minimist(process.argv.slice(2), {boolean: ['strictBabelTransform']});
 
 require('./build-system/tasks');
@@ -455,8 +453,7 @@ function compileCss(watch) {
       bundleOnlyIfListedInFiles: false,
       compileOnlyCss: true
     });
-  })
-  .then(patchWebAnimations);
+  });
 }
 
 /**
@@ -1309,7 +1306,6 @@ function mkdirSync(path) {
  */
 function patchWebAnimations() {
   // Copies web-animations-js into a new file that has an export.
-  const startTime = Date.now();
   const patchedName = 'node_modules/web-animations-js/' +
       'web-animations.install.js';
   var file = fs.readFileSync(
@@ -1320,9 +1316,10 @@ function patchWebAnimations() {
       'var document = window.document;\n' +
       file + '\n' +
       '}\n';
-  return writeFileAsync(patchedName, file).then (() => {
-    endBuildStep('Wrote', patchedName, startTime);
-  });
+  fs.writeFileSync(patchedName, file);
+  if (!process.env.TRAVIS) {
+    log('Wrote', cyan(patchedName));
+  }
 }
 
 function toPromise(readable) {
@@ -1332,69 +1329,36 @@ function toPromise(readable) {
 }
 
 /**
- * Creates an async child process that handles Ctrl + C and immediately cancels
- * the ongoing `gulp watch | build | dist` task.
- *
- * @param {string} command.
- */
-function createCtrlcHandler(command) {
-  if (!process.env.TRAVIS) {
-    log(green('Running'), cyan(command) + green('. Press'), cyan('Ctrl + C'),
-        green('to cancel...'));
-  }
-  const killCmd =
-      (process.platform == 'win32') ? 'taskkill /pid' : 'kill -KILL';
-  const killMessage = green('\nDetected ') + cyan('Ctrl + C') +
-      green ('. Canceling ') + cyan(command) + green('.');
-  const listenerCmd = `
-    #!/bin/sh
-    ctrlcHandler() {
-      echo -e "${killMessage}"
-      ${killCmd} ${process.pid}
-      exit 1
-    }
-    trap 'ctrlcHandler' INT
-    read _ # Waits until the process is terminated
-  `;
-  return execAsync(
-      listenerCmd, {'stdio': [null, process.stdout, process.stderr]}).pid;
-}
-
-/**
- * Exits the Ctrl C handler process.
- *
- * @param {string} handlerProcess
- */
-function exitCtrlcHandler(handlerProcess) {
-  process.kill(handlerProcess, 'SIGKILL');
-}
-
-/**
  * Gulp tasks
  */
-gulp.task('build', 'Builds the AMP library', ['update-packages'], build, {
-  options: {
-    config: '  Sets the runtime\'s AMP_CONFIG to one of "prod" or "canary"',
-  }
-});
+gulp.task('build', 'Builds the AMP library',
+    ['update-packages', 'patch-web-animations'], build, {
+      options: {
+        config: '  Sets the runtime\'s AMP_CONFIG to one of "prod" or "canary"',
+      }
+    });
 gulp.task('check-all', 'Run through all presubmit checks',
     ['lint', 'dep-check', 'check-types', 'presubmit']);
 gulp.task('check-types', 'Check JS types', checkTypes);
+gulp.task('patch-web-animations',
+    'Patches the Web Animations API with an install function',
+    ['update-packages'], patchWebAnimations);
 gulp.task('css', 'Recompile css to build directory', ['update-packages'], css);
 gulp.task('default', 'Runs "watch" and then "serve"',
     ['update-packages', 'watch'], serve);
-gulp.task('dist', 'Build production binaries', ['update-packages'], dist, {
-  options: {
-    pseudo_names: '  Compiles with readable names. ' +
-        'Great for profiling and debugging production code.',
-    fortesting: '  Compiles production binaries for local testing',
-    config: '  Sets the runtime\'s AMP_CONFIG to one of "prod" or "canary"',
-    minimal_set: '  Only compile files needed to load article.amp.html',
-  }
-});
+gulp.task('dist', 'Build production binaries',
+    ['update-packages', 'patch-web-animations'], dist, {
+      options: {
+        pseudo_names: '  Compiles with readable names. ' +
+            'Great for profiling and debugging production code.',
+        fortesting: '  Compiles production binaries for local testing',
+        config: '  Sets the runtime\'s AMP_CONFIG to one of "prod" or "canary"',
+        minimal_set: '  Only compile files needed to load article.amp.html',
+      }
+    });
 gulp.task('extensions', 'Build AMP Extensions', buildExtensions);
 gulp.task('watch', 'Watches for changes in files, re-builds when detected',
-    ['update-packages'], watch, {
+    ['update-packages', 'patch-web-animations'], watch, {
       options: {
         with_inabox: '  Also watch and build the amp-inabox.js binary.',
         with_shadow: '  Also watch and build the amp-shadow.js binary.',


### PR DESCRIPTION
#13199 moved the call to `patchWebAnimations()` from the global scope in `gulpfile.js` to `performBuild()`, which is called by `build()` and `watch()`. Then, #13221 added a call to `dist()`. Turns out we need the call in `gulp dep-check` as well.

This PR adds a new `gulp patch-web-animations` task that's used as a prerequisite for `gulp`, `gulp build`, `gulp watch`, `gulp dist`, and `gulp dep-check`

See https://travis-ci.org/ampproject/amphtml/jobs/336675870#L1736 for the failure case.

Follow up to #13199 and #13221
Fixes #13177 