### PR TITLE
Run lint and presubmit on gulpfile.js

### DIFF
--- a/build-system/check-package-manager.js
+++ b/build-system/check-package-manager.js
@@ -35,24 +35,22 @@ function main() {
 
   // If npm is being run, print a message and cause 'npm install' to fail.
   if (process.env.npm_execpath.indexOf('yarn') === -1) {
-    console/*OK*/.log(red(
+    console.log(red(
         '*** The AMP project uses yarn for package management ***'), '\n');
-    console/*OK*/.log(yellow('To install all packages:'));
-    console/*OK*/.log(cyan('$'), 'yarn', '\n');
-    console/*OK*/.log(
+    console.log(yellow('To install all packages:'));
+    console.log(cyan('$'), 'yarn', '\n');
+    console.log(
         yellow('To install a new (runtime) package to "dependencies":'));
-    console/*OK*/.log(cyan('$'),
-        'yarn add --exact [package_name@version]', '\n');
-    console/*OK*/.log(
+    console.log(cyan('$'), 'yarn add --exact [package_name@version]', '\n');
+    console.log(
         yellow('To install a new (toolset) package to "devDependencies":'));
-    console/*OK*/.log(cyan('$'),
+    console.log(cyan('$'),
         'yarn add --dev --exact [package_name@version]', '\n');
-    console/*OK*/.log(yellow('To upgrade a package:'));
-    console/*OK*/.log(cyan('$'),
-        'yarn upgrade --exact [package_name@version]', '\n');
-    console/*OK*/.log(yellow('To remove a package:'));
-    console/*OK*/.log(cyan('$'), 'yarn remove [package_name]', '\n');
-    console/*OK*/.log(yellow('For detailed instructions, see'),
+    console.log(yellow('To upgrade a package:'));
+    console.log(cyan('$'), 'yarn upgrade --exact [package_name@version]', '\n');
+    console.log(yellow('To remove a package:'));
+    console.log(cyan('$'), 'yarn remove [package_name]', '\n');
+    console.log(yellow('For detailed instructions, see'),
         cyan(setupInstructionsUrl), '\n');
     return 1;
   }
@@ -65,15 +63,15 @@ function main() {
   }
   majorVersion = parseInt(majorVersion, 10);
   if (majorVersion < 6 || majorVersion == 7) {
-    console/*OK*/.log(yellow('WARNING: Detected node version'),
+    console.log(yellow('WARNING: Detected node version'),
         cyan(nodeVersion) + yellow('. Recommended version is'),
         cyan('v6') + yellow('.'));
-    console/*OK*/.log(yellow('To fix this, run'),
+    console.log(yellow('To fix this, run'),
         cyan('"nvm install 6"'), yellow('or see'),
         cyan('https://nodejs.org/en/download/package-manager'),
         yellow('for instructions.'));
   } else {
-    console/*OK*/.log(green('Detected node version'), cyan(nodeVersion) +
+    console.log(green('Detected node version'), cyan(nodeVersion) +
         green('.'));
   }
 
@@ -82,16 +80,16 @@ function main() {
   const major = parseInt(yarnVersion.split('.')[0], 10);
   const minor = parseInt(yarnVersion.split('.')[1], 10);
   if ((major < 1) || (minor < 2)) {
-    console/*OK*/.log(yellow('WARNING: Detected yarn version'),
+    console.log(yellow('WARNING: Detected yarn version'),
         cyan(yarnVersion) + yellow('. Minimum recommended version is'),
         cyan('1.2.0') + yellow('.'));
-    console/*OK*/.log(yellow('To upgrade, run'),
+    console.log(yellow('To upgrade, run'),
         cyan('"curl -o- -L https://yarnpkg.com/install.sh | bash"'),
         yellow('or see'), cyan('https://yarnpkg.com/docs/install'),
         yellow('for instructions.'));
-    console/*OK*/.log(yellow('Attempting to install packages...'));
+    console.log(yellow('Attempting to install packages...'));
   } else {
-    console/*OK*/.log(green('Detected yarn version'), cyan(yarnVersion) +
+    console.log(green('Detected yarn version'), cyan(yarnVersion) +
         green('. Installing packages...'));
   };
   return 0;

--- a/build-system/config.js
+++ b/build-system/config.js
@@ -116,7 +116,6 @@ module.exports = {
     // TODO: temporary, remove when validator is up to date
     '!validator/**/*.*',
     '!eslint-rules/**/*.*',
-    '!gulpfile.js',
     '!karma.conf.js',
     '!**/local-amp-chrome-extension/background.js',
     '!extensions/amp-access/0.1/access-expr-impl.js',

--- a/build-system/config.js
+++ b/build-system/config.js
@@ -145,7 +145,6 @@ module.exports = {
     '!build-system/tasks/presubmit-checks.js',
     '!build/polyfills.js',
     '!build/polyfills/*.js',
-    '!gulpfile.js',
     '!third_party/**/*.*',
     '!validator/chromeextension/*.*',
     // Files in this testdata dir are machine-generated and are not part

--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -90,7 +90,7 @@ const forbiddenTerms = {
         '  If this is cross domain, overwrite the method directly.',
   },
   'console\\.\\w+\\(': {
-    message: 'If you run against this, use console/*OK*/. to ' +
+    message: 'If you run against this, use console/*OK*/.[log|error] to ' +
       'whitelist a legit case.',
     whitelist: [
       'build-system/pr-check.js',

--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -90,7 +90,7 @@ const forbiddenTerms = {
         '  If this is cross domain, overwrite the method directly.',
   },
   'console\\.\\w+\\(': {
-    message: 'If you run against this, use console/*OK*/.log to ' +
+    message: 'If you run against this, use console/*OK*/. to ' +
       'whitelist a legit case.',
     whitelist: [
       'build-system/pr-check.js',
@@ -99,6 +99,7 @@ const forbiddenTerms = {
       'validator/engine/parse-css.js',
       'validator/engine/validator-in-browser.js',
       'validator/engine/validator.js',
+      'gulpfile.js',
     ],
     checkInTestFolder: true,
   },
@@ -575,6 +576,7 @@ const forbiddenTerms = {
       'src/worker-error-reporting.js',
       'tools/experiments/experiments.js',
       'build-system/amp4test.js',
+      'gulpfile.js',
     ],
   },
   'data:image/svg(?!\\+xml;charset=utf-8,)[^,]*,': {
@@ -843,6 +845,7 @@ const forbiddenTermsSrcInclusive = {
       'validator/webui/serve-standalone.go',
       'build-system/tasks/check-links.js',
       'build-system/tasks/extension-generator/index.js',
+      'gulpfile.js',
     ],
   },
   '\\<\\<\\<\\<\\<\\<': {

--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -95,6 +95,7 @@ const forbiddenTerms = {
     whitelist: [
       'build-system/pr-check.js',
       'build-system/app.js',
+      'build-system/check-package-manager.js',
       'validator/nodejs/index.js', // NodeJs only.
       'validator/engine/parse-css.js',
       'validator/engine/validator-in-browser.js',

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -19,29 +19,29 @@
 checkMinVersion();
 
 const $$ = require('gulp-load-plugins')();
+const applyConfig = require('./build-system/tasks/prepend-global/index.js').applyConfig;
 const babel = require('babelify');
 const browserify = require('browserify');
 const buffer = require('vinyl-buffer');
-const closureCompile = require('./build-system/tasks/compile').closureCompile;
 const cleanupBuildDir = require('./build-system/tasks/compile').cleanupBuildDir;
-const jsifyCssAsync = require('./build-system/tasks/jsify-css').jsifyCssAsync;
-const applyConfig = require('./build-system/tasks/prepend-global/index.js').applyConfig;
-const removeConfig = require('./build-system/tasks/prepend-global/index.js').removeConfig;
-const serve = require('./build-system/tasks/serve.js').serve;
+const closureCompile = require('./build-system/tasks/compile').closureCompile;
+const colors = require('ansi-colors');
+const createCtrlcHandler = require('./build-system/ctrlcHandler').createCtrlcHandler;
+const exitCtrlcHandler = require('./build-system/ctrlcHandler').exitCtrlcHandler;
 const fs = require('fs-extra');
 const gulp = $$.help(require('gulp'));
+const internalRuntimeToken = require('./build-system/internal-version').TOKEN;
+const internalRuntimeVersion = require('./build-system/internal-version').VERSION;
+const jsifyCssAsync = require('./build-system/tasks/jsify-css').jsifyCssAsync;
 const lazypipe = require('lazypipe');
+const log = require('fancy-log');
 const minimatch = require('minimatch');
 const minimist = require('minimist');
+const removeConfig = require('./build-system/tasks/prepend-global/index.js').removeConfig;
+const serve = require('./build-system/tasks/serve.js').serve;
 const source = require('vinyl-source-stream');
 const touch = require('touch');
 const watchify = require('watchify');
-const internalRuntimeVersion = require('./build-system/internal-version').VERSION;
-const internalRuntimeToken = require('./build-system/internal-version').TOKEN;
-const colors = require('ansi-colors');
-const log = require('fancy-log');
-const createCtrlcHandler = require('./build-system/ctrlcHandler').createCtrlcHandler;
-const exitCtrlcHandler = require('./build-system/ctrlcHandler').exitCtrlcHandler;
 const argv = minimist(
     process.argv.slice(2), {boolean: ['strictBabelTransform']});
 
@@ -625,7 +625,7 @@ function parseExtensionFlags() {
         green('to build just the extensions needed to load ') +
         cyan('article.amp.html') + green('.');
     if (argv.extensions) {
-      if (typeof(argv.extensions) !== 'string') {
+      if (typeof (argv.extensions) !== 'string') {
         log(red('ERROR:'), 'Missing list of extensions.');
         log(noExtensionsMessage);
         log(extensionsMessage);
@@ -761,12 +761,12 @@ function copyAliasExtensions() {
   if (argv.noextensions) {
     return;
   }
-  var extensionsToBuild = [];
+  let extensionsToBuild = [];
   if (!!argv.extensions) {
     extensionsToBuild = argv.extensions.split(',');
   }
 
-  for (var key in extensionAliasFilePath) {
+  for (const key in extensionAliasFilePath) {
     if (extensionsToBuild.length > 0 &&
         extensionsToBuild.indexOf(extensionAliasFilePath[key]['name']) == -1) {
       continue;
@@ -1423,7 +1423,7 @@ gulp.task('dist', 'Build production binaries',
             'Great for profiling and debugging production code.',
         fortesting: '  Compiles production binaries for local testing',
         config: '  Sets the runtime\'s AMP_CONFIG to one of "prod" or "canary"',
-      }
+      },
     });
 gulp.task('watch', 'Watches for changes in files, re-builds when detected',
     ['update-packages', 'patch-web-animations'], watch, {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -725,7 +725,6 @@ function dist() {
   }
   parseExtensionFlags();
   return compileCss().then(() => {
-    log('---------------> creating promises');
     return Promise.all([
       compile(false, true, true),
       // NOTE:
@@ -999,50 +998,36 @@ function compileJs(srcDir, srcFilename, destDir, options) {
   const destFilename = options.toName || srcFilename;
   function rebundle() {
     const startTime = Date.now();
-    return toPromise(bundler.bundle()
-      .on('error', function(err) {
-        // Drop the node_modules call stack, which begins with '    at'.
-        const message = err.stack.replace(/    at[^]*/, '').trim();
-        console.error(red(message));
-        process.exit(1);
-      })
-      .pipe(lazybuild())
-      .pipe($$.rename(destFilename))
-      .pipe(lazywrite())
-      .on('end', function() {
-        appendToCompiledFile(srcFilename, destDir + '/' + destFilename);
-      })).then(() => {
-        endBuildStep('Compiled', srcFilename, startTime);
-      }).then(() => {
-        if (process.env.NODE_ENV === 'development') {
-          if (srcFilename === 'amp.js') {
-            return enableLocalTesting(unminifiedRuntimeTarget);
-          } else if (srcFilename === 'integration.js') {
-            return enableLocalTesting(unminified3pTarget);
-          } else {
-            log(red(err.message));
-          }
+    return toPromise(
+        bundler.bundle()
+            .on('error', function(err) {
+              // Drop the node_modules call stack, which begins with '    at'.
+              const message = err.stack.replace(/    at[^]*/, '').trim();
+              console.error(red(message));
+              process.exit(1);
+            })
+            .pipe(lazybuild())
+            .pipe($$.rename(destFilename))
+            .pipe(lazywrite())
+            .on('end', function() {
+              appendToCompiledFile(srcFilename, destDir + '/' + destFilename);
+            }))
+        .then(() => {
+          endBuildStep('Compiled', srcFilename, startTime);
         })
-        .pipe(lazybuild())
-        .pipe($$.rename(destFilename))
-        .pipe(lazywrite())
-        .on('end', function() {
-          appendToCompiledFile(srcFilename, destDir + '/' + destFilename);
-        })).then(() => {
-      endBuildStep('Compiled', srcFilename, startTime);
-    }).then(() => {
-      if (process.env.NODE_ENV === 'development') {
-        if (srcFilename === 'amp.js') {
-          return enableLocalTesting(unminifiedRuntimeTarget);
-        } else if (srcFilename === 'integration.js') {
-          return enableLocalTesting(unminified3pTarget);
-        } else {
-          return Promise.resolve();
-        }
-      } else {
-        return Promise.resolve();
-      }
-    });
+        .then(() => {
+          if (process.env.NODE_ENV === 'development') {
+            if (srcFilename === 'amp.js') {
+              return enableLocalTesting(unminifiedRuntimeTarget);
+            } else if (srcFilename === 'integration.js') {
+              return enableLocalTesting(unminified3pTarget);
+            } else {
+              return Promise.resolve();
+            }
+          } else {
+            return Promise.resolve();
+          }
+        });
   }
 
   if (options.watch) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,52 +14,54 @@
  * limitations under the License.
  */
 
+/* global require, process */
+
 checkMinVersion();
 
-var $$ = require('gulp-load-plugins')();
-var babel = require('babelify');
-var browserify = require('browserify');
-var buffer = require('vinyl-buffer');
-var closureCompile = require('./build-system/tasks/compile').closureCompile;
-var cleanupBuildDir = require('./build-system/tasks/compile').cleanupBuildDir;
-var jsifyCssAsync = require('./build-system/tasks/jsify-css').jsifyCssAsync;
-var applyConfig = require('./build-system/tasks/prepend-global/index.js').applyConfig;
-var removeConfig = require('./build-system/tasks/prepend-global/index.js').removeConfig;
-var serve = require('./build-system/tasks/serve.js').serve;
-var fs = require('fs-extra');
-var gulp = $$.help(require('gulp'));
-var lazypipe = require('lazypipe');
-var minimatch = require('minimatch');
-var minimist = require('minimist');
-var source = require('vinyl-source-stream');
-var touch = require('touch');
-var watchify = require('watchify');
-var internalRuntimeVersion = require('./build-system/internal-version').VERSION;
-var internalRuntimeToken = require('./build-system/internal-version').TOKEN;
-var colors = require('ansi-colors');
-var log = require('fancy-log');
-var createCtrlcHandler = require('./build-system/ctrlcHandler').createCtrlcHandler;
-var exitCtrlcHandler = require('./build-system/ctrlcHandler').exitCtrlcHandler;
-var argv = minimist(process.argv.slice(2), {boolean: ['strictBabelTransform']});
+const $$ = require('gulp-load-plugins')();
+const babel = require('babelify');
+const browserify = require('browserify');
+const buffer = require('vinyl-buffer');
+const closureCompile = require('./build-system/tasks/compile').closureCompile;
+const cleanupBuildDir = require('./build-system/tasks/compile').cleanupBuildDir;
+const jsifyCssAsync = require('./build-system/tasks/jsify-css').jsifyCssAsync;
+const applyConfig = require('./build-system/tasks/prepend-global/index.js').applyConfig;
+const removeConfig = require('./build-system/tasks/prepend-global/index.js').removeConfig;
+const serve = require('./build-system/tasks/serve.js').serve;
+const fs = require('fs-extra');
+const gulp = $$.help(require('gulp'));
+const lazypipe = require('lazypipe');
+const minimatch = require('minimatch');
+const minimist = require('minimist');
+const source = require('vinyl-source-stream');
+const touch = require('touch');
+const watchify = require('watchify');
+const internalRuntimeVersion = require('./build-system/internal-version').VERSION;
+const internalRuntimeToken = require('./build-system/internal-version').TOKEN;
+const colors = require('ansi-colors');
+const log = require('fancy-log');
+const createCtrlcHandler = require('./build-system/ctrlcHandler').createCtrlcHandler;
+const exitCtrlcHandler = require('./build-system/ctrlcHandler').exitCtrlcHandler;
+const argv = minimist(
+    process.argv.slice(2), {boolean: ['strictBabelTransform']});
 
 require('./build-system/tasks');
 
-var hostname = argv.hostname || 'cdn.ampproject.org';
-var hostname3p = argv.hostname3p || '3p.ampproject.net';
+const hostname = argv.hostname || 'cdn.ampproject.org';
+const hostname3p = argv.hostname3p || '3p.ampproject.net';
 
 // All declared extensions.
-var extensions = {};
-var extensionAliasFilePath = {};
+const extensions = {};
+const extensionAliasFilePath = {};
 
-var green = colors.green;
-var yellow = colors.yellow;
-var red = colors.red;
-var cyan = colors.cyan;
+const green = colors.green;
+const red = colors.red;
+const cyan = colors.cyan;
 
-var minifiedRuntimeTarget = 'dist/v0.js';
-var minified3pTarget = 'dist.3p/current-min/f.js';
-var unminifiedRuntimeTarget = 'dist/amp.js';
-var unminified3pTarget = 'dist.3p/current/integration.js';
+const minifiedRuntimeTarget = 'dist/v0.js';
+const minified3pTarget = 'dist.3p/current-min/f.js';
+const unminifiedRuntimeTarget = 'dist/amp.js';
+const unminified3pTarget = 'dist.3p/current/integration.js';
 
 // Each extension and version must be listed individually here.
 declareExtension('amp-3q-player', '0.1', {hasCss: false});
@@ -176,7 +178,7 @@ declareExtensionVersionAlias(
  *   loadPriority: ?string
  * }}
  */
-const ExtensionOption = {};
+const ExtensionOption = {}; // eslint-disable-line no-unused-vars
 
 /**
  * @param {string} name
@@ -227,7 +229,7 @@ function endBuildStep(stepName, targetName, startTime) {
   const executionTime = new Date(endTime - startTime);
   const secs = executionTime.getSeconds();
   const ms = ('000' + executionTime.getMilliseconds().toString()).slice(-3);
-  var timeString = '(';
+  let timeString = '(';
   if (secs === 0) {
     timeString += ms + ' ms)';
   } else {
@@ -249,19 +251,19 @@ function buildExtensions(options) {
     return Promise.resolve();
   }
 
-  var extensionsToBuild = [];
+  let extensionsToBuild = [];
   if (!!argv.extensions) {
     extensionsToBuild = argv.extensions.split(',');
   }
 
-  var results = [];
-  for (var key in extensions) {
+  const results = [];
+  for (const key in extensions) {
     if (extensionsToBuild.length > 0 &&
         extensionsToBuild.indexOf(extensions[key].name) == -1) {
       continue;
     }
-    var e = extensions[key];
-    var o = Object.assign({}, options);
+    const e = extensions[key];
+    let o = Object.assign({}, options);
     o = Object.assign(o, e);
     results.push(buildExtension(e.name, e.version, e.hasCss, o, e.extraGlobs));
   }
@@ -287,46 +289,46 @@ function polyfillsForTests() {
  * @return {!Promise}
  */
 function compile(watch, shouldMinify, opt_preventRemoveAndMakeDir,
-    opt_checkTypes) {
-  var promises = [
+  opt_checkTypes) {
+  const promises = [
     compileJs('./3p/', 'integration.js',
         './dist.3p/' + (shouldMinify ? internalRuntimeVersion : 'current'), {
-      minifiedName: 'f.js',
-      checkTypes: opt_checkTypes,
-      watch: watch,
-      minify: shouldMinify,
-      preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
-      externs: ['ads/ads.extern.js',],
-      include3pDirectories: true,
-      includePolyfills: true,
-    }),
+          minifiedName: 'f.js',
+          checkTypes: opt_checkTypes,
+          watch,
+          minify: shouldMinify,
+          preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
+          externs: ['ads/ads.extern.js'],
+          include3pDirectories: true,
+          includePolyfills: true,
+        }),
     compileJs('./3p/', 'ampcontext-lib.js',
         './dist.3p/' + (shouldMinify ? internalRuntimeVersion : 'current'), {
-      minifiedName: 'ampcontext-v0.js',
-      checkTypes: opt_checkTypes,
-      watch: watch,
-      minify: shouldMinify,
-      preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
-      externs: ['ads/ads.extern.js',],
-      include3pDirectories: true,
-      includePolyfills: false,
-    }),
+          minifiedName: 'ampcontext-v0.js',
+          checkTypes: opt_checkTypes,
+          watch,
+          minify: shouldMinify,
+          preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
+          externs: ['ads/ads.extern.js'],
+          include3pDirectories: true,
+          includePolyfills: false,
+        }),
     compileJs('./3p/', 'iframe-transport-client-lib.js',
         './dist.3p/' + (shouldMinify ? internalRuntimeVersion : 'current'), {
-      minifiedName: 'iframe-transport-client-v0.js',
-      checkTypes: opt_checkTypes,
-      watch: watch,
-      minify: shouldMinify,
-      preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
-      externs: ['ads/ads.extern.js',],
-      include3pDirectories: true,
-      includePolyfills: false,
-    }),
+          minifiedName: 'iframe-transport-client-v0.js',
+          checkTypes: opt_checkTypes,
+          watch,
+          minify: shouldMinify,
+          preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
+          externs: ['ads/ads.extern.js'],
+          include3pDirectories: true,
+          includePolyfills: false,
+        }),
     compileJs('./src/', 'amp.js', './dist', {
       minifiedName: 'v0.js',
       includePolyfills: true,
       checkTypes: opt_checkTypes,
-      watch: watch,
+      watch,
       preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
       minify: shouldMinify,
       // If there is a sync JS error during initial load,
@@ -337,70 +339,70 @@ function compile(watch, shouldMinify, opt_preventRemoveAndMakeDir,
           's.opacity=1;' +
           's.visibility="visible";' +
           's.animation="none";' +
-          's.WebkitAnimation="none;"},1000);throw e};'
+          's.WebkitAnimation="none;"},1000);throw e};',
     }),
     compileJs('./extensions/amp-viewer-integration/0.1/examples/',
-      'amp-viewer-host.js', './dist/v0/examples', {
-        toName: 'amp-viewer-host.max.js',
-        minifiedName: 'amp-viewer-host.js',
-        incudePolyfills: true,
-        watch: watch,
-        extraGlobs: ['extensions/amp-viewer-integration/**/*.js'],
-        compilationLevel: 'WHITESPACE_ONLY',
-        preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
-        minify: false,
-      }),
+        'amp-viewer-host.js', './dist/v0/examples', {
+          toName: 'amp-viewer-host.max.js',
+          minifiedName: 'amp-viewer-host.js',
+          incudePolyfills: true,
+          watch,
+          extraGlobs: ['extensions/amp-viewer-integration/**/*.js'],
+          compilationLevel: 'WHITESPACE_ONLY',
+          preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
+          minify: false,
+        }),
   ];
 
   // We don't rerun type check for the shadow entry point for now.
   if (!opt_checkTypes) {
     if (!watch || argv.with_shadow) {
       promises.push(
-        compileJs('./src/', 'amp-shadow.js', './dist', {
-          minifiedName: 'shadow-v0.js',
-          includePolyfills: true,
-          checkTypes: opt_checkTypes,
-          watch: watch,
-          preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
-          minify: shouldMinify,
-        })
+          compileJs('./src/', 'amp-shadow.js', './dist', {
+            minifiedName: 'shadow-v0.js',
+            includePolyfills: true,
+            checkTypes: opt_checkTypes,
+            watch,
+            preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
+            minify: shouldMinify,
+          })
       );
     }
 
     if (!watch || argv.with_inabox) {
       promises.push(
-        // Entry point for inabox runtime.
-        compileJs('./src/inabox/', 'amp-inabox.js', './dist', {
-          toName: 'amp-inabox.js',
-          minifiedName: 'amp4ads-v0.js',
-          includePolyfills: true,
-          extraGlobs: ['src/inabox/*.js', '3p/iframe-messaging-client.js'],
-          checkTypes: opt_checkTypes,
-          watch: watch,
-          preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
-          minify: shouldMinify,
-          wrapper: '<%= contents %>',
-        }),
+          // Entry point for inabox runtime.
+          compileJs('./src/inabox/', 'amp-inabox.js', './dist', {
+            toName: 'amp-inabox.js',
+            minifiedName: 'amp4ads-v0.js',
+            includePolyfills: true,
+            extraGlobs: ['src/inabox/*.js', '3p/iframe-messaging-client.js'],
+            checkTypes: opt_checkTypes,
+            watch,
+            preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
+            minify: shouldMinify,
+            wrapper: '<%= contents %>',
+          }),
 
-        // inabox-host
-        compileJs('./ads/inabox/', 'inabox-host.js', './dist', {
-          toName: 'amp-inabox-host.js',
-          minifiedName: 'amp4ads-host-v0.js',
-          includePolyfills: false,
-          checkTypes: opt_checkTypes,
-          watch: watch,
-          preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
-          minify: shouldMinify,
-          wrapper: '<%= contents %>',
-        })
+          // inabox-host
+          compileJs('./ads/inabox/', 'inabox-host.js', './dist', {
+            toName: 'amp-inabox-host.js',
+            minifiedName: 'amp4ads-host-v0.js',
+            includePolyfills: false,
+            checkTypes: opt_checkTypes,
+            watch,
+            preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
+            minify: shouldMinify,
+            wrapper: '<%= contents %>',
+          })
       );
     }
 
     promises.push(
-      thirdPartyBootstrap(
-          '3p/frame.max.html', 'frame.html', shouldMinify),
-      thirdPartyBootstrap(
-          '3p/nameframe.max.html', 'nameframe.html',shouldMinify)
+        thirdPartyBootstrap(
+            '3p/frame.max.html', 'frame.html', shouldMinify),
+        thirdPartyBootstrap(
+            '3p/nameframe.max.html', 'nameframe.html',shouldMinify)
     );
 
     if (watch) {
@@ -447,26 +449,26 @@ function compileCss(watch) {
 
   const startTime = Date.now();
   return jsifyCssAsync('css/amp.css')
-  .then(function(css) {
-    return toPromise(gulp.src('css/**.css')
-          .pipe($$.file('css.js', 'export const cssText = ' +
+      .then(function(css) {
+        return toPromise(gulp.src('css/**.css')
+            .pipe($$.file('css.js', 'export const cssText = ' +
               JSON.stringify(css)))
-          .pipe(gulp.dest('build'))
-          .on('end', function() {
-            mkdirSync('build');
-            mkdirSync('build/css');
-            fs.writeFileSync('build/css/v0.css', css);
-          }));
-  })
-  .then(() => {
-    endBuildStep('Recompiled CSS in', 'amp.css', startTime);
-  })
-  .then(() => {
-    return buildExtensions({
-      bundleOnlyIfListedInFiles: false,
-      compileOnlyCss: true
-    });
-  });
+            .pipe(gulp.dest('build'))
+            .on('end', function() {
+              mkdirSync('build');
+              mkdirSync('build/css');
+              fs.writeFileSync('build/css/v0.css', css);
+            }));
+      })
+      .then(() => {
+        endBuildStep('Recompiled CSS in', 'amp.css', startTime);
+      })
+      .then(() => {
+        return buildExtensions({
+          bundleOnlyIfListedInFiles: false,
+          compileOnlyCss: true,
+        });
+      });
 }
 
 /**
@@ -508,9 +510,9 @@ function buildExtension(name, version, hasCss, options, opt_extraGlobs) {
   if (options.compileOnlyCss && !hasCss) {
     return Promise.resolve();
   }
-  var path = 'extensions/' + name + '/' + version;
-  var jsPath = path + '/' + name + '.js';
-  var jsTestPath = path + '/test/' + 'test-' + name + '.js';
+  const path = 'extensions/' + name + '/' + version;
+  const jsPath = path + '/' + name + '.js';
+  const jsTestPath = path + '/test/test-' + name + '.js';
   if (argv.files && options.bundleOnlyIfListedInFiles) {
     const passedFiles = Array.isArray(argv.files) ? argv.files : [argv.files];
     const shouldBundle = passedFiles.some(glob => {
@@ -525,7 +527,7 @@ function buildExtension(name, version, hasCss, options, opt_extraGlobs) {
   // it to the destination and adds the CSS.
   if (options.watch) {
     // Do not set watchers again when we get called by the watcher.
-    var copy = Object.create(options);
+    const copy = Object.create(options);
     copy.watch = false;
     $$.watch(path + '/*', function() {
       buildExtension(name, version, hasCss, copy);
@@ -536,9 +538,9 @@ function buildExtension(name, version, hasCss, options, opt_extraGlobs) {
     mkdirSync('build/css');
     const startTime = Date.now();
     return jsifyCssAsync(path + '/' + name + '.css').then(function(css) {
-      var jsCss = 'export const CSS = ' + JSON.stringify(css) + ';\n';
-      var jsName = 'build/' + name + '-' + version + '.css.js';
-      var cssName = 'build/css/' + name + '-' + version + '.css';
+      const jsCss = 'export const CSS = ' + JSON.stringify(css) + ';\n';
+      const jsName = 'build/' + name + '-' + version + '.css.js';
+      const cssName = 'build/css/' + name + '-' + version + '.css';
       fs.writeFileSync(jsName, jsCss, 'utf-8');
       fs.writeFileSync(cssName, css, 'utf-8');
       if (options.compileOnlyCss) {
@@ -546,9 +548,9 @@ function buildExtension(name, version, hasCss, options, opt_extraGlobs) {
       }
       return buildExtensionJs(path, name, version, options);
     })
-    .then(() => {
-      endBuildStep('Recompiled CSS in', name, startTime);
-    });
+        .then(() => {
+          endBuildStep('Recompiled CSS in', name, startTime);
+        });
   } else {
     return buildExtensionJs(path, name, version, options);
   }
@@ -566,11 +568,11 @@ function buildExtension(name, version, hasCss, options, opt_extraGlobs) {
  * @return {!Promise}
  */
 function buildExtensionJs(path, name, version, options) {
-  var filename = options.filename || name + '.js';
+  const filename = options.filename || name + '.js';
   if (options.loadPriority && options.loadPriority != 'high') {
     throw new Error('Unsupported loadPriority: ' + options.loadPriority);
   }
-  var priority = options.loadPriority ? 'p:"high",' : '';
+  const priority = options.loadPriority ? 'p:"high",' : '';
   return compileJs(path + '/', filename, './dist/v0', {
     watch: options.watch,
     preventRemoveAndMakeDir: options.preventRemoveAndMakeDir,
@@ -659,8 +661,9 @@ function parseExtensionFlags() {
  * @param {string} targetFile File to which the config is to be written.
  */
 function enableLocalTesting(targetFile) {
-  let config = (argv.config === 'canary') ? 'canary' : 'prod';
-  let baseConfigFile = 'build-system/global-configs/' + config + '-config.json';
+  const config = (argv.config === 'canary') ? 'canary' : 'prod';
+  const baseConfigFile =
+      'build-system/global-configs/' + config + '-config.json';
 
   return removeConfig(targetFile).then(() => {
     return applyConfig(
@@ -681,11 +684,11 @@ function performBuild(watch) {
   return compileCss(watch).then(() => {
     return Promise.all([
       polyfillsForTests(),
-      buildAlp({watch: watch}),
-      buildExaminer({watch: watch}),
-      buildSw({watch: watch}),
-      buildWebWorker({watch: watch}),
-      buildExtensions({bundleOnlyIfListedInFiles: !watch, watch: watch}),
+      buildAlp({watch}),
+      buildExaminer({watch}),
+      buildSw({watch}),
+      buildWebWorker({watch}),
+      buildExtensions({bundleOnlyIfListedInFiles: !watch, watch}),
       compile(watch),
     ]);
   });
@@ -718,23 +721,29 @@ function dist() {
   process.env.NODE_ENV = 'production';
   cleanupBuildDir();
   if (argv.fortesting) {
-    printConfigHelp('gulp dist --fortesting')
+    printConfigHelp('gulp dist --fortesting');
   }
   parseExtensionFlags();
   return compileCss().then(() => {
+    log('---------------> creating promises');
     return Promise.all([
       compile(false, true, true),
       // NOTE:
       // When adding a line here, consider whether you need to include polyfills
       // and whether you need to init logging (initLogConstructor).
       buildAlp({minify: true, watch: false, preventRemoveAndMakeDir: true}),
-      buildExaminer({minify: true, watch: false, preventRemoveAndMakeDir: true}),
+      buildExaminer({
+        minify: true, watch: false, preventRemoveAndMakeDir: true}),
       buildSw({minify: true, watch: false, preventRemoveAndMakeDir: true}),
-      buildWebWorker({minify: true, watch: false, preventRemoveAndMakeDir: true}),
+      buildWebWorker({
+        minify: true, watch: false, preventRemoveAndMakeDir: true}),
       buildExtensions({minify: true, preventRemoveAndMakeDir: true}),
-      buildExperiments({minify: true, watch: false, preventRemoveAndMakeDir: true}),
-      buildLoginDone({minify: true, watch: false, preventRemoveAndMakeDir: true}),
-      buildWebPushPublisherFiles({minify: true, watch: false, preventRemoveAndMakeDir: true}),
+      buildExperiments({
+        minify: true, watch: false, preventRemoveAndMakeDir: true}),
+      buildLoginDone({
+        minify: true, watch: false, preventRemoveAndMakeDir: true}),
+      buildWebPushPublisherFiles({
+        minify: true, watch: false, preventRemoveAndMakeDir: true}),
       copyCss(),
     ]);
   }).then(() => {
@@ -786,7 +795,7 @@ function checkTypes() {
     checkTypes: true,
     preventRemoveAndMakeDir: true,
   });*/
-  var compileSrcs = [
+  const compileSrcs = [
     './src/amp.js',
     './src/amp-shadow.js',
     './src/inabox/amp-inabox.js',
@@ -797,10 +806,10 @@ function checkTypes() {
     './src/service-worker/kill.js',
     './src/web-worker/web-worker.js',
   ];
-  var extensionValues = Object.keys(extensions).map(function(key) {
+  const extensionValues = Object.keys(extensions).map(function(key) {
     return extensions[key];
   });
-  var extensionSrcs = extensionValues.filter(function(extension) {
+  const extensionSrcs = extensionValues.filter(function(extension) {
     return !extension.noTypeCheck;
   }).map(function(extension) {
     return './extensions/' + extension.name + '/' +
@@ -817,26 +826,26 @@ function checkTypes() {
           }),
       // Type check 3p/ads code.
       closureCompile(['./3p/integration.js'], './dist',
-        'integration-check-types.js', {
-          externs: ['ads/ads.extern.js'],
-          include3pDirectories: true,
-          includePolyfills: true,
-          checkTypes: true,
-        }),
+          'integration-check-types.js', {
+            externs: ['ads/ads.extern.js'],
+            include3pDirectories: true,
+            includePolyfills: true,
+            checkTypes: true,
+          }),
       closureCompile(['./3p/ampcontext-lib.js'], './dist',
-        'ampcontext-check-types.js', {
-          externs: ['ads/ads.extern.js'],
-          include3pDirectories: true,
-          includePolyfills: true,
-          checkTypes: true,
-        }),
+          'ampcontext-check-types.js', {
+            externs: ['ads/ads.extern.js'],
+            include3pDirectories: true,
+            includePolyfills: true,
+            checkTypes: true,
+          }),
       closureCompile(['./3p/iframe-transport-client-lib.js'], './dist',
-        'iframe-transport-client-check-types.js', {
-          externs: ['ads/ads.extern.js'],
-          include3pDirectories: true,
-          includePolyfills: true,
-          checkTypes: true,
-        }),
+          'iframe-transport-client-check-types.js', {
+            externs: ['ads/ads.extern.js'],
+            include3pDirectories: true,
+            includePolyfills: true,
+            checkTypes: true,
+          }),
     ]);
   });
 }
@@ -864,16 +873,16 @@ function thirdPartyBootstrap(input, outputName, shouldMinify) {
   // actual frame host for the JS inside the frame.
   // But during testing we need a relative reference because the
   // version is not available on the absolute path.
-  var integrationJs = argv.fortesting
-      ? './f.js'
-      : `https://${hostname3p}/${internalRuntimeVersion}/f.js`;
+  const integrationJs = argv.fortesting
+    ? './f.js'
+    : `https://${hostname3p}/${internalRuntimeVersion}/f.js`;
   // Convert default relative URL to absolute min URL.
-  var html = fs.readFileSync(input, 'utf8')
+  const html = fs.readFileSync(input, 'utf8')
       .replace(/\.\/integration\.js/g, integrationJs);
   return toPromise($$.file(outputName, html, {src: true})
       .pipe(gulp.dest('dist.3p/' + internalRuntimeVersion))
       .on('end', function() {
-        var aliasToLatestBuild = 'dist.3p/current-min';
+        const aliasToLatestBuild = 'dist.3p/current-min';
         if (fs.existsSync(aliasToLatestBuild)) {
           fs.unlinkSync(aliasToLatestBuild);
         }
@@ -952,30 +961,30 @@ function compileJs(srcDir, srcFilename, destDir, options) {
         });
   }
 
-  var browsers = [];
+  const browsers = [];
   if (process.env.TRAVIS) {
     browsers.push('last 2 versions', 'safari >= 9');
   } else {
     browsers.push('Last 4 Chrome versions');
   }
 
-  var bundler = browserify(srcDir + srcFilename, {debug: true})
+  let bundler = browserify(srcDir + srcFilename, {debug: true})
       .transform(babel, {
         presets: [
-          ["env", {
+          ['env', {
             targets: {
-              browsers: browsers,
+              browsers,
             },
-          }]
+          }],
         ],
       });
   if (options.watch) {
     bundler = watchify(bundler);
   }
 
-  var wrapper = options.wrapper || '<%= contents %>';
+  const wrapper = options.wrapper || '<%= contents %>';
 
-  var lazybuild = lazypipe()
+  const lazybuild = lazypipe()
       .pipe(source, srcFilename)
       .pipe(buffer)
       .pipe($$.replace, /\$internalRuntimeVersion\$/g, internalRuntimeVersion)
@@ -983,11 +992,11 @@ function compileJs(srcDir, srcFilename, destDir, options) {
       .pipe($$.wrap, wrapper)
       .pipe($$.sourcemaps.init.bind($$.sourcemaps), {loadMaps: true});
 
-  var lazywrite = lazypipe()
+  const lazywrite = lazypipe()
       .pipe($$.sourcemaps.write.bind($$.sourcemaps), './')
       .pipe(gulp.dest.bind(gulp), destDir);
 
-  var destFilename = options.toName || srcFilename;
+  const destFilename = options.toName || srcFilename;
   function rebundle() {
     const startTime = Date.now();
     return toPromise(bundler.bundle()
@@ -1011,12 +1020,29 @@ function compileJs(srcDir, srcFilename, destDir, options) {
           } else if (srcFilename === 'integration.js') {
             return enableLocalTesting(unminified3pTarget);
           } else {
-            return Promise.resolve();
+            log(red(err.message));
           }
+        })
+        .pipe(lazybuild())
+        .pipe($$.rename(destFilename))
+        .pipe(lazywrite())
+        .on('end', function() {
+          appendToCompiledFile(srcFilename, destDir + '/' + destFilename);
+        })).then(() => {
+      endBuildStep('Compiled', srcFilename, startTime);
+    }).then(() => {
+      if (process.env.NODE_ENV === 'development') {
+        if (srcFilename === 'amp.js') {
+          return enableLocalTesting(unminifiedRuntimeTarget);
+        } else if (srcFilename === 'integration.js') {
+          return enableLocalTesting(unminified3pTarget);
         } else {
           return Promise.resolve();
         }
-      });
+      } else {
+        return Promise.resolve();
+      }
+    });
   }
 
   if (options.watch) {
@@ -1049,10 +1075,10 @@ function compileJs(srcDir, srcFilename, destDir, options) {
  */
 function buildExperiments(options) {
   options = options || {};
-  var path = 'tools/experiments';
-  var htmlPath = path + '/experiments.html';
-  var jsPath = path + '/experiments.js';
-  var watch = options.watch;
+  const path = 'tools/experiments';
+  const htmlPath = path + '/experiments.html';
+  const jsPath = path + '/experiments.js';
+  let watch = options.watch;
   if (watch === undefined) {
     watch = argv.watch || argv.w;
   }
@@ -1062,7 +1088,7 @@ function buildExperiments(options) {
   // it to the destination and adds the CSS.
   if (watch) {
     // Do not set watchers again when we get called by the watcher.
-    var copy = Object.create(options);
+    const copy = Object.create(options);
     copy.watch = false;
     $$.watch(path + '/*', function() {
       buildExperiments(copy);
@@ -1070,17 +1096,17 @@ function buildExperiments(options) {
   }
 
   // Build HTML.
-  var html = fs.readFileSync(htmlPath, 'utf8');
-  var minHtml = html.replace('/dist.tools/experiments/experiments.js',
+  const html = fs.readFileSync(htmlPath, 'utf8');
+  const minHtml = html.replace('/dist.tools/experiments/experiments.js',
       `https://${hostname}/v0/experiments.js`);
   gulp.src(htmlPath)
       .pipe($$.file('experiments.cdn.html', minHtml))
       .pipe(gulp.dest('dist.tools/experiments/'));
 
   // Build JS.
-  var js = fs.readFileSync(jsPath, 'utf8');
-  var builtName = 'experiments.max.js';
-  var minifiedName = 'experiments.js';
+  const js = fs.readFileSync(jsPath, 'utf8');
+  const builtName = 'experiments.max.js';
+  const minifiedName = 'experiments.js';
   return toPromise(gulp.src(path + '/*.js')
       .pipe($$.file(builtName, js))
       .pipe(gulp.dest('build/experiments/')))
@@ -1090,7 +1116,7 @@ function buildExperiments(options) {
               watch: false,
               minify: options.minify || argv.minify,
               includePolyfills: true,
-              minifiedName: minifiedName,
+              minifiedName,
               preventRemoveAndMakeDir: options.preventRemoveAndMakeDir,
               checkTypes: options.checkTypes,
             });
@@ -1115,31 +1141,16 @@ function buildWebPushPublisherFiles(options) {
  */
 function buildWebPushPublisherFilesVersion(version, options) {
   options = options || {};
-  var watch = options.watch;
-  if (watch === undefined) {
-    watch = argv.watch || argv.w;
-  }
-
-  // Building extensions is a 2 step process because of the renaming
-  // and CSS inlining. This watcher watches the original file, copies
-  // it to the destination and adds the CSS.
-  if (watch) {
-    // Do not set watchers again when we get called by the watcher.
-    var copy = Object.create(options);
-    copy.watch = false;
-    $$.watch(path + '/*', function() {
-      buildWebPushPublisherFiles(version);
-    });
-  }
-
-  var fileNames = ['amp-web-push-helper-frame', 'amp-web-push-permission-dialog'];
-  var promises = [];
+  const watch = options.watch;
+  const fileNames =
+      ['amp-web-push-helper-frame', 'amp-web-push-permission-dialog'];
+  const promises = [];
 
   mkdirSync('dist');
   mkdirSync('dist/v0');
 
-  for (var i = 0; i < fileNames.length; i++) {
-    var fileName = fileNames[i];
+  for (let i = 0; i < fileNames.length; i++) {
+    const fileName = fileNames[i];
     promises.push(buildWebPushPublisherFile(version, fileName, watch, options));
   }
 
@@ -1147,40 +1158,41 @@ function buildWebPushPublisherFilesVersion(version, options) {
 }
 
 function buildWebPushPublisherFile(version, fileName, watch, options) {
-  var basePath = 'extensions/amp-web-push/' + version + '/';
-  var tempBuildDir = 'build/all/v0/';
-  var distDir = 'dist/v0';
+  const basePath = 'extensions/amp-web-push/' + version + '/';
+  const tempBuildDir = 'build/all/v0/';
+  const distDir = 'dist/v0';
 
   // Build Helper Frame JS
-  var js = fs.readFileSync(basePath + fileName + '.js', 'utf8');
-  var builtName = fileName + '.js';
-  var minifiedName = fileName + '.js';
+  const js = fs.readFileSync(basePath + fileName + '.js', 'utf8');
+  const builtName = fileName + '.js';
+  const minifiedName = fileName + '.js';
   return toPromise(gulp.src(basePath + '/*.js')
-    .pipe($$.file(builtName, js))
-    .pipe(gulp.dest(tempBuildDir)))
-    .then(function () {
-      return compileJs('./' + tempBuildDir, builtName, './' + distDir, {
-        watch: watch,
-        includePolyfills: true,
-        minify: options.minify || argv.minify,
-        minifiedName: minifiedName,
-        preventRemoveAndMakeDir: options.preventRemoveAndMakeDir,
-      });
-    })
-    .then(function () {
-      if (fs.existsSync(distDir + '/' + minifiedName)) {
-        // Build Helper Frame HTML
-        var fileContents = fs.readFileSync(basePath + fileName + '.html', 'utf8');
-        fileContents = fileContents.replace(
-          '<!-- [GULP-MAGIC-REPLACE ' + fileName + '.js] -->',
-          '<script>' + fs.readFileSync(distDir + '/' + minifiedName, 'utf8') +
-          '</script>'
-        );
+      .pipe($$.file(builtName, js))
+      .pipe(gulp.dest(tempBuildDir)))
+      .then(function() {
+        return compileJs('./' + tempBuildDir, builtName, './' + distDir, {
+          watch,
+          includePolyfills: true,
+          minify: options.minify || argv.minify,
+          minifiedName,
+          preventRemoveAndMakeDir: options.preventRemoveAndMakeDir,
+        });
+      })
+      .then(function() {
+        if (fs.existsSync(distDir + '/' + minifiedName)) {
+          // Build Helper Frame HTML
+          let fileContents =
+              fs.readFileSync(basePath + fileName + '.html', 'utf8');
+          fileContents = fileContents.replace(
+              '<!-- [GULP-MAGIC-REPLACE ' + fileName + '.js] -->',
+              '<script>' + fs.readFileSync(distDir + '/' +
+              minifiedName, 'utf8') + '</script>'
+          );
 
-        fs.writeFileSync('dist/v0/' + fileName + '.html',
-          fileContents);
-      }
-    });
+          fs.writeFileSync('dist/v0/' + fileName + '.html',
+              fileContents);
+        }
+      });
 }
 
 
@@ -1200,10 +1212,10 @@ function buildLoginDone(options) {
  */
 function buildLoginDoneVersion(version, options) {
   options = options || {};
-  var path = 'extensions/amp-access/' + version + '/';
-  var htmlPath = path + 'amp-login-done.html';
-  var jsPath = path + 'amp-login-done.js';
-  var watch = options.watch;
+  const path = 'extensions/amp-access/' + version + '/';
+  const htmlPath = path + 'amp-login-done.html';
+  const jsPath = path + 'amp-login-done.js';
+  let watch = options.watch;
   if (watch === undefined) {
     watch = argv.watch || argv.w;
   }
@@ -1213,7 +1225,7 @@ function buildLoginDoneVersion(version, options) {
   // it to the destination and adds the CSS.
   if (watch) {
     // Do not set watchers again when we get called by the watcher.
-    var copy = Object.create(options);
+    const copy = Object.create(options);
     copy.watch = false;
     $$.watch(path + '/*', function() {
       buildLoginDoneVersion(version, copy);
@@ -1221,9 +1233,9 @@ function buildLoginDoneVersion(version, options) {
   }
 
   // Build HTML.
-  var html = fs.readFileSync(htmlPath, 'utf8');
-  var minJs = `https://${hostname}/v0/amp-login-done-${version}.js`;
-  var minHtml = html
+  const html = fs.readFileSync(htmlPath, 'utf8');
+  const minJs = `https://${hostname}/v0/amp-login-done-${version}.js`;
+  const minHtml = html
       .replace(
           `../../../dist/v0/amp-login-done-${version}.max.js`,
           minJs)
@@ -1241,10 +1253,10 @@ function buildLoginDoneVersion(version, options) {
       minHtml);
 
   // Build JS.
-  var js = fs.readFileSync(jsPath, 'utf8');
-  var builtName = 'amp-login-done-' + version + '.max.js';
-  var minifiedName = 'amp-login-done-' + version + '.js';
-  var latestName = 'amp-login-done-latest.js';
+  const js = fs.readFileSync(jsPath, 'utf8');
+  const builtName = 'amp-login-done-' + version + '.max.js';
+  const minifiedName = 'amp-login-done-' + version + '.js';
+  const latestName = 'amp-login-done-latest.js';
   return toPromise(gulp.src(path + '/*.js')
       .pipe($$.file(builtName, js))
       .pipe(gulp.dest('build/all/v0/')))
@@ -1253,9 +1265,9 @@ function buildLoginDoneVersion(version, options) {
           watch: false,
           includePolyfills: true,
           minify: options.minify || argv.minify,
-          minifiedName: minifiedName,
+          minifiedName,
           preventRemoveAndMakeDir: options.preventRemoveAndMakeDir,
-          latestName: latestName,
+          latestName,
         });
       });
 }
@@ -1300,7 +1312,7 @@ function buildExaminer(options) {
  * @param {!Object} options
  */
 function buildSw(options) {
-  var opts = Object.assign({}, options);
+  const opts = Object.assign({}, options);
   return Promise.all([
     // The service-worker script loaded by the browser.
     compileJs('./src/service-worker/', 'shell.js', './dist/', {
@@ -1330,7 +1342,7 @@ function buildSw(options) {
  * @param {!Object} options
  */
 function buildWebWorker(options) {
-  var opts = Object.assign({}, options);
+  const opts = Object.assign({}, options);
   return compileJs('./src/web-worker/', 'web-worker.js', './dist/', {
     toName: 'ww.max.js',
     minifiedName: 'ww.js',
@@ -1347,7 +1359,7 @@ function buildWebWorker(options) {
  * errors from modules that e.g. use let.
  */
 function checkMinVersion() {
-  var majorVersion = Number(process.version.replace(/v/, '').split('.')[0]);
+  const majorVersion = Number(process.version.replace(/v/, '').split('.')[0]);
   if (majorVersion < 4) {
     log('Please run AMP with node.js version 4 or newer.');
     log('Your version is', process.version);
@@ -1358,7 +1370,7 @@ function checkMinVersion() {
 function mkdirSync(path) {
   try {
     fs.mkdirSync(path);
-  } catch(e) {
+  } catch (e) {
     if (e.code != 'EEXIST') {
       throw e;
     }
@@ -1376,7 +1388,7 @@ function patchWebAnimations() {
   // Copies web-animations-js into a new file that has an export.
   const patchedName = 'node_modules/web-animations-js/' +
       'web-animations.install.js';
-  var file = fs.readFileSync(
+  let file = fs.readFileSync(
       'node_modules/web-animations-js/' +
       'web-animations.min.js').toString();
   // Wrap the contents inside the install function.
@@ -1396,6 +1408,8 @@ function toPromise(readable) {
   });
 }
 
+/* eslint "google-camelcase/google-camelcase": 0 */
+
 /**
  * Gulp tasks
  */
@@ -1405,7 +1419,7 @@ gulp.task('build', 'Builds the AMP library',
         config: '  Sets the runtime\'s AMP_CONFIG to one of "prod" or "canary"',
         extensions: '  Builds only the listed extensions.',
         noextensions: '  Builds with no extensions.',
-      }
+      },
     });
 gulp.task('check-all', 'Run through all presubmit checks',
     ['lint', 'dep-check', 'check-types', 'presubmit']);
@@ -1419,7 +1433,7 @@ gulp.task('default', 'Runs "watch" and then "serve"',
       options: {
         extensions: '  Watches and builds only the listed extensions.',
         noextensions: '  Watches and builds with no extensions.',
-      }
+      },
     });
 gulp.task('dist', 'Build production binaries',
     ['update-packages', 'patch-web-animations'], dist, {
@@ -1437,7 +1451,7 @@ gulp.task('watch', 'Watches for changes in files, re-builds when detected',
         with_shadow: '  Also watch and build the amp-shadow.js binary.',
         extensions: '  Watches and builds only the listed extensions.',
         noextensions: '  Watches and builds with no extensions.',
-      }
-});
+      },
+    });
 gulp.task('build-experiments', 'Builds experiments.html/js', buildExperiments);
 gulp.task('build-login-done', 'Builds login-done.html/js', buildLoginDone);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -602,9 +602,8 @@ function printConfigHelp(command) {
     log(green('Building the runtime for local testing with the'),
         cyan((argv.config === 'canary') ? 'canary' : 'prod'),
         green('AMP config.'));
-    log(green('⤷ To specify which config to apply, use'),
-        cyan('--config={canary|prod}'), green('with your'),
-        cyan(command), green('command.'));
+    log(green('⤷ Use'), cyan('--config={canary|prod}'), green('with your'),
+        cyan(command), green('command to specify which config to apply.'));
   }
 }
 
@@ -615,14 +614,22 @@ function printConfigHelp(command) {
  */
 function parseExtensionFlags() {
   if (!process.env.TRAVIS) {
+    const noExtensionsMessage = green('⤷ Use ') +
+        cyan('--noextensions ') +
+        green('to skip building extensions.');
+    const extensionsMessage = green('⤷ Use ') +
+        cyan('--extensions=amp-foo,amp-bar ') +
+        green('to choose which extensions to build.');
+    const minimalSetMessage = green('⤷ Use ') +
+        cyan('--extensions=minimal_set ') +
+        green('to build just the extensions needed to load ') +
+        cyan('article.amp.html') + green('.');
     if (argv.extensions) {
       if (typeof(argv.extensions) !== 'string') {
-        log(red('ERROR:'), 'Missing list of extensions. Expected format:',
-            cyan('--extensions=amp-foo,amp-bar'),
-            'to choose which ones to build, or',
-            cyan('--extensions=minimal_set'),
-            'to build the ones needed to load',
-            cyan('article.amp.html') + '.');
+        log(red('ERROR:'), 'Missing list of extensions.');
+        log(noExtensionsMessage);
+        log(extensionsMessage);
+        log(minimalSetMessage);
         process.exit(1);
       }
       if (argv.extensions === 'minimal_set') {
@@ -633,25 +640,14 @@ function parseExtensionFlags() {
       }
       log(green('Building extension(s):'),
           cyan(argv.extensions.split(',').join(', ')));
-      log(green('⤷ Use'), cyan('--noextensions'),
-          green('to skip building extensions.'));
     } else if (argv.noextensions) {
       log(green('Not building any AMP extensions.'));
-      log(green('⤷ Use'), cyan('--extensions=amp-foo,amp-bar'),
-          green('to choose which ones to build, or'),
-          cyan('--extensions=minimal_set'),
-          green('to build the ones needed to load'),
-          cyan('article.amp.html') + green('.'));
     } else {
       log(green('Building all AMP extensions.'));
-      log(green('⤷ Use'), cyan('--noextensions'),
-          green('to skip building extensions, or'),
-          cyan('--extensions=amp-foo,amp-bar'),
-          green('to choose which ones to build, or'),
-          cyan('--extensions=minimal_set'),
-          green('to build the ones needed to load'),
-          cyan('article.amp.html') + green('.'));
     }
+    log(noExtensionsMessage);
+    log(extensionsMessage);
+    log(minimalSetMessage);
   }
 }
 


### PR DESCRIPTION
This PR:
1. Enables `lint` and `presubmit` checks for `gulpfile.js`
2. Fixes all existing `lint` and `presubmit` errors in `gulpfile.js` 
3. Makes minor improvements to `presubmit` rules
4. Shortens the help messages printed by `gulp [default|watch|build|dist]`.

Fixes #13257