### PR TITLE
Fix missing parens in handleShrinkRequest_

### DIFF
--- a/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
@@ -562,9 +562,9 @@ export class SafeframeHostApi {
       return;
     }
     const shrinkHeight = Number(this.iframe_.height) -
-          payload['shrink_b'] + payload['shrink_t'];
+          (payload['shrink_b'] + payload['shrink_t']);
     const shrinkWidth = Number(this.iframe_.width) -
-          payload['shrink_r'] + payload['shrink_l'];
+          (payload['shrink_r'] + payload['shrink_l']);
     // Make sure we are actually shrinking here.
     if (isNaN(shrinkWidth) || isNaN(shrinkHeight) ||
         shrinkWidth > this.creativeSize_.width ||

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-safeframe.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-safeframe.js
@@ -655,17 +655,17 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
      * @param {number} height Pixels to shrink height by.
      * @param {number} width Pixels to shrink width by.
      */
-    function sendShrinkMessage(height, width) {
+    function sendShrinkMessage(top, bottom, left, right) {
       const shrinkMessage = {};
       shrinkMessage[MESSAGE_FIELDS.CHANNEL] = safeframeHost.channel;
       shrinkMessage[MESSAGE_FIELDS.ENDPOINT_IDENTITY] = 1;
       shrinkMessage[MESSAGE_FIELDS.SERVICE] = SERVICE.SHRINK_REQUEST;
       shrinkMessage[MESSAGE_FIELDS.PAYLOAD] = JSON.stringify({
         'uid': 0.623462509818004,
-        'shrink_t': 0,
-        'shrink_r': width,
-        'shrink_b': height,
-        'shrink_l': 0,
+        'shrink_t': top,
+        'shrink_r': right,
+        'shrink_b': bottom,
+        'shrink_l': left,
         'sentinel': safeframeHost.sentinel_,
       });
       receiveMessage(shrinkMessage);
@@ -682,7 +682,7 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
         return {'catch': () => {}};
       };
       attemptChangeSizeStub.returns({then});
-      sendShrinkMessage(10, 10);
+      sendShrinkMessage(5, 5, 5, 5);
 
       return Services.timerFor(env.win).promise(100).then(() => {
         expect(resizeSafeframeSpy).to.be.calledOnce;


### PR DESCRIPTION
Use of shrink should really only pass shrink_b and shrink_r anyway, which this bug does not affect, but if both are passed this won't work as expected.