### PR TITLE
Doubleclick SRA fix for header unnesting

### DIFF
--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -1151,7 +1151,8 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
                   (creative, headersObj, done) => {
                     checkStillCurrent();
                     const headerNames = Object.keys(headersObj);
-                    if (headerNames.length == 1 && isObject(headerNames[0])) {
+                    if (headerNames.length == 1 &&
+                        isObject(headersObj[headerNames[0]])) {
                       // TODO(keithwrightbos) - fix upstream so response does
                       // not improperly place headers under key.
                       headersObj =


### PR DESCRIPTION
Current Doubleclick Fast Fetch SRA response places headers nested under inventory unit.  Code moving headers to top-level was not properly checking if nested was object.  Fixed unit test coverage to run properly (was failing to actually execute due to allowConsoleError) and cover this case.