### PR TITLE
Validator update

### DIFF
--- a/extensions/amp-story/0.1/test/validator-amp-story-cta-layer-error.html
+++ b/extensions/amp-story/0.1/test/validator-amp-story-cta-layer-error.html
@@ -1,3 +1,19 @@
+<!--
+  Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS-IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the license.
+-->
+<!--
+  Test Description:
+  Tests for the amp-story tag.
+-->
 <!doctype html>
 <html ⚡>
 <head>

--- a/extensions/amp-story/0.1/test/validator-amp-story-cta-layer-error.out
+++ b/extensions/amp-story/0.1/test/validator-amp-story-cta-layer-error.out
@@ -1,4 +1,20 @@
 FAIL
+|  <!--
+|    Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|        http://www.apache.org/licenses/LICENSE-2.0
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests for the amp-story tag.
+|  -->
 |  <!doctype html>
 |  <html ⚡>
 |  <head>
@@ -38,7 +54,7 @@ FAIL
 |      <amp-story-page id="fill-template-title">
 |        <amp-story-cta-layer>
 >>       ^~~~~~~~~
-amp-story/0.1/test/validator-amp-story-cta-layer-error.html:38:6 Tag 'amp-story-cta-layer', if present, must be the last child of tag 'amp-story-page'. [AMP_TAG_PROBLEM]
+amp-story/0.1/test/validator-amp-story-cta-layer-error.html:54:6 Tag 'amp-story-cta-layer', if present, must be the last child of tag 'amp-story-page'. [AMP_TAG_PROBLEM]
 |          <a href="http://www.google.com" class="button"> Illegal CTA layer above grid layer! </a>
 |        </amp-story-cta-layer>
 |        <amp-story-grid-layer template="vertical">
@@ -47,9 +63,9 @@ amp-story/0.1/test/validator-amp-story-cta-layer-error.html:38:6 Tag 'amp-story-
 |      </amp-story-page>
 |      <amp-story-cta-layer>
 >>     ^~~~~~~~~
-amp-story/0.1/test/validator-amp-story-cta-layer-error.html:45:4 The tag 'amp-story-cta-layer' may only appear as a descendant of tag 'amp-story-page'. [AMP_TAG_PROBLEM]
+amp-story/0.1/test/validator-amp-story-cta-layer-error.html:61:4 The tag 'amp-story-cta-layer' may only appear as a descendant of tag 'amp-story-page'. [AMP_TAG_PROBLEM]
 >>     ^~~~~~~~~
-amp-story/0.1/test/validator-amp-story-cta-layer-error.html:45:4 Tag 'amp-story-cta-layer' is disallowed as child of tag 'amp-story'. Child tag must be one of ['amp-analytics', 'amp-pixel', 'amp-story-auto-ads', 'amp-story-page']. (see https://www.ampproject.org/docs/reference/components/amp-story) [AMP_TAG_PROBLEM]
+amp-story/0.1/test/validator-amp-story-cta-layer-error.html:61:4 Tag 'amp-story-cta-layer' is disallowed as child of tag 'amp-story'. Child tag must be one of ['amp-analytics', 'amp-pixel', 'amp-story-auto-ads', 'amp-story-page']. (see https://www.ampproject.org/docs/reference/components/amp-story) [AMP_TAG_PROBLEM]
 |        <a href="http://www.google.com" class="button"> Illegal CTA layer outside of amp-story-page! </a>
 |      </amp-story-cta-layer>
 |    </amp-story>

--- a/extensions/amp-story/0.1/test/validator-amp-story-cta-layer.html
+++ b/extensions/amp-story/0.1/test/validator-amp-story-cta-layer.html
@@ -1,3 +1,19 @@
+<!--
+  Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS-IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the license.
+-->
+<!--
+  Test Description:
+  Tests for the amp-story tag.
+-->
 <!doctype html>
 <html ⚡>
 <head>

--- a/extensions/amp-story/0.1/test/validator-amp-story-cta-layer.out
+++ b/extensions/amp-story/0.1/test/validator-amp-story-cta-layer.out
@@ -1,4 +1,20 @@
 PASS
+|  <!--
+|    Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|        http://www.apache.org/licenses/LICENSE-2.0
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests for the amp-story tag.
+|  -->
 |  <!doctype html>
 |  <html ⚡>
 |  <head>

--- a/validator/testdata/feature_tests/link_meta_values.html
+++ b/validator/testdata/feature_tests/link_meta_values.html
@@ -28,6 +28,7 @@
   <meta name="amp-experiment-token" content="HfmyLgNLmblRg3Alqy164Vywr">
   <link rel="manifest" href="foo">
   <link rel="manifest foo" href="foo">
+  <link rel="preload" as="script" href="https://cdn.ampproject.org/v0.js">
   <link rel="shortcut icon" type="a" href="b" sizes="c">
   <link rel="author" href="me">
   <link rel="DCTERMS.any" href="foo">

--- a/validator/testdata/feature_tests/link_meta_values.out
+++ b/validator/testdata/feature_tests/link_meta_values.out
@@ -31,18 +31,19 @@ FAIL
 |    <link rel="manifest foo" href="foo">
 >>   ^~~~~~~~~
 feature_tests/link_meta_values.html:30:2 The attribute 'rel' in tag 'link rel=' is set to the invalid value 'manifest foo'. (see https://www.ampproject.org/docs/reference/spec#html-tags) [DISALLOWED_HTML]
+|    <link rel="preload" as="script" href="https://cdn.ampproject.org/v0.js">
 |    <link rel="shortcut icon" type="a" href="b" sizes="c">
 |    <link rel="author" href="me">
 |    <link rel="DCTERMS.any" href="foo">
 |  
 |    <meta name="content-disposition" content="any">
 >>   ^~~~~~~~~
-feature_tests/link_meta_values.html:35:2 The attribute 'name' in tag 'meta name= and content=' is set to the invalid value 'content-disposition'. [DISALLOWED_HTML]
+feature_tests/link_meta_values.html:36:2 The attribute 'name' in tag 'meta name= and content=' is set to the invalid value 'content-disposition'. [DISALLOWED_HTML]
 |    <meta name=viewport content=invalid>
 >>   ^~~~~~~~~
-feature_tests/link_meta_values.html:36:2 The property 'minimum-scale' is missing from attribute 'content' in tag 'meta name=viewport'. (see https://www.ampproject.org/docs/reference/spec#required-markup) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
+feature_tests/link_meta_values.html:37:2 The property 'minimum-scale' is missing from attribute 'content' in tag 'meta name=viewport'. (see https://www.ampproject.org/docs/reference/spec#required-markup) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
 >>   ^~~~~~~~~
-feature_tests/link_meta_values.html:36:2 The property 'width' is missing from attribute 'content' in tag 'meta name=viewport'. (see https://www.ampproject.org/docs/reference/spec#required-markup) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
+feature_tests/link_meta_values.html:37:2 The property 'width' is missing from attribute 'content' in tag 'meta name=viewport'. (see https://www.ampproject.org/docs/reference/spec#required-markup) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
 |    <link rel="unknown" href="foo">
 |  
 |    <link rel="comment cite map" href="foo">
@@ -55,7 +56,7 @@ feature_tests/link_meta_values.html:36:2 The property 'width' is missing from at
 |    <!-- Invalid as we need some additional attributes e.g. "rel=canonical" -->
 |    <link href="foo">
 >>   ^~~~~~~~~
-feature_tests/link_meta_values.html:47:2 The mandatory attribute 'rel' is missing in tag 'link rel='. (see https://www.ampproject.org/docs/reference/spec#html-tags) [DISALLOWED_HTML]
+feature_tests/link_meta_values.html:48:2 The mandatory attribute 'rel' is missing in tag 'link rel='. (see https://www.ampproject.org/docs/reference/spec#html-tags) [DISALLOWED_HTML]
 |  </head>
 |  <body>
 |  Hello, world.

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -26,7 +26,7 @@ min_validator_revision_required: 319
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 585
+spec_file_revision: 586
 
 styles_spec_url: "https://www.ampproject.org/docs/guides/author-develop/responsive/style_pages"
 script_spec_url: "https://www.ampproject.org/docs/reference/spec#html-tags"

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -26,7 +26,7 @@ min_validator_revision_required: 319
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 584
+spec_file_revision: 585
 
 styles_spec_url: "https://www.ampproject.org/docs/guides/author-develop/responsive/style_pages"
 script_spec_url: "https://www.ampproject.org/docs/reference/spec#html-tags"
@@ -182,13 +182,12 @@ tags: {
         "components|"
         "import|"
         "manifest|"  # Handled separately below, has specific requirements.
+        "preload|"  # Handled separately below, has specific requirements.
         "serviceworker|"
         "stylesheet|"  # Handled separately below, has specific requirements.
         "subresource|"
         ")(\\s|$)"
   }
-  attrs: { name: "sizes" }
-  attrs: { name: "type" }
   attr_lists: "common-link-attrs"
   spec_url: "https://www.ampproject.org/docs/reference/spec#html-tags"
 }
@@ -240,6 +239,24 @@ tags: {
     name: "rel"
     value_casei: "manifest"
     mandatory: true
+    dispatch_key: NAME_VALUE_DISPATCH
+  }
+  attr_lists: "common-link-attrs"
+  spec_url: "https://www.ampproject.org/docs/reference/spec#html-tags"
+}
+tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: EXPERIMENTAL
+  tag_name: "LINK"
+  spec_name: "link rel=preload"
+  disallowed_ancestor: "TEMPLATE"
+  attrs: { name: "as" }
+  attrs: { name: "href" }
+  attrs: {
+    name: "rel"
+    mandatory: true
+    value_casei: "preload"
     dispatch_key: NAME_VALUE_DISPATCH
   }
   attr_lists: "common-link-attrs"

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -26,7 +26,7 @@ min_validator_revision_required: 319
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 583
+spec_file_revision: 584
 
 styles_spec_url: "https://www.ampproject.org/docs/guides/author-develop/responsive/style_pages"
 script_spec_url: "https://www.ampproject.org/docs/reference/spec#html-tags"


### PR DESCRIPTION
Revision bumps for 13962, 13978. Allow `as` attribute for `link` tags with `rel=preload`.