### PR TITLE
🏗 Use a mock instead of a stub to catch console errors during tests

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -30,7 +30,8 @@
     "sandbox": true,
     "context": false,
     "global": false,
-    "describes": true
+    "describes": true,
+    "allowConsoleError": false
   },
   "rules": {
     "amphtml-internal/closure-type-primitives": 2,

--- a/ads/google/test/test-adsense.js
+++ b/ads/google/test/test-adsense.js
@@ -84,14 +84,19 @@ describes.realWin('adsenseDelayedFetch', {}, env => {
     data['fullWidth'] = 'true';
     data['autoFormat'] = 'rspv';
     data['height'] = '666';
-    expect(() => adsense(env.win, data)).to.throw(
-        /Specified height 666 in <amp-ad> tag is not equal to the required/);
+    allowConsoleError(() => {
+      expect(() => adsense(env.win, data)).to.throw(
+          /Specified height 666 in <amp-ad> tag is not equal to the required/);
+    });
   });
 
   it('should throw on missing fullWidth field for responsive ad unit', () => {
     data['autoFormat'] = 'rspv';
     data['height'] = '320';
-    expect(() => adsense(env.win, data)).to.throw(
-        /Responsive AdSense ad units require the attribute data-full-width.​/);
+    allowConsoleError(() => {
+      expect(() => adsense(env.win, data)).to.throw(
+          /Responsive AdSense ad units require the attribute data-full-width.​/
+      );
+    });
   });
 });

--- a/build-system/tasks/karma.conf.js
+++ b/build-system/tasks/karma.conf.js
@@ -66,7 +66,7 @@ module.exports = {
     suppressSkipped: true,
     suppressFailed: false,
     suppressErrorSummary: true,
-    maxLogLines: 10,
+    maxLogLines: 20,
   },
 
   mochaReporter: {

--- a/build-system/tasks/karma.conf.js
+++ b/build-system/tasks/karma.conf.js
@@ -197,7 +197,8 @@ module.exports = {
       // Longer timeout on Travis; fail quickly at local.
       timeout: process.env.TRAVIS ? 10000 : 2000,
     },
-    captureConsole: false,
+    // TODO(rsimha, #14432): Set to false after all tests are fixed.
+    captureConsole: true,
   },
 
   singleRun: true,

--- a/extensions/amp-3q-player/0.1/test/test-amp-3q-player.js
+++ b/extensions/amp-3q-player/0.1/test/test-amp-3q-player.js
@@ -64,8 +64,10 @@ describes.realWin('amp-3q-player', {
   });
 
   it('requires data-id', () => {
-    return get3QElement('').should.eventually.be.rejectedWith(
-        /The data-id attribute is required/);
+    allowConsoleError(() => {
+      return get3QElement('').should.eventually.be.rejectedWith(
+          /The data-id attribute is required/);
+    });
   });
 
   it('should forward events from amp-3q-player to the amp element', () => {

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -1928,9 +1928,9 @@ describe('amp-a4a', () => {
     });
 
     it('should rethrow cancellation', () => {
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         a4a.promiseErrorHandler_(cancellation());
-      }).to.throw(/CANCELLED/);
+      }).to.throw(/CANCELLED/); });
     });
 
     it('should create an error if needed', () => {

--- a/extensions/amp-access/0.1/test/test-access-expr.js
+++ b/extensions/amp-access/0.1/test/test-access-expr.js
@@ -20,9 +20,9 @@ import {evaluateAccessExpr} from '../access-expr';
 describe('evaluateAccessExpr', () => {
 
   it('should NOT allow double equal', () => {
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       evaluateAccessExpr('access == true', {});
-    }).to.throw(/\"\=\=\" is not allowed, use \"\=\"/);
+    }).to.throw(/\"\=\=\" is not allowed, use \"\=\"/); });
   });
 
   it('should evaluate simple boolean expressions', () => {
@@ -256,18 +256,18 @@ describe('evaluateAccessExpr', () => {
 
     expect(evaluateAccessExpr('obj.other = NULL', {obj: 11})).to.be.true;
 
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       evaluateAccessExpr('obj.NULL', {});
-    }).to.throw();
-    expect(() => {
+    }).to.throw(); });
+    allowConsoleError(() => { expect(() => {
       evaluateAccessExpr('NULL.obj', {});
-    }).to.throw();
-    expect(() => {
+    }).to.throw(); });
+    allowConsoleError(() => { expect(() => {
       evaluateAccessExpr('1.obj', {});
-    }).to.throw();
-    expect(() => {
+    }).to.throw(); });
+    allowConsoleError(() => { expect(() => {
       evaluateAccessExpr('TRUE.obj', {});
-    }).to.throw();
+    }).to.throw(); });
   });
 
   it('should evaluate nested expressions securely', () => {
@@ -280,14 +280,14 @@ describe('evaluateAccessExpr', () => {
     expect(evaluateAccessExpr('num_ = 10', {num_: 10})).to.be.true;
     expect(evaluateAccessExpr('_num = 10', {_num: 10})).to.be.true;
 
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       evaluateAccessExpr('1num = 10', {'1num': 10});
-    }).to.throw();
-    expect(() => {
+    }).to.throw(); });
+    allowConsoleError(() => { expect(() => {
       evaluateAccessExpr('num-a = 10', {'num-a': 10});
-    }).to.throw();
-    expect(() => {
+    }).to.throw(); });
+    allowConsoleError(() => { expect(() => {
       evaluateAccessExpr('num-1 = 10', {'num-1': 10});
-    }).to.throw();
+    }).to.throw(); });
   });
 });

--- a/extensions/amp-access/0.1/test/test-amp-access-client.js
+++ b/extensions/amp-access/0.1/test/test-amp-access-client.js
@@ -93,33 +93,33 @@ describes.realWin('AccessClientAdapter', {
 
     it('should fail when authorization timeout is malformed', () => {
       validConfig['authorizationTimeout'] = 'someString';
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         new AccessClientAdapter(ampdoc, validConfig, context);
-      }).to.throw(/"authorizationTimeout" must be a number/);
+      }).to.throw(/"authorizationTimeout" must be a number/); });
     });
 
     it('should fail if config authorization is missing or malformed', () => {
       delete validConfig['authorization'];
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         new AccessClientAdapter(ampdoc, validConfig, context);
-      }).to.throw(/"authorization" URL must be specified/);
+      }).to.throw(/"authorization" URL must be specified/); });
 
       validConfig['authorization'] = 'http://acme.com/a';
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         new AccessClientAdapter(ampdoc, validConfig, context);
-      }).to.throw(/"authorization".*https\:/);
+      }).to.throw(/"authorization".*https\:/); });
     });
 
     it('should fail if config pingback is missing or malformed', () => {
       delete validConfig['pingback'];
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         new AccessClientAdapter(ampdoc, validConfig, context);
-      }).to.throw(/"pingback" URL must be specified/);
+      }).to.throw(/"pingback" URL must be specified/); });
 
       validConfig['pingback'] = 'http://acme.com/p';
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         new AccessClientAdapter(ampdoc, validConfig, context);
-      }).to.throw(/"pingback".*https\:/);
+      }).to.throw(/"pingback".*https\:/); });
     });
 
     it('should allow missing pingback when noPingback=true', () => {

--- a/extensions/amp-access/0.1/test/test-amp-access-iframe.js
+++ b/extensions/amp-access/0.1/test/test-amp-access-iframe.js
@@ -76,30 +76,30 @@ describes.realWin('AccessIframeAdapter', {
 
     it('should require "iframeSrc"', () => {
       delete validConfig['iframeSrc'];
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         new AccessIframeAdapter(ampdoc, validConfig, context);
-      }).to.throw(/iframeSrc/);
+      }).to.throw(/iframeSrc/); });
     });
 
     it('should require "iframeSrc" to be secure', () => {
       validConfig['iframeSrc'] = 'http://acme.com/iframe';
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         new AccessIframeAdapter(ampdoc, validConfig, context);
-      }).to.throw(/https/);
+      }).to.throw(/https/); });
     });
 
     it('should require "defaultResponse"', () => {
       delete validConfig['defaultResponse'];
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         new AccessIframeAdapter(ampdoc, validConfig, context);
-      }).to.throw(/defaultResponse/);
+      }).to.throw(/defaultResponse/); });
     });
 
     it('should disallow non-array vars', () => {
       validConfig['iframeVars'] = {};
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         new AccessIframeAdapter(ampdoc, validConfig, context);
-      }).to.throw(/array/);
+      }).to.throw(/array/); });
     });
   });
 

--- a/extensions/amp-access/0.1/test/test-amp-access-other.js
+++ b/extensions/amp-access/0.1/test/test-amp-access-other.js
@@ -104,9 +104,9 @@ describes.realWin('AccessOtherAdapter', {amp: true}, env => {
       adapter.isProxyOrigin_ = true;
       adapter.authorizationResponse_ = {};
       contextMock.expects('buildUrl').never();
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         adapter.authorize();
-      }).to.throw();
+      }).to.throw(); });
     });
 
     it('should respond to authorization when not on proxy proxy', () => {

--- a/extensions/amp-access/0.1/test/test-amp-access-server-jwt.js
+++ b/extensions/amp-access/0.1/test/test-amp-access-server-jwt.js
@@ -78,23 +78,23 @@ describes.realWin('AccessServerJwtAdapter', {amp: true}, env => {
 
     it('should fail if config is invalid: authorization', () => {
       delete validConfig['authorization'];
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         new AccessServerJwtAdapter(ampdoc, validConfig, context);
-      }).to.throw(/"authorization" URL must be specified/);
+      }).to.throw(/"authorization" URL must be specified/); });
     });
 
     it('should fail if config is invalid: publicKeyUrl', () => {
       delete validConfig['publicKeyUrl'];
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         new AccessServerJwtAdapter(ampdoc, validConfig, context);
-      }).to.throw(/"publicKey" or "publicKeyUrl" must be specified/);
+      }).to.throw(/"publicKey" or "publicKeyUrl" must be specified/); });
     });
 
     it('should fail if config is invalid: http publicKeyUrl', () => {
       validConfig['publicKeyUrl'] = 'http://acme.com/pk';
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         new AccessServerJwtAdapter(ampdoc, validConfig, context);
-      }).to.throw(/https/);
+      }).to.throw(/https/); });
     });
 
     it('should support either publicKey or publicKeyUrl', () => {
@@ -589,23 +589,23 @@ describes.realWin('AccessServerJwtAdapter', {amp: true}, env => {
 
       it('should fail w/o exp', () => {
         delete jwt['exp'];
-        expect(() => {
+        allowConsoleError(() => { expect(() => {
           adapter.validateJwt_(jwt);
-        }).to.throw(/"exp" field must be specified/);
+        }).to.throw(/"exp" field must be specified/); });
       });
 
       it('should fail w/invalid exp', () => {
         jwt['exp'] = 'invalid';
-        expect(() => {
+        allowConsoleError(() => { expect(() => {
           adapter.validateJwt_(jwt);
-        }).to.throw();
+        }).to.throw(); });
       });
 
       it('should fail when expired', () => {
         jwt['exp'] = Math.floor((Date.now() - 10000) / 1000);
-        expect(() => {
+        allowConsoleError(() => { expect(() => {
           adapter.validateJwt_(jwt);
-        }).to.throw(/token has expired/);
+        }).to.throw(/token has expired/); });
       });
 
       it('should succeed with array aud', () => {
@@ -621,23 +621,23 @@ describes.realWin('AccessServerJwtAdapter', {amp: true}, env => {
 
       it('should fail w/o aud', () => {
         delete jwt['aud'];
-        expect(() => {
+        allowConsoleError(() => { expect(() => {
           adapter.validateJwt_(jwt);
-        }).to.throw(/"aud" field must be specified/);
+        }).to.throw(/"aud" field must be specified/); });
       });
 
       it('should fail w/non-AMP aud', () => {
         jwt['aud'] = 'other.org';
-        expect(() => {
+        allowConsoleError(() => { expect(() => {
           adapter.validateJwt_(jwt);
-        }).to.throw(/"aud" must be "ampproject.org"/);
+        }).to.throw(/"aud" must be "ampproject.org"/); });
       });
 
       it('should fail w/non-AMP aud array', () => {
         jwt['aud'] = ['another.org', 'other.org'];
-        expect(() => {
+        allowConsoleError(() => { expect(() => {
           adapter.validateJwt_(jwt);
-        }).to.throw(/"aud" must be "ampproject.org"/);
+        }).to.throw(/"aud" must be "ampproject.org"/); });
       });
     });
 

--- a/extensions/amp-access/0.1/test/test-amp-access-server.js
+++ b/extensions/amp-access/0.1/test/test-amp-access-server.js
@@ -73,9 +73,9 @@ describes.realWin('AccessServerAdapter', {amp: true}, env => {
 
     it('should fail if config is invalid', () => {
       delete validConfig['authorization'];
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         new AccessServerAdapter(ampdoc, validConfig, context);
-      }).to.throw(/"authorization" URL must be specified/);
+      }).to.throw(/"authorization" URL must be specified/); });
     });
 
     it('should tolerate when i-amphtml-access-state is missing', () => {

--- a/extensions/amp-access/0.1/test/test-amp-access-vendor.js
+++ b/extensions/amp-access/0.1/test/test-amp-access-vendor.js
@@ -45,9 +45,9 @@ describes.realWin('AccessVendorAdapter', {amp: true}, env => {
 
     it('should require vendor name', () => {
       delete validConfig['vendor'];
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         new AccessVendorAdapter(ampdoc, validConfig);
-      }).to.throw(/"vendor" name must be specified/);
+      }).to.throw(/"vendor" name must be specified/); });
     });
 
     it('should wait on registration', () => {
@@ -65,9 +65,9 @@ describes.realWin('AccessVendorAdapter', {amp: true}, env => {
       const adapter = new AccessVendorAdapter(ampdoc, validConfig);
       expect(adapter.vendorResolve_).to.exist;
       adapter.registerVendor('vendor1', {});
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         adapter.registerVendor('vendor2', {});
-      }).to.throw(/Vendor has already been registered/);
+      }).to.throw(/Vendor has already been registered/); });
     });
   });
 

--- a/extensions/amp-access/0.1/test/test-amp-access.js
+++ b/extensions/amp-access/0.1/test/test-amp-access.js
@@ -61,17 +61,17 @@ describes.fakeWin('AccessService', {
   });
 
   it('should fail if config is malformed', () => {
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       new AccessService(ampdoc);
-    }).to.throw(Error);
+    }).to.throw(Error); });
   });
 
   it('should default to "client" and fail if authorization is missing', () => {
     const config = {};
     element.textContent = JSON.stringify(config);
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       new AccessService(ampdoc);
-    }).to.throw(/"authorization" URL must be specified/);
+    }).to.throw(/"authorization" URL must be specified/); });
   });
 
   it('should fail if config login is malformed', () => {
@@ -81,9 +81,9 @@ describes.fakeWin('AccessService', {
       'login': 'http://acme.com/l',
     };
     element.textContent = JSON.stringify(config);
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       new AccessService(ampdoc);
-    }).to.throw(/https\:/);
+    }).to.throw(/https\:/); });
   });
 
   it('should parse the complete config', () => {
@@ -111,9 +111,9 @@ describes.fakeWin('AccessService', {
       'login': 'https://acme.com/l',
     };
     element.textContent = JSON.stringify(config);
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       new AccessService(ampdoc);
-    }).to.throw(/Unknown access type/);
+    }).to.throw(/Unknown access type/); });
   });
 
   it('should start when enabled', () => {
@@ -186,9 +186,9 @@ describes.fakeWin('AccessService', {
     };
     element.textContent = JSON.stringify(config);
     const accessService = new AccessService(ampdoc);
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       accessService.getVendorSource('vendor1');
-    }).to.throw(/can only be used for "type=vendor"/);
+    }).to.throw(/can only be used for "type=vendor"/); });
   });
 
   it('should parse multiple sources', () => {
@@ -229,15 +229,15 @@ describes.fakeWin('AccessService', {
       },
     ];
     element.textContent = JSON.stringify(config);
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       new AccessService(ampdoc);
-    }).to.throw(/Namespace already used/);
+    }).to.throw(/Namespace already used/); });
 
     delete (config[0].namespace);
     element.textContent = JSON.stringify(config);
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       new AccessService(ampdoc);
-    }).to.throw(/Namespace required/);
+    }).to.throw(/Namespace required/); });
   });
 });
 
@@ -1150,7 +1150,10 @@ describes.fakeWin('AccessService login', {
 
   it('should fail to open dialog if loginUrl is not built yet', () => {
     service.sources_[0].loginUrlMap_[''] = null;
-    expect(() => service.loginWithType_('')).to.throw(/Login URL is not ready/);
+    allowConsoleError(() => {
+      expect(() => service.loginWithType_('')).to.throw(
+          /Login URL is not ready/);
+    });
   });
 
   it('should succeed login with success=true', () => {

--- a/extensions/amp-access/0.1/test/test-amp-login-done-dialog.js
+++ b/extensions/amp-access/0.1/test/test-amp-login-done-dialog.js
@@ -248,9 +248,9 @@ describe('LoginDoneDialog', () => {
           encodeURIComponent(
               encodeURIComponent(encodeURIComponent('https://acme.com/doc1')));
       windowApi.opener = null;
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         dialog.postbackOrRedirect_();
-      }).to.throw(/URL must start with/);
+      }).to.throw(/URL must start with/); });
       expect(windowApi.location.replace).to.have.not.been.called;
     });
 
@@ -258,9 +258,9 @@ describe('LoginDoneDialog', () => {
       windowApi.location.search = '?url=' +
           encodeURIComponent(/*eslint no-script-url: 0*/ 'javascript:alert(1)');
       windowApi.opener = null;
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         dialog.postbackOrRedirect_();
-      }).to.throw(/URL must start with/);
+      }).to.throw(/URL must start with/); });
       expect(windowApi.location.replace).to.have.not.been.called;
     });
 

--- a/extensions/amp-access/0.1/test/test-iframe-messenger.js
+++ b/extensions/amp-access/0.1/test/test-iframe-messenger.js
@@ -43,9 +43,9 @@ describes.fakeWin('Messenger', {}, env => {
     });
 
     it('should now allow connecting twice', () => {
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         messenger.connect(onCommand);
-      }).to.throw(/already connected/);
+      }).to.throw(/already connected/); });
     });
 
     it('should add and remove message listener', () => {
@@ -62,9 +62,9 @@ describes.fakeWin('Messenger', {}, env => {
     });
 
     it('should fail target until connected', () => {
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         messenger.getTarget();
-      }).to.throw(/not connected/);
+      }).to.throw(/not connected/); });
     });
 
     it('should succeed target once connected', () => {
@@ -78,9 +78,9 @@ describes.fakeWin('Messenger', {}, env => {
     });
 
     it('should fail sending a command until connected', () => {
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         messenger.sendCommand('start', {});
-      }).to.throw(/not connected/);
+      }).to.throw(/not connected/); });
     });
 
     it('should send a command once connected', () => {
@@ -214,7 +214,9 @@ describes.fakeWin('Messenger', {}, env => {
       return promise.then(() => {
         throw new Error('must have failed');
       }, reason => {
-        expect(() => {throw reason;}).to.throw(/intentional/);
+        allowConsoleError(() => {
+          expect(() => {throw reason;}).to.throw(/intentional/);
+        });
       });
     });
 
@@ -319,15 +321,15 @@ describes.fakeWin('Messenger', {}, env => {
 
     it('should fail to return origin until connected', () => {
       expect(messenger.isConnected()).to.be.false;
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         messenger.getTargetOrigin();
-      }).to.throw(/not connected/);
+      }).to.throw(/not connected/); });
     });
 
     it('should disallow other commands before connect', () => {
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         messenger.sendCommand('other', {});
-      }).to.throw(/not connected/);
+      }).to.throw(/not connected/); });
       expect(target.postMessage).to.not.be.called;
     });
 
@@ -376,9 +378,9 @@ describes.fakeWin('Messenger', {}, env => {
         data: {sentinel: '__AMP__', cmd: 'other', payload: {a: 1}},
       });
       expect(messenger.isConnected()).to.be.false;
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         messenger.getTargetOrigin();
-      }).to.throw(/not connected/);
+      }).to.throw(/not connected/); });
       expect(onCommand).to.not.be.called;
     });
   });

--- a/extensions/amp-access/0.1/test/test-jwt.js
+++ b/extensions/amp-access/0.1/test/test-jwt.js
@@ -63,23 +63,23 @@ describe('JwtHelper', () => {
     });
 
     it('should fail on invalid format', () => {
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         helper.decodeInternal_('ABC');
-      }).to.throw(/Invalid token/);
+      }).to.throw(/Invalid token/); });
     });
 
     it('should fail on invalid JSON in header', () => {
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         helper.decodeInternal_(
             `${TOKEN_HEADER.substring(1)}.${TOKEN_PAYLOAD}.${TOKEN_SIG}`);
-      }).to.throw(/Invalid token/);
+      }).to.throw(/Invalid token/); });
     });
 
     it('should fail on invalid JSON in payload', () => {
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         helper.decodeInternal_(
             `${TOKEN_HEADER}.${TOKEN_PAYLOAD.substring(1)}.${TOKEN_SIG}`);
-      }).to.throw(/Invalid token/);
+      }).to.throw(/Invalid token/); });
     });
 
     it('should decode web safe and non-web-safe base64', () => {

--- a/extensions/amp-access/0.1/test/test-signin.js
+++ b/extensions/amp-access/0.1/test/test-signin.js
@@ -122,7 +122,7 @@ describes.realWin('SignInProtocol', {amp: true}, env => {
     it('should disallow invalid signinServices', () => {
       // Not an array.
       configJson['signinServices'] = 'https://authority.acme.com';
-      expect(() => create()).to.throw(/array/);
+      allowConsoleError(() => { expect(() => create()).to.throw(/array/); });
     });
   });
 

--- a/extensions/amp-ad-network-adzerk-impl/0.1/test/test-amp-ad-network-adzerk-impl.js
+++ b/extensions/amp-ad-network-adzerk-impl/0.1/test/test-amp-ad-network-adzerk-impl.js
@@ -66,7 +66,9 @@ describes.fakeWin('amp-ad-network-adzerk-impl', {amp: true}, env => {
     });
 
     it('should be invalid', () => {
-      expect(() => impl.getAdUrl()).to.throw(/Expected data-r attribte/);
+      allowConsoleError(() => {
+        expect(() => impl.getAdUrl()).to.throw(/Expected data-r attribte/);
+      });
     });
   });
 

--- a/extensions/amp-ad/0.1/test/test-amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-3p-impl.js
@@ -143,7 +143,9 @@ describes.realWin('amp-ad-3p-impl', {
     it('should throw on position:fixed', () => {
       ad3p.element.style.position = 'fixed';
       ad3p.onLayoutMeasure();
-      expect(() => ad3p.layoutCallback()).to.throw('position:fixed');
+      allowConsoleError(() => {
+        expect(() => ad3p.layoutCallback()).to.throw('position:fixed');
+      });
     });
 
     it('should throw on parent being position:fixed', () => {
@@ -154,7 +156,9 @@ describes.realWin('amp-ad-3p-impl', {
       adContainerElement.appendChild(ad3p.element);
 
       ad3p.onLayoutMeasure();
-      expect(() => ad3p.layoutCallback()).to.throw('position:fixed');
+      allowConsoleError(() => {
+        expect(() => ad3p.layoutCallback()).to.throw('position:fixed');
+      });
     });
 
     it('should allow position:fixed with whitelisted ad container', () => {

--- a/extensions/amp-ad/0.1/test/test-amp-ad-custom.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-custom.js
@@ -208,26 +208,28 @@ describe('Amp custom ad', () => {
       removeChildren(elem);
       const ad = new AmpAdCustom(elem);
       ad.buildCallback();
-      expect(() => {
-        ad.handleTemplateData_({
-          'data': {
-            'a': '1',
-            'b': '2',
-          },
-          'vars': {
-            'abc': '456',
-          },
-        });
-      }).to.throw('TemplateId not specified');
+      allowConsoleError(() => {
+        expect(() => {
+          ad.handleTemplateData_({
+            'data': {
+              'a': '1',
+              'b': '2',
+            },
+            'vars': {
+              'abc': '456',
+            },
+          });
+        }).to.throw('TemplateId not specified');
 
-      expect(() => {
-        ad.handleTemplateData_({
-          'templateId': '1',
-          'vars': {
-            'abc': '456',
-          },
-        });
-      }).to.throw('Template data not specified');
+        expect(() => {
+          ad.handleTemplateData_({
+            'templateId': '1',
+            'vars': {
+              'abc': '456',
+            },
+          });
+        }).to.throw('Template data not specified');
+      });
     });
   });
 });

--- a/extensions/amp-ad/0.1/test/test-concurrent-load.js
+++ b/extensions/amp-ad/0.1/test/test-concurrent-load.js
@@ -62,7 +62,9 @@ describes.realWin('concurrent-load', {}, env => {
       const element = createElementWithAttributes(env.win.document, 'amp-ad', {
         'data-loading-strategy': loadingStrategy,
       });
-      expect(() => getAmpAdRenderOutsideViewport(element)).to.throw();
+      allowConsoleError(() => {
+        expect(() => getAmpAdRenderOutsideViewport(element)).to.throw();
+      });
     }
   });
 

--- a/extensions/amp-analytics/0.1/test/test-amp-analytics.js
+++ b/extensions/amp-analytics/0.1/test/test-amp-analytics.js
@@ -450,9 +450,9 @@ describes.realWin('amp-analytics', {
     const analytics = getAnalyticsTag();
     // An incomplete click request.
     analytics.addTriggerNoInline_({'on': 'click'});
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       clock.tick(1);
-    }).to.throw(/Failed to process trigger/);
+    }).to.throw(/Failed to process trigger/); });
   });
 
   it('expands recursive requests', function() {

--- a/extensions/amp-analytics/0.1/test/test-events.js
+++ b/extensions/amp-analytics/0.1/test/test-events.js
@@ -79,9 +79,9 @@ describes.realWin('Events', {amp: 1}, env => {
     });
 
     it('should require selector', () => {
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         tracker.add(analyticsElement, 'click', {selector: ''});
-      }).to.throw(/Missing required selector/);
+      }).to.throw(/Missing required selector/); });
     });
 
     it('should add listener', () => {
@@ -570,53 +570,55 @@ describes.realWin('Events', {amp: 1}, env => {
 
     it('should validate timerSpec', () => {
       const handler = sandbox.stub();
-      expect(() => {
-        tracker.add(analyticsElement, 'timer', {}, handler);
-      }).to.throw(/Bad timer specification/);
-      expect(() => {
-        tracker.add(analyticsElement, 'timer', {timerSpec: 1}, handler);
-      }).to.throw(/Bad timer specification/);
-      expect(() => {
-        tracker.add(analyticsElement, 'timer', {timerSpec: {}}, handler);
-      }).to.throw(/Timer interval specification required/);
-      expect(() => {
-        tracker.add(analyticsElement, 'timer', {timerSpec: {
-          interval: null,
-        }}, handler);
-      }).to.throw(/Bad timer interval specification/);
-      expect(() => {
-        tracker.add(analyticsElement, 'timer', {timerSpec: {
-          interval: 'two',
-        }}, handler);
-      }).to.throw(/Bad timer interval specification/);
-      expect(() => {
-        tracker.add(analyticsElement, 'timer', {timerSpec: {
-          interval: 0.1,
-        }}, handler);
-      }).to.throw(/Bad timer interval specification/);
-      expect(() => {
-        tracker.add(analyticsElement, 'timer', {timerSpec: {
-          interval: 0.49,
-        }}, handler);
-      }).to.throw(/Bad timer interval specification/);
-      expect(() => {
-        tracker.add(analyticsElement, 'timer', {timerSpec: {
-          interval: 1,
-          maxTimerLength: '',
-        }}, handler);
-      }).to.throw(/Bad maxTimerLength specification/);
-      expect(() => {
-        tracker.add(analyticsElement, 'timer', {timerSpec: {
-          interval: 1,
-          maxTimerLength: 0,
-        }}, handler);
-      }).to.throw(/Bad maxTimerLength specification/);
-      expect(() => {
-        tracker.add(analyticsElement, 'timer', {timerSpec: {
-	  interval: 1,
-	  startSpec: {on: 'timer', selector: '.target'},
-        }}, handler);
-      }).to.throw(/Cannot track timer start/);
+      allowConsoleError(() => {
+        expect(() => {
+          tracker.add(analyticsElement, 'timer', {}, handler);
+        }).to.throw(/Bad timer specification/);
+        expect(() => {
+          tracker.add(analyticsElement, 'timer', {timerSpec: 1}, handler);
+        }).to.throw(/Bad timer specification/);
+        expect(() => {
+          tracker.add(analyticsElement, 'timer', {timerSpec: {}}, handler);
+        }).to.throw(/Timer interval specification required/);
+        expect(() => {
+          tracker.add(analyticsElement, 'timer', {timerSpec: {
+            interval: null,
+          }}, handler);
+        }).to.throw(/Bad timer interval specification/);
+        expect(() => {
+          tracker.add(analyticsElement, 'timer', {timerSpec: {
+            interval: 'two',
+          }}, handler);
+        }).to.throw(/Bad timer interval specification/);
+        expect(() => {
+          tracker.add(analyticsElement, 'timer', {timerSpec: {
+            interval: 0.1,
+          }}, handler);
+        }).to.throw(/Bad timer interval specification/);
+        expect(() => {
+          tracker.add(analyticsElement, 'timer', {timerSpec: {
+            interval: 0.49,
+          }}, handler);
+        }).to.throw(/Bad timer interval specification/);
+        expect(() => {
+          tracker.add(analyticsElement, 'timer', {timerSpec: {
+            interval: 1,
+            maxTimerLength: '',
+          }}, handler);
+        }).to.throw(/Bad maxTimerLength specification/);
+        expect(() => {
+          tracker.add(analyticsElement, 'timer', {timerSpec: {
+            interval: 1,
+            maxTimerLength: 0,
+          }}, handler);
+        }).to.throw(/Bad maxTimerLength specification/);
+        expect(() => {
+          tracker.add(analyticsElement, 'timer', {timerSpec: {
+            interval: 1,
+            startSpec: {on: 'timer', selector: '.target'},
+          }}, handler);
+        }).to.throw(/Cannot track timer start/);
+      });
 
       expect(handler).to.not.be.called;
       expect(() => {
@@ -722,11 +724,11 @@ describes.realWin('Events', {amp: 1}, env => {
 
     it('only fires when the timer interval exceeds the minimum', () => {
       const fn1 = sandbox.stub();
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         tracker.add(analyticsElement, 'timer', {timerSpec: {
           interval: 0,
         }}, fn1);
-      }).to.throw();
+      }).to.throw(); });
       expect(fn1).to.have.not.been.called;
 
       const fn2 = sandbox.stub();

--- a/extensions/amp-analytics/0.1/test/test-iframe-transport-client.js
+++ b/extensions/amp-analytics/0.1/test/test-iframe-transport-client.js
@@ -64,30 +64,30 @@ describe('iframe-transport-client', () => {
 
   it('fails to create iframeTransportClient if no window.name ', () => {
     const oldWindowName = window.name;
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       window.name = '';
       new IframeTransportClient(window);
-    }).to.throw(/Cannot read property/);
+    }).to.throw(/Cannot read property/); });
     window.name = oldWindowName;
   });
 
   it('fails to create iframeTransportClient if window.name is missing' +
     ' sentinel', () => {
     const oldWindowName = window.name;
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       window.name = JSON.stringify({type: 'some-vendor'});
       new IframeTransportClient(window);
-    }).to.throw(/missing sentinel/);
+    }).to.throw(/missing sentinel/); });
     window.name = oldWindowName;
   });
 
   it('fails to create iframeTransportClient if window.name is missing' +
     ' type', () => {
     const oldWindowName = window.name;
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       window.name = JSON.stringify({sentinel});
       new IframeTransportClient(window);
-    }).to.throw(/must supply vendor name/);
+    }).to.throw(/must supply vendor name/); });
     window.name = oldWindowName;
   });
 
@@ -108,11 +108,11 @@ describe('iframe-transport-client', () => {
   });
 
   it('requires onNewContextInstance', () => {
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       new IframeTransportContext(window,
           iframeTransportClient.iframeMessagingClient_,
           'my_creative', 'my_vendor');
-    }).to.throw(/Must implement onNewContextInstance/);
+    }).to.throw(/Must implement onNewContextInstance/); });
   });
 
   it('calls onNewContextInstance', () => {

--- a/extensions/amp-analytics/0.1/test/test-instrumentation.js
+++ b/extensions/amp-analytics/0.1/test/test-instrumentation.js
@@ -107,18 +107,18 @@ describes.realWin('InstrumentationService', {amp: 1}, env => {
 
     it('should reject trigger in a disallowed environment', () => {
       sandbox.stub(root, 'getType').callsFake(() => 'other');
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         group.addTrigger({on: 'click', selector: '*'});
-      }).to.throw(/Trigger type "click" is not allowed in the other/);
+      }).to.throw(/Trigger type "click" is not allowed in the other/); });
     });
 
     it('should reject trigger that fails to initialize', () => {
       sandbox.stub(root, 'getTracker').callsFake(() => {
         throw new Error('intentional');
       });
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         group.addTrigger({on: 'click', selector: '*'});
-      }).to.throw(/intentional/);
+      }).to.throw(/intentional/); });
     });
 
     it('should delegate to deprecated addListener', () => {

--- a/extensions/amp-analytics/0.1/test/test-transport.js
+++ b/extensions/amp-analytics/0.1/test/test-transport.js
@@ -111,15 +111,15 @@ describe('amp-analytics.transport', () => {
   });
 
   it('asserts that urls are https', () => {
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       sendRequest(window, 'http://example.com/test');
-    }).to.throw(/https/);
+    }).to.throw(/https/); });
   });
 
   it('should NOT allow __amp_source_origin', () => {
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       sendRequest(window, 'https://twitter.com?__amp_source_origin=1');
-    }).to.throw(/Source origin is not allowed in/);
+    }).to.throw(/Source origin is not allowed in/); });
   });
 
   describe('sendRequestUsingIframe', () => {
@@ -140,18 +140,17 @@ describe('amp-analytics.transport', () => {
     });
 
     it('iframe asserts that urls are https', () => {
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         sendRequestUsingIframe(window, 'http://example.com/test');
-      }).to.throw(/https/);
+      }).to.throw(/https/); });
     });
 
     it('forbids same origin', () => {
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         sendRequestUsingIframe(window, 'http://localhost:9876/');
       }).to.throw(
-          /Origin of iframe request must not be equal to the document origin./
-      );
+          /Origin of iframe request must not be equal to the document origin./);
+      });
     });
   });
 });
-

--- a/extensions/amp-analytics/0.1/test/test-visibility-model.js
+++ b/extensions/amp-analytics/0.1/test/test-visibility-model.js
@@ -572,12 +572,14 @@ describes.sandboxed('VisibilityModel', {}, () => {
 
     it('should NOT allow invalid values', () => {
       const vh = new VisibilityModel(NO_SPEC, NO_CALC);
-      expect(() => {
-        vh.updateCounters_(-1);
-      }).to.throw(/invalid visibility value/);
-      expect(() => {
-        vh.updateCounters_(1.00001);
-      }).to.throw(/invalid visibility value/);
+      allowConsoleError(() => {
+        expect(() => {
+          vh.updateCounters_(-1);
+        }).to.throw(/invalid visibility value/);
+        expect(() => {
+          vh.updateCounters_(1.00001);
+        }).to.throw(/invalid visibility value/);
+      });
     });
 
     it('should match custom visibility position', () => {

--- a/extensions/amp-animation/0.1/test/test-css-expr.js
+++ b/extensions/amp-animation/0.1/test/test-css-expr.js
@@ -596,9 +596,9 @@ describes.sandboxed('CSS resolve', {}, () => {
           .throws(new Error('intentional'))
           .once();
       const node = new ast.CssUrlNode('http://acme.org/non-secure');
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         node.calc(context);
-      }).to.throw(/intentional/);
+      }).to.throw(/intentional/); });
     });
   });
 
@@ -712,21 +712,23 @@ describes.sandboxed('CSS resolve', {}, () => {
     });
 
     it('should disallow a real-length node', () => {
-      expect(() => {
-        new ast.CssLengthNode(1, 'cm').norm(context);
-      }).to.throw(/unknown/);
-      expect(() => {
-        new ast.CssLengthNode(1, 'mm').norm(context);
-      }).to.throw(/unknown/);
-      expect(() => {
-        new ast.CssLengthNode(1, 'in').norm(context);
-      }).to.throw(/unknown/);
-      expect(() => {
-        new ast.CssLengthNode(1, 'pt').norm(context);
-      }).to.throw(/unknown/);
-      expect(() => {
-        new ast.CssLengthNode(1, 'q').norm(context);
-      }).to.throw(/unknown/);
+      allowConsoleError(() => {
+        expect(() => {
+          new ast.CssLengthNode(1, 'cm').norm(context);
+        }).to.throw(/unknown/);
+        expect(() => {
+          new ast.CssLengthNode(1, 'mm').norm(context);
+        }).to.throw(/unknown/);
+        expect(() => {
+          new ast.CssLengthNode(1, 'in').norm(context);
+        }).to.throw(/unknown/);
+        expect(() => {
+          new ast.CssLengthNode(1, 'pt').norm(context);
+        }).to.throw(/unknown/);
+        expect(() => {
+          new ast.CssLengthNode(1, 'q').norm(context);
+        }).to.throw(/unknown/);
+      });
     });
 
     it('should resolve a percent-length in w-direction', () => {
@@ -1078,7 +1080,7 @@ describes.sandboxed('CSS resolve', {}, () => {
     it('should be always a non-const and no css', () => {
       const node = new ast.CssDimSizeNode('?');
       expect(node.isConst()).to.be.false;
-      expect(() => node.css()).to.throw(/no css/);
+      allowConsoleError(() => { expect(() => node.css()).to.throw(/no css/); });
     });
 
     it('should resolve width on the current node', () => {
@@ -1121,7 +1123,7 @@ describes.sandboxed('CSS resolve', {}, () => {
     it('should always be a non-const and no css', () => {
       const node = new ast.CssNumConvertNode();
       expect(node.isConst()).to.equal(false);
-      expect(() => node.css()).to.throw(/no css/);
+      allowConsoleError(() => { expect(() => node.css()).to.throw(/no css/); });
     });
 
     it('should resolve num from a number', () => {
@@ -1214,7 +1216,7 @@ describes.sandboxed('CSS resolve', {}, () => {
     it('should always be a non-const and no css', () => {
       const node = new ast.CssRandNode();
       expect(node.isConst()).to.equal(false);
-      expect(() => node.css()).to.throw(/no css/);
+      allowConsoleError(() => { expect(() => node.css()).to.throw(/no css/); });
     });
 
     it('should resolve a no-arg rand', () => {
@@ -1297,18 +1299,18 @@ describes.sandboxed('CSS resolve', {}, () => {
       const node = new ast.CssRandNode(
           new ast.CssPassthroughNode('A'),
           new ast.CssPassthroughNode('B'));
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         resolvedCss(node);
-      }).to.throw(/both numerical/);
+      }).to.throw(/both numerical/); });
     });
 
     it('should only allow same-type', () => {
       const node = new ast.CssRandNode(
           new ast.CssLengthNode(30, 'px'),
           new ast.CssTimeNode(20, 's'));
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         resolvedCss(node);
-      }).to.throw(/same type/);
+      }).to.throw(/same type/); });
     });
 
     it('should normalize units', () => {
@@ -1331,7 +1333,7 @@ describes.sandboxed('CSS resolve', {}, () => {
       const node = new ast.CssIndexNode();
       expect(node.isConst()).to.be.false;
       expect(node.isConst(normalize)).to.be.false;
-      expect(() => node.css()).to.throw(/no css/);
+      allowConsoleError(() => { expect(() => node.css()).to.throw(/no css/); });
     });
 
     it('should resolve a no-arg', () => {
@@ -1538,9 +1540,9 @@ describes.sandboxed('CSS resolve', {}, () => {
             new ast.CssPassthroughNode('A'),
             new ast.CssPassthroughNode('B'),
             '+');
-        expect(() => {
+        allowConsoleError(() => { expect(() => {
           resolvedCss(node);
-        }).to.throw(/both numerical/);
+        }).to.throw(/both numerical/); });
       });
 
       it('should only allow same-type', () => {
@@ -1548,9 +1550,9 @@ describes.sandboxed('CSS resolve', {}, () => {
             new ast.CssLengthNode(30, 'px'),
             new ast.CssTimeNode(20, 's'),
             '+');
-        expect(() => {
+        allowConsoleError(() => { expect(() => {
           resolvedCss(node);
-        }).to.throw(/same type/);
+        }).to.throw(/same type/); });
       });
 
       it('should normalize units', () => {
@@ -1631,9 +1633,9 @@ describes.sandboxed('CSS resolve', {}, () => {
             new ast.CssPassthroughNode('A'),
             new ast.CssPassthroughNode('B'),
             '*');
-        expect(() => {
+        allowConsoleError(() => { expect(() => {
           resolvedCss(node);
-        }).to.throw(/both numerical/);
+        }).to.throw(/both numerical/); });
       });
 
       it('should multiply with right number', () => {
@@ -1681,9 +1683,9 @@ describes.sandboxed('CSS resolve', {}, () => {
             new ast.CssLengthNode(10, 'px'),
             new ast.CssLengthNode(20, 'px'),
             '*');
-        expect(() => {
+        allowConsoleError(() => { expect(() => {
           resolvedCss(node);
-        }).to.throw(/one of sides in multiplication must be a number/);
+        }).to.throw(/one of sides in multiplication must be a number/); });
       });
 
       it('should divide with right number', () => {
@@ -1721,9 +1723,9 @@ describes.sandboxed('CSS resolve', {}, () => {
             new ast.CssTimeNode(10, 's'),
             new ast.CssTimeNode(2, 's'),
             '/');
-        expect(() => {
+        allowConsoleError(() => { expect(() => {
           resolvedCss(node);
-        }).to.throw(/denominator must be a number/);
+        }).to.throw(/denominator must be a number/); });
       });
 
       it('should resolve divide-by-zero as null', () => {

--- a/extensions/amp-animation/0.1/test/test-web-animations.js
+++ b/extensions/amp-animation/0.1/test/test-web-animations.js
@@ -134,8 +134,12 @@ describes.realWin('MeasureScanner', {amp: 1}, env => {
     expect(scanTiming({duration: 'calc(10ms)'}).duration).to.equal(10);
     expect(scanTiming({duration: 'var(--unk)'}).duration).to.equal(0);
     expect(scanTiming({duration: 'var(--unk, 11ms)'}).duration).to.equal(11);
-    expect(() => scanTiming({duration: 'a'})).to.throw(/"duration" is invalid/);
-    expect(() => scanTiming({duration: -1})).to.throw(/"duration" is invalid/);
+    allowConsoleError(() => {
+      expect(() => scanTiming({duration: 'a'})).to.throw(
+          /"duration" is invalid/);
+      expect(() => scanTiming({duration: -1})).to.throw(
+          /"duration" is invalid/);
+    });
     expect(warnStub).to.not.be.calledWith(sinon.match.any, sinon.match(arg => {
       return /fractional/.test(arg);
     }));
@@ -153,7 +157,9 @@ describes.realWin('MeasureScanner', {amp: 1}, env => {
     expect(scanTiming({delay: 'var(--unk, 11ms)'}).delay).to.equal(11);
     // Note! The negative "delay" is allowed.
     expect(scanTiming({delay: -1}).delay).to.equal(-1);
-    expect(() => scanTiming({delay: 'a'})).to.throw(/"delay" is invalid/);
+    allowConsoleError(() => {
+      expect(() => scanTiming({delay: 'a'})).to.throw(/"delay" is invalid/);
+    });
 
     expect(scanTiming({}).endDelay).to.equal(0);
     expect(scanTiming({endDelay: 0}).endDelay).to.equal(0);
@@ -162,8 +168,12 @@ describes.realWin('MeasureScanner', {amp: 1}, env => {
     expect(scanTiming({endDelay: '10s'}).endDelay).to.equal(10000);
     expect(scanTiming({endDelay: '10ms'}).endDelay).to.equal(10);
     expect(scanTiming({endDelay: 'calc(10ms)'}).endDelay).to.equal(10);
-    expect(() => scanTiming({endDelay: 'a'})).to.throw(/"endDelay" is invalid/);
-    expect(() => scanTiming({endDelay: -1})).to.throw(/"endDelay" is invalid/);
+    allowConsoleError(() => {
+      expect(() => scanTiming({endDelay: 'a'})).to.throw(
+          /"endDelay" is invalid/);
+      expect(() => scanTiming({endDelay: -1})).to.throw(
+          /"endDelay" is invalid/);
+    });
   });
 
   it('should parse/validate timing iterations', () => {
@@ -176,20 +186,24 @@ describes.realWin('MeasureScanner', {amp: 1}, env => {
     expect(scanTiming({iterations: 'Infinity'}).iterations).to.equal(Infinity);
     expect(scanTiming({iterations: 'infinite'}).iterations).to.equal(Infinity);
     expect(scanTiming({iterations: 'INFINITE'}).iterations).to.equal(Infinity);
-    expect(() => scanTiming({iterations: 'a'}))
-        .to.throw(/"iterations" is invalid/);
-    expect(() => scanTiming({iterations: -1}))
-        .to.throw(/"iterations" is invalid/);
+    allowConsoleError(() => {
+      expect(() => scanTiming({iterations: 'a'})).to.throw(
+          /"iterations" is invalid/);
+      expect(() => scanTiming({iterations: -1})).to.throw(
+          /"iterations" is invalid/);
+    });
 
     expect(scanTiming({}).iterationStart).to.equal(0);
     expect(scanTiming({iterationStart: 0}).iterationStart).to.equal(0);
     expect(scanTiming({iterationStart: 10}).iterationStart).to.equal(10);
     expect(scanTiming({iterationStart: 'calc(10)'}).iterationStart)
         .to.equal(10);
-    expect(() => scanTiming({iterationStart: 'a'}))
-        .to.throw(/"iterationStart" is invalid/);
-    expect(() => scanTiming({iterationStart: -1}))
-        .to.throw(/"iterationStart" is invalid/);
+    allowConsoleError(() => {
+      expect(() => scanTiming({iterationStart: 'a'})).to.throw(
+          /"iterationStart" is invalid/);
+      expect(() => scanTiming({iterationStart: -1})).to.throw(
+          /"iterationStart" is invalid/);
+    });
   });
 
   it('should warn if timing is fractional', () => {
@@ -217,8 +231,10 @@ describes.realWin('MeasureScanner', {amp: 1}, env => {
     expect(scanTiming({direction: 'reverse'}).direction).to.equal('reverse');
     expect(scanTiming({direction: 'var(--unk, reverse)'}).direction)
         .to.equal('reverse');
-    expect(() => scanTiming({direction: 'invalid'}))
-        .to.throw(/Unknown direction value/);
+    allowConsoleError(() => {
+      expect(() => scanTiming({direction: 'invalid'})).to.throw(
+          /Unknown direction value/);
+    });
   });
 
   it('should parse/validate timing fill', () => {
@@ -226,8 +242,10 @@ describes.realWin('MeasureScanner', {amp: 1}, env => {
     expect(scanTiming({fill: 'both'}).fill).to.equal('both');
     expect(scanTiming({fill: 'var(--unk, backwards)'}).fill)
         .to.equal('backwards');
-    expect(() => scanTiming({fill: 'invalid'}))
-        .to.throw(/Unknown fill value/);
+    allowConsoleError(() => {
+      expect(() => scanTiming({fill: 'invalid'})).to.throw(
+          /Unknown fill value/);
+    });
   });
 
   it('should merge timing', () => {
@@ -685,8 +703,10 @@ describes.realWin('MeasureScanner', {amp: 1}, env => {
   });
 
   it('should fail when cannot discover style keyframes', () => {
-    expect(() => scan({target: target1, keyframes: 'keyframes1'}))
-        .to.throw(/Keyframes not found/);
+    allowConsoleError(() => {
+      expect(() => scan({target: target1, keyframes: 'keyframes1'})).to.throw(
+          /Keyframes not found/);
+    });
   });
 
   it('should discover style keyframes', () => {
@@ -855,16 +875,16 @@ describes.realWin('MeasureScanner', {amp: 1}, env => {
   });
 
   it('should require any target spec', () => {
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       scan([{duration: 400, keyframes: {}}]);
-    }).to.throw(/No target specified/);
+    }).to.throw(/No target specified/); });
   });
 
   it('should not allow both selector and target spec', () => {
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       scan([{selector: '#target1', target: 'target1',
         duration: 400, keyframes: {}}]);
-    }).to.throw(/Both/);
+    }).to.throw(/Both/); });
   });
 
   it('should build keyframe for multiple targets', () => {
@@ -952,18 +972,18 @@ describes.realWin('MeasureScanner', {amp: 1}, env => {
     });
 
     it('should fail when animation cannot be found', () => {
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         scanner.resolveRequests({animation: 'animation3'});
-      }).to.throw(/Animation not found/);
+      }).to.throw(/Animation not found/); });
     });
 
     it('should fail when animation reference is not an amp-animation', () => {
       const animation3 = env.createAmpElement('amp-other');
       animation3.id = 'animation3';
       doc.body.appendChild(animation3);
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         scanner.resolveRequests({animation: 'animation3'});
-      }).to.throw(/Element is not an animation/);
+      }).to.throw(/Element is not an animation/); });
     });
 
     it('should fail the recursive animation', () => {
@@ -1239,8 +1259,10 @@ describes.realWin('MeasureScanner', {amp: 1}, env => {
     });
 
     it('should require target for CSS that need element context', () => {
-      expect(() => css.resolveCss('calc(10em + 10px)'))
-          .to.throw(/target is specified/);
+      allowConsoleError(() => {
+        expect(() => css.resolveCss('calc(10em + 10px)')).to.throw(
+            /target is specified/);
+      });
       target1.style.fontSize = '10px';
       expect(css.withTarget(target1, 0,
           () => css.resolveCss('calc(10em + 10px)')))
@@ -1333,10 +1355,12 @@ describes.realWin('MeasureScanner', {amp: 1}, env => {
       }, () => {
         expect(css.getVar('--var1').num_).to.equal(11);
         expect(css.getVar('--var2').num_).to.equal(11);
-        expect(() => css.getVar('--rec1')).to.throw(/Recursive/);
-        expect(() => css.getVar('--rec2')).to.throw(/Recursive/);
-        expect(() => css.getVar('--rec3')).to.throw(/Recursive/);
-        expect(() => css.getVar('--rec4')).to.throw(/Recursive/);
+        allowConsoleError(() => {
+          expect(() => css.getVar('--rec1')).to.throw(/Recursive/);
+          expect(() => css.getVar('--rec2')).to.throw(/Recursive/);
+          expect(() => css.getVar('--rec3')).to.throw(/Recursive/);
+          expect(() => css.getVar('--rec4')).to.throw(/Recursive/);
+        });
       });
     });
 
@@ -1358,7 +1382,9 @@ describes.realWin('MeasureScanner', {amp: 1}, env => {
     });
 
     it('should resolve current index', () => {
-      expect(() => css.getCurrentIndex()).to.throw(/target is specified/);
+      allowConsoleError(() => {
+        expect(() => css.getCurrentIndex()).to.throw(/target is specified/);
+      });
       expect(css.withTarget(target1, 0, () => css.getCurrentIndex()))
           .to.equal(0);
       expect(css.withTarget(target1, 11, () => css.getCurrentIndex()))
@@ -1370,7 +1396,9 @@ describes.realWin('MeasureScanner', {amp: 1}, env => {
       expect(css.getRootFontSize()).to.equal(12);
 
       target1.style.fontSize = '16px';
-      expect(() => css.getCurrentFontSize()).to.throw(/target is specified/);
+      allowConsoleError(() => {
+        expect(() => css.getCurrentFontSize()).to.throw(/target is specified/);
+      });
       expect(css.withTarget(target1, 0, () => css.getCurrentFontSize()))
           .to.equal(16);
       expect(css.withTarget(target2, 0, () => css.getCurrentFontSize()))
@@ -1380,7 +1408,10 @@ describes.realWin('MeasureScanner', {amp: 1}, env => {
     it('should resolve current element size', () => {
       target1.style.width = '11px';
       target1.style.height = '12px';
-      expect(() => css.getCurrentElementSize()).to.throw(/target is specified/);
+      allowConsoleError(() => {
+        expect(() => css.getCurrentElementSize()).to.throw(
+            /target is specified/);
+      });
       expect(css.withTarget(target1, 0, () => css.getCurrentElementSize()))
           .to.deep.equal({width: 11, height: 12});
     });
@@ -1400,8 +1431,10 @@ describes.realWin('MeasureScanner', {amp: 1}, env => {
           .to.deep.equal({width: 11, height: 12});
 
       // Closest selectors always need a context node.
-      expect(() => css.getElementSize('#target1', 'closest'))
-          .to.throw(/target is specified/);
+      allowConsoleError(() => {
+        expect(() => css.getElementSize('#target1', 'closest')).to.throw(
+            /target is specified/);
+      });
       expect(css.withTarget(child, 0,
           () => css.getElementSize('.parent', 'closest')))
           .to.deep.equal({width: 11, height: 12});
@@ -1415,8 +1448,9 @@ describes.realWin('MeasureScanner', {amp: 1}, env => {
     });
 
     it('should NOT resolve an invalid URL', () => {
-      expect(() => css.resolveUrl('http://acme.org/path'))
-          .to.throw(/https/);
+      allowConsoleError(() => {
+        expect(() => css.resolveUrl('http://acme.org/path')).to.throw(/https/);
+      });
     });
   });
 
@@ -1617,9 +1651,9 @@ describes.sandboxed('WebAnimationRunner', {}, () => {
 
   it('should fail to init twice', () => {
     runner.init();
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       runner.init();
-    }).to.throw();
+    }).to.throw(); });
   });
 
   it('should set vars on start', () => {
@@ -1666,9 +1700,9 @@ describes.sandboxed('WebAnimationRunner', {}, () => {
   });
 
   it('should only allow pause when started', () => {
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       runner.pause();
-    }).to.throw();
+    }).to.throw(); });
   });
 
   it('should resume all animations', () => {
@@ -1726,9 +1760,9 @@ describes.sandboxed('WebAnimationRunner', {}, () => {
   });
 
   it('should only allow resume when started', () => {
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       runner.resume();
-    }).to.throw();
+    }).to.throw(); });
   });
 
   it('should reverse all animations', () => {
@@ -1742,9 +1776,9 @@ describes.sandboxed('WebAnimationRunner', {}, () => {
   });
 
   it('should only allow reverse when started', () => {
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       runner.reverse();
-    }).to.throw();
+    }).to.throw(); });
   });
 
   it('should finish all animations', () => {
@@ -1887,7 +1921,9 @@ describes.sandboxed('WebAnimationRunner', {}, () => {
       const runner = new WebAnimationRunner([
         {target: target1, keyframes: keyframes1, timing},
       ]);
-      expect(() => runner.getTotalDuration_()).to.throw(/has infinite/);
+      allowConsoleError(() => {
+        expect(() => runner.getTotalDuration_()).to.throw(/has infinite/);
+      });
     });
 
     it('multiple requests - 0 total', () => {
@@ -1994,7 +2030,9 @@ describes.sandboxed('WebAnimationRunner', {}, () => {
         {target: target1, keyframes: keyframes1, timing: timing2},
       ]);
 
-      expect(() => runner.getTotalDuration_()).to.throw(/has infinite/);
+      allowConsoleError(() => {
+        expect(() => runner.getTotalDuration_()).to.throw(/has infinite/);
+      });
     });
 
   });

--- a/extensions/amp-apester-media/0.1/test/test-amp-apester-media.js
+++ b/extensions/amp-apester-media/0.1/test/test-amp-apester-media.js
@@ -187,9 +187,10 @@ describes.realWin(
       });
 
       it('requires media-id or channel-token', () => {
-        expect(getApester()).to.be.rejectedWith(
-            /The media-id attribute is required for/
-        );
+        allowConsoleError(() => {
+          expect(getApester()).to.be.rejectedWith(
+              /The media-id attribute is required for/);
+        });
       });
     }
 );

--- a/extensions/amp-app-banner/0.1/test/test-amp-app-banner.js
+++ b/extensions/amp-app-banner/0.1/test/test-amp-app-banner.js
@@ -128,11 +128,13 @@ describes.realWin('amp-app-banner', {
   }
 
   function testButtonMissing() {
-    return getAppBanner({
+    allowConsoleError(() => { return getAppBanner({
       iosMeta,
       androidManifest,
       noOpenButton: true,
-    }).should.eventually.be.rejectedWith(/<button open-button> is required/);
+    }).should.eventually.be.rejectedWith(
+        /<button open-button> is required/);
+    });
   }
 
   function testRemoveBannerIfDismissed() {
@@ -193,11 +195,12 @@ describes.realWin('amp-app-banner', {
     });
 
     it('should parse meta content and validate app-argument url', () => {
-      return getAppBanner({
+      allowConsoleError(() => { return getAppBanner({
         iosMeta: {content:
             'app-id=828256236, app-argument=javascript:alert("foo");'},
       }).should.eventually.be.rejectedWith(
           /The url in app-argument has invalid protocol/);
+      });
     });
   }
 

--- a/extensions/amp-auto-ads/0.1/test/test-amp-auto-ads.js
+++ b/extensions/amp-auto-ads/0.1/test/test-amp-auto-ads.js
@@ -337,8 +337,10 @@ describes.realWin('amp-auto-ads', {
 
   it('should throw an error if no type', () => {
     ampAutoAdsElem.setAttribute('data-ad-client', AD_CLIENT);
-    expect(() => ampAutoAds.buildCallback())
-        .to.throw(/Missing type attribute​​/);
+    allowConsoleError(() => {
+      expect(() => ampAutoAds.buildCallback()).to.throw(
+          /Missing type attribute​​/);
+    });
     expect(xhr.fetchJson).not.to.have.been.called;
   });
 
@@ -346,8 +348,10 @@ describes.realWin('amp-auto-ads', {
     ampAutoAdsElem.setAttribute('data-ad-client', AD_CLIENT);
     ampAutoAdsElem.setAttribute('type', 'unknowntype');
 
-    expect(() => ampAutoAds.buildCallback())
-        .to.throw(/No AdNetworkConfig for type: unknowntype​​​/);
+    allowConsoleError(() => {
+      expect(() => ampAutoAds.buildCallback()).to.throw(
+          /No AdNetworkConfig for type: unknowntype​​​/);
+    });
 
     expect(xhr.fetchJson).not.to.have.been.called;
   });
@@ -357,8 +361,9 @@ describes.realWin('amp-auto-ads', {
     ampAutoAdsElem.setAttribute('data-ad-client', AD_CLIENT);
     ampAutoAdsElem.setAttribute('type', 'adsense');
 
-    expect(() => ampAutoAds.buildCallback())
-        .to.throw(/Experiment is off​​​/);
+    allowConsoleError(() => {
+      expect(() => ampAutoAds.buildCallback()).to.throw(/Experiment is off​​​/);
+    });
     expect(xhr.fetchJson).not.to.have.been.called;
   });
 

--- a/extensions/amp-auto-ads/0.1/test/test-placement.js
+++ b/extensions/amp-auto-ads/0.1/test/test-placement.js
@@ -94,7 +94,9 @@ describes.realWin('placement', {
       });
       expect(placements).to.have.lengthOf(1);
 
-      expect(() => placements[0].getAdElement()).to.throw(/No ad element/);
+      allowConsoleError(() => {
+        expect(() => placements[0].getAdElement()).to.throw(/No ad element/);
+      });
     });
   });
 

--- a/extensions/amp-bind/0.1/test/test-bind-expression.js
+++ b/extensions/amp-bind/0.1/test/test-bind-expression.js
@@ -74,27 +74,29 @@ describe('BindExpression', () => {
     });
 
     it('disallow: operators with side effects', () => {
-      expect(() => { evaluate('foo = 1', {foo: 0}); }).to.throw();
-      expect(() => { evaluate('foo += 1', {foo: 0}); }).to.throw();
-      expect(() => { evaluate('foo -= 1', {foo: 0}); }).to.throw();
-      expect(() => { evaluate('foo *= 1', {foo: 0}); }).to.throw();
-      expect(() => { evaluate('foo /= 1', {foo: 0}); }).to.throw();
-      expect(() => { evaluate('foo %= 1', {foo: 0}); }).to.throw();
-      expect(() => { evaluate('foo **= 1', {foo: 0}); }).to.throw();
-      expect(() => { evaluate('foo <<= 1', {foo: 0}); }).to.throw();
-      expect(() => { evaluate('foo >>= 1', {foo: 0}); }).to.throw();
-      expect(() => { evaluate('foo >>>= 1', {foo: 0}); }).to.throw();
-      expect(() => { evaluate('foo &= 1', {foo: 0}); }).to.throw();
-      expect(() => { evaluate('foo ^= 1', {foo: 0}); }).to.throw();
-      expect(() => { evaluate('foo |= 1', {foo: 0}); }).to.throw();
-      expect(() => { evaluate('foo++', {foo: 0}); }).to.throw();
-      expect(() => { evaluate('foo--', {foo: 0}); }).to.throw();
-      expect(() => { evaluate('~foo', {foo: 0}); }).to.throw();
-      expect(() => { evaluate('foo << 1', {foo: 0}); }).to.throw();
-      expect(() => { evaluate('foo >> 1', {foo: 0}); }).to.throw();
-      expect(() => { evaluate('foo >>> 1', {foo: 0}); }).to.throw();
-      expect(() => { evaluate('new Object()', {foo: 0}); }).to.throw();
-      expect(() => { evaluate('delete foo', {foo: 0}); }).to.throw();
+      allowConsoleError(() => {
+        expect(() => { evaluate('foo = 1', {foo: 0}); }).to.throw();
+        expect(() => { evaluate('foo += 1', {foo: 0}); }).to.throw();
+        expect(() => { evaluate('foo -= 1', {foo: 0}); }).to.throw();
+        expect(() => { evaluate('foo *= 1', {foo: 0}); }).to.throw();
+        expect(() => { evaluate('foo /= 1', {foo: 0}); }).to.throw();
+        expect(() => { evaluate('foo %= 1', {foo: 0}); }).to.throw();
+        expect(() => { evaluate('foo **= 1', {foo: 0}); }).to.throw();
+        expect(() => { evaluate('foo <<= 1', {foo: 0}); }).to.throw();
+        expect(() => { evaluate('foo >>= 1', {foo: 0}); }).to.throw();
+        expect(() => { evaluate('foo >>>= 1', {foo: 0}); }).to.throw();
+        expect(() => { evaluate('foo &= 1', {foo: 0}); }).to.throw();
+        expect(() => { evaluate('foo ^= 1', {foo: 0}); }).to.throw();
+        expect(() => { evaluate('foo |= 1', {foo: 0}); }).to.throw();
+        expect(() => { evaluate('foo++', {foo: 0}); }).to.throw();
+        expect(() => { evaluate('foo--', {foo: 0}); }).to.throw();
+        expect(() => { evaluate('~foo', {foo: 0}); }).to.throw();
+        expect(() => { evaluate('foo << 1', {foo: 0}); }).to.throw();
+        expect(() => { evaluate('foo >> 1', {foo: 0}); }).to.throw();
+        expect(() => { evaluate('foo >>> 1', {foo: 0}); }).to.throw();
+        expect(() => { evaluate('new Object()', {foo: 0}); }).to.throw();
+        expect(() => { evaluate('delete foo', {foo: 0}); }).to.throw();
+      });
     });
 
     /** @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators */
@@ -109,10 +111,12 @@ describe('BindExpression', () => {
       expect(evaluate('new')).to.be.null;
       expect(evaluate('super')).to.be.null;
 
-      expect(() => { evaluate('function*'); }).to.throw();
-      expect(() => { evaluate('/ab+c/i'); }).to.throw();
-      expect(() => { evaluate('yield*'); }).to.throw();
-      expect(() => { evaluate('async function*'); }).to.throw();
+      allowConsoleError(() => {
+        expect(() => { evaluate('function*'); }).to.throw();
+        expect(() => { evaluate('/ab+c/i'); }).to.throw();
+        expect(() => { evaluate('yield*'); }).to.throw();
+        expect(() => { evaluate('async function*'); }).to.throw();
+      });
     });
   });
 
@@ -300,7 +304,9 @@ describe('BindExpression', () => {
       expect(evaluate('{null: "b"}')).to.deep.equal({null: 'b'});
       // Unquoted string keys should _not_ be evaluated as expressions.
       expect(evaluate('{a: "b"}', {a: 'foo'})).to.deep.equal({a: 'b'});
-      expect(() => evaluate('{1+1: "b"}')).to.throw();
+      allowConsoleError(() => {
+        expect(() => evaluate('{1+1: "b"}')).to.throw();
+      });
     });
 
     it('computed property names', () => {
@@ -344,17 +350,17 @@ describe('BindExpression', () => {
       expect(evaluate('abs(-2) + abs', {abs: 2})).to.equal(4);
 
       // Don't support non-whitelisted functions.
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         evaluate('sin(0.5)');
-      }).to.throw(unsupportedFunctionError);
-      expect(() => {
+      }).to.throw(unsupportedFunctionError); });
+      allowConsoleError(() => { expect(() => {
         evaluate('pow(3, 2)');
-      }).to.throw(unsupportedFunctionError);
+      }).to.throw(unsupportedFunctionError); });
 
       // Don't support calling functions with `Math.` prefix.
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         evaluate('Math.abs(-1)', {Math});
-      }).to.throw(unsupportedFunctionError);
+      }).to.throw(unsupportedFunctionError); });
     });
 
     it('encodeURI and encodeURIComponent', () => {
@@ -366,8 +372,10 @@ describe('BindExpression', () => {
 
     it('splice()', () => {
       const a = [1, 2, 3];
-      expect(() => evaluate('splice()')).to.throw(/not an array/);
-      expect(() => evaluate('splice(x)', {x: 8472})).to.throw(/not an array/);
+      allowConsoleError(() => {
+        expect(() => evaluate('splice()')).to.throw(/not an array/);
+        expect(() => evaluate('splice(x)', {x: 8472})).to.throw(/not an array/);
+      });
       expect(evaluate('splice(a)', {a})).to.not.equal(a);
       expect(evaluate('splice(a)', {a})).to.deep.equal(a);
       expect(evaluate('splice(a, 1)', {a})).to.deep.equal([1]);
@@ -377,8 +385,10 @@ describe('BindExpression', () => {
 
     it('sort()', () => {
       const a = [2, 3, 1];
-      expect(() => evaluate('sort()')).to.throw(/not an array/);
-      expect(() => evaluate('sort("abc")')).to.throw(/not an array/);
+      allowConsoleError(() => {
+        expect(() => evaluate('sort()')).to.throw(/not an array/);
+        expect(() => evaluate('sort("abc")')).to.throw(/not an array/);
+      });
       expect(evaluate('sort(a)', {a})).to.not.equal(a);
       expect(evaluate('sort(a)', {a})).to.deep.equal([1, 2, 3]);
     });
@@ -408,11 +418,16 @@ describe('BindExpression', () => {
         qux: window.Function,
       };
       // baz() throws a parse error because functions must have a caller.
-      expect(() => { evaluate('baz()', scope); }).to.throw();
+      allowConsoleError(() => {
+        expect(() => { evaluate('baz()', scope); }).to.throw();
+      });
       expect(() => { evaluate('foo.bar()', scope); })
           .to.throw(Error, unsupportedFunctionError);
-      expect(() => { evaluate('foo.qux("a", "return a")', scope); })
-          .to.throw(unsupportedFunctionError);
+      allowConsoleError(() => {
+        expect(() => {
+          evaluate('foo.qux("a", "return a")', scope);
+        }).to.throw(unsupportedFunctionError);
+      });
     });
 
     it('disallow: invocation of prototype functions', () => {
@@ -497,19 +512,21 @@ describe('BindExpression', () => {
     });
 
     it('disallow: loops', () => {
-      expect(() => { evaluate('if (foo) "bar"', {foo: 0}); }).to.throw();
-      expect(() => {
-        evaluate('switch (foo) { case 0: "bar" }', {foo: 0});
-      }).to.throw();
-      expect(() => { evaluate('for (;;) {}'); }).to.throw();
-      expect(() => { evaluate('while (true) {}'); }).to.throw();
-      expect(() => { evaluate('do {} while (true)'); }).to.throw();
-      expect(() => {
-        evaluate('for (var i in foo) {}', {foo: [1, 2, 3]});
-      }).to.throw();
-      expect(() => {
-        evaluate('for (var i of foo) {}', {foo: [1, 2, 3]});
-      }).to.throw();
+      allowConsoleError(() => {
+        expect(() => { evaluate('if (foo) "bar"', {foo: 0}); }).to.throw();
+        expect(() => {
+          evaluate('switch (foo) { case 0: "bar" }', {foo: 0});
+        }).to.throw();
+        expect(() => { evaluate('for (;;) {}'); }).to.throw();
+        expect(() => { evaluate('while (true) {}'); }).to.throw();
+        expect(() => { evaluate('do {} while (true)'); }).to.throw();
+        expect(() => {
+          evaluate('for (var i in foo) {}', {foo: [1, 2, 3]});
+        }).to.throw();
+        expect(() => {
+          evaluate('for (var i of foo) {}', {foo: [1, 2, 3]});
+        }).to.throw();
+      });
     });
 
     /** @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects */
@@ -521,16 +538,18 @@ describe('BindExpression', () => {
       expect(evaluate('NaN')).to.be.null;
       expect(evaluate('undefined')).to.be.null;
 
-      expect(() => { evaluate('eval()'); }).to.throw();
-      expect(() => { evaluate('uneval()'); }).to.throw();
-      expect(() => { evaluate('isFinite()'); }).to.throw();
-      expect(() => { evaluate('isNaN()'); }).to.throw();
-      expect(() => { evaluate('parseFloat()'); }).to.throw();
-      expect(() => { evaluate('parseInt()'); }).to.throw();
-      expect(() => { evaluate('decodeURI()'); }).to.throw();
-      expect(() => { evaluate('decodeURIComponent()'); }).to.throw();
-      expect(() => { evaluate('escape()'); }).to.throw();
-      expect(() => { evaluate('unescape()'); }).to.throw();
+      allowConsoleError(() => {
+        expect(() => { evaluate('eval()'); }).to.throw();
+        expect(() => { evaluate('uneval()'); }).to.throw();
+        expect(() => { evaluate('isFinite()'); }).to.throw();
+        expect(() => { evaluate('isNaN()'); }).to.throw();
+        expect(() => { evaluate('parseFloat()'); }).to.throw();
+        expect(() => { evaluate('parseInt()'); }).to.throw();
+        expect(() => { evaluate('decodeURI()'); }).to.throw();
+        expect(() => { evaluate('decodeURIComponent()'); }).to.throw();
+        expect(() => { evaluate('escape()'); }).to.throw();
+        expect(() => { evaluate('unescape()'); }).to.throw();
+      });
 
       expect(evaluate('Object')).to.be.null;
       expect(evaluate('Function')).to.be.null;
@@ -595,9 +614,9 @@ describe('BindExpression', () => {
 
       // The expression '1 + 1' should have an AST size of 3 -- one for each
       // literal, and a PLUS expression wrapping them.
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         new BindExpression('1 + 1', {}, /* maxAstSize */ 2);
-      }).to.throw(expressionSizeExceededError);
+      }).to.throw(expressionSizeExceededError); });
 
       // Test size computation for macros.
       const add = new BindMacro({
@@ -611,24 +630,26 @@ describe('BindExpression', () => {
       expect(new BindExpression('add(1, 1)', {add}, /* maxAstSize */ 3))
           .to.not.be.null;
 
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         new BindExpression('add(1, 1)', {add}, /* maxAstSize */ 2);
-      }).to.throw(expressionSizeExceededError);
+      }).to.throw(expressionSizeExceededError); });
 
       // The expression add(1, 1 + 1) should have an AST size of 5.
       expect(new BindExpression('add(1, 1 + 1)', {add}, /* maxAstSize */ 5))
           .to.not.be.null;
 
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         new BindExpression('add(1, 1 + 1)', {add}, /* maxAstSize */ 4);
-      }).to.throw(expressionSizeExceededError);
+      }).to.throw(expressionSizeExceededError); });
     });
   });
 
   describe('arrow functions', () => {
     it('known issue: single parameters with parentheses are ambiguous', () => {
       // Single parameters in parentheses are ambiguous to the parser.
-      expect(() => evaluate('[1, 2, 3].map((x) => x * x)')).to.throw();
+      allowConsoleError(() => {
+        expect(() => evaluate('[1, 2, 3].map((x) => x * x)')).to.throw();
+      });
     });
 
     it('Array#map()', () => {
@@ -647,7 +668,9 @@ describe('BindExpression', () => {
 
       // Only support arrow functions as the only parameter in applicable
       // function invocations (don't support optional `thisArg`, etc.).
-      expect(() => evaluate('a.reduce((x, y)) => x + y, 0)', {a})).to.throw();
+      allowConsoleError(() => {
+        expect(() => evaluate('a.reduce((x, y)) => x + y, 0)', {a})).to.throw();
+      });
     });
 
     it('Array#filter', () => {
@@ -662,17 +685,19 @@ describe('BindExpression', () => {
     });
 
     it('disallow: usage other than as function parameter', () => {
-      expect(() => { evaluate('() => 123'); }).to.throw();
-      expect(() => { evaluate('x => 123'); }).to.throw();
-      expect(() => { evaluate('(x, y) => 123'); }).to.throw();
+      allowConsoleError(() => {
+        expect(() => { evaluate('() => 123'); }).to.throw();
+        expect(() => { evaluate('x => 123'); }).to.throw();
+        expect(() => { evaluate('(x, y) => 123'); }).to.throw();
 
-      expect(() => { evaluate('(() => 123).constructor()'); }).to.throw();
-      expect(() => { evaluate('(x => 123).constructor()'); }).to.throw();
-      expect(() => { evaluate('((x, y) => 123).constructor()'); }).to.throw();
+        expect(() => { evaluate('(() => 123).constructor()'); }).to.throw();
+        expect(() => { evaluate('(x => 123).constructor()'); }).to.throw();
+        expect(() => { evaluate('((x, y) => 123).constructor()'); }).to.throw();
 
-      expect(() => { evaluate('(() => 123).name'); }).to.throw();
-      expect(() => { evaluate('(x => 123).name'); }).to.throw();
-      expect(() => { evaluate('((x, y) => 123).name'); }).to.throw();
+        expect(() => { evaluate('(() => 123).name'); }).to.throw();
+        expect(() => { evaluate('(x => 123).name'); }).to.throw();
+        expect(() => { evaluate('((x, y) => 123).name'); }).to.throw();
+      });
     });
 
     it('disallow: `arguments` or `this`', () => {

--- a/extensions/amp-brid-player/0.1/test/test-amp-brid-player.js
+++ b/extensions/amp-brid-player/0.1/test/test-amp-brid-player.js
@@ -87,19 +87,21 @@ describes.realWin('amp-brid-player', {
   });
 
   it('requires data-partner', () => {
-    return getBridPlayer({
+    allowConsoleError(() => { return getBridPlayer({
       'data-player': '4144',
       'data-video': '13663',
     }).should.eventually.be.rejectedWith(
         /The data-partner attribute is required for/);
+    });
   });
 
   it('requires data-player', () => {
-    return getBridPlayer({
+    allowConsoleError(() => { return getBridPlayer({
       'data-partner': '264',
       'data-video': '13663',
     }).should.eventually.be.rejectedWith(
         /The data-player attribute is required for/);
+    });
   });
 
   it('should forward events from brid-player to the amp element', () => {

--- a/extensions/amp-brightcove/0.1/test/test-amp-brightcove.js
+++ b/extensions/amp-brightcove/0.1/test/test-amp-brightcove.js
@@ -69,8 +69,10 @@ describes.realWin('amp-brightcove', {
   });
 
   it('requires data-account', () => {
-    return getBrightcove({}).should.eventually.be.rejectedWith(
-        /The data-account attribute is required for/);
+    allowConsoleError(() => {
+      return getBrightcove({}).should.eventually.be.rejectedWith(
+          /The data-account attribute is required for/);
+    });
   });
 
   it('removes iframe after unlayoutCallback', () => {

--- a/extensions/amp-byside-content/0.1/test/test-amp-byside-content.js
+++ b/extensions/amp-byside-content/0.1/test/test-amp-byside-content.js
@@ -72,17 +72,19 @@ describes.realWin('amp-byside-content', {
   });
 
   it('requires data-label', () => {
-    return getElement({
+    allowConsoleError(() => { return getElement({
       'data-webcare-id': 'D6604AE5D0',
     }).should.eventually.be.rejectedWith(
         /The data-label attribute is required for/);
+    });
   });
 
   it('requires data-webcare-id', () => {
-    return (getElement({
+    allowConsoleError(() => { return getElement({
       'data-label': 'placeholder-label',
-    })).should.eventually.be.rejectedWith(
+    }).should.eventually.be.rejectedWith(
         /The data-webcare-id attribute is required for/);
+    });
   });
 
   it('generates correct default origin', () => {

--- a/extensions/amp-consent/0.1/test/test-amp-consent.js
+++ b/extensions/amp-consent/0.1/test/test-amp-consent.js
@@ -116,21 +116,29 @@ describes.realWin('amp-consent', {
         scriptElement.textContent = JSON.stringify(defaultConfig);
         consentElement.appendChild(scriptElement);
         scriptElement.setAttribute('type', '');
-        expect(() => ampConsent.assertAndParseConfig_()).to.throw();
+        allowConsoleError(() => {
+          expect(() => ampConsent.assertAndParseConfig_()).to.throw();
+        });
         doc.body.appendChild(consentElement);
         const ampConsent = new AmpConsent(consentElement);
-        expect(() => ampConsent.assertAndParseConfig_()).to.throw();
+        allowConsoleError(() => {
+          expect(() => ampConsent.assertAndParseConfig_()).to.throw();
+        });
 
         // Check consent config exists
         scriptElement.setAttribute('type', 'application/json');
         scriptElement.textContent = JSON.stringify({});
-        expect(() => ampConsent.assertAndParseConfig_()).to.throw();
+        allowConsoleError(() => {
+          expect(() => ampConsent.assertAndParseConfig_()).to.throw();
+        });
 
         // Check there is only one script object
         scriptElement.textContent = JSON.stringify(defaultConfig);
         const script2 = doc.createElement('script');
         consentElement.appendChild(script2);
-        expect(() => ampConsent.assertAndParseConfig_()).to.throw();
+        allowConsoleError(() => {
+          expect(() => ampConsent.assertAndParseConfig_()).to.throw();
+        });
       });
     });
   });
@@ -290,8 +298,10 @@ describes.realWin('amp-consent', {
       yield macroTask();
       ampConsent.handleAction_(ACTION_TYPE.DISMISS);
       yield macroTask();
-      expect(() => ampConsent.handleAction_(ACTION_TYPE.DISMISS)).to.throw(
-          /No consent is displaying/);
+      allowConsoleError(() => {
+        expect(() => ampConsent.handleAction_(ACTION_TYPE.DISMISS)).to.throw(
+            /No consent is displaying/);
+      });
     });
 
     describe('schedule display', () => {

--- a/extensions/amp-consent/0.1/test/test-consent-state-manager.js
+++ b/extensions/amp-consent/0.1/test/test-consent-state-manager.js
@@ -71,8 +71,10 @@ describes.realWin('ConsentStateManager', {amp: 1}, env => {
 
     it('should not register consent instance twice', () => {
       manager.registerConsentInstance('test');
-      expect(() => manager.registerConsentInstance('test')).to.throw(
-          'CONSENT-STATE-MANAGER: instance already registered');
+      allowConsoleError(() => {
+        expect(() => manager.registerConsentInstance('test')).to.throw(
+            'CONSENT-STATE-MANAGER: instance already registered');
+      });
     });
 
     it('get consent state', function* () {

--- a/extensions/amp-dailymotion/0.1/test/test-amp-dailymotion.js
+++ b/extensions/amp-dailymotion/0.1/test/test-amp-dailymotion.js
@@ -75,7 +75,9 @@ describes.realWin('amp-dailymotion', {
   });
 
   it('requires data-videoid', () => {
-    return getDailymotion('').should.eventually.be.rejectedWith(
-        /The data-videoid attribute is required for/);
+    allowConsoleError(() => {
+      return getDailymotion('').should.eventually.be.rejectedWith(
+          /The data-videoid attribute is required for/);
+    });
   });
 });

--- a/extensions/amp-document-recommendations/0.1/test/test-config.js
+++ b/extensions/amp-document-recommendations/0.1/test/test-config.js
@@ -48,20 +48,26 @@ describe('amp-document-recommendations config', () => {
     });
 
     it('throws on null config', () => {
-      expect(() => assertConfig(null, host))
-          .to.throw('amp-document-recommendations config must be specified');
+      allowConsoleError(() => {
+        expect(() => assertConfig(null, host)).to.throw(
+            'amp-document-recommendations config must be specified');
+      });
     });
 
     it('throws on config with no "recommendations" key', () => {
       const config = {};
-      expect(() => assertConfig(config, host))
-          .to.throw('recommendations must be an array');
+      allowConsoleError(() => {
+        expect(() => assertConfig(config, host)).to.throw(
+            'recommendations must be an array');
+      });
     });
 
     it('throws on config with non-array "recommendations" key', () => {
       const config = {recommendations: {}};
-      expect(() => assertConfig(config, host))
-          .to.throw('recommendations must be an array');
+      allowConsoleError(() => {
+        expect(() => assertConfig(config, host)).to.throw(
+            'recommendations must be an array');
+      });
     });
 
     it('throws on config with missing recommendation title', () => {
@@ -71,8 +77,10 @@ describe('amp-document-recommendations config', () => {
           image: 'https://example.com/image.png',
         }],
       };
-      expect(() => assertConfig(config, host))
-          .to.throw('title must be a string');
+      allowConsoleError(() => {
+        expect(() => assertConfig(config, host)).to.throw(
+            'title must be a string');
+      });
     });
 
     it('throws on config with non-string recommendation title', () => {
@@ -83,8 +91,10 @@ describe('amp-document-recommendations config', () => {
           title: {},
         }],
       };
-      expect(() => assertConfig(config, host))
-          .to.throw('title must be a string');
+      allowConsoleError(() => {
+        expect(() => assertConfig(config, host)).to.throw(
+            'title must be a string');
+      });
     });
 
     it('throws on config with missing recommendation image', () => {
@@ -94,8 +104,10 @@ describe('amp-document-recommendations config', () => {
           title: 'Article 1',
         }],
       };
-      expect(() => assertConfig(config, host))
-          .to.throw('image must be a string');
+      allowConsoleError(() => {
+        expect(() => assertConfig(config, host)).to.throw(
+            'image must be a string');
+      });
     });
 
     it('throws on config with non-string recommendation image', () => {
@@ -106,8 +118,10 @@ describe('amp-document-recommendations config', () => {
           title: 'Article 1',
         }],
       };
-      expect(() => assertConfig(config, host))
-          .to.throw('image must be a string');
+      allowConsoleError(() => {
+        expect(() => assertConfig(config, host)).to.throw(
+            'image must be a string');
+      });
     });
 
     it('throws on config with recommendations from different domains', () => {
@@ -120,10 +134,11 @@ describe('amp-document-recommendations config', () => {
           },
         ],
       };
-      expect(() => assertConfig(config, host))
-          .to.throw(
-              'recommendations must be from the same host as the current' +
-              ' document');
+      allowConsoleError(() => {
+        expect(() => assertConfig(config, host)).to.throw(
+            'recommendations must be from the same host as the current' +
+            ' document');
+      });
     });
 
     it('throws on config with recommendations from different subdomains',
@@ -137,10 +152,11 @@ describe('amp-document-recommendations config', () => {
               },
             ],
           };
-          expect(() => assertConfig(config, host))
-              .to.throw(
-                  'recommendations must be from the same host as the current' +
-                  ' document');
+          allowConsoleError(() => {
+            expect(() => assertConfig(config, host)).to.throw(
+                'recommendations must be from the same host as the current' +
+                ' document');
+          });
         });
 
     it('throws on config with recommendations on different ports', () => {
@@ -153,10 +169,11 @@ describe('amp-document-recommendations config', () => {
           },
         ],
       };
-      expect(() => assertConfig(config, host))
-          .to.throw(
-              'recommendations must be from the same host as the current' +
-              ' document');
+      allowConsoleError(() => {
+        expect(() => assertConfig(config, host)).to.throw(
+            'recommendations must be from the same host as the current' +
+            ' document');
+      });
     });
   });
 });

--- a/extensions/amp-experiment/0.1/test/test-amp-experiment.js
+++ b/extensions/amp-experiment/0.1/test/test-amp-experiment.js
@@ -82,38 +82,38 @@ describes.realWin('amp-experiment', {
   });
 
   it('should throw if it has no child element', () => {
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       experiment.buildCallback();
-    }).to.throw(/should contain exactly one/);
+    }).to.throw(/should contain exactly one/); });
   });
 
   it('should throw if it has multiple child elements', () => {
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       addConfigElement('script');
       addConfigElement('script');
       experiment.buildCallback();
-    }).to.throw(/should contain exactly one/);
+    }).to.throw(/should contain exactly one/); });
   });
 
   it('should throw if the child element is not a <script> element', () => {
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       addConfigElement('a');
       experiment.buildCallback();
-    }).to.throw(/script/);
+    }).to.throw(/script/); });
   });
 
   it('should throw if the child script element is not json typed', () => {
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       addConfigElement('script', 'wrongtype');
       experiment.buildCallback();
-    }).to.throw(/application\/json/);
+    }).to.throw(/application\/json/); });
   });
 
   it('should throw if the child script element has non-JSON content', () => {
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       addConfigElement('script', 'application/json', '{not json}');
       experiment.buildCallback();
-    }).to.throw();
+    }).to.throw(); });
   });
 
   it('should add attributes to body element for the allocated variants', () => {

--- a/extensions/amp-experiment/0.1/test/test-variant.js
+++ b/extensions/amp-experiment/0.1/test/test-variant.js
@@ -50,87 +50,87 @@ describes.sandboxed('allocateVariant', {}, () => {
   });
 
   it('should throw for invalid config', () => {
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       allocateVariant(ampdoc, 'name', null);
-    }).to.throw();
+    }).to.throw(); });
 
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       allocateVariant(ampdoc, 'name', undefined);
-    }).to.throw();
+    }).to.throw(); });
 
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       allocateVariant(ampdoc, 'name', {});
-    }).to.throw(/Missing experiment variants config/);
+    }).to.throw(/Missing experiment variants config/); });
 
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       allocateVariant(ampdoc, 'name', {variants: {}});
-    }).to.throw(/Missing experiment variants config/);
+    }).to.throw(/Missing experiment variants config/); });
 
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       allocateVariant(ampdoc, 'name', {
         variants: {
           'invalid_char_%_in_name': 1,
         },
       });
-    }).to.throw(/Invalid name/);
+    }).to.throw(/Invalid name/); });
 
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       allocateVariant(ampdoc, 'name', {
         variants: {
           'variant_1': 50,
           'variant_2': 51,
         },
       });
-    }).to.throw(/Total percentage is bigger than 100/);
+    }).to.throw(/Total percentage is bigger than 100/); });
 
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       allocateVariant(ampdoc, 'name', {
         variants: {
           'negative_percentage': -1,
         },
       });
-    }).to.throw(/Invalid percentage/);
+    }).to.throw(/Invalid percentage/); });
 
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       allocateVariant(ampdoc, 'name', {
         variants: {
           'too_big_percentage': 101,
         },
       });
-    }).to.throw(/Invalid percentage/);
+    }).to.throw(/Invalid percentage/); });
 
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       allocateVariant(ampdoc, 'name', {
         variants: {
           'non_number_percentage': '50',
         },
       });
-    }).to.throw(/Invalid percentage/);
+    }).to.throw(/Invalid percentage/); });
 
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       allocateVariant(ampdoc, 'invalid_name!', {
         variants: {
           'variant_1': 50,
         },
       });
-    }).to.throw(/Invalid name/);
+    }).to.throw(/Invalid name/); });
 
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       allocateVariant(ampdoc, '', {
         variants: {
           'variant_1': 50,
         },
       });
-    }).to.throw(/Invalid name/);
+    }).to.throw(/Invalid name/); });
 
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       allocateVariant(ampdoc, 'name', {
         group: 'invalid_group_name!',
         variants: {
           'variant_1': 50,
         },
       });
-    }).to.throw(/Invalid name/);
+    }).to.throw(/Invalid name/); });
   });
 
   it('should work around float rounding error', () => {
@@ -270,13 +270,13 @@ describes.sandboxed('allocateVariant', {}, () => {
     getNotificationStub.withArgs('notif-1')
         .returns(Promise.resolve(null));
 
-    return expect(allocateVariant(ampdoc, 'name', {
+    allowConsoleError(() => { return expect(allocateVariant(ampdoc, 'name', {
       consentNotificationId: 'notif-1',
       variants: {
         '-Variant_1': 50,
         '-Variant_2': 50,
       },
-    })).to.eventually.rejectedWith('Notification not found: notif-1');
+    })).to.eventually.be.rejectedWith('Notification not found: notif-1'); });
   });
 
   it('should have no variant allocated if consent is missing', () => {

--- a/extensions/amp-form/0.1/test/test-amp-form.js
+++ b/extensions/amp-form/0.1/test/test-amp-form.js
@@ -126,11 +126,15 @@ describes.repeated('', {
       const form = getForm();
       document.body.appendChild(form);
       form.setAttribute('action-xhr', 'http://example.com');
-      expect(() => new AmpForm(form)).to.throw(
-          /form action-xhr must start with/);
+      allowConsoleError(() => {
+        expect(() => new AmpForm(form)).to.throw(
+            /form action-xhr must start with/);
+      });
       form.setAttribute('action-xhr', 'https://cdn.ampproject.org/example.com');
-      expect(() => new AmpForm(form)).to.throw(
-          /form action-xhr should not be on AMP CDN/);
+      allowConsoleError(() => {
+        expect(() => new AmpForm(form)).to.throw(
+            /form action-xhr should not be on AMP CDN/);
+      });
       form.setAttribute('action-xhr', 'https://example.com');
       expect(() => new AmpForm(form)).to.not.throw;
       document.body.removeChild(form);
@@ -144,8 +148,10 @@ describes.repeated('', {
       illegalInput.setAttribute('name', '__amp_source_origin');
       illegalInput.value = 'https://example.com';
       form.appendChild(illegalInput);
-      expect(() => new AmpForm(form)).to.throw(
-          /Illegal input name, __amp_source_origin found/);
+      allowConsoleError(() => {
+        expect(() => new AmpForm(form)).to.throw(
+            /Illegal input name, __amp_source_origin found/);
+      });
       document.body.removeChild(form);
     });
 
@@ -231,7 +237,9 @@ describes.repeated('', {
       sandbox.spy(form, 'checkValidity');
       const errorRe =
         /Only XHR based \(via action-xhr attribute\) submissions are supported/;
-      expect(() => ampForm.handleSubmitEvent_(event)).to.throw(errorRe);
+      allowConsoleError(() => {
+        expect(() => ampForm.handleSubmitEvent_(event)).to.throw(errorRe);
+      });
       expect(event.preventDefault).to.be.called;
       expect(ampForm.analyticsEvent_).to.have.not.been.called;
       document.body.removeChild(form);
@@ -291,7 +299,9 @@ describes.repeated('', {
       sandbox.spy(form, 'checkValidity');
       const submitErrorRe =
         /Only XHR based \(via action-xhr attribute\) submissions are supported/;
-      expect(() => ampForm.handleSubmitEvent_(event)).to.throw(submitErrorRe);
+      allowConsoleError(() => {
+        expect(() => ampForm.handleSubmitEvent_(event)).to.throw(submitErrorRe);
+      });
       expect(event.preventDefault).to.be.called;
       document.body.removeChild(form);
     });

--- a/extensions/amp-gfycat/0.1/test/test-amp-gfycat.js
+++ b/extensions/amp-gfycat/0.1/test/test-amp-gfycat.js
@@ -109,8 +109,10 @@ describes.realWin('amp-gfycat', {
   }
 
   it('requires data-gfyid', () => {
-    return getGfycat('').should.eventually.be.rejectedWith(
-        /The data-gfyid attribute is required for/);
+    allowConsoleError(() => {
+      return getGfycat('').should.eventually.be.rejectedWith(
+          /The data-gfyid attribute is required for/);
+    });
   });
 
   it('renders placeholder with an alt', () => {

--- a/extensions/amp-gist/0.1/test/test-amp-gist.js
+++ b/extensions/amp-gist/0.1/test/test-amp-gist.js
@@ -58,7 +58,9 @@ describes.realWin('amp-gist', {
   });
 
   it('Rejects because data-gistid is missing', () => {
-    expect(getIns('')).to.be.rejectedWith(
-        /The data-gistid attribute is required for/);
+    allowConsoleError(() => {
+      expect(getIns('')).to.be.rejectedWith(
+          /The data-gistid attribute is required for/);
+    });
   });
 });

--- a/extensions/amp-google-vrview-image/0.1/test/test-amp-google-vrview-image.js
+++ b/extensions/amp-google-vrview-image/0.1/test/test-amp-google-vrview-image.js
@@ -80,12 +80,16 @@ describes.realWin('amp-google-vrview-image', {
   });
 
   it('requires src', () => {
-    return getVrImage({}).should.eventually.be.rejectedWith(
-        /must be available/);
+    allowConsoleError(() => {
+      return getVrImage({}).should.eventually.be.rejectedWith(
+          /must be available/);
+    });
   });
 
   it('requires https src', () => {
-    return getVrImage({'src': 'http://example.com/image1'}).should
-        .eventually.be.rejectedWith(/https/);
+    allowConsoleError(() => {
+      return getVrImage({'src': 'http://example.com/image1'})
+          .should.eventually.be.rejectedWith(/https/);
+    });
   });
 });

--- a/extensions/amp-hulu/0.1/test/test-amp-hulu.js
+++ b/extensions/amp-hulu/0.1/test/test-amp-hulu.js
@@ -60,7 +60,9 @@ describes.realWin('amp-hulu', {
   });
 
   it('requires data-eid', () => {
-    return getHulu('').should.eventually.be.rejectedWith(
-        /The data-eid attribute is required for/);
+    allowConsoleError(() => {
+      return getHulu('').should.eventually.be.rejectedWith(
+          /The data-eid attribute is required for/);
+    });
   });
 });

--- a/extensions/amp-iframe/0.1/test/test-amp-iframe.js
+++ b/extensions/amp-iframe/0.1/test/test-amp-iframe.js
@@ -384,30 +384,30 @@ describes.realWin('amp-iframe', {
     it('should deny same origin', () => {
       const ampIframe = createAmpIframe(env);
       const impl = ampIframe.implementation_;
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         impl.assertSource('https://google.com/fpp', 'https://google.com/abc',
             'allow-same-origin');
-      }).to.throw(/must not be equal to container/);
+      }).to.throw(/must not be equal to container/); });
 
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         impl.assertSource('https://google.com/fpp', 'https://google.com/abc',
             'Allow-same-origin');
-      }).to.throw(/must not be equal to container/);
+      }).to.throw(/must not be equal to container/); });
 
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         impl.assertSource('https://google.com/fpp', 'https://google.com/abc',
             'allow-same-origin allow-scripts');
-      }).to.throw(/must not be equal to container/);
+      }).to.throw(/must not be equal to container/); });
       // Same origin, but sandboxed.
       impl.assertSource('https://google.com/fpp', 'https://google.com/abc', '');
 
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         impl.assertSource('http://google.com/', 'https://foo.com', '');
-      }).to.throw(/Must start with https/);
+      }).to.throw(/Must start with https/); });
 
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         impl.assertSource('./foo', location.href, 'allow-same-origin');
-      }).to.throw(/must not be equal to container/);
+      }).to.throw(/must not be equal to container/); });
 
       impl.assertSource('http://iframe.localhost:123/foo',
           'https://foo.com', '');
@@ -415,20 +415,22 @@ describes.realWin('amp-iframe', {
       ampIframe.setAttribute('srcdoc', 'abc');
       ampIframe.setAttribute('sandbox', 'allow-same-origin');
 
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         impl.transformSrcDoc_('<script>try{parent.location.href}catch(e){' +
           'parent.parent./*OK*/postMessage(\'loaded-iframe\', \'*\');}' +
           '</script>', 'Allow-Same-Origin');
-      }).to.throw(/allow-same-origin is not allowed with the srcdoc attribute/);
+      }).to.throw(
+          /allow-same-origin is not allowed with the srcdoc attribute/);
+      });
 
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         impl.assertSource('https://3p.ampproject.net:999/t',
             'https://google.com/abc');
-      }).to.throw(/not allow embedding of frames from ampproject\.\*/);
-      expect(() => {
+      }).to.throw(/not allow embedding of frames from ampproject\.\*/); });
+      allowConsoleError(() => { expect(() => {
         impl.assertSource('https://3p.ampproject.net:999/t',
             'https://google.com/abc');
-      }).to.throw(/not allow embedding of frames from ampproject\.\*/);
+      }).to.throw(/not allow embedding of frames from ampproject\.\*/); });
     });
 
     it('should transform source', () => {

--- a/extensions/amp-instagram/0.1/test/test-amp-instagram.js
+++ b/extensions/amp-instagram/0.1/test/test-amp-instagram.js
@@ -153,8 +153,10 @@ describes.realWin('amp-instagram', {
   });
 
   it('requires data-shortcode', () => {
-    expect(getIns('')).to.be.rejectedWith(
-        /The data-shortcode attribute is required for/);
+    allowConsoleError(() => {
+      expect(getIns('')).to.be.rejectedWith(
+          /The data-shortcode attribute is required for/);
+    });
   });
 
   it('resizes in response to messages from Instagram iframe', () => {

--- a/extensions/amp-install-serviceworker/0.1/test/test-amp-install-serviceworker.js
+++ b/extensions/amp-install-serviceworker/0.1/test/test-amp-install-serviceworker.js
@@ -254,14 +254,14 @@ describes.realWin('amp-install-serviceworker', {
     it('should reject bad iframe URLs', () => {
       const iframeSrc = 'https://www2.example.com/install-sw.html';
       install.setAttribute('data-iframe-src', iframeSrc);
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         implementation.buildCallback();
-      }).to.throw(/should be a URL on the same origin as the source/);
+      }).to.throw(/should be a URL on the same origin as the source/); });
       install.setAttribute('data-iframe-src',
           'http://www.example.com/install-sw.html');
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         implementation.buildCallback();
-      }).to.throw(/https/);
+      }).to.throw(/https/); });
     });
   });
 });
@@ -339,32 +339,32 @@ describes.fakeWin('url rewriter', {
 
     it('should fail when only mask configured', () => {
       element.removeAttribute('data-no-service-worker-fallback-shell-url');
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         implementation.maybeInstallUrlRewrite_();
-      }).to.throw(/must be specified/);
+      }).to.throw(/must be specified/); });
     });
 
     it('should fail when only shell configured', () => {
       element.removeAttribute('data-no-service-worker-fallback-url-match');
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         implementation.maybeInstallUrlRewrite_();
-      }).to.throw(/must be specified/);
+      }).to.throw(/must be specified/); });
     });
 
     it('should fail when shell is on different origin', () => {
       element.setAttribute('data-no-service-worker-fallback-shell-url',
           'https://acme.org/shell#abc');
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         implementation.maybeInstallUrlRewrite_();
-      }).to.throw(/must be the same as source origin/);
+      }).to.throw(/must be the same as source origin/); });
     });
 
     it('should fail when mask is an invalid expression', () => {
       element.setAttribute('data-no-service-worker-fallback-url-match',
           '?');
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         implementation.maybeInstallUrlRewrite_();
-      }).to.throw(/Invalid/);
+      }).to.throw(/Invalid/); });
     });
   });
 

--- a/extensions/amp-izlesene/0.1/test/test-amp-izlesene.js
+++ b/extensions/amp-izlesene/0.1/test/test-amp-izlesene.js
@@ -62,7 +62,9 @@ describes.realWin('amp-izlesene', {
   });
 
   it('requires data-videoid', () => {
-    return getIzlesene('').should.eventually.be.rejectedWith(
-        /The data-videoid attribute is required for/);
+    allowConsoleError(() => {
+      return getIzlesene('').should.eventually.be.rejectedWith(
+          /The data-videoid attribute is required for/);
+    });
   });
 });

--- a/extensions/amp-jwplayer/0.1/test/test-amp-jwplayer.js
+++ b/extensions/amp-jwplayer/0.1/test/test-amp-jwplayer.js
@@ -69,19 +69,19 @@ describes.realWin('amp-jwplayer', {
   });
 
   it('fails if no media is specified', () => {
-    return getjwplayer({
+    allowConsoleError(() => { return getjwplayer({
       'data-player-id': 'sDZEo0ea',
     }).should.eventually.be.rejectedWith(
-        /Either the data-media-id or the data-playlist-id attributes must be/
-    );
+        /Either the data-media-id or the data-playlist-id attributes must be/);
+    });
   });
 
   it('fails if no player is specified', () => {
-    return getjwplayer({
+    allowConsoleError(() => { return getjwplayer({
       'data-media-id': 'Wferorsv',
     }).should.eventually.be.rejectedWith(
-        /The data-player-id attribute is required for/
-    );
+        /The data-player-id attribute is required for/);
+    });
   });
 
   it('renders with a bad playlist', () => {

--- a/extensions/amp-kaltura-player/0.1/test/test-amp-kaltura-player.js
+++ b/extensions/amp-kaltura-player/0.1/test/test-amp-kaltura-player.js
@@ -72,10 +72,11 @@ describes.realWin('amp-kaltura-player', {
   });
 
   it('requires data-account', () => {
-    return getKaltura({}).then(kp => {
+    allowConsoleError(() => { return getKaltura({}).then(kp => {
       kp.build();
     }).should.eventually.be.rejectedWith(
         /The data-partner attribute is required for/);
+    });
   });
 
   it('should pass data-param-* attributes to the iframe src', () => {

--- a/extensions/amp-live-list/0.1/test/test-amp-live-list.js
+++ b/extensions/amp-live-list/0.1/test/test-amp-live-list.js
@@ -120,9 +120,9 @@ describes.realWin('amp-live-list', {
 
   it('validates that elem has an id on initial load', () => {
     buildElement(elem, {});
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       liveList.buildCallback();
-    }).to.throw(/must have an id/);
+    }).to.throw(/must have an id/); });
 
     expect(() => {
       liveList.element.setAttribute('id', 'my-list');
@@ -144,21 +144,21 @@ describes.realWin('amp-live-list', {
     const child = document.createElement('div');
     elem.querySelector('[items]').appendChild(child);
     buildElement(elem, dftAttrs);
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       liveList.validateLiveListItems_(elem.querySelector('[items]'));
-    }).to.throw(/children must have id and data-sort-time/);
+    }).to.throw(/children must have id and data-sort-time/); });
 
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       child.setAttribute('id', 'child-id');
       liveList.buildCallback();
-    }).to.throw(/children must have id and data-sort-time/);
+    }).to.throw(/children must have id and data-sort-time/); });
 
     child.removeAttribute('id');
 
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       child.setAttribute('data-sort-time', Date.now());
       liveList.buildCallback();
-    }).to.throw(/children must have id and data-sort-time/);
+    }).to.throw(/children must have id and data-sort-time/); });
 
     expect(() => {
       child.setAttribute('id', 'child-id');
@@ -190,9 +190,9 @@ describes.realWin('amp-live-list', {
     // Errors out because no data-max-items-per-page is given
     expect(liveList.element.getAttribute('data-max-items-per-page'))
         .to.equal('');
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       liveList.buildCallback();
-    }).to.throw(/must have data-max-items-per-page/);
+    }).to.throw(/must have data-max-items-per-page/); });
 
     // Errors out because data-max-items-per-page does not exist
     attrs = Object.assign({}, dftAttrs);
@@ -200,18 +200,18 @@ describes.realWin('amp-live-list', {
     delete attrs['data-max-items-per-page'];
     expect('data-max-items-per-page' in attrs).to.be.false;
     buildElement(elem, attrs);
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       liveList.buildCallback();
-    }).to.throw(/must have data-max-items-per-page/);
+    }).to.throw(/must have data-max-items-per-page/); });
 
     // Errors out because data-max-items-per-page is not parseable as a number
     attrs = Object.assign({}, dftAttrs, {'data-max-items-per-page': 'hello'});
     buildElement(elem, attrs);
     expect(liveList.element.getAttribute('data-max-items-per-page'))
         .to.equal('hello');
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       liveList.buildCallback();
-    }).to.throw(/must have data-max-items-per-page/);
+    }).to.throw(/must have data-max-items-per-page/); });
 
     attrs = Object.assign({}, dftAttrs, {'data-max-items-per-page': '10'});
     buildElement(elem, attrs);
@@ -245,17 +245,17 @@ describes.realWin('amp-live-list', {
   it('should enforce update slot', () => {
     buildElement(elem, dftAttrs);
     elem.removeChild(elem.querySelector('[update]'));
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       liveList.buildCallback();
-    }).to.throw(/must have an "update" slot/);
+    }).to.throw(/must have an "update" slot/); });
   });
 
   it('should enforce items slot', () => {
     buildElement(elem, dftAttrs);
     elem.removeChild(elem.querySelector('[items]'));
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       liveList.buildCallback();
-    }).to.throw(/must have an "items" slot/);
+    }).to.throw(/must have an "items" slot/); });
   });
 
   it('should have aria-live=polite by default', () => {
@@ -381,9 +381,9 @@ describes.realWin('amp-live-list', {
       updateLiveListItems.appendChild(document.createElement('div'));
       const stub = sandbox.stub(liveList, 'validateLiveListItems_');
       expect(stub).to.have.not.been.called;
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         liveList.update(update);
-      }).to.throw();
+      }).to.throw(); });
       expect(stub).to.be.calledOnce;
     });
 

--- a/extensions/amp-nexxtv-player/0.1/test/test-amp-nexxtv-player.js
+++ b/extensions/amp-nexxtv-player/0.1/test/test-amp-nexxtv-player.js
@@ -67,13 +67,18 @@ describes.realWin('amp-nexxtv-player', {
   });
 
   it('fails without mediaid', () => {
-    return getNexxtv(null, '761').should.eventually.be.rejectedWith(
-        /The data-mediaid attribute is required/);
+    allowConsoleError(() => {
+      return getNexxtv(null, '761').should.eventually.be.rejectedWith(
+          /The data-mediaid attribute is required/);
+    });
   });
 
   it('fails without client', () => {
-    return getNexxtv('71QQG852413DU7J', null).should.eventually.be.rejectedWith(
-        /The data-client attribute is required/);
+    allowConsoleError(() => {
+      return getNexxtv('71QQG852413DU7J', null)
+          .should.eventually.be.rejectedWith(
+              /The data-client attribute is required/);
+    });
   });
 
   it('should forward events from nexxtv-player to the amp element', () => {

--- a/extensions/amp-o2-player/0.1/test/test-amp-o2-player.js
+++ b/extensions/amp-o2-player/0.1/test/test-amp-o2-player.js
@@ -68,22 +68,26 @@ describes.realWin('amp-o2-player', {
   });
 
   it('requires data-pid', () => {
-    return getO2player({
+    allowConsoleError(() => { return getO2player({
       'data-bcid': '50d595ec0364e95588c77bd2',
     }).should.eventually.be.rejectedWith(
         /data-pid attribute is required for/);
+    });
   });
 
   it('requires data-bcid', () => {
-    return getO2player({
+    allowConsoleError(() => { return getO2player({
       'data-pid': '573acb47e4b0564ec2e10011',
     }).should.eventually.be.rejectedWith(
         /data-bcid attribute is required for/);
+    });
   });
 
   it('requires data-pid && data-bcid', () => {
-    return getO2player({}).should.eventually.be.rejectedWith(
-        /data-pid attribute is required for/);
+    allowConsoleError(() => {
+      return getO2player({}).should.eventually.be.rejectedWith(
+          /data-pid attribute is required for/);
+    });
   });
 
   it('renders with data-vid passed', () => {

--- a/extensions/amp-ooyala-player/0.1/test/test-amp-ooyala.js
+++ b/extensions/amp-ooyala-player/0.1/test/test-amp-ooyala.js
@@ -88,24 +88,28 @@ describes.realWin('amp-ooyala-player', {
   });
 
   it('fails without an embed code', () => {
-    return getOoyalaElement(null,
-        '6440813504804d76ba35c8c787a4b33c',
-        '5zb2wxOlZcNCe_HVT3a6cawW298X').should.eventually.be.rejectedWith(
-        /The data-embedcode attribute is required/);
+    allowConsoleError(() => {
+      return getOoyalaElement(null, '6440813504804d76ba35c8c787a4b33c',
+          '5zb2wxOlZcNCe_HVT3a6cawW298X').should.eventually.be.rejectedWith(
+          /The data-embedcode attribute is required/);
+    });
   });
 
   it('fails without a player ID', () => {
-    return getOoyalaElement('Vxc2k0MDE6Y_C7J5podo3UDxlFxGaZrQ',
-        null,
-        '5zb2wxOlZcNCe_HVT3a6cawW298X').should.eventually.be.rejectedWith(
-        /The data-playerid attribute is required/);
+    allowConsoleError(() => {
+      return getOoyalaElement('Vxc2k0MDE6Y_C7J5podo3UDxlFxGaZrQ', null,
+          '5zb2wxOlZcNCe_HVT3a6cawW298X').should.eventually.be.rejectedWith(
+          /The data-playerid attribute is required/);
+    });
   });
 
   it('fails without a p-code', () => {
-    return getOoyalaElement('Vxc2k0MDE6Y_C7J5podo3UDxlFxGaZrQ',
-        '6440813504804d76ba35c8c787a4b33c',
-        null).should.eventually.be.rejectedWith(
-        /The data-pcode attribute is required/);
+    allowConsoleError(() => {
+      return getOoyalaElement('Vxc2k0MDE6Y_C7J5podo3UDxlFxGaZrQ',
+          '6440813504804d76ba35c8c787a4b33c', null)
+          .should.eventually.be.rejectedWith(
+              /The data-pcode attribute is required/);
+    });
   });
 
 });

--- a/extensions/amp-playbuzz/0.1/test/test-amp-playbuzz.js
+++ b/extensions/amp-playbuzz/0.1/test/test-amp-playbuzz.js
@@ -174,7 +174,9 @@ describes.realWin('amp-playbuzz', {
 
   it('requires item attribute', () => {
     const src = createItemSrc().withUrl('');
-    expect(getIns(src)).to.be.rejectedWith(
-        /The item attribute is required for/);
+    allowConsoleError(() => {
+      expect(getIns(src)).to.be.rejectedWith(
+          /The item attribute is required for/);
+    });
   });
 });

--- a/extensions/amp-reddit/0.1/test/test-amp-reddit.js
+++ b/extensions/amp-reddit/0.1/test/test-amp-reddit.js
@@ -100,13 +100,17 @@ describes.realWin('amp-reddit', {
   });
 
   it('requires data-src', () => {
-    return getReddit('', 'post').should.eventually.be.rejectedWith(
-        /The data-src attribute is required for/);
+    allowConsoleError(() => {
+      return getReddit('', 'post').should.eventually.be.rejectedWith(
+          /The data-src attribute is required for/);
+    });
   });
 
   it('requires data-embedtype', () => {
-    return getReddit('https://www.reddit.com/r/me_irl/comments/52rmir/me_irl/?ref=share&amp;ref_source=embed', '')
-        .should.eventually.be.rejectedWith(
-            /The data-embedtype attribute is required for/);
+    allowConsoleError(() => {
+      return getReddit('https://www.reddit.com/r/me_irl/comments/52rmir/me_irl/?ref=share&amp;ref_source=embed', '')
+          .should.eventually.be.rejectedWith(
+              /The data-embedtype attribute is required for/);
+    });
   });
 });

--- a/extensions/amp-selector/0.1/test/test-amp-selector.js
+++ b/extensions/amp-selector/0.1/test/test-amp-selector.js
@@ -942,8 +942,10 @@ describes.realWin('amp-selector', {
             multiple: true,
           },
         });
-        return expect(ampSelector.build()).to.eventually.be.rejectedWith(
-            /not supported for multiple selection amp-selector​​​/);
+        allowConsoleError(() => {
+          return expect(ampSelector.build()).to.eventually.be.rejectedWith(
+              /not supported for multiple selection amp-selector​​​/);
+        });
       });
 
       it('should ONLY change selection in `select` mode', () => {

--- a/extensions/amp-social-share/0.1/test/test-amp-social-share.js
+++ b/extensions/amp-social-share/0.1/test/test-amp-social-share.js
@@ -79,23 +79,29 @@ describes.realWin('amp-social-share', {
     const share = doc.createElement('amp-social-share');
     share.setAttribute('type', 'unknown-provider');
     doc.body.appendChild(share);
-    return expect(loaded(share)).to.be.eventually.rejectedWith(
-        /data-share-endpoint attribute is required/);
+    allowConsoleError(() => {
+      return expect(loaded(share)).to.eventually.be.rejectedWith(
+          /data-share-endpoint attribute is required/);
+    });
   });
 
   it('errors if type is missing', () => {
     const share = doc.createElement('amp-social-share');
     doc.body.appendChild(share);
-    return expect(loaded(share)).to.be.eventually.rejectedWith(
-        /type attribute is required/);
+    allowConsoleError(() => {
+      return expect(loaded(share)).to.eventually.be.rejectedWith(
+          /type attribute is required/);
+    });
   });
 
   it('errors if type has space characters', () => {
     const share = doc.createElement('amp-social-share');
     share.setAttribute('type', 'hello world');
     doc.body.appendChild(share);
-    return expect(loaded(share)).to.be.eventually.rejectedWith(
-        /Space characters are not allowed in type attribute value/);
+    allowConsoleError(() => {
+      return expect(loaded(share)).to.eventually.be.rejectedWith(
+          /Space characters are not allowed in type attribute value/);
+    });
   });
 
   it('renders unconfigured providers if share endpoint provided', () => {

--- a/extensions/amp-soundcloud/0.1/test/test-amp-soundcloud.js
+++ b/extensions/amp-soundcloud/0.1/test/test-amp-soundcloud.js
@@ -105,7 +105,9 @@ describes.realWin('amp-soundcloud', {
   });
 
   it('renders data-trackid', () => {
-    expect(getIns('')).to.be.rejectedWith(
-        /The data-trackid attribute is required for/);
+    allowConsoleError(() => {
+      expect(getIns('')).to.be.rejectedWith(
+          /The data-trackid attribute is required for/);
+    });
   });
 });

--- a/extensions/amp-subscriptions/0.1/test/test-actions.js
+++ b/extensions/amp-subscriptions/0.1/test/test-actions.js
@@ -167,22 +167,22 @@ describes.realWin('Actions', {amp: true}, env => {
     }).then(() => {
       throw new Error('must have failed');
     }, reason => {
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         throw reason;
-      }).to.throw(/broken/);
+      }).to.throw(/broken/); });
       expect(actions.actionPromise_).to.be.null;
     });
   });
 
   it('should disallow unknown action', () => {
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       actions.execute('unknown');
-    }).to.throw(/Action URL is not configured/);
+    }).to.throw(/Action URL is not configured/); });
   });
 
   it('should fail before build is complete', () => {
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       actions.execute('login');
-    }).to.throw(/Action URL is not ready/);
+    }).to.throw(/Action URL is not ready/); });
   });
 });

--- a/extensions/amp-video/0.1/test/test-amp-video.js
+++ b/extensions/amp-video/0.1/test/test-amp-video.js
@@ -188,7 +188,7 @@ describes.realWin('amp-video', {
   });
 
   it('should not load a video with http src', () => {
-    return expect(getVideo({
+    allowConsoleError(() => { return expect(getVideo({
       src: 'http://example.com/video.mp4',
       width: 160,
       height: 90,
@@ -196,7 +196,7 @@ describes.realWin('amp-video', {
       'autoplay': '',
       'muted': '',
       'loop': '',
-    })).to.be.rejectedWith(/start with/);
+    })).to.be.rejectedWith(/start with/); });
   });
 
   it('should not load a video with http source children', () => {
@@ -209,7 +209,7 @@ describes.realWin('amp-video', {
       source.setAttribute('type', mediatype);
       sources.push(source);
     }
-    return expect(getVideo({
+    allowConsoleError(() => { return expect(getVideo({
       src: 'video.mp4',
       width: 160,
       height: 90,
@@ -217,7 +217,7 @@ describes.realWin('amp-video', {
       'autoplay': '',
       'muted': '',
       'loop': '',
-    }, sources)).to.be.rejectedWith(/start with/);
+    }, sources)).to.be.rejectedWith(/start with/); });
   });
 
   it('should set poster, controls, controlsList in prerender mode', () => {

--- a/extensions/amp-vimeo/0.1/test/test-amp-vimeo.js
+++ b/extensions/amp-vimeo/0.1/test/test-amp-vimeo.js
@@ -62,7 +62,9 @@ describes.realWin('amp-vimeo', {
   });
 
   it('requires data-videoid', () => {
-    return getVimeo('').should.eventually.be.rejectedWith(
-        /The data-videoid attribute is required for/);
+    allowConsoleError(() => {
+      return getVimeo('').should.eventually.be.rejectedWith(
+          /The data-videoid attribute is required for/);
+    });
   });
 });

--- a/extensions/amp-vine/0.1/test/test-amp-vine.js
+++ b/extensions/amp-vine/0.1/test/test-amp-vine.js
@@ -59,7 +59,9 @@ describes.realWin('amp-vine', {
   });
 
   it('requires data-vineid', () => {
-    return getVine('').should.eventually.be.rejectedWith(
-        /The data-vineid attribute is required for/);
+    allowConsoleError(() => {
+      return getVine('').should.eventually.be.rejectedWith(
+          /The data-vineid attribute is required for/);
+    });
   });
 });

--- a/extensions/amp-vk/0.1/test/test-amp-vk.js
+++ b/extensions/amp-vk/0.1/test/test-amp-vk.js
@@ -70,8 +70,10 @@ describes.realWin('amp-vk', {
   it('requires data-embedtype', () => {
     const params = Object.assign({}, POST_PARAMS);
     delete params['embedtype'];
-    return createAmpVkElement(params).should.eventually.be.rejectedWith(
-        /The data-embedtype attribute is required for/);
+    allowConsoleError(() => {
+      return createAmpVkElement(params).should.eventually.be.rejectedWith(
+          /The data-embedtype attribute is required for/);
+    });
   });
 
   it('removes iframe after unlayoutCallback', () => {
@@ -91,22 +93,28 @@ describes.realWin('amp-vk', {
   it('post::requires data-hash', () => {
     const params = Object.assign({}, POST_PARAMS);
     delete params['hash'];
-    return createAmpVkElement(params).should.eventually.be.rejectedWith(
-        /The data-hash attribute is required for/);
+    allowConsoleError(() => {
+      return createAmpVkElement(params).should.eventually.be.rejectedWith(
+          /The data-hash attribute is required for/);
+    });
   });
 
   it('post::requires data-owner-id', () => {
     const params = Object.assign({}, POST_PARAMS);
     delete params['owner-id'];
-    return createAmpVkElement(params).should.eventually.be.rejectedWith(
-        /The data-owner-id attribute is required for/);
+    allowConsoleError(() => {
+      return createAmpVkElement(params).should.eventually.be.rejectedWith(
+          /The data-owner-id attribute is required for/);
+    });
   });
 
   it('post::requires data-post-id', () => {
     const params = Object.assign({}, POST_PARAMS);
     delete params['post-id'];
-    return createAmpVkElement(params).should.eventually.be.rejectedWith(
-        /The data-post-id attribute is required for/);
+    allowConsoleError(() => {
+      return createAmpVkElement(params).should.eventually.be.rejectedWith(
+          /The data-post-id attribute is required for/);
+    });
   });
 
   it('post::renders iframe in amp-vk', () => {
@@ -149,15 +157,19 @@ describes.realWin('amp-vk', {
   it('poll::requires data-api-id', () => {
     const params = Object.assign({}, POLL_PARAMS);
     delete params['api-id'];
-    return createAmpVkElement(params).should.eventually.be.rejectedWith(
-        /The data-api-id attribute is required for/);
+    allowConsoleError(() => {
+      return createAmpVkElement(params).should.eventually.be.rejectedWith(
+          /The data-api-id attribute is required for/);
+    });
   });
 
   it('poll::requires data-poll-id', () => {
     const params = Object.assign({}, POLL_PARAMS);
     delete params['poll-id'];
-    return createAmpVkElement(params).should.eventually.be.rejectedWith(
-        /The data-poll-id attribute is required for/);
+    allowConsoleError(() => {
+      return createAmpVkElement(params).should.eventually.be.rejectedWith(
+          /The data-poll-id attribute is required for/);
+    });
   });
 
   it('poll::renders iframe in amp-vk', () => {

--- a/extensions/amp-web-push/0.1/test/test-web-push-config.js
+++ b/extensions/amp-web-push/0.1/test/test-web-push-config.js
@@ -65,9 +65,9 @@ describes.realWin('web-push-config', {
     return env.ampdoc.whenReady().then(() => {
       const element = createConfigElementWithAttributes(webPushConfig);
       element.removeAttribute('id');
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         element.implementation_.validate();
-      }).to.throw(/must have an id attribute with value/);
+      }).to.throw(/must have an id attribute with value/); });
     });
   });
 
@@ -75,9 +75,9 @@ describes.realWin('web-push-config', {
     return env.ampdoc.whenReady().then(() => {
       createConfigElementWithAttributes(webPushConfig);
       const element = createConfigElementWithAttributes(webPushConfig);
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         element.implementation_.validate();
-      }).to.throw(/only one .* element may exist on a page/i);
+      }).to.throw(/only one .* element may exist on a page/i); });
     });
   });
 
@@ -90,10 +90,11 @@ describes.realWin('web-push-config', {
         webPushConfig = setDefaultWebPushConfig();
         delete webPushConfig[configName];
         const element = createConfigElementWithAttributes(webPushConfig);
-        expect(() => {
+        allowConsoleError(() => { expect(() => {
           element.implementation_.validate();
         }).to.throw(
             new RegExp('must have a valid ' + configName + ' attribute'));
+        });
       });
       promises.push(promise);
     }
@@ -108,9 +109,9 @@ describes.realWin('web-push-config', {
         removeAllWebPushConfigElements();
         webPushConfig[configName] = 'http://example.com/test';
         const element = createConfigElementWithAttributes(webPushConfig);
-        expect(() => {
+        allowConsoleError(() => { expect(() => {
           element.implementation_.validate();
-        }).to.throw(/should begin with the https:\/\/ protocol/);
+        }).to.throw(/should begin with the https:\/\/ protocol/); });
       });
       promises.push(promise);
     }
@@ -125,9 +126,9 @@ describes.realWin('web-push-config', {
         removeAllWebPushConfigElements();
         webPushConfig[configName] = 'http://example.com/';
         const element = createConfigElementWithAttributes(webPushConfig);
-        expect(() => {
+        allowConsoleError(() => { expect(() => {
           element.implementation_.validate();
-        }).to.throw(/and point to the/);
+        }).to.throw(/and point to the/); });
       });
       promises.push(promise);
     }
@@ -142,9 +143,9 @@ describes.realWin('web-push-config', {
         removeAllWebPushConfigElements();
         webPushConfig[configName] = 'www.example.com/test';
         const element = createConfigElementWithAttributes(webPushConfig);
-        expect(() => {
+        allowConsoleError(() => { expect(() => {
           element.implementation_.validate();
-        }).to.throw(/should begin with the https:\/\/ protocol/);
+        }).to.throw(/should begin with the https:\/\/ protocol/); });
       });
       promises.push(promise);
     }
@@ -156,9 +157,9 @@ describes.realWin('web-push-config', {
       'https://another-origin.com/test';
     return env.ampdoc.whenReady().then(() => {
       const element = createConfigElementWithAttributes(webPushConfig);
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         element.implementation_.validate();
-      }).to.throw(/must all share the same origin/);
+      }).to.throw(/must all share the same origin/); });
     });
   });
 

--- a/extensions/amp-wistia-player/0.1/test/test-amp-wistia-player.js
+++ b/extensions/amp-wistia-player/0.1/test/test-amp-wistia-player.js
@@ -49,7 +49,9 @@ describes.realWin('amp-wistia-player', {
   });
 
   it('requires data-media-hashed-id', () => {
-    return getWistiaEmbed('').should.eventually.be.rejectedWith(
-        /The data-media-hashed-id attribute is required for/);
+    allowConsoleError(() => {
+      return getWistiaEmbed('').should.eventually.be.rejectedWith(
+          /The data-media-hashed-id attribute is required for/);
+    });
   });
 });

--- a/extensions/amp-youtube/0.1/test/test-amp-youtube.js
+++ b/extensions/amp-youtube/0.1/test/test-amp-youtube.js
@@ -251,8 +251,10 @@ describes.realWin('amp-youtube', {
   });
 
   it('requires data-videoid or data-live-channelid', () => {
-    return getYt({}).should.eventually.be.rejectedWith(
-        /Exactly one of data-videoid or data-live-channelid should/);
+    allowConsoleError(() => {
+      return getYt({}).should.eventually.be.rejectedWith(
+          /Exactly one of data-videoid or data-live-channelid should/);
+    });
   });
 
   it('adds an img placeholder in prerender mode if source is videoid', () => {

--- a/test/_init_tests.js
+++ b/test/_init_tests.js
@@ -41,7 +41,10 @@ import {setReportError} from '../src/log';
 import stringify from 'json-stable-stringify';
 
 // Used to surface console errors as mocha test failures.
-let consoleSandbox;
+let consoleErrorSandbox;
+let consoleErrorMock;
+let consoleInfoLogWarnSandbox;
+let testName;
 
 // All exposed describes.
 global.describes = describes;
@@ -265,32 +268,70 @@ sinon.sandbox.create = function(config) {
   return sandbox;
 };
 
+// Used during normal test execution, to detect unexpected console errors.
 function mockConsoleError() {
-  consoleSandbox = sinon.sandbox.create();
-  this.consoleMock = consoleSandbox.mock(console);
-  this.consoleMock.expects('error').never();
+  if (consoleErrorSandbox) {
+    consoleErrorSandbox.restore();
+  }
+  consoleErrorSandbox = sinon.sandbox.create();
+  consoleErrorMock = consoleErrorSandbox.mock(console);
+  consoleErrorMock.expects('error').never();
+  this.allowConsoleError = function(func) {
+    verifyConsoleErrorMock();
+    stubConsoleError();
+    func();
+    mockConsoleError();
+  };
 }
 
-function checkForUnexpectedConsoleErrors() {
-  try {
-    this.consoleMock.verify();
-  } catch (e) {
-    const helpMessage =
-        'Your test resulted in an unexpected call to console.error.\n' +
-        '⤷ If the error is real, fix the code that generated it.\n' +
-        '⤷ If the error is expected:\n' +
-        '  ⤷ Call "this.consoleMock.expects(\'error\').withArgs' +
-            '(\'<message>\')" before the code containing the error.\n' +
-        '  ⤷ Call "this.consoleMock.expects(\'error\').never()" ' +
-            'after the code containing the error.\n';
-    throw new Error(e.message + '\n\n' + helpMessage);
+// Used during sections of tests where an error is expected.
+function stubConsoleError() {
+  if (consoleErrorSandbox) {
+    consoleErrorSandbox.restore();
   }
-  consoleSandbox.restore();
+  consoleErrorSandbox = sinon.sandbox.create();
+  consoleErrorSandbox.stub(console, 'error').callsFake(() => {});
+}
+
+// Used to silence info, log, and warn level logging during each test.
+function stubConsoleInfoLogWarn() {
+  consoleInfoLogWarnSandbox = sinon.sandbox.create();
+  consoleInfoLogWarnSandbox.stub(console, 'info').callsFake(() => {});
+  consoleInfoLogWarnSandbox.stub(console, 'log').callsFake(() => {});
+  consoleInfoLogWarnSandbox.stub(console, 'warn').callsFake(() => {});
+}
+
+// Used to restore info, log, and warn level logging after each test.
+function restoreConsoleInfoLogWarn() {
+  consoleInfoLogWarnSandbox.restore();
+}
+
+// Checks if unexpected errors were detected.
+function verifyConsoleErrorMock() {
+  try {
+    consoleErrorMock.verify();
+  } catch (e) {
+    const helpMessage = '    The test "' + testName + '"' +
+        ' resulted in a call to console.error.\n' +
+        '    ⤷ If this is not expected, fix the code that generated ' +
+            'the error.\n' +
+        '    ⤷ If this is expected, use the following pattern to wrap the ' +
+            'test code that generated the error:\n' +
+        '        \'allowConsoleError(() => { <code that generated the ' +
+            'error> });';
+    const message = e.message.split('\n', 1)[0]; // Log just the first line.
+    // TODO(rsimha, #14432): Throw an error here after all tests are fixed.
+    console/*OK*/.error(message + '\'\n' + helpMessage);
+  } finally {
+    consoleErrorSandbox.restore();
+  }
 }
 
 beforeEach(function() {
   this.timeout(BEFORE_AFTER_TIMEOUT);
   beforeTest();
+  testName = this.currentTest.fullTitle();
+  stubConsoleInfoLogWarn();
   mockConsoleError();
 });
 
@@ -312,7 +353,8 @@ function beforeTest() {
 // Global cleanup of tags added during tests. Cool to add more
 // to selector.
 afterEach(function() {
-  checkForUnexpectedConsoleErrors();
+  verifyConsoleErrorMock();
+  restoreConsoleInfoLogWarn();
   this.timeout(BEFORE_AFTER_TIMEOUT);
   const cleanupTagNames = ['link', 'meta'];
   if (!Services.platformFor(window).isSafari()) {

--- a/test/_init_tests.js
+++ b/test/_init_tests.js
@@ -269,9 +269,8 @@ beforeEach(function() {
   this.timeout(BEFORE_AFTER_TIMEOUT);
   beforeTest();
   consoleSandbox = sinon.sandbox.create();
-  consoleSandbox.stub(console, 'error').callsFake((...messages) => {
-    throw new Error(messages.join(' '));
-  });
+  this.consoleMock = consoleSandbox.mock(console);
+  this.consoleMock.expects('error').never();
 });
 
 function beforeTest() {
@@ -292,6 +291,19 @@ function beforeTest() {
 // Global cleanup of tags added during tests. Cool to add more
 // to selector.
 afterEach(function() {
+  try {
+    this.consoleMock.verify();
+  } catch (e) {
+    const helpMessage =
+        'Your test resulted in an unexpected call to console.error.\n' +
+        '⤷ If the error is real, fix the code that generated it.\n' +
+        '⤷ If the error is expected:\n' +
+        '  ⤷ Call "this.consoleMock.expects(\'error\').withArgs' +
+            '(\'<message>\')" before the code containing the error.\n' +
+        '  ⤷ Call "this.consoleMock.expects(\'error\').never()" ' +
+            'after the code containing the error.\n';
+    throw new Error(e.message + '\n\n' + helpMessage);
+  }
   consoleSandbox.restore();
   this.timeout(BEFORE_AFTER_TIMEOUT);
   const cleanupTagNames = ['link', 'meta'];

--- a/test/functional/test-3p-environment.js
+++ b/test/functional/test-3p-environment.js
@@ -225,9 +225,11 @@ describe('3p environment', () => {
     expect(win.prompt()).to.equal('');
     expect(win.confirm()).to.be.false;
     // We only allow 3 calls to these functions.
-    expect(() => win.alert()).to.throw(/security error/);
-    expect(() => win.prompt()).to.throw(/security error/);
-    expect(() => win.confirm()).to.throw(/security error/);
+    allowConsoleError(() => {
+      expect(() => win.alert()).to.throw(/security error/);
+      expect(() => win.prompt()).to.throw(/security error/);
+      expect(() => win.confirm()).to.throw(/security error/);
+    });
   }
 
   function waitForMutationObserver(iframe) {

--- a/test/functional/test-3p.js
+++ b/test/functional/test-3p.js
@@ -42,15 +42,15 @@ describe('3p', () => {
   describe('validateSrcPrefix()', () => {
 
     it('should throw when a string prefix does not match', () => {
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         validateSrcPrefix('https:', 'http://example.org');
-      }).to.throw(/Invalid src/);
+      }).to.throw(/Invalid src/); });
     });
 
     it('should throw when array prefixes do not match', () => {
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         validateSrcPrefix(['https:', 'ftp:'], 'http://example.org');
-      }).to.throw(/Invalid src/);
+      }).to.throw(/Invalid src/); });
     });
 
     it('should not throw when a string prefix matches', () => {
@@ -64,9 +64,9 @@ describe('3p', () => {
   });
 
   it('should throw an error if src does not contain addyn', () => {
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       validateSrcContains('/addyn/', 'http://adserver.adtechus.com/');
-    }).to.throw(/Invalid src/);
+    }).to.throw(/Invalid src/); });
   });
 
   it('should not throw if source contains /addyn/', () => {
@@ -107,16 +107,16 @@ describe('3p', () => {
       }, ['foo', 'bar']);
       clock.tick(1);
 
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         validateData({
           width: '',
           type: 'xxxxxx',
           foo: true,
           bar: true,
         }, ['foo', 'bar', 'persika']);
-      }).to.throw(/Missing attribute for xxxxxx: persika./);
+      }).to.throw(/Missing attribute for xxxxxx: persika./); });
 
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         validateData({
           width: '',
           type: 'xxxxxx',
@@ -125,6 +125,7 @@ describe('3p', () => {
         }, [['red', 'green', 'blue']]);
       }).to.throw(
           /xxxxxx must contain exactly one of attributes: red, green, blue./);
+      });
     });
 
     it('should check mandatory fields with alternative options', () => {
@@ -163,9 +164,9 @@ describe('3p', () => {
         'not-whitelisted': true,
       }, [], ['foo']);
 
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         clock.tick(1);
-      }).to.throw(/Unknown attribute for TEST: not-whitelisted./);
+      }).to.throw(/Unknown attribute for TEST: not-whitelisted./); });
     });
 
     it('should check mandatory and optional fields', () => {

--- a/test/functional/test-action.js
+++ b/test/functional/test-action.js
@@ -363,67 +363,73 @@ describe('ActionService parseAction', () => {
   });
 
   it('should fail parse without event', () => {
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       parseAction('target1.method1');
-    }).to.throw(/expected \[\:\]/);
+    }).to.throw(/expected \[\:\]/); });
   });
 
   it('should fail parse without target', () => {
-    expect(() => {
-      parseAction('event1:');
-    }).to.throw(/Invalid action/);
-    expect(() => {
-      parseAction('.method1');
-    }).to.throw(/Invalid action/);
-    expect(() => {
-      parseAction('event1:.method1');
-    }).to.throw(/Invalid action/);
+    allowConsoleError(() => {
+      expect(() => {
+        parseAction('event1:');
+      }).to.throw(/Invalid action/);
+      expect(() => {
+        parseAction('.method1');
+      }).to.throw(/Invalid action/);
+      expect(() => {
+        parseAction('event1:.method1');
+      }).to.throw(/Invalid action/);
+    });
   });
 
   it('should fail parse with period in event or method', () => {
-    expect(() => {
-      parseAction('event.1:target1.method');
-    }).to.throw(/Invalid action/);
-    expect(() => {
-      parseAction('event:target1.method.1');
-    }).to.throw(/Invalid action/);
+    allowConsoleError(() => {
+      expect(() => {
+        parseAction('event.1:target1.method');
+      }).to.throw(/Invalid action/);
+      expect(() => {
+        parseAction('event:target1.method.1');
+      }).to.throw(/Invalid action/);
+    });
   });
 
   it('should fail parse with invalid args', () => {
-    // No args allowed without explicit action.
-    expect(() => {
-      parseAction('event:target1()');
-    }).to.throw(/Invalid action/);
-    // Missing parens
-    expect(() => {
-      parseAction('event:target1.method(');
-    }).to.throw(/Invalid action/);
-    expect(() => {
-      parseAction('event:target1.method(key = value');
-    }).to.throw(/Invalid action/);
-    // No arg value.
-    expect(() => {
-      parseAction('event:target1.method(key)');
-    }).to.throw(/Invalid action/);
-    expect(() => {
-      parseAction('event:target1.method(key=)');
-    }).to.throw(/Invalid action/);
-    // Missing quote
-    expect(() => {
-      parseAction('event:target1.method(key = "value)');
-    }).to.throw(/Invalid action/);
-    // Broken quotes.
-    expect(() => {
-      parseAction('event:target1.method(key = "value"")');
-    }).to.throw(/Invalid action/);
-    // Missing comma.
-    expect(() => {
-      parseAction('event:target1.method(key = value key2 = value2)');
-    }).to.throw(/Invalid action/);
-    // Empty (2...n)nd target
-    expect(() => {
-      parseAction('event:target1,');
-    }).to.throw(/Invalid action/);
+    allowConsoleError(() => {
+      // No args allowed without explicit action.
+      expect(() => {
+        parseAction('event:target1()');
+      }).to.throw(/Invalid action/);
+      // Missing parens
+      expect(() => {
+        parseAction('event:target1.method(');
+      }).to.throw(/Invalid action/);
+      expect(() => {
+        parseAction('event:target1.method(key = value');
+      }).to.throw(/Invalid action/);
+      // No arg value.
+      expect(() => {
+        parseAction('event:target1.method(key)');
+      }).to.throw(/Invalid action/);
+      expect(() => {
+        parseAction('event:target1.method(key=)');
+      }).to.throw(/Invalid action/);
+      // Missing quote
+      expect(() => {
+        parseAction('event:target1.method(key = "value)');
+      }).to.throw(/Invalid action/);
+      // Broken quotes.
+      expect(() => {
+        parseAction('event:target1.method(key = "value"")');
+      }).to.throw(/Invalid action/);
+      // Missing comma.
+      expect(() => {
+        parseAction('event:target1.method(key = value key2 = value2)');
+      }).to.throw(/Invalid action/);
+      // Empty (2...n)nd target
+      expect(() => {
+        parseAction('event:target1,');
+      }).to.throw(/Invalid action/);
+    });
   });
 });
 
@@ -649,18 +655,18 @@ describe('Action method', () => {
   });
 
   it('should not allow invoke on non-AMP and non-whitelisted element', () => {
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       action.invoke_(new ActionInvocation(document.createElement('img'),
           'method1', /* args */ null, 'source1', 'event1'));
-    }).to.throw(/Target element does not support provided action/);
+    }).to.throw(/Target element does not support provided action/); });
     expect(onEnqueue).to.have.not.been.called;
   });
 
   it('should not allow invoke on unresolved AMP element', () => {
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       action.invoke_(new ActionInvocation(document.createElement('amp-foo'),
           'method1', /* args */ null, 'source1', 'event1'));
-    }).to.throw(/Unrecognized AMP element/);
+    }).to.throw(/Unrecognized AMP element/); });
     expect(onEnqueue).to.have.not.been.called;
   });
 
@@ -1258,14 +1264,20 @@ describes.fakeWin('Core events', {amp: true}, env => {
       const errorText = 'cannot access native event functions';
 
       // Specifically test these commonly used functions
-      expect(() => deferredEvent.preventDefault()).to.throw(errorText);
-      expect(() => deferredEvent.stopPropagation()).to.throw(errorText);
+      allowConsoleError(() => {
+        expect(() => deferredEvent.preventDefault()).to.throw(errorText);
+      });
+      allowConsoleError(() => {
+        expect(() => deferredEvent.stopPropagation()).to.throw(errorText);
+      });
 
       // Test all functions
       for (const key in deferredEvent) {
         const value = deferredEvent[key];
         if (typeof value === 'function') {
-          expect(() => value()).to.throw(errorText);
+          allowConsoleError(() => {
+            expect(() => value()).to.throw(errorText);
+          });
         }
       }
     });

--- a/test/functional/test-ad-cid.js
+++ b/test/functional/test-ad-cid.js
@@ -112,6 +112,8 @@ describes.realWin('ad-cid', {amp: true}, env => {
     sandbox.stub(cidService, 'get').callsFake(() => {
       return Promise.reject(new Error('nope'));
     });
-    return expect(getAdCid(adElement)).to.eventually.be.undefined;
+    allowConsoleError(() => {
+      return expect(getAdCid(adElement)).to.eventually.be.undefined;
+    });
   });
 });

--- a/test/functional/test-amp-context.js
+++ b/test/functional/test-amp-context.js
@@ -150,14 +150,18 @@ describe('3p ampcontext.js', () => {
 
   it('should throw error if sentinel invalid', () => {
     win.name = generateSerializedAttributes('foobar');
-    expect(() => new AmpContext(win)).to.throw('Incorrect sentinel format');
+    allowConsoleError(() => {
+      expect(() => new AmpContext(win)).to.throw('Incorrect sentinel format');
+    });
   });
 
   it('should throw error if metadata missing', () => {
     win.name = generateIncorrectAttributes();
     const platform = new Platform(window);
-    expect(() => new AmpContext(win)).to.throw(platform.isSafari() ?
-      /undefined is not an object/ : /Cannot read property/);
+    allowConsoleError(() => {
+      expect(() => new AmpContext(win)).to.throw(platform.isSafari() ?
+        /undefined is not an object/ : /Cannot read property/);
+    });
   });
 
   it('should be able to send an intersection observer request', () => {

--- a/test/functional/test-amp-pixel.js
+++ b/test/functional/test-amp-pixel.js
@@ -100,20 +100,26 @@ describes.realWin('amp-pixel', {amp: true}, env => {
 
   it('should disallow http URLs', () => {
     const url = 'http://pubads.g.doubleclick.net/activity;dc_iu=1/abc;ord=2';
-    return expect(trigger(url)).to.eventually
-        .rejectedWith(/src attribute must start with/);
+    allowConsoleError(() => {
+      return expect(trigger(url)).to.eventually.be.rejectedWith(
+          /src attribute must start with/);
+    });
   });
 
   it('should disallow relative URLs', () => {
     const url = '/activity;dc_iu=1/abc;ord=2';
-    return expect(trigger(url)).to.eventually
-        .rejectedWith(/src attribute must start with/);
+    allowConsoleError(() => {
+      return expect(trigger(url)).to.eventually.be.rejectedWith(
+          /src attribute must start with/);
+    });
   });
 
   it('should disallow fake-protocol URLs', () => {
     const url = 'https/activity;dc_iu=1/abc;ord=2';
-    return expect(trigger(url)).to.eventually
-        .rejectedWith(/src attribute must start with/);
+    allowConsoleError(() => {
+      return expect(trigger(url)).to.eventually.be.rejectedWith(
+          /src attribute must start with/);
+    });
   });
 
   it('should replace URL parameters', () => {
@@ -127,14 +133,16 @@ describes.realWin('amp-pixel', {amp: true}, env => {
 
   it('should throw for referrerpolicy with value other than ' +
       'no-referrer', () => {
-    return createPixel(
-        'https://pubads.g.doubleclick.net/activity;dc_iu=1/abc;ord=1?',
-        'origin')
-        .then(() => {
-          throw new Error('must have failed.');
-        }, reason => {
-          expect(reason.message).to.match(/referrerpolicy/);
-        });
+    allowConsoleError(() => {
+      return createPixel(
+          'https://pubads.g.doubleclick.net/activity;dc_iu=1/abc;ord=1?',
+          'origin')
+          .then(() => {
+            throw new Error('must have failed.');
+          }, reason => {
+            expect(reason.message).to.match(/referrerpolicy/);
+          });
+    });
   });
 });
 

--- a/test/functional/test-ampdoc.js
+++ b/test/functional/test-ampdoc.js
@@ -133,9 +133,9 @@ describe('AmpDocService', () => {
       if (!shadowRoot) {
         return;
       }
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         service.getAmpDoc(content);
-      }).to.throw(/No ampdoc found/);
+      }).to.throw(/No ampdoc found/); });
 
       const newAmpDoc = installShadowDoc(service, 'https://a.org/', shadowRoot);
       const ampDoc = service.getAmpDoc(content);
@@ -151,9 +151,9 @@ describe('AmpDocService', () => {
       if (!shadowRoot) {
         return;
       }
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         service.getAmpDoc(host);
-      }).to.throw(/No ampdoc found/);
+      }).to.throw(/No ampdoc found/); });
     });
 
     it('should fail to install shadow doc twice', () => {
@@ -161,9 +161,9 @@ describe('AmpDocService', () => {
         return;
       }
       installShadowDoc(service, 'https://a.org/', shadowRoot);
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         installShadowDoc(service, 'https://a.org/', shadowRoot);
-      }).to.throw(/The shadow root already contains ampdoc/);
+      }).to.throw(/The shadow root already contains ampdoc/); });
     });
 
     // TODO(dvoytenko, #11827): Make this test work on Safari.
@@ -211,9 +211,9 @@ describe('AmpDocService', () => {
 
     it('should fail when installing AmpDocShell in single-doc mode', () => {
       const ampdocService = new AmpDocService(window, /* isSingleDoc */ true);
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         installShadowDocForShell(ampdocService);
-      }).to.throw(/AmpDocShell cannot be installed in single-doc mode/);
+      }).to.throw(/AmpDocShell cannot be installed in single-doc mode/); });
     });
 
     it('should install AmpDocShell in shadow-doc mode', () => {
@@ -366,7 +366,9 @@ describe('AmpDocSingle', () => {
     const ampdoc = new AmpDocSingle(win);
 
     expect(ampdoc.isBodyAvailable()).to.be.false;
-    expect(() => ampdoc.getBody()).to.throw(/body not available/);
+    allowConsoleError(() => {
+      expect(() => ampdoc.getBody()).to.throw(/body not available/);
+    });
     const bodyPromise = ampdoc.whenBodyAvailable();
     const readyPromise = ampdoc.whenReady();
 
@@ -463,7 +465,9 @@ describe('AmpDocShadow', () => {
   it('should update when body is available', () => {
     // Body is still expected.
     expect(ampdoc.isBodyAvailable()).to.be.false;
-    expect(() => ampdoc.getBody()).to.throw(/body not available/);
+    allowConsoleError(() => {
+      expect(() => ampdoc.getBody()).to.throw(/body not available/);
+    });
     expect(ampdoc.bodyResolver_).to.be.ok;
 
     // Set body.
@@ -483,9 +487,9 @@ describe('AmpDocShadow', () => {
   it('should only allow one body update', () => {
     const body = {nodeType: 1};
     shadowDocHasBody(ampdoc, body);
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       shadowDocHasBody(ampdoc, body);
-    }).to.throw(/Duplicate body/);
+    }).to.throw(/Duplicate body/); });
   });
 
   it('should update when doc is ready', () => {
@@ -506,9 +510,9 @@ describe('AmpDocShadow', () => {
 
   it('should only allow one ready update', () => {
     shadowDocReady(ampdoc);
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       shadowDocReady(ampdoc);
-    }).to.throw(/Duplicate ready state/);
+    }).to.throw(/Duplicate ready state/); });
   });
 });
 

--- a/test/functional/test-base-element.js
+++ b/test/functional/test-base-element.js
@@ -87,9 +87,9 @@ describes.realWin('BaseElement', {amp: true}, env => {
   });
 
   it('should fail execution of unregistered action', () => {
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       element.executeAction({method: 'method1'}, false);
-    }).to.throw(/Method not found/);
+    }).to.throw(/Method not found/); });
   });
 
   it('`this` context of handler should not be the holder', () => {

--- a/test/functional/test-batched-json.js
+++ b/test/functional/test-batched-json.js
@@ -82,12 +82,14 @@ describe('batchFetchJsonFor', () => {
       urlReplacements.collectUnwhitelistedVars
           .withArgs(el)
           .returns(Promise.resolve(['BAR']));
-      const userError = sandbox.stub(user(), 'error');
-
-      const optIn = UrlReplacementPolicy.OPT_IN;
-      return batchFetchJsonFor(ampdoc, el, null, optIn).then(() => {
-        expect(fetchJson).to.be.calledWith('https://data.com?x=abc&y=BAR');
-        expect(userError).calledWithMatch('AMP-LIST', /data-amp-replace="BAR"/);
+      allowConsoleError(() => {
+        const userError = sandbox.stub(user(), 'error');
+        const optIn = UrlReplacementPolicy.OPT_IN;
+        return batchFetchJsonFor(ampdoc, el, null, optIn).then(() => {
+          expect(fetchJson).to.be.calledWith('https://data.com?x=abc&y=BAR');
+          expect(userError).calledWithMatch(
+              'AMP-LIST', /data-amp-replace="BAR"/);
+        });
       });
     });
 
@@ -97,13 +99,14 @@ describe('batchFetchJsonFor', () => {
       urlReplacements.expandUrlAsync
           .withArgs('https://data.com?x=FOO&y=BAR')
           .returns(Promise.resolve('https://data.com?x=abc&y=BAR'));
-      const userError = sandbox.stub(user(), 'error');
-
-      const all = UrlReplacementPolicy.ALL;
-      return batchFetchJsonFor(ampdoc, el, null, all).then(() => {
-        expect(fetchJson).to.be.calledWith('https://data.com?x=abc&y=BAR');
-        expect(urlReplacements.collectUnwhitelistedVars).to.not.be.called;
-        expect(userError).to.not.be.called;
+      allowConsoleError(() => {
+        const userError = sandbox.stub(user(), 'error');
+        const all = UrlReplacementPolicy.ALL;
+        return batchFetchJsonFor(ampdoc, el, null, all).then(() => {
+          expect(fetchJson).to.be.calledWith('https://data.com?x=abc&y=BAR');
+          expect(urlReplacements.collectUnwhitelistedVars).to.not.be.called;
+          expect(userError).to.not.be.called;
+        });
       });
     });
   });

--- a/test/functional/test-cid.js
+++ b/test/functional/test-cid.js
@@ -495,9 +495,9 @@ describe('cid', () => {
     });
 
     it('should fail on invalid scope', () => {
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         cid.get({scope: '$$$'}, Promise.resolve());
-      }).to.throw(/\$\$\$/);
+      }).to.throw(/\$\$\$/); });
     });
 
     it('should not store until persistence promise resolves', () => {
@@ -712,9 +712,9 @@ describe('cid', () => {
 
 describe('getProxySourceOrigin', () => {
   it('should fail on non-proxy origin', () => {
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       getProxySourceOrigin(parseUrl('https://abc.org/v/foo.com/'));
-    }).to.throw(/Expected proxy origin/);
+    }).to.throw(/Expected proxy origin/); });
   });
 });
 
@@ -874,7 +874,9 @@ describes.fakeWin('cid optout:', {amp: true}, env => {
 
     it('should reject promise if storage set fails', () => {
       storageSetStub.returns(Promise.reject('failed!'));
-      return optOutOfCid(ampdoc).should.eventually.be.rejectedWith('failed!');
+      allowConsoleError(() => {
+        return optOutOfCid(ampdoc).should.eventually.be.rejectedWith('failed!');
+      });
     });
   });
 

--- a/test/functional/test-cookies.js
+++ b/test/functional/test-cookies.js
@@ -107,28 +107,32 @@ describe('cookies', () => {
     test('www.example.net', 'example.com', true);
     test('example.net', 'example.com', true);
     test('cdn.ampproject.org', 'ampproject.org', true, true);
-    expect(() => {
-      test('cdn.ampproject.org', 'ampproject.org', true);
-    }).to.throw(/Should never attempt to set cookie on proxy origin\: c\&1/);
-    expect(() => {
-      test('CDN.ampproject.org', 'ampproject.org', true);
-    }).to.throw(/Should never attempt to set cookie on proxy origin\: c\&1/);
-    expect(() => {
-      test('CDN.ampproject.org', 'AMPproject.org', true);
-    }).to.throw(/Should never attempt to set cookie on proxy origin\: c\&1/);
+    allowConsoleError(() => {
+      expect(() => {
+        test('cdn.ampproject.org', 'ampproject.org', true);
+      }).to.throw(/Should never attempt to set cookie on proxy origin\: c\&1/);
+      expect(() => {
+        test('CDN.ampproject.org', 'ampproject.org', true);
+      }).to.throw(/Should never attempt to set cookie on proxy origin\: c\&1/);
+      expect(() => {
+        test('CDN.ampproject.org', 'AMPproject.org', true);
+      }).to.throw(/Should never attempt to set cookie on proxy origin\: c\&1/);
+    });
     test('www.ampproject.org', 'www.ampproject.org');
     test('cdn.ampproject.org', 'cdn.ampproject.org', false, true);
-    expect(() => {
-      test('cdn.ampproject.org', 'cdn.ampproject.org', false);
-    }).to.throw(/Should never attempt to set cookie on proxy origin\: c\&1/);
-    expect(() => {
-      test('foo.bar.cdn.ampproject.org', 'foo.bar.cdn.ampproject.org', false);
-    }).to.throw(/in depth check/);
-    expect(() => {
-      test('&&&.cdn.ampproject.org', '&&&.cdn.ampproject.org', false);
-    }).to.throw(/in depth check/);
-    expect(() => {
-      test('&&&.CDN.ampproject.org', '&&&.cdn.AMPproject.org', false);
-    }).to.throw(/in depth check/);
+    allowConsoleError(() => {
+      expect(() => {
+        test('cdn.ampproject.org', 'cdn.ampproject.org', false);
+      }).to.throw(/Should never attempt to set cookie on proxy origin\: c\&1/);
+      expect(() => {
+        test('foo.bar.cdn.ampproject.org', 'foo.bar.cdn.ampproject.org', false);
+      }).to.throw(/in depth check/);
+      expect(() => {
+        test('&&&.cdn.ampproject.org', '&&&.cdn.ampproject.org', false);
+      }).to.throw(/in depth check/);
+      expect(() => {
+        test('&&&.CDN.ampproject.org', '&&&.cdn.AMPproject.org', false);
+      }).to.throw(/in depth check/);
+    });
   });
 });

--- a/test/functional/test-crypto.js
+++ b/test/functional/test-crypto.js
@@ -84,9 +84,11 @@ describes.realWin('crypto-impl', {}, env => {
       });
 
       it('should throw when input contains chars out of range [0,255]', () => {
-        expect(() => crypto.sha384('abc今')).to.throw();
-        expect(() => crypto.sha384Base64('abc今')).to.throw();
-        expect(() => crypto.uniform('abc今')).to.throw();
+        allowConsoleError(() => {
+          expect(() => crypto.sha384('abc今')).to.throw();
+          expect(() => crypto.sha384Base64('abc今')).to.throw();
+          expect(() => crypto.uniform('abc今')).to.throw();
+        });
       });
 
       it('should hash "abc" to uniform number', () => {

--- a/test/functional/test-custom-element.js
+++ b/test/functional/test-custom-element.js
@@ -148,9 +148,13 @@ describes.realWin('CustomElement', {amp: true}, env => {
     it('should initialize ampdoc and resources on attach only', () => {
       const element = new ElementClass();
       expect(element.ampdoc_).to.be.null;
-      expect(() => element.getAmpDoc()).to.throw(/no ampdoc yet/);
+      allowConsoleError(() => {
+        expect(() => element.getAmpDoc()).to.throw(/no ampdoc yet/);
+      });
       expect(element.resources_).to.be.null;
-      expect(() => element.getResources()).to.throw(/no resources yet/);
+      allowConsoleError(() => {
+        expect(() => element.getResources()).to.throw(/no resources yet/);
+      });
 
       // Resources available after attachment.
       container.appendChild(element);
@@ -504,9 +508,9 @@ describes.realWin('CustomElement', {amp: true}, env => {
 
     it('Element - build NOT allowed before attachment', () => {
       const element = new ElementClass();
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         element.build();
-      }).to.throw(/upgrade/);
+      }).to.throw(/upgrade/); });
     });
 
     it('Element - build allowed', () => {
@@ -565,8 +569,10 @@ describes.realWin('CustomElement', {amp: true}, env => {
 
       clock.tick(1);
       container.appendChild(element);
-      return expect(element.whenBuilt())
-          .to.be.eventually.rejectedWith(/BLOCK_BY_CONSENT/);
+      allowConsoleError(() => {
+        return expect(element.whenBuilt()).to.eventually.be.rejectedWith(
+            /BLOCK_BY_CONSENT/);
+      });
     });
 
 
@@ -579,8 +585,10 @@ describes.realWin('CustomElement', {amp: true}, env => {
       expect(element.isBuilt()).to.be.false;
       expect(element).to.have.class('i-amphtml-notbuilt');
       expect(element).to.have.class('amp-notbuilt');
-      return expect(element.whenBuilt())
-          .to.be.eventually.rejectedWith(/intentional/);
+      allowConsoleError(() => {
+        return expect(element.whenBuilt()).to.eventually.be.rejectedWith(
+            /intentional/);
+      });
     });
 
     it('Element - build creates a placeholder if one does not exist' , () => {
@@ -648,9 +656,9 @@ describes.realWin('CustomElement', {amp: true}, env => {
       expect(testElementBuildCallback).to.have.not.been.called;
 
       element.isInTemplate_ = true;
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         element.build();
-      }).to.throw(/Must never be called in template/);
+      }).to.throw(/Must never be called in template/); });
 
       expect(element.isBuilt()).to.equal(false);
       expect(testElementBuildCallback).to.have.not.been.called;
@@ -661,9 +669,9 @@ describes.realWin('CustomElement', {amp: true}, env => {
       expect(element.isBuilt()).to.equal(false);
       expect(testElementBuildCallback).to.have.not.been.called;
 
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         element.build();
-      }).to.throw(/Cannot build unupgraded element/);
+      }).to.throw(/Cannot build unupgraded element/); });
 
       expect(element.isBuilt()).to.equal(false);
       expect(testElementBuildCallback).to.have.not.been.called;
@@ -773,9 +781,9 @@ describes.realWin('CustomElement', {amp: true}, env => {
       expect(testElementLayoutCallback).to.have.not.been.called;
       expect(element.isBuilt()).to.equal(false);
 
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         element.layoutCallback();
-      }).to.throw(/Must be built to receive viewport events/);
+      }).to.throw(/Must be built to receive viewport events/); });
 
       expect(testElementLayoutCallback).to.have.not.been.called;
     });
@@ -787,18 +795,18 @@ describes.realWin('CustomElement', {amp: true}, env => {
 
       expect(element.isUpgraded()).to.equal(false);
       expect(element.isBuilt()).to.equal(false);
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         element.layoutCallback();
-      }).to.throw(/Must be built to receive viewport events/);
+      }).to.throw(/Must be built to receive viewport events/); });
 
       resourcesMock.expects('upgraded').withExactArgs(element).never();
       element.upgrade(TestElement);
 
       expect(element.isUpgraded()).to.equal(false);
       expect(element.isBuilt()).to.equal(false);
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         element.layoutCallback();
-      }).to.throw(/Must be built to receive viewport events/);
+      }).to.throw(/Must be built to receive viewport events/); });
 
       expect(testElementLayoutCallback).to.have.not.been.called;
     });
@@ -859,9 +867,9 @@ describes.realWin('CustomElement', {amp: true}, env => {
         expect(testElementLayoutCallback).to.have.not.been.called;
 
         element.isInTemplate_ = true;
-        expect(() => {
+        allowConsoleError(() => { expect(() => {
           element.layoutCallback();
-        }).to.throw(/Must never be called in template/);
+        }).to.throw(/Must never be called in template/); });
       });
     });
 
@@ -870,7 +878,10 @@ describes.realWin('CustomElement', {amp: true}, env => {
       element.setAttribute('layout', 'fill');
       resourcesMock.expects('upgraded').withExactArgs(element).never();
       element.upgrade(TestElement);
-      expect(() => element.build()).to.throw(/Cannot build unupgraded element/);
+      allowConsoleError(() => {
+        expect(() => element.build()).to.throw(
+            /Cannot build unupgraded element/);
+      });
       expect(element.isUpgraded()).to.equal(false);
       expect(element.isBuilt()).to.equal(false);
       expect(testElementLayoutCallback).to.have.not.been.called;
@@ -958,9 +969,9 @@ describes.realWin('CustomElement', {amp: true}, env => {
 
       const inv = {};
       element.isInTemplate_ = true;
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         element.enqueAction(inv);
-      }).to.throw(/Must never be called in template/);
+      }).to.throw(/Must never be called in template/); });
     });
 
 
@@ -1129,9 +1140,9 @@ describes.realWin('CustomElement', {amp: true}, env => {
       const element1 = new ElementClass();
       element1.setAttribute('media', '(min-width: 1px)');
       element1.isInTemplate_ = true;
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         element1.applySizesAndMediaQuery();
-      }).to.throw(/Must never be called in template/);
+      }).to.throw(/Must never be called in template/); });
     });
 
     it('should change size to zero', () => {
@@ -1404,9 +1415,9 @@ describes.realWin('CustomElement', {amp: true}, env => {
           expect(testElementViewportCallback).to.have.not.been.called;
 
           element.isInTemplate_ = true;
-          expect(() => {
+          allowConsoleError(() => { expect(() => {
             element.viewportCallback(true);
-          }).to.throw(/Must never be called in template/);
+          }).to.throw(/Must never be called in template/); });
         });
       });
     });
@@ -1566,9 +1577,9 @@ describes.realWin('CustomElement Service Elements', {amp: true}, env => {
 
   it('togglePlaceholder should NOT call in template', () => {
     element.isInTemplate_ = true;
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       element.togglePlaceholder(false);
-    }).to.throw(/Must never be called in template/);
+    }).to.throw(/Must never be called in template/); });
   });
 });
 
@@ -1791,9 +1802,9 @@ describes.realWin('CustomElement', {amp: true}, env => {
     it('should ignore loading-off if never created', () => {
       stubInA4A(false);
       element.isInTemplate_ = true;
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         element.toggleLoading(false);
-      }).to.throw(/Must never be called in template/);
+      }).to.throw(/Must never be called in template/); });
     });
 
     it('should turn off when exits viewport', () => {

--- a/test/functional/test-document-submit.js
+++ b/test/functional/test-document-submit.js
@@ -50,18 +50,24 @@ describe('test-document-submit onDocumentFormSubmit_', () => {
 
   it('should check target and action attributes', () => {
     tgt.removeAttribute('action');
-    expect(() => onDocumentFormSubmit_(evt)).to.throw(
-        /form action-xhr or action attribute is required for method=GET/);
+    allowConsoleError(() => {
+      expect(() => onDocumentFormSubmit_(evt)).to.throw(
+          /form action-xhr or action attribute is required for method=GET/);
+    });
 
     tgt.setAttribute('action', 'http://example.com');
     tgt.__AMP_INIT_ACTION__ = undefined;
-    expect(() => onDocumentFormSubmit_(evt)).to.throw(
-        /form action must start with "https:/);
+    allowConsoleError(() => {
+      expect(() => onDocumentFormSubmit_(evt)).to.throw(
+          /form action must start with "https:/);
+    });
 
     tgt.setAttribute('action', 'https://cdn.ampproject.org');
     tgt.__AMP_INIT_ACTION__ = undefined;
-    expect(() => onDocumentFormSubmit_(evt)).to.throw(
-        /form action should not be on AMP CDN/);
+    allowConsoleError(() => {
+      expect(() => onDocumentFormSubmit_(evt)).to.throw(
+          /form action should not be on AMP CDN/);
+    });
 
     tgt.setAttribute('action', 'https://valid.example.com');
     tgt.__AMP_INIT_ACTION__ = undefined;
@@ -71,8 +77,10 @@ describe('test-document-submit onDocumentFormSubmit_', () => {
     tgt.setAttribute('action', 'https://valid.example.com');
     tgt.__AMP_INIT_ACTION__ = undefined;
     tgt.setAttribute('target', '_self');
-    expect(() => onDocumentFormSubmit_(evt)).to.throw(
-        /form target=_self is invalid/);
+    allowConsoleError(() => {
+      expect(() => onDocumentFormSubmit_(evt)).to.throw(
+          /form target=_self is invalid/);
+    });
 
     tgt.setAttribute('action', 'https://valid.example.com');
     tgt.__AMP_INIT_ACTION__ = undefined;
@@ -86,22 +94,28 @@ describe('test-document-submit onDocumentFormSubmit_', () => {
     illegalInput.setAttribute('name', '__amp_source_origin');
     illegalInput.value = 'https://example.com';
     tgt.appendChild(illegalInput);
-    expect(() => onDocumentFormSubmit_(evt)).to.throw(
-        /Illegal input name, __amp_source_origin found/);
+    allowConsoleError(() => {
+      expect(() => onDocumentFormSubmit_(evt)).to.throw(
+          /Illegal input name, __amp_source_origin found/);
+    });
   });
 
   it('should assert __amp_source_origin is not set in action', () => {
     evt.target.setAttribute('action',
         'https://example.com/?__amp_source_origin=12');
-    expect(() => onDocumentFormSubmit_(evt))
-        .to.throw(/Source origin is not allowed in/);
+    allowConsoleError(() => {
+      expect(() => onDocumentFormSubmit_(evt)).to.throw(
+          /Source origin is not allowed in/);
+    });
   });
 
   it('should fail when POST and action-xhr is not set', () => {
     evt.target.removeAttribute('action');
     evt.target.setAttribute('method', 'post');
-    expect(() => onDocumentFormSubmit_(evt))
-        .to.throw(/Only XHR based \(via action-xhr attribute\) submissions/);
+    allowConsoleError(() => {
+      expect(() => onDocumentFormSubmit_(evt)).to.throw(
+          /Only XHR based \(via action-xhr attribute\) submissions/);
+    });
     expect(preventDefaultSpy).to.have.been.called;
     const callCount = preventDefaultSpy.callCount;
 
@@ -126,7 +140,9 @@ describe('test-document-submit onDocumentFormSubmit_', () => {
 
   it('should throw if no target', () => {
     evt.target = null;
-    expect(() => onDocumentFormSubmit_(evt)).to.throw(/Element expected/);
+    allowConsoleError(() => {
+      expect(() => onDocumentFormSubmit_(evt)).to.throw(/Element expected/);
+    });
     expect(preventDefaultSpy).to.have.not.been.called;
     expect(tgt.checkValidity).to.have.not.been.called;
   });

--- a/test/functional/test-dom.js
+++ b/test/functional/test-dom.js
@@ -832,10 +832,10 @@ describes.sandboxed('DOM', {}, env => {
           .withExactArgs('https://example.com/', '_top')
           .throws(new Error('intentional2'))
           .once();
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         dom.openWindowDialog(windowApi, 'https://example.com/',
             '_blank', 'width=1');
-      }).to.throw(/intentional2/);
+      }).to.throw(/intentional2/); });
     });
 
     it('should retry only non-top target', () => {
@@ -1025,8 +1025,10 @@ describes.realWin('DOM', {
 
     it('should not continue if element is not AMP element', () => {
       const element = doc.createElement('div');
-      expect(() => dom.whenUpgradedToCustomElement(element)).to.throw(
-          'element is not AmpElement');
+      allowConsoleError(() => {
+        expect(() => dom.whenUpgradedToCustomElement(element)).to.throw(
+            'element is not AmpElement');
+      });
     });
 
     it('should resolve if element has already upgrade', () => {

--- a/test/functional/test-error.js
+++ b/test/functional/test-error.js
@@ -549,9 +549,9 @@ describes.sandboxed('reportError', {}, () => {
     expect(result.message).to.contain('error');
     expect(result.origError).to.be.equal('error');
     expect(result.reported).to.be.true;
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       clock.tick();
-    }).to.throw(/_reported_ Error reported incorrectly/);
+    }).to.throw(/_reported_ Error reported incorrectly/); });
   });
 
   it('should accept number and report incorrect use', () => {
@@ -561,9 +561,9 @@ describes.sandboxed('reportError', {}, () => {
     expect(result.message).to.contain('101');
     expect(result.origError).to.be.equal(101);
     expect(result.reported).to.be.true;
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       clock.tick();
-    }).to.throw(/_reported_ Error reported incorrectly/);
+    }).to.throw(/_reported_ Error reported incorrectly/); });
   });
 
   it('should accept null and report incorrect use', () => {
@@ -573,9 +573,9 @@ describes.sandboxed('reportError', {}, () => {
     expect(result.message).to.contain('Unknown error');
     expect(result.origError).to.be.undefined;
     expect(result.reported).to.be.true;
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       clock.tick();
-    }).to.throw(/_reported_ Error reported incorrectly/);
+    }).to.throw(/_reported_ Error reported incorrectly/); });
   });
 });
 

--- a/test/functional/test-extensions.js
+++ b/test/functional/test-extensions.js
@@ -112,11 +112,11 @@ describes.sandboxed('Extensions', {}, () => {
     });
 
     it('should fail registration without promise', () => {
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         registerExtension(extensions, 'amp-ext', () => {
           throw new Error('intentional');
         }, {});
-      }).to.throw(/intentional/);
+      }).to.throw(/intentional/); });
       expect(extensions.currentExtensionId_).to.be.null;
 
       const holder = extensions.extensions_['amp-ext'];
@@ -138,11 +138,11 @@ describes.sandboxed('Extensions', {}, () => {
 
     it('should fail registration with promise', () => {
       const promise = extensions.waitForExtension('amp-ext');
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         registerExtension(extensions, 'amp-ext', () => {
           throw new Error('intentional');
         }, {});
-      }).to.throw(/intentional/);
+      }).to.throw(/intentional/); });
       expect(extensions.currentExtensionId_).to.be.null;
 
       const holder = extensions.extensions_['amp-ext'];
@@ -448,10 +448,12 @@ describes.sandboxed('Extensions', {}, () => {
       expect(ampdoc.declaresExtension('amp-test')).to.be.false;
       expect(factory1).to.be.not.called;
       expect(factory2).to.be.not.called;
-      expect(() => getServiceForDoc(ampdoc, 'service1'))
-          .to.throw(/to be registered/);
-      expect(() => getServiceForDoc(ampdoc, 'service2'))
-          .to.throw(/to be registered/);
+      allowConsoleError(() => {
+        expect(() => getServiceForDoc(ampdoc, 'service1')).to.throw(
+            /to be registered/);
+        expect(() => getServiceForDoc(ampdoc, 'service2')).to.throw(
+            /to be registered/);
+      });
     });
 
     it('should install declared services for single-doc', () => {
@@ -765,10 +767,12 @@ describes.sandboxed('Extensions', {}, () => {
       expect(ampdoc.declaresExtension('amp-test')).to.be.false;
 
       // Services do not exist yet.
-      expect(() => getServiceForDoc(ampdoc, 'service1'))
-          .to.throw(/to be registered/);
-      expect(() => getServiceForDoc(ampdoc, 'service2'))
-          .to.throw(/to be registered/);
+      allowConsoleError(() => {
+        expect(() => getServiceForDoc(ampdoc, 'service1')).to.throw(
+            /to be registered/);
+        expect(() => getServiceForDoc(ampdoc, 'service2')).to.throw(
+            /to be registered/);
+      });
       expect(factory1Spy).to.not.be.called;
       expect(factory2Spy).to.not.be.called;
 
@@ -821,7 +825,9 @@ describes.sandboxed('Extensions', {}, () => {
         expect(getServiceForDoc(ampdoc, 'service3').a).to.equal(3);
         // Erroneous
         expect(factory3Spy).to.be.calledOnce;
-        expect(() => getServiceForDoc(ampdoc, 'service2')).to.throw();
+        allowConsoleError(() => {
+          expect(() => getServiceForDoc(ampdoc, 'service2')).to.throw();
+        });
         // Extension is marked as declared.
         expect(ampdoc.declaresExtension('amp-test')).to.be.true;
       });

--- a/test/functional/test-gesture.js
+++ b/test/functional/test-gesture.js
@@ -217,9 +217,9 @@ describe('Gestures', () => {
 
   it('should deny emit if another eventing', () => {
     gestures.eventing_ = {};
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       gestures.signalEmit_(recognizer, {}, null);
-    }).to.throw(/Recognizer is not currently allowed/);
+    }).to.throw(/Recognizer is not currently allowed/); });
     expect(onGesture).to.have.not.been.called;
   });
 

--- a/test/functional/test-iframe-helper.js
+++ b/test/functional/test-iframe-helper.js
@@ -49,18 +49,18 @@ describe('iframe-helper', function() {
   it('should assert src in iframe', () => {
     const iframe = container.doc.createElement('iframe');
     iframe.srcdoc = '<html>';
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       IframeHelper.listenFor(iframe, 'test', () => {});
-    }).to.throw('only iframes with src supported');
+    }).to.throw('only iframes with src supported'); });
   });
 
   it('should assert iframe is detached', () => {
     const iframe = container.doc.createElement('iframe');
     iframe.src = iframeSrc;
     insert(iframe);
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       IframeHelper.listenFor(iframe, 'test', () => {});
-    }).to.throw('cannot register events on an attached iframe');
+    }).to.throw('cannot register events on an attached iframe'); });
   });
 
   // TODO(dvoytenko, #12499): Make this work with latest mocha / karma.

--- a/test/functional/test-integration.js
+++ b/test/functional/test-integration.js
@@ -70,13 +70,13 @@ describe('3p integration.js', () => {
         const parent = {
           origin: 'abc',
         };
-        expect(() => {
+        allowConsoleError(() => { expect(() => {
           validateParentOrigin({
             location: {
               ancestorOrigins: ['xyz'],
             },
           }, parent);
-        }).to.throw(/Parent origin mismatch/);
+        }).to.throw(/Parent origin mismatch/); });
       });
 
   it('should parse JSON from fragment unencoded (most browsers)', () => {
@@ -185,9 +185,9 @@ describe('3p integration.js', () => {
         tagName: 'AMP-EMBED',
       },
     };
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       draw3p(win, data);
-    }).to.throw(/Embed type testAction not allowed with tag AMP-EMBED/);
+    }).to.throw(/Embed type testAction not allowed with tag AMP-EMBED/); });
   });
 
   it('should allow all types on localhost', () => {
@@ -225,9 +225,9 @@ describe('3p integration.js', () => {
     validateAllowedTypes(get('d-123.ampproject.net'), 'twitter');
     validateAllowedTypes(get('d-46851196780996873.ampproject.net'), 'adtech');
     validateAllowedTypes(get('d-46851196780996873.ampproject.net'), 'a9');
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       validateAllowedTypes(get('d-124.ampproject.net.com'), 'not present');
-    }).to.throw(/Non-whitelisted 3p type for custom iframe/);
+    }).to.throw(/Non-whitelisted 3p type for custom iframe/); });
   });
 
   it('should validate types on custom host', () => {
@@ -239,12 +239,12 @@ describe('3p integration.js', () => {
     validateAllowedTypes(defaultHost, 'twitter');
     validateAllowedTypes(defaultHost, 'facebook');
     validateAllowedTypes(defaultHost, 'doubleclick');
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       validateAllowedTypes(defaultHost, 'not present');
-    }).to.throw(/Non-whitelisted 3p type for custom iframe/);
-    expect(() => {
+    }).to.throw(/Non-whitelisted 3p type for custom iframe/); });
+    allowConsoleError(() => { expect(() => {
       validateAllowedTypes(defaultHost, 'adtech');
-    }).to.throw(/Non-whitelisted 3p type for custom iframe/);
+    }).to.throw(/Non-whitelisted 3p type for custom iframe/); });
     validateAllowedTypes(defaultHost, 'adtech', ['adtech']);
   });
 
@@ -259,9 +259,9 @@ describe('3p integration.js', () => {
       },
     };
     win.parent = win;
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       ensureFramed(win);
-    }).to.throw(/Must be framed: sentinel/);
+    }).to.throw(/Must be framed: sentinel/); });
   });
 
   it('should validateAllowedEmbeddingOrigins: non-cache', () => {
@@ -274,7 +274,9 @@ describe('3p integration.js', () => {
       },
     };
     function invalid(fn) {
-      expect(fn).to.throw(/Invalid embedding hostname/);
+      allowConsoleError(() => {
+        expect(fn).to.throw(/Invalid embedding hostname/);
+      });
     }
     validateAllowedEmbeddingOrigins(win, ['foo.com']);
     validateAllowedEmbeddingOrigins(win, ['foo.net', 'foo.com']);
@@ -294,7 +296,9 @@ describe('3p integration.js', () => {
       },
     };
     function invalid(fn) {
-      expect(fn).to.throw(/Invalid embedding hostname/);
+      allowConsoleError(() => {
+        expect(fn).to.throw(/Invalid embedding hostname/);
+      });
     }
     validateAllowedEmbeddingOrigins(win, ['foo.com']);
     validateAllowedEmbeddingOrigins(win, ['www.foo.com']);
@@ -314,7 +318,9 @@ describe('3p integration.js', () => {
       },
     };
     function invalid(fn) {
-      expect(fn).to.throw(/Invalid embedding hostname/);
+      allowConsoleError(() => {
+        expect(fn).to.throw(/Invalid embedding hostname/);
+      });
     }
     validateAllowedEmbeddingOrigins(win, ['foo.com']);
     validateAllowedEmbeddingOrigins(win, ['www.foo.com']);
@@ -332,7 +338,9 @@ describe('3p integration.js', () => {
       },
     };
     function invalid(fn) {
-      expect(fn).to.throw(/Invalid embedding hostname/);
+      allowConsoleError(() => {
+        expect(fn).to.throw(/Invalid embedding hostname/);
+      });
     }
     validateAllowedEmbeddingOrigins(win, ['foo.com']);
     validateAllowedEmbeddingOrigins(win, ['www.foo.com']);

--- a/test/functional/test-intersection-observer-polyfill.js
+++ b/test/functional/test-intersection-observer-polyfill.js
@@ -225,12 +225,10 @@ describe('IntersectionObserverPolyfill', () => {
           threshold: Infinity,
         });
       };
-      expect(io1).to.throw(
-          'Threshold should be a ' +
-          'finite number or an array of finite numbers');
-      expect(io2).to.throw(
-          'Threshold should be a ' +
-          'finite number or an array of finite numbers');
+      allowConsoleError(() => { expect(io1).to.throw('Threshold should be a ' +
+          'finite number or an array of finite numbers'); });
+      allowConsoleError(() => { expect(io2).to.throw('Threshold should be a ' +
+          'finite number or an array of finite numbers'); });
     });
 
     it('will be sorted', () => {
@@ -251,10 +249,10 @@ describe('IntersectionObserverPolyfill', () => {
           threshold: [0, 1.1],
         });
       };
-      expect(io1).to.throw(
-          'Threshold should be in the range from "[0, 1]"');
-      expect(io2).to.throw(
-          'Threshold should be in the range from "[0, 1]"');
+      allowConsoleError(() => {
+        expect(io1).to.throw('Threshold should be in the range from "[0, 1]"');
+        expect(io2).to.throw('Threshold should be in the range from "[0, 1]"');
+      });
     });
 
     it('getThresholdSlot function', () => {

--- a/test/functional/test-json.js
+++ b/test/functional/test-json.js
@@ -168,9 +168,9 @@ describe('json', () => {
 
   describe('recursiveEquals', () => {
     it('should throw on non-finite depth arg', () => {
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         recursiveEquals({}, {}, Number.POSITIVE_INFINITY);
-      }).to.throw(/must be finite/);
+      }).to.throw(/must be finite/); });
     });
 
     it('should handle null and empty objects', () => {

--- a/test/functional/test-layout.js
+++ b/test/functional/test-layout.js
@@ -105,24 +105,24 @@ describe('Layout', () => {
     expect(assertLength('10.1em')).to.equal('10.1em');
     expect(assertLength('10.1vmin')).to.equal('10.1vmin');
 
-    expect(function() {
+    allowConsoleError(() => { expect(function() {
       assertLength('10%');
-    }).to.throw(/Invalid length value/);
-    expect(function() {
+    }).to.throw(/Invalid length value/); });
+    allowConsoleError(() => { expect(function() {
       assertLength(10);
-    }).to.throw(/Invalid length value/);
-    expect(function() {
+    }).to.throw(/Invalid length value/); });
+    allowConsoleError(() => { expect(function() {
       assertLength('10');
-    }).to.throw(/Invalid length value/);
-    expect(function() {
+    }).to.throw(/Invalid length value/); });
+    allowConsoleError(() => { expect(function() {
       assertLength(undefined);
-    }).to.throw(/Invalid length value/);
-    expect(function() {
+    }).to.throw(/Invalid length value/); });
+    allowConsoleError(() => { expect(function() {
       assertLength(null);
-    }).to.throw(/Invalid length value/);
-    expect(function() {
+    }).to.throw(/Invalid length value/); });
+    allowConsoleError(() => { expect(function() {
       assertLength('');
-    }).to.throw(/Invalid length value/);
+    }).to.throw(/Invalid length value/); });
   });
 
 
@@ -136,21 +136,21 @@ describe('Layout', () => {
     expect(assertLengthOrPercent('10.1vmin')).to.equal('10.1vmin');
     expect(assertLengthOrPercent('10.1%')).to.equal('10.1%');
 
-    expect(function() {
+    allowConsoleError(() => { expect(function() {
       assertLengthOrPercent(10);
-    }).to.throw(/Invalid length or percent value/);
-    expect(function() {
+    }).to.throw(/Invalid length or percent value/); });
+    allowConsoleError(() => { expect(function() {
       assertLengthOrPercent('10');
-    }).to.throw(/Invalid length or percent value/);
-    expect(function() {
+    }).to.throw(/Invalid length or percent value/); });
+    allowConsoleError(() => { expect(function() {
       assertLengthOrPercent(undefined);
-    }).to.throw(/Invalid length or percent value/);
-    expect(function() {
+    }).to.throw(/Invalid length or percent value/); });
+    allowConsoleError(() => { expect(function() {
       assertLengthOrPercent(null);
-    }).to.throw(/Invalid length or percent value/);
-    expect(function() {
+    }).to.throw(/Invalid length or percent value/); });
+    allowConsoleError(() => { expect(function() {
       assertLengthOrPercent('');
-    }).to.throw(/Invalid length or percent value/);
+    }).to.throw(/Invalid length or percent value/); });
   });
 
 
@@ -188,8 +188,10 @@ describe('Layout', () => {
 
   it('layout=fixed - requires width/height', () => {
     div.setAttribute('layout', 'fixed');
-    expect(() => applyStaticLayout(div)).to.throw(
-        /Expected height to be available/);
+    allowConsoleError(() => {
+      expect(() => applyStaticLayout(div)).to.throw(
+          /Expected height to be available/);
+    });
   });
 
 
@@ -220,9 +222,9 @@ describe('Layout', () => {
     div.setAttribute('layout', 'fixed-height');
     div.setAttribute('height', 200);
     div.setAttribute('width', 300);
-    expect(function() {
+    allowConsoleError(() => { expect(function() {
       applyStaticLayout(div);
-    }).to.throw(/Expected width to be either absent or equal "auto"/);
+    }).to.throw(/Expected width to be either absent or equal "auto"/); });
   });
 
   it('layout=fixed-height - default with height', () => {
@@ -242,8 +244,10 @@ describe('Layout', () => {
 
   it('layout=fixed-height - requires height', () => {
     div.setAttribute('layout', 'fixed-height');
-    expect(() => applyStaticLayout(div)).to.throw(
-        /Expected height to be available/);
+    allowConsoleError(() => {
+      expect(() => applyStaticLayout(div)).to.throw(
+          /Expected height to be available/);
+    });
   });
 
 
@@ -362,9 +366,9 @@ describe('Layout', () => {
 
   it('layout=unknown', () => {
     div.setAttribute('layout', 'foo');
-    expect(function() {
+    allowConsoleError(() => { expect(function() {
       applyStaticLayout(div);
-    }).to.throw(/Unknown layout: foo/);
+    }).to.throw(/Unknown layout: foo/); });
   });
 
 
@@ -425,16 +429,16 @@ describe('Layout', () => {
 
     // Width=X is invalid.
     pixel.setAttribute('width', 'X');
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       applyStaticLayout(pixel);
-    }).to.throw(/Invalid width value/);
+    }).to.throw(/Invalid width value/); });
 
     // Height=X is invalid.
     pixel.setAttribute('height', 'X');
     pixel.setAttribute('width', '1px');
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       applyStaticLayout(pixel);
-    }).to.throw(/Invalid height value/);
+    }).to.throw(/Invalid height value/); });
   });
 
   it('should trust server layout', () => {
@@ -478,6 +482,8 @@ describe('Layout', () => {
 
   it('should fail when server generates invalid layout', () => {
     div.setAttribute('i-amphtml-layout', 'invalid');
-    expect(() => applyStaticLayout(div)).to.throw(/failed/);
+    allowConsoleError(() => {
+      expect(() => applyStaticLayout(div)).to.throw(/failed/);
+    });
   });
 });

--- a/test/functional/test-log.js
+++ b/test/functional/test-log.js
@@ -298,9 +298,9 @@ describe('Logging', () => {
     });
 
     it('should fail', () => {
-      expect(function() {
+      allowConsoleError(() => { expect(function() {
         log.assert(false, 'xyz');
-      }).to.throw(/xyz/);
+      }).to.throw(/xyz/); });
       try {
         log.assert(false, '123');
       } catch (e) {
@@ -318,18 +318,18 @@ describe('Logging', () => {
     });
 
     it('should substitute', () => {
-      expect(function() {
+      allowConsoleError(() => { expect(function() {
         log.assert(false, 'should fail %s', 'XYZ');
-      }).to.throw(/should fail XYZ/);
-      expect(function() {
+      }).to.throw(/should fail XYZ/); });
+      allowConsoleError(() => { expect(function() {
         log.assert(false, 'should fail %s %s', 'XYZ', 'YYY');
-      }).to.throw(/should fail XYZ YYY/);
+      }).to.throw(/should fail XYZ YYY/); });
       const div = document.createElement('div');
       div.id = 'abc';
       div.textContent = 'foo';
-      expect(function() {
+      allowConsoleError(() => { expect(function() {
         log.assert(false, 'should fail %s', div);
-      }).to.throw(/should fail div#abc/);
+      }).to.throw(/should fail div#abc/); });
 
       let error;
       try {
@@ -430,15 +430,15 @@ describe('Logging', () => {
     });
 
     it('should should identify non-elements', () => {
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         log.assertElement(document);
-      }).to.throw(/Element expected: /);
-      expect(() => {
+      }).to.throw(/Element expected: /); });
+      allowConsoleError(() => { expect(() => {
         log.assertElement(null);
-      }).to.throw(/Element expected: null/);
-      expect(() => {
+      }).to.throw(/Element expected: null/); });
+      allowConsoleError(() => { expect(() => {
         log.assertElement(null, 'custom error');
-      }).to.throw(/custom error: null/);
+      }).to.throw(/custom error: null/); });
     });
   });
 
@@ -458,16 +458,13 @@ describe('Logging', () => {
     });
 
     it('should fail with on non string', () => {
-      expect(() => log.assertString({}))
-          .to.throw('String expected: ');
-      expect(() => log.assertString(3))
-          .to.throw('String expected: ');
-      expect(() => log.assertString(null))
-          .to.throw('String expected: ');
-      expect(() => log.assertString(undefined))
-          .to.throw('String expected: ');
-      expect(() => log.assertString([]))
-          .to.throw('String expected: ');
+      allowConsoleError(() => {
+        expect(() => log.assertString({})).to.throw('String expected: ');
+        expect(() => log.assertString(3)).to.throw('String expected: ');
+        expect(() => log.assertString(null)).to.throw('String expected: ');
+        expect(() => log.assertString(undefined)).to.throw('String expected: ');
+        expect(() => log.assertString([])).to.throw('String expected: ');
+      });
     });
   });
 
@@ -491,16 +488,13 @@ describe('Logging', () => {
     });
 
     it('should fail with on non number', () => {
-      expect(() => log.assertNumber({}))
-          .to.throw('Number expected: ');
-      expect(() => log.assertNumber('a'))
-          .to.throw('Number expected: ');
-      expect(() => log.assertNumber(null))
-          .to.throw('Number expected: ');
-      expect(() => log.assertNumber(undefined))
-          .to.throw('Number expected: ');
-      expect(() => log.assertNumber([]))
-          .to.throw('Number expected: ');
+      allowConsoleError(() => {
+        expect(() => log.assertNumber({})).to.throw('Number expected: ');
+        expect(() => log.assertNumber('a')).to.throw('Number expected: ');
+        expect(() => log.assertNumber(null)).to.throw('Number expected: ');
+        expect(() => log.assertNumber(undefined)).to.throw('Number expected: ');
+        expect(() => log.assertNumber([])).to.throw('Number expected: ');
+      });
     });
   });
 
@@ -520,16 +514,20 @@ describe('Logging', () => {
 
     it('should fail with unknown enum value', () => {
       const enum1 = {a: 'value1', b: 'value2'};
-      expect(() => log.assertEnumValue(enum1, 'value3'))
-          .to.throw('Unknown enum value: "value3"');
-      expect(() => log.assertEnumValue(enum1, 'value3', 'MyEnum'))
-          .to.throw('Unknown MyEnum value: "value3"');
+      allowConsoleError(() => {
+        expect(() => log.assertEnumValue(enum1, 'value3')).to.throw(
+            'Unknown enum value: "value3"');
+        expect(() => log.assertEnumValue(enum1, 'value3', 'MyEnum')).to.throw(
+            'Unknown MyEnum value: "value3"');
+      });
     });
 
     it('should fail with values of different case', () => {
       const enum1 = {a: 'value1', b: 'value2'};
-      expect(() => log.assertEnumValue(enum1, 'VALUE1'))
-          .to.throw('Unknown enum value: "VALUE1"');
+      allowConsoleError(() => {
+        expect(() => log.assertEnumValue(enum1, 'VALUE1')).to.throw(
+            'Unknown enum value: "VALUE1"');
+      });
     });
   });
 

--- a/test/functional/test-mediasession-helper.js
+++ b/test/functional/test-mediasession-helper.js
@@ -146,7 +146,9 @@ describes.sandboxed('MediaSessionAPI Helper Functions', {}, () => {
       ],
       'title': '',
     };
-    expect(() => {setMediaSession(ampdoc.win, fakeMetaData);}).to.throw();
+    allowConsoleError(() => {
+      expect(() => {setMediaSession(ampdoc.win, fakeMetaData);}).to.throw();
+    });
   });
 
   it('should throw if artwork src is invalid - string', () => {
@@ -159,7 +161,9 @@ describes.sandboxed('MediaSessionAPI Helper Functions', {}, () => {
       ],
       'title': '',
     };
-    expect(() => {setMediaSession(ampdoc.win, fakeMetaData);}).to.throw();
+    allowConsoleError(() => {
+      expect(() => {setMediaSession(ampdoc.win, fakeMetaData);}).to.throw();
+    });
   });
 
   it('should throw if artwork is not array', () => {
@@ -169,6 +173,8 @@ describes.sandboxed('MediaSessionAPI Helper Functions', {}, () => {
       'artwork': 'https://NotArray',
       'title': '',
     };
-    expect(() => {setMediaSession(ampdoc.win, fakeMetaData);}).to.throw();
+    allowConsoleError(() => {
+      expect(() => {setMediaSession(ampdoc.win, fakeMetaData);}).to.throw();
+    });
   });
 });

--- a/test/functional/test-object.js
+++ b/test/functional/test-object.js
@@ -149,8 +149,10 @@ describe('Object', () => {
       destObject.a = {};
       const fromObject = {};
       fromObject.a = fromObject;
-      expect(() => object.deepMerge(destObject, fromObject))
-          .to.throw(/Source object has a circular reference./);
+      allowConsoleError(() => {
+        expect(() => object.deepMerge(destObject, fromObject)).to.throw(
+            /Source object has a circular reference./);
+      });
     });
 
     it('should merge null and undefined correctly', () => {

--- a/test/functional/test-origin-experiments.js
+++ b/test/functional/test-origin-experiments.js
@@ -72,36 +72,46 @@ describe('OriginExperiments', () => {
   it('should throw for an unknown token version number', () => {
     const verify = originExperiments.verifyToken(
         tokenWithBadVersion, 'https://origin.com', publicKey);
-    return expect(verify)
-        .to.eventually.be.rejectedWith('Unrecognized token version: 42');
+    allowConsoleError(() => {
+      return expect(verify).to.eventually.be.rejectedWith(
+          'Unrecognized token version: 42');
+    });
   });
 
   it('should throw if config length exceeds byte length', () => {
     const verify = originExperiments.verifyToken(
         tokenWithBadConfigLength, 'https://origin.com', publicKey);
-    return expect(verify)
-        .to.eventually.be.rejectedWith('Unexpected config length: 999');
+    allowConsoleError(() => {
+      return expect(verify).to.eventually.be.rejectedWith(
+          'Unexpected config length: 999');
+    });
   });
 
   it('should throw if signature cannot be verified', () => {
     const verify = originExperiments.verifyToken(
         tokenWithBadSignature, 'https://origin.com', publicKey);
-    return expect(verify)
-        .to.eventually.be.rejectedWith('Failed to verify token signature.');
+    allowConsoleError(() => {
+      return expect(verify).to.eventually.be.rejectedWith(
+          'Failed to verify token signature.');
+    });
   });
 
   it('should throw if approved origin is not current origin', () => {
     const verify = originExperiments.verifyToken(
         token, 'https://not-origin.com', publicKey);
-    return expect(verify)
-        .to.eventually.be.rejectedWith(/does not match window/);
+    allowConsoleError(() => {
+      return expect(verify).to.eventually.be.rejectedWith(
+          /does not match window/);
+    });
   });
 
   it('should return false if trial has expired', () => {
     const verify = originExperiments.verifyToken(
         tokenWithExpiredExperiment, 'https://origin.com', publicKey);
-    return expect(verify)
-        .to.eventually.be.rejectedWith('Experiment "expired" has expired.');
+    allowConsoleError(() => {
+      return expect(verify).to.eventually.be.rejectedWith(
+          'Experiment "expired" has expired.');
+    });
   });
 
   it('should return true for a well-formed, unexpired token', () => {

--- a/test/functional/test-polyfill-object-assign.js
+++ b/test/functional/test-polyfill-object-assign.js
@@ -18,10 +18,12 @@ import {assign} from '../../src/polyfills/object-assign';
 
 describe('Object.assign', () => {
   it('should throw an error if target is null or undefined', () => {
-    expect(() => assign(null, {a: 1})).to.throw(
-        /Cannot convert undefined or null to object/);
-    expect(() => assign(undefined, {a: 1})).to.throw(
-        /Cannot convert undefined or null to object/);
+    allowConsoleError(() => {
+      expect(() => assign(null, {a: 1})).to.throw(
+          /Cannot convert undefined or null to object/);
+      expect(() => assign(undefined, {a: 1})).to.throw(
+          /Cannot convert undefined or null to object/);
+    });
   });
 
   it('should ignore null or undefined sources', () => {

--- a/test/functional/test-render-delaying-services.js
+++ b/test/functional/test-render-delaying-services.js
@@ -67,7 +67,9 @@ describe('waitForServices', () => {
     dynamicCssResolve();
     experimentResolve(); // 'amp-experiment' is actually blocked by 'variant'
     clock.tick(3000);
-    return expect(promise).to.eventually.be.rejectedWith('variant');
+    allowConsoleError(() => {
+      return expect(promise).to.eventually.be.rejectedWith('variant');
+    });
   });
 
   it('should resolve when all extensions are ready', () => {

--- a/test/functional/test-resource.js
+++ b/test/functional/test-resource.js
@@ -460,18 +460,18 @@ describes.realWin('Resource', {amp: true}, env => {
     elementMock.expects('layoutCallback').never();
 
     resource.state_ = ResourceState.NOT_BUILT;
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       resource.startLayout();
-    }).to.throw(/Not ready to start layout/);
+    }).to.throw(/Not ready to start layout/); });
   });
 
   it('should ignore startLayout if not visible', () => {
     elementMock.expects('layoutCallback').never();
     resource.state_ = ResourceState.READY_FOR_LAYOUT;
     resource.layoutBox_ = {left: 11, top: 12, width: 0, height: 0};
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       resource.startLayout();
-    }).to.throw(/Not displayed/);
+    }).to.throw(/Not displayed/); });
   });
 
   it('should force startLayout for first layout', () => {

--- a/test/functional/test-sanitizer.js
+++ b/test/functional/test-sanitizer.js
@@ -308,10 +308,9 @@ describe('rewriteAttributeValue', () => {
 describe('resolveUrlAttr', () => {
 
   it('should throw if __amp_source_origin is set', () => {
-    expect(() => resolveUrlAttr('a', 'href',
+    allowConsoleError(() => { expect(() => resolveUrlAttr('a', 'href',
         '/doc2?__amp_source_origin=https://google.com',
-        'http://acme.org/doc1'))
-        .to.throw(/Source origin is not allowed in/);
+        'http://acme.org/doc1')).to.throw(/Source origin is not allowed in/); });
   });
 
   it('should be called by sanitizer', () => {

--- a/test/functional/test-service.js
+++ b/test/functional/test-service.js
@@ -70,8 +70,10 @@ describe('service', () => {
 
     it('should assert disposable interface', () => {
       expect(assertDisposable(disposable)).to.equal(disposable);
-      expect(() => assertDisposable(nonDisposable))
-          .to.throw(/required to implement Disposable/);
+      allowConsoleError(() => {
+        expect(() => assertDisposable(nonDisposable)).to.throw(
+            /required to implement Disposable/);
+      });
     });
   });
 
@@ -140,15 +142,15 @@ describe('service', () => {
     });
 
     it('should throw before creation if factory is not provided', () => {
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         getService(window, 'c');
-      }).to.throw();
+      }).to.throw(); });
     });
 
     it('should fail without factory on initial setup', () => {
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         getService(window, 'not-present');
-      }).to.throw(/Expected service not-present to be registered/);
+      }).to.throw(/Expected service not-present to be registered/); });
     });
 
     it('should provide a promise that resolves when instantiated', () => {
@@ -401,9 +403,9 @@ describe('service', () => {
     });
 
     it('should fail without factory on initial setup', () => {
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         getServiceForDoc(node, 'not-present');
-      }).to.throw(/Expected service not-present to be registered/);
+      }).to.throw(/Expected service not-present to be registered/); });
     });
 
     it('should provide a promise that resolves when instantiated', () => {
@@ -602,15 +604,15 @@ describe('service', () => {
         });
 
         it('should refuse adopt of non-embeddable', () => {
-          expect(() => {
+          allowConsoleError(() => { expect(() => {
             adoptServiceForEmbed(embedWin, 'nonEmbeddable');
-          }).to.throw(/implement EmbeddableService/);
+          }).to.throw(/implement EmbeddableService/); });
         });
 
         it('should refuse adopt of unknown service', () => {
-          expect(() => {
+          allowConsoleError(() => { expect(() => {
             adoptServiceForEmbed(embedWin, 'unknown');
-          }).to.throw(/unknown/);
+          }).to.throw(/unknown/); });
         });
       });
 

--- a/test/functional/test-size-list.js
+++ b/test/functional/test-size-list.js
@@ -97,17 +97,17 @@ describe('SizeList parseSizeList', () => {
 
   it('should fail on invalid CSS functions', () => {
     // Spaces are not allowed between function name and `(`.
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       parseSizeList('screen calc (111vw + 10px) \n, 10px ');
-    }).to.throw(/Invalid CSS function/);
+    }).to.throw(/Invalid CSS function/); });
 
     // Parens don't match.
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       parseSizeList('screen calc(111vw + 10px)) \n, 10px ');
-    }).to.throw(/Invalid CSS function/);
-    expect(() => {
+    }).to.throw(/Invalid CSS function/); });
+    allowConsoleError(() => { expect(() => {
       parseSizeList('screen calc((111vw + 10px) \n, 10px ');
-    }).to.throw(/Invalid CSS function/);
+    }).to.throw(/Invalid CSS function/); });
   });
 
   it('should accept percent when allowed', () => {
@@ -119,15 +119,15 @@ describe('SizeList parseSizeList', () => {
   });
 
   it('should not accept percent', () => {
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       parseSizeList(' \n 111% \n ', /* opt_allowPercentAsLength */ false);
-    }).to.throw(/Invalid length value/);
+    }).to.throw(/Invalid length value/); });
   });
 
   it('should fail bad length', () => {
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       parseSizeList(' \n 111 \n ');
-    }).to.throw(/Invalid length value/);
+    }).to.throw(/Invalid length value/); });
   });
 });
 
@@ -135,25 +135,29 @@ describe('SizeList parseSizeList', () => {
 describe('SizeList construct', () => {
 
   it('should have at least one option', () => {
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       new SizeList([]);
-    }).to.throw(/SizeList must have at least one option/);
+    }).to.throw(/SizeList must have at least one option/); });
   });
 
   it('the last option must not have a query', () => {
-    expect(() => {
-      new SizeList([{mediaQuery: 'screen', size: '111px'}]);
-    }).to.throw(/The last option must not have a media condition/);
-    expect(() => {
-      new SizeList([{mediaQuery: 'print', size: '222px'},
-        {mediaQuery: 'screen', size: '111px'}]);
-    }).to.throw(/The last option must not have a media condition/);
+    allowConsoleError(() => {
+      expect(() => {
+        new SizeList([{mediaQuery: 'screen', size: '111px'}]);
+      }).to.throw(/The last option must not have a media condition/);
+      expect(() => {
+        new SizeList([{mediaQuery: 'print', size: '222px'},
+          {mediaQuery: 'screen', size: '111px'}]);
+      }).to.throw(/The last option must not have a media condition/);
+    });
   });
 
   it('non-last options must have media query', () => {
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       new SizeList([{size: '222px'}, {size: '111px'}]);
-    }).to.throw(/All options except for the last must have a media condition/);
+    }).to.throw(
+        /All options except for the last must have a media condition/);
+    });
   });
 });
 

--- a/test/functional/test-srcset.js
+++ b/test/functional/test-srcset.js
@@ -178,9 +178,9 @@ describe('Srcset', () => {
     });
 
     it('should not accept mixed sources', () => {
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         parseSrcset(' \n image1 100w\n , \n image2 1.5x\n , image3 ');
-      }).to.throw(/Srcset must have width or dpr sources, but not both/);
+      }).to.throw(/Srcset must have width or dpr sources, but not both/); });
     });
 
     it('should parse misc examples', () => {
@@ -258,10 +258,11 @@ describe('Srcset', () => {
     });
 
     it('should require srcset or src to be available', () => {
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         srcsetFromElement(document.createElement('div'));
       }).to.throw(
           /Either non-empty "srcset" or "src" attribute must be specified/);
+      });
     });
   });
 
@@ -281,38 +282,38 @@ describe('Srcset', () => {
 
   describe('construct', () => {
     it('should enforce only one type of descriptor per source', () => {
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         new Srcset([{url: 'image-1000', width: 100, dpr: 2}]);
-      }).to.throw(/Srcset must have width or dpr sources, but not both/);
+      }).to.throw(/Srcset must have width or dpr sources, but not both/); });
     });
 
     it('should not allow 0-width descriptor', () => {
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         new Srcset([{url: 'image-1000', width: 0}]);
-      }).to.throw(/Srcset must have width or dpr sources, but not both/);
+      }).to.throw(/Srcset must have width or dpr sources, but not both/); });
     });
 
     it('should not allow 0-dpr descriptor', () => {
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         new Srcset([{url: 'image-1000', dpr: 0}]);
-      }).to.throw(/Srcset must have width or dpr sources, but not both/);
+      }).to.throw(/Srcset must have width or dpr sources, but not both/); });
     });
 
     it('should enforce only one type of descriptor total', () => {
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         new Srcset([{url: 'image-1000', width: 100},
           {url: 'image-2x', dpr: 2}]);
-      }).to.throw(/Srcset must have width or dpr sources, but not both/);
+      }).to.throw(/Srcset must have width or dpr sources, but not both/); });
     });
 
     it('should not allow duplicate sources', () => {
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         new Srcset([{url: 'image', width: 100},
           {url: 'image', width: 100}]);
-      }).to.throw(/Duplicate width/);
-      expect(() => {
+      }).to.throw(/Duplicate width/); });
+      allowConsoleError(() => { expect(() => {
         new Srcset([{url: 'image', dpr: 2}, {url: 'image', dpr: 2}]);
-      }).to.throw(/Duplicate dpr/);
+      }).to.throw(/Duplicate dpr/); });
     });
   });
 

--- a/test/functional/test-standard-actions.js
+++ b/test/functional/test-standard-actions.js
@@ -374,7 +374,9 @@ describes.sandboxed('StandardActions', {}, () => {
           },
         },
       };
-      expect(() => standardActions.handleAmpTarget(invocation)).to.throw();
+      allowConsoleError(() => {
+        expect(() => standardActions.handleAmpTarget(invocation)).to.throw();
+      });
       expect(printStub).to.not.be.called;
     });
 

--- a/test/functional/test-storage.js
+++ b/test/functional/test-storage.js
@@ -415,12 +415,14 @@ describe('Store', () => {
   });
 
   it('should prohibit unsafe values', () => {
-    expect(() => {
-      store.set('__proto__', 'value1');
-    }).to.throw(/Name is not allowed/);
-    expect(() => {
-      store.set('prototype', 'value1');
-    }).to.throw(/Name is not allowed/);
+    allowConsoleError(() => {
+      expect(() => {
+        store.set('__proto__', 'value1');
+      }).to.throw(/Name is not allowed/);
+      expect(() => {
+        store.set('prototype', 'value1');
+      }).to.throw(/Name is not allowed/);
+    });
   });
 });
 

--- a/test/functional/test-task-queue.js
+++ b/test/functional/test-task-queue.js
@@ -46,9 +46,9 @@ describe('TaskQueue', () => {
     expect(queue.getLastEnqueueTime()).to.equal(1000);
     expect(queue.getLastDequeueTime()).to.equal(0);
 
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       queue.enqueue({id: '1'});
-    }).to.throw(/Task already enqueued/);
+    }).to.throw(/Task already enqueued/); });
 
     queue.dequeue({id: '1'});
     expect(queue.getTaskById('1')).to.equal(null);

--- a/test/functional/test-template.js
+++ b/test/functional/test-template.js
@@ -81,10 +81,10 @@ describes.fakeWin('Template', {}, env => {
     const templateElement = createTemplateElement();
     registerExtendedTemplate(win, templateElement.getAttribute('type'),
         TemplateImpl);
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       registerExtendedTemplate(win, templateElement.getAttribute('type'),
           TemplateImpl);
-    }).to.throw(/Duplicate template type/);
+    }).to.throw(/Duplicate template type/); });
   });
 
   it('should block render until template registered', () => {
@@ -168,9 +168,9 @@ describes.fakeWin('Template', {}, env => {
     const parentElement = doc.createElement('div');
     parentElement.setAttribute('template', id);
     doc.body.appendChild(parentElement);
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       templates.findAndRenderTemplate(parentElement, {value: 0});
-    }).to.throw(/Template element must be a "template" tag/);
+    }).to.throw(/Template element must be a "template" tag/); });
   });
 
   it('should discover template via children', () => {
@@ -189,14 +189,14 @@ describes.fakeWin('Template', {}, env => {
   it('should fail when template not found', () => {
     const parentElement = doc.createElement('div');
     doc.body.appendChild(parentElement);
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       templates.findAndRenderTemplate(parentElement, {value: 0});
-    }).to.throw(/Template not found/);
+    }).to.throw(/Template not found/); });
 
     parentElement.setAttribute('template', 'notemplate' + Math.random());
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       templates.findAndRenderTemplate(parentElement, {value: 0});
-    }).to.throw(/Template not found/);
+    }).to.throw(/Template not found/); });
   });
 
   it('should detect if a template is present in a container', () => {
@@ -254,9 +254,9 @@ describes.fakeWin('BaseTemplate', {}, env => {
   });
 
   it('should require render override', () => {
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       new BaseTemplate(templateElement).render();
-    }).to.throw(/Not implemented/);
+    }).to.throw(/Not implemented/); });
   });
 
   it('should unwrap single element', () => {

--- a/test/functional/test-url-replacements.js
+++ b/test/functional/test-url-replacements.js
@@ -881,9 +881,9 @@ describes.sandboxed('UrlReplacements', {}, () => {
     });
     const p = expect(replacements.expandUrlAsync('?a=ONE')).to.eventually
         .equal('?a=');
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       clock.tick(1);
-    }).to.throw(/boom/);
+    }).to.throw(/boom/); });
     return p;
   });
 
@@ -896,9 +896,9 @@ describes.sandboxed('UrlReplacements', {}, () => {
     return expect(replacements.expandUrlAsync('?a=ONE'))
         .to.eventually.equal('?a=')
         .then(() => {
-          expect(() => {
+          allowConsoleError(() => { expect(() => {
             clock.tick(1);
-          }).to.throw(/boom/);
+          }).to.throw(/boom/); });
         });
   });
 
@@ -1156,10 +1156,10 @@ describes.sandboxed('UrlReplacements', {}, () => {
     it('should reject javascript protocol', () => {
       const win = getFakeWindow();
       const urlReplacements = Services.urlReplacementsForDoc(win.ampdoc);
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         /*eslint no-script-url: 0*/
         urlReplacements.expandUrlSync('javascript://example.com/?r=RANDOM');
-      }).to.throw('invalid protocol');
+      }).to.throw('invalid protocol'); });
     });
   });
 
@@ -1470,8 +1470,10 @@ describes.sandboxed('UrlReplacements', {}, () => {
       const input = document.createElement('textarea');
       input.value = 'RANDOM';
       input.setAttribute('data-amp-replace', 'RANDOM');
-      expect(() => urlReplacements.expandInputValueSync(input)).to.throw(
-          /Input value expansion only works on hidden input fields/);
+      allowConsoleError(() => {
+        expect(() => urlReplacements.expandInputValueSync(input)).to.throw(
+            /Input value expansion only works on hidden input fields/);
+      });
       expect(input.value).to.equal('RANDOM');
     });
 
@@ -1481,8 +1483,10 @@ describes.sandboxed('UrlReplacements', {}, () => {
       const input = document.createElement('input');
       input.value = 'RANDOM';
       input.setAttribute('data-amp-replace', 'RANDOM');
-      expect(() => urlReplacements.expandInputValueSync(input)).to.throw(
-          /Input value expansion only works on hidden input fields/);
+      allowConsoleError(() => {
+        expect(() => urlReplacements.expandInputValueSync(input)).to.throw(
+            /Input value expansion only works on hidden input fields/);
+      });
       expect(input.value).to.equal('RANDOM');
     });
 

--- a/test/functional/test-url.js
+++ b/test/functional/test-url.js
@@ -325,12 +325,14 @@ describe('serializeQueryString', () => {
 describe('assertHttpsUrl/isSecureUrl', () => {
   const referenceElement = document.createElement('div');
   it('should NOT allow null or undefined, but allow empty string', () => {
-    expect(() => {
-      assertHttpsUrl(null, referenceElement);
-    }).to.throw(/source must be available/);
-    expect(() => {
-      assertHttpsUrl(undefined, referenceElement);
-    }).to.throw(/source must be available/);
+    allowConsoleError(() => {
+      expect(() => {
+        assertHttpsUrl(null, referenceElement);
+      }).to.throw(/source must be available/);
+      expect(() => {
+        assertHttpsUrl(undefined, referenceElement);
+      }).to.throw(/source must be available/);
+    });
     assertHttpsUrl('', referenceElement);
   });
   it('should allow https', () => {
@@ -353,15 +355,15 @@ describe('assertHttpsUrl/isSecureUrl', () => {
   });
 
   it('should fail on http', () => {
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       assertHttpsUrl('http://twitter.com', referenceElement);
-    }).to.throw(/source must start with/);
+    }).to.throw(/source must start with/); });
     expect(isSecureUrl('http://twitter.com')).to.be.false;
   });
   it('should fail on http with localhost in the name', () => {
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       assertHttpsUrl('http://foolocalhost', referenceElement);
-    }).to.throw(/source must start with/);
+    }).to.throw(/source must start with/); });
     expect(isSecureUrl('http://foolocalhost')).to.be.false;
   });
 });
@@ -380,20 +382,20 @@ describe('assertAbsoluteHttpOrHttpsUrl', () => {
         .to.equal('https://twitter.com/');
   });
   it('should fail on relative protocol', () => {
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       assertAbsoluteHttpOrHttpsUrl('//twitter.com/');
-    }).to.throw(/URL must start with/);
+    }).to.throw(/URL must start with/); });
   });
   it('should fail on relative url', () => {
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       assertAbsoluteHttpOrHttpsUrl('/path');
-    }).to.throw(/URL must start with/);
+    }).to.throw(/URL must start with/); });
   });
   it('should fail on not allowed protocol', () => {
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       assertAbsoluteHttpOrHttpsUrl(
           /*eslint no-script-url: 0*/ 'javascript:alert');
-    }).to.throw(/URL must start with/);
+    }).to.throw(/URL must start with/); });
   });
 });
 
@@ -699,9 +701,9 @@ describe('getSourceOrigin/Url', () => {
       'https://origin.com/foo/?f=0');
 
   it('should fail on invalid source origin', () => {
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       getSourceOrigin(parseUrl('https://cdn.ampproject.org/v/yyy/'));
-    }).to.throw(/Expected a \. in origin http:\/\/yyy/);
+    }).to.throw(/Expected a \. in origin http:\/\/yyy/); });
   });
 });
 
@@ -786,8 +788,7 @@ describe('resolveRelativeUrl', () => {
 
 describe('getCorsUrl', () => {
   it('should error if __amp_source_origin is set', () => {
-    expect(() => getCorsUrl(window, 'http://example.com/?__amp_source_origin'))
-        .to.throw(/Source origin is not allowed in/);
+    allowConsoleError(() => { expect(() => getCorsUrl(window, 'http://example.com/?__amp_source_origin')).to.throw(/Source origin is not allowed in/); });
     expect(() => getCorsUrl(window, 'http://example.com/?name=hello'))
         .to.not.throw;
   });

--- a/test/functional/test-viewer-cid-api.js
+++ b/test/functional/test-viewer-cid-api.js
@@ -118,8 +118,10 @@ describes.realWin('viewerCidApi', {amp: true}, env => {
           '<meta name="amp-google-client-id-api" content="googleanalytics">';
       viewerMock.sendMessageAwaitResponse
           .returns(Promise.reject('Client API error'));
-      return expect(api.getScopedCid('AMP_ECID_GOOGLE'))
-          .to.eventually.be.rejectedWith(/Client API error/);
+      allowConsoleError(() => {
+        return expect(api.getScopedCid('AMP_ECID_GOOGLE'))
+            .to.eventually.be.rejectedWith(/Client API error/);
+      });
     });
   });
 

--- a/test/functional/test-viewer.js
+++ b/test/functional/test-viewer.js
@@ -446,11 +446,11 @@ describe('Viewer', () => {
       viewer.receiveMessage('visibilitychange', {
         state: 'paused',
       });
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         viewer.receiveMessage('visibilitychange', {
           state: 'what is this',
         });
-      }).to.throw('Unknown VisibilityState value');
+      }).to.throw('Unknown VisibilityState value'); });
       expect(viewer.getVisibilityState()).to.equal('paused');
       expect(viewer.isVisible()).to.equal(false);
     });
@@ -920,9 +920,9 @@ describe('Viewer', () => {
       windowApi.parent = {};
       windowApi.location.ancestorOrigins = null;
       const viewer = new Viewer(ampdoc);
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         viewer.setMessageDeliverer(() => {});
-      }).to.throw(/message channel must have an origin/);
+      }).to.throw(/message channel must have an origin/); });
     });
 
     it('should allow channel without origin thats an empty string', () => {
@@ -971,9 +971,9 @@ describe('Viewer', () => {
         windowApi.location.hash = '#webview=1';
         windowApi.location.ancestorOrigins = [];
         const viewer = new Viewer(ampdoc);
-        expect(() => {
+        allowConsoleError(() => { expect(() => {
           viewer.setMessageDeliverer(() => {});
-        }).to.throw(/message channel must have an origin/);
+        }).to.throw(/message channel must have an origin/); });
       });
 
       it('should decide non-trusted on connection with wrong origin', () => {
@@ -1043,9 +1043,9 @@ describe('Viewer', () => {
         windowApi.location.hash = '#origin=g.com&webview=1';
         windowApi.location.ancestorOrigins = null;
         const viewer = new Viewer(ampdoc);
-        expect(() => {
+        allowConsoleError(() => { expect(() => {
           viewer.setMessageDeliverer(() => {});
-        }).to.throw(/message channel must have an origin/);
+        }).to.throw(/message channel must have an origin/); });
       });
 
       it('should decide non-trusted on connection with wrong origin', () => {

--- a/test/functional/test-vsync.js
+++ b/test/functional/test-vsync.js
@@ -99,9 +99,9 @@ describe('vsync', () => {
     });
 
     it('should fail canAnimate without node', () => {
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         vsync.canAnimate();
-      }).to.throw(/Assertion failed/);
+      }).to.throw(/Assertion failed/); });
     });
 
     // TODO(choumx, #12476): Make this test work with sinon 4.0.

--- a/test/functional/test-xhr.js
+++ b/test/functional/test-xhr.js
@@ -123,9 +123,9 @@ describe.configure().skipSafari().run('XHR', function() {
 
           expect(get).to.not.throw();
           expect(post).to.not.throw();
-          expect(put).to.throw();
-          expect(patch).to.throw();
-          expect(deleteMethod).to.throw();
+          allowConsoleError(() => { expect(put).to.throw(); });
+          allowConsoleError(() => { expect(patch).to.throw(); });
+          allowConsoleError(() => { expect(deleteMethod).to.throw(); });
         });
 
         it('should allow FormData as body', () => {
@@ -177,21 +177,21 @@ describe.configure().skipSafari().run('XHR', function() {
 
         it('should defend against invalid source origin query ' +
            'parameter', () => {
-          expect(() => {
+          allowConsoleError(() => { expect(() => {
             xhr.fetchJson('/get?k=v1&__amp_source_origin=invalid#h1');
-          }).to.throw(/Source origin is not allowed/);
+          }).to.throw(/Source origin is not allowed/); });
         });
 
         it('should defend against empty source origin query parameter', () => {
-          expect(() => {
+          allowConsoleError(() => { expect(() => {
             xhr.fetchJson('/get?k=v1&__amp_source_origin=#h1');
-          }).to.throw(/Source origin is not allowed/);
+          }).to.throw(/Source origin is not allowed/); });
         });
 
         it('should defend against re-encoded source origin parameter', () => {
-          expect(() => {
+          allowConsoleError(() => { expect(() => {
             xhr.fetchJson('/get?k=v1&_%5famp_source_origin=#h1');
-          }).to.throw(/Source origin is not allowed/);
+          }).to.throw(/Source origin is not allowed/); });
         });
 
         it('should not include __amp_source_origin if ampCors ' +
@@ -408,9 +408,9 @@ describe.configure().skipSafari().run('XHR', function() {
       });
 
       it('should NOT succeed CORS with invalid credentials', () => {
-        expect(() => {
+        allowConsoleError(() => { expect(() => {
           xhr.fetchJson('https://acme.org/', {credentials: null});
-        }).to.throw(/Only credentials=include|omit support: null/);
+        }).to.throw(/Only credentials=include|omit support: null/); });
       });
 
       it('should expose HTTP headers', () => {
@@ -671,10 +671,10 @@ describe.configure().skipSafari().run('XHR', function() {
 
         expect(objectFn).to.not.throw();
         expect(arrayFn).to.not.throw();
-        expect(stringFn).to.throw();
-        expect(numberFn).to.throw();
-        expect(booleanFn).to.throw();
-        expect(nullFn).to.throw();
+        allowConsoleError(() => { expect(stringFn).to.throw(); });
+        allowConsoleError(() => { expect(numberFn).to.throw(); });
+        allowConsoleError(() => { expect(booleanFn).to.throw(); });
+        allowConsoleError(() => { expect(nullFn).to.throw(); });
       });
 
     });

--- a/test/functional/url-expander/test-expander.js
+++ b/test/functional/url-expander/test-expander.js
@@ -231,9 +231,9 @@ describes.realWin('Expander', {
 
     it('throws on bad input with back ticks', () => {
       const url = 'CONCAT(bad`hello`, world)';
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         expander.expand(url, mockBindings);
-      }).to.throw(/bad/);
+      }).to.throw(/bad/); });
     });
 
     it('should handle tokens with parenthesis next to each other', () => {

--- a/test/functional/utils/test-base64.js
+++ b/test/functional/utils/test-base64.js
@@ -105,11 +105,15 @@ describe('base64UrlDecodeToBytes', () => {
   });
 
   it('should signal an error with bad input characters', () => {
-    expect(() => base64UrlDecodeToBytes('@#*#')).to.throw();
+    allowConsoleError(() => {
+      expect(() => base64UrlDecodeToBytes('@#*#')).to.throw();
+    });
   });
 
   it('should signal an error with bad padding', () => {
-    expect(() => base64UrlDecodeToBytes('c3Vy.')).to.throw();
+    allowConsoleError(() => {
+      expect(() => base64UrlDecodeToBytes('c3Vy.')).to.throw();
+    });
   });
 });
 
@@ -132,11 +136,15 @@ describe('base64DecodeToBytes', () => {
   });
 
   it('should signal an error with bad input characters', () => {
-    expect(() => base64DecodeToBytes('@#*#')).to.throw();
+    allowConsoleError(() => {
+      expect(() => base64DecodeToBytes('@#*#')).to.throw();
+    });
   });
 
   it('should signal an error with bad padding', () => {
-    expect(() => base64DecodeToBytes('c3Vy=')).to.throw();
+    allowConsoleError(() => {
+      expect(() => base64DecodeToBytes('c3Vy=')).to.throw();
+    });
   });
 });
 

--- a/test/functional/utils/test-bytes.js
+++ b/test/functional/utils/test-bytes.js
@@ -47,9 +47,9 @@ describe('stringToBytes', function() {
   });
 
   it('should signal an error with a character >255', () => {
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       return stringToBytes('ab☺');
-    }).to.throw();
+    }).to.throw(); });
   });
 
   it('should convert bytes array to string', () => {

--- a/test/functional/utils/test-priority-queue.js
+++ b/test/functional/utils/test-priority-queue.js
@@ -85,6 +85,8 @@ describe('PriorityQueue', function() {
   });
 
   it('should throw error when priority is NaN', () => {
-    expect(() => { pq.enqueue(NaN); }).to.throw(Error);
+    allowConsoleError(() => {
+      expect(() => { pq.enqueue(NaN); }).to.throw(Error);
+    });
   });
 });

--- a/test/functional/web-worker/test-amp-worker.js
+++ b/test/functional/web-worker/test-amp-worker.js
@@ -70,8 +70,10 @@ describe('invokeWebWorker', () => {
 
   it('should check if Worker is supported', () => {
     fakeWin.Worker = undefined;
-    return expect(invokeWebWorker(fakeWin, 'foo'))
-        .to.eventually.be.rejectedWith('not supported');
+    allowConsoleError(() => {
+      return expect(invokeWebWorker(fakeWin, 'foo'))
+          .to.eventually.be.rejectedWith('not supported');
+    });
   });
 
   it('should send and receive a message', () => {
@@ -190,13 +192,13 @@ describe('invokeWebWorker', () => {
       expect(errorStub).to.have.been.calledWith('web-worker');
 
       // Unexpected method at valid `id`.
-      expect(() => {
+      allowConsoleError(() => { expect(() => {
         fakeWorker.onmessage({data: {
           method: 'bar',
           returnValue: undefined,
           id: 0,
         }});
-      }).to.throw('mismatched method');
+      }).to.throw('mismatched method'); });
     });
   });
 

--- a/test/integration/test-3p-frame.js
+++ b/test/integration/test-3p-frame.js
@@ -339,16 +339,16 @@ describe.configure().ifNewChrome().run('3p-frame', () => {
 
   it('should pick the right bootstrap url (custom)', () => {
     addCustomBootstrap('http://example.com/boot/remote.html');
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       getBootstrapBaseUrl(window);
-    }).to.throw(/meta source must start with "https/);
+    }).to.throw(/meta source must start with "https/); });
   });
 
   it('should pick the right bootstrap url (custom)', () => {
     addCustomBootstrap('http://localhost:9876/boot/remote.html');
-    expect(() => {
+    allowConsoleError(() => { expect(() => {
       getBootstrapBaseUrl(window, true);
-    }).to.throw(/must not be on the same origin as the/);
+    }).to.throw(/must not be on the same origin as the/); });
   });
 
   // TODO(keithwrightbos, #14336): Fails due to console errors.


### PR DESCRIPTION
In #14336, a stub was added for `console.error` that would throw an exception when called from within a test.

This PR implements the same check more elegantly by using a mock for `console.error`. It also adds a helper function called `allowConsoleError` that tests can use when they want execute code that may generate an error.

For now, given the sheer number of AMP tests that generate console errors, we print a warning after each test (local dev) / after all tests (on Travis) with instructions for how to fix these errors. Once all of them are fixed (or wrapped in an `allowConsoleError` block), we can start failing tests when an error is encountered.

**Examples:**

This test will print a warning...
```
it('test with unexpected console errors', () => {
  doAThing();  // No console error
  doAnotherThing(); // Contains a console error
  doYetAnotherThing(); // Contains a console error
});
```
... and so will this test...
```
it('test with some unexpected console errors', () => {
  doAThing();  // No console error
  allowConsoleError(() => {
    doAnotherThing(); // Contains a console error
  });
  doYetAnotherThing(); // Contains a console error
});
```
... but this test will pass...
```
it('test with all expected console errors', () => {
  doAThing();  // No console error
  allowConsoleError(() => {
    doAnotherThing(); // Contains a console error
    doYetAnotherThing(); // Contains a console error
  });
});
```

Fixes #7381
Follow up to #14336
Related to #14406
