### PR TITLE
Add transition UX polish for lightbox animations

### DIFF
--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.css
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.css
@@ -107,14 +107,20 @@
   }
 }
 
-.i-amphtml-lbg-controls {
+.i-amphtml-lbg-controls.show {
+  opacity: 1;
+}
+
+.i-amphtml-lbg-controls.hidden {
   opacity: 0;
+}
+
+.i-amphtml-lbg-controls.fade-in {
   animation: fadeIn ease-in 0.4s 1 forwards;
 }
 
 .i-amphtml-lbg-controls.fade-out
  {
-  opacity: 1;
   animation: fadeOut linear 0.4s 1 forwards;
 }
 
@@ -126,8 +132,6 @@
   overflow: hidden !important;
   color: #ffffff;
   z-index: 2 !important;
-  opacity: 0;
-  animation: fadeIn ease-in 0.4s 1 forwards;
 }
 
 .i-amphtml-lbg-desc-box.standard {

--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -381,6 +381,8 @@ export class AmpLightboxGallery extends AMP.BaseElement {
         // text area is a div that does not contain descendant elements.
         this.descriptionTextArea_./*OK*/innerText = descText;
 
+        // Avoid flickering out if transitioning from a slide with no text
+        this.descriptionBox_.classList.remove('fade-out');
         toggle(dev().assertElement(this.descriptionBox_), true);
 
         // If the description is in overflow mode, we set it to the correct


### PR DESCRIPTION
1. We want to hide controls and text description until the transition is complete. 
2. If the text description is in overflow mode at time of closing the lightbox, we want it to be set to standard the next time the lightbox opens. 
3. We want to separate the animation for toggling controls from the show / hide state. 
4. Maintain consistency with gallery view. 

There's probably a better way to decompose some of this code though. 