### PR TITLE
SauceLabs iOS 9.1 -> 9.3

### DIFF
--- a/build-system/tasks/karma.conf.js
+++ b/build-system/tasks/karma.conf.js
@@ -153,10 +153,10 @@ module.exports = {
       browserName: 'iphone',
       version: '10.0',
     },
-    SL_iOS_9_1: {
+    SL_iOS_9_3: {
       base: 'SauceLabs',
       browserName: 'iphone',
-      version: '9.1',
+      version: '9.3',
     },
     SL_Firefox_latest: {
       base: 'SauceLabs',

--- a/build-system/tasks/runtime-test.js
+++ b/build-system/tasks/runtime-test.js
@@ -84,7 +84,7 @@ function getConfig() {
         'SL_Safari_9',
         'SL_iOS_latest',
         'SL_iOS_10_0',
-        'SL_iOS_9_1',
+        'SL_iOS_9_3',
         'SL_Edge_latest',
         'SL_IE_11',
       ] : [


### PR DESCRIPTION
Fixes #13981 (I think). 

SauceLabs seems to have silently dropped support for iOS 9.1 simulator.