### PR TITLE
🐛 Add last check time stamp to the polling url to bypass caching

### DIFF
--- a/extensions/amp-live-list/0.1/live-list-manager.js
+++ b/extensions/amp-live-list/0.1/live-list-manager.js
@@ -134,6 +134,8 @@ export class LiveListManager {
       url = addParamToUrl(url, 'amp_latest_update_time',
           String(this.latestUpdateTime_));
     }
+    // This is important for cache busting as some environments force a
+    // cache-control: max-age header.
     if (this.lastCheckTime_ > 0) {
       url = addParamToUrl(url, 'amp_last_check_time',
           String(this.lastCheckTime_));

--- a/extensions/amp-live-list/0.1/live-list-manager.js
+++ b/extensions/amp-live-list/0.1/live-list-manager.js
@@ -68,7 +68,7 @@ export class LiveListManager {
     this.latestUpdateTime_ = 0;
 
     /** @private {time} */
-    this.LastCheckTime_ = 0;
+    this.lastCheckTime_ = 0;
 
     /** @private @const {function(): Promise} */
     this.work_ = this.fetchDocument_.bind(this);
@@ -83,7 +83,7 @@ export class LiveListManager {
           .map(key => this.liveLists_[key].getUpdateTime());
       this.latestUpdateTime_ = Math.max.apply(Math, initialUpdateTimes);
 
-      this.LastCheckTime_ = Number(new Date());
+      this.lastCheckTime_ = Number(new Date());
       // For testing purposes only, we speed up the interval of the update.
       // This should NEVER be allowed in production.
       if (getMode().localDev) {
@@ -134,9 +134,9 @@ export class LiveListManager {
       url = addParamToUrl(url, 'amp_latest_update_time',
           String(this.latestUpdateTime_));
     }
-    if (this.LastCheckTime_ > 0) {
+    if (this.lastCheckTime_ > 0) {
       url = addParamToUrl(url, 'amp_last_check_time',
-          String(this.LastCheckTime_));
+          String(this.lastCheckTime_));
     }
     return Services.xhrFor(this.ampdoc.win)
         // TODO(erwinm): add update time here when possible.
@@ -159,7 +159,7 @@ export class LiveListManager {
     if (latestUpdateTime > 0) {
       this.latestUpdateTime_ = latestUpdateTime;
     }
-    this.LastCheckTime_ = Number(new Date());
+    this.lastCheckTime_ = Number(new Date());
     // We need to do this after calling `updateLiveList` since that
     // would apply the disabled attribute if any exist from the server.
     if (!this.hasActiveLiveLists_()) {

--- a/extensions/amp-live-list/0.1/live-list-manager.js
+++ b/extensions/amp-live-list/0.1/live-list-manager.js
@@ -67,6 +67,9 @@ export class LiveListManager {
     /** @private {time} */
     this.latestUpdateTime_ = 0;
 
+    /** @private {time} */
+    this.LastCheckTime_ = 0;
+
     /** @private @const {function(): Promise} */
     this.work_ = this.fetchDocument_.bind(this);
 
@@ -80,6 +83,7 @@ export class LiveListManager {
           .map(key => this.liveLists_[key].getUpdateTime());
       this.latestUpdateTime_ = Math.max.apply(Math, initialUpdateTimes);
 
+      this.LastCheckTime_ = Number(new Date());
       // For testing purposes only, we speed up the interval of the update.
       // This should NEVER be allowed in production.
       if (getMode().localDev) {
@@ -130,6 +134,10 @@ export class LiveListManager {
       url = addParamToUrl(url, 'amp_latest_update_time',
           String(this.latestUpdateTime_));
     }
+    if (this.LastCheckTime_ > 0) {
+      url = addParamToUrl(url, 'amp_last_check_time',
+          String(this.LastCheckTime_));
+    }
     return Services.xhrFor(this.ampdoc.win)
         // TODO(erwinm): add update time here when possible.
         .fetchDocument(url, {
@@ -151,6 +159,7 @@ export class LiveListManager {
     if (latestUpdateTime > 0) {
       this.latestUpdateTime_ = latestUpdateTime;
     }
+    this.LastCheckTime_ = Number(new Date());
     // We need to do this after calling `updateLiveList` since that
     // would apply the disabled attribute if any exist from the server.
     if (!this.hasActiveLiveLists_()) {


### PR DESCRIPTION
Adds `amp_last_check_time` query var with the timestamp of the last successful poll.
This is to bypass server side caching in some environments that can result in the `live_list` never updating after the first poll.

Fixes #14278 
