### PR TITLE
🏗 Restrict same-line logging in gulp lint to TTY terminals

### DIFF
--- a/build-system/tasks/lint.js
+++ b/build-system/tasks/lint.js
@@ -62,7 +62,7 @@ function initializeStream(globs, streamOptions) {
  * @param {string} message
  */
 function logOnSameLine(message) {
-  if (!process.env.TRAVIS) {
+  if (!process.env.TRAVIS && process.stdout.isTTY) {
     process.stdout.moveCursor(0, -1);
     process.stdout.cursorTo(0);
     process.stdout.clearLine();


### PR DESCRIPTION
This allows you to do things like `gulp lint > foo.txt`.

Follow up to #13811 and #13858