### PR TITLE
Upstream more validator changes.

### DIFF
--- a/extensions/amp-bind/validator-amp-bind.protoascii
+++ b/extensions/amp-bind/validator-amp-bind.protoascii
@@ -45,6 +45,8 @@ tags: {  # <amp-state> (json)
     dispatch_key: NAME_VALUE_PARENT_DISPATCH
   }
   cdata: {
+    max_bytes: 100000
+    max_bytes_spec_url: "https://www.ampproject.org/docs/reference/components/dynamic/amp-bind#state"
     blacklisted_cdata_regex: {
       regex: "<!--"
       error_message: "html comments"

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -4504,7 +4504,7 @@ attr_lists: {
   # https://www.ampproject.org/docs/reference/components/amp-fx-collection
   attrs: {
     name: "amp-fx"
-    value_casei: "parallax"
+    value_regex_casei: "(fade-in|parallax)"
     requires_extension: "amp-fx-collection"
   }
   # amp-subscriptions specific attributes, see

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -26,7 +26,7 @@ min_validator_revision_required: 322
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 599
+spec_file_revision: 600
 
 styles_spec_url: "https://www.ampproject.org/docs/guides/author-develop/responsive/style_pages"
 script_spec_url: "https://www.ampproject.org/docs/reference/spec#html-tags"
@@ -4504,7 +4504,7 @@ attr_lists: {
   # https://www.ampproject.org/docs/reference/components/amp-fx-collection
   attrs: {
     name: "amp-fx"
-    value_regex_casei: "(fade-in|parallax)"
+    value_casei: "parallax"
     requires_extension: "amp-fx-collection"
   }
   # amp-subscriptions specific attributes, see


### PR DESCRIPTION
Limit the size of the amp-bind state to 100000 bytes.