### PR TITLE
Allow `style` attr in sanitizer for `inline-styles` experiment

### DIFF
--- a/test/functional/test-sanitizer.js
+++ b/test/functional/test-sanitizer.js
@@ -21,6 +21,7 @@ import {
   sanitizeFormattingHtml,
   sanitizeHtml,
 } from '../../src/sanitizer';
+import {toggleExperiment} from '../../src/experiments';
 
 
 describe('sanitizeHtml', () => {
@@ -416,8 +417,40 @@ describe('sanitizeFormattingHtml', () => {
         .to.be.equal('<b>abc</b>');
   });
 
-  it('should compentsate for broken markup', () => {
+  it('should compensate for broken markup', () => {
     expect(sanitizeFormattingHtml('<b>a<i>b')).to.be.equal(
         '<b>a<i>b</i></b>');
+  });
+
+  describe('should sanitize `style` attribute', () => {
+    before(() => {
+      toggleExperiment(self, 'inline-styles', true,
+          /* opt_transientExperiment */ true);
+    });
+
+    after(() => {
+      toggleExperiment(self, 'inline-styles', false,
+          /* opt_transientExperiment */ true);
+    });
+
+    it('should allow valid styles',() => {
+      expect(sanitizeHtml('<div style="color:blue">Test</div>'))
+          .to.equal('<div style="color:blue">Test</div>');
+    });
+
+    it('should ignore styles containing `!important`',() => {
+      expect(sanitizeHtml('<div style="color:blue!important">Test</div>'))
+          .to.equal('<div>Test</div>');
+    });
+
+    it('should ignore styles containing `position:fixed`', () => {
+      expect(sanitizeHtml('<div style="position:fixed">Test</div>'))
+          .to.equal('<div>Test</div>');
+    });
+
+    it('should ignore styles containing `position:sticky`', () => {
+      expect(sanitizeHtml('<div style="position:sticky">Test</div>'))
+          .to.equal('<div>Test</div>');
+    });
   });
 });


### PR DESCRIPTION
Partial for #11881, adapted from #13781.

- Disallows `!important`, `position: fixed`, and `position: sticky`
- Allows `top`, `left`, etc. 

Would like thoughts on "future optimizations" comment on #11881: 

> Based on some future optimizations we want to do, we should probably also disallow top:X, left:X, right:X, bottom:X. Though we may be able to remove this restriction.

/to @dvoytenko /cc @alabiaga 