### PR TITLE
Add <amp-anim> to <amp-lightbox-gallery> 

### DIFF
--- a/extensions/amp-image-viewer/0.1/amp-image-viewer.js
+++ b/extensions/amp-image-viewer/0.1/amp-image-viewer.js
@@ -46,6 +46,14 @@ const ARIA_ATTRIBUTES = ['aria-label', 'aria-describedby',
   'aria-labelledby'];
 const DEFAULT_MAX_SCALE = 2;
 
+const ELIGIBLE_TAGS = {
+  'amp-img': true,
+  'amp-anim': true,
+};
+
+const SUPPORT_VALIDATION_MSG = `amp-image-viewer should have its target element
+   as the one and only child`;
+
 export class AmpImageViewer extends AMP.BaseElement {
 
   /** @param {!AmpElement} element */
@@ -122,10 +130,13 @@ export class AmpImageViewer extends AMP.BaseElement {
     this.vsync_ = this.getVsync();
     this.element.classList.add('i-amphtml-image-viewer');
     const children = this.getRealChildren();
+
+    user().assert(children.length == 1, SUPPORT_VALIDATION_MSG);
     user().assert(
-        children.length == 1 && children[0].tagName == 'AMP-IMG',
-        'amp-image-viewer should have an amp-img as its one and only child'
+        this.elementIsSupported_(children[0]),
+        children[0].tagName + ' is not supported by <amp-image-viewer>'
     );
+
     this.sourceAmpImage_ = children[0];
     this.setAsOwner(this.sourceAmpImage_);
   }
@@ -237,6 +248,16 @@ export class AmpImageViewer extends AMP.BaseElement {
         this.posX_,
         this.posY_
     );
+  }
+
+  /**
+   * Checks to see if an element is supported.
+   * @param {Element} element
+   * @return {boolean}
+   * @private
+   */
+  elementIsSupported_(element) {
+    return ELIGIBLE_TAGS[element.tagName.toLowerCase()];
   }
 
   /**

--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -19,13 +19,14 @@ import * as tr from '../../../src/transition';
 import {Animation} from '../../../src/animation';
 import {CSS} from '../../../build/amp-lightbox-gallery-0.1.css';
 import {CommonSignals} from '../../../src/common-signals';
-import {Gestures} from '../../../src/gesture';
-import {KeyCodes} from '../../../src/utils/key-codes';
-import {Layout} from '../../../src/layout';
 import {
+  ELIGIBLE_TAP_TAGS,
   LightboxManager,
   LightboxedCarouselMetadataDef,
 } from './service/lightbox-manager-impl';
+import {Gestures} from '../../../src/gesture';
+import {KeyCodes} from '../../../src/utils/key-codes';
+import {Layout} from '../../../src/layout';
 import {Services} from '../../../src/services';
 import {SwipeYRecognizer} from '../../../src/gesture-recognizers';
 import {bezierCurve} from '../../../src/curve';
@@ -241,7 +242,8 @@ export class AmpLightboxGallery extends AMP.BaseElement {
         sourceElement: element,
       };
       let slide = clonedNode;
-      if (clonedNode.tagName === 'AMP-IMG') {
+      const tagName = clonedNode.tagName.toLowerCase();
+      if (ELIGIBLE_TAP_TAGS[tagName]) {
         const container = this.element.ownerDocument.createElement('div');
         container.classList.add('i-amphtml-image-lightbox-container');
         const imageViewer = this.win.document.createElement('amp-image-viewer');
@@ -484,7 +486,6 @@ export class AmpLightboxGallery extends AMP.BaseElement {
     button.classList.add(className);
     button.classList.add('amp-lbg-button');
 
-
     button.addEventListener('click', event => {
       action();
       event.stopPropagation();
@@ -674,8 +675,8 @@ export class AmpLightboxGallery extends AMP.BaseElement {
     // type checking to work.
     /**@type {?}*/ (this.carousel_).implementation_.showSlideWhenReady(
         this.currentElemId_);
-    const tagName = this.getCurrentElement_().tagName;
-    if (tagName === 'AMP-IMG') {
+    const tagName = this.getCurrentElement_().tagName.toLowerCase();
+    if (ELIGIBLE_TAP_TAGS[tagName]) {
       this.getCurrentElement_().imageViewer.signals()
           .whenSignal(CommonSignals.LOAD_END)
           .then(() => this.enter_());
@@ -691,7 +692,7 @@ export class AmpLightboxGallery extends AMP.BaseElement {
    * @private
    */
   shouldAnimate_(element) {
-    if (element.tagName !== 'AMP-IMG') {
+    if (!ELIGIBLE_TAP_TAGS[element.tagName.toLowerCase()]) {
       return false;
     }
     const img = elementByTag(dev().assertElement(element), 'img');
@@ -812,7 +813,6 @@ export class AmpLightboxGallery extends AMP.BaseElement {
       }), MOTION_DURATION_RATIO, ENTER_CURVE_);
 
       if (sourceElement !== null
-        && sourceElement.tagName == 'AMP-IMG'
         && this.shouldAnimate_(sourceElement)
         && (sourceElement == this.sourceElement_
         || this.manager_.hasCarousel(this.currentLightboxGroupId_))) {

--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -242,8 +242,7 @@ export class AmpLightboxGallery extends AMP.BaseElement {
         sourceElement: element,
       };
       let slide = clonedNode;
-      const tagName = clonedNode.tagName.toLowerCase();
-      if (ELIGIBLE_TAP_TAGS[tagName]) {
+      if (ELIGIBLE_TAP_TAGS[clonedNode.tagName]) {
         const container = this.element.ownerDocument.createElement('div');
         container.classList.add('i-amphtml-image-lightbox-container');
         const imageViewer = this.win.document.createElement('amp-image-viewer');
@@ -675,7 +674,7 @@ export class AmpLightboxGallery extends AMP.BaseElement {
     // type checking to work.
     /**@type {?}*/ (this.carousel_).implementation_.showSlideWhenReady(
         this.currentElemId_);
-    const tagName = this.getCurrentElement_().tagName.toLowerCase();
+    const tagName = this.getCurrentElement_().tagName;
     if (ELIGIBLE_TAP_TAGS[tagName]) {
       this.getCurrentElement_().imageViewer.signals()
           .whenSignal(CommonSignals.LOAD_END)
@@ -692,7 +691,7 @@ export class AmpLightboxGallery extends AMP.BaseElement {
    * @private
    */
   shouldAnimate_(element) {
-    if (!ELIGIBLE_TAP_TAGS[element.tagName.toLowerCase()]) {
+    if (!ELIGIBLE_TAP_TAGS[element.tagName]) {
       return false;
     }
     const img = elementByTag(dev().assertElement(element), 'img');

--- a/extensions/amp-lightbox-gallery/0.1/service/lightbox-manager-impl.js
+++ b/extensions/amp-lightbox-gallery/0.1/service/lightbox-manager-impl.js
@@ -36,8 +36,9 @@ const LIGHTBOX_ELIGIBLE_TAGS = {
   'amp-facebook': true,
 };
 
-const ELIGIBLE_TAP_TAGS = {
+export const ELIGIBLE_TAP_TAGS = {
   'amp-img': true,
+  'amp-anim': true,
 };
 
 const GALLERY_TAG = 'amp-lightbox-gallery';

--- a/extensions/amp-lightbox-gallery/0.1/service/lightbox-manager-impl.js
+++ b/extensions/amp-lightbox-gallery/0.1/service/lightbox-manager-impl.js
@@ -28,22 +28,22 @@ import {isExperimentOn} from '../../../../src/experiments';
 import {toArray} from '../../../../src/types';
 
 const LIGHTBOX_ELIGIBLE_TAGS = {
-  'amp-img': true,
-  'amp-anim': true,
-  'amp-video': true,
-  'amp-youtube': true,
-  'amp-instagram': true,
-  'amp-facebook': true,
+  'AMP-IMG': true,
+  'AMP-ANIM': true,
+  'AMP-VIDEO': true,
+  'AMP-YOUTUBE': true,
+  'AMP-INSTAGRAM': true,
+  'AMP-FACEBOOK': true,
 };
 
 export const ELIGIBLE_TAP_TAGS = {
-  'amp-img': true,
-  'amp-anim': true,
+  'AMP-IMG': true,
+  'AMP-ANIM': true,
 };
 
 const GALLERY_TAG = 'amp-lightbox-gallery';
-const CAROUSEL_TAG = 'amp-carousel';
-const FIGURE_TAG = 'figure';
+const CAROUSEL_TAG = 'AMP-CAROUSEL';
+const FIGURE_TAG = 'FIGURE';
 const SLIDE_SELECTOR = '.amp-carousel-slide';
 
 /** @typedef {{
@@ -162,7 +162,7 @@ export class LightboxManager {
     dev().assert(element);
     dev().assert(element.hasAttribute('lightbox'));
 
-    if (!ELIGIBLE_TAP_TAGS[element.tagName.toLowerCase()]) {
+    if (!ELIGIBLE_TAP_TAGS[element.tagName]) {
       return false;
     }
     if (element.hasAttribute('on')) {
@@ -192,7 +192,7 @@ export class LightboxManager {
    * @private
    */
   baseElementIsSupported_(element) {
-    return LIGHTBOX_ELIGIBLE_TAGS[element.tagName.toLowerCase()];
+    return LIGHTBOX_ELIGIBLE_TAGS[element.tagName];
   }
 
   /**
@@ -237,7 +237,7 @@ export class LightboxManager {
       return;
     }
     this.seen_.push(element);
-    if (element.tagName.toLowerCase() == CAROUSEL_TAG) {
+    if (element.tagName == CAROUSEL_TAG) {
       this.processLightboxCarousel_(element);
     } else {
       const lightboxGroupId = element.getAttribute('lightbox') || 'default';
@@ -270,7 +270,7 @@ export class LightboxManager {
    * @param {string} lightboxGroupId
    */
   processBaseLightboxElement_(element, lightboxGroupId) {
-    if (element.tagName.toLowerCase() == FIGURE_TAG) {
+    if (element.tagName == FIGURE_TAG) {
       const unwrappedFigureElement = this.unwrapLightboxedFigure_(element,
           lightboxGroupId);
       if (!unwrappedFigureElement) {

--- a/test/manual/amp-lightbox-gallery-launch.amp.html
+++ b/test/manual/amp-lightbox-gallery-launch.amp.html
@@ -44,6 +44,10 @@
       height="200"
       alt="a sample image"></amp-img>
     <amp-anim
+      role="button"
+      tabindex="0"
+      width="400"
+      height="225"
       src="https://lh3.googleusercontent.com/qNn8GDz8Jfd-s9lt3Nc4lJeLjVyEaqGJTk1vuCUWazCmAeOBVjSWDD0SMTU7x0zhVe5UzOTKR0n-kN4SXx7yElvpKYvCMaRyS_g-jydhJ_cEVYmYPiZ_j1Y9de43mlKxU6s06uK1NAlpbSkL_046amEKOdgIACICkuWfOBwlw2hUDfjPOWskeyMrcTu8XOEerCLuVqXugG31QC345hz3lUyOlkdT9fMYVUynSERGNzHba7bXMOxKRe3izS5DIWUgJs3oeKYqA-V8iqgCvneD1jj0Ff68V_ajm4BDchQubBJU0ytXVkoWh27ngeEHubpnApOS6fcGsjPxeuMjnzAUtoTsiXz2FZi1mMrxrblJ-kZoAq1DJ95cnoqoa2CYq3BTgq2E8BRe2paNxLJ5GXBCTpNdXMpVJc6eD7ceijQyn-2qanilX-iK3ChbOq0uBHMvsdoC_LsFOu5KzbbNH71vM3DPkvDGmHJmF67Vj8sQ6uBrLnzpYlCyN4-Y9frR8zugDcqX5Q=w400-h300-no" width="400" height="300">
     </amp-anim>
     <figure>


### PR DESCRIPTION
`<amp-anim>` should be treated the same way as `<amp-img>` for parity with `<amp-image-lightbox>`, i.e. we should be able to open it in the lightbox as well as zoom / pan. 