### PR TITLE
Click shield on top of story videos.

### DIFF
--- a/extensions/amp-story/0.1/amp-story.css
+++ b/extensions/amp-story/0.1/amp-story.css
@@ -164,6 +164,21 @@ amp-story:not([desktop]) >
   z-index: 2 !important;
 }
 
+/**
+ * Click shield to make sure click events are never swallowed by videos on
+ * Safari iOS 11.2, which would prevent the user from navigating through the
+ * story.
+ * See #14401
+ */
+amp-video::after {
+  content: "";
+  position: absolute;
+  height: 100%;
+  width: 100%;
+  top: 0;
+  left: 0;
+}
+
 amp-story-cta-layer, amp-story-grid-layer {
   bottom: 0 !important;
   left: 0 !important;


### PR DESCRIPTION
iOS Safari 11.2 videos with subtitles are sometimes swallowing the click events, preventing tap navigation to the next page.
Adding a click shield on top of videos, to make sure events are never swallowed.

Fixes #14401 