### PR TITLE
fix amp-image-lightbox activation regression, update invocation source to caller

### DIFF
--- a/extensions/amp-image-lightbox/0.1/amp-image-lightbox.js
+++ b/extensions/amp-image-lightbox/0.1/amp-image-lightbox.js
@@ -800,7 +800,7 @@ class AmpImageLightbox extends AMP.BaseElement {
     }
     this.buildLightbox_();
 
-    const source = invocation.source;
+    const source = invocation.caller;
     user().assert(source && SUPPORTED_ELEMENTS_[source.tagName.toLowerCase()],
         'Unsupported element: %s', source.tagName);
 

--- a/extensions/amp-image-lightbox/0.1/test/test-amp-image-lightbox.js
+++ b/extensions/amp-image-lightbox/0.1/test/test-amp-image-lightbox.js
@@ -68,7 +68,7 @@ describes.realWin('amp-image-lightbox component', {
 
       const ampImage = doc.createElement('amp-img');
       ampImage.setAttribute('src', 'data:');
-      impl.activate({source: ampImage});
+      impl.activate({caller: ampImage});
 
       const container = lightbox
           .querySelector('.i-amphtml-image-lightbox-container');
@@ -117,7 +117,7 @@ describes.realWin('amp-image-lightbox component', {
 
       const ampImage = doc.createElement('amp-img');
       ampImage.setAttribute('src', 'data:');
-      impl.activate({source: ampImage});
+      impl.activate({caller: ampImage});
 
       expect(viewportOnChanged).to.be.calledOnce;
       expect(impl.unlistenViewport_).to.not.equal(null);
@@ -189,13 +189,13 @@ describes.realWin('amp-image-lightbox component', {
       ampImage.setAttribute('src', 'data:');
       ampImage.setAttribute('width', '100');
       ampImage.setAttribute('height', '100');
-      impl.activate({source: ampImage});
+      impl.activate({caller: ampImage});
       impl.closeOnEscape_({keyCode: KeyCodes.ESCAPE});
       expect(setupCloseSpy).to.be.calledOnce;
 
       // Regression test: ensure escape event listener is bound properly
       expect(nullAddEventListenerSpy).to.have.not.been.called;
-      impl.activate({source: ampImage});
+      impl.activate({caller: ampImage});
       expect(nullAddEventListenerSpy).to.have.not.been.called;
     });
   });
@@ -211,7 +211,7 @@ describes.realWin('amp-image-lightbox component', {
       const sourceElement = doc.createElement('amp-img');
       sourceElement.setAttribute('src', 'data:');
 
-      impl.activate({source: sourceElement});
+      impl.activate({caller: sourceElement});
       impl.close();
 
       expect(tryFocus).to.be.calledOnce;


### PR DESCRIPTION
The update of `invocation.source` to `invocation.caller` from https://github.com/ampproject/amphtml/pull/13128 also needs to be applied to `amp-image-lightbox`. 

Fixes https://github.com/ampproject/amp-by-example/issues/1158, which causes `<amp-image-lightbox>` to be completely unusable. 