### PR TITLE
Doubleclick/AdSense Fast Fetch: Active View w/o immediate experiment

### DIFF
--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -405,8 +405,9 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
             this.lifecycleReporter_.getDeltaTime(),
             this.lifecycleReporter_.getInitTime());
       }
-      this.ampAnalyticsElement_ =
-          insertAnalyticsElement(this.element, this.ampAnalyticsConfig_, true);
+      this.ampAnalyticsElement_ = insertAnalyticsElement(
+          this.element, this.ampAnalyticsConfig_, /*loadAnalytics*/ true,
+          !!this.postAdResponseExperimentFeatures['avr_disable_immediate']);
     }
 
     this.lifecycleReporter_.addPingsForVisibility(this.element);

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
@@ -229,62 +229,70 @@ describes.realWin('amp-ad-network-adsense-impl', {
       sandbox.stub(env.ampdocService, 'getAmpDoc').callsFake(() => ampdoc);
     });
 
-    it('injects amp analytics', () => {
-      impl.ampAnalyticsConfig_ = {
-        transport: {beacon: false, xhrpost: false},
-        requests: {
-          visibility1: 'https://foo.com?hello=world',
-          visibility2: 'https://bar.com?a=b',
-        },
-        triggers: {
-          continuousVisible: {
-            on: 'visible',
-            request: ['visibility1', 'visibility2'],
-            visibilitySpec: {
+    [true, false].forEach(exp => {
+      it('injects amp analytics' +
+        (exp ? ', trigger immediate disable exp' : ''), () => {
+        impl.ampAnalyticsConfig_ = {
+          transport: {beacon: false, xhrpost: false},
+          requests: {
+            visibility1: 'https://foo.com?hello=world',
+            visibility2: 'https://bar.com?a=b',
+          },
+          triggers: {
+            continuousVisible: {
+              on: 'visible',
+              request: ['visibility1', 'visibility2'],
+              visibilitySpec: {
+                selector: 'amp-ad',
+                selectionMethod: 'closest',
+                visiblePercentageMin: 50,
+                continuousTimeMin: 1000,
+              },
+            },
+            continuousVisibleIniLoad: {
+              on: 'ini-load',
               selector: 'amp-ad',
               selectionMethod: 'closest',
-              visiblePercentageMin: 50,
-              continuousTimeMin: 1000,
+            },
+            continuousVisibleRenderStart: {
+              on: 'render-start',
+              selector: 'amp-ad',
+              selectionMethod: 'closest',
             },
           },
-          continuousVisibleIniLoad: {
-            on: 'ini-load',
-            selector: 'amp-ad',
-            selectionMethod: 'closest',
+        };
+        // To placate assertion.
+        impl.responseHeaders_ = {
+          get: function(name) {
+            if (name == 'X-QQID') {
+              return 'qqid_string';
+            }
           },
-          continuousVisibleRenderStart: {
-            on: 'render-start',
-            selector: 'amp-ad',
-            selectionMethod: 'closest',
+          has: function(name) {
+            if (name == 'X-QQID') {
+              return true;
+            }
           },
-        },
-      };
-      // To placate assertion.
-      impl.responseHeaders_ = {
-        get: function(name) {
-          if (name == 'X-QQID') {
-            return 'qqid_string';
-          }
-        },
-        has: function(name) {
-          if (name == 'X-QQID') {
-            return true;
-          }
-        },
-      };
-      // Next two lines are to ensure that internal parts not relevant for this
-      // test are properly set.
-      impl.size_ = {width: 200, height: 50};
-      impl.iframe = impl.win.document.createElement('iframe');
-      impl.onCreativeRender(false);
-      const ampAnalyticsElement = impl.element.querySelector('amp-analytics');
-      expect(ampAnalyticsElement).to.be.ok;
-      expect(ampAnalyticsElement.CONFIG).jsonEqual(impl.ampAnalyticsConfig_);
-      expect(ampAnalyticsElement.getAttribute('sandbox')).to.equal('true');
-      expect(impl.ampAnalyticsElement_).to.be.ok;
-      // Exact format of amp-analytics element covered in
-      // test/functional/test-analytics.js.
-      // Just ensure extensions is loaded, and analytics element appended.
+        };
+        // Next two lines are to ensure that internal parts not relevant for this
+        // test are properly set.
+        impl.size_ = {width: 200, height: 50};
+        impl.iframe = impl.win.document.createElement('iframe');
+        if (exp) {
+          impl.postAdResponseExperimentFeatures['avr_disable_immediate'] = '1';
+        }
+        impl.onCreativeRender(false);
+        const ampAnalyticsElement = impl.element.querySelector('amp-analytics');
+        expect(ampAnalyticsElement).to.be.ok;
+        expect(ampAnalyticsElement.CONFIG).jsonEqual(impl.ampAnalyticsConfig_);
+        expect(ampAnalyticsElement.getAttribute('sandbox')).to.equal('true');
+        expect(ampAnalyticsElement.getAttribute('trigger')).to.equal(
+            exp ? '' : 'immediate');
+        expect(impl.ampAnalyticsElement_).to.be.ok;
+        // Exact format of amp-analytics element covered in
+        // test/functional/test-analytics.js.
+        // Just ensure extensions is loaded, and analytics element appended.
+      });
     });
 
     it('should register click listener', () => {

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -900,8 +900,9 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
             this.lifecycleReporter_.getDeltaTime(),
             this.lifecycleReporter_.getInitTime());
       }
-      this.ampAnalyticsElement_ =
-          insertAnalyticsElement(this.element, this.ampAnalyticsConfig_, true);
+      this.ampAnalyticsElement_ = insertAnalyticsElement(
+          this.element, this.ampAnalyticsConfig_, /*loadAnalytics*/ true,
+          !!this.postAdResponseExperimentFeatures['avr_disable_immediate']);
     }
     if (this.isRefreshing) {
       dev().assert(this.refreshManager_);

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -272,57 +272,66 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
       });
     });
 
-    it('injects amp analytics', () => {
-      impl.ampAnalyticsConfig_ = {
-        transport: {beacon: false, xhrpost: false},
-        requests: {
-          visibility1: 'https://foo.com?hello=world',
-          visibility2: 'https://bar.com?a=b',
-        },
-        triggers: {
-          continuousVisible: {
-            on: 'visible',
-            request: ['visibility1', 'visibility2'],
-            visibilitySpec: {
+    [true, false].forEach(exp => {
+      it('injects amp analytics' +
+        (exp ? ', trigger immediate disable exp' : ''), () => {
+        impl.ampAnalyticsConfig_ = {
+          transport: {beacon: false, xhrpost: false},
+          requests: {
+            visibility1: 'https://foo.com?hello=world',
+            visibility2: 'https://bar.com?a=b',
+          },
+          triggers: {
+            continuousVisible: {
+              on: 'visible',
+              request: ['visibility1', 'visibility2'],
+              visibilitySpec: {
+                selector: 'amp-ad',
+                selectionMethod: 'closest',
+                visiblePercentageMin: 50,
+                continuousTimeMin: 1000,
+              },
+            },
+            continuousVisibleIniLoad: {
+              on: 'ini-load',
               selector: 'amp-ad',
               selectionMethod: 'closest',
-              visiblePercentageMin: 50,
-              continuousTimeMin: 1000,
+            },
+            continuousVisibleRenderStart: {
+              on: 'render-start',
+              selector: 'amp-ad',
+              selectionMethod: 'closest',
             },
           },
-          continuousVisibleIniLoad: {
-            on: 'ini-load',
-            selector: 'amp-ad',
-            selectionMethod: 'closest',
+        };
+        // To placate assertion.
+        impl.responseHeaders_ = {
+          get: function(name) {
+            if (name == 'X-QQID') {
+              return 'qqid_string';
+            }
           },
-          continuousVisibleRenderStart: {
-            on: 'render-start',
-            selector: 'amp-ad',
-            selectionMethod: 'closest',
+          has: function(name) {
+            if (name == 'X-QQID') {
+              return true;
+            }
           },
-        },
-      }; // To placate assertion.
-      impl.responseHeaders_ = {
-        get: function(name) {
-          if (name == 'X-QQID') {
-            return 'qqid_string';
-          }
-        },
-        has: function(name) {
-          if (name == 'X-QQID') {
-            return true;
-          }
-        },
-      };
-      impl.onCreativeRender(false);
-      const ampAnalyticsElement = impl.element.querySelector('amp-analytics');
-      expect(ampAnalyticsElement).to.be.ok;
-      expect(ampAnalyticsElement.CONFIG).jsonEqual(impl.ampAnalyticsConfig_);
-      expect(ampAnalyticsElement.getAttribute('sandbox')).to.equal('true');
-      expect(impl.ampAnalyticsElement_).to.be.ok;
-      // Exact format of amp-analytics element covered in
-      // test/functional/test-analytics.js.
-      // Just ensure extensions is loaded, and analytics element appended.
+        };
+        if (exp) {
+          impl.postAdResponseExperimentFeatures['avr_disable_immediate'] = '1';
+        }
+        impl.onCreativeRender(false);
+        const ampAnalyticsElement = impl.element.querySelector('amp-analytics');
+        expect(ampAnalyticsElement).to.be.ok;
+        expect(ampAnalyticsElement.CONFIG).jsonEqual(impl.ampAnalyticsConfig_);
+        expect(ampAnalyticsElement.getAttribute('sandbox')).to.equal('true');
+        expect(ampAnalyticsElement.getAttribute('trigger')).to.equal(
+            exp ? '' : 'immediate');
+        expect(impl.ampAnalyticsElement_).to.be.ok;
+        // Exact format of amp-analytics element covered in
+        // test/functional/test-analytics.js.
+        // Just ensure extensions is loaded, and analytics element appended.
+      });
     });
 
     it('should register click listener', () => {

--- a/src/extension-analytics.js
+++ b/src/extension-analytics.js
@@ -31,16 +31,17 @@ import {triggerAnalyticsEvent} from './analytics';
  * @param {!Element} parentElement
  * @param {!JsonObject} config
  * @param {boolean=} loadAnalytics
+ * @param {boolean=} disableImmediate
  * @return {!Element} created analytics element
  */
 export function insertAnalyticsElement(
-  parentElement, config, loadAnalytics = false) {
+  parentElement, config, loadAnalytics = false, disableImmediate = false) {
   const doc = /** @type {!Document} */ (parentElement.ownerDocument);
   const analyticsElem = createElementWithAttributes(
       doc,
       'amp-analytics', dict({
         'sandbox': 'true',
-        'trigger': 'immediate',
+        'trigger': disableImmediate ? '' : 'immediate',
       }));
   const scriptElem = createElementWithAttributes(
       doc,

--- a/test/functional/test-extension-analytics.js
+++ b/test/functional/test-extension-analytics.js
@@ -54,36 +54,41 @@ describes.realWin('extension-analytics', {
       sandbox.restore();
     });
 
-    it('should create analytics element if analytics is installed', () => {
-      const ele = win.document.createElement('div');
-      win.document.body.appendChild(ele);
-      const baseEle = new BaseElement(ele);
-      registerServiceBuilderForDoc(
-          ampdoc, 'amp-analytics-instrumentation', MockInstrumentation);
-      // Force instantiation
-      getServiceForDoc(ampdoc, 'amp-analytics-instrumentation');
-      const config = {
-        'requests': {
-          'pageview': 'https://example.com/analytics',
-        },
-        'triggers': {
-          'trackPageview': {
-            'on': 'visible',
-            'request': 'pageview',
+    [true, false].forEach(disableImmediate => {
+      it('should create analytics element if analytics is installed, ' +
+          `disableImmediate ${disableImmediate}`, () => {
+        const config = {
+          'requests': {
+            'pageview': 'https://example.com/analytics',
           },
-        },
-      };
-      expect(baseEle.element.querySelector('amp-analytics')).to.be.null;
-      expect(insertAnalyticsElement(baseEle.element, config, true)).to.be.ok;
-      return timer.promise(50).then(() => {
-        const analyticsEle = baseEle.element.querySelector('amp-analytics');
-        expect(analyticsEle).to.not.be.null;
-        expect(analyticsEle.getAttribute('sandbox')).to.equal('true');
-        expect(analyticsEle.getAttribute('trigger')).to.equal('immediate');
-        const script = (analyticsEle).querySelector('script');
-        expect(script.textContent).to.jsonEqual(JSON.stringify(config));
-        expect(analyticsEle.CONFIG).to.jsonEqual(config);
-        expect(analyticsEle.getAttribute('sandbox')).to.equal('true');
+          'triggers': {
+            'trackPageview': {
+              'on': 'visible',
+              'request': 'pageview',
+            },
+          },
+        };
+        const ele = win.document.createElement('div');
+        win.document.body.appendChild(ele);
+        const baseEle = new BaseElement(ele);
+        registerServiceBuilderForDoc(
+            ampdoc, 'amp-analytics-instrumentation', MockInstrumentation);
+        // Force instantiation
+        getServiceForDoc(ampdoc, 'amp-analytics-instrumentation');
+        expect(baseEle.element.querySelector('amp-analytics')).to.be.null;
+        expect(insertAnalyticsElement(
+            baseEle.element, config, true, disableImmediate)).to.be.ok;
+        return timer.promise(50).then(() => {
+          const analyticsEle = baseEle.element.querySelector('amp-analytics');
+          expect(analyticsEle).to.not.be.null;
+          expect(analyticsEle.getAttribute('sandbox')).to.equal('true');
+          expect(analyticsEle.getAttribute('trigger')).to.equal(
+              disableImmediate ? '' : 'immediate');
+          const script = (analyticsEle).querySelector('script');
+          expect(script.textContent).to.jsonEqual(JSON.stringify(config));
+          expect(analyticsEle.CONFIG).to.jsonEqual(config);
+          expect(analyticsEle.getAttribute('sandbox')).to.equal('true');
+        });
       });
     });
   });
@@ -465,5 +470,3 @@ describes.realWin('extension-analytics', {
     });
   });
 });
-
-


### PR DESCRIPTION
Active View integration for Doubleclick/AdSense Fast Fetch utilizes amp-analytics outside of the creative (measuring containing frame state) which currently gets trigger=immediate treatment.  This was intentional as delayed fetch creatives have no such constraints given they run any 3rd party JS independent of AMP lifecycle.  However, this causes amp analytics to execute at high priority than default of 1 and independent of viewport location while amp-analytics within the creative does not get such lift.  Result is possible delta in measurement.  Create experiment that allows for measuring impact of removing trigger=immediate.