### PR TITLE
🏗️ Temporarily skip gulp visual-diff --verify

### DIFF
--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -350,7 +350,7 @@ function runAllCommands() {
     command.runJsonCheck();
     command.runDepAndTypeChecks();
     command.runUnitTests();
-    command.verifyVisualDiffTests();
+    // command.verifyVisualDiffTests(); is flaky due to Amp By Example tests
     // command.testDocumentLinks() is skipped during push builds.
     command.buildValidatorWebUI();
     command.buildValidator();
@@ -382,7 +382,7 @@ function runAllCommandsLocally() {
   command.runVisualDiffTests();
   command.runUnitTests();
   command.runIntegrationTests(/* compiled */ false);
-  command.verifyVisualDiffTests();
+  // command.verifyVisualDiffTests(); is flaky due to Amp By Example tests
 
   // Validator tests.
   command.buildValidatorWebUI();


### PR DESCRIPTION
It frequently happens that a visual diff in one of the newly added amp-by-example pages causes `gulp visual-diff --verify` to either stall or fail on Travis.

With this PR, we continue to run the tests, but do not block when there are diffs. This is temporary, until we figure out a way to make the snapshots deterministic for a small handful of pages that seem like they have dynamic content.

See https://percy.io/ampproject/amphtml/builds/521098 for example

Follow up to #13411
Follow up to #13394