### PR TITLE
Allow amp-list with only [src] attribute

### DIFF
--- a/extensions/amp-list/0.1/test/validator-amp-list.html
+++ b/extensions/amp-list/0.1/test/validator-amp-list.html
@@ -36,7 +36,7 @@
   </amp-list>
   <!-- Valid: amp-list with only [src] attribute -->
   <amp-list width=10 height=10
-            src="https://data.com/articles.json?ref=CANONICAL_URL">
+            [src]="foo.bar">
     <div></div>
   </amp-list>
   <!-- Valid: amp-list with both src and [src] attributes -->

--- a/extensions/amp-list/0.1/test/validator-amp-list.html
+++ b/extensions/amp-list/0.1/test/validator-amp-list.html
@@ -29,12 +29,17 @@
     src="https://cdn.ampproject.org/v0/amp-list-0.1.js"></script>
 </head>
 <body>
-  <!-- Example of a valid amp-list -->
+  <!-- Valid: amp-list with only src attribute -->
   <amp-list width=10 height=10
             src="https://data.com/articles.json?ref=CANONICAL_URL">
     <div></div>
   </amp-list>
-  <!-- Valid amp-list with amp-bind attributes -->
+  <!-- Valid: amp-list with only [src] attribute -->
+  <amp-list width=10 height=10
+            src="https://data.com/articles.json?ref=CANONICAL_URL">
+    <div></div>
+  </amp-list>
+  <!-- Valid: amp-list with both src and [src] attributes -->
   <amp-list width=10 height=10
             src="https://data.com/articles.json?ref=CANONICAL_URL"
             [src]="foo.bar" [state]="baz.qux">
@@ -49,7 +54,7 @@
   <amp-list width=10 height=10>
     <div></div>
   </amp-list>
-  <!-- also invalid: width/height missing, so it's container layout
+  <!-- Invalid: width/height missing, so it's container layout
        which isn't supported. -->
   <amp-list src="https://data.com/articles.json?ref=CANONICAL_URL">
     <div></div>

--- a/extensions/amp-list/0.1/test/validator-amp-list.out
+++ b/extensions/amp-list/0.1/test/validator-amp-list.out
@@ -30,12 +30,17 @@ FAIL
 |      src="https://cdn.ampproject.org/v0/amp-list-0.1.js"></script>
 |  </head>
 |  <body>
-|    <!-- Example of a valid amp-list -->
+|    <!-- Valid: amp-list with only src attribute -->
 |    <amp-list width=10 height=10
 |              src="https://data.com/articles.json?ref=CANONICAL_URL">
 |      <div></div>
 |    </amp-list>
-|    <!-- Valid amp-list with amp-bind attributes -->
+|    <!-- Valid: amp-list with only [src] attribute -->
+|    <amp-list width=10 height=10
+|              src="https://data.com/articles.json?ref=CANONICAL_URL">
+|      <div></div>
+|    </amp-list>
+|    <!-- Valid: amp-list with both src and [src] attributes -->
 |    <amp-list width=10 height=10
 |              src="https://data.com/articles.json?ref=CANONICAL_URL"
 |              [src]="foo.bar" [state]="baz.qux">
@@ -43,22 +48,22 @@ FAIL
 |    </amp-list>
 |    <!-- Invalid: width is mistyped. -->
 |    <amp-list src="https://data.com/articles.json?ref=CANONICAL_URL"
->>   ^~~~~~~~~
-amp-list/0.1/test/validator-amp-list.html:44:2 The attribute 'wdith' may not appear in tag 'amp-list'. (see https://www.ampproject.org/docs/reference/components/amp-list) [AMP_TAG_PROBLEM]
+    >>   ^~~~~~~~~
+    amp-list/0.1/test/validator-amp-list.html:49:2 The attribute 'wdith' may not appear in tag 'amp-list'. (see https://www.ampproject.org/docs/reference/components/amp-list) [AMP_TAG_PROBLEM]
 |              wdith=10 height=10>
 |      <div></div>
 |    </amp-list>
 |    <!-- Invalid: src is missing. -->
 |    <amp-list width=10 height=10>
->>   ^~~~~~~~~
-amp-list/0.1/test/validator-amp-list.html:49:2 The mandatory attribute 'src' is missing in tag 'amp-list'. (see https://www.ampproject.org/docs/reference/components/amp-list) [AMP_TAG_PROBLEM]
+    >>   ^~~~~~~~~
+    amp-list/0.1/test/validator-amp-list.html:54:2 The mandatory attribute 'src' is missing in tag 'amp-list'. (see https://www.ampproject.org/docs/reference/components/amp-list) [AMP_TAG_PROBLEM]
 |      <div></div>
 |    </amp-list>
-|    <!-- also invalid: width/height missing, so it's container layout
+|    <!-- Invalid: width/height missing, so it's container layout
 |         which isn't supported. -->
 |    <amp-list src="https://data.com/articles.json?ref=CANONICAL_URL">
->>   ^~~~~~~~~
-amp-list/0.1/test/validator-amp-list.html:54:2 The implied layout 'CONTAINER' is not supported by tag 'amp-list'. (see https://www.ampproject.org/docs/reference/components/amp-list) [AMP_LAYOUT_PROBLEM]
+    >>   ^~~~~~~~~
+    amp-list/0.1/test/validator-amp-list.html:59:2 The implied layout 'CONTAINER' is not supported by tag 'amp-list'. (see https://www.ampproject.org/docs/reference/components/amp-list) [AMP_LAYOUT_PROBLEM]
 |      <div></div>
 |    </amp-list>
 |  </body>

--- a/extensions/amp-list/0.1/test/validator-amp-list.out
+++ b/extensions/amp-list/0.1/test/validator-amp-list.out
@@ -48,22 +48,22 @@ FAIL
 |    </amp-list>
 |    <!-- Invalid: width is mistyped. -->
 |    <amp-list src="https://data.com/articles.json?ref=CANONICAL_URL"
-    >>   ^~~~~~~~~
-    amp-list/0.1/test/validator-amp-list.html:49:2 The attribute 'wdith' may not appear in tag 'amp-list'. (see https://www.ampproject.org/docs/reference/components/amp-list) [AMP_TAG_PROBLEM]
+>>   ^~~~~~~~~
+amp-list/0.1/test/validator-amp-list.html:49:2 The attribute 'wdith' may not appear in tag 'amp-list'. (see https://www.ampproject.org/docs/reference/components/amp-list) [AMP_TAG_PROBLEM]
 |              wdith=10 height=10>
 |      <div></div>
 |    </amp-list>
 |    <!-- Invalid: src is missing. -->
 |    <amp-list width=10 height=10>
-    >>   ^~~~~~~~~
-    amp-list/0.1/test/validator-amp-list.html:54:2 The mandatory attribute 'src' is missing in tag 'amp-list'. (see https://www.ampproject.org/docs/reference/components/amp-list) [AMP_TAG_PROBLEM]
+>>   ^~~~~~~~~
+amp-list/0.1/test/validator-amp-list.html:54:2 The mandatory attribute 'src' is missing in tag 'amp-list'. (see https://www.ampproject.org/docs/reference/components/amp-list) [AMP_TAG_PROBLEM]
 |      <div></div>
 |    </amp-list>
 |    <!-- Invalid: width/height missing, so it's container layout
 |         which isn't supported. -->
 |    <amp-list src="https://data.com/articles.json?ref=CANONICAL_URL">
-    >>   ^~~~~~~~~
-    amp-list/0.1/test/validator-amp-list.html:59:2 The implied layout 'CONTAINER' is not supported by tag 'amp-list'. (see https://www.ampproject.org/docs/reference/components/amp-list) [AMP_LAYOUT_PROBLEM]
+>>   ^~~~~~~~~
+amp-list/0.1/test/validator-amp-list.html:59:2 The implied layout 'CONTAINER' is not supported by tag 'amp-list'. (see https://www.ampproject.org/docs/reference/components/amp-list) [AMP_LAYOUT_PROBLEM]
 |      <div></div>
 |    </amp-list>
 |  </body>

--- a/extensions/amp-list/0.1/test/validator-amp-list.out
+++ b/extensions/amp-list/0.1/test/validator-amp-list.out
@@ -37,7 +37,7 @@ FAIL
 |    </amp-list>
 |    <!-- Valid: amp-list with only [src] attribute -->
 |    <amp-list width=10 height=10
-|              src="https://data.com/articles.json?ref=CANONICAL_URL">
+|              [src]="foo.bar">
 |      <div></div>
 |    </amp-list>
 |    <!-- Valid: amp-list with both src and [src] attributes -->

--- a/extensions/amp-list/amp-list.md
+++ b/extensions/amp-list/amp-list.md
@@ -164,7 +164,7 @@ Learn more in [Placeholders & Fallbacks](https://www.ampproject.org/docs/guides/
 
 ### Refreshing data
 
-The `amp-list` element exposes a `refresh` action that other elements can reference in `on="tap:..."` attributes. 
+The `amp-list` element exposes a `refresh` action that other elements can reference in `on="tap:..."` attributes.
 
 ```html
 <button on="tap:myList.refresh">Refresh List</button>
@@ -185,6 +185,8 @@ within this `amp-list`. This must be a CORS HTTP service. The URL's protocol mus
 {% call callout('Important', type='caution') %}
 Your endpoint must implement the requirements specified in the [CORS Requests in AMP](https://www.ampproject.org/docs/fundamentals/amp-cors-requests) spec.
 {% endcall %}
+
+The `src` attribute may be ommitted if the `[src]` attribute exists. This is useful when rendering content as a result of a user gesture instead of on page load when working with [`amp-bind`](https://www.ampproject.org/docs/reference/components/amp-bind).
 
 ##### credentials (optional)
 

--- a/extensions/amp-list/amp-list.md
+++ b/extensions/amp-list/amp-list.md
@@ -186,7 +186,7 @@ within this `amp-list`. This must be a CORS HTTP service. The URL's protocol mus
 Your endpoint must implement the requirements specified in the [CORS Requests in AMP](https://www.ampproject.org/docs/fundamentals/amp-cors-requests) spec.
 {% endcall %}
 
-The `src` attribute may be ommitted if the `[src]` attribute exists. This is useful when rendering content as a result of a user gesture instead of on page load when working with [`amp-bind`](https://www.ampproject.org/docs/reference/components/amp-bind).
+The `src` attribute may be omitted if the `[src]` attribute exists. This is useful when rendering content as a result of a user gesture instead of on page load when working with [`amp-bind`](https://www.ampproject.org/docs/reference/components/amp-bind).
 
 ##### credentials (optional)
 

--- a/extensions/amp-list/validator-amp-list.protoascii
+++ b/extensions/amp-list/validator-amp-list.protoascii
@@ -75,7 +75,7 @@ tags: {  # <amp-list> with mandatory [src] attr
   html_format: AMP
   html_format: EXPERIMENTAL
   tag_name: "AMP-LIST"
-  spec_name: "AMP-LIST-[SRC]"
+  spec_name: "AMP-LIST [SRC]"
   requires_extension: "amp-list"
   attrs: { name: "credentials" }
   attrs: { name: "items" }

--- a/extensions/amp-list/validator-amp-list.protoascii
+++ b/extensions/amp-list/validator-amp-list.protoascii
@@ -37,7 +37,7 @@ tags: {  # amp-list
   }
   attr_lists: "common-extension-attrs"
 }
-tags: {  # <amp-list>
+tags: {  # <amp-list> with mandatory src attr
   html_format: AMP
   html_format: EXPERIMENTAL
   tag_name: "AMP-LIST"
@@ -60,7 +60,42 @@ tags: {  # <amp-list>
   attrs: { name: "template" }
   # <amp-bind>
   attrs: { name: "[src]" }
-  attrs: { name: "[state]" }
+  attrs: { name: "[state]" } # Deprecated.
+  attr_lists: "extended-amp-global"
+  amp_layout: {
+    supported_layouts: FILL
+    supported_layouts: FIXED
+    supported_layouts: FIXED_HEIGHT
+    supported_layouts: FLEX_ITEM
+    supported_layouts: NODISPLAY
+    supported_layouts: RESPONSIVE
+  }
+}
+tags: {  # <amp-list> with mandatory [src] attr
+  html_format: AMP
+  html_format: EXPERIMENTAL
+  tag_name: "AMP-LIST"
+  requires_extension: "amp-list"
+  attrs: { name: "credentials" }
+  attrs: { name: "items" }
+  attrs: { name: "max-items" }
+  attrs: { name: "single-item" }
+  attrs: {
+    name: "src"
+    value_url: {
+      allowed_protocol: "https"
+      allow_relative: true  # Will be set to false at a future date.
+    }
+    blacklisted_value_regex: "__amp_source_origin"
+  }
+  # TODO(gregable): Implement validation that requires the template attr value
+  # to reference the id of an existing template element.
+  attrs: { name: "template" }
+  # <amp-bind>
+  attrs: {
+    name: "[src]"
+    mandatory: true
+  }
   attr_lists: "extended-amp-global"
   amp_layout: {
     supported_layouts: FILL

--- a/extensions/amp-list/validator-amp-list.protoascii
+++ b/extensions/amp-list/validator-amp-list.protoascii
@@ -75,6 +75,7 @@ tags: {  # <amp-list> with mandatory [src] attr
   html_format: AMP
   html_format: EXPERIMENTAL
   tag_name: "AMP-LIST"
+  spec_name: "AMP-LIST-[SRC]"
   requires_extension: "amp-list"
   attrs: { name: "credentials" }
   attrs: { name: "items" }


### PR DESCRIPTION
Fixes #12372.

- Dupes the tag spec with `[src]` being mandatory and `src` being optional instead.

FR for a less ugly implementation: #14006