### PR TITLE
Support use of source tag in mustache

### DIFF
--- a/src/sanitizer.js
+++ b/src/sanitizer.js
@@ -198,7 +198,8 @@ const INVALID_INLINE_STYLE_REGEX =
  * @return {string}
  */
 export function sanitizeHtml(html) {
-  const tagPolicy = htmlSanitizer.makeTagPolicy();
+  const tagPolicy = htmlSanitizer.makeTagPolicy(parsed =>
+    parsed.scheme_ === 'https' ? parsed : null);
   const output = [];
   let ignore = 0;
 

--- a/src/sanitizer.js
+++ b/src/sanitizer.js
@@ -199,7 +199,7 @@ const INVALID_INLINE_STYLE_REGEX =
  */
 export function sanitizeHtml(html) {
   const tagPolicy = htmlSanitizer.makeTagPolicy(parsed =>
-    parsed.scheme_ === 'https' ? parsed : null);
+    parsed.getScheme() === 'https' ? parsed : null);
   const output = [];
   let ignore = 0;
 

--- a/test/functional/test-sanitizer.js
+++ b/test/functional/test-sanitizer.js
@@ -241,6 +241,18 @@ describe('sanitizeHtml', () => {
     expect(sanitizeHtml('<div subscriptions-dialog="">link</div>'))
         .to.equal('<div subscriptions-dialog="">link</div>');
   });
+
+  it('should allow source::src with vaild protocol', () => {
+    expect(sanitizeHtml('<source src="https://www.foo.com/">'))
+        .to.equal('<source src="https://www.foo.com/">');
+  });
+
+  it('should not allow source::src with invaild protocol', () => {
+    expect(sanitizeHtml('<source src="http://www.foo.com">'))
+        .to.equal('<source src="">');
+    expect(sanitizeHtml('<source src="<script>bad()</script>">'))
+        .to.equal('<source src="">');
+  });
 });
 
 

--- a/third_party/caja/html-sanitizer.js
+++ b/third_party/caja/html-sanitizer.js
@@ -990,6 +990,7 @@ html4.ATTRIBS = {
   'select::onfocus': 2,
   'select::required': 0,
   'select::size': 0,
+  'source::src': 1,
   'source::type': 0,
   'table::align': 0,
   'table::bgcolor': 0,

--- a/third_party/caja/patches/0003-add-source-src.patch
+++ b/third_party/caja/patches/0003-add-source-src.patch
@@ -1,5 +1,3 @@
-diff --git a/third_party/caja/html-sanitizer.js b/third_party/caja/html-sanitizer.js
-index d8a2a955a..31401ef49 100644
 --- a/third_party/caja/html-sanitizer.js
 +++ b/third_party/caja/html-sanitizer.js
 @@ -990,6 +990,7 @@ html4.ATTRIBS = {

--- a/third_party/caja/patches/0003-add-source-src.patch
+++ b/third_party/caja/patches/0003-add-source-src.patch
@@ -1,0 +1,12 @@
+diff --git a/third_party/caja/html-sanitizer.js b/third_party/caja/html-sanitizer.js
+index d8a2a955a..31401ef49 100644
+--- a/third_party/caja/html-sanitizer.js
++++ b/third_party/caja/html-sanitizer.js
+@@ -990,6 +990,7 @@ html4.ATTRIBS = {
+   'select::onfocus': 2,
+   'select::required': 0,
+   'select::size': 0,
++  'source::src': 1,
+   'source::type': 0,
+   'table::align': 0,
+   'table::bgcolor': 0,


### PR DESCRIPTION
the `src` attribute of a `source` tag is currently scrubbed by caja. This allows these attributes as long as the protocol is `https`
