### PR TITLE
Get creative content

### DIFF
--- a/extensions/amp-a4a/0.1/a4a-variable-source.js
+++ b/extensions/amp-a4a/0.1/a4a-variable-source.js
@@ -68,8 +68,8 @@ const WHITELISTED_VARIABLES = [
   'FIRST_CONTENTFUL_PAINT',
   'FIRST_VIEWPORT_READY',
   'MAKE_BODY_VISIBLE',
+  'HTML_ATTR',
 ];
-
 
 /** Provides A4A specific variable substitution. */
 export class A4AVariableSource extends VariableSource {

--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -56,6 +56,15 @@ const WHITELIST_EVENT_IN_SANDBOX = [
   AnalyticsEventType.HIDDEN,
 ];
 
+/**
+ * @typedef {(string|!Promise<string>|function(): string)}
+ */
+let DynamicVariableBindingDef;
+
+/**
+ * @typedef {function(string, ...?): string}
+ */
+let HtmlAttrBindingDef;
 
 export class AmpAnalytics extends AMP.BaseElement {
 
@@ -685,7 +694,7 @@ export class AmpAnalytics extends AMP.BaseElement {
   /**
    * @param {!JsonObject} trigger JSON config block that resulted in this event.
    * @param {!ExpansionOptions} expansionOptions Expansion options.
-   * @return {!Object<string, (string|!Promise<string>|function(): string)>}
+   * @return {!Object<string, DynamicVariableBindingDef>}
    * @private
    */
   getDynamicVariableBindings_(trigger, expansionOptions) {
@@ -721,11 +730,53 @@ export class AmpAnalytics extends AMP.BaseElement {
   expandAndSendRequest_(request, trigger, event) {
     this.config_['vars']['requestCount']++;
     const expansionOptions = this.expansionOptions_(event, trigger);
+    /** @type {!Object<string, (DynamicVariableBindingDef|HtmlAttrBindingDef)>} */
     const dynamicBindings =
         this.getDynamicVariableBindings_(trigger, expansionOptions);
+    dynamicBindings['HTML_ATTR'] = this.htmlAttrBinding_.bind(this);
     request.send(
         this.config_['extraUrlParams'], trigger, expansionOptions,
         dynamicBindings);
+  }
+
+  /**
+   * Provides a binding for getting attributes from the DOM.
+   * Most such bindings are provided in src/service/url-replacements-impl, but
+   * this one needs access to this.win.document, which if the amp-analytics
+   * tag is contained within an amp-ad tag will NOT be the parent/publisher
+   * page. Hence the need to put it here.
+   * @param {string} cssSelector Elements matching this selector will be
+   *     included, provided they have at least one of the attributeNames
+   *     set, up to a max of 10.
+   * @param attributeNames The attributes whose values will be returned.
+   * @returns {string}
+   */
+  htmlAttrBinding_(cssSelector, ...attributeNames) {
+    const HTML_ATTR_MAX_RETURN_SIZE = 10;
+    const result = [];
+    if (!cssSelector || !attributeNames || !attributeNames.length) {
+      return JSON.stringify(result);
+    }
+    try {
+      const elements = this.win.document.querySelectorAll(cssSelector);
+      for (let i = 0; elements && i < elements.length &&
+      result.length < HTML_ATTR_MAX_RETURN_SIZE; ++i) {
+        const currentResult = {};
+        attributeNames.forEach(attributeName => {
+          const attributeValue = elements[i].getAttribute(attributeName);
+          if (attributeValue) {
+            currentResult[attributeName] = attributeValue;
+          }
+        });
+        if (Object.keys(currentResult).length) {
+          result.push(currentResult);
+        }
+      }
+    } catch (e) {
+      const TAG = this.getName_();
+      user().warn(TAG, `Invalid selector: ${cssSelector}`);
+    }
+    return JSON.stringify(result);
   }
 
   /**

--- a/extensions/amp-analytics/0.1/test/test-amp-analytics.js
+++ b/extensions/amp-analytics/0.1/test/test-amp-analytics.js
@@ -470,6 +470,18 @@ describes.realWin('amp-analytics', {
     });
   });
 
+  it('should replace HTML_ATTR', () => {
+    const analytics = getAnalyticsTag({
+      'requests': {'foo': 'https://example.com/bar&ids=${htmlAttr(div,id)}'},
+      'triggers': [{'on': 'visible', 'request': ['foo']}],
+    });
+
+    return waitForSendRequest(analytics).then(() => {
+      expect(sendRequestSpy.calledOnce).to.be.true;
+      expect(decodeURIComponent(sendRequestSpy.args[0][0])).to.equal('https://example.com/bar&ids=[{"id":"parent"}]');
+    });
+  });
+
   it('fills cid', function() {
     const analytics = getAnalyticsTag({
       'requests': {'foo': 'https://example.com/cid=${clientId(analytics-abc)}'},

--- a/extensions/amp-analytics/0.1/vendors.js
+++ b/extensions/amp-analytics/0.1/vendors.js
@@ -50,6 +50,7 @@ export const ANALYTICS_CONFIG = /** @type {!JsonObject} */ ({
       'externalReferrer': 'EXTERNAL_REFERRER',
       'firstContentfulPaint': 'FIRST_CONTENTFUL_PAINT',
       'firstViewportReady': 'FIRST_VIEWPORT_READY',
+      'htmlAttr': 'HTML_ATTR',
       'makeBodyVisible': 'MAKE_BODY_VISIBLE',
       'incrementalEngagedTime': 'INCREMENTAL_ENGAGED_TIME',
       'navRedirectCount': 'NAV_REDIRECT_COUNT',

--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -225,6 +225,10 @@ export class GlobalVariableSource extends VariableSource {
       return info.pageViewId;
     }));
 
+    // Will be overridden by amp-analytics, but needs to exist here or will get
+    // a null pointer exception at A4AVariableSource.initialize
+    this.set('HTML_ATTR', () => '');
+
     this.setBoth('QUERY_PARAM', (param, defaultValue = '') => {
       return this.getQueryParamData_(param, defaultValue);
     }, (param, defaultValue = '') => {


### PR DESCRIPTION
Allows amp-analytics request to include htmlAttr expansion variable. Example:
${htmlAttr(img,src,width)}
...to get the src and width attrs of images. Documentation to follow in separate PR.
Caveats:

Only up to 10 matching elements will be returned.
An element counts as a match if it matches the CSS query selector (first arg) and has one or more of the attrs specified in the remaining args

Created from PR #13111 which got stale.