### PR TITLE
✨ AdSense Ads: add support for specifying package code

### DIFF
--- a/ads/google/adsense.js
+++ b/ads/google/adsense.js
@@ -29,7 +29,7 @@ export function adsense(global, data) {
   // TODO: check mandatory fields
   validateData(data, [],
       ['adClient', 'adSlot', 'adHost', 'adtest', 'tagOrigin', 'experimentId',
-        'ampSlotIndex', 'adChannel', 'autoFormat', 'fullWidth']);
+        'ampSlotIndex', 'adChannel', 'autoFormat', 'fullWidth', 'package']);
 
   if (data['autoFormat'] == 'rspv') {
     user().assert(data.hasOwnProperty('fullWidth'),
@@ -53,7 +53,8 @@ export function adsense(global, data) {
   global.document.body.appendChild(s);
 
   const i = global.document.createElement('ins');
-  ['adChannel', 'adClient', 'adSlot', 'adHost', 'adtest', 'tagOrigin']
+  ['adChannel', 'adClient', 'adSlot', 'adHost', 'adtest', 'tagOrigin',
+    'package']
       .forEach(datum => {
         if (data[datum]) {
           i.setAttribute('data-' + camelCaseToDash(datum), data[datum]);

--- a/ads/google/test/test-adsense.js
+++ b/ads/google/test/test-adsense.js
@@ -28,6 +28,7 @@ describes.realWin('adsenseDelayedFetch', {}, env => {
     'adHost': 'data-ad-host',
     'adtest': 'data-adtest',
     'tagOrigin': 'data-tag-origin',
+    'package': 'data-package',
   };
 
   beforeEach(() => {


### PR DESCRIPTION
Add support for data-package attribute to AdSense delayed fetch <amp-ad> element. This is required for integration between <amp-auto-ads> and <amp-ad> to which of the packages that publisher created in AdSense frontend was used to create ads.

See similar change for fast fetch: https://github.com/ampproject/amphtml/pull/14395