### PR TITLE
🏗 Update lightbox validator rules

### DIFF
--- a/extensions/amp-carousel/validator-amp-carousel.protoascii
+++ b/extensions/amp-carousel/validator-amp-carousel.protoascii
@@ -69,13 +69,9 @@ tags: {  # <amp-carousel>
 }
 tags: {  # <amp-carousel> lightbox
   tag_name: "AMP-CAROUSEL"
-  spec_name: "amp-carousel with lightbox attribute"
+  spec_name: "AMP-CAROUSEL[lightbox]"
   requires_extension: "amp-carousel"
   requires_extension: "amp-lightbox-gallery"
-  attrs: {
-    name: "lightbox"
-    mandatory: true
-  }
   attrs: {
     name: "arrows"
     value: ""
@@ -92,6 +88,10 @@ tags: {  # <amp-carousel> lightbox
   attrs: {
     name: "dots"
     value: ""
+  }
+  attrs: {
+    name: "lightbox"
+    mandatory: true
   }
   attrs: {
     name: "loop"
@@ -124,4 +124,14 @@ tags: {
   tag_name: "$REFERENCE_POINT"
   spec_name : "AMP-CAROUSEL lightbox [child]"
   attr_lists: "children-of-lightboxed-carousel"
+}
+attr_lists: {
+  name: "children-of-lightboxed-carousel"
+  attrs: {
+    name: "lightbox-exclude"
+  }
+  attrs: {
+    name: "lightbox-thumbnail-id"
+    value_regex_casei: "^[a-z][a-z\\d_-]*"
+  }
 }

--- a/extensions/amp-carousel/validator-amp-carousel.protoascii
+++ b/extensions/amp-carousel/validator-amp-carousel.protoascii
@@ -56,7 +56,6 @@ tags: {  # <amp-carousel>
   # <amp-bind>
   attrs: { name: "[slide]" }
   attr_lists: "extended-amp-global"
-  attr_lists: "lightboxable-elements"
   spec_url: "https://www.ampproject.org/docs/reference/components/amp-carousel"
   amp_layout: {
     supported_layouts: FILL
@@ -105,7 +104,6 @@ tags: {  # <amp-carousel> lightbox
   # <amp-bind>
   attrs: { name: "[slide]" }
   attr_lists: "extended-amp-global"
-  attr_lists: "lightboxable-elements"
   spec_url: "https://www.ampproject.org/docs/reference/components/amp-carousel"
   amp_layout: {
     supported_layouts: FILL

--- a/extensions/amp-carousel/validator-amp-carousel.protoascii
+++ b/extensions/amp-carousel/validator-amp-carousel.protoascii
@@ -69,7 +69,7 @@ tags: {  # <amp-carousel>
 }
 tags: {  # <amp-carousel> lightbox
   tag_name: "AMP-CAROUSEL"
-  spec_name: "AMP-CAROUSEL[lightbox]"
+  spec_name: "AMP-CAROUSEL [lightbox]"
   requires_extension: "amp-carousel"
   requires_extension: "amp-lightbox-gallery"
   attrs: {
@@ -123,10 +123,6 @@ tags: {
   html_format: EXPERIMENTAL
   tag_name: "$REFERENCE_POINT"
   spec_name : "AMP-CAROUSEL lightbox [child]"
-  attr_lists: "children-of-lightboxed-carousel"
-}
-attr_lists: {
-  name: "children-of-lightboxed-carousel"
   attrs: {
     name: "lightbox-exclude"
   }

--- a/extensions/amp-carousel/validator-amp-carousel.protoascii
+++ b/extensions/amp-carousel/validator-amp-carousel.protoascii
@@ -68,3 +68,62 @@ tags: {  # <amp-carousel>
     supported_layouts: RESPONSIVE
   }
 }
+tags: {  # <amp-carousel> lightbox
+  tag_name: "AMP-CAROUSEL"
+  spec_name: "amp-carousel with lightbox attribute"
+  requires_extension: "amp-carousel"
+  requires_extension: "amp-lightbox-gallery"
+  attrs: {
+    name: "lightbox"
+    mandatory: true
+  }
+  attrs: {
+    name: "arrows"
+    value: ""
+  }
+  attrs: {
+    name: "autoplay"
+    value: ""
+  }
+  attrs: { name: "controls" }
+  attrs: {
+    name: "delay"
+    value_regex: "[0-9]+"
+  }
+  attrs: {
+    name: "dots"
+    value: ""
+  }
+  attrs: {
+    name: "loop"
+    value: ""
+  }
+  attrs: {
+    name: "type"
+    value_regex: "slides|carousel"
+  }
+  # <amp-bind>
+  attrs: { name: "[slide]" }
+  attr_lists: "extended-amp-global"
+  attr_lists: "lightboxable-elements"
+  spec_url: "https://www.ampproject.org/docs/reference/components/amp-carousel"
+  amp_layout: {
+    supported_layouts: FILL
+    supported_layouts: FIXED
+    supported_layouts: FIXED_HEIGHT
+    supported_layouts: FLEX_ITEM
+    supported_layouts: INTRINSIC
+    supported_layouts: NODISPLAY
+    supported_layouts: RESPONSIVE
+  }
+  reference_points: {
+    tag_spec_name: "AMP-CAROUSEL lightbox [child]"
+  }
+}
+tags: {
+  html_format: AMP
+  html_format: EXPERIMENTAL
+  tag_name: "$REFERENCE_POINT"
+  spec_name : "AMP-CAROUSEL lightbox [child]"
+  attr_lists: "children-of-lightboxed-carousel"
+}

--- a/extensions/amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.html
+++ b/extensions/amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.html
@@ -29,7 +29,6 @@
   <script async custom-element="amp-youtube" src="https://cdn.ampproject.org/v0/amp-youtube-0.1.js"></script>
   <script async custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.1.js"></script>
   <script async custom-element="amp-video" src="https://cdn.ampproject.org/v0/amp-video-0.1.js"></script>
-
 </head>
 <body>
   <!-- Valid -->
@@ -37,7 +36,7 @@
   <amp-img src="/awesome.png" width="300" height="300" lightbox="a"></amp-img>
   <amp-img src="/awesome.png" width="300" height="300" lightbox lightbox-thumbnail-id="a"></amp-img>
 
-  <!-- Valid -->
+  <!-- Valid: basic use case -->
   <amp-video
     lightbox
     src="../av/ForBiggerJoyrides-short.mp4"
@@ -51,21 +50,22 @@
     width="358"
     height="204"
     layout="responsive"></amp-youtube>
-
-  <!-- Valid -->
   <amp-carousel width=400 height=300 layout=responsive type=slides lightbox></amp-carousel>
+
   <!-- Valid: lightboxed carousel with lightbox exclude and lightbox thumbnail -->
   <amp-carousel width=400 height=300 layout=responsive type=slides lightbox>
       <amp-img src="/awesome.png" width="300" height="300"></amp-img>
       <amp-img src="/awesome.png" width="300" height="300" lightbox-exclude></amp-img>
       <amp-img src="/awesome.png" width="300" height="300" lightbox-thumbnail-id="a"></amp-img>
   </amp-carousel>
-  <!-- lightboxed child of unlightboxed carousel -->
+
+  <!-- Valid: lightboxed child of unlightboxed carousel -->
   <amp-carousel width=400 height=300 layout=responsive type=slides>
       <amp-img src="/awesome.png" width="300" height="300" lightbox></amp-img>
       <amp-img src="/awesome.png" width="300" height="300"></amp-img>
   </amp-carousel>
-  <!-- carousel with video, img, youtube -->
+
+  <!-- Valid: carousel with video, img, youtube -->
   <amp-carousel width=400 height=300 layout=responsive type=slides lightbox>
     <amp-video
       src="../av/ForBiggerJoyrides-short.mp4"
@@ -88,6 +88,5 @@
   <amp-img src="/awesome.png" width="300" height="300" lightbox-thumbnail-id="a"></amp-img>
   <!-- Invalid: invalid use of lightbox-exclude -->
   <amp-img src="/awesome.png" width="300" height="300" lightbox-exclude></amp-img>
-
 </body>
 </html>

--- a/extensions/amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.html
+++ b/extensions/amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.html
@@ -29,6 +29,7 @@
   <script async custom-element="amp-youtube" src="https://cdn.ampproject.org/v0/amp-youtube-0.1.js"></script>
   <script async custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.1.js"></script>
   <script async custom-element="amp-video" src="https://cdn.ampproject.org/v0/amp-video-0.1.js"></script>
+  <script async custom-element="amp-ad" src="https://cdn.ampproject.org/v0/amp-ad-0.1.js"></script>
 </head>
 <body>
   <!-- Valid -->
@@ -65,7 +66,7 @@
       <amp-img src="/awesome.png" width="300" height="300"></amp-img>
   </amp-carousel>
 
-  <!-- Valid: carousel with video, img, youtube -->
+  <!-- Valid: carousel with video, img, youtube, ad -->
   <amp-carousel width=400 height=300 layout=responsive type=slides lightbox>
     <amp-video
       src="../av/ForBiggerJoyrides-short.mp4"
@@ -80,6 +81,13 @@
       height="204"
       layout="responsive"></amp-youtube>
     <amp-img src="/awesome.png" width="300" height="300" lightbox-exclude></amp-img>
+    <amp-ad width="300"
+      height="250"
+      type="a9"
+      data-aax_size="300x250"
+      data-aax_pubname="test123"
+      data-aax_src="302">
+    </amp-ad>
   </amp-carousel>
 
   <!-- Invalid: missing value for lightbox-thumbnail-id -->

--- a/extensions/amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.html
+++ b/extensions/amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.html
@@ -37,11 +37,6 @@
   <amp-img src="/awesome.png" width="300" height="300" lightbox="a"></amp-img>
   <amp-img src="/awesome.png" width="300" height="300" lightbox lightbox-thumbnail-id="a"></amp-img>
 
-  <!-- Invalid: missing value for lightbox-thumbnail-id -->
-  <amp-img src="/awesome.png" width="300" height="300" lightbox lightbox-thumbnail-id></amp-img>
-  <!-- Invalid: missing lightbox attribute for element with lightbox-thumbnail-id -->
-  <amp-img src="/awesome.png" width="300" height="300" lightbox-thumbnail-id="a"></amp-img>
-
   <!-- Valid -->
   <amp-video
     lightbox
@@ -59,13 +54,40 @@
 
   <!-- Valid -->
   <amp-carousel width=400 height=300 layout=responsive type=slides lightbox></amp-carousel>
+  <!-- Valid: lightboxed carousel with lightbox exclude and lightbox thumbnail -->
   <amp-carousel width=400 height=300 layout=responsive type=slides lightbox>
-      <amp-img src="/awesome.png" width="300" height="300" lightbox></amp-img>
+      <amp-img src="/awesome.png" width="300" height="300"></amp-img>
       <amp-img src="/awesome.png" width="300" height="300" lightbox-exclude></amp-img>
+      <amp-img src="/awesome.png" width="300" height="300" lightbox-thumbnail-id="a"></amp-img>
   </amp-carousel>
+  <!-- lightboxed child of unlightboxed carousel -->
   <amp-carousel width=400 height=300 layout=responsive type=slides>
       <amp-img src="/awesome.png" width="300" height="300" lightbox></amp-img>
       <amp-img src="/awesome.png" width="300" height="300"></amp-img>
   </amp-carousel>
+  <!-- carousel with video, img, youtube -->
+  <amp-carousel width=400 height=300 layout=responsive type=slides lightbox>
+    <amp-video
+      src="../av/ForBiggerJoyrides-short.mp4"
+      width="720"
+      height="405"
+      layout="responsive"
+      controls></amp-video>
+    <amp-youtube
+      lightbox-thumbnail-id="a"
+      data-videoid="lBTCB7yLs8Y"
+      width="358"
+      height="204"
+      layout="responsive"></amp-youtube>
+    <amp-img src="/awesome.png" width="300" height="300" lightbox-exclude></amp-img>
+  </amp-carousel>
+
+  <!-- Invalid: missing value for lightbox-thumbnail-id -->
+  <amp-img src="/awesome.png" width="300" height="300" lightbox lightbox-thumbnail-id></amp-img>
+  <!-- Invalid: missing lightbox attribute for element with lightbox-thumbnail-id -->
+  <amp-img src="/awesome.png" width="300" height="300" lightbox-thumbnail-id="a"></amp-img>
+  <!-- Invalid: invalid use of lightbox-exclude -->
+  <amp-img src="/awesome.png" width="300" height="300" lightbox-exclude></amp-img>
+
 </body>
 </html>

--- a/extensions/amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.out
+++ b/extensions/amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.out
@@ -89,8 +89,6 @@ FAIL
 amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.html:86:2 The attribute 'lightbox-thumbnail-id' in tag 'amp-img' is set to the invalid value ''. (see https://www.ampproject.org/docs/reference/components/amp-img) [AMP_TAG_PROBLEM]
 |    <!-- Invalid: missing lightbox attribute for element with lightbox-thumbnail-id -->
 |    <amp-img src="/awesome.png" width="300" height="300" lightbox-thumbnail-id="a"></amp-img>
->>   ^~~~~~~~~
-amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.html:88:2 The attribute 'lightbox' in tag 'amp-img' is missing or incorrect, but required by attribute 'lightbox-thumbnail-id'. (see https://www.ampproject.org/docs/reference/components/amp-img) [DISALLOWED_HTML]
 |    <!-- Invalid: invalid use of lightbox-exclude -->
 |    <amp-img src="/awesome.png" width="300" height="300" lightbox-exclude></amp-img>
 >>   ^~~~~~~~~

--- a/extensions/amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.out
+++ b/extensions/amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.out
@@ -1,13 +1,13 @@
 FAIL
 |  <!--
 |    Copyright 2018 The AMP HTML Authors. All Rights Reserved.
-|  
+|
 |    Licensed under the Apache License, Version 2.0 (the "License");
 |    you may not use this file except in compliance with the License.
 |    You may obtain a copy of the License at
-|  
+|
 |        http://www.apache.org/licenses/LICENSE-2.0
-|  
+|
 |    Unless required by applicable law or agreed to in writing, software
 |    distributed under the License is distributed on an "AS-IS" BASIS,
 |    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -30,23 +30,14 @@ FAIL
 |    <script async custom-element="amp-youtube" src="https://cdn.ampproject.org/v0/amp-youtube-0.1.js"></script>
 |    <script async custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.1.js"></script>
 |    <script async custom-element="amp-video" src="https://cdn.ampproject.org/v0/amp-video-0.1.js"></script>
-|  
+|
 |  </head>
 |  <body>
 |    <!-- Valid -->
 |    <amp-img src="/awesome.png" width="300" height="300" lightbox></amp-img>
 |    <amp-img src="/awesome.png" width="300" height="300" lightbox="a"></amp-img>
 |    <amp-img src="/awesome.png" width="300" height="300" lightbox lightbox-thumbnail-id="a"></amp-img>
-|  
-|    <!-- Invalid: missing value for lightbox-thumbnail-id -->
-|    <amp-img src="/awesome.png" width="300" height="300" lightbox lightbox-thumbnail-id></amp-img>
->>   ^~~~~~~~~
-amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.html:41:2 The attribute 'lightbox-thumbnail-id' in tag 'amp-img' is set to the invalid value ''. (see https://www.ampproject.org/docs/reference/components/amp-img) [AMP_TAG_PROBLEM]
-|    <!-- Invalid: missing lightbox attribute for element with lightbox-thumbnail-id -->
-|    <amp-img src="/awesome.png" width="300" height="300" lightbox-thumbnail-id="a"></amp-img>
->>   ^~~~~~~~~
-amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.html:43:2 The attribute 'lightbox' in tag 'amp-img' is missing or incorrect, but required by attribute 'lightbox-thumbnail-id'. (see https://www.ampproject.org/docs/reference/components/amp-img) [DISALLOWED_HTML]
-|  
+|
 |    <!-- Valid -->
 |    <amp-video
 |      lightbox
@@ -61,16 +52,49 @@ amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.html:43:2 The attri
 |      width="358"
 |      height="204"
 |      layout="responsive"></amp-youtube>
-|  
+|
 |    <!-- Valid -->
 |    <amp-carousel width=400 height=300 layout=responsive type=slides lightbox></amp-carousel>
+|    <!-- Valid: lightboxed carousel with lightbox exclude and lightbox thumbnail -->
 |    <amp-carousel width=400 height=300 layout=responsive type=slides lightbox>
-|        <amp-img src="/awesome.png" width="300" height="300" lightbox></amp-img>
+|        <amp-img src="/awesome.png" width="300" height="300"></amp-img>
 |        <amp-img src="/awesome.png" width="300" height="300" lightbox-exclude></amp-img>
+|        <amp-img src="/awesome.png" width="300" height="300" lightbox-thumbnail-id="a"></amp-img>
 |    </amp-carousel>
+|    <!-- lightboxed child of unlightboxed carousel -->
 |    <amp-carousel width=400 height=300 layout=responsive type=slides>
 |        <amp-img src="/awesome.png" width="300" height="300" lightbox></amp-img>
 |        <amp-img src="/awesome.png" width="300" height="300"></amp-img>
 |    </amp-carousel>
+|    <!-- carousel with video, img, youtube -->
+|    <amp-carousel width=400 height=300 layout=responsive type=slides lightbox>
+|      <amp-video
+|        src="../av/ForBiggerJoyrides-short.mp4"
+|        width="720"
+|        height="405"
+|        layout="responsive"
+|        controls></amp-video>
+|      <amp-youtube
+|        lightbox-thumbnail-id="a"
+|        data-videoid="lBTCB7yLs8Y"
+|        width="358"
+|        height="204"
+|        layout="responsive"></amp-youtube>
+|      <amp-img src="/awesome.png" width="300" height="300" lightbox-exclude></amp-img>
+|    </amp-carousel>
+|
+|    <!-- Invalid: missing value for lightbox-thumbnail-id -->
+|    <amp-img src="/awesome.png" width="300" height="300" lightbox lightbox-thumbnail-id></amp-img>
+>>   ^~~~~~~~~
+amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.html:86:2 The attribute 'lightbox-thumbnail-id' in tag 'amp-img' is set to the invalid value ''. (see https://www.ampproject.org/docs/reference/components/amp-img) [AMP_TAG_PROBLEM]
+|    <!-- Invalid: missing lightbox attribute for element with lightbox-thumbnail-id -->
+|    <amp-img src="/awesome.png" width="300" height="300" lightbox-thumbnail-id="a"></amp-img>
+>>   ^~~~~~~~~
+amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.html:88:2 The attribute 'lightbox' in tag 'amp-img' is missing or incorrect, but required by attribute 'lightbox-thumbnail-id'. (see https://www.ampproject.org/docs/reference/components/amp-img) [DISALLOWED_HTML]
+|    <!-- Invalid: invalid use of lightbox-exclude -->
+|    <amp-img src="/awesome.png" width="300" height="300" lightbox-exclude></amp-img>
+>>   ^~~~~~~~~
+amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.html:90:2 The attribute 'lightbox-exclude' may not appear in tag 'amp-img'. (see https://www.ampproject.org/docs/reference/components/amp-img) [AMP_TAG_PROBLEM]
+|
 |  </body>
 |  </html>

--- a/extensions/amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.out
+++ b/extensions/amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.out
@@ -1,13 +1,13 @@
 FAIL
 |  <!--
 |    Copyright 2018 The AMP HTML Authors. All Rights Reserved.
-|
+|  
 |    Licensed under the Apache License, Version 2.0 (the "License");
 |    you may not use this file except in compliance with the License.
 |    You may obtain a copy of the License at
-|
+|  
 |        http://www.apache.org/licenses/LICENSE-2.0
-|
+|  
 |    Unless required by applicable law or agreed to in writing, software
 |    distributed under the License is distributed on an "AS-IS" BASIS,
 |    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -30,15 +30,14 @@ FAIL
 |    <script async custom-element="amp-youtube" src="https://cdn.ampproject.org/v0/amp-youtube-0.1.js"></script>
 |    <script async custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.1.js"></script>
 |    <script async custom-element="amp-video" src="https://cdn.ampproject.org/v0/amp-video-0.1.js"></script>
-|
 |  </head>
 |  <body>
 |    <!-- Valid -->
 |    <amp-img src="/awesome.png" width="300" height="300" lightbox></amp-img>
 |    <amp-img src="/awesome.png" width="300" height="300" lightbox="a"></amp-img>
 |    <amp-img src="/awesome.png" width="300" height="300" lightbox lightbox-thumbnail-id="a"></amp-img>
-|
-|    <!-- Valid -->
+|  
+|    <!-- Valid: basic use case -->
 |    <amp-video
 |      lightbox
 |      src="../av/ForBiggerJoyrides-short.mp4"
@@ -52,21 +51,22 @@ FAIL
 |      width="358"
 |      height="204"
 |      layout="responsive"></amp-youtube>
-|
-|    <!-- Valid -->
 |    <amp-carousel width=400 height=300 layout=responsive type=slides lightbox></amp-carousel>
+|  
 |    <!-- Valid: lightboxed carousel with lightbox exclude and lightbox thumbnail -->
 |    <amp-carousel width=400 height=300 layout=responsive type=slides lightbox>
 |        <amp-img src="/awesome.png" width="300" height="300"></amp-img>
 |        <amp-img src="/awesome.png" width="300" height="300" lightbox-exclude></amp-img>
 |        <amp-img src="/awesome.png" width="300" height="300" lightbox-thumbnail-id="a"></amp-img>
 |    </amp-carousel>
-|    <!-- lightboxed child of unlightboxed carousel -->
+|  
+|    <!-- Valid: lightboxed child of unlightboxed carousel -->
 |    <amp-carousel width=400 height=300 layout=responsive type=slides>
 |        <amp-img src="/awesome.png" width="300" height="300" lightbox></amp-img>
 |        <amp-img src="/awesome.png" width="300" height="300"></amp-img>
 |    </amp-carousel>
-|    <!-- carousel with video, img, youtube -->
+|  
+|    <!-- Valid: carousel with video, img, youtube -->
 |    <amp-carousel width=400 height=300 layout=responsive type=slides lightbox>
 |      <amp-video
 |        src="../av/ForBiggerJoyrides-short.mp4"
@@ -82,7 +82,7 @@ FAIL
 |        layout="responsive"></amp-youtube>
 |      <amp-img src="/awesome.png" width="300" height="300" lightbox-exclude></amp-img>
 |    </amp-carousel>
-|
+|  
 |    <!-- Invalid: missing value for lightbox-thumbnail-id -->
 |    <amp-img src="/awesome.png" width="300" height="300" lightbox lightbox-thumbnail-id></amp-img>
 >>   ^~~~~~~~~
@@ -93,6 +93,5 @@ amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.html:86:2 The attri
 |    <amp-img src="/awesome.png" width="300" height="300" lightbox-exclude></amp-img>
 >>   ^~~~~~~~~
 amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.html:90:2 The attribute 'lightbox-exclude' may not appear in tag 'amp-img'. (see https://www.ampproject.org/docs/reference/components/amp-img) [AMP_TAG_PROBLEM]
-|
 |  </body>
 |  </html>

--- a/extensions/amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.out
+++ b/extensions/amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.out
@@ -30,6 +30,7 @@ FAIL
 |    <script async custom-element="amp-youtube" src="https://cdn.ampproject.org/v0/amp-youtube-0.1.js"></script>
 |    <script async custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.1.js"></script>
 |    <script async custom-element="amp-video" src="https://cdn.ampproject.org/v0/amp-video-0.1.js"></script>
+|    <script async custom-element="amp-ad" src="https://cdn.ampproject.org/v0/amp-ad-0.1.js"></script>
 |  </head>
 |  <body>
 |    <!-- Valid -->
@@ -66,7 +67,7 @@ FAIL
 |        <amp-img src="/awesome.png" width="300" height="300"></amp-img>
 |    </amp-carousel>
 |  
-|    <!-- Valid: carousel with video, img, youtube -->
+|    <!-- Valid: carousel with video, img, youtube, ad -->
 |    <amp-carousel width=400 height=300 layout=responsive type=slides lightbox>
 |      <amp-video
 |        src="../av/ForBiggerJoyrides-short.mp4"
@@ -81,17 +82,24 @@ FAIL
 |        height="204"
 |        layout="responsive"></amp-youtube>
 |      <amp-img src="/awesome.png" width="300" height="300" lightbox-exclude></amp-img>
+|      <amp-ad width="300"
+|        height="250"
+|        type="a9"
+|        data-aax_size="300x250"
+|        data-aax_pubname="test123"
+|        data-aax_src="302">
+|      </amp-ad>
 |    </amp-carousel>
 |  
 |    <!-- Invalid: missing value for lightbox-thumbnail-id -->
 |    <amp-img src="/awesome.png" width="300" height="300" lightbox lightbox-thumbnail-id></amp-img>
 >>   ^~~~~~~~~
-amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.html:86:2 The attribute 'lightbox-thumbnail-id' in tag 'amp-img' is set to the invalid value ''. (see https://www.ampproject.org/docs/reference/components/amp-img) [AMP_TAG_PROBLEM]
+amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.html:94:2 The attribute 'lightbox-thumbnail-id' in tag 'amp-img' is set to the invalid value ''. (see https://www.ampproject.org/docs/reference/components/amp-img) [AMP_TAG_PROBLEM]
 |    <!-- Invalid: missing lightbox attribute for element with lightbox-thumbnail-id -->
 |    <amp-img src="/awesome.png" width="300" height="300" lightbox-thumbnail-id="a"></amp-img>
 |    <!-- Invalid: invalid use of lightbox-exclude -->
 |    <amp-img src="/awesome.png" width="300" height="300" lightbox-exclude></amp-img>
 >>   ^~~~~~~~~
-amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.html:90:2 The attribute 'lightbox-exclude' may not appear in tag 'amp-img'. (see https://www.ampproject.org/docs/reference/components/amp-img) [AMP_TAG_PROBLEM]
+amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.html:98:2 The attribute 'lightbox-exclude' may not appear in tag 'amp-img'. (see https://www.ampproject.org/docs/reference/components/amp-img) [AMP_TAG_PROBLEM]
 |  </body>
 |  </html>

--- a/extensions/amp-lightbox-gallery/validator-amp-lightbox-gallery.protoascii
+++ b/extensions/amp-lightbox-gallery/validator-amp-lightbox-gallery.protoascii
@@ -31,9 +31,6 @@ attr_lists: {
   attrs: {
     name: "lightbox-thumbnail-id"
     value_regex_casei: "^[a-z][a-z\\d_-]*"
-    trigger: {
-      also_requires_attr: "lightbox"
-    }
   }
 }
 attr_lists: {

--- a/extensions/amp-lightbox-gallery/validator-amp-lightbox-gallery.protoascii
+++ b/extensions/amp-lightbox-gallery/validator-amp-lightbox-gallery.protoascii
@@ -29,14 +29,20 @@ attr_lists: {
   name: "lightboxable-elements"
   attrs: { name: "lightbox" }
   attrs: {
-    name: "lightbox-exclude"
-    value: ""
-  }
-  attrs: {
     name: "lightbox-thumbnail-id"
     value_regex_casei: "^[a-z][a-z\\d_-]*"
     trigger: {
       also_requires_attr: "lightbox"
     }
+  }
+}
+attr_lists: {
+  name: "children-of-lightboxed-carousel"
+  attrs: {
+    name: "lightbox-exclude"
+  }
+  attrs: {
+    name: "lightbox-thumbnail-id"
+    value_regex_casei: "^[a-z][a-z\\d_-]*"
   }
 }

--- a/extensions/amp-lightbox-gallery/validator-amp-lightbox-gallery.protoascii
+++ b/extensions/amp-lightbox-gallery/validator-amp-lightbox-gallery.protoascii
@@ -33,13 +33,3 @@ attr_lists: {
     value_regex_casei: "^[a-z][a-z\\d_-]*"
   }
 }
-attr_lists: {
-  name: "children-of-lightboxed-carousel"
-  attrs: {
-    name: "lightbox-exclude"
-  }
-  attrs: {
-    name: "lightbox-thumbnail-id"
-    value_regex_casei: "^[a-z][a-z\\d_-]*"
-  }
-}

--- a/validator/testdata/feature_tests/mandatory_dimensions.out
+++ b/validator/testdata/feature_tests/mandatory_dimensions.out
@@ -125,11 +125,11 @@ feature_tests/mandatory_dimensions.html:96:4 The tag 'amp-iframe' requires inclu
 feature_tests/mandatory_dimensions.html:100:4 The tag 'amp-fit-text' requires including the 'amp-fit-text' extension JavaScript. (see https://www.ampproject.org/docs/reference/components/amp-fit-text) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
 |      <amp-carousel height="42"></amp-carousel>
 >>     ^~~~~~~~~
-feature_tests/mandatory_dimensions.html:101:4 The mandatory attribute 'lightbox' is missing in tag 'AMP-CAROUSEL[lightbox]'. (see https://www.ampproject.org/docs/reference/components/amp-carousel) [DISALLOWED_HTML]
+feature_tests/mandatory_dimensions.html:101:4 The mandatory attribute 'lightbox' is missing in tag 'AMP-CAROUSEL [lightbox]'. (see https://www.ampproject.org/docs/reference/components/amp-carousel) [DISALLOWED_HTML]
 >>     ^~~~~~~~~
-feature_tests/mandatory_dimensions.html:101:4 The tag 'AMP-CAROUSEL[lightbox]' requires including the 'amp-carousel' extension JavaScript. (see https://www.ampproject.org/docs/reference/components/amp-carousel) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
+feature_tests/mandatory_dimensions.html:101:4 The tag 'AMP-CAROUSEL [lightbox]' requires including the 'amp-carousel' extension JavaScript. (see https://www.ampproject.org/docs/reference/components/amp-carousel) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
 >>     ^~~~~~~~~
-feature_tests/mandatory_dimensions.html:101:4 The tag 'AMP-CAROUSEL[lightbox]' requires including the 'amp-lightbox-gallery' extension JavaScript. (see https://www.ampproject.org/docs/reference/components/amp-carousel) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
+feature_tests/mandatory_dimensions.html:101:4 The tag 'AMP-CAROUSEL [lightbox]' requires including the 'amp-lightbox-gallery' extension JavaScript. (see https://www.ampproject.org/docs/reference/components/amp-carousel) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
 |      <amp-youtube data-videoid="dQw4w9WgXcQ" height="42"></amp-youtube>
 >>     ^~~~~~~~~
 feature_tests/mandatory_dimensions.html:102:4 The tag 'amp-youtube' requires including the 'amp-youtube' extension JavaScript. (see https://www.ampproject.org/docs/reference/components/amp-youtube) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]

--- a/validator/testdata/feature_tests/mandatory_dimensions.out
+++ b/validator/testdata/feature_tests/mandatory_dimensions.out
@@ -125,7 +125,11 @@ feature_tests/mandatory_dimensions.html:96:4 The tag 'amp-iframe' requires inclu
 feature_tests/mandatory_dimensions.html:100:4 The tag 'amp-fit-text' requires including the 'amp-fit-text' extension JavaScript. (see https://www.ampproject.org/docs/reference/components/amp-fit-text) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
 |      <amp-carousel height="42"></amp-carousel>
 >>     ^~~~~~~~~
-feature_tests/mandatory_dimensions.html:101:4 The tag 'amp-carousel' requires including the 'amp-carousel' extension JavaScript. (see https://www.ampproject.org/docs/reference/components/amp-carousel) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
+feature_tests/mandatory_dimensions.html:101:4 The mandatory attribute 'lightbox' is missing in tag 'amp-carousel with lightbox attribute'. (see https://www.ampproject.org/docs/reference/components/amp-carousel) [AMP_TAG_PROBLEM]
+>>     ^~~~~~~~~
+feature_tests/mandatory_dimensions.html:101:4 The tag 'amp-carousel with lightbox attribute' requires including the 'amp-carousel' extension JavaScript. (see https://www.ampproject.org/docs/reference/components/amp-carousel) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
+>>     ^~~~~~~~~
+feature_tests/mandatory_dimensions.html:101:4 The tag 'amp-carousel with lightbox attribute' requires including the 'amp-lightbox-gallery' extension JavaScript. (see https://www.ampproject.org/docs/reference/components/amp-carousel) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
 |      <amp-youtube data-videoid="dQw4w9WgXcQ" height="42"></amp-youtube>
 >>     ^~~~~~~~~
 feature_tests/mandatory_dimensions.html:102:4 The tag 'amp-youtube' requires including the 'amp-youtube' extension JavaScript. (see https://www.ampproject.org/docs/reference/components/amp-youtube) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]

--- a/validator/testdata/feature_tests/mandatory_dimensions.out
+++ b/validator/testdata/feature_tests/mandatory_dimensions.out
@@ -125,11 +125,11 @@ feature_tests/mandatory_dimensions.html:96:4 The tag 'amp-iframe' requires inclu
 feature_tests/mandatory_dimensions.html:100:4 The tag 'amp-fit-text' requires including the 'amp-fit-text' extension JavaScript. (see https://www.ampproject.org/docs/reference/components/amp-fit-text) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
 |      <amp-carousel height="42"></amp-carousel>
 >>     ^~~~~~~~~
-feature_tests/mandatory_dimensions.html:101:4 The mandatory attribute 'lightbox' is missing in tag 'amp-carousel with lightbox attribute'. (see https://www.ampproject.org/docs/reference/components/amp-carousel) [AMP_TAG_PROBLEM]
+feature_tests/mandatory_dimensions.html:101:4 The mandatory attribute 'lightbox' is missing in tag 'AMP-CAROUSEL[lightbox]'. (see https://www.ampproject.org/docs/reference/components/amp-carousel) [DISALLOWED_HTML]
 >>     ^~~~~~~~~
-feature_tests/mandatory_dimensions.html:101:4 The tag 'amp-carousel with lightbox attribute' requires including the 'amp-carousel' extension JavaScript. (see https://www.ampproject.org/docs/reference/components/amp-carousel) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
+feature_tests/mandatory_dimensions.html:101:4 The tag 'AMP-CAROUSEL[lightbox]' requires including the 'amp-carousel' extension JavaScript. (see https://www.ampproject.org/docs/reference/components/amp-carousel) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
 >>     ^~~~~~~~~
-feature_tests/mandatory_dimensions.html:101:4 The tag 'amp-carousel with lightbox attribute' requires including the 'amp-lightbox-gallery' extension JavaScript. (see https://www.ampproject.org/docs/reference/components/amp-carousel) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
+feature_tests/mandatory_dimensions.html:101:4 The tag 'AMP-CAROUSEL[lightbox]' requires including the 'amp-lightbox-gallery' extension JavaScript. (see https://www.ampproject.org/docs/reference/components/amp-carousel) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
 |      <amp-youtube data-videoid="dQw4w9WgXcQ" height="42"></amp-youtube>
 >>     ^~~~~~~~~
 feature_tests/mandatory_dimensions.html:102:4 The tag 'amp-youtube' requires including the 'amp-youtube' extension JavaScript. (see https://www.ampproject.org/docs/reference/components/amp-youtube) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]


### PR DESCRIPTION
Closes https://github.com/ampproject/amphtml/issues/13789. Should be the final version for validator rules for this iteration of lightbox. 
1. Add tests for `<amp-lightbox-gallery>`. 
2. Add attribute lists to cover `lightboxable-elements` and `children-of-lightboxed-carousel`. 
3. Add reference point for `<amp-carousel>` with `lightbox` attribute. 
4. Update validator.out files for `validator/testdata/feature_tests/mandatory_dimensions.out` to account for side effect of adding a reference point for `<amp-carousel>`. 