### PR TITLE
Tweak hidden input naming. Test the behavior.

### DIFF
--- a/extensions/amp-date-picker/0.1/amp-date-picker.js
+++ b/extensions/amp-date-picker/0.1/amp-date-picker.js
@@ -129,7 +129,6 @@ const DateFieldType = {
   END_DATE: 'end-input',
 };
 
-/** @enum {string} */
 const DateFieldNameByType = {
   [DateFieldType.DATE]: 'date',
   [DateFieldType.START_DATE]: 'start-date',

--- a/extensions/amp-date-picker/0.1/amp-date-picker.js
+++ b/extensions/amp-date-picker/0.1/amp-date-picker.js
@@ -627,24 +627,28 @@ export class AmpDatePicker extends AMP.BaseElement {
    * Date pickers not in a form don't need named hidden inputs.
    * @param {!Element} form
    * @param {!DateFieldType} type
+   * @return {string}
    * @private
    */
   getHiddenInputId_(form, type) {
     const id = this.element.id;
     const name = DateFieldNameByType[type];
-    if (form) {
-      const alternativeName = `${id}-${name}`;
-      if (!form.elements[name]) {
-        return name;
-      } else if (id && !form.elements[alternativeName]) {
-        return alternativeName;
-      } else {
-        user().error(TAG,
-            `Multiple date-pickers with implicit ${name} fields ` +
-            'need to have IDs');
-        return '';
-      }
+    if (!form) {
+      return '';
     }
+
+    if (!form.elements[name]) {
+      return name;
+    }
+
+    const alternativeName = `${id}-${name}`;
+    if (id && !form.elements[alternativeName]) {
+      return alternativeName;
+    }
+
+    user().error(TAG, `Multiple date-pickers with implicit ${name} fields ` +
+        'need to have IDs');
+    return '';
   }
 
   /**

--- a/extensions/amp-date-picker/0.1/amp-date-picker.js
+++ b/extensions/amp-date-picker/0.1/amp-date-picker.js
@@ -130,6 +130,13 @@ const DateFieldType = {
 };
 
 /** @enum {string} */
+const DateFieldNameByType = {
+  [DateFieldType.DATE]: 'date',
+  [DateFieldType.START_DATE]: 'start-date',
+  [DateFieldType.END_DATE]: 'end-date',
+};
+
+/** @enum {string} */
 const DatePickerEvent = {
   /**
    * Triggered when the overlay opens or when the static date picker should
@@ -624,15 +631,16 @@ export class AmpDatePicker extends AMP.BaseElement {
    */
   getHiddenInputId_(form, type) {
     const id = this.element.id;
+    const name = DateFieldNameByType[type];
     if (form) {
-      const alternativeName = `${id}-${type}`;
-      if (!form.elements[type]) {
-        return type;
+      const alternativeName = `${id}-${name}`;
+      if (!form.elements[name]) {
+        return name;
       } else if (id && !form.elements[alternativeName]) {
-        return `${id}-${type}`;
+        return alternativeName;
       } else {
         user().error(TAG,
-            `Multiple date-pickers with implicit ${type} fields` +
+            `Multiple date-pickers with implicit ${name} fields ` +
             'need to have IDs');
         return '';
       }
@@ -652,6 +660,7 @@ export class AmpDatePicker extends AMP.BaseElement {
       this.listen_(root, 'click', this.handleClick_.bind(this));
     }
     this.listen_(root, 'input', this.handleInput_.bind(this));
+    // TODO(cvializ): Add aria message to use down arrow to trigger calendar.
     this.listen_(root, 'focusin', this.handleFocus_.bind(this));
     this.listen_(root, 'keydown', this.handleKeydown_.bind(this));
   }

--- a/extensions/amp-date-picker/0.1/amp-date-picker.js
+++ b/extensions/amp-date-picker/0.1/amp-date-picker.js
@@ -606,19 +606,20 @@ export class AmpDatePicker extends AMP.BaseElement {
     const fieldSelector = this.element.getAttribute(`${type}-selector`);
     const existingField = this.getAmpDoc().getRootNode().querySelector(
         fieldSelector);
-    const form = this.element.closest('form');
-
     if (existingField) {
       return existingField;
-    } else if (this.mode_ == DatePickerMode.STATIC && form) {
+    }
+
+    const form = this.element.closest('form');
+    if (this.mode_ == DatePickerMode.STATIC && form) {
       const hiddenInput = this.document_.createElement('input');
       hiddenInput.type = 'hidden';
       hiddenInput.name = this.getHiddenInputId_(form, type);
       this.element.appendChild(hiddenInput);
       return hiddenInput;
-    } else {
-      return null;
     }
+
+    return null;
   }
 
   /**

--- a/extensions/amp-date-picker/0.1/test/test-amp-date-picker.js
+++ b/extensions/amp-date-picker/0.1/test/test-amp-date-picker.js
@@ -248,7 +248,7 @@ describes.realWin('amp-date-picker', {
         });
       });
 
-      it('should name one of the inputs `${id}-date` when another ' +
+      it('should name an input `${id}-(start|end)-date` when another ' +
           '#(start|end)-date input exists', () => {
         const form = document.createElement('form');
         const startDateInput = document.createElement('input');
@@ -267,7 +267,7 @@ describes.realWin('amp-date-picker', {
         });
       });
 
-      it('should name both of the inputs `${id}-date` when other ' +
+      it('should name both inputs `${id}-(start|end)-date` when other ' +
           '#start-date and #end-date inputs exists', () => {
         const form = document.createElement('form');
         const startDateInput = document.createElement('input');

--- a/extensions/amp-date-picker/0.1/test/test-amp-date-picker.js
+++ b/extensions/amp-date-picker/0.1/test/test-amp-date-picker.js
@@ -20,7 +20,7 @@ import {toggleExperiment} from '../../../../src/experiments';
 
 describes.realWin('amp-date-picker', {
   amp: {
-    runtimeOn: true,
+    runtimeOn: false,
     extensions: ['amp-date-picker'],
   },
 }, env => {
@@ -45,19 +45,23 @@ describes.realWin('amp-date-picker', {
     height: '360',
   };
 
-  function createDatePicker(opt_attrs) {
+  function createDatePicker(opt_attrs, opt_parent = document.body) {
     const element = document.createElement('amp-date-picker');
     const attrs = Object.assign({}, DEFAULT_ATTRS, opt_attrs);
     for (const key in attrs) {
       element.setAttribute(key, attrs[key]);
     }
 
-    document.body.appendChild(element);
+    opt_parent.appendChild(element);
     const picker = new AmpDatePicker(element);
 
     return {
       element,
       picker,
+      layoutCallback() {
+        return Promise.resolve(picker.buildCallback())
+            .then(() => picker.layoutCallback());
+      },
     };
   }
 
@@ -97,12 +101,12 @@ describes.realWin('amp-date-picker', {
   });
 
   it('should render in the simplest case', () => {
-    const {picker} = createDatePicker({
+    const {picker, layoutCallback} = createDatePicker({
       layout: 'fixed-height',
       height: 360,
     });
 
-    return picker.layoutCallback().then(() => {
+    return layoutCallback().then(() => {
       const container = picker.container_;
       expect(container.children.length).to.be.greaterThan(0);
     });
@@ -154,7 +158,7 @@ describes.realWin('amp-date-picker', {
         const defaultTemplate = createDateTemplate('{{val}}', {
           id: 'defaultTemplate',
         });
-        const {picker, element} = createDatePicker();
+        const {element, picker} = createDatePicker();
         element.appendChild(template);
         element.appendChild(defaultTemplate);
 
@@ -165,6 +169,142 @@ describes.realWin('amp-date-picker', {
         expect(srcTemplates[0].dates.contains('2018-01-03')).to.be.true;
         expect(srcTemplates[0].template).to.equal(template);
         expect(srcDefaultTemplate).to.equal(defaultTemplate);
+      });
+    });
+
+    describe('hidden inputs in single date picker in forms', () => {
+      it('should not create hidden inputs outside of forms', () => {
+        const {element} = createDatePicker();
+
+        expect(element.querySelector('input[type="hidden"]')).to.be.null;
+      });
+
+      it('should create a hidden input when inside a form', () => {
+        const form = document.createElement('form');
+        document.body.appendChild(form);
+        const {element, layoutCallback} = createDatePicker({}, form);
+
+        return layoutCallback().then(() => {
+          const input = element.querySelector('input[type="hidden"]');
+          expect(input).to.not.be.null;
+          expect(input.name).to.equal('date');
+        });
+      });
+
+      it('should name the input `${id}-date` when another ' +
+          '#date input exists', () => {
+        const form = document.createElement('form');
+        const dateInput = document.createElement('input');
+        dateInput.type = 'hidden';
+        dateInput.name = 'date';
+        form.appendChild(dateInput);
+        document.body.appendChild(form);
+        const {element, layoutCallback} =
+            createDatePicker({id: 'delivery'}, form);
+
+        return layoutCallback().then(() => {
+          const input = element.querySelector('input[type="hidden"]');
+          expect(input).to.not.be.null;
+          expect(input.name).to.equal('delivery-date');
+        });
+      });
+
+      it('should error if the input when another ' +
+          '#date input exists and the picker has no ID', () => {
+        const form = document.createElement('form');
+        const dateInput = document.createElement('input');
+        dateInput.type = 'hidden';
+        dateInput.name = 'date';
+        form.appendChild(dateInput);
+        document.body.appendChild(form);
+
+        const {layoutCallback} = createDatePicker({}, form);
+
+        allowConsoleError(() => {
+          expect(layoutCallback()).to.be.rejectedWith(
+              'another #date input exists');
+        });
+      });
+    });
+
+    describe('hidden inputs in range date picker in forms', () => {
+      it('should not create hidden inputs outside of forms', () => {
+        const {element} = createDatePicker({type: 'range'});
+
+        expect(element.querySelector('input[type="hidden"]')).to.be.null;
+      });
+
+      it('should create a hidden input when inside a form', () => {
+        const form = document.createElement('form');
+        document.body.appendChild(form);
+        const {element, layoutCallback} =
+            createDatePicker({type: 'range'}, form);
+
+        return layoutCallback().then(() => {
+          const inputs = element.querySelectorAll('input[type="hidden"]');
+          expect(inputs.length).to.equal(2);
+          expect(inputs[0].name).to.equal('start-date');
+          expect(inputs[1].name).to.equal('end-date');
+        });
+      });
+
+      it('should name one of the inputs `${id}-date` when another ' +
+          '#(start|end)-date input exists', () => {
+        const form = document.createElement('form');
+        const startDateInput = document.createElement('input');
+        startDateInput.type = 'hidden';
+        startDateInput.name = 'start-date';
+        form.appendChild(startDateInput);
+        document.body.appendChild(form);
+        const {element, layoutCallback} =
+            createDatePicker({type: 'range', id: 'delivery'}, form);
+
+        return layoutCallback().then(() => {
+          const inputs = element.querySelectorAll('input[type="hidden"]');
+          expect(inputs.length).to.equal(2);
+          expect(inputs[0].name).to.equal('delivery-start-date');
+          expect(inputs[1].name).to.equal('end-date');
+        });
+      });
+
+      it('should name both of the inputs `${id}-date` when other ' +
+          '#start-date and #end-date inputs exists', () => {
+        const form = document.createElement('form');
+        const startDateInput = document.createElement('input');
+        startDateInput.type = 'hidden';
+        startDateInput.name = 'start-date';
+        form.appendChild(startDateInput);
+        const endDateInput = document.createElement('input');
+        endDateInput.type = 'hidden';
+        endDateInput.name = 'end-date';
+        form.appendChild(endDateInput);
+        document.body.appendChild(form);
+        const {element, layoutCallback} =
+            createDatePicker({type: 'range', id: 'delivery'}, form);
+
+        return layoutCallback().then(() => {
+          const inputs = element.querySelectorAll('input[type="hidden"]');
+          expect(inputs.length).to.equal(2);
+          expect(inputs[0].name).to.equal('delivery-start-date');
+          expect(inputs[1].name).to.equal('delivery-end-date');
+        });
+      });
+
+      it('should error if the input when another ' +
+          '#date input exists and the picker has no ID', () => {
+        const form = document.createElement('form');
+        const dateInput = document.createElement('input');
+        dateInput.type = 'hidden';
+        dateInput.name = 'start-date';
+        form.appendChild(dateInput);
+        document.body.appendChild(form);
+
+        const {layoutCallback} = createDatePicker({type: 'range'}, form);
+
+        allowConsoleError(() => {
+          expect(layoutCallback()).to.be.rejectedWith(
+              'another #start-date input exists');
+        });
       });
     });
   });

--- a/extensions/amp-date-picker/amp-date-picker.md
+++ b/extensions/amp-date-picker/amp-date-picker.md
@@ -90,7 +90,7 @@ By specifying `mode="static"`, the `amp-date-picker` renders a static calendar v
 
 For a static date picker, you must specify a size-defined layout, which can be one of: `fixed`, `fixed-height`, `responsive`, `fill` or `flex-item`.
 
-When the `static` amp-date-picker is rendered in a `<form>`, if there are no [inputs specified with `*input-selector`](#input-selector-[optional]), the amp-date-picker creates hidden input elements (e.g., `<input type="hidden" ...`). The amp-date-picker names the elements as `input` or `start-input` and `end-input`; if those names are already used in the form, the amp-date-picker attempts to name the input fields with the `id` of the `<amp-date-picker>`.
+When the `static` amp-date-picker is rendered in a `<form>`, if there are no [inputs specified with `*input-selector`](#input-selector-[optional]), the amp-date-picker creates hidden input elements (e.g., `<input type="hidden" ...`). The amp-date-picker names the elements as `date` or `start-date` and `end-date`; if those names are already used in the form, the amp-date-picker attempts to name the input fields with the `id` of the `<amp-date-picker>`.
 
 *Example: static date picker in a form field*
 
@@ -114,14 +114,14 @@ This example demonstrates using a static date picker in a form, where the user c
       layout="fixed-height"
       height="360">
     <!-- automatically generates hidden input fields:
-    <input type="hidden" name="start-input">
-    <input type="hidden" name="end-input"> -->
+    <input type="hidden" name="start-date">
+    <input type="hidden" name="end-date"> -->
   </amp-date-picker>
   <input type="submit" value="Subscribe">
 </fieldset>
 <div submit-success>
 <template type="amp-mustache">
-  Success! Thanks {{name}} for choosing {{start-input}} and {{end-input}}.
+  Success! Thanks {{name}} for choosing {{start-date}} and {{end-date}}.
 </template>
 </div>
 </form>
@@ -220,7 +220,7 @@ Specifies the selection type for the date picker. Allowed values are:
 
 A query selector for a single date picker's input. If this is omitted,
 the date picker automatically generates a hidden input field, and assigns it
-a name of `input` or `${id}-input` using the date picker's id. If either of these conflict
+a name of `date` or `${id}-date` using the date picker's id. If either of these conflict
 with an existing element in the form, an error is emitted.
 
 ```html
@@ -237,7 +237,7 @@ with an existing element in the form, an error is emitted.
 
 A query selector for a date range picker's start date input. If this is omitted,
 the date picker automatically generates a hidden input field, and assigns it
-a name of `start-input` or `${id}-start-input` using the date picker's id. If either of these conflict
+a name of `start-date` or `${id}-start-date` using the date picker's id. If either of these conflict
 with an existing element in the form, an error is emitted.
 
 ```html
@@ -253,7 +253,7 @@ with an existing element in the form, an error is emitted.
 
 A query selector for a date range picker's end date input. If this is omitted,
 the date picker automatically generates a hidden input field, and assigns it
-a name of `end-input` or `${id}-end-date` using the date picker's id. If either of these conflict
+a name of `end-date` or `${id}-end-date` using the date picker's id. If either of these conflict
 with an existing element in the form, an error is emitted.
 
 ```html


### PR DESCRIPTION
The names were too generic like "input" or "end-input" and meant to match with the `${type}-selector`, so I added a mapping from input type to hidden input name. To verify the behavior for the future, I added tests.