### PR TITLE
<amp-facebook-page> Fix typo in propagating data-show-facepile

### DIFF
--- a/3p/facebook.js
+++ b/3p/facebook.js
@@ -82,7 +82,7 @@ function getPageContainer(global, data) {
   container.setAttribute('data-href', data.href);
   container.setAttribute('data-tabs', data.tabs);
   container.setAttribute('data-hide-cover', data.hideCover);
-  container.setAttribute('data-show-facepile', data.showFacePile);
+  container.setAttribute('data-show-facepile', data.showFacepile);
   container.setAttribute('data-hide-cta', data.hideCta);
   container.setAttribute('data-small-header', data.smallHeader);
   container.setAttribute(

--- a/build-system/amp.extern.js
+++ b/build-system/amp.extern.js
@@ -270,7 +270,7 @@ data.hideCover;
 data.hideCta;
 data.smallHeader;
 data.adaptContainerWidth;
-data.showFacePile;
+data.showFacepile;
 data.showText;
 
 // 3p code

--- a/examples/facebook.amp.html
+++ b/examples/facebook.amp.html
@@ -107,5 +107,12 @@
     data-href="https://www.facebook.com/YoloBookStore/">
 </amp-facebook-page>
 
+<amp-facebook-page width="300" height="300"
+    layout="fixed"
+    data-adapt-container-width="true"
+    data-show-facepile="true"
+    data-href="https://www.facebook.com/FileHorse">
+</amp-facebook-page>
+
 </body>
 </html>

--- a/examples/facebook.amp.html
+++ b/examples/facebook.amp.html
@@ -111,7 +111,7 @@
     layout="fixed"
     data-adapt-container-width="true"
     data-show-facepile="true"
-    data-href="https://www.facebook.com/FileHorse">
+    data-href="https://www.facebook.com/itsdougthepug">
 </amp-facebook-page>
 
 </body>

--- a/extensions/amp-facebook-page/0.1/test/validator-amp-facebook-page.html
+++ b/extensions/amp-facebook-page/0.1/test/validator-amp-facebook-page.html
@@ -33,5 +33,12 @@
       data-tabs="timeline"
       data-href="https://www.facebook.com/barackobama/">
   </amp-facebook-page>
+
+  <amp-facebook-page width="300" height="300"
+    layout="fixed"
+    data-adapt-container-width="true"
+    data-show-facepile="true"
+    data-href="https://www.facebook.com/FileHorse">
+  </amp-facebook-page>
 </body>
 </html>

--- a/extensions/amp-facebook-page/0.1/test/validator-amp-facebook-page.html
+++ b/extensions/amp-facebook-page/0.1/test/validator-amp-facebook-page.html
@@ -38,7 +38,7 @@
     layout="fixed"
     data-adapt-container-width="true"
     data-show-facepile="true"
-    data-href="https://www.facebook.com/FileHorse">
+    data-href="https://www.facebook.com/itsdougthepug">
   </amp-facebook-page>
 </body>
 </html>

--- a/extensions/amp-facebook-page/0.1/test/validator-amp-facebook-page.html
+++ b/extensions/amp-facebook-page/0.1/test/validator-amp-facebook-page.html
@@ -35,10 +35,10 @@
   </amp-facebook-page>
 
   <amp-facebook-page width="300" height="300"
-    layout="fixed"
-    data-adapt-container-width="true"
-    data-show-facepile="true"
-    data-href="https://www.facebook.com/itsdougthepug">
+      layout="fixed"
+      data-adapt-container-width="true"
+      data-show-facepile="true"
+      data-href="https://www.facebook.com/itsdougthepug">
   </amp-facebook-page>
 </body>
 </html>

--- a/extensions/amp-facebook-page/0.1/test/validator-amp-facebook-page.html
+++ b/extensions/amp-facebook-page/0.1/test/validator-amp-facebook-page.html
@@ -33,7 +33,6 @@
       data-tabs="timeline"
       data-href="https://www.facebook.com/barackobama/">
   </amp-facebook-page>
-
   <amp-facebook-page width="300" height="300"
       layout="fixed"
       data-adapt-container-width="true"

--- a/extensions/amp-facebook-page/0.1/test/validator-amp-facebook-page.out
+++ b/extensions/amp-facebook-page/0.1/test/validator-amp-facebook-page.out
@@ -34,6 +34,7 @@ PASS
 |        data-tabs="timeline"
 |        data-href="https://www.facebook.com/barackobama/">
 |    </amp-facebook-page>
+|
 |    <amp-facebook-page width="300" height="300"
 |        layout="fixed"
 |        data-adapt-container-width="true"

--- a/extensions/amp-facebook-page/0.1/test/validator-amp-facebook-page.out
+++ b/extensions/amp-facebook-page/0.1/test/validator-amp-facebook-page.out
@@ -34,7 +34,6 @@ PASS
 |        data-tabs="timeline"
 |        data-href="https://www.facebook.com/barackobama/">
 |    </amp-facebook-page>
-|
 |    <amp-facebook-page width="300" height="300"
 |        layout="fixed"
 |        data-adapt-container-width="true"

--- a/extensions/amp-facebook-page/0.1/test/validator-amp-facebook-page.out
+++ b/extensions/amp-facebook-page/0.1/test/validator-amp-facebook-page.out
@@ -34,5 +34,11 @@ PASS
 |        data-tabs="timeline"
 |        data-href="https://www.facebook.com/barackobama/">
 |    </amp-facebook-page>
+|    <amp-facebook-page width="300" height="300"
+|        layout="fixed"
+|        data-adapt-container-width="true"
+|        data-show-facepile="true"
+|        data-href="https://www.facebook.com/FileHorse">
+|    </amp-facebook-page>
 |  </body>
 |  </html>

--- a/extensions/amp-facebook-page/0.1/test/validator-amp-facebook-page.out
+++ b/extensions/amp-facebook-page/0.1/test/validator-amp-facebook-page.out
@@ -38,7 +38,7 @@ PASS
 |        layout="fixed"
 |        data-adapt-container-width="true"
 |        data-show-facepile="true"
-|        data-href="https://www.facebook.com/FileHorse">
+|        data-href="https://www.facebook.com/itsdougthepug">
 |    </amp-facebook-page>
 |  </body>
 |  </html>


### PR DESCRIPTION
The issue is here: 
https://github.com/ampproject/amphtml/blob/master/3p/facebook.js#L85
`container.setAttribute('data-show-facepile', data.showFacePile);` should read
`container.setAttribute('data-show-facepile', data.showFacepile);` (note the change in capitalization on `data.showFacepile`)

I have also added a test case to the validator file and added an example to facebook.amp.html

Addresses problem 2 in #13609. 