### PR TITLE
Allow fallback elements for amp-story

### DIFF
--- a/examples/amp-story/progress-bar.html
+++ b/examples/amp-story/progress-bar.html
@@ -28,6 +28,7 @@
 
   <body>
     <amp-story standalone bookend-config-src="bookend.json">
+
       <amp-story-page id="cover">
         <amp-story-grid-layer template="vertical">
           <h1>Progress Bar examples with bookend</h1>

--- a/examples/amp-story/progress-bar.html
+++ b/examples/amp-story/progress-bar.html
@@ -28,7 +28,9 @@
 
   <body>
     <amp-story standalone bookend-config-src="bookend.json">
-
+      <div fallback>
+        hey there
+      </div>
       <amp-story-page id="cover">
         <amp-story-grid-layer template="vertical">
           <h1>Progress Bar examples with bookend</h1>

--- a/examples/amp-story/progress-bar.html
+++ b/examples/amp-story/progress-bar.html
@@ -28,9 +28,6 @@
 
   <body>
     <amp-story standalone bookend-config-src="bookend.json">
-      <div fallback>
-        hey there
-      </div>
       <amp-story-page id="cover">
         <amp-story-grid-layer template="vertical">
           <h1>Progress Bar examples with bookend</h1>

--- a/extensions/amp-story/0.1/amp-story-store-service.js
+++ b/extensions/amp-story/0.1/amp-story-store-service.js
@@ -67,6 +67,7 @@ export const Action = {
   TOGGLE_HAS_AUDIO: 'togglehasaudio',
   TOGGLE_MUTED: 'togglemuted',
   CHANGE_PAGE: 'changepage',
+  ENTER_FALLBACK: 'enterfallback',
 };
 
 
@@ -74,10 +75,10 @@ export const Action = {
  * Returns the new sate.
  * @param  {!State} state Immutable state
  * @param  {!Action} action
- * @param  {*} data
+ * @param  {*=} data
  * @return {!State} new state
  */
-const actions = (state, action, data) => {
+const actions = (state, action, data = undefined) => {
   switch (action) {
     // Shows or hides the bookend.
     case Action.TOGGLE_BOOKEND:
@@ -170,9 +171,9 @@ export class AmpStoryStoreService {
    * Dispatches an action and triggers the listeners for the updated state
    * properties.
    * @param  {!Action} action
-   * @param  {*} data
+   * @param  {*=} data
    */
-  dispatch(action, data) {
+  dispatch(action, data = undefined) {
     const oldState = Object.assign({}, this.state_);
     this.state_ = actions(this.state_, action, data);
 

--- a/extensions/amp-story/0.1/amp-story-store-service.js
+++ b/extensions/amp-story/0.1/amp-story-store-service.js
@@ -75,10 +75,10 @@ export const Action = {
  * Returns the new sate.
  * @param  {!State} state Immutable state
  * @param  {!Action} action
- * @param  {*=} data
+ * @param  {*} data
  * @return {!State} new state
  */
-const actions = (state, action, data = undefined) => {
+const actions = (state, action, data) => {
   switch (action) {
     // Shows or hides the bookend.
     case Action.TOGGLE_BOOKEND:
@@ -171,9 +171,9 @@ export class AmpStoryStoreService {
    * Dispatches an action and triggers the listeners for the updated state
    * properties.
    * @param  {!Action} action
-   * @param  {*=} data
+   * @param  {*} data
    */
-  dispatch(action, data = undefined) {
+  dispatch(action, data) {
     const oldState = Object.assign({}, this.state_);
     this.state_ = actions(this.state_, action, data);
 

--- a/extensions/amp-story/0.1/amp-story-store-service.js
+++ b/extensions/amp-story/0.1/amp-story-store-service.js
@@ -32,6 +32,7 @@ const TAG = 'amp-story';
  *    canshowsystemlayerbuttons: boolean,
  *    bookendstate: boolean,
  *    desktopstate: boolean,
+ *    fallbackstate: boolean,
  *    hasaudiostate: boolean,
  *    mutedstate: boolean,
  *    currentpageid: string,
@@ -52,6 +53,7 @@ export const StateProperty = {
   // App States.
   BOOKEND_STATE: 'bookendstate',
   DESKTOP_STATE: 'desktopstate',
+  FALLBACK_STATE: 'fallbackstate',
   HAS_AUDIO_STATE: 'hasaudiostate',
   MUTED_STATE: 'mutedstate',
   CURRENT_PAGE_ID: 'currentpageid',
@@ -99,6 +101,19 @@ const actions = (state, action, data) => {
     case Action.CHANGE_PAGE:
       return /** @type {!State} */ (Object.assign(
           {}, state, {[StateProperty.CURRENT_PAGE_ID]: data}));
+    case Action.ENTER_FALLBACK:
+      return /** @type {!State} */ ({
+        [StateProperty.CAN_INSERT_AUTOMATIC_AD]: false,
+        [StateProperty.CAN_SHOW_BOOKEND]: false,
+        [StateProperty.CAN_SHOW_NAVIGATION_OVERLAY_HINT]: false,
+        [StateProperty.CAN_SHOW_PREVIOUS_PAGE_HELP]: false,
+        [StateProperty.CAN_SHOW_SYSTEM_LAYER_BUTTONS]: false,
+        [StateProperty.BOOKEND_STATE]: false,
+        [StateProperty.DESKTOP_STATE]: false,
+        [StateProperty.FALLBACK_STATE]: true,
+        [StateProperty.HAS_AUDIO_STATE]: false,
+        [StateProperty.MUTED_STATE]: true,
+      });
     default:
       dev().error(TAG, `Unknown action ${action}.`);
       return state;
@@ -184,6 +199,7 @@ export class AmpStoryStoreService {
       [StateProperty.CAN_SHOW_SYSTEM_LAYER_BUTTONS]: true,
       [StateProperty.BOOKEND_STATE]: false,
       [StateProperty.DESKTOP_STATE]: false,
+      [StateProperty.FALLBACK_STATE]: false,
       [StateProperty.HAS_AUDIO_STATE]: false,
       [StateProperty.MUTED_STATE]: true,
       [StateProperty.CURRENT_PAGE_ID]: '',

--- a/extensions/amp-story/0.1/amp-story-store-service.js
+++ b/extensions/amp-story/0.1/amp-story-store-service.js
@@ -106,18 +106,19 @@ const actions = (state, action, data) => {
       if (!data) {
         dev().error(TAG, 'Cannot exit fallback state.');
       }
-      return /** @type {!State} */ ({
-        [StateProperty.CAN_INSERT_AUTOMATIC_AD]: false,
-        [StateProperty.CAN_SHOW_BOOKEND]: false,
-        [StateProperty.CAN_SHOW_NAVIGATION_OVERLAY_HINT]: false,
-        [StateProperty.CAN_SHOW_PREVIOUS_PAGE_HELP]: false,
-        [StateProperty.CAN_SHOW_SYSTEM_LAYER_BUTTONS]: false,
-        [StateProperty.BOOKEND_STATE]: false,
-        [StateProperty.DESKTOP_STATE]: false,
-        [StateProperty.FALLBACK_STATE]: true,
-        [StateProperty.HAS_AUDIO_STATE]: false,
-        [StateProperty.MUTED_STATE]: true,
-      });
+      return /** @type {!State} */ (Object.assign(
+          {}, state, {
+            [StateProperty.CAN_INSERT_AUTOMATIC_AD]: false,
+            [StateProperty.CAN_SHOW_BOOKEND]: false,
+            [StateProperty.CAN_SHOW_NAVIGATION_OVERLAY_HINT]: false,
+            [StateProperty.CAN_SHOW_PREVIOUS_PAGE_HELP]: false,
+            [StateProperty.CAN_SHOW_SYSTEM_LAYER_BUTTONS]: false,
+            [StateProperty.BOOKEND_STATE]: false,
+            [StateProperty.DESKTOP_STATE]: false,
+            [StateProperty.FALLBACK_STATE]: true,
+            [StateProperty.HAS_AUDIO_STATE]: false,
+            [StateProperty.MUTED_STATE]: true,
+          }));
     default:
       dev().error(TAG, `Unknown action ${action}.`);
       return state;

--- a/extensions/amp-story/0.1/amp-story-store-service.js
+++ b/extensions/amp-story/0.1/amp-story-store-service.js
@@ -64,10 +64,10 @@ export const StateProperty = {
 export const Action = {
   TOGGLE_BOOKEND: 'togglebookend',
   TOGGLE_DESKTOP: 'toggledesktop',
+  TOGGLE_FALLBACK: 'togglefallback',
   TOGGLE_HAS_AUDIO: 'togglehasaudio',
   TOGGLE_MUTED: 'togglemuted',
   CHANGE_PAGE: 'changepage',
-  ENTER_FALLBACK: 'enterfallback',
 };
 
 
@@ -102,7 +102,10 @@ const actions = (state, action, data) => {
     case Action.CHANGE_PAGE:
       return /** @type {!State} */ (Object.assign(
           {}, state, {[StateProperty.CURRENT_PAGE_ID]: data}));
-    case Action.ENTER_FALLBACK:
+    case Action.TOGGLE_FALLBACK:
+      if (!data) {
+        dev().error(TAG, 'Cannot exit fallback state.');
+      }
       return /** @type {!State} */ ({
         [StateProperty.CAN_INSERT_AUTOMATIC_AD]: false,
         [StateProperty.CAN_SHOW_BOOKEND]: false,

--- a/extensions/amp-story/0.1/amp-story.css
+++ b/extensions/amp-story/0.1/amp-story.css
@@ -104,7 +104,6 @@ amp-story .amp-video-eq {
 /** Page level */
 amp-story-page {
   bottom: 0 !important;
-  display: none !important;
   height: auto !important;
   left: 0 !important;
   position: absolute !important;
@@ -113,8 +112,8 @@ amp-story-page {
   transition: none !important;
 }
 
-amp-story-page.i-amphtml-layout-container {
-  display: block !important;
+.i-amphtml-story-fallback amp-story-page {
+  display: none !important;
 }
 
 /* Setting `translateY` distances as a trick so that the runtime schedules

--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -627,7 +627,7 @@ export class AmpStory extends AMP.BaseElement {
   /** @override */
   layoutCallback() {
     if (!AmpStory.isBrowserSupported(this.win) && !this.platform_.isBot()) {
-      this.storeService_.dispatch(Action.TOGGLE_FALLBACK);
+      this.storeService_.dispatch(Action.TOGGLE_FALLBACK, true);
       return Promise.resolve();
     }
 

--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -429,11 +429,11 @@ export class AmpStory extends AMP.BaseElement {
 
     this.storeService_.subscribe(StateProperty.FALLBACK_STATE,
         fallbackState => {
-          if (fallbackState) {
-            this.enterFallback_();
-          } else {
+          if (!fallbackState) {
             dev().error(TAG, 'No handler to exit fallback state.');
           }
+
+          this.enterFallback_();
         });
 
     this.element.addEventListener(EventType.SWITCH_PAGE, e => {
@@ -627,7 +627,7 @@ export class AmpStory extends AMP.BaseElement {
   /** @override */
   layoutCallback() {
     if (!AmpStory.isBrowserSupported(this.win) && !this.platform_.isBot()) {
-      this.storeService_.dispatch(Action.ENTER_FALLBACK);
+      this.storeService_.dispatch(Action.TOGGLE_FALLBACK);
       return Promise.resolve();
     }
 

--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -427,6 +427,15 @@ export class AmpStory extends AMP.BaseElement {
       this.onMutedStateUpdate_(isMuted);
     });
 
+    this.storeService_.subscribe(StateProperty.FALLBACK_STATE,
+        fallbackState => {
+          if (fallbackState) {
+            this.enterFallback_();
+          } else {
+            dev().error(TAG, 'No handler to exit fallback state.');
+          }
+        });
+
     this.element.addEventListener(EventType.SWITCH_PAGE, e => {
       if (this.storeService_.get(StateProperty.BOOKEND_STATE)) {
         // Disallow switching pages while the bookend is active.
@@ -618,8 +627,7 @@ export class AmpStory extends AMP.BaseElement {
   /** @override */
   layoutCallback() {
     if (!AmpStory.isBrowserSupported(this.win) && !this.platform_.isBot()) {
-      this.buildUnsupportedBrowserOverlay_();
-      dev().expectedError(TAG, 'Unsupported browser');
+      this.storeService_.dispatch(Action.ENTER_FALLBACK);
       return Promise.resolve();
     }
 
@@ -1072,6 +1080,22 @@ export class AmpStory extends AMP.BaseElement {
           this.element.firstChild);
     });
   }
+
+
+  /** @private */
+  enterFallback_() {
+    const fallbackEl = this.getFallback();
+    this.mutateElement(() => {
+      this.element.classList.add('i-amphtml-story-fallback');
+    });
+
+    if (fallbackEl) {
+      this.toggleFallback(true);
+    } else {
+      this.buildUnsupportedBrowserOverlay_();
+    }
+  }
+
 
   /**
    * Build overlay for Landscape mode mobile

--- a/extensions/amp-story/0.1/test/test-amp-story-store-service.js
+++ b/extensions/amp-story/0.1/test/test-amp-story-store-service.js
@@ -119,4 +119,12 @@ describes.fakeWin('amp-story-store-service actions', {}, env => {
     expect(listenerSpy).to.have.been.calledOnce;
     expect(listenerSpy).to.have.been.calledWith(true);
   });
+
+  it('should set the fallback state', () => {
+    const listenerSpy = sandbox.spy();
+    storeService.subscribe(StateProperty.FALLBACK_STATE, listenerSpy);
+    storeService.dispatch(Action.ENTER_FALLBACK);
+    expect(listenerSpy).to.have.been.calledOnce;
+    expect(listenerSpy).to.have.been.calledWith(true);
+  });
 });

--- a/extensions/amp-story/0.1/test/test-amp-story-store-service.js
+++ b/extensions/amp-story/0.1/test/test-amp-story-store-service.js
@@ -123,7 +123,7 @@ describes.fakeWin('amp-story-store-service actions', {}, env => {
   it('should set the fallback state', () => {
     const listenerSpy = sandbox.spy();
     storeService.subscribe(StateProperty.FALLBACK_STATE, listenerSpy);
-    storeService.dispatch(Action.ENTER_FALLBACK);
+    storeService.dispatch(Action.TOGGLE_FALLBACK, true);
     expect(listenerSpy).to.have.been.calledOnce;
     expect(listenerSpy).to.have.been.calledWith(true);
   });


### PR DESCRIPTION
If a direct child of `amp-story` is specified with the `fallback` attribute, we show it instead of the "browser unsupported" screen.

Fixes #14101 