### PR TITLE
Update source width and height for amp-image-lightbox

### DIFF
--- a/extensions/amp-image-lightbox/0.1/amp-image-lightbox.js
+++ b/extensions/amp-image-lightbox/0.1/amp-image-lightbox.js
@@ -229,6 +229,36 @@ export class ImageViewer {
   }
 
   /**
+   * @param {!Element} sourceElement
+   * @param {?Element} sourceImage
+   * @return {number}
+   * @private
+   */
+  getSourceWidth_(sourceElement, sourceImage) {
+    if (sourceElement.hasAttribute('width')) {
+      return parseInt(sourceElement.getAttribute('width'), 10);
+    } else {
+      return sourceImage ? sourceImage.naturalWidth
+        : sourceElement./*OK*/offsetWidth;
+    }
+  }
+
+  /**
+   * @param {!Element} sourceElement
+   * @param {?Element} sourceImage
+   * @return {number}
+   * @private
+   */
+  getSourceHeight_(sourceElement, sourceImage) {
+    if (sourceElement.hasAttribute('height')) {
+      return parseInt(sourceElement.getAttribute('height'), 10);
+    } else {
+      return sourceImage ? sourceImage.naturalHeight
+        : sourceElement./*OK*/offsetHeight;
+    }
+  }
+
+  /**
    * Initializes the image viewer to the target image element such as
    * "amp-img". The target image element may or may not yet have the img
    * element initialized.
@@ -236,8 +266,8 @@ export class ImageViewer {
    * @param {?Element} sourceImage
    */
   init(sourceElement, sourceImage) {
-    this.sourceWidth_ = sourceElement./*OK*/offsetWidth;
-    this.sourceHeight_ = sourceElement./*OK*/offsetHeight;
+    this.sourceWidth_ = this.getSourceWidth_(sourceElement, sourceImage);
+    this.sourceHeight_ = this.getSourceHeight_(sourceElement, sourceImage);
     this.srcset_ = srcsetFromElement(sourceElement);
 
     Object.keys(this.ariaAttributes_).forEach(key => {

--- a/extensions/amp-image-lightbox/0.1/test/test-amp-image-lightbox.js
+++ b/extensions/amp-image-lightbox/0.1/test/test-amp-image-lightbox.js
@@ -204,8 +204,14 @@ describes.realWin('amp-image-lightbox component', {
   it('should return focus to source element after close', () => {
     return getImageLightbox().then(lightbox => {
       const impl = lightbox.implementation_;
-
       impl.enter_ = () => {};
+      impl.getHistory_ = () => {
+        return {
+          pop: () => {},
+          push: () => Promise.resolve(11),
+        };
+      };
+
       const tryFocus = sandbox.spy(dom, 'tryFocus');
 
       const sourceElement = doc.createElement('amp-img');
@@ -278,6 +284,7 @@ describes.realWin('amp-image-lightbox image viewer', {
         }
         return undefined;
       },
+      hasAttribute: () => undefined,
     };
 
     imageViewer.init(sourceElement, null);
@@ -297,6 +304,7 @@ describes.realWin('amp-image-lightbox image viewer', {
         }
         return undefined;
       },
+      hasAttribute: () => undefined,
     };
     const sourceImage = {
       complete: false,
@@ -318,6 +326,7 @@ describes.realWin('amp-image-lightbox image viewer', {
         }
         return undefined;
       },
+      hasAttribute: () => undefined,
     };
     const sourceImage = {
       complete: true,

--- a/extensions/amp-image-lightbox/OWNERS.yaml
+++ b/extensions/amp-image-lightbox/OWNERS.yaml
@@ -1,2 +1,3 @@
 - aghassemi
 - dvoytenko
+- cathyzhu


### PR DESCRIPTION
Backport image dimension selection logic from `<amp-image-viewer>` to `<amp-image-lightbox>`. Closes https://github.com/ampproject/amphtml/issues/12100. 
