### PR TITLE
Adding the muted state to the store.

### DIFF
--- a/extensions/amp-story/0.1/amp-story-store-service.js
+++ b/extensions/amp-story/0.1/amp-story-store-service.js
@@ -47,12 +47,14 @@ export const StateProperty = {
 
   // App States.
   BOOKEND_STATE: 'bookendstate',
+  MUTED_STATE: 'mutedstate',
 };
 
 
 /** @private @const @enum {string} */
 export const Action = {
   TOGGLE_BOOKEND: 'togglebookend',
+  TOGGLE_MUTED: 'togglemuted',
 };
 
 
@@ -71,6 +73,9 @@ const actions = (state, action, data) => {
       }
       return /** @type {!State} */ (Object.assign(
           {}, state, {[StateProperty.BOOKEND_STATE]: !!data}));
+    case Action.TOGGLE_MUTED:
+      return /** @type {!State} */ (Object.assign(
+          {}, state, {[StateProperty.MUTED_STATE]: !!data}));
     default:
       dev().error(TAG, `Unknown action ${action}.`);
       return state;
@@ -155,6 +160,7 @@ export class AmpStoryStoreService {
       [StateProperty.CAN_SHOW_PREVIOUS_PAGE_HELP]: true,
       [StateProperty.CAN_SHOW_SYSTEM_LAYER_BUTTONS]: true,
       [StateProperty.BOOKEND_STATE]: false,
+      [StateProperty.MUTED_STATE]: true,
     });
   }
 

--- a/extensions/amp-story/0.1/amp-story-store-service.js
+++ b/extensions/amp-story/0.1/amp-story-store-service.js
@@ -31,6 +31,7 @@ const TAG = 'amp-story';
  *    canshowpreviouspagehelp: boolean,
  *    canshowsystemlayerbuttons: boolean,
  *    bookendstate: boolean,
+ *    mutedstate: boolean,
  * }}
  */
 export let State;

--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -1398,6 +1398,7 @@ export class AmpStory extends AMP.BaseElement {
   /**
    * Reacts to muted state updates.
    * @param  {boolean} isMuted Whether the story just got muted.
+   * @private
    */
   onMutedStateUpdate_(isMuted) {
     isMuted ? this.mute_() : this.unmute_();

--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -346,6 +346,7 @@ export class AmpStory extends AMP.BaseElement {
       this.variableService_.onStateChange(stateChangeEvent));
 
     // Mute `amp-story` in beginning.
+    // TODO(gmajoulet): Support unmuted embed mode option.
     this.mute_();
   }
 
@@ -393,20 +394,8 @@ export class AmpStory extends AMP.BaseElement {
       this.previous_();
     });
 
-    this.element.addEventListener(EventType.MUTE, () => {
-      this.mute_();
-    });
-
-    this.element.addEventListener(EventType.UNMUTE, () => {
-      this.unmute_();
-    });
-
-    this.element.addEventListener(EventType.AUDIO_PLAYING, () => {
-      this.audioPlaying_();
-    });
-
-    this.element.addEventListener(EventType.AUDIO_STOPPED, () => {
-      this.audioStopped_();
+    this.storeService_.subscribe(StateProperty.MUTED_STATE, isMuted => {
+      this.onMutedStateUpdate_(isMuted);
     });
 
     this.element.addEventListener(EventType.SWITCH_PAGE, e => {
@@ -1407,6 +1396,14 @@ export class AmpStory extends AMP.BaseElement {
   }
 
   /**
+   * Reacts to muted state updates.
+   * @param  {boolean} isMuted Whether the story just got muted.
+   */
+  onMutedStateUpdate_(isMuted) {
+    isMuted ? this.mute_() : this.unmute_();
+  }
+
+  /**
    * Mutes the audio for the story.
    * @private
    */
@@ -1486,24 +1483,8 @@ export class AmpStory extends AMP.BaseElement {
     const hasStoryAudio = this.element.hasAttribute('background-audio');
 
     if (containsMediaElement || hasStoryAudio) {
-      this.audioPlaying_();
+      this.element.classList.add('audio-playing');
     }
-  }
-
-  /**
-   * Marks the story as having audio playing on the active page.
-   * @private
-   */
-  audioPlaying_() {
-    this.element.classList.add('audio-playing');
-  }
-
-  /**
-   * Marks the story as not having audio playing on the active page.
-   * @private
-   */
-  audioStopped_() {
-    this.element.classList.remove('audio-playing');
   }
 
   /** @private */

--- a/extensions/amp-story/0.1/events.js
+++ b/extensions/amp-story/0.1/events.js
@@ -25,12 +25,6 @@ export const EventType = {
   // Triggered when the user unmutes the story
   UNMUTE: 'ampstory:unmute',
 
-  // Triggered when there are audio sources playing on the active page
-  AUDIO_PLAYING: 'ampstory:audioplaying',
-
-  // Triggered when there are no audio sources playing on the active page
-  AUDIO_STOPPED: 'ampstory:audiostopped',
-
   // Triggered when the story should switch to a specified page
   SWITCH_PAGE: 'ampstory:switchpage',
 

--- a/extensions/amp-story/0.1/system-layer.js
+++ b/extensions/amp-story/0.1/system-layer.js
@@ -13,11 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import {Action, StateProperty} from './amp-story-store-service';
 import {DevelopmentModeLog, DevelopmentModeLogButtonSet} from './development-ui';
-import {EventType, dispatch} from './events';
 import {ProgressBar} from './progress-bar';
 import {Services} from '../../../src/services';
-import {StateProperty} from './amp-story-store-service';
 import {dev} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {getMode} from '../../../src/mode';
@@ -102,12 +101,6 @@ export class SystemLayer {
     this.root_ = null;
 
     /** @private {?Element} */
-    this.muteAudioBtn_ = null;
-
-    /** @private {?Element} */
-    this.unmuteAudioBtn_ = null;
-
-    /** @private {?Element} */
     this.leftButtonTray_ = null;
 
     /** @private @const {!ProgressBar} */
@@ -144,7 +137,7 @@ export class SystemLayer {
 
     this.buildForDevelopmentMode_();
 
-    this.addEventHandlers_();
+    this.initializeListeners_();
 
     // TODO(newmuis): Observe this value.
     if (!this.storeService_.get(StateProperty.CAN_SHOW_SYSTEM_LAYER_BUTTONS)) {
@@ -170,19 +163,18 @@ export class SystemLayer {
   /**
    * @private
    */
-  addEventHandlers_() {
+  initializeListeners_() {
     // TODO(alanorozco): Listen to tap event properly (i.e. fastclick)
-    this.root_.addEventListener('click', e => {
-      const target = dev().assertElement(e.target);
+    this.root_.addEventListener('click', event => {
+      const target = dev().assertElement(event.target);
 
       if (matches(target, `.${MUTE_CLASS}, .${MUTE_CLASS} *`)) {
-        this.onMuteAudioClick_(e);
+        this.onMuteAudioClick_();
       } else if (matches(target, `.${UNMUTE_CLASS}, .${UNMUTE_CLASS} *`)) {
-        this.onUnmuteAudioClick_(e);
+        this.onUnmuteAudioClick_();
       }
     });
   }
-
 
   /**
    * @return {!Element}
@@ -192,32 +184,19 @@ export class SystemLayer {
   }
 
   /**
-   * @param {!Event} e
+   * Handles click events on the mute button.
    * @private
    */
-  onMuteAudioClick_(e) {
-    this.dispatch_(EventType.MUTE, e);
+  onMuteAudioClick_() {
+    this.storeService_.dispatch(Action.TOGGLE_MUTED, true);
   }
 
   /**
-   * @param {!Event} e
+   * Handles click events on the unmute button.
    * @private
    */
-  onUnmuteAudioClick_(e) {
-    this.dispatch_(EventType.UNMUTE, e);
-  }
-
-  /**
-   * @param {string} eventType
-   * @param {!Event=} opt_event
-   * @private
-   */
-  dispatch_(eventType, opt_event) {
-    if (opt_event) {
-      dev().assert(opt_event).stopPropagation();
-    }
-
-    dispatch(this.getRoot(), eventType, /* opt_bubbles */ true);
+  onUnmuteAudioClick_() {
+    this.storeService_.dispatch(Action.TOGGLE_MUTED, false);
   }
 
   /**

--- a/extensions/amp-story/0.1/test/test-amp-story-store-service.js
+++ b/extensions/amp-story/0.1/test/test-amp-story-store-service.js
@@ -87,4 +87,12 @@ describes.fakeWin('amp-story-store-service actions', {}, env => {
     storeService.dispatch(Action.TOGGLE_BOOKEND, true);
     expect(listenerSpy).to.have.callCount(0);
   });
+
+  it('should toggle the muted state', () => {
+    const listenerSpy = sandbox.spy();
+    storeService.subscribe(StateProperty.MUTED_STATE, listenerSpy);
+    storeService.dispatch(Action.TOGGLE_MUTED, false);
+    expect(listenerSpy).to.have.been.calledOnce;
+    expect(listenerSpy).to.have.been.calledWith(false);
+  });
 });

--- a/extensions/amp-story/0.1/test/test-system-layer.js
+++ b/extensions/amp-story/0.1/test/test-system-layer.js
@@ -51,14 +51,14 @@ describes.fakeWin('amp-story system layer', {}, env => {
   });
 
   it('should build UI', () => {
-    const addEventHandlers =
-        sandbox.stub(systemLayer, 'addEventHandlers_').callsFake(NOOP);
+    const initializeListeners =
+        sandbox.stub(systemLayer, 'initializeListeners_').callsFake(NOOP);
 
     const root = systemLayer.build();
 
     expect(root).to.not.be.null;
 
-    expect(addEventHandlers).to.have.been.called;
+    expect(initializeListeners).to.have.been.called;
   });
 
   // TODO(alanorozco, #12476): Make this test work with sinon 4.0.
@@ -68,7 +68,7 @@ describes.fakeWin('amp-story system layer', {}, env => {
     sandbox.stub(systemLayer, 'root_').callsFake(rootMock);
     sandbox.stub(systemLayer, 'win_').callsFake(rootMock);
 
-    systemLayer.addEventHandlers_();
+    systemLayer.initializeListeners_();
 
     expect(rootMock.addEventListener).to.have.been.calledWith('click');
   });


### PR DESCRIPTION
- Storing the ``muted`` state in the store
- Does not break the blessing logic (blessing is still executed upon the user gesture, tested on iOS and Android, with and without ``auto-advance``)
- Renaming ``audio-playing`` with ``has-audio``
- Code cleaning
- Normalizing the ``initializeListeners_`` method name to be consistent with our other classes