### PR TITLE
♻️Change custom ad request batching 

### DIFF
--- a/extensions/amp-ad/0.1/amp-ad-custom.js
+++ b/extensions/amp-ad/0.1/amp-ad-custom.js
@@ -85,7 +85,7 @@ export class AmpAdCustom extends AMP.BaseElement {
     /** @const {string} fullUrl */
     const fullUrl = this.getFullUrl_();
     // If this promise has no URL yet, create one for it.
-    if (!(fullUrl in ampCustomadXhrPromises)) {
+    if (this.slot_ === null || !(fullUrl in ampCustomadXhrPromises)) {
       // Here is a promise that will return the data for this URL
       ampCustomadXhrPromises[fullUrl] =
           Services.xhrFor(this.win).fetchJson(fullUrl).then(res => res.json());

--- a/extensions/amp-ad/0.1/amp-ad-custom.js
+++ b/extensions/amp-ad/0.1/amp-ad-custom.js
@@ -84,13 +84,15 @@ export class AmpAdCustom extends AMP.BaseElement {
   layoutCallback() {
     /** @const {string} fullUrl */
     const fullUrl = this.getFullUrl_();
-    // If this promise has no URL yet, create one for it.
-    if (this.slot_ === null || !(fullUrl in ampCustomadXhrPromises)) {
-      // Here is a promise that will return the data for this URL
-      ampCustomadXhrPromises[fullUrl] =
-          Services.xhrFor(this.win).fetchJson(fullUrl).then(res => res.json());
+    // if we have cached the response, find it, otherwise fetch
+    const responsePromise = ampCustomadXhrPromises[fullUrl] ||
+        Services.xhrFor(this.win).fetchJson(fullUrl).then(res => res.json());
+    if (this.slot_ !== null) {
+      // Cache this response if using `data-slot` feature so only one request
+      // is made per url
+      ampCustomadXhrPromises[fullUrl] = responsePromise;
     }
-    return ampCustomadXhrPromises[fullUrl].then(data => {
+    return responsePromise.then(data => {
       // We will get here when the data has been fetched from the server
       let templateData = data;
       if (this.slot_ !== null) {

--- a/extensions/amp-ad/0.1/test/test-amp-ad-custom.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-custom.js
@@ -16,10 +16,12 @@
 
 import * as sinon from 'sinon';
 import {AmpAdCustom} from '../amp-ad-custom';
+import {Services} from '../../../../src/services';
 import {
   createElementWithAttributes,
   removeChildren,
 } from '../../../../src/dom';
+
 describe('Amp custom ad', () => {
   let sandbox;
 
@@ -95,6 +97,28 @@ describe('Amp custom ad', () => {
     expect(ad2.getFullUrl_()).to.equal(expected2);
     expect(ad3.getFullUrl_()).to.equal(expected34);
     expect(ad4.getFullUrl_()).to.equal(expected34);
+  });
+
+  it('should perform multiple requests if no `data-slot`', () => {
+    const stub = sandbox.stub(Services, 'xhrFor').callsFake(() => ({
+      fetchJson: () => Promise.resolve({'foo': 1}),
+    }));
+
+    // Single ad with no slot
+    const url1 = 'example.com/ad';
+    const element1 = getCustomAd(url1);
+    const ad1 = new AmpAdCustom(element1);
+    ad1.buildCallback();
+    ad1.layoutCallback();
+
+    // Single ad with no slot
+    const url2 = 'example.com/ad';
+    const element2 = getCustomAd(url2);
+    const ad2 = new AmpAdCustom(element2);
+    ad2.buildCallback();
+    ad1.layoutCallback();
+
+    assert(stub.calledTwice);
   });
 
   describe('#getLayoutPriority', () => {


### PR DESCRIPTION
Amp custom ads currently have a feature that allows multiple ads to be fetched on a single request. However if we want to make multiple requests to the same endpoint (eg an ad server delivers dynamic data) this same logic will cause there to be only one request to be made.

This changes the "single request" logic to only be enabled if there is a `data-slot` attribute present on the ad.