### PR TITLE
Remove the hacky instantiation of story pages in the story tests.

### DIFF
--- a/extensions/amp-story/1.0/test/test-amp-story.js
+++ b/extensions/amp-story/1.0/test/test-amp-story.js
@@ -15,7 +15,6 @@
  */
 import {Action} from '../amp-story-store-service';
 import {AmpStory} from '../amp-story';
-import {AmpStoryPage} from '../amp-story-page';
 import {EventType} from '../events';
 import {KeyCodes} from '../../../../src/utils/key-codes';
 import {MediaType} from '../media-pool';
@@ -51,7 +50,6 @@ describes.realWin('amp-story', {
     return Array(count).fill(undefined).map((unused, i) => {
       const page = win.document.createElement('amp-story-page');
       page.id = opt_ids && opt_ids[i] ? opt_ids[i] : `-page-${i}`;
-      page.getImpl = () => Promise.resolve(new AmpStoryPage(page));
       container.appendChild(page);
       return page;
     });


### PR DESCRIPTION
We can now get rid of this hack, since the way custom elements are loaded has been fixed during the version bump to 1.0:

````
AMP.extension('amp-story', '1.0', AMP => {
  ...
  AMP.registerElement('amp-story-page', AmpStoryPage);
  ...
});
```` 