### PR TITLE
Update lightbox launch test images to medium resolution

### DIFF
--- a/test/manual/amp-lightbox-gallery-launch.amp.html
+++ b/test/manual/amp-lightbox-gallery-launch.amp.html
@@ -37,34 +37,35 @@
   </script>
 
   <h1>Lightbox Carousel Description Test</h1>
-  <amp-img src="https://images.unsplash.com/photo-1503843778847-2b8bdce2ed3d"
+  <p>The following images belong to the default lightbox group. </p>
+  <amp-img src="https://picsum.photos/1600/900?image=107"
     aria-describedby="longest-description"
     lightbox
-    width="300"
-    height="200"
+    width="400"
+    height="225"
     alt="a beautiful cat"></amp-img>
 
-  <amp-img src="https://images.unsplash.com/photo-1503843778847-2b8bdce2ed3d"
+  <amp-img src="https://picsum.photos/1600/900?image=108"
     aria-describedby="medium-description"
     lightbox
-    width="300"
-    height="200"
+    width="400"
+    height="225"
     alt="a beautiful cat"></amp-img>
 
-  <amp-img src="https://images.unsplash.com/photo-1503843778847-2b8bdce2ed3d"
+  <amp-img src="https://picsum.photos/1600/900?image=109"
     lightbox
-    width="300"
-    height="200"></amp-img>
+    width="400"
+    height="225"></amp-img>
 
   <amp-carousel
-    height="300"
     width="400"
+    height="300"
     layout="fixed"
     type="slides"
     lightbox>
-    <amp-img src="https://images.unsplash.com/photo-1503843778847-2b8bdce2ed3d"
-      width="300"
-      height="200"
+    <amp-img src="https://picsum.photos/1600/900?image=110"
+      width="400"
+      height="225"
       alt="a beautiful cat"></amp-img>
     <amp-anim
       role="button"
@@ -74,23 +75,23 @@
       src="https://lh3.googleusercontent.com/qNn8GDz8Jfd-s9lt3Nc4lJeLjVyEaqGJTk1vuCUWazCmAeOBVjSWDD0SMTU7x0zhVe5UzOTKR0n-kN4SXx7yElvpKYvCMaRyS_g-jydhJ_cEVYmYPiZ_j1Y9de43mlKxU6s06uK1NAlpbSkL_046amEKOdgIACICkuWfOBwlw2hUDfjPOWskeyMrcTu8XOEerCLuVqXugG31QC345hz3lUyOlkdT9fMYVUynSERGNzHba7bXMOxKRe3izS5DIWUgJs3oeKYqA-V8iqgCvneD1jj0Ff68V_ajm4BDchQubBJU0ytXVkoWh27ngeEHubpnApOS6fcGsjPxeuMjnzAUtoTsiXz2FZi1mMrxrblJ-kZoAq1DJ95cnoqoa2CYq3BTgq2E8BRe2paNxLJ5GXBCTpNdXMpVJc6eD7ceijQyn-2qanilX-iK3ChbOq0uBHMvsdoC_LsFOu5KzbbNH71vM3DPkvDGmHJmF67Vj8sQ6uBrLnzpYlCyN4-Y9frR8zugDcqX5Q=w400-h300-no" width="400" height="300">
     </amp-anim>
     <figure>
-        <amp-img src="https://images.unsplash.com/photo-1515002246390-7bf7e8f87b54"
-        width="300"
-        height="200"
+        <amp-img src="https://picsum.photos/1600/900?image=111"
+        width="400"
+        height="225"
         alt="another beautiful cat"></amp-img>
         <figcaption>This is a figure with a figcaption.</figcaption>
     </figure>
-    <amp-img src="https://images.unsplash.com/photo-1445499348736-29b6cdfc03b9"
-      width="300"
-      height="200"
+    <amp-img src="https://picsum.photos/1600/900?image=110"
+      width="400"
+      height="225"
       aria-label="Aria labels are cool."></amp-img>
-    <amp-img src="https://images.unsplash.com/photo-1482066490729-6f26115b60dc"
-      width="300"
-      height="200"
+    <amp-img src="https://picsum.photos/1600/900?image=112"
+      width="400"
+      height="225"
       aria-describedby="my-aria-describe"></amp-img>
-    <amp-img src="https://images.unsplash.com/photo-1511275539165-cc46b1ee89bf"
-      width="300"
-      height="200"
+    <amp-img src="https://picsum.photos/1600/900?image=113"
+      width="400"
+      height="225"
       aria-labelledby="my-aria-label"></amp-img>
   </amp-carousel>
 
@@ -104,14 +105,15 @@
     <li>Fixed Height</li>
     <li>Fixed</li>
   </ul>
-  <amp-carousel height="600"
-  width="800"
-  layout="fixed"
-  type="slides"
-  lightbox>
-    <amp-img src="https://images.unsplash.com/photo-1503843778847-2b8bdce2ed3d"
-      width="600"
-      height="400"
+  <amp-carousel
+    width="800"
+    height="450"
+    layout="fixed"
+    type="slides"
+    lightbox>
+    <amp-img src="https://picsum.photos/1600/900?image=114"
+      width="800"
+      height="450"
       alt="a beautiful cat"></amp-img>
     <amp-video
       src="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4"
@@ -137,22 +139,22 @@
       layout="fill"
       poster="https://i.ytimg.com/vi/5Yjoe54vzwE/mqdefault.jpg"
       controls>
-  </amp-video>
-  <amp-video
-    src="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4"
-    height="204"
-    layout="fixed-height"
-    poster="https://i.ytimg.com/vi/5Yjoe54vzwE/mqdefault.jpg"
-    controls>
-  </amp-video>
-  <amp-video
-    src="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4"
-    width="358"
-    height="204"
-    layout="fixed"
-    poster="https://i.ytimg.com/vi/5Yjoe54vzwE/mqdefault.jpg"
-    controls>
-  </amp-video>
+    </amp-video>
+    <amp-video
+      src="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4"
+      height="204"
+      layout="fixed-height"
+      poster="https://i.ytimg.com/vi/5Yjoe54vzwE/mqdefault.jpg"
+      controls>
+    </amp-video>
+    <amp-video
+      src="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4"
+      width="358"
+      height="204"
+      layout="fixed"
+      poster="https://i.ytimg.com/vi/5Yjoe54vzwE/mqdefault.jpg"
+      controls>
+    </amp-video>
   </amp-carousel>
 
   <h2>AMP-YOUTUBE Layout Test</h2>
@@ -164,14 +166,15 @@
     <li>Fixed Height</li>
     <li>Fixed</li>
   </ul>
-  <amp-carousel height="600"
+  <amp-carousel
     width="800"
+    height="600"
     layout="fixed"
     type="slides"
     lightbox>
-    <amp-img src="https://images.unsplash.com/photo-1503843778847-2b8bdce2ed3d"
-      width="600"
-      height="400"
+    <amp-img src="https://picsum.photos/1600/900?image=115"
+      width="800"
+      height="450"
       alt="a beautiful cat"></amp-img>
     <amp-youtube width="480"
       height="270"
@@ -207,14 +210,15 @@
   </amp-carousel>
 
   <h1>Lightbox Carousel Ads Support Test</h1>
-  <amp-carousel height="600"
+  <amp-carousel
     width="800"
+    height="600"
     layout="fixed"
     type="slides"
     lightbox>
-    <amp-img src="https://images.unsplash.com/photo-1503843778847-2b8bdce2ed3d"
-      width="600"
-      height="400"
+    <amp-img src="https://picsum.photos/1600/900?image=300"
+      width="800"
+      height="450"
       alt="a beautiful cat"></amp-img>
     <amp-ad width="300"
       height="250"
@@ -241,14 +245,14 @@
     <li>Fixed</li>
   </ul>
   <amp-carousel
-    height="600"
     width="800"
+    height="600"
     layout="fixed"
     type="slides"
     lightbox>
-    <amp-img src="https://images.unsplash.com/photo-1503843778847-2b8bdce2ed3d"
-      width="600"
-      height="400"
+    <amp-img src="https://picsum.photos/1600/900?image=115"
+      width="800"
+      height="450"
       alt="a beautiful cat"></amp-img>
     <amp-instagram data-shortcode="1totVhIFXl"
       width="400"
@@ -279,14 +283,15 @@
     <li>Fixed Height</li>
     <li>Fixed</li>
   </ul>
-  <amp-carousel height="600"
+  <amp-carousel
     width="800"
+    height="600"
     layout="fixed"
     type="slides"
     lightbox>
-    <amp-img src="https://images.unsplash.com/photo-1503843778847-2b8bdce2ed3d"
-      width="600"
-      height="400"
+    <amp-img src="https://picsum.photos/1600/900?image=116"
+      width="800"
+      height="450"
       alt="a beautiful cat"></amp-img>
     <amp-facebook
       lightbox-thumbnail-id="fb-thumbnail-img"
@@ -330,9 +335,9 @@
     layout="fixed"
     type="slides"
     lightbox>
-    <amp-img src="https://images.unsplash.com/photo-1503843778847-2b8bdce2ed3d"
-      width="600"
-      height="400"
+    <amp-img src="https://picsum.photos/1600/900?image=117"
+      width="800"
+      height="450"
       alt="a beautiful cat"></amp-img>
     <amp-facebook
       width="552"
@@ -367,9 +372,9 @@
   <h2>Lightbox Group Test</h2>
   <h3>Test 1</h3>
   <p>The following image and youtube video should belong to the same lightbox group. The lightbox group should include a third image from the carousel in Test 3 below. </p>
-  <amp-img src="https://images.unsplash.com/photo-1503843778847-2b8bdce2ed3d"
-    width="300"
-    height="200"
+  <amp-img src="https://picsum.photos/1600/900?image=118"
+    width="400"
+    height="225"
     lightbox="group-1"
     alt="a beautiful cat"></amp-img>
   <amp-youtube lightbox="group-1"
@@ -379,35 +384,36 @@
     data-videoid="lBTCB7yLs8Y">
   </amp-youtube>
   <h3>Test 2</h3>
-  <p>The following image should belong to its own lightbox group. </p>
-  <amp-img src="https://images.unsplash.com/photo-1445499348736-29b6cdfc03b9"
-    width="300"
-    height="200"
+  <p>The following image should belong to the default lightbox group. </p>
+  <amp-img src="https://picsum.photos/1600/900?image=119"
+    width="400"
+    height="225"
     lightbox
     aria-label="Aria labels are cool."></amp-img>
   <h3>Test 3</h3>
   <p>In the following carousel, images 2 and 4 should be excluded from the lightbox. Image 4 should belong to the lightbox group in Test 1.</p>
-  <amp-carousel height="300"
+  <amp-carousel
     width="400"
+    height="300"
     layout="fixed"
     type="slides"
     lightbox>
-    <amp-img src="https://images.unsplash.com/photo-1503843778847-2b8bdce2ed3d"
-      width="300"
-      height="200"
+    <amp-img src="https://picsum.photos/1600/900?image=120"
+      width="400"
+      height="225"
       alt="a beautiful cat"></amp-img>
-    <amp-img src="https://images.unsplash.com/photo-1445499348736-29b6cdfc03b9"
-      width="300"
-      height="200"
+    <amp-img src="https://picsum.photos/1600/900?image=121"
+      width="400"
+      height="225"
       lightbox-exclude
       aria-label="Aria labels are cool."></amp-img>
-    <amp-img src="https://images.unsplash.com/photo-1482066490729-6f26115b60dc"
-      width="300"
-      height="200"
+    <amp-img src="https://picsum.photos/1600/900?image=122"
+      width="400"
+      height="225"
       aria-describedby="my-aria-describe"></amp-img>
-    <amp-img src="https://images.unsplash.com/photo-1511275539165-cc46b1ee89bf"
-      width="300"
-      height="200"
+    <amp-img src="https://picsum.photos/1600/900?image=123"
+      width="400"
+      height="225"
       lightbox="group-1"
       aria-labelledby="my-aria-label"></amp-img>
   </amp-carousel>


### PR DESCRIPTION
I accidentally used images that were in the order of 6k x 4k pixels, which caused zoom performance to be ridiculously slow on Android. This is good to know but doesn't help with general QA / bug bashing otherwise, so reverting to reasonable resolution images for next round of QA. 