### PR TITLE
Fix Travis 😅

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -808,7 +808,7 @@ function performBuild(watch) {
  */
 function checkBinarySize(compiled) {
   const file = compiled ? './dist/v0.js' : './dist/amp.js';
-  const size = compiled ? '76.49KB' : '333.27KB';
+  const size = compiled ? '76.5KB' : '333.28KB';
   const cmd = `npx bundlesize -f "${file}" -s "${size}"`;
   log(green('Running ') + cyan(cmd) + green('...\n'));
   const p = exec(cmd);


### PR DESCRIPTION
Add small buffer to current size cap to fix failure on master due to #14224. 

My guess is it passed on the PR build and local build because it was missing a few PRs merged today that might've added a few bytes here and there.

Separately, perhaps we shouldn't be running `bundlesize` against the unminified `amp.js` on Travis.

/to @rsimha @danielrozenberg 