### PR TITLE
Add basic documentation for amp-lightbox-gallery

### DIFF
--- a/extensions/amp-lightbox-gallery/amp-lightbox-gallery.md
+++ b/extensions/amp-lightbox-gallery/amp-lightbox-gallery.md
@@ -1,0 +1,71 @@
+<!---
+Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS-IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# <a name="amp-lightbox-gallery"></a> `amp-lightbox-gallery`
+[TOC]
+
+<table>
+  <tr>
+    <td width="40%"><strong>Description</strong></td>
+    <td>Allows for a "lightbox” experience where upon user interaction, a ui component expands to fill the viewport until it is closed again by the user. Currently only images are supported. </td>
+  </tr>
+   <tr>
+    <td width="40%"><strong>Availability</strong></td>
+    <td><div><a href="https://www.ampproject.org/docs/reference/experimental.html">Experimental</a>; no validations yet.</div><div>Work in progress under the 'amp-lightbox-gallery' experiment flag.</div></td>
+  </tr>
+  <tr>
+    <td width="40%"><strong>Required Script</strong></td>
+    <td><code>&lt;script async custom-element="amp-lightbox-gallery" src="https://cdn.ampproject.org/v0/amp-lightbox-gallery-0.1.js">&lt;/script></code></td>
+  </tr>
+  <tr>
+    <td class="col-fourty"><strong><a href="https://www.ampproject.org/docs/guides/responsive/control_layout.html">Supported Layouts</a></strong></td>
+    <td>nodisplay</td>
+  </tr>
+</table>
+
+## Behavior
+All you need to do is to include the 'lightbox' attribute on an `<amp-img>` or `<amp-carousel>`. A typical usage looks like this:
+
+### Lightbox with AMP-IMG
+
+```html
+<amp-img src="image1" width=200 height=100 lightbox></amp-img>
+<amp-img src="image2" width=200 height=100 lightbox></amp-img>
+```
+
+The `<amp-lightbox-gallery>` extension automatically inserts an invisible `<amp-lightbox-gallery>` component (with the id 'amp-lightbox-gallery') into the dom.
+
+It iterates through each item that has the `lightbox` attribute and processes it. If the component is a basic item (e.g. `AMP-IMG`), it will install a tap handler on each basic lightboxed item (`on=tap:amp-lightbox-gallery.activate`) if a tap handler does not already exist. Currently, `<amp-img>` is the only type of basic item supported.
+
+### Lightbox with AMP-CAROUSEL
+```html
+<amp-carousel lightbox width=1600 height=900 layout=responsive type=slides>
+  <amp-img src="image1" width=200 height=100></amp-img>
+  <amp-img src="image2" width=200 height=100></amp-img>
+  <amp-img src="image3" width=200 height=100></amp-img>
+</amp-carousel>
+```
+
+`<amp-carousel>` is considered a lightbox container item. To process an `<amp-carousel>` with the `lightbox` attribute,  `<amp-lightbox-gallery>` extension will iterate all of the `<amp-carousel>`'s children, add the `lightbox` attribute and a tap-handler to each child.
+
+### Captions
+Lightbox optionally allows the user to specify a caption for each element. These fields are automatically read and displayed by `<amp-lightbox-gallery>` in the following order of priority:
+- figcaption (if the lightboxed element is a figure)
+- aria-describedby
+- alt
+- aria-label
+- aria-labelledby
+

--- a/extensions/amp-lightbox-gallery/amp-lightbox-gallery.md
+++ b/extensions/amp-lightbox-gallery/amp-lightbox-gallery.md
@@ -37,9 +37,9 @@ limitations under the License.
 </table>
 
 ## Behavior
-All you need to do is to include the 'lightbox' attribute on an `<amp-img>` or `<amp-carousel>`. A typical usage looks like this:
+All you need to do is to include the extension script and put the 'lightbox' attribute on an `<amp-img>` or `<amp-carousel>`. A typical usage looks like this:
 
-### Lightbox with AMP-IMG
+### Lightbox with `<amp-img>`
 
 ```html
 <amp-img src="image1" width=200 height=100 lightbox></amp-img>
@@ -48,9 +48,9 @@ All you need to do is to include the 'lightbox' attribute on an `<amp-img>` or `
 
 The `<amp-lightbox-gallery>` extension automatically inserts an invisible `<amp-lightbox-gallery>` component (with the id 'amp-lightbox-gallery') into the dom.
 
-It iterates through each item that has the `lightbox` attribute and processes it. If the component is a basic item (e.g. `AMP-IMG`), it will install a tap handler on each basic lightboxed item (`on=tap:amp-lightbox-gallery.activate`) if a tap handler does not already exist. Currently, `<amp-img>` is the only type of basic item supported.
+It iterates through each `<amp-img>` that has the `lightbox` attribute and installs a tap handler on it (`on=tap:amp-lightbox-gallery.activate`) if a tap handler does not already exist. Tapping on any `<amp-img>` will open the image in a lightbox gallery. The lightbox gallery does image-handling (e.g. zoom and pan), enables swiping to navigate between images, and offers a thumbnail gallery view for browsing all picture thumbnails in a grid.
 
-### Lightbox with AMP-CAROUSEL
+### Lightbox with `<amp-carousel>`
 ```html
 <amp-carousel lightbox width=1600 height=900 layout=responsive type=slides>
   <amp-img src="image1" width=200 height=100></amp-img>
@@ -59,11 +59,11 @@ It iterates through each item that has the `lightbox` attribute and processes it
 </amp-carousel>
 ```
 
-`<amp-carousel>` is considered a lightbox container item. To process an `<amp-carousel>` with the `lightbox` attribute,  `<amp-lightbox-gallery>` extension will iterate all of the `<amp-carousel>`'s children, add the `lightbox` attribute and a tap-handler to each child.
+You can add the `lightbox` attribute on an `<amp-carousel>` to lightbox all of its children. `<amp-lightbox-gallery>` currently supports only carousels containing `<amp-img>` as children. As you navigate through the carousel items in the lightbox, the original carousel slides will be sync-ed so that when the lightbox is closed, you will end up on the same slide as you were on originally. Currently on the the `type='slides'` carousel is supported.
 
 ### Captions
 Lightbox optionally allows the user to specify a caption for each element. These fields are automatically read and displayed by `<amp-lightbox-gallery>` in the following order of priority:
-- figcaption (if the lightboxed element is a figure)
+- figcaption (if the lightboxed element is the child of a figure)
 - aria-describedby
 - alt
 - aria-label

--- a/extensions/amp-lightbox-gallery/amp-lightbox-gallery.md
+++ b/extensions/amp-lightbox-gallery/amp-lightbox-gallery.md
@@ -38,7 +38,7 @@ limitations under the License.
 
 ## Overview
 
-The `amp-lightbox-gallery` component provides a "lightbox” experience for AMP components (e.g., `amp-img`, `amp-carousel`). When the user interacts with the AMP element, a UI component expands to fill the viewport until it is closed by the user. Currently, only images are supported. 
+The `amp-lightbox-gallery` component provides a "lightbox” experience for AMP components (e.g., `amp-img`, `amp-carousel`). When the user interacts with the AMP element, a UI component expands to fill the viewport until it is closed by the user. Currently, only images are supported.
 
 ## Usage
 
@@ -47,21 +47,19 @@ To use `amp-lightbox-gallery`, ensure the required script is included in your `<
 ### Lightbox with `<amp-img>`
 
 ```html
-<amp-img src="image1" width=200 height=100 lightbox></amp-img>
-<amp-img src="image2" width=200 height=100 lightbox></amp-img>
+<amp-img src="image1" width="200" height="100" lightbox></amp-img>
+<amp-img src="image2" width="200" height="100" lightbox></amp-img>
 ```
 
-The `<amp-lightbox-gallery>` extension automatically inserts an invisible `<amp-lightbox-gallery>` component (with the id 'amp-lightbox-gallery') into the dom.
-
-It iterates through each `<amp-img>` that has the `lightbox` attribute and installs a tap handler on it (`on=tap:amp-lightbox-gallery.activate`) if a tap handler does not already exist. Tapping on any `<amp-img>` will open the image in a lightbox gallery. The lightbox gallery does image-handling (e.g. zoom and pan), enables swiping to navigate between images, and offers a thumbnail gallery view for browsing all picture thumbnails in a grid.
+ Tapping on any `<amp-img>` will open the image in a lightbox gallery. The lightbox gallery does image-handling (e.g. zoom and pan), enables swiping to navigate between images, and offers a thumbnail gallery view for browsing all picture thumbnails in a grid.
 
 ### Lightbox with `<amp-carousel>`
 
 ```html
-<amp-carousel lightbox width=1600 height=900 layout=responsive type=slides>
-  <amp-img src="image1" width=200 height=100></amp-img>
-  <amp-img src="image2" width=200 height=100></amp-img>
-  <amp-img src="image3" width=200 height=100></amp-img>
+<amp-carousel lightbox width="1600" height="900" layout=responsive type=slides>
+  <amp-img src="image1" width="200" height="100"></amp-img>
+  <amp-img src="image1" width="200" height="100"></amp-img>
+  <amp-img src="image1" width="200" height="100"></amp-img>
 </amp-carousel>
 ```
 
@@ -77,3 +75,30 @@ Optionally, you can specify a caption for each element in the lightbox. These fi
 - `aria-label`
 - `aria-labelledby`
 
+For example:
+
+E.g. 1: in this example, `<amp-lightbox-gallery>` will display the figcaption as its description, showing "Toront's CN tower was ....".
+
+```html
+<figure>
+  <amp-img id="hero-img" lightbox="toronto" src="https://picsum.photos/1600/900?image=1075" layout="responsive" width="1600"
+    height="900" alt="Picture of CN tower.">
+  </amp-img>
+  <figcaption class='image'>
+    Toronto's CN tower was built in 1976 and was the tallest free-standing structure until 2007.
+  </figcaption>
+</figure>
+```
+
+E.g. 2: in this example, `<amp-lightbox-gallery>` will display the alt as its description, showing "Picture of CN tower.".
+```html
+<amp-img
+  id="hero-img"
+  lightbox="toronto"
+  src="https://picsum.photos/1600/900?image=1075"
+  layout="responsive"
+  width="1600"
+  height="900"
+  alt="Picture of CN tower.">
+</amp-img>
+```

--- a/extensions/amp-lightbox-gallery/amp-lightbox-gallery.md
+++ b/extensions/amp-lightbox-gallery/amp-lightbox-gallery.md
@@ -20,11 +20,11 @@ limitations under the License.
 <table>
   <tr>
     <td width="40%"><strong>Description</strong></td>
-    <td>Allows for a "lightbox” experience where upon user interaction, a ui component expands to fill the viewport until it is closed again by the user. Currently only images are supported. </td>
+    <td>Provides a "lightbox” experience. Upon user interaction, a UI component expands to fill the viewport until it is closed by the user.</td>
   </tr>
    <tr>
     <td width="40%"><strong>Availability</strong></td>
-    <td><div><a href="https://www.ampproject.org/docs/reference/experimental.html">Experimental</a>; no validations yet.</div><div>Work in progress under the 'amp-lightbox-gallery' experiment flag.</div></td>
+    <td><a href="https://www.ampproject.org/docs/reference/experimental.html">Experimental</a>; no validations yet.</td>
   </tr>
   <tr>
     <td width="40%"><strong>Required Script</strong></td>
@@ -36,8 +36,13 @@ limitations under the License.
   </tr>
 </table>
 
-## Behavior
-All you need to do is to include the extension script and put the 'lightbox' attribute on an `<amp-img>` or `<amp-carousel>`. A typical usage looks like this:
+## Overview
+
+The `amp-lightbox-gallery` component provides a "lightbox” experience for AMP components (e.g., `amp-img`, `amp-carousel`). When the user interacts with the AMP element, a UI component expands to fill the viewport until it is closed by the user. Currently, only images are supported. 
+
+## Usage
+
+To use `amp-lightbox-gallery`, ensure the required script is included in your `<head>` section, then add the `lightbox` attribute on an `<amp-img>` or `<amp-carousel>` element. A typical usage looks like this:
 
 ### Lightbox with `<amp-img>`
 
@@ -51,6 +56,7 @@ The `<amp-lightbox-gallery>` extension automatically inserts an invisible `<amp-
 It iterates through each `<amp-img>` that has the `lightbox` attribute and installs a tap handler on it (`on=tap:amp-lightbox-gallery.activate`) if a tap handler does not already exist. Tapping on any `<amp-img>` will open the image in a lightbox gallery. The lightbox gallery does image-handling (e.g. zoom and pan), enables swiping to navigate between images, and offers a thumbnail gallery view for browsing all picture thumbnails in a grid.
 
 ### Lightbox with `<amp-carousel>`
+
 ```html
 <amp-carousel lightbox width=1600 height=900 layout=responsive type=slides>
   <amp-img src="image1" width=200 height=100></amp-img>
@@ -59,13 +65,15 @@ It iterates through each `<amp-img>` that has the `lightbox` attribute and insta
 </amp-carousel>
 ```
 
-You can add the `lightbox` attribute on an `<amp-carousel>` to lightbox all of its children. `<amp-lightbox-gallery>` currently supports only carousels containing `<amp-img>` as children. As you navigate through the carousel items in the lightbox, the original carousel slides will be sync-ed so that when the lightbox is closed, you will end up on the same slide as you were on originally. Currently on the the `type='slides'` carousel is supported.
+You can add the `lightbox` attribute on an `<amp-carousel>` to lightbox all of its children. Currently, the `<amp-lightbox-gallery>` component only supports carousels containing `<amp-img>` as children. As you navigate through the carousel items in the lightbox, the original carousel slides are synchronized so that when the lightbox is closed, the user ends up on the same slide as the were originally on. Currently, only the `type='slides'` carousel is supported.
 
 ### Captions
-Lightbox optionally allows the user to specify a caption for each element. These fields are automatically read and displayed by `<amp-lightbox-gallery>` in the following order of priority:
-- figcaption (if the lightboxed element is the child of a figure)
-- aria-describedby
-- alt
-- aria-label
-- aria-labelledby
+
+Optionally, you can specify a caption for each element in the lightbox. These fields are automatically read and displayed by the `<amp-lightbox-gallery>` in the following order of priority:
+
+- `figcaption` (if the lightboxed element is the child of a figure)
+- `aria-describedby`
+- `alt`
+- `aria-label`
+- `aria-labelledby`
 

--- a/extensions/amp-lightbox-gallery/amp-lightbox-gallery.md
+++ b/extensions/amp-lightbox-gallery/amp-lightbox-gallery.md
@@ -56,7 +56,7 @@ To use `amp-lightbox-gallery`, ensure the required script is included in your `<
 ### Lightbox with `<amp-carousel>`
 
 ```html
-<amp-carousel lightbox width="1600" height="900" layout=responsive type=slides>
+<amp-carousel lightbox width="1600" height="900" layout="responsive" type="slides">
   <amp-img src="image1" width="200" height="100"></amp-img>
   <amp-img src="image1" width="200" height="100"></amp-img>
   <amp-img src="image1" width="200" height="100"></amp-img>
@@ -75,22 +75,24 @@ Optionally, you can specify a caption for each element in the lightbox. These fi
 - `aria-label`
 - `aria-labelledby`
 
-For example:
+#### Example 1: Using figcaption for description
 
-E.g. 1: in this example, `<amp-lightbox-gallery>` will display the figcaption as its description, showing "Toront's CN tower was ....".
+In this example, `<amp-lightbox-gallery>` displays the `figcaption` value as its description, showing "Toront's CN tower was ....".
 
 ```html
 <figure>
   <amp-img id="hero-img" lightbox="toronto" src="https://picsum.photos/1600/900?image=1075" layout="responsive" width="1600"
     height="900" alt="Picture of CN tower.">
   </amp-img>
-  <figcaption class='image'>
+  <figcaption class="image">
     Toronto's CN tower was built in 1976 and was the tallest free-standing structure until 2007.
   </figcaption>
 </figure>
 ```
 
-E.g. 2: in this example, `<amp-lightbox-gallery>` will display the alt as its description, showing "Picture of CN tower.".
+#### Example 2: Using alt for description
+
+In this example, `<amp-lightbox-gallery>` displays the `alt` value as its description, showing "Picture of CN tower".
 ```html
 <amp-img
   id="hero-img"
@@ -99,6 +101,6 @@ E.g. 2: in this example, `<amp-lightbox-gallery>` will display the alt as its de
   layout="responsive"
   width="1600"
   height="900"
-  alt="Picture of CN tower.">
+  alt="Picture of CN tower">
 </amp-img>
 ```


### PR DESCRIPTION
Basic documentation for an experimental component `<amp-lightbox-gallery>`. The API for styling, thumbnails, and supported elements is still in progress, hence there is only basic usage under an experiment flag. 