### PR TITLE
Allow autofocus to work inside `<amp-lightbox>` on iOS

### DIFF
--- a/extensions/amp-lightbox/0.1/amp-lightbox.js
+++ b/extensions/amp-lightbox/0.1/amp-lightbox.js
@@ -210,19 +210,21 @@ class AmpLightbox extends AMP.BaseElement {
       st.setStyle(this.element, 'webkitOverflowScrolling', 'touch');
     }
 
-    // This should be in a mutateElement block, but iOS focus doesn't work
-    // if triggered asynchronously.
+    // This should be in a mutateElement block, but focus on iOS won't work
+    // if triggered asynchronously inside a callback.
     st.setStyles(this.element, {
       display: '',
       opacity: 0,
       // TODO(dvoytenko): use new animations support instead.
       transition: 'opacity 0.1s ease-in',
     });
-    Services.vsyncFor(this.win).mutate(() => {
-      st.setStyle(this.element, 'opacity', '');
-    });
 
     this.handleAutofocus_();
+
+    // TODO (jridgewell): expose an API accomodating this per PR #14676
+    this.mutateElement(() => {
+      st.setStyle(this.element, 'opacity', '');
+    });
 
     const container = dev().assertElement(this.container_);
     if (!this.isScrollable_) {

--- a/extensions/amp-lightbox/0.1/amp-lightbox.js
+++ b/extensions/amp-lightbox/0.1/amp-lightbox.js
@@ -29,6 +29,7 @@ import {debounce} from '../../../src/utils/rate-limit';
 import {dev, user} from '../../../src/log';
 import {getMode} from '../../../src/mode';
 import {toArray} from '../../../src/types';
+import {tryFocus} from '../../../src/dom';
 
 /** @const {string} */
 const TAG = 'amp-lightbox';
@@ -189,36 +190,54 @@ class AmpLightbox extends AMP.BaseElement {
         .then(() => this.finalizeOpen_());
   }
 
+  /**
+   * Any child of the lightbox with the autofocus attribute should be focused
+   * after the lightbox opens.
+   * @private
+   */
+  handleAutofocus_() {
+    const autofocusElement = this.container_.querySelector('[autofocus]');
+    if (autofocusElement) {
+      tryFocus(autofocusElement);
+    }
+  }
+
+  /**
+   * @private
+   */
   finalizeOpen_() {
     if (this.isScrollable_) {
       st.setStyle(this.element, 'webkitOverflowScrolling', 'touch');
     }
-    this.mutateElement(() => {
-      st.setStyles(this.element, {
-        display: '',
-        opacity: 0,
-        // TODO(dvoytenko): use new animations support instead.
-        transition: 'opacity 0.1s ease-in',
-      });
-      Services.vsyncFor(this.win).mutate(() => {
-        st.setStyle(this.element, 'opacity', '');
-      });
-    }).then(() => {
-      const container = dev().assertElement(this.container_);
-      if (!this.isScrollable_) {
-        this.updateInViewport(container, true);
-      } else {
-        this.scrollHandler_();
-        this.updateChildrenInViewport_(this.pos_, this.pos_);
-      }
-      // TODO: instead of laying out children all at once, layout children based
-      // on visibility.
-      this.element.addEventListener('transitionend', this.boundReschedule_);
-      this.element.addEventListener('animationend', this.boundReschedule_);
-      this.scheduleLayout(container);
-      this.scheduleResume(container);
-      this.triggerEvent_(LightboxEvents.OPEN);
+
+    // This should be in a mutateElement block, but iOS focus doesn't work
+    // if triggered asynchronously.
+    st.setStyles(this.element, {
+      display: '',
+      opacity: 0,
+      // TODO(dvoytenko): use new animations support instead.
+      transition: 'opacity 0.1s ease-in',
     });
+    Services.vsyncFor(this.win).mutate(() => {
+      st.setStyle(this.element, 'opacity', '');
+    });
+
+    this.handleAutofocus_();
+
+    const container = dev().assertElement(this.container_);
+    if (!this.isScrollable_) {
+      this.updateInViewport(container, true);
+    } else {
+      this.scrollHandler_();
+      this.updateChildrenInViewport_(this.pos_, this.pos_);
+    }
+    // TODO: instead of laying out children all at once, layout children based
+    // on visibility.
+    this.element.addEventListener('transitionend', this.boundReschedule_);
+    this.element.addEventListener('animationend', this.boundReschedule_);
+    this.scheduleLayout(container);
+    this.scheduleResume(container);
+    this.triggerEvent_(LightboxEvents.OPEN);
 
     this.getHistory_().push(this.close.bind(this)).then(historyId => {
       this.historyId_ = historyId;

--- a/test/manual/amp-lightbox-focus.amp.html
+++ b/test/manual/amp-lightbox-focus.amp.html
@@ -43,12 +43,12 @@
   </style>
 </head>
 <body>
-  <amp-lightbox id="my-lightbox" layout="nodisplay" on="lightboxOpen:input.focus">
+  <amp-lightbox id="my-lightbox" layout="nodisplay">
     <div class="lightbox" role="button" tabindex="0">
       <button id="close-button" on="tap:my-lightbox.close" role="button" tabindex="0">
         Close lightbox
       </button>
-      <input id="input" type="text">
+      <input id="input" type="text" autofocus>
       
     </div>
   </amp-lightbox>

--- a/test/manual/amp-lightbox-focus.amp.html
+++ b/test/manual/amp-lightbox-focus.amp.html
@@ -1,0 +1,60 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>amp-lightbox</title>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-lightbox" src="https://cdn.ampproject.org/v0/amp-lightbox-0.1.js"></script>
+  <link rel="canonical" href="https://ampbyexample.com/components/amp-lightbox/">
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <style amp-custom>
+    .lightbox {
+      background: rgba(0,0,0,0.8);
+      width: 100%;
+      height: 100%;
+      position: absolute;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    
+    #close-button {
+      position: fixed;
+      top: 20px;
+      left: 20px;
+    }
+
+    #button {
+      width: 180px;
+      height: 120px;
+      font-size: 24px;
+    }
+    
+    html,
+    body {
+      width: 100%;
+      height: 100vh !important;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+    }
+    
+  </style>
+</head>
+<body>
+  <amp-lightbox id="my-lightbox" layout="nodisplay" on="lightboxOpen:input.focus">
+    <div class="lightbox" role="button" tabindex="0">
+      <button id="close-button" on="tap:my-lightbox.close" role="button" tabindex="0">
+        Close lightbox
+      </button>
+      <input id="input" type="text">
+      
+    </div>
+  </amp-lightbox>
+    <button id="button" on="tap:my-lightbox" role="button" tabindex="0">
+      Open lightbox
+    </button>
+
+</body>
+</html>


### PR DESCRIPTION
Addresses https://github.com/ampproject/amphtml/issues/13332. 
1. iOS requires focus to be inside a click handler in order to trigger focus and pop up the keyboard. 
2. The focus cannot be in an async callback. 
3. The lightbox needs to be visible (aka not display none) in order for input to be focusable. 

Hence, proposing this fix for lack of a better solution (suggestions more than welcome). The downside is that it removes the `mutateElement` block surrounding the set `display` to `''`. 

iOS Safari working demo: https://amp-cathyxz.herokuapp.com/test/manual/amp-lightbox-focus.amp.html