### PR TITLE
📖 Recommend npx rather than global installation of gulp

### DIFF
--- a/ads/README.md
+++ b/ads/README.md
@@ -250,7 +250,7 @@ If you're adding support for a new 3P ad service, changes to the following files
 
 ### Verify your examples
 
-To verify the examples that you have put in `/examples/ads.amp.html`, you will need to start a local gulp web server by running command `gulp`. Then visit `http://localhost:8000/examples/ads.amp.html?type=yournetwork` in your browser to make sure the examples load ads.
+To verify the examples that you have put in `/examples/ads.amp.html`, you will need to start a local gulp web server by running command `npx gulp`. Then visit `http://localhost:8000/examples/ads.amp.html?type=yournetwork` in your browser to make sure the examples load ads.
 
 Please consider having the example consistently load a fake ad (with ad targeting disabled). Not only it will be a more confident example for publishers to follow, but also for us to catch any regression bug during our releases.
 
@@ -263,7 +263,7 @@ Please verify your ad is fully functioning, for example, by clicking on an ad. W
 Please make sure your changes pass the tests:
 
 ```
-gulp test --watch --nobuild --files=test/functional/{test-ads-config.js,test-integration.js}
+npx gulp test --watch --nobuild --files=test/functional/{test-ads-config.js,test-integration.js}
 
 ```
 
@@ -271,7 +271,7 @@ If you have non-trivial logic in `/ads/yournetwork.js`, adding a unit test at `/
 
 ### Lint and type-check
 
-To speed up the review process, please run `gulp lint` and `gulp check-types`, then fix errors, if any, before sending out the PR.
+To speed up the review process, please run `npx gulp lint` and `npx gulp check-types`, then fix errors, if any, before sending out the PR.
 
 ### Other tips
 

--- a/contributing/DEVELOPING.md
+++ b/contributing/DEVELOPING.md
@@ -30,7 +30,7 @@ Before you start developing in AMP, check out these resources:
 
 For most developers the instructions in the [Getting Started Quick Start Guide](getting-started-quick.md) will be sufficient for building/running/testing during development.  This section provides a more detailed reference.
 
-The Quick Start Guide's  [One-time setup](getting-started-quick.md#one-time-setup) has instructions for installing Node.js, yarn, and Gulp which you'll need before running these commands.
+The Quick Start Guide's  [One-time setup](getting-started-quick.md#one-time-setup) has instructions for installing Node.js, yarn, and Gulp which you'll need before running these commands. You can prefix `gulp` with `npx` to use it without installing Gulp globally.
 
 | Command                                                                 | Description                                                           |
 | ----------------------------------------------------------------------- | --------------------------------------------------------------------- |

--- a/contributing/building-an-amp-extension.md
+++ b/contributing/building-an-amp-extension.md
@@ -747,7 +747,7 @@ For faster testing during development, consider using --files argument
 to only run your extensions' tests.
 
 ```shell
-$ gulp test --files=extensions/amp-my-element/0.1/test/test-amp-my-element.js --watch
+$ npx gulp test --files=extensions/amp-my-element/0.1/test/test-amp-my-element.js --watch
 ```
 
 ## Type checking
@@ -760,7 +760,7 @@ your code. The following command should be run to ensure no type
 violations are introduced by your extension.
 
 ```shell
-$ gulp check-types
+$ npx gulp check-types
 ```
 
 ## Example PRs

--- a/contributing/getting-started-e2e.md
+++ b/contributing/getting-started-e2e.md
@@ -184,23 +184,13 @@ amphtml uses Node.js, the Yarn package manager and the Gulp build system to buil
     127.0.0.1 ads.localhost iframe.localhost
     ```
 
-* The AMP Project uses Gulp as our build system.   Gulp uses a configuration file ([gulpfile.js](https://github.com/ampproject/amphtml/blob/master/gulpfile.js)) to build amphtml (including the amphtml javascript) and to start up the Node.js server with the proper settings.  You don't really have to understand exactly what it is doing at this point--you just have to install it and use it.
-
-   You can install Gulp using Yarn:
-
-   ```
-   yarn global add gulp-cli
-   ```
-
-   The preceding command might require elevated privileges using `sudo` on some platforms.
-
 Now whenever you're ready to build amphtml and start up your local server, simply go to your local repository directory and run:
 
 ```
-gulp
+npx gulp
 ```
 
-Running the `gulp` command will compile the code and start up a Node.js server listening on port 8000.  Once you see a message like `Finished 'default'` you can access the local server in your browser at [http://localhost:8000](http://localhost:8000)
+`npx` is a command that comes with Node.js that runs a command installed locally with `yarn`, as `gulp` is. Running the `npx gulp` command will compile the code and start up a Node.js server listening on port 8000.  Once you see a message like `Finished 'default'` you can access the local server in your browser at [http://localhost:8000](http://localhost:8000)
 
 You can browse the [http://localhost:8000/examples](http://localhost:8000/examples) directory to see some demo pages for various AMP components and combination of components.
 
@@ -212,7 +202,7 @@ Note that by default each of the pages in the /examples directory uses the unmin
 
 - [http://localhost:8000/serve_mode=compiled](http://localhost:8000/serve_mode=compiled)
 
-  Minified AMP JavaScript is served from the local server. This is only available after running `gulp dist --fortesting`.
+  Minified AMP JavaScript is served from the local server. This is only available after running `npx gulp dist --fortesting`.
 
 - [http://localhost:8000/serve_mode=cdn](http://localhost:8000/serve_mode=cdn)
 
@@ -348,12 +338,12 @@ Before sending your code changes for review, you will want to make sure that all
 Make sure you are in the branch that has your changes (`git checkout <branch name>`), pull in the latest changes from the remote amphtml repository and then simply run:
 
 ```
-gulp test
+npx gulp test
 ```
 
-You'll see some messages about stuff being compiled and then after a short time you will see a new Chrome window open up that says "Karma" at the top.  In the window where you ran `gulp test`, you'll see a bunch of tests scrolling by (`Executed NNNN of MMMM`) and hopefully a lot of `SUCCESS` messages.
+You'll see some messages about stuff being compiled and then after a short time you will see a new Chrome window open up that says "Karma" at the top.  In the window where you ran `npx gulp test`, you'll see a bunch of tests scrolling by (`Executed NNNN of MMMM`) and hopefully a lot of `SUCCESS` messages.
 
-By default `gulp test` runs tests on Chrome.  Depending on what your tests affect (e.g. if you're fixing a bug in a different browser), you may need to run `gulp test --firefox` or `gulp test --safari` to run in other browsers.
+By default `gulp test` runs tests on Chrome.  Depending on what your tests affect (e.g. if you're fixing a bug in a different browser), you may need to run `npx gulp test --firefox` or `npx gulp test --safari` to run in other browsers.
 
 If the tests have failed you will need to determine whether the failure is related to your change.
 
@@ -366,26 +356,26 @@ Fixing the tests will depend heavily on the change you are making and what tests
 Sometimes, it can be useful to pre-emptively eliminate errors in your pull request by running all the Travis CI checks on your local machine. You can do so by running:
 
 ```
-gulp pr-check
+npx gulp pr-check
 ```
 
 To run all Travis CI checks, but skip the `gulp build` step, you can run:
 
 ```
-gulp pr-check --nobuild
+npx gulp pr-check --nobuild
 ```
 
 To run all Travis CI checks, and restrict the unit tests and integration tests to just a subset of files, you can run:
 
 ```
-gulp pr-check --files=<test-files-path-glob>
+npx gulp pr-check --files=<test-files-path-glob>
 ```
 
 Notes:
 
 * This will force a clean build and run all the PR checks one by one.
 * Just like on Travis, a failing check will prevent subsequent checks from being run.
-* The `gulp visual-diff` check will be skipped unless you have set up a Percy account as described [here](https://github.com/ampproject/amphtml/blob/master/contributing/DEVELOPING.md#running-visual-diff-tests-locally).
+* The `npx gulp visual-diff` check will be skipped unless you have set up a Percy account as described [here](https://github.com/ampproject/amphtml/blob/master/contributing/DEVELOPING.md#running-visual-diff-tests-locally).
 * The AMP unit and integration tests will be run on local Chrome unless you have set up a Sauce Labs account as described [here](https://github.com/ampproject/amphtml/blob/master/contributing/DEVELOPING.md#testing-on-sauce-labs).
 
 ## Adding tests for your change
@@ -394,15 +384,15 @@ If your change was not already covered by existing tests, you will generally be 
 
 The amphtml unit tests use the [Mocha](https://mochajs.org/) framework, the [Chai](http://chaijs.com/) assertion library and the [Sinon](http://sinonjs.org/) mocking library.  The specifics of the tests you will need to add will vary depending on the issue/feature you are working on.  If you are fixing a bug in an existing component there should already be tests in the test directory for that component that you can look at for guidance.  For example the [amp-video](https://github.com/ampproject/amphtml/blob/master/extensions/amp-video/amp-video.md) component has [tests](https://github.com/ampproject/amphtml/blob/master/extensions/amp-video/0.1/test/test-amp-video.js).
 
-You can run the tests in a single file by running `gulp test --files=<file to test>`, e.g. for amp-video:
+You can run the tests in a single file by running `npx gulp test --files=<file to test>`, e.g. for amp-video:
 
 ```
-gulp test --files=extensions/amp-youtube/0.1/test/test-amp-youtube.js
+npx gulp test --files=extensions/amp-youtube/0.1/test/test-amp-youtube.js
 ```
 
-Alternatively you can take advantage of a Mocha feature that allows for running only certain tests--`describe.only`.  Simply replace the `describe` in the Mocha tests you want to run with `describe.only` and only those tests will be run when you run `gulp test`.  Make sure to remove the `.only` and run all tests before sending your code for review.
+Alternatively you can take advantage of a Mocha feature that allows for running only certain tests--`describe.only`.  Simply replace the `describe` in the Mocha tests you want to run with `describe.only` and only those tests will be run when you run `npx gulp test`.  Make sure to remove the `.only` and run all tests before sending your code for review.
 
-To make running the tests more convenient you can also use the `--watch` flag in any `gulp test` command.  This will cause the tests you've indicated to automatically be rerun whenever a file is modified.
+To make running the tests more convenient you can also use the `--watch` flag in any `npx gulp test` command.  This will cause the tests you've indicated to automatically be rerun whenever a file is modified.
 
 If you are not sure how to create these tests you can ask on the GitHub issue you're working on or reach out to the community as described in [How to get help](#how-to-get-help).
 

--- a/contributing/getting-started-e2e.md
+++ b/contributing/getting-started-e2e.md
@@ -189,7 +189,7 @@ amphtml uses Node.js, the Yarn package manager and the Gulp build system to buil
    You can install Gulp using Yarn:
 
    ```
-   yarn global add gulp
+   yarn global add gulp-cli
    ```
 
    The preceding command might require elevated privileges using `sudo` on some platforms.

--- a/contributing/getting-started-quick.md
+++ b/contributing/getting-started-quick.md
@@ -29,8 +29,6 @@ This Quick Start guide is the TL;DR version of the longer [end-to-end guide](get
 
 * Install [Yarn](https://yarnpkg.com/) version >= 1.2.0 (instructions [here](https://yarnpkg.com/en/docs/install), this may require elevated privileges using `sudo` on some platforms)
 
-* Install Gulp by running `yarn global add gulp-cli` (this may require elevated privileges using `sudo` on some platforms)
-
 * Add this line to your hosts file (`/etc/hosts` on Mac or Linux, `%SystemRoot%\System32\drivers\etc\hosts` on Windows):
 
     ```
@@ -49,19 +47,19 @@ This Quick Start guide is the TL;DR version of the longer [end-to-end guide](get
 # Build AMP & run a local server
 
 * Make sure you have the latest packages (after you pull): `yarn`
-* Start the server: `gulp`
+* Start the server: `npx gulp`
 * Access your server at [http://localhost:8000](http://localhost:8000)
 * Access your sample pages at [http://localhost:8000/examples](http://localhost:8000/examples)
 
 # Test AMP
 
-* Run all tests: `gulp test`
-* Run only the unit tests: `gulp test --unit` (doesn't build the runtime)
-* Run only the integration tests: `gulp test --integration` (builds the runtime)
-* Run tests, but skip building after having done so previously: `gulp test --nobuild`
-* Run the tests in a specified set of files: `gulp test --files=<filename>`
-* Add the `--watch` flag to any `gulp test` command to automatically re-run the tests when a file changes
-* To run only a certain set of Mocha tests change  `describe` to `describe.only` for the tests you want to run; combine this with `gulp test --watch` to automatically rerun your test when files are changed   (but make sure to run all the tests before sending your change for review)
+* Run all tests: `npx gulp test`
+* Run only the unit tests: `npx gulp test --unit` (doesn't build the runtime)
+* Run only the integration tests: `npx gulp test --integration` (builds the runtime)
+* Run tests, but skip building after having done so previously: `npx gulp test --nobuild`
+* Run the tests in a specified set of files: `npx gulp test --files=<filename>`
+* Add the `--watch` flag to any `npx gulp test` command to automatically re-run the tests when a file changes
+* To run only a certain set of Mocha tests change  `describe` to `describe.only` for the tests you want to run; combine this with `npx gulp test --watch` to automatically rerun your test when files are changed   (but make sure to run all the tests before sending your change for review)
 
 # Create commits to contain your changes
 

--- a/contributing/getting-started-quick.md
+++ b/contributing/getting-started-quick.md
@@ -29,7 +29,7 @@ This Quick Start guide is the TL;DR version of the longer [end-to-end guide](get
 
 * Install [Yarn](https://yarnpkg.com/) version >= 1.2.0 (instructions [here](https://yarnpkg.com/en/docs/install), this may require elevated privileges using `sudo` on some platforms)
 
-* Install Gulp by running `yarn global add gulp` (this may require elevated privileges using `sudo` on some platforms)
+* Install Gulp by running `yarn global add gulp-cli` (this may require elevated privileges using `sudo` on some platforms)
 
 * Add this line to your hosts file (`/etc/hosts` on Mac or Linux, `%SystemRoot%\System32\drivers\etc\hosts` on Windows):
 

--- a/contributing/good-first-issues-template.md
+++ b/contributing/good-first-issues-template.md
@@ -40,7 +40,7 @@ Step-by-step instructions for the contributor to follow as they work through the
 - [ ] [Create a Git branch](https://github.com/ampproject/amphtml/blob/master/contributing/getting-started-e2e.md#create-a-git-branch) for making your changes.
 - [ ] [Sign the Contributor License Agreement](https://github.com/ampproject/amphtml/blob/master/CONTRIBUTING.md#contributor-license-agreement) before creating a Pull Request.  (If you are contributing code on behalf of a corporation start this process as early as possible.)
 <!--
-Add steps that are specific to the issue here, e.g. perhaps they should edit a test, run gulp test to see it fails, change a file and then run gulp test again to see that the new test succeeds?  Adjust the level of detail for the background you indicated the contributor should have.
+Add steps that are specific to the issue here, e.g. perhaps they should edit a test, run npx gulp test to see it fails, change a file and then run npx gulp test again to see that the new test succeeds?  Adjust the level of detail for the background you indicated the contributor should have.
 -->
 - [ ] [Commit your changes](https://github.com/ampproject/amphtml/blob/master/contributing/getting-started-e2e.md#edit-files-and-commit-them) frequently.
 - [ ] [Push your changes to GitHub](https://github.com/ampproject/amphtml/blob/master/contributing/getting-started-e2e.md#push-your-changes-to-your-github-fork).


### PR DESCRIPTION
Developers have occasionally run into trouble with version conflicts with a globally installed `gulp`. This can be avoided with the `npx` command in Node, which runs a locally installed command.