### PR TITLE
✅ Add a method expectConsoleError to test-helper.js to run code blocks that are expected to call console.error, but not fail because of it.

### DIFF
--- a/testing/test-helper.js
+++ b/testing/test-helper.js
@@ -122,7 +122,7 @@ export function assertScreenReaderElement(element) {
  * @param {!Array<string, !RegExp>} expectedErrorMessages list of expected
  * messages to match against the output of calling console.error
  */
-export function expectConsoleError(func, expectedErrorMessages) {
+export function expectConsoleErrors(func, expectedErrorMessages) {
   let callIndex = 0;
   console.error.callsFake((...messages) => {
     // On every call to console.error assert that there are still expected

--- a/testing/test-helper.js
+++ b/testing/test-helper.js
@@ -118,8 +118,9 @@ export function assertScreenReaderElement(element) {
  *   console.error('This is the second error');
  * }, ['This is the first error', /second/]);
  *
- * @param {!Function} func
- * @param {!Array<string, !RegExp>} expectedErrorMessages
+ * @param {function()} func Code to be tested
+ * @param {!Array<string, !RegExp>} expectedErrorMessages list of expected
+ * messages to match against the output of calling console.error
  */
 export function expectConsoleError(func, expectedErrorMessages) {
   let callIndex = 0;


### PR DESCRIPTION
Example usage:

```javascript
expectConsoleError(() => {
  console.error('This is the first error');
  console.warn('Warns and logs are not caught');
  console.error('This is the second error');
}, ['This is the first error', /second/]);
```