### PR TITLE
Rename AMP-to-AMP linking message from a2a to a2aNavigate

### DIFF
--- a/examples/viewer-iframe-poll.html
+++ b/examples/viewer-iframe-poll.html
@@ -403,7 +403,7 @@
         case 'tick':
           log('[CSI] tick. label:', data.label);
           return Promise.resolve();
-        case 'a2a':
+        case 'a2aNavigate':
           log('a2a navigation', data);
           return Promise.resolve();
         case 'sendCsi':

--- a/examples/viewer-webview.html
+++ b/examples/viewer-webview.html
@@ -404,7 +404,7 @@
         case 'tick':
           log('[CSI] tick. label:', data.label);
           return Promise.resolve();
-        case 'a2a':
+        case 'a2aNavigate':
           log('a2a navigation', data);
           return Promise.resolve();
         case 'sendCsi':

--- a/examples/viewer.html
+++ b/examples/viewer.html
@@ -402,7 +402,7 @@
         case 'tick':
           log('[CSI] tick. label:', data.label);
           return Promise.resolve();
-        case 'a2a':
+        case 'a2aNavigate':
           log('a2a navigation', data);
           return Promise.resolve();
         case 'sendCsi':

--- a/extensions/amp-viewer-integration/0.1/test/viewer-initiated-handshake-viewer-for-testing.js
+++ b/extensions/amp-viewer-integration/0.1/test/viewer-initiated-handshake-viewer-for-testing.js
@@ -186,7 +186,7 @@ export class WebviewViewerForTesting {
       case 'tick':
       case 'sendCsi':
       case 'scroll':
-      case 'a2a':
+      case 'a2aNavigate':
       case 'unloaded':
       case 'visibilitychange':
         return;

--- a/extensions/amp-viewer-integration/0.1/test/webview-viewer-for-testing.js
+++ b/extensions/amp-viewer-integration/0.1/test/webview-viewer-for-testing.js
@@ -232,7 +232,7 @@ export class WebviewViewerForTesting {
       case 'tick':
       case 'sendCsi':
       case 'scroll':
-      case 'a2a':
+      case 'a2aNavigate':
       case 'unloaded':
       case 'visibilitychange':
         return;

--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -474,7 +474,7 @@ export class Viewer {
    */
   navigateToAmpUrl(url, requestedBy) {
     if (this.hasCapability('a2a')) {
-      this.sendMessage('a2a', dict({
+      this.sendMessage('a2aNavigate', dict({
         'url': url,
         'requestedBy': requestedBy,
       }));

--- a/test/functional/test-viewer.js
+++ b/test/functional/test-viewer.js
@@ -1429,7 +1429,7 @@ describe('Viewer', () => {
       const viewer = new Viewer(ampdoc);
       const send = sandbox.stub(viewer, 'sendMessage');
       const result = viewer.navigateToAmpUrl(ampUrl, 'abc123');
-      expect(send.lastCall.args[0]).to.equal('a2a');
+      expect(send.lastCall.args[0]).to.equal('a2aNavigate');
       expect(send.lastCall.args[1]).to.jsonEqual({
         url: ampUrl,
         requestedBy: 'abc123',


### PR DESCRIPTION
Renaming this message after offline discussions with @choumx 

Original implementation in #13300 