### PR TITLE
🏗Reduce closure compiler parallelism on Travis to number of cores

### DIFF
--- a/build-system/tasks/compile.js
+++ b/build-system/tasks/compile.js
@@ -31,7 +31,7 @@ const shortenLicense = require('../shorten-license');
 const isProdBuild = !!argv.type;
 const queue = [];
 let inProgress = 0;
-const MAX_PARALLEL_CLOSURE_INVOCATIONS = 4;
+const MAX_PARALLEL_CLOSURE_INVOCATIONS = process.env.Travis ? 2 : 4;
 
 // Compiles AMP with the closure compiler. This is intended only for
 // production use. During development we intend to continue using


### PR DESCRIPTION
This PR reduces the number of parallel closure compiler invocations to the number of cores available on Travis.

See https://docs.travis-ci.com/user/reference/overview/#Virtualisation-Environment-vs-Operating-System

This is a speculative mitigation for #13954