### PR TITLE
🐛Handle connectedCallback when disconnected

### DIFF
--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -22,7 +22,6 @@ import {bezierCurve} from '../../../src/curve';
 import {createCustomEvent} from '../../../src/event-helper';
 import {dev} from '../../../src/log';
 import {getStyle, setStyle} from '../../../src/style';
-import {isConnectedNode} from '../../../src/dom';
 import {isLayoutSizeDefined} from '../../../src/layout';
 import {numeric} from '../../../src/transition';
 import {startsWith} from '../../../src/string';
@@ -182,10 +181,6 @@ export class AmpSlideScroll extends BaseSlides {
       slideWrapper.classList.add('i-amphtml-slide-item');
       this.slidesContainer_.appendChild(slideWrapper);
 
-      // Slides must only be re-parented to DOM-connected nodes to avoid
-      // errors when used in a shadow document (#9291).
-      dev().assert(isConnectedNode(slideWrapper),
-          'Slides must only be re-parented to connected nodes.');
       slideWrapper.appendChild(slide);
 
       this.slideWrappers_.push(slideWrapper);

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -681,6 +681,15 @@ function createBaseCustomElementClass(win) {
      * @final @this {!Element}
      */
     connectedCallback() {
+      // Chrome and Safari can trigger connectedCallback even when the node is
+      // disconnected. See #12849, https://crbug.com/821195, and
+      // https://bugs.webkit.org/show_bug.cgi?id=180940. Thankfully,
+      // connectedCallback will later be called when the disconnected root is
+      // connected to the document tree.
+      if (!dom.isConnected(this)) {
+        return;
+      }
+
       if (!this.everAttached) {
         this.classList.add('i-amphtml-element');
         this.classList.add('i-amphtml-notbuilt');

--- a/src/dom.js
+++ b/src/dom.js
@@ -198,6 +198,11 @@ export function createElementWithAttributes(doc, tagName, attributes) {
  * @see https://dom.spec.whatwg.org/#connected
  */
 export function isConnectedNode(node) {
+  const connected = node.isConnected;
+  if (connected !== undefined) {
+    return connected;
+  }
+
   // "An element is connected if its shadow-including root is a document."
   let n = node;
   do {

--- a/test/functional/test-custom-element.js
+++ b/test/functional/test-custom-element.js
@@ -238,7 +238,7 @@ describes.realWin('CustomElement', {amp: true}, env => {
       });
     });
 
-    it('Element - should handle async connectedCallback when disconnected', () => {
+    it('Element - handles async connectedCallback when disconnected', () => {
       const element = new ElementClass();
       Object.defineProperty(element, 'isConnected', {
         value: false,
@@ -699,7 +699,7 @@ describes.realWin('CustomElement', {amp: true}, env => {
       expect(testElementFirstAttachedCallback).to.be.calledOnce;
     });
 
-    it('Element - should handle async detachedCallback when connected', () => {
+    it('Element - handles async detachedCallback when connected', () => {
       const element = new ElementClass();
       element.setAttribute('layout', 'fill');
       expect(testElementFirstAttachedCallback).to.have.not.been.called;

--- a/test/functional/test-custom-element.js
+++ b/test/functional/test-custom-element.js
@@ -229,7 +229,7 @@ describes.realWin('CustomElement', {amp: true}, env => {
       element.classList.remove('i-amphtml-notbuilt');
       element.classList.remove('amp-notbuilt');
 
-      element.attachedCallback();
+      container.appendChild(element);
       return buildPromise.then(() => {
         expect(buildStub).to.be.called;
         expect(element).to.not.have.class('i-amphtml-element');
@@ -238,7 +238,7 @@ describes.realWin('CustomElement', {amp: true}, env => {
       });
     });
 
-    it('Element - should handle buggy connectedCallback #12849', () => {
+    it('Element - should handle async connectedCallback when disconnected', () => {
       const element = new ElementClass();
       Object.defineProperty(element, 'isConnected', {
         value: false,
@@ -262,13 +262,14 @@ describes.realWin('CustomElement', {amp: true}, env => {
       const buildStub = sandbox.stub(element, 'build').callsFake(
           () => buildPromise);
       container.appendChild(element);
+      container.removeChild(element);
 
       sandbox.stub(element, 'reconstructWhenReparented').callsFake(() => true);
       element.layoutCount_ = 10;
       element.isFirstLayoutCompleted_ = true;
       element.signals().signal('render-start');
       element.signals().signal('load-end');
-      element.attachedCallback();
+      container.appendChild(element);
       return buildPromise.then(() => {
         expect(buildStub).to.be.called;
         expect(element.layoutCount_).to.equal(0);
@@ -283,6 +284,7 @@ describes.realWin('CustomElement', {amp: true}, env => {
       const element = new ElementClass();
       sandbox.stub(element, 'build');
       container.appendChild(element);
+      container.removeChild(element);
 
       sandbox.stub(element, 'reconstructWhenReparented').callsFake(() => false);
       element.layoutCount_ = 10;
@@ -290,7 +292,7 @@ describes.realWin('CustomElement', {amp: true}, env => {
       element.signals().signal('render-start');
       expect(element.signals().get('render-start')).to.be.ok;
       element.signals().signal('load-end');
-      element.attachedCallback();
+      container.appendChild(element);
       expect(element.layoutCount_).to.equal(10);
       expect(element.isFirstLayoutCompleted_).to.be.true;
       expect(element.signals().get('render-start')).to.be.ok;
@@ -689,7 +691,30 @@ describes.realWin('CustomElement', {amp: true}, env => {
       container.appendChild(element);
 
       resourcesMock.expects('remove').withExactArgs(element).once();
-      element.detachedCallback();
+      container.removeChild(element);
+
+      expect(element.everAttached).to.equal(true);
+      expect(element.layout_).to.equal(Layout.FILL);
+      expect(element.implementation_.layout_).to.equal(Layout.FILL);
+      expect(testElementFirstAttachedCallback).to.be.calledOnce;
+    });
+
+    it('Element - should handle async detachedCallback when connected', () => {
+      const element = new ElementClass();
+      element.setAttribute('layout', 'fill');
+      expect(testElementFirstAttachedCallback).to.have.not.been.called;
+      expect(element.everAttached).to.equal(false);
+      expect(element.layout_).to.equal(Layout.NODISPLAY);
+
+      resourcesMock.expects('add').withExactArgs(element).atLeast(1);
+      resourcesMock.expects('upgraded').withExactArgs(element).atLeast(1);
+      container.appendChild(element);
+
+      resourcesMock.expects('remove').withExactArgs(element).never();
+      Object.defineProperty(element, 'isConnected', {
+        value: true,
+      });
+      container.removeChild(element);
 
       expect(element.everAttached).to.equal(true);
       expect(element.layout_).to.equal(Layout.FILL);

--- a/test/functional/test-custom-element.js
+++ b/test/functional/test-custom-element.js
@@ -238,6 +238,23 @@ describes.realWin('CustomElement', {amp: true}, env => {
       });
     });
 
+    it('Element - should handle buggy connectedCallback #12849', () => {
+      const element = new ElementClass();
+      Object.defineProperty(element, 'isConnected', {
+        value: false,
+      });
+
+      expect(element).to.not.have.class('i-amphtml-element');
+      expect(element).to.not.have.class('i-amphtml-notbuilt');
+      expect(element).to.not.have.class('amp-notbuilt');
+
+      container.appendChild(element);
+
+      expect(element).to.not.have.class('i-amphtml-element');
+      expect(element).to.not.have.class('i-amphtml-notbuilt');
+      expect(element).to.not.have.class('amp-notbuilt');
+    });
+
     it('Element - should reset on 2nd attachedCallback when requested', () => {
       clock.tick(1);
       const element = new ElementClass();

--- a/test/functional/test-dom.js
+++ b/test/functional/test-dom.js
@@ -87,6 +87,39 @@ describes.sandboxed('DOM', {}, env => {
     expect(dom.isConnectedNode(c)).to.be.false;
   });
 
+  it('isConnectedNode (no Node.p.isConnected)', () => {
+    if (!Object.hasOwnProperty.call(Node.prototype, 'isConnected')) {
+      return;
+    }
+
+    const desc = Object.getOwnPropertyDescriptor(Node.prototype,
+        'isConnected');
+    try {
+      delete Node.prototype.isConnected;
+
+      expect(dom.isConnectedNode(document)).to.be.true;
+
+      const a = document.createElement('div');
+      expect(dom.isConnectedNode(a)).to.be.false;
+
+      const b = document.createElement('div');
+      b.appendChild(a);
+
+      document.body.appendChild(b);
+      expect(dom.isConnectedNode(a)).to.be.true;
+
+      const shadow = a.attachShadow({mode: 'open'});
+      const c = document.createElement('div');
+      shadow.appendChild(c);
+      expect(dom.isConnectedNode(c)).to.be.true;
+
+      document.body.removeChild(b);
+      expect(dom.isConnectedNode(c)).to.be.false;
+    } finally {
+      Object.defineProperty(Node.prototype, 'isConnected', desc);
+    }
+  });
+
   it('rootNodeFor', () => {
     const a = document.createElement('div');
     expect(dom.rootNodeFor(a)).to.equal(a);
@@ -98,6 +131,31 @@ describes.sandboxed('DOM', {}, env => {
     const c = document.createElement('div');
     b.appendChild(c);
     expect(dom.rootNodeFor(c)).to.equal(a);
+  });
+
+  it('rootNodeFor (no Node.p.getRootNode)', () => {
+    if (!Object.hasOwnProperty.call(Node.prototype, 'getRootNode')) {
+      return;
+    }
+
+    const desc = Object.getOwnPropertyDescriptor(Node.prototype,
+        'getRootNode');
+    try {
+      delete Node.prototype.getRootNode;
+
+      const a = document.createElement('div');
+      expect(dom.rootNodeFor(a)).to.equal(a);
+
+      const b = document.createElement('div');
+      a.appendChild(b);
+      expect(dom.rootNodeFor(b)).to.equal(a);
+
+      const c = document.createElement('div');
+      b.appendChild(c);
+      expect(dom.rootNodeFor(c)).to.equal(a);
+    } finally {
+      Object.defineProperty(Node.prototype, 'getRootNode', desc);
+    }
   });
 
   it('closest should find itself', () => {


### PR DESCRIPTION
Fixes #12849.
Reverts part of #9432, since the bug is being addressed in runtime.
Closes #9441, since root bug is being addressed.