### PR TITLE
Fix amp-list dynamic CORS detection

### DIFF
--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -71,8 +71,8 @@ export class AmpList extends AMP.BaseElement {
      */
     this.layoutCompleted_ = false;
 
-    /** @const @private {string} */
-    this.initialSrc_ = element.getAttribute('src');
+    /** @const @private {?string} */
+    this.initialSrc_ = null;
 
     this.registerAction('refresh', () => {
       if (this.layoutCompleted_) {
@@ -88,6 +88,8 @@ export class AmpList extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
+    this.initialSrc_ = this.element.getAttribute('src');
+    
     this.container_ = this.win.document.createElement('div');
     this.applyFillContent(this.container_, true);
     this.element.appendChild(this.container_);

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -88,6 +88,8 @@ export class AmpList extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
+    // Store this in buildCallback() because `this.element` sometimes 
+    // is missing attributes in the constructor.
     this.initialSrc_ = this.element.getAttribute('src');
     
     this.container_ = this.win.document.createElement('div');

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -71,7 +71,10 @@ export class AmpList extends AMP.BaseElement {
      */
     this.layoutCompleted_ = false;
 
-    /** @const @private {?string} */
+    /**
+     * The `src` attribute's initial value.
+     * @private {?string}
+     */
     this.initialSrc_ = null;
 
     this.registerAction('refresh', () => {

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -88,10 +88,10 @@ export class AmpList extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
-    // Store this in buildCallback() because `this.element` sometimes 
+    // Store this in buildCallback() because `this.element` sometimes
     // is missing attributes in the constructor.
     this.initialSrc_ = this.element.getAttribute('src');
-    
+
     this.container_ = this.win.document.createElement('div');
     this.applyFillContent(this.container_, true);
     this.element.appendChild(this.container_);


### PR DESCRIPTION
Surprising result: In testing on prod AMP pages, the `element` param passed into the `BaseElement` constructor sometimes is missing attributes etc. 

Wait until `buildCallback()` to store initial values of attributes instead.