### PR TITLE
Add expand-single-section attribute to <amp-accordion>. 

### DIFF
--- a/examples/accordion.amp.html
+++ b/examples/accordion.amp.html
@@ -9,7 +9,7 @@
   <script async custom-element="amp-accordion" src="https://cdn.ampproject.org/v0/amp-accordion-0.1.js"></script>
 </head>
 <body>
-  <amp-accordion expand-one>
+  <amp-accordion expand-single-section>
     <section>
       <h2>Section 1</h2>
       <p>Bunch of awesome content</p>

--- a/examples/accordion.amp.html
+++ b/examples/accordion.amp.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <link rel="canonical" href="./regular-html-version.html">
+  <meta name="viewport" content="width=device-width,minimum-scale=1">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-accordion" src="https://cdn.ampproject.org/v0/amp-accordion-0.1.js"></script>
+</head>
+<body>
+  <amp-accordion expand-one>
+    <section>
+      <h2>Section 1</h2>
+      <p>Bunch of awesome content</p>
+    </section>
+    <section expanded>
+      <h2>Section 2</h2>
+      <div>Bunch of awesome content</div>
+    </section>
+    <section expanded>
+      <h2>Section 3</h2>
+      <amp-img src="/awesome.png" width="300" height="300"></amp-img>
+    </section>
+    <section>
+      <h2>Properly nested amp-accordion</h2>
+      <amp-accordion>
+        <section>
+          <h2>Nested section</h2>
+          <p>It's possible to nest amp-accordions.</p>
+        </section>
+      </amp-accordion>
+    </section>
+    <section>
+      <header>The header tag is supported as well.</header>
+      <p>Even more awesome.</p>
+    </section>
+  </amp-accordion>
+</body>
+</html>

--- a/extensions/amp-accordion/0.1/amp-accordion.js
+++ b/extensions/amp-accordion/0.1/amp-accordion.js
@@ -224,9 +224,20 @@ class AmpAccordion extends AMP.BaseElement {
       } else {
         toExpand = !section.hasAttribute('expanded');
       }
+
       if (toExpand) {
         section.setAttribute('expanded', '');
         header.setAttribute('aria-expanded', 'true');
+        // if expand-one is set, only allow one <section> to be expanded at a time
+        if (this.element.hasAttribute('expand-one')) {
+          this.sections_ = this.getRealChildren();
+          this.sections_.forEach(sectionIter => {
+            if (sectionIter != section) {
+              sectionIter.removeAttribute('expanded');
+              sectionIter.children[0].setAttribute('aria-expanded', 'false');
+            }
+          });
+        }
       } else {
         section.removeAttribute('expanded');
         header.setAttribute('aria-expanded', 'false');

--- a/extensions/amp-accordion/0.1/amp-accordion.js
+++ b/extensions/amp-accordion/0.1/amp-accordion.js
@@ -230,7 +230,6 @@ class AmpAccordion extends AMP.BaseElement {
         header.setAttribute('aria-expanded', 'true');
         // if expand-one is set, only allow one <section> to be expanded at a time
         if (this.element.hasAttribute('expand-one')) {
-          this.sections_ = this.getRealChildren();
           this.sections_.forEach(sectionIter => {
             if (sectionIter != section) {
               sectionIter.removeAttribute('expanded');

--- a/extensions/amp-accordion/0.1/amp-accordion.js
+++ b/extensions/amp-accordion/0.1/amp-accordion.js
@@ -228,8 +228,8 @@ class AmpAccordion extends AMP.BaseElement {
       if (toExpand) {
         section.setAttribute('expanded', '');
         header.setAttribute('aria-expanded', 'true');
-        // if expand-one is set, only allow one <section> to be expanded at a time
-        if (this.element.hasAttribute('expand-one')) {
+        // if expand-single-section is set, only allow one <section> to be expanded at a time
+        if (this.element.hasAttribute('expand-single-section')) {
           this.sections_.forEach(sectionIter => {
             if (sectionIter != section) {
               sectionIter.removeAttribute('expanded');

--- a/extensions/amp-accordion/0.1/test/test-amp-accordion.js
+++ b/extensions/amp-accordion/0.1/test/test-amp-accordion.js
@@ -105,6 +105,38 @@ describes.realWin('amp-accordion', {
         });
       });
 
+  it('should collapse other sections when expand action is triggered on a ' +
+    'collapsed section if expand-once attribute is set',
+  () => {
+    return getAmpAccordion().then(ampAccordion => {
+      ampAccordion.setAttribute('expand-one', '');
+      expect(ampAccordion.hasAttribute('expand-one')).to.be.true;
+      const impl = ampAccordion.implementation_;
+      const headerElements = doc.querySelectorAll(
+          'section > *:first-child');
+      // second section is expanded by default
+      expect(headerElements[1]
+          .parentNode.hasAttribute('expanded')).to.be.true;
+      expect(headerElements[1]
+          .getAttribute('aria-expanded')).to.equal('true');
+
+      // expand the first section
+      impl.expand_(headerElements[0].parentNode);
+
+      // we expect the first section to be expanded
+      expect(headerElements[0].parentNode
+          .hasAttribute('expanded')).to.be.true;
+      expect(headerElements[0]
+          .getAttribute('aria-expanded')).to.equal('true');
+
+      // we expect the second section to be collapsed
+      expect(headerElements[1]
+          .parentNode.hasAttribute('expanded')).to.be.false;
+      expect(headerElements[1]
+          .getAttribute('aria-expanded')).to.equal('false');
+    });
+  });
+
   it('should stay expanded on the expand action when expanded',
       () => {
         return getAmpAccordion().then(ampAccordion => {

--- a/extensions/amp-accordion/0.1/test/test-amp-accordion.js
+++ b/extensions/amp-accordion/0.1/test/test-amp-accordion.js
@@ -106,11 +106,11 @@ describes.realWin('amp-accordion', {
       });
 
   it('should collapse other sections when expand action is triggered on a ' +
-    'collapsed section if expand-once attribute is set',
+    'collapsed section if expand-single-section attribute is set',
   () => {
     return getAmpAccordion().then(ampAccordion => {
-      ampAccordion.setAttribute('expand-one', '');
-      expect(ampAccordion.hasAttribute('expand-one')).to.be.true;
+      ampAccordion.setAttribute('expand-single-section', '');
+      expect(ampAccordion.hasAttribute('expand-single-section')).to.be.true;
       const impl = ampAccordion.implementation_;
       const headerElements = doc.querySelectorAll(
           'section > *:first-child');

--- a/extensions/amp-accordion/amp-accordion.md
+++ b/extensions/amp-accordion/amp-accordion.md
@@ -81,15 +81,15 @@ This action collapses an `amp-accordion`. If it is already collapsed, it will st
 
 #### Attributes
 
-##### disable-session-states
+##### `disable-session-states`
 
 Set this attribute on the `<amp-accordion>` to opt out of preserving the collapsed/expanded state of the accordion.
 
-#####  expanded
+#####  `expanded`
 
 Set this attribute on a `<section>` to display the section as expanded on page load.
 
-#####  expand-single-section
+#####  `expand-single-section`
 
 Set this attribute on the `<amp-accordion>` to only allow one `<section>` to be expanded at a time. If the user focuses on one `<section>` any other previously expanded `<section>` will be collapsed.
 

--- a/extensions/amp-accordion/amp-accordion.md
+++ b/extensions/amp-accordion/amp-accordion.md
@@ -89,7 +89,7 @@ Set this attribute on the `<amp-accordion>` to opt out of preserving the collaps
 
 Set this attribute on a `<section>` to display the section as expanded on page load.
 
-#####  expand-one
+#####  expand-single-section
 
 Set this attribute on the `<amp-accordion>` to only allow one `<section>` to be expanded at a time. If the user focuses on one `<section>` any other previously expanded `<section>` will be collapsed.
 

--- a/extensions/amp-accordion/amp-accordion.md
+++ b/extensions/amp-accordion/amp-accordion.md
@@ -69,10 +69,13 @@ To see more demos of the `amp-accordion`, visit [AMP By Example](https://ampbyex
 {% endcall %}
 
 ### Actions
+
 #### `toggle`
 This action toggles between the `expanded` and `collapsed` states of the `amp-accordion`. When called with no arguements, it will toggle all sections of the accordion. A single section may be specified with the `section` arguement and the corresponding `id` as the value.
+
 #### `expand`
 This action expands an `amp-accordion`. If it is already `expanded`, it will stay so. When called with no arguements, it will expand all sections of the accordion. A single section may be spefified with the `section` arguement and the corresponding `id` as the value.
+
 #### `collapse`
 This action collapses an `amp-accordion`. If it is already collapsed, it will stay so. When called with no arguements, it will collapse all sections of the accordion. A single section may be spefified with the `section` arguement and the corresponding `id` as the value.
 
@@ -85,6 +88,10 @@ Set this attribute on the `<amp-accordion>` to opt out of preserving the collaps
 #####  expanded
 
 Set this attribute on a `<section>` to display the section as expanded on page load.
+
+#####  expand-one
+
+Set this attribute on the `<amp-accordion>` to only allow one `<section>` to be expanded at a time. If the user focuses on one `<section>` any other previously expanded `<section>` will be collapsed.
 
 ## Styling
 

--- a/extensions/amp-accordion/validator-amp-accordion.protoascii
+++ b/extensions/amp-accordion/validator-amp-accordion.protoascii
@@ -41,7 +41,7 @@ tags: {  # <amp-accordion> > <section>
   spec_name: "amp-accordion > section"
   mandatory_parent: "AMP-ACCORDION"
   attrs: { name: "expanded" value: "" }
-  attrs: { name: "expand-one" value: "" }
+  attrs: { name: "expand-single-section" value: "" }
   child_tags: {
     mandatory_num_child_tags: 2
     first_child_tag_name_oneof: "H1"

--- a/extensions/amp-accordion/validator-amp-accordion.protoascii
+++ b/extensions/amp-accordion/validator-amp-accordion.protoascii
@@ -41,6 +41,7 @@ tags: {  # <amp-accordion> > <section>
   spec_name: "amp-accordion > section"
   mandatory_parent: "AMP-ACCORDION"
   attrs: { name: "expanded" value: "" }
+  attrs: { name: "expand-one" value: "" }
   child_tags: {
     mandatory_num_child_tags: 2
     first_child_tag_name_oneof: "H1"


### PR DESCRIPTION
This PR does the following
- Adds an `expand-one` attribute to `<amp-accordion>` that ensures that only one `<section>` in `<amp-accordion>` is expanded at any given time. 
- Adds a test for the expansion/collapse of `<section>`s in <amp-accordion>
- Adds an example file (I found it weird that `<amp-accordion>` didn't have an example page. Is that for a reason?). This example needs some work. 

Fixes #11359 