### PR TITLE
Ensuring the bookend config is only rendered once.

### DIFF
--- a/extensions/amp-story/0.1/bookend.js
+++ b/extensions/amp-story/0.1/bookend.js
@@ -219,6 +219,9 @@ export class Bookend {
     /** @private {boolean} */
     this.isBuilt_ = false;
 
+    /** @private {boolean} */
+    this.isConfigRendered_ = false;
+
     /** @private {?Element} */
     this.replayButton_ = null;
 
@@ -319,7 +322,7 @@ export class Bookend {
   loadConfig(applyConfig = true) {
     if (this.config_ !== undefined) {
       if (applyConfig && this.config_) {
-        this.setConfig(this.config_);
+        this.setConfig_(this.config_);
       }
       return Promise.resolve(this.config_);
     }
@@ -339,7 +342,7 @@ export class Bookend {
           // Allows the config to be fetched before the component is built, for
           // cases like getting the share providers on desktop.
           if (applyConfig) {
-            this.setConfig(this.config_);
+            this.setConfig_(this.config_);
           }
 
           return this.config_;
@@ -446,9 +449,15 @@ export class Bookend {
 
   /**
    * @param {!BookendConfigDef} bookendConfig
+   * @private
    */
-  setConfig(bookendConfig) {
+  setConfig_(bookendConfig) {
+    if (this.isConfigRendered_) {
+      return;
+    }
+
     this.assertBuilt_();
+    this.isConfigRendered_ = true;
 
     if (bookendConfig.shareProviders) {
       this.shareWidget_.setProviders(


### PR DESCRIPTION
Patch to fix a bug in the canary. Not fancy at all, we might want to find a better fix sometime this week.

The bookend config was rendered every time we visit the last page of the story, meaning that if you open the bookend 4 times, the content would be duplicated 4 times.