### PR TITLE
Fix import ordering in amp-access-scroll

### DIFF
--- a/extensions/amp-access-scroll/0.1/scroll-impl.js
+++ b/extensions/amp-access-scroll/0.1/scroll-impl.js
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import {CSS} from '../../../build/amp-access-scroll-0.1.css';
 import {AccessClientAdapter} from '../../amp-access/0.1/amp-access-client';
+import {CSS} from '../../../build/amp-access-scroll-0.1.css';
 import {installStylesForDoc} from '../../../src/style-installer';
 
 const TAG = 'amp-access-scroll-elt';


### PR DESCRIPTION
Fix for #12955, which introduced a misordered import lint error.

Follow up to #13256
Fixes #13253