### PR TITLE
Create new experiment to ignore remote.html

### DIFF
--- a/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
@@ -149,7 +149,8 @@ export class DoubleclickA4aEligibility {
     const urlExperimentId = extractUrlExperimentId(win, element);
     if (hasUSDRD || (useRemoteHtml &&
                      !element.getAttribute('rtc-config') &&
-                     urlExperimentId != '10')) {
+                     URL_EXPERIMENT_MAPPING[urlExperimentId] !=
+                     DOUBLECLICK_EXPERIMENT_FEATURE.REMOTE_HTML_EXPERIMENT)) {
       return false;
     }
     if (!this.isCdnProxy(win)) {

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
@@ -55,6 +55,8 @@ export const DOUBLECLICK_EXPERIMENT_FEATURE = {
   CANONICAL_EXPERIMENT: '21060933',
   CACHE_EXTENSION_INJECTION_CONTROL: '21060955',
   CACHE_EXTENSION_INJECTION_EXP: '21060956',
+  REMOTE_HTML_CONTROL: '21061728',
+  REMOTE_HTML_EXPERIMENT: '21061729',
 };
 
 /** @const @enum{string} */
@@ -73,6 +75,8 @@ export const URL_EXPERIMENT_MAPPING = {
   // SRA
   '7': DOUBLECLICK_EXPERIMENT_FEATURE.SRA_CONTROL,
   '8': DOUBLECLICK_EXPERIMENT_FEATURE.SRA,
+  '9': DOUBLECLICK_EXPERIMENT_FEATURE.REMOTE_HTML_CONTROL,
+  '10': DOUBLECLICK_EXPERIMENT_FEATURE.REMOTE_HTML_EXPERIMENT,
 };
 
 /**
@@ -141,11 +145,13 @@ export class DoubleclickA4aEligibility {
     if (useRemoteHtml) {
       warnDeprecation('remote.html');
     }
-    if (hasUSDRD || (useRemoteHtml && !element.getAttribute('rtc-config'))) {
-      return false;
-    }
     let experimentId;
     const urlExperimentId = extractUrlExperimentId(win, element);
+    if (hasUSDRD || (useRemoteHtml &&
+                     !element.getAttribute('rtc-config') &&
+                     urlExperimentId != '10')) {
+      return false;
+    }
     if (!this.isCdnProxy(win)) {
       // Ensure that forcing FF via url is applied if test/localDev.
       if (urlExperimentId == -1 &&
@@ -176,7 +182,7 @@ export class DoubleclickA4aEligibility {
       addExperimentIdToElement(experimentId, element);
       forceExperimentBranch(win, DOUBLECLICK_A4A_EXPERIMENT_NAME, experimentId);
     }
-    return true;
+    return experimentId != DOUBLECLICK_EXPERIMENT_FEATURE.REMOTE_HTML_CONTROL;
   }
 
   /**

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
@@ -149,6 +149,7 @@ export class DoubleclickA4aEligibility {
     const urlExperimentId = extractUrlExperimentId(win, element);
     if (hasUSDRD || (useRemoteHtml &&
                      !element.getAttribute('rtc-config') &&
+                     urlExperimentId &&
                      URL_EXPERIMENT_MAPPING[urlExperimentId] !=
                      DOUBLECLICK_EXPERIMENT_FEATURE.REMOTE_HTML_EXPERIMENT)) {
       return false;

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
@@ -149,9 +149,9 @@ export class DoubleclickA4aEligibility {
     const urlExperimentId = extractUrlExperimentId(win, element);
     if (hasUSDRD || (useRemoteHtml &&
                      !element.getAttribute('rtc-config') &&
-                     urlExperimentId &&
+                     (!urlExperimentId ||
                      URL_EXPERIMENT_MAPPING[urlExperimentId] !=
-                     DOUBLECLICK_EXPERIMENT_FEATURE.REMOTE_HTML_EXPERIMENT)) {
+                      DOUBLECLICK_EXPERIMENT_FEATURE.REMOTE_HTML_EXPERIMENT))) {
       return false;
     }
     if (!this.isCdnProxy(win)) {

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-a4a-config.js
@@ -82,6 +82,21 @@ describe('doubleclick-a4a-config', () => {
       expect(elem.getAttribute(EXPERIMENT_ATTRIBUTE)).to.not.be.ok;
     });
 
+    it('should use FFF if useRemoteHtml is true and in experiment', () => {
+      // Ensure no selection in order to very experiment attribute.
+      sandbox.stub(DoubleclickA4aEligibility.prototype, 'maybeSelectExperiment')
+          .returns(null);
+      mockWin.location = parseUrl(
+          'https://cdn.ampproject.org/some/path/to/content.html?exp=da:10');
+      const elem = testFixture.doc.createElement('div');
+      elem.setAttribute('type', 'doubleclick');
+      testFixture.doc.body.appendChild(elem);
+      const useRemoteHtml = true;
+      expect(
+          doubleclickIsA4AEnabled(mockWin, elem, useRemoteHtml)).to.be.true;
+      expect(elem.getAttribute(EXPERIMENT_ATTRIBUTE)).to.be.ok;
+    });
+
     it('should use Fast Fetch if useRemoteHtml is true and RTC is set', () => {
       // Ensure no selection in order to very experiment attribute.
       sandbox.stub(DoubleclickA4aEligibility.prototype, 'maybeSelectExperiment')
@@ -171,8 +186,9 @@ describe('doubleclick-a4a-config', () => {
             String(expFlagValue));
         const elem = testFixture.doc.createElement('div');
         testFixture.doc.body.appendChild(elem);
-        // Enabled for all
-        expect(doubleclickIsA4AEnabled(mockWin, elem)).to.be.true;
+        // Enabled for all except da:9
+        expect(doubleclickIsA4AEnabled(mockWin, elem)).to.equal(
+            expFlagValue != '9');
         if (expFlagValue == 0) {
           expect(elem.getAttribute(EXPERIMENT_ATTRIBUTE)).to.not.be.ok;
         } else {


### PR DESCRIPTION
If publishers are specifying a custom remote.html, in the experiment branch we ignore this and still attempt fast fetch selection. 