### PR TITLE
Improving/cleaning up docs for lightbox-related components

### DIFF
--- a/extensions/amp-image-lightbox/amp-image-lightbox.md
+++ b/extensions/amp-image-lightbox/amp-image-lightbox.md
@@ -19,7 +19,7 @@ limitations under the License.
 <table>
   <tr>
     <td width="40%"><strong>Description</strong></td>
-    <td>Allows for a “image lightbox” or similar experience where upon user interaction, an image expands to fill the viewport until it is closed again by the user.</td>
+    <td>Provides a lightbox effect for a specified image.</td>
   </tr>
   <tr>
     <td width="40%"><strong>Required Script</strong></td>
@@ -31,7 +31,7 @@ limitations under the License.
   </tr>
   <tr>
     <td width="40%"><strong>Examples</strong></td>
-    <td><a href="https://ampbyexample.com/components/amp-image-lightbox/">Annotated code example for amp-image-lightbox</a></td>
+    <td>See AMP By Example's <a href="https://ampbyexample.com/components/amp-image-lightbox/">amp-image-lightbox</a> sample.</td>
   </tr>
 </table>
 
@@ -39,70 +39,122 @@ limitations under the License.
 
 ## Behavior
 
-The typical scenario looks like this:
+The `amp-image-lightbox` component provides a lightbox experience for a specified image. When the user clicks the image, the image displays in the center of a full-viewport lightbox.
+
+#### Typical usage
+
+The following is a typical example using an `amp-image-lightbox`:
+
 ```html
-<amp-img
-    on="tap:lightbox1"
+<amp-image-lightbox id="lightbox1" layout="nodisplay"></amp-image-lightbox>
+<amp-img on="tap:lightbox1"
     role="button"
     tabindex="0"
-    src="image1" width=200 height=100></amp-img>
-<amp-image-lightbox id="lightbox1" layout="nodisplay"></amp-image-lightbox>
+    src="image1.jpg"
+    width="200" height="100"></amp-img>
 ```
 
-The `amp-image-lightbox` is activated using [`on`](https://github.com/ampproject/amphtml/blob/master/spec/amp-html-format.md#on) action on the `amp-img` element
-by referencing the lightbox element's ID. When activated, it places the image in
-the center of the full-viewport lightbox. Notice that any number of images in
-the article can use the same `amp-image-lightbox`. The `amp-image-lightbox`
-element itself must be empty and have `layout=nodisplay` set.
+When the user clicks the image, the `<amp-img>` activates the `<amp-image-lightbox>` via the [`on`](https://www.ampproject.org/docs/reference/spec#on) action, which references the ID of the `<amp-image-lightbox>` element (i.e., `lightbox1`). The `<amp-image-lightbox>` then displays the image in the center of the full-viewport lightbox. Note that the `amp-image-lightbox` element itself must be empty and must be set to `layout=nodisplay`.
 
-The `amp-image-lightbox` also can optionally display a caption for the image
-at the bottom of the viewport. The caption is discovered as following:
- 1. The contents of the `<figcaption>` element when image is in the `figure` tag.
- 2. The contents of the element whose ID is specified by the image's
-  `aria-describedby` attribute.
+Among other things the `amp-image-lightbox` allows the following user manipulations: zooming, panning, showing/hiding of the description.
+Pressing the escape key on a keyboard closes the lightbox.
 
-Among other things the `amp-image-lightbox` allows the following user manipulations:
-zooming, panning, showing/hiding of the description.
-Pressing the escape key on the keyboard will close the lightbox.
+*Using a single lightbox for multiple images*
 
-## Styling
+You can use the same `amp-image-lightbox` for more than one image on the AMP page.
 
-The `amp-image-lightbox` component can be styled with standard CSS. Some of the
-properties that can be styled are `background` and `color`.
-
-The `amp-image-lightbox-caption` class is also available to style the caption
-section.
-
-## Actions
-The `amp-image-lightbox` exposes the following actions you can use [AMP on-syntax to trigger](https://github.com/ampproject/amphtml/blob/master/spec/amp-actions-and-events.md):
-
-<table>
-  <tr>
-    <th>Action</th>
-    <th>Description</th>
-  </tr>
-  <tr>
-    <td>(default)</td>
-    <td>Opens the image lightbox with the source image being the one that triggered the action.</td>
-  </tr>
-</table>
-
-### Examples
+In this example, two images display: a cat and a frog.  When the user clicks either image, the image displays in the lightbox.
 
 ```html
-<amp-img on="tap:lightbox1" role="button" tabindex="0" src="image1" width=200 height=100></amp-img>
 <amp-image-lightbox id="lightbox1" layout="nodisplay"></amp-image-lightbox>
+
+<amp-img on="tap:lightbox1"
+    role="button"
+    tabindex="0"
+    src="/img/frog.jpg"
+    layout="responsive"
+    width="360" height="360"></amp-img>
+  
+<amp-img on="tap:lightbox1"
+    role="button"
+    tabindex="0"
+    src="/img/cat.jpg"
+    layout="responsive"
+    width="360" height="360"></amp-img>
+```
+
+### Captions
+
+Optionally, you can display captions at the bottom of the viewport for the image. The `<amp-image-lightbox>` components determines the content for the caption as follows:
+
+1.  If the image is in a `figure` tag, the content of the `<figcaption>` displays for the caption.
+2.  If the image specifies an `aria-describedby` attribute, the content of the element whose ID is specified by the `aria-describedby`attribute displays for the caption.
+
+*Examples: Using captions*
+```html
+<!-- Captions via figcaption -->
+<figure>
+  <amp-img on="tap:lightbox1"
+      role="button"
+      tabindex="0"
+      src="dog.jpg"
+      layout="responsive"
+      width="300" height="246"></amp-img>
+  <figcaption>Border Collie</figcaption>
+</figure>
+
+<!-- Captions via aria-describedby -->
+<div>
+  <amp-img on="tap:lightbox1"
+      role="button"
+      tabindex="0"
+      src="dog.jpg"
+      aria-describedby="imageDescription"
+      layout="responsive"
+      width="300" height="246"></amp-img>
+   <div id="imageDescription">This is a border collie.</div>
+</div>
 ```
 
 ## Attributes
 
-##### layout
+##### layout (required)
 
 Must be set to `nodisplay`.
 
-##### data-close-button-aria-label
+##### id (required)
 
-Optional string used as ARIA label for close button.
+The ID for the lightbox element that's used as a target for the image's `on` action.
+
+##### data-close-button-aria-label (optional)
+
+An ARIA label that you can use for a close button.
+
+```html
+<amp-image-lightbox id="image-lightbox1" layout="nodisplay" 
+    data-close-button-aria-label="Close"></amp-image-lightbox>
+```
+
+## Styling
+
+You can style the `amp-image-lightbox` component with standard CSS. Some of the
+properties that can be styled are `background` and `color`. The `amp-image-lightbox-caption` class is also available to style the caption
+section.
+
+## Actions
+
+The `amp-image-lightbox` exposes the following actions you can use [AMP on-syntax to trigger](https://www.ampproject.org/docs/reference/amp-actions-and-events):
+
+<table>
+  <tr>
+    <th width="20%">Action</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td>open (default)</td>
+    <td>Opens the image lightbox with the source image being the one that triggered the action.</td>
+  </tr>
+</table>
 
 ## Validation
 

--- a/extensions/amp-lightbox-gallery/amp-lightbox-gallery.md
+++ b/extensions/amp-lightbox-gallery/amp-lightbox-gallery.md
@@ -34,6 +34,10 @@ limitations under the License.
     <td class="col-fourty"><strong><a href="https://www.ampproject.org/docs/guides/responsive/control_layout.html">Supported Layouts</a></strong></td>
     <td>nodisplay</td>
   </tr>
+  <tr>
+    <td width="40%"><strong>Examples</strong></td>
+    <td>See AMP By Example's <a href="https://ampbyexample.com/components/amp-lightbox-gallery/">amp-lightbox-gallery</a> sample.</td>
+  </tr>
 </table>
 
 ## Overview
@@ -47,11 +51,12 @@ To use `amp-lightbox-gallery`, ensure the required script is included in your `<
 ### Lightbox with `<amp-img>`
 
 ```html
-<amp-img src="image1" width="200" height="100" lightbox></amp-img>
-<amp-img src="image2" width="200" height="100" lightbox></amp-img>
+<amp-img src="cat.jpg" width="100" height="100" lightbox></amp-img>
+<amp-img src="dog.jpg" width="100" height="100" lightbox></amp-img>
+<amp-img src="bird.jpg" width="100" height="100" lightbox></amp-img>
 ```
 
- Tapping on any `<amp-img>` will open the image in a lightbox gallery. The lightbox gallery does image-handling (e.g. zoom and pan), enables swiping to navigate between images, and offers a thumbnail gallery view for browsing all picture thumbnails in a grid.
+Tapping on any `<amp-img>` opens the image in a lightbox gallery. The lightbox gallery does image-handling (e.g., zoom and pan), enables swiping to navigate between images, and offers a thumbnail gallery view for browsing all picture thumbnails in a grid.
 
 ### Lightbox with `<amp-carousel>`
 

--- a/extensions/amp-lightbox/amp-lightbox.md
+++ b/extensions/amp-lightbox/amp-lightbox.md
@@ -19,7 +19,7 @@ limitations under the License.
 <table>
   <tr>
     <td width="40%"><strong>Description</strong></td>
-    <td>Allows for a “lightbox” or similar experience where upon user interaction, a component expands to fill the viewport until it is closed again by the user.</td>
+    <td>Displays elements in a full-viewport “lightbox” modal.</td>
   </tr>
   <tr>
     <td width="40%"><strong>Required Script</strong></td>
@@ -31,7 +31,7 @@ limitations under the License.
   </tr>
   <tr>
     <td width="40%"><strong>Examples</strong></td>
-    <td><a href="https://ampbyexample.com/components/amp-lightbox/">Annotated code example for amp-lightbox</a></td>
+    <td>See AMP By Example's <a href="https://ampbyexample.com/components/amp-lightbox/">amp-lightbox</a> sample.</td>
   </tr>
 </table>
 
@@ -39,54 +39,22 @@ limitations under the License.
 
 ## Behavior
 
-The `amp-lightbox` component defines the child elements that will be displayed in a full-viewport overlay. It is triggered to take up the viewport when the user taps or clicks on an element with `on` attribute that targets `amp-lightbox` element’s `id`.
+The `amp-lightbox` component defines child elements that display in a full-viewport overlay/modal. When the user taps or clicks an element (e.g., a button), the `amp-lightbox` ID referenced in the clicked element's `on` attribute triggers the lightbox to take up the full viewport and displays the child elements of the `amp-lightbox`.
 
-### Closing the lightbox
-Pressing the escape key on the keyboard will close the lightbox.
-Alternatively setting the `on` attribute on one or more elements within the lightbox and setting its method to `close` will close the lightbox when the element is tapped or clicked.
-
-Example:
-```html
-<button on="tap:my-lightbox">Open lightbox</button>
-
-<amp-lightbox id="my-lightbox" layout="nodisplay">
-  <div class="lightbox">
-    <amp-img src="my-full-image.jpg" width=300 height=800 on="tap:my-lightbox.close">
-  </div>
-</amp-lightbox>
-```
-
-## Styling
-
-The `amp-lightbox` component can be styled with standard CSS.
-
-## Actions
-The `amp-lightbox` exposes the following actions you can use [AMP on-syntax to trigger](https://github.com/ampproject/amphtml/blob/master/spec/amp-actions-and-events.md):
-
-<table>
-  <tr>
-    <th>Action</th>
-    <th>Description</th>
-  </tr>
-  <tr>
-    <td>open (default)</td>
-    <td>Opens the lightbox</td>
-  </tr>
-  <tr>
-    <td>close</td>
-    <td>Closes the lightbox</td>
-  </tr>
-</table>
-
-### Examples
+Pressing the escape key on the keyboard closes the lightbox. Alternatively, setting the `on` attribute on one or more elements within the lightbox and setting its method to `close` closes the lightbox when the element is tapped or clicked.
 
 ```html
-<button on="tap:tweets-lb">See Quote</button>
-<amp-lightbox id="tweets-lb" layout="nodisplay">
+<button on="tap:quote-lb">See Quote</button>
+<amp-lightbox id="quote-lb" layout="nodisplay">
     <blockquote>"Don't talk to me about JavaScript fatigue" - Horse JS</blockquote>
-    <button on="tap:tweets-lb.close">Nice!</button>
+    <button on="tap:quote-lb.close">Nice!</button>
 </amp-lightbox>
 ```
+
+{% call callout('Read on', type='read') %}
+For showing images in a lightbox, there's also the [`<amp-image-lightbox>`](https://www.ampproject.org/docs/reference/components/amp-lightbox) component.
+{% endcall %}
+
 
 ## Attributes
 
@@ -94,14 +62,35 @@ The `amp-lightbox` exposes the following actions you can use [AMP on-syntax to t
 
 A unique identifer for the lightbox.
 
-##### layout
+##### layout (required)
 
 Must be set to `nodisplay`.
 
-##### scrollable
+##### scrollable (optional)
 
-When `scrollable` attribute is present, the content of the lightbox can scroll
-when overflowing the height of the lightbox.
+When the `scrollable` attribute is present, the content of the lightbox can scroll when overflowing the height of the lightbox.
+
+## Styling
+
+You can style the `amp-lightbox` with standard CSS.
+
+## Actions
+The `amp-lightbox` exposes the following actions you can use [AMP on-syntax to trigger](https://www.ampproject.org/docs/reference/amp-actions-and-events):
+
+<table>
+  <tr>
+    <th width="20%">Action</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td><code>open</code> (default)</td>
+    <td>Opens the lightbox.</td>
+  </tr>
+  <tr>
+    <td><code>close</code></td>
+    <td>Closes the lightbox.</td>
+  </tr>
+</table>
 
 ## Validation
 


### PR DESCRIPTION
Wanted to clean up the wording in the "lightbox" elements.  Knowing that these will likely change with lightbox 2.0; but for the moment at least provide cleaner docs and snippets.