### PR TITLE
Improve the reliability of gulp test

### DIFF
--- a/build-system/config.js
+++ b/build-system/config.js
@@ -19,16 +19,7 @@ const initTestsPath = [
   'test/_init_tests.js',
 ];
 
-const exmaplesPath = [
-  {
-    pattern: 'examples/**/*',
-    included: false,
-    nocache: false,
-    watched: true,
-  },
-];
-
-const commonTestPaths = initTestsPath.concat(exmaplesPath, [
+const fixturesExamplesPaths = [
   'test/fixtures/*.html',
   {
     pattern: 'test/fixtures/served/*.html',
@@ -37,13 +28,16 @@ const commonTestPaths = initTestsPath.concat(exmaplesPath, [
     watched: true,
   },
   {
-    pattern: 'dist/**/*.js',
+    pattern: 'examples/**/*',
     included: false,
     nocache: false,
     watched: true,
   },
+];
+
+const builtRuntimePaths = [
   {
-    pattern: 'dist.tools/**/*.js',
+    pattern: 'dist/**/*.js',
     included: false,
     nocache: false,
     watched: true,
@@ -55,12 +49,24 @@ const commonTestPaths = initTestsPath.concat(exmaplesPath, [
     watched: true,
   },
   {
+    pattern: 'dist.tools/**/*.js',
+    included: false,
+    nocache: false,
+    watched: true,
+  },
+];
+
+const commonTestPaths =
+    initTestsPath.concat(fixturesExamplesPaths, builtRuntimePaths);
+
+const coveragePaths = [
+  {
     pattern: 'test/coverage/**/*',
     included: false,
     nocache: false,
     watched: false,
   },
-]);
+];
 
 const simpleTestPath = [
   'test/simple-test.js',
@@ -82,13 +88,13 @@ const chaiAsPromised = [
   'test/chai-as-promised/chai-as-promised.js',
 ];
 
-const unitTestPaths = initTestsPath.concat(exmaplesPath, [
+const unitTestPaths = initTestsPath.concat(fixturesExamplesPaths, [
   'test/functional/**/*.js',
   'ads/**/test/test-*.js',
   'extensions/**/test/*.js',
 ]);
 
-const unitTestOnSaucePaths = initTestsPath.concat(exmaplesPath, [
+const unitTestOnSaucePaths = initTestsPath.concat(fixturesExamplesPaths, [
   'test/functional/**/*.js',
   'ads/**/test/test-*.js',
 ]);
@@ -109,6 +115,7 @@ module.exports = {
   unitTestPaths,
   unitTestOnSaucePaths,
   integrationTestPaths,
+  coveragePaths,
   lintGlobs: [
     '**/*.js',
     '!**/*.extern.js',

--- a/build-system/config.js
+++ b/build-system/config.js
@@ -19,7 +19,16 @@ const initTestsPath = [
   'test/_init_tests.js',
 ];
 
-const commonTestPaths = initTestsPath.concat([
+const exmaplesPath = [
+  {
+    pattern: 'examples/**/*',
+    included: false,
+    nocache: false,
+    watched: true,
+  },
+];
+
+const commonTestPaths = initTestsPath.concat(exmaplesPath, [
   'test/fixtures/*.html',
   {
     pattern: 'test/fixtures/served/*.html',
@@ -35,12 +44,6 @@ const commonTestPaths = initTestsPath.concat([
   },
   {
     pattern: 'dist.tools/**/*.js',
-    included: false,
-    nocache: false,
-    watched: true,
-  },
-  {
-    pattern: 'examples/**/*',
     included: false,
     nocache: false,
     watched: true,
@@ -79,13 +82,13 @@ const chaiAsPromised = [
   'test/chai-as-promised/chai-as-promised.js',
 ];
 
-const unitTestPaths = commonTestPaths.concat([
+const unitTestPaths = initTestsPath.concat(exmaplesPath, [
   'test/functional/**/*.js',
   'ads/**/test/test-*.js',
   'extensions/**/test/*.js',
 ]);
 
-const unitTestOnSaucePaths = commonTestPaths.concat([
+const unitTestOnSaucePaths = initTestsPath.concat(exmaplesPath, [
   'test/functional/**/*.js',
   'ads/**/test/test-*.js',
 ]);

--- a/build-system/tasks/dep-check.js
+++ b/build-system/tasks/dep-check.js
@@ -297,6 +297,5 @@ function flatten(arr) {
 gulp.task(
     'dep-check',
     'Runs a dependency check on each module',
-    // Defined in gulpfile.js, and must be run before dep-check.
-    ['update-packages', 'patch-web-animations', 'css'],
+    ['update-packages', 'css'],
     depCheck);

--- a/build-system/tasks/runtime-test.js
+++ b/build-system/tasks/runtime-test.js
@@ -295,6 +295,7 @@ function runTests() {
 
   if (argv.coverage) {
     log(cyan('Including code coverage tests'));
+    c.files = c.files.concat(config.coveragePaths);
     c.browserify.transform.push(
         ['browserify-istanbul', {instrumenterConfig: {embedSource: true}}]);
     c.reporters = c.reporters.concat(['progress', 'coverage']);

--- a/build-system/tasks/runtime-test.js
+++ b/build-system/tasks/runtime-test.js
@@ -184,7 +184,6 @@ function printArgvMessages() {
 
 /**
  * Applies the prod or canary AMP config to the AMP runtime.
- * @param {string} targetFile File to which the config is to be written.
  * @return {Promise}
  */
 function applyAmpConfig() {

--- a/build-system/tasks/runtime-test.js
+++ b/build-system/tasks/runtime-test.js
@@ -156,10 +156,12 @@ function printArgvMessages() {
     compiled: 'Running tests against minified code.',
     grep: 'Only running tests that match the pattern "' +
         cyan(argv.grep) + '".',
+    coverage: 'Runing tests in code coverage mode.',
   };
   if (!process.env.TRAVIS) {
     log(green('Run'), cyan('gulp help'),
-        green('to see a list of all test flags. (Use'), cyan('--nohelp'),
+        green('to see a list of all test flags.'));
+    log(green('⤷ Use'), cyan('--nohelp'),
         green('to silence these messages.)'));
     if (!argv.unit && !argv.integration && !argv.files && !argv.a4a) {
       log(green('Running all tests.'));
@@ -167,7 +169,7 @@ function printArgvMessages() {
           green('to run just the unit tests or integration tests.'));
     }
     if (!argv.testnames && !argv.files) {
-      log(green('Use'), cyan('--testnames'),
+      log(green('⤷ Use'), cyan('--testnames'),
           green('to see the names of all tests being run.'));
     }
     if (!argv.compiled) {
@@ -294,11 +296,10 @@ function runTests() {
   }
 
   if (argv.coverage) {
-    log(cyan('Including code coverage tests'));
     c.files = c.files.concat(config.coveragePaths);
     c.browserify.transform.push(
         ['browserify-istanbul', {instrumenterConfig: {embedSource: true}}]);
-    c.reporters = c.reporters.concat(['progress', 'coverage']);
+    c.reporters = c.reporters.concat(['coverage']);
     if (c.preprocessors['src/**/*.js']) {
       c.preprocessors['src/**/*.js'].push('coverage');
     }
@@ -417,5 +418,6 @@ gulp.task('test', 'Runs tests', preTestTasks, function() {
     'nohelp': '  Silence help messages that are printed prior to test run',
     'a4a': '  Runs all A4A tests',
     'config': '  Sets the runtime\'s AMP config to one of "prod" or "canary"',
+    'coverage': '  Run tests in code coverage mode',
   },
 });

--- a/build-system/tasks/runtime-test.js
+++ b/build-system/tasks/runtime-test.js
@@ -188,7 +188,7 @@ function printArgvMessages() {
  * @return {Promise}
  */
 function applyAmpConfig() {
-  if (argv.a4a) {
+  if (argv.unit || argv.a4a) {
     return Promise.resolve();
   }
   log(green('Setting the runtime\'s AMP config to'), cyan(ampConfig));

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -427,6 +427,7 @@ function compile(watch, shouldMinify, opt_preventRemoveAndMakeDir,
  * @return {!Promise}
  */
 function css() {
+  printNobuildHelp();
   return compileCss();
 }
 
@@ -437,13 +438,6 @@ function css() {
  * @return {!Promise}
  */
 function compileCss(watch, opt_compileAll) {
-  // Print a message that could help speed up local development.
-  if (!process.env.TRAVIS && argv['_'].indexOf('test') != -1) {
-    log(green('To skip building during future test runs, use'),
-        cyan('--nobuild'), green('with your'), cyan('gulp test'),
-        green('command.'));
-  }
-
   if (watch) {
     $$.watch('css/**/*.css', function() {
       compileCss();
@@ -597,6 +591,18 @@ function buildExtensionJs(path, name, version, options) {
   });
 }
 
+
+/**
+ * Prints a message that could help speed up local development.
+ */
+function printNobuildHelp() {
+  if (!process.env.TRAVIS && argv['_'].indexOf('test') != -1) {
+    log(green('To skip building during future test runs, use'),
+        cyan('--nobuild'), green('with your'), cyan('gulp test'),
+        green('command.'));
+  }
+}
+
 /**
  * Prints a helpful message that lets the developer know how to switch configs.
  * @param {string} command Command being run.
@@ -680,6 +686,7 @@ function enableLocalTesting(targetFile) {
  */
 function performBuild(watch) {
   process.env.NODE_ENV = 'development';
+  printNobuildHelp();
   printConfigHelp(watch ? 'gulp watch' : 'gulp build');
   parseExtensionFlags();
   return compileCss(watch).then(() => {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1375,31 +1375,6 @@ function mkdirSync(path) {
   }
 }
 
-/**
- * Patches Web Animations API by wrapping its body into `install` function.
- * This gives us an option to call polyfill directly on the main window
- * or a friendly iframe.
- *
- * @return {!Promise}
- */
-function patchWebAnimations() {
-  // Copies web-animations-js into a new file that has an export.
-  const patchedName = 'node_modules/web-animations-js/' +
-      'web-animations.install.js';
-  let file = fs.readFileSync(
-      'node_modules/web-animations-js/' +
-      'web-animations.min.js').toString();
-  // Wrap the contents inside the install function.
-  file = 'exports.installWebAnimations = function(window) {\n' +
-      'var document = window.document;\n' +
-      file + '\n' +
-      '}\n';
-  fs.writeFileSync(patchedName, file);
-  if (!process.env.TRAVIS) {
-    log('Wrote', cyan(patchedName));
-  }
-}
-
 function toPromise(readable) {
   return new Promise(function(resolve, reject) {
     readable.on('error', reject).on('end', resolve);
@@ -1411,22 +1386,17 @@ function toPromise(readable) {
 /**
  * Gulp tasks
  */
-gulp.task('build', 'Builds the AMP library',
-    ['update-packages', 'patch-web-animations'], build, {
-      options: {
-        config: '  Sets the runtime\'s AMP_CONFIG to one of "prod" or "canary"',
-        extensions: '  Builds only the listed extensions.',
-        noextensions: '  Builds with no extensions.',
-      },
-    });
+gulp.task('build', 'Builds the AMP library', ['update-packages'], build, {
+  options: {
+    config: '  Sets the runtime\'s AMP_CONFIG to one of "prod" or "canary"',
+    extensions: '  Builds only the listed extensions.',
+    noextensions: '  Builds with no extensions.',
+  },
+});
 gulp.task('check-all', 'Run through all presubmit checks',
     ['lint', 'dep-check', 'check-types', 'presubmit']);
 gulp.task('check-types', 'Check JS types', checkTypes);
-gulp.task('patch-web-animations',
-    'Patches the Web Animations API with an install function',
-    ['update-packages'], patchWebAnimations);
-gulp.task('css', 'Recompile css to build directory',
-    ['update-packages', 'patch-web-animations'], css);
+gulp.task('css', 'Recompile css to build directory', ['update-packages'], css);
 gulp.task('default', 'Runs "watch" and then "serve"',
     ['update-packages', 'watch'], serve, {
       options: {
@@ -1434,17 +1404,16 @@ gulp.task('default', 'Runs "watch" and then "serve"',
         noextensions: '  Watches and builds with no extensions.',
       },
     });
-gulp.task('dist', 'Build production binaries',
-    ['update-packages', 'patch-web-animations'], dist, {
-      options: {
-        pseudo_names: '  Compiles with readable names. ' +
+gulp.task('dist', 'Build production binaries', ['update-packages'], dist, {
+  options: {
+    pseudo_names: '  Compiles with readable names. ' +
             'Great for profiling and debugging production code.',
-        fortesting: '  Compiles production binaries for local testing',
-        config: '  Sets the runtime\'s AMP_CONFIG to one of "prod" or "canary"',
-      },
-    });
+    fortesting: '  Compiles production binaries for local testing',
+    config: '  Sets the runtime\'s AMP_CONFIG to one of "prod" or "canary"',
+  },
+});
 gulp.task('watch', 'Watches for changes in files, re-builds when detected',
-    ['update-packages', 'patch-web-animations'], watch, {
+    ['update-packages'], watch, {
       options: {
         with_inabox: '  Also watch and build the amp-inabox.js binary.',
         with_shadow: '  Also watch and build the amp-shadow.js binary.',

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1425,7 +1425,8 @@ gulp.task('check-types', 'Check JS types', checkTypes);
 gulp.task('patch-web-animations',
     'Patches the Web Animations API with an install function',
     ['update-packages'], patchWebAnimations);
-gulp.task('css', 'Recompile css to build directory', ['update-packages'], css);
+gulp.task('css', 'Recompile css to build directory',
+    ['update-packages', 'patch-web-animations'], css);
 gulp.task('default', 'Runs "watch" and then "serve"',
     ['update-packages', 'watch'], serve, {
       options: {


### PR DESCRIPTION
Running the AMP unit tests via `gulp test --unit` only requires `gulp css` to have been run first. It does not require the entire AMP runtime to be built via `gulp build`. Yet, we include all the runtime files in `build/` and `dist/` (if they happen to be built) while running `gulp test --unit`. This reliance on the initial conditions results in test flakiness, as evidenced by https://github.com/ampproject/amphtml/issues/12135#issuecomment-363650136.

This PR does the following:
1. Excludes the built runtime in the file set for `gulp test --unit`
2. Excludes `test/coverage/` for tests runs that don't use the `--coverage` flag
3. Removes `gulp patch-web-animations` and refactors functionality into `gulp update-packages`
4. Makes a few other minor maintenance fixes to `runtime-test.js` and `gulpfile.js`

Here is the list of directories that used to be included, with the newly excluded ones noted:
```
'test/fixtures/*.html',           (still included)
'test/fixtures/served/*.html',    (still included)
'examples/**/*',                  (still included)
'dist/**/*.js',                   (excluded for --unit and --a4a)
'dist.tools/**/*.js',             (excluded for --unit and --a4a)
'dist.3p/**/*',                   (excluded for --unit and --a4a)
'test/coverage/**/*',             (included only for --coverage)
```
With this, the expectation is fewer flaky runs on Travis, and more efficient testing during local development.

Follow up to #13331 
Related to #12135