### PR TITLE
🏗🐛 Correctly apply local dev config during visual tests

### DIFF
--- a/build-system/tasks/visual-diff.rb
+++ b/build-system/tasks/visual-diff.rb
@@ -365,8 +365,7 @@ def snapshot_webpages(page, webpages, config)
         forbidden_css,
         loading_incomplete_css,
         loading_complete_css)
-    # TODO(rsimha): Enable JS after percy/percy-capybara/issues/51 is fixed.
-    Percy::Capybara.snapshot(page, name: name, enable_javascript: false)
+    Percy::Capybara.snapshot(page, name: name, enable_javascript: true)
     clear_experiments(page)
   end
 end

--- a/build-system/tasks/visual-diff.rb
+++ b/build-system/tasks/visual-diff.rb
@@ -23,7 +23,8 @@
 
 require 'json'
 require 'net/http'
-require 'percy/capybara/anywhere'
+require 'percy/capybara'
+require 'capybara'
 require 'selenium/webdriver'
 
 
@@ -36,6 +37,7 @@ PORT = '8000'
 WEBSERVER_TIMEOUT_SECS = 15
 CONFIGS = %w(canary prod)
 AMP_RUNTIME_FILE = 'dist/amp.js'
+AMP_3P_FRAME_FILE = 'dist.3p/current/integration.js'
 BUILD_STATUS_URL = 'https://amphtml-percy-status-checker.appspot.com/status'
 BUILD_PROCESSING_POLLING_INTERVAL_SECS = 5
 BUILD_PROCESSING_TIMEOUT_SECS = 60 * 10
@@ -281,7 +283,33 @@ def run_visual_tests(visual_tests_config)
 end
 
 
-# Generates percy snapshots for a set of given webpages.
+# Cleans up any existing AMP config from the runtime and 3p frame.
+def cleanup_amp_config
+  log('verbose', 'Cleaning up existing AMP config')
+  cmd_runtime = "gulp prepend-global --target #{AMP_RUNTIME_FILE} --remove"
+  cmd_3p_frame = "gulp prepend-global --target #{AMP_3P_FRAME_FILE} --remove"
+  system(cmd_runtime, :out => OUT)
+  system(cmd_3p_frame, :out => OUT)
+end
+
+
+# Applies the AMP config to the runtime and 3p frame.
+#
+# Args:
+# - config: Config to apply. One of 'canary' or 'prod'.
+def apply_amp_config(config)
+  log('verbose', 'Switching to the ' + cyan("#{config}") + ' AMP config')
+  cmd_runtime = "gulp prepend-global --local_dev " +
+      "--target #{AMP_RUNTIME_FILE} --#{config}"
+  cmd_3p_frame = "gulp prepend-global --local_dev " +
+      "--target #{AMP_3P_FRAME_FILE} --#{config}"
+  system(cmd_runtime, :out => OUT)
+  system(cmd_3p_frame, :out => OUT)
+end
+
+
+# Sets the AMP config, launches a server, and generates Percy snapshots for a
+# set of given webpages.
 #
 # Args:
 # - page: Page object used by Percy for snapshotting.
@@ -291,38 +319,55 @@ def generate_snapshots(page, webpages)
   if ARGV.include? '--master'
     Percy::Capybara.snapshot(page, name: 'Blank page')
   end
-  log('verbose', 'Cleaning up existing AMP config')
-  remove_cmd = "gulp prepend-global --target #{AMP_RUNTIME_FILE} --remove"
-  system(remove_cmd, :out => OUT)
+  cleanup_amp_config
   CONFIGS.each do |config|
-    log('verbose', 'Switching to the ' + cyan("#{config}") + ' AMP config')
-    config_cmd = "gulp prepend-global --target #{AMP_RUNTIME_FILE} --#{config}"
-    system(config_cmd, :out => OUT)
+    apply_amp_config(config)
     log('verbose',
         'Generating snapshots using the ' + cyan("#{config}") + ' AMP config')
-    page.visit('/')
-    webpages.each do |webpage|
-      url = webpage['url']
-      if url.include? 'examples/visual-tests/amp-by-example/' and
-          !ARGV.include? '--master'
-        next
+    begin
+      pid = launch_web_server
+      unless wait_for_web_server
+        log('error', 'Failed to start webserver')
+        raise 'Webserver launch failure'
       end
-      name = "#{webpage['name']} (#{config})"
-      forbidden_css = webpage['forbidden_css']
-      loading_incomplete_css = webpage['loading_incomplete_css']
-      loading_complete_css = webpage['loading_complete_css']
-      enable_experiments(page, webpage['experiments'])
-      log('verbose', 'Navigating to page ' + yellow(url) + '...')
-      page.visit(url)
-      verify_css_elements(
-          page,
-          url,
-          forbidden_css,
-          loading_incomplete_css,
-          loading_complete_css)
-      Percy::Capybara.snapshot(page, name: name)
-      clear_experiments(page)
+      page.visit('/')
+      snapshot_webpages(page, webpages, config)
+    ensure
+      close_web_server(pid)
     end
+  end
+end
+
+
+# Generates Percy snapshots for a set of given webpages.
+#
+# Args:
+# - page: Page object used by Percy for snapshotting.
+# - webpages: JSON object containing details about the pages to snapshot.
+# - config: Config being used. One of 'canary' or 'prod'.
+def snapshot_webpages(page, webpages, config)
+  webpages.each do |webpage|
+    url = webpage['url']
+    if url.include? 'examples/visual-tests/amp-by-example/' and
+        !ARGV.include? '--master'
+      next
+    end
+    name = "#{webpage['name']} (#{config})"
+    forbidden_css = webpage['forbidden_css']
+    loading_incomplete_css = webpage['loading_incomplete_css']
+    loading_complete_css = webpage['loading_complete_css']
+    enable_experiments(page, webpage['experiments'])
+    log('verbose', 'Navigating to page ' + yellow(url) + '...')
+    page.visit(url)
+    verify_css_elements(
+        page,
+        url,
+        forbidden_css,
+        loading_incomplete_css,
+        loading_complete_css)
+    # TODO(rsimha): Enable JS after percy/percy-capybara/issues/51 is fixed.
+    Percy::Capybara.snapshot(page, name: name, enable_javascript: false)
+    clear_experiments(page)
   end
 end
 
@@ -446,19 +491,10 @@ def main
         cyan('PERCY_TOKEN') + ' environment variables.')
     raise 'Missing environment variables'
   end
-  begin
-    set_debugging_level
-    pid = launch_web_server
-    unless wait_for_web_server
-      log('error', 'Failed to start webserver')
-      raise 'Webserver launch failure'
-    end
-    visual_tests_config_json = load_visual_tests_config_json
-    visual_tests_config = JSON.parse(visual_tests_config_json)
-    run_visual_tests(visual_tests_config)
-  ensure
-    close_web_server(pid)
-  end
+  set_debugging_level
+  visual_tests_config_json = load_visual_tests_config_json
+  visual_tests_config = JSON.parse(visual_tests_config_json)
+  run_visual_tests(visual_tests_config)
 end
 
 

--- a/test/visual-diff/visual-tests.js
+++ b/test/visual-diff/visual-tests.js
@@ -183,11 +183,10 @@
       "url": "examples/visual-tests/amp-by-example/components/amp-carousel/index.html",
       "name": "amp-carousel - Amp By Example"
     },
-    // Dynamic content. TODO(rsimha-amp, #13394): Make this deterministic.
-    // {
-    //   "url": "examples/visual-tests/amp-by-example/components/amp-dailymotion/index.html",
-    //   "name": "amp-dailymotion - Amp By Example"
-    // },
+    {
+      "url": "examples/visual-tests/amp-by-example/components/amp-dailymotion/index.html",
+      "name": "amp-dailymotion - Amp By Example"
+    },
     {
       "url": "examples/visual-tests/amp-by-example/components/amp-date-picker/index.html",
       "name": "amp-date-picker - Amp By Example"
@@ -196,11 +195,10 @@
       "url": "examples/visual-tests/amp-by-example/components/amp-dynamic-css-classes/index.html",
       "name": "amp-dynamic-css-classes - Amp By Example"
     },
-    // Dynamic content. TODO(rsimha-amp, #13394): Make this deterministic.
-    // {
-    //   "url": "examples/visual-tests/amp-by-example/components/amp-experiment/index.html",
-    //   "name": "amp-experiment - Amp By Example"
-    // },
+    {
+      "url": "examples/visual-tests/amp-by-example/components/amp-experiment/index.html",
+      "name": "amp-experiment - Amp By Example"
+    },
     {
       "url": "examples/visual-tests/amp-by-example/components/amp-facebook/index.html",
       "name": "amp-facebook - Amp By Example"
@@ -225,11 +223,10 @@
       "url": "examples/visual-tests/amp-by-example/components/amp-fx-parallax/index.html",
       "name": "amp-fx-parallax - Amp By Example"
     },
-    // Dynamic content. TODO(rsimha-amp, #13394): Make this deterministic.
-    // {
-    //   "url": "examples/visual-tests/amp-by-example/components/amp-gfycat/index.html",
-    //   "name": "amp-gfycat - Amp By Example"
-    // },
+    {
+      "url": "examples/visual-tests/amp-by-example/components/amp-gfycat/index.html",
+      "name": "amp-gfycat - Amp By Example"
+    },
     {
       "url": "examples/visual-tests/amp-by-example/components/amp-gist/index.html",
       "name": "amp-gist - Amp By Example"
@@ -350,11 +347,10 @@
       "url": "examples/visual-tests/amp-by-example/components/amp-vimeo/index.html",
       "name": "amp-vimeo - Amp By Example"
     },
-    // Dynamic content. TODO(rsimha-amp, #13394): Make this deterministic.
-    // {
-    //   "url": "examples/visual-tests/amp-by-example/components/amp-vine/index.html",
-    //   "name": "amp-vine - Amp By Example"
-    // },
+    {
+      "url": "examples/visual-tests/amp-by-example/components/amp-vine/index.html",
+      "name": "amp-vine - Amp By Example"
+    },
     {
       "url": "examples/visual-tests/amp-by-example/components/amp-youtube/index.html",
       "name": "amp-youtube - Amp By Example"


### PR DESCRIPTION
It turns out that we weren't correctly applying the `local_dev` specific config to the AMP runtime before starting up a local server for the visual diff tests. This resulted in several test pages with bad / incomplete content in iframes, that had later been disabled.

This PR fixes the mechanism by which we configure the AMP runtime and start a local server. It also re-enables all the visual tests that were previously disabled.

We will need to follow this up with another PR that looks at all the new visual diffs on `master` that are genuinely due to dynamic content on test pages, and disable only those pages.

Note: Further work on this is blocked by what appear to be rendering errors in the snapshots generated by the Percy backend. See https://github.com/percy/percy-capybara/issues/51 for more details.

Follow up to #13394
Follow up to #13425
Partial fix for #10155
Partial fix for #11427
Partial fix for #11425
Partial fix for #11424
Partial fix for #11423
Partial fix for #11422
Partial fix for #11421
Partial fix for #11420
Partial fix for #11419
Partial fix for #11418
Partial fix for #11417
Partial fix for #11416
Partial fix for #11415
Partial fix for #11414

