### PR TITLE
🐛 Call `self.emitAsync('exit')` on Karma instead of calling `process.exit` on `gulp test`

### DIFF
--- a/build-system/tasks/runtime-test.js
+++ b/build-system/tasks/runtime-test.js
@@ -371,10 +371,8 @@ function runTests() {
       log(
           red('ERROR:'),
           yellow('Karma test failed with exit code ' + exitCode));
-      // TODO(rsimha, 14814): Remove after Karma / Sauce ticket is resolved.
-      setTimeout(() => {
-        process.exit(exitCode);
-      }, 5000);
+      process.exitCode = exitCode;
+      self.emitAsync('exit');
     }
     resolver();
   }).on('run_start', function() {


### PR DESCRIPTION
We're battling timeout errors on Travis due to Karma / Sauce, and in order to temporarily mitigate them, #14814 added a call to `process.exit` on the `gulp test` process after all browsers have reported their test completion.

In this PR, we replace the call to `process.exit()` with a call to `self.emitAsync('exit')` on the Karma server object. It's definitely more elegant than calling `process.exit()` on the parent process. What's left to be seen is if Travis likes this alternative method of force-closing the Karma server.

I'll test this a few times on Travis and merge it if things look good.

Borrowed from [here](https://github.com/karma-runner/karma/blob/2270abb805793463f8193779620f8cae67edff33/lib/server.js#L427).
Follow up to #14814
