### PR TITLE
✨✅Add support for date input. Begin tests for date-picker functionality.

### DIFF
--- a/examples/date-picker.amp.html
+++ b/examples/date-picker.amp.html
@@ -19,7 +19,7 @@
     left: 0;
   }
 
-  [type=tel] {
+  [type=tel],[type=date] {
     padding: 13px 35px;
     font-size: 16px;
     background-image: url('data:image/svg+xml,<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 1393.1 1500" style="enable-background:new 0 0 1393.1 1500;" xml:space="preserve"><path d="M107.2,1392.9h241.1v-241.1H107.2V1392.9z M401.9,1392.9h267.9v-241.1H401.9V1392.9z M107.2,1098.2h241.1V830.4H107.2 V1098.2z M401.9,1098.2h267.9V830.4H401.9V1098.2z M107.2,776.8h241.1V535.7H107.2V776.8z M723.4,1392.9h267.9v-241.1H723.4V1392.9z M401.9,776.8h267.9V535.7H401.9V776.8z M1044.8,1392.9H1286v-241.1h-241.1V1392.9z M723.4,1098.2h267.9V830.4H723.4V1098.2z M428.7,375V133.9c0-7.3-2.7-13.5-8-18.8c-5.3-5.3-11.6-8-18.8-8h-53.6c-7.3,0-13.5,2.7-18.8,8c-5.3,5.3-8,11.6-8,18.8V375 c0,7.3,2.7,13.5,8,18.8c5.3,5.3,11.6,8,18.8,8h53.6c7.3,0,13.5-2.7,18.8-8C426,388.5,428.7,382.3,428.7,375z M1044.8,1098.2H1286 V830.4h-241.1V1098.2z M723.4,776.8h267.9V535.7H723.4V776.8z M1044.8,776.8H1286V535.7h-241.1V776.8z M1071.6,375V133.9 c0-7.3-2.7-13.5-8-18.8c-5.3-5.3-11.6-8-18.8-8h-53.6c-7.3,0-13.5,2.7-18.8,8c-5.3,5.3-8,11.6-8,18.8V375c0,7.3,2.7,13.5,8,18.8 c5.3,5.3,11.6,8,18.8,8h53.6c7.3,0,13.5-2.7,18.8-8C1069,388.5,1071.6,382.3,1071.6,375z M1393.1,321.4v1071.4 c0,29-10.6,54.1-31.8,75.3c-21.2,21.2-46.3,31.8-75.3,31.8H107.2c-29,0-54.1-10.6-75.3-31.8C10.6,1447,0,1421.9,0,1392.9V321.4 c0-29,10.6-54.1,31.8-75.3s46.3-31.8,75.3-31.8h107.2v-80.4c0-36.8,13.1-68.4,39.3-94.6S311.4,0,348.3,0h53.6 c36.8,0,68.4,13.1,94.6,39.3c26.2,26.2,39.3,57.8,39.3,94.6v80.4h321.5v-80.4c0-36.8,13.1-68.4,39.3-94.6 C922.9,13.1,954.4,0,991.3,0h53.6c36.8,0,68.4,13.1,94.6,39.3s39.3,57.8,39.3,94.6v80.4H1286c29,0,54.1,10.6,75.3,31.8 C1382.5,267.3,1393.1,292.4,1393.1,321.4z"/></svg>');
@@ -31,6 +31,10 @@
 
   .amp-date-picker-selecting {
     border-bottom: 2px solid blue;
+  }
+
+  .spacer {
+    margin-bottom: 360px;
   }
   </style>
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
@@ -163,5 +167,19 @@
         </template>
     </div>
 </form>
+
+<h2>date input</h2>
+<p>(recommend against, but compatible)</p>
+<amp-date-picker
+    mode="overlay"
+    type="range"
+    start-input-selector="#start-date"
+    end-input-selector="#end-date"
+>
+  <input type="date" id="start-date">
+  <input type="date" id="end-date">
+</amp-date-picker>
+
+<div class="spacer"></div>
 </body>
 </html>

--- a/extensions/amp-date-picker/0.1/amp-date-picker.css
+++ b/extensions/amp-date-picker/0.1/amp-date-picker.css
@@ -24,14 +24,22 @@ amp-date-picker[mode="overlay"] .i-amphtml-date-picker-container {
   z-index: 10;
 }
 
-amp-date-picker[fullscreen] .i-amphtml-date-picker-container,
-amp-date-picker[with-full-screen-portal],
-amp-date-picker[with-full-screen-portal] .i-amphtml-date-picker-container {
+amp-date-picker[fullscreen] .i-amphtml-date-picker-container {
   position: absolute;
   top: 0;
   right: 0;
   bottom: 0;
   left: 0;
+}
+
+/**
+ * Remove duplicate calendar view in Chrome for overlay pickers.
+ * To avoid being too opinionated about date inputs in general,
+ * publishers who make static date pickers with `input[type="date"]`
+ * can add a rule like this themselves.
+ */
+ amp-date-picker input::-webkit-calendar-picker-indicator {
+  display: none;
 }
 
 .amp-date-picker-calendar-container * {

--- a/extensions/amp-date-picker/0.1/amp-date-picker.js
+++ b/extensions/amp-date-picker/0.1/amp-date-picker.js
@@ -31,7 +31,7 @@ import {createDeferred} from './react-utils';
 import {createSingleDatePicker} from './single-date-picker';
 import {dashToCamelCase} from '../../../src/string';
 import {dev, user} from '../../../src/log';
-import {escapeCssSelectorIdent, isRTL, mapCursor} from '../../../src/dom';
+import {escapeCssSelectorIdent, isRTL, iterateCursor} from '../../../src/dom';
 import {isExperimentOn} from '../../../src/experiments';
 import {map} from '../../../src/utils/object';
 import {requireExternal} from '../../../src/module';
@@ -900,13 +900,24 @@ export class AmpDatePicker extends AMP.BaseElement {
    * @private
    */
   parseElementTemplates_(templates) {
-    return mapCursor(templates, template => {
-      const dates = template.getAttribute('dates').split(DATE_SEPARATOR);
-      return {
-        dates: new DatesList(dates),
-        template,
-      };
-    });
+    const parsed = [];
+    iterateCursor(templates,
+        template => parsed.push(this.parseElementTemplate_(template)));
+    return parsed;
+  }
+
+  /**
+   * Parse a date picker template element.
+   * @param {!Element} template
+   * @return {!DateTemplateMapDef}
+   * @private
+   */
+  parseElementTemplate_(template) {
+    const dates = template.getAttribute('dates').split(DATE_SEPARATOR);
+    return {
+      dates: new DatesList(dates),
+      template,
+    };
   }
 
   /**

--- a/extensions/amp-date-picker/0.1/amp-date-picker.js
+++ b/extensions/amp-date-picker/0.1/amp-date-picker.js
@@ -31,12 +31,11 @@ import {createDeferred} from './react-utils';
 import {createSingleDatePicker} from './single-date-picker';
 import {dashToCamelCase} from '../../../src/string';
 import {dev, user} from '../../../src/log';
-import {escapeCssSelectorIdent, isRTL} from '../../../src/dom';
+import {escapeCssSelectorIdent, isRTL, mapCursor} from '../../../src/dom';
 import {isExperimentOn} from '../../../src/experiments';
 import {map} from '../../../src/utils/object';
 import {requireExternal} from '../../../src/module';
 import {sanitizeFormattingHtml} from '../../../src/sanitizer';
-import {toArray} from '../../../src/types';
 
 
 /**
@@ -169,7 +168,7 @@ const PRIVATE_CALENDAR_CONTAINER_CSS = 'amp-date-picker-calendar-container';
 
 const INFO_TEMPLATE_AREA_CSS = 'i-amphtml-amp-date-picker-info';
 
-class AmpDatePicker extends AMP.BaseElement {
+export class AmpDatePicker extends AMP.BaseElement {
   /** @param {!AmpElement} element */
   constructor(element) {
     super(element);
@@ -177,16 +176,10 @@ class AmpDatePicker extends AMP.BaseElement {
     this.timer_ = Services.timerFor(this.win);
 
     /** @private @const */
-    this.ampdoc_ = Services.ampdoc(this.element);
-
-    /** @private @const */
-    this.win_ = this.ampdoc_.win;
-
-    /** @private @const */
     this.document_ = this.element.ownerDocument;
 
     /** @private @const */
-    this.vsync_ = Services.vsyncFor(this.win_);
+    this.vsync_ = Services.vsyncFor(this.win);
 
     /** @private @const */
     this.moment_ = requireExternal('moment');
@@ -206,11 +199,11 @@ class AmpDatePicker extends AMP.BaseElement {
     /** @private @const */
     this.ReactDatesConstants_ = requireExternal('react-dates/constants');
 
-    /** @private @const */
-    this.action_ = Services.actionServiceForDoc(element);
+    /** @private {?../../../src/service/action-impl.ActionService} */
+    this.action_ = null;
 
     /** @private @const */
-    this.templates_ = Services.templatesFor(this.win_);
+    this.templates_ = Services.templatesFor(this.win);
 
     /** @const */
     this.onDateChange = this.onDateChange.bind(this);
@@ -296,7 +289,8 @@ class AmpDatePicker extends AMP.BaseElement {
 
 
     /** @private @const */
-    this.elementTemplates_ = this.parseElementTemplates_();
+    this.elementTemplates_ = this.parseElementTemplates_(
+        this.element.querySelectorAll('[date-template][dates]'));
 
     /** @private {!Array<!DateTemplateMapDef>} */
     this.srcTemplates_ = [];
@@ -304,8 +298,8 @@ class AmpDatePicker extends AMP.BaseElement {
     /** @private {?Element} */
     this.srcDefaultTemplate_ = null;
 
-    /** @private @const */
-    this.isRTL_ = isRTL(/** @type {!Document} */ (this.ampdoc_.getRootNode()));
+    /** @private {boolean} */
+    this.isRTL_ = false;
 
     /** @private {?function(?):?} */
     this.templateThen_ = null;
@@ -340,8 +334,9 @@ class AmpDatePicker extends AMP.BaseElement {
     this.stateMachine_ = new FiniteStateMachine(initialState);
     this.setupStateMachine_(this.stateMachine_);
 
-    const locale = this.element.getAttribute('locale') || DEFAULT_LOCALE;
-    this.moment_.locale(locale);
+    /** @private @const */
+    this.locale_ = this.element.getAttribute('locale') || DEFAULT_LOCALE;
+    this.moment_.locale(this.locale_);
 
     /** @private @const */
     this.props_ = this.getProps_();
@@ -446,6 +441,9 @@ class AmpDatePicker extends AMP.BaseElement {
     user().assert(isExperimentOn(this.win, TAG),
         `Experiment ${TAG} is disabled.`);
 
+    this.action_ = Services.actionServiceForDoc(this.element);
+
+    this.isRTL_ = isRTL(this.win.document);
 
     this.vsync_.mutate(() => {
       // NOTE(cvializ): There is no standard date format for just the first letter
@@ -598,7 +596,7 @@ class AmpDatePicker extends AMP.BaseElement {
    */
   setupDateField_(type) {
     const fieldSelector = this.element.getAttribute(`${type}-selector`);
-    const existingField = this.ampdoc_.getRootNode().querySelector(
+    const existingField = this.getAmpDoc().getRootNode().querySelector(
         fieldSelector);
     const form = this.element.closest('form');
 
@@ -645,8 +643,8 @@ class AmpDatePicker extends AMP.BaseElement {
    * @private
    */
   setupListeners_() {
-    const root =
-        this.ampdoc_.getRootNode().documentElement || this.ampdoc_.getBody();
+    const ampdoc = this.getAmpDoc();
+    const root = ampdoc.getRootNode().documentElement || ampdoc.getBody();
     // Only add for overlay since click events just handle opening and closing
     if (this.mode_ == DatePickerMode.OVERLAY) {
       this.listen_(root, 'click', this.handleClick_.bind(this));
@@ -821,7 +819,15 @@ class AmpDatePicker extends AMP.BaseElement {
   setupTemplates_() {
     return this.fetchSrcTemplates_()
         .then(json => this.parseSrcTemplates_(json))
-        .then(() => this.templatesReadyResolver_())
+        .then(parsedTemplates => {
+          if (parsedTemplates) {
+            const {srcTemplates, srcDefaultTemplate} = parsedTemplates;
+            this.srcTemplates_ = srcTemplates;
+            this.srcDefaultTemplate_ = srcDefaultTemplate;
+          }
+
+          this.templatesReadyResolver_();
+        })
         .catch(error => {
           user().error(TAG, 'Failed fetching date src data', error);
         });
@@ -834,35 +840,38 @@ class AmpDatePicker extends AMP.BaseElement {
    */
   fetchSrcTemplates_() {
     return this.element.getAttribute('src') ?
-      batchFetchJsonFor(this.ampdoc_, this.element) :
+      batchFetchJsonFor(this.getAmpDoc(), this.element) :
       Promise.resolve();
   }
 
   /**
    * Create an array of objects mapping dates to templates.
    * @param {!JsonObject|!Array<JsonObject>} srcJson
+   * @return {?{srcTemplates: !Array<!DateTemplateMapDef>, srcDefaultTemplate: ?Element}}
    * @private
    */
   parseSrcTemplates_(srcJson) {
     const templates = srcJson && srcJson['templates'];
     if (!templates) {
-      return;
+      return null;
     }
-
+    const ampdoc = this.getAmpDoc();
     const srcTemplates = templates
         .filter(t => t.dates)
         .map(t => ({
           dates: new DatesList(t.dates),
-          template: this.ampdoc_.getRootNode().querySelector(
+          template: ampdoc.getRootNode().querySelector(
               `#${escapeCssSelectorIdent(t.id)}[date-template]`),
         }));
 
-    const defaultTemplate = templates
+    const srcDefaultTemplate = templates
         .filter(t => t.dates == null)
-        .map(t => this.ampdoc_.getElementById(t.id))[0];
+        .map(t => ampdoc.getElementById(t.id))[0];
 
-    this.srcTemplates_ = srcTemplates;
-    this.srcDefaultTemplate_ = defaultTemplate;
+    return {
+      srcTemplates,
+      srcDefaultTemplate,
+    };
   }
 
   /**
@@ -886,14 +895,12 @@ class AmpDatePicker extends AMP.BaseElement {
   /**
    * Iterate over template element children and map their IDs
    * to a list of dates
+   * @param {!NodeList<!Element>} templates
    * @return {!Array<!DateTemplateMapDef>}
    * @private
    */
-  parseElementTemplates_() {
-    const templates = toArray(
-        this.element.querySelectorAll('[date-template][dates]'));
-
-    return templates.map(template => {
+  parseElementTemplates_(templates) {
+    return mapCursor(templates, template => {
       const dates = template.getAttribute('dates').split(DATE_SEPARATOR);
       return {
         dates: new DatesList(dates),
@@ -1033,7 +1040,7 @@ class AmpDatePicker extends AMP.BaseElement {
    * @private
    */
   triggerEvent_(name, opt_data = null) {
-    const event = createCustomEvent(this.win_, `${TAG}.${name}`, opt_data);
+    const event = createCustomEvent(this.win, `${TAG}.${name}`, opt_data);
     this.action_.trigger(this.element, name, event, ActionTrust.HIGH);
   }
 
@@ -1070,14 +1077,18 @@ class AmpDatePicker extends AMP.BaseElement {
   }
 
   /**
-   * Assign the provided date value to the given input
+   * Assign the provided date value to the given input.
+   * input[type="date"] expects YYYY-MM-DD for setting its value,
+   * so it is special-cased here.
    * @param {?Element} field An input field
    * @param {?moment} date A date value
    * @private
    */
   updateDateField_(field, date) {
     if (field) {
-      field.value = this.getFormattedDate_(date);
+      field.value = (field.type == 'date' ?
+        this.getFormattedDate_(date, DEFAULT_FORMAT, DEFAULT_LOCALE) :
+        this.getFormattedDate_(date));
     }
   }
 
@@ -1148,17 +1159,20 @@ class AmpDatePicker extends AMP.BaseElement {
   /**
    * Formats a date in the page's locale and the element's configured format.
    * @param {?moment} date
+   * @param {string=} opt_format
+   * @param {string=} opt_locale
    * @return {string}
    * @private
    */
-  getFormattedDate_(date) {
+  getFormattedDate_(date, opt_format, opt_locale) {
     if (!date) {
       return '';
     }
-
-    const isUnixTimestamp = this.format_.match(/[Xx]/);
-    return (isUnixTimestamp ? date.clone().locale(DEFAULT_LOCALE) : date)
-        .format(this.format_);
+    const format = opt_format || this.format_;
+    const isUnixTimestamp = format.match(/[Xx]/);
+    const locale =
+        isUnixTimestamp ? DEFAULT_LOCALE : (opt_locale || this.locale_);
+    return date.clone().locale(locale).format(format);
   }
 
   /**
@@ -1358,7 +1372,7 @@ class AmpDatePicker extends AMP.BaseElement {
       });
     } else {
       const renderedEvent = createCustomEvent(
-          this.win_,
+          this.win,
           AmpEvents.DOM_UPDATE,
           /* detail */ null,
           {bubbles: true});

--- a/extensions/amp-date-picker/0.1/constants.js
+++ b/extensions/amp-date-picker/0.1/constants.js
@@ -16,6 +16,10 @@
 
 export const DEFAULT_LOCALE = 'en';
 
+/**
+ * Standard ISO 8601 date format. https://xkcd.com/1179/
+ * Matches what input[type="date"] expects for setting the value property.
+ */
 export const DEFAULT_FORMAT = 'YYYY-MM-DD';
 
 export const FORMAT_STRINGS = [

--- a/extensions/amp-date-picker/0.1/test/test-amp-date-picker.js
+++ b/extensions/amp-date-picker/0.1/test/test-amp-date-picker.js
@@ -111,21 +111,21 @@ describes.realWin('amp-date-picker', {
   describe('getFormattedDate_', () => {
     it('should render dates in the default format', () => {
       const {picker} = createDatePicker({locale: 'en'});
-      const date = moment('2018-01-01');
+      const date = moment('2018-01-01 08Z');
       const formattedDate = picker.getFormattedDate_(date);
       expect(formattedDate).to.equal('2018-01-01');
     });
 
     it('should always render Unix epoch seconds in english digits', () => {
       const {picker} = createDatePicker({locale: 'en', format: 'X'});
-      const date = moment('2018-01-01');
+      const date = moment('2018-01-01 08Z');
       const formattedDate = picker.getFormattedDate_(date);
       expect(formattedDate).to.equal('1514793600');
     });
 
     it('should always render Unix epoch millis in english digits', () => {
       const {picker} = createDatePicker({locale: 'en', format: 'x'});
-      const date = moment('2018-01-01');
+      const date = moment('2018-01-01 08Z');
       const formattedDate = picker.getFormattedDate_(date);
       expect(formattedDate).to.equal('1514793600000');
     });

--- a/extensions/amp-date-picker/0.1/test/test-amp-date-picker.js
+++ b/extensions/amp-date-picker/0.1/test/test-amp-date-picker.js
@@ -1,0 +1,171 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import '../../../../third_party/react-dates/bundle';
+import {AmpDatePicker} from '../amp-date-picker';
+import {requireExternal} from '../../../../src/module';
+import {toggleExperiment} from '../../../../src/experiments';
+
+describes.realWin('amp-date-picker', {
+  amp: {
+    runtimeOn: true,
+    extensions: ['amp-date-picker'],
+  },
+}, env => {
+  const moment = requireExternal('moment');
+  let win;
+  let document;
+
+  const templateJson = `{
+    "templates": [{
+      "id": "srcTemplate",
+      "dates": [
+        "2018-01-01",
+        "FREQ=WEEKLY;DTSTART=20180101T080000Z;WKST=SU;BYDAY=WE"
+      ]
+    }, {
+      "id": "defaultTemplate"
+    }]
+  }`;
+
+  const DEFAULT_ATTRS = {
+    layout: 'fixed-height',
+    height: '360',
+  };
+
+  function createDatePicker(opt_attrs) {
+    const element = document.createElement('amp-date-picker');
+    const attrs = Object.assign({}, DEFAULT_ATTRS, opt_attrs);
+    for (const key in attrs) {
+      element.setAttribute(key, attrs[key]);
+    }
+
+    document.body.appendChild(element);
+    const picker = new AmpDatePicker(element);
+
+    return {
+      element,
+      picker,
+    };
+  }
+
+  /**
+   * Create a template element
+   * @param {string} body
+   */
+  function createTemplate(body) {
+    const template = document.createElement('template');
+    template.setAttribute('type', 'amp-mustache');
+    template.content.appendChild(document.createTextNode(body));
+    return template;
+  }
+
+  const DEFAULT_TEMPLATE_ATTRS = {
+    'date-template': '',
+  };
+
+  /**
+   * Create a template from a body and attributes
+   * @param {string} body
+   * @param {!Object<string, string>=} opt_attrs
+   */
+  function createDateTemplate(body, opt_attrs) {
+    const template = createTemplate(body);
+    const attrs = Object.assign({}, DEFAULT_TEMPLATE_ATTRS, opt_attrs);
+    for (const key in attrs) {
+      template.setAttribute(key, attrs[key]);
+    }
+    return template;
+  }
+
+  beforeEach(() => {
+    win = env.win;
+    document = env.win.document;
+    toggleExperiment(win, 'amp-date-picker', true);
+  });
+
+  it('should render in the simplest case', () => {
+    const {picker} = createDatePicker({
+      layout: 'fixed-height',
+      height: 360,
+    });
+
+    return picker.layoutCallback().then(() => {
+      const container = picker.container_;
+      expect(container.children.length).to.be.greaterThan(0);
+    });
+  });
+
+  describe('getFormattedDate_', () => {
+    it('should render dates in the default format', () => {
+      const {picker} = createDatePicker({locale: 'en'});
+      const date = moment('2018-01-01');
+      const formattedDate = picker.getFormattedDate_(date);
+      expect(formattedDate).to.equal('2018-01-01');
+    });
+
+    it('should always render Unix epoch seconds in english digits', () => {
+      const {picker} = createDatePicker({locale: 'en', format: 'X'});
+      const date = moment('2018-01-01');
+      const formattedDate = picker.getFormattedDate_(date);
+      expect(formattedDate).to.equal('1514793600');
+    });
+
+    it('should always render Unix epoch millis in english digits', () => {
+      const {picker} = createDatePicker({locale: 'en', format: 'x'});
+      const date = moment('2018-01-01');
+      const formattedDate = picker.getFormattedDate_(date);
+      expect(formattedDate).to.equal('1514793600000');
+    });
+  });
+
+  describe('templates', () => {
+    describe('element templates', () => {
+      it('should parse RRULE and date templates', () => {
+        const template = createDateTemplate('{{template}}', {
+          dates: '2018-01-01',
+        });
+        const {picker} = createDatePicker();
+        const results = picker.parseElementTemplates_([template]);
+        expect(results[0].dates.contains('2018-01-01')).to.be.true;
+        expect(results[0].dates.contains('2018-01-02')).to.be.false;
+        expect(results[0].template).to.equal(template);
+      });
+    });
+
+    describe('src templates', () => {
+      it('should parse RRULE and date templates', () => {
+        const template = createDateTemplate('{{val}}', {
+          dates: '2018-01-01',
+          id: 'srcTemplate',
+        });
+        const defaultTemplate = createDateTemplate('{{val}}', {
+          id: 'defaultTemplate',
+        });
+        const {picker, element} = createDatePicker();
+        element.appendChild(template);
+        element.appendChild(defaultTemplate);
+
+        const {srcTemplates, srcDefaultTemplate} =
+            picker.parseSrcTemplates_(win.JSON.parse(templateJson));
+        expect(srcTemplates[0].dates.contains('2018-01-01')).to.be.true;
+        expect(srcTemplates[0].dates.contains('2018-01-02')).to.be.false;
+        expect(srcTemplates[0].dates.contains('2018-01-03')).to.be.true;
+        expect(srcTemplates[0].template).to.equal(template);
+        expect(srcDefaultTemplate).to.equal(defaultTemplate);
+      });
+    });
+  });
+});

--- a/src/dom.js
+++ b/src/dom.js
@@ -649,6 +649,24 @@ export function iterateCursor(iterable, cb) {
 }
 
 /**
+ * Map over an array-like. This uses a similar approact as `iterateCursor`.
+ * However it also pre-allocates the Array to eke out slightly more performance.
+ * Test cases: http://jsbench.github.io/#1f0f0ac3a7c49d483a1009d3473788fe
+ * @param {!IArrayLike<T>} iterable
+ * @param {function(T, number)} cb
+ * @param {number=} opt_size
+ * @template T
+ */
+export function mapCursor(iterable, cb, opt_size = 100) {
+  const array = new Array(opt_size);
+  for (let i = 0, value; (value = iterable[i]) !== undefined; i++) {
+    array[i] = cb(value, i);
+  }
+  array.length = iterable.length;
+  return array;
+}
+
+/**
  * This method wraps around window's open method. It first tries to execute
  * `open` call with the provided target and if it fails, it retries the call
  * with the `_top` target. This is necessary given that in some embedding

--- a/src/dom.js
+++ b/src/dom.js
@@ -649,24 +649,6 @@ export function iterateCursor(iterable, cb) {
 }
 
 /**
- * Map over an array-like. This uses a similar approact as `iterateCursor`.
- * However it also pre-allocates the Array to eke out slightly more performance.
- * Test cases: http://jsbench.github.io/#1f0f0ac3a7c49d483a1009d3473788fe
- * @param {!IArrayLike<T>} iterable
- * @param {function(T, number)} cb
- * @param {number=} opt_size
- * @template T
- */
-export function mapCursor(iterable, cb, opt_size = 100) {
-  const array = new Array(opt_size);
-  for (let i = 0, value; (value = iterable[i]) !== undefined; i++) {
-    array[i] = cb(value, i);
-  }
-  array.length = iterable.length;
-  return array;
-}
-
-/**
  * This method wraps around window's open method. It first tries to execute
  * `open` call with the provided target and if it fails, it retries the call
  * with the `_top` target. This is necessary given that in some embedding


### PR DESCRIPTION
First round of tests for the `AmpDatePicker` class. Make the `type="date"` input behave correctly since it needs its value property set as 'YYYY-MM-DD'.