### PR TITLE
inabox: add window.AMP.inaboxUnregisterIframe(iframe)

### DIFF
--- a/ads/inabox/inabox-host.js
+++ b/ads/inabox/inabox-host.js
@@ -31,6 +31,8 @@ const AMP_INABOX_INITIALIZED = 'ampInaboxInitialized';
 const PENDING_MESSAGES = 'ampInaboxPendingMessages';
 /** @const {string} */
 const INABOX_IFRAMES = 'ampInaboxIframes';
+//* @const {string} */
+const INABOX_UNREGISTER_IFRAME = 'inaboxUnregisterIframe';
 
 /**
  * Class for initializing host script and consuming queued messages.
@@ -56,6 +58,14 @@ export class InaboxHost {
       win[INABOX_IFRAMES] = [];
     }
     const host = new InaboxMessagingHost(win, win[INABOX_IFRAMES]);
+    win.AMP = win.AMP || {};
+    if (win.AMP[INABOX_UNREGISTER_IFRAME]) {
+      // It's already defined; log a debug message and assume the existing
+      // implmentation is good.
+      dev().info(TAG, `win.AMP[${INABOX_UNREGISTER_IFRAME}] already defined}`);
+    } else {
+      win.AMP[INABOX_UNREGISTER_IFRAME] = host.unregisterIframe.bind(host);
+    }
 
     const queuedMsgs = win[PENDING_MESSAGES];
     if (queuedMsgs) {

--- a/ads/inabox/inabox-messaging-host.js
+++ b/ads/inabox/inabox-messaging-host.js
@@ -65,6 +65,10 @@ class NamedObservable {
 
 export class InaboxMessagingHost {
 
+  /**
+   * @param win {!Window}
+   * @param iframes {!Array<!HTMLIFrameElement>}
+   */
   constructor(win, iframes) {
     this.win_ = win;
     this.iframes_ = iframes;
@@ -139,13 +143,13 @@ export class InaboxMessagingHost {
       return true;
     }
 
-    const positionObserverHandle = this.positionObserver_.observe(
+    const observeUnregisterFn = this.positionObserver_.observe(
         iframe, data => {
           this.sendPosition_(request, source, origin, data);
         }
     );
     this.registeredIframeSentinels_[request.sentinel] = {
-      iframe, positionObserverHandle};
+      iframe, observeUnregisterFn};
     return true;
   }
 
@@ -321,8 +325,7 @@ export class InaboxMessagingHost {
     // And the position observer listener.
     for (const sentinel in this.registeredIframeSentinels_) {
       if (iframe == this.registeredIframeSentinels_[sentinel].iframe) {
-        this.positionObserver_.stopObserving(
-            this.registeredIframeSentinels_[sentinel].positionObserverHandle);
+        this.registeredIframeSentinels_[sentinel].observeUnregisterFn();
         delete this.registeredIframeSentinels_[sentinel];
       }
     }

--- a/ads/inabox/position-observer.js
+++ b/ads/inabox/position-observer.js
@@ -52,8 +52,12 @@ export class PositionObserver {
   /**
    * Start to observe the target element's position change and trigger callback.
    * TODO: maybe take DOM mutation into consideration
+   *
+   * Returns a handle that can be passed to stopObserving().
+   *
    * @param element {!Element}
    * @param callback {function(!PositionEntryDef)}
+   * @returns {function}
    */
   observe(element, callback) {
     if (!this.positionObservable_) {
@@ -68,9 +72,20 @@ export class PositionObserver {
     }
     // Send the 1st ping immediately
     callback(this.getPositionEntry_(element));
-    this.positionObservable_.add(() => {
+    const positionObservationHandler = (() => {
       callback(this.getPositionEntry_(element));
     });
+    this.positionObservable_.add(positionObservationHandler);
+    return positionObservationHandler;
+  }
+
+  /**
+   * Undoes a call to observe().
+   *
+   * @param handler {function}  The handler returned from observe().
+   */
+  stopObserving(handler) {
+    this.positionObservable_.remove(handler);
   }
 
   update_() {

--- a/ads/inabox/position-observer.js
+++ b/ads/inabox/position-observer.js
@@ -53,11 +53,11 @@ export class PositionObserver {
    * Start to observe the target element's position change and trigger callback.
    * TODO: maybe take DOM mutation into consideration
    *
-   * Returns a handle that can be passed to stopObserving().
+   * Returns function that can be called to stop obeserving this target.
    *
    * @param element {!Element}
    * @param callback {function(!PositionEntryDef)}
-   * @returns {function}
+   * @returns {!UnlistenDef}
    */
   observe(element, callback) {
     if (!this.positionObservable_) {
@@ -72,20 +72,9 @@ export class PositionObserver {
     }
     // Send the 1st ping immediately
     callback(this.getPositionEntry_(element));
-    const positionObservationHandler = (() => {
+    return this.positionObservable_.add(() => {
       callback(this.getPositionEntry_(element));
     });
-    this.positionObservable_.add(positionObservationHandler);
-    return positionObservationHandler;
-  }
-
-  /**
-   * Undoes a call to observe().
-   *
-   * @param handler {function}  The handler returned from observe().
-   */
-  stopObserving(handler) {
-    this.positionObservable_.remove(handler);
   }
 
   update_() {

--- a/examples/inabox.host.memory.html
+++ b/examples/inabox.host.memory.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <title>amp-inabox-host example</title>
+  <style>
+    body {
+      font-size: 1.2em;
+    }
+  </style>
+</head>
+<body>
+  <h2>
+    This page tests amp-inabox memory usage on refresh. Follow the instructions
+    below.
+  </h2>
+  <hr>
+  <h3>Inabox above the fold</h3>
+  <div>
+    Open the Task Manager (Shift+ESC) and turn on tracking JavaScript memory
+    (right click table header, select JavaScript memory).  The "live" portion
+    shouldn't just climb and climb, but bounce around near a single number.
+  </div>
+
+  <script>
+    let n = 0;
+    let iframe = null;
+    window.ampInaboxIframes = window.ampInaboxIframes || [];
+    function make_ad_iframe() {
+      iframe = document.createElement('iframe');
+      iframe.name = 'iframe-' + n;
+      n++;
+      iframe.src = '//ads.localhost:8000/examples/inabox.amp.html';
+      iframe.scrolling = 'no';
+      iframe.width = 300;
+      iframe.height = 200;
+      window.ampInaboxIframes.push(iframe);
+      document.body.appendChild(iframe);
+    }
+    function remove_ad_iframe() {
+      if (!window.AMP) {
+        console.log("window.AMP not defined");
+      } else {
+        window.AMP.inaboxUnregisterIframe(iframe);
+      }
+      iframe.remove();
+    }
+    function repeatedly_replace_ad_iframe() {
+      make_ad_iframe();
+      window.setTimeout(() => {
+        remove_ad_iframe(iframe);
+        repeatedly_replace_ad_iframe();
+      }, 1000);
+    }
+    repeatedly_replace_ad_iframe();
+  </script>
+  <script src="./inabox-tag-integration.js"></script>
+</body>

--- a/test/functional/inabox/test-inabox-messaging-host.js
+++ b/test/functional/inabox/test-inabox-messaging-host.js
@@ -405,7 +405,7 @@ describes.realWin('inabox-host:messaging', {}, env => {
     });
   });
 
-  describe.only('unregisterIframe', () => {
+  describe('unregisterIframe', () => {
     it('unregisters frames', () => {
       const iframeObjA = createNestedIframeMocks(6,3);
       const frameMockA = iframeObjA.topWin.document.querySelectorAll()[0];


### PR DESCRIPTION
The current API for inabox is that when you want to remove a frame you delete it
from ampInaboxIframes.  This means there isn't a way for inabox to run any
additional cleanup on frame removal, and currently there's a memory leak where
references to iframes (or their descendents) are maintained indefinitely in
InaboxMessagingHost.iframeMap_ and in the position observation listeners.

This changes the API from 'delete from a list of frames' to 'call a function',
which allows the function to do arbitrary cleanup like removing references.

I'm not that happy with the test, since it runs in a very mocked environment.
To test this manually I've added examples/inabox.host.memory.html which
repeatedly adds an iframe and removes it again.  This initially showed us as
leaking about 4MB of memory per refresh (desktop chrome; silly fake ad) but now
doesn't show any leaking.