### PR TITLE
Add Lotame as a vendor to RTC config

### DIFF
--- a/extensions/amp-a4a/0.1/callout-vendors.js
+++ b/extensions/amp-a4a/0.1/callout-vendors.js
@@ -52,6 +52,10 @@ export const RTC_VENDORS = {
     macros: ['SITE_ID'],
     disableKeyAppend: true,
   },
+  lotame: {
+    url: 'https://ad.crwdcntrl.net/5/pe=y/c=CLIENT_ID/an=AD_NETWORK',
+    macros: ['CLIENT_ID', 'AD_NETWORK'],
+  },
 };
 
 // DO NOT MODIFY: Setup for tests


### PR DESCRIPTION
Add Lotame Solutions, Inc. as a vendor in the RTC config. Lotame had been using the remote.html approach to retrieve targeting data to apply to ad network calls. This approach has been deprecated, so we would like to include Lotame as a vendor to be referenced by the rtc-config attribute in an amp-ad tag.
