### PR TITLE
🏗 Update minimum versions of node and yarn in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "description": "Fastish HTML",
   "main": "index.js",
   "engines": {
-    "node": ">=6",
-    "yarn": ">=1.0.2"
+    "node": ">=8.10.0",
+    "yarn": ">=1.2.0"
   },
   "author": "The AMP HTML Authors",
   "license": "Apache-2.0",


### PR DESCRIPTION
AMP development requires the latest `lts` version of `node` and version 1.2.0 of `yarn`. This PR updates the `engines` section of `package.json` to reflect the new version numbers for `node` and `yarn`.

Unfortunately, there's no way to specify `lts` in `package.json`, so the file will have to be periodically updated. See https://github.com/npm/npm/issues/11113.