### PR TITLE
Add current page id to story store

### DIFF
--- a/extensions/amp-story/0.1/amp-story-store-service.js
+++ b/extensions/amp-story/0.1/amp-story-store-service.js
@@ -33,6 +33,7 @@ const TAG = 'amp-story';
  *    bookendstate: boolean,
  *    desktopstate: boolean,
  *    mutedstate: boolean,
+ *    currentpageid: string,
  * }}
  */
 export let State;
@@ -51,6 +52,7 @@ export const StateProperty = {
   BOOKEND_STATE: 'bookendstate',
   DESKTOP_STATE: 'desktopstate',
   MUTED_STATE: 'mutedstate',
+  CURRENT_PAGE_ID: 'currentpageid',
 };
 
 
@@ -59,6 +61,7 @@ export const Action = {
   TOGGLE_BOOKEND: 'togglebookend',
   TOGGLE_DESKTOP: 'toggledesktop',
   TOGGLE_MUTED: 'togglemuted',
+  CHANGE_PAGE: 'changepage',
 };
 
 
@@ -86,6 +89,9 @@ const actions = (state, action, data) => {
     case Action.TOGGLE_MUTED:
       return /** @type {!State} */ (Object.assign(
           {}, state, {[StateProperty.MUTED_STATE]: !!data}));
+    case Action.CHANGE_PAGE:
+      return /** @type {!State} */ (Object.assign(
+          {}, state, {[StateProperty.CURRENT_PAGE_ID]: data}));
     default:
       dev().error(TAG, `Unknown action ${action}.`);
       return state;
@@ -172,6 +178,7 @@ export class AmpStoryStoreService {
       [StateProperty.BOOKEND_STATE]: false,
       [StateProperty.DESKTOP_STATE]: false,
       [StateProperty.MUTED_STATE]: true,
+      [StateProperty.CURRENT_PAGE_ID]: '',
     });
   }
 

--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -862,6 +862,8 @@ export class AmpStory extends AMP.BaseElement {
    */
   // TODO(newmuis): Update history state
   switchTo_(targetPageId) {
+    this.storeService_.dispatch(Action.CHANGE_PAGE, targetPageId);
+
     const targetPage = this.getPageById(targetPageId);
     const pageIndex = this.getPageIndex(targetPage);
 

--- a/extensions/amp-story/0.1/test/test-amp-story-store-service.js
+++ b/extensions/amp-story/0.1/test/test-amp-story-store-service.js
@@ -103,4 +103,12 @@ describes.fakeWin('amp-story-store-service actions', {}, env => {
     expect(listenerSpy).to.have.been.calledOnce;
     expect(listenerSpy).to.have.been.calledWith(true);
   });
+
+  it('should update the current page', () => {
+    const listenerSpy = sandbox.spy();
+    storeService.subscribe(StateProperty.CURRENT_PAGE_ID, listenerSpy);
+    storeService.dispatch(Action.CHANGE_PAGE, 'test-page');
+    expect(listenerSpy).to.have.been.calledOnce;
+    expect(listenerSpy).to.have.been.calledWith('test-page');
+  });
 });

--- a/extensions/amp-story/0.1/test/test-amp-story.js
+++ b/extensions/amp-story/0.1/test/test-amp-story.js
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import {Action} from '../amp-story-store-service';
 import {AmpStory} from '../amp-story';
 import {AmpStoryPage} from '../amp-story-page';
 import {EventType} from '../events';
@@ -292,6 +293,20 @@ describes.realWin('amp-story', {
         expect(story.element.classList.contains('i-amphtml-story-landscape'))
             .to.be.false;
       });
+
+  it('should update page id in store', () => {
+    const firstPageId = 'page-one';
+    const pageCount = 2;
+    createPages(story.element, pageCount, [firstPageId, 'page-1']);
+    const dispatchStub =
+        sandbox.stub(story.storeService_, 'dispatch');
+
+    return story.layoutCallback()
+        .then(() => {
+          expect(dispatchStub)
+              .to.have.been.calledWith(Action.CHANGE_PAGE, firstPageId);
+        });
+  });
 });
 
 


### PR DESCRIPTION
Each time a page is changed, update the `CURRENT_PAGE_ID` in the store.

NOTE: this differs from the previous effort in that it is not actually using the store for navigation, just writing the state changes.