### PR TITLE
<amp-facebook-page> Propagate user specified `width` and `height` attributes

### DIFF
--- a/3p/facebook.js
+++ b/3p/facebook.js
@@ -87,6 +87,8 @@ function getPageContainer(global, data) {
   container.setAttribute('data-small-header', data.smallHeader);
   container.setAttribute(
       'data-adapt-container-width', data.adaptContainerWidth);
+  container.setAttribute('data-width', data.width);
+  container.setAttribute('data-height', data.height);
   return container;
 }
 

--- a/examples/facebook.amp.html
+++ b/examples/facebook.amp.html
@@ -107,5 +107,12 @@
     data-href="https://www.facebook.com/YoloBookStore/">
 </amp-facebook-page>
 
+<amp-facebook-page width="300" height="300"
+    layout="fixed"
+    data-adapt-container-width="true"
+    data-show-facepile="true"
+    data-href="https://www.facebook.com/itsdougthepug">
+</amp-facebook-page>
+
 </body>
 </html>

--- a/extensions/amp-facebook/0.1/test/test-amp-facebook.js
+++ b/extensions/amp-facebook/0.1/test/test-amp-facebook.js
@@ -30,6 +30,7 @@ describes.realWin('amp-facebook', {
 
   const fbPostHref = 'https://www.facebook.com/zuck/posts/10102593740125791';
   const fbVideoHref = 'https://www.facebook.com/zuck/videos/10102509264909801/';
+  const fbPageHref = 'https://www.facebook.com/itsdougthepug';
   let win, doc;
 
   beforeEach(() => {
@@ -146,6 +147,25 @@ describes.realWin('amp-facebook', {
     expect(fbVideo.getAttribute('data-show-text')).to.equal('true');
   });
 
+  it('adds fb-page element with `data-width` and `data-height` ' +
+    'attributes set correctly', () => {
+    const div = doc.createElement('div');
+    div.setAttribute('id', 'c');
+    doc.body.appendChild(div);
+    win.context = {
+      tagName: 'AMP-FACEBOOK-PAGE',
+    };
+
+    facebook(win, {
+      href: fbPageHref,
+      width: 200,
+      height: 200,
+    });
+    const fbPage = doc.body.getElementsByClassName('fb-page')[0];
+    expect(fbPage).not.to.be.undefined;
+    expect(fbPage.getAttribute('data-width')).to.equal('200');
+    expect(fbPage.getAttribute('data-height')).to.equal('200');
+  });
 
   it('removes iframe after unlayoutCallback', () => {
     return getAmpFacebook(fbPostHref).then(ampFB => {


### PR DESCRIPTION
Addresses #13609

Propagates the `data-width` and `data-height` attributes to 3p plugin so that they are useful. 

Added a test as well.