### PR TITLE
Fix SF bug & add feature to detect isAmp

### DIFF
--- a/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
@@ -221,8 +221,12 @@ export class SafeframeHostApi {
             'sf_ver': this.baseInstance_.safeframeVersion,
             'ck_on': 1,
             'flash_ver': '26.0.0',
+            // Once GPT Safeframe is updated to look in amp object,
+            // remove this canonical_url here.
             'canonical_url': this.maybeGetCanonicalUrl(),
-            'is_amp': true,
+            'amp': {
+              'canonical_url': this.maybeGetCanonicalUrl(),
+            },
           },
         }));
     attributes['reportCreativeGeometry'] = this.isFluid_;
@@ -274,14 +278,14 @@ export class SafeframeHostApi {
     const ampAdBox = this.baseInstance_.getPageLayoutBox();
     const heightOffset = (ampAdBox.height - this.creativeSize_.height) / 2;
     const widthOffset = (ampAdBox.width - this.creativeSize_.width) / 2;
-    const iframeBox = {
+    const iframeBox = /** @type {!../../../src/layout-rect.LayoutRectDef} */ ({
       top: ampAdBox.top + heightOffset,
       bottom: ampAdBox.bottom - heightOffset,
       left: ampAdBox.left + widthOffset,
       right: ampAdBox.right - widthOffset,
       height: this.initialCreativeSize_.height,
       width: this.initialCreativeSize_.width,
-    };
+    });
     return this.formatGeom_(iframeBox);
   }
 
@@ -360,7 +364,7 @@ export class SafeframeHostApi {
   /**
    * Builds geometry update format expected by GPT Safeframe.
    * Also sets this.currentGeometry as side effect.
-   * @param {!Object} iframeBox The elementRect for the safeframe.
+   * @param {!../../../src/layout-rect.LayoutRectDef} iframeBox The elementRect for the safeframe.
    * @return {string} Safeframe formatted changes.
    * @private
    */

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
@@ -222,6 +222,7 @@ export class SafeframeHostApi {
             'ck_on': 1,
             'flash_ver': '26.0.0',
             'canonical_url': this.maybeGetCanonicalUrl(),
+            'is_amp': true,
           },
         }));
     attributes['reportCreativeGeometry'] = this.isFluid_;
@@ -364,17 +365,16 @@ export class SafeframeHostApi {
    * @private
    */
   formatGeom_(iframeBox) {
-    const ampAdBox = this.baseInstance_.getPageLayoutBox();
     const viewportSize = this.viewport_.getSize();
     const currentGeometry = /** @type {JsonObject} */({
       'windowCoords_t': 0,
       'windowCoords_r': viewportSize.width,
       'windowCoords_b': viewportSize.height,
       'windowCoords_l': 0,
-      'frameCoords_t': ampAdBox.top,
-      'frameCoords_r': ampAdBox.right,
-      'frameCoords_b': ampAdBox.bottom,
-      'frameCoords_l': ampAdBox.left,
+      'frameCoords_t': iframeBox.top,
+      'frameCoords_r': iframeBox.right,
+      'frameCoords_b': iframeBox.bottom,
+      'frameCoords_l': iframeBox.left,
       'styleZIndex': this.baseInstance_.element.style.zIndex,
       // AMP's built in resize methodology that we use only allows expansion
       // to the right and bottom, so we enforce that here.

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-safeframe.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-safeframe.js
@@ -211,7 +211,7 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
           'ck_on': 1,
           'flash_ver': '26.0.0',
           'canonical_url': 'http://example.org/canonical',
-          'is_amp': true,
+          'amp': {'canonical_url': 'http://example.org/canonical'},
         },
       });
     });
@@ -230,7 +230,7 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
           'sf_ver': doubleclickImpl.safeframeVersion,
           'ck_on': 1,
           'flash_ver': '26.0.0',
-          'is_amp': true,
+          'amp': {},
         },
       });
     });
@@ -250,7 +250,7 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
           'sf_ver': doubleclickImpl.safeframeVersion,
           'ck_on': 1,
           'flash_ver': '26.0.0',
-          'is_amp': true,
+          'amp': {},
         },
       });
     });
@@ -271,7 +271,7 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
           'ck_on': 1,
           'flash_ver': '26.0.0',
           'canonical_url': 'http://example.org',
-          'is_amp': true,
+          'amp': {'canonical_url': 'http://example.org'},
         },
       });
     });

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-safeframe.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-safeframe.js
@@ -211,6 +211,7 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
           'ck_on': 1,
           'flash_ver': '26.0.0',
           'canonical_url': 'http://example.org/canonical',
+          'is_amp': true,
         },
       });
     });
@@ -229,6 +230,7 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
           'sf_ver': doubleclickImpl.safeframeVersion,
           'ck_on': 1,
           'flash_ver': '26.0.0',
+          'is_amp': true,
         },
       });
     });
@@ -248,6 +250,7 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
           'sf_ver': doubleclickImpl.safeframeVersion,
           'ck_on': 1,
           'flash_ver': '26.0.0',
+          'is_amp': true,
         },
       });
     });
@@ -268,6 +271,7 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
           'ck_on': 1,
           'flash_ver': '26.0.0',
           'canonical_url': 'http://example.org',
+          'is_amp': true,
         },
       });
     });
@@ -296,8 +300,8 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
       // amp-ad element
       const css = createElementWithAttributes(doc, 'style');
       css.innerHTML = '.safeframe' +
-          '{height:50px!important;' +
-          'width:50px!important;' +
+          '{height:250px!important;' +
+          'width:300px!important;' +
           'background-color:blue!important;' +
           'display:block!important;}';
       doc.head.appendChild(css);
@@ -309,14 +313,14 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
           'sendMessage_');
       safeframeHost.updateGeometry_();
 
-      return Services.timerFor(env.win).promise(1000).then(() => {
+      return Services.timerFor(env.win).promise(100).then(() => {
         const payload = sendMessageStub.firstCall.args[0];
         const messageType = sendMessageStub.firstCall.args[1];
         expect(payload['newGeometry']).to.equal(
             '{"windowCoords_t":0,"windowCoords_r":500,"windowCoords_b":1000,' +
               '"windowCoords_l":0,"frameCoords_t":0,"frameCoords_r":300,' +
               '"frameCoords_b":250,"frameCoords_l":0,"styleZIndex":"",' +
-              '"allowedExpansion_r":450,"allowedExpansion_b":950,' +
+              '"allowedExpansion_r":200,"allowedExpansion_b":750,' +
               '"allowedExpansion_t":0,"allowedExpansion_l":0,"yInView":1,' +
               '"xInView":1}');
         expect(payload['uid']).to.equal(safeframeHost.uid_);
@@ -352,13 +356,13 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
           'sendMessage_');
       safeframeHost.updateGeometry_();
 
-      return Services.timerFor(env.win).promise(1000).then(() => {
+      return Services.timerFor(env.win).promise(100).then(() => {
         const payload = sendMessageStub.firstCall.args[0];
         const messageType = sendMessageStub.firstCall.args[1];
         expect(payload['newGeometry']).to.equal(
             '{"windowCoords_t":0,"windowCoords_r":500,"windowCoords_b":1000,' +
-              '"windowCoords_l":0,"frameCoords_t":0,"frameCoords_r":50,' +
-              '"frameCoords_b":50,"frameCoords_l":0,"styleZIndex":"",' +
+              '"windowCoords_l":0,"frameCoords_t":0,"frameCoords_r":10,' +
+              '"frameCoords_b":10,"frameCoords_l":0,"styleZIndex":"",' +
               '"allowedExpansion_r":490,"allowedExpansion_b":990,' +
               '"allowedExpansion_t":0,"allowedExpansion_l":0,"yInView":1,' +
               '"xInView":1}');
@@ -388,7 +392,7 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
       maybeUpdateGeometry1();
       maybeUpdateGeometry2();
 
-      return Services.timerFor(env.win).promise(500).then(() => {
+      return Services.timerFor(env.win).promise(100).then(() => {
         expect(sendMessageStub).to.be.calledTwice;
         const payload = sendMessageStub.secondCall.args[0];
         const messageType = sendMessageStub.secondCall.args[1];
@@ -433,8 +437,8 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
       });
       const expectedParsedSfGU = {
         'windowCoords_t': 0, 'windowCoords_r': 500, 'windowCoords_b': 1000,
-        'windowCoords_l': 0, 'frameCoords_t': 200, 'frameCoords_r': 400,
-        'frameCoords_b': 800, 'frameCoords_l': 100, 'styleZIndex': '',
+        'windowCoords_l': 0, 'frameCoords_t': 300, 'frameCoords_r': 500,
+        'frameCoords_b': 1000, 'frameCoords_l': 200, 'styleZIndex': '',
         'allowedExpansion_r': 200, 'allowedExpansion_b': 300,
         'allowedExpansion_t': 0, 'allowedExpansion_l': 0, 'yInView': 1,
         'xInView': 1,


### PR DESCRIPTION
Fix two issues:

https://github.com/ampproject/amphtml/issues/14285 - Sending amp-ad size instead of sf size for $sf.ext.geom().self 
https://github.com/ampproject/amphtml/issues/14269- Feature request to expose is_amp bit on $sf.ext.meta() - will require a matching update in ext.js 

Testing: Updated unit tests, and verified correct behavior via manually testing on example page. 