### PR TITLE
Avoid function names for IE11

### DIFF
--- a/build-system/conformance-config.textproto
+++ b/build-system/conformance-config.textproto
@@ -248,3 +248,11 @@ requirement: {
   whitelist: 'src/service/cid-api.js'
   whitelist: 'src/service/cid-impl.js'
 }
+
+# Function
+
+requirement: {
+  type: BANNED_PROPERTY_CALL
+  error_message: 'Function.prototype.name is not allowed due to IE11 non-support.'
+  value: 'Function.prototype.name'
+}

--- a/extensions/amp-bind/0.1/bind-expression.js
+++ b/extensions/amp-bind/0.1/bind-expression.js
@@ -15,11 +15,11 @@
  */
 
 import {AstNodeType} from './bind-expr-defines';
+import {dev, user} from '../../../src/log';
 import {dict, hasOwn, map} from '../../../src/utils/object';
 import {getMode} from '../../../src/mode';
 import {isArray, isObject} from '../../../src/types';
 import {parser} from './bind-expr-impl';
-import {dev, user} from '../../../src/log';
 
 const TAG = 'amp-bind';
 
@@ -160,8 +160,8 @@ function generateFunctionWhitelist() {
     Object.keys(functionsForType).forEach(name => {
       const func = functionsForType[name];
       if (func) {
-        dev().assert(!func.name || name === func.name, `Listed function name ` +
-            `"${name}" doesn't match name property "${func.name}".`)
+        dev().assert(!func.name || name === func.name, 'Listed function name ' +
+            `"${name}" doesn't match name property "${func.name}".`);
 
         out[type][name] = func;
       } else {


### PR DESCRIPTION
Fixes #13528.

- Fixes issue in `amp-bind` and bans future usage.

/to @danielrozenberg 