### PR TITLE
🏗 Use a JWT encoded sauce token

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ branches:
     - /^greenkeeper/.*$/
 env:
   global:
-    - SAUCE_USERNAME="amphtml-travis-sauce"
+    - SAUCE_USERNAME="amphtml"
     - NPM_CONFIG_PROGRESS="false"
 addons:
   chrome: stable

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -256,9 +256,8 @@ function determineBuildTargets(filePaths) {
 }
 
 function startSauceConnect() {
-  process.env['SAUCE_ACCESS_KEY'] = getStdout(
-      'curl --silent https://amphtml-sauce-token-dealer.appspot.com/getToken')
-      .trim();
+  process.env['SAUCE_ACCESS_KEY'] = getStdout('curl --silent ' +
+      'https://amphtml-sauce-token-dealer.appspot.com/getJwtToken').trim();
   const startScCmd = 'build-system/sauce_connect/start_sauce_connect.sh';
   console.log('\n' + fileLogPrefix,
       'Starting Sauce Connect Proxy:', colors.cyan(startScCmd));


### PR DESCRIPTION
Due to the fact that we use a new sauce access key for each build, we're seeing auth errors on Travis. See https://travis-ci.org/ampproject/amphtml/jobs/361730076#L705

This PR switches from an always-changing token to a JWT encoded token, which keeps previous tokens alive for up to 90 minutes.

Follow up to #14034