### PR TITLE
Doubleclick FF: launch exp for render on idle

### DIFF
--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -1379,7 +1379,7 @@ describes.realWin('additional amp-ad-network-doubleclick-impl',
           expect(impl.isIdleRender_).to.be.false;
         });
 
-        it('should return true if launch experiment enabled', () => {
+        it('should return 12 if launch experiment enabled', () => {
           forceExperimentBranch(impl.win, 'dfp_ff_render_idle_launch', 1);
           expect(impl.idleRenderOutsideViewport()).to.equal(12);
         });

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -1378,6 +1378,11 @@ describes.realWin('additional amp-ad-network-doubleclick-impl',
           expect(impl.idleRenderOutsideViewport()).to.be.false;
           expect(impl.isIdleRender_).to.be.false;
         });
+
+        it('should return true if launch experiment enabled', () => {
+          forceExperimentBranch(impl.win, 'dfp_ff_render_idle_launch', 1);
+          expect(impl.idleRenderOutsideViewport()).to.equal(12);
+        });
       });
 
       describe('idle renderNonAmpCreative', () => {


### PR DESCRIPTION
Allows for launch render on idle experiment for Doubleclick Fast Fetch once approved.  Will update documentation accordingly at the time.