### PR TITLE
✅ Unskip tests that were skipped due to console errors

### DIFF
--- a/ads/google/a4a/test/test-utils.js
+++ b/ads/google/a4a/test/test-utils.js
@@ -123,8 +123,7 @@ describe('Google A4A utils', () => {
       },
     };
 
-    // TODO(zhouyx, #14336): Fails due to console errors.
-    it.skip('should extract correct config from header', () => {
+    it('should extract correct config from header', () => {
       return createIframePromise().then(fixture => {
         setupForAdTesting(fixture);
         let url;

--- a/ads/google/test/test-doubleclick.js
+++ b/ads/google/test/test-doubleclick.js
@@ -56,8 +56,7 @@ describes.sandboxed('writeAdScript', {}, env => {
     verifyScript(win, 'gpt.js');
   });
 
-  // TODO(bradfrizzell, #14336): Fails due to console errors.
-  it.skip('should use GPT when multiSize is not null', () => {
+  it('should use GPT when multiSize is not null', () => {
     const data = {multiSize: 'hey!'};
     writeAdScript(win, data);
     verifyScript(win, 'gpt.js');

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -643,8 +643,7 @@ describe('amp-a4a', () => {
         a4a.onLayoutMeasure();
       });
 
-      // TODO(lannka, #14336): Fails due to console errors.
-      it.skip('should render via cached iframe', () => {
+      it('should render via cached iframe', () => {
         return a4a.layoutCallback().then(() => {
           verifyCachedContentIframeRender(a4aElement, TEST_URL);
           // Should have reported an error.
@@ -657,9 +656,7 @@ describe('amp-a4a', () => {
         });
       });
 
-      // TODO(keithwrightbos, #14336): Fails due to console errors.
-      it.skip('should fire amp-analytics triggers for illegal ' +
-          'render modes', () => {
+      it('should fire amp-analytics triggers for illegal render modes', () => {
         const triggerAnalyticsEventSpy =
             sandbox.spy(analytics, 'triggerAnalyticsEvent');
         return a4a.layoutCallback().then(() => {
@@ -716,8 +713,7 @@ describe('amp-a4a', () => {
 
       ['', 'client_cache', 'safeframe', 'some_random_thing'].forEach(
           headerVal => {
-            // TODO(lannka, #14336): Fails due to console errors.
-            it.skip(`should not attach a NameFrame when header is ${headerVal}`,
+            it(`should not attach a NameFrame when header is ${headerVal}`,
                 () => {
                   // Make sure there's no signature, so that we go down the 3p iframe path.
                   delete adResponse.headers['AMP-Fast-Fetch-Signature'];
@@ -808,8 +804,7 @@ describe('amp-a4a', () => {
 
       ['', 'client_cache', 'nameframe', 'some_random_thing'].forEach(
           headerVal => {
-            // TODO(lannka, #14336): Fails due to console errors.
-            it.skip(`should not attach a SafeFrame when header is ${headerVal}`,
+            it(`should not attach a SafeFrame when header is ${headerVal}`,
                 () => {
                   // If rendering type is anything but safeframe, we SHOULD NOT attach a
                   // SafeFrame.
@@ -1359,8 +1354,7 @@ describe('amp-a4a', () => {
         }));
       });
     });
-    it('should handle XHR error when resolves after ' +
-        'layoutCallback', () => {
+    it('should handle XHR error when resolves after layoutCallback', () => {
       return createIframePromise().then(fixture => {
         setupForAdTesting(fixture);
         let rejectXhr;
@@ -2216,9 +2210,7 @@ describes.realWin('AmpA4a-RTC', {amp: true}, env => {
       expect(AMP.maybeExecuteRealTimeConfig).to.be.undefined;
       expect(a4a.tryExecuteRealTimeConfig_()).to.be.undefined;
     });
-    // TODO(bradfrizzell, #14336): Fails due to console errors.
-    it.skip('should log user error if RTC Config set but RTC not ' +
-        'supported', () => {
+    it('should log user error if RTC Config set but RTC not supported', () => {
       element.setAttribute('rtc-config',
           JSON.stringify({'urls': ['https://a.com']}));
       expect(a4a.tryExecuteRealTimeConfig_()).to.be.undefined;
@@ -2235,8 +2227,7 @@ describes.realWin('AmpA4a-RTC', {amp: true}, env => {
       expect(AMP.maybeExecuteRealTimeConfig.called).to.be.true;
       expect(AMP.maybeExecuteRealTimeConfig.calledWith(a4a, macros)).to.be.true;
     });
-    // TODO(bradfrizzell, #14336): Fails due to console errors.
-    it.skip('should catch error in maybeExecuteRealTimeConfig', () => {
+    it('should catch error in maybeExecuteRealTimeConfig', () => {
       const err = new Error('Test');
       AMP.maybeExecuteRealTimeConfig = sandbox.stub().throws(err);
       a4a.tryExecuteRealTimeConfig_();

--- a/extensions/amp-access/0.1/test/test-amp-access-source.js
+++ b/extensions/amp-access/0.1/test/test-amp-access-source.js
@@ -79,8 +79,7 @@ describes.fakeWin('AccessSource', {
     });
   });
 
-  // TODO(dvoytenko, #14336): Fails due to console errors.
-  it.skip('should parse type', () => {
+  it('should parse type', () => {
     let config = {
       'authorization': 'https://acme.com/a',
       'pingback': 'https://acme.com/p',

--- a/extensions/amp-access/0.1/test/test-amp-access.js
+++ b/extensions/amp-access/0.1/test/test-amp-access.js
@@ -468,8 +468,7 @@ describes.fakeWin('AccessService authorization', {
     });
   });
 
-  // TODO(dvoytenko, #14336): Fails due to console errors.
-  it.skip('should use fallback on authorization failure when available', () => {
+  it('should use fallback on authorization failure when available', () => {
     expectGetReaderId('reader1');
     adapterMock.expects('authorize')
         .withExactArgs()

--- a/extensions/amp-access/0.1/test/test-login-dialog.js
+++ b/extensions/amp-access/0.1/test/test-login-dialog.js
@@ -242,8 +242,7 @@ describes.sandboxed('WebLoginDialog', {}, () => {
     expect(windowApi.open.firstCall.args[0]).to.equal('');
   });
 
-  // TODO(dvoytenko, #14336): Fails due to console errors.
-  it.skip('should yield error if window.open fails', () => {
+  it('should yield error if window.open fails', () => {
     // Open is called twice due to retry on _top.
     windowMock.expects('open').twice().throws('OPEN ERROR');
     return openLoginDialog(ampdoc, 'http://acme.com/login')

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
@@ -135,8 +135,7 @@ describes.realWin('amp-ad-network-adsense-impl', {
       element.setAttribute('width', '666');
       expect(impl.isValidElement()).to.be.false;
     });
-    it('should NOT be valid (responsive with missing ' +
-        'data-full-width)', () => {
+    it('should NOT be valid (responsive with missing data-full-width)', () => {
       isResponsiveStub.callsFake(() => true);
       element.setAttribute('height', '320');
       element.setAttribute('width', '100vw');
@@ -859,8 +858,8 @@ describes.realWin('amp-ad-network-adsense-impl', {
       }
       doc.body.style.direction = '';
     });
-    // TODO(charliereams, #14336): Fails due to console errors.
-    it.skip('should change left margin for responsive', () => {
+
+    it('should change left margin for responsive', () => {
       containerContainer = doc.createElement('div');
       container = doc.createElement('div');
       return buildImpl({
@@ -875,8 +874,7 @@ describes.realWin('amp-ad-network-adsense-impl', {
       });
     });
 
-    // TODO(charliereams, #14336): Fails due to console errors.
-    it.skip('should change right margin for responsive in RTL', () => {
+    it('should change right margin for responsive in RTL', () => {
       containerContainer = doc.createElement('div');
       container = doc.createElement('div');
       doc.body.style.direction = 'rtl'; // todo: revert

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -913,8 +913,7 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
       });
     });
 
-    // TODO(glevitzky, #14336): Fails due to console errors.
-    it.skip('should force iframe to match size of creative', () => {
+    it('should force iframe to match size of creative', () => {
       sandbox.stub(impl, 'sendXhrRequest').returns(
           mockSendXhrRequest('150x50'));
       impl.buildCallback();
@@ -927,8 +926,7 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
       });
     });
 
-    // TODO(glevitzky, #14336): Fails due to console errors.
-    it.skip('amp creative - should force iframe to match size of slot', () => {
+    it('amp creative - should force iframe to match size of slot', () => {
       stubForAmpCreative();
       sandbox.stub(impl, 'sendXhrRequest').callsFake(mockSendXhrRequest);
       sandbox.stub(impl, 'renderViaCachedContentIframe_').callsFake(
@@ -948,8 +946,7 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
       });
     });
 
-    // TODO(glevitzky, #14336): Fails due to console errors.
-    it.skip('should force iframe to match size of slot', () => {
+    it('should force iframe to match size of slot', () => {
       sandbox.stub(impl, 'sendXhrRequest').callsFake(mockSendXhrRequest);
       sandbox.stub(impl, 'renderViaCachedContentIframe_').callsFake(
           () => impl.iframeRenderHelper_({src: impl.adUrl_, name: 'name'}));
@@ -965,9 +962,7 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
       });
     });
 
-    // TODO(glevitzky, #14336): Fails due to console errors.
-    it.skip('should issue an ad request even with bad multi-size ' +
-        'data attr', () => {
+    it('should issue an ad request even with bad multi-size data attr', () => {
       stubForAmpCreative();
       sandbox.stub(impl, 'sendXhrRequest').callsFake(mockSendXhrRequest);
       impl.element.setAttribute('data-multi-size', '201x50');
@@ -1298,8 +1293,7 @@ describes.realWin('additional amp-ad-network-doubleclick-impl',
         });
       });
 
-      // TODO(bradfrizzell, #14336): Fails due to console errors.
-      describe.skip('centering', () => {
+      describe('centering', () => {
         const size = {width: '300px', height: '150px'};
 
         function verifyCss(iframe, expectedSize) {

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-fluid.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-fluid.js
@@ -131,8 +131,7 @@ describes.realWin('DoubleClick Fast Fetch Fluid', realWinConfig, env => {
     expect(fireDelayedImpressionsSpy).to.not.be.calledOnce;
   });
 
-  // TODO(glevitzky, #14336): Fails due to console errors.
-  it.skip('should contain sz=320x50 in ad request by default', () => {
+  it('should contain sz=320x50 in ad request by default', () => {
     impl.initiateAdRequest();
     return impl.adPromise_.then(() => {
       expect(impl.adUrl_).to.be.ok;
@@ -140,8 +139,7 @@ describes.realWin('DoubleClick Fast Fetch Fluid', realWinConfig, env => {
     });
   });
 
-  // TODO(glevitzky, #14336): Fails due to console errors.
-  it.skip('should contain mulitple sizes in ad request', () => {
+  it('should contain mulitple sizes in ad request', () => {
     multiSizeImpl.initiateAdRequest();
     return multiSizeImpl.adPromise_.then(() => {
       expect(multiSizeImpl.adUrl_).to.be.ok;

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-safeframe.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-safeframe.js
@@ -591,8 +591,7 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
      * If the safeframed creative asks to expand with invalid expand
      * values, should fail gracefully.
      */
-    // TODO(bradfrizzell, #14336): Fails due to console errors.
-    it.skip('expand_request fails if invalid values sent', () => {
+    it('expand_request fails if invalid values sent', () => {
       const expandMessage = {};
       expandMessage[MESSAGE_FIELDS.CHANNEL] = safeframeHost.channel;
       expandMessage[MESSAGE_FIELDS.ENDPOINT_IDENTITY] = 1;

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-sra.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-sra.js
@@ -430,21 +430,16 @@ describes.realWin('amp-ad-network-doubleclick-impl', config , env => {
     it('should not send SRA request if only 1 slot is valid', () =>
       executeTest([{networkId: 1234, instances: 1, invalidInstances: 2}]));
 
-    // TODO(bradfrizzell, #14336): Fails due to console errors.
-    it.skip('should handle xhr failure by not sending subsequent request',
+    it('should handle xhr failure by not sending subsequent request',
         () => executeTest([{networkId: 1234, instances: 2, xhrFail: true}]));
 
-    // TODO(bradfrizzell, #14336): Fails due to console errors.
-    it.skip('should handle mixture of xhr and ' +
-        'non xhr failures', () => executeTest(
+    it('should handle mixture of xhr and non xhr failures', () => executeTest(
         [{networkId: 1234, instances: 2, xhrFail: true}, 4567, 4567]));
 
     it('should correctly use SRA for multiple slots. multiple networks',
         () => executeTest([1234, 4567, 1234, 4567]));
 
-    // TODO(bradfrizzell, #14336): Fails due to console errors.
-    it.skip('should handle mixture of all ' +
-        'possible scenarios', () => executeTest(
+    it('should handle mixture of all possible scenarios', () => executeTest(
         [1234, 1234, 101, {networkId: 4567, instances: 2, xhrFail: true}, 202,
           {networkId: 8901, instances: 3, invalidInstances: 1}]));
   });

--- a/extensions/amp-ad/0.1/test/test-amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-3p-impl.js
@@ -201,8 +201,8 @@ describes.realWin('amp-ad-3p-impl', {
             `${remoteUrl}?$internalRuntimeVersion$"]`)).to.be.ok;
       });
     });
-    // TODO(keithwrightbos, #14336): Fails due to console errors.
-    it.skip('should use default path if custom disabled', () => {
+
+    it('should use default path if custom disabled', () => {
       const meta = win.document.createElement('meta');
       meta.setAttribute('name', 'amp-3p-iframe-src');
       meta.setAttribute('content', 'https://example.com/boot/remote.html');
@@ -265,8 +265,7 @@ describes.realWin('amp-ad-3p-impl', {
       });
     });
 
-    // TODO(keithwrightbos, #14336): Fails due to console errors.
-    it.skip('should not use remote html path for preload if disabled', () => {
+    it('should not use remote html path for preload if disabled', () => {
       const meta = win.document.createElement('meta');
       meta.setAttribute('name', 'amp-3p-iframe-src');
       meta.setAttribute('content', 'https://example.com/boot/remote.html');

--- a/extensions/amp-ad/0.1/test/test-amp-ad.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad.js
@@ -124,9 +124,7 @@ describes.realWin('Ad loader', {amp: true}, env => {
         });
       });
 
-      // TODO(jridgewell, #14336): Fails due to console errors.
-      it.skip('fails upgrade on A4A upgrade with loadElementClass ' +
-          'error', () => {
+      it('fails upgrade on A4A upgrade with loadElementClass error', () => {
         a4aRegistry['zort'] = function() {
           return true;
         };

--- a/extensions/amp-analytics/0.1/test/test-amp-analytics.js
+++ b/extensions/amp-analytics/0.1/test/test-amp-analytics.js
@@ -189,8 +189,7 @@ describes.realWin('amp-analytics', {
       actualResults[vendor] = {};
       describe('analytics vendor: ' + vendor, function() {
         for (const name in config.requests) {
-          // TODO(malteubl, #14336): Fails due to console errors.
-          it.skip('should produce request: ' + name +
+          it('should produce request: ' + name +
               '. If this test fails update vendor-requests.json', function* () {
             const urlReplacements =
                 Services.urlReplacementsForDoc(ampdoc);
@@ -266,8 +265,7 @@ describes.realWin('amp-analytics', {
     }
   });
 
-  // TODO(jonkeller, #14336): Fails due to console errors.
-  it.skip('does not unnecessarily preload iframe transport script', function() {
+  it('does not unnecessarily preload iframe transport script', function() {
     const el = doc.createElement('amp-analytics');
     doc.body.appendChild(el);
     const analytics = new AmpAnalytics(el);
@@ -323,8 +321,7 @@ describes.realWin('amp-analytics', {
     });
   });
 
-  // TODO(avimehta, #14336): Fails due to console errors.
-  it.skip('does not send a hit when config is not in a script tag', function() {
+  it('does not send a hit when config is not in a script tag', function() {
     const config = JSON.stringify(trivialConfig);
     const el = doc.createElement('amp-analytics');
     el.textContent = config;
@@ -364,8 +361,7 @@ describes.realWin('amp-analytics', {
     expect(whenFirstVisibleStub).to.be.calledOnce;
   });
 
-  // TODO(avimehta, #14336): Fails due to console errors.
-  it.skip('does not send a hit when multiple child tags exist', function() {
+  it('does not send a hit when multiple child tags exist', function() {
     const analytics = getAnalyticsTag(trivialConfig);
     const script2 = document.createElement('script');
     script2.setAttribute('type', 'application/json');
@@ -375,8 +371,7 @@ describes.realWin('amp-analytics', {
     });
   });
 
-  // TODO(avimehta, #14336): Fails due to console errors.
-  it.skip('does not send a hit when script tag does not have a type attribute',
+  it('does not send a hit when script tag does not have a type attribute',
       function() {
         const el = doc.createElement('amp-analytics');
         const script = doc.createElement('script');
@@ -394,8 +389,7 @@ describes.realWin('amp-analytics', {
         });
       });
 
-  // TODO(avimehta, #14336): Fails due to console errors.
-  it.skip('does not send a hit when request is not provided', function() {
+  it('does not send a hit when request is not provided', function() {
     const analytics = getAnalyticsTag({
       'requests': {'foo': 'https://example.com/bar'},
       'triggers': [{'on': 'visible'}],
@@ -406,8 +400,7 @@ describes.realWin('amp-analytics', {
     });
   });
 
-  // TODO(avimehta, #14336): Fails due to console errors.
-  it.skip('does not send a hit when request type is not defined', function() {
+  it('does not send a hit when request type is not defined', function() {
     const analytics = getAnalyticsTag({
       'triggers': [{'on': 'visible', 'request': 'foo'}],
     });
@@ -1159,8 +1152,7 @@ describes.realWin('amp-analytics', {
     });
   });
 
-  // TODO(zhouyx, #14336): Fails due to console errors.
-  it.skip('ignore transport iframe from remote config', () => {
+  it('ignore transport iframe from remote config', () => {
     const analytics = getAnalyticsTag({
       'vars': {'title': 'local'},
       'requests': {'foo': 'https://example.com/${title}'},
@@ -1285,8 +1277,7 @@ describes.realWin('amp-analytics', {
       });
     });
 
-    // TODO(avimehta, #14336): Fails due to console errors.
-    it.skip('works when sampleSpec is incomplete', () => {
+    it('works when sampleSpec is incomplete', () => {
       const incompleteConfig = {
         'requests': {
           'pageview1': '/test1=${requestCount}',
@@ -1306,8 +1297,7 @@ describes.realWin('amp-analytics', {
       });
     });
 
-    // TODO(avimehta, #14336): Fails due to console errors.
-    it.skip('works for invalid threadhold (Infinity)', () => {
+    it('works for invalid threadhold (Infinity)', () => {
       const analytics = getAnalyticsTag(getConfig(Infinity));
 
       return waitForSendRequest(analytics).then(() => {
@@ -1315,8 +1305,7 @@ describes.realWin('amp-analytics', {
       });
     });
 
-    // TODO(avimehta, #14336): Fails due to console errors.
-    it.skip('works for invalid threadhold (NaN)', () => {
+    it('works for invalid threadhold (NaN)', () => {
       const analytics = getAnalyticsTag(getConfig(NaN));
 
       return waitForSendRequest(analytics).then(() => {
@@ -1324,8 +1313,7 @@ describes.realWin('amp-analytics', {
       });
     });
 
-    // TODO(avimehta, #14336): Fails due to console errors.
-    it.skip('works for invalid threadhold (-1)', () => {
+    it('works for invalid threadhold (-1)', () => {
       const analytics = getAnalyticsTag(getConfig(-1));
 
       return waitForSendRequest(analytics).then(() => {
@@ -1686,9 +1674,7 @@ describes.realWin('amp-analytics', {
       });
     });
 
-    // TODO(zhouyx, #14336): Fails due to console errors.
-    it.skip('should not add listener when eventType is not ' +
-        'whitelist', function() {
+    it('should not add listener when eventType is not whitelist', function() {
       // Right now we only whitelist VISIBLE & HIDDEN
       const tracker = ins.ampdocRoot_.getTracker('click', ClickEventTracker);
       const addStub = sandbox.stub(tracker, 'add');

--- a/extensions/amp-analytics/0.1/test/test-instrumentation.js
+++ b/extensions/amp-analytics/0.1/test/test-instrumentation.js
@@ -381,8 +381,7 @@ describe('amp-analytics.instrumentation OLD', function() {
     expect(fn1).to.have.callCount(2);
   });
 
-  // TODO(avimehta, #14336): Fails due to console errors.
-  it.skip('fails gracefully on bad scroll config', () => {
+  it('fails gracefully on bad scroll config', () => {
     const fn1 = sandbox.stub();
 
     ins.addListenerDepr_({'on': 'scroll'}, fn1);
@@ -414,8 +413,7 @@ describe('amp-analytics.instrumentation OLD', function() {
     expect(fn1).to.have.not.been.called;
   });
 
-  // TODO(avimehta, #14336): Fails due to console errors.
-  it.skip('normalizes boundaries correctly.', () => {
+  it('normalizes boundaries correctly.', () => {
     expect(ins.normalizeBoundaries_([])).to.be.empty;
     expect(ins.normalizeBoundaries_(undefined)).to.be.empty;
     expect(ins.normalizeBoundaries_(['foo'])).to.be.empty;

--- a/extensions/amp-analytics/0.1/test/test-requests.js
+++ b/extensions/amp-analytics/0.1/test/test-requests.js
@@ -363,8 +363,7 @@ describes.realWin('Requests', {amp: 1}, env => {
         }
       });
 
-      // TODO(zhouyx, #14336): Fails due to console errors.
-      it.skip('should handle batchPlugin function error', function* () {
+      it('should handle batchPlugin function error', function* () {
         const spy = sandbox.spy();
         const r = {'baseUrl': 'r', 'batchInterval': 1, 'batchPlugin': '_ping_'};
         const handler = new RequestHandler(

--- a/extensions/amp-analytics/0.1/test/test-variables.js
+++ b/extensions/amp-analytics/0.1/test/test-variables.js
@@ -68,16 +68,14 @@ describe('amp-analytics.VariableService', function() {
           );
     });
 
-    // TODO(avimehta, #14336): Fails due to console errors.
-    it.skip('expands nested vars', () => {
+    it('expands nested vars', () => {
       return variables.expandTemplate('${1}', new ExpansionOptions(vars))
           .then(actual =>
             expect(actual).to.equal('123%24%7B4%7D')
           );
     });
 
-    // TODO(avimehta, #14336): Fails due to console errors.
-    it.skip('expands nested vars (no encode)', () => {
+    it('expands nested vars (no encode)', () => {
       return variables.expandTemplate('${1}',
           new ExpansionOptions(vars, undefined, true))
           .then(actual =>
@@ -85,15 +83,13 @@ describe('amp-analytics.VariableService', function() {
           );
     });
 
-    // TODO(avimehta, #14336): Fails due to console errors.
-    it.skip('expands nested vars without double encoding', () => {
+    it('expands nested vars without double encoding', () => {
       return expect(variables.expandTemplate('${a}',
           new ExpansionOptions(vars))).to.eventually.equal(
           'https%3A%2F%2Fwww.google.com%2Fa%3Fb%3D1%26c%3D2');
     });
 
-    // TODO(avimehta, #14336): Fails due to console errors.
-    it.skip('limits the recursion to n', () => {
+    it('limits the recursion to n', () => {
       return variables.expandTemplate('${1}', new ExpansionOptions(vars, 3))
           .then(actual =>
             expect(actual).to.equal('1234%24%7B1%7D'))

--- a/extensions/amp-analytics/0.1/test/test-visibility-manager.js
+++ b/extensions/amp-analytics/0.1/test/test-visibility-manager.js
@@ -235,8 +235,7 @@ describes.fakeWin('VisibilityManagerForDoc', {amp: true}, env => {
     expect(root.getRootVisibility()).to.equal(0);
   });
 
-  // TODO(zhouyx, #14336): Fails due to console errors.
-  it.skip('create correct number of models', () => {
+  it('create correct number of models', () => {
     let spec = {};
     root.listenRoot(spec, null, null, null);
     expect(root.models_).to.have.length(1);
@@ -282,8 +281,7 @@ describes.fakeWin('VisibilityManagerForDoc', {amp: true}, env => {
     root.dispose();
   });
 
-  // TODO(jonkeller, #14336): Fails due to console errors.
-  it.skip('does not allow min==max, when they are neither 0 nor 100', () => {
+  it('does not allow min==max, when they are neither 0 nor 100', () => {
     let spec = {visiblePercentageThresholds: [[50, 50]]};
     root.listenRoot(spec, null, null, null);
     expect(root.models_).to.have.length(0);

--- a/extensions/amp-animation/0.1/test/test-amp-animation.js
+++ b/extensions/amp-animation/0.1/test/test-amp-animation.js
@@ -745,8 +745,7 @@ describes.sandboxed('AmpAnimation', {}, () => {
       });
     });
 
-    // TODO(dvoytenko, #14336): Fails due to console errors.
-    it.skip('should find target in the embed only via target', function* () {
+    it('should find target in the embed only via target', function* () {
       const parentWin = env.ampdoc.win;
       const embedWin = embed.win;
       const anim = yield createAnim({},

--- a/extensions/amp-animation/0.1/test/test-web-animations.js
+++ b/extensions/amp-animation/0.1/test/test-web-animations.js
@@ -856,8 +856,7 @@ describes.realWin('MeasureScanner', {amp: 1}, env => {
     expect(requests[0].timing.duration).to.equal(0);
   });
 
-  // TODO(dvoytenko, #14336): Fails due to console errors.
-  it.skip('should find target by ID', () => {
+  it('should find target by ID', () => {
     const requests = scan([
       {target: 'target1', keyframes: {}},
     ]);

--- a/extensions/amp-app-banner/0.1/test/test-amp-app-banner.js
+++ b/extensions/amp-app-banner/0.1/test/test-amp-app-banner.js
@@ -157,8 +157,7 @@ describes.realWin('amp-app-banner', {
       });
     });
 
-    // TODO(aghassemi, #14336): Fails due to console errors.
-    it.skip('should show banner and set up correctly', testSetupAndShowBanner);
+    it('should show banner and set up correctly', testSetupAndShowBanner);
 
     it('should throw if open button is missing', testButtonMissing);
 
@@ -239,8 +238,7 @@ describes.realWin('amp-app-banner', {
       });
     });
 
-    // TODO(aghassemi, #14336): Fails due to console errors.
-    it.skip('should show banner and set up correctly', testSetupAndShowBanner);
+    it('should show banner and set up correctly', testSetupAndShowBanner);
 
     it('should throw if open button is missing', testButtonMissing);
 

--- a/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
@@ -105,8 +105,7 @@ function waitForEvent(env, name) {
   });
 }
 
-// TODO(choumx, #14336): Fails due to console errors.
-describe.skip('Bind', function() {
+describe.configure().ifNewChrome().run('Bind', function() {
   // Give more than default 2000ms timeout for local testing.
   const TIMEOUT = Math.max(window.ampTestRuntimeConfig.mochaTimeout, 4000);
   this.timeout(TIMEOUT);

--- a/extensions/amp-bind/0.1/test/test-amp-state.js
+++ b/extensions/amp-bind/0.1/test/test-amp-state.js
@@ -115,8 +115,7 @@ describes.realWin('AmpState', {
     });
   });
 
-  // TODO(choumx, #14336): Fails due to console errors.
-  it.skip('should fetch json if `src` is mutated', () => {
+  it('should fetch json if `src` is mutated', () => {
     element.setAttribute('src', 'https://foo.com/bar?baz=1');
     element.build();
 

--- a/extensions/amp-carousel/0.1/test/test-slidescroll.js
+++ b/extensions/amp-carousel/0.1/test/test-slidescroll.js
@@ -924,8 +924,7 @@ describes.realWin('SlideScroll', {
       });
     });
 
-    // TODO(choumx, #14336): Fails due to console errors.
-    it.skip('should update slide when `slide` attribute is mutated', () => {
+    it('should update slide when `slide` attribute is mutated', () => {
       return getAmpSlideScroll(true).then(ampSlideScroll => {
         const impl = ampSlideScroll.implementation_;
         const showSlideSpy = sandbox.spy(impl, 'showSlide_');
@@ -962,8 +961,7 @@ describes.realWin('SlideScroll', {
       });
     });
 
-    // TODO(choumx, #14336): Fails due to console errors.
-    it.skip('should goToSlide on action', () => {
+    it('should goToSlide on action', () => {
       return getAmpSlideScroll(true).then(ampSlideScroll => {
         const impl = ampSlideScroll.implementation_;
         const showSlideSpy = sandbox.spy(impl, 'showSlide_');

--- a/extensions/amp-consent/0.1/test/test-consent-state-manager.js
+++ b/extensions/amp-consent/0.1/test/test-consent-state-manager.js
@@ -197,8 +197,7 @@ describes.realWin('ConsentStateManager', {amp: 1}, env => {
         expect(value).to.equal(CONSENT_ITEM_STATE.REJECTED);
       });
 
-      // TODO(zhouyx, #14336): Fails due to console errors.
-      it.skip('should return unknown value with error', function* () {
+      it('should return unknown value with error', function* () {
         let value;
         storageGetSpy = () => {
           const e = new Error('intentional');

--- a/extensions/amp-form/0.1/test/integration/test-integration-form.js
+++ b/extensions/amp-form/0.1/test/integration/test-integration-form.js
@@ -32,297 +32,290 @@ describes.realWin('AmpForm Integration', {
   },
   mockFetch: false,
 }, env => {
-  // TODO(aghassemi, #14336): Fails due to console errors.
-  describe.skip('AmpForm Integration', () => {
-    const baseUrl = 'http://localhost:31862';
-    let doc;
-    let sandbox;
+  const baseUrl = 'http://localhost:31862';
+  let doc;
+  let sandbox;
 
-    const realSetTimeout = window.setTimeout;
-    const stubSetTimeout = (callback, delay) => {
-      realSetTimeout(() => {
-        try {
-          callback();
-        } catch (e) {}
-      }, delay);
-    };
+  const realSetTimeout = window.setTimeout;
+  const stubSetTimeout = (callback, delay) => {
+    realSetTimeout(() => {
+      try {
+        callback();
+      } catch (e) {}
+    }, delay);
+  };
 
-    beforeEach(() => {
-      sandbox = env.sandbox;
-      doc = env.win.document;
-      const scriptElement = document.createElement('script');
-      scriptElement.setAttribute('custom-template', 'amp-mustache');
-      doc.body.appendChild(scriptElement);
-      registerExtendedTemplate(env.win, 'amp-mustache', AmpMustache);
-      new AmpFormService(env.ampdoc);
-    });
+  beforeEach(() => {
+    sandbox = env.sandbox;
+    doc = env.win.document;
+    const scriptElement = document.createElement('script');
+    scriptElement.setAttribute('custom-template', 'amp-mustache');
+    doc.body.appendChild(scriptElement);
+    registerExtendedTemplate(env.win, 'amp-mustache', AmpMustache);
+    new AmpFormService(env.ampdoc);
+  });
 
-    function getForm(config) {
-      const form = doc.createElement('form');
-      form.id = config.id || 'test-form';
-      form.setAttribute('method', config.method || 'POST');
-      form.setAttribute('target', config.target || '_top');
+  function getForm(config) {
+    const form = doc.createElement('form');
+    form.id = config.id || 'test-form';
+    form.setAttribute('method', config.method || 'POST');
+    form.setAttribute('target', config.target || '_top');
 
-      const nameInput = doc.createElement('input');
-      nameInput.setAttribute('name', 'name');
-      nameInput.setAttribute('value', 'John Miller');
-      form.appendChild(nameInput);
-      if (config.actionXhr) {
-        form.setAttribute('action-xhr', config.actionXhr);
-      }
-      if (config.action) {
-        form.setAttribute('action', config.action);
-      }
-      const submitButton = doc.createElement('input');
-      submitButton.setAttribute('type', 'submit');
-      form.appendChild(submitButton);
+    const nameInput = doc.createElement('input');
+    nameInput.setAttribute('name', 'name');
+    nameInput.setAttribute('value', 'John Miller');
+    form.appendChild(nameInput);
+    if (config.actionXhr) {
+      form.setAttribute('action-xhr', config.actionXhr);
+    }
+    if (config.action) {
+      form.setAttribute('action', config.action);
+    }
+    const submitButton = doc.createElement('input');
+    submitButton.setAttribute('type', 'submit');
+    form.appendChild(submitButton);
 
-      if (config.on) {
-        form.setAttribute('on', config.on);
-      }
-
-      if (config.success) {
-        const {message, template} = config.success;
-        const successDiv = doc.createElement('div');
-        successDiv.setAttribute('submit-success', '');
-        if (template) {
-          const child = doc.createElement('template');
-          child.setAttribute('type', 'amp-mustache');
-          child./*OK*/innerHTML = message;
-          successDiv.appendChild(child);
-        } else {
-          successDiv./*OK*/innerHTML = message;
-        }
-
-        form.appendChild(successDiv);
-      }
-
-      if (config.error) {
-        const {message, template} = config.error;
-        const errorDiv = doc.createElement('div');
-        errorDiv.setAttribute('submit-error', '');
-        if (template) {
-          const child = doc.createElement('template');
-          child.setAttribute('type', 'amp-mustache');
-          child./*OK*/innerHTML = message;
-          errorDiv.appendChild(child);
-        } else {
-          errorDiv./*OK*/innerHTML = message;
-        }
-        form.appendChild(errorDiv);
-      }
-
-      doc.body.appendChild(form);
-      return form;
+    if (config.on) {
+      form.setAttribute('on', config.on);
     }
 
-    const describeChrome =
-        describe.configure().skipFirefox().skipSafari().skipEdge();
+    if (config.success) {
+      const {message, template} = config.success;
+      const successDiv = doc.createElement('div');
+      successDiv.setAttribute('submit-success', '');
+      if (template) {
+        const child = doc.createElement('template');
+        child.setAttribute('type', 'amp-mustache');
+        child./*OK*/innerHTML = message;
+        successDiv.appendChild(child);
+      } else {
+        successDiv./*OK*/innerHTML = message;
+      }
 
-    describeChrome.run('on=submit:form.submit', () => {
-      it('should be protected from recursive-submission', () => {
-        const form = getForm({
-          id: 'sameform',
-          actionXhr: baseUrl + '/form/post',
-          on: 'submit:sameform.submit',
-        });
-        const ampForm = new AmpForm(form, 'sameform');
-        sandbox.spy(ampForm, 'handleXhrSubmit_');
-        sandbox.spy(ampForm, 'handleSubmitAction_');
-        sandbox.spy(ampForm.xhr_, 'fetch');
-        const fetch = poll('submit request sent',
-            () => ampForm.xhrSubmitPromiseForTesting());
+      form.appendChild(successDiv);
+    }
 
-        form.dispatchEvent(new Event('submit'));
-        return fetch.then(() => {
-          // Due to recursive nature of 'on=submit:sameform.submit' we expect
-          // the action handler to be called twice, the first time for the
-          // actual user submission.
-          // The second time in response to the `submit` event being triggered
-          // and sameform.submit being invoked.
-          expect(ampForm.handleSubmitAction_).to.have.been.calledTwice;
+    if (config.error) {
+      const {message, template} = config.error;
+      const errorDiv = doc.createElement('div');
+      errorDiv.setAttribute('submit-error', '');
+      if (template) {
+        const child = doc.createElement('template');
+        child.setAttribute('type', 'amp-mustache');
+        child./*OK*/innerHTML = message;
+        errorDiv.appendChild(child);
+      } else {
+        errorDiv./*OK*/innerHTML = message;
+      }
+      form.appendChild(errorDiv);
+    }
 
-          // However, only the first invocation should be handled completely.
-          // and any subsequent calls should be stopped early-on.
-          expect(ampForm.handleXhrSubmit_).to.have.been.calledOnce;
-          expect(ampForm.xhr_.fetch).to.have.been.calledOnce;
-        });
+    doc.body.appendChild(form);
+    return form;
+  }
+
+  const describeChrome =
+      describe.configure().skipFirefox().skipSafari().skipEdge();
+
+  describeChrome.run('on=submit:form.submit', () => {
+    it('should be protected from recursive-submission', () => {
+      const form = getForm({
+        id: 'sameform',
+        actionXhr: baseUrl + '/form/post',
+        on: 'submit:sameform.submit',
+      });
+      const ampForm = new AmpForm(form, 'sameform');
+      sandbox.spy(ampForm, 'handleXhrSubmit_');
+      sandbox.spy(ampForm, 'handleSubmitAction_');
+      sandbox.spy(ampForm.xhr_, 'fetch');
+      const fetch = poll('submit request sent',
+          () => ampForm.xhrSubmitPromiseForTesting());
+
+      form.dispatchEvent(new Event('submit'));
+      return fetch.then(() => {
+        // Due to recursive nature of 'on=submit:sameform.submit' we expect
+        // the action handler to be called twice, the first time for the
+        // actual user submission.
+        // The second time in response to the `submit` event being triggered
+        // and sameform.submit being invoked.
+        expect(ampForm.handleSubmitAction_).to.have.been.calledTwice;
+
+        // However, only the first invocation should be handled completely.
+        // and any subsequent calls should be stopped early-on.
+        expect(ampForm.handleXhrSubmit_).to.have.been.calledOnce;
+        expect(ampForm.xhr_.fetch).to.have.been.calledOnce;
+      });
+    });
+  });
+
+  describeChrome.run('Submit xhr-POST', function() {
+    this.timeout(RENDER_TIMEOUT);
+
+    it('should submit and render success', () => {
+      const form = getForm({
+        id: 'form1',
+        actionXhr: baseUrl + '/form/post/success',
+        success: {
+          message: 'Thanks {{name}} for adding your interests:' +
+              ' {{#interests}}{{title}} {{/interests}}.',
+          template: true,
+        },
+        error: {message: 'Should not render this.', template: true},
+      });
+      const ampForm = new AmpForm(form, 'form1');
+      const fetch = poll('submit request sent',
+          () => ampForm.xhrSubmitPromiseForTesting());
+      const render = listenOncePromise(form, AmpEvents.DOM_UPDATE);
+
+      form.dispatchEvent(new Event('submit'));
+      return fetch.then(() => render).then(() => {
+        const rendered = form.querySelector('[i-amphtml-rendered]');
+        expect(rendered.textContent).to.equal(
+            'Thanks John Miller for adding your interests: ' +
+            'Football Basketball Writing .');
       });
     });
 
-    describeChrome.run('Submit xhr-POST', function() {
-      this.timeout(RENDER_TIMEOUT);
+    it('should submit and render error', () => {
+      // Stubbing timeout to catch async-thrown errors and expect
+      // them. These catch errors thrown inside the catch-clause of the
+      // xhr request using rethrowAsync.
+      sandbox.stub(window, 'setTimeout').callsFake(stubSetTimeout);
 
-      it('should submit and render success', () => {
-        const form = getForm({
-          id: 'form1',
-          actionXhr: baseUrl + '/form/post/success',
-          success: {
-            message: 'Thanks {{name}} for adding your interests:' +
-                ' {{#interests}}{{title}} {{/interests}}.',
-            template: true,
-          },
-          error: {message: 'Should not render this.', template: true},
-        });
-        const ampForm = new AmpForm(form, 'form1');
-        const fetch = poll('submit request sent',
-            () => ampForm.xhrSubmitPromiseForTesting());
-        const render = listenOncePromise(form, AmpEvents.DOM_UPDATE);
+      const form = getForm({
+        id: 'form1',
+        actionXhr: baseUrl + '/form/post/error',
+        success: {message: 'Should not render this.', template: true},
+        error: {
+          message: 'Oops. {{name}} your email {{email}} is already ' +
+              'subscribed.',
+          template: true,
+        },
+      });
+      const ampForm = new AmpForm(form, 'form1');
+      const fetchSpy = sandbox.spy(ampForm.xhr_, 'fetch');
+      const fetch = poll('submit request sent', () => fetchSpy.returnValues[0]);
+      const render = listenOncePromise(form, AmpEvents.DOM_UPDATE);
 
-        form.dispatchEvent(new Event('submit'));
-        return fetch.then(() => render).then(() => {
+      form.dispatchEvent(new Event('submit'));
+      return fetch.then(() => {
+        throw new Error('UNREACHABLE');
+      }, fetchError => {
+        expect(fetchError.message).to.match(/HTTP error 500/);
+        return render.then(() => {
           const rendered = form.querySelector('[i-amphtml-rendered]');
           expect(rendered.textContent).to.equal(
-              'Thanks John Miller for adding your interests: ' +
-              'Football Basketball Writing .');
-        });
-      });
-
-      it('should submit and render error', () => {
-        // Stubbing timeout to catch async-thrown errors and expect
-        // them. These catch errors thrown inside the catch-clause of the
-        // xhr request using rethrowAsync.
-        sandbox.stub(window, 'setTimeout').callsFake(stubSetTimeout);
-
-        const form = getForm({
-          id: 'form1',
-          actionXhr: baseUrl + '/form/post/error',
-          success: {message: 'Should not render this.', template: true},
-          error: {
-            message: 'Oops. {{name}} your email {{email}} is already ' +
-                'subscribed.',
-            template: true,
-          },
-        });
-        const ampForm = new AmpForm(form, 'form1');
-        const fetchSpy = sandbox.spy(ampForm.xhr_, 'fetch');
-        const fetch =
-            poll('submit request sent', () => fetchSpy.returnValues[0]);
-        const render = listenOncePromise(form, AmpEvents.DOM_UPDATE);
-
-        form.dispatchEvent(new Event('submit'));
-        return fetch.then(() => {
-          throw new Error('UNREACHABLE');
-        }, fetchError => {
-          expect(fetchError.message).to.match(/HTTP error 500/);
-          return render.then(() => {
-            const rendered = form.querySelector('[i-amphtml-rendered]');
-            expect(rendered.textContent).to.equal(
-                'Oops. John Miller your email john@miller.what is already ' +
-                'subscribed.');
-          });
+              'Oops. John Miller your email john@miller.what is already ' +
+              'subscribed.');
         });
       });
     });
+  });
 
-    describeChrome.run('Submit xhr-GET', function() {
-      this.timeout(RENDER_TIMEOUT);
+  describeChrome.run('Submit xhr-GET', function() {
+    this.timeout(RENDER_TIMEOUT);
 
-      it('should submit and render success', () => {
-        const form = getForm({
-          id: 'form1',
-          method: 'GET',
-          actionXhr: baseUrl + '/form/post/success',
-          success: {
-            message: 'Thanks {{name}} for adding your interests:' +
-                ' {{#interests}}{{title}} {{/interests}}.',
-            template: true,
-          },
-          error: {message: 'Should not render this.', template: true},
-        });
-        const ampForm = new AmpForm(form, 'form1');
-        const fetch = poll('submit request sent',
-            () => ampForm.xhrSubmitPromiseForTesting());
-        const render = listenOncePromise(form, AmpEvents.DOM_UPDATE);
-
-        form.dispatchEvent(new Event('submit'));
-        return fetch.then(() => render).then(() => {
-          const rendered = form.querySelectorAll('[i-amphtml-rendered]');
-          expect(rendered.length).to.equal(1);
-          expect(rendered[0].textContent).to.equal(
-              'Thanks John Miller for adding your interests: ' +
-              'Football Basketball Writing .');
-        });
+    it('should submit and render success', () => {
+      const form = getForm({
+        id: 'form1',
+        method: 'GET',
+        actionXhr: baseUrl + '/form/post/success',
+        success: {
+          message: 'Thanks {{name}} for adding your interests:' +
+              ' {{#interests}}{{title}} {{/interests}}.',
+          template: true,
+        },
+        error: {message: 'Should not render this.', template: true},
       });
+      const ampForm = new AmpForm(form, 'form1');
+      const fetch = poll('submit request sent',
+          () => ampForm.xhrSubmitPromiseForTesting());
+      const render = listenOncePromise(form, AmpEvents.DOM_UPDATE);
 
-      it('should submit and render error', () => {
-        // Stubbing timeout to catch async-thrown errors and expect
-        // them. These catch errors thrown inside the catch-clause of the
-        // xhr request using rethrowAsync.
-        sandbox.stub(window, 'setTimeout').callsFake(stubSetTimeout);
-
-        const form = getForm({
-          id: 'form1',
-          actionXhr: baseUrl + '/form/post/error',
-          success: {message: 'Should not render this.', template: true},
-          error: {
-            message: 'Oops. {{name}} your email {{email}} is already ' +
-                'subscribed.',
-            template: true,
-          },
-        });
-        const ampForm = new AmpForm(form, 'form1');
-        const fetchSpy = sandbox.spy(ampForm.xhr_, 'fetch');
-        const fetch =
-            poll('submit request sent', () => fetchSpy.returnValues[0]);
-        const render = listenOncePromise(form, AmpEvents.DOM_UPDATE);
-
-        form.dispatchEvent(new Event('submit'));
-        return fetch.then(() => {
-          throw new Error('UNREACHABLE');
-        }, fetchError => {
-          expect(fetchError.message).to.match(/HTTP error 500/);
-          return render.then(() => {
-            const rendered = form.querySelector('[i-amphtml-rendered]');
-            expect(rendered.textContent).to.equal(
-                'Oops. John Miller your email john@miller.what is already ' +
-                'subscribed.');
-          });
-        });
+      form.dispatchEvent(new Event('submit'));
+      return fetch.then(() => render).then(() => {
+        const rendered = form.querySelectorAll('[i-amphtml-rendered]');
+        expect(rendered.length).to.equal(1);
+        expect(rendered[0].textContent).to.equal(
+            'Thanks John Miller for adding your interests: ' +
+            'Football Basketball Writing .');
       });
     });
 
-    describeChrome.run('Submit result message', () => {
-      // TODO(cvializ, #14336): Fails due to console errors.
-      it.skip('should render messages with or without a template', () => {
-        // Stubbing timeout to catch async-thrown errors and expect
-        // them. These catch errors thrown inside the catch-clause of the
-        // xhr request using rethrowAsync.
-        sandbox.stub(window, 'setTimeout').callsFake(stubSetTimeout);
+    it('should submit and render error', () => {
+      // Stubbing timeout to catch async-thrown errors and expect
+      // them. These catch errors thrown inside the catch-clause of the
+      // xhr request using rethrowAsync.
+      sandbox.stub(window, 'setTimeout').callsFake(stubSetTimeout);
 
-        const form = getForm({
-          id: 'form1',
-          actionXhr: baseUrl + '/form/post/error',
-          success: {message: 'Should not render this.', template: false},
-          error: {
-            message: 'Oops! Your email is already subscribed.' +
-                '<amp-img src="/examples/img/ampicon.png" ' +
-                'width="42" height="42"></amp-img>',
-            template: false,
-          },
+      const form = getForm({
+        id: 'form1',
+        actionXhr: baseUrl + '/form/post/error',
+        success: {message: 'Should not render this.', template: true},
+        error: {
+          message: 'Oops. {{name}} your email {{email}} is already ' +
+              'subscribed.',
+          template: true,
+        },
+      });
+      const ampForm = new AmpForm(form, 'form1');
+      const fetchSpy = sandbox.spy(ampForm.xhr_, 'fetch');
+      const fetch = poll('submit request sent', () => fetchSpy.returnValues[0]);
+      const render = listenOncePromise(form, AmpEvents.DOM_UPDATE);
+
+      form.dispatchEvent(new Event('submit'));
+      return fetch.then(() => {
+        throw new Error('UNREACHABLE');
+      }, fetchError => {
+        expect(fetchError.message).to.match(/HTTP error 500/);
+        return render.then(() => {
+          const rendered = form.querySelector('[i-amphtml-rendered]');
+          expect(rendered.textContent).to.equal(
+              'Oops. John Miller your email john@miller.what is already ' +
+              'subscribed.');
         });
-        const ampForm = new AmpForm(form, 'form1');
-        const fetchSpy = sandbox.spy(ampForm.xhr_, 'fetch');
-        const fetch =
-            poll('submit request sent', () => fetchSpy.returnValues[0]);
+      });
+    });
+  });
 
-        form.dispatchEvent(new Event('submit'));
-        return fetch.then(() => {
-          throw new Error('UNREACHABLE');
-        }, fetchError => {
-          expect(fetchError.message).to.match(/HTTP error 500/);
+  describeChrome.run('Submit result message', () => {
+    it('should render messages with or without a template', () => {
+      // Stubbing timeout to catch async-thrown errors and expect
+      // them. These catch errors thrown inside the catch-clause of the
+      // xhr request using rethrowAsync.
+      sandbox.stub(window, 'setTimeout').callsFake(stubSetTimeout);
 
-          // It shouldn't have the i-amphtml-rendered attribute since no
-          // template was rendered.
-          const rendered = form.querySelectorAll('[i-amphtml-rendered]');
-          expect(rendered.length).to.equal(0);
+      const form = getForm({
+        id: 'form1',
+        actionXhr: baseUrl + '/form/post/error',
+        success: {message: 'Should not render this.', template: false},
+        error: {
+          message: 'Oops! Your email is already subscribed.' +
+              '<amp-img src="/examples/img/ampicon.png" ' +
+              'width="42" height="42"></amp-img>',
+          template: false,
+        },
+      });
+      const ampForm = new AmpForm(form, 'form1');
+      const fetchSpy = sandbox.spy(ampForm.xhr_, 'fetch');
+      const fetch = poll('submit request sent', () => fetchSpy.returnValues[0]);
 
-          // Any amp elements inside the message should be layed out.
-          const layout = listenOncePromise(form, AmpEvents.LOAD_START);
-          return layout.then(() => {
-            const img = form.querySelector('amp-img img');
-            expect(img.src).to.contain('/examples/img/ampicon.png');
-          });
+      form.dispatchEvent(new Event('submit'));
+      return fetch.then(() => {
+        throw new Error('UNREACHABLE');
+      }, fetchError => {
+        expect(fetchError.message).to.match(/HTTP error 500/);
+
+        // It shouldn't have the i-amphtml-rendered attribute since no
+        // template was rendered.
+        const rendered = form.querySelectorAll('[i-amphtml-rendered]');
+        expect(rendered.length).to.equal(0);
+
+        // Any amp elements inside the message should be layed out.
+        const layout = listenOncePromise(form, AmpEvents.LOAD_START);
+        return layout.then(() => {
+          const img = form.querySelector('amp-img img');
+          expect(img.src).to.contain('/examples/img/ampicon.png');
         });
       });
     });

--- a/extensions/amp-form/0.1/test/test-amp-form.js
+++ b/extensions/amp-form/0.1/test/test-amp-form.js
@@ -538,9 +538,7 @@ describes.repeated('', {
       });
     });
 
-    // TODO(danielrozenberg, #14336): Fails due to console errors.
-    it.skip('should allow rendering responses through inlined ' +
-        'templates', () => {
+    it('should allow rendering responses through inlined templates', () => {
       return getAmpForm(getForm(env.win.document, true)).then(ampForm => {
         const form = ampForm.form_;
         // Add a div[submit-error] with a template child.
@@ -1633,8 +1631,7 @@ describes.repeated('', {
           });
         });
 
-        // TODO(cvializ, #14336): Fails due to console errors.
-        it.skip('should redirect on error and header is set', () => {
+        it('should redirect on error and header is set', () => {
           sandbox.stub(ampForm.xhr_, 'fetch').returns(fetchRejectPromise);
           redirectToValue = 'https://example2.com/hello';
           const logSpy = sandbox.spy(user(), 'error');

--- a/extensions/amp-gwd-animation/0.1/test/test-amp-gwd-animation.js
+++ b/extensions/amp-gwd-animation/0.1/test/test-amp-gwd-animation.js
@@ -283,8 +283,7 @@ describes.sandboxed('AMP GWD Animation', {}, () => {
         });
       });
 
-      // TODO(dvoytenko, #14336): Fails due to console errors.
-      it.skip('should execute play', () => {
+      it('should execute play', () => {
         return ampdoc.whenBodyAvailable().then(() => {
           // Pause an animation to test resuming it.
           const pauseInvocation = {
@@ -313,8 +312,7 @@ describes.sandboxed('AMP GWD Animation', {}, () => {
         });
       });
 
-      // TODO(dvoytenko, #14336): Fails due to console errors.
-      it.skip('should execute pause', () => {
+      it('should execute pause', () => {
         return ampdoc.whenBodyAvailable().then(() => {
           const invocation = {
             method: 'pause',
@@ -336,8 +334,7 @@ describes.sandboxed('AMP GWD Animation', {}, () => {
         });
       });
 
-      // TODO(dvoytenko, #14336): Fails due to console errors.
-      it.skip('should execute togglePlay', () => {
+      it('should execute togglePlay', () => {
         return ampdoc.whenBodyAvailable().then(() => {
           const invocation = {
             method: 'togglePlay',
@@ -358,8 +355,7 @@ describes.sandboxed('AMP GWD Animation', {}, () => {
         });
       });
 
-      // TODO(dvoytenko, #14336): Fails due to console errors.
-      it.skip('should execute gotoAndPlay', () => {
+      it('should execute gotoAndPlay', () => {
         return ampdoc.whenBodyAvailable().then(() => {
           const invocation = {
             method: 'gotoAndPlay',
@@ -391,8 +387,7 @@ describes.sandboxed('AMP GWD Animation', {}, () => {
         });
       });
 
-      // TODO(dvoytenko, #14336): Fails due to console errors.
-      it.skip('should execute gotoAndPause', () => {
+      it('should execute gotoAndPause', () => {
         return ampdoc.whenBodyAvailable().then(() => {
           // Test handling missing arguments.
           const invocation = {
@@ -419,8 +414,7 @@ describes.sandboxed('AMP GWD Animation', {}, () => {
         });
       });
 
-      // TODO(dvoytenko, #14336): Fails due to console errors.
-      it.skip('should execute gotoAndPlayNTimes', () => {
+      it('should execute gotoAndPlayNTimes', () => {
         return ampdoc.whenBodyAvailable().then(() => {
           // Invoking gotoAndPlayNTimes with a negative N value is a no-op.
           const invocationWithBadNValue = {

--- a/extensions/amp-iframe/0.1/test/test-amp-iframe.js
+++ b/extensions/amp-iframe/0.1/test/test-amp-iframe.js
@@ -515,9 +515,7 @@ describes.realWin('amp-iframe', {
       expect(attemptChangeSize.firstCall.args[1]).to.be.undefined;
     });
 
-    // TODO(zhouyx, #14336): Fails due to console errors.
-    it.skip('should not resize amp-iframe if request height is' +
-        'small', function* () {
+    it('should not resize amp-iframe if request height is small', function* () {
       const ampIframe = createAmpIframe(env, {
         src: iframeSrc,
         sandbox: 'allow-scripts',
@@ -532,9 +530,7 @@ describes.realWin('amp-iframe', {
       expect(attemptChangeSize).to.have.not.been.called;
     });
 
-    // TODO(zhouyx, #14336): Fails due to console errors.
-    it.skip('should not resize amp-iframe if it is ' +
-        'non-resizable', function* () {
+    it('should not resize amp-iframe if it is non-resizable', function* () {
       const ampIframe = createAmpIframe(env, {
         src: iframeSrc,
         sandbox: 'allow-scripts',
@@ -578,8 +574,7 @@ describes.realWin('amp-iframe', {
       expect(impl.looksLikeTrackingIframe_()).to.be.false;
     });
 
-    // TODO(zhouyx, #14336): Fails due to console errors.
-    it.skip('should detect tracking iframes', function* () {
+    it('should detect tracking iframes', function* () {
       const ampIframe1 = createAmpIframe(env, {
         src: clickableIframeSrc,
         sandbox: 'allow-scripts allow-same-origin',
@@ -624,8 +619,7 @@ describes.realWin('amp-iframe', {
       expect(ampIframe3.querySelector('iframe')).to.not.be.null;
     });
 
-    // TODO(zhouyx, #14336): Fails due to console errors.
-    it.skip('should not detect traking iframe in amp container', function* () {
+    it('should not detect traking iframe in amp container', function* () {
       const ampIframeRealTracking = createAmpIframe(env, {
         src: iframeSrc,
         width: 5,

--- a/extensions/amp-install-serviceworker/0.1/test/test-amp-install-serviceworker.js
+++ b/extensions/amp-install-serviceworker/0.1/test/test-amp-install-serviceworker.js
@@ -99,8 +99,7 @@ describes.realWin('amp-install-serviceworker', {
     expect(maybeInstallUrlRewriteStub).to.be.calledOnce;
   });
 
-  // TODO(malteubl, #14336): Fails due to console errors.
-  it.skip('should do nothing with non-matching origins', () => {
+  it('should do nothing with non-matching origins', () => {
     const install = doc.createElement('amp-install-serviceworker');
     const implementation = install.implementation_;
     expect(implementation).to.exist;

--- a/extensions/amp-mustache/0.1/test/test-amp-mustache.js
+++ b/extensions/amp-mustache/0.1/test/test-amp-mustache.js
@@ -38,8 +38,7 @@ describe('amp-mustache template', () => {
     expect(result./*OK*/innerHTML).to.equal('value = abc');
   });
 
-  // TODO(dvoytenko, #14336): Fails due to console errors.
-  it.skip('should sanitize output', () => {
+  it('should sanitize output', () => {
     const templateElement = document.createElement('template');
     templateElement./*OK*/innerHTML =
         'value = <a href="{{value}}">abc</a>';
@@ -65,8 +64,7 @@ describe('amp-mustache template', () => {
     expect(result.firstElementChild).to.be.null;
   });
 
-  // TODO(dvoytenko, #14336): Fails due to console errors.
-  describe.skip('Sanitizing data- attributes', () => {
+  describe('Sanitizing data- attributes', () => {
 
     it('should sanitize templated attribute names', () => {
       const templateElement = document.createElement('template');
@@ -134,8 +132,7 @@ describe('amp-mustache template', () => {
     });
   });
 
-  // TODO(mkhatib, #14336): Fails due to console errors.
-  describe.skip('Rendering Form Fields', () => {
+  describe('Rendering Form Fields', () => {
     it('should allow rendering inputs', () => {
       const templateElement = document.createElement('template');
       templateElement./*OK*/innerHTML = 'value = ' +
@@ -303,8 +300,7 @@ describe('amp-mustache template', () => {
       expect(nestedResult./*OK*/innerHTML).to.equal('nested: Nested');
     });
 
-    // TODO(danielrozenberg, #14336): Fails due to console errors.
-    it.skip('should sanitize the inner template when it gets rendered', () => {
+    it('should sanitize the inner template when it gets rendered', () => {
       const outerTemplateElement = document.createElement('template');
       outerTemplateElement./*OK*/innerHTML =
           'outer: {{value}} ' +

--- a/extensions/amp-share-tracking/0.1/test/test-amp-share-tracking.js
+++ b/extensions/amp-share-tracking/0.1/test/test-amp-share-tracking.js
@@ -185,8 +185,7 @@ describes.fakeWin('amp-share-tracking', {
         });
   });
 
-  // TODO(lannka, #14336): Fails due to console errors.
-  it.skip('should get empty outgoing fragment if vendor url is provided ' +
+  it('should get empty outgoing fragment if vendor url is provided ' +
       'but the response format is NOT correct', () => {
     historyGetFragmentStub.onFirstCall().returns(Promise.resolve(''));
     xhrStub.onFirstCall().returns(Promise.resolve({
@@ -227,8 +226,7 @@ describes.fakeWin('amp-share-tracking', {
         });
   });
 
-  // TODO(lannka, #14336): Fails due to console errors.
-  it.skip('should get empty outgoing fragment if vendor url is provided ' +
+  it('should get empty outgoing fragment if vendor url is provided ' +
       'but the xhr fails', () => {
     historyGetFragmentStub.onFirstCall().returns(Promise.resolve(''));
     xhrStub.onFirstCall().returns(Promise.reject({

--- a/extensions/amp-sidebar/0.1/test/integration/test-amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/test/integration/test-amp-sidebar.js
@@ -16,8 +16,7 @@
 
 import {poll} from '../../../../../testing/iframe';
 
-// TODO(cathyxz, #14336): Fails due to console errors.
-describe.skip('amp-sidebar', function() {
+describe.configure().skipSafari().skipEdge().run('amp-sidebar', function() {
   // Extend timeout slightly for flakes on Windows environments
   this.timeout(4000);
   const extensions = ['amp-sidebar'];

--- a/extensions/amp-sticky-ad/1.0/test/test-amp-sticky-ad.js
+++ b/extensions/amp-sticky-ad/1.0/test/test-amp-sticky-ad.js
@@ -51,8 +51,7 @@ describes.realWin('amp-sticky-ad 1.0 version', {
               () => addToFixedLayerPromise);
     });
 
-    // TODO(zhouyx, #14336): Fails due to console errors.
-    it.skip('should listen to scroll event', function * () {
+    it('should listen to scroll event', function * () {
       expect(impl.scrollUnlisten_).to.be.null;
       yield macroTask();
       expect(impl.scrollUnlisten_).to.be.a('function');

--- a/extensions/amp-subscriptions/0.1/test/test-platform-store.js
+++ b/extensions/amp-subscriptions/0.1/test/test-platform-store.js
@@ -18,6 +18,7 @@ import {Entitlement} from '../entitlement';
 
 import {PlatformStore} from '../platform-store';
 import {SubscriptionPlatform} from '../subscription-platform';
+import {user} from '../../../../src/log';
 
 describes.realWin('Platform store', {}, () => {
   let platformStore;
@@ -256,11 +257,17 @@ describes.realWin('Platform store', {}, () => {
   });
 
   describe('reportPlatformFailure_', () => {
+    let errorSpy;
+    beforeEach(() => {
+      errorSpy = sandbox.spy(user(), 'error');
+    });
 
     it('should report fatal error if all platforms fail', () => {
       platformStore.reportPlatformFailure('service1');
-      expect(() => platformStore.reportPlatformFailure('service2'))
-          .to.throw(/All platforms have failed to resolve/);
+      allowConsoleError(() => {
+        platformStore.reportPlatformFailure('service2');
+      });
+      expect(errorSpy).to.be.calledOnce;
     });
   });
 

--- a/extensions/amp-user-notification/0.1/test/test-amp-user-notification.js
+++ b/extensions/amp-user-notification/0.1/test/test-amp-user-notification.js
@@ -287,8 +287,7 @@ describes.realWin('amp-user-notification', {
     });
   });
 
-  // TODO(dvoytenko, #14336): Fails due to console errors.
-  it.skip('shouldShow should recover from error to xhr', () => {
+  it('shouldShow should recover from error to xhr', () => {
     const el = getUserNotification(dftAttrs);
     const impl = el.implementation_;
     impl.buildCallback();
@@ -311,9 +310,7 @@ describes.realWin('amp-user-notification', {
     });
   });
 
-  // TODO(dvoytenko, #14336): Fails due to console errors.
-  it.skip('shouldShow should recover from error and return true with ' +
-      'no xhr', () => {
+  it('shouldShow should recover from error and return true with no xhr', () => {
     const el = getUserNotification({id: 'n1'});
     const impl = el.implementation_;
     impl.buildCallback();
@@ -647,8 +644,7 @@ describes.realWin('amp-user-notification', {
       });
     });
 
-    // TODO(aghassemi, #14336): Fails due to console errors.
-    it.skip('should dissmiss without persistence if cid.optOut() fails', () => {
+    it('should dissmiss without persistence if cid.optOut() fails', () => {
       const element = getUserNotification({id: 'n1'});
       const impl = element.implementation_;
       impl.buildCallback();

--- a/extensions/amp-youtube/0.1/test/test-amp-youtube.js
+++ b/extensions/amp-youtube/0.1/test/test-amp-youtube.js
@@ -134,9 +134,7 @@ describes.realWin('amp-youtube', {
       });
     });
 
-
-    // TODO(cathyxz, #14336): Fails due to console errors.
-    it.skip('should pass data-param-* attributes to the iframe src', () => {
+    it('should pass data-param-* attributes to the iframe src', () => {
       return getYt({
         'data-videoid': datasource,
         'data-param-autoplay': '1',

--- a/test/_init_tests.js
+++ b/test/_init_tests.js
@@ -309,6 +309,9 @@ function restoreConsoleError() {
 
 // Used to silence info, log, and warn level logging during each test.
 function stubConsoleInfoLogWarn() {
+  if (consoleInfoLogWarnSandbox) {
+    consoleInfoLogWarnSandbox.restore();
+  }
   consoleInfoLogWarnSandbox = sinon.sandbox.create();
   consoleInfoLogWarnSandbox.stub(console, 'info').callsFake(() => {});
   consoleInfoLogWarnSandbox.stub(console, 'log').callsFake(() => {});

--- a/test/functional/inabox/test-inabox-frame-overlay-manager.js
+++ b/test/functional/inabox/test-inabox-frame-overlay-manager.js
@@ -40,6 +40,7 @@ describes.fakeWin('inabox-host:FrameOverlayManager', {}, env => {
   });
 
   afterEach(() => {
+    sandbox.reset();
     sandbox.restore();
   });
 

--- a/test/functional/inabox/test-inabox-viewport.js
+++ b/test/functional/inabox/test-inabox-viewport.js
@@ -84,8 +84,7 @@ describes.fakeWin('inabox-viewport', {amp: {}}, env => {
     sandbox.restore();
   });
 
-  // TODO(alanorozco, #14336): Fails due to console errors.
-  it.skip('should work for size, layoutRect and position observer', () => {
+  it('should work for size, layoutRect and position observer', () => {
     stubIframeClientMakeRequest(
         'send-positions',
         'position',
@@ -114,7 +113,7 @@ describes.fakeWin('inabox-viewport', {amp: {}}, env => {
     expect(measureSpy).to.be.calledOnce;
     expect(binding.getLayoutRect(element))
         .to.deep.equal(layoutRectLtwh(10, 20, 100, 100));
-    sandbox.restore();
+    sandbox.reset();
 
     // Scroll, viewport position changed
     positionCallback({
@@ -127,7 +126,7 @@ describes.fakeWin('inabox-viewport', {amp: {}}, env => {
     expect(measureSpy).to.not.be.called;
     expect(binding.getLayoutRect(element))
         .to.deep.equal(layoutRectLtwh(10, 20, 100, 100));
-    sandbox.restore();
+    sandbox.reset();
 
     // Resize, viewport size changed
     positionCallback({
@@ -140,6 +139,7 @@ describes.fakeWin('inabox-viewport', {amp: {}}, env => {
     expect(measureSpy).to.not.be.called;
     expect(binding.getLayoutRect(element))
         .to.deep.equal(layoutRectLtwh(10, 20, 100, 100));
+    sandbox.reset();
 
     // DOM change, target position changed
     sandbox.restore();

--- a/test/functional/test-3p.js
+++ b/test/functional/test-3p.js
@@ -74,17 +74,6 @@ describe('3p', () => {
   });
 
   describe('validateData', () => {
-    let sandbox;
-    let clock;
-
-    beforeEach(() => {
-      sandbox = sinon.sandbox.create();
-      clock = sandbox.useFakeTimers();
-    });
-
-    afterEach(() => {
-      sandbox.restore();
-    });
 
     it('should check mandatory fields', () => {
       validateData({

--- a/test/functional/test-action.js
+++ b/test/functional/test-action.js
@@ -720,8 +720,7 @@ describe('installActionHandler', () => {
     expect(callArgs.event).to.be.equal('tap');
   });
 
-  // TODO(choumx, #14336): Fails due to console errors.
-  it.skip('should check trust level before invoking action', () => {
+  it('should check trust level before invoking action', () => {
     const handlerSpy = sandbox.spy();
     const target = document.createElement('form');
     action.installActionHandler(target, handlerSpy, ActionTrust.HIGH);
@@ -960,8 +959,7 @@ describe('Action common handler', () => {
     expect(target['__AMP_ACTION_QUEUE__']).to.not.exist;
   });
 
-  // TODO(choumx, #14336): Fails due to console errors.
-  it.skip('should check trust before invoking action', () => {
+  it('should check trust before invoking action', () => {
     const handler = sandbox.spy();
     action.addGlobalMethodHandler('foo', handler, ActionTrust.HIGH);
 

--- a/test/functional/test-cid-api.js
+++ b/test/functional/test-cid-api.js
@@ -148,8 +148,7 @@ describes.realWin('test-cid-api', {amp: true}, env => {
     });
   });
 
-  // TODO(lannka, #14336): Fails due to console errors.
-  it.skip('should return null if API rejects', () => {
+  it('should return null if API rejects', () => {
     fetchJsonStub.returns(Promise.reject());
     return api.getScopedCid('api-key', 'scope-a').then(cid => {
       expect(cid).to.be.null;

--- a/test/functional/test-cid.js
+++ b/test/functional/test-cid.js
@@ -874,8 +874,7 @@ describes.realWin('cid', {amp: true}, env => {
       expect(cid.isScopeOptedIn_('bar')).to.equal('bar-api-key');
     });
 
-    // TODO(lannka, #14336): Fails due to console errors.
-    it.skip('should not work if vendor not whitelisted', () => {
+    it('should not work if vendor not whitelisted', () => {
       ampdoc.win.document.head.innerHTML +=
           '<meta name="amp-google-client-id-api" content="abodeanalytics">';
       expect(cid.isScopeOptedIn_('AMP_ECID_GOOGLE')).to.equal(undefined);

--- a/test/functional/test-cid.js
+++ b/test/functional/test-cid.js
@@ -296,8 +296,7 @@ describe('cid', () => {
           '');
     });
 
-    // TODO(lannka, #14336): Fails due to console errors.
-    it.skip('should read from viewer storage if embedded', () => {
+    it('should read from viewer storage if embedded', () => {
       fakeWin.parent = {};
       const expectedBaseCid = 'from-viewer';
       viewerStorage = JSON.stringify({
@@ -320,8 +319,7 @@ describe('cid', () => {
       });
     });
 
-    // TODO(lannka, #14336): Fails due to console errors.
-    it.skip('should read from viewer storage if embedded and convert cid to ' +
+    it('should read from viewer storage if embedded and convert cid to ' +
         'new format', () => {
       fakeWin.parent = {};
       const expectedBaseCid = 'from-viewer';
@@ -352,8 +350,7 @@ describe('cid', () => {
       });
     });
 
-    // TODO(lannka, #14336): Fails due to console errors.
-    it.skip('should store to viewer storage if embedded', () => {
+    it('should store to viewer storage if embedded', () => {
       fakeWin.parent = {};
       const expectedBaseCid = 'sha384([1,2,3,0,0,0,0,0,0,0,0,0,0,0,0,15])';
       return compare('e2', `sha384(${expectedBaseCid}http://www.origin.come2)`)
@@ -384,8 +381,7 @@ describe('cid', () => {
           'sha384(in-storagehttp://www.origin.come2)');
     });
 
-    // TODO(lannka, #14336): Fails due to console errors.
-    it.skip('should expire on read after 365 days', () => {
+    it('should expire on read after 365 days', () => {
       const expected = 'sha384(sha384([1,2,3,0,0,0,0,0,0,0,0,0,0,0,0,15])http://www.origin.come2)';
       return compare('e2', expected).then(() => {
         clock.tick(364 * DAY);
@@ -403,8 +399,7 @@ describe('cid', () => {
       });
     });
 
-    // TODO(lannka, #14336): Fails due to console errors.
-    it.skip('should expire on read after 365 days when embedded', () => {
+    it('should expire on read after 365 days when embedded', () => {
       fakeWin.parent = {};
       const expectedBaseCid = 'from-viewer';
       viewerStorage = JSON.stringify({
@@ -445,8 +440,7 @@ describe('cid', () => {
       });
     });
 
-    // TODO(lannka, #14336): Fails due to console errors.
-    it.skip('should set last access time once a day when embedded', () => {
+    it('should set last access time once a day when embedded', () => {
       fakeWin.parent = {};
       const expected = 'sha384(sha384([1,2,3,0,0,0,0,0,0,0,0,0,0,0,0,15])http://www.origin.come2)';
       function getStoredTime() {
@@ -532,8 +526,7 @@ describe('cid', () => {
       });
     });
 
-    // TODO(lannka, #14336): Fails due to console errors.
-    it.skip('should not wait persistence consent for viewer storage', () => {
+    it('should not wait persistence consent for viewer storage', () => {
       fakeWin.parent = {};
       const persistencePromise = new Promise(() => {/* never resolves */});
       return cid.get({scope: 'e2'}, hasConsent, persistencePromise).then(() => {
@@ -769,8 +762,7 @@ describes.realWin('cid', {amp: true}, env => {
         .to.eventually.equal('cid-from-viewer');
   });
 
-  // TODO(zhouyx, #14336): Fails due to console errors.
-  it.skip('get method should time out when in Viewer', function *() {
+  it('get method should time out when in Viewer', function *() {
     win.parent = {};
     stubServiceForDoc(sandbox, ampdoc, 'viewer', 'sendMessageAwaitResponse')
         .returns(new Promise(() => {}));

--- a/test/functional/test-crypto.js
+++ b/test/functional/test-crypto.js
@@ -129,14 +129,13 @@ describes.realWin('crypto-impl', {}, env => {
       },
     },
   });
-  // TODO(keithwrightbos, #14336): Fails due to console errors.
-  // testSuite('with native crypto API throws', {
-  //   crypto: {
-  //     subtle: {
-  //       digest: () => {throw new Error();},
-  //     },
-  //   },
-  // });
+  testSuite('with native crypto API throws', {
+    crypto: {
+      subtle: {
+        digest: () => {throw new Error();},
+      },
+    },
+  });
 
   it('native API result should exactly equal to crypto lib result', () => {
     return Promise

--- a/test/functional/test-custom-element.js
+++ b/test/functional/test-custom-element.js
@@ -323,8 +323,7 @@ describes.realWin('CustomElement', {amp: true}, env => {
       expect(element.implementation_.layoutWidth_).to.equal(111);
     });
 
-    // TODO(dvoytenko, #14336): Fails due to console errors.
-    it.skip('should tolerate erros in onLayoutMeasure', () => {
+    it('should tolerate erros in onLayoutMeasure', () => {
       const element = new ElementClass();
       sandbox.stub(element.implementation_, 'onLayoutMeasure').callsFake(() => {
         throw new Error('intentional');
@@ -987,8 +986,7 @@ describes.realWin('CustomElement', {amp: true}, env => {
       expect(element2).to.have.class('i-amphtml-hidden-by-media-query');
     });
 
-    // TODO(dvoytenko, #14336): Fails due to console errors.
-    it.skip('should apply sizes condition', () => {
+    it('should apply sizes condition', () => {
       const element1 = new ElementClass();
       element1.setAttribute('sizes', '(min-width: 1px) 200px, 50vw');
       element1.applySizesAndMediaQuery();
@@ -1000,8 +998,7 @@ describes.realWin('CustomElement', {amp: true}, env => {
       expect(element2.style.width).to.equal('50vw');
     });
 
-    // TODO(dvoytenko, #14336): Fails due to console errors.
-    it.skip('should apply heights condition', () => {
+    it('should apply heights condition', () => {
       const element1 = new ElementClass();
       element1.sizerElement = doc.createElement('div');
       element1.setAttribute('layout', 'responsive');

--- a/test/functional/test-dom.js
+++ b/test/functional/test-dom.js
@@ -792,8 +792,7 @@ describes.sandboxed('DOM', {}, env => {
       expect(res).to.equal(dialog);
     });
 
-    // TODO(dvoytenko, #14336): Fails due to console errors.
-    it.skip('should retry on first exception', () => {
+    it('should retry on first exception', () => {
       const dialog = {};
       windowMock.expects('open')
           .withExactArgs('https://example.com/', '_blank', 'width=1')
@@ -822,8 +821,7 @@ describes.sandboxed('DOM', {}, env => {
       expect(res).to.be.null;
     });
 
-    // TODO(dvoytenko, #14336): Fails due to console errors.
-    it.skip('should return the final exception', () => {
+    it('should return the final exception', () => {
       windowMock.expects('open')
           .withExactArgs('https://example.com/', '_blank', 'width=1')
           .throws(new Error('intentional1'))

--- a/test/functional/test-error.js
+++ b/test/functional/test-error.js
@@ -39,64 +39,60 @@ import {
 import {user} from '../../src/log';
 
 describes.fakeWin('installErrorReporting', {}, env => {
-  // TODO(dvoytenko, #14336): Fails due to console errors.
-  describe.skip('installErrorReporting',() => {
-    let sandbox;
-    let win;
-    let rejectedPromiseError;
-    let rejectedPromiseEvent;
-    let rejectedPromiseEventCancelledSpy;
+  let sandbox;
+  let win;
+  let rejectedPromiseError;
+  let rejectedPromiseEvent;
+  let rejectedPromiseEventCancelledSpy;
 
-    beforeEach(() => {
-      win = env.win;
-      installErrorReporting(win);
-      sandbox = env.sandbox;
-      rejectedPromiseEventCancelledSpy = sandbox.spy();
-      rejectedPromiseError = new Error('error');
-      rejectedPromiseEvent = {
-        type: 'unhandledrejection',
-        reason: rejectedPromiseError,
-        preventDefault: rejectedPromiseEventCancelledSpy,
-      };
-    });
+  beforeEach(() => {
+    win = env.win;
+    installErrorReporting(win);
+    sandbox = env.sandbox;
+    rejectedPromiseEventCancelledSpy = sandbox.spy();
+    rejectedPromiseError = new Error('error');
+    rejectedPromiseEvent = {
+      type: 'unhandledrejection',
+      reason: rejectedPromiseError,
+      preventDefault: rejectedPromiseEventCancelledSpy,
+    };
+  });
 
-    it('should install window.onerror handler', () => {
-      expect(win.onerror).to.not.be.null;
-    });
+  it('should install window.onerror handler', () => {
+    expect(win.onerror).to.not.be.null;
+  });
 
-    it('should install unhandledrejection handler', () => {
-      expect(win.eventListeners.count('unhandledrejection')).to.equal(1);
-    });
+  it('should install unhandledrejection handler', () => {
+    expect(win.eventListeners.count('unhandledrejection')).to.equal(1);
+  });
 
-    it('should report the normal promise rejection', () => {
-      win.eventListeners.fire(rejectedPromiseEvent);
-      expect(rejectedPromiseError.reported).to.be.true;
-      expect(rejectedPromiseEventCancelledSpy).to.not.be.called;
-    });
+  it('should report the normal promise rejection', () => {
+    win.eventListeners.fire(rejectedPromiseEvent);
+    expect(rejectedPromiseError.reported).to.be.true;
+    expect(rejectedPromiseEventCancelledSpy).to.not.be.called;
+  });
 
-    it('should allow null errors', () => {
-      rejectedPromiseEvent.reason = null;
-      win.eventListeners.fire(rejectedPromiseEvent);
-      expect(rejectedPromiseEventCancelledSpy).to.not.be.called;
-    });
+  it('should allow null errors', () => {
+    rejectedPromiseEvent.reason = null;
+    win.eventListeners.fire(rejectedPromiseEvent);
+    expect(rejectedPromiseEventCancelledSpy).to.not.be.called;
+  });
 
-    it('should allow string errors', () => {
-      rejectedPromiseEvent.reason = 'string error';
-      win.eventListeners.fire(rejectedPromiseEvent);
-      expect(rejectedPromiseEventCancelledSpy).to.not.be.called;
-    });
+  it('should allow string errors', () => {
+    rejectedPromiseEvent.reason = 'string error';
+    win.eventListeners.fire(rejectedPromiseEvent);
+    expect(rejectedPromiseEventCancelledSpy).to.not.be.called;
+  });
 
-    it('should ignore cancellation', () => {
-      rejectedPromiseEvent.reason = rejectedPromiseError = cancellation();
-      win.eventListeners.fire(rejectedPromiseEvent);
-      expect(rejectedPromiseError.reported).to.be.not.be.ok;
-      expect(rejectedPromiseEventCancelledSpy).to.be.calledOnce;
-    });
+  it('should ignore cancellation', () => {
+    rejectedPromiseEvent.reason = rejectedPromiseError = cancellation();
+    win.eventListeners.fire(rejectedPromiseEvent);
+    expect(rejectedPromiseError.reported).to.be.not.be.ok;
+    expect(rejectedPromiseEventCancelledSpy).to.be.calledOnce;
   });
 });
 
-// TODO(dvoytenko, #14336): Fails due to console errors.
-describe.skip('maybeReportErrorToViewer', () => {
+describe('maybeReportErrorToViewer', () => {
   let win;
   let viewer;
   let sandbox;
@@ -169,8 +165,7 @@ describe.skip('maybeReportErrorToViewer', () => {
   });
 });
 
-// TODO(dvoytenko, #14336): Fails due to console errors.
-describe.skip('reportErrorToServer', () => {
+describe('reportErrorToServer', () => {
   let sandbox;
   let onError;
   let nextRandomNumber;
@@ -532,8 +527,7 @@ describes.sandboxed('reportError', {}, () => {
     clock = sandbox.useFakeTimers();
   });
 
-  // TODO(dvoytenko, #14336): Fails due to console errors.
-  it.skip('should accept Error type', () => {
+  it('should accept Error type', () => {
     const error = new Error('error');
     const result = reportError(error);
     expect(result).to.equal(error);
@@ -630,8 +624,7 @@ describes.fakeWin('user error reporting', {amp: true}, env => {
     toggleExperiment(win, 'user-error-reporting', true);
   });
 
-  // TODO(tiendao, #14336): Fails due to console errors.
-  it.skip('should trigger triggerAnalyticsEvent with correct arguments', () => {
+  it('should trigger triggerAnalyticsEvent with correct arguments', () => {
     reportErrorToAnalytics(error, win);
     expect(analyticsEventSpy).to.have.been.called;
     expect(analyticsEventSpy).to.have.been.calledWith(

--- a/test/functional/test-experiments.js
+++ b/test/functional/test-experiments.js
@@ -893,16 +893,14 @@ describes.fakeWin('isOriginExperimentOn', {amp: false}, env => {
         .to.eventually.be.false;
   });
 
-  // TODO(choumx, #14336): Fails due to console errors.
-  it.skip('should return false for missing token', () => {
+  it('should return false for missing token', () => {
     setupMetaTagWith('');
 
     return expect(isOriginExperimentOn(win, 'foo', true))
         .to.eventually.be.false;
   });
 
-  // TODO(choumx, #14336): Fails due to console errors.
-  it.skip('should return false if origin does not match', () => {
+  it('should return false if origin does not match', () => {
     setupMetaTagWith(token);
     win.location.href = 'https://not-origin.com';
 

--- a/test/functional/test-navigation.js
+++ b/test/functional/test-navigation.js
@@ -496,8 +496,7 @@ describes.sandboxed('Navigation', {}, () => {
         win.location.href = 'https://www.pub.com/';
       });
 
-      // TODO(choumx, #14336): Fails due to console errors.
-      it.skip('should reject invalid protocols', () => {
+      it('should reject invalid protocols', () => {
         const newUrl = /*eslint no-script-url: 0*/ 'javascript:alert(1)';
 
         expect(win.location.href).to.equal('https://www.pub.com/');

--- a/test/functional/test-resource.js
+++ b/test/functional/test-resource.js
@@ -111,8 +111,7 @@ describes.realWin('Resource', {amp: true}, env => {
     });
   });
 
-  // TODO(dvoytenko, #14336): Fails due to console errors.
-  it.skip('should blacklist on build failure', () => {
+  it('should blacklist on build failure', () => {
     elementMock.expects('isUpgraded').returns(true).atLeast(1);
     elementMock.expects('build')
         .returns(Promise.reject(new Error('intentional'))).once();

--- a/test/functional/test-resources.js
+++ b/test/functional/test-resources.js
@@ -2959,8 +2959,7 @@ describes.fakeWin('Resources.add/upgrade/remove', {amp: true}, env => {
       expect(resources.pendingBuildResources_.length).to.be.equal(0);
     });
 
-    // TODO(mkhatib, #14336): Fails due to console errors.
-    it.skip('should build everything pending when document is ready', () => {
+    it('should build everything pending when document is ready', () => {
       resources.documentReady_ = true;
       resources.pendingBuildResources_ = [parentResource, resource1, resource2];
       const child1BuildSpy = sandbox.spy();
@@ -2993,8 +2992,7 @@ describes.fakeWin('Resources.add/upgrade/remove', {amp: true}, env => {
       });
     });
 
-    // TODO(dvoytenko, #14336): Fails due to console errors.
-    it.skip('should not schedule pass if all builds failed', () => {
+    it('should not schedule pass if all builds failed', () => {
       resources.documentReady_ = true;
       resources.pendingBuildResources_ = [resource1];
       const child1BuildSpy = sandbox.spy();

--- a/test/functional/test-runtime.js
+++ b/test/functional/test-runtime.js
@@ -1026,8 +1026,7 @@ describes.realWin('runtime multidoc', {
       win.AMP.attachShadowDoc(hostElement, importDoc, docUrl);
     });
 
-    // TODO(dvoytenko, #14336): Fails due to console errors.
-    it.skip('should ignore unknown script', () => {
+    it('should ignore unknown script', () => {
       extensionsMock.expects('preloadExtension').never();
 
       const scriptEl = win.document.createElement('script');
@@ -1107,8 +1106,7 @@ describes.realWin('runtime multidoc', {
           'script[data-id="test1"]').textContent).to.equal('{}');
     });
 
-    // TODO(dvoytenko, #14336): Fails due to console errors.
-    it.skip('should ignore inline script if javascript', () => {
+    it('should ignore inline script if javascript', () => {
       const scriptEl1 = win.document.createElement('script');
       scriptEl1.setAttribute('type', 'application/javascript');
       scriptEl1.setAttribute('data-id', 'test1');
@@ -1370,8 +1368,7 @@ describes.realWin('runtime multidoc', {
       return ampdoc.whenBodyAvailable();
     });
 
-    // TODO(dvoytenko, #14336): Fails due to console errors.
-    it.skip('should ignore unknown script', () => {
+    it('should ignore unknown script', () => {
       shadowDoc = win.AMP.attachShadowDocAsStream(hostElement, docUrl);
       writer = shadowDoc.writer;
       extensionsMock.expects('preloadExtension').never();
@@ -1437,8 +1434,7 @@ describes.realWin('runtime multidoc', {
       });
     });
 
-    // TODO(dvoytenko, #14336): Fails due to console errors.
-    it.skip('should ignore inline script if javascript', () => {
+    it('should ignore inline script if javascript', () => {
       shadowDoc = win.AMP.attachShadowDocAsStream(hostElement, docUrl);
       writer = shadowDoc.writer;
       writer.write(

--- a/test/functional/test-sanitizer.js
+++ b/test/functional/test-sanitizer.js
@@ -136,8 +136,7 @@ describe('sanitizeHtml', () => {
         + '<a target="_top">other</a>');
   });
 
-  // TODO(dvoytenko, #14336): Fails due to console errors.
-  it.skip('should NOT output security-sensitive attributes', () => {
+  it('should NOT output security-sensitive attributes', () => {
     expect(sanitizeHtml('a<a onclick="alert">b</a>')).to.be.equal('a<a>b</a>');
     expect(sanitizeHtml('a<a style="color: red;">b</a>')).to.be.equal(
         'a<a>b</a>');
@@ -161,14 +160,12 @@ describe('sanitizeHtml', () => {
         'a<a target="_top">b</a>');
   });
 
-  // TODO(dvoytenko, #14336): Fails due to console errors.
-  it.skip('should catch attribute value whitespace variations', () => {
+  it('should catch attribute value whitespace variations', () => {
     expect(sanitizeHtml('a<a href=" j\na\tv\ra s&#00;cript:alert">b</a>'))
         .to.be.equal('a<a target="_top">b</a>');
   });
 
-  // TODO(dvoytenko, #14336): Fails due to console errors.
-  it.skip('should NOT output security-sensitive attributes', () => {
+  it('should NOT output security-sensitive attributes', () => {
     expect(sanitizeHtml('a<a onclick="alert">b</a>')).to.be.equal('a<a>b</a>');
     expect(sanitizeHtml('a<a [onclick]="alert">b</a>')).to.be
         .equal('a<a>b</a>');
@@ -186,8 +183,7 @@ describe('sanitizeHtml', () => {
         .equal('<p [text]="foo" [class]="bar"></p>');
   });
 
-  // TODO(dvoytenko, #14336): Fails due to console errors.
-  it.skip('should NOT output blacklisted values for class attributes', () => {
+  it('should NOT output blacklisted values for class attributes', () => {
     expect(sanitizeHtml('<p class="i-amphtml-">hello</p>')).to.be
         .equal('<p>hello</p>');
     expect(sanitizeHtml('<p class="i-amphtml-class">hello</p>')).to.be
@@ -202,8 +198,7 @@ describe('sanitizeHtml', () => {
         .equal('<p>hello</p>');
   });
 
-  // TODO(dvoytenko, #14336): Fails due to console errors.
-  it.skip('should NOT output security-sensitive binding attributes', () => {
+  it('should NOT output security-sensitive binding attributes', () => {
     expect(sanitizeHtml('a<a [onclick]="alert">b</a>')).to.be.equal(
         'a<a>b</a>');
     expect(sanitizeHtml('a<a [style]="color: red;">b</a>')).to.be.equal(
@@ -442,20 +437,17 @@ describe('sanitizeFormattingHtml', () => {
           .to.equal('<div style="color:blue">Test</div>');
     });
 
-    // TODO(choumx, #14336): Fails due to console errors.
-    it.skip('should ignore styles containing `!important`',() => {
+    it('should ignore styles containing `!important`',() => {
       expect(sanitizeHtml('<div style="color:blue!important">Test</div>'))
           .to.equal('<div>Test</div>');
     });
 
-    // TODO(choumx, #14336): Fails due to console errors.
-    it.skip('should ignore styles containing `position:fixed`', () => {
+    it('should ignore styles containing `position:fixed`', () => {
       expect(sanitizeHtml('<div style="position:fixed">Test</div>'))
           .to.equal('<div>Test</div>');
     });
 
-    // TODO(choumx, #14336): Fails due to console errors.
-    it.skip('should ignore styles containing `position:sticky`', () => {
+    it('should ignore styles containing `position:sticky`', () => {
       expect(sanitizeHtml('<div style="position:sticky">Test</div>'))
           .to.equal('<div>Test</div>');
     });

--- a/test/functional/test-service.js
+++ b/test/functional/test-service.js
@@ -449,8 +449,7 @@ describe('service', () => {
       expect(getServiceForDoc(grandChildWinNode, 'c')).to.equal(c);
     });
 
-    // TODO(dvoytenko, #14336): Fails due to console errors.
-    it.skip('should dispose disposable services', () => {
+    it('should dispose disposable services', () => {
       const disposableFactory = function() {
         return {
           dispose: sandbox.spy(),

--- a/test/functional/test-shadow-embed.js
+++ b/test/functional/test-shadow-embed.js
@@ -41,8 +41,7 @@ describes.sandboxed('shadow-embed', {}, () => {
 
   [ShadowDomVersion.NONE, ShadowDomVersion.V0, ShadowDomVersion.V1]
       .forEach(scenario => {
-        // TODO(dvoytenko, #14336): Fails due to console errors.
-        describe.skip('shadow APIs ' + scenario, () => {
+        describe('shadow APIs ' + scenario, () => {
           let hostElement;
 
           beforeEach(function() {

--- a/test/functional/test-standard-actions.js
+++ b/test/functional/test-standard-actions.js
@@ -290,8 +290,7 @@ describes.sandboxed('StandardActions', {}, () => {
       });
     });
 
-    // TODO(choumx, #14336): Fails due to console errors.
-    it.skip('should not allow chained setState', () => {
+    it('should not allow chained setState', () => {
       const spy = sandbox.spy();
       window.services.bind = {
         obj: {

--- a/test/functional/test-storage.js
+++ b/test/functional/test-storage.js
@@ -166,8 +166,7 @@ describe('Storage', () => {
     });
   });
 
-  // TODO(dvoytenko, #14336): Fails due to console errors.
-  it.skip('should recover from binding failure', () => {
+  it('should recover from binding failure', () => {
     bindingMock.expects('loadBlob')
         .withExactArgs('https://acme.com')
         .returns(Promise.reject('intentional'))
@@ -180,8 +179,7 @@ describe('Storage', () => {
     });
   });
 
-  // TODO(dvoytenko, #14336): Fails due to console errors.
-  it.skip('should recover from binding error', () => {
+  it('should recover from binding error', () => {
     bindingMock.expects('loadBlob')
         .withExactArgs('https://acme.com')
         .returns(Promise.resolve('UNKNOWN FORMAT'))
@@ -449,8 +447,7 @@ describe('LocalStorageBinding', () => {
     sandbox.restore();
   });
 
-  // TODO(erwinmombay, #14336): Fails due to console errors.
-  it.skip('should throw if localStorage is not supported', () => {
+  it('should throw if localStorage is not supported', () => {
     const errorSpy = sandbox.spy(dev(), 'expectedError');
 
     expect(errorSpy).to.have.not.been.called;
@@ -508,8 +505,7 @@ describe('LocalStorageBinding', () => {
         });
   });
 
-  // TODO(newmuis, #14336): Fails due to console errors.
-  it.skip('should bypass loading from localStorage if getItem throws', () => {
+  it('should bypass loading from localStorage if getItem throws', () => {
     localStorageMock.expects('getItem')
         .throws(new Error('unknown'))
         .once();
@@ -552,8 +548,7 @@ describe('LocalStorageBinding', () => {
         });
   });
 
-  // TODO(newmuis, #14336): Fails due to console errors.
-  it.skip('should bypass saving to localStorage if getItem throws', () => {
+  it('should bypass saving to localStorage if getItem throws', () => {
     const setItemSpy = sandbox.spy(windowApi.localStorage, 'setItem');
 
     localStorageMock.expects('getItem')

--- a/test/integration/test-3p-frame.js
+++ b/test/integration/test-3p-frame.js
@@ -351,8 +351,7 @@ describe.configure().ifNewChrome().run('3p-frame', () => {
     }).to.throw(/must not be on the same origin as the/); });
   });
 
-  // TODO(keithwrightbos, #14336): Fails due to console errors.
-  it.skip('should pick default url if custom disabled', () => {
+  it('should pick default url if custom disabled', () => {
     addCustomBootstrap('http://localhost:9876/boot/remote.html');
     expect(getBootstrapBaseUrl(window, true, undefined, true)).to.equal(
         'http://ads.localhost:9876/dist.3p/current/frame.max.html');
@@ -380,8 +379,7 @@ describe.configure().ifNewChrome().run('3p-frame', () => {
     });
   });
 
-  // TODO(keithwrightbos, #14336): Fails due to console errors.
-  it.skip('should prefetch default bootstrap frame if custom disabled', () => {
+  it('should prefetch default bootstrap frame if custom disabled', () => {
     window.AMP_MODE = {localDev: true};
     addCustomBootstrap('http://localhost:9876/boot/remote.html');
     preloadBootstrap(window, preconnect, undefined, true);

--- a/test/integration/test-video-players-helper.js
+++ b/test/integration/test-video-players-helper.js
@@ -67,8 +67,7 @@ export function runVideoPlayerIntegrationTests(
     return button;
   }
 
-  // TODO(alanorozco, #14336): Fails due to console errors.
-  describe.skip('Video Interface', function() {
+  describe.configure().ifNewChrome().run('Video Interface', function() {
     this.timeout(TIMEOUT);
 
     it('should override the video interface methods', function() {
@@ -90,8 +89,7 @@ export function runVideoPlayerIntegrationTests(
     afterEach(cleanUp);
   });
 
-  // TODO(alanorozco, #14336): Fails due to console errors.
-  describe.skip('Actions', function() {
+  describe.configure().ifNewChrome().run('Actions', function() {
     this.timeout(TIMEOUT);
 
     it('should support mute, play, pause, unmute actions', function() {
@@ -140,8 +138,7 @@ export function runVideoPlayerIntegrationTests(
     afterEach(cleanUp);
   });
 
-  // TODO(alanorozco, #14336): Fails due to console errors.
-  describe.skip('Analytics Triggers', function() {
+  describe.configure().ifNewChrome().run('Analytics Triggers', function() {
     this.timeout(TIMEOUT);
     let video;
 
@@ -330,8 +327,7 @@ export function runVideoPlayerIntegrationTests(
     afterEach(cleanUp);
   });
 
-  // TODO(alanorozco, #14336): Fails due to console errors.
-  describe.skip('Video Docking', function() {
+  describe.configure().ifNewChrome().run('Video Docking', function() {
     this.timeout(TIMEOUT);
 
     describe('General Behavior', () => {
@@ -349,8 +345,7 @@ export function runVideoPlayerIntegrationTests(
         });
       });
 
-      it('should have class when attribute is set ' +
-          '(no-autoplay)', function() {
+      it('should have class when attribute is set (no-autoplay)', function() {
         return getVideoPlayer(
             {
               outsideView: false,
@@ -412,8 +407,7 @@ export function runVideoPlayerIntegrationTests(
       });
     });
 
-    // TODO(aghassemi, #14336): Fails due to console errors.
-    describe.skip('with-autoplay', () => {
+    describe('with-autoplay', () => {
       it('should minimize when out of viewport', function() {
         let viewport;
         let video;
@@ -506,8 +500,7 @@ export function runVideoPlayerIntegrationTests(
     afterEach(cleanUp);
   });
 
-  // TODO(alanorozco, #14336): Fails due to console errors.
-  describe.skip('Autoplay', function() {
+  describe.configure().ifNewChrome().run('Autoplay', function() {
     this.timeout(TIMEOUT);
 
     describe('play/pause', () => {

--- a/test/integration/test-visibility-states.js
+++ b/test/integration/test-visibility-states.js
@@ -20,8 +20,7 @@ import {createCustomEvent} from '../../src/event-helper';
 import {getVendorJsPropertyName} from '../../src/style';
 import {whenUpgradedToCustomElement} from '../../src/dom';
 
-// TODO(jridgewell, #14336): Fails due to console errors.
-describe.skip('Viewer Visibility State', () => {
+describe.configure().ifNewChrome().run('Viewer Visibility State', () => {
 
   function noop() {}
 
@@ -127,8 +126,7 @@ describe.skip('Viewer Visibility State', () => {
     });
 
     describe('from in the PRERENDER state', () => {
-      // TODO(jridgewell, #14336): Fails due to console errors.
-      describe.skip('for prerenderable element', () => {
+      describe('for prerenderable element', () => {
         beforeEach(() => {
           prerenderAllowed.returns(true);
           setupSpys();


### PR DESCRIPTION
This PR unskips all the tests that were skipped earlier due to `console.error`. Tests will now have to use an `allowConsoleError` block around code that legitimately needs to generate an error. Until then, they will continue to pass, but will print a message with the `console.error` text, and instructions for how to fix it.

In addition, this test temporarily reverts to using `sinon.stub` for `console.error` until such time that we're ready to fail tests that contain unexpected errors. This will make testing less prone to failures until everyone fixes the errors in their tests.

Follow up to #14336 
Follow up to #14432
Related to #14406 
Related to #7381