### PR TITLE
Remove incorrect info on amp-img

### DIFF
--- a/builtins/amp-img.md
+++ b/builtins/amp-img.md
@@ -142,8 +142,7 @@ amp-img {
 If you want your image to scale as the window is resized but up to a maximum width (so the image doesn't stretch beyond its width):
 
 1. Set `layout=responsive` for `<amp-img>`.
-2. On the container of the image, specify the `max-width:<max width to display image>` CSS attribute.  Why on the container?  An `amp-img` element with `layout=responsive` is a *block-level* element, whereas, `<img>` is *inline*. Alternatively, you could set `display: inline-block` in your CSS for the amp-img element.
-
+2. On the container of the image, specify the `max-width:<max width to display image>` CSS attribute.
 
 #### Setting a fixed sized image
 

--- a/builtins/amp-img.md
+++ b/builtins/amp-img.md
@@ -85,8 +85,8 @@ Additional image features like captions can be implemented with standard HTML (f
 {% call callout('Read on', type='read') %}
 Learn more about using `amp-img` from these resources:
 
-- [Placeholders & fallbacks](https://www.ampproject.org/docs/guides/responsive/placeholders)
-- [Include Images & Video](https://www.ampproject.org/docs/guides/amp_replacements)
+- [Placeholders & fallbacks](https://www.ampproject.org/docs/design/responsive/placeholders)
+- [Include Images & Video](https://www.ampproject.org/docs/media/amp_replacements)
 {% endcall %}
 
 ## Attributes
@@ -104,7 +104,7 @@ Same as `srcset` attribute on the `img` tag. The behavior will be polyfilled whe
 Same as `sizes` attribute on the `img` tag. 
 
 {% call callout('Read on', type='read') %}
-See [Responsive images with srcset, sizes & heights](https://www.ampproject.org/docs/guides/responsive/art_direction) for usage of `sizes` and `srcset`.
+See [Responsive images with srcset, sizes & heights](https://www.ampproject.org/docs/design/responsive/art_direction) for usage of `sizes` and `srcset`.
 {% endcall %}
 
 **alt**
@@ -152,7 +152,7 @@ If you want your image to display at a fixed size:
 2. Specify the `width` and `height`.
 
 {% call callout('Read on', type='read') %}
-Learn about the [inferred layout](https://www.ampproject.org/docs/guides/responsive/control_layout#what-if-the-layout-attribute-isn’t-specified?) if you don't specify the `layout` attribute.
+Learn about the [inferred layout](https://www.ampproject.org/docs/design/responsive/control_layout#what-if-the-layout-attribute-isn%E2%80%99t-specified?) if you don't specify the `layout` attribute.
 {% endcall %}
 
 
@@ -175,7 +175,7 @@ For example, instead of specifying `width="900"` and `height="675"`, you can jus
 
 #### Maintaining the aspect ratio for images with unknown dimensions
 
-The AMP layout system requires the aspect ratio of an image in advance before fetching the image; however, in some cases you might not know the image's dimensions. To display images with unknown dimensions and maintain the aspect ratios, combine AMP's [`fill`](https://www.ampproject.org/docs/guides/responsive/control_layout#the-layout-attribute) layout with the [`object-fit`](https://css-tricks.com/almanac/properties/o/object-fit/) CSS property. For more information, see AMP By Example's [How to support images with unknown dimensions](https://ampbyexample.com/advanced/how_to_support_images_with_unknown_dimensions).
+The AMP layout system requires the aspect ratio of an image in advance before fetching the image; however, in some cases you might not know the image's dimensions. To display images with unknown dimensions and maintain the aspect ratios, combine AMP's [`fill`](https://www.ampproject.org/docs/design/responsive/control_layout#the-layout-attribute) layout with the [`object-fit`](https://css-tricks.com/almanac/properties/o/object-fit/) CSS property. For more information, see AMP By Example's [How to support images with unknown dimensions](https://ampbyexample.com/advanced/how_to_support_images_with_unknown_dimensions).
 
 ## Validation
 


### PR DESCRIPTION
Incorrect sentence in tips & tricks.  Removed suggestion to make amp-img an `inline-block`.
Fixes: https://github.com/ampproject/docs/issues/876
