### PR TITLE
`:book: Updated getting started docs with production release timing`

### DIFF
--- a/contributing/getting-started-e2e.md
+++ b/contributing/getting-started-e2e.md
@@ -515,7 +515,7 @@ git push -d origin <branch name>
 
 If your change affected internal documentation, tests, the build process, etc. you can generally see your changes right after they're merged.  If your change was to the code that runs on AMP pages across the web you'll have to wait for the change to be included in a release.
 
-In general we cut a release of amphtml on Wednesdays during working hours (Pacific time) and push it to the AMP Dev Channel the next day.  After verifying there are no issues, we push that build to 1% of AMP pages the following Monday and complete the push to all AMP pages a few days later on Thursday.  That is:  on Thursday we will typically push last week's build to all AMP pages and this week's build to the Dev Channel.
+AMP is pushed to production after undergoing testing. Generally, it takes about 1-2 weeks for a change to be live for all users. For more specific details on the timing of production releases, reference our [release schedule](release-schedule.md).
 
 **Once the push of the build that includes your change is complete all users of AMP will be using the code you contributed!**
 

--- a/contributing/getting-started-quick.md
+++ b/contributing/getting-started-quick.md
@@ -102,7 +102,8 @@ This Quick Start guide is the TL;DR version of the longer [end-to-end guide](get
 
 # See your changes in production
 
-* Barring any issues releases are cut on Wednesdays, pushed to Dev Channel Thursday, pushed to 1% of AMP pages on Monday and pushed to all pages a few days later on Thursday.
+* If your change affected internal documentation, tests, the build process, etc. you can generally see your changes right after they're merged.
+* If your change was to the code that runs on AMP pages across the web, you'll have to wait for the change to be included in a production release. Generally, it takes about 1-2 weeks for a change to be live for all users. Reference our [release schedule](release-schedule.md) for more specific details.
 * The [amphtml Releases page](https://github.com/ampproject/amphtml/releases) will list your PR in the first build that contains it.  `Pre-release` is the build on the Dev Channel, `Latest Release` is the build in production.
 * Opt-in to using the Dev Channel in a browser by enabling `dev-channel` on the [AMP Experiments](https://cdn.ampproject.org/experiments.html) page.
 * Find the AMP version being used on a page in the developer console, i.e. `Powered by AMP ⚡ HTML – Version <build number>`).


### PR DESCRIPTION
@mrjoro I have updated the getting started documentation in the Contributing folder with production release timing information according to the instructions provided. Please let me know if you'd like any further edits to either of the documents.  

Fixes Issue 12977