### PR TITLE
Fix how the desktop share options are hidden on embed modes.

### DIFF
--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -454,13 +454,10 @@ export class AmpStory extends AMP.BaseElement {
       this.onDesktopStateUpdate_(isDesktop);
     });
 
-    this.storeService_.subscribe(StateProperty.CAN_SHOW_SYSTEM_LAYER_BUTTONS,
-        canShowButtons => {
-          this.mutateElement(() => {
-            this.topBar_.classList
-                .toggle('i-amphtml-story-ui-no-buttons', !canShowButtons);
-          });
-        }, true /* callToInitialize */);
+    this.storeService_.subscribe(
+        StateProperty.CAN_SHOW_SYSTEM_LAYER_BUTTONS, canShowButtons => {
+          this.onCanShowSystemLayerButtonsUpdate_(canShowButtons);
+        });
 
     this.win.document.addEventListener('keydown', e => {
       this.onKeyDown_(e);
@@ -579,6 +576,9 @@ export class AmpStory extends AMP.BaseElement {
     this.topBar_.appendChild(this.buildTopBarShare_());
 
     this.element.insertBefore(this.topBar_, this.element.firstChild);
+
+    this.onCanShowSystemLayerButtonsUpdate_(
+        !!this.storeService_.get(StateProperty.CAN_SHOW_SYSTEM_LAYER_BUTTONS));
   }
 
   /**
@@ -1050,6 +1050,22 @@ export class AmpStory extends AMP.BaseElement {
         this.storeService_.dispatch(Action.TOGGLE_LANDSCAPE, state.isLandscape);
       },
     }, {});
+  }
+
+  /**
+   * Reacts to system layer buttons display state.
+   * @param {boolean} canShowButtons
+   * @private
+   */
+  onCanShowSystemLayerButtonsUpdate_(canShowButtons) {
+    if (!this.topBar_) {
+      return;
+    }
+
+    this.mutateElement(() => {
+      this.topBar_.classList
+          .toggle('i-amphtml-story-ui-no-buttons', !canShowButtons);
+    });
   }
 
   /**


### PR DESCRIPTION
- Make sure we're not applying a class to an element that doesn't exist
- Make sure the class is added when a user resizes their screen from mobile to desktop

Follow up for #14606