### PR TITLE
Stories media pool performance improvements.

### DIFF
--- a/extensions/amp-story/0.1/amp-story-page.js
+++ b/extensions/amp-story/0.1/amp-story-page.js
@@ -185,7 +185,7 @@ export class AmpStoryPage extends AMP.BaseElement {
     this.advancement_.stop();
 
     this.stopListeningToVideoEvents_();
-    this.pauseAllMedia_(/* opt_rewindToBeginning */ false);
+    this.pauseAllMedia_(true /* rewindToBeginning */);
 
     if (this.animationManager_) {
       this.animationManager_.cancelAll();
@@ -223,7 +223,6 @@ export class AmpStoryPage extends AMP.BaseElement {
 
   /** @return {!Promise} */
   beforeVisible() {
-    this.rewindAllMediaToBeginning_();
     return this.scale_().then(() => this.maybeApplyFirstAnimationFrame());
   }
 
@@ -329,15 +328,15 @@ export class AmpStoryPage extends AMP.BaseElement {
 
   /**
    * Pauses all media on this page.
-   * @param {boolean=} opt_rewindToBeginning Whether to rewind the currentTime
+   * @param {boolean=} rewindToBeginning Whether to rewind the currentTime
    *     of media items to the beginning.
    * @return {!Promise} Promise that resolves after the callbacks are called.
    * @private
    */
-  pauseAllMedia_(opt_rewindToBeginning) {
+  pauseAllMedia_(rewindToBeginning = false) {
     return this.whenAllMediaElements_((mediaPool, mediaEl) => {
-      return mediaPool.pause(/** @type {!HTMLMediaElement} */ (mediaEl),
-          opt_rewindToBeginning);
+      return mediaPool.pause(
+          /** @type {!HTMLMediaElement} */ (mediaEl), rewindToBeginning);
     });
   }
 
@@ -362,18 +361,6 @@ export class AmpStoryPage extends AMP.BaseElement {
   preloadAllMedia_() {
     return this.whenAllMediaElements_((mediaPool, mediaEl) => {
       return mediaPool.preload(/** @type {!HTMLMediaElement} */ (mediaEl));
-    });
-  }
-
-
-  /**
-   * @return {!Promise} Promise that resolves after the callbacks are called.
-   * @private
-   */
-  rewindAllMediaToBeginning_() {
-    return this.whenAllMediaElements_((mediaPool, mediaEl) => {
-      return mediaPool.rewindToBeginning(
-          /** @type {!HTMLMediaElement} */ (mediaEl));
     });
   }
 

--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -398,12 +398,7 @@ export class AmpStory extends AMP.BaseElement {
 
     this.element.addEventListener(EventType.TAP_NAVIGATION, e => {
       const {direction} = e.detail;
-
       this.performTapNavigation_(direction);
-
-      // We bless after the navigation so as not to slow down the navigation
-      // interaction.
-      this.mediaPool_.blessAll();
     });
 
     const gestures = Gestures.get(this.element,

--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -1320,7 +1320,17 @@ export class AmpStory extends AMP.BaseElement {
 
   /** @override */
   getMaxMediaElementCounts() {
-    return MAX_MEDIA_ELEMENT_COUNTS;
+    const audioMediaElements =
+        scopedQuerySelectorAll(this.element, 'amp-audio, [background-audio]');
+    const videoMediaElements =
+        scopedQuerySelectorAll(this.element, 'amp-video');
+
+    return {
+      [MediaType.AUDIO]: Math.min(
+          audioMediaElements.length, MAX_MEDIA_ELEMENT_COUNTS[MediaType.AUDIO]),
+      [MediaType.VIDEO]: Math.min(
+          videoMediaElements.length, MAX_MEDIA_ELEMENT_COUNTS[MediaType.VIDEO]),
+    };
   }
 
 

--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -1321,9 +1321,8 @@ export class AmpStory extends AMP.BaseElement {
   /** @override */
   getMaxMediaElementCounts() {
     const audioMediaElements =
-        scopedQuerySelectorAll(this.element, 'amp-audio, [background-audio]');
-    const videoMediaElements =
-        scopedQuerySelectorAll(this.element, 'amp-video');
+        this.element.querySelectorAll('amp-audio, [background-audio]');
+    const videoMediaElements = this.element.querySelectorAll('amp-video');
 
     return {
       [MediaType.AUDIO]: Math.min(

--- a/extensions/amp-story/0.1/media-pool.js
+++ b/extensions/amp-story/0.1/media-pool.js
@@ -675,12 +675,12 @@ export class MediaPool {
   /**
    * Pauses the specified media element in the DOM.
    * @param {!HTMLMediaElement} domMediaEl The media element to be paused.
-   * @param {boolean=} opt_rewindToBeginning Whether to rewind the currentTime
+   * @param {boolean=} rewindToBeginning Whether to rewind the currentTime
    *     of media items to the beginning.
    * @return {!Promise} A promise that is resolved when the specified media
    *     element has been successfully paused.
    */
-  pause(domMediaEl, opt_rewindToBeginning) {
+  pause(domMediaEl, rewindToBeginning = false) {
     const mediaType = this.getMediaType_(domMediaEl);
     const poolMediaEl =
         this.getMatchingMediaElementFromPool_(mediaType, domMediaEl);
@@ -691,7 +691,7 @@ export class MediaPool {
 
     return this.enqueueMediaElementTask_(poolMediaEl, new PauseTask())
         .then(() => {
-          if (opt_rewindToBeginning) {
+          if (rewindToBeginning) {
             this.enqueueMediaElementTask_(
                 /** @type {!HTMLMediaElement} */ (poolMediaEl),
                 new RewindTask());


### PR DESCRIPTION
These fixes are mostly trying to make the Safari and iOS experience smoother, but also positively impact any low memory phone.
Very small PR but big improvement, congrats to everyone who've been working on the media pool code, it's really great and I couldn't find much to make it faster!

I will keep the code running here until this PR is merged.
[Testing link](http://ampgmajoulet.herokuapp.com/proxy/www.washingtonpost.com/graphics/2018/sports/amp-stories/olympics-ice-dancing-figure-skating/)

Before / after:
![giphy](https://user-images.githubusercontent.com/1492044/36505190-bbc30f50-1720-11e8-82f9-9205120c87b0.gif) ![giphy 2](https://user-images.githubusercontent.com/1492044/36505127-8a0eb9fa-1720-11e8-97c2-ed1c683609b9.gif)

Short description:

### 1. Stops blessing videos on first navigation

Any action on ``HTMLMediaElement`` is really slow on Safari, as shown in [this codepen](https://codepen.io/gmajoulet/pen/GQOorq?editors=0011).
The blessing action is a succession of actions on these media elements, which is really slow on iOS phones, and any low end phone. It was blocking the navigation.

It also fixes a bug where a user, upon first navigation, could hear sound from the videos for a fraction of second. This was caused by the 

### 2. Blesses videos only when unmuting the story

We only bless the media elements once the user wants to turn the sound on.
On iOS and low end phones, it will still block the event loop, and the sound may take up to one or two seconds to play. But with the tap feedback on the sound icon, and the video still playing, the experience feels much better as we're not blocking any visual element/action.

### 3. Rewind videos when navigating away

Fixes a Safari issue where the user, after navigating back, could see the video being rewinded back to the beginning before playing again.

[Before](https://user-images.githubusercontent.com/1492044/36505329-262e29b0-1721-11e8-837f-0bf82e96d62d.gif)
[After](https://user-images.githubusercontent.com/1492044/36505344-32960fba-1721-11e8-9493-e6ba16c890b0.gif)


### 4. Reduce max elements in the media pool

We scan the DOM to know how many elements the media pool should instantiate.
Eg: If there is only one audio element, we no longer instantiate four.
See: #13245 