### PR TITLE
Fix gulp test --a4a

### DIFF
--- a/build-system/config.js
+++ b/build-system/config.js
@@ -15,8 +15,11 @@
  */
 'use strict';
 
-const commonTestPaths = [
+const initTestsPath = [
   'test/_init_tests.js',
+];
+
+const commonTestPaths = initTestsPath.concat([
   'test/fixtures/*.html',
   {
     pattern: 'test/fixtures/served/*.html',
@@ -54,25 +57,23 @@ const commonTestPaths = [
     nocache: false,
     watched: false,
   },
-];
+]);
 
 const simpleTestPath = [
   'test/simple-test.js',
 ];
 
-const basicTestPaths = [
+const testPaths = commonTestPaths.concat([
   'test/**/*.js',
   'ads/**/test/test-*.js',
   'extensions/**/test/**/*.js',
-];
+]);
 
-const testPaths = commonTestPaths.concat(basicTestPaths);
-
-const a4aTestPaths = [
+const a4aTestPaths = initTestsPath.concat([
   'extensions/amp-a4a/**/test/**/*.js',
   'extensions/amp-ad-network-*/**/test/**/*.js',
   'ads/google/a4a/test/*.js',
-];
+]);
 
 const chaiAsPromised = [
   'test/chai-as-promised/chai-as-promised.js',
@@ -99,7 +100,6 @@ const integrationTestPaths = commonTestPaths.concat([
 module.exports = {
   commonTestPaths,
   simpleTestPath,
-  basicTestPaths,
   testPaths,
   a4aTestPaths,
   chaiAsPromised,

--- a/build-system/tasks/runtime-test.js
+++ b/build-system/tasks/runtime-test.js
@@ -240,7 +240,7 @@ function runTests() {
       c.files = c.files.concat(config.unitTestPaths);
     }
   } else if (argv.a4a) {
-    c.files = c.files.concat(config.commonTestPaths, config.a4aTestPaths);
+    c.files = c.files.concat(config.a4aTestPaths);
   } else {
     c.files = c.files.concat(config.testPaths);
   }


### PR DESCRIPTION
When the runtime is built via `gulp build`, the following directories are generated and included with `gulp test --a4a` via `build-system/config.commonTestPaths`:
```
'test/fixtures/*.html',
'test/fixtures/served/*.html',
'dist/**/*.js',
'dist.tools/**/*.js',
'examples/**/*',
'dist.3p/**/*',
'test/coverage/**/*',
```
One of these files was messing with the logger, causing test failures when `gulp test --a4a` was run after `gulp build`.

None of these files are actually needed to run the A4A unit tests (or any unit tests for that matter), and they should be removed from the list of test files. With this PR, `gulp test --a4a` works irrespective of the runtime-built-or-not-built initial condition.

We should probably follow this up with another PR that removes unnecessary test files from the other `gulp test --unit` variations so that they too run without being influenced by the runtime-built-or-not-built initial condition.

Fixes #12135