### PR TITLE
Support for background-audio on the <amp-story> tag.

### DIFF
--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -1173,7 +1173,7 @@ export class AmpStory extends AMP.BaseElement {
    * @private
    */
   registerAndPreloadBackgroundAudio_() {
-    const backgroundAudioEl = upgradeBackgroundAudio(this.element);
+    let backgroundAudioEl = upgradeBackgroundAudio(this.element);
 
     if (!backgroundAudioEl) {
       return;
@@ -1184,12 +1184,15 @@ export class AmpStory extends AMP.BaseElement {
     // it programmatically later.
     this.activePage_.whenLoaded()
         .then(() => {
+          backgroundAudioEl =
+            /** @type {!HTMLMediaElement} */ (backgroundAudioEl);
           this.mediaPool_.register(backgroundAudioEl);
           return this.mediaPool_.preload(backgroundAudioEl);
         }).then(() => {
-          this.backgroundAudioEl_ = childElement(this.element, el => {
-            return el.tagName.toLowerCase() === 'audio';
-          });
+          this.backgroundAudioEl_ = /** @type {!HTMLMediaElement} */
+              (childElement(this.element, el => {
+                return el.tagName.toLowerCase() === 'audio';
+              }));
         });
   }
 

--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -51,6 +51,7 @@ import {ShareWidget} from './share';
 import {SystemLayer} from './system-layer';
 import {TapNavigationDirection} from './page-advancement';
 import {
+  childElement,
   closest,
   escapeCssSelectorIdent,
   matches,
@@ -264,6 +265,9 @@ export class AmpStory extends AMP.BaseElement {
     /** @private {?AmpStoryBackground} */
     this.background_ = null;
 
+    /** @private {?HTMLMediaElement} */
+    this.backgroundAudioEl_ = null;
+
     /** @private {?./pagination-buttons.PaginationButtons} */
     this.paginationButtons_ = null;
 
@@ -318,8 +322,6 @@ export class AmpStory extends AMP.BaseElement {
 
     // Mute `amp-story` in beginning.
     this.mute_();
-
-    upgradeBackgroundAudio(this.element);
 
     registerServiceBuilder(this.win, 'story-variable',
         () => this.variableService_);
@@ -832,6 +834,11 @@ export class AmpStory extends AMP.BaseElement {
             PRE_ACTIVE_PAGE_ATTRIBUTE_NAME);
       }
 
+      // If first navigation.
+      if (!oldPage) {
+        this.registerAndPreloadBackgroundAudio_();
+      }
+
       this.preloadPagesByDistance_();
       this.reapplyMuting_();
       this.forceRepaintForSafari_();
@@ -1162,6 +1169,32 @@ export class AmpStory extends AMP.BaseElement {
 
 
   /**
+   * Handles a background-audio attribute set on an <amp-story> tag.
+   * @private
+   */
+  registerAndPreloadBackgroundAudio_() {
+    const backgroundAudioEl = upgradeBackgroundAudio(this.element);
+
+    if (!backgroundAudioEl) {
+      return;
+    }
+
+    // Once the media pool is ready, registers and preloads the background
+    // audio, and then gets the swapped element from the DOM to mute/unmute/play
+    // it programmatically later.
+    this.activePage_.whenLoaded()
+        .then(() => {
+          this.mediaPool_.register(backgroundAudioEl);
+          return this.mediaPool_.preload(backgroundAudioEl);
+        }).then(() => {
+          this.backgroundAudioEl_ = childElement(this.element, el => {
+            return el.tagName.toLowerCase() === 'audio';
+          });
+        });
+  }
+
+
+  /**
    * Preloads the bookend config if on the last page.
    * @private
    */
@@ -1320,10 +1353,12 @@ export class AmpStory extends AMP.BaseElement {
 
 
   /**
+   * Retrieves the page containing the element, or null. A background audio
+   * set on the <amp-story> tag would not be contained in a page.
    * @param {!Element} element The element whose containing AmpStoryPage should
    *     be retrieved
-   * @return {!./amp-story-page.AmpStoryPage} The AmpStoryPage containing the
-   *     specified element.
+   * @return {?./amp-story-page.AmpStoryPage} The AmpStoryPage containing the
+   *     specified element, if any.
    */
   getPageContainingElement_(element) {
     const pageIndex = findIndex(this.pages_, page => {
@@ -1334,29 +1369,42 @@ export class AmpStory extends AMP.BaseElement {
       return !!pageEl;
     });
 
-    return dev().assert(this.pages_[pageIndex],
-        'Element not contained on any amp-story-page');
+    return this.pages_[pageIndex] || null;
   }
 
 
   /** @override */
   getElementDistance(element) {
     const page = this.getPageContainingElement_(element);
+
+    // An element not contained in a page is likely to be global to the story,
+    // like a background audio. Setting the distance to -1 ensures it will not
+    // get evicted from the media pool.
+    if (!page) {
+      return -1;
+    }
+
     return page.getDistance();
   }
 
 
   /** @override */
   getMaxMediaElementCounts() {
-    const audioMediaElements =
-        this.element.querySelectorAll('amp-audio, [background-audio]');
-    const videoMediaElements = this.element.querySelectorAll('amp-video');
+    let audioMediaElementsCount =
+        this.element.querySelectorAll('amp-audio, [background-audio]').length;
+    const videoMediaElementsCount =
+        this.element.querySelectorAll('amp-video').length;
+
+    // The root element (amp-story) might have a background-audio as well.
+    if (this.element.hasAttribute('background-audio')) {
+      audioMediaElementsCount++;
+    }
 
     return {
       [MediaType.AUDIO]: Math.min(
-          audioMediaElements.length, MAX_MEDIA_ELEMENT_COUNTS[MediaType.AUDIO]),
+          audioMediaElementsCount, MAX_MEDIA_ELEMENT_COUNTS[MediaType.AUDIO]),
       [MediaType.VIDEO]: Math.min(
-          videoMediaElements.length, MAX_MEDIA_ELEMENT_COUNTS[MediaType.VIDEO]),
+          videoMediaElementsCount, MAX_MEDIA_ELEMENT_COUNTS[MediaType.VIDEO]),
     };
   }
 
@@ -1371,6 +1419,9 @@ export class AmpStory extends AMP.BaseElement {
    * @private
    */
   mute_() {
+    if (this.backgroundAudioEl_) {
+      this.mediaPool_.mute(this.backgroundAudioEl_);
+    }
     this.pages_.forEach(page => {
       page.muteAllMedia();
     });
@@ -1382,7 +1433,14 @@ export class AmpStory extends AMP.BaseElement {
    * @private
    */
   unmute_() {
-    const unmuteAllMedia = () => this.activePage_.unmuteAllMedia();
+    const unmuteAllMedia = () => {
+      if (this.backgroundAudioEl_) {
+        this.mediaPool_.unmute(this.backgroundAudioEl_);
+        this.mediaPool_.play(this.backgroundAudioEl_);
+      }
+      this.activePage_.unmuteAllMedia();
+    };
+
     this.mediaPool_.blessAll()
         .then(unmuteAllMedia, unmuteAllMedia);
     this.toggleMutedAttribute_(false);

--- a/extensions/amp-story/0.1/audio.js
+++ b/extensions/amp-story/0.1/audio.js
@@ -26,18 +26,24 @@ const BACKGROUND_AUDIO_ELEMENT_CLASS_NAME = 'i-amphtml-story-background-audio';
  * Adds support for the background-audio property on the specified element.
  * @param {!Element} element The element to upgrade with support for background
  *     audio.
+ * @return {?Element} audioEl
  */
 export function upgradeBackgroundAudio(element) {
-  if (element.hasAttribute('background-audio')) {
-    const audioEl = element.ownerDocument.createElement('audio');
-    const audioSrc =
-        assertHttpsUrl(element.getAttribute('background-audio'), element);
-    audioEl.setAttribute('src', audioSrc);
-    audioEl.setAttribute('preload', 'auto');
-    audioEl.setAttribute('loop', '');
-    audioEl.setAttribute('autoplay', '');
-    audioEl.setAttribute('muted', '');
-    audioEl.classList.add(BACKGROUND_AUDIO_ELEMENT_CLASS_NAME);
-    element.appendChild(audioEl);
+  if (!element.hasAttribute('background-audio')) {
+    return null;
   }
+
+  const audioEl = element.ownerDocument.createElement('audio');
+  const audioSrc =
+      assertHttpsUrl(element.getAttribute('background-audio'), element);
+  audioEl.setAttribute('src', audioSrc);
+  audioEl.setAttribute('preload', 'auto');
+  audioEl.setAttribute('loop', '');
+  audioEl.setAttribute('autoplay', '');
+  audioEl.setAttribute('muted', '');
+  audioEl.muted = true;
+  audioEl.classList.add(BACKGROUND_AUDIO_ELEMENT_CLASS_NAME);
+  element.appendChild(audioEl);
+
+  return audioEl;
 }


### PR DESCRIPTION
This PR adds very basic controls for a ``background-audio`` attribute on a ``<amp-story>`` tag.

- Mutes ``background-audio``  elements by default by adding ``audioEl.muted = true`` to the ``audio.js`` file
- Adds the ``amp-story`` ``background audio`` to the media pool and preloads it right away
- Media pool elements that does not belong to a page have a ``distance`` of ``-1`` so they're never evicted from the media pool
- Unmutes and plays it once the user unmutes the story

Fixes #13635

