### PR TITLE
Initial support for Single Page Story Ads on DoubleClick

### DIFF
--- a/examples/refresh.amp.html
+++ b/examples/refresh.amp.html
@@ -5,7 +5,7 @@
     <title>DoubleClick with Refresh Example</title>
     <link rel="canonical" href="http://nonblocking.io/" >
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
-    <!--<meta name="amp-ad-enable-refresh" content="doubleclick=30">-->
+    <meta name="amp-ad-enable-refresh" content="doubleclick=30">
     <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
     <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
     <script async src="https://cdn.ampproject.org/v0.js"></script>
@@ -21,7 +21,7 @@
   <body>
     <h1>AMP Static Image DFP Reservation.</h1>
     <p>Tests a static image ad in an AMP page.</p>
-    <!--<div class="artificialfold"></div>-->
-    <amp-ad data-slot="/30497360/samfrank_native_v2_a4a" height=50 layout=fixed type=doubleclick width=320></amp-ad>
-    <!--<amp-ad data-slot="/701/wpni.amp.opinions/blog/plum-line" height=250 layout=fixed type=doubleclick width=300></amp-ad>-->
+    <div class="artificialfold"></div>
+    <amp-ad data-slot="/701/wpni.amp.opinions/blog/plum-line" height=250 layout=fixed type=doubleclick width=300></amp-ad>
+    <amp-ad data-slot="/701/wpni.amp.opinions/blog/plum-line" height=250 layout=fixed type=doubleclick width=300></amp-ad>
 </body></html>

--- a/examples/refresh.amp.html
+++ b/examples/refresh.amp.html
@@ -5,7 +5,7 @@
     <title>DoubleClick with Refresh Example</title>
     <link rel="canonical" href="http://nonblocking.io/" >
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
-    <meta name="amp-ad-enable-refresh" content="doubleclick=30">
+    <!--<meta name="amp-ad-enable-refresh" content="doubleclick=30">-->
     <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
     <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
     <script async src="https://cdn.ampproject.org/v0.js"></script>
@@ -21,7 +21,7 @@
   <body>
     <h1>AMP Static Image DFP Reservation.</h1>
     <p>Tests a static image ad in an AMP page.</p>
-    <div class="artificialfold"></div>
-    <amp-ad data-slot="/701/wpni.amp.opinions/blog/plum-line" height=250 layout=fixed type=doubleclick width=300></amp-ad>
-    <amp-ad data-slot="/701/wpni.amp.opinions/blog/plum-line" height=250 layout=fixed type=doubleclick width=300></amp-ad>
+    <!--<div class="artificialfold"></div>-->
+    <amp-ad data-slot="/30497360/samfrank_native_v2_a4a" height=50 layout=fixed type=doubleclick width=320></amp-ad>
+    <!--<amp-ad data-slot="/701/wpni.amp.opinions/blog/plum-line" height=250 layout=fixed type=doubleclick width=300></amp-ad>-->
 </body></html>

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -809,8 +809,9 @@ export class AmpA4A extends AMP.BaseElement {
           return creativeMetaDataDef;
         })
         .catch(error => {
-          switch (error) {
+          switch (error.message || error) {
             case NETWORK_FAILURE: return null;
+            case INVALID_SPSA_RESPONSE:
             case NO_CONTENT_RESPONSE: return {
               minifiedCreative: '',
               customElementExtensions: [],

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -810,13 +810,15 @@ export class AmpA4A extends AMP.BaseElement {
         })
         .catch(error => {
           switch (error.message || error) {
-            case NETWORK_FAILURE: return null;
+            case NETWORK_FAILURE:
+              return null;
             case INVALID_SPSA_RESPONSE:
-            case NO_CONTENT_RESPONSE: return {
-              minifiedCreative: '',
-              customElementExtensions: [],
-              customStylesheets: [],
-            };
+            case NO_CONTENT_RESPONSE:
+              return {
+                minifiedCreative: '',
+                customElementExtensions: [],
+                customStylesheets: [],
+              };
           }
           // If error in chain occurs, report it and return null so that
           // layoutCallback can render via cross domain iframe assuming ad

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -461,7 +461,7 @@ export class AmpA4A extends AMP.BaseElement {
           this.element, this.a4aAnalyticsConfig_, true /* loadAnalytics */);
     }
 
-    this.isSinglePageStoryAd = !!this.element.getAttribute('amp-story');
+    this.isSinglePageStoryAd = this.element.hasAttribute('amp-story');
   }
 
   /** @override */

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -461,7 +461,7 @@ export class AmpA4A extends AMP.BaseElement {
           this.element, this.a4aAnalyticsConfig_, true /* loadAnalytics */);
     }
 
-    this.isSinglePageStoryAd = 'ampStory' in this.element.dataset;
+    this.isSinglePageStoryAd = !!this.element.getAttribute('amp-story');
   }
 
   /** @override */

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -96,6 +96,9 @@ export const NO_CONTENT_RESPONSE = 'NO-CONTENT-RESPONSE';
 /** @type {string} */
 export const NETWORK_FAILURE = 'NETWORK-FAILURE';
 
+/** @type {string} */
+export const INVALID_SPSA_RESPONSE = 'INVALID-SPSA-RESPONSE';
+
 /** @enum {string} */
 export const XORIGIN_MODE = {
   CLIENT_CACHE: 'client_cache',

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -25,11 +25,12 @@ import '../../../amp-ad/0.1/amp-ad';
 import * as analytics from '../../../../src/analytics';
 import * as analyticsExtension from '../../../../src/extension-analytics';
 import * as sinon from 'sinon';
-import {AMP_SIGNATURE_HEADER} from '../signature-verifier';
+import {AMP_SIGNATURE_HEADER, VerificationStatus} from '../signature-verifier';
 import {
   AmpA4A,
   DEFAULT_SAFEFRAME_VERSION,
   IFRAME_SANDBOXING_FLAGS,
+  INVALID_SPSA_RESPONSE,
   RENDERING_TYPE_HEADER,
   SAFEFRAME_VERSION_HEADER,
   SANDBOX_HEADER,
@@ -1683,7 +1684,69 @@ describe('amp-a4a', () => {
       expect(a4a.getAmpAdMetadata(buildCreativeString(metaData)).images.length)
           .to.equal(5);
     });
+
+    it('should throw due to missing CTA type', () => {
+      metaData.ctaUrl = 'http://foo.com';
+      a4a.isSinglePageStoryAd = true;
+      expect(() => a4a.getAmpAdMetadata(buildCreativeString(metaData)))
+          .to.throw(new RegExp(INVALID_SPSA_RESPONSE));
+    });
+
+    it('should throw due to missing outlink', () => {
+      metaData.ctaType = '0';
+      a4a.isSinglePageStoryAd = true;
+      expect(() => a4a.getAmpAdMetadata(buildCreativeString(metaData)))
+          .to.throw(new RegExp(INVALID_SPSA_RESPONSE));
+    });
+
+    it('should set appropriate attributes and return metadata object', () => {
+      metaData.ctaType = '0';
+      metaData.ctaUrl = 'http://foo.com';
+      a4a.isSinglePageStoryAd = true;
+      const actual = a4a.getAmpAdMetadata(buildCreativeString(metaData));
+      const expected = Object.assign({
+        minifiedCreative: testFragments.minimalDocOneStyleSrcDoc,
+      }, metaData);
+      delete expected.ctaType;
+      delete expected.ctaUrl;
+      expect(actual).to.deep.equal(expected);
+      expect(a4a.element.dataset.varsCtatype).to.equal('0');
+      expect(a4a.element.dataset.varsCtaurl).to.equal('http://foo.com');
+    });
+
     // FAILURE cases here
+  });
+
+  describe('#maybeValidateAmpCreative', () => {
+
+    let a4a;
+    let verifier;
+
+    beforeEach(() => {
+      return createIframePromise().then(fixture => {
+        setupForAdTesting(fixture);
+        a4a = new MockA4AImpl(createA4aElement(fixture.doc));
+        verifier = a4a.win['AMP_FAST_FETCH_SIGNATURE_VERIFIER_'] = {};
+        a4a.keysetPromise_ = Promise.resolve();
+        return fixture;
+      });
+    });
+
+    it('should pass verification with story ad', () => {
+      a4a.isSinglePageStoryAd = true;
+      verifier.verify = () => Promise.resolve(VerificationStatus.OK);
+      return a4a.maybeValidateAmpCreative(/* bytes */ 'foo').then(result => {
+        expect(result).to.equal('foo');
+      });
+    });
+
+    it('should throw due to invalid AMP creative with story ad', () => {
+      a4a.isSinglePageStoryAd = true;
+      verifier.verify = () => Promise.resolve(VerificationStatus.UNVERIFIED);
+      return a4a.maybeValidateAmpCreative().catch(error => {
+        expect(error.message).to.equal(INVALID_SPSA_RESPONSE);
+      });
+    });
   });
 
   describe('#renderOutsideViewport', () => {

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -2151,6 +2151,25 @@ describe('amp-a4a', () => {
         })).to.be.calledOnce;
       });
     });
+
+    it('should set isSinglePageStoryAd to false', () => {
+      return createIframePromise().then(fixture => {
+        const element = createA4aElement(fixture.doc);
+        const a4a = new MockA4AImpl(element);
+        a4a.buildCallback();
+        expect(a4a.isSinglePageStoryAd).to.be.false;
+      });
+    });
+
+    it('should set isSinglePageStoryAd to true', () => {
+      return createIframePromise().then(fixture => {
+        const element = createA4aElement(fixture.doc);
+        element.setAttribute('amp-story', 1);
+        const a4a = new MockA4AImpl(element);
+        a4a.buildCallback();
+        expect(a4a.isSinglePageStoryAd).to.be.true;
+      });
+    });
   });
 
   describe('canonical AMP', () => {

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -531,6 +531,8 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     this.win['ampAdGoogleIfiCounter'] = this.win['ampAdGoogleIfiCounter'] || 1;
     this.ifi_ = (this.isRefreshing && this.ifi_) ||
         this.win['ampAdGoogleIfiCounter']++;
+    const pageLayoutBox = this.isSinglePageStoryAd_ ?
+      this.element.getPageLayoutBox() : null;
     return Object.assign({
       'iu': this.element.getAttribute('data-slot'),
       'co': this.jsonTargeting_ &&
@@ -550,7 +552,8 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
           (this.jsonTargeting_ && this.jsonTargeting_['targeting']) || null,
           (this.jsonTargeting_ &&
             this.jsonTargeting_['categoryExclusions']) || null),
-      'spsa': this.isSinglePageStoryAd_ ? '1' : null,
+      'spsa': this.isSinglePageStoryAd_ ?
+        `${pageLayoutBox.width}x${pageLayoutBox.height}` : null,
     }, googleBlockParameters(this));
   }
 

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -445,7 +445,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
       this.preloadSafeframe_ = sfPreloadExpId == '21061135';
     }
 
-    this.isSinglePageStoryAd_ = 'ampSpsa' in this.element.dataset;
+    this.isSinglePageStoryAd_ = 'ampStory' in this.element.dataset;
 
     const viewer = Services.viewerForDoc(this.getAmpDoc());
     viewer.onVisibilityChanged(() => {
@@ -1367,9 +1367,9 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     if (!this.isSinglePageStoryAd_) {
       return metadata;
     }
-    if (metadata && metadata.cta && metadata.outlink) {
-      this.element.setAttribute('data-amp-spsa-cta', metadata.cta);
-      this.element.setAttribute('data-amp-spsa-outlink', metadata.outlink);
+    if (metadata && metadata.ctaType && metadata.ctaUrl) {
+      this.element.setAttribute('data-vars-ctatype', metadata.ctaType);
+      this.element.setAttribute('data-vars-ctaurl', metadata.ctaUrl);
       return metadata;
     }
     throw new Error(INVALID_SPSA_RESPONSE);

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -532,7 +532,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
       'co': this.jsonTargeting_ &&
           this.jsonTargeting_['cookieOptOut'] ? '1' : null,
       'adk': this.adKey_,
-      'sz': this.parameterSize_,
+      'sz': this.isSinglePageStoryAd ? '1x1' : this.parameterSize_,
       'output': 'html',
       'impl': 'ifr',
       'tfcd': tfcd == undefined ? null : tfcd,

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -445,7 +445,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
       this.preloadSafeframe_ = sfPreloadExpId == '21061135';
     }
 
-    this.isSinglePageStoryAd_ = true || 'ampSpsa' in this.element.dataset;
+    this.isSinglePageStoryAd_ = 'ampSpsa' in this.element.dataset;
 
     const viewer = Services.viewerForDoc(this.getAmpDoc());
     viewer.onVisibilityChanged(() => {
@@ -1360,8 +1360,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     }
     // Ensure that this fully drops the creative, and halts any further
     // rendering.
-    Promise.reject(INVALID_SPSA_RESPONSE);
-    return null;
+    throw new Error(INVALID_SPSA_RESPONSE);
   }
 }
 

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -1348,6 +1348,20 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
   }
 
   /** @override */
+  maybeValidateAmpCreative(bytes, headers) {
+    const validationPromise = super.maybeValidateAmpCreative(bytes, headers);
+    if (!this.isSinglePageStoryAd_) {
+      return validationPromise;
+    }
+    return validationPromise.then(result => {
+      if (result) {
+        return result;
+      }
+      throw new Error(INVALID_SPSA_RESPONSE);
+    });
+  }
+
+  /** @override */
   getAmpAdMetadata(creative) {
     const metadata = super.getAmpAdMetadata(creative);
     if (!this.isSinglePageStoryAd_) {
@@ -1358,8 +1372,6 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
       this.element.setAttribute('data-amp-spsa-outlink', metadata.outlink);
       return metadata;
     }
-    // Ensure that this fully drops the creative, and halts any further
-    // rendering.
     throw new Error(INVALID_SPSA_RESPONSE);
   }
 }

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -482,6 +482,12 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
       });
     });
 
+    it('handles Single Page Story Ad parameter', () => {
+      const impl = new AmpAdNetworkDoubleclickImpl(element);
+      impl.isSinglePageStoryAd_ = true;
+      expect(impl.getAdUrl()).to.eventually.match(/(\?|&)spsa=\d+x\d+(&|$)/);
+    });
+
     it('handles tagForChildDirectedTreatment', () => {
       element.setAttribute('json', '{"tagForChildDirectedTreatment": 1}');
       new AmpAd(element).upgradeCallback();

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -26,7 +26,6 @@ import {
 import {
   AmpA4A,
   CREATIVE_SIZE_HEADER,
-  INVALID_SPSA_RESPONSE,
   XORIGIN_MODE,
   signatureVerifierFor,
 } from '../../../amp-a4a/0.1/amp-a4a';
@@ -1267,105 +1266,6 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
       element.setAttribute('data-force-safeframe', '1');
       expect(new AmpAdNetworkDoubleclickImpl(element)
           .getNonAmpCreativeRenderingMethod()).to.equal(XORIGIN_MODE.SAFEFRAME);
-    });
-  });
-
-  describe('#getAmpAdMetadata', () => {
-    let sandbox;
-    let baseMetadata;
-    const outlink = 'http://www.myadlandingpage.com/1234';
-
-    beforeEach(() => {
-      element = createElementWithAttributes(doc, 'amp-ad', {
-        'width': '200',
-        'height': '50',
-        'type': 'doubleclick',
-      });
-      doc.body.appendChild(element);
-      impl = new AmpAdNetworkDoubleclickImpl(element);
-      baseMetadata = {customElementExtensions: ['amp-foo']};
-      sandbox = sinon.sandbox.create();
-    });
-
-    afterEach(() => sandbox.restore());
-
-    it('should pass the same object as given by super', () => {
-      sandbox.stub(AmpA4A.prototype, 'getAmpAdMetadata').callsFake(
-          () => baseMetadata);
-      expect(impl.getAmpAdMetadata()).to.deep.equal(baseMetadata);
-    });
-
-    it('should throw due to missing CTA type', () => {
-      baseMetadata.ctaUrl = outlink;
-      sandbox.stub(AmpA4A.prototype, 'getAmpAdMetadata').callsFake(
-          () => baseMetadata);
-      impl.isSinglePageStoryAd_ = true;
-      expect(() => impl.getAmpAdMetadata())
-          .to.throw(new RegExp(INVALID_SPSA_RESPONSE));
-    });
-
-    it('should throw due to missing outlink', () => {
-      baseMetadata.ctaType = '0';
-      sandbox.stub(AmpA4A.prototype, 'getAmpAdMetadata').callsFake(
-          () => baseMetadata);
-      impl.isSinglePageStoryAd_ = true;
-      expect(() => impl.getAmpAdMetadata())
-          .to.throw(new RegExp(INVALID_SPSA_RESPONSE));
-    });
-
-    it('should set appropriate attributes and return metadata object', () => {
-      baseMetadata.ctaUrl = outlink;
-      baseMetadata.ctaType = '0';
-      sandbox.stub(AmpA4A.prototype, 'getAmpAdMetadata').callsFake(
-          () => baseMetadata);
-      impl.isSinglePageStoryAd_ = true;
-      expect(impl.getAmpAdMetadata())
-          .to.deep.equal(baseMetadata);
-      expect(element.dataset.varsCtatype).to.equal('0');
-      expect(element.dataset.varsCtaurl).to.equal(outlink);
-    });
-  });
-
-  describe('#maybeValidateAmpCreative', () => {
-    let sandbox;
-
-    beforeEach(() => {
-      element = createElementWithAttributes(doc, 'amp-ad', {
-        'width': '200',
-        'height': '50',
-        'type': 'doubleclick',
-      });
-      doc.body.appendChild(element);
-      impl = new AmpAdNetworkDoubleclickImpl(element);
-      sandbox = sinon.sandbox.create();
-    });
-
-    afterEach(() => sandbox.restore());
-
-    it('should pass same return value as given by super -- no SPSA', () => {
-      sandbox.stub(AmpA4A.prototype, 'maybeValidateAmpCreative').callsFake(
-          () => Promise.resolve('foo'));
-      return impl.maybeValidateAmpCreative().then(result => {
-        expect(result).to.equal('foo');
-      });
-    });
-
-    it('should pass same return value as given by super -- with SPSA', () => {
-      sandbox.stub(AmpA4A.prototype, 'maybeValidateAmpCreative').callsFake(
-          () => Promise.resolve('foo'));
-      impl.isSinglePageStoryAd_ = true;
-      return impl.maybeValidateAmpCreative().then(result => {
-        expect(result).to.equal('foo');
-      });
-    });
-
-    it('should throw due to invalid AMP creative', () => {
-      sandbox.stub(AmpA4A.prototype, 'maybeValidateAmpCreative').callsFake(
-          () => Promise.resolve(null));
-      impl.isSinglePageStoryAd_ = true;
-      return impl.maybeValidateAmpCreative().catch(error => {
-        expect(error.message).to.equal(INVALID_SPSA_RESPONSE);
-      });
     });
   });
 });

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -484,7 +484,9 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
     it('handles Single Page Story Ad parameter', () => {
       const impl = new AmpAdNetworkDoubleclickImpl(element);
       impl.isSinglePageStoryAd_ = true;
-      expect(impl.getAdUrl()).to.eventually.match(/(\?|&)spsa=\d+x\d+(&|$)/);
+      const urlPromise = impl.getAdUrl();
+      expect(urlPromise).to.eventually.match(/(\?|&)spsa=\d+x\d+(&|$)/);
+      expect(urlPromise).to.eventually.match(/(\?|&)sz=1x1(&|$)/);
     });
 
     it('handles tagForChildDirectedTreatment', () => {

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -1266,7 +1266,7 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
 
   describe('#getAmpAdMetadata', () => {
     let sandbox;
-    let baseMetadata = {customElementExtensions: ['amp-foo']};
+    let baseMetadata;
     const outlink = 'http://www.myadlandingpage.com/1234';
     beforeEach(() => {
       element = createElementWithAttributes(doc, 'amp-ad', {
@@ -1283,7 +1283,7 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
     afterEach(() => sandbox.restore());
 
     it('should pass the same object as given by super', () => {
-      sandbox.stub(impl.prototype, 'getAmpAdMetadata').callsFake(
+      sandbox.stub(AmpA4A.prototype, 'getAmpAdMetadata').callsFake(
           unusedCreative => baseMetadata);
       expect(impl.getAmpAdMetadata('unusedCreative'))
           .to.deep.equal(baseMetadata);
@@ -1291,26 +1291,26 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
 
     it('should throw due to missing CTA', () => {
       baseMetadata.outlink = outlink;
-      sandbox.stub(impl.prototype, 'getAmpAdMetadata').callsFake(
+      sandbox.stub(AmpA4A.prototype, 'getAmpAdMetadata').callsFake(
           unusedCreative => baseMetadata);
       impl.isSinglePageStoryAd_ = true;
-      expect(impl.getAmpAdMetadata('unusedCreative'))
-          .to.throw(INVALID_SPSA_RESPONSE);
+      expect(() => impl.getAmpAdMetadata('unusedCreative'))
+          .to.throw(new RegExp(INVALID_SPSA_RESPONSE));
     });
 
     it('should throw due to missing outlink', () => {
       baseMetadata.cta = '0';
-      sandbox.stub(impl.prototype, 'getAmpAdMetadata').callsFake(
+      sandbox.stub(AmpA4A.prototype, 'getAmpAdMetadata').callsFake(
           unusedCreative => baseMetadata);
       impl.isSinglePageStoryAd_ = true;
-      expect(impl.getAmpAdMetadata('unusedCreative'))
-          .to.throw(INVALID_SPSA_RESPONSE);
+      expect(() => impl.getAmpAdMetadata('unusedCreative'))
+          .to.throw(new RegExp(INVALID_SPSA_RESPONSE));
     });
 
     it('should set appropriate attributes and return metadata object', () => {
       baseMetadata.outlink = outlink;
       baseMetadata.cta = '0';
-      sandbox.stub(impl.prototype, 'getAmpAdMetadata').callsFake(
+      sandbox.stub(AmpA4A.prototype, 'getAmpAdMetadata').callsFake(
           unusedCreative => baseMetadata);
       impl.isSinglePageStoryAd_ = true;
       expect(impl.getAmpAdMetadata('unusedCreative'))

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -1289,8 +1289,8 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
       expect(impl.getAmpAdMetadata()).to.deep.equal(baseMetadata);
     });
 
-    it('should throw due to missing CTA', () => {
-      baseMetadata.outlink = outlink;
+    it('should throw due to missing CTA type', () => {
+      baseMetadata.ctaUrl = outlink;
       sandbox.stub(AmpA4A.prototype, 'getAmpAdMetadata').callsFake(
           () => baseMetadata);
       impl.isSinglePageStoryAd_ = true;
@@ -1299,7 +1299,7 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
     });
 
     it('should throw due to missing outlink', () => {
-      baseMetadata.cta = '0';
+      baseMetadata.ctaType = '0';
       sandbox.stub(AmpA4A.prototype, 'getAmpAdMetadata').callsFake(
           () => baseMetadata);
       impl.isSinglePageStoryAd_ = true;
@@ -1308,15 +1308,15 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
     });
 
     it('should set appropriate attributes and return metadata object', () => {
-      baseMetadata.outlink = outlink;
-      baseMetadata.cta = '0';
+      baseMetadata.ctaUrl = outlink;
+      baseMetadata.ctaType = '0';
       sandbox.stub(AmpA4A.prototype, 'getAmpAdMetadata').callsFake(
           () => baseMetadata);
       impl.isSinglePageStoryAd_ = true;
       expect(impl.getAmpAdMetadata())
           .to.deep.equal(baseMetadata);
-      expect(element.dataset.ampSpsaCta).to.equal('0');
-      expect(element.dataset.ampSpsaOutlink).to.equal(outlink);
+      expect(element.dataset.varsCtatype).to.equal('0');
+      expect(element.dataset.varsCtaurl).to.equal(outlink);
     });
   });
 


### PR DESCRIPTION
In anticipation of Single Page Story Ads (SPSA) in DoubleClick, this PR does the following:

- If the slot has been marked by the runtime with the `amp-story` attribute, the slot should be aware that it is in an SPSA situation.
- If in SPSA situation, add `spsa=${viewport_width}x${viewport_height}` to ad request.
- If in SPSA situation and invalid AMP creative is served, throw error.
- If in SPSA situation, look for the call to action (CTA) enum and the outlink in the metadata object.
- If both properties are found on the metadata object, add them to appropriate data attributes on the slot, otherwise throw error.