### PR TITLE
Update amp-iframe container in build callback

### DIFF
--- a/extensions/amp-iframe/0.1/amp-iframe.js
+++ b/extensions/amp-iframe/0.1/amp-iframe.js
@@ -105,7 +105,11 @@ export class AmpIframe extends AMP.BaseElement {
      **/
     this.iframeSrc = null;
 
-    /** @private {?Element} */
+    /**
+     * The element which will contain the iframe. This may be the amp-iframe
+     * itself if the iframe is non-scrolling, or a wrapper element if it is.
+     * @private {?Element}
+     */
     this.container_ = null;
 
     /** @private {boolean|undefined} */
@@ -215,13 +219,6 @@ export class AmpIframe extends AMP.BaseElement {
             this.element.getAttribute('srcdoc'), this.sandbox_);
     this.iframeSrc = this.assertSource(
         iframeSrc, window.location.href, this.sandbox_);
-
-    /**
-     * The element which will contain the iframe. This may be the amp-iframe
-     * itself if the iframe is non-scrolling, or a wrapper element if it is.
-     * @type {!Element}
-     */
-    this.container_ = makeIOsScrollable(this.element);
   }
 
   /**
@@ -246,6 +243,8 @@ export class AmpIframe extends AMP.BaseElement {
     if (!this.element.hasAttribute('frameborder')) {
       this.element.setAttribute('frameborder', '0');
     }
+
+    this.container_ = makeIOsScrollable(this.element);
   }
 
   /**


### PR DESCRIPTION
`#buildCallback` is a blessed mutation phase event, and `#firstAttachedCallback` is not. Do not mutate things inside `#firstAttachedCallback`.

Identified with [black magic](https://github.com/ampproject/amphtml/pull/13223).