### PR TITLE
🏗 Disable JS during Percy rendering

### DIFF
--- a/build-system/tasks/visual-diff.rb
+++ b/build-system/tasks/visual-diff.rb
@@ -365,7 +365,7 @@ def snapshot_webpages(page, webpages, config)
         forbidden_css,
         loading_incomplete_css,
         loading_complete_css)
-    Percy::Capybara.snapshot(page, name: name, enable_javascript: true)
+    Percy::Capybara.snapshot(page, name: name)
     clear_experiments(page)
   end
 end


### PR DESCRIPTION
Based on the discussion in https://github.com/percy/percy-capybara/issues/51#issuecomment-367461500, we shouldn't enable JS during Percy's rendering phase since we already enable JS during local rendering on Chrome using Capybara.
