### PR TITLE
Adding bookend scroll momentum on iOS for canonical URLs.

### DIFF
--- a/extensions/amp-story/0.1/amp-story-bookend.css
+++ b/extensions/amp-story/0.1/amp-story-bookend.css
@@ -42,6 +42,7 @@
 
 .i-amphtml-story-bookend-overflow {
   overflow: auto !important;
+  -webkit-overflow-scrolling: touch !important;
   margin-top: auto !important; /* positions it at the bottom of container */
   transition: opacity 0.3s, transform 0.3s ease-out !important;
 }


### PR DESCRIPTION
DOM elements apparently don't get scroll momentum by default on iOS, even if you specify ``overflow-y: scroll;``.
Runtime enables scroll momentum by adding ``-webkit-overflow-scrolling: touch;`` when the story is embed (local development or served from the cache), but not when it's served from the canonical URL.

Fixes #14253