### PR TITLE
Resets and disables touch zoom for amp stories.

### DIFF
--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -459,6 +459,8 @@ export class AmpStory extends AMP.BaseElement {
       'overflow': 'hidden',
     });
 
+    this.getViewport().resetTouchZoom();
+    this.getViewport().disableTouchZoom();
     this.maybeLockScreenOrientation_();
   }
 


### PR DESCRIPTION
🐛 

- Resets and disables touch zoom for amp-stories using the viewport.

Fixes #13309
