### PR TITLE
Updating the WhatsApp share endpoint.

### DIFF
--- a/examples/amp-story/bookend.json
+++ b/examples/amp-story/bookend.json
@@ -1,6 +1,7 @@
 {
   "share-providers": {
-    "facebook": true
+    "facebook": true,
+    "whatsapp": true
   },
   "related-articles": {
     "test": [

--- a/extensions/amp-social-share/0.1/amp-social-share-config.js
+++ b/extensions/amp-social-share/0.1/amp-social-share-config.js
@@ -79,7 +79,7 @@ const BUILTINS = dict({
     },
   },
   'whatsapp': {
-    'shareEndpoint': 'whatsapp://send',
+    'shareEndpoint': 'https://api.whatsapp.com/send',
     'defaultParams': {
       'text': 'TITLE - CANONICAL_URL',
     },

--- a/extensions/amp-social-share/0.1/amp-social-share.js
+++ b/extensions/amp-social-share/0.1/amp-social-share.js
@@ -104,13 +104,12 @@ class AmpSocialShare extends AMP.BaseElement {
 
     urlReplacements.expandUrlAsync(hrefWithVars, bindings).then(href => {
       this.href_ = href;
-      // mailto:, whatsapp: protocols breaks when opened in _blank on iOS Safari
+      // mailto:, sms: protocols breaks when opened in _blank on iOS Safari
       const protocol = parseUrl(href).protocol;
       const isMailTo = protocol === 'mailto:';
-      const isWhatsApp = protocol === 'whatsapp:';
       const isSms = protocol === 'sms:';
       const isIosSafari = this.platform_.isIos() && this.platform_.isSafari();
-      this.target_ = (isIosSafari && (isMailTo || isWhatsApp || isSms))
+      this.target_ = (isIosSafari && (isMailTo || isSms))
         ? '_top' : '_blank';
       if (isSms) {
         // http://stackoverflow.com/a/19126326


### PR DESCRIPTION
Updates the WhatsApp endpoint from ``whatsapp://`` to ``https://api.whatsapp.com/send`` as per [the documentation](https://faq.whatsapp.com/en/general/26000030/?category=5245251).

The major improvement is that it now [fallbacks to the web version](https://user-images.githubusercontent.com/1492044/37312428-6d3581c8-2621-11e8-8f0a-490182077420.png) for users who don't have the WhatsApp app installed, instead of a blank page.

Demo running until this PR gets reviewed: https://ampgmajoulet.herokuapp.com/examples/amp-story/bookend.html
