### PR TITLE
<amp-facebook-*> clean up assignment of dataLocale_ private variable

### DIFF
--- a/extensions/amp-facebook-comments/0.1/amp-facebook-comments.js
+++ b/extensions/amp-facebook-comments/0.1/amp-facebook-comments.js
@@ -30,11 +30,10 @@ class AmpFacebookComments extends AMP.BaseElement {
     /** @private {?HTMLIFrameElement} */
     this.iframe_ = null;
 
-    /** @private {string} */
-    this.dataLocale_ = element.getAttribute('data-locale');
-    if (!this.dataLocale_) {
-      this.dataLocale_ = dashToUnderline(window.navigator.language);
-    }
+    /** @private @const {string} */
+    this.dataLocale_ = element.hasAttribute('data-locale') ?
+      element.getAttribute('data-locale') :
+      dashToUnderline(window.navigator.language);
   }
 
   /** @override */

--- a/extensions/amp-facebook-like/0.1/amp-facebook-like.js
+++ b/extensions/amp-facebook-like/0.1/amp-facebook-like.js
@@ -30,11 +30,10 @@ class AmpFacebookLike extends AMP.BaseElement {
     /** @private {?HTMLIFrameElement} */
     this.iframe_ = null;
 
-    /** @private {string} */
-    this.dataLocale_ = element.getAttribute('data-locale');
-    if (!this.dataLocale_) {
-      this.dataLocale_ = dashToUnderline(window.navigator.language);
-    }
+    /** @private @const {string} */
+    this.dataLocale_ = element.hasAttribute('data-locale') ?
+      element.getAttribute('data-locale') :
+      dashToUnderline(window.navigator.language);
   }
 
   /** @override */

--- a/extensions/amp-facebook/0.1/amp-facebook.js
+++ b/extensions/amp-facebook/0.1/amp-facebook.js
@@ -30,11 +30,10 @@ class AmpFacebook extends AMP.BaseElement {
     /** @private {?HTMLIFrameElement} */
     this.iframe_ = null;
 
-    /** @private {string} */
-    this.dataLocale_ = element.getAttribute('data-locale');
-    if (!this.dataLocale_) {
-      this.dataLocale_ = dashToUnderline(window.navigator.language);
-    }
+    /** @private @const {string} */
+    this.dataLocale_ = element.hasAttribute('data-locale') ?
+      element.getAttribute('data-locale') :
+      dashToUnderline(window.navigator.language);
   }
 
   /** @override */


### PR DESCRIPTION
This PR isn't related to issue. 

It cleans up the assignment of the `dataLocale_` private variable on `<amp-facebook-*>` elements by making it assigned via a ternary operation. This also allows us to make it a const. 

Please note that `<amp-facebook-page>` already follows this behaviour, which is why it's missing from this PR.