### PR TITLE
✨ amp-next-page: Only show article links if next page fails to load in time

### DIFF
--- a/extensions/amp-next-page/0.1/amp-next-page.js
+++ b/extensions/amp-next-page/0.1/amp-next-page.js
@@ -86,11 +86,9 @@ export class AmpNextPage extends AMP.BaseElement {
     user().assert(separatorElements.length <= 1,
         `${TAG} should contain at most one <div separator> child`);
 
-    let separator;
+    let separator = null;
     if (separatorElements.length === 1) {
       separator = separatorElements[0];
-    } else {
-      separator = this.win.document.createElement('div');
     }
 
     this.service_.register(this.element, config, separator);

--- a/extensions/amp-next-page/0.1/next-page-service.js
+++ b/extensions/amp-next-page/0.1/next-page-service.js
@@ -163,19 +163,14 @@ export class NextPageService {
    * @return {?Object} Return value of {@link MultidocManager#attachShadowDoc}
    */
   attachShadowDoc_(shadowRoot, doc) {
-    try {
-      const amp =
-          this.multidocManager_.attachShadowDoc(shadowRoot, doc, '', {});
-      installStylesForDoc(amp.ampdoc, CSS, null, false, TAG);
+    const amp =
+        this.multidocManager_.attachShadowDoc(shadowRoot, doc, '', {});
+    installStylesForDoc(amp.ampdoc, CSS, null, false, TAG);
 
-      const body = amp.ampdoc.getBody();
-      body.classList.add('i-amphtml-next-page-document');
+    const body = amp.ampdoc.getBody();
+    body.classList.add('i-amphtml-next-page-document');
 
-      return amp;
-    } catch (e) {
-      // TODO(emarchiori): Handle loading errors.
-    }
-    return null;
+    return amp;
   }
 
   /**
@@ -227,7 +222,9 @@ export class NextPageService {
                 documentRef.amp = amp;
                 this.documentQueued_ = false;
               }),
-          () => {});
+          e => dev().error(TAG, `failed to fetch ${next.ampUrl}`, e))
+          .catch(e => dev().error(TAG,
+              `failed to attach shadow document for ${next.ampUrl}`, e));
     }
   }
 

--- a/extensions/amp-next-page/0.1/next-page-service.js
+++ b/extensions/amp-next-page/0.1/next-page-service.js
@@ -112,7 +112,8 @@ export class NextPageService {
    * subsequent calls will be ignored.
    * @param {!Element} element {@link AmpNextPage} element.
    * @param {!./config.AmpNextPageConfig} config Element configuration.
-   * @param {!Element} separator Separator element to display between pages.
+   * @param {?Element} separator Separator element to display between pages. If
+   *     none is specified a default hairline separator will be used.
    */
   register(element, config, separator) {
     if (this.isActive()) {
@@ -123,8 +124,8 @@ export class NextPageService {
     const win = ampDoc.win;
 
     this.config_ = config;
-    this.separator_ = separator;
     this.win_ = win;
+    this.separator_ = separator || this.createDivider_();
     this.element_ = element;
 
     this.viewer_ = Services.viewerForDoc(ampDoc);

--- a/extensions/amp-next-page/0.1/next-page-service.js
+++ b/extensions/amp-next-page/0.1/next-page-service.js
@@ -220,6 +220,8 @@ export class NextPageService {
               () => {
                 const amp = this.attachShadowDoc_(shadowRoot, doc);
                 documentRef.amp = amp;
+
+                setStyle(documentRef.recUnit, 'display', 'none');
                 this.documentQueued_ = false;
               }),
           e => dev().error(TAG, `failed to fetch ${next.ampUrl}`, e))

--- a/extensions/amp-next-page/0.1/next-page-service.js
+++ b/extensions/amp-next-page/0.1/next-page-service.js
@@ -216,14 +216,20 @@ export class NextPageService {
 
       Services.xhrFor(/** @type {!Window} */ (this.win_))
           .fetchDocument(next.ampUrl, {ampCors: false})
-          .then(doc => this.resources_.mutateElement(container,
-              () => {
+          .then(doc => new Promise((resolve, reject) => {
+            this.resources_.mutateElement(container, () => {
+              try {
                 const amp = this.attachShadowDoc_(shadowRoot, doc);
                 documentRef.amp = amp;
 
                 setStyle(documentRef.recUnit, 'display', 'none');
                 this.documentQueued_ = false;
-              }),
+                resolve();
+              } catch (e) {
+                reject(e);
+              }
+            });
+          }),
           e => dev().error(TAG, `failed to fetch ${next.ampUrl}`, e))
           .catch(e => dev().error(TAG,
               `failed to attach shadow document for ${next.ampUrl}`, e));

--- a/extensions/amp-next-page/0.1/next-page-service.js
+++ b/extensions/amp-next-page/0.1/next-page-service.js
@@ -41,7 +41,8 @@ const TAG = 'amp-next-page';
 /**
  * @typedef {{
  *   ampUrl: string,
- *   amp: ?Object
+ *   amp: ?Object,
+ *   recUnit: ?Element
  * }}
  */
 export let DocumentRef;
@@ -138,6 +139,7 @@ export class NextPageService {
     this.documentRefs_.push({
       ampUrl: win.document.location.href,
       amp: {title: win.document.title},
+      recUnit: null,
     });
     this.activeDocumentRef_ = this.documentRefs_[0];
 
@@ -193,7 +195,7 @@ export class NextPageService {
     if (this.nextArticle_ < MAX_ARTICLES &&
         this.nextArticle_ < this.config_.pages.length) {
       const next = this.config_.pages[this.nextArticle_];
-      const documentRef = {ampUrl: next.ampUrl, amp: null};
+      const documentRef = {ampUrl: next.ampUrl, amp: null, recUnit: null};
       this.documentRefs_.push(documentRef);
       this.nextArticle_++;
 
@@ -210,6 +212,7 @@ export class NextPageService {
 
       const articleLinks = this.createArticleLinks_(this.nextArticle_);
       container.appendChild(articleLinks);
+      documentRef.recUnit = articleLinks;
 
       const shadowRoot = this.win_.document.createElement('div');
       container.appendChild(shadowRoot);

--- a/extensions/amp-next-page/0.1/next-page-service.js
+++ b/extensions/amp-next-page/0.1/next-page-service.js
@@ -172,9 +172,6 @@ export class NextPageService {
         PositionObserverFidelity.LOW,
         position => this.positionUpdate_(page, position));
 
-    const divider = this.createDivider_();
-    container.appendChild(divider);
-
     const articleLinks = this.createArticleLinks_(this.nextArticle_);
     container.appendChild(articleLinks);
 
@@ -250,6 +247,9 @@ export class NextPageService {
     }
 
     const element = doc.createElement('div');
+    const divider = this.createDivider_();
+    element.appendChild(divider);
+
     while (article < this.config_.pages.length &&
            article - nextPage < SEPARATOR_RECOS) {
       const next = this.config_.pages[article];


### PR DESCRIPTION
• Hides the article links block when the next page is added to the DOM
• Stops the next page from being added to the DOM if the article links have already been scrolled into view
• Switches to use a default separator if none is specified (to make up for not having the article links in between)
• Adds proper error handling for failed XHRs/failed shadow DOM attaching
