### PR TITLE
🐛🖍 Fix form validation error default display from inline to none

### DIFF
--- a/css/amp.css
+++ b/css/amp.css
@@ -618,6 +618,13 @@ form [submit-error] {
 }
 
 /**
+ * Form validation error messages should be hidden at first.
+ */
+span[visible-when-invalid] {
+  display: none;  
+}
+
+/**
  * Hide the update reference point of amp-live-list by default. This is
  * reset by the `amp-live-list > .amp-active[update]` selector.
  */


### PR DESCRIPTION
Form validation error messages wrapped in `span[visible-when-invalid]` are shown by default, this commit corrects that, and thereby attempts to fix https://github.com/ampproject/amphtml/issues/13576.

Closes https://github.com/ampproject/amphtml/issues/13576