### PR TITLE
AMP Access Laterpay: Change path of LaterPay Connector API

### DIFF
--- a/extensions/amp-access-laterpay/0.1/laterpay-impl.js
+++ b/extensions/amp-access-laterpay/0.1/laterpay-impl.js
@@ -38,7 +38,7 @@ const CONFIG_URLS = {
 
 const DEFAULT_REGION = 'eu';
 
-const CONFIG_BASE_PATH = '/api/public/amp?' +
+const CONFIG_BASE_PATH = '/api/v1/public/amp?' +
                          'article_url=CANONICAL_URL' +
                          '&amp_reader_id=READER_ID' +
                          '&return_url=RETURN_URL';


### PR DESCRIPTION
Ensures the extension is talking to the v1 API.

This is also in preparation to convert the extension to use our V2 API.