### PR TITLE
📖 add layout to amp-geo examples

### DIFF
--- a/extensions/amp-geo/amp-geo.md
+++ b/extensions/amp-geo/amp-geo.md
@@ -39,10 +39,10 @@ The `amp-geo` component provides country-level geolocation. The `amp-geo` compon
 
 ##### Example: Changing background based on country location
 
-In the following example, we add the `<amp-geo>` to determine the user's location so that we can apply the appropriate background for their location.
+In the following example, we add `<amp-geo>` to determine the user's location so that we can apply the appropriate background for their location.
 
 ```html
-<amp-geo></amp-geo>
+<amp-geo layout="nodisplay"></amp-geo>
 ```
 
 If the user is in Canada, the `amp-geo` component applies the `amp-iso-country-ca` CSS class  to the `body` tag.  We can then use CSS to apply the correct background for Canada:
@@ -73,7 +73,7 @@ Optionally, you can include a JSON configuration script in the `amp-geo` tag.
 The `ISOCountryGroups` key allows selections by groups of country codes.
 
 ```html
-<amp-geo>
+<amp-geo layout="nodisplay">
   <script type="application-json">
   {
     "ISOCountryGroups": {
@@ -98,7 +98,7 @@ If country groups are specified, `amp-geo` iterates through the groups. For any 
 In the following example, we determine if the user is in a "soccer" country and display a "football" message for those users.
 
 ```html
-<amp-geo>
+<amp-geo layout="nodisplay">
   <script type="application-json">
   {
     "ISOCountryGroups": {
@@ -132,7 +132,7 @@ The game is called <span class='football'>!
 If the `AMPBind` key is present in the configuration, `amp-geo` inserts an `amp-state` tag containing the current country and group information.  Using the football example above, set the  `AMPBind` flag to true to enable `amp-bind` integration.
 
 ```html
-<amp-geo>
+<amp-geo layout="nodisplay">
   <script type="application-json">
   {
    "AMPBind": true,

--- a/extensions/amp-geo/amp-geo.md
+++ b/extensions/amp-geo/amp-geo.md
@@ -74,7 +74,7 @@ The `ISOCountryGroups` key allows selections by groups of country codes.
 
 ```html
 <amp-geo layout="nodisplay">
-  <script type="application-json">
+  <script type="application/json">
   {
     "ISOCountryGroups": {
       "soccer": [ "au", "ca", "ie", "nz", "us", "za" ],
@@ -99,7 +99,7 @@ In the following example, we determine if the user is in a "soccer" country and 
 
 ```html
 <amp-geo layout="nodisplay">
-  <script type="application-json">
+  <script type="application/json">
   {
     "ISOCountryGroups": {
       "soccer": [ "au", "ca", "ie", "nz", "us", "za" ],
@@ -133,7 +133,7 @@ If the `AMPBind` key is present in the configuration, `amp-geo` inserts an `amp-
 
 ```html
 <amp-geo layout="nodisplay">
-  <script type="application-json">
+  <script type="application/json">
   {
    "AMPBind": true,
     "ISOCountryGroups": {


### PR DESCRIPTION
Adds required `layout="nodisplay"` to `amp-geo` examples.
