### PR TITLE
🐛Story ads showing segments in progress bar

### DIFF
--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -332,7 +332,13 @@ export class AmpStory extends AMP.BaseElement {
    * @private
    */
   buildSystemLayer_() {
-    const pageIds = this.pages_.map(page => page.element.id);
+    const pageIds = this.pages_.reduce((ids, page) => {
+      if (page.isAd()) {
+        return ids;
+      }
+      return ids.concat(page.element.id);
+    }, []);
+
     this.element.appendChild(this.systemLayer_.build(pageIds));
     this.updateAudioIcon_();
   }


### PR DESCRIPTION
There is a race condition where sometimes the ad page element is inserted into the `pages_` array before `buildSystemLayer_` is called. The result is that there is a segment created for an ad page. 

This ensures that a page id associated with an ad is never passed to the progress bar, regardless of when the ad page is added to the `pages_` array.