### PR TITLE
Add code conformance rules for style property

### DIFF
--- a/build-system/conformance-config.textproto
+++ b/build-system/conformance-config.textproto
@@ -7,6 +7,15 @@ requirement: {
   error_message: 'Should not throw a non-Error object.'
 }
 
+#HTMLElement
+
+requirement: {
+  type: BANNED_PROPERTY_CALL
+  error_message: 'HTMLElement.style is not allowed'
+  value: 'HTMLElement.style'
+  whitelist: 'src/style.js'
+}
+
 # Strings
 
 requirement: {

--- a/build-system/conformance-config.textproto
+++ b/build-system/conformance-config.textproto
@@ -7,12 +7,22 @@ requirement: {
   error_message: 'Should not throw a non-Error object.'
 }
 
-#HTMLElement
+# Element
+
+requirement: {
+  type: BANNED_PROPERTY_WRITE
+  error_message: 'Use style.js#setStyle or style.js#setStyles'
+  value: 'Element.prototype.style'
+  whitelist: 'src/style.js'
+  whitelist: 'extensions/amp-story/0.1/test/test-amp-story.js'
+}
+
+# CSSStyleDeclaration
 
 requirement: {
   type: BANNED_PROPERTY_CALL
-  error_message: 'HTMLElement.style is not allowed'
-  value: 'HTMLElement.style'
+  error_message: 'Use style.js#setStyle or style.js#setStyles'
+  value: 'CSSStyleDeclaration.prototype.setProperty'
   whitelist: 'src/style.js'
 }
 
@@ -32,7 +42,7 @@ requirement: {
 
 requirement: {
   type: BANNED_PROPERTY_CALL
-  error_message: 'string.prototype.startsWith is not allowed'
+  error_message: 'Use string.js#startsWith'
   value: 'string.prototype.startsWith'
 }
 

--- a/build-system/conformance-config.textproto
+++ b/build-system/conformance-config.textproto
@@ -14,7 +14,6 @@ requirement: {
   error_message: 'Use style.js#setStyle or style.js#setStyles'
   value: 'Element.prototype.style'
   whitelist: 'src/style.js'
-  whitelist: 'extensions/amp-story/0.1/test/test-amp-story.js'
 }
 
 # CSSStyleDeclaration

--- a/extensions/amp-animation/0.1/web-animations.js
+++ b/extensions/amp-animation/0.1/web-animations.js
@@ -41,7 +41,7 @@ import {getMode} from '../../../src/mode';
 import {isArray, isObject, toArray} from '../../../src/types';
 import {map} from '../../../src/utils/object';
 import {parseCss} from './css-expr';
-import {setStyle} from '../../../src/style';
+import {setStyles} from '../../../src/style';
 
 
 /** @const {string} */
@@ -126,11 +126,8 @@ export class WebAnimationRunner {
     this.players_ = this.requests_.map(request => {
       // Apply vars.
       if (request.vars) {
-        for (const k in request.vars) {
-          setStyle(request.target, String(request.vars[k]));
-        }
+        setStyles(request.target, request.vars);
       }
-
       const player = request.target.animate(request.keyframes, request.timing);
       player.pause();
       return player;

--- a/extensions/amp-animation/0.1/web-animations.js
+++ b/extensions/amp-animation/0.1/web-animations.js
@@ -127,7 +127,7 @@ export class WebAnimationRunner {
       // Apply vars.
       if (request.vars) {
         for (const k in request.vars) {
-          setStyle(request.target, k, String(request.vars[k]));
+          setStyle(request.target, String(request.vars[k]));
         }
       }
 

--- a/extensions/amp-animation/0.1/web-animations.js
+++ b/extensions/amp-animation/0.1/web-animations.js
@@ -41,6 +41,7 @@ import {getMode} from '../../../src/mode';
 import {isArray, isObject, toArray} from '../../../src/types';
 import {map} from '../../../src/utils/object';
 import {parseCss} from './css-expr';
+import {setStyle} from '../../../src/style';
 
 
 /** @const {string} */
@@ -126,7 +127,7 @@ export class WebAnimationRunner {
       // Apply vars.
       if (request.vars) {
         for (const k in request.vars) {
-          request.target.style.setProperty(k, String(request.vars[k]));
+          setStyle(request.target, k, String(request.vars[k]));
         }
       }
 

--- a/extensions/amp-animation/0.1/web-animations.js
+++ b/extensions/amp-animation/0.1/web-animations.js
@@ -41,7 +41,7 @@ import {getMode} from '../../../src/mode';
 import {isArray, isObject, toArray} from '../../../src/types';
 import {map} from '../../../src/utils/object';
 import {parseCss} from './css-expr';
-import {setStyle} from '../../../src/style';
+import {setImportantStyles} from '../../../src/style';
 
 
 /** @const {string} */
@@ -127,7 +127,7 @@ export class WebAnimationRunner {
       // Apply vars.
       if (request.vars) {
         for (const k in request.vars) {
-          setStyle(request.target, k, String(request.vars[k]));
+          setImportantStyles(request.target, {[k]: String(request.vars[k])});
         }
       }
 

--- a/extensions/amp-animation/0.1/web-animations.js
+++ b/extensions/amp-animation/0.1/web-animations.js
@@ -127,7 +127,7 @@ export class WebAnimationRunner {
       // Apply vars.
       if (request.vars) {
         for (const k in request.vars) {
-          setStyle(request.target, [k], String(request.vars[k]));
+          setStyle(request.target, k, String(request.vars[k]));
         }
       }
 

--- a/extensions/amp-animation/0.1/web-animations.js
+++ b/extensions/amp-animation/0.1/web-animations.js
@@ -41,7 +41,7 @@ import {getMode} from '../../../src/mode';
 import {isArray, isObject, toArray} from '../../../src/types';
 import {map} from '../../../src/utils/object';
 import {parseCss} from './css-expr';
-import {setImportantStyles} from '../../../src/style';
+import {setStyle} from '../../../src/style';
 
 
 /** @const {string} */
@@ -127,7 +127,7 @@ export class WebAnimationRunner {
       // Apply vars.
       if (request.vars) {
         for (const k in request.vars) {
-          setImportantStyles(request.target, {[k]: String(request.vars[k])});
+          setStyle(request.target, [k], String(request.vars[k]));
         }
       }
 

--- a/extensions/amp-story/1.0/amp-story-grid-layer.js
+++ b/extensions/amp-story/1.0/amp-story-grid-layer.js
@@ -28,6 +28,7 @@
 
 import {AmpStoryBaseLayer} from './amp-story-base-layer';
 import {matches, scopedQuerySelectorAll} from '../../../src/dom';
+import {setStyle} from '../../../src/style';
 
 /**
  * A mapping of attribute names we support for grid layers to the CSS Grid
@@ -151,7 +152,7 @@ export class AmpStoryGridLayer extends AmpStoryBaseLayer {
       const attributeName = attribute.name.toLowerCase();
       const propertyName = SUPPORTED_CSS_GRID_ATTRIBUTES[attributeName];
       if (propertyName) {
-        element.style[propertyName] = attribute.value;
+        setStyle(element, propertyName, attribute.value);
         element.removeAttribute(attributeName);
       }
     }

--- a/extensions/amp-story/1.0/amp-story-grid-layer.js
+++ b/extensions/amp-story/1.0/amp-story-grid-layer.js
@@ -28,7 +28,7 @@
 
 import {AmpStoryBaseLayer} from './amp-story-base-layer';
 import {matches, scopedQuerySelectorAll} from '../../../src/dom';
-import {setImportantStyles} from '../../../src/style';
+import {setStyle} from '../../../src/style';
 
 /**
  * A mapping of attribute names we support for grid layers to the CSS Grid
@@ -152,7 +152,7 @@ export class AmpStoryGridLayer extends AmpStoryBaseLayer {
       const attributeName = attribute.name.toLowerCase();
       const propertyName = SUPPORTED_CSS_GRID_ATTRIBUTES[attributeName];
       if (propertyName) {
-        setImportantStyles(element, {[propertyName]: attribute.value});
+        setStyle(element, propertyName, attribute.value);
         element.removeAttribute(attributeName);
       }
     }

--- a/extensions/amp-story/1.0/amp-story-grid-layer.js
+++ b/extensions/amp-story/1.0/amp-story-grid-layer.js
@@ -28,7 +28,7 @@
 
 import {AmpStoryBaseLayer} from './amp-story-base-layer';
 import {matches, scopedQuerySelectorAll} from '../../../src/dom';
-import {setStyle} from '../../../src/style';
+import {setImportantStyles} from '../../../src/style';
 
 /**
  * A mapping of attribute names we support for grid layers to the CSS Grid
@@ -152,7 +152,7 @@ export class AmpStoryGridLayer extends AmpStoryBaseLayer {
       const attributeName = attribute.name.toLowerCase();
       const propertyName = SUPPORTED_CSS_GRID_ATTRIBUTES[attributeName];
       if (propertyName) {
-        setStyle(element, propertyName, attribute.value);
+        setImportantStyles(element, {[propertyName]: attribute.value});
         element.removeAttribute(attributeName);
       }
     }

--- a/extensions/amp-story/1.0/page-scaling.js
+++ b/extensions/amp-story/1.0/page-scaling.js
@@ -17,7 +17,7 @@ import {Services} from '../../../src/services';
 import {childElementsByTag, matches} from '../../../src/dom';
 import {dev, user} from '../../../src/log';
 import {isExperimentOn} from '../../../src/experiments';
-import {px, setImportantStyles, setStyle} from '../../../src/style';
+import {px, setImportantStyles} from '../../../src/style';
 import {throttle} from '../../../src/utils/rate-limit';
 import {toArray, toWin} from '../../../src/types';
 import {unscaledClientRect} from './utils';
@@ -441,9 +441,11 @@ class CssPropsZoomScalingService extends PageScalingService {
   updateRootProps() {
     const {width, height, factor} = this.targetDimensions_;
     this.vsync_.mutate(() => {
-      setStyle(this.rootEl_, '--i-amphtml-story-width', px(width));
-      setStyle(this.rootEl_, '--i-amphtml-story-height', px(height));
-      setStyle(this.rootEl_, '--i-amphtml-story-factor', factor.toString());
+      setImportantStyles(this.rootEl_, {
+        '--i-amphtml-story-width': px(width),
+        '--i-amphtml-story-height': px(height),
+        '--i-amphtml-story-factor': factor.toString(),
+      });
     });
   }
 

--- a/extensions/amp-story/1.0/page-scaling.js
+++ b/extensions/amp-story/1.0/page-scaling.js
@@ -17,7 +17,7 @@ import {Services} from '../../../src/services';
 import {childElementsByTag, matches} from '../../../src/dom';
 import {dev, user} from '../../../src/log';
 import {isExperimentOn} from '../../../src/experiments';
-import {px, setImportantStyles} from '../../../src/style';
+import {px, setStyle, setImportantStyles} from '../../../src/style';
 import {throttle} from '../../../src/utils/rate-limit';
 import {toArray, toWin} from '../../../src/types';
 import {unscaledClientRect} from './utils';
@@ -441,10 +441,9 @@ class CssPropsZoomScalingService extends PageScalingService {
   updateRootProps() {
     const {width, height, factor} = this.targetDimensions_;
     this.vsync_.mutate(() => {
-      this.rootEl_.style.setProperty('--i-amphtml-story-width', px(width));
-      this.rootEl_.style.setProperty('--i-amphtml-story-height', px(height));
-      this.rootEl_.style.setProperty('--i-amphtml-story-factor',
-          factor.toString());
+      setStyle(this.rootEl_, '--i-amphtml-story-width', px(width));
+      setStyle(this.rootEl_, '--i-amphtml-story-height', px(height));
+      setStyle(this.rootEl_, '--i-amphtml-story-factor', factor.toString());
     });
   }
 

--- a/extensions/amp-story/1.0/page-scaling.js
+++ b/extensions/amp-story/1.0/page-scaling.js
@@ -17,7 +17,7 @@ import {Services} from '../../../src/services';
 import {childElementsByTag, matches} from '../../../src/dom';
 import {dev, user} from '../../../src/log';
 import {isExperimentOn} from '../../../src/experiments';
-import {px, setImportantStyles} from '../../../src/style';
+import {px, setImportantStyles, setStyle} from '../../../src/style';
 import {throttle} from '../../../src/utils/rate-limit';
 import {toArray, toWin} from '../../../src/types';
 import {unscaledClientRect} from './utils';
@@ -441,11 +441,9 @@ class CssPropsZoomScalingService extends PageScalingService {
   updateRootProps() {
     const {width, height, factor} = this.targetDimensions_;
     this.vsync_.mutate(() => {
-      setImportantStyles(this.rootEl_, {
-        '--i-amphtml-story-width': px(width),
-        '--i-amphtml-story-height': px(height),
-        '--i-amphtml-story-factor': factor.toString(),
-      });
+      setStyle(this.rootEl_, '--i-amphtml-story-width', px(width));
+      setStyle(this.rootEl_, '--i-amphtml-story-height', px(height));
+      setStyle(this.rootEl_, '--i-amphtml-story-factor', factor.toString());
     });
   }
 

--- a/extensions/amp-story/1.0/page-scaling.js
+++ b/extensions/amp-story/1.0/page-scaling.js
@@ -17,7 +17,7 @@ import {Services} from '../../../src/services';
 import {childElementsByTag, matches} from '../../../src/dom';
 import {dev, user} from '../../../src/log';
 import {isExperimentOn} from '../../../src/experiments';
-import {px, setStyle, setImportantStyles} from '../../../src/style';
+import {px, setImportantStyles, setStyle} from '../../../src/style';
 import {throttle} from '../../../src/utils/rate-limit';
 import {toArray, toWin} from '../../../src/types';
 import {unscaledClientRect} from './utils';

--- a/src/style.js
+++ b/src/style.js
@@ -107,7 +107,7 @@ export function setImportantStyles(element, styles) {
 
 /**
  * Sets the CSS style of the specified element with optional units, e.g. "px".
- * @param {Element?} element
+ * @param {?Element} element
  * @param {string} property
  * @param {*} value
  * @param {string=} opt_units

--- a/src/style.js
+++ b/src/style.js
@@ -107,7 +107,7 @@ export function setImportantStyles(element, styles) {
 
 /**
  * Sets the CSS style of the specified element with optional units, e.g. "px".
- * @param {Element} element
+ * @param {Element?} element
  * @param {string} property
  * @param {*} value
  * @param {string=} opt_units

--- a/test/functional/test-style.js
+++ b/test/functional/test-style.js
@@ -63,6 +63,16 @@ describe('Style', () => {
     expect(element.style.height).to.equal('102px');
   });
 
+  it('setImportantStyles', () => {
+    const element = document.createElement('div');
+    st.setImportantStyles(element, {
+      width: st.px(101),
+    });
+    expect(element.style.width).to.equal('101px');
+    expect(element.style.getPropertyPriority('width'))
+        .to.equal('important');
+  });
+
   it('px', () => {
     expect(st.px(0)).to.equal('0px');
     expect(st.px(101)).to.equal('101px');


### PR DESCRIPTION
- add conformance rules for setting style. see issue #14178
- apply usage of setStyle(s) where applicable

Note that these new conformance requirements does not ban the user from doing 

element.style['some-property'] = ...

as I am in the process of investigating how to do this with a regex or if it's even supported. I asked the closure compiler group and still poking around. Only violations caught for now are

element.style = .. 
element.setProperty(...);

e.g. of rule violations 

>> gulp check-types

Compiler error for check-types.js:
extensions/amp-animation/0.1/web-animations.js:129: WARNING - Violation: Use style.js#setStyle or style.js#setStyles
          request.target.style.setProperty(k, String(request.vars[k]));
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

extensions/amp-story/0.1/page-scaling.js:444: WARNING - Violation: Use style.js#setStyle or style.js#setStyles
      this.rootEl_.style.setProperty('--i-amphtml-story-width', px(width));
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

extensions/amp-story/0.1/page-scaling.js:445: WARNING - Violation: Use style.js#setStyle or style.js#setStyles
      this.rootEl_.style.setProperty('--i-amphtml-story-height', px(height));
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

extensions/amp-story/0.1/page-scaling.js:446: WARNING - Violation: Use style.js#setStyle or style.js#setStyles
      this.rootEl_.style.setProperty('--i-amphtml-story-factor',
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

0 error(s), 4 warning(s), 86.2% typed