### PR TITLE
♻️ Use aria roles instead of custom list for amp-story clicks exempted from navigation

### DIFF
--- a/build-system/dep-check-config.js
+++ b/build-system/dep-check-config.js
@@ -245,6 +245,8 @@ exports.rules = [
           'src/service/video-manager-impl.js',
       'extensions/amp-story/1.0/amp-story-page.js->' +
           'src/service/video-manager-impl.js',
+      'extensions/amp-story/1.0/page-advancement.js->' +
+          'src/service/action-impl.js',
     ],
   },
   {

--- a/extensions/amp-story/1.0/amp-story-cta-layer.js
+++ b/extensions/amp-story/1.0/amp-story-cta-layer.js
@@ -60,13 +60,19 @@ export class AmpStoryCtaLayer extends AmpStoryBaseLayer {
   }
 
   /**
-   * Overwrite or set target attribute to _blank in call-to-action links.
+   * Overwrite or set target attributes that are cta-layer-specific.
    * @private
    */
-  setOrOverwriteTargetAttribute_() {
+  setOrOverwriteAttributes_() {
     const ctaLinks = this.element.querySelectorAll('a');
     for (let i = 0; i < ctaLinks.length; i++) {
       ctaLinks[i].setAttribute('target', '_blank');
+      ctaLinks[i].setAttribute('role', 'link');
+    }
+
+    const ctaButtons = this.element.querySelectorAll('button');
+    for (let i = 0; i < ctaButtons.length; i++) {
+      ctaButtons[i].setAttribute('role', 'button');
     }
   }
 

--- a/extensions/amp-story/1.0/amp-story-cta-layer.js
+++ b/extensions/amp-story/1.0/amp-story-cta-layer.js
@@ -69,10 +69,10 @@ export class AmpStoryCtaLayer extends AmpStoryBaseLayer {
     const ctaLinks = this.element.querySelectorAll('a');
     for (let i = 0; i < ctaLinks.length; i++) {
       addAttributesToElement(ctaLinks[i],
-          /** @type {!JsonObject} */ (parseJson({'target': '_blank'})));
+          /** @type {!JsonObject} */ (parseJson(`{"target": "_blank"}`)));
       if (!ctaLinks[i].getAttribute('role')) {
         addAttributesToElement(ctaLinks[i],
-            /** @type {!JsonObject} */ (parseJson({'role': 'link'})));
+            /** @type {!JsonObject} */ (parseJson(`{"role": "link"}`)));
       }
     }
 
@@ -80,7 +80,7 @@ export class AmpStoryCtaLayer extends AmpStoryBaseLayer {
     for (let i = 0; i < ctaButtons.length; i++) {
       if (!ctaButtons[i].getAttribute('role')) {
         addAttributesToElement(ctaButtons[i],
-            /** @type {!JsonObject} */ (parseJson({'role': 'button'})));
+            /** @type {!JsonObject} */ (parseJson(`{"role": "button"}`)));
       }
     }
   }

--- a/extensions/amp-story/1.0/amp-story-cta-layer.js
+++ b/extensions/amp-story/1.0/amp-story-cta-layer.js
@@ -31,8 +31,8 @@
 
 import {AmpStoryBaseLayer} from './amp-story-base-layer';
 import {addAttributesToElement} from '../../../src/dom';
+import {dict} from '../../../src/utils/object';
 import {matches, removeElement} from '../../../src/dom';
-import {parseJson} from '../../../src/json';
 import {user} from '../../../src/log';
 
 /**
@@ -57,7 +57,7 @@ export class AmpStoryCtaLayer extends AmpStoryBaseLayer {
   /** @override */
   buildCallback() {
     super.buildCallback();
-    this.setOrOverwriteTargetAttribute_();
+    this.setOrOverwriteAttributes_();
     this.checkAndRemoveLayerIfOnFirstPage_();
   }
 
@@ -68,19 +68,17 @@ export class AmpStoryCtaLayer extends AmpStoryBaseLayer {
   setOrOverwriteAttributes_() {
     const ctaLinks = this.element.querySelectorAll('a');
     for (let i = 0; i < ctaLinks.length; i++) {
-      addAttributesToElement(ctaLinks[i],
-          /** @type {!JsonObject} */ (parseJson(`{"target": "_blank"}`)));
+      addAttributesToElement(ctaLinks[i], dict({'target': '_blank'}));
+
       if (!ctaLinks[i].getAttribute('role')) {
-        addAttributesToElement(ctaLinks[i],
-            /** @type {!JsonObject} */ (parseJson(`{"role": "link"}`)));
+        addAttributesToElement(ctaLinks[i], dict({'role': 'link'}));
       }
     }
 
     const ctaButtons = this.element.querySelectorAll('button');
     for (let i = 0; i < ctaButtons.length; i++) {
       if (!ctaButtons[i].getAttribute('role')) {
-        addAttributesToElement(ctaButtons[i],
-            /** @type {!JsonObject} */ (parseJson(`{"role": "button"}`)));
+        addAttributesToElement(ctaButtons[i], dict({'role': 'button'}));
       }
     }
   }

--- a/extensions/amp-story/1.0/amp-story-cta-layer.js
+++ b/extensions/amp-story/1.0/amp-story-cta-layer.js
@@ -30,7 +30,9 @@
  */
 
 import {AmpStoryBaseLayer} from './amp-story-base-layer';
+import {addAttributesToElement} from '../../../src/dom';
 import {matches, removeElement} from '../../../src/dom';
+import {parseJson} from '../../../src/json';
 import {user} from '../../../src/log';
 
 /**
@@ -66,13 +68,20 @@ export class AmpStoryCtaLayer extends AmpStoryBaseLayer {
   setOrOverwriteAttributes_() {
     const ctaLinks = this.element.querySelectorAll('a');
     for (let i = 0; i < ctaLinks.length; i++) {
-      ctaLinks[i].setAttribute('target', '_blank');
-      ctaLinks[i].setAttribute('role', 'link');
+      addAttributesToElement(ctaLinks[i],
+          /** @type {!JsonObject} */ (parseJson({'target': '_blank'})));
+      if (!ctaLinks[i].getAttribute('role')) {
+        addAttributesToElement(ctaLinks[i],
+            /** @type {!JsonObject} */ (parseJson({'role': 'link'})));
+      }
     }
 
     const ctaButtons = this.element.querySelectorAll('button');
     for (let i = 0; i < ctaButtons.length; i++) {
-      ctaButtons[i].setAttribute('role', 'button');
+      if (!ctaButtons[i].getAttribute('role')) {
+        addAttributesToElement(ctaButtons[i],
+            /** @type {!JsonObject} */ (parseJson({'role': 'button'})));
+      }
     }
   }
 

--- a/extensions/amp-story/1.0/page-advancement.js
+++ b/extensions/amp-story/1.0/page-advancement.js
@@ -14,13 +14,12 @@
  * limitations under the License.
  */
 import {Services} from '../../../src/services';
+import {TAPPABLE_ARIA_ROLES} from '../../../src/service/action-impl';
 import {VideoEvents} from '../../../src/video-interface';
 import {closest, escapeCssSelectorIdent} from '../../../src/dom';
 import {dev, user} from '../../../src/log';
 import {hasTapAction, timeStrToMillis} from './utils';
 import {listenOnce} from '../../../src/event-helper';
-import {map} from '../../../src/utils/object';
-
 
 /** @private @const {number} */
 const NEXT_SCREEN_AREA_RATIO = 0.75;
@@ -33,12 +32,6 @@ export const TapNavigationDirection = {
   'NEXT': 1,
   'PREVIOUS': 2,
 };
-
-/** @const */
-const PROTECTED_ELEMENTS = map({
-  A: true,
-  BUTTON: true,
-});
 
 /**
  * Base class for the AdvancementConfig.  By default, does nothing other than
@@ -308,7 +301,12 @@ class ManualAdvancement extends AdvancementConfig {
    * @return {boolean}
    */
   isProtectedTarget_(event) {
-    return !!PROTECTED_ELEMENTS[event.target.tagName];
+    const elementRole = event.target.getAttribute('role');
+
+    if (elementRole) {
+      return !!TAPPABLE_ARIA_ROLES[elementRole.toLowerCase()];
+    }
+    return false;
   }
 
 

--- a/extensions/amp-story/1.0/test/test-amp-story-cta-layer.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-cta-layer.js
@@ -95,4 +95,40 @@ describes.realWin('amp-story-cta-layer', {
     });
   });
 
+  it('should add or overwrite role attribute to links', () => {
+    const ctaLink = win.document.createElement('a');
+    expect(ctaLink).to.not.have.attribute('role');
+
+    ampStoryCtaLayer.element.appendChild(ctaLink);
+    ampStoryCtaLayer.buildCallback();
+
+    return ampStoryCtaLayer.layoutCallback().then(() => {
+      expect(ctaLink).to.have.attribute('role');
+      expect(ctaLink.getAttribute('role')).to.equal('link');
+    });
+  });
+
+  it('should add or overwrite role attribute to buttons', () => {
+    const ctaButton = win.document.createElement('button');
+    expect(ctaButton).to.not.have.attribute('role');
+
+    ampStoryCtaLayer.element.appendChild(ctaButton);
+    ampStoryCtaLayer.buildCallback();
+
+    return ampStoryCtaLayer.layoutCallback().then(() => {
+      expect(ctaButton).to.have.attribute('role');
+      expect(ctaButton.getAttribute('role')).to.equal('button');
+    });
+  });
+
+  it('should not add role attribute to other elements', () => {
+    const elem = win.document.createElement('span');
+    ampStoryCtaLayer.element.appendChild(elem);
+    ampStoryCtaLayer.buildCallback();
+
+    return ampStoryCtaLayer.layoutCallback().then(() => {
+      expect(elem).to.not.have.attribute('role');
+    });
+  });
+
 });


### PR DESCRIPTION
Closes #14575.

Inside amp-story, all clicks are considered as navigational, except those coming from a custom list. 

Instead of using an extra custom list we have to maintain, we can use the already existing aria roles list.