### PR TITLE
🐛 Build break: Fix gulp dist

### DIFF
--- a/extensions/amp-access/0.1/amp-access-iframe.js
+++ b/extensions/amp-access/0.1/amp-access-iframe.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {Messenger} from './iframe-api/messenger';
+import {Messenger} from 'extensions/amp-access/0.1/iframe-api/messenger';
 import {assertHttpsUrl} from '../../../src/url';
 import {parseUrl} from '../../../src/url';
 import {toggle} from '../../../src/style';


### PR DESCRIPTION
#14195 broke `gulp dist` due to a relative path that doesn't work during a closure compile because the extension's path changes from `extensions/amp-access/0.1/amp-access-iframe.js` to `build/all/v0/amp-access-iframe.js`. This PR fixes `gulp dist` by switching the path of `iframe-api/messenger.js` to the full path from the src root.
```
Compiler error:
build/all/v0/amp-access-iframe.js:17: WARNING - Failed to load module "./iframe-api/messenger.js"

0 error(s), 1 warning(s)
```