### PR TITLE
Fail build on compiler error, after printing a useful message

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -954,11 +954,10 @@ function compileJs(srcDir, srcFilename, destDir, options) {
     const startTime = Date.now();
     return toPromise(bundler.bundle()
       .on('error', function(err) {
-        if (err instanceof SyntaxError) {
-          console.error(red('Syntax error: ' + err.message));
-        } else {
-          console.error(red(err.message));
-        }
+        // Drop the node_modules call stack, which begins with '    at'.
+        const message = err.stack.replace(/    at[^]*/, '').trim();
+        console.error(red(message));
+        process.exit(1);
       })
       .pipe(lazybuild())
       .pipe($$.rename(destFilename))


### PR DESCRIPTION
This PR causes the build to fail after a compiler error, after printing a useful message.

**Syntax error:**
```
SyntaxError: amphtml/src/foo.js: Unexpected token (20:6)
  18 | 
  19 | if (foo) {
> 20 |   bar(;
     |       ^
  21 | }
  22 | 
```

**Other errors, like bad imports:**
```
Error: Cannot find module './bar' from 'amphtml/src/foo'
```
Fixes #1213
