### PR TITLE
✨ A4A: Add new browser capabilities (bc) parameter to ad requests

### DIFF
--- a/ads/google/a4a/test/test-utils.js
+++ b/ads/google/a4a/test/test-utils.js
@@ -439,11 +439,11 @@ describe('Google A4A utils', () => {
       });
     });
 
-    it('should have correct bc value when everything supported', function() {
+    it('should have correct bc value when everything supported', () => {
       return createIframePromise().then(fixture => {
         setupForAdTesting(fixture);
         const doc = fixture.doc;
-        doc.win = window;
+        doc.win = fixture.win;
         const elem = createElementWithAttributes(doc, 'amp-a4a', {
           'type': 'adsense',
           'width': '320',
@@ -459,18 +459,17 @@ describe('Google A4A utils', () => {
           },
         });
         return fixture.addElement(elem).then(() => {
-          return googleAdUrl(impl, '', 0, {}, []).then(url1 => {
-            expect(url1).to.match(/[&?]bc=7[&$]/);
-          });
+          return expect(googleAdUrl(impl, '', 0, {}, [])).to.eventually.match(
+            /[&?]bc=7[&$]/);
         });
       });
     });
 
-    it('should have correct bc value when sandbox not supported', function() {
+    it('should have correct bc value when sandbox not supported', () => {
       return createIframePromise().then(fixture => {
         setupForAdTesting(fixture);
         const doc = fixture.doc;
-        doc.win = window;
+        doc.win = fixture.win;
         const elem = createElementWithAttributes(doc, 'amp-a4a', {
           'type': 'adsense',
           'width': '320',
@@ -481,23 +480,20 @@ describe('Google A4A utils', () => {
         const createElementStub =
           sandbox.stub(impl.win.document, 'createElement');
         createElementStub.withArgs('iframe').returns({
-          sandbox: {
-            supports: undefined,
-          },
+          sandbox: {},
         });
         return fixture.addElement(elem).then(() => {
-          return googleAdUrl(impl, '', 0, {}, []).then(url1 => {
-            expect(url1).to.match(/[&?]bc=1[&$]/);
-          });
+          return expect(googleAdUrl(impl, '', 0, {}, [])).to.eventually.match(
+            /[&?]bc=1[&$]/);
         });
       });
     });
 
-    it('should not include bc when nothing supported', function() {
+    it('should not include bc when nothing supported', () => {
       return createIframePromise().then(fixture => {
         setupForAdTesting(fixture);
         const doc = fixture.doc;
-        doc.win = window;
+        doc.win = fixture.win;
         const elem = createElementWithAttributes(doc, 'amp-a4a', {
           'type': 'adsense',
           'width': '320',
@@ -514,9 +510,9 @@ describe('Google A4A utils', () => {
           },
         });
         return fixture.addElement(elem).then(() => {
-          return googleAdUrl(impl, '', 0, {}, []).then(url1 => {
-            expect(url1).to.not.match(/[&?]bc=/);
-          });
+          return expect(
+            googleAdUrl(impl, '', 0, {}, [])).to.eventually.not.match(
+              /[&?]bc=1[&$]/);
         });
       });
     });

--- a/ads/google/a4a/test/test-utils.js
+++ b/ads/google/a4a/test/test-utils.js
@@ -460,7 +460,7 @@ describe('Google A4A utils', () => {
         });
         return fixture.addElement(elem).then(() => {
           return expect(googleAdUrl(impl, '', 0, {}, [])).to.eventually.match(
-            /[&?]bc=7[&$]/);
+              /[&?]bc=7[&$]/);
         });
       });
     });
@@ -484,7 +484,7 @@ describe('Google A4A utils', () => {
         });
         return fixture.addElement(elem).then(() => {
           return expect(googleAdUrl(impl, '', 0, {}, [])).to.eventually.match(
-            /[&?]bc=1[&$]/);
+              /[&?]bc=1[&$]/);
         });
       });
     });
@@ -511,7 +511,7 @@ describe('Google A4A utils', () => {
         });
         return fixture.addElement(elem).then(() => {
           return expect(
-            googleAdUrl(impl, '', 0, {}, [])).to.eventually.not.match(
+              googleAdUrl(impl, '', 0, {}, [])).to.eventually.not.match(
               /[&?]bc=1[&$]/);
         });
       });

--- a/ads/google/a4a/test/test-utils.js
+++ b/ads/google/a4a/test/test-utils.js
@@ -438,6 +438,33 @@ describe('Google A4A utils', () => {
         });
       });
     });
+
+    it('should include browser capabilities', function() {
+      return createIframePromise().then(fixture => {
+        setupForAdTesting(fixture);
+        const doc = fixture.doc;
+        doc.win = window;
+        const elem = createElementWithAttributes(doc, 'amp-a4a', {
+          'type': 'adsense',
+          'width': '320',
+          'height': '50',
+        });
+        const impl = new MockA4AImpl(elem);
+        noopMethods(impl, doc, sandbox);
+        const createElementStub =
+          sandbox.stub(impl.win.document, 'createElement');
+        createElementStub.withArgs('iframe').returns({
+          sandbox: {
+            supports: () => true,
+          },
+        });
+        return fixture.addElement(elem).then(() => {
+          return googleAdUrl(impl, '', 0, {}, []).then(url1 => {
+            expect(url1).to.match(/[&?]bc=7[&$]/);
+          });
+        });
+      });
+    });
   });
 
   describe('#mergeExperimentIds', () => {

--- a/ads/google/a4a/test/test-utils.js
+++ b/ads/google/a4a/test/test-utils.js
@@ -466,7 +466,7 @@ describe('Google A4A utils', () => {
       });
     });
 
-    it('should not include bc when sandbox not supported', function() {
+    it('should have correct bc value when sandbox not supported', function() {
       return createIframePromise().then(fixture => {
         setupForAdTesting(fixture);
         const doc = fixture.doc;

--- a/ads/google/a4a/utils.js
+++ b/ads/google/a4a/utils.js
@@ -230,7 +230,6 @@ export function googlePageParameters(win, nodeOrDoc, startTime) {
         const visibilityState = Services.viewerForDoc(nodeOrDoc)
             .getVisibilityState();
         const art = getBinaryTypeNumericalCode(getBinaryType(win));
-        const browserCapabilities = getBrowserCapabilitiesBitmap(win);
         return {
           'is_amp': AmpAdImplementation.AMP_AD_XHR_TO_IFRAME_OR_AMP,
           'amp_v': '$internalRuntimeVersion$',
@@ -254,7 +253,7 @@ export function googlePageParameters(win, nodeOrDoc, startTime) {
           'vis': visibilityStateCodes[visibilityState] || '0',
           'scr_x': viewport.getScrollLeft(),
           'scr_y': viewport.getScrollTop(),
-          'bc': browserCapabilities || null,
+          'bc': getBrowserCapabilitiesBitmap(win) || null,
           'debug_experiment_id':
               (/,?deid=(\d+)/i.exec(win.location.hash) || [])[1] || null,
           'url': documentInfo.canonicalUrl,
@@ -853,15 +852,15 @@ function getBrowserCapabilitiesBitmap(win) {
     browserCapabilities |= Capability.SVG_SUPPORTED;
   }
   const iframeEl = doc.createElement('iframe');
-  const supportsSandboxFlag = flagToCheck => iframeEl.sandbox &&
-      iframeEl.sandbox.supports && iframeEl.sandbox.supports(flagToCheck);
-  if (supportsSandboxFlag('allow-top-navigation-by-user-activation')) {
-    browserCapabilities |=
-      Capability.SANDBOXING_ALLOW_TOP_NAVIGATION_BY_USER_ACTIVATION_SUPPORTED;
-  }
-  if (supportsSandboxFlag('allow-popups-to-escape-sandbox')) {
-    browserCapabilities |=
-      Capability.SANDBOXING_ALLOW_POPUPS_TO_ESCAPE_SANDBOX_SUPPORTED;
+  if (iframeEl.sandbox && iframeEl.sandbox.supports) {
+    if (iframeEl.sandbox.supports('allow-top-navigation-by-user-activation')) {
+      browserCapabilities |=
+        Capability.SANDBOXING_ALLOW_TOP_NAVIGATION_BY_USER_ACTIVATION_SUPPORTED;
+    }
+    if (iframeEl.sandbox.supports('allow-popups-to-escape-sandbox')) {
+      browserCapabilities |=
+        Capability.SANDBOXING_ALLOW_POPUPS_TO_ESCAPE_SANDBOX_SUPPORTED;
+    }
   }
   return browserCapabilities;
 }


### PR DESCRIPTION
Adds a new parameter to A4A ad requests, which is a bitvector of supported browser features. This helps identify ad requests which are eligible for sandboxing.

