### PR TITLE
Creation of base class for amp-story layers.

### DIFF
--- a/extensions/amp-story/0.1/amp-story-base-layer.js
+++ b/extensions/amp-story/0.1/amp-story-base-layer.js
@@ -21,9 +21,18 @@
 import {Layout} from '../../../src/layout';
 
 export class AmpBaseLayer extends AMP.BaseElement {
+  /** @param {!AmpElement} element */
+  constructor(element) {
+    super(element);
+  }
 
   /** @override */
   isLayoutSupported(layout) {
     return layout == Layout.CONTAINER;
+  }
+
+  /** @override */
+  buildCallback() {
+    this.element.classList.add('i-amphtml-story-layer');
   }
 }

--- a/extensions/amp-story/0.1/amp-story-base-layer.js
+++ b/extensions/amp-story/0.1/amp-story-base-layer.js
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Base layer from which other layers in a story page extend from.
+ */
+
+import {Layout} from '../../../src/layout';
+
+export class AmpBaseLayer extends AMP.BaseElement {
+
+  /** @override */
+  isLayoutSupported(layout) {
+    return layout == Layout.CONTAINER;
+  }
+}

--- a/extensions/amp-story/0.1/amp-story-base-layer.js
+++ b/extensions/amp-story/0.1/amp-story-base-layer.js
@@ -20,7 +20,7 @@
 
 import {Layout} from '../../../src/layout';
 
-export class AmpBaseLayer extends AMP.BaseElement {
+export class AmpStoryBaseLayer extends AMP.BaseElement {
   /** @param {!AmpElement} element */
   constructor(element) {
     super(element);

--- a/extensions/amp-story/0.1/amp-story-cta-layer.js
+++ b/extensions/amp-story/0.1/amp-story-cta-layer.js
@@ -29,8 +29,7 @@
  * ...
  */
 
-import {Layout} from '../../../src/layout';
-import { AmpBaseLayer } from './amp-story-base-layer';
+import {AmpBaseLayer} from './amp-story-base-layer';
 
 export class AmpStoryCtaLayer extends AmpBaseLayer {
 

--- a/extensions/amp-story/0.1/amp-story-cta-layer.js
+++ b/extensions/amp-story/0.1/amp-story-cta-layer.js
@@ -30,13 +30,9 @@
  */
 
 import {Layout} from '../../../src/layout';
+import { AmpBaseLayer } from './amp-story-base-layer';
 
-export class AmpStoryCtaLayer extends AMP.BaseElement {
-
-  /** @override */
-  isLayoutSupported(layout) {
-    return layout == Layout.CONTAINER;
-  }
+export class AmpStoryCtaLayer extends AmpBaseLayer {
 
   /** @override */
   prerenderAllowed() {

--- a/extensions/amp-story/0.1/amp-story-cta-layer.js
+++ b/extensions/amp-story/0.1/amp-story-cta-layer.js
@@ -29,9 +29,9 @@
  * ...
  */
 
-import {AmpBaseLayer} from './amp-story-base-layer';
+import {AmpStoryBaseLayer} from './amp-story-base-layer';
 
-export class AmpStoryCtaLayer extends AmpBaseLayer {
+export class AmpStoryCtaLayer extends AmpStoryBaseLayer {
 
   /** @override */
   prerenderAllowed() {

--- a/extensions/amp-story/0.1/amp-story-grid-layer.js
+++ b/extensions/amp-story/0.1/amp-story-grid-layer.js
@@ -26,9 +26,8 @@
  * </code>
  */
 
-import {Layout} from '../../../src/layout';
+import {AmpBaseLayer} from './amp-story-base-layer';
 import {matches, scopedQuerySelectorAll} from '../../../src/dom';
-import { AmpBaseLayer } from './amp-story-base-layer';
 
 /**
  * A mapping of attribute names we support for grid layers to the CSS Grid
@@ -86,6 +85,7 @@ export class AmpStoryGridLayer extends AmpBaseLayer {
 
   /** @override */
   buildCallback() {
+    super.buildCallback();
     this.applyTemplateClassName_();
     this.setOwnCssGridStyles_();
     this.setDescendentCssGridStyles_();

--- a/extensions/amp-story/0.1/amp-story-grid-layer.js
+++ b/extensions/amp-story/0.1/amp-story-grid-layer.js
@@ -26,7 +26,7 @@
  * </code>
  */
 
-import {AmpBaseLayer} from './amp-story-base-layer';
+import {AmpStoryBaseLayer} from './amp-story-base-layer';
 import {matches, scopedQuerySelectorAll} from '../../../src/dom';
 
 /**
@@ -72,7 +72,7 @@ const TEMPLATE_CLASS_NAMES = {
   'thirds': 'i-amphtml-story-grid-template-thirds',
 };
 
-export class AmpStoryGridLayer extends AmpBaseLayer {
+export class AmpStoryGridLayer extends AmpStoryBaseLayer {
   /** @param {!AmpElement} element */
   constructor(element) {
     super(element);

--- a/extensions/amp-story/0.1/amp-story-grid-layer.js
+++ b/extensions/amp-story/0.1/amp-story-grid-layer.js
@@ -28,6 +28,7 @@
 
 import {Layout} from '../../../src/layout';
 import {matches, scopedQuerySelectorAll} from '../../../src/dom';
+import { AmpBaseLayer } from './amp-story-base-layer';
 
 /**
  * A mapping of attribute names we support for grid layers to the CSS Grid
@@ -72,7 +73,7 @@ const TEMPLATE_CLASS_NAMES = {
   'thirds': 'i-amphtml-story-grid-template-thirds',
 };
 
-export class AmpStoryGridLayer extends AMP.BaseElement {
+export class AmpStoryGridLayer extends AmpBaseLayer {
   /** @param {!AmpElement} element */
   constructor(element) {
     super(element);
@@ -155,11 +156,6 @@ export class AmpStoryGridLayer extends AMP.BaseElement {
         element.removeAttribute(attributeName);
       }
     }
-  }
-
-  /** @override */
-  isLayoutSupported(layout) {
-    return layout == Layout.CONTAINER;
   }
 }
 

--- a/extensions/amp-story/0.1/amp-story.css
+++ b/extensions/amp-story/0.1/amp-story.css
@@ -268,24 +268,23 @@ amp-story:not([desktop]) >
   z-index: 2 !important;
 }
 
+.i-amphtml-story-layer, amp-story-cta-layer, amp-story-grid-layer {
+  bottom: 0 !important;
+  left: 0 !important;
+  right: 0 !important;
+  position: absolute !important;
+}
+
 /** Call to action layer */
 amp-story-cta-layer {
-  bottom: 0 !important;
   display: block !important;
   height: 20% !important;
-  left: 0 !important;
-  position: absolute !important;
-  right: 0 !important;
   z-index: 3 !important;
 }
 
 /** Grid level */
 amp-story-grid-layer {
-  bottom: 0 !important;
   display: grid !important;
-  left: 0 !important;
-  position: absolute !important;
-  right: 0 !important;
   top: 0 !important;
   z-index: 2 !important;
 }

--- a/extensions/amp-story/0.1/amp-story.css
+++ b/extensions/amp-story/0.1/amp-story.css
@@ -268,7 +268,7 @@ amp-story:not([desktop]) >
   z-index: 2 !important;
 }
 
-.i-amphtml-story-layer, amp-story-cta-layer, amp-story-grid-layer {
+amp-story-cta-layer, amp-story-grid-layer {
   bottom: 0 !important;
   left: 0 !important;
   right: 0 !important;


### PR DESCRIPTION
Fixes #13710

Addition of a new base class for amp-story layers. Right now there are two layers `AmpStoryCtaLayer` and `AmpStoryGridLayer`.

This will make them share an implementation so that other components have a way to get all layers if they need to do so.

