### PR TITLE
Name store service consistently 

### DIFF
--- a/extensions/amp-story/0.1/amp-story-bookend.js
+++ b/extensions/amp-story/0.1/amp-story-bookend.js
@@ -242,7 +242,7 @@ export class Bookend {
     this.shareWidget_ = ScrollableShareWidget.create(this.win_);
 
     /** @private @const {!./amp-story-store-service.AmpStoryStoreService} */
-    this.storeService_ = Services.storyStoreServiceV01(this.win_);
+    this.storeService_ = Services.storyStoreService(this.win_);
 
     /** @private @const {!Element} */
     this.parentEl_ = parentEl;

--- a/extensions/amp-story/0.1/amp-story-hint.js
+++ b/extensions/amp-story/0.1/amp-story-hint.js
@@ -144,7 +144,7 @@ export class AmpStoryHint {
     this.hintTimeout_ = null;
 
     /** @private @const {!./amp-story-store-service.AmpStoryStoreService} */
-    this.storeService_ = Services.storyStoreServiceV01(this.win_);
+    this.storeService_ = Services.storyStoreService(this.win_);
 
     /** @private @const {!Element} */
     this.parentEl_ = parentEl;

--- a/extensions/amp-story/0.1/amp-story-share-menu.js
+++ b/extensions/amp-story/0.1/amp-story-share-menu.js
@@ -88,7 +88,7 @@ export class ShareMenu {
     this.shareWidget_ = ShareWidget.create(this.win_);
 
     /** @private @const {!./amp-story-store-service.AmpStoryStoreService} */
-    this.storeService_ = Services.storyStoreServiceV01(this.win_);
+    this.storeService_ = Services.storyStoreService(this.win_);
 
     /** @private @const {!Element} */
     this.parentEl_ = parentEl;

--- a/extensions/amp-story/0.1/amp-story-system-layer.js
+++ b/extensions/amp-story/0.1/amp-story-system-layer.js
@@ -119,7 +119,7 @@ export class SystemLayer {
     this.developerButtons_ = DevelopmentModeLogButtonSet.create(win);
 
     /** @private @const {!./amp-story-store-service.AmpStoryStoreService} */
-    this.storeService_ = Services.storyStoreServiceV01(this.win_);
+    this.storeService_ = Services.storyStoreService(this.win_);
 
     /** @const @private {!../../../src/service/vsync-impl.Vsync} */
     this.vsync_ = Services.vsyncFor(this.win_);

--- a/extensions/amp-story/0.1/amp-story-viewport-warning-layer.js
+++ b/extensions/amp-story/0.1/amp-story-viewport-warning-layer.js
@@ -111,7 +111,7 @@ export class ViewportWarningLayer {
     this.platform_ = Services.platformFor(this.win_);
 
     /** @private @const {!./amp-story-store-service.AmpStoryStoreService} */
-    this.storeService_ = Services.storyStoreServiceV01(this.win_);
+    this.storeService_ = Services.storyStoreService(this.win_);
 
     /** @private @const {!Element} */
     this.storyElement_ = storyElement;

--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -186,7 +186,7 @@ export class AmpStory extends AMP.BaseElement {
     /** @private @const {!AmpStoryStoreService} */
     this.storeService_ = new AmpStoryStoreService(this.win);
     registerServiceBuilder(
-        this.win, 'story-store-v01', () => this.storeService_);
+        this.win, 'story-store', () => this.storeService_);
 
     /** @private @const {!AmpStoryRequestService} */
     this.requestService_ = new AmpStoryRequestService(this.win, this.element);

--- a/extensions/amp-story/0.1/navigation-state.js
+++ b/extensions/amp-story/0.1/navigation-state.js
@@ -53,7 +53,7 @@ export class NavigationState {
     this.win_ = win;
 
     /** @private @const {!./amp-story-store-service.AmpStoryStoreService} */
-    this.storeService_ = Services.storyStoreServiceV01(this.win_);
+    this.storeService_ = Services.storyStoreService(this.win_);
 
     this.initializeListeners_();
   }

--- a/extensions/amp-story/0.1/pagination-buttons.js
+++ b/extensions/amp-story/0.1/pagination-buttons.js
@@ -146,7 +146,7 @@ export class PaginationButtons {
   /** @param {!Window} win */
   constructor(win) {
     const doc = win.document;
-    const storeService = Services.storyStoreServiceV01(win);
+    const storeService = Services.storyStoreService(win);
 
     /** @private @const {!PaginationButton} */
     this.forwardButton_ =

--- a/src/services.js
+++ b/src/services.js
@@ -357,26 +357,6 @@ export class Services {
   /**
    * TODO(#14357): Remove this when amp-story:0.1 is deprecated.
    * @param {!Window} win
-   * @return {?Promise<?../extensions/amp-story/0.1/amp-story-store-service.AmpStoryStoreService>}
-   */
-  static storyStoreServiceForOrNullV01(win) {
-    return (
-    /** @type {!Promise<?../extensions/amp-story/0.1/amp-story-store-service.AmpStoryStoreService>} */
-      (getElementServiceIfAvailable(win, 'story-store-v01', 'amp-story')));
-  }
-
-  /**
-   * TODO(#14357): Remove this when amp-story:0.1 is deprecated.
-   * @param {!Window} win
-   * @return {!../extensions/amp-story/0.1/amp-story-store-service.AmpStoryStoreService}
-   */
-  static storyStoreServiceV01(win) {
-    return getService(win, 'story-store-v01');
-  }
-
-  /**
-   * TODO(#14357): Remove this when amp-story:0.1 is deprecated.
-   * @param {!Window} win
    * @return {!../extensions/amp-story/0.1/amp-story-request-service.AmpStoryRequestService}
    */
   static storyRequestServiceV01(win) {


### PR DESCRIPTION
`amp-story-auto-ads` has a dependency on the store service from`amp-story`. Since ads does not know what version of story is loaded it does not know which version of the service to use.

The proposed solution is to name the store service consistently across v0.1 and v1.0. Note: this means that the store API must remain backwards compatibility.
