### PR TITLE
✨ Add CONTAINER and CONTAINER_TOKEN variable support to amp-analytics.

### DIFF
--- a/extensions/amp-analytics/0.1/vendors.js
+++ b/extensions/amp-analytics/0.1/vendors.js
@@ -47,6 +47,8 @@ export const ANALYTICS_CONFIG = /** @type {!JsonObject} */ ({
       'documentReferrer': 'DOCUMENT_REFERRER',
       'domainLookupTime': 'DOMAIN_LOOKUP_TIME',
       'domInteractiveTime': 'DOM_INTERACTIVE_TIME',
+      'container': 'CONTAINER',
+      'containerToken': 'CONTAINER_TOKEN',
       'externalReferrer': 'EXTERNAL_REFERRER',
       'navRedirectCount': 'NAV_REDIRECT_COUNT',
       'navTiming': 'NAV_TIMING',

--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -22,6 +22,7 @@ import {
 } from '../service';
 import {
   parseUrl,
+  getFragment,
   removeFragment,
   parseQueryString,
   addParamsToUrl,
@@ -513,6 +514,21 @@ export class GlobalVariableSource extends VariableSource {
       return this.getStoryValue_(storyVariables => storyVariables.pageId,
           'STORY_PAGE_ID');
     });
+
+    this.set('CONTAINER_TOKEN', () => {
+      let fragment = getFragment(this.ampdoc.win.location.href);
+      if (!fragment) {
+	return '';
+      }
+      let args = parseQueryString(fragment.substring(1, fragment.length));
+      if (!args.ct) {
+	return '';
+      }
+      return args.ct;
+    });
+    this.set('CONTAINER', () => {
+      return document.location.ancestorOrigins[0];
+    });
   }
 
   /**
@@ -973,7 +989,8 @@ export class UrlReplacements {
       if (opt_collectVars) {
         opt_collectVars[match] = val;
       }
-      return encodeValue(val);
+      // Should this be implemented as a whitelist or something?
+      return match == 'CONTAINER' ? val : encodeValue(val);
     });
 
     if (replacementPromise) {


### PR DESCRIPTION
- Implements a CONTAINER variable, allowing access to ancestorOrigins[0] without %-encoding
- Implements a CONTAINER_TOKEN variable, allowing access to the value of the ct in the hash fragment the document was initialized with

Please advise on how to better not %-encode CONTAINER, and what kind of unit testing would be good for this, etc.

Fixes #13498