### PR TITLE
✅ 🐛 Don't load the karma-coverage plugin by default

### DIFF
--- a/build-system/tasks/karma.conf.js
+++ b/build-system/tasks/karma.conf.js
@@ -214,7 +214,6 @@ module.exports = {
     'karma-browserify',
     'karma-chai',
     'karma-chrome-launcher',
-    'karma-coverage',
     'karma-edge-launcher',
     'karma-firefox-launcher',
     'karma-fixture',

--- a/build-system/tasks/runtime-test.js
+++ b/build-system/tasks/runtime-test.js
@@ -309,6 +309,7 @@ function runTests() {
     c.files = c.files.concat(config.coveragePaths);
     c.browserify.transform.push(
         ['browserify-istanbul', {instrumenterConfig: {embedSource: true}}]);
+    c.plugins.push('karma-coverage');
     c.reporters = c.reporters.concat(['coverage']);
     if (c.preprocessors['src/**/*.js']) {
       c.preprocessors['src/**/*.js'].push('coverage');


### PR DESCRIPTION
We're seeing `karma` disconnects on Travis whenever our tests use sauce labs. See https://travis-ci.org/ampproject/amphtml/jobs/367837186#L728-L740

It's possible that this could be due to the use of code coverage plugins. See https://github.com/karma-runner/karma-sauce-launcher/issues/95#issuecomment-255020888

This PR lazily loads the `karma-coverage` plugin only if the `--coverage` flag is used. Hopefully, this will reduce the number of disconnects on Travis. 