### PR TITLE
🐛 Delayed force-exit `gulp test` after Karma reports test completion

### DIFF
--- a/build-system/tasks/runtime-test.js
+++ b/build-system/tasks/runtime-test.js
@@ -371,7 +371,10 @@ function runTests() {
       log(
           red('ERROR:'),
           yellow('Karma test failed with exit code ' + exitCode));
-      process.exitCode = exitCode;
+      // TODO(rsimha): Remove this after Karma / Sauce ticket is resolved.
+      setTimeout(() => {
+        process.exit(exitCode);
+      }, 5000);
     }
     resolver();
   }).on('run_start', function() {

--- a/build-system/tasks/runtime-test.js
+++ b/build-system/tasks/runtime-test.js
@@ -371,7 +371,7 @@ function runTests() {
       log(
           red('ERROR:'),
           yellow('Karma test failed with exit code ' + exitCode));
-      // TODO(rsimha): Remove this after Karma / Sauce ticket is resolved.
+      // TODO(rsimha, 14814): Remove after Karma / Sauce ticket is resolved.
       setTimeout(() => {
         process.exit(exitCode);
       }, 5000);


### PR DESCRIPTION
There are several potential causes for the disconnect / timeout issues we're seeing on Travis, where Karma reports that all tests are complete, but `gulp test` doesn't terminate because something is holding it up from doing so.

For example, see https://travis-ci.org/ampproject/amphtml/jobs/370168309

**Related issues:**
- https://github.com/karma-runner/karma/issues/2980
- https://github.com/karma-runner/karma/issues/1035
- https://github.com/karma-runner/karma/issues/1788
- https://github.com/karma-runner/karma-sauce-launcher/issues/95

We have a ticket open with Sauce labs to investigate this.

Meanwhile, this PR temporarily mitigates the problem by force-exiting the `gulp test` process after a gap of 5 seconds, so that Karma reporters can print all their output to the console.