### PR TITLE
🏗 Visual tests: Use large viewport with 1x pixel ratio

### DIFF
--- a/build-system/tasks/visual-diff.rb
+++ b/build-system/tasks/visual-diff.rb
@@ -32,6 +32,8 @@ ENV['PERCY_DEBUG'] = '0'
 ENV['WEBSERVER_QUIET'] = '--quiet'
 # CSS widths: iPhone: 375, Pixel: 411, Desktop: 1400.
 DEFAULT_WIDTHS = [375, 411, 1400]
+VIEWPORT_WIDTH = 1400
+VIEWPORT_HEIGHT = 100000
 HOST = 'localhost'
 PORT = '8000'
 WEBSERVER_TIMEOUT_SECS = 15
@@ -232,10 +234,20 @@ def configure_browser
   capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
     chromeOptions: { args: chrome_args }
   )
+  options = Selenium::WebDriver::Chrome::Options.new
+  options.add_emulation(
+    device_metrics: {
+      width: VIEWPORT_WIDTH,
+      height: VIEWPORT_HEIGHT,
+      pixelRatio: 1,
+      touch: false
+    }
+  )
   Capybara.register_driver :chrome do |app|
     Capybara::Selenium::Driver.new app,
       browser: :chrome,
-      desired_capabilities: capabilities
+      desired_capabilities: capabilities,
+      options: options
   end
   Capybara.javascript_driver = :chrome
 end
@@ -365,7 +377,7 @@ def snapshot_webpages(page, webpages, config)
         forbidden_css,
         loading_incomplete_css,
         loading_complete_css)
-    Percy::Capybara.snapshot(page, name: name)
+    Percy::Capybara.snapshot(page, name: name, enable_javascript: true)
     clear_experiments(page)
   end
 end

--- a/build-system/tasks/visual-diff.rb
+++ b/build-system/tasks/visual-diff.rb
@@ -377,7 +377,7 @@ def snapshot_webpages(page, webpages, config)
         forbidden_css,
         loading_incomplete_css,
         loading_complete_css)
-    Percy::Capybara.snapshot(page, name: name, enable_javascript: true)
+    Percy::Capybara.snapshot(page, name: name)
     clear_experiments(page)
   end
 end


### PR DESCRIPTION
This PR attempts to fix a few issues being seen in the visual tests:
1. Increases the viewport height to make sure that all the page content loads before visual diffing
2. Forces the pages to be rendered with a pixel ratio of 1x, based on the suggestion in https://github.com/percy/percy-capybara/issues/51#issuecomment-367845681
3. ~~Enables JS so that all content rendered by AMP is visible when Percy renders the DOM snapshots~~ Edit: This will be done after https://github.com/percy/percy-capybara/issues/51 is fixed.
