### PR TITLE
Fix Exp in Amp Dfp Safeframes to return data consistent with DFP safeframes

### DIFF
--- a/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
@@ -340,11 +340,11 @@ export class SafeframeHostApi {
       // AMP's built in resize methodology that we use only allows expansion
       // to the right and bottom, so we enforce that here.
       'allowedExpansion_r': viewportSize.width -
-          iframeBox.width,
+          iframeBox.right,
       'allowedExpansion_b': viewportSize.height -
-          iframeBox.height,
-      'allowedExpansion_t': 0,
-      'allowedExpansion_l': 0,
+          iframeBox.bottom,
+      'allowedExpansion_t': iframeBox.top,
+      'allowedExpansion_l': iframeBox.left,
       'yInView': this.getPercInView(viewportSize.height,
           iframeBox.top, iframeBox.bottom),
       'xInView': this.getPercInView(viewportSize.width,

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-safeframe.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-safeframe.js
@@ -358,8 +358,8 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
       const iframeBox = {
         top: 300,
         left: 200,
-        bottom: 1000,
-        right: 500,
+        bottom: 900,
+        right: 350,
         width: 300,
         height: 700,
       };
@@ -371,8 +371,8 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
         'windowCoords_t': 0, 'windowCoords_r': 500, 'windowCoords_b': 1000,
         'windowCoords_l': 0, 'frameCoords_t': 200, 'frameCoords_r': 400,
         'frameCoords_b': 800, 'frameCoords_l': 100, 'styleZIndex': '',
-        'allowedExpansion_r': 200, 'allowedExpansion_b': 300,
-        'allowedExpansion_t': 0, 'allowedExpansion_l': 0, 'yInView': 1,
+        'allowedExpansion_r': 150, 'allowedExpansion_b': 100,
+        'allowedExpansion_t': 300, 'allowedExpansion_l': 200, 'yInView': 1,
         'xInView': 1,
       };
       const safeframeGeometryUpdate = safeframeHost.formatGeom_(


### PR DESCRIPTION
Fixes Exp in Amp Dfp to return the distance available to expand in each direction like the dfp safeframes do. 

Exp is expected to return the distance that can be expanded in each direction from the item to the outside of the screen. For example, it is expected to be the distance from the left side of the content to the left side of the screen or from the top side to the top of the screen, etc. Previously the code returned the size of the screen minus the size of the safeframe for right and bottom, and then 0 for top and left. 