### PR TITLE
Refactor amp-story progress bar to use page-ids 

### DIFF
--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -322,7 +322,7 @@ export class AmpStory extends AMP.BaseElement {
    * @private
    */
   buildSystemLayer_() {
-    this.element.appendChild(this.systemLayer_.build(this.getPageCount()));
+    this.element.appendChild(this.systemLayer_.build(this.pages_));
     this.updateAudioIcon_();
   }
 
@@ -388,8 +388,7 @@ export class AmpStory extends AMP.BaseElement {
         return;
       }
 
-      const pageIndex = this.getPageIndexById_(pageId);
-      this.systemLayer_.updateProgress(pageIndex, progress);
+      this.systemLayer_.updateProgress(pageId, progress);
     });
 
     this.element.addEventListener(EventType.REPLAY, () => {
@@ -775,7 +774,7 @@ export class AmpStory extends AMP.BaseElement {
     this.updateBackground_(targetPage.element, /* initial */ !this.activePage_);
 
     // TODO(alanorozco): decouple this using NavigationState
-    this.systemLayer_.setActivePageIndex(pageIndex);
+    this.systemLayer_.setActivePageIndex(targetPageId);
 
     // TODO(alanorozco): check if autoplay
     this.navigationState_.updateActivePage(
@@ -1337,7 +1336,6 @@ export class AmpStory extends AMP.BaseElement {
   getElement() {
     return this.element;
   }
-
 
   /**
    * Mutes the audio for the story.

--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -775,7 +775,7 @@ export class AmpStory extends AMP.BaseElement {
     this.updateBackground_(targetPage.element, /* initial */ !this.activePage_);
 
     // TODO(alanorozco): decouple this using NavigationState
-    this.systemLayer_.setActivePageIndex(targetPageId);
+    this.systemLayer_.setActivePageId(targetPageId);
 
     // TODO(alanorozco): check if autoplay
     this.navigationState_.updateActivePage(

--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -322,7 +322,8 @@ export class AmpStory extends AMP.BaseElement {
    * @private
    */
   buildSystemLayer_() {
-    this.element.appendChild(this.systemLayer_.build(this.pages_));
+    const pageIds = this.pages_.map(page => page.element.id);
+    this.element.appendChild(this.systemLayer_.build(pageIds));
     this.updateAudioIcon_();
   }
 

--- a/extensions/amp-story/0.1/progress-bar.js
+++ b/extensions/amp-story/0.1/progress-bar.js
@@ -87,7 +87,7 @@ export class ProgressBar {
     this.isBuilt_ = true;
     this.segmentCount_ = segmentCount;
 
-    this.makeSegmentIdMap_(segmentIds);
+    segmentIds.forEach((id, i) => this.segmentIdMap_[id] = i);
 
     this.root_ = this.win_.document.createElement('ol');
     this.root_.classList.add('i-amphtml-story-progress-bar');
@@ -102,14 +102,6 @@ export class ProgressBar {
     }
 
     return this.getRoot();
-  }
-
-  /**
-   * create mapping of segmentIds to position in progress bar
-   * @param {!Array<string>} segmentIds
-   */
-  makeSegmentIdMap_(segmentIds) {
-    segmentIds.forEach((id, i) => this.segmentIdMap_[id] = i);
   }
 
 

--- a/extensions/amp-story/0.1/progress-bar.js
+++ b/extensions/amp-story/0.1/progress-bar.js
@@ -53,7 +53,7 @@ export class ProgressBar {
     this.root_ = null;
 
     /** @private {number} */
-    this.pageCount_ = 0;
+    this.segmentCount_ = 0;
 
     /** @private {number} */
     this.activePageIndex_ = 0;
@@ -62,7 +62,7 @@ export class ProgressBar {
     this.vsync_ = Services.vsyncFor(this.win_);
 
     /** @private {!Object<string, number>} */
-    this.pageIdMap_ = map();
+    this.segmentIdMap_ = map();
   }
 
   /**
@@ -73,27 +73,26 @@ export class ProgressBar {
   }
 
   /**
-   * @param {!Array} pages The number of pages in the story.
+   * @param {!Array<string>} segmentIds The id of each page in the story.
    * @return {!Element}
    */
-  build(pages) {
+  build(segmentIds) {
     if (this.isBuilt_) {
       return this.getRoot();
     }
 
-    const pageCount = pages.length;
-    dev().assertNumber(pageCount);
-    dev().assert(pageCount > 0);
+    const segmentCount = segmentIds.length;
+    dev().assert(segmentCount > 0);
 
     this.isBuilt_ = true;
-    this.pageCount_ = pageCount;
+    this.segmentCount_ = segmentCount;
 
-    this.makePageIdMap_(pages);
+    this.makeSegmentIdMap_(segmentIds);
 
     this.root_ = this.win_.document.createElement('ol');
     this.root_.classList.add('i-amphtml-story-progress-bar');
 
-    for (let i = 0; i < this.pageCount_; i++) {
+    for (let i = 0; i < this.segmentCount_; i++) {
       const pageProgressBar = this.win_.document.createElement('li');
       pageProgressBar.classList.add('i-amphtml-story-page-progress-bar');
       const pageProgressValue = this.win_.document.createElement('div');
@@ -106,11 +105,11 @@ export class ProgressBar {
   }
 
   /**
-   * create mapping of pageIds to position in progress bar
-   * @param {Array} pages
+   * create mapping of segmentIds to position in progress bar
+   * @param {!Array<string>} segmentIds
    */
-  makePageIdMap_(pages) {
-    pages.forEach((page, i) => this.pageIdMap_[page.element.id] = i);
+  makeSegmentIdMap_(segmentIds) {
+    segmentIds.forEach((id, i) => this.segmentIdMap_[id] = i);
   }
 
 
@@ -127,8 +126,8 @@ export class ProgressBar {
    * @private
    */
   assertValidPageIndex_(pageIndex) {
-    dev().assert(pageIndex >= 0 && pageIndex < this.pageCount_,
-        `Page index ${pageIndex} is not between 0 and ${this.pageCount_}.`);
+    dev().assert(pageIndex >= 0 && pageIndex < this.segmentCount_,
+        `Page index ${pageIndex} is not between 0 and ${this.segmentCount_}.`);
   }
 
 
@@ -137,9 +136,9 @@ export class ProgressBar {
    * @public
    */
   setActivePageIndex(pageId) {
-    const progressBarIndex = this.pageIdMap_[pageId];
-    this.assertValidPageIndex_(progressBarIndex);
-    for (let i = 0; i < this.pageCount_; i++) {
+    const progressBarIndex = this.segmentIdMap_[pageId];
+
+    for (let i = 0; i < this.segmentCount_; i++) {
       if (i < progressBarIndex) {
         this.updateProgressByIndex_(i, 1.0,
             /* withTransition */ i == progressBarIndex - 1);
@@ -160,7 +159,7 @@ export class ProgressBar {
    *     progress of the current page.
    */
   updateProgress(pageId, progress) {
-    const progressBarIndex = this.pageIdMap_[pageId];
+    const progressBarIndex = this.segmentIdMap_[pageId];
     this.updateProgressByIndex_(progressBarIndex, progress);
   }
 

--- a/extensions/amp-story/0.1/progress-bar.js
+++ b/extensions/amp-story/0.1/progress-bar.js
@@ -88,7 +88,7 @@ export class ProgressBar {
     this.isBuilt_ = true;
     this.pageCount_ = pageCount;
 
-    this.makeIdMap_(pages);
+    this.makePageIdMap_(pages);
 
     this.root_ = this.win_.document.createElement('ol');
     this.root_.classList.add('i-amphtml-story-progress-bar');
@@ -109,7 +109,7 @@ export class ProgressBar {
    * create mapping of pageIds to position in progress bar
    * @param {Array} pages
    */
-  makeIdMap_(pages) {
+  makePageIdMap_(pages) {
     pages.forEach((page, i) => this.pageIdMap_[page.element.id] = i);
   }
 

--- a/extensions/amp-story/0.1/system-layer.js
+++ b/extensions/amp-story/0.1/system-layer.js
@@ -119,10 +119,10 @@ export class SystemLayer {
   }
 
   /**
-   * @param {!Array} pages the pages in the story
+   * @param {!Array<string>} pageIds the ids of each page in the story
    * @return {!Element}
    */
-  build(pages) {
+  build(pageIds) {
     if (this.isBuilt_) {
       return this.getRoot();
     }
@@ -132,7 +132,7 @@ export class SystemLayer {
     this.root_ = renderAsElement(this.win_.document, TEMPLATE);
 
     this.root_.insertBefore(
-        this.progressBar_.build(pages), this.root_.lastChild);
+        this.progressBar_.build(pageIds), this.root_.lastChild);
 
     this.leftButtonTray_ =
         this.root_.querySelector('.i-amphtml-story-ui-left');
@@ -215,6 +215,7 @@ export class SystemLayer {
    * @public
    */
   setActivePageIndex(pageId) {
+    // TODO(newmuis) avoid passing progress logic through system-layer
     this.progressBar_.setActivePageIndex(pageId);
   }
 
@@ -226,6 +227,7 @@ export class SystemLayer {
    * @public
    */
   updateProgress(pageId, progress) {
+    // TODO(newmuis) avoid passing progress logic through system-layer
     this.progressBar_.updateProgress(pageId, progress);
   }
 

--- a/extensions/amp-story/0.1/system-layer.js
+++ b/extensions/amp-story/0.1/system-layer.js
@@ -119,10 +119,10 @@ export class SystemLayer {
   }
 
   /**
-   * @param {number} pageCount The number of pages in the story.
+   * @param {!Array} pages the pages in the story
    * @return {!Element}
    */
-  build(pageCount) {
+  build(pages) {
     if (this.isBuilt_) {
       return this.getRoot();
     }
@@ -132,7 +132,7 @@ export class SystemLayer {
     this.root_ = renderAsElement(this.win_.document, TEMPLATE);
 
     this.root_.insertBefore(
-        this.progressBar_.build(pageCount), this.root_.lastChild);
+        this.progressBar_.build(pages), this.root_.lastChild);
 
     this.leftButtonTray_ =
         this.root_.querySelector('.i-amphtml-story-ui-left');
@@ -211,22 +211,22 @@ export class SystemLayer {
   }
 
   /**
-   * @param {number} pageIndex The index of the new active page.
+   * @param {string} pageId The page id of the new active page.
    * @public
    */
-  setActivePageIndex(pageIndex) {
-    this.progressBar_.setActivePageIndex(pageIndex);
+  setActivePageIndex(pageId) {
+    this.progressBar_.setActivePageIndex(pageId);
   }
 
   /**
-   * @param {number} pageIndex The index of the page whose progress should be
+   * @param {string} pageId The id of the page whose progress should be
    *     changed.
    * @param {number} progress A number from 0.0 to 1.0, representing the
    *     progress of the current page.
    * @public
    */
-  updateProgress(pageIndex, progress) {
-    this.progressBar_.updateProgress(pageIndex, progress);
+  updateProgress(pageId, progress) {
+    this.progressBar_.updateProgress(pageId, progress);
   }
 
   /**

--- a/extensions/amp-story/0.1/system-layer.js
+++ b/extensions/amp-story/0.1/system-layer.js
@@ -214,9 +214,9 @@ export class SystemLayer {
    * @param {string} pageId The page id of the new active page.
    * @public
    */
-  setActivePageIndex(pageId) {
+  setActivePageId(pageId) {
     // TODO(newmuis) avoid passing progress logic through system-layer
-    this.progressBar_.setActivePageIndex(pageId);
+    this.progressBar_.setActiveSegmentId(pageId);
   }
 
   /**

--- a/extensions/amp-story/0.1/test/test-system-layer.js
+++ b/extensions/amp-story/0.1/test/test-system-layer.js
@@ -35,7 +35,7 @@ describes.fakeWin('amp-story system layer', {}, env => {
     progressBarStub = {
       build: sandbox.stub().returns(progressBarRoot),
       getRoot: sandbox.stub().returns(progressBarRoot),
-      setActivePageIndex: sandbox.spy(),
+      setActiveSegmentId: sandbox.spy(),
       updateProgress: sandbox.spy(),
     };
 
@@ -73,8 +73,8 @@ describes.fakeWin('amp-story system layer', {}, env => {
 
   it('should set the active page index', () => {
     [0, 1, 2, 3, 4].forEach(index => {
-      systemLayer.setActivePageIndex(index);
-      progressBarStub.setActivePageIndex.should.have.been.calledWith(index);
+      systemLayer.setActivePageId(index);
+      progressBarStub.setActiveSegmentId.should.have.been.calledWith(index);
     });
   });
 });


### PR DESCRIPTION
This is necessary because as we begin to ad things like ads to stories, we will often want things to be treated as a page in `amp-story.js` but may want to hide or have special behavior in the progress bar.

related-to: #13284
