### PR TITLE
Change RTC macros to use AsyncResolver, add adCid macro, and count time

### DIFF
--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -1710,7 +1710,7 @@ export class AmpA4A extends AMP.BaseElement {
    * To be overriden by network impl. Should return a mapping of macro keys
    * to values for substitution in publisher-specified URLs for RTC.
    * @return {?Object<string,
-   *   !../../../src/service/variable-source.SyncResolverDef>}
+   *   !../../../src/service/variable-source.AsyncResolverDef>}
    */
   getCustomRealTimeConfigMacros_() {
     return null;

--- a/extensions/amp-a4a/0.1/real-time-config-manager.js
+++ b/extensions/amp-a4a/0.1/real-time-config-manager.js
@@ -50,14 +50,13 @@ export const RTC_ERROR_ENUM = {
 };
 
 /**
- * @param {!Array<!Promise<!rtcResponseDef>>} promiseArray
  * @param {string} error
  * @param {string} callout
  * @private
  */
-function logAndAddErrorResponse_(promiseArray, error, callout) {
+function logAndAddErrorResponse_(error, callout) {
   dev().warn(TAG, `Dropping RTC Callout to ${callout} due to ${error}`);
-  promiseArray.push(buildErrorResponse_(error, callout));
+  return buildErrorResponse_(error, callout);
 }
 
 /**
@@ -76,7 +75,7 @@ function buildErrorResponse_(error, callout, opt_rtcTime) {
  * For a given A4A Element, sends out Real Time Config requests to
  * any urls or vendors specified by the publisher.
  * @param {!AMP.BaseElement} a4aElement
- * @param {!Object<string, !../../../src/service/variable-source.SyncResolverDef>} customMacros The ad-network specified macro
+ * @param {!Object<string, !../../../src/service/variable-source.AsyncResolverDef>} customMacros The ad-network specified macro
  *   substitutions available to use.
  * @return {Promise<!Array<!rtcResponseDef>>|undefined}
  * @visibleForTesting
@@ -102,8 +101,8 @@ export function maybeExecuteRealTimeConfig_(a4aElement, customMacros) {
     const vendorObject = RTC_VENDORS[vendor.toLowerCase()];
     const url = vendorObject ? vendorObject.url : '';
     if (!url) {
-      return logAndAddErrorResponse_(promiseArray,
-          RTC_ERROR_ENUM.UNKNOWN_VENDOR, vendor);
+      return promiseArray.push(
+          logAndAddErrorResponse_(RTC_ERROR_ENUM.UNKNOWN_VENDOR, vendor));
     }
     const validVendorMacros = {};
     Object.keys(rtcConfig['vendors'][vendor]).forEach(macro => {
@@ -130,7 +129,7 @@ export function maybeExecuteRealTimeConfig_(a4aElement, customMacros) {
  * @param {!Object<string, boolean>} seenUrls
  * @param {!Array<!Promise<!rtcResponseDef>>} promiseArray
  * @param {number} rtcStartTime
- * @param {!Object<string, !../../../src/service/variable-source.SyncResolverDef>} macros
+ * @param {!Object<string, !../../../src/service/variable-source.AsyncResolverDef>} macros
  * @param {number} timeoutMillis
  * @param {string=} opt_vendor
  * @private
@@ -140,32 +139,46 @@ function inflateAndSendRtc_(a4aElement, url, seenUrls, promiseArray,
   opt_vendor) {
   const win = a4aElement.win;
   const ampDoc = a4aElement.getAmpDoc();
-  if (Object.keys(seenUrls).length == MAX_RTC_CALLOUTS) {
-    return logAndAddErrorResponse_(
-        promiseArray, RTC_ERROR_ENUM.MAX_CALLOUTS_EXCEEDED,
-        opt_vendor || url);
-  }
+  /**
+   * The time that it takes to substitute the macros into the URL can vary
+   * depending on what the url requires to be substituted, i.e. a long
+   * async call. Thus, however long the URL replacement took is treated as a
+   * time penalty.
+   */
+  const send = (url, timePenalty) => {
+    if (Object.keys(seenUrls).length == MAX_RTC_CALLOUTS) {
+      return logAndAddErrorResponse_(
+          RTC_ERROR_ENUM.MAX_CALLOUTS_EXCEEDED,
+          opt_vendor || url);
+    }
+    if (!isSecureUrl(url)) {
+      return logAndAddErrorResponse_(RTC_ERROR_ENUM.INSECURE_URL,
+          opt_vendor || url);
+    }
+    if (seenUrls[url]) {
+      return logAndAddErrorResponse_(RTC_ERROR_ENUM.DUPLICATE_URL,
+          opt_vendor || url);
+    }
+    seenUrls[url] = true;
+    if (url.length > MAX_URL_LENGTH) {
+      url = truncUrl_(url);
+    }
+    return sendRtcCallout_(
+        url, rtcStartTime, win, timeoutMillis - timePenalty, opt_vendor || url);
+  };
+
   if (macros && Object.keys(macros).length) {
     const urlReplacements = Services.urlReplacementsForDoc(ampDoc);
     const whitelist = {};
     Object.keys(macros).forEach(key => whitelist[key] = true);
-    url = urlReplacements.expandUrlSync(
-        url, macros, /** opt_collectVars */undefined, whitelist);
+    const urlReplacementStartTime = Date.now();
+    promiseArray.push(urlReplacements.expandUrlAsync(
+        url, macros, whitelist).then(url => {
+      return send(url, Date.now() - urlReplacementStartTime);
+    }));
+  } else {
+    promiseArray.push(send(url, 0));
   }
-  if (!isSecureUrl(url)) {
-    return logAndAddErrorResponse_(promiseArray, RTC_ERROR_ENUM.INSECURE_URL,
-        opt_vendor || url);
-  }
-  if (seenUrls[url]) {
-    return logAndAddErrorResponse_(promiseArray, RTC_ERROR_ENUM.DUPLICATE_URL,
-        opt_vendor || url);
-  }
-  seenUrls[url] = true;
-  if (url.length > MAX_URL_LENGTH) {
-    url = truncUrl_(url);
-  }
-  promiseArray.push(sendRtcCallout_(
-      url, rtcStartTime, win, timeoutMillis, opt_vendor || url));
 }
 
 /**

--- a/extensions/amp-a4a/0.1/real-time-config-manager.js
+++ b/extensions/amp-a4a/0.1/real-time-config-manager.js
@@ -171,9 +171,9 @@ export function inflateAndSendRtc_(a4aElement, url, seenUrls, promiseArray,
     promiseArray.push(Services.timerFor(win).timeoutPromise(
         timeoutMillis,
         urlReplacements.expandUrlAsync(url, macros, whitelist)).then(url => {
-          timeoutMillis -= (urlReplacementStartTime - Date.now());
-          return send(url);
-    }).catch(err => {
+      timeoutMillis -= (urlReplacementStartTime - Date.now());
+      return send(url);
+    }).catch(unused => {
       return buildErrorResponse_(RTC_ERROR_ENUM.MACRO_EXPAND_TIMEOUT,
           opt_vendor || url, undefined, true);
     }));

--- a/extensions/amp-a4a/0.1/real-time-config-manager.js
+++ b/extensions/amp-a4a/0.1/real-time-config-manager.js
@@ -168,9 +168,11 @@ export function inflateAndSendRtc_(a4aElement, url, seenUrls, promiseArray,
     const whitelist = {};
     Object.keys(macros).forEach(key => whitelist[key] = true);
     const urlReplacementStartTime = Date.now();
-    promiseArray.push(Services.timerFor(win).timeoutPromise(timeoutMillis,
+    promiseArray.push(Services.timerFor(win).timeoutPromise(
+        timeoutMillis,
         urlReplacements.expandUrlAsync(url, macros, whitelist)).then(url => {
-      return send(url);
+          timeoutMillis -= (urlReplacementStartTime - Date.now());
+          return send(url);
     }).catch(err => {
       return buildErrorResponse_(RTC_ERROR_ENUM.MACRO_EXPAND_TIMEOUT,
           opt_vendor || url, undefined, true);

--- a/extensions/amp-a4a/0.1/real-time-config-manager.js
+++ b/extensions/amp-a4a/0.1/real-time-config-manager.js
@@ -157,8 +157,11 @@ function inflateAndSendRtc_(a4aElement, url, seenUrls, promiseArray,
     if (url.length > MAX_URL_LENGTH) {
       url = truncUrl_(url);
     }
-    return sendRtcCallout_(
-        url, rtcStartTime, win, timeoutMillis - timePenalty, opt_vendor || url);
+    timeoutMillis -= timePenalty;
+    if (timeoutMillis > 0) {
+      return sendRtcCallout_(
+          url, rtcStartTime, win, timeoutMillis, opt_vendor || url);
+    }
   };
 
   if (macros && Object.keys(macros).length) {

--- a/extensions/amp-a4a/0.1/test/test-real-time-config-manager.js
+++ b/extensions/amp-a4a/0.1/test/test-real-time-config-manager.js
@@ -22,10 +22,12 @@ import '../../../amp-ad/0.1/amp-ad';
 import {AmpA4A} from '../amp-a4a';
 import {
   RTC_ERROR_ENUM,
+  inflateAndSendRtc_,
   maybeExecuteRealTimeConfig_,
   truncUrl_,
   validateRtcConfig_,
 } from '../real-time-config-manager';
+import {Services} from '../../../../src/services';
 import {Xhr} from '../../../../src/service/xhr-impl';
 import {createElementWithAttributes} from '../../../../src/dom';
 import {isFiniteNumber} from '../../../../src/types';
@@ -495,6 +497,30 @@ describes.realWin('real-time-config-manager', {amp: true}, env => {
       element.setAttribute('rtc-config', rtcConfig);
       validatedRtcConfig = validateRtcConfig_(element);
       expect(validatedRtcConfig).to.be.null;
+    });
+  });
+
+  describe('#inflateAndSendRtc_', () => {
+    it('should not send RTC if macro expansion exceeds timeout', () => {
+      const url = 'https://www.example.biz/?dummy=DUMMY';
+      const seenUrls = {};
+      const promiseArray = [];
+      const rtcStartTime = Date.now();
+      const timeoutMillis = 10;
+      const macroDelay = 20;
+      const macros = {
+        DUMMY: () => {
+          return Services.timerFor(env.win).promise(macroDelay).then(
+              () => {return 'foo';}
+          );
+        },
+      };
+      inflateAndSendRtc_(a4aElement, url, seenUrls, promiseArray,
+          rtcStartTime, macros, timeoutMillis);
+      return promiseArray[0].then(errorResponse => {
+        expect(errorResponse.error).to.equal(
+            RTC_ERROR_ENUM.MACRO_EXPAND_TIMEOUT);
+      });
     });
   });
 });

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -760,7 +760,8 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
             (tryParseJson(
                 this.element.getAttribute('json')) || {})['targeting']),
       ADCID: opt_timeout => getOrCreateAdCid(
-          this.getAmpDoc(), 'AMP_ECID_GOOGLE', '_ga', parseInt(opt_timeout, 10)),
+          this.getAmpDoc(), 'AMP_ECID_GOOGLE', '_ga',
+          parseInt(opt_timeout, 10)),
       ATTR: name => {
         if (!whitelist[name.toLowerCase()]) {
           dev().warn('TAG', `Invalid attribute ${name}`);

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -759,7 +759,8 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
         JSON.stringify(
             (tryParseJson(
                 this.element.getAttribute('json')) || {})['targeting']),
-      ADCID: () => getOrCreateAdCid(this.getAmpDoc(), 'AMP_ECID_GOOGLE', '_ga'),
+      ADCID: opt_timeout => getOrCreateAdCid(
+          this.getAmpDoc(), 'AMP_ECID_GOOGLE', '_ga', opt_timeout),
       ATTR: name => {
         if (!whitelist[name.toLowerCase()]) {
           dev().warn('TAG', `Invalid attribute ${name}`);

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -78,6 +78,7 @@ import {domFingerprintPlain} from '../../../src/utils/dom-fingerprint';
 import {getData} from '../../../src/event-helper';
 import {getMode} from '../../../src/mode';
 import {getMultiSizeDimensions} from '../../../ads/google/utils';
+import {getOrCreateAdCid} from '../../../src/ad-cid';
 import {
   googleLifecycleReporterFactory,
   setGoogleLifecycleVarsFromHeaders,
@@ -758,6 +759,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
         JSON.stringify(
             (tryParseJson(
                 this.element.getAttribute('json')) || {})['targeting']),
+      ADCID: () => getOrCreateAdCid(this.getAmpDoc(), 'AMP_ECID_GOOGLE', '_ga'),
       ATTR: name => {
         if (!whitelist[name.toLowerCase()]) {
           dev().warn('TAG', `Invalid attribute ${name}`);

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -760,7 +760,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
             (tryParseJson(
                 this.element.getAttribute('json')) || {})['targeting']),
       ADCID: opt_timeout => getOrCreateAdCid(
-          this.getAmpDoc(), 'AMP_ECID_GOOGLE', '_ga', opt_timeout),
+          this.getAmpDoc(), 'AMP_ECID_GOOGLE', '_ga', parseInt(opt_timeout, 10)),
       ATTR: name => {
         if (!whitelist[name.toLowerCase()]) {
           dev().warn('TAG', `Invalid attribute ${name}`);

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-rtc.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-rtc.js
@@ -312,6 +312,42 @@ describes.realWin('DoubleClick Fast Fetch RTC', {amp: true}, env => {
       Object.keys(macros).forEach(macro => {
         expect(customMacros.ATTR(macro)).to.equal(macros[macro]);
       });
+      return customMacros.ADCID().then(adcid => {
+        expect(adcid).to.not.be.null;
+      });
+    });
+
+    it('should return the same ADCID on multiple calls', () => {
+      element = createElementWithAttributes(env.win.document, 'amp-ad', {
+        type: 'doubleclick',
+      });
+      env.win.document.body.appendChild(element);
+      impl = new AmpAdNetworkDoubleclickImpl(
+          element, env.win.document, env.win);
+      impl.populateAdUrlState();
+      const customMacros = impl.getCustomRealTimeConfigMacros_();
+      let adcid;
+      return customMacros.ADCID().then(adcid1 => {
+        adcid = adcid1;
+        expect(adcid).to.not.be.null;
+        return customMacros.ADCID().then(adcid2 => {
+          expect(adcid2).to.equal(adcid);
+        });
+      });
+    });
+
+    it('should respect timeout for adcid', () => {
+      element = createElementWithAttributes(env.win.document, 'amp-ad', {
+        type: 'doubleclick',
+      });
+      env.win.document.body.appendChild(element);
+      impl = new AmpAdNetworkDoubleclickImpl(
+          element, env.win.document, env.win);
+      impl.populateAdUrlState();
+      const customMacros = impl.getCustomRealTimeConfigMacros_();
+      return customMacros.ADCID(0).then(adcid => {
+        expect(adcid).to.be.undefined;
+      });
     });
 
     it('should handle TGT macro when targeting not set', () => {

--- a/extensions/amp-ad-network-doubleclick-impl/doubleclick-rtc.md
+++ b/extensions/amp-ad-network-doubleclick-impl/doubleclick-rtc.md
@@ -17,6 +17,15 @@ AMP Real Time Config (RTC) is a feature of Fast Fetch that allows Publishers to 
 
 For instructions on how to set the rtc-config attribute on the amp-ad, refer to [Setting Up RTC-Config](https://github.com/ampproject/amphtml/blob/master/extensions/amp-a4a/rtc-publisher-implementation-guide.md#setting-up-rtc-config) in the Publisher Implementation Guide.
 
+## Available URL Macros
+Doubleclick's RTC implementation has made many macros available for RTC url expansion. Please note that the time to expand the URL is counted against the RTC timeout. Currently available macros are as follows:
+
+* **PAGEVIEWID**: pageViewId for the amp-ad element.
+* **HREF**: window.location.href
+* **TGT**: The JSON stringified targeting parameter extracted from the JSON attribute on the amp-ad element.
+* **ADCID**: The adClientId that corresponds to the given publisher page and DoubleClick. This adCid should be the same as used by AMP Analytics. IMPORTANT NOTE: This is an asynchronous call to use this macro, and can be slow. To impose a strict timeout, can pass an optional timeout. This is done in the url like: `https://www.foo.com/?adcid=ADCID(10)` where the passed timeout is in milliseconds.
+* **ATTR**: Makes various attributes on the amp-ad element available, by calling as ATTR(attribute). Currently available attributes are: height, width, data-slot, data-multi-size, data-multi-size-validation, data-override-width, data-override-height. 
+
 
 ## Response and Endpoint Specification
 

--- a/extensions/amp-ad-network-doubleclick-impl/doubleclick-rtc.md
+++ b/extensions/amp-ad-network-doubleclick-impl/doubleclick-rtc.md
@@ -18,13 +18,13 @@ AMP Real Time Config (RTC) is a feature of Fast Fetch that allows Publishers to 
 For instructions on how to set the rtc-config attribute on the amp-ad, refer to [Setting Up RTC-Config](https://github.com/ampproject/amphtml/blob/master/extensions/amp-a4a/rtc-publisher-implementation-guide.md#setting-up-rtc-config) in the Publisher Implementation Guide.
 
 ## Available URL Macros
-Doubleclick's RTC implementation has made many macros available for RTC url expansion. Please note that the time to expand the URL is counted against the RTC timeout. Currently available macros are as follows:
+Doubleclick's RTC implementation has made many macros available for RTC url expansion. Please note that the time to expand the URL is counted against the RTC timeout. Additionally, note that all RTC URLs are truncated at 16384 characters, so keep possible truncation in mind when determining which macros to include, and which order to include them in your URL. Currently available macros are as follows:
 
 * **PAGEVIEWID**: pageViewId for the amp-ad element.
 * **HREF**: window.location.href
 * **TGT**: The JSON stringified targeting parameter extracted from the JSON attribute on the amp-ad element.
 * **ADCID**: The adClientId that corresponds to the given publisher page and DoubleClick. This adCid should be the same as used by AMP Analytics. IMPORTANT NOTE: This is an asynchronous call to use this macro, and can be slow. To impose a strict timeout, can pass an optional timeout. This is done in the url like: `https://www.foo.com/?adcid=ADCID(10)` where the passed timeout is in milliseconds.
-* **ATTR**: Makes various attributes on the amp-ad element available, by calling as ATTR(attribute). Currently available attributes are: height, width, data-slot, data-multi-size, data-multi-size-validation, data-override-width, data-override-height. 
+* **ATTR**: Makes various attributes on the amp-ad element available, by calling as ATTR(attribute).If the attribute does not exist, returns empty string. Currently available attributes are: height, width, data-slot, data-multi-size, data-multi-size-validation, data-override-width, data-override-height.
 
 
 ## Response and Endpoint Specification

--- a/src/ad-cid.js
+++ b/src/ad-cid.js
@@ -17,6 +17,7 @@
 import {Services} from './services';
 import {adConfig} from '../ads/_config';
 import {dev} from '../src/log';
+import {isFiniteNumber} from '../src/types';
 
 /**
  * @param {AMP.BaseElement} adElement
@@ -37,10 +38,13 @@ export function getAdCid(adElement) {
  * @param {!./service/ampdoc-impl.AmpDoc|!Node} ampDoc
  * @param {string} clientIdScope
  * @param {string=} opt_clientIdCookieName
+ * @param {number=} opt_timeout
  * @return {!Promise<string|undefined>} A promise for a CID or undefined.
  */
 export function getOrCreateAdCid(
-  ampDoc, clientIdScope, opt_clientIdCookieName) {
+  ampDoc, clientIdScope, opt_clientIdCookieName, opt_timeout) {
+  const timeout = !!opt_timeout && isFiniteNumber(opt_timeout) ?
+    opt_timeout : 1000;
   const cidPromise = Services.cidForDoc(ampDoc).then(cidService => {
     if (!cidService) {
       return;
@@ -58,7 +62,7 @@ export function getOrCreateAdCid(
   // The CID should never be crucial for an ad. If it does not come within
   // 1 second, assume it will never arrive.
   return Services.timerFor(ampDoc.win)
-      .timeoutPromise(1000, cidPromise, 'cid timeout').catch(error => {
+      .timeoutPromise(timeout, cidPromise, 'cid timeout').catch(error => {
         // Timeout is not fatal.
         dev().warn('AD-CID', error);
         return undefined;

--- a/src/ad-cid.js
+++ b/src/ad-cid.js
@@ -17,7 +17,6 @@
 import {Services} from './services';
 import {adConfig} from '../ads/_config';
 import {dev} from '../src/log';
-import {isFiniteNumber} from '../src/types';
 
 /**
  * @param {AMP.BaseElement} adElement
@@ -42,9 +41,9 @@ export function getAdCid(adElement) {
  * @return {!Promise<string|undefined>} A promise for a CID or undefined.
  */
 export function getOrCreateAdCid(
-  ampDoc, clientIdScope, opt_clientIdCookieName, opt_timeout) {
-  const timeout = opt_timeout != undefined && isFiniteNumber(opt_timeout) ?
-    opt_timeout : 1000;
+    ampDoc, clientIdScope, opt_clientIdCookieName, opt_timeout) {
+  const timeout = isNaN(opt_timeout) || opt_timeout == null ?
+        1000 : opt_timeout;
   const cidPromise = Services.cidForDoc(ampDoc).then(cidService => {
     if (!cidService) {
       return;

--- a/src/ad-cid.js
+++ b/src/ad-cid.js
@@ -43,7 +43,7 @@ export function getAdCid(adElement) {
  */
 export function getOrCreateAdCid(
   ampDoc, clientIdScope, opt_clientIdCookieName, opt_timeout) {
-  const timeout = !!opt_timeout && isFiniteNumber(opt_timeout) ?
+  const timeout = opt_timeout != undefined && isFiniteNumber(opt_timeout) ?
     opt_timeout : 1000;
   const cidPromise = Services.cidForDoc(ampDoc).then(cidService => {
     if (!cidService) {

--- a/src/ad-cid.js
+++ b/src/ad-cid.js
@@ -41,9 +41,9 @@ export function getAdCid(adElement) {
  * @return {!Promise<string|undefined>} A promise for a CID or undefined.
  */
 export function getOrCreateAdCid(
-    ampDoc, clientIdScope, opt_clientIdCookieName, opt_timeout) {
+  ampDoc, clientIdScope, opt_clientIdCookieName, opt_timeout) {
   const timeout = isNaN(opt_timeout) || opt_timeout == null ?
-        1000 : opt_timeout;
+    1000 : opt_timeout;
   const cidPromise = Services.cidForDoc(ampDoc).then(cidService => {
     if (!cidService) {
       return;

--- a/src/service/variable-source.js
+++ b/src/service/variable-source.js
@@ -24,7 +24,7 @@ let ResolverReturnDef;
 export let SyncResolverDef;
 
 /** @typedef {function(...*):!Promise<ResolverReturnDef>} */
-let AsyncResolverDef;
+export let AsyncResolverDef;
 
 /** @typedef {{sync: SyncResolverDef, async: AsyncResolverDef}} */
 let ReplacementDef;


### PR DESCRIPTION
This PR does three things:

- Changes RTC's getCustomMacros to return AsyncResolverDef, instead of SyncResolverDef.
- Now counts the time it takes for URL macro replacement as part of the RTC timeout. 
- Adds adCid macro. 