### PR TITLE
🐛Increase Selenium's read timeout

### DIFF
--- a/build-system/tasks/visual-diff.rb
+++ b/build-system/tasks/visual-diff.rb
@@ -258,9 +258,13 @@ def configure_browser
     }
   )
   Capybara.register_driver :chrome do |app|
+    http_client = Selenium::WebDriver::Remote::Http::Default.new
+    http_client.read_timeout = 120
+
     Capybara::Selenium::Driver.new(
       app,
       browser: :chrome,
+      http_client: http_client,
       options: options
     )
   end


### PR DESCRIPTION
The visual-diffs task is [intermittently seeing a Net::ReadTimeout error](https://github.com/ampproject/amphtml/issues/13700) when talking with selenium.

`/home/travis/.rvm/rubies/ruby-2.4.1/lib/ruby/2.4.0/net/protocol.rb:176:in 'rbuf_fill': Net::ReadTimeout (Net::ReadTimeout)`

This PR increases the read_timeout to 120 seconds.  This follows recommendations from one of the Capybara core team members, Tom Walpole, described [here](https://stackoverflow.com/questions/31383385/capybara-increase-max-allowed-page-load-time).  

As the error is intermittent and hard to reproduce, it's unclear whether this will solve the issue.  It won't cause any harm though.

Also see this as a possible [alternative solution](https://stackoverflow.com/questions/46163756/capybara-selenium-headless-chrome-ubuntu-netreadtimeout) if increasing the read timeout doesn't solve the issue.

cc: @rsimha 

