### PR TITLE
Remove deferMutate

### DIFF
--- a/contributing/building-an-amp-extension.md
+++ b/contributing/building-an-amp-extension.md
@@ -442,7 +442,7 @@ image directly from instagram media endpoint.
 
 ```javascript
 class AmpInstagram extends AMP.BaseElement {
-  // ...  
+  // ...
   /** @override */
   createPlaceholderCallback() {
     const placeholder = this.getWin().document.createElement('div');
@@ -527,7 +527,7 @@ embedded when `unlayoutCallback` is called.
 unlayoutCallback() {
   if (this.iframe_) {
     removeElement(this.iframe_);
-    this.iframe_ = null;    
+    this.iframe_ = null;
     this.iframePromise_ = null;
     setStyles(this.placeholderWrapper_, {
       'display': '',
@@ -542,7 +542,7 @@ probably wants to return true in order to signal to AMP the need to call
 `layoutCallback` again once the document is active. Otherwise your
 element will never be re-laid out.
 
-### vsync, mutateElement, deferMutate and changeSize
+### vsync, mutateElement, and changeSize
 
 AMP provides multiple utilities to optimize many mutations and measuring
 for better performance. These include vsync service with a mutate and
@@ -628,7 +628,7 @@ in EXPERIMENTS variable.
 const EXPERIMENTS = [
   // ...
   {
-    id: 'amp-my-element',  
+    id: 'amp-my-element',
     name: 'AMP My Element',
     spec: 'https://github.com/ampproject/amphtml/blob/master/extensions/' +
       'amp-my-element/amp-my-element.md',
@@ -665,7 +665,7 @@ Class AmpMyElement extends AMP.BaseElement {
   }
 
   /** @override */
-  buildCallback() {  
+  buildCallback() {
     if (!isExperimentOn(this.getWin(), EXPERIMENT)) {
       user.warn('Experiment %s is not turned on.', EXPERIMENT);
       return;

--- a/extensions/amp-a4a/0.1/test/utils.js
+++ b/extensions/amp-a4a/0.1/test/utils.js
@@ -38,7 +38,7 @@ export class MockA4AImpl extends AmpA4A {
     // Do nothing.
   }
 
-  deferMutate(callback) {
+  mutateElement(callback) {
     callback();
   }
 

--- a/extensions/amp-ad/0.1/amp-ad-ui.js
+++ b/extensions/amp-ad/0.1/amp-ad-ui.js
@@ -58,8 +58,8 @@ export class AmpAdUIHandler {
       return;
     }
     // The order here is collapse > user provided fallback > default fallback
-    this.baseInstance_.attemptCollapse().then(() => {}, () => {
-      this.baseInstance_.deferMutate(() => {
+    this.baseInstance_.attemptCollapse().catch(() => {
+      this.baseInstance_.mutateElement(() => {
         this.baseInstance_.togglePlaceholder(false);
         this.baseInstance_.toggleFallback(true);
       });
@@ -71,7 +71,7 @@ export class AmpAdUIHandler {
    * Note: No need to togglePlaceholder here, unlayout show it by default.
    */
   applyUnlayoutUI() {
-    this.baseInstance_.deferMutate(() => {
+    this.baseInstance_.mutateElement(() => {
       this.baseInstance_.toggleFallback(false);
     });
   }

--- a/extensions/amp-ad/0.1/test/test-amp-ad-ui.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-ui.js
@@ -78,7 +78,7 @@ describes.realWin('amp-ad-ui handler', {
           () => {
             return Promise.reject();
           });
-      sandbox.stub(uiHandler.baseInstance_, 'deferMutate').callsFake(
+      sandbox.stub(uiHandler.baseInstance_, 'mutateElement').callsFake(
           callback => {
             callback();
             resolve();
@@ -101,7 +101,7 @@ describes.realWin('amp-ad-ui handler', {
       sandbox.stub(adImpl, 'attemptCollapse').callsFake(() => {
         return Promise.reject();
       });
-      sandbox.stub(adImpl, 'deferMutate').callsFake(callback => {
+      sandbox.stub(adImpl, 'mutateElement').callsFake(callback => {
         callback();
         resolve();
       });

--- a/extensions/amp-carousel/0.1/base-carousel.js
+++ b/extensions/amp-carousel/0.1/base-carousel.js
@@ -185,7 +185,7 @@ export class BaseCarousel extends AMP.BaseElement {
       const className = 'i-amphtml-carousel-button-start-hint';
       this.element.classList.add(className);
       Services.timerFor(this.win).delay(() => {
-        this.deferMutate(() => {
+        this.mutateElement(() => {
           this.element.classList.remove(className);
           this.prevButton_.classList.toggle(
               'i-amphtml-screen-reader', !this.showControls_);

--- a/extensions/amp-iframe/0.1/amp-iframe.js
+++ b/extensions/amp-iframe/0.1/amp-iframe.js
@@ -383,7 +383,7 @@ export class AmpIframe extends AMP.BaseElement {
       // 1s later via `amp-active` class.
       if (this.container_ != this.element) {
         Services.timerFor(this.win).delay(() => {
-          this.deferMutate(() => {
+          this.mutateElement(() => {
             this.container_.classList.add('amp-active');
           });
         }, 1000);

--- a/extensions/amp-install-serviceworker/0.1/amp-install-serviceworker.js
+++ b/extensions/amp-install-serviceworker/0.1/amp-install-serviceworker.js
@@ -181,7 +181,7 @@ export class AmpInstallServiceWorker extends AMP.BaseElement {
     const whenVisible =
         Services.viewerForDoc(this.getAmpDoc()).whenFirstVisible();
     return Promise.all([whenReady, whenVisible]).then(() => {
-      this.deferMutate(() => this.preloadShell_(shellUrl));
+      this.mutateElement(() => this.preloadShell_(shellUrl));
     });
   }
 

--- a/extensions/amp-install-serviceworker/0.1/test/test-amp-install-serviceworker.js
+++ b/extensions/amp-install-serviceworker/0.1/test/test-amp-install-serviceworker.js
@@ -360,8 +360,8 @@ describes.fakeWin('url rewriter', {
     let preloadStub;
 
     beforeEach(() => {
-      mutateElementStub = sandbox.stub(implementation, 'deferMutate').callsFake(
-          callback => callback());
+      mutateElementStub = sandbox.stub(implementation, 'mutateElement')
+          .callsFake(callback => callback());
       preloadStub = sandbox.stub(implementation, 'preloadShell_');
       viewer.setVisibilityState_('visible');
     });

--- a/extensions/amp-install-serviceworker/0.1/test/test-amp-install-serviceworker.js
+++ b/extensions/amp-install-serviceworker/0.1/test/test-amp-install-serviceworker.js
@@ -356,11 +356,11 @@ describes.fakeWin('url rewriter', {
   });
 
   describe('start shell preload', () => {
-    let deferMutateStub;
+    let mutateElementStub;
     let preloadStub;
 
     beforeEach(() => {
-      deferMutateStub = sandbox.stub(implementation, 'deferMutate').callsFake(
+      mutateElementStub = sandbox.stub(implementation, 'deferMutate').callsFake(
           callback => callback());
       preloadStub = sandbox.stub(implementation, 'preloadShell_');
       viewer.setVisibilityState_('visible');
@@ -388,7 +388,7 @@ describes.fakeWin('url rewriter', {
         return viewer.whenFirstVisible();
       }).then(() => {
         expect(preloadStub).to.be.calledOnce;
-        expect(deferMutateStub).to.be.calledOnce;
+        expect(mutateElementStub).to.be.calledOnce;
       });
     });
   });

--- a/extensions/amp-live-list/0.1/amp-live-list.js
+++ b/extensions/amp-live-list/0.1/amp-live-list.js
@@ -269,7 +269,7 @@ export class AmpLiveList extends AMP.BaseElement {
     // We prefer user interaction if we have pending items to insert at the
     // top of the component.
     if (this.pendingItemsInsert_.length > 0) {
-      this.deferMutate(() => {
+      this.mutateElement(() => {
         this.toggleUpdateButton_(true);
         this.viewport_.updateFixedLayer();
       });

--- a/extensions/amp-live-list/0.1/test/test-amp-live-list.js
+++ b/extensions/amp-live-list/0.1/test/test-amp-live-list.js
@@ -79,9 +79,6 @@ describe('amp-live-list', () => {
         cb();
       });
     };
-    liveList.deferMutate = cb => {
-      cb();
-    };
     return elem;
   }
 

--- a/extensions/amp-live-list/0.1/test/test-amp-live-list.js
+++ b/extensions/amp-live-list/0.1/test/test-amp-live-list.js
@@ -390,7 +390,9 @@ describe('amp-live-list', () => {
       const fromServer1 = createFromServer([{id: 'id0'}]);
       expect(spy).to.have.not.been.called;
       liveList.update(fromServer1);
-      expect(spy).to.have.been.calledOnce;
+      return Promise.resolve().then(() => {
+        expect(spy).to.have.been.calledOnce;
+      });
     });
 
     it('no items slot on update should be a no op update', () => {
@@ -527,9 +529,11 @@ describe('amp-live-list', () => {
       const fromServer1 = createFromServer([{id: 'id0'}]);
       liveList.update(fromServer1);
       expect(liveList.pendingItemsInsert_).to.have.length(1);
-      expect(liveList.updateSlot_).to.not.have.class('amp-hidden');
+      return Promise.resolve().then(() => {
+        expect(liveList.updateSlot_).to.not.have.class('amp-hidden');
 
-      return liveList.updateAction_(fromServer1).then(() => {
+        return liveList.updateAction_(fromServer1);
+      }).then(() => {
         expect(liveList.updateSlot_).to.have.class('amp-hidden');
       });
     });

--- a/extensions/amp-sticky-ad/1.0/amp-sticky-ad.js
+++ b/extensions/amp-sticky-ad/1.0/amp-sticky-ad.js
@@ -161,7 +161,7 @@ class AmpStickyAd extends AMP.BaseElement {
     this.removeOnScrollListener_();
     this.adReadyPromise_.then(() => {
       // Wait for ad build ready. For example user dismiss user notification.
-      this.deferMutate(() => {
+      this.mutateElement(() => {
         if (this.collapsed_) {
           // It's possible that if an AMP ad collapse before its layoutCallback.
           return;

--- a/extensions/amp-sticky-ad/1.0/test/test-amp-sticky-ad.js
+++ b/extensions/amp-sticky-ad/1.0/test/test-amp-sticky-ad.js
@@ -99,7 +99,7 @@ describes.realWin('amp-sticky-ad 1.0 version', {
           sandbox.stub(impl.viewport_, 'getScrollHeight');
       getScrollHeightStub.returns(300);
 
-      impl.deferMutate = function(callback) {
+      impl.mutateElement = function(callback) {
         callback();
       };
       impl.vsync_.mutate = function(callback) {
@@ -151,7 +151,7 @@ describes.realWin('amp-sticky-ad 1.0 version', {
       impl.viewport_.getScrollHeight = function() {
         return 300;
       };
-      impl.deferMutate = function(callback) {
+      impl.mutateElement = function(callback) {
         callback();
       };
       impl.vsync_.mutate = function(callback) {
@@ -332,7 +332,7 @@ describes.realWin('amp-sticky-ad 1.0 with real ad child', {
     impl.viewport_.getScrollHeight = function() {
       return 300;
     };
-    impl.deferMutate = function(callback) {
+    impl.mutateElement = function(callback) {
       callback();
     };
     impl.vsync_.mutate = function(callback) {
@@ -372,7 +372,7 @@ describes.realWin('amp-sticky-ad 1.0 with real ad child', {
     impl.viewport_.getScrollHeight = function() {
       return 300;
     };
-    impl.deferMutate = function(callback) {
+    impl.mutateElement = function(callback) {
       callback();
     };
     impl.vsync_.mutate = function(callback) {

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -920,15 +920,6 @@ export class BaseElement {
   }
 
   /**
-   * Schedules callback to be complete within the next batch. This call is
-   * intended for heavy DOM mutations that typically cause re-layouts.
-   * @param {!Function} callback
-   */
-  deferMutate(callback) {
-    this.element.getResources().deferMutate(this.element, callback);
-  }
-
-  /**
    * Called every time an owned AmpElement collapses itself.
    * See {@link collapse}.
    * @param {!AmpElement} unusedElement Child element that was collapsed.

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -645,7 +645,7 @@ function createBaseCustomElementClass(win) {
         this.sizerElement = null;
         setStyle(sizer, 'paddingTop', '0');
         if (this.resources_) {
-          this.resources_.deferMutate(this, () => {
+          this.resources_.mutateElement(this, () => {
             dom.removeElement(sizer);
           });
         }
@@ -1535,7 +1535,7 @@ function createBaseCustomElementClass(win) {
           const loadingContainer = this.loadingContainer_;
           this.loadingContainer_ = null;
           this.loadingElement_ = null;
-          this.getResources().deferMutate(this, () => {
+          this.getResources().mutateElement(this, () => {
             dom.removeElement(loadingContainer);
           });
         }

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -188,9 +188,6 @@ export class Resources {
     */
     this.requestsChangeSize_ = [];
 
-    /** @private {!Array<!Function>} */
-    this.deferredMutates_ = [];
-
     /** @private {?Array<!Resource>} */
     this.pendingBuildResources_ = [];
 
@@ -894,16 +891,6 @@ export class Resources {
   }
 
   /**
-   * Requests mutate callback to executed at the earliest possibility.
-   * @param {!Element} element
-   * @param {!Function} callback
-   */
-  deferMutate(element, callback) {
-    this.scheduleDeferredMutate_(Resource.forElement(element), callback);
-    this.schedulePassVsync();
-  }
-
-  /**
    * Runs the specified mutation on the element and ensures that measures
    * and layouts performed for the affected elements.
    *
@@ -1119,8 +1106,7 @@ export class Resources {
    * @private
    */
   hasMutateWork_() {
-    return (this.deferredMutates_.length > 0 ||
-        this.requestsChangeSize_.length > 0);
+    return (this.requestsChangeSize_.length > 0);
   }
 
   /**
@@ -1159,16 +1145,6 @@ export class Resources {
     const isScrollingStopped = (Math.abs(this.lastVelocity_) < 1e-2 &&
         now - this.lastScrollTime_ > MUTATE_DEFER_DELAY_ ||
         now - this.lastScrollTime_ > MUTATE_DEFER_DELAY_ * 2);
-
-    if (this.deferredMutates_.length > 0) {
-      dev().fine(TAG_, 'deferred mutates:', this.deferredMutates_.length);
-      const deferredMutates = this.deferredMutates_;
-      this.deferredMutates_ = [];
-      for (let i = 0; i < deferredMutates.length; i++) {
-        deferredMutates[i]();
-      }
-      this.maybeChangeHeight_ = true;
-    }
 
     // TODO(jridgewell, #12780): Update resize rules to account for layers.
     if (this.requestsChangeSize_.length > 0) {
@@ -1873,16 +1849,6 @@ export class Resources {
       });
     }
     this.schedulePassVsync();
-  }
-
-  /**
-   * Schedules deferred mutate.
-   * @param {!Resource} resource
-   * @param {!Function} callback
-   * @private
-   */
-  scheduleDeferredMutate_(resource, callback) {
-    this.deferredMutates_.push(callback);
   }
 
   /**

--- a/src/service/standard-actions-impl.js
+++ b/src/service/standard-actions-impl.js
@@ -342,8 +342,12 @@ export class StandardActions {
     });
 
     this.resources_.mutateElement(target, () => {
-      toggle(target, true);
-      target.removeAttribute('hidden');
+      if (target.classList.contains('i-amphtml-element')) {
+        target./*OK*/expand();
+      } else {
+        toggle(target, true);
+        target.removeAttribute('hidden');
+      }
     });
 
     return null;

--- a/src/service/standard-actions-impl.js
+++ b/src/service/standard-actions-impl.js
@@ -341,17 +341,10 @@ export class StandardActions {
       }
     });
 
-    // deferMutate will only work on AMP elements
-    if (target.classList.contains('i-amphtml-element')) {
-      this.resources_.deferMutate(target, () => {
-        target./*OK*/expand();
-      });
-    } else {
-      this.resources_.mutateElement(target, () => {
-        toggle(target, true);
-        target.removeAttribute('hidden');
-      });
-    }
+    this.resources_.mutateElement(target, () => {
+      toggle(target, true);
+      target.removeAttribute('hidden');
+    });
 
     return null;
   }

--- a/test/functional/test-custom-element.js
+++ b/test/functional/test-custom-element.js
@@ -1678,7 +1678,7 @@ describes.realWin('CustomElement', {amp: true}, env => {
     it('should turn off and cleanup', () => {
       stubInA4A(false);
       element.prepareLoading_();
-      resourcesMock.expects('deferMutate').once();
+      resourcesMock.expects('mutateElement').once();
       element.toggleLoading_(false, true);
 
       expect(vsyncTasks).to.have.length.of(1);
@@ -1807,7 +1807,7 @@ describes.realWin('CustomElement', {amp: true}, env => {
 
     it('should ignore loading "on" if layout completed before vsync', () => {
       stubInA4A(false);
-      resourcesMock.expects('deferMutate').once();
+      resourcesMock.expects('mutateElement').once();
       container.appendChild(element);
       element.prepareLoading_();
       element.toggleLoading_(true);

--- a/test/functional/test-standard-actions.js
+++ b/test/functional/test-standard-actions.js
@@ -25,7 +25,6 @@ import {setParentWindow} from '../../src/service';
 describes.sandboxed('StandardActions', {}, () => {
   let standardActions;
   let mutateElementStub;
-  let deferMutateStub;
   let scrollStub;
   let ampdoc;
 
@@ -66,8 +65,8 @@ describes.sandboxed('StandardActions', {}, () => {
   }
 
   function expectAmpElementToHaveBeenShown(element) {
-    expect(deferMutateStub).to.be.calledOnce;
-    expect(deferMutateStub.firstCall.args[0]).to.equal(element);
+    expect(mutateElementStub).to.be.calledOnce;
+    expect(mutateElementStub.firstCall.args[0]).to.equal(element);
     expect(element.expand).to.be.calledOnce;
   }
 
@@ -80,7 +79,6 @@ describes.sandboxed('StandardActions', {}, () => {
     ampdoc = new AmpDocSingle(window);
     standardActions = new StandardActions(ampdoc);
     mutateElementStub = stubMutate('mutateElement');
-    deferMutateStub = stubMutate('deferMutate');
     scrollStub = sandbox.stub(
         standardActions.viewport_,
         'animateScrollIntoView');


### PR DESCRIPTION
This is part 1 of syncing Layers and mutations.

Basically, `#deferMutate` is horrible. It does not notify Resources (the current measurer, which will soon be Layers) that any mutation has happened. And it's not synchronized to the Vsync measure/mutate phases.