### PR TITLE
🏗 Print only the first line of error messages

### DIFF
--- a/test/_init_tests.js
+++ b/test/_init_tests.js
@@ -275,6 +275,7 @@ function warnForConsoleError() {
   consoleErrorSandbox = sinon.sandbox.create();
   const originalConsoleError = console/*OK*/.error;
   consoleErrorSandbox.stub(console, 'error').callsFake((...messages) => {
+    const errorMessage = messages.join(' ').split('\n', 1)[0]; // First line.
     const helpMessage = '    The test "' + testName + '"' +
         ' resulted in a call to console.error.\n' +
         '    ⤷ If this is not expected, fix the code that generated ' +
@@ -284,7 +285,7 @@ function warnForConsoleError() {
         '        \'allowConsoleError(() => { <code that generated the ' +
             'error> });';
     // TODO(rsimha, #14432): Throw an error here after all tests are fixed.
-    originalConsoleError(messages.join(' ') + '\'\n' + helpMessage);
+    originalConsoleError(errorMessage + '\'\n' + helpMessage);
   });
   this.allowConsoleError = function(func) {
     dontWarnForConsoleError();


### PR DESCRIPTION
Most error messages we warn about during tests are just one line long. However, some contain a top line, followed by a mostly useless mocha call stack. For example, https://travis-ci.org/ampproject/amphtml/jobs/365597632#L972-L982

This PR truncates error messages to the first line while logging them after tests.