### PR TITLE
🐛BeOpinion : Fix extension declaration.

### DIFF
--- a/3p/beopinion.js
+++ b/3p/beopinion.js
@@ -96,7 +96,7 @@ function getBeOpinionAsyncInit(global, accountId) {
       onHeightChange: function(newHeight) {
         const c = global.document.getElementById('c');
         const boundingClientRect = c./*REVIEW*/getBoundingClientRect();
-        context.onResizeDenied(context.requestResize);
+        context.onResizeDenied(context.requestResize.bind(context));
         context.requestResize(boundingClientRect.width, newHeight);
       },
     });

--- a/3p/integration.js
+++ b/3p/integration.js
@@ -66,12 +66,12 @@ import {urls} from '../src/config';
 /* eslint-disable sort-imports-es6-autofix/sort-imports-es6 */
 
 // 3P - please keep in alphabetic order
+import {beopinion} from './beopinion';
 import {bodymovinanimation} from './bodymovinanimation';
 import {facebook} from './facebook';
 import {github} from './github';
 import {mathml} from './mathml';
 import {reddit} from './reddit';
-import {beopinion} from './beopinion';
 import {twitter} from './twitter';
 
 import {_ping_} from '../ads/_ping_';

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -90,6 +90,7 @@ declareExtension('amp-apester-media', '0.1', {hasCss: true});
 declareExtension('amp-app-banner', '0.1', {hasCss: true});
 declareExtension('amp-audio', '0.1');
 declareExtension('amp-auto-ads', '0.1');
+declareExtension('amp-beopinion', '0.1');
 declareExtension('amp-bind', '0.1');
 declareExtension('amp-bodymovin-animation', '0.1', {hasCss: false});
 declareExtension('amp-brid-player', '0.1');


### PR DESCRIPTION
The declaration of the BeOpinion extension used to work from `integration.js` but it seems like now the source of truth as far as extensions are concerned is `gulpfile.js`.