### PR TITLE
Add <amp-ad> to <amp-lightbox-gallery> support 

### DIFF
--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -224,7 +224,6 @@ export class AmpLightboxGallery extends AMP.BaseElement {
     const clonedNode = element.cloneNode(deepClone);
     clonedNode.removeAttribute('on');
     clonedNode.removeAttribute('id');
-    clonedNode.removeAttribute('class');
     return clonedNode;
   }
   /**
@@ -250,6 +249,7 @@ export class AmpLightboxGallery extends AMP.BaseElement {
         container.classList.add('i-amphtml-image-lightbox-container');
         const imageViewer = this.win.document.createElement('amp-image-viewer');
         imageViewer.setAttribute('layout', 'fill');
+        clonedNode.removeAttribute('class');
         imageViewer.appendChild(clonedNode);
         container.appendChild(imageViewer);
         slide = container;

--- a/extensions/amp-lightbox-gallery/0.1/service/lightbox-manager-impl.js
+++ b/extensions/amp-lightbox-gallery/0.1/service/lightbox-manager-impl.js
@@ -31,6 +31,7 @@ import {srcsetFromElement, srcsetFromSrc} from '../../../../src/srcset';
 import {toArray} from '../../../../src/types';
 
 const LIGHTBOX_ELIGIBLE_TAGS = {
+  'AMP-AD': true,
   'AMP-IMG': true,
   'AMP-ANIM': true,
   'AMP-VIDEO': true,

--- a/src/ad-helper.js
+++ b/src/ad-helper.js
@@ -28,6 +28,7 @@ const CONTAINERS = {
   'AMP-FX-FLYING-CARPET': true,
   'AMP-LIGHTBOX': true,
   'AMP-STICKY-AD': true,
+  'AMP-LIGHTBOX-GALLERY': true,
 };
 
 /**

--- a/test/manual/amp-lightbox-gallery-launch.amp.html
+++ b/test/manual/amp-lightbox-gallery-launch.amp.html
@@ -13,6 +13,7 @@
   <script async custom-element="amp-youtube" src="https://cdn.ampproject.org/v0/amp-youtube-0.1.js"></script>
   <script async custom-element="amp-instagram" src="https://cdn.ampproject.org/v0/amp-instagram-0.1.js"></script>
   <script async custom-element="amp-facebook" src="https://cdn.ampproject.org/v0/amp-facebook-0.1.js"></script>
+  <script async custom-element="amp-ad" src="https://cdn.ampproject.org/v0/amp-ad-0.1.js"></script>
 
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <style amp-custom>
@@ -37,7 +38,7 @@
   <h1>Lightbox Carousel Test</h1>
   <amp-carousel height="300"
   layout="fixed-height"
-  type="carousel"
+  type="slides"
   lightbox>
     <amp-img src="https://picsum.photos/300/200/?image=30"
       width="300"
@@ -121,6 +122,14 @@
       layout="fill"
       />
     </amp-facebook>
+    <amp-ad width="300"
+      height="250"
+      type="a9"
+      data-aax_size="300x250"
+      data-aax_pubname="test123"
+      data-aax_src="302">
+    </amp-ad>
+
   </amp-carousel>
 
   <amp-img id="fb-thumbnail-img"

--- a/test/manual/amp-lightbox-gallery-launch.amp.html
+++ b/test/manual/amp-lightbox-gallery-launch.amp.html
@@ -37,13 +37,14 @@
 
   <h1>Lightbox Carousel Test</h1>
   <amp-carousel height="300"
-  layout="fixed-height"
+  width="400"
+  layout="fixed"
   type="slides"
   lightbox>
-    <amp-img src="https://picsum.photos/300/200/?image=30"
-      width="300"
-      height="200"
-      alt="a sample image"></amp-img>
+    <amp-img src="https://images.unsplash.com/photo-1503843778847-2b8bdce2ed3d"
+      width="400"
+      height="300"
+      alt="a beautiful cat"></amp-img>
     <amp-anim
       role="button"
       tabindex="0"
@@ -52,23 +53,23 @@
       src="https://lh3.googleusercontent.com/qNn8GDz8Jfd-s9lt3Nc4lJeLjVyEaqGJTk1vuCUWazCmAeOBVjSWDD0SMTU7x0zhVe5UzOTKR0n-kN4SXx7yElvpKYvCMaRyS_g-jydhJ_cEVYmYPiZ_j1Y9de43mlKxU6s06uK1NAlpbSkL_046amEKOdgIACICkuWfOBwlw2hUDfjPOWskeyMrcTu8XOEerCLuVqXugG31QC345hz3lUyOlkdT9fMYVUynSERGNzHba7bXMOxKRe3izS5DIWUgJs3oeKYqA-V8iqgCvneD1jj0Ff68V_ajm4BDchQubBJU0ytXVkoWh27ngeEHubpnApOS6fcGsjPxeuMjnzAUtoTsiXz2FZi1mMrxrblJ-kZoAq1DJ95cnoqoa2CYq3BTgq2E8BRe2paNxLJ5GXBCTpNdXMpVJc6eD7ceijQyn-2qanilX-iK3ChbOq0uBHMvsdoC_LsFOu5KzbbNH71vM3DPkvDGmHJmF67Vj8sQ6uBrLnzpYlCyN4-Y9frR8zugDcqX5Q=w400-h300-no" width="400" height="300">
     </amp-anim>
     <figure>
-        <amp-img src="https://picsum.photos/300/200/?image=31"
-        width="300"
-        height="200"
-        alt="another sample image"></amp-img>
+        <amp-img src="https://images.unsplash.com/photo-1515002246390-7bf7e8f87b54"
+        width="400"
+        height="300"
+        alt="another beautiful cat"></amp-img>
         <figcaption>This is a figure with a figcaption.</figcaption>
     </figure>
-    <amp-img src="https://picsum.photos/300/200/?image=32"
-      width="300"
-      height="200"
+    <amp-img src="https://images.unsplash.com/photo-1445499348736-29b6cdfc03b9"
+      width="400"
+      height="300"
       aria-label="Aria labels are cool."></amp-img>
-    <amp-img src="https://picsum.photos/300/200/?image=33"
-      width="300"
-      height="200"
+    <amp-img src="https://images.unsplash.com/photo-1482066490729-6f26115b60dc"
+      width="400"
+      height="300"
       aria-describedby="my-aria-describe"></amp-img>
-    <amp-img src="https://picsum.photos/300/200/?image=34"
-      width="300"
-      height="200"
+    <amp-img src="https://images.unsplash.com/photo-1511275539165-cc46b1ee89bf"
+      width="400"
+      height="300"
       aria-labelledby="my-aria-label"></amp-img>
     <amp-video
       src="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4"
@@ -100,15 +101,15 @@
         />
     </amp-youtube>
     <amp-instagram data-shortcode="1totVhIFXl"
-      width="1"
-      height="1"
-      layout="responsive">
+      width="400"
+      height="400"
+      layout="fixed">
     </amp-instagram>
     <amp-facebook
       lightbox-thumbnail-id="fb-thumbnail-img"
       width="552"
       height="303"
-      layout="responsive"
+      layout="fixed"
       data-href="https://www.facebook.com/zuck/posts/10102593740125791">
     </amp-facebook>
     <amp-facebook width="552"


### PR DESCRIPTION
1. Updates launch tests to add `<amp-ad>`. 
2. Adds `<amp-ad>` to lightbox support validation. 
3. Adds `<amp-lightbox-gallery>` to allowed containers with fixed positioning for ads. 