### PR TITLE
<amp-lightbox-gallery> launch-blocking manual tests

### DIFF
--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -801,10 +801,6 @@ export class AmpLightboxGallery extends AMP.BaseElement {
     const anim = new Animation(this.element);
     let duration = MIN_TRANSITION_DURATION;
     const currentElementMetadata = this.getCurrentElement_();
-    const imageBox = /**@type {?}*/ (currentElementMetadata.imageViewer)
-        .implementation_.getImageBoxWithOffset();
-    const image = /**@type {?}*/ (currentElementMetadata.imageViewer)
-        .implementation_.getImage();
     const sourceElement = currentElementMetadata.sourceElement;
     // Try to transition to the source image.
     let transLayer = null;
@@ -820,6 +816,11 @@ export class AmpLightboxGallery extends AMP.BaseElement {
         && this.shouldAnimate_(sourceElement)
         && (sourceElement == this.sourceElement_
         || this.manager_.hasCarousel(this.currentLightboxGroupId_))) {
+
+        const imageBox = /**@type {?}*/ (currentElementMetadata.imageViewer)
+            .implementation_.getImageBoxWithOffset();
+        const image = /**@type {?}*/ (currentElementMetadata.imageViewer)
+            .implementation_.getImage();
 
         sourceElement.classList.add('i-amphtml-ghost');
         transLayer = this.element.ownerDocument.createElement('div');

--- a/extensions/amp-lightbox-gallery/0.1/service/lightbox-manager-impl.js
+++ b/extensions/amp-lightbox-gallery/0.1/service/lightbox-manager-impl.js
@@ -29,6 +29,11 @@ import {toArray} from '../../../../src/types';
 
 const LIGHTBOX_ELIGIBLE_TAGS = {
   'amp-img': true,
+  'amp-anim': true,
+  'amp-video': true,
+  'amp-youtube': true,
+  'amp-instagram': true,
+  'amp-facebook': true,
 };
 
 const ELIGIBLE_TAP_TAGS = {
@@ -41,8 +46,7 @@ const FIGURE_TAG = 'figure';
 const SLIDE_SELECTOR = '.amp-carousel-slide';
 
 const VALIDATION_ERROR_MSG = `lightbox attribute is only supported for the
-  <amp-img> tag and <figure> and <amp-carousel> tags containing the <amp-img>
-  tag right now.`;
+  following tags and <amp-carousel> tags containing said tags right now: `;
 
 /** @typedef {{
  *  url: string,
@@ -278,7 +282,9 @@ export class LightboxManager {
       }
     }
 
-    user().assert(this.baseElementIsSupported_(element), VALIDATION_ERROR_MSG);
+    const errorMsg = VALIDATION_ERROR_MSG + LIGHTBOX_ELIGIBLE_TAGS.toString();
+
+    user().assert(this.baseElementIsSupported_(element), errorMsg);
 
     if (!this.lightboxGroups_[lightboxGroupId]) {
       this.lightboxGroups_[lightboxGroupId] = [];

--- a/extensions/amp-lightbox-gallery/0.1/service/lightbox-manager-impl.js
+++ b/extensions/amp-lightbox-gallery/0.1/service/lightbox-manager-impl.js
@@ -45,9 +45,6 @@ const CAROUSEL_TAG = 'amp-carousel';
 const FIGURE_TAG = 'figure';
 const SLIDE_SELECTOR = '.amp-carousel-slide';
 
-const VALIDATION_ERROR_MSG = `lightbox attribute is only supported for the
-  following tags and <amp-carousel> tags containing said tags right now: `;
-
 /** @typedef {{
  *  url: string,
  *  element: !Element
@@ -282,9 +279,8 @@ export class LightboxManager {
       }
     }
 
-    const errorMsg = VALIDATION_ERROR_MSG + LIGHTBOX_ELIGIBLE_TAGS.toString();
-
-    user().assert(this.baseElementIsSupported_(element), errorMsg);
+    user().assert(this.baseElementIsSupported_(element),
+        `The element ${element.tagName} isn't supported in lightbox yet.`);
 
     if (!this.lightboxGroups_[lightboxGroupId]) {
       this.lightboxGroups_[lightboxGroupId] = [];

--- a/test/manual/amp-lightbox-gallery-launch.amp.html
+++ b/test/manual/amp-lightbox-gallery-launch.amp.html
@@ -1,0 +1,117 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>Lightbox Gallery Launch Tests</title>
+  <link rel="canonical" href="amps.html" >
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-lightbox-gallery" src="https://cdn.ampproject.org/v0/amp-lightbox-gallery-0.1.js"></script>
+  <script async custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.1.js"></script>
+  <script async custom-element="amp-video" src="https://cdn.ampproject.org/v0/amp-video-0.1.js"></script>
+  <script async custom-element="amp-youtube" src="https://cdn.ampproject.org/v0/amp-youtube-0.1.js"></script>
+  <script async custom-element="amp-instagram" src="https://cdn.ampproject.org/v0/amp-instagram-0.1.js"></script>
+  <script async custom-element="amp-facebook" src="https://cdn.ampproject.org/v0/amp-facebook-0.1.js"></script>
+
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <style amp-custom>
+    body {
+      font-family: sans-serif;
+    }
+
+  </style>
+</head>
+<body>
+  <script>
+    // Enable amp-lightbox-viewer experiment automatically if it is not enabled.
+    // Disable amp-lightbox-viewer-auto experiment if it is enabled.
+    setTimeout(function() {
+        if (!AMP.isExperimentOn('amp-lightbox-gallery')) {
+          AMP.toggleExperiment('amp-lightbox-gallery');
+          location.reload();
+        }
+    }, 1000);
+  </script>
+
+  <h1>Lightbox Carousel Test</h1>
+  <amp-carousel height="300"
+  layout="fixed-height"
+  type="carousel"
+  lightbox>
+    <amp-img src="https://picsum.photos/300/200/?image=30"
+      width="300"
+      height="200"
+      alt="a sample image"></amp-img>
+    <figure>
+        <amp-img src="https://picsum.photos/300/200/?image=31"
+        width="300"
+        height="200"
+        alt="another sample image"></amp-img>
+        <figcaption>This is a figure with a figcaption.</figcaption>
+    </figure>
+    <amp-img src="https://picsum.photos/300/200/?image=32"
+      width="300"
+      height="200"
+      aria-label="Aria labels are cool."></amp-img>
+    <amp-img src="https://picsum.photos/300/200/?image=33"
+      width="300"
+      height="200"
+      aria-describedby="my-aria-describe"></amp-img>
+    <amp-img src="https://picsum.photos/300/200/?image=34"
+      width="300"
+      height="200"
+      aria-labelledby="my-aria-label"></amp-img>
+    <amp-video
+      src="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4"
+      width="358"
+      height="204"
+      layout="responsive"
+      controls>
+      <div placeholder>
+        This is a placeholder
+      </div>
+      <div fallback>
+        This is a fallback
+      </div>
+    </amp-video>
+    <amp-youtube width="480"
+      height="270"
+      layout="responsive"
+      data-videoid="lBTCB7yLs8Y">
+    </amp-youtube>
+    <amp-youtube width="480"
+      height="270"
+      layout="responsive"
+      data-videoid="lBTCB7yLs8Y"
+      autoplay>
+    </amp-youtube>
+    <amp-instagram data-shortcode="1totVhIFXl"
+      width="1"
+      height="1"
+      layout="responsive">
+    </amp-instagram>
+    <amp-facebook
+      width="552"
+      height="303"
+      layout="responsive"
+      data-href="https://www.facebook.com/zuck/posts/10102593740125791">
+    </amp-facebook>
+    <amp-facebook width="552"
+      height="310"
+      layout="responsive"
+      data-embed-as="video"
+      data-href="https://www.facebook.com/zuck/videos/10102509264909801/">
+    </amp-facebook>
+  </amp-carousel>
+  <div id='my-aria-describe'>
+    This is an aria described by a div. <br/>
+    I have a linebreak.
+  </div>
+  <div id='my-aria-label'>
+    This is an aria labelled by a div. <br/>
+    I also have a newline.
+  </div>
+
+
+</body>
+</html>

--- a/test/manual/amp-lightbox-gallery-launch.amp.html
+++ b/test/manual/amp-lightbox-gallery-launch.amp.html
@@ -8,6 +8,7 @@
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <script async custom-element="amp-lightbox-gallery" src="https://cdn.ampproject.org/v0/amp-lightbox-gallery-0.1.js"></script>
   <script async custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.1.js"></script>
+  <script async custom-element="amp-anim" src="https://cdn.ampproject.org/v0/amp-anim-0.1.js"></script>
   <script async custom-element="amp-video" src="https://cdn.ampproject.org/v0/amp-video-0.1.js"></script>
   <script async custom-element="amp-youtube" src="https://cdn.ampproject.org/v0/amp-youtube-0.1.js"></script>
   <script async custom-element="amp-instagram" src="https://cdn.ampproject.org/v0/amp-instagram-0.1.js"></script>
@@ -42,6 +43,9 @@
       width="300"
       height="200"
       alt="a sample image"></amp-img>
+    <amp-anim
+      src="https://lh3.googleusercontent.com/qNn8GDz8Jfd-s9lt3Nc4lJeLjVyEaqGJTk1vuCUWazCmAeOBVjSWDD0SMTU7x0zhVe5UzOTKR0n-kN4SXx7yElvpKYvCMaRyS_g-jydhJ_cEVYmYPiZ_j1Y9de43mlKxU6s06uK1NAlpbSkL_046amEKOdgIACICkuWfOBwlw2hUDfjPOWskeyMrcTu8XOEerCLuVqXugG31QC345hz3lUyOlkdT9fMYVUynSERGNzHba7bXMOxKRe3izS5DIWUgJs3oeKYqA-V8iqgCvneD1jj0Ff68V_ajm4BDchQubBJU0ytXVkoWh27ngeEHubpnApOS6fcGsjPxeuMjnzAUtoTsiXz2FZi1mMrxrblJ-kZoAq1DJ95cnoqoa2CYq3BTgq2E8BRe2paNxLJ5GXBCTpNdXMpVJc6eD7ceijQyn-2qanilX-iK3ChbOq0uBHMvsdoC_LsFOu5KzbbNH71vM3DPkvDGmHJmF67Vj8sQ6uBrLnzpYlCyN4-Y9frR8zugDcqX5Q=w400-h300-no" width="400" height="300">
+    </amp-anim>
     <figure>
         <amp-img src="https://picsum.photos/300/200/?image=31"
         width="300"


### PR DESCRIPTION
Basing this off of launch-blocking support components from https://github.com/ampproject/amphtml/issues/13565. Fixed a bug where lightbox breaks if you try to exit on a non-image component. 