### PR TITLE
🚀 Parsely: Eliminate unnecessary http requests for incremental engaged time tracking

### DIFF
--- a/build-system/amp.extern.js
+++ b/build-system/amp.extern.js
@@ -295,7 +295,7 @@ amp.validator.validateUrlAndLog = function(string, doc, filter) {}
 // Temporary Access types (delete when amp-access is compiled
 // for type checking).
 Activity.prototype.getTotalEngagedTime = function() {};
-Activity.prototype.getIncrementalEngagedTime = function(name) {};
+Activity.prototype.getIncrementalEngagedTime = function(name, reset) {};
 AccessService.prototype.getAccessReaderId = function() {};
 AccessService.prototype.getAuthdataField = function(field) {};
 // Same for amp-analytics

--- a/examples/analytics-vendors.amp.html
+++ b/examples/analytics-vendors.amp.html
@@ -796,7 +796,7 @@ For complete documentation and additional examples please see: https://marketing
           "on": "visible",
           "request": "pageview"
       },
-      "heartbeat": {
+      "defaultHeartbeat": {
          "on": "timer",
          "enabled": "${incrementalEngagedTime(parsely-js,false)}",
          "timerSpec": {

--- a/examples/analytics-vendors.amp.html
+++ b/examples/analytics-vendors.amp.html
@@ -789,7 +789,22 @@ For complete documentation and additional examples please see: https://marketing
 <script type="application/json">
 {
   "vars": {
-    "apikey": "example.com"
+    "apikey": "missing.parsely.com"
+  },
+  "triggers": {
+      "defaultPageview": {
+          "on": "visible",
+          "request": "pageview"
+      },
+      "heartbeat": {
+         "on": "timer",
+         "enabled": "${incrementalEngagedTime(parsely-js,false)}",
+         "timerSpec": {
+             "interval": 5,
+             "maxTimerLength": 7200
+         },
+         "request": "heartbeat"
+      }
   }
 }
 </script>

--- a/examples/analytics-vendors.amp.html
+++ b/examples/analytics-vendors.amp.html
@@ -789,7 +789,7 @@ For complete documentation and additional examples please see: https://marketing
 <script type="application/json">
 {
   "vars": {
-    "apikey": "missing.parsely.com"
+    "apikey": "example.com"
   },
   "triggers": {
       "defaultPageview": {

--- a/extensions/amp-analytics/0.1/activity-impl.js
+++ b/extensions/amp-analytics/0.1/activity-impl.js
@@ -320,10 +320,10 @@ export class Activity {
   /**
    * Get the incremental engaged time since the last push and reset it if asked.
    * @param {string} name
-   * @param {string=} reset
+   * @param {boolean=} reset
    * @return {number}
    */
-  getIncrementalEngagedTime(name, reset = 'true') {
+  getIncrementalEngagedTime(name, reset = true) {
     if (!this.totalEngagedTimeByTrigger_.hasOwnProperty(name)) {
       this.totalEngagedTimeByTrigger_[name] =
         this.getTotalEngagedTime();
@@ -331,7 +331,7 @@ export class Activity {
     }
     const currentIncrementalEngagedTime =
       this.totalEngagedTimeByTrigger_[name];
-    if (reset == 'false') {
+    if (reset === false) {
       return this.getTotalEngagedTime() - currentIncrementalEngagedTime;
     }
     this.totalEngagedTimeByTrigger_[name] = this.getTotalEngagedTime();

--- a/extensions/amp-analytics/0.1/activity-impl.js
+++ b/extensions/amp-analytics/0.1/activity-impl.js
@@ -318,20 +318,33 @@ export class Activity {
     return this.activityHistory_.getTotalEngagedTime(secondsSinceStart);
   }
   /**
-   * Get the incremental engaged time since the last push and reset it.
+   * Get the incremental engaged time since the last push and reset it if asked.
    * @param {string} name
+   * @param {boolean} reset
    * @return {number}
    */
-  getIncrementalEngagedTime(name = '') {
+  getIncrementalEngagedTime(name='', reset='true') {
+    // if it doesn't exist set the initial value and return
     if (!this.totalEngagedTimeByTrigger_.hasOwnProperty(name)) {
       this.totalEngagedTimeByTrigger_[name] =
         this.getTotalEngagedTime();
       return this.totalEngagedTimeByTrigger_[name];
     }
+    // if it does exist get the last value
     const currentIncrementalEngagedTime =
       this.totalEngagedTimeByTrigger_[name];
+    // if we are just checking the value compute and return
+    if (reset !== 'true') {
+        let otherRetval = this.getTotalEngagedTime() - currentIncrementalEngagedTime;
+        console.log('Not resetting ' + otherRetval);
+        console.log('Not resetting total ' + this.getTotalEngagedTime());
+        return otherRetval;
+    }
     this.totalEngagedTimeByTrigger_[name] = this.getTotalEngagedTime();
-    return this.totalEngagedTimeByTrigger_[name] -
+    let retval = this.totalEngagedTimeByTrigger_[name] -
       currentIncrementalEngagedTime;
+    console.log('Resetting ' + retval);
+    console.log('Resetting total ' + this.getTotalEngagedTime());
+    return retval;
   }
 }

--- a/extensions/amp-analytics/0.1/activity-impl.js
+++ b/extensions/amp-analytics/0.1/activity-impl.js
@@ -324,27 +324,18 @@ export class Activity {
    * @return {number}
    */
   getIncrementalEngagedTime(name='', reset='true') {
-    // if it doesn't exist set the initial value and return
     if (!this.totalEngagedTimeByTrigger_.hasOwnProperty(name)) {
       this.totalEngagedTimeByTrigger_[name] =
         this.getTotalEngagedTime();
       return this.totalEngagedTimeByTrigger_[name];
     }
-    // if it does exist get the last value
     const currentIncrementalEngagedTime =
       this.totalEngagedTimeByTrigger_[name];
-    // if we are just checking the value compute and return
     if (reset !== 'true') {
-        let otherRetval = this.getTotalEngagedTime() - currentIncrementalEngagedTime;
-        console.log('Not resetting ' + otherRetval);
-        console.log('Not resetting total ' + this.getTotalEngagedTime());
-        return otherRetval;
+        return this.getTotalEngagedTime() - currentIncrementalEngagedTime;
     }
     this.totalEngagedTimeByTrigger_[name] = this.getTotalEngagedTime();
-    let retval = this.totalEngagedTimeByTrigger_[name] -
+    return this.totalEngagedTimeByTrigger_[name] -
       currentIncrementalEngagedTime;
-    console.log('Resetting ' + retval);
-    console.log('Resetting total ' + this.getTotalEngagedTime());
-    return retval;
   }
 }

--- a/extensions/amp-analytics/0.1/activity-impl.js
+++ b/extensions/amp-analytics/0.1/activity-impl.js
@@ -320,10 +320,10 @@ export class Activity {
   /**
    * Get the incremental engaged time since the last push and reset it if asked.
    * @param {string} name
-   * @param {string} reset
+   * @param {string=} reset
    * @return {number}
    */
-  getIncrementalEngagedTime(name = '', reset = 'true') {
+  getIncrementalEngagedTime(name, reset = 'true') {
     if (!this.totalEngagedTimeByTrigger_.hasOwnProperty(name)) {
       this.totalEngagedTimeByTrigger_[name] =
         this.getTotalEngagedTime();
@@ -331,7 +331,7 @@ export class Activity {
     }
     const currentIncrementalEngagedTime =
       this.totalEngagedTimeByTrigger_[name];
-    if (reset !== 'true') {
+    if (reset == 'false') {
       return this.getTotalEngagedTime() - currentIncrementalEngagedTime;
     }
     this.totalEngagedTimeByTrigger_[name] = this.getTotalEngagedTime();

--- a/extensions/amp-analytics/0.1/activity-impl.js
+++ b/extensions/amp-analytics/0.1/activity-impl.js
@@ -323,7 +323,7 @@ export class Activity {
    * @param {boolean} reset
    * @return {number}
    */
-  getIncrementalEngagedTime(name='', reset='true') {
+  getIncrementalEngagedTime(name = '', reset = 'true') {
     if (!this.totalEngagedTimeByTrigger_.hasOwnProperty(name)) {
       this.totalEngagedTimeByTrigger_[name] =
         this.getTotalEngagedTime();
@@ -332,7 +332,7 @@ export class Activity {
     const currentIncrementalEngagedTime =
       this.totalEngagedTimeByTrigger_[name];
     if (reset !== 'true') {
-        return this.getTotalEngagedTime() - currentIncrementalEngagedTime;
+      return this.getTotalEngagedTime() - currentIncrementalEngagedTime;
     }
     this.totalEngagedTimeByTrigger_[name] = this.getTotalEngagedTime();
     return this.totalEngagedTimeByTrigger_[name] -

--- a/extensions/amp-analytics/0.1/activity-impl.js
+++ b/extensions/amp-analytics/0.1/activity-impl.js
@@ -320,7 +320,7 @@ export class Activity {
   /**
    * Get the incremental engaged time since the last push and reset it if asked.
    * @param {string} name
-   * @param {boolean} reset
+   * @param {string} reset
    * @return {number}
    */
   getIncrementalEngagedTime(name = '', reset = 'true') {

--- a/extensions/amp-analytics/0.1/vendors.js
+++ b/extensions/amp-analytics/0.1/vendors.js
@@ -1434,6 +1434,15 @@ export const ANALYTICS_CONFIG = /** @type {!JsonObject} */ ({
         'on': 'visible',
         'request': 'pageview',
       },
+      'defaultHeartbeat': {
+        'on': 'timer',
+        'enabled': '${incrementalEngagedTime(parsely-js,false)}',
+        'timerSpec': {
+          'interval': 5,
+          'maxTimerLength': 7200,
+        },
+        'request': 'heartbeat',
+      },
     },
     'transport': {
       'beacon': false,

--- a/extensions/amp-analytics/0.1/vendors.js
+++ b/extensions/amp-analytics/0.1/vendors.js
@@ -1434,6 +1434,15 @@ export const ANALYTICS_CONFIG = /** @type {!JsonObject} */ ({
         'on': 'visible',
         'request': 'pageview',
       },
+      "defaultHeartbeat": {
+         "on": "timer",
+         "enabled": "${incrementalEngagedTime(parsely-js,false)}",
+         "timerSpec": {
+             "interval": 5,
+             "maxTimerLength": 7200
+         },
+         "request": "heartbeat"
+      }
     },
     'transport': {
       'beacon': false,

--- a/extensions/amp-analytics/0.1/vendors.js
+++ b/extensions/amp-analytics/0.1/vendors.js
@@ -1427,7 +1427,7 @@ export const ANALYTICS_CONFIG = /** @type {!JsonObject} */ ({
         'ampid=${clientId(_parsely_visitor)}',
       'pageview': '${basePrefix}&action=pageview',
       'heartbeat': '${basePrefix}&action=heartbeat' +
-      '&tt=${totalEngagedTime}&inc=${incrementalEngagedTime(parsely-js)}',
+      '&tt=${totalEngagedTime}&inc=${incrementalEngagedTime(parsely-js,true)}',
     },
     'triggers': {
       'defaultPageview': {

--- a/extensions/amp-analytics/0.1/vendors.js
+++ b/extensions/amp-analytics/0.1/vendors.js
@@ -1434,15 +1434,6 @@ export const ANALYTICS_CONFIG = /** @type {!JsonObject} */ ({
         'on': 'visible',
         'request': 'pageview',
       },
-      'defaultHeartbeat': {
-        'on': 'timer',
-        'enabled': '${incrementalEngagedTime(parsely-js,false)}',
-        'timerSpec': {
-          'interval': 5,
-          'maxTimerLength': 7200,
-        },
-        'request': 'heartbeat',
-      },
     },
     'transport': {
       'beacon': false,

--- a/extensions/amp-analytics/0.1/vendors.js
+++ b/extensions/amp-analytics/0.1/vendors.js
@@ -1427,7 +1427,7 @@ export const ANALYTICS_CONFIG = /** @type {!JsonObject} */ ({
         'ampid=${clientId(_parsely_visitor)}',
       'pageview': '${basePrefix}&action=pageview',
       'heartbeat': '${basePrefix}&action=heartbeat' +
-      '&tt=${totalEngagedTime}&inc=${incrementalEngagedTime(parsely-js,true)}',
+      '&tt=${totalEngagedTime}&inc=${incrementalEngagedTime(parsely-js)}',
     },
     'triggers': {
       'defaultPageview': {

--- a/extensions/amp-analytics/0.1/vendors.js
+++ b/extensions/amp-analytics/0.1/vendors.js
@@ -1434,15 +1434,15 @@ export const ANALYTICS_CONFIG = /** @type {!JsonObject} */ ({
         'on': 'visible',
         'request': 'pageview',
       },
-      "defaultHeartbeat": {
-         "on": "timer",
-         "enabled": "${incrementalEngagedTime(parsely-js,false)}",
-         "timerSpec": {
-             "interval": 5,
-             "maxTimerLength": 7200
-         },
-         "request": "heartbeat"
-      }
+      'defaultHeartbeat': {
+        'on': 'timer',
+        'enabled': '${incrementalEngagedTime(parsely-js,false)}',
+        'timerSpec': {
+          'interval': 5,
+          'maxTimerLength': 7200,
+        },
+        'request': 'heartbeat',
+      },
     },
     'transport': {
       'beacon': false,

--- a/spec/amp-var-substitutions.md
+++ b/spec/amp-var-substitutions.md
@@ -205,6 +205,7 @@ The tables below list the available URL variables grouped by type of usage. Furt
 |----------------|--------------------|------------------------|
 | [Horizontal Scroll Boundary](#horizontal-scroll-boundary) | N/A | `${horizontalScrollBoundary}` |
 | [Total Engaged Time](#total-engaged-time) | `TOTAL_ENGAGED_TIME` | `${totalEngagedTime}` |
+| [Incremental Engaged Time](#incremental-engaged-time) | `INCREMENTAL_ENGAGED_TIME` | `${incrementalEngagedTime(foo)}` |
 | [Vertical Scroll Boundary](#vertical-scroll-boundary) | N/A | `${verticalScrollBoundary}` |
 
 ### Visibility
@@ -1083,6 +1084,14 @@ Provides the total time (in seconds) the user has been engaged with the page sin
 
 * **platform variable**: `TOTAL_ENGAGED_TIME`
 * **amp-analytics variable**: `${totalEngagedTime}`
+  * Example value: `36`
+
+#### Incremental Engaged Time
+
+Provides the time (in seconds) the user has been engaged with the page since the the last time the named timer (foo in the example below) was polled. If the timer name is not specified it will default to ''. Incremental engaged time will be 0 until the page first becomes visible. This variable requires the [amp-analytics](../extensions/amp-analytics/amp-analytics.md) extension to be present on the page.
+
+* **platform variable**: `INCREMENTAL_ENGAGED_TIME`
+* **amp-analytics variable**: `${incrementalEngagedTime(foo)}`
   * Example value: `36`
 
 #### Total Time

--- a/spec/amp-var-substitutions.md
+++ b/spec/amp-var-substitutions.md
@@ -205,7 +205,7 @@ The tables below list the available URL variables grouped by type of usage. Furt
 |----------------|--------------------|------------------------|
 | [Horizontal Scroll Boundary](#horizontal-scroll-boundary) | N/A | `${horizontalScrollBoundary}` |
 | [Total Engaged Time](#total-engaged-time) | `TOTAL_ENGAGED_TIME` | `${totalEngagedTime}` |
-| [Incremental Engaged Time](#incremental-engaged-time) | `INCREMENTAL_ENGAGED_TIME` | `${incrementalEngagedTime(foo)}` |
+| [Incremental Engaged Time](#incremental-engaged-time) | `INCREMENTAL_ENGAGED_TIME` | `${incrementalEngagedTime}` |
 | [Vertical Scroll Boundary](#vertical-scroll-boundary) | N/A | `${verticalScrollBoundary}` |
 
 ### Visibility
@@ -639,7 +639,7 @@ Provides the horizontal scroll boundary that triggered a scroll event. This vari
 
 #### HTML Attributes
 
-Provides values of attributes of HTML elements inside of an amp-ad tag which match a given CSS selector. 
+Provides values of attributes of HTML elements inside of an amp-ad tag which match a given CSS selector.
 This only allows an amp-analytics tag to query attributes of HTML elements loaded by that amp-analytics tag's parent
 amp-ad tag. It will not allow a publisher to obtain information about the content of an ad, nor will it allow metrics
 of one ad to be seen by the provider of another ad on the page.
@@ -656,14 +656,14 @@ Example:
 This will return the "src" and "decoding" attributes of img tags in the ad.
 
 Caveats:
-* If the CSS selector matches 20 or more elements, an empty array will be returned. This is because traversing a 
-large list of elements is inefficient. 
+* If the CSS selector matches 20 or more elements, an empty array will be returned. This is because traversing a
+large list of elements is inefficient.
 * Attributes of at most 10 elements will be returned.
-* If an element matches the CSS selector but has none of the requested attributes, that element will not be 
+* If an element matches the CSS selector but has none of the requested attributes, that element will not be
 represented in the returned array.
-* The returned values will be in the form of a URL encoded JSON array of objects wherein the object keys are the 
+* The returned values will be in the form of a URL encoded JSON array of objects wherein the object keys are the
 requested attribute names and the object values are the elements' values for those attributes.
-* The CSS selector may contain only letters (upper- and/or lower-case), numbers, hyphens, underscores, and periods. 
+* The CSS selector may contain only letters (upper- and/or lower-case), numbers, hyphens, underscores, and periods.
 [Issue #14252](https://github.com/ampproject/amphtml/issues/14252) has been created to address potential future demand for more complex CSS selectors.
 
 
@@ -1077,7 +1077,7 @@ Provides the user's IANA time-zone code (if available).
   ```
 * **amp-analytics variable**: `${timezoneCode}`
   * Example value: `Europe/Rome`.
- 
+
 #### Total Engaged Time
 
 Provides the total time (in seconds) the user has been engaged with the page since the page first became visible in the viewport. Total engaged time will be 0 until the page first becomes visible. This variable requires the [amp-analytics](../extensions/amp-analytics/amp-analytics.md) extension to be present on the page.
@@ -1088,10 +1088,10 @@ Provides the total time (in seconds) the user has been engaged with the page sin
 
 #### Incremental Engaged Time
 
-Provides the time (in seconds) the user has been engaged with the page since the the last time the named timer (foo in the example below) was polled. If the timer name is not specified it will default to ''. Incremental engaged time will be 0 until the page first becomes visible. This variable requires the [amp-analytics](../extensions/amp-analytics/amp-analytics.md) extension to be present on the page.
+Provides the time (in seconds) the user has been engaged with the page since the last time it was reset. It takes two optional arguments. The first is the name of the timer (defaults to ''), the second is whether or not to reset it (defaults to true). Incremental engaged time will be 0 until the page first becomes visible. This variable requires the [amp-analytics](../extensions/amp-analytics/amp-analytics.md) extension to be present on the page.
 
 * **platform variable**: `INCREMENTAL_ENGAGED_TIME`
-* **amp-analytics variable**: `${incrementalEngagedTime(foo)}`
+* **amp-analytics variable**: `${incrementalEngagedTime(foo,true)}`
   * Example value: `36`
 
 #### Total Time

--- a/spec/amp-var-substitutions.md
+++ b/spec/amp-var-substitutions.md
@@ -1088,7 +1088,7 @@ Provides the total time (in seconds) the user has been engaged with the page sin
 
 #### Incremental Engaged Time
 
-Provides the time (in seconds) the user has been engaged with the page since the last time it was reset. It takes two arguments. The first is the name of the timer, the second is whether or not to reset it (defaults to true). Incremental engaged time will be 0 until the page first becomes visible. This variable requires the [amp-analytics](../extensions/amp-analytics/amp-analytics.md) extension to be present on the page.
+Provides the time (in seconds) the user has been engaged with the page since the last time it was reset. It takes two arguments. The first is the name of the timer, the second is whether or not to reset it (it is optional and defaults to true). Incremental engaged time will be 0 until the page first becomes visible. This variable requires the [amp-analytics](../extensions/amp-analytics/amp-analytics.md) extension to be present on the page.
 
 * **platform variable**: `INCREMENTAL_ENGAGED_TIME`
 * **amp-analytics variable**: `${incrementalEngagedTime(foo,false)}`

--- a/spec/amp-var-substitutions.md
+++ b/spec/amp-var-substitutions.md
@@ -1088,10 +1088,10 @@ Provides the total time (in seconds) the user has been engaged with the page sin
 
 #### Incremental Engaged Time
 
-Provides the time (in seconds) the user has been engaged with the page since the last time it was reset. It takes two optional arguments. The first is the name of the timer (defaults to ''), the second is whether or not to reset it (defaults to true). Incremental engaged time will be 0 until the page first becomes visible. This variable requires the [amp-analytics](../extensions/amp-analytics/amp-analytics.md) extension to be present on the page.
+Provides the time (in seconds) the user has been engaged with the page since the last time it was reset. It takes two arguments. The first is the name of the timer, the second is whether or not to reset it (defaults to true). Incremental engaged time will be 0 until the page first becomes visible. This variable requires the [amp-analytics](../extensions/amp-analytics/amp-analytics.md) extension to be present on the page.
 
 * **platform variable**: `INCREMENTAL_ENGAGED_TIME`
-* **amp-analytics variable**: `${incrementalEngagedTime(foo,true)}`
+* **amp-analytics variable**: `${incrementalEngagedTime(foo,false)}`
   * Example value: `36`
 
 #### Total Time

--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -510,9 +510,9 @@ export class GlobalVariableSource extends VariableSource {
 
     // Returns the incremental engaged time since the last push under the
     // same name.
-    this.setAsync('INCREMENTAL_ENGAGED_TIME', name => {
+    this.setAsync('INCREMENTAL_ENGAGED_TIME', (name, reset) => {
       return Services.activityForDoc(this.ampdoc).then(activity => {
-        return activity.getIncrementalEngagedTime(name);
+        return activity.getIncrementalEngagedTime(name, reset);
       });
     });
 

--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -512,12 +512,7 @@ export class GlobalVariableSource extends VariableSource {
     // same name.
     this.setAsync('INCREMENTAL_ENGAGED_TIME', (name, reset) => {
       return Services.activityForDoc(this.ampdoc).then(activity => {
-        if (reset === 'false') {
-          reset = false;
-        } else {
-          reset = true;
-        }
-        return activity.getIncrementalEngagedTime(name, reset);
+        return activity.getIncrementalEngagedTime(name, reset !== 'false');
       });
     });
 

--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -512,6 +512,11 @@ export class GlobalVariableSource extends VariableSource {
     // same name.
     this.setAsync('INCREMENTAL_ENGAGED_TIME', (name, reset) => {
       return Services.activityForDoc(this.ampdoc).then(activity => {
+        if (reset === 'false') {
+            reset = false;
+        } else {
+            reset = true;
+        }
         return activity.getIncrementalEngagedTime(name, reset);
       });
     });

--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -513,9 +513,9 @@ export class GlobalVariableSource extends VariableSource {
     this.setAsync('INCREMENTAL_ENGAGED_TIME', (name, reset) => {
       return Services.activityForDoc(this.ampdoc).then(activity => {
         if (reset === 'false') {
-            reset = false;
+          reset = false;
         } else {
-            reset = true;
+          reset = true;
         }
         return activity.getIncrementalEngagedTime(name, reset);
       });

--- a/test/functional/test-activity.js
+++ b/test/functional/test-activity.js
@@ -379,6 +379,33 @@ describe('Activity getIncrementalEngagedTime', () => {
     });
   });
 
+  it('should not reset incremental engaged time after each poll if reset is specified as false', () => {
+    whenFirstVisibleResolve();
+    return viewer.whenFirstVisible().then(() => {
+      // don't reset
+      const first = activity.getIncrementalEngagedTime('tests', 'false');
+      expect(first).to.equal(0);
+      mousedownObservable.fire();
+      clock.tick(10000);
+      // more engaged time, don't reset
+      const second = activity.getIncrementalEngagedTime('tests', 'false');
+      expect(second).to.equal(5);
+      mousedownObservable.fire();
+      clock.tick(10000);
+      // more engaged time, don't reset
+      const third = activity.getIncrementalEngagedTime('tests', 'false');
+      expect(third).to.equal(10);
+      // more engaged time, reset
+      const fourth = activity.getIncrementalEngagedTime('tests', 'true');
+      expect(fourth).to.equal(10);
+      mousedownObservable.fire();
+      clock.tick(10000);
+      // more engaged time, don't reset
+      const fifth = activity.getIncrementalEngagedTime('tests', 'false');
+      return expect(fifth).to.equal(5);
+    });
+  });
+
   it('should keep individual incremental engaged times per name', () => {
     whenFirstVisibleResolve();
     return viewer.whenFirstVisible().then(() => {

--- a/test/functional/test-activity.js
+++ b/test/functional/test-activity.js
@@ -379,7 +379,7 @@ describe('Activity getIncrementalEngagedTime', () => {
     });
   });
 
-  it('should not reset incremental engaged time after each poll if reset is specified as false', () => {
+  it('should not reset incremental engaged time if reset is false', () => {
     whenFirstVisibleResolve();
     return viewer.whenFirstVisible().then(() => {
       // don't reset

--- a/test/functional/test-activity.js
+++ b/test/functional/test-activity.js
@@ -402,7 +402,13 @@ describe('Activity getIncrementalEngagedTime', () => {
       clock.tick(10000);
       // more engaged time, don't reset
       const fifth = activity.getIncrementalEngagedTime('tests', 'false');
-      return expect(fifth).to.equal(5);
+      expect(fifth).to.equal(5);
+      // reset with default value
+      const sixth = activity.getIncrementalEngagedTime('tests');
+      expect(sixth).to.equal(5);
+      // should be reset
+      const seventh = activity.getIncrementalEngagedTime('tests', 'false');
+      return expect(seventh).to.equal(0);
     });
   });
 

--- a/test/functional/test-activity.js
+++ b/test/functional/test-activity.js
@@ -383,31 +383,31 @@ describe('Activity getIncrementalEngagedTime', () => {
     whenFirstVisibleResolve();
     return viewer.whenFirstVisible().then(() => {
       // don't reset
-      const first = activity.getIncrementalEngagedTime('tests', 'false');
+      const first = activity.getIncrementalEngagedTime('tests', false);
       expect(first).to.equal(0);
       mousedownObservable.fire();
       clock.tick(10000);
       // more engaged time, don't reset
-      const second = activity.getIncrementalEngagedTime('tests', 'false');
+      const second = activity.getIncrementalEngagedTime('tests', false);
       expect(second).to.equal(5);
       mousedownObservable.fire();
       clock.tick(10000);
       // more engaged time, don't reset
-      const third = activity.getIncrementalEngagedTime('tests', 'false');
+      const third = activity.getIncrementalEngagedTime('tests', false);
       expect(third).to.equal(10);
       // more engaged time, reset
-      const fourth = activity.getIncrementalEngagedTime('tests', 'true');
+      const fourth = activity.getIncrementalEngagedTime('tests', true);
       expect(fourth).to.equal(10);
       mousedownObservable.fire();
       clock.tick(10000);
       // more engaged time, don't reset
-      const fifth = activity.getIncrementalEngagedTime('tests', 'false');
+      const fifth = activity.getIncrementalEngagedTime('tests', false);
       expect(fifth).to.equal(5);
       // reset with default value
       const sixth = activity.getIncrementalEngagedTime('tests');
       expect(sixth).to.equal(5);
       // should be reset
-      const seventh = activity.getIncrementalEngagedTime('tests', 'false');
+      const seventh = activity.getIncrementalEngagedTime('tests', false);
       return expect(seventh).to.equal(0);
     });
   });


### PR DESCRIPTION
This PR uses the 'enabled' feature for triggers to eliminate incremental engaged time heartbeats where the incremental engaged time is 0. 

- Adds a second parameter to getIncrementalEngagedTime, `reset`, which defaults to true. This parameter allows calculating incremental engaged time without resetting the counter.
- Adds an enabled check to the heartbeat trigger of the Parsely test page 
    - Do not reset the counter in the enabled check
    - Do reset the counter in the actual heartbeat URL.

Resolves #13354 