### PR TITLE
📖 Make the AMP PR template more readable

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,34 +1,32 @@
-Please pick a meaningful title for your pull request using sentence case.
+Instructions:
 
-Do not overuse punctuation in the title like `(chore):`. If it is helpful feel free to start with a project name, though, like `ProjectX: Implement some feature`.
+- Pick a meaningful title for your pull request. (Use sentence case.)
+  - Prefix the title with an emoji to identify what is being done. (Copy-paste from the list below.)
+  - Do not overuse punctuation in the title (like `(chore):`).
+  - If it is helpful, use a simple prefix (like `ProjectX: Implement some feature`).
+- Enter a succinct description that says why the PR is necessary, and what it does.
+  - Mention the GitHub issue that is being addressed by the pull request.
+  - The keywords `Fixes`, `Closes`, or `Resolves` followed the issue number will automatically close the issue.
 
-# Title instructions above.
-
-Enter a succinct description of what is achieved by the PR. Ideally describe why the change is being made.
-
-Bullet points like
+Example of a good description:
 
 - Implements aspect X
 - Leaves out feature Y because of A
 - Improves performance by B
 - Improves accessibility by C
 
-really help with making this more readable.
+Emojis for categorizing pull requests:
 
-Fixes/Closes/Related-to #1 (enter issue number, except in rare cases where none exists).
-
-It is also helpful to add an emoji before the commit message to identify the kind of work done on a single commit. See the following suggestions below:
-
-- 🐛 - `:bug:` Bug fix
-- ✨ - `:sparkles:` New feature
-- ✅ - `:white_check_mark:` Tests
-- 🔥 - `:fire:` P0
-- 🚀 - `:rocket:` Performance improvements
-- 🖍️ - `:crayon:` CSS / Styling
-- ♿ - `:wheelchair:` Accessibility
-- 🌐 - `:globe_with_meridians:` i18n (Internationalization)
-- 📖 - `:book:` Documentation
-- ♻️ - `:recycle:` Refactoring (like moving around code w/o any changes)
-- 🏗️ - `:building_construction:` Infrastructure / Tooling / Builds / CI
-- ⏪ - `:rewind:` Revert
-- 🚮 - `:put_litter_in_its_place:` Deleting code
+✨ New feature (`:sparkles:`)
+🐛 Bug fix (`:bug:`)
+🔥 P0 fix (`:fire:`)
+✅ Tests (`:white_check_mark:`)
+🚀 Performance improvements (`:rocket:`)
+🖍 CSS / Styling (`:crayon:`)
+♿ Accessibility (`:wheelchair:`)
+🌐 Internationalization (`:globe_with_meridians:`)
+📖 Documentation (`:book:`)
+🏗 Infrastructure / Tooling / Builds / CI (`:building_construction:`)
+⏪ Reverting a previous change (`:rewind:`)
+♻️ Refactoring (like moving around code w/o any changes) (`:recycle:`)
+🚮 Deleting code (`:put_litter_in_its_place:`)


### PR DESCRIPTION
The pull request template is displayed in raw text whenever someone opens a PR, and provides instructions for how to make the PR more readable. Ironically, the instructions themselves aren't very readable when displayed in raw text.

This PR makes the text more readable, and the emojis easier to copy-paste.

See [here](https://raw.githubusercontent.com/rsimha-amp/amphtml/c68e826592d6e0b4ccdab79563da8ca44e957b18/.github/PULL_REQUEST_TEMPLATE.md) for what this will actually look like when you open a new PR.

Follow up to #13037 and #13319
