### PR TITLE
✨ Doubleclick Fast Fetch: Add referrer macro

### DIFF
--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -700,6 +700,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     return {
       PAGEVIEWID: () => Services.documentInfoForDoc(this.element).pageViewId,
       HREF: () => this.win.location.href,
+      REFERRER: () => this.win.document.referrer,
       TGT: () =>
         JSON.stringify(
             (tryParseJson(

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -719,24 +719,24 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
         Services.documentInfoForDoc(this.element).canonicalUrl,
     };
   }
-  
+
   /**
    * Returns the referrer or undefined if the referrer is not resolved
    * before the given timeout
    * @param {number=} opt_timeout
-   * @return {!Promise<string|undefined>} A promise for a referrer or undefined 
+   * @return {!Promise<string|undefined>} A promise for a referrer or undefined
    * @private
    */
   getReferrer_(opt_timeout) {
     const timeoutInt = parseInt(opt_timeout, 10);
-    const refererPromise = Services.viewerForDoc(this.getAmpDoc())
-      .getReferrerUrl();
-    if (opt_timeout == null || isNaN(opt_timeout) || opt_timeout < 0) {
-      return refererPromise;
+    const referrerPromise = Services.viewerForDoc(this.getAmpDoc())
+        .getReferrerUrl();
+    if (isNaN(timeoutInt) || timeoutInt < 0) {
+      return referrerPromise;
     }
     return Services.timerFor(this.win)
-      .timeoutPromise(opt_timeout, refererPromise)
-      .catch(() => undefined);
+        .timeoutPromise(timeoutInt, referrerPromise)
+        .catch(() => undefined);
   }
 
   /**

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -700,7 +700,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     return {
       PAGEVIEWID: () => Services.documentInfoForDoc(this.element).pageViewId,
       HREF: () => this.win.location.href,
-      REFERRER: () => this.win.document.referrer,
+      REFERRER: opt_timeout => this.getReferrer_(opt_timeout),
       TGT: () =>
         JSON.stringify(
             (tryParseJson(
@@ -718,6 +718,25 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
       CANONICAL_URL: () =>
         Services.documentInfoForDoc(this.element).canonicalUrl,
     };
+  }
+  
+  /**
+   * Returns the referrer or undefined if the referrer is not resolved
+   * before the given timeout
+   * @param {number=} opt_timeout
+   * @return {!Promise<string|undefined>} A promise for a referrer or undefined 
+   * @private
+   */
+  getReferrer_(opt_timeout) {
+    const timeoutInt = parseInt(opt_timeout, 10);
+    const refererPromise = Services.viewerForDoc(this.getAmpDoc())
+      .getReferrerUrl();
+    if (opt_timeout == null || isNaN(opt_timeout) || opt_timeout < 0) {
+      return refererPromise;
+    }
+    return Services.timerFor(this.win)
+      .timeoutPromise(opt_timeout, refererPromise)
+      .catch(() => undefined);
   }
 
   /**

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -724,7 +724,8 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
    * Returns the referrer or undefined if the referrer is not resolved
    * before the given timeout
    * @param {number=} opt_timeout
-   * @return {!Promise<string|undefined>} A promise for a referrer or undefined
+   * @return {!(Promise<string>|Promise<undefined>)} A promise with a referrer or undefined
+   * if timed out
    * @private
    */
   getReferrer_(opt_timeout) {

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-rtc.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-rtc.js
@@ -296,6 +296,7 @@ describes.realWin('DoubleClick Fast Fetch RTC', {amp: true}, env => {
         'json': JSON.stringify(json),
       });
       env.win.document.body.appendChild(element);
+      env.win.document.referrer = 'https://www.google.com/';
       const docInfo = Services.documentInfoForDoc(element);
       impl = new AmpAdNetworkDoubleclickImpl(
           element, env.win.document, env.win);
@@ -304,6 +305,7 @@ describes.realWin('DoubleClick Fast Fetch RTC', {amp: true}, env => {
       expect(customMacros.PAGEVIEWID()).to.equal(docInfo.pageViewId);
       expect(customMacros.HREF()).to.equal(env.win.location.href);
       expect(customMacros.TGT()).to.equal(JSON.stringify(json['targeting']));
+      expect(customMacros.REFERRER()).to.equal(env.win.document.referrer);
       Object.keys(macros).forEach(macro => {
         expect(customMacros.ATTR(macro)).to.equal(macros[macro]);
       });

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-rtc.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-rtc.js
@@ -362,9 +362,7 @@ describes.realWin('DoubleClick Fast Fetch RTC', {amp: true}, env => {
       const viewer = Services.viewerForDoc(impl.getAmpDoc());
       sandbox.stub(viewer, 'getReferrerUrl').returns(new Promise(() => {}));
       const customMacros = impl.getCustomRealTimeConfigMacros_();
-      return customMacros.REFERRER(0).then(referrer => {
-        expect(referrer).to.be.undefined;
-      });
+      return expect(customMacros.REFERRER(0)).to.eventually.be.undefined;
     });
 
     it('should handle TGT macro when targeting not set', () => {


### PR DESCRIPTION
Adds the page referrer as a macro to be sent to the RTC Endpoint. The page referrer helps to identify the traffic source in canonical pages using AMP.

The discussion started in our forked version: https://github.com/Marfeel/amphtml/pull/29