### PR TITLE
Amp consent API to get real time consent status

### DIFF
--- a/extensions/amp-consent/0.1/consent-policy-manager.js
+++ b/extensions/amp-consent/0.1/consent-policy-manager.js
@@ -92,18 +92,9 @@ export class ConsentPolicyManager {
    */
   whenPolicyResolved(policyId) {
     return this.whenPolicyInstanceReady_(policyId).then(() => {
-      return this.instances_[policyId].getReadyPromise();
-    });
-  }
-
-  /**
-   *
-   * @param {string} policyId
-   * @return {!Promise<CONSENT_POLICY_STATE>}
-   */
-  getPolicyStatus(policyId) {
-    return this.whenPolicyInstanceReady_(policyId).then(() => {
-      return this.instances_[policyId].getCurrentPolicyStatus();
+      return this.instances_[policyId].getReadyPromise().then(() => {
+        return this.instances_[policyId].getCurrentPolicyStatus();
+      });
     });
   }
 
@@ -131,10 +122,10 @@ export class ConsentPolicyInstance {
     /** @private {!Object<string, ?CONSENT_ITEM_STATE>} */
     this.itemToConsentState_ = map();
 
-    /** @private {?function(CONSENT_POLICY_STATE)} */
+    /** @private {?function()} */
     this.readyPromiseResolver_ = null;
 
-    /** @private {!Promise<CONSENT_POLICY_STATE>} */
+    /** @private {!Promise} */
     this.readyPromise_ = new Promise(resolve => {
       this.readyPromiseResolver_ = resolve;
     });
@@ -205,7 +196,7 @@ export class ConsentPolicyInstance {
     this.status_ = state;
 
     if (this.readyPromiseResolver_) {
-      this.readyPromiseResolver_(state);
+      this.readyPromiseResolver_();
       this.readyPromiseResolver_ = null;
     }
   }
@@ -213,7 +204,7 @@ export class ConsentPolicyInstance {
   /**
    * Return a promise that resolved when policy ready.
    * Note: the promise can be reset if use toggle consent state
-   * @return {!Promise<CONSENT_POLICY_STATE>}
+   * @return {!Promise}
    */
   getReadyPromise() {
     return this.readyPromise_;

--- a/extensions/amp-consent/0.1/test/test-consent-policy-manager.js
+++ b/extensions/amp-consent/0.1/test/test-consent-policy-manager.js
@@ -146,5 +146,19 @@ describes.realWin('ConsentStateManager', {amp: 1}, env => {
         expect(policyState).to.equal(CONSENT_POLICY_STATE.INSUFFICIENT);
       });
     });
+
+    describe('getCurrentPolicyStatus', () => {
+      it('should return current policy state', function* () {
+        instance = new ConsentPolicyInstance(['ABC']);
+        expect(instance.getCurrentPolicyStatus()).to.equal(
+            CONSENT_ITEM_STATE.UNKNOWN);
+        instance.consentStateChangeHandler('ABC', CONSENT_ITEM_STATE.REJECTED);
+        expect(instance.getCurrentPolicyStatus()).to.equal(
+            CONSENT_POLICY_STATE.INSUFFICIENT);
+        instance.consentStateChangeHandler('ABC', CONSENT_ITEM_STATE.GRANTED);
+        expect(instance.getCurrentPolicyStatus()).to.equal(
+            CONSENT_POLICY_STATE.SUFFICIENT);
+      });
+    });
   });
 });

--- a/extensions/amp-consent/0.1/test/test-consent-policy-manager.js
+++ b/extensions/amp-consent/0.1/test/test-consent-policy-manager.js
@@ -135,16 +135,16 @@ describes.realWin('ConsentStateManager', {amp: 1}, env => {
 
       it('promise should resolve when consents are dimissed', function* () {
         instance = new ConsentPolicyInstance(['ABC']);
-        let policyState = null;
-        instance.getReadyPromise().then(state => policyState = state);
+        let ready = false;
+        instance.getReadyPromise().then(() => ready = true);
         yield macroTask();
-        expect(policyState).to.be.null;
+        expect(ready).to.be.false;
         instance.consentStateChangeHandler('ABC', CONSENT_ITEM_STATE.UNKNOWN);
         yield macroTask();
-        expect(policyState).to.be.null;
+        expect(ready).to.be.false;
         instance.consentStateChangeHandler('ABC', CONSENT_ITEM_STATE.DISMISSED);
         yield macroTask();
-        expect(policyState).to.equal(CONSENT_POLICY_STATE.INSUFFICIENT);
+        expect(ready).to.be.true;
       });
     });
 

--- a/extensions/amp-consent/0.1/test/test-consent-policy-manager.js
+++ b/extensions/amp-consent/0.1/test/test-consent-policy-manager.js
@@ -118,18 +118,19 @@ describes.realWin('ConsentStateManager', {amp: 1}, env => {
     describe('getReadyPromise', () => {
       it('promise should resolve when all consents are gathered', function* () {
         instance = new ConsentPolicyInstance(['ABC']);
-        let policyState = null;
-        instance.getReadyPromise().then(state => policyState = state);
+        let ready = false;
+        instance.getReadyPromise().then(() => ready = true);
         yield macroTask();
-        expect(policyState).to.be.null;
+        expect(ready).to.be.false;
         instance.consentStateChangeHandler('ABC', CONSENT_ITEM_STATE.REJECTED);
         yield macroTask();
-        expect(policyState).to.equal(CONSENT_POLICY_STATE.INSUFFICIENT);
+        expect(ready).to.be.true;
+        ready = false;
         instance = new ConsentPolicyInstance(['ABC']);
-        instance.getReadyPromise().then(state => policyState = state);
+        instance.getReadyPromise().then(() => ready = true);
         instance.consentStateChangeHandler('ABC', CONSENT_ITEM_STATE.GRANTED);
         yield macroTask();
-        expect(policyState).to.equal(CONSENT_POLICY_STATE.SUFFICIENT);
+        expect(ready).to.be.true;
       });
 
       it('promise should resolve when consents are dimissed', function* () {

--- a/src/consent-state.js
+++ b/src/consent-state.js
@@ -21,8 +21,9 @@ import {Services} from './services';
  * @enum {number}
  */
 export const CONSENT_POLICY_STATE = {
-  SUFFICIENT: 0,
-  INSUFFICIENT: 1,
+  UNKNOWN: 0,
+  SUFFICIENT: 1,
+  INSUFFICIENT: 2,
 };
 
 /**
@@ -39,6 +40,28 @@ export function getConsentPolicyPromise(ampdoc, policyId) {
           return null;
         }
         return consentPolicy.whenPolicyResolved(
+            /** @type {string} */ (policyId));
+      });
+}
+
+/**
+ * Returns a promise with the real time consent policy state value.
+ * This is the sync version of #getConsentPolicyPromise method.
+ * #getConsentPolicyPromise wait for consent policy to resolve
+ * #getCurrentConsentPolicy returns the real time consent policy status
+ * Note should consider using `getConsentPolicyPromise`
+ * to avoid pulling policy status everytime.
+ * @param {!./service/ampdoc-impl.AmpDoc} ampdoc
+ * @param {string} policyId
+ * @return {!Promise<?CONSENT_POLICY_STATE>}
+ */
+export function getCurrentConsentPolicy(ampdoc, policyId) {
+  return Services.consentPolicyServiceForDocOrNull(ampdoc)
+      .then(consentPolicy => {
+        if (!consentPolicy) {
+          return null;
+        }
+        return consentPolicy.getPolicyStatus(
             /** @type {string} */ (policyId));
       });
 }

--- a/src/consent-state.js
+++ b/src/consent-state.js
@@ -33,7 +33,7 @@ export const CONSENT_POLICY_STATE = {
  * @param {string} policyId
  * @return {!Promise<?CONSENT_POLICY_STATE>}
  */
-export function getConsentPolicyPromise(ampdoc, policyId) {
+export function getConsentPolicyState(ampdoc, policyId) {
   return Services.consentPolicyServiceForDocOrNull(ampdoc)
       .then(consentPolicy => {
         if (!consentPolicy) {
@@ -44,24 +44,4 @@ export function getConsentPolicyPromise(ampdoc, policyId) {
       });
 }
 
-/**
- * Returns a promise with the real time consent policy state value.
- * This is the sync version of #getConsentPolicyPromise method.
- * #getConsentPolicyPromise wait for consent policy to resolve
- * #getCurrentConsentPolicy returns the real time consent policy status
- * Note should consider using `getConsentPolicyPromise`
- * to avoid pulling policy status everytime.
- * @param {!./service/ampdoc-impl.AmpDoc} ampdoc
- * @param {string} policyId
- * @return {!Promise<?CONSENT_POLICY_STATE>}
- */
-export function getCurrentConsentPolicy(ampdoc, policyId) {
-  return Services.consentPolicyServiceForDocOrNull(ampdoc)
-      .then(consentPolicy => {
-        if (!consentPolicy) {
-          return null;
-        }
-        return consentPolicy.getPolicyStatus(
-            /** @type {string} */ (policyId));
-      });
-}
+

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -18,7 +18,7 @@ import * as dom from './dom';
 import {AmpEvents} from './amp-events';
 import {
   CONSENT_POLICY_STATE,
-  getConsentPolicyPromise,
+  getConsentPolicyState,
 } from './consent-state';
 import {CommonSignals} from './common-signals';
 import {ElementStub} from './element-stub';
@@ -482,7 +482,7 @@ function createBaseCustomElementClass(win) {
         if (!policyId) {
           resolve(this.implementation_.buildCallback());
         } else {
-          getConsentPolicyPromise(this.getAmpDoc(), policyId).then(state => {
+          getConsentPolicyState(this.getAmpDoc(), policyId).then(state => {
             if (state == CONSENT_POLICY_STATE.INSUFFICIENT) {
               // Need to change after support more policy state
               reject(blockedByConsentError());


### PR DESCRIPTION
Real time consent status API. 

@keithwrightbos FYI: ends up providing a general API that can be used by any service, not only baseInstance.