### PR TITLE
Add Prebid-AppNexus as a vendor to RTC config

### DIFF
--- a/extensions/amp-a4a/0.1/callout-vendors.js
+++ b/extensions/amp-a4a/0.1/callout-vendors.js
@@ -42,6 +42,11 @@ export const RTC_VENDORS = {
     macros: ['CID'],
     disableKeyAppend: true,
   },
+  prebid_appnexus : {
+    url: 'https://prebid.adnxs.com/pbs/v1/openrtb2/amp?tag_id=PLACEMENT_ID',
+    macros : ['PLACEMENT_ID'],
+    disableKeyAppend: true,
+  }
 };
 
 // DO NOT MODIFY: Setup for tests

--- a/extensions/amp-a4a/0.1/callout-vendors.js
+++ b/extensions/amp-a4a/0.1/callout-vendors.js
@@ -42,11 +42,11 @@ export const RTC_VENDORS = {
     macros: ['CID'],
     disableKeyAppend: true,
   },
-  prebid_appnexus : {
+  prebidappnexus: {
     url: 'https://prebid.adnxs.com/pbs/v1/openrtb2/amp?tag_id=PLACEMENT_ID',
-    macros : ['PLACEMENT_ID'],
+    macros: ['PLACEMENT_ID'],
     disableKeyAppend: true,
-  }
+  },
 };
 
 // DO NOT MODIFY: Setup for tests


### PR DESCRIPTION
# Add Prebid-AppNexus as a vendor to RTC config

Title really says it all. I'm not sure if there is a corresponding docs piece that is needed as well? 

Some background. We have built an endpoint into prebid server that will support returning a response that conforms to the RTC spec. This endpoint accepts a single param for AppNexus Placement ID. 