### PR TITLE
🏗 AMP Header Minification: Returned theme-color through new <meta> dictionary in documentLoaded message payload.

### DIFF
--- a/src/service/document-info-impl.js
+++ b/src/service/document-info-impl.js
@@ -169,7 +169,7 @@ function getMetaTags(doc) {
 
       let value = metaTags[name];
       if (value) {
-        // Change to array if more than one href for the same rel
+        // Change to array if more than one content for the same name
         if (!isArray(value)) {
           value = metaTags[name] = [value];
         }

--- a/src/service/document-info-impl.js
+++ b/src/service/document-info-impl.js
@@ -31,12 +31,15 @@ const filteredLinkRels = ['prefetch', 'preload', 'preconnect', 'dns-prefetch'];
  *       for concurrent page views of a user().
  *     - linkRels: A map object of link tag's rel (key) and corresponding
  *       hrefs (value). rel could be 'canonical', 'icon', etc.
+ *     - metaTags: A map object of meta tag's name (key) and corresponding
+ *       contents (value).
  *
  * @typedef {{
  *   sourceUrl: string,
  *   canonicalUrl: string,
  *   pageViewId: string,
  *   linkRels: !Object<string, string|!Array<string>>,
+ *   metaTags: !Object<string, string|!Array<string>>,
  * }}
  */
 export let DocumentInfoDef;
@@ -80,6 +83,7 @@ export class DocInfo {
     }
     const pageViewId = getPageViewId(ampdoc.win);
     const linkRels = getLinkRels(ampdoc.win.document);
+    const metaTags = getMetaTags(ampdoc.win.document);
 
     return this.info_ = {
       /** @return {string} */
@@ -89,6 +93,7 @@ export class DocInfo {
       canonicalUrl,
       pageViewId,
       linkRels,
+      metaTags,
     };
   }
 }
@@ -142,4 +147,37 @@ function getLinkRels(doc) {
     }
   }
   return linkRels;
+}
+
+/**
+ * Returns a map object of meta tags in document head.
+ * Key is the meta name, value is a list of corresponding content values.
+ * @param {!Document} doc
+ * @return {!JsonObject<string, string|!Array<string>>}
+ */
+function getMetaTags(doc) {
+  const metaTags = map();
+  if (doc.head) {
+    const metas = doc.head.querySelectorAll('meta[name]');
+    for (let i = 0; i < metas.length; i++) {
+      const meta = metas[i];
+      const content = meta.getAttribute('content');
+      const name = meta.getAttribute('name');
+      if (!name || !content) {
+        continue;
+      }
+
+      let value = metaTags[name];
+      if (value) {
+        // Change to array if more than one href for the same rel
+        if (!isArray(value)) {
+          value = metaTags[name] = [value];
+        }
+        value.push(content);
+      } else {
+        metaTags[name] = content;
+      }
+    }
+  }
+  return metaTags;
 }

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -1126,11 +1126,13 @@ export class Resources {
     if (firstPassAfterDocumentReady) {
       this.firstPassAfterDocumentReady_ = false;
       const doc = this.win.document;
+      const documentInfo = Services.documentInfoForDoc(this.ampdoc);
       this.viewer_.sendMessage('documentLoaded', dict({
         'title': doc.title,
         'sourceUrl': getSourceUrl(this.ampdoc.getUrl()),
         'serverLayout': doc.documentElement.hasAttribute('i-amphtml-element'),
-        'linkRels': Services.documentInfoForDoc(this.ampdoc).linkRels,
+        'linkRels': documentInfo.linkRels,
+        'metaTags': documentInfo.metaTags,
       }), /* cancelUnsent */true);
 
       this.contentHeight_ = this.viewport_.getContentHeight();

--- a/test/functional/test-document-info.js
+++ b/test/functional/test-document-info.js
@@ -32,7 +32,7 @@ describe('document-info', () => {
     sandbox.restore();
   });
 
-  function getWin(links) {
+  function getWin(links, metas) {
     return createIframePromise().then(iframe => {
       if (links) {
         for (const rel in links) {
@@ -42,6 +42,17 @@ describe('document-info', () => {
             link.setAttribute('rel', rel);
             link.setAttribute('href', hrefs[i]);
             iframe.doc.head.appendChild(link);
+          }
+        }
+      }
+      if (metas) {
+        for (const name in metas) {
+          const contents = metas[name];
+          for (let i = 0; i < contents.length; i++) {
+            const meta = iframe.doc.createElement('meta');
+            meta.setAttribute('name', name);
+            meta.setAttribute('content', contents[i]);
+            iframe.doc.head.appendChild(meta);
           }
         }
       }
@@ -203,6 +214,21 @@ describe('document-info', () => {
           .to.be.undefined;
       expect(Services.documentInfoForDoc(win.document).linkRels['preconnect'])
           .to.be.undefined;
+    });
+  });
+
+  it('should provide the metaTags', () => {
+    return getWin({}, {
+      'theme-color': ['#123456'],
+    }).then(win => {
+      expect(Services.documentInfoForDoc(win.document).metaTags['theme-color'])
+          .to.equal('#123456');
+    });
+  });
+
+  it('should provide empty metaTags if there are no meta tags', () => {
+    return getWin().then(win => {
+      expect(Services.documentInfoForDoc(win.document).metaTags).to.be.empty;
     });
   });
 


### PR DESCRIPTION
Creates new dictionary of <meta> tags mapping from name to content and passes this to the viewer through the documentLoaded message. This allows the viewer to access the page's theme-color to update the header's color, and can ease development of future features that also rely on <meta> tag values. 