### PR TITLE
Clean up amp-image-lightbox activation test

### DIFF
--- a/extensions/amp-image-lightbox/0.1/test/integration/test-amp-image-lightbox.js
+++ b/extensions/amp-image-lightbox/0.1/test/integration/test-amp-image-lightbox.js
@@ -17,6 +17,7 @@
 import {poll} from '../../../../../testing/iframe';
 
 describe.configure().run('amp-image-lightbox', function() {
+  this.timeout(5000);
   const extensions = ['amp-image-lightbox'];
   const imageLightboxBody = `
   <figure>
@@ -48,8 +49,7 @@ describe.configure().run('amp-image-lightbox', function() {
       win = env.win;
     });
 
-    // TODO(cathyxz, #13458): Find out why this is flaky on master.
-    it.skip('should activate on tap of source image', () => {
+    it('should activate on tap of source image', () => {
       const lightbox = win.document.getElementById('image-lightbox-1');
       expect(lightbox.style.display).to.equal('none');
       const ampImage = win.document.getElementById('img0');


### PR DESCRIPTION
Closes https://github.com/ampproject/amphtml/issues/13442

The issue with this test is timeouts on Windows environments on SauceLabs. Short of disabling all Windows tests, the best solution I can think of here is to increase the timeout. 