### PR TITLE
♻️Cleanup FxProvider's private fields

### DIFF
--- a/extensions/amp-fx-collection/0.1/providers/amp-fx-presets.js
+++ b/extensions/amp-fx-collection/0.1/providers/amp-fx-presets.js
@@ -34,10 +34,10 @@ export const Presets = {
     },
     update(entry) {
       const fxElement = this;
-      dev().assert(fxElement.adjustedViewportHeight_);
+      dev().assert(fxElement.adjustedViewportHeight);
       const top = entry.positionRect ? entry.positionRect.top : null;
       // outside viewport
-      if (!top || top > fxElement.adjustedViewportHeight_) {
+      if (!top || top > fxElement.adjustedViewportHeight) {
         return;
       }
 
@@ -47,7 +47,7 @@ export const Presets = {
       const adjustedFactor = -(parseFloat(fxElement.getFactor()) - 1);
       // Offset is how much extra to move the element which is position within
       // viewport times adjusted factor.
-      const offset = (fxElement.adjustedViewportHeight_ - top) * adjustedFactor;
+      const offset = (fxElement.adjustedViewportHeight - top) * adjustedFactor;
       fxElement.setOffset(offset);
 
       if (fxElement.isMutateScheduled()) {
@@ -82,11 +82,11 @@ export const Presets = {
     },
     update(entry) {
       const fxElement = this;
-      dev().assert(fxElement.adjustedViewportHeight_);
+      dev().assert(fxElement.adjustedViewportHeight);
       const top = entry.positionRect ? entry.positionRect.top : null;
       // Outside viewport
       if (!top || top > (1 - fxElement.getMarginStart()) *
-        fxElement.adjustedViewportHeight_) {
+        fxElement.adjustedViewportHeight) {
         return;
       }
 
@@ -132,11 +132,11 @@ export const Presets = {
     },
     update(entry) {
       const fxElement = this;
-      dev().assert(fxElement.adjustedViewportHeight_);
+      dev().assert(fxElement.adjustedViewportHeight);
       const top = entry.positionRect ? entry.positionRect.top : null;
       // Outside viewport or margins
       if (!top || (top > (1 - fxElement.getMarginStart()) *
-        fxElement.adjustedViewportHeight_)) {
+        fxElement.adjustedViewportHeight)) {
         return;
       }
 
@@ -152,9 +152,9 @@ export const Presets = {
       const marginDelta = fxElement.getMarginEnd() - fxElement.getMarginStart();
       // Offset is how much extra to move the element which is position within
       // viewport times adjusted factor.
-      const offset = 1 * (fxElement.adjustedViewportHeight_ - top -
-        (fxElement.getMarginStart() * fxElement.adjustedViewportHeight_)) /
-        (marginDelta * fxElement.adjustedViewportHeight_);
+      const offset = 1 * (fxElement.adjustedViewportHeight - top -
+        (fxElement.getMarginStart() * fxElement.adjustedViewportHeight)) /
+        (marginDelta * fxElement.adjustedViewportHeight);
       fxElement.setOffset(offset);
 
       if (fxElement.isMutateScheduled()) {

--- a/extensions/amp-fx-collection/0.1/providers/fx-provider.js
+++ b/extensions/amp-fx-collection/0.1/providers/fx-provider.js
@@ -85,9 +85,8 @@ export class FxProvider {
    */
   installOn(element) {
     setStyles(element, installStyles[this.fxType_]);
-    const parallaxElement = new FxElement(
-        element, this.positionObserver_, this.viewport_, this.resources_,
-        this.fxType_);
+    new FxElement(element, this.positionObserver_, this.viewport_,
+        this.resources_, this.fxType_);
   }
 }
 

--- a/extensions/amp-fx-collection/0.1/providers/fx-provider.js
+++ b/extensions/amp-fx-collection/0.1/providers/fx-provider.js
@@ -111,8 +111,8 @@ export class FxElement {
     /** @const @private {!../../../../src/service/resources-impl.Resources} */
     this.resources_ = resources;
 
-    /** @private {?number} */
-    this.adjustedViewportHeight_ = null;
+    /** @type {?number} */
+    this.adjustedViewportHeight = null;
 
     /** @private @const {!Element} */
     this.element_ = element;
@@ -153,7 +153,7 @@ export class FxElement {
     this.hasRepeat_ = element.hasAttribute('data-repeat');
 
     this.getAdjustedViewportHeight_().then(adjustedViewportHeight => {
-      this.adjustedViewportHeight_ = adjustedViewportHeight;
+      this.adjustedViewportHeight = adjustedViewportHeight;
 
       // start observing position of the element.
       this.observePositionChanges_();
@@ -170,7 +170,7 @@ export class FxElement {
 
     this.viewport_.onResize(() => {
       this.getAdjustedViewportHeight_().then(adjustedViewportHeight => {
-        this.adjustedViewportHeight_ = adjustedViewportHeight;
+        this.adjustedViewportHeight = adjustedViewportHeight;
       });
     });
   }

--- a/extensions/amp-fx-collection/0.1/providers/fx-provider.js
+++ b/extensions/amp-fx-collection/0.1/providers/fx-provider.js
@@ -64,9 +64,6 @@ export class FxProvider {
    */
   constructor(ampdoc, fxType) {
 
-    /** @private @const {!../../../../src/service/ampdoc-impl.AmpDoc} */
-    this.ampdoc_ = ampdoc;
-
     /** @private @const {!../../../../src/service/viewport/viewport-impl.Viewport} */
     this.viewport_ = Services.viewportForDoc(ampdoc);
 
@@ -91,7 +88,6 @@ export class FxProvider {
     const parallaxElement = new FxElement(
         element, this.positionObserver_, this.viewport_, this.resources_,
         this.fxType_);
-    parallaxElement.initialize_();
   }
 }
 
@@ -157,14 +153,6 @@ export class FxElement {
     /** @private {boolean} */
     this.hasRepeat_ = element.hasAttribute('data-repeat');
 
-  }
-
-  /**
-   * Handles initializations such as getting initial positions and listening to
-   * events.
-   * @private
-   */
-  initialize_() {
     this.getAdjustedViewportHeight_().then(adjustedViewportHeight => {
       this.adjustedViewportHeight_ = adjustedViewportHeight;
 


### PR DESCRIPTION
- `ampdoc_` appears unused,
- `initialize_` is called externally (meaning it's really public)
  - Additionally, it's only ever called after construction, so why isn't
  it just in the constructor?
- `adjustedViewportHeight_` is called externally (meaning it's really public)

Part of #14761.