### PR TITLE
Pass two new RTC macros to media.net

### DIFF
--- a/extensions/amp-a4a/0.1/callout-vendors.js
+++ b/extensions/amp-a4a/0.1/callout-vendors.js
@@ -38,7 +38,7 @@ let RtcVendorDef;
 export const RTC_VENDORS = {
   // Add vendors here
   medianet: {
-    url: 'https://amprtc.media.net/rtb/getrtc?cid=CID&w=ATTR(width)&h=ATTR(height)&ow=ATTR(data-override-width)&oh=ATTR(data-override-height)&ms=ATTR(data-multi-size)&slot=ATTR(data-slot)&tgt=TGT&purl=HREF',
+    url: 'https://amprtc.media.net/rtb/getrtc?cid=CID&w=ATTR(width)&h=ATTR(height)&ow=ATTR(data-override-width)&oh=ATTR(data-override-height)&ms=ATTR(data-multi-size)&slot=ATTR(data-slot)&tgt=TGT&curl=CANONICAL_URL&to=TIMEOUT&purl=HREF',
     macros: ['CID'],
     disableKeyAppend: true,
   },


### PR DESCRIPTION
:sparkles: Pass the two new RTC macros: CANONICAL_URL and TIMEOUT, in the medianet vendor call