### PR TITLE
Lightbox bugfixes

### DIFF
--- a/extensions/amp-image-viewer/0.1/amp-image-viewer.js
+++ b/extensions/amp-image-viewer/0.1/amp-image-viewer.js
@@ -76,11 +76,11 @@ export class AmpImageViewer extends AMP.BaseElement {
     /** @private {number} */
     this.sourceHeight_ = 0;
 
-    /** @private {!../../../src/layout-rect.LayoutRectDef} */
-    this.elementBox_ = layoutRectLtwh(0, 0, 0, 0);
+    /** @private {?../../../src/layout-rect.LayoutRectDef} */
+    this.elementBox_ = null;
 
-    /** @private {!../../../src/layout-rect.LayoutRectDef} */
-    this.imageBox_ = layoutRectLtwh(0, 0, 0, 0);
+    /** @private {?../../../src/layout-rect.LayoutRectDef} */
+    this.imageBox_ = null;
 
     /** @private {!UnlistenDef|null} */
     this.unlistenOnSwipePan_ = null;
@@ -219,7 +219,7 @@ export class AmpImageViewer extends AMP.BaseElement {
 
   /**
    * Returns the boundaries of the image element.
-   * @return {!../../../src/layout-rect.LayoutRectDef}
+   * @return {?../../../src/layout-rect.LayoutRectDef}
    */
   getImageBox() {
     return this.imageBox_;
@@ -236,10 +236,10 @@ export class AmpImageViewer extends AMP.BaseElement {
   /**
    * Returns the boundaries of the image element with the offset if it was
    * moved by a gesture.
-   * @return {!../../../src/layout-rect.LayoutRectDef}
+   * @return {?../../../src/layout-rect.LayoutRectDef}
    */
   getImageBoxWithOffset() {
-    if (this.posX_ == 0 && this.posY_ == 0) {
+    if (this.posX_ == 0 && this.posY_ == 0 || !this.imageBox_) {
       return this.imageBox_;
     }
     const expansionScale = (this.scale_ - 1) / 2;

--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -867,15 +867,6 @@ export class AmpLightboxGallery extends AMP.BaseElement {
     const anim = new Animation(this.element);
     let duration = MIN_TRANSITION_DURATION;
 
-    const imageBox = /**@type {?}*/ (this.getCurrentElement_().imageViewer)
-        .implementation_.getImageBoxWithOffset();
-
-    // If the image isn't initialized, bail out the transition.
-    if (imageBox.width == 0 && imageBox.height == 0) {
-      return this.fade_(0, 1);
-    }
-
-    // TODO (#13039): implement crop and object fit contain transitions
     const transLayer = this.element.ownerDocument.createElement('div');
     transLayer.classList.add('i-amphtml-lightbox-gallery-trans');
     const sourceImg = childElementByTag(sourceElement, 'img');
@@ -883,79 +874,89 @@ export class AmpLightboxGallery extends AMP.BaseElement {
     clone.removeAttribute('class');
     transLayer.appendChild(clone);
 
-    // Gradually fade in the black background
-    anim.add(0, tr.setStyles(this.element, {
-      opacity: tr.numeric(0, 1),
-    }), MOTION_DURATION_RATIO, ENTER_CURVE_);
-
-    // Fade in the carousel at the end of the animation while fading out
-    // the transition layer
-    anim.add(MOTION_DURATION_RATIO - 0.01,
-        tr.setStyles(dev().assertElement(this.carousel_), {
-          opacity: tr.numeric(0, 1),
-        }),
-        0.01
-    );
-
-    // At the end of the animation, fade out the transition layer.
-    anim.add(0.9, tr.setStyles(transLayer, {
-      opacity: tr.numeric(1, 0.01),
-    }), 0.1, EXIT_CURVE_);
-
-    return this.vsync_.runPromise({
-      measure: () => {
-        const rect = layoutRectFromDomRect(sourceElement
-            ./*OK*/getBoundingClientRect());
-        st.setStyles(clone, {
-          position: 'absolute',
-          top: st.px(rect.top),
-          left: st.px(rect.left),
-          width: st.px(rect.width),
-          height: st.px(rect.height),
-          transformOrigin: 'top left',
-          willChange: 'transform',
-        });
-        const dx = imageBox.left - rect.left;
-        const dy = imageBox.top - rect.top;
-        const scaleX = rect.width != 0 ? imageBox.width / rect.width : 1;
-        const viewportHeight = this.getViewport().getSize().height;
-        duration = this.getTransitionDuration_(Math.abs(dy), viewportHeight);
-
-        // Animate the position and scale of the transition image to its
-        // final lightbox destination in the middle of the page
-        anim.add(0, tr.setStyles(clone, {
-          transform: tr.concat([
-            tr.translate(tr.numeric(0, dx), tr.numeric(0, dy)),
-            tr.scale(tr.numeric(1, scaleX)),
-          ]),
-        }), MOTION_DURATION_RATIO, ENTER_CURVE_);
-      },
-      mutate: () => {
-        st.setStyles(dev().assertElement(this.carousel_), {
-          opacity: 0,
-          display: '',
-        });
-        sourceElement.classList.add('i-amphtml-ghost');
-        this.element.ownerDocument.body.appendChild(transLayer);
-      },
-    }).then(() => {
-      return anim.start(duration).thenAlways(() => {
-        return this.vsync_.mutatePromise(() => {
-          st.setStyles(this.element, {opacity: ''});
-          st.setStyles(dev().assertElement(this.carousel_), {opacity: ''});
-          sourceElement.classList.remove('i-amphtml-ghost');
-          if (transLayer) {
-            this.element.ownerDocument.body.removeChild(transLayer);
+    return this.getCurrentElement_().imageViewer.getImpl()
+        .then(imageViewer => {
+          const imageBox = imageViewer.getImageBoxWithOffset();
+          if (!imageBox) {
+            return this.fade_(0, 1);
           }
+
+          // Gradually fade in the black background
+          anim.add(0, tr.setStyles(this.element, {
+            opacity: tr.numeric(0, 1),
+          }), MOTION_DURATION_RATIO, ENTER_CURVE_);
+
+          // Fade in the carousel at the end of the animation while fading out
+          // the transition layer
+          anim.add(MOTION_DURATION_RATIO - 0.01,
+              tr.setStyles(dev().assertElement(this.carousel_), {
+                opacity: tr.numeric(0, 1),
+              }),
+              0.01
+          );
+
+          // At the end of the animation, fade out the transition layer.
+          anim.add(0.9, tr.setStyles(transLayer, {
+            opacity: tr.numeric(1, 0.01),
+          }), 0.1, EXIT_CURVE_);
+
+          return this.vsync_.runPromise({
+            measure: () => {
+              const rect = layoutRectFromDomRect(sourceElement
+                  ./*OK*/getBoundingClientRect());
+              st.setStyles(clone, {
+                position: 'absolute',
+                top: st.px(rect.top),
+                left: st.px(rect.left),
+                width: st.px(rect.width),
+                height: st.px(rect.height),
+                transformOrigin: 'top left',
+                willChange: 'transform',
+              });
+              const dx = imageBox.left - rect.left;
+              const dy = imageBox.top - rect.top;
+              const scaleX = rect.width != 0 ? imageBox.width / rect.width : 1;
+              const viewportHeight = this.getViewport().getSize().height;
+              duration = this.getTransitionDuration_(Math.abs(dy),
+                  viewportHeight);
+
+              // Animate the position and scale of the transition image to its
+              // final lightbox destination in the middle of the page
+              anim.add(0, tr.setStyles(clone, {
+                transform: tr.concat([
+                  tr.translate(tr.numeric(0, dx), tr.numeric(0, dy)),
+                  tr.scale(tr.numeric(1, scaleX)),
+                ]),
+              }), MOTION_DURATION_RATIO, ENTER_CURVE_);
+            },
+            mutate: () => {
+              st.setStyles(dev().assertElement(this.carousel_), {
+                opacity: 0,
+                display: '',
+              });
+              sourceElement.classList.add('i-amphtml-ghost');
+              this.element.ownerDocument.body.appendChild(transLayer);
+            },
+          });
+        }).then(() => {
+          return anim.start(duration).thenAlways(() => {
+            return this.vsync_.mutatePromise(() => {
+              st.setStyles(this.element, {opacity: ''});
+              st.setStyles(dev().assertElement(this.carousel_), {opacity: ''});
+              sourceElement.classList.remove('i-amphtml-ghost');
+              if (transLayer) {
+                this.element.ownerDocument.body.removeChild(transLayer);
+              }
+            });
+          });
         });
-      });
-    });
   }
 
   /**
    * If no transition image is applicable, fade the lightbox in and out.
    * @param {number} startOpacity
    * @param {number} endOpacity
+   * @returns {!Promise}
    * @private
    */
   fade_(startOpacity, endOpacity) {
@@ -1012,6 +1013,11 @@ export class AmpLightboxGallery extends AMP.BaseElement {
         .then(imageViewer => {
           const imageBox = imageViewer.getImageBoxWithOffset();
           const image = imageViewer.getImage();
+
+          if (!imageBox) {
+            return this.fade_(1, 0);
+          }
+
           const clone = image.cloneNode(true);
           clone.removeAttribute('class');
           clone.removeAttribute('style');
@@ -1388,23 +1394,20 @@ export class AmpLightboxGallery extends AMP.BaseElement {
   }
 
   /**
-   *
+   * @param {Event} event
    * @param {string} id
-   * @return {function(Event)}
    * @private
    */
-  generateThumbnailClickHandler_(id) {
-    return event => {
-      event.stopPropagation();
-      Promise.all([
-        this.closeGallery_(),
-        dev().assert(this.carousel_).getImpl(),
-      ]).then(values => {
-        this.currentElemId_ = id;
-        values[1].showSlideWhenReady(this.currentElemId_);
-        this.updateDescriptionBox_();
-      });
-    };
+  handleThumbnailClick_(event, id) {
+    event.stopPropagation();
+    Promise.all([
+      this.closeGallery_(),
+      dev().assert(this.carousel_).getImpl(),
+    ]).then(values => {
+      this.currentElemId_ = id;
+      values[1].showSlideWhenReady(this.currentElemId_);
+      this.updateDescriptionBox_();
+    });
   }
 
   /**
@@ -1447,9 +1450,9 @@ export class AmpLightboxGallery extends AMP.BaseElement {
       element.appendChild(timestampDiv);
     }
 
-    const handleThumbnailClick = this.generateThumbnailClickHandler_(
-        thumbnailObj.element.lightboxItemId);
-    element.addEventListener('click', handleThumbnailClick.bind(this));
+    element.addEventListener('click', e => {
+      this.handleThumbnailClick_(e, thumbnailObj.element.lightboxItemId);
+    });
     return element;
   }
 }


### PR DESCRIPTION
1. Bail out of transition when image height and width is 0, 0. 
2. Wait for carousel to be visible in close gallery to avoid race when the image shows as 0, 0. 