### PR TITLE
Set muted property on media elements

### DIFF
--- a/extensions/amp-story/0.1/media-pool.js
+++ b/extensions/amp-story/0.1/media-pool.js
@@ -171,6 +171,7 @@ export class MediaPool {
         const audioEl = this.win_.document.createElement('audio');
         audioEl.setAttribute('src', BLANK_AUDIO_SRC);
         audioEl.setAttribute('muted', '');
+        audioEl.muted = true;
         audioEl.classList.add('i-amphtml-pool-media');
         audioEl.classList.add('i-amphtml-pool-audio');
         return audioEl;
@@ -179,6 +180,7 @@ export class MediaPool {
         const videoEl = this.win_.document.createElement('video');
         videoEl.setAttribute('src', BLANK_VIDEO_SRC);
         videoEl.setAttribute('muted', '');
+        videoEl.muted = true;
         videoEl.setAttribute('playsinline', '');
         videoEl.classList.add('i-amphtml-pool-media');
         videoEl.classList.add('i-amphtml-pool-video');


### PR DESCRIPTION
Fixes an issue where, on some devices, media is not muted by default (and as such, although the story appears muted while navigating, media elements end up playing sound anyway).