### PR TITLE
✨ Added maps protocol to allowed AMP ones

### DIFF
--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -1212,6 +1212,7 @@ tags: {
       allow_relative: true
       allowed_protocol: "ftp"
       allowed_protocol: "geo"
+      allowed_protocol: "maps"
       allowed_protocol: "http"
       allowed_protocol: "https"
       allowed_protocol: "mailto"


### PR DESCRIPTION
## 🐛 Issue:
Google Search Console retrives an error for AMP pages using **maps** protocol in hyperlinks. 
E.g.:
`<a href="maps:?daddr=Corso Mortara, 46 10154 Torino(TO)">Navlink</a>`

##  ✨ Solution: 
Added **maps** protocol to AMP pages allowed ones 
