### PR TITLE
🏗️ Don't pre-launch headless chrome on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ before_install:
   - export DISPLAY=:99.0
   - unset _JAVA_OPTIONS  # JVM heap sizes break closure compiler. #11203.
   - sh -e /etc/init.d/xvfb start
-  - google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost &
   # Required due to https://github.com/greenkeeperio/greenkeeper-lockfile/issues/98#issuecomment-352087908
   - export PATH="`yarn global bin`:$PATH"
   - yarn global add greenkeeper-lockfile@1


### PR DESCRIPTION
We now use the `chrome` addon on Travis instead of installing `google-chrome-stable`, and start a headless background instance of Chrome before tests are run.

This causes messages like https://travis-ci.org/ampproject/amphtml/jobs/339625462#L747 during Travis VM shutdown. While this doesn't affect testing, it's not a clean exit.

In any case, we start an `xvfb` instance, making the headless-ness of Chrome moot. Moreover, the AMP tests start their own instance of Chrome.

Follow up to #13396