### PR TITLE
Add `open` action to `<amp-lightbox-gallery>` update demo with video, youtube, and ads 

### DIFF
--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -194,6 +194,7 @@ export class AmpLightboxGallery extends AMP.BaseElement {
       this.element.appendChild(this.container_);
       this.manager_.maybeInit();
       this.buildMask_();
+      this.registerAction('open', invocation => this.activate(invocation));
     });
   }
 
@@ -787,13 +788,7 @@ export class AmpLightboxGallery extends AMP.BaseElement {
         .then(carousel => carousel.showSlideWhenReady(this.currentElemId_));
     const tagName = this.getCurrentElement_().tagName;
     this.updateDescriptionBox_();
-    if (ELIGIBLE_TAP_TAGS[tagName]) {
-      return this.getCurrentElement_().imageViewer.signals()
-          .whenSignal(CommonSignals.LOAD_END)
-          .then(() => this.enter_());
-    } else {
-      return Promise.resolve();
-    }
+    return this.enter_();
   }
 
   /**
@@ -996,7 +991,9 @@ export class AmpLightboxGallery extends AMP.BaseElement {
     return this.shouldAnimate_(sourceElement)
         .then(shouldAnimate => {
           if (shouldAnimate) {
-            return this.transitionIn_(sourceElement);
+            return this.getCurrentElement_().imageViewer.signals()
+                .whenSignal(CommonSignals.LOAD_END)
+                .then(() => this.transitionIn_(sourceElement));
           } else {
             return this.fade_(0, 1);
           }

--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -1004,16 +1004,15 @@ export class AmpLightboxGallery extends AMP.BaseElement {
       return this.fade_(0, 1);
     }
 
-    return Promise.all([
+    const promises = [
       this.shouldAnimate_(sourceElement),
       this.getCurrentElement_().imageViewer.signals()
           .whenSignal(CommonSignals.LOAD_END),
-    ]).then(values => {
-      if (values[0]) {
-        return this.transitionIn_(sourceElement);
-      } else {
-        return this.fade_(0, 1);
-      }
+    ];
+
+    return Promise.all(promises).then(values => {
+      return values[0] ? this.transitionIn_(sourceElement)
+        : this.fade_(0, 1);
     });
   }
 

--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -1011,7 +1011,9 @@ export class AmpLightboxGallery extends AMP.BaseElement {
     ];
 
     return Promise.all(promises).then(values => {
-      return values[0] ? this.transitionIn_(sourceElement)
+      const shouldAnimate = values[0];
+      return shouldAnimate
+        ? this.transitionIn_(sourceElement)
         : this.fade_(0, 1);
     });
   }

--- a/test/manual/article-with-lightbox-2.0-gallery.amp.html
+++ b/test/manual/article-with-lightbox-2.0-gallery.amp.html
@@ -407,13 +407,11 @@
           <span id=img2desc>The brutalist architecture of this building is obvious from its small windows and raw concrete look.</span>
         </amp-img>
 
-        <amp-ad lightbox="toronto" 
-          width="300"
+        <amp-ad data-slot="/30497360/a4a/a4a_native"
+          lightbox="toronto"
           height="250"
-          type="a9"
-          data-aax_size="300x250"
-          data-aax_pubname="test123"
-          data-aax_src="302">
+          type="doubleclick"
+          width="300">
         </amp-ad>
 
         <amp-img lightbox="toronto" src="https://picsum.photos/1600/1600?image=430" layout="responsive" width="1600" height="1600"
@@ -450,6 +448,15 @@
                 </p>
               </div>
             </amp-img>
+
+            <amp-ad
+              width="300"
+              height="250"
+              type="a9"
+              data-aax_size="300x250"
+              data-aax_pubname="test123"
+              data-aax_src="302">
+            </amp-ad>
 
             <amp-img src="https://picsum.photos/1600/900?image=870" layout="responsive" width="1600" height="900" aria-describedby="desc3">
               <div id="desc3" class="lightbox-only-description">

--- a/test/manual/article-with-lightbox-2.0-gallery.amp.html
+++ b/test/manual/article-with-lightbox-2.0-gallery.amp.html
@@ -273,6 +273,7 @@
   <script async custom-element="amp-lightbox-gallery" src="https://cdn.ampproject.org/v0/amp-lightbox-gallery-0.1.js"></script>
   <script async custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.1.js"></script>
   <script async custom-element="amp-youtube" src="https://cdn.ampproject.org/v0/amp-youtube-0.1.js"></script>
+  <script async custom-element="amp-video" src="https://cdn.ampproject.org/v0/amp-video-0.1.js"></script>
   <script async custom-element="amp-ad" src="https://cdn.ampproject.org/v0/amp-ad-0.1.js"></script>
 
   <style amp-boilerplate>
@@ -440,6 +441,14 @@
                 <p>Short - Sed pharetra semper fringilla. Nulla fringilla, neque eget</p>
               </div>
             </amp-img>
+
+            <amp-ad
+              width="300"
+              height="250"
+              type="doubleclick"
+              data-slot="/35096353/amptesting/adx">
+            </amp-ad>
+
             <amp-img src="https://picsum.photos/1600/900?image=864" layout="responsive" width="1600" height="900" aria-describedby="desc2">
               <div id="desc2" class="lightbox-only-description">
                 <p> Medium - Sed pharetra semper fringilla. Nulla fringilla, neque eget varius suscipit, mi turpis congue odio,

--- a/test/manual/article-with-lightbox-2.0-gallery.amp.html
+++ b/test/manual/article-with-lightbox-2.0-gallery.amp.html
@@ -250,6 +250,8 @@
   <link href='https://fonts.googleapis.com/css?family=Georgia|Open+Sans|Roboto' rel='stylesheet' type='text/css'>
   <script async custom-element="amp-lightbox-gallery" src="https://cdn.ampproject.org/v0/amp-lightbox-gallery-0.1.js"></script>
   <script async custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.1.js"></script>
+  <script async custom-element="amp-youtube" src="https://cdn.ampproject.org/v0/amp-youtube-0.1.js"></script>
+  <script async custom-element="amp-ad" src="https://cdn.ampproject.org/v0/amp-ad-0.1.js"></script>
 
   <style amp-boilerplate>
     body {
@@ -370,10 +372,27 @@
           </figcaption>
         </figure>
 
+        <amp-youtube lightbox="toronto"
+          width="480"
+          height="270"
+          layout="responsive"
+          data-videoid="UsZ2dXf7qh4"
+          autoplay>
+        </amp-youtube>
+
         <amp-img lightbox="toronto" src="https://picsum.photos/900/1600?image=948" layout="responsive" width="900" height="1600"
           alt="Picture of a tall building" aria-describedby="img2desc">
           <span id=img2desc>The brutalist architecture of this building is obvious from its small windows and raw concrete look.</span>
         </amp-img>
+
+        <amp-ad lightbox="toronto" 
+          width="300"
+          height="250"
+          type="a9"
+          data-aax_size="300x250"
+          data-aax_pubname="test123"
+          data-aax_src="302">
+        </amp-ad>
 
         <amp-img lightbox="toronto" src="https://picsum.photos/1600/1600?image=430" layout="responsive" width="1600" height="1600"
         alt="Picture of new york city skyline" aria-describedby="img3desc">

--- a/test/manual/article-with-lightbox-2.0-gallery.amp.html
+++ b/test/manual/article-with-lightbox-2.0-gallery.amp.html
@@ -262,6 +262,12 @@
       cursor: pointer;
     }
 
+    .open-in-lightbox span {
+      position: absolute;
+      bottom: 10px;
+      left: 10px;
+    }
+
   </style>
   <link href='https://fonts.googleapis.com/css?family=Georgia|Open+Sans|Roboto' rel='stylesheet' type='text/css'>
   <script async custom-element="amp-lightbox-gallery" src="https://cdn.ampproject.org/v0/amp-lightbox-gallery-0.1.js"></script>
@@ -566,7 +572,9 @@
             layout="responsive"
             lightbox="gallery"
             controls>
-            <div class="open-in-lightbox" on="tap:amp-lightbox-gallery.activate(id='lightboxed-video')">Open in lightbox</div>
+            <div class="open-in-lightbox" on="tap:amp-lightbox-gallery.activate(id='lightboxed-video')">
+              <span>Open video in lightbox</span>
+            </div>
           </amp-video>
         </div>
     </article>

--- a/test/manual/article-with-lightbox-2.0-gallery.amp.html
+++ b/test/manual/article-with-lightbox-2.0-gallery.amp.html
@@ -246,6 +246,22 @@
       cursor: pointer;
     }
 
+    .video-container {
+      margin: auto;
+      width: 80%;
+    }
+
+    .open-in-lightbox {
+      position: absolute;
+      top: 0;
+      z-index: 1;
+      color: white;
+      bottom: 32px;
+      left: 0;
+      right: 0;
+      cursor: pointer;
+    }
+
   </style>
   <link href='https://fonts.googleapis.com/css?family=Georgia|Open+Sans|Roboto' rel='stylesheet' type='text/css'>
   <script async custom-element="amp-lightbox-gallery" src="https://cdn.ampproject.org/v0/amp-lightbox-gallery-0.1.js"></script>
@@ -442,6 +458,14 @@
               </div>
             </amp-img>
 
+            <amp-youtube
+              width="480"
+              height="270"
+              layout="responsive"
+              data-videoid="Yyrtm7c1Ivs"
+              autoplay>
+            </amp-youtube>
+
             <amp-img src="https://picsum.photos/1600/400?image=857" layout="responsive" width="1600" height="400"
               alt="Wide image">
             </amp-img>
@@ -532,6 +556,18 @@
             at erat. Duis non nibh vel erat vehicula hendrerit eget vel velit. Donec congue augue magna, nec eleifend dui
             porttitor
           </p>
+        </div>
+        <div class="video-container">
+          <amp-video
+            src="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4"
+            id="lightboxed-video"
+            width="358"
+            height="204"
+            layout="responsive"
+            lightbox="gallery"
+            controls>
+            <div class="open-in-lightbox" on="tap:amp-lightbox-gallery.activate(id='lightboxed-video')">Open in lightbox</div>
+          </amp-video>
         </div>
     </article>
   </main>


### PR DESCRIPTION
1. In preparation for QA, add `<amp-video>`, `<amp-youtube>`, `<amp-ad>` to the article demo for lightbox. 
2. Add the `open` action to `<amp-lightbox-gallery>`. 