### PR TITLE
Add test to enforce that RTC_VENDORS can not have any keys with capital letters

### DIFF
--- a/extensions/amp-a4a/0.1/test/test-callout-vendors.js
+++ b/extensions/amp-a4a/0.1/test/test-callout-vendors.js
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {RTC_VENDORS} from '../callout-vendors';
 
 // The keys of RTC_VENDORS are not allowed to have any capital letters.

--- a/extensions/amp-a4a/0.1/test/test-callout-vendors.js
+++ b/extensions/amp-a4a/0.1/test/test-callout-vendors.js
@@ -1,0 +1,11 @@
+import {RTC_VENDORS} from '../callout-vendors';
+
+// The keys of RTC_VENDORS are not allowed to have any capital letters.
+// This test acts as a presubmit to enforce that.
+describe('RTC_VENDORS', () => {
+  it('should have all lowercase keys', () => {
+    Object.keys(RTC_VENDORS).forEach(key => {
+      expect(key).to.equal(key.toLowerCase());
+    });
+  });
+});

--- a/extensions/amp-a4a/0.1/test/test-callout-vendors.js
+++ b/extensions/amp-a4a/0.1/test/test-callout-vendors.js
@@ -4,8 +4,6 @@ import {RTC_VENDORS} from '../callout-vendors';
 // This test acts as a presubmit to enforce that.
 describe('RTC_VENDORS', () => {
   it('should have all lowercase keys', () => {
-    Object.keys(RTC_VENDORS).forEach(key => {
-      expect(key).to.equal(key.toLowerCase());
-    });
+    Object.keys(RTC_VENDORS).forEach(key => expect(key).to.equal(key.toLowerCase()));
   });
 });

--- a/extensions/amp-a4a/0.1/test/test-callout-vendors.js
+++ b/extensions/amp-a4a/0.1/test/test-callout-vendors.js
@@ -4,7 +4,7 @@ import {RTC_VENDORS} from '../callout-vendors';
 // This test acts as a presubmit to enforce that.
 describe('RTC_VENDORS', () => {
   it('should have all lowercase keys', () =>
-    Object.keys(RTC_VENDORS).forEach(key =>
-                                     expect(key).to.equal(key.toLowerCase()));
-  );
+    Object.keys(RTC_VENDORS).forEach(
+        key => expect(key).to.equal(key.toLowerCase())
+    ));
 });

--- a/extensions/amp-a4a/0.1/test/test-callout-vendors.js
+++ b/extensions/amp-a4a/0.1/test/test-callout-vendors.js
@@ -3,7 +3,8 @@ import {RTC_VENDORS} from '../callout-vendors';
 // The keys of RTC_VENDORS are not allowed to have any capital letters.
 // This test acts as a presubmit to enforce that.
 describe('RTC_VENDORS', () => {
-  it('should have all lowercase keys', () => {
-    Object.keys(RTC_VENDORS).forEach(key => expect(key).to.equal(key.toLowerCase()));
-  });
+  it('should have all lowercase keys', () =>
+    Object.keys(RTC_VENDORS).forEach(key =>
+                                     expect(key).to.equal(key.toLowerCase()));
+  );
 });


### PR DESCRIPTION
Add a presubmit test to enforce constraint that all keys in RTC_VENDORS must be all lowercase 