### PR TITLE
Disable same-line logging for non-TTY Travis

### DIFF
--- a/build-system/tasks/lint.js
+++ b/build-system/tasks/lint.js
@@ -63,9 +63,11 @@ function initializeStream(globs, streamOptions) {
  * @param {string} message
  */
 function logOnSameLine(message) {
-  process.stdout.moveCursor(0, -1);
-  process.stdout.cursorTo(0);
-  process.stdout.clearLine();
+  if (!process.env.TRAVIS) {
+    process.stdout.moveCursor(0, -1);
+    process.stdout.cursorTo(0);
+    process.stdout.clearLine();
+  }
   log(message);
 }
 


### PR DESCRIPTION
Travis doesn't have a TTY `stdout`, so same-line logging won't work there. This PR gracefully reverts to regular logging in that case.

Avoids issues like the one in https://travis-ci.org/ampproject/amphtml/jobs/339065849#L1677

Follow up to #13274