### PR TITLE
<amp-pinterest> Sanitize URLs

### DIFF
--- a/extensions/amp-pinterest/0.1/pin-widget.js
+++ b/extensions/amp-pinterest/0.1/pin-widget.js
@@ -58,9 +58,9 @@ export class PinWidget {
     const log = el.getAttribute('data-pin-log');
     if (href) {
       if (shouldPop) {
-        openWindowDialog(window, href, '_pinit', POP);
+        openWindowDialog(window, encodeURI(href), '_pinit', POP);
       } else {
-        openWindowDialog(window, `${href}?amp=1&guid=${Util.guid}`, '_blank');
+        openWindowDialog(window, encodeURI(href+'?amp=1&guid=$'+Util.guid), '_blank');
       }
     }
     if (log) {

--- a/extensions/amp-pinterest/0.1/pin-widget.js
+++ b/extensions/amp-pinterest/0.1/pin-widget.js
@@ -16,7 +16,7 @@
 
 import {Services} from '../../../src/services';
 import {Util} from './util';
-import {assertHttpsUrl} from '../../../src/url';
+import {assertAbsoluteHttpOrHttpsUrl, assertHttpsUrl} from '../../../src/url';
 import {openWindowDialog} from '../../../src/dom';
 import {toWin} from '../../../src/types';
 
@@ -57,10 +57,11 @@ export class PinWidget {
     const href = el.getAttribute('data-pin-href');
     const log = el.getAttribute('data-pin-log');
     if (href) {
+      assertAbsoluteHttpOrHttpsUrl(href);
       if (shouldPop) {
-        openWindowDialog(window, encodeURI(href), '_pinit', POP);
+        openWindowDialog(window, href, '_pinit', POP);
       } else {
-        openWindowDialog(window, encodeURI(href+'?amp=1&guid=$'+Util.guid), '_blank');
+        openWindowDialog(window, `${href}?amp=1&guid=${Util.guid}`, '_blank');
       }
     }
     if (log) {


### PR DESCRIPTION
Currently we call openWindowDialog on a click on an AMP widget. These `href`s should be sanitized before being passed to openWindowDialog.