### PR TITLE
Add amp-story embed modes

### DIFF
--- a/extensions/amp-story/0.1/amp-story-auto-ads.js
+++ b/extensions/amp-story/0.1/amp-story-auto-ads.js
@@ -25,6 +25,7 @@ import {createElementWithAttributes} from '../../../src/dom';
 import {dev, user} from '../../../src/log';
 import {dict, hasOwn} from '../../../src/utils/object';
 import {isJsonScriptTag} from '../../../src/dom';
+import {parseEmbedMode} from './embed-mode';
 import {parseJson} from '../../../src/json';
 
 
@@ -109,7 +110,7 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
-    const embedMode = this.parseEmbedMode_(this.win.location.hash);
+    const embedMode = parseEmbedMode(this.win.location.hash);
     this.stateService_.initializeEmbedMode(embedMode);
     if (!this.isAutomaticAdInsertionAllowed_()) {
       return;

--- a/extensions/amp-story/0.1/amp-story-state-service.js
+++ b/extensions/amp-story/0.1/amp-story-state-service.js
@@ -1,0 +1,189 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {EmbedMode} from './embed-mode';
+import {Observable} from '../../../src/observable';
+import {dev} from '../../../src/log';
+import {dict} from '../../../src/utils/object';
+import {isArray} from '../../../src/types';
+
+
+/** @typedef {{type: !StateType, value: *}} */
+export let StateChangeEventDef;
+
+/** @private @const @enum {string} */
+export const StateType = {
+  BOOKEND_ACTIVE: 'bookendactive',
+  NAVIGATION_OVERLAY_HINT_SHOWN: 'navigationoverlayhintshown',
+  NO_PREVIOUS_PAGE_HELP_SHOWN: 'nopreviouspagehelpshown',
+  ALLOW_AUTOMATIC_AD_INSERTION: 'allowautomaticadinsertion',
+  SYSTEM_LAYER_BUTTONS_SHOWN: 'systemlayerbuttonsshown',
+  MUTE_AUDIO_BY_DEFAULT: 'muteaudiobydefault',
+};
+
+/**
+ *
+ */
+export class AmpStoryStateService {
+  // TODO(newmuis): Scope this to story using a static for(...) function so that
+  // it can be retrieved from other classes (e.g. AmpStoryPage) without directly
+  // passing it.
+  constructor() {
+    this.states_ = dict({});
+  }
+
+  /**
+   * @param {!StateType} stateType
+   * @return {!State}
+   */
+  getState(stateType) {
+    return dev().assert(this.states_[stateType], `Unknown state ${stateType}.`);
+  }
+
+  /**
+   * @param {!State|!Array<!State>} stateOrArr
+   */
+  initializeState(stateOrArr) {
+    if (isArray(stateOrArr)) {
+      stateOrArr.forEach(state => {
+        this.initializeSinglevalue_(state);
+      });
+    } else {
+      this.initializeSinglevalue_(/** @type {!State} */ (stateOrArr));
+    }
+  }
+
+  /**
+   * @param {!State} state
+   * @private
+   */
+  initializeSinglevalue_(state) {
+    dev().assert(!this.states_[state.type],
+        `Duplicate entries for state ${state.type}.`);
+    this.states_[state.type] = state;
+  }
+
+  /**
+   * @param {!EmbedMode} embedMode
+   */
+  initializeEmbedMode(embedMode) {
+    switch (embedMode) {
+      case EmbedMode.NAME_TBD:
+        this.initializeState([
+          new State(StateType.BOOKEND_ACTIVE,
+              false /* defaultValue */, false /* isModifiable */),
+          new State(StateType.NAVIGATION_OVERLAY_HINT_SHOWN,
+              false /* defaultValue */, false /* isModifiable */),
+          new State(StateType.NO_PREVIOUS_PAGE_HELP_SHOWN,
+              false /* defaultValue */, true /* isModifiable */),
+          new State(StateType.ALLOW_AUTOMATIC_AD_INSERTION,
+              false /* defaultValue */, false /* isModifiable */),
+          new State(StateType.SYSTEM_LAYER_BUTTONS_SHOWN,
+              false /* defaultValue */, false /* isModifiable */),
+          new State(StateType.MUTE_AUDIO_BY_DEFAULT,
+              false /* defaultValue */, false /* isModifiable */),
+        ]);
+        break;
+
+      default:
+        this.initializeState([
+          new State(StateType.BOOKEND_ACTIVE,
+              false /* defaultValue */, true /* isModifiable */),
+          new State(StateType.NAVIGATION_OVERLAY_HINT_SHOWN,
+              false /* defaultValue */, true /* isModifiable */),
+          new State(StateType.NO_PREVIOUS_PAGE_HELP_SHOWN,
+              false /* defaultValue */, true /* isModifiable */),
+          new State(StateType.ALLOW_AUTOMATIC_AD_INSERTION,
+              true /* defaultValue */, true /* isModifiable */),
+          new State(StateType.SYSTEM_LAYER_BUTTONS_SHOWN,
+              true /* defaultValue */, true /* isModifiable */),
+          new State(StateType.MUTE_AUDIO_BY_DEFAULT,
+              true /* defaultValue */, true /* isModifiable */),
+        ]);
+        break;
+    }
+  }
+}
+
+
+/**
+ * TODO(newmuis): Perhaps some of this can be merged with
+ * ../../../src/finite-state-machine.js
+ * @template T
+ */
+class State {
+  /**
+   * @param {!StateType} type
+   * @param {T} defaultValue
+   * @param {boolean} isModifiable
+   */
+  constructor(type, defaultValue, isModifiable) {
+    /** @const {!StateType} */
+    this.type = type;
+
+    /** @private {T} */
+    this.value_ = defaultValue;
+
+    /** @private @const {!Observable<StateChangeEventDef>} */
+    this.observable_ = new Observable();
+
+    /** @private @const {boolean} */
+    this.isModifiable_ = isModifiable;
+  }
+
+  /**
+   * @return {boolean}
+   */
+  isModifiable() {
+    return this.isModifiable_;
+  }
+
+  /**
+   * @return {T}
+   */
+  getValue() {
+    return this.value_;
+  }
+
+  /**
+   * @param {function(!StateChangeEventDef):void} stateChangeFn
+   */
+  observe(stateChangeFn) {
+    this.observable_.add(stateChangeFn);
+  }
+
+  /**
+   * @param {T} value The new state
+   */
+  setValue(value) {
+    if (this.isModifiable) {
+      dev().error('AMP-STORY',
+          `Cannot change readonly state ${this.isModifiable}.`);
+      return;
+    }
+
+    if (value === this.getValue()) {
+      return;
+    }
+
+    this.value_ = value;
+    this.onStateUpdated_();
+  }
+
+  /** @private */
+  onStateUpdated_() {
+    this.observable_.fire({type: this.type, value: this.value_});
+  }
+}

--- a/extensions/amp-story/0.1/amp-story.css
+++ b/extensions/amp-story/0.1/amp-story.css
@@ -202,7 +202,9 @@ amp-story[standalone]:fullscreen {
 
 .i-amphtml-story-ui-no-buttons .i-amphtml-story-button,
 .i-amphtml-story-ui-no-buttons .i-amphtml-story-ui-left,
-.i-amphtml-story-ui-no-buttons .i-amphtml-story-ui-right {
+.i-amphtml-story-ui-no-buttons .i-amphtml-story-ui-right,
+[desktop] .i-amphtml-story-ui-no-buttons .i-amphtml-story-ui-left,
+[desktop] .i-amphtml-story-ui-no-buttons .i-amphtml-story-ui-right {
   display: none !important;
 }
 

--- a/extensions/amp-story/0.1/amp-story.css
+++ b/extensions/amp-story/0.1/amp-story.css
@@ -200,6 +200,12 @@ amp-story[standalone]:fullscreen {
   display: block !important;
 }
 
+.i-amphtml-story-ui-no-buttons .i-amphtml-story-button,
+.i-amphtml-story-ui-no-buttons .i-amphtml-story-ui-left,
+.i-amphtml-story-ui-no-buttons .i-amphtml-story-ui-right {
+  display: none !important;
+}
+
 amp-story .amp-video-eq {
   display: none !important;
 }

--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -43,7 +43,6 @@ import {
   DoubletapRecognizer,
   SwipeXYRecognizer,
 } from '../../../src/gesture-recognizers';
-import {EmbedMode} from './embed-mode';
 import {EventType, dispatch} from './events';
 import {Gestures} from '../../../src/gesture';
 import {KeyCodes} from '../../../src/utils/key-codes';
@@ -75,10 +74,9 @@ import {dict} from '../../../src/utils/object';
 import {findIndex} from '../../../src/utils/array';
 import {getMode} from '../../../src/mode';
 import {getSourceOrigin, parseUrl} from '../../../src/url';
-import {isEnumValue} from '../../../src/types';
 import {isExperimentOn, toggleExperiment} from '../../../src/experiments';
 import {once} from '../../../src/utils/function';
-import {parseQueryString} from '../../../src/url';
+import {parseEmbedMode} from './embed-mode';
 import {registerServiceBuilder} from '../../../src/service';
 import {relatedArticlesFromJson} from './related-articles';
 import {renderSimpleTemplate} from './simple-template';
@@ -369,7 +367,7 @@ export class AmpStory extends AMP.BaseElement {
       this.onResize();
     }, html);
 
-    const embedMode = this.parseEmbedMode_(this.win.location.hash);
+    const embedMode = parseEmbedMode(this.win.location.hash);
     this.stateService_.initializeEmbedMode(embedMode);
   }
 
@@ -772,22 +770,6 @@ export class AmpStory extends AMP.BaseElement {
     this.element.appendChild(errorEl);
 
     user().error(TAG, 'enable amp-story experiment');
-  }
-
-
-  /**
-   * @param {string} str
-   * @return {!EmbedMode}
-   * @private
-   */
-  parseEmbedMode_(str) {
-    const params = parseQueryString(str);
-    const unsanitizedEmbedMode = params['embedMode'];
-    const embedModeIndex = parseInt(unsanitizedEmbedMode, 10);
-
-    return isEnumValue(EmbedMode, embedModeIndex)
-      ? /** @type {!EmbedMode} */ (embedModeIndex)
-      : EmbedMode.NOT_EMBEDDED;
   }
 
 

--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -1580,8 +1580,7 @@ export class AmpStory extends AMP.BaseElement {
     const allowAutomaticAdInsertion = this.stateService_
         .getState(StateType.ALLOW_AUTOMATIC_AD_INSERTION);
 
-    if (pageToBeInsertedEl.hasAttribute('ad') &&
-        !allowAutomaticAdInsertion.getValue()) {
+    if (pageToBeInserted.isAd() && !allowAutomaticAdInsertion.getValue()) {
       dev().expectedError(TAG, 'Inserting ads automatically is disallowed.');
       return false;
     }

--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -31,6 +31,10 @@ import {ActionTrust} from '../../../src/action-trust';
 import {AmpStoryAnalytics} from './analytics';
 import {AmpStoryBackground} from './background';
 import {AmpStoryHint} from './amp-story-hint';
+import {
+  AmpStoryStateService,
+  StateType,
+} from './amp-story-state-service';
 import {AmpStoryVariableService} from './variable-service';
 import {Bookend} from './bookend';
 import {CSS} from '../../../build/amp-story-0.1.css';
@@ -39,6 +43,7 @@ import {
   DoubletapRecognizer,
   SwipeXYRecognizer,
 } from '../../../src/gesture-recognizers';
+import {EmbedMode} from './embed-mode';
 import {EventType, dispatch} from './events';
 import {Gestures} from '../../../src/gesture';
 import {KeyCodes} from '../../../src/utils/key-codes';
@@ -70,8 +75,10 @@ import {dict} from '../../../src/utils/object';
 import {findIndex} from '../../../src/utils/array';
 import {getMode} from '../../../src/mode';
 import {getSourceOrigin, parseUrl} from '../../../src/url';
+import {isEnumValue} from '../../../src/types';
 import {isExperimentOn, toggleExperiment} from '../../../src/experiments';
 import {once} from '../../../src/utils/function';
+import {parseQueryString} from '../../../src/url';
 import {registerServiceBuilder} from '../../../src/service';
 import {relatedArticlesFromJson} from './related-articles';
 import {renderSimpleTemplate} from './simple-template';
@@ -253,6 +260,9 @@ export class AmpStory extends AMP.BaseElement {
     this.navigationState_ =
         new NavigationState(element, () => this.hasBookend_());
 
+    /** @private @const {!AmpStoryStateService} */
+    this.stateService_ = new AmpStoryStateService();
+
     /** @const @private {!../../../src/service/vsync-impl.Vsync} */
     this.vsync_ = this.getVsync();
 
@@ -260,7 +270,7 @@ export class AmpStory extends AMP.BaseElement {
     this.bookend_ = new Bookend(this.win);
 
     /** @private @const {!SystemLayer} */
-    this.systemLayer_ = new SystemLayer(this.win);
+    this.systemLayer_ = new SystemLayer(this.win, this.stateService_);
 
     /** @private @const {!Array<string>} */
     this.pageHistoryStack_ = [];
@@ -321,14 +331,7 @@ export class AmpStory extends AMP.BaseElement {
     this.assertAmpStoryExperiment_();
 
     if (this.element.hasAttribute(AMP_STORY_STANDALONE_ATTRIBUTE)) {
-      const html = this.win.document.documentElement;
-      this.mutateElement(() => {
-        html.classList.add('i-amphtml-story-standalone');
-        // Lock body to prevent overflow.
-        this.lockBody_();
-        // Standalone CSS affects sizing of the entire page.
-        this.onResize();
-      }, html);
+      this.initializeStandaloneStory_();
     }
 
     if (this.isDesktop_()) {
@@ -352,6 +355,22 @@ export class AmpStory extends AMP.BaseElement {
 
     registerServiceBuilder(this.win, 'story-variable',
         () => this.variableService_);
+  }
+
+
+  /** @private */
+  initializeStandaloneStory_() {
+    const html = this.win.document.documentElement;
+    this.mutateElement(() => {
+      html.classList.add('i-amphtml-story-standalone');
+      // Lock body to prevent overflow.
+      this.lockBody_();
+      // Standalone CSS affects sizing of the entire page.
+      this.onResize();
+    }, html);
+
+    const embedMode = this.parseEmbedMode_(this.win.location.hash);
+    this.stateService_.initializeEmbedMode(embedMode);
   }
 
 
@@ -386,7 +405,11 @@ export class AmpStory extends AMP.BaseElement {
     });
 
     this.element.addEventListener(EventType.SHOW_BOOKEND, () => {
-      this.showBookend_();
+      this.hasBookend_().then(hasBookend => {
+        if (hasBookend) {
+          this.showBookend_();
+        }
+      });
     });
 
     this.element.addEventListener(EventType.CLOSE_BOOKEND, () => {
@@ -437,8 +460,13 @@ export class AmpStory extends AMP.BaseElement {
       this.replay_();
     });
 
+    const noPreviousPageHelpShown = this.stateService_
+        .getState(StateType.NO_PREVIOUS_PAGE_HELP_SHOWN);
+
     this.element.addEventListener(EventType.SHOW_NO_PREVIOUS_PAGE_HELP, () => {
-      this.ampStoryHint_.showFirstPageHintOverlay();
+      if (noPreviousPageHelpShown.isModifiable()) {
+        this.ampStoryHint_.showFirstPageHintOverlay();
+      }
     });
 
     this.element.addEventListener(EventType.TAP_NAVIGATION, e => {
@@ -474,6 +502,12 @@ export class AmpStory extends AMP.BaseElement {
       if (!this.isSwipeLargeEnoughForHint_(deltaX)) {
         return;
       }
+      const navigationOverlayHintShown = this.stateService_
+          .getState(StateType.NAVIGATION_OVERLAY_HINT_SHOWN);
+      if (!navigationOverlayHintShown.isModifiable()) {
+        return;
+      }
+
       this.ampStoryHint_.showNavigationOverlay();
     });
   }
@@ -741,6 +775,22 @@ export class AmpStory extends AMP.BaseElement {
   }
 
 
+  /**
+   * @param {string} str
+   * @return {!EmbedMode}
+   * @private
+   */
+  parseEmbedMode_(str) {
+    const params = parseQueryString(str);
+    const unsanitizedEmbedMode = params['embedMode'];
+    const embedModeIndex = parseInt(unsanitizedEmbedMode, 10);
+
+    return isEnumValue(EmbedMode, embedModeIndex)
+      ? /** @type {!EmbedMode} */ (embedModeIndex)
+      : EmbedMode.NOT_EMBEDDED;
+  }
+
+
   /** @private */
   initializePages_() {
     const pageImplPromises = Array.prototype.map.call(
@@ -770,11 +820,7 @@ export class AmpStory extends AMP.BaseElement {
         activePage !== lastPage) {
       activePage.next(opt_isAutomaticAdvance);
     } else {
-      this.hasBookend_().then(hasBookend => {
-        if (hasBookend) {
-          dispatch(this.element, EventType.SHOW_BOOKEND);
-        }
-      });
+      dispatch(this.element, EventType.SHOW_BOOKEND);
     }
   }
 
@@ -1265,6 +1311,14 @@ export class AmpStory extends AMP.BaseElement {
    * @private
    */
   hasBookend_() {
+    const bookendActive = this.stateService_.getState(StateType.BOOKEND_ACTIVE);
+    if (!bookendActive.isModifiable()) {
+      // Whether the bookend is active cannot be modified; its current value can
+      // be assumed.
+      return Promise.resolve(bookendActive.getValue());
+    }
+
+    // TODO(newmuis): Change this comment.
     // On mobile there is always a bookend. On desktop, the bookend will only
     // be shown if related articles have been configured.
     if (!this.isDesktop_()) {
@@ -1540,6 +1594,15 @@ export class AmpStory extends AMP.BaseElement {
     // TODO(ccordry): make sure this method moves to PageManager when implemented
     const pageToBeInserted = this.getPageById(pageToBeInsertedId);
     const pageToBeInsertedEl = pageToBeInserted.element;
+
+    const allowAutomaticAdInsertion = this.stateService_
+        .getState(StateType.ALLOW_AUTOMATIC_AD_INSERTION);
+
+    if (pageToBeInsertedEl.hasAttribute('ad') &&
+        !allowAutomaticAdInsertion.getValue()) {
+      dev().expectedError(TAG, 'Inserting ads automatically is disallowed.');
+      return false;
+    }
 
     const pageBefore = this.getPageById(pageBeforeId);
     const pageBeforeEl = pageBefore.element;

--- a/extensions/amp-story/0.1/embed-mode.js
+++ b/extensions/amp-story/0.1/embed-mode.js
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+/**
+ * Embed mode for AMP story.  See ../embed-modes.md for details.
+ * @enum {number}
+ */
+export const EmbedMode = {
+  /**
+   * Default mode.
+   */
+  NOT_EMBEDDED: 0,
+
+  /**
+   * TBD embed mode.
+   *
+   * This differs from the NOT_EMBEDDED embed mode in the following ways:
+   * - Hides bookend
+   * - Hides all system layer buttons
+   * - Disables swipe-based user education
+   * - Disallows ads
+   * - Unmutes audio in the story by default
+   */
+  NAME_TBD: 1,
+};

--- a/extensions/amp-story/0.1/embed-mode.js
+++ b/extensions/amp-story/0.1/embed-mode.js
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import {isEnumValue} from '../../../src/types';
+import {parseQueryString} from '../../../src/url';
 
 
 /**
@@ -37,3 +39,19 @@ export const EmbedMode = {
    */
   NAME_TBD: 1,
 };
+
+
+/**
+ * @param {string} str
+ * @return {!EmbedMode}
+ * @private
+ */
+export function parseEmbedMode(str) {
+  const params = parseQueryString(str);
+  const unsanitizedEmbedMode = params['embedMode'];
+  const embedModeIndex = parseInt(unsanitizedEmbedMode, 10);
+
+  return isEnumValue(EmbedMode, embedModeIndex)
+    ? /** @type {!EmbedMode} */ (embedModeIndex)
+    : EmbedMode.NOT_EMBEDDED;
+}

--- a/extensions/amp-story/0.1/system-layer.js
+++ b/extensions/amp-story/0.1/system-layer.js
@@ -17,6 +17,7 @@ import {DevelopmentModeLog, DevelopmentModeLogButtonSet} from './development-ui'
 import {EventType, dispatch} from './events';
 import {ProgressBar} from './progress-bar';
 import {Services} from '../../../src/services';
+import {StateType} from './amp-story-state-service';
 import {dev} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {getMode} from '../../../src/mode';
@@ -88,8 +89,9 @@ const TEMPLATE = {
 export class SystemLayer {
   /**
    * @param {!Window} win
+   * @param {!./amp-story-state-service.AmpStoryStateService} stateService
    */
-  constructor(win) {
+  constructor(win, stateService) {
     /** @private {!Window} */
     this.win_ = win;
 
@@ -116,6 +118,9 @@ export class SystemLayer {
 
     /** @private {!DevelopmentModeLogButtonSet} */
     this.developerButtons_ = DevelopmentModeLogButtonSet.create(win);
+
+    /** @private {!./amp-story-state-service.AmpStoryStateService} */
+    this.stateService_ = stateService;
   }
 
   /**
@@ -140,6 +145,15 @@ export class SystemLayer {
     this.buildForDevelopmentMode_();
 
     this.addEventHandlers_();
+
+    const systemLayerButtonsShown = this.stateService_
+        .getState(StateType.SYSTEM_LAYER_BUTTONS_SHOWN);
+
+    // TODO(newmuis): Observe this value.
+    if (!systemLayerButtonsShown.getValue() &&
+        !systemLayerButtonsShown.isModifiable()) {
+      this.root_.classList.add('i-amphtml-story-ui-no-buttons');
+    }
 
     return this.getRoot();
   }

--- a/extensions/amp-story/0.1/test/test-system-layer.js
+++ b/extensions/amp-story/0.1/test/test-system-layer.js
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import {AmpStoryStateService} from '../amp-story-state-service';
 import {ProgressBar} from '../progress-bar';
 import {Services} from '../../../../src/services';
 import {SystemLayer} from '../system-layer';
@@ -26,6 +27,7 @@ describes.fakeWin('amp-story system layer', {}, env => {
   let systemLayer;
   let progressBarStub;
   let progressBarRoot;
+  let stateService;
 
   beforeEach(() => {
     win = env.win;
@@ -41,7 +43,9 @@ describes.fakeWin('amp-story system layer', {}, env => {
 
     sandbox.stub(ProgressBar, 'create').returns(progressBarStub);
 
-    systemLayer = new SystemLayer(win);
+    stateService = new AmpStoryStateService();
+
+    systemLayer = new SystemLayer(win, stateService);
 
     sandbox.stub(Services, 'vsyncFor').returns({
       mutate: fn => fn(),


### PR DESCRIPTION
This allows us to have an "embed mode" that changes the functionality/appearance of a story.  It currently only adds a single mode that disables ads and most system UI.

/cc @gmajoulet but I might not have time to wait for his review, since he's on Paris time at the moment 😄 