### PR TITLE
[Prototype] Slightly more generous animations for lightbox

### DIFF
--- a/extensions/amp-image-viewer/0.1/amp-image-viewer.js
+++ b/extensions/amp-image-viewer/0.1/amp-image-viewer.js
@@ -226,7 +226,7 @@ export class AmpImageViewer extends AMP.BaseElement {
   }
 
   /**
-   * Returns the boundaries of the image element.
+   * Returns the image element.
    * @return {?Element}
    */
   getImage() {

--- a/src/transition.js
+++ b/src/transition.js
@@ -201,11 +201,15 @@ export function translate(transitionX, opt_transitionY) {
 
 /**
  * A transition for "scale" of CSS "transform" property.
- * @param {!TransitionDef<number|string>} transition
+ * @param {!TransitionDef<number|string>} transitionX
+ * @param {!TransitionDef<number|string>|undefined=} opt_transitionY
  * @return {!TransitionDef<string>}
  */
-export function scale(transition) {
+export function scale(transitionX, opt_transitionY) {
   return time => {
-    return `scale(${transition(time)})`;
+    if (!opt_transitionY) {
+      return `scale(${transitionX(time)})`;
+    }
+    return `scale(${transitionX(time)}, ${opt_transitionY(time)})`;
   };
 }


### PR DESCRIPTION
Not intended for merge. Possible revisit after `<amp-image-viewer>` becomes more mature. 

Prototype for addressing #13039 and #12385. Experimented with trying to animate images uncropping for mismatched aspect ratios. The blocker here is that we can't maintain `object-fit` over hardware accelerated CSS transforms so the images look off. 
Codepen illustrating problem: https://codepen.io/cathyxz/pen/mXgEMB

Mostly sadness until we: 
1. Decide to propagate object-fit into `<amp-image-viewer>` (this is a possible discussion). 
2. Get performant animations on `width` and `height`, which is super unlikely. =( 




