### PR TITLE
<amp-accordion> Move expand-single-section attribute to correct validation section

### DIFF
--- a/extensions/amp-accordion/validator-amp-accordion.protoascii
+++ b/extensions/amp-accordion/validator-amp-accordion.protoascii
@@ -28,6 +28,7 @@ tags: {  # <amp-accordion>
   tag_name: "AMP-ACCORDION"
   requires_extension: "amp-accordion"
   attrs: { name: "disable-session-states" value: "" }
+  attrs: { name: "expand-single-section" value: "" }
   child_tags: {
     child_tag_name_oneof: "SECTION"
   }
@@ -41,7 +42,6 @@ tags: {  # <amp-accordion> > <section>
   spec_name: "amp-accordion > section"
   mandatory_parent: "AMP-ACCORDION"
   attrs: { name: "expanded" value: "" }
-  attrs: { name: "expand-single-section" value: "" }
   child_tags: {
     mandatory_num_child_tags: 2
     first_child_tag_name_oneof: "H1"


### PR DESCRIPTION
Fixes #13948. 

I am a silly who mistakenly moved the attribute to the wrong section in response to a comment. 