### PR TITLE
Change store service registration

### DIFF
--- a/src/services.js
+++ b/src/services.js
@@ -300,7 +300,7 @@ export class Services {
   static storyStoreServiceForOrNull(win) {
     return (
     /** @type {!Promise<?../extensions/amp-story/0.1/amp-story-store-service.AmpStoryStoreService>} */
-      (getElementServiceIfAvailable(win, 'story-store', 'amp-story', true)));
+      (getElementServiceIfAvailable(win, 'story-store', 'amp-story')));
   }
 
   /**


### PR DESCRIPTION
Under its current implementation if a separate extension `amp-story-auto-ads` tries to access the store it will return `null` if `amp-story` has not yet registered it. 

I found some detail on the `opt_element` parameter [here](https://github.com/ampproject/amphtml/pull/9386). It seems that the distinction is if the service is registered in the extension itself (register element, maybe constructor) vs in the element code (lifecycle etc). 

The actual codepath for my use case differs [here](https://github.com/ampproject/amphtml/blob/9099c9edbd72d578eaab5a19be10a1143bf165aa/src/element-service.js#L132-L136). If `opt_element === true` it returns `null` rather than waiting for the registration.

This is still a bit convoluted because I could see a use case where you want a promise for the service even though the service is registered by a lifecycle callback or a optional child element or something of the like. 