### PR TITLE
Enable AMP.printState even in non-dev mode

### DIFF
--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -167,10 +167,8 @@ export class Bind {
     /** @private {Promise} */
     this.setStatePromise_ = null;
 
-    // Expose for testing on dev.
-    if (getMode().development || getMode().localDev) {
-      AMP.printState = this.printState_.bind(this);
-    }
+    // Expose for debugging in the console.
+    AMP.printState = this.printState_.bind(this);
   }
 
   /** @override */

--- a/extensions/amp-bind/amp-bind.md
+++ b/extensions/amp-bind/amp-bind.md
@@ -585,7 +585,7 @@ There are several types of runtime errors that may be encountered when working w
 
 ### Debugging State
 
-In development mode, use `AMP.printState()` to print the current state to the console.
+Use `AMP.printState()` to print the current state to the console.
 
 ## Appendix
 


### PR DESCRIPTION
- Enable AMP.printState even in non-dev mode

@choumx 