### PR TITLE
Fix how safeframe measures after expand

### DIFF
--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -1046,7 +1046,7 @@ export class AmpA4A extends AMP.BaseElement {
     // unlayoutCallback so that it is reverted to original size in case
     // of resumeCallback.
     this.originalSlotSize_ = this.originalSlotSize_ || this.getLayoutBox();
-    return super.attemptChangeSize(newHeight, newWidth);
+    return super.attemptChangeSize(newHeight, newWidth).catch(() => {});
   }
 
   /** @override  */

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -1046,7 +1046,7 @@ export class AmpA4A extends AMP.BaseElement {
     // unlayoutCallback so that it is reverted to original size in case
     // of resumeCallback.
     this.originalSlotSize_ = this.originalSlotSize_ || this.getLayoutBox();
-    return super.attemptChangeSize(newHeight, newWidth).catch(() => {});
+    return super.attemptChangeSize(newHeight, newWidth);
   }
 
   /** @override  */

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -228,7 +228,7 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
       return this.attemptChangeSize(
           AmpAdNetworkAdsenseImpl.getResponsiveHeightForContext_(
               viewportSize),
-          viewportSize.width);
+          viewportSize.width).catch(() => {});
     }
   }
 

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
@@ -579,28 +579,18 @@ export class SafeframeHostApi {
       if (success || optIsCollapse) {
         this.resizeIframe(height, width);
         this.isCollapsed_ = !!optIsCollapse;
-        this.baseInstance_.element.getResources().resources_.forEach(
-            resource => {
-              if (resource.element == this.baseInstance_.element) {
-                // Need to force a measure event, as measure won't happen immediately
-                // if the element was above the viewport when resize occured, and
-                // without a measure, we'll send the wrong size for the creative
-                // on the geometry update message.
-                resource.measure();
-              }
-            });
+        this.baseInstance_.getResource().measure();
       } else {
         // attemptChangeSize automatically registers a pendingChangeSize if
         // the initial attempt failed. We do not want to do that, so clear it.
-        this.baseInstance_.element.getResources().resources_.forEach(
-            resource => {
-              if (resource.element == this.baseInstance_.element) {
-                resource.pendingChangeSize_ = undefined;
-              }
-            });
+        this.baseInstance_.getResource().resetPendingChangeSize();
       }
-      this.sendResizeResponse(success || !!optIsCollapse, messageType);
-    }).catch(() => {});
+      this.sendResizeResponse(success || !!optIsCollapse,
+          messageType, height, width);
+    }).catch(() => {
+      // If there are errors, try sending a failure message.
+      this.sendResizeResponse(false, messageType, height, width);
+    });
   }
 
   /**

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
@@ -153,7 +153,7 @@ export class SafeframeHostApi {
     this.isFluid_ = isFluid;
 
     /** @private {?({width: number, height: number}|../../../src/layout-rect.LayoutRectDef)} */
-    this.ampAdSize_ = initialSize;
+    this.slotSize_ = initialSize;
 
     /** @private {?({width, height}|../../../src/layout-rect.LayoutRectDef)} */
     this.creativeSize_ = creativeSize;
@@ -539,8 +539,8 @@ export class SafeframeHostApi {
    */
   handleSizeChange(height, width, messageType, optIsCollapse) {
     if (!optIsCollapse &&
-        width <= this.ampAdSize_.width &&
-        height <= this.ampAdSize_.height) {
+        width <= this.slotSize_.width &&
+        height <= this.slotSize_.height) {
       this.resizeSafeframe(height, width, !!optIsCollapse, messageType);
     } else {
       this.resizeAmpAdAndSafeframe(
@@ -590,8 +590,8 @@ export class SafeframeHostApi {
       // Update our stored record of what the amp-ad's size is. This
       // is just for caching. Setting it here doesn't actually change
       // the size of the amp-ad, the attempt change size above did that.
-      this.ampAdSize_.height = height;
-      this.ampAdSize_.width = width;
+      this.slotSize_.height = height;
+      this.slotSize_.width = width;
     }, /** REJECT CALLBACK */ () => {
       // If the resize initially failed, it may have been queued
       // as a pendingChangeSize, which will cause the size change

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
@@ -503,23 +503,21 @@ export class SafeframeHostApi {
    */
   resizeSafeframe(height, width, isCollapsed, messageType) {
     this.isCollapsed_ = isCollapsed;
-    this.baseInstance_.mutateElement(() => {
-      if (this.iframe_) {
-        setStyles(this.iframe_, {
-          'height': height + 'px',
-          'width': width + 'px',
-        });
-      }
-      this.sendResizeResponse(/** SUCCESS */ true, messageType);
-    }, this.iframe_);
-    // We need to force a measure right now, as without remeasuring, we
-    // will have the wrong size information for the amp-ad and the
-    // safeframe when we send the response message into the safeframe.
-    // This would be an issue specifically for when expand is successful
-    // while amp-ad is out of the viewport, for example.
-    this.baseInstance_.measureElement(() => {
-      this.baseInstance_.getResource().measure();
-    });
+    this.baseInstance_.measureMutateElement(
+        /** MEASURER */ () => {
+          this.baseInstance_.getResource().measure();
+        },
+        /** MUTATOR */ () => {
+          if (this.iframe_) {
+            setStyles(this.iframe_, {
+              'height': height + 'px',
+              'width': width + 'px',
+            });
+          }
+          this.sendResizeResponse(/** SUCCESS */ true, messageType);
+        },
+        this.iframe_
+    );
   }
 
   /**

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
@@ -571,28 +571,27 @@ export class SafeframeHostApi {
    * @param {boolean=} optIsCollapse
    */
   resizeAmpAdAndSafeframe(height, width, messageType, optIsCollapse) {
-    const resizeAndMeasure = () => {
-      this.resizeIframe(height, width);
-      this.isCollapsed_ = !!optIsCollapse;
-      // We need to force a measure right now, as without remeasuring, we
-      // will have the wrong size information for the amp-ad and the
-      // safeframe when we send the response message into the safeframe.
-      // This would be an issue specifically for when expand is successful
-      // while amp-ad is out of the viewport, for example.
-      this.baseInstance_.measureElement(() => {
-        this.baseInstance_.getResource().measure();
-      });
-      this.sendResizeResponse(true, messageType);
-    };
     this.baseInstance_.attemptChangeSize(height, width).then(() => {
-      resizeAndMeasure();
-    }).catch(() => {
-      this.baseInstance_.getResource().resetPendingChangeSize();
-      if (optIsCollapse) {
-        resizeAndMeasure();
+      const success = !!this.baseInstance_.element.style.height.match(height)
+            && !!this.baseInstance_.element.style.width.match(width);
+      if (success || optIsCollapse) {
+        this.resizeIframe(height, width);
+        this.isCollapsed_ = !!optIsCollapse;
+        // We need to force a measure right now, as without remeasuring, we
+        // will have the wrong size information for the amp-ad and the
+        // safeframe when we send the response message into the safeframe.
+        // This would be an issue specifically for when expand is successful
+        // while amp-ad is out of the viewport, for example.
+        this.baseInstance_.measureElement(() => {
+          this.baseInstance_.getResource().measure();
+        });
+        this.sendResizeResponse(true, messageType);
       } else {
+        this.baseInstance_.getResource().resetPendingChangeSize();
         this.sendResizeResponse(false, messageType);
       }
+    }).catch(() => {
+      this.sendResizeResponse(false, messageType);
     });
   }
 

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
@@ -571,8 +571,9 @@ export class SafeframeHostApi {
   resizeAmpAdAndSafeframe(height, width, messageType, optIsCollapse) {
     this.baseInstance_.attemptChangeSize(height, width).then(() => {
       try {
-        const success = !!this.baseInstance_.element.style.height.match(height)
-              && !!this.baseInstance_.element.style.width.match(width);
+        const success =
+              (this.baseInstance_.element.style.height == height + 'px')
+              && (this.baseInstance_.element.style.width == width + 'px');
         // If the amp-ad element was successfully resized, always update
         // the size of the safeframe as well. If the amp-ad element could not
         // be resized, but this is a collapse request, then only collapse

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-safeframe.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-safeframe.js
@@ -512,13 +512,15 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
       sendExpandMessage(50, 50);
       // Verify that we can immediately resize the safeframe, and don't
       // need to call any of the fancy AMP element resize things.
-      expect(resizeIframeSpy).to.be.calledOnce;
-      expect(resizeIframeSpy).to.be.calledWith(100, 100);
-      expect(safeframeMock.style.height).to.equal('100px');
-      expect(safeframeMock.style.width).to.equal('100px');
-      expect(sendResizeResponseSpy).to.be.calledWith(
-          true, SERVICE.EXPAND_RESPONSE);
-      expect(resizeAmpAdAndSafeframeSpy).to.not.be.called;
+      return Services.timerFor(env.win).promise(100).then(() => {
+        expect(resizeIframeSpy).to.be.calledOnce;
+        expect(resizeIframeSpy).to.be.calledWith(100, 100);
+        expect(safeframeMock.style.height).to.equal('100px');
+        expect(safeframeMock.style.width).to.equal('100px');
+        expect(sendResizeResponseSpy).to.be.calledWith(
+            true, SERVICE.EXPAND_RESPONSE);
+        expect(resizeAmpAdAndSafeframeSpy).to.not.be.called;
+      });
     });
 
     /**
@@ -540,13 +542,15 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
       attemptChangeSizeStub.returns({then});
       sendExpandMessage(550,550);
 
-      expect(resizeIframeSpy).to.be.calledOnce;
-      expect(resizeIframeSpy).to.be.calledWith(600, 600);
-      expect(safeframeMock.style.height).to.equal('600px');
-      expect(safeframeMock.style.width).to.equal('600px');
-      expect(sendResizeResponseSpy).to.be.calledWith(
-          true, SERVICE.EXPAND_RESPONSE);
-      expect(resizeAmpAdAndSafeframeSpy).to.be.calledOnce;
+      return Services.timerFor(env.win).promise(100).then(() => {
+           expect(resizeIframeSpy).to.be.calledOnce;
+           expect(resizeIframeSpy).to.be.calledWith(600, 600);
+           expect(safeframeMock.style.height).to.equal('600px');
+           expect(safeframeMock.style.width).to.equal('600px');
+           expect(sendResizeResponseSpy).to.be.calledWith(
+               true, SERVICE.EXPAND_RESPONSE);
+           expect(resizeAmpAdAndSafeframeSpy).to.be.calledOnce;
+         });
     });
 
     /**
@@ -582,12 +586,14 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
 
       sendExpandMessage(550, 550);
 
-      expect(resizeIframeSpy).to.not.be.called;
-      expect(safeframeMock.height).to.equal('50');
-      expect(safeframeMock.width).to.equal('50');
-      expect(sendResizeResponseSpy).to.be.calledWith(
-          false, SERVICE.EXPAND_RESPONSE);
-      expect(resizeAmpAdAndSafeframeSpy).to.be.calledOnce;
+      return Services.timerFor(env.win).promise(100).then(() => {
+        expect(resizeIframeSpy).to.not.be.called;
+        expect(safeframeMock.height).to.equal('50');
+        expect(safeframeMock.width).to.equal('50');
+        expect(sendResizeResponseSpy).to.be.calledWith(
+            false, SERVICE.EXPAND_RESPONSE);
+        expect(resizeAmpAdAndSafeframeSpy).to.be.calledOnce;
+      });
     });
 
     function sendCollapseMessage() {
@@ -618,13 +624,15 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
       attemptChangeSizeStub.returns({then});
       sendCollapseMessage();
 
-      expect(resizeIframeSpy).to.be.calledOnce;
-      expect(resizeIframeSpy).to.be.calledWith(250, 300);
-      expect(safeframeMock.style.height).to.equal('250px');
-      expect(safeframeMock.style.width).to.equal('300px');
-      expect(sendResizeResponseSpy).to.be.calledWith(
-          true, SERVICE.COLLAPSE_RESPONSE);
-      expect(resizeAmpAdAndSafeframeSpy).to.be.calledOnce;
+      return Services.timerFor(env.win).promise(100).then(() => {
+        expect(resizeIframeSpy).to.be.calledOnce;
+        expect(resizeIframeSpy).to.be.calledWith(250, 300);
+        expect(safeframeMock.style.height).to.equal('250px');
+        expect(safeframeMock.style.width).to.equal('300px');
+        expect(sendResizeResponseSpy).to.be.calledWith(
+            true, SERVICE.COLLAPSE_RESPONSE);
+        expect(resizeAmpAdAndSafeframeSpy).to.be.calledOnce;
+      });
     });
 
     it('should collapse safeframe on amp-ad resize success', () => {
@@ -644,13 +652,15 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
       attemptChangeSizeStub.returns({then});
       sendCollapseMessage();
 
-      expect(resizeIframeSpy).to.be.calledOnce;
-      expect(resizeIframeSpy).to.be.calledWith(250, 300);
-      expect(safeframeMock.style.height).to.equal('250px');
-      expect(safeframeMock.style.width).to.equal('300px');
-      expect(sendResizeResponseSpy).to.be.calledWith(
-          true, SERVICE.COLLAPSE_RESPONSE);
-      expect(resizeAmpAdAndSafeframeSpy).to.be.calledOnce;
+      return Services.timerFor(env.win).promise(100).then(() => {
+        expect(resizeIframeSpy).to.be.calledOnce;
+        expect(resizeIframeSpy).to.be.calledWith(250, 300);
+        expect(safeframeMock.style.height).to.equal('250px');
+        expect(safeframeMock.style.width).to.equal('300px');
+        expect(sendResizeResponseSpy).to.be.calledWith(
+            true, SERVICE.COLLAPSE_RESPONSE);
+        expect(resizeAmpAdAndSafeframeSpy).to.be.calledOnce;
+      });
     });
   });
 });

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-safeframe.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-safeframe.js
@@ -560,7 +560,7 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
       safeframeHost.resizeAmpAdAndSafeframe(550, 550, SERVICE.EXPAND_RESPONSE);
       return Services.timerFor(env.win).promise(100).then(() => {
         expect(sendResizeResponseSpy).to.be.calledWith(
-            false, SERVICE.EXPAND_RESPONSE, 550, 550);
+            false, SERVICE.EXPAND_RESPONSE);
       });
     });
 

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-safeframe.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-safeframe.js
@@ -522,7 +522,7 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
     });
 
     /**
-     * If the safeframed creative asks to resize within the bounds of
+     * If the safeframed creative asks to resize outside the bounds of
      * the amp-ad element, first we try to resize the amp-ad element by
      * using element.attemptChangeSize. If that succeeds, then we also
      * resize the safeframe.
@@ -547,6 +547,21 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
       expect(sendResizeResponseSpy).to.be.calledWith(
           true, SERVICE.EXPAND_RESPONSE);
       expect(resizeAmpAdAndSafeframeSpy).to.be.calledOnce;
+    });
+
+    /**
+     * If the safeframed creative asks to resize outside the bounds of
+     * the amp-ad element, first we try to resize the amp-ad element by
+     * using element.attemptChangeSize. If that rejects, we should send
+     * a failure message.
+     */
+    it('resizeAmpAdAndSafeframe should send error on rejection', () => {
+      attemptChangeSizeStub.rejects();
+      safeframeHost.resizeAmpAdAndSafeframe(550, 550, SERVICE.EXPAND_RESPONSE);
+      return Services.timerFor(env.win).promise(100).then(() => {
+        expect(sendResizeResponseSpy).to.be.calledWith(
+            false, SERVICE.EXPAND_RESPONSE, 550, 550);
+      });
     });
 
     /**

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-safeframe.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-safeframe.js
@@ -537,20 +537,20 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
         ampAd.style.height = '600px';
         ampAd.style.width = '600px';
         f();
-        return {'catch': f => f()};
+        return {'catch': () => {}};
       };
       attemptChangeSizeStub.returns({then});
       sendExpandMessage(550,550);
 
       return Services.timerFor(env.win).promise(100).then(() => {
-           expect(resizeIframeSpy).to.be.calledOnce;
-           expect(resizeIframeSpy).to.be.calledWith(600, 600);
-           expect(safeframeMock.style.height).to.equal('600px');
-           expect(safeframeMock.style.width).to.equal('600px');
-           expect(sendResizeResponseSpy).to.be.calledWith(
-               true, SERVICE.EXPAND_RESPONSE);
-           expect(resizeAmpAdAndSafeframeSpy).to.be.calledOnce;
-         });
+        expect(resizeIframeSpy).to.be.calledOnce;
+        expect(resizeIframeSpy).to.be.calledWith(600, 600);
+        expect(safeframeMock.style.height).to.equal('600px');
+        expect(safeframeMock.style.width).to.equal('600px');
+        expect(sendResizeResponseSpy).to.be.calledWith(
+            true, SERVICE.EXPAND_RESPONSE);
+        expect(resizeAmpAdAndSafeframeSpy).to.be.calledOnce;
+      });
     });
 
     /**
@@ -575,14 +575,7 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
      */
     it('expand_request should fail if expanding past amp-ad bounds and would ' +
        'create reflow', () => {
-      // Sneaky hack to do a synchronous mock of attemptChangeSize
-      // In our mock, we don't do anything to the iframe that would be seen as a
-      // success, thus we are failing the resizing.
-      const then = f => {
-        f();
-        return {'catch': f => f()};
-      };
-      attemptChangeSizeStub.returns({then});
+      attemptChangeSizeStub.rejects();
 
       sendExpandMessage(550, 550);
 
@@ -615,13 +608,7 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
       ampAd.style.width = '600px';
       safeframeMock.style.height = 600;
       safeframeMock.style.width = 600;
-      // Sneaky hack to do a synchronous mock of attemptChangeSize
-      // Resize the ampAd to simulate a success.
-      const then = f => {
-        f();
-        return {'catch': f => f()};
-      };
-      attemptChangeSizeStub.returns({then});
+      attemptChangeSizeStub.rejects();
       sendCollapseMessage();
 
       return Services.timerFor(env.win).promise(100).then(() => {
@@ -647,7 +634,7 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
         ampAd.style.height = '250px';
         ampAd.style.width = '300px';
         f();
-        return {'catch': f => f()};
+        return {'catch': () => {}};
       };
       attemptChangeSizeStub.returns({then});
       sendCollapseMessage();

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-safeframe.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-safeframe.js
@@ -447,7 +447,7 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
 
   describe('Resizing', () => {
     let safeframeMock;
-    let resizeIframeSpy;
+    let resizeSafeframeSpy;
     let sendResizeResponseSpy;
     let resizeAmpAdAndSafeframeSpy;
     let attemptChangeSizeStub;
@@ -465,8 +465,8 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
       });
       ampAd.appendChild(safeframeMock);
       doubleclickImpl.iframe = safeframeMock;
-      resizeIframeSpy = sandbox.spy(
-          safeframeHost, 'resizeIframe');
+      resizeSafeframeSpy = sandbox.spy(
+          safeframeHost, 'resizeSafeframe');
       sendResizeResponseSpy = sandbox.spy(
           safeframeHost, 'sendResizeResponse');
       resizeAmpAdAndSafeframeSpy = sandbox.spy(
@@ -513,8 +513,8 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
       // Verify that we can immediately resize the safeframe, and don't
       // need to call any of the fancy AMP element resize things.
       return Services.timerFor(env.win).promise(100).then(() => {
-        expect(resizeIframeSpy).to.be.calledOnce;
-        expect(resizeIframeSpy).to.be.calledWith(100, 100);
+        expect(resizeSafeframeSpy).to.be.calledOnce;
+        expect(resizeSafeframeSpy).to.be.calledWith(100, 100);
         expect(safeframeMock.style.height).to.equal('100px');
         expect(safeframeMock.style.width).to.equal('100px');
         expect(sendResizeResponseSpy).to.be.calledWith(
@@ -543,8 +543,8 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
       sendExpandMessage(550,550);
 
       return Services.timerFor(env.win).promise(100).then(() => {
-        expect(resizeIframeSpy).to.be.calledOnce;
-        expect(resizeIframeSpy).to.be.calledWith(600, 600);
+        expect(resizeSafeframeSpy).to.be.calledOnce;
+        expect(resizeSafeframeSpy).to.be.calledWith(600, 600);
         expect(safeframeMock.style.height).to.equal('600px');
         expect(safeframeMock.style.width).to.equal('600px');
         expect(sendResizeResponseSpy).to.be.calledWith(
@@ -580,7 +580,7 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
       sendExpandMessage(550, 550);
 
       return Services.timerFor(env.win).promise(100).then(() => {
-        expect(resizeIframeSpy).to.not.be.called;
+        expect(resizeSafeframeSpy).to.not.be.called;
         expect(safeframeMock.height).to.equal('50');
         expect(safeframeMock.width).to.equal('50');
         expect(sendResizeResponseSpy).to.be.calledWith(
@@ -612,8 +612,8 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
       sendCollapseMessage();
 
       return Services.timerFor(env.win).promise(100).then(() => {
-        expect(resizeIframeSpy).to.be.calledOnce;
-        expect(resizeIframeSpy).to.be.calledWith(250, 300);
+        expect(resizeSafeframeSpy).to.be.calledOnce;
+        expect(resizeSafeframeSpy).to.be.calledWith(250, 300);
         expect(safeframeMock.style.height).to.equal('250px');
         expect(safeframeMock.style.width).to.equal('300px');
         expect(sendResizeResponseSpy).to.be.calledWith(
@@ -640,8 +640,8 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
       sendCollapseMessage();
 
       return Services.timerFor(env.win).promise(100).then(() => {
-        expect(resizeIframeSpy).to.be.calledOnce;
-        expect(resizeIframeSpy).to.be.calledWith(250, 300);
+        expect(resizeSafeframeSpy).to.be.calledOnce;
+        expect(resizeSafeframeSpy).to.be.calledWith(250, 300);
         expect(safeframeMock.style.height).to.equal('250px');
         expect(safeframeMock.style.width).to.equal('300px');
         expect(sendResizeResponseSpy).to.be.calledWith(


### PR DESCRIPTION
Bug in safeframe host API, was accessing a private variable that we don't actually have access to. This was silently throwing because we were immediately catching and doing nothing with the error. This means that all expands and collapses were never sending results to the creative, so the creative never knows whether it actually succeeded or not. This bug was not caught initially because:

1. Testing against local builds hides the issue, as touching the private variable does not throw locally. Thus for local manual testing and unit tests, this issue does not arise. 
2. Somehow presubmits did not catch that we're touching this variable we don't have access to.

Found due to[ comments here. ](https://github.com/ampproject/amphtml/issues/11834#issuecomment-372630235) (Which I initially did not see the gravity of, thanks @RonanDrouglazet for being patient with my questions :) ) 