### PR TITLE
🏗️ Don't install greenkeeper-lockfile on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,15 +13,12 @@ before_install:
   - export DISPLAY=:99.0
   - unset _JAVA_OPTIONS  # JVM heap sizes break closure compiler. #11203.
   - sh -e /etc/init.d/xvfb start
-  # Required due to https://github.com/greenkeeperio/greenkeeper-lockfile/issues/98#issuecomment-352087908
-  - export PATH="`yarn global bin`:$PATH"
-  - yarn global add greenkeeper-lockfile@1
 before_script:
   - pip install --user protobuf
   - gem install percy-capybara poltergeist selenium-webdriver chromedriver-helper
-  - greenkeeper-lockfile-update
+  - ./node_modules/.bin/greenkeeper-lockfile-update
 script: node build-system/pr-check.js
-after_script: greenkeeper-lockfile-upload
+after_script: ./node_modules/.bin/greenkeeper-lockfile-upload
 branches:
   only:
     - master

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "fetch-mock": "5.13.1",
     "formidable": "1.1.1",
     "fs-extra": "5.0.0",
+    "greenkeeper-lockfile": "1.13.2",
     "gulp": "3.9.1",
     "gulp-ava": "0.18.0",
     "gulp-batch-replace": "0.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4574,6 +4574,14 @@ graceful-fs@~1.2.0:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-1.2.3.tgz#15a4806a57547cb2d2dbf27f42e89a8c3451b364"
 
+greenkeeper-lockfile@1.13.2:
+  version "1.13.2"
+  resolved "https://registry.yarnpkg.com/greenkeeper-lockfile/-/greenkeeper-lockfile-1.13.2.tgz#3a225f6fef967fc558adf60f5ebfd192fe7d4618"
+  dependencies:
+    lodash "^4.17.4"
+    require-relative "^0.8.7"
+    semver "^5.3.0"
+
 growl@1.10.3:
   version "1.10.3"
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.3.tgz#1926ba90cf3edfe2adb4927f5880bc22c66c790f"
@@ -8941,6 +8949,10 @@ require-main-filename@^1.0.1:
 require-precompiled@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/require-precompiled/-/require-precompiled-0.1.0.tgz#5a1b52eb70ebed43eb982e974c85ab59571e56fa"
+
+require-relative@^0.8.7:
+  version "0.8.7"
+  resolved "https://registry.yarnpkg.com/require-relative/-/require-relative-0.8.7.tgz#7999539fc9e047a37928fa196f8e1563dabd36de"
 
 require-uncached@^1.0.3:
   version "1.0.3"


### PR DESCRIPTION
Instead of using `yarn` to separately install `greenkeeper-lockfile` on Travis, we add it to our existing list of `devDependencies` and invoke the binary from `./node_modules`. This should mitigate https://github.com/greenkeeperio/greenkeeper-lockfile/issues/109 and improve the reliability of Travis builds.