### PR TITLE
Create task queue to synchronize function calls to media pool elements

### DIFF
--- a/extensions/amp-story/0.1/amp-story-page.js
+++ b/extensions/amp-story/0.1/amp-story-page.js
@@ -316,12 +316,14 @@ export class AmpStoryPage extends AMP.BaseElement {
    *     callback to be applied to each media element.
    * @return {!Promise} Promise that resolves after the callbacks are called.
    */
-  forEachMediaElement_(callbackFn) {
+  whenAllMediaElements_(callbackFn) {
     const mediaSet = this.getAllMedia_();
     return this.mediaPoolPromise_.then(mediaPool => {
-      Array.prototype.forEach.call(mediaSet, mediaEl => {
-        callbackFn(mediaPool, mediaEl);
+      const promises = Array.prototype.map.call(mediaSet, mediaEl => {
+        return callbackFn(mediaPool, mediaEl);
       });
+
+      return Promise.all(promises);
     });
   }
 
@@ -334,8 +336,8 @@ export class AmpStoryPage extends AMP.BaseElement {
    * @private
    */
   pauseAllMedia_(opt_rewindToBeginning) {
-    return this.forEachMediaElement_((mediaPool, mediaEl) => {
-      mediaPool.pause(/** @type {!HTMLMediaElement} */ (mediaEl),
+    return this.whenAllMediaElements_((mediaPool, mediaEl) => {
+      return mediaPool.pause(/** @type {!HTMLMediaElement} */ (mediaEl),
           opt_rewindToBeginning);
     });
   }
@@ -347,8 +349,8 @@ export class AmpStoryPage extends AMP.BaseElement {
    * @private
    */
   playAllMedia_() {
-    return this.forEachMediaElement_((mediaPool, mediaEl) => {
-      mediaPool.play(/** @type {!HTMLMediaElement} */ (mediaEl));
+    return this.whenAllMediaElements_((mediaPool, mediaEl) => {
+      return mediaPool.play(/** @type {!HTMLMediaElement} */ (mediaEl));
     });
   }
 
@@ -359,8 +361,8 @@ export class AmpStoryPage extends AMP.BaseElement {
    * @private
    */
   preloadAllMedia_() {
-    return this.forEachMediaElement_((mediaPool, mediaEl) => {
-      mediaPool.preload(/** @type {!HTMLMediaElement} */ (mediaEl));
+    return this.whenAllMediaElements_((mediaPool, mediaEl) => {
+      return mediaPool.preload(/** @type {!HTMLMediaElement} */ (mediaEl));
     });
   }
 
@@ -370,8 +372,9 @@ export class AmpStoryPage extends AMP.BaseElement {
    * @private
    */
   rewindAllMediaToBeginning_() {
-    return this.forEachMediaElement_((mediaPool, mediaEl) => {
-      mediaPool.rewindToBeginning(/** @type {!HTMLMediaElement} */ (mediaEl));
+    return this.whenAllMediaElements_((mediaPool, mediaEl) => {
+      return mediaPool.rewindToBeginning(
+          /** @type {!HTMLMediaElement} */ (mediaEl));
     });
   }
 
@@ -381,8 +384,8 @@ export class AmpStoryPage extends AMP.BaseElement {
    * @return {!Promise} Promise that resolves after the callbacks are called.
    */
   muteAllMedia() {
-    return this.forEachMediaElement_((mediaPool, mediaEl) => {
-      mediaPool.mute(/** @type {!HTMLMediaElement} */ (mediaEl));
+    return this.whenAllMediaElements_((mediaPool, mediaEl) => {
+      return mediaPool.mute(/** @type {!HTMLMediaElement} */ (mediaEl));
     });
   }
 
@@ -392,8 +395,8 @@ export class AmpStoryPage extends AMP.BaseElement {
    * @return {!Promise} Promise that resolves after the callbacks are called.
    */
   unmuteAllMedia() {
-    return this.forEachMediaElement_((mediaPool, mediaEl) => {
-      mediaPool.unmute(/** @type {!HTMLMediaElement} */ (mediaEl));
+    return this.whenAllMediaElements_((mediaPool, mediaEl) => {
+      return mediaPool.unmute(/** @type {!HTMLMediaElement} */ (mediaEl));
     });
   }
 
@@ -404,8 +407,8 @@ export class AmpStoryPage extends AMP.BaseElement {
    * @private
    */
   registerAllMedia_() {
-    return this.forEachMediaElement_((mediaPool, mediaEl) => {
-      mediaPool.register(/** @type {!HTMLMediaElement} */ (mediaEl));
+    return this.whenAllMediaElements_((mediaPool, mediaEl) => {
+      return mediaPool.register(/** @type {!HTMLMediaElement} */ (mediaEl));
     });
   }
 

--- a/extensions/amp-story/0.1/amp-story-page.js
+++ b/extensions/amp-story/0.1/amp-story-page.js
@@ -196,11 +196,9 @@ export class AmpStoryPage extends AMP.BaseElement {
 
   /** @override */
   resumeCallback() {
-    console.log('resume', this.element.id);
     this.registerAllMedia_();
 
     if (this.isActive()) {
-      console.log('resume isActive', this.element.id);
       this.advancement_.start();
       this.maybeStartAnimations();
       this.preloadAllMedia_()
@@ -351,7 +349,6 @@ export class AmpStoryPage extends AMP.BaseElement {
    * @private
    */
   playAllMedia_() {
-    console.log('playing all media on', this.element.id);
     return this.whenAllMediaElements_((mediaPool, mediaEl) => {
       return mediaPool.play(/** @type {!HTMLMediaElement} */ (mediaEl));
     });
@@ -364,7 +361,6 @@ export class AmpStoryPage extends AMP.BaseElement {
    * @private
    */
   preloadAllMedia_() {
-    console.log('preloading all media on', this.element.id);
     return this.whenAllMediaElements_((mediaPool, mediaEl) => {
       return mediaPool.preload(/** @type {!HTMLMediaElement} */ (mediaEl));
     });

--- a/extensions/amp-story/0.1/amp-story-page.js
+++ b/extensions/amp-story/0.1/amp-story-page.js
@@ -196,9 +196,11 @@ export class AmpStoryPage extends AMP.BaseElement {
 
   /** @override */
   resumeCallback() {
+    console.log('resume', this.element.id);
     this.registerAllMedia_();
 
     if (this.isActive()) {
+      console.log('resume isActive', this.element.id);
       this.advancement_.start();
       this.maybeStartAnimations();
       this.preloadAllMedia_()
@@ -349,6 +351,7 @@ export class AmpStoryPage extends AMP.BaseElement {
    * @private
    */
   playAllMedia_() {
+    console.log('playing all media on', this.element.id);
     return this.whenAllMediaElements_((mediaPool, mediaEl) => {
       return mediaPool.play(/** @type {!HTMLMediaElement} */ (mediaEl));
     });
@@ -361,6 +364,7 @@ export class AmpStoryPage extends AMP.BaseElement {
    * @private
    */
   preloadAllMedia_() {
+    console.log('preloading all media on', this.element.id);
     return this.whenAllMediaElements_((mediaPool, mediaEl) => {
       return mediaPool.preload(/** @type {!HTMLMediaElement} */ (mediaEl));
     });

--- a/extensions/amp-story/0.1/media-pool.js
+++ b/extensions/amp-story/0.1/media-pool.js
@@ -27,7 +27,6 @@ import {toWin} from '../../../src/types';
 import {BLANK_AUDIO_SRC, BLANK_VIDEO_SRC} from './default-media';
 import {listenOncePromise} from '../../../src/event-helper';
 import {dispatch} from './events';
-import {Services} from '../../../src/services';
 
 
 
@@ -284,9 +283,6 @@ export class MediaPool {
     /** @private @const {!Window} */
     this.win_ = win;
 
-    /** @private @const */
-    this.vsync_ = Services.vsyncFor(win);
-
     /**
      * The function used to retrieve the distance between an element and the
      * current position in the document.
@@ -525,9 +521,7 @@ export class MediaPool {
       return null;
     }
 
-    this.vsync_.mutate(() => {
-      this.swapPoolMediaElementOutOfDom_(poolMediaEl);
-    });
+    this.swapPoolMediaElementOutOfDom_(poolMediaEl);
     return poolMediaEl;
   }
 
@@ -749,10 +743,7 @@ export class MediaPool {
       return null;
     }
 
-    this.vsync_.mutate(() => {
-      this.swapPoolMediaElementIntoDom_(domMediaEl, poolMediaEl, sources);
-    });
-
+    this.swapPoolMediaElementIntoDom_(domMediaEl, poolMediaEl, sources);
     this.allocateMediaElement_(mediaType, poolMediaEl);
     return poolMediaEl;
   }

--- a/extensions/amp-story/0.1/media-pool.js
+++ b/extensions/amp-story/0.1/media-pool.js
@@ -73,9 +73,9 @@ function blessMediaElement(mediaEl) {
   const isMuted = mediaEl.muted;
   const currentTime = mediaEl.currentTime;
 
-  console.log('media to be played for blessing', mediaEl);
+  console.log('media to be played for blessing', mediaEl.outerHTML);
   const playResult = mediaEl.play();
-  console.log('media has been played for blessing', mediaEl, playResult);
+  console.log('media has been played for blessing', mediaEl.outerHTML, playResult);
 
   return Promise.resolve(playResult).then(() => {
     console.log('inner bless', mediaEl);

--- a/extensions/amp-story/0.1/media-pool.js
+++ b/extensions/amp-story/0.1/media-pool.js
@@ -237,7 +237,7 @@ export class MediaPool {
         return new Sources(BLANK_VIDEO_SRC);
       default:
         dev().error('AMP-STORY', `No default media for type ${mediaType}.`);
-        return '';
+        return new Sources();
     }
   }
 
@@ -642,8 +642,8 @@ export class MediaPool {
    * Preloads the content of the specified media element in the DOM.
    * @param {!HTMLMediaElement} domMediaEl The media element, found in the DOM,
    *     whose content should be loaded.
-   * @return {!Promise<!HTMLMediaElement>} A promise that is resolved when the
-   *     specified media element has been successfully loaded.
+   * @return {!Promise} A promise that is resolved when the specified media
+   *     element has successfully started preloading.
    */
   preload(domMediaEl) {
     // Empty then() invocation hides the value yielded by the loadInternal_
@@ -657,14 +657,14 @@ export class MediaPool {
    * Plays the specified media element in the DOM by replacing it with a media
    * element from the pool and playing that.
    * @param {!HTMLMediaElement} domMediaEl The media element to be played.
-   * @return {!Promise<!HTMLMediaElement>} A promise that is resolved when the
-   *     specified media element has been successfully played.
+   * @return {!Promise} A promise that is resolved when the specified media
+   *     element has been successfully played.
    */
   play(domMediaEl) {
     return this.loadInternal_(domMediaEl)
         .then(poolMediaEl => {
           if (!poolMediaEl) {
-            return;
+            return Promise.resolve();
           }
 
           return this.enqueueMediaElementTask_(poolMediaEl, new PlayTask());
@@ -677,8 +677,8 @@ export class MediaPool {
    * @param {!HTMLMediaElement} domMediaEl The media element to be paused.
    * @param {boolean=} opt_rewindToBeginning Whether to rewind the currentTime
    *     of media items to the beginning.
-   * @return {!Promise<!HTMLMediaElement>} A promise that is resolved when the
-   *     specified media element has been successfully paused.
+   * @return {!Promise} A promise that is resolved when the specified media
+   *     element has been successfully paused.
    */
   pause(domMediaEl, opt_rewindToBeginning) {
     const mediaType = this.getMediaType_(domMediaEl);
@@ -686,13 +686,15 @@ export class MediaPool {
         this.getMatchingMediaElementFromPool_(mediaType, domMediaEl);
 
     if (!poolMediaEl) {
-      return;
+      return Promise.resolve();
     }
 
     return this.enqueueMediaElementTask_(poolMediaEl, new PauseTask())
         .then(() => {
           if (opt_rewindToBeginning) {
-            this.enqueueMediaElementTask_(poolMediaEl, new RewindTask());
+            this.enqueueMediaElementTask_(
+                /** @type {!HTMLMediaElement} */ (poolMediaEl),
+                new RewindTask());
           }
         });
   }
@@ -701,7 +703,7 @@ export class MediaPool {
   /**
    * Rewinds a specified media element in the DOM to 0.
    * @param {!HTMLMediaElement} domMediaEl The media element to be rewound.
-   * @return {!Promise<!HTMLMediaElement>} A promise that is resolved when the
+   * @return {!Promise} A promise that is resolved when the
    *     specified media element has been successfully rewound.
    */
   rewindToBeginning(domMediaEl) {
@@ -710,7 +712,7 @@ export class MediaPool {
         this.getMatchingMediaElementFromPool_(mediaType, domMediaEl);
 
     if (!poolMediaEl) {
-      return;
+      return Promise.resolve();
     }
 
     return this.enqueueMediaElementTask_(poolMediaEl, new RewindTask());
@@ -720,8 +722,8 @@ export class MediaPool {
   /**
    * Mutes the specified media element in the DOM.
    * @param {!HTMLMediaElement} domMediaEl The media element to be muted.
-   * @return {!Promise<!HTMLMediaElement>} A promise that is resolved when the
-   *     specified media element has been successfully muted.
+   * @return {!Promise} A promise that is resolved when the specified media
+   *     element has been successfully muted.
    */
   mute(domMediaEl) {
     const mediaType = this.getMediaType_(domMediaEl);
@@ -729,7 +731,7 @@ export class MediaPool {
         this.getMatchingMediaElementFromPool_(mediaType, domMediaEl);
 
     if (!poolMediaEl) {
-      return;
+      return Promise.resolve();
     }
 
     return this.enqueueMediaElementTask_(poolMediaEl, new MuteTask());
@@ -739,8 +741,8 @@ export class MediaPool {
   /**
    * Unmutes the specified media element in the DOM.
    * @param {!HTMLMediaElement} domMediaEl The media element to be unmuted.
-   * @return {!Promise<!HTMLMediaElement>} A promise that is resolved when the
-   *     specified media element has been successfully paused.
+   * @return {!Promise} A promise that is resolved when the specified media
+   *     element has been successfully paused.
    */
   unmute(domMediaEl) {
     const mediaType = this.getMediaType_(domMediaEl);
@@ -748,7 +750,7 @@ export class MediaPool {
         this.getMatchingMediaElementFromPool_(mediaType, domMediaEl);
 
     if (!poolMediaEl) {
-      return;
+      return Promise.resolve();
     }
 
     return this.enqueueMediaElementTask_(poolMediaEl, new UnmuteTask());
@@ -816,7 +818,7 @@ export class MediaPool {
   /**
    * @param {!HTMLMediaElement} mediaEl The element for which the specified task
    *     should be executed.
-   * @param {!MediaTask} task The task to be executed.
+   * @param {!./media-tasks.MediaTask} task The task to be executed.
    * @return {!Promise} A promise that is resolved when the specified task is
    *     completed.
    * @private

--- a/extensions/amp-story/0.1/media-pool.js
+++ b/extensions/amp-story/0.1/media-pool.js
@@ -778,7 +778,7 @@ export class MediaPool {
    */
   executeNextMediaElementTask_(mediaEl) {
     const queue = mediaEl[ELEMENT_TASK_QUEUE_PROPERTY_NAME];
-    console.log('queue contains', queue);
+    console.log('queue contains', queue, mediaEl);
     if (queue.length === 0) {
       return;
     }

--- a/extensions/amp-story/0.1/media-pool.js
+++ b/extensions/amp-story/0.1/media-pool.js
@@ -27,6 +27,7 @@ import {toWin} from '../../../src/types';
 import {BLANK_AUDIO_SRC, BLANK_VIDEO_SRC} from './default-media';
 import {listenOncePromise} from '../../../src/event-helper';
 import {dispatch} from './events';
+import {Services} from '../../../src/services';
 
 
 
@@ -283,6 +284,9 @@ export class MediaPool {
     /** @private @const {!Window} */
     this.win_ = win;
 
+    /** @private @const */
+    this.vsync_ = Services.vsyncFor(win);
+
     /**
      * The function used to retrieve the distance between an element and the
      * current position in the document.
@@ -521,7 +525,9 @@ export class MediaPool {
       return null;
     }
 
-    this.swapPoolMediaElementOutOfDom_(poolMediaEl);
+    this.vsync_.mutate(() => {
+      this.swapPoolMediaElementOutOfDom_(poolMediaEl);
+    });
     return poolMediaEl;
   }
 
@@ -743,7 +749,10 @@ export class MediaPool {
       return null;
     }
 
-    this.swapPoolMediaElementIntoDom_(domMediaEl, poolMediaEl, sources);
+    this.vsync_.mutate(() => {
+      this.swapPoolMediaElementIntoDom_(domMediaEl, poolMediaEl, sources);
+    });
+
     this.allocateMediaElement_(mediaType, poolMediaEl);
     return poolMediaEl;
   }

--- a/extensions/amp-story/0.1/media-pool.js
+++ b/extensions/amp-story/0.1/media-pool.js
@@ -789,6 +789,7 @@ export class MediaPool {
       task.execute(mediaEl)
           .catch(reason => dev().error('AMP-STORY', reason))
           .then(() => {
+            // Run regardless of success or failure of task execution.
             queue.shift();
             this.executeNextMediaElementTask_(mediaEl);
           });
@@ -816,9 +817,11 @@ export class MediaPool {
     }
 
     const queue = mediaEl[ELEMENT_TASK_QUEUE_PROPERTY_NAME];
+    const isQueueRunning = queue.length === 0;
+
     queue.push(task);
 
-    if (queue.length === 1) {
+    if (!isQueueRunning) {
       this.executeNextMediaElementTask_(mediaEl);
     }
 

--- a/extensions/amp-story/0.1/media-pool.js
+++ b/extensions/amp-story/0.1/media-pool.js
@@ -211,10 +211,12 @@ export class MediaPool {
         this.vsync_.mutate(() => {
           const mediaEl = this.mediaFactory_[type].call(this);
           mediaEl.setAttribute('pool-element', elId++);
-          mediaEl.src = this.getDefaultSource_(type);
-          // TODO(newmuis): Check the 'error' field to see if MEDIA_ERR_DECODE is
-          // returned.  If so, we should adjust the pool size/distribution between
-          // media types.
+          const sources = this.getDefaultSource_(type);
+          this.enqueueMediaElementTask_(mediaEl,
+              new UpdateSourcesTask(sources, this.vsync_));
+          // TODO(newmuis): Check the 'error' field to see if MEDIA_ERR_DECODE
+          // is returned.  If so, we should adjust the pool size/distribution
+          // between media types.
           this.unallocated[type].push(mediaEl);
         });
       }

--- a/extensions/amp-story/0.1/media-pool.js
+++ b/extensions/amp-story/0.1/media-pool.js
@@ -73,7 +73,11 @@ function blessMediaElement(mediaEl) {
   const isMuted = mediaEl.muted;
   const currentTime = mediaEl.currentTime;
 
-  return Promise.resolve(mediaEl.play()).then(() => {
+  console.log('media to be played for blessing', mediaEl);
+  const playResult = mediaEl.play();
+  console.log('media has been played for blessing', mediaEl, playResult);
+
+  return Promise.resolve(playResult).then(() => {
     console.log('inner bless', mediaEl);
     mediaEl.muted = false;
 

--- a/extensions/amp-story/0.1/media-pool.js
+++ b/extensions/amp-story/0.1/media-pool.js
@@ -74,6 +74,7 @@ function blessMediaElement(mediaEl) {
   const currentTime = mediaEl.currentTime;
 
   return Promise.resolve(mediaEl.play()).then(() => {
+    console.log('inner bless', mediaEl);
     mediaEl.muted = false;
 
     if (isPaused) {
@@ -87,10 +88,11 @@ function blessMediaElement(mediaEl) {
 
     mediaEl[ELEMENT_BLESSED_PROPERTY_NAME] = true;
   }).catch(reason => {
+    console.log('bless failed', mediaEl);
     dev().expectedError('AMP-STORY', 'Blessing media element failed:',
         reason, mediaEl);
   }).then(() => {
-    console.log('dispatch bless');
+    console.log('dispatch bless', mediaEl);
     dispatch(mediaEl, 'bless', false);
   });
 }

--- a/extensions/amp-story/0.1/media-pool.js
+++ b/extensions/amp-story/0.1/media-pool.js
@@ -778,7 +778,7 @@ export class MediaPool {
    */
   executeNextMediaElementTask_(mediaEl) {
     const queue = mediaEl[ELEMENT_TASK_QUEUE_PROPERTY_NAME];
-
+    console.log('queue contains', queue);
     if (queue.length === 0) {
       return;
     }

--- a/extensions/amp-story/0.1/media-pool.js
+++ b/extensions/amp-story/0.1/media-pool.js
@@ -14,17 +14,10 @@
  * limitations under the License.
  */
 
-import {isConnectedNode} from '../../../src/dom';
-import {dev} from '../../../src/log';
-import {findIndex} from '../../../src/utils/array';
-import {toWin} from '../../../src/types';
 import {BLANK_AUDIO_SRC, BLANK_VIDEO_SRC} from './default-media';
-import {Services} from '../../../src/services';
-import {Sources} from './sources';
-import {ampMediaElementFor} from './utils';
 import {
-  ELEMENT_BLESSED_PROPERTY_NAME,
   BlessTask,
+  ELEMENT_BLESSED_PROPERTY_NAME,
   LoadTask,
   MuteTask,
   PauseTask,
@@ -35,6 +28,13 @@ import {
   UnmuteTask,
   UpdateSourcesTask,
 } from './media-tasks';
+import {Services} from '../../../src/services';
+import {Sources} from './sources';
+import {ampMediaElementFor} from './utils';
+import {dev} from '../../../src/log';
+import {findIndex} from '../../../src/utils/array';
+import {isConnectedNode} from '../../../src/dom';
+import {toWin} from '../../../src/types';
 
 
 /** @const @enum {string} */

--- a/extensions/amp-story/0.1/media-pool.js
+++ b/extensions/amp-story/0.1/media-pool.js
@@ -225,14 +225,14 @@ export class MediaPool {
   /**
    * @param {!MediaType} mediaType The media type whose source should be
    *     retrieved.
-   * @return {string} The default source for the specified type of media.
+   * @return {!Sources} The default source for the specified type of media.
    */
   getDefaultSource_(mediaType) {
     switch (mediaType) {
       case MediaType.AUDIO:
-        return BLANK_AUDIO_SRC;
+        return new Sources(BLANK_AUDIO_SRC);
       case MediaType.VIDEO:
-        return BLANK_VIDEO_SRC;
+        return new Sources(BLANK_VIDEO_SRC);
       default:
         dev().error('AMP-STORY', `No default media for type ${mediaType}.`);
         return '';
@@ -778,7 +778,6 @@ export class MediaPool {
    */
   executeNextMediaElementTask_(mediaEl) {
     const queue = mediaEl[ELEMENT_TASK_QUEUE_PROPERTY_NAME];
-    console.log('queue contains', queue, mediaEl);
     if (queue.length === 0) {
       return;
     }
@@ -796,9 +795,9 @@ export class MediaPool {
     };
 
     if (task.requiresSynchronousExecution()) {
-      executionFn.call();
+      executionFn.call(this);
     } else {
-      this.timer_.delay(executionFn, 0);
+      this.timer_.delay(executionFn.bind(this), 0);
     }
   }
 
@@ -817,7 +816,7 @@ export class MediaPool {
     }
 
     const queue = mediaEl[ELEMENT_TASK_QUEUE_PROPERTY_NAME];
-    const isQueueRunning = queue.length === 0;
+    const isQueueRunning = queue.length !== 0;
 
     queue.push(task);
 

--- a/extensions/amp-story/0.1/media-pool.js
+++ b/extensions/amp-story/0.1/media-pool.js
@@ -171,6 +171,7 @@ export class MediaPool {
         const audioEl = this.win_.document.createElement('audio');
         audioEl.setAttribute('src', BLANK_AUDIO_SRC);
         audioEl.setAttribute('muted', '');
+        audioEl.muted = true;
         audioEl.classList.add('i-amphtml-pool-media');
         audioEl.classList.add('i-amphtml-pool-audio');
         return audioEl;
@@ -179,6 +180,7 @@ export class MediaPool {
         const videoEl = this.win_.document.createElement('video');
         videoEl.setAttribute('src', BLANK_VIDEO_SRC);
         videoEl.setAttribute('muted', '');
+        videoEl.muted = true;
         videoEl.setAttribute('playsinline', '');
         videoEl.classList.add('i-amphtml-pool-media');
         videoEl.classList.add('i-amphtml-pool-video');

--- a/extensions/amp-story/0.1/media-pool.js
+++ b/extensions/amp-story/0.1/media-pool.js
@@ -327,6 +327,13 @@ export class MediaPool {
    */
   allocateMediaElement_(mediaType, poolMediaEl) {
     this.allocated[mediaType].push(poolMediaEl);
+
+    const unallocatedEls = this.unallocated[mediaType];
+    const indexToRemove = unallocatedEls.indexOf(poolMediaEl);
+
+    if (indexToRemove >= 0) {
+      unallocatedEls.splice(indexToRemove, 1);
+    }
   }
 
 
@@ -498,12 +505,14 @@ export class MediaPool {
         this.domMediaEls_[oldDomMediaElId],
         'No media element to put back into DOM after eviction.'));
 
-    return this.enqueueMediaElementTask_(poolMediaEl,
+    const swapOutOfDom = this.enqueueMediaElementTask_(poolMediaEl,
         new SwapOutOfDomTask(oldDomMediaEl, this.vsync_))
         .then(() => {
           poolMediaEl[REPLACED_MEDIA_PROPERTY_NAME] = null;
-          this.resetPoolMediaElementSource_(poolMediaEl);
         });
+
+    this.resetPoolMediaElementSource_(poolMediaEl);
+    return swapOutOfDom;
   }
 
 

--- a/extensions/amp-story/0.1/media-pool.js
+++ b/extensions/amp-story/0.1/media-pool.js
@@ -85,20 +85,6 @@ const ELEMENT_TASK_QUEUE_PROPERTY_NAME = '__AMP_MEDIA_ELEMENT_TASKS__';
 export const REPLACED_MEDIA_PROPERTY_NAME = 'replaced-media';
 
 
-// TODO(newmuis): DO NOT SUBMIT!!!! DEBUGGING ONLY!!!!
-let lastTime = 0;
-function doLogA() {
-  const currentTime = new Date().getTime();
-  const timeDelta = lastTime === 0 ? 0 : (currentTime - lastTime);
-  const timeStr = `@${currentTime} (+${timeDelta}ms)`;
-  const logArgs = [timeStr].concat(Array.from(arguments));
-  console.log.apply(this, logArgs);
-  lastTime = currentTime;
-}
-
-function doLog(){}
-
-
 /**
  * @type {!Object<string, !MediaPool>}
  */
@@ -451,17 +437,13 @@ export class MediaPool {
     return this.enqueueMediaElementTask_(poolMediaEl,
         new SwapIntoDomTask(domMediaEl, this.vsync_))
         .then(() => {
-          doLog('swapping into dom tasks', poolMediaEl);
           this.maybeResetAmpMedia_(ampMediaForPoolEl);
           this.maybeResetAmpMedia_(ampMediaForDomEl);
           this.enqueueMediaElementTask_(poolMediaEl,
               new UpdateSourcesTask(sources, this.vsync_));
           this.enqueueMediaElementTask_(poolMediaEl, new LoadTask());
-          doLog('swapping into dom done', poolMediaEl);
         }, () => {
-          doLog('force deallocating', poolMediaEl);
           this.forceDeallocateMediaElement_(poolMediaEl);
-          doLog('force deallocated', poolMediaEl);
         });
   }
 
@@ -509,7 +491,6 @@ export class MediaPool {
    * @private
    */
   swapPoolMediaElementOutOfDom_(poolMediaEl) {
-    doLog('swapping out of dom', poolMediaEl);
     const oldDomMediaElId = poolMediaEl[REPLACED_MEDIA_PROPERTY_NAME];
     const oldDomMediaEl = /** @type {!HTMLMediaElement} */ (dev().assertElement(
         this.domMediaEls_[oldDomMediaElId],
@@ -518,10 +499,8 @@ export class MediaPool {
     return this.enqueueMediaElementTask_(poolMediaEl,
         new SwapOutOfDomTask(oldDomMediaEl, this.vsync_))
         .then(() => {
-          doLog('swapping out of reset media element', poolMediaEl);
           poolMediaEl[REPLACED_MEDIA_PROPERTY_NAME] = null;
           this.resetPoolMediaElementSource_(poolMediaEl);
-          doLog('swapping out of dom done', poolMediaEl);
         });
   }
 
@@ -607,8 +586,7 @@ export class MediaPool {
       return Promise.resolve();
     }
 
-    return this.enqueueMediaElementTask_(poolMediaEl, new BlessTask())
-        .then(() => doLog('bless complete for', poolMediaEl));
+    return this.enqueueMediaElementTask_(poolMediaEl, new BlessTask());
   }
 
 
@@ -800,7 +778,6 @@ export class MediaPool {
    */
   executeNextMediaElementTask_(mediaEl) {
     const queue = mediaEl[ELEMENT_TASK_QUEUE_PROPERTY_NAME];
-    doLogA('element task queue contains ', queue, mediaEl);
 
     if (queue.length === 0) {
       return;

--- a/extensions/amp-story/0.1/media-pool.js
+++ b/extensions/amp-story/0.1/media-pool.js
@@ -255,7 +255,7 @@ function enqueueMediaElementTask(mediaEl, taskName) {
 
   const queue = mediaEl[ELEMENT_TASK_QUEUE_PROPERTY_NAME];
   queue.push(taskName);
-  console.log('element ' + mediaEl + ' task queue contains ' + JSON.stringify(queue));
+  console.log('element task queue contains ' + JSON.stringify(queue), mediaEl);
 
   if (queue.length === 1) {
     executeNextMediaElementTask(mediaEl);

--- a/extensions/amp-story/0.1/media-pool.js
+++ b/extensions/amp-story/0.1/media-pool.js
@@ -255,8 +255,7 @@ function enqueueMediaElementTask(mediaEl, taskName) {
 
   const queue = mediaEl[ELEMENT_TASK_QUEUE_PROPERTY_NAME];
   queue.push(taskName);
-  console.log('element ' + mediaEl.getAttribute('pool-element') +
-      ' task queue contains ' + JSON.stringify(queue));
+  console.log('element ' + mediaEl + ' task queue contains ' + JSON.stringify(queue));
 
   if (queue.length === 1) {
     executeNextMediaElementTask(mediaEl);

--- a/extensions/amp-story/0.1/media-pool.js
+++ b/extensions/amp-story/0.1/media-pool.js
@@ -53,6 +53,13 @@ let ElementTaskDef;
 
 
 /**
+ * @const {string}
+ */
+const ELEMENT_BLESSED_PROPERTY_NAME = '__AMP_MEDIA_IS_BLESSED__';
+
+
+
+/**
  * "Blesses" the specified media element for future playback without a user
  * gesture.  In order for this to bless the media element, this function must
  * be invoked in response to a user gesture.
@@ -61,6 +68,10 @@ let ElementTaskDef;
  *     element is complete.
  */
 function blessMediaElement(mediaEl) {
+  if (mediaEl[ELEMENT_BLESSED_PROPERTY_NAME]) {
+    return Promise.resolve();
+  }
+
   const isPaused = mediaEl.paused;
   const isMuted = mediaEl.muted;
   const currentTime = mediaEl.currentTime;
@@ -98,6 +109,7 @@ function blessMediaElement(mediaEl) {
 
     console.log('dispatch bless success');
     dispatch(mediaEl, 'bless', false);
+    mediaEl[ELEMENT_BLESSED_PROPERTY_NAME] = true;
   }).catch(reason => {
     console.log('dispatch bless fail');
     dispatch(mediaEl, 'bless', false);

--- a/extensions/amp-story/0.1/media-pool.js
+++ b/extensions/amp-story/0.1/media-pool.js
@@ -103,14 +103,13 @@ function blessMediaElement(mediaEl) {
       mediaEl.muted = true;
     }
 
-    console.log('dispatch bless success');
-    dispatch(mediaEl, 'bless', false);
     mediaEl[ELEMENT_BLESSED_PROPERTY_NAME] = true;
   }).catch(reason => {
-    console.log('dispatch bless fail');
-    dispatch(mediaEl, 'bless', false);
     dev().expectedError('AMP-STORY', 'Blessing media element failed:',
         reason, mediaEl);
+  }).then(() => {
+    console.log('dispatch bless');
+    dispatch(mediaEl, 'bless', false);
   });
 }
 
@@ -236,13 +235,6 @@ function executeNextMediaElementTask(mediaEl) {
   const task = ELEMENT_TASKS[taskName] || NOOP_ELEMENT_TASK;
 
   task(mediaEl)
-      .then(() => {
-        console.log('dispatch ' + taskName + ' in execute success');
-        dispatch(mediaEl, taskName, true);
-      }, () => {
-        console.log('dispatch ' + taskName + ' in execute failure');
-        dispatch(mediaEl, taskName, true);
-      })
       .catch(reason => dev().error('AMP-STORY', reason))
       .then(() => {
         queue.shift();
@@ -263,6 +255,7 @@ function enqueueMediaElementTask(mediaEl, taskName) {
 
   const queue = mediaEl[ELEMENT_TASK_QUEUE_PROPERTY_NAME];
   queue.push(taskName);
+  console.log('enqueue ' + taskName, mediaEl);
   console.log('element task queue contains ' + JSON.stringify(queue), mediaEl);
 
   if (queue.length === 1) {

--- a/extensions/amp-story/0.1/media-pool.js
+++ b/extensions/amp-story/0.1/media-pool.js
@@ -223,7 +223,6 @@ function executeNextMediaElementTask(mediaEl) {
   }
 
   const taskName = queue[0];
-  console.log('[task]', 'Executing', taskName, 'for', mediaEl);
   const task = ELEMENT_TASKS[taskName] || NOOP_ELEMENT_TASK;
 
   task(mediaEl)
@@ -247,8 +246,7 @@ function enqueueMediaElementTask(mediaEl, taskName) {
 
   const queue = mediaEl[ELEMENT_TASK_QUEUE_PROPERTY_NAME];
   queue.push(taskName);
-  console.log('[task]', 'Enqueued', taskName, 'for', mediaEl);
-  console.log('[task]', 'Queue contains', JSON.stringify(queue), mediaEl);
+  console.log('[task] Queue contains ' + JSON.stringify(queue), mediaEl);
 
   if (queue.length === 1) {
     executeNextMediaElementTask(mediaEl);

--- a/extensions/amp-story/0.1/media-pool.js
+++ b/extensions/amp-story/0.1/media-pool.js
@@ -605,16 +605,17 @@ export class MediaPool {
      */
     const playFn = () => {
       if (isPaused) {
-        return mediaEl.play();
+        // The playFn() invocation is wrapped in a Promise.resolve(...) due to
+        // the fact that some browsers return a promise from media elements'
+        // play() function, while others return a boolean.
+        return Promise.resolve(mediaEl.play());
       }
 
-      return null;
+      // This media element was already playing.
+      return Promise.resolve();
     };
 
-    // The playFn() invocation is wrapped in a Promise.resolve(...) due to the
-    // fact that some browsers return a promise from media elements' play()
-    // function, while others return a boolean.
-    return Promise.resolve(playFn()).then(() => {
+    return playFn().then(() => {
       mediaEl.muted = false;
 
       if (isPaused) {

--- a/extensions/amp-story/0.1/media-pool.js
+++ b/extensions/amp-story/0.1/media-pool.js
@@ -605,17 +605,16 @@ export class MediaPool {
      */
     const playFn = () => {
       if (isPaused) {
-        // The playFn() invocation is wrapped in a Promise.resolve(...) due to
-        // the fact that some browsers return a promise from media elements'
-        // play() function, while others return a boolean.
-        return Promise.resolve(mediaEl.play());
+        return mediaEl.play();
       }
 
-      // This media element was already playing.
-      return Promise.resolve();
+      return null;
     };
 
-    return playFn().then(() => {
+    // The playFn() invocation is wrapped in a Promise.resolve(...) due to the
+    // fact that some browsers return a promise from media elements' play()
+    // function, while others return a boolean.
+    return Promise.resolve(playFn()).then(() => {
       mediaEl.muted = false;
 
       if (isPaused) {

--- a/extensions/amp-story/0.1/media-pool.js
+++ b/extensions/amp-story/0.1/media-pool.js
@@ -255,8 +255,8 @@ function enqueueMediaElementTask(mediaEl, taskName) {
 
   const queue = mediaEl[ELEMENT_TASK_QUEUE_PROPERTY_NAME];
   queue.push(taskName);
-  // console.log('element ' + mediaEl.getAttribute('pool-element') +
-  //     ' task queue contains ' + JSON.stringify(queue));
+  console.log('element ' + mediaEl.getAttribute('pool-element') +
+      ' task queue contains ' + JSON.stringify(queue));
 
   if (queue.length === 1) {
     executeNextMediaElementTask(mediaEl);

--- a/extensions/amp-story/0.1/media-pool.js
+++ b/extensions/amp-story/0.1/media-pool.js
@@ -100,7 +100,7 @@ function blessMediaElement(mediaEl) {
   blessPromise.catch(reason => {
     dev().expectedError('AMP-STORY', 'Blessing media element failed:',
         reason, mediaEl);
-  });
+  }).then(() => dispatch(mediaEl, 'bless', false));
 
   return blessPromise;
 }
@@ -229,7 +229,6 @@ function executeNextMediaElementTask(mediaEl) {
 
   task(mediaEl)
       .catch(reason => dev().error('AMP-STORY', reason))
-      .then(() => dispatch(mediaEl, taskName, false))
       .then(() => {
         queue.shift();
         executeNextMediaElementTask(mediaEl);
@@ -906,7 +905,7 @@ export class MediaPool {
     const blessPromises = [];
     this.forEachMediaElement_(mediaEl => {
       this.bless_(mediaEl);
-      blessPromises.push(listenOncePromise(mediaEl, ElementTaskName.BLESS));
+      blessPromises.push(listenOncePromise(mediaEl, 'bless'));
     });
 
     return Promise.all(blessPromises)

--- a/extensions/amp-story/0.1/media-pool.js
+++ b/extensions/amp-story/0.1/media-pool.js
@@ -615,6 +615,7 @@ export class MediaPool {
       return Promise.resolve();
     };
 
+    console.log('blessing video');
     return playFn().then(() => {
       mediaEl.muted = false;
 
@@ -626,6 +627,7 @@ export class MediaPool {
       if (isMuted) {
         mediaEl.muted = true;
       }
+      console.log('blessed video');
     }).catch(reason => {
       dev().expectedError('AMP-STORY', 'Blessing media element failed:',
           reason, mediaEl);
@@ -843,6 +845,7 @@ class Sources {
   applyToElement(element) {
     Sources.removeFrom(element);
 
+    console.log('updating sources');
     if (!this.srcAttr_) {
       element.removeAttribute('src');
     } else {
@@ -851,9 +854,12 @@ class Sources {
 
     Array.prototype.forEach.call(this.srcEls_,
         srcEl => element.appendChild(srcEl));
+    console.log('updated sources');
 
     // Reset media element after changing sources.
+    console.log('loading media');
     element.load();
+    console.log('loaded media');
   }
 
 

--- a/extensions/amp-story/0.1/media-pool.js
+++ b/extensions/amp-story/0.1/media-pool.js
@@ -766,13 +766,21 @@ export class MediaPool {
    * gesture.  In order for this to bless the media element, this function must
    * be invoked in response to a user gesture.
    * @param {!HTMLMediaElement} poolMediaEl The media element to bless.
+   * @return {!Promise} A promise that is resolved when blessing the media
+   *     element is complete.
    */
   bless_(poolMediaEl) {
     if (poolMediaEl[ELEMENT_BLESSED_PROPERTY_NAME]) {
-      return;
+      return Promise.resolve();
     }
 
+    const blessPromise = listenOncePromise(poolMediaEl, ElementTaskName.BLESS, {
+      capture: true,
+    }).then(() => console.log('bless complete for', poolMediaEl));
+
     enqueueMediaElementTask(poolMediaEl, ElementTaskName.BLESS);
+
+    return blessPromise;
   }
 
 
@@ -923,11 +931,7 @@ export class MediaPool {
 
     const blessPromises = [];
     this.forEachMediaElement_(mediaEl => {
-      const blessPromise = listenOncePromise(mediaEl, ElementTaskName.BLESS, {
-        capture: true,
-      }).then(() => console.log('bless complete for', mediaEl));
-      this.bless_(mediaEl);
-      blessPromises.push(blessPromise);
+      blessPromises.push(this.bless_(mediaEl));
     });
 
     return Promise.all(blessPromises)

--- a/extensions/amp-story/0.1/media-pool.js
+++ b/extensions/amp-story/0.1/media-pool.js
@@ -219,7 +219,6 @@ function ampMediaElementFor(el) {
  */
 function executeNextMediaElementTask(mediaEl) {
   const queue = mediaEl[ELEMENT_TASK_QUEUE_PROPERTY_NAME];
-  console.log('[task]', 'Queue contains', JSON.stringify(queue), mediaEl);
   if (queue.length === 0) {
     return;
   }
@@ -250,6 +249,7 @@ function enqueueMediaElementTask(mediaEl, taskName) {
   const queue = mediaEl[ELEMENT_TASK_QUEUE_PROPERTY_NAME];
   queue.push(taskName);
   console.log('[task]', 'Enqueued', taskName, 'for', mediaEl);
+  console.log('[task]', 'Queue contains', JSON.stringify(queue), mediaEl);
 
   if (queue.length === 1) {
     executeNextMediaElementTask(mediaEl);

--- a/extensions/amp-story/0.1/media-pool.js
+++ b/extensions/amp-story/0.1/media-pool.js
@@ -68,30 +68,12 @@ const ELEMENT_BLESSED_PROPERTY_NAME = '__AMP_MEDIA_IS_BLESSED__';
  *     element is complete.
  */
 function blessMediaElement(mediaEl) {
+  console.log('blessing element', mediaEl);
   const isPaused = mediaEl.paused;
   const isMuted = mediaEl.muted;
   const currentTime = mediaEl.currentTime;
 
-  /**
-   * @return {!Promise} A promise that is resolved when playback has been
-   *    initiated or rejected if playback fails to initiate.  If the media
-   *    element is already playing, the promise is immediately resolved
-   *    without playing the media element again, to avoid interrupting
-   *    playback.
-   */
-  const playFn = () => {
-    if (isPaused) {
-      // The playFn() invocation is wrapped in a Promise.resolve(...) due to
-      // the fact that some browsers return a promise from media elements'
-      // play() function, while others return a boolean.
-      return Promise.resolve(mediaEl.play());
-    }
-
-    // This media element was already playing.
-    return Promise.resolve();
-  };
-
-  return playFn().then(() => {
+  return Promise.resolve(mediaEl.play()).then(() => {
     mediaEl.muted = false;
 
     if (isPaused) {

--- a/extensions/amp-story/0.1/media-pool.js
+++ b/extensions/amp-story/0.1/media-pool.js
@@ -925,6 +925,7 @@ export class MediaPool {
 
     return Promise.all(blessPromises)
         .then(() => {
+          console.log('all blessed');
           this.blessed_ = true;
         }).catch(reason => {
           dev().expectedError('AMP-STORY', 'Blessing all media failed: ',

--- a/extensions/amp-story/0.1/media-pool.js
+++ b/extensions/amp-story/0.1/media-pool.js
@@ -171,7 +171,6 @@ export class MediaPool {
         const audioEl = this.win_.document.createElement('audio');
         audioEl.setAttribute('src', BLANK_AUDIO_SRC);
         audioEl.setAttribute('muted', '');
-        audioEl.muted = true;
         audioEl.classList.add('i-amphtml-pool-media');
         audioEl.classList.add('i-amphtml-pool-audio');
         return audioEl;
@@ -180,7 +179,6 @@ export class MediaPool {
         const videoEl = this.win_.document.createElement('video');
         videoEl.setAttribute('src', BLANK_VIDEO_SRC);
         videoEl.setAttribute('muted', '');
-        videoEl.muted = true;
         videoEl.setAttribute('playsinline', '');
         videoEl.classList.add('i-amphtml-pool-media');
         videoEl.classList.add('i-amphtml-pool-video');
@@ -615,7 +613,6 @@ export class MediaPool {
       return Promise.resolve();
     };
 
-    console.log('blessing video');
     return playFn().then(() => {
       mediaEl.muted = false;
 
@@ -627,7 +624,6 @@ export class MediaPool {
       if (isMuted) {
         mediaEl.muted = true;
       }
-      console.log('blessed video');
     }).catch(reason => {
       dev().expectedError('AMP-STORY', 'Blessing media element failed:',
           reason, mediaEl);
@@ -845,7 +841,6 @@ class Sources {
   applyToElement(element) {
     Sources.removeFrom(element);
 
-    console.log('updating sources');
     if (!this.srcAttr_) {
       element.removeAttribute('src');
     } else {
@@ -854,12 +849,9 @@ class Sources {
 
     Array.prototype.forEach.call(this.srcEls_,
         srcEl => element.appendChild(srcEl));
-    console.log('updated sources');
 
     // Reset media element after changing sources.
-    console.log('loading media');
     element.load();
-    console.log('loaded media');
   }
 
 

--- a/extensions/amp-story/0.1/media-pool.js
+++ b/extensions/amp-story/0.1/media-pool.js
@@ -219,7 +219,7 @@ function ampMediaElementFor(el) {
  */
 function executeNextMediaElementTask(mediaEl) {
   const queue = mediaEl[ELEMENT_TASK_QUEUE_PROPERTY_NAME];
-  console.log('[task]', 'Queue contains', JSON.stringify(queue));
+  console.log('[task]', 'Queue contains', JSON.stringify(queue), mediaEl);
   if (queue.length === 0) {
     return;
   }

--- a/extensions/amp-story/0.1/media-pool.js
+++ b/extensions/amp-story/0.1/media-pool.js
@@ -84,7 +84,7 @@ function blessMediaElement(mediaEl) {
     return Promise.resolve();
   };
 
-  const blessPromise = playFn().then(() => {
+  return playFn().then(() => {
     mediaEl.muted = false;
 
     if (isPaused) {
@@ -95,14 +95,13 @@ function blessMediaElement(mediaEl) {
     if (isMuted) {
       mediaEl.muted = true;
     }
-  });
 
-  blessPromise.catch(reason => {
+    dispatch(mediaEl, 'bless', false);
+  }).catch(reason => {
+    dispatch(mediaEl, 'bless', false);
     dev().expectedError('AMP-STORY', 'Blessing media element failed:',
         reason, mediaEl);
-  }).then(() => dispatch(mediaEl, 'bless', false));
-
-  return blessPromise;
+  });
 }
 
 

--- a/extensions/amp-story/0.1/media-pool.js
+++ b/extensions/amp-story/0.1/media-pool.js
@@ -68,10 +68,6 @@ const ELEMENT_BLESSED_PROPERTY_NAME = '__AMP_MEDIA_IS_BLESSED__';
  *     element is complete.
  */
 function blessMediaElement(mediaEl) {
-  if (mediaEl[ELEMENT_BLESSED_PROPERTY_NAME]) {
-    return Promise.resolve();
-  }
-
   const isPaused = mediaEl.paused;
   const isMuted = mediaEl.muted;
   const currentTime = mediaEl.currentTime;
@@ -777,6 +773,10 @@ export class MediaPool {
    * @param {!HTMLMediaElement} poolMediaEl The media element to bless.
    */
   bless_(poolMediaEl) {
+    if (poolMediaEl[ELEMENT_BLESSED_PROPERTY_NAME]) {
+      return;
+    }
+
     enqueueMediaElementTask(poolMediaEl, ElementTaskName.BLESS);
   }
 

--- a/extensions/amp-story/0.1/media-pool.js
+++ b/extensions/amp-story/0.1/media-pool.js
@@ -237,7 +237,9 @@ function executeNextMediaElementTask(mediaEl) {
   task(mediaEl)
       .catch(reason => dev().error('AMP-STORY', reason))
       .then(() => {
-        queue.shift();
+        const oldTaskName = queue.shift();
+        console.log('dequeue ' + oldTaskName, mediaEl);
+        console.log('element task queue contains ' + JSON.stringify(queue), mediaEl);
         executeNextMediaElementTask(mediaEl);
       });
 }

--- a/extensions/amp-story/0.1/media-pool.js
+++ b/extensions/amp-story/0.1/media-pool.js
@@ -917,8 +917,9 @@ export class MediaPool {
 
     const blessPromises = [];
     this.forEachMediaElement_(mediaEl => {
-      const blessPromise = listenOncePromise(mediaEl, ElementTaskName.BLESS)
-          .then(() => console.log('bless complete for', mediaEl));
+      const blessPromise = listenOncePromise(mediaEl, ElementTaskName.BLESS, {
+        capture: true,
+      }).then(() => console.log('bless complete for', mediaEl));
       this.bless_(mediaEl);
       blessPromises.push(blessPromise);
     });

--- a/extensions/amp-story/0.1/media-pool.js
+++ b/extensions/amp-story/0.1/media-pool.js
@@ -219,12 +219,13 @@ function ampMediaElementFor(el) {
  */
 function executeNextMediaElementTask(mediaEl) {
   const queue = mediaEl[ELEMENT_TASK_QUEUE_PROPERTY_NAME];
-
+  console.log('[task]', 'Queue contains', JSON.stringify(queue));
   if (queue.length === 0) {
     return;
   }
 
   const taskName = queue[0];
+  console.log('[task]', 'Executing', taskName, 'for', mediaEl);
   const task = ELEMENT_TASKS[taskName] || NOOP_ELEMENT_TASK;
 
   task(mediaEl)
@@ -248,6 +249,7 @@ function enqueueMediaElementTask(mediaEl, taskName) {
 
   const queue = mediaEl[ELEMENT_TASK_QUEUE_PROPERTY_NAME];
   queue.push(taskName);
+  console.log('[task]', 'Enqueued', taskName, 'for', mediaEl);
 
   if (queue.length === 1) {
     executeNextMediaElementTask(mediaEl);

--- a/extensions/amp-story/0.1/media-tasks.js
+++ b/extensions/amp-story/0.1/media-tasks.js
@@ -1,0 +1,484 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {isConnectedNode} from '../../../src/dom';
+import {dev} from '../../../src/log';
+import {Sources} from './sources';
+
+
+
+/**
+ * The name for a boolean property on an element indicating whether that element
+ * has already been "blessed".
+ * @const {string}
+ */
+export const ELEMENT_BLESSED_PROPERTY_NAME = '__AMP_MEDIA_IS_BLESSED__';
+
+
+/**
+ * CSS class names that should not be removed from an element when swapping it
+ * into/out of the DOM.
+ * @const {!Array<string>}
+ */
+const PROTECTED_CSS_CLASS_NAMES = [
+  'i-amphtml-pool-media',
+  'i-amphtml-pool-audio',
+  'i-amphtml-pool-video',
+];
+
+
+/**
+ * Attribute names that should not be removed from an element when swapping it
+ * into/out of the DOM.
+ * @const {!Array<string>}
+ */
+const PROTECTED_ATTRIBUTES = [
+  'id',
+  'src',
+  'class',
+  'autoplay',
+];
+
+
+
+/**
+ * Determines whether a CSS class name is allowed to be removed or copied from
+ * media elements.
+ * @param {string} cssClassName The CSS class name name to check.
+ * @return {boolean} true, if the specified CSS class name is allowed to be
+ *     removed or copied from media elements; false otherwise.
+ * @private
+ */
+function isProtectedCssClassName(cssClassName) {
+  return PROTECTED_CSS_CLASS_NAMES.indexOf(cssClassName) >= 0;
+}
+
+
+/**
+ * Determines whether an attribute is allowed to be removed or copied from
+ * media elements.
+ * @param {string} attributeName The attribute name to check.
+ * @return {boolean} true, if the specified attribute is allowed to be removed
+ *     or copied from media elements; false otherwise.
+ * @private
+ */
+function isProtectedAttributeName(attributeName) {
+  return PROTECTED_ATTRIBUTES.indexOf(attributeName) >= 0;
+}
+
+
+/**
+ * Copies all unprotected CSS classes from fromEl to toEl.
+ * @param {!HTMLMediaElement} fromEl The element from which CSS classes should
+ *     be copied.
+ * @param {!HTMLMediaElement} toEl The element to which CSS classes should be
+ *     copied.
+ * @private
+ */
+function copyCssClasses(fromEl, toEl) {
+  // Remove all of the unprotected CSS classes from the toEl.
+  for (let i = toEl.classList.length - 1; i >= 0; i--) {
+    const cssClass = toEl.classList.item(i);
+    if (!isProtectedCssClassName(cssClass)) {
+      toEl.classList.remove(cssClass);
+    }
+  }
+
+  // Copy all of the unprotected CSS classes from the fromEl to the toEl.
+  for (let i = 0; i < fromEl.classList.length; i++) {
+    const cssClass = fromEl.classList.item(i);
+    if (!isProtectedCssClassName(cssClass)) {
+      toEl.classList.add(cssClass);
+    }
+  }
+}
+
+
+/**
+ * Copies all unprotected attributes from fromEl to toEl.
+ * @param {!HTMLMediaElement} fromEl The element from which attributes should
+ *     be copied.
+ * @param {!HTMLMediaElement} toEl The element to which attributes should be
+ *     copied.
+ * @private
+ */
+function copyAttributes(fromEl, toEl) {
+  const fromAttributes = fromEl.attributes;
+  const toAttributes = toEl.attributes;
+
+  // Remove all of the unprotected attributes from the toEl.
+  for (let i = toAttributes.length - 1; i >= 0; i--) {
+    const attributeName = toAttributes[i].name;
+    if (!isProtectedAttributeName(attributeName)) {
+      toEl.removeAttribute(attributeName);
+    }
+  }
+
+  // Copy all of the unprotected attributes from the fromEl to the toEl.
+  for (let i = 0; i < fromAttributes.length; i++) {
+    const attributeName = fromAttributes[i].name;
+    const attributeValue = fromAttributes[i].value;
+    if (!isProtectedAttributeName(attributeName)) {
+      toEl.setAttribute(attributeName, attributeValue);
+    }
+  }
+}
+
+
+// TODO(newmuis): DO NOT SUBMIT!!!! DEBUGGING ONLY!!!!
+let lastTime = 0;
+function doLog() {
+  const currentTime = new Date().getTime();
+  const timeDelta = lastTime === 0 ? 0 : (currentTime - lastTime);
+  const timeStr = `@${currentTime} (+${timeDelta}ms)`;
+  const logArgs = [timeStr].concat(Array.from(arguments));
+  //console.log.apply(this, logArgs);
+  lastTime = currentTime;
+}
+
+
+
+/**
+ * Base class for tasks executed in order on HTMLMediaElements.
+ */
+class MediaTask {
+  constructor(name) {
+    /** @private @const {string} */
+    this.name_ = name;
+
+    /** @private {?function()} */
+    this.resolve_ = null;
+
+    /** @private {?function(*)} */
+    this.reject_ = null;
+
+    /** @private @const {!Promise} */
+    this.completionPromise_ = new Promise((resolve, reject) => {
+      this.resolve_ = resolve;
+      this.reject_ = reject;
+    });
+  }
+
+  /**
+   * @return {string} The name of this task.
+   */
+  getName() {
+    return this.name_;
+  }
+
+  /**
+   * @return {!Promise<*>} A promise that is resolved when the task has
+   *     completed execution.
+   */
+  whenComplete() {
+    return this.completionPromise_;
+  }
+
+  /**
+   * @param {!HTMLMediaElement} mediaEl The media element on which this task
+   *     should be executed.
+   */
+  execute(mediaEl) {
+    return this.executeInternal(mediaEl)
+        .then(this.resolve_, this.reject_);
+  }
+
+  /**
+   * @param {!HTMLMediaElement} unusedMediaEl The media element on which this
+   *     task should be executed.
+   * @protected
+   */
+  executeInternal(unusedMediaEl) {
+    return Promise.resolve();
+  }
+
+  /**
+   * @return {boolean} true, if this task must be executed synchronously, e.g.
+   *    if it requires a user gesture.
+   */
+  requiresSynchronousExecution() {
+    return false;
+  }
+
+  /**
+   * @param {*} reason The reason for failing the task.
+   * @protected
+   */
+  failTask(reason) {
+    this.reject_(reason);
+  }
+}
+
+
+/**
+ * Plays the specified media element.
+ */
+export class PlayTask extends MediaTask {
+  constructor() {
+    super('play');
+  }
+
+  /** @override */
+  executeInternal(mediaEl) {
+    if (!mediaEl.paused) {
+      // We do not want to invoke play() if the media element is already
+      // playing, as this can interrupt playback in some browsers.
+      return Promise.resolve();
+    }
+
+    // The play() invocation is wrapped in a Promise.resolve(...) due to the
+    // fact that some browsers return a promise from media elements' play()
+    // function, while others return a boolean.
+    return Promise.resolve(mediaEl.play());
+  }
+}
+
+
+/**
+ * Pauses the specified media element.
+ */
+export class PauseTask extends MediaTask {
+  constructor() {
+    super('pause');
+  }
+
+  /** @override */
+  executeInternal(mediaEl) {
+    mediaEl.pause();
+    return Promise.resolve();
+  }
+}
+
+
+/**
+ * Unmutes the specified media element.
+ */
+export class UnmuteTask extends MediaTask {
+  constructor() {
+    super('unmute');
+  }
+
+  /** @override */
+  executeInternal(mediaEl) {
+    doLog('unmuting video');
+    mediaEl.muted = false;
+    mediaEl.removeAttribute('muted');
+    doLog('video unmuted');
+    return Promise.resolve();
+  }
+}
+
+
+/**
+ * Mutes the specified media element.
+ */
+export class MuteTask extends MediaTask {
+  constructor() {
+    super('mute');
+  }
+
+  /** @override */
+  executeInternal(mediaEl) {
+    mediaEl.muted = true;
+    mediaEl.setAttribute('muted', '');
+    return Promise.resolve();
+  }
+}
+
+
+/**
+ * Seeks the specified media element to the beginning.
+ */
+export class RewindTask extends MediaTask {
+  constructor() {
+    super('rewind');
+  }
+
+  /** @override */
+  executeInternal(mediaEl) {
+    mediaEl.currentTime = 0;
+    return Promise.resolve();
+  }
+}
+
+
+/**
+ * Loads the specified media element.
+ */
+export class LoadTask extends MediaTask {
+  constructor() {
+    super('load');
+  }
+
+  /** @override */
+  executeInternal(mediaEl) {
+    mediaEl.load();
+    return Promise.resolve();
+  }
+}
+
+
+/**
+ * "Blesses" the specified media element for future playback without a user
+ * gesture.  In order for this to bless the media element, this function must
+ * be invoked in response to a user gesture.
+ */
+export class BlessTask extends MediaTask {
+  constructor() {
+    super('bless');
+  }
+
+  /** @override */
+  requiresSynchronousExecution() {
+    return true;
+  }
+
+  /** @override */
+  executeInternal(mediaEl) {
+    doLog('blessing element', mediaEl);
+    const isPaused = mediaEl.paused;
+    const isMuted = mediaEl.muted;
+    const currentTime = mediaEl.currentTime;
+
+    doLog('media to be played for blessing', mediaEl);
+    const playResult = mediaEl.play();
+    doLog('media has been played for blessing', mediaEl, playResult);
+
+    return Promise.resolve(playResult).then(() => {
+      doLog('inner bless', mediaEl);
+      mediaEl.muted = false;
+
+      if (isPaused) {
+        mediaEl.pause();
+        mediaEl.currentTime = currentTime;
+      }
+
+      if (isMuted) {
+        mediaEl.muted = true;
+      }
+
+      mediaEl[ELEMENT_BLESSED_PROPERTY_NAME] = true;
+    }).catch(reason => {
+      doLog('bless failed', mediaEl);
+      dev().expectedError('AMP-STORY', 'Blessing media element failed:',
+          reason, mediaEl);
+    });
+  }
+}
+
+
+/**
+ * Updates the sources of the specified media element.
+ */
+export class UpdateSourcesTask extends MediaTask {
+  /**
+   * @param {!Sources} newSources The sources to which the media element should
+   *     be updated.
+   * @param {!../../../src/service/vsync-impl.Vsync} vsync
+   */
+  constructor(newSources, vsync) {
+    super('update-src');
+
+    /** @private @const {!Sources} */
+    this.newSources_ = newSources;
+
+    /** @private @const {!../../../src/service/vsync-impl.Vsync} */
+    this.vsync_ = vsync;
+  }
+
+  /** @override */
+  executeInternal(mediaEl) {
+    return this.vsync_.mutatePromise(() => {
+      Sources.removeFrom(mediaEl);
+      this.newSources_.applyToElement(mediaEl);
+    });
+  }
+}
+
+
+/**
+ * Swaps a media element into the DOM, in the place of another media element.
+ */
+export class SwapIntoDomTask extends MediaTask {
+  /**
+   * @param {!HTMLMediaElement} replacedMediaEl The element to be replaced by
+   *     the media element on which this task is executed.
+   * @param {!../../../src/service/vsync-impl.Vsync} vsync
+   */
+  constructor(replacedMediaEl, vsync) {
+    super('swap-into-dom');
+
+    /** @private @const {!HTMLMediaElement} */
+    this.replacedMediaEl_ = replacedMediaEl;
+
+    /** @private @const {!../../../src/service/vsync-impl.Vsync} */
+    this.vsync_ = vsync;
+  }
+
+  /** @override */
+  executeInternal(mediaEl) {
+    doLog('swapping into dom', mediaEl);
+
+    return this.vsync_.mutatePromise(() => {
+      if (!isConnectedNode(this.replacedMediaEl_)) {
+        this.failTask('Cannot swap media for element that is not in DOM.');
+        return;
+      }
+
+      doLog('swapping into dom mutate', mediaEl);
+      copyCssClasses(this.replacedMediaEl_, mediaEl);
+      copyAttributes(this.replacedMediaEl_, mediaEl);
+      this.replacedMediaEl_.parentElement
+          .replaceChild(mediaEl, this.replacedMediaEl_);
+      doLog('swapping into dom mutate done', mediaEl);
+    });
+  }
+}
+
+
+/**
+ * Swaps a media element out the DOM, in the place of a placeholder media
+ * element.
+ */
+export class SwapOutOfDomTask extends MediaTask {
+  /**
+   * @param {!HTMLMediaElement} placeholderMediaEl The element to be replaced by
+   *     the media element on which this task is executed.
+   * @param {!../../../src/service/vsync-impl.Vsync} vsync
+   */
+  constructor(placeholderMediaEl, vsync) {
+    super('swap-out-of-dom');
+
+    /** @private @const {!HTMLMediaElement} */
+    this.placeholderMediaEl_ = placeholderMediaEl;
+
+    /** @private @const {!../../../src/service/vsync-impl.Vsync} */
+    this.vsync_ = vsync;
+  }
+
+  /** @override */
+  executeInternal(mediaEl) {
+    doLog('swapping out of dom', mediaEl);
+
+    return this.vsync_.mutatePromise(() => {
+      doLog('swapping out of dom mutate', mediaEl);
+      copyCssClasses(mediaEl, this.placeholderMediaEl_);
+      copyAttributes(mediaEl, this.placeholderMediaEl_);
+      mediaEl.parentElement.replaceChild(this.placeholderMediaEl_, mediaEl);
+      doLog('swapping out of dom mutate done', mediaEl);
+    });
+  }
+}

--- a/extensions/amp-story/0.1/media-tasks.js
+++ b/extensions/amp-story/0.1/media-tasks.js
@@ -384,10 +384,9 @@ export class UpdateSourcesTask extends MediaTask {
 
   /** @override */
   executeInternal(mediaEl) {
-    return this.vsync_.mutatePromise(() => {
-      Sources.removeFrom(mediaEl);
-      this.newSources_.applyToElement(mediaEl);
-    });
+    Sources.removeFrom(mediaEl);
+    this.newSources_.applyToElement(mediaEl);
+    return Promise.resolve();
   }
 }
 
@@ -413,17 +412,16 @@ export class SwapIntoDomTask extends MediaTask {
 
   /** @override */
   executeInternal(mediaEl) {
-    return this.vsync_.mutatePromise(() => {
-      if (!isConnectedNode(this.replacedMediaEl_)) {
-        this.failTask('Cannot swap media for element that is not in DOM.');
-        return;
-      }
+    if (!isConnectedNode(this.replacedMediaEl_)) {
+      this.failTask('Cannot swap media for element that is not in DOM.');
+      return Promise.resolve();
+    }
 
-      copyCssClasses(this.replacedMediaEl_, mediaEl);
-      copyAttributes(this.replacedMediaEl_, mediaEl);
-      this.replacedMediaEl_.parentElement
-          .replaceChild(mediaEl, this.replacedMediaEl_);
-    });
+    copyCssClasses(this.replacedMediaEl_, mediaEl);
+    copyAttributes(this.replacedMediaEl_, mediaEl);
+    this.replacedMediaEl_.parentElement
+        .replaceChild(mediaEl, this.replacedMediaEl_);
+    return Promise.resolve();
   }
 }
 
@@ -450,10 +448,9 @@ export class SwapOutOfDomTask extends MediaTask {
 
   /** @override */
   executeInternal(mediaEl) {
-    return this.vsync_.mutatePromise(() => {
-      copyCssClasses(mediaEl, this.placeholderMediaEl_);
-      copyAttributes(mediaEl, this.placeholderMediaEl_);
-      mediaEl.parentElement.replaceChild(this.placeholderMediaEl_, mediaEl);
-    });
+    copyCssClasses(mediaEl, this.placeholderMediaEl_);
+    copyAttributes(mediaEl, this.placeholderMediaEl_);
+    mediaEl.parentElement.replaceChild(this.placeholderMediaEl_, mediaEl);
+    return Promise.resolve();
   }
 }

--- a/extensions/amp-story/0.1/media-tasks.js
+++ b/extensions/amp-story/0.1/media-tasks.js
@@ -190,6 +190,8 @@ class MediaTask {
   /**
    * @param {!HTMLMediaElement} mediaEl The media element on which this task
    *     should be executed.
+   * @return {!Promise} A promise that is resolved when the task has completed
+   *     execution.
    */
   execute(mediaEl) {
     return this.executeInternal(mediaEl)

--- a/extensions/amp-story/0.1/media-tasks.js
+++ b/extensions/amp-story/0.1/media-tasks.js
@@ -142,7 +142,7 @@ function copyAttributes(fromEl, toEl) {
 /**
  * Base class for tasks executed in order on HTMLMediaElements.
  */
-class MediaTask {
+export class MediaTask {
   constructor(name) {
     /** @private @const {string} */
     this.name_ = name;

--- a/extensions/amp-story/0.1/media-tasks.js
+++ b/extensions/amp-story/0.1/media-tasks.js
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import {isConnectedNode} from '../../../src/dom';
-import {dev} from '../../../src/log';
 import {Sources} from './sources';
+import {dev} from '../../../src/log';
+import {isConnectedNode} from '../../../src/dom';
 
 
 

--- a/extensions/amp-story/0.1/media-tasks.js
+++ b/extensions/amp-story/0.1/media-tasks.js
@@ -340,9 +340,7 @@ export class BlessTask extends MediaTask {
     const isMuted = mediaEl.muted;
     const currentTime = mediaEl.currentTime;
 
-    const playResult = mediaEl.play();
-
-    return Promise.resolve(playResult).then(() => {
+    return Promise.resolve(mediaEl.play()).then(() => {
       mediaEl.muted = false;
 
       if (isPaused) {

--- a/extensions/amp-story/0.1/media-tasks.js
+++ b/extensions/amp-story/0.1/media-tasks.js
@@ -340,7 +340,10 @@ export class BlessTask extends MediaTask {
     const isMuted = mediaEl.muted;
     const currentTime = mediaEl.currentTime;
 
-    return Promise.resolve(mediaEl.play()).then(() => {
+    const whenPlaying = isPaused ?
+      Promise.resolve(mediaEl.play()) : Promise.resolve();
+
+    return whenPlaying.then(() => {
       mediaEl.muted = false;
 
       if (isPaused) {

--- a/extensions/amp-story/0.1/media-tasks.js
+++ b/extensions/amp-story/0.1/media-tasks.js
@@ -138,18 +138,6 @@ function copyAttributes(fromEl, toEl) {
 }
 
 
-// TODO(newmuis): DO NOT SUBMIT!!!! DEBUGGING ONLY!!!!
-let lastTime = 0;
-function doLog() {
-  const currentTime = new Date().getTime();
-  const timeDelta = lastTime === 0 ? 0 : (currentTime - lastTime);
-  const timeStr = `@${currentTime} (+${timeDelta}ms)`;
-  const logArgs = [timeStr].concat(Array.from(arguments));
-  //console.log.apply(this, logArgs);
-  lastTime = currentTime;
-}
-
-
 
 /**
  * Base class for tasks executed in order on HTMLMediaElements.
@@ -275,10 +263,8 @@ export class UnmuteTask extends MediaTask {
 
   /** @override */
   executeInternal(mediaEl) {
-    doLog('unmuting video');
     mediaEl.muted = false;
     mediaEl.removeAttribute('muted');
-    doLog('video unmuted');
     return Promise.resolve();
   }
 }
@@ -350,17 +336,13 @@ export class BlessTask extends MediaTask {
 
   /** @override */
   executeInternal(mediaEl) {
-    doLog('blessing element', mediaEl);
     const isPaused = mediaEl.paused;
     const isMuted = mediaEl.muted;
     const currentTime = mediaEl.currentTime;
 
-    doLog('media to be played for blessing', mediaEl);
     const playResult = mediaEl.play();
-    doLog('media has been played for blessing', mediaEl, playResult);
 
     return Promise.resolve(playResult).then(() => {
-      doLog('inner bless', mediaEl);
       mediaEl.muted = false;
 
       if (isPaused) {
@@ -374,7 +356,6 @@ export class BlessTask extends MediaTask {
 
       mediaEl[ELEMENT_BLESSED_PROPERTY_NAME] = true;
     }).catch(reason => {
-      doLog('bless failed', mediaEl);
       dev().expectedError('AMP-STORY', 'Blessing media element failed:',
           reason, mediaEl);
     });
@@ -432,20 +413,16 @@ export class SwapIntoDomTask extends MediaTask {
 
   /** @override */
   executeInternal(mediaEl) {
-    doLog('swapping into dom', mediaEl);
-
     return this.vsync_.mutatePromise(() => {
       if (!isConnectedNode(this.replacedMediaEl_)) {
         this.failTask('Cannot swap media for element that is not in DOM.');
         return;
       }
 
-      doLog('swapping into dom mutate', mediaEl);
       copyCssClasses(this.replacedMediaEl_, mediaEl);
       copyAttributes(this.replacedMediaEl_, mediaEl);
       this.replacedMediaEl_.parentElement
           .replaceChild(mediaEl, this.replacedMediaEl_);
-      doLog('swapping into dom mutate done', mediaEl);
     });
   }
 }
@@ -473,14 +450,10 @@ export class SwapOutOfDomTask extends MediaTask {
 
   /** @override */
   executeInternal(mediaEl) {
-    doLog('swapping out of dom', mediaEl);
-
     return this.vsync_.mutatePromise(() => {
-      doLog('swapping out of dom mutate', mediaEl);
       copyCssClasses(mediaEl, this.placeholderMediaEl_);
       copyAttributes(mediaEl, this.placeholderMediaEl_);
       mediaEl.parentElement.replaceChild(this.placeholderMediaEl_, mediaEl);
-      doLog('swapping out of dom mutate done', mediaEl);
     });
   }
 }

--- a/extensions/amp-story/0.1/sources.js
+++ b/extensions/amp-story/0.1/sources.js
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  removeElement,
+  scopedQuerySelectorAll,
+} from '../../../src/dom';
+import {ampMediaElementFor} from './utils';
+
+
+
+export class Sources {
+  /**
+   * @param {string} srcAttr The 'src' attribute of the media element.
+   * @param {!IArrayLike<!Element>} srcEls Any child <source> tags of the media
+   *     element.
+   */
+  constructor(srcAttr, srcEls) {
+    /** @private @const {?string} */
+    this.srcAttr_ = srcAttr && srcAttr.length ? srcAttr : null;
+
+    /** @private @const {!IArrayLike<!Element>} */
+    this.srcEls_ = srcEls;
+  }
+
+
+  /**
+   * Applies the src attribute and source tags to a specified element.
+   * @param {!HTMLMediaElement} element The element to adopt the sources
+   *     represented by this object.
+   */
+  applyToElement(element) {
+    Sources.removeFrom(element);
+
+    if (!this.srcAttr_) {
+      element.removeAttribute('src');
+    } else {
+      element.setAttribute('src', this.srcAttr_);
+    }
+
+    Array.prototype.forEach.call(this.srcEls_,
+        srcEl => element.appendChild(srcEl));
+  }
+
+
+  /**
+   * Removes and returns the sources from a specified element.
+   * @param {!Element} element The element whose sources should be removed and
+   *     returned.
+   * @return {!Sources} An object representing the sources of the specified
+   *     element.
+   */
+  static removeFrom(element) {
+    const elementToUse = ampMediaElementFor(element) || element;
+    const srcAttr = elementToUse.getAttribute('src');
+    elementToUse.removeAttribute('src');
+    const srcEls = scopedQuerySelectorAll(elementToUse, 'source');
+    Array.prototype.forEach.call(srcEls, srcEl => removeElement(srcEl));
+
+    return new Sources(srcAttr, srcEls);
+  }
+}

--- a/extensions/amp-story/0.1/sources.js
+++ b/extensions/amp-story/0.1/sources.js
@@ -24,16 +24,16 @@ import {
 
 export class Sources {
   /**
-   * @param {?string} srcAttr The 'src' attribute of the media element.
-   * @param {!IArrayLike<!Element>} srcEls Any child <source> tags of the media
-   *     element.
+   * @param {?string=} opt_srcAttr The 'src' attribute of the media element.
+   * @param {?IArrayLike<!Element>=} opt_srcEls Any child <source> tags of the
+   *     media element.
    */
-  constructor(srcAttr, srcEls) {
+  constructor(opt_srcAttr, opt_srcEls) {
     /** @private @const {?string} */
-    this.srcAttr_ = srcAttr && srcAttr.length ? srcAttr : null;
+    this.srcAttr_ = opt_srcAttr && opt_srcAttr.length ? opt_srcAttr : null;
 
     /** @private @const {!IArrayLike<!Element>} */
-    this.srcEls_ = srcEls;
+    this.srcEls_ = opt_srcEls || [];
   }
 
 

--- a/extensions/amp-story/0.1/sources.js
+++ b/extensions/amp-story/0.1/sources.js
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
+import {ampMediaElementFor} from './utils';
 import {
   removeElement,
   scopedQuerySelectorAll,
 } from '../../../src/dom';
-import {ampMediaElementFor} from './utils';
 
 
 

--- a/extensions/amp-story/0.1/sources.js
+++ b/extensions/amp-story/0.1/sources.js
@@ -24,7 +24,7 @@ import {ampMediaElementFor} from './utils';
 
 export class Sources {
   /**
-   * @param {string} srcAttr The 'src' attribute of the media element.
+   * @param {?string} srcAttr The 'src' attribute of the media element.
    * @param {!IArrayLike<!Element>} srcEls Any child <source> tags of the media
    *     element.
    */

--- a/extensions/amp-story/0.1/test/test-media-pool.js
+++ b/extensions/amp-story/0.1/test/test-media-pool.js
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 import {MediaPool, MediaType} from '../media-pool';
+import {Services} from '../../../../src/services';
 import {findIndex} from '../../../../src/utils/array';
+
+const NOOP = () => {};
 
 describes.realWin('media-pool', {}, env => {
   let win;
@@ -27,6 +30,11 @@ describes.realWin('media-pool', {}, env => {
 
   beforeEach(() => {
     win = env.win;
+    sandbox.stub(Services, 'vsyncFor')
+        .callsFake(() => ({mutate: task => task()}));
+    sandbox.stub(Services, 'timerFor')
+        .callsFake(() => ({delay: NOOP}));
+
     mediaPool = new MediaPool(win, COUNTS, element => {
       return distanceFnStub(element);
     });
@@ -74,12 +82,6 @@ describes.realWin('media-pool', {}, env => {
 
   it('should not be null', () => {
     expect(mediaPool).to.not.be.null;
-  });
-
-  it('should pre-populate default sources', () => {
-    getElements([mediaPool.allocated, mediaPool.unallocated]).forEach(el => {
-      expect(!!el.getAttribute('src')).to.be.true;
-    });
   });
 
   it('should start with no allocated elements', () => {

--- a/extensions/amp-story/0.1/test/test-media-tasks.js
+++ b/extensions/amp-story/0.1/test/test-media-tasks.js
@@ -41,11 +41,8 @@ describes.realWin('media-tasks', {}, () => {
     vsyncApi = {
       mutatePromise: () => {},
     };
-    sandbox.stub(vsyncApi, 'mutatePromise')
-        .callsFake(callback => {
-          callback();
-          return Promise.resolve();
-        });
+    sandbox.stub(vsyncApi, 'mutatePromise').resolves(callback => {callback();});
+
   });
 
   describe('PauseTask', () => {

--- a/extensions/amp-story/0.1/test/test-media-tasks.js
+++ b/extensions/amp-story/0.1/test/test-media-tasks.js
@@ -232,7 +232,7 @@ describes.realWin('media-tasks', {}, env => {
       expect(el.parentElement).to.equal(parent);
       expect(placeholderEl.parentElement).to.equal(null);
 
-      const task = new SwapIntoDomTask(placeholderEl, vsyncApi);
+      const task = new SwapOutOfDomTask(placeholderEl, vsyncApi);
       return task.execute(el).then(() => {
         expect(el.parentElement).to.equal(null);
         expect(placeholderEl.parentElement).to.equal(parent);

--- a/extensions/amp-story/0.1/test/test-media-tasks.js
+++ b/extensions/amp-story/0.1/test/test-media-tasks.js
@@ -15,7 +15,6 @@
  */
 import * as sinon from 'sinon';
 import {
-  BlessTask,
   LoadTask,
   MuteTask,
   PauseTask,
@@ -29,15 +28,12 @@ import {
 import {Sources} from '../sources';
 import {toArray} from '../../../../src/types';
 
-describes.realWin('media-tasks', {}, env => {
-  let win;
+describes.realWin('media-tasks', {}, () => {
   let sandbox;
   let el;
   let vsyncApi;
-  let mutatePromiseStub;
 
   beforeEach(() => {
-    win = env.win;
     sandbox = sinon.sandbox.create();
     el = document.createElement('video');
 
@@ -45,7 +41,7 @@ describes.realWin('media-tasks', {}, env => {
     vsyncApi = {
       mutatePromise: () => {},
     };
-    mutatePromiseStub = sandbox.stub(vsyncApi, 'mutatePromise')
+    sandbox.stub(vsyncApi, 'mutatePromise')
         .callsFake(callback => {
           callback();
           return Promise.resolve();

--- a/extensions/amp-story/0.1/test/test-media-tasks.js
+++ b/extensions/amp-story/0.1/test/test-media-tasks.js
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  BlessTask,
+  LoadTask,
+  MuteTask,
+  PauseTask,
+  PlayTask,
+  RewindTask,
+  SwapIntoDomTask,
+  SwapOutOfDomTask,
+  UnmuteTask,
+  UpdateSourcesTask,
+} from '../media-tasks';
+
+describes.realWin('media-tasks', {}, env => {
+  let win;
+  let el;
+
+  beforeEach(() => {
+    win = env.win;
+    el = document.createElement('video');
+  });
+
+  describe('Pause task', () => {
+    it('should call pause()', () => {
+      const pause = sandbox.spy(el, 'pause');
+      const task = new PauseTask();
+      task.execute(el);
+      expect(pause).to.have.been.called;
+    });
+  });
+});

--- a/extensions/amp-story/0.1/utils.js
+++ b/extensions/amp-story/0.1/utils.js
@@ -15,6 +15,7 @@
  */
 
 import {user} from '../../../src/log';
+import {closestBySelector} from '../../../src/dom';
 
 /**
  * Returns millis as number if given a string(e.g. 1s, 200ms etc)
@@ -72,4 +73,14 @@ export function unscaledClientRect(el) {
     width: width / scaleFactorX,
     height: height / scaleFactorY,
   });
+}
+
+
+/**
+ * Finds an amp-video/amp-audio ancestor.
+ * @param {!Element} el
+ * @return {?AmpElement}
+ */
+export function ampMediaElementFor(el) {
+  return closestBySelector(el, 'amp-video, amp-audio');
 }

--- a/extensions/amp-story/0.1/utils.js
+++ b/extensions/amp-story/0.1/utils.js
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import {user} from '../../../src/log';
 import {closestBySelector} from '../../../src/dom';
+import {user} from '../../../src/log';
 
 /**
  * Returns millis as number if given a string(e.g. 1s, 200ms etc)


### PR DESCRIPTION
Fixes #13232.  Also includes changes from #13245.

This PR creates a task queue on each media element in the `MediaPool`, implemented as an array of strings.  The array stores the next functions to be invoked for that element (e.g. `['bless', 'load', 'play', 'unmute']), and ensures that they are each only called after the previous one has finished executing.

This is necessary due to the async nature of the `amp-story` code, as well as the async nature of the media element's `play()` function.  In some cases, `play()` is invoked but then other code is executed before any callbacks on `play()`'s promise chain are invoked.  In our case, the "other code" that gets executed is sometimes also media-related code, calling `load()` or `play()` again, both of which can cause the media in question to cease playback.

See #13232 for more details on the issue.