### PR TITLE
Allow tap targets to trigger inside accordion header

### DIFF
--- a/extensions/amp-accordion/0.1/amp-accordion.js
+++ b/extensions/amp-accordion/0.1/amp-accordion.js
@@ -19,7 +19,7 @@ import {Layout} from '../../../src/layout';
 import {Services} from '../../../src/services';
 import {closest} from '../../../src/dom';
 import {dev, user} from '../../../src/log';
-import {dict, hasOwn, map} from '../../../src/utils/object';
+import {dict} from '../../../src/utils/object';
 import {parseJson} from '../../../src/json';
 import {removeFragment} from '../../../src/url';
 import {tryFocus} from '../../../src/dom';
@@ -51,8 +51,6 @@ class AmpAccordion extends AMP.BaseElement {
     /** @private {?../../../src/service/action-impl.ActionService} */
     this.action_ = null;
 
-    /** @private {!Object} */
-    this.shouldHandleClickCache_ = map();
   }
 
   /** @override */
@@ -286,25 +284,8 @@ class AmpAccordion extends AMP.BaseElement {
    * Handles clicks on an accordion header to expand/collapse its content.
    */
   clickHandler_(event) {
-    if (this.cachedShouldHandleClick_(event)) {
-      // Don't use clicks on links in header to expand/collapse.
+    if (this.shouldHandleClick_(event)) {
       this.onHeaderPicked_(event);
-    }
-  }
-
-  cachedShouldHandleClick_(event) {
-    const target = dev().assertElement(event.target);
-    const header = dev().assertElement(event.currentTarget);
-
-    const targetId = target.getAttribute('id');
-    if (targetId) {
-      if (hasOwn(this.shouldHandleClickCache_, targetId)) {
-        this.shouldHandleClickCache_[targetId] =
-          this.shouldHandleClick_(target, header);
-      }
-      return this.shouldHandleClickCache_[targetId];
-    } else {
-      return this.shouldHandleClick_(target, header);
     }
   }
 
@@ -312,12 +293,13 @@ class AmpAccordion extends AMP.BaseElement {
    * We should support clicks on any children of the header except for on
    * links or elements with tap targets, which should not have their default
    * behavior overidden.
-   * @param {!Element} target
-   * @param {!Element} header
+   * @param {!Event} event
    * @returns {boolean}
    * @private
    */
-  shouldHandleClick_(target, header) {
+  shouldHandleClick_(event) {
+    const target = dev().assertElement(event.target);
+    const header = dev().assertElement(event.currentTarget);
     const hasAnchor = !!closest(target, e => (e.tagName == 'A'), header);
     const hasTapAction = this.action_.hasAction(target,'tap', header);
     return !hasAnchor && !hasTapAction;

--- a/extensions/amp-accordion/0.1/amp-accordion.js
+++ b/extensions/amp-accordion/0.1/amp-accordion.js
@@ -283,8 +283,13 @@ class AmpAccordion extends AMP.BaseElement {
     // overidden.
     const target = dev().assertElement(event.target);
     const header = dev().assertElement(event.currentTarget);
-    const anchor = closest(target, e => e.tagName == 'A', header);
-    if (anchor === null) {
+    const anchorOrTapTarget = closest(target, e => {
+      return (e.tagName == 'A')
+        || (e.hasAttribute('on')
+          && e.getAttribute('on')./*OK*/matches(/(^|;)\s*tap\s*/));
+    }, header);
+
+    if (anchorOrTapTarget === null) {
       // Don't use clicks on links in header to expand/collapse.
       this.onHeaderPicked_(event);
     }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -822,7 +822,7 @@ function performBuild(watch) {
  */
 function checkBinarySize(compiled) {
   const file = compiled ? './dist/v0.js' : './dist/amp.js';
-  const size = compiled ? '76.85KB' : '336.00KB';
+  const size = compiled ? '76.85KB' : '336.10KB';
   const cmd = `npx bundlesize -f "${file}" -s "${size}"`;
   log(green('Running ') + cyan(cmd) + green('...\n'));
   const p = exec(cmd);

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -406,11 +406,11 @@ export class ActionService {
    * Checks if the given element has registered a particular action type.
    * @param {!Element} target
    * @param {string} actionEventType
-   * @param {!Element=} opt_parent
+   * @param {!Element=} opt_stopAt
    * @returns {boolean}
    */
-  hasAction(target, actionEventType, opt_parent) {
-    return !!this.findAction_(target, actionEventType, opt_parent);
+  hasAction(target, actionEventType, opt_stopAt) {
+    return !!this.findAction_(target, actionEventType, opt_stopAt);
   }
 
   /**
@@ -535,14 +535,14 @@ export class ActionService {
   /**
    * @param {!Element} target
    * @param {string} actionEventType
-   * @param {!Element=} opt_parent
+   * @param {!Element=} opt_stopAt
    * @return {?{node: !Element, actionInfos: !Array<!ActionInfoDef>}}
    */
-  findAction_(target, actionEventType, opt_parent) {
+  findAction_(target, actionEventType, opt_stopAt) {
     // Go from target up the DOM tree and find the applicable action.
     let n = target;
     while (n) {
-      if (opt_parent && n == opt_parent) {
+      if (opt_stopAt && n == opt_stopAt) {
         return null;
       }
       const actionInfos = this.matchActionInfos_(n, actionEventType);

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -403,6 +403,17 @@ export class ActionService {
   }
 
   /**
+   * Checks if the given element has registered a particular action type.
+   * @param {!Element} target
+   * @param {string} actionEventType
+   * @param {!Element=} opt_parent
+   * @returns {boolean}
+   */
+  hasAction(target, actionEventType, opt_parent) {
+    return !!this.findAction_(target, actionEventType, opt_parent);
+  }
+
+  /**
    * @param {!Element} source
    * @param {string} actionEventType
    * @param {?ActionEventDef} event
@@ -524,12 +535,16 @@ export class ActionService {
   /**
    * @param {!Element} target
    * @param {string} actionEventType
+   * @param {!Element=} opt_parent
    * @return {?{node: !Element, actionInfos: !Array<!ActionInfoDef>}}
    */
-  findAction_(target, actionEventType) {
+  findAction_(target, actionEventType, opt_parent) {
     // Go from target up the DOM tree and find the applicable action.
     let n = target;
     while (n) {
+      if (opt_parent && n == opt_parent) {
+        return null;
+      }
       const actionInfos = this.matchActionInfos_(n, actionEventType);
       if (actionInfos && isEnabled(n)) {
         return {node: n, actionInfos: dev().assert(actionInfos)};

--- a/test/functional/test-action.js
+++ b/test/functional/test-action.js
@@ -598,6 +598,46 @@ describe('Action findAction', () => {
   });
 });
 
+describe('Action hasAction', () => {
+  let sandbox;
+  let action;
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+    action = actionService();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('returns true if the target element has the target action', () => {
+    const element = document.createElement('div');
+    element.setAttribute('on', 'event1:action1');
+    expect(action.hasAction(element, 'event1')).to.equal(true);
+  });
+
+  it('returns true if an intermediate element has target action', () => {
+    const child = document.createElement('div');
+    const element = document.createElement('div');
+    element.appendChild(child);
+    element.setAttribute('on', 'event1:action1');
+    const parent = document.createElement('div');
+    parent.appendChild(element);
+    parent.setAttribute('on', 'event2:action2');
+    expect(action.hasAction(element, 'event1', parent)).to.equal(true);
+    expect(action.hasAction(element, 'event2', parent)).to.equal(false);
+  });
+
+  it('returns false if the target element does not have the target action',
+      () => {
+        const element = document.createElement('div');
+        element.setAttribute('on', 'event1:action1');
+        expect(action.hasAction(element, 'event2')).to.equal(false);
+      });
+
+});
+
 
 describe('Action method', () => {
   let sandbox;

--- a/test/manual/amp-accordion.amp.html
+++ b/test/manual/amp-accordion.amp.html
@@ -19,7 +19,9 @@
   }
   </style>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
-  <script async custom-element="amp-youtube" src="https://cdn.ampproject.org/v0/amp-accordion-0.1.js"></script>
+  <script async custom-element="amp-accordion" src="https://cdn.ampproject.org/v0/amp-accordion-0.1.js"></script>
+  <script async custom-element="amp-image-lightbox" src="https://cdn.ampproject.org/v0/amp-image-lightbox-0.1.js"></script>
+
 </head>
 <body>
   <h1>AMP #0</h1>
@@ -61,5 +63,32 @@
     </section>
   </amp-accordion>
 
+<h1>amp-image-lightbox in accordion header test</h1>
+  <amp-accordion>
+    <section expanded>
+      <header>
+        <h4>Section 1</h4>
+        <amp-img
+           on="tap:lightbox1"
+           role="button"
+           tabindex="0"
+           src="https://picsum.photos/1600/900"
+           alt="Picture of a dog"
+           layout="fixed"
+           width="400" height="300">
+        </amp-img>
+      </header>
+      <div>
+        <p>Bunch of awesome content.</p>
+      </div>
+    </section>
+    <section>
+      <div>
+        <h4>Section 2</h4>
+      </div>
+      <div>Bunch of even more awesome content. This time in a <code>&lt;div&gt;</code>.</div>
+    </section>
+   </amp-accordion>
+   <amp-image-lightbox id="lightbox1" layout="nodisplay"></amp-image-lightbox>
 </body>
 </html>


### PR DESCRIPTION
Closes https://github.com/ampproject/amphtml/issues/14627. 

It seems like a reasonable use case to support tap targets that are located inside of a `<amp-accordion>` header, e.g. lightboxed images. 