### PR TITLE
Only preloads the share menu on mobile.

### DIFF
--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -574,8 +574,13 @@ export class AmpStory extends AMP.BaseElement {
         })
         .then(() => this.switchTo_(initialPageId))
         .then(() => this.preloadPagesByDistance_())
-        // TODO(gmajoulet): only preload the share menu on mobile.
-        .then(() => this.shareMenu_.build());
+        .then(() => {
+          // Preloads and prerenders the share menu if mobile, where the share
+          // button is visible.
+          if (!this.storeService_.get(StateProperty.DESKTOP_STATE)) {
+            this.shareMenu_.build();
+          }
+        });
 
     // Do not block the layout callback on the completion of these promises, as
     // that prevents descendents from being laid out (and therefore loaded).
@@ -1014,6 +1019,10 @@ export class AmpStory extends AMP.BaseElement {
         this.updateBackground_(this.activePage_.element, /* initial */ true);
       }
     } else {
+      // Preloads and prerenders the share menu as the share button gets visible
+      // on the mobile UI. No-op if already built.
+      this.shareMenu_.build();
+
       this.vsync_.mutate(() => {
         this.element.removeAttribute('desktop');
       });

--- a/extensions/amp-story/0.1/test/test-amp-story.js
+++ b/extensions/amp-story/0.1/test/test-amp-story.js
@@ -156,6 +156,32 @@ describes.realWin('amp-story', {
         });
   });
 
+  it('should prerender/load the share menu', () => {
+    createPages(story.element, 1, ['cover']);
+
+    sandbox.stub(story.bookend_, 'build');
+    const buildShareMenuStub = sandbox.stub(story.shareMenu_, 'build');
+
+    return story.layoutCallback()
+        .then(() => {
+          expect(buildShareMenuStub).to.have.been.calledOnce;
+        });
+  });
+
+  it('should not prerender/load the share menu on desktop', () => {
+    createPages(story.element, 1, ['cover']);
+
+    story.storeService_.dispatch(Action.TOGGLE_DESKTOP, true);
+
+    sandbox.stub(story.bookend_, 'build');
+    const buildShareMenuStub = sandbox.stub(story.shareMenu_, 'build');
+
+    return story.layoutCallback()
+        .then(() => {
+          expect(buildShareMenuStub).to.not.have.been.called;
+        });
+  });
+
   // TODO(#11639): Re-enable this test.
   it.skip('should hide bookend when CLOSE_BOOKEND is triggered', () => {
     const hideBookendStub = sandbox.stub(


### PR DESCRIPTION
Only preloads the share menu on mobile, since the button is not visible on desktop.

Partial for #12186