### PR TITLE
Making the unmute icon easier to target.

### DIFF
--- a/extensions/amp-story/0.1/amp-story.css
+++ b/extensions/amp-story/0.1/amp-story.css
@@ -120,18 +120,16 @@ amp-story[standalone]:fullscreen {
 
 .i-amphtml-story-ui-right {
   float: right !important;
-  margin: 0 8px !important;
 }
 
 .i-amphtml-story-button {
   background-repeat: no-repeat !important;
   background-position: center center !important;
-  height: 40px !important;
-  width: 40px !important;
+  height: 48px !important;
+  width: 48px !important;
   cursor: pointer !important;
-  border-radius: 40px !important;
+  border-radius: 50% !important;
   box-sizing: border-box !important;
-  padding: 8px !important;
   position: relative !important;
 
   /* for svg backgrounds: */


### PR DESCRIPTION
- Changing the icons size to 48px as suggested by Material Design
- Aligning the unmute icon to the right of the page (clicks too far from the edge would go to the next page)