### PR TITLE
🐛Refactor interaction counting for <amp-story-auto-ads>

### DIFF
--- a/extensions/amp-story/0.1/amp-story-auto-ads.js
+++ b/extensions/amp-story/0.1/amp-story-auto-ads.js
@@ -248,7 +248,7 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
     }
 
     if (this.uniquePagesCount_ > MIN_INTERVAL && !this.allAdsPlaced_()) {
-      this.placeAdAfterPage_(pageId);
+      this.tryToPlaceAdAfterPage_(pageId);
     }
   }
 
@@ -266,21 +266,29 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
    * @param {string} currentPageId
    * @private
    */
-  placeAdAfterPage_(currentPageId) {
+  tryToPlaceAdAfterPage_(currentPageId) {
     const nextAdPageEl = this.adPageEls_[this.adPageEls_.length - 1];
 
     if (!nextAdPageEl || !this.isCurrentAdLoaded_) {
-      return;
+      return false;
+    }
+
+    const currentPage = this.ampStory_.getPageById(currentPageId);
+    const nextPage = this.ampStory_.getNextPage(currentPage);
+    // we do not ever want two consecutive ads
+    if (currentPage.isAd() || nextPage.isAd()) {
+      return false;
     }
 
     const inserted = this.ampStory_.insertPage(currentPageId, nextAdPageEl.id);
     // failed insertion (consecutive ads, or no next page)
     if (!inserted) {
-      return;
+      return false;
     }
 
     this.adsPlaced_++;
     this.uniquePagesCount_ = 0;
+
 
     if (!this.allAdsPlaced_()) {
       // start loading next ad

--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -1527,6 +1527,9 @@ export class AmpStory extends AMP.BaseElement {
    */
   getNextPage(page) {
     const nextPageId = page.getNextPageId(true /*opt_isAutomaticAdvance */);
+    if (!nextPageId) {
+      return null;
+    }
     return this.getPageById(nextPageId);
   }
 

--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -787,7 +787,7 @@ export class AmpStory extends AMP.BaseElement {
    */
   // TODO(newmuis): Update history state
   switchTo_(targetPageId) {
-    const targetPage = this.getPageById_(targetPageId);
+    const targetPage = this.getPageById(targetPageId);
     const pageIndex = this.getPageIndex(targetPage);
 
     this.updateBackground_(targetPage.element, /* initial */ !this.activePage_);
@@ -1133,7 +1133,7 @@ export class AmpStory extends AMP.BaseElement {
     }
 
     map[pageId] = distance;
-    const page = this.getPageById_(pageId);
+    const page = this.getPageById(pageId);
     page.getAdjacentPageIds().forEach(adjacentPageId => {
       if (map[adjacentPageId] !== undefined
           && map[adjacentPageId] <= distance) {
@@ -1155,7 +1155,7 @@ export class AmpStory extends AMP.BaseElement {
     this.mutateElement(() => {
       pagesByDistance.forEach((pageIds, distance) => {
         pageIds.forEach(pageId => {
-          const page = this.getPageById_(pageId);
+          const page = this.getPageById(pageId);
           page.setDistance(distance);
         });
       });
@@ -1296,9 +1296,8 @@ export class AmpStory extends AMP.BaseElement {
    * @param {string} id The ID of the page to be retrieved.
    * @return {!./amp-story-page.AmpStoryPage} Retrieves the page with the
    *     specified ID.
-   * @private
    */
-  getPageById_(id) {
+  getPageById(id) {
     const pageIndex = this.getPageIndexById_(id);
     return dev().assert(this.pages_[pageIndex],
         `Page at index ${pageIndex} exists, but is missing from the array.`);
@@ -1489,43 +1488,48 @@ export class AmpStory extends AMP.BaseElement {
   /**
    * Insert a new page in navigation flow by changing the attr pointers
    * on amp-story-page elements
-   * @param {string} currentPageId
+   * @param {string} pageBeforeId
    * @param {string} pageToBeInsertedId
    * @return {boolean} was page inserted
    */
-  insertPage(currentPageId, pageToBeInsertedId) {
+  insertPage(pageBeforeId, pageToBeInsertedId) {
     // TODO(ccordry): make sure this method moves to PageManager when implemented
-    const pageToBeInserted = this.getPageById_(pageToBeInsertedId);
+    const pageToBeInserted = this.getPageById(pageToBeInsertedId);
     const pageToBeInsertedEl = pageToBeInserted.element;
 
-    const currentPage = this.getPageById_(currentPageId);
-    const currentPageEl = currentPage.element;
+    const pageBefore = this.getPageById(pageBeforeId);
+    const pageBeforeEl = pageBefore.element;
 
-    const nextPageId = currentPage
-        .getNextPageId(true /*opt_isAutomaticAdvance */);
+    const nextPage = this.getNextPage(pageBefore);
 
-    if (nextPageId) {
-      const nextPage = this.getPageById_(nextPageId);
-
-      // we do not ever want two consecutive ads
-      if (currentPage.isAd() || nextPage.isAd()) {
-        return false;
-      }
-
-      currentPageEl.setAttribute(ADVANCE_TO_ATTR, pageToBeInsertedId);
-      currentPageEl.setAttribute(AUTO_ADVANCE_TO_ATTR, pageToBeInsertedId);
-      pageToBeInsertedEl.setAttribute(RETURN_TO_ATTR, currentPageId);
-
-      const nextPageEl = nextPage.element;
-      pageToBeInsertedEl.setAttribute(ADVANCE_TO_ATTR, nextPageEl.id);
-      pageToBeInsertedEl.setAttribute(AUTO_ADVANCE_TO_ATTR, nextPageEl.id);
-      nextPageEl.setAttribute(RETURN_TO_ATTR, pageToBeInsertedId);
-
-      return true;
+    if (!nextPage) {
+      return false;
     }
 
-    return false;
+    pageBeforeEl.setAttribute(ADVANCE_TO_ATTR, pageToBeInsertedId);
+    pageBeforeEl.setAttribute(AUTO_ADVANCE_TO_ATTR, pageToBeInsertedId);
+    pageToBeInsertedEl.setAttribute(RETURN_TO_ATTR, pageBeforeId);
+
+    const nextPageEl = nextPage.element;
+    const nextPageId = nextPageEl.id;
+    pageToBeInsertedEl.setAttribute(ADVANCE_TO_ATTR, nextPageId);
+    pageToBeInsertedEl.setAttribute(AUTO_ADVANCE_TO_ATTR, nextPageId);
+    nextPageEl.setAttribute(RETURN_TO_ATTR, pageToBeInsertedId);
+
+    return true;
   }
+
+
+  /**
+   * Get next page object
+   * @param {!./amp-story-page.AmpStoryPage} page
+   * @return {?./amp-story-page.AmpStoryPage}
+   */
+  getNextPage(page) {
+    const nextPageId = page.getNextPageId(true /*opt_isAutomaticAdvance */);
+    return this.getPageById(nextPageId);
+  }
+
 
   /**
    * @param {!Window} win

--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -1491,6 +1491,7 @@ export class AmpStory extends AMP.BaseElement {
    * on amp-story-page elements
    * @param {string} currentPageId
    * @param {string} pageToBeInsertedId
+   * @return {boolean} was page inserted
    */
   insertPage(currentPageId, pageToBeInsertedId) {
     // TODO(ccordry): make sure this method moves to PageManager when implemented
@@ -1503,18 +1504,27 @@ export class AmpStory extends AMP.BaseElement {
     const nextPageId = currentPage
         .getNextPageId(true /*opt_isAutomaticAdvance */);
 
-
     if (nextPageId) {
+      const nextPage = this.getPageById_(nextPageId);
+
+      // we do not ever want two consecutive ads
+      if (currentPage.isAd() || nextPage.isAd()) {
+        return false;
+      }
+
       currentPageEl.setAttribute(ADVANCE_TO_ATTR, pageToBeInsertedId);
       currentPageEl.setAttribute(AUTO_ADVANCE_TO_ATTR, pageToBeInsertedId);
       pageToBeInsertedEl.setAttribute(RETURN_TO_ATTR, currentPageId);
 
-      const nextPage = this.getPageById_(nextPageId);
       const nextPageEl = nextPage.element;
       pageToBeInsertedEl.setAttribute(ADVANCE_TO_ATTR, nextPageEl.id);
       pageToBeInsertedEl.setAttribute(AUTO_ADVANCE_TO_ATTR, nextPageEl.id);
       nextPageEl.setAttribute(RETURN_TO_ATTR, pageToBeInsertedId);
+
+      return true;
     }
+
+    return false;
   }
 
   /**


### PR DESCRIPTION
This makes some changes to the algo that determines when to try to insert a page.  

The original was only counting interactions, and could get stuck in a cycle with the right conditions. This update ensures that two consecutive pages cannot be inserted next to each other and only counts unique pages seen.

This algo will likely continue to be refined.
