### PR TITLE
Update animation curves to S curve and tweak timing

### DIFF
--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.css
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.css
@@ -146,7 +146,7 @@
   overflow-y: auto !important;
   -webkit-overflow-scrolling: touch !important;
   max-height: 100% !important;
-  transition: max-height ease-in 0.3s !important;
+  transition: max-height ease-out 0.7s !important;
 }
 
 .i-amphtml-lbg-desc-mask {
@@ -168,7 +168,7 @@
   z-index: 1 !important;
   height: 4rem !important;
   background: linear-gradient(transparent, transparent 50%, rgba(0,0,0,0.9));
-  transition: background-color ease-out 0.4s !important;
+  transition: background-color ease-out 0.5s !important;
 }
 .i-amphtml-lbg-desc-box.overflow .i-amphtml-lbg-desc-mask {
   background-color: rgba(0,0,0,0.4) !important;

--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -57,8 +57,10 @@ const LightboxControlsModes = {
 
 const SWIPE_TO_CLOSE_THRESHOLD = 10;
 
-const ENTER_CURVE_ = bezierCurve(0.4, 0, 0.2, 1);
-const EXIT_CURVE_ = bezierCurve(0.4, 0, 0.2, 1);
+// Use S Curves for entry and exit animations
+const ENTER_CURVE_ = bezierCurve(0.8, 0, 0.2, 1);
+const EXIT_CURVE_ = bezierCurve(0.8, 0, 0.2, 1);
+
 const MAX_TRANSITION_DURATION = 1000; // ms
 const MIN_TRANSITION_DURATION = 500; // ms
 const MAX_DISTANCE_APPROXIMATION = 250; // px
@@ -812,7 +814,8 @@ export class AmpLightboxGallery extends AMP.BaseElement {
         const dx = imageBox.left - rect.left;
         const dy = imageBox.top - rect.top;
         const scaleX = rect.width != 0 ? imageBox.width / rect.width : 1;
-        duration = this.getTransitionDuration_(dy);
+        const viewportHeight = this.getViewport().getSize().height;
+        duration = this.getTransitionDuration_(Math.abs(dy), viewportHeight);
 
         // Animate the position and scale of the transition image to its
         // final lightbox destination in the middle of the page
@@ -941,7 +944,8 @@ export class AmpLightboxGallery extends AMP.BaseElement {
         const dx = rect.left - imageBox.left;
         const dy = rect.top - imageBox.top;
         const scaleX = imageBox.width != 0 ? rect.width / imageBox.width : 1;
-        duration = this.getTransitionDuration_(dy);
+        const viewportHeight = this.getViewport().getSize().height;
+        duration = this.getTransitionDuration_(Math.abs(dy), viewportHeight);
 
         // Animate the position and scale of the transition image to its
         // final lightbox destination in the middle of the page


### PR DESCRIPTION
These are all animation changes from UX office hour today, will probably go through one more round of review. 
1. Tweaked entrance and exit curves to S Curves. 
2. Changed text overflow transition to `ease-out` and increased timing to `0.7s`. 
3. Revisited `getTransitionDuration` and actually added `maxY = viewport height`. 

/cc @spacedino 