### PR TITLE
Fix elementHeight, elementWidth for ads

### DIFF
--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -626,7 +626,7 @@ export class AmpAnalytics extends AMP.BaseElement {
           requests[k] = new RequestHandler(
               this.getAmpDoc(), request, this.preconnect,
               this.sendRequest_.bind(this),
-              this.isSandbox_);
+              this.isSandbox_, this.element);
         }
       }
       this.requests_ = requests;

--- a/extensions/amp-analytics/0.1/requests.js
+++ b/extensions/amp-analytics/0.1/requests.js
@@ -41,8 +41,10 @@ export class RequestHandler {
    * @param {!../../../src/preconnect.Preconnect} preconnect
    * @param {function(string, !JsonObject)} handler
    * @param {boolean} isSandbox
+   * @param {!AmpElement} ampAnalyticsElement
    */
-  constructor(ampdoc, request, preconnect, handler, isSandbox) {
+  constructor(ampdoc, request, preconnect, handler, isSandbox,
+    ampAnalyticsElement) {
 
     /** @const {!Window} */
     this.win = ampdoc.win;
@@ -75,7 +77,8 @@ export class RequestHandler {
     this.variableService_ = variableServiceFor(this.win);
 
     /** @private {!../../../src/service/url-replacements-impl.UrlReplacements} */
-    this.urlReplacementService_ = Services.urlReplacementsForDoc(ampdoc);
+    this.urlReplacementService_ =
+        Services.urlReplacementsForDoc(ampAnalyticsElement);
 
     /** @private {?Promise<string>} */
     this.baseUrlPromise_ = null;


### PR DESCRIPTION
${elementWidth} and ${elementHeight} give the size of the amp-ad element. But if the ad that fills the slot is smaller than the available space, it still gives the size of the slot. We want the size of the creative document. There is no reason for the ad to know that it doesn't completely fill the slot.

Fixes #12954
