### PR TITLE
✨Disallow sync XHR in ad iframes.

### DIFF
--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -1369,6 +1369,12 @@ export class AmpA4A extends AMP.BaseElement {
             'allowtransparency': '',
             'scrolling': 'no',
           })));
+    if (isExperimentOn(parentWindow, 'no-sync-xhr-in-ads')) {
+      // Block synchronous XHR in ad. These are very rare, but super bad for UX
+      // as they block the UI thread for the arbitrary amount of time until the
+      // request completes.
+      iframe.setAttribute('allow', 'sync-xhr \'none\';');
+    }
     this.applyFillContent(this.iframe);
     const fontsArray = [];
     if (creativeMetaData.customStylesheets) {

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -53,6 +53,7 @@ import {
 } from '../../../src/service/url-replacements-impl';
 import {isAdPositionAllowed} from '../../../src/ad-helper';
 import {isArray, isEnumValue, isObject} from '../../../src/types';
+import {isExperimentOn} from '../../../src/experiments';
 import {parseJson} from '../../../src/json';
 import {setStyle} from '../../../src/style';
 import {signingServerURLs} from '../../../ads/_a4a-config';
@@ -1369,12 +1370,6 @@ export class AmpA4A extends AMP.BaseElement {
             'allowtransparency': '',
             'scrolling': 'no',
           })));
-    if (isExperimentOn(parentWindow, 'no-sync-xhr-in-ads')) {
-      // Block synchronous XHR in ad. These are very rare, but super bad for UX
-      // as they block the UI thread for the arbitrary amount of time until the
-      // request completes.
-      iframe.setAttribute('allow', 'sync-xhr \'none\';');
-    }
     this.applyFillContent(this.iframe);
     const fontsArray = [];
     if (creativeMetaData.customStylesheets) {
@@ -1449,6 +1444,12 @@ export class AmpA4A extends AMP.BaseElement {
     }
     if (this.shouldSandbox_) {
       mergedAttributes['sandbox'] = IFRAME_SANDBOXING_FLAGS;
+    }
+    if (isExperimentOn(this.win, 'no-sync-xhr-in-ads')) {
+      // Block synchronous XHR in ad. These are very rare, but super bad for UX
+      // as they block the UI thread for the arbitrary amount of time until the
+      // request completes.
+      mergedAttributes['allow'] = 'sync-xhr \'none\';';
     }
     this.iframe = createElementWithAttributes(
         /** @type {!Document} */ (this.element.ownerDocument),

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -58,6 +58,7 @@ import {data as testFragments} from './testdata/test_fragments';
 import {
   data as validCSSAmp,
 } from './testdata/valid_css_at_rules_amp.reserialized';
+import {toggleExperiment} from '../../../../src/experiments';
 
 describe('amp-a4a', () => {
   let sandbox;
@@ -608,6 +609,25 @@ describe('amp-a4a', () => {
           verifyCachedContentIframeRender(a4aElement, TEST_URL,
               false /* shouldSandbox */);
           expect(fetchMock.called('ad')).to.be.true;
+        });
+      });
+
+      it('shouldn\'t set feature policy for sync-xhr with exp off-a4a', () => {
+        adResponse.headers[SANDBOX_HEADER] = 'true';
+        a4a.onLayoutMeasure();
+        return a4a.layoutCallback().then(() => {
+          verifyCachedContentIframeRender(a4aElement, TEST_URL, true);
+          expect(a4a.iframe.getAttribute('allow')).to.not.match(/sync-xhr/);
+        });
+      });
+
+      it('should set feature policy for sync-xhr with exp on-a4a', () => {
+        adResponse.headers[SANDBOX_HEADER] = 'true';
+        toggleExperiment(a4a.win, 'no-sync-xhr-in-ads', true);
+        a4a.onLayoutMeasure();
+        return a4a.layoutCallback().then(() => {
+          verifyCachedContentIframeRender(a4aElement, TEST_URL, true);
+          expect(a4a.iframe.getAttribute('allow')).to.equal('sync-xhr \'none\';');
         });
       });
     });

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -55,10 +55,10 @@ import {
   resetScheduledElementForTesting,
 } from '../../../../src/service/custom-element-registry';
 import {data as testFragments} from './testdata/test_fragments';
+import {toggleExperiment} from '../../../../src/experiments';
 import {
   data as validCSSAmp,
 } from './testdata/valid_css_at_rules_amp.reserialized';
-import {toggleExperiment} from '../../../../src/experiments';
 
 describe('amp-a4a', () => {
   let sandbox;
@@ -627,7 +627,8 @@ describe('amp-a4a', () => {
         a4a.onLayoutMeasure();
         return a4a.layoutCallback().then(() => {
           verifyCachedContentIframeRender(a4aElement, TEST_URL, true);
-          expect(a4a.iframe.getAttribute('allow')).to.equal('sync-xhr \'none\';');
+          expect(a4a.iframe.getAttribute('allow'))
+              .to.equal('sync-xhr \'none\';');
         });
       });
     });

--- a/src/3p-frame.js
+++ b/src/3p-frame.js
@@ -128,7 +128,6 @@ export function getIframe(
     // request completes.
     iframe.setAttribute('allow', 'sync-xhr \'none\';');
   }
-  iframe.setAttribute('allow', 'sync-xhr \'none\';');
   iframe.setAttribute('data-amp-3p-sentinel',
       attributes['_context']['sentinel']);
   return iframe;

--- a/src/3p-frame.js
+++ b/src/3p-frame.js
@@ -19,6 +19,7 @@ import {dev, user} from './log';
 import {dict} from './utils/object';
 import {getContextMetadata} from '../src/iframe-attributes';
 import {getMode} from './mode';
+import {isExperimentOn} from './experiments';
 import {setStyle} from './style';
 import {startsWith} from './string';
 import {tryParseJson} from './json';
@@ -121,6 +122,13 @@ export function getIframe(
     // Chrome does not reflect the iframe readystate.
     this.readyState = 'complete';
   };
+  if (isExperimentOn(parentWindow, 'no-sync-xhr-in-ads')) {
+    // Block synchronous XHR in ad. These are very rare, but super bad for UX
+    // as they block the UI thread for the arbitrary amount of time until the
+    // request completes.
+    iframe.setAttribute('allow', 'sync-xhr \'none\';');
+  }
+  iframe.setAttribute('allow', 'sync-xhr \'none\';');
   iframe.setAttribute('data-amp-3p-sentinel',
       attributes['_context']['sentinel']);
   return iframe;

--- a/test/integration/test-3p-frame.js
+++ b/test/integration/test-3p-frame.js
@@ -272,6 +272,23 @@ describe.configure().ifNewChrome().run('3p-frame', () => {
     expect(iframe.not_whitelisted).to.equal(undefined);
   });
 
+  it('should not set feature policy for sync-xhr with exp off', () => {
+    const div = document.createElement('my-element');
+    setupElementFunctions(div);
+    container.appendChild(div);
+    const iframe = getIframe(window, div, 'none');
+    expect(iframe.getAttribute('allow')).to.equal(null);
+  });
+
+  it('should set feature policy for sync-xhr with exp on', () => {
+    toggleExperiment(window, 'no-sync-xhr-in-ads', true);
+    const div = document.createElement('my-element');
+    setupElementFunctions(div);
+    container.appendChild(div);
+    const iframe = getIframe(window, div, 'none');
+    expect(iframe.getAttribute('allow')).to.equal('sync-xhr \'none\';');
+  });
+
   it('should pick the right bootstrap url for local-dev mode', () => {
     window.AMP_MODE = {localDev: true};
     expect(getBootstrapBaseUrl(window)).to.equal(

--- a/tools/experiments/experiments.js
+++ b/tools/experiments/experiments.js
@@ -277,6 +277,12 @@ const EXPERIMENTS = [
     spec: 'https://github.com/ampproject/amphtml/issues/13716',
   },
   {
+    id: 'no-sync-xhr-in-ads',
+    name: 'Disables syncronous XHR requests in 3p iframes.',
+    spec: 'TODO',
+    cleanupIssue: 'TODO',
+  },
+  {
     id: 'video-service',
     name: 'Enables new implementation of unified Video Interface services.',
     spec: 'https://github.com/ampproject/amphtml/issues/13674',


### PR DESCRIPTION
While these are rare, if they happen they can arbitrarily lock down the UI thread.

The change uses the new [Feature Policy](https://wicg.github.io/feature-policy/) mechanism that is shipped in Chrome.

The idea is to manually test the change in production for a while before considering to flip the flag to on.

JSBin sample of the concept: https://output.jsbin.com/wudihed/1/quiet