### PR TITLE
Added comments to doubleclick.js dep check whitelist

### DIFF
--- a/build-system/dep-check-config.js
+++ b/build-system/dep-check-config.js
@@ -296,7 +296,7 @@ exports.rules = [
   // Please see https://github.com/ampproject/amphtml/issues/11834
   // for more information.
   // Do not add any additional files to this whitelist without express
-  // permission from bradfrizzell@, kjwright@, or rhazan@.
+  // permission from @bradfrizzell, @keithwrightbos, or @robhazan.
   {
     mustNotDependOn: [
       'ads/google/doubleclick.js',

--- a/build-system/dep-check-config.js
+++ b/build-system/dep-check-config.js
@@ -295,21 +295,27 @@ exports.rules = [
   // Doubleclick.js will be deleted from the repository at that time.
   // Please see https://github.com/ampproject/amphtml/issues/11834
   // for more information.
+  // Do not add any additional files to this whitelist without express
+  // permission from bradfrizzell@, kjwright@, or rhazan@.
   {
     mustNotDependOn: [
       'ads/google/doubleclick.js',
     ],
     whitelist: [
+      /** DO NOT ADD TO WHITELIST **/
       'ads/ix.js->ads/google/doubleclick.js',
       'ads/imonomy.js->ads/google/doubleclick.js',
       'ads/medianet.js->ads/google/doubleclick.js',
       'ads/navegg.js->ads/google/doubleclick.js',
+      /** DO NOT ADD TO WHITELIST **/
       'ads/openx.js->ads/google/doubleclick.js',
       'ads/pulsepoint.js->ads/google/doubleclick.js',
       'ads/rubicon.js->ads/google/doubleclick.js',
       'ads/yieldbot.js->ads/google/doubleclick.js',
+      /** DO NOT ADD TO WHITELIST **/
       'ads/criteo.js->ads/google/doubleclick.js',
       '3p/integration.js->ads/google/doubleclick.js',
+      /** DO NOT ADD TO WHITELIST **/
     ],
   },
 ];


### PR DESCRIPTION
Doubleclick.js is going away March 29. However, recent additions to the whitelist slipped through. Update with more comments to make sure this does not happen again. 