### PR TITLE
Fix flaky Karma startup by refreshing the `wd` cache

### DIFF
--- a/build-system/tasks/runtime-test.js
+++ b/build-system/tasks/runtime-test.js
@@ -20,6 +20,7 @@ const applyConfig = require('./prepend-global/index.js').applyConfig;
 const argv = require('minimist')(process.argv.slice(2));
 const colors = require('ansi-colors');
 const config = require('../config');
+const exec = require('../exec').exec;
 const fs = require('fs');
 const gulp = require('gulp-help')(require('gulp'));
 const Karma = require('karma').Server;
@@ -123,6 +124,11 @@ function getAdTypes() {
   return adTypes;
 }
 
+// Mitigates https://github.com/karma-runner/karma-sauce-launcher/issues/117
+// by refreshing the wd cache so that Karma can launch without an error.
+function refreshKarmaWdCache() {
+  exec('node ./node_modules/wd/scripts/build-browser-scripts.js')
+}
 
 /**
  * Prints help messages for args if tests are being run for local development.
@@ -320,6 +326,7 @@ function runTests() {
 
   let resolver;
   const deferred = new Promise(resolverIn => {resolver = resolverIn;});
+  refreshKarmaWdCache();
   new Karma(c, function(exitCode) {
     server.emit('kill');
     if (exitCode) {

--- a/build-system/tasks/runtime-test.js
+++ b/build-system/tasks/runtime-test.js
@@ -127,7 +127,7 @@ function getAdTypes() {
 // Mitigates https://github.com/karma-runner/karma-sauce-launcher/issues/117
 // by refreshing the wd cache so that Karma can launch without an error.
 function refreshKarmaWdCache() {
-  exec('node ./node_modules/wd/scripts/build-browser-scripts.js')
+  exec('node ./node_modules/wd/scripts/build-browser-scripts.js');
 }
 
 /**

--- a/contributing/DEVELOPING.md
+++ b/contributing/DEVELOPING.md
@@ -198,8 +198,6 @@ To run the tests on Sauce Labs:
    ```
 * It may take a few minutes for the tests to start.  You can see the status of your tests on the Sauce Labs [Automated Tests](https://saucelabs.com/beta/dashboard/tests) dashboard.  (You can also see the status of your proxy on the [Tunnels](https://saucelabs.com/beta/tunnels) dashboard.
 
-* If you see "Cannot find module '../build/safe-execute'", this is caused by a caching issue - try uninstalling and reinstalling the 'wd' module as described in [karma-sauce-launcher issue #117](https://github.com/karma-runner/karma-sauce-launcher/issues/117).
-
 ## Visual Diff Tests
 
 **NOTE:** *We are working on giving all `ampproject/amphtml` committers automatic access to visual diff test results. Until this is in place, you can fill out [this](https://docs.google.com/forms/d/e/1FAIpQLScZma6qVJtYUTqSm4KtiF3Zc-n5ukNe2GXNFqnaHxospsz0sQ/viewform) form, and your request should be approved soon.*


### PR DESCRIPTION
This PR mitigates the well-known `Karma` startup issue https://github.com/karma-runner/karma-sauce-launcher/issues/117 by manually refreshing the `wd` cache in `node_modules/wd/build` before trying to launch a `Karma` server, as described in https://github.com/admc/wd/issues/466#issuecomment-292847107

This PR essentially repeats what is done when `wd` is installed for the first time: https://github.com/admc/wd/blob/master/package.json#L84. 

Tested by manually deleting the files in `node_modules/wd/build` and running `gulp test`. The cache is auto-refreshed by `runtime-test.js` prior to `Karma` startup. This should greatly reduce flakiness on Travis.

Follow up to #10966