### PR TITLE
✅ Replace the console.error stub with a mock in _init_tests.js

### DIFF
--- a/test/_init_tests.js
+++ b/test/_init_tests.js
@@ -268,10 +268,8 @@ sinon.sandbox.create = function(config) {
 beforeEach(function() {
   this.timeout(BEFORE_AFTER_TIMEOUT);
   beforeTest();
-  consoleSandbox = sinon.sandbox.create();
-  consoleSandbox.stub(console, 'error').callsFake((...messages) => {
-    throw new Error(messages.join(' '));
-  });
+  consoleSandbox = sinon.mock(console);
+  consoleSandbox.expects('error').never();
 });
 
 function beforeTest() {
@@ -292,7 +290,7 @@ function beforeTest() {
 // Global cleanup of tags added during tests. Cool to add more
 // to selector.
 afterEach(function() {
-  consoleSandbox.restore();
+  consoleSandbox.verify();
   this.timeout(BEFORE_AFTER_TIMEOUT);
   const cleanupTagNames = ['link', 'meta'];
   if (!Services.platformFor(window).isSafari()) {


### PR DESCRIPTION
Followup to PR #14406 

Note that to fix skipped tests now:

This test will fail...
```javascript
it('test with a console error', () => {
  console.error('foo');
});
```

... but this test will pass...
```javascript
it('test with an expected console error', () => {
  sinon.mock(console).expects('error').withArgs('foo');
  console.error('foo');
});
```

You can also match multiple arguments and RegExp with:
```javascript
it('test with an expected console error', () => {
  sinon.mock(console).expects('error').withArgs(
      'foo', sinon.match(/ba./)); // or withExactArgs to match all args
  console.error('foo', 'bar', 'baz');
});
```