### PR TITLE
Apester Media Monetization Options

### DIFF
--- a/examples/apester-media.amp.html
+++ b/examples/apester-media.amp.html
@@ -16,14 +16,14 @@
     <!--Usage example of a simple unit-->
     <amp-apester-media
       height="404"
-      data-apester-media-id="57a336dba187a2ca3005e826"
+      data-apester-media-id="5aaa6ff6377c180c56c4450d"
       layout="fixed-height">
     </amp-apester-media>
 
     <!--Usage example of a playlist unit-->
     <amp-apester-media
       height="404"
-      data-apester-channel-token="57a36e1e96cd505a7f01ed12"
+      data-apester-channel-token="5aaa70636ddf7e0001f222f2"
       data-apester-fallback="true">
     </amp-apester-media>
 </article>

--- a/extensions/amp-apester-media/0.1/amp-apester-media.js
+++ b/extensions/amp-apester-media/0.1/amp-apester-media.js
@@ -335,9 +335,9 @@ class AmpApesterMedia extends AMP.BaseElement {
           const payload = response['payload'];
           // If it's a playlist we choose a media randomly.
           // The response will be an array.
-          const media = this.embedOptions_.playlist
+          const media = /** @type {JsonObject} */ (this.embedOptions_.playlist
             ? payload[Math.floor(Math.random() * payload.length)]
-            : payload;
+            : payload);
           const src = this.constructUrlFromMedia_(media['interactionId']);
           const iframe = this.constructIframe_(src);
           this.intersectionObserverApi_ = new IntersectionObserverApi(
@@ -359,7 +359,7 @@ class AmpApesterMedia extends AMP.BaseElement {
                     this.iframe_.classList
                         .add('i-amphtml-apester-iframe-ready');
                     this.iframe_.contentWindow./*OK*/ postMessage(
-                        {type: 'campaigns', data: media['campaignData']},
+                        /** @type {JsonObject} */ ({type: 'campaigns', data: media['campaignData']}),
                         '*'
                     );
                     this.togglePlaceholder(false);

--- a/extensions/amp-apester-media/0.1/amp-apester-media.js
+++ b/extensions/amp-apester-media/0.1/amp-apester-media.js
@@ -359,7 +359,8 @@ class AmpApesterMedia extends AMP.BaseElement {
                     this.iframe_.classList
                         .add('i-amphtml-apester-iframe-ready');
                     this.iframe_.contentWindow./*OK*/ postMessage(
-                        /** @type {JsonObject} */ ({type: 'campaigns', data: media['campaignData']}),
+                        /** @type {JsonObject} */ ({type: 'campaigns',
+                          data: media['campaignData']}),
                         '*'
                     );
                     this.togglePlaceholder(false);

--- a/extensions/amp-apester-media/0.1/amp-apester-media.js
+++ b/extensions/amp-apester-media/0.1/amp-apester-media.js
@@ -67,8 +67,6 @@ class AmpApesterMedia extends AMP.BaseElement {
     this.seen_ = false;
     /** @private {?Element}  */
     this.iframe_ = null;
-    /** @private {?Promise}  */
-    this.iframePromise_ = null;
     /** @private {boolean}  */
     this.ready_ = false;
     /** @private {?number|undefined}  */
@@ -320,67 +318,59 @@ class AmpApesterMedia extends AMP.BaseElement {
   /** @override */
   layoutCallback() {
     this.element.classList.add('amp-apester-container');
-    return (
-      this.queryMedia_()
-          .then(
-              response => {
-                const payload = response['payload'];
-                // If it's a playlist we choose a media randomly.
-                // The response will be an array.
-                const media = this.embedOptions_.playlist
-                  ? payload[Math.floor(Math.random() * payload.length)]
-                  : payload;
-                const src = this.constructUrlFromMedia_(media['interactionId']);
-                const iframe = this.constructIframe_(src);
-                this.intersectionObserverApi_ = new IntersectionObserverApi(
-                    this,
-                    iframe
-                );
-                const overflow = this.constructOverflow_();
-                const mutate = state => {
-                  state.element.classList.add('i-amphtml-apester-iframe-ready');
-                };
-                const state = {
-                  element: iframe,
-                  mutator: mutate,
-                };
-                this.mediaId_ = media['interactionId'];
-                this.iframe_ = iframe;
-                this.element.appendChild(overflow);
-                this.element.appendChild(iframe);
-                this.registerToApesterEvents_();
+    const vsync = Services.vsyncFor(this.win);
+    return this.queryMedia_().then(
+        response => {
+          const payload = response['payload'];
+          // If it's a playlist we choose a media randomly.
+          // The response will be an array.
+          const media = this.embedOptions_.playlist
+            ? payload[Math.floor(Math.random() * payload.length)]
+            : payload;
+          const src = this.constructUrlFromMedia_(media['interactionId']);
+          const iframe = this.constructIframe_(src);
+          this.intersectionObserverApi_ = new IntersectionObserverApi(
+              this,
+              iframe
+          );
 
-                return (this.iframePromise_ = this.loadPromise(iframe).then(() => {
-                  Services.vsyncFor(this.win).runPromise({mutate}, state);
-                  this.iframe_.contentWindow./*OK*/ postMessage(
-                      {type: 'campaigns', data: media['campaignData']},
-                      '*'
-                  );
-                  return media;
-                }));
-              },
-              error => {
-                dev().error(TAG, 'Display', error);
-                return undefined;
-              }
-          )
-    /** @param {!JsonObject} media */
-          .then(media => {
-            this.togglePlaceholder(false);
-            this.ready_ = true;
-            let height = 0;
-            if (media && media['data'] && media['data']['size']) {
-              height = media['data']['size']['height'];
-            }
-            if (height != this.height_) {
-              this.height_ = height;
-              if (this.random_) {
-                this./*OK*/ attemptChangeHeight(height);
-              } else {
-                this./*OK*/ changeHeight(height);
-              }
-            }
-          })
+          this.mediaId_ = media['interactionId'];
+          this.iframe_ = iframe;
+          this.registerToApesterEvents_();
+
+          return vsync.mutatePromise(() => {
+            const overflow = this.constructOverflow_();
+            this.element.appendChild(overflow);
+            this.element.appendChild(iframe);
+            return this.loadPromise(iframe).then(() => {
+              return vsync.mutatePromise(() => {
+                this.iframe_.classList.add('i-amphtml-apester-iframe-ready');
+                this.iframe_.contentWindow./*OK*/ postMessage(
+                    {type: 'campaigns', data: media['campaignData']},
+                    '*'
+                );
+                this.togglePlaceholder(false);
+                this.ready_ = true;
+                let height = 0;
+                if (media && media['data'] && media['data']['size']) {
+                  height = media['data']['size']['height'];
+                }
+                if (height != this.height_) {
+                  this.height_ = height;
+                  if (this.random_) {
+                    this./*OK*/ attemptChangeHeight(height);
+                  } else {
+                    this./*OK*/ changeHeight(height);
+                  }
+                }
+              });
+            });
+          });
+        },
+        error => {
+          dev().error(TAG, 'Display', error);
+          return undefined;
+        }
     );
   }
 
@@ -408,7 +398,6 @@ class AmpApesterMedia extends AMP.BaseElement {
       this.unlisteners_.forEach(unlisten => unlisten());
       removeElement(this.iframe_);
       this.iframe_ = null;
-      this.iframePromise_ = null;
     }
     return true; //Call layoutCallback again.
   }

--- a/extensions/amp-apester-media/0.1/amp-apester-media.js
+++ b/extensions/amp-apester-media/0.1/amp-apester-media.js
@@ -353,36 +353,33 @@ class AmpApesterMedia extends AMP.BaseElement {
             const overflow = this.constructOverflow_();
             this.element.appendChild(overflow);
             this.element.appendChild(iframe);
+          }).then(() => {
             return this.loadPromise(iframe).then(() => {
-              return vsync
-                  .mutatePromise(() => {
-                    this.iframe_.classList
-                        .add('i-amphtml-apester-iframe-ready');
-                    if (media['campaignData']) {
-                      this.iframe_.contentWindow./*OK*/ postMessage(
-                          /** @type {JsonObject} */ ({type: 'campaigns',
-                            data: media['campaignData']}),
-                          '*'
-                      );
-                    }
-                    this.togglePlaceholder(false);
-                    this.ready_ = true;
-                    let height = 0;
-                    if (media && media['data'] && media['data']['size']) {
-                      height = media['data']['size']['height'];
-                    }
-                    if (height != this.height_) {
-                      this.height_ = height;
-                      if (this.random_) {
-                        this./*OK*/ attemptChangeHeight(height);
-                      } else {
-                        this./*OK*/ changeHeight(height);
-                      }
-                    }
-                  })
-                  .then(() => {
-                    return this.loadPromise(iframe);
-                  });
+              return vsync.mutatePromise(() => {
+                this.iframe_.classList
+                    .add('i-amphtml-apester-iframe-ready');
+                if (media['campaignData']) {
+                  this.iframe_.contentWindow./*OK*/ postMessage(
+                      /** @type {JsonObject} */ ({type: 'campaigns',
+                        data: media['campaignData']}),
+                      '*'
+                  );
+                }
+                this.togglePlaceholder(false);
+                this.ready_ = true;
+                let height = 0;
+                if (media && media['data'] && media['data']['size']) {
+                  height = media['data']['size']['height'];
+                }
+                if (height != this.height_) {
+                  this.height_ = height;
+                  if (this.random_) {
+                    this./*OK*/ attemptChangeHeight(height);
+                  } else {
+                    this./*OK*/ changeHeight(height);
+                  }
+                }
+              });
             });
           });
         },

--- a/extensions/amp-apester-media/0.1/amp-apester-media.js
+++ b/extensions/amp-apester-media/0.1/amp-apester-media.js
@@ -356,7 +356,8 @@ class AmpApesterMedia extends AMP.BaseElement {
             return this.loadPromise(iframe).then(() => {
               return vsync
                   .mutatePromise(() => {
-                    this.iframe_.classList.add('i-amphtml-apester-iframe-ready');
+                    this.iframe_.classList
+                        .add('i-amphtml-apester-iframe-ready');
                     this.iframe_.contentWindow./*OK*/ postMessage(
                         {type: 'campaigns', data: media['campaignData']},
                         '*'

--- a/extensions/amp-apester-media/0.1/amp-apester-media.js
+++ b/extensions/amp-apester-media/0.1/amp-apester-media.js
@@ -381,6 +381,9 @@ class AmpApesterMedia extends AMP.BaseElement {
                 }
               });
             });
+          }).catch(error => {
+            dev().error(TAG, 'Display', error);
+            return undefined;
           });
         },
         error => {

--- a/extensions/amp-apester-media/0.1/amp-apester-media.js
+++ b/extensions/amp-apester-media/0.1/amp-apester-media.js
@@ -358,11 +358,13 @@ class AmpApesterMedia extends AMP.BaseElement {
                   .mutatePromise(() => {
                     this.iframe_.classList
                         .add('i-amphtml-apester-iframe-ready');
-                    this.iframe_.contentWindow./*OK*/ postMessage(
-                        /** @type {JsonObject} */ ({type: 'campaigns',
-                          data: media['campaignData']}),
-                        '*'
-                    );
+                    if (media['campaignData']) {
+                      this.iframe_.contentWindow./*OK*/ postMessage(
+                          /** @type {JsonObject} */ ({type: 'campaigns',
+                            data: media['campaignData']}),
+                          '*'
+                      );
+                    }
                     this.togglePlaceholder(false);
                     this.ready_ = true;
                     let height = 0;

--- a/extensions/amp-apester-media/0.1/test/test-amp-apester-media.js
+++ b/extensions/amp-apester-media/0.1/test/test-amp-apester-media.js
@@ -130,11 +130,8 @@ describes.realWin(
               .to.equal('/interaction/5aaa70c79aaf0c5443078d31');
           expect(qs.get('sdk')).to.equal('amp');
           expect(qs.get('type')).to.equal('editorial');
-          setTimeout(() => {
-            expect(changeSizeSpy).to.be.calledOnce;
-            expect(changeSizeSpy.args[0][0]).to.equal('404');
-          },1000);
-
+          expect(changeSizeSpy).to.be.calledOnce;
+          expect(changeSizeSpy.args[0][0]).to.equal('404');
         });
       });
 
@@ -152,11 +149,8 @@ describes.realWin(
               .to.equal('/interaction/5aaa70c79aaf0c5443078d31');
           expect(qs.get('sdk')).to.equal('amp');
           expect(qs.get('type')).to.equal('playlist');
-          setTimeout(() => {
-            expect(attemptChangeSizeSpy).to.be.calledOnce;
-            expect(attemptChangeSizeSpy.args[0][0]).to.equal('404');
-          },1000);
-
+          expect(attemptChangeSizeSpy).to.be.calledOnce;
+          expect(attemptChangeSizeSpy.args[0][0]).to.equal('404');
         });
       });
 

--- a/extensions/amp-apester-media/0.1/test/test-amp-apester-media.js
+++ b/extensions/amp-apester-media/0.1/test/test-amp-apester-media.js
@@ -46,7 +46,7 @@ describes.realWin(
           code: 200,
           message: 'ok',
           payload: {
-            interactionId: '57a336dba187a2ca3005e826',
+            interactionId: '5aaa70c79aaf0c5443078d31',
             data: {
               size: {width: '600', height: '404'},
             },
@@ -63,7 +63,7 @@ describes.realWin(
           message: 'ok',
           payload: [
             {
-              interactionId: '57a336dba187a2ca3005e826',
+              interactionId: '5aaa70c79aaf0c5443078d31',
               data: {
                 size: {width: '600', height: '404'},
               },
@@ -118,7 +118,7 @@ describes.realWin(
 
       it('renders', () => {
         return getApester({
-          'data-apester-media-id': '57a336dba187a2ca3005e826',
+          'data-apester-media-id': '5aaa70c79aaf0c5443078d31',
         }).then(ape => {
           const iframe = ape.querySelector('iframe');
           expect(iframe).to.not.be.null;
@@ -127,11 +127,14 @@ describes.realWin(
           const qs = new URLSearchParams(url.searchParams);
           expect(url.hostname).to.equal('renderer.apester.com');
           expect(url.pathname)
-              .to.equal('/interaction/57a336dba187a2ca3005e826');
+              .to.equal('/interaction/5aaa70c79aaf0c5443078d31');
           expect(qs.get('sdk')).to.equal('amp');
           expect(qs.get('type')).to.equal('editorial');
-          expect(changeSizeSpy).to.be.calledOnce;
-          expect(changeSizeSpy.args[0][0]).to.equal('404');
+          setTimeout(() => {
+            expect(changeSizeSpy).to.be.calledOnce;
+            expect(changeSizeSpy.args[0][0]).to.equal('404');
+          },1000);
+
         });
       });
 
@@ -146,11 +149,14 @@ describes.realWin(
           const qs = new URLSearchParams(url.searchParams);
           expect(url.hostname).to.equal('renderer.apester.com');
           expect(url.pathname)
-              .to.equal('/interaction/57a336dba187a2ca3005e826');
+              .to.equal('/interaction/5aaa70c79aaf0c5443078d31');
           expect(qs.get('sdk')).to.equal('amp');
           expect(qs.get('type')).to.equal('playlist');
-          expect(attemptChangeSizeSpy).to.be.calledOnce;
-          expect(attemptChangeSizeSpy.args[0][0]).to.equal('404');
+          setTimeout(() => {
+            expect(attemptChangeSizeSpy).to.be.calledOnce;
+            expect(attemptChangeSizeSpy.args[0][0]).to.equal('404');
+          },1000);
+
         });
       });
 
@@ -158,7 +164,7 @@ describes.realWin(
       it('renders responsively', () => {
         return getApester(
             {
-              'data-apester-media-id': '57a336dba187a2ca3005e826',
+              'data-apester-media-id': '5aaa70c79aaf0c5443078d31',
               width: '500',
             },
             true
@@ -170,7 +176,7 @@ describes.realWin(
 
       it('removes iframe after unlayoutCallback', () => {
         return getApester({
-          'data-apester-media-id': '57a336dba187a2ca3005e826',
+          'data-apester-media-id': '5aaa70c79aaf0c5443078d31',
         }).then(ape => {
           const iframe = ape.querySelector('iframe');
           expect(iframe).to.not.be.null;
@@ -178,7 +184,7 @@ describes.realWin(
           const url = new URL(iframe.src);
           expect(url.hostname).to.equal('renderer.apester.com');
           expect(url.pathname)
-              .to.equal('/interaction/57a336dba187a2ca3005e826');
+              .to.equal('/interaction/5aaa70c79aaf0c5443078d31');
           const tag = ape.implementation_;
           tag.unlayoutCallback();
           expect(ape.querySelector('iframe')).to.be.null;


### PR DESCRIPTION
# This PR is allowing publishers to monetize their content using Apester dynamic content

- Added IntersectionObserverApi in order to allow advertisers to test viewability as they would with amp-iframe
- Fixed issue #13531, and mutate only in mutation phase.


