### PR TITLE
Make click shield more specific and important

### DIFF
--- a/extensions/amp-story/0.1/amp-story.css
+++ b/extensions/amp-story/0.1/amp-story.css
@@ -170,13 +170,13 @@ amp-story:not([desktop]) >
  * story.
  * See #14401
  */
-amp-video::after {
-  content: "";
-  position: absolute;
-  height: 100%;
-  width: 100%;
-  top: 0;
-  left: 0;
+amp-story amp-video::after {
+  content: "" !important;
+  position: absolute !important;
+  height: 100% !important;
+  width: 100% !important;
+  top: 0 !important;
+  left: 0 !important;
 }
 
 amp-story-cta-layer, amp-story-grid-layer {


### PR DESCRIPTION
This prevents the important attributes for the video click shield from being (perhaps accidentally) overridden by the publisher, and also makes sure to only apply it to videos within the story.