### PR TITLE
Fix story desktop share-pill styles overriding before we use shadow DOM.

### DIFF
--- a/extensions/amp-story/0.1/amp-story-desktop.css
+++ b/extensions/amp-story/0.1/amp-story-desktop.css
@@ -297,7 +297,7 @@ amp-story[standalone][desktop] {
 }
 
 /* Top bar */
-.i-amphtml-story-top {
+div.i-amphtml-story-top {
   position: relative!important;
   display: block!important;
   height: 96px!important;
@@ -334,6 +334,7 @@ amp-story[standalone][desktop] {
   letter-spacing: .5px!important;
   margin: auto!important;
   color:#fff!important;
+  box-sizing: initial !important;
 }
 
 /* background for the share box */
@@ -345,6 +346,7 @@ amp-story[standalone][desktop] {
   padding: 0 16px!important;
   background-color: rgba(255, 255, 255, .2)!important;
   border-radius: 500px!important;
+  box-sizing: initial !important;
   transition: width 300ms ease-in-out!important;
   right: 0!important;
 }

--- a/extensions/amp-story/0.1/amp-story.css
+++ b/extensions/amp-story/0.1/amp-story.css
@@ -28,6 +28,7 @@ amp-story, amp-story-page, amp-story-grid-layer, amp-story-cta-layer {
 .i-amphtml-story-system-reset,
 .i-amphtml-story-system-reset * {
   border: none !important;
+  box-sizing: initial !important;
   color: initial !important;
   font-family: 'Roboto', sans-serif !important;
   font-size: initial !important;

--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -548,7 +548,8 @@ export class AmpStory extends AMP.BaseElement {
     const doc = this.element.ownerDocument;
 
     this.topBar_ = doc.createElement('div');
-    this.topBar_.classList.add('i-amphtml-story-top');
+    this.topBar_.classList.add(
+        'i-amphtml-story-top', 'i-amphtml-story-system-reset');
     this.topBar_.appendChild(this.buildTopBarShare_());
 
     this.element.insertBefore(this.topBar_, this.element.firstChild);


### PR DESCRIPTION
Fix story desktop share-pill styles overriding before we use shadow DOM.

Desktop sharing button was broken when publishers were using:

````
*::before {
  box-sizing: border-box;
}
````