### PR TITLE
🐛 Fix `ad` overlay for stories

### DIFF
--- a/extensions/amp-story/0.1/amp-story-ads.css
+++ b/extensions/amp-story/0.1/amp-story-ads.css
@@ -59,9 +59,11 @@ amp-story-page[active] .i-amphtml-story-ad-link {
 
 .i-amphtml-ad-overlay-container {
   height: 24px !important;
+  left: 0 !important;
   padding: 14px 0 0 !important;
   position: absolute !important;
-  z-index: 5 !important;
+  top: 0 !important;
+  z-index: 100001 !important;
 }
 
 .i-amphtml-story-ad-attribution {


### PR DESCRIPTION
Z-Index was not high enough, the system layer uses 100000.

Sometimes there is a state (hard to repro) where story has 2x height on system layer. We want to ignore that.