### PR TITLE
Allow specifying ExtensionOptions in declareExtensionVersionAlias

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -195,7 +195,7 @@ declareExtension('amp-video-service', '0.1', {
 declareExtension('amp-vk', '0.1');
 declareExtension('amp-youtube', '0.1');
 declareExtensionVersionAlias(
-    'amp-sticky-ad', '0.1', /* lastestVersion */ '1.0', {hasCss: true});
+    'amp-sticky-ad', '0.1', /* latestVersion */ '1.0', {hasCss: true});
 
 
 /**
@@ -265,25 +265,25 @@ function declareExtension(name, version, options) {
  * the correct one to use.
  * @param {string} name
  * @param {string} version E.g. 0.1
- * @param {string} lastestVersion
+ * @param {string} latestVersion
  * @param {!ExtensionOption} options extension options object.
  */
-function declareExtensionVersionAlias(name, version, lastestVersion, options) {
+function declareExtensionVersionAlias(name, version, latestVersion, options) {
   extensionAliasFilePath[name + '-' + version + '.js'] = {
     'name': name,
-    'file': name + '-' + lastestVersion + '.js',
+    'file': name + '-' + latestVersion + '.js',
   };
   if (options.hasCss) {
     extensionAliasFilePath[name + '-' + version + '.css'] = {
       'name': name,
-      'file': name + '-' + lastestVersion + '.css',
+      'file': name + '-' + latestVersion + '.css',
     };
   }
   if (options.cssBinaries) {
     options.cssBinaries.forEach(cssBinaryName => {
       extensionAliasFilePath[cssBinaryName + '-' + version + '.css'] = {
         'name': cssBinaryName,
-        'file': cssBinaryName + '-' + lastestVersion + '.css',
+        'file': cssBinaryName + '-' + latestVersion + '.css',
       };
     });
   }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -195,7 +195,7 @@ declareExtension('amp-video-service', '0.1', {
 declareExtension('amp-vk', '0.1');
 declareExtension('amp-youtube', '0.1');
 declareExtensionVersionAlias(
-    'amp-sticky-ad', '0.1', /* lastestVersion */ '1.0', /* hasCss */ true);
+    'amp-sticky-ad', '0.1', /* lastestVersion */ '1.0', {hasCss: true});
 
 
 /**
@@ -266,18 +266,26 @@ function declareExtension(name, version, options) {
  * @param {string} name
  * @param {string} version E.g. 0.1
  * @param {string} lastestVersion
- * @param {boolean} hasCss
+ * @param {!ExtensionOption} options extension options object.
  */
-function declareExtensionVersionAlias(name, version, lastestVersion, hasCss) {
+function declareExtensionVersionAlias(name, version, lastestVersion, options) {
   extensionAliasFilePath[name + '-' + version + '.js'] = {
     'name': name,
     'file': name + '-' + lastestVersion + '.js',
   };
-  if (hasCss) {
+  if (options.hasCss) {
     extensionAliasFilePath[name + '-' + version + '.css'] = {
       'name': name,
       'file': name + '-' + lastestVersion + '.css',
     };
+  }
+  if (options.cssBinaries) {
+    options.cssBinaries.forEach(cssBinaryName => {
+      extensionAliasFilePath[cssBinaryName + '-' + version + '.css'] = {
+        'name': cssBinaryName,
+        'file': cssBinaryName + '-' + lastestVersion + '.css',
+      };
+    });
   }
 }
 


### PR DESCRIPTION
We will need to use `declareExtensionVersionAlias` for amp-story in #14357, but amp-story has multiple `cssBinaries`, which is unsupported by `declareExtensionVersionAlias`.  This PR adds support for this.

FYI @zhouyx, in case you see `amp-sticky-ad` breakages in the near future.