### PR TITLE
Simplify getTimingDataAsync

### DIFF
--- a/src/service/variable-source.js
+++ b/src/service/variable-source.js
@@ -42,14 +42,9 @@ let ReplacementDef;
  * @return {!Promise<ResolverReturnDef>}
  */
 export function getTimingDataAsync(win, startEvent, endEvent) {
-  const metric = getTimingDataSync(win, startEvent, endEvent);
-  if (metric === '') {
-    // Metric is not yet available. Retry after a delay.
-    return loadPromise(win).then(() => {
-      return getTimingDataSync(win, startEvent, endEvent);
-    });
-  }
-  return Promise.resolve(metric);
+  return loadPromise(win).then(() => {
+    return getTimingDataSync(win, startEvent, endEvent);
+  });
 }
 
 /**
@@ -75,11 +70,9 @@ export function getTimingDataSync(win, startEvent, endEvent) {
     ? timingInfo[startEvent]
     : timingInfo[endEvent] - timingInfo[startEvent];
 
-  if (!isFiniteNumber(metric)) {
+  if (!isFiniteNumber(metric) || metric < 0) {
     // The metric is not supported.
     return;
-  } else if (metric < 0) {
-    return '';
   } else {
     return metric;
   }

--- a/test/functional/test-variable-source.js
+++ b/test/functional/test-variable-source.js
@@ -126,4 +126,29 @@ describes.fakeWin('VariableSource', {
     });
 
   });
+
+  describes.fakeWin('getTimingData', {}, env => {
+    let win;
+ 
+    beforeEach(() => {
+      win = env.win;
+      win.performance = {
+        timing: {
+          navigationStart: 1,
+          loadEventStart: 0,
+        },
+      };
+    });
+ 
+    it('should wait for load event', () => {
+      win.readyState = 'other';
+      const p = getTimingDataAsync(win, 'navigationStart', 'loadEventStart');
+      expect(win.eventListeners.count('load')).to.equal(1);
+      win.performance.timing.loadEventStart = 12;
+      win.eventListeners.fire({type: 'load'});
+      return p.then(value => {
+        expect(value).to.equal(11);
+      });
+    });
+  });
 });

--- a/test/functional/test-variable-source.js
+++ b/test/functional/test-variable-source.js
@@ -129,7 +129,7 @@ describes.fakeWin('VariableSource', {
 
   describes.fakeWin('getTimingData', {}, env => {
     let win;
- 
+
     beforeEach(() => {
       win = env.win;
       win.performance = {
@@ -139,7 +139,7 @@ describes.fakeWin('VariableSource', {
         },
       };
     });
- 
+
     it('should wait for load event', () => {
       win.readyState = 'other';
       const p = getTimingDataAsync(win, 'navigationStart', 'loadEventStart');

--- a/test/functional/test-variable-source.js
+++ b/test/functional/test-variable-source.js
@@ -126,37 +126,4 @@ describes.fakeWin('VariableSource', {
     });
 
   });
-
-  describes.fakeWin('getTimingData', {}, env => {
-    let win;
-
-    beforeEach(() => {
-      win = env.win;
-      win.performance = {
-        timing: {
-          navigationStart: 1,
-          loadEventStart: 0,
-        },
-      };
-    });
-
-    it('should resolve immediate when data is ready', () => {
-      win.performance.timing.loadEventStart = 12;
-      return getTimingDataAsync(win, 'navigationStart', 'loadEventStart')
-          .then(value => {
-            expect(value).to.equal(11);
-          });
-    });
-
-    it('should wait for load event', () => {
-      win.readyState = 'other';
-      const p = getTimingDataAsync(win, 'navigationStart', 'loadEventStart');
-      expect(win.eventListeners.count('load')).to.equal(1);
-      win.performance.timing.loadEventStart = 12;
-      win.eventListeners.fire({type: 'load'});
-      return p.then(value => {
-        expect(value).to.equal(11);
-      });
-    });
-  });
 });


### PR DESCRIPTION
In the already-loaded case, the delay from an already resolved promise is inconsequential. Let's save space.