### PR TITLE
Restart failing `<amp-bodymovin-animation>` integration test

### DIFF
--- a/extensions/amp-bodymovin-animation/0.1/test/integration/test-amp-bodymovin-animation.js
+++ b/extensions/amp-bodymovin-animation/0.1/test/integration/test-amp-bodymovin-animation.js
@@ -17,7 +17,7 @@
 import {poll} from '../../../../../testing/iframe';
 
 // TODO(nainar, #14336): Fails due to console errors.
-describe.skip('amp-bodymovin-animation', function() {
+describe.configure().ifNewChrome().run('amp-bodymovin-animation', function() {
   const extensions = ['amp-bodymovin-animation'];
   const bodymovinBody = `
     <amp-bodymovin-animation id="anim"

--- a/extensions/amp-bodymovin-animation/0.1/test/integration/test-amp-bodymovin-animation.js
+++ b/extensions/amp-bodymovin-animation/0.1/test/integration/test-amp-bodymovin-animation.js
@@ -16,7 +16,6 @@
 
 import {poll} from '../../../../../testing/iframe';
 
-// TODO(nainar, #14336): Fails due to console errors.
 describe.configure().ifNewChrome().run('amp-bodymovin-animation', function() {
   const extensions = ['amp-bodymovin-animation'];
   const bodymovinBody = `


### PR DESCRIPTION
This addresses one of the test failures in #14360 

This test doesn't seem to be surfacing any console errors - hence I am just turning it on again.