### PR TITLE
Pull request for registering Zinrelo AMP tag

### DIFF
--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -671,6 +671,7 @@ export class AmpAnalytics extends AMP.BaseElement {
       const TAG = this.getName_();
       this.user().error(TAG, 'Ignoring event. Request string ' +
           'not found: ', trigger['request']);
+      return;
     }
 
     this.checkTriggerEnabled_(trigger, event).then(enabled => {

--- a/extensions/amp-analytics/0.1/test/test-amp-analytics.js
+++ b/extensions/amp-analytics/0.1/test/test-amp-analytics.js
@@ -399,8 +399,10 @@ describes.realWin('amp-analytics', {
     const analytics = getAnalyticsTag({
       'triggers': [{'on': 'visible', 'request': 'foo'}],
     });
+    const spy = sandbox.spy(analytics, 'expandAndSendRequest_');
 
     return waitForNoSendRequest(analytics).then(() => {
+      expect(spy).to.have.not.been.called;
       expect(sendRequestSpy).to.have.not.been.called;
     });
   });


### PR DESCRIPTION
Zinrelo (formerly ShopSocially) offers loyalty and referral programs, helping to maximize customer acquisition, engagement and retention through 360-degree customer interaction. There are many customers who are migrating to a Google AMP Tag based implementation. To support them we need to create tag with Google AMP project.

I am requesting the pull to contribute for the same.
