### PR TITLE
🖍 Make padding top from viewer important

### DIFF
--- a/css/amp.css
+++ b/css/amp.css
@@ -829,7 +829,7 @@ amp-accordion > section[expanded] > :last-child {
  */
 amp-story[standalone], amp-story-page {
   display: block !important;
-  height: 100vh !important;
+  height: 100% !important;
   margin: 0 !important;
   padding: 0 !important;
   overflow: hidden !important;

--- a/src/service/viewport/viewport-binding-ios-embed-wrapper.js
+++ b/src/service/viewport/viewport-binding-ios-embed-wrapper.js
@@ -20,7 +20,7 @@ import {ViewportBindingDef} from './viewport-binding-def';
 import {dev} from '../../log';
 import {isExperimentOn} from '../../experiments';
 import {layoutRectLtwh} from '../../layout-rect';
-import {px, setStyle} from '../../style';
+import {px, setImportantStyles} from '../../style';
 import {waitForBody} from '../../dom';
 import {whenDocumentReady} from '../../document-ready';
 
@@ -163,7 +163,9 @@ export class ViewportBindingIosEmbedWrapper_ {
 
   /** @override */
   updatePaddingTop(paddingTop) {
-    setStyle(this.wrapper_, 'paddingTop', px(paddingTop));
+    setImportantStyles(this.wrapper_, {
+      'padding-top': px(paddingTop),
+    });
   }
 
   /** @override */

--- a/src/service/viewport/viewport-binding-natural.js
+++ b/src/service/viewport/viewport-binding-natural.js
@@ -20,7 +20,7 @@ import {ViewportBindingDef} from './viewport-binding-def';
 import {dev} from '../../log';
 import {isExperimentOn} from '../../experiments';
 import {layoutRectLtwh} from '../../layout-rect';
-import {px, setStyles, setImportantStyles} from '../../style';
+import {px, setImportantStyles} from '../../style';
 
 
 const TAG_ = 'Viewport';

--- a/src/service/viewport/viewport-binding-natural.js
+++ b/src/service/viewport/viewport-binding-natural.js
@@ -20,7 +20,7 @@ import {ViewportBindingDef} from './viewport-binding-def';
 import {dev} from '../../log';
 import {isExperimentOn} from '../../experiments';
 import {layoutRectLtwh} from '../../layout-rect';
-import {px, setStyle} from '../../style';
+import {px, setStyles, setImportantStyles} from '../../style';
 
 
 const TAG_ = 'Viewport';
@@ -121,7 +121,9 @@ export class ViewportBindingNatural_ {
 
   /** @override */
   updatePaddingTop(paddingTop) {
-    setStyle(this.win.document.documentElement, 'paddingTop', px(paddingTop));
+    setImportantStyles(this.win.document.documentElement, {
+      'padding-top': px(paddingTop),
+    });
   }
 
   /** @override */

--- a/test/functional/test-activity.js
+++ b/test/functional/test-activity.js
@@ -70,6 +70,7 @@ describe('Activity getTotalEngagedTime', () => {
         style: {
           // required to instantiate Viewport service
           paddingTop: 0,
+          setProperty: () => {},
         },
         classList: {
           add: () => {},
@@ -272,6 +273,7 @@ describe('Activity getIncrementalEngagedTime', () => {
         style: {
           // required to instantiate Viewport service
           paddingTop: 0,
+          setProperty: () => {},
         },
         classList: {
           add: () => {},


### PR DESCRIPTION
This allows `amp-story` to respect the `paddingTop` viewer parameter.

Fixes #14106 