### PR TITLE
🐛 Fix extension generator name in validation file

### DIFF
--- a/build-system/tasks/extension-generator/index.js
+++ b/build-system/tasks/extension-generator/index.js
@@ -91,7 +91,7 @@ tags: {  # <${name}>
   satisfies: "${name}"
   requires: "${name} extension .js script"
   attr_lists: "extended-amp-global"
-  spec_url: "https://www.ampproject.org/docs/reference/components/amp-hello-world"
+  spec_url: "https://www.ampproject.org/docs/reference/components/${name}"
   amp_layout: {
     supported_layouts: RESPONSIVE
   }


### PR DESCRIPTION
This PR bug fixes the spec url property not using the correct name for the extension to be generated.
