### PR TITLE
Wrap inabox host in try/catch

### DIFF
--- a/ads/inabox/inabox-host.js
+++ b/ads/inabox/inabox-host.js
@@ -55,26 +55,28 @@ export class InaboxHost {
           win[INABOX_IFRAMES]);
       win[INABOX_IFRAMES] = [];
     }
-    const host = new InaboxMessagingHost(win, win[INABOX_IFRAMES]);
+    try {
+      const host = new InaboxMessagingHost(win, win[INABOX_IFRAMES]);
 
-    const queuedMsgs = win[PENDING_MESSAGES];
-    if (queuedMsgs) {
-      if (Array.isArray(queuedMsgs)) {
-        queuedMsgs.forEach(message => {
-          try {
-            host.processMessage(message);
-          } catch (err) {
-            dev().error(TAG, 'Error processing inabox message', message, err);
-          }
-        });
-      } else {
-        dev().info(TAG, `Invalid ${PENDING_MESSAGES}`, queuedMsgs);
+      const queuedMsgs = win[PENDING_MESSAGES];
+      if (queuedMsgs) {
+        if (Array.isArray(queuedMsgs)) {
+          queuedMsgs.forEach(message => {
+            try {
+              host.processMessage(message);
+            } catch (err) {
+              dev().error(TAG, 'Error processing inabox message', message, err);
+            }
+          });
+        } else {
+          dev().info(TAG, `Invalid ${PENDING_MESSAGES}`, queuedMsgs);
+        }
       }
-    }
-    // Empty and ensure that future messages are no longer stored in the array.
-    win[PENDING_MESSAGES] = [];
-    win[PENDING_MESSAGES]['push'] = () => {};
-    win.addEventListener('message', host.processMessage.bind(host));
+      // Empty and ensure that future messages are no longer stored in the array.
+      win[PENDING_MESSAGES] = [];
+      win[PENDING_MESSAGES]['push'] = () => {};
+      win.addEventListener('message', host.processMessage.bind(host));
+    } catch (unused) {}
   }
 }
 

--- a/ads/inabox/inabox-messaging-host.js
+++ b/ads/inabox/inabox-messaging-host.js
@@ -29,7 +29,6 @@ import {layoutRectFromDomRect} from '../../src/layout-rect';
 const TAG = 'InaboxMessagingHost';
 
 
-
 /** Simple helper for named callbacks. */
 class NamedObservable {
 
@@ -96,26 +95,28 @@ export class InaboxMessagingHost {
    * @return {boolean} true if message get successfully processed
    */
   processMessage(message) {
-    const request = deserializeMessage(getData(message));
-    if (!request || !request['sentinel']) {
-      dev().fine(TAG, 'Ignored non-AMP message:', message);
-      return false;
-    }
+    try {
+      const request = deserializeMessage(getData(message));
+      if (!request || !request['sentinel']) {
+        dev().fine(TAG, 'Ignored non-AMP message:', message);
+        return false;
+      }
 
-    const iframe =
-        this.getFrameElement_(message.source, request['sentinel']);
-    if (!iframe) {
-      dev().info(TAG, 'Ignored message from untrusted iframe:', message);
-      return false;
-    }
+      const iframe =
+            this.getFrameElement_(message.source, request['sentinel']);
+      if (!iframe) {
+        dev().info(TAG, 'Ignored message from untrusted iframe:', message);
+        return false;
+      }
 
-    if (!this.msgObservable_.fire(request['type'], this,
-        [iframe, request, message.source, message.origin])) {
-      dev().warn(TAG, 'Unprocessed AMP message:', message);
-      return false;
-    }
+      if (!this.msgObservable_.fire(request['type'], this,
+          [iframe, request, message.source, message.origin])) {
+        dev().warn(TAG, 'Unprocessed AMP message:', message);
+        return false;
+      }
 
-    return true;
+      return true;
+    } catch (unused) {}
   }
 
   /**
@@ -128,7 +129,7 @@ export class InaboxMessagingHost {
   handleSendPositions_(iframe, request, source, origin) {
     const viewportRect = this.positionObserver_.getViewportRect();
     const targetRect =
-        layoutRectFromDomRect(iframe./*OK*/getBoundingClientRect());
+          layoutRectFromDomRect(iframe./*OK*/getBoundingClientRect());
     this.sendPosition_(request, source, origin, dict({
       'viewportRect': viewportRect,
       'targetRect': targetRect,


### PR DESCRIPTION
We are getting notified by some partners that they are seeing (very infrequently) an error with postMessage not being available. While there is more we can do here, we need to start by wrapping to make sure user visible errors are not bubbling up. 