### PR TITLE
Remove extra duplicated text

### DIFF
--- a/spec/amp-actions-and-events.md
+++ b/spec/amp-actions-and-events.md
@@ -206,21 +206,6 @@ event.index</pre></td>
   </tr>
 </table>
 
-### amp-carousel[type="slides"]
-<table>
-  <tr>
-    <th width="25%">Event</th>
-    <th width="35%">Description</th>
-    <th width="40%">Data</th>
-  </tr>
-  <tr>
-    <td><code>slideChange</code></td>
-    <td>Fired when the user manually changes the carousel's current slide. Does not fire on autoplay or the <code>goToSlide</code> action.</td>
-    <td><pre>// Slide number.
-event.index</pre></td>
-  </tr>
-</table>
-
 ### amp-video, amp-youtube
 <table>
   <tr>


### PR DESCRIPTION
Remove repeat of `amp-carousel[type="slides"]`; it's already there.