### PR TITLE
Fix youtube test console error

### DIFF
--- a/extensions/amp-youtube/0.1/test/test-amp-youtube.js
+++ b/extensions/amp-youtube/0.1/test/test-amp-youtube.js
@@ -137,7 +137,7 @@ describes.realWin('amp-youtube', {
     it('should pass data-param-* attributes to the iframe src', () => {
       return getYt({
         'data-videoid': datasource,
-        'data-param-autoplay': '1',
+        'autoplay': '1',
         'data-param-my-param': 'hello world',
       }).then(yt => {
         const iframe = yt.querySelector('iframe');


### PR DESCRIPTION
Tests should be using `autoplay` instead of `data-param-autoplay` per https://github.com/ampproject/amphtml/pull/3794. 