### PR TITLE
Make a smaller param for ard, and fix order of params

### DIFF
--- a/extensions/amp-a4a/0.1/real-time-config-manager.js
+++ b/extensions/amp-a4a/0.1/real-time-config-manager.js
@@ -68,9 +68,7 @@ export const RTC_ERROR_ENUM = {
  * @private
  */
 function buildErrorResponse_(error, callout, opt_rtcTime) {
-  if (opt_log) {
-    dev().warn(TAG, `RTC callout to ${callout} caused ${error}`);
-  }
+  dev().warn(TAG, `RTC callout to ${callout} caused ${error}`);
   return Promise.resolve(/**@type {rtcResponseDef} */(
     {error, callout, rtcTime: opt_rtcTime || 0}));
 }

--- a/extensions/amp-a4a/0.1/real-time-config-manager.js
+++ b/extensions/amp-a4a/0.1/real-time-config-manager.js
@@ -64,13 +64,12 @@ export const RTC_ERROR_ENUM = {
  * @param {string} error
  * @param {string} callout
  * @param {number=} opt_rtcTime
- * @param {boolean=} opt_log
  * @return {!Promise<!rtcResponseDef>}
  * @private
  */
-function buildErrorResponse_(error, callout, opt_rtcTime, opt_log) {
+function buildErrorResponse_(error, callout, opt_rtcTime) {
   if (opt_log) {
-    dev().warn(TAG, `Dropping RTC Callout to ${callout} due to ${error}`);
+    dev().warn(TAG, `RTC callout to ${callout} caused ${error}`);
   }
   return Promise.resolve(/**@type {rtcResponseDef} */(
     {error, callout, rtcTime: opt_rtcTime || 0}));
@@ -124,7 +123,7 @@ export function maybeExecuteRealTimeConfig_(a4aElement, customMacros) {
     if (!url) {
       return promiseArray.push(
           buildErrorResponse_(
-              RTC_ERROR_ENUM.UNKNOWN_VENDOR, vendor, undefined, true));
+              RTC_ERROR_ENUM.UNKNOWN_VENDOR, vendor));
     }
     const validVendorMacros = {};
     Object.keys(rtcConfig['vendors'][vendor]).forEach(macro => {
@@ -171,15 +170,15 @@ export function inflateAndSendRtc_(a4aElement, url, seenUrls, promiseArray,
     if (Object.keys(seenUrls).length == MAX_RTC_CALLOUTS) {
       return buildErrorResponse_(
           RTC_ERROR_ENUM.MAX_CALLOUTS_EXCEEDED,
-          callout, undefined, true);
+          callout);
     }
     if (!isSecureUrl(url)) {
       return buildErrorResponse_(RTC_ERROR_ENUM.INSECURE_URL,
-          callout, undefined, true);
+          callout);
     }
     if (seenUrls[url]) {
       return buildErrorResponse_(RTC_ERROR_ENUM.DUPLICATE_URL,
-          callout, undefined, true);
+          callout);
     }
     seenUrls[url] = true;
     if (url.length > MAX_URL_LENGTH) {
@@ -200,7 +199,7 @@ export function inflateAndSendRtc_(a4aElement, url, seenUrls, promiseArray,
     return send(url);
   }).catch(unused => {
     return buildErrorResponse_(RTC_ERROR_ENUM.MACRO_EXPAND_TIMEOUT,
-        callout, undefined, true);
+        callout);
   }));
 }
 

--- a/extensions/amp-a4a/0.1/real-time-config-manager.js
+++ b/extensions/amp-a4a/0.1/real-time-config-manager.js
@@ -247,7 +247,7 @@ function sendRtcCallout_(
           }
           const response = tryParseJson(text);
           return response ? {response, rtcTime,
-                             callout: getCalloutParam(callout)} :
+            callout: getCalloutParam(callout)} :
             buildErrorResponse_(
                 RTC_ERROR_ENUM.MALFORMED_JSON_RESPONSE, callout, rtcTime);
         });

--- a/extensions/amp-a4a/0.1/test/test-real-time-config-manager.js
+++ b/extensions/amp-a4a/0.1/test/test-real-time-config-manager.js
@@ -22,11 +22,11 @@ import '../../../amp-ad/0.1/amp-ad';
 import {AmpA4A} from '../amp-a4a';
 import {
   RTC_ERROR_ENUM,
+  getCalloutParam,
   inflateAndSendRtc_,
   maybeExecuteRealTimeConfig_,
   truncUrl_,
   validateRtcConfig_,
-  getCalloutParam,
 } from '../real-time-config-manager';
 import {Services} from '../../../../src/services';
 import {Xhr} from '../../../../src/service/xhr-impl';
@@ -356,9 +356,9 @@ describes.realWin('real-time-config-manager', {amp: true}, env => {
       ];
       const expectedRtcArray = [
         {response: rtcCalloutResponses[0],
-         callout: getCalloutParam(urls[0]), rtcTime: 10},
+          callout: getCalloutParam(urls[0]), rtcTime: 10},
         {callout: getCalloutParam(urls[1]),
-         error: RTC_ERROR_ENUM.DUPLICATE_URL, rtcTime: 10},
+          error: RTC_ERROR_ENUM.DUPLICATE_URL, rtcTime: 10},
       ];
       return executeTest({
         urls, inflatedUrls: urls, rtcCalloutResponses, calloutCount,
@@ -382,11 +382,11 @@ describes.realWin('real-time-config-manager', {amp: true}, env => {
       ];
       const expectedRtcArray = [
         {response: rtcCalloutResponses[0],
-         callout: getCalloutParam(urls[0]), rtcTime: 10},
+          callout: getCalloutParam(urls[0]), rtcTime: 10},
         {response: rtcCalloutResponses[1],
-         callout: getCalloutParam(urls[1]), rtcTime: 10},
+          callout: getCalloutParam(urls[1]), rtcTime: 10},
         {callout: getCalloutParam(urls[2]),
-         error: RTC_ERROR_ENUM.INSECURE_URL, rtcTime: 10},
+          error: RTC_ERROR_ENUM.INSECURE_URL, rtcTime: 10},
       ];
       return executeTest({
         urls, inflatedUrls: urls, rtcCalloutResponses, calloutCount,

--- a/extensions/amp-a4a/0.1/test/test-real-time-config-manager.js
+++ b/extensions/amp-a4a/0.1/test/test-real-time-config-manager.js
@@ -26,6 +26,7 @@ import {
   maybeExecuteRealTimeConfig_,
   truncUrl_,
   validateRtcConfig_,
+  getCalloutParam,
 } from '../real-time-config-manager';
 import {Services} from '../../../../src/services';
 import {Xhr} from '../../../../src/service/xhr-impl';
@@ -137,7 +138,8 @@ describes.realWin('real-time-config-manager', {amp: true}, env => {
       return urls;
     }
 
-    function rtcEntry(response, callout, error) {
+    function rtcEntry(response, url, error) {
+      const callout = getCalloutParam(url);
       return response ? {response, callout, rtcTime: 10} :
         {callout, error, rtcTime: 10};
     }
@@ -168,7 +170,8 @@ describes.realWin('real-time-config-manager', {amp: true}, env => {
       const expectedRtcArray = [];
       urls.forEach((url, i) => {
         expectedRtcArray.push({
-          callout: url, rtcTime: 10, response: rtcCalloutResponses[i]});
+          callout: getCalloutParam(url), rtcTime: 10,
+          response: rtcCalloutResponses[i]});
       });
       return executeTest({
         urls, inflatedUrls: urls, rtcCalloutResponses, calloutCount,
@@ -352,8 +355,10 @@ describes.realWin('real-time-config-manager', {amp: true}, env => {
         'https://www.0.com/',
       ];
       const expectedRtcArray = [
-        {response: rtcCalloutResponses[0], callout: urls[0], rtcTime: 10},
-        {callout: urls[1], error: RTC_ERROR_ENUM.DUPLICATE_URL, rtcTime: 10},
+        {response: rtcCalloutResponses[0],
+         callout: getCalloutParam(urls[0]), rtcTime: 10},
+        {callout: getCalloutParam(urls[1]),
+         error: RTC_ERROR_ENUM.DUPLICATE_URL, rtcTime: 10},
       ];
       return executeTest({
         urls, inflatedUrls: urls, rtcCalloutResponses, calloutCount,
@@ -376,9 +381,12 @@ describes.realWin('real-time-config-manager', {amp: true}, env => {
         'https://www.2.com',
       ];
       const expectedRtcArray = [
-        {response: rtcCalloutResponses[0], callout: urls[0], rtcTime: 10},
-        {response: rtcCalloutResponses[1], callout: urls[1], rtcTime: 10},
-        {callout: urls[2], error: RTC_ERROR_ENUM.INSECURE_URL, rtcTime: 10},
+        {response: rtcCalloutResponses[0],
+         callout: getCalloutParam(urls[0]), rtcTime: 10},
+        {response: rtcCalloutResponses[1],
+         callout: getCalloutParam(urls[1]), rtcTime: 10},
+        {callout: getCalloutParam(urls[2]),
+         error: RTC_ERROR_ENUM.INSECURE_URL, rtcTime: 10},
       ];
       return executeTest({
         urls, inflatedUrls: urls, rtcCalloutResponses, calloutCount,

--- a/extensions/amp-a4a/0.1/test/test-real-time-config-manager.js
+++ b/extensions/amp-a4a/0.1/test/test-real-time-config-manager.js
@@ -22,7 +22,7 @@ import '../../../amp-ad/0.1/amp-ad';
 import {AmpA4A} from '../amp-a4a';
 import {
   RTC_ERROR_ENUM,
-  getCalloutParam,
+  getCalloutParam_,
   inflateAndSendRtc_,
   maybeExecuteRealTimeConfig_,
   truncUrl_,
@@ -91,6 +91,22 @@ describes.realWin('real-time-config-manager', {amp: true}, env => {
     });
   });
 
+  describe('#getCalloutParam_', () => {
+    it('should convert url to callout param when parseable', () => {
+      const url = 'https://www.example.com/endpoint.php?unincluded';
+      const ard = getCalloutParam_(url);
+      expect(ard).to.equal('www.example.com/endpoint.php');
+    });
+
+    it('should convert & trunc url when parseable', () => {
+      const url = 'https://www.example.com/thisIsTooMany' +
+            'Characters1234567891011121314.php';
+      const ard = getCalloutParam_(url);
+      expect(ard).to.equal(
+          'www.example.com/thisIsTooManyCharacters12345678910');
+    });
+  });
+
   describe('#maybeExecuteRealTimeConfig_', () => {
     function executeTest(args) {
       const {urls, vendors, timeoutMillis, rtcCalloutResponses,
@@ -138,8 +154,10 @@ describes.realWin('real-time-config-manager', {amp: true}, env => {
       return urls;
     }
 
-    function rtcEntry(response, url, error) {
-      const callout = getCalloutParam(url);
+    function rtcEntry(response, url, error, isVendor) {
+      // If this is an entry for a vendor, then the callout is just
+      // the vendor name passed in to url here.
+      const callout = !!isVendor ? url : getCalloutParam_(url);
       return response ? {response, callout, rtcTime: 10} :
         {callout, error, rtcTime: 10};
     }
@@ -170,7 +188,7 @@ describes.realWin('real-time-config-manager', {amp: true}, env => {
       const expectedRtcArray = [];
       urls.forEach((url, i) => {
         expectedRtcArray.push({
-          callout: getCalloutParam(url), rtcTime: 10,
+          callout: getCalloutParam_(url), rtcTime: 10,
           response: rtcCalloutResponses[i]});
       });
       return executeTest({
@@ -234,7 +252,7 @@ describes.realWin('real-time-config-manager', {amp: true}, env => {
       const calloutCount = 1;
       const expectedRtcArray = [];
       expectedRtcArray.push(rtcEntry(rtcCalloutResponses[0],
-          Object.keys(vendors)[0].toLowerCase()));
+          Object.keys(vendors)[0].toLowerCase(), undefined, true));
       return executeTest({
         vendors, customMacros, inflatedUrls, rtcCalloutResponses,
         calloutCount, expectedCalloutUrls: inflatedUrls, expectedRtcArray});
@@ -257,7 +275,7 @@ describes.realWin('real-time-config-manager', {amp: true}, env => {
       const calloutCount = 1;
       const expectedRtcArray = [];
       expectedRtcArray.push(rtcEntry(rtcCalloutResponses[0],
-          Object.keys(vendors)[0].toLowerCase()));
+          Object.keys(vendors)[0].toLowerCase(), undefined, true));
       return executeTest({
         vendors, inflatedUrls, rtcCalloutResponses,
         calloutCount, expectedCalloutUrls: inflatedUrls, expectedRtcArray});
@@ -286,7 +304,7 @@ describes.realWin('real-time-config-manager', {amp: true}, env => {
             rtcEntry(rtcCalloutResponses[i], inflatedUrls[i]));
       }
       expectedRtcArray.push(rtcEntry(rtcCalloutResponses[4],
-          Object.keys(vendors)[0].toLowerCase()));
+          Object.keys(vendors)[0].toLowerCase(), undefined, true));
       const calloutCount = 5;
       return executeTest({
         urls, vendors, customMacros, inflatedUrls, rtcCalloutResponses,
@@ -304,7 +322,7 @@ describes.realWin('real-time-config-manager', {amp: true}, env => {
       for (let i = 0; i < 1; i++) {
         expectedRtcArray.push(
             rtcEntry(rtcCalloutResponses[i],
-                Object.keys(vendors)[0].toLowerCase()));
+                Object.keys(vendors)[0].toLowerCase(), undefined, true));
       }
       const calloutCount = 1;
       return executeTest({
@@ -356,8 +374,8 @@ describes.realWin('real-time-config-manager', {amp: true}, env => {
       ];
       const expectedRtcArray = [
         {response: rtcCalloutResponses[0],
-          callout: getCalloutParam(urls[0]), rtcTime: 10},
-        {callout: getCalloutParam(urls[1]),
+          callout: getCalloutParam_(urls[0]), rtcTime: 10},
+        {callout: getCalloutParam_(urls[1]),
           error: RTC_ERROR_ENUM.DUPLICATE_URL, rtcTime: 10},
       ];
       return executeTest({
@@ -382,10 +400,10 @@ describes.realWin('real-time-config-manager', {amp: true}, env => {
       ];
       const expectedRtcArray = [
         {response: rtcCalloutResponses[0],
-          callout: getCalloutParam(urls[0]), rtcTime: 10},
+          callout: getCalloutParam_(urls[0]), rtcTime: 10},
         {response: rtcCalloutResponses[1],
-          callout: getCalloutParam(urls[1]), rtcTime: 10},
-        {callout: getCalloutParam(urls[2]),
+          callout: getCalloutParam_(urls[1]), rtcTime: 10},
+        {callout: getCalloutParam_(urls[2]),
           error: RTC_ERROR_ENUM.INSECURE_URL, rtcTime: 10},
       ];
       return executeTest({
@@ -400,7 +418,7 @@ describes.realWin('real-time-config-manager', {amp: true}, env => {
       const expectedRtcArray = [];
       expectedRtcArray.push(
           rtcEntry(null, Object.keys(vendors)[0].toLowerCase(),
-              RTC_ERROR_ENUM.UNKNOWN_VENDOR));
+              RTC_ERROR_ENUM.UNKNOWN_VENDOR, true));
       return executeTest({vendors, calloutCount, expectedRtcArray});
     });
     it('should handle bad JSON response', () => {

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -872,8 +872,8 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
           this.identityToken = results[1];
           return googleAdUrl(
               this, DOUBLECLICK_BASE_URL, startTime, Object.assign(
-                  this.getBlockParameters_(), rtcParams,
-                  this.buildIdentityParams_(), this.getPageParameters_()));
+                  this.getBlockParameters_(), this.buildIdentityParams_(),
+                  this.getPageParameters_(), rtcParams));
         });
     this.troubleshootData_.adUrl = urlPromise;
     return urlPromise;


### PR DESCRIPTION
We had been passing the entire url that we call out to, now instead we shorten it. So instead of a doubleclick request including, for example:
...&ard=https://www.example.com/endpoint.php?a=1&b=2&c=3&d=4
it would now include 
 &ard=www.example.com/endpoint.php