### PR TITLE
🐛Assert only when rotate to fullscreen is enabled

### DIFF
--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -468,11 +468,13 @@ class VideoEntry {
    */
   hasAutoFullscreen_() {
     const {element} = this.video;
-    user().assert(this.video.isInteractive(),
+    if (!element.hasAttribute(VideoAttributes.ROTATE_TO_FULLSCREEN)) {
+      return false;
+    }
+    return user().assert(this.video.isInteractive(),
         'Only interactive videos are allowed to enter fullscreen on rotate.',
-        'Set the `controls` attribute to enable.',
+        'Set the `controls` attribute on %s to enable.',
         this.video);
-    return element.hasAttribute(VideoAttributes.ROTATE_TO_FULLSCREEN);
   }
 
   /**

--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -474,7 +474,7 @@ class VideoEntry {
     return user().assert(this.video.isInteractive(),
         'Only interactive videos are allowed to enter fullscreen on rotate.',
         'Set the `controls` attribute on %s to enable.',
-        this.video);
+        element);
   }
 
   /**


### PR DESCRIPTION
(Almost causes a 🔥.)

Also correctly uses `%s` in assertion.