### PR TITLE
✨Implement story-ad outlinks

### DIFF
--- a/examples/amp-story-auto-ads-payload.json
+++ b/examples/amp-story-auto-ads-payload.json
@@ -4,9 +4,9 @@
     "imgSrc": "https://ampbyexample.com/img/amp.jpg",
     "impressionUrl": "https://example.com/track?iid=18745543"
   },
-  "var": {
-    "ctaType": "EXPLORE",
-    "ctaUrl": "https://google.com",
+  "vars": {
+    "ctaType": "SHOP",
+    "ctaUrl": "https://ampproject.org",
     "impressionId": "ac2d1s2E3B"
   }
 }

--- a/examples/amp-story-auto-ads-payload.json
+++ b/examples/amp-story-auto-ads-payload.json
@@ -1,7 +1,7 @@
 {
   "templateId": "template-1",
   "data": {
-    "imgSrc": "https://ampbyexample.com/img/amp.jpg",
+    "imgSrc": "https://i.imgur.com/4wUqhsQ.jpg",
     "impressionUrl": "https://example.com/track?iid=18745543"
   },
   "vars": {

--- a/examples/amp-story-auto-ads.amp.html
+++ b/examples/amp-story-auto-ads.amp.html
@@ -34,6 +34,9 @@
     .circle {
       border-radius: 80px;
     }
+    .fill-img img {
+      object-fit: cover;
+    }
     </style>
 </head>
 <body>
@@ -49,16 +52,8 @@
       </script>
 
       <template type="amp-mustache" id="template-1">
-        <amp-img layout="fill" src="{{imgSrc}}"></amp-img>
-        <amp-pixel src="{{impressionUrl}}"></amp-pixel>
-      </template>
-
-      <!-- TODO(ccordry) make a example server that returns different payloads
-      and can take advantage of multiple templates. -->
-      <template type="amp-mustache" id="template-2">
-        <div class="creative-line-1">{{creativeLine1}}</div>
-        <div class="creative-line-2">{{creativeLine2}}</div>
-        <amp-pixel src="{{impressionUrl}}"></amp-pixel>
+            <amp-img class="fill-img" layout="fill" src="{{imgSrc}}"></amp-img>
+            <amp-pixel src="{{impressionUrl}}"></amp-pixel>
       </template>
     </amp-story-auto-ads>
 

--- a/extensions/amp-story/0.1/amp-story-ads.css
+++ b/extensions/amp-story/0.1/amp-story-ads.css
@@ -1,4 +1,3 @@
-
 .i-amphtml-story-ad-button {
   background-color: #FFFFFF !important;
   border: none !important;
@@ -7,18 +6,23 @@
   box-shadow: 0px 2px 12px rgba(0, 0, 0, 0.16) !important;
   height: 36px !important;
   left: 50% !important;
-  margin: 0 auto !important;
+  margin-left: -60px !important;
   opacity: 0 !important;
   position: absolute !important;
-  transition: all 300ms cubic-bezier(0.4, 0.0, 0.2, 1) 100ms !important;
   transform: scale(0) !important;
   width: 120px !important;
 }
 
+amp-story-page[active] .i-amphtml-story-ad-button,
+amp-story-page[active] .i-amphtml-story-ad-button-text {
+  animation-delay: 100ms !important;
+  animation-duration: 300ms !important;
+  animation-timing-function: cubic-bezier(0.4, 0.0, 0.2, 1) !important;
+  animation-fill-mode: forwards !important;
+}
+
 amp-story-page[active] .i-amphtml-story-ad-button {
-  margin-left: -60px !important;
-  opacity: 1 !important;
-  transform: scale(1) !important;
+  animation-name: ad-cta-btn !important;
 }
 
 .i-amphtml-story-ad-button-text {
@@ -29,7 +33,31 @@ amp-story-page[active] .i-amphtml-story-ad-button {
 }
 
 amp-story-page[active] .i-amphtml-story-ad-button-text {
-  font-size: 13px !important;
+  animation-name: ad-cta-btn-text !important;
+}
+
+@keyframes ad-cta-btn {
+  from {
+    opacity: 0;
+    transform: scale(0)
+  }
+
+  to {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+@keyframes ad-cta-btn-text {
+  from {
+    opacity: 0;
+    font-size: 0px;
+  }
+
+  to {
+    opacity: 1;
+    font-size: 13px;
+  }
 }
 
 .i-amphtml-story-ad-attribution {

--- a/extensions/amp-story/0.1/amp-story-ads.css
+++ b/extensions/amp-story/0.1/amp-story-ads.css
@@ -8,16 +8,28 @@
   height: 36px !important;
   left: 50% !important;
   margin: 0 auto !important;
-  margin-left: -60px !important;
+  opacity: 0 !important;
   position: absolute !important;
+  transition: all 300ms cubic-bezier(0.4, 0.0, 0.2, 1) 100ms !important;
+  transform: scale(0) !important;
   width: 120px !important;
+}
+
+amp-story-page[active] .i-amphtml-story-ad-button {
+  margin-left: -60px !important;
+  opacity: 1 !important;
+  transform: scale(1) !important;
 }
 
 .i-amphtml-story-ad-button-text {
   color: #4285F4 !important;
-  font-size: 13px !important;
+  font-size: 0px !important;
   font-family: 'Roboto-Bold', sans-serif !important;
   letter-spacing: 0.2px !important;
+}
+
+amp-story-page[active] .i-amphtml-story-ad-button-text {
+  font-size: 13px !important;
 }
 
 .i-amphtml-story-ad-attribution {

--- a/extensions/amp-story/0.1/amp-story-ads.css
+++ b/extensions/amp-story/0.1/amp-story-ads.css
@@ -1,0 +1,29 @@
+
+.i-amphtml-story-ad-button {
+  background-color: #FFFFFF !important;
+  border: none !important;
+  border-radius: 20px;
+  bottom: 32px !important;
+  box-shadow: 0px 2px 12px rgba(0, 0, 0, 0.16) !important;
+  height: 36px !important;
+  left: 50% !important;
+  margin: 0 auto !important;
+  margin-left: -60px !important;
+  position: absolute !important;
+  width: 120px !important;
+}
+
+.i-amphtml-story-ad-button-text {
+  color: #4285F4 !important;
+  font-size: 13px !important;
+  font-family: 'Roboto-Bold', sans-serif !important;
+  letter-spacing: 0.2px !important;
+}
+
+.i-amphtml-story-ad-attribution {
+  color: #FFFFFF !important;
+  font-size: 18px !important;
+  font-family: 'Roboto-Bold', sans-serif !important;
+  letter-spacing: 0.5px !important;
+}
+

--- a/extensions/amp-story/0.1/amp-story-ads.css
+++ b/extensions/amp-story/0.1/amp-story-ads.css
@@ -1,62 +1,43 @@
-.i-amphtml-story-ad-button {
+.i-amphtml-story-ad-link {
   background-color: #FFFFFF !important;
-  border: none !important;
-  border-radius: 20px;
+  border-radius: 20px !important;
   bottom: 32px !important;
   box-shadow: 0px 2px 12px rgba(0, 0, 0, 0.16) !important;
+  color: #4285F4 !important;
+  font-size: 0px !important;
+  font-family: 'Roboto-Bold', sans-serif !important;
   height: 36px !important;
   left: 50% !important;
+  letter-spacing: 0.2px !important;
+  line-height: 36px;
   margin-left: -60px !important;
   opacity: 0 !important;
   position: absolute !important;
   transform: scale(0) !important;
+  text-align: center;
+  text-decoration: none !important;
   width: 120px !important;
 }
 
-amp-story-page[active] .i-amphtml-story-ad-button,
-amp-story-page[active] .i-amphtml-story-ad-button-text {
+amp-story-page[active] .i-amphtml-story-ad-link {
   animation-delay: 100ms !important;
   animation-duration: 300ms !important;
   animation-timing-function: cubic-bezier(0.4, 0.0, 0.2, 1) !important;
   animation-fill-mode: forwards !important;
+  animation-name: ad-cta !important;
 }
 
-amp-story-page[active] .i-amphtml-story-ad-button {
-  animation-name: ad-cta-btn !important;
-}
-
-.i-amphtml-story-ad-button-text {
-  color: #4285F4 !important;
-  font-size: 0px !important;
-  font-family: 'Roboto-Bold', sans-serif !important;
-  letter-spacing: 0.2px !important;
-}
-
-amp-story-page[active] .i-amphtml-story-ad-button-text {
-  animation-name: ad-cta-btn-text !important;
-}
-
-@keyframes ad-cta-btn {
-  from {
-    opacity: 0;
-    transform: scale(0)
-  }
-
-  to {
-    transform: scale(1);
-    opacity: 1;
-  }
-}
-
-@keyframes ad-cta-btn-text {
+@keyframes ad-cta {
   from {
     opacity: 0;
     font-size: 0px;
+    transform: scale(0);
   }
 
   to {
     opacity: 1;
     font-size: 13px;
+    transform: scale(1);
   }
 }
 

--- a/extensions/amp-story/0.1/amp-story-ads.css
+++ b/extensions/amp-story/0.1/amp-story-ads.css
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 .i-amphtml-story-ad-link {
   background-color: #FFFFFF !important;
   border-radius: 20px !important;

--- a/extensions/amp-story/0.1/amp-story-auto-ads.js
+++ b/extensions/amp-story/0.1/amp-story-auto-ads.js
@@ -269,8 +269,7 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
 
     const ctaText = CTA_TYPES[ctaType];
     if (!ctaType) {
-      user().error(ctaText, `${TAG}: the 'CTA Type' returned by the ad-server` +
-          'must be one of the predefined choices.');
+      user().error(TAG, 'invalid "CTA Type" in ad response');
       return false;
     }
 

--- a/extensions/amp-story/0.1/amp-story.css
+++ b/extensions/amp-story/0.1/amp-story.css
@@ -17,6 +17,7 @@
 @import './amp-story-desktop.css';
 @import './amp-story-user-overridable.css';
 @import './amp-story-hint.css';
+@import './amp-story-ads.css';
 
 /** Common */
 amp-story, amp-story-page, amp-story-grid-layer, amp-story-cta-layer {


### PR DESCRIPTION
`amp-story-auto-ads` will now create an out-link button contained in the new `amp-story-cta-layer` .  The button text and target url is derived from JSON returned by the ad-server. The resulting `HTML` will me structured like so:

```
<amp-story-page>
    <amp-story-grid-layer>
      <amp-story-ad>
        ...
      </amp-story-ad>
      <amp-story-cta-layer>
          <button class="i-amphtml-story-ad-button">
            <span class=""i-amphtml-story-ad-button-text">Shop Now</span>
          </button>
        </amp-story-cta-layer>
    </amp-story-grid-layer>
</amp-story-page>
```

edit: changed to `<a>` tag
```
<amp-story-cta-layer>
    <a class="i-amphtml-story-ad-button">Shop Now</a>
</amp-story-cta-layer>

```


