### PR TITLE
🐛 Avoid immediate font display change to reduce risk of errors.

### DIFF
--- a/src/font-stylesheet-timeout.js
+++ b/src/font-stylesheet-timeout.js
@@ -42,7 +42,6 @@ export function fontStylesheetTimeout(win) {
  * @param {!Window} win
  */
 function maybeTimeoutFonts(win) {
-  timeoutFontFaces(win);
   let timeSinceResponseStart = 0;
   // If available, we start counting from the time the HTTP response
   // for the page started. The preload scanner should then quickly

--- a/test/functional/test-font-stylesheet-timeout.js
+++ b/test/functional/test-font-stylesheet-timeout.js
@@ -173,22 +173,28 @@ describes.realWin('font-stylesheet-timeout', {
     it('should not do anything with experiment off', () => {
       toggleExperiment(win, 'font-display-swap', false);
       fontStylesheetTimeout(win);
+      clock.tick(250);
       expect(fonts[1].display).to.equal('auto');
     });
 
     it('should not change loaded fonts', () => {
       fontStylesheetTimeout(win);
+      clock.tick(250);
       expect(fonts[0].display).to.equal('auto');
     });
 
     it('should change loading fonts to swap', () => {
       fontStylesheetTimeout(win);
+      expect(fonts[1].display).to.equal('auto');
+      expect(fonts[2].display).to.equal('auto');
+      clock.tick(250);
       expect(fonts[1].display).to.equal('swap');
       expect(fonts[2].display).to.equal('swap');
     });
 
     it('should not override non-default values', () => {
       fontStylesheetTimeout(win);
+      clock.tick(250);
       expect(fonts[3].display).to.equal('optional');
     });
   });


### PR DESCRIPTION
In the first launch we were not seeing errors, but overall reduction in requests which was suspicious.

Arguably giving the page some time to retrieve the fonts from cache also makes sense. Unfortunately there is no declarative display mode that allows expressing that.

