### PR TITLE
Deprecate Delayed Fetch for Doubleclick

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -33,7 +33,7 @@
   "expUnconditionedAdxIdentity": 0.01,
   "expUnconditionedDfpIdentity": 0.01,
   "expUnconditionedCanonicalHoldback": 0.01,
-  "rollback-delayed-fetch-deprecation": 1,
+  "rollback-delayed-fetch-deprecation": 0,
   "rollback-dfd-ix": 1,
   "rollback-dfd-criteo": 1,
   "rollback-dfd-rubicon": 1,

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -32,7 +32,7 @@
   "expUnconditionedAdxIdentity": 0.01,
   "expUnconditionedDfpIdentity": 0.01,
   "expUnconditionedCanonicalHoldback": 0.01,
-  "rollback-delayed-fetch-deprecation": 1,
+  "rollback-delayed-fetch-deprecation": 0,
   "rollback-dfd-ix": 1,
   "rollback-dfd-criteo": 1,
   "rollback-dfd-rubicon": 1,


### PR DESCRIPTION
This PR launches the deprecation of Delayed Fetch for Doubleclick. 
Please see https://github.com/ampproject/amphtml/issues/11834 for more information. 