### PR TITLE
🏗 Optimize testing on Greenkeeper branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,8 @@ before_script:
   - gem install percy-capybara capybara selenium-webdriver chromedriver-helper rspec-retry
   - chromedriver-update 2.35
   - chromedriver -v
-  - ./node_modules/.bin/greenkeeper-lockfile-update
 script: node build-system/pr-check.js
 after_script:
-  - ./node_modules/.bin/greenkeeper-lockfile-upload
   - build-system/sauce_connect/stop_sauce_connect.sh
 branches:
   only:
@@ -30,10 +28,6 @@ branches:
     - canary
     - /^amp-release-.*$/
     - /^greenkeeper/.*$/
-env:
-  global:
-    - SAUCE_USERNAME="amphtml"
-    - NPM_CONFIG_PROGRESS="false"
 addons:
   chrome: stable
   hosts:
@@ -48,8 +42,20 @@ addons:
     - python-protobuf
 matrix:
   include:
-    - env: BUILD_SHARD="unit_tests"
-    - env: BUILD_SHARD="integration_tests"
+    # For non-greenkeeper branches, use the normal environment.
+    - if: NOT branch =~ ^greenkeeper/.*$
+      env: BUILD_SHARD="unit_tests"
+    - if: NOT branch =~ ^greenkeeper/.*$
+      env: BUILD_SHARD="integration_tests"
+    # For greenkeeper branches, add a secure GH token for the lockfile upload.
+    - if: branch =~ ^greenkeeper/.*$
+      env:
+        # BUILD_SHARD="unit_tests" GH_TOKEN=[secure]
+        secure: "vDfldX3uQ6Y5hG7RY4DGwm28TFTOhRjn2stwWxl6CCN0Dys6qLCm9z6aexZBnarOqoZRjX/MSaV57VSOMAZuvs4sJiR8jpEK3j8ZKYPsgw50HzkuzMT9365atDy2weCs0NniIXMk2X6pHr4VIXjdr07CWCrT31BJVCixAfPIIdTF3IAjrxSws/9SXHa2oWrFDrwJEmASQsDQ79uGKyvid+q5G9mYrpp9oT7nkDZTV2EwdHfIWWQ1xFq2ZFep9UjNmlVRYfGJLIg9LdfgnyY2qQKODGFiwHN3fY14A6PCm4kRHebwGqjL5TKrMSeexdpjDiAp80BAnlsN9eRk0lM+thoUfRlHi6LLAUGp7rR4+j1m/nyhhgQ1BLEHo6oUVZGpd733IqgRufIcxWQl3hImpysldfwR72oGFq0eZBrJa5yJbo1Qc89trS3Jpd5O9NLkvH4gaBrvrE6zJq8KfrAFvqvOINOyvJfQSVOOQkEbc/vUx1X2fEB/rFRnb+hNVR8gPvjlBCiYW2JqdtiUwqMjUHhmQwQkWXrAxGnf4XXCjXmpKl6XDeeVzMaaNNuZFn1F9bm8giA66UcRDvsi5tw7eR5HHEfyt1WBwByFopp6hwioy9symoCdsW+hUKLCBo1mo1cJ273I21z45jagPcgI99jlgAqnlHQ76/aUqtvRvro="
+    - if: branch =~ ^greenkeeper/.*$
+      env:
+        # BUILD_SHARD="integration_tests" GH_TOKEN=[secure]
+        secure: "juB/a5PPXjd3DtE0XzGTBG+QV14z3NNFiw+bUoGpc6/OzvN3e7ZhHOpzNV/MoIzHZXm4Rj4fwoehS4zRx034ecS1o9vfWM1Yw6yWXMKI5oDxB4xPWY1G+WAIXCWJnDzaETTLrjcGZ3ENr4XkPFAD7a7w45Uxqg37T8xUgT6OJwj0uTumeJdy9oj6VI9OycOD4C5xBcB3X7vkxsnc59sUmyPZYodQIVpzX/g6Ofvc0ofQaheHKfsZUZKWIEv7hvR1pxoLQOxMnue+mr43pOLe6CBgWIo2TBHz5t5pp3IMKewvAcavdnMjsC8phMk/rqXd42DmvR9SDIiTDio2FmPaQHRry2+asPAQarXDPFXnepQ2Od+e0AhmCLl01+wkQ5zEmDNWORPLqBDjJ1urq7DuTif77hKk/eeHyaBKGQGV1qQO1h/4Qh7rw8NsgzztqmfE6lCi1ZoWl56OJs1KZU3WltQmtYJ2xDN6h/UCK3YKC8rpVCRd0ed9Ftu7HZyRPiCUBwqQ24Fz1aZ1KzDS2Ig5NUaHS0U3JgDO9xojGeG2K7As0Ik0WeoLwf9h3PDWTAv8f4WhQbDCkZ/CTLi+RrkmsV+lrYF+TZ17l0X7fDIhLbULaK4Y1/kK7VWAT6chVQ8zFL8H1ahcGmSwzJ3n1qPbeHRyFpcvFMuIXJgjUoEQEz4="
 cache:
   yarn: true
   directories:


### PR DESCRIPTION
This PR does the following:

- Reduces the amount of unnecessary work we do on GK and non-GK branches.
- Eliminates the need to maintain a repository-wide secure token, which messes with output formatting / coloring on push builds (https://github.com/travis-ci/travis-ci/issues/7967)

With this, log formatting will be readable once again for push builds on `master`, since we'll no longer have a secure token during those builds.

Tested via #14945