### PR TITLE
🖍 Set font-display for amp-story

### DIFF
--- a/extensions/amp-story/0.1/amp-story-user-overridable.css
+++ b/extensions/amp-story/0.1/amp-story-user-overridable.css
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+amp-story {
+  font-display: optional;
+}
 
 .i-amphtml-story-grid-template-vertical {
   align-content: start;


### PR DESCRIPTION
This prevents fonts from swapping unless the browser will for sure give up on that font.  It overrides AMP's default of `font-display: swap`.  Publishers are free to override this to meet the design they think is best.