### PR TITLE
inabox: add window.AMP.inaboxUnregisterIframe(iframe)

### DIFF
--- a/ads/inabox/inabox-host.js
+++ b/ads/inabox/inabox-host.js
@@ -58,7 +58,7 @@ export class InaboxHost {
       win[INABOX_IFRAMES] = [];
     }
     const host = new InaboxMessagingHost(win, win[INABOX_IFRAMES]);
-
+    win.AMP = win.AMP || {};
     if (win.AMP[INABOX_UNREGISTER_IFRAME]) {
       // It's already defined; log a debug message and assume the existing
       // implmentation is good.

--- a/ads/inabox/inabox-host.js
+++ b/ads/inabox/inabox-host.js
@@ -31,6 +31,8 @@ const AMP_INABOX_INITIALIZED = 'ampInaboxInitialized';
 const PENDING_MESSAGES = 'ampInaboxPendingMessages';
 /** @const {string} */
 const INABOX_IFRAMES = 'ampInaboxIframes';
+/** @const {string} */
+const INABOX_UNREGISTER_IFRAME = 'inaboxUnregisterIframe';
 
 /**
  * Class for initializing host script and consuming queued messages.
@@ -57,6 +59,13 @@ export class InaboxHost {
     }
     const host = new InaboxMessagingHost(win, win[INABOX_IFRAMES]);
 
+    if (win.AMP[INABOX_UNREGISTER_IFRAME]) {
+      // It's already defined; log a debug message and assume the existing
+      // implmentation is good.
+      dev().info(TAG, `win.AMP[${INABOX_UNREGISTER_IFRAME}] already defined}`);
+    } else {
+      win.AMP[INABOX_UNREGISTER_IFRAME] = host.unregisterIframe.bind(host);
+    }
     const queuedMsgs = win[PENDING_MESSAGES];
     if (queuedMsgs) {
       if (Array.isArray(queuedMsgs)) {

--- a/ads/inabox/inabox-messaging-host.js
+++ b/ads/inabox/inabox-messaging-host.js
@@ -64,7 +64,7 @@ class NamedObservable {
 
 /** @typedef {{
       iframe: !HTMLIFrameElement,
-      measureableFrame: !HTMLIFrameElement,
+      measurableFrame: !HTMLIFrameElement,
       observeUnregisterFn: (!UnlistenDef|undefined),
   }} */
 let AdFrameDef;
@@ -252,18 +252,18 @@ export class InaboxMessagingHost {
    */
   getFrameElement_(source, sentinel) {
     if (this.iframeMap_[sentinel]) {
-      return this.iframeMap_[sentinel].measureableFrame;
+      return this.iframeMap_[sentinel].measurableFrame;
     }
-    const measureableFrame =
+    const measurableFrame =
         /** @type {HTMLIFrameElement} */(this.getMeasureableFrame(source));
-    const measureableWin = measureableFrame.contentWindow;
+    const measurableWin = measurableFrame.contentWindow;
     for (let i = 0; i < this.iframes_.length; i++) {
       const iframe = this.iframes_[i];
-      for (let j = 0, tempWin = measureableWin;
+      for (let j = 0, tempWin = measurableWin;
         j < 10; j++, tempWin = tempWin.parent) {
         if (iframe.contentWindow == tempWin) {
-          this.iframeMap_[sentinel] = {iframe, measureableFrame};
-          return measureableFrame;
+          this.iframeMap_[sentinel] = {iframe, measurableFrame};
+          return measurableFrame;
         }
         if (tempWin == window.top) {
           break;

--- a/test/functional/inabox/test-inabox-messaging-host.js
+++ b/test/functional/inabox/test-inabox-messaging-host.js
@@ -413,9 +413,11 @@ describes.realWin('inabox-host:messaging', {}, env => {
       const frameMockB = iframeObjB.topWin.document.querySelectorAll()[0];
       const iframeObjC = createNestedIframeMocks(6,0);
       const frameMockC = iframeObjC.topWin.document.querySelectorAll()[0];
+      const observeUnregisterMock = sandbox.spy();
       host = new InaboxMessagingHost(win, [frameMockA, frameMockB, frameMockC]);
       host.getFrameElement_(iframeObjA.source, 'sentinelA');
       host.getFrameElement_(iframeObjB.source, 'sentinelB');
+      host.iframeMap_['sentinelB'].observeUnregisterFn = observeUnregisterMock;
       host.getFrameElement_(iframeObjC.source, 'sentinelC');
       expect(host.iframes_.length).to.equal(3);
       expect('sentinelA' in host.iframeMap_).to.be.true;
@@ -426,14 +428,17 @@ describes.realWin('inabox-host:messaging', {}, env => {
       expect('sentinelA' in host.iframeMap_).to.be.false;
       expect('sentinelB' in host.iframeMap_).to.be.true;
       expect('sentinelC' in host.iframeMap_).to.be.true;
+      expect(observeUnregisterMock).to.not.be.called;
       host.unregisterIframe(frameMockB);
       expect(host.iframes_.length).to.equal(1);
       expect('sentinelA' in host.iframeMap_).to.be.false;
       expect('sentinelB' in host.iframeMap_).to.be.false;
       expect('sentinelC' in host.iframeMap_).to.be.true;
+      expect(observeUnregisterMock).to.be.calledOnce;
       host.unregisterIframe(frameMockC);
       expect(host.iframes_).to.be.empty;
       expect(host.iframeMap_).to.be.empty;
+      expect(observeUnregisterMock).to.be.calledOnce;
     });
 
     it('no errors or effects if called with a non-registered iframe', () => {

--- a/test/functional/inabox/test-inabox-messaging-host.js
+++ b/test/functional/inabox/test-inabox-messaging-host.js
@@ -383,7 +383,8 @@ describes.realWin('inabox-host:messaging', {}, env => {
       };
       const creativeWinMock = {};
       const creativeIframeMock = {};
-      host.iframeMap_[sentinel] = creativeIframeMock;
+      host.iframeMap_[sentinel] = {
+        'iframe': creativeIframeMock, 'measurableFrame': creativeIframeMock};
       expect(host.getFrameElement_(creativeWinMock, sentinel)
       ).to.equal(creativeIframeMock);
     });
@@ -401,6 +402,48 @@ describes.realWin('inabox-host:messaging', {}, env => {
       const frameMock = topWinMock.document.querySelectorAll()[0];
       host = new InaboxMessagingHost(win, [frameMock]);
       expect(host.getFrameElement_(sourceMock, sentinel)).to.be.null;
+    });
+  });
+
+  describe('unregisterIframe', () => {
+    it('unregisters frames', () => {
+      const iframeObjA = createNestedIframeMocks(6,3);
+      const frameMockA = iframeObjA.topWin.document.querySelectorAll()[0];
+      const iframeObjB = createNestedIframeMocks(6,6);
+      const frameMockB = iframeObjB.topWin.document.querySelectorAll()[0];
+      const iframeObjC = createNestedIframeMocks(6,0);
+      const frameMockC = iframeObjC.topWin.document.querySelectorAll()[0];
+      host = new InaboxMessagingHost(win, [frameMockA, frameMockB, frameMockC]);
+      host.getFrameElement_(iframeObjA.source, 'sentinelA');
+      host.getFrameElement_(iframeObjB.source, 'sentinelB');
+      host.getFrameElement_(iframeObjC.source, 'sentinelC');
+      expect(host.iframes_.length).to.equal(3);
+      expect('sentinelA' in host.iframeMap_).to.be.true;
+      expect('sentinelB' in host.iframeMap_).to.be.true;
+      expect('sentinelC' in host.iframeMap_).to.be.true;
+      host.unregisterIframe(frameMockA);
+      expect(host.iframes_.length).to.equal(2);
+      expect('sentinelA' in host.iframeMap_).to.be.false;
+      expect('sentinelB' in host.iframeMap_).to.be.true;
+      expect('sentinelC' in host.iframeMap_).to.be.true;
+      host.unregisterIframe(frameMockB);
+      expect(host.iframes_.length).to.equal(1);
+      expect('sentinelA' in host.iframeMap_).to.be.false;
+      expect('sentinelB' in host.iframeMap_).to.be.false;
+      expect('sentinelC' in host.iframeMap_).to.be.true;
+      host.unregisterIframe(frameMockC);
+      expect(host.iframes_).to.be.empty;
+      expect(host.iframeMap_).to.be.empty;
+    });
+
+    it('no errors or effects if called with a non-registered iframe', () => {
+      const iframeObj = createNestedIframeMocks(6,3);
+      const frameMock = iframeObj.topWin.document.querySelectorAll()[0];
+      host = new InaboxMessagingHost(win, [frameMock]);
+      host.getFrameElement_(iframeObj.source, 'sentinelA');
+      host.unregisterIframe(createNestedIframeMocks(1,1));
+      expect(host.iframes_.length).to.equal(1);
+      expect('sentinelA' in host.iframeMap_).to.be.true;
     });
   });
 });

--- a/test/functional/inabox/test-inabox-messaging-host.js
+++ b/test/functional/inabox/test-inabox-messaging-host.js
@@ -407,6 +407,7 @@ describes.realWin('inabox-host:messaging', {}, env => {
 
   describe('unregisterIframe', () => {
     it('unregisters frames', () => {
+      // Setup 3 frames with mock sentinel values.
       const iframeObjA = createNestedIframeMocks(6,3);
       const frameMockA = iframeObjA.topWin.document.querySelectorAll()[0];
       const iframeObjB = createNestedIframeMocks(6,6);
@@ -423,6 +424,7 @@ describes.realWin('inabox-host:messaging', {}, env => {
       expect('sentinelA' in host.iframeMap_).to.be.true;
       expect('sentinelB' in host.iframeMap_).to.be.true;
       expect('sentinelC' in host.iframeMap_).to.be.true;
+      // Unregister each frame one at a time and verify state.
       host.unregisterIframe(frameMockA);
       expect(host.iframes_.length).to.equal(2);
       expect('sentinelA' in host.iframeMap_).to.be.false;


### PR DESCRIPTION
Clone of #13776 as Jeff OOTO.  Modified to centralize state in single map to ease cleanup and future additions.

The current API for inabox is that when you want to remove a frame you delete it
from ampInaboxIframes. This means there isn't a way for inabox to run any
additional cleanup on frame removal, and currently there's a memory leak where
references to iframes (or their descendents) are maintained indefinitely in
InaboxMessagingHost.iframeMap_ and in the position observation listeners.

This changes the API from 'delete from a list of frames' to 'call a function',
which allows the function to do arbitrary cleanup like removing references.