### PR TITLE
🐛 amp-next-page: Fix fixed element hiding

### DIFF
--- a/extensions/amp-next-page/0.1/amp-next-page.js
+++ b/extensions/amp-next-page/0.1/amp-next-page.js
@@ -234,7 +234,7 @@ export class AmpNextPage extends AMP.BaseElement {
 
             installStylesForDoc(amp.ampdoc, CSS, null, false, TAG);
             const body = amp.ampdoc.getBody();
-            body.classList.add('i-amphtml-recommended-document');
+            body.classList.add('i-amphtml-next-page-document');
           } catch (e) {
             // TODO(emarchiori): Handle loading errors.
           }


### PR DESCRIPTION
I accidentally broke it when renaming the component and forgot to update a class name in the JS.
