### PR TITLE
Fixes issue where fluid response is treated as empty multi-size response.

### DIFF
--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -981,7 +981,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     // We want to resize only if neither returned dimension is larger than its
     // primary counterpart, and if at least one of the returned dimensions
     // differ from its primary counterpart.
-    if (this.isFluid_ ||
+    if ((this.isFluid_ && width > 0 && height > 0) ||
         (width != pWidth || height != pHeight) &&
         (width <= pWidth && height <= pHeight)) {
       this.attemptChangeSize(height, width).catch(() => {});

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -981,7 +981,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     // We want to resize only if neither returned dimension is larger than its
     // primary counterpart, and if at least one of the returned dimensions
     // differ from its primary counterpart.
-    if ((this.isFluid_ && width > 0 && height > 0) ||
+    if ((this.isFluid_ && width && height) ||
         (width != pWidth || height != pHeight) &&
         (width <= pWidth && height <= pHeight)) {
       this.attemptChangeSize(height, width).catch(() => {});

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -172,6 +172,21 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
       preloadExtensionSpy = sandbox.spy(extensions, 'preloadExtension');
     });
 
+    it('should ignore creative-size header for fluid response', () => {
+      impl.isFluid_ = true;
+      impl.element.setAttribute('height', 'fluid');
+      const resizeSpy = sandbox.spy(impl, 'attemptChangeSize');
+      expect(impl.extractSize({
+        get(name) {
+          return name == CREATIVE_SIZE_HEADER ? '0x0' : undefined;
+        },
+        has(name) {
+          return name == CREATIVE_SIZE_HEADER;
+        },
+      })).to.deep.equal({width: 0, height: 0});
+      expect(resizeSpy).to.not.be.called;
+    });
+
     it('should not load amp-analytics without an analytics header', () => {
       expect(impl.extractSize({
         get() {


### PR DESCRIPTION
For requests that are both multi-size and fluid, the response may be fluid but may contain a multi-size header indicating the size of the creative. Since fluid creatives by default have no size (i.e., return a size header of '0x0'), this causes the slot to collapse when it should not.