### PR TITLE
Indicate progress during `gulp lint` and cleanly exit

### DIFF
--- a/build-system/tasks/lint.js
+++ b/build-system/tasks/lint.js
@@ -59,6 +59,17 @@ function initializeStream(globs, streamOptions) {
 }
 
 /**
+ * Logs a message on the same line to indicate progress
+ * @param {string} message
+ */
+function logOnSameLine(message) {
+  process.stdout.moveCursor(0, -1);
+  process.stdout.cursorTo(0);
+  process.stdout.clearLine();
+  log(message);
+}
+
+/**
  * Runs the linter on the given stream using the given options.
  * @param {string} path
  * @param {!ReadableStream} stream
@@ -67,12 +78,31 @@ function initializeStream(globs, streamOptions) {
  */
 function runLinter(path, stream, options) {
   let errorsFound = false;
+  if (!process.env.TRAVIS) {
+    log(colors.green('Starting linter...'));
+  }
   return stream.pipe(eslint(options))
       .pipe(eslint.formatEach('stylish', function(msg) {
         errorsFound = true;
-        log(msg);
+        logOnSameLine(colors.red('Linter error:') + msg + '\n');
       }))
       .pipe(gulpIf(isFixed, gulp.dest(path)))
+      .pipe(eslint.result(function(result) {
+        if (!process.env.TRAVIS) {
+          logOnSameLine(colors.green('Linting: ') + result.filePath);
+        }
+      }))
+      .pipe(eslint.results(function(results) {
+        if (results.errorCount == 0) {
+          if (!process.env.TRAVIS) {
+            logOnSameLine(colors.green('Success: ') + 'No linter errors');
+          }
+        } else {
+          logOnSameLine(colors.red('Error: ') + results.errorCount +
+              ' linter error(s) found.');
+          process.exit(1);
+        }
+      }))
       .pipe(eslint.failAfterError())
       .on('error', function() {
         if (errorsFound && !options.fix) {


### PR DESCRIPTION
This PR makes sure `gulp lint` exits cleanly after errors are reported. It also adds an in-place progress indicator during non-travis runs, so it doesn't look like nothing is happening for a whole minute.