### PR TITLE
🏗 Fix Ctrl + C handler on Windows (part 2)

### DIFF
--- a/build-system/ctrlcHandler.js
+++ b/build-system/ctrlcHandler.js
@@ -16,14 +16,15 @@
 
 const colors = require('ansi-colors');
 const exec = require('./exec').exec;
-const execAsync = require('./exec').execAsync;
+const execScriptAsync = require('./exec').execScriptAsync;
 const log = require('fancy-log');
 
 const green = colors.green;
 const cyan = colors.cyan;
 
 const killCmd =
-    (process.platform == 'win32') ? 'taskkill /pid' : 'kill -KILL';
+    (process.platform == 'win32') ? 'taskkill /f /pid' : 'kill -KILL';
+const killSuffix = (process.platform == 'win32') ? '>NUL' : '';
 
 /**
  * Creates an async child process that handles Ctrl + C and immediately cancels
@@ -48,7 +49,7 @@ exports.createCtrlcHandler = function(command) {
     trap 'ctrlcHandler' INT
     read _ # Waits until the process is terminated
   `;
-  return execAsync(
+  return execScriptAsync(
       listenerCmd, {'stdio': [null, process.stdout, process.stderr]}).pid;
 };
 
@@ -58,6 +59,6 @@ exports.createCtrlcHandler = function(command) {
  * @param {string} handlerProcess
  */
 exports.exitCtrlcHandler = function(handlerProcess) {
-  const exitCmd = killCmd + ' ' + handlerProcess;
+  const exitCmd = killCmd + ' ' + handlerProcess + ' ' + killSuffix;
   exec(exitCmd);
 };

--- a/build-system/exec.js
+++ b/build-system/exec.js
@@ -45,13 +45,13 @@ exports.exec = function(cmd) {
 };
 
 /**
- * Executes the provided command in an asynchronous process.
+ * Executes the provided shell script in an asynchronous process.
  *
- * @param {string} cmd
+ * @param {string} script
  * @param {<Object>} options
  */
-exports.execAsync = function(cmd, options) {
-  return childProcess.spawn(shellCmd, [shellFlag, cmd], options);
+exports.execScriptAsync = function(script, options) {
+  return childProcess.spawn('sh', ['-c', script], options);
 };
 
 /**


### PR DESCRIPTION
Running a shell command in windows is done using `sh` and not `cmd`. This PR updates the way Ctrl + C handler on Windows is started and stopped.

This will prevent issues like the ones recently reported on slack, where error messages like the following were being seen on Windows:
```
[14:44:15] 'watch' errored after 2.15 min
[14:44:15] Error: kill ESRCH
   at Object._errnoException (util.js:1022:11)
   at process.kill (internal/process.js:183:18)
   at exports.exitCtrlcHandler (C:\repos\amp\jlucero-amhtml\build-system\ctrlcHandler.js:59:11)
   at performBuild.then (C:\repos\amp\jlucero-amhtml\gulpfile.js:737:40)
   at <anonymous>
   at process._tickCallback (internal/process/next_tick.js:188:7)
```
or
```
ERROR: The process "10004" not found.
```

Tested on Windows 10 under a `cmd` window, and on linux and macos.
 
![](https://user-images.githubusercontent.com/26553114/37186482-b5ced562-2313-11e8-8560-ca4a91354c51.png)

Follow up to #13598