### PR TITLE
Change thumbnail src to thumbnail id for lightbox thumbnail api

### DIFF
--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -1085,7 +1085,7 @@ export class AmpLightboxGallery extends AMP.BaseElement {
     if (thumbnailObj.srcset) {
       imgElement.setAttribute('srcset', thumbnailObj.srcset.stringify());
     } else {
-      imgElement.setAttribute('src', thumbnailObj.placeholderUrl);
+      imgElement.setAttribute('src', thumbnailObj.placeholderSrc);
     }
     element.appendChild(imgElement);
     const closeGalleryAndShowTargetSlide = event => {

--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -22,6 +22,7 @@ import {CommonSignals} from '../../../src/common-signals';
 import {
   ELIGIBLE_TAP_TAGS,
   LightboxManager,
+  LightboxThumbnailDataDef,
   LightboxedCarouselMetadataDef,
 } from './service/lightbox-manager-impl';
 import {Gestures} from '../../../src/gesture';
@@ -1071,7 +1072,7 @@ export class AmpLightboxGallery extends AMP.BaseElement {
 
   /**
    * Create an element inside gallery from the thumbnail info from manager.
-   * @param {{url: string, element: !Element}} thumbnailObj
+   * @param {!LightboxThumbnailDataDef} thumbnailObj
    * @return {!Element}
    * @private
    */
@@ -1080,7 +1081,12 @@ export class AmpLightboxGallery extends AMP.BaseElement {
     element.classList.add('i-amphtml-lbg-gallery-thumbnail');
     const imgElement = this.win.document.createElement('img');
     imgElement.classList.add('i-amphtml-lbg-gallery-thumbnail-img');
-    imgElement.setAttribute('src', thumbnailObj.url);
+
+    if (thumbnailObj.srcset) {
+      imgElement.setAttribute('srcset', thumbnailObj.srcset.stringify());
+    } else {
+      imgElement.setAttribute('src', thumbnailObj.placeholderUrl);
+    }
     element.appendChild(imgElement);
     const closeGalleryAndShowTargetSlide = event => {
       this.closeGallery_();

--- a/extensions/amp-lightbox-gallery/0.1/service/lightbox-placeholders.js
+++ b/extensions/amp-lightbox-gallery/0.1/service/lightbox-placeholders.js
@@ -1,1 +1,16 @@
-export const defaultPlaceholder = 'data:image/svg+xml;utf8,<svg fill="#FFFFFF" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M6 2c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6H6zm7 7V3.5L18.5 9H13z"/><path d="M0 0h24v24H0z" fill="none"/></svg>';
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export const defaultPlaceholder = 'data:image/svg+xml;charset=utf-8,<svg fill="#FFFFFF" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M6 2c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6H6zm7 7V3.5L18.5 9H13z"/><path d="M0 0h24v24H0z" fill="none"/></svg>';

--- a/extensions/amp-lightbox-gallery/0.1/service/lightbox-placeholders.js
+++ b/extensions/amp-lightbox-gallery/0.1/service/lightbox-placeholders.js
@@ -1,0 +1,1 @@
+export const defaultPlaceholder = 'data:image/svg+xml;utf8,<svg fill="#FFFFFF" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M6 2c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6H6zm7 7V3.5L18.5 9H13z"/><path d="M0 0h24v24H0z" fill="none"/></svg>';

--- a/extensions/amp-lightbox-gallery/amp-lightbox-gallery.md
+++ b/extensions/amp-lightbox-gallery/amp-lightbox-gallery.md
@@ -110,9 +110,34 @@ In this example, `<amp-lightbox-gallery>` displays the `alt` value as its descri
 </amp-img>
 ```
 
+## Thumbnail API
+Lightboxed items have a thumbnail gallery view. You can optionally specify a thumbnail item for your lightboxed element via the attribute `lightbox-thumbnail-id` that references the `id` of an `<amp-img>` element with `layout="nodisplay"`.
+
+#### Example: using `lightbox-thumbnail-id` to specify a thumbnail
+
+```html
+<amp-facebook
+  lightbox
+  lightbox-thumbnail-id="fb-thumbnail-img"
+  width="552"
+  height="303"
+  layout="responsive"
+  data-href="https://www.facebook.com/zuck/posts/10102593740125791">
+</amp-facebook>
+
+<amp-img id="fb-thumbnail-img"
+  width="200"
+  height="200"
+  layout="nodisplay"
+  src="https://picsum.photos/200/200?image=1074">
+</amp-img>
+```
+
+If no thumbnail is specified, `<amp-img>` elements will be cropped per `object-fit: cover`, `<amp-video>` will use the image src specified in its `poster` attribute, and placeholder images will be used for lightboxed elements that have one.
+
 ## CSS API
 
-The CSS API exposes the following CSS classes so that you can customize the style of your lightbox: 
+The CSS API exposes the following CSS classes so that you can customize the style of your lightbox:
 
 <table>
   <tr>

--- a/test/manual/amp-lightbox-gallery-launch.amp.html
+++ b/test/manual/amp-lightbox-gallery-launch.amp.html
@@ -74,24 +74,29 @@
       width="358"
       height="204"
       layout="responsive"
+      poster="https://i.ytimg.com/vi/5Yjoe54vzwE/mqdefault.jpg"
       controls>
-      <div placeholder>
-        This is a placeholder
-      </div>
-      <div fallback>
-        This is a fallback
-      </div>
     </amp-video>
     <amp-youtube width="480"
       height="270"
       layout="responsive"
       data-videoid="lBTCB7yLs8Y">
+      <amp-img
+        src="https://i.ytimg.com/vi/UKsAoboS-Wc/mqdefault.jpg"
+        placeholder
+        layout="fill"
+        />
     </amp-youtube>
     <amp-youtube width="480"
       height="270"
       layout="responsive"
       data-videoid="lBTCB7yLs8Y"
       autoplay>
+      <amp-img
+        src="https://i.ytimg.com/vi/OO9oKhs80aI/mqdefault.jpg"
+        placeholder
+        layout="fill"
+        />
     </amp-youtube>
     <amp-instagram data-shortcode="1totVhIFXl"
       width="1"
@@ -109,6 +114,11 @@
       layout="responsive"
       data-embed-as="video"
       data-href="https://www.facebook.com/zuck/videos/10102509264909801/">
+      <amp-img
+      src="https://scontent-sjc3-1.xx.fbcdn.net/v/t15.0-10/cp0/e15/q65/p173x172/12104343_10102509276925721_413295500_n.jpg?oh=3ab5d6e109a83d59a7dec75cfc310bcd&oe=5B028D9E"
+      placeholder
+      layout="fill"
+      />
     </amp-facebook>
   </amp-carousel>
   <div id='my-aria-describe'>

--- a/test/manual/amp-lightbox-gallery-launch.amp.html
+++ b/test/manual/amp-lightbox-gallery-launch.amp.html
@@ -104,6 +104,7 @@
       layout="responsive">
     </amp-instagram>
     <amp-facebook
+      lightbox-thumbnail-id="fb-thumbnail-img"
       width="552"
       height="303"
       layout="responsive"
@@ -121,6 +122,14 @@
       />
     </amp-facebook>
   </amp-carousel>
+
+  <amp-img id="fb-thumbnail-img"
+    width="200"
+    height="200"
+    layout="nodisplay"
+    src="https://picsum.photos/200/200?image=1074">
+  </amp-img>
+
   <div id='my-aria-describe'>
     This is an aria described by a div. <br/>
     I have a linebreak.


### PR DESCRIPTION
Closes https://github.com/ampproject/amphtml/issues/12856. 
Pending this PR, `<amp-lightbox-gallery>` API should be feature complete. =) 

TODOs: a default icon from Material Design was used here for testing purposes, that will be substituted with the launch icons per https://github.com/ampproject/amphtml/issues/12713. 