### PR TITLE
🐛Register the actions in buildCallback so they are available before the first activation

### DIFF
--- a/extensions/amp-lightbox/0.1/amp-lightbox.js
+++ b/extensions/amp-lightbox/0.1/amp-lightbox.js
@@ -92,6 +92,9 @@ class AmpLightbox extends AMP.BaseElement {
     this.element.classList.add('i-amphtml-overlay');
     this.action_ = Services.actionServiceForDoc(this.element);
     this.maybeSetTransparentBody_();
+
+    this.registerAction('open', this.activate.bind(this));
+    this.registerAction('close', this.close.bind(this));
   }
 
   /** @override */
@@ -159,9 +162,6 @@ class AmpLightbox extends AMP.BaseElement {
 
       this.element.addEventListener('scroll', this.scrollHandler_.bind(this));
     }
-
-    this.registerAction('open', this.activate.bind(this));
-    this.registerAction('close', this.close.bind(this));
 
     if (!this.isScrollable_) {
       const gestures = Gestures.get(this.element);


### PR DESCRIPTION
Fixes #13755

I don't think there are any downsides to moving these calls to `buildCallback`. `amp-accordion` registers actions in `buildCallback` as well so there is precedence.