### PR TITLE
Whitelist links in <pre> blocks

### DIFF
--- a/build-system/tasks/check-links.js
+++ b/build-system/tasks/check-links.js
@@ -141,6 +141,9 @@ function filterWhitelistedLinks(markdown) {
 
   // Links inside a <code> block (illustrative, and not always valid)
   filteredMarkdown = filteredMarkdown.replace(/<code>(.*?)<\/code>/g, '');
+  
+  // Links inside a <pre> block (illustrative, and not always valid)
+  filteredMarkdown = filteredMarkdown.replace(/<pre>(.*?)<\/pre>/g, '');
 
   // The heroku nightly build page is not always acccessible by the checker.
   filteredMarkdown = filteredMarkdown.replace(

--- a/build-system/tasks/check-links.js
+++ b/build-system/tasks/check-links.js
@@ -143,7 +143,7 @@ function filterWhitelistedLinks(markdown) {
   filteredMarkdown = filteredMarkdown.replace(/<code>(.*?)<\/code>/g, '');
   
   // Links inside a <pre> block (illustrative, and not always valid)
-  filteredMarkdown = filteredMarkdown.replace(/<pre>(.*?)<\/pre>/g, '');
+  filteredMarkdown = filteredMarkdown.replace(/<pre>(.*?)<\/pre>/gs, '');
 
   // The heroku nightly build page is not always acccessible by the checker.
   filteredMarkdown = filteredMarkdown.replace(

--- a/build-system/tasks/check-links.js
+++ b/build-system/tasks/check-links.js
@@ -141,7 +141,7 @@ function filterWhitelistedLinks(markdown) {
 
   // Links inside a <code> block (illustrative, and not always valid)
   filteredMarkdown = filteredMarkdown.replace(/<code>(.*?)<\/code>/gs, '');
-  
+
   // Links inside a <pre> block (illustrative, and not always valid)
   filteredMarkdown = filteredMarkdown.replace(/<pre>(.*?)<\/pre>/gs, '');
 

--- a/build-system/tasks/check-links.js
+++ b/build-system/tasks/check-links.js
@@ -140,7 +140,7 @@ function filterWhitelistedLinks(markdown) {
   filteredMarkdown = filteredMarkdown.replace(/src="http.*?"/g, '');
 
   // Links inside a <code> block (illustrative, and not always valid)
-  filteredMarkdown = filteredMarkdown.replace(/<code>(.*?)<\/code>/g, '');
+  filteredMarkdown = filteredMarkdown.replace(/<code>(.*?)<\/code>/gs, '');
   
   // Links inside a <pre> block (illustrative, and not always valid)
   filteredMarkdown = filteredMarkdown.replace(/<pre>(.*?)<\/pre>/gs, '');


### PR DESCRIPTION
Whitelist links in `<pre>` blocks, as these links are often illustrative and not valid URLs.