### PR TITLE
Upgrade fetch-mock to 6.1.0 

### DIFF
--- a/extensions/amp-pinterest/0.1/test/test-amp-pinterest.js
+++ b/extensions/amp-pinterest/0.1/test/test-amp-pinterest.js
@@ -26,7 +26,8 @@ describes.realWin('amp-pinterest', {
 }, env => {
 
   function widgetURL(pinID) {
-    return '^https://widgets.pinterest.com/v3/pidgets/pins/info/?pin_ids=' + pinID;
+    return 'begin:https://widgets.pinterest.com/v3/pidgets/pins/info/?pin_ids='
+        + pinID;
   }
 
   function getPin(pinDo, pinUrl, pinMedia, pinDescription) {

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "esprima": "4.0.0",
     "express": "4.16.2",
     "fancy-log": "1.3.2",
-    "fetch-mock": "5.13.1",
+    "fetch-mock": "6.1.0",
     "formidable": "1.2.0",
     "fs-extra": "5.0.0",
     "greenkeeper-lockfile": "1.14.0",

--- a/testing/describes.js
+++ b/testing/describes.js
@@ -295,7 +295,7 @@ export const repeated = (function() {
  * @see http://www.wheresrhys.co.uk/fetch-mock/quickstart
  */
 function attachFetchMock(env) {
-  fetchMock.constructor.global = env.win;
+  fetchMock.global = env.win;
   fetchMock._mock();
 
   env.fetchMock = fetchMock;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4182,13 +4182,12 @@ fbjs@^0.8.16, fbjs@^0.8.4:
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.9"
 
-fetch-mock@5.13.1:
-  version "5.13.1"
-  resolved "https://registry.yarnpkg.com/fetch-mock/-/fetch-mock-5.13.1.tgz#955794a77f3d972f1644b9ace65a0fdfd60f1df7"
+fetch-mock@6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/fetch-mock/-/fetch-mock-6.1.0.tgz#29a6b15d2b362b286a04b40255b069008c5931b2"
   dependencies:
     glob-to-regexp "^0.3.0"
-    node-fetch "^1.3.3"
-    path-to-regexp "^1.7.0"
+    path-to-regexp "^2.1.0"
 
 figures@^2.0.0:
   version "2.0.0"
@@ -7512,7 +7511,7 @@ node-abi@^2.2.0:
   dependencies:
     semver "^5.4.1"
 
-node-fetch@^1.0.1, node-fetch@^1.3.3:
+node-fetch@^1.0.1:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
   dependencies:
@@ -8176,6 +8175,10 @@ path-to-regexp@^1.7.0:
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
   dependencies:
     isarray "0.0.1"
+
+path-to-regexp@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-2.2.0.tgz#80f0ff45c1e0e641da74df313644eaf115050972"
 
 path-type@^1.0.0:
   version "1.1.0"


### PR DESCRIPTION
- update fetch-mock to 6.1.0 Fixes #13923  
- Fetchmock no longer a function but is an object literal, fix describes.js#attachFetchMock global property assignment.
- update deprecated ^ symbol to denote start of url with 'begin'

e.g. error
IT => no alternate text and no title provided by the Pinterest API
Using '^' to denote the start of a url is deprecated. Use 'begin:' instead...


