### PR TITLE
Fixes validation rules for amp-story-cta-layer and adds test 🐛 

### DIFF
--- a/extensions/amp-story/0.1/test/validator-amp-story-cta-layer-error.html
+++ b/extensions/amp-story/0.1/test/validator-amp-story-cta-layer-error.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-0.1.js"></script>
+  <title>My Story</title>
+  <meta name="description" content="Get started with amp-story">
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <link rel="canonical" href="grid-layer-templates.html">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <style amp-custom>
+    body {
+      font-family: 'Roboto', sans-serif;
+    }
+    amp-story-page {
+      background: white;
+    }
+    .button {
+      font: bold 20px Arial;
+      text-decoration: none;
+      background-color: rgba(0, 240, 248, 0.63);
+      color: #333333;
+      padding: 2px 6px 2px 6px;
+      border-top: 1px solid #CCCCCC;
+      border-right: 1px solid #333333;
+      border-bottom: 1px solid #333333;
+      border-left: 1px solid #CCCCCC;
+      width: 100%;
+      height: 100%;
+      position: absolute;
+    }
+  </style>
+</head>
+<body>
+  <amp-story standalone>
+    <amp-story-page id="fill-template-title">
+      <amp-story-cta-layer>
+        <a href="http://www.google.com" class="button"> Illegal CTA layer above grid layer! </a>
+      </amp-story-cta-layer>
+      <amp-story-grid-layer template="vertical">
+        <h1>fill</h1>
+      </amp-story-grid-layer>
+    </amp-story-page>
+    <amp-story-cta-layer>
+      <a href="http://www.google.com" class="button"> Illegal CTA layer outside of amp-story-page! </a>
+    </amp-story-cta-layer>
+  </amp-story>
+</body>
+</html>

--- a/extensions/amp-story/0.1/test/validator-amp-story-cta-layer-error.out
+++ b/extensions/amp-story/0.1/test/validator-amp-story-cta-layer-error.out
@@ -1,0 +1,57 @@
+FAIL
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-0.1.js"></script>
+|    <title>My Story</title>
+|    <meta name="description" content="Get started with amp-story">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+|    <link rel="canonical" href="grid-layer-templates.html">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <style amp-custom>
+|      body {
+|        font-family: 'Roboto', sans-serif;
+|      }
+|      amp-story-page {
+|        background: white;
+|      }
+|      .button {
+|        font: bold 20px Arial;
+|        text-decoration: none;
+|        background-color: rgba(0, 240, 248, 0.63);
+|        color: #333333;
+|        padding: 2px 6px 2px 6px;
+|        border-top: 1px solid #CCCCCC;
+|        border-right: 1px solid #333333;
+|        border-bottom: 1px solid #333333;
+|        border-left: 1px solid #CCCCCC;
+|        width: 100%;
+|        height: 100%;
+|        position: absolute;
+|      }
+|    </style>
+|  </head>
+|  <body>
+|    <amp-story standalone>
+|      <amp-story-page id="fill-template-title">
+|        <amp-story-cta-layer>
+>>       ^~~~~~~~~
+amp-story/0.1/test/validator-amp-story-cta-layer-error.html:38:6 Tag 'amp-story-cta-layer', if present, must be the last child of tag 'amp-story-page'. [AMP_TAG_PROBLEM]
+|          <a href="http://www.google.com" class="button"> Illegal CTA layer above grid layer! </a>
+|        </amp-story-cta-layer>
+|        <amp-story-grid-layer template="vertical">
+|          <h1>fill</h1>
+|        </amp-story-grid-layer>
+|      </amp-story-page>
+|      <amp-story-cta-layer>
+>>     ^~~~~~~~~
+amp-story/0.1/test/validator-amp-story-cta-layer-error.html:45:4 The tag 'amp-story-cta-layer' may only appear as a descendant of tag 'amp-story-page'. [AMP_TAG_PROBLEM]
+>>     ^~~~~~~~~
+amp-story/0.1/test/validator-amp-story-cta-layer-error.html:45:4 Tag 'amp-story-cta-layer' is disallowed as child of tag 'amp-story'. Child tag must be one of ['amp-analytics', 'amp-pixel', 'amp-story-auto-ads', 'amp-story-page']. (see https://www.ampproject.org/docs/reference/components/amp-story) [AMP_TAG_PROBLEM]
+|        <a href="http://www.google.com" class="button"> Illegal CTA layer outside of amp-story-page! </a>
+|      </amp-story-cta-layer>
+|    </amp-story>
+|  </body>
+|  </html>

--- a/extensions/amp-story/0.1/test/validator-amp-story-cta-layer.html
+++ b/extensions/amp-story/0.1/test/validator-amp-story-cta-layer.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html ⚡>
+
+<head>
+  <meta charset="utf-8">
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-0.1.js"></script>
+  <title>My Story</title>
+  <meta name="description" content="Get started with amp-story">
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <link rel="canonical" href="grid-layer-templates.html">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <style amp-custom>
+    body {
+      font-family: 'Roboto', sans-serif;
+    }
+
+    amp-story-page {
+      background: white;
+    }
+
+    .button {
+      font: bold 20px Arial;
+      text-decoration: none;
+      background-color: rgba(0, 240, 248, 0.63);
+      color: #333333;
+      padding: 2px 6px 2px 6px;
+      border-top: 1px solid #CCCCCC;
+      border-right: 1px solid #333333;
+      border-bottom: 1px solid #333333;
+      border-left: 1px solid #CCCCCC;
+      width: 100%;
+      height: 100%;
+      position: absolute;
+    }
+  </style>
+</head>
+
+<body>
+  <amp-story standalone>
+
+    <amp-story-page id="fill-template-title">
+      <amp-story-grid-layer template="vertical">
+        <h1>fill</h1>
+      </amp-story-grid-layer>
+      <amp-story-cta-layer>
+        <a href="http://www.google.com" class="button"> Call to action! </a>
+      </amp-story-cta-layer>
+    </amp-story-page>
+
+  </amp-story>
+</body>
+
+</html>

--- a/extensions/amp-story/0.1/test/validator-amp-story-cta-layer.html
+++ b/extensions/amp-story/0.1/test/validator-amp-story-cta-layer.html
@@ -1,6 +1,5 @@
 <!doctype html>
 <html ⚡>
-
 <head>
   <meta charset="utf-8">
   <script async src="https://cdn.ampproject.org/v0.js"></script>
@@ -14,11 +13,9 @@
     body {
       font-family: 'Roboto', sans-serif;
     }
-
     amp-story-page {
       background: white;
     }
-
     .button {
       font: bold 20px Arial;
       text-decoration: none;
@@ -35,10 +32,8 @@
     }
   </style>
 </head>
-
 <body>
   <amp-story standalone>
-
     <amp-story-page id="fill-template-title">
       <amp-story-grid-layer template="vertical">
         <h1>fill</h1>
@@ -47,8 +42,6 @@
         <a href="http://www.google.com" class="button"> Call to action! </a>
       </amp-story-cta-layer>
     </amp-story-page>
-
   </amp-story>
 </body>
-
 </html>

--- a/extensions/amp-story/0.1/test/validator-amp-story-cta-layer.out
+++ b/extensions/amp-story/0.1/test/validator-amp-story-cta-layer.out
@@ -1,0 +1,48 @@
+PASS
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-0.1.js"></script>
+|    <title>My Story</title>
+|    <meta name="description" content="Get started with amp-story">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+|    <link rel="canonical" href="grid-layer-templates.html">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <style amp-custom>
+|      body {
+|        font-family: 'Roboto', sans-serif;
+|      }
+|      amp-story-page {
+|        background: white;
+|      }
+|      .button {
+|        font: bold 20px Arial;
+|        text-decoration: none;
+|        background-color: rgba(0, 240, 248, 0.63);
+|        color: #333333;
+|        padding: 2px 6px 2px 6px;
+|        border-top: 1px solid #CCCCCC;
+|        border-right: 1px solid #333333;
+|        border-bottom: 1px solid #333333;
+|        border-left: 1px solid #CCCCCC;
+|        width: 100%;
+|        height: 100%;
+|        position: absolute;
+|      }
+|    </style>
+|  </head>
+|  <body>
+|    <amp-story standalone>
+|      <amp-story-page id="fill-template-title">
+|        <amp-story-grid-layer template="vertical">
+|          <h1>fill</h1>
+|        </amp-story-grid-layer>
+|        <amp-story-cta-layer>
+|          <a href="http://www.google.com" class="button"> Call to action! </a>
+|        </amp-story-cta-layer>
+|      </amp-story-page>
+|    </amp-story>
+|  </body>
+|  </html>

--- a/extensions/amp-story/validator-amp-story.protoascii
+++ b/extensions/amp-story/validator-amp-story.protoascii
@@ -83,8 +83,8 @@ tags: {  # <amp-story-page>
   child_tags: {
     child_tag_name_oneof: "AMP-ANALYTICS"
     child_tag_name_oneof: "AMP-PIXEL"
-    child_tag_name_oneof: "AMP-STORY-GRID-LAYER"
     child_tag_name_oneof: "AMP-STORY-CTA-LAYER"
+    child_tag_name_oneof: "AMP-STORY-GRID-LAYER"
     mandatory_min_num_child_tags: 1
   }
 }

--- a/extensions/amp-story/validator-amp-story.protoascii
+++ b/extensions/amp-story/validator-amp-story.protoascii
@@ -84,6 +84,7 @@ tags: {  # <amp-story-page>
     child_tag_name_oneof: "AMP-ANALYTICS"
     child_tag_name_oneof: "AMP-PIXEL"
     child_tag_name_oneof: "AMP-STORY-GRID-LAYER"
+    child_tag_name_oneof: "AMP-STORY-CTA-LAYER"
     mandatory_min_num_child_tags: 1
   }
 }


### PR DESCRIPTION
Closes: #12169

Fixes validation rules for amp-story-cta-layer to allow it as a child of the 'amp-story-page' tag. Includes tests.