### PR TITLE
🏗 Make visual tests more resilient to Selenium read timeouts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
   - sh -e /etc/init.d/xvfb start
 before_script:
   - pip install --user protobuf
-  - gem install percy-capybara poltergeist selenium-webdriver chromedriver-helper
+  - gem install percy-capybara capybara selenium-webdriver chromedriver-helper rspec-retry
   - ./node_modules/.bin/greenkeeper-lockfile-update
 script: node build-system/pr-check.js
 after_script: ./node_modules/.bin/greenkeeper-lockfile-upload


### PR DESCRIPTION
We're seeing several visual test failures due to Selenium read timeouts. This PR implements the fix suggested in https://github.com/ampproject/amphtml/issues/13700#issuecomment-369094066

Speculative fix for #13700