### PR TITLE
amp-lightbox-gallery: install component if extension is loaded

### DIFF
--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -1115,13 +1115,10 @@ function installLightboxGallery(win) {
   return ampdoc.whenBodyAvailable().then(body => {
     const existingGallery = elementByTag(ampdoc.getRootNode(), TAG);
     if (!existingGallery) {
-      const matches = ampdoc.getRootNode().querySelectorAll('[lightbox]');
-      if (matches.length > 0) {
-        const gallery = ampdoc.getRootNode().createElement(TAG);
-        gallery.setAttribute('layout', 'nodisplay');
-        gallery.setAttribute('id', DEFAULT_GALLERY_ID);
-        body.appendChild(gallery);
-      }
+      const gallery = ampdoc.getRootNode().createElement(TAG);
+      gallery.setAttribute('layout', 'nodisplay');
+      gallery.setAttribute('id', DEFAULT_GALLERY_ID);
+      body.appendChild(gallery);
     }
   });
 }


### PR DESCRIPTION
If the extension is included, load the component unconditionally. `amp-list` and other dynamic content can create lightboxable elements so only doing it if there is a `[lightbox]` initially won't work.

We can optimize this later so we install the component when we see ` new `[lightbox]` but the instantiation of the component should be light anyway.