### PR TITLE
Fix vsync mutation race in lightbox open

### DIFF
--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -636,20 +636,19 @@ export class AmpLightboxGallery extends AMP.BaseElement {
       || 'default';
     this.currentLightboxGroupId_ = lightboxGroupId;
     return this.findOrInitializeLightbox_(lightboxGroupId).then(() => {
-      this.getViewport().enterLightboxMode();
-
-      this.vsync_.mutate(() => {
+      return this.vsync_.mutatePromise(() => {
+        toggle(this.element, true);
         st.setStyles(this.element, {
           opacity: 0,
           display: '',
         });
-
         st.setStyles(dev().assertElement(this.carousel_), {
           opacity: 0,
           display: '',
         });
       });
-
+    }).then(() => {
+      this.getViewport().enterLightboxMode();
       this.active_ = true;
 
       this.updateInViewport(dev().assertElement(this.container_), true);


### PR DESCRIPTION
On lightbox open, we need to toggle the `<amp-lightbox-gallery>` element to true. We also need to put this vsync mutate in a promise, since we must make sure that the carousel and image-viewer is correctly laid out before animations happen. 

This fixes the bug where `<amp-image-viewer>`'s `measure` goes to (0,0,0,0) and the animations go into the left top corner. 