### PR TITLE
Fix amp-bind tests and elementByTag()

### DIFF
--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -874,7 +874,7 @@ export class Bind {
     switch (property) {
       case 'text':
         element.textContent = String(newValue);
-        if (tag === 'TITLE') {
+        if (tag === 'TITLE' && this.ampdoc.isSingleDoc()) {
           this.localWin_.document.title = String(newValue);
         }
         // Setting `textContent` on TEXTAREA element only works if user

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -162,7 +162,7 @@ export class Bind {
     this.initializePromise_ =
         this.viewer_.whenFirstVisible().then(() => bodyPromise).then(body => {
           const head = (opt_win) ? opt_win.document.head : ampdoc.getHeadNode();
-          return this.initialize_(body, elementByTag(head, 'title'));
+          return this.initialize_(body, head && elementByTag(head, 'title'));
         });
 
     /** @private {Promise} */
@@ -283,7 +283,7 @@ export class Bind {
   /**
    * Scans the ampdoc for bindings and creates the expression evaluator.
    * @param {!Node} rootNode
-   * @param {Node} titleNode
+   * @param {?Node} titleNode
    * @return {!Promise}
    * @private
    */

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -161,8 +161,8 @@ export class Bind {
      */
     this.initializePromise_ =
         this.viewer_.whenFirstVisible().then(() => bodyPromise).then(body => {
-          return this.initialize_(
-              body, elementByTag(ampdoc.getHeadNode(), 'title'));
+          const head = (opt_win) ? opt_win.document.head : ampdoc.getHeadNode();
+          return this.initialize_(body, elementByTag(head, 'title'));
         });
 
     /** @private {Promise} */
@@ -874,7 +874,9 @@ export class Bind {
     switch (property) {
       case 'text':
         element.textContent = String(newValue);
-        if (tag === 'TITLE' && this.ampdoc.isSingleDoc()) {
+        // If this is a <title> element in the <head>, update document title.
+        if (tag === 'TITLE'
+            && element.parentNode === this.localWin_.document.head) {
           this.localWin_.document.title = String(newValue);
         }
         // Setting `textContent` on TEXTAREA element only works if user

--- a/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
@@ -148,11 +148,14 @@ describe.configure().ifNewChrome().run('Bind', function() {
     });
 
     it('should not update host document title for <title> elements', () => {
-      createElement(env, fieBody, '[text]="\'a\' + \'b\' + \'c\'"', 'title',
+      createElement(env, fieBody, '[text]="\'bar\'"', 'title',
           /* opt_amp */ false, /* opt_head */ true);
+      fieWindow.document.title = 'foo';
+      hostWindow.document.title = 'foo';
       return onBindReadyAndSetState(env, fieBind, {}).then(() => {
         // Make sure it does not update the host window's document title.
-        expect(hostWindow.document.title).to.not.equal('abc');
+        expect(fieWindow.document.title).to.equal('bar');
+        expect(hostWindow.document.title).to.equal('foo');
       });
     });
 
@@ -222,11 +225,12 @@ describe.configure().ifNewChrome().run('Bind', function() {
     });
 
     it('should not update document title for <title> elements', () => {
-      createElement(env, container, '[text]="\'a\' + \'b\' + \'c\'"', 'title',
+      createElement(env, container, '[text]="\'bar\'"', 'title',
           /* opt_amp */ false, /* opt_head */ true);
+      env.win.document.title = 'foo';
       return onBindReadyAndSetState(env, bind, {}).then(() => {
         // Make sure does not update the host window's document title.
-        expect(env.win.document.title).to.not.equal('abc');
+        expect(env.win.document.title).to.equal('foo');
       });
     });
   }); // in shadow ampdoc
@@ -398,14 +402,13 @@ describe.configure().ifNewChrome().run('Bind', function() {
     });
 
     it('should update document title for <title> elements', () => {
-      const element = createElement(env, container,
-          '[text]="\'a\' + \'b\' + \'c\'"', 'title', /* opt_amp */ false,
-          /* opt_head */ true);
+      const element = createElement(env, container, '[text]="\'bar\'"',
+          'title', /* opt_amp */ false, /* opt_head */ true);
       element.textContent = 'foo';
       env.win.document.title = 'foo';
       return onBindReadyAndSetState(env, bind, {}).then(() => {
-        expect(element.textContent).to.equal('abc');
-        expect(env.win.document.title).to.equal('abc');
+        expect(element.textContent).to.equal('bar');
+        expect(env.win.document.title).to.equal('bar');
       });
     });
 
@@ -414,12 +417,12 @@ describe.configure().ifNewChrome().run('Bind', function() {
       // `textContent` on a <title> element in the <body> will strangely update
       // `document.title`.
       const title = env.win.document.createElement('title');
-      title.textContent = 'my-title';
+      title.textContent = 'foo';
       env.win.document.head.appendChild(title);
-      // Add <title [text]="'abc'"> to <body>.
-      createElement(env, container, '[text]="\'abc\'"', 'title');
+      // Add <title [text]="'bar'"> to <body>.
+      createElement(env, container, '[text]="\'bar\'"', 'title');
       return onBindReadyAndSetState(env, bind, {}).then(() => {
-        expect(env.win.document.title).to.equal('my-title');
+        expect(env.win.document.title).to.equal('foo');
       });
     });
 

--- a/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
@@ -402,9 +402,24 @@ describe.configure().ifNewChrome().run('Bind', function() {
           '[text]="\'a\' + \'b\' + \'c\'"', 'title', /* opt_amp */ false,
           /* opt_head */ true);
       element.textContent = 'foo';
+      env.win.document.title = 'foo';
       return onBindReadyAndSetState(env, bind, {}).then(() => {
         expect(element.textContent).to.equal('abc');
         expect(env.win.document.title).to.equal('abc');
+      });
+    });
+
+    it('should not update document title for <title> elements in body', () => {
+      // Add a <title> element to <head> because if we don't, setting
+      // `textContent` on a <title> element in the <body> will strangely update
+      // `document.title`.
+      const title = env.win.document.createElement('title');
+      title.textContent = 'my-title';
+      env.win.document.head.appendChild(title);
+      // Add <title [text]="'abc'"> to <body>.
+      createElement(env, container, '[text]="\'abc\'"', 'title');
+      return onBindReadyAndSetState(env, bind, {}).then(() => {
+        expect(env.win.document.title).to.equal('my-title');
       });
     });
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -808,7 +808,7 @@ function performBuild(watch) {
  */
 function checkBinarySize(compiled) {
   const file = compiled ? './dist/v0.js' : './dist/amp.js';
-  const size = compiled ? '76.81KB' : '334.41KB';
+  const size = compiled ? '76.79KB' : '334.46KB';
   const cmd = `npx bundlesize -f "${file}" -s "${size}"`;
   log(green('Running ') + cyan(cmd) + green('...\n'));
   const p = exec(cmd);

--- a/src/dom.js
+++ b/src/dom.js
@@ -324,8 +324,14 @@ export function matches(el, selector) {
  * @return {?Element}
  */
 export function elementByTag(element, tagName) {
-  const elements = element.getElementsByTagName(tagName);
-  return elements[0] || null;
+  let elements;
+  // getElementsByTagName() is not supported on ShadowRoot.
+  if (typeof element.getElementsByTagName === 'function') {
+    elements = element.getElementsByTagName(tagName);
+  } else {
+    elements = scopedQuerySelectorAll(element, tagName);
+  }
+  return (elements && elements[0]) || null;
 }
 
 

--- a/src/dom.js
+++ b/src/dom.js
@@ -329,7 +329,7 @@ export function elementByTag(element, tagName) {
   if (typeof element.getElementsByTagName === 'function') {
     elements = element.getElementsByTagName(tagName);
   } else {
-    elements = scopedQuerySelectorAll(element, tagName);
+    elements = element./*OK*/querySelectorAll(tagName);
   }
   return (elements && elements[0]) || null;
 }


### PR DESCRIPTION
Follow-up to #14564. 

Also adds tests to ensure correct behavior in PWA/FIE cases and when `<title>` is not in the `<head>` (which is valid AMP!).

/to @rsimha 