### PR TITLE
🏗Forbid importing sinon

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -43,7 +43,7 @@
     "amphtml-internal/no-export-side-effect": 2,
     "amphtml-internal/no-for-of-statement": 2,
     "amphtml-internal/no-global": 0,
-    "amphtml-internal/no-import": 0,
+    "amphtml-internal/no-import": 2,
     "amphtml-internal/no-spread": 2,
     "amphtml-internal/no-style-property-setting": 2,
     "amphtml-internal/query-selector": 2,

--- a/.eslintrc
+++ b/.eslintrc
@@ -43,6 +43,7 @@
     "amphtml-internal/no-export-side-effect": 2,
     "amphtml-internal/no-for-of-statement": 2,
     "amphtml-internal/no-global": 0,
+    "amphtml-internal/no-import": 0,
     "amphtml-internal/no-spread": 2,
     "amphtml-internal/no-style-property-setting": 2,
     "amphtml-internal/query-selector": 2,

--- a/ads/google/a4a/test/test-google-ads-a4a-config.js
+++ b/ads/google/a4a/test/test-google-ads-a4a-config.js
@@ -86,7 +86,7 @@ describe('a4a_config', () => {
   let element;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     rand = sandbox.stub(Math, 'random');
     win = {
       AMP_MODE: {
@@ -310,7 +310,7 @@ describe('a4a_config hash param parsing', () => {
   let element;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     win = {
       AMP_MODE: {
         localDev: true,

--- a/ads/google/a4a/test/test-google-ads-a4a-config.js
+++ b/ads/google/a4a/test/test-google-ads-a4a-config.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {Services} from '../../../../src/services';
 import {
   googleAdsIsA4AEnabled,

--- a/ads/google/a4a/test/test-line-delimited-response-handler.js
+++ b/ads/google/a4a/test/test-line-delimited-response-handler.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {
   lineDelimitedStreamer,
   metaJsonCreativeGrouper,

--- a/ads/google/a4a/test/test-line-delimited-response-handler.js
+++ b/ads/google/a4a/test/test-line-delimited-response-handler.js
@@ -84,7 +84,7 @@ describe('#line-delimited-response-handler', () => {
   }
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     chunkHandlerStub = sandbox.stub();
   });
 
@@ -146,7 +146,7 @@ describe('#line-delimited-response-handler', () => {
     }
 
     beforeEach(() => {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.sandbox;
       readStub = sandbox.stub();
       response = {
         text: () => Promise.resolve(),

--- a/ads/google/a4a/test/test-performance.js
+++ b/ads/google/a4a/test/test-performance.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {
   BaseLifecycleReporter,
   GoogleAdLifecycleReporter,

--- a/ads/google/a4a/test/test-performance.js
+++ b/ads/google/a4a/test/test-performance.js
@@ -74,7 +74,7 @@ describe('GoogleAdLifecycleReporter', () => {
   let emitPingSpy;
   let iframe;
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     emitPingSpy = sandbox.spy(GoogleAdLifecycleReporter.prototype, 'emitPing_');
     iframe = createIframePromise(false).then(iframeFixture => {
       const win = iframeFixture.win;

--- a/ads/google/a4a/test/test-utils.js
+++ b/ads/google/a4a/test/test-utils.js
@@ -16,7 +16,6 @@
 
 import '../../../../extensions/amp-ad/0.1/amp-ad-ui';
 import '../../../../extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler';
-import * as sinon from 'sinon';
 import {
   EXPERIMENT_ATTRIBUTE,
   TRUNCATION_PARAM,

--- a/ads/google/a4a/test/test-utils.js
+++ b/ads/google/a4a/test/test-utils.js
@@ -234,7 +234,7 @@ describe('Google A4A utils', () => {
     let sandbox;
 
     beforeEach(() => {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.sandbox;
     });
 
     afterEach(() => {
@@ -737,7 +737,7 @@ describe('Google A4A utils', () => {
     let sandbox;
 
     beforeEach(() => {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.sandbox;
       return createIframePromise().then(fixture => {
         setupForAdTesting(fixture);
         const element = createElementWithAttributes(fixture.doc, 'amp-a4a', {

--- a/ads/google/test/test-doubleclick.js
+++ b/ads/google/test/test-doubleclick.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as sinon from 'sinon';
 import {createServedIframe} from '../../../testing/iframe';
 import {dev} from '../../../src/log';
 import {doubleclick} from '../doubleclick';

--- a/ads/google/test/test-doubleclick.js
+++ b/ads/google/test/test-doubleclick.js
@@ -107,7 +107,7 @@ describe('doubleclick delayed fetch white list deprecation', () => {
   let sandbox;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     sandbox.stub(dev(), 'error');
   });
 

--- a/build-system/eslint-rules/no-import.js
+++ b/build-system/eslint-rules/no-import.js
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+const imports = ['sinon'];
+
+module.exports = function(context) {
+  return {
+    ImportDeclaration(node) {
+      const name = node.source.value;
+      if (imports.includes(name)) {
+        context.report(node, `Importing ${name} is forbidden.`);
+      }
+    },
+  };
+};

--- a/extensions/amp-a4a/0.1/test/test-a4a-integration.js
+++ b/extensions/amp-a4a/0.1/test/test-a4a-integration.js
@@ -88,7 +88,7 @@ describe('integration test: a4a', () => {
   let a4aElement;
   let a4aRegistry;
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     a4aRegistry = getA4ARegistry();
     a4aRegistry['mock'] = () => {return true;};
     return createIframePromise().then(f => {

--- a/extensions/amp-a4a/0.1/test/test-a4a-integration.js
+++ b/extensions/amp-a4a/0.1/test/test-a4a-integration.js
@@ -20,7 +20,6 @@
 // AmpAd is not loaded already, so we need to load it separately.
 import '../../../amp-ad/0.1/amp-ad';
 import '../../../amp-ad/0.1/amp-ad-xorigin-iframe-handler';
-import * as sinon from 'sinon';
 import {AMP_SIGNATURE_HEADER} from '../signature-verifier';
 import {FetchMock, networkFailure} from './fetch-mock';
 import {MockA4AImpl, TEST_URL} from './utils';

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -24,7 +24,6 @@ import '../../../amp-ad/0.1/amp-ad';
 // methods in tests.
 import * as analytics from '../../../../src/analytics';
 import * as analyticsExtension from '../../../../src/extension-analytics';
-import * as sinon from 'sinon';
 import {AMP_SIGNATURE_HEADER} from '../signature-verifier';
 import {
   AmpA4A,

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -70,7 +70,7 @@ describe('amp-a4a', () => {
   let getResourceStub;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     fetchMock = null;
     getSigningServiceNamesMock = sandbox.stub(AmpA4A.prototype,
         'getSigningServiceNames');
@@ -2085,7 +2085,7 @@ describe('amp-a4a', () => {
     let sandbox;
 
     beforeEach(() => {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.sandbox;
     });
 
     afterEach(() => {
@@ -2136,7 +2136,7 @@ describe('amp-a4a', () => {
     let sandbox;
 
     beforeEach(() => {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.sandbox;
     });
 
     afterEach(() => {

--- a/extensions/amp-a4a/0.1/test/test-cryptographic-validator.js
+++ b/extensions/amp-a4a/0.1/test/test-cryptographic-validator.js
@@ -39,7 +39,7 @@ describes.realWin('CryptographicValidator', realWinConfig, env => {
 
   beforeEach(() => {
     validator = new CryptographicValidator();
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     userErrorStub = sandbox.stub(user(), 'error');
   });
 

--- a/extensions/amp-a4a/0.1/test/test-cryptographic-validator.js
+++ b/extensions/amp-a4a/0.1/test/test-cryptographic-validator.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {AdResponseType, ValidatorResult} from '../amp-ad-type-defs';
 import {
   CryptographicValidator,

--- a/extensions/amp-a4a/0.1/test/test-refresh-manager.js
+++ b/extensions/amp-a4a/0.1/test/test-refresh-manager.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {
   DATA_ATTR_NAME,
   DATA_MANAGER_ID_NAME,

--- a/extensions/amp-a4a/0.1/test/test-refresh-manager.js
+++ b/extensions/amp-a4a/0.1/test/test-refresh-manager.js
@@ -42,7 +42,7 @@ describe('refresh-manager', () => {
   };
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     mockA4a = {
       win: window,
       element: getTestElement(),

--- a/extensions/amp-a4a/0.1/test/test-signature-verifier.js
+++ b/extensions/amp-a4a/0.1/test/test-signature-verifier.js
@@ -16,8 +16,6 @@
 
 // TODO(@jridgewell, #11081): fix linter to allow fixing weird indentation
 
-import * as sinon from 'sinon';
-
 import {SignatureVerifier, VerificationStatus} from '../signature-verifier';
 import {base64EncodeFromBytes} from '../../../../src/utils/base64';
 import {dev, user} from '../../../../src/log';

--- a/extensions/amp-access/0.1/test/test-amp-access-client.js
+++ b/extensions/amp-access/0.1/test/test-amp-access-client.js
@@ -16,7 +16,6 @@
 
 import * as lolex from 'lolex';
 import * as mode from '../../../../src/mode';
-import * as sinon from 'sinon';
 import {AccessClientAdapter} from '../amp-access-client';
 
 

--- a/extensions/amp-access/0.1/test/test-amp-access-server-jwt.js
+++ b/extensions/amp-access/0.1/test/test-amp-access-server-jwt.js
@@ -15,7 +15,6 @@
  */
 
 import * as lolex from 'lolex';
-import * as sinon from 'sinon';
 import {AccessServerJwtAdapter} from '../amp-access-server-jwt';
 import {getMode} from '../../../../src/mode';
 import {isUserErrorMessage} from '../../../../src/log';

--- a/extensions/amp-access/0.1/test/test-amp-access.js
+++ b/extensions/amp-access/0.1/test/test-amp-access.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {AccessClientAdapter} from '../amp-access-client';
 import {AccessService} from '../amp-access';
 import {AmpEvents} from '../../../../src/amp-events';

--- a/extensions/amp-access/0.1/test/test-amp-login-done-dialog.js
+++ b/extensions/amp-access/0.1/test/test-amp-login-done-dialog.js
@@ -29,7 +29,7 @@ describe('LoginDoneDialog', () => {
   let closeButton;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     clock = sandbox.useFakeTimers();
 
     messageListener = undefined;

--- a/extensions/amp-access/0.1/test/test-amp-login-done-dialog.js
+++ b/extensions/amp-access/0.1/test/test-amp-login-done-dialog.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {LoginDoneDialog, buildLangSelector} from '../amp-login-done-dialog';
 
 

--- a/extensions/amp-access/0.1/test/test-jwt.js
+++ b/extensions/amp-access/0.1/test/test-jwt.js
@@ -34,7 +34,7 @@ describe('JwtHelper', () => {
   let helper;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     helper = new JwtHelper(window);
   });
 

--- a/extensions/amp-access/0.1/test/test-jwt.js
+++ b/extensions/amp-access/0.1/test/test-jwt.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {JwtHelper} from '../jwt';
 import {pemToBytes} from '../../../../src/utils/pem';
 

--- a/extensions/amp-access/0.1/test/test-login-dialog.js
+++ b/extensions/amp-access/0.1/test/test-login-dialog.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {Services} from '../../../../src/services';
 import {
   WebLoginDialog,

--- a/extensions/amp-access/0.1/test/test-login-dialog.js
+++ b/extensions/amp-access/0.1/test/test-login-dialog.js
@@ -32,7 +32,7 @@ describes.sandboxed('ViewerLoginDialog', {}, () => {
   let windowApi;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
 
     viewer = {
       getParam: param => {

--- a/extensions/amp-ad-exit/0.1/test/test-amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/test/test-amp-ad-exit.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {
   ANALYTICS_IFRAME_TRANSPORT_CONFIG,
 } from '../../../amp-analytics/0.1/vendors';

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-adsense-a4a-config.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-adsense-a4a-config.js
@@ -33,7 +33,7 @@ describe('adsense-a4a-config', () => {
   let testFixture;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     mockWin = {
       location: parseUrl('https://nowhere.org/a/place/page.html?s=foo&q=bar'),
       document: {

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-adsense-a4a-config.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-adsense-a4a-config.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {EXPERIMENT_ATTRIBUTE} from '../../../../ads/google/a4a/utils';
 import {
   URL_EXPERIMENT_MAPPING,

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-a4a-config.js
@@ -40,7 +40,7 @@ describe('doubleclick-a4a-config', () => {
   let testFixture;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     mockWin = {
       location: parseUrl('https://nowhere.org/a/place/page.html?s=foo&q=bar'),
       crypto: {

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-a4a-config.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {
   DOUBLECLICK_EXPERIMENT_FEATURE,
   DOUBLECLICK_UNCONDITIONED_EXPERIMENTS,

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-sra.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-sra.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import '../../../amp-ad/0.1/amp-ad';
-import * as sinon from 'sinon';
 import {
   AmpA4A,
   EXPERIMENT_FEATURE_HEADER_NAME,

--- a/extensions/amp-ad/0.1/test/test-amp-ad-custom.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-custom.js
@@ -26,7 +26,7 @@ describe('Amp custom ad', () => {
   let sandbox;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
   });
 
   afterEach(() => {

--- a/extensions/amp-ad/0.1/test/test-amp-ad-custom.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-custom.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {AmpAdCustom} from '../amp-ad-custom';
 import {LayoutPriority} from '../../../../src/layout';
 import {Services} from '../../../../src/services';

--- a/extensions/amp-ad/0.1/test/test-amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-xorigin-iframe-handler.js
@@ -37,7 +37,7 @@ describe('amp-ad-xorigin-iframe-handler', () => {
   let testIndex = 0;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     const ampdocService = Services.ampdocServiceFor(window);
     const ampdoc = ampdocService.getAmpDoc();
     const adElement = document.createElement('container-element');

--- a/extensions/amp-ad/0.1/test/test-amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-xorigin-iframe-handler.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {AmpAdUIHandler} from '../amp-ad-ui';
 import {AmpAdXOriginIframeHandler} from '../amp-ad-xorigin-iframe-handler';
 import {BaseElement} from '../../../../src/base-element';

--- a/extensions/amp-analytics/0.1/test/test-events.js
+++ b/extensions/amp-analytics/0.1/test/test-events.js
@@ -15,7 +15,6 @@
  */
 
 import * as lolex from 'lolex';
-import * as sinon from 'sinon';
 import {AmpdocAnalyticsRoot} from '../analytics-root';
 import {
   AnalyticsEvent,

--- a/extensions/amp-analytics/0.1/test/test-iframe-transport-client.js
+++ b/extensions/amp-analytics/0.1/test/test-iframe-transport-client.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {
   IframeTransportClient, IframeTransportContext,
 } from '../../../../3p/iframe-transport-client';

--- a/extensions/amp-analytics/0.1/test/test-iframe-transport-client.js
+++ b/extensions/amp-analytics/0.1/test/test-iframe-transport-client.js
@@ -33,7 +33,7 @@ describe('iframe-transport-client', () => {
   let sentinel;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     sentinel = createUniqueId();
     window.name = JSON.stringify({sentinel, type: 'some-vendor'});
     iframeTransportClient = new IframeTransportClient(window);

--- a/extensions/amp-analytics/0.1/test/test-instrumentation.js
+++ b/extensions/amp-analytics/0.1/test/test-instrumentation.js
@@ -298,7 +298,7 @@ describe('amp-analytics.instrumentation OLD', function() {
   let ampdoc;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     const docState = Services.documentStateFor(window);
     sandbox.stub(docState, 'isHidden').callsFake(() => false);
     ampdoc = new AmpDocSingle(window);

--- a/extensions/amp-analytics/0.1/test/test-instrumentation.js
+++ b/extensions/amp-analytics/0.1/test/test-instrumentation.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {AmpDocSingle} from '../../../../src/service/ampdoc-impl';
 import {
   AnalyticsEventType,

--- a/extensions/amp-analytics/0.1/test/test-transport.js
+++ b/extensions/amp-analytics/0.1/test/test-transport.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {Transport, sendRequest, sendRequestUsingIframe} from '../transport';
 import {adopt} from '../../../../src/runtime';
 import {loadPromise} from '../../../../src/event-helper';

--- a/extensions/amp-analytics/0.1/test/test-transport.js
+++ b/extensions/amp-analytics/0.1/test/test-transport.js
@@ -24,7 +24,7 @@ describe('amp-analytics.transport', () => {
 
   let sandbox;
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
   });
 
   afterEach(() => {

--- a/extensions/amp-analytics/0.1/test/test-variables.js
+++ b/extensions/amp-analytics/0.1/test/test-variables.js
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {
   ExpansionOptions,
   installVariableService,

--- a/extensions/amp-analytics/0.1/test/test-variables.js
+++ b/extensions/amp-analytics/0.1/test/test-variables.js
@@ -31,7 +31,7 @@ describe('amp-analytics.VariableService', function() {
   let variables, sandbox;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     installVariableService(window);
     variables = variableServiceFor(window);
   });

--- a/extensions/amp-animation/0.1/test/test-web-animations.js
+++ b/extensions/amp-animation/0.1/test/test-web-animations.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {
   Builder,
   WebAnimationRunner,

--- a/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
@@ -19,7 +19,6 @@
  *               because it requires building web-worker binary.
  */
 
-import * as sinon from 'sinon';
 import {AmpEvents} from '../../../../../src/amp-events';
 import {Bind} from '../../bind-impl';
 import {BindEvents} from '../../bind-events';

--- a/extensions/amp-bind/0.1/test/test-bind-evaluator.js
+++ b/extensions/amp-bind/0.1/test/test-bind-evaluator.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {BindEvaluator, BindingDef} from '../bind-evaluator';
 import {BindExpression} from '../bind-expression';
 

--- a/extensions/amp-bind/0.1/test/test-bind-evaluator.js
+++ b/extensions/amp-bind/0.1/test/test-bind-evaluator.js
@@ -23,7 +23,7 @@ describe('BindEvaluator', () => {
 
   beforeEach(() => {
     evaluator = new BindEvaluator();
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
   });
 
   afterEach(() => {

--- a/extensions/amp-carousel/0.1/test/test-slidescroll.js
+++ b/extensions/amp-carousel/0.1/test/test-slidescroll.js
@@ -564,7 +564,7 @@ describes.realWin('SlideScroll', {
 
   describe('Looping', () => {
     beforeEach(() => {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.sandbox;
     });
 
     afterEach(() => {

--- a/extensions/amp-carousel/0.1/test/test-slidescroll.js
+++ b/extensions/amp-carousel/0.1/test/test-slidescroll.js
@@ -15,7 +15,6 @@
  */
 
 import '../amp-carousel';
-import * as sinon from 'sinon';
 
 
 describes.realWin('SlideScroll', {

--- a/extensions/amp-form/0.1/test/test-amp-form.js
+++ b/extensions/amp-form/0.1/test/test-amp-form.js
@@ -16,7 +16,6 @@
 
 import '../../../amp-mustache/0.1/amp-mustache';
 import '../../../amp-selector/0.1/amp-selector';
-import * as sinon from 'sinon';
 import {AmpEvents} from '../../../../src/amp-events';
 import {
   AmpForm,

--- a/extensions/amp-gwd-animation/0.1/test/test-amp-gwd-animation.js
+++ b/extensions/amp-gwd-animation/0.1/test/test-amp-gwd-animation.js
@@ -91,7 +91,7 @@ describes.sandboxed('AMP GWD Animation', {}, () => {
         // part of the service's public API, but stubbing it here is the only
         // way to verify it is called. Revisit if another solution becomes
         // available.
-        sandbox = sinon.sandbox.create();
+        sandbox = sinon.sandbox;
         initializeSpy =
             sandbox.spy(AmpGwdRuntimeService.prototype, 'initialize_');
       });

--- a/extensions/amp-gwd-animation/0.1/test/test-amp-gwd-animation.js
+++ b/extensions/amp-gwd-animation/0.1/test/test-amp-gwd-animation.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as sinon from 'sinon';
 import {
   ANIMATIONS_DISABLED_CLASS,
   AmpGwdRuntimeService,

--- a/extensions/amp-iframe/0.1/test/test-amp-iframe.js
+++ b/extensions/amp-iframe/0.1/test/test-amp-iframe.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 
 import {ActionTrust} from '../../../../src/action-trust';
 import {

--- a/extensions/amp-live-list/0.1/test/test-amp-live-list.js
+++ b/extensions/amp-live-list/0.1/test/test-amp-live-list.js
@@ -36,7 +36,7 @@ describes.realWin('amp-live-list', {
 
   beforeEach(() => {
     win = env.win;
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     ampdoc = new AmpDocSingle(win);
     elem = document.createElement('amp-live-list');
     elem.getAmpDoc = () => ampdoc;

--- a/extensions/amp-live-list/0.1/test/test-amp-live-list.js
+++ b/extensions/amp-live-list/0.1/test/test-amp-live-list.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {AmpDocSingle} from '../../../../src/service/ampdoc-impl';
 import {AmpEvents} from '../../../../src/amp-events';
 import {AmpLiveList, getNumberMaxOrDefault} from '../amp-live-list';

--- a/extensions/amp-live-list/0.1/test/test-live-list-manager.js
+++ b/extensions/amp-live-list/0.1/test/test-live-list-manager.js
@@ -32,7 +32,7 @@ describes.fakeWin('LiveListManager', {amp: true}, env => {
   let sandbox;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     win = env.win;
     doc = win.document;
     ampdoc = env.ampdoc;

--- a/extensions/amp-live-list/0.1/test/test-poller.js
+++ b/extensions/amp-live-list/0.1/test/test-poller.js
@@ -15,7 +15,6 @@
  */
 
 
-import * as sinon from 'sinon';
 import {Poller} from '../poller';
 import {Services} from '../../../../src/services';
 

--- a/extensions/amp-live-list/0.1/test/test-poller.js
+++ b/extensions/amp-live-list/0.1/test/test-poller.js
@@ -27,7 +27,7 @@ describe('Poller', () => {
   const timer = Services.timerFor(window);
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     clock = sandbox.useFakeTimers();
     const obj = {
       work() {},

--- a/extensions/amp-sidebar/0.1/test/test-toolbar.js
+++ b/extensions/amp-sidebar/0.1/test/test-toolbar.js
@@ -99,7 +99,7 @@ describe('amp-sidebar - toolbar', () => {
   }
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
   });
 
   afterEach(() => {

--- a/extensions/amp-sidebar/0.1/test/test-toolbar.js
+++ b/extensions/amp-sidebar/0.1/test/test-toolbar.js
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {AmpDocSingle} from '../../../../src/service/ampdoc-impl';
 import {Services} from '../../../../src/services';
 import {Toolbar} from '../toolbar';

--- a/extensions/amp-story/0.1/test/test-media-tasks.js
+++ b/extensions/amp-story/0.1/test/test-media-tasks.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as sinon from 'sinon';
 import {
   LoadTask,
   MuteTask,

--- a/extensions/amp-story/0.1/test/test-media-tasks.js
+++ b/extensions/amp-story/0.1/test/test-media-tasks.js
@@ -33,7 +33,7 @@ describes.realWin('media-tasks', {}, () => {
   let vsyncApi;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     el = document.createElement('video');
 
     // Mock vsync

--- a/extensions/amp-story/1.0/test/test-media-tasks.js
+++ b/extensions/amp-story/1.0/test/test-media-tasks.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as sinon from 'sinon';
 import {
   LoadTask,
   MuteTask,

--- a/extensions/amp-story/1.0/test/test-media-tasks.js
+++ b/extensions/amp-story/1.0/test/test-media-tasks.js
@@ -33,7 +33,7 @@ describes.realWin('media-tasks', {}, () => {
   let vsyncApi;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     el = document.createElement('video');
 
     // Mock vsync

--- a/extensions/amp-subscriptions/0.1/test/test-local-subscription-rendering.js
+++ b/extensions/amp-subscriptions/0.1/test/test-local-subscription-rendering.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as sinon from 'sinon';
 import {Dialog} from '../dialog';
 import {Entitlement} from '../entitlement';
 import {LocalSubscriptionPlatformRenderer} from '../local-subscription-platform-renderer';

--- a/extensions/amp-video-service/0.1/test/test-amp-video-service.js
+++ b/extensions/amp-video-service/0.1/test/test-amp-video-service.js
@@ -21,7 +21,6 @@
  * it gets automatically inserted by the runtime when required.
  */
 
-import * as sinon from 'sinon';
 import {Observable} from '../../../../src/observable';
 import {Services} from '../../../../src/services';
 import {VideoEntry} from '../amp-video-service';

--- a/extensions/amp-viewer-integration/0.1/test/test-touch-handler.js
+++ b/extensions/amp-viewer-integration/0.1/test/test-touch-handler.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {Messaging} from '../messaging/messaging';
 import {TouchHandler} from '../touch-handler';
 

--- a/extensions/amp-youtube/0.1/test/test-amp-youtube.js
+++ b/extensions/amp-youtube/0.1/test/test-amp-youtube.js
@@ -15,7 +15,6 @@
  */
 
 import '../amp-youtube';
-import * as sinon from 'sinon';
 import {Services} from '../../../../src/services';
 import {VideoEvents} from '../../../../src/video-interface';
 import {listenOncePromise} from '../../../../src/event-helper';

--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
     "request": "2.84.0",
     "rimraf": "2.6.2",
     "rocambole": "0.7.0",
-    "sinon": "4.4.6",
+    "sinon": "4.5.0",
     "sinon-chai": "3.0.0",
     "text-table": "0.2.0",
     "through2": "2.0.3",

--- a/test/_init_tests.js
+++ b/test/_init_tests.js
@@ -257,7 +257,7 @@ function warnForConsoleError(runner) {
   const testName = runner.currentTest.fullTitle();
 
   function record(var_args) {
-    const errorMessage = Array.prototype.slice.call(arugments).join(' ')
+    const errorMessage = Array.prototype.slice.call(arguments).join(' ')
         .split('\n', 1)[0]; // First line.
     const helpMessage = '    The test "' + testName + '"' +
         ' resulted in a call to console.error.\n' +
@@ -333,7 +333,7 @@ afterEach(function() {
   const globalState = Object.keys(global);
   const windowState = Object.keys(window);
 
-  consoleSandbox.restore();;
+  consoleSandbox.restore();
   this.timeout(BEFORE_AFTER_TIMEOUT);
   const cleanupTagNames = ['link', 'meta'];
   if (!Services.platformFor(window).isSafari()) {

--- a/test/functional/ads/test-adplugg.js
+++ b/test/functional/ads/test-adplugg.js
@@ -30,7 +30,7 @@ describes.fakeWin('amp-ad-adplugg-impl', {}, () => {
   beforeEach(() => {
 
     // Set up our test sandbox.
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     return createIframePromise(true).then(iframe => {
       // Simulate the iframe that adplugg will be called inside.
       win = iframe.win;

--- a/test/functional/ads/test-adplugg.js
+++ b/test/functional/ads/test-adplugg.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {
   adplugg,
 } from '../../../ads/adplugg';

--- a/test/functional/ads/test-csa.js
+++ b/test/functional/ads/test-csa.js
@@ -15,7 +15,6 @@
  */
 
 import * as _3p from '../../../3p/3p';
-import * as sinon from 'sinon';
 import {
   AD_TYPE,
   callbackWithBackfill,

--- a/test/functional/ads/test-csa.js
+++ b/test/functional/ads/test-csa.js
@@ -54,7 +54,7 @@ describes.fakeWin('amp-ad-csa-impl', {}, () => {
   let win;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     return createIframePromise(true).then(iframe => {
       win = iframe.win;
       win.context = {

--- a/test/functional/inabox/test-inabox-frame-overlay-manager.js
+++ b/test/functional/inabox/test-inabox-frame-overlay-manager.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {FrameOverlayManager} from '../../../ads/inabox/frame-overlay-manager';
 import {
   stubCollapseFrameForTesting,

--- a/test/functional/inabox/test-inabox-messaging-host.js
+++ b/test/functional/inabox/test-inabox-messaging-host.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {InaboxMessagingHost} from '../../../ads/inabox/inabox-messaging-host';
 import {deserializeMessage} from '../../../src/3p-frame-messaging';
 import {layoutRectLtwh} from '../../../src/layout-rect';

--- a/test/functional/test-3p.js
+++ b/test/functional/test-3p.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {
   computeInMasterFrame,
   loadScript,

--- a/test/functional/test-3p.js
+++ b/test/functional/test-3p.js
@@ -29,7 +29,7 @@ describe('3p', () => {
   let clock;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     clock = sandbox.useFakeTimers();
   });
 

--- a/test/functional/test-action.js
+++ b/test/functional/test-action.js
@@ -511,7 +511,7 @@ describe('Action findAction', () => {
   let action;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     action = actionService();
   });
 
@@ -603,7 +603,7 @@ describe('Action hasAction', () => {
   let action;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     action = actionService();
   });
 
@@ -646,7 +646,7 @@ describe('Action method', () => {
   let targetElement, parent, child, execElement;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     action = actionService();
     onEnqueue = sandbox.spy();
     targetElement = document.createElement('target');
@@ -736,7 +736,7 @@ describe('installActionHandler', () => {
   let action;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     action = actionService();
   });
 
@@ -784,7 +784,7 @@ describe('Multiple handlers action method', () => {
   let targetElement, parent, child, execElement1, execElement2;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     action = actionService();
     onEnqueue1 = sandbox.spy();
     onEnqueue2 = sandbox.spy();
@@ -870,7 +870,7 @@ describe('Action interceptor', () => {
   let target;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     clock = sandbox.useFakeTimers();
     action = actionService();
     target = document.createElement('target');
@@ -970,7 +970,7 @@ describe('Action common handler', () => {
   let target;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     action = actionService();
     target = document.createElement('target');
     target.setAttribute('id', 'amp-test-1');

--- a/test/functional/test-action.js
+++ b/test/functional/test-action.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {
   ActionInvocation,
   ActionService,

--- a/test/functional/test-activity.js
+++ b/test/functional/test-activity.js
@@ -48,7 +48,7 @@ describe('Activity getTotalEngagedTime', () => {
   let scrollObservable;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     clock = sandbox.useFakeTimers();
 
     // start at something other than 0
@@ -251,7 +251,7 @@ describe('Activity getIncrementalEngagedTime', () => {
   let scrollObservable;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     clock = sandbox.useFakeTimers();
 
     // start at something other than 0

--- a/test/functional/test-activity.js
+++ b/test/functional/test-activity.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {AmpDocSingle} from '../../src/service/ampdoc-impl';
 import {Observable} from '../../src/observable';
 import {Services} from '../../src/services';

--- a/test/functional/test-alp-handler.js
+++ b/test/functional/test-alp-handler.js
@@ -27,7 +27,7 @@ describe('alp-handler', () => {
   let image;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     image = undefined;
     win = {
       location: {},

--- a/test/functional/test-alp-handler.js
+++ b/test/functional/test-alp-handler.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {handleClick, warmupDynamic, warmupStatic} from '../../ads/alp/handler';
 import {parseUrl} from '../../src/url';
 

--- a/test/functional/test-amp-context.js
+++ b/test/functional/test-amp-context.js
@@ -28,7 +28,7 @@ describe('3p ampcontext.js', () => {
   let sandbox;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     windowPostMessageSpy = sandbox.spy();
     win = {
       addEventListener: (eventType, handlerFn) => {

--- a/test/functional/test-amp-context.js
+++ b/test/functional/test-amp-context.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as sinon from 'sinon';
 import {
   AmpContext,
 } from '../../3p/ampcontext';

--- a/test/functional/test-amp-img.js
+++ b/test/functional/test-amp-img.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {AmpImg, installImg} from '../../builtins/amp-img';
 import {BaseElement} from '../../src/base-element';
 import {LayoutPriority} from '../../src/layout';

--- a/test/functional/test-amp-img.js
+++ b/test/functional/test-amp-img.js
@@ -26,7 +26,7 @@ describe('amp-img', () => {
   let windowWidth;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     screenWidth = 320;
     windowWidth = 320;
     sandbox.stub(BaseElement.prototype, 'isInViewport')

--- a/test/functional/test-ampdoc.js
+++ b/test/functional/test-ampdoc.js
@@ -16,7 +16,6 @@
 
 import * as docready from '../../src/document-ready';
 import * as dom from '../../src/dom';
-import * as sinon from 'sinon';
 import {
   AmpDocService,
   AmpDocShadow,

--- a/test/functional/test-ampdoc.js
+++ b/test/functional/test-ampdoc.js
@@ -41,7 +41,7 @@ describe('AmpDocService', () => {
   let sandbox;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
   });
 
   afterEach(() => {
@@ -197,7 +197,7 @@ describe('AmpDocService', () => {
     let host, content;
 
     beforeEach(() => {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.sandbox;
       ampdocService = new AmpDocService(window, /* isSingleDoc */ false);
       content = document.createElement('span');
       host = document.createElement('div');
@@ -301,7 +301,7 @@ describe('AmpDocSingle', () => {
   let ampdoc;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     ampdoc = new AmpDocSingle(window);
   });
 
@@ -421,7 +421,7 @@ describe('AmpDocShadow', () => {
   let ampdoc;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     content = document.createElement('div');
     host = document.createElement('div');
     shadowRoot = createShadowRoot(host);
@@ -520,7 +520,7 @@ describe('AmpDocShell', () => {
   let ampdocShell;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     ampdocShell = new AmpDocShell(window);
   });
 

--- a/test/functional/test-analytics.js
+++ b/test/functional/test-analytics.js
@@ -42,7 +42,7 @@ describes.realWin('analytics', {
     }
 
     beforeEach(() => {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.sandbox;
       timer = Services.timerFor(env.win);
       ampdoc = env.ampdoc;
       triggerEventSpy = sandbox.spy();

--- a/test/functional/test-analytics.js
+++ b/test/functional/test-analytics.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {Services} from '../../src/services';
 import {
   getServiceForDoc,

--- a/test/functional/test-animation.js
+++ b/test/functional/test-animation.js
@@ -26,7 +26,7 @@ describe('Animation', () => {
   let contextNode;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     clock = sandbox.useFakeTimers();
     vsyncTasks = [];
     vsync = {

--- a/test/functional/test-animation.js
+++ b/test/functional/test-animation.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {Animation} from '../../src/animation';
 
 describe('Animation', () => {

--- a/test/functional/test-batched-json.js
+++ b/test/functional/test-batched-json.js
@@ -42,7 +42,7 @@ describe('batchFetchJsonFor', () => {
   }
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
 
     urlReplacements = {
       expandUrlAsync: sandbox.stub(),

--- a/test/functional/test-cache-sw-core.js
+++ b/test/functional/test-cache-sw-core.js
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
-
 /**
  * Cache SW has some side-effects, so we've got to do a little jig to test.
  */

--- a/test/functional/test-cache-sw-core.js
+++ b/test/functional/test-cache-sw-core.js
@@ -94,7 +94,7 @@ runner.run('Cache SW', () => {
   }
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
   });
 
   afterEach(() => {

--- a/test/functional/test-chunk.js
+++ b/test/functional/test-chunk.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {Services} from '../../src/services';
 import {
   activateChunkingForTesting,

--- a/test/functional/test-chunk.js
+++ b/test/functional/test-chunk.js
@@ -324,7 +324,7 @@ describe('onIdle', () => {
   let clock;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     clock = sandbox.useFakeTimers();
     calls = [];
     callbackCalled = false;

--- a/test/functional/test-cid.js
+++ b/test/functional/test-cid.js
@@ -15,7 +15,6 @@
  */
 
 import * as lolex from 'lolex';
-import * as sinon from 'sinon';
 import * as url from '../../src/url';
 import {Crypto, installCryptoService} from '../../src/service/crypto-impl';
 import {Services} from '../../src/services';

--- a/test/functional/test-cid.js
+++ b/test/functional/test-cid.js
@@ -65,7 +65,7 @@ describe('cid', () => {
 
   beforeEach(() => {
     let call = 1;
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     clock = sandbox.useFakeTimers();
     whenFirstVisible = Promise.resolve();
     trustedViewer = true;

--- a/test/functional/test-curve.js
+++ b/test/functional/test-curve.js
@@ -21,7 +21,7 @@ describe('Curve', () => {
   let sandbox;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
   });
 
   afterEach(() => {

--- a/test/functional/test-curve.js
+++ b/test/functional/test-curve.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {Curves, bezierCurve, getCurve} from '../../src/curve';
 
 describe('Curve', () => {

--- a/test/functional/test-document-info.js
+++ b/test/functional/test-document-info.js
@@ -24,7 +24,7 @@ describe('document-info', () => {
   let sandbox;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
   });
 
   afterEach(() => {

--- a/test/functional/test-document-info.js
+++ b/test/functional/test-document-info.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {Services} from '../../src/services';
 import {createIframePromise} from '../../testing/iframe';
 import {installDocService} from '../../src/service/ampdoc-impl';

--- a/test/functional/test-document-ready.js
+++ b/test/functional/test-document-ready.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {Services} from '../../src/services';
 import {isDocumentReady,
   onDocumentReady,

--- a/test/functional/test-document-ready.js
+++ b/test/functional/test-document-ready.js
@@ -30,7 +30,7 @@ describe('documentReady', () => {
   const timer = Services.timerFor(window);
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     eventListeners = {};
     testDoc = {
       readyState: 'loading',

--- a/test/functional/test-document-state.js
+++ b/test/functional/test-document-state.js
@@ -27,7 +27,7 @@ describe('DocumentState', () => {
   let docState;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     eventListeners = {};
     testDoc = {
       readyState: 'complete',

--- a/test/functional/test-document-state.js
+++ b/test/functional/test-document-state.js
@@ -15,7 +15,6 @@
  */
 
 import * as dom from '../../src/dom';
-import * as sinon from 'sinon';
 import {DocumentState} from '../../src/service/document-state';
 
 

--- a/test/functional/test-document-submit.js
+++ b/test/functional/test-document-submit.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {Services} from '../../src/services';
 import {onDocumentFormSubmit_} from '../../src/document-submit';
 

--- a/test/functional/test-document-submit.js
+++ b/test/functional/test-document-submit.js
@@ -25,7 +25,7 @@ describe('test-document-submit onDocumentFormSubmit_', () => {
   let stopImmediatePropagationSpy;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     preventDefaultSpy = sandbox.spy();
     stopImmediatePropagationSpy = sandbox.spy();
     tgt = document.createElement('form');

--- a/test/functional/test-error.js
+++ b/test/functional/test-error.js
@@ -102,7 +102,7 @@ describe('maybeReportErrorToViewer', () => {
       new Error('XYZ', false));
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
 
     const optedInDoc = window.document.implementation.createHTMLDocument('');
     optedInDoc.documentElement.setAttribute('report-errors-to-viewer', '');
@@ -171,7 +171,7 @@ describe('reportErrorToServer', () => {
 
   beforeEach(() => {
     onError = window.onerror;
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     nextRandomNumber = 0;
     sandbox.stub(Math, 'random').callsFake(() => nextRandomNumber);
   });

--- a/test/functional/test-error.js
+++ b/test/functional/test-error.js
@@ -15,7 +15,6 @@
  */
 
 import * as analytics from '../../src/analytics';
-import * as sinon from 'sinon';
 import {Services} from '../../src/services';
 import {
   cancellation,

--- a/test/functional/test-event-helper.js
+++ b/test/functional/test-event-helper.js
@@ -45,7 +45,7 @@ describe('EventHelper', () => {
   let removeEventListenerStub;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     loadObservable = new Observable();
     errorObservable = new Observable();
     element = {

--- a/test/functional/test-event-helper.js
+++ b/test/functional/test-event-helper.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {Observable} from '../../src/observable';
 import {
   createCustomEvent,

--- a/test/functional/test-experiments.js
+++ b/test/functional/test-experiments.js
@@ -104,7 +104,7 @@ describe('isExperimentOn', () => {
   let sandbox;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     win = {
       document: {
         cookie: '',
@@ -223,7 +223,7 @@ describe('toggleExperiment', () => {
   let expTime;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     clock = sandbox.useFakeTimers();
     clock.tick(1);
     expTime = new Date(1 + 180 * 24 * 60 * 60 * 1000).toUTCString();
@@ -601,7 +601,7 @@ describe('experiment branch tests', () => {
           branches: ['branch1_id', 'branch2_id'],
         },
       };
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.sandbox;
       sandbox.win = {
         location: {
           hostname: 'test.server.name.com',

--- a/test/functional/test-experiments.js
+++ b/test/functional/test-experiments.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {
   RANDOM_NUMBER_GENERATORS,
   experimentToggles,

--- a/test/functional/test-exponential-backoff.js
+++ b/test/functional/test-exponential-backoff.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {exponentialBackoff, exponentialBackoffClock}
   from '../../src/exponential-backoff';
 

--- a/test/functional/test-exponential-backoff.js
+++ b/test/functional/test-exponential-backoff.js
@@ -24,7 +24,7 @@ describe('exponentialBackoff', () => {
   let clock;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     clock = sandbox.useFakeTimers();
     sandbox.stub(Math, 'random').callsFake(() => 1);
   });

--- a/test/functional/test-extension-analytics.js
+++ b/test/functional/test-extension-analytics.js
@@ -43,7 +43,7 @@ describes.realWin('extension-analytics', {
     }
 
     beforeEach(() => {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.sandbox;
       timer = Services.timerFor(env.win);
       ampdoc = env.ampdoc;
       win = env.win;
@@ -98,7 +98,7 @@ describes.realWin('extension-analytics', {
     let sandbox;
 
     beforeEach(() => {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.sandbox;
       parent = document.createElement('div');
       builder = new CustomEventReporterBuilder(parent);
     });
@@ -193,7 +193,7 @@ describes.realWin('extension-analytics', {
 
     beforeEach(() => {
       ampdoc = env.ampdoc;
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.sandbox;
       triggerEventSpy = sandbox.spy();
       resetServiceForTesting(env.win, 'amp-analytics-instrumentation');
       registerServiceBuilderForDoc(

--- a/test/functional/test-extension-analytics.js
+++ b/test/functional/test-extension-analytics.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {BaseElement} from '../../src/base-element';
 import {
   CustomEventReporterBuilder,

--- a/test/functional/test-finite-state-machine.js
+++ b/test/functional/test-finite-state-machine.js
@@ -25,7 +25,7 @@ describe('Finite State Machine', () => {
     let other;
 
     beforeEach(() => {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.sandbox;
       fsm = new FiniteStateMachine('init');
       spy = sandbox.spy();
       other = sandbox.spy();

--- a/test/functional/test-finite-state-machine.js
+++ b/test/functional/test-finite-state-machine.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {FiniteStateMachine} from '../../src/finite-state-machine';
 
 describe('Finite State Machine', () => {

--- a/test/functional/test-fixed-layer.js
+++ b/test/functional/test-fixed-layer.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {AmpDocSingle} from '../../src/service/ampdoc-impl';
 import {FixedLayer} from '../../src/service/fixed-layer';
 import {endsWith} from '../../src/string';

--- a/test/functional/test-fixed-layer.js
+++ b/test/functional/test-fixed-layer.js
@@ -35,7 +35,7 @@ describe('FixedLayer', () => {
   let allRules;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
 
     allRules = {};
 

--- a/test/functional/test-focus-history.js
+++ b/test/functional/test-focus-history.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {FocusHistory} from '../../src/focus-history';
 import {installTimerService} from '../../src/service/timer-impl';
 

--- a/test/functional/test-focus-history.js
+++ b/test/functional/test-focus-history.js
@@ -29,7 +29,7 @@ describe('FocusHistory', () => {
   let focusHistory;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     clock = sandbox.useFakeTimers();
 
     eventListeners = {};

--- a/test/functional/test-friendly-iframe-embed.js
+++ b/test/functional/test-friendly-iframe-embed.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {
   FriendlyIframeEmbed,
   getFriendlyIframeEmbedOptional,

--- a/test/functional/test-friendly-iframe-embed.js
+++ b/test/functional/test-friendly-iframe-embed.js
@@ -39,7 +39,7 @@ describe('friendly-iframe-embed', () => {
   let resourcesMock;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
 
     const extensions = Services.extensionsFor(window);
     const resources = Services.resourcesForDoc(window.document);

--- a/test/functional/test-gesture-recognizers.js
+++ b/test/functional/test-gesture-recognizers.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {DoubletapRecognizer, PinchRecognizer, SwipeXYRecognizer, TapRecognizer,
   TapzoomRecognizer} from '../../src/gesture-recognizers';
 import {Gestures} from '../../src/gesture';

--- a/test/functional/test-gesture-recognizers.js
+++ b/test/functional/test-gesture-recognizers.js
@@ -28,7 +28,7 @@ describe('TapRecognizer', () => {
   let gesturesMock;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
 
     element = {
       addEventListener: (unusedEventType, unusedHandler) => {},
@@ -120,7 +120,7 @@ describe('DoubletapRecognizer', () => {
   let gesturesMock;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
 
     element = {
       addEventListener: (unusedEventType, unusedHandler) => {},
@@ -227,7 +227,7 @@ describe('SwipeXYRecognizer', () => {
   let gesturesMock;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     clock = sandbox.useFakeTimers();
 
     element = {
@@ -414,7 +414,7 @@ describe('TapzoomRecognizer', () => {
   let gesturesMock;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     clock = sandbox.useFakeTimers();
 
     element = {
@@ -595,7 +595,7 @@ describe('PinchRecognizer', () => {
   let gesturesMock;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     clock = sandbox.useFakeTimers();
 
     element = {

--- a/test/functional/test-gesture.js
+++ b/test/functional/test-gesture.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {GestureRecognizer, Gestures} from '../../src/gesture';
 
 

--- a/test/functional/test-gesture.js
+++ b/test/functional/test-gesture.js
@@ -41,7 +41,7 @@ describe('Gestures', () => {
   let onGesture;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     clock = sandbox.useFakeTimers();
 
     eventListeners = {};
@@ -390,7 +390,7 @@ describe('Gestures', () => {
     let onGesture;
 
     beforeEach(() => {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.sandbox;
       clock = sandbox.useFakeTimers();
 
       eventListeners = {};

--- a/test/functional/test-history.js
+++ b/test/functional/test-history.js
@@ -398,7 +398,7 @@ describe('HistoryBindingVirtual', () => {
   let viewer;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     clock = sandbox.useFakeTimers();
     onStackIndexUpdated = sandbox.spy();
     viewerHistoryPoppedHandler = undefined;

--- a/test/functional/test-history.js
+++ b/test/functional/test-history.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {AmpDocSingle} from '../../src/service/ampdoc-impl';
 import {
   History,

--- a/test/functional/test-ie-media-bug.js
+++ b/test/functional/test-ie-media-bug.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {checkAndFix} from '../../src/service/ie-media-bug';
 import {dev} from '../../src/log';
 

--- a/test/functional/test-ie-media-bug.js
+++ b/test/functional/test-ie-media-bug.js
@@ -27,7 +27,7 @@ describe('ie-media-bug', () => {
   let devErrorStub;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     clock = sandbox.useFakeTimers();
     platform = {
       isIe: () => false,

--- a/test/functional/test-iframe-helper.js
+++ b/test/functional/test-iframe-helper.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import * as IframeHelper from '../../src/iframe-helper';
-import * as sinon from 'sinon';
 import {createIframePromise} from '../../testing/iframe';
 import {generateSentinel} from '../../src/3p-frame.js';
 

--- a/test/functional/test-iframe-helper.js
+++ b/test/functional/test-iframe-helper.js
@@ -32,7 +32,7 @@ describe('iframe-helper', function() {
   }
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     return createIframePromise().then(c => {
       container = c;
       const i = c.doc.createElement('iframe');

--- a/test/functional/test-impression.js
+++ b/test/functional/test-impression.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {Services} from '../../src/services';
 import {
   getExtraParamsUrl,

--- a/test/functional/test-impression.js
+++ b/test/functional/test-impression.js
@@ -36,7 +36,7 @@ describe('impression', () => {
   let warnStub;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     viewer = Services.viewerForDoc(window.document);
     sandbox.stub(viewer, 'getParam');
     sandbox.stub(viewer, 'hasCapability');

--- a/test/functional/test-input.js
+++ b/test/functional/test-input.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {Input} from '../../src/input';
 import {installTimerService} from '../../src/service/timer-impl.js';
 

--- a/test/functional/test-input.js
+++ b/test/functional/test-input.js
@@ -28,7 +28,7 @@ describe('Input', () => {
   let documentApi;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     clock = sandbox.useFakeTimers();
 
     eventListeners = {};

--- a/test/functional/test-intersection-observer-polyfill.js
+++ b/test/functional/test-intersection-observer-polyfill.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {
   DEFAULT_THRESHOLD,
   IntersectionObserverApi,

--- a/test/functional/test-intersection-observer-polyfill.js
+++ b/test/functional/test-intersection-observer-polyfill.js
@@ -47,7 +47,7 @@ describe('IntersectionObserverApi', () => {
   }
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     onScrollSpy = sandbox.spy();
     onChangeSpy = sandbox.spy();
     testIframe = getIframe(iframeSrc);
@@ -146,7 +146,7 @@ describe('IntersectionObserverApi', () => {
 describe('getIntersectionChangeEntry', () => {
   let sandbox;
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     sandbox.stub(performance, 'now').callsFake(() => 100);
   });
 
@@ -192,7 +192,7 @@ describe('getIntersectionChangeEntry', () => {
 describe('IntersectionObserverPolyfill', () => {
   let sandbox;
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     sandbox.stub(performance, 'now').callsFake(() => 100);
   });
 

--- a/test/functional/test-intersection-observer.js
+++ b/test/functional/test-intersection-observer.js
@@ -26,7 +26,7 @@ import {layoutRectLtwh} from '../../src/layout-rect';
 describe('getIntersectionChangeEntry', () => {
   let sandbox;
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     sandbox.useFakeTimers();
   });
 
@@ -350,7 +350,7 @@ describe('IntersectionObserver', () => {
   }
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     clock = sandbox.useFakeTimers();
     testElementCreatedCallback = sandbox.spy();
     testElementPreconnectCallback = sandbox.spy();

--- a/test/functional/test-intersection-observer.js
+++ b/test/functional/test-intersection-observer.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {BaseElement} from '../../src/base-element';
 import {
   IntersectionObserver,

--- a/test/functional/test-log.js
+++ b/test/functional/test-log.js
@@ -42,7 +42,7 @@ describe('Logging', () => {
   let timeoutSpy;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
 
     mode = {};
     window.AMP_MODE = mode;
@@ -680,7 +680,7 @@ describe('Logging', () => {
     let element2;
 
     beforeEach(() => {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.sandbox;
       iframe = document.createElement('iframe');
       document.body.appendChild(iframe);
     });

--- a/test/functional/test-log.js
+++ b/test/functional/test-log.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {
   Log,
   LogLevel,

--- a/test/functional/test-motion.js
+++ b/test/functional/test-motion.js
@@ -61,7 +61,7 @@ describe('Motion continueMotion', () => {
   let contextNode;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     clock = sandbox.useFakeTimers();
     vsyncTasks = [];
     vsync = {

--- a/test/functional/test-motion.js
+++ b/test/functional/test-motion.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {calcVelocity, continueMotion} from '../../src/motion';
 
 

--- a/test/functional/test-observable.js
+++ b/test/functional/test-observable.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {Observable} from '../../src/observable';
 
 describe('Observable', () => {

--- a/test/functional/test-observable.js
+++ b/test/functional/test-observable.js
@@ -22,7 +22,7 @@ describe('Observable', () => {
   let observable;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     observable = new Observable();
   });
 

--- a/test/functional/test-pass.js
+++ b/test/functional/test-pass.js
@@ -25,7 +25,7 @@ describe('Pass', () => {
   let handlerCalled;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     timerMock = sandbox.mock(Services.timerFor(window));
     handlerCalled = 0;
     pass = new Pass(window, () => {

--- a/test/functional/test-pass.js
+++ b/test/functional/test-pass.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {Pass} from '../../src/pass';
 import {Services} from '../../src/services';
 

--- a/test/functional/test-performance.js
+++ b/test/functional/test-performance.js
@@ -15,7 +15,6 @@
  */
 
 import * as lolex from 'lolex';
-import * as sinon from 'sinon';
 import {Services} from '../../src/services';
 import {getMode} from '../../src/mode';
 import {installPerformanceService} from '../../src/service/performance-impl';

--- a/test/functional/test-polyfill-document-contains.js
+++ b/test/functional/test-polyfill-document-contains.js
@@ -30,7 +30,7 @@ describe('HTMLDocument.contains', () => {
   let disconnectedChild;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
 
     fakeWinWithContains = {
       HTMLDocument: class {

--- a/test/functional/test-polyfill-document-contains.js
+++ b/test/functional/test-polyfill-document-contains.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {install} from '../../src/polyfills/document-contains';
 
 

--- a/test/functional/test-polyfill-domtokenlist-toggle.js
+++ b/test/functional/test-polyfill-domtokenlist-toggle.js
@@ -32,7 +32,7 @@ describes.fakeWin('DOMTokenList.toggle on non-IE', {
 
   beforeEach(() => {
     originalToggle = env.win.DOMTokenList.prototype.toggle;
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
 
     element = env.win.document.createElement('div');
     env.win.document.body.appendChild(element);
@@ -69,7 +69,7 @@ describes.fakeWin('DOMTokenList.toggle On IE', {
 
   beforeEach(() => {
     originalToggle = env.win.DOMTokenList.prototype.toggle;
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
 
     element = env.win.document.createElement('div');
     env.win.document.body.appendChild(element);

--- a/test/functional/test-polyfill-domtokenlist-toggle.js
+++ b/test/functional/test-polyfill-domtokenlist-toggle.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {install} from '../../src/polyfills/domtokenlist-toggle';
 import {toArray} from '../../src/types';
 

--- a/test/functional/test-preconnect.js
+++ b/test/functional/test-preconnect.js
@@ -15,7 +15,6 @@
  */
 
 import * as lolex from 'lolex';
-import * as sinon from 'sinon';
 import {createIframePromise} from '../../testing/iframe';
 import {preconnectForElement, setPreconnectFeaturesForTesting} from
   '../../src/preconnect';

--- a/test/functional/test-preconnect.js
+++ b/test/functional/test-preconnect.js
@@ -71,7 +71,7 @@ describe('preconnect', () => {
     // to test for preload/preconnect support.
     preloadSupported = false;
     preconnectSupported = false;
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     clock = sandbox.useFakeTimers();
   });
 

--- a/test/functional/test-pull-to-refresh.js
+++ b/test/functional/test-pull-to-refresh.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {PullToRefreshBlocker} from '../../src/pull-to-refresh';
 
 

--- a/test/functional/test-pull-to-refresh.js
+++ b/test/functional/test-pull-to-refresh.js
@@ -25,7 +25,7 @@ describe('PullToRefreshBlocker', () => {
   let blocker;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
 
     eventListeners = {};
     const documentApi = {

--- a/test/functional/test-render-delaying-services.js
+++ b/test/functional/test-render-delaying-services.js
@@ -16,7 +16,6 @@
 
 import * as lolex from 'lolex';
 import * as service from '../../src/service';
-import * as sinon from 'sinon';
 import {createIframePromise} from '../../testing/iframe';
 import {
   hasRenderDelayingServices,

--- a/test/functional/test-render-delaying-services.js
+++ b/test/functional/test-render-delaying-services.js
@@ -32,7 +32,7 @@ describe('waitForServices', () => {
   let variantResolve;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     const getService = sandbox.stub(service, 'getServicePromise');
     dynamicCssResolve = waitForService(getService, 'amp-dynamic-css-classes');
     experimentResolve = waitForService(getService, 'amp-experiment');

--- a/test/functional/test-resource.js
+++ b/test/functional/test-resource.js
@@ -856,7 +856,7 @@ describe('Resource idleRenderOutsideViewport', () => {
   let withinViewportMultiplier;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     idleRenderOutsideViewport = sandbox.stub();
     element = {
       idleRenderOutsideViewport,
@@ -913,7 +913,7 @@ describe('Resource renderOutsideViewport', () => {
   let resolveRenderOutsideViewportSpy;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
 
     element = {
       ownerDocument: {defaultView: window},

--- a/test/functional/test-resource.js
+++ b/test/functional/test-resource.js
@@ -857,7 +857,6 @@ describe('Resource idleRenderOutsideViewport', () => {
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
-    sandbox = sinon.sandbox.create();
     idleRenderOutsideViewport = sandbox.stub();
     element = {
       idleRenderOutsideViewport,

--- a/test/functional/test-resource.js
+++ b/test/functional/test-resource.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {AmpDocSingle} from '../../src/service/ampdoc-impl';
 import {LayoutPriority} from '../../src/layout';
 import {Resource, ResourceState} from '../../src/service/resource';

--- a/test/functional/test-resources.js
+++ b/test/functional/test-resources.js
@@ -32,7 +32,7 @@ describe('Resources', () => {
   let resources;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     clock = sandbox.useFakeTimers();
     resources = new Resources(new AmpDocSingle(window));
     resources.isRuntimeOn_ = false;
@@ -588,7 +588,7 @@ describes.fakeWin('Resources startup', {
 
   beforeEach(() => {
     win = env.win;
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     clock = sandbox.useFakeTimers();
     resources = Services.resourcesForDoc(win.document.body);
     resources.relayoutAll_ = false;
@@ -703,7 +703,7 @@ describes.realWin('getElementLayoutBox', {}, env => {
 
   beforeEach(() => {
     win = env.win;
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     resources = new Resources(new AmpDocSingle(window));
     resources.isRuntimeOn_ = false;
     vsyncSpy = sandbox.stub(resources.vsync_, 'run').callsFake(task => {
@@ -1090,7 +1090,7 @@ describe('Resources discoverWork', () => {
   let resource1, resource2;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     resources = new Resources(new AmpDocSingle(window));
     viewportMock = sandbox.mock(resources.viewport_);
 
@@ -1763,7 +1763,7 @@ describe('Resources changeSize', () => {
   let resource1, resource2;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     clock = sandbox.useFakeTimers();
     resources = new Resources(new AmpDocSingle(window));
     resources.isRuntimeOn_ = false;
@@ -2503,7 +2503,7 @@ describe('Resources mutateElement and collapse', () => {
   let resource1RequestMeasureStub, resource2RequestMeasureStub;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     resources = new Resources(new AmpDocSingle(window));
     resources.isRuntimeOn_ = false;
     viewportMock = sandbox.mock(resources.viewport_);

--- a/test/functional/test-resources.js
+++ b/test/functional/test-resources.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {AmpDocSingle} from '../../src/service/ampdoc-impl';
 import {LayoutPriority} from '../../src/layout';
 import {Resource, ResourceState} from '../../src/service/resource';

--- a/test/functional/test-runtime.js
+++ b/test/functional/test-runtime.js
@@ -16,7 +16,6 @@
 
 import * as dom from '../../src/dom';
 import * as ext from '../../src/service/extensions-impl';
-import * as sinon from 'sinon';
 import * as styles from '../../src/style-installer';
 import {AmpDocShadow, AmpDocSingle} from '../../src/service/ampdoc-impl';
 import {ElementStub} from '../../src/element-stub';

--- a/test/functional/test-service.js
+++ b/test/functional/test-service.js
@@ -45,7 +45,7 @@ describe('service', () => {
   let sandbox;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
   });
 
   afterEach(() => {

--- a/test/functional/test-service.js
+++ b/test/functional/test-service.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {
   adoptServiceForEmbed,
   adoptServiceForEmbedIfEmbeddable,

--- a/test/functional/test-storage.js
+++ b/test/functional/test-storage.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {AmpDocSingle} from '../../src/service/ampdoc-impl';
 import {
   LocalStorageBinding,

--- a/test/functional/test-storage.js
+++ b/test/functional/test-storage.js
@@ -36,7 +36,7 @@ describe('Storage', () => {
   let viewerBroadcastHandler;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
 
     viewerBroadcastHandler = undefined;
     viewer = {
@@ -324,7 +324,7 @@ describe('Store', () => {
   let store;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     clock = sandbox.useFakeTimers();
     store = new Store({}, 2);
   });
@@ -431,7 +431,7 @@ describe('LocalStorageBinding', () => {
   let binding;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     windowApi = {
       localStorage: {
         getItem: () => {},
@@ -571,7 +571,7 @@ describe('ViewerStorageBinding', () => {
   let binding;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     viewer = {
       sendMessageAwaitResponse: () => {},
     };

--- a/test/functional/test-style-installer.js
+++ b/test/functional/test-style-installer.js
@@ -15,7 +15,6 @@
  */
 
 import * as rds from '../../src/render-delaying-services';
-import * as sinon from 'sinon';
 import * as styles from '../../src/style-installer';
 import {AmpDocShadow, AmpDocSingle} from '../../src/service/ampdoc-impl';
 import {Services} from '../../src/services';

--- a/test/functional/test-style.js
+++ b/test/functional/test-style.js
@@ -21,7 +21,7 @@ describe('Style', () => {
   let sandbox;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
   });
 
   afterEach(() => {

--- a/test/functional/test-style.js
+++ b/test/functional/test-style.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import * as st from '../../src/style';
 
 describe('Style', () => {

--- a/test/functional/test-task-queue.js
+++ b/test/functional/test-task-queue.js
@@ -24,7 +24,7 @@ describe('TaskQueue', () => {
   let queue;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     clock = sandbox.useFakeTimers();
     queue = new TaskQueue();
   });

--- a/test/functional/test-task-queue.js
+++ b/test/functional/test-task-queue.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {TaskQueue} from '../../src/service/task-queue';
 
 

--- a/test/functional/test-timer.js
+++ b/test/functional/test-timer.js
@@ -23,7 +23,7 @@ describes.fakeWin('Timer', {}, env => {
   let timer;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     const WindowApi = function() {};
     WindowApi.prototype.setTimeout = function(unusedCallback, unusedDelay) {};
     WindowApi.prototype.clearTimeout = function(unusedTimerId) {};

--- a/test/functional/test-timer.js
+++ b/test/functional/test-timer.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {Timer} from '../../src/service/timer-impl';
 
 describes.fakeWin('Timer', {}, env => {

--- a/test/functional/test-transition.js
+++ b/test/functional/test-transition.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import * as tr from '../../src/transition';
 
 describe('Transition', () => {

--- a/test/functional/test-transition.js
+++ b/test/functional/test-transition.js
@@ -21,7 +21,7 @@ describe('Transition', () => {
   let sandbox;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
   });
 
   afterEach(() => {

--- a/test/functional/test-viewer.js
+++ b/test/functional/test-viewer.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {Services} from '../../src/services';
 import {Viewer} from '../../src/service/viewer-impl';
 import {dev} from '../../src/log';

--- a/test/functional/test-viewer.js
+++ b/test/functional/test-viewer.js
@@ -52,7 +52,7 @@ describe('Viewer', () => {
   }
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     clock = sandbox.useFakeTimers();
     const WindowApi = function() {};
     windowApi = new WindowApi();

--- a/test/functional/test-viewport.js
+++ b/test/functional/test-viewport.js
@@ -1153,7 +1153,7 @@ describe('Viewport META', () => {
     let viewportMetaSetter;
 
     beforeEach(() => {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.sandbox;
       clock = sandbox.useFakeTimers();
       viewer = {
         isEmbedded: () => false,

--- a/test/functional/test-viewport.js
+++ b/test/functional/test-viewport.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {AmpDocSingle, installDocService} from '../../src/service/ampdoc-impl';
 import {Services} from '../../src/services';
 import {

--- a/test/functional/test-vsync.js
+++ b/test/functional/test-vsync.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {AmpDocShadow, installDocService} from '../../src/service/ampdoc-impl';
 import {Services} from '../../src/services';
 import {Vsync} from '../../src/service/vsync-impl';

--- a/test/functional/test-vsync.js
+++ b/test/functional/test-vsync.js
@@ -31,7 +31,7 @@ describe('vsync', () => {
   let contextNode;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     clock = sandbox.useFakeTimers();
     win = {
       document: {

--- a/test/functional/test-xhr.js
+++ b/test/functional/test-xhr.js
@@ -70,7 +70,7 @@ describe.configure().skipSafari().run('XHR', function() {
   }
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     ampdocServiceForStub = sandbox.stub(Services, 'ampdocServiceFor');
     ampdocServiceForStub.returns({isSingleDoc: () => false});
     location.href = 'https://acme.com/path';

--- a/test/functional/test-xhr.js
+++ b/test/functional/test-xhr.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {
   FetchResponse,
   assertSuccess,

--- a/test/functional/utils/test-rate-limit.js
+++ b/test/functional/utils/test-rate-limit.js
@@ -22,7 +22,7 @@ describe('function utils', () => {
     let clock;
 
     beforeEach(() => {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.sandbox;
       clock = sandbox.useFakeTimers();
     });
 
@@ -93,7 +93,7 @@ describe('function utils', () => {
     let clock;
 
     beforeEach(() => {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.sandbox;
       clock = sandbox.useFakeTimers();
     });
 

--- a/test/functional/utils/test-rate-limit.js
+++ b/test/functional/utils/test-rate-limit.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {debounce, throttle} from '../../../src/utils/rate-limit';
 
 describe('function utils', () => {

--- a/test/functional/web-worker/test-amp-worker.js
+++ b/test/functional/web-worker/test-amp-worker.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {Services} from '../../../src/services';
 import {
   ampWorkerForTesting,

--- a/test/functional/web-worker/test-amp-worker.js
+++ b/test/functional/web-worker/test-amp-worker.js
@@ -32,7 +32,7 @@ describe('invokeWebWorker', () => {
   let workerReadyPromise;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     sandbox.stub(Services, 'ampdocServiceFor').returns({
       isSingleDoc: () => false,
     });

--- a/test/integration/test-3p-frame.js
+++ b/test/integration/test-3p-frame.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {DomFingerprint} from '../../src/utils/dom-fingerprint';
 import {Services} from '../../src/services';
 import {

--- a/test/integration/test-3p-frame.js
+++ b/test/integration/test-3p-frame.js
@@ -44,7 +44,7 @@ describe.configure().ifNewChrome().run('3p-frame', () => {
   let preconnect;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     clock = sandbox.useFakeTimers();
     container = document.createElement('div');
     document.body.appendChild(container);

--- a/test/integration/test-amp-bind.js
+++ b/test/integration/test-amp-bind.js
@@ -30,7 +30,7 @@ describe.configure().ifNewChrome().run('amp-bind', function() {
   let numTemplated;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
     numSetStates = 0;
     numTemplated = 0;
   });

--- a/test/integration/test-amp-bind.js
+++ b/test/integration/test-amp-bind.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as sinon from 'sinon';
 import {AmpEvents} from '../../src/amp-events';
 import {BindEvents} from '../../extensions/amp-bind/0.1/bind-events';
 import {FormEvents} from '../../extensions/amp-form/0.1/form-events';

--- a/test/integration/test-video-manager.js
+++ b/test/integration/test-video-manager.js
@@ -247,7 +247,7 @@ describe.configure().ifNewChrome().run('VideoManager', function() {
         });
 
     beforeEach(() => {
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.sandbox;
       klass = createFakeVideoPlayerClass(env.win);
       video = env.createAmpElement('amp-test-fake-videoplayer', klass);
       impl = video.implementation_;
@@ -278,7 +278,7 @@ describe.configure().ifNewChrome().run('Autoplay support', () => {
   let playStub;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
 
     video = {
       setAttribute() {},

--- a/test/integration/test-video-manager.js
+++ b/test/integration/test-video-manager.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as sinon from 'sinon';
 import {PlayingStates, VideoEvents} from '../../src/video-interface';
 import {Services} from '../../src/services';
 import {VideoUtils} from '../../src/utils/video';

--- a/test/simple-test.js
+++ b/test/simple-test.js
@@ -22,7 +22,7 @@ describe.configure().enableIe().run('simple-test', () => {
   let sandbox;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox;
   });
 
   afterEach(() => {

--- a/testing/describes.js
+++ b/testing/describes.js
@@ -114,7 +114,6 @@ import {
   resetScheduledElementForTesting,
 } from '../src/service/custom-element-registry';
 import {setStyles} from '../src/style';
-import * as sinon from 'sinon';
 
 /** Should have something in the name, otherwise nothing is shown. */
 const SUB = ' ';

--- a/testing/describes.js
+++ b/testing/describes.js
@@ -30,7 +30,7 @@
  *     describe('myTest', () => {
  *       // I gotta do this sandbox creation and restore for every test? Ugh...
  *       let sandbox;
- *       beforeEach(() => { sandbox = sinon.sandbox.create(); })
+ *       beforeEach(() => { sandbox = sinon.sandbox; })
  *       it('stubbing', () => { sandbox.stub(foo, 'bar'); });
  *       afterEach(() => { sandbox.restore(); });
  *     });
@@ -428,7 +428,7 @@ class SandboxFixture {
     // Sandbox.
     let sandbox = global.sandbox;
     if (!sandbox) {
-      sandbox = global.sandbox = sinon.sandbox.create();
+      sandbox = global.sandbox = sinon.sandbox;
       this.sandboxOwner_ = true;
     }
     env.sandbox = sandbox;

--- a/yarn.lock
+++ b/yarn.lock
@@ -9644,9 +9644,9 @@ sinon-chai@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/sinon-chai/-/sinon-chai-3.0.0.tgz#d5cbd70fa71031edd96b528e0eed4038fcc99f29"
 
-sinon@4.4.6:
-  version "4.4.6"
-  resolved "https://registry.yarnpkg.com/sinon/-/sinon-4.4.6.tgz#0b21ce56f1b11015749a82a3bbde2f46b78ec0e1"
+sinon@4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-4.5.0.tgz#427ae312a337d3c516804ce2754e8c0d5028cb04"
   dependencies:
     "@sinonjs/formatio" "^2.0.0"
     diff "^3.1.0"


### PR DESCRIPTION
It's already imported in test suites, and importing your own copy breaks
our special "ensure everything is cleaned up" phase.

Closes #14167.