### PR TITLE
Always providing the story-variable service.

### DIFF
--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -231,7 +231,7 @@ export class AmpStory extends AMP.BaseElement {
     /** @const @private {!AmpStoryVariableService} */
     this.variableService_ = new AmpStoryVariableService();
     registerServiceBuilder(
-        this.win, 'story-variable-v01', () => this.variableService_.get());
+        this.win, 'story-variable', () => this.variableService_.get());
 
     /** @private {?./amp-story-page.AmpStoryPage} */
     this.activePage_ = null;

--- a/src/services.js
+++ b/src/services.js
@@ -349,18 +349,6 @@ export class Services {
   /**
    * TODO(#14357): Remove this when amp-story:0.1 is deprecated.
    * @param {!Window} win
-   * @return {?Promise<?../extensions/amp-story/0.1/variable-service.StoryVariableDef>}
-   */
-  static storyVariableServiceForOrNullV01(win) {
-    return (
-    /** @type {!Promise<?../extensions/amp-story/0.1/variable-service.StoryVariableDef>} */
-      (getElementServiceIfAvailable(win, 'story-variable-v01', 'amp-story',
-          true)));
-  }
-
-  /**
-   * TODO(#14357): Remove this when amp-story:0.1 is deprecated.
-   * @param {!Window} win
    * @return {!../extensions/amp-story/0.1/amp-story-store-service.AmpStoryStoreService}
    */
   static storyStoreServiceV01(win) {


### PR DESCRIPTION
The analytics extension is using the ``storyVariableServiceForOrNull`` method, that only returns the expected service if you're using ``amp-story v1.0``. All publishers are using ``amp-story v0.1``.

This PR ensures ``storyVariableServiceForOrNull`` always return the ``story-variable`` service.

Fixes #14736