### PR TITLE
Cleanup old shrink code in safeframe host

### DIFF
--- a/extensions/amp-a4a/0.1/callout-vendors.js
+++ b/extensions/amp-a4a/0.1/callout-vendors.js
@@ -81,7 +81,7 @@ if (getMode().localDev || getMode().test) {
   });
   RTC_VENDORS['fakevendor2'] = /** @type {RtcVendorDef} */({
     url: 'https://localhost:8000/examples/rtcE1.json?slot_id=SLOT_ID&page_id=PAGE_ID&foo_id=FOO_ID',
-    errorReportingUrl: 'https://localhost:8000/examples/ERROR_TYPE',
+    errorReportingUrl: 'https://localhost:8000/examples?e=ERROR_TYPE&h=HREF',
     disableKeyAppend: true,
   });
 }

--- a/extensions/amp-a4a/0.1/callout-vendors.js
+++ b/extensions/amp-a4a/0.1/callout-vendors.js
@@ -81,7 +81,7 @@ if (getMode().localDev || getMode().test) {
   });
   RTC_VENDORS['fakevendor2'] = /** @type {RtcVendorDef} */({
     url: 'https://localhost:8000/examples/rtcE1.json?slot_id=SLOT_ID&page_id=PAGE_ID&foo_id=FOO_ID',
-    errorReportingUrl: 'https://localhost:8000/examples?e=ERROR_TYPE&h=HREF',
+    errorReportingUrl: 'https://localhost:8000/examples/ERROR_TYPE',
     disableKeyAppend: true,
   });
 }

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
@@ -54,8 +54,8 @@ export const SERVICE = {
   REGISTER_DONE: 'register_done',
   COLLAPSE_REQUEST: 'collapse_request',
   COLLAPSE_RESPONSE: 'collapse_response',
-  SHRINK_REQUEST: 'shrink_request',
-  SHRINK_RESPONSE: 'shrink_response',
+  RESIZE_REQUEST: 'resize_request',
+  RESIZE_RESPONSE: 'resize_response',
 };
 
 /** @private {string} */
@@ -456,8 +456,8 @@ export class SafeframeHostApi {
       case SERVICE.COLLAPSE_REQUEST:
         this.handleCollapseRequest_();
         break;
-      case SERVICE.SHRINK_REQUEST:
-        this.handleShrinkRequest_(payload);
+      case SERVICE.RESIZE_REQUEST:
+        this.handleResizeRequest_(payload);
       default:
         break;
     }
@@ -566,7 +566,7 @@ export class SafeframeHostApi {
         height <= this.slotSize_.height) {
       this.resizeSafeframe(height, width, messageType);
     } else {
-      this.resizeAmpAdAndSafeframe(height, width, messageType);
+      this.resizeAmpAdAndSafeframe(height, width, messageType, optIsCollapse);
     }
   }
 
@@ -574,25 +574,25 @@ export class SafeframeHostApi {
    * @param {!JsonObject} payload
    * @private
    */
-  handleShrinkRequest_(payload) {
+  handleResizeRequest_(payload) {
     if (!this.isRegistered_) {
       return;
     }
-    const shrinkHeight = Number(this.creativeSize_.height) -
-          (payload['shrink_b'] + payload['shrink_t']);
-    const shrinkWidth = Number(this.creativeSize_.width) -
-          (payload['shrink_r'] + payload['shrink_l']);
+    const resizeHeight = Number(this.creativeSize_.height) +
+          (payload['resize_b'] + payload['resize_t']);
+    const resizeWidth = Number(this.creativeSize_.width) +
+          (payload['resize_r'] + payload['resize_l']);
 
-    // Make sure we are actually shrinking here.
-    if (isNaN(shrinkWidth) || isNaN(shrinkHeight) ||
-        shrinkWidth > this.creativeSize_.width ||
-        shrinkHeight > this.creativeSize_.height) {
-      dev().error(TAG, 'Invalid shrink values.');
+    // Make sure we are actually resizing here.
+    if (isNaN(resizeWidth) || isNaN(resizeHeight) ||
+        resizeWidth > this.creativeSize_.width ||
+        resizeHeight > this.creativeSize_.height) {
+      dev().error(TAG, 'Invalid resize values.');
       return;
     }
 
-    this.resizeAmpAdAndSafeframe(shrinkHeight, shrinkWidth,
-        SERVICE.SHRINK_RESPONSE);
+    this.resizeAmpAdAndSafeframe(resizeHeight, resizeWidth,
+        SERVICE.RESIZE_RESPONSE, true);
   }
 
   /**
@@ -625,8 +625,9 @@ export class SafeframeHostApi {
    * @param {number} height
    * @param {number} width
    * @param {string} messageType
+   * @param {boolean=} opt_isShrinking True if collapsing or resizing smaller.
    */
-  resizeAmpAdAndSafeframe(height, width, messageType) {
+  resizeAmpAdAndSafeframe(height, width, messageType, opt_isShrinking) {
     // First, attempt to resize the Amp-Ad that is the parent of the
     // safeframe
     this.baseInstance_.attemptChangeSize(height, width).then(() => {
@@ -644,9 +645,8 @@ export class SafeframeHostApi {
       // to execute upon the next user interaction. We don't want
       // that for safeframe, so we reset it here.
       this.baseInstance_.getResource().resetPendingChangeSize();
-      if (messageType == SERVICE.COLLAPSE_RESPONSE ||
-          messageType == SERVICE.SHRINK_RESPONSE) {
-        // If this is a collapse or shrink request, then even if resizing
+      if (opt_isShrinking) {
+        // If this is a collapse or resize request, then even if resizing
         // the amp-ad failed, still resize the iframe.
         // resizeSafeframe also sends the resize response.
         // Only register as collapsed if explicitly a collapse request.

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-safeframe.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-safeframe.js
@@ -718,27 +718,27 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
     });
 
     /**
-     * Send a message requesting a shrink.
-     * @param {number} height Pixels to shrink height by.
-     * @param {number} width Pixels to shrink width by.
+     * Send a message requesting a resize.
+     * @param {number} height Pixels to resize height by.
+     * @param {number} width Pixels to resize width by.
      */
-    function sendShrinkMessage(top, bottom, left, right) {
-      const shrinkMessage = {};
-      shrinkMessage[MESSAGE_FIELDS.CHANNEL] = safeframeHost.channel;
-      shrinkMessage[MESSAGE_FIELDS.ENDPOINT_IDENTITY] = 1;
-      shrinkMessage[MESSAGE_FIELDS.SERVICE] = SERVICE.SHRINK_REQUEST;
-      shrinkMessage[MESSAGE_FIELDS.PAYLOAD] = JSON.stringify({
+    function sendResizeMessage(top, bottom, left, right) {
+      const resizeMessage = {};
+      resizeMessage[MESSAGE_FIELDS.CHANNEL] = safeframeHost.channel;
+      resizeMessage[MESSAGE_FIELDS.ENDPOINT_IDENTITY] = 1;
+      resizeMessage[MESSAGE_FIELDS.SERVICE] = SERVICE.RESIZE_REQUEST;
+      resizeMessage[MESSAGE_FIELDS.PAYLOAD] = JSON.stringify({
         'uid': 0.623462509818004,
-        'shrink_t': top,
-        'shrink_r': right,
-        'shrink_b': bottom,
-        'shrink_l': left,
+        'resize_t': top,
+        'resize_r': right,
+        'resize_b': bottom,
+        'resize_l': left,
         'sentinel': safeframeHost.sentinel_,
       });
-      receiveMessage(shrinkMessage);
+      receiveMessage(resizeMessage);
     }
 
-    it('should shrink safeframe on amp-ad resize success', () => {
+    it('should resize safeframe on amp-ad resize success', () => {
       safeframeHost.isCollapsed_ = false;
       // Sneaky hack to do a synchronous mock of attemptChangeSize
       // Resize the ampAd to simulate a success.
@@ -749,7 +749,7 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
         return {'catch': () => {}};
       };
       attemptChangeSizeStub.returns({then});
-      sendShrinkMessage(5, 5, 5, 5);
+      sendResizeMessage(-5, -5, -5, -5);
 
       return Services.timerFor(env.win).promise(100).then(() => {
         expect(resizeSafeframeSpy).to.be.calledOnce;
@@ -757,7 +757,7 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
         expect(safeframeMock.style.height).to.equal('240px');
         expect(safeframeMock.style.width).to.equal('290px');
         expect(sendResizeResponseSpy).to.be.calledWith(
-            true, SERVICE.SHRINK_RESPONSE);
+            true, SERVICE.RESIZE_RESPONSE);
         expect(resizeAmpAdAndSafeframeSpy).to.be.calledOnce;
       });
     });


### PR DESCRIPTION
Switch over to using resize message. Shrink message was a temporary holdover. No change in behavior for anyone using the safeframe resize API on AMP pages. 

Tested = Manually tested example doubleclick-safeframe.amp.html as working, and unit tests. 