### PR TITLE
🏗 First pass at validator rules for amp-date-picker

### DIFF
--- a/extensions/amp-date-picker/0.1/test/validator-amp-date-picker.html
+++ b/extensions/amp-date-picker/0.1/test/validator-amp-date-picker.html
@@ -1,0 +1,114 @@
+<!--
+  Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS-IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the license.
+-->
+<!--
+  Test Description:
+  Tests for the amp-date-picker tag.
+-->
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <link rel="canonical" href="./regular-html-version.html">
+  <meta name="viewport" content="width=device-width,minimum-scale=1">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-date-picker"
+    src="https://cdn.ampproject.org/v0/amp-date-picker-0.1.js"></script>
+</head>
+<body>
+  <!-- Valid: amp-date-picker with only layout attributes -->
+  <amp-date-picker layout="fixed-height" height="360">
+  </amp-date-picker>
+  <!-- Valid: amp-date-picker with only mode="overlay" attribute -->
+  <amp-date-picker mode="overlay" input-selector="[name=date1]">
+    <input type="text" name="date1">
+  </amp-date-picker>
+  <!-- Valid: amp-date-picker with only mode="static" attribute -->
+  <amp-date-picker mode="static" layout="fixed-height" height="360">
+  </amp-date-picker>
+  <!-- Valid: amp-date-picker with only type="single" attribute -->
+  <amp-date-picker type="single" layout="fixed-height" height="360">
+  </amp-date-picker>
+  <!-- Valid: amp-date-picker with only type="range" attribute -->
+  <amp-date-picker type="range" layout="fixed-height" height="360">
+  </amp-date-picker>
+  <!-- Valid: range amp-date-picker with mode="overlay" attribute -->
+  <amp-date-picker type="range" mode="overlay" start-input-selector="[name=date2]" end-input-selector="[name=date3]">
+    <input type="text" name="date2">
+    <input type="text" name="date3">
+  </amp-date-picker>
+  <!-- Valid: single amp-date-picker with input-selector -->
+  <amp-date-picker type="single" input-selector="#a1" layout="fixed-height" height="360">
+  </amp-date-picker>
+  <!-- Valid: range amp-date-picker with input-selector -->
+  <amp-date-picker type="range" start-input-selector="#a2" end-input-selector="#b2" layout="fixed-height" height="360">
+    </amp-date-picker>
+  <!-- Valid: explicit static amp-date-picker with fullscreen attribute -->
+  <amp-date-picker mode="static" layout="fill" fullscreen>
+  </amp-date-picker>
+  <!-- Valid: implicit static amp-date-picker with fullscreen attribute -->
+  <amp-date-picker layout="fill" fullscreen>
+  </amp-date-picker>
+  <!-- Valid: amp-date-picker with day-size-->
+  <amp-date-picker type="range" layout="fixed-height" height="360"
+      day-size="50">
+  </amp-date-picker>
+  <!-- Valid: amp-date-picker with number-of-months -->
+  <amp-date-picker type="range" layout="fixed-height" height="360"
+      number-of-months="12">
+  </amp-date-picker>
+  <!-- Valid: amp-date-picker with first-day-of-week -->
+  <amp-date-picker type="range" layout="fixed-height" height="360"
+      first-day-of-week="1">
+  </amp-date-picker>
+  <!-- Valid: amp-date-picker with src -->
+  <amp-date-picker layout="fixed-height" height="360"
+      src="https://data.com/dates.json?ref=CANONICAL_URL">
+  </amp-date-picker>
+
+
+  <!-- Invalid: single amp-date-picker with start-input-selector -->
+  <amp-date-picker type="single" mode="static" start-input-selector="#a3" layout="fixed-height" height="360">
+  </amp-date-picker>
+  <!-- Invalid: range amp-date-picker with input-selector -->
+  <amp-date-picker type="range" input-selector="#a4" layout="fixed-height" height="360">
+    </amp-date-picker>
+  <!-- Invalid: amp-date-picker with implicit mode="static" without layout -->
+  <amp-date-picker></amp-date-picker>
+  <!-- Invalid: amp-date-picker with explicit mode="static" without layout -->
+  <amp-date-picker mode="static">
+  </amp-date-picker>
+  <!-- Invalid: overlay amp-date-picker with fullscreen attribute -->
+  <amp-date-picker mode="overlay" fullscreen>
+    <input type="text" name="date4">
+  </amp-date-picker>
+  <!-- Invalid: width is mistyped. -->
+  <amp-date-picker height="360" wdith="360">
+  </amp-date-picker>
+  <!-- Invalid: amp-date-picker with bad day-size-->
+  <amp-date-picker type="range" layout="fixed-height" height="360"
+      day-size="five">
+  </amp-date-picker>
+  <!-- Invalid: amp-date-picker with bad number-of-months -->
+  <amp-date-picker type="range" layout="fixed-height" height="360"
+      number-of-months="twele">
+  </amp-date-picker>
+  <!-- Invalid: amp-date-picker with bad first-day-of-week -->
+  <amp-date-picker type="range" layout="fixed-height" height="360"
+      first-day-of-week="7">
+  </amp-date-picker>
+</body>
+</html>

--- a/extensions/amp-date-picker/0.1/test/validator-amp-date-picker.out
+++ b/extensions/amp-date-picker/0.1/test/validator-amp-date-picker.out
@@ -1,0 +1,149 @@
+FAIL
+|  <!--
+|    Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests for the amp-date-picker tag.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <script async custom-element="amp-date-picker"
+|      src="https://cdn.ampproject.org/v0/amp-date-picker-0.1.js"></script>
+|  </head>
+|  <body>
+|    <!-- Valid: amp-date-picker with only layout attributes -->
+|    <amp-date-picker layout="fixed-height" height="360">
+|    </amp-date-picker>
+|    <!-- Valid: amp-date-picker with only mode="overlay" attribute -->
+|    <amp-date-picker mode="overlay" input-selector="[name=date1]">
+|      <input type="text" name="date1">
+|    </amp-date-picker>
+|    <!-- Valid: amp-date-picker with only mode="static" attribute -->
+|    <amp-date-picker mode="static" layout="fixed-height" height="360">
+|    </amp-date-picker>
+|    <!-- Valid: amp-date-picker with only type="single" attribute -->
+|    <amp-date-picker type="single" layout="fixed-height" height="360">
+|    </amp-date-picker>
+|    <!-- Valid: amp-date-picker with only type="range" attribute -->
+|    <amp-date-picker type="range" layout="fixed-height" height="360">
+|    </amp-date-picker>
+|    <!-- Valid: range amp-date-picker with mode="overlay" attribute -->
+|    <amp-date-picker type="range" mode="overlay" start-input-selector="[name=date2]" end-input-selector="[name=date3]">
+|      <input type="text" name="date2">
+|      <input type="text" name="date3">
+|    </amp-date-picker>
+|    <!-- Valid: single amp-date-picker with input-selector -->
+|    <amp-date-picker type="single" input-selector="#a1" layout="fixed-height" height="360">
+|    </amp-date-picker>
+|    <!-- Valid: range amp-date-picker with input-selector -->
+|    <amp-date-picker type="range" start-input-selector="#a2" end-input-selector="#b2" layout="fixed-height" height="360">
+|      </amp-date-picker>
+|    <!-- Valid: explicit static amp-date-picker with fullscreen attribute -->
+|    <amp-date-picker mode="static" layout="fill" fullscreen>
+|    </amp-date-picker>
+|    <!-- Valid: implicit static amp-date-picker with fullscreen attribute -->
+|    <amp-date-picker layout="fill" fullscreen>
+|    </amp-date-picker>
+|    <!-- Valid: amp-date-picker with day-size-->
+|    <amp-date-picker type="range" layout="fixed-height" height="360"
+|        day-size="50">
+|    </amp-date-picker>
+|    <!-- Valid: amp-date-picker with number-of-months -->
+|    <amp-date-picker type="range" layout="fixed-height" height="360"
+|        number-of-months="12">
+|    </amp-date-picker>
+|    <!-- Valid: amp-date-picker with first-day-of-week -->
+|    <amp-date-picker type="range" layout="fixed-height" height="360"
+|        first-day-of-week="1">
+|    </amp-date-picker>
+|    <!-- Valid: amp-date-picker with src -->
+|    <amp-date-picker layout="fixed-height" height="360"
+|        src="https://data.com/dates.json?ref=CANONICAL_URL">
+|    </amp-date-picker>
+|  
+|  
+|    <!-- Invalid: single amp-date-picker with start-input-selector -->
+|    <amp-date-picker type="single" mode="static" start-input-selector="#a3" layout="fixed-height" height="360">
+>>   ^~~~~~~~~
+amp-date-picker/0.1/test/validator-amp-date-picker.html:84:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=single][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
+>>   ^~~~~~~~~
+amp-date-picker/0.1/test/validator-amp-date-picker.html:84:2 The attribute 'mode' in tag 'amp-date-picker[type=single][mode=overlay]' is set to the invalid value 'static'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_TAG_PROBLEM]
+>>   ^~~~~~~~~
+amp-date-picker/0.1/test/validator-amp-date-picker.html:84:2 The attribute 'start-input-selector' may not appear in tag 'amp-date-picker[type=single][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_TAG_PROBLEM]
+|    </amp-date-picker>
+|    <!-- Invalid: range amp-date-picker with input-selector -->
+|    <amp-date-picker type="range" input-selector="#a4" layout="fixed-height" height="360">
+>>   ^~~~~~~~~
+amp-date-picker/0.1/test/validator-amp-date-picker.html:87:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=single][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
+>>   ^~~~~~~~~
+amp-date-picker/0.1/test/validator-amp-date-picker.html:87:2 The attribute 'type' in tag 'amp-date-picker[type=single][mode=overlay]' is set to the invalid value 'range'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_TAG_PROBLEM]
+|      </amp-date-picker>
+|    <!-- Invalid: amp-date-picker with implicit mode="static" without layout -->
+|    <amp-date-picker></amp-date-picker>
+>>   ^~~~~~~~~
+amp-date-picker/0.1/test/validator-amp-date-picker.html:90:2 The implied layout 'CONTAINER' is not supported by tag 'amp-date-picker[type=single][mode=static]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
+|    <!-- Invalid: amp-date-picker with explicit mode="static" without layout -->
+|    <amp-date-picker mode="static">
+>>   ^~~~~~~~~
+amp-date-picker/0.1/test/validator-amp-date-picker.html:92:2 The implied layout 'CONTAINER' is not supported by tag 'amp-date-picker[type=single][mode=static]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
+|    </amp-date-picker>
+|    <!-- Invalid: overlay amp-date-picker with fullscreen attribute -->
+|    <amp-date-picker mode="overlay" fullscreen>
+>>   ^~~~~~~~~
+amp-date-picker/0.1/test/validator-amp-date-picker.html:95:2 The implied layout 'CONTAINER' is not supported by tag 'amp-date-picker[type=single][mode=static]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
+>>   ^~~~~~~~~
+amp-date-picker/0.1/test/validator-amp-date-picker.html:95:2 The attribute 'mode' in tag 'amp-date-picker[type=single][mode=static]' is set to the invalid value 'overlay'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_TAG_PROBLEM]
+|      <input type="text" name="date4">
+|    </amp-date-picker>
+|    <!-- Invalid: width is mistyped. -->
+|    <amp-date-picker height="360" wdith="360">
+>>   ^~~~~~~~~
+amp-date-picker/0.1/test/validator-amp-date-picker.html:99:2 The implied layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=single][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
+>>   ^~~~~~~~~
+amp-date-picker/0.1/test/validator-amp-date-picker.html:99:2 The attribute 'wdith' may not appear in tag 'amp-date-picker[type=single][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_TAG_PROBLEM]
+|    </amp-date-picker>
+|    <!-- Invalid: amp-date-picker with bad day-size-->
+|    <amp-date-picker type="range" layout="fixed-height" height="360"
+>>   ^~~~~~~~~
+amp-date-picker/0.1/test/validator-amp-date-picker.html:102:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=range][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
+>>   ^~~~~~~~~
+amp-date-picker/0.1/test/validator-amp-date-picker.html:102:2 The attribute 'day-size' in tag 'amp-date-picker[type=range][mode=overlay]' is set to the invalid value 'five'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_TAG_PROBLEM]
+|        day-size="five">
+|    </amp-date-picker>
+|    <!-- Invalid: amp-date-picker with bad number-of-months -->
+|    <amp-date-picker type="range" layout="fixed-height" height="360"
+>>   ^~~~~~~~~
+amp-date-picker/0.1/test/validator-amp-date-picker.html:106:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=range][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
+>>   ^~~~~~~~~
+amp-date-picker/0.1/test/validator-amp-date-picker.html:106:2 The attribute 'number-of-months' in tag 'amp-date-picker[type=range][mode=overlay]' is set to the invalid value 'twele'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_TAG_PROBLEM]
+|        number-of-months="twele">
+|    </amp-date-picker>
+|    <!-- Invalid: amp-date-picker with bad first-day-of-week -->
+|    <amp-date-picker type="range" layout="fixed-height" height="360"
+>>   ^~~~~~~~~
+amp-date-picker/0.1/test/validator-amp-date-picker.html:110:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=range][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
+>>   ^~~~~~~~~
+amp-date-picker/0.1/test/validator-amp-date-picker.html:110:2 The attribute 'first-day-of-week' in tag 'amp-date-picker[type=range][mode=overlay]' is set to the invalid value '7'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_TAG_PROBLEM]
+|        first-day-of-week="7">
+|    </amp-date-picker>
+|  </body>
+|  </html>

--- a/extensions/amp-date-picker/validator-amp-date-picker.protoascii
+++ b/extensions/amp-date-picker/validator-amp-date-picker.protoascii
@@ -1,0 +1,95 @@
+#
+# Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the license.
+#
+
+tags: {  # amp-date-picker
+  tag_name: "SCRIPT"
+  extension_spec: {
+    name: "amp-date-picker"
+    allowed_versions: "0.1"
+    allowed_versions: "latest"
+  }
+  attr_lists: "common-extension-attrs"
+}
+tags: {  # <amp-date-picker>
+  tag_name: "AMP-DATE-PICKER"
+  requires_extension: "amp-date-picker"
+  attrs: {
+    name: "mode"
+    value_regex: "overlay|static|"
+  }
+  attrs: {
+    name: "type"
+    value_regex: "range|single|"
+  }
+  attrs: { name: "input-selector" }
+  attrs: { name: "start-date-selector" }
+  attrs: { name: "end-date-selector" }
+  attrs: { name: "min" }
+  attrs: { name: "max" }
+  attrs: { name: "month-format" }
+  attrs: { name: "format" }
+  attrs: { name: "week-day-format" }
+  attrs: { name: "locale" }
+  attrs: {
+    name: "number-of-months"
+    value_regex: "[0-9]+"
+  }
+  attrs: {
+    name: "first-day-of-week"
+    value_regex: "[0-9]"
+  }
+  attrs: { name: "blocked" }
+  attrs: { name: "highlighted" }
+  attrs: {
+    name: "day-size"
+    value_regex: "[0-9]+"
+  }
+  attrs: {
+    name: "allow-blocked-ranges"
+    value: ""
+  }
+  attrs: {
+    name: "src"
+    mandatory: true
+    value_url: {
+      allowed_protocol: "https"
+      allow_relative: true  # Will be set to false at a future date.
+    }
+    blacklisted_value_regex: "__amp_source_origin"
+  }
+  attrs: {
+    name: "fullscreen"
+    value: ""
+  }
+  attrs: {
+    name: "open-after-select"
+    value: ""
+  }
+  attrs: {
+    name: "open-after-clear"
+    value: ""
+  }
+  amp_layout: {
+    supported_layouts: FILL
+    supported_layouts: FIXED
+    supported_layouts: FIXED_HEIGHT
+    supported_layouts: FLEX_ITEM
+    supported_layouts: INTRINSIC
+    supported_layouts: NODISPLAY
+    supported_layouts: RESPONSIVE
+    supported_layouts: CONTAINER
+  }
+}

--- a/extensions/amp-date-picker/validator-amp-date-picker.protoascii
+++ b/extensions/amp-date-picker/validator-amp-date-picker.protoascii
@@ -27,21 +27,21 @@ tags: {
 
 tags: {
   html_format: AMP
-  spec_name: "amp-date-picker[type=single][mode=static]"
   tag_name: "AMP-DATE-PICKER"
+  spec_name: "amp-date-picker[type=single][mode=static]"
   requires_extension: "amp-date-picker"
+  attrs: {
+    name: "mode"
+    value_casei: "static"
+  }
+  attrs: {
+    name: "type"
+    value_casei: "single"
+  }
   attr_lists: "amp-date-picker-common-attributes"
   attr_lists: "amp-date-picker-single-type-attributes"
   attr_lists: "amp-date-picker-static-mode-attributes"
   attr_lists: "extended-amp-global"
-  attrs: {
-    name: "mode"
-    value_regex_casei: "static|"
-  }
-  attrs: {
-    name: "type"
-    value_regex_casei: "single|"
-  }
   amp_layout: {
     supported_layouts: FILL
     supported_layouts: FIXED
@@ -55,20 +55,21 @@ tags: {
 
 tags: {
   html_format: AMP
-  spec_name: "amp-date-picker[type=single][mode=overlay]"
   tag_name: "AMP-DATE-PICKER"
+  spec_name: "amp-date-picker[type=single][mode=overlay]"
   requires_extension: "amp-date-picker"
-  attr_lists: "amp-date-picker-common-attributes"
-  attr_lists: "amp-date-picker-single-type-attributes"
-  attr_lists: "extended-amp-global"
   attrs: {
     name: "mode"
+    mandatory: true
     value_casei: "overlay"
   }
   attrs: {
     name: "type"
-    value_regex_casei: "single|"
+    value_casei: "single"
   }
+  attr_lists: "amp-date-picker-common-attributes"
+  attr_lists: "amp-date-picker-single-type-attributes"
+  attr_lists: "extended-amp-global"
   amp_layout: {
     supported_layouts: CONTAINER
     supported_layouts: NODISPLAY
@@ -77,21 +78,22 @@ tags: {
 
 tags: {
   html_format: AMP
-  spec_name: "amp-date-picker[type=range][mode=static]"
   tag_name: "AMP-DATE-PICKER"
+  spec_name: "amp-date-picker[type=range][mode=static]"
   requires_extension: "amp-date-picker"
+  attrs: {
+    name: "mode"
+    value_casei: "static"
+  }
+  attrs: {
+    name: "type"
+    mandatory: true
+    value_casei: "range"
+  }
   attr_lists: "amp-date-picker-common-attributes"
   attr_lists: "amp-date-picker-range-type-attributes"
   attr_lists: "amp-date-picker-static-mode-attributes"
   attr_lists: "extended-amp-global"
-  attrs: {
-    name: "mode"
-    value_regex_casei: "static|"
-  }
-  attrs: {
-    name: "type"
-    value_casei: "range"
-  }
   amp_layout: {
     supported_layouts: FILL
     supported_layouts: FIXED
@@ -105,20 +107,22 @@ tags: {
 
 tags: {
   html_format: AMP
-  spec_name: "amp-date-picker[type=range][mode=overlay]"
   tag_name: "AMP-DATE-PICKER"
+  spec_name: "amp-date-picker[type=range][mode=overlay]"
   requires_extension: "amp-date-picker"
-  attr_lists: "amp-date-picker-common-attributes"
-  attr_lists: "amp-date-picker-range-type-attributes"
-  attr_lists: "extended-amp-global"
   attrs: {
     name: "mode"
+    mandatory: true
     value_casei: "overlay"
   }
   attrs: {
     name: "type"
+    mandatory: true
     value_casei: "range"
   }
+  attr_lists: "amp-date-picker-common-attributes"
+  attr_lists: "amp-date-picker-range-type-attributes"
+  attr_lists: "extended-amp-global"
   amp_layout: {
     supported_layouts: CONTAINER
     supported_layouts: NODISPLAY
@@ -138,7 +142,7 @@ attr_lists: {
   }
   attrs: {
     name: "first-day-of-week"
-    value_regex: "[0-9]"
+    value_regex: "[0-6]"
   }
   attrs: { name: "format" }
   attrs: { name: "highlighted" }
@@ -160,7 +164,6 @@ attr_lists: {
   }
   attrs: {
     name: "src"
-    mandatory: true
     value_url: {
       allowed_protocol: "https"
       allow_relative: true  # Will be set to false at a future date.

--- a/extensions/amp-date-picker/validator-amp-date-picker.protoascii
+++ b/extensions/amp-date-picker/validator-amp-date-picker.protoascii
@@ -15,6 +15,7 @@
 #
 
 tags: {
+  html_format: AMP
   tag_name: "SCRIPT"
   extension_spec: {
     name: "amp-date-picker"
@@ -25,63 +26,22 @@ tags: {
 }
 
 tags: {
+  html_format: AMP
   spec_name: "amp-date-picker[type=single][mode=static]"
   tag_name: "AMP-DATE-PICKER"
   requires_extension: "amp-date-picker"
-  attrs: {
-    name: "allow-blocked-ranges"
-    value: ""
-  }
-  attrs: { name: "blocked" }
-  attrs: {
-    name: "day-size"
-    value_regex: "[0-9]+"
-  }
-  attrs: {
-    name: "first-day-of-week"
-    value_regex: "[0-9]"
-  }
-  attrs: { name: "format" }
-  attrs: {
-    name: "fullscreen"
-    value: ""
-  }
-  attrs: { name: "highlighted" }
-  attrs: { name: "input-selector" }
-  attrs: { name: "locale" }
-  attrs: { name: "max" }
-  attrs: { name: "min" }
+  attr_lists: "amp-date-picker-common-attributes"
+  attr_lists: "amp-date-picker-single-type-attributes"
+  attr_lists: "amp-date-picker-static-mode-attributes"
+  attr_lists: "extended-amp-global"
   attrs: {
     name: "mode"
     value_regex_casei: "static|"
-  }
-  attrs: { name: "month-format" }
-  attrs: {
-    name: "number-of-months"
-    value_regex: "[0-9]+"
-  }
-  attrs: {
-    name: "open-after-clear"
-    value: ""
-  }
-  attrs: {
-    name: "open-after-select"
-    value: ""
-  }
-  attrs: {
-    name: "src"
-    mandatory: true
-    value_url: {
-      allowed_protocol: "https"
-      allow_relative: true  # Will be set to false at a future date.
-    }
-    blacklisted_value_regex: "__amp_source_origin"
   }
   attrs: {
     name: "type"
     value_regex_casei: "single|"
   }
-  attrs: { name: "week-day-format" }
   amp_layout: {
     supported_layouts: FILL
     supported_layouts: FIXED
@@ -94,63 +54,21 @@ tags: {
 }
 
 tags: {
+  html_format: AMP
   spec_name: "amp-date-picker[type=single][mode=overlay]"
   tag_name: "AMP-DATE-PICKER"
   requires_extension: "amp-date-picker"
-  attrs: {
-    name: "allow-blocked-ranges"
-    value: ""
-  }
-  attrs: { name: "blocked" }
-  attrs: {
-    name: "day-size"
-    value_regex: "[0-9]+"
-  }
-  attrs: {
-    name: "first-day-of-week"
-    value_regex: "[0-9]"
-  }
-  attrs: { name: "format" }
-  attrs: {
-    name: "fullscreen"
-    value: ""
-  }
-  attrs: { name: "highlighted" }
-  attrs: { name: "input-selector" }
-  attrs: { name: "locale" }
-  attrs: { name: "max" }
-  attrs: { name: "min" }
+  attr_lists: "amp-date-picker-common-attributes"
+  attr_lists: "amp-date-picker-single-type-attributes"
+  attr_lists: "extended-amp-global"
   attrs: {
     name: "mode"
     value_casei: "overlay"
-  }
-  attrs: { name: "month-format" }
-  attrs: {
-    name: "number-of-months"
-    value_regex: "[0-9]+"
-  }
-  attrs: {
-    name: "open-after-clear"
-    value: ""
-  }
-  attrs: {
-    name: "open-after-select"
-    value: ""
-  }
-  attrs: {
-    name: "src"
-    mandatory: true
-    value_url: {
-      allowed_protocol: "https"
-      allow_relative: true  # Will be set to false at a future date.
-    }
-    blacklisted_value_regex: "__amp_source_origin"
   }
   attrs: {
     name: "type"
     value_regex_casei: "single|"
   }
-  attrs: { name: "week-day-format" }
   amp_layout: {
     supported_layouts: CONTAINER
     supported_layouts: NODISPLAY
@@ -158,64 +76,22 @@ tags: {
 }
 
 tags: {
+  html_format: AMP
   spec_name: "amp-date-picker[type=range][mode=static]"
   tag_name: "AMP-DATE-PICKER"
   requires_extension: "amp-date-picker"
-  attrs: {
-    name: "allow-blocked-ranges"
-    value: ""
-  }
-  attrs: { name: "blocked" }
-  attrs: {
-    name: "day-size"
-    value_regex: "[0-9]+"
-  }
-  attrs: { name: "end-input-selector" }
-  attrs: {
-    name: "first-day-of-week"
-    value_regex: "[0-9]"
-  }
-  attrs: { name: "format" }
-  attrs: {
-    name: "fullscreen"
-    value: ""
-  }
-  attrs: { name: "highlighted" }
-  attrs: { name: "locale" }
-  attrs: { name: "max" }
-  attrs: { name: "min" }
+  attr_lists: "amp-date-picker-common-attributes"
+  attr_lists: "amp-date-picker-range-type-attributes"
+  attr_lists: "amp-date-picker-static-mode-attributes"
+  attr_lists: "extended-amp-global"
   attrs: {
     name: "mode"
     value_regex_casei: "static|"
   }
-  attrs: { name: "month-format" }
-  attrs: {
-    name: "number-of-months"
-    value_regex: "[0-9]+"
-  }
-  attrs: {
-    name: "open-after-clear"
-    value: ""
-  }
-  attrs: {
-    name: "open-after-select"
-    value: ""
-  }
-  attrs: {
-    name: "src"
-    mandatory: true
-    value_url: {
-      allowed_protocol: "https"
-      allow_relative: true  # Will be set to false at a future date.
-    }
-    blacklisted_value_regex: "__amp_source_origin"
-  }
-  attrs: { name: "start-input-selector" }
   attrs: {
     name: "type"
     value_casei: "range"
   }
-  attrs: { name: "week-day-format" }
   amp_layout: {
     supported_layouts: FILL
     supported_layouts: FIXED
@@ -227,11 +103,30 @@ tags: {
   }
 }
 
-
 tags: {
+  html_format: AMP
   spec_name: "amp-date-picker[type=range][mode=overlay]"
   tag_name: "AMP-DATE-PICKER"
   requires_extension: "amp-date-picker"
+  attr_lists: "amp-date-picker-common-attributes"
+  attr_lists: "amp-date-picker-range-type-attributes"
+  attr_lists: "extended-amp-global"
+  attrs: {
+    name: "mode"
+    value_casei: "overlay"
+  }
+  attrs: {
+    name: "type"
+    value_casei: "range"
+  }
+  amp_layout: {
+    supported_layouts: CONTAINER
+    supported_layouts: NODISPLAY
+  }
+}
+
+attr_lists: {
+  name: "amp-date-picker-common-attributes"
   attrs: {
     name: "allow-blocked-ranges"
     value: ""
@@ -241,24 +136,15 @@ tags: {
     name: "day-size"
     value_regex: "[0-9]+"
   }
-  attrs: { name: "end-input-selector" }
   attrs: {
     name: "first-day-of-week"
     value_regex: "[0-9]"
   }
   attrs: { name: "format" }
-  attrs: {
-    name: "fullscreen"
-    value: ""
-  }
   attrs: { name: "highlighted" }
   attrs: { name: "locale" }
   attrs: { name: "max" }
   attrs: { name: "min" }
-  attrs: {
-    name: "mode"
-    value_casei: "overlay"
-  }
   attrs: { name: "month-format" }
   attrs: {
     name: "number-of-months"
@@ -281,14 +167,24 @@ tags: {
     }
     blacklisted_value_regex: "__amp_source_origin"
   }
-  attrs: { name: "start-input-selector" }
-  attrs: {
-    name: "type"
-    value_casei: "range"
-  }
   attrs: { name: "week-day-format" }
-  amp_layout: {
-    supported_layouts: CONTAINER
-    supported_layouts: NODISPLAY
+}
+
+attr_lists: {
+  name: "amp-date-picker-range-type-attributes"
+  attrs: { name: "end-input-selector" }
+  attrs: { name: "start-input-selector" }
+}
+
+attr_lists: {
+  name: "amp-date-picker-single-type-attributes"
+  attrs: { name: "input-selector" }
+}
+
+attr_lists: {
+  name: "amp-date-picker-static-mode-attributes"
+  attrs: {
+    name: "fullscreen"
+    value: ""
   }
 }

--- a/extensions/amp-date-picker/validator-amp-date-picker.protoascii
+++ b/extensions/amp-date-picker/validator-amp-date-picker.protoascii
@@ -153,6 +153,7 @@ tags: {
   attrs: { name: "week-day-format" }
   amp_layout: {
     supported_layouts: CONTAINER
+    supported_layouts: NODISPLAY
   }
 }
 
@@ -288,5 +289,6 @@ tags: {
   attrs: { name: "week-day-format" }
   amp_layout: {
     supported_layouts: CONTAINER
+    supported_layouts: NODISPLAY
   }
 }

--- a/extensions/amp-date-picker/validator-amp-date-picker.protoascii
+++ b/extensions/amp-date-picker/validator-amp-date-picker.protoascii
@@ -14,7 +14,7 @@
 # limitations under the license.
 #
 
-tags: {  # amp-date-picker
+tags: {
   tag_name: "SCRIPT"
   extension_spec: {
     name: "amp-date-picker"
@@ -23,42 +23,49 @@ tags: {  # amp-date-picker
   }
   attr_lists: "common-extension-attrs"
 }
-tags: {  # <amp-date-picker>
+
+tags: {
+  spec_name: "amp-date-picker[type=single][mode=static]"
   tag_name: "AMP-DATE-PICKER"
   requires_extension: "amp-date-picker"
   attrs: {
-    name: "mode"
-    value_regex: "overlay|static|"
+    name: "allow-blocked-ranges"
+    value: ""
   }
+  attrs: { name: "blocked" }
   attrs: {
-    name: "type"
-    value_regex: "range|single|"
-  }
-  attrs: { name: "input-selector" }
-  attrs: { name: "start-date-selector" }
-  attrs: { name: "end-date-selector" }
-  attrs: { name: "min" }
-  attrs: { name: "max" }
-  attrs: { name: "month-format" }
-  attrs: { name: "format" }
-  attrs: { name: "week-day-format" }
-  attrs: { name: "locale" }
-  attrs: {
-    name: "number-of-months"
+    name: "day-size"
     value_regex: "[0-9]+"
   }
   attrs: {
     name: "first-day-of-week"
     value_regex: "[0-9]"
   }
-  attrs: { name: "blocked" }
-  attrs: { name: "highlighted" }
+  attrs: { name: "format" }
   attrs: {
-    name: "day-size"
+    name: "fullscreen"
+    value: ""
+  }
+  attrs: { name: "highlighted" }
+  attrs: { name: "input-selector" }
+  attrs: { name: "locale" }
+  attrs: { name: "max" }
+  attrs: { name: "min" }
+  attrs: {
+    name: "mode"
+    value_regex_casei: "static|"
+  }
+  attrs: { name: "month-format" }
+  attrs: {
+    name: "number-of-months"
     value_regex: "[0-9]+"
   }
   attrs: {
-    name: "allow-blocked-ranges"
+    name: "open-after-clear"
+    value: ""
+  }
+  attrs: {
+    name: "open-after-select"
     value: ""
   }
   attrs: {
@@ -71,17 +78,10 @@ tags: {  # <amp-date-picker>
     blacklisted_value_regex: "__amp_source_origin"
   }
   attrs: {
-    name: "fullscreen"
-    value: ""
+    name: "type"
+    value_regex_casei: "single|"
   }
-  attrs: {
-    name: "open-after-select"
-    value: ""
-  }
-  attrs: {
-    name: "open-after-clear"
-    value: ""
-  }
+  attrs: { name: "week-day-format" }
   amp_layout: {
     supported_layouts: FILL
     supported_layouts: FIXED
@@ -90,6 +90,203 @@ tags: {  # <amp-date-picker>
     supported_layouts: INTRINSIC
     supported_layouts: NODISPLAY
     supported_layouts: RESPONSIVE
+  }
+}
+
+tags: {
+  spec_name: "amp-date-picker[type=single][mode=overlay]"
+  tag_name: "AMP-DATE-PICKER"
+  requires_extension: "amp-date-picker"
+  attrs: {
+    name: "allow-blocked-ranges"
+    value: ""
+  }
+  attrs: { name: "blocked" }
+  attrs: {
+    name: "day-size"
+    value_regex: "[0-9]+"
+  }
+  attrs: {
+    name: "first-day-of-week"
+    value_regex: "[0-9]"
+  }
+  attrs: { name: "format" }
+  attrs: {
+    name: "fullscreen"
+    value: ""
+  }
+  attrs: { name: "highlighted" }
+  attrs: { name: "input-selector" }
+  attrs: { name: "locale" }
+  attrs: { name: "max" }
+  attrs: { name: "min" }
+  attrs: {
+    name: "mode"
+    value_casei: "overlay"
+  }
+  attrs: { name: "month-format" }
+  attrs: {
+    name: "number-of-months"
+    value_regex: "[0-9]+"
+  }
+  attrs: {
+    name: "open-after-clear"
+    value: ""
+  }
+  attrs: {
+    name: "open-after-select"
+    value: ""
+  }
+  attrs: {
+    name: "src"
+    mandatory: true
+    value_url: {
+      allowed_protocol: "https"
+      allow_relative: true  # Will be set to false at a future date.
+    }
+    blacklisted_value_regex: "__amp_source_origin"
+  }
+  attrs: {
+    name: "type"
+    value_regex_casei: "single|"
+  }
+  attrs: { name: "week-day-format" }
+  amp_layout: {
+    supported_layouts: CONTAINER
+  }
+}
+
+tags: {
+  spec_name: "amp-date-picker[type=range][mode=static]"
+  tag_name: "AMP-DATE-PICKER"
+  requires_extension: "amp-date-picker"
+  attrs: {
+    name: "allow-blocked-ranges"
+    value: ""
+  }
+  attrs: { name: "blocked" }
+  attrs: {
+    name: "day-size"
+    value_regex: "[0-9]+"
+  }
+  attrs: { name: "end-input-selector" }
+  attrs: {
+    name: "first-day-of-week"
+    value_regex: "[0-9]"
+  }
+  attrs: { name: "format" }
+  attrs: {
+    name: "fullscreen"
+    value: ""
+  }
+  attrs: { name: "highlighted" }
+  attrs: { name: "locale" }
+  attrs: { name: "max" }
+  attrs: { name: "min" }
+  attrs: {
+    name: "mode"
+    value_regex_casei: "static|"
+  }
+  attrs: { name: "month-format" }
+  attrs: {
+    name: "number-of-months"
+    value_regex: "[0-9]+"
+  }
+  attrs: {
+    name: "open-after-clear"
+    value: ""
+  }
+  attrs: {
+    name: "open-after-select"
+    value: ""
+  }
+  attrs: {
+    name: "src"
+    mandatory: true
+    value_url: {
+      allowed_protocol: "https"
+      allow_relative: true  # Will be set to false at a future date.
+    }
+    blacklisted_value_regex: "__amp_source_origin"
+  }
+  attrs: { name: "start-input-selector" }
+  attrs: {
+    name: "type"
+    value_casei: "range"
+  }
+  attrs: { name: "week-day-format" }
+  amp_layout: {
+    supported_layouts: FILL
+    supported_layouts: FIXED
+    supported_layouts: FIXED_HEIGHT
+    supported_layouts: FLEX_ITEM
+    supported_layouts: INTRINSIC
+    supported_layouts: NODISPLAY
+    supported_layouts: RESPONSIVE
+  }
+}
+
+
+tags: {
+  spec_name: "amp-date-picker[type=range][mode=overlay]"
+  tag_name: "AMP-DATE-PICKER"
+  requires_extension: "amp-date-picker"
+  attrs: {
+    name: "allow-blocked-ranges"
+    value: ""
+  }
+  attrs: { name: "blocked" }
+  attrs: {
+    name: "day-size"
+    value_regex: "[0-9]+"
+  }
+  attrs: { name: "end-input-selector" }
+  attrs: {
+    name: "first-day-of-week"
+    value_regex: "[0-9]"
+  }
+  attrs: { name: "format" }
+  attrs: {
+    name: "fullscreen"
+    value: ""
+  }
+  attrs: { name: "highlighted" }
+  attrs: { name: "locale" }
+  attrs: { name: "max" }
+  attrs: { name: "min" }
+  attrs: {
+    name: "mode"
+    value_casei: "overlay"
+  }
+  attrs: { name: "month-format" }
+  attrs: {
+    name: "number-of-months"
+    value_regex: "[0-9]+"
+  }
+  attrs: {
+    name: "open-after-clear"
+    value: ""
+  }
+  attrs: {
+    name: "open-after-select"
+    value: ""
+  }
+  attrs: {
+    name: "src"
+    mandatory: true
+    value_url: {
+      allowed_protocol: "https"
+      allow_relative: true  # Will be set to false at a future date.
+    }
+    blacklisted_value_regex: "__amp_source_origin"
+  }
+  attrs: { name: "start-input-selector" }
+  attrs: {
+    name: "type"
+    value_casei: "range"
+  }
+  attrs: { name: "week-day-format" }
+  amp_layout: {
     supported_layouts: CONTAINER
   }
 }


### PR DESCRIPTION
Simple validation rules for the date picker.

Some attributes only make sense for the single date picker (`type="single"`) or for the date range picker (`type="range"). To simplify the validator protoascii structure, I enforce those with runtime errors.