### PR TITLE
🐛 Fix AmpShadowDoc#declareExtension_(string) behaviour when minified

### DIFF
--- a/src/service/ampdoc-impl.js
+++ b/src/service/ampdoc-impl.js
@@ -35,7 +35,7 @@ const AMPDOC_PROP = '__AMPDOC';
  * @restricted
  */
 export function declareExtension(ampdoc, extensionId) {
-  ampdoc.declareExtension_(extensionId);
+  ampdoc.declareExtension(extensionId);
 }
 
 
@@ -298,10 +298,9 @@ export class AmpDoc {
 
   /**
    * @param {string} extensionId
-   * @private
    * @restricted
    */
-  declareExtension_(extensionId) {
+  declareExtension(extensionId) {
     if (!this.declaresExtension(extensionId)) {
       this.declaredExtensions_.push(extensionId);
     }

--- a/test/functional/test-custom-element-registry.js
+++ b/test/functional/test-custom-element-registry.js
@@ -41,7 +41,7 @@ describes.realWin('CustomElement register', {amp: true}, env => {
     doc = win.document;
     ampdoc = env.ampdoc;
     extensions = env.extensions;
-    ampdoc.declareExtension_('amp-element1');
+    ampdoc.declareExtension('amp-element1');
   });
 
   function insertElement(name) {
@@ -107,7 +107,7 @@ describes.realWin('CustomElement register', {amp: true}, env => {
   });
 
   it('should not install declared pre-stubbed element extension', () => {
-    ampdoc.declareExtension_('amp-element2');
+    ampdoc.declareExtension('amp-element2');
     const stub = sandbox.stub(extensions, 'installExtensionForDoc');
 
     stubElementIfNotKnown(win, 'amp-element2');

--- a/test/functional/test-custom-element.js
+++ b/test/functional/test-custom-element.js
@@ -124,7 +124,7 @@ describes.realWin('CustomElement', {amp: true}, env => {
       });
       win.ampExtendedElements['amp-test'] = TestElement;
       win.ampExtendedElements['amp-stub'] = ElementStub;
-      ampdoc.declareExtension_('amp-stub');
+      ampdoc.declareExtension('amp-stub');
 
       testElementCreatedCallback = sandbox.spy();
       testElementPreconnectCallback = sandbox.spy();
@@ -1432,7 +1432,7 @@ describes.realWin('CustomElement Service Elements', {amp: true}, env => {
     StubElementClass = doc.registerElement('amp-stub2', {
       prototype: createAmpElementProtoForTesting(win, 'amp-stub2', ElementStub),
     });
-    env.ampdoc.declareExtension_('amp-stub2');
+    env.ampdoc.declareExtension('amp-stub2');
     element = new StubElementClass();
   });
 

--- a/test/functional/test-extensions.js
+++ b/test/functional/test-extensions.js
@@ -227,7 +227,7 @@ describes.sandboxed('Extensions', {}, () => {
 
     it('should install declared elements for single-doc', () => {
       const ampdoc = Services.ampdocServiceFor(win).getAmpDoc();
-      ampdoc.declareExtension_('amp-test');
+      ampdoc.declareExtension('amp-test');
       expect(win.ampExtendedElements &&
           win.ampExtendedElements['amp-test']).to.be.undefined;
       expect(win.ampExtendedElements &&
@@ -248,7 +248,7 @@ describes.sandboxed('Extensions', {}, () => {
 
     it('should install non-auto declared elements for single-doc', () => {
       const ampdoc = Services.ampdocServiceFor(win).getAmpDoc();
-      ampdoc.declareExtension_('amp-test');
+      ampdoc.declareExtension('amp-test');
       expect(win.ampExtendedElements &&
           win.ampExtendedElements['amp-test']).to.be.undefined;
       expect(win.ampExtendedElements &&
@@ -320,7 +320,7 @@ describes.sandboxed('Extensions', {}, () => {
           .returns(ampdocShell)
           .twice();
 
-      ampdocShell.declareExtension_('amp-test');
+      ampdocShell.declareExtension('amp-test');
       expect(win.ampExtendedElements &&
         win.ampExtendedElements['amp-test']).to.be.undefined;
       expect(win.ampExtendedElements &&
@@ -458,7 +458,7 @@ describes.sandboxed('Extensions', {}, () => {
 
     it('should install declared services for single-doc', () => {
       const ampdoc = Services.ampdocServiceFor(win).getAmpDoc();
-      ampdoc.declareExtension_('amp-test');
+      ampdoc.declareExtension('amp-test');
 
       const factory1Spy = sandbox.spy();
       const factory2Spy = sandbox.spy();
@@ -528,7 +528,7 @@ describes.sandboxed('Extensions', {}, () => {
           .returns(ampdocShell)
           .twice();
 
-      ampdocShell.declareExtension_('amp-test');
+      ampdocShell.declareExtension('amp-test');
 
       const factory1Spy = sandbox.spy();
       const factory2Spy = sandbox.spy();

--- a/test/functional/test-runtime.js
+++ b/test/functional/test-runtime.js
@@ -535,7 +535,7 @@ describes.fakeWin('runtime', {
       const servicePromise = getServicePromise(win, 'amp-ext');
       const installStylesStub = sandbox.stub(styles, 'installStylesForDoc');
 
-      ampdoc.declareExtension_('amp-ext');
+      ampdoc.declareExtension('amp-ext');
       win.AMP.push({
         n: 'amp-ext',
         f: amp => {
@@ -573,7 +573,7 @@ describes.fakeWin('runtime', {
                 installStylesCallback = cb;
               });
 
-      ampdoc.declareExtension_('amp-ext');
+      ampdoc.declareExtension('amp-ext');
       win.AMP.push({
         n: 'amp-ext',
         f: amp => {
@@ -612,7 +612,7 @@ describes.fakeWin('runtime', {
     it('should register doc-service as ctor and install imm', function* () {
       class Service1 {}
       const ampdoc = new AmpDocSingle(win);
-      ampdoc.declareExtension_('amp-ext');
+      ampdoc.declareExtension('amp-ext');
       ampdocServiceMock.expects('getAmpDoc')
           .returns(ampdoc)
           .atLeast(1);
@@ -643,7 +643,7 @@ describes.fakeWin('runtime', {
         return {str: 'A'};
       }
       const ampdoc = new AmpDocSingle(win);
-      ampdoc.declareExtension_('amp-ext');
+      ampdoc.declareExtension('amp-ext');
       ampdocServiceMock.expects('getAmpDoc')
           .returns(ampdoc)
           .atLeast(1);

--- a/testing/describes.js
+++ b/testing/describes.js
@@ -694,7 +694,7 @@ class AmpFixture {
         const installer = extensionsBuffer[`${extensionId}:${version}`];
         if (installer) {
           if (env.ampdoc) {
-            env.ampdoc.declareExtension_(extensionId);
+            env.ampdoc.declareExtension(extensionId);
           }
           registerExtension(env.extensions, extensionId, installer, win.AMP);
         }
@@ -725,7 +725,7 @@ class AmpFixture {
             ' Make sure the module is imported');
       }
       if (env.ampdoc) {
-        env.ampdoc.declareExtension_(extensionId);
+        env.ampdoc.declareExtension(extensionId);
       }
       registerExtension(env.extensions, extensionId, installer, win.AMP);
     };


### PR DESCRIPTION
Changes visibility of AmpDoc#declareExtension_(string) from private to public. Previously marked as private, but used from the exported function `declareExtension` outside of the class (in the same module). This happens to work fine for `AmpDocSingle`, but property renaming screws up `AmpDocShadow` and the method breaks.

Discovered by running the `amp-next-page` example from minified AMP sources, which fails to install any extensions on the second page.