### PR TITLE
Overwrite or set attr target=_blank in outlinks for amp-story

### DIFF
--- a/extensions/amp-story/0.1/amp-story-cta-layer.js
+++ b/extensions/amp-story/0.1/amp-story-cta-layer.js
@@ -51,7 +51,6 @@ export class AmpStoryCtaLayer extends AmpStoryBaseLayer {
   }
 
   applyTargetAttribute_(){
-    console.log(this.element);
     // Overwrite or set target attribute to _top in call to action links.
     const ctaLinks = this.element.querySelectorAll('a');
     for (let i = 0; i < ctaLinks.length; i++) {

--- a/extensions/amp-story/0.1/amp-story-cta-layer.js
+++ b/extensions/amp-story/0.1/amp-story-cta-layer.js
@@ -54,10 +54,10 @@ export class AmpStoryCtaLayer extends AmpStoryBaseLayer {
    * Overwrite or set target attribute to _blank in call-to-action links.
    * @private
    */
-  setOrOverwriteTargetAttribute_(){
+  setOrOverwriteTargetAttribute_() {
     const ctaLinks = this.element.querySelectorAll('a');
     for (let i = 0; i < ctaLinks.length; i++) {
-      ctaLinks[i].target = '_blank';
+      ctaLinks[i].setAttribute('target', '_blank');
     }
   }
 }

--- a/extensions/amp-story/0.1/amp-story-cta-layer.js
+++ b/extensions/amp-story/0.1/amp-story-cta-layer.js
@@ -43,6 +43,21 @@ export class AmpStoryCtaLayer extends AmpStoryBaseLayer {
      */
     return false;
   }
+
+  /** @override */
+  buildCallback() {
+    super.buildCallback();
+    this.applyTargetAttribute_();
+  }
+
+  applyTargetAttribute_(){
+    console.log(this.element);
+    // Overwrite or set target attribute to _top in call to action links.
+    const ctaLinks = this.element.querySelectorAll('a');
+    for (let i = 0; i < ctaLinks.length; i++) {
+      ctaLinks[i].target = '_blank';
+    }
+  }
 }
 
 AMP.registerElement('amp-story-cta-layer', AmpStoryCtaLayer);

--- a/extensions/amp-story/0.1/amp-story-cta-layer.js
+++ b/extensions/amp-story/0.1/amp-story-cta-layer.js
@@ -50,7 +50,10 @@ export class AmpStoryCtaLayer extends AmpStoryBaseLayer {
     this.setOrOverwriteTargetAttribute_();
   }
 
-  // Overwrite or set target attribute to _blank in call to action links.
+  /**
+   * Overwrite or set target attribute to _blank in call-to-action links.
+   * @private
+   */
   setOrOverwriteTargetAttribute_(){
     const ctaLinks = this.element.querySelectorAll('a');
     for (let i = 0; i < ctaLinks.length; i++) {

--- a/extensions/amp-story/0.1/amp-story-cta-layer.js
+++ b/extensions/amp-story/0.1/amp-story-cta-layer.js
@@ -47,11 +47,11 @@ export class AmpStoryCtaLayer extends AmpStoryBaseLayer {
   /** @override */
   buildCallback() {
     super.buildCallback();
-    this.applyTargetAttribute_();
+    this.setOrOverwriteTargetAttribute_();
   }
 
-  applyTargetAttribute_(){
-    // Overwrite or set target attribute to _top in call to action links.
+  // Overwrite or set target attribute to _blank in call to action links.
+  setOrOverwriteTargetAttribute_(){
     const ctaLinks = this.element.querySelectorAll('a');
     for (let i = 0; i < ctaLinks.length; i++) {
       ctaLinks[i].target = '_blank';

--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -25,8 +25,8 @@
  * </code>
  */
 import './amp-story-auto-ads';
-import './amp-story-grid-layer';
 import './amp-story-cta-layer';
+import './amp-story-grid-layer';
 import './amp-story-page';
 import {
   Action,

--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -26,6 +26,7 @@
  */
 import './amp-story-auto-ads';
 import './amp-story-grid-layer';
+import './amp-story-cta-layer';
 import './amp-story-page';
 import {
   Action,

--- a/extensions/amp-story/0.1/test/test-amp-story-cta-layer.js
+++ b/extensions/amp-story/0.1/test/test-amp-story-cta-layer.js
@@ -27,7 +27,8 @@ describes.realWin('amp-story-cta-layer', {
 
   beforeEach(() => {
     win = env.win;
-    const ampStoryCtaLayerEl = win.document.createElement('amp-story-cta-layer');
+    const ampStoryCtaLayerEl =
+      win.document.createElement('amp-story-cta-layer');
     win.document.body.appendChild(ampStoryCtaLayerEl);
     ampStoryCtaLayer = new AmpStoryCtaLayer(ampStoryCtaLayerEl);
   });
@@ -40,7 +41,7 @@ describes.realWin('amp-story-cta-layer', {
   });
 
   it('should add or overwrite target attribute to links', () => {
-    let ctaLink = win.document.createElement('a');
+    const ctaLink = win.document.createElement('a');
     expect(ctaLink).to.not.have.attribute('target');
 
     ampStoryCtaLayer.element.appendChild(ctaLink);

--- a/extensions/amp-story/0.1/test/test-amp-story-cta-layer.js
+++ b/extensions/amp-story/0.1/test/test-amp-story-cta-layer.js
@@ -53,4 +53,14 @@ describes.realWin('amp-story-cta-layer', {
     });
   });
 
+  it('should not add target attribute to other elements', () => {
+    const elem = win.document.createElement('span');
+    ampStoryCtaLayer.element.appendChild(elem);
+    ampStoryCtaLayer.buildCallback();
+
+    return ampStoryCtaLayer.layoutCallback().then(() => {
+      expect(elem).to.not.have.attribute('target');
+    });
+  });
+
 });

--- a/extensions/amp-story/0.1/test/test-amp-story-cta-layer.js
+++ b/extensions/amp-story/0.1/test/test-amp-story-cta-layer.js
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {AmpStoryCtaLayer} from '../amp-story-cta-layer';
+
+describes.realWin('amp-story-cta-layer', {
+  amp: {
+    runtimeOn: true,
+    extensions: ['amp-story'],
+  },
+}, env => {
+  let win;
+  let ampStoryCtaLayer;
+  let ampStoryCtaLayerEl;
+
+  beforeEach(() => {
+    win = env.win;
+    ampStoryCtaLayerEl = win.document.createElement('amp-story-cta-layer');
+    win.document.body.appendChild(ampStoryCtaLayerEl);
+    ampStoryCtaLayer = new AmpStoryCtaLayer(ampStoryCtaLayerEl);
+  });
+
+  it('should build the cta layer', () => {
+    ampStoryCtaLayer.buildCallback();
+    return ampStoryCtaLayer.layoutCallback().then(() => {
+      expect(
+        ampStoryCtaLayer.element.classList.contains('i-amphtml-story-layer'))
+          .to.be.true;
+    });
+  });
+
+  it('should add or overwrite target attribute to links', () => {
+    let ctaLink = win.document.createElement('a');
+    expect(ctaLink.hasAttribute('target')).to.be.false;
+
+    ampStoryCtaLayer.element.appendChild(ctaLink);
+    ampStoryCtaLayer.buildCallback();
+
+    return ampStoryCtaLayer.layoutCallback().then(() => {
+      expect(ctaLink.hasAttribute('target')).to.be.true;
+      expect(ctaLink.getAttribute('target')).to.equal('_blank');
+    });
+  });
+
+});

--- a/extensions/amp-story/0.1/test/test-amp-story-cta-layer.js
+++ b/extensions/amp-story/0.1/test/test-amp-story-cta-layer.js
@@ -24,11 +24,10 @@ describes.realWin('amp-story-cta-layer', {
 }, env => {
   let win;
   let ampStoryCtaLayer;
-  let ampStoryCtaLayerEl;
 
   beforeEach(() => {
     win = env.win;
-    ampStoryCtaLayerEl = win.document.createElement('amp-story-cta-layer');
+    const ampStoryCtaLayerEl = win.document.createElement('amp-story-cta-layer');
     win.document.body.appendChild(ampStoryCtaLayerEl);
     ampStoryCtaLayer = new AmpStoryCtaLayer(ampStoryCtaLayerEl);
   });
@@ -36,21 +35,19 @@ describes.realWin('amp-story-cta-layer', {
   it('should build the cta layer', () => {
     ampStoryCtaLayer.buildCallback();
     return ampStoryCtaLayer.layoutCallback().then(() => {
-      expect(
-        ampStoryCtaLayer.element.classList.contains('i-amphtml-story-layer'))
-          .to.be.true;
+      expect(ampStoryCtaLayer.element).to.have.class('i-amphtml-story-layer');
     });
   });
 
   it('should add or overwrite target attribute to links', () => {
     let ctaLink = win.document.createElement('a');
-    expect(ctaLink.hasAttribute('target')).to.be.false;
+    expect(ctaLink).to.not.have.attribute('target');
 
     ampStoryCtaLayer.element.appendChild(ctaLink);
     ampStoryCtaLayer.buildCallback();
 
     return ampStoryCtaLayer.layoutCallback().then(() => {
-      expect(ctaLink.hasAttribute('target')).to.be.true;
+      expect(ctaLink).to.have.attribute('target');
       expect(ctaLink.getAttribute('target')).to.equal('_blank');
     });
   });


### PR DESCRIPTION
Fixes #13775

Also imports `amp-story-cta-layer` in `amp-story`.