### PR TITLE
Add documentation for Percy access

### DIFF
--- a/contributing/getting-started-e2e.md
+++ b/contributing/getting-started-e2e.md
@@ -466,11 +466,15 @@ The reviewer should be one of the [core committers](https://github.com/ampprojec
 
 When you're done click "Create pull request."  This will bring you to your Pull Request page where you can track progress, add comments, etc.
 
-On the Pull Request page you can see that a couple of checks are running:
+On the Pull Request page you can see that a few checks are running:
 
-* the tests are being run on [Travis](https://travis-ci.org/ampproject/amphtml/pull_requests)
+* The tests are being run on [Travis](https://travis-ci.org/ampproject/amphtml/pull_requests)
 
-* the system is verifying that you have signed a CLA (Contributor License Agreement).  If this is your first time submitting a Pull Request for the amphtml project you'll need to sign an agreement.  (Make sure the email address you use to sign the CLA is the same one that you configured Git with.)  See details in the [Contributing code](https://github.com/ampproject/amphtml/blob/master/CONTRIBUTING.md#contributing-code) documentation.
+* The system is verifying that you have signed a CLA (Contributor License Agreement).  If this is your first time submitting a Pull Request for the amphtml project you'll need to sign an agreement.  (Make sure the email address you use to sign the CLA is the same one that you configured Git with.)  See details in the [Contributing code](https://github.com/ampproject/amphtml/blob/master/CONTRIBUTING.md#contributing-code) documentation.
+
+* Your code is going through static analysis by [LGTM](https://lgtm.com/projects/g/ampproject/amphtml/).
+
+* Visual diff tests that are run on Travis are being analyzed by [Percy](percy.io/ampproject/amphtml). (To access the results, fill out this [form](https://docs.google.com/forms/d/e/1FAIpQLScZma6qVJtYUTqSm4KtiF3Zc-n5ukNe2GXNFqnaHxospsz0sQ/viewform), and your request should be approved soon.)
 
 If you don't hear back from your reviewer within 2 business days, feel free to ping the pull request by adding a comment.
 

--- a/contributing/getting-started-e2e.md
+++ b/contributing/getting-started-e2e.md
@@ -474,7 +474,7 @@ On the Pull Request page you can see that a few checks are running:
 
 * Your code is going through static analysis by [LGTM](https://lgtm.com/projects/g/ampproject/amphtml/).
 
-* Visual diff tests that are run on Travis are being analyzed by [Percy](percy.io/ampproject/amphtml). (To access the results, fill out this [form](https://docs.google.com/forms/d/e/1FAIpQLScZma6qVJtYUTqSm4KtiF3Zc-n5ukNe2GXNFqnaHxospsz0sQ/viewform), and your request should be approved soon.)
+* Visual diff tests that are run on Travis are being analyzed by [Percy](http://percy.io/ampproject/amphtml). (To access the results, fill out this [form](https://docs.google.com/forms/d/e/1FAIpQLScZma6qVJtYUTqSm4KtiF3Zc-n5ukNe2GXNFqnaHxospsz0sQ/viewform), and your request should be approved soon.)
 
 If you don't hear back from your reviewer within 2 business days, feel free to ping the pull request by adding a comment.
 

--- a/contributing/getting-started-quick.md
+++ b/contributing/getting-started-quick.md
@@ -90,7 +90,7 @@ This Quick Start guide is the TL;DR version of the longer [end-to-end guide](get
 * If your reviewer requests changes make them locally and then repeat the steps in this section to push the changes to your branch back up to GitHub again
 * For pushes after the first, just use `git push`
 * If you don't get a new review within 2 business days, feel free to ping the pull request by adding a comment
-* If you see visual diffs reported by [Percy](percy.io/ampproject/amphtml), and want to access the results, fill out this [form](https://docs.google.com/forms/d/e/1FAIpQLScZma6qVJtYUTqSm4KtiF3Zc-n5ukNe2GXNFqnaHxospsz0sQ/viewform).
+* If you see visual diffs reported by [Percy](http://percy.io/ampproject/amphtml), and want to access the results, fill out this [form](https://docs.google.com/forms/d/e/1FAIpQLScZma6qVJtYUTqSm4KtiF3Zc-n5ukNe2GXNFqnaHxospsz0sQ/viewform).
 
 * Once approved your changes are merged into the amphtml repository by a core committer (you don't do this merge)
 

--- a/contributing/getting-started-quick.md
+++ b/contributing/getting-started-quick.md
@@ -55,7 +55,10 @@ This Quick Start guide is the TL;DR version of the longer [end-to-end guide](get
 
 # Test AMP
 
-* Run the tests: `gulp test`
+* Run all tests: `gulp test`
+* Run only the unit tests: `gulp test --unit` (doesn't build the runtime)
+* Run only the integration tests: `gulp test --integration` (builds the runtime)
+* Run tests, but skip building after having done so previously: `gulp test --nobuild`
 * Run the tests in a specified set of files: `gulp test --files=<filename>`
 * Add the `--watch` flag to any `gulp test` command to automatically re-run the tests when a file changes
 * To run only a certain set of Mocha tests change  `describe` to `describe.only` for the tests you want to run; combine this with `gulp test --watch` to automatically rerun your test when files are changed   (but make sure to run all the tests before sending your change for review)
@@ -87,6 +90,8 @@ This Quick Start guide is the TL;DR version of the longer [end-to-end guide](get
 * If your reviewer requests changes make them locally and then repeat the steps in this section to push the changes to your branch back up to GitHub again
 * For pushes after the first, just use `git push`
 * If you don't get a new review within 2 business days, feel free to ping the pull request by adding a comment
+* If you see visual diffs reported by [Percy](percy.io/ampproject/amphtml), and want to access the results, fill out this [form](https://docs.google.com/forms/d/e/1FAIpQLScZma6qVJtYUTqSm4KtiF3Zc-n5ukNe2GXNFqnaHxospsz0sQ/viewform).
+
 * Once approved your changes are merged into the amphtml repository by a core committer (you don't do this merge)
 
 # Delete your branch after your changes are merged (optional)


### PR DESCRIPTION
Now that we've added several more visual diff tests, it's likely that more people will want access to the results. This PR adds instructions to more places in our developer docs.

Follow up to #13394