### PR TITLE
<amp-facebook> Bug fix for video always showing caption

### DIFF
--- a/3p/facebook.js
+++ b/3p/facebook.js
@@ -56,8 +56,7 @@ function getPostContainer(global, data) {
   // If the user hasn't set the `data-embed-as` attribute and the provided href
   // is a video, Force the `data-embed-as` attribute to 'video' and make sure
   // to show the post's text.
-  if (data.href.match(/\/videos\/\d+\/?$/) &&
-    !container.hasAttribute('data-embed-as')) {
+  if (data.href.match(/\/videos\/\d+\/?$/) && !data.embedAs) {
     embedAs = 'video';
     container.setAttribute('data-embed-as', 'video');
     // Since 'data-embed-as="video"' disables post text, setting the 'data-show-text'

--- a/extensions/amp-facebook/0.1/test/test-amp-facebook.js
+++ b/extensions/amp-facebook/0.1/test/test-amp-facebook.js
@@ -147,6 +147,44 @@ describes.realWin('amp-facebook', {
     expect(fbVideo.getAttribute('data-show-text')).to.equal('true');
   });
 
+  it('retains fb-video element with `data-embed-as=\'video\'`', () => {
+    const div = doc.createElement('div');
+    div.setAttribute('id', 'c');
+    doc.body.appendChild(div);
+    win.context = {
+      tagName: 'AMP-FACEBOOK',
+    };
+
+    facebook(win, {
+      embedAs: 'video',
+      href: fbVideoHref,
+      width: 111,
+      height: 222,
+    });
+    const fbVideo = doc.body.getElementsByClassName('fb-video')[0];
+    expect(fbVideo).not.to.be.undefined;
+    expect(fbVideo.classList.contains('fb-video')).to.be.true;
+  });
+
+  it('retains fb-video element with `data-embed-as=\'post\'`', () => {
+    const div = doc.createElement('div');
+    div.setAttribute('id', 'c');
+    doc.body.appendChild(div);
+    win.context = {
+      tagName: 'AMP-FACEBOOK',
+    };
+
+    facebook(win, {
+      embedAs: 'post',
+      href: fbVideoHref,
+      width: 111,
+      height: 222,
+    });
+    const fbVideo = doc.body.getElementsByClassName('fb-post')[0];
+    expect(fbVideo).not.to.be.undefined;
+    expect(fbVideo.classList.contains('fb-post')).to.be.true;
+  });
+
   it('check that fb-page element correctly sets `data-adapt-container-width` ' +
     'attribute to \'true\'', () => {
     const div = doc.createElement('div');

--- a/extensions/amp-facebook/amp-facebook.md
+++ b/extensions/amp-facebook/amp-facebook.md
@@ -84,7 +84,7 @@ The URL of the Facebook post/video. For example, `https://www.facebook.com/zuck/
 
 The value is either `post` or `video`.  The default is `post`.
 
-Both posts and videos can be embedded as a post. Setting `data-embed-as="video"` for Facebook videos only embeds the player of the video, and ignores the accompanying post card with it. This is recommended if you'd like a better aspect ratio management for the video to be responsive.  
+Both posts and videos can be embedded as a post. Setting `data-embed-as="video"` for Facebook videos embeds the player of the video, and adds the accompanying post card with it. Setting `data-embed-as="post"` ignores the caption card. This is done to make sure we are zooming in on videos correctly.
 
 Check out the documentation for differences between [post embeds](https://developers.facebook.com/docs/plugins/embedded-posts) and [video embeds](https://developers.facebook.com/docs/plugins/embedded-video-player).
 


### PR DESCRIPTION
This fixes #13478

The issue was due to the fact that I was accessing `container.hasAttribute('data-embed-as')` which hasn't been set yet. Needed to use `data.embedAs` instead. 

Added tests to check this behaviour. And added explanation for why the original change was made in the markdown. 

Will also follow up with a ABE comment in the relevant repo.