### PR TITLE
🐛 Small fixes in animation presets

### DIFF
--- a/examples/amp-story/animations-presets.html
+++ b/examples/amp-story/animations-presets.html
@@ -162,40 +162,34 @@
       <amp-story-grid-layer template="vertical">
         <h1>ken-burns-effect</h1>
         <div animate-in="zoom-in" animate-in-duration="30s" class="img-container">
-            <amp-img id="img-city1"
-               src="img-city1.jpeg"
-               animate-in="pan-left"
-               animate-in-duration="30s"
-               layout="fixed"
-               width="2255"
-               height="1494">
+            <amp-img id="ken-burns-img1"
+              src="https://picsum.photos/1024/768?image=1077"
+              animate-in="pan-right"
+              animate-in-duration="30s"
+              layout="fixed"
+              width="1024"
+              height="768">
             </amp-img>
         </div>
-        <div animate-in="fade-in" animate-in-after="img-city1" animate-in-delay="0.25s" animate-in-duration="1s">
+        <div animate-in="fade-in" animate-in-after="ken-burns-img1" animate-in-delay="0.25s" animate-in-duration="1s">
           <div
             animate-in="zoom-out"
             animate-in-duration="30s"
             class="img-container"
-            animate-in-after="img-city1">
-            <amp-img
-              src="img-city2.jpeg"
+            animate-in-after="ken-burns-img1">
+            <amp-img id="ken-burns-img2"
+              src="https://picsum.photos/1024/768?image=1026"
               layout="fixed"
-              width="1000"
-              height="1250"
+              width="1024"
+              height="768"
               animate-in="pan-down"
               animate-in-duration="30s"
-              animate-in-after="img-city1"
-              id="img-city2">
+              animate-in-after="ken-burns-img1">
             </amp-img>
           </div>
         </div>
-      </amp-story-grid-layer>
-      <amp-story-cta-layer>
-        <p>Image credits</p>
-        <p>First image <a href="https://unsplash.com/@jessedo81">Jesse Orrico</a></p>
-        <p>Second image <a href="https://unsplash.com/@omgitsyeshi">Yeshi Kangrang</a></p>
-      </amp-story-cta-layer>
-    </amp-story-page>
+        </amp-story-grid-layer>
+      </amp-story-page>
   </amp-story>
 </body>
 </html>

--- a/extensions/amp-story/0.1/animation-presets.js
+++ b/extensions/amp-story/0.1/animation-presets.js
@@ -184,7 +184,7 @@ export const PRESETS = {
     easing: 'linear',
     keyframes(dimensions) {
       const offsetX = dimensions.pageWidth - dimensions.targetWidth;
-      const offsetY = dimensions.pageHeight - dimensions.targetHeight / 2;
+      const offsetY = (dimensions.pageHeight - dimensions.targetHeight) / 2;
       return translate2d(offsetX, offsetY, 0, offsetY);
     },
   },
@@ -193,7 +193,7 @@ export const PRESETS = {
     easing: 'linear',
     keyframes(dimensions) {
       const offsetX = dimensions.pageWidth - dimensions.targetWidth;
-      const offsetY = dimensions.pageHeight - dimensions.targetHeight / 2;
+      const offsetY = (dimensions.pageHeight - dimensions.targetHeight) / 2;
       return translate2d(0, offsetY, offsetX, offsetY);
     },
   },


### PR DESCRIPTION
*Fixes the `pan-right/left` animation presets for large images.
*Changes the example for the presets to match with the future article tutorial in amp-by-example.