### PR TITLE
🐛 amp-next-page: Set overflow-y: hidden on child document body elements

### DIFF
--- a/extensions/amp-next-page/0.1/amp-next-page.css
+++ b/extensions/amp-next-page/0.1/amp-next-page.css
@@ -27,6 +27,10 @@
   font-size: 17px;
 }
 
+.i-amphtml-next-page-document {
+  overflow-y: hidden;
+}
+
 .i-amphtml-next-page-document > *[i-amphtml-fixedid] {
   display: none;
 }


### PR DESCRIPTION
Auto (default) can cause double scrollbars in certain cases, e.g. where the last element in the body has `position: absolute`. `overflow-y: visible` works too, but causes the document to overlap the content below.