### PR TITLE
Allow to lint a file glob instead of all files

### DIFF
--- a/build-system/tasks/lint.js
+++ b/build-system/tasks/lint.js
@@ -127,7 +127,7 @@ function lint() {
   if (argv.fix) {
     options.fix = true;
   }
-  const stream = initializeStream(config.lintGlobs, {});
+  const stream = initializeStream(argv.file || config.lintGlobs, {});
   return runLinter('.', stream, options);
 }
 

--- a/build-system/tasks/lint.js
+++ b/build-system/tasks/lint.js
@@ -127,7 +127,7 @@ function lint() {
   if (argv.fix) {
     options.fix = true;
   }
-  const stream = initializeStream(argv.file || config.lintGlobs, {});
+  const stream = initializeStream(argv.files || config.lintGlobs, {});
   return runLinter('.', stream, options);
 }
 

--- a/contributing/DEVELOPING.md
+++ b/contributing/DEVELOPING.md
@@ -47,7 +47,7 @@ The Quick Start Guide's  [One-time setup](getting-started-quick.md#one-time-setu
 | `gulp lint`                                                             | Validates against Google Closure Linter.                              |
 | `gulp lint --watch`                                                     | Watches for changes in files, Validates against Google Closure Linter.|
 | `gulp lint --fix`                                                       | Fixes simple lint warnings/errors automatically.                      |
-| `gulp lint --files=path/to/file.js`                                      | Lints specified files                                                 |
+| `gulp lint --files=path/to/file.js`                                     | Lints specified files                                                 |
 | `gulp build`<sup>[[1]](#footnote-1)</sup>                               | Builds the AMP library.                                               |
 | `gulp build --extensions=<amp-foo,amp-bar>`                             | Builds the AMP library, with only the listed extensions.
 | `gulp build --extensions=minimal_set`                                   | Builds the AMP library, with only the extensions needed to load `article.amp.html`.

--- a/contributing/DEVELOPING.md
+++ b/contributing/DEVELOPING.md
@@ -47,6 +47,7 @@ The Quick Start Guide's  [One-time setup](getting-started-quick.md#one-time-setu
 | `gulp lint`                                                             | Validates against Google Closure Linter.                              |
 | `gulp lint --watch`                                                     | Watches for changes in files, Validates against Google Closure Linter.|
 | `gulp lint --fix`                                                       | Fixes simple lint warnings/errors automatically.                      |
+| `gulp lint --file=path/to/file.js`                                      | Lints just a single file.                                             |
 | `gulp build`<sup>[[1]](#footnote-1)</sup>                               | Builds the AMP library.                                               |
 | `gulp build --extensions=<amp-foo,amp-bar>`                             | Builds the AMP library, with only the listed extensions.
 | `gulp build --extensions=minimal_set`                                   | Builds the AMP library, with only the extensions needed to load `article.amp.html`.

--- a/contributing/DEVELOPING.md
+++ b/contributing/DEVELOPING.md
@@ -47,7 +47,7 @@ The Quick Start Guide's  [One-time setup](getting-started-quick.md#one-time-setu
 | `gulp lint`                                                             | Validates against Google Closure Linter.                              |
 | `gulp lint --watch`                                                     | Watches for changes in files, Validates against Google Closure Linter.|
 | `gulp lint --fix`                                                       | Fixes simple lint warnings/errors automatically.                      |
-| `gulp lint --file=path/to/file.js`                                      | Lints just a single file.                                             |
+| `gulp lint --files=path/to/file.js`                                      | Lints specified files                                                 |
 | `gulp build`<sup>[[1]](#footnote-1)</sup>                               | Builds the AMP library.                                               |
 | `gulp build --extensions=<amp-foo,amp-bar>`                             | Builds the AMP library, with only the listed extensions.
 | `gulp build --extensions=minimal_set`                                   | Builds the AMP library, with only the extensions needed to load `article.amp.html`.

--- a/contributing/DEVELOPING.md
+++ b/contributing/DEVELOPING.md
@@ -47,7 +47,7 @@ The Quick Start Guide's  [One-time setup](getting-started-quick.md#one-time-setu
 | `gulp lint`                                                             | Validates against Google Closure Linter.                              |
 | `gulp lint --watch`                                                     | Watches for changes in files, Validates against Google Closure Linter.|
 | `gulp lint --fix`                                                       | Fixes simple lint warnings/errors automatically.                      |
-| `gulp lint --files=path/to/file.js`                                     | Lints specified files.                                                |
+| `gulp lint --files=<files-path-glob>`                                   | Lints just the files provided.                                         |
 | `gulp build`<sup>[[1]](#footnote-1)</sup>                               | Builds the AMP library.                                               |
 | `gulp build --extensions=<amp-foo,amp-bar>`                             | Builds the AMP library, with only the listed extensions.
 | `gulp build --extensions=minimal_set`                                   | Builds the AMP library, with only the extensions needed to load `article.amp.html`.

--- a/contributing/DEVELOPING.md
+++ b/contributing/DEVELOPING.md
@@ -47,7 +47,7 @@ The Quick Start Guide's  [One-time setup](getting-started-quick.md#one-time-setu
 | `gulp lint`                                                             | Validates against Google Closure Linter.                              |
 | `gulp lint --watch`                                                     | Watches for changes in files, Validates against Google Closure Linter.|
 | `gulp lint --fix`                                                       | Fixes simple lint warnings/errors automatically.                      |
-| `gulp lint --files=path/to/file.js`                                     | Lints specified files                                                 |
+| `gulp lint --files=path/to/file.js`                                     | Lints specified files.                                                |
 | `gulp build`<sup>[[1]](#footnote-1)</sup>                               | Builds the AMP library.                                               |
 | `gulp build --extensions=<amp-foo,amp-bar>`                             | Builds the AMP library, with only the listed extensions.
 | `gulp build --extensions=minimal_set`                                   | Builds the AMP library, with only the extensions needed to load `article.amp.html`.


### PR DESCRIPTION
`gulp lint` runs across all files. Allow to run linter against just a file glob
`gulp lint --files=<file glob>`