### PR TITLE
🚀 Increase Ad Priority in Stories

### DIFF
--- a/extensions/amp-ad/0.1/amp-ad-custom.js
+++ b/extensions/amp-ad/0.1/amp-ad-custom.js
@@ -57,10 +57,8 @@ export class AmpAdCustom extends AMP.BaseElement {
 
   /** @override */
   getLayoutPriority() {
-    // Loads ads after other content
-    const isPWA = !this.element.getAmpDoc().isSingleDoc();
-    // give the ad higher priority if it is inside a PWA
-    return isPWA ? 1 : 2;
+    // Since this is AMPHTML we are trusting that it will load responsibly
+    return 0;
   }
 
   /** @override **/

--- a/extensions/amp-ad/0.1/test/test-amp-ad-custom.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-custom.js
@@ -130,10 +130,10 @@ describe('Amp custom ad', () => {
         ampdoc: 'shadow',
       },
     }, env => {
-      it('should return priority of 1', () => {
+      it('should return priority of 0', () => {
         const adElement = getCustomAd(url, slot, /*body*/env.ampdoc.getBody());
         const customAd = new AmpAdCustom(adElement);
-        expect(customAd.getLayoutPriority()).to.equal(1);
+        expect(customAd.getLayoutPriority()).to.equal(0);
       });
     });
 
@@ -142,10 +142,10 @@ describe('Amp custom ad', () => {
         ampdoc: 'single',
       },
     }, env => {
-      it('should return priority of 2', () => {
+      it('should return priority of 0', () => {
         const adElement = getCustomAd(url, slot, /*body*/env.ampdoc.getBody());
         const customAd = new AmpAdCustom(adElement);
-        expect(customAd.getLayoutPriority()).to.equal(2);
+        expect(customAd.getLayoutPriority()).to.equal(0);
       });
     });
   });

--- a/extensions/amp-story/0.1/amp-story-auto-ads.js
+++ b/extensions/amp-story/0.1/amp-story-auto-ads.js
@@ -269,7 +269,7 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
     const attributes = dict({
       'id': `i-amphtml-ad-page-${id}`,
       'ad': '',
-      'distance': '1',
+      'distance': '2',
     });
 
     return createElementWithAttributes(

--- a/extensions/amp-story/0.1/amp-story-page.js
+++ b/extensions/amp-story/0.1/amp-story-page.js
@@ -461,7 +461,7 @@ export class AmpStoryPage extends AMP.BaseElement {
   setDistance(distance) {
     // TODO(ccordry) refactor this when pages are managed
     if (this.isAd()) {
-      distance = Math.min(distance, 1);
+      distance = Math.min(distance, 2);
     }
 
     this.element.setAttribute('distance', distance);


### PR DESCRIPTION
While clicking through an amp story at a moderate pace, the inserted ad would never get laid out due to queuing.

