### PR TITLE
🏗 Forbid prototype access to hasOwnProperty and toString

### DIFF
--- a/3p/3p.js
+++ b/3p/3p.js
@@ -188,7 +188,7 @@ export function computeInMasterFrame(global, taskId, work, cb) {
   const master = global.context.master;
   let tasks = master.__ampMasterTasks;
   if (!tasks) {
-    tasks = master.__ampMasterTasks = {};
+    tasks = master.__ampMasterTasks = map();
   }
   let cbs = tasks[taskId];
   if (!tasks[taskId]) {
@@ -271,23 +271,23 @@ function validateExactlyOne(data, alternativeFields) {
  * @param {!Array<string>} allowedFields
  */
 function validateAllowedFields(data, allowedFields) {
-  const defaultAvailableFields = {
-    width: true,
-    height: true,
-    type: true,
-    referrer: true,
-    canonicalUrl: true,
-    pageViewId: true,
-    location: true,
-    mode: true,
-    consentNotificationId: true,
-    ampSlotIndex: true,
-    adHolderText: true,
-    loadingStrategy: true,
-  };
+  const defaultAvailableFields = map({
+    'width': true,
+    'height': true,
+    'type': true,
+    'referrer': true,
+    'canonicalUrl': true,
+    'pageViewId': true,
+    'location': true,
+    'mode': true,
+    'consentNotificationId': true,
+    'ampSlotIndex': true,
+    'adHolderText': true,
+    'loadingStrategy': true,
+  });
 
   for (const field in data) {
-    if (!data.hasOwnProperty(field) || field in defaultAvailableFields) {
+    if (!defaultAvailableFields[field]) {
       continue;
     }
     if (allowedFields.indexOf(field) < 0) {
@@ -300,7 +300,7 @@ function validateAllowedFields(data, allowedFields) {
 }
 
 /** @private {!Object<string, boolean>} */
-let experimentToggles = {};
+let experimentToggles = map();
 
 /**
  * Returns true if an experiment is enabled.
@@ -316,5 +316,5 @@ export function isExperimentOn(experimentId) {
  * @param {!Object<string, boolean>} toggles
  */
 export function setExperimentToggles(toggles) {
-  experimentToggles = toggles;
+  experimentToggles = map(toggles);
 }

--- a/3p/3p.js
+++ b/3p/3p.js
@@ -23,8 +23,8 @@
 
 
 import {dev, user} from '../src/log';
+import {hasOwn, map} from '../src/utils/object';
 import {isArray} from '../src/types';
-import {map} from '../src/utils/object';
 import {rethrowAsync} from '../src/log';
 
 
@@ -271,7 +271,7 @@ function validateExactlyOne(data, alternativeFields) {
  * @param {!Array<string>} allowedFields
  */
 function validateAllowedFields(data, allowedFields) {
-  const defaultAvailableFields = map({
+  const defaultAvailableFields = {
     'width': true,
     'height': true,
     'type': true,
@@ -284,10 +284,10 @@ function validateAllowedFields(data, allowedFields) {
     'ampSlotIndex': true,
     'adHolderText': true,
     'loadingStrategy': true,
-  });
+  };
 
   for (const field in data) {
-    if (!defaultAvailableFields[field]) {
+    if (!hasOwn(data, field) || hasOwn(defaultAvailableFields, field)) {
       continue;
     }
     if (allowedFields.indexOf(field) < 0) {

--- a/ads/ads.extern.js
+++ b/ads/ads.extern.js
@@ -359,7 +359,6 @@ data.slot.replace;
 
 // medianet.js
 data.crid;
-data.hasOwnProperty;
 data.requrl;
 data.refurl;
 data.versionId;

--- a/ads/connatix.js
+++ b/ads/connatix.js
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import {tryParseJson} from '../src/json.js';
+import {hasOwn} from '../src/utils/object';
+import {tryParseJson} from '../src/json';
 import {validateData} from '../3p/3p';
 
 /**
@@ -31,7 +32,7 @@ export function connatix(global, data) {
   const cnxData = Object.assign(Object(tryParseJson(data['connatix'])));
   global.cnxAmpAd = true;
   for (const key in cnxData) {
-    if (cnxData.hasOwnProperty(key)) {
+    if (hasOwn(cnxData, key)) {
       script.setAttribute(key, cnxData[key]);
     }
   }

--- a/ads/google/a4a/performance.js
+++ b/ads/google/a4a/performance.js
@@ -21,6 +21,7 @@ import {dev} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {getCorrelator} from './utils';
 import {getTimingDataSync} from '../../../src/service/variable-source';
+import {hasOwn} from '../../../src/utils/object';
 import {serializeQueryString} from '../../../src/url';
 
 /**
@@ -93,7 +94,7 @@ export class BaseLifecycleReporter {
    */
   setPingParameters(parametersToValues) {
     for (const variable in parametersToValues) {
-      if (parametersToValues.hasOwnProperty(variable)) {
+      if (hasOwn(parametersToValues, variable)) {
         this.setPingParameter(variable, parametersToValues[variable]);
       }
     }

--- a/ads/google/a4a/traffic-experiments.js
+++ b/ads/google/a4a/traffic-experiments.js
@@ -36,6 +36,7 @@ import {
 } from '../../../src/experiments';
 import {Services} from '../../../src/services';
 import {dev} from '../../../src/log';
+import {hasOwn} from '../../../src/utils/object';
 import {parseQueryString} from '../../../src/url';
 
 /** @typedef {{
@@ -142,13 +143,13 @@ export function googleAdsIsA4AEnabled(win, element, experimentName,
 /**
  * @param {!Window} win
  * @param {!Element} element Ad tag Element.
- * @return {?string} experiment extracted from page url.
+ * @return {string} experiment extracted from page url.
  */
 export function extractUrlExperimentId(win, element) {
   const expParam = Services.viewerForDoc(element).getParam('exp') ||
     parseQueryString(win.location.search)['exp'];
   if (!expParam) {
-    return null;
+    return '';
   }
   // Allow for per type experiment control with Doubleclick key set for 'da'
   // and AdSense using 'aa'.  Fallback to 'a4a' if type specific is missing.
@@ -162,7 +163,7 @@ export function extractUrlExperimentId(win, element) {
   expKeys.forEach(key => arg = arg ||
     ((match = new RegExp(`(?:^|,)${key}:(-?\\d+)`).exec(expParam)) &&
       match[1]));
-  return arg || null;
+  return arg || '';
 }
 
 /**
@@ -214,7 +215,7 @@ function maybeSetExperimentFromUrl(win, element, experimentName,
     '6': sfgTreatmentId,
   };
   const arg = extractUrlExperimentId(win, element);
-  if (argMapping.hasOwnProperty(arg)) {
+  if (hasOwn(argMapping, arg)) {
     forceExperimentBranch(win, experimentName, argMapping[arg]);
     return true;
   } else {

--- a/ads/ix.js
+++ b/ads/ix.js
@@ -15,6 +15,7 @@
  */
 
 import {doubleclick} from '../ads/google/doubleclick';
+import {hasOwn} from '../src/utils/object';
 import {loadScript, writeScript} from '../3p/3p';
 
 const DEFAULT_TIMEOUT = 500; // ms
@@ -68,7 +69,7 @@ export function ix(global, data) {
 
 function prepareData(data) {
   for (const attr in data) {
-    if (data.hasOwnProperty(attr) && /^ix[A-Z]/.test(attr)) {
+    if (hasOwn(data, attr) && /^ix[A-Z]/.test(attr)) {
       delete data[attr];
     }
   }

--- a/ads/kiosked.js
+++ b/ads/kiosked.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {hasOwn} from '../src/utils/object';
 import {validateData, writeScript} from '../3p/3p';
 
 /**
@@ -23,7 +24,7 @@ import {validateData, writeScript} from '../3p/3p';
 export function kiosked(global, data) {
   let scriptId;
   validateData(data, ['scriptid'], []);
-  if (data.hasOwnProperty('scriptid')) {
+  if (hasOwn(data, 'scriptid')) {
     scriptId = data['scriptid'];
   }
   window.addEventListener('kioskedAdRender', function() {

--- a/ads/medianet.js
+++ b/ads/medianet.js
@@ -17,6 +17,7 @@
 import {computeInMasterFrame, validateData, writeScript} from '../3p/3p';
 import {doubleclick} from '../ads/google/doubleclick';
 import {getSourceUrl, parseUrl} from '../src/url';
+import {hasOwn} from '../src/utils/object';
 
 const mandatoryParams = ['tagtype', 'cid'],
     optionalParams = [
@@ -69,7 +70,7 @@ function loadCMTag(global, data, publisherUrl, referrerUrl) {
       return;
     }
     const name = 'medianet_' + type;
-    if (data.hasOwnProperty(type)) {
+    if (hasOwn(data, type)) {
       global[name] = data[type];
     }
   }

--- a/ads/openx.js
+++ b/ads/openx.js
@@ -15,10 +15,9 @@
  */
 
 import {doubleclick} from '../ads/google/doubleclick';
+import {hasOwn} from '../src/utils/object';
 import {loadScript, validateData, writeScript} from '../3p/3p';
 import {startsWith} from '../src/string';
-
-const hasOwnProperty = Object.prototype.hasOwnProperty;
 
 /**
  * Sort of like Object.assign.
@@ -28,7 +27,7 @@ const hasOwnProperty = Object.prototype.hasOwnProperty;
  */
 function assign(target, source) {
   for (const prop in source) {
-    if (hasOwnProperty.call(source, prop)) {
+    if (hasOwn(source, prop)) {
       target[prop] = source[prop];
     }
   }

--- a/ads/rubicon.js
+++ b/ads/rubicon.js
@@ -16,6 +16,7 @@
 
 import {doubleclick} from '../ads/google/doubleclick';
 import {getSourceUrl} from '../src/url';
+import {hasOwn} from '../src/utils/object';
 import {loadScript, validateData, writeScript} from '../3p/3p';
 
 /* global rubicontag: false */
@@ -56,7 +57,7 @@ function fastLane(global, data) {
   function setFPD(type, data) {
     if (typeof data === 'object' && (type === 'V' || type === 'I')) {
       for (const key in data) {
-        if (data.hasOwnProperty(key)) {
+        if (hasOwn(data, key)) {
           if (type === 'V') {
             rubicontag.setFPV(key, data[key]);
           }

--- a/ads/spotx.js
+++ b/ads/spotx.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {hasOwn} from '../src/utils/object';
 import {startsWith} from '../src/string';
 import {validateData} from '../3p/3p';
 
@@ -36,7 +37,7 @@ export function spotx(global, data) {
 
   // Add data-* attribute for each data value passed in.
   for (const key in data) {
-    if (data.hasOwnProperty(key) && startsWith(key, 'spotx_')) {
+    if (hasOwn(data, key) && startsWith(key, 'spotx_')) {
       script.setAttribute(`data-${key}`, data[key]);
     }
   }

--- a/build-system/conformance-config.textproto
+++ b/build-system/conformance-config.textproto
@@ -86,6 +86,18 @@ requirement: {
   value: 'Object.getOwnPropertyDescriptors'
 }
 
+requirement: {
+  type: BANNED_PROPERTY_CALL
+  error_message: 'Use hasOwn in src/utils/object.js'
+  value: 'Object.prototype.hasOwnProperty'
+}
+
+requirement: {
+  type: BANNED_PROPERTY_CALL
+  error_message: 'Use explicit String(value) conversion'
+  value: 'Object.prototype.toString'
+}
+
 # Array
 
 requirement: {

--- a/extensions/amp-accordion/0.1/amp-accordion.js
+++ b/extensions/amp-accordion/0.1/amp-accordion.js
@@ -144,7 +144,7 @@ class AmpAccordion extends AMP.BaseElement {
       header.setAttribute('role', 'button');
       header.setAttribute('aria-controls', contentId);
       header.setAttribute('aria-expanded',
-          section.hasAttribute('expanded').toString());
+          String(section.hasAttribute('expanded')));
       if (!header.hasAttribute('tabindex')) {
         header.setAttribute('tabindex', 0);
       }

--- a/extensions/amp-ad-network-cloudflare-impl/0.1/amp-ad-network-cloudflare-impl.js
+++ b/extensions/amp-ad-network-cloudflare-impl/0.1/amp-ad-network-cloudflare-impl.js
@@ -92,8 +92,8 @@ export class AmpAdNetworkCloudflareImpl extends AmpA4A {
 
     // compute replacement values
     const values = {
-      slotWidth: (rect.width || 0).toString(),
-      slotHeight: (rect.height || 0).toString(),
+      slotWidth: String(rect.width || 0),
+      slotHeight: String(rect.height || 0),
     };
 
     // encode for safety

--- a/extensions/amp-ad/0.1/amp-ad-custom.js
+++ b/extensions/amp-ad/0.1/amp-ad-custom.js
@@ -18,6 +18,7 @@ import {AmpAdUIHandler} from './amp-ad-ui';
 import {Services} from '../../../src/services';
 import {addParamToUrl} from '../../../src/url';
 import {ancestorElementsByTag} from '../../../src/dom';
+import {hasOwn} from '../../../src/utils/object';
 import {isLayoutSizeDefined} from '../../../src/layout';
 import {removeChildren} from '../../../src/dom';
 import {user} from '../../../src/log';
@@ -91,7 +92,7 @@ export class AmpAdCustom extends AMP.BaseElement {
       // We will get here when the data has been fetched from the server
       let templateData = data;
       if (this.slot_ !== null) {
-        templateData = data.hasOwnProperty(this.slot_) ? data[this.slot_] :
+        templateData = hasOwn(data, this.slot_) ? data[this.slot_] :
           null;
       }
       // Set UI state

--- a/extensions/amp-analytics/0.1/activity-impl.js
+++ b/extensions/amp-analytics/0.1/activity-impl.js
@@ -20,6 +20,7 @@
  */
 
 import {Services} from '../../../src/services';
+import {hasOwn} from '../../../src/utils/object';
 import {listen} from '../../../src/event-helper';
 import {registerServiceBuilderForDoc} from '../../../src/service';
 
@@ -323,7 +324,7 @@ export class Activity {
    * @return {number}
    */
   getIncrementalEngagedTime(name = '') {
-    if (!this.totalEngagedTimeByTrigger_.hasOwnProperty(name)) {
+    if (!hasOwn(this.totalEngagedTimeByTrigger_, name)) {
       this.totalEngagedTimeByTrigger_[name] =
         this.getTotalEngagedTime();
       return this.totalEngagedTimeByTrigger_[name];

--- a/extensions/amp-analytics/0.1/events.js
+++ b/extensions/amp-analytics/0.1/events.js
@@ -24,6 +24,7 @@ import {
 import {dev, user} from '../../../src/log';
 import {getData} from '../../../src/event-helper';
 import {getDataParamsFromAttributes} from '../../../src/dom';
+import {hasOwn} from '../../../src/utils/object';
 import {isEnumValue} from '../../../src/types';
 import {startsWith} from '../../../src/string';
 
@@ -128,7 +129,7 @@ export function getTrackerKeyName(eventType) {
   if (!isReservedTriggerType(eventType)) {
     return 'custom';
   }
-  return TRACKER_TYPE.hasOwnProperty(eventType) ?
+  return hasOwn(TRACKER_TYPE, eventType) ?
     TRACKER_TYPE[eventType].name : eventType;
 }
 
@@ -139,8 +140,7 @@ export function getTrackerKeyName(eventType) {
 export function getTrackerTypesForParentType(parentType) {
   const filtered = {};
   Object.keys(TRACKER_TYPE).forEach(key => {
-    if (TRACKER_TYPE.hasOwnProperty(key) &&
-        TRACKER_TYPE[key].allowedFor.indexOf(parentType) != -1) {
+    if (TRACKER_TYPE[key].allowedFor.indexOf(parentType) != -1) {
       filtered[key] = TRACKER_TYPE[key].klass;
     }
   }, this);

--- a/extensions/amp-analytics/0.1/instrumentation.js
+++ b/extensions/amp-analytics/0.1/instrumentation.js
@@ -37,6 +37,7 @@ import {
   getServicePromiseForDoc,
   registerServiceBuilderForDoc,
 } from '../../../src/service';
+import {hasOwn} from '../../../src/utils/object';
 
 const SCROLL_PRECISION_PERCENT = 5;
 const VAR_H_SCROLL_BOUNDARY = 'horizontalScrollBoundary';
@@ -252,7 +253,7 @@ export class InstrumentationService {
       // Goes through each of the boundaries and fires an event if it has not
       // been fired so far and it should be.
       for (const b in bounds) {
-        if (!bounds.hasOwnProperty(b) || b > scrollPos || bounds[b]) {
+        if (!hasOwn(bounds, b) || b > scrollPos || bounds[b]) {
           continue;
         }
         bounds[b] = true;

--- a/extensions/amp-bind/0.1/bind-expression.js
+++ b/extensions/amp-bind/0.1/bind-expression.js
@@ -393,8 +393,7 @@ export class BindExpression {
           return null;
         }
         // Ignore Closure's type constraint for `hasOwnProperty`.
-        if (Object.prototype.hasOwnProperty.call(
-            /** @type {Object} */ (target), member)) {
+        if (hasOwn(/** @type {Object} */ (target), member)) {
           return target[member];
         } else {
           this.memberAccessWarning_(target, member);
@@ -406,7 +405,7 @@ export class BindExpression {
 
       case AstNodeType.VARIABLE:
         const variable = value;
-        if (Object.prototype.hasOwnProperty.call(scope, variable)) {
+        if (hasOwn(scope, variable)) {
           return scope[variable];
         } else {
           user().warn(TAG, `${variable} is not defined; returning null.`);

--- a/extensions/amp-bind/0.1/bind-validator.js
+++ b/extensions/amp-bind/0.1/bind-validator.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {hasOwn} from '../../../src/utils/object';
 import {ownProperty} from '../../../src/utils/object';
 import {parseSrcset} from '../../../src/srcset';
 import {startsWith} from '../../../src/string';
@@ -165,7 +166,7 @@ export class BindValidator {
       if (match !== null) {
         const protocol = match[1].toLowerCase().trim();
         // hasOwnProperty() needed since nested objects are not prototype-less.
-        if (!allowedProtocols.hasOwnProperty(protocol)) {
+        if (!hasOwn(allowedProtocols, protocol)) {
           return false;
         }
       }

--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -177,7 +177,7 @@ export class AmpSlideScroll extends BaseSlides {
 
     this.slides_.forEach((slide, index) => {
       this.dataSlideIdArr_.push(
-          slide.getAttribute('data-slide-id') || index.toString());
+          slide.getAttribute('data-slide-id') || String(index));
       this.setAsOwner(slide);
       slide.classList.add('amp-carousel-slide');
 

--- a/extensions/amp-experiment/0.1/variant.js
+++ b/extensions/amp-experiment/0.1/variant.js
@@ -16,6 +16,7 @@
 
 import {Services} from '../../../src/services';
 import {dev, user} from '../../../src/log';
+import {hasOwn} from '../../../src/utils/object';
 import {isObject} from '../../../src/types';
 
 const ATTR_PREFIX = 'amp-x-';
@@ -36,7 +37,7 @@ export function allocateVariant(ampdoc, experimentName, config) {
   // Variant can be overridden from URL fragment.
   const viewer = Services.viewerForDoc(ampdoc);
   const override = viewer.getParam(ATTR_PREFIX + experimentName);
-  if (override && config['variants'].hasOwnProperty(override)) {
+  if (override && hasOwn(config['variants'], override)) {
     return Promise.resolve(/** @type {?string} */ (override));
   }
 
@@ -93,7 +94,7 @@ function validateConfig(config) {
   }
   let totalPercentage = 0;
   for (const variantName in variants) {
-    if (variants.hasOwnProperty(variantName)) {
+    if (hasOwn(variants, variantName)) {
       assertName(variantName);
       const percentage = variants[variantName];
       user().assert(

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -49,6 +49,7 @@ import {
   isCheckValiditySupported,
 } from './form-validators';
 import {getMode} from '../../../src/mode';
+import {hasOwn} from '../../../src/utils/object';
 import {installFormProxy} from './form-proxy';
 import {installStylesForDoc} from '../../../src/style-installer';
 import {
@@ -308,7 +309,7 @@ export class AmpForm {
 
 
     for (const k in formObject) {
-      if (Object.prototype.hasOwnProperty.call(formObject, k)) {
+      if (hasOwn(formObject, k)) {
         formDataForAnalytics['formFields[' + k + ']'] = formObject[k].join(',');
       }
     }

--- a/extensions/amp-form/0.1/form-proxy.js
+++ b/extensions/amp-form/0.1/form-proxy.js
@@ -15,6 +15,7 @@
  */
 
 import {dev} from '../../../src/log';
+import {hasOwn} from '../../../src/utils/object';
 import {parseUrl} from '../../../src/url';
 import {startsWith} from '../../../src/string';
 import {toWin} from '../../../src/types';
@@ -109,7 +110,7 @@ function createFormProxyConstr(win) {
           // Exclude on-events.
           startsWith(name, 'on') ||
           // Exclude properties that already been created.
-          win.Object.prototype.hasOwnProperty.call(FormProxyProto, name) ||
+          hasOwn(FormProxyProto, name) ||
           // Exclude some properties. Currently only used for testing.
           blacklistedProperties && blacklistedProperties.indexOf(name) != -1) {
         continue;

--- a/extensions/amp-gwd-animation/0.1/amp-gwd-animation-impl.js
+++ b/extensions/amp-gwd-animation/0.1/amp-gwd-animation-impl.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import {createCustomEvent} from '../../../src/event-helper';
+import {hasOwn} from '../../../src/utils/object';
 import {user} from '../../../src/log';
 
 /**
@@ -91,7 +92,7 @@ const LOG_ID = 'GWD';
  */
 function getCounter(receiver, counterName) {
   if (receiver.gwdGotoCounters &&
-      receiver.gwdGotoCounters.hasOwnProperty(counterName)) {
+      hasOwn(receiver.gwdGotoCounters, counterName)) {
     return receiver.gwdGotoCounters[counterName];
   }
   return 0;
@@ -109,7 +110,7 @@ function setCounter(receiver, counterName, counterValue) {
   if (!receiver.gwdGotoCounters) {
     receiver.gwdGotoCounters = {};
   }
-  if (!receiver.gwdGotoCounters.hasOwnProperty(counterName)) {
+  if (!hasOwn(receiver.gwdGotoCounters, counterName)) {
     receiver.gwdGotoCounters[counterName] = 0;
   }
   receiver.gwdGotoCounters[counterName] = counterValue;

--- a/extensions/amp-story/0.1/analytics.js
+++ b/extensions/amp-story/0.1/analytics.js
@@ -59,7 +59,7 @@ export class AmpStoryAnalytics {
   onActivePageChange_(pageIndex, pageId) {
     if (!this.seenPagesIndices_[pageIndex]) {
       this.triggerEvent_(Events.PAGE_VISIBLE, {
-        'storyPageIndex': pageIndex.toString(),
+        'storyPageIndex': String(pageIndex),
         'storyPageId': pageId,
       });
 

--- a/extensions/amp-story/0.1/page-scaling.js
+++ b/extensions/amp-story/0.1/page-scaling.js
@@ -448,7 +448,7 @@ class CssPropsZoomScalingService extends PageScalingService {
       this.rootEl_.style.setProperty('--i-amphtml-story-width', px(width));
       this.rootEl_.style.setProperty('--i-amphtml-story-height', px(height));
       this.rootEl_.style.setProperty('--i-amphtml-story-factor',
-          factor.toString());
+          String(factor));
     });
   }
 

--- a/extensions/amp-web-push/0.1/amp-web-push-helper-frame.js
+++ b/extensions/amp-web-push/0.1/amp-web-push-helper-frame.js
@@ -241,7 +241,7 @@ export class AmpWebPushHelperFrame {
               replyToFrame,
               true,
               null,
-              error ? error.message || error.toString() : null
+              error ? error.message || String(error) : null
           );
         });
   }

--- a/src/experiments.js
+++ b/src/experiments.js
@@ -24,6 +24,7 @@
 import {OriginExperiments} from './origin-experiments';
 import {Services} from './services';
 import {getCookie, setCookie} from './cookies';
+import {hasOwn} from './utils/object';
 import {parseQueryString} from './url';
 import {user} from './log';
 
@@ -391,8 +392,8 @@ export function randomlySelectUnsetExperiments(win, experiments) {
   for (const experimentName in experiments) {
     // Skip experimentName if it is not a key of experiments object or if it
     // has already been populated by some other property.
-    if (!experiments.hasOwnProperty(experimentName) ||
-        win.experimentBranches.hasOwnProperty(experimentName)) {
+    if (!hasOwn(experiments, experimentName) ||
+        hasOwn(win.experimentBranches, experimentName)) {
       continue;
     }
 

--- a/src/json.js
+++ b/src/json.js
@@ -19,6 +19,7 @@
  * {@link http://json.org/}.
  */
 
+import {hasOwn} from './utils/object';
 import {isObject} from './types';
 
 
@@ -197,6 +198,5 @@ function hasOwnProperty(obj, key) {
   if (obj == null || typeof obj != 'object') {
     return false;
   }
-  return Object.prototype.hasOwnProperty.call(
-      /** @type {!Object} */ (obj), key);
+  return hasOwn(/** @type {!Object} */ (obj), key);
 }

--- a/src/service.js
+++ b/src/service.js
@@ -24,6 +24,7 @@
 import './polyfills'; // eslint-disable-line sort-imports-es6-autofix/sort-imports-es6
 
 import {dev} from './log';
+import {hasOwn} from './utils/object';
 import {toWin} from './types';
 
 
@@ -568,7 +569,7 @@ function disposeServicesInternal(holder) {
   // service to be canceled automatically.
   const services = getServices(holder);
   for (const id in services) {
-    if (!Object.prototype.hasOwnProperty.call(services, id)) {
+    if (!hasOwn(services, id)) {
       continue;
     }
     const serviceHolder = services[id];

--- a/src/service/url-expander/expander.js
+++ b/src/service/url-expander/expander.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {hasOwn} from '../../utils/object';
 import {rethrowAsync, user} from '../../log';
 
 export const PARSER_IGNORE_FLAG = '`';
@@ -99,7 +100,7 @@ export class Expander {
         if (match && urlIndex === match.start) {
           let binding;
           // find out where this keyword is coming from
-          if (opt_bindings && opt_bindings.hasOwnProperty(match.name)) {
+          if (opt_bindings && hasOwn(opt_bindings, match.name)) {
             // the optional bindings
             binding = opt_bindings[match.name];
           } else {

--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -35,6 +35,7 @@ import {
 } from '../url';
 import {dev, rethrowAsync, user} from '../log';
 import {getTrackImpressionPromise} from '../impression.js';
+import {hasOwn} from '../utils/object';
 import {
   installServiceInEmbedScope,
   registerServiceBuilderForDoc,
@@ -800,7 +801,7 @@ export class UrlReplacements {
     const requestedReplacements = {};
     whitelist.trim().split(/\s+/).forEach(replacement => {
       if (!opt_supportedReplacement ||
-          opt_supportedReplacement.hasOwnProperty(replacement)) {
+          hasOwn(opt_supportedReplacement, replacement)) {
         requestedReplacements[replacement] = true;
       } else {
         user().warn('URL', 'Ignoring unsupported replacement', replacement);

--- a/src/style.js
+++ b/src/style.js
@@ -100,7 +100,7 @@ export function getVendorJsPropertyName(style, camelCase, opt_bypassCache) {
 export function setImportantStyles(element, styles) {
   for (const k in styles) {
     element.style.setProperty(
-        getVendorJsPropertyName(styles, k), styles[k].toString(), 'important');
+        getVendorJsPropertyName(styles, k), String(styles[k]), 'important');
   }
 }
 

--- a/src/url.js
+++ b/src/url.js
@@ -428,7 +428,7 @@ export function resolveRelativeUrl(relativeUrlString, baseUrl) {
     baseUrl = parseUrl(baseUrl);
   }
   if (typeof URL == 'function') {
-    return new URL(relativeUrlString, baseUrl.href).toString();
+    return String(new URL(relativeUrlString, baseUrl.href));
   }
   return resolveRelativeUrlFallback_(relativeUrlString, baseUrl);
 }

--- a/src/utils/object.js
+++ b/src/utils/object.js
@@ -53,10 +53,11 @@ export function dict(opt_initial) {
 }
 
 /**
- * Checks if the given key is a property in the map.
+ * Checks if the given key is a property in the map. This works with
+ * prototype-less objects as well as regular objects.
  *
  * @param {T}  obj a map like property.
- * @param {string}  key
+ * @param {*}  key
  * @return {boolean}
  * @template T
  */

--- a/src/web-components.js
+++ b/src/web-components.js
@@ -81,7 +81,7 @@ export function isShadowCssSupported() {
  * @return {boolean}
  */
 function isNative(func) {
-  return !!func && func.toString().indexOf('[native code]') != -1;
+  return !!func && String(func).indexOf('[native code]') != -1;
 }
 
 /**


### PR DESCRIPTION
`hasOwnProperty` in particular is frequently used when iterating
objects, but not all objects have a `#hasOwnProperty` method
(protoype-less). This forbids the practice, so we can further encourage
prototype-less dictionary maps throughout the codebase.

Fixes https://github.com/ampproject/amphtml/issues/6548.