### PR TITLE
When passing a file glob to lint, don't lose the files we're not supposed to be linting.

### DIFF
--- a/build-system/tasks/lint.js
+++ b/build-system/tasks/lint.js
@@ -127,7 +127,10 @@ function lint() {
   if (argv.fix) {
     options.fix = true;
   }
-  const stream = initializeStream(argv.files || config.lintGlobs, {});
+  if (argv.files) {
+    config.lintGlobs[config.lintGlobs.indexOf('**/*.js')] = argv.files;
+  }
+  const stream = initializeStream(config.lintGlobs, {});
   return runLinter('.', stream, options);
 }
 


### PR DESCRIPTION
See comment https://github.com/ampproject/amphtml/pull/13811#issuecomment-371248664