### PR TITLE
Initialize DOM for page scaling

### DIFF
--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -288,6 +288,11 @@ export class AmpStory extends AMP.BaseElement {
       }, html);
     }
 
+    if (this.isDesktop_()) {
+      this.element.setAttribute('desktop','');
+    }
+    this.element.querySelector('amp-story-page').setAttribute('active', '');
+
     this.initializeListeners_();
     this.initializeListenersForDev_();
 


### PR DESCRIPTION
Page scaling service expects an active amp-story-page for measuring.