### PR TITLE
🏗 Replace JWT sauce token with a temporary per-run token

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,9 @@ before_script:
   - chromedriver -v
   - ./node_modules/.bin/greenkeeper-lockfile-update
 script: node build-system/pr-check.js
-after_script: ./node_modules/.bin/greenkeeper-lockfile-upload
+after_script:
+  - ./node_modules/.bin/greenkeeper-lockfile-upload
+  - build-system/stop_sauce_connect.sh
 branches:
   only:
     - master
@@ -31,11 +33,9 @@ branches:
 env:
   global:
     - SAUCE_USERNAME="amphtml-travis-sauce"
-    - SAUCE_ACCESS_KEY="`curl --silent https://amphtml-sauce-token-dealer.appspot.com/getToken`"
     - NPM_CONFIG_PROGRESS="false"
 addons:
   chrome: stable
-  sauce_connect: true
   hosts:
     - ads.localhost
     - iframe.localhost

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,15 +30,12 @@ branches:
     - /^greenkeeper/.*$/
 env:
   global:
-    - SAUCE_USERNAME="amphtml"
+    - SAUCE_USERNAME="amphtml-travis-sauce"
+    - SAUCE_ACCESS_KEY="`curl --silent https://amphtml-sauce-token-dealer.appspot.com/getToken`"
     - NPM_CONFIG_PROGRESS="false"
 addons:
   chrome: stable
-  sauce_connect:
-    username: "amphtml"
-  jwt:
-    # SAUCE_ACCESS_KEY for sauce_connect
-    - secure: "Wze0F0vGL0UcxryOx1n/vcuD5LIMGyR+69Nc6IWLoRvZBbbIpFwVFhDE6rE9ranIXiA2Hc684N4sV8ASfNDF8RRSB+jyLov159qwgji2rBxIfQ/4kuDV2vYoAJvYMz8m42kwx5FV2VV9awqMMt8mwU3wYIrKIaVCxB34uV86KIlDlbrHxt17Bm5EIiUmwi9r1AAnW/63vVRUN264D77oB4j9UQ759PfD6BDwEt54O87KurNIaLseNCr1IvzfL8veEsZ3uTbLC1GtgHfR4IGgkS2YyN2QIk06VZWeRDEOalS3RcY0nDkbCmBywxIGObnrpEMzOpjBiOb2fxLoLvvpjlla5W84zJGfWE6q4T9IvkyHuDJE+sft5B+arjMIeA6PIeUhKdV27+6qqDEf7fILZ/U/Ekn9ds4zSV8hekAZPUyyPncOeyWppCIJ8sOeCrsebkRjH1BoX/d+FE+nP0bN/XkBpIi/nManx5FyS/kqjQWGKmvsFQfEWlSUaZi7XtEQEjvBizRkzvpJanSDaoiTDS2Keulmwii3XRId51FuGtnfDZFeggLaMTKGfBX9DlPkccwYAZe6vPNfYk1pNgEj6AtnifEhYVEO+aAuWhEnJ86od+1wDOL/h+a2XY6h8/gFBywsD95p7sXPfdVDCKgwagiBo+Hw5MNjztVF7lszg1A="
+  sauce_connect: true
   hosts:
     - ads.localhost
     - iframe.localhost

--- a/build-system/start_sauce_connect.sh
+++ b/build-system/start_sauce_connect.sh
@@ -30,35 +30,35 @@ START_MESSAGE="Sauce Connect is up, you may start your tests."
 LOG_PREFIX=$(YELLOW "start_sauce_connect.sh")
 
 # Download and unpack sauce connect proxy binary.
-echo $LOG_PREFIX "Downloading" $(CYAN $DOWNLOAD_URL)
-wget -q $DOWNLOAD_URL
-echo $LOG_PREFIX "Unpacking" $(CYAN $TAR_FILE)
-tar -xzf $TAR_FILE
+echo "$LOG_PREFIX Downloading $(CYAN "$DOWNLOAD_URL")"
+wget -q "$DOWNLOAD_URL"
+echo "$LOG_PREFIX Unpacking $(CYAN "$TAR_FILE")"
+tar -xzf "$TAR_FILE"
 
 # Clean up old log files, if any.
-if [ -f $LOG_FILE ]; then
-  echo $LOG_PREFIX "Deleting old log file" $(CYAN $LOG_FILE)
-  rm $LOG_FILE
+if [[ -f "$LOG_FILE" ]]; then
+  echo "$LOG_PREFIX Deleting old log file $(CYAN "$LOG_FILE")"
+  rm "$LOG_FILE"
 fi
-if [ -f $PID_FILE ]; then
-  echo $LOG_PREFIX "Deleting old pid file" $(CYAN $PID_FILE)
-  rm $PID_FILE
+if [[ -f $PID_FILE ]]; then
+  echo "$LOG_PREFIX Deleting old pid file $(CYAN "$PID_FILE")"
+  rm "$PID_FILE"
 fi
 
 # Establish the tunnel identifier (job number on Travis / username during local dev).
-if [ -z $TRAVIS_JOB_NUMBER ]; then
-  TUNNEL_IDENTIFIER=$(git log -1 --pretty=format:"%ae")
+if [[ -z "$TRAVIS_JOB_NUMBER" ]]; then
+  TUNNEL_IDENTIFIER="$(git log -1 --pretty=format:"%ae")"
 else
-  TUNNEL_IDENTIFIER=$TRAVIS_JOB_NUMBER
+  TUNNEL_IDENTIFIER="$TRAVIS_JOB_NUMBER"
 fi
 
 # Launch proxy and wait for completion.
-echo $LOG_PREFIX "Launching" $(CYAN $BINARY_FILE)
-$BINARY_FILE --tunnel-identifier $TUNNEL_IDENTIFIER --pidfile $PID_FILE 1>$LOG_FILE 2>&1 &
+echo "$LOG_PREFIX Launching $(CYAN "$BINARY_FILE")"
+"$BINARY_FILE" --tunnel-identifier "$TUNNEL_IDENTIFIER" --pidfile "$PID_FILE" 1>"$LOG_FILE" 2>&1 &
 sleep 2
-( tail -f -n0 $LOG_FILE & ) | grep -q "$START_MESSAGE"
+( tail -f -n0 "$LOG_FILE" & ) | grep -q "$START_MESSAGE"
 
 # Print confirmation.
-PID=$(cat $PID_FILE)
-TUNNEL_ID=$(grep -oP "Tunnel ID: \K.*$" $LOG_FILE)
-echo $LOG_PREFIX "Sauce Connect Proxy with tunnel ID" $(CYAN $TUNNEL_ID) "and identifier" $(CYAN $TUNNEL_IDENTIFIER) "is now running as pid" $(CYAN $PID)
+PID="$(cat "$PID_FILE")"
+TUNNEL_ID="$(grep -oP "Tunnel ID: \K.*$" "$LOG_FILE")"
+echo "$LOG_PREFIX Sauce Connect Proxy with tunnel ID $(CYAN "$TUNNEL_ID") and identifier $(CYAN "$TUNNEL_IDENTIFIER") is now running as pid $(CYAN "$PID")"

--- a/build-system/start_sauce_connect.sh
+++ b/build-system/start_sauce_connect.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+#
+# Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the license.
+#
+# This script starts the sauce connect proxy, and waits for a successful
+# connection.
+
+CYAN() { echo -e "\033[0;36m$1\033[0m"; }
+YELLOW() { echo -e "\033[1;33m$1\033[0m"; }
+
+DOWNLOAD_URL="https://saucelabs.com/downloads/sc-4.4.12-linux.tar.gz"
+TAR_FILE="sc-4.4.12-linux.tar.gz"
+BINARY_FILE="sc-4.4.12-linux/bin/sc"
+PID_FILE="sauce_connect_pid"
+LOG_FILE="sauce_connect_log"
+START_MESSAGE="Sauce Connect is up, you may start your tests."
+LOG_PREFIX=$(YELLOW "start_sauce_connect.sh")
+
+# Download and unpack sauce connect proxy binary.
+echo $LOG_PREFIX "Downloading" $(CYAN $DOWNLOAD_URL)
+eval "wget -q $DOWNLOAD_URL"
+echo $LOG_PREFIX "Unpacking" $(CYAN $TAR_FILE)
+eval "tar -xzf $TAR_FILE"
+
+# Clean up old log files, if any.
+if [ -f $LOG_FILE ]; then
+  echo $LOG_PREFIX "Deleting old log file" $(CYAN $LOG_FILE)
+  eval "rm $LOG_FILE"
+fi
+if [ -f $PID_FILE ]; then
+  echo $LOG_PREFIX "Deleting old pid file" $(CYAN $PID_FILE)
+  eval "rm $PID_FILE"
+fi
+
+# Establish the tunnel identifier (job number on Travis / username during local dev).
+if [ -z ${TRAVIS_JOB_NUMBER} ]; then
+  TUNNEL_IDENTIFIER=`git log -1 --pretty=format:"%ae"`
+else
+  TUNNEL_IDENTIFIER=$TRAVIS_JOB_NUMBER
+fi
+
+# Launch proxy and wait for completion.
+echo $LOG_PREFIX "Launching" $(CYAN $BINARY_FILE)
+eval "$BINARY_FILE --tunnel-identifier $TUNNEL_IDENTIFIER --pidfile $PID_FILE 1>$LOG_FILE 2>&1 &"
+sleep 2
+( tail -f -n0 $LOG_FILE & ) | grep -q "$START_MESSAGE"
+
+# Print confirmation.
+PID=`cat $PID_FILE`
+TUNNEL_ID=`grep -oP "Tunnel ID: \K.*$" $LOG_FILE`
+echo $LOG_PREFIX "Sauce Connect Proxy with tunnel ID" $(CYAN $TUNNEL_ID) "and identifier" $(CYAN $TUNNEL_IDENTIFIER) "is now running as pid" $(CYAN $PID)

--- a/build-system/start_sauce_connect.sh
+++ b/build-system/start_sauce_connect.sh
@@ -20,9 +20,10 @@
 CYAN() { echo -e "\033[0;36m$1\033[0m"; }
 YELLOW() { echo -e "\033[1;33m$1\033[0m"; }
 
-DOWNLOAD_URL="https://saucelabs.com/downloads/sc-4.4.12-linux.tar.gz"
-TAR_FILE="sc-4.4.12-linux.tar.gz"
-BINARY_FILE="sc-4.4.12-linux/bin/sc"
+SC_VERSION="sc-4.4.12-linux"
+DOWNLOAD_URL="https://saucelabs.com/downloads/$SC_VERSION.tar.gz"
+TAR_FILE="$SC_VERSION.tar.gz"
+BINARY_FILE="$SC_VERSION/bin/sc"
 PID_FILE="sauce_connect_pid"
 LOG_FILE="sauce_connect_log"
 START_MESSAGE="Sauce Connect is up, you may start your tests."
@@ -30,34 +31,34 @@ LOG_PREFIX=$(YELLOW "start_sauce_connect.sh")
 
 # Download and unpack sauce connect proxy binary.
 echo $LOG_PREFIX "Downloading" $(CYAN $DOWNLOAD_URL)
-eval "wget -q $DOWNLOAD_URL"
+wget -q $DOWNLOAD_URL
 echo $LOG_PREFIX "Unpacking" $(CYAN $TAR_FILE)
-eval "tar -xzf $TAR_FILE"
+tar -xzf $TAR_FILE
 
 # Clean up old log files, if any.
 if [ -f $LOG_FILE ]; then
   echo $LOG_PREFIX "Deleting old log file" $(CYAN $LOG_FILE)
-  eval "rm $LOG_FILE"
+  rm $LOG_FILE
 fi
 if [ -f $PID_FILE ]; then
   echo $LOG_PREFIX "Deleting old pid file" $(CYAN $PID_FILE)
-  eval "rm $PID_FILE"
+  rm $PID_FILE
 fi
 
 # Establish the tunnel identifier (job number on Travis / username during local dev).
-if [ -z ${TRAVIS_JOB_NUMBER} ]; then
-  TUNNEL_IDENTIFIER=`git log -1 --pretty=format:"%ae"`
+if [ -z $TRAVIS_JOB_NUMBER ]; then
+  TUNNEL_IDENTIFIER=$(git log -1 --pretty=format:"%ae")
 else
   TUNNEL_IDENTIFIER=$TRAVIS_JOB_NUMBER
 fi
 
 # Launch proxy and wait for completion.
 echo $LOG_PREFIX "Launching" $(CYAN $BINARY_FILE)
-eval "$BINARY_FILE --tunnel-identifier $TUNNEL_IDENTIFIER --pidfile $PID_FILE 1>$LOG_FILE 2>&1 &"
+$BINARY_FILE --tunnel-identifier $TUNNEL_IDENTIFIER --pidfile $PID_FILE 1>$LOG_FILE 2>&1 &
 sleep 2
 ( tail -f -n0 $LOG_FILE & ) | grep -q "$START_MESSAGE"
 
 # Print confirmation.
-PID=`cat $PID_FILE`
-TUNNEL_ID=`grep -oP "Tunnel ID: \K.*$" $LOG_FILE`
+PID=$(cat $PID_FILE)
+TUNNEL_ID=$(grep -oP "Tunnel ID: \K.*$" $LOG_FILE)
 echo $LOG_PREFIX "Sauce Connect Proxy with tunnel ID" $(CYAN $TUNNEL_ID) "and identifier" $(CYAN $TUNNEL_IDENTIFIER) "is now running as pid" $(CYAN $PID)

--- a/build-system/stop_sauce_connect.sh
+++ b/build-system/stop_sauce_connect.sh
@@ -25,26 +25,26 @@ STOP_MESSAGE="Goodbye."
 LOG_PREFIX=$(YELLOW "stop_sauce_connect.sh")
 
 # Early exit if there's no proxy running.
-if [ ! -f $PID_FILE ]; then
-  echo $LOG_PREFIX "Sauce Connect Proxy is not running"
+if [[ ! -f "$PID_FILE" ]]; then
+  echo "$LOG_PREFIX Sauce Connect Proxy is not running"
   exit 0
 fi
 
 # Wait for clean exit.
-PID=$(cat $PID_FILE)
-echo $LOG_PREFIX "Stopping Sauce Connect Proxy pid" $(CYAN $PID)
-kill $PID
-( tail -f -n0 $LOG_FILE & ) | grep -q "$STOP_MESSAGE"
+PID="$(cat "$PID_FILE")"
+echo "$LOG_PREFIX Stopping Sauce Connect Proxy pid $(CYAN "$PID")"
+kill "$PID"
+( tail -f -n0 "$LOG_FILE" & ) | grep -q "$STOP_MESSAGE"
 
 # Clean up files.
-if [ -f $LOG_FILE ]; then
-  echo $LOG_PREFIX "Cleaning up log file" $(CYAN $LOG_FILE)
-  rm $LOG_FILE
+if [[ -f "$LOG_FILE" ]]; then
+  echo "$LOG_PREFIX Cleaning up log file $(CYAN "$LOG_FILE")"
+  rm "$LOG_FILE"
 fi
-if [ -f $PID_FILE ]; then
-  echo $LOG_PREFIX "Cleaning up pid file" $(CYAN $PID_FILE)
-  rm $PID_FILE
+if [[ -f "$PID_FILE" ]]; then
+  echo "$LOG_PREFIX Cleaning up pid file $(CYAN "$PID_FILE")"
+  rm "$PID_FILE"
 fi
 
 # Done.
-echo $LOG_PREFIX "Successfully stopped Sauce Connect Proxy"
+echo "$LOG_PREFIX Successfully stopped Sauce Connect Proxy"

--- a/build-system/stop_sauce_connect.sh
+++ b/build-system/stop_sauce_connect.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+#
+# Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the license.
+#
+# This script stops the sauce connect proxy, and waits for a clean exit.
+
+CYAN() { echo -e "\033[0;36m$1\033[0m"; }
+YELLOW() { echo -e "\033[1;33m$1\033[0m"; }
+
+PID_FILE="sauce_connect_pid"
+LOG_FILE="sauce_connect_log"
+STOP_MESSAGE="Goodbye."
+LOG_PREFIX=$(YELLOW "stop_sauce_connect.sh")
+
+# Early exit if there's no proxy running.
+if [ ! -f $PID_FILE ]; then
+  echo $LOG_PREFIX "Sauce Connect Proxy is not running"
+  exit 0
+fi
+
+# Wait for clean exit.
+PID=`cat $PID_FILE`
+echo $LOG_PREFIX "Stopping Sauce Connect Proxy pid" $(CYAN $PID)
+kill $PID
+( tail -f -n0 $LOG_FILE & ) | grep -q "$STOP_MESSAGE"
+
+# Clean up files.
+if [ -f $LOG_FILE ]; then
+  echo $LOG_PREFIX "Cleaning up log file" $(CYAN $LOG_FILE)
+  eval "rm $LOG_FILE"
+fi
+if [ -f $PID_FILE ]; then
+  echo $LOG_PREFIX "Cleaning up pid file" $(CYAN $PID_FILE)
+  eval "rm $PID_FILE"
+fi
+
+# Done.
+echo $LOG_PREFIX "Successfully stopped Sauce Connect Proxy"

--- a/build-system/stop_sauce_connect.sh
+++ b/build-system/stop_sauce_connect.sh
@@ -31,7 +31,7 @@ if [ ! -f $PID_FILE ]; then
 fi
 
 # Wait for clean exit.
-PID=`cat $PID_FILE`
+PID=$(cat $PID_FILE)
 echo $LOG_PREFIX "Stopping Sauce Connect Proxy pid" $(CYAN $PID)
 kill $PID
 ( tail -f -n0 $LOG_FILE & ) | grep -q "$STOP_MESSAGE"
@@ -39,11 +39,11 @@ kill $PID
 # Clean up files.
 if [ -f $LOG_FILE ]; then
   echo $LOG_PREFIX "Cleaning up log file" $(CYAN $LOG_FILE)
-  eval "rm $LOG_FILE"
+  rm $LOG_FILE
 fi
 if [ -f $PID_FILE ]; then
   echo $LOG_PREFIX "Cleaning up pid file" $(CYAN $PID_FILE)
-  eval "rm $PID_FILE"
+  rm $PID_FILE
 fi
 
 # Done.


### PR DESCRIPTION
Since Travis has dropped native support for the use of `sauce_connect` and `jwt` during PR builds, we must manually run the Sauce Connect Proxy prior to tests that use Sauce Labs.

This PR adds two scripts `build-system/start_sauce_connect.sh` and `build-system/stop_sauce_connect.sh` which start and stop the Sauce Connect Proxy before and after running tests.

Fixes #13047