### PR TITLE
Inline styles: Ignore fixed/sticky elements

### DIFF
--- a/build-system/tasks/bundle-size.js
+++ b/build-system/tasks/bundle-size.js
@@ -21,7 +21,7 @@ const gulp = require('gulp-help')(require('gulp'));
 const log = require('fancy-log');
 
 const runtimeFile = './dist/v0.js';
-const maxSize = '77.49KB';
+const maxSize = '77.61KB';
 
 const green = colors.green;
 const red = colors.red;

--- a/src/service/fixed-layer.js
+++ b/src/service/fixed-layer.js
@@ -25,6 +25,7 @@ import {
 import {dev, user} from '../log';
 import {endsWith} from '../string';
 import {htmlFor} from '../static-template';
+import {isExperimentOn} from '../experiments';
 
 const TAG = 'FixedLayer';
 
@@ -34,7 +35,7 @@ const DECLARED_STICKY_PROP = '__AMP_DECLSTICKY';
 
 /**
  * The fixed layer is a *sibling* of the body element. I.e. it's a direct
- * child of documentElement. It's used to manage the `postition:fixed` and
+ * child of documentElement. It's used to manage the `position:fixed` and
  * `position:sticky` elements in iOS-iframe case due to the
  * https://bugs.webkit.org/show_bug.cgi?id=154399 bug, which is itself
  * a result of workaround for the issue where scrolling is not supported
@@ -101,17 +102,17 @@ export class FixedLayer {
       return;
     }
 
-    // Find all `position:fixed` and `sticky` elements.
     const fixedSelectors = [];
     const stickySelectors = [];
     for (let i = 0; i < stylesheets.length; i++) {
       const stylesheet = stylesheets[i];
+      const ownerNode = stylesheet.ownerNode;
       if (stylesheet.disabled ||
-              !stylesheet.ownerNode ||
-              stylesheet.ownerNode.tagName != 'STYLE' ||
-              stylesheet.ownerNode.hasAttribute('amp-boilerplate') ||
-              stylesheet.ownerNode.hasAttribute('amp-runtime') ||
-              stylesheet.ownerNode.hasAttribute('amp-extension')) {
+              !ownerNode ||
+              ownerNode.tagName != 'STYLE' ||
+              ownerNode.hasAttribute('amp-boilerplate') ||
+              ownerNode.hasAttribute('amp-runtime') ||
+              ownerNode.hasAttribute('amp-extension')) {
         continue;
       }
       this.discoverSelectors_(
@@ -266,7 +267,7 @@ export class FixedLayer {
 
     // Next, the positioning-related properties will be measured. If a
     // potentially fixed/sticky element turns out to be actually fixed/sticky,
-    // it will be decorated and possibly move to a separate layer.
+    // it will be decorated and possibly moved to a separate layer.
     let hasTransferables = false;
     return this.vsync_.runPromise({
       measure: state => {
@@ -323,7 +324,7 @@ export class FixedLayer {
               (fe.forceTransfer || (offsetWidth > 0 && offsetHeight > 0)));
           // Element is indeed sticky.
           const isSticky = endsWith(position, 'sticky');
-          const isDisplayed = display !== 'none';
+          const isDisplayed = (display !== 'none');
 
           if (!isDisplayed || !(isFixed || isSticky)) {
             state[fe.id] = {
@@ -450,7 +451,9 @@ export class FixedLayer {
           // We shouldn't have too many of `fixed` elements.
           break;
         }
-        this.setupElement_(elements[j], fixedSelector, 'fixed');
+        const el = elements[j];
+        this.removeStyleAttributeIfNecessary_(el);
+        this.setupElement_(el, fixedSelector, 'fixed');
       }
     }
     for (let i = 0; i < stickySelectors.length; i++) {
@@ -458,7 +461,26 @@ export class FixedLayer {
       const elements = this.ampdoc.getRootNode().querySelectorAll(
           stickySelector);
       for (let j = 0; j < elements.length; j++) {
-        this.setupElement_(elements[j], stickySelector, 'sticky');
+        const element = elements[j];
+        this.removeStyleAttributeIfNecessary_(element);
+        this.setupElement_(element, stickySelector, 'sticky');
+      }
+    }
+  }
+
+  /**
+   * If the given element has a `style` attribute, remove it and throw a user
+   * error. This is done since FixedLayer's implementation currently assumes
+   * that publisher-authored inline styles are impossible.
+   * @param {!Element} element
+   * @private
+   */
+  removeStyleAttributeIfNecessary_(element) {
+    if (isExperimentOn(this.ampdoc.win, 'inline-styles')) {
+      if (element.hasAttribute('style')) {
+        element.removeAttribute('style');
+        user().error(TAG, 'Inline styles are not supported yet for fixed ' +
+            'or sticky elements. Removing `style` attr from element:', element);
       }
     }
   }
@@ -478,9 +500,9 @@ export class FixedLayer {
   setupElement_(element, selector, position, opt_forceTransfer) {
     let fe = null;
     for (let i = 0; i < this.elements_.length; i++) {
-      if (this.elements_[i].element == element &&
-              this.elements_[i].position == position) {
-        fe = this.elements_[i];
+      const el = this.elements_[i];
+      if (el.element == element && el.position == position) {
+        fe = el;
         break;
       }
     }
@@ -523,11 +545,12 @@ export class FixedLayer {
   removeElement_(element) {
     const removed = [];
     for (let i = 0; i < this.elements_.length; i++) {
-      if (this.elements_[i].element == element) {
+      const el = this.elements_[i];
+      if (el.element == element) {
         this.vsync_.mutate(() => {
           setStyle(element, 'top', '');
         });
-        const fe = this.elements_[i];
+        const fe = el;
         this.elements_.splice(i, 1);
         removed.push(fe);
       }
@@ -725,6 +748,7 @@ export class FixedLayer {
   }
 
   /**
+   * Find all `position:fixed` and `position:sticky` elements.
    * @param {!Array<CSSRule>} rules
    * @param {!Array<string>} foundSelectors
    * @param {!Array<string>} stickySelectors

--- a/src/service/fixed-layer.js
+++ b/src/service/fixed-layer.js
@@ -451,8 +451,7 @@ export class FixedLayer {
           // We shouldn't have too many of `fixed` elements.
           break;
         }
-        const el = elements[j];
-        this.setupElement_(el, fixedSelector, 'fixed');
+        this.setupElement_(elements[j], fixedSelector, 'fixed');
       }
     }
     for (let i = 0; i < stickySelectors.length; i++) {
@@ -460,8 +459,7 @@ export class FixedLayer {
       const elements = this.ampdoc.getRootNode().querySelectorAll(
           stickySelector);
       for (let j = 0; j < elements.length; j++) {
-        const element = elements[j];
-        this.setupElement_(element, stickySelector, 'sticky');
+        this.setupElement_(elements[j], stickySelector, 'sticky');
       }
     }
   }
@@ -547,12 +545,11 @@ export class FixedLayer {
   removeElement_(element) {
     const removed = [];
     for (let i = 0; i < this.elements_.length; i++) {
-      const el = this.elements_[i];
-      if (el.element == element) {
+      const fe = this.elements_[i];
+      if (fe.element == element) {
         this.vsync_.mutate(() => {
           setStyle(element, 'top', '');
         });
-        const fe = el;
         this.elements_.splice(i, 1);
         removed.push(fe);
       }

--- a/src/service/fixed-layer.js
+++ b/src/service/fixed-layer.js
@@ -469,18 +469,20 @@ export class FixedLayer {
   }
 
   /**
-   * If the given element has a `style` attribute, remove it and throw a user
-   * error. This is done since FixedLayer's implementation currently assumes
-   * that publisher-authored inline styles are impossible.
+   * If the given element has a `style` attribute with a top/bottom CSS rule,
+   * remove it and throw a user error. FixedLayer's implementation currently
+   * assumes that those rules cannot be set by the publisher.
    * @param {!Element} element
    * @private
    */
   removeStyleAttributeIfNecessary_(element) {
     if (isExperimentOn(this.ampdoc.win, 'inline-styles')) {
-      if (element.hasAttribute('style')) {
+      if (element.hasAttribute('style')
+          && (element.style.top || element.style.bottom)) {
         element.removeAttribute('style');
-        user().error(TAG, 'Inline styles are not supported yet for fixed ' +
-            'or sticky elements. Removing `style` attr from element:', element);
+        user().error(TAG, 'Inline styles with `top` or `bottom` rules are ' +
+            'not supported yet for fixed or sticky elements. Removing ' +
+            '`style` attribute from element:', element);
       }
     }
   }

--- a/src/service/fixed-layer.js
+++ b/src/service/fixed-layer.js
@@ -452,7 +452,6 @@ export class FixedLayer {
           break;
         }
         const el = elements[j];
-        this.removeStyleAttributeIfNecessary_(el);
         this.setupElement_(el, fixedSelector, 'fixed');
       }
     }
@@ -462,7 +461,6 @@ export class FixedLayer {
           stickySelector);
       for (let j = 0; j < elements.length; j++) {
         const element = elements[j];
-        this.removeStyleAttributeIfNecessary_(element);
         this.setupElement_(element, stickySelector, 'sticky');
       }
     }
@@ -470,19 +468,18 @@ export class FixedLayer {
 
   /**
    * If the given element has a `style` attribute with a top/bottom CSS rule,
-   * remove it and throw a user error. FixedLayer's implementation currently
-   * assumes that those rules cannot be set by the publisher.
+   * display a user error. FixedLayer's implementation currently overrides
+   * top, bottom and a few other CSS rules.
    * @param {!Element} element
    * @private
    */
-  removeStyleAttributeIfNecessary_(element) {
+  warnAboutInlineStylesIfNecessary_(element) {
     if (isExperimentOn(this.ampdoc.win, 'inline-styles')) {
       if (element.hasAttribute('style')
           && (element.style.top || element.style.bottom)) {
-        element.removeAttribute('style');
-        user().error(TAG, 'Inline styles with `top` or `bottom` rules are ' +
-            'not supported yet for fixed or sticky elements. Removing ' +
-            '`style` attribute from element:', element);
+        user().error(TAG, 'Inline styles with `top`, `bottom` and other ' +
+            'CSS rules are not supported yet for fixed or sticky elements ' +
+            '(#14186). Unexpected behavior may occur.', element);
       }
     }
   }
@@ -500,6 +497,9 @@ export class FixedLayer {
    * @private
    */
   setupElement_(element, selector, position, opt_forceTransfer) {
+    // Warn that pub-authored inline styles may be overriden by FixedLayer.
+    this.warnAboutInlineStylesIfNecessary_(element);
+
     let fe = null;
     for (let i = 0; i < this.elements_.length; i++) {
       const el = this.elements_[i];

--- a/test/functional/test-fixed-layer.js
+++ b/test/functional/test-fixed-layer.js
@@ -19,6 +19,8 @@ import {AmpDocSingle} from '../../src/service/ampdoc-impl';
 import {FixedLayer} from '../../src/service/fixed-layer';
 import {endsWith} from '../../src/string';
 import {installPlatformService} from '../../src/service/platform-impl';
+import {toggleExperiment} from '../../src/experiments';
+import {user} from '../../src/log';
 
 
 describe('FixedLayer', () => {
@@ -48,7 +50,7 @@ describe('FixedLayer', () => {
     element2 = createElement('element2');
     element3 = createElement('element3');
     element4 = createElement('element4');
-    element5 = createElement('element4');
+    element5 = createElement('element5');
     docBody.appendChild(element1);
     docBody.appendChild(element2);
     docBody.appendChild(element3);
@@ -274,8 +276,8 @@ describe('FixedLayer', () => {
         }
         return 0;
       },
-      getAttribute: name => {
-        return attrs[name];
+      hasAttribute: name => {
+        return !!attrs[name];
       },
       setAttribute: (name, value) => {
         attrs[name] = value;
@@ -370,7 +372,7 @@ describe('FixedLayer', () => {
       fixedLayer.setup();
     });
 
-    it('should initiale fixed layer to null', () => {
+    it('should initialize fixed layer to null', () => {
       expect(fixedLayer.transferLayer_).to.be.null;
     });
 
@@ -1037,6 +1039,17 @@ describe('FixedLayer', () => {
       fixedLayer.transformMutate('translateY(-10px)');
       expect(fe.element.style.transform).to.equal('');
     });
+
+    it('should remove inline style and throw user error', () => {
+      toggleExperiment(ampdoc.win, 'inline-styles', true,
+          /* opt_transientExperiment */ true);
+      element1.setAttribute('style', 'color:blue;');
+      const userError = sandbox.stub(user(), 'error');
+      fixedLayer.setup();
+      // Expect error regarding inline styles.
+      expect(userError).calledWithMatch('FixedLayer', /Inline styles are not supported/);
+      expect(element1.hasAttribute('style')).to.be.false;
+    });
   });
 
   describe('with-transfer', () => {
@@ -1048,7 +1061,7 @@ describe('FixedLayer', () => {
       fixedLayer.setup();
     });
 
-    it('should initiale fixed layer to null', () => {
+    it('should initialize fixed layer to null', () => {
       expect(fixedLayer.transfer_).to.be.true;
       expect(fixedLayer.transferLayer_).to.be.null;
     });
@@ -1299,6 +1312,17 @@ describe('FixedLayer', () => {
 
       expect(state['F0'].fixed).to.equal(true);
       expect(state['F0'].transferrable).to.equal(true);
+    });
+
+    it('should remove inline style and throw user error', () => {
+      toggleExperiment(ampdoc.win, 'inline-styles', true,
+          /* opt_transientExperiment */ true);
+      element1.setAttribute('style', 'color:blue;');
+      const userError = sandbox.stub(user(), 'error');
+      fixedLayer.setup();
+      // Expect error regarding inline styles.
+      expect(userError).calledWithMatch('FixedLayer', /Inline styles are not supported/);
+      expect(element1.hasAttribute('style')).to.be.false;
     });
   });
 });

--- a/test/functional/test-fixed-layer.js
+++ b/test/functional/test-fixed-layer.js
@@ -1040,7 +1040,7 @@ describe('FixedLayer', () => {
       expect(fe.element.style.transform).to.equal('');
     });
 
-    it('should remove inline style and throw user error', () => {
+    it('should user error when inline styles may be overriden', () => {
       toggleExperiment(ampdoc.win, 'inline-styles', true,
           /* opt_transientExperiment */ true);
 
@@ -1052,8 +1052,7 @@ describe('FixedLayer', () => {
       fixedLayer.setup();
       // Expect error regarding inline styles.
       expect(userError).calledWithMatch('FixedLayer',
-          /Inline styles with `top` or `bottom` rules are not supported/);
-      expect(element1.hasAttribute('style')).to.be.false;
+          /not supported yet for fixed or sticky elements/);
     });
   });
 
@@ -1319,7 +1318,7 @@ describe('FixedLayer', () => {
       expect(state['F0'].transferrable).to.equal(true);
     });
 
-    it('should remove inline style and throw user error', () => {
+    it('should user error when inline styles may be overriden', () => {
       toggleExperiment(ampdoc.win, 'inline-styles', true,
           /* opt_transientExperiment */ true);
 
@@ -1331,8 +1330,7 @@ describe('FixedLayer', () => {
       fixedLayer.setup();
       // Expect error regarding inline styles.
       expect(userError).calledWithMatch('FixedLayer',
-          /Inline styles with `top` or `bottom` rules are not supported/);
-      expect(element1.hasAttribute('style')).to.be.false;
+          /not supported yet for fixed or sticky elements/);
     });
   });
 });

--- a/test/functional/test-fixed-layer.js
+++ b/test/functional/test-fixed-layer.js
@@ -1043,12 +1043,16 @@ describe('FixedLayer', () => {
     it('should remove inline style and throw user error', () => {
       toggleExperiment(ampdoc.win, 'inline-styles', true,
           /* opt_transientExperiment */ true);
-      element1.setAttribute('style', 'color:blue;');
+
+      // Set both attribute and property since element1 is a fake element.
+      element1.setAttribute('style', 'bottom: 10px');
+      element1.style.bottom = '10px';
+
       const userError = sandbox.stub(user(), 'error');
       fixedLayer.setup();
       // Expect error regarding inline styles.
       expect(userError).calledWithMatch('FixedLayer',
-          /Inline styles are not supported/);
+          /Inline styles with `top` or `bottom` rules are not supported/);
       expect(element1.hasAttribute('style')).to.be.false;
     });
   });
@@ -1318,12 +1322,16 @@ describe('FixedLayer', () => {
     it('should remove inline style and throw user error', () => {
       toggleExperiment(ampdoc.win, 'inline-styles', true,
           /* opt_transientExperiment */ true);
-      element1.setAttribute('style', 'color:blue;');
+
+      // Set both attribute and property since element1 is a fake element.
+      element1.setAttribute('style', 'bottom: 10px');
+      element1.style.bottom = '10px';
+
       const userError = sandbox.stub(user(), 'error');
       fixedLayer.setup();
       // Expect error regarding inline styles.
       expect(userError).calledWithMatch('FixedLayer',
-          /Inline styles are not supported/);
+          /Inline styles with `top` or `bottom` rules are not supported/);
       expect(element1.hasAttribute('style')).to.be.false;
     });
   });

--- a/test/functional/test-fixed-layer.js
+++ b/test/functional/test-fixed-layer.js
@@ -1047,7 +1047,8 @@ describe('FixedLayer', () => {
       const userError = sandbox.stub(user(), 'error');
       fixedLayer.setup();
       // Expect error regarding inline styles.
-      expect(userError).calledWithMatch('FixedLayer', /Inline styles are not supported/);
+      expect(userError).calledWithMatch('FixedLayer',
+          /Inline styles are not supported/);
       expect(element1.hasAttribute('style')).to.be.false;
     });
   });
@@ -1321,7 +1322,8 @@ describe('FixedLayer', () => {
       const userError = sandbox.stub(user(), 'error');
       fixedLayer.setup();
       // Expect error regarding inline styles.
-      expect(userError).calledWithMatch('FixedLayer', /Inline styles are not supported/);
+      expect(userError).calledWithMatch('FixedLayer',
+          /Inline styles are not supported/);
       expect(element1.hasAttribute('style')).to.be.false;
     });
   });


### PR DESCRIPTION
Partial for #11881, adapted from #13744.

- Short-term: Avoid `FixedLayer`'s problematic assumption that no publisher-authored inline styles exist by simply removing inline styles for fixed/sticky elements (and throwing a user error)
- Long-term: Adapt `FixedLayer`'s implementation to remove the above assumption

/to @dvoytenko /cc @alabiaga 