### PR TITLE
Adjust lightbox arrow button sizing per UX Review

### DIFF
--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.css
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.css
@@ -54,11 +54,15 @@ amp-lightbox-gallery .amp-carousel-button {
   background-image: url('data:image/svg+xml;charset=utf-8,<svg viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd"><g id="image" fill="#fff"><path d="M5,3 L19,3 C20.1045695,3 21,3.8954305 21,5 L21,19 C21,20.1045695 20.1045695,21 19,21 L5,21 C3.8954305,21 3,20.1045695 3,19 L3,5 C3,3.8954305 3.8954305,3 5,3 Z M19,15 L19,5 L5,5 L5,13.0000896 L8,10.0003584 L13,15 L16,12 L19,15 Z M15.5,10 C14.6715729,10 14,9.32842712 14,8.5 C14,7.67157288 14.6715729,7 15.5,7 C16.3284271,7 17,7.67157288 17,8.5 C17,9.32842712 16.3284271,10 15.5,10 Z" id="Combined-Shape"></path></g></g></svg>');
 }
 
-.i-amphtml-lbg-button-next, .i-amphtml-lbg-button-prev {
+.i-amphtml-lbg-button.i-amphtml-lbg-button-next,
+.i-amphtml-lbg-button.i-amphtml-lbg-button-prev {
   top: 0 !important;
   bottom: 0 !important;
   margin: auto !important;
   filter: drop-shadow(0 0 1px black) !important;
+  width: 40px;
+  height: 40px;
+  padding: 20px;
 }
 
 .i-amphtml-lbg-button-next {

--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -515,6 +515,12 @@ export class AmpLightboxGallery extends AMP.BaseElement {
         'i-amphtml-lbg-button-next', nextSlide);
     const prevButton = this.buildButton_('Prev',
         'i-amphtml-lbg-button-prev', prevSlide);
+
+    const input = Services.inputFor(this.win);
+    if (!input.isMouseDetected()) {
+      prevButton.classList.add('i-amphtml-screen-reader');
+      nextButton.classList.add('i-amphtml-screen-reader');
+    }
     this.navControls_.appendChild(nextButton);
     this.navControls_.appendChild(prevButton);
     this.controlsContainer_.appendChild(this.navControls_);


### PR DESCRIPTION
1. The right / left navigation arrows on lightbox should maintain a consistently large size and not downsize based on screen size. 
2. We should hide arrows when not in desktop mode. Removed the hinting because we got feedback that that particular feature looks like a bug. 
<img width="507" alt="screen shot 2018-04-11 at 11 09 48 am" src="https://user-images.githubusercontent.com/1528181/38634980-e65c85d8-3d78-11e8-992e-cdfb0555338e.png">
