### PR TITLE
<amp-lightbox-gallery> validator rules

### DIFF
--- a/extensions/amp-carousel/validator-amp-carousel.protoascii
+++ b/extensions/amp-carousel/validator-amp-carousel.protoascii
@@ -53,8 +53,17 @@ tags: {  # <amp-carousel>
     name: "type"
     value_regex: "slides|carousel"
   }
+  # <amp-lightbox-gallery>
+  attrs: {
+    name: "lightbox-exclude"
+    requires_extension: "amp-lightbox-gallery"
+    value: ""
+  }
   # <amp-bind>
   attrs: { name: "[slide]" }
+  reference_points: {
+    tag_spec_name: "AMP-CAROUSEL [lightbox]"
+  }
   attr_lists: "extended-amp-global"
   spec_url: "https://www.ampproject.org/docs/reference/components/amp-carousel"
   amp_layout: {
@@ -66,4 +75,16 @@ tags: {  # <amp-carousel>
     supported_layouts: NODISPLAY
     supported_layouts: RESPONSIVE
   }
+}
+tags: {
+  html_format: AMP
+  html_format: EXPERIMENTAL
+  tag_name: "$REFERENCE_POINT"
+  spec_name : "AMP-CAROUSEL lightbox"
+  attrs: {
+    name: "lightbox-exclude"
+    requires_extension: "amp-lightbox-gallery"
+    value: ""
+  }
+  spec_url: "https://www.ampproject.org/docs/reference/components/amp-lightbox-gallery"
 }

--- a/extensions/amp-carousel/validator-amp-carousel.protoascii
+++ b/extensions/amp-carousel/validator-amp-carousel.protoascii
@@ -53,18 +53,10 @@ tags: {  # <amp-carousel>
     name: "type"
     value_regex: "slides|carousel"
   }
-  # <amp-lightbox-gallery>
-  attrs: {
-    name: "lightbox-exclude"
-    requires_extension: "amp-lightbox-gallery"
-    value: ""
-  }
   # <amp-bind>
   attrs: { name: "[slide]" }
-  reference_points: {
-    tag_spec_name: "AMP-CAROUSEL [lightbox]"
-  }
   attr_lists: "extended-amp-global"
+  attr_lists: "lightboxable-elements"
   spec_url: "https://www.ampproject.org/docs/reference/components/amp-carousel"
   amp_layout: {
     supported_layouts: FILL
@@ -75,16 +67,4 @@ tags: {  # <amp-carousel>
     supported_layouts: NODISPLAY
     supported_layouts: RESPONSIVE
   }
-}
-tags: {
-  html_format: AMP
-  html_format: EXPERIMENTAL
-  tag_name: "$REFERENCE_POINT"
-  spec_name : "AMP-CAROUSEL lightbox"
-  attrs: {
-    name: "lightbox-exclude"
-    requires_extension: "amp-lightbox-gallery"
-    value: ""
-  }
-  spec_url: "https://www.ampproject.org/docs/reference/components/amp-lightbox-gallery"
 }

--- a/extensions/amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.html
+++ b/extensions/amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.html
@@ -1,0 +1,36 @@
+<!--
+  Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS-IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the license.
+-->
+<!--
+  Test Description:
+  Tests for the amp-lightbox-gallery tag. See the inline comments.
+-->
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <link rel="canonical" href="./regular-html-version.html">
+  <meta name="viewport" content="width=device-width,minimum-scale=1">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-lightbox-gallery" src="https://cdn.ampproject.org/v0/amp-lightbox-gallery-0.1.js"></script>
+</head>
+<body>
+  <!-- Valid -->
+  <amp-lightbox-gallery layout="nodisplay"></amp-lightbox-gallery>
+  <!-- Invalid: invalid layout -->
+  <amp-lightbox-gallery layout="responsive" height="400" width="400"></amp-lightbox-gallery>
+</body>
+</html>

--- a/extensions/amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.html
+++ b/extensions/amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.html
@@ -29,8 +29,41 @@
 </head>
 <body>
   <!-- Valid -->
-  <amp-lightbox-gallery layout="nodisplay"></amp-lightbox-gallery>
-  <!-- Invalid: invalid layout -->
-  <amp-lightbox-gallery layout="responsive" height="400" width="400"></amp-lightbox-gallery>
+  <amp-img src="/awesome.png" width="300" height="300" lightbox></amp-img>
+  <amp-img src="/awesome.png" width="300" height="300" lightbox="a"></amp-img>
+  <amp-img src="/awesome.png" width="300" height="300" lightbox lightbox-thumbnail-id="a"></amp-img>
+
+  <!-- Invalid: missing value for lightbox-thumbnail-id -->
+  <amp-img src="/awesome.png" width="300" height="300" lightbox lightbox-thumbnail-id></amp-img>
+  <!-- Invalid: missing lightbox attribute for element with lightbox-thumbnail-id -->
+  <amp-img src="/awesome.png" width="300" height="300" lightbox-thumbnail-id="a"></amp-img>
+  <!-- Invalid: cannot have lightbox-exclude on an item that isn't in a carousel -->
+  <amp-img src="/awesome.png" width="300" height="300" lightbox-exclude></amp-img>
+
+  <!-- Valid -->
+  <amp-video
+    lightbox
+    src="../av/ForBiggerJoyrides-short.mp4"
+    width="720"
+    height="405"
+    layout="responsive"
+    controls></amp-video>
+  <amp-youtube
+    lightbox
+    data-videoid="lBTCB7yLs8Y"
+    width="358"
+    height="204"
+    layout="responsive"></amp-youtube>
+
+  <!-- Valid -->
+  <amp-carousel width=400 height=300 layout=responsive type=slides lightbox></amp-carousel>
+  <amp-carousel width=400 height=300 layout=responsive type=slides lightbox>
+      <amp-img src="/awesome.png" width="300" height="300" lightbox></amp-img>
+      <amp-img src="/awesome.png" width="300" height="300" lightbox-exclude></amp-img>
+  </amp-carousel>
+  <amp-carousel width=400 height=300 layout=responsive type=slides>
+      <amp-img src="/awesome.png" width="300" height="300" lightbox></amp-img>
+      <amp-img src="/awesome.png" width="300" height="300"></amp-img>
+  </amp-carousel>
 </body>
 </html>

--- a/extensions/amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.html
+++ b/extensions/amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.html
@@ -41,9 +41,7 @@
   <amp-img src="/awesome.png" width="300" height="300" lightbox lightbox-thumbnail-id></amp-img>
   <!-- Invalid: missing lightbox attribute for element with lightbox-thumbnail-id -->
   <amp-img src="/awesome.png" width="300" height="300" lightbox-thumbnail-id="a"></amp-img>
-  <!-- Invalid: cannot have lightbox-exclude on an item that isn't in a carousel -->
-  <amp-img src="/awesome.png" width="300" height="300" lightbox-exclude></amp-img>
-
+  
   <!-- Valid -->
   <amp-video
     lightbox

--- a/extensions/amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.html
+++ b/extensions/amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.html
@@ -26,6 +26,10 @@
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <script async custom-element="amp-lightbox-gallery" src="https://cdn.ampproject.org/v0/amp-lightbox-gallery-0.1.js"></script>
+  <script async custom-element="amp-youtube" src="https://cdn.ampproject.org/v0/amp-youtube-0.1.js"></script>
+  <script async custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.1.js"></script>
+  <script async custom-element="amp-video" src="https://cdn.ampproject.org/v0/amp-video-0.1.js"></script>
+
 </head>
 <body>
   <!-- Valid -->

--- a/extensions/amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.html
+++ b/extensions/amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.html
@@ -15,7 +15,7 @@
 -->
 <!--
   Test Description:
-  Tests for the amp-lightbox-gallery tag. See the inline comments.
+  Tests for the amp-lightbox-gallery tag. See inline comments.
 -->
 <!doctype html>
 <html ⚡>

--- a/extensions/amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.out
+++ b/extensions/amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.out
@@ -1,0 +1,39 @@
+FAIL
+|  <!--
+|    Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+|
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|
+|        http://www.apache.org/licenses/LICENSE-2.0
+|
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests for the amp-lightbox-gallery tag. See the inline comments.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <script async custom-element="amp-lightbox-gallery" src="https://cdn.ampproject.org/v0/amp-lightbox-gallery-0.1.js"></script>
+|  </head>
+|  <body>
+|    <!-- Valid -->
+|    <amp-lightbox-gallery layout="nodisplay"></amp-lightbox-gallery>
+|    <!-- Invalid: invalid layout -->
+|    <amp-lightbox-gallery layout="responsive" height="400" width="400"></amp-lightbox-gallery>
+>>   ^~~~~~~~~
+amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.html:34:2 The specified layout 'RESPONSIVE' is not supported by tag 'amp-lightbox-gallery'. (see https://www.ampproject.org/docs/reference/components/amp-lightbox-gallery) [AMP_LAYOUT_PROBLEM]
+|  </body>
+|  </html>

--- a/extensions/amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.out
+++ b/extensions/amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.out
@@ -1,39 +1,76 @@
-FAIL
-|  <!--
-|    Copyright 2018 The AMP HTML Authors. All Rights Reserved.
-|  
-|    Licensed under the Apache License, Version 2.0 (the "License");
-|    you may not use this file except in compliance with the License.
-|    You may obtain a copy of the License at
-|  
-|        http://www.apache.org/licenses/LICENSE-2.0
-|  
-|    Unless required by applicable law or agreed to in writing, software
-|    distributed under the License is distributed on an "AS-IS" BASIS,
-|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-|    See the License for the specific language governing permissions and
-|    limitations under the license.
-|  -->
-|  <!--
-|    Test Description:
-|    Tests for the amp-lightbox-gallery tag. See inline comments.
-|  -->
-|  <!doctype html>
-|  <html ⚡>
-|  <head>
-|    <meta charset="utf-8">
-|    <link rel="canonical" href="./regular-html-version.html">
-|    <meta name="viewport" content="width=device-width,minimum-scale=1">
-|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
-|    <script async src="https://cdn.ampproject.org/v0.js"></script>
-|    <script async custom-element="amp-lightbox-gallery" src="https://cdn.ampproject.org/v0/amp-lightbox-gallery-0.1.js"></script>
-|  </head>
-|  <body>
-|    <!-- Valid -->
-|    <amp-lightbox-gallery layout="nodisplay"></amp-lightbox-gallery>
-|    <!-- Invalid: invalid layout -->
-|    <amp-lightbox-gallery layout="responsive" height="400" width="400"></amp-lightbox-gallery>
->>   ^~~~~~~~~
-amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.html:34:2 The specified layout 'RESPONSIVE' is not supported by tag 'amp-lightbox-gallery'. (see https://www.ampproject.org/docs/reference/components/amp-lightbox-gallery) [AMP_LAYOUT_PROBLEM]
-|  </body>
-|  </html>
+    FAIL
+    |  <!--
+    |    Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+    |
+    |    Licensed under the Apache License, Version 2.0 (the "License");
+    |    you may not use this file except in compliance with the License.
+    |    You may obtain a copy of the License at
+    |
+    |        http://www.apache.org/licenses/LICENSE-2.0
+    |
+    |    Unless required by applicable law or agreed to in writing, software
+    |    distributed under the License is distributed on an "AS-IS" BASIS,
+    |    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    |    See the License for the specific language governing permissions and
+    |    limitations under the license.
+    |  -->
+    |  <!--
+    |    Test Description:
+    |    Tests for the amp-lightbox-gallery tag. See inline comments.
+    |  -->
+    |  <!doctype html>
+    |  <html ⚡>
+    |  <head>
+    |    <meta charset="utf-8">
+    |    <link rel="canonical" href="./regular-html-version.html">
+    |    <meta name="viewport" content="width=device-width,minimum-scale=1">
+    |    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+    |    <script async src="https://cdn.ampproject.org/v0.js"></script>
+    |    <script async custom-element="amp-lightbox-gallery" src="https://cdn.ampproject.org/v0/amp-lightbox-gallery-0.1.js"></script>
+    |    <script async custom-element="amp-youtube" src="https://cdn.ampproject.org/v0/amp-youtube-0.1.js"></script>
+    |    <script async custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.1.js"></script>
+    |    <script async custom-element="amp-video" src="https://cdn.ampproject.org/v0/amp-video-0.1.js"></script>
+    |
+    |  </head>
+    |  <body>
+    |    <!-- Valid -->
+    |    <amp-img src="/awesome.png" width="300" height="300" lightbox></amp-img>
+    |    <amp-img src="/awesome.png" width="300" height="300" lightbox="a"></amp-img>
+    |    <amp-img src="/awesome.png" width="300" height="300" lightbox lightbox-thumbnail-id="a"></amp-img>
+    |
+    |    <!-- Invalid: missing value for lightbox-thumbnail-id -->
+    |    <amp-img src="/awesome.png" width="300" height="300" lightbox lightbox-thumbnail-id></amp-img>
+    |    <!-- Invalid: missing lightbox attribute for element with lightbox-thumbnail-id -->
+    |    <amp-img src="/awesome.png" width="300" height="300" lightbox-thumbnail-id="a"></amp-img>
+    >>   ^~~~~~~~~
+    amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.html:43:2 The attribute 'lightbox' in tag 'amp-img' is missing or incorrect, but required by attribute 'lightbox-thumbnail-id'. (see https://www.ampproject.org/docs/reference/components/amp-img) [DISALLOWED_HTML]
+    |    <!-- Invalid: cannot have lightbox-exclude on an item that isn't in a carousel -->
+    |    <amp-img src="/awesome.png" width="300" height="300" lightbox-exclude></amp-img>
+    |
+    |    <!-- Valid -->
+    |    <amp-video
+    |      lightbox
+    |      src="../av/ForBiggerJoyrides-short.mp4"
+    |      width="720"
+    |      height="405"
+    |      layout="responsive"
+    |      controls></amp-video>
+    |    <amp-youtube
+    |      lightbox
+    |      data-videoid="lBTCB7yLs8Y"
+    |      width="358"
+    |      height="204"
+    |      layout="responsive"></amp-youtube>
+    |
+    |    <!-- Valid -->
+    |    <amp-carousel width=400 height=300 layout=responsive type=slides lightbox></amp-carousel>
+    |    <amp-carousel width=400 height=300 layout=responsive type=slides lightbox>
+    |        <amp-img src="/awesome.png" width="300" height="300" lightbox></amp-img>
+    |        <amp-img src="/awesome.png" width="300" height="300" lightbox-exclude></amp-img>
+    |    </amp-carousel>
+    |    <amp-carousel width=400 height=300 layout=responsive type=slides>
+    |        <amp-img src="/awesome.png" width="300" height="300" lightbox></amp-img>
+    |        <amp-img src="/awesome.png" width="300" height="300"></amp-img>
+    |    </amp-carousel>
+    |  </body>
+    |  </html>

--- a/extensions/amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.out
+++ b/extensions/amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.out
@@ -1,13 +1,13 @@
 FAIL
 |  <!--
 |    Copyright 2018 The AMP HTML Authors. All Rights Reserved.
-|
+|  
 |    Licensed under the Apache License, Version 2.0 (the "License");
 |    you may not use this file except in compliance with the License.
 |    You may obtain a copy of the License at
-|
+|  
 |        http://www.apache.org/licenses/LICENSE-2.0
-|
+|  
 |    Unless required by applicable law or agreed to in writing, software
 |    distributed under the License is distributed on an "AS-IS" BASIS,
 |    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,7 +16,7 @@ FAIL
 |  -->
 |  <!--
 |    Test Description:
-|    Tests for the amp-lightbox-gallery tag. See the inline comments.
+|    Tests for the amp-lightbox-gallery tag. See inline comments.
 |  -->
 |  <!doctype html>
 |  <html ⚡>

--- a/extensions/amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.out
+++ b/extensions/amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.out
@@ -1,76 +1,78 @@
-    FAIL
-    |  <!--
-    |    Copyright 2018 The AMP HTML Authors. All Rights Reserved.
-    |
-    |    Licensed under the Apache License, Version 2.0 (the "License");
-    |    you may not use this file except in compliance with the License.
-    |    You may obtain a copy of the License at
-    |
-    |        http://www.apache.org/licenses/LICENSE-2.0
-    |
-    |    Unless required by applicable law or agreed to in writing, software
-    |    distributed under the License is distributed on an "AS-IS" BASIS,
-    |    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    |    See the License for the specific language governing permissions and
-    |    limitations under the license.
-    |  -->
-    |  <!--
-    |    Test Description:
-    |    Tests for the amp-lightbox-gallery tag. See inline comments.
-    |  -->
-    |  <!doctype html>
-    |  <html ⚡>
-    |  <head>
-    |    <meta charset="utf-8">
-    |    <link rel="canonical" href="./regular-html-version.html">
-    |    <meta name="viewport" content="width=device-width,minimum-scale=1">
-    |    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
-    |    <script async src="https://cdn.ampproject.org/v0.js"></script>
-    |    <script async custom-element="amp-lightbox-gallery" src="https://cdn.ampproject.org/v0/amp-lightbox-gallery-0.1.js"></script>
-    |    <script async custom-element="amp-youtube" src="https://cdn.ampproject.org/v0/amp-youtube-0.1.js"></script>
-    |    <script async custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.1.js"></script>
-    |    <script async custom-element="amp-video" src="https://cdn.ampproject.org/v0/amp-video-0.1.js"></script>
-    |
-    |  </head>
-    |  <body>
-    |    <!-- Valid -->
-    |    <amp-img src="/awesome.png" width="300" height="300" lightbox></amp-img>
-    |    <amp-img src="/awesome.png" width="300" height="300" lightbox="a"></amp-img>
-    |    <amp-img src="/awesome.png" width="300" height="300" lightbox lightbox-thumbnail-id="a"></amp-img>
-    |
-    |    <!-- Invalid: missing value for lightbox-thumbnail-id -->
-    |    <amp-img src="/awesome.png" width="300" height="300" lightbox lightbox-thumbnail-id></amp-img>
-    |    <!-- Invalid: missing lightbox attribute for element with lightbox-thumbnail-id -->
-    |    <amp-img src="/awesome.png" width="300" height="300" lightbox-thumbnail-id="a"></amp-img>
-    >>   ^~~~~~~~~
-    amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.html:43:2 The attribute 'lightbox' in tag 'amp-img' is missing or incorrect, but required by attribute 'lightbox-thumbnail-id'. (see https://www.ampproject.org/docs/reference/components/amp-img) [DISALLOWED_HTML]
-    |    <!-- Invalid: cannot have lightbox-exclude on an item that isn't in a carousel -->
-    |    <amp-img src="/awesome.png" width="300" height="300" lightbox-exclude></amp-img>
-    |
-    |    <!-- Valid -->
-    |    <amp-video
-    |      lightbox
-    |      src="../av/ForBiggerJoyrides-short.mp4"
-    |      width="720"
-    |      height="405"
-    |      layout="responsive"
-    |      controls></amp-video>
-    |    <amp-youtube
-    |      lightbox
-    |      data-videoid="lBTCB7yLs8Y"
-    |      width="358"
-    |      height="204"
-    |      layout="responsive"></amp-youtube>
-    |
-    |    <!-- Valid -->
-    |    <amp-carousel width=400 height=300 layout=responsive type=slides lightbox></amp-carousel>
-    |    <amp-carousel width=400 height=300 layout=responsive type=slides lightbox>
-    |        <amp-img src="/awesome.png" width="300" height="300" lightbox></amp-img>
-    |        <amp-img src="/awesome.png" width="300" height="300" lightbox-exclude></amp-img>
-    |    </amp-carousel>
-    |    <amp-carousel width=400 height=300 layout=responsive type=slides>
-    |        <amp-img src="/awesome.png" width="300" height="300" lightbox></amp-img>
-    |        <amp-img src="/awesome.png" width="300" height="300"></amp-img>
-    |    </amp-carousel>
-    |  </body>
-    |  </html>
+FAIL
+|  <!--
+|    Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests for the amp-lightbox-gallery tag. See inline comments.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <script async custom-element="amp-lightbox-gallery" src="https://cdn.ampproject.org/v0/amp-lightbox-gallery-0.1.js"></script>
+|    <script async custom-element="amp-youtube" src="https://cdn.ampproject.org/v0/amp-youtube-0.1.js"></script>
+|    <script async custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.1.js"></script>
+|    <script async custom-element="amp-video" src="https://cdn.ampproject.org/v0/amp-video-0.1.js"></script>
+|  
+|  </head>
+|  <body>
+|    <!-- Valid -->
+|    <amp-img src="/awesome.png" width="300" height="300" lightbox></amp-img>
+|    <amp-img src="/awesome.png" width="300" height="300" lightbox="a"></amp-img>
+|    <amp-img src="/awesome.png" width="300" height="300" lightbox lightbox-thumbnail-id="a"></amp-img>
+|  
+|    <!-- Invalid: missing value for lightbox-thumbnail-id -->
+|    <amp-img src="/awesome.png" width="300" height="300" lightbox lightbox-thumbnail-id></amp-img>
+>>   ^~~~~~~~~
+amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.html:41:2 The attribute 'lightbox-thumbnail-id' in tag 'amp-img' is set to the invalid value ''. (see https://www.ampproject.org/docs/reference/components/amp-img) [AMP_TAG_PROBLEM]
+|    <!-- Invalid: missing lightbox attribute for element with lightbox-thumbnail-id -->
+|    <amp-img src="/awesome.png" width="300" height="300" lightbox-thumbnail-id="a"></amp-img>
+>>   ^~~~~~~~~
+amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.html:43:2 The attribute 'lightbox' in tag 'amp-img' is missing or incorrect, but required by attribute 'lightbox-thumbnail-id'. (see https://www.ampproject.org/docs/reference/components/amp-img) [DISALLOWED_HTML]
+|    <!-- Invalid: cannot have lightbox-exclude on an item that isn't in a carousel -->
+|    <amp-img src="/awesome.png" width="300" height="300" lightbox-exclude></amp-img>
+|  
+|    <!-- Valid -->
+|    <amp-video
+|      lightbox
+|      src="../av/ForBiggerJoyrides-short.mp4"
+|      width="720"
+|      height="405"
+|      layout="responsive"
+|      controls></amp-video>
+|    <amp-youtube
+|      lightbox
+|      data-videoid="lBTCB7yLs8Y"
+|      width="358"
+|      height="204"
+|      layout="responsive"></amp-youtube>
+|  
+|    <!-- Valid -->
+|    <amp-carousel width=400 height=300 layout=responsive type=slides lightbox></amp-carousel>
+|    <amp-carousel width=400 height=300 layout=responsive type=slides lightbox>
+|        <amp-img src="/awesome.png" width="300" height="300" lightbox></amp-img>
+|        <amp-img src="/awesome.png" width="300" height="300" lightbox-exclude></amp-img>
+|    </amp-carousel>
+|    <amp-carousel width=400 height=300 layout=responsive type=slides>
+|        <amp-img src="/awesome.png" width="300" height="300" lightbox></amp-img>
+|        <amp-img src="/awesome.png" width="300" height="300"></amp-img>
+|    </amp-carousel>
+|  </body>
+|  </html>

--- a/extensions/amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.out
+++ b/extensions/amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.out
@@ -46,9 +46,7 @@ amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.html:41:2 The attri
 |    <amp-img src="/awesome.png" width="300" height="300" lightbox-thumbnail-id="a"></amp-img>
 >>   ^~~~~~~~~
 amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.html:43:2 The attribute 'lightbox' in tag 'amp-img' is missing or incorrect, but required by attribute 'lightbox-thumbnail-id'. (see https://www.ampproject.org/docs/reference/components/amp-img) [DISALLOWED_HTML]
-|    <!-- Invalid: cannot have lightbox-exclude on an item that isn't in a carousel -->
-|    <amp-img src="/awesome.png" width="300" height="300" lightbox-exclude></amp-img>
-|  
+|    
 |    <!-- Valid -->
 |    <amp-video
 |      lightbox

--- a/extensions/amp-lightbox-gallery/validator-amp-lightbox-gallery.protoascii
+++ b/extensions/amp-lightbox-gallery/validator-amp-lightbox-gallery.protoascii
@@ -25,3 +25,18 @@ tags: {  # amp-lightbox-gallery
   }
   attr_lists: "common-extension-attrs"
 }
+attr_lists: {
+  name: "lightboxable-elements"
+  attrs: { name: "lightbox" }
+  attrs: { 
+    name: "lightbox-thumbnail-id" 
+    value_regex: "^[a-zA-Z][a-zA-Z\d_-]*"
+    trigger: {
+      also_requires_attr: "lightbox"
+    }
+  }
+  attrs: { 
+    name: "lightbox-exclude" 
+    value: ""
+  }
+}

--- a/extensions/amp-lightbox-gallery/validator-amp-lightbox-gallery.protoascii
+++ b/extensions/amp-lightbox-gallery/validator-amp-lightbox-gallery.protoascii
@@ -1,0 +1,34 @@
+#
+# Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the license.
+#
+
+tags: {  # amp-lightbox-gallery
+  html_format: AMP
+  tag_name: "SCRIPT"
+  extension_spec: {
+    name: "amp-lightbox-gallery"
+    allowed_versions: "0.1"
+    allowed_versions: "latest"
+  }
+  attr_lists: "common-extension-attrs"
+}
+tags: {  # <amp-lightbox-gallery>
+  html_format: AMP
+  tag_name: "AMP-LIGHTBOX-GALLERY"
+  requires_extension: "amp-lightbox-gallery"
+  amp_layout: {
+    supported_layouts: NODISPLAY
+  }
+}

--- a/extensions/amp-lightbox-gallery/validator-amp-lightbox-gallery.protoascii
+++ b/extensions/amp-lightbox-gallery/validator-amp-lightbox-gallery.protoascii
@@ -21,14 +21,7 @@ tags: {  # amp-lightbox-gallery
     name: "amp-lightbox-gallery"
     allowed_versions: "0.1"
     allowed_versions: "latest"
+    requires_usage: NONE
   }
   attr_lists: "common-extension-attrs"
-}
-tags: {  # <amp-lightbox-gallery>
-  html_format: AMP
-  tag_name: "AMP-LIGHTBOX-GALLERY"
-  requires_extension: "amp-lightbox-gallery"
-  amp_layout: {
-    supported_layouts: NODISPLAY
-  }
 }

--- a/extensions/amp-video/validator-amp-video.protoascii
+++ b/extensions/amp-video/validator-amp-video.protoascii
@@ -101,6 +101,7 @@ tags: {  # <amp-video> not in amp-story.
   attrs: { name: "poster" }
   attr_lists: "extended-amp-global"
   attr_lists: "amp-video-common"
+  attr_lists: "lightboxable-elements"
   spec_url: "https://www.ampproject.org/docs/reference/components/amp-video"
   amp_layout: {
     supported_layouts: FILL

--- a/extensions/amp-youtube/validator-amp-youtube.protoascii
+++ b/extensions/amp-youtube/validator-amp-youtube.protoascii
@@ -46,6 +46,7 @@ tags: {  # <amp-youtube>
   # <amp-bind>
   attrs: { name: "[data-videoid]" }
   attr_lists: "extended-amp-global"
+  attr_lists: "lightboxable-elements"
   amp_layout: {
     supported_layouts: FILL
     supported_layouts: FIXED

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -4084,6 +4084,24 @@ attr_lists: {
   attrs: { name: "media" }
   attrs: { name: "noloading" value: "" }
 }
+
+# Lightboxable Elements
+attr_lists: {
+  name: "lightboxable-elements"
+  attrs: { name: "lightbox" }
+  attrs: { 
+    name: "lightbox-thumbnail-id" 
+    value_regex: "^[a-zA-Z][a-zA-Z\d_-]*"
+    trigger: {
+      also_requires_attr: "lightbox"
+    }
+  }
+  attrs: { 
+    name: "lightbox-exclude" 
+    value: ""
+  }
+}
+
 tags: {  # <amp-img>
   html_format: AMP
   html_format: AMP4ADS
@@ -4099,6 +4117,7 @@ tags: {  # <amp-img>
   attrs: { name: "[srcset]" }
   attr_lists: "extended-amp-global"
   attr_lists: "mandatory-src-or-srcset"
+  attr_lists: "lightboxable-elements"
   spec_url: "https://www.ampproject.org/docs/reference/components/amp-img"
   amp_layout: {
     supported_layouts: FILL
@@ -4485,20 +4504,6 @@ attr_lists: {
     name: "amp-fx"
     value_casei: "parallax"
     requires_extension: "amp-fx-collection"
-  }
-  # amp-lightbox-gallery specific attributes, see
-  # https://www.ampproject.org/docs/reference/components/amp-lightbox-gallery
-  attrs: {
-    name: "lightbox"
-    requires_extension: "amp-lightbox-gallery"
-  }
-  attrs: {
-    name: "lightbox-thumbnail-id"
-    requires_extension: "amp-lightbox-gallery"
-    value_regex: "^[a-zA-Z][a-zA-Z\d_-]*"
-    trigger: {
-      also_requires_attr: "lightbox"
-    }
   }
   # <amp-bind>
   attrs: { name: "[aria-activedescendant]" }

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -4500,11 +4500,6 @@ attr_lists: {
       also_requires_attr: "lightbox"
     }
   }
-  attrs: {
-    name: "lightbox-exclude"
-    requires_extension: "amp-lightbox-gallery"
-    value: ""
-  }
   # <amp-bind>
   attrs: { name: "[aria-activedescendant]" }
   attrs: { name: "[aria-atomic]" }

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -4496,6 +4496,11 @@ attr_lists: {
     name: "lightbox-thumbnail-id"
     requires_extension: "amp-lightbox-gallery"
   }
+  attrs: {
+    name: "lightbox-exclude"
+    requires_extension: "amp-lightbox-gallery"
+    value: ""
+  }
   # <amp-bind>
   attrs: { name: "[aria-activedescendant]" }
   attrs: { name: "[aria-atomic]" }

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -4085,23 +4085,6 @@ attr_lists: {
   attrs: { name: "noloading" value: "" }
 }
 
-# Lightboxable Elements
-attr_lists: {
-  name: "lightboxable-elements"
-  attrs: { name: "lightbox" }
-  attrs: { 
-    name: "lightbox-thumbnail-id" 
-    value_regex: "^[a-zA-Z][a-zA-Z\d_-]*"
-    trigger: {
-      also_requires_attr: "lightbox"
-    }
-  }
-  attrs: { 
-    name: "lightbox-exclude" 
-    value: ""
-  }
-}
-
 tags: {  # <amp-img>
   html_format: AMP
   html_format: AMP4ADS

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -4486,6 +4486,16 @@ attr_lists: {
     value_casei: "parallax"
     requires_extension: "amp-fx-collection"
   }
+  # amp-lightbox-gallery specific attributes, see
+  # https://www.ampproject.org/docs/reference/components/amp-lightbox-gallery
+  attrs: {
+    name: "lightbox"
+    requires_extension: "amp-lightbox-gallery"
+  }
+  attrs: {
+    name: "lightbox-thumbnail-id"
+    requires_extension: "amp-lightbox-gallery"
+  }
   # <amp-bind>
   attrs: { name: "[aria-activedescendant]" }
   attrs: { name: "[aria-atomic]" }

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -4495,6 +4495,9 @@ attr_lists: {
   attrs: {
     name: "lightbox-thumbnail-id"
     requires_extension: "amp-lightbox-gallery"
+    trigger: {
+      also_requires_attr: "lightbox"
+    }
   }
   attrs: {
     name: "lightbox-exclude"

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -4495,6 +4495,7 @@ attr_lists: {
   attrs: {
     name: "lightbox-thumbnail-id"
     requires_extension: "amp-lightbox-gallery"
+    value_regex: "^[a-zA-Z][\w:.-]*$"
     trigger: {
       also_requires_attr: "lightbox"
     }

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -4495,7 +4495,7 @@ attr_lists: {
   attrs: {
     name: "lightbox-thumbnail-id"
     requires_extension: "amp-lightbox-gallery"
-    value_regex: "^[a-zA-Z][\w:.-]*$"
+    value_regex: "^[a-zA-Z][a-zA-Z\d_-]*"
     trigger: {
       also_requires_attr: "lightbox"
     }


### PR DESCRIPTION
Adds validator rules for `<amp-lightbox-gallery>`. I still need to add one more validator rule that specifies that only children of `<amp-carousel>` with the `lightbox` attribute can include the attribute `lightbox-exclude`. Because validator is so fickle with regards to whitespace, I'm opening a second PR for it. 

Partially addresses https://github.com/ampproject/amphtml/issues/13789