### PR TITLE
🏗 Use latest LTS version of node for AMP development

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 sudo: required  # See http://docs.travis-ci.com/user/trusty-ci-environment/
 dist: trusty
 node_js:
-  - "8"
+  - "lts/*"
 python:
   - "2.7"
 notifications:

--- a/contributing/getting-started-e2e.md
+++ b/contributing/getting-started-e2e.md
@@ -160,9 +160,13 @@ Now that you have all of the files copied locally you can actually build the cod
 
 amphtml uses Node.js, the Yarn package manager and the Gulp build system to build amphtml and start up a local server that lets you try out your changes.  Installing these and getting amphtml built is straightforward:
 
-* Install [Node.js](https://nodejs.org/) version >= 8 (which includes npm).
+* Install the latest LTS version of [Node.js](https://nodejs.org/) (which includes npm).
 
-  [NVM](https://github.com/creationix/nvm) is a convenient way to do this on Mac and Linux, especially if you have other projects that require different versions of Node.
+  On Mac and Linux, you can use [nvm](https://github.com/creationix/nvm), especially if you have other projects that require different versions of Node.
+
+   ```
+   nvm install --lts
+   ```
 
 * Install [Yarn](https://yarnpkg.com/) version >= 1.2.0 (instructions [here](https://yarnpkg.com/en/docs/install), this may require elevated privileges using `sudo` on some platforms)
 

--- a/contributing/getting-started-quick.md
+++ b/contributing/getting-started-quick.md
@@ -25,7 +25,7 @@ This Quick Start guide is the TL;DR version of the longer [end-to-end guide](get
 
 * [Install and set up Git](https://help.github.com/articles/set-up-git/); in the "Authenticating" step of that page use SSH instead of HTTPS
 
-* Install [Node.js](https://nodejs.org/) version >= 8 (which includes npm); [NVM](https://github.com/creationix/nvm) is a convenient way to do this on Mac and Linux
+* Install the latest LTS version of [Node.js](https://nodejs.org/) (which includes npm). [nvm](https://github.com/creationix/nvm) is a convenient way to do this on Mac and Linux
 
 * Install [Yarn](https://yarnpkg.com/) version >= 1.2.0 (instructions [here](https://yarnpkg.com/en/docs/install), this may require elevated privileges using `sudo` on some platforms)
 


### PR DESCRIPTION
In #13848, we switched the minimum node version for AMP development from v6 to v8 because v6 is about to enter maintenance mode, while v8 is the latest LTS version.

Since the node version recommended for AMP development is hard-coded, it is likely to go out of date the next time the latest LTS version changes.

This PR ads a detection mechanism for the latest LTS version of node, and warns the user when the major version of their local node installation does not match the major version of the latest LTS version. Minor version changes are ignored. It also pins the version of node we use on Travis to the latest LTS version.

Tested on Windows, Mac and Linux.

Follow up to #13848
Related to https://github.com/ampproject/amphtml/pull/13792#discussion_r172301815