### PR TITLE
🐛Validator: Adding missing "interact-and-submit" strategy regular expressions for custom-validation-reporting on "POST" method amp-forms

### DIFF
--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -3243,7 +3243,7 @@ tags {  # <form method=POST ...>
   attrs: { name: "autocomplete" }
   attrs: {
     name: "custom-validation-reporting"
-    value_regex: "(show-first-on-submit|show-all-on-submit|as-you-go)"
+    value_regex: "(show-first-on-submit|show-all-on-submit|as-you-go|interact-and-submit)"
   }
   attrs: { name: "enctype" }
   attrs: {
@@ -3335,6 +3335,7 @@ tags {  # <form method=POST ...>
   attrs: {
     name: "custom-validation-reporting"
     value_regex: "(as-you-go|"
+        "interact-and-submit|"
         "show-all-on-submit|"
         "show-first-on-submit)"
   }

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -3246,7 +3246,10 @@ tags {  # <form method=POST ...>
   attrs: { name: "autocomplete" }
   attrs: {
     name: "custom-validation-reporting"
-    value_regex: "(as-you-go|interact-and-submit|show-all-on-submit|show-first-on-submit)"
+    value_regex: "(as-you-go|"
+                  "interact-and-submit|"
+                  "show-all-on-submit|"
+                  "show-first-on-submit)"
   }
   attrs: { name: "enctype" }
   attrs: {
@@ -3338,9 +3341,9 @@ tags {  # <form method=POST ...>
   attrs: {
     name: "custom-validation-reporting"
     value_regex: "(as-you-go|"
-        "interact-and-submit|"
-        "show-all-on-submit|"
-        "show-first-on-submit)"
+                  "interact-and-submit|"
+                  "show-all-on-submit|"
+                  "show-first-on-submit)"
   }
   attrs: { name: "enctype" }
   attrs: {

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -3195,7 +3195,10 @@ tags {  # <form method=GET ...>
   attrs: { name: "autocomplete" }
   attrs: {
     name: "custom-validation-reporting"
-    value_regex: "(show-first-on-submit|show-all-on-submit|as-you-go|interact-and-submit)"
+    value_regex: "(as-you-go|"
+                  "interact-and-submit|"
+                  "show-all-on-submit|"
+                  "show-first-on-submit)"
   }
   attrs: { name: "enctype" }
   attrs: {
@@ -3243,7 +3246,7 @@ tags {  # <form method=POST ...>
   attrs: { name: "autocomplete" }
   attrs: {
     name: "custom-validation-reporting"
-    value_regex: "(show-first-on-submit|show-all-on-submit|as-you-go|interact-and-submit)"
+    value_regex: "(as-you-go|interact-and-submit|show-all-on-submit|show-first-on-submit)"
   }
   attrs: { name: "enctype" }
   attrs: {
@@ -3291,9 +3294,9 @@ tags {  # <form method=GET ...>
   attrs: {
     name: "custom-validation-reporting"
     value_regex: "(as-you-go|"
-        "interact-and-submit|"
-        "show-all-on-submit|"
-        "show-first-on-submit)"
+                  "interact-and-submit|"
+                  "show-all-on-submit|"
+                  "show-first-on-submit)"
   }
   attrs: { name: "enctype" }
   attrs: {


### PR DESCRIPTION
This PR fixes a validation issue in which amp-forms that implement both the "method='POST'" attribute and the "custom-validation-reporting='interact-and-submit'" attribute are resulting in amp validation errors.  The implementation of the interact-and-submit strategy is working properly, but the validation error below is being incorrectly produced due to missing "value_regex" strings for some cases of the "custom-validation-reporting" attribute configuration in the file "validator/validator-main.protoascii"

ORIGINAL PULL REQUEST
This PR extends the fix provided by the merged PR as identified by: #10782.  The initial PR fixed the validation issue for GET method forms, but failed to fix the validation issue for POST method forms.

CONSOLE ERROR
`The attribute 'custom-validation-reporting' in tag 'FORM [method=POST]' is set to the invalid value 'interact-and-submit'.`


Fixes: https://github.com/ampproject/amphtml/issues/10773