### PR TITLE
Scroll amp-access extension adds its own page analytics

### DIFF
--- a/extensions/amp-access/0.1/amp-access-vendor.js
+++ b/extensions/amp-access/0.1/amp-access-vendor.js
@@ -42,8 +42,8 @@ export class AccessVendorAdapter {
     this.vendorName_ = user().assert(configJson['vendor'],
         '"vendor" name must be specified');
 
-    /** @const @private {JsonObject} */
-    this.vendorConfig_ = configJson[this.vendorName_];
+    /** @const @private {!JsonObject} */
+    this.vendorConfig_ = configJson[this.vendorName_] || {};
 
     /** @const @private {boolean} */
     this.isPingbackEnabled_ = !configJson['noPingback'];


### PR DESCRIPTION
Pursue the automatic solution described in #13526 . If a page adds the amp-access-scroll extension, references it from their access config, and the user is logged in at scroll.com, then and only then send back analytics information to Scroll.

The plan is to merge only this PR _or_ #14471 but want to have both options ready.
