### PR TITLE
🐛Tweaks "ken burns" animations to check for image sizes

### DIFF
--- a/examples/amp-story/animations-presets.html
+++ b/examples/amp-story/animations-presets.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html amp>
+
 <head>
   <meta charset="utf-8">
   <title>amp-story</title>
@@ -12,48 +13,56 @@
     body {
       font-family: sans-serif;
     }
-    h1, p {
+
+    h1,
+    p {
       font-family: Menlo, Monaco, monospace;
       width: 100%;
       font-weight: bold;
     }
+
     h1 {
       font-size: 24px;
       z-index: 1;
       text-align: left;
     }
+
     p {
       font-size: 18px;
       text-align: right;
     }
+
     amp-story-page {
       background: #ddd;
     }
+
     amp-story-grid-layer {
       justify-items: center;
     }
+
     .square,
     .circle {
       background: #4285f4;
       width: 80px;
       height: 80px;
     }
+
     .circle {
       border-radius: 80px;
     }
+
     .img-container {
       position: absolute;
     }
-    </style>
+  </style>
 </head>
+
 <body>
   <amp-story standalone>
     <amp-story-page id="pulse-page">
       <amp-story-grid-layer template="vertical">
         <h1>pulse</h1>
-        <div class="circle"
-            animate-in="pulse"
-            animate-in-duration="1s">
+        <div class="circle" animate-in="pulse" animate-in-duration="1s">
         </div>
       </amp-story-grid-layer>
     </amp-story-page>
@@ -61,9 +70,7 @@
     <amp-story-page id="fade-in-page">
       <amp-story-grid-layer template="vertical">
         <h1>fade-in</h1>
-        <div class="circle"
-            animate-in="fade-in"
-            animate-in-duration="0.8s">
+        <div class="circle" animate-in="fade-in" animate-in-duration="0.8s">
         </div>
       </amp-story-grid-layer>
     </amp-story-page>
@@ -71,8 +78,7 @@
     <amp-story-page id="twirl-in-page">
       <amp-story-grid-layer template="vertical">
         <h1>twirl-in</h1>
-        <div class="square"
-            animate-in="twirl-in">
+        <div class="square" animate-in="twirl-in">
         </div>
       </amp-story-grid-layer>
     </amp-story-page>
@@ -80,8 +86,7 @@
     <amp-story-page id="fly-in-left-page">
       <amp-story-grid-layer template="vertical">
         <h1>fly-in-left</h1>
-        <div class="square"
-            animate-in="fly-in-left">
+        <div class="square" animate-in="fly-in-left">
         </div>
       </amp-story-grid-layer>
     </amp-story-page>
@@ -89,8 +94,7 @@
     <amp-story-page id="fly-in-right-page">
       <amp-story-grid-layer template="vertical">
         <h1>fly-in-right</h1>
-        <div class="square"
-            animate-in="fly-in-right">
+        <div class="square" animate-in="fly-in-right">
         </div>
       </amp-story-grid-layer>
     </amp-story-page>
@@ -98,8 +102,7 @@
     <amp-story-page id="fly-in-top-page">
       <amp-story-grid-layer template="vertical">
         <h1>fly-in-top</h1>
-        <div class="square"
-            animate-in="fly-in-top">
+        <div class="square" animate-in="fly-in-top">
         </div>
       </amp-story-grid-layer>
     </amp-story-page>
@@ -107,8 +110,7 @@
     <amp-story-page id="fly-in-bottom-page">
       <amp-story-grid-layer template="vertical">
         <h1>fly-in-bottom</h1>
-        <div class="square"
-            animate-in="fly-in-bottom">
+        <div class="square" animate-in="fly-in-bottom">
         </div>
       </amp-story-grid-layer>
     </amp-story-page>
@@ -116,8 +118,7 @@
     <amp-story-page id="rotate-in-left-page">
       <amp-story-grid-layer template="vertical">
         <h1>rotate-in-left</h1>
-        <div class="square"
-            animate-in="rotate-in-left">
+        <div class="square" animate-in="rotate-in-left">
         </div>
       </amp-story-grid-layer>
     </amp-story-page>
@@ -125,8 +126,7 @@
     <amp-story-page id="rotate-in-right-page">
       <amp-story-grid-layer template="vertical">
         <h1>rotate-in-right</h1>
-        <div class="square"
-            animate-in="rotate-in-right">
+        <div class="square" animate-in="rotate-in-right">
         </div>
       </amp-story-grid-layer>
     </amp-story-page>
@@ -134,8 +134,7 @@
     <amp-story-page id="drop-page">
       <amp-story-grid-layer template="vertical">
         <h1>drop-in</h1>
-        <div class="circle"
-             animate-in="drop">
+        <div class="circle" animate-in="drop">
         </div>
       </amp-story-grid-layer>
     </amp-story-page>
@@ -143,8 +142,7 @@
     <amp-story-page id="whoosh-in-left-page">
       <amp-story-grid-layer template="vertical">
         <h1>whoosh-in-left</h1>
-        <div class="square"
-            animate-in="whoosh-in-left">
+        <div class="square" animate-in="whoosh-in-left">
         </div>
       </amp-story-grid-layer>
     </amp-story-page>
@@ -152,107 +150,83 @@
     <amp-story-page id="whoosh-in-right-page">
       <amp-story-grid-layer template="vertical">
         <h1>whoosh-in-right</h1>
-        <div class="square"
-            animate-in="whoosh-in-right">
+        <div class="square" animate-in="whoosh-in-right">
         </div>
       </amp-story-grid-layer>
     </amp-story-page>
 
     <!-- ## Zoom-In -->
     <amp-story-page id="zoom-in">
-        <amp-story-grid-layer template="fill">
-          <amp-img animate-in="zoom-in"
-                   animate-in-duration="4s"
-                   layout="responsive"
-                   src="https://picsum.photos/720/320?image=1026"
-                   width="720"
-                   height="320">
-          </amp-img>
-        </amp-story-grid-layer>
-        <amp-story-grid-layer template="fill">
-          <h1>zoom-in</h1>
-        </amp-story-grid-layer>
-      </amp-story-page>
+      <amp-story-grid-layer template="fill">
+        <amp-img animate-in="zoom-in" animate-in-duration="4s" layout="responsive" src="https://picsum.photos/720/320?image=1026"
+          width="720" height="320">
+        </amp-img>
+      </amp-story-grid-layer>
+      <amp-story-grid-layer template="fill">
+        <h1>zoom-in</h1>
+      </amp-story-grid-layer>
+    </amp-story-page>
 
-      <!-- ## Zoom-Out -->
-      <amp-story-page id="zoom-out">
-        <amp-story-grid-layer template="fill">
-          <amp-img animate-in="zoom-out"
-                   animate-in-duration="4s"
-                   layout="responsive"
-                   src="https://picsum.photos/720/320?image=1026"
-                   width="720"
-                   height="320">
-          </amp-img>
-        </amp-story-grid-layer>
-        <amp-story-grid-layer template="fill">
-          <h1>zoom-out</h1>
-        </amp-story-grid-layer>
-      </amp-story-page>
+    <!-- ## Zoom-Out -->
+    <amp-story-page id="zoom-out">
+      <amp-story-grid-layer template="fill">
+        <amp-img animate-in="zoom-out" animate-in-duration="4s" layout="responsive" src="https://picsum.photos/720/320?image=1026"
+          width="720" height="320">
+        </amp-img>
+      </amp-story-grid-layer>
+      <amp-story-grid-layer template="fill">
+        <h1>zoom-out</h1>
+      </amp-story-grid-layer>
+    </amp-story-page>
 
-      <!-- ## Pan-Left -->
-      <amp-story-page id="pan-left">
-        <amp-story-grid-layer template="fill">
-          <amp-img animate-in="pan-left" id="img-pan-left"
-                   animate-in-duration="4s"
-                   layout="fixed"
-                   src="https://picsum.photos/720/320?image=1026"
-                   width="720"
-                   height="320">
-          </amp-img>
-        </amp-story-grid-layer>
-          <amp-story-grid-layer template="fill">
-              <h1>pan-left</h1>
-          </amp-story-grid-layer>
-      </amp-story-page>
+    <!-- ## Pan-Left -->
+    <amp-story-page id="pan-left">
+      <amp-story-grid-layer template="fill">
+        <amp-img animate-in="pan-left" id="img-pan-left" animate-in-duration="4s" layout="fixed" src="https://picsum.photos/720/320?image=1026"
+          width="720" height="320">
+        </amp-img>
+      </amp-story-grid-layer>
+      <amp-story-grid-layer template="fill">
+        <h1>pan-left</h1>
+      </amp-story-grid-layer>
+    </amp-story-page>
 
-      <!-- ## Pan-Right -->
-      <amp-story-page id="pan-right">
-        <amp-story-grid-layer template="fill">
-            <amp-img animate-in="pan-right"
-                     animate-in-duration="4s"
-                     layout="fixed"
-                     src="https://picsum.photos/720/320?image=1026"
-                     width="720"
-                     height="320">
-            </amp-img>
-        </amp-story-grid-layer>
-        <amp-story-grid-layer template="fill">
-          <h1>pan-right</h1>
-        </amp-story-grid-layer>
-      </amp-story-page>
+    <!-- ## Pan-Right -->
+    <amp-story-page id="pan-right">
+      <amp-story-grid-layer template="fill">
+        <amp-img animate-in="pan-right" animate-in-duration="4s" layout="fixed" src="https://picsum.photos/720/320?image=1026" width="720"
+          height="320">
+        </amp-img>
+      </amp-story-grid-layer>
+      <amp-story-grid-layer template="fill">
+        <h1>pan-right</h1>
+      </amp-story-grid-layer>
+    </amp-story-page>
 
-      <!-- ## Pan-Up -->
-      <amp-story-page id="pan-up">
-        <amp-story-grid-layer template="fill">
-          <amp-img animate-in="pan-up"
-                   animate-in-duration="4s"
-                   layout="fixed"
-                   src="https://picsum.photos/720/320?image=1026"
-                   width="720"
-                   height="320">
-          </amp-img>
-        </amp-story-grid-layer>
-        <amp-story-grid-layer template="fill">
-          <h1>pan-up</h1>
-        </amp-story-grid-layer>
-      </amp-story-page>
+    <!-- ## Pan-Up -->
+    <amp-story-page id="pan-up">
+      <amp-story-grid-layer template="fill">
+        <amp-img animate-in="pan-up" animate-in-duration="4s" layout="fixed" src="https://picsum.photos/720/320?image=1026" width="720"
+          height="320">
+        </amp-img>
+      </amp-story-grid-layer>
+      <amp-story-grid-layer template="fill">
+        <h1>pan-up</h1>
+      </amp-story-grid-layer>
+    </amp-story-page>
 
-      <!-- ## Pan-Down -->
-      <amp-story-page id="pan-down">
-        <amp-story-grid-layer template="fill">
-          <amp-img animate-in="pan-down"
-                   animate-in-duration="4s"
-                   layout="fixed"
-                   src="https://picsum.photos/720/320?image=1026"
-                   width="720"
-                   height="320">
-          </amp-img>
-        </amp-story-grid-layer>
-        <amp-story-grid-layer template="fill">
-          <h1>pan-down</h1>
-        </amp-story-grid-layer>
-      </amp-story-page>
+    <!-- ## Pan-Down -->
+    <amp-story-page id="pan-down">
+      <amp-story-grid-layer template="fill">
+        <amp-img animate-in="pan-down" animate-in-duration="4s" layout="fixed" src="https://picsum.photos/720/320?image=1026" width="720"
+          height="320">
+        </amp-img>
+      </amp-story-grid-layer>
+      <amp-story-grid-layer template="fill">
+        <h1>pan-down</h1>
+      </amp-story-grid-layer>
+    </amp-story-page>
   </amp-story>
 </body>
+
 </html>

--- a/examples/amp-story/animations-presets.html
+++ b/examples/amp-story/animations-presets.html
@@ -158,36 +158,99 @@
       </amp-story-grid-layer>
     </amp-story-page>
 
-    <amp-story-page id="ken-burns-effect">
-      <amp-story-grid-layer template="vertical">
-        <h1>ken-burns-effect</h1>
-        <div animate-in="zoom-in" animate-in-duration="30s" class="img-container">
-            <amp-img id="ken-burns-img1"
-              src="https://picsum.photos/1024/768?image=1077"
-              animate-in="pan-right"
-              animate-in-duration="30s"
-              layout="fixed"
-              width="1024"
-              height="768">
+    <!-- ## Zoom-In -->
+    <amp-story-page id="zoom-in">
+        <amp-story-grid-layer template="fill">
+          <amp-img animate-in="zoom-in"
+                   animate-in-duration="4s"
+                   layout="responsive"
+                   src="https://picsum.photos/720/320?image=1026"
+                   width="720"
+                   height="320">
+          </amp-img>
+        </amp-story-grid-layer>
+        <amp-story-grid-layer template="fill">
+          <h1>zoom-in</h1>
+        </amp-story-grid-layer>
+      </amp-story-page>
+
+      <!-- ## Zoom-Out -->
+      <amp-story-page id="zoom-out">
+        <amp-story-grid-layer template="fill">
+          <amp-img animate-in="zoom-out"
+                   animate-in-duration="4s"
+                   layout="responsive"
+                   src="https://picsum.photos/720/320?image=1026"
+                   width="720"
+                   height="320">
+          </amp-img>
+        </amp-story-grid-layer>
+        <amp-story-grid-layer template="fill">
+          <h1>zoom-out</h1>
+        </amp-story-grid-layer>
+      </amp-story-page>
+
+      <!-- ## Pan-Left -->
+      <amp-story-page id="pan-left">
+        <amp-story-grid-layer template="fill">
+          <amp-img animate-in="pan-left" id="img-pan-left"
+                   animate-in-duration="4s"
+                   layout="fixed"
+                   src="https://picsum.photos/720/320?image=1026"
+                   width="720"
+                   height="320">
+          </amp-img>
+        </amp-story-grid-layer>
+          <amp-story-grid-layer template="fill">
+              <h1>pan-left</h1>
+          </amp-story-grid-layer>
+      </amp-story-page>
+
+      <!-- ## Pan-Right -->
+      <amp-story-page id="pan-right">
+        <amp-story-grid-layer template="fill">
+            <amp-img animate-in="pan-right"
+                     animate-in-duration="4s"
+                     layout="fixed"
+                     src="https://picsum.photos/720/320?image=1026"
+                     width="720"
+                     height="320">
             </amp-img>
-        </div>
-        <div animate-in="fade-in" animate-in-after="ken-burns-img1" animate-in-delay="0.25s" animate-in-duration="1s">
-          <div
-            animate-in="zoom-out"
-            animate-in-duration="30s"
-            class="img-container"
-            animate-in-after="ken-burns-img1">
-            <amp-img id="ken-burns-img2"
-              src="https://picsum.photos/1024/768?image=1026"
-              layout="fixed"
-              width="1024"
-              height="768"
-              animate-in="pan-down"
-              animate-in-duration="30s"
-              animate-in-after="ken-burns-img1">
-            </amp-img>
-          </div>
-        </div>
+        </amp-story-grid-layer>
+        <amp-story-grid-layer template="fill">
+          <h1>pan-right</h1>
+        </amp-story-grid-layer>
+      </amp-story-page>
+
+      <!-- ## Pan-Up -->
+      <amp-story-page id="pan-up">
+        <amp-story-grid-layer template="fill">
+          <amp-img animate-in="pan-up"
+                   animate-in-duration="4s"
+                   layout="fixed"
+                   src="https://picsum.photos/720/320?image=1026"
+                   width="720"
+                   height="320">
+          </amp-img>
+        </amp-story-grid-layer>
+        <amp-story-grid-layer template="fill">
+          <h1>pan-up</h1>
+        </amp-story-grid-layer>
+      </amp-story-page>
+
+      <!-- ## Pan-Down -->
+      <amp-story-page id="pan-down">
+        <amp-story-grid-layer template="fill">
+          <amp-img animate-in="pan-down"
+                   animate-in-duration="4s"
+                   layout="fixed"
+                   src="https://picsum.photos/720/320?image=1026"
+                   width="720"
+                   height="320">
+          </amp-img>
+        </amp-story-grid-layer>
+        <amp-story-grid-layer template="fill">
+          <h1>pan-down</h1>
         </amp-story-grid-layer>
       </amp-story-page>
   </amp-story>

--- a/examples/amp-story/visual-effects.html
+++ b/examples/amp-story/visual-effects.html
@@ -44,135 +44,131 @@
 
     <amp-story-page id="ken-burns-effect2">
       <amp-story-grid-layer template="fill">
-        <div>
-          <div animate-in="zoom-in" animate-in-duration="5s" class="img-container">
-            <amp-img id="ken-burns-img2"
-              src="https://picsum.photos/1600/1200?image=1078"
-              animate-in="pan-right"
-              animate-in-duration="5s"
+        <div animate-in="zoom-in" animate-in-duration="5s" class="img-container">
+          <amp-img id="ken-burns-img2"
+            src="https://picsum.photos/1600/1200?image=1078"
+            animate-in="pan-right"
+            animate-in-duration="5s"
+            layout="fixed"
+            width="1600"
+            height="1200">
+          </amp-img>
+        </div>
+        <div animate-in="fade-in" animate-in-after="ken-burns-img2" animate-in-duration="1s" class="img-container">
+          <div
+            animate-in="zoom-out"
+            animate-in-duration="5s"
+            class="img-container"
+            animate-in-after="ken-burns-img2">
+            <amp-img id="ken-burns-img3"
+              src="https://picsum.photos/1600/1200?image=1026"
               layout="fixed"
               width="1600"
-              height="1200">
+              height="1200"
+              animate-in="pan-down"
+              animate-in-duration="5s"
+              animate-in-after="ken-burns-img2">
             </amp-img>
           </div>
-          <div animate-in="fade-in" animate-in-after="ken-burns-img2" animate-in-duration="1s" class="img-container">
-            <div
-              animate-in="zoom-out"
+        </div>
+        <div animate-in="fade-in" animate-in-after="ken-burns-img3" animate-in-duration="1s" class="img-container">
+          <div
+            animate-in="zoom-in"
+            animate-in-duration="5s"
+            class="img-container"
+            animate-in-after="ken-burns-img3">
+            <amp-img id="ken-burns-img4"
+              src="https://picsum.photos/1600/1200?image=1029"
+              layout="fixed"
+              width="1600"
+              height="1200"
+              animate-in="pan-right"
               animate-in-duration="5s"
-              class="img-container"
-              animate-in-after="ken-burns-img2">
-              <amp-img id="ken-burns-img3"
-                src="https://picsum.photos/1600/1200?image=1026"
-                layout="fixed"
-                width="1600"
-                height="1200"
-                animate-in="pan-down"
-                animate-in-duration="5s"
-                animate-in-after="ken-burns-img2">
-              </amp-img>
-            </div>
-          </div>
-          <div animate-in="fade-in" animate-in-after="ken-burns-img3" animate-in-duration="1s" class="img-container">
-            <div
-              animate-in="zoom-in"
-              animate-in-duration="5s"
-              class="img-container"
               animate-in-after="ken-burns-img3">
-              <amp-img id="ken-burns-img4"
-                src="https://picsum.photos/1600/1200?image=1029"
-                layout="fixed"
-                width="1600"
-                height="1200"
-                animate-in="pan-right"
-                animate-in-duration="5s"
-                animate-in-after="ken-burns-img3">
-              </amp-img>
-            </div>
+            </amp-img>
           </div>
-          <div animate-in="fade-in" animate-in-after="ken-burns-img4" animate-in-duration="1s" class="img-container">
-              <div
-                animate-in="zoom-out"
-                animate-in-duration="5s"
-                class="img-container"
-                animate-in-after="ken-burns-img4">
-                <amp-img id="ken-burns-img5"
-                  src="https://picsum.photos/1600/1200?image=1033"
-                  layout="fixed"
-                  width="1600"
-                  height="1200"
-                  animate-in="pan-up"
-                  animate-in-duration="5s"
-                  animate-in-after="ken-burns-img4">
-                </amp-img>
-              </div>
-            </div>
+        </div>
+        <div animate-in="fade-in" animate-in-after="ken-burns-img4" animate-in-duration="1s" class="img-container">
+          <div
+            animate-in="zoom-out"
+            animate-in-duration="5s"
+            class="img-container"
+            animate-in-after="ken-burns-img4">
+            <amp-img id="ken-burns-img5"
+              src="https://picsum.photos/1600/1200?image=1033"
+              layout="fixed"
+              width="1600"
+              height="1200"
+              animate-in="pan-up"
+              animate-in-duration="5s"
+              animate-in-after="ken-burns-img4">
+            </amp-img>
+          </div>
         </div>
       </amp-story-grid-layer>
     </amp-story-page>
 
     <amp-story-page id="ken-burns-effect3">
       <amp-story-grid-layer template="fill">
-        <div>
-          <div animate-in="zoom-in" animate-in-duration="30s" class="img-container">
+        <div animate-in="zoom-in" animate-in-duration="30s" class="img-container">
+          <amp-img
+            src="https://picsum.photos/1600/1200?image=1078"
+            animate-in="pan-right"
+            animate-in-duration="30s"
+            layout="fixed"
+            width="1600"
+            height="1200">
+          </amp-img>
+        </div>
+        <div animate-in="fade-in" animate-in-delay="5s" animate-in-duration="1s" class="img-container">
+          <div
+            animate-in="zoom-out"
+            animate-in-duration="30s"
+            class="img-container"
+            animate-in-delay="5s">
             <amp-img
-              src="https://picsum.photos/1600/1200?image=1078"
-              animate-in="pan-right"
-              animate-in-duration="30s"
+              src="https://picsum.photos/1600/1200?image=1026"
               layout="fixed"
               width="1600"
-              height="1200">
+              height="1200"
+              animate-in="pan-up"
+              animate-in-duration="30s"
+              animate-in-delay="5s">
             </amp-img>
           </div>
-          <div animate-in="fade-in" animate-in-delay="5s" animate-in-duration="1s" class="img-container">
-            <div
-              animate-in="zoom-out"
+        </div>
+        <div animate-in="fade-in" animate-in-delay="10s" animate-in-duration="1s" class="img-container">
+          <div
+            animate-in="zoom-out"
+            animate-in-duration="30s"
+            class="img-container"
+            animate-in-delay="10s">
+            <amp-img
+              src="https://picsum.photos/1600/1200?image=1029"
+              layout="fixed"
+              width="1600"
+              height="1200"
+              animate-in="pan-right"
               animate-in-duration="30s"
-              class="img-container"
-              animate-in-delay="5s">
-              <amp-img
-                src="https://picsum.photos/1600/1200?image=1026"
-                layout="fixed"
-                width="1600"
-                height="1200"
-                animate-in="pan-up"
-                animate-in-duration="30s"
-                animate-in-delay="5s">
-              </amp-img>
-            </div>
-          </div>
-          <div animate-in="fade-in" animate-in-delay="10s" animate-in-duration="1s" class="img-container">
-            <div
-              animate-in="zoom-out"
-              animate-in-duration="30s"
-              class="img-container"
               animate-in-delay="10s">
-              <amp-img
-                src="https://picsum.photos/1600/1200?image=1029"
-                layout="fixed"
-                width="1600"
-                height="1200"
-                animate-in="pan-right"
-                animate-in-duration="30s"
-                animate-in-delay="10s">
-              </amp-img>
-            </div>
+            </amp-img>
           </div>
-          <div animate-in="fade-in" animate-in-delay="15s" animate-in-duration="1s" class="img-container">
-            <div
-              animate-in="zoom-out"
+        </div>
+        <div animate-in="fade-in" animate-in-delay="15s" animate-in-duration="1s" class="img-container">
+          <div
+            animate-in="zoom-out"
+            animate-in-duration="30s"
+            class="img-container"
+            animate-in-delay="15s">
+            <amp-img
+              src="https://picsum.photos/1600/1200?image=1033"
+              layout="fixed"
+              width="1600"
+              height="1200"
+              animate-in="pan-left"
               animate-in-duration="30s"
-              class="img-container"
               animate-in-delay="15s">
-              <amp-img
-                src="https://picsum.photos/1600/1200?image=1033"
-                layout="fixed"
-                width="1600"
-                height="1200"
-                animate-in="pan-left"
-                animate-in-duration="30s"
-                animate-in-delay="15s">
-              </amp-img>
-            </div>
+            </amp-img>
           </div>
         </div>
       </amp-story-grid-layer>

--- a/examples/amp-story/visual-effects.html
+++ b/examples/amp-story/visual-effects.html
@@ -1,0 +1,183 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <link rel="canonical" href="visual-effects.html">
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-0.1.js"></script>
+  <style amp-custom>
+    amp-story-page {
+      font-family: 'Roboto', sans-serif;
+      background: #fff;
+    }
+    amp-story-grid-layer {
+      align-items: center;
+      justify-items: center;
+    }
+    .img-container {
+      position: absolute;
+      width: 0px;
+      height: 0px;
+    }
+  </style>
+  <title>Visual Effects</title>
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+</head>
+<body>
+  <amp-story standalone>
+
+    <amp-story-page id="ken-burns-effect1">
+      <amp-story-grid-layer template="fill">
+        <div animate-in="zoom-in" animate-in-duration="30s" class="img-container">
+            <amp-img id="ken-burns-img1"
+              src="https://picsum.photos/1600/1200?image=1077"
+              animate-in="pan-left"
+              animate-in-duration="30s"
+              layout="fixed"
+              width="1600"
+              height="1200">
+            </amp-img>
+        </div>
+      </amp-story-grid-layer>
+    </amp-story-page>
+
+    <amp-story-page id="ken-burns-effect2">
+      <amp-story-grid-layer template="fill">
+        <div>
+          <div animate-in="zoom-in" animate-in-duration="5s" class="img-container">
+            <amp-img id="ken-burns-img2"
+              src="https://picsum.photos/1600/1200?image=1078"
+              animate-in="pan-right"
+              animate-in-duration="5s"
+              layout="fixed"
+              width="1600"
+              height="1200">
+            </amp-img>
+          </div>
+          <div animate-in="fade-in" animate-in-after="ken-burns-img2" animate-in-duration="1s" class="img-container">
+            <div
+              animate-in="zoom-out"
+              animate-in-duration="5s"
+              class="img-container"
+              animate-in-after="ken-burns-img2">
+              <amp-img id="ken-burns-img3"
+                src="https://picsum.photos/1600/1200?image=1026"
+                layout="fixed"
+                width="1600"
+                height="1200"
+                animate-in="pan-down"
+                animate-in-duration="5s"
+                animate-in-after="ken-burns-img2">
+              </amp-img>
+            </div>
+          </div>
+          <div animate-in="fade-in" animate-in-after="ken-burns-img3" animate-in-duration="1s" class="img-container">
+            <div
+              animate-in="zoom-in"
+              animate-in-duration="5s"
+              class="img-container"
+              animate-in-after="ken-burns-img3">
+              <amp-img id="ken-burns-img4"
+                src="https://picsum.photos/1600/1200?image=1029"
+                layout="fixed"
+                width="1600"
+                height="1200"
+                animate-in="pan-right"
+                animate-in-duration="5s"
+                animate-in-after="ken-burns-img3">
+              </amp-img>
+            </div>
+          </div>
+          <div animate-in="fade-in" animate-in-after="ken-burns-img4" animate-in-duration="1s" class="img-container">
+              <div
+                animate-in="zoom-out"
+                animate-in-duration="5s"
+                class="img-container"
+                animate-in-after="ken-burns-img4">
+                <amp-img id="ken-burns-img5"
+                  src="https://picsum.photos/1600/1200?image=1033"
+                  layout="fixed"
+                  width="1600"
+                  height="1200"
+                  animate-in="pan-up"
+                  animate-in-duration="5s"
+                  animate-in-after="ken-burns-img4">
+                </amp-img>
+              </div>
+            </div>
+        </div>
+      </amp-story-grid-layer>
+    </amp-story-page>
+
+    <amp-story-page id="ken-burns-effect3">
+      <amp-story-grid-layer template="fill">
+        <div>
+          <div animate-in="zoom-in" animate-in-duration="30s" class="img-container">
+            <amp-img
+              src="https://picsum.photos/1600/1200?image=1078"
+              animate-in="pan-right"
+              animate-in-duration="30s"
+              layout="fixed"
+              width="1600"
+              height="1200">
+            </amp-img>
+          </div>
+          <div animate-in="fade-in" animate-in-delay="5s" animate-in-duration="1s" class="img-container">
+            <div
+              animate-in="zoom-out"
+              animate-in-duration="30s"
+              class="img-container"
+              animate-in-delay="5s">
+              <amp-img
+                src="https://picsum.photos/1600/1200?image=1026"
+                layout="fixed"
+                width="1600"
+                height="1200"
+                animate-in="pan-up"
+                animate-in-duration="30s"
+                animate-in-delay="5s">
+              </amp-img>
+            </div>
+          </div>
+          <div animate-in="fade-in" animate-in-delay="10s" animate-in-duration="1s" class="img-container">
+            <div
+              animate-in="zoom-out"
+              animate-in-duration="30s"
+              class="img-container"
+              animate-in-delay="10s">
+              <amp-img
+                src="https://picsum.photos/1600/1200?image=1029"
+                layout="fixed"
+                width="1600"
+                height="1200"
+                animate-in="pan-right"
+                animate-in-duration="30s"
+                animate-in-delay="10s">
+              </amp-img>
+            </div>
+          </div>
+          <div animate-in="fade-in" animate-in-delay="15s" animate-in-duration="1s" class="img-container">
+            <div
+              animate-in="zoom-out"
+              animate-in-duration="30s"
+              class="img-container"
+              animate-in-delay="15s">
+              <amp-img
+                src="https://picsum.photos/1600/1200?image=1033"
+                layout="fixed"
+                width="1600"
+                height="1200"
+                animate-in="pan-left"
+                animate-in-duration="30s"
+                animate-in-delay="15s">
+              </amp-img>
+            </div>
+          </div>
+        </div>
+      </amp-story-grid-layer>
+    </amp-story-page>
+
+  </amp-story>
+</body>
+</html>

--- a/examples/amp-story/visual-effects.html
+++ b/examples/amp-story/visual-effects.html
@@ -1,5 +1,6 @@
 <!doctype html>
 <html ⚡>
+
 <head>
   <meta charset="utf-8">
   <link rel="canonical" href="visual-effects.html">
@@ -11,10 +12,12 @@
       font-family: 'Roboto', sans-serif;
       background: #fff;
     }
+
     amp-story-grid-layer {
       align-items: center;
       justify-items: center;
     }
+
     .img-container {
       position: absolute;
       width: 0px;
@@ -24,20 +27,16 @@
   <title>Visual Effects</title>
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
 </head>
+
 <body>
   <amp-story standalone>
 
     <amp-story-page id="ken-burns-effect1">
       <amp-story-grid-layer template="fill">
         <div animate-in="zoom-in" animate-in-duration="30s" class="img-container">
-            <amp-img id="ken-burns-img1"
-              src="https://picsum.photos/1600/1200?image=1077"
-              animate-in="pan-left"
-              animate-in-duration="30s"
-              layout="fixed"
-              width="1600"
-              height="1200">
-            </amp-img>
+          <amp-img id="ken-burns-img1" src="https://picsum.photos/1600/1200?image=1077" animate-in="pan-left" animate-in-duration="30s"
+            layout="fixed" width="1600" height="1200">
+          </amp-img>
         </div>
       </amp-story-grid-layer>
     </amp-story-page>
@@ -45,63 +44,28 @@
     <amp-story-page id="ken-burns-effect2">
       <amp-story-grid-layer template="fill">
         <div animate-in="zoom-in" animate-in-duration="5s" class="img-container">
-          <amp-img id="ken-burns-img2"
-            src="https://picsum.photos/1600/1200?image=1078"
-            animate-in="pan-right"
-            animate-in-duration="5s"
-            layout="fixed"
-            width="1600"
-            height="1200">
+          <amp-img id="ken-burns-img2" src="https://picsum.photos/1600/1200?image=1078" animate-in="pan-right" animate-in-duration="5s"
+            layout="fixed" width="1600" height="1200">
           </amp-img>
         </div>
         <div animate-in="fade-in" animate-in-after="ken-burns-img2" animate-in-duration="1s" class="img-container">
-          <div
-            animate-in="zoom-out"
-            animate-in-duration="5s"
-            class="img-container"
-            animate-in-after="ken-burns-img2">
-            <amp-img id="ken-burns-img3"
-              src="https://picsum.photos/1600/1200?image=1026"
-              layout="fixed"
-              width="1600"
-              height="1200"
-              animate-in="pan-down"
-              animate-in-duration="5s"
-              animate-in-after="ken-burns-img2">
+          <div animate-in="zoom-out" animate-in-duration="5s" class="img-container" animate-in-after="ken-burns-img2">
+            <amp-img id="ken-burns-img3" src="https://picsum.photos/1600/1200?image=1026" layout="fixed" width="1600" height="1200" animate-in="pan-down"
+              animate-in-duration="5s" animate-in-after="ken-burns-img2">
             </amp-img>
           </div>
         </div>
         <div animate-in="fade-in" animate-in-after="ken-burns-img3" animate-in-duration="1s" class="img-container">
-          <div
-            animate-in="zoom-in"
-            animate-in-duration="5s"
-            class="img-container"
-            animate-in-after="ken-burns-img3">
-            <amp-img id="ken-burns-img4"
-              src="https://picsum.photos/1600/1200?image=1029"
-              layout="fixed"
-              width="1600"
-              height="1200"
-              animate-in="pan-right"
-              animate-in-duration="5s"
-              animate-in-after="ken-burns-img3">
+          <div animate-in="zoom-in" animate-in-duration="5s" class="img-container" animate-in-after="ken-burns-img3">
+            <amp-img id="ken-burns-img4" src="https://picsum.photos/1600/1200?image=1029" layout="fixed" width="1600" height="1200" animate-in="pan-right"
+              animate-in-duration="5s" animate-in-after="ken-burns-img3">
             </amp-img>
           </div>
         </div>
         <div animate-in="fade-in" animate-in-after="ken-burns-img4" animate-in-duration="1s" class="img-container">
-          <div
-            animate-in="zoom-out"
-            animate-in-duration="5s"
-            class="img-container"
-            animate-in-after="ken-burns-img4">
-            <amp-img id="ken-burns-img5"
-              src="https://picsum.photos/1600/1200?image=1033"
-              layout="fixed"
-              width="1600"
-              height="1200"
-              animate-in="pan-up"
-              animate-in-duration="5s"
-              animate-in-after="ken-burns-img4">
+          <div animate-in="zoom-out" animate-in-duration="5s" class="img-container" animate-in-after="ken-burns-img4">
+            <amp-img id="ken-burns-img5" src="https://picsum.photos/1600/1200?image=1033" layout="fixed" width="1600" height="1200" animate-in="pan-up"
+              animate-in-duration="5s" animate-in-after="ken-burns-img4">
             </amp-img>
           </div>
         </div>
@@ -111,63 +75,28 @@
     <amp-story-page id="ken-burns-effect3">
       <amp-story-grid-layer template="fill">
         <div animate-in="zoom-in" animate-in-duration="30s" class="img-container">
-          <amp-img
-            src="https://picsum.photos/1600/1200?image=1078"
-            animate-in="pan-right"
-            animate-in-duration="30s"
-            layout="fixed"
-            width="1600"
-            height="1200">
+          <amp-img src="https://picsum.photos/1600/1200?image=1078" animate-in="pan-right" animate-in-duration="30s" layout="fixed"
+            width="1600" height="1200">
           </amp-img>
         </div>
         <div animate-in="fade-in" animate-in-delay="5s" animate-in-duration="1s" class="img-container">
-          <div
-            animate-in="zoom-out"
-            animate-in-duration="30s"
-            class="img-container"
-            animate-in-delay="5s">
-            <amp-img
-              src="https://picsum.photos/1600/1200?image=1026"
-              layout="fixed"
-              width="1600"
-              height="1200"
-              animate-in="pan-up"
-              animate-in-duration="30s"
+          <div animate-in="zoom-out" animate-in-duration="30s" class="img-container" animate-in-delay="5s">
+            <amp-img src="https://picsum.photos/1600/1200?image=1026" layout="fixed" width="1600" height="1200" animate-in="pan-up" animate-in-duration="30s"
               animate-in-delay="5s">
             </amp-img>
           </div>
         </div>
         <div animate-in="fade-in" animate-in-delay="10s" animate-in-duration="1s" class="img-container">
-          <div
-            animate-in="zoom-out"
-            animate-in-duration="30s"
-            class="img-container"
-            animate-in-delay="10s">
-            <amp-img
-              src="https://picsum.photos/1600/1200?image=1029"
-              layout="fixed"
-              width="1600"
-              height="1200"
-              animate-in="pan-right"
-              animate-in-duration="30s"
-              animate-in-delay="10s">
+          <div animate-in="zoom-out" animate-in-duration="30s" class="img-container" animate-in-delay="10s">
+            <amp-img src="https://picsum.photos/1600/1200?image=1029" layout="fixed" width="1600" height="1200" animate-in="pan-right"
+              animate-in-duration="30s" animate-in-delay="10s">
             </amp-img>
           </div>
         </div>
         <div animate-in="fade-in" animate-in-delay="15s" animate-in-duration="1s" class="img-container">
-          <div
-            animate-in="zoom-out"
-            animate-in-duration="30s"
-            class="img-container"
-            animate-in-delay="15s">
-            <amp-img
-              src="https://picsum.photos/1600/1200?image=1033"
-              layout="fixed"
-              width="1600"
-              height="1200"
-              animate-in="pan-left"
-              animate-in-duration="30s"
-              animate-in-delay="15s">
+          <div animate-in="zoom-out" animate-in-duration="30s" class="img-container" animate-in-delay="15s">
+            <amp-img src="https://picsum.photos/1600/1200?image=1033" layout="fixed" width="1600" height="1200" animate-in="pan-left"
+              animate-in-duration="30s" animate-in-delay="15s">
             </amp-img>
           </div>
         </div>
@@ -176,4 +105,5 @@
 
   </amp-story>
 </body>
+
 </html>

--- a/extensions/amp-animation/0.1/web-animation-types.js
+++ b/extensions/amp-animation/0.1/web-animation-types.js
@@ -184,6 +184,7 @@ export const WebAnimationTimingFill = {
 const WHITELISTED_RPOPS = {
   'opacity': true,
   'transform': true,
+  'transform-origin': true,
   'visibility': true,
   'offset-distance': true,
   'offsetDistance': true,

--- a/extensions/amp-story/0.1/amp-story-grid-layer.js
+++ b/extensions/amp-story/0.1/amp-story-grid-layer.js
@@ -45,6 +45,25 @@ const SUPPORTED_CSS_GRID_ATTRIBUTES = {
 };
 
 /**
+ * A list of animation panning names.
+ * @private @const {!Array<string>}
+ */
+const PANNING_ANIMATIONS = [
+  'pan-up',
+  'pan-down',
+  'pan-right',
+  'pan-left'
+];
+
+/**
+ * A mapping of animation names to CSS class names.
+ * @private @const {!Object<string, string>}
+ */
+const ANIMATION_CLASS_NAMES = {
+  'pan': 'i-amphtml-story-grid-template-pan-animation',
+};
+
+/**
  * Converts the keys of the SUPPORTED_CSS_GRID_ATTRIBUTES object above into a
  * selector for the specified attributes.
  * (e.g. [align-content], [align-items], ...)
@@ -89,6 +108,7 @@ export class AmpStoryGridLayer extends AmpStoryBaseLayer {
     this.applyTemplateClassName_();
     this.setOwnCssGridStyles_();
     this.setDescendentCssGridStyles_();
+    this.setAnimationSpecificCssStyles_();
   }
 
 
@@ -128,6 +148,35 @@ export class AmpStoryGridLayer extends AmpStoryBaseLayer {
     });
   }
 
+  /**
+   * To prevent the grid layer "fill" template CSS class to interfere with the 
+   * pan animation calculations by changing the first element's dimensions, we 
+   * remove the grid layer "fill" CSS class, and replace it with a custom pan
+   * CSS class.
+   * @private
+   */
+  setAnimationSpecificCssStyles_() {
+    const firstChild = this.element.firstElementChild;
+
+    const fillClass = TEMPLATE_CLASS_NAMES['fill'];
+    if (this.element.classList.contains(fillClass) &&
+        firstChild && 
+        this.containsPanAnimation_(firstChild)) {
+        this.element.classList.remove(fillClass);
+        this.element.classList.add(ANIMATION_CLASS_NAMES['pan']);
+    }
+  }
+
+  /**
+   * Checks if the first child of the grid layer contains a pan animation.
+   * @param {!Element} element First child of the grid layer.
+   * @return {boolean}
+   * @private
+   */
+  containsPanAnimation_(element) {
+    return PANNING_ANIMATIONS.includes(element.attributes['animate-in'] && 
+      element.attributes['animate-in'].value);
+  }
 
   /**
    * Copies the whitelisted CSS grid styles for the <amp-story-grid-layer>

--- a/extensions/amp-story/0.1/amp-story-grid-layer.js
+++ b/extensions/amp-story/0.1/amp-story-grid-layer.js
@@ -45,25 +45,6 @@ const SUPPORTED_CSS_GRID_ATTRIBUTES = {
 };
 
 /**
- * A list of animation panning names.
- * @private @const {!Array<string>}
- */
-const PANNING_ANIMATIONS = [
-  'pan-up',
-  'pan-down',
-  'pan-right',
-  'pan-left'
-];
-
-/**
- * A mapping of animation names to CSS class names.
- * @private @const {!Object<string, string>}
- */
-const ANIMATION_CLASS_NAMES = {
-  'pan': 'i-amphtml-story-grid-template-pan-animation',
-};
-
-/**
  * Converts the keys of the SUPPORTED_CSS_GRID_ATTRIBUTES object above into a
  * selector for the specified attributes.
  * (e.g. [align-content], [align-items], ...)
@@ -82,9 +63,9 @@ const TEMPLATE_ATTRIBUTE_NAME = 'template';
 
 /**
  * A mapping of template attribute values to CSS class names.
- * @private @const {!Object<string, string>}
+ * @const {!Object<string, string>}
  */
-const TEMPLATE_CLASS_NAMES = {
+export const GRID_LAYER_TEMPLATE_CLASS_NAMES = {
   'fill': 'i-amphtml-story-grid-template-fill',
   'vertical': 'i-amphtml-story-grid-template-vertical',
   'horizontal': 'i-amphtml-story-grid-template-horizontal',
@@ -108,7 +89,6 @@ export class AmpStoryGridLayer extends AmpStoryBaseLayer {
     this.applyTemplateClassName_();
     this.setOwnCssGridStyles_();
     this.setDescendentCssGridStyles_();
-    this.setAnimationSpecificCssStyles_();
   }
 
 
@@ -128,7 +108,7 @@ export class AmpStoryGridLayer extends AmpStoryBaseLayer {
   applyTemplateClassName_() {
     if (this.element.hasAttribute(TEMPLATE_ATTRIBUTE_NAME)) {
       const templateName = this.element.getAttribute(TEMPLATE_ATTRIBUTE_NAME);
-      const templateClassName = TEMPLATE_CLASS_NAMES[templateName];
+      const templateClassName = GRID_LAYER_TEMPLATE_CLASS_NAMES[templateName];
       this.element.classList.add(templateClassName);
     }
   }
@@ -146,36 +126,6 @@ export class AmpStoryGridLayer extends AmpStoryBaseLayer {
     Array.prototype.forEach.call(elementsToUpgradeStyles, element => {
       this.setCssGridStyles_(element);
     });
-  }
-
-  /**
-   * To prevent the grid layer "fill" template CSS class to interfere with the 
-   * pan animation calculations by changing the first element's dimensions, we 
-   * remove the grid layer "fill" CSS class, and replace it with a custom pan
-   * CSS class.
-   * @private
-   */
-  setAnimationSpecificCssStyles_() {
-    const firstChild = this.element.firstElementChild;
-
-    const fillClass = TEMPLATE_CLASS_NAMES['fill'];
-    if (this.element.classList.contains(fillClass) &&
-        firstChild && 
-        this.containsPanAnimation_(firstChild)) {
-        this.element.classList.remove(fillClass);
-        this.element.classList.add(ANIMATION_CLASS_NAMES['pan']);
-    }
-  }
-
-  /**
-   * Checks if the first child of the grid layer contains a pan animation.
-   * @param {!Element} element First child of the grid layer.
-   * @return {boolean}
-   * @private
-   */
-  containsPanAnimation_(element) {
-    return PANNING_ANIMATIONS.includes(element.attributes['animate-in'] && 
-      element.attributes['animate-in'].value);
   }
 
   /**

--- a/extensions/amp-story/0.1/amp-story.css
+++ b/extensions/amp-story/0.1/amp-story.css
@@ -205,7 +205,7 @@ amp-story-grid-layer * {
   margin: 0 !important;
 }
 
-.i-amphtml-story-grid-template-with-full-screen-animation {
+.i-amphtml-story-grid-template-with-full-bleed-animation {
   position: absolute !important;
   display: block !important;
   padding: 0;

--- a/extensions/amp-story/0.1/amp-story.css
+++ b/extensions/amp-story/0.1/amp-story.css
@@ -205,7 +205,7 @@ amp-story-grid-layer * {
   margin: 0 !important;
 }
 
-.i-amphtml-story-grid-template-with-pan-animation {
+.i-amphtml-story-grid-template-with-full-screen-animation {
   position: absolute !important;
   display: block !important;
   padding: 0;

--- a/extensions/amp-story/0.1/amp-story.css
+++ b/extensions/amp-story/0.1/amp-story.css
@@ -208,7 +208,7 @@ amp-story-grid-layer * {
 .i-amphtml-story-grid-template-with-full-bleed-animation {
   position: absolute !important;
   display: block !important;
-  padding: 0;
+  padding: 0 !important;
 }
 
 .i-amphtml-story-grid-template-fill > :not(:first-child) {

--- a/extensions/amp-story/0.1/amp-story.css
+++ b/extensions/amp-story/0.1/amp-story.css
@@ -205,7 +205,7 @@ amp-story-grid-layer * {
   margin: 0 !important;
 }
 
-.i-amphtml-story-grid-template-pan-animation {
+.i-amphtml-story-grid-template-with-pan-animation {
   position: absolute !important;
   display: block !important;
   padding: 0;

--- a/extensions/amp-story/0.1/amp-story.css
+++ b/extensions/amp-story/0.1/amp-story.css
@@ -205,6 +205,12 @@ amp-story-grid-layer * {
   margin: 0 !important;
 }
 
+.i-amphtml-story-grid-template-pan-animation {
+  position: absolute !important;
+  display: block !important;
+  padding: 0;
+}
+
 .i-amphtml-story-grid-template-fill > :not(:first-child) {
   display: none !important;
 }

--- a/extensions/amp-story/0.1/animation-presets-utils.js
+++ b/extensions/amp-story/0.1/animation-presets-utils.js
@@ -86,6 +86,7 @@ export function whooshIn(startX, startY, endX, endY) {
  * those of the page.
  * @param {StoryAnimationDimsDef} dimensions Dimensions of page and target.
  * @return {boolean}
+ * @visibleForTesting
  */
 export function targetFitsWithinPage(dimensions) {
   return dimensions.targetWidth <= dimensions.pageWidth ||

--- a/extensions/amp-story/0.1/animation-presets-utils.js
+++ b/extensions/amp-story/0.1/animation-presets-utils.js
@@ -27,12 +27,6 @@ import {
 } from '../../../src/style';
 
 /**
- * Factor used to increase size to images that are too small to outgrow the viewport.
- * @const {number}
- */
-const scalingFactor = 1.25;
-
-/**
  * Translates the element on the 2d plane according to the given points.
  * @param {number} startX Starting point in the abscissa.
  * @param {number} startY Starting point in the ordinate.
@@ -99,10 +93,11 @@ export function pageIsLargerThanTarget(dimensions) {
  * @return {number}
  */
 export function calculateTargetScalingFactor(dimensions) {
+  const scalingFactor = 1.25;
   const widthFactor = dimensions.pageWidth > dimensions.targetWidth ?
-      dimensions.pageWidth / dimensions.targetWidth : 1;
+    dimensions.pageWidth / dimensions.targetWidth : 1;
   const heightFactor = dimensions.pageHeight > dimensions.targetHeight ?
-      dimensions.pageHeight / dimensions.targetHeight : 1;
+    dimensions.pageHeight / dimensions.targetHeight : 1;
   return Math.max(widthFactor, heightFactor) * scalingFactor;
 }
 

--- a/extensions/amp-story/0.1/animation-presets-utils.js
+++ b/extensions/amp-story/0.1/animation-presets-utils.js
@@ -115,7 +115,7 @@ export function calculateTargetScalingFactor(dimensions) {
  * @param {number} scalingFactor Scaling factor at which target will be scaled.
  * @return {KeyframesDef}
  */
-export function enlargeKeyFrames(keyframes, scalingFactor) {
+function enlargeKeyFrames(keyframes, scalingFactor) {
   keyframes.forEach(frame => {
     frame['transform'] += ' ' + scale(scalingFactor);
     frame['transform-origin'] = 'left top';

--- a/extensions/amp-story/0.1/animation-presets-utils.js
+++ b/extensions/amp-story/0.1/animation-presets-utils.js
@@ -82,7 +82,8 @@ export function whooshIn(startX, startY, endX, endY) {
 }
 
 /**
- * Checks if the target's dimensions are smaller than or equal to those of the page.
+ * Checks if either of the target's dimensions are smaller than or equal to
+ * those of the page.
  * @param {StoryAnimationDimsDef} dimensions Dimensions of page and target.
  * @return {boolean}
  */
@@ -97,12 +98,15 @@ export function targetFitsWithinPage(dimensions) {
  * @return {number}
  */
 export function calculateTargetScalingFactor(dimensions) {
-  const scalingFactor = 1.25;
-  const widthFactor = dimensions.pageWidth > dimensions.targetWidth ?
-    dimensions.pageWidth / dimensions.targetWidth : 1;
-  const heightFactor = dimensions.pageHeight > dimensions.targetHeight ?
-    dimensions.pageHeight / dimensions.targetHeight : 1;
-  return Math.max(widthFactor, heightFactor) * scalingFactor;
+  if (targetFitsWithinPage(dimensions)) {
+    const scalingFactor = 1.25;
+    const widthFactor = dimensions.pageWidth > dimensions.targetWidth ?
+      dimensions.pageWidth / dimensions.targetWidth : 1;
+    const heightFactor = dimensions.pageHeight > dimensions.targetHeight ?
+      dimensions.pageHeight / dimensions.targetHeight : 1;
+    return Math.max(widthFactor, heightFactor) * scalingFactor;
+  }
+  return 1;
 }
 
 /**
@@ -117,4 +121,21 @@ export function enlargeKeyFrames(keyframes, scalingFactor) {
     frame['transform-origin'] = 'left top';
   });
   return keyframes;
+}
+
+/**
+ * Translates the element and scales it if necessary.
+ * @param {number} startX Starting point in the abscissa.
+ * @param {number} startY Starting point in the ordinate.
+ * @param {number} endX Ending point in the abscissa.
+ * @param {number} endY Ending point in the ordinate.
+ * @param {number} scalingFactor Factor by which target will be scaled.
+ * @return {KeyframesDef} Keyframes that make up the animation.
+ */
+export function scaleAndTranslate(startX, startY, endX, endY, scalingFactor) {
+  if (scalingFactor === 1) {
+    return translate2d(startX, startY, endX, endY);
+  }
+  return enlargeKeyFrames(
+      translate2d(startX, startY, endX, endY), scalingFactor);
 }

--- a/extensions/amp-story/0.1/animation-presets-utils.js
+++ b/extensions/amp-story/0.1/animation-presets-utils.js
@@ -27,6 +27,12 @@ import {
 } from '../../../src/style';
 
 /**
+ * Factor used to increase size to images that are too small to outgrow the viewport.
+ * @const {number}
+ */
+const scalingFactor = 1.25;
+
+/**
  * Translates the element on the 2d plane according to the given points.
  * @param {number} startX Starting point in the abscissa.
  * @param {number} startY Starting point in the ordinate.
@@ -94,10 +100,10 @@ export function pageIsLargerThanTarget(dimensions) {
  */
 export function calculateTargetScalingFactor(dimensions) {
   const widthFactor = dimensions.pageWidth > dimensions.targetWidth ?
-                      dimensions.pageWidth / dimensions.targetWidth : 1;
+      dimensions.pageWidth / dimensions.targetWidth : 1;
   const heightFactor = dimensions.pageHeight > dimensions.targetHeight ?
-                       dimensions.pageHeight / dimensions.targetHeight : 1;
-  return Math.max(widthFactor, heightFactor) + 0.25;
+      dimensions.pageHeight / dimensions.targetHeight : 1;
+  return Math.max(widthFactor, heightFactor) * scalingFactor;
 }
 
 /**
@@ -108,8 +114,8 @@ export function calculateTargetScalingFactor(dimensions) {
  */
 export function enlargeKeyFrames(keyframes, scalingFactor) {
   keyframes.forEach(frame => {
-    frame["transform"] += " " + scale(scalingFactor);
-    frame["transform-origin"] = "left top";
+    frame['transform'] += ' ' + scale(scalingFactor);
+    frame['transform-origin'] = 'left top';
   });
   return keyframes;
 }

--- a/extensions/amp-story/0.1/animation-presets-utils.js
+++ b/extensions/amp-story/0.1/animation-presets-utils.js
@@ -77,3 +77,39 @@ export function whooshIn(startX, startY, endX, endY) {
     },
   ];
 }
+
+/**
+ * Checks if page dimensions are larger than those of the target to be animated.
+ * @param {StoryAnimationDimsDef} dimensions Dimensions of page and target.
+ */
+export function pageIsLargerThanTarget(dimensions) {
+  return dimensions.pageWidth > dimensions.targetWidth ||
+         dimensions.pageHeight > dimensions.targetHeight;
+}
+
+/**
+ * Calculate target scaling factor so that it is at least 25% larger than the page.
+ * @param {StoryAnimationDimsDef} dimensions Dimensions of page and target.
+ * @return {number}
+ */
+export function calculateTargetScalingFactor(dimensions) {
+  const widthFactor = dimensions.pageWidth > dimensions.targetWidth ?
+                      dimensions.pageWidth / dimensions.targetWidth : 1;
+  const heightFactor = dimensions.pageHeight > dimensions.targetHeight ?
+                       dimensions.pageHeight / dimensions.targetHeight : 1;
+  return Math.max(widthFactor, heightFactor) + 0.25;
+}
+
+/**
+ * Scale the image in every frame by a certain factor.
+ * @param {KeyframesDef} keyframes Keyframes that will be used for the animation.
+ * @param {number} scalingFactor Scaling factor at which target will be scaled.
+ * @return {KeyframesDef}
+ */
+export function enlargeKeyFrames(keyframes, scalingFactor) {
+  keyframes.forEach(frame => {
+    frame["transform"] += " " + scale(scalingFactor);
+    frame["transform-origin"] = "left top";
+  });
+  return keyframes;
+}

--- a/extensions/amp-story/0.1/animation-presets-utils.js
+++ b/extensions/amp-story/0.1/animation-presets-utils.js
@@ -82,12 +82,13 @@ export function whooshIn(startX, startY, endX, endY) {
 }
 
 /**
- * Checks if page dimensions are larger than those of the target to be animated.
+ * Checks if the target's dimensions are smaller than or equal to those of the page.
  * @param {StoryAnimationDimsDef} dimensions Dimensions of page and target.
+ * @return {boolean}
  */
-export function pageIsLargerThanTarget(dimensions) {
-  return dimensions.pageWidth >= dimensions.targetWidth ||
-         dimensions.pageHeight >= dimensions.targetHeight;
+export function targetFitsWithinPage(dimensions) {
+  return dimensions.targetWidth <= dimensions.pageWidth ||
+         dimensions.targetHeight <= dimensions.pageHeight;
 }
 
 /**

--- a/extensions/amp-story/0.1/animation-presets-utils.js
+++ b/extensions/amp-story/0.1/animation-presets-utils.js
@@ -83,8 +83,8 @@ export function whooshIn(startX, startY, endX, endY) {
  * @param {StoryAnimationDimsDef} dimensions Dimensions of page and target.
  */
 export function pageIsLargerThanTarget(dimensions) {
-  return dimensions.pageWidth > dimensions.targetWidth ||
-         dimensions.pageHeight > dimensions.targetHeight;
+  return dimensions.pageWidth >= dimensions.targetWidth ||
+         dimensions.pageHeight >= dimensions.targetHeight;
 }
 
 /**

--- a/extensions/amp-story/0.1/animation-presets-utils.js
+++ b/extensions/amp-story/0.1/animation-presets-utils.js
@@ -19,7 +19,10 @@
  * presets.
  */
 
-import {KeyframesDef} from './animation-types';
+import {
+  KeyframesDef,
+  StoryAnimationDimsDef,
+} from './animation-types';
 import {
   rotate,
   scale,

--- a/extensions/amp-story/0.1/animation-presets.js
+++ b/extensions/amp-story/0.1/animation-presets.js
@@ -18,13 +18,14 @@ import {GRID_LAYER_TEMPLATE_CLASS_NAMES} from './amp-story-grid-layer';
 import {StoryAnimationPresetDef} from './animation-types';
 import {
   calculateTargetScalingFactor,
-  enlargeKeyFrames,
   rotateAndTranslate,
-  targetFitsWithinPage,
+  scaleAndTranslate,
   translate2d,
   whooshIn,
 } from './animation-presets-utils';
 import {px} from '../../../src/style';
+
+const FULL_BLEED_CATEGORY = 'full-bleed';
 
 /**
  * A list of animations that are full bleed.
@@ -44,7 +45,8 @@ const FULL_BLEED_ANIMATION_NAMES = [
  * @private @const {!Object<string, string>}
  */
 const ANIMATION_CSS_CLASS_NAMES = {
-  'full-bleed': 'i-amphtml-story-grid-template-with-full-bleed-animation',
+  [FULL_BLEED_CATEGORY]:
+      'i-amphtml-story-grid-template-with-full-bleed-animation',
 };
 
 /**
@@ -53,7 +55,6 @@ const ANIMATION_CSS_CLASS_NAMES = {
  * @param {string} presetName
  */
 export function setStyleForPreset(el, presetName) {
-  const fullBleed = 'full-bleed';
   const fillTemplate = 'fill';
 
   // For full bleed animations.
@@ -63,7 +64,7 @@ export function setStyleForPreset(el, presetName) {
         GRID_LAYER_TEMPLATE_CLASS_NAMES[fillTemplate])) {
       parent.classList.remove(GRID_LAYER_TEMPLATE_CLASS_NAMES[fillTemplate]);
     }
-    parent.classList.add(ANIMATION_CSS_CLASS_NAMES[fullBleed]);
+    parent.classList.add(ANIMATION_CSS_CLASS_NAMES[FULL_BLEED_CATEGORY]);
   }
 }
 
@@ -227,88 +228,56 @@ export const PRESETS = {
     duration: 1000,
     easing: 'linear',
     keyframes(dimensions) {
-      let resized = false;
-      let scalingFactor = 1;
-
-      if (targetFitsWithinPage(dimensions)) {
-        scalingFactor = calculateTargetScalingFactor(dimensions);
-        resized = true;
-        dimensions.targetWidth *= scalingFactor;
-        dimensions.targetHeight *= scalingFactor;
-      }
+      const scalingFactor = calculateTargetScalingFactor(dimensions);
+      dimensions.targetWidth *= scalingFactor;
+      dimensions.targetHeight *= scalingFactor;
 
       const offsetX = dimensions.pageWidth - dimensions.targetWidth;
       const offsetY = (dimensions.pageHeight - dimensions.targetHeight) / 2;
 
-      let frames = translate2d(offsetX, offsetY, 0, offsetY);
-
-      if (resized) { frames = enlargeKeyFrames(frames, scalingFactor); }
-      return frames;
+      return scaleAndTranslate(offsetX, offsetY, 0, offsetY, scalingFactor);
     },
   },
   'pan-right': {
     duration: 1000,
     easing: 'linear',
     keyframes(dimensions) {
-      let resized = false;
-      let scalingFactor = 1;
-
-      if (targetFitsWithinPage(dimensions)) {
-        scalingFactor = calculateTargetScalingFactor(dimensions);
-        resized = true;
-        dimensions.targetWidth *= scalingFactor;
-        dimensions.targetHeight *= scalingFactor;
-      }
+      const scalingFactor = calculateTargetScalingFactor(dimensions);
+      dimensions.targetWidth *= scalingFactor;
+      dimensions.targetHeight *= scalingFactor;
 
       const offsetX = dimensions.pageWidth - dimensions.targetWidth;
       const offsetY = (dimensions.pageHeight - dimensions.targetHeight) / 2;
 
-      let frames = translate2d(0, offsetY, offsetX, offsetY);
-      if (resized) { frames = enlargeKeyFrames(frames, scalingFactor); }
-      return frames;
+      return scaleAndTranslate(0, offsetY, offsetX, offsetY, scalingFactor);
     },
   },
   'pan-down': {
     duration: 1000,
     easing: 'linear',
     keyframes(dimensions) {
-      let resized = false;
-      let scalingFactor = 1;
+      const scalingFactor = calculateTargetScalingFactor(dimensions);
+      dimensions.targetWidth *= scalingFactor;
+      dimensions.targetHeight *= scalingFactor;
 
-      if (targetFitsWithinPage(dimensions)) {
-        scalingFactor = calculateTargetScalingFactor(dimensions);
-        resized = true;
-        dimensions.targetWidth *= scalingFactor;
-        dimensions.targetHeight *= scalingFactor;
-      }
       const offsetX = -dimensions.targetWidth / 2;
       const offsetY = dimensions.pageHeight - dimensions.targetHeight;
 
-      let frames = translate2d(offsetX, 0, offsetX, offsetY);
-      if (resized) { frames = enlargeKeyFrames(frames, scalingFactor); }
-      return frames;
+      return scaleAndTranslate(offsetX, 0, offsetX, offsetY, scalingFactor);
     },
   },
   'pan-up': {
     duration: 1000,
     easing: 'linear',
     keyframes(dimensions) {
-      let resized = false;
-      let scalingFactor = 1;
-
-      if (targetFitsWithinPage(dimensions)) {
-        scalingFactor = calculateTargetScalingFactor(dimensions);
-        resized = true;
-        dimensions.targetWidth *= scalingFactor;
-        dimensions.targetHeight *= scalingFactor;
-      }
+      const scalingFactor = calculateTargetScalingFactor(dimensions);
+      dimensions.targetWidth *= scalingFactor;
+      dimensions.targetHeight *= scalingFactor;
 
       const offsetX = -dimensions.targetWidth / 2;
       const offsetY = dimensions.pageHeight - dimensions.targetHeight;
 
-      let frames = translate2d(offsetX, offsetY, offsetX, 0);
-      if (resized) { frames = enlargeKeyFrames(frames, scalingFactor); }
-      return frames;
+      return scaleAndTranslate(offsetX, offsetY, offsetX, 0, scalingFactor);
     },
   },
   'zoom-in': {

--- a/extensions/amp-story/0.1/animation-presets.js
+++ b/extensions/amp-story/0.1/animation-presets.js
@@ -18,8 +18,8 @@ import {StoryAnimationPresetDef} from './animation-types';
 import {
   calculateTargetScalingFactor,
   enlargeKeyFrames,
-  pageIsLargerThanTarget,
   rotateAndTranslate,
+  targetFitsWithinPage,
   translate2d,
   whooshIn,
 } from './animation-presets-utils';
@@ -189,7 +189,7 @@ export const PRESETS = {
       let resized = false;
       let scalingFactor = 1;
 
-      if (pageIsLargerThanTarget(dimensions)) {
+      if (targetFitsWithinPage(dimensions)) {
         scalingFactor = calculateTargetScalingFactor(dimensions);
         resized = true;
         dimensions.targetWidth *= scalingFactor;
@@ -212,7 +212,7 @@ export const PRESETS = {
       let resized = false;
       let scalingFactor = 1;
 
-      if (pageIsLargerThanTarget(dimensions)) {
+      if (targetFitsWithinPage(dimensions)) {
         scalingFactor = calculateTargetScalingFactor(dimensions);
         resized = true;
         dimensions.targetWidth *= scalingFactor;
@@ -234,7 +234,7 @@ export const PRESETS = {
       let resized = false;
       let scalingFactor = 1;
 
-      if (pageIsLargerThanTarget(dimensions)) {
+      if (targetFitsWithinPage(dimensions)) {
         scalingFactor = calculateTargetScalingFactor(dimensions);
         resized = true;
         dimensions.targetWidth *= scalingFactor;
@@ -256,7 +256,7 @@ export const PRESETS = {
       let resized = false;
       let scalingFactor = 1;
 
-      if (pageIsLargerThanTarget(dimensions)) {
+      if (targetFitsWithinPage(dimensions)) {
         scalingFactor = calculateTargetScalingFactor(dimensions);
         resized = true;
         dimensions.targetWidth *= scalingFactor;

--- a/extensions/amp-story/0.1/animation-presets.js
+++ b/extensions/amp-story/0.1/animation-presets.js
@@ -20,6 +20,9 @@ import {
   rotateAndTranslate,
   translate2d,
   whooshIn,
+  pageIsLargerThanTarget,
+  calculateTargetScalingFactor,
+  enlargeKeyFrames
 } from './animation-presets-utils';
 
 
@@ -183,36 +186,89 @@ export const PRESETS = {
     duration: 1000,
     easing: 'linear',
     keyframes(dimensions) {
+      let resized = false;
+      let scalingFactor = 1;
+
+      if(pageIsLargerThanTarget(dimensions)) {
+        scalingFactor = calculateTargetScalingFactor(dimensions);
+        resized = true;
+        dimensions.targetWidth *= scalingFactor;
+        dimensions.targetHeight *= scalingFactor;
+      }
+
       const offsetX = dimensions.pageWidth - dimensions.targetWidth;
       const offsetY = (dimensions.pageHeight - dimensions.targetHeight) / 2;
-      return translate2d(offsetX, offsetY, 0, offsetY);
+
+      let frames = translate2d(offsetX, offsetY, 0, offsetY);
+
+      if (resized) { frames = enlargeKeyFrames(frames, scalingFactor); }
+      return frames;
     },
   },
   'pan-right': {
     duration: 1000,
     easing: 'linear',
     keyframes(dimensions) {
+      let resized = false;
+      let scalingFactor = 1;
+
+      if(pageIsLargerThanTarget(dimensions)) {
+        scalingFactor = calculateTargetScalingFactor(dimensions);
+        resized = true;
+        dimensions.targetWidth *= scalingFactor;
+        dimensions.targetHeight *= scalingFactor;
+      }
+
       const offsetX = dimensions.pageWidth - dimensions.targetWidth;
       const offsetY = (dimensions.pageHeight - dimensions.targetHeight) / 2;
-      return translate2d(0, offsetY, offsetX, offsetY);
+
+      let frames = translate2d(0, offsetY, offsetX, offsetY);
+      if (resized) { frames = enlargeKeyFrames(frames, scalingFactor); }
+      return frames;
     },
   },
   'pan-down': {
     duration: 1000,
     easing: 'linear',
     keyframes(dimensions) {
+      let resized = false;
+      let scalingFactor = 1;
+
+      if(pageIsLargerThanTarget(dimensions)) {
+        scalingFactor = calculateTargetScalingFactor(dimensions);
+        resized = true;
+        dimensions.targetWidth *= scalingFactor;
+        dimensions.targetHeight *= scalingFactor;
+      }
+
       const offsetX = -dimensions.targetWidth / 2;
       const offsetY = dimensions.pageHeight - dimensions.targetHeight;
-      return translate2d(offsetX, 0, offsetX, offsetY);
+
+      let frames = translate2d(offsetX, 0, offsetX, offsetY);
+      if (resized) { frames = enlargeKeyFrames(frames, scalingFactor); }
+      return frames;
     },
   },
   'pan-up': {
     duration: 1000,
     easing: 'linear',
     keyframes(dimensions) {
+      let resized = false;
+      let scalingFactor = 1;
+
+      if(pageIsLargerThanTarget(dimensions)) {
+        scalingFactor = calculateTargetScalingFactor(dimensions);
+        resized = true;
+        dimensions.targetWidth *= scalingFactor;
+        dimensions.targetHeight *= scalingFactor;
+      }
+
       const offsetX = -dimensions.targetWidth / 2;
       const offsetY = dimensions.pageHeight - dimensions.targetHeight;
-      return translate2d(offsetX, offsetY, offsetX, 0);
+
+      let frames = translate2d(offsetX, offsetY, offsetX, 0);
+      if (resized) { frames = enlargeKeyFrames(frames, scalingFactor); }
+      return frames;
     },
   },
   'zoom-in': {

--- a/extensions/amp-story/0.1/animation-presets.js
+++ b/extensions/amp-story/0.1/animation-presets.js
@@ -40,7 +40,7 @@ const FULL_BLEED_ANIMATION_NAMES = [
 ];
 
 /**
- * A mapping of animation names to CSS class names.
+ * A mapping of animation categories to corresponding CSS class names.
  * @private @const {!Object<string, string>}
  */
 const ANIMATION_CSS_CLASS_NAMES = {

--- a/extensions/amp-story/0.1/animation-presets.js
+++ b/extensions/amp-story/0.1/animation-presets.js
@@ -17,12 +17,12 @@
 import {StoryAnimationPresetDef} from './animation-types';
 import {px} from '../../../src/style';
 import {
+  calculateTargetScalingFactor,
+  enlargeKeyFrames,
+  pageIsLargerThanTarget,
   rotateAndTranslate,
   translate2d,
   whooshIn,
-  pageIsLargerThanTarget,
-  calculateTargetScalingFactor,
-  enlargeKeyFrames
 } from './animation-presets-utils';
 
 
@@ -189,7 +189,7 @@ export const PRESETS = {
       let resized = false;
       let scalingFactor = 1;
 
-      if(pageIsLargerThanTarget(dimensions)) {
+      if (pageIsLargerThanTarget(dimensions)) {
         scalingFactor = calculateTargetScalingFactor(dimensions);
         resized = true;
         dimensions.targetWidth *= scalingFactor;
@@ -212,7 +212,7 @@ export const PRESETS = {
       let resized = false;
       let scalingFactor = 1;
 
-      if(pageIsLargerThanTarget(dimensions)) {
+      if (pageIsLargerThanTarget(dimensions)) {
         scalingFactor = calculateTargetScalingFactor(dimensions);
         resized = true;
         dimensions.targetWidth *= scalingFactor;
@@ -234,7 +234,7 @@ export const PRESETS = {
       let resized = false;
       let scalingFactor = 1;
 
-      if(pageIsLargerThanTarget(dimensions)) {
+      if (pageIsLargerThanTarget(dimensions)) {
         scalingFactor = calculateTargetScalingFactor(dimensions);
         resized = true;
         dimensions.targetWidth *= scalingFactor;
@@ -256,7 +256,7 @@ export const PRESETS = {
       let resized = false;
       let scalingFactor = 1;
 
-      if(pageIsLargerThanTarget(dimensions)) {
+      if (pageIsLargerThanTarget(dimensions)) {
         scalingFactor = calculateTargetScalingFactor(dimensions);
         resized = true;
         dimensions.targetWidth *= scalingFactor;

--- a/extensions/amp-story/0.1/animation-presets.js
+++ b/extensions/amp-story/0.1/animation-presets.js
@@ -27,10 +27,10 @@ import {
 import {px} from '../../../src/style';
 
 /**
- * A list of animations that take the whole screen.
+ * A list of animations that are full bleed.
  * @private @const {!Array<string>}
  */
-const FULL_SCREEN_ANIMATION_NAMES = [
+const FULL_BLEED_ANIMATION_NAMES = [
   'pan-up',
   'pan-down',
   'pan-right',
@@ -44,7 +44,7 @@ const FULL_SCREEN_ANIMATION_NAMES = [
  * @private @const {!Object<string, string>}
  */
 const ANIMATION_CSS_CLASS_NAMES = {
-  'full-screen': 'i-amphtml-story-grid-template-with-full-screen-animation',
+  'full-bleed': 'i-amphtml-story-grid-template-with-full-bleed-animation',
 };
 
 /**
@@ -53,17 +53,17 @@ const ANIMATION_CSS_CLASS_NAMES = {
  * @param {string} presetName
  */
 export function setStyleForPreset(el, presetName) {
-  const fullScreen = 'full-screen';
+  const fullBleed = 'full-bleed';
   const fillTemplate = 'fill';
 
-  // For full screen animations.
-  if (FULL_SCREEN_ANIMATION_NAMES.indexOf(presetName) >= 0) {
+  // For full bleed animations.
+  if (FULL_BLEED_ANIMATION_NAMES.indexOf(presetName) >= 0) {
     const parent = el.parentElement;
     if (parent.classList.contains(
         GRID_LAYER_TEMPLATE_CLASS_NAMES[fillTemplate])) {
       parent.classList.remove(GRID_LAYER_TEMPLATE_CLASS_NAMES[fillTemplate]);
     }
-    parent.classList.add(ANIMATION_CSS_CLASS_NAMES[fullScreen]);
+    parent.classList.add(ANIMATION_CSS_CLASS_NAMES[fullBleed]);
   }
 }
 

--- a/extensions/amp-story/0.1/animation-presets.js
+++ b/extensions/amp-story/0.1/animation-presets.js
@@ -55,7 +55,7 @@ export function setStyleForPreset(el, presetName) {
   const fillTemplate = 'fill';
 
   // For panning and zooming animations.
-  if (PANNING_ANIMATION_NAMES.includes(presetName)) {
+  if (PANNING_ANIMATION_NAMES.indexOf(presetName) >= 0) {
     const parent = el.parentElement;
     if (parent.classList.contains(
         GRID_LAYER_TEMPLATE_CLASS_NAMES[fillTemplate])) {

--- a/extensions/amp-story/0.1/animation-presets.js
+++ b/extensions/amp-story/0.1/animation-presets.js
@@ -15,7 +15,6 @@
  */
 
 import {StoryAnimationPresetDef} from './animation-types';
-import {px} from '../../../src/style';
 import {
   calculateTargetScalingFactor,
   enlargeKeyFrames,
@@ -24,6 +23,7 @@ import {
   translate2d,
   whooshIn,
 } from './animation-presets-utils';
+import {px} from '../../../src/style';
 
 
 /** @const {!Object<string, !StoryAnimationPresetDef>} */

--- a/extensions/amp-story/0.1/animation-presets.js
+++ b/extensions/amp-story/0.1/animation-presets.js
@@ -27,14 +27,16 @@ import {
 import {px} from '../../../src/style';
 
 /**
- * A list of panning animation names.
+ * A list of animations that take the whole screen.
  * @private @const {!Array<string>}
  */
-const PANNING_ANIMATION_NAMES = [
+const FULL_SCREEN_ANIMATION_NAMES = [
   'pan-up',
   'pan-down',
   'pan-right',
   'pan-left',
+  'zoom-in',
+  'zoom-out',
 ];
 
 /**
@@ -42,7 +44,7 @@ const PANNING_ANIMATION_NAMES = [
  * @private @const {!Object<string, string>}
  */
 const ANIMATION_CSS_CLASS_NAMES = {
-  'pan': 'i-amphtml-story-grid-template-with-pan-animation',
+  'full-screen': 'i-amphtml-story-grid-template-with-full-screen-animation',
 };
 
 /**
@@ -51,17 +53,17 @@ const ANIMATION_CSS_CLASS_NAMES = {
  * @param {string} presetName
  */
 export function setStyleForPreset(el, presetName) {
-  const pan = 'pan';
+  const fullScreen = 'full-screen';
   const fillTemplate = 'fill';
 
-  // For panning and zooming animations.
-  if (PANNING_ANIMATION_NAMES.indexOf(presetName) >= 0) {
+  // For full screen animations.
+  if (FULL_SCREEN_ANIMATION_NAMES.indexOf(presetName) >= 0) {
     const parent = el.parentElement;
     if (parent.classList.contains(
         GRID_LAYER_TEMPLATE_CLASS_NAMES[fillTemplate])) {
       parent.classList.remove(GRID_LAYER_TEMPLATE_CLASS_NAMES[fillTemplate]);
     }
-    parent.classList.add(ANIMATION_CSS_CLASS_NAMES[pan]);
+    parent.classList.add(ANIMATION_CSS_CLASS_NAMES[fullScreen]);
   }
 }
 

--- a/extensions/amp-story/0.1/animation-presets.js
+++ b/extensions/amp-story/0.1/animation-presets.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {GRID_LAYER_TEMPLATE_CLASS_NAMES} from './amp-story-grid-layer';
 import {StoryAnimationPresetDef} from './animation-types';
 import {
   calculateTargetScalingFactor,
@@ -25,6 +26,44 @@ import {
 } from './animation-presets-utils';
 import {px} from '../../../src/style';
 
+/**
+ * A list of panning animation names.
+ * @private @const {!Array<string>}
+ */
+const PANNING_ANIMATION_NAMES = [
+  'pan-up',
+  'pan-down',
+  'pan-right',
+  'pan-left',
+];
+
+/**
+ * A mapping of animation names to CSS class names.
+ * @private @const {!Object<string, string>}
+ */
+const ANIMATION_CSS_CLASS_NAMES = {
+  'pan': 'i-amphtml-story-grid-template-with-pan-animation',
+};
+
+/**
+ * Perform style-specific operations for presets.
+ * @param {!Element} el
+ * @param {string} presetName
+ */
+export function setStyleForPreset(el, presetName) {
+  const pan = 'pan';
+  const fillTemplate = 'fill';
+
+  // For panning and zooming animations.
+  if (PANNING_ANIMATION_NAMES.includes(presetName)) {
+    const parent = el.parentElement;
+    if (parent.classList.contains(
+        GRID_LAYER_TEMPLATE_CLASS_NAMES[fillTemplate])) {
+      parent.classList.remove(GRID_LAYER_TEMPLATE_CLASS_NAMES[fillTemplate]);
+    }
+    parent.classList.add(ANIMATION_CSS_CLASS_NAMES[pan]);
+  }
+}
 
 /** @const {!Object<string, !StoryAnimationPresetDef>} */
 // First keyframe will always be considered offset: 0 and will be applied to the
@@ -240,7 +279,6 @@ export const PRESETS = {
         dimensions.targetWidth *= scalingFactor;
         dimensions.targetHeight *= scalingFactor;
       }
-
       const offsetX = -dimensions.targetWidth / 2;
       const offsetY = dimensions.pageHeight - dimensions.targetHeight;
 

--- a/extensions/amp-story/0.1/animation-presets.js
+++ b/extensions/amp-story/0.1/animation-presets.js
@@ -26,6 +26,7 @@ import {
 import {px} from '../../../src/style';
 
 const FULL_BLEED_CATEGORY = 'full-bleed';
+const FILL_TEMPLATE_LAYOUT = 'fill';
 
 /**
  * A list of animations that are full bleed.
@@ -55,14 +56,13 @@ const ANIMATION_CSS_CLASS_NAMES = {
  * @param {string} presetName
  */
 export function setStyleForPreset(el, presetName) {
-  const fillTemplate = 'fill';
-
   // For full bleed animations.
   if (FULL_BLEED_ANIMATION_NAMES.indexOf(presetName) >= 0) {
     const parent = el.parentElement;
     if (parent.classList.contains(
-        GRID_LAYER_TEMPLATE_CLASS_NAMES[fillTemplate])) {
-      parent.classList.remove(GRID_LAYER_TEMPLATE_CLASS_NAMES[fillTemplate]);
+        GRID_LAYER_TEMPLATE_CLASS_NAMES[FILL_TEMPLATE_LAYOUT])) {
+      parent.classList
+          .remove(GRID_LAYER_TEMPLATE_CLASS_NAMES[FILL_TEMPLATE_LAYOUT]);
     }
     parent.classList.add(ANIMATION_CSS_CLASS_NAMES[FULL_BLEED_CATEGORY]);
   }

--- a/extensions/amp-story/0.1/animation.js
+++ b/extensions/amp-story/0.1/animation.js
@@ -21,7 +21,7 @@ import {
   StoryAnimationDimsDef,
   StoryAnimationPresetDef,
 } from './animation-types';
-import {PRESETS} from './animation-presets';
+import {PRESETS, setStyleForPreset} from './animation-presets';
 import {Services} from '../../../src/services';
 import {
   WebAnimationPlayState,
@@ -33,7 +33,7 @@ import {setStyles} from '../../../src/style';
 import {timeStrToMillis, unscaledClientRect} from './utils';
 
 /** const {string} */
-const ANIMATE_IN_ATTRIBUTE_NAME = 'animate-in';
+export const ANIMATE_IN_ATTRIBUTE_NAME = 'animate-in';
 /** const {string} */
 const ANIMATE_IN_DURATION_ATTRIBUTE_NAME = 'animate-in-duration';
 /** const {string} */
@@ -527,6 +527,7 @@ export class AnimationManager {
    */
   getPreset_(el) {
     const name = el.getAttribute(ANIMATE_IN_ATTRIBUTE_NAME);
+    setStyleForPreset(el, name);
 
     return user().assert(
         PRESETS[name],

--- a/extensions/amp-story/0.1/test/test-full-bleed-animations.js
+++ b/extensions/amp-story/0.1/test/test-full-bleed-animations.js
@@ -69,8 +69,8 @@ describes.realWin('amp-story-full-bleed-animations', {
     container.appendChild(gridLayer);
   }
 
-  it('should add corresponding css class when a full bleed animation target is'
-  + ' attached as a child of a grid layer with fill template', () => {
+  it('Should add corresponding CSS class when a full bleed animation target is'
+  + ' attached as a child of a grid layer with fill template.', () => {
     createPages(ampStory.element, 2, ['cover', 'page-1']);
     return ampStory.layoutCallback()
         .then(() => {
@@ -93,8 +93,9 @@ describes.realWin('amp-story-full-bleed-animations', {
         });
   });
 
-  it('should not add additional css class to full-bleed animation target ' +
-     'attached as a child of a grid layer with a template OTHER than fill',
+  it('Should not add additional CSS class to the target when a full-bleed ' +
+     'animation is used BUT the target is a child of a grid layer with a ' +
+     'template other than `fill`.',
   () => {
     createPages(ampStory.element, 2, ['cover', 'page-1']);
     return ampStory.layoutCallback()
@@ -118,8 +119,8 @@ describes.realWin('amp-story-full-bleed-animations', {
         });
   });
 
-  it('should not add additional css class to non-full-bleed animation target ' +
-     'attached as a child of a grid layer with fill template', () => {
+  it('Should not add additional CSS class to the target when a non-full-bleed' +
+     'animation is used.', () => {
     createPages(ampStory.element, 2, ['cover', 'page-1']);
     return ampStory.layoutCallback()
         .then(() => {
@@ -159,19 +160,22 @@ describes.realWin('amp-story-animations-utils', {
     });
   }
 
-  it('should tell if target fits within page', () => {
-    let dimensions = setDimensions(380 , 580, 360, 580);
+  it('Should fit target same size as the screen.', () => {
+    const dimensions = setDimensions(380 , 580, 360, 580);
     expect(targetFitsWithinPage(dimensions)).to.be.true;
+  });
 
-    dimensions = setDimensions(380, 580, 400, 580);
+  it('Should fit target with bigger width but same height as screen.', () => {
+    const dimensions = setDimensions(380, 580, 400, 580);
     expect(targetFitsWithinPage(dimensions)).to.be.true;
+  });
 
-    dimensions = setDimensions(380, 580, 400, 600);
+  it('Should not fit target with larger width and height than screen.', () => {
+    const dimensions = setDimensions(380, 580, 400, 600);
     expect(targetFitsWithinPage(dimensions)).to.be.false;
   });
 
-
-  it('scale target accordingly', () => {
+  it('Should scale the target accordingly.', () => {
     const dimensions = setDimensions(380, 580, 360, 580);
     expect(targetFitsWithinPage(dimensions)).to.be.true;
 
@@ -185,14 +189,15 @@ describes.realWin('amp-story-animations-utils', {
     const offsetX = -dimensions.targetWidth / 2;
     const offsetY = dimensions.pageHeight - dimensions.targetHeight;
 
-    const expectedKeyframes = [{
-      'transform': `translate(${offsetX}px, ${offsetY}px) scale(${factor})`,
-      'transform-origin': 'left top',
-    },
-    {
-      'transform': `translate(${offsetX}px, 0px) scale(${factor})`,
-      'transform-origin': 'left top',
-    },
+    const expectedKeyframes = [
+      {
+        'transform': `translate(${offsetX}px, ${offsetY}px) scale(${factor})`,
+        'transform-origin': 'left top',
+      },
+      {
+        'transform': `translate(${offsetX}px, 0px) scale(${factor})`,
+        'transform-origin': 'left top',
+      },
     ];
 
     expect(calculatedKeyframes.keyframes).to.deep.equal(expectedKeyframes);

--- a/extensions/amp-story/0.1/test/test-full-bleed-animations.js
+++ b/extensions/amp-story/0.1/test/test-full-bleed-animations.js
@@ -1,8 +1,3 @@
-import {AmpStory} from '../amp-story';
-import {AmpStoryPage} from '../amp-story-page';
-import {PRESETS} from '../animation-presets';
-import {calculateTargetScalingFactor, targetFitsWithinPage} from '../animation-presets-utils';
-
 /**
  * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
  *
@@ -22,6 +17,11 @@ import {calculateTargetScalingFactor, targetFitsWithinPage} from '../animation-p
 /**
  * @fileoverview Tests full-bleed animations like panning and zooming.
  */
+
+import {AmpStory} from '../amp-story';
+import {AmpStoryPage} from '../amp-story-page';
+import {PRESETS} from '../animation-presets';
+import {calculateTargetScalingFactor, targetFitsWithinPage} from '../animation-presets-utils';
 
 describes.realWin('amp-story-full-bleed-animations', {
   amp: {

--- a/extensions/amp-story/0.1/test/test-full-bleed-animations.js
+++ b/extensions/amp-story/0.1/test/test-full-bleed-animations.js
@@ -1,0 +1,80 @@
+import {AmpStory} from '../amp-story';
+import {AmpStoryGridLayer} from '../amp-story-grid-layer';
+import {AmpStoryPage} from '../amp-story-page';
+
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Tests full-bleed animations like panning and zooming.
+ */
+
+describes.realWin('amp-story-full-bleed-animations', {
+  amp: {
+    runtimeOn: true,
+    extensions: ['amp-story'],
+  },
+}, env => {
+  let win;
+
+  beforeEach(() => {
+    win = env.win;
+  });
+
+  function createPages(container, count, opt_ids) {
+    return Array(count).fill(undefined).map((unused, i) => {
+      const page = win.document.createElement('amp-story-page');
+      page.id = opt_ids && opt_ids[i] ? opt_ids[i] : `-page-${i}`;
+
+      const img = win.document.createElement('amp-img');
+      const gridLayer = win.document.createElement('amp-story-grid-layer');
+      img.setAttribute('animate-in', 'pan-down');
+      gridLayer.setAttribute('template', 'fill');
+      gridLayer.appendChild(img);
+      page.appendChild(gridLayer);
+
+
+      page.getImpl = () => Promise.resolve(new AmpStoryPage(page));
+      container.appendChild(page);
+      return page;
+    });
+  }
+
+  it('should add corresponding css class after the grid layer is built', () => {
+    const storyElem = win.document.createElement('amp-story');
+    win.document.body.appendChild(storyElem);
+    AmpStory.isBrowserSupported = () => true;
+    const story = new AmpStory(storyElem);
+
+    createPages(story.element, 2, ['cover', 'page-1']);
+    return story.layoutCallback()
+        .then(() => {
+          // Get pages.
+          const pageElements =
+              story.element.getElementsByTagName('amp-story-page');
+          const pages = Array.from(pageElements).map(el => el.getImpl());
+
+          return Promise.all(pages);
+        })
+        .then(pages => {
+          pages[0].layoutCallback().then(() => {
+            const imgEls = pages[0].element.getElementsByTagName('amp-img');
+            expect(imgEls[0]).to.have.class(
+                'i-amphtml-story-grid-template-with-full-bleed-animation');
+          });
+        });
+  });
+});

--- a/extensions/amp-story/0.1/test/test-full-bleed-animations.js
+++ b/extensions/amp-story/0.1/test/test-full-bleed-animations.js
@@ -1,7 +1,7 @@
 import {AmpStory} from '../amp-story';
 import {AmpStoryPage} from '../amp-story-page';
-import { targetFitsWithinPage, calculateTargetScalingFactor } from '../animation-presets-utils';
-import { PRESETS } from '../animation-presets';
+import {PRESETS} from '../animation-presets';
+import {calculateTargetScalingFactor, targetFitsWithinPage} from '../animation-presets-utils';
 
 /**
  * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
@@ -69,8 +69,8 @@ describes.realWin('amp-story-full-bleed-animations', {
     container.appendChild(gridLayer);
   }
 
-  it('should add corresponding css class when a full bleed animation target is \
-attached as a child of a grid layer with fill template', () => {
+  it('should add corresponding css class when a full bleed animation target is'
+  + ' attached as a child of a grid layer with fill template', () => {
     createPages(ampStory.element, 2, ['cover', 'page-1']);
     return ampStory.layoutCallback()
         .then(() => {
@@ -93,15 +93,15 @@ attached as a child of a grid layer with fill template', () => {
         });
   });
 
-  it('should not add additional css class to full-bleed animation target \
-attached as a child of a grid layer with a template OTHER than fill',
+  it('should not add additional css class to full-bleed animation target ' +
+     'attached as a child of a grid layer with a template OTHER than fill',
   () => {
     createPages(ampStory.element, 2, ['cover', 'page-1']);
     return ampStory.layoutCallback()
         .then(() => {
           // Get pages.
           const pageElements =
-            ampStory.element.getElementsByTagName('amp-story-page');
+                ampStory.element.getElementsByTagName('amp-story-page');
           const pages = Array.from(pageElements).map(el => el.getImpl());
           return Promise.all(pages);
         })
@@ -118,8 +118,8 @@ attached as a child of a grid layer with a template OTHER than fill',
         });
   });
 
-  it('should not add additional css class to non-full-bleed animation target \
-attached as a child of a grid layer with fill template', () => {
+  it('should not add additional css class to non-full-bleed animation target ' +
+     'attached as a child of a grid layer with fill template', () => {
     createPages(ampStory.element, 2, ['cover', 'page-1']);
     return ampStory.layoutCallback()
         .then(() => {


### PR DESCRIPTION
"Pan" animations will not look as intended with screen sizes bigger than the image.

This PR addresses this issue by checking if the images are smaller than the screen size and scaling it accordingly.

It also checks if the image is a direct child of a grid layer using a "fill" template, and overwrites the styles so that the calculations of the animation won't be affected.