### PR TITLE
🐛 Lock chromedriver to 2.35 to avoid intermittent errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,9 @@ before_install:
 before_script:
   - pip install --user protobuf
   - gem install percy-capybara capybara selenium-webdriver chromedriver-helper rspec-retry
-  - ./node_modules/.bin/greenkeeper-lockfile-update
   - chromedriver-update 2.35
   - chromedriver -v
+  - ./node_modules/.bin/greenkeeper-lockfile-update
 script: node build-system/pr-check.js
 after_script: ./node_modules/.bin/greenkeeper-lockfile-upload
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ before_script:
   - pip install --user protobuf
   - gem install percy-capybara capybara selenium-webdriver chromedriver-helper rspec-retry
   - ./node_modules/.bin/greenkeeper-lockfile-update
+  - chromedriver-update 2.35
+  - chromedriver -v
 script: node build-system/pr-check.js
 after_script: ./node_modules/.bin/greenkeeper-lockfile-upload
 branches:


### PR DESCRIPTION
Addresses https://github.com/ampproject/amphtml/issues/13700

`gulp visual-diff` uses capybara and selenium to drive Chrome to take DOM snapshots.  Recently this has been intermittently failing.

In my testing, I haven't been able to reproduce the error since locking chromedriver back to the previous 2.35 version.  
