### PR TITLE
🚮 Remove unused vsync imports from viewport

### DIFF
--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -223,7 +223,6 @@ export class AmpImg extends BaseElement {
 /**
  * @param {!Window} win Destination window for the new element.
  * @this {undefined}  // Make linter happy
- * @return {undefined}
  */
 export function installImg(win) {
   registerElement(win, 'amp-img', AmpImg);

--- a/src/log.js
+++ b/src/log.js
@@ -227,7 +227,6 @@ export class Log {
    * Reports an error message.
    * @param {string} tag
    * @param {...*} var_args
-   * @return {undefined}
    */
   error(tag, var_args) {
     const error = this.error_.apply(this, arguments);

--- a/src/log.js
+++ b/src/log.js
@@ -227,7 +227,7 @@ export class Log {
    * Reports an error message.
    * @param {string} tag
    * @param {...*} var_args
-   * @return {!Error|undefined}
+   * @return {undefined}
    */
   error(tag, var_args) {
     const error = this.error_.apply(this, arguments);

--- a/src/service/viewport/viewport-binding-ios-embed-wrapper.js
+++ b/src/service/viewport/viewport-binding-ios-embed-wrapper.js
@@ -15,7 +15,6 @@
  */
 
 import {Observable} from '../../observable';
-import {Services} from '../../services';
 import {ViewportBindingDef} from './viewport-binding-def';
 import {dev} from '../../log';
 import {isExperimentOn} from '../../experiments';
@@ -54,9 +53,6 @@ export class ViewportBindingIosEmbedWrapper_ {
     this.wrapper_ = wrapper;
     wrapper.id = 'i-amphtml-wrapper';
     wrapper.className = topClasses;
-
-    /** @private {!../../service/vsync-impl.Vsync} */
-    this.vsync_ = Services.vsyncFor(this.win);
 
     /** @private @const {!Observable} */
     this.scrollObservable_ = new Observable();

--- a/src/service/viewport/viewport-binding-natural.js
+++ b/src/service/viewport/viewport-binding-natural.js
@@ -51,9 +51,6 @@ export class ViewportBindingNatural_ {
     /** @const {!../../service/platform-impl.Platform} */
     this.platform_ = Services.platformFor(this.win);
 
-    /** @private {!../../service/vsync-impl.Vsync} */
-    this.vsync_ = Services.vsyncFor(this.win);
-
     /** @private @const {!../viewer-impl.Viewer} */
     this.viewer_ = viewer;
 


### PR DESCRIPTION
Also tightens up a return type for `Log#error`.