### PR TITLE
amp-story: Metadata validation

### DIFF
--- a/extensions/amp-story-auto-ads/0.1/test/validator-amp-story-auto-ads.out
+++ b/extensions/amp-story-auto-ads/0.1/test/validator-amp-story-auto-ads.out
@@ -34,7 +34,7 @@ PASS
 |  <body>
 |    <amp-story standalone>
 >>   ^~~~~~~~~
-amp-story-auto-ads/0.1/test/validator-amp-story-auto-ads.html:34:2 The tag 'AMP-STORY NO-METADATA' is deprecated - use 'AMP-STORY' instead. (see https://www.ampproject.org/docs/reference/components/amp-story#announcements) [DEPRECATION]
+amp-story-auto-ads/0.1/test/validator-amp-story-auto-ads.html:34:2 The tag 'AMP-STORY (beta)' is deprecated - use 'AMP-STORY' instead. (see https://www.ampproject.org/docs/reference/components/amp-story#announcements) [DEPRECATION]
 |      <amp-story-page id="1">
 |        <amp-story-grid-layer template="horizontal">
 |        </amp-story-grid-layer>

--- a/extensions/amp-story-auto-ads/0.1/test/validator-amp-story-auto-ads.out
+++ b/extensions/amp-story-auto-ads/0.1/test/validator-amp-story-auto-ads.out
@@ -33,6 +33,8 @@ PASS
 |  </head>
 |  <body>
 |    <amp-story standalone>
+>>   ^~~~~~~~~
+amp-story-auto-ads/0.1/test/validator-amp-story-auto-ads.html:34:2 The tag 'AMP-STORY NO-METADATA' is deprecated - use 'AMP-STORY' instead. (see TODO(choumx)) [DEPRECATION]
 |      <amp-story-page id="1">
 |        <amp-story-grid-layer template="horizontal">
 |        </amp-story-grid-layer>

--- a/extensions/amp-story-auto-ads/0.1/test/validator-amp-story-auto-ads.out
+++ b/extensions/amp-story-auto-ads/0.1/test/validator-amp-story-auto-ads.out
@@ -34,7 +34,7 @@ PASS
 |  <body>
 |    <amp-story standalone>
 >>   ^~~~~~~~~
-amp-story-auto-ads/0.1/test/validator-amp-story-auto-ads.html:34:2 The tag 'AMP-STORY NO-METADATA' is deprecated - use 'AMP-STORY' instead. (see TODO(choumx)) [DEPRECATION]
+amp-story-auto-ads/0.1/test/validator-amp-story-auto-ads.html:34:2 The tag 'AMP-STORY NO-METADATA' is deprecated - use 'AMP-STORY' instead. (see https://www.ampproject.org/docs/reference/components/amp-story#announcements) [DEPRECATION]
 |      <amp-story-page id="1">
 |        <amp-story-grid-layer template="horizontal">
 |        </amp-story-grid-layer>

--- a/extensions/amp-story/0.1/test/validator-amp-story-animations-error.out
+++ b/extensions/amp-story/0.1/test/validator-amp-story-animations-error.out
@@ -46,6 +46,8 @@ FAIL
 |  </head>
 |  <body>
 |    <amp-story standalone>
+>>   ^~~~~~~~~
+amp-story/0.1/test/validator-amp-story-animations-error.html:47:2 The tag 'AMP-STORY NO-METADATA' is deprecated - use 'AMP-STORY' instead. (see TODO(choumx)) [DEPRECATION]
 |      <amp-story-page id="combining-animations">
 |          <amp-story-grid-layer template="thirds">
 |            <h1>invalid animation value + empty animation value</h1>

--- a/extensions/amp-story/0.1/test/validator-amp-story-animations-error.out
+++ b/extensions/amp-story/0.1/test/validator-amp-story-animations-error.out
@@ -47,7 +47,7 @@ FAIL
 |  <body>
 |    <amp-story standalone>
 >>   ^~~~~~~~~
-amp-story/0.1/test/validator-amp-story-animations-error.html:47:2 The tag 'AMP-STORY NO-METADATA' is deprecated - use 'AMP-STORY' instead. (see TODO(choumx)) [DEPRECATION]
+amp-story/0.1/test/validator-amp-story-animations-error.html:47:2 The tag 'AMP-STORY NO-METADATA' is deprecated - use 'AMP-STORY' instead. (see https://www.ampproject.org/docs/reference/components/amp-story#announcements) [DEPRECATION]
 |      <amp-story-page id="combining-animations">
 |          <amp-story-grid-layer template="thirds">
 |            <h1>invalid animation value + empty animation value</h1>

--- a/extensions/amp-story/0.1/test/validator-amp-story-animations-error.out
+++ b/extensions/amp-story/0.1/test/validator-amp-story-animations-error.out
@@ -47,7 +47,7 @@ FAIL
 |  <body>
 |    <amp-story standalone>
 >>   ^~~~~~~~~
-amp-story/0.1/test/validator-amp-story-animations-error.html:47:2 The tag 'AMP-STORY NO-METADATA' is deprecated - use 'AMP-STORY' instead. (see https://www.ampproject.org/docs/reference/components/amp-story#announcements) [DEPRECATION]
+amp-story/0.1/test/validator-amp-story-animations-error.html:47:2 The tag 'AMP-STORY (beta)' is deprecated - use 'AMP-STORY' instead. (see https://www.ampproject.org/docs/reference/components/amp-story#announcements) [DEPRECATION]
 |      <amp-story-page id="combining-animations">
 |          <amp-story-grid-layer template="thirds">
 |            <h1>invalid animation value + empty animation value</h1>

--- a/extensions/amp-story/0.1/test/validator-amp-story-animations.out
+++ b/extensions/amp-story/0.1/test/validator-amp-story-animations.out
@@ -45,7 +45,7 @@ PASS
 |  <body>
 |    <amp-story standalone>
 >>   ^~~~~~~~~
-amp-story/0.1/test/validator-amp-story-animations.html:45:2 The tag 'AMP-STORY NO-METADATA' is deprecated - use 'AMP-STORY' instead. (see https://www.ampproject.org/docs/reference/components/amp-story#announcements) [DEPRECATION]
+amp-story/0.1/test/validator-amp-story-animations.html:45:2 The tag 'AMP-STORY (beta)' is deprecated - use 'AMP-STORY' instead. (see https://www.ampproject.org/docs/reference/components/amp-story#announcements) [DEPRECATION]
 |      <amp-story-page id="ken-burns-effect">
 |        <amp-story-grid-layer template="vertical">
 |          <h1>ken-burns-effect</h1>

--- a/extensions/amp-story/0.1/test/validator-amp-story-animations.out
+++ b/extensions/amp-story/0.1/test/validator-amp-story-animations.out
@@ -45,7 +45,7 @@ PASS
 |  <body>
 |    <amp-story standalone>
 >>   ^~~~~~~~~
-amp-story/0.1/test/validator-amp-story-animations.html:45:2 The tag 'AMP-STORY NO-METADATA' is deprecated - use 'AMP-STORY' instead. (see TODO(choumx)) [DEPRECATION]
+amp-story/0.1/test/validator-amp-story-animations.html:45:2 The tag 'AMP-STORY NO-METADATA' is deprecated - use 'AMP-STORY' instead. (see https://www.ampproject.org/docs/reference/components/amp-story#announcements) [DEPRECATION]
 |      <amp-story-page id="ken-burns-effect">
 |        <amp-story-grid-layer template="vertical">
 |          <h1>ken-burns-effect</h1>

--- a/extensions/amp-story/0.1/test/validator-amp-story-animations.out
+++ b/extensions/amp-story/0.1/test/validator-amp-story-animations.out
@@ -44,6 +44,8 @@ PASS
 |  </head>
 |  <body>
 |    <amp-story standalone>
+>>   ^~~~~~~~~
+amp-story/0.1/test/validator-amp-story-animations.html:45:2 The tag 'AMP-STORY NO-METADATA' is deprecated - use 'AMP-STORY' instead. (see TODO(choumx)) [DEPRECATION]
 |      <amp-story-page id="ken-burns-effect">
 |        <amp-story-grid-layer template="vertical">
 |          <h1>ken-burns-effect</h1>

--- a/extensions/amp-story/0.1/test/validator-amp-story-cta-layer-error.html
+++ b/extensions/amp-story/0.1/test/validator-amp-story-cta-layer-error.html
@@ -49,7 +49,7 @@
   </style>
 </head>
 <body>
-  <amp-story standalone>
+  <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/poster.jpg">
     <amp-story-page id="fill-template-title">
       <amp-story-cta-layer>
         <a href="http://www.google.com" class="button"> Illegal CTA layer above grid layer! </a>

--- a/extensions/amp-story/0.1/test/validator-amp-story-cta-layer-error.out
+++ b/extensions/amp-story/0.1/test/validator-amp-story-cta-layer-error.out
@@ -65,7 +65,7 @@ amp-story/0.1/test/validator-amp-story-cta-layer-error.html:54:6 Tag 'amp-story-
 >>     ^~~~~~~~~
 amp-story/0.1/test/validator-amp-story-cta-layer-error.html:61:4 The tag 'amp-story-cta-layer' may only appear as a descendant of tag 'amp-story-page'. [AMP_TAG_PROBLEM]
 >>     ^~~~~~~~~
-amp-story/0.1/test/validator-amp-story-cta-layer-error.html:61:4 Tag 'amp-story-cta-layer' is disallowed as child of tag 'amp-story'. Child tag must be one of ['amp-analytics', 'amp-pixel', 'amp-story-auto-ads', 'amp-story-bookend', 'amp-story-page']. (see https://www.ampproject.org/docs/reference/components/amp-story) [AMP_TAG_PROBLEM]
+amp-story/0.1/test/validator-amp-story-cta-layer-error.html:61:4 Tag 'amp-story-cta-layer' is disallowed as child of tag 'amp-story'. Child tag must be one of ['amp-analytics', 'amp-pixel', 'amp-story-auto-ads', 'amp-story-page']. (see https://www.ampproject.org/docs/reference/components/amp-story) [AMP_TAG_PROBLEM]
 |        <a href="http://www.google.com" class="button"> Illegal CTA layer outside of amp-story-page! </a>
 |      </amp-story-cta-layer>
 |    </amp-story>

--- a/extensions/amp-story/0.1/test/validator-amp-story-cta-layer-error.out
+++ b/extensions/amp-story/0.1/test/validator-amp-story-cta-layer-error.out
@@ -65,7 +65,7 @@ amp-story/0.1/test/validator-amp-story-cta-layer-error.html:54:6 Tag 'amp-story-
 >>     ^~~~~~~~~
 amp-story/0.1/test/validator-amp-story-cta-layer-error.html:61:4 The tag 'amp-story-cta-layer' may only appear as a descendant of tag 'amp-story-page'. [AMP_TAG_PROBLEM]
 >>     ^~~~~~~~~
-amp-story/0.1/test/validator-amp-story-cta-layer-error.html:61:4 Tag 'amp-story-cta-layer' is disallowed as child of tag 'amp-story'. Child tag must be one of ['amp-analytics', 'amp-pixel', 'amp-story-auto-ads', 'amp-story-page']. (see https://www.ampproject.org/docs/reference/components/amp-story) [AMP_TAG_PROBLEM]
+amp-story/0.1/test/validator-amp-story-cta-layer-error.html:61:4 Tag 'amp-story-cta-layer' is disallowed as child of tag 'amp-story'. Child tag must be one of ['amp-analytics', 'amp-pixel', 'amp-story-auto-ads', 'amp-story-bookend', 'amp-story-page']. (see https://www.ampproject.org/docs/reference/components/amp-story) [AMP_TAG_PROBLEM]
 |        <a href="http://www.google.com" class="button"> Illegal CTA layer outside of amp-story-page! </a>
 |      </amp-story-cta-layer>
 |    </amp-story>

--- a/extensions/amp-story/0.1/test/validator-amp-story-cta-layer-error.out
+++ b/extensions/amp-story/0.1/test/validator-amp-story-cta-layer-error.out
@@ -50,7 +50,7 @@ FAIL
 |    </style>
 |  </head>
 |  <body>
-|    <amp-story standalone>
+|    <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/poster.jpg">
 |      <amp-story-page id="fill-template-title">
 |        <amp-story-cta-layer>
 >>       ^~~~~~~~~

--- a/extensions/amp-story/0.1/test/validator-amp-story-cta-layer.html
+++ b/extensions/amp-story/0.1/test/validator-amp-story-cta-layer.html
@@ -49,7 +49,7 @@
   </style>
 </head>
 <body>
-  <amp-story standalone>
+  <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/poster.jpg">
     <amp-story-page id="fill-template-title">
       <amp-story-grid-layer template="vertical">
         <h1>fill</h1>

--- a/extensions/amp-story/0.1/test/validator-amp-story-cta-layer.out
+++ b/extensions/amp-story/0.1/test/validator-amp-story-cta-layer.out
@@ -50,7 +50,7 @@ PASS
 |    </style>
 |  </head>
 |  <body>
-|    <amp-story standalone>
+|    <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/poster.jpg">
 |      <amp-story-page id="fill-template-title">
 |        <amp-story-grid-layer template="vertical">
 |          <h1>fill</h1>

--- a/extensions/amp-story/0.1/test/validator-amp-story-deprecated.html
+++ b/extensions/amp-story/0.1/test/validator-amp-story-deprecated.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+  Copyright 2018 The AMP HTML Authors. All Rights Reserved.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/extensions/amp-story/0.1/test/validator-amp-story-deprecated.html
+++ b/extensions/amp-story/0.1/test/validator-amp-story-deprecated.html
@@ -29,10 +29,7 @@
   <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-0.1.js"></script>
 </head>
 <body>
-  <amp-story standalone
-    title="STAMP examples" publisher="STAMP team" publisher-logo-src="http://pub.com/logo.png"
-    poster-portrait-src="http://pub.com/portrait.jpg" poster-square-src="http://pub.com/square.jpg" poster-landscape-src="http://pub.com/landscape.jpg"
-    bookend-config-src="./bookend-config-src.json" background-audio="path/to/my.mp3">
+  <amp-story standalone bookend-config-src="./bookend-config-src.json" background-audio="path/to/my.mp3">
     <amp-story-page id="1" background-audio="path/to/my.mp3" auto-advance-after="any-value">
       <amp-story-grid-layer template="horizontal">
         <h5 animate-in="drop">

--- a/extensions/amp-story/0.1/test/validator-amp-story-deprecated.out
+++ b/extensions/amp-story/0.1/test/validator-amp-story-deprecated.out
@@ -32,7 +32,7 @@ PASS
 |  <body>
 |    <amp-story standalone bookend-config-src="./bookend-config-src.json" background-audio="path/to/my.mp3">
 >>   ^~~~~~~~~
-amp-story/0.1/test/validator-amp-story-deprecated.html:32:2 The tag 'AMP-STORY NO-METADATA' is deprecated - use 'AMP-STORY' instead. (see https://www.ampproject.org/docs/reference/components/amp-story#announcements) [DEPRECATION]
+amp-story/0.1/test/validator-amp-story-deprecated.html:32:2 The tag 'AMP-STORY (beta)' is deprecated - use 'AMP-STORY' instead. (see https://www.ampproject.org/docs/reference/components/amp-story#announcements) [DEPRECATION]
 |      <amp-story-page id="1" background-audio="path/to/my.mp3" auto-advance-after="any-value">
 |        <amp-story-grid-layer template="horizontal">
 |          <h5 animate-in="drop">

--- a/extensions/amp-story/0.1/test/validator-amp-story-deprecated.out
+++ b/extensions/amp-story/0.1/test/validator-amp-story-deprecated.out
@@ -31,6 +31,8 @@ PASS
 |  </head>
 |  <body>
 |    <amp-story standalone bookend-config-src="./bookend-config-src.json" background-audio="path/to/my.mp3">
+>>   ^~~~~~~~~
+amp-story/0.1/test/validator-amp-story-deprecated.html:32:2 The tag 'AMP-STORY NO-METADATA' is deprecated - use 'AMP-STORY' instead. (see TODO(choumx)) [DEPRECATION]
 |      <amp-story-page id="1" background-audio="path/to/my.mp3" auto-advance-after="any-value">
 |        <amp-story-grid-layer template="horizontal">
 |          <h5 animate-in="drop">

--- a/extensions/amp-story/0.1/test/validator-amp-story-deprecated.out
+++ b/extensions/amp-story/0.1/test/validator-amp-story-deprecated.out
@@ -1,0 +1,55 @@
+PASS
+|  <!--
+|    Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+|  
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests for the amp-story tag.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <title>STAMP examples</title>
+|    <link rel="canonical" href="http://nonblocking.io/" >
+|    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-0.1.js"></script>
+|  </head>
+|  <body>
+|    <amp-story standalone bookend-config-src="./bookend-config-src.json" background-audio="path/to/my.mp3">
+|      <amp-story-page id="1" background-audio="path/to/my.mp3" auto-advance-after="any-value">
+|        <amp-story-grid-layer template="horizontal">
+|          <h5 animate-in="drop">
+|            <h1>
+|              <h4 animate-in-delay="anything"></h4>
+|            </h1>
+|            <h2></h2>
+|          </h5>
+|          <h3 grid-area="any value">
+|            <h6 animate-in-after="whatever-value"></h6>
+|          </h3>
+|          <h3 align-content="center"></h3>
+|          <h3 align-items="stretch"></h3>
+|          <h3 align-self="start"></h3>
+|        </amp-story-grid-layer>
+|        <amp-story-grid-layer template="horizontal">
+|          <h1></h1>
+|        </amp-story-grid-layer>
+|      </amp-story-page>
+|    </amp-story>
+|  </body>
+|  </html>

--- a/extensions/amp-story/0.1/test/validator-amp-story-deprecated.out
+++ b/extensions/amp-story/0.1/test/validator-amp-story-deprecated.out
@@ -32,7 +32,7 @@ PASS
 |  <body>
 |    <amp-story standalone bookend-config-src="./bookend-config-src.json" background-audio="path/to/my.mp3">
 >>   ^~~~~~~~~
-amp-story/0.1/test/validator-amp-story-deprecated.html:32:2 The tag 'AMP-STORY NO-METADATA' is deprecated - use 'AMP-STORY' instead. (see TODO(choumx)) [DEPRECATION]
+amp-story/0.1/test/validator-amp-story-deprecated.html:32:2 The tag 'AMP-STORY NO-METADATA' is deprecated - use 'AMP-STORY' instead. (see https://www.ampproject.org/docs/reference/components/amp-story#announcements) [DEPRECATION]
 |      <amp-story-page id="1" background-audio="path/to/my.mp3" auto-advance-after="any-value">
 |        <amp-story-grid-layer template="horizontal">
 |          <h5 animate-in="drop">

--- a/extensions/amp-story/0.1/test/validator-amp-story-deprecated.out
+++ b/extensions/amp-story/0.1/test/validator-amp-story-deprecated.out
@@ -1,6 +1,6 @@
 PASS
 |  <!--
-|    Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+|    Copyright 2018 The AMP HTML Authors. All Rights Reserved.
 |  
 |    Licensed under the Apache License, Version 2.0 (the "License");
 |    you may not use this file except in compliance with the License.

--- a/extensions/amp-story/0.1/test/validator-amp-story-error.html
+++ b/extensions/amp-story/0.1/test/validator-amp-story-error.html
@@ -37,9 +37,7 @@
           </h1>
         </h5>
       </amp-story-grid-layer>
-      <amp-story-bookend></amp-story-bookend><!-- error because 'amp-story-bookend' should only be a child of <amp-story> -->
     </amp-story-page>
-    <amp-story-bookend></amp-story-bookend><!-- error because there should only be one instance of 'amp-story-bookend' -->
   </amp-story>
   <div></div> <!-- this should create an error for the 'no siblings allowed' rule on <amp-story> -->
 </body>

--- a/extensions/amp-story/0.1/test/validator-amp-story-error.html
+++ b/extensions/amp-story/0.1/test/validator-amp-story-error.html
@@ -39,6 +39,7 @@
       </amp-story-grid-layer>
       <amp-story-bookend></amp-story-bookend><!-- error because 'amp-story-bookend' should only be a child of <amp-story> -->
     </amp-story-page>
+    <amp-story-bookend></amp-story-bookend><!-- error because there should only be one instance of 'amp-story-bookend' -->
   </amp-story>
   <div></div> <!-- this should create an error for the 'no siblings allowed' rule on <amp-story> -->
 </body>

--- a/extensions/amp-story/0.1/test/validator-amp-story-error.html
+++ b/extensions/amp-story/0.1/test/validator-amp-story-error.html
@@ -28,7 +28,7 @@
   <script async src="https://cdn.ampproject.org/v0.js"></script>
 </head>
 <body>
-  <amp-story> <!-- error because the 'standalone' attribute isn't set -->
+  <amp-story> <!-- error because the 'standalone' and metadata attributes aren't set -->
     <amp-story-page> <!-- error because the 'id' attribute isn't set -->
       <amp-story-grid-layer> <!-- error because one of 'fill', 'horizontal', 'vertical', 'thirds' should be set. -->
         <h5>
@@ -37,6 +37,7 @@
           </h1>
         </h5>
       </amp-story-grid-layer>
+      <amp-story-bookend></amp-story-bookend><!-- error because 'amp-story-bookend' should only be a child of <amp-story> -->
     </amp-story-page>
   </amp-story>
   <div></div> <!-- this should create an error for the 'no siblings allowed' rule on <amp-story> -->

--- a/extensions/amp-story/0.1/test/validator-amp-story-error.out
+++ b/extensions/amp-story/0.1/test/validator-amp-story-error.out
@@ -31,9 +31,9 @@ FAIL
 |  <body>
 |    <amp-story> <!-- error because the 'standalone' attribute isn't set -->
 >>   ^~~~~~~~~
-amp-story/0.1/test/validator-amp-story-error.html:31:2 The mandatory attribute 'standalone' is missing in tag 'AMP-STORY NO-METADATA'. (see https://www.ampproject.org/docs/reference/components/amp-story) [DISALLOWED_HTML]
+amp-story/0.1/test/validator-amp-story-error.html:31:2 The mandatory attribute 'standalone' is missing in tag 'AMP-STORY (beta)'. (see https://www.ampproject.org/docs/reference/components/amp-story) [DISALLOWED_HTML]
 >>   ^~~~~~~~~
-amp-story/0.1/test/validator-amp-story-error.html:31:2 The tag 'AMP-STORY NO-METADATA' requires including the 'amp-story' extension JavaScript. (see https://www.ampproject.org/docs/reference/components/amp-story) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
+amp-story/0.1/test/validator-amp-story-error.html:31:2 The tag 'AMP-STORY (beta)' requires including the 'amp-story' extension JavaScript. (see https://www.ampproject.org/docs/reference/components/amp-story) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
 |      <amp-story-page> <!-- error because the 'id' attribute isn't set -->
 >>     ^~~~~~~~~
 amp-story/0.1/test/validator-amp-story-error.html:32:4 The mandatory attribute 'id' is missing in tag 'amp-story-page'. (see https://www.ampproject.org/docs/reference/components/amp-story) [AMP_TAG_PROBLEM]

--- a/extensions/amp-story/0.1/test/validator-amp-story-error.out
+++ b/extensions/amp-story/0.1/test/validator-amp-story-error.out
@@ -50,13 +50,7 @@ amp-story/0.1/test/validator-amp-story-error.html:36:12 The attribute 'height' m
 |            </h1>
 |          </h5>
 |        </amp-story-grid-layer>
-|        <amp-story-bookend></amp-story-bookend><!-- error because 'amp-story-bookend' should only be a child of <amp-story> -->
->>       ^~~~~~~~~
-amp-story/0.1/test/validator-amp-story-error.html:40:6 The parent tag of tag 'amp-story-bookend' is 'amp-story-page', but it can only be 'amp-story'. (see https://www.ampproject.org/docs/reference/components/amp-story) [AMP_TAG_PROBLEM]
 |      </amp-story-page>
-|      <amp-story-bookend></amp-story-bookend><!-- error because there should only be one instance of 'amp-story-bookend' -->
->>     ^~~~~~~~~
-amp-story/0.1/test/validator-amp-story-error.html:42:4 The tag 'amp-story-bookend' appears more than once in the document. (see https://www.ampproject.org/docs/reference/components/amp-story) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
 |    </amp-story>
 |    <div></div> <!-- this should create an error for the 'no siblings allowed' rule on <amp-story> -->
 |  </body>

--- a/extensions/amp-story/0.1/test/validator-amp-story-error.out
+++ b/extensions/amp-story/0.1/test/validator-amp-story-error.out
@@ -31,9 +31,9 @@ FAIL
 |  <body>
 |    <amp-story> <!-- error because the 'standalone' attribute isn't set -->
 >>   ^~~~~~~~~
-amp-story/0.1/test/validator-amp-story-error.html:31:2 The mandatory attribute 'standalone' is missing in tag 'amp-story'. (see https://www.ampproject.org/docs/reference/components/amp-story) [AMP_TAG_PROBLEM]
+amp-story/0.1/test/validator-amp-story-error.html:31:2 The mandatory attribute 'standalone' is missing in tag 'AMP-STORY NO-METADATA'. (see https://www.ampproject.org/docs/reference/components/amp-story) [DISALLOWED_HTML]
 >>   ^~~~~~~~~
-amp-story/0.1/test/validator-amp-story-error.html:31:2 The tag 'amp-story' requires including the 'amp-story' extension JavaScript. (see https://www.ampproject.org/docs/reference/components/amp-story) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
+amp-story/0.1/test/validator-amp-story-error.html:31:2 The tag 'AMP-STORY NO-METADATA' requires including the 'amp-story' extension JavaScript. (see https://www.ampproject.org/docs/reference/components/amp-story) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
 |      <amp-story-page> <!-- error because the 'id' attribute isn't set -->
 >>     ^~~~~~~~~
 amp-story/0.1/test/validator-amp-story-error.html:32:4 The mandatory attribute 'id' is missing in tag 'amp-story-page'. (see https://www.ampproject.org/docs/reference/components/amp-story) [AMP_TAG_PROBLEM]

--- a/extensions/amp-story/0.1/test/validator-amp-story-error.out
+++ b/extensions/amp-story/0.1/test/validator-amp-story-error.out
@@ -29,7 +29,7 @@ FAIL
 |    <script async src="https://cdn.ampproject.org/v0.js"></script>
 |  </head>
 |  <body>
-|    <amp-story> <!-- error because the 'standalone' attribute isn't set -->
+|    <amp-story> <!-- error because the 'standalone' and metadata attributes aren't set -->
 >>   ^~~~~~~~~
 amp-story/0.1/test/validator-amp-story-error.html:31:2 The mandatory attribute 'standalone' is missing in tag 'AMP-STORY (beta)'. (see https://www.ampproject.org/docs/reference/components/amp-story) [DISALLOWED_HTML]
 >>   ^~~~~~~~~
@@ -50,6 +50,9 @@ amp-story/0.1/test/validator-amp-story-error.html:36:12 The attribute 'height' m
 |            </h1>
 |          </h5>
 |        </amp-story-grid-layer>
+|        <amp-story-bookend></amp-story-bookend><!-- error because 'amp-story-bookend' should only be a child of <amp-story> -->
+>>       ^~~~~~~~~
+amp-story/0.1/test/validator-amp-story-error.html:40:6 The parent tag of tag 'amp-story-bookend' is 'amp-story-page', but it can only be 'amp-story'. (see https://www.ampproject.org/docs/reference/components/amp-story) [AMP_TAG_PROBLEM]
 |      </amp-story-page>
 |    </amp-story>
 |    <div></div> <!-- this should create an error for the 'no siblings allowed' rule on <amp-story> -->

--- a/extensions/amp-story/0.1/test/validator-amp-story-error.out
+++ b/extensions/amp-story/0.1/test/validator-amp-story-error.out
@@ -54,6 +54,9 @@ amp-story/0.1/test/validator-amp-story-error.html:36:12 The attribute 'height' m
 >>       ^~~~~~~~~
 amp-story/0.1/test/validator-amp-story-error.html:40:6 The parent tag of tag 'amp-story-bookend' is 'amp-story-page', but it can only be 'amp-story'. (see https://www.ampproject.org/docs/reference/components/amp-story) [AMP_TAG_PROBLEM]
 |      </amp-story-page>
+|      <amp-story-bookend></amp-story-bookend><!-- error because there should only be one instance of 'amp-story-bookend' -->
+>>     ^~~~~~~~~
+amp-story/0.1/test/validator-amp-story-error.html:42:4 The tag 'amp-story-bookend' appears more than once in the document. (see https://www.ampproject.org/docs/reference/components/amp-story) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
 |    </amp-story>
 |    <div></div> <!-- this should create an error for the 'no siblings allowed' rule on <amp-story> -->
 |  </body>

--- a/extensions/amp-story/0.1/test/validator-amp-story-reference-point.html
+++ b/extensions/amp-story/0.1/test/validator-amp-story-reference-point.html
@@ -29,7 +29,7 @@
   <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-0.1.js"></script>
 </head>
 <body>
-  <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/poster.jpg" bookend-config-src="./related.json" background-audio="path/to/my.mp3">
+  <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/poster.jpg" background-audio="path/to/my.mp3">
     <amp-story-page id="1" background-audio="path/to/my.mp3" auto-advance-after="any-value">
       <amp-story-grid-layer template="horizontal">
         <img class="footer-logo" src="img/foot-logo.svg" width="40" height="40" /> <!-- The real error here is that <img/> tag is not allowed. But this is a weird use case where the validator error will comment about reference points. This needs to be fixed in the near future. -->

--- a/extensions/amp-story/0.1/test/validator-amp-story-reference-point.html
+++ b/extensions/amp-story/0.1/test/validator-amp-story-reference-point.html
@@ -29,7 +29,7 @@
   <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-0.1.js"></script>
 </head>
 <body>
-  <amp-story standalone bookend-config-src="./related.json" background-audio="path/to/my.mp3">
+  <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/poster.jpg" bookend-config-src="./related.json" background-audio="path/to/my.mp3">
     <amp-story-page id="1" background-audio="path/to/my.mp3" auto-advance-after="any-value">
       <amp-story-grid-layer template="horizontal">
         <img class="footer-logo" src="img/foot-logo.svg" width="40" height="40" /> <!-- The real error here is that <img/> tag is not allowed. But this is a weird use case where the validator error will comment about reference points. This needs to be fixed in the near future. -->

--- a/extensions/amp-story/0.1/test/validator-amp-story-reference-point.html
+++ b/extensions/amp-story/0.1/test/validator-amp-story-reference-point.html
@@ -29,7 +29,7 @@
   <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-0.1.js"></script>
 </head>
 <body>
-  <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/poster.jpg" background-audio="path/to/my.mp3">
+  <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/poster.jpg" bookend-config-src="./related.json" background-audio="path/to/my.mp3">
     <amp-story-page id="1" background-audio="path/to/my.mp3" auto-advance-after="any-value">
       <amp-story-grid-layer template="horizontal">
         <img class="footer-logo" src="img/foot-logo.svg" width="40" height="40" /> <!-- The real error here is that <img/> tag is not allowed. But this is a weird use case where the validator error will comment about reference points. This needs to be fixed in the near future. -->

--- a/extensions/amp-story/0.1/test/validator-amp-story-reference-point.out
+++ b/extensions/amp-story/0.1/test/validator-amp-story-reference-point.out
@@ -31,6 +31,10 @@ FAIL
 |  </head>
 |  <body>
 |    <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/poster.jpg" bookend-config-src="./related.json" background-audio="path/to/my.mp3">
+>>   ^~~~~~~~~
+amp-story/0.1/test/validator-amp-story-reference-point.html:32:2 The relative URL 'path/to/my.mp3' for attribute 'background-audio' in tag 'amp-story' is disallowed. (see https://www.ampproject.org/docs/reference/components/amp-story) [AMP_TAG_PROBLEM]
+>>   ^~~~~~~~~
+amp-story/0.1/test/validator-amp-story-reference-point.html:32:2 The relative URL './related.json' for attribute 'bookend-config-src' in tag 'amp-story' is disallowed. (see https://www.ampproject.org/docs/reference/components/amp-story) [AMP_TAG_PROBLEM]
 |      <amp-story-page id="1" background-audio="path/to/my.mp3" auto-advance-after="any-value">
 |        <amp-story-grid-layer template="horizontal">
 |          <img class="footer-logo" src="img/foot-logo.svg" width="40" height="40" /> <!-- The real error here is that <img/> tag is not allowed. But this is a weird use case where the validator error will comment about reference points. This needs to be fixed in the near future. -->

--- a/extensions/amp-story/0.1/test/validator-amp-story-reference-point.out
+++ b/extensions/amp-story/0.1/test/validator-amp-story-reference-point.out
@@ -30,7 +30,7 @@ FAIL
 |    <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-0.1.js"></script>
 |  </head>
 |  <body>
-|    <amp-story standalone bookend-config-src="./related.json" background-audio="path/to/my.mp3">
+|    <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/poster.jpg" bookend-config-src="./related.json" background-audio="path/to/my.mp3">
 |      <amp-story-page id="1" background-audio="path/to/my.mp3" auto-advance-after="any-value">
 |        <amp-story-grid-layer template="horizontal">
 |          <img class="footer-logo" src="img/foot-logo.svg" width="40" height="40" /> <!-- The real error here is that <img/> tag is not allowed. But this is a weird use case where the validator error will comment about reference points. This needs to be fixed in the near future. -->

--- a/extensions/amp-story/0.1/test/validator-amp-story-reference-point.out
+++ b/extensions/amp-story/0.1/test/validator-amp-story-reference-point.out
@@ -30,7 +30,7 @@ FAIL
 |    <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-0.1.js"></script>
 |  </head>
 |  <body>
-|    <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/poster.jpg" bookend-config-src="./related.json" background-audio="path/to/my.mp3">
+|    <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/poster.jpg" background-audio="path/to/my.mp3">
 |      <amp-story-page id="1" background-audio="path/to/my.mp3" auto-advance-after="any-value">
 |        <amp-story-grid-layer template="horizontal">
 |          <img class="footer-logo" src="img/foot-logo.svg" width="40" height="40" /> <!-- The real error here is that <img/> tag is not allowed. But this is a weird use case where the validator error will comment about reference points. This needs to be fixed in the near future. -->

--- a/extensions/amp-story/0.1/test/validator-amp-story-reference-point.out
+++ b/extensions/amp-story/0.1/test/validator-amp-story-reference-point.out
@@ -30,7 +30,7 @@ FAIL
 |    <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-0.1.js"></script>
 |  </head>
 |  <body>
-|    <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/poster.jpg" background-audio="path/to/my.mp3">
+|    <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/poster.jpg" bookend-config-src="./related.json" background-audio="path/to/my.mp3">
 |      <amp-story-page id="1" background-audio="path/to/my.mp3" auto-advance-after="any-value">
 |        <amp-story-grid-layer template="horizontal">
 |          <img class="footer-logo" src="img/foot-logo.svg" width="40" height="40" /> <!-- The real error here is that <img/> tag is not allowed. But this is a weird use case where the validator error will comment about reference points. This needs to be fixed in the near future. -->

--- a/extensions/amp-story/0.1/test/validator-amp-story-video-error.html
+++ b/extensions/amp-story/0.1/test/validator-amp-story-video-error.html
@@ -31,7 +31,7 @@
   <script async custom-element="amp-video" src="https://cdn.ampproject.org/v0/amp-video-0.1.js"></script>
 </head>
 <body>
-  <amp-story standalone bookend-config-src="./related.json" background-audio="path/to/my.mp3">
+  <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/poster.jpg" bookend-config-src="./related.json" background-audio="path/to/my.mp3">
     <amp-story-page id="1" background-audio="path/to/my.mp3" auto-advance-after="any-value">
       <amp-story-grid-layer template="horizontal">
         <!-- This should fail because amp-video doesn't have the [poster] attribute. -->

--- a/extensions/amp-story/0.1/test/validator-amp-story-video-error.html
+++ b/extensions/amp-story/0.1/test/validator-amp-story-video-error.html
@@ -31,7 +31,7 @@
   <script async custom-element="amp-video" src="https://cdn.ampproject.org/v0/amp-video-0.1.js"></script>
 </head>
 <body>
-  <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/poster.jpg" bookend-config-src="./related.json" background-audio="path/to/my.mp3">
+  <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/poster.jpg" background-audio="path/to/my.mp3">
     <amp-story-page id="1" background-audio="path/to/my.mp3" auto-advance-after="any-value">
       <amp-story-grid-layer template="horizontal">
         <!-- This should fail because amp-video doesn't have the [poster] attribute. -->

--- a/extensions/amp-story/0.1/test/validator-amp-story-video-error.html
+++ b/extensions/amp-story/0.1/test/validator-amp-story-video-error.html
@@ -31,7 +31,7 @@
   <script async custom-element="amp-video" src="https://cdn.ampproject.org/v0/amp-video-0.1.js"></script>
 </head>
 <body>
-  <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/poster.jpg" background-audio="path/to/my.mp3">
+  <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/poster.jpg" bookend-config-src="./related.json" background-audio="path/to/my.mp3">
     <amp-story-page id="1" background-audio="path/to/my.mp3" auto-advance-after="any-value">
       <amp-story-grid-layer template="horizontal">
         <!-- This should fail because amp-video doesn't have the [poster] attribute. -->

--- a/extensions/amp-story/0.1/test/validator-amp-story-video-error.out
+++ b/extensions/amp-story/0.1/test/validator-amp-story-video-error.out
@@ -33,6 +33,10 @@ FAIL
 |  </head>
 |  <body>
 |    <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/poster.jpg" bookend-config-src="./related.json" background-audio="path/to/my.mp3">
+>>   ^~~~~~~~~
+amp-story/0.1/test/validator-amp-story-video-error.html:34:2 The relative URL 'path/to/my.mp3' for attribute 'background-audio' in tag 'amp-story' is disallowed. (see https://www.ampproject.org/docs/reference/components/amp-story) [AMP_TAG_PROBLEM]
+>>   ^~~~~~~~~
+amp-story/0.1/test/validator-amp-story-video-error.html:34:2 The relative URL './related.json' for attribute 'bookend-config-src' in tag 'amp-story' is disallowed. (see https://www.ampproject.org/docs/reference/components/amp-story) [AMP_TAG_PROBLEM]
 |      <amp-story-page id="1" background-audio="path/to/my.mp3" auto-advance-after="any-value">
 |        <amp-story-grid-layer template="horizontal">
 |          <!-- This should fail because amp-video doesn't have the [poster] attribute. -->

--- a/extensions/amp-story/0.1/test/validator-amp-story-video-error.out
+++ b/extensions/amp-story/0.1/test/validator-amp-story-video-error.out
@@ -32,7 +32,7 @@ FAIL
 |    <script async custom-element="amp-video" src="https://cdn.ampproject.org/v0/amp-video-0.1.js"></script>
 |  </head>
 |  <body>
-|    <amp-story standalone bookend-config-src="./related.json" background-audio="path/to/my.mp3">
+|    <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/poster.jpg" bookend-config-src="./related.json" background-audio="path/to/my.mp3">
 |      <amp-story-page id="1" background-audio="path/to/my.mp3" auto-advance-after="any-value">
 |        <amp-story-grid-layer template="horizontal">
 |          <!-- This should fail because amp-video doesn't have the [poster] attribute. -->

--- a/extensions/amp-story/0.1/test/validator-amp-story-video-error.out
+++ b/extensions/amp-story/0.1/test/validator-amp-story-video-error.out
@@ -32,7 +32,7 @@ FAIL
 |    <script async custom-element="amp-video" src="https://cdn.ampproject.org/v0/amp-video-0.1.js"></script>
 |  </head>
 |  <body>
-|    <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/poster.jpg" background-audio="path/to/my.mp3">
+|    <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/poster.jpg" bookend-config-src="./related.json" background-audio="path/to/my.mp3">
 |      <amp-story-page id="1" background-audio="path/to/my.mp3" auto-advance-after="any-value">
 |        <amp-story-grid-layer template="horizontal">
 |          <!-- This should fail because amp-video doesn't have the [poster] attribute. -->

--- a/extensions/amp-story/0.1/test/validator-amp-story-video-error.out
+++ b/extensions/amp-story/0.1/test/validator-amp-story-video-error.out
@@ -32,7 +32,7 @@ FAIL
 |    <script async custom-element="amp-video" src="https://cdn.ampproject.org/v0/amp-video-0.1.js"></script>
 |  </head>
 |  <body>
-|    <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/poster.jpg" bookend-config-src="./related.json" background-audio="path/to/my.mp3">
+|    <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/poster.jpg" background-audio="path/to/my.mp3">
 |      <amp-story-page id="1" background-audio="path/to/my.mp3" auto-advance-after="any-value">
 |        <amp-story-grid-layer template="horizontal">
 |          <!-- This should fail because amp-video doesn't have the [poster] attribute. -->

--- a/extensions/amp-story/0.1/test/validator-amp-story.html
+++ b/extensions/amp-story/0.1/test/validator-amp-story.html
@@ -29,27 +29,7 @@
   <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-0.1.js"></script>
 </head>
 <body>
-  <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/portrait.jpg" poster-square-src="http://me.com/square.jpg" poster-landscape-src="http://me.com/landscape.jpg" background-audio="path/to/my.mp3">
-    <!-- Ideally, publishers would only specify `src` or the <script> child, but not both. -->
-    <amp-story-bookend src="http://me.com/bookend.json">
-      <script type="application/json">
-        {
-          "share-providers": {
-            "facebook": true
-          },
-          "related-articles": {
-            "Article Set": [
-              {
-                "title": "This is an example article",
-                "url": "http://example.com/article.html",
-                "image": "http://placehold.it/256x128"
-              }
-            ]
-          }
-        }
-      </script>
-    </amp-story-bookend>
-
+  <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/portrait.jpg" poster-square-src="http://me.com/square.jpg" poster-landscape-src="http://me.com/landscape.jpg" bookend-config-src="./bookend-config-src.json" background-audio="path/to/my.mp3">
     <amp-story-page id="1" background-audio="path/to/my.mp3" auto-advance-after="any-value">
       <amp-story-grid-layer template="horizontal">
         <h5 animate-in="drop">

--- a/extensions/amp-story/0.1/test/validator-amp-story.html
+++ b/extensions/amp-story/0.1/test/validator-amp-story.html
@@ -29,7 +29,27 @@
   <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-0.1.js"></script>
 </head>
 <body>
-  <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/portrait.jpg" poster-square-src="http://me.com/square.jpg" poster-landscape-src="http://me.com/landscape.jpg" bookend-config-src="./bookend-config-src.json" background-audio="path/to/my.mp3">
+  <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/portrait.jpg" poster-square-src="http://me.com/square.jpg" poster-landscape-src="http://me.com/landscape.jpg" background-audio="path/to/my.mp3">
+    <!-- Ideally, publishers would only specify `src` or the <script> child, but not both. -->
+    <amp-story-bookend src="http://me.com/bookend.json">
+      <script type="application/json">
+        {
+          "share-providers": {
+            "facebook": true
+          },
+          "related-articles": {
+            "Article Set": [
+              {
+                "title": "This is an example article",
+                "url": "http://example.com/article.html",
+                "image": "http://placehold.it/256x128"
+              }
+            ]
+          }
+        }
+      </script>
+    </amp-story-bookend>
+
     <amp-story-page id="1" background-audio="path/to/my.mp3" auto-advance-after="any-value">
       <amp-story-grid-layer template="horizontal">
         <h5 animate-in="drop">

--- a/extensions/amp-story/0.1/test/validator-amp-story.html
+++ b/extensions/amp-story/0.1/test/validator-amp-story.html
@@ -29,7 +29,7 @@
   <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-0.1.js"></script>
 </head>
 <body>
-  <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/portrait.jpg" poster-square-src="http://me.com/square.jpg" poster-landscape-src="http://me.com/landscape.jpg" bookend-config-src="./bookend-config-src.json" background-audio="path/to/my.mp3">
+  <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/portrait.jpg" poster-square-src="http://me.com/square.jpg" poster-landscape-src="http://me.com/landscape.jpg" bookend-config-src="http://me.com/bookend-config-src.json" background-audio="http://me.com/path/to/my.mp3">
     <amp-story-page id="1" background-audio="path/to/my.mp3" auto-advance-after="any-value">
       <amp-story-grid-layer template="horizontal">
         <h5 animate-in="drop">

--- a/extensions/amp-story/0.1/test/validator-amp-story.html
+++ b/extensions/amp-story/0.1/test/validator-amp-story.html
@@ -29,10 +29,7 @@
   <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-0.1.js"></script>
 </head>
 <body>
-  <amp-story standalone
-    title="STAMP examples" publisher="STAMP team" publisher-logo-src="http://pub.com/logo.png"
-    poster-portrait-src="http://pub.com/portrait.jpg" poster-square-src="http://pub.com/square.jpg" poster-landscape-src="http://pub.com/landscape.jpg"
-    bookend-config-src="./bookend-config-src.json" background-audio="path/to/my.mp3">
+  <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/portrait.jpg" poster-square-src="http://me.com/square.jpg" poster-landscape-src="http://me.com/landscape.jpg" bookend-config-src="./bookend-config-src.json" background-audio="path/to/my.mp3">
     <amp-story-page id="1" background-audio="path/to/my.mp3" auto-advance-after="any-value">
       <amp-story-grid-layer template="horizontal">
         <h5 animate-in="drop">

--- a/extensions/amp-story/0.1/test/validator-amp-story.out
+++ b/extensions/amp-story/0.1/test/validator-amp-story.out
@@ -30,7 +30,27 @@ PASS
 |    <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-0.1.js"></script>
 |  </head>
 |  <body>
-|    <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/portrait.jpg" poster-square-src="http://me.com/square.jpg" poster-landscape-src="http://me.com/landscape.jpg" bookend-config-src="./bookend-config-src.json" background-audio="path/to/my.mp3">
+|    <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/portrait.jpg" poster-square-src="http://me.com/square.jpg" poster-landscape-src="http://me.com/landscape.jpg" background-audio="path/to/my.mp3">
+|      <!-- Ideally, publishers would only specify `src` or the <script> child, but not both. -->
+|      <amp-story-bookend src="http://me.com/bookend.json">
+|        <script type="application/json">
+|          {
+|            "share-providers": {
+|              "facebook": true
+|            },
+|            "related-articles": {
+|              "Article Set": [
+|                {
+|                  "title": "This is an example article",
+|                  "url": "http://example.com/article.html",
+|                  "image": "http://placehold.it/256x128"
+|                }
+|              ]
+|            }
+|          }
+|        </script>
+|      </amp-story-bookend>
+|  
 |      <amp-story-page id="1" background-audio="path/to/my.mp3" auto-advance-after="any-value">
 |        <amp-story-grid-layer template="horizontal">
 |          <h5 animate-in="drop">

--- a/extensions/amp-story/0.1/test/validator-amp-story.out
+++ b/extensions/amp-story/0.1/test/validator-amp-story.out
@@ -30,7 +30,7 @@ PASS
 |    <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-0.1.js"></script>
 |  </head>
 |  <body>
-|    <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/portrait.jpg" poster-square-src="http://me.com/square.jpg" poster-landscape-src="http://me.com/landscape.jpg" bookend-config-src="./bookend-config-src.json" background-audio="path/to/my.mp3">
+|    <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/portrait.jpg" poster-square-src="http://me.com/square.jpg" poster-landscape-src="http://me.com/landscape.jpg" bookend-config-src="http://me.com/bookend-config-src.json" background-audio="http://me.com/path/to/my.mp3">
 |      <amp-story-page id="1" background-audio="path/to/my.mp3" auto-advance-after="any-value">
 |        <amp-story-grid-layer template="horizontal">
 |          <h5 animate-in="drop">

--- a/extensions/amp-story/0.1/test/validator-amp-story.out
+++ b/extensions/amp-story/0.1/test/validator-amp-story.out
@@ -30,27 +30,7 @@ PASS
 |    <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-0.1.js"></script>
 |  </head>
 |  <body>
-|    <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/portrait.jpg" poster-square-src="http://me.com/square.jpg" poster-landscape-src="http://me.com/landscape.jpg" background-audio="path/to/my.mp3">
-|      <!-- Ideally, publishers would only specify `src` or the <script> child, but not both. -->
-|      <amp-story-bookend src="http://me.com/bookend.json">
-|        <script type="application/json">
-|          {
-|            "share-providers": {
-|              "facebook": true
-|            },
-|            "related-articles": {
-|              "Article Set": [
-|                {
-|                  "title": "This is an example article",
-|                  "url": "http://example.com/article.html",
-|                  "image": "http://placehold.it/256x128"
-|                }
-|              ]
-|            }
-|          }
-|        </script>
-|      </amp-story-bookend>
-|  
+|    <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/portrait.jpg" poster-square-src="http://me.com/square.jpg" poster-landscape-src="http://me.com/landscape.jpg" bookend-config-src="./bookend-config-src.json" background-audio="path/to/my.mp3">
 |      <amp-story-page id="1" background-audio="path/to/my.mp3" auto-advance-after="any-value">
 |        <amp-story-grid-layer template="horizontal">
 |          <h5 animate-in="drop">

--- a/extensions/amp-story/0.1/test/validator-amp-story.out
+++ b/extensions/amp-story/0.1/test/validator-amp-story.out
@@ -30,7 +30,7 @@ PASS
 |    <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-0.1.js"></script>
 |  </head>
 |  <body>
-|    <amp-story standalone bookend-config-src="./bookend-config-src.json" background-audio="path/to/my.mp3">
+|    <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/portrait.jpg" poster-square-src="http://me.com/square.jpg" poster-landscape-src="http://me.com/landscape.jpg" bookend-config-src="./bookend-config-src.json" background-audio="path/to/my.mp3">
 |      <amp-story-page id="1" background-audio="path/to/my.mp3" auto-advance-after="any-value">
 |        <amp-story-grid-layer template="horizontal">
 |          <h5 animate-in="drop">

--- a/extensions/amp-story/0.1/test/validator-empty-story.html
+++ b/extensions/amp-story/0.1/test/validator-empty-story.html
@@ -30,7 +30,7 @@
   <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-0.1.js"></script>
 </head>
 <body>
-  <amp-story standalone>
+  <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/poster.jpg">
     <amp-pixel src=""></amp-pixel>
   </amp-story>
 </body>

--- a/extensions/amp-story/0.1/test/validator-empty-story.out
+++ b/extensions/amp-story/0.1/test/validator-empty-story.out
@@ -31,7 +31,7 @@ FAIL
 |    <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-0.1.js"></script>
 |  </head>
 |  <body>
-|    <amp-story standalone>
+|    <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/poster.jpg">
 |      <amp-pixel src=""></amp-pixel>
 |    </amp-story>
 |  </body>

--- a/extensions/amp-story/validator-amp-story.protoascii
+++ b/extensions/amp-story/validator-amp-story.protoascii
@@ -90,6 +90,7 @@ tags: {  # <amp-story>
     child_tag_name_oneof: "AMP-ANALYTICS"
     child_tag_name_oneof: "AMP-PIXEL"
     child_tag_name_oneof: "AMP-STORY-AUTO-ADS"
+    child_tag_name_oneof: "AMP-STORY-BOOKEND"
     child_tag_name_oneof: "AMP-STORY-PAGE"
   }
 }
@@ -160,7 +161,7 @@ tags: {  # <amp-story-page>
 tags: { # <amp-story-bookend>
   html_format: AMP
   tag_name: "AMP-STORY-BOOKEND"
-  mandatory_ancestor: "AMP-STORY"
+  mandatory_parent: "AMP-STORY"
   attrs: {
     name: "src"
     value_url: {

--- a/extensions/amp-story/validator-amp-story.protoascii
+++ b/extensions/amp-story/validator-amp-story.protoascii
@@ -53,6 +53,81 @@ tags: {  # <amp-story>
       allowed_protocol: "https"
     }
   }
+  attrs: {
+    name: "title"
+    mandatory: true
+  }
+  attrs: {
+    name: "publisher"
+    mandatory: true
+  }
+  attrs: {
+    name: "publisher-logo-src"
+    mandatory: true
+    value_url: {
+      allowed_protocol: "http"
+      allowed_protocol: "https"
+    }
+  }
+  attrs: {
+    name: "poster-portrait-src"
+    mandatory: true
+    value_url: {
+      allowed_protocol: "http"
+      allowed_protocol: "https"
+    }
+  }
+  attrs: {
+    name: "poster-square-src"
+    value_url: {
+      allowed_protocol: "http"
+      allowed_protocol: "https"
+    }
+  }
+  attrs: {
+    name: "poster-landscape-src"
+    value_url: {
+      allowed_protocol: "http"
+      allowed_protocol: "https"
+    }
+  }
+  siblings_disallowed: true
+  child_tags: {
+    mandatory_min_num_child_tags: 1
+    child_tag_name_oneof: "AMP-ANALYTICS"
+    child_tag_name_oneof: "AMP-PIXEL"
+    child_tag_name_oneof: "AMP-STORY-AUTO-ADS"
+    child_tag_name_oneof: "AMP-STORY-PAGE"
+  }
+}
+tags: {  # <amp-story> without metadata (deprecated)
+  html_format: AMP
+  tag_name: "AMP-STORY"
+  spec_name: "AMP-STORY NO-METADATA"
+  deprecation: "AMP-STORY"
+  deprecation_url: "TODO(choumx)"
+  requires_extension: "amp-story"
+  mandatory_parent: "BODY"
+  requires: "amp-story-page"
+  attrs: {
+    name: "standalone"
+    mandatory: true
+    value: ""
+  }
+  attrs: {
+    name: "bookend-config-src"
+    value_url: {
+      allowed_protocol: "http"
+      allowed_protocol: "https"
+    }
+  }
+  attrs: {
+    name: "background-audio"
+    value_url: {
+      allowed_protocol: "http"
+      allowed_protocol: "https"
+    }
+  }
   siblings_disallowed: true
   child_tags: {
     mandatory_min_num_child_tags: 1

--- a/extensions/amp-story/validator-amp-story.protoascii
+++ b/extensions/amp-story/validator-amp-story.protoascii
@@ -40,13 +40,6 @@ tags: {  # <amp-story>
     value: ""
   }
   attrs: {
-    name: "bookend-config-src"
-    value_url: {
-      allowed_protocol: "http"
-      allowed_protocol: "https"
-    }
-  }
-  attrs: {
     name: "background-audio"
     value_url: {
       allowed_protocol: "http"
@@ -100,7 +93,8 @@ tags: {  # <amp-story>
     child_tag_name_oneof: "AMP-STORY-PAGE"
   }
 }
-tags: {  # <amp-story> without metadata (deprecated)
+# TODO(choumx): Remove this spec prior to launch.
+tags: {  # <amp-story> without metadata attrs or <amp-story-bookend> element
   html_format: AMP
   tag_name: "AMP-STORY"
   spec_name: "AMP-STORY (beta)"
@@ -162,6 +156,44 @@ tags: {  # <amp-story-page>
     child_tag_name_oneof: "AMP-STORY-GRID-LAYER"
     mandatory_min_num_child_tags: 1
   }
+}
+tags: { # <amp-story-bookend>
+  html_format: AMP
+  tag_name: "AMP-STORY-BOOKEND"
+  mandatory_ancestor: "AMP-STORY"
+  attrs: {
+    name: "src"
+    value_url: {
+      allowed_protocol: "http"
+      allowed_protocol: "https"
+    }
+    blacklisted_value_regex: "__amp_source_origin"
+  }
+  child_tags: {
+    first_child_tag_name_oneof: "SCRIPT"
+  }
+  spec_url: "https://www.ampproject.org/docs/reference/components/amp-story"
+}
+tags: {  # <amp-story-bookend> (json)
+  html_format: AMP
+  tag_name: "SCRIPT"
+  spec_name: "AMP-STORY-BOOKEND .json script"
+  requires_extension: "amp-story"
+  mandatory_parent: "AMP-STORY-BOOKEND"
+  attrs: { name: "nonce" }
+  attrs: {
+    name: "type"
+    mandatory: true
+    value_casei: "application/json"
+    dispatch_key: NAME_VALUE_PARENT_DISPATCH
+  }
+  cdata: {
+    blacklisted_cdata_regex: {
+      regex: "<!--"
+      error_message: "html comments"
+    }
+  }
+  spec_url: "https://www.ampproject.org/docs/reference/components/amp-story"
 }
 tags: {  # <amp-story-grid-layer>
   html_format: AMP

--- a/extensions/amp-story/validator-amp-story.protoascii
+++ b/extensions/amp-story/validator-amp-story.protoascii
@@ -35,7 +35,7 @@ tags: {  # <amp-story>
   # requirement to be expressed on the <amp-story> children, however.
   requires: "amp-story-page"
   attrs: {
-    name: "bookend-config-src"
+    name: "background-audio"
     value_url: {
       allowed_protocol: "http"
       allowed_protocol: "https"
@@ -43,7 +43,7 @@ tags: {  # <amp-story>
     }
   }
   attrs: {
-    name: "background-audio"
+    name: "bookend-config-src"
     value_url: {
       allowed_protocol: "http"
       allowed_protocol: "https"
@@ -116,14 +116,14 @@ tags: {  # <amp-story> without metadata (deprecated)
   mandatory_parent: "BODY"
   requires: "amp-story-page"
   attrs: {
-    name: "bookend-config-src"
+    name: "background-audio"
     value_url: {
       allowed_protocol: "http"
       allowed_protocol: "https"
     }
   }
   attrs: {
-    name: "background-audio"
+    name: "bookend-config-src"
     value_url: {
       allowed_protocol: "http"
       allowed_protocol: "https"

--- a/extensions/amp-story/validator-amp-story.protoascii
+++ b/extensions/amp-story/validator-amp-story.protoascii
@@ -39,6 +39,7 @@ tags: {  # <amp-story>
     value_url: {
       allowed_protocol: "http"
       allowed_protocol: "https"
+      allow_relative: false
     }
   }
   attrs: {
@@ -46,6 +47,7 @@ tags: {  # <amp-story>
     value_url: {
       allowed_protocol: "http"
       allowed_protocol: "https"
+      allow_relative: false
     }
   }
   attrs: {
@@ -53,6 +55,7 @@ tags: {  # <amp-story>
     value_url: {
       allowed_protocol: "http"
       allowed_protocol: "https"
+      allow_relative: false
     }
   }
   attrs: {
@@ -61,6 +64,7 @@ tags: {  # <amp-story>
     value_url: {
       allowed_protocol: "http"
       allowed_protocol: "https"
+      allow_relative: false
     }
   }
   attrs: {
@@ -68,6 +72,7 @@ tags: {  # <amp-story>
     value_url: {
       allowed_protocol: "http"
       allowed_protocol: "https"
+      allow_relative: false
     }
   }
   attrs: {
@@ -80,6 +85,7 @@ tags: {  # <amp-story>
     value_url: {
       allowed_protocol: "http"
       allowed_protocol: "https"
+      allow_relative: false
     }
   }
   attrs: {

--- a/extensions/amp-story/validator-amp-story.protoascii
+++ b/extensions/amp-story/validator-amp-story.protoascii
@@ -105,7 +105,7 @@ tags: {  # <amp-story> without metadata (deprecated)
   tag_name: "AMP-STORY"
   spec_name: "AMP-STORY NO-METADATA"
   deprecation: "AMP-STORY"
-  deprecation_url: "TODO(choumx)"
+  deprecation_url: "https://www.ampproject.org/docs/reference/components/amp-story#announcements"
   requires_extension: "amp-story"
   mandatory_parent: "BODY"
   requires: "amp-story-page"

--- a/extensions/amp-story/validator-amp-story.protoascii
+++ b/extensions/amp-story/validator-amp-story.protoascii
@@ -35,11 +35,6 @@ tags: {  # <amp-story>
   # requirement to be expressed on the <amp-story> children, however.
   requires: "amp-story-page"
   attrs: {
-    name: "standalone"
-    mandatory: true
-    value: ""
-  }
-  attrs: {
     name: "bookend-config-src"
     value_url: {
       allowed_protocol: "http"
@@ -54,16 +49,7 @@ tags: {  # <amp-story>
     }
   }
   attrs: {
-    name: "title"
-    mandatory: true
-  }
-  attrs: {
-    name: "publisher"
-    mandatory: true
-  }
-  attrs: {
-    name: "publisher-logo-src"
-    mandatory: true
+    name: "poster-landscape-src"
     value_url: {
       allowed_protocol: "http"
       allowed_protocol: "https"
@@ -85,11 +71,25 @@ tags: {  # <amp-story>
     }
   }
   attrs: {
-    name: "poster-landscape-src"
+    name: "publisher"
+    mandatory: true
+  }
+  attrs: {
+    name: "publisher-logo-src"
+    mandatory: true
     value_url: {
       allowed_protocol: "http"
       allowed_protocol: "https"
     }
+  }
+  attrs: {
+    name: "standalone"
+    mandatory: true
+    value: ""
+  }
+  attrs: {
+    name: "title"
+    mandatory: true
   }
   siblings_disallowed: true
   child_tags: {
@@ -110,11 +110,6 @@ tags: {  # <amp-story> without metadata (deprecated)
   mandatory_parent: "BODY"
   requires: "amp-story-page"
   attrs: {
-    name: "standalone"
-    mandatory: true
-    value: ""
-  }
-  attrs: {
     name: "bookend-config-src"
     value_url: {
       allowed_protocol: "http"
@@ -127,6 +122,11 @@ tags: {  # <amp-story> without metadata (deprecated)
       allowed_protocol: "http"
       allowed_protocol: "https"
     }
+  }
+  attrs: {
+    name: "standalone"
+    mandatory: true
+    value: ""
   }
   siblings_disallowed: true
   child_tags: {

--- a/extensions/amp-story/validator-amp-story.protoascii
+++ b/extensions/amp-story/validator-amp-story.protoascii
@@ -40,6 +40,13 @@ tags: {  # <amp-story>
     value: ""
   }
   attrs: {
+    name: "bookend-config-src"
+    value_url: {
+      allowed_protocol: "http"
+      allowed_protocol: "https"
+    }
+  }
+  attrs: {
     name: "background-audio"
     value_url: {
       allowed_protocol: "http"
@@ -90,12 +97,10 @@ tags: {  # <amp-story>
     child_tag_name_oneof: "AMP-ANALYTICS"
     child_tag_name_oneof: "AMP-PIXEL"
     child_tag_name_oneof: "AMP-STORY-AUTO-ADS"
-    child_tag_name_oneof: "AMP-STORY-BOOKEND"
     child_tag_name_oneof: "AMP-STORY-PAGE"
   }
 }
-# TODO(choumx): Remove this spec prior to launch.
-tags: {  # <amp-story> without metadata attrs or <amp-story-bookend> element
+tags: {  # <amp-story> without metadata (deprecated)
   html_format: AMP
   tag_name: "AMP-STORY"
   spec_name: "AMP-STORY (beta)"
@@ -157,45 +162,6 @@ tags: {  # <amp-story-page>
     child_tag_name_oneof: "AMP-STORY-GRID-LAYER"
     mandatory_min_num_child_tags: 1
   }
-}
-tags: { # <amp-story-bookend>
-  html_format: AMP
-  tag_name: "AMP-STORY-BOOKEND"
-  mandatory_parent: "AMP-STORY"
-  attrs: {
-    name: "src"
-    value_url: {
-      allowed_protocol: "http"
-      allowed_protocol: "https"
-    }
-    blacklisted_value_regex: "__amp_source_origin"
-  }
-  child_tags: {
-    first_child_tag_name_oneof: "SCRIPT"
-  }
-  spec_url: "https://www.ampproject.org/docs/reference/components/amp-story"
-  unique: true # A story should only have one bookend configuration.
-}
-tags: {  # <amp-story-bookend> (json)
-  html_format: AMP
-  tag_name: "SCRIPT"
-  spec_name: "AMP-STORY-BOOKEND .json script"
-  requires_extension: "amp-story"
-  mandatory_parent: "AMP-STORY-BOOKEND"
-  attrs: { name: "nonce" }
-  attrs: {
-    name: "type"
-    mandatory: true
-    value_casei: "application/json"
-    dispatch_key: NAME_VALUE_PARENT_DISPATCH
-  }
-  cdata: {
-    blacklisted_cdata_regex: {
-      regex: "<!--"
-      error_message: "html comments"
-    }
-  }
-  spec_url: "https://www.ampproject.org/docs/reference/components/amp-story"
 }
 tags: {  # <amp-story-grid-layer>
   html_format: AMP

--- a/extensions/amp-story/validator-amp-story.protoascii
+++ b/extensions/amp-story/validator-amp-story.protoascii
@@ -103,7 +103,7 @@ tags: {  # <amp-story>
 tags: {  # <amp-story> without metadata (deprecated)
   html_format: AMP
   tag_name: "AMP-STORY"
-  spec_name: "AMP-STORY NO-METADATA"
+  spec_name: "AMP-STORY (beta)"
   deprecation: "AMP-STORY"
   deprecation_url: "https://www.ampproject.org/docs/reference/components/amp-story#announcements"
   requires_extension: "amp-story"

--- a/extensions/amp-story/validator-amp-story.protoascii
+++ b/extensions/amp-story/validator-amp-story.protoascii
@@ -174,6 +174,7 @@ tags: { # <amp-story-bookend>
     first_child_tag_name_oneof: "SCRIPT"
   }
   spec_url: "https://www.ampproject.org/docs/reference/components/amp-story"
+  unique: true # A story should only have one bookend configuration.
 }
 tags: {  # <amp-story-bookend> (json)
   html_format: AMP


### PR DESCRIPTION
Fixes #11989.

- Adds new `<amp-story>` tagspec with new required metadata attributes
- Deprecates old tagspec as `AMP-STORY (beta)`