### PR TITLE
🐛 Pass karma's exit code to gulp

### DIFF
--- a/build-system/tasks/runtime-test.js
+++ b/build-system/tasks/runtime-test.js
@@ -371,6 +371,7 @@ function runTests() {
       log(
           red('ERROR:'),
           yellow('Karma test failed with exit code ' + exitCode));
+      process.exitCode = exitCode;
     }
     resolver();
   }).on('run_start', function() {


### PR DESCRIPTION
Without this, Karma failures aren't passed on to gulp, and Travis passes builds that should've failed.