### PR TITLE
🖍Add amp-story-grid-layer to injected ads

### DIFF
--- a/examples/amp-story-auto-ads.amp.html
+++ b/examples/amp-story-auto-ads.amp.html
@@ -49,8 +49,7 @@
       </script>
 
       <template type="amp-mustache" id="template-1">
-        <h2>Template ad 1</h2>
-        <amp-img layout='fixed' height="300" width="300" src="{{imgSrc}}"></amp-img>
+        <amp-img layout="fill" src="{{imgSrc}}"></amp-img>
         <amp-pixel src="{{impressionUrl}}"></amp-pixel>
       </template>
 

--- a/extensions/amp-story/0.1/amp-story-auto-ads.js
+++ b/extensions/amp-story/0.1/amp-story-auto-ads.js
@@ -176,7 +176,10 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
     const ampStoryAdPage = this.createPageElement_();
     const ampAd = this.createAdElement_();
 
-    ampStoryAdPage.appendChild(ampAd);
+    const gridLayer = document.createElement('amp-story-grid-layer');
+    gridLayer.setAttribute('template', 'fill');
+    gridLayer.appendChild(ampAd);
+    ampStoryAdPage.appendChild(gridLayer);
 
     this.isCurrentAdLoaded_ = false;
 
@@ -216,8 +219,7 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
   createAdElement_() {
     const defaultAttrs = {
       'id': 'i-amphtml-story-ad',
-      'height': '100vh',
-      'width': '100vw',
+      'layout': 'fill',
     };
 
     const configAttrs = this.config_['ad-attributes'];


### PR DESCRIPTION
In my original PR I was hardcoding width and height. I should have used the existing grid system. 

We are now wrapping the `amp-ad` in an `amp-story-grid-layer`:

```
<amp-story-grid-layer template="fill">
  <amp-ad layout="fill">
    ...
  <amp-ad>
</amp-story-grid-layer>
```

