### PR TITLE
Not adding sticky-ad to fixed layer with collapsed AMP Ad

### DIFF
--- a/examples/sticky.ads.amp.html
+++ b/examples/sticky.ads.amp.html
@@ -159,9 +159,13 @@
   </header>
   <main role="main">
   <amp-sticky-ad layout="nodisplay">
-    <amp-ad width=320 height=50
-      type="doubleclick"
-      data-slot="/4119129/mobile_ad_banner">
+    <amp-ad width=300 height=50
+        type="_ping_"
+        data-url='https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w400-h300-no-n'
+        data-valid='true'
+        data-ad-width=300
+        data-ad-height=50>
+    </amp-ad>
   </amp-ad>
 
   </amp-sticky-ad>

--- a/extensions/amp-sticky-ad/1.0/amp-sticky-ad.js
+++ b/extensions/amp-sticky-ad/1.0/amp-sticky-ad.js
@@ -45,6 +45,9 @@ class AmpStickyAd extends AMP.BaseElement {
 
     /** @private {?UnlistenDef} */
     this.scrollUnlisten_ = null;
+
+    /** @private {boolean} */
+    this.collapsed_ = false;
   }
 
   /** @override */
@@ -114,6 +117,7 @@ class AmpStickyAd extends AMP.BaseElement {
 
   /** @override */
   collapsedCallback() {
+    this.collapsed_ = true;
     toggle(this.element, false);
     this.vsync_.mutate(() => {
       this.viewport_.updatePaddingBottom(0);
@@ -151,6 +155,10 @@ class AmpStickyAd extends AMP.BaseElement {
   display_() {
     this.removeOnScrollListener_();
     this.deferMutate(() => {
+      if (this.collapsed_) {
+        // It's possible that if an AMP ad collapse before its layoutCallback.
+        return;
+      }
       this.visible_ = true;
       this.addCloseButton_();
       this.viewport_.addToFixedLayer(


### PR DESCRIPTION
AMP Ad can fetch ad and decide to collapse before `layoutCallback`.
`#SetOwner` doesn't help much in this case. Sticky-ad should check if it has been collapsed already before adding itself to fixed layer.
Fix #13327 