### PR TITLE
Implement A2A support

### DIFF
--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -609,7 +609,8 @@ export class AmpForm {
         user().assert(false, 'The `AMP-Redirect-To` header value must be an ' +
             'absolute URL starting with https://. Found %s', redirectTo);
       }
-      this.win_.top.location.href = redirectTo;
+      const clickHandler = Services.clickHandlerForDoc(this.form_);
+      clickHandler.navigateTo(this.win_, redirectTo, REDIRECT_TO_HEADER);
     }
   }
 

--- a/extensions/amp-form/0.1/test/test-amp-form.js
+++ b/extensions/amp-form/0.1/test/test-amp-form.js
@@ -1512,6 +1512,7 @@ describes.repeated('', {
       fetchRejectPromise.catch(() => {
         // Just avoiding a global uncaught promise exception.
       });
+      let navigateTo;
 
       beforeEach(() => {
         form = getForm(env.win.document);
@@ -1519,6 +1520,9 @@ describes.repeated('', {
         sandbox.stub(form, 'checkValidity').returns(true);
         ampForm = new AmpForm(form);
         ampForm.target_ = '_top';
+
+        navigateTo = sandbox.spy();
+        sandbox.stub(Services, 'clickHandlerForDoc').returns({navigateTo});
       });
 
       describe('AMP-Redirect-To', () => {
@@ -1527,8 +1531,12 @@ describes.repeated('', {
           redirectToValue = 'https://google.com/';
           ampForm.handleSubmitAction_(/* invocation */ {});
 
+          expect(navigateTo).to.not.be.called;
           return ampForm.xhrSubmitPromiseForTesting().then(() => {
-            expect(env.win.top.location.href).to.be.equal(redirectToValue);
+            expect(navigateTo).to.be.calledOnce;
+            const args = navigateTo.firstCall.args;
+            expect(args[1]).to.equal('https://google.com/');
+            expect(args[2]).to.equal('AMP-Redirect-To');
           });
         });
 
@@ -1540,8 +1548,7 @@ describes.repeated('', {
           return ampForm.xhrSubmitPromiseForTesting().then(() => {
             assert.fail('Submit should have failed.');
           }, () => {
-            expect(env.win.top.location.href).to.be.equal(
-                'https://example-top.com/');
+            expect(navigateTo).to.not.be.called;
           });
         });
 
@@ -1553,8 +1560,7 @@ describes.repeated('', {
           return ampForm.xhrSubmitPromiseForTesting().then(() => {
             assert.fail('Submit should have failed.');
           }, () => {
-            expect(env.win.top.location.href).to.be.equal(
-                'https://example-top.com/');
+            expect(navigateTo).to.not.be.called;
           });
         });
 
@@ -1567,8 +1573,7 @@ describes.repeated('', {
           return ampForm.xhrSubmitPromiseForTesting().then(() => {
             assert.fail('Submit should have failed.');
           }, () => {
-            expect(env.win.top.location.href).to.be.equal(
-                'https://example-top.com/');
+            expect(navigateTo).to.not.be.called;
           });
         });
 
@@ -1578,11 +1583,16 @@ describes.repeated('', {
           const logSpy = sandbox.spy(user(), 'error');
           ampForm.handleSubmitAction_(/* invocation */ {});
 
+          expect(navigateTo).to.not.be.called;
           return ampForm.xhrSubmitPromiseForTesting().then(() => {
             expect(logSpy).to.be.calledOnce;
             const error = logSpy.getCall(0).args[1];
             expect(error).to.match(/Form submission failed/);
-            expect(env.win.top.location.href).to.be.equal(redirectToValue);
+
+            expect(navigateTo).to.be.calledOnce;
+            const args = navigateTo.firstCall.args;
+            expect(args[1]).to.equal('https://example2.com/hello');
+            expect(args[2]).to.equal('AMP-Redirect-To');
           });
         });
       });

--- a/src/service/document-click.js
+++ b/src/service/document-click.js
@@ -21,7 +21,7 @@ import {
   isIframed,
   openWindowDialog,
 } from '../dom';
-import {dev} from '../log';
+import {dev, user} from '../log';
 import {
   getExtraParamsUrl,
   shouldAppendExtraParams,
@@ -32,6 +32,7 @@ import {
   registerServiceBuilderForDoc,
 } from '../service';
 import {
+  isProtocolValid,
   parseUrl,
   parseUrlWithA,
 } from '../url';
@@ -54,7 +55,7 @@ export function installGlobalClickListenerForDoc(ampdoc) {
       /* opt_instantiate */ true);
 }
 
-
+// TODO(willchou): Rename this to Navigation.
 /**
  * Intercept any click on the current document and prevent any
  * linking to an identifier from pushing into the history stack.
@@ -83,7 +84,6 @@ export class ClickHandler {
     this.history_ = Services.historyForDoc(this.ampdoc);
 
     const platform = Services.platformFor(this.ampdoc.win);
-
     /** @private @const {boolean} */
     this.isIosSafari_ = platform.isIos() && platform.isSafari();
 
@@ -107,11 +107,17 @@ export class ClickHandler {
     this.boundHandle_ = this.handle_.bind(this);
     this.rootNode_.addEventListener('click', this.boundHandle_);
 
+    /** @private {boolean} */
     this.appendExtraParams_ = false;
-
     shouldAppendExtraParams(this.ampdoc).then(res => {
       this.appendExtraParams_ = res;
     });
+
+    /**
+     * Lazy-generated list of A2A-enabled navigation features.
+     * @private {?Array<string>}
+     */
+    this.a2aFeatures_ = null;
   }
 
   /** @override */
@@ -127,6 +133,42 @@ export class ClickHandler {
     if (this.boundHandle_) {
       this.rootNode_.removeEventListener('click', this.boundHandle_);
     }
+  }
+
+  /**
+   * Navigates a window to a URL.
+   *
+   * If opt_requestedBy matches a feature name in a meta[amp-to-amp-navigation]
+   * tag, then treats the URL as an AMP URL (A2A).
+   *
+   * @param {!Window} win
+   * @param {string} url
+   * @param {string=} opt_requestedBy
+   */
+  navigateTo(win, url, opt_requestedBy) {
+    if (!this.a2aFeatures_) {
+      const meta = this.rootNode_.querySelector(
+          'meta[name="amp-to-amp-navigation"]');
+      this.a2aFeatures_ = meta.getAttribute('content')
+          .split(';')
+          .map(feature => feature.trim());
+    }
+
+    if (isProtocolValid(url)) {
+      user().error(TAG, 'Cannot navigate to invalid protocol: ' + url);
+      return;
+    }
+
+    // If this redirect was requested by a feature that opted into A2A,
+    // try to ask the viewer to navigate this AMP URL.
+    if (opt_requestedBy && this.a2aFeatures_.indexOf(opt_requestedBy) >= 0) {
+      if (this.viewer_.navigateToAmpUrl(url, opt_requestedBy)) {
+        return;
+      }
+    }
+
+    // Otherwise, perform normal behavior of navigating the top frame.
+    win.top.location.href = url;
   }
 
   /**
@@ -156,51 +198,93 @@ export class ClickHandler {
       defaultExpandParamsUrl = getExtraParamsUrl(this.ampdoc.win, target);
     }
 
-    Services.urlReplacementsForDoc(target).maybeExpandLink(
-        target, defaultExpandParamsUrl);
-    const tgtLoc = this.parseUrl_(target.href);
+    const urlReplacements = Services.urlReplacementsForDoc(target);
+    urlReplacements.maybeExpandLink(target, defaultExpandParamsUrl);
 
-    // Handle custom protocols only if the document is iframed.
-    if (this.isIframed_) {
-      this.handleCustomProtocolClick_(e, target, tgtLoc);
+    const location = this.parseUrl_(target.href);
+
+    // Handle AMP-to-AMP navigation if rel=amphtml.
+    if (this.handleA2AClick_(e, target, location)) {
+      return;
     }
 
-    // Handle navigation clicks.
-    if (!e.defaultPrevented) {
-      this.handleNavClick_(e, target, tgtLoc);
+    // Handle navigating to custom protocol if applicable.
+    if (this.handleCustomProtocolClick_(e, target, location)) {
+      return;
     }
+
+    // Finally, handle normal click-navigation behavior.
+    this.handleNavClick_(e, target, location);
   }
 
   /**
    * Handles clicking on a custom protocol link.
+   * Returns true if the navigation was handled. Otherwise, returns false.
    * @param {!Event} e
    * @param {!Element} target
-   * @param {!Location} tgtLoc
+   * @param {!Location} location
+   * @return {boolean}
    * @private
    */
-  handleCustomProtocolClick_(e, target, tgtLoc) {
+  handleCustomProtocolClick_(e, target, location) {
+    // Handle custom protocols only if the document is iframed.
+    if (!this.isIframed_) {
+      return false;
+    }
+
     /** @const {!Window} */
     const win = toWin(target.ownerDocument.defaultView);
+    const url = target.href;
+    const protocol = location.protocol;
+
     // On Safari iOS, custom protocol links will fail to open apps when the
     // document is iframed - in order to go around this, we set the top.location
     // to the custom protocol href.
-    const isFTP = tgtLoc.protocol == 'ftp:';
+    const isFTP = protocol == 'ftp:';
 
     // In case of FTP Links in embedded documents always open then in _blank.
     if (isFTP) {
-      openWindowDialog(win, target.href, '_blank');
+      openWindowDialog(win, url, '_blank');
       e.preventDefault();
-      return;
+      return true;
     }
 
-    const isNormalProtocol = /^(https?|mailto):$/.test(tgtLoc.protocol);
+    const isNormalProtocol = /^(https?|mailto):$/.test(protocol);
     if (this.isIosSafari_ && !isNormalProtocol) {
-      openWindowDialog(win, target.href, '_top');
+      openWindowDialog(win, url, '_top');
       // Without preventing default the page would should an alert error twice
       // in the case where there's no app to handle the custom protocol.
       e.preventDefault();
+      return true;
     }
+
+    return false;
   }
+
+  /**
+   * Handles clicking on an AMP link.
+   * Returns true if the navigation was handled. Otherwise, returns false.
+   * @param {!Event} e
+   * @param {!Element} target
+   * @param {!Location} location
+   * @return {boolean}
+   * @private
+   */
+  handleA2AClick_(e, target, location) {
+    const relations = target.getAttribute('rel')
+        .split(' ')
+        .map(r => r.trim());
+    if (relations.indexOf('amphtml') < 0) {
+      return false;
+    }
+    // The viewer may not support the capability for navigating AMP links.
+    if (this.viewer_.navigateToAmpUrl(location.href, '<a rel=amphtml>')) {
+      e.preventDefault();
+      return true;
+    }
+    return false;
+  }
+
 
   /**
    * Handles clicking on a link with hash navigation.

--- a/src/service/document-click.js
+++ b/src/service/document-click.js
@@ -155,13 +155,9 @@ export class ClickHandler {
     // try to ask the viewer to navigate this AMP URL.
     if (opt_requestedBy) {
       if (!this.a2aFeatures_) {
-        const meta = this.rootNode_.querySelector(
-            'meta[name="amp-to-amp-navigation"]');
-        this.a2aFeatures_ = (meta && meta.hasAttribute('content'))
-          ? meta.getAttribute('content').split(',').map(s => s.trim())
-          : [];
+        this.a2aFeatures_ = this.queryA2AFeatures_();
       }
-      if (this.a2aFeatures_.indexOf(opt_requestedBy) >= 0) {
+      if (this.a2aFeatures_.includes(opt_requestedBy)) {
         if (this.viewer_.navigateToAmpUrl(url, opt_requestedBy)) {
           return;
         }
@@ -170,6 +166,19 @@ export class ClickHandler {
 
     // Otherwise, perform normal behavior of navigating the top frame.
     win.top.location.href = url;
+  }
+
+  /**
+   * @return {!Array<string>}
+   * @private
+   */
+  queryA2AFeatures_() {
+    const meta = this.rootNode_.querySelector(
+        'meta[name="amp-to-amp-navigation"]');
+    if (meta && meta.hasAttribute('content')) {
+      return meta.getAttribute('content').split(',').map(s => s.trim());
+    }
+    return [];
   }
 
   /**
@@ -272,10 +281,11 @@ export class ClickHandler {
    * @private
    */
   handleA2AClick_(e, target, location) {
-    const relations = (target.hasAttribute('rel'))
-      ? target.getAttribute('rel').split(' ').map(s => s.trim())
-      : [];
-    if (relations.indexOf('amphtml') < 0) {
+    if (!target.hasAttribute('rel')) {
+      return false;
+    }
+    const relations = target.getAttribute('rel').split(' ').map(s => s.trim());
+    if (!relations.includes('amphtml')) {
       return false;
     }
     // The viewer may not support the capability for navigating AMP links.

--- a/src/service/document-click.js
+++ b/src/service/document-click.js
@@ -158,8 +158,8 @@ export class ClickHandler {
         const meta = this.rootNode_.querySelector(
             'meta[name="amp-to-amp-navigation"]');
         this.a2aFeatures_ = (meta && meta.hasAttribute('content'))
-            ? meta.getAttribute('content').split(',').map(s => s.trim())
-            : [];
+          ? meta.getAttribute('content').split(',').map(s => s.trim())
+          : [];
       }
       if (this.a2aFeatures_.indexOf(opt_requestedBy) >= 0) {
         if (this.viewer_.navigateToAmpUrl(url, opt_requestedBy)) {
@@ -273,8 +273,8 @@ export class ClickHandler {
    */
   handleA2AClick_(e, target, location) {
     const relations = (target.hasAttribute('rel'))
-        ? target.getAttribute('rel').split(' ').map(s => s.trim())
-        : [];
+      ? target.getAttribute('rel').split(' ').map(s => s.trim())
+      : [];
     if (relations.indexOf('amphtml') < 0) {
       return false;
     }

--- a/src/service/standard-actions-impl.js
+++ b/src/service/standard-actions-impl.js
@@ -175,7 +175,7 @@ export class StandardActions {
     const node = invocation.target;
     const win = (node.ownerDocument || node).defaultView;
     const url = invocation.args['url'];
-    const requestedBy = `${invocation.target}.${invocation.method}`;
+    const requestedBy = `AMP.${invocation.method}`;
     Services.clickHandlerForDoc(this.ampdoc).navigateTo(win, url, requestedBy);
     return null;
   }

--- a/src/service/standard-actions-impl.js
+++ b/src/service/standard-actions-impl.js
@@ -21,7 +21,6 @@ import {Services} from '../services';
 import {computedStyle, getStyle, toggle} from '../style';
 import {dev, user} from '../log';
 import {dict} from '../utils/object';
-import {isProtocolValid} from '../url';
 import {registerServiceBuilderForDoc} from '../service';
 import {toWin} from '../types';
 import {tryFocus} from '../dom';
@@ -173,15 +172,11 @@ export class StandardActions {
     if (!invocation.satisfiesTrust(ActionTrust.HIGH)) {
       return null;
     }
-    const url = invocation.args['url'];
-    if (!isProtocolValid(url)) {
-      user().error(TAG, 'Cannot navigate to invalid protocol: ' + url);
-      return null;
-    }
-    const expandedUrl = this.urlReplacements_.expandUrlSync(url);
     const node = invocation.target;
     const win = (node.ownerDocument || node).defaultView;
-    win.location = expandedUrl;
+    const url = invocation.args['url'];
+    const requestedBy = `${invocation.target}.${invocation.method}`;
+    Services.clickHandlerForDoc(this.ampdoc).navigateTo(win, url, requestedBy);
     return null;
   }
 

--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -465,23 +465,23 @@ export class Viewer {
 
   /**
    * Requests A2A navigation to the given destination. If the viewer does
-   * not support this operation, will navigate the top level window
-   * to the destination.
+   * not support this operation, does nothing.
    * The URL is assumed to be in AMP Cache format already.
    * @param {string} url An AMP article URL.
    * @param {string} requestedBy Informational string about the entity that
    *     requested the navigation.
+   * @return {boolean} Returns true if navigation message was sent to viewer.
+   *     Otherwise, returns false.
    */
-  navigateTo(url, requestedBy) {
-    dev().assert(isProxyOrigin(url), 'Invalid A2A URL %s %s', url, requestedBy);
+  navigateToAmpUrl(url, requestedBy) {
     if (this.hasCapability('a2a')) {
       this.sendMessage('a2a', dict({
         'url': url,
         'requestedBy': requestedBy,
       }));
-    } else {
-      this.win.top.location.href = url;
+      return true;
     }
+    return false;
   }
 
   /**

--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -22,7 +22,6 @@ import {dict, map} from '../utils/object';
 import {findIndex} from '../utils/array';
 import {
   getSourceOrigin,
-  isProxyOrigin,
   parseQueryString,
   parseUrl,
   removeFragment,

--- a/src/services.js
+++ b/src/services.js
@@ -151,6 +151,15 @@ export class Services {
   }
 
   /**
+   * @param {!Node|!./service/ampdoc-impl.AmpDoc} nodeOrDoc
+   * @return {!./service/document-click.ClickHandler}
+   */
+  static clickHandlerForDoc(nodeOrDoc) {
+    return /** @type {!./service/document-click.ClickHandler} */ (
+      getServiceForDoc(nodeOrDoc, 'clickhandler'));
+  }
+
+  /**
    * @param {!Window} window
    * @return {!./service/crypto-impl.Crypto}
    */

--- a/test/functional/test-document-click.js
+++ b/test/functional/test-document-click.js
@@ -457,8 +457,7 @@ describes.sandboxed('ClickHandler', {}, () => {
 
       it('should delegate navigation if viewer supports A2A', () => {
         const stub =
-            sandbox.stub(handler.viewer_, 'navigateToAmpUrl')
-            .returns(true);
+            sandbox.stub(handler.viewer_, 'navigateToAmpUrl').returns(true);
 
         handler.handle_(event);
 
@@ -474,8 +473,7 @@ describes.sandboxed('ClickHandler', {}, () => {
 
       it('should behave normally if viewer does not support A2A', () => {
         const stub =
-            sandbox.stub(handler.viewer_, 'navigateToAmpUrl')
-            .returns(false);
+            sandbox.stub(handler.viewer_, 'navigateToAmpUrl').returns(false);
 
         handler.handle_(event);
 
@@ -499,7 +497,7 @@ describes.sandboxed('ClickHandler', {}, () => {
       });
 
       it('should reject invalid protocols', () => {
-        const newUrl =  /*eslint no-script-url: 0*/ 'javascript:alert(1)';
+        const newUrl = /*eslint no-script-url: 0*/ 'javascript:alert(1)';
 
         expect(win.location.href).to.equal('https://www.pub.com/');
         handler.navigateTo(win, newUrl);
@@ -514,8 +512,7 @@ describes.sandboxed('ClickHandler', {}, () => {
         ampdoc.getRootNode().head.appendChild(meta);
 
         const stub =
-            sandbox.stub(handler.viewer_, 'navigateToAmpUrl')
-            .returns(true);
+            sandbox.stub(handler.viewer_, 'navigateToAmpUrl').returns(true);
         expect(win.location.href).to.equal('https://www.pub.com/');
 
         // Delegate to viewer if opt_requestedBy matches the <meta> tag content

--- a/test/functional/test-document-click.js
+++ b/test/functional/test-document-click.js
@@ -16,6 +16,7 @@
 
 import '../../src/service/document-click';
 import * as Impression from '../../src/impression';
+import {Services} from '../../src/services';
 import {addParamToUrl} from '../../src/url';
 import {macroTask} from '../../testing/yield';
 
@@ -56,7 +57,7 @@ describes.sandboxed('ClickHandler', {}, () => {
       win = env.win;
       doc = win.document;
 
-      handler = win.services.clickhandler.obj;
+      handler = Services.clickHandlerForDoc(doc);
       handler.isIframed_ = true;
       decorationSpy = sandbox.spy(Impression, 'getExtraParamsUrl');
       handleNavSpy = sandbox.spy(handler, 'handleNavClick_');
@@ -66,9 +67,9 @@ describes.sandboxed('ClickHandler', {}, () => {
       winOpenStub = sandbox.stub(win, 'open').callsFake(() => {
         return {};
       });
-      const viewport = win.services.viewport.obj;
+      const viewport = Services.viewportForDoc(doc);
       scrollIntoViewStub = sandbox.stub(viewport, 'scrollIntoView');
-      const history = win.services.history.obj;
+      const history = Services.historyForDoc(doc);
       replaceStateForTargetPromise = Promise.resolve();
       replaceStateForTargetStub = sandbox.stub(
           history, 'replaceStateForTarget').callsFake(
@@ -100,7 +101,8 @@ describes.sandboxed('ClickHandler', {}, () => {
       it('should NOT handle custom protocol when not iframed', () => {
         handler.isIframed_ = false;
         handler.handle_(event);
-        expect(handleCustomProtocolSpy).to.not.be.called;
+        expect(handleCustomProtocolSpy).to.be.calledOnce;
+        expect(handleCustomProtocolSpy).to.have.returned(false);
       });
 
       it('should discover a link from a nested target', () => {
@@ -351,7 +353,6 @@ describes.sandboxed('ClickHandler', {}, () => {
     });
 
     describe('when linking to identifier', () => {
-
       beforeEach(() => {
         anchor.href = 'https://www.google.com/some-path?hello=world#test';
       });
@@ -447,6 +448,99 @@ describes.sandboxed('ClickHandler', {}, () => {
         expect(scrollIntoViewStub).to.be.calledWith(elementWithId);
       });
     });
+
+    describe('when linking to rel=amphtml', () => {
+      beforeEach(() => {
+        anchor.href = 'https://amp.pub.com/amp_page';
+        anchor.setAttribute('rel', 'unused amphtml unused');
+      });
+
+      it('should delegate navigation if viewer supports A2A', () => {
+        const stub =
+            sandbox.stub(handler.viewer_, 'navigateToAmpUrl')
+            .returns(true);
+
+        handler.handle_(event);
+
+        expect(stub).to.be.calledOnce;
+        expect(stub).calledWithExactly(
+            'https://amp.pub.com/amp_page', '<a rel=amphtml>');
+
+        // If viewer handles it, we should prevent default and not handle nav
+        // ourselves.
+        expect(event.defaultPrevented).to.be.true;
+        expect(handleNavSpy).to.not.be.called;
+      });
+
+      it('should behave normally if viewer does not support A2A', () => {
+        const stub =
+            sandbox.stub(handler.viewer_, 'navigateToAmpUrl')
+            .returns(false);
+
+        handler.handle_(event);
+
+        expect(stub).to.be.calledOnce;
+        expect(stub).calledWithExactly(
+            'https://amp.pub.com/amp_page', '<a rel=amphtml>');
+
+        // If viewer doesn't handles it, we should not prevent default and
+        // handle nav ourselves.
+        expect(event.defaultPrevented).to.be.false;
+        expect(handleNavSpy).to.be.calledOnce;
+      });
+    });
+
+    describe('navigateTo', () => {
+      let ampdoc;
+
+      beforeEach(() => {
+        ampdoc = Services.ampdoc(doc);
+        win.location.href = 'https://www.pub.com/';
+      });
+
+      it('should reject invalid protocols', () => {
+        const newUrl =  /*eslint no-script-url: 0*/ 'javascript:alert(1)';
+
+        expect(win.location.href).to.equal('https://www.pub.com/');
+        handler.navigateTo(win, newUrl);
+        // No navigation so window location should be unchanged.
+        expect(win.location.href).to.equal('https://www.pub.com/');
+      });
+
+      it('should delegate navigation to viewer if necessary', () => {
+        const meta = doc.createElement('meta');
+        meta.setAttribute('name', 'amp-to-amp-navigation');
+        meta.setAttribute('content', 'feature-foo, action-bar');
+        ampdoc.getRootNode().head.appendChild(meta);
+
+        const stub =
+            sandbox.stub(handler.viewer_, 'navigateToAmpUrl')
+            .returns(true);
+        expect(win.location.href).to.equal('https://www.pub.com/');
+
+        // Delegate to viewer if opt_requestedBy matches the <meta> tag content
+        // and the viewer supports A2A.
+        handler.navigateTo(win, 'https://amp.pub.com/amp_page', 'feature-foo');
+        expect(stub).to.be.calledOnce;
+        expect(stub).to.be.calledWithExactly(
+            'https://amp.pub.com/amp_page', 'feature-foo');
+        expect(win.location.href).to.equal('https://www.pub.com/');
+
+        // If opt_requestedBy doesn't match, navigate top normally.
+        handler.navigateTo(win, 'https://amp.pub.com/amp_page', 'no-match');
+        expect(stub).to.be.calledOnce;
+        expect(win.location.href).to.equal('https://amp.pub.com/amp_page');
+
+        // If opt_requestedBy matches but viewer doesn't support A2A, navigate
+        // top normally.
+        stub.returns(false);
+        handler.navigateTo(win, 'https://amp.pub.com/different', 'action-bar');
+        expect(stub).to.be.calledTwice;
+        expect(stub).to.be.calledWithExactly(
+            'https://amp.pub.com/different', 'action-bar');
+        expect(win.location.href).to.equal('https://amp.pub.com/different');
+      });
+    });
   });
 
   describes.realWin('fie embed', {
@@ -540,7 +634,6 @@ describes.sandboxed('ClickHandler', {}, () => {
       });
 
       describe('when linking to identifier', () => {
-
         beforeEach(() => {
           anchor.href = 'http://ads.localhost:8000/example#test';
         });

--- a/test/functional/test-standard-actions.js
+++ b/test/functional/test-standard-actions.js
@@ -206,12 +206,10 @@ describes.sandboxed('StandardActions', {}, () => {
 
   describe('"AMP" global target', () => {
     it('should implement navigateTo', () => {
-      const expandUrlStub = sandbox.stub(standardActions.urlReplacements_,
-          'expandUrlSync').callsFake(url => url);
+      const clickHandler = {navigateTo: sandbox.stub()};
+      sandbox.stub(Services, 'clickHandlerForDoc').returns(clickHandler);
 
-      const win = {
-        location: 'http://foo.com',
-      };
+      const win = {};
       const invocation = {
         method: 'navigateTo',
         args: {
@@ -227,20 +225,14 @@ describes.sandboxed('StandardActions', {}, () => {
       // Should check trust and fail.
       invocation.satisfiesTrust = () => false;
       standardActions.handleAmpTarget(invocation);
-      expect(win.location).to.equal('http://foo.com');
-      expect(expandUrlStub).to.not.be.called;
+      expect(clickHandler.navigateTo).to.be.not.called;
 
       // Should succeed.
       invocation.satisfiesTrust = () => true;
       standardActions.handleAmpTarget(invocation);
-      expect(win.location).to.equal('http://bar.com');
-      expect(expandUrlStub.calledOnce);
-
-      // Invalid protocols should fail.
-      invocation.args.url = /*eslint no-script-url: 0*/ 'javascript:alert(1)';
-      standardActions.handleAmpTarget(invocation);
-      expect(win.location).to.equal('http://bar.com');
-      expect(expandUrlStub.calledOnce);
+      expect(clickHandler.navigateTo).to.be.calledOnce;
+      expect(clickHandler.navigateTo).to.be.calledWithExactly(
+          win, 'http://bar.com', 'AMP.navigateTo');
     });
 
     it('should implement goBack', () => {

--- a/test/functional/test-viewer.js
+++ b/test/functional/test-viewer.js
@@ -1424,40 +1424,25 @@ describe('Viewer', () => {
 
   describe('navigateTo', () => {
     const ampUrl = 'https://cdn.ampproject.org/test/123';
-    it('should initiate a2a navigation', () => {
+    it('should message viewer if a2a capability is supported', () => {
       windowApi.location.hash = '#cap=a2a';
-      windowApi.top = {
-        location: {},
-      };
       const viewer = new Viewer(ampdoc);
       const send = sandbox.stub(viewer, 'sendMessage');
-      viewer.navigateTo(ampUrl, 'abc123');
+      const result = viewer.navigateToAmpUrl(ampUrl, 'abc123');
       expect(send.lastCall.args[0]).to.equal('a2a');
       expect(send.lastCall.args[1]).to.jsonEqual({
         url: ampUrl,
         requestedBy: 'abc123',
       });
-      expect(windowApi.top.location.href).to.be.undefined;
+      expect(result).to.be.true;
     });
 
-    it('should fail for non-amp url', () => {
-      windowApi.location.hash = '#cap=a2a';
-      const viewer = new Viewer(ampdoc);
-      sandbox.stub(viewer, 'sendMessage');
-      expect(() => {
-        viewer.navigateTo('http://www.test.com', 'abc123');
-      }).to.throw(/Invalid A2A URL/);
-    });
-
-    it('should perform fallback navigation', () => {
-      windowApi.top = {
-        location: {},
-      };
+    it('should return false if a2a capability is not supported', () => {
       const viewer = new Viewer(ampdoc);
       const send = sandbox.stub(viewer, 'sendMessage');
-      viewer.navigateTo(ampUrl, 'abc123');
+      const result = viewer.navigateToAmpUrl(ampUrl, 'abc123');
       expect(send).to.have.not.been.called;
-      expect(windowApi.top.location.href).to.equal(ampUrl);
+      expect(result).to.be.false;
     });
   });
 });


### PR DESCRIPTION
Closes #12496 and fixes #13056.

- Repurpose unused `a2a` viewer message and capability
- Consolidate navigation logic in `ClickHandler` service (will be renamed to `Navigation` after)
- Add A2A support by support `<a rel=amphtml>` for links and `<meta name="amp-to-amp-navigation" content="AMP.navigateTo, AMP-Redirect-To">` for other navigational features 

TODO: Follow up with documentation and validator changes.