### PR TITLE
Doubleclick throttling: wake up ads sequentially

### DIFF
--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -901,7 +901,8 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     if (this.postAdResponseExperimentFeatures['render-idle-throttle'] &&
           this.isIdleRender_) {
       if (is3pThrottled(this.win)) {
-        return waitFor3pThrottle().then(() => super.renderNonAmpCreative());
+        return waitFor3pThrottle(this.win).then(
+            () => super.renderNonAmpCreative());
       } else {
         incrementLoadingAds(this.win);
         return super.renderNonAmpCreative(true);

--- a/extensions/amp-ad/0.1/concurrent-load.js
+++ b/extensions/amp-ad/0.1/concurrent-load.js
@@ -24,7 +24,7 @@ import {user} from '../../../src/log';
 const LOADING_ADS_WIN_ID_ = '3pla';
 
 /** @private {!Array<function()>} resolve when no 3p throttle */
-let throttlePromiseResolvers_ = [];
+const throttlePromiseResolvers_ = [];
 
 /**
  * @param {!Window} win
@@ -84,7 +84,7 @@ export function incrementLoadingAds(win, opt_loadingPromise) {
       .catch(() => {})
       .then(() => {
         if (!--win[LOADING_ADS_WIN_ID_]) {
-          throttlePromiseResolver = throttlePromiseResolvers_.shift();
+          const throttlePromiseResolver = throttlePromiseResolvers_.shift();
           if (throttlePromiseResolver !== undefined) {
             throttlePromiseResolver();
           }

--- a/extensions/amp-ad/0.1/test/test-concurrent-load.js
+++ b/extensions/amp-ad/0.1/test/test-concurrent-load.js
@@ -113,8 +113,8 @@ describes.realWin('concurrent-load', {}, env => {
     });
 
     it('should block if incremented', () => {
-      incrementLoadingAds(env.win);
       const start = Date.now();
+      incrementLoadingAds(env.win);
       return waitFor3pThrottle(env.win).then(
           () => expect(Date.now() - start).to.be.at.least(1000));
     });

--- a/extensions/amp-ad/0.1/test/test-concurrent-load.js
+++ b/extensions/amp-ad/0.1/test/test-concurrent-load.js
@@ -112,8 +112,7 @@ describes.realWin('concurrent-load', {}, env => {
       installTimerService(env.win);
     });
 
-    // TODO(jeffkaufman, #13422): this test was silently failing
-    it.skip('should block if incremented', () => {
+    it('should block if incremented', () => {
       incrementLoadingAds(env.win);
       const start = Date.now();
       return waitFor3pThrottle(env.win).then(
@@ -125,5 +124,19 @@ describes.realWin('concurrent-load', {}, env => {
       return waitFor3pThrottle(env.win).then(
           () => expect(Date.now() - start).to.be.at.most(50));
     });
+
+    it('should block 3x if incremented 3x times', function() {
+      // This test needs to wait 1s three times.
+      this.timeout(4000);
+      incrementLoadingAds(env.win);
+      const start = Date.now();
+      waitFor3pThrottle(env.win).then(
+          () => incrementLoadingAds(env.win));
+      waitFor3pThrottle(env.win).then(
+          () => incrementLoadingAds(env.win));
+      return waitFor3pThrottle(env.win).then(
+          () => expect(Date.now() - start).to.be.at.least(3000));
+    });
+
   });
 });


### PR DESCRIPTION
When throttling non-amp creatives the goal is that we wait at least one second between leading each one.  The current code is buggy, however, and if several creatives are waiting to be woken up it wakes them all up at once instead of waiting one second between each.  This switches us from a single Promise to a queue for waking up creatives that want to run.

I've extended the unit test to cover this case, and verified that it fails in the expected way without my change (it waits ~1s instead of the expected 3s: `expected 1001 to be at least 3000`).  I haven't been able to reproduce the buggy behavior on a real page yet, so I'm not completely convinced this is correct.