### PR TITLE
Failed to call initLogConstructor error should include how to fix

### DIFF
--- a/src/log.js
+++ b/src/log.js
@@ -597,7 +597,11 @@ export function user(opt_element) {
  */
 function getUserLogger(suffix) {
   if (!logConstructor) {
-    throw new Error('failed to call initLogConstructor');
+    const errorMsg = 'failed to call initLogConstructor.' +
+          (getMode().test || getMode().localDev) ?
+          ' Run "gulp clean && gulp css && gulp build" and try again' :
+          '';
+    throw new Error(errorMsg);
   }
   return new logConstructor(self, mode => {
     const logNum = parseInt(mode.log, 10);
@@ -623,7 +627,11 @@ export function dev() {
     return logs.dev;
   }
   if (!logConstructor) {
-    throw new Error('failed to call initLogConstructor');
+    const errorMsg = 'failed to call initLogConstructor' +
+          (getMode().test || getMode().localDev) ?
+          ' Run "gulp clean && gulp css && gulp build" and try again' :
+          '';
+    throw new Error(errorMsg);
   }
   return logs.dev = new logConstructor(self, mode => {
     const logNum = parseInt(mode.log, 10);

--- a/src/log.js
+++ b/src/log.js
@@ -599,8 +599,8 @@ function getUserLogger(suffix) {
   if (!logConstructor) {
     const errorMsg = 'failed to call initLogConstructor.' +
           (getMode().test || getMode().localDev) ?
-          ' Run "gulp clean && gulp css && gulp build" and try again' :
-          '';
+      ' Run "gulp clean && gulp css && gulp build" and try again' :
+      '';
     throw new Error(errorMsg);
   }
   return new logConstructor(self, mode => {
@@ -629,8 +629,8 @@ export function dev() {
   if (!logConstructor) {
     const errorMsg = 'failed to call initLogConstructor' +
           (getMode().test || getMode().localDev) ?
-          ' Run "gulp clean && gulp css && gulp build" and try again' :
-          '';
+      ' Run "gulp clean && gulp css && gulp build" and try again' :
+      '';
     throw new Error(errorMsg);
   }
   return logs.dev = new logConstructor(self, mode => {

--- a/src/log.js
+++ b/src/log.js
@@ -599,7 +599,7 @@ function getUserLogger(suffix) {
   if (!logConstructor) {
     const errorMsg = 'failed to call initLogConstructor.' +
           (getMode().test || getMode().localDev) ?
-      ' Run "gulp clean && gulp css && gulp build" and try again' :
+      ' Run "gulp clean && gulp css" and try again' :
       '';
     throw new Error(errorMsg);
   }
@@ -629,7 +629,7 @@ export function dev() {
   if (!logConstructor) {
     const errorMsg = 'failed to call initLogConstructor' +
           (getMode().test || getMode().localDev) ?
-      ' Run "gulp clean && gulp css && gulp build" and try again' :
+      ' Run "gulp clean && gulp css" and try again' :
       '';
     throw new Error(errorMsg);
   }


### PR DESCRIPTION
"failed to call initLogConstructor" error occurs with a lot of frequency when working locally, at least for the A4A team. This PR adds an extra comment when in localdev or test mode, to indicate how to attempt to fix this issue. 