### PR TITLE
🐛 Fix progress-bar segments showing on ads in story

### DIFF
--- a/extensions/amp-story/0.1/amp-story-auto-ads.js
+++ b/extensions/amp-story/0.1/amp-story-auto-ads.js
@@ -15,6 +15,7 @@
  */
 
 import {CommonSignals} from '../../../src/common-signals';
+import {EventType} from './events';
 import {Services} from '../../../src/services';
 import {StateChangeType} from './navigation-state';
 import {createElementWithAttributes} from '../../../src/dom';
@@ -99,9 +100,25 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
 
   /** @override */
   layoutCallback() {
-    this.readConfig_();
-    this.schedulePage_();
-    return Promise.resolve();
+    return this.createStoryLoadPromise_()
+        .then(() => {
+          this.readConfig_();
+          this.schedulePage_();
+        });
+  }
+
+
+  /**
+   * promise that resolves on STORY_LOADED event
+   * @private
+   * @return {!Promise}
+   */
+  createStoryLoadPromise_() {
+    return new Promise(resolve => {
+      this.ampStory_.element.addEventListener(EventType.STORY_LOADED, () => {
+        resolve();
+      });
+    });
   }
 
 

--- a/extensions/amp-story/0.1/amp-story-auto-ads.js
+++ b/extensions/amp-story/0.1/amp-story-auto-ads.js
@@ -115,9 +115,7 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
    */
   createStoryLoadPromise_() {
     return new Promise(resolve => {
-      this.ampStory_.element.addEventListener(EventType.STORY_LOADED, () => {
-        resolve();
-      });
+      this.ampStory_.element.addEventListener(EventType.STORY_LOADED, resolve);
     });
   }
 


### PR DESCRIPTION
There is a race condition where sometimes the ad page element is inserted into the `pages_` array before `buildSystemLayer_` is called. The result is that there is a segment created for an ad page.

We are now waiting for the `STORY_LOADED` event before we start the ad insertion process. This ensures that the system layer is built before any ad-page is created. Also is probably right design overall to let story load before ads start competing for resources.