### PR TITLE
Enable arrow key navigation of carousel on lightbox

### DIFF
--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -1044,15 +1044,15 @@ export class AmpLightboxGallery extends AMP.BaseElement {
     switch (keyCode) {
       case KeyCodes.ESCAPE:
         this.close_();
-        return;
+        break;
       case KeyCodes.LEFT_ARROW:
         this.maybeSlideCarousel_(/*Prev*/ -1);
-        return;
+        break;
       case KeyCodes.RIGHT_ARROW:
         this.maybeSlideCarousel_(/*Next*/ 1);
-        return;
+        break;
       default:
-        return;
+        // Keycode not registered. Do nothing.
     }
 
   }

--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -642,10 +642,8 @@ export class AmpLightboxGallery extends AMP.BaseElement {
    */
   openLightboxForElement_(element) {
     this.currentElemId_ = element.lightboxItemId;
-    // Hack to access private property. Better than not getting
-    // type checking to work.
-    /**@type {?}*/ (this.carousel_).implementation_.showSlideWhenReady(
-        this.currentElemId_);
+    dev().assert(this.carousel_).getImpl()
+        .then(carousel => carousel.showSlideWhenReady(this.currentElemId_));
     const tagName = this.getCurrentElement_().tagName;
     if (ELIGIBLE_TAP_TAGS[tagName]) {
       this.getCurrentElement_().imageViewer.signals()
@@ -984,8 +982,8 @@ export class AmpLightboxGallery extends AMP.BaseElement {
         }
       });
 
-      /**@type {?}*/ (lightboxCarouselMetadata.sourceCarousel).implementation_
-          .showSlideWhenReady(returnSlideIndex);
+      dev().assert(lightboxCarouselMetadata.sourceCarousel).getImpl()
+        .then(carousel => carousel.showSlideWhenReady(returnSlideIndex));
     }
   }
 
@@ -1175,10 +1173,8 @@ export class AmpLightboxGallery extends AMP.BaseElement {
       this.closeGallery_();
       this.currentElemId_ = thumbnailObj.element.lightboxItemId;
       this.updateDescriptionBox_();
-      // Hack to access private property. Better than not getting
-      // type checking to work.
-      /**@type {?}*/ (this.carousel_).implementation_.showSlideWhenReady(
-          this.currentElemId_);
+      dev().assert(this.carousel_).getImpl()
+        .then(carousel => carousel.showSlideWhenReady(this.currentElemId_));
       this.updateDescriptionBox_();
       event.stopPropagation();
     };

--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -1039,9 +1039,17 @@ export class AmpLightboxGallery extends AMP.BaseElement {
    * @private
    */
   handleKeyboardEvents_(event) {
-    const code = event.keyCode;
-    if (code == KeyCodes.ESCAPE) {
-      this.close_();
+    if (this.active_) {
+      const code = event.keyCode;
+      if (code == KeyCodes.ESCAPE) {
+        this.close_();
+      } else if (code == KeyCodes.LEFT_ARROW) {
+        /**@type {?}*/ (this.carousel_).implementation_.goCallback(
+            /*Prev*/ -1, /*Animate*/ true, /*Autoplay*/ false);
+      } else if (code == KeyCodes.RIGHT_ARROW) {
+        /**@type {?}*/ (this.carousel_).implementation_.goCallback(
+            /*Next*/ 1, /*Animate*/ true, /*Autoplay*/ false);
+      }
     }
   }
 

--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -93,7 +93,7 @@ export class AmpLightboxGallery extends AMP.BaseElement {
     super(element);
 
     /** @private {boolean} */
-    this.active_ = false;
+    this.isActive_ = false;
 
     /** @private {number} */
     this.currentElemId_ = -1;
@@ -614,7 +614,7 @@ export class AmpLightboxGallery extends AMP.BaseElement {
       });
     }).then(() => {
       this.getViewport().enterLightboxMode();
-      this.active_ = true;
+      this.isActive_ = true;
 
       this.updateInViewport(dev().assertElement(this.container_), true);
       this.scheduleLayout(dev().assertElement(this.container_));
@@ -995,11 +995,11 @@ export class AmpLightboxGallery extends AMP.BaseElement {
    * @private
    */
   close_() {
-    if (!this.active_) {
+    if (!this.isActive_) {
       return Promise.resolve();
     }
 
-    this.active_ = false;
+    this.isActive_ = false;
 
     this.cleanupEventListeners_();
 
@@ -1039,7 +1039,7 @@ export class AmpLightboxGallery extends AMP.BaseElement {
    * @private
    */
   handleKeyboardEvents_(event) {
-    if (this.active_) {
+    if (this.isActive_) {
       const code = event.keyCode;
       if (code == KeyCodes.ESCAPE) {
         this.close_();

--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -983,7 +983,7 @@ export class AmpLightboxGallery extends AMP.BaseElement {
       });
 
       dev().assert(lightboxCarouselMetadata.sourceCarousel).getImpl()
-        .then(carousel => carousel.showSlideWhenReady(returnSlideIndex));
+          .then(carousel => carousel.showSlideWhenReady(returnSlideIndex));
     }
   }
 
@@ -1046,10 +1046,10 @@ export class AmpLightboxGallery extends AMP.BaseElement {
         this.close_();
         break;
       case KeyCodes.LEFT_ARROW:
-        this.maybeSlideCarousel_(/*Prev*/ -1);
+        this.maybeSlideCarousel_(/*direction*/ -1);
         break;
       case KeyCodes.RIGHT_ARROW:
-        this.maybeSlideCarousel_(/*Next*/ 1);
+        this.maybeSlideCarousel_(/*direction*/ 1);
         break;
       default:
         // Keycode not registered. Do nothing.
@@ -1174,7 +1174,7 @@ export class AmpLightboxGallery extends AMP.BaseElement {
       this.currentElemId_ = thumbnailObj.element.lightboxItemId;
       this.updateDescriptionBox_();
       dev().assert(this.carousel_).getImpl()
-        .then(carousel => carousel.showSlideWhenReady(this.currentElemId_));
+          .then(carousel => carousel.showSlideWhenReady(this.currentElemId_));
       this.updateDescriptionBox_();
       event.stopPropagation();
     };

--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -1044,11 +1044,15 @@ export class AmpLightboxGallery extends AMP.BaseElement {
       if (code == KeyCodes.ESCAPE) {
         this.close_();
       } else if (code == KeyCodes.LEFT_ARROW) {
-        /**@type {?}*/ (this.carousel_).implementation_.goCallback(
-            /*Prev*/ -1, /*Animate*/ true, /*Autoplay*/ false);
+        if (!this.container_.hasAttribute('gallery-view')) {
+          /**@type {?}*/ (this.carousel_).implementation_.goCallback(
+              /*Prev*/ -1, /*Animate*/ true, /*Autoplay*/ false);
+        }
       } else if (code == KeyCodes.RIGHT_ARROW) {
-        /**@type {?}*/ (this.carousel_).implementation_.goCallback(
-            /*Next*/ 1, /*Animate*/ true, /*Autoplay*/ false);
+        if (!this.container_.hasAttribute('gallery-view')) {
+          /**@type {?}*/ (this.carousel_).implementation_.goCallback(
+              /*Next*/ 1, /*Animate*/ true, /*Autoplay*/ false);
+        }
       }
     }
   }

--- a/test/manual/amp-lightbox-gallery-launch.amp.html
+++ b/test/manual/amp-lightbox-gallery-launch.amp.html
@@ -40,30 +40,31 @@
   <amp-img src="https://images.unsplash.com/photo-1503843778847-2b8bdce2ed3d"
     aria-describedby="longest-description"
     lightbox
-    width="400"
-    height="300"
+    width="300"
+    height="200"
     alt="a beautiful cat"></amp-img>
 
   <amp-img src="https://images.unsplash.com/photo-1503843778847-2b8bdce2ed3d"
     aria-describedby="medium-description"
     lightbox
-    width="400"
-    height="300"
+    width="300"
+    height="200"
     alt="a beautiful cat"></amp-img>
 
   <amp-img src="https://images.unsplash.com/photo-1503843778847-2b8bdce2ed3d"
     lightbox
-    width="400"
-    height="300"></amp-img>
+    width="300"
+    height="200"></amp-img>
 
-  <amp-carousel height="300"
+  <amp-carousel
+    height="300"
     width="400"
     layout="fixed"
     type="slides"
     lightbox>
     <amp-img src="https://images.unsplash.com/photo-1503843778847-2b8bdce2ed3d"
-      width="400"
-      height="300"
+      width="300"
+      height="200"
       alt="a beautiful cat"></amp-img>
     <amp-anim
       role="button"
@@ -74,22 +75,22 @@
     </amp-anim>
     <figure>
         <amp-img src="https://images.unsplash.com/photo-1515002246390-7bf7e8f87b54"
-        width="400"
-        height="300"
+        width="300"
+        height="200"
         alt="another beautiful cat"></amp-img>
         <figcaption>This is a figure with a figcaption.</figcaption>
     </figure>
     <amp-img src="https://images.unsplash.com/photo-1445499348736-29b6cdfc03b9"
-      width="400"
-      height="300"
+      width="300"
+      height="200"
       aria-label="Aria labels are cool."></amp-img>
     <amp-img src="https://images.unsplash.com/photo-1482066490729-6f26115b60dc"
-      width="400"
-      height="300"
+      width="300"
+      height="200"
       aria-describedby="my-aria-describe"></amp-img>
     <amp-img src="https://images.unsplash.com/photo-1511275539165-cc46b1ee89bf"
-      width="400"
-      height="300"
+      width="300"
+      height="200"
       aria-labelledby="my-aria-label"></amp-img>
   </amp-carousel>
 
@@ -109,8 +110,8 @@
   type="slides"
   lightbox>
     <amp-img src="https://images.unsplash.com/photo-1503843778847-2b8bdce2ed3d"
-      width="800"
-      height="600"
+      width="600"
+      height="400"
       alt="a beautiful cat"></amp-img>
     <amp-video
       src="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4"
@@ -169,8 +170,8 @@
     type="slides"
     lightbox>
     <amp-img src="https://images.unsplash.com/photo-1503843778847-2b8bdce2ed3d"
-      width="800"
-      height="600"
+      width="600"
+      height="400"
       alt="a beautiful cat"></amp-img>
     <amp-youtube width="480"
       height="270"
@@ -212,8 +213,8 @@
     type="slides"
     lightbox>
     <amp-img src="https://images.unsplash.com/photo-1503843778847-2b8bdce2ed3d"
-      width="800"
-      height="600"
+      width="600"
+      height="400"
       alt="a beautiful cat"></amp-img>
     <amp-ad width="300"
       height="250"
@@ -246,8 +247,8 @@
     type="slides"
     lightbox>
     <amp-img src="https://images.unsplash.com/photo-1503843778847-2b8bdce2ed3d"
-      width="800"
-      height="600"
+      width="600"
+      height="400"
       alt="a beautiful cat"></amp-img>
     <amp-instagram data-shortcode="1totVhIFXl"
       width="400"
@@ -284,8 +285,8 @@
     type="slides"
     lightbox>
     <amp-img src="https://images.unsplash.com/photo-1503843778847-2b8bdce2ed3d"
-      width="800"
-      height="600"
+      width="600"
+      height="400"
       alt="a beautiful cat"></amp-img>
     <amp-facebook
       lightbox-thumbnail-id="fb-thumbnail-img"
@@ -330,8 +331,8 @@
     type="slides"
     lightbox>
     <amp-img src="https://images.unsplash.com/photo-1503843778847-2b8bdce2ed3d"
-      width="800"
-      height="600"
+      width="600"
+      height="400"
       alt="a beautiful cat"></amp-img>
     <amp-facebook
       width="552"
@@ -367,8 +368,8 @@
   <h3>Test 1</h3>
   <p>The following image and youtube video should belong to the same lightbox group. The lightbox group should include a third image from the carousel in Test 3 below. </p>
   <amp-img src="https://images.unsplash.com/photo-1503843778847-2b8bdce2ed3d"
-    width="400"
-    height="300"
+    width="300"
+    height="200"
     lightbox="group-1"
     alt="a beautiful cat"></amp-img>
   <amp-youtube lightbox="group-1"
@@ -380,8 +381,8 @@
   <h3>Test 2</h3>
   <p>The following image should belong to its own lightbox group. </p>
   <amp-img src="https://images.unsplash.com/photo-1445499348736-29b6cdfc03b9"
-    width="400"
-    height="300"
+    width="300"
+    height="200"
     lightbox
     aria-label="Aria labels are cool."></amp-img>
   <h3>Test 3</h3>
@@ -392,21 +393,21 @@
     type="slides"
     lightbox>
     <amp-img src="https://images.unsplash.com/photo-1503843778847-2b8bdce2ed3d"
-      width="400"
-      height="300"
+      width="300"
+      height="200"
       alt="a beautiful cat"></amp-img>
     <amp-img src="https://images.unsplash.com/photo-1445499348736-29b6cdfc03b9"
-      width="400"
-      height="300"
+      width="300"
+      height="200"
       lightbox-exclude
       aria-label="Aria labels are cool."></amp-img>
     <amp-img src="https://images.unsplash.com/photo-1482066490729-6f26115b60dc"
-      width="400"
-      height="300"
+      width="300"
+      height="200"
       aria-describedby="my-aria-describe"></amp-img>
     <amp-img src="https://images.unsplash.com/photo-1511275539165-cc46b1ee89bf"
-      width="400"
-      height="300"
+      width="300"
+      height="200"
       lightbox="group-1"
       aria-labelledby="my-aria-label"></amp-img>
   </amp-carousel>


### PR DESCRIPTION
Feature request from lightbox launch burndown checklist, enable carousel navigation via arrow keys in `<amp-lightbox-gallery>`. 