### PR TITLE
🏗️ Add an eslint rule to prevent misuse of expect

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -36,6 +36,7 @@
     "arrow-parens": [2, "as-needed"],
     "arrow-spacing": 2,
     "chai-expect/missing-assertion": 2,
+    "chai-expect/no-inner-compare": 2,
     "chai-expect/terminating-properties": 2,
     "comma-dangle": [2, "always-multiline"],
     "computed-property-spacing": [2, "never"],

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,7 @@
 {
   "parser": "babel-eslint",
   "plugins": [
+    "chai-expect",
     "eslint-plugin-google-camelcase",
     "sort-imports-es6-autofix",
     "sort-requires"
@@ -34,6 +35,8 @@
     "array-bracket-spacing": [2, "never"],
     "arrow-parens": [2, "as-needed"],
     "arrow-spacing": 2,
+    "chai-expect/missing-assertion": 2,
+    "chai-expect/terminating-properties": 2,
     "comma-dangle": [2, "always-multiline"],
     "computed-property-spacing": [2, "never"],
     "curly": 2,

--- a/build-system/tasks/lint.js
+++ b/build-system/tasks/lint.js
@@ -133,7 +133,11 @@ function lint() {
 }
 
 
-gulp.task('lint', 'Validates against Google Closure Linter', lint,
+gulp.task(
+    'lint',
+    'Validates against Google Closure Linter',
+    ['update-packages'],
+    lint,
     {
       options: {
         'watch': '  Watches for changes in files, validates against the linter',

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "envify": "4.1.0",
     "escodegen": "1.9.0",
     "eslint": "4.17.0",
+    "eslint-plugin-chai-expect": "1.1.1",
     "eslint-plugin-google-camelcase": "0.0.2",
     "eslint-plugin-sort-imports-es6-autofix": "0.2.2",
     "eslint-plugin-sort-requires": "2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3486,6 +3486,10 @@ escope@^3.6.0:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
+eslint-plugin-chai-expect@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-chai-expect/-/eslint-plugin-chai-expect-1.1.1.tgz#cd640b8b38cf6c3abcc378673b7b173b99ddc70a"
+
 eslint-plugin-google-camelcase@0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-google-camelcase/-/eslint-plugin-google-camelcase-0.0.2.tgz#0c27555e4782073442d034a3db1f214ee0b37401"


### PR DESCRIPTION
This PR adds a couple of `.eslint` rules to prevent the misuse of `expect`. The plugin used is https://www.npmjs.com/package/eslint-plugin-chai-expect

See #13422 for why this was necessary, and https://github.com/ampproject/amphtml/issues/13422#issuecomment-364692277 for context around the new lint rules being added by this PR

Follow up to #13424
Fixes #13422 
