### PR TITLE
Wrap inabox binaries in function to prevent vars leaking to global window.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -392,7 +392,6 @@ function compile(watch, shouldMinify, opt_preventRemoveAndMakeDir,
             watch,
             preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
             minify: shouldMinify,
-            wrapper: '<%= contents %>',
           }),
 
           // inabox-host
@@ -404,7 +403,6 @@ function compile(watch, shouldMinify, opt_preventRemoveAndMakeDir,
             watch,
             preventRemoveAndMakeDir: opt_preventRemoveAndMakeDir,
             minify: shouldMinify,
-            wrapper: '<%= contents %>',
           })
       );
     }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1040,6 +1040,9 @@ function compileJs(srcDir, srcFilename, destDir, options) {
     bundler = watchify(bundler);
   }
 
+  // Default wrapper for `gulp build`.
+  // We don't need an explicit function wrapper like we do for `gulp dist`
+  // because Babel handles that for you.
   const wrapper = options.wrapper || '<%= contents %>';
 
   const lazybuild = lazypipe()


### PR DESCRIPTION
Remove the wrapper override and enable the default wrapper, which is defined here:
https://github.com/ampproject/amphtml/blob/master/build-system/tasks/compile.js#L117

Tested locally.

Fixes #13734