### PR TITLE
Make sure to clear iframe in SafeframeHostApi on destroy

### DIFF
--- a/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
@@ -135,9 +135,6 @@ export class SafeframeHostApi {
     /** @private {?Element} */
     this.iframe_ = null;
 
-    /** @private {?IntersectionObserver} */
-    this.intersectionObserver_ = null;
-
     /** @type {?string} */
     this.channel = null;
 
@@ -613,6 +610,7 @@ export class SafeframeHostApi {
    * Unregister this Host API.
    */
   destroy() {
+    this.iframe_ = null;
     delete safeframeHosts[this.sentinel_];
     if (this.unlisten_) {
       this.unlisten_();


### PR DESCRIPTION
Iframe was not being cleared. This was an issue, because the way that throttle works means that a race condition could occur the following way:

0ms: scroll detected, updateGeometry called
5ms: scroll detected, updateGeometry called but throttling simple queues up call
10ms: unlayoutCallback triggered for amp-ad element, iframe destroyed
1000ms: updateGeometry called from throttle queue, iframe no longer exists but we never actually cleared it in the safeframeHost. 