### PR TITLE
🐛 fix line length and typo in amp-geo example 

### DIFF
--- a/examples/amp-geo.amp.html
+++ b/examples/amp-geo.amp.html
@@ -60,7 +60,10 @@
     </code>
   </pre>
   <p>
-      This means that if your country is "unknown" you will appear in the "nafta" and "unknown" groups.  To change the country for testing append #amp-go=&lt;code&gt; to the url and reload the page (eg #amp-geo=nz)
+      This means that if your country is "unknown" you will appear in the
+      "nafta" and "unknown" groups.  To change the country for testing
+      append #amp-geo=&lt;code&gt; to the url and reload the page
+      (eg #amp-geo=nz)
   </p>
   
 
@@ -91,8 +94,5 @@
           }
           </script>
   </amp-analytics>
-
-
 </body>
-
 </html>


### PR DESCRIPTION
Fix a minor typo and the line length in amp-geo example 

