### PR TITLE
🐛 Temporarily disable Percy build verification

### DIFF
--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -593,20 +593,24 @@ function main() {
       command.cleanBuild();
       command.buildRuntime();
       command.runVisualDiffTests();
+    } else {
+      // Generates a blank Percy build to satisfy the required Github check.
+      command.runVisualDiffTests(/* opt_mode */ 'skip');
     }
     command.runPresubmitTests();
     if (buildTargets.has('INTEGRATION_TEST') ||
         buildTargets.has('RUNTIME')) {
       command.runIntegrationTests(/* compiled */ false);
     }
-    if (buildTargets.has('INTEGRATION_TEST') ||
-        buildTargets.has('RUNTIME') ||
-        buildTargets.has('VISUAL_DIFF')) {
-      command.verifyVisualDiffTests();
-    } else {
-      // Generates a blank Percy build to satisfy the required Github check.
-      command.runVisualDiffTests(/* opt_mode */ 'skip');
-    }
+    // TODO(rsimha, #14851): Failing due to long proessing times.
+    // if (buildTargets.has('INTEGRATION_TEST') ||
+    //     buildTargets.has('RUNTIME') ||
+    //     buildTargets.has('VISUAL_DIFF')) {
+    //   command.verifyVisualDiffTests();
+    // } else {
+    //   // Generates a blank Percy build to satisfy the required Github check.
+    //   command.runVisualDiffTests(/* opt_mode */ 'skip');
+    // }
     if (buildTargets.has('VALIDATOR_WEBUI')) {
       command.buildValidatorWebUI();
     }


### PR DESCRIPTION
Percy builds aren't completing fast enough, and the verification step is causing Travis to time out. Re-enable this once we have more capacity.

See comment thread at https://github.com/ampproject/amphtml/pull/14851#issuecomment-384687399