### PR TITLE
✨Adds option to suppress warning for analytics image requests

### DIFF
--- a/extensions/amp-analytics/0.1/test/test-transport.js
+++ b/extensions/amp-analytics/0.1/test/test-transport.js
@@ -72,10 +72,10 @@ describe('amp-analytics.transport', () => {
     assertCallCounts(0, 0, 1);
   });
 
-  it('falls back to image setting ignoreWarnings to true', () => {
+  it('falls back to image setting suppressWarnings to true', () => {
     setupStubs(true, true);
     sendRequest(window, 'https://example.com/test', {
-      beacon: false, xhrpost: false, image: {ignoreWarnings: true},
+      beacon: false, xhrpost: false, image: {suppressWarnings: true},
     });
     assertCallCounts(0, 0, 1);
   });

--- a/extensions/amp-analytics/0.1/test/test-transport.js
+++ b/extensions/amp-analytics/0.1/test/test-transport.js
@@ -72,6 +72,14 @@ describe('amp-analytics.transport', () => {
     assertCallCounts(0, 0, 1);
   });
 
+  it('falls back to image setting ignoreWarnings to true', () => {
+    setupStubs(true, true);
+    sendRequest(window, 'https://example.com/test', {
+      beacon: false, xhrpost: false, image: {ignoreWarnings: true},
+    });
+    assertCallCounts(0, 0, 1);
+  });
+
   it('falls back to xhrpost when enabled and beacon is not available', () => {
     setupStubs(false, true);
     sendRequest(window, 'https://example.com/test', {

--- a/extensions/amp-analytics/0.1/transport.js
+++ b/extensions/amp-analytics/0.1/transport.js
@@ -47,7 +47,7 @@ export function sendRequest(win, request, transportOptions) {
   const image = transportOptions['image'];
   if (image) {
     const suppressWarnings = (typeof image == 'object' &&
-                              image['suppressWarnings']);
+        image['suppressWarnings']);
     Transport.sendRequestUsingImage(request, suppressWarnings);
     return;
   }

--- a/extensions/amp-analytics/0.1/transport.js
+++ b/extensions/amp-analytics/0.1/transport.js
@@ -44,9 +44,11 @@ export function sendRequest(win, request, transportOptions) {
       Transport.sendRequestUsingXhr(win, request)) {
     return;
   }
-  if (transportOptions['image']) {
-    Transport.sendRequestUsingImage(
-        request, transportOptions['image']['ignoreWarnings']);
+  const image = transportOptions['image'];
+  if (image) {
+    const suppressWarnings = (typeof image == 'object' &&
+                              image['suppressWarnings']);
+    Transport.sendRequestUsingImage(request, suppressWarnings);
     return;
   }
   user().warn(TAG_, 'Failed to send request', request, transportOptions);
@@ -59,9 +61,9 @@ export class Transport {
 
   /**
    * @param {string} request
-   * @param {boolean} ignoreWarnin
+   * @param {boolean} suppressWarnings
    */
-  static sendRequestUsingImage(request, ignoreWarnings) {
+  static sendRequestUsingImage(request, suppressWarnings) {
     const image = new Image();
     image.src = request;
     image.width = 1;
@@ -69,7 +71,7 @@ export class Transport {
     loadPromise(image).then(() => {
       dev().fine(TAG_, 'Sent image request', request);
     }).catch(() => {
-      if (!ignoreWarnings) {
+      if (!suppressWarnings) {
         user().warn(TAG_, 'Response unparseable or failed to send image ' +
             'request', request);
       }

--- a/extensions/amp-analytics/0.1/transport.js
+++ b/extensions/amp-analytics/0.1/transport.js
@@ -45,7 +45,8 @@ export function sendRequest(win, request, transportOptions) {
     return;
   }
   if (transportOptions['image']) {
-    Transport.sendRequestUsingImage(request);
+    Transport.sendRequestUsingImage(
+        request, transportOptions['image']['ignoreWarnings']);
     return;
   }
   user().warn(TAG_, 'Failed to send request', request, transportOptions);
@@ -58,8 +59,9 @@ export class Transport {
 
   /**
    * @param {string} request
+   * @param {boolean} ignoreWarnin
    */
-  static sendRequestUsingImage(request) {
+  static sendRequestUsingImage(request, ignoreWarnings) {
     const image = new Image();
     image.src = request;
     image.width = 1;
@@ -67,8 +69,10 @@ export class Transport {
     loadPromise(image).then(() => {
       dev().fine(TAG_, 'Sent image request', request);
     }).catch(() => {
-      user().warn(TAG_, 'Response unparseable or failed to send image ' +
-          'request', request);
+      if (!ignoreWarnings) {
+        user().warn(TAG_, 'Response unparseable or failed to send image ' +
+            'request', request);
+      }
     });
   }
 

--- a/extensions/amp-analytics/amp-analytics.md
+++ b/extensions/amp-analytics/amp-analytics.md
@@ -624,7 +624,7 @@ indicate which transport methods are acceptable.
 
   - `beacon` Indicates [`navigator.sendBeacon`](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/sendBeacon)  can be used to transmit the request. This will send a POST request, with credentials, and an empty body.
   - `xhrpost` Indicates `XMLHttpRequest` can be used to transmit the request. This will send a POST request, with credentials, and an empty body.
-  - `image` Indicates the request can be sent by generating an `Image` tag. This will send a GET request. There is an option to suppress the warnings of empty GET responses by setting "image": {"ignoreWarnings": true}.
+  - `image` Indicates the request can be sent by generating an `Image` tag. This will send a GET request. To suppress console warnings due to empty responses or request failures, set `"image": {"suppressWarnings": true}`.
   - `iframe` The value is a URL string. Indicates that an iframe should be created, with its `src` attribute set to this URL, and requests will be sent to that iframe via `window.postMessage()`. In this case, requests need not be full-fledged URLs. `iframe` may only be specified in `vendors.js`, not inline within the `amp-analytics` tag, nor via remote configuration. This option is also only available to MRC-accredited vendors.
 
 If more than one of the above transport methods are enabled, the precedence is `iframe` > `beacon` > `xhrpost` > `image`. Only one transport method will be used, and it will be the highest precedence one that is permitted and available. If the client's user agent does not support a method, the next highest precedence method enabled will be used. By default, all four methods above are enabled.

--- a/extensions/amp-analytics/amp-analytics.md
+++ b/extensions/amp-analytics/amp-analytics.md
@@ -624,7 +624,7 @@ indicate which transport methods are acceptable.
 
   - `beacon` Indicates [`navigator.sendBeacon`](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/sendBeacon)  can be used to transmit the request. This will send a POST request, with credentials, and an empty body.
   - `xhrpost` Indicates `XMLHttpRequest` can be used to transmit the request. This will send a POST request, with credentials, and an empty body.
-  - `image` Indicates the request can be sent by generating an `Image` tag. This will send a GET request.
+  - `image` Indicates the request can be sent by generating an `Image` tag. This will send a GET request. There is an option to suppress the warnings of empty GET responses by setting "image": {"ignoreWarnings": true}.
   - `iframe` The value is a URL string. Indicates that an iframe should be created, with its `src` attribute set to this URL, and requests will be sent to that iframe via `window.postMessage()`. In this case, requests need not be full-fledged URLs. `iframe` may only be specified in `vendors.js`, not inline within the `amp-analytics` tag, nor via remote configuration. This option is also only available to MRC-accredited vendors.
 
 If more than one of the above transport methods are enabled, the precedence is `iframe` > `beacon` > `xhrpost` > `image`. Only one transport method will be used, and it will be the highest precedence one that is permitted and available. If the client's user agent does not support a method, the next highest precedence method enabled will be used. By default, all four methods above are enabled.


### PR DESCRIPTION
A warning is generated for each 204 logging requests because the response is empty. This change adds an option to suppress the warnings since the empty responses are expected behavior for 204 requests.
@choumx @zhouyx 