### PR TITLE
🚮 Cleanup AmpStory MediaTask private fields

### DIFF
--- a/extensions/amp-story/0.1/media-pool.js
+++ b/extensions/amp-story/0.1/media-pool.js
@@ -231,7 +231,7 @@ export class MediaPool {
           const sources = this.getDefaultSource_(type);
           mediaEl.setAttribute('pool-element', elId++);
           this.enqueueMediaElementTask_(mediaEl,
-              new UpdateSourcesTask(sources, this.vsync_));
+              new UpdateSourcesTask(sources));
           // TODO(newmuis): Check the 'error' field to see if MEDIA_ERR_DECODE
           // is returned.  If so, we should adjust the pool size/distribution
           // between media types.
@@ -462,12 +462,12 @@ export class MediaPool {
     poolMediaEl[REPLACED_MEDIA_PROPERTY_NAME] = domMediaEl.id;
 
     return this.enqueueMediaElementTask_(poolMediaEl,
-        new SwapIntoDomTask(domMediaEl, this.vsync_))
+        new SwapIntoDomTask(domMediaEl))
         .then(() => {
           this.maybeResetAmpMedia_(ampMediaForPoolEl);
           this.maybeResetAmpMedia_(ampMediaForDomEl);
           this.enqueueMediaElementTask_(poolMediaEl,
-              new UpdateSourcesTask(sources, this.vsync_));
+              new UpdateSourcesTask(sources));
           this.enqueueMediaElementTask_(poolMediaEl, new LoadTask());
         }, () => {
           this.forceDeallocateMediaElement_(poolMediaEl);
@@ -504,7 +504,7 @@ export class MediaPool {
     const defaultSources = this.getDefaultSource_(mediaType);
 
     return this.enqueueMediaElementTask_(poolMediaEl,
-        new UpdateSourcesTask(defaultSources, this.vsync_));
+        new UpdateSourcesTask(defaultSources));
   }
 
 
@@ -524,7 +524,7 @@ export class MediaPool {
         'No media element to put back into DOM after eviction.'));
 
     const swapOutOfDom = this.enqueueMediaElementTask_(poolMediaEl,
-        new SwapOutOfDomTask(oldDomMediaEl, this.vsync_))
+        new SwapOutOfDomTask(oldDomMediaEl))
         .then(() => {
           poolMediaEl[REPLACED_MEDIA_PROPERTY_NAME] = null;
         });

--- a/extensions/amp-story/0.1/media-tasks.js
+++ b/extensions/amp-story/0.1/media-tasks.js
@@ -352,16 +352,12 @@ export class UpdateSourcesTask extends MediaTask {
   /**
    * @param {!Sources} newSources The sources to which the media element should
    *     be updated.
-   * @param {!../../../src/service/vsync-impl.Vsync} vsync
    */
-  constructor(newSources, vsync) {
+  constructor(newSources) {
     super('update-src');
 
     /** @private @const {!Sources} */
     this.newSources_ = newSources;
-
-    /** @private @const {!../../../src/service/vsync-impl.Vsync} */
-    this.vsync_ = vsync;
   }
 
   /** @override */
@@ -380,16 +376,12 @@ export class SwapIntoDomTask extends MediaTask {
   /**
    * @param {!HTMLMediaElement} replacedMediaEl The element to be replaced by
    *     the media element on which this task is executed.
-   * @param {!../../../src/service/vsync-impl.Vsync} vsync
    */
-  constructor(replacedMediaEl, vsync) {
+  constructor(replacedMediaEl) {
     super('swap-into-dom');
 
     /** @private @const {!HTMLMediaElement} */
     this.replacedMediaEl_ = replacedMediaEl;
-
-    /** @private @const {!../../../src/service/vsync-impl.Vsync} */
-    this.vsync_ = vsync;
   }
 
   /** @override */
@@ -416,16 +408,12 @@ export class SwapOutOfDomTask extends MediaTask {
   /**
    * @param {!HTMLMediaElement} placeholderMediaEl The element to be replaced by
    *     the media element on which this task is executed.
-   * @param {!../../../src/service/vsync-impl.Vsync} vsync
    */
-  constructor(placeholderMediaEl, vsync) {
+  constructor(placeholderMediaEl) {
     super('swap-out-of-dom');
 
     /** @private @const {!HTMLMediaElement} */
     this.placeholderMediaEl_ = placeholderMediaEl;
-
-    /** @private @const {!../../../src/service/vsync-impl.Vsync} */
-    this.vsync_ = vsync;
   }
 
   /** @override */

--- a/extensions/amp-story/0.1/test/test-media-tasks.js
+++ b/extensions/amp-story/0.1/test/test-media-tasks.js
@@ -138,7 +138,7 @@ describes.realWin('media-tasks', {}, () => {
 
       expect(el.src).to.not.be.empty;
       const newSources = new Sources(null, []);
-      const task = new UpdateSourcesTask(newSources, vsyncApi);
+      const task = new UpdateSourcesTask(newSources);
       task.execute(el);
       expect(el.src).to.be.empty;
       expect(toArray(el.children)).to.be.empty;
@@ -152,7 +152,7 @@ describes.realWin('media-tasks', {}, () => {
 
       expect(toArray(el.children)).to.deep.equal(OLD_SRC_ELS);
       const newSources = new Sources(null, []);
-      const task = new UpdateSourcesTask(newSources, vsyncApi);
+      const task = new UpdateSourcesTask(newSources);
       task.execute(el);
       expect(el.src).to.be.empty;
       expect(toArray(el.children)).to.be.empty;
@@ -165,7 +165,7 @@ describes.realWin('media-tasks', {}, () => {
 
       expect(el.src).to.not.be.empty;
       const newSources = new Sources(NEW_SRC_URL, []);
-      const task = new UpdateSourcesTask(newSources, vsyncApi);
+      const task = new UpdateSourcesTask(newSources);
       task.execute(el);
       expect(el.src).to.equal(NEW_SRC_URL);
       expect(toArray(el.children)).to.be.empty;
@@ -181,7 +181,7 @@ describes.realWin('media-tasks', {}, () => {
 
       expect(toArray(el.children)).to.deep.equal(OLD_SRC_ELS);
       const newSources = new Sources(null, NEW_SRC_ELS);
-      const task = new UpdateSourcesTask(newSources, vsyncApi);
+      const task = new UpdateSourcesTask(newSources);
       task.execute(el);
       expect(el.src).to.be.empty;
       expect(toArray(el.children)).to.deep.equal(NEW_SRC_ELS);
@@ -206,7 +206,7 @@ describes.realWin('media-tasks', {}, () => {
       expect(replacedMedia.parentElement).to.equal(parent);
       expect(el.parentElement).to.equal(null);
 
-      const task = new SwapIntoDomTask(replacedMedia, vsyncApi);
+      const task = new SwapIntoDomTask(replacedMedia);
       return task.execute(el).then(() => {
         expect(replacedMedia.parentElement).to.equal(null);
         expect(el.parentElement).to.equal(parent);
@@ -225,7 +225,7 @@ describes.realWin('media-tasks', {}, () => {
       expect(el.parentElement).to.equal(parent);
       expect(placeholderEl.parentElement).to.equal(null);
 
-      const task = new SwapOutOfDomTask(placeholderEl, vsyncApi);
+      const task = new SwapOutOfDomTask(placeholderEl);
       return task.execute(el).then(() => {
         expect(el.parentElement).to.equal(null);
         expect(placeholderEl.parentElement).to.equal(parent);

--- a/extensions/amp-story/1.0/media-pool.js
+++ b/extensions/amp-story/1.0/media-pool.js
@@ -231,7 +231,7 @@ export class MediaPool {
           const sources = this.getDefaultSource_(type);
           mediaEl.setAttribute('pool-element', elId++);
           this.enqueueMediaElementTask_(mediaEl,
-              new UpdateSourcesTask(sources, this.vsync_));
+              new UpdateSourcesTask(sources));
           // TODO(newmuis): Check the 'error' field to see if MEDIA_ERR_DECODE
           // is returned.  If so, we should adjust the pool size/distribution
           // between media types.
@@ -462,12 +462,12 @@ export class MediaPool {
     poolMediaEl[REPLACED_MEDIA_PROPERTY_NAME] = domMediaEl.id;
 
     return this.enqueueMediaElementTask_(poolMediaEl,
-        new SwapIntoDomTask(domMediaEl, this.vsync_))
+        new SwapIntoDomTask(domMediaEl))
         .then(() => {
           this.maybeResetAmpMedia_(ampMediaForPoolEl);
           this.maybeResetAmpMedia_(ampMediaForDomEl);
           this.enqueueMediaElementTask_(poolMediaEl,
-              new UpdateSourcesTask(sources, this.vsync_));
+              new UpdateSourcesTask(sources));
           this.enqueueMediaElementTask_(poolMediaEl, new LoadTask());
         }, () => {
           this.forceDeallocateMediaElement_(poolMediaEl);
@@ -504,7 +504,7 @@ export class MediaPool {
     const defaultSources = this.getDefaultSource_(mediaType);
 
     return this.enqueueMediaElementTask_(poolMediaEl,
-        new UpdateSourcesTask(defaultSources, this.vsync_));
+        new UpdateSourcesTask(defaultSources));
   }
 
 
@@ -524,7 +524,7 @@ export class MediaPool {
         'No media element to put back into DOM after eviction.'));
 
     const swapOutOfDom = this.enqueueMediaElementTask_(poolMediaEl,
-        new SwapOutOfDomTask(oldDomMediaEl, this.vsync_))
+        new SwapOutOfDomTask(oldDomMediaEl))
         .then(() => {
           poolMediaEl[REPLACED_MEDIA_PROPERTY_NAME] = null;
         });

--- a/extensions/amp-story/1.0/media-tasks.js
+++ b/extensions/amp-story/1.0/media-tasks.js
@@ -352,16 +352,12 @@ export class UpdateSourcesTask extends MediaTask {
   /**
    * @param {!Sources} newSources The sources to which the media element should
    *     be updated.
-   * @param {!../../../src/service/vsync-impl.Vsync} vsync
    */
-  constructor(newSources, vsync) {
+  constructor(newSources) {
     super('update-src');
 
     /** @private @const {!Sources} */
     this.newSources_ = newSources;
-
-    /** @private @const {!../../../src/service/vsync-impl.Vsync} */
-    this.vsync_ = vsync;
   }
 
   /** @override */
@@ -380,16 +376,12 @@ export class SwapIntoDomTask extends MediaTask {
   /**
    * @param {!HTMLMediaElement} replacedMediaEl The element to be replaced by
    *     the media element on which this task is executed.
-   * @param {!../../../src/service/vsync-impl.Vsync} vsync
    */
-  constructor(replacedMediaEl, vsync) {
+  constructor(replacedMediaEl) {
     super('swap-into-dom');
 
     /** @private @const {!HTMLMediaElement} */
     this.replacedMediaEl_ = replacedMediaEl;
-
-    /** @private @const {!../../../src/service/vsync-impl.Vsync} */
-    this.vsync_ = vsync;
   }
 
   /** @override */
@@ -416,16 +408,12 @@ export class SwapOutOfDomTask extends MediaTask {
   /**
    * @param {!HTMLMediaElement} placeholderMediaEl The element to be replaced by
    *     the media element on which this task is executed.
-   * @param {!../../../src/service/vsync-impl.Vsync} vsync
    */
-  constructor(placeholderMediaEl, vsync) {
+  constructor(placeholderMediaEl) {
     super('swap-out-of-dom');
 
     /** @private @const {!HTMLMediaElement} */
     this.placeholderMediaEl_ = placeholderMediaEl;
-
-    /** @private @const {!../../../src/service/vsync-impl.Vsync} */
-    this.vsync_ = vsync;
   }
 
   /** @override */

--- a/extensions/amp-story/1.0/test/test-media-tasks.js
+++ b/extensions/amp-story/1.0/test/test-media-tasks.js
@@ -138,7 +138,7 @@ describes.realWin('media-tasks', {}, () => {
 
       expect(el.src).to.not.be.empty;
       const newSources = new Sources(null, []);
-      const task = new UpdateSourcesTask(newSources, vsyncApi);
+      const task = new UpdateSourcesTask(newSources);
       task.execute(el);
       expect(el.src).to.be.empty;
       expect(toArray(el.children)).to.be.empty;
@@ -152,7 +152,7 @@ describes.realWin('media-tasks', {}, () => {
 
       expect(toArray(el.children)).to.deep.equal(OLD_SRC_ELS);
       const newSources = new Sources(null, []);
-      const task = new UpdateSourcesTask(newSources, vsyncApi);
+      const task = new UpdateSourcesTask(newSources);
       task.execute(el);
       expect(el.src).to.be.empty;
       expect(toArray(el.children)).to.be.empty;
@@ -165,7 +165,7 @@ describes.realWin('media-tasks', {}, () => {
 
       expect(el.src).to.not.be.empty;
       const newSources = new Sources(NEW_SRC_URL, []);
-      const task = new UpdateSourcesTask(newSources, vsyncApi);
+      const task = new UpdateSourcesTask(newSources);
       task.execute(el);
       expect(el.src).to.equal(NEW_SRC_URL);
       expect(toArray(el.children)).to.be.empty;
@@ -181,7 +181,7 @@ describes.realWin('media-tasks', {}, () => {
 
       expect(toArray(el.children)).to.deep.equal(OLD_SRC_ELS);
       const newSources = new Sources(null, NEW_SRC_ELS);
-      const task = new UpdateSourcesTask(newSources, vsyncApi);
+      const task = new UpdateSourcesTask(newSources);
       task.execute(el);
       expect(el.src).to.be.empty;
       expect(toArray(el.children)).to.deep.equal(NEW_SRC_ELS);
@@ -206,7 +206,7 @@ describes.realWin('media-tasks', {}, () => {
       expect(replacedMedia.parentElement).to.equal(parent);
       expect(el.parentElement).to.equal(null);
 
-      const task = new SwapIntoDomTask(replacedMedia, vsyncApi);
+      const task = new SwapIntoDomTask(replacedMedia);
       return task.execute(el).then(() => {
         expect(replacedMedia.parentElement).to.equal(null);
         expect(el.parentElement).to.equal(parent);
@@ -225,7 +225,7 @@ describes.realWin('media-tasks', {}, () => {
       expect(el.parentElement).to.equal(parent);
       expect(placeholderEl.parentElement).to.equal(null);
 
-      const task = new SwapOutOfDomTask(placeholderEl, vsyncApi);
+      const task = new SwapOutOfDomTask(placeholderEl);
       return task.execute(el).then(() => {
         expect(el.parentElement).to.equal(null);
         expect(placeholderEl.parentElement).to.equal(parent);


### PR DESCRIPTION
`vsync_` appears unused in all.

Part of #14761.

