### PR TITLE
Simplified media blessing.

### DIFF
--- a/extensions/amp-story/0.1/media-tasks.js
+++ b/extensions/amp-story/0.1/media-tasks.js
@@ -15,7 +15,6 @@
  */
 
 import {Sources} from './sources';
-import {dev} from '../../../src/log';
 import {isConnectedNode} from '../../../src/dom';
 
 
@@ -336,30 +335,12 @@ export class BlessTask extends MediaTask {
 
   /** @override */
   executeInternal(mediaEl) {
-    const isPaused = mediaEl.paused;
     const isMuted = mediaEl.muted;
-    const currentTime = mediaEl.currentTime;
-
-    const whenPlaying = isPaused ?
-      Promise.resolve(mediaEl.play()) : Promise.resolve();
-
-    return whenPlaying.then(() => {
-      mediaEl.muted = false;
-
-      if (isPaused) {
-        mediaEl.pause();
-        mediaEl.currentTime = currentTime;
-      }
-
-      if (isMuted) {
-        mediaEl.muted = true;
-      }
-
-      mediaEl[ELEMENT_BLESSED_PROPERTY_NAME] = true;
-    }).catch(reason => {
-      dev().expectedError('AMP-STORY', 'Blessing media element failed:',
-          reason, mediaEl);
-    });
+    mediaEl.muted = false;
+    if (isMuted) {
+      mediaEl.muted = true;
+    }
+    return Promise.resolve();
   }
 }
 


### PR DESCRIPTION
Blessing elements on iOS is very slow because it performs many operations. This PR reduces the number of operations needed to bless media elements and therefore improves the performance.

- Fixes the 5+ seconds delay when unmuting a story on an old iPhone
- Fixes the burst of sound when blessing elements on low end devices

Tested both with regular tap navigation, and auto advance.

Fixes #13588 #13587 