### PR TITLE
🐛 partial fix for amp-geo race using singleton service promise

### DIFF
--- a/extensions/amp-geo/0.1/amp-geo.js
+++ b/extensions/amp-geo/0.1/amp-geo.js
@@ -253,11 +253,11 @@ export class AmpGeo extends AMP.BaseElement {
  * Create the service promise at load time to prevent race between extensions
  */
 
-/** singleton {?Promise<!Object<string, (string|Array<string>)>>} */
+/** singleton @type {?Promise<!Object<string, (string|Array<string>)>>} */
 let geoResolver = null;
 
 AMP.extension('amp-geo', '0.1', AMP => {
-  /** {Promise<!Object<string, (string|Array<string>)>>} */
+  /** @type {Promise<!Object<string, (string|Array<string>)>>} */
   const geoPromise = new Promise(resolve => {
     geoResolver = resolve;
   });

--- a/extensions/amp-geo/0.1/amp-geo.js
+++ b/extensions/amp-geo/0.1/amp-geo.js
@@ -42,7 +42,6 @@ import {isCanary} from '../../../src/experiments';
 import {isJsonScriptTag} from '../../../src/dom';
 import {isProxyOrigin} from '../../../src/url';
 import {parseJson} from '../../../src/json';
-import {registerServiceBuilder} from '../../../src/service';
 import {user} from '../../../src/log';
 import {waitForBodyPromise} from '../../../src/dom';
 
@@ -62,6 +61,7 @@ const COUNTRY_PREFIX = 'amp-iso-country-';
 const GROUP_PREFIX = 'amp-geo-group-';
 const PRE_RENDER_REGEX = new RegExp(`${COUNTRY_PREFIX}(\\w+)`);
 const GEO_ID = 'ampGeo';
+const SERVICE_TAG = 'geo';
 
 /**
  * Operating Mode
@@ -110,9 +110,8 @@ export class AmpGeo extends AMP.BaseElement {
         children.length ?
           parseJson(children[0].textContent) : {});
 
-    registerServiceBuilder(this.win, 'geo', function() {
-      return geo;
-    });
+    /* resolve the service promise singleton we stashes earlier */
+    geoResolver(geo);
   }
 
   /**
@@ -249,4 +248,20 @@ export class AmpGeo extends AMP.BaseElement {
   }
 }
 
-AMP.registerElement(TAG, AmpGeo);
+
+/**
+ * Create the service promise at load time to prevent race between extensions
+ */
+
+/** singleton {?Promise<!Object<string, (string|Array<string>)>>} */
+let geoResolver = null;
+
+AMP.extension('amp-geo', '0.1', AMP => {
+  /** {Promise<!Object<string, (string|Array<string>)>>} */
+  const geoPromise = new Promise(resolve => {
+    geoResolver = resolve;
+  });
+  AMP.registerElement(TAG, AmpGeo);
+  AMP.registerServiceForDoc(SERVICE_TAG, () => geoPromise);
+});
+

--- a/extensions/amp-geo/0.1/amp-geo.js
+++ b/extensions/amp-geo/0.1/amp-geo.js
@@ -110,7 +110,7 @@ export class AmpGeo extends AMP.BaseElement {
         children.length ?
           parseJson(children[0].textContent) : {});
 
-    /* resolve the service promise singleton we stashes earlier */
+    /* resolve the service promise singleton we stashed earlier */
     geoResolver(geo);
   }
 


### PR DESCRIPTION
This is a partial fix for the `amp-geo` service race.  It move the service creation to script load time which greatly reduces the chances of it failing. A plan for a full fix in documented in #14841
