### PR TITLE
Turn on font-display-swap for canary in preparation for rollout.

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -33,6 +33,7 @@
   "expUnconditionedAdxIdentity": 0.01,
   "expUnconditionedDfpIdentity": 0.01,
   "expUnconditionedCanonicalHoldback": 0.01,
+  "font-display-swap": 1,
   "rollback-delayed-fetch-deprecation": 0,
   "rollback-dfd-ix": 1,
   "rollback-dfd-criteo": 1,


### PR DESCRIPTION
This experiment now works in Chrome (in addition to the new Safari that was just released). Previously Chrome didn't support changing `font-display` at runtime.