### PR TITLE
Get creative content

### DIFF
--- a/examples/analytics-html-attr.amp.html
+++ b/examples/analytics-html-attr.amp.html
@@ -14,9 +14,10 @@
 <body>
   Here is some text above the ad.<br/>
   <amp-ad width="800" height="970"
+          id="i-amphtml-demo-id"
           type="fake"
-          src="fake_amp_ad_with_html_attr.html"
-          data-use-a4a="true" fakesig="true">
+          a4a-conversion="true"
+          src="http://localhost:8000/extensions/amp-ad-network-fake-impl/0.1/data/fake_amp_ad_with_html_attr.html">
     <div placeholder>Loading...</div>
     <div fallback>Could not display the fake ad :(</div>
   </amp-ad>

--- a/examples/analytics-html-attr.amp.html
+++ b/examples/analytics-html-attr.amp.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>3P AMP Analytics Example</title>
+  <link rel="canonical" href="amps.html" >
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <link href='https://fonts.googleapis.com/css?family=Georgia|Open+Sans|Roboto' rel='stylesheet' type='text/css'>
+  <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
+  <script async custom-element="amp-ad" src="https://cdn.ampproject.org/v0/amp-ad-0.1.js"></script>
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+  Here is some text above the ad.<br/>
+  <amp-ad width="800" height="970"
+          type="fake"
+          src="fake_amp_ad_with_html_attr.html"
+          data-use-a4a="true" fakesig="true">
+    <div placeholder>Loading...</div>
+    <div fallback>Could not display the fake ad :(</div>
+  </amp-ad>
+  <br/>
+  Here is some text below the ad.<br/>
+</body>
+</html>

--- a/extensions/amp-a4a/0.1/a4a-variable-source.js
+++ b/extensions/amp-a4a/0.1/a4a-variable-source.js
@@ -131,12 +131,14 @@ export class A4AVariableSource extends VariableSource {
    * @param {string} cssSelector Elements matching this selector will be
    *     included, provided they have at least one of the attributeNames
    *     set, up to a max of 10. May be URI encoded.
-   * @param attributeNames The attributes whose values will be returned.
+   * Note: Additional params will be the names of the attributes whose values
+   * will be returned. There should be at least 1.
    * @returns {string}
    */
-  htmlAttrBinding_(cssSelector, ...attributeNames) {
+  htmlAttrBinding_(cssSelector) {
     const HTML_ATTR_MAX_RETURN_SIZE = 10;
     const result = [];
+    const attributeNames = Array.prototype.slice.call(arguments, 1);
     if (!cssSelector || !attributeNames || !attributeNames.length) {
       return JSON.stringify(result);
     }

--- a/extensions/amp-a4a/0.1/a4a-variable-source.js
+++ b/extensions/amp-a4a/0.1/a4a-variable-source.js
@@ -142,7 +142,7 @@ export class A4AVariableSource extends VariableSource {
    */
   htmlAttrBinding_(cssSelector, ...attributeNames) {
     // Generate an error if cssSelector matches more than this many elements
-    const HTML_ATTR_MAX_ELEMENTS_TO_TRAVERSE = 50;
+    const HTML_ATTR_MAX_ELEMENTS_TO_TRAVERSE = 20;
 
     // Of the elements matched by cssSelector, see which contain one or more
     // of the specified attributes, and return an array of at most this many.

--- a/extensions/amp-a4a/0.1/a4a-variable-source.js
+++ b/extensions/amp-a4a/0.1/a4a-variable-source.js
@@ -131,7 +131,7 @@ export class A4AVariableSource extends VariableSource {
    * @param {string} cssSelector Elements matching this selector will be
    *     included, provided they have at least one of the attributeNames
    *     set, up to a max of 10. May be URI encoded.
-   * @param {...string} attributeNames Additional params will be the names of
+   * @param {...string} var_args Additional params will be the names of
    *     attributes whose values will be returned. There should be at least 1.
    * @returns {string} A stringified JSON array containing one member for each
    *     matching element. Each member will contain the names and values of the
@@ -140,7 +140,7 @@ export class A4AVariableSource extends VariableSource {
    *     requested attributes, then nothing will be included in the array
    *     for that element.
    */
-  htmlAttributeBinding_(cssSelector, ...attributeNames) {
+  htmlAttributeBinding_(cssSelector, var_args) {
     // Generate an error if cssSelector matches more than this many elements
     const HTML_ATTR_MAX_ELEMENTS_TO_TRAVERSE = 20;
 
@@ -152,6 +152,8 @@ export class A4AVariableSource extends VariableSource {
     const HTML_ATTR_MAX_ATTRS = 10;
 
     const TAG = 'A4AVariableSource';
+
+    const attributeNames = Array.prototype.slice.call(arguments, 1);
     if (!cssSelector || !attributeNames.length) {
       return '[]';
     }

--- a/extensions/amp-a4a/0.1/a4a-variable-source.js
+++ b/extensions/amp-a4a/0.1/a4a-variable-source.js
@@ -131,8 +131,8 @@ export class A4AVariableSource extends VariableSource {
    * @param {string} cssSelector Elements matching this selector will be
    *     included, provided they have at least one of the attributeNames
    *     set, up to a max of 10. May be URI encoded.
-   * Note: Additional params will be the names of the attributes whose values
-   * will be returned. There should be at least 1.
+   * Note: Additional params will be the names of the attributes whose
+   *     values will be returned. There should be at least 1.
    * @returns {string} A stringified JSON array containing one member for each
    *     matching element. Each member will contain the names and values of the
    *     specified attributes, if the corresponding element has that attribute.
@@ -141,7 +141,8 @@ export class A4AVariableSource extends VariableSource {
    *     for that element.
    */
   htmlAttrBinding_(cssSelector) {
-    const HTML_ATTR_MAX_RETURN_SIZE = 10;
+    const HTML_ATTR_MAX_ELEMENTS = 10;
+    const HTML_ATTR_MAX_ATTRS = 10;
     const attributeNames = Array.prototype.slice.call(arguments, 1);
     if (!cssSelector || !attributeNames.length) {
       return '[]';
@@ -152,15 +153,16 @@ export class A4AVariableSource extends VariableSource {
       elements = this.win_.document.querySelectorAll(cssSelector);
     } catch (e) {
       const TAG = 'A4AVariableSource';
-      user().warn(TAG, `Invalid selector: ${cssSelector}`);
+      user().error(TAG, `Invalid selector: ${cssSelector}`);
       return '[]';
     }
     const result = [];
     for (let i = 0; i < elements.length &&
-        result.length < HTML_ATTR_MAX_RETURN_SIZE; ++i) {
+        result.length < HTML_ATTR_MAX_ELEMENTS; ++i) {
       const currentResult = {};
       let foundAtLeastOneAttr = false;
-      for (let j = 0; j < attributeNames.length; ++j) {
+      for (let j = 0; j < attributeNames.length &&
+          j < HTML_ATTR_MAX_ATTRS; ++j) {
         const attributeName = attributeNames[j];
         if (elements[i].hasAttribute(attributeName)) {
           currentResult[attributeName] =

--- a/extensions/amp-a4a/0.1/a4a-variable-source.js
+++ b/extensions/amp-a4a/0.1/a4a-variable-source.js
@@ -68,7 +68,6 @@ const WHITELISTED_VARIABLES = [
   'FIRST_CONTENTFUL_PAINT',
   'FIRST_VIEWPORT_READY',
   'MAKE_BODY_VISIBLE',
-  'HTML_ATTR',
 ];
 
 /** Provides A4A specific variable substitution. */

--- a/extensions/amp-a4a/0.1/a4a-variable-source.js
+++ b/extensions/amp-a4a/0.1/a4a-variable-source.js
@@ -133,7 +133,12 @@ export class A4AVariableSource extends VariableSource {
    *     set, up to a max of 10. May be URI encoded.
    * Note: Additional params will be the names of the attributes whose values
    * will be returned. There should be at least 1.
-   * @returns {string}
+   * @returns {string} A stringified JSON array containing one member for each
+   *     matching element. Each member will contain the names and values of the
+   *     specified attributes, if the corresponding element has that attribute.
+   *     Note that if an element matches the cssSelected but has none of the
+   *     requested attributes, then nothing will be included in the array
+   *     for that element.
    */
   htmlAttrBinding_(cssSelector) {
     const HTML_ATTR_MAX_RETURN_SIZE = 10;

--- a/extensions/amp-a4a/0.1/a4a-variable-source.js
+++ b/extensions/amp-a4a/0.1/a4a-variable-source.js
@@ -68,8 +68,8 @@ const WHITELISTED_VARIABLES = [
   'FIRST_CONTENTFUL_PAINT',
   'FIRST_VIEWPORT_READY',
   'MAKE_BODY_VISIBLE',
+  'HTML_ATTR',
 ];
-
 
 /** Provides A4A specific variable substitution. */
 export class A4AVariableSource extends VariableSource {
@@ -113,10 +113,56 @@ export class A4AVariableSource extends VariableSource {
       return getNavigationData(this.win_, 'redirectCount');
     });
 
+    this.set('HTML_ATTR',
+        /** @type {function(...*)} */(this.htmlAttrBinding_.bind(this)));
+
     for (let v = 0; v < WHITELISTED_VARIABLES.length; v++) {
       const varName = WHITELISTED_VARIABLES[v];
       const resolvers = this.globalVariableSource_.get(varName);
       this.set(varName, resolvers.sync).setAsync(varName, resolvers.async);
     }
+  }
+
+  /**
+   * Provides a binding for getting attributes from the DOM.
+   * Most such bindings are provided in src/service/url-replacements-impl, but
+   * this one needs access to this.win_.document, which if the amp-analytics
+   * tag is contained within an amp-ad tag will NOT be the parent/publisher
+   * page. Hence the need to put it here.
+   * @param {string} cssSelector Elements matching this selector will be
+   *     included, provided they have at least one of the attributeNames
+   *     set, up to a max of 10. May be URI encoded.
+   * @param attributeNames The attributes whose values will be returned.
+   * @returns {string}
+   */
+  htmlAttrBinding_(cssSelector, ...attributeNames) {
+    const HTML_ATTR_MAX_RETURN_SIZE = 10;
+    const result = [];
+    if (!cssSelector || !attributeNames || !attributeNames.length) {
+      return JSON.stringify(result);
+    }
+    cssSelector = decodeURI(cssSelector);
+    try {
+      const elements = this.win_.document.querySelectorAll(cssSelector);
+      for (let i = 0; i < elements.length &&
+      result.length < HTML_ATTR_MAX_RETURN_SIZE; ++i) {
+        const currentResult = {};
+        let foundAttr = false;
+        attributeNames.forEach(attributeName => {
+          if (elements[i].hasAttribute(attributeName)) {
+            currentResult[attributeName] =
+                elements[i].getAttribute(attributeName);
+            foundAttr = true;
+          }
+        });
+        if (foundAttr) {
+          result.push(currentResult);
+        }
+      }
+    } catch (e) {
+      const TAG = 'A4AVariableSource';
+      user().warn(TAG, `Invalid selector: ${cssSelector}`);
+    }
+    return JSON.stringify(result);
   }
 }

--- a/extensions/amp-a4a/0.1/a4a-variable-source.js
+++ b/extensions/amp-a4a/0.1/a4a-variable-source.js
@@ -156,7 +156,7 @@ export class A4AVariableSource extends VariableSource {
         result.length < HTML_ATTR_MAX_RETURN_SIZE; ++i) {
       const currentResult = {};
       let foundAtLeastOneAttr = false;
-      for (let j=0; j<attributeNames.length; ++j) {
+      for (let j = 0; j < attributeNames.length; ++j) {
         const attributeName = attributeNames[j];
         if (elements[i].hasAttribute(attributeName)) {
           currentResult[attributeName] =

--- a/extensions/amp-a4a/0.1/a4a-variable-source.js
+++ b/extensions/amp-a4a/0.1/a4a-variable-source.js
@@ -113,7 +113,7 @@ export class A4AVariableSource extends VariableSource {
     });
 
     this.set('HTML_ATTR',
-        /** @type {function(...*)} */(this.htmlAttrBinding_.bind(this)));
+        /** @type {function(...*)} */(this.htmlAttributeBinding_.bind(this)));
 
     for (let v = 0; v < WHITELISTED_VARIABLES.length; v++) {
       const varName = WHITELISTED_VARIABLES[v];
@@ -140,7 +140,7 @@ export class A4AVariableSource extends VariableSource {
    *     requested attributes, then nothing will be included in the array
    *     for that element.
    */
-  htmlAttrBinding_(cssSelector, ...attributeNames) {
+  htmlAttributeBinding_(cssSelector, ...attributeNames) {
     // Generate an error if cssSelector matches more than this many elements
     const HTML_ATTR_MAX_ELEMENTS_TO_TRAVERSE = 20;
 

--- a/extensions/amp-a4a/0.1/test/test-a4a-var-source.js
+++ b/extensions/amp-a4a/0.1/test/test-a4a-var-source.js
@@ -68,6 +68,10 @@ describe('A4AVariableSource', () => {
     expect(expandSync('AD_NAV_REDIRECT_COUNT')).to.match(/\d/);
   });
 
+  it('should replace HTML_ATTR', () => {
+    expect(expandSync('HTML_ATTR', ['div', 'id'])).to.equal("[{\"id\":\"parent\"}]");
+  });
+
   function undefinedVariable(varName) {
     it('should not replace ' + varName, () => {
       expect(varSource.get(varName)).to.be.undefined;

--- a/extensions/amp-a4a/0.1/test/test-a4a-var-source.js
+++ b/extensions/amp-a4a/0.1/test/test-a4a-var-source.js
@@ -69,7 +69,8 @@ describe('A4AVariableSource', () => {
   });
 
   it('should replace HTML_ATTR', () => {
-    expect(expandSync('HTML_ATTR', ['div', 'id'])).to.equal("[{\"id\":\"parent\"}]");
+    expect(expandSync('HTML_ATTR', ['div', 'id'])).to.equal(
+        '[{\"id\":\"parent\"}]');
   });
 
   function undefinedVariable(varName) {

--- a/extensions/amp-ad-network-fake-impl/0.1/data/fake_amp_ad_with_html_attr.html
+++ b/extensions/amp-ad-network-fake-impl/0.1/data/fake_amp_ad_with_html_attr.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<html amp4ads>
+  <head>
+    <title>Ad with 3p Analytics and amp-ad-exit</title>
+    <meta charset=utf-8>
+    <script async src='https://cdn.ampproject.org/v0.js'></script>
+    <script async custom-element='amp-analytics' src='https://cdn.ampproject.org/v0/amp-analytics-0.1.js'></script>
+    <script async custom-element='amp-ad-exit' src='https://cdn.ampproject.org/v0/amp-ad-exit-0.1.js'></script>
+    <style amp4ads-boilerplate>body{visibility:hidden}</style>
+    <meta name=viewport content=width=device-width,minimum-scale=1>
+  </head>
+  <body>
+    Before using this example page, please add the following to
+    extensions/amp-analytics/0.1/vendors.js:
+    <pre>
+      'example-3p-vendor': {
+        'transport': {'beacon': true, 'xhrpost': true, 'image': true},
+      },
+    </pre>
+    Then look at the network log, and see the requests including "imgData="
+    <amp-analytics type='example-3p-vendor'>
+      <script type='application/json'>
+        {
+          "requests": {
+            "sample_visibility_request": "//nowhere/imgData=${htmlAttr(img,src,decoding)}"
+          },
+          "triggers": {
+            "sample_visibility_trigger": {
+              "on": "visible",
+              "request": "sample_visibility_request"
+            }
+          }
+        }
+      </script>
+    </amp-analytics>
+    <div id='ad'>
+      <div class='golden_retriever'>
+        <amp-img id='img1' src='https://upload.wikimedia.org/wikipedia/commons/6/6e/Golde33443.jpg' width=300 height=249></amp-img>
+        <p class='frob'>
+          By Golden Trvs Gol twister (Own work) [CC BY-SA 4.0 (http://creativecommons.org/licenses/by-sa/4.0)], via Wikimedia Commons
+        </p>
+      </div>
+      <div class='shiba_inu'>
+        <amp-img id='img2' src='https://upload.wikimedia.org/wikipedia/commons/a/a3/Taro_%28black_and_tan%2C_reu%29_-_Chiko_%28rood%2C_reu%29_-_Ichigo_%28rood%2C_teef%29.jpg' width=300 height=200></amp-img>
+        <p class='frob'>
+          By Wesl90 (Own work) [CC BY-SA 3.0 (http://creativecommons.org/licenses/by-sa/3.0)], via Wikimedia Commons
+        </p>
+      </div>
+      <div class='saint_bernard'>
+        <amp-img id='img3' src='https://upload.wikimedia.org/wikipedia/commons/f/f6/St_Bernard_Dog_001.jpg' width=300 height=225></amp-img>
+        <p class='frob'>
+          By Cassie J (Own work) [CC BY 2.0 (http://creativecommons.org/licenses/by/2.0)], via Wikimedia Commons
+        </p>
+      </div>
+    </div>
+  </body>
+</html>
+

--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -626,7 +626,7 @@ export class AmpAnalytics extends AMP.BaseElement {
           requests[k] = new RequestHandler(
               this.getAmpDoc(), request, this.preconnect,
               this.sendRequest_.bind(this),
-              this.isSandbox_);
+              this.isSandbox_, this.element);
         }
       }
       this.requests_ = requests;

--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -624,9 +624,9 @@ export class AmpAnalytics extends AMP.BaseElement {
         if (hasOwn(this.config_['requests'], k)) {
           const request = this.config_['requests'][k];
           requests[k] = new RequestHandler(
-              this.getAmpDoc(), request, this.preconnect,
+              this.element, request, this.preconnect,
               this.sendRequest_.bind(this),
-              this.isSandbox_, this.element);
+              this.isSandbox_);
         }
       }
       this.requests_ = requests;

--- a/extensions/amp-analytics/0.1/requests.js
+++ b/extensions/amp-analytics/0.1/requests.js
@@ -36,15 +36,16 @@ const BATCH_INTERVAL_MIN = 200;
 
 export class RequestHandler {
   /**
-   * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
+   * @param {!Element} ampAnalyticsElement
    * @param {!JsonObject} request
    * @param {!../../../src/preconnect.Preconnect} preconnect
    * @param {function(string, !JsonObject)} handler
    * @param {boolean} isSandbox
-   * @param {!Element} ampAnalyticsElement
    */
-  constructor(ampdoc, request, preconnect, handler, isSandbox,
-    ampAnalyticsElement) {
+  constructor(ampAnalyticsElement, request, preconnect, handler, isSandbox) {
+
+    /** @type {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc */
+    const ampdoc = ampAnalyticsElement.getAmpDoc();
 
     /** @const {!Window} */
     this.win = ampdoc.win;

--- a/extensions/amp-analytics/0.1/requests.js
+++ b/extensions/amp-analytics/0.1/requests.js
@@ -44,11 +44,8 @@ export class RequestHandler {
    */
   constructor(ampAnalyticsElement, request, preconnect, handler, isSandbox) {
 
-    /** @type {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc */
-    const ampdoc = ampAnalyticsElement.getAmpDoc();
-
     /** @const {!Window} */
-    this.win = ampdoc.win;
+    this.win = ampAnalyticsElement.getAmpDoc().win;
 
     /** @const {string} */
     this.baseUrl = dev().assert(request['baseUrl']);

--- a/extensions/amp-analytics/0.1/requests.js
+++ b/extensions/amp-analytics/0.1/requests.js
@@ -41,8 +41,10 @@ export class RequestHandler {
    * @param {!../../../src/preconnect.Preconnect} preconnect
    * @param {function(string, !JsonObject)} handler
    * @param {boolean} isSandbox
+   * @param {!Element} ampAnalyticsElement
    */
-  constructor(ampdoc, request, preconnect, handler, isSandbox) {
+  constructor(ampdoc, request, preconnect, handler, isSandbox,
+    ampAnalyticsElement) {
 
     /** @const {!Window} */
     this.win = ampdoc.win;
@@ -75,7 +77,8 @@ export class RequestHandler {
     this.variableService_ = variableServiceFor(this.win);
 
     /** @private {!../../../src/service/url-replacements-impl.UrlReplacements} */
-    this.urlReplacementService_ = Services.urlReplacementsForDoc(ampdoc);
+    this.urlReplacementService_ =
+      Services.urlReplacementsForDoc(ampAnalyticsElement);
 
     /** @private {?Promise<string>} */
     this.baseUrlPromise_ = null;

--- a/extensions/amp-analytics/0.1/test/test-amp-analytics.js
+++ b/extensions/amp-analytics/0.1/test/test-amp-analytics.js
@@ -473,7 +473,7 @@ describes.realWin('amp-analytics', {
   it('should not replace HTML_ATTR outside of amp-ad', () => {
     const analytics = getAnalyticsTag({
       'requests': {
-        'htmlAttrRequest': 'https://example.com/bar&ids=${htmlAttr(div,id)}'
+        'htmlAttrRequest': 'https://example.com/bar&ids=${htmlAttr(div,id)}',
       },
       'triggers': [{'on': 'visible', 'request': 'htmlAttrRequest'}],
     });

--- a/extensions/amp-analytics/0.1/test/test-amp-analytics.js
+++ b/extensions/amp-analytics/0.1/test/test-amp-analytics.js
@@ -470,15 +470,17 @@ describes.realWin('amp-analytics', {
     });
   });
 
-  it('should replace HTML_ATTR', () => {
+  it('should not replace HTML_ATTR outside of amp-ad', () => {
     const analytics = getAnalyticsTag({
-      'requests': {'foo': 'https://example.com/bar&ids=${htmlAttr(div,id)}'},
-      'triggers': [{'on': 'visible', 'request': ['foo']}],
+      'requests': {
+        'htmlAttrRequest': 'https://example.com/bar&ids=${htmlAttr(div,id)}'
+      },
+      'triggers': [{'on': 'visible', 'request': 'htmlAttrRequest'}],
     });
 
     return waitForSendRequest(analytics).then(() => {
       expect(sendRequestSpy.calledOnce).to.be.true;
-      expect(decodeURIComponent(sendRequestSpy.args[0][0])).to.equal('https://example.com/bar&ids=[{"id":"parent"}]');
+      expect(decodeURIComponent(sendRequestSpy.args[0][0])).to.equal('https://example.com/bar&ids=HTML_ATTR(div,id)');
     });
   });
 

--- a/extensions/amp-analytics/0.1/test/test-amp-analytics.js
+++ b/extensions/amp-analytics/0.1/test/test-amp-analytics.js
@@ -470,6 +470,18 @@ describes.realWin('amp-analytics', {
     });
   });
 
+  it('should replace HTML_ATTR', () => {
+    const analytics = getAnalyticsTag({
+      'requests': {'foo': 'https://example.com/bar&ids=${htmlAttr(div,id)}'},
+      'triggers': [{'on': 'visible', 'request': ['foo']}],
+    });
+
+    return waitForSendRequest(analytics).then(() => {
+      expect(sendRequestSpy.calledOnce).to.be.true;
+      expect(decodeURIComponent(sendRequestSpy.args[0][0])).to.equal('https://example.com/bar&ids=[{"id":"parent"}]');
+    });
+  });
+
   it('fills cid', function() {
     const analytics = getAnalyticsTag({
       'requests': {'foo': 'https://example.com/cid=${clientId(analytics-abc)}'},

--- a/extensions/amp-analytics/0.1/test/test-requests.js
+++ b/extensions/amp-analytics/0.1/test/test-requests.js
@@ -48,7 +48,7 @@ describes.realWin('Requests', {amp: 1}, env => {
         const spy = sandbox.spy();
         const r = {'baseUrl': 'r2', 'batchInterval': 1};
         const handler = new RequestHandler(ampdoc, r, preconnect, spy, false,
-          ampdoc);
+            ampdoc);
         const expansionOptions = new ExpansionOptions({});
         handler.send({}, {}, expansionOptions, {});
         handler.send({}, {}, expansionOptions, {});
@@ -63,7 +63,7 @@ describes.realWin('Requests', {amp: 1}, env => {
         const spy = sandbox.spy();
         const r = {'baseUrl': 'r1'};
         const handler = new RequestHandler(ampdoc, r, preconnect, spy, false,
-          ampdoc);
+            ampdoc);
         const expansionOptions = new ExpansionOptions({});
         handler.send({}, {}, expansionOptions, {});
         handler.send({}, {}, expansionOptions, {});
@@ -94,7 +94,7 @@ describes.realWin('Requests', {amp: 1}, env => {
       it('should support number', () => {
         const r = {'baseUrl': 'r1', 'batchInterval': 5};
         const handler = new RequestHandler(ampdoc, r, preconnect, spy, false,
-          ampdoc);
+            ampdoc);
         expect(handler.batchIntervalPointer_).to.not.be.null;
         expect(handler.batchInterval_).to.deep.equal([5000]);
       });
@@ -102,7 +102,7 @@ describes.realWin('Requests', {amp: 1}, env => {
       it('should support array', () => {
         const r = {'baseUrl': 'r1', 'batchInterval': [1, 2, 3]};
         const handler = new RequestHandler(ampdoc, r, preconnect, spy, false,
-          ampdoc);
+            ampdoc);
         expect(handler.batchIntervalPointer_).to.not.be.null;
         expect(handler.batchInterval_).to.deep.equal([1000, 2000, 3000]);
       });
@@ -113,14 +113,14 @@ describes.realWin('Requests', {amp: 1}, env => {
         const r2 = {'baseUrl': 'r', 'batchInterval': ['invalid']};
         try {
           new RequestHandler(ampdoc, r1, preconnect, spy, false,
-            ampdoc);
+              ampdoc);
           throw new Error('should never happen');
         } catch (e) {
           expect(e).to.match(/Invalid batchInterval value/);
         }
         try {
           new RequestHandler(ampdoc, r2, preconnect, spy, false,
-            ampdoc);
+              ampdoc);
           throw new Error('should never happen');
         } catch (e) {
           expect(e).to.match(/Invalid batchInterval value/);
@@ -132,21 +132,21 @@ describes.realWin('Requests', {amp: 1}, env => {
         const r5 = {'baseUrl': 'r', 'batchInterval': [1, 0.01]};
         try {
           new RequestHandler(ampdoc, r3, preconnect, spy, false,
-            ampdoc);
+              ampdoc);
           throw new Error('should never happen');
         } catch (e) {
           expect(e).to.match(/Invalid batchInterval value/);
         }
         try {
           new RequestHandler(ampdoc, r4, preconnect, spy, false,
-            ampdoc);
+              ampdoc);
           throw new Error('should never happen');
         } catch (e) {
           expect(e).to.match(/Invalid batchInterval value/);
         }
         try {
           new RequestHandler(ampdoc, r5, preconnect, spy, false,
-            ampdoc);
+              ampdoc);
           throw new Error('should never happen');
         } catch (e) {
           expect(e).to.match(/Invalid batchInterval value/);
@@ -156,7 +156,7 @@ describes.realWin('Requests', {amp: 1}, env => {
       it('should schedule send request with interval array', function* () {
         const r = {'baseUrl': 'r', 'batchInterval': [1, 2]};
         const handler = new RequestHandler(ampdoc, r, preconnect, spy, false,
-          ampdoc);
+            ampdoc);
         const expansionOptions = new ExpansionOptions({});
         clock.tick(998);
         handler.send({}, {}, expansionOptions, {});
@@ -185,7 +185,7 @@ describes.realWin('Requests', {amp: 1}, env => {
       it('should not schedule send request w/o trigger', function* () {
         const r = {'baseUrl': 'r', 'batchInterval': [1]};
         new RequestHandler(ampdoc, r, preconnect, spy, false,
-          ampdoc);
+            ampdoc);
         clock.tick(1000);
         yield macroTask();
         expect(spy).to.not.be.called;
@@ -194,7 +194,7 @@ describes.realWin('Requests', {amp: 1}, env => {
       it('should schedule send independent of trigger immediate', function* () {
         const r = {'baseUrl': 'r', 'batchInterval': [1, 2]};
         const handler = new RequestHandler(ampdoc, r, preconnect, spy, false,
-          ampdoc);
+            ampdoc);
         const expansionOptions = new ExpansionOptions({});
         handler.send({}, {}, expansionOptions, {});
         clock.tick(999);
@@ -218,13 +218,13 @@ describes.realWin('Requests', {amp: 1}, env => {
       it('should accept reportWindow with number', () => {
         const r = {'baseUrl': 'r', 'reportWindow': 1};
         const handler = new RequestHandler(ampdoc, r, preconnect, spy, false,
-          ampdoc);
+            ampdoc);
         const r2 = {'baseUrl': 'r', 'reportWindow': '2'};
         const handler2 = new RequestHandler(ampdoc, r2, preconnect, spy, false,
-          ampdoc);
+            ampdoc);
         const r3 = {'baseUrl': 'r', 'reportWindow': 'invalid'};
         const handler3 = new RequestHandler(ampdoc, r3, preconnect, spy, false,
-          ampdoc);
+            ampdoc);
         expect(handler.reportWindow_).to.equal(1);
         expect(handler2.reportWindow_).to.equal(2);
         expect(handler3.reportWindow_).to.be.null;
@@ -233,7 +233,7 @@ describes.realWin('Requests', {amp: 1}, env => {
       it('should stop bathInterval outside batch report window', function* () {
         const r = {'baseUrl': 'r', 'batchInterval': 0.5, 'reportWindow': 1};
         const handler = new RequestHandler(ampdoc, r, preconnect, spy, false,
-          ampdoc);
+            ampdoc);
         const expansionOptions = new ExpansionOptions({});
         handler.send({}, {}, expansionOptions, {});
         clock.tick(500);
@@ -251,7 +251,7 @@ describes.realWin('Requests', {amp: 1}, env => {
       it('should stop send request outside batch report window', function* () {
         const r = {'baseUrl': 'r', 'reportWindow': 1};
         const handler = new RequestHandler(ampdoc, r, preconnect, spy, false,
-          ampdoc);
+            ampdoc);
         const expansionOptions = new ExpansionOptions({});
         handler.send({}, {}, expansionOptions, {});
         yield macroTask();
@@ -266,7 +266,7 @@ describes.realWin('Requests', {amp: 1}, env => {
       it('should flush batch queue after batch report window', function* () {
         const r = {'baseUrl': 'r', 'batchInterval': 5, 'reportWindow': 1};
         const handler = new RequestHandler(ampdoc, r, preconnect, spy, false,
-          ampdoc);
+            ampdoc);
         const expansionOptions = new ExpansionOptions({});
         handler.send({}, {}, expansionOptions, {});
         clock.tick(1000);
@@ -277,7 +277,7 @@ describes.realWin('Requests', {amp: 1}, env => {
       it('should respect immediate trigger', function* () {
         const r = {'baseUrl': 'r', 'batchInterval': 0.2, 'reportWindow': 0.5};
         const handler = new RequestHandler(ampdoc, r, preconnect, spy, false,
-          ampdoc);
+            ampdoc);
         const expansionOptions = new ExpansionOptions({});
         clock.tick(500);
         yield macroTask();
@@ -293,7 +293,7 @@ describes.realWin('Requests', {amp: 1}, env => {
         const spy = sandbox.spy();
         const r = {'baseUrl': 'r1', 'batchInterval': 1};
         const handler = new RequestHandler(ampdoc, r, preconnect, spy, false,
-          ampdoc);
+            ampdoc);
         const expansionOptions = new ExpansionOptions({});
         handler.send({'e1': 'e1'}, {}, expansionOptions, {});
         handler.send({'e1': 'e1'}, {}, expansionOptions, {});
@@ -307,7 +307,7 @@ describes.realWin('Requests', {amp: 1}, env => {
         const spy = sandbox.spy();
         const r = {'baseUrl': 'r1', 'batchInterval': 1};
         const handler = new RequestHandler(ampdoc, r, preconnect, spy, false,
-          ampdoc);
+            ampdoc);
         const expansionOptions = new ExpansionOptions({'v2': '中'});
         handler.send({}, {
           'extraUrlParams': {
@@ -327,7 +327,7 @@ describes.realWin('Requests', {amp: 1}, env => {
         const spy = sandbox.spy();
         const r = {'baseUrl': 'r1&${extraUrlParams}&r2', 'batchInterval': 1};
         const handler = new RequestHandler(ampdoc, r, preconnect, spy, false,
-          ampdoc);
+            ampdoc);
         const expansionOptions = new ExpansionOptions({});
         handler.send(
             {}, {'extraUrlParams': {'e1': 'e1'}}, expansionOptions, {});
@@ -346,7 +346,7 @@ describes.realWin('Requests', {amp: 1}, env => {
         const r = {'baseUrl': 'r', 'batchPlugin': '_ping_'};
         try {
           new RequestHandler(ampdoc, r, preconnect, spy, false,
-            ampdoc);
+              ampdoc);
         } catch (e) {
           expect(e).to.match(
               /batchPlugin cannot be set on non-batched request/);
@@ -359,7 +359,7 @@ describes.realWin('Requests', {amp: 1}, env => {
             {'baseUrl': 'r', 'batchInterval': 1, 'batchPlugin': 'invalid'};
         try {
           new RequestHandler(ampdoc, r, preconnect, spy, false,
-            ampdoc);
+              ampdoc);
         } catch (e) {
           expect(e).to.match(/unsupported batch plugin/);
         }
@@ -369,7 +369,7 @@ describes.realWin('Requests', {amp: 1}, env => {
         const spy = sandbox.spy();
         const r = {'baseUrl': 'r', 'batchInterval': 1, 'batchPlugin': '_ping_'};
         const handler = new RequestHandler(ampdoc, r, preconnect, spy, false,
-          ampdoc);
+            ampdoc);
         // Overwrite batchPlugin function
         handler.batchingPlugin_ = () => {throw new Error('test');};
         const expansionOptions = new ExpansionOptions({});
@@ -384,7 +384,7 @@ describes.realWin('Requests', {amp: 1}, env => {
         const spy = sandbox.spy();
         const r = {'baseUrl': 'r', 'batchInterval': 1, 'batchPlugin': '_ping_'};
         const handler = new RequestHandler(ampdoc, r, preconnect, spy, false,
-          ampdoc);
+            ampdoc);
         // Overwrite batchPlugin function
         const batchPluginSpy = sandbox.spy(handler, 'batchingPlugin_');
         const expansionOptions = new ExpansionOptions({});
@@ -455,7 +455,7 @@ describes.realWin('Requests', {amp: 1}, env => {
     const spy = sandbox.spy();
     const r = {'baseUrl': 'r1&${extraUrlParams}&BASE_VALUE'};
     const handler = new RequestHandler(ampdoc, r, preconnect, spy, false,
-      ampdoc);
+        ampdoc);
     const expansionOptions = new ExpansionOptions({
       'param1': 'PARAM_1',
       'param2': 'PARAM_2',
@@ -489,7 +489,7 @@ describes.realWin('Requests', {amp: 1}, env => {
       'baseUrl': 'r1&${extraUrlParams}&BASE_VALUE&foo=${foo}',
     };
     const handler = new RequestHandler(ampdoc, r, preconnect, spy, false,
-      ampdoc);
+        ampdoc);
     const expansionOptions = new ExpansionOptions({
       'param1': 'PARAM_1',
       'param2': 'PARAM_2',

--- a/extensions/amp-analytics/0.1/test/test-requests.js
+++ b/extensions/amp-analytics/0.1/test/test-requests.js
@@ -24,7 +24,7 @@ import {toggleExperiment} from '../../../../src/experiments';
 
 describes.realWin('Requests', {amp: 1}, env => {
   let ampdoc;
-  let analytics;
+  let analyticsMock;
   let clock;
   let preconnect;
   let preconnectSpy;
@@ -32,7 +32,12 @@ describes.realWin('Requests', {amp: 1}, env => {
   beforeEach(() => {
     installVariableService(env.win);
     ampdoc = env.ampdoc;
-    analytics = {getAmpDoc: function() { return ampdoc; }};
+    ampdoc.defaultView = env.win;
+    analyticsMock = {
+      nodeType: 1,
+      ownerDocument: ampdoc,
+      getAmpDoc: function() { return ampdoc; }
+    };
     clock = lolex.install({target: ampdoc.win});
     preconnectSpy = sandbox.spy();
     preconnect = {
@@ -50,7 +55,7 @@ describes.realWin('Requests', {amp: 1}, env => {
         const spy = sandbox.spy();
         const r = {'baseUrl': 'r2', 'batchInterval': 1};
         const handler = new RequestHandler(
-            analytics, r, preconnect, spy, false);
+            analyticsMock, r, preconnect, spy, false);
         const expansionOptions = new ExpansionOptions({});
         handler.send({}, {}, expansionOptions, {});
         handler.send({}, {}, expansionOptions, {});
@@ -65,7 +70,7 @@ describes.realWin('Requests', {amp: 1}, env => {
         const spy = sandbox.spy();
         const r = {'baseUrl': 'r1'};
         const handler = new RequestHandler(
-            analytics, r, preconnect, spy, false);
+            analyticsMock, r, preconnect, spy, false);
         const expansionOptions = new ExpansionOptions({});
         handler.send({}, {}, expansionOptions, {});
         handler.send({}, {}, expansionOptions, {});
@@ -77,7 +82,7 @@ describes.realWin('Requests', {amp: 1}, env => {
       it('should preconnect', function* () {
         const r = {'baseUrl': 'r2?cid=CLIENT_ID(scope)&var=${test}'};
         const handler = new RequestHandler(
-            analytics, r, preconnect, sandbox.spy(), false);
+            analyticsMock, r, preconnect, sandbox.spy(), false);
         const expansionOptions = new ExpansionOptions({'test': 'expanded'});
         handler.send({}, {}, expansionOptions, {});
         yield macroTask();
@@ -95,7 +100,7 @@ describes.realWin('Requests', {amp: 1}, env => {
       it('should support number', () => {
         const r = {'baseUrl': 'r1', 'batchInterval': 5};
         const handler = new RequestHandler(
-            analytics, r, preconnect, spy, false);
+            analyticsMock, r, preconnect, spy, false);
         expect(handler.batchIntervalPointer_).to.not.be.null;
         expect(handler.batchInterval_).to.deep.equal([5000]);
       });
@@ -103,7 +108,7 @@ describes.realWin('Requests', {amp: 1}, env => {
       it('should support array', () => {
         const r = {'baseUrl': 'r1', 'batchInterval': [1, 2, 3]};
         const handler = new RequestHandler(
-            analytics, r, preconnect, spy, false);
+            analyticsMock, r, preconnect, spy, false);
         expect(handler.batchIntervalPointer_).to.not.be.null;
         expect(handler.batchInterval_).to.deep.equal([1000, 2000, 3000]);
       });
@@ -113,13 +118,13 @@ describes.realWin('Requests', {amp: 1}, env => {
         const r1 = {'baseUrl': 'r', 'batchInterval': 'invalid'};
         const r2 = {'baseUrl': 'r', 'batchInterval': ['invalid']};
         try {
-          new RequestHandler(analytics, r1, preconnect, spy, false);
+          new RequestHandler(analyticsMock, r1, preconnect, spy, false);
           throw new Error('should never happen');
         } catch (e) {
           expect(e).to.match(/Invalid batchInterval value/);
         }
         try {
-          new RequestHandler(analytics, r2, preconnect, spy, false);
+          new RequestHandler(analyticsMock, r2, preconnect, spy, false);
           throw new Error('should never happen');
         } catch (e) {
           expect(e).to.match(/Invalid batchInterval value/);
@@ -130,19 +135,19 @@ describes.realWin('Requests', {amp: 1}, env => {
         const r4 = {'baseUrl': 'r', 'batchInterval': [-1, 5]};
         const r5 = {'baseUrl': 'r', 'batchInterval': [1, 0.01]};
         try {
-          new RequestHandler(analytics, r3, preconnect, spy, false);
+          new RequestHandler(analyticsMock, r3, preconnect, spy, false);
           throw new Error('should never happen');
         } catch (e) {
           expect(e).to.match(/Invalid batchInterval value/);
         }
         try {
-          new RequestHandler(analytics, r4, preconnect, spy, false);
+          new RequestHandler(analyticsMock, r4, preconnect, spy, false);
           throw new Error('should never happen');
         } catch (e) {
           expect(e).to.match(/Invalid batchInterval value/);
         }
         try {
-          new RequestHandler(analytics, r5, preconnect, spy, false);
+          new RequestHandler(analyticsMock, r5, preconnect, spy, false);
           throw new Error('should never happen');
         } catch (e) {
           expect(e).to.match(/Invalid batchInterval value/);
@@ -152,7 +157,7 @@ describes.realWin('Requests', {amp: 1}, env => {
       it('should schedule send request with interval array', function* () {
         const r = {'baseUrl': 'r', 'batchInterval': [1, 2]};
         const handler = new RequestHandler(
-            analytics, r, preconnect, spy, false);
+            analyticsMock, r, preconnect, spy, false);
         const expansionOptions = new ExpansionOptions({});
         clock.tick(998);
         handler.send({}, {}, expansionOptions, {});
@@ -180,7 +185,7 @@ describes.realWin('Requests', {amp: 1}, env => {
 
       it('should not schedule send request w/o trigger', function* () {
         const r = {'baseUrl': 'r', 'batchInterval': [1]};
-        new RequestHandler(analytics, r, preconnect, spy, false);
+        new RequestHandler(analyticsMock, r, preconnect, spy, false);
         clock.tick(1000);
         yield macroTask();
         expect(spy).to.not.be.called;
@@ -189,7 +194,7 @@ describes.realWin('Requests', {amp: 1}, env => {
       it('should schedule send independent of trigger immediate', function* () {
         const r = {'baseUrl': 'r', 'batchInterval': [1, 2]};
         const handler = new RequestHandler(
-            analytics, r, preconnect, spy, false);
+            analyticsMock, r, preconnect, spy, false);
         const expansionOptions = new ExpansionOptions({});
         handler.send({}, {}, expansionOptions, {});
         clock.tick(999);
@@ -213,13 +218,13 @@ describes.realWin('Requests', {amp: 1}, env => {
       it('should accept reportWindow with number', () => {
         const r = {'baseUrl': 'r', 'reportWindow': 1};
         const handler = new RequestHandler(
-            analytics, r, preconnect, spy, false);
+            analyticsMock, r, preconnect, spy, false);
         const r2 = {'baseUrl': 'r', 'reportWindow': '2'};
         const handler2 = new RequestHandler(
-            analytics, r2, preconnect, spy, false);
+            analyticsMock, r2, preconnect, spy, false);
         const r3 = {'baseUrl': 'r', 'reportWindow': 'invalid'};
         const handler3 = new RequestHandler(
-            analytics, r3, preconnect, spy, false);
+            analyticsMock, r3, preconnect, spy, false);
         expect(handler.reportWindow_).to.equal(1);
         expect(handler2.reportWindow_).to.equal(2);
         expect(handler3.reportWindow_).to.be.null;
@@ -228,7 +233,7 @@ describes.realWin('Requests', {amp: 1}, env => {
       it('should stop bathInterval outside batch report window', function* () {
         const r = {'baseUrl': 'r', 'batchInterval': 0.5, 'reportWindow': 1};
         const handler = new RequestHandler(
-            analytics, r, preconnect, spy, false);
+            analyticsMock, r, preconnect, spy, false);
         const expansionOptions = new ExpansionOptions({});
         handler.send({}, {}, expansionOptions, {});
         clock.tick(500);
@@ -246,7 +251,7 @@ describes.realWin('Requests', {amp: 1}, env => {
       it('should stop send request outside batch report window', function* () {
         const r = {'baseUrl': 'r', 'reportWindow': 1};
         const handler = new RequestHandler(
-            analytics, r, preconnect, spy, false);
+            analyticsMock, r, preconnect, spy, false);
         const expansionOptions = new ExpansionOptions({});
         handler.send({}, {}, expansionOptions, {});
         yield macroTask();
@@ -261,7 +266,7 @@ describes.realWin('Requests', {amp: 1}, env => {
       it('should flush batch queue after batch report window', function* () {
         const r = {'baseUrl': 'r', 'batchInterval': 5, 'reportWindow': 1};
         const handler = new RequestHandler(
-            analytics, r, preconnect, spy, false);
+            analyticsMock, r, preconnect, spy, false);
         const expansionOptions = new ExpansionOptions({});
         handler.send({}, {}, expansionOptions, {});
         clock.tick(1000);
@@ -272,7 +277,7 @@ describes.realWin('Requests', {amp: 1}, env => {
       it('should respect immediate trigger', function* () {
         const r = {'baseUrl': 'r', 'batchInterval': 0.2, 'reportWindow': 0.5};
         const handler = new RequestHandler(
-            analytics, r, preconnect, spy, false);
+            analyticsMock, r, preconnect, spy, false);
         const expansionOptions = new ExpansionOptions({});
         clock.tick(500);
         yield macroTask();
@@ -288,7 +293,7 @@ describes.realWin('Requests', {amp: 1}, env => {
         const spy = sandbox.spy();
         const r = {'baseUrl': 'r1', 'batchInterval': 1};
         const handler = new RequestHandler(
-            analytics, r, preconnect, spy, false);
+            analyticsMock, r, preconnect, spy, false);
         const expansionOptions = new ExpansionOptions({});
         handler.send({'e1': 'e1'}, {}, expansionOptions, {});
         handler.send({'e1': 'e1'}, {}, expansionOptions, {});
@@ -302,7 +307,7 @@ describes.realWin('Requests', {amp: 1}, env => {
         const spy = sandbox.spy();
         const r = {'baseUrl': 'r1', 'batchInterval': 1};
         const handler = new RequestHandler(
-            analytics, r, preconnect, spy, false);
+            analyticsMock, r, preconnect, spy, false);
         const expansionOptions = new ExpansionOptions({'v2': '中'});
         handler.send({}, {
           'extraUrlParams': {
@@ -322,7 +327,7 @@ describes.realWin('Requests', {amp: 1}, env => {
         const spy = sandbox.spy();
         const r = {'baseUrl': 'r1&${extraUrlParams}&r2', 'batchInterval': 1};
         const handler = new RequestHandler(
-            analytics, r, preconnect, spy, false);
+            analyticsMock, r, preconnect, spy, false);
         const expansionOptions = new ExpansionOptions({});
         handler.send(
             {}, {'extraUrlParams': {'e1': 'e1'}}, expansionOptions, {});
@@ -340,7 +345,7 @@ describes.realWin('Requests', {amp: 1}, env => {
         const spy = sandbox.spy();
         const r = {'baseUrl': 'r', 'batchPlugin': '_ping_'};
         try {
-          new RequestHandler(analytics, r, preconnect, spy, false);
+          new RequestHandler(analyticsMock, r, preconnect, spy, false);
         } catch (e) {
           expect(e).to.match(
               /batchPlugin cannot be set on non-batched request/);
@@ -352,7 +357,7 @@ describes.realWin('Requests', {amp: 1}, env => {
         const r =
             {'baseUrl': 'r', 'batchInterval': 1, 'batchPlugin': 'invalid'};
         try {
-          new RequestHandler(analytics, r, preconnect, spy, false);
+          new RequestHandler(analyticsMock, r, preconnect, spy, false);
         } catch (e) {
           expect(e).to.match(/unsupported batch plugin/);
         }
@@ -362,7 +367,7 @@ describes.realWin('Requests', {amp: 1}, env => {
         const spy = sandbox.spy();
         const r = {'baseUrl': 'r', 'batchInterval': 1, 'batchPlugin': '_ping_'};
         const handler = new RequestHandler(
-            analytics, r, preconnect, spy, false);
+            analyticsMock, r, preconnect, spy, false);
         // Overwrite batchPlugin function
         handler.batchingPlugin_ = () => {throw new Error('test');};
         const expansionOptions = new ExpansionOptions({});
@@ -377,7 +382,7 @@ describes.realWin('Requests', {amp: 1}, env => {
         const spy = sandbox.spy();
         const r = {'baseUrl': 'r', 'batchInterval': 1, 'batchPlugin': '_ping_'};
         const handler = new RequestHandler(
-            analytics, r, preconnect, spy, false);
+            analyticsMock, r, preconnect, spy, false);
         // Overwrite batchPlugin function
         const batchPluginSpy = sandbox.spy(handler, 'batchingPlugin_');
         const expansionOptions = new ExpansionOptions({});
@@ -448,7 +453,7 @@ describes.realWin('Requests', {amp: 1}, env => {
     const spy = sandbox.spy();
     const r = {'baseUrl': 'r1&${extraUrlParams}&BASE_VALUE'};
     const handler = new RequestHandler(
-        analytics, r, preconnect, spy, false);
+        analyticsMock, r, preconnect, spy, false);
     const expansionOptions = new ExpansionOptions({
       'param1': 'PARAM_1',
       'param2': 'PARAM_2',
@@ -482,7 +487,7 @@ describes.realWin('Requests', {amp: 1}, env => {
       'baseUrl': 'r1&${extraUrlParams}&BASE_VALUE&foo=${foo}',
     };
     const handler = new RequestHandler(
-        analytics, r, preconnect, spy, false);
+        analyticsMock, r, preconnect, spy, false);
     const expansionOptions = new ExpansionOptions({
       'param1': 'PARAM_1',
       'param2': 'PARAM_2',

--- a/extensions/amp-analytics/0.1/test/test-requests.js
+++ b/extensions/amp-analytics/0.1/test/test-requests.js
@@ -36,7 +36,7 @@ describes.realWin('Requests', {amp: 1}, env => {
     analyticsMock = {
       nodeType: 1,
       ownerDocument: ampdoc,
-      getAmpDoc: function() { return ampdoc; }
+      getAmpDoc: function() { return ampdoc; },
     };
     clock = lolex.install({target: ampdoc.win});
     preconnectSpy = sandbox.spy();

--- a/extensions/amp-analytics/0.1/test/test-requests.js
+++ b/extensions/amp-analytics/0.1/test/test-requests.js
@@ -22,7 +22,6 @@ import {dict} from '../../../../src/utils/object';
 import {macroTask} from '../../../../testing/yield';
 import {toggleExperiment} from '../../../../src/experiments';
 
-
 describes.realWin('Requests', {amp: 1}, env => {
   let ampdoc;
   let clock;
@@ -48,7 +47,8 @@ describes.realWin('Requests', {amp: 1}, env => {
       it('should batch multiple send', function* () {
         const spy = sandbox.spy();
         const r = {'baseUrl': 'r2', 'batchInterval': 1};
-        const handler = new RequestHandler(ampdoc, r, preconnect, spy, false);
+        const handler = new RequestHandler(ampdoc, r, preconnect, spy, false,
+          ampdoc);
         const expansionOptions = new ExpansionOptions({});
         handler.send({}, {}, expansionOptions, {});
         handler.send({}, {}, expansionOptions, {});
@@ -62,7 +62,8 @@ describes.realWin('Requests', {amp: 1}, env => {
       it('should work properly with no batch', function* () {
         const spy = sandbox.spy();
         const r = {'baseUrl': 'r1'};
-        const handler = new RequestHandler(ampdoc, r, preconnect, spy, false);
+        const handler = new RequestHandler(ampdoc, r, preconnect, spy, false,
+          ampdoc);
         const expansionOptions = new ExpansionOptions({});
         handler.send({}, {}, expansionOptions, {});
         handler.send({}, {}, expansionOptions, {});
@@ -74,7 +75,8 @@ describes.realWin('Requests', {amp: 1}, env => {
       it('should preconnect', function* () {
         const r = {'baseUrl': 'r2?cid=CLIENT_ID(scope)&var=${test}'};
         const handler =
-            new RequestHandler(ampdoc, r, preconnect, sandbox.spy(), false);
+            new RequestHandler(ampdoc, r, preconnect, sandbox.spy(), false,
+              ampdoc);
         const expansionOptions = new ExpansionOptions({'test': 'expanded'});
         handler.send({}, {}, expansionOptions, {});
         yield macroTask();
@@ -91,14 +93,16 @@ describes.realWin('Requests', {amp: 1}, env => {
 
       it('should support number', () => {
         const r = {'baseUrl': 'r1', 'batchInterval': 5};
-        const handler = new RequestHandler(ampdoc, r, preconnect, spy, false);
+        const handler = new RequestHandler(ampdoc, r, preconnect, spy, false,
+          ampdoc);
         expect(handler.batchIntervalPointer_).to.not.be.null;
         expect(handler.batchInterval_).to.deep.equal([5000]);
       });
 
       it('should support array', () => {
         const r = {'baseUrl': 'r1', 'batchInterval': [1, 2, 3]};
-        const handler = new RequestHandler(ampdoc, r, preconnect, spy, false);
+        const handler = new RequestHandler(ampdoc, r, preconnect, spy, false,
+          ampdoc);
         expect(handler.batchIntervalPointer_).to.not.be.null;
         expect(handler.batchInterval_).to.deep.equal([1000, 2000, 3000]);
       });
@@ -108,13 +112,15 @@ describes.realWin('Requests', {amp: 1}, env => {
         const r1 = {'baseUrl': 'r', 'batchInterval': 'invalid'};
         const r2 = {'baseUrl': 'r', 'batchInterval': ['invalid']};
         try {
-          new RequestHandler(ampdoc, r1, preconnect, spy, false);
+          new RequestHandler(ampdoc, r1, preconnect, spy, false,
+            ampdoc);
           throw new Error('should never happen');
         } catch (e) {
           expect(e).to.match(/Invalid batchInterval value/);
         }
         try {
-          new RequestHandler(ampdoc, r2, preconnect, spy, false);
+          new RequestHandler(ampdoc, r2, preconnect, spy, false,
+            ampdoc);
           throw new Error('should never happen');
         } catch (e) {
           expect(e).to.match(/Invalid batchInterval value/);
@@ -125,19 +131,22 @@ describes.realWin('Requests', {amp: 1}, env => {
         const r4 = {'baseUrl': 'r', 'batchInterval': [-1, 5]};
         const r5 = {'baseUrl': 'r', 'batchInterval': [1, 0.01]};
         try {
-          new RequestHandler(ampdoc, r3, preconnect, spy, false);
+          new RequestHandler(ampdoc, r3, preconnect, spy, false,
+            ampdoc);
           throw new Error('should never happen');
         } catch (e) {
           expect(e).to.match(/Invalid batchInterval value/);
         }
         try {
-          new RequestHandler(ampdoc, r4, preconnect, spy, false);
+          new RequestHandler(ampdoc, r4, preconnect, spy, false,
+            ampdoc);
           throw new Error('should never happen');
         } catch (e) {
           expect(e).to.match(/Invalid batchInterval value/);
         }
         try {
-          new RequestHandler(ampdoc, r5, preconnect, spy, false);
+          new RequestHandler(ampdoc, r5, preconnect, spy, false,
+            ampdoc);
           throw new Error('should never happen');
         } catch (e) {
           expect(e).to.match(/Invalid batchInterval value/);
@@ -146,7 +155,8 @@ describes.realWin('Requests', {amp: 1}, env => {
 
       it('should schedule send request with interval array', function* () {
         const r = {'baseUrl': 'r', 'batchInterval': [1, 2]};
-        const handler = new RequestHandler(ampdoc, r, preconnect, spy, false);
+        const handler = new RequestHandler(ampdoc, r, preconnect, spy, false,
+          ampdoc);
         const expansionOptions = new ExpansionOptions({});
         clock.tick(998);
         handler.send({}, {}, expansionOptions, {});
@@ -174,7 +184,8 @@ describes.realWin('Requests', {amp: 1}, env => {
 
       it('should not schedule send request w/o trigger', function* () {
         const r = {'baseUrl': 'r', 'batchInterval': [1]};
-        new RequestHandler(ampdoc, r, preconnect, spy, false);
+        new RequestHandler(ampdoc, r, preconnect, spy, false,
+          ampdoc);
         clock.tick(1000);
         yield macroTask();
         expect(spy).to.not.be.called;
@@ -182,7 +193,8 @@ describes.realWin('Requests', {amp: 1}, env => {
 
       it('should schedule send independent of trigger immediate', function* () {
         const r = {'baseUrl': 'r', 'batchInterval': [1, 2]};
-        const handler = new RequestHandler(ampdoc, r, preconnect, spy, false);
+        const handler = new RequestHandler(ampdoc, r, preconnect, spy, false,
+          ampdoc);
         const expansionOptions = new ExpansionOptions({});
         handler.send({}, {}, expansionOptions, {});
         clock.tick(999);
@@ -205,11 +217,14 @@ describes.realWin('Requests', {amp: 1}, env => {
 
       it('should accept reportWindow with number', () => {
         const r = {'baseUrl': 'r', 'reportWindow': 1};
-        const handler = new RequestHandler(ampdoc, r, preconnect, spy, false);
+        const handler = new RequestHandler(ampdoc, r, preconnect, spy, false,
+          ampdoc);
         const r2 = {'baseUrl': 'r', 'reportWindow': '2'};
-        const handler2 = new RequestHandler(ampdoc, r2, preconnect, spy, false);
+        const handler2 = new RequestHandler(ampdoc, r2, preconnect, spy, false,
+          ampdoc);
         const r3 = {'baseUrl': 'r', 'reportWindow': 'invalid'};
-        const handler3 = new RequestHandler(ampdoc, r3, preconnect, spy, false);
+        const handler3 = new RequestHandler(ampdoc, r3, preconnect, spy, false,
+          ampdoc);
         expect(handler.reportWindow_).to.equal(1);
         expect(handler2.reportWindow_).to.equal(2);
         expect(handler3.reportWindow_).to.be.null;
@@ -217,7 +232,8 @@ describes.realWin('Requests', {amp: 1}, env => {
 
       it('should stop bathInterval outside batch report window', function* () {
         const r = {'baseUrl': 'r', 'batchInterval': 0.5, 'reportWindow': 1};
-        const handler = new RequestHandler(ampdoc, r, preconnect, spy, false);
+        const handler = new RequestHandler(ampdoc, r, preconnect, spy, false,
+          ampdoc);
         const expansionOptions = new ExpansionOptions({});
         handler.send({}, {}, expansionOptions, {});
         clock.tick(500);
@@ -234,7 +250,8 @@ describes.realWin('Requests', {amp: 1}, env => {
 
       it('should stop send request outside batch report window', function* () {
         const r = {'baseUrl': 'r', 'reportWindow': 1};
-        const handler = new RequestHandler(ampdoc, r, preconnect, spy, false);
+        const handler = new RequestHandler(ampdoc, r, preconnect, spy, false,
+          ampdoc);
         const expansionOptions = new ExpansionOptions({});
         handler.send({}, {}, expansionOptions, {});
         yield macroTask();
@@ -248,7 +265,8 @@ describes.realWin('Requests', {amp: 1}, env => {
 
       it('should flush batch queue after batch report window', function* () {
         const r = {'baseUrl': 'r', 'batchInterval': 5, 'reportWindow': 1};
-        const handler = new RequestHandler(ampdoc, r, preconnect, spy, false);
+        const handler = new RequestHandler(ampdoc, r, preconnect, spy, false,
+          ampdoc);
         const expansionOptions = new ExpansionOptions({});
         handler.send({}, {}, expansionOptions, {});
         clock.tick(1000);
@@ -258,7 +276,8 @@ describes.realWin('Requests', {amp: 1}, env => {
 
       it('should respect immediate trigger', function* () {
         const r = {'baseUrl': 'r', 'batchInterval': 0.2, 'reportWindow': 0.5};
-        const handler = new RequestHandler(ampdoc, r, preconnect, spy, false);
+        const handler = new RequestHandler(ampdoc, r, preconnect, spy, false,
+          ampdoc);
         const expansionOptions = new ExpansionOptions({});
         clock.tick(500);
         yield macroTask();
@@ -273,7 +292,8 @@ describes.realWin('Requests', {amp: 1}, env => {
       it('should respect config extraUrlParam', function* () {
         const spy = sandbox.spy();
         const r = {'baseUrl': 'r1', 'batchInterval': 1};
-        const handler = new RequestHandler(ampdoc, r, preconnect, spy, false);
+        const handler = new RequestHandler(ampdoc, r, preconnect, spy, false,
+          ampdoc);
         const expansionOptions = new ExpansionOptions({});
         handler.send({'e1': 'e1'}, {}, expansionOptions, {});
         handler.send({'e1': 'e1'}, {}, expansionOptions, {});
@@ -286,7 +306,8 @@ describes.realWin('Requests', {amp: 1}, env => {
       it('should respect trigger extraUrlParam', function* () {
         const spy = sandbox.spy();
         const r = {'baseUrl': 'r1', 'batchInterval': 1};
-        const handler = new RequestHandler(ampdoc, r, preconnect, spy, false);
+        const handler = new RequestHandler(ampdoc, r, preconnect, spy, false,
+          ampdoc);
         const expansionOptions = new ExpansionOptions({'v2': '中'});
         handler.send({}, {
           'extraUrlParams': {
@@ -305,7 +326,8 @@ describes.realWin('Requests', {amp: 1}, env => {
       it('should replace extraUrlParam', function* () {
         const spy = sandbox.spy();
         const r = {'baseUrl': 'r1&${extraUrlParams}&r2', 'batchInterval': 1};
-        const handler = new RequestHandler(ampdoc, r, preconnect, spy, false);
+        const handler = new RequestHandler(ampdoc, r, preconnect, spy, false,
+          ampdoc);
         const expansionOptions = new ExpansionOptions({});
         handler.send(
             {}, {'extraUrlParams': {'e1': 'e1'}}, expansionOptions, {});
@@ -323,7 +345,8 @@ describes.realWin('Requests', {amp: 1}, env => {
         const spy = sandbox.spy();
         const r = {'baseUrl': 'r', 'batchPlugin': '_ping_'};
         try {
-          new RequestHandler(ampdoc, r, preconnect, spy, false);
+          new RequestHandler(ampdoc, r, preconnect, spy, false,
+            ampdoc);
         } catch (e) {
           expect(e).to.match(
               /batchPlugin cannot be set on non-batched request/);
@@ -335,7 +358,8 @@ describes.realWin('Requests', {amp: 1}, env => {
         const r =
             {'baseUrl': 'r', 'batchInterval': 1, 'batchPlugin': 'invalid'};
         try {
-          new RequestHandler(ampdoc, r, preconnect, spy, false);
+          new RequestHandler(ampdoc, r, preconnect, spy, false,
+            ampdoc);
         } catch (e) {
           expect(e).to.match(/unsupported batch plugin/);
         }
@@ -344,7 +368,8 @@ describes.realWin('Requests', {amp: 1}, env => {
       it('should handle batchPlugin function error', function* () {
         const spy = sandbox.spy();
         const r = {'baseUrl': 'r', 'batchInterval': 1, 'batchPlugin': '_ping_'};
-        const handler = new RequestHandler(ampdoc, r, preconnect, spy, false);
+        const handler = new RequestHandler(ampdoc, r, preconnect, spy, false,
+          ampdoc);
         // Overwrite batchPlugin function
         handler.batchingPlugin_ = () => {throw new Error('test');};
         const expansionOptions = new ExpansionOptions({});
@@ -358,7 +383,8 @@ describes.realWin('Requests', {amp: 1}, env => {
       it('should pass in correct batchSegments', function* () {
         const spy = sandbox.spy();
         const r = {'baseUrl': 'r', 'batchInterval': 1, 'batchPlugin': '_ping_'};
-        const handler = new RequestHandler(ampdoc, r, preconnect, spy, false);
+        const handler = new RequestHandler(ampdoc, r, preconnect, spy, false,
+          ampdoc);
         // Overwrite batchPlugin function
         const batchPluginSpy = sandbox.spy(handler, 'batchingPlugin_');
         const expansionOptions = new ExpansionOptions({});
@@ -428,7 +454,8 @@ describes.realWin('Requests', {amp: 1}, env => {
   it('should replace dynamic bindings', function* () {
     const spy = sandbox.spy();
     const r = {'baseUrl': 'r1&${extraUrlParams}&BASE_VALUE'};
-    const handler = new RequestHandler(ampdoc, r, preconnect, spy, false);
+    const handler = new RequestHandler(ampdoc, r, preconnect, spy, false,
+      ampdoc);
     const expansionOptions = new ExpansionOptions({
       'param1': 'PARAM_1',
       'param2': 'PARAM_2',
@@ -461,7 +488,8 @@ describes.realWin('Requests', {amp: 1}, env => {
     const r = {
       'baseUrl': 'r1&${extraUrlParams}&BASE_VALUE&foo=${foo}',
     };
-    const handler = new RequestHandler(ampdoc, r, preconnect, spy, false);
+    const handler = new RequestHandler(ampdoc, r, preconnect, spy, false,
+      ampdoc);
     const expansionOptions = new ExpansionOptions({
       'param1': 'PARAM_1',
       'param2': 'PARAM_2',

--- a/extensions/amp-analytics/0.1/vendors.js
+++ b/extensions/amp-analytics/0.1/vendors.js
@@ -51,6 +51,7 @@ export const ANALYTICS_CONFIG = /** @type {!JsonObject} */ ({
       'firstContentfulPaint': 'FIRST_CONTENTFUL_PAINT',
       'firstViewportReady': 'FIRST_VIEWPORT_READY',
       'makeBodyVisible': 'MAKE_BODY_VISIBLE',
+      'htmlAttr': 'HTML_ATTR',
       'incrementalEngagedTime': 'INCREMENTAL_ENGAGED_TIME',
       'navRedirectCount': 'NAV_REDIRECT_COUNT',
       'navTiming': 'NAV_TIMING',

--- a/extensions/amp-analytics/0.1/vendors.js
+++ b/extensions/amp-analytics/0.1/vendors.js
@@ -50,6 +50,7 @@ export const ANALYTICS_CONFIG = /** @type {!JsonObject} */ ({
       'externalReferrer': 'EXTERNAL_REFERRER',
       'firstContentfulPaint': 'FIRST_CONTENTFUL_PAINT',
       'firstViewportReady': 'FIRST_VIEWPORT_READY',
+      'htmlAttr': 'HTML_ATTR',
       'makeBodyVisible': 'MAKE_BODY_VISIBLE',
       'incrementalEngagedTime': 'INCREMENTAL_ENGAGED_TIME',
       'navRedirectCount': 'NAV_REDIRECT_COUNT',

--- a/extensions/amp-analytics/0.1/vendors.js
+++ b/extensions/amp-analytics/0.1/vendors.js
@@ -50,7 +50,6 @@ export const ANALYTICS_CONFIG = /** @type {!JsonObject} */ ({
       'externalReferrer': 'EXTERNAL_REFERRER',
       'firstContentfulPaint': 'FIRST_CONTENTFUL_PAINT',
       'firstViewportReady': 'FIRST_VIEWPORT_READY',
-      'htmlAttr': 'HTML_ATTR',
       'makeBodyVisible': 'MAKE_BODY_VISIBLE',
       'incrementalEngagedTime': 'INCREMENTAL_ENGAGED_TIME',
       'navRedirectCount': 'NAV_REDIRECT_COUNT',


### PR DESCRIPTION
Allows amp-analytics request to include htmlAttr expansion variable. Example:
${htmlAttr(img,src,width)}
...to get the src and width attrs of images. Documentation to follow in separate PR.
Caveats:

Only up to 10 matching elements will be returned.
An element counts as a match if it matches the CSS query selector (first arg) and has one or more of the attrs specified in the remaining args

Cloned from #13111 