### PR TITLE
Rename document-click.js to navigation.js

### DIFF
--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -304,7 +304,7 @@ const forbiddenTerms = {
     message: 'Use parseUrl instead.',
     whitelist: [
       'src/url.js',
-      'src/service/document-click.js',
+      'src/service/navigation.js',
       'dist.3p/current/integration.js',
     ],
   },

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -609,8 +609,8 @@ export class AmpForm {
         user().assert(false, 'The `AMP-Redirect-To` header value must be an ' +
             'absolute URL starting with https://. Found %s', redirectTo);
       }
-      const clickHandler = Services.clickHandlerForDoc(this.form_);
-      clickHandler.navigateTo(this.win_, redirectTo, REDIRECT_TO_HEADER);
+      const navigator = Services.navigationForDoc(this.form_);
+      navigator.navigateTo(this.win_, redirectTo, REDIRECT_TO_HEADER);
     }
   }
 

--- a/extensions/amp-form/0.1/test/test-amp-form.js
+++ b/extensions/amp-form/0.1/test/test-amp-form.js
@@ -1566,7 +1566,7 @@ describes.repeated('', {
         ampForm.target_ = '_top';
 
         navigateTo = sandbox.spy();
-        sandbox.stub(Services, 'clickHandlerForDoc').returns({navigateTo});
+        sandbox.stub(Services, 'navigationForDoc').returns({navigateTo});
       });
 
       describe('AMP-Redirect-To', () => {

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -50,7 +50,7 @@ import {installCidService} from './service/cid-impl';
 import {installCryptoService} from './service/crypto-impl';
 import {installDocumentInfoServiceForDoc} from './service/document-info-impl';
 import {installDocumentStateService} from './service/document-state';
-import {installGlobalClickListenerForDoc} from './service/document-click';
+import {installGlobalNavigationHandlerForDoc} from './service/navigation';
 import {installGlobalSubmitListenerForDoc} from './document-submit';
 import {installHistoryServiceForDoc} from './service/history-impl';
 import {installInputService} from './input';
@@ -124,7 +124,7 @@ export function installAmpdocServices(ampdoc, opt_initParams) {
   installActionServiceForDoc(ampdoc);
   installStandardActionsForDoc(ampdoc);
   installStorageServiceForDoc(ampdoc);
-  installGlobalClickListenerForDoc(ampdoc);
+  installGlobalNavigationHandlerForDoc(ampdoc);
   installGlobalSubmitListenerForDoc(ampdoc);
 }
 

--- a/src/service/extensions-impl.js
+++ b/src/service/extensions-impl.js
@@ -715,7 +715,7 @@ function adoptStandardServicesForEmbed(childWin) {
   // to pass the "embeddable" flag if this set becomes too unwieldy.
   adoptServiceForEmbed(childWin, 'action');
   adoptServiceForEmbed(childWin, 'standard-actions');
-  adoptServiceForEmbed(childWin, 'clickhandler');
+  adoptServiceForEmbed(childWin, 'navigation');
 }
 
 

--- a/src/service/navigation.js
+++ b/src/service/navigation.js
@@ -38,31 +38,31 @@ import {
 } from '../url';
 import {toWin} from '../types';
 
-
-const TAG = 'clickhandler';
-
+const TAG = 'navigation';
 
 /**
- * Install click handler service for ampdoc. Immediately instantiates the
- * the click handler service.
+ * Install navigation service for ampdoc, which handles navigations from anchor
+ * tag clicks and other runtime features like AMP.navigateTo().
+ *
+ * Immediately instantiates the service.
+ *
  * @param {!./ampdoc-impl.AmpDoc} ampdoc
  */
-export function installGlobalClickListenerForDoc(ampdoc) {
+export function installGlobalNavigationHandlerForDoc(ampdoc) {
   registerServiceBuilderForDoc(
       ampdoc,
       TAG,
-      ClickHandler,
+      Navigation,
       /* opt_instantiate */ true);
 }
 
-// TODO(willchou): Rename to navigation.js#Navigation.
 /**
  * Intercept any click on the current document and prevent any
  * linking to an identifier from pushing into the history stack.
  * @implements {../service.EmbeddableService}
  * @visibleForTesting
  */
-export class ClickHandler {
+export class Navigation {
   /**
    * @param {!./ampdoc-impl.AmpDoc} ampdoc
    * @param {(!Document|!ShadowRoot)=} opt_rootNode
@@ -123,7 +123,7 @@ export class ClickHandler {
   /** @override */
   adoptEmbedWindow(embedWin) {
     installServiceInEmbedScope(embedWin, TAG,
-        new ClickHandler(this.ampdoc, embedWin.document));
+        new Navigation(this.ampdoc, embedWin.document));
   }
 
   /**

--- a/src/service/standard-actions-impl.js
+++ b/src/service/standard-actions-impl.js
@@ -176,7 +176,7 @@ export class StandardActions {
     const win = (node.ownerDocument || node).defaultView;
     const url = invocation.args['url'];
     const requestedBy = `AMP.${invocation.method}`;
-    Services.clickHandlerForDoc(this.ampdoc).navigateTo(win, url, requestedBy);
+    Services.navigationForDoc(this.ampdoc).navigateTo(win, url, requestedBy);
     return null;
   }
 

--- a/src/services.js
+++ b/src/services.js
@@ -152,11 +152,11 @@ export class Services {
 
   /**
    * @param {!Node|!./service/ampdoc-impl.AmpDoc} nodeOrDoc
-   * @return {!./service/document-click.ClickHandler}
+   * @return {!./service/navigation.Navigation}
    */
-  static clickHandlerForDoc(nodeOrDoc) {
-    return /** @type {!./service/document-click.ClickHandler} */ (
-      getServiceForDoc(nodeOrDoc, 'clickhandler'));
+  static navigationForDoc(nodeOrDoc) {
+    return /** @type {!./service/navigation.Navigation} */ (
+      getServiceForDoc(nodeOrDoc, 'navigation'));
   }
 
   /**

--- a/test/functional/test-navigation.js
+++ b/test/functional/test-navigation.js
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-import '../../src/service/document-click';
+import '../../src/service/navigation';
 import * as Impression from '../../src/impression';
 import {Services} from '../../src/services';
 import {addParamToUrl} from '../../src/url';
 import {macroTask} from '../../testing/yield';
 
 
-describes.sandboxed('ClickHandler', {}, () => {
+describes.sandboxed('Navigation', {}, () => {
   let event;
 
   beforeEach(() => {
@@ -57,7 +57,7 @@ describes.sandboxed('ClickHandler', {}, () => {
       win = env.win;
       doc = win.document;
 
-      handler = Services.clickHandlerForDoc(doc);
+      handler = Services.navigationForDoc(doc);
       handler.isIframed_ = true;
       decorationSpy = sandbox.spy(Impression, 'getExtraParamsUrl');
       handleNavSpy = sandbox.spy(handler, 'handleNavClick_');
@@ -567,7 +567,7 @@ describes.sandboxed('ClickHandler', {}, () => {
         parentWin = env.parentWin;
         embed = env.embed;
 
-        handler = win.services.clickhandler.obj;
+        handler = win.services.navigation.obj;
         winOpenStub = sandbox.stub(win, 'open').callsFake(() => {
           return {};
         });

--- a/test/functional/test-standard-actions.js
+++ b/test/functional/test-standard-actions.js
@@ -206,8 +206,8 @@ describes.sandboxed('StandardActions', {}, () => {
 
   describe('"AMP" global target', () => {
     it('should implement navigateTo', () => {
-      const clickHandler = {navigateTo: sandbox.stub()};
-      sandbox.stub(Services, 'clickHandlerForDoc').returns(clickHandler);
+      const navigator = {navigateTo: sandbox.stub()};
+      sandbox.stub(Services, 'navigationForDoc').returns(navigator);
 
       const win = {};
       const invocation = {
@@ -225,13 +225,13 @@ describes.sandboxed('StandardActions', {}, () => {
       // Should check trust and fail.
       invocation.satisfiesTrust = () => false;
       standardActions.handleAmpTarget(invocation);
-      expect(clickHandler.navigateTo).to.be.not.called;
+      expect(navigator.navigateTo).to.be.not.called;
 
       // Should succeed.
       invocation.satisfiesTrust = () => true;
       standardActions.handleAmpTarget(invocation);
-      expect(clickHandler.navigateTo).to.be.calledOnce;
-      expect(clickHandler.navigateTo).to.be.calledWithExactly(
+      expect(navigator.navigateTo).to.be.calledOnce;
+      expect(navigator.navigateTo).to.be.calledWithExactly(
           win, 'http://bar.com', 'AMP.navigateTo');
     });
 


### PR DESCRIPTION
Follow-up to #13300.

- `ClickHandler` service in document-click.js now handles more than just clicks and is the arbiter for navigations in general