### PR TITLE
🐛✨Create "glass pane" over story ads

### DIFF
--- a/examples/amp-story-auto-ads.amp.html
+++ b/examples/amp-story-auto-ads.amp.html
@@ -5,7 +5,7 @@
   <title>amp-story</title>
   <link rel="canonical" href="animations-presets.html">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
-  <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-0.1.js"></script>
+  <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-1.0.js"></script>
   <script async custom-element="amp-story-auto-ads" src="https://cdn.ampproject.org/v0/amp-story-auto-ads-0.1.js"></script>
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.css
+++ b/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.css
@@ -81,3 +81,9 @@ amp-story-page[active] .i-amphtml-story-ad-link {
 amp-story[ad-showing] .i-amphtml-story-ad-attribution {
   visibility: visible !important;
 }
+
+.i-amphtml-glass-pane {
+  height: 100% !important;
+  width: 100% !important;
+  z-index: 1 !important;
+}

--- a/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
+++ b/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
@@ -194,10 +194,10 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
    * @private
    */
   createAdOverlay_() {
-    const container = document.createElement('aside');
+    const container = this.win.document.createElement('aside');
     container.className = 'i-amphtml-ad-overlay-container';
 
-    const span = document.createElement('p');
+    const span = this.win.document.createElement('p');
     span.className = 'i-amphtml-story-ad-attribution';
     span.textContent = 'Ad';
 
@@ -246,10 +246,10 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
     const ampStoryAdPage = this.createPageElement_();
     const ampAd = this.createAdElement_();
 
-    const glassPane = document.createElement('div');
+    const glassPane = this.win.document.createElement('div');
     glassPane.classList.add(GLASS_PANE_CLASS);
 
-    const gridLayer = document.createElement('amp-story-grid-layer');
+    const gridLayer = this.win.document.createElement('amp-story-grid-layer');
     gridLayer.setAttribute('template', 'fill');
 
     const paneGridLayer = gridLayer.cloneNode(false);
@@ -287,7 +287,7 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
     });
 
     return createElementWithAttributes(
-        document, 'amp-story-page', attributes);
+        this.win.document, 'amp-story-page', attributes);
   }
 
 
@@ -318,7 +318,7 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
         configAttrs, requiredAttrs));
 
     return createElementWithAttributes(
-        document, 'amp-ad', attributes);
+        this.win.document, 'amp-ad', attributes);
   }
 
 
@@ -355,7 +355,7 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
    * @return {boolean}
    */
   createCtaLayer_(adPageElement, ctaText, ctaUrl) {
-    const a = document.createElement('a');
+    const a = this.win.document.createElement('a');
     a.className = 'i-amphtml-story-ad-link';
     a.setAttribute('target', '_blank');
     a.href = ctaUrl;
@@ -366,7 +366,7 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
       return false;
     }
 
-    const ctaLayer = document.createElement('amp-story-cta-layer');
+    const ctaLayer = this.win.document.createElement('amp-story-cta-layer');
     ctaLayer.appendChild(a);
     adPageElement.appendChild(ctaLayer);
     return true;

--- a/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
+++ b/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
@@ -41,6 +41,8 @@ const MUSTACHE_TAG = 'amp-mustache';
 /** @const */
 const TIMEOUT_LIMIT = 10000; // 10 seconds
 
+const GLASS_PANE_CLASS = 'i-amphtml-glass-pane';
+
 /** @const */
 const DATA_ATTR = {
   CTA_TYPE: 'data-vars-ctatype',
@@ -244,10 +246,18 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
     const ampStoryAdPage = this.createPageElement_();
     const ampAd = this.createAdElement_();
 
+    const glassPane = document.createElement('div');
+    glassPane.classList.add(GLASS_PANE_CLASS);
+
     const gridLayer = document.createElement('amp-story-grid-layer');
     gridLayer.setAttribute('template', 'fill');
+
+    const paneGridLayer = gridLayer.cloneNode(false);
+
     gridLayer.appendChild(ampAd);
+    paneGridLayer.appendChild(glassPane);
     ampStoryAdPage.appendChild(gridLayer);
+    ampStoryAdPage.appendChild(paneGridLayer);
 
     this.currentAdElement_ = ampAd;
     this.isCurrentAdLoaded_ = false;

--- a/extensions/amp-story-auto-ads/0.1/test/test-amp-story-auto-ads.js
+++ b/extensions/amp-story-auto-ads/0.1/test/test-amp-story-auto-ads.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-// import {AmpStoryAutoAds} from '../amp-story-auto-ads';
+import {AmpStoryAutoAds} from '../amp-story-auto-ads';
 
 describes.realWin('amp-story-auto-ads', {
   amp: {
@@ -24,13 +24,42 @@ describes.realWin('amp-story-auto-ads', {
 
   let win;
   let element;
+  let storyElement;
+  let ASAAImpl;
 
   beforeEach(() => {
     win = env.win;
     element = win.document.createElement('amp-story-auto-ads');
-    win.document.body.appendChild(element);
+    storyElement = win.document.createElement('amp-story');
+    win.document.body.appendChild(storyElement);
+    storyElement.appendChild(element);
+    ASAAImpl = new AmpStoryAutoAds(element);
+    ASAAImpl.config_ = {
+      'ad-attributes': {
+        type: 'doubleclick',
+        'data-slot': '/30497360/samfrank_native_v2_a4a',
+      },
+    };
   });
 
-  it('should build', () => {
-  });
+  describe('glass pane', () => {
+    let page;
+    let pane;
+
+    beforeEach(() => {
+      page = ASAAImpl.createAdPage_();
+      pane = page.querySelector('.i-amphtml-glass-pane');
+    });
+
+    it('should create glassPane', () => {
+      expect(pane).to.exist;
+    });
+
+    it('glass pane should have full viewport grid parent', () => {
+      const parent = pane.parentElement;
+      expect(parent.tagName).to.equal('AMP-STORY-GRID-LAYER');
+      expect(parent.getAttribute('template')).to.equal('fill');
+    })
+
+  })
 });

--- a/extensions/amp-story-auto-ads/0.1/test/test-amp-story-auto-ads.js
+++ b/extensions/amp-story-auto-ads/0.1/test/test-amp-story-auto-ads.js
@@ -59,7 +59,6 @@ describes.realWin('amp-story-auto-ads', {
       const parent = pane.parentElement;
       expect(parent.tagName).to.equal('AMP-STORY-GRID-LAYER');
       expect(parent.getAttribute('template')).to.equal('fill');
-    })
-
-  })
+    });
+  });
 });


### PR DESCRIPTION
Create invisible `div` over ad pages so that if there are `iframes` they are not capturing clicks. Also prevents clicks on things that are valid in the a4a spec but would break the story experience (e.g. `<amp-accordion>, <amp-form>` etc.)