### PR TITLE
🐛 Fix self-closing tags

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -65,8 +65,9 @@
     "key-spacing": 2,
     "max-len": [2, 80, 4, {
       "ignoreComments": true,
-      "ignoreUrls": true,
-      "ignorePattern": "^import.*';|}\\ from.*;|.*require\\(.*;$"
+      "ignoreRegExpLiterals": true,
+      "ignorePattern": "^import.*';|}\\ from.*;|.*require\\(.*;$",
+      "ignoreUrls": true
     }],
     "no-alert": 2,
     "no-cond-assign": 2,

--- a/build-system/eslint-rules/html-template.js
+++ b/build-system/eslint-rules/html-template.js
@@ -65,6 +65,38 @@ module.exports = function(context) {
           ' HEAD root elements. Please do so manually with' +
           ' document.createElement.');
     }
+
+    const invalids = invalidVoidTag(string);
+    if (invalids.length) {
+      const sourceCode = context.getSourceCode();
+      const {start} = template;
+
+      for (let i = 0; i < invalids.length; i++) {
+        const {tag, offset} = invalids[i];
+        context.report({
+          node: template,
+          loc: sourceCode.getLocFromIndex(start + offset),
+          message: `Invalid void tag "${tag}"`,
+        });
+      }
+    }
+  }
+
+  function invalidVoidTag(string) {
+    // Void tags are defined at
+    // https://html.spec.whatwg.org/multipage/syntax.html#void-elements
+    const invalid = /<(?!area|base|br|col|embed|hr|img|input|link|meta|param|source|track|wbr)([a-zA-Z-]+)[^>]+\/>/g;
+    const matches = [];
+
+    let match;
+    while ((match = invalid.exec(string))) {
+      matches.push({
+        tag: match[1],
+        offset: match.index,
+      });
+    }
+
+    return matches;
   }
 
   return {

--- a/build-system/eslint-rules/html-template.js
+++ b/build-system/eslint-rules/html-template.js
@@ -85,7 +85,7 @@ module.exports = function(context) {
   function invalidVoidTag(string) {
     // Void tags are defined at
     // https://html.spec.whatwg.org/multipage/syntax.html#void-elements
-    const invalid = /<(?!area|base|br|col|embed|hr|img|input|link|meta|param|source|track|wbr)([a-zA-Z-]+)[^>]+\/>/g;
+    const invalid = /<(?!area|base|br|col|embed|hr|img|input|link|meta|param|source|track|wbr)([a-zA-Z-]+) [^>]+\/>/g;
     const matches = [];
 
     let match;

--- a/build-system/eslint-rules/html-template.js
+++ b/build-system/eslint-rules/html-template.js
@@ -85,7 +85,7 @@ module.exports = function(context) {
   function invalidVoidTag(string) {
     // Void tags are defined at
     // https://html.spec.whatwg.org/multipage/syntax.html#void-elements
-    const invalid = /<(?!area|base|br|col|embed|hr|img|input|link|meta|param|source|track|wbr)([a-zA-Z-]+) [^>]+\/>/g;
+    const invalid = /<(?!area|base|br|col|embed|hr|img|input|link|meta|param|source|track|wbr)([a-zA-Z-]+)( [^>]*)?\/>/g;
     const matches = [];
 
     let match;

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -1515,7 +1515,7 @@ function createBaseCustomElementClass(win) {
 
         const container = htmlFor(doc)`
             <div class="i-amphtml-loading-container i-amphtml-fill-content
-              amp-hidden" />`;
+              amp-hidden"></div>`;
 
         const element = createLoaderElement(doc, this.elementName());
         container.appendChild(element);

--- a/src/loader.js
+++ b/src/loader.js
@@ -31,12 +31,12 @@ const LINE_LOADER_ELEMENTS = {
 export function createLoaderElement(doc, elementName) {
   if (LINE_LOADER_ELEMENTS[elementName.toUpperCase()]) {
     return htmlFor(doc)`<div class="i-amphtml-loader-line">
-          <div class="i-amphtml-loader-moving-line" />
+          <div class="i-amphtml-loader-moving-line"></div>
         </div>`;
   }
   return htmlFor(doc)`<div class="i-amphtml-loader">
-        <div class="i-amphtml-loader-dot" />
-        <div class="i-amphtml-loader-dot" />
-        <div class="i-amphtml-loader-dot" />
+        <div class="i-amphtml-loader-dot"></div>
+        <div class="i-amphtml-loader-dot"></div>
+        <div class="i-amphtml-loader-dot"></div>
       </div>`;
 }

--- a/src/service/fixed-layer.js
+++ b/src/service/fixed-layer.js
@@ -620,7 +620,7 @@ export class FixedLayer {
       // Never been transfered before: ensure that it's properly configured.
       setStyle(element, 'pointer-events', 'initial');
       const placeholder = fe.placeholder = htmlFor(element)`
-          <i-amphtml-fpa style="display: none" />`;
+          <i-amphtml-fpa style="display: none"></i-amphtml-fpa>`;
       placeholder.setAttribute('i-amphtml-fixedid', fe.id);
     }
 

--- a/src/service/jank-meter.js
+++ b/src/service/jank-meter.js
@@ -119,7 +119,7 @@ export class JankMeter {
   displayMeterDisplay_(batteryDrop) {
     const doc = this.win_.document;
     const display = htmlFor(doc)`
-      <div class="i-amphtml-jank-meter" />`;
+      <div class="i-amphtml-jank-meter"></div>`;
     display.textContent =
         `bf:${this.badFrameCnt_}, lts: ${this.longTaskSelf_}, ` +
         `ltc:${this.longTaskChild_}, bd:${batteryDrop}`;

--- a/test/functional/test-fixed-layer.js
+++ b/test/functional/test-fixed-layer.js
@@ -314,7 +314,8 @@ describe('FixedLayer', () => {
           return;
         }
         // Updating the placeholder means we have to update the tests.
-        expect(html.trim()).to.equal('<i-amphtml-fpa style="display: none" />');
+        expect(html.trim()).to.equal(
+            '<i-amphtml-fpa style="display: none"></i-amphtml-fpa>');
         this.firstElementChild = createElement('i-amphtml-fpa');
         this.firstElementChild.style.display = 'none';
       },


### PR DESCRIPTION
Some rendering scenarios cause the elements to be nested as opposed to siblings:

![2018-04-24](https://user-images.githubusercontent.com/254946/39213317-15087e44-47c6-11e8-9155-f2d475f103d6.png)
