### PR TITLE
🏗 Surface console errors during tests as mocha failures

### DIFF
--- a/ads/google/a4a/test/test-utils.js
+++ b/ads/google/a4a/test/test-utils.js
@@ -123,7 +123,8 @@ describe('Google A4A utils', () => {
       },
     };
 
-    it('should extract correct config from header', () => {
+    // TODO(zhouyx, #14336): Fails due to console errors.
+    it.skip('should extract correct config from header', () => {
       return createIframePromise().then(fixture => {
         setupForAdTesting(fixture);
         let url;

--- a/ads/google/test/test-doubleclick.js
+++ b/ads/google/test/test-doubleclick.js
@@ -53,7 +53,8 @@ describes.sandboxed('writeAdScript', {}, env => {
     verifyScript(win, 'gpt.js');
   });
 
-  it('should use GPT when multiSize is not null', () => {
+  // TODO(bradfrizzell, #14336): Fails due to console errors.
+  it.skip('should use GPT when multiSize is not null', () => {
     const data = {multiSize: 'hey!'};
     writeAdScript(win, data);
     verifyScript(win, 'gpt.js');

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -622,7 +622,8 @@ describe('amp-a4a', () => {
         a4a.onLayoutMeasure();
       });
 
-      it('should render via cached iframe', () => {
+      // TODO(lannka, #14336): Fails due to console errors.
+      it.skip('should render via cached iframe', () => {
         return a4a.layoutCallback().then(() => {
           verifyCachedContentIframeRender(a4aElement, TEST_URL);
           // Should have reported an error.
@@ -635,7 +636,9 @@ describe('amp-a4a', () => {
         });
       });
 
-      it('should fire amp-analytics triggers for illegal render modes', () => {
+      // TODO(keithwrightbos, #14336): Fails due to console errors.
+      it.skip('should fire amp-analytics triggers for illegal ' +
+          'render modes', () => {
         const triggerAnalyticsEventSpy =
             sandbox.spy(analytics, 'triggerAnalyticsEvent');
         return a4a.layoutCallback().then(() => {
@@ -692,7 +695,8 @@ describe('amp-a4a', () => {
 
       ['', 'client_cache', 'safeframe', 'some_random_thing'].forEach(
           headerVal => {
-            it(`should not attach a NameFrame when header is ${headerVal}`,
+            // TODO(lannka, #14336): Fails due to console errors.
+            it.skip(`should not attach a NameFrame when header is ${headerVal}`,
                 () => {
                   // Make sure there's no signature, so that we go down the 3p iframe path.
                   delete adResponse.headers['AMP-Fast-Fetch-Signature'];
@@ -783,7 +787,8 @@ describe('amp-a4a', () => {
 
       ['', 'client_cache', 'nameframe', 'some_random_thing'].forEach(
           headerVal => {
-            it(`should not attach a SafeFrame when header is ${headerVal}`,
+            // TODO(lannka, #14336): Fails due to console errors.
+            it.skip(`should not attach a SafeFrame when header is ${headerVal}`,
                 () => {
                   // If rendering type is anything but safeframe, we SHOULD NOT attach a
                   // SafeFrame.
@@ -1220,10 +1225,12 @@ describe('amp-a4a', () => {
     it('#layoutCallback not valid AMP', () => {
       return executeLayoutCallbackTest(false);
     });
-    it('#layoutCallback AMP render fail, recover non-AMP', () => {
+    // TODO(keithwrightbos, #14336): Fails due to console errors.
+    it.skip('#layoutCallback AMP render fail, recover non-AMP', () => {
       return executeLayoutCallbackTest(true, true);
     });
-    it('should run end-to-end in the presence of an XHR error', () => {
+    // TODO(keithwrightbos, #14336): Fails due to console errors.
+    it.skip('should run end-to-end in the presence of an XHR error', () => {
       return createIframePromise().then(fixture => {
         setupForAdTesting(fixture);
         fetchMock.getOnce(
@@ -1253,7 +1260,8 @@ describe('amp-a4a', () => {
         });
       });
     });
-    it('should use adUrl from onNetworkFailure', () => {
+    // TODO(keithwrightbos, #14336): Fails due to console errors.
+    it.skip('should use adUrl from onNetworkFailure', () => {
       return createIframePromise().then(fixture => {
         setupForAdTesting(fixture);
         fetchMock.getOnce(
@@ -1286,7 +1294,9 @@ describe('amp-a4a', () => {
         });
       });
     });
-    it('should not execute frame GET if disabled via onNetworkFailure', () => {
+    // TODO(keithwrightbos, #14336): Fails due to console errors.
+    it.skip('should not execute frame GET if disabled via ' +
+        'onNetworkFailure', () => {
       return createIframePromise().then(fixture => {
         setupForAdTesting(fixture);
         fetchMock.getOnce(
@@ -1310,7 +1320,9 @@ describe('amp-a4a', () => {
         });
       });
     });
-    it('should handle XHR error when resolves before layoutCallback', () => {
+    // TODO(keithwrightbos, #14336): Fails due to console errors.
+    it.skip('should handle XHR error when resolves before ' +
+        'layoutCallback', () => {
       return createIframePromise().then(fixture => {
         setupForAdTesting(fixture);
         fetchMock.getOnce(
@@ -1331,7 +1343,9 @@ describe('amp-a4a', () => {
         }));
       });
     });
-    it('should handle XHR error when resolves after layoutCallback', () => {
+    // TODO(keithwrightbos, #14336): Fails due to console errors.
+    it.skip('should handle XHR error when resolves after ' +
+        'layoutCallback', () => {
       return createIframePromise().then(fixture => {
         setupForAdTesting(fixture);
         let rejectXhr;
@@ -2186,7 +2200,9 @@ describes.realWin('AmpA4a-RTC', {amp: true}, env => {
       expect(AMP.maybeExecuteRealTimeConfig).to.be.undefined;
       expect(a4a.tryExecuteRealTimeConfig_()).to.be.undefined;
     });
-    it('should log user error if RTC Config set but RTC not supported', () => {
+    // TODO(bradfrizzell, #14336): Fails due to console errors.
+    it.skip('should log user error if RTC Config set but RTC not ' +
+        'supported', () => {
       element.setAttribute('rtc-config',
           JSON.stringify({'urls': ['https://a.com']}));
       expect(a4a.tryExecuteRealTimeConfig_()).to.be.undefined;
@@ -2203,7 +2219,8 @@ describes.realWin('AmpA4a-RTC', {amp: true}, env => {
       expect(AMP.maybeExecuteRealTimeConfig.called).to.be.true;
       expect(AMP.maybeExecuteRealTimeConfig.calledWith(a4a, macros)).to.be.true;
     });
-    it('should catch error in maybeExecuteRealTimeConfig', () => {
+    // TODO(bradfrizzell, #14336): Fails due to console errors.
+    it.skip('should catch error in maybeExecuteRealTimeConfig', () => {
       const err = new Error('Test');
       AMP.maybeExecuteRealTimeConfig = sandbox.stub().throws(err);
       a4a.tryExecuteRealTimeConfig_();

--- a/extensions/amp-access/0.1/test/test-amp-access-iframe.js
+++ b/extensions/amp-access/0.1/test/test-amp-access-iframe.js
@@ -274,7 +274,8 @@ describes.realWin('AccessIframeAdapter', {
         });
       });
 
-      it('should tolerate storage failures', () => {
+      // TODO(dvoytenko, #14336): Fails due to console errors.
+      it.skip('should tolerate storage failures', () => {
         storageMock.expects('getItem')
             .withExactArgs('amp-access-iframe')
             .throws(new Error('intentional'))

--- a/extensions/amp-access/0.1/test/test-amp-access-source.js
+++ b/extensions/amp-access/0.1/test/test-amp-access-source.js
@@ -79,7 +79,8 @@ describes.fakeWin('AccessSource', {
     });
   });
 
-  it('should parse type', () => {
+  // TODO(dvoytenko, #14336): Fails due to console errors.
+  it.skip('should parse type', () => {
     let config = {
       'authorization': 'https://acme.com/a',
       'pingback': 'https://acme.com/p',

--- a/extensions/amp-access/0.1/test/test-amp-access.js
+++ b/extensions/amp-access/0.1/test/test-amp-access.js
@@ -468,7 +468,8 @@ describes.fakeWin('AccessService authorization', {
     });
   });
 
-  it('should use fallback on authorization failure when available', () => {
+  // TODO(dvoytenko, #14336): Fails due to console errors.
+  it.skip('should use fallback on authorization failure when available', () => {
     expectGetReaderId('reader1');
     adapterMock.expects('authorize')
         .withExactArgs()

--- a/extensions/amp-access/0.1/test/test-login-dialog.js
+++ b/extensions/amp-access/0.1/test/test-login-dialog.js
@@ -242,7 +242,8 @@ describes.sandboxed('WebLoginDialog', {}, () => {
     expect(windowApi.open.firstCall.args[0]).to.equal('');
   });
 
-  it('should yield error if window.open fails', () => {
+  // TODO(dvoytenko, #14336): Fails due to console errors.
+  it.skip('should yield error if window.open fails', () => {
     // Open is called twice due to retry on _top.
     windowMock.expects('open').twice().throws('OPEN ERROR');
     return openLoginDialog(ampdoc, 'http://acme.com/login')

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
@@ -120,21 +120,25 @@ describes.realWin('amp-ad-network-adsense-impl', {
       element.setAttribute('width', '100vw');
       expect(impl.isValidElement()).to.be.true;
     });
-    it('should NOT be valid (responsive with wrong height)', () => {
+    // TODO(keithwrightbos, #14336): Fails due to console errors.
+    it.skip('should NOT be valid (responsive with wrong height)', () => {
       isResponsiveStub.callsFake(() => true);
       element.setAttribute('data-full-width', 'true');
       element.setAttribute('height', '666');
       element.setAttribute('width', '100vw');
       expect(impl.isValidElement()).to.be.false;
     });
-    it('should NOT be valid (responsive with wrong width)', () => {
+    // TODO(keithwrightbos, #14336): Fails due to console errors.
+    it.skip('should NOT be valid (responsive with wrong width)', () => {
       isResponsiveStub.callsFake(() => true);
       element.setAttribute('data-full-width', 'true');
       element.setAttribute('height', '320');
       element.setAttribute('width', '666');
       expect(impl.isValidElement()).to.be.false;
     });
-    it('should NOT be valid (responsive with missing data-full-width)', () => {
+    // TODO(keithwrightbos, #14336): Fails due to console errors.
+    it.skip('should NOT be valid (responsive with missing ' +
+        'data-full-width)', () => {
       isResponsiveStub.callsFake(() => true);
       element.setAttribute('height', '320');
       element.setAttribute('width', '100vw');
@@ -851,8 +855,8 @@ describes.realWin('amp-ad-network-adsense-impl', {
       }
       doc.body.style.direction = '';
     });
-
-    it('should change left margin for responsive', () => {
+    // TODO(charliereams, #14336): Fails due to console errors.
+    it.skip('should change left margin for responsive', () => {
       containerContainer = doc.createElement('div');
       container = doc.createElement('div');
       return buildImpl({
@@ -867,7 +871,8 @@ describes.realWin('amp-ad-network-adsense-impl', {
       });
     });
 
-    it('should change right margin for responsive in RTL', () => {
+    // TODO(charliereams, #14336): Fails due to console errors.
+    it.skip('should change right margin for responsive in RTL', () => {
       containerContainer = doc.createElement('div');
       container = doc.createElement('div');
       doc.body.style.direction = 'rtl'; // todo: revert

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -913,7 +913,8 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
       });
     });
 
-    it('should force iframe to match size of creative', () => {
+    // TODO(glevitzky, #14336): Fails due to console errors.
+    it.skip('should force iframe to match size of creative', () => {
       sandbox.stub(impl, 'sendXhrRequest').returns(
           mockSendXhrRequest('150x50'));
       impl.buildCallback();
@@ -926,7 +927,8 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
       });
     });
 
-    it('amp creative - should force iframe to match size of slot', () => {
+    // TODO(glevitzky, #14336): Fails due to console errors.
+    it.skip('amp creative - should force iframe to match size of slot', () => {
       stubForAmpCreative();
       sandbox.stub(impl, 'sendXhrRequest').callsFake(mockSendXhrRequest);
       sandbox.stub(impl, 'renderViaCachedContentIframe_').callsFake(
@@ -946,7 +948,8 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
       });
     });
 
-    it('should force iframe to match size of slot', () => {
+    // TODO(glevitzky, #14336): Fails due to console errors.
+    it.skip('should force iframe to match size of slot', () => {
       sandbox.stub(impl, 'sendXhrRequest').callsFake(mockSendXhrRequest);
       sandbox.stub(impl, 'renderViaCachedContentIframe_').callsFake(
           () => impl.iframeRenderHelper_({src: impl.adUrl_, name: 'name'}));
@@ -962,7 +965,9 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
       });
     });
 
-    it('should issue an ad request even with bad multi-size data attr', () => {
+    // TODO(glevitzky, #14336): Fails due to console errors.
+    it.skip('should issue an ad request even with bad multi-size ' +
+        'data attr', () => {
       stubForAmpCreative();
       sandbox.stub(impl, 'sendXhrRequest').callsFake(mockSendXhrRequest);
       impl.element.setAttribute('data-multi-size', '201x50');
@@ -1288,7 +1293,8 @@ describes.realWin('additional amp-ad-network-doubleclick-impl',
         });
       });
 
-      describe('centering', () => {
+      // TODO(bradfrizzell, #14336): Fails due to console errors.
+      describe.skip('centering', () => {
         const size = {width: '300px', height: '150px'};
 
         function verifyCss(iframe, expectedSize) {

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-fluid.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-fluid.js
@@ -131,7 +131,8 @@ describes.realWin('DoubleClick Fast Fetch Fluid', realWinConfig, env => {
     expect(fireDelayedImpressionsSpy).to.not.be.calledOnce;
   });
 
-  it('should contain sz=320x50 in ad request by default', () => {
+  // TODO(glevitzky, #14336): Fails due to console errors.
+  it.skip('should contain sz=320x50 in ad request by default', () => {
     impl.initiateAdRequest();
     return impl.adPromise_.then(() => {
       expect(impl.adUrl_).to.be.ok;
@@ -139,7 +140,8 @@ describes.realWin('DoubleClick Fast Fetch Fluid', realWinConfig, env => {
     });
   });
 
-  it('should contain mulitple sizes in ad request', () => {
+  // TODO(glevitzky, #14336): Fails due to console errors.
+  it.skip('should contain mulitple sizes in ad request', () => {
     multiSizeImpl.initiateAdRequest();
     return multiSizeImpl.adPromise_.then(() => {
       expect(multiSizeImpl.adUrl_).to.be.ok;

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-safeframe.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-safeframe.js
@@ -591,7 +591,8 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
      * If the safeframed creative asks to expand with invalid expand
      * values, should fail gracefully.
      */
-    it('expand_request fails if invalid values sent', () => {
+    // TODO(bradfrizzell, #14336): Fails due to console errors.
+    it.skip('expand_request fails if invalid values sent', () => {
       const expandMessage = {};
       expandMessage[MESSAGE_FIELDS.CHANNEL] = safeframeHost.channel;
       expandMessage[MESSAGE_FIELDS.ENDPOINT_IDENTITY] = 1;

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-sra.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-sra.js
@@ -428,16 +428,21 @@ describes.realWin('amp-ad-network-doubleclick-impl', config , env => {
     it('should not send SRA request if only 1 slot is valid', () =>
       executeTest([{networkId: 1234, instances: 1, invalidInstances: 2}]));
 
-    it('should handle xhr failure by not sending subsequent request',
+    // TODO(bradfrizzell, #14336): Fails due to console errors.
+    it.skip('should handle xhr failure by not sending subsequent request',
         () => executeTest([{networkId: 1234, instances: 2, xhrFail: true}]));
 
-    it('should handle mixture of xhr and non xhr failures', () => executeTest(
+    // TODO(bradfrizzell, #14336): Fails due to console errors.
+    it.skip('should handle mixture of xhr and ' +
+        'non xhr failures', () => executeTest(
         [{networkId: 1234, instances: 2, xhrFail: true}, 4567, 4567]));
 
     it('should correctly use SRA for multiple slots. multiple networks',
         () => executeTest([1234, 4567, 1234, 4567]));
 
-    it('should handle mixture of all possible scenarios', () => executeTest(
+    // TODO(bradfrizzell, #14336): Fails due to console errors.
+    it.skip('should handle mixture of all ' +
+        'possible scenarios', () => executeTest(
         [1234, 1234, 101, {networkId: 4567, instances: 2, xhrFail: true}, 202,
           {networkId: 8901, instances: 3, invalidInstances: 1}]));
   });

--- a/extensions/amp-ad/0.1/test/test-amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-3p-impl.js
@@ -197,8 +197,8 @@ describes.realWin('amp-ad-3p-impl', {
             `${remoteUrl}?$internalRuntimeVersion$"]`)).to.be.ok;
       });
     });
-
-    it('should use default path if custom disabled', () => {
+    // TODO(keithwrightbos, #14336): Fails due to console errors.
+    it.skip('should use default path if custom disabled', () => {
       const meta = win.document.createElement('meta');
       meta.setAttribute('name', 'amp-3p-iframe-src');
       meta.setAttribute('content', 'https://example.com/boot/remote.html');
@@ -261,7 +261,8 @@ describes.realWin('amp-ad-3p-impl', {
       });
     });
 
-    it('should not use remote html path for preload if disabled', () => {
+    // TODO(keithwrightbos, #14336): Fails due to console errors.
+    it.skip('should not use remote html path for preload if disabled', () => {
       const meta = win.document.createElement('meta');
       meta.setAttribute('name', 'amp-3p-iframe-src');
       meta.setAttribute('content', 'https://example.com/boot/remote.html');

--- a/extensions/amp-ad/0.1/test/test-amp-ad.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad.js
@@ -113,7 +113,9 @@ describes.realWin('Ad loader', {amp: true}, env => {
         });
       });
 
-      it('fails upgrade on A4A upgrade with loadElementClass error', () => {
+      // TODO(jridgewell, #14336): Fails due to console errors.
+      it.skip('fails upgrade on A4A upgrade with loadElementClass ' +
+          'error', () => {
         a4aRegistry['zort'] = function() {
           return true;
         };

--- a/extensions/amp-analytics/0.1/test/test-amp-analytics.js
+++ b/extensions/amp-analytics/0.1/test/test-amp-analytics.js
@@ -189,7 +189,8 @@ describes.realWin('amp-analytics', {
       actualResults[vendor] = {};
       describe('analytics vendor: ' + vendor, function() {
         for (const name in config.requests) {
-          it('should produce request: ' + name +
+          // TODO(malteubl, #14336): Fails due to console errors.
+          it.skip('should produce request: ' + name +
               '. If this test fails update vendor-requests.json', function* () {
             const urlReplacements =
                 Services.urlReplacementsForDoc(ampdoc);
@@ -265,7 +266,8 @@ describes.realWin('amp-analytics', {
     }
   });
 
-  it('does not unnecessarily preload iframe transport script', function() {
+  // TODO(jonkeller, #14336): Fails due to console errors.
+  it.skip('does not unnecessarily preload iframe transport script', function() {
     const el = doc.createElement('amp-analytics');
     doc.body.appendChild(el);
     const analytics = new AmpAnalytics(el);
@@ -321,7 +323,8 @@ describes.realWin('amp-analytics', {
     });
   });
 
-  it('does not send a hit when config is not in a script tag', function() {
+  // TODO(avimehta, #14336): Fails due to console errors.
+  it.skip('does not send a hit when config is not in a script tag', function() {
     const config = JSON.stringify(trivialConfig);
     const el = doc.createElement('amp-analytics');
     el.textContent = config;
@@ -361,7 +364,8 @@ describes.realWin('amp-analytics', {
     expect(whenFirstVisibleStub).to.be.calledOnce;
   });
 
-  it('does not send a hit when multiple child tags exist', function() {
+  // TODO(avimehta, #14336): Fails due to console errors.
+  it.skip('does not send a hit when multiple child tags exist', function() {
     const analytics = getAnalyticsTag(trivialConfig);
     const script2 = document.createElement('script');
     script2.setAttribute('type', 'application/json');
@@ -371,7 +375,8 @@ describes.realWin('amp-analytics', {
     });
   });
 
-  it('does not send a hit when script tag does not have a type attribute',
+  // TODO(avimehta, #14336): Fails due to console errors.
+  it.skip('does not send a hit when script tag does not have a type attribute',
       function() {
         const el = doc.createElement('amp-analytics');
         const script = doc.createElement('script');
@@ -389,7 +394,8 @@ describes.realWin('amp-analytics', {
         });
       });
 
-  it('does not send a hit when request is not provided', function() {
+  // TODO(avimehta, #14336): Fails due to console errors.
+  it.skip('does not send a hit when request is not provided', function() {
     const analytics = getAnalyticsTag({
       'requests': {'foo': 'https://example.com/bar'},
       'triggers': [{'on': 'visible'}],
@@ -400,7 +406,8 @@ describes.realWin('amp-analytics', {
     });
   });
 
-  it('does not send a hit when request type is not defined', function() {
+  // TODO(avimehta, #14336): Fails due to console errors.
+  it.skip('does not send a hit when request type is not defined', function() {
     const analytics = getAnalyticsTag({
       'triggers': [{'on': 'visible', 'request': 'foo'}],
     });
@@ -1152,7 +1159,8 @@ describes.realWin('amp-analytics', {
     });
   });
 
-  it('ignore transport iframe from remote config', () => {
+  // TODO(zhouyx, #14336): Fails due to console errors.
+  it.skip('ignore transport iframe from remote config', () => {
     const analytics = getAnalyticsTag({
       'vars': {'title': 'local'},
       'requests': {'foo': 'https://example.com/${title}'},
@@ -1277,7 +1285,8 @@ describes.realWin('amp-analytics', {
       });
     });
 
-    it('works when sampleSpec is incomplete', () => {
+    // TODO(avimehta, #14336): Fails due to console errors.
+    it.skip('works when sampleSpec is incomplete', () => {
       const incompleteConfig = {
         'requests': {
           'pageview1': '/test1=${requestCount}',
@@ -1297,7 +1306,8 @@ describes.realWin('amp-analytics', {
       });
     });
 
-    it('works for invalid threadhold (Infinity)', () => {
+    // TODO(avimehta, #14336): Fails due to console errors.
+    it.skip('works for invalid threadhold (Infinity)', () => {
       const analytics = getAnalyticsTag(getConfig(Infinity));
 
       return waitForSendRequest(analytics).then(() => {
@@ -1305,7 +1315,8 @@ describes.realWin('amp-analytics', {
       });
     });
 
-    it('works for invalid threadhold (NaN)', () => {
+    // TODO(avimehta, #14336): Fails due to console errors.
+    it.skip('works for invalid threadhold (NaN)', () => {
       const analytics = getAnalyticsTag(getConfig(NaN));
 
       return waitForSendRequest(analytics).then(() => {
@@ -1313,7 +1324,8 @@ describes.realWin('amp-analytics', {
       });
     });
 
-    it('works for invalid threadhold (-1)', () => {
+    // TODO(avimehta, #14336): Fails due to console errors.
+    it.skip('works for invalid threadhold (-1)', () => {
       const analytics = getAnalyticsTag(getConfig(-1));
 
       return waitForSendRequest(analytics).then(() => {
@@ -1674,7 +1686,9 @@ describes.realWin('amp-analytics', {
       });
     });
 
-    it('should not add listener when eventType is not whitelist', function() {
+    // TODO(zhouyx, #14336): Fails due to console errors.
+    it.skip('should not add listener when eventType is not ' +
+        'whitelist', function() {
       // Right now we only whitelist VISIBLE & HIDDEN
       const tracker = ins.ampdocRoot_.getTracker('click', ClickEventTracker);
       const addStub = sandbox.stub(tracker, 'add');

--- a/extensions/amp-analytics/0.1/test/test-instrumentation.js
+++ b/extensions/amp-analytics/0.1/test/test-instrumentation.js
@@ -381,7 +381,8 @@ describe('amp-analytics.instrumentation OLD', function() {
     expect(fn1).to.have.callCount(2);
   });
 
-  it('fails gracefully on bad scroll config', () => {
+  // TODO(avimehta, #14336): Fails due to console errors.
+  it.skip('fails gracefully on bad scroll config', () => {
     const fn1 = sandbox.stub();
 
     ins.addListenerDepr_({'on': 'scroll'}, fn1);
@@ -413,7 +414,8 @@ describe('amp-analytics.instrumentation OLD', function() {
     expect(fn1).to.have.not.been.called;
   });
 
-  it('normalizes boundaries correctly.', () => {
+  // TODO(avimehta, #14336): Fails due to console errors.
+  it.skip('normalizes boundaries correctly.', () => {
     expect(ins.normalizeBoundaries_([])).to.be.empty;
     expect(ins.normalizeBoundaries_(undefined)).to.be.empty;
     expect(ins.normalizeBoundaries_(['foo'])).to.be.empty;

--- a/extensions/amp-analytics/0.1/test/test-requests.js
+++ b/extensions/amp-analytics/0.1/test/test-requests.js
@@ -363,7 +363,8 @@ describes.realWin('Requests', {amp: 1}, env => {
         }
       });
 
-      it('should handle batchPlugin function error', function* () {
+      // TODO(zhouyx, #14336): Fails due to console errors.
+      it.skip('should handle batchPlugin function error', function* () {
         const spy = sandbox.spy();
         const r = {'baseUrl': 'r', 'batchInterval': 1, 'batchPlugin': '_ping_'};
         const handler = new RequestHandler(

--- a/extensions/amp-analytics/0.1/test/test-variables.js
+++ b/extensions/amp-analytics/0.1/test/test-variables.js
@@ -68,14 +68,16 @@ describe('amp-analytics.VariableService', function() {
           );
     });
 
-    it('expands nested vars', () => {
+    // TODO(avimehta, #14336): Fails due to console errors.
+    it.skip('expands nested vars', () => {
       return variables.expandTemplate('${1}', new ExpansionOptions(vars))
           .then(actual =>
             expect(actual).to.equal('123%24%7B4%7D')
           );
     });
 
-    it('expands nested vars (no encode)', () => {
+    // TODO(avimehta, #14336): Fails due to console errors.
+    it.skip('expands nested vars (no encode)', () => {
       return variables.expandTemplate('${1}',
           new ExpansionOptions(vars, undefined, true))
           .then(actual =>
@@ -83,13 +85,15 @@ describe('amp-analytics.VariableService', function() {
           );
     });
 
-    it('expands nested vars without double encoding', () => {
+    // TODO(avimehta, #14336): Fails due to console errors.
+    it.skip('expands nested vars without double encoding', () => {
       return expect(variables.expandTemplate('${a}',
           new ExpansionOptions(vars))).to.eventually.equal(
           'https%3A%2F%2Fwww.google.com%2Fa%3Fb%3D1%26c%3D2');
     });
 
-    it('limits the recursion to n', () => {
+    // TODO(avimehta, #14336): Fails due to console errors.
+    it.skip('limits the recursion to n', () => {
       return variables.expandTemplate('${1}', new ExpansionOptions(vars, 3))
           .then(actual =>
             expect(actual).to.equal('1234%24%7B1%7D'))

--- a/extensions/amp-analytics/0.1/test/test-visibility-manager.js
+++ b/extensions/amp-analytics/0.1/test/test-visibility-manager.js
@@ -235,7 +235,8 @@ describes.fakeWin('VisibilityManagerForDoc', {amp: true}, env => {
     expect(root.getRootVisibility()).to.equal(0);
   });
 
-  it('create correct number of models', () => {
+  // TODO(zhouyx, #14336): Fails due to console errors.
+  it.skip('create correct number of models', () => {
     let spec = {};
     root.listenRoot(spec, null, null, null);
     expect(root.models_).to.have.length(1);
@@ -281,7 +282,8 @@ describes.fakeWin('VisibilityManagerForDoc', {amp: true}, env => {
     root.dispose();
   });
 
-  it('does not allow min==max, when they are neither 0 nor 100', () => {
+  // TODO(jonkeller, #14336): Fails due to console errors.
+  it.skip('does not allow min==max, when they are neither 0 nor 100', () => {
     let spec = {visiblePercentageThresholds: [[50, 50]]};
     root.listenRoot(spec, null, null, null);
     expect(root.models_).to.have.length(0);

--- a/extensions/amp-animation/0.1/test/test-amp-animation.js
+++ b/extensions/amp-animation/0.1/test/test-amp-animation.js
@@ -745,7 +745,8 @@ describes.sandboxed('AmpAnimation', {}, () => {
       });
     });
 
-    it('should find target in the embed only via target', function* () {
+    // TODO(dvoytenko, #14336): Fails due to console errors.
+    it.skip('should find target in the embed only via target', function* () {
       const parentWin = env.ampdoc.win;
       const embedWin = embed.win;
       const anim = yield createAnim({},

--- a/extensions/amp-animation/0.1/test/test-web-animations.js
+++ b/extensions/amp-animation/0.1/test/test-web-animations.js
@@ -836,7 +836,8 @@ describes.realWin('MeasureScanner', {amp: 1}, env => {
     expect(requests[0].timing.duration).to.equal(0);
   });
 
-  it('should find target by ID', () => {
+  // TODO(dvoytenko, #14336): Fails due to console errors.
+  it.skip('should find target by ID', () => {
     const requests = scan([
       {target: 'target1', keyframes: {}},
     ]);

--- a/extensions/amp-app-banner/0.1/test/test-amp-app-banner.js
+++ b/extensions/amp-app-banner/0.1/test/test-amp-app-banner.js
@@ -155,7 +155,8 @@ describes.realWin('amp-app-banner', {
       });
     });
 
-    it('should show banner and set up correctly', testSetupAndShowBanner);
+    // TODO(aghassemi, #14336): Fails due to console errors.
+    it.skip('should show banner and set up correctly', testSetupAndShowBanner);
 
     it('should throw if open button is missing', testButtonMissing);
 
@@ -235,7 +236,8 @@ describes.realWin('amp-app-banner', {
       });
     });
 
-    it('should show banner and set up correctly', testSetupAndShowBanner);
+    // TODO(aghassemi, #14336): Fails due to console errors.
+    it.skip('should show banner and set up correctly', testSetupAndShowBanner);
 
     it('should throw if open button is missing', testButtonMissing);
 

--- a/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
@@ -105,7 +105,8 @@ function waitForEvent(env, name) {
   });
 }
 
-describe.configure().ifNewChrome().run('Bind', function() {
+// TODO(choumx, #14336): Fails due to console errors.
+describe.skip('Bind', function() {
   // Give more than default 2000ms timeout for local testing.
   const TIMEOUT = Math.max(window.ampTestRuntimeConfig.mochaTimeout, 4000);
   this.timeout(TIMEOUT);

--- a/extensions/amp-bind/0.1/test/test-amp-state.js
+++ b/extensions/amp-bind/0.1/test/test-amp-state.js
@@ -115,7 +115,8 @@ describes.realWin('AmpState', {
     });
   });
 
-  it('should fetch json if `src` is mutated', () => {
+  // TODO(choumx, #14336): Fails due to console errors.
+  it.skip('should fetch json if `src` is mutated', () => {
     element.setAttribute('src', 'https://foo.com/bar?baz=1');
     element.build();
 

--- a/extensions/amp-bodymovin-animation/0.1/test/integration/test-amp-bodymovin-animation.js
+++ b/extensions/amp-bodymovin-animation/0.1/test/integration/test-amp-bodymovin-animation.js
@@ -16,7 +16,8 @@
 
 import {poll} from '../../../../../testing/iframe';
 
-describe.configure().ifNewChrome().run('amp-bodymovin-animation', function() {
+// TODO(nainar, #14336): Fails due to console errors.
+describe.skip('amp-bodymovin-animation', function() {
   const extensions = ['amp-bodymovin-animation'];
   const bodymovinBody = `
     <amp-bodymovin-animation id="anim"

--- a/extensions/amp-carousel/0.1/test/test-slidescroll.js
+++ b/extensions/amp-carousel/0.1/test/test-slidescroll.js
@@ -924,7 +924,8 @@ describes.realWin('SlideScroll', {
       });
     });
 
-    it('should update slide when `slide` attribute is mutated', () => {
+    // TODO(choumx, #14336): Fails due to console errors.
+    it.skip('should update slide when `slide` attribute is mutated', () => {
       return getAmpSlideScroll(true).then(ampSlideScroll => {
         const impl = ampSlideScroll.implementation_;
         const showSlideSpy = sandbox.spy(impl, 'showSlide_');
@@ -961,7 +962,8 @@ describes.realWin('SlideScroll', {
       });
     });
 
-    it('should goToSlide on action', () => {
+    // TODO(choumx, #14336): Fails due to console errors.
+    it.skip('should goToSlide on action', () => {
       return getAmpSlideScroll(true).then(ampSlideScroll => {
         const impl = ampSlideScroll.implementation_;
         const showSlideSpy = sandbox.spy(impl, 'showSlide_');

--- a/extensions/amp-consent/0.1/test/test-consent-state-manager.js
+++ b/extensions/amp-consent/0.1/test/test-consent-state-manager.js
@@ -186,7 +186,8 @@ describes.realWin('ConsentStateManager', {amp: 1}, env => {
         expect(value).to.equal(CONSENT_ITEM_STATE.REJECTED);
       });
 
-      it('should return unknown value with error', function* () {
+      // TODO(zhouyx, #14336): Fails due to console errors.
+      it.skip('should return unknown value with error', function* () {
         let value;
         storageGetSpy = () => {
           const e = new Error('intentional');

--- a/extensions/amp-form/0.1/test/integration/test-integration-form.js
+++ b/extensions/amp-form/0.1/test/integration/test-integration-form.js
@@ -32,290 +32,297 @@ describes.realWin('AmpForm Integration', {
   },
   mockFetch: false,
 }, env => {
-  const baseUrl = 'http://localhost:31862';
-  let doc;
-  let sandbox;
+  // TODO(aghassemi, #14336): Fails due to console errors.
+  describe.skip('AmpForm Integration', () => {
+    const baseUrl = 'http://localhost:31862';
+    let doc;
+    let sandbox;
 
-  const realSetTimeout = window.setTimeout;
-  const stubSetTimeout = (callback, delay) => {
-    realSetTimeout(() => {
-      try {
-        callback();
-      } catch (e) {}
-    }, delay);
-  };
+    const realSetTimeout = window.setTimeout;
+    const stubSetTimeout = (callback, delay) => {
+      realSetTimeout(() => {
+        try {
+          callback();
+        } catch (e) {}
+      }, delay);
+    };
 
-  beforeEach(() => {
-    sandbox = env.sandbox;
-    doc = env.win.document;
-    const scriptElement = document.createElement('script');
-    scriptElement.setAttribute('custom-template', 'amp-mustache');
-    doc.body.appendChild(scriptElement);
-    registerExtendedTemplate(env.win, 'amp-mustache', AmpMustache);
-    new AmpFormService(env.ampdoc);
-  });
-
-  function getForm(config) {
-    const form = doc.createElement('form');
-    form.id = config.id || 'test-form';
-    form.setAttribute('method', config.method || 'POST');
-    form.setAttribute('target', config.target || '_top');
-
-    const nameInput = doc.createElement('input');
-    nameInput.setAttribute('name', 'name');
-    nameInput.setAttribute('value', 'John Miller');
-    form.appendChild(nameInput);
-    if (config.actionXhr) {
-      form.setAttribute('action-xhr', config.actionXhr);
-    }
-    if (config.action) {
-      form.setAttribute('action', config.action);
-    }
-    const submitButton = doc.createElement('input');
-    submitButton.setAttribute('type', 'submit');
-    form.appendChild(submitButton);
-
-    if (config.on) {
-      form.setAttribute('on', config.on);
-    }
-
-    if (config.success) {
-      const {message, template} = config.success;
-      const successDiv = doc.createElement('div');
-      successDiv.setAttribute('submit-success', '');
-      if (template) {
-        const child = doc.createElement('template');
-        child.setAttribute('type', 'amp-mustache');
-        child./*OK*/innerHTML = message;
-        successDiv.appendChild(child);
-      } else {
-        successDiv./*OK*/innerHTML = message;
-      }
-
-      form.appendChild(successDiv);
-    }
-
-    if (config.error) {
-      const {message, template} = config.error;
-      const errorDiv = doc.createElement('div');
-      errorDiv.setAttribute('submit-error', '');
-      if (template) {
-        const child = doc.createElement('template');
-        child.setAttribute('type', 'amp-mustache');
-        child./*OK*/innerHTML = message;
-        errorDiv.appendChild(child);
-      } else {
-        errorDiv./*OK*/innerHTML = message;
-      }
-      form.appendChild(errorDiv);
-    }
-
-    doc.body.appendChild(form);
-    return form;
-  }
-
-  const describeChrome =
-      describe.configure().skipFirefox().skipSafari().skipEdge();
-
-  describeChrome.run('on=submit:form.submit', () => {
-    it('should be protected from recursive-submission', () => {
-      const form = getForm({
-        id: 'sameform',
-        actionXhr: baseUrl + '/form/post',
-        on: 'submit:sameform.submit',
-      });
-      const ampForm = new AmpForm(form, 'sameform');
-      sandbox.spy(ampForm, 'handleXhrSubmit_');
-      sandbox.spy(ampForm, 'handleSubmitAction_');
-      sandbox.spy(ampForm.xhr_, 'fetch');
-      const fetch = poll('submit request sent',
-          () => ampForm.xhrSubmitPromiseForTesting());
-
-      form.dispatchEvent(new Event('submit'));
-      return fetch.then(() => {
-        // Due to recursive nature of 'on=submit:sameform.submit' we expect
-        // the action handler to be called twice, the first time for the
-        // actual user submission.
-        // The second time in response to the `submit` event being triggered
-        // and sameform.submit being invoked.
-        expect(ampForm.handleSubmitAction_).to.have.been.calledTwice;
-
-        // However, only the first invocation should be handled completely.
-        // and any subsequent calls should be stopped early-on.
-        expect(ampForm.handleXhrSubmit_).to.have.been.calledOnce;
-        expect(ampForm.xhr_.fetch).to.have.been.calledOnce;
-      });
-    });
-  });
-
-  describeChrome.run('Submit xhr-POST', function() {
-    this.timeout(RENDER_TIMEOUT);
-
-    it('should submit and render success', () => {
-      const form = getForm({
-        id: 'form1',
-        actionXhr: baseUrl + '/form/post/success',
-        success: {
-          message: 'Thanks {{name}} for adding your interests:' +
-              ' {{#interests}}{{title}} {{/interests}}.',
-          template: true,
-        },
-        error: {message: 'Should not render this.', template: true},
-      });
-      const ampForm = new AmpForm(form, 'form1');
-      const fetch = poll('submit request sent',
-          () => ampForm.xhrSubmitPromiseForTesting());
-      const render = listenOncePromise(form, AmpEvents.DOM_UPDATE);
-
-      form.dispatchEvent(new Event('submit'));
-      return fetch.then(() => render).then(() => {
-        const rendered = form.querySelector('[i-amphtml-rendered]');
-        expect(rendered.textContent).to.equal(
-            'Thanks John Miller for adding your interests: ' +
-            'Football Basketball Writing .');
-      });
+    beforeEach(() => {
+      sandbox = env.sandbox;
+      doc = env.win.document;
+      const scriptElement = document.createElement('script');
+      scriptElement.setAttribute('custom-template', 'amp-mustache');
+      doc.body.appendChild(scriptElement);
+      registerExtendedTemplate(env.win, 'amp-mustache', AmpMustache);
+      new AmpFormService(env.ampdoc);
     });
 
-    it('should submit and render error', () => {
-      // Stubbing timeout to catch async-thrown errors and expect
-      // them. These catch errors thrown inside the catch-clause of the
-      // xhr request using rethrowAsync.
-      sandbox.stub(window, 'setTimeout').callsFake(stubSetTimeout);
+    function getForm(config) {
+      const form = doc.createElement('form');
+      form.id = config.id || 'test-form';
+      form.setAttribute('method', config.method || 'POST');
+      form.setAttribute('target', config.target || '_top');
 
-      const form = getForm({
-        id: 'form1',
-        actionXhr: baseUrl + '/form/post/error',
-        success: {message: 'Should not render this.', template: true},
-        error: {
-          message: 'Oops. {{name}} your email {{email}} is already ' +
-              'subscribed.',
-          template: true,
-        },
-      });
-      const ampForm = new AmpForm(form, 'form1');
-      const fetchSpy = sandbox.spy(ampForm.xhr_, 'fetch');
-      const fetch = poll('submit request sent', () => fetchSpy.returnValues[0]);
-      const render = listenOncePromise(form, AmpEvents.DOM_UPDATE);
+      const nameInput = doc.createElement('input');
+      nameInput.setAttribute('name', 'name');
+      nameInput.setAttribute('value', 'John Miller');
+      form.appendChild(nameInput);
+      if (config.actionXhr) {
+        form.setAttribute('action-xhr', config.actionXhr);
+      }
+      if (config.action) {
+        form.setAttribute('action', config.action);
+      }
+      const submitButton = doc.createElement('input');
+      submitButton.setAttribute('type', 'submit');
+      form.appendChild(submitButton);
 
-      form.dispatchEvent(new Event('submit'));
-      return fetch.then(() => {
-        throw new Error('UNREACHABLE');
-      }, fetchError => {
-        expect(fetchError.message).to.match(/HTTP error 500/);
-        return render.then(() => {
-          const rendered = form.querySelector('[i-amphtml-rendered]');
-          expect(rendered.textContent).to.equal(
-              'Oops. John Miller your email john@miller.what is already ' +
-              'subscribed.');
+      if (config.on) {
+        form.setAttribute('on', config.on);
+      }
+
+      if (config.success) {
+        const {message, template} = config.success;
+        const successDiv = doc.createElement('div');
+        successDiv.setAttribute('submit-success', '');
+        if (template) {
+          const child = doc.createElement('template');
+          child.setAttribute('type', 'amp-mustache');
+          child./*OK*/innerHTML = message;
+          successDiv.appendChild(child);
+        } else {
+          successDiv./*OK*/innerHTML = message;
+        }
+
+        form.appendChild(successDiv);
+      }
+
+      if (config.error) {
+        const {message, template} = config.error;
+        const errorDiv = doc.createElement('div');
+        errorDiv.setAttribute('submit-error', '');
+        if (template) {
+          const child = doc.createElement('template');
+          child.setAttribute('type', 'amp-mustache');
+          child./*OK*/innerHTML = message;
+          errorDiv.appendChild(child);
+        } else {
+          errorDiv./*OK*/innerHTML = message;
+        }
+        form.appendChild(errorDiv);
+      }
+
+      doc.body.appendChild(form);
+      return form;
+    }
+
+    const describeChrome =
+        describe.configure().skipFirefox().skipSafari().skipEdge();
+
+    describeChrome.run('on=submit:form.submit', () => {
+      it('should be protected from recursive-submission', () => {
+        const form = getForm({
+          id: 'sameform',
+          actionXhr: baseUrl + '/form/post',
+          on: 'submit:sameform.submit',
+        });
+        const ampForm = new AmpForm(form, 'sameform');
+        sandbox.spy(ampForm, 'handleXhrSubmit_');
+        sandbox.spy(ampForm, 'handleSubmitAction_');
+        sandbox.spy(ampForm.xhr_, 'fetch');
+        const fetch = poll('submit request sent',
+            () => ampForm.xhrSubmitPromiseForTesting());
+
+        form.dispatchEvent(new Event('submit'));
+        return fetch.then(() => {
+          // Due to recursive nature of 'on=submit:sameform.submit' we expect
+          // the action handler to be called twice, the first time for the
+          // actual user submission.
+          // The second time in response to the `submit` event being triggered
+          // and sameform.submit being invoked.
+          expect(ampForm.handleSubmitAction_).to.have.been.calledTwice;
+
+          // However, only the first invocation should be handled completely.
+          // and any subsequent calls should be stopped early-on.
+          expect(ampForm.handleXhrSubmit_).to.have.been.calledOnce;
+          expect(ampForm.xhr_.fetch).to.have.been.calledOnce;
         });
       });
     });
-  });
 
-  describeChrome.run('Submit xhr-GET', function() {
-    this.timeout(RENDER_TIMEOUT);
+    describeChrome.run('Submit xhr-POST', function() {
+      this.timeout(RENDER_TIMEOUT);
 
-    it('should submit and render success', () => {
-      const form = getForm({
-        id: 'form1',
-        method: 'GET',
-        actionXhr: baseUrl + '/form/post/success',
-        success: {
-          message: 'Thanks {{name}} for adding your interests:' +
-              ' {{#interests}}{{title}} {{/interests}}.',
-          template: true,
-        },
-        error: {message: 'Should not render this.', template: true},
-      });
-      const ampForm = new AmpForm(form, 'form1');
-      const fetch = poll('submit request sent',
-          () => ampForm.xhrSubmitPromiseForTesting());
-      const render = listenOncePromise(form, AmpEvents.DOM_UPDATE);
+      it('should submit and render success', () => {
+        const form = getForm({
+          id: 'form1',
+          actionXhr: baseUrl + '/form/post/success',
+          success: {
+            message: 'Thanks {{name}} for adding your interests:' +
+                ' {{#interests}}{{title}} {{/interests}}.',
+            template: true,
+          },
+          error: {message: 'Should not render this.', template: true},
+        });
+        const ampForm = new AmpForm(form, 'form1');
+        const fetch = poll('submit request sent',
+            () => ampForm.xhrSubmitPromiseForTesting());
+        const render = listenOncePromise(form, AmpEvents.DOM_UPDATE);
 
-      form.dispatchEvent(new Event('submit'));
-      return fetch.then(() => render).then(() => {
-        const rendered = form.querySelectorAll('[i-amphtml-rendered]');
-        expect(rendered.length).to.equal(1);
-        expect(rendered[0].textContent).to.equal(
-            'Thanks John Miller for adding your interests: ' +
-            'Football Basketball Writing .');
-      });
-    });
-
-    it('should submit and render error', () => {
-      // Stubbing timeout to catch async-thrown errors and expect
-      // them. These catch errors thrown inside the catch-clause of the
-      // xhr request using rethrowAsync.
-      sandbox.stub(window, 'setTimeout').callsFake(stubSetTimeout);
-
-      const form = getForm({
-        id: 'form1',
-        actionXhr: baseUrl + '/form/post/error',
-        success: {message: 'Should not render this.', template: true},
-        error: {
-          message: 'Oops. {{name}} your email {{email}} is already ' +
-              'subscribed.',
-          template: true,
-        },
-      });
-      const ampForm = new AmpForm(form, 'form1');
-      const fetchSpy = sandbox.spy(ampForm.xhr_, 'fetch');
-      const fetch = poll('submit request sent', () => fetchSpy.returnValues[0]);
-      const render = listenOncePromise(form, AmpEvents.DOM_UPDATE);
-
-      form.dispatchEvent(new Event('submit'));
-      return fetch.then(() => {
-        throw new Error('UNREACHABLE');
-      }, fetchError => {
-        expect(fetchError.message).to.match(/HTTP error 500/);
-        return render.then(() => {
+        form.dispatchEvent(new Event('submit'));
+        return fetch.then(() => render).then(() => {
           const rendered = form.querySelector('[i-amphtml-rendered]');
           expect(rendered.textContent).to.equal(
-              'Oops. John Miller your email john@miller.what is already ' +
-              'subscribed.');
+              'Thanks John Miller for adding your interests: ' +
+              'Football Basketball Writing .');
+        });
+      });
+
+      it('should submit and render error', () => {
+        // Stubbing timeout to catch async-thrown errors and expect
+        // them. These catch errors thrown inside the catch-clause of the
+        // xhr request using rethrowAsync.
+        sandbox.stub(window, 'setTimeout').callsFake(stubSetTimeout);
+
+        const form = getForm({
+          id: 'form1',
+          actionXhr: baseUrl + '/form/post/error',
+          success: {message: 'Should not render this.', template: true},
+          error: {
+            message: 'Oops. {{name}} your email {{email}} is already ' +
+                'subscribed.',
+            template: true,
+          },
+        });
+        const ampForm = new AmpForm(form, 'form1');
+        const fetchSpy = sandbox.spy(ampForm.xhr_, 'fetch');
+        const fetch =
+            poll('submit request sent', () => fetchSpy.returnValues[0]);
+        const render = listenOncePromise(form, AmpEvents.DOM_UPDATE);
+
+        form.dispatchEvent(new Event('submit'));
+        return fetch.then(() => {
+          throw new Error('UNREACHABLE');
+        }, fetchError => {
+          expect(fetchError.message).to.match(/HTTP error 500/);
+          return render.then(() => {
+            const rendered = form.querySelector('[i-amphtml-rendered]');
+            expect(rendered.textContent).to.equal(
+                'Oops. John Miller your email john@miller.what is already ' +
+                'subscribed.');
+          });
         });
       });
     });
-  });
 
-  describeChrome.run('Submit result message', () => {
-    it('should render messages with or without a template', () => {
-      // Stubbing timeout to catch async-thrown errors and expect
-      // them. These catch errors thrown inside the catch-clause of the
-      // xhr request using rethrowAsync.
-      sandbox.stub(window, 'setTimeout').callsFake(stubSetTimeout);
+    describeChrome.run('Submit xhr-GET', function() {
+      this.timeout(RENDER_TIMEOUT);
 
-      const form = getForm({
-        id: 'form1',
-        actionXhr: baseUrl + '/form/post/error',
-        success: {message: 'Should not render this.', template: false},
-        error: {
-          message: 'Oops! Your email is already subscribed.' +
-              '<amp-img src="/examples/img/ampicon.png" ' +
-              'width="42" height="42"></amp-img>',
-          template: false,
-        },
+      it('should submit and render success', () => {
+        const form = getForm({
+          id: 'form1',
+          method: 'GET',
+          actionXhr: baseUrl + '/form/post/success',
+          success: {
+            message: 'Thanks {{name}} for adding your interests:' +
+                ' {{#interests}}{{title}} {{/interests}}.',
+            template: true,
+          },
+          error: {message: 'Should not render this.', template: true},
+        });
+        const ampForm = new AmpForm(form, 'form1');
+        const fetch = poll('submit request sent',
+            () => ampForm.xhrSubmitPromiseForTesting());
+        const render = listenOncePromise(form, AmpEvents.DOM_UPDATE);
+
+        form.dispatchEvent(new Event('submit'));
+        return fetch.then(() => render).then(() => {
+          const rendered = form.querySelectorAll('[i-amphtml-rendered]');
+          expect(rendered.length).to.equal(1);
+          expect(rendered[0].textContent).to.equal(
+              'Thanks John Miller for adding your interests: ' +
+              'Football Basketball Writing .');
+        });
       });
-      const ampForm = new AmpForm(form, 'form1');
-      const fetchSpy = sandbox.spy(ampForm.xhr_, 'fetch');
-      const fetch = poll('submit request sent', () => fetchSpy.returnValues[0]);
 
-      form.dispatchEvent(new Event('submit'));
-      return fetch.then(() => {
-        throw new Error('UNREACHABLE');
-      }, fetchError => {
-        expect(fetchError.message).to.match(/HTTP error 500/);
+      it('should submit and render error', () => {
+        // Stubbing timeout to catch async-thrown errors and expect
+        // them. These catch errors thrown inside the catch-clause of the
+        // xhr request using rethrowAsync.
+        sandbox.stub(window, 'setTimeout').callsFake(stubSetTimeout);
 
-        // It shouldn't have the i-amphtml-rendered attribute since no
-        // template was rendered.
-        const rendered = form.querySelectorAll('[i-amphtml-rendered]');
-        expect(rendered.length).to.equal(0);
+        const form = getForm({
+          id: 'form1',
+          actionXhr: baseUrl + '/form/post/error',
+          success: {message: 'Should not render this.', template: true},
+          error: {
+            message: 'Oops. {{name}} your email {{email}} is already ' +
+                'subscribed.',
+            template: true,
+          },
+        });
+        const ampForm = new AmpForm(form, 'form1');
+        const fetchSpy = sandbox.spy(ampForm.xhr_, 'fetch');
+        const fetch =
+            poll('submit request sent', () => fetchSpy.returnValues[0]);
+        const render = listenOncePromise(form, AmpEvents.DOM_UPDATE);
 
-        // Any amp elements inside the message should be layed out.
-        const layout = listenOncePromise(form, AmpEvents.LOAD_START);
-        return layout.then(() => {
-          const img = form.querySelector('amp-img img');
-          expect(img.src).to.contain('/examples/img/ampicon.png');
+        form.dispatchEvent(new Event('submit'));
+        return fetch.then(() => {
+          throw new Error('UNREACHABLE');
+        }, fetchError => {
+          expect(fetchError.message).to.match(/HTTP error 500/);
+          return render.then(() => {
+            const rendered = form.querySelector('[i-amphtml-rendered]');
+            expect(rendered.textContent).to.equal(
+                'Oops. John Miller your email john@miller.what is already ' +
+                'subscribed.');
+          });
+        });
+      });
+    });
+
+    describeChrome.run('Submit result message', () => {
+      // TODO(cvializ, #14336): Fails due to console errors.
+      it.skip('should render messages with or without a template', () => {
+        // Stubbing timeout to catch async-thrown errors and expect
+        // them. These catch errors thrown inside the catch-clause of the
+        // xhr request using rethrowAsync.
+        sandbox.stub(window, 'setTimeout').callsFake(stubSetTimeout);
+
+        const form = getForm({
+          id: 'form1',
+          actionXhr: baseUrl + '/form/post/error',
+          success: {message: 'Should not render this.', template: false},
+          error: {
+            message: 'Oops! Your email is already subscribed.' +
+                '<amp-img src="/examples/img/ampicon.png" ' +
+                'width="42" height="42"></amp-img>',
+            template: false,
+          },
+        });
+        const ampForm = new AmpForm(form, 'form1');
+        const fetchSpy = sandbox.spy(ampForm.xhr_, 'fetch');
+        const fetch =
+            poll('submit request sent', () => fetchSpy.returnValues[0]);
+
+        form.dispatchEvent(new Event('submit'));
+        return fetch.then(() => {
+          throw new Error('UNREACHABLE');
+        }, fetchError => {
+          expect(fetchError.message).to.match(/HTTP error 500/);
+
+          // It shouldn't have the i-amphtml-rendered attribute since no
+          // template was rendered.
+          const rendered = form.querySelectorAll('[i-amphtml-rendered]');
+          expect(rendered.length).to.equal(0);
+
+          // Any amp elements inside the message should be layed out.
+          const layout = listenOncePromise(form, AmpEvents.LOAD_START);
+          return layout.then(() => {
+            const img = form.querySelector('amp-img img');
+            expect(img.src).to.contain('/examples/img/ampicon.png');
+          });
         });
       });
     });

--- a/extensions/amp-form/0.1/test/test-amp-form.js
+++ b/extensions/amp-form/0.1/test/test-amp-form.js
@@ -528,7 +528,9 @@ describes.repeated('', {
       });
     });
 
-    it('should allow rendering responses through inlined templates', () => {
+    // TODO(danielrozenberg, #14336): Fails due to console errors.
+    it.skip('should allow rendering responses through inlined ' +
+        'templates', () => {
       return getAmpForm(getForm(env.win.document, true)).then(ampForm => {
         const form = ampForm.form_;
         // Add a div[submit-error] with a template child.
@@ -1621,7 +1623,8 @@ describes.repeated('', {
           });
         });
 
-        it('should redirect on error and header is set', () => {
+        // TODO(cvializ, #14336): Fails due to console errors.
+        it.skip('should redirect on error and header is set', () => {
           sandbox.stub(ampForm.xhr_, 'fetch').returns(fetchRejectPromise);
           redirectToValue = 'https://example2.com/hello';
           const logSpy = sandbox.spy(user(), 'error');

--- a/extensions/amp-gwd-animation/0.1/test/test-amp-gwd-animation.js
+++ b/extensions/amp-gwd-animation/0.1/test/test-amp-gwd-animation.js
@@ -283,7 +283,8 @@ describes.sandboxed('AMP GWD Animation', {}, () => {
         });
       });
 
-      it('should execute play', () => {
+      // TODO(dvoytenko, #14336): Fails due to console errors.
+      it.skip('should execute play', () => {
         return ampdoc.whenBodyAvailable().then(() => {
           // Pause an animation to test resuming it.
           const pauseInvocation = {
@@ -312,7 +313,8 @@ describes.sandboxed('AMP GWD Animation', {}, () => {
         });
       });
 
-      it('should execute pause', () => {
+      // TODO(dvoytenko, #14336): Fails due to console errors.
+      it.skip('should execute pause', () => {
         return ampdoc.whenBodyAvailable().then(() => {
           const invocation = {
             method: 'pause',
@@ -334,7 +336,8 @@ describes.sandboxed('AMP GWD Animation', {}, () => {
         });
       });
 
-      it('should execute togglePlay', () => {
+      // TODO(dvoytenko, #14336): Fails due to console errors.
+      it.skip('should execute togglePlay', () => {
         return ampdoc.whenBodyAvailable().then(() => {
           const invocation = {
             method: 'togglePlay',
@@ -355,7 +358,8 @@ describes.sandboxed('AMP GWD Animation', {}, () => {
         });
       });
 
-      it('should execute gotoAndPlay', () => {
+      // TODO(dvoytenko, #14336): Fails due to console errors.
+      it.skip('should execute gotoAndPlay', () => {
         return ampdoc.whenBodyAvailable().then(() => {
           const invocation = {
             method: 'gotoAndPlay',
@@ -387,7 +391,8 @@ describes.sandboxed('AMP GWD Animation', {}, () => {
         });
       });
 
-      it('should execute gotoAndPause', () => {
+      // TODO(dvoytenko, #14336): Fails due to console errors.
+      it.skip('should execute gotoAndPause', () => {
         return ampdoc.whenBodyAvailable().then(() => {
           // Test handling missing arguments.
           const invocation = {
@@ -414,7 +419,8 @@ describes.sandboxed('AMP GWD Animation', {}, () => {
         });
       });
 
-      it('should execute gotoAndPlayNTimes', () => {
+      // TODO(dvoytenko, #14336): Fails due to console errors.
+      it.skip('should execute gotoAndPlayNTimes', () => {
         return ampdoc.whenBodyAvailable().then(() => {
           // Invoking gotoAndPlayNTimes with a negative N value is a no-op.
           const invocationWithBadNValue = {

--- a/extensions/amp-iframe/0.1/test/test-amp-iframe.js
+++ b/extensions/amp-iframe/0.1/test/test-amp-iframe.js
@@ -513,7 +513,9 @@ describes.realWin('amp-iframe', {
       expect(attemptChangeSize.firstCall.args[1]).to.be.undefined;
     });
 
-    it('should not resize amp-iframe if request height is small', function* () {
+    // TODO(zhouyx, #14336): Fails due to console errors.
+    it.skip('should not resize amp-iframe if request height is' +
+        'small', function* () {
       const ampIframe = createAmpIframe(env, {
         src: iframeSrc,
         sandbox: 'allow-scripts',
@@ -528,7 +530,9 @@ describes.realWin('amp-iframe', {
       expect(attemptChangeSize).to.have.not.been.called;
     });
 
-    it('should not resize amp-iframe if it is non-resizable', function* () {
+    // TODO(zhouyx, #14336): Fails due to console errors.
+    it.skip('should not resize amp-iframe if it is ' +
+        'non-resizable', function* () {
       const ampIframe = createAmpIframe(env, {
         src: iframeSrc,
         sandbox: 'allow-scripts',
@@ -572,7 +576,8 @@ describes.realWin('amp-iframe', {
       expect(impl.looksLikeTrackingIframe_()).to.be.false;
     });
 
-    it('should detect tracking iframes', function* () {
+    // TODO(zhouyx, #14336): Fails due to console errors.
+    it.skip('should detect tracking iframes', function* () {
       const ampIframe1 = createAmpIframe(env, {
         src: clickableIframeSrc,
         sandbox: 'allow-scripts allow-same-origin',
@@ -617,7 +622,8 @@ describes.realWin('amp-iframe', {
       expect(ampIframe3.querySelector('iframe')).to.not.be.null;
     });
 
-    it('should not detect traking iframe in amp container', function* () {
+    // TODO(zhouyx, #14336): Fails due to console errors.
+    it.skip('should not detect traking iframe in amp container', function* () {
       const ampIframeRealTracking = createAmpIframe(env, {
         src: iframeSrc,
         width: 5,

--- a/extensions/amp-install-serviceworker/0.1/test/test-amp-install-serviceworker.js
+++ b/extensions/amp-install-serviceworker/0.1/test/test-amp-install-serviceworker.js
@@ -99,7 +99,8 @@ describes.realWin('amp-install-serviceworker', {
     expect(maybeInstallUrlRewriteStub).to.be.calledOnce;
   });
 
-  it('should do nothing with non-matching origins', () => {
+  // TODO(malteubl, #14336): Fails due to console errors.
+  it.skip('should do nothing with non-matching origins', () => {
     const install = doc.createElement('amp-install-serviceworker');
     const implementation = install.implementation_;
     expect(implementation).to.exist;

--- a/extensions/amp-mustache/0.1/test/test-amp-mustache.js
+++ b/extensions/amp-mustache/0.1/test/test-amp-mustache.js
@@ -38,7 +38,8 @@ describe('amp-mustache template', () => {
     expect(result./*OK*/innerHTML).to.equal('value = abc');
   });
 
-  it('should sanitize output', () => {
+  // TODO(dvoytenko, #14336): Fails due to console errors.
+  it.skip('should sanitize output', () => {
     const templateElement = document.createElement('template');
     templateElement./*OK*/innerHTML =
         'value = <a href="{{value}}">abc</a>';
@@ -64,7 +65,8 @@ describe('amp-mustache template', () => {
     expect(result.firstElementChild).to.be.null;
   });
 
-  describe('Sanitizing data- attributes', () => {
+  // TODO(dvoytenko, #14336): Fails due to console errors.
+  describe.skip('Sanitizing data- attributes', () => {
 
     it('should sanitize templated attribute names', () => {
       const templateElement = document.createElement('template');
@@ -132,7 +134,8 @@ describe('amp-mustache template', () => {
     });
   });
 
-  describe('Rendering Form Fields', () => {
+  // TODO(mkhatib, #14336): Fails due to console errors.
+  describe.skip('Rendering Form Fields', () => {
     it('should allow rendering inputs', () => {
       const templateElement = document.createElement('template');
       templateElement./*OK*/innerHTML = 'value = ' +
@@ -300,7 +303,8 @@ describe('amp-mustache template', () => {
       expect(nestedResult./*OK*/innerHTML).to.equal('nested: Nested');
     });
 
-    it('should sanitize the inner template when it gets rendered', () => {
+    // TODO(danielrozenberg, #14336): Fails due to console errors.
+    it.skip('should sanitize the inner template when it gets rendered', () => {
       const outerTemplateElement = document.createElement('template');
       outerTemplateElement./*OK*/innerHTML =
           'outer: {{value}} ' +

--- a/extensions/amp-share-tracking/0.1/test/test-amp-share-tracking.js
+++ b/extensions/amp-share-tracking/0.1/test/test-amp-share-tracking.js
@@ -185,7 +185,8 @@ describes.fakeWin('amp-share-tracking', {
         });
   });
 
-  it('should get empty outgoing fragment if vendor url is provided ' +
+  // TODO(lannka, #14336): Fails due to console errors.
+  it.skip('should get empty outgoing fragment if vendor url is provided ' +
       'but the response format is NOT correct', () => {
     historyGetFragmentStub.onFirstCall().returns(Promise.resolve(''));
     xhrStub.onFirstCall().returns(Promise.resolve({
@@ -226,7 +227,8 @@ describes.fakeWin('amp-share-tracking', {
         });
   });
 
-  it('should get empty outgoing fragment if vendor url is provided ' +
+  // TODO(lannka, #14336): Fails due to console errors.
+  it.skip('should get empty outgoing fragment if vendor url is provided ' +
       'but the xhr fails', () => {
     historyGetFragmentStub.onFirstCall().returns(Promise.resolve(''));
     xhrStub.onFirstCall().returns(Promise.reject({

--- a/extensions/amp-sidebar/0.1/test/integration/test-amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/test/integration/test-amp-sidebar.js
@@ -16,7 +16,8 @@
 
 import {poll} from '../../../../../testing/iframe';
 
-describe.configure().skipSafari().skipEdge().run('amp-sidebar', function() {
+// TODO(cathyxz, #14336): Fails due to console errors.
+describe.skip('amp-sidebar', function() {
   // Extend timeout slightly for flakes on Windows environments
   this.timeout(4000);
   const extensions = ['amp-sidebar'];

--- a/extensions/amp-sticky-ad/1.0/test/test-amp-sticky-ad.js
+++ b/extensions/amp-sticky-ad/1.0/test/test-amp-sticky-ad.js
@@ -51,7 +51,8 @@ describes.realWin('amp-sticky-ad 1.0 version', {
               () => addToFixedLayerPromise);
     });
 
-    it('should listen to scroll event', function * () {
+    // TODO(zhouyx, #14336): Fails due to console errors.
+    it.skip('should listen to scroll event', function * () {
       expect(impl.scrollUnlisten_).to.be.null;
       yield macroTask();
       expect(impl.scrollUnlisten_).to.be.a('function');

--- a/extensions/amp-subscriptions/0.1/test/test-platform-store.js
+++ b/extensions/amp-subscriptions/0.1/test/test-platform-store.js
@@ -262,7 +262,8 @@ describes.realWin('Platform store', {}, () => {
       errorSpy = sandbox.spy(user(), 'error');
     });
 
-    it('should report fatal error if all platforms fail', () => {
+    // TODO(prateekbh, #14336): Fails due to console errors.
+    it.skip('should report fatal error if all platforms fail', () => {
       platformStore.reportPlatformFailure('service1');
       platformStore.reportPlatformFailure('service2');
       expect(errorSpy).to.be.calledOnce;

--- a/extensions/amp-user-notification/0.1/test/test-amp-user-notification.js
+++ b/extensions/amp-user-notification/0.1/test/test-amp-user-notification.js
@@ -287,7 +287,8 @@ describes.realWin('amp-user-notification', {
     });
   });
 
-  it('shouldShow should recover from error to xhr', () => {
+  // TODO(dvoytenko, #14336): Fails due to console errors.
+  it.skip('shouldShow should recover from error to xhr', () => {
     const el = getUserNotification(dftAttrs);
     const impl = el.implementation_;
     impl.buildCallback();
@@ -310,7 +311,9 @@ describes.realWin('amp-user-notification', {
     });
   });
 
-  it('shouldShow should recover from error and return true with no xhr', () => {
+  // TODO(dvoytenko, #14336): Fails due to console errors.
+  it.skip('shouldShow should recover from error and return true with ' +
+      'no xhr', () => {
     const el = getUserNotification({id: 'n1'});
     const impl = el.implementation_;
     impl.buildCallback();
@@ -644,7 +647,8 @@ describes.realWin('amp-user-notification', {
       });
     });
 
-    it('should dissmiss without persistence if cid.optOut() fails', () => {
+    // TODO(aghassemi, #14336): Fails due to console errors.
+    it.skip('should dissmiss without persistence if cid.optOut() fails', () => {
       const element = getUserNotification({id: 'n1'});
       const impl = element.implementation_;
       impl.buildCallback();

--- a/extensions/amp-youtube/0.1/test/test-amp-youtube.js
+++ b/extensions/amp-youtube/0.1/test/test-amp-youtube.js
@@ -134,7 +134,9 @@ describes.realWin('amp-youtube', {
       });
     });
 
-    it('should pass data-param-* attributes to the iframe src', () => {
+
+    // TODO(cathyxz, #14336): Fails due to console errors.
+    it.skip('should pass data-param-* attributes to the iframe src', () => {
       return getYt({
         'data-videoid': datasource,
         'data-param-autoplay': '1',

--- a/test/_init_tests.js
+++ b/test/_init_tests.js
@@ -40,6 +40,9 @@ import {setDefaultBootstrapBaseUrlForTesting} from '../src/3p-frame';
 import {setReportError} from '../src/log';
 import stringify from 'json-stable-stringify';
 
+// Used to surface console errors as mocha test failures.
+let consoleSandbox;
+
 // All exposed describes.
 global.describes = describes;
 
@@ -265,6 +268,10 @@ sinon.sandbox.create = function(config) {
 beforeEach(function() {
   this.timeout(BEFORE_AFTER_TIMEOUT);
   beforeTest();
+  consoleSandbox = sinon.sandbox.create();
+  consoleSandbox.stub(console, 'error').callsFake((...messages) => {
+    throw new Error(messages.join(' '));
+  });
 });
 
 function beforeTest() {
@@ -285,6 +292,7 @@ function beforeTest() {
 // Global cleanup of tags added during tests. Cool to add more
 // to selector.
 afterEach(function() {
+  consoleSandbox.restore();
   this.timeout(BEFORE_AFTER_TIMEOUT);
   const cleanupTagNames = ['link', 'meta'];
   if (!Services.platformFor(window).isSafari()) {

--- a/test/functional/inabox/test-inabox-frame-overlay-manager.js
+++ b/test/functional/inabox/test-inabox-frame-overlay-manager.js
@@ -40,7 +40,6 @@ describes.fakeWin('inabox-host:FrameOverlayManager', {}, env => {
   });
 
   afterEach(() => {
-    sandbox.reset();
     sandbox.restore();
   });
 

--- a/test/functional/inabox/test-inabox-viewport.js
+++ b/test/functional/inabox/test-inabox-viewport.js
@@ -84,7 +84,8 @@ describes.fakeWin('inabox-viewport', {amp: {}}, env => {
     sandbox.restore();
   });
 
-  it('should work for size, layoutRect and position observer', () => {
+  // TODO(alanorozco, #14336): Fails due to console errors.
+  it.skip('should work for size, layoutRect and position observer', () => {
     stubIframeClientMakeRequest(
         'send-positions',
         'position',
@@ -113,7 +114,7 @@ describes.fakeWin('inabox-viewport', {amp: {}}, env => {
     expect(measureSpy).to.be.calledOnce;
     expect(binding.getLayoutRect(element))
         .to.deep.equal(layoutRectLtwh(10, 20, 100, 100));
-    sandbox.reset();
+    sandbox.restore();
 
     // Scroll, viewport position changed
     positionCallback({
@@ -126,7 +127,7 @@ describes.fakeWin('inabox-viewport', {amp: {}}, env => {
     expect(measureSpy).to.not.be.called;
     expect(binding.getLayoutRect(element))
         .to.deep.equal(layoutRectLtwh(10, 20, 100, 100));
-    sandbox.reset();
+    sandbox.restore();
 
     // Resize, viewport size changed
     positionCallback({
@@ -139,7 +140,6 @@ describes.fakeWin('inabox-viewport', {amp: {}}, env => {
     expect(measureSpy).to.not.be.called;
     expect(binding.getLayoutRect(element))
         .to.deep.equal(layoutRectLtwh(10, 20, 100, 100));
-    sandbox.reset();
 
     // DOM change, target position changed
     sandbox.restore();

--- a/test/functional/test-3p.js
+++ b/test/functional/test-3p.js
@@ -74,6 +74,17 @@ describe('3p', () => {
   });
 
   describe('validateData', () => {
+    let sandbox;
+    let clock;
+
+    beforeEach(() => {
+      sandbox = sinon.sandbox.create();
+      clock = sandbox.useFakeTimers();
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+    });
 
     it('should check mandatory fields', () => {
       validateData({

--- a/test/functional/test-action.js
+++ b/test/functional/test-action.js
@@ -714,7 +714,8 @@ describe('installActionHandler', () => {
     expect(callArgs.event).to.be.equal('tap');
   });
 
-  it('should check trust level before invoking action', () => {
+  // TODO(choumx, #14336): Fails due to console errors.
+  it.skip('should check trust level before invoking action', () => {
     const handlerSpy = sandbox.spy();
     const target = document.createElement('form');
     action.installActionHandler(target, handlerSpy, ActionTrust.HIGH);
@@ -953,7 +954,8 @@ describe('Action common handler', () => {
     expect(target['__AMP_ACTION_QUEUE__']).to.not.exist;
   });
 
-  it('should check trust before invoking action', () => {
+  // TODO(choumx, #14336): Fails due to console errors.
+  it.skip('should check trust before invoking action', () => {
     const handler = sandbox.spy();
     action.addGlobalMethodHandler('foo', handler, ActionTrust.HIGH);
 

--- a/test/functional/test-cid-api.js
+++ b/test/functional/test-cid-api.js
@@ -148,7 +148,8 @@ describes.realWin('test-cid-api', {amp: true}, env => {
     });
   });
 
-  it('should return null if API rejects', () => {
+  // TODO(lannka, #14336): Fails due to console errors.
+  it.skip('should return null if API rejects', () => {
     fetchJsonStub.returns(Promise.reject());
     return api.getScopedCid('api-key', 'scope-a').then(cid => {
       expect(cid).to.be.null;

--- a/test/functional/test-cid.js
+++ b/test/functional/test-cid.js
@@ -294,7 +294,8 @@ describe('cid', () => {
           '');
     });
 
-    it('should read from viewer storage if embedded', () => {
+    // TODO(lannka, #14336): Fails due to console errors.
+    it.skip('should read from viewer storage if embedded', () => {
       fakeWin.parent = {};
       const expectedBaseCid = 'from-viewer';
       viewerStorage = JSON.stringify({
@@ -317,7 +318,8 @@ describe('cid', () => {
       });
     });
 
-    it('should read from viewer storage if embedded and convert cid to ' +
+    // TODO(lannka, #14336): Fails due to console errors.
+    it.skip('should read from viewer storage if embedded and convert cid to ' +
         'new format', () => {
       fakeWin.parent = {};
       const expectedBaseCid = 'from-viewer';
@@ -348,7 +350,8 @@ describe('cid', () => {
       });
     });
 
-    it('should store to viewer storage if embedded', () => {
+    // TODO(lannka, #14336): Fails due to console errors.
+    it.skip('should store to viewer storage if embedded', () => {
       fakeWin.parent = {};
       const expectedBaseCid = 'sha384([1,2,3,0,0,0,0,0,0,0,0,0,0,0,0,15])';
       return compare('e2', `sha384(${expectedBaseCid}http://www.origin.come2)`)
@@ -379,7 +382,8 @@ describe('cid', () => {
           'sha384(in-storagehttp://www.origin.come2)');
     });
 
-    it('should expire on read after 365 days', () => {
+    // TODO(lannka, #14336): Fails due to console errors.
+    it.skip('should expire on read after 365 days', () => {
       const expected = 'sha384(sha384([1,2,3,0,0,0,0,0,0,0,0,0,0,0,0,15])http://www.origin.come2)';
       return compare('e2', expected).then(() => {
         clock.tick(364 * DAY);
@@ -397,7 +401,8 @@ describe('cid', () => {
       });
     });
 
-    it('should expire on read after 365 days when embedded', () => {
+    // TODO(lannka, #14336): Fails due to console errors.
+    it.skip('should expire on read after 365 days when embedded', () => {
       fakeWin.parent = {};
       const expectedBaseCid = 'from-viewer';
       viewerStorage = JSON.stringify({
@@ -438,7 +443,8 @@ describe('cid', () => {
       });
     });
 
-    it('should set last access time once a day when embedded', () => {
+    // TODO(lannka, #14336): Fails due to console errors.
+    it.skip('should set last access time once a day when embedded', () => {
       fakeWin.parent = {};
       const expected = 'sha384(sha384([1,2,3,0,0,0,0,0,0,0,0,0,0,0,0,15])http://www.origin.come2)';
       function getStoredTime() {
@@ -524,7 +530,8 @@ describe('cid', () => {
       });
     });
 
-    it('should not wait persistence consent for viewer storage', () => {
+    // TODO(lannka, #14336): Fails due to console errors.
+    it.skip('should not wait persistence consent for viewer storage', () => {
       fakeWin.parent = {};
       const persistencePromise = new Promise(() => {/* never resolves */});
       return cid.get({scope: 'e2'}, hasConsent, persistencePromise).then(() => {
@@ -759,7 +766,8 @@ describes.realWin('cid', {amp: true}, env => {
         .to.eventually.equal('cid-from-viewer');
   });
 
-  it('get method should time out when in Viewer', function *() {
+  // TODO(zhouyx, #14336): Fails due to console errors.
+  it.skip('get method should time out when in Viewer', function *() {
     win.parent = {};
     stubServiceForDoc(sandbox, ampdoc, 'viewer', 'sendMessageAwaitResponse')
         .returns(new Promise(() => {}));

--- a/test/functional/test-crypto.js
+++ b/test/functional/test-crypto.js
@@ -127,13 +127,14 @@ describes.realWin('crypto-impl', {}, env => {
       },
     },
   });
-  testSuite('with native crypto API throws', {
-    crypto: {
-      subtle: {
-        digest: () => {throw new Error();},
-      },
-    },
-  });
+  // TODO(keithwrightbos, #14336): Fails due to console errors.
+  // testSuite('with native crypto API throws', {
+  //   crypto: {
+  //     subtle: {
+  //       digest: () => {throw new Error();},
+  //     },
+  //   },
+  // });
 
   it('native API result should exactly equal to crypto lib result', () => {
     return Promise

--- a/test/functional/test-custom-element.js
+++ b/test/functional/test-custom-element.js
@@ -319,7 +319,8 @@ describes.realWin('CustomElement', {amp: true}, env => {
       expect(element.implementation_.layoutWidth_).to.equal(111);
     });
 
-    it('should tolerate erros in onLayoutMeasure', () => {
+    // TODO(dvoytenko, #14336): Fails due to console errors.
+    it.skip('should tolerate erros in onLayoutMeasure', () => {
       const element = new ElementClass();
       sandbox.stub(element.implementation_, 'onLayoutMeasure').callsFake(() => {
         throw new Error('intentional');
@@ -975,7 +976,8 @@ describes.realWin('CustomElement', {amp: true}, env => {
       expect(element2).to.have.class('i-amphtml-hidden-by-media-query');
     });
 
-    it('should apply sizes condition', () => {
+    // TODO(dvoytenko, #14336): Fails due to console errors.
+    it.skip('should apply sizes condition', () => {
       const element1 = new ElementClass();
       element1.setAttribute('sizes', '(min-width: 1px) 200px, 50vw');
       element1.applySizesAndMediaQuery();
@@ -987,7 +989,8 @@ describes.realWin('CustomElement', {amp: true}, env => {
       expect(element2.style.width).to.equal('50vw');
     });
 
-    it('should apply heights condition', () => {
+    // TODO(dvoytenko, #14336): Fails due to console errors.
+    it.skip('should apply heights condition', () => {
       const element1 = new ElementClass();
       element1.sizerElement = doc.createElement('div');
       element1.setAttribute('layout', 'responsive');

--- a/test/functional/test-dom.js
+++ b/test/functional/test-dom.js
@@ -792,7 +792,8 @@ describes.sandboxed('DOM', {}, env => {
       expect(res).to.equal(dialog);
     });
 
-    it('should retry on first exception', () => {
+    // TODO(dvoytenko, #14336): Fails due to console errors.
+    it.skip('should retry on first exception', () => {
       const dialog = {};
       windowMock.expects('open')
           .withExactArgs('https://example.com/', '_blank', 'width=1')
@@ -821,7 +822,8 @@ describes.sandboxed('DOM', {}, env => {
       expect(res).to.be.null;
     });
 
-    it('should return the final exception', () => {
+    // TODO(dvoytenko, #14336): Fails due to console errors.
+    it.skip('should return the final exception', () => {
       windowMock.expects('open')
           .withExactArgs('https://example.com/', '_blank', 'width=1')
           .throws(new Error('intentional1'))

--- a/test/functional/test-error.js
+++ b/test/functional/test-error.js
@@ -39,60 +39,64 @@ import {
 import {user} from '../../src/log';
 
 describes.fakeWin('installErrorReporting', {}, env => {
-  let sandbox;
-  let win;
-  let rejectedPromiseError;
-  let rejectedPromiseEvent;
-  let rejectedPromiseEventCancelledSpy;
+  // TODO(dvoytenko, #14336): Fails due to console errors.
+  describe.skip('installErrorReporting',() => {
+    let sandbox;
+    let win;
+    let rejectedPromiseError;
+    let rejectedPromiseEvent;
+    let rejectedPromiseEventCancelledSpy;
 
-  beforeEach(() => {
-    win = env.win;
-    installErrorReporting(win);
-    sandbox = env.sandbox;
-    rejectedPromiseEventCancelledSpy = sandbox.spy();
-    rejectedPromiseError = new Error('error');
-    rejectedPromiseEvent = {
-      type: 'unhandledrejection',
-      reason: rejectedPromiseError,
-      preventDefault: rejectedPromiseEventCancelledSpy,
-    };
-  });
+    beforeEach(() => {
+      win = env.win;
+      installErrorReporting(win);
+      sandbox = env.sandbox;
+      rejectedPromiseEventCancelledSpy = sandbox.spy();
+      rejectedPromiseError = new Error('error');
+      rejectedPromiseEvent = {
+        type: 'unhandledrejection',
+        reason: rejectedPromiseError,
+        preventDefault: rejectedPromiseEventCancelledSpy,
+      };
+    });
 
-  it('should install window.onerror handler', () => {
-    expect(win.onerror).to.not.be.null;
-  });
+    it('should install window.onerror handler', () => {
+      expect(win.onerror).to.not.be.null;
+    });
 
-  it('should install unhandledrejection handler', () => {
-    expect(win.eventListeners.count('unhandledrejection')).to.equal(1);
-  });
+    it('should install unhandledrejection handler', () => {
+      expect(win.eventListeners.count('unhandledrejection')).to.equal(1);
+    });
 
-  it('should report the normal promise rejection', () => {
-    win.eventListeners.fire(rejectedPromiseEvent);
-    expect(rejectedPromiseError.reported).to.be.true;
-    expect(rejectedPromiseEventCancelledSpy).to.not.be.called;
-  });
+    it('should report the normal promise rejection', () => {
+      win.eventListeners.fire(rejectedPromiseEvent);
+      expect(rejectedPromiseError.reported).to.be.true;
+      expect(rejectedPromiseEventCancelledSpy).to.not.be.called;
+    });
 
-  it('should allow null errors', () => {
-    rejectedPromiseEvent.reason = null;
-    win.eventListeners.fire(rejectedPromiseEvent);
-    expect(rejectedPromiseEventCancelledSpy).to.not.be.called;
-  });
+    it('should allow null errors', () => {
+      rejectedPromiseEvent.reason = null;
+      win.eventListeners.fire(rejectedPromiseEvent);
+      expect(rejectedPromiseEventCancelledSpy).to.not.be.called;
+    });
 
-  it('should allow string errors', () => {
-    rejectedPromiseEvent.reason = 'string error';
-    win.eventListeners.fire(rejectedPromiseEvent);
-    expect(rejectedPromiseEventCancelledSpy).to.not.be.called;
-  });
+    it('should allow string errors', () => {
+      rejectedPromiseEvent.reason = 'string error';
+      win.eventListeners.fire(rejectedPromiseEvent);
+      expect(rejectedPromiseEventCancelledSpy).to.not.be.called;
+    });
 
-  it('should ignore cancellation', () => {
-    rejectedPromiseEvent.reason = rejectedPromiseError = cancellation();
-    win.eventListeners.fire(rejectedPromiseEvent);
-    expect(rejectedPromiseError.reported).to.be.not.be.ok;
-    expect(rejectedPromiseEventCancelledSpy).to.be.calledOnce;
+    it('should ignore cancellation', () => {
+      rejectedPromiseEvent.reason = rejectedPromiseError = cancellation();
+      win.eventListeners.fire(rejectedPromiseEvent);
+      expect(rejectedPromiseError.reported).to.be.not.be.ok;
+      expect(rejectedPromiseEventCancelledSpy).to.be.calledOnce;
+    });
   });
 });
 
-describe('maybeReportErrorToViewer', () => {
+// TODO(dvoytenko, #14336): Fails due to console errors.
+describe.skip('maybeReportErrorToViewer', () => {
   let win;
   let viewer;
   let sandbox;
@@ -165,7 +169,8 @@ describe('maybeReportErrorToViewer', () => {
   });
 });
 
-describe('reportErrorToServer', () => {
+// TODO(dvoytenko, #14336): Fails due to console errors.
+describe.skip('reportErrorToServer', () => {
   let sandbox;
   let onError;
   let nextRandomNumber;
@@ -527,7 +532,8 @@ describes.sandboxed('reportError', {}, () => {
     clock = sandbox.useFakeTimers();
   });
 
-  it('should accept Error type', () => {
+  // TODO(dvoytenko, #14336): Fails due to console errors.
+  it.skip('should accept Error type', () => {
     const error = new Error('error');
     const result = reportError(error);
     expect(result).to.equal(error);
@@ -624,7 +630,8 @@ describes.fakeWin('user error reporting', {amp: true}, env => {
     toggleExperiment(win, 'user-error-reporting', true);
   });
 
-  it('should trigger triggerAnalyticsEvent with correct arguments', () => {
+  // TODO(tiendao, #14336): Fails due to console errors.
+  it.skip('should trigger triggerAnalyticsEvent with correct arguments', () => {
     reportErrorToAnalytics(error, win);
     expect(analyticsEventSpy).to.have.been.called;
     expect(analyticsEventSpy).to.have.been.calledWith(

--- a/test/functional/test-experiments.js
+++ b/test/functional/test-experiments.js
@@ -893,14 +893,16 @@ describes.fakeWin('isOriginExperimentOn', {amp: false}, env => {
         .to.eventually.be.false;
   });
 
-  it('should return false for missing token', () => {
+  // TODO(choumx, #14336): Fails due to console errors.
+  it.skip('should return false for missing token', () => {
     setupMetaTagWith('');
 
     return expect(isOriginExperimentOn(win, 'foo', true))
         .to.eventually.be.false;
   });
 
-  it('should return false if origin does not match', () => {
+  // TODO(choumx, #14336): Fails due to console errors.
+  it.skip('should return false if origin does not match', () => {
     setupMetaTagWith(token);
     win.location.href = 'https://not-origin.com';
 

--- a/test/functional/test-navigation.js
+++ b/test/functional/test-navigation.js
@@ -496,7 +496,8 @@ describes.sandboxed('Navigation', {}, () => {
         win.location.href = 'https://www.pub.com/';
       });
 
-      it('should reject invalid protocols', () => {
+      // TODO(choumx, #14336): Fails due to console errors.
+      it.skip('should reject invalid protocols', () => {
         const newUrl = /*eslint no-script-url: 0*/ 'javascript:alert(1)';
 
         expect(win.location.href).to.equal('https://www.pub.com/');

--- a/test/functional/test-resource.js
+++ b/test/functional/test-resource.js
@@ -111,7 +111,8 @@ describes.realWin('Resource', {amp: true}, env => {
     });
   });
 
-  it('should blacklist on build failure', () => {
+  // TODO(dvoytenko, #14336): Fails due to console errors.
+  it.skip('should blacklist on build failure', () => {
     elementMock.expects('isUpgraded').returns(true).atLeast(1);
     elementMock.expects('build')
         .returns(Promise.reject(new Error('intentional'))).once();

--- a/test/functional/test-resources.js
+++ b/test/functional/test-resources.js
@@ -2959,7 +2959,8 @@ describes.fakeWin('Resources.add/upgrade/remove', {amp: true}, env => {
       expect(resources.pendingBuildResources_.length).to.be.equal(0);
     });
 
-    it('should build everything pending when document is ready', () => {
+    // TODO(mkhatib, #14336): Fails due to console errors.
+    it.skip('should build everything pending when document is ready', () => {
       resources.documentReady_ = true;
       resources.pendingBuildResources_ = [parentResource, resource1, resource2];
       const child1BuildSpy = sandbox.spy();
@@ -2992,7 +2993,8 @@ describes.fakeWin('Resources.add/upgrade/remove', {amp: true}, env => {
       });
     });
 
-    it('should not schedule pass if all builds failed', () => {
+    // TODO(dvoytenko, #14336): Fails due to console errors.
+    it.skip('should not schedule pass if all builds failed', () => {
       resources.documentReady_ = true;
       resources.pendingBuildResources_ = [resource1];
       const child1BuildSpy = sandbox.spy();

--- a/test/functional/test-runtime.js
+++ b/test/functional/test-runtime.js
@@ -1026,7 +1026,8 @@ describes.realWin('runtime multidoc', {
       win.AMP.attachShadowDoc(hostElement, importDoc, docUrl);
     });
 
-    it('should ignore unknown script', () => {
+    // TODO(dvoytenko, #14336): Fails due to console errors.
+    it.skip('should ignore unknown script', () => {
       extensionsMock.expects('preloadExtension').never();
 
       const scriptEl = win.document.createElement('script');
@@ -1106,7 +1107,8 @@ describes.realWin('runtime multidoc', {
           'script[data-id="test1"]').textContent).to.equal('{}');
     });
 
-    it('should ignore inline script if javascript', () => {
+    // TODO(dvoytenko, #14336): Fails due to console errors.
+    it.skip('should ignore inline script if javascript', () => {
       const scriptEl1 = win.document.createElement('script');
       scriptEl1.setAttribute('type', 'application/javascript');
       scriptEl1.setAttribute('data-id', 'test1');
@@ -1368,7 +1370,8 @@ describes.realWin('runtime multidoc', {
       return ampdoc.whenBodyAvailable();
     });
 
-    it('should ignore unknown script', () => {
+    // TODO(dvoytenko, #14336): Fails due to console errors.
+    it.skip('should ignore unknown script', () => {
       shadowDoc = win.AMP.attachShadowDocAsStream(hostElement, docUrl);
       writer = shadowDoc.writer;
       extensionsMock.expects('preloadExtension').never();
@@ -1434,7 +1437,8 @@ describes.realWin('runtime multidoc', {
       });
     });
 
-    it('should ignore inline script if javascript', () => {
+    // TODO(dvoytenko, #14336): Fails due to console errors.
+    it.skip('should ignore inline script if javascript', () => {
       shadowDoc = win.AMP.attachShadowDocAsStream(hostElement, docUrl);
       writer = shadowDoc.writer;
       writer.write(

--- a/test/functional/test-sanitizer.js
+++ b/test/functional/test-sanitizer.js
@@ -136,7 +136,8 @@ describe('sanitizeHtml', () => {
         + '<a target="_top">other</a>');
   });
 
-  it('should NOT output security-sensitive attributes', () => {
+  // TODO(dvoytenko, #14336): Fails due to console errors.
+  it.skip('should NOT output security-sensitive attributes', () => {
     expect(sanitizeHtml('a<a onclick="alert">b</a>')).to.be.equal('a<a>b</a>');
     expect(sanitizeHtml('a<a style="color: red;">b</a>')).to.be.equal(
         'a<a>b</a>');
@@ -160,12 +161,14 @@ describe('sanitizeHtml', () => {
         'a<a target="_top">b</a>');
   });
 
-  it('should catch attribute value whitespace variations', () => {
+  // TODO(dvoytenko, #14336): Fails due to console errors.
+  it.skip('should catch attribute value whitespace variations', () => {
     expect(sanitizeHtml('a<a href=" j\na\tv\ra s&#00;cript:alert">b</a>'))
         .to.be.equal('a<a target="_top">b</a>');
   });
 
-  it('should NOT output security-sensitive attributes', () => {
+  // TODO(dvoytenko, #14336): Fails due to console errors.
+  it.skip('should NOT output security-sensitive attributes', () => {
     expect(sanitizeHtml('a<a onclick="alert">b</a>')).to.be.equal('a<a>b</a>');
     expect(sanitizeHtml('a<a [onclick]="alert">b</a>')).to.be
         .equal('a<a>b</a>');
@@ -183,7 +186,8 @@ describe('sanitizeHtml', () => {
         .equal('<p [text]="foo" [class]="bar"></p>');
   });
 
-  it('should NOT output blacklisted values for class attributes', () => {
+  // TODO(dvoytenko, #14336): Fails due to console errors.
+  it.skip('should NOT output blacklisted values for class attributes', () => {
     expect(sanitizeHtml('<p class="i-amphtml-">hello</p>')).to.be
         .equal('<p>hello</p>');
     expect(sanitizeHtml('<p class="i-amphtml-class">hello</p>')).to.be
@@ -198,7 +202,8 @@ describe('sanitizeHtml', () => {
         .equal('<p>hello</p>');
   });
 
-  it('should NOT output security-sensitive binding attributes', () => {
+  // TODO(dvoytenko, #14336): Fails due to console errors.
+  it.skip('should NOT output security-sensitive binding attributes', () => {
     expect(sanitizeHtml('a<a [onclick]="alert">b</a>')).to.be.equal(
         'a<a>b</a>');
     expect(sanitizeHtml('a<a [style]="color: red;">b</a>')).to.be.equal(
@@ -438,17 +443,20 @@ describe('sanitizeFormattingHtml', () => {
           .to.equal('<div style="color:blue">Test</div>');
     });
 
-    it('should ignore styles containing `!important`',() => {
+    // TODO(choumx, #14336): Fails due to console errors.
+    it.skip('should ignore styles containing `!important`',() => {
       expect(sanitizeHtml('<div style="color:blue!important">Test</div>'))
           .to.equal('<div>Test</div>');
     });
 
-    it('should ignore styles containing `position:fixed`', () => {
+    // TODO(choumx, #14336): Fails due to console errors.
+    it.skip('should ignore styles containing `position:fixed`', () => {
       expect(sanitizeHtml('<div style="position:fixed">Test</div>'))
           .to.equal('<div>Test</div>');
     });
 
-    it('should ignore styles containing `position:sticky`', () => {
+    // TODO(choumx, #14336): Fails due to console errors.
+    it.skip('should ignore styles containing `position:sticky`', () => {
       expect(sanitizeHtml('<div style="position:sticky">Test</div>'))
           .to.equal('<div>Test</div>');
     });

--- a/test/functional/test-service.js
+++ b/test/functional/test-service.js
@@ -447,7 +447,8 @@ describe('service', () => {
       expect(getServiceForDoc(grandChildWinNode, 'c')).to.equal(c);
     });
 
-    it('should dispose disposable services', () => {
+    // TODO(dvoytenko, #14336): Fails due to console errors.
+    it.skip('should dispose disposable services', () => {
       const disposableFactory = function() {
         return {
           dispose: sandbox.spy(),

--- a/test/functional/test-shadow-embed.js
+++ b/test/functional/test-shadow-embed.js
@@ -41,7 +41,8 @@ describes.sandboxed('shadow-embed', {}, () => {
 
   [ShadowDomVersion.NONE, ShadowDomVersion.V0, ShadowDomVersion.V1]
       .forEach(scenario => {
-        describe('shadow APIs ' + scenario, () => {
+        // TODO(dvoytenko, #14336): Fails due to console errors.
+        describe.skip('shadow APIs ' + scenario, () => {
           let hostElement;
 
           beforeEach(function() {

--- a/test/functional/test-standard-actions.js
+++ b/test/functional/test-standard-actions.js
@@ -290,7 +290,8 @@ describes.sandboxed('StandardActions', {}, () => {
       });
     });
 
-    it('should not allow chained setState', () => {
+    // TODO(choumx, #14336): Fails due to console errors.
+    it.skip('should not allow chained setState', () => {
       const spy = sandbox.spy();
       window.services.bind = {
         obj: {

--- a/test/functional/test-storage.js
+++ b/test/functional/test-storage.js
@@ -166,7 +166,8 @@ describe('Storage', () => {
     });
   });
 
-  it('should recover from binding failure', () => {
+  // TODO(dvoytenko, #14336): Fails due to console errors.
+  it.skip('should recover from binding failure', () => {
     bindingMock.expects('loadBlob')
         .withExactArgs('https://acme.com')
         .returns(Promise.reject('intentional'))
@@ -179,7 +180,8 @@ describe('Storage', () => {
     });
   });
 
-  it('should recover from binding error', () => {
+  // TODO(dvoytenko, #14336): Fails due to console errors.
+  it.skip('should recover from binding error', () => {
     bindingMock.expects('loadBlob')
         .withExactArgs('https://acme.com')
         .returns(Promise.resolve('UNKNOWN FORMAT'))
@@ -445,7 +447,8 @@ describe('LocalStorageBinding', () => {
     sandbox.restore();
   });
 
-  it('should throw if localStorage is not supported', () => {
+  // TODO(erwinmombay, #14336): Fails due to console errors.
+  it.skip('should throw if localStorage is not supported', () => {
     const errorSpy = sandbox.spy(dev(), 'expectedError');
 
     expect(errorSpy).to.have.not.been.called;
@@ -503,7 +506,8 @@ describe('LocalStorageBinding', () => {
         });
   });
 
-  it('should bypass loading from localStorage if getItem throws', () => {
+  // TODO(newmuis, #14336): Fails due to console errors.
+  it.skip('should bypass loading from localStorage if getItem throws', () => {
     localStorageMock.expects('getItem')
         .throws(new Error('unknown'))
         .once();
@@ -546,7 +550,8 @@ describe('LocalStorageBinding', () => {
         });
   });
 
-  it('should bypass saving to localStorage if getItem throws', () => {
+  // TODO(newmuis, #14336): Fails due to console errors.
+  it.skip('should bypass saving to localStorage if getItem throws', () => {
     const setItemSpy = sandbox.spy(windowApi.localStorage, 'setItem');
 
     localStorageMock.expects('getItem')

--- a/test/functional/test-viewer-cid-api.js
+++ b/test/functional/test-viewer-cid-api.js
@@ -86,7 +86,8 @@ describes.realWin('viewerCidApi', {amp: true}, env => {
       return verifyClientIdApiInUse(false);
     });
 
-    it('should not use client ID API if vendor not whitelisted', () => {
+    // TODO(lannka, #14336): Fails due to console errors.
+    it.skip('should not use client ID API if vendor not whitelisted', () => {
       ampdoc.win.document.head.innerHTML +=
           '<meta name="amp-google-client-id-api" content="abodeanalytics">';
       return verifyClientIdApiInUse(false);

--- a/test/integration/test-3p-frame.js
+++ b/test/integration/test-3p-frame.js
@@ -334,7 +334,8 @@ describe.configure().ifNewChrome().run('3p-frame', () => {
     }).to.throw(/must not be on the same origin as the/);
   });
 
-  it('should pick default url if custom disabled', () => {
+  // TODO(keithwrightbos, #14336): Fails due to console errors.
+  it.skip('should pick default url if custom disabled', () => {
     addCustomBootstrap('http://localhost:9876/boot/remote.html');
     expect(getBootstrapBaseUrl(window, true, undefined, true)).to.equal(
         'http://ads.localhost:9876/dist.3p/current/frame.max.html');
@@ -362,7 +363,8 @@ describe.configure().ifNewChrome().run('3p-frame', () => {
     });
   });
 
-  it('should prefetch default bootstrap frame if custom disabled', () => {
+  // TODO(keithwrightbos, #14336): Fails due to console errors.
+  it.skip('should prefetch default bootstrap frame if custom disabled', () => {
     window.AMP_MODE = {localDev: true};
     addCustomBootstrap('http://localhost:9876/boot/remote.html');
     preloadBootstrap(window, preconnect, undefined, true);

--- a/test/integration/test-video-players-helper.js
+++ b/test/integration/test-video-players-helper.js
@@ -67,7 +67,8 @@ export function runVideoPlayerIntegrationTests(
     return button;
   }
 
-  describe.configure().ifNewChrome().run('Video Interface', function() {
+  // TODO(alanorozco, #14336): Fails due to console errors.
+  describe.skip('Video Interface', function() {
     this.timeout(TIMEOUT);
 
     it('should override the video interface methods', function() {
@@ -89,7 +90,8 @@ export function runVideoPlayerIntegrationTests(
     afterEach(cleanUp);
   });
 
-  describe.configure().ifNewChrome().run('Actions', function() {
+  // TODO(alanorozco, #14336): Fails due to console errors.
+  describe.skip('Actions', function() {
     this.timeout(TIMEOUT);
 
     it('should support mute, play, pause, unmute actions', function() {
@@ -138,7 +140,8 @@ export function runVideoPlayerIntegrationTests(
     afterEach(cleanUp);
   });
 
-  describe.configure().ifNewChrome().run('Analytics Triggers', function() {
+  // TODO(alanorozco, #14336): Fails due to console errors.
+  describe.skip('Analytics Triggers', function() {
     this.timeout(TIMEOUT);
     let video;
 
@@ -327,7 +330,8 @@ export function runVideoPlayerIntegrationTests(
     afterEach(cleanUp);
   });
 
-  describe.configure().ifNewChrome().run('Video Docking', function() {
+  // TODO(alanorozco, #14336): Fails due to console errors.
+  describe.skip('Video Docking', function() {
     this.timeout(TIMEOUT);
 
     describe('General Behavior', () => {
@@ -345,7 +349,8 @@ export function runVideoPlayerIntegrationTests(
         });
       });
 
-      it('should have class when attribute is set (no-autoplay)', function() {
+      it('should have class when attribute is set ' +
+          '(no-autoplay)', function() {
         return getVideoPlayer(
             {
               outsideView: false,
@@ -407,7 +412,8 @@ export function runVideoPlayerIntegrationTests(
       });
     });
 
-    describe('with-autoplay', () => {
+    // TODO(aghassemi, #14336): Fails due to console errors.
+    describe.skip('with-autoplay', () => {
       it('should minimize when out of viewport', function() {
         let viewport;
         let video;
@@ -500,7 +506,8 @@ export function runVideoPlayerIntegrationTests(
     afterEach(cleanUp);
   });
 
-  describe.configure().ifNewChrome().run('Autoplay', function() {
+  // TODO(alanorozco, #14336): Fails due to console errors.
+  describe.skip('Autoplay', function() {
     this.timeout(TIMEOUT);
 
     describe('play/pause', () => {

--- a/test/integration/test-visibility-states.js
+++ b/test/integration/test-visibility-states.js
@@ -20,7 +20,8 @@ import {createCustomEvent} from '../../src/event-helper';
 import {getVendorJsPropertyName} from '../../src/style';
 import {whenUpgradedToCustomElement} from '../../src/dom';
 
-describe.configure().ifNewChrome().run('Viewer Visibility State', () => {
+// TODO(jridgewell, #14336): Fails due to console errors.
+describe.skip('Viewer Visibility State', () => {
 
   function noop() {}
 
@@ -126,7 +127,8 @@ describe.configure().ifNewChrome().run('Viewer Visibility State', () => {
     });
 
     describe('from in the PRERENDER state', () => {
-      describe('for prerenderable element', () => {
+      // TODO(jridgewell, #14336): Fails due to console errors.
+      describe.skip('for prerenderable element', () => {
         beforeEach(() => {
           prerenderAllowed.returns(true);
           setupSpys();


### PR DESCRIPTION
Calls to `console.info`, `console.log`, `console.warn`, and `console.error` are suppressed during AMP tests due to the `client.captureConsole: false` configuration value in `karma-conf.js`. If not for this, the test logs will become extremely noisy. However, suppressing `console.error` in particular is a bad thing, since genuine runtime errors during tests can get masked.

This PR does the following:
- Stubs calls to `console.error` during tests and surfaces them as mocha test errors, causing the individual test that generated the error to fail with a useful message. Other tests will continue to be run like normal.
- Fixes / skips tests that were silently passing earlier, but now fail due to a legitimate console error from the runtime.

**General instructions:** If a test you wrote was skipped by this PR, unskip it and see what the `console.error` is all about.
- If it is a genuine error, fix it.
- If the error is expected during the test, use an `expect` block around the code that generates the error.

This will pass...
```
expect(() => {
  console.error('foo');
}).to.throw('foo');
```
... and this will fail...
```
expect(() => {
  console.error('foo');
}).to.throw('bar');
```

Fixes #7381
Partial fix for #14360
