### PR TITLE
♻️ node.js validator: separate cli functionality from main API code

### DIFF
--- a/validator/nodejs/README.md
+++ b/validator/nodejs/README.md
@@ -93,3 +93,6 @@ As expected, this emits errors because the provided string in the example, `<htm
 * The amphtml-validator binary now requires the Node.js binary to be called node.
   On systems where the Node.js binary is called nodejs, consider installing
   the nodejs-legacy Debian package or better yet, NVM.
+
+### 1.0.24
+  * Separated the cli functionality from the main API code

--- a/validator/nodejs/cli.js
+++ b/validator/nodejs/cli.js
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+
+/**
+ * @license
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the license.
+ */
+
+'use strict';
+
+var cli = require('.').cli;
+
+if (require.main === module) {
+  cli();
+}

--- a/validator/nodejs/index.js
+++ b/validator/nodejs/index.js
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 /**
  * @license
  * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
@@ -387,7 +386,7 @@ function logValidationResult(filename, validationResult, color) {
 /**
  * Main entry point into the command line tool.
  */
-function main() {
+function cli() {
   program
       .usage(
           '[options] <fileOrUrlOrMinus...>\n\n' +
@@ -506,7 +505,4 @@ function main() {
             });
       });
 }
-
-if (require.main === module) {
-  main();
-}
+exports.cli = cli;

--- a/validator/nodejs/package.json
+++ b/validator/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amphtml-validator",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "description": "Official validator for AMP HTML (www.ampproject.org)",
   "keywords": [
     "AMP",
@@ -19,7 +19,7 @@
     "url": "https://github.com/ampproject/amphtml/tree/master/validator/nodejs/"
   },
   "bin": {
-    "amphtml-validator": "index.js"
+    "amphtml-validator": "cli.js"
   },
   "dependencies": {
     "colors": "1.1.2",


### PR DESCRIPTION
This PR simply moves the CLI functionality of the node.js validator to a separate file.

The cli needs a hashbang `#!/usr/bin/env node` at the start of the file.  However, when trying to use the node API directly, and using a module bundler like webpack, it fails on the invalid syntax of the hashbang.
