### PR TITLE
Add attribute to amp-story-auto-ad

### DIFF
--- a/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
+++ b/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
@@ -288,6 +288,7 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
     const requiredAttrs = {
       'class': 'i-amphtml-story-ad',
       'layout': 'fill',
+      'amp-story': '',
     };
 
     const configAttrs = this.config_['ad-attributes'];


### PR DESCRIPTION
Add attribute named `amp-story` to all ads so that 3p ad-servers know that they are being requested from within a story context.
