### PR TITLE
Use inherited isLayoutSupported

### DIFF
--- a/extensions/amp-app-banner/0.1/amp-app-banner.js
+++ b/extensions/amp-app-banner/0.1/amp-app-banner.js
@@ -15,7 +15,6 @@
  */
 
 import {CSS} from '../../../build/amp-app-banner-0.1.css';
-import {Layout} from '../../../src/layout';
 import {Services} from '../../../src/services';
 import {assertHttpsUrl} from '../../../src/url';
 import {dev, rethrowAsync, user} from '../../../src/log';
@@ -42,11 +41,6 @@ export class AbstractAppBanner extends AMP.BaseElement {
 
     /** @protected {boolean} */
     this.canShowBuiltinBanner_ = false;
-  }
-
-  /** @override */
-  isLayoutSupported(layout) {
-    return layout == Layout.NODISPLAY;
   }
 
   /**

--- a/extensions/amp-consent/0.1/amp-consent.js
+++ b/extensions/amp-consent/0.1/amp-consent.js
@@ -20,7 +20,6 @@ import {
   ConsentPolicyManager,
   MULTI_CONSENT_EXPERIMENT,
 } from './consent-policy-manager';
-import {Layout} from '../../../src/layout';
 import {
   NOTIFICATION_UI_MANAGER,
   NotificationUiManager,
@@ -272,11 +271,6 @@ export class AmpConsent extends AMP.BaseElement {
     }
     // Hide current dialog
     this.hide_();
-  }
-
-  /** @override */
-  isLayoutSupported(layout) {
-    return layout == Layout.NODISPLAY;
   }
 
   /**

--- a/extensions/amp-geo/0.1/amp-geo.js
+++ b/extensions/amp-geo/0.1/amp-geo.js
@@ -35,7 +35,6 @@
  * the amp-geo element's layout type is nodisplay.
  */
 
-import {Layout} from '../../../src/layout';
 import {getMode} from '../../../src/mode';
 import {isArray, isObject} from '../../../src/types';
 import {isCanary} from '../../../src/experiments';
@@ -86,11 +85,6 @@ export class AmpGeo extends AMP.BaseElement {
     /** @private {Array<string>} */
     this.matchedGroups_ = [];
     /** @Private {} */
-  }
-
-  /** @override */
-  isLayoutSupported(layout) {
-    return layout == Layout.NODISPLAY;
   }
 
   /** @override */

--- a/extensions/amp-image-lightbox/0.1/amp-image-lightbox.js
+++ b/extensions/amp-image-lightbox/0.1/amp-image-lightbox.js
@@ -27,7 +27,6 @@ import {
 } from '../../../src/gesture-recognizers';
 import {Gestures} from '../../../src/gesture';
 import {KeyCodes} from '../../../src/utils/key-codes';
-import {Layout} from '../../../src/layout';
 import {Services} from '../../../src/services';
 import {bezierCurve} from '../../../src/curve';
 import {continueMotion} from '../../../src/motion';
@@ -756,11 +755,6 @@ class AmpImageLightbox extends AMP.BaseElement {
 
     /** @private {function(this:AmpImageLightbox, Event)} */
     this.boundCloseOnEscape_ = this.closeOnEscape_.bind(this);
-  }
-
-  /** @override */
-  isLayoutSupported(layout) {
-    return layout == Layout.NODISPLAY;
   }
 
   /**

--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -28,7 +28,6 @@ import {
 } from './service/lightbox-manager-impl';
 import {Gestures} from '../../../src/gesture';
 import {KeyCodes} from '../../../src/utils/key-codes';
-import {Layout} from '../../../src/layout';
 import {Services} from '../../../src/services';
 import {SwipeYRecognizer} from '../../../src/gesture-recognizers';
 import {bezierCurve} from '../../../src/curve';
@@ -172,11 +171,6 @@ export class AmpLightboxGallery extends AMP.BaseElement {
 
     /** @private {?Element} */
     this.sourceElement_ = null;
-  }
-
-  /** @override */
-  isLayoutSupported(layout) {
-    return layout == Layout.NODISPLAY;
   }
 
   /** @override */

--- a/extensions/amp-lightbox/0.1/amp-lightbox.js
+++ b/extensions/amp-lightbox/0.1/amp-lightbox.js
@@ -20,7 +20,6 @@ import {AmpEvents} from '../../../src/amp-events';
 import {CSS} from '../../../build/amp-lightbox-0.1.css';
 import {Gestures} from '../../../src/gesture';
 import {KeyCodes} from '../../../src/utils/key-codes';
-import {Layout} from '../../../src/layout';
 import {Services} from '../../../src/services';
 import {SwipeXYRecognizer} from '../../../src/gesture-recognizers';
 import {computedStyle, setImportantStyles} from '../../../src/style';
@@ -96,11 +95,6 @@ class AmpLightbox extends AMP.BaseElement {
 
     this.registerAction('open', this.activate.bind(this));
     this.registerAction('close', this.close.bind(this));
-  }
-
-  /** @override */
-  isLayoutSupported(layout) {
-    return layout == Layout.NODISPLAY;
   }
 
   /**

--- a/extensions/amp-position-observer/0.1/amp-position-observer.js
+++ b/extensions/amp-position-observer/0.1/amp-position-observer.js
@@ -16,13 +16,6 @@
 
 import {ActionTrust} from '../../../src/action-trust';
 import {
-  Layout,
-  assertLength,
-  getLengthNumeral,
-  getLengthUnits,
-  parseLength,
-} from '../../../src/layout';
-import {
   PositionObserverFidelity,
 } from '../../../src/service/position-observer/position-observer-worker';
 import {
@@ -31,6 +24,12 @@ import {
   layoutRectsRelativePos,
 } from '../../../src/layout-rect';
 import {Services} from '../../../src/services';
+import {
+  assertLength,
+  getLengthNumeral,
+  getLengthUnits,
+  parseLength,
+} from '../../../src/layout';
 import {createCustomEvent} from '../../../src/event-helper';
 import {dev, user} from '../../../src/log';
 import {getServiceForDoc} from '../../../src/service';
@@ -94,11 +93,6 @@ export class AmpVisibilityObserver extends AMP.BaseElement {
 
     /** @private {number} */
     this.scrollProgress_ = 0;
-  }
-
-  /** @override */
-  isLayoutSupported(layout) {
-    return layout == Layout.NODISPLAY;
   }
 
   /** @override */

--- a/extensions/amp-sidebar/0.1/amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.js
@@ -17,7 +17,6 @@
 import {ActionTrust} from '../../../src/action-trust';
 import {CSS} from '../../../build/amp-sidebar-0.1.css';
 import {KeyCodes} from '../../../src/utils/key-codes';
-import {Layout} from '../../../src/layout';
 import {Services} from '../../../src/services';
 import {Toolbar} from './toolbar';
 import {closestByTag, isRTL, tryFocus} from '../../../src/dom';
@@ -96,11 +95,6 @@ export class AmpSidebar extends AMP.BaseElement {
 
     /** @private {number} */
     this.initialScrollTop_ = 0;
-  }
-
-  /** @override */
-  isLayoutSupported(layout) {
-    return layout == Layout.NODISPLAY;
   }
 
   /** @override */

--- a/extensions/amp-sticky-ad/1.0/amp-sticky-ad.js
+++ b/extensions/amp-sticky-ad/1.0/amp-sticky-ad.js
@@ -16,7 +16,6 @@
 
 import {CSS} from '../../../build/amp-sticky-ad-1.0.css';
 import {CommonSignals} from '../../../src/common-signals';
-import {Layout} from '../../../src/layout';
 import {computedStyle, toggle} from '../../../src/style';
 import {dev,user} from '../../../src/log';
 import {
@@ -51,11 +50,6 @@ class AmpStickyAd extends AMP.BaseElement {
 
     /** @private {?Promise} */
     this.adReadyPromise_ = null;
-  }
-
-  /** @override */
-  isLayoutSupported(layout) {
-    return layout == Layout.NODISPLAY;
   }
 
   /** @override */

--- a/extensions/amp-web-push/0.1/amp-web-push-config.js
+++ b/extensions/amp-web-push/0.1/amp-web-push-config.js
@@ -15,7 +15,6 @@
  */
 
 import {CONFIG_TAG, SERVICE_TAG, TAG} from './vars';
-import {Layout} from '../../../src/layout';
 import {dev, user} from '../../../src/log';
 import {escapeCssSelectorIdent} from '../../../src/dom';
 import {getServiceForDoc} from '../../../src/service';
@@ -58,11 +57,6 @@ export class WebPushConfig extends AMP.BaseElement {
   /** @param {!AmpElement} element */
   constructor(element) {
     super(element);
-  }
-
-  /** @override */
-  isLayoutSupported(layout) {
-    return layout == Layout.NODISPLAY;
   }
 
   /**


### PR DESCRIPTION
TIL that the default `isLayoutSupported` just checks for `NODISPLAY`. So, there's no need to duplicate that in all these extensions.

64 bytes in 10 extensions, ~28b gziped for each. Small wins.