### PR TITLE
🚮 Cleanup unused WebPush private field

### DIFF
--- a/extensions/amp-web-push/0.1/web-push-service.js
+++ b/extensions/amp-web-push/0.1/web-push-service.js
@@ -588,13 +588,6 @@ export class WebPushService {
   }
 
   /** @private */
-  updateWidgetVisibilitiesNotificationPermissionsBlocked_() {
-    this.setWidgetVisibilities(WebPushWidgetVisibilities.UNSUBSCRIBED, false);
-    this.setWidgetVisibilities(WebPushWidgetVisibilities.SUBSCRIBED, false);
-    this.setWidgetVisibilities(WebPushWidgetVisibilities.BLOCKED, true);
-  }
-
-  /** @private */
   updateWidgetVisibilitiesServiceWorkerActivated_() {
     return Services.timerFor(this.ampdoc.win).timeoutPromise(
         5000,


### PR DESCRIPTION
`updateWidgetVisibilitiesNotificationPermissionsBlocked_` is a
duplication of `updateWidgetVisibilitiesBlocked_`, and unused.