### PR TITLE
RTC: fix invalid timeout logging

### DIFF
--- a/extensions/amp-a4a/0.1/real-time-config-manager.js
+++ b/extensions/amp-a4a/0.1/real-time-config-manager.js
@@ -298,10 +298,11 @@ export function validateRtcConfig_(element) {
           if (isNaN(timeout)) {
             user().warn(TAG, 'Invalid RTC timeout is NaN, ' +
                         `using default timeout ${defaultTimeoutMillis}ms`);
-          } else if (timeout >= defaultTimeoutMillis || timeout < 0) {
             timeout = undefined;
+          } else if (timeout >= defaultTimeoutMillis || timeout < 0) {
             user().warn(TAG, `Invalid RTC timeout: ${timeout}ms, ` +
                         `using default timeout ${defaultTimeoutMillis}ms`);
+            timeout = undefined;
           }
           break;
         default:


### PR DESCRIPTION
Steps to reproduce:

- set rtc config with non-numeric timeout

Result is that error message indicates "undefined" timeout value given.

Also correct possible issue where non-numeric values are improperly being set in the config
