### PR TITLE
✅ Fix desktop CSS width for visual diff tests

### DIFF
--- a/build-system/tasks/visual-diff.rb
+++ b/build-system/tasks/visual-diff.rb
@@ -29,8 +29,8 @@ require 'selenium/webdriver'
 
 ENV['PERCY_DEBUG'] = '0'
 ENV['WEBSERVER_QUIET'] = '--quiet'
-# CSS widths: iPhone: 375, Pixel: 411, Macbook Pro 15": 1440.
-DEFAULT_WIDTHS = [375, 411, 1440]
+# CSS widths: iPhone: 375, Pixel: 411, Desktop: 1400.
+DEFAULT_WIDTHS = [375, 411, 1400]
 HOST = 'localhost'
 PORT = '8000'
 WEBSERVER_TIMEOUT_SECS = 15


### PR DESCRIPTION
The AMP visual diff tests were using a desktop CSS width of 1440 px (as that's the standard width on a macbook pro). It turns out that the Percy service supports a max desktop CSS width of 1400 px. (See https://percy.io/docs/learn/responsive#limits)

This PR reduces the width from 1440 px to 1400 px. 