### PR TITLE
Force the 'data-embed-as' attribute to 'video' and make sure to show post text

### DIFF
--- a/3p/facebook.js
+++ b/3p/facebook.js
@@ -49,10 +49,16 @@ function getPostContainer(global, data) {
     setStyle(c, 'text-align', 'center');
   }
   const container = global.document.createElement('div');
-  const embedAs = data.embedAs || 'post';
+  let embedAs = data.embedAs || 'post';
   user().assert(['post', 'video'].indexOf(embedAs) !== -1,
       'Attribute data-embed-as  for <amp-facebook> value is wrong, should be' +
       ' "post" or "video" was: %s', embedAs);
+  // Force the `data-embed-as` attribute to 'video' and make sure to show the post's text.
+  if (data.href.indexOf('/videos/') > 0) {
+    embedAs = 'video';
+    container.setAttribute('data-embed-as', 'video');
+    container.setAttribute('data-show-text', 'true');
+  }
   container.className = 'fb-' + embedAs;
   container.setAttribute('data-href', data.href);
   return container;

--- a/build-system/amp.extern.js
+++ b/build-system/amp.extern.js
@@ -265,6 +265,7 @@ data.inViewport;
 data.numposts;
 data.orderBy;
 data.colorscheme;
+data.showText;
 
 // 3p code
 var twttr;

--- a/extensions/amp-facebook/0.1/test/test-amp-facebook.js
+++ b/extensions/amp-facebook/0.1/test/test-amp-facebook.js
@@ -125,6 +125,28 @@ describes.realWin('amp-facebook', {
     expect(fbVideo.getAttribute('data-href')).to.equal(fbVideoHref);
   });
 
+  it('adds fb-video element with `data-embed-as` and `data-show-text` ' +
+    'attributes set correctly', () => {
+    const div = doc.createElement('div');
+    div.setAttribute('id', 'c');
+    doc.body.appendChild(div);
+    win.context = {
+      tagName: 'AMP-FACEBOOK',
+    };
+
+    facebook(win, {
+      href: fbVideoHref,
+      width: 111,
+      height: 222,
+    });
+    const fbVideo = doc.body.getElementsByClassName('fb-video')[0];
+    expect(fbVideo).not.to.be.undefined;
+    expect(fbVideo.classList.contains('fb-video')).to.be.true;
+    expect(fbVideo.getAttribute('data-embed-as')).to.equal('video');
+    expect(fbVideo.getAttribute('data-show-text')).to.equal('true');
+  });
+
+
   it('removes iframe after unlayoutCallback', () => {
     return getAmpFacebook(fbPostHref).then(ampFB => {
       const iframe = ampFB.querySelector('iframe');


### PR DESCRIPTION
Fixes #12088 

It does so by:
- Forcing the `data-embed-as` for all videos to 'video'
- Since that disables post text, enables the ability to see the text by setting the `data-show-text` to 'true' (changed from the default 'false')
- Also adds a test to this effect

Initially the issue would repro when switching from desktop to mobile mode in Chrome devtools as well. 