### PR TITLE
Fix bug where lightboxed carousel images show up twice

### DIFF
--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -43,13 +43,6 @@ const TAG = 'amp-lightbox-gallery';
 const DEFAULT_GALLERY_ID = 'amp-lightbox-gallery';
 
 /**
- * Regular expression that identifies AMP CSS classes.
- * Includes 'i-amphtml-', '-amp-', and 'amp-' prefixes.
- * @type {!RegExp}
- */
-const AMP_CSS_RE = /^(i?-)?amp(html)?-/;
-
-/**
  * Set of namespaces that indicate the lightbox controls mode.
  * Lightbox controls include top bar, description box
  *
@@ -227,15 +220,7 @@ export class AmpLightboxGallery extends AMP.BaseElement {
     const clonedNode = element.cloneNode(deepClone);
     clonedNode.removeAttribute('on');
     clonedNode.removeAttribute('id');
-
-    const ampClasses = [];
-    for (let i = 0; i < clonedNode.classList.length; i++) {
-      const cssClass = clonedNode.classList[i];
-      if (AMP_CSS_RE.test(cssClass)) {
-        ampClasses.push(cssClass);
-      }
-    }
-    clonedNode.classList.remove.apply(clonedNode.classList, ampClasses);
+    clonedNode.setAttribute('class', '');
     return clonedNode;
   }
   /**

--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -222,8 +222,8 @@ export class AmpLightboxGallery extends AMP.BaseElement {
     clonedNode.removeAttribute('on');
     clonedNode.removeAttribute('id');
     const ampClasses = Array.from(clonedNode.classList)
-      .filter(c => c.startsWith('i-amphtml-') || c.startsWith('amp-'));
-    clonedNode.classList.remove(...ampClasses);
+        .filter(c => c.startsWith('i-amphtml-') || c.startsWith('amp-'));
+    clonedNode.classList.remove.apply(clonedNode.classList, ampClasses);
     return clonedNode;
   }
   /**

--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -220,7 +220,7 @@ export class AmpLightboxGallery extends AMP.BaseElement {
     const clonedNode = element.cloneNode(deepClone);
     clonedNode.removeAttribute('on');
     clonedNode.removeAttribute('id');
-    clonedNode.setAttribute('class', '');
+    clonedNode.removeAttribute('class');
     return clonedNode;
   }
   /**

--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -221,6 +221,9 @@ export class AmpLightboxGallery extends AMP.BaseElement {
     const clonedNode = element.cloneNode(deepClone);
     clonedNode.removeAttribute('on');
     clonedNode.removeAttribute('id');
+    const ampClasses = Array.from(clonedNode.classList)
+      .filter(c => c.startsWith('i-amphtml-') || c.startsWith('amp-'));
+    clonedNode.classList.remove(...ampClasses);
     return clonedNode;
   }
   /**

--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -38,10 +38,16 @@ import {isLoaded} from '../../../src/event-helper';
 import {layoutRectFromDomRect} from '../../../src/layout-rect';
 import {setStyle, toggle} from '../../../src/style';
 
-
 /** @const */
 const TAG = 'amp-lightbox-gallery';
 const DEFAULT_GALLERY_ID = 'amp-lightbox-gallery';
+
+/**
+ * Regular expression that identifies AMP CSS classes.
+ * Includes 'i-amphtml-', '-amp-', and 'amp-' prefixes.
+ * @type {!RegExp}
+ */
+const AMP_CSS_RE = /^(i?-)?amp(html)?-/;
 
 /**
  * Set of namespaces that indicate the lightbox controls mode.
@@ -221,8 +227,14 @@ export class AmpLightboxGallery extends AMP.BaseElement {
     const clonedNode = element.cloneNode(deepClone);
     clonedNode.removeAttribute('on');
     clonedNode.removeAttribute('id');
-    const ampClasses = Array.from(clonedNode.classList)
-        .filter(c => c.startsWith('i-amphtml-') || c.startsWith('amp-'));
+
+    const ampClasses = [];
+    for (let i = 0; i < clonedNode.classList.length; i++) {
+      const cssClass = clonedNode.classList[i];
+      if (AMP_CSS_RE.test(cssClass)) {
+        ampClasses.push(cssClass);
+      }
+    }
     clonedNode.classList.remove.apply(clonedNode.classList, ampClasses);
     return clonedNode;
   }


### PR DESCRIPTION
Happens when you lightbox the image inside the carousel, like so: 

```
  <amp-carousel height="300"
  layout="fixed-height"
  type="carousel"
  >
    <amp-img src="https://picsum.photos/300/200/?image=10"
      width="300"
      height="200"
      alt="a sample image"
      lightbox></amp-img>
 </amp-carousel>
```

<img width="413" alt="screen shot 2018-02-20 at 11 44 24 am" src="https://user-images.githubusercontent.com/1528181/36445536-75cea4c0-1633-11e8-8b2f-66a9b60f2882.png">


The bug itself is a bit awkward. It's because I can't toggle `display: none` on an `<amp-img>` with the `.amp-scrollable-carousel-slide` class, since it sets the `display` css property with `!important`. I'm not sure whether we should be using `!important` there, and I'm also not sure if the `amp-scrollable-carousel-slide` class should be prefixed with `i-amphtml` instead of `amp-`. 

It seems reasonable to strip amp-related css classes, since basically what we're doing is taking the raw image with its raw aspect ratio, and blowing it to fill the screen. I'm wondering if we could just strip ALL CSS classes, or are there situations where it would be valid to keep the user-defined css classes? It's possible, like maybe they apply an opacity, or other visual effects... 