### PR TITLE
Make sure safeframe geom matches gpt

### DIFF
--- a/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
@@ -325,16 +325,17 @@ export class SafeframeHostApi {
    * @private
    */
   formatGeom_(iframeBox) {
+    const ampAdBox = this.baseInstance_.getPageLayoutBox();
     const viewportSize = this.viewport_.getSize();
     const currentGeometry = /** @type {JsonObject} */({
       'windowCoords_t': 0,
       'windowCoords_r': viewportSize.width,
       'windowCoords_b': viewportSize.height,
       'windowCoords_l': 0,
-      'frameCoords_t': iframeBox.top,
-      'frameCoords_r': iframeBox.right,
-      'frameCoords_b': iframeBox.bottom,
-      'frameCoords_l': iframeBox.left,
+      'frameCoords_t': ampAdBox.top,
+      'frameCoords_r': ampAdBox.right,
+      'frameCoords_b': ampAdBox.bottom,
+      'frameCoords_l': ampAdBox.left,
       'styleZIndex': this.baseInstance_.element.style.zIndex,
       // AMP's built in resize methodology that we use only allows expansion
       // to the right and bottom, so we enforce that here.

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-safeframe.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-safeframe.js
@@ -232,8 +232,8 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
       // amp-ad element
       const css = createElementWithAttributes(doc, 'style');
       css.innerHTML = '.safeframe' +
-          '{height:250px!important;' +
-          'width:300px!important;' +
+          '{height:50px!important;' +
+          'width:50px!important;' +
           'background-color:blue!important;' +
           'display:block!important;}';
       doc.head.appendChild(css);
@@ -252,7 +252,7 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
             '{"windowCoords_t":0,"windowCoords_r":500,"windowCoords_b":1000,' +
               '"windowCoords_l":0,"frameCoords_t":0,"frameCoords_r":300,' +
               '"frameCoords_b":250,"frameCoords_l":0,"styleZIndex":"",' +
-              '"allowedExpansion_r":200,"allowedExpansion_b":750,' +
+              '"allowedExpansion_r":450,"allowedExpansion_b":950,' +
               '"allowedExpansion_t":0,"allowedExpansion_l":0,"yInView":1,' +
               '"xInView":1}');
         expect(payload['uid']).to.equal(safeframeHost.uid_);
@@ -275,8 +275,8 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
       });
       const css = createElementWithAttributes(doc, 'style');
       css.innerHTML = '.safeframe' +
-          '{height:50px!important;' +
-          'width:50px!important;' +
+          '{height:10px!important;' +
+          'width:10px!important;' +
           'background-color:blue!important;' +
           'display:block!important;}';
       doc.head.appendChild(css);
@@ -295,7 +295,7 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
             '{"windowCoords_t":0,"windowCoords_r":500,"windowCoords_b":1000,' +
               '"windowCoords_l":0,"frameCoords_t":0,"frameCoords_r":50,' +
               '"frameCoords_b":50,"frameCoords_l":0,"styleZIndex":"",' +
-              '"allowedExpansion_r":450,"allowedExpansion_b":950,' +
+              '"allowedExpansion_r":490,"allowedExpansion_b":990,' +
               '"allowedExpansion_t":0,"allowedExpansion_l":0,"yInView":1,' +
               '"xInView":1}');
         expect(payload['uid']).to.equal(safeframeHost.uid_);
@@ -356,12 +356,12 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
         bottom: 800,
       });
       const iframeBox = {
-        top: 200,
-        left: 100,
-        bottom: 800,
-        right: 400,
+        top: 300,
+        left: 200,
+        bottom: 1000,
+        right: 500,
         width: 300,
-        height: 600,
+        height: 700,
       };
       sandbox./*OK*/stub(safeframeHost.viewport_, 'getSize').returns({
         width: 500,
@@ -371,7 +371,7 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
         'windowCoords_t': 0, 'windowCoords_r': 500, 'windowCoords_b': 1000,
         'windowCoords_l': 0, 'frameCoords_t': 200, 'frameCoords_r': 400,
         'frameCoords_b': 800, 'frameCoords_l': 100, 'styleZIndex': '',
-        'allowedExpansion_r': 200, 'allowedExpansion_b': 400,
+        'allowedExpansion_r': 200, 'allowedExpansion_b': 300,
         'allowedExpansion_t': 0, 'allowedExpansion_l': 0, 'yInView': 1,
         'xInView': 1,
       };

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-safeframe.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-safeframe.js
@@ -218,6 +218,13 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
     });
 
     it('should get current geometry when safeframe fills amp-ad', () => {
+      sandbox./*OK*/stub(safeframeHost.baseInstance_,
+          'getPageLayoutBox').returns({
+        top: 0,
+        left: 0,
+        right: 300,
+        bottom: 250,
+      });
       const safeframeMock = createElementWithAttributes(doc, 'iframe', {
         'class': 'safeframe',
       });
@@ -254,6 +261,13 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
     });
 
     it('should get geometry when safeframe does not fill amp-ad', () => {
+      sandbox./*OK*/stub(safeframeHost.baseInstance_,
+          'getPageLayoutBox').returns({
+        top: 0,
+        left: 0,
+        right: 50,
+        bottom: 50,
+      });
       // In this case, the safeframe is smaller than its containing
       // amp-ad element.
       const safeframeMock = createElementWithAttributes(doc, 'iframe', {
@@ -334,6 +348,13 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
 
   describe('formatGeom', () => {
     it('should build proper geometry update', () => {
+      sandbox./*OK*/stub(safeframeHost.baseInstance_,
+          'getPageLayoutBox').returns({
+        top: 200,
+        left: 100,
+        right: 400,
+        bottom: 800,
+      });
       const iframeBox = {
         top: 200,
         left: 100,


### PR DESCRIPTION
There was a mismatch between $sf.ext.geom().self on AMP pages and non-AMP pages. This should fix that. 

On AMP pages, self was being measured relative to the top of the viewport. However, on non-amp pages self is measured relative to the top of the page. 