### PR TITLE
Remove flashes on iOS story pages transitions.

### DIFF
--- a/extensions/amp-story/0.1/amp-story.css
+++ b/extensions/amp-story/0.1/amp-story.css
@@ -56,6 +56,7 @@ html.i-amphtml-story-standalone body {
   /** Remove the cursor: pointer; style set by the runtime, to avoid wrong
       touch feedback on mobile, like a flashing overlay on page transitions. */
   cursor: auto !important;
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0) !important;
 }
 
 html.i-amphtml-story-standalone body {


### PR DESCRIPTION
The previous fix didn't work for iOS.