### PR TITLE
🐛 Respect CAN_SHOW_SYSTEM_LAYER_BUTTONS property on desktop

### DIFF
--- a/extensions/amp-story/1.0/amp-story-desktop.css
+++ b/extensions/amp-story/1.0/amp-story-desktop.css
@@ -423,6 +423,10 @@ span.i-amphtml-story-share-pill-label {
   padding: 0;
 }
 
+.i-amphtml-story-ui-no-buttons .i-amphtml-story-share-pill {
+  visibility: hidden !important;
+}
+
 [desktop] .i-amphtml-story-share-icon {
   font-size: 0px!important;
   background-size: 24px 24px !important;

--- a/extensions/amp-story/1.0/amp-story-system-layer.css
+++ b/extensions/amp-story/1.0/amp-story-system-layer.css
@@ -115,7 +115,7 @@
 
 .i-amphtml-story-ui-no-buttons .i-amphtml-story-button,
 .i-amphtml-story-ui-no-buttons .i-amphtml-story-system-layer-buttons {
-  display: none !important;
+  visibility: hidden !important;
 }
 
 .i-amphtml-story-unmute-audio-control {

--- a/extensions/amp-story/1.0/amp-story-system-layer.js
+++ b/extensions/amp-story/1.0/amp-story-system-layer.js
@@ -152,10 +152,11 @@ export class SystemLayer {
 
     this.initializeListeners_();
 
-    // TODO(newmuis): Observe this value.
-    if (!this.storeService_.get(StateProperty.CAN_SHOW_SYSTEM_LAYER_BUTTONS)) {
-      this.systemLayerEl_.classList.add('i-amphtml-story-ui-no-buttons');
-    }
+    this.storeService_.subscribe(StateProperty.CAN_SHOW_SYSTEM_LAYER_BUTTONS,
+        canShowButtons => {
+          this.systemLayerEl_.classList
+              .toggle('i-amphtml-story-ui-no-buttons', !canShowButtons);
+        }, true /* callToInitialize */);
 
     if (Services.platformFor(this.win_).isIos()) {
       this.systemLayerEl_.setAttribute('ios', '');

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -528,6 +528,7 @@ export class AmpStory extends AMP.BaseElement {
 
   /** @private */
   buildTopBar_() {
+    // TODO(gmajoulet): Move the desktop "top bar" into the system layer.
     const doc = this.element.ownerDocument;
 
     this.topBar_ = doc.createElement('div');

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -412,6 +412,14 @@ export class AmpStory extends AMP.BaseElement {
       this.onDesktopStateUpdate_(isDesktop);
     });
 
+    this.storeService_.subscribe(StateProperty.CAN_SHOW_SYSTEM_LAYER_BUTTONS,
+        canShowButtons => {
+          this.mutateElement(() => {
+            this.topBar_.classList
+                .toggle('i-amphtml-story-ui-no-buttons', !canShowButtons);
+          });
+        }, true /* callToInitialize */);
+
     this.win.document.addEventListener('keydown', e => {
       this.onKeyDown_(e);
     }, true);

--- a/extensions/amp-story/1.0/test/test-amp-story-system-layer.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-system-layer.js
@@ -31,7 +31,10 @@ describes.fakeWin('amp-story system layer', {amp: true}, env => {
   beforeEach(() => {
     win = env.win;
 
-    registerServiceBuilder(win, 'story-store', () => ({get: NOOP}));
+    registerServiceBuilder(win, 'story-store', () => ({
+      get: NOOP,
+      subscribe: NOOP,
+    }));
     progressBarRoot = win.document.createElement('div');
 
     progressBarStub = {


### PR DESCRIPTION
Also subscribes to the state for both the share pill and the system layer.  Also, switches to using `visibility: hidden` instead of `display: none` to simplify (since we often change the `display` property for other reasons).

Fixes #14574 