### PR TITLE
Making sure extensions can retrieve the story store service.

### DIFF
--- a/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
+++ b/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
@@ -107,7 +107,12 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
     /** @private {Object<string, string>} */
     this.config_ = {};
 
-    /** @private {?../../amp-story/0.1/amp-story-store-service.AmpStoryStoreService} */
+    /**
+     * Version of the story store service depends on which version of amp-story
+     * the publisher is loading. They all have the same implementation.
+     * @private {?../../amp-story/0.1/amp-story-store-service.AmpStoryStoreService|
+     *           ?../../amp-story/1.0/amp-story-store-service.AmpStoryStoreService}
+     */
     this.storeService_ = null;
   }
 

--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -186,7 +186,7 @@ export class AmpStory extends AMP.BaseElement {
     /** @private @const {!AmpStoryStoreService} */
     this.storeService_ = new AmpStoryStoreService(this.win);
     registerServiceBuilder(
-        this.win, 'story-store-v01', () => this.storeService_);
+        this.win, 'story-store', () => this.storeService_);
 
     /** @private @const {!AmpStoryRequestService} */
     this.requestService_ = new AmpStoryRequestService(this.win, this.element);

--- a/extensions/amp-story/0.1/test/test-amp-story-hint.js
+++ b/extensions/amp-story/0.1/test/test-amp-story-hint.js
@@ -30,7 +30,7 @@ describes.fakeWin('amp-story hint layer', {}, env => {
     win = env.win;
 
     const storeService = new AmpStoryStoreService(win);
-    registerServiceBuilder(win, 'story-store-v01', () => storeService);
+    registerServiceBuilder(win, 'story-store', () => storeService);
 
     sandbox.stub(Services, 'vsyncFor').callsFake(
         () => ({mutate: task => task()}));

--- a/extensions/amp-story/0.1/test/test-amp-story-share-menu.js
+++ b/extensions/amp-story/0.1/test/test-amp-story-share-menu.js
@@ -36,7 +36,7 @@ describes.realWin('amp-story-share-menu', {amp: true}, env => {
   beforeEach(() => {
     win = env.win;
     storeService = new AmpStoryStoreService(win);
-    registerServiceBuilder(win, 'story-store-v01', () => storeService);
+    registerServiceBuilder(win, 'story-store', () => storeService);
 
     isSystemShareSupported = false;
 

--- a/extensions/amp-story/0.1/test/test-amp-story-system-layer.js
+++ b/extensions/amp-story/0.1/test/test-amp-story-system-layer.js
@@ -31,7 +31,7 @@ describes.fakeWin('amp-story system layer', {amp: true}, env => {
   beforeEach(() => {
     win = env.win;
 
-    registerServiceBuilder(win, 'story-store-v01', () => ({
+    registerServiceBuilder(win, 'story-store', () => ({
       get: NOOP,
       subscribe: NOOP,
     }));

--- a/extensions/amp-story/0.1/test/test-navigation-state.js
+++ b/extensions/amp-story/0.1/test/test-navigation-state.js
@@ -29,7 +29,7 @@ describes.fakeWin('amp-story navigation state', {ampdoc: 'none'}, env => {
 
   beforeEach(() => {
     storeService = new AmpStoryStoreService(env.win);
-    registerServiceBuilder(env.win, 'story-store-v01', () => storeService);
+    registerServiceBuilder(env.win, 'story-store', () => storeService);
     hasBookend = false;
     navigationState = new NavigationState(env.win,
         // Not using `Promise.resolve` since we need synchronicity.

--- a/src/services.js
+++ b/src/services.js
@@ -299,12 +299,16 @@ export class Services {
   }
 
   /**
+   * Version of the story store service depends on which version of amp-story
+   * the publisher is loading. They all have the same implementation.
    * @param {!Window} win
-   * @return {?Promise<?../extensions/amp-story/1.0/amp-story-store-service.AmpStoryStoreService>}
+   * @return {?Promise<?../extensions/amp-story/1.0/amp-story-store-service.AmpStoryStoreService|
+   *                   ?../extensions/amp-story/0.1/amp-story-store-service.AmpStoryStoreService>}
    */
   static storyStoreServiceForOrNull(win) {
     return (
-    /** @type {!Promise<?../extensions/amp-story/1.0/amp-story-store-service.AmpStoryStoreService>} */
+    /** @type {!Promise<?../extensions/amp-story/1.0/amp-story-store-service.AmpStoryStoreService|
+                        ?../extensions/amp-story/0.1/amp-story-store-service.AmpStoryStoreService>} */
       (getElementServiceIfAvailable(win, 'story-store', 'amp-story')));
   }
 
@@ -357,21 +361,10 @@ export class Services {
   /**
    * TODO(#14357): Remove this when amp-story:0.1 is deprecated.
    * @param {!Window} win
-   * @return {?Promise<?../extensions/amp-story/0.1/amp-story-store-service.AmpStoryStoreService>}
-   */
-  static storyStoreServiceForOrNullV01(win) {
-    return (
-    /** @type {!Promise<?../extensions/amp-story/0.1/amp-story-store-service.AmpStoryStoreService>} */
-      (getElementServiceIfAvailable(win, 'story-store-v01', 'amp-story')));
-  }
-
-  /**
-   * TODO(#14357): Remove this when amp-story:0.1 is deprecated.
-   * @param {!Window} win
    * @return {!../extensions/amp-story/0.1/amp-story-store-service.AmpStoryStoreService}
    */
   static storyStoreServiceV01(win) {
-    return getService(win, 'story-store-v01');
+    return getService(win, 'story-store');
   }
 
   /**


### PR DESCRIPTION
The version of the ``story-store-service`` registered depends on the ``amp-story`` version that is loaded.

At the ``amp-story`` extension level, we query the expected version of the service with the synchronous ``storyStoreService`` and ``storyStoreServiceV01`` methods, which satisfies the type checks.

For the other extensions, we expose the asynchronous ``storyStoreServiceForOrNull`` method, that can return either the ``0.1`` or ``1.0`` version.
We will have to make sure both versions of the service keep the same implementation.