### PR TITLE
✨ Add the "sandbox" iframe attribute to cross domain A4A rendering modes

### DIFF
--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -82,6 +82,9 @@ export const SAFEFRAME_VERSION_HEADER = 'X-AmpSafeFrameVersion';
 /** @type {string} @visibleForTesting */
 export const EXPERIMENT_FEATURE_HEADER_NAME = 'amp-ff-exps';
 
+/** @type {string} @visibileForTesting */
+export const SANDBOX_HEADER = 'amp-ff-sandbox';
+
 /** @type {string} */
 const TAG = 'amp-a4a';
 
@@ -185,6 +188,21 @@ const LIFECYCLE_STAGE_TO_ANALYTICS_TRIGGER = {
 };
 
 /**
+ * The sandboxing flags to use when applying the "sandbox" attribute to ad
+ * iframes. See http://go/mdn/HTML/Element/iframe#attr-sandbox.
+ * @const {!Array<string>}
+ */
+const IFRAME_SANDBOXING_FLAGS = [
+  'allow-forms',
+  'allow-pointer-lock',
+  'allow-popups',
+  'allow-popups-to-escape-sandbox',
+  'allow-same-origin',
+  'allow-scripts',
+  'allow-top-navigation-by-user-activation',
+];
+
+/**
  * Utility function that ensures any error thrown is handled by optional
  * onError handler (if none provided or handler throws, error is swallowed and
  * undefined is returned).
@@ -282,6 +300,13 @@ export class AmpA4A extends AMP.BaseElement {
      */
     this.experimentalNonAmpCreativeRenderMethod_ =
         this.getNonAmpCreativeRenderingMethod();
+
+    /**
+     * Whether or not the iframe containing the ad should be sandboxed via the
+     * "sandbox" attribute.
+     * @private {boolean}
+     */
+    this.shouldSandbox_ = false;
 
     /**
      * Gets a notion of current time, in ms.  The value is not necessarily
@@ -699,6 +724,8 @@ export class AmpA4A extends AMP.BaseElement {
           const method = this.getNonAmpCreativeRenderingMethod(
               fetchResponse.headers.get(RENDERING_TYPE_HEADER));
           this.experimentalNonAmpCreativeRenderMethod_ = method;
+          this.shouldSandbox_ =
+            fetchResponse.headers.get(SANDBOX_HEADER) == 'true';
           const safeframeVersionHeader =
             fetchResponse.headers.get(SAFEFRAME_VERSION_HEADER);
           if (/^[0-9-]+$/.test(safeframeVersionHeader) &&
@@ -1413,6 +1440,11 @@ export class AmpA4A extends AMP.BaseElement {
 
     if (this.sentinel) {
       mergedAttributes['data-amp-3p-sentinel'] = this.sentinel;
+    }
+    const browserSupportsSandbox = this.win.HTMLIFrameElement &&
+        'sandbox' in this.win.HTMLIFrameElement.prototype;
+    if (this.shouldSandbox_ && browserSupportsSandbox) {
+      mergedAttributes['sandbox'] = IFRAME_SANDBOXING_FLAGS.join(' ');
     }
     this.iframe = createElementWithAttributes(
         /** @type {!Document} */ (this.element.ownerDocument),


### PR DESCRIPTION
Implements adding the sandbox attribute to A4A cross domain iframe rendering modes, in order to prevent malicious ads from redirecting users. The attribute will only be added if the "amp-ff-sandbox" header is present in the response, with a value of true. 

We set the following iframe sandboxing flags:
allow-same-origin: Allows the iframe content to be treated the same as all other content from the iframe’s domain.
allow-forms: Re-enables form submission.
allow-popups: Re-enables popups.
allow-scripts: Re-enables scripts.
allow-pointer-lock: Re-enables pointer-lock APIs.
allow-popups-to-escape-sandbox: Allows the sandboxed document to spawn new windows without forcing the sandboxing flags upon them, thereby avoiding breaking landing pages.
allow-top-navigation-by-user-activation: Allows ads to navigate the top page when the browser detects a valid user gesture. 