### PR TITLE
Setting a z-index to stories toast messages.

### DIFF
--- a/extensions/amp-story/0.1/amp-story.css
+++ b/extensions/amp-story/0.1/amp-story.css
@@ -879,6 +879,7 @@ amp-story[standalone] .i-amphtml-story-developer-log {
   font-weight: 400 !important;
   font-size: 12px !important;
   max-width: 640px !important;
+  z-index: 100002 !important; /** Bookend + 1 */
 }
 
 @media (min-width: 640px) {


### PR DESCRIPTION
Setting a z-index to stories toast messages to make sure it's on top of the bookend.

Fixes #13739 