### PR TITLE
Workaround for double-encoding issue on login-done event

### DIFF
--- a/extensions/amp-access/0.1/amp-login-done-dialog.js
+++ b/extensions/amp-access/0.1/amp-login-done-dialog.js
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import {assertAbsoluteHttpOrHttpsUrl, parseQueryString} from '../../../src/url';
+import {
+  assertAbsoluteHttpOrHttpsUrl,
+  parseQueryString,
+  tryDecodeUriComponent,
+} from '../../../src/url';
 import {listen} from '../../../src/event-helper';
 
 
@@ -57,7 +61,12 @@ export class LoginDoneDialog {
 
     if (query['url']) {
       // Source URL is specified. Try to redirect back.
-      this.win.location.replace(assertAbsoluteHttpOrHttpsUrl(query['url']));
+      let url = query['url'];
+      // Protect against double-encoding.
+      if (/^https?\%/i.test(url)) {
+        url = tryDecodeUriComponent(url);
+      }
+      this.win.location.replace(assertAbsoluteHttpOrHttpsUrl(url));
       return Promise.resolve();
     }
 

--- a/extensions/amp-access/0.1/test/test-amp-login-done-dialog.js
+++ b/extensions/amp-access/0.1/test/test-amp-login-done-dialog.js
@@ -201,6 +201,20 @@ describe('LoginDoneDialog', () => {
           });
     });
 
+    it('should work around double-encoding of URL on redirect', () => {
+      windowApi.location.search = '?url=' +
+          encodeURIComponent(encodeURIComponent('http://acme.com/doc1'));
+      windowApi.opener = null;
+      return dialog.postbackOrRedirect_()
+          .then(() => 'SUCCESS', error => 'ERROR ' + error)
+          .then(res => {
+            expect(res).to.equal('SUCCESS');
+            expect(windowApi.location.replace).to.be.calledOnce;
+            expect(windowApi.location.replace.firstCall.args[0]).to.equal(
+                'http://acme.com/doc1');
+          });
+    });
+
     it('should redirect to url without opener with HTTPS', () => {
       windowApi.location.search = '?url=' +
           encodeURIComponent('https://acme.com/doc1');
@@ -213,6 +227,31 @@ describe('LoginDoneDialog', () => {
             expect(windowApi.location.replace.firstCall.args[0]).to.equal(
                 'https://acme.com/doc1');
           });
+    });
+
+    it('should work around double-encoding of URL on redirect w/HTTPS', () => {
+      windowApi.location.search = '?url=' +
+          encodeURIComponent(encodeURIComponent('https://acme.com/doc1'));
+      windowApi.opener = null;
+      return dialog.postbackOrRedirect_()
+          .then(() => 'SUCCESS', error => 'ERROR ' + error)
+          .then(res => {
+            expect(res).to.equal('SUCCESS');
+            expect(windowApi.location.replace).to.be.calledOnce;
+            expect(windowApi.location.replace.firstCall.args[0]).to.equal(
+                'https://acme.com/doc1');
+          });
+    });
+
+    it('should fail tripple-encoding of URL', () => {
+      windowApi.location.search = '?url=' +
+          encodeURIComponent(
+              encodeURIComponent(encodeURIComponent('https://acme.com/doc1')));
+      windowApi.opener = null;
+      expect(() => {
+        dialog.postbackOrRedirect_();
+      }).to.throw(/URL must start with/);
+      expect(windowApi.location.replace).to.have.not.been.called;
     });
 
     it('should fail redirect to url without opener and invalid URL', () => {


### PR DESCRIPTION
It looks to be a common issue where a publisher login form double-encodes `url` query parameter. This will give us some freedom to investigate.