### PR TITLE
Add support for Safeframe shrink to Doubleclick safeframe

### DIFF
--- a/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
@@ -478,9 +478,7 @@ export class SafeframeHostApi {
     if ((payload['push'] && !this.expandByPush_) ||
         (!payload['push'] && !this.expandByOverlay_ &&
          (expandWidth > this.creativeSize_.width ||
-          expandHeight > this.creativeSize_.height)) ||
-        expandWidth <= this.creativeSize_.width ||
-        expandHeight <= this.creativeSize_.height) {
+          expandHeight > this.creativeSize_.height))) {
       dev().error(TAG, 'Invalid expand values.');
       return;
     }

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
@@ -217,8 +217,6 @@ export class SafeframeHostApi {
             'ck_on': 1,
             'flash_ver': '26.0.0',
             'canonical_url': this.maybeGetCanonicalUrl(),
-            'initial_slot_width': this.slotSize_.width,
-            'initial_slot_height': this.slotSize_.height,
           },
         }));
     attributes['reportCreativeGeometry'] = this.isFluid_;

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
@@ -475,7 +475,9 @@ export class SafeframeHostApi {
     if ((payload['push'] && !this.expandByPush_) ||
         (!payload['push'] && !this.expandByOverlay_ &&
          (expandWidth > this.creativeSize_.width ||
-          expandHeight > this.creativeSize_.height))) {
+          expandHeight > this.creativeSize_.height)) ||
+        expandWidth <= this.creativeSize_.width ||
+        expandHeight <= this.creativeSize_.height) {
       return;
     }
     // Can't expand to greater than the viewport size
@@ -567,6 +569,12 @@ export class SafeframeHostApi {
           payload['shrink_b'] + payload['shrink_t'];
     const shrinkWidth = Number(this.iframe_.width) -
           payload['shrink_r'] + payload['shrink_l'];
+    // Make sure we are actually shrinking here.
+    if (shrinkWidth > this.creativeSize_.width ||
+        shrinkHeight > this.creativeSize_.height) {
+      return;
+    }
+
     this.resizeAmpAdAndSafeframe(shrinkHeight, shrinkWidth,
         SERVICE.SHRINK_RESPONSE, true);
   }

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-safeframe.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-safeframe.js
@@ -208,6 +208,8 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
           'ck_on': 1,
           'flash_ver': '26.0.0',
           'canonical_url': 'http://example.org/canonical',
+          'initial_slot_width': ampAdWidth,
+          'initial_slot_height': ampAdHeight,
         },
       });
     });
@@ -226,6 +228,8 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
           'sf_ver': doubleclickImpl.safeframeVersion,
           'ck_on': 1,
           'flash_ver': '26.0.0',
+          'initial_slot_width': ampAdWidth,
+          'initial_slot_height': ampAdHeight,
         },
       });
     });
@@ -245,6 +249,8 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
           'sf_ver': doubleclickImpl.safeframeVersion,
           'ck_on': 1,
           'flash_ver': '26.0.0',
+          'initial_slot_width': ampAdWidth,
+          'initial_slot_height': ampAdHeight,
         },
       });
     });
@@ -265,6 +271,8 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
           'ck_on': 1,
           'flash_ver': '26.0.0',
           'canonical_url': 'http://example.org',
+          'initial_slot_width': ampAdWidth,
+          'initial_slot_height': ampAdHeight,
         },
       });
     });
@@ -646,6 +654,49 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
         expect(safeframeMock.style.width).to.equal('300px');
         expect(sendResizeResponseSpy).to.be.calledWith(
             true, SERVICE.COLLAPSE_RESPONSE);
+        expect(resizeAmpAdAndSafeframeSpy).to.be.calledOnce;
+      });
+    });
+
+    /**
+     * Send a message requesting a shrink.
+     */
+    function sendShrinkMessage(height, width) {
+      const shrinkMessage = {};
+      shrinkMessage[MESSAGE_FIELDS.CHANNEL] = safeframeHost.channel;
+      shrinkMessage[MESSAGE_FIELDS.ENDPOINT_IDENTITY] = 1;
+      shrinkMessage[MESSAGE_FIELDS.SERVICE] = SERVICE.SHRINK_REQUEST;
+      shrinkMessage[MESSAGE_FIELDS.PAYLOAD] = JSON.stringify({
+        'uid': 0.623462509818004,
+        'shrink_t': 0,
+        'shrink_r': width,
+        'shrink_b': height,
+        'shrink_l': 0,
+        'sentinel': safeframeHost.sentinel_,
+      });
+      receiveMessage(shrinkMessage);
+    }
+
+    it('should shrink safeframe on amp-ad resize success', () => {
+      safeframeHost.isCollapsed_ = false;
+      // Sneaky hack to do a synchronous mock of attemptChangeSize
+      // Resize the ampAd to simulate a success.
+      const then = f => {
+        ampAd.style.height = '40px';
+        ampAd.style.width = '40px';
+        f();
+        return {'catch': () => {}};
+      };
+      attemptChangeSizeStub.returns({then});
+      sendShrinkMessage(10, 10);
+
+      return Services.timerFor(env.win).promise(100).then(() => {
+        expect(resizeSafeframeSpy).to.be.calledOnce;
+        expect(resizeSafeframeSpy).to.be.calledWith(40, 40);
+        expect(safeframeMock.style.height).to.equal('40px');
+        expect(safeframeMock.style.width).to.equal('40px');
+        expect(sendResizeResponseSpy).to.be.calledWith(
+            true, SERVICE.SHRINK_RESPONSE);
         expect(resizeAmpAdAndSafeframeSpy).to.be.calledOnce;
       });
     });

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-safeframe.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-safeframe.js
@@ -208,8 +208,6 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
           'ck_on': 1,
           'flash_ver': '26.0.0',
           'canonical_url': 'http://example.org/canonical',
-          'initial_slot_width': ampAdWidth,
-          'initial_slot_height': ampAdHeight,
         },
       });
     });
@@ -228,8 +226,6 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
           'sf_ver': doubleclickImpl.safeframeVersion,
           'ck_on': 1,
           'flash_ver': '26.0.0',
-          'initial_slot_width': ampAdWidth,
-          'initial_slot_height': ampAdHeight,
         },
       });
     });
@@ -249,8 +245,6 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
           'sf_ver': doubleclickImpl.safeframeVersion,
           'ck_on': 1,
           'flash_ver': '26.0.0',
-          'initial_slot_width': ampAdWidth,
-          'initial_slot_height': ampAdHeight,
         },
       });
     });
@@ -271,8 +265,6 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
           'ck_on': 1,
           'flash_ver': '26.0.0',
           'canonical_url': 'http://example.org',
-          'initial_slot_width': ampAdWidth,
-          'initial_slot_height': ampAdHeight,
         },
       });
     });

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-safeframe.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-safeframe.js
@@ -660,6 +660,8 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
 
     /**
      * Send a message requesting a shrink.
+     * @param {number} height Pixels to shrink height by.
+     * @param {number} width Pixels to shrink width by.
      */
     function sendShrinkMessage(height, width) {
       const shrinkMessage = {};


### PR DESCRIPTION
After this PR, AMP GPT safeframe will support a new shrink request, and will also now pass initial slot size as metadata. 

# IMPORTANT NOTE: This will not take effect until changes are live in ext.js to allow this message to be used within a safeframe. These changes are not yet available there. 