### PR TITLE
Eslint: Remove unnecessary semicolons

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -62,6 +62,7 @@
     "no-export-side-effect": 2,
     "no-extend-native": 2,
     "no-extra-bind": 2,
+    "no-extra-semi": 2,
     "no-for-of-statement": 2,
     "no-implicit-coercion": [2, { "boolean": false }],
     "no-implied-eval": 2,

--- a/3p/ampcontext.js
+++ b/3p/ampcontext.js
@@ -178,7 +178,7 @@ export class AbstractAmpContext {
     });
 
     return unlisten;
-  };
+  }
 
   /**
    *  Requests HTML snippet from the parent window.
@@ -216,7 +216,7 @@ export class AbstractAmpContext {
       'width': width,
       'height': height,
     }));
-  };
+  }
 
   /**
    *  Allows a creative to set the callback function for when the resize
@@ -228,7 +228,7 @@ export class AbstractAmpContext {
   onResizeSuccess(callback) {
     this.client_.registerCallback(MessageType.EMBED_SIZE_CHANGED, obj => {
       callback(obj['requestedHeight'], obj['requestedWidth']); });
-  };
+  }
 
   /**
    *  Allows a creative to set the callback function for when the resize
@@ -241,7 +241,7 @@ export class AbstractAmpContext {
     this.client_.registerCallback(MessageType.EMBED_SIZE_DENIED, obj => {
       callback(obj['requestedHeight'], obj['requestedWidth']);
     });
-  };
+  }
 
   /**
    *  Takes the current name on the window, and attaches it to

--- a/3p/environment.js
+++ b/3p/environment.js
@@ -261,4 +261,4 @@ export function installEmbedStateListener() {
   listenParent(window, 'embed-state', function(data) {
     inViewport = data.inViewport;
   });
-};
+}

--- a/3p/frame-metadata.js
+++ b/3p/frame-metadata.js
@@ -155,7 +155,7 @@ export function getContextState() {
     startTime: rawContext['startTime'],
     tagName: rawContext['tagName'],
   };
-};
+}
 
 
 /**

--- a/3p/integration.js
+++ b/3p/integration.js
@@ -462,7 +462,7 @@ export function draw3p(win, data, configCallback) {
   } else {
     run(type, win, data);
   }
-};
+}
 
 /**
  * @return {boolean} Whether this is the master iframe.

--- a/3p/twitter.js
+++ b/3p/twitter.js
@@ -122,4 +122,4 @@ export function cleanupTweetId_(tweetid) {
   }
 
   return tweetid;
-};
+}

--- a/ads/google/a4a/test/test-performance.js
+++ b/ads/google/a4a/test/test-performance.js
@@ -217,7 +217,7 @@ describe('GoogleAdLifecycleReporter', () => {
               /&st=30/.test(src));
           slotCounts[slotId] = slotCounts[slotId] || 0;
           ++slotCounts[slotId];
-        };
+        }
         // SlotId 0 corresponds to unusedReporter, so ignore it.
         for (let s = 1; s <= nSlots; ++s) {
           expect(slotCounts[s], 'slotCounts[' + s + ']').to.equal(nStages);

--- a/ads/google/a4a/test/test-utils.js
+++ b/ads/google/a4a/test/test-utils.js
@@ -34,7 +34,7 @@ import {
 } from '../utils';
 import {
   MockA4AImpl,
-} from '../../../../extensions/amp-a4a/0.1/test/utils';;
+} from '../../../../extensions/amp-a4a/0.1/test/utils';
 import {Services} from '../../../../src/services';
 import {buildUrl} from '../url-builder';
 import {createElementWithAttributes} from '../../../../src/dom';

--- a/ads/google/a4a/utils.js
+++ b/ads/google/a4a/utils.js
@@ -426,7 +426,7 @@ export function additionalDimensions(win, viewportSize) {
     outerHeight,
     innerWidth,
     innerHeight].join();
-};
+}
 
 /**
  * Returns amp-analytics config for a new CSI trigger.
@@ -727,7 +727,7 @@ export function getIdentityToken(win, nodeOrDoc) {
   win['goog_identity_prom'] = win['goog_identity_prom'] ||
       executeIdentityTokenFetch(win, nodeOrDoc);
   return /** @type {!Promise<!IdentityToken>} */(win['goog_identity_prom']);
-};
+}
 
 /**
  * @param {!Window} win
@@ -794,7 +794,7 @@ export function getIdentityTokenRequestUrl(win, nodeOrDoc, domain = undefined) {
   const canonical =
     parseUrl(Services.documentInfoForDoc(nodeOrDoc).canonicalUrl).hostname;
   return `https://adservice${domain}/adsid/integrator.json?domain=${canonical}`;
-};
+}
 
 /**
  * Returns whether we are running on the AMP CDN.

--- a/ads/google/adsense-amp-auto-ads.js
+++ b/ads/google/adsense-amp-auto-ads.js
@@ -60,4 +60,4 @@ export function getAdSenseAmpAutoAdsExpBranch(win) {
   randomlySelectUnsetExperiments(win, experiments);
   return getExperimentBranch(win, ADSENSE_AMP_AUTO_ADS_HOLDOUT_EXPERIMENT_NAME)
       || null;
-};
+}

--- a/ads/google/imaVideo.js
+++ b/ads/google/imaVideo.js
@@ -812,7 +812,7 @@ function getPagePosition(el) {
     el != null;
     lx += el./*OK*/offsetLeft, ly += el./*OK*/offsetTop,
     el = el./*OK*/offsetParent)
-  {};
+  {}
   return {x: lx,y: ly};
 }
 

--- a/ads/google/test/test-doubleclick.js
+++ b/ads/google/test/test-doubleclick.js
@@ -30,7 +30,7 @@ function verifyScript(win, name) {
           .to.equal(script == name);
     }
   });
-};
+}
 
 describes.sandboxed('writeAdScript', {}, env => {
 

--- a/ads/imedia.js
+++ b/ads/imedia.js
@@ -73,4 +73,4 @@ export function imedia(global, data) {
       return used; // remove (filter) element filled with add
     });
   });
-};
+}

--- a/ads/ix.js
+++ b/ads/ix.js
@@ -106,5 +106,5 @@ function reportStats(siteID, slotID, dfpSlot, start, code) {
     xhttp.open('POST', url, true);
     xhttp.setRequestHeader('Content-Type', 'application/json');
     xhttp.send(stats);
-  } catch (e) {};
+  } catch (e) {}
 }

--- a/ads/navegg.js
+++ b/ads/navegg.js
@@ -35,7 +35,7 @@ export function navegg(global, data) {
     nvg.getProfile(nvgTargeting => {
       for (seg in nvgTargeting) {
         data.targeting[seg] = nvgTargeting[seg];
-      };
+      }
       doubleclick(global, data);
     });
   });

--- a/ads/netletix.js
+++ b/ads/netletix.js
@@ -73,7 +73,7 @@ export function netletix(global, data) {
           if (event.data.width && event.data.height &&
               (event.data.width != nxw || event.data.height != nxh)) {
             global.context.requestResize(event.data.width, event.data.height);
-          };
+          }
           break;
         case 'nx-empty':
           global.context.noContentAvailable();

--- a/ads/sogouad.js
+++ b/ads/sogouad.js
@@ -41,4 +41,4 @@ export function sogouad(global, data) {
   }
   slot.appendChild(ad);
   loadScript(global, 'https://theta.sogoucdn.com/wap/js/aw.js');
-};
+}

--- a/build-system/check-package-manager.js
+++ b/build-system/check-package-manager.js
@@ -91,7 +91,7 @@ function main() {
   } else {
     console.log(green('Detected yarn version'), cyan(yarnVersion) +
         green('. Installing packages...'));
-  };
+  }
   return 0;
 }
 

--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -222,7 +222,7 @@ export class AmpImg extends BaseElement {
       this.togglePlaceholder(false);
     });
   }
-};
+}
 
 /**
  * @param {!Window} win Destination window for the new element.

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -219,7 +219,7 @@ export function protectFunctionWrapper(
       return undefined;
     }
   };
-};
+}
 
 export class AmpA4A extends AMP.BaseElement {
   // TODO: Add more error handling throughout code.
@@ -1772,7 +1772,7 @@ export function assignAdUrlToError(error, adUrl) {
   }
   (error.args || (error.args = {}))['au'] =
     adUrl.substring(adQueryIdx + 1, adQueryIdx + 251);
-};
+}
 
 /**
  * Returns the signature verifier for the given window. Lazily creates it if it

--- a/extensions/amp-a4a/0.1/callout-vendors.js
+++ b/extensions/amp-a4a/0.1/callout-vendors.js
@@ -54,4 +54,4 @@ if (getMode().localDev || getMode().test) {
     url: 'https://localhost:8000/examples/rtcE1.json?slot_id=SLOT_ID&page_id=PAGE_ID&foo_id=FOO_ID',
     disableKeyAppend: true,
   });
-};
+}

--- a/extensions/amp-access/0.1/test/test-amp-access.js
+++ b/extensions/amp-access/0.1/test/test-amp-access.js
@@ -328,7 +328,7 @@ describes.fakeWin('AccessService', {
     };
     element.textContent = JSON.stringify(config);
     const accessService = new AccessService(ampdoc);
-    class Vendor1 {};
+    class Vendor1 {}
     const vendor1 = new Vendor1();
     accessService.registerVendor('vendor1', vendor1);
     return accessService.adapter_.vendorPromise_.then(vendor => {
@@ -344,7 +344,7 @@ describes.fakeWin('AccessService', {
     };
     element.textContent = JSON.stringify(config);
     const accessService = new AccessService(ampdoc);
-    class Vendor1 {};
+    class Vendor1 {}
     const vendor1 = new Vendor1();
     expect(() => {
       accessService.registerVendor('vendor1', vendor1);

--- a/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
@@ -121,7 +121,7 @@ export class AmpAdXOriginIframeHandler {
             this.sendPosition_();
             this.registerPosition_();
           });
-    };
+    }
 
     // Triggered by context.reportRenderedEntityIdentifier(…) inside the ad
     // iframe.

--- a/extensions/amp-analytics/0.1/activity-impl.js
+++ b/extensions/amp-analytics/0.1/activity-impl.js
@@ -334,4 +334,4 @@ export class Activity {
     return this.totalEngagedTimeByTrigger_[name] -
       currentIncrementalEngagedTime;
   }
-};
+}

--- a/extensions/amp-analytics/0.1/requests.js
+++ b/extensions/amp-analytics/0.1/requests.js
@@ -152,7 +152,7 @@ export class RequestHandler {
         return this.urlReplacementService_.expandUrlAsync(
             baseUrl, bindings, this.whiteList_);
       });
-    };
+    }
 
     const extraUrlParamsPromise = this.expandExtraUrlParams_(
         configParams, triggerParams, expansionOption)

--- a/extensions/amp-analytics/0.1/resource-timing.js
+++ b/extensions/amp-analytics/0.1/resource-timing.js
@@ -131,7 +131,7 @@ function entryToExpansionOptions(entry, name, format) {
     'initiatorType': entry.initiatorType,
   };
   return new ExpansionOptions(vars, 1 /* opt_iterations */);
-};
+}
 
 /**
  * Returns the variables for the given resource timing entry if it matches one

--- a/extensions/amp-analytics/0.1/test/test-amp-analytics.js
+++ b/extensions/amp-analytics/0.1/test/test-amp-analytics.js
@@ -1667,7 +1667,7 @@ describes.realWin('amp-analytics', {
       });
 
       return waitForNoSendRequest(analytics).then(() => {
-        expect(addStub).to.not.be.called;;
+        expect(addStub).to.not.be.called;
       });
     });
 

--- a/extensions/amp-analytics/0.1/test/test-resource-timing.js
+++ b/extensions/amp-analytics/0.1/test/test-resource-timing.js
@@ -39,7 +39,7 @@ export function newResourceTimingSpec() {
       'delim': '~',
     },
   };
-};
+}
 
 /**
  * Returns a sample PerformanceResourceTiming entry. Timing intervals are fixed
@@ -77,7 +77,7 @@ export function newPerformanceResourceTiming(
     encodedBodySize: bodySize * 0.7,
     transferSize: cached ? 0 : bodySize * 0.7 + 200, // +200 for header size
   };
-};
+}
 
 describes.fakeWin('resourceTiming', {amp: true}, env => {
   let win;

--- a/extensions/amp-analytics/0.1/test/test-visibility-model.js
+++ b/extensions/amp-analytics/0.1/test/test-visibility-model.js
@@ -42,7 +42,7 @@ describes.sandboxed('VisibilityModel', {}, () => {
       return {
         repeat: model.repeat_,
       };
-    };
+    }
 
     it('should parse visiblePercentageMin', () => {
       expect(config({}).visiblePercentageMin).to.equal(0);

--- a/extensions/amp-auto-ads/0.1/attributes.js
+++ b/extensions/amp-auto-ads/0.1/attributes.js
@@ -64,4 +64,4 @@ function parseAttributes(attributeObject) {
     attributes[key] = String(attributeObject[key]);
   }
   return attributes;
-};
+}

--- a/extensions/amp-auto-ads/0.1/test/test-placement.js
+++ b/extensions/amp-auto-ads/0.1/test/test-placement.js
@@ -549,7 +549,7 @@ describes.realWin('placement', {
         initialMinSpacing: 0,
         subsequentMinSpacing: [],
         maxAdCount: 10,
-      });;
+      });
       return placements[0].placeAd(attributes, adTracker)
           .then(placementState => {
             expect(resource.attemptChangeSize).to.have.been.calledWith(

--- a/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
@@ -100,7 +100,7 @@ function waitForEvent(env, name) {
     function callback() {
       resolve();
       env.win.removeEventListener(name, callback);
-    };
+    }
     env.win.addEventListener(name, callback);
   });
 }

--- a/extensions/amp-byside-content/0.1/utils.js
+++ b/extensions/amp-byside-content/0.1/utils.js
@@ -31,11 +31,11 @@ export function debounce(func, wait, immediate) {
 	  clearTimeout(timeout);
 	  timeout = setTimeout(function() {
       timeout = null;
-      if (!immediate) { func.apply(context, args); };
+      if (!immediate) { func.apply(context, args); }
 	  }, wait);
 	  if (immediate && !timeout) { func.apply(context, args); }
   };
-};
+}
 
 /**
  *
@@ -56,4 +56,4 @@ export function getElementCreator(document) {
 function appendChildren(element, children) {
   children = (!children) ? [] : Array.isArray(children) ? children : [children];
   children.forEach(child => element.appendChild(child));
-};
+}

--- a/extensions/amp-date-picker/0.1/date-picker-common.js
+++ b/extensions/amp-date-picker/0.1/date-picker-common.js
@@ -141,7 +141,7 @@ export function withDatePickerCommon(WrappedComponent) {
         isOutsideRange: this.isOutsideRange,
       }));
     }
-  };
+  }
 
   Component.defaultProps = defaultProps;
 

--- a/extensions/amp-fit-text/0.1/amp-fit-text.js
+++ b/extensions/amp-fit-text/0.1/amp-fit-text.js
@@ -138,7 +138,7 @@ export function calculateFontSize_(measurer, expectedHeight, expectedWidth,
     }
   }
   return minFontSize;
-};
+}
 
 
 /**

--- a/extensions/amp-fx-collection/0.1/amp-fx-collection.js
+++ b/extensions/amp-fx-collection/0.1/amp-fx-collection.js
@@ -172,7 +172,7 @@ export class FxProviderInterface {
    * @param {!Element} unusedElement
    */
   installOn(unusedElement) {}
-};
+}
 
 AMP.extension(TAG, '0.1', AMP => {
   AMP.registerServiceForDoc(TAG, AmpFxCollection);

--- a/extensions/amp-fx-collection/0.1/providers/parallax.js
+++ b/extensions/amp-fx-collection/0.1/providers/parallax.js
@@ -186,4 +186,4 @@ class ParallaxElement {
       return aboveTheFold ? offsetTop : viewportHeight;
     });
   }
-};
+}

--- a/extensions/amp-gwd-animation/0.1/amp-gwd-animation-impl.js
+++ b/extensions/amp-gwd-animation/0.1/amp-gwd-animation-impl.js
@@ -95,7 +95,7 @@ function getCounter(receiver, counterName) {
     return receiver.gwdGotoCounters[counterName];
   }
   return 0;
-};
+}
 
 /**
  * @param {!Element} receiver
@@ -113,7 +113,7 @@ function setCounter(receiver, counterName, counterValue) {
     receiver.gwdGotoCounters[counterName] = 0;
   }
   receiver.gwdGotoCounters[counterName] = counterValue;
-};
+}
 
 /**
  * AMP GWD animation runtime service.
@@ -423,4 +423,4 @@ export class AmpGwdRuntimeService {
  */
 function reflow(element) {
   element./*OK*/offsetWidth = element./*OK*/offsetWidth;
-};
+}

--- a/extensions/amp-gwd-animation/0.1/amp-gwd-animation.js
+++ b/extensions/amp-gwd-animation/0.1/amp-gwd-animation.js
@@ -180,7 +180,7 @@ export function addAction(ampdoc, element, event, actionStr) {
 
   // Reset the element's actions with the new actions string.
   Services.actionServiceForDoc(ampdoc).setActions(element, newActionsStr);
-};
+}
 
 AMP.extension(TAG, '0.1', AMP => {
   AMP.registerServiceForDoc(GWD_SERVICE_NAME, AmpGwdRuntimeService);

--- a/extensions/amp-iframe/0.1/amp-iframe.js
+++ b/extensions/amp-iframe/0.1/amp-iframe.js
@@ -547,7 +547,7 @@ export class AmpIframe extends AMP.BaseElement {
     }
     return !this.isInContainer_;
   }
-};
+}
 
 /**
  * We always set a sandbox. Default is that none of the things that need

--- a/extensions/amp-nexxtv-player/0.1/amp-nexxtv-player.js
+++ b/extensions/amp-nexxtv-player/0.1/amp-nexxtv-player.js
@@ -196,7 +196,7 @@ class AmpNexxtvPlayer extends AMP.BaseElement {
         }), '*');
       }
     });
-  };
+  }
 
   // emitter
   handleNexxMessages_(event) {

--- a/extensions/amp-ooyala-player/0.1/test/test-amp-ooyala.js
+++ b/extensions/amp-ooyala-player/0.1/test/test-amp-ooyala.js
@@ -58,7 +58,7 @@ describes.realWin('amp-ooyala-player', {
     return player.build()
         .then(() => player.layoutCallback())
         .then(() => player);
-  };
+  }
 
   it('renders a V3 player', () => {
     return getOoyalaElement('Vxc2k0MDE6Y_C7J5podo3UDxlFxGaZrQ',

--- a/extensions/amp-pinterest/0.1/pin-widget.js
+++ b/extensions/amp-pinterest/0.1/pin-widget.js
@@ -259,4 +259,4 @@ export class PinWidget {
         .then(this.renderPin.bind(this));
   }
 
-};
+}

--- a/extensions/amp-pinterest/0.1/pinit-button.js
+++ b/extensions/amp-pinterest/0.1/pinit-button.js
@@ -181,4 +181,4 @@ export class PinItButton {
     }
     return promise.then(this.renderTemplate.bind(this));
   }
-};
+}

--- a/extensions/amp-pinterest/0.1/test/test-amp-pinterest.js
+++ b/extensions/amp-pinterest/0.1/test/test-amp-pinterest.js
@@ -42,7 +42,7 @@ describes.realWin('amp-pinterest', {
     return pin.implementation_.layoutCallback().then(() => {
       return pin;
     });
-  };
+  }
 
   function getEmbedPin(pinID, pinAlt, mockResponse) {
     const div = document.createElement('div');
@@ -61,7 +61,7 @@ describes.realWin('amp-pinterest', {
     return pin.implementation_.layoutCallback().then(() => {
       return pin;
     });
-  };
+  }
 
 
   it('renders', () => {

--- a/extensions/amp-pinterest/0.1/util.js
+++ b/extensions/amp-pinterest/0.1/util.js
@@ -36,7 +36,7 @@ function log(queryParams) {
   }
   query = query + '&via=' + encodeURIComponent(window.location.href);
   call.src = query;
-};
+}
 
 /**
  * Strip data from string
@@ -53,7 +53,7 @@ function filter(str) {
   ret = decoded.replace(/</g, '&lt;');
   ret = ret.replace(/>/g, '&gt;');
   return ret;
-};
+}
 
 /**
  * Create a DOM element with attributes
@@ -73,7 +73,7 @@ function make(doc, data) {
     break;
   }
   return el;
-};
+}
 
 /**
  * Set a DOM element attribute
@@ -87,6 +87,6 @@ function set(el, attr, value) {
   } else {
     el.setAttribute(attr, value);
   }
-};
+}
 
 export const Util = {filter, guid, log, make, set};

--- a/extensions/amp-playbuzz/0.1/utils.js
+++ b/extensions/amp-playbuzz/0.1/utils.js
@@ -41,11 +41,11 @@ export function debounce(func, wait, immediate) {
     clearTimeout(timeout);
     timeout = setTimeout(function() {
       timeout = null;
-      if (!immediate) { func.apply(context, args); };
+      if (!immediate) { func.apply(context, args); }
     }, wait);
     if (immediate && !timeout) { func.apply(context, args); }
   };
-};
+}
 
 
 /**
@@ -67,7 +67,7 @@ export function getElementCreator(document) {
 function appendChildren(element, children) {
   children = (!children) ? [] : Array.isArray(children) ? children : [children];
   children.forEach(child => element.appendChild(child));
-};
+}
 
 
 /**

--- a/extensions/amp-selector/0.1/test/test-amp-selector.js
+++ b/extensions/amp-selector/0.1/test/test-amp-selector.js
@@ -324,7 +324,7 @@ describes.realWin('amp-selector', {
 
       impl = ampSelector.implementation_;
       yield ampSelector.build();
-      expect(impl.inputs_.length).to.equal(0);;
+      expect(impl.inputs_.length).to.equal(0);
 
       ampSelector = getSelector({
         attributes: {

--- a/extensions/amp-sidebar/0.1/test/test-amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/test/test-amp-sidebar.js
@@ -69,7 +69,7 @@ describes.realWin('amp-sidebar 0.1 version', {
     if (options.closeText) {
       ampSidebar.setAttribute('data-close-button-aria-label',
           options.closeText);
-    };
+    }
     ampSidebar.setAttribute('id', 'sidebar1');
     ampSidebar.setAttribute('layout', 'nodisplay');
     doc.body.appendChild(ampSidebar);

--- a/extensions/amp-story/0.1/media-pool.js
+++ b/extensions/amp-story/0.1/media-pool.js
@@ -885,7 +885,7 @@ export class MediaPoolRoot {
   /**
    * @return {!Element} The root element of this media pool.
    */
-  getElement() {};
+  getElement() {}
 
   /**
    * @param {!Element} unusedElement The element whose distance should be
@@ -897,12 +897,12 @@ export class MediaPoolRoot {
    *     furthest from the user's current position in the document are evicted
    *     from the MediaPool first).
    */
-  getElementDistance(unusedElement) {};
+  getElementDistance(unusedElement) {}
 
 
   /**
    * @return {!Object<!MediaType, number>} The maximum amount of each media
    *     type to allow within this element.
    */
-  getMaxMediaElementCounts() {};
+  getMaxMediaElementCounts() {}
 }

--- a/extensions/amp-viewer-integration/0.1/examples/amp-viewer-host.js
+++ b/extensions/amp-viewer-integration/0.1/examples/amp-viewer-host.js
@@ -134,7 +134,7 @@ export class AmpViewerHost {
       state: this.visibilityState_,
       prerenderSize: this.prerenderSize,
     }, true);
-  };
+  }
 
   /**
    * @param {*} eventData
@@ -143,7 +143,7 @@ export class AmpViewerHost {
    */
   isChannelOpen_(eventData) {
     return eventData.app == APP && eventData.name == CHANNEL_OPEN_MSG;
-  };
+  }
 
   /**
    * @param {string} type
@@ -157,7 +157,7 @@ export class AmpViewerHost {
       return;
     }
     return this.messaging_.sendRequest(type, data, awaitResponse);
-  };
+  }
 
   log() {
     const var_args = Array.prototype.slice.call(arguments, 0);

--- a/extensions/amp-viewer-integration/0.1/messaging/messaging.js
+++ b/extensions/amp-viewer-integration/0.1/messaging/messaging.js
@@ -324,7 +324,7 @@ export class Messaging {
     const dataStr = ' data: ' + this.errorToString_(opt_data);
     stateStr += dataStr;
     this.win['viewerState'] = stateStr;
-  };
+  }
 
   /**
    * @param {*} err !Error most of time, string sometimes, * rarely.

--- a/extensions/amp-viewer-integration/0.1/test/viewer-initiated-handshake-viewer-for-testing.js
+++ b/extensions/amp-viewer-integration/0.1/test/viewer-initiated-handshake-viewer-for-testing.js
@@ -136,7 +136,7 @@ export class WebviewViewerForTesting {
   isChannelOpen_(e) {
     return e.type == 'message' && e.data.app == APP &&
       e.data.name == 'channelOpen';
-  };
+  }
 
   completeHandshake_(requestId) {
     this.log('Viewer ' + this.id + ' messaging established!');
@@ -156,7 +156,7 @@ export class WebviewViewerForTesting {
     });
 
     this.handshakeResponseResolve_();
-  };
+  }
 
   sendRequest_(eventType, payload) {
     const requestId = ++this.requestIdCounter_;
@@ -169,7 +169,7 @@ export class WebviewViewerForTesting {
       type: MessageType.REQUEST,
     };
     this.iframe.contentWindow./*OK*/postMessage(message, this.frameOrigin_);
-  };
+  }
 
   processRequest_(eventData) {
     const data = eventData;
@@ -193,7 +193,7 @@ export class WebviewViewerForTesting {
       default:
         return Promise.reject('request not supported: ' + data.name);
     }
-  };
+  }
 
   log() {
     const var_args = Array.prototype.slice.call(arguments, 0);

--- a/extensions/amp-viewer-integration/0.1/test/webview-viewer-for-testing.js
+++ b/extensions/amp-viewer-integration/0.1/test/webview-viewer-for-testing.js
@@ -145,7 +145,7 @@ export class WebviewViewerForTesting {
     const data = JSON.parse(e.data);
     return e.type == 'message' && data.app == APP &&
       data.name == 'channelOpen';
-  };
+  }
 
 
   completeHandshake_(channel, requestId) {
@@ -189,7 +189,7 @@ export class WebviewViewerForTesting {
     }, true);
 
     this.handshakeResponseResolve_();
-  };
+  }
 
   sendRequest_(type, data, awaitResponse) {
     this.log('Viewer.prototype.sendRequest_');
@@ -197,7 +197,7 @@ export class WebviewViewerForTesting {
       return;
     }
     return this.messaging_.sendRequest(type, data, awaitResponse);
-  };
+  }
 
   handleMessage_(e) {
     if (this.messageHandlers_[this.id]) {
@@ -206,7 +206,7 @@ export class WebviewViewerForTesting {
 
     this.log('************** viewer got a message,', e.data);
     this.processRequest_(e.data);
-  };
+  }
 
   /**
    * This is used in test-amp-viewer-integration to test the handshake and make
@@ -239,7 +239,7 @@ export class WebviewViewerForTesting {
       default:
         return Promise.reject('request not supported: ' + data.name);
     }
-  };
+  }
 
   log() {
     const var_args = Array.prototype.slice.call(arguments, 0);

--- a/src/chunk.js
+++ b/src/chunk.js
@@ -104,11 +104,11 @@ export function chunkInstanceForTesting(nodeOrAmpDoc) {
  */
 export function deactivateChunking() {
   deactivated = true;
-};
+}
 
 export function activateChunkingForTesting() {
   deactivated = false;
-};
+}
 
 /**
  * Runs all currently scheduled chunks.

--- a/src/cookies.js
+++ b/src/cookies.js
@@ -139,7 +139,7 @@ function trySetCookie(win, name, value, expirationTime, domain) {
     // Do not throw if setting the cookie failed Exceptions can be thrown
     // when AMP docs are opened on origins that do not allow setting
     // cookies such as null origins.
-  };
+  }
 }
 
 /**

--- a/src/curve.js
+++ b/src/curve.js
@@ -237,7 +237,7 @@ class Bezier {
   lerp(a, b, x) {
     return a + x * (b - a);
   }
-};
+}
 
 
 /**

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -1601,7 +1601,7 @@ function createBaseCustomElementClass(win) {
         }
       }
     }
-  };
+  }
   win.BaseCustomElementClass = BaseCustomElement;
   return win.BaseCustomElementClass;
 }

--- a/src/mediasession-helper.js
+++ b/src/mediasession-helper.js
@@ -103,7 +103,7 @@ export function parseSchemaImage(doc) {
   } else {
     return;
   }
-};
+}
 
 /**
  * Parses the og:image if it exists and returns it
@@ -117,7 +117,7 @@ export function parseOgImage(doc) {
   } else {
     return;
   }
-};
+}
 
 /**
  * Parses the website's Favicon and returns it
@@ -148,4 +148,4 @@ function validateMetadata(metadata) {
       }
     });
   }
-};
+}

--- a/src/polyfills/math-sign.js
+++ b/src/polyfills/math-sign.js
@@ -31,7 +31,7 @@ export function sign(x) {
   }
 
   return x > 0 ? 1 : -1;
-};
+}
 
 
 /**

--- a/src/service/ampdoc-impl.js
+++ b/src/service/ampdoc-impl.js
@@ -609,4 +609,4 @@ export function installDocService(win, isSingleDoc) {
       function() {
         return new AmpDocService(win, isSingleDoc);
       });
-};
+}

--- a/src/service/batched-xhr-impl.js
+++ b/src/service/batched-xhr-impl.js
@@ -102,4 +102,4 @@ export function batchedXhrServiceForTesting(window) {
  */
 export function installBatchedXhrService(window) {
   registerServiceBuilder(window, 'batched-xhr', BatchedXhr);
-};
+}

--- a/src/service/layers-impl.js
+++ b/src/service/layers-impl.js
@@ -1093,4 +1093,4 @@ export function installLayersServiceForDoc(ampdoc, scrollingElement) {
   registerServiceBuilderForDoc(ampdoc, 'layers', function(ampdoc) {
     return new LayoutLayers(ampdoc, scrollingElement);
   }, /* opt_instantiate */ true);
-};
+}

--- a/src/service/platform-impl.js
+++ b/src/service/platform-impl.js
@@ -195,7 +195,7 @@ export class Platform {
     }
     return Number(currentIosVersion.split('.')[0]);
   }
-};
+}
 
 
 /**
@@ -203,4 +203,4 @@ export class Platform {
  */
 export function installPlatformService(window) {
   return registerServiceBuilder(window, 'platform', Platform);
-};
+}

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -2246,4 +2246,4 @@ export let SizeDef;
  */
 export function installResourcesServiceForDoc(ampdoc) {
   registerServiceBuilderForDoc(ampdoc, 'resources', Resources);
-};
+}

--- a/src/service/standard-actions-impl.js
+++ b/src/service/standard-actions-impl.js
@@ -348,4 +348,4 @@ export function installStandardActionsForDoc(ampdoc) {
       'standard-actions',
       StandardActions,
       /* opt_instantiate */ true);
-};
+}

--- a/src/service/timer-impl.js
+++ b/src/service/timer-impl.js
@@ -172,4 +172,4 @@ export class Timer {
  */
 export function installTimerService(window) {
   registerServiceBuilder(window, 'timer', Timer);
-};
+}

--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -62,7 +62,7 @@ function encodeValue(val) {
     return '';
   }
   return encodeURIComponent(/** @type {string} */(val));
-};
+}
 
 /**
  * Class to provide variables that pertain to top level AMP window.

--- a/src/service/variable-source.js
+++ b/src/service/variable-source.js
@@ -78,7 +78,7 @@ export function getTimingDataSync(win, startEvent, endEvent) {
   if (!isFiniteNumber(metric)) {
     // The metric is not supported.
     return;
-  } else if (metric < 0) {;
+  } else if (metric < 0) {
     return '';
   } else {
     return metric;

--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -1091,7 +1091,7 @@ class VideoEntry {
       const internalElement = this.internalElement_;
       function cloneStyle(prop) {
         return st.getStyle(dev().assertElement(internalElement), prop);
-      };
+      }
 
       st.setStyles(dev().assertElement(this.draggingMask_), {
         'top': cloneStyle('top'),
@@ -1990,4 +1990,4 @@ export function clearSupportsAutoplayCacheForTesting() {
  */
 export function installVideoManagerForDoc(nodeOrDoc) {
   registerServiceBuilderForDoc(nodeOrDoc, 'video-manager', VideoManager);
-};
+}

--- a/src/service/xhr-impl.js
+++ b/src/service/xhr-impl.js
@@ -826,4 +826,4 @@ export function xhrServiceForTesting(window) {
  */
 export function installXhrService(window) {
   registerServiceBuilder(window, 'xhr', Xhr);
-};
+}

--- a/src/services.js
+++ b/src/services.js
@@ -201,7 +201,7 @@ export class Services {
    */
   static inputFor(win) {
     return getService(win, 'input');
-  };
+  }
 
   /**
    * @param {!Node|!./service/ampdoc-impl.AmpDoc} nodeOrDoc

--- a/src/size-list.js
+++ b/src/size-list.js
@@ -122,7 +122,7 @@ export function parseSizeList(s, opt_allowPercentAsLength) {
           assertLength(sizeStr)});
   });
   return new SizeList(sizes);
-};
+}
 
 
 /**

--- a/src/string.js
+++ b/src/string.js
@@ -126,4 +126,4 @@ export function stringHash32(str) {
   }
   // Convert from 32-bit signed to unsigned.
   return String(hash >>> 0);
-};
+}

--- a/src/style-installer.js
+++ b/src/style-installer.js
@@ -318,4 +318,4 @@ function styleLoaded(doc, style) {
     }
   }
   return false;
-};
+}

--- a/src/utils/bytes.js
+++ b/src/utils/bytes.js
@@ -56,7 +56,7 @@ export function stringToBytes(str) {
     bytes[i] = charCode;
   }
   return bytes;
-};
+}
 
 /**
  * Converts a 8-bit bytes array into a string
@@ -71,7 +71,7 @@ export function bytesToString(bytes) {
     array[i] = String.fromCharCode(bytes[i]);
   }
   return array.join('');
-};
+}
 
 /**
  * Converts a 4-item byte array to an unsigned integer.

--- a/src/utils/dom-fingerprint.js
+++ b/src/utils/dom-fingerprint.js
@@ -61,7 +61,7 @@ export function domFingerprintPlain(element) {
     element = element.parentElement;
   }
   return ids.join();
-};
+}
 
 
 export class DomFingerprint {
@@ -107,4 +107,4 @@ function indexWithinParent(element) {
   }
   // If we got to the end, then the count is accurate; otherwise skip count.
   return count < 25 && i < 100 ? `.${count}` : '';
-};
+}

--- a/src/utils/math.js
+++ b/src/utils/math.js
@@ -51,7 +51,7 @@ export function mapRange(val, min1, max1, min2, max2) {
   }
 
   return (val - min1) * (max2 - min2) / (max1 - min1) + min2;
-};
+}
 
 /**
  * Restricts a number to be in the given min/max range.
@@ -68,4 +68,4 @@ export function mapRange(val, min1, max1, min2, max2) {
  */
 export function clamp(val, min, max) {
   return Math.min(Math.max(val, min), max);
-};
+}

--- a/test/functional/test-dom.js
+++ b/test/functional/test-dom.js
@@ -961,7 +961,7 @@ describes.realWin('DOM', {
   },
 }, env => {
   let doc;
-  class TestElement extends BaseElement {};
+  class TestElement extends BaseElement {}
   describe('whenUpgradeToCustomElement function', () => {
     beforeEach(() => {
       doc = env.win.document;

--- a/test/functional/test-extension-analytics.js
+++ b/test/functional/test-extension-analytics.js
@@ -41,7 +41,7 @@ describes.realWin('extension-analytics', {
   describe('insertAnalyticsElement', () => {
     let sandbox;
     class MockInstrumentation {
-    };
+    }
 
     beforeEach(() => {
       sandbox = sinon.sandbox.create();
@@ -160,7 +160,7 @@ describes.realWin('extension-analytics', {
       } catch (e) {
         expect(e.message).to.equal(
             'customEventReporterBuilder should not track same eventType twice');
-      };
+      }
     });
 
     it('should return a customEventReporter instance', () => {

--- a/test/functional/test-extensions.js
+++ b/test/functional/test-extensions.js
@@ -150,7 +150,7 @@ describes.sandboxed('Extensions', {}, () => {
       expect(holder.error.message).to.equal('intentional');
       expect(holder.loaded).to.be.undefined;
       expect(holder.resolve).to.exist;
-      expect(holder.reject).to.exist;;
+      expect(holder.reject).to.exist;
       expect(holder.promise).to.exist;
       expect(promise).to.equal(holder.promise);
 

--- a/test/functional/test-runtime.js
+++ b/test/functional/test-runtime.js
@@ -183,7 +183,7 @@ describes.fakeWin('runtime', {
       expect(progress).to.equal('12345');
       expect(queueExtensions).to.have.length(0);
     });
-  };
+  }
 
   it('should execute scheduled extensions & execute new extensions',
       extensionRegistrationTest);

--- a/test/integration/test-amp-bind.js
+++ b/test/integration/test-amp-bind.js
@@ -427,7 +427,7 @@ describe.configure().ifNewChrome().run('amp-bind', function() {
       const button = fixture.doc.getElementById('disallowedVidUrlButton');
       const vid = fixture.doc.getElementById('video');
       expect(vid.getAttribute('src')).to
-          .equal('https://www.google.com/unbound.webm');;
+          .equal('https://www.google.com/unbound.webm');
       button.click();
       return waitForSetState().then(() => {
         expect(vid.getAttribute('src')).to

--- a/test/integration/test-position-observer.js
+++ b/test/integration/test-position-observer.js
@@ -176,7 +176,7 @@ config.run('amp-position-observer', function() {
 function getOpacity(win) {
   const animTarget = win.document.querySelector('#animTarget');
   return parseFloat(win.getComputedStyle(animTarget).opacity);
-};
+}
 
 function waitForOpacity(win, comparison, factor) {
   return poll('wait for opacity to ' + comparison + ': ' + factor, () => {
@@ -188,7 +188,7 @@ function waitForOpacity(win, comparison, factor) {
       return getOpacity(win) > factor;
     }
   });
-};
+}
 
 function ensureOpacityIsNoChangingAnymore(win) {
   return new Promise((resolve, reject) => {
@@ -207,4 +207,4 @@ function ensureOpacityIsNoChangingAnymore(win) {
 
 function getViewportHeight(win) {
   return win.document.querySelector('.spacer').offsetHeight;
-};
+}


### PR DESCRIPTION
This PR adds a new `eslint` rule `no-extra-semi` and removes all extra semicolons in the AMP code.

Fixes #10499