### PR TITLE
✨ amp-document-recommendations: Update local document title/history path when appending new document

### DIFF
--- a/extensions/amp-document-recommendations/0.1/amp-document-recommendations.js
+++ b/extensions/amp-document-recommendations/0.1/amp-document-recommendations.js
@@ -98,8 +98,12 @@ export class AmpDocumentRecommendations extends AMP.BaseElement {
           .then(doc => this.attachShadowDoc_(doc), () => {})
           .then(amp => {
             this.win.document.title = amp.title || '';
+            if (this.win.history.replaceState) {
+              const url = parseUrl(next.ampUrl);
+              this.win.history.replaceState({}, amp.title, url.pathname);
+            }
 
-            // TODO(peterjosling): Send request to viewer with title
+            // TODO(peterjosling): Send request to viewer with title/URL
             // TODO(peterjosling): Set title back when scrolling up
             // TODO(peterjosling): Only set title when document becomes active
             // TODO(emarchiori): Trigger analtyics event when active

--- a/extensions/amp-document-recommendations/0.1/amp-document-recommendations.js
+++ b/extensions/amp-document-recommendations/0.1/amp-document-recommendations.js
@@ -93,9 +93,20 @@ export class AmpDocumentRecommendations extends AMP.BaseElement {
 
       // TODO(emarchiori): ampUrl needs to be updated to point to
       // the cache or same domain, otherwise this is a CORS request.
-      Services.xhrFor(this.win).fetchDocument(next.ampUrl).then(doc => {
-        this.attachShadowDoc_(doc);
-      }, () => {});
+      Services.xhrFor(this.win)
+          .fetchDocument(next.ampUrl)
+          .then(doc => this.attachShadowDoc_(doc), () => {})
+          .then(amp => {
+            this.win.document.title = amp.title || '';
+
+            // TODO(peterjosling): Send request to viewer with title
+            // TODO(peterjosling): Set title back when scrolling up
+            // TODO(peterjosling): Only set title when document becomes active
+            // TODO(emarchiori): Trigger analtyics event when active
+            // document changes.
+            // TODO(emarchiori): Hide position fixed elements of inactive
+            // documents and update approriately.
+          });
     }
   }
 
@@ -153,12 +164,6 @@ export class AmpDocumentRecommendations extends AMP.BaseElement {
           try {
             amp =
                 this.multidocManager_.attachShadowDoc(shadowRoot, doc, '', {});
-
-            // TODO(peterjosling): Update document title.
-            // TODO(emarchiori): Trigger analtyics event when active
-            // document changes.
-            // TODO(emarchiori): Hide position fixed elements of inactive
-            // documents and update approriately.
 
             this.element.appendChild(shadowRoot);
             this.appendDivision_();

--- a/extensions/amp-document-recommendations/0.1/amp-document-recommendations.js
+++ b/extensions/amp-document-recommendations/0.1/amp-document-recommendations.js
@@ -141,32 +141,37 @@ export class AmpDocumentRecommendations extends AMP.BaseElement {
   /**
    * Attach a ShadowDoc using the given document.
    * @param {!Document} doc
+   * @return {!Promise<?Object>} Promise resolved with the return value of
+   *     {@link MultiDocManager#attachShadowDoc}
    */
   attachShadowDoc_(doc) {
-    this.getVsync().mutate(() => {
-      const shadowRoot = this.win.document.createElement('div');
+    let amp = null;
+    return this.getVsync()
+        .mutatePromise(() => {
+          const shadowRoot = this.win.document.createElement('div');
 
-      try {
-        this.multidocManager_.attachShadowDoc(shadowRoot, doc, '', {});
+          try {
+            amp =
+                this.multidocManager_.attachShadowDoc(shadowRoot, doc, '', {});
 
-        // TODO(peterjosling): Update document title.
-        // TODO(emarchiori): Trigger analtyics event when active
-        // document changes.
-        // TODO(emarchiori): Hide position fixed elements of inactive
-        // documents and update approriately.
+            // TODO(peterjosling): Update document title.
+            // TODO(emarchiori): Trigger analtyics event when active
+            // document changes.
+            // TODO(emarchiori): Hide position fixed elements of inactive
+            // documents and update approriately.
 
-        this.element.appendChild(shadowRoot);
-        this.appendDivision_();
-        this.appendArticleLinks_(this.nextArticle_ + 1);
+            this.element.appendChild(shadowRoot);
+            this.appendDivision_();
+            this.appendArticleLinks_(this.nextArticle_ + 1);
 
-        if (this.nextArticle_ < this.config_.recommendations.length) {
-          this.appendNextArticle_();
-        }
-
-      } catch (e) {
-        // TODO(emarchiori): Handle loading errors.
-      }
-    });
+            if (this.nextArticle_ < this.config_.recommendations.length) {
+              this.appendNextArticle_();
+            }
+          } catch (e) {
+            // TODO(emarchiori): Handle loading errors.
+          }
+        })
+        .then(() => amp);
   }
 
   /** @override */

--- a/extensions/amp-document-recommendations/0.1/amp-document-recommendations.js
+++ b/extensions/amp-document-recommendations/0.1/amp-document-recommendations.js
@@ -24,6 +24,7 @@ import {isJsonScriptTag} from '../../../src/dom';
 import {parseUrl} from '../../../src/url';
 import {setStyle} from '../../../src/style';
 import {tryParseJson} from '../../../src/json';
+
 import {user} from '../../../src/log';
 
 /** @const */
@@ -92,11 +93,9 @@ export class AmpDocumentRecommendations extends AMP.BaseElement {
 
       // TODO(emarchiori): ampUrl needs to be updated to point to
       // the cache or same domain, otherwise this is a CORS request.
-      Services.xhrFor(this.win)
-          .fetchDocument(next.ampUrl)
-          .then(
-              doc => {this.attachShadowDoc_(doc);},
-              () => {});
+      Services.xhrFor(this.win).fetchDocument(next.ampUrl).then(doc => {
+        this.attachShadowDoc_(doc);
+      }, () => {});
     }
   }
 
@@ -110,7 +109,7 @@ export class AmpDocumentRecommendations extends AMP.BaseElement {
     let article = from;
 
     while (article < this.config_.recommendations.length &&
-        article - from < SEPARATOR_RECOS) {
+           article - from < SEPARATOR_RECOS) {
       const next = this.config_.recommendations[article];
       article++;
 
@@ -121,14 +120,14 @@ export class AmpDocumentRecommendations extends AMP.BaseElement {
       });
 
       const imageElement = doc.createElement('div');
-      imageElement.classList.add('i-amphtml-next-article-image',
-          'amp-document-recommendations-image');
+      imageElement.classList.add(
+          'i-amphtml-next-article-image', 'amp-document-recommendations-image');
       setStyle(imageElement, 'background-image', `url(${next.image})`);
       articleHolder.appendChild(imageElement);
 
       const titleElement = doc.createElement('div');
-      titleElement.classList.add('i-amphtml-next-article-title',
-          'amp-document-recommendations-text');
+      titleElement.classList.add(
+          'i-amphtml-next-article-title', 'amp-document-recommendations-text');
 
       titleElement.textContent = next.title;
       articleHolder.appendChild(titleElement);
@@ -172,8 +171,7 @@ export class AmpDocumentRecommendations extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
-    user().assert(isExperimentOn(this.win, TAG),
-        `Experiment ${TAG} disabled`);
+    user().assert(isExperimentOn(this.win, TAG), `Experiment ${TAG} disabled`);
 
     if (activeInstance_ !== this) {
       return Promise.resolve();
@@ -181,11 +179,9 @@ export class AmpDocumentRecommendations extends AMP.BaseElement {
 
     this.element.classList.add('i-amphtml-document-recommendations');
 
-    this.multidocManager_ = new MultidocManager(
-        this.win,
-        Services.ampdocServiceFor(this.win),
-        Services.extensionsFor(this.win),
-        Services.timerFor(this.win));
+    this.multidocManager_ =
+        new MultidocManager(this.win, Services.ampdocServiceFor(this.win),
+          Services.extensionsFor(this.win), Services.timerFor(this.win));
 
     // TODO(peterjosling): Read config from another source.
 
@@ -193,16 +189,14 @@ export class AmpDocumentRecommendations extends AMP.BaseElement {
     user().assert(children.length == 1,
         'The tag should contain exactly one <script> child.');
     const scriptElement = children[0];
-    user().assert(
-        isJsonScriptTag(scriptElement),
+    user().assert(isJsonScriptTag(scriptElement),
         'The amp-document-recommendations config should ' +
-        'be inside a <script> tag with type="application/json"');
+            'be inside a <script> tag with type="application/json"');
 
-    const configJson = tryParseJson(
-        scriptElement.textContent, error => {
-          throw user().createError(
-              'failed to parse content discovery script', error);
-        });
+    const configJson = tryParseJson(scriptElement.textContent, error => {
+      throw user().createError(
+          'failed to parse content discovery script', error);
+    });
 
     const docInfo = Services.documentInfoForDoc(this.element);
     const host = parseUrl(docInfo.sourceUrl).host;


### PR DESCRIPTION
- Updates local document.title and URL (with replaceState) when appending a new document in amp-content-recommendations. Both required for use outside of a viewer.
- Viewer integration will require changes to the viewer history API to support updating the path (currently only the hash can be changed).