### PR TITLE
✅ Disable visual tests for pages with dynamic content

### DIFF
--- a/test/visual-diff/visual-tests.js
+++ b/test/visual-diff/visual-tests.js
@@ -183,10 +183,11 @@
       "url": "examples/visual-tests/amp-by-example/components/amp-carousel/index.html",
       "name": "amp-carousel - Amp By Example"
     },
-    {
-      "url": "examples/visual-tests/amp-by-example/components/amp-dailymotion/index.html",
-      "name": "amp-dailymotion - Amp By Example"
-    },
+    // Dynamic content. TODO(rsimha-amp, #13394): Make this deterministic.
+    // {
+    //   "url": "examples/visual-tests/amp-by-example/components/amp-dailymotion/index.html",
+    //   "name": "amp-dailymotion - Amp By Example"
+    // },
     {
       "url": "examples/visual-tests/amp-by-example/components/amp-date-picker/index.html",
       "name": "amp-date-picker - Amp By Example"
@@ -195,10 +196,11 @@
       "url": "examples/visual-tests/amp-by-example/components/amp-dynamic-css-classes/index.html",
       "name": "amp-dynamic-css-classes - Amp By Example"
     },
-    {
-      "url": "examples/visual-tests/amp-by-example/components/amp-experiment/index.html",
-      "name": "amp-experiment - Amp By Example"
-    },
+    // Dynamic content. TODO(rsimha-amp, #13394): Make this deterministic.
+    // {
+    //   "url": "examples/visual-tests/amp-by-example/components/amp-experiment/index.html",
+    //   "name": "amp-experiment - Amp By Example"
+    // },
     {
       "url": "examples/visual-tests/amp-by-example/components/amp-facebook/index.html",
       "name": "amp-facebook - Amp By Example"
@@ -223,10 +225,11 @@
       "url": "examples/visual-tests/amp-by-example/components/amp-fx-parallax/index.html",
       "name": "amp-fx-parallax - Amp By Example"
     },
-    {
-      "url": "examples/visual-tests/amp-by-example/components/amp-gfycat/index.html",
-      "name": "amp-gfycat - Amp By Example"
-    },
+    // Dynamic content. TODO(rsimha-amp, #13394): Make this deterministic.
+    // {
+    //   "url": "examples/visual-tests/amp-by-example/components/amp-gfycat/index.html",
+    //   "name": "amp-gfycat - Amp By Example"
+    // },
     {
       "url": "examples/visual-tests/amp-by-example/components/amp-gist/index.html",
       "name": "amp-gist - Amp By Example"
@@ -347,20 +350,14 @@
       "url": "examples/visual-tests/amp-by-example/components/amp-vimeo/index.html",
       "name": "amp-vimeo - Amp By Example"
     },
-    {
-      "url": "examples/visual-tests/amp-by-example/components/amp-vine/index.html",
-      "name": "amp-vine - Amp By Example"
-    },
+    // Dynamic content. TODO(rsimha-amp, #13394): Make this deterministic.
+    // {
+    //   "url": "examples/visual-tests/amp-by-example/components/amp-vine/index.html",
+    //   "name": "amp-vine - Amp By Example"
+    // },
     {
       "url": "examples/visual-tests/amp-by-example/components/amp-youtube/index.html",
       "name": "amp-youtube - Amp By Example"
     }
-  ],
-
-  /**
-   * List of failing webpages. Move pages here if they fail, since visual tests
-   * block PRs from being merged. Move them back once failures are fixed.
-   */
-  "failing_webpages": [
   ]
 }


### PR DESCRIPTION
#13394 added visual tests for all components on www.ampbyexample.com. It turns out that some of those pages have dynamic content, resulting in visual diffs. See https://percy.io/ampproject/amphtml/builds/521546

This PR disables those tests until we come up with a way of making the snapshots deterministic.

Follow up to #13394