### PR TITLE
Add new story analytics triggers and variables

### DIFF
--- a/examples/amp-story/analytics.html
+++ b/examples/amp-story/analytics.html
@@ -4,12 +4,11 @@
     <meta charset="utf-8">
     <script async src="https://cdn.ampproject.org/v0.js"></script>
     <script async custom-element="amp-video" src="https://cdn.ampproject.org/v0/amp-video-0.1.js"></script>
-    <script async custom-element="amp-audio" src="https://cdn.ampproject.org/v0/amp-audio-0.1.js"></script>
     <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-0.1.js"></script>
     <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
     <title>My Story</title>
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
-    <link rel="canonical" href="helloworld.html">
+    <link rel="canonical" href="analytics.html">
     <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
     <style amp-custom>
       body {
@@ -30,71 +29,72 @@
   <body>
     <amp-story standalone bookend-config-src="bookend.json">
 
-      <amp-story-page id="cover">
+      <amp-analytics id="analytics1">
+        <script type="application/json">
+          {
+            "requests": {
+              "endpoint": "https://raw.githubusercontent.com/ampproject/amphtml/master/examples/img/ampicon.png",
+              "base": "${endpoint}?${type|default:foo}&path=${canonicalPath}",
+              "pageView": "${base}?&index=${storyPageIndex}&count=${storyPageCount}&id=${storyPageId}&muted=${storyIsMuted}&progress=${storyProgress}"
+            },
+            "triggers": {
+              "trackPageview": {
+                "on": "story-page-visible",
+                "request": "pageView"
+              },
+              "trackBookendEnter": {
+                "on": "story-bookend-enter",
+                "request": "pageView"
+              },
+              "trackBookendExit": {
+                "on": "story-bookend-exit",
+                "request": "pageView"
+              },
+              "trackAudioEnable": {
+                "on": "story-audio-muted",
+                "request": "pageView"
+              },
+              "trackAudioDisable": {
+                "on": "story-audio-unmuted",
+                "request": "pageView"
+              }
+            }
+          }
+        </script>
+      </amp-analytics>
+
+      <amp-story-page id="p1">
         <amp-story-grid-layer template="vertical">
-          <h1>Progress Bar examples with bookend</h1>
-          <p>This is the cover page. It does not have auto-advance enabled</p>
+          <h1>Page One</h1>
         </amp-story-grid-layer>
       </amp-story-page>
 
-      <amp-story-page id="page-1" auto-advance-after="4s">
+      <amp-story-page id="p2">
         <amp-story-grid-layer template="vertical">
-          <h1>Auto advance page</h1>
-          <p>This page has auto-advance enabled</p>
+          <h1>Page Two</h1>
         </amp-story-grid-layer>
       </amp-story-page>
 
-      <amp-story-page id="page-2" auto-advance-after="vid1">
+      <amp-story-page id="p3">
         <amp-story-grid-layer template="vertical">
-          <h1>Short version of video</h1>
+          <h1>Page Three</h1>
+        </amp-story-grid-layer>
+      </amp-story-page>
+
+      <amp-story-page id="p4">
+        <amp-story-grid-layer template="vertical">
+          <h1>Page Four</h1>
           <amp-video
             id="vid1"
             src="../av/ForBiggerJoyrides-short.mp4"
             width="720"
             height="405"
             layout="responsive"
-            controls>
+            autoplay>
           </amp-video>
         </amp-story-grid-layer>
       </amp-story-page>
 
-      <amp-story-page id="page-3" auto-advance-after="vid2">
-        <amp-story-grid-layer template="vertical">
-          <h1>Full length video</h1>
-          <amp-video
-            id="vid2"
-            src="../av/ForBiggerJoyrides.mp4"
-            width="720"
-            height="405"
-            layout="responsive"
-            controls>
-          </amp-video>
-        </amp-story-grid-layer>
-      </amp-story-page>
-
-      <amp-story-page id="page-4" auto-advance-after="aud1">
-        <amp-story-grid-layer template="vertical">
-          <h1>Audio</h1>
-          <amp-audio
-            id="aud1"
-            src="https://storage.googleapis.com/media-session/sintel/snow-fight.mp3"
-            artwork="https://storage.googleapis.com/media-session/sintel/artwork-512.png"
-            title="Snow Fight"
-            album="Jan Morgenstern"
-            artist="Sintel"
-            height="50"
-            width="auto"
-            controls>
-          </amp-audio>
-        </amp-story-grid-layer>
-      </amp-story-page>
-
-      <amp-story-page id="page-5">
-        <amp-story-grid-layer template="vertical">
-          <h1>Fifth Page</h1>
-          <p>This is the fifth page of this story.</p>
-        </amp-story-grid-layer>
-      </amp-story-page>
     </amp-story>
   </body>
 </html>

--- a/examples/amp-story/progress-bar.html
+++ b/examples/amp-story/progress-bar.html
@@ -6,6 +6,7 @@
     <script async custom-element="amp-video" src="https://cdn.ampproject.org/v0/amp-video-0.1.js"></script>
     <script async custom-element="amp-audio" src="https://cdn.ampproject.org/v0/amp-audio-0.1.js"></script>
     <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-0.1.js"></script>
+    <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
     <title>My Story</title>
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
     <link rel="canonical" href="helloworld.html">
@@ -28,6 +29,43 @@
 
   <body>
     <amp-story standalone bookend-config-src="bookend.json">
+
+      <amp-analytics type="adobeanalytics">
+        <script type="application/json">
+          {
+            "requests": {
+              "base": "https://localhost:8000/s${random}",
+              "pageView": "${base}?&index=${storyPageIndex}&count=${storyPageCount}&id=${storyPageId}&muted=${storyIsMuted}&progress=${storyProgress}"
+            },
+            "vars": {
+              "trackingServer": "metrics.example.com",
+              "accounts": "example"
+            },
+            "triggers": {
+              "trackPageview": {
+                "on": "story-page-visible",
+                "request": "pageView"
+              },
+              "trackBookendEnter": {
+                "on": "story-bookend-enter",
+                "request": "pageView"
+              },
+              "trackBookendExit": {
+                "on": "story-bookend-exit",
+                "request": "pageView"
+              },
+              "trackAudioEnable": {
+                "on": "story-audio-muted",
+                "request": "pageView"
+              },
+              "trackAudioDisable": {
+                "on": "story-audio-unmuted",
+                "request": "pageView"
+              }
+            }
+          }
+        </script>
+      </amp-analytics>
 
       <amp-story-page id="cover">
         <amp-story-grid-layer template="vertical">

--- a/extensions/amp-story/0.1/analytics.js
+++ b/extensions/amp-story/0.1/analytics.js
@@ -61,7 +61,7 @@ export class AmpStoryAnalytics {
         this.triggerEvent_(Events.BOOKEND_ENTER);
         break;
       case StateChangeType.BOOKEND_EXIT:
-        this.triggerEvent_(Events.BOOKEND_ENTER);
+        this.triggerEvent_(Events.BOOKEND_EXIT);
         break;
     }
   }

--- a/extensions/amp-story/0.1/analytics.js
+++ b/extensions/amp-story/0.1/analytics.js
@@ -82,7 +82,8 @@ export class AmpStoryAnalytics {
     const variablesPromise = Services.storyVariableServiceForOrNull(this.win_);
     variablesPromise.then(
         variables => {
-          triggerAnalyticsEvent(this.element_, eventType, variables);
+          triggerAnalyticsEvent(this.element_, eventType,
+              /** @type {!Object<string, string>} */ (variables));
         },
         reason => {
           dev().error('AMP-STORY', 'Could not get analytics variables', reason);

--- a/extensions/amp-story/0.1/navigation-state.js
+++ b/extensions/amp-story/0.1/navigation-state.js
@@ -87,12 +87,13 @@ export class NavigationState {
    * @param {string=} pageId
    */
   // TODO(alanorozco): pass whether change was automatic or on user action
-  updateActivePage(pageIndex, totalPages, pageId = undefined) {
-    const changeValue = {pageIndex, totalPages};
-
-    if (pageId) {
-      changeValue.pageId = pageId;
-    }
+  updateActivePage(pageIndex, totalPages, pageId) {
+    const changeValue = {
+      pageIndex,
+      pageId,
+      totalPages,
+      storyProgress: pageIndex / totalPages,
+    };
 
     this.fire_(StateChangeType.ACTIVE_PAGE, changeValue);
 

--- a/extensions/amp-story/0.1/test/test-analytics.js
+++ b/extensions/amp-story/0.1/test/test-analytics.js
@@ -29,53 +29,10 @@ describes.fakeWin('amp-story analytics', {}, env => {
   it('should trigger `story-page-visible` on change', () => {
     const trigger = sandbox.stub(analytics, 'triggerEvent_');
 
-    analytics.onStateChange({
+    analytics.onNavigationStateChange({
       type: StateChangeType.ACTIVE_PAGE,
-      value: {
-        pageIndex: 123,
-        pageId: 'my-page-id',
-      },
     });
 
-    expect(trigger).to.have.been.calledWith('story-page-visible',
-        sandbox.match(vars =>
-          vars.storyPageIndex === '123' &&
-            vars.storyPageId == 'my-page-id'));
-  });
-
-  it('should trigger `story-page-visible` only once per page', () => {
-    const trigger = sandbox.stub(analytics, 'triggerEvent_');
-
-    for (let i = 0; i < 10; i++) {
-      analytics.onStateChange({
-        type: StateChangeType.ACTIVE_PAGE,
-        value: {
-          pageIndex: 123,
-          pageId: 'my-page-id',
-        },
-      });
-    }
-
-    expect(trigger).to.have.been.calledOnce;
-    expect(trigger).to.have.been.calledWith('story-page-visible',
-        sandbox.match(vars =>
-          vars.storyPageIndex === '123' &&
-            vars.storyPageId == 'my-page-id'));
-
-    for (let i = 0; i < 10; i++) {
-      analytics.onStateChange({
-        type: StateChangeType.ACTIVE_PAGE,
-        value: {
-          pageIndex: 6,
-          pageId: 'foo-page-id',
-        },
-      });
-    }
-
-    expect(trigger).to.have.been.calledTwice;
-    expect(trigger).to.have.been.calledWith('story-page-visible',
-        sandbox.match(vars =>
-          vars.storyPageIndex === '6' &&
-            vars.storyPageId == 'foo-page-id'));
+    expect(trigger).to.have.been.calledWith('story-page-visible');
   });
 });

--- a/extensions/amp-story/0.1/test/test-navigation-state.js
+++ b/extensions/amp-story/0.1/test/test-navigation-state.js
@@ -48,17 +48,19 @@ describes.fakeWin('amp-story navigation state', {ampdoc: 'none'}, env => {
         e.type == StateChangeType.ACTIVE_PAGE
               && e.value.pageIndex === 0
               && e.value.totalPages === 10
-              && e.value.pageId == 'my-page-id-1'));
+              && e.value.pageId == 'my-page-id-1'
+              && e.value.storyProgress === 0));
     });
 
-    navigationState.updateActivePage(5, 15);
+    navigationState.updateActivePage(5, 15, 'foo');
 
     observers.forEach(observer => {
       expect(observer).to.have.been.calledWith(sandbox.match(e =>
         e.type == StateChangeType.ACTIVE_PAGE
               && e.value.pageIndex === 5
               && e.value.totalPages === 15
-              && !('pageId' in e.value)));
+              && e.value.pageId === 'foo'
+              && e.value.storyProgress === (1 / 3)));
     });
 
     navigationState.updateActivePage(2, 5, 'one-two-three');
@@ -68,7 +70,8 @@ describes.fakeWin('amp-story navigation state', {ampdoc: 'none'}, env => {
         e.type == StateChangeType.ACTIVE_PAGE
               && e.value.pageIndex === 2
               && e.value.totalPages === 5
-              && e.value.pageId == 'one-two-three'));
+              && e.value.pageId == 'one-two-three'
+              && e.value.storyProgress === 0.4));
     });
   });
 

--- a/extensions/amp-story/0.1/test/test-variable-service.js
+++ b/extensions/amp-story/0.1/test/test-variable-service.js
@@ -34,7 +34,7 @@ describes.fakeWin('amp-story variable service', {}, () => {
     });
 
     const variables = variableService.get();
-    expect(variables.pageIndex).to.equal(123);
-    expect(variables.pageId).to.equal('my-page-id');
+    expect(variables['storyPageIndex']).to.equal(123);
+    expect(variables['storyPageId']).to.equal('my-page-id');
   });
 });

--- a/extensions/amp-story/0.1/test/test-variable-service.js
+++ b/extensions/amp-story/0.1/test/test-variable-service.js
@@ -25,7 +25,7 @@ describes.fakeWin('amp-story variable service', {}, () => {
   });
 
   it('should update pageIndex and pageId on change', () => {
-    variableService.onStateChange({
+    variableService.onNavigationStateChange({
       type: StateChangeType.ACTIVE_PAGE,
       value: {
         pageIndex: 123,

--- a/extensions/amp-story/0.1/variable-service.js
+++ b/extensions/amp-story/0.1/variable-service.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import {StateChangeType} from './navigation-state';
-import {dev} from '../../../src/log';
 
 /**
  * @typedef {!Object<string, *>}

--- a/extensions/amp-story/0.1/variable-service.js
+++ b/extensions/amp-story/0.1/variable-service.js
@@ -17,12 +17,20 @@ import {StateChangeType} from './navigation-state';
 import {dev} from '../../../src/log';
 
 /**
- * @typedef {{
- *   pageIndex: string,
- *   pageId: number,
- * }}
+ * @typedef {!Object<string, *>}
  */
 export let StoryVariableDef;
+
+
+/** @enum {string} */
+const Variable = {
+  STORY_PAGE_ID: 'storyPageId',
+  STORY_PAGE_INDEX: 'storyPageIndex',
+  STORY_PAGE_COUNT: 'storyPageCount',
+  STORY_IS_MUTED: 'storyIsMuted',
+  STORY_PROGRESS: 'storyProgress',
+};
+
 
 /**
  * Variable service for amp-story.
@@ -32,8 +40,11 @@ export class AmpStoryVariableService {
   constructor() {
     /** @private {!StoryVariableDef} */
     this.variables_ = {
-      pageIndex: '',
-      pageId: 0,
+      [Variable.STORY_PAGE_INDEX]: null,
+      [Variable.STORY_PAGE_ID]: null,
+      [Variable.STORY_PAGE_COUNT]: null,
+      [Variable.STORY_PROGRESS]: null,
+      [Variable.STORY_IS_MUTED]: null,
     };
 
     /** @private {boolean} */
@@ -43,23 +54,30 @@ export class AmpStoryVariableService {
   /**
    * @param {!./navigation-state.StateChangeEventDef} stateChangeEvent
    */
-  onStateChange(stateChangeEvent) {
+  onNavigationStateChange(stateChangeEvent) {
     switch (stateChangeEvent.type) {
       case StateChangeType.ACTIVE_PAGE:
-        const {pageIndex, pageId} = stateChangeEvent.value;
-        const variables = this.variables_;
-        this.isInitialized_ = true;
-        variables.pageIndex = pageIndex;
-        variables.pageId = pageId;
+        const {pageIndex, pageId, storyProgress, totalPages} =
+            stateChangeEvent.value;
+        this.variables_[Variable.STORY_PAGE_INDEX] = pageIndex;
+        this.variables_[Variable.STORY_PAGE_ID] = pageId;
+        this.variables_[Variable.STORY_PROGRESS] = storyProgress;
+        this.variables_[Variable.STORY_PAGE_COUNT] = totalPages;
         break;
     }
+  }
+
+  /**
+   * @param {boolean} isMuted
+   */
+  onMutedStateChange(isMuted) {
+    this.variables_[Variable.STORY_IS_MUTED] = isMuted;
   }
 
   /**
    * @return {!StoryVariableDef}
    */
   get() {
-    dev().assert(this.isInitialized_);
     // TODO(newmius): You should probably Object.freeze this in development.
     return this.variables_;
   }


### PR DESCRIPTION
This PR adds two analytics triggers (fixes #14313):

1. `story-audio-unmuted` when the story is unmuted
2. `story-audio-muted` when the story is muted

It also adds three analytics variables (fixes #14312):

1. `storyIsMuted`: Whether or not the story was muted at the time the event was triggered
2. `storyPageCount`: The total number of pages in the story at the time the event was triggered
3. `storyProgress`: The user's current progress through the story at the time the event was triggered (in the range of 0...1)

This required some refactoring of the `AmpStoryVariableService`, `NavigationState`, and `AmpStoryAnalytics`.