### PR TITLE
🏗 Print logs from chromedriver when visual diff tests fail

### DIFF
--- a/build-system/exec.js
+++ b/build-system/exec.js
@@ -36,12 +36,13 @@ function spawnProcess(cmd, options) {
 }
 
 /**
- * Executes the provided command.
+ * Executes the provided command, returning the process object.
  *
  * @param {string} cmd Command line to execute.
+ * @return {<Object>} Process info.
  */
 exports.exec = function(cmd) {
-  spawnProcess(cmd, {'stdio': 'inherit'});
+  return spawnProcess(cmd, {'stdio': 'inherit'});
 };
 
 /**

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -65,11 +65,13 @@ function stopTimer(functionName, startTime) {
 /**
  * Executes the provided command and times it. Errors, if any, are printed.
  * @param {string} cmd
+ * @return {<Object>} Process info.
  */
 function timedExec(cmd) {
   const startTime = startTimer(cmd);
-  exec(cmd);
+  const p = exec(cmd);
   stopTimer(cmd, startTime);
+  return p;
 }
 
 /**
@@ -328,7 +330,14 @@ const command = {
     } else if (opt_mode === 'master') {
       cmd += ' --master';
     }
-    timedExec(cmd);
+    const status = timedExec(cmd).status;
+    if (status != 0) {
+      console.error(fileLogPrefix, colors.red('ERROR:'),
+          'Found errors while running', colors.cyan(cmd) +
+          '. Here are the last 100 lines from',
+          colors.cyan('chromedriver.log') + ':\n');
+      exec('tail -n 100 chromedriver.log');
+    }
   },
   verifyVisualDiffTests: function() {
     if (!process.env.PERCY_PROJECT || !process.env.PERCY_TOKEN) {

--- a/build-system/tasks/visual-diff.rb
+++ b/build-system/tasks/visual-diff.rb
@@ -225,21 +225,8 @@ def load_visual_tests_config_json
 end
 
 
-# Make the visual tests more resilient to Selenium read timeouts. See #13700.
-def configure_browser_timeout
-  RSpec.configure do |config|
-    if ARGV.include? '--chrome_debug'
-      config.verbose_retry = true
-    end
-    config.default_retry_count = 2
-    config.exceptions_to_retry = [Net::ReadTimeout]
-  end
-end
-
-
 # Configures the Chrome browser (optionally in headless mode)
 def configure_browser
-  configure_browser_timeout
   if ARGV.include? '--headless'
     chrome_args = %w[--no-sandbox --disable-extensions --headless --disable-gpu]
   else
@@ -265,7 +252,8 @@ def configure_browser
       app,
       browser: :chrome,
       http_client: http_client,
-      options: options
+      options: options,
+      driver_opts: {log_path: 'chromedriver.log'}
     )
   end
   Capybara.default_driver = :chrome


### PR DESCRIPTION
We're trying to get to the bottom of some selenium errors while running the visual tests. They've been elusive while debugging, but appear frequently in the wild.

This PR prints the last 100 lines from `chromedriver.log` when failures do occur. It also cleans up an earlier fix that didn't work.

To aid in the debugging of #13700 