### PR TITLE
✨ AdSense Ads: add support for specifying package code

### DIFF
--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -292,6 +292,9 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
       'rc': this.fromResumeCallback ? 1 : null,
       'rafmt': this.isResponsive_() ? 13 : null,
       'pfx': pfx ? '1' : '0',
+      // Package code (also known as URL group) that was used to 
+      // create ad.
+      'pwprc': this.element.getAttribute('data-package'),
     };
 
     const experimentIds = [];

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -292,7 +292,7 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
       'rc': this.fromResumeCallback ? 1 : null,
       'rafmt': this.isResponsive_() ? 13 : null,
       'pfx': pfx ? '1' : '0',
-      // Package code (also known as URL group) that was used to 
+      // Package code (also known as URL group) that was used to
       // create ad.
       'pwprc': this.element.getAttribute('data-package'),
     };

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
@@ -624,6 +624,14 @@ describes.realWin('amp-ad-network-adsense-impl', {
             regexp => expect(url).to.match(regexp));
       });
     });
+
+    it('includes adsense package code when present', () => {
+      element.setAttribute('data-package', 'package_code');
+      return impl.getAdUrl().then(url => {
+        expect(url).to.match(new RegExp(
+            'pwprc=package_code(&|$)'));
+      });
+    });
   });
 
   describe('#unlayoutCallback', () => {

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
@@ -627,10 +627,8 @@ describes.realWin('amp-ad-network-adsense-impl', {
 
     it('includes adsense package code when present', () => {
       element.setAttribute('data-package', 'package_code');
-      return impl.getAdUrl().then(url => {
-        expect(url).to.match(new RegExp(
-            'pwprc=package_code(&|$)'));
-      });
+      return expect(impl.getAdUrl()).to.eventually
+          .match(/pwprc=package_code(&|$)/);
     });
   });
 


### PR DESCRIPTION
Add support for `data-package` attribute to AdSense `<amp-ad>` element. This is required for integration between `<amp-auto-ads>` and `<amp-ad>` to which of the packages that publisher created in AdSense frontend was used to create ads. 