### PR TITLE
🏗 Correctly set up Selenium options for visual tests

### DIFF
--- a/build-system/tasks/visual-diff.rb
+++ b/build-system/tasks/visual-diff.rb
@@ -227,14 +227,14 @@ end
 # Configures the Chrome browser (optionally in headless mode)
 def configure_browser
   if ARGV.include? '--headless'
-    chrome_args = %w(no-sandbox disable-extensions headless disable-gpu)
+    chrome_args = %w[--no-sandbox --disable-extensions --headless --disable-gpu]
   else
-    chrome_args = %w(no-sandbox disable-extensions)
+    chrome_args = %w[--no-sandbox --disable-extensions]
   end
-  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
-    chromeOptions: { args: chrome_args }
-  )
   options = Selenium::WebDriver::Chrome::Options.new
+  chrome_args.each do |option|
+    options.add_argument(option)
+  end
   options.add_emulation(
     device_metrics: {
       width: VIEWPORT_WIDTH,
@@ -244,11 +244,13 @@ def configure_browser
     }
   )
   Capybara.register_driver :chrome do |app|
-    Capybara::Selenium::Driver.new app,
+    Capybara::Selenium::Driver.new(
+      app,
       browser: :chrome,
-      desired_capabilities: capabilities,
       options: options
+    )
   end
+  Capybara.default_driver = :chrome
   Capybara.javascript_driver = :chrome
 end
 


### PR DESCRIPTION
Earlier, we were using `Selenium::WebDriver::Remote::Capabilities.chrome` to set up the flags used by Selenium to launch Chrome. It turns out that these weren't really working, possibly causing the timeouts we're seeing during page loads during the visual tests.

This PR uses `Selenium::WebDriver::Chrome::Options.add_argument` to set up the Chrome flags. I've tested locally to confirm that `gulp visual-diff --headless` actually opens a headless Chrome window.

Speculative fix for #13700 
