### PR TITLE
Update layout documentation for <amp-instagram> and <amp-facebook>, add layout tests

### DIFF
--- a/extensions/amp-facebook/amp-facebook.md
+++ b/extensions/amp-facebook/amp-facebook.md
@@ -29,7 +29,7 @@ limitations under the License.
   </tr>
   <tr>
     <td class="col-fourty"><strong><a href="https://www.ampproject.org/docs/guides/responsive/control_layout.html">Supported Layouts</a></strong></td>
-    <td>fill, fixed, fixed-height, flex-item, nodisplay, responsive</td>
+    <td>fill, fixed, flex-item, nodisplay, responsive</td>
   </tr>
   <tr>
     <td width="40%"><strong>Examples</strong></td>
@@ -40,6 +40,9 @@ limitations under the License.
 ## Overview 
 
 You can use the `amp-facebook` component to embed a Facebook post or a Facebook video.
+
+### Layout Behavior
+Due to the [instagram API](https://developers.facebook.com/docs/plugins/embedded-posts) not accepting a `height`, `layout="responsive"` will size the `<amp-facebook>` component to the width of its container. This means that if the container aspect ratio has a shorter relative height than the actual facebook post component, `<amp-facebook>` will overflow its container. This is worth noting in context of embedding `<amp-facebook>` in landscape components like `<amp-carousel>`. 
 
 #### Example: Embedding a post
 

--- a/extensions/amp-instagram/amp-instagram.md
+++ b/extensions/amp-instagram/amp-instagram.md
@@ -27,7 +27,7 @@ limitations under the License.
   </tr>
   <tr>
     <td class="col-fourty"><strong><a href="https://www.ampproject.org/docs/guides/responsive/control_layout.html">Supported Layouts</a></strong></td>
-    <td>fill, fixed, fixed-height, flex-item, nodisplay, responsive</td>
+    <td>responsive, fill, fixed, flex-item, nodisplay</td>
   </tr>
   <tr>
     <td width="40%"><strong>Examples</strong></td>
@@ -57,6 +57,8 @@ Example:
 ```
 
 If the Instagram is not square you will need to enter the actual dimensions of the image.
+
+Due to the [instagram API](https://www.instagram.com/developer/embedding/) not accepting a `max-height`, `layout="responsive"` will size the `<amp-instagram>` component to the width of its container. This means that if the container aspect ratio has a shorter relative height than the actual instagram component, `<amp-instagram>` will overflow its container. This is worth noting in context of embedding `<amp-instagram>` in landscape components like `<amp-carousel>`. 
 
 When using non-responsive layout you will need to account for the extra space added for the "instagram chrome" around the image. This is currently 48px above and below the image and 8px on the sides.
 

--- a/test/manual/amp-facebook.amp.html
+++ b/test/manual/amp-facebook.amp.html
@@ -1,0 +1,85 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>AMP Facebook Manual Tests</title>
+  <link rel="canonical" href="amps.html" >
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
+  <script async custom-element="amp-facebook" src="https://cdn.ampproject.org/v0/amp-facebook-0.1.js"></script>
+  <style amp-custom>
+    body {
+      font-family: 'Questrial', Arial;
+    }
+
+    .portrait-fixed {
+      width: 400px;
+      height: 200px;
+      overflow: hidden;
+    }
+
+    .portrait-container {
+      position: relative;
+      width: 100%;
+      padding-bottom: 25%;
+    }
+
+    .portrait-container > div {
+      position: absolute;
+      top: 0; bottom: 0; left: 0; right: 0;
+      overflow: hidden;
+    }
+
+  </style>
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+  <h1>amp #0</h1>
+  <amp-facebook width="552" height="310"
+    layout="responsive"
+    data-href="https://www.facebook.com/ParksCanada/posts/1712989015384373">
+  </amp-facebook>
+
+  <h2>Layout Responsive with Aspect Ratio Landscape</h2>
+  <h3>Fixed Size </h3>
+  <div class="portrait-fixed">
+      <amp-facebook width="552" height="310"
+        layout="responsive"
+        data-href="https://www.facebook.com/ParksCanada/posts/1712989015384373">
+      </amp-facebook>
+  </div>
+  <h3>Fluid Size</h3>
+  <div class="portrait-container">
+    <div>
+      <amp-facebook width="552" height="310"
+        layout="responsive"
+        data-href="https://www.facebook.com/ParksCanada/posts/1712989015384373">
+    </amp-facebook>
+    </div>
+  </div>
+  <h2>Layout Fill with Aspect Ratio Portrait</h2>
+  <h3>Fixed Size</h3>
+  <div class="portrait-fixed">
+    <amp-facebook width="552" height="310"
+      layout="responsive"
+      data-href="https://www.facebook.com/ParksCanada/posts/1712989015384373">
+    </amp-facebook>
+  </div>
+  <h3>Fluid Size</h3>
+  <div class="portrait-container">
+    <div>
+      <amp-facebook width="552" height="310"
+        layout="fill"
+        data-href="https://www.facebook.com/ParksCanada/posts/1712989015384373">
+      </amp-facebook>
+    </div>
+  </div>
+  <h2>Layout Fixed Height</h2>
+  <amp-facebook height="310"
+        layout="fixed-height"
+        data-href="https://www.facebook.com/ParksCanada/posts/1712989015384373">
+    </amp-facebook>
+
+</body>
+</html>

--- a/test/manual/amp-instagram.amp.html
+++ b/test/manual/amp-instagram.amp.html
@@ -18,6 +18,26 @@
       padding: 30px;
       border: 10px solid red;
     }
+
+    .portrait-fixed {
+      position: absolute; 
+      width: 400px;
+      height: 300px;
+      overflow: hidden;
+    }
+
+    .portrait-container {
+      position: relative;
+      width: 100%;
+      padding-bottom: 75%;
+    }
+
+    .portrait-container > div {
+      position: absolute;
+      top: 0; bottom: 0; left: 0; right: 0;
+      overflow: hidden;
+    }
+
   </style>
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
@@ -31,5 +51,37 @@
     height="392"
     layout="responsive">
   </amp-instagram>
+  <h2>Layout Responsive with Aspect Ratio Portrait</h2>
+  <div class="portrait-fixed">
+    <amp-instagram
+      data-shortcode="fBwFP"
+      alt="Malte Ubl computing on a couch."
+      width="320"
+      height="392"
+      layout="responsive">
+    </amp-instagram>
+  </div>
+  <div class="portrait-container">
+    <div>
+      <amp-instagram
+        data-shortcode="fBwFP"
+        alt="Malte Ubl computing on a couch."
+        width="320"
+        height="392"
+        layout="responsive">
+      </amp-instagram>
+    </div>
+  </div>
+  <h2>Layout Fill with Aspect Ratio Portrait</h2>
+  <div class="portrait-fixed">
+    <amp-instagram
+      data-shortcode="fBwFP"
+      alt="Malte Ubl computing on a couch."
+      width="320"
+      height="392"
+      layout="fill">
+    </amp-instagram>
+  </div>
+  
 </body>
 </html>


### PR DESCRIPTION
Partially addresses https://github.com/ampproject/amphtml/issues/13872. Adds some layout tests for verifying the `responsive` / `fixed-height` layout problem. 