### PR TITLE
Update lightbox tests to prune invalid ads and add all layouts for video and social share

### DIFF
--- a/test/manual/amp-lightbox-gallery-launch.amp.html
+++ b/test/manual/amp-lightbox-gallery-launch.amp.html
@@ -176,14 +176,6 @@
         </a>
       </template>
     </amp-ad>
-    <amp-ad width=480 height=75
-      type="doubleclick"
-      data-slot="/30497360/samfrank_native_v2_a4a"
-      data-multi-size="320x50"
-      >
-      <div placeholder></div>
-      <div fallback></div>
-    </amp-ad>
   </amp-carousel>
 
   <amp-img id="fb-thumbnail-img"

--- a/test/manual/amp-lightbox-gallery-launch.amp.html
+++ b/test/manual/amp-lightbox-gallery-launch.amp.html
@@ -14,7 +14,6 @@
   <script async custom-element="amp-instagram" src="https://cdn.ampproject.org/v0/amp-instagram-0.1.js"></script>
   <script async custom-element="amp-facebook" src="https://cdn.ampproject.org/v0/amp-facebook-0.1.js"></script>
   <script async custom-element="amp-ad" src="https://cdn.ampproject.org/v0/amp-ad-0.1.js"></script>
-  <script async custom-element="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.1.js"></script>
   <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
 
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
@@ -209,18 +208,10 @@
       type="doubleclick"
       width="300">
     </amp-ad>
-    <amp-ad width="500" height="60"
-      type="custom"
-      data-url="/examples/custom.ad.example.single.json">
-      <template type="amp-mustache" id="amp-template-id-no-slot">
-        <a href="{{href}}" target="_blank" rel="noopener noreferrer">
-          <amp-img layout='fixed' height="60" width="500" src="{{src}}" data-info="{{info}}"></amp-img>
-        </a>
-      </template>
-    </amp-ad>
   </amp-carousel>
 
   <h1>Lightbox Carousel Social Share Tests</h1>
+  <p>Feel free to deprioritize these social share tests for now, as V1 is focused on images, videos, and ads. </p>
   <h2>Instagram Layout Test</h2>
   <p>This carousel includes amp-instagram with the following layouts: </p>
   <ul>

--- a/test/manual/amp-lightbox-gallery-launch.amp.html
+++ b/test/manual/amp-lightbox-gallery-launch.amp.html
@@ -76,14 +76,23 @@
   </amp-carousel>
 
   <h1>Lightbox Carousel with Video Test</h1>
-  <amp-carousel height="300"
-  width="400"
+  <h2>AMP-VIDEO Layout Test</h2>
+  <p>This carousel includes amp-video with the following layouts: </p>
+  <ul>
+    <li>Responsive</li>
+    <li>Responsive with autoplay</li>
+    <li>Fill</li>
+    <li>Fixed Height</li>
+    <li>Fixed</li>
+  </ul>
+  <amp-carousel height="600"
+  width="800"
   layout="fixed"
   type="slides"
   lightbox>
     <amp-img src="https://images.unsplash.com/photo-1503843778847-2b8bdce2ed3d"
-      width="400"
-      height="300"
+      width="800"
+      height="600"
       alt="a beautiful cat"></amp-img>
     <amp-video
       src="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4"
@@ -93,6 +102,58 @@
       poster="https://i.ytimg.com/vi/5Yjoe54vzwE/mqdefault.jpg"
       controls>
     </amp-video>
+    <amp-video
+      src="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4"
+      width="358"
+      height="204"
+      layout="responsive"
+      autoplay
+      poster="https://i.ytimg.com/vi/5Yjoe54vzwE/mqdefault.jpg"
+      controls>
+    </amp-video>
+    <amp-video
+      src="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4"
+      width="358"
+      height="204"
+      layout="fill"
+      poster="https://i.ytimg.com/vi/5Yjoe54vzwE/mqdefault.jpg"
+      controls>
+  </amp-video>
+  <amp-video
+    src="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4"
+    height="204"
+    layout="fixed-height"
+    poster="https://i.ytimg.com/vi/5Yjoe54vzwE/mqdefault.jpg"
+    controls>
+  </amp-video>
+  <amp-video
+    src="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4"
+    width="358"
+    height="204"
+    layout="fixed"
+    poster="https://i.ytimg.com/vi/5Yjoe54vzwE/mqdefault.jpg"
+    controls>
+  </amp-video>
+  </amp-carousel>
+
+  <h2>AMP-YOUTUBE Layout Test</h2>
+  <p>This carousel includes amp-video with the following layouts: </p>
+  <ul>
+    <li>Responsive</li>
+    <li>Responsive with autoplay</li>
+    <li>Fill</li>
+    <li>Fixed Height</li>
+    <li>Fixed</li>
+  </ul>
+  <amp-carousel height="600"
+    width="800"
+    layout="fixed"
+    type="slides"
+    lightbox>
+    <amp-img src="https://images.unsplash.com/photo-1503843778847-2b8bdce2ed3d"
+      width="800"
+      height="600"
+      alt="a beautiful cat"></amp-img>
     <amp-youtube width="480"
       height="270"
       layout="responsive"
@@ -109,6 +170,54 @@
         layout="fill"
         />
     </amp-youtube>
+    <amp-youtube width="480"
+      height="270"
+      layout="fill"
+      data-videoid="lBTCB7yLs8Y">
+    </amp-youtube>
+    <amp-youtube
+      height="270"
+      layout="fixed-height"
+      data-videoid="lBTCB7yLs8Y">
+    </amp-youtube>
+    <amp-youtube width="480"
+      height="270"
+      layout="fixed"
+      data-videoid="lBTCB7yLs8Y">
+    </amp-youtube>
+  </amp-carousel>
+
+  <h1>Lightbox Carousel Ads Support Test</h1>
+  <amp-carousel height="600"
+    width="800"
+    layout="fixed"
+    type="slides"
+    lightbox>
+    <amp-img src="https://images.unsplash.com/photo-1503843778847-2b8bdce2ed3d"
+      width="800"
+      height="600"
+      alt="a beautiful cat"></amp-img>
+    <amp-ad width="300"
+      height="250"
+      type="a9"
+      data-aax_size="300x250"
+      data-aax_pubname="test123"
+      data-aax_src="302">
+    </amp-ad>
+    <amp-ad data-slot="/30497360/a4a/a4a_native"
+      height="250"
+      type="doubleclick"
+      width="300">
+    </amp-ad>
+    <amp-ad width="500" height="60"
+      type="custom"
+      data-url="/examples/custom.ad.example.single.json">
+      <template type="amp-mustache" id="amp-template-id-no-slot">
+        <a href="{{href}}" target="_blank" rel="noopener noreferrer">
+          <amp-img layout='fixed' height="60" width="500" src="{{src}}" data-info="{{info}}"></amp-img>
+        </a>
+      </template>
+    </amp-ad>
   </amp-carousel>
 
   <h1>Lightbox Carousel Social Share Tests</h1>
@@ -241,39 +350,6 @@
       data-embed-as="video"
       data-href="https://www.facebook.com/zuck/videos/10102509264909801/">
     </amp-facebook>
-  </amp-carousel>
-
-<h1>Lightbox Carousel Ad Support Test</h1>
-  <amp-carousel height="300"
-    width="400"
-    layout="fixed"
-    type="slides"
-    lightbox>
-    <amp-img src="https://images.unsplash.com/photo-1503843778847-2b8bdce2ed3d"
-      width="400"
-      height="300"
-      alt="a beautiful cat"></amp-img>
-    <amp-ad width="300"
-      height="250"
-      type="a9"
-      data-aax_size="300x250"
-      data-aax_pubname="test123"
-      data-aax_src="302">
-    </amp-ad>
-    <amp-ad data-slot="/30497360/a4a/a4a_native"
-      height="250"
-      type="doubleclick"
-      width="300">
-    </amp-ad>
-    <amp-ad width="500" height="60"
-      type="custom"
-      data-url="/examples/custom.ad.example.single.json">
-      <template type="amp-mustache" id="amp-template-id-no-slot">
-        <a href="{{href}}" target="_blank" rel="noopener noreferrer">
-          <amp-img layout='fixed' height="60" width="500" src="{{src}}" data-info="{{info}}"></amp-img>
-        </a>
-      </template>
-    </amp-ad>
   </amp-carousel>
 
   <amp-img id="fb-thumbnail-img"

--- a/test/manual/amp-lightbox-gallery-launch.amp.html
+++ b/test/manual/amp-lightbox-gallery-launch.amp.html
@@ -111,21 +111,63 @@
     </amp-youtube>
   </amp-carousel>
 
-  <h1>Lightbox Carousel Social Share Test</h1>
-  <amp-carousel height="300"
-  width="400"
-  layout="fixed"
-  type="slides"
-  lightbox>
+  <h1>Lightbox Carousel Social Share Tests</h1>
+  <h2>Instagram Layout Test</h2>
+  <p>This carousel includes amp-instagram with the following layouts: </p>
+  <ul>
+    <li>Responsive</li>
+    <li>Fill</li>
+    <li>Fixed Height</li>
+    <li>Fixed</li>
+  </ul>
+  <amp-carousel 
+    height="600"
+    width="800"
+    layout="fixed"
+    type="slides"
+    lightbox>
     <amp-img src="https://images.unsplash.com/photo-1503843778847-2b8bdce2ed3d"
-      width="400"
-      height="300"
+      width="800"
+      height="600"
       alt="a beautiful cat"></amp-img>
     <amp-instagram data-shortcode="1totVhIFXl"
       width="400"
       height="400"
       layout="responsive">
     </amp-instagram>
+    <amp-instagram data-shortcode="1totVhIFXl"
+      width="400"
+      height="400"
+      layout="fill">
+    </amp-instagram>
+    <amp-instagram data-shortcode="1totVhIFXl"
+      height="400"
+      layout="fixed-height">
+    </amp-instagram>
+    <amp-instagram data-shortcode="1totVhIFXl"
+      width="400"
+      height="400"
+      layout="fixed">
+    </amp-instagram>
+  </amp-carousel>
+
+  <h2>Facebook Layout Test</h2>
+  <p>This carousel includes amp-facebook with the following layouts: </p>
+  <ul>
+    <li>Responsive</li>
+    <li>Fill</li>
+    <li>Fixed Height</li>
+    <li>Fixed</li>
+  </ul>
+  <amp-carousel height="600"
+    width="800"
+    layout="fixed"
+    type="slides"
+    lightbox>
+    <amp-img src="https://images.unsplash.com/photo-1503843778847-2b8bdce2ed3d"
+      width="800"
+      height="600"
+      alt="a beautiful cat"></amp-img>
     <amp-facebook
       lightbox-thumbnail-id="fb-thumbnail-img"
       width="552"
@@ -133,15 +175,71 @@
       layout="responsive"
       data-href="https://www.facebook.com/zuck/posts/10102593740125791">
     </amp-facebook>
-    <amp-facebook width="552"
+    <amp-facebook
+      lightbox-thumbnail-id="fb-thumbnail-img"
+      width="552"
+      height="303"
+      layout="fill"
+      data-href="https://www.facebook.com/zuck/posts/10102593740125791">
+    </amp-facebook>
+    <amp-facebook
+      lightbox-thumbnail-id="fb-thumbnail-img"
+      width="552"
+      height="303"
+      layout="fixed"
+      data-href="https://www.facebook.com/zuck/posts/10102593740125791">
+    </amp-facebook>
+    <amp-facebook
+      lightbox-thumbnail-id="fb-thumbnail-img"
+      height="303"
+      layout="fixed-height"
+      data-href="https://www.facebook.com/zuck/posts/10102593740125791">
+    </amp-facebook>
+  </amp-carousel>
+
+  <h2>Facebook Video Post Layout Test</h2>
+  <p>This carousel includes amp-facebook data-embed-as="video" with the following layouts: </p>
+  <ul>
+    <li>Responsive</li>
+    <li>Fill</li>
+    <li>Fixed Height</li>
+    <li>Fixed</li>
+  </ul>
+  <amp-carousel height="600"
+    width="800"
+    layout="fixed"
+    type="slides"
+    lightbox>
+    <amp-img src="https://images.unsplash.com/photo-1503843778847-2b8bdce2ed3d"
+      width="800"
+      height="600"
+      alt="a beautiful cat"></amp-img>
+    <amp-facebook 
+      width="552"
       height="310"
       layout="responsive"
       data-embed-as="video"
       data-href="https://www.facebook.com/zuck/videos/10102509264909801/">
-      <amp-img
-        src="https://scontent-sjc3-1.xx.fbcdn.net/v/t15.0-10/cp0/e15/q65/p173x172/12104343_10102509276925721_413295500_n.jpg?oh=3ab5d6e109a83d59a7dec75cfc310bcd&oe=5B028D9E"
-        placeholder
-        layout="fill"/>
+    </amp-facebook>
+    <amp-facebook 
+      width="552"
+      height="310"
+      layout="fill"
+      data-embed-as="video"
+      data-href="https://www.facebook.com/zuck/videos/10102509264909801/">
+    </amp-facebook>
+    <amp-facebook 
+      height="310"
+      layout="fixed-height"
+      data-embed-as="video"
+      data-href="https://www.facebook.com/zuck/videos/10102509264909801/">
+    </amp-facebook>
+    <amp-facebook 
+      width="552"
+      height="310"
+      layout="fixed"
+      data-embed-as="video"
+      data-href="https://www.facebook.com/zuck/videos/10102509264909801/">
     </amp-facebook>
   </amp-carousel>
 

--- a/test/manual/amp-lightbox-gallery-launch.amp.html
+++ b/test/manual/amp-lightbox-gallery-launch.amp.html
@@ -343,6 +343,55 @@
     </amp-facebook>
   </amp-carousel>
 
+  <h1>Lightbox API Tests</h1>
+  <h2>Lightbox Group Test</h2>
+  <h3>Test 1</h3>
+  <p>The following image and youtube video should belong to the same lightbox group. The lightbox group should include a third image from the carousel in Test 3 below. </p>
+  <amp-img src="https://images.unsplash.com/photo-1503843778847-2b8bdce2ed3d"
+    width="400"
+    height="300"
+    lightbox="group-1"
+    alt="a beautiful cat"></amp-img>
+  <amp-youtube lightbox="group-1"
+    width="480"
+    height="270"
+    layout="fixed"
+    data-videoid="lBTCB7yLs8Y">
+  </amp-youtube>
+  <h3>Test 2</h3>
+  <p>The following image should belong to its own lightbox group. </p>
+  <amp-img src="https://images.unsplash.com/photo-1445499348736-29b6cdfc03b9"
+    width="400"
+    height="300"
+    lightbox
+    aria-label="Aria labels are cool."></amp-img>
+  <h3>Test 3</h3>
+  <p>In the following carousel, images 2 and 4 should be excluded from the lightbox. Image 4 should belong to the lightbox group in Test 1.</p>
+  <amp-carousel height="300"
+    width="400"
+    layout="fixed"
+    type="slides"
+    lightbox>
+    <amp-img src="https://images.unsplash.com/photo-1503843778847-2b8bdce2ed3d"
+      width="400"
+      height="300"
+      alt="a beautiful cat"></amp-img>
+    <amp-img src="https://images.unsplash.com/photo-1445499348736-29b6cdfc03b9"
+      width="400"
+      height="300"
+      lightbox-exclude
+      aria-label="Aria labels are cool."></amp-img>
+    <amp-img src="https://images.unsplash.com/photo-1482066490729-6f26115b60dc"
+      width="400"
+      height="300"
+      aria-describedby="my-aria-describe"></amp-img>
+    <amp-img src="https://images.unsplash.com/photo-1511275539165-cc46b1ee89bf"
+      width="400"
+      height="300"
+      lightbox="group-1"
+      aria-labelledby="my-aria-label"></amp-img>
+  </amp-carousel>
+
   <amp-img id="fb-thumbnail-img"
     width="200"
     height="200"
@@ -350,11 +399,11 @@
     src="https://picsum.photos/200/200?image=1074">
   </amp-img>
 
-  <div id='my-aria-describe'>
+  <div id='my-aria-describe' layout="nodisplay">
     This is an aria described by a div. <br/>
     I have a linebreak.
   </div>
-  <div id='my-aria-label'>
+  <div id='my-aria-label' layout="nodisplay">
     This is an aria labelled by a div. <br/>
     I also have a newline.
   </div>


### PR DESCRIPTION
1. Per `validator-amp-ad.protoascii`, `<amp-ad>` with `data-multi-size` cannot be a child of `<amp-carousel>`. Therefore it cannot be lightboxed, and we should prune it from our launch tests. 
2. Template ads also pruned from v1 launch. 
3. All supported layouts for `<amp-video>` and `<amp-youtube>` are added for completeness. These should be supported in V1 launch. 
4. All supported layouts for `<amp-instagram>` and `<amp-facebook>` are also added. These will not necessarily be supported in V1 launch since they are currently broken in `<amp-carousel>`. They are added here for troubleshooting purposes. 
5. Add tests for `lightbox-exclude` and using lightbox groups. 