### PR TITLE
Undo important on grid for media query

### DIFF
--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.css
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.css
@@ -159,7 +159,7 @@
   display: grid !important;
   justify-content: center !important;
   grid-gap: 5px !important;
-  grid-template-columns: repeat(3, 1fr) !important;
+  grid-template-columns: repeat(3, 1fr);
   grid-auto-rows: min-content !important;
   padding: 5px;
 }


### PR DESCRIPTION
We have two grid templates (3 / row, 4 / row) that alternate based on a media query. In order for the media query to register, we can't `!important` this property. 