### PR TITLE
🐛Fixes error in document.contains polyfill in IE 10 (#13768)

### DIFF
--- a/src/polyfills/document-contains.js
+++ b/src/polyfills/document-contains.js
@@ -36,8 +36,9 @@ function documentContainsPolyfill(node) {
  * @param {!Window} win
  */
 export function install(win) {
-  if (!win.HTMLDocument.prototype.contains) {
-    win.Object.defineProperty(win.HTMLDocument.prototype, 'contains', {
+  const documentClass = win.HTMLDocument || win.Document;
+  if (!documentClass.prototype.contains) {
+    win.Object.defineProperty(documentClass.prototype, 'contains', {
       enumerable: false,
       configurable: true,
       writable: true,

--- a/src/polyfills/document-contains.js
+++ b/src/polyfills/document-contains.js
@@ -36,6 +36,8 @@ function documentContainsPolyfill(node) {
  * @param {!Window} win
  */
 export function install(win) {
+  // HTMLDocument is undefined in Internet Explorer 10, but it has Document,
+  // so we use that as a fallback.
   const documentClass = win.HTMLDocument || win.Document;
   if (!documentClass.prototype.contains) {
     win.Object.defineProperty(documentClass.prototype, 'contains', {


### PR DESCRIPTION
In IE 10 `window.HTMLDocument` is not available, so accessing its `prototype` property gives an error.  With this patch it will fall back to using `window.Document` instead.

Fixes #13768.