### PR TITLE
🏗️ Run lint checks on build-system/eslint-rules

### DIFF
--- a/build-system/config.js
+++ b/build-system/config.js
@@ -121,7 +121,6 @@ module.exports = {
     '!**/*.extern.js',
     '!{node_modules,build,dist,dist.3p,dist.tools,' +
         'third_party}/**/*.*',
-    '!build-system/eslint-rules/**/*.*',
     '!{testing,examples}/**/*.*',
     // TODO: temporary, remove when validator is up to date
     '!validator/**/*.*',

--- a/build-system/eslint-rules/dict-string-keys.js
+++ b/build-system/eslint-rules/dict-string-keys.js
@@ -20,7 +20,7 @@ module.exports = function(context) {
     CallExpression: function(node) {
       if (node.callee.name === 'dict') {
         if (node.arguments[0]) {
-          var arg1 = node.arguments[0];
+          const arg1 = node.arguments[0];
           if (arg1.type !== 'ObjectExpression') {
             context.report(node,
                 'calls to `dict` must have an Object Literal Expression as ' +
@@ -30,7 +30,7 @@ module.exports = function(context) {
           checkNode(arg1, context);
         }
       }
-    }
+    },
   };
 };
 

--- a/build-system/eslint-rules/enforce-private-props.js
+++ b/build-system/eslint-rules/enforce-private-props.js
@@ -71,6 +71,6 @@ module.exports = function(context) {
         context.report(node,
             'Property marked as private but has no trailing underscore.');
       }
-    }
-  }
+    },
+  };
 };

--- a/build-system/eslint-rules/no-array-destructuring.js
+++ b/build-system/eslint-rules/no-array-destructuring.js
@@ -19,6 +19,6 @@ module.exports = function(context) {
   return {
     ArrayPattern: function(node) {
       context.report(node, 'No Array destructuring allowed.');
-    }
+    },
   };
 };

--- a/build-system/eslint-rules/no-es2015-number-props.js
+++ b/build-system/eslint-rules/no-es2015-number-props.js
@@ -15,7 +15,7 @@
  */
 'use strict';
 
-var INVALID_PROPS = [
+const INVALID_PROPS = [
   'EPSILON',
   'MAX_SAFE_INTEGER',
   'MIN_SAFE_INTEGER',
@@ -39,6 +39,6 @@ module.exports = function(context) {
         context.report(node,
             'no ES2015 "Number" methods and properties allowed to be used.');
       }
-    }
+    },
   };
 };

--- a/build-system/eslint-rules/no-export-side-effect.js
+++ b/build-system/eslint-rules/no-export-side-effect.js
@@ -19,11 +19,11 @@ module.exports = function(context) {
   return {
     ExportNamedDeclaration: function(node) {
       if (node.declaration) {
-        var declaration = node.declaration;
+        const declaration = node.declaration;
         if (declaration.type === 'VariableDeclaration') {
           declaration.declarations
               .map(function(declarator) {
-                return declarator.init
+                return declarator.init;
               }).filter(function(init) {
                 return init && /(?:Call|New)Expression/.test(init.type);
               }).forEach(function(init) {

--- a/build-system/eslint-rules/no-for-of-statement.js
+++ b/build-system/eslint-rules/no-for-of-statement.js
@@ -19,6 +19,6 @@ module.exports = function(context) {
   return {
     ForOfStatement: function(node) {
       context.report(node, 'No for-of statement allowed.');
-    }
+    },
   };
 };

--- a/build-system/eslint-rules/no-global.js
+++ b/build-system/eslint-rules/no-global.js
@@ -15,16 +15,16 @@
  */
 'use strict';
 
-var astUtils = require('eslint/lib/ast-utils');
+const astUtils = require('eslint/lib/ast-utils');
 
-var GLOBALS = Object.create(null);
+const GLOBALS = Object.create(null);
 GLOBALS.window = 'Use `self` instead.';
 GLOBALS.document = 'Reference it as `self.document` or similar instead.';
 
 module.exports = function(context) {
   return {
     Identifier: function(node) {
-      var name = node.name;
+      const name = node.name;
       if (!(name in GLOBALS)) {
         return;
       }
@@ -37,16 +37,17 @@ module.exports = function(context) {
         return;
       }
 
-      var variable = astUtils.getVariableByName(context.getScope(), node.name);
+      const variable =
+          astUtils.getVariableByName(context.getScope(), node.name);
       if (variable.defs.length > 0) {
         return;
       }
 
-      var message = 'Forbidden global `' + node.name + '`.';
+      let message = 'Forbidden global `' + node.name + '`.';
       if (GLOBALS[name]) {
         message += ' ' + GLOBALS[name];
       }
       context.report(node, message);
-    }
+    },
   };
 };

--- a/build-system/eslint-rules/no-spread.js
+++ b/build-system/eslint-rules/no-spread.js
@@ -19,6 +19,6 @@ module.exports = function(context) {
   return {
     SpreadElement: function(node) {
       context.report(node, 'No spread element allowed.');
-    }
+    },
   };
 };

--- a/build-system/eslint-rules/todo-format.js
+++ b/build-system/eslint-rules/todo-format.js
@@ -28,6 +28,6 @@ module.exports = function(context) {
           }
         });
       }
-    }
+    },
   };
 };


### PR DESCRIPTION
We don't run `gulp lint` on `build-system/eslint-rules`. We probably should.

See https://github.com/ampproject/amphtml/pull/13449#pullrequestreview-96142015 for context.

This PR adds lint coverage for the directory and fixes all errors.