### PR TITLE
✨Add custom carousel controls for <amp-lightbox-gallery>

### DIFF
--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.css
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.css
@@ -55,10 +55,15 @@
   mask-image: url('data:image/svg+xml;charset=utf-8,<svg viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd"><g id="image" fill="#fff"><path d="M5,3 L19,3 C20.1045695,3 21,3.8954305 21,5 L21,19 C21,20.1045695 20.1045695,21 19,21 L5,21 C3.8954305,21 3,20.1045695 3,19 L3,5 C3,3.8954305 3.8954305,3 5,3 Z M19,15 L19,5 L5,5 L5,13.0000896 L8,10.0003584 L13,15 L16,12 L19,15 Z M15.5,10 C14.6715729,10 14,9.32842712 14,8.5 C14,7.67157288 14.6715729,7 15.5,7 C16.3284271,7 17,7.67157288 17,8.5 C17,9.32842712 16.3284271,10 15.5,10 Z" id="Combined-Shape"></path></g></g></svg>');
 }
 
+.i-amphtml-lbg-button-next, .i-amphtml-lbg-button-prev {
+  top: 0 !important;
+  bottom: 0 !important;
+  margin: auto !important;
+  filter: drop-shadow(0 0 1px black) !important;
+}
+
 .i-amphtml-lbg-button-next {
-  top: calc(50vh - 18px) !important;
   right: 0 !important;
-  filter: drop-shadow(0 0 1px black);
 }
 
 .i-amphtml-lbg-button-next .i-amphtml-lbg-icon {
@@ -66,9 +71,7 @@
 }
 
 .i-amphtml-lbg-button-prev {
-  top: calc(50vh - 18px) !important;
   left: 0 !important;
-  filter: drop-shadow(0 0 1px black);
 }
 
 .i-amphtml-lbg-button-prev .i-amphtml-lbg-icon {

--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.css
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.css
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+ .amp-carousel-button {
+  display: none;
+ }
+
 .i-amphtml-lbg-icon {
   width: 100% !important;
   height: 100% !important;
@@ -48,6 +52,26 @@
 }
 
 .i-amphtml-lbg-button-slide .i-amphtml-lbg-icon {
+  mask-image: url('data:image/svg+xml;charset=utf-8,<svg viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd"><g id="image" fill="#fff"><path d="M5,3 L19,3 C20.1045695,3 21,3.8954305 21,5 L21,19 C21,20.1045695 20.1045695,21 19,21 L5,21 C3.8954305,21 3,20.1045695 3,19 L3,5 C3,3.8954305 3.8954305,3 5,3 Z M19,15 L19,5 L5,5 L5,13.0000896 L8,10.0003584 L13,15 L16,12 L19,15 Z M15.5,10 C14.6715729,10 14,9.32842712 14,8.5 C14,7.67157288 14.6715729,7 15.5,7 C16.3284271,7 17,7.67157288 17,8.5 C17,9.32842712 16.3284271,10 15.5,10 Z" id="Combined-Shape"></path></g></g></svg>');
+}
+
+.i-amphtml-lbg-button-next {
+  top: 50vh !important;
+  left: 0 !important;
+  display: none;
+}
+
+.i-amphtml-lbg-button-next .i-amphtml-lbg-icon {
+  mask-image: url('data:image/svg+xml;charset=utf-8,<svg viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd"><g id="image" fill="#fff"><path d="M5,3 L19,3 C20.1045695,3 21,3.8954305 21,5 L21,19 C21,20.1045695 20.1045695,21 19,21 L5,21 C3.8954305,21 3,20.1045695 3,19 L3,5 C3,3.8954305 3.8954305,3 5,3 Z M19,15 L19,5 L5,5 L5,13.0000896 L8,10.0003584 L13,15 L16,12 L19,15 Z M15.5,10 C14.6715729,10 14,9.32842712 14,8.5 C14,7.67157288 14.6715729,7 15.5,7 C16.3284271,7 17,7.67157288 17,8.5 C17,9.32842712 16.3284271,10 15.5,10 Z" id="Combined-Shape"></path></g></g></svg>');
+}
+
+.i-amphtml-lbg-button-prev {
+  top: 50vh !important;
+  right: 0 !important;
+  display: none;
+}
+
+.i-amphtml-lbg-button-prev .i-amphtml-lbg-icon {
   mask-image: url('data:image/svg+xml;charset=utf-8,<svg viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd"><g id="image" fill="#fff"><path d="M5,3 L19,3 C20.1045695,3 21,3.8954305 21,5 L21,19 C21,20.1045695 20.1045695,21 19,21 L5,21 C3.8954305,21 3,20.1045695 3,19 L3,5 C3,3.8954305 3.8954305,3 5,3 Z M19,15 L19,5 L5,5 L5,13.0000896 L8,10.0003584 L13,15 L16,12 L19,15 Z M15.5,10 C14.6715729,10 14,9.32842712 14,8.5 C14,7.67157288 14.6715729,7 15.5,7 C16.3284271,7 17,7.67157288 17,8.5 C17,9.32842712 16.3284271,10 15.5,10 Z" id="Combined-Shape"></path></g></g></svg>');
 }
 

--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.css
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.css
@@ -56,23 +56,23 @@
 }
 
 .i-amphtml-lbg-button-next {
-  top: 50vh !important;
-  left: 0 !important;
-  display: none;
+  top: calc(50vh - 18px) !important;
+  right: 0 !important;
+  filter: drop-shadow(0 0 1px black);
 }
 
 .i-amphtml-lbg-button-next .i-amphtml-lbg-icon {
-  mask-image: url('data:image/svg+xml;charset=utf-8,<svg viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd"><g id="image" fill="#fff"><path d="M5,3 L19,3 C20.1045695,3 21,3.8954305 21,5 L21,19 C21,20.1045695 20.1045695,21 19,21 L5,21 C3.8954305,21 3,20.1045695 3,19 L3,5 C3,3.8954305 3.8954305,3 5,3 Z M19,15 L19,5 L5,5 L5,13.0000896 L8,10.0003584 L13,15 L16,12 L19,15 Z M15.5,10 C14.6715729,10 14,9.32842712 14,8.5 C14,7.67157288 14.6715729,7 15.5,7 C16.3284271,7 17,7.67157288 17,8.5 C17,9.32842712 16.3284271,10 15.5,10 Z" id="Combined-Shape"></path></g></g></svg>');
+  mask-image: url('data:image/svg+xml;charset=utf-8,<svg viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><defs></defs><g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd"><g id="arrow_right_03" fill="#000000"><path d="M7.75,9.75 L7.75,15.25 C7.75,15.8022847 7.30228475,16.25 6.75,16.25 C6.19771525,16.25 5.75,15.8022847 5.75,15.25 L5.75,8.75 C5.75,8.19771525 6.19771525,7.75 6.75,7.75 L13.25,7.75 C13.8022847,7.75 14.25,8.19771525 14.25,8.75 C14.25,9.30228475 13.8022847,9.75 13.25,9.75 L7.75,9.75 Z" id="Combined-Shape" transform="translate(10.000000, 12.000000) rotate(-225.000000) translate(-10.000000, -12.000000) "></path></g></g></svg>');
 }
 
 .i-amphtml-lbg-button-prev {
-  top: 50vh !important;
-  right: 0 !important;
-  display: none;
+  top: calc(50vh - 18px) !important;
+  left: 0 !important;
+  filter: drop-shadow(0 0 1px black);
 }
 
 .i-amphtml-lbg-button-prev .i-amphtml-lbg-icon {
-  mask-image: url('data:image/svg+xml;charset=utf-8,<svg viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd"><g id="image" fill="#fff"><path d="M5,3 L19,3 C20.1045695,3 21,3.8954305 21,5 L21,19 C21,20.1045695 20.1045695,21 19,21 L5,21 C3.8954305,21 3,20.1045695 3,19 L3,5 C3,3.8954305 3.8954305,3 5,3 Z M19,15 L19,5 L5,5 L5,13.0000896 L8,10.0003584 L13,15 L16,12 L19,15 Z M15.5,10 C14.6715729,10 14,9.32842712 14,8.5 C14,7.67157288 14.6715729,7 15.5,7 C16.3284271,7 17,7.67157288 17,8.5 C17,9.32842712 16.3284271,10 15.5,10 Z" id="Combined-Shape"></path></g></g></svg>');
+  mask-image: url('data:image/svg+xml;charset=utf-8,<svg viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd"><g id="arrow_left_03" fill="#000000"><path d="M11.7604076,9.75 L11.7604076,15.25 C11.7604076,15.8022847 11.3126924,16.25 10.7604076,16.25 C10.2081229,16.25 9.76040764,15.8022847 9.76040764,15.25 L9.76040764,8.75 C9.76040764,8.19771525 10.2081229,7.75 10.7604076,7.75 L17.2604076,7.75 C17.8126924,7.75 18.2604076,8.19771525 18.2604076,8.75 C18.2604076,9.30228475 17.8126924,9.75 17.2604076,9.75 L11.7604076,9.75 Z" id="Combined-Shape" transform="translate(14.010408, 12.000000) rotate(-45.000000) translate(-14.010408, -12.000000) "></path></g></g></svg>');
 }
 
 .i-amphtml-lbg-button {

--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.css
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.css
@@ -16,7 +16,7 @@
 
 amp-lightbox-gallery .amp-carousel-button {
   display: none;
- }
+}
 
 .i-amphtml-lbg-icon {
   width: 100% !important;

--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.css
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.css
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
- .amp-carousel-button {
+amp-lightbox-gallery .amp-carousel-button {
   display: none;
  }
 

--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -483,7 +483,7 @@ export class AmpLightboxGallery extends AMP.BaseElement {
     const openGallery = this.openGallery_.bind(this);
     const closeGallery = this.closeGallery_.bind(this);
     const nextSlide = this.nextSlide_.bind(this);
-    const prevSide = this.prevSlide_.bind(this);
+    const prevSlide = this.prevSlide_.bind(this);
 
     // TODO(aghassemi): i18n and customization. See https://git.io/v6JWu
     this.buildButton_('Close', 'i-amphtml-lbg-button-close', close);

--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -457,7 +457,7 @@ export class AmpLightboxGallery extends AMP.BaseElement {
       if (state.isInStandardMode && state.descriptionOverflows) {
         this.descriptionBox_.classList.remove('i-amphtml-lbg-standard');
         this.descriptionBox_.classList.add('i-amphtml-lbg-overflow');
-        toggle(this.navControls_, false);
+        toggle(dev().assertElement(this.navControls_), false);
       } else if (state.isInOverflowMode) {
         this.clearDescOverflowState_();
       }
@@ -469,25 +469,37 @@ export class AmpLightboxGallery extends AMP.BaseElement {
     }, {});
   }
 
+  /**
+   * @private
+   */
   clearDescOverflowState_() {
     this.descriptionBox_./*OK*/scrollTop = 0;
     this.descriptionBox_.classList.remove('i-amphtml-lbg-overflow');
     this.descriptionBox_.classList.add('i-amphtml-lbg-standard');
-    toggle(this.navControls_, true);
+    toggle(dev().assertElement(this.navControls_), true);
   }
 
+  /**
+   * @private
+   */
   nextSlide_() {
     dev().assert(this.carousel_).getImpl().then(carousel => {
       carousel.interactionNext();
     });
   }
 
+  /**
+   * @private
+   */
   prevSlide_() {
     dev().assert(this.carousel_).getImpl().then(carousel => {
       carousel.interactionPrev();
     });
   }
 
+  /**
+   * @private
+   */
   buildNavControls_() {
     this.navControls_ = this.win.document.createElement('div');
     const nextSlide = this.nextSlide_.bind(this);
@@ -510,7 +522,6 @@ export class AmpLightboxGallery extends AMP.BaseElement {
     const close = this.close_.bind(this);
     const openGallery = this.openGallery_.bind(this);
     const closeGallery = this.closeGallery_.bind(this);
-
 
     // TODO(aghassemi): i18n and customization. See https://git.io/v6JWu
     const closeButton = this.buildButton_('Close', 'i-amphtml-lbg-button-close', close);

--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -277,7 +277,6 @@ export class AmpLightboxGallery extends AMP.BaseElement {
       let slide = clonedNode;
       if (ELIGIBLE_TAP_TAGS[clonedNode.tagName]) {
         const container = this.element.ownerDocument.createElement('div');
-        container.classList.add('i-amphtml-image-lightbox-container');
         const imageViewer = this.win.document.createElement('amp-image-viewer');
         imageViewer.setAttribute('layout', 'fill');
         clonedNode.removeAttribute('class');
@@ -405,7 +404,7 @@ export class AmpLightboxGallery extends AMP.BaseElement {
         // of this element to measure 1 rem.
         st.setStyles(dev().assertElement(this.descriptionOverflowMask_), {
           visibility: state.descriptionOverflows || state.isInOverflowMode
-              ? 'visible' : 'hidden',
+            ? 'visible' : 'hidden',
         });
 
         if (state.isInOverflowMode) {
@@ -504,8 +503,10 @@ export class AmpLightboxGallery extends AMP.BaseElement {
     this.navControls_ = this.win.document.createElement('div');
     const nextSlide = this.nextSlide_.bind(this);
     const prevSlide = this.prevSlide_.bind(this);
-    const nextButton = this.buildButton_('Next', 'i-amphtml-lbg-button-next', nextSlide);
-    const prevButton = this.buildButton_('Prev', 'i-amphtml-lbg-button-prev', prevSlide);
+    const nextButton = this.buildButton_('Next',
+        'i-amphtml-lbg-button-next', nextSlide);
+    const prevButton = this.buildButton_('Prev',
+        'i-amphtml-lbg-button-prev', prevSlide);
     this.navControls_.appendChild(nextButton);
     this.navControls_.appendChild(prevButton);
     this.controlsContainer_.appendChild(this.navControls_);
@@ -524,9 +525,12 @@ export class AmpLightboxGallery extends AMP.BaseElement {
     const closeGallery = this.closeGallery_.bind(this);
 
     // TODO(aghassemi): i18n and customization. See https://git.io/v6JWu
-    const closeButton = this.buildButton_('Close', 'i-amphtml-lbg-button-close', close);
-    const openGalleryButton = this.buildButton_('Gallery', 'i-amphtml-lbg-button-gallery', openGallery);
-    const closeGalleryButton = this.buildButton_('Content', 'i-amphtml-lbg-button-slide', closeGallery);
+    const closeButton = this.buildButton_('Close',
+        'i-amphtml-lbg-button-close', close);
+    const openGalleryButton = this.buildButton_('Gallery',
+        'i-amphtml-lbg-button-gallery', openGallery);
+    const closeGalleryButton = this.buildButton_('Content',
+        'i-amphtml-lbg-button-slide', closeGallery);
 
     this.topBar_.appendChild(closeButton);
     this.topBar_.appendChild(openGalleryButton);

--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -127,6 +127,9 @@ export class AmpLightboxGallery extends AMP.BaseElement {
     this.controlsContainer_ = null;
 
     /** @private {?Element} */
+    this.navControls_ = null;
+
+    /** @private {?Element} */
     this.carousel_ = null;
 
     /** @private {?Element} */
@@ -205,6 +208,7 @@ export class AmpLightboxGallery extends AMP.BaseElement {
     this.controlsContainer_.classList.add('i-amphtml-lbg-controls');
     this.buildDescriptionBox_();
     this.buildTopBar_();
+    this.buildNavControls_();
     this.vsync_.mutate(() => {
       this.container_.appendChild(this.controlsContainer_);
     });
@@ -445,10 +449,12 @@ export class AmpLightboxGallery extends AMP.BaseElement {
       if (state.isInStandardMode && state.descriptionOverflows) {
         this.descriptionBox_.classList.remove('i-amphtml-lbg-standard');
         this.descriptionBox_.classList.add('i-amphtml-lbg-overflow');
+        toggle(this.navControls_, false);
       } else if (state.isInOverflowMode) {
         this.descriptionBox_./*OK*/scrollTop = 0;
         this.descriptionBox_.classList.remove('i-amphtml-lbg-overflow');
         this.descriptionBox_.classList.add('i-amphtml-lbg-standard');
+        toggle(this.navControls_, true);
       }
     };
 
@@ -470,6 +476,16 @@ export class AmpLightboxGallery extends AMP.BaseElement {
     });
   }
 
+  buildNavControls_() {
+    this.navControls_ = this.win.document.createElement('div');
+    const nextSlide = this.nextSlide_.bind(this);
+    const prevSlide = this.prevSlide_.bind(this);
+    const nextButton = this.buildButton_('Next', 'i-amphtml-lbg-button-next', nextSlide);
+    const prevButton = this.buildButton_('Prev', 'i-amphtml-lbg-button-prev', prevSlide);
+    this.navControls_.appendChild(nextButton);
+    this.navControls_.appendChild(prevButton);
+    this.controlsContainer_.appendChild(this.navControls_);
+  }
   /**
    * Builds the top bar containing buttons and appends them to the container.
    * @private
@@ -482,15 +498,16 @@ export class AmpLightboxGallery extends AMP.BaseElement {
     const close = this.close_.bind(this);
     const openGallery = this.openGallery_.bind(this);
     const closeGallery = this.closeGallery_.bind(this);
-    const nextSlide = this.nextSlide_.bind(this);
-    const prevSlide = this.prevSlide_.bind(this);
+
 
     // TODO(aghassemi): i18n and customization. See https://git.io/v6JWu
-    this.buildButton_('Close', 'i-amphtml-lbg-button-close', close);
-    this.buildButton_('Gallery', 'i-amphtml-lbg-button-gallery', openGallery);
-    this.buildButton_('Content', 'i-amphtml-lbg-button-slide', closeGallery);
-    this.buildButton_('Next', 'i-amphtml-lbg-button-next', nextSlide);
-    this.buildButton_('Prev', 'i-amphtml-lbg-button-prev', prevSlide);
+    const closeButton = this.buildButton_('Close', 'i-amphtml-lbg-button-close', close);
+    const openGalleryButton = this.buildButton_('Gallery', 'i-amphtml-lbg-button-gallery', openGallery);
+    const closeGalleryButton = this.buildButton_('Content', 'i-amphtml-lbg-button-slide', closeGallery);
+
+    this.topBar_.appendChild(closeButton);
+    this.topBar_.appendChild(openGalleryButton);
+    this.topBar_.appendChild(closeGalleryButton);
 
     this.controlsContainer_.appendChild(this.topBar_);
   }
@@ -519,8 +536,7 @@ export class AmpLightboxGallery extends AMP.BaseElement {
       event.stopPropagation();
       event.preventDefault();
     });
-
-    this.topBar_.appendChild(button);
+    return button;
   }
 
   /**
@@ -1174,6 +1190,7 @@ export class AmpLightboxGallery extends AMP.BaseElement {
       this.findOrBuildGallery_();
     }
     this.container_.setAttribute('gallery-view', '');
+    toggle(dev().assertElement(this.navControls_), false);
     toggle(dev().assertElement(this.carousel_), false);
     toggle(dev().assertElement(this.descriptionBox_), false);
   }
@@ -1184,6 +1201,7 @@ export class AmpLightboxGallery extends AMP.BaseElement {
    */
   closeGallery_() {
     this.container_.removeAttribute('gallery-view');
+    toggle(dev().assertElement(this.navControls_), true);
     toggle(dev().assertElement(this.carousel_), true);
     this.updateDescriptionBox_();
     toggle(dev().assertElement(this.descriptionBox_), true);
@@ -1261,7 +1279,6 @@ export class AmpLightboxGallery extends AMP.BaseElement {
     const closeGalleryAndShowTargetSlide = event => {
       this.closeGallery_();
       this.currentElemId_ = thumbnailObj.element.lightboxItemId;
-      this.updateDescriptionBox_();
       dev().assert(this.carousel_).getImpl()
           .then(carousel => carousel.showSlideWhenReady(this.currentElemId_));
       this.updateDescriptionBox_();

--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -458,6 +458,18 @@ export class AmpLightboxGallery extends AMP.BaseElement {
     }, {});
   }
 
+  nextSlide_() {
+    dev().assert(this.carousel_).getImpl().then(carousel => {
+      carousel.interactionNext();
+    });
+  }
+
+  prevSlide_() {
+    dev().assert(this.carousel_).getImpl().then(carousel => {
+      carousel.interactionPrev();
+    });
+  }
+
   /**
    * Builds the top bar containing buttons and appends them to the container.
    * @private
@@ -470,11 +482,15 @@ export class AmpLightboxGallery extends AMP.BaseElement {
     const close = this.close_.bind(this);
     const openGallery = this.openGallery_.bind(this);
     const closeGallery = this.closeGallery_.bind(this);
+    const nextSlide = this.nextSlide_.bind(this);
+    const prevSide = this.prevSlide_.bind(this);
 
     // TODO(aghassemi): i18n and customization. See https://git.io/v6JWu
     this.buildButton_('Close', 'i-amphtml-lbg-button-close', close);
     this.buildButton_('Gallery', 'i-amphtml-lbg-button-gallery', openGallery);
     this.buildButton_('Content', 'i-amphtml-lbg-button-slide', closeGallery);
+    this.buildButton_('Next', 'i-amphtml-lbg-button-next', nextSlide);
+    this.buildButton_('Prev', 'i-amphtml-lbg-button-prev', prevSlide);
 
     this.controlsContainer_.appendChild(this.topBar_);
   }


### PR DESCRIPTION
We want to remove the next / prev buttons on lightbox when we toggle the description overflow, so that they don't obscure the text. We also wanted new icons (with drop shadow) for these next / prev arrows on lightbox. 

<img width="463" alt="screen shot 2018-04-04 at 4 00 41 pm" src="https://user-images.githubusercontent.com/1528181/38339152-a53ffe9c-3821-11e8-9dc6-90995b99eb16.png">
<img width="954" alt="screen shot 2018-04-04 at 4 02 39 pm" src="https://user-images.githubusercontent.com/1528181/38339153-a552d738-3821-11e8-8b91-099d607deca5.png">
