### PR TITLE
🏗️ Enable headless mode for gulp test

### DIFF
--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -273,7 +273,7 @@ const command = {
     timedExecOrDie('gulp check-types');
   },
   runUnitTests: function() {
-    let cmd = 'gulp test --unit --nobuild';
+    let cmd = 'gulp test --unit --nobuild --headless';
     if (argv.files) {
       cmd = cmd + ' --files ' + argv.files;
     }
@@ -287,7 +287,7 @@ const command = {
   },
   runIntegrationTests: function(compiled) {
     // Integration tests on chrome, or on all saucelabs browsers if set up
-    let cmd = 'gulp test --nobuild --integration';
+    let cmd = 'gulp test --integration --nobuild';
     if (argv.files) {
       cmd = cmd + ' --files ' + argv.files;
     }
@@ -296,6 +296,8 @@ const command = {
     }
     if (!!process.env.SAUCE_USERNAME && !!process.env.SAUCE_ACCESS_KEY) {
       cmd += ' --saucelabs';
+    } else {
+      cmd += ' --headless';
     }
     timedExecOrDie(cmd);
   },

--- a/build-system/tasks/karma.conf.js
+++ b/build-system/tasks/karma.conf.js
@@ -121,6 +121,10 @@ module.exports = {
       // Dramatically speeds up iframe creation time.
       flags: ['--disable-extensions'],
     },
+    Chrome_no_extensions_headless: {
+      base: 'ChromeHeadless',
+      flags: ['--disable-extensions'],
+    },
     // SauceLabs configurations.
     // New configurations can be created here:
     // https://wiki.saucelabs.com/display/DOCS/Platform+Configurator#/

--- a/build-system/tasks/runtime-test.js
+++ b/build-system/tasks/runtime-test.js
@@ -60,6 +60,10 @@ function getConfig() {
   if (argv.ie) {
     return Object.assign({}, karmaDefault, {browsers: ['IE']});
   }
+  if (argv.headless) {
+    return Object.assign({}, karmaDefault,
+        {browsers: ['Chrome_no_extensions_headless']});
+  }
   if (argv.saucelabs || argv.saucelabs_lite) {
     if (!process.env.SAUCE_USERNAME) {
       throw new Error('Missing SAUCE_USERNAME Env variable');
@@ -156,7 +160,8 @@ function printArgvMessages() {
     compiled: 'Running tests against minified code.',
     grep: 'Only running tests that match the pattern "' +
         cyan(argv.grep) + '".',
-    coverage: 'Runing tests in code coverage mode.',
+    coverage: 'Running tests in code coverage mode.',
+    headless: 'Running tests in a headless Chrome window.',
   };
   if (!process.env.TRAVIS) {
     log(green('Run'), cyan('gulp help'),
@@ -171,6 +176,10 @@ function printArgvMessages() {
     if (!argv.testnames && !argv.files) {
       log(green('⤷ Use'), cyan('--testnames'),
           green('to see the names of all tests being run.'));
+    }
+    if (!argv.headless) {
+      log(green('⤷ Use'), cyan('--headless'),
+          green('to run tests in a headless Chrome window.'));
     }
     if (!argv.compiled) {
       log(green('Running tests against unminified code.'));
@@ -419,5 +428,6 @@ gulp.task('test', 'Runs tests', preTestTasks, function() {
     'a4a': '  Runs all A4A tests',
     'config': '  Sets the runtime\'s AMP config to one of "prod" or "canary"',
     'coverage': '  Run tests in code coverage mode',
+    'headless': '  Run tests in a headless Chrome window',
   },
 });


### PR DESCRIPTION
This PR does the following:
1. Adds the `--headless` flag to `gulp test`. With this, you can run tests on local Chrome in headless mode.
2. `build-system/pr-check.js` will run `gulp test --headless` by default when using local Chrome.
3. Running `gulp test` will offer a suggestion to add the `--headless` flag to your invocation.

Partial fix for #13402