### PR TITLE
:fire: Switch to correct parameter name for detecting CCT

### DIFF
--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -279,7 +279,7 @@ export class Viewer {
      * @private @const {boolean}
      */
     this.isCctEmbedded_ = !this.isIframed_ &&
-        parseQueryString(this.win.location.search)['amp_agsa'] === '1';
+        parseQueryString(this.win.location.search)['amp_gsa'] === '1';
 
     const url = parseUrl(this.ampdoc.win.location.href);
     /**

--- a/test/functional/test-viewer.js
+++ b/test/functional/test-viewer.js
@@ -161,7 +161,7 @@ describe('Viewer', () => {
     windowApi.parent = windowApi;
     windowApi.location.href = 'http://www.example.com/';
     windowApi.location.hash = '#origin=g.com';
-    windowApi.location.search = '?amp_agsa=1';
+    windowApi.location.search = '?amp_gsa=1';
     const viewer = new Viewer(ampdoc);
     expect(viewer.isCctEmbedded()).to.be.true;
     expect(windowApi.history.replaceState).to.be.calledWith({}, '',
@@ -172,7 +172,7 @@ describe('Viewer', () => {
     windowApi.parent = windowApi;
     windowApi.location.href = 'http://www.example.com/#test=1';
     windowApi.location.hash = '#origin=g.com&test=1';
-    windowApi.location.search = '?amp_agsa=1';
+    windowApi.location.search = '?amp_gsa=1';
     const viewer = new Viewer(ampdoc);
     expect(viewer.getParam('test')).to.equal('1');
     expect(viewer.isCctEmbedded()).to.be.true;
@@ -195,7 +195,7 @@ describe('Viewer', () => {
     windowApi.parent = windowApi;
     windowApi.location.href = 'http://www.example.com#click=abc';
     windowApi.location.hash = '#click=abc';
-    windowApi.location.search = '?amp_agsa=1';
+    windowApi.location.search = '?amp_gsa=1';
     const viewer = new Viewer(ampdoc);
     expect(windowApi.history.replaceState).to.be.calledWith({}, '',
         'http://www.example.com');


### PR DESCRIPTION
Unfortunately, an incorrect parameter name is being checked to determine whether code is running within CCT.

This updates the parameter's name.