### PR TITLE
🏗Make node 8 the minimum version for AMP development

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 sudo: required  # See http://docs.travis-ci.com/user/trusty-ci-environment/
 dist: trusty
 node_js:
-  - "6"
+  - "8"
 python:
   - "2.7"
 notifications:

--- a/build-system/check-package-manager.js
+++ b/build-system/check-package-manager.js
@@ -55,19 +55,19 @@ function main() {
     return 1;
   }
 
-  // Perform a node version check and print a warning if it is < v6 or == v7.
+  // Perform a node version check and print a warning if it is < v8.
   const nodeVersion = getStdout('node --version').trim();
   let majorVersion = nodeVersion.split('.')[0];
   if (majorVersion.charAt(0) === 'v') {
     majorVersion = majorVersion.slice(1);
   }
   majorVersion = parseInt(majorVersion, 10);
-  if (majorVersion < 6 || majorVersion == 7) {
+  if (majorVersion < 8) {
     console.log(yellow('WARNING: Detected node version'),
         cyan(nodeVersion) + yellow('. Recommended version is'),
-        cyan('v6') + yellow('.'));
+        cyan('v8') + yellow('.'));
     console.log(yellow('To fix this, run'),
-        cyan('"nvm install 6"'), yellow('or see'),
+        cyan('"nvm install 8"'), yellow('or see'),
         cyan('https://nodejs.org/en/download/package-manager'),
         yellow('for instructions.'));
   } else {

--- a/contributing/getting-started-e2e.md
+++ b/contributing/getting-started-e2e.md
@@ -160,7 +160,7 @@ Now that you have all of the files copied locally you can actually build the cod
 
 amphtml uses Node.js, the Yarn package manager and the Gulp build system to build amphtml and start up a local server that lets you try out your changes.  Installing these and getting amphtml built is straightforward:
 
-* Install [Node.js](https://nodejs.org/) version >= 6 (which includes npm).
+* Install [Node.js](https://nodejs.org/) version >= 8 (which includes npm).
 
   [NVM](https://github.com/creationix/nvm) is a convenient way to do this on Mac and Linux, especially if you have other projects that require different versions of Node.
 

--- a/contributing/getting-started-quick.md
+++ b/contributing/getting-started-quick.md
@@ -25,7 +25,7 @@ This Quick Start guide is the TL;DR version of the longer [end-to-end guide](get
 
 * [Install and set up Git](https://help.github.com/articles/set-up-git/); in the "Authenticating" step of that page use SSH instead of HTTPS
 
-* Install [Node.js](https://nodejs.org/) version >= 6 (which includes npm); [NVM](https://github.com/creationix/nvm) is a convenient way to do this on Mac and Linux
+* Install [Node.js](https://nodejs.org/) version >= 8 (which includes npm); [NVM](https://github.com/creationix/nvm) is a convenient way to do this on Mac and Linux
 
 * Install [Yarn](https://yarnpkg.com/) version >= 1.2.0 (instructions [here](https://yarnpkg.com/en/docs/install), this may require elevated privileges using `sudo` on some platforms)
 


### PR DESCRIPTION
We currently use node 6 for AMP development. Soon, node 6 will enter maintenance mode, and node 8 will be the lowest active LTS version. See https://github.com/nodejs/Release

This PR makes node 8 the minimum version for AMP development.


Related to https://github.com/ampproject/amphtml/pull/13792#discussion_r172301815