### PR TITLE
Linear transitions for media story pages progress bar.

### DIFF
--- a/extensions/amp-story/0.1/page-advancement.js
+++ b/extensions/amp-story/0.1/page-advancement.js
@@ -26,7 +26,7 @@ import {scopedQuerySelector} from '../../../src/dom';
 const NEXT_SCREEN_AREA_RATIO = 0.75;
 
 /** @const {number} */
-const POLL_INTERVAL_MS = 250;
+export const POLL_INTERVAL_MS = 300;
 
 /** @const @enum */
 export const TapNavigationDirection = {

--- a/extensions/amp-story/0.1/progress-bar.js
+++ b/extensions/amp-story/0.1/progress-bar.js
@@ -159,7 +159,8 @@ export class ProgressBar {
       if (withTransition) {
         // Using an eased transition only if filling the bar to 0 or 1.
         transition =
-            progress === ~~progress ? TRANSITION_EASE : TRANSITION_LINEAR;
+            (progress === 1 || progress === 0) ?
+              TRANSITION_EASE : TRANSITION_LINEAR;
       }
       setImportantStyles(dev().assertElement(progressEl), {
         'transform': scale(`${progress},1`),

--- a/extensions/amp-story/0.1/progress-bar.js
+++ b/extensions/amp-story/0.1/progress-bar.js
@@ -13,14 +13,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import {POLL_INTERVAL_MS} from './page-advancement';
 import {Services} from '../../../src/services';
 import {dev} from '../../../src/log';
 import {scale, setImportantStyles} from '../../../src/style';
 import {scopedQuerySelector} from '../../../src/dom';
 
 
-/** @const {string} */
-const TRANSITION = 'transform 0.2s ease';
+/**
+ * Transition used to show the progress of a media. Has to be linear so the
+ * animation is smooth and constant.
+ * @const {string}
+ */
+const TRANSITION_LINEAR = `transform ${POLL_INTERVAL_MS}ms linear`;
+
+/**
+ * Transition used to fully fill or unfill a progress bar item.
+ * @const {string}
+ */
+const TRANSITION_EASE = 'transform 200ms ease';
 
 
 /**
@@ -144,9 +155,15 @@ export class ProgressBar {
         `.i-amphtml-story-page-progress-bar:nth-child(${nthChildIndex}) ` +
         '.i-amphtml-story-page-progress-value');
     this.vsync_.mutate(() => {
+      let transition = 'none';
+      if (withTransition) {
+        // Using an eased transition only if filling the bar to 0 or 1.
+        transition =
+            progress === ~~progress ? TRANSITION_EASE : TRANSITION_LINEAR;
+      }
       setImportantStyles(dev().assertElement(progressEl), {
         'transform': scale(`${progress},1`),
-        'transition': withTransition ? TRANSITION : 'none',
+        'transition': transition,
       });
     });
   }


### PR DESCRIPTION
Media based progress bars need a linear transition to avoid bumps caused by the easing method.

By keeping the POLL_INTERVAL equals to the animation timing, the animation is smooth.

One caveat is that we can't be sure the vsync task will be triggered right away though. Even if the vsync task is triggered a bit later because the browser is busy, I don't expect a ~10ms delay to be perceptible. If we still notice jank/bumps, we could switch to a better and more accurate implementation where we update the progress bar in every frame.

Fixes #13164
