### PR TITLE
:bug: Filter out internal AMP GSA parameter from URLs.

### DIFF
--- a/src/url.js
+++ b/src/url.js
@@ -55,6 +55,9 @@ let cache;
 /** @private @const Matches amp_js_* parameters in query string. */
 const AMP_JS_PARAMS_REGEX = /[?&]amp_js[^&]*/;
 
+/** @private @const Matches amp_gsa parameters in query string. */
+const AMP_GSA_PARAMS_REGEX = /[?&]amp_gsa[^&]*/;
+
 /** @private @const Matches usqp parameters from goog experiment in query string. */
 const GOOGLE_EXPERIMENT_PARAMS_REGEX = /[?&]usqp[^&]*/;
 
@@ -387,6 +390,7 @@ function removeAmpJsParams(urlSearch) {
   }
   const search = urlSearch
       .replace(AMP_JS_PARAMS_REGEX, '')
+      .replace(AMP_GSA_PARAMS_REGEX, '')
       .replace(GOOGLE_EXPERIMENT_PARAMS_REGEX, '')
       .replace(/^[?&]/, ''); // Removes first ? or &.
   return search ? '?' + search : '';


### PR DESCRIPTION
Support for detecting a new "amp_gsa" parameter was recently added to facilitate embedding within Chrome Custom Tabs (CCT).

Like other internal parameters (i.e., amp_js_v), this parameter should be filtered from URLs prior to further processing.

This change implements this behavior.