### PR TITLE
✅ Fixes 2 unit tests

### DIFF
--- a/extensions/amp-analytics/0.1/test/test-amp-analytics.js
+++ b/extensions/amp-analytics/0.1/test/test-amp-analytics.js
@@ -266,13 +266,28 @@ describes.realWin('amp-analytics', {
     }
   });
 
-  // TODO(jonkeller, #14336): Fails due to console errors.
-  it.skip('does not unnecessarily preload iframe transport script', function() {
+  it('does not unnecessarily preload iframe transport script', function() {
     const el = doc.createElement('amp-analytics');
+    el.setAttribute('type', 'foo');
     doc.body.appendChild(el);
     const analytics = new AmpAnalytics(el);
     sandbox.stub(analytics, 'assertAmpAdResourceId').callsFake(() => 'fakeId');
     const preloadSpy = sandbox.spy(analytics, 'preload');
+    sandbox.stub(analytics, 'predefinedConfig_').value(
+        {
+          'foo': {
+            'triggers': {
+              'sample_visibility_trigger': {
+                'on': 'visible',
+                'request': 'sample_visibility_request',
+              },
+            },
+            'requests': {
+              'sample_visibility_request': 'fake-request',
+            },
+          },
+        }
+    );
     analytics.buildCallback();
     analytics.preconnectCallback();
     return analytics.layoutCallback().then(() => {

--- a/extensions/amp-analytics/0.1/test/test-visibility-manager.js
+++ b/extensions/amp-analytics/0.1/test/test-visibility-manager.js
@@ -282,14 +282,21 @@ describes.fakeWin('VisibilityManagerForDoc', {amp: true}, env => {
     root.dispose();
   });
 
-  // TODO(jonkeller, #14336): Fails due to console errors.
-  it.skip('does not allow min==max, when they are neither 0 nor 100', () => {
+  it('does not allow min==max, when they are neither 0 nor 100', () => {
     let spec = {visiblePercentageThresholds: [[50, 50]]};
-    root.listenRoot(spec, null, null, null);
+    allowConsoleError(() => {
+      // Expect user().error(TAG,
+      //   'visiblePercentageThresholds entry invalid min/max value')
+      root.listenRoot(spec, null, null, null);
+    });
     expect(root.models_).to.have.length(0);
     root.dispose();
     spec = {visiblePercentageThresholds: [[0, 10], [10, 10], [30, 30]]};
-    root.listenRoot(spec, null, null, null);
+    allowConsoleError(() => {
+      // On the [10, 10] only, again expect user().error(TAG,
+      //   'visiblePercentageThresholds entry invalid min/max value')
+      root.listenRoot(spec, null, null, null);
+    });
     expect(root.models_).to.have.length(1);
     root.dispose();
   });


### PR DESCRIPTION
Fixes the 2 unit tests assigned to me in #14336 
In the first test, we were getting a console error which was not necessary, so fixed the code to not cause that.
In the second test, we were testing an error condition which was expected to generate a console error, so wrapped that in allowConsoleError()