### PR TITLE
:sparkles: Implement the refresh action for amp-list

### DIFF
--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {ActionTrust} from '../../../src/action-trust';
 import {AmpEvents} from '../../../src/amp-events';
 import {Services} from '../../../src/services';
 import {
@@ -57,6 +58,10 @@ export class AmpList extends AMP.BaseElement {
 
     /** @const @private {string} */
     this.initialSrc_ = element.getAttribute('src');
+
+    this.registerAction('refresh', () => {
+      this.fetchList_();
+    }, ActionTrust.LOW);
   }
 
   /** @override */

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -227,6 +227,24 @@ describes.realWin('amp-list component', {
     });
   });
 
+  it('should refetch if refresh action is called', () => {
+    const items = [{title: 'foo'}];
+    const foo = doc.createElement('div');
+    const rendered = expectFetchAndRender(items, [foo]);
+
+    return list.layoutCallback().then(() => rendered).then(() => {
+      expect(list.container_.contains(foo)).to.be.true;
+
+      const renderedAgain = expectFetchAndRender(items, [foo]);
+
+      list.executeAction({
+        method: 'refresh',
+        satisfiesTrust: () => true,
+      });
+      return renderedAgain;
+    });
+  });
+
   it('fetch should resolve if `src` is empty', () => {
     const spy = sandbox.spy(list, 'fetchList_');
     element.setAttribute('src', '');

--- a/extensions/amp-list/amp-list.md
+++ b/extensions/amp-list/amp-list.md
@@ -162,6 +162,19 @@ Learn more in [Placeholders & Fallbacks](https://www.ampproject.org/docs/guides/
 </amp-list>
 ```
 
+### Refreshing data
+
+The `amp-list` element exposes a `refresh` action that other elements can reference in `on="tap:..."` attributes. 
+
+```html
+<button on="tap:myList.refresh">Refresh List</button>
+<amp-list id="myList" src="https://foo.com/list.json">
+  <template type="amp-mustache">
+    <div>{{title}}</div>
+  </template>
+</amp-list>
+```
+
 ## Attributes
 
 ##### src (required)


### PR DESCRIPTION
- Implements the refresh action for amp-list
- Resolves #13717

cc @aghassemi @choumx 