### PR TITLE
Only add http prefix to thirdPartyUrl where necessary

### DIFF
--- a/build-system/tasks/prepend-global/index.js
+++ b/build-system/tasks/prepend-global/index.js
@@ -169,10 +169,10 @@ function enableLocalDev(config, target, configJson) {
   }
   const TESTING_HOST = process.env.AMP_TESTING_HOST;
   if (typeof TESTING_HOST == 'string') {
-    const TESTING_HOST_FULL_URL = TESTING_HOST.match(/^[a-zA-Z]+:\/\//) ?
+    const TESTING_HOST_FULL_URL = TESTING_HOST.match(/^https?:\/\//) ?
       TESTING_HOST : 'http://' + TESTING_HOST;
     const TESTING_HOST_NO_PROTOCOL =
-      TESTING_HOST.replace(/^[a-zA-Z]+:\/\//, '');
+      TESTING_HOST.replace(/^https?:\/\//, '');
 
     LOCAL_DEV_AMP_CONFIG = Object.assign(LOCAL_DEV_AMP_CONFIG, {
       thirdPartyUrl: TESTING_HOST_FULL_URL,

--- a/build-system/tasks/prepend-global/index.js
+++ b/build-system/tasks/prepend-global/index.js
@@ -169,10 +169,15 @@ function enableLocalDev(config, target, configJson) {
   }
   const TESTING_HOST = process.env.AMP_TESTING_HOST;
   if (typeof TESTING_HOST == 'string') {
+    const TESTING_HOST_FULL_URL = TESTING_HOST.match(/^[a-zA-Z]+:\/\//) ?
+      TESTING_HOST : 'http://' + TESTING_HOST;
+    const TESTING_HOST_NO_PROTOCOL =
+      TESTING_HOST.replace(/^[a-zA-Z]+:\/\//, '');
+
     LOCAL_DEV_AMP_CONFIG = Object.assign(LOCAL_DEV_AMP_CONFIG, {
-      thirdPartyUrl: 'http://' + TESTING_HOST,
-      thirdPartyFrameHost: TESTING_HOST,
-      thirdPartyFrameRegex: TESTING_HOST,
+      thirdPartyUrl: TESTING_HOST_FULL_URL,
+      thirdPartyFrameHost: TESTING_HOST_NO_PROTOCOL,
+      thirdPartyFrameRegex: TESTING_HOST_NO_PROTOCOL,
     });
     if (!process.env.TRAVIS) {
       log('Set', cyan('TESTING_HOST'), 'to', cyan(TESTING_HOST),


### PR DESCRIPTION
Per https://github.com/ampproject/amphtml/pull/12673, only add the `http` prefix to `thirdPartyUrl` where necessary. Also make sure to strip the protocol prefix from `thirdPartyFrameHost` and `thirdPartyFrameRegex`. 

Tested and verified is working on: 
* heroku with both http and https
* localhost
* computer's ip address via `gulp --host=my.ip.address` with `export AMP_TESTING_HOST=my.ip.address`. 