### PR TITLE
🐛♻️Use a signal to know when story is loaded

### DIFF
--- a/extensions/amp-story/0.1/amp-story-auto-ads.js
+++ b/extensions/amp-story/0.1/amp-story-auto-ads.js
@@ -15,7 +15,6 @@
  */
 
 import {CommonSignals} from '../../../src/common-signals';
-import {EventType} from './events';
 import {Services} from '../../../src/services';
 import {StateChangeType} from './navigation-state';
 import {createElementWithAttributes} from '../../../src/dom';
@@ -100,23 +99,11 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
 
   /** @override */
   layoutCallback() {
-    return this.createStoryLoadPromise_()
+    return this.ampStory_.signals().whenSignal(CommonSignals.INI_LOAD)
         .then(() => {
           this.readConfig_();
           this.schedulePage_();
         });
-  }
-
-
-  /**
-   * promise that resolves on STORY_LOADED event
-   * @private
-   * @return {!Promise}
-   */
-  createStoryLoadPromise_() {
-    return new Promise(resolve => {
-      this.ampStory_.element.addEventListener(EventType.STORY_LOADED, resolve);
-    });
   }
 
 

--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -34,6 +34,7 @@ import {AmpStoryHint} from './amp-story-hint';
 import {AmpStoryVariableService} from './variable-service';
 import {Bookend} from './bookend';
 import {CSS} from '../../../build/amp-story-0.1.css';
+import {CommonSignals} from '../../../src/common-signals';
 import {
   DoubletapRecognizer,
   SwipeXYRecognizer,
@@ -606,6 +607,7 @@ export class AmpStory extends AMP.BaseElement {
   /** @private */
   markStoryAsLoaded_() {
     dispatch(this.element, EventType.STORY_LOADED, true);
+    this.signals().signal(CommonSignals.INI_LOAD);
     this.mutateElement(() => {
       this.element.classList.add(STORY_LOADED_CLASS_NAME);
     });


### PR DESCRIPTION
Refactor: add a signal to `amp-story` that is then used by `amp-story-auto-ads` to know when story has loaded.