### PR TITLE
🐛 Flush stdout before exiting process after running tests

### DIFF
--- a/build-system/tasks/runtime-test.js
+++ b/build-system/tasks/runtime-test.js
@@ -239,6 +239,8 @@ function runTests() {
     log(red('ERROR:'), 'Only integration tests may be run on the full set of ' +
         'Sauce Labs browsers');
     log('Use', cyan('--saucelabs'), 'with', cyan('--integration'));
+    // Flush stdout.
+    process.stdout.write('\n');
     process.exit();
   }
 
@@ -346,6 +348,8 @@ function runTests() {
             log(yellow(
                 'Shutting down test responses server on localhost:31862'));
             process.nextTick(function() {
+              // Flush stdout.
+              process.stdout.write('\n');
               process.exit();
             });
           }));
@@ -376,6 +380,8 @@ function runTests() {
       log(
           red('ERROR:'),
           yellow('Karma test failed with exit code ' + exitCode));
+      // Flush stdout.
+      process.stdout.write('\n');
       process.exit(exitCode);
     } else {
       resolver();


### PR DESCRIPTION
When we exit Karma after running tests, it sometimes prematurely exits while its reporters are busy writing to the console. This also breaks Travis log folding, and makes the logs difficult to read. For example, see https://travis-ci.org/ampproject/amphtml/jobs/367291014#L1391-L1397

Unfortunately, this is due to the asynchronous nature of stdout in nodejs. See https://github.com/nodejs/node/issues/6456, https://github.com/nodejs/node/issues/6379, https://github.com/yarnpkg/yarn/issues/5005, etc.

This PR inserts `process.stdout.write('\n')` before each call to `process.exit`, since that will cause the output to get flushed.