### PR TITLE
Reinforcing width check for full-width responsive ad units

### DIFF
--- a/3p/3p.js
+++ b/3p/3p.js
@@ -244,21 +244,12 @@ export function validateData(data, mandatoryFields, opt_optionalFields) {
 
 /**
  * Throws an exception if data does not contains exactly one field
- * mentioned in the alternativeField array.
+ * mentioned in the alternativeFields array.
  * @param {!Object} data
  * @param {!Array<string>} alternativeFields
  */
 function validateExactlyOne(data, alternativeFields) {
-  let countFileds = 0;
-
-  for (let i = 0; i < alternativeFields.length; i++) {
-    const field = alternativeFields[i];
-    if (data[field]) {
-      countFileds += 1;
-    }
-  }
-
-  user().assert(countFileds === 1,
+  user().assert(alternativeFields.filter(field => data[field]).length === 1,
       '%s must contain exactly one of attributes: %s.',
       data.type,
       alternativeFields.join(', '));

--- a/ads/google/adsense.js
+++ b/ads/google/adsense.js
@@ -31,12 +31,15 @@ export function adsense(global, data) {
       ['adClient', 'adSlot', 'adHost', 'adtest', 'tagOrigin', 'experimentId',
         'ampSlotIndex', 'adChannel', 'autoFormat', 'fullWidth']);
 
-  user().assert(
-      data['autoFormat'] != 'rspv'
-        || data['height'] == ADSENSE_RSPV_WHITELISTED_HEIGHT,
-      `Specified height ${data['height']} in <amp-ad> tag is not equal to ` +
+  if (data['autoFormat'] == 'rspv') {
+    user().assert(data.hasOwnProperty('fullWidth'),
+        'Responsive AdSense ad units require the attribute data-full-width.');
+
+    user().assert(data['height'] == ADSENSE_RSPV_WHITELISTED_HEIGHT,
+        `Specified height ${data['height']} in <amp-ad> tag is not equal to ` +
       `the required height of ${ADSENSE_RSPV_WHITELISTED_HEIGHT} for ` +
       'responsive AdSense ad units.');
+  }
 
   if (global.context.clientId) {
     // Read by GPT for GA/GPT integration.

--- a/ads/google/test/test-adsense.js
+++ b/ads/google/test/test-adsense.js
@@ -74,15 +74,24 @@ describes.realWin('adsenseDelayedFetch', {}, env => {
   });
 
   it('should not throw for valid responsive ad unit height', () => {
+    data['fullWidth'] = 'true';
     data['autoFormat'] = 'rspv';
     data['height'] = '320';
     expect(() => adsense(env.win, data)).to.not.throw();
   });
 
   it('should throw on invalid responsive ad unit height', () => {
+    data['fullWidth'] = 'true';
     data['autoFormat'] = 'rspv';
     data['height'] = '666';
     expect(() => adsense(env.win, data)).to.throw(
         /Specified height 666 in <amp-ad> tag is not equal to the required/);
+  });
+
+  it('should throw on missing fullWidth field for responsive ad unit', () => {
+    data['autoFormat'] = 'rspv';
+    data['height'] = '320';
+    expect(() => adsense(env.win, data)).to.throw(
+        /Responsive AdSense ad units require the attribute data-full-width.​/);
   });
 });

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -179,6 +179,13 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
      * that it has been verified.
      */
     if (this.isResponsive_()) {
+      if (!this.element.hasAttribute('data-full-width')) {
+        user().error(TAG,
+            'Responsive AdSense ad units require the attribute ' +
+            'data-full-width.');
+        return false;
+      }
+
       const height = this.element.getAttribute('height');
       const width = this.element.getAttribute('width');
       if (height != ADSENSE_RSPV_WHITELISTED_HEIGHT) {

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
@@ -115,19 +115,29 @@ describes.realWin('amp-ad-network-adsense-impl', {
     });
     it('should be valid (responsive)', () => {
       isResponsiveStub.callsFake(() => true);
+      element.setAttribute('data-full-width', 'true');
       element.setAttribute('height', '320');
       element.setAttribute('width', '100vw');
       expect(impl.isValidElement()).to.be.true;
     });
     it('should NOT be valid (responsive with wrong height)', () => {
       isResponsiveStub.callsFake(() => true);
+      element.setAttribute('data-full-width', 'true');
       element.setAttribute('height', '666');
+      element.setAttribute('width', '100vw');
       expect(impl.isValidElement()).to.be.false;
     });
     it('should NOT be valid (responsive with wrong width)', () => {
       isResponsiveStub.callsFake(() => true);
+      element.setAttribute('data-full-width', 'true');
       element.setAttribute('height', '320');
       element.setAttribute('width', '666');
+      expect(impl.isValidElement()).to.be.false;
+    });
+    it('should NOT be valid (responsive with missing data-full-width)', () => {
+      isResponsiveStub.callsFake(() => true);
+      element.setAttribute('height', '320');
+      element.setAttribute('width', '100vw');
       expect(impl.isValidElement()).to.be.false;
     });
     it('should NOT be valid (impl tag name)', () => {


### PR DESCRIPTION
Full-width responsive ad units with `data-auto-format='rspv'` could still bypass the width check if `data-full-width` is not set.

This fix prevents publishers from tampering with the width of a full-width responsive ad unit by ensuring that `data-full-width` must be set whenever `data-auto-format='rspv'`.

(And a random typo)