### PR TITLE
🐛 Don't call process.exit() in Karma during normal pass / fail flow

### DIFF
--- a/build-system/tasks/runtime-test.js
+++ b/build-system/tasks/runtime-test.js
@@ -239,8 +239,6 @@ function runTests() {
     log(red('ERROR:'), 'Only integration tests may be run on the full set of ' +
         'Sauce Labs browsers');
     log('Use', cyan('--saucelabs'), 'with', cyan('--integration'));
-    // Flush stdout.
-    process.stdout.write('\n');
     process.exit();
   }
 
@@ -337,22 +335,14 @@ function runTests() {
   }
 
   // Run fake-server to test XHR responses.
-  const server = gulp.src(process.cwd())
-      .pipe(webserver({
-        port: 31862,
-        host: 'localhost',
-        directoryListing: true,
-        middleware: [app],
-      })
-          .on('kill', function() {
-            log(yellow(
-                'Shutting down test responses server on localhost:31862'));
-            process.nextTick(function() {
-              // Flush stdout.
-              process.stdout.write('\n');
-              process.exit();
-            });
-          }));
+  const server = gulp.src(process.cwd()).pipe(webserver({
+    port: 31862,
+    host: 'localhost',
+    directoryListing: true,
+    middleware: [app],
+  }).on('kill', function() {
+    log(yellow('Shutting down test responses server on localhost:31862'));
+  }));
   log(yellow(
       'Started test responses server on localhost:31862'));
 
@@ -380,12 +370,8 @@ function runTests() {
       log(
           red('ERROR:'),
           yellow('Karma test failed with exit code ' + exitCode));
-      // Flush stdout.
-      process.stdout.write('\n');
-      process.exit(exitCode);
-    } else {
-      resolver();
     }
+    resolver();
   }).on('run_start', function() {
     if (argv.saucelabs || argv.saucelabs_lite) {
       console./* OK*/log(green(


### PR DESCRIPTION

When we exit Karma after running tests, it sometimes prematurely exits while its reporters are busy writing to the console. This also breaks Travis log folding, and makes the logs difficult to read. For example, see https://travis-ci.org/ampproject/amphtml/jobs/367291014#L1391-L1397

Unfortunately, this is due to the asynchronous nature of stdout in nodejs. See nodejs/node#6456, nodejs/node#6379, yarnpkg/yarn#5005, etc.

In #14653, we tried to flush stdout before exiting. It turns out that `process.exit()` is the wrong way to exit from a Karma process after tests have run. This PR removes calls to `process.exit()` from all normal exit flows, and instead, allows the resolver to do its thing.

Follow up to #14653