### PR TITLE
Unmute audio by default in #embedMode=1

### DIFF
--- a/extensions/amp-story/0.1/amp-story-store-service.js
+++ b/extensions/amp-story/0.1/amp-story-store-service.js
@@ -191,6 +191,7 @@ export class AmpStoryStoreService {
           [StateProperty.CAN_SHOW_NAVIGATION_OVERLAY_HINT]: false,
           [StateProperty.CAN_SHOW_PREVIOUS_PAGE_HELP]: true,
           [StateProperty.CAN_SHOW_SYSTEM_LAYER_BUTTONS]: false,
+          [StateProperty.MUTED_STATE]: false,
         };
       default:
         return {};

--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -346,8 +346,9 @@ export class AmpStory extends AMP.BaseElement {
     this.navigationState_.observe(stateChangeEvent =>
       this.variableService_.onStateChange(stateChangeEvent));
 
-    // Mute `amp-story` in beginning.
-    this.mute_();
+    // Set muted state for `amp-story` in beginning.
+    const isMuted = this.storeService_.get(StateProperty.MUTED_STATE);
+    this.onMutedStateUpdate_(isMuted);
   }
 
 
@@ -606,7 +607,6 @@ export class AmpStory extends AMP.BaseElement {
           });
         })
         .then(() => this.switchTo_(firstPageEl.id))
-        .then(() => this.intializeMutedState_())
         .then(() => this.preloadPagesByDistance_());
 
     // Do not block the layout callback on the completion of these promises, as
@@ -758,14 +758,6 @@ export class AmpStory extends AMP.BaseElement {
         });
 
     return Promise.all(pageImplPromises);
-  }
-
-
-  /** @private */
-  intializeMutedState_() {
-    if (!this.storeService_.get(StateProperty.MUTED_STATE)) {
-      this.onMutedStateUpdate_(false /* isMuted */);
-    }
   }
 
 
@@ -1462,7 +1454,9 @@ export class AmpStory extends AMP.BaseElement {
         this.mediaPool_.unmute(this.backgroundAudioEl_);
         this.mediaPool_.play(this.backgroundAudioEl_);
       }
-      this.activePage_.unmuteAllMedia();
+      if (this.activePage_) {
+        this.activePage_.unmuteAllMedia();
+      }
     };
 
     this.mediaPool_.blessAll()

--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -347,7 +347,6 @@ export class AmpStory extends AMP.BaseElement {
       this.variableService_.onStateChange(stateChangeEvent));
 
     // Mute `amp-story` in beginning.
-    // TODO(gmajoulet): Support unmuted embed mode option.
     this.mute_();
   }
 
@@ -607,6 +606,7 @@ export class AmpStory extends AMP.BaseElement {
           });
         })
         .then(() => this.switchTo_(firstPageEl.id))
+        .then(() => this.intializeMutedState_())
         .then(() => this.preloadPagesByDistance_());
 
     // Do not block the layout callback on the completion of these promises, as
@@ -758,6 +758,14 @@ export class AmpStory extends AMP.BaseElement {
         });
 
     return Promise.all(pageImplPromises);
+  }
+
+
+  /** @private */
+  intializeMutedState_() {
+    if (!this.storeService_.get(StateProperty.MUTED_STATE)) {
+      this.onMutedStateUpdate_(false /* isMuted */);
+    }
   }
 
 

--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -348,7 +348,7 @@ export class AmpStory extends AMP.BaseElement {
 
     // Set muted state for `amp-story` in beginning.
     const isMuted = this.storeService_.get(StateProperty.MUTED_STATE);
-    this.onMutedStateUpdate_(isMuted);
+    this.onMutedStateUpdate_(!!isMuted);
   }
 
 


### PR DESCRIPTION
This is only supported by some browsers; it is the responsibility of the embedding platform to ensure that this works for their users.

Tested on Mac OS X Chrome, which will be removing default unmuted audio very soon.

Fixes #14104