### PR TITLE
🚮 Cleanup Subscriptions Private Fields

### DIFF
--- a/extensions/amp-subscriptions/0.1/amp-subscriptions.js
+++ b/extensions/amp-subscriptions/0.1/amp-subscriptions.js
@@ -18,7 +18,6 @@ import {CSS} from '../../../build/amp-subscriptions-0.1.css';
 import {Dialog} from './dialog';
 import {DocImpl} from './doc-impl';
 import {Entitlement} from './entitlement';
-import {JwtHelper} from '../../amp-access/0.1/jwt';
 import {LocalSubscriptionPlatform} from './local-subscription-platform';
 import {PageConfig, PageConfigResolver} from '../../../third_party/subscriptions-project/config';
 import {PlatformStore} from './platform-store';
@@ -99,9 +98,6 @@ export class SubscriptionService {
 
     /** @private @const {boolean} */
     this.doesViewerProvideAuth_ = this.viewer_.hasCapability('auth');
-
-    /** @private @const {!JwtHelper} */
-    this.jwtHelper_ = new JwtHelper(ampdoc.win);
   }
 
   /**

--- a/extensions/amp-subscriptions/0.1/local-subscription-platform.js
+++ b/extensions/amp-subscriptions/0.1/local-subscription-platform.js
@@ -50,9 +50,6 @@ export class LocalSubscriptionPlatform {
     /** @private @const {!./service-adapter.ServiceAdapter} */
     this.serviceAdapter_ = serviceAdapter;
 
-    /** @const @private {!PageConfig} */
-    this.pageConfig_ = serviceAdapter.getPageConfig();
-
     /** @const @private {!../../../src/service/xhr-impl.Xhr} */
     this.xhr_ = Services.xhrFor(this.ampdoc_.win);
 
@@ -93,9 +90,6 @@ export class LocalSubscriptionPlatform {
 
     /** @private {?Entitlement}*/
     this.entitlement_ = null;
-
-    /** @private @const {boolean} */
-    this.isPingbackEnabled_ = true;
 
     /** @private @const {?string} */
     this.pingbackUrl_ = this.serviceConfig_['pingbackUrl'] || null;


### PR DESCRIPTION
`LocalSubscriptionPlatform`'s deletions look like they're leftovers from `AccessClientAdapter`?

And `SubscriptionService`'s looks like it was moved into `ViewerSubscriptionPlatform`.

Part of #14761.