### PR TITLE
Story audio improvements.

### DIFF
--- a/extensions/amp-story/0.1/amp-story-store-service.js
+++ b/extensions/amp-story/0.1/amp-story-store-service.js
@@ -31,6 +31,7 @@ const TAG = 'amp-story';
  *    canshowpreviouspagehelp: boolean,
  *    canshowsharinguis: boolean,
  *    canshowsystemlayerbuttons: boolean,
+ *    adstate: boolean,
  *    bookendstate: boolean,
  *    desktopstate: boolean,
  *    hasaudiostate: boolean,

--- a/extensions/amp-story/0.1/amp-story-store-service.js
+++ b/extensions/amp-story/0.1/amp-story-store-service.js
@@ -242,9 +242,9 @@ export class AmpStoryStoreService {
     });
   }
 
+  // @TODO(gmajoulet): These should get their own file if they start growing.
   /**
    * Retrieves the embed mode config, that will override the default state.
-   * @todo(gmajoulet): These should get their own file if they start growing.
    * @return {!Object<StateProperty, *>} Partial state
    * @private
    */

--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -453,7 +453,11 @@ export class AmpStory extends AMP.BaseElement {
     });
   }
 
-  /** @private */
+  /**
+   * @param {number} deltaX
+   * @return {boolean}
+   * @private
+   */
   isSwipeLargeEnoughForHint_(deltaX) {
     return (Math.abs(deltaX) >= MIN_SWIPE_FOR_HINT_OVERLAY_PX);
   }

--- a/extensions/amp-story/1.0/amp-story-store-service.js
+++ b/extensions/amp-story/1.0/amp-story-store-service.js
@@ -31,6 +31,7 @@ const TAG = 'amp-story';
  *    canshowpreviouspagehelp: boolean,
  *    canshowsharinguis: boolean,
  *    canshowsystemlayerbuttons: boolean,
+ *    adstate: boolean,
  *    bookendstate: boolean,
  *    desktopstate: boolean,
  *    hasaudiostate: boolean,

--- a/extensions/amp-story/1.0/amp-story-store-service.js
+++ b/extensions/amp-story/1.0/amp-story-store-service.js
@@ -242,9 +242,9 @@ export class AmpStoryStoreService {
     });
   }
 
+  // @TODO(gmajoulet): These should get their own file if they start growing.
   /**
    * Retrieves the embed mode config, that will override the default state.
-   * @todo(gmajoulet): These should get their own file if they start growing.
    * @return {!Object<StateProperty, *>} Partial state
    * @private
    */

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -1047,7 +1047,7 @@ export class AmpStory extends AMP.BaseElement {
       return;
     }
 
-    isAd ? this.muteBackgroundAudio_() : this.unmuteBackgroundAudio_();
+    isAd ? this.pauseBackgroundAudio_() : this.playBackgroundAudio_();
   }
 
   /**
@@ -1529,21 +1529,20 @@ export class AmpStory extends AMP.BaseElement {
    * @private
    */
   mute_() {
-    this.muteBackgroundAudio_();
+    this.pauseBackgroundAudio_();
     if (this.activePage_) {
       this.activePage_.muteAllMedia();
     }
   }
 
   /**
-   * Mutes and pauses the background audio.
+   * Pauses the background audio.
    * @private
    */
-  muteBackgroundAudio_() {
+  pauseBackgroundAudio_() {
     if (!this.backgroundAudioEl_) {
       return;
     }
-    this.mediaPool_.mute(this.backgroundAudioEl_);
     this.mediaPool_.pause(this.backgroundAudioEl_);
   }
 
@@ -1553,7 +1552,7 @@ export class AmpStory extends AMP.BaseElement {
    */
   unmute_() {
     const unmuteAllMedia = () => {
-      this.unmuteBackgroundAudio_();
+      this.playBackgroundAudio_();
       if (this.activePage_) {
         this.activePage_.unmuteAllMedia();
       }
@@ -1567,7 +1566,7 @@ export class AmpStory extends AMP.BaseElement {
    * Unmutes and plays the background audio.
    * @private
    */
-  unmuteBackgroundAudio_() {
+  playBackgroundAudio_() {
     if (!this.backgroundAudioEl_) {
       return;
     }

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -485,7 +485,11 @@ export class AmpStory extends AMP.BaseElement {
     });
   }
 
-  /** @private */
+  /**
+   * @param {number} deltaX
+   * @return {boolean}
+   * @private
+   */
   isSwipeLargeEnoughForHint_(deltaX) {
     return (Math.abs(deltaX) >= MIN_SWIPE_FOR_HINT_OVERLAY_PX);
   }

--- a/extensions/amp-story/1.0/test/test-amp-story.js
+++ b/extensions/amp-story/1.0/test/test-amp-story.js
@@ -454,6 +454,30 @@ describes.realWin('amp-story', {
       expect(unmuteStub).not.to.have.been.called;
       expect(playStub).not.to.have.been.called;
     });
+
+    it('should mute the page and unmute the next page upon navigation', () => {
+      sandbox.stub(win.history, 'replaceState');
+      createPages(story.element, 4, ['cover', 'page-1', 'page-2', 'page-3']);
+
+      story.storeService_.dispatch(Action.TOGGLE_MUTED, false);
+      story.buildCallback();
+
+      let coverMuteStub;
+      let firstPageUnmuteStub;
+
+      return story.layoutCallback()
+          .then(() => {
+            coverMuteStub =
+                sandbox.stub(story.getPageById('cover'), 'muteAllMedia');
+            firstPageUnmuteStub =
+                sandbox.stub(story.getPageById('page-1'), 'unmuteAllMedia');
+            return story.switchTo_('page-1');
+          })
+          .then(() => {
+            expect(coverMuteStub).to.have.been.calledOnce;
+            expect(firstPageUnmuteStub).to.have.been.calledOnce;
+          });
+    });
   });
 
   describe('#getMaxMediaElementCounts', () => {

--- a/extensions/amp-story/1.0/test/test-amp-story.js
+++ b/extensions/amp-story/1.0/test/test-amp-story.js
@@ -401,14 +401,11 @@ describes.realWin('amp-story', {
       createPages(story.element, 2, ['cover', 'page-1']);
       story.buildCallback();
 
-      const muteStub = sandbox.stub(story.mediaPool_, 'mute');
       const pauseStub = sandbox.stub(story.mediaPool_, 'pause');
 
       story.storeService_.dispatch(Action.TOGGLE_MUTED, false);
       story.storeService_.dispatch(Action.TOGGLE_AD, true);
 
-      expect(muteStub).to.have.been.calledOnce;
-      expect(muteStub).to.have.been.calledWith(backgroundAudioEl);
       expect(pauseStub).to.have.been.calledOnce;
       expect(pauseStub).to.have.been.calledWith(backgroundAudioEl);
     });

--- a/extensions/amp-story/1.0/test/test-amp-story.js
+++ b/extensions/amp-story/1.0/test/test-amp-story.js
@@ -66,6 +66,7 @@ describes.realWin('amp-story', {
 
   beforeEach(() => {
     win = env.win;
+
     element = win.document.createElement('amp-story');
     win.document.body.appendChild(element);
 
@@ -78,7 +79,6 @@ describes.realWin('amp-story', {
   });
 
   afterEach(() => {
-    sandbox.restore();
     element.remove();
   });
 
@@ -326,7 +326,7 @@ describes.realWin('amp-story', {
 
   it('should update page id in browser history', () => {
     // Have to stub this because tests run in iframe and you can't write
-    // history from another domain (about:srcdoc)
+    // history from another domain (about:srcdoc).
     const replaceStub = sandbox.stub(win.history, 'replaceState');
     const firstPageId = 'page-zero';
     const pageCount = 2;
@@ -358,6 +358,102 @@ describes.realWin('amp-story', {
         .then(() => {
           return expect(replaceStub).to.not.have.been.called;
         });
+  });
+
+  describe('amp-story audio', () => {
+    it('should register and preload the background audio', () => {
+      sandbox.stub(win.history, 'replaceState');
+      const src = 'https://example.com/foo.mp3';
+      story.element.setAttribute('background-audio', src);
+      const registerStub = sandbox.stub(story.mediaPool_, 'register');
+      const preloadStub = sandbox.stub(story.mediaPool_, 'preload').resolves();
+
+      createPages(story.element, 2, ['cover', 'page-1']);
+
+      story.buildCallback();
+
+      return story.layoutCallback()
+          .then(() => {
+            expect(story.backgroundAudioEl_).to.exist;
+            expect(story.backgroundAudioEl_.src).to.equal(src);
+            expect(registerStub).to.have.been.calledOnce;
+            expect(preloadStub).to.have.been.calledOnce;
+          });
+    });
+
+    it('should bless the media on unmute', () => {
+      const blessAllStub =
+          sandbox.stub(story.mediaPool_, 'blessAll').resolves();
+
+      createPages(story.element, 2, ['cover', 'page-1']);
+      story.buildCallback();
+
+      story.storeService_.dispatch(Action.TOGGLE_MUTED, false);
+
+      expect(blessAllStub).to.have.been.calledOnce;
+    });
+
+    it('should pause the background audio on ad state if not muted', () => {
+      const backgroundAudioEl = win.document.createElement('audio');
+      backgroundAudioEl.setAttribute('id', 'foo');
+      story.backgroundAudioEl_ = backgroundAudioEl;
+
+      createPages(story.element, 2, ['cover', 'page-1']);
+      story.buildCallback();
+
+      const muteStub = sandbox.stub(story.mediaPool_, 'mute');
+      const pauseStub = sandbox.stub(story.mediaPool_, 'pause');
+
+      story.storeService_.dispatch(Action.TOGGLE_MUTED, false);
+      story.storeService_.dispatch(Action.TOGGLE_AD, true);
+
+      expect(muteStub).to.have.been.calledOnce;
+      expect(muteStub).to.have.been.calledWith(backgroundAudioEl);
+      expect(pauseStub).to.have.been.calledOnce;
+      expect(pauseStub).to.have.been.calledWith(backgroundAudioEl);
+    });
+
+    it('should play the background audio when hiding ad if not muted', () => {
+      const backgroundAudioEl = win.document.createElement('audio');
+      backgroundAudioEl.setAttribute('id', 'foo');
+      story.backgroundAudioEl_ = backgroundAudioEl;
+
+      createPages(story.element, 2, ['cover', 'page-1']);
+      story.buildCallback();
+
+      // Displaying an ad and not muted.
+      story.storeService_.dispatch(Action.TOGGLE_AD, true);
+      story.storeService_.dispatch(Action.TOGGLE_MUTED, false);
+
+      const unmuteStub = sandbox.stub(story.mediaPool_, 'unmute');
+      const playStub = sandbox.stub(story.mediaPool_, 'play');
+
+      story.storeService_.dispatch(Action.TOGGLE_AD, false);
+
+      expect(unmuteStub).to.have.been.calledOnce;
+      expect(unmuteStub).to.have.been.calledWith(backgroundAudioEl);
+      expect(playStub).to.have.been.calledOnce;
+      expect(playStub).to.have.been.calledWith(backgroundAudioEl);
+    });
+
+    it('should not play the background audio when hiding ad if muted', () => {
+      const backgroundAudioEl = win.document.createElement('audio');
+      backgroundAudioEl.setAttribute('id', 'foo');
+      story.backgroundAudioEl_ = backgroundAudioEl;
+
+      createPages(story.element, 2, ['cover', 'page-1']);
+      story.buildCallback();
+
+      story.storeService_.dispatch(Action.TOGGLE_AD, true);
+
+      const unmuteStub = sandbox.stub(story.mediaPool_, 'unmute');
+      const playStub = sandbox.stub(story.mediaPool_, 'play');
+
+      story.storeService_.dispatch(Action.TOGGLE_AD, false);
+
+      expect(unmuteStub).not.to.have.been.called;
+      expect(playStub).not.to.have.been.called;
+    });
   });
 
   describe('#getMaxMediaElementCounts', () => {
@@ -396,7 +492,6 @@ describes.realWin('amp-story', {
       };
       expect(story.getMaxMediaElementCounts()).to.deep.equal(expected);
     });
-
   });
 });
 


### PR DESCRIPTION
- Play/Pause the story background audio when an ad is displayed/hidden
- Don't play/pause the story background audio on navigation
- Only mute the media that were actually playing on navigation
- Unblock the ``test-amp-story`` tests, that, for some reason, were not running at all
- Write basic unit tests for the story background-audio

Fixes #14862
Fixes #14868 
Fixes #14572