### PR TITLE
🐛 Protect certain attributes in story-ads

### DIFF
--- a/extensions/amp-story/0.1/amp-story-auto-ads.js
+++ b/extensions/amp-story/0.1/amp-story-auto-ads.js
@@ -19,7 +19,7 @@ import {Services} from '../../../src/services';
 import {StateChangeType} from './navigation-state';
 import {createElementWithAttributes} from '../../../src/dom';
 import {dev, user} from '../../../src/log';
-import {dict, hasOwn} from '../../../src/utils/object';
+import {dict, hasOwn, map} from '../../../src/utils/object';
 import {isJsonScriptTag} from '../../../src/dom';
 import {parseJson} from '../../../src/json';
 
@@ -252,17 +252,35 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
    * @private
    */
   createAdElement_() {
-    const defaultAttrs = {
+    const requiredAttrs = {
       'id': 'i-amphtml-story-ad',
       'layout': 'fill',
     };
 
     const configAttrs = this.config_['ad-attributes'];
+
+    user().assert(this.isTypeAllowed_(configAttrs.type), `${TAG}: ` +
+      `"${configAttrs.type}" ad type is not supported`);
+
     const attributes = /** @type {!JsonObject} */ (Object.assign({},
-        defaultAttrs, configAttrs));
+        configAttrs, requiredAttrs));
 
     return createElementWithAttributes(
         document, 'amp-ad', attributes);
+  }
+
+
+  /**
+   * @param {string} type
+   * @return {boolean}
+   * @private
+   */
+  isTypeAllowed_(type) {
+    const allowedTypes = map({
+      'custom': true,
+    });
+
+    return allowedTypes[type] || false;
   }
 
 

--- a/extensions/amp-story/0.1/amp-story-auto-ads.js
+++ b/extensions/amp-story/0.1/amp-story-auto-ads.js
@@ -259,6 +259,13 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
 
     const configAttrs = this.config_['ad-attributes'];
 
+    ['height', 'width', 'layout'].forEach(attr => {
+      if (configAttrs[attr]) {
+        user().warn(TAG, `ad-attribute "${attr}" is not allowed`);
+        delete configAttrs[attr];
+      }
+    });
+
     user().assert(this.isTypeAllowed_(configAttrs.type), `${TAG}: ` +
       `"${configAttrs.type}" ad type is not supported`);
 

--- a/extensions/amp-story/0.1/amp-story-auto-ads.js
+++ b/extensions/amp-story/0.1/amp-story-auto-ads.js
@@ -59,6 +59,11 @@ const AD_STATE = {
   FAILED: 2,
 };
 
+/** @const */
+const ALLOWED_AD_TYPES = map({
+  'custom': true,
+});
+
 
 export class AmpStoryAutoAds extends AMP.BaseElement {
 
@@ -253,20 +258,20 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
    */
   createAdElement_() {
     const requiredAttrs = {
-      'id': 'i-amphtml-story-ad',
+      'class': 'i-amphtml-story-ad',
       'layout': 'fill',
     };
 
     const configAttrs = this.config_['ad-attributes'];
 
     ['height', 'width', 'layout'].forEach(attr => {
-      if (configAttrs[attr]) {
+      if (configAttrs[attr] !== undefined) {
         user().warn(TAG, `ad-attribute "${attr}" is not allowed`);
         delete configAttrs[attr];
       }
     });
 
-    user().assert(this.isTypeAllowed_(configAttrs.type), `${TAG}: ` +
+    user().assert(!!ALLOWED_AD_TYPES[configAttrs.type], `${TAG}: ` +
       `"${configAttrs.type}" ad type is not supported`);
 
     const attributes = /** @type {!JsonObject} */ (Object.assign({},
@@ -274,20 +279,6 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
 
     return createElementWithAttributes(
         document, 'amp-ad', attributes);
-  }
-
-
-  /**
-   * @param {string} type
-   * @return {boolean}
-   * @private
-   */
-  isTypeAllowed_(type) {
-    const allowedTypes = map({
-      'custom': true,
-    });
-
-    return allowedTypes[type] || false;
   }
 
 


### PR DESCRIPTION
There are certain attributes for an amp-ad shown in a story that we do not want to be defined by user input.

