### PR TITLE
🐛 🏗 Intrinsic image size bug, reduce size of svg

### DIFF
--- a/css/amp.css
+++ b/css/amp.css
@@ -250,6 +250,10 @@ i-amphtml-sizer {
   max-width: 100%;
 }
 
+.i-amphtml-intrinsic-sizer {
+  display: block !important;
+}
+
 .i-amphtml-replaced-content {
   padding: 0 !important;
   border: none !important;

--- a/css/amp.css
+++ b/css/amp.css
@@ -174,6 +174,7 @@ html.i-amphtml-ios-embed.i-amphtml-ios-overscroll > #i-amphtml-wrapper {
 
 .i-amphtml-intrinsic-sizer {
   max-width: 100%;
+  display: block !important;
 }
 
 .i-amphtml-layout-fixed-height,
@@ -248,10 +249,6 @@ i-amphtml-sizer {
 
 .i-amphtml-layout-intrinsic .i-amphtml-sizer {
   max-width: 100%;
-}
-
-.i-amphtml-intrinsic-sizer {
-  display: block !important;
 }
 
 .i-amphtml-replaced-content {

--- a/src/layout.js
+++ b/src/layout.js
@@ -449,7 +449,7 @@ export function applyStaticLayout(element) {
     sizer.classList.add('i-amphtml-sizer');
     intrinsicSizer.classList.add('i-amphtml-intrinsic-sizer');
     intrinsicSizer.setAttribute('src',
-        `data:image/svg+xml;charset=utf-8,<svg height="${height}" width="${width}" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1"></svg>`);
+        `data:image/svg+xml;charset=utf-8,<svg height="${height}" width="${width}" xmlns="http://www.w3.org/2000/svg" version="1.1"/>`);
     sizer.appendChild(intrinsicSizer);
     element.insertBefore(sizer, element.firstChild);
     element.sizerElement = intrinsicSizer;

--- a/test/functional/test-layout.js
+++ b/test/functional/test-layout.js
@@ -293,7 +293,7 @@ describe('Layout', () => {
     expect(div.children[0].tagName.toLowerCase()).to.equal('i-amphtml-sizer');
     expect(div.children[0].children.length).to.equal(1);
     expect(div.children[0].children[0].tagName.toLowerCase()).to.equal('img');
-    expect(div.children[0].children[0].src).to.equal('data:image/svg+xml;charset=utf-8,<svg height="200px" width="100px" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1"></svg>');
+    expect(div.children[0].children[0].src).to.equal('data:image/svg+xml;charset=utf-8,<svg height="200px" width="100px" xmlns="http://www.w3.org/2000/svg" version="1.1"/>');
   });
 
   it('layout=intrinsic - default with sizes', () => {
@@ -310,7 +310,7 @@ describe('Layout', () => {
     expect(div.children[0].tagName.toLowerCase()).to.equal('i-amphtml-sizer');
     expect(div.children[0].children.length).to.equal(1);
     expect(div.children[0].children[0].tagName.toLowerCase()).to.equal('img');
-    expect(div.children[0].children[0].src).to.equal('data:image/svg+xml;charset=utf-8,<svg height="200px" width="100px" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1"></svg>');
+    expect(div.children[0].children[0].src).to.equal('data:image/svg+xml;charset=utf-8,<svg height="200px" width="100px" xmlns="http://www.w3.org/2000/svg" version="1.1"/>');
   });
 
   it('layout=fill', () => {


### PR DESCRIPTION
Fix #14528 
Fix #14524 

Adds `display: block` to intrinsic image size

Use a more compact SVG  to reduce JS size.
