### PR TITLE
Inabox: position fixed not use scroll left/top

### DIFF
--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -18,6 +18,7 @@ import {AmpEvents} from '../amp-events';
 import {Layout} from '../layout';
 import {computedStyle, toggle} from '../style';
 import {dev} from '../log';
+import {getMode} from '../mode';
 import {isExperimentOn} from '../experiments';
 import {
   layoutRectLtwh,
@@ -471,10 +472,11 @@ export class Resource {
     }
     this.isFixed_ = isFixed;
 
-    if (isFixed) {
+    if (isFixed && getMode(this.hostWin).runtime != 'inabox') {
       // For fixed position elements, we need the relative position to the
       // viewport. When accessing the layoutBox through #getLayoutBox, we'll
-      // return the new absolute position.
+      // return the new absolute position.  For inabox viewport scroll is
+      // for top, not containing window so ignore.
       this.layoutBox_ = moveLayoutRect(box, -viewport.getScrollLeft(),
           -viewport.getScrollTop());
     }
@@ -568,7 +570,11 @@ export class Resource {
       return layoutRectLtwh(pos.left, pos.top, size.width, size.height);
     }
 
-    if (!this.isFixed_) {
+    // For inabox, viewport is based on containing window relative to top
+    // and therefore scroll left/top do not reflect the element's position
+    // relative to its containing window.  Instead, assume the window
+    // has no scroll position as one typically does not scroll inner windows.
+    if (!this.isFixed_ || getMode(this.hostWin).runtime == 'inabox') {
       return this.layoutBox_;
     }
     const viewport = this.resources_.getViewport();

--- a/test/functional/test-resource.js
+++ b/test/functional/test-resource.js
@@ -334,6 +334,29 @@ describes.realWin('Resource', {amp: true}, env => {
     expect(resource.getPageLayoutBox()).to.eql(layoutRectLtwh(0, 0, 10, 10));
   });
 
+  it('should not subtract viewport scroll offset for inabox', () => {
+    win.AMP_MODE = {runtime: 'inabox'};
+    elementMock.expects('isUpgraded').returns(true).atLeast(1);
+    elementMock.expects('getBoundingClientRect').returns(
+        layoutRectLtwh(0, 0, 10, 10)).once();
+    viewportMock.expects('getScrollTop').returns(123).atLeast(0);
+    const fixedParent = doc.createElement('div');
+    fixedParent.style.position = 'fixed';
+    doc.body.appendChild(fixedParent);
+    fixedParent.appendChild(element);
+    viewportMock.expects('isDeclaredFixed')
+        .withExactArgs(element)
+        .returns(false)
+        .once();
+    viewportMock.expects('isDeclaredFixed')
+        .withExactArgs(fixedParent)
+        .returns(true)
+        .once();
+    resource.measure();
+    expect(resource.isFixed()).to.be.true;
+    expect(resource.getLayoutBox()).to.eql(layoutRectLtwh(0, 123, 10, 10));
+  });
+
   describe('placeholder measure', () => {
     let rect;
 


### PR DESCRIPTION
Resource measure/getLayoutBox takes into account the scroll x/y position, for instance within measureViewResources_:

  if (isFixed) {
      // For fixed position elements, we need the relative position to the
      // viewport. When accessing the layoutBox through #getLayoutBox, we'll
      // return the new absolute position. 
      this.layoutBox_ = moveLayoutRect(box, -viewport.getScrollLeft(),
          -viewport.getScrollTop());
    }

However for inabox, the viewport scroll left/top are based on the top window and not the window containing the creative (and therefore the fixed element).  As a result, they rect is incorrect such that if a slot is more than 3 viewports away, layoutCallback will never execute.

Fix is to take into account if inabox and assume viewport scroll left/top are 0 as its very rare that an inner window has a left/top scroll.  Other option would be to explicitly use window.scrollX/scrollY for the element in question.  Happy to do either...