### PR TITLE
Initial draft for lightbox CSS API

### DIFF
--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.css
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.css
@@ -23,23 +23,22 @@
   z-index: 2147483642;
 }
 
-.i-amphtml-lbg-mask,
-.i-amphtml-lbg-gallery {
-  position: absolute !important;
-  left: 0 !important;
-  right: 0 !important;
-  bottom: 0 !important;
+.amp-lbg-mask {
   opacity: 1;
   background-color: rgba(0,0,0, 1);
 }
 
-.i-amphtml-lbg-mask {
+.i-amphtml-lbg-mask,
+.i-amphtml-lbg-gallery {
+  position: absolute !important;
   top:0 !important;
+  left: 0 !important;
+  right: 0 !important;
+  bottom: 0 !important;
 }
 
 .i-amphtml-lbg-gallery {
   display: none;
-  top: 0 !important;
   padding-top: 56px !important;
   overflow: auto !important;
 }
@@ -57,7 +56,7 @@
   top: 0 !important;
   height: 56px !important;
   background: linear-gradient(rgba(0,0,0,0.3), rgba(0,0,0,0));
-  z-index: 2;
+  z-index: 2 !important;
 }
 
 @media (min-width: 1024px) {
@@ -75,14 +74,6 @@
  {
   opacity: 1;
   animation: fadeOut linear 0.4s 1 forwards;
-}
-
-.i-amphtml-lbg-top-bar.fullscreen .i-amphtml-lbg-top-bar-top-gradient {
-  position: absolute !important;
-  left: 0 !important;
-  right: 0 !important;
-  top: 0 !important;
-  background: linear-gradient(rgba(0,0,0,0.3), rgba(0,0,0,0));
 }
 
 .i-amphtml-lbg-desc-box {
@@ -128,7 +119,7 @@
   grid-gap: 5px !important;
   grid-template-columns: repeat(3, 1fr) !important;
   grid-auto-rows: min-content !important;
-  padding: 5px !important;
+  padding: 5px;
 }
 
 @media (min-width: 1024px) {
@@ -185,8 +176,12 @@
   right: 0;
 }
 
+.amp-lbg-icon {
+  background-color: #ffffff;
+}
+
 .amp-lbg-button-close .amp-lbg-icon {
-  background-image: url('data:image/svg+xml;charset=utf-8,<svg viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd"><g id="close" fill="#fff" fill-rule="nonzero"><path d="M18.295,5.705 L18.295,5.705 C17.9056393,5.31563925 17.2743607,5.31563925 16.885,5.705 L12,10.59 L7.115,5.705 C6.72563925,5.31563925 6.09436075,5.31563925 5.705,5.705 L5.705,5.705 C5.31563925,6.09436075 5.31563925,6.72563925 5.705,7.115 L10.59,12 L5.705,16.885 C5.31563925,17.2743607 5.31563925,17.9056393 5.705,18.295 L5.705,18.295 C6.09436075,18.6843607 6.72563925,18.6843607 7.115,18.295 L12,13.41 L16.885,18.295 C17.2743607,18.6843607 17.9056393,18.6843607 18.295,18.295 L18.295,18.295 C18.6843607,17.9056393 18.6843607,17.2743607 18.295,16.885 L13.41,12 L18.295,7.115 C18.6843607,6.72563925 18.6843607,6.09436075 18.295,5.705 Z" id="Shape"></path></g></g></svg>');
+  mask-image: url('data:image/svg+xml;charset=utf-8,<svg viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd"><g id="close" fill="#fff" fill-rule="nonzero"><path d="M18.295,5.705 L18.295,5.705 C17.9056393,5.31563925 17.2743607,5.31563925 16.885,5.705 L12,10.59 L7.115,5.705 C6.72563925,5.31563925 6.09436075,5.31563925 5.705,5.705 L5.705,5.705 C5.31563925,6.09436075 5.31563925,6.72563925 5.705,7.115 L10.59,12 L5.705,16.885 C5.31563925,17.2743607 5.31563925,17.9056393 5.705,18.295 L5.705,18.295 C6.09436075,18.6843607 6.72563925,18.6843607 7.115,18.295 L12,13.41 L16.885,18.295 C17.2743607,18.6843607 17.9056393,18.6843607 18.295,18.295 L18.295,18.295 C18.6843607,17.9056393 18.6843607,17.2743607 18.295,16.885 L13.41,12 L18.295,7.115 C18.6843607,6.72563925 18.6843607,6.09436075 18.295,5.705 Z" id="Shape"></path></g></g></svg>');
 }
 
 
@@ -196,7 +191,7 @@
 }
 
 .amp-lbg-button-gallery .amp-lbg-icon {
-  background-image: url('data:image/svg+xml;charset=utf-8,<svg viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd"><g id="grid" fill="#fff"><path d="M4,3 L8,3 C8.55228475,3 9,3.44771525 9,4 L9,10 C9,10.5522847 8.55228475,11 8,11 L4,11 C3.44771525,11 3,10.5522847 3,10 L3,4 C3,3.44771525 3.44771525,3 4,3 Z M12,3 L20,3 C20.5522847,3 21,3.44771525 21,4 L21,10 C21,10.5522847 20.5522847,11 20,11 L12,11 C11.4477153,11 11,10.5522847 11,10 L11,4 C11,3.44771525 11.4477153,3 12,3 Z M4,13 L12,13 C12.5522847,13 13,13.4477153 13,14 L13,20 C13,20.5522847 12.5522847,21 12,21 L4,21 C3.44771525,21 3,20.5522847 3,20 L3,14 C3,13.4477153 3.44771525,13 4,13 Z M16,13 L20,13 C20.5522847,13 21,13.4477153 21,14 L21,20 C21,20.5522847 20.5522847,21 20,21 L16,21 C15.4477153,21 15,20.5522847 15,20 L15,14 C15,13.4477153 15.4477153,13 16,13 Z" id="Combined-Shape"></path></g></g></svg>');
+  mask-image: url('data:image/svg+xml;charset=utf-8,<svg viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd"><g id="grid" fill="#fff"><path d="M4,3 L8,3 C8.55228475,3 9,3.44771525 9,4 L9,10 C9,10.5522847 8.55228475,11 8,11 L4,11 C3.44771525,11 3,10.5522847 3,10 L3,4 C3,3.44771525 3.44771525,3 4,3 Z M12,3 L20,3 C20.5522847,3 21,3.44771525 21,4 L21,10 C21,10.5522847 20.5522847,11 20,11 L12,11 C11.4477153,11 11,10.5522847 11,10 L11,4 C11,3.44771525 11.4477153,3 12,3 Z M4,13 L12,13 C12.5522847,13 13,13.4477153 13,14 L13,20 C13,20.5522847 12.5522847,21 12,21 L4,21 C3.44771525,21 3,20.5522847 3,20 L3,14 C3,13.4477153 3.44771525,13 4,13 Z M16,13 L20,13 C20.5522847,13 21,13.4477153 21,14 L21,20 C21,20.5522847 20.5522847,21 20,21 L16,21 C15.4477153,21 15,20.5522847 15,20 L15,14 C15,13.4477153 15.4477153,13 16,13 Z" id="Combined-Shape"></path></g></g></svg>');
 }
 
 .amp-lbg-button-slide {
@@ -206,7 +201,7 @@
 }
 
 .amp-lbg-button-slide .amp-lbg-icon {
-  background-image: url('data:image/svg+xml;charset=utf-8,<svg viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd"><g id="image" fill="#fff"><path d="M5,3 L19,3 C20.1045695,3 21,3.8954305 21,5 L21,19 C21,20.1045695 20.1045695,21 19,21 L5,21 C3.8954305,21 3,20.1045695 3,19 L3,5 C3,3.8954305 3.8954305,3 5,3 Z M19,15 L19,5 L5,5 L5,13.0000896 L8,10.0003584 L13,15 L16,12 L19,15 Z M15.5,10 C14.6715729,10 14,9.32842712 14,8.5 C14,7.67157288 14.6715729,7 15.5,7 C16.3284271,7 17,7.67157288 17,8.5 C17,9.32842712 16.3284271,10 15.5,10 Z" id="Combined-Shape"></path></g></g></svg>');
+  mask-image: url('data:image/svg+xml;charset=utf-8,<svg viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd"><g id="image" fill="#fff"><path d="M5,3 L19,3 C20.1045695,3 21,3.8954305 21,5 L21,19 C21,20.1045695 20.1045695,21 19,21 L5,21 C3.8954305,21 3,20.1045695 3,19 L3,5 C3,3.8954305 3.8954305,3 5,3 Z M19,15 L19,5 L5,5 L5,13.0000896 L8,10.0003584 L13,15 L16,12 L19,15 Z M15.5,10 C14.6715729,10 14,9.32842712 14,8.5 C14,7.67157288 14.6715729,7 15.5,7 C16.3284271,7 17,7.67157288 17,8.5 C17,9.32842712 16.3284271,10 15.5,10 Z" id="Combined-Shape"></path></g></g></svg>');
 }
 
 .i-amphtml-lbg[gallery-view] .amp-lbg-button-gallery {

--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.css
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.css
@@ -16,15 +16,15 @@
 
  /* Public CSS Classes */
 
- .amp-lbv-desc-box.standard {
+ .amp-lbg-desc-box.standard {
   background: linear-gradient(rgba(0,0,0,0), rgba(0,0,0,0.5));
  }
 
- .amp-lbv-desc-box.overflow {
+ .amp-lbg-desc-box.overflow {
   background-color: rgba(0,0,0,0.5);
  }
 
- .amp-lbv-desc-text {
+ .amp-lbg-desc-text {
    /* Public CSS class for description font */
  }
 

--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.css
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.css
@@ -29,12 +29,8 @@
   left: 0 !important;
   right: 0 !important;
   bottom: 0 !important;
-  /*
-   * For now we force a non-transparent shim until we find a good solution
-   * for the background page shifting when items get lightboxed.
-   */
-  opacity: 1 !important;
-  background-color: rgba(0,0,0, 1) !important;
+  opacity: 1;
+  background-color: rgba(0,0,0, 1);
 }
 
 .i-amphtml-lbg-mask {
@@ -96,7 +92,7 @@
   bottom: 0 !important;
   overflow-x: hidden !important;
   color: #ffffff;
-  z-index: 2;
+  z-index: 2 !important;
   opacity: 0;
   animation: fadeIn ease-in 0.4s 1 forwards;
 }
@@ -127,12 +123,12 @@
 }
 
 .i-amphtml-lbg[gallery-view] .i-amphtml-lbg-gallery {
-  display: grid;
-  justify-content: center;
-  grid-gap: 5px;
-  grid-template-columns: repeat(3, 1fr);
-  grid-auto-rows: min-content;
-  padding: 5px;
+  display: grid !important;
+  justify-content: center !important;
+  grid-gap: 5px !important;
+  grid-template-columns: repeat(3, 1fr) !important;
+  grid-auto-rows: min-content !important;
+  padding: 5px !important;
 }
 
 @media (min-width: 1024px) {
@@ -142,12 +138,12 @@
 }
 
 .i-amphtml-lbg[gallery-view] .i-amphtml-lbg-gallery.i-amphtml-lbg-gallery-hidden {
-  display: none;
+  display: none !important;
 }
 
 .i-amphtml-lbg-gallery-thumbnail {
-  position: relative;
-  padding-top: 100%;
+  position: relative !important;
+  padding-top: 100% !important;
 }
 
 .i-amphtml-lbg-gallery-thumbnail-img {

--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.css
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.css
@@ -14,6 +14,75 @@
  * limitations under the License.
  */
 
+ /* Public CSS Classes */
+
+ .amp-lbv-desc-box.standard {
+  background: linear-gradient(rgba(0,0,0,0), rgba(0,0,0,0.5));
+ }
+
+ .amp-lbv-desc-box.overflow {
+  background-color: rgba(0,0,0,0.5);
+ }
+
+ .amp-lbv-desc-text {
+   /* Public CSS class for description font */
+ }
+
+.amp-lbg-mask {
+  opacity: 1;
+  background-color: rgba(0,0,0, 1);
+}
+
+.amp-lbg-icon {
+  width: 100%;
+  height: 100%;
+  display: block;
+  background-repeat: no-repeat;
+  background-position: center center;
+}
+
+.amp-lbg-button-close {
+  top: 0;
+  right: 0;
+}
+
+.amp-lbg-icon {
+  background-color: #ffffff;
+}
+
+.amp-lbg-button-close .amp-lbg-icon {
+  mask-image: url('data:image/svg+xml;charset=utf-8,<svg viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd"><g id="close" fill="#fff" fill-rule="nonzero"><path d="M18.295,5.705 L18.295,5.705 C17.9056393,5.31563925 17.2743607,5.31563925 16.885,5.705 L12,10.59 L7.115,5.705 C6.72563925,5.31563925 6.09436075,5.31563925 5.705,5.705 L5.705,5.705 C5.31563925,6.09436075 5.31563925,6.72563925 5.705,7.115 L10.59,12 L5.705,16.885 C5.31563925,17.2743607 5.31563925,17.9056393 5.705,18.295 L5.705,18.295 C6.09436075,18.6843607 6.72563925,18.6843607 7.115,18.295 L12,13.41 L16.885,18.295 C17.2743607,18.6843607 17.9056393,18.6843607 18.295,18.295 L18.295,18.295 C18.6843607,17.9056393 18.6843607,17.2743607 18.295,16.885 L13.41,12 L18.295,7.115 C18.6843607,6.72563925 18.6843607,6.09436075 18.295,5.705 Z" id="Shape"></path></g></g></svg>');
+}
+
+.amp-lbg-button-gallery {
+  top: 0;
+  left: 0;
+}
+
+.amp-lbg-button-gallery .amp-lbg-icon {
+  mask-image: url('data:image/svg+xml;charset=utf-8,<svg viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd"><g id="grid" fill="#fff"><path d="M4,3 L8,3 C8.55228475,3 9,3.44771525 9,4 L9,10 C9,10.5522847 8.55228475,11 8,11 L4,11 C3.44771525,11 3,10.5522847 3,10 L3,4 C3,3.44771525 3.44771525,3 4,3 Z M12,3 L20,3 C20.5522847,3 21,3.44771525 21,4 L21,10 C21,10.5522847 20.5522847,11 20,11 L12,11 C11.4477153,11 11,10.5522847 11,10 L11,4 C11,3.44771525 11.4477153,3 12,3 Z M4,13 L12,13 C12.5522847,13 13,13.4477153 13,14 L13,20 C13,20.5522847 12.5522847,21 12,21 L4,21 C3.44771525,21 3,20.5522847 3,20 L3,14 C3,13.4477153 3.44771525,13 4,13 Z M16,13 L20,13 C20.5522847,13 21,13.4477153 21,14 L21,20 C21,20.5522847 20.5522847,21 20,21 L16,21 C15.4477153,21 15,20.5522847 15,20 L15,14 C15,13.4477153 15.4477153,13 16,13 Z" id="Combined-Shape"></path></g></g></svg>');
+}
+
+.amp-lbg-button-slide {
+  top: 0;
+  left: 0;
+  display: none;
+}
+
+.amp-lbg-button-slide .amp-lbg-icon {
+  mask-image: url('data:image/svg+xml;charset=utf-8,<svg viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd"><g id="image" fill="#fff"><path d="M5,3 L19,3 C20.1045695,3 21,3.8954305 21,5 L21,19 C21,20.1045695 20.1045695,21 19,21 L5,21 C3.8954305,21 3,20.1045695 3,19 L3,5 C3,3.8954305 3.8954305,3 5,3 Z M19,15 L19,5 L5,5 L5,13.0000896 L8,10.0003584 L13,15 L16,12 L19,15 Z M15.5,10 C14.6715729,10 14,9.32842712 14,8.5 C14,7.67157288 14.6715729,7 15.5,7 C16.3284271,7 17,7.67157288 17,8.5 C17,9.32842712 16.3284271,10 15.5,10 Z" id="Combined-Shape"></path></g></g></svg>');
+}
+
+.amp-lbg-button {
+  position: absolute !important;
+  cursor: pointer;
+  width: 24px;
+  height: 24px;
+  padding: 16px;
+}
+
+/* Private CSS Classes Below */
+
 .i-amphtml-lbg {
   position: fixed !important;
   top: 0 !important;
@@ -21,11 +90,6 @@
   right: 0 !important;
   bottom: 0 !important;
   z-index: 2147483642;
-}
-
-.amp-lbg-mask {
-  opacity: 1;
-  background-color: rgba(0,0,0, 1);
 }
 
 .i-amphtml-lbg-mask,
@@ -89,14 +153,12 @@
 }
 
 .i-amphtml-lbg-desc-box.standard {
-  max-height: 6rem;
-  background: linear-gradient(rgba(0,0,0,0), rgba(0,0,0,0.5));
+  max-height: 6rem !important;
 }
 
 .i-amphtml-lbg-desc-box.overflow {
   overflow-y: auto !important;
   -webkit-overflow-scrolling: touch !important;
-  background-color: rgba(0,0,0,0.5);
   top: 0px !important;
   padding-top: 50px !important;
 }
@@ -146,62 +208,12 @@
   cursor: pointer;
 }
 
-/* Controls */
-.amp-lbg-button {
-  position: absolute !important;
-  cursor: pointer;
-  width: 24px;
-  height: 24px;
-  padding: 16px;
-}
-
 @media (min-width: 1024px) {
   .amp-lbg-button {
     width: 40px;
     height: 40px;
     padding: 20px;
   }
-}
-
-.amp-lbg-icon {
-  width: 100%;
-  height: 100%;
-  display: block;
-  background-repeat: no-repeat;
-  background-position: center center;
-}
-
-.amp-lbg-button-close {
-  top: 0;
-  right: 0;
-}
-
-.amp-lbg-icon {
-  background-color: #ffffff;
-}
-
-.amp-lbg-button-close .amp-lbg-icon {
-  mask-image: url('data:image/svg+xml;charset=utf-8,<svg viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd"><g id="close" fill="#fff" fill-rule="nonzero"><path d="M18.295,5.705 L18.295,5.705 C17.9056393,5.31563925 17.2743607,5.31563925 16.885,5.705 L12,10.59 L7.115,5.705 C6.72563925,5.31563925 6.09436075,5.31563925 5.705,5.705 L5.705,5.705 C5.31563925,6.09436075 5.31563925,6.72563925 5.705,7.115 L10.59,12 L5.705,16.885 C5.31563925,17.2743607 5.31563925,17.9056393 5.705,18.295 L5.705,18.295 C6.09436075,18.6843607 6.72563925,18.6843607 7.115,18.295 L12,13.41 L16.885,18.295 C17.2743607,18.6843607 17.9056393,18.6843607 18.295,18.295 L18.295,18.295 C18.6843607,17.9056393 18.6843607,17.2743607 18.295,16.885 L13.41,12 L18.295,7.115 C18.6843607,6.72563925 18.6843607,6.09436075 18.295,5.705 Z" id="Shape"></path></g></g></svg>');
-}
-
-
-.amp-lbg-button-gallery {
-  top: 0;
-  left: 0;
-}
-
-.amp-lbg-button-gallery .amp-lbg-icon {
-  mask-image: url('data:image/svg+xml;charset=utf-8,<svg viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd"><g id="grid" fill="#fff"><path d="M4,3 L8,3 C8.55228475,3 9,3.44771525 9,4 L9,10 C9,10.5522847 8.55228475,11 8,11 L4,11 C3.44771525,11 3,10.5522847 3,10 L3,4 C3,3.44771525 3.44771525,3 4,3 Z M12,3 L20,3 C20.5522847,3 21,3.44771525 21,4 L21,10 C21,10.5522847 20.5522847,11 20,11 L12,11 C11.4477153,11 11,10.5522847 11,10 L11,4 C11,3.44771525 11.4477153,3 12,3 Z M4,13 L12,13 C12.5522847,13 13,13.4477153 13,14 L13,20 C13,20.5522847 12.5522847,21 12,21 L4,21 C3.44771525,21 3,20.5522847 3,20 L3,14 C3,13.4477153 3.44771525,13 4,13 Z M16,13 L20,13 C20.5522847,13 21,13.4477153 21,14 L21,20 C21,20.5522847 20.5522847,21 20,21 L16,21 C15.4477153,21 15,20.5522847 15,20 L15,14 C15,13.4477153 15.4477153,13 16,13 Z" id="Combined-Shape"></path></g></g></svg>');
-}
-
-.amp-lbg-button-slide {
-  top: 0;
-  left: 0;
-  display: none;
-}
-
-.amp-lbg-button-slide .amp-lbg-icon {
-  mask-image: url('data:image/svg+xml;charset=utf-8,<svg viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd"><g id="image" fill="#fff"><path d="M5,3 L19,3 C20.1045695,3 21,3.8954305 21,5 L21,19 C21,20.1045695 20.1045695,21 19,21 L5,21 C3.8954305,21 3,20.1045695 3,19 L3,5 C3,3.8954305 3.8954305,3 5,3 Z M19,15 L19,5 L5,5 L5,13.0000896 L8,10.0003584 L13,15 L16,12 L19,15 Z M15.5,10 C14.6715729,10 14,9.32842712 14,8.5 C14,7.67157288 14.6715729,7 15.5,7 C16.3284271,7 17,7.67157288 17,8.5 C17,9.32842712 16.3284271,10 15.5,10 Z" id="Combined-Shape"></path></g></g></svg>');
 }
 
 .i-amphtml-lbg[gallery-view] .amp-lbg-button-gallery {

--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -329,14 +329,14 @@ export class AmpLightboxGallery extends AMP.BaseElement {
     this.descriptionBox_.classList.add('standard');
 
     // public css api for styling the description box
-    this.descriptionBox_.classList.add('amp-lbv-desc-box');
+    this.descriptionBox_.classList.add('amp-lbg-desc-box');
 
     this.descriptionTextArea_ = this.win.document.createElement('div');
     this.descriptionTextArea_.classList.add('i-amphtml-lbg-desc-text');
     this.descriptionTextArea_.classList.add('non-expanded');
 
     // public css api for styling the description text area
-    this.descriptionTextArea_.classList.add('amp-lbv-desc-text');
+    this.descriptionTextArea_.classList.add('amp-lbg-desc-text');
 
     this.descriptionBox_.appendChild(this.descriptionTextArea_);
 

--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -491,7 +491,6 @@ export class AmpLightboxGallery extends AMP.BaseElement {
     button.classList.add(className);
     button.classList.add('amp-lbg-button');
 
-
     button.addEventListener('click', event => {
       action();
       event.stopPropagation();

--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -457,9 +457,8 @@ export class AmpLightboxGallery extends AMP.BaseElement {
     this.topBar_.classList.add('i-amphtml-lbg-top-bar');
     this.topBar_.classList.add('i-amphtml-lbg-controls');
 
-    this.topGradient_ = this.win.document.createElement('div');
-    this.topGradient_.classList.add('i-amphtml-lbg-top-bar-top-gradient');
-    this.topBar_.appendChild(this.topGradient_);
+    // public css api for top control bar
+    this.topBar_.classList.add('amp-lbg-top-bar');
 
     const close = this.close_.bind(this);
     const openGallery = this.openGallery_.bind(this);

--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -205,6 +205,8 @@ export class AmpLightboxGallery extends AMP.BaseElement {
     dev().assert(this.container_);
     const mask = this.win.document.createElement('div');
     mask.classList.add('i-amphtml-lbg-mask');
+    // public css class for user styling
+    mask.classList.add('amp-lbg-mask');
     this.container_.appendChild(mask);
   }
 
@@ -324,12 +326,18 @@ export class AmpLightboxGallery extends AMP.BaseElement {
     this.descriptionBox_ = this.win.document.createElement('div');
     this.descriptionBox_.classList.add('i-amphtml-lbg-desc-box');
     this.descriptionBox_.classList.add('i-amphtml-lbg-controls');
-
     this.descriptionBox_.classList.add('standard');
+
+    // public css api for styling the description box
+    this.descriptionBox_.classList.add('amp-lbv-desc-box');
 
     this.descriptionTextArea_ = this.win.document.createElement('div');
     this.descriptionTextArea_.classList.add('i-amphtml-lbg-desc-text');
     this.descriptionTextArea_.classList.add('non-expanded');
+
+    // public css api for styling the description text area
+    this.descriptionTextArea_.classList.add('amp-lbv-desc-text');
+
     this.descriptionBox_.appendChild(this.descriptionTextArea_);
 
     this.descriptionBox_.addEventListener('click', event => {

--- a/extensions/amp-lightbox-gallery/amp-lightbox-gallery.md
+++ b/extensions/amp-lightbox-gallery/amp-lightbox-gallery.md
@@ -116,35 +116,39 @@ The CSS API exposes the following CSS classes so that you can customize the styl
 
 <table>
   <tr>
-    <td width="40%"><pre>.amp-lbg-mask</pre></td>
-    <td>Class to customize the background color and opacity for the lightbox.</td>
+    <td width="40%">CSS class</td>
+    <td>Description</td>
+  </tr>
+  <tr>
+    <td><code>.amp-lbg-mask</code></td>
+    <td>Use to customize the background color and opacity for the lightbox.</td>
   </tr>
    <tr>
-    <td width="40%"><pre>.amp-lbv-desc-box.standard, .amp-lbv-desc-box.overflow</pre></td>
-    <td>Class to customize the description box's background color and gradient.</td>
+    <td><code>.amp-lbv-desc-box.standard</code>,<code>.amp-lbv-desc-box.overflow</code></td>
+    <td>Use to customize the description box's background color and gradient.</td>
   </tr>
   <tr>
-    <td width="40%"><pre>.amp-lbg-top-bar</pre></td>
-    <td>Class to customize the color and gradient for the lightbox's top controls bar.</td>
+    <td><code>.amp-lbg-top-bar</code></td>
+    <td>Use to customize the color and gradient for the lightbox's top controls bar.</td>
   </tr>
-    <td width="40%"><pre>.amp-lbv-desc-text</ore></td>
-    <td>Class to customize the font and colors for the description.</td>
-  </tr>
-  <tr>
-    <td width="40%"><pre>.amp-lbg-icon</pre></td>
-    <td>Class to customize the icon colors.</td>
+    <td><code>.amp-lbv-desc-text</code></td>
+    <td>Use to customize the font and colors for the description.</td>
   </tr>
   <tr>
-    <td width="40%"><pre>.amp-lbg-button-close .amp-lbg-icon</pre></td>
-    <td>Class to customize the icon for the close button.</td>
+    <td><code>.amp-lbg-icon</code></td>
+    <td>Use to customize the icon colors.</td>
   </tr>
   <tr>
-    <td width="40%"><pre>.amp-lbg-button-gallery .amp-lbg-icon</pre></td>
-    <td>Class to customize the icon for the gallery button.</td>
+    <td><code>.amp-lbg-button-close</code>,<code>.amp-lbg-icon</code></td>
+    <td>Use to customize the icon for the close button.</td>
+  </tr>
+  <tr>
+    <td><code>.amp-lbg-button-gallery</code>,<code>.amp-lbg-icon</code></td>
+    <td>Use to customize the icon for the gallery button.</td>
   </tr>
     <tr>
-    <td width="40%"><pre>.amp-lbg-button-slide .amp-lbg-icon</pre></td>
-    <td>Class to customize the icon for the slide button.</td>
+    <td><code>.amp-lbg-button-slide</code>,<code>.amp-lbg-icon</code></td>
+    <td>Use to customize the icon for the slide button.</td>
   </tr>
 </table>
 

--- a/extensions/amp-lightbox-gallery/amp-lightbox-gallery.md
+++ b/extensions/amp-lightbox-gallery/amp-lightbox-gallery.md
@@ -112,66 +112,66 @@ In this example, `<amp-lightbox-gallery>` displays the `alt` value as its descri
 
 ## CSS API
 
-The following CSS classes are exposed for custom styling.
+The CSS API exposes the following CSS classes so that you can customize the style of your lightbox: 
 
 <table>
   <tr>
     <td width="40%"><pre>.amp-lbg-mask</pre></td>
-    <td>For customizing the lightbox background's color and opacity.</td>
+    <td>Class to customize the background color and opacity for the lightbox.</td>
   </tr>
    <tr>
     <td width="40%"><pre>.amp-lbv-desc-box.standard, .amp-lbv-desc-box.overflow</pre></td>
-    <td>For customizing the description box's background color and gradient.</td>
+    <td>Class to customize the description box's background color and gradient.</td>
   </tr>
   <tr>
     <td width="40%"><pre>.amp-lbg-top-bar</pre></td>
-    <td>For customizing the color and gradient for the lightbox's top controls bar.</td>
+    <td>Class to customize the color and gradient for the lightbox's top controls bar.</td>
   </tr>
     <td width="40%"><pre>.amp-lbv-desc-text</ore></td>
-    <td>For customizing description text font and colors.</td>
+    <td>Class to customize the font and colors for the description.</td>
   </tr>
   <tr>
     <td width="40%"><pre>.amp-lbg-icon</pre></td>
-    <td>For customizing icon colors.</td>
+    <td>Class to customize the icon colors.</td>
   </tr>
   <tr>
     <td width="40%"><pre>.amp-lbg-button-close .amp-lbg-icon</pre></td>
-    <td>For customizing the icon for the close button</td>
+    <td>Class to customize the icon for the close button.</td>
   </tr>
   <tr>
     <td width="40%"><pre>.amp-lbg-button-gallery .amp-lbg-icon</pre></td>
-    <td>For customizing the icon for the gallery button</td>
+    <td>Class to customize the icon for the gallery button.</td>
   </tr>
     <tr>
     <td width="40%"><pre>.amp-lbg-button-slide .amp-lbg-icon</pre></td>
-    <td>For customizing the icon for the slide button</td>
+    <td>Class to customize the icon for the slide button.</td>
   </tr>
 </table>
 
-#### Example 3: Using CSS to invert lightbox colors
+#### Example: Using CSS to invert lightbox colors
 
 The following example uses the CSS API to set the lightbox background to white and the icon colors to black.
 
 ```html
-    .amp-lbg-mask {
-      opacity: 0.9;
-      background-color: rgba(255, 255, 255, 1);
-    }
+.amp-lbg-mask {
+  opacity: 0.9;
+  background-color: rgba(255, 255, 255, 1);
+}
 
-    .amp-lbv-desc-box.standard, .amp-lbv-desc-box.overflow {
-      background: linear-gradient(transparent,rgba(255, 255, 255, 0.5));
-      color: #000000;
-    }
+.amp-lbv-desc-box.standard, .amp-lbv-desc-box.overflow {
+  background: linear-gradient(transparent,rgba(255, 255, 255, 0.5));
+  color: #000000;
+}
 
-    .amp-lbg-top-bar {
-      background: linear-gradient(rgba(255,255,255,0.3), rgba(255,255,255,0));
-    }
+.amp-lbg-top-bar {
+  background: linear-gradient(rgba(255,255,255,0.3), rgba(255,255,255,0));
+}
 
-    .amp-lbg-icon {
-      background-color: #000000;
-    }
+.amp-lbg-icon {
+  background-color: #000000;
+}
 
-    .amp-lbv-desc-text {
-      font-family: 'Gill Sans', 'Gill Sans MT', Calibri, 'Trebuchet MS', sans-serif;
-    }
+.amp-lbv-desc-text {
+  font-family: 'Gill Sans', 'Gill Sans MT', Calibri, 'Trebuchet MS', sans-serif;
+}
 ```

--- a/extensions/amp-lightbox-gallery/amp-lightbox-gallery.md
+++ b/extensions/amp-lightbox-gallery/amp-lightbox-gallery.md
@@ -109,3 +109,69 @@ In this example, `<amp-lightbox-gallery>` displays the `alt` value as its descri
   alt="Picture of CN tower">
 </amp-img>
 ```
+
+## CSS API
+
+The following CSS classes are exposed for custom styling.
+
+<table>
+  <tr>
+    <td width="40%"><pre>.amp-lbg-mask</pre></td>
+    <td>For customizing the lightbox background's color and opacity.</td>
+  </tr>
+   <tr>
+    <td width="40%"><pre>.amp-lbv-desc-box.standard, .amp-lbv-desc-box.overflow</pre></td>
+    <td>For customizing the description box's background color and gradient.</td>
+  </tr>
+  <tr>
+    <td width="40%"><pre>.amp-lbg-top-bar</pre></td>
+    <td>For customizing the color and gradient for the lightbox's top controls bar.</td>
+  </tr>
+    <td width="40%"><pre>.amp-lbv-desc-text</ore></td>
+    <td>For customizing description text font and colors.</td>
+  </tr>
+  <tr>
+    <td width="40%"><pre>.amp-lbg-icon</pre></td>
+    <td>For customizing icon colors.</td>
+  </tr>
+  <tr>
+    <td width="40%"><pre>.amp-lbg-button-close .amp-lbg-icon</pre></td>
+    <td>For customizing the icon for the close button</td>
+  </tr>
+  <tr>
+    <td width="40%"><pre>.amp-lbg-button-gallery .amp-lbg-icon</pre></td>
+    <td>For customizing the icon for the gallery button</td>
+  </tr>
+    <tr>
+    <td width="40%"><pre>.amp-lbg-button-slide .amp-lbg-icon</pre></td>
+    <td>For customizing the icon for the slide button</td>
+  </tr>
+</table>
+
+#### Example 3: Using CSS to invert lightbox colors
+
+The following example uses the CSS API to set the lightbox background to white and the icon colors to black.
+
+```html
+    .amp-lbg-mask {
+      opacity: 0.9;
+      background-color: rgba(255, 255, 255, 1);
+    }
+
+    .amp-lbv-desc-box.standard, .amp-lbv-desc-box.overflow {
+      background: linear-gradient(transparent,rgba(255, 255, 255, 0.5));
+      color: #000000;
+    }
+
+    .amp-lbg-top-bar {
+      background: linear-gradient(rgba(255,255,255,0.3), rgba(255,255,255,0));
+    }
+
+    .amp-lbg-icon {
+      background-color: #000000;
+    }
+
+    .amp-lbv-desc-text {
+      font-family: 'Gill Sans', 'Gill Sans MT', Calibri, 'Trebuchet MS', sans-serif;
+    }
+```

--- a/extensions/amp-lightbox-gallery/amp-lightbox-gallery.md
+++ b/extensions/amp-lightbox-gallery/amp-lightbox-gallery.md
@@ -116,8 +116,8 @@ The CSS API exposes the following CSS classes so that you can customize the styl
 
 <table>
   <tr>
-    <td width="40%">CSS class</td>
-    <td>Description</td>
+    <th width="40%">CSS class</th>
+    <th>Description</th>
   </tr>
   <tr>
     <td><code>.amp-lbg-mask</code></td>

--- a/test/manual/amp-lightbox-gallery-css.amp.html
+++ b/test/manual/amp-lightbox-gallery-css.amp.html
@@ -1,0 +1,77 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>Lightbox Carousel Demo</title>
+  <link rel="canonical" href="amps.html" >
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-lightbox-gallery" src="https://cdn.ampproject.org/v0/amp-lightbox-gallery-0.1.js"></script>
+  <script async custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.1.js"></script>
+  <script async custom-element="amp-youtube" src="https://cdn.ampproject.org/v0/amp-youtube-0.1.js"></script>
+  <script async custom-element="amp-twitter" src="https://cdn.ampproject.org/v0/amp-twitter-0.1.js"></script>
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <style amp-custom>
+    body {
+      font-family: sans-serif;
+    }
+
+    .amp-lbg-mask {
+      opacity: 0.9;
+      background-color: rgba(255, 255, 255, 1);
+    }
+
+    .amp-lbv-desc-box.standard {
+      background: linear-gradient(transparent,rgba(255, 255, 255, 0.5));
+      color: #000000;
+    }
+
+    .amp-lbv-desc-box.overflow {
+      background: linear-gradient(transparent,rgba(255, 255, 255, 0.5));
+      color: #000000;
+    }
+
+    .amp-lbg-top-bar {
+      background: linear-gradient(rgba(255,255,255,0.3), rgba(255,255,255,0));
+    }
+
+    .amp-lbg-icon {
+      background-color: #000000;
+    }
+
+    .amp-lbv-desc-text {
+      font-family: 'Gill Sans', 'Gill Sans MT', Calibri, 'Trebuchet MS', sans-serif;
+    }
+
+  </style>
+</head>
+<body>
+  <script>
+    // Enable amp-lightbox-viewer experiment automatically if it is not enabled.
+    // Disable amp-lightbox-viewer-auto experiment if it is enabled.
+    setTimeout(function() {
+        if (!AMP.isExperimentOn('amp-lightbox-gallery')) {
+          AMP.toggleExperiment('amp-lightbox-gallery');
+          location.reload();
+        }
+    }, 1000);
+  </script>
+
+  <h1>CSS API Tests</h1>
+
+  <amp-carousel height="300"
+  layout="fixed-height"
+  type="slides"
+  lightbox>
+    <amp-img src="https://picsum.photos/300/200/?image=10"
+      width="300"
+      height="200"
+      alt="a sample image"></amp-img>
+    <amp-img src="https://picsum.photos/300/200/?image=11"
+      width="300"
+      height="200"
+      alt="another sample image"></amp-img>
+  </amp-carousel>
+
+</body>
+</html>

--- a/test/manual/amp-lightbox-gallery-css.amp.html
+++ b/test/manual/amp-lightbox-gallery-css.amp.html
@@ -21,12 +21,7 @@
       background-color: rgba(255, 255, 255, 1);
     }
 
-    .amp-lbv-desc-box.standard {
-      background: linear-gradient(transparent,rgba(255, 255, 255, 0.5));
-      color: #000000;
-    }
-
-    .amp-lbv-desc-box.overflow {
+    .amp-lbv-desc-box.standard, .amp-lbv-desc-box.overflow {
       background: linear-gradient(transparent,rgba(255, 255, 255, 0.5));
       color: #000000;
     }


### PR DESCRIPTION
Addresses https://github.com/ampproject/amphtml/issues/12857. 

/cc @ericlindley-g could you take a look at the documentation and see if we've addressed everything we want to style, per https://github.com/ampproject/amphtml/issues/13565? 

We may want something prettier for ABE, but here's an example of something we can achieve with this CSS API: 
<img width="436" alt="screen shot 2018-02-21 at 7 05 23 pm" src="https://user-images.githubusercontent.com/1528181/36521206-7157d7e6-174a-11e8-98fc-457548c2ea9c.png">
