### PR TITLE
🏗️ Use (headless) chrome addon on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,11 @@ notifications:
   webhooks:
     - http://savage.nonblocking.io:8080/savage/travis
 before_install:
-  - export CHROME_BIN=google-chrome
+  - export CHROME_BIN=google-chrome-stable
   - export DISPLAY=:99.0
   - unset _JAVA_OPTIONS  # JVM heap sizes break closure compiler. #11203.
   - sh -e /etc/init.d/xvfb start
-  - wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-  - sudo dpkg -i google-chrome*.deb
+  - google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost &
   # Required due to https://github.com/greenkeeperio/greenkeeper-lockfile/issues/98#issuecomment-352087908
   - export PATH="`yarn global bin`:$PATH"
   - yarn global add greenkeeper-lockfile@1
@@ -38,6 +37,7 @@ env:
     - SAUCE_USERNAME="amphtml"
     - NPM_CONFIG_PROGRESS="false"
 addons:
+  chrome: stable
   sauce_connect:
     username: "amphtml"
   jwt:


### PR DESCRIPTION
This PR does the following:
1. Removes the code that downloads Chrome stable before each Travis build
2. Uses the `chrome` addon that is built in to Travis
3. Since there's no display on Travis, launches Chrome in headless mode

See https://docs.travis-ci.com/user/chrome

Related to #13397