### PR TITLE
🏗 Remove .js extension from visual tests config file

### DIFF
--- a/build-system/config.js
+++ b/build-system/config.js
@@ -131,7 +131,6 @@ module.exports = {
     '!extensions/amp-animation/0.1/css-expr-impl.js',
     '!extensions/amp-bind/0.1/bind-expr-impl.js',
     '!test/coverage/**/*.*',
-    '!test/visual-diff/visual-tests.js',
   ],
   jsonGlobs: [
     '**/*.json',
@@ -163,7 +162,6 @@ module.exports = {
     '!examples/*.js',
     '!examples/visual-tests/**/*',
     '!test/coverage/**/*.*',
-    '!test/visual-diff/visual-tests.js',
   ],
   changelogIgnoreFileTypes: /\.md|\.json|\.yaml|LICENSE|CONTRIBUTORS$/,
 };

--- a/build-system/tasks/visual-diff.rb
+++ b/build-system/tasks/visual-diff.rb
@@ -216,7 +216,7 @@ def load_visual_tests_config_json
   json_file = File.open(
       File.join(
           File.dirname(__FILE__),
-          '../../test/visual-diff/visual-tests.js'),
+          '../../test/visual-diff/visual-tests'),
       'r')
   json_file.read
 end

--- a/test/visual-diff/visual-tests
+++ b/test/visual-diff/visual-tests
@@ -16,10 +16,6 @@
 
 /**
  * Particulars of the webpages used in the AMP visual diff tests.
- *
- * Note: While the extension of this file is .js, the contents are pseudo-json
- * due to the presence of detailed comments. Ruby's json parser natively
- * supports comments in json files, and is capable of parsing this file.
  */
 {
   /**


### PR DESCRIPTION
The visual tests file at `test/visual-diff/{visual-tests.js` is a pseudo-json file. The fact that it has a `.js` extension caused it to occasionally be picked up by `gulp` tasks like `lint`, `presubmit`, and `test`, and required exceptions to be put in place. 

This PR removes the extension, since it is purely a config file. With this, we no longer need to add exceptions for the file for each of the `gulp` tasks that might pick it up.