### PR TITLE
Update docs deprecate update ping

### DIFF
--- a/spec/amp-cache-debugging.md
+++ b/spec/amp-cache-debugging.md
@@ -55,7 +55,7 @@ If you still have a problem after following these steps, check the table below.
     <tr>
       <td>Content is being served that must be removed due to a legal takedown notice.</td>
       <td>The AMP Cache has not yet picked up the removal.</td>
-      <td>Follow the guidelines for each AMP Cache to refresh the content. For Google AMP Cache, see <a href="hhttps://developers.google.com/amp/cache/update-cache">Update AMP Content</a>.</td>
+      <td>Follow the guidelines for each AMP Cache to refresh the content. For Google AMP Cache, see <a href="https://developers.google.com/amp/cache/update-cache">Update AMP Content</a>.</td>
     </tr>
 </tbody>
 </table>

--- a/spec/amp-cache-debugging.md
+++ b/spec/amp-cache-debugging.md
@@ -55,7 +55,7 @@ If you still have a problem after following these steps, check the table below.
     <tr>
       <td>Content is being served that must be removed due to a legal takedown notice.</td>
       <td>The AMP Cache has not yet picked up the removal.</td>
-      <td>Follow the guidelines for each AMP Cache to refresh the content. For Google AMP Cache, see <a href="https://developers.google.com/amp/cache/update-ping">update ping</a>.</td>
+      <td>Follow the guidelines for each AMP Cache to refresh the content. For Google AMP Cache, see <a href="hhttps://developers.google.com/amp/cache/update-cache">Update AMP Content</a>.</td>
     </tr>
 </tbody>
 </table>

--- a/spec/amp-cache-guidelines.md
+++ b/spec/amp-cache-guidelines.md
@@ -40,9 +40,9 @@ AMP is an open ecosystem and the AMP Project actively encourages the development
 
     3. Caches must update their CSP in a timely fashion (within 7 days) at the request of the AMP Project.
 
-8. Supports a public Update ping mechanism which provides a mechanism for document publishers to notify the AMP cache about new, updated or deleted documents: 
+8. Supports a public Update Cache mechanism for document publishers to notify the AMP cache about new, updated or deleted documents: 
 
-    1. Equivalent to the [Google AMP Cache Update ping API](https://developers.google.com/amp/cache/update-ping#update-ping-format)
+    1. Equivalent to the [Google AMP Update Cache API](https://developers.google.com/amp/cache/update-cache)
 
 9. Supports a public AMP Cache URL API:
 


### PR DESCRIPTION
Change references of "update-ping" method (which is deprecated) to "update-cache".