### PR TITLE
docs: fix JS translation from pseudo-code

### DIFF
--- a/spec/amp-cors-requests.md
+++ b/spec/amp-cors-requests.md
@@ -301,7 +301,7 @@ function assertCors(req, res, opt_validMethods, opt_exposeHeaders) {
   if (req.headers['amp-same-origin'] == 'true') {
       origin = sourceOrigin;
   // If allowed CORS origin & allowed source origin
-  } else if (allowedOrigins.indexOf(req.headers.origin) == -1 &&
+  } else if (allowedOrigins.indexOf(req.headers.origin) !== -1 &&
       sourceOrigin == allowedSourceOrigin) {
       origin = req.headers.origin;
   } else {


### PR DESCRIPTION
I think the JS equivalent of the pseudo-code `origin IN allowed-origins` should be `allowedOrigins.indexOf(req.headers.origin) !== -1` not `allowedOrigins.indexOf(req.headers.origin) == -1`.