### PR TITLE
Orientation layer and unsupported browser layer as Shadow DOM components.

### DIFF
--- a/extensions/amp-story/0.1/amp-story-store-service.js
+++ b/extensions/amp-story/0.1/amp-story-store-service.js
@@ -34,6 +34,7 @@ const TAG = 'amp-story';
  *    desktopstate: boolean,
  *    fallbackstate: boolean,
  *    hasaudiostate: boolean,
+ *    landscapestate: boolean,
  *    mutedstate: boolean,
  *    currentpageid: string,
  * }}
@@ -55,6 +56,7 @@ export const StateProperty = {
   DESKTOP_STATE: 'desktopstate',
   FALLBACK_STATE: 'fallbackstate',
   HAS_AUDIO_STATE: 'hasaudiostate',
+  LANDSCAPE_STATE: 'landscapestate',
   MUTED_STATE: 'mutedstate',
   CURRENT_PAGE_ID: 'currentpageid',
 };
@@ -66,6 +68,7 @@ export const Action = {
   TOGGLE_DESKTOP: 'toggledesktop',
   TOGGLE_FALLBACK: 'togglefallback',
   TOGGLE_HAS_AUDIO: 'togglehasaudio',
+  TOGGLE_LANDSCAPE: 'togglelandscape',
   TOGGLE_MUTED: 'togglemuted',
   CHANGE_PAGE: 'changepage',
 };
@@ -95,6 +98,9 @@ const actions = (state, action, data) => {
     case Action.TOGGLE_HAS_AUDIO:
       return /** @type {!State} */ (Object.assign(
           {}, state, {[StateProperty.HAS_AUDIO_STATE]: !!data}));
+    case Action.TOGGLE_LANDSCAPE:
+      return /** @type {!State} */ (Object.assign(
+          {}, state, {[StateProperty.LANDSCAPE_STATE]: !!data}));
     // Mutes or unmutes the story media.
     case Action.TOGGLE_MUTED:
       return /** @type {!State} */ (Object.assign(
@@ -212,6 +218,7 @@ export class AmpStoryStoreService {
       [StateProperty.DESKTOP_STATE]: false,
       [StateProperty.FALLBACK_STATE]: false,
       [StateProperty.HAS_AUDIO_STATE]: false,
+      [StateProperty.LANDSCAPE_STATE]: false,
       [StateProperty.MUTED_STATE]: true,
       [StateProperty.CURRENT_PAGE_ID]: '',
     });

--- a/extensions/amp-story/0.1/amp-story-store-service.js
+++ b/extensions/amp-story/0.1/amp-story-store-service.js
@@ -32,7 +32,6 @@ const TAG = 'amp-story';
  *    canshowsystemlayerbuttons: boolean,
  *    bookendstate: boolean,
  *    desktopstate: boolean,
- *    fallbackstate: boolean,
  *    hasaudiostate: boolean,
  *    landscapestate: boolean,
  *    mutedstate: boolean,
@@ -55,7 +54,6 @@ export const StateProperty = {
   // App States.
   BOOKEND_STATE: 'bookendstate',
   DESKTOP_STATE: 'desktopstate',
-  FALLBACK_STATE: 'fallbackstate',
   HAS_AUDIO_STATE: 'hasaudiostate',
   LANDSCAPE_STATE: 'landscapestate',
   MUTED_STATE: 'mutedstate',
@@ -68,7 +66,6 @@ export const StateProperty = {
 export const Action = {
   TOGGLE_BOOKEND: 'togglebookend',
   TOGGLE_DESKTOP: 'toggledesktop',
-  TOGGLE_FALLBACK: 'togglefallback',
   TOGGLE_HAS_AUDIO: 'togglehasaudio',
   TOGGLE_LANDSCAPE: 'togglelandscape',
   TOGGLE_MUTED: 'togglemuted',
@@ -109,14 +106,8 @@ const actions = (state, action, data) => {
       return /** @type {!State} */ (Object.assign(
           {}, state, {[StateProperty.MUTED_STATE]: !!data}));
     case Action.TOGGLE_SUPPORTED_BROWSER:
-      return /** @type {!State} */ (Object.assign(
-          {}, state, {[StateProperty.SUPPORTED_BROWSER_STATE]: !!data}));
-    case Action.CHANGE_PAGE:
-      return /** @type {!State} */ (Object.assign(
-          {}, state, {[StateProperty.CURRENT_PAGE_ID]: data}));
-    case Action.TOGGLE_FALLBACK:
-      if (!data) {
-        dev().error(TAG, 'Cannot exit fallback state.');
+      if (data) {
+        dev().error(TAG, 'Cannot exit unsupported browser state.');
       }
       return /** @type {!State} */ (Object.assign(
           {}, state, {
@@ -127,10 +118,13 @@ const actions = (state, action, data) => {
             [StateProperty.CAN_SHOW_SYSTEM_LAYER_BUTTONS]: false,
             [StateProperty.BOOKEND_STATE]: false,
             [StateProperty.DESKTOP_STATE]: false,
-            [StateProperty.FALLBACK_STATE]: true,
             [StateProperty.HAS_AUDIO_STATE]: false,
             [StateProperty.MUTED_STATE]: true,
+            [StateProperty.SUPPORTED_BROWSER_STATE]: false,
           }));
+    case Action.CHANGE_PAGE:
+      return /** @type {!State} */ (Object.assign(
+          {}, state, {[StateProperty.CURRENT_PAGE_ID]: data}));
     default:
       dev().error(TAG, `Unknown action ${action}.`);
       return state;
@@ -222,7 +216,6 @@ export class AmpStoryStoreService {
       [StateProperty.CAN_SHOW_SYSTEM_LAYER_BUTTONS]: true,
       [StateProperty.BOOKEND_STATE]: false,
       [StateProperty.DESKTOP_STATE]: false,
-      [StateProperty.FALLBACK_STATE]: false,
       [StateProperty.HAS_AUDIO_STATE]: false,
       [StateProperty.LANDSCAPE_STATE]: false,
       [StateProperty.MUTED_STATE]: true,

--- a/extensions/amp-story/0.1/amp-story-store-service.js
+++ b/extensions/amp-story/0.1/amp-story-store-service.js
@@ -36,6 +36,7 @@ const TAG = 'amp-story';
  *    hasaudiostate: boolean,
  *    landscapestate: boolean,
  *    mutedstate: boolean,
+ *    supportedbrowserstate: boolean,
  *    currentpageid: string,
  * }}
  */
@@ -58,6 +59,7 @@ export const StateProperty = {
   HAS_AUDIO_STATE: 'hasaudiostate',
   LANDSCAPE_STATE: 'landscapestate',
   MUTED_STATE: 'mutedstate',
+  SUPPORTED_BROWSER_STATE: 'supportedbrowserstate',
   CURRENT_PAGE_ID: 'currentpageid',
 };
 
@@ -70,6 +72,7 @@ export const Action = {
   TOGGLE_HAS_AUDIO: 'togglehasaudio',
   TOGGLE_LANDSCAPE: 'togglelandscape',
   TOGGLE_MUTED: 'togglemuted',
+  TOGGLE_SUPPORTED_BROWSER: 'supportedbrowserstate',
   CHANGE_PAGE: 'changepage',
 };
 
@@ -105,6 +108,9 @@ const actions = (state, action, data) => {
     case Action.TOGGLE_MUTED:
       return /** @type {!State} */ (Object.assign(
           {}, state, {[StateProperty.MUTED_STATE]: !!data}));
+    case Action.TOGGLE_SUPPORTED_BROWSER:
+      return /** @type {!State} */ (Object.assign(
+          {}, state, {[StateProperty.SUPPORTED_BROWSER_STATE]: !!data}));
     case Action.CHANGE_PAGE:
       return /** @type {!State} */ (Object.assign(
           {}, state, {[StateProperty.CURRENT_PAGE_ID]: data}));
@@ -220,6 +226,7 @@ export class AmpStoryStoreService {
       [StateProperty.HAS_AUDIO_STATE]: false,
       [StateProperty.LANDSCAPE_STATE]: false,
       [StateProperty.MUTED_STATE]: true,
+      [StateProperty.SUPPORTED_BROWSER_STATE]: true,
       [StateProperty.CURRENT_PAGE_ID]: '',
     });
   }

--- a/extensions/amp-story/0.1/amp-story-unsupported-browser-layer.css
+++ b/extensions/amp-story/0.1/amp-story-unsupported-browser-layer.css
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-.i-amphtml-story-no-rotation-overlay {
+.i-amphtml-story-unsupported-browser-overlay {
   position: fixed !important;
-  z-index: 200000!important; /** unsupported-browser-overlay - 1 */
+  z-index: 200001 !important; /** no-rotation-overlay + 1 */
   font-family: 'Roboto', sans-serif;
   font-weight: 700 !important;
   line-height: 1.5;
@@ -33,12 +33,11 @@
   display: none !important;
 }
 
-.i-amphtml-story-landscape.i-amphtml-story-no-rotation-overlay {
+.i-amphtml-story-unsupported-browser-overlay {
   display: flex !important;
 }
 
-.i-amphtml-rotate-icon,
-.i-amphtml-desktop-size-icon {
+.i-amphtml-gear-icon {
   background-repeat: no-repeat!important;
   background-position: center center!important;
   border-radius: 50%!important;
@@ -49,10 +48,6 @@
   margin: 16px auto!important;
 }
 
-.i-amphtml-rotate-icon {
-  background-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" viewBox="0 0 24 24" fill="#000000"><path d="M0 0h24v24H0z" fill="none"/><path d="M16.48 2.52c3.27 1.55 5.61 4.72 5.97 8.48h1.5C23.44 4.84 18.29 0 12 0l-.66.03 3.81 3.81 1.33-1.32zm-6.25-.77c-.59-.59-1.54-.59-2.12 0L1.75 8.11c-.59.59-.59 1.54 0 2.12l12.02 12.02c.59.59 1.54.59 2.12 0l6.36-6.36c.59-.59.59-1.54 0-2.12L10.23 1.75zm4.6 19.44L2.81 9.17l6.36-6.36 12.02 12.02-6.36 6.36zm-7.31.29C4.25 19.94 1.91 16.76 1.55 13H.05C.56 19.16 5.71 24 12 24l.66-.03-3.81-3.81-1.33 1.32z"/></svg>')!important;
-}
-
-.i-amphtml-desktop-size-icon {
-  background-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" viewBox="0 0 24 24" fill="#000000"><path d="M0 0h24v24H0z" fill="none"/><path d="M12.01 5.5L10 8h4l-1.99-2.5zM18 10v4l2.5-1.99L18 10zM6 10l-2.5 2.01L6 14v-4zm8 6h-4l2.01 2.5L14 16zm7-13H3c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h18c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16.01H3V4.99h18v14.02z"/></svg>')!important;
+.i-amphtml-gear-icon {
+  background-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" viewBox="0 0 20 20" fill="#000000"><path fill="none" d="M0 0h20v20H0V0z"/><path d="M15.95 10.78c.03-.25.05-.51.05-.78s-.02-.53-.06-.78l1.69-1.32c.15-.12.19-.34.1-.51l-1.6-2.77c-.1-.18-.31-.24-.49-.18l-1.99.8c-.42-.32-.86-.58-1.35-.78L12 2.34c-.03-.2-.2-.34-.4-.34H8.4c-.2 0-.36.14-.39.34l-.3 2.12c-.49.2-.94.47-1.35.78l-1.99-.8c-.18-.07-.39 0-.49.18l-1.6 2.77c-.1.18-.06.39.1.51l1.69 1.32c-.04.25-.07.52-.07.78s.02.53.06.78L2.37 12.1c-.15.12-.19.34-.1.51l1.6 2.77c.1.18.31.24.49.18l1.99-.8c.42.32.86.58 1.35.78l.3 2.12c.04.2.2.34.4.34h3.2c.2 0 .37-.14.39-.34l.3-2.12c.49-.2.94-.47 1.35-.78l1.99.8c.18.07.39 0 .49-.18l1.6-2.77c.1-.18.06-.39-.1-.51l-1.67-1.32zM10 13c-1.65 0-3-1.35-3-3s1.35-3 3-3 3 1.35 3 3-1.35 3-3 3z"/></svg>')!important;
 }

--- a/extensions/amp-story/0.1/amp-story-unsupported-browser-layer.js
+++ b/extensions/amp-story/0.1/amp-story-unsupported-browser-layer.js
@@ -24,7 +24,7 @@ import {renderAsElement} from './simple-template';
 
 
 /**
- * Container for "pill-style" share widget, rendered on desktop.
+ * Full viewport black layer indicating browser is not supported.
  * @private @const {!./simple-template.ElementDef}
  */
 const UNSUPPORTED_BROWSER_LAYER_TEMPLATE = {

--- a/extensions/amp-story/0.1/amp-story-unsupported-browser-layer.js
+++ b/extensions/amp-story/0.1/amp-story-unsupported-browser-layer.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {CSS} from '../../../build/amp-story-orientation-layer-0.1.css';
+import {CSS} from '../../../build/amp-story-unsupported-browser-layer-0.1.css';
 import {LocalizedStringId} from './localization';
 import {Services} from '../../../src/services';
 import {StateProperty} from './amp-story-store-service';
@@ -27,7 +27,7 @@ import {renderSimpleTemplate} from './simple-template';
  * Container for "pill-style" share widget, rendered on desktop.
  * @private @const {!./simple-template.ElementDef}
  */
-const UNSUPPORTED_BROWSER_WARNING_TEMPLATE = [
+const UNSUPPORTED_BROWSER_LAYER_TEMPLATE = [
   {
     tag: 'div',
     attrs: dict({'class': 'i-amphtml-story-unsupported-browser-overlay'}),
@@ -88,7 +88,7 @@ export class UnsupportedBrowserLayer {
     const root = this.win_.document.createElement('div');
     const overlayEl =
         renderSimpleTemplate(
-        		this.win_.document, UNSUPPORTED_BROWSER_WARNING_TEMPLATE);
+        		this.win_.document, UNSUPPORTED_BROWSER_LAYER_TEMPLATE);
 
     createShadowRootWithStyle(root, overlayEl, CSS);
 

--- a/extensions/amp-story/0.1/amp-story-unsupported-browser-layer.js
+++ b/extensions/amp-story/0.1/amp-story-unsupported-browser-layer.js
@@ -1,0 +1,133 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {CSS} from '../../../build/amp-story-orientation-layer-0.1.css';
+import {LocalizedStringId} from './localization';
+import {Services} from '../../../src/services';
+import {StateProperty} from './amp-story-store-service';
+import {createShadowRootWithStyle} from './utils';
+import {dict} from './../../../src/utils/object';
+import {renderSimpleTemplate} from './simple-template';
+
+
+/**
+ * Container for "pill-style" share widget, rendered on desktop.
+ * @private @const {!./simple-template.ElementDef}
+ */
+const UNSUPPORTED_BROWSER_WARNING_TEMPLATE = [
+  {
+    tag: 'div',
+    attrs: dict({'class': 'i-amphtml-story-unsupported-browser-overlay'}),
+    children: [
+      {
+        tag: 'div',
+        attrs: dict({'class': 'i-amphtml-overlay-container'}),
+        children: [
+          {
+            tag: 'div',
+            attrs: dict({'class': 'i-amphtml-gear-icon'}),
+          },
+          {
+            tag: 'div',
+            attrs: dict({'class': 'i-amphtml-story-overlay-text'}),
+            localizedStringId:
+                LocalizedStringId.AMP_STORY_WARNING_UNSUPPORTED_BROWSER_TEXT,
+          },
+        ],
+      },
+    ],
+  },
+];
+
+
+export class UnsupportedBrowserLayer {
+  /**
+   * @param {!Window} win
+   * @param {!Element} storyElement Element where to append the component
+   */
+  constructor(win, storyElement) {
+    /** @private @const {!Window} */
+    this.win_ = win;
+
+    /** @private {boolean} */
+    this.isBuilt_ = false;
+
+    /** @private @const {!./amp-story-store-service.AmpStoryStoreService} */
+    this.storeService_ = Services.storyStoreService(this.win_);
+
+    /** @private @const {!Element} */
+    this.storyElement_ = storyElement;
+
+    /** @const @private {!../../../src/service/vsync-impl.Vsync} */
+    this.vsync_ = Services.vsyncFor(this.win_);
+
+    this.initializeListeners_();
+  }
+
+  /**
+   * Builds and appends the component in the story.
+   */
+  build() {
+  	if (this.isBuilt()) {
+  		return;
+  	}
+
+    const root = this.win_.document.createElement('div');
+    const overlayEl =
+        renderSimpleTemplate(
+        		this.win_.document, UNSUPPORTED_BROWSER_WARNING_TEMPLATE);
+
+    createShadowRootWithStyle(root, overlayEl, CSS);
+
+    this.isBuilt_ = true;
+
+    this.vsync_.mutate(() => {
+      this.storyElement_.prepend(root);
+    });
+  }
+
+  /**
+   * Whether the component is built.
+   * @return {boolean}
+   */
+  isBuilt() {
+  	return this.isBuilt_;
+  }
+
+  /**
+   * @private
+   */
+  initializeListeners_() {
+    this.storeService_.subscribe(
+        StateProperty.SUPPORTED_BROWSER_STATE, isBrowserSupported => {
+      this.onSupportedBrowserStateUpdate_(isBrowserSupported);
+    }, true /** callToInitialize */);
+  }
+
+  /**
+   * Reacts to browser compatibility updates. Can only be changed to false,
+   * which shows the layer.
+   * @param {boolean} isBrowserSupported
+   * @private
+   */
+  onSupportedBrowserStateUpdate_(isBrowserSupported) {
+    if (isBrowserSupported) {
+      return;
+    }
+
+    this.build();
+  }
+}

--- a/extensions/amp-story/0.1/amp-story-unsupported-browser-layer.js
+++ b/extensions/amp-story/0.1/amp-story-unsupported-browser-layer.js
@@ -16,8 +16,6 @@
 
 import {CSS} from '../../../build/amp-story-unsupported-browser-layer-0.1.css';
 import {LocalizedStringId} from './localization';
-import {Services} from '../../../src/services';
-import {StateProperty} from './amp-story-store-service';
 import {createShadowRootWithStyle} from './utils';
 import {dict} from './../../../src/utils/object';
 import {renderAsElement} from './simple-template';
@@ -54,77 +52,29 @@ const UNSUPPORTED_BROWSER_LAYER_TEMPLATE = {
 export class UnsupportedBrowserLayer {
   /**
    * @param {!Window} win
-   * @param {!Element} storyElement Element where to append the component
    */
-  constructor(win, storyElement) {
+  constructor(win) {
     /** @private @const {!Window} */
     this.win_ = win;
 
-    /** @private {boolean} */
-    this.isBuilt_ = false;
-
-    /** @private @const {!./amp-story-store-service.AmpStoryStoreService} */
-    this.storeService_ = Services.storyStoreService(this.win_);
-
-    /** @private @const {!Element} */
-    this.storyElement_ = storyElement;
-
-    /** @const @private {!../../../src/service/vsync-impl.Vsync} */
-    this.vsync_ = Services.vsyncFor(this.win_);
-
-    this.initializeListeners_();
+    /** @private {?Element} */
+    this.root_ = null;
   }
 
   /**
    * Builds and appends the component in the story.
    */
   build() {
-    if (this.isBuilt()) {
-      return;
+    if (this.root_) {
+      return this.root_;
     }
 
-    const root = this.win_.document.createElement('div');
+    this.root_ = this.win_.document.createElement('div');
     const overlayEl =
         renderAsElement(this.win_.document, UNSUPPORTED_BROWSER_LAYER_TEMPLATE);
 
-    createShadowRootWithStyle(root, overlayEl, CSS);
+    createShadowRootWithStyle(this.root_, overlayEl, CSS);
 
-    this.isBuilt_ = true;
-
-    this.vsync_.mutate(() => {
-      this.storyElement_.insertBefore(root, this.storyElement_.firstChild);
-    });
-  }
-
-  /**
-   * Whether the component is built.
-   * @return {boolean}
-   */
-  isBuilt() {
-    return this.isBuilt_;
-  }
-
-  /**
-   * @private
-   */
-  initializeListeners_() {
-    this.storeService_.subscribe(
-        StateProperty.SUPPORTED_BROWSER_STATE, isBrowserSupported => {
-          this.onSupportedBrowserStateUpdate_(isBrowserSupported);
-        }, true /** callToInitialize */);
-  }
-
-  /**
-   * Reacts to browser compatibility updates. Can only be changed to false,
-   * which shows the layer.
-   * @param {boolean} isBrowserSupported
-   * @private
-   */
-  onSupportedBrowserStateUpdate_(isBrowserSupported) {
-    if (isBrowserSupported) {
-      return;
-    }
-
-    this.build();
+    return this.root_;
   }
 }

--- a/extensions/amp-story/0.1/amp-story-unsupported-browser-layer.js
+++ b/extensions/amp-story/0.1/amp-story-unsupported-browser-layer.js
@@ -20,37 +20,35 @@ import {Services} from '../../../src/services';
 import {StateProperty} from './amp-story-store-service';
 import {createShadowRootWithStyle} from './utils';
 import {dict} from './../../../src/utils/object';
-import {renderSimpleTemplate} from './simple-template';
+import {renderAsElement} from './simple-template';
 
 
 /**
  * Container for "pill-style" share widget, rendered on desktop.
  * @private @const {!./simple-template.ElementDef}
  */
-const UNSUPPORTED_BROWSER_LAYER_TEMPLATE = [
-  {
-    tag: 'div',
-    attrs: dict({'class': 'i-amphtml-story-unsupported-browser-overlay'}),
-    children: [
-      {
-        tag: 'div',
-        attrs: dict({'class': 'i-amphtml-overlay-container'}),
-        children: [
-          {
-            tag: 'div',
-            attrs: dict({'class': 'i-amphtml-gear-icon'}),
-          },
-          {
-            tag: 'div',
-            attrs: dict({'class': 'i-amphtml-story-overlay-text'}),
-            localizedStringId:
-                LocalizedStringId.AMP_STORY_WARNING_UNSUPPORTED_BROWSER_TEXT,
-          },
-        ],
-      },
-    ],
-  },
-];
+const UNSUPPORTED_BROWSER_LAYER_TEMPLATE = {
+  tag: 'div',
+  attrs: dict({'class': 'i-amphtml-story-unsupported-browser-overlay'}),
+  children: [
+    {
+      tag: 'div',
+      attrs: dict({'class': 'i-amphtml-overlay-container'}),
+      children: [
+        {
+          tag: 'div',
+          attrs: dict({'class': 'i-amphtml-gear-icon'}),
+        },
+        {
+          tag: 'div',
+          attrs: dict({'class': 'i-amphtml-story-overlay-text'}),
+          localizedStringId:
+              LocalizedStringId.AMP_STORY_WARNING_UNSUPPORTED_BROWSER_TEXT,
+        },
+      ],
+    },
+  ],
+};
 
 
 export class UnsupportedBrowserLayer {
@@ -81,21 +79,20 @@ export class UnsupportedBrowserLayer {
    * Builds and appends the component in the story.
    */
   build() {
-  	if (this.isBuilt()) {
-  		return;
-  	}
+    if (this.isBuilt()) {
+      return;
+    }
 
     const root = this.win_.document.createElement('div');
     const overlayEl =
-        renderSimpleTemplate(
-        		this.win_.document, UNSUPPORTED_BROWSER_LAYER_TEMPLATE);
+        renderAsElement(this.win_.document, UNSUPPORTED_BROWSER_LAYER_TEMPLATE);
 
     createShadowRootWithStyle(root, overlayEl, CSS);
 
     this.isBuilt_ = true;
 
     this.vsync_.mutate(() => {
-      this.storyElement_.prepend(root);
+      this.storyElement_.insertBefore(root, this.storyElement_.firstChild);
     });
   }
 
@@ -104,7 +101,7 @@ export class UnsupportedBrowserLayer {
    * @return {boolean}
    */
   isBuilt() {
-  	return this.isBuilt_;
+    return this.isBuilt_;
   }
 
   /**
@@ -113,8 +110,8 @@ export class UnsupportedBrowserLayer {
   initializeListeners_() {
     this.storeService_.subscribe(
         StateProperty.SUPPORTED_BROWSER_STATE, isBrowserSupported => {
-      this.onSupportedBrowserStateUpdate_(isBrowserSupported);
-    }, true /** callToInitialize */);
+          this.onSupportedBrowserStateUpdate_(isBrowserSupported);
+        }, true /** callToInitialize */);
   }
 
   /**

--- a/extensions/amp-story/0.1/amp-story-viewport-warning-layer.css
+++ b/extensions/amp-story/0.1/amp-story-viewport-warning-layer.css
@@ -23,6 +23,7 @@
   line-height: 1.5;
   padding: 32px;
   background-color: #000 !important;
+  color: #fff!important;
   top:0 !important;
   left:0 !important;
   right:0 !important;
@@ -33,23 +34,14 @@
   display: none !important;
 }
 
-[desktop].i-amphtml-story-no-rotation-overlay {
-  display: none !important;
-}
-
 .i-amphtml-story-landscape.i-amphtml-story-no-rotation-overlay,
 .i-amphtml-story-unsupported-browser-overlay {
   display: flex !important;
 }
 
-div  .i-amphtml-story-no-rotation-overlay,
-div  .i-amphtml-story-unsupported-browser-overlay {
-  color: #fff!important;
-}
-
-div .i-amphtml-rotate-icon,
-div .i-amphtml-desktop-size-icon,
-div .i-amphtml-gear-icon {
+.i-amphtml-rotate-icon,
+.i-amphtml-desktop-size-icon,
+.i-amphtml-gear-icon {
   background-repeat: no-repeat!important;
   background-position: center center!important;
   border-radius: 50%!important;
@@ -60,19 +52,14 @@ div .i-amphtml-gear-icon {
   margin: 16px auto!important;
 }
 
-div  .i-amphtml-rotate-icon {
+.i-amphtml-rotate-icon {
   background-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" viewBox="0 0 24 24" fill="#000000"><path d="M0 0h24v24H0z" fill="none"/><path d="M16.48 2.52c3.27 1.55 5.61 4.72 5.97 8.48h1.5C23.44 4.84 18.29 0 12 0l-.66.03 3.81 3.81 1.33-1.32zm-6.25-.77c-.59-.59-1.54-.59-2.12 0L1.75 8.11c-.59.59-.59 1.54 0 2.12l12.02 12.02c.59.59 1.54.59 2.12 0l6.36-6.36c.59-.59.59-1.54 0-2.12L10.23 1.75zm4.6 19.44L2.81 9.17l6.36-6.36 12.02 12.02-6.36 6.36zm-7.31.29C4.25 19.94 1.91 16.76 1.55 13H.05C.56 19.16 5.71 24 12 24l.66-.03-3.81-3.81-1.33 1.32z"/></svg>')!important;
 }
 
-div  .i-amphtml-gear-icon {
+.i-amphtml-gear-icon {
   background-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" viewBox="0 0 20 20" fill="#000000"><path fill="none" d="M0 0h20v20H0V0z"/><path d="M15.95 10.78c.03-.25.05-.51.05-.78s-.02-.53-.06-.78l1.69-1.32c.15-.12.19-.34.1-.51l-1.6-2.77c-.1-.18-.31-.24-.49-.18l-1.99.8c-.42-.32-.86-.58-1.35-.78L12 2.34c-.03-.2-.2-.34-.4-.34H8.4c-.2 0-.36.14-.39.34l-.3 2.12c-.49.2-.94.47-1.35.78l-1.99-.8c-.18-.07-.39 0-.49.18l-1.6 2.77c-.1.18-.06.39.1.51l1.69 1.32c-.04.25-.07.52-.07.78s.02.53.06.78L2.37 12.1c-.15.12-.19.34-.1.51l1.6 2.77c.1.18.31.24.49.18l1.99-.8c.42.32.86.58 1.35.78l.3 2.12c.04.2.2.34.4.34h3.2c.2 0 .37-.14.39-.34l.3-2.12c.49-.2.94-.47 1.35-.78l1.99.8c.18.07.39 0 .49-.18l1.6-2.77c.1-.18.06-.39-.1-.51l-1.67-1.32zM10 13c-1.65 0-3-1.35-3-3s1.35-3 3-3 3 1.35 3 3-1.35 3-3 3z"/></svg>')!important;
 }
 
-div  .i-amphtml-desktop-size-icon {
+.i-amphtml-desktop-size-icon {
   background-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" viewBox="0 0 24 24" fill="#000000"><path d="M0 0h24v24H0z" fill="none"/><path d="M12.01 5.5L10 8h4l-1.99-2.5zM18 10v4l2.5-1.99L18 10zM6 10l-2.5 2.01L6 14v-4zm8 6h-4l2.01 2.5L14 16zm7-13H3c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h18c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16.01H3V4.99h18v14.02z"/></svg>')!important;
-}
-
-div .i-amphtml-story-overlay-text {
-  color: #fff !important;
-  font-weight: 700 !important;
 }

--- a/extensions/amp-story/0.1/amp-story-viewport-warning-layer.css
+++ b/extensions/amp-story/0.1/amp-story-viewport-warning-layer.css
@@ -1,0 +1,78 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.i-amphtml-story-no-rotation-overlay,
+.i-amphtml-story-unsupported-browser-overlay {
+  position: fixed !important;
+  z-index: 200000!important;
+  font-family: 'Roboto', sans-serif;
+  font-weight: 700 !important;
+  line-height: 1.5;
+  padding: 32px;
+  background-color: #000 !important;
+  top:0 !important;
+  left:0 !important;
+  right:0 !important;
+  bottom:0 !important;
+  align-items: center !important;
+  justify-content: center !important;
+  text-align: center !important;
+  display: none !important;
+}
+
+[desktop].i-amphtml-story-no-rotation-overlay {
+  display: none !important;
+}
+
+.i-amphtml-story-landscape.i-amphtml-story-no-rotation-overlay,
+.i-amphtml-story-unsupported-browser-overlay {
+  display: flex !important;
+}
+
+div  .i-amphtml-story-no-rotation-overlay,
+div  .i-amphtml-story-unsupported-browser-overlay {
+  color: #fff!important;
+}
+
+div .i-amphtml-rotate-icon,
+div .i-amphtml-desktop-size-icon,
+div .i-amphtml-gear-icon {
+  background-repeat: no-repeat!important;
+  background-position: center center!important;
+  border-radius: 50%!important;
+  background-color: #fff!important;
+  padding: 16px!important;
+  height: 24px!important;
+  width: 24px!important;
+  margin: 16px auto!important;
+}
+
+div  .i-amphtml-rotate-icon {
+  background-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" viewBox="0 0 24 24" fill="#000000"><path d="M0 0h24v24H0z" fill="none"/><path d="M16.48 2.52c3.27 1.55 5.61 4.72 5.97 8.48h1.5C23.44 4.84 18.29 0 12 0l-.66.03 3.81 3.81 1.33-1.32zm-6.25-.77c-.59-.59-1.54-.59-2.12 0L1.75 8.11c-.59.59-.59 1.54 0 2.12l12.02 12.02c.59.59 1.54.59 2.12 0l6.36-6.36c.59-.59.59-1.54 0-2.12L10.23 1.75zm4.6 19.44L2.81 9.17l6.36-6.36 12.02 12.02-6.36 6.36zm-7.31.29C4.25 19.94 1.91 16.76 1.55 13H.05C.56 19.16 5.71 24 12 24l.66-.03-3.81-3.81-1.33 1.32z"/></svg>')!important;
+}
+
+div  .i-amphtml-gear-icon {
+  background-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" viewBox="0 0 20 20" fill="#000000"><path fill="none" d="M0 0h20v20H0V0z"/><path d="M15.95 10.78c.03-.25.05-.51.05-.78s-.02-.53-.06-.78l1.69-1.32c.15-.12.19-.34.1-.51l-1.6-2.77c-.1-.18-.31-.24-.49-.18l-1.99.8c-.42-.32-.86-.58-1.35-.78L12 2.34c-.03-.2-.2-.34-.4-.34H8.4c-.2 0-.36.14-.39.34l-.3 2.12c-.49.2-.94.47-1.35.78l-1.99-.8c-.18-.07-.39 0-.49.18l-1.6 2.77c-.1.18-.06.39.1.51l1.69 1.32c-.04.25-.07.52-.07.78s.02.53.06.78L2.37 12.1c-.15.12-.19.34-.1.51l1.6 2.77c.1.18.31.24.49.18l1.99-.8c.42.32.86.58 1.35.78l.3 2.12c.04.2.2.34.4.34h3.2c.2 0 .37-.14.39-.34l.3-2.12c.49-.2.94-.47 1.35-.78l1.99.8c.18.07.39 0 .49-.18l1.6-2.77c.1-.18.06-.39-.1-.51l-1.67-1.32zM10 13c-1.65 0-3-1.35-3-3s1.35-3 3-3 3 1.35 3 3-1.35 3-3 3z"/></svg>')!important;
+}
+
+div  .i-amphtml-desktop-size-icon {
+  background-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" viewBox="0 0 24 24" fill="#000000"><path d="M0 0h24v24H0z" fill="none"/><path d="M12.01 5.5L10 8h4l-1.99-2.5zM18 10v4l2.5-1.99L18 10zM6 10l-2.5 2.01L6 14v-4zm8 6h-4l2.01 2.5L14 16zm7-13H3c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h18c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16.01H3V4.99h18v14.02z"/></svg>')!important;
+}
+
+div .i-amphtml-story-overlay-text {
+  color: #fff !important;
+  font-weight: 700 !important;
+}

--- a/extensions/amp-story/0.1/amp-story-viewport-warning-layer.js
+++ b/extensions/amp-story/0.1/amp-story-viewport-warning-layer.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {CSS} from '../../../build/amp-story-orientation-layer-0.1.css';
+import {CSS} from '../../../build/amp-story-viewport-warning-layer-0.1.css';
 import {LocalizedStringId} from './localization';
 import {Services} from '../../../src/services';
 import {StateProperty} from './amp-story-store-service';
@@ -130,6 +130,8 @@ export class ViewportWarningLayer {
       return;
     }
 
+    this.isBuilt_ = true;
+
     const root = this.win_.document.createElement('div');
     this.overlayEl_ =
         renderAsElement(
@@ -137,9 +139,9 @@ export class ViewportWarningLayer {
 
     createShadowRootWithStyle(root, this.overlayEl_, CSS);
 
-    this.isBuilt_ = true;
-
-    // SHOULD CHECK IF DESKTOP IN THIS PR.
+    // Initializes the desktop state now that the component is built.
+    this.onDesktopStateUpdate_(
+        this.storeService_.get(StateProperty.DESKTOP_STATE));
 
     this.vsync_.mutate(() => {
       this.storyElement_.prepend(root);
@@ -151,7 +153,7 @@ export class ViewportWarningLayer {
    * @return {boolean}
    */
   isBuilt() {
-    return this.built_;
+    return this.isBuilt_;
   }
 
   /**
@@ -173,6 +175,7 @@ export class ViewportWarningLayer {
    * @private
    */
   onLandscapeStateUpdate_(isLandscape) {
+    console.log('onLandscapeStateUpdate_', isLandscape);
     const isDesktop = this.storeService_.get(StateProperty.DESKTOP_STATE);
 
     // Adds the landscape class if (not desktop and landscape).

--- a/extensions/amp-story/0.1/amp-story-viewport-warning-layer.js
+++ b/extensions/amp-story/0.1/amp-story-viewport-warning-layer.js
@@ -91,6 +91,36 @@ const DESKTOP_SIZE_WARNING_TEMPLATE = {
 };
 
 
+/**
+ * Container for "pill-style" share widget, rendered on desktop.
+ * @private @const {!./simple-template.ElementDef}
+ */
+const UNSUPPORTED_BROWSER_WARNING_TEMPLATE = [
+  {
+    tag: 'div',
+    attrs: dict({'class': 'i-amphtml-story-unsupported-browser-overlay'}),
+    children: [
+      {
+        tag: 'div',
+        attrs: dict({'class': 'i-amphtml-overlay-container'}),
+        children: [
+          {
+            tag: 'div',
+            attrs: dict({'class': 'i-amphtml-gear-icon'}),
+          },
+          {
+            tag: 'div',
+            attrs: dict({'class': 'i-amphtml-story-overlay-text'}),
+            localizedStringId:
+                LocalizedStringId.AMP_STORY_WARNING_UNSUPPORTED_BROWSER_TEXT,
+          },
+        ],
+      },
+    ],
+  },
+];
+
+
 export class ViewportWarningLayer {
   /**
    * @param {!Window} win
@@ -167,6 +197,11 @@ export class ViewportWarningLayer {
     this.storeService_.subscribe(StateProperty.LANDSCAPE_STATE, isLandscape => {
       this.onLandscapeStateUpdate_(isLandscape);
     }, true /** callToInitialize */);
+
+    this.storeService_.subscribe(
+        StateProperty.SUPPORTED_BROWSER_STATE, isBrowserSupported => {
+      this.onSupportedBrowserStateUpdate_(isBrowserSupported);
+    }, true /** callToInitialize */);
   }
 
   /**
@@ -194,6 +229,19 @@ export class ViewportWarningLayer {
         this.getShadowRoot().setAttribute('desktop', '') :
         this.getShadowRoot().removeAttribute('desktop');
     });
+  }
+
+  /**
+   * Reacts to browser compatibility updates. Can only be changed to false.
+   * @param {boolean} isBrowserSupported
+   * @private
+   */
+  onSupportedBrowserStateUpdate_(isBrowserSupported) {
+    if (isBrowserSupported) {
+      return;
+    }
+    this.getShadowRoot().prepend(
+          renderSimpleTemplate(this.win_.document, UNSUPPORTED_BROWSER_WARNING));
   }
 
   /**

--- a/extensions/amp-story/0.1/amp-story-viewport-warning-layer.js
+++ b/extensions/amp-story/0.1/amp-story-viewport-warning-layer.js
@@ -1,0 +1,209 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {CSS} from '../../../build/amp-story-orientation-layer-0.1.css';
+import {LocalizedStringId} from './localization';
+import {Services} from '../../../src/services';
+import {StateProperty} from './amp-story-store-service';
+import {createShadowRootWithStyle} from './utils';
+import {dev} from '../../../src/log';
+import {dict} from './../../../src/utils/object';
+import {renderAsElement} from './simple-template';
+
+
+/**
+ * CSS class indicating the format is landscape.
+ * @const {string}
+ */
+const LANDSCAPE_OVERLAY_CLASS = 'i-amphtml-story-landscape';
+
+
+/**
+ * Container for "pill-style" share widget, rendered on desktop.
+ * @private @const {!./simple-template.ElementDef}
+ */
+const LANDSCAPE_ORIENTATION_WARNING_TEMPLATE = {
+  tag: 'div',
+  attrs: dict({
+    'class': 'i-amphtml-story-no-rotation-overlay ' +
+        'i-amphtml-story-system-reset'}),
+  children: [
+    {
+      tag: 'div',
+      attrs: dict({'class': 'i-amphtml-overlay-container'}),
+      children: [
+        {
+          tag: 'div',
+          attrs: dict({'class': 'i-amphtml-rotate-icon'}),
+        },
+        {
+          tag: 'div',
+          attrs: dict({'class': 'i-amphtml-story-overlay-text'}),
+          localizedStringId:
+              LocalizedStringId.AMP_STORY_WARNING_LANDSCAPE_ORIENTATION_TEXT,
+        },
+      ],
+    },
+  ],
+};
+
+
+/**
+ * Container for "pill-style" share widget, rendered on desktop.
+ * @private @const {!./simple-template.ElementDef}
+ */
+const DESKTOP_SIZE_WARNING_TEMPLATE = {
+  tag: 'div',
+  attrs: dict({
+    'class': 'i-amphtml-story-no-rotation-overlay ' +
+        'i-amphtml-story-system-reset'}),
+  children: [
+    {
+      tag: 'div',
+      attrs: dict({'class': 'i-amphtml-overlay-container'}),
+      children: [
+        {
+          tag: 'div',
+          attrs: dict({'class': 'i-amphtml-desktop-size-icon'}),
+        },
+        {
+          tag: 'div',
+          attrs: dict({'class': 'i-amphtml-story-overlay-text'}),
+          localizedStringId:
+              LocalizedStringId.AMP_STORY_WARNING_DESKTOP_SIZE_TEXT,
+        },
+      ],
+    },
+  ],
+};
+
+
+export class ViewportWarningLayer {
+  /**
+   * @param {!Window} win
+   * @param {!Element} storyElement Element where to append the component
+   */
+  constructor(win, storyElement) {
+    /** @private @const {!Window} */
+    this.win_ = win;
+
+    /** @private {?Element} */
+    this.overlayEl_ = null;
+
+    /** @private @const {!../../../src/service/platform-impl.Platform} */
+    this.platform_ = Services.platformFor(this.win_);
+
+    /** @private {?Element} */
+    this.root_ = null;
+
+    /** @private @const {!./amp-story-store-service.AmpStoryStoreService} */
+    this.storeService_ = Services.storyStoreService(this.win_);
+
+    /** @private @const {!Element} */
+    this.storyElement_ = storyElement;
+
+    /** @const @private {!../../../src/service/vsync-impl.Vsync} */
+    this.vsync_ = Services.vsyncFor(this.win_);
+  }
+
+  /**
+   * Builds and appends the component in the story.
+   */
+  build() {
+    if (this.root_) {
+      return;
+    }
+
+    this.root_ = this.win_.document.createElement('div');
+    this.overlayEl_ =
+        renderAsElement(
+            this.win_.document, this.getViewportWarningOverlayTemplate_());
+
+    createShadowRootWithStyle(this.root_, this.overlayEl_, CSS);
+
+    this.vsync_.mutate(() => {
+      this.storyElement_
+          .insertBefore(this.root_, this.storyElement_.firstChild);
+    });
+
+    this.initializeListeners_();
+  }
+
+  /**
+   * @return {!Element}
+   */
+  getRoot() {
+    return dev().assertElement(this.root_);
+  }
+
+  /**
+   * @return {!Element}
+   */
+  getShadowRoot() {
+    return dev().assertElement(this.overlayEl_);
+  }
+
+  /**
+   * @private
+   */
+  initializeListeners_() {
+    this.storeService_.subscribe(StateProperty.DESKTOP_STATE, isDesktop => {
+      this.onDesktopStateUpdate_(isDesktop);
+    }, true /** callToInitialize */);
+
+    this.storeService_.subscribe(StateProperty.LANDSCAPE_STATE, isLandscape => {
+      this.onLandscapeStateUpdate_(isLandscape);
+    }, true /** callToInitialize */);
+  }
+
+  /**
+   * Reacts to the landscape state update, only on mobile.
+   * @param  {boolean} isLandscape
+   */
+  onLandscapeStateUpdate_(isLandscape) {
+    const isDesktop = this.storeService_.get(StateProperty.DESKTOP_STATE);
+
+    // Adds the landscape class if (not desktop and landscape).
+    this.vsync_.mutate(() => {
+      this.getShadowRoot()
+          .classList.toggle(LANDSCAPE_OVERLAY_CLASS, !isDesktop && isLandscape);
+    });
+  }
+
+  /**
+   * Reacts to desktop state updates.
+   * @param {boolean} isDesktop
+   * @private
+   */
+  onDesktopStateUpdate_(isDesktop) {
+    this.vsync_.mutate(() => {
+      isDesktop ?
+        this.getShadowRoot().setAttribute('desktop', '') :
+        this.getShadowRoot().removeAttribute('desktop');
+    });
+  }
+
+  /**
+   * Returns the overlay corresponding to the device currently used.
+   * @return {!./simple-template.ElementDef} template
+   * @private
+   */
+  getViewportWarningOverlayTemplate_() {
+    return (this.platform_.isIos() || this.platform_.isAndroid()) ?
+      LANDSCAPE_ORIENTATION_WARNING_TEMPLATE :
+      DESKTOP_SIZE_WARNING_TEMPLATE;
+  }
+}

--- a/extensions/amp-story/0.1/amp-story-viewport-warning-layer.js
+++ b/extensions/amp-story/0.1/amp-story-viewport-warning-layer.js
@@ -19,7 +19,6 @@ import {LocalizedStringId} from './localization';
 import {Services} from '../../../src/services';
 import {StateProperty} from './amp-story-store-service';
 import {createShadowRootWithStyle} from './utils';
-import {dev} from '../../../src/log';
 import {dict} from './../../../src/utils/object';
 import {renderAsElement} from './simple-template';
 
@@ -141,10 +140,10 @@ export class ViewportWarningLayer {
 
     // Initializes the desktop state now that the component is built.
     this.onDesktopStateUpdate_(
-        this.storeService_.get(StateProperty.DESKTOP_STATE));
+        !!this.storeService_.get(StateProperty.DESKTOP_STATE));
 
     this.vsync_.mutate(() => {
-      this.storyElement_.prepend(root);
+      this.storyElement_.insertBefore(root, this.storyElement_.firstChild);
     });
   }
 
@@ -175,7 +174,6 @@ export class ViewportWarningLayer {
    * @private
    */
   onLandscapeStateUpdate_(isLandscape) {
-    console.log('onLandscapeStateUpdate_', isLandscape);
     const isDesktop = this.storeService_.get(StateProperty.DESKTOP_STATE);
 
     // Adds the landscape class if (not desktop and landscape).

--- a/extensions/amp-story/0.1/amp-story-viewport-warning-layer.js
+++ b/extensions/amp-story/0.1/amp-story-viewport-warning-layer.js
@@ -31,7 +31,7 @@ const LANDSCAPE_OVERLAY_CLASS = 'i-amphtml-story-landscape';
 
 
 /**
- * Container for "pill-style" share widget, rendered on desktop.
+ * Full viewport layer advising the user to rotate his device. Mobile only.
  * @private @const {!./simple-template.ElementDef}
  */
 const LANDSCAPE_ORIENTATION_WARNING_TEMPLATE = {
@@ -61,7 +61,8 @@ const LANDSCAPE_ORIENTATION_WARNING_TEMPLATE = {
 
 
 /**
- * Container for "pill-style" share widget, rendered on desktop.
+ * Full viewport layer advising the user to expand his window. Only displayed
+ * for small desktop viewports.
  * @private @const {!./simple-template.ElementDef}
  */
 const DESKTOP_SIZE_WARNING_TEMPLATE = {
@@ -176,7 +177,7 @@ export class ViewportWarningLayer {
   onLandscapeStateUpdate_(isLandscape) {
     const isDesktop = this.storeService_.get(StateProperty.DESKTOP_STATE);
 
-    // Adds the landscape class if (not desktop and landscape).
+    // Adds the landscape class if we are mobile landscape.
     const shouldShowLandscapeOverlay = !isDesktop && isLandscape;
 
     // Don't build the layer until we need to display it.

--- a/extensions/amp-story/0.1/amp-story.css
+++ b/extensions/amp-story/0.1/amp-story.css
@@ -505,69 +505,6 @@ amp-story[standalone] .i-amphtml-story-developer-log {
   white-space: nowrap !important;
 }
 
-amp-story[standalone] .i-amphtml-story-no-rotation-overlay,
-.i-amphtml-story-unsupported-browser-overlay {
-  position: fixed !important;
-  z-index: 200000!important;
-  font-family: 'Roboto', sans-serif;
-  font-weight: 700 !important;
-  line-height: 1.5;
-  padding: 32px;
-  background-color: #000 !important;
-  top:0 !important;
-  left:0 !important;
-  right:0 !important;
-  bottom:0 !important;
-  align-items: center !important;
-  justify-content: center !important;
-  text-align: center !important;
-  display: none !important;
-}
-
-[desktop] .i-amphtml-story-no-rotation-overlay {
-  display: none !important;
-}
-
-amp-story[standalone].i-amphtml-story-landscape .i-amphtml-story-no-rotation-overlay,
-.i-amphtml-story-unsupported-browser-overlay {
-  display: flex !important;
-}
-
-amp-story .i-amphtml-story-no-rotation-overlay,
-amp-story .i-amphtml-story-unsupported-browser-overlay {
-  color: #fff!important;
-}
-
-amp-story .i-amphtml-rotate-icon,
-amp-story .i-amphtml-desktop-size-icon,
-amp-story .i-amphtml-gear-icon {
-  background-repeat: no-repeat!important;
-  background-position: center center!important;
-  border-radius: 50%!important;
-  background-color: #fff!important;
-  padding: 16px!important;
-  height: 24px!important;
-  width: 24px!important;
-  margin: 16px auto!important;
-}
-
-amp-story .i-amphtml-rotate-icon {
-  background-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" viewBox="0 0 24 24" fill="#000000"><path d="M0 0h24v24H0z" fill="none"/><path d="M16.48 2.52c3.27 1.55 5.61 4.72 5.97 8.48h1.5C23.44 4.84 18.29 0 12 0l-.66.03 3.81 3.81 1.33-1.32zm-6.25-.77c-.59-.59-1.54-.59-2.12 0L1.75 8.11c-.59.59-.59 1.54 0 2.12l12.02 12.02c.59.59 1.54.59 2.12 0l6.36-6.36c.59-.59.59-1.54 0-2.12L10.23 1.75zm4.6 19.44L2.81 9.17l6.36-6.36 12.02 12.02-6.36 6.36zm-7.31.29C4.25 19.94 1.91 16.76 1.55 13H.05C.56 19.16 5.71 24 12 24l.66-.03-3.81-3.81-1.33 1.32z"/></svg>')!important;
-}
-
-amp-story .i-amphtml-gear-icon {
-  background-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" viewBox="0 0 20 20" fill="#000000"><path fill="none" d="M0 0h20v20H0V0z"/><path d="M15.95 10.78c.03-.25.05-.51.05-.78s-.02-.53-.06-.78l1.69-1.32c.15-.12.19-.34.1-.51l-1.6-2.77c-.1-.18-.31-.24-.49-.18l-1.99.8c-.42-.32-.86-.58-1.35-.78L12 2.34c-.03-.2-.2-.34-.4-.34H8.4c-.2 0-.36.14-.39.34l-.3 2.12c-.49.2-.94.47-1.35.78l-1.99-.8c-.18-.07-.39 0-.49.18l-1.6 2.77c-.1.18-.06.39.1.51l1.69 1.32c-.04.25-.07.52-.07.78s.02.53.06.78L2.37 12.1c-.15.12-.19.34-.1.51l1.6 2.77c.1.18.31.24.49.18l1.99-.8c.42.32.86.58 1.35.78l.3 2.12c.04.2.2.34.4.34h3.2c.2 0 .37-.14.39-.34l.3-2.12c.49-.2.94-.47 1.35-.78l1.99.8c.18.07.39 0 .49-.18l1.6-2.77c.1-.18.06-.39-.1-.51l-1.67-1.32zM10 13c-1.65 0-3-1.35-3-3s1.35-3 3-3 3 1.35 3 3-1.35 3-3 3z"/></svg>')!important;
-}
-
-amp-story .i-amphtml-desktop-size-icon {
-  background-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" viewBox="0 0 24 24" fill="#000000"><path d="M0 0h24v24H0z" fill="none"/><path d="M12.01 5.5L10 8h4l-1.99-2.5zM18 10v4l2.5-1.99L18 10zM6 10l-2.5 2.01L6 14v-4zm8 6h-4l2.01 2.5L14 16zm7-13H3c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h18c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16.01H3V4.99h18v14.02z"/></svg>')!important;
-}
-
-amp-story .i-amphtml-story-overlay-text {
-  color: #fff !important;
-  font-weight: 700 !important;
-}
-
 .i-amphtml-story-button-container {
   display: none !important;
 }

--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -1523,7 +1523,7 @@ export class AmpStory extends AMP.BaseElement {
    *     for amp-story.
    */
   static isBrowserSupported(win) {
-    return Boolean(win.CSS && win.CSS.supports &&
+    return false && Boolean(win.CSS && win.CSS.supports &&
         win.CSS.supports('display', 'grid'));
   }
 }

--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -194,7 +194,7 @@ export class AmpStory extends AMP.BaseElement {
     this.bookend_ = new Bookend(this.win, this.element);
 
     /** @private @const {!SystemLayer} */
-    this.systemLayer_ = new SystemLayer(this.win, this.element);
+    this.systemLayer_ = new SystemLayer(this.win);
 
     /** @private @const {!UnsupportedBrowserLayer} */
     this.unsupportedBrowserLayer_ =
@@ -1523,7 +1523,7 @@ export class AmpStory extends AMP.BaseElement {
    *     for amp-story.
    */
   static isBrowserSupported(win) {
-    return false && Boolean(win.CSS && win.CSS.supports &&
+    return Boolean(win.CSS && win.CSS.supports &&
         win.CSS.supports('display', 'grid'));
   }
 }

--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -559,7 +559,6 @@ export class AmpStory extends AMP.BaseElement {
     const storyLayoutPromise = this.initializePages_()
         .then(() => this.buildSystemLayer_())
         .then(() => this.buildHintLayer_())
-        .then(() => this.viewportWarningLayer_.build())
         .then(() => {
           this.pages_.forEach(page => {
             page.setActive(false);
@@ -985,7 +984,7 @@ export class AmpStory extends AMP.BaseElement {
     if (fallbackEl) {
       this.toggleFallback(true);
     } else {
-      this.storeService_.dispatch(Action.TOGGLE_SUPPORTED_BROWSER, true);
+      this.storeService_.dispatch(Action.TOGGLE_SUPPORTED_BROWSER, false);
     }
   }
 
@@ -1519,7 +1518,7 @@ export class AmpStory extends AMP.BaseElement {
    *     for amp-story.
    */
   static isBrowserSupported(win) {
-    return Boolean(win.CSS && win.CSS.supports &&
+    return false && Boolean(win.CSS && win.CSS.supports &&
         win.CSS.supports('display', 'grid'));
   }
 }

--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -143,32 +143,6 @@ const MAX_MEDIA_ELEMENT_COUNTS = {
 const TAG = 'amp-story';
 
 
-const UNSUPPORTED_BROWSER_WARNING = [
-  {
-    tag: 'div',
-    attrs: dict({'class': 'i-amphtml-story-unsupported-browser-overlay'}),
-    children: [
-      {
-        tag: 'div',
-        attrs: dict({'class': 'i-amphtml-overlay-container'}),
-        children: [
-          {
-            tag: 'div',
-            attrs: dict({'class': 'i-amphtml-gear-icon'}),
-          },
-          {
-            tag: 'div',
-            attrs: dict({'class': 'i-amphtml-story-overlay-text'}),
-            localizedStringId:
-                LocalizedStringId.AMP_STORY_WARNING_UNSUPPORTED_BROWSER_TEXT,
-          },
-        ],
-      },
-    ],
-  },
-];
-
-
 /**
  * Container for "pill-style" share widget, rendered on desktop.
  * @private @const {!./simple-template.ElementDef}
@@ -185,7 +159,6 @@ const SHARE_WIDGET_PILL_CONTAINER = {
     },
   ],
 };
-
 
 
 /**
@@ -1012,22 +985,9 @@ export class AmpStory extends AMP.BaseElement {
     if (fallbackEl) {
       this.toggleFallback(true);
     } else {
-      this.buildUnsupportedBrowserOverlay_();
+      this.storeService_.dispatch(Action.TOGGLE_SUPPORTED_BROWSER, true);
     }
   }
-
-
-  /**
-   * Build overlay for Landscape mode mobile
-   */
-  buildUnsupportedBrowserOverlay_() {
-    this.mutateElement(() => {
-      this.element.insertBefore(
-          renderSimpleTemplate(this.win.document, UNSUPPORTED_BROWSER_WARNING),
-          this.element.firstChild);
-    });
-  }
-
 
   /**
    * Get the URL of the given page's background resource.

--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -61,6 +61,7 @@ import {Services} from '../../../src/services';
 import {ShareWidget} from './amp-story-share';
 import {SystemLayer} from './amp-story-system-layer';
 import {TapNavigationDirection} from './page-advancement';
+import {UnsupportedBrowserLayer} from './amp-story-unsupported-browser-layer';
 import {ViewportWarningLayer} from './amp-story-viewport-warning-layer';
 import {
   childElement,
@@ -194,6 +195,10 @@ export class AmpStory extends AMP.BaseElement {
 
     /** @private @const {!SystemLayer} */
     this.systemLayer_ = new SystemLayer(this.win, this.element);
+
+    /** @private @const {!UnsupportedBrowserLayer} */
+    this.unsupportedBrowserLayer_ =
+        new UnsupportedBrowserLayer(this.win, this.element);
 
     /** @private @const {!ViewportWarningLayer} */
     this.viewportWarningLayer_ =
@@ -1518,7 +1523,7 @@ export class AmpStory extends AMP.BaseElement {
    *     for amp-story.
    */
   static isBrowserSupported(win) {
-    return false && Boolean(win.CSS && win.CSS.supports &&
+    return Boolean(win.CSS && win.CSS.supports &&
         win.CSS.supports('display', 'grid'));
   }
 }

--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -929,11 +929,11 @@ export class AmpStory extends AMP.BaseElement {
     this.storeService_.dispatch(Action.TOGGLE_DESKTOP, isDesktop);
 
     if (isDesktop) {
+      this.storeService_.dispatch(Action.TOGGLE_LANDSCAPE, false);
       return;
     }
 
     // On mobile, maybe display the landscape overlay warning.
-    // TODO(gmajoulet): This code seems to fail if the story is not standalone.
     this.vsync_.run({
       measure: state => {
         const {offsetWidth, offsetHeight} = this.element;

--- a/extensions/amp-story/0.1/test/test-amp-story-store-service.js
+++ b/extensions/amp-story/0.1/test/test-amp-story-store-service.js
@@ -140,4 +140,20 @@ describes.fakeWin('amp-story-store-service actions', {}, env => {
     expect(listenerSpy).to.have.been.calledOnce;
     expect(listenerSpy).to.have.been.calledWith(true);
   });
+
+  it('should toggle the landscape state', () => {
+    const listenerSpy = sandbox.spy();
+    storeService.subscribe(StateProperty.LANDSCAPE_STATE, listenerSpy);
+    storeService.dispatch(Action.TOGGLE_LANDSCAPE, true);
+    expect(listenerSpy).to.have.been.calledOnce;
+    expect(listenerSpy).to.have.been.calledWith(true);
+  });
+
+  it('should toggle the supported browser state', () => {
+    const listenerSpy = sandbox.spy();
+    storeService.subscribe(StateProperty.SUPPORTED_BROWSER_STATE, listenerSpy);
+    storeService.dispatch(Action.TOGGLE_SUPPORTED_BROWSER, false);
+    expect(listenerSpy).to.have.been.calledOnce;
+    expect(listenerSpy).to.have.been.calledWith(false);
+  });
 });

--- a/extensions/amp-story/0.1/test/test-amp-story-store-service.js
+++ b/extensions/amp-story/0.1/test/test-amp-story-store-service.js
@@ -133,14 +133,6 @@ describes.fakeWin('amp-story-store-service actions', {}, env => {
     expect(listenerSpy).to.have.been.calledWith(true);
   });
 
-  it('should set the fallback state', () => {
-    const listenerSpy = sandbox.spy();
-    storeService.subscribe(StateProperty.FALLBACK_STATE, listenerSpy);
-    storeService.dispatch(Action.TOGGLE_FALLBACK, true);
-    expect(listenerSpy).to.have.been.calledOnce;
-    expect(listenerSpy).to.have.been.calledWith(true);
-  });
-
   it('should toggle the landscape state', () => {
     const listenerSpy = sandbox.spy();
     storeService.subscribe(StateProperty.LANDSCAPE_STATE, listenerSpy);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -148,6 +148,7 @@ declareExtension('amp-story', '0.1', {
   hasCss: true,
   cssBinaries: [
     'amp-story-bookend',
+    'amp-story-viewport-warning-layer',
     'amp-story-share',
     'amp-story-system-layer',
   ],

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -148,6 +148,7 @@ declareExtension('amp-story', '0.1', {
   hasCss: true,
   cssBinaries: [
     'amp-story-bookend',
+    'amp-story-unsupported-browser-layer',
     'amp-story-viewport-warning-layer',
     'amp-story-share',
     'amp-story-system-layer',


### PR DESCRIPTION
- Extract the orientation layer + unsupported browser layer into their own component
- Only render the components when needed
- New store properties to interact with these components

This PR doesn't try to make it perfect, but simply moves most of the code to new self contained components. There are many things we could do better, if you feel like some of these should get done in this PR, please be very nitty during the review : )