### PR TITLE
🚀Make story-ads start loading immediately

### DIFF
--- a/extensions/amp-story/0.1/amp-story-page.js
+++ b/extensions/amp-story/0.1/amp-story-page.js
@@ -459,6 +459,11 @@ export class AmpStoryPage extends AMP.BaseElement {
    *     page.
    */
   setDistance(distance) {
+    // TODO(ccordry) refactor this when pages are managed
+    if (this.isAd()) {
+      distance = Math.min(distance, 1);
+    }
+
     this.element.setAttribute('distance', distance);
     this.registerAllMedia_();
     if (distance > 0 && distance <= 2) {


### PR DESCRIPTION
`amp-story-auto-ads` creates an `amp-ad` and wraps it in an `amp-story-page`. It then appends it to the end of an `amp-story` in the DOM.  We want these ads to instantly start loading in the background when inserted.

Since the story logic preloads the next page already, this PR fakes the distance from the current page so that its assets will immediately be loaded. Note: this is only ever happening for one ad at a time.

