### PR TITLE
Fix test failure due to browser behavior on getting location.hash

### DIFF
--- a/test/functional/test-navigation.js
+++ b/test/functional/test-navigation.js
@@ -420,10 +420,10 @@ describes.sandboxed('Navigation', {}, () => {
 
       it('should use escaped css selectors with quotes', () => {
         anchor.href =
-            'https://www.google.com/some-path?hello=world#test"hello';
-        anchorWithName.setAttribute('name', 'test"hello');
+            'https://www.google.com/some-path?hello=world#test%22hello';
+        anchorWithName.setAttribute('name', 'test%22hello');
         handler.handle_(event);
-        expect(replaceStateForTargetStub).to.be.calledWith('#test"hello');
+        expect(replaceStateForTargetStub).to.be.calledWith('#test%22hello');
         return replaceStateForTargetPromise.then(() => {
           expect(scrollIntoViewStub).to.be.calledWith(anchorWithName);
         });


### PR DESCRIPTION
I assume travis changed the testing environment, and it caused the test to fail. Because `window.location.hash` was encoded in new environment.  I encoded the hash to fix the test failure.
Note I tried with Chrome and Firefox. Firefox won't double encode the string, and Chrome won't decode the string so the fix shouldn't be flaky. 