### PR TITLE
✨ amp-document-recommendations: Require recommendation URLs to be from the same host

### DIFF
--- a/extensions/amp-document-recommendations/0.1/amp-document-recommendations.js
+++ b/extensions/amp-document-recommendations/0.1/amp-document-recommendations.js
@@ -21,6 +21,7 @@ import {Services} from '../../../src/services';
 import {assertConfig} from './config';
 import {isExperimentOn} from '../../../src/experiments';
 import {isJsonScriptTag} from '../../../src/dom';
+import {parseUrl} from '../../../src/url';
 import {setStyle} from '../../../src/style';
 import {tryParseJson} from '../../../src/json';
 import {user} from '../../../src/log';
@@ -203,7 +204,9 @@ export class AmpDocumentRecommendations extends AMP.BaseElement {
               'failed to parse content discovery script', error);
         });
 
-    this.config_ = assertConfig(configJson, this.win.document.location.host);
+    const docInfo = Services.documentInfoForDoc(this.element);
+    const host = parseUrl(docInfo.sourceUrl).host;
+    this.config_ = assertConfig(configJson, host);
 
     this.mutateElement(() => {
       this.appendDivision_();

--- a/extensions/amp-document-recommendations/0.1/amp-document-recommendations.js
+++ b/extensions/amp-document-recommendations/0.1/amp-document-recommendations.js
@@ -203,7 +203,7 @@ export class AmpDocumentRecommendations extends AMP.BaseElement {
               'failed to parse content discovery script', error);
         });
 
-    this.config_ = assertConfig(configJson);
+    this.config_ = assertConfig(configJson, this.win.document.location.host);
 
     this.mutateElement(() => {
       this.appendDivision_();

--- a/extensions/amp-document-recommendations/0.1/config.js
+++ b/extensions/amp-document-recommendations/0.1/config.js
@@ -15,6 +15,7 @@
  */
 
 import {isArray} from '../../../src/types';
+import {parseUrl} from '../../../src/url';
 import {user} from '../../../src/log';
 
 /**
@@ -23,7 +24,6 @@ import {user} from '../../../src/log';
  * }}
  */
 export let AmpDocumentRecommendationsConfig;
-
 
 /**
  * @typedef {{
@@ -34,32 +34,34 @@ export let AmpDocumentRecommendationsConfig;
  */
 export let AmpDocumentRecommendationsReco;
 
-
 /**
- * Checks whether the object conforms to the AmpDocumentRecommendationsConfig spec.
+ * Checks whether the object conforms to the AmpDocumentRecommendationsConfig
+ * spec.
  *
  * @param {*} config The config to validate.
+ * @param {string} host The host of the current document
+ *     (document.location.host). All recommendations must be for the same domain
+ *     as the current document so the URL can be updated safely.
  * @return {!./config.AmpDocumentRecommendationsConfig}
  */
-export function assertConfig(config) {
-  user().assert(config);
-  user().assert(isArray(config.recommendations));
-  assertRecos(config.recommendations);
+export function assertConfig(config, host) {
+  user().assert(
+      config, 'amp-document-recommendations config must be specified');
+  user().assert(
+      isArray(config.recommendations), 'recommendations must be an array');
+  assertRecos(config.recommendations, host);
   return /** @type {!AmpDocumentRecommendationsConfig} */ (config);
 }
 
-function assertRecos(recos) {
-  recos.forEach(reco => assertReco(reco));
+function assertRecos(recos, host) {
+  recos.forEach(reco => assertReco(reco, host));
 }
 
-function assertReco(reco) {
-  user().assert(
-      typeof reco.ampUrl == 'string',
-      'ampUrl must be a string');
-  user().assert(
-      typeof reco.image == 'string',
-      'image must be a string');
-  user().assert(
-      typeof reco.title == 'string',
-      'title must be a string');
+function assertReco(reco, host) {
+  const url = parseUrl(reco.ampUrl);
+  user().assert(typeof reco.ampUrl == 'string', 'ampUrl must be a string');
+  user().assert(url.host == host,
+      'recommendations must be from the same host as the current document');
+  user().assert(typeof reco.image == 'string', 'image must be a string');
+  user().assert(typeof reco.title == 'string', 'title must be a string');
 }

--- a/extensions/amp-document-recommendations/0.1/test/test-config.js
+++ b/extensions/amp-document-recommendations/0.1/test/test-config.js
@@ -1,0 +1,162 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {assertConfig} from '../config';
+
+describe('amp-document-recommendations config', () => {
+  describe('assertConfig', () => {
+    const host = 'example.com';
+
+    it('allows a valid config', () => {
+      const config = {
+        recommendations: [{
+          ampUrl: 'https://example.com/article1',
+          image: 'https://example.com/image.png',
+          title: 'Article 1',
+        }],
+      };
+      expect(() => assertConfig(config, host)).to.not.throw();
+    });
+
+    it('allows a config with no recommendations', () => {
+      const config = {recommendations: []};
+      expect(() => assertConfig(config, host)).to.not.throw();
+    });
+
+    it('allows recommendations with relative URLs', () => {
+      const config = {
+        recommendations: [{
+          ampUrl: '/article1',
+          image: '/image.png',
+          title: 'Article 1',
+        }],
+      };
+      expect(() => assertConfig(config, document.location.host)).to.not.throw();
+    });
+
+    it('throws on null config', () => {
+      expect(() => assertConfig(null, host))
+          .to.throw('amp-document-recommendations config must be specified');
+    });
+
+    it('throws on config with no "recommendations" key', () => {
+      const config = {};
+      expect(() => assertConfig(config, host))
+          .to.throw('recommendations must be an array');
+    });
+
+    it('throws on config with non-array "recommendations" key', () => {
+      const config = {recommendations: {}};
+      expect(() => assertConfig(config, host))
+          .to.throw('recommendations must be an array');
+    });
+
+    it('throws on config with missing recommendation title', () => {
+      const config = {
+        recommendations: [{
+          ampUrl: 'https://example.com/article1',
+          image: 'https://example.com/image.png',
+        }],
+      };
+      expect(() => assertConfig(config, host))
+          .to.throw('title must be a string');
+    });
+
+    it('throws on config with non-string recommendation title', () => {
+      const config = {
+        recommendations: [{
+          ampUrl: 'https://example.com/article1',
+          image: 'https://example.com/image.png',
+          title: {},
+        }],
+      };
+      expect(() => assertConfig(config, host))
+          .to.throw('title must be a string');
+    });
+
+    it('throws on config with missing recommendation image', () => {
+      const config = {
+        recommendations: [{
+          ampUrl: 'https://example.com/article1',
+          title: 'Article 1',
+        }],
+      };
+      expect(() => assertConfig(config, host))
+          .to.throw('image must be a string');
+    });
+
+    it('throws on config with non-string recommendation image', () => {
+      const config = {
+        recommendations: [{
+          ampUrl: 'https://example.com/article1',
+          image: {},
+          title: 'Article 1',
+        }],
+      };
+      expect(() => assertConfig(config, host))
+          .to.throw('image must be a string');
+    });
+
+    it('throws on config with recommendations from different domains', () => {
+      const config = {
+        recommendations: [
+          {
+            ampUrl: 'https://othersite.com/article1',
+            image: 'https://othersite.com/image.png',
+            title: 'Article 1',
+          },
+        ],
+      };
+      expect(() => assertConfig(config, host))
+          .to.throw(
+              'recommendations must be from the same host as the current' +
+              ' document');
+    });
+
+    it('throws on config with recommendations from different subdomains',
+        () => {
+          const config = {
+            recommendations: [
+              {
+                ampUrl: 'https://www.example.com/article1',
+                image: 'https://example.com/image.png',
+                title: 'Article 1',
+              },
+            ],
+          };
+          expect(() => assertConfig(config, host))
+              .to.throw(
+                  'recommendations must be from the same host as the current' +
+                  ' document');
+        });
+
+    it('throws on config with recommendations on different ports', () => {
+      const config = {
+        recommendations: [
+          {
+            ampUrl: 'https://example.com:8080/article1',
+            image: 'https://example.com/image.png',
+            title: 'Article 1',
+          },
+        ],
+      };
+      expect(() => assertConfig(config, host))
+          .to.throw(
+              'recommendations must be from the same host as the current' +
+              ' document');
+    });
+  });
+});


### PR DESCRIPTION
We want to keep document.location updated as the current document changes so that browser refreshes maintain the current document/sharing works. This requires that all recommendations be for the same host.

- Adds additional error messages to asserts
- Adds tests for all assertions
- Formats with clang-format