### PR TITLE
🏗️ Skip amp-by-example visual tests for PRs

### DIFF
--- a/build-system/tasks/visual-diff.rb
+++ b/build-system/tasks/visual-diff.rb
@@ -38,7 +38,7 @@ CONFIGS = %w(canary prod)
 AMP_RUNTIME_FILE = 'dist/amp.js'
 BUILD_STATUS_URL = 'https://amphtml-percy-status-checker.appspot.com/status'
 BUILD_PROCESSING_POLLING_INTERVAL_SECS = 5
-BUILD_PROCESSING_TIMEOUT_SECS = 60 * 5
+BUILD_PROCESSING_TIMEOUT_SECS = 60 * 10
 PERCY_BUILD_URL = 'https://percy.io/ampproject/amphtml/builds'
 OUT = ENV['TRAVIS'] ? '/dev/null' : :out
 

--- a/build-system/tasks/visual-diff.rb
+++ b/build-system/tasks/visual-diff.rb
@@ -303,6 +303,10 @@ def generate_snapshots(page, webpages)
     page.visit('/')
     webpages.each do |webpage|
       url = webpage['url']
+      if url.include? 'examples/visual-tests/amp-by-example/' and
+          !ARGV.include? '--master'
+        next
+      end
       name = "#{webpage['name']} (#{config})"
       forbidden_css = webpage['forbidden_css']
       loading_incomplete_css = webpage['loading_incomplete_css']


### PR DESCRIPTION
Several new visual tests were added in #13394. This has resulted in Percy taking longer to process diffs. Increasing the Percy verification timeout for `gulp visual-diff --verify` from 5 mins to 10 mins can help, but it doesn't alleviate the increased load for PRs. In addition, the increased odds of diffs leading to build failures makes things worse.

This PR skips the amp-by-example visual tests for PRs and increases the verification timeout for `master` builds. The increased time should not greatly increase the build time on `master`, since we run unit tests in between `gulp visual-diff` and `gulp visual-diff --verify`.

Follow up to #13394