### PR TITLE
13174 ampstory desktop viewport warning

### DIFF
--- a/extensions/amp-story/0.1/amp-story.css
+++ b/extensions/amp-story/0.1/amp-story.css
@@ -948,6 +948,7 @@ amp-story .i-amphtml-story-unsupported-browser-overlay {
 }
 
 amp-story .i-amphtml-rotate-icon,
+amp-story .i-amphtml-desktop-size-icon,
 amp-story .i-amphtml-gear-icon {
   background-repeat: no-repeat!important;
   background-position: center center!important;
@@ -965,6 +966,10 @@ amp-story .i-amphtml-rotate-icon {
 
 amp-story .i-amphtml-gear-icon {
   background-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" viewBox="0 0 20 20" fill="#000000"><path fill="none" d="M0 0h20v20H0V0z"/><path d="M15.95 10.78c.03-.25.05-.51.05-.78s-.02-.53-.06-.78l1.69-1.32c.15-.12.19-.34.1-.51l-1.6-2.77c-.1-.18-.31-.24-.49-.18l-1.99.8c-.42-.32-.86-.58-1.35-.78L12 2.34c-.03-.2-.2-.34-.4-.34H8.4c-.2 0-.36.14-.39.34l-.3 2.12c-.49.2-.94.47-1.35.78l-1.99-.8c-.18-.07-.39 0-.49.18l-1.6 2.77c-.1.18-.06.39.1.51l1.69 1.32c-.04.25-.07.52-.07.78s.02.53.06.78L2.37 12.1c-.15.12-.19.34-.1.51l1.6 2.77c.1.18.31.24.49.18l1.99-.8c.42.32.86.58 1.35.78l.3 2.12c.04.2.2.34.4.34h3.2c.2 0 .37-.14.39-.34l.3-2.12c.49-.2.94-.47 1.35-.78l1.99.8c.18.07.39 0 .49-.18l1.6-2.77c.1-.18.06-.39-.1-.51l-1.67-1.32zM10 13c-1.65 0-3-1.35-3-3s1.35-3 3-3 3 1.35 3 3-1.35 3-3 3z"/></svg>')!important;
+}
+
+amp-story .i-amphtml-desktop-size-icon {
+  background-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" viewBox="0 0 24 24" fill="#000000"><path d="M0 0h24v24H0z" fill="none"/><path d="M12.01 5.5L10 8h4l-1.99-2.5zM18 10v4l2.5-1.99L18 10zM6 10l-2.5 2.01L6 14v-4zm8 6h-4l2.01 2.5L14 16zm7-13H3c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h18c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16.01H3V4.99h18v14.02z"/></svg>')!important;
 }
 
 amp-story .i-amphtml-story-overlay-text {

--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -165,6 +165,31 @@ const LANDSCAPE_ORIENTATION_WARNING = [
   },
 ];
 
+const DESKTOP_SIZE_WARNING = [
+  {
+    tag: 'div',
+    attrs: dict({
+      'class': 'i-amphtml-story-no-rotation-overlay ' +
+          'i-amphtml-story-system-reset'}),
+    children: [
+      {
+        tag: 'div',
+        attrs: dict({'class': 'i-amphtml-overlay-container'}),
+        children: [
+          {
+            tag: 'div',
+            attrs: dict({'class': 'i-amphtml-desktop-size-icon'}),
+          },
+          {
+            tag: 'div',
+            attrs: dict({'class': 'i-amphtml-story-overlay-text'}),
+            text: 'Expand your window to view this experience',
+          },
+        ],
+      },
+    ],
+  },
+];
 
 const UNSUPPORTED_BROWSER_WARNING = [
   {
@@ -945,6 +970,16 @@ export class AmpStory extends AMP.BaseElement {
         this.desktopMedia_.matches;
   }
 
+  /**
+   * Return right overlay for mobile or desktop
+   */
+  viewportWarningOverlay_() {
+    const platform = Services.platformFor(this.win);
+
+    return (platform.isIos() || platform.isAndroid())
+      ? LANDSCAPE_ORIENTATION_WARNING
+      : DESKTOP_SIZE_WARNING;
+  }
 
   /**
    * Build overlay for Landscape mode mobile
@@ -953,11 +988,10 @@ export class AmpStory extends AMP.BaseElement {
     this.mutateElement(() => {
       this.element.insertBefore(
           renderSimpleTemplate(this.win.document,
-              LANDSCAPE_ORIENTATION_WARNING),
+              this.viewportWarningOverlay_()),
           this.element.firstChild);
     });
   }
-
 
   /**
    * Build overlay for Landscape mode mobile


### PR DESCRIPTION
**Provide a different message when viewport is too small for amp-story on desktop**

Closes #13174  ✨ 

At runtime detect the device via [Services.Platform().isIos()](https://github.com/ampproject/amphtml/blob/6e2a5d310b940f91834655cdc048e5252d9bd766/src/service/platform-impl.js#L46) and [.isAndroid()](https://github.com/ampproject/amphtml/blob/6e2a5d310b940f91834655cdc048e5252d9bd766/src/service/platform-impl.js#L38) and build the correct overlay.

As far as I can see that's probably all that needs to change.  The existing [onResize()](https://github.com/ampproject/amphtml/blob/6e2a5d310b940f91834655cdc048e5252d9bd766/extensions/amp-story/0.1/amp-story.js#L913) method detects if the window is greater than 1024px wide and disables the overlay.  If it's less than 1024px wide then it checks to see if the height is less than the width and then displays the overlay.

I believe that satisfies the conditions laid out by @newmuis in the [issue](https://github.com/ampproject/amphtml/issues/13174) but happy to get feedback!

p.s: The overlay is not rebuilt on resize, you will need to refresh the page when switching to and from emulators in the browser to build the right overlay.  I felt like that was acceptable as it keeps the code smaller and simpler, but again, open to feedback.

https://github.com/ampproject/amphtml/blob/6e2a5d310b940f91834655cdc048e5252d9bd766/extensions/amp-story/0.1/amp-story.js#L913-L940
