### PR TITLE
inabox: fix memory leak

### DIFF
--- a/ads/inabox/position-observer.js
+++ b/ads/inabox/position-observer.js
@@ -54,6 +54,7 @@ export class PositionObserver {
    * TODO: maybe take DOM mutation into consideration
    * @param element {!Element}
    * @param callback {function(!PositionEntryDef)}
+   * @return {!UnlistenDef}
    */
   observe(element, callback) {
     if (!this.positionObservable_) {
@@ -68,7 +69,7 @@ export class PositionObserver {
     }
     // Send the 1st ping immediately
     callback(this.getPositionEntry_(element));
-    this.positionObservable_.add(() => {
+    return this.positionObservable_.add(() => {
       callback(this.getPositionEntry_(element));
     });
   }

--- a/examples/inabox.host.memory.html
+++ b/examples/inabox.host.memory.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <title>amp-inabox-host example</title>
+  <style>
+    body {
+      font-size: 1.2em;
+    }
+  </style>
+</head>
+<body>
+  <h2>
+    This page tests amp-inabox memory usage on refresh. Follow the instructions
+    below.
+  </h2>
+  <hr>
+  <h3>Inabox above the fold</h3>
+  <div>
+    Open the Task Manager (Shift+ESC) and turn on tracking JavaScript memory
+    (right click table header, select JavaScript memory).  The "live" portion
+    shouldn't just climb and climb, but bounce around near a single number.
+  </div>
+
+  <script>
+    let n = 0;
+    let iframe = null;
+    window.ampInaboxIframes = window.ampInaboxIframes || [];
+    function make_ad_iframe() {
+      iframe = document.createElement('iframe');
+      iframe.name = 'iframe-' + n;
+      n++;
+      iframe.src = '//ads.localhost:8000/examples/inabox.amp.html';
+      iframe.scrolling = 'no';
+      iframe.width = 300;
+      iframe.height = 200;
+      window.ampInaboxIframes.push(iframe);
+      document.body.appendChild(iframe);
+    }
+    function remove_ad_iframe() {
+      if (!window.AMP) {
+        console.log("window.AMP not defined");
+      } else {
+        window.AMP.inaboxUnregisterIframe(iframe);
+      }
+      iframe.remove();
+    }
+    function repeatedly_replace_ad_iframe() {
+      make_ad_iframe();
+      window.setTimeout(() => {
+        remove_ad_iframe(iframe);
+        repeatedly_replace_ad_iframe();
+      }, 1000);
+    }
+    repeatedly_replace_ad_iframe();
+  </script>
+  <script src="./inabox-tag-integration.js"></script>
+</body>


### PR DESCRIPTION
In #13795 we tried to fix a memory leak but missed that `PositionObserver.observe(...)` wasn't passing back the unregister function from `Observable.add()`, and so we weren't removing the listener.

After this change we still leak on refresh: with `examples/inabox.host.memory.html` I measure us as leaking 200k in 60 refreshes without this PR, vs 30k with it.  I'm still trying to figure out where else we leak, but getting the per-refresh leak down from 3k to 0.5k is still worth shipping.