### PR TITLE
Doubleclick/AdSense Fast Fetch: Include GA parameters

### DIFF
--- a/ads/google/a4a/test/test-utils.js
+++ b/ads/google/a4a/test/test-utils.js
@@ -415,6 +415,28 @@ describe('Google A4A utils', () => {
         });
       });
     });
+
+    it('should include GA cid/hid', () => {
+      return createIframePromise().then(fixture => {
+        setupForAdTesting(fixture);
+        const doc = fixture.doc;
+        doc.win = fixture.win;
+        const elem = createElementWithAttributes(doc, 'amp-a4a', {
+          'type': 'adsense',
+          'width': '320',
+          'height': '50',
+        });
+        const impl = new MockA4AImpl(elem);
+        noopMethods(impl, doc, sandbox);
+        impl.win.gaGlobal = {cid: 'foo', hid: 'bar'};
+        return fixture.addElement(elem).then(() => {
+          return googleAdUrl(impl, '', 0, [], []).then(url => {
+            expect(url).to.match(/[&?]ga_cid=foo[&$]/);
+            expect(url).to.match(/[&?]ga_hid=bar[&$]/);
+          });
+        });
+      });
+    });
   });
 
   describe('#mergeExperimentIds', () => {

--- a/ads/google/a4a/utils.js
+++ b/ads/google/a4a/utils.js
@@ -235,6 +235,8 @@ export function googlePageParameters(win, nodeOrDoc, startTime) {
           'amp_v': '$internalRuntimeVersion$',
           'd_imp': '1',
           'c': getCorrelator(win, clientId, nodeOrDoc),
+          'ga_cid': win.gaGlobal.cid || null,
+          'ga_hid': win.gaGlobal.hid || null,
           'dt': startTime,
           'biw': viewportRect.width,
           'bih': viewportRect.height,


### PR DESCRIPTION
Add GA integration for Doubleclick/AdSense fast fetch by passing ga_cid/ga_hid parameters.