### PR TITLE
Delete build-system/tasks/package.json, whitelist heroku page

### DIFF
--- a/build-system/tasks/check-links.js
+++ b/build-system/tasks/check-links.js
@@ -143,6 +143,10 @@ function filterWhitelistedLinks(markdown) {
   // Links inside a <code> block (illustrative, and not always valid)
   filteredMarkdown = filteredMarkdown.replace(/<code>(.*?)<\/code>/g, '');
 
+  // The heroku nightly build page is not always acccessible by the checker.
+  filteredMarkdown = filteredMarkdown.replace(
+      /\(http:\/\/amphtml-nightly.herokuapp.com\/\)/g, '');
+
   // After all whitelisting is done, clean up any remaining empty blocks bounded
   // by backticks. Otherwise, `` will be treated as the start of a code block
   // and confuse the link extractor.

--- a/build-system/tasks/package.json
+++ b/build-system/tasks/package.json
@@ -1,5 +1,0 @@
-{
-  "dependencies": {
-    "markdown-link-check": "^3.0.3"
-  }
-}


### PR DESCRIPTION
This PR contains two `gulp check-links` fixes:

1. `build-system/tasks/package.json` is superfluous, since the only dependency it contains already exists in `ampproject/amphtml/package.json`. The file was added in #9099, back when I didn't know what I was doing :)
2. The link checker frequently trips up on `http://amphtml-nightly.herokuapp.com/`, resulting in several failed builds on Travis. Since this is a well known page that's unlikely to ever be a truly dead link, we whitelist it during `gulp check-links`.