### PR TITLE
Doubleclick Fast Fetch Auto SRA experiment

### DIFF
--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -280,7 +280,6 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     /** @private {number} */
     this.adKey_ = 0;
 
-    // TODO(keithwrightbos) - how can pub enable?
     /** @protected @const {boolean} */
     this.useSra = getMode().localDev && /(\?|&)force_sra=true(&|$)/.test(
         this.win.location.search) ||

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
@@ -169,13 +169,22 @@ export class DoubleclickA4aEligibility {
         }
         return false;
       }
+
     } else {
-      // See if in holdback control/experiment.
       if (urlExperimentId != undefined) {
         experimentId = URL_EXPERIMENT_MAPPING[urlExperimentId];
-        dev().info(
-            TAG,
-            `url experiment selection ${urlExperimentId}: ${experimentId}.`);
+        // For SRA experiments, do not include pages that are using refresh.
+        if ((experimentId == DOUBLECLICK_EXPERIMENT_FEATURE.SRA_CONTROL ||
+          experimentId == DOUBLECLICK_EXPERIMENT_FEATURE.SRA) &&
+          (win.document.querySelector('meta[name=amp-ad-enable-refresh]') ||
+           win.document.querySelector(
+               'amp-ad[type=doubleclick][data-enable-refresh]'))) {
+          experimentId = undefined;
+        } else {
+          dev().info(
+              TAG,
+              `url experiment selection ${urlExperimentId}: ${experimentId}.`);
+        }
       }
     }
     if (experimentId) {


### PR DESCRIPTION
Ensure that Doubleclick Fast Fetch experiment enabling SRA by default carves out pages using refresh as currently SRA + refresh is not supported.