### PR TITLE
amp-form: remove  for the visible-when-invalid CSS

### DIFF
--- a/css/amp.css
+++ b/css/amp.css
@@ -620,8 +620,8 @@ form [submit-error] {
 /**
  * Form validation error messages should be hidden at first.
  */
-span[visible-when-invalid] {
-  display: none;  
+[visible-when-invalid] {
+  display: none;
 }
 
 /**


### PR DESCRIPTION
Follow up to https://github.com/ampproject/amphtml/pull/13580 `span` part is too restrictive since it can be a `div`