### PR TITLE
Remove defaults for freshLifetimeSecs and validLifetimeSecs

### DIFF
--- a/ads/google/a4a/test/test-utils.js
+++ b/ads/google/a4a/test/test-utils.js
@@ -583,8 +583,8 @@ describe('Google A4A utils', () => {
         expect(result.token).to.equal('abc');
         expect(result.jar).to.equal('');
         expect(result.pucrd).to.equal('');
-        expect(result.freshLifetimeSecs).to.equal(3600);
-        expect(result.validLifetimeSecs).to.equal(86400);
+        expect(result.freshLifetimeSecs).to.equal(NaN);
+        expect(result.validLifetimeSecs).to.equal(NaN);
         expect(result.fetchTimeMs).to.be.at.least(0);
       });
     });
@@ -614,8 +614,8 @@ describe('Google A4A utils', () => {
         expect(result.token).to.equal('abc');
         expect(result.jar).to.equal('');
         expect(result.pucrd).to.equal('');
-        expect(result.freshLifetimeSecs).to.equal(3600);
-        expect(result.validLifetimeSecs).to.equal(86400);
+        expect(result.freshLifetimeSecs).to.equal(NaN);
+        expect(result.validLifetimeSecs).to.equal(NaN);
         expect(result.fetchTimeMs).to.be.at.least(0);
       });
     });

--- a/ads/google/a4a/test/test-utils.js
+++ b/ads/google/a4a/test/test-utils.js
@@ -577,14 +577,14 @@ describe('Google A4A utils', () => {
           'domain=f\.blah\.com';
     };
 
-    it('should fetch minimal token as expected', () => {
+    it('should ignore response if required fields are missing', () => {
       env.expectFetch(getUrl(), JSON.stringify({newToken: 'abc'}));
       return getIdentityToken(env.win, env.win.document).then(result => {
-        expect(result.token).to.equal('abc');
-        expect(result.jar).to.equal('');
-        expect(result.pucrd).to.equal('');
-        expect(result.freshLifetimeSecs).to.equal(NaN);
-        expect(result.validLifetimeSecs).to.equal(NaN);
+        expect(result.token).to.not.be.ok;
+        expect(result.jar).to.not.be.ok;
+        expect(result.pucrd).to.not.be.ok;
+        expect(result.freshLifetimeSecs).to.not.be.ok;
+        expect(result.validLifetimeSecs).to.not.be.ok;
         expect(result.fetchTimeMs).to.be.at.least(0);
       });
     });
@@ -609,13 +609,17 @@ describe('Google A4A utils', () => {
 
     it('should redirect as expected', () => {
       env.expectFetch(getUrl(), JSON.stringify({altDomain: '.google.fr'}));
-      env.expectFetch(getUrl('google\.fr'), JSON.stringify({newToken: 'abc'}));
+      env.expectFetch(getUrl('google\.fr'), JSON.stringify({
+        newToken: 'abc',
+        freshLifetimeSecs: '1234',
+        validLifetimeSecs: '5678',
+      }));
       return getIdentityToken(env.win, env.win.document).then(result => {
         expect(result.token).to.equal('abc');
         expect(result.jar).to.equal('');
         expect(result.pucrd).to.equal('');
-        expect(result.freshLifetimeSecs).to.equal(NaN);
-        expect(result.validLifetimeSecs).to.equal(NaN);
+        expect(result.freshLifetimeSecs).to.equal(1234);
+        expect(result.validLifetimeSecs).to.equal(5678);
         expect(result.fetchTimeMs).to.be.at.least(0);
       });
     });
@@ -633,7 +637,11 @@ describe('Google A4A utils', () => {
     });
 
     it('should use previous execution', () => {
-      const ident = {newToken: 'foo'};
+      const ident = {
+        newToken: 'foo',
+        freshLifetimeSecs: '1234',
+        validLifetimeSecs: '5678',
+      };
       env.win['goog_identity_prom'] = Promise.resolve(ident);
       return getIdentityToken(env.win, env.win.document)
           .then(result => expect(result).to.jsonEqual(ident));

--- a/ads/google/a4a/utils.js
+++ b/ads/google/a4a/utils.js
@@ -757,10 +757,8 @@ function executeIdentityTokenFetch(win, nodeOrDoc, redirectsRemaining = 1,
         const token = obj['newToken'];
         const jar = obj['1p_jar'] || '';
         const pucrd = obj['pucrd'] || '';
-        const freshLifetimeSecs =
-            parseInt(obj['freshLifetimeSecs'] || '', 10) || 3600;
-        const validLifetimeSecs =
-            parseInt(obj['validLifetimeSecs'] || '', 10) || 86400;
+        const freshLifetimeSecs = parseInt(obj['freshLifetimeSecs'] || '', 10);
+        const validLifetimeSecs = parseInt(obj['validLifetimeSecs'] || '', 10);
         const altDomain = obj['altDomain'];
         const fetchTimeMs = Date.now() - startTime;
         if (IDENTITY_DOMAIN_REGEXP_.test(altDomain)) {


### PR DESCRIPTION
The identity server now reliably sends these values, and indeed the team is starting to experiment with different timeouts, so these defaults are just complicating things.