### PR TITLE
🐛Don't save story ads to history

### DIFF
--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -118,6 +118,8 @@ const AUTO_ADVANCE_TO_ATTR = 'auto-advance-to';
 /** @private @const {string} */
 const AD_SHOWING_ATTR = 'ad-showing';
 
+/** @private @const {string} */
+const AD_PAGE_ID_PREFIX = 'i-amphtml-ad-page';
 
 /**
  * The duration of time (in milliseconds) to wait for a page to be loaded,
@@ -936,6 +938,10 @@ export class AmpStory extends AMP.BaseElement {
    * @private
    */
   setHistoryStatePageId_(pageId) {
+    // Never save ad pages to history as they are unique to each visit.
+    if (pageId.slice(0, AD_PAGE_ID_PREFIX.length) === AD_PAGE_ID_PREFIX) {
+      return;
+    }
     const history = this.win.history;
     if (history.replaceState && this.getHistoryStatePageId_() !== pageId) {
       history.replaceState({

--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -118,9 +118,6 @@ const AUTO_ADVANCE_TO_ATTR = 'auto-advance-to';
 /** @private @const {string} */
 const AD_SHOWING_ATTR = 'ad-showing';
 
-/** @private @const {string} */
-const AD_PAGE_ID_PREFIX = 'i-amphtml-ad-page';
-
 /**
  * The duration of time (in milliseconds) to wait for a page to be loaded,
  * before the story becomes visible.
@@ -939,9 +936,11 @@ export class AmpStory extends AMP.BaseElement {
    */
   setHistoryStatePageId_(pageId) {
     // Never save ad pages to history as they are unique to each visit.
-    if (pageId.slice(0, AD_PAGE_ID_PREFIX.length) === AD_PAGE_ID_PREFIX) {
+    const page = this.getPageById(pageId);
+    if (page.isAd()) {
       return;
     }
+
     const history = this.win.history;
     if (history.replaceState && this.getHistoryStatePageId_() !== pageId) {
       history.replaceState({

--- a/extensions/amp-story/0.1/test/test-amp-story.js
+++ b/extensions/amp-story/0.1/test/test-amp-story.js
@@ -332,7 +332,9 @@ describes.realWin('amp-story', {
     const replaceStub = sandbox.stub(win.history, 'replaceState');
     const firstPageId = 'i-amphtml-ad-page-1';
     const pageCount = 2;
-    createPages(story.element, pageCount, [firstPageId, 'page-1']);
+    const pages = createPages(story.element, pageCount, [firstPageId, 'page-1']);
+    const firstPage = pages[0];
+    firstPage.setAttribute('ad', '');
 
     story.buildCallback();
     return story.layoutCallback()

--- a/extensions/amp-story/0.1/test/test-amp-story.js
+++ b/extensions/amp-story/0.1/test/test-amp-story.js
@@ -332,7 +332,8 @@ describes.realWin('amp-story', {
     const replaceStub = sandbox.stub(win.history, 'replaceState');
     const firstPageId = 'i-amphtml-ad-page-1';
     const pageCount = 2;
-    const pages = createPages(story.element, pageCount, [firstPageId, 'page-1']);
+    const pages = createPages(story.element, pageCount,
+        [firstPageId, 'page-1']);
     const firstPage = pages[0];
     firstPage.setAttribute('ad', '');
 

--- a/extensions/amp-story/0.1/test/test-amp-story.js
+++ b/extensions/amp-story/0.1/test/test-amp-story.js
@@ -325,6 +325,21 @@ describes.realWin('amp-story', {
           );
         });
   });
+
+  it('should NOT update page id in browser history if ad', () => {
+    // Have to stub this because tests run in iframe and you can't write
+    // history from another domain (about:srcdoc)
+    const replaceStub = sandbox.stub(win.history, 'replaceState');
+    const firstPageId = 'i-amphtml-ad-page-1';
+    const pageCount = 2;
+    createPages(story.element, pageCount, [firstPageId, 'page-1']);
+
+    story.buildCallback();
+    return story.layoutCallback()
+        .then(() => {
+          return expect(replaceStub).to.not.have.been.called;
+        });
+  });
 });
 
 


### PR DESCRIPTION
Ads do not persist after a nav to out-link. Therefore when returning to a page you cannot switch back to that ad.

Remove the logic that saves the ad to history.