### PR TITLE
✅ Disable flaky tests that are causing master to be red

### DIFF
--- a/extensions/amp-image-lightbox/0.1/test/integration/test-amp-image-lightbox.js
+++ b/extensions/amp-image-lightbox/0.1/test/integration/test-amp-image-lightbox.js
@@ -48,7 +48,8 @@ describe.configure().run('amp-image-lightbox', function() {
       win = env.win;
     });
 
-    it('should activate on tap of source image', () => {
+    // TODO(cathyxz, #13458): Find out why this is flaky on master.
+    it.skip('should activate on tap of source image', () => {
       const lightbox = win.document.getElementById('image-lightbox-1');
       expect(lightbox.style.display).to.equal('none');
       const ampImage = win.document.getElementById('img0');

--- a/test/integration/test-video-players-helper.js
+++ b/test/integration/test-video-players-helper.js
@@ -156,7 +156,8 @@ export function runVideoPlayerIntegrationTests(
       });
     });
 
-    it('should trigger pause analytics when the video pauses', function() {
+    // TODO(cvializ, #10283): Find out why this is flaky on master.
+    it.skip('should trigger pause analytics when the video pauses', function() {
       let pauseButton;
 
       return getVideoPlayer(


### PR DESCRIPTION
- #10283 added several tests to test/integration/test-video-players-helper.js
- #13458 added several tests to extensions/amp-image-lightbox/0.1/test/integration/test-amp-image-lightbox.js

A couple of these tests are flaky, causing master to be red more often than not.

See:
- https://travis-ci.org/ampproject/amphtml/jobs/343908930#L674
- https://travis-ci.org/ampproject/amphtml/jobs/343973857#L678

