### PR TITLE
Set scrollTop to zero before shrinking the description overflow

### DIFF
--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -404,6 +404,7 @@ export class AmpLightboxGallery extends AMP.BaseElement {
         this.descriptionBox_.classList.remove('standard');
         this.descriptionBox_.classList.add('overflow');
       } else {
+        this.descriptionBox_./*OK*/scrollTop = 0;
         this.descriptionBox_.classList.remove('overflow');
         this.descriptionBox_.classList.add('standard');
       }


### PR DESCRIPTION
Theoretically this isn't terrible because it's inside a `vsync`, but if there's a better solution than this, let me know. 

This is the bug: 
![insta](https://user-images.githubusercontent.com/1528181/37548055-9a8ca7fa-2932-11e8-810e-91d5c5e607f8.gif)

This is after the fix: 
![insta](https://user-images.githubusercontent.com/1528181/37548085-c2ace592-2932-11e8-9366-c170f67e79cc.gif)
