### PR TITLE
Updated adtech.md

### DIFF
--- a/ads/adtech.md
+++ b/ads/adtech.md
@@ -30,14 +30,14 @@ limitations under the License.
 For semantics of configuration, please see ad network documentation.
 
 ### Required Parameters:
-* `data-atwMN` - magic number for the ad spot
+* `data-atwMN` - magic number (placement alias) for the ad spot
 * `data-atwDiv` - div name of the ad spot; can be class or id
 
 ### Optional parameters:
 * `data-atwPlId` - placement ID (instead of Magic Number)
 * `data-atwOthAT` - generic var to set key/value pairs to send with the ad call; accepts mulitple values in a semi-colon delimited list
 * `data-atwCo` - override default country code
-* `data-atwHtNmAT` - override ad host name
+* `data-atwHtNmAT` - override ad host name (`adserver.adtech.de`, `adserver.adtechus.com`, default: `at.atwola.com`)
 * `data-atwNetId` - network ID
 * `data-atwWidth` - ad width (use with atwHeight only if the ad is not 300x250)
 * `data-atwHeight`- ad height (use with atwWidth only if the ad is not 300x250)


### PR DESCRIPTION
 - 📖 Clarified "Magic Number" with the term "Alias"
 - 📖  Added examples for hostnames

Confusion over the term "Magic Number". In the ADTECH frontend, it is referred to as "alias".
Default hostname is `at.atwola.com`. Most setups require the EU/US endpoints `adserver.adtech.de`/`adserver.adtechus.com`
