### PR TITLE
🚀 Make sure amp-story ad is loaded before display

### DIFF
--- a/extensions/amp-story/0.1/amp-story-auto-ads.js
+++ b/extensions/amp-story/0.1/amp-story-auto-ads.js
@@ -56,8 +56,11 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
     /** @private {number} */
     this.adsPlaced_ = 0;
 
+    /** @private {number} */
+    this.adPagesCreated_ = 0;
+
     /** @private {boolean} */
-    this.iscurrentAdLoaded_ = false;
+    this.isCurrentAdLoaded_ = false;
   }
 
   /** @override */
@@ -118,14 +121,14 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
 
     ampStoryAdPage.appendChild(ampAd);
 
-    this.iscurrentAdLoaded_ = false;
+    this.isCurrentAdLoaded_ = false;
 
     // set up listener for ad-loaded event
     ampAd.getImpl().then(impl => {
       const signals = impl.signals();
       return signals.whenSignal(CommonSignals.INI_LOAD);
     }).then(() => {
-      this.iscurrentAdLoaded_ = true;
+      this.isCurrentAdLoaded_ = true;
     });
 
     return ampStoryAdPage;
@@ -137,7 +140,7 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
    * @private
    */
   createPageElement_() {
-    const id = this.adsPlaced_ + 1;
+    const id = ++this.adPagesCreated_;
     const attributes = dict({
       'id': `i-amphtml-ad-page-${id}`,
       'ad': '',
@@ -213,7 +216,7 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
   placeAdAfterPage_(currentPageId) {
     const nextAdPageEl = this.adPageEls_[this.adPageEls_.length - 1];
 
-    if (!nextAdPageEl || !this.iscurrentAdLoaded_) {
+    if (!nextAdPageEl || !this.isCurrentAdLoaded_) {
       return;
     }
 

--- a/extensions/amp-story/0.1/amp-story-page.js
+++ b/extensions/amp-story/0.1/amp-story-page.js
@@ -701,6 +701,11 @@ export class AmpStoryPage extends AMP.BaseElement {
     });
   }
 
+
+  /**
+   * check to see if this page is a wrapper for an ad
+   * @return {boolean}
+   */
   isAd() {
     return this.element.hasAttribute(ADVERTISEMENT_ATTR_NAME);
   }


### PR DESCRIPTION
The idea with `amp-story-auto-ads` is to place an ad as the next page after a certain amount of users interactions, but only after that ad is loaded. If the ad is not loaded it will wait for another user interaction before it tries again to place the ad. 

This PR ads a more realistic ad implementation (using the fake-ad component), and the logic to make sure that the `loaded` event has fired on the ad before it will insert the page.
