### PR TITLE
<amp-ad type=custom>: allow defining template via the "template" attribute

### DIFF
--- a/extensions/amp-ad/0.1/test/validator-amp-ad.html
+++ b/extensions/amp-ad/0.1/test/validator-amp-ad.html
@@ -27,14 +27,22 @@
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <script async custom-element="amp-ad" src="https://cdn.ampproject.org/v0/amp-ad-0.1.js"></script>
   <script async custom-element="amp-fx-flying-carpet" src="https://cdn.ampproject.org/v0/amp-fx-flying-carpet-0.1.js"></script>
+  <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.1.js"></script>
 </head>
 <body>
+  <template type="amp-mustache" id="template-1">
+  </template>
   <!-- Valid -->
   <amp-ad width=300 height=250
           type="a9"
           data-aax_size="300x250"
           data-aax_pubname="test123"
           data-aax_src="302">
+  </amp-ad>
+  <!-- Valid -->
+  <amp-ad width=300 height=250
+      type="custom"
+      template="template-1">
   </amp-ad>
   <!-- Valid -->
   <amp-fx-flying-carpet height="300">

--- a/extensions/amp-ad/0.1/test/validator-amp-ad.out
+++ b/extensions/amp-ad/0.1/test/validator-amp-ad.out
@@ -28,14 +28,22 @@ FAIL
 |    <script async src="https://cdn.ampproject.org/v0.js"></script>
 |    <script async custom-element="amp-ad" src="https://cdn.ampproject.org/v0/amp-ad-0.1.js"></script>
 |    <script async custom-element="amp-fx-flying-carpet" src="https://cdn.ampproject.org/v0/amp-fx-flying-carpet-0.1.js"></script>
+|    <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.1.js"></script>
 |  </head>
 |  <body>
+|    <template type="amp-mustache" id="template-1">
+|    </template>
 |    <!-- Valid -->
 |    <amp-ad width=300 height=250
 |            type="a9"
 |            data-aax_size="300x250"
 |            data-aax_pubname="test123"
 |            data-aax_src="302">
+|    </amp-ad>
+|    <!-- Valid -->
+|    <amp-ad width=300 height=250
+|        type="custom"
+|        template="template-1">
 |    </amp-ad>
 |    <!-- Valid -->
 |    <amp-fx-flying-carpet height="300">
@@ -47,17 +55,17 @@ FAIL
 |    <amp-fx-flying-carpet height="300">
 |      <amp-ad data-multi-size="" height="300" type="foo"></amp-ad>
 >>     ^~~~~~~~~
-amp-ad/0.1/test/validator-amp-ad.html:47:4 The tag 'amp-ad with data-multi-size attribute' may not appear as a descendant of tag 'amp-fx-flying-carpet'. (see https://www.ampproject.org/docs/reference/components/amp-ad) [AMP_TAG_PROBLEM]
+amp-ad/0.1/test/validator-amp-ad.html:55:4 The tag 'amp-ad with data-multi-size attribute' may not appear as a descendant of tag 'amp-fx-flying-carpet'. (see https://www.ampproject.org/docs/reference/components/amp-ad) [AMP_TAG_PROBLEM]
 |    </amp-fx-flying-carpet>
 |    <!-- Invalid: amp-ad in an amp ad container with data-multi-size attr -->
 |    <amp-fx-flying-carpet height="300">
 |      <amp-embed data-multi-size="" height="300" type="foo"></amp-ad>
 >>     ^~~~~~~~~
-amp-ad/0.1/test/validator-amp-ad.html:51:4 The tag 'amp-embed with data-multi-size attribute' may not appear as a descendant of tag 'amp-fx-flying-carpet'. (see https://www.ampproject.org/docs/reference/components/amp-ad) [AMP_TAG_PROBLEM]
+amp-ad/0.1/test/validator-amp-ad.html:59:4 The tag 'amp-embed with data-multi-size attribute' may not appear as a descendant of tag 'amp-fx-flying-carpet'. (see https://www.ampproject.org/docs/reference/components/amp-ad) [AMP_TAG_PROBLEM]
 |    </amp-fx-flying-carpet>
 |    <!-- Invalid: amp-ad missing layout=fluid for fluid ad -->
 |    <amp-ad type=doubleclick width="100" height="fluid"></amp-ad>
 >>   ^~~~~~~~~
-amp-ad/0.1/test/validator-amp-ad.html:54:2 The attribute 'height' in tag 'amp-ad' is set to the invalid value 'fluid'. (see https://www.ampproject.org/docs/reference/components/amp-ad) [AMP_LAYOUT_PROBLEM]
+amp-ad/0.1/test/validator-amp-ad.html:62:2 The attribute 'height' in tag 'amp-ad' is set to the invalid value 'fluid'. (see https://www.ampproject.org/docs/reference/components/amp-ad) [AMP_LAYOUT_PROBLEM]
 |  </body>
 |  </html>

--- a/extensions/amp-ad/validator-amp-ad.protoascii
+++ b/extensions/amp-ad/validator-amp-ad.protoascii
@@ -177,6 +177,7 @@ tags: {  # <amp-embed>
   attrs: { name: "alt" }
   attrs: { name: "json" }
   attrs: { name: "rtc-config" }
+  attrs: { name: "template" }
   attrs: {
     name: "src"
     value_url: {

--- a/extensions/amp-ad/validator-amp-ad.protoascii
+++ b/extensions/amp-ad/validator-amp-ad.protoascii
@@ -54,6 +54,7 @@ tags: {  # <amp-ad>
   attrs: { name: "alt" }
   attrs: { name: "json" }
   attrs: { name: "rtc-config" }
+  attrs: { name: "template" }
   attrs: {
     name: "src"
     value_url: {


### PR DESCRIPTION
This PR allows `template` attribute in any `amp-ad`. We actually can restrict it to only `<amp-ad type="custom">`. Not sure how to do that. @Gregable 
