### PR TITLE
♿Add more ARIA roles to emit the AMP tap event

### DIFF
--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -21,13 +21,13 @@ import {debounce, throttle} from '../utils/rate-limit';
 import {dev, user} from '../log';
 import {getMode} from '../mode';
 import {getValueForExpr} from '../json';
+import {hasOwn, map} from '../utils/object';
 import {
   installServiceInEmbedScope,
   registerServiceBuilderForDoc,
 } from '../service';
 import {isArray, isFiniteNumber, toWin} from '../types';
 import {isEnabled} from '../dom';
-import {map} from '../utils/object';
 
 /**
  * ActionInfoDef args key that maps to the an unparsed object literal string.
@@ -67,28 +67,28 @@ const ELEMENTS_ACTIONS_MAP_ = {
  * since they are readonly or composite widgets that shouldn't need to trigger
  * tap events on their own.
  * See https://www.w3.org/TR/wai-aria-1.1/#widget_roles
- * @const {!Array<string>}
+ * @const {!Object<boolean>}
  */
-export const TAP_WIDGET_ROLES = [
-  'button',
-  'checkbox',
-  'combobox',
-  'link',
-  'listbox',
-  'menuitem',
-  'menuitemcheckbox',
-  'menuitemradio',
-  'option',
-  'radio',
-  'scrollbar',
-  'searchbox',
-  'slider',
-  'spinbutton',
-  'switch',
-  'tab',
-  'textbox',
-  'treeitem',
-];
+export const TAP_EVENT_ROLE_WHITELIST = {
+  'button': true,
+  'checkbox': true,
+  'combobox': true,
+  'link': true,
+  'listbox': true,
+  'menuitem': true,
+  'menuitemcheckbox': true,
+  'menuitemradio': true,
+  'option': true,
+  'radio': true,
+  'scrollbar': true,
+  'searchbox': true,
+  'slider': true,
+  'spinbutton': true,
+  'switch': true,
+  'tab': true,
+  'textbox': true,
+  'treeitem': true,
+};
 
 /**
  * An expression arg value, e.g. `foo.bar` in `e:t.m(arg=foo.bar)`.
@@ -263,9 +263,9 @@ export class ActionService {
         const element = dev().assertElement(event.target);
         const keyCode = event.keyCode;
         if (keyCode == KeyCodes.ENTER || keyCode == KeyCodes.SPACE) {
-          const isTapWidgetRole = TAP_WIDGET_ROLES.includes(
+          const isTapEventRole = hasOwn(TAP_EVENT_ROLE_WHITELIST,
               element.getAttribute('role').toLowerCase());
-          if (!event.defaultPrevented && isTapWidgetRole) {
+          if (!event.defaultPrevented && isTapEventRole) {
             event.preventDefault();
             this.trigger(element, name, event, ActionTrust.HIGH);
           }

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -62,6 +62,35 @@ const ELEMENTS_ACTIONS_MAP_ = {
 };
 
 /**
+ * Interactable widgets which should trigger tap events when the user clicks
+ * or activates via the keyboard. Not all are here, e.g. progressbar, tabpanel,
+ * since they are readonly or composite widgets that shouldn't need to trigger
+ * tap events on their own.
+ * See https://www.w3.org/TR/wai-aria-1.1/#widget_roles
+ * @const {!Array<string>}
+ */
+export const TAP_WIDGET_ROLES = [
+  'button',
+  'checkbox',
+  'combobox',
+  'link',
+  'listbox',
+  'menuitem',
+  'menuitemcheckbox',
+  'menuitemradio',
+  'option',
+  'radio',
+  'scrollbar',
+  'searchbox',
+  'slider',
+  'spinbutton',
+  'switch',
+  'tab',
+  'textbox',
+  'treeitem',
+];
+
+/**
  * An expression arg value, e.g. `foo.bar` in `e:t.m(arg=foo.bar)`.
  * @typedef {{expression: string}}
  */
@@ -234,8 +263,9 @@ export class ActionService {
         const element = dev().assertElement(event.target);
         const keyCode = event.keyCode;
         if (keyCode == KeyCodes.ENTER || keyCode == KeyCodes.SPACE) {
-          if (!event.defaultPrevented &&
-              element.getAttribute('role') == 'button') {
+          const isTapWidgetRole = TAP_WIDGET_ROLES.includes(
+              element.getAttribute('role').toLowerCase());
+          if (!event.defaultPrevented && isTapWidgetRole) {
             event.preventDefault();
             this.trigger(element, name, event, ActionTrust.HIGH);
           }

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -64,15 +64,14 @@ const ELEMENTS_ACTIONS_MAP_ = {
 /**
  * Interactable widgets which should trigger tap events when the user clicks
  * or activates via the keyboard. Not all are here, e.g. progressbar, tabpanel,
- * since they are readonly or composite widgets that shouldn't need to trigger
- * tap events on their own.
+ * since they are text inputs, readonly, or composite widgets that shouldn't
+ * need to trigger tap events from spacebar or enter on their own.
  * See https://www.w3.org/TR/wai-aria-1.1/#widget_roles
  * @const {!Object<boolean>}
  */
-export const TAP_EVENT_ROLE_WHITELIST = {
+export const TAPPABLE_ARIA_ROLES = {
   'button': true,
   'checkbox': true,
-  'combobox': true,
   'link': true,
   'listbox': true,
   'menuitem': true,
@@ -81,12 +80,10 @@ export const TAP_EVENT_ROLE_WHITELIST = {
   'option': true,
   'radio': true,
   'scrollbar': true,
-  'searchbox': true,
   'slider': true,
   'spinbutton': true,
   'switch': true,
   'tab': true,
-  'textbox': true,
   'treeitem': true,
 };
 
@@ -263,7 +260,7 @@ export class ActionService {
         const element = dev().assertElement(event.target);
         const keyCode = event.keyCode;
         if (keyCode == KeyCodes.ENTER || keyCode == KeyCodes.SPACE) {
-          const isTapEventRole = hasOwn(TAP_EVENT_ROLE_WHITELIST,
+          const isTapEventRole = hasOwn(TAPPABLE_ARIA_ROLES,
               element.getAttribute('role').toLowerCase());
           if (!event.defaultPrevented && isTapEventRole) {
             event.preventDefault();

--- a/test/functional/test-action.js
+++ b/test/functional/test-action.js
@@ -20,6 +20,7 @@ import {
   ActionService,
   DeferredEvent,
   OBJECT_STRING_ARGS_KEY,
+  TAP_WIDGET_ROLES,
   dereferenceExprsInArgs,
   parseActionMap,
 } from '../../src/service/action-impl';
@@ -1052,17 +1053,20 @@ describes.fakeWin('Core events', {amp: true}, env => {
 
   it('should trigger tap event on key press if focused element has ' +
      'role=button', () => {
-    expect(window.document.addEventListener).to.have.been.calledWith('keydown');
-    const handler = window.document.addEventListener.getCall(1).args[1];
-    const element = document.createElement('div');
-    element.setAttribute('role', 'button');
-    const event = {
-      target: element,
-      keyCode: KeyCodes.ENTER,
-      preventDefault: sandbox.stub()};
-    handler(event);
-    expect(event.preventDefault).to.have.been.called;
-    expect(action.trigger).to.have.been.calledWith(element, 'tap', event);
+    TAP_WIDGET_ROLES.forEach(role => {
+      expect(window.document.addEventListener).to.have.been.calledWith(
+          'keydown');
+      const handler = window.document.addEventListener.getCall(1).args[1];
+      const element = document.createElement('div');
+      element.setAttribute('role', role);
+      const event = {
+        target: element,
+        keyCode: KeyCodes.ENTER,
+        preventDefault: sandbox.stub()};
+      handler(event);
+      expect(event.preventDefault).to.have.been.called;
+      expect(action.trigger).to.have.been.calledWith(element, 'tap', event);
+    });
   });
 
   it('should NOT trigger tap event on key press if focused element DOES NOT ' +

--- a/test/functional/test-action.js
+++ b/test/functional/test-action.js
@@ -20,7 +20,7 @@ import {
   ActionService,
   DeferredEvent,
   OBJECT_STRING_ARGS_KEY,
-  TAP_WIDGET_ROLES,
+  TAP_EVENT_ROLE_WHITELIST,
   dereferenceExprsInArgs,
   parseActionMap,
 } from '../../src/service/action-impl';
@@ -1053,7 +1053,7 @@ describes.fakeWin('Core events', {amp: true}, env => {
 
   it('should trigger tap event on key press if focused element has ' +
      'role=button', () => {
-    TAP_WIDGET_ROLES.forEach(role => {
+    Object.keys(TAP_EVENT_ROLE_WHITELIST).forEach(role => {
       expect(window.document.addEventListener).to.have.been.calledWith(
           'keydown');
       const handler = window.document.addEventListener.getCall(1).args[1];

--- a/test/functional/test-action.js
+++ b/test/functional/test-action.js
@@ -20,7 +20,6 @@ import {
   ActionService,
   DeferredEvent,
   OBJECT_STRING_ARGS_KEY,
-  TAP_EVENT_ROLE_WHITELIST,
   dereferenceExprsInArgs,
   parseActionMap,
 } from '../../src/service/action-impl';
@@ -1053,20 +1052,34 @@ describes.fakeWin('Core events', {amp: true}, env => {
 
   it('should trigger tap event on key press if focused element has ' +
      'role=button', () => {
-    Object.keys(TAP_EVENT_ROLE_WHITELIST).forEach(role => {
-      expect(window.document.addEventListener).to.have.been.calledWith(
-          'keydown');
-      const handler = window.document.addEventListener.getCall(1).args[1];
-      const element = document.createElement('div');
-      element.setAttribute('role', role);
-      const event = {
-        target: element,
-        keyCode: KeyCodes.ENTER,
-        preventDefault: sandbox.stub()};
-      handler(event);
-      expect(event.preventDefault).to.have.been.called;
-      expect(action.trigger).to.have.been.calledWith(element, 'tap', event);
-    });
+    expect(window.document.addEventListener).to.have.been.calledWith(
+        'keydown');
+    const handler = window.document.addEventListener.getCall(1).args[1];
+    const element = document.createElement('div');
+    element.setAttribute('role', 'button');
+    const event = {
+      target: element,
+      keyCode: KeyCodes.ENTER,
+      preventDefault: sandbox.stub()};
+    handler(event);
+    expect(event.preventDefault).to.have.been.called;
+    expect(action.trigger).to.have.been.calledWith(element, 'tap', event);
+  });
+
+  it('should trigger tap event on key press if focused element has ' +
+     'role=option', () => {
+    expect(window.document.addEventListener).to.have.been.calledWith(
+        'keydown');
+    const handler = window.document.addEventListener.getCall(1).args[1];
+    const element = document.createElement('div');
+    element.setAttribute('role', 'option');
+    const event = {
+      target: element,
+      keyCode: KeyCodes.ENTER,
+      preventDefault: sandbox.stub()};
+    handler(event);
+    expect(event.preventDefault).to.have.been.called;
+    expect(action.trigger).to.have.been.calledWith(element, 'tap', event);
   });
 
   it('should NOT trigger tap event on key press if focused element DOES NOT ' +


### PR DESCRIPTION
Fixes #14310 

Before this PR, pressing spacebar on `amp-selector` options would not trigger tap since they are `role="option"` and not `role="button"`. This gave keyboard-only users a degraded experience. 