### PR TITLE
🐛Contain placeholder in fluid ads

### DIFF
--- a/css/amp.css
+++ b/css/amp.css
@@ -211,6 +211,10 @@ html.i-amphtml-ios-embed.i-amphtml-ios-overscroll > #i-amphtml-wrapper {
   flex: 1 1 auto;
 }
 
+.i-amphtml-layout-fluid {
+  position: relative;
+}
+
 .i-amphtml-layout-size-defined {
   overflow: hidden !important;
 }
@@ -219,10 +223,6 @@ html.i-amphtml-ios-embed.i-amphtml-ios-overscroll > #i-amphtml-wrapper {
   position: absolute !important;
   top: auto !important;
   bottom: auto !important;
-}
-
-.i-amphtml-layout-fluid {
-  position: relative;
 }
 
 i-amphtml-sizer {


### PR DESCRIPTION
When an `amp-ad` is fluid it can get into a state where the placeholder can break out of its containing ad element, capturing any clicks on the page. This happens when the ad has the `i-amphtml-layout-awaiting-size` class removed but before the placeholder is hidden.

If we add `position:relative` to the `i-amphtml-layout-fluid` class it prevents this problem.

