### PR TITLE
🏗️ Remove chalk and replace it with ansi-colors

### DIFF
--- a/build-system/tasks/check-links.js
+++ b/build-system/tasks/check-links.js
@@ -177,6 +177,7 @@ function runLinkChecker(markdownFile) {
 gulp.task(
     'check-links',
     'Detects dead links in markdown files',
+    ['update-packages'],
     checkLinks,
     {
       options: {

--- a/build-system/tasks/check-links.js
+++ b/build-system/tasks/check-links.js
@@ -17,7 +17,6 @@
 
 const argv = require('minimist')(process.argv.slice(2));
 const BBPromise = require('bluebird');
-const chalk = require('chalk');
 const colors = require('ansi-colors');
 const fs = require('fs-extra');
 const getStdout = require('../exec').getStdout;
@@ -71,9 +70,9 @@ function checkLinks() {
             if (result.status === 'dead') {
               deadLinksFound = true;
               deadLinksFoundInFile = true;
-              log('[%s] %s', chalk.red('✖'), result.link);
+              log('[%s] %s', colors.red('✖'), result.link);
             } else if (!process.env.TRAVIS) {
-              log('[%s] %s', chalk.green('✔'), result.link);
+              log('[%s] %s', colors.green('✔'), result.link);
             }
           });
           if (deadLinksFoundInFile) {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "browserify-istanbul": "3.0.1",
     "chai": "4.1.2",
     "chai-as-promised": "7.1.1",
-    "chalk": "2.3.0",
     "cli-highlight": "1.2.3",
     "connect-header": "0.0.5",
     "cssnano": "4.0.0-rc.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2021,14 +2021,6 @@ chai@4.1.2:
     pathval "^1.0.0"
     type-detect "^4.0.0"
 
-chalk@2.3.0, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.0.tgz#b5ea48efc9c1793dccc9b4767c93914d3f2d52ba"
-  dependencies:
-    ansi-styles "^3.1.0"
-    escape-string-regexp "^1.0.5"
-    supports-color "^4.0.0"
-
 chalk@^0.4.0, chalk@~0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-0.4.0.tgz#5199a3ddcd0c1efe23bc08c1b027b06176e0c64f"
@@ -2056,6 +2048,14 @@ chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
     has-ansi "^2.0.0"
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
+
+chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.0.tgz#b5ea48efc9c1793dccc9b4767c93914d3f2d52ba"
+  dependencies:
+    ansi-styles "^3.1.0"
+    escape-string-regexp "^1.0.5"
+    supports-color "^4.0.0"
 
 chardet@^0.4.0:
   version "0.4.2"


### PR DESCRIPTION
We don't need `chalk` since we already use `ansi-colors` everywhere else. This PR also makes #13431 redundant.