### PR TITLE
turn off font display swap

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -33,7 +33,6 @@
   "expUnconditionedAdxIdentity": 0.01,
   "expUnconditionedDfpIdentity": 0.01,
   "expUnconditionedCanonicalHoldback": 0.01,
-  "font-display-swap": 1,
   "rollback-delayed-fetch-deprecation": 0,
   "rollback-dfd-ix": 1,
   "rollback-dfd-criteo": 1,


### PR DESCRIPTION
need to deploy current latest canary to 1%. this experiment is currently the only suspect for some performance regression (still not 100% proven)