### PR TITLE
Pass story navigation through store

### DIFF
--- a/extensions/amp-story/0.1/amp-story-store-service.js
+++ b/extensions/amp-story/0.1/amp-story-store-service.js
@@ -31,6 +31,7 @@ const TAG = 'amp-story';
  *    canshowpreviouspagehelp: boolean,
  *    canshowsystemlayerbuttons: boolean,
  *    bookendstate: boolean,
+ *    currentpage: string,
  * }}
  */
 export let State;
@@ -47,12 +48,14 @@ export const StateProperty = {
 
   // App States.
   BOOKEND_STATE: 'bookendstate',
+  CURRENT_PAGE: 'currentpage',
 };
 
 
 /** @private @const @enum {string} */
 export const Action = {
   TOGGLE_BOOKEND: 'togglebookend',
+  PAGE_CHANGE: 'pagechange',
 };
 
 
@@ -71,6 +74,9 @@ const actions = (state, action, data) => {
       }
       return /** @type {!State} */ (Object.assign(
           {}, state, {[StateProperty.BOOKEND_STATE]: !!data}));
+    case Action.PAGE_CHANGE:
+      return /** @type {!State} */ (Object.assign(
+          {}, state, {[StateProperty.CURRENT_PAGE]: data}));
     default:
       dev().error(TAG, `Unknown action ${action}.`);
       return state;
@@ -155,6 +161,7 @@ export class AmpStoryStoreService {
       [StateProperty.CAN_SHOW_PREVIOUS_PAGE_HELP]: true,
       [StateProperty.CAN_SHOW_SYSTEM_LAYER_BUTTONS]: true,
       [StateProperty.BOOKEND_STATE]: false,
+      [StateProperty.CURRENT_PAGE]: '',
     });
   }
 

--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -417,13 +417,13 @@ export class AmpStory extends AMP.BaseElement {
       this.audioStopped_();
     });
 
-    this.element.addEventListener(EventType.SWITCH_PAGE, e => {
+    this.storeService_.subscribe(StateProperty.CURRENT_PAGE, pageId => {
       if (this.storeService_.get(StateProperty.BOOKEND_STATE)) {
         // Disallow switching pages while the bookend is active.
         return;
       }
 
-      this.switchTo_(e.detail.targetPageId);
+      this.switchTo_(pageId);
       this.ampStoryHint_.hideAllNavigationHint();
     });
 
@@ -620,9 +620,9 @@ export class AmpStory extends AMP.BaseElement {
             page.setActive(false);
           });
         })
-        .then(() => this.switchTo_(firstPageEl.id))
+        .then(() => this.storeService_.dispatch(Action.PAGE_CHANGE,
+            firstPageEl.id))
         .then(() => this.preloadPagesByDistance_());
-
     // Do not block the layout callback on the completion of these promises, as
     // that prevents descendents from being laid out (and therefore loaded).
     storyLayoutPromise.then(() => this.whenPagesLoaded_(PAGE_LOAD_TIMEOUT_MS))
@@ -1568,7 +1568,8 @@ export class AmpStory extends AMP.BaseElement {
     if (this.bookend_.isActive()) {
       this.hideBookend_();
     }
-    this.switchTo_(dev().assertElement(this.pages_[0].element).id);
+    const pageId = dev().assertElement(this.pages_[0].element).id;
+    this.storeService_.dispatch(Action.PAGE_CHANGE, pageId);
   }
 
   /** @return {!NavigationState} */


### PR DESCRIPTION
Make all navigation flow through the store so that we have a source of truth. Lessen ping-pong between story and page.
