### PR TITLE
Make sure polyfills.js is imported before anything else

### DIFF
--- a/3p/ampcontext-lib.js
+++ b/3p/ampcontext-lib.js
@@ -13,7 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import './polyfills';
+
+// src/polyfills.js must be the first import.
+import './polyfills'; // eslint-disable-line sort-imports-es6-autofix/sort-imports-es6
+
 import {AmpContext} from './ampcontext.js';
 import {initLogConstructor, setReportError} from '../src/log';
 

--- a/3p/iframe-transport-client-lib.js
+++ b/3p/iframe-transport-client-lib.js
@@ -13,7 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import './polyfills';
+
+// src/polyfills.js must be the first import.
+import './polyfills'; // eslint-disable-line sort-imports-es6-autofix/sort-imports-es6
+
 import {IframeTransportClient} from './iframe-transport-client.js';
 import {initLogConstructor, setReportError} from '../src/log';
 

--- a/3p/integration.js
+++ b/3p/integration.js
@@ -22,7 +22,9 @@
  * https://3p.ampproject.net/$version/f.js
  */
 
-import './polyfills';
+// src/polyfills.js must be the first import.
+import './polyfills'; // eslint-disable-line sort-imports-es6-autofix/sort-imports-es6
+
 import {AmpEvents} from '../src/amp-events';
 import {
   IntegrationAmpContext,

--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -619,6 +619,7 @@ const forbiddenTerms = {
     message: 'Use a line-level "no-unused-vars" rule instead.',
     whitelist: [
       'viewer-api/swipe-api.js',
+      'dist.3p/current/integration.js',
     ],
   },
 };

--- a/src/amp-shadow.js
+++ b/src/amp-shadow.js
@@ -19,7 +19,9 @@
  * multiple AMP Docs in Shadow DOM.
  */
 
-import './polyfills';
+// src/polyfills.js must be the first import.
+import './polyfills'; // eslint-disable-line sort-imports-es6-autofix/sort-imports-es6
+
 import {Services} from './services';
 import {
   adoptShadowMode,

--- a/src/amp.js
+++ b/src/amp.js
@@ -18,7 +18,9 @@
  * The entry point for AMP Runtime (v0.js) when AMP Runtime = AMP Doc.
  */
 
-import './polyfills';
+// src/polyfills.js must be the first import.
+import './polyfills'; // eslint-disable-line sort-imports-es6-autofix/sort-imports-es6
+
 import {Services} from './services';
 import {adopt, installAmpdocServices, installBuiltins, installRuntimeServices} from './runtime';
 import {cssText} from '../build/css';

--- a/src/service.js
+++ b/src/service.js
@@ -20,8 +20,9 @@
  * Invariant: Service getters never return null for registered services.
  */
 
-// Requires polyfills in immediate side effect.
-import './polyfills';
+// src/polyfills.js must be the first import.
+import './polyfills'; // eslint-disable-line sort-imports-es6-autofix/sort-imports-es6
+
 import {dev} from './log';
 import {toWin} from './types';
 


### PR DESCRIPTION
In #13256, we introduced new `eslint` rules to keep our `import` and `require` statements sorted. However, some modules like `polyfill.js` must be imported before any others.

This PR adds `eslint` rule exceptions to all `import './polyfills';` statements to ensure that they appear at the top of their respective files. This will prevent `gulp lint` from complaining if another file-level import that alphabetically precedes `./polyfill` (for example, `./foo`) is added below it.

**Will generate a linter error:**
```
// src/polyfills.js must be the first import.
import './polyfills'; // eslint-disable-line sort-imports-es6-autofix/sort-imports-es6
import './foo';
```
**Won't generate a linter error:**
```
// src/polyfills.js must be the first import.
import './polyfills'; // eslint-disable-line sort-imports-es6-autofix/sort-imports-es6
import './foo'; // eslint-disable-line sort-imports-es6-autofix/sort-imports-es6
```
