### PR TITLE
Rewrite `target` for <a> during [href] mutate

### DIFF
--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -921,7 +921,7 @@ export class Bind {
           }
         } else if (newValue !== oldValue) {
           const rewrittenValue =
-              this.rewriteAttributes_(element, property, newValue);
+              this.rewriteAttributes_(element, property, String(newValue));
           if (rewrittenValue) { // Rewriting can fail due to e.g. invalid URL.
             if (updateProperty) {
               element[property] = rewrittenValue;

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -939,13 +939,13 @@ export class Bind {
   }
 
   /**
-   * Performs any necessary CDN rewrites for the given mutation and updates
-   * the element. Returns true if rewrite succeeds. Otherwise returns false.
+   * Performs CDN rewrites for the given mutation and updates the element.
+   * Returns the rewrite of `value` on success. Otherwise, returns undefined.
    * @see amp-cache-modifications.md#url-rewrites
    * @param {!Element} element
    * @param {string} property
    * @param {string} value
-   * @return {string}
+   * @return {string|undefined}
    * @private
    */
   rewriteAttributes_(element, property, value) {

--- a/src/sanitizer.js
+++ b/src/sanitizer.js
@@ -28,10 +28,11 @@ import {startsWith} from './string';
 import {urls} from './config';
 import {user} from './log';
 
-
 /** @private @const {string} */
 const TAG = 'sanitizer';
 
+/** @private @const {string} */
+const ORIGINAL_TARGET_VALUE = '__AMP_ORIGINAL_TARGET_VALUE_';
 
 /**
  * @const {!Object<string, boolean>}
@@ -57,7 +58,6 @@ const BLACKLISTED_TAGS = dict({
   'video': true,
 });
 
-
 /** @const {!Object<string, boolean>} */
 const SELF_CLOSING_TAGS = dict({
   'br': true,
@@ -78,7 +78,6 @@ const SELF_CLOSING_TAGS = dict({
   'param': true,
 });
 
-
 /** @const {!Array<string>} */
 const WHITELISTED_FORMAT_TAGS = [
   'b',
@@ -98,7 +97,6 @@ const WHITELISTED_FORMAT_TAGS = [
   'time',
   'u',
 ];
-
 
 /** @const {!Array<string>} */
 const WHITELISTED_ATTRS = [
@@ -132,10 +130,8 @@ const WHITELISTED_ATTRS_BY_TAGS = dict({
   ],
 });
 
-
 /** @const {!RegExp} */
 const WHITELISTED_ATTR_PREFIX_REGEX = /^data-/i;
-
 
 /** @const {!Array<string>} */
 const WHITELISTED_TARGETS = ['_top', '_blank'];
@@ -156,7 +152,6 @@ const BLACKLISTED_TAG_SPECIFIC_ATTR_VALUES = dict({
   },
 });
 
-
 /** @const {!Array<string>} */
 const BLACKLISTED_FIELDS_ATTR = [
   'form',
@@ -167,14 +162,12 @@ const BLACKLISTED_FIELDS_ATTR = [
   'formenctype',
 ];
 
-
 /** @const {!Object<string, !Array<string>>} */
 const BLACKLISTED_TAG_SPECIFIC_ATTRS = dict({
   'input': BLACKLISTED_FIELDS_ATTR,
   'textarea': BLACKLISTED_FIELDS_ATTR,
   'select': BLACKLISTED_FIELDS_ATTR,
 });
-
 
 /**
  * Sanitizes the provided HTML.
@@ -321,7 +314,6 @@ export function sanitizeHtml(html) {
   return output.join('');
 }
 
-
 /**
  * Sanitizes the provided formatting HTML. Only the most basic inline tags are
  * allowed, such as <b>, <i>, etc.
@@ -352,7 +344,6 @@ export function sanitizeFormattingHtml(html) {
       }
   );
 }
-
 
 /**
  * Whether the attribute/value are valid.
@@ -411,6 +402,41 @@ export function isValidAttr(tagName, attrName, attrValue) {
 }
 
 /**
+ * The same as rewriteAttributeValue() but actually updates the element and
+ * modifies other related attribute(s) for special cases, i.e. `target` for <a>.
+ * @param {!Element} element
+ * @param {string} attrName
+ * @param {string} attrValue
+ * @return {string}
+ */
+export function rewriteAttributesForElement(element, attrName, attrValue) {
+  const tag = element.tagName.toLowerCase();
+  const attr = attrName.toLowerCase();
+  const rewrittenValue = rewriteAttributeValue(tag, attr, attrValue);
+  // When served from proxy (CDN), changing an <a> tag from a hash link to a
+  // non-hash link requires updating `target` attribute per cache modification
+  // rules. @see amp-cache-modifications.md#url-rewrites
+  const isProxy = true;//isProxyOrigin(self.location);
+  if (isProxy && tag == 'a' && attr == 'href') {
+    const newValueIsHash = rewrittenValue.startsWith('#');
+    const oldValueIsHash = element.getAttribute(attrName).startsWith('#');
+
+    if (newValueIsHash && !oldValueIsHash) {
+      // Save the original value of `target` so it can be restored (if needed).
+      if (!element[ORIGINAL_TARGET_VALUE]) {
+        element[ORIGINAL_TARGET_VALUE] = element.getAttribute('target');
+      }
+      element.removeAttribute('target');
+    } else if (oldValueIsHash && !newValueIsHash) {
+      // Restore the original value of `target` or default to `_top`.
+      element.setAttribute('target', element[ORIGINAL_TARGET_VALUE] || '_top');
+    }
+  }
+  element.setAttribute(attr, rewrittenValue);
+  return rewrittenValue;
+}
+
+/**
  * If (tagName, attrName) is a CDN-rewritable URL attribute, returns the
  * rewritten URL value. Otherwise, returns the unchanged `attrValue`.
  * @see resolveUrlAttr for rewriting rules.
@@ -418,6 +444,7 @@ export function isValidAttr(tagName, attrName, attrValue) {
  * @param {string} attrName
  * @param {string} attrValue
  * @return {string}
+ * @private Visible for testing.
  */
 export function rewriteAttributeValue(tagName, attrName, attrValue) {
   const tag = tagName.toLowerCase();

--- a/src/sanitizer.js
+++ b/src/sanitizer.js
@@ -407,19 +407,22 @@ export function isValidAttr(tagName, attrName, attrValue) {
  * @param {!Element} element
  * @param {string} attrName
  * @param {string} attrValue
+ * @param {!Location=} opt_location
  * @return {string}
  */
-export function rewriteAttributesForElement(element, attrName, attrValue) {
+export function rewriteAttributesForElement(
+  element, attrName, attrValue, opt_location)
+{
   const tag = element.tagName.toLowerCase();
   const attr = attrName.toLowerCase();
   const rewrittenValue = rewriteAttributeValue(tag, attr, attrValue);
   // When served from proxy (CDN), changing an <a> tag from a hash link to a
   // non-hash link requires updating `target` attribute per cache modification
   // rules. @see amp-cache-modifications.md#url-rewrites
-  const isProxy = true;//isProxyOrigin(self.location);
-  if (isProxy && tag == 'a' && attr == 'href') {
-    const newValueIsHash = rewrittenValue.startsWith('#');
-    const oldValueIsHash = element.getAttribute(attrName).startsWith('#');
+  const isProxy = isProxyOrigin(opt_location || self.location);
+  if (isProxy && tag === 'a' && attr === 'href') {
+    const newValueIsHash = rewrittenValue[0] === '#';
+    const oldValueIsHash = element.getAttribute(attr)[0] === '#';
 
     if (newValueIsHash && !oldValueIsHash) {
       // Save the original value of `target` so it can be restored (if needed).

--- a/src/sanitizer.js
+++ b/src/sanitizer.js
@@ -421,8 +421,9 @@ export function rewriteAttributesForElement(
   // rules. @see amp-cache-modifications.md#url-rewrites
   const isProxy = isProxyOrigin(opt_location || self.location);
   if (isProxy && tag === 'a' && attr === 'href') {
+    const oldValue = element.getAttribute(attr);
     const newValueIsHash = rewrittenValue[0] === '#';
-    const oldValueIsHash = element.getAttribute(attr)[0] === '#';
+    const oldValueIsHash = oldValue && oldValue[0] === '#';
 
     if (newValueIsHash && !oldValueIsHash) {
       // Save the original value of `target` so it can be restored (if needed).

--- a/test/functional/test-sanitizer.js
+++ b/test/functional/test-sanitizer.js
@@ -246,7 +246,8 @@ describe('rewriteAttributesForElement', () => {
       const element = document.createElement('a');
       element.setAttribute('href', '#hash');
 
-      rewriteAttributesForElement(element, 'href', 'https://not.hash/', location);
+      rewriteAttributesForElement(
+          element, 'href', 'https://not.hash/', location);
 
       expect(element.getAttribute('href')).to.equal('https://not.hash/');
       expect(element.getAttribute('target')).to.equal('_top');
@@ -260,7 +261,7 @@ describe('rewriteAttributesForElement', () => {
 
       expect(element.getAttribute('href')).to.equal('#hash');
       expect(element.hasAttribute('target')).to.equal(false);
-    })
+    });
   });
 });
 


### PR DESCRIPTION
Fixes #13446.

- When changing a link's href from non-hash to hash, remove `target` attribute (and store it)
- When changing a link's href from hash to non-hash, add `target=_top` (or the previously removed `target` value if applicable)