### PR TITLE
🐛 Fix bug in unknown country handling.

### DIFF
--- a/extensions/amp-geo/0.1/amp-geo.js
+++ b/extensions/amp-geo/0.1/amp-geo.js
@@ -62,7 +62,6 @@ const COUNTRY_PREFIX = 'amp-iso-country-';
 const GROUP_PREFIX = 'amp-geo-group-';
 const PRE_RENDER_REGEX = new RegExp(`${COUNTRY_PREFIX}(\\w+)`);
 const GEO_ID = 'ampGeo';
-const defaultLen = COUNTRY.length;
 
 /**
  * Operating Mode
@@ -130,10 +129,8 @@ export class AmpGeo extends AMP.BaseElement {
     } else {
       this.mode_ = mode.GEO_HOT_PATCH;
       this.country_ = COUNTRY.trim();
-      // Catch the case where we didn't get patched or we are on a local system
-      // Note we can't use a string compare becasue it will get overwritten when
-      // the AMP_ISO_COUNTRY default is hot patched to the actual country.
-      if (this.country_.length === defaultLen) {
+      // If the length isn't 2 then the country is unknown.
+      if (this.country_.length !== 2) {
         this.country_ = 'unknown';
       }
     }

--- a/extensions/amp-geo/0.1/amp-geo.js
+++ b/extensions/amp-geo/0.1/amp-geo.js
@@ -129,7 +129,10 @@ export class AmpGeo extends AMP.BaseElement {
     } else {
       this.mode_ = mode.GEO_HOT_PATCH;
       this.country_ = COUNTRY.trim();
-      // If the length isn't 2 then the country is unknown.
+      // If we got a country code it will be 2 characters
+      // If the lengths is 0 the country is unknown
+      // If the length is > 2 we didn't get patched
+      // (probably local dev) so we treat it as unknown.
       if (this.country_.length !== 2) {
         this.country_ = 'unknown';
       }


### PR DESCRIPTION
Originally we were going to hotpatch "unknown" for unknown country but in the end we decided to hotpatch spaces.  This code didn't get changed to reflect that. 

This patch fixes it, any country code that is not 2 characters is unknown which will catch both the unpatched case and the unknown country case.
