### PR TITLE
🏗 Refactor greenkeeper branch optimization in pr-check.js

### DIFF
--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -435,7 +435,7 @@ function runYarnLockfileCheck() {
  */
 function isGreenkeeperPrBuild() {
   return (process.env.TRAVIS_EVENT_TYPE == 'pull_request') &&
-      (process.env.TRAVIS_PULL_REQUEST_BRANCH.indexOf('greenkeeper/') != -1);
+      (process.env.TRAVIS_PULL_REQUEST_BRANCH.indexOf('greenkeeper/') == 0);
 }
 
 /**
@@ -443,7 +443,7 @@ function isGreenkeeperPrBuild() {
  */
 function isGreenkeeperPushBuild() {
   return (process.env.TRAVIS_EVENT_TYPE == 'push') &&
-      (process.env.TRAVIS_BRANCH.indexOf('greenkeeper/') != -1);
+      (process.env.TRAVIS_BRANCH.indexOf('greenkeeper/') == 0);
 }
 
 /**

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -452,7 +452,8 @@ function isGreenkeeperPushBuild() {
  */
 function isGreenkeeperLockfilePushBuild() {
   return isGreenkeeperPushBuild() &&
-      (process.env.TRAVIS_COMMIT_MESSAGE.indexOf('update lockfile') != -1);
+      (process.env.TRAVIS_COMMIT_MESSAGE.indexOf(
+          'chore(package): update lockfile') == 0);
 }
 
 /**


### PR DESCRIPTION
This PR does a minor refactor of the `greenkeeper` branch checks / optimizations.

1. We now run the oprimization before `runYarnLockfileCheck()`, since it makes no sense to verify the contents of `yarn.lock` before it's properly updated. This will avoid false negatives like https://travis-ci.org/ampproject/amphtml/jobs/338627508#L1665
2. We now do `startsWith` style matches of the `greenkeeper` branch names and `lockfile updated` commit messages. This way, should a `greenkeeper` PR need to be reverted, we no longer exempt it from testing, like in https://travis-ci.org/ampproject/amphtml/jobs/338760558

This came out of the second half of https://github.com/ampproject/amphtml/pull/13333#issuecomment-363908168