### PR TITLE
✨ Document-level infinite-scroll (#12945): Adds support for a separator that is attached in-between pages.

### DIFF
--- a/examples/amp-document-recommendations.amp.html
+++ b/examples/amp-document-recommendations.amp.html
@@ -105,6 +105,9 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean vitae libero por
 Donec vehicula nisi eget metus blandit, at semper nunc porttitor. Vestibulum sit amet posuere risus, at mattis nibh. Maecenas ultricies scelerisque nibh et feugiat. Praesent mattis, nibh viverra consequat rhoncus, turpis leo venenatis orci, vitae mollis libero magna eget massa. In dapibus, metus sit amet venenatis finibus, lacus metus rhoncus massa, sit amet mattis tortor massa vitae nunc. Mauris a enim sagittis, condimentum tortor vitae, egestas nulla. Ut dictum laoreet sapien non blandit. Etiam fermentum, magna et tincidunt maximus, ex orci sollicitudin felis, ut dapibus  orci ipsum quis leo. Nam accumsan tortor sit amet orci gravida, eget dapibus metus dapibus. Fusce congue ultrices dignissim. Duis quis metus in mi pharetra tempus. Etiam dapibus tellus vitae blandit rhoncus. Fusce commodo risus id sapien ultrices vehicula.
 </p>
   <amp-document-recommendations>
+    <div separator>
+        READ ANOTHER ARTICLE FROM OUR SITE!
+    </div>
     <script type='application/json'>
       {
         "recommendations": [

--- a/extensions/amp-document-recommendations/0.1/amp-document-recommendations.css
+++ b/extensions/amp-document-recommendations/0.1/amp-document-recommendations.css
@@ -31,6 +31,10 @@
   background: #FFFFFF;
 }
 
+.i-amphtml-document-recommendations > *[separator] {
+  display: none;
+}
+
 .i-amphtml-reco-holder-article {
   padding-top: 10px;
   padding-bottom: 10px;

--- a/extensions/amp-document-recommendations/0.1/amp-document-recommendations.js
+++ b/extensions/amp-document-recommendations/0.1/amp-document-recommendations.js
@@ -98,7 +98,7 @@ export class AmpDocumentRecommendations extends AMP.BaseElement {
     this.positionObserver_ = getServiceForDoc(ampDoc, 'position-observer');
 
     /** @private @const {!Array<!DocumentRef>} */
-    this.documentRef_ = [{
+    this.documentRefs_ = [{
       ampUrl: this.win.document.location.href,
       amp: {title: this.win.document.title},
     }];
@@ -241,10 +241,10 @@ export class AmpDocumentRecommendations extends AMP.BaseElement {
 
     const scriptElements = childElementsByTag(this.element, 'SCRIPT');
     user().assert(scriptElements.length == 1,
-        'The tag should contain only one <script> child.');
+        `${TAG} should contain only one <script> child.`);
     const scriptElement = scriptElements[0];
     user().assert(isJsonScriptTag(scriptElement),
-        'The amp-document-recommendations config should ' +
+        `${TAG} config should ` +
             'be inside a <script> tag with type="application/json"');
     const configJson = tryParseJson(scriptElement.textContent, error => {
       throw user().createError(
@@ -257,7 +257,7 @@ export class AmpDocumentRecommendations extends AMP.BaseElement {
 
     const separatorElements = childElementsByAttr(this.element, 'separator');
     user().assert(separatorElements.length <= 1,
-        'The tag should contain at most one <div separator> child.');
+        `${TAG} should contain at most one <div separator> child`);
 
     if (separatorElements.length == 1) {
       this.separator_ = separatorElements[0];

--- a/extensions/amp-document-recommendations/0.1/amp-document-recommendations.js
+++ b/extensions/amp-document-recommendations/0.1/amp-document-recommendations.js
@@ -126,12 +126,6 @@ export class AmpDocumentRecommendations extends AMP.BaseElement {
   appendNextArticle_() {
     if (this.nextArticle_ < MAX_ARTICLES &&
         this.nextArticle_ < this.config_.recommendations.length) {
-      if (this.separator_) {
-        const separatorClone = this.separator_.cloneNode(true);
-        separatorClone.removeAttribute('separator');
-        this.element.appendChild(separatorClone);
-      }
-
       const next = this.config_.recommendations[this.nextArticle_];
       const documentRef = {ampUrl: next.ampUrl, amp: null};
       this.documentRefs_.push(documentRef);
@@ -208,6 +202,12 @@ export class AmpDocumentRecommendations extends AMP.BaseElement {
           try {
             amp =
                 this.multidocManager_.attachShadowDoc(shadowRoot, doc, '', {});
+
+            if (this.separator_) {
+              const separatorClone = this.separator_.cloneNode(true);
+              separatorClone.removeAttribute('separator');
+              this.element.appendChild(separatorClone);
+            }
 
             this.element.appendChild(shadowRoot);
             this.element.appendChild(this.createDivider_());

--- a/extensions/amp-document-recommendations/validator-amp-document-recommendations.protoascii
+++ b/extensions/amp-document-recommendations/validator-amp-document-recommendations.protoascii
@@ -36,6 +36,15 @@ tags: {  # amp-document-recommendations: json config
   }
   spec_url: "https://www.ampproject.org/docs/reference/components/amp-document-recommendations"
 }
+tags: {
+  tag_name: "DIV"
+  spec_name: "AMP-DOCUMENT-RECOMMENDATIONS > DIV [separator]"
+  mandatory_parent: "AMP-DOCUMENT-RECOMMENDATIONS"
+  attrs: {
+    name: "separator"
+    mandatory: true
+  }
+}
 tags: {  # <amp-document-recommendations>
   html_format: AMP
   tag_name: "AMP-DOCUMENT-RECOMMENDATIONS"


### PR DESCRIPTION
Implements support for separator elements in between pages.

Publishers can define an element (add, title, etc) that can be added between elements.

Future changes could use a template for image and title, but expected use case is styling or ads, so not yet a requirement.

@peterjosling 
