### PR TITLE
🐛 Fix AmpDoc/Extensions method visibility

### DIFF
--- a/extensions/amp-ad/0.1/test/test-amp-ad.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad.js
@@ -259,8 +259,8 @@ describes.realWin('Ad loader', {amp: true}, env => {
             const zortInstance = {};
             const zortConstructor = function() { return zortInstance; };
             const extensions = Services.extensionsFor(win);
-            extensions.registerExtension_('amp-ad-network-zort-impl', () => {
-              extensions.addElement_('amp-ad-network-zort-impl',
+            extensions.registerExtension('amp-ad-network-zort-impl', () => {
+              extensions.addElement('amp-ad-network-zort-impl',
                   zortConstructor);
             }, {});
           });

--- a/src/amp-shadow.js
+++ b/src/amp-shadow.js
@@ -37,10 +37,7 @@ import {
 import {cssText} from '../build/css';
 import {deactivateChunking} from './chunk';
 import {doNotTrackImpression} from './impression';
-import {
-  installDocService,
-  installShadowDocForShell,
-} from './service/ampdoc-impl';
+import {installDocService} from './service/ampdoc-impl';
 import {installPerformanceService} from './service/performance-impl';
 import {isExperimentOn} from './experiments';
 import {stubElementsForDoc} from './service/custom-element-registry';
@@ -63,7 +60,7 @@ if (isExperimentOn(self, 'ampdoc-shell')) {
   //Shadow mode with an Ampdoc for the shell
   installPerformanceService(self);
   const ampdocService = Services.ampdocServiceFor(self);
-  const ampdocShell = installShadowDocForShell(ampdocService);
+  const ampdocShell = ampdocService.installShellShadowDoc();
   installStylesForDoc(ampdocShell, cssText, () => {
     installAmpdocServices(ampdocShell);
 

--- a/src/service/ampdoc-impl.js
+++ b/src/service/ampdoc-impl.js
@@ -29,66 +29,6 @@ const AMPDOC_PROP = '__AMPDOC';
 
 
 /**
- * Adds a declared extension to an ampdoc.
- * @param {!AmpDoc} ampdoc
- * @param {string} extensionId
- * @restricted
- */
-export function declareExtension(ampdoc, extensionId) {
-  ampdoc.declareExtension(extensionId);
-}
-
-
-/**
- * Creates and installs the ampdoc for the shadow root.
- * @param {!AmpDocService} ampdocService
- * @param {string} url
- * @param {!ShadowRoot} shadowRoot
- * @return {!AmpDocShadow}
- * @restricted
- */
-export function installShadowDoc(ampdocService, url, shadowRoot) {
-  return ampdocService.installShadowDoc_(url, shadowRoot);
-}
-
-/**
- * Creates and installs an ampdoc for the shell in shadow-doc mode.
- * `AmpDocShell` is a subclass of `AmpDocShadow` that is installed for
- * `window.document` and allows to use AMP components as part of the shell,
- * outside shadow roots
- *
- * Currently guarded by 'ampdoc-shell' experiment
- *
- * @param {!AmpDocService} ampdocService
- * @returns {!AmpDocShell}
- */
-export function installShadowDocForShell(ampdocService) {
-  return ampdocService.installShellShadowDoc_();
-}
-
-
-/**
- * Signals that the shadow doc is ready.
- * @param {!AmpDocShadow} ampdoc
- * @restricted
- */
-export function shadowDocReady(ampdoc) {
-  ampdoc.setReady_();
-}
-
-
-/**
- * Signals that the shadow doc has a body.
- * @param {!AmpDocShadow} ampdoc
- * @param {!Element} body
- * @restricted
- */
-export function shadowDocHasBody(ampdoc, body) {
-  ampdoc.setBody_(body);
-}
-
-
-/**
  * This service helps locate an ampdoc (`AmpDoc` instance) for any node,
  * either in the single-doc or shadow-doc environments.
  *
@@ -211,9 +151,9 @@ export class AmpDocService {
    * @param {string} url
    * @param {!ShadowRoot} shadowRoot
    * @return {!AmpDocShadow}
-   * @private
+   * @restricted
    */
-  installShadowDoc_(url, shadowRoot) {
+  installShadowDoc(url, shadowRoot) {
     dev().assert(!shadowRoot[AMPDOC_PROP],
         'The shadow root already contains ampdoc');
     const ampdoc = new AmpDocShadow(this.win, url, shadowRoot);
@@ -222,19 +162,25 @@ export class AmpDocService {
   }
 
   /**
-   * Creates and installs an ampdoc for the shell in shadow-doc mode
+   * Creates and installs an ampdoc for the shell in shadow-doc mode.
+   * `AmpDocShell` is a subclass of `AmpDocShadow` that is installed for
+   * `window.document` and allows to use AMP components as part of the shell,
+   * outside shadow roots
+   *
+   * Currently guarded by 'ampdoc-shell' experiment
+   *
    * @return {!AmpDocShell}
-   * @private
+   * @restricted
    */
-  installShellShadowDoc_() {
+  installShellShadowDoc() {
     dev().assert(this.singleDoc_ === null,
         'AmpDocShell cannot be installed in single-doc mode');
     this.shellShadowDoc_ = new AmpDocShell(this.win);
     this.win.document[AMPDOC_PROP] = this.shellShadowDoc_;
 
     whenDocumentReady(this.win.document).then(document => {
-      this.shellShadowDoc_.setBody_(dev().assertElement(document.body));
-      this.shellShadowDoc_.setReady_();
+      this.shellShadowDoc_.setBody(dev().assertElement(document.body));
+      this.shellShadowDoc_.setReady();
     });
 
     return this.shellShadowDoc_;
@@ -297,6 +243,7 @@ export class AmpDoc {
   }
 
   /**
+   * Adds a declared extension to an ampdoc.
    * @param {string} extensionId
    * @restricted
    */
@@ -544,10 +491,11 @@ export class AmpDocShadow extends AmpDoc {
   }
 
   /**
+   * Signals that the shadow doc has a body.
    * @param {!Element} body
-   * @private
+   * @restricted
    */
-  setBody_(body) {
+  setBody(body) {
     dev().assert(!this.body_, 'Duplicate body');
     this.body_ = body;
     this.bodyResolver_(body);
@@ -564,8 +512,11 @@ export class AmpDocShadow extends AmpDoc {
     return this.ready_;
   }
 
-  /** @private */
-  setReady_() {
+  /**
+   * Signals that the shadow doc is ready.
+   * @restricted
+   */
+  setReady() {
     dev().assert(!this.ready_, 'Duplicate ready state');
     this.ready_ = true;
     this.readyResolver_();

--- a/src/service/custom-element-registry.js
+++ b/src/service/custom-element-registry.js
@@ -16,7 +16,6 @@
 
 import {ElementStub, stubbedElements} from '../element-stub';
 import {createCustomElementClass} from '../custom-element';
-import {declareExtension} from './ampdoc-impl';
 import {reportError} from '../error';
 import {user} from '../log';
 
@@ -99,7 +98,7 @@ export function stubElementsForDoc(ampdoc) {
   const list = ampdoc.getHeadNode().querySelectorAll('script[custom-element]');
   for (let i = 0; i < list.length; i++) {
     const name = list[i].getAttribute('custom-element');
-    declareExtension(ampdoc, name);
+    ampdoc.declareExtension(name);
     stubElementIfNotKnown(ampdoc.win, name);
   }
 }

--- a/src/service/extensions-impl.js
+++ b/src/service/extensions-impl.js
@@ -29,7 +29,6 @@ import {
   upgradeOrRegisterElement,
 } from './custom-element-registry';
 import {cssText} from '../../build/css';
-import {declareExtension} from './ampdoc-impl';
 import {dev, rethrowAsync} from '../log';
 import {getMode} from '../mode';
 import {
@@ -105,76 +104,6 @@ export function installExtensionsService(window) {
   registerServiceBuilder(window, 'extensions', Extensions);
 }
 
-/**
- * Register and process the specified extension. The factory is called
- * immediately, which in turn is expected to register elements, templates,
- * services and document factories.
- * @param {!Extensions} extensions
- * @param {string} extensionId
- * @param {function(!Object)} factory
- * @param {!Object} arg
- * @restricted
- */
-export function registerExtension(extensions, extensionId, factory, arg) {
-  extensions.registerExtension_(extensionId, factory, arg);
-}
-
-
-/**
- * Apply all registered factories to the specified ampdoc.
- * @param {!Extensions} extensions
- * @param {!./ampdoc-impl.AmpDoc} ampdoc
- * @param {!Array<string>} extensionIds
- * @return {!Promise}
- * @restricted
- */
-export function installExtensionsInDoc(extensions, ampdoc, extensionIds) {
-  return extensions.installExtensionsInDoc_(ampdoc, extensionIds);
-}
-
-
-/**
- * Add an element to the extension currently being registered. This is a
- * restricted method and it's allowed to be called only during the overall
- * extension registration.
- * @param {!Extensions} extensions
- * @param {string} name
- * @param {function(new:../base-element.BaseElement, !Element)}
- *     implementationClass
- * @param {?string|undefined} css
- * @restricted
- */
-export function addElementToExtension(
-  extensions, name, implementationClass, css) {
-  extensions.addElement_(name, implementationClass, css);
-}
-
-/**
- * Add a service to the extension currently being registered. This is a
- * restricted method and it's allowed to be called only during the overall
- * extension registration.
- * @param {!Extensions} extensions
- * @param {string} name
- * @param {function(new:Object, !./ampdoc-impl.AmpDoc)} implementationClass
- * @restricted
- */
-export function addServiceToExtension(extensions, name, implementationClass) {
-  extensions.addService_(name, implementationClass);
-}
-
-/**
- * Add a ampdoc factory to the extension currently being registered. This is a
- * restricted method and it's allowed to be called only during the overall
- * extension registration.
- * @param {!Extensions} extensions
- * @param {function(!./ampdoc-impl.AmpDoc)} factory
- * @param {string=} opt_forName
- * @restricted
- */
-export function addDocFactoryToExtension(extensions, factory, opt_forName) {
-  extensions.addDocFactory_(factory, opt_forName);
-}
-
 
 /**
  * The services that manages extensions in the runtime.
@@ -200,15 +129,16 @@ export class Extensions {
   }
 
   /**
-   * Registers a new extension. This method is called by the extension's script
-   * itself when it's loaded using the regular `AMP.push()` callback.
+   * Register and process the specified extension. The factory is called
+   * immediately, which in turn is expected to register elements, templates,
+   * services and document factories. This method is called by the extension's
+   * script itself when it's loaded using the regular `AMP.push()` callback.
    * @param {string} extensionId
    * @param {function(!Object)} factory
    * @param {!Object} arg
-   * @private
    * @restricted
    */
-  registerExtension_(extensionId, factory, arg) {
+  registerExtension(extensionId, factory, arg) {
     const holder = this.getExtensionHolder_(extensionId, /* auto */ true);
     try {
       this.currentExtensionId_ = extensionId;
@@ -320,17 +250,19 @@ export class Extensions {
   }
 
   /**
-   * Registers the element implementation with the current extension.
+   * Add an element to the extension currently being registered. This is a
+   * restricted method and it's allowed to be called only during the overall
+   * extension registration.
    * @param {string} name
-   * @param {!Function} implementationClass
+   * @param {function(new:../base-element.BaseElement, !Element)}
+   *     implementationClass
    * @param {?string|undefined} css
-   * @private
    * @restricted
    */
-  addElement_(name, implementationClass, css) {
+  addElement(name, implementationClass, css) {
     const holder = this.getCurrentExtensionHolder_(name);
     holder.extension.elements[name] = {implementationClass, css};
-    this.addDocFactory_(ampdoc => {
+    this.addDocFactory(ampdoc => {
       this.installElement_(ampdoc, name, implementationClass, css);
     });
   }
@@ -367,15 +299,16 @@ export class Extensions {
   }
 
   /**
-   * Adds `name` to the list of services registered by the current extension.
+   * Add a service to the extension currently being registered. This is a
+   * restricted method and it's allowed to be called only during the overall
+   * extension registration.
    * @param {string} name
    * @param {function(new:Object, !./ampdoc-impl.AmpDoc)} implementationClass
-   * @private
    */
-  addService_(name, implementationClass) {
+  addService(name, implementationClass) {
     const holder = this.getCurrentExtensionHolder_();
     holder.extension.services.push(name);
-    this.addDocFactory_(ampdoc => {
+    this.addDocFactory(ampdoc => {
       registerServiceBuilderForDoc(
           ampdoc,
           name,
@@ -385,13 +318,14 @@ export class Extensions {
   }
 
   /**
-   * Registers an ampdoc factory.
+   * Add a ampdoc factory to the extension currently being registered. This is a
+   * restricted method and it's allowed to be called only during the overall
+   * extension registration.
    * @param {function(!./ampdoc-impl.AmpDoc)} factory
    * @param {string=} opt_forName
-   * @private
    * @restricted
    */
-  addDocFactory_(factory, opt_forName) {
+  addDocFactory(factory, opt_forName) {
     const holder = this.getCurrentExtensionHolder_(opt_forName);
     holder.docFactories.push(factory);
 
@@ -409,14 +343,13 @@ export class Extensions {
 
   /**
    * Installs all ampdoc factories previously registered with
-   * `addDocFactory_`.
+   * `addDocFactory`.
    * @param {!./ampdoc-impl.AmpDoc} ampdoc
    * @param {!Array<string>} extensionIds
    * @return {!Promise}
-   * @private
    * @restricted
    */
-  installExtensionsInDoc_(ampdoc, extensionIds) {
+  installExtensionsInDoc(ampdoc, extensionIds) {
     const promises = [];
     extensionIds.forEach(extensionId => {
       promises.push(this.installExtensionInDoc_(ampdoc, extensionId));
@@ -434,7 +367,7 @@ export class Extensions {
   installExtensionInDoc_(ampdoc, extensionId) {
     const holder = this.getExtensionHolder_(extensionId, /* auto */ false);
     return this.waitFor_(holder).then(() => {
-      declareExtension(ampdoc, extensionId);
+      ampdoc.declareExtension(extensionId);
       holder.docFactories.forEach(factory => {
         try {
           factory(ampdoc);

--- a/test/functional/test-extensions.js
+++ b/test/functional/test-extensions.js
@@ -23,12 +23,7 @@ import {BaseElement} from '../../src/base-element';
 import {ElementStub} from '../../src/element-stub';
 import {
   Extensions,
-  addDocFactoryToExtension,
-  addElementToExtension,
-  addServiceToExtension,
-  installExtensionsInDoc,
   installExtensionsService,
-  registerExtension,
 } from '../../src/service/extensions-impl';
 import {Services} from '../../src/services';
 import {getServiceForDoc} from '../../src/service';
@@ -65,7 +60,7 @@ describes.sandboxed('Extensions', {}, () => {
       const amp = {};
       let factoryExecuted = false;
       let currentHolder;
-      registerExtension(extensions, 'amp-ext', arg => {
+      extensions.registerExtension('amp-ext', arg => {
         expect(factoryExecuted).to.be.false;
         expect(arg).to.equal(amp);
         expect(extensions.currentExtensionId_).to.equal('amp-ext');
@@ -94,7 +89,7 @@ describes.sandboxed('Extensions', {}, () => {
 
     it('should register successfully with promise', () => {
       const promise = extensions.waitForExtension('amp-ext');
-      registerExtension(extensions, 'amp-ext', () => {}, {});
+      extensions.registerExtension('amp-ext', () => {}, {});
       expect(extensions.currentExtensionId_).to.be.null;
 
       const holder = extensions.extensions_['amp-ext'];
@@ -113,7 +108,7 @@ describes.sandboxed('Extensions', {}, () => {
 
     it('should fail registration without promise', () => {
       allowConsoleError(() => { expect(() => {
-        registerExtension(extensions, 'amp-ext', () => {
+        extensions.registerExtension('amp-ext', () => {
           throw new Error('intentional');
         }, {});
       }).to.throw(/intentional/); });
@@ -139,7 +134,7 @@ describes.sandboxed('Extensions', {}, () => {
     it('should fail registration with promise', () => {
       const promise = extensions.waitForExtension('amp-ext');
       allowConsoleError(() => { expect(() => {
-        registerExtension(extensions, 'amp-ext', () => {
+        extensions.registerExtension('amp-ext', () => {
           throw new Error('intentional');
         }, {});
       }).to.throw(/intentional/); });
@@ -163,8 +158,8 @@ describes.sandboxed('Extensions', {}, () => {
 
     it('should add element in registration', () => {
       const ctor = function() {};
-      registerExtension(extensions, 'amp-ext', () => {
-        addElementToExtension(extensions, 'e1', ctor);
+      extensions.registerExtension('amp-ext', () => {
+        extensions.addElement('e1', ctor);
       }, {});
       return extensions.waitForExtension('amp-ext').then(extension => {
         expect(extension.elements['e1']).to.exist;
@@ -174,7 +169,7 @@ describes.sandboxed('Extensions', {}, () => {
 
     it('should add element out of registration', () => {
       const ctor = function() {};
-      addElementToExtension(extensions, 'e1', ctor);
+      extensions.addElement('e1', ctor);
       expect(Object.keys(extensions.extensions_)).to.deep.equal(['_UNKNOWN_']);
       const unknown = extensions.extensions_['_UNKNOWN_'];
       expect(unknown.extension.elements['e1']).to.exist;
@@ -191,9 +186,9 @@ describes.sandboxed('Extensions', {}, () => {
       expect(win.customElements.elements['amp-test']).to.not.exist;
 
       // Resolve the promise.
-      registerExtension(extensions, 'amp-test', () => {
-        addElementToExtension(extensions, 'amp-test', AmpTest);
-        addElementToExtension(extensions, 'amp-test-sub', AmpTestSub);
+      extensions.registerExtension('amp-test', () => {
+        extensions.addElement('amp-test', AmpTest);
+        extensions.addElement('amp-test-sub', AmpTestSub);
       }, {});
       expect(win.ampExtendedElements['amp-test']).to.equal(AmpTest);
       expect(win.ampExtendedElements['amp-test-sub']).to.equal(AmpTestSub);
@@ -213,9 +208,9 @@ describes.sandboxed('Extensions', {}, () => {
       extensions.preloadExtension('amp-test');
 
       // Resolve the promise.
-      registerExtension(extensions, 'amp-test', () => {
-        addElementToExtension(extensions, 'amp-test', AmpTest);
-        addElementToExtension(extensions, 'amp-test-sub', AmpTestSub);
+      extensions.registerExtension('amp-test', () => {
+        extensions.addElement('amp-test', AmpTest);
+        extensions.addElement('amp-test-sub', AmpTestSub);
       }, {});
       expect(win.ampExtendedElements &&
           win.ampExtendedElements['amp-test']).to.be.undefined;
@@ -236,9 +231,9 @@ describes.sandboxed('Extensions', {}, () => {
       expect(win.services['amp-test']).to.not.exist;
 
       // Resolve the promise.
-      registerExtension(extensions, 'amp-test', () => {
-        addElementToExtension(extensions, 'amp-test', AmpTest);
-        addElementToExtension(extensions, 'amp-test-sub', AmpTestSub);
+      extensions.registerExtension('amp-test', () => {
+        extensions.addElement('amp-test', AmpTest);
+        extensions.addElement('amp-test-sub', AmpTestSub);
       }, {});
       expect(win.ampExtendedElements['amp-test']).to.equal(AmpTest);
       expect(win.ampExtendedElements['amp-test-sub']).to.equal(AmpTestSub);
@@ -259,9 +254,9 @@ describes.sandboxed('Extensions', {}, () => {
       extensions.preloadExtension('amp-test');
 
       // Resolve the promise.
-      registerExtension(extensions, 'amp-test', () => {
-        addElementToExtension(extensions, 'amp-test', AmpTest);
-        addElementToExtension(extensions, 'amp-test-sub', AmpTestSub);
+      extensions.registerExtension('amp-test', () => {
+        extensions.addElement('amp-test', AmpTest);
+        extensions.addElement('amp-test-sub', AmpTestSub);
       }, {});
       expect(win.ampExtendedElements['amp-test']).to.equal(AmpTest);
       expect(win.ampExtendedElements['amp-test-sub']).to.equal(AmpTestSub);
@@ -279,9 +274,9 @@ describes.sandboxed('Extensions', {}, () => {
       expect(win.customElements.elements['amp-test']).to.not.exist;
 
       // Resolve the promise.
-      registerExtension(extensions, 'amp-test', () => {
-        addElementToExtension(extensions, 'amp-test', AmpTest);
-        addElementToExtension(extensions, 'amp-test-sub', AmpTestSub);
+      extensions.registerExtension('amp-test', () => {
+        extensions.addElement('amp-test', AmpTest);
+        extensions.addElement('amp-test-sub', AmpTestSub);
       }, {});
       expect(win.ampExtendedElements &&
           win.ampExtendedElements['amp-test']).to.be.undefined;
@@ -293,7 +288,7 @@ describes.sandboxed('Extensions', {}, () => {
       const shadowRoot = document.createDocumentFragment();
       installRuntimeStylesTo(shadowRoot);
       const ampdoc = new AmpDocShadow(win, 'https://a.org/', shadowRoot);
-      const promise = installExtensionsInDoc(extensions, ampdoc, ['amp-test']);
+      const promise = extensions.installExtensionsInDoc(ampdoc, ['amp-test']);
       return promise.then(() => {
         // Resolved later.
         expect(win.ampExtendedElements['amp-test']).to.equal(AmpTest);
@@ -329,9 +324,9 @@ describes.sandboxed('Extensions', {}, () => {
       expect(win.services['amp-test']).to.not.exist;
 
       // Resolve the promise.
-      registerExtension(extensions, 'amp-test', () => {
-        addElementToExtension(extensions, 'amp-test', AmpTest);
-        addElementToExtension(extensions, 'amp-test-sub', AmpTestSub);
+      extensions.registerExtension('amp-test', () => {
+        extensions.addElement('amp-test', AmpTest);
+        extensions.addElement('amp-test-sub', AmpTestSub);
       }, {});
       expect(win.ampExtendedElements['amp-test']).to.equal(AmpTest);
       expect(win.ampExtendedElements['amp-test-sub']).to.equal(AmpTestSub);
@@ -342,8 +337,8 @@ describes.sandboxed('Extensions', {}, () => {
 
     it('should add doc factory in registration', () => {
       const factory = function() {};
-      registerExtension(extensions, 'amp-ext', () => {
-        addDocFactoryToExtension(extensions, factory);
+      extensions.registerExtension('amp-ext', () => {
+        extensions.addDocFactory(factory);
       }, {});
 
       const holder = extensions.getExtensionHolder_('amp-ext');
@@ -354,7 +349,7 @@ describes.sandboxed('Extensions', {}, () => {
 
     it('should add doc factory out of registration', () => {
       const factory = function() {};
-      addDocFactoryToExtension(extensions, factory);
+      extensions.addDocFactory(factory);
 
       const holder = extensions.getExtensionHolder_('_UNKNOWN_');
       expect(holder.docFactories).to.exist;
@@ -370,16 +365,15 @@ describes.sandboxed('Extensions', {}, () => {
         throw new Error('intentional');
       };
       const factory3 = sandbox.spy();
-      registerExtension(extensions, 'amp-ext', () => {
-        addDocFactoryToExtension(extensions, factory1);
-        addDocFactoryToExtension(extensions, factory2);
-        addDocFactoryToExtension(extensions, factory3);
+      extensions.registerExtension('amp-ext', () => {
+        extensions.addDocFactory(factory1);
+        extensions.addDocFactory(factory2);
+        extensions.addDocFactory(factory3);
       }, {});
 
       const shadowRoot = document.createDocumentFragment();
       const ampdoc = new AmpDocShadow(win, 'https://a.org/', shadowRoot);
-      const promise = installExtensionsInDoc(
-          extensions, ampdoc, ['amp-ext']);
+      const promise = extensions.installExtensionsInDoc(ampdoc, ['amp-ext']);
       return promise.then(() => {
         expect(factory1).to.be.calledOnce;
         expect(factory1.args[0][0]).to.equal(ampdoc);
@@ -391,8 +385,8 @@ describes.sandboxed('Extensions', {}, () => {
 
     it('should add service factory in registration', () => {
       const factory = function() {};
-      registerExtension(extensions, 'amp-ext', () => {
-        addServiceToExtension(extensions, 'service1', factory);
+      extensions.registerExtension('amp-ext', () => {
+        extensions.addService('service1', factory);
       }, {});
 
       const holder = extensions.getExtensionHolder_('amp-ext');
@@ -401,7 +395,7 @@ describes.sandboxed('Extensions', {}, () => {
 
     it('should add service factory out of registration', () => {
       const factory = function() {};
-      addServiceToExtension(extensions, 'service1', factory);
+      extensions.addService('service1', factory);
 
       const holder = extensions.getExtensionHolder_('_UNKNOWN_');
       expect(holder.extension.services).to.deep.equal(['service1']);
@@ -421,9 +415,9 @@ describes.sandboxed('Extensions', {}, () => {
       };
 
       // Resolve the promise.
-      registerExtension(extensions, 'amp-test', () => {
-        addServiceToExtension(extensions, 'service1', factory1);
-        addServiceToExtension(extensions, 'service2', factory2);
+      extensions.registerExtension('amp-test', () => {
+        extensions.addService('service1', factory1);
+        extensions.addService('service2', factory2);
       }, {});
       expect(ampdoc.declaresExtension('amp-test')).to.be.false;
       expect(factory1Spy).to.be.calledOnce;
@@ -441,9 +435,9 @@ describes.sandboxed('Extensions', {}, () => {
       extensions.preloadExtension('amp-test');
 
       // Resolve the promise.
-      registerExtension(extensions, 'amp-test', () => {
-        addServiceToExtension(extensions, 'service1', factory1);
-        addServiceToExtension(extensions, 'service2', factory2);
+      extensions.registerExtension('amp-test', () => {
+        extensions.addService('service1', factory1);
+        extensions.addService('service2', factory2);
       }, {});
       expect(ampdoc.declaresExtension('amp-test')).to.be.false;
       expect(factory1).to.be.not.called;
@@ -472,9 +466,9 @@ describes.sandboxed('Extensions', {}, () => {
       };
 
       // Resolve the promise.
-      registerExtension(extensions, 'amp-test', () => {
-        addServiceToExtension(extensions, 'service1', factory1);
-        addServiceToExtension(extensions, 'service2', factory2);
+      extensions.registerExtension('amp-test', () => {
+        extensions.addService('service1', factory1);
+        extensions.addService('service2', factory2);
       }, {});
       expect(factory1Spy).to.be.calledOnce;
       expect(factory2Spy).to.be.calledOnce;
@@ -492,17 +486,16 @@ describes.sandboxed('Extensions', {}, () => {
         throw new Error('intentional');
       };
       const factory3 = sandbox.spy();
-      registerExtension(extensions, 'amp-ext', () => {
-        addServiceToExtension(extensions, 'service1', factory1);
-        addServiceToExtension(extensions, 'service2', factory2);
-        addServiceToExtension(extensions, 'service3', factory3);
+      extensions.registerExtension('amp-ext', () => {
+        extensions.addService('service1', factory1);
+        extensions.addService('service2', factory2);
+        extensions.addService('service3', factory3);
       }, {});
 
       // Install into shadow doc.
       const shadowRoot = document.createDocumentFragment();
       const ampdoc = new AmpDocShadow(win, 'https://a.org/', shadowRoot);
-      const promise = installExtensionsInDoc(
-          extensions, ampdoc, ['amp-ext']);
+      const promise = extensions.installExtensionsInDoc(ampdoc, ['amp-ext']);
       return promise.then(() => {
         expect(factory1).to.be.calledOnce;
         expect(factory1.args[0][0]).to.equal(ampdoc);
@@ -542,9 +535,9 @@ describes.sandboxed('Extensions', {}, () => {
       };
 
       // Resolve the promise.
-      registerExtension(extensions, 'amp-test', () => {
-        addServiceToExtension(extensions, 'service1', factory1);
-        addServiceToExtension(extensions, 'service2', factory2);
+      extensions.registerExtension('amp-test', () => {
+        extensions.addService('service1', factory1);
+        extensions.addService('service2', factory2);
       }, {});
       expect(factory1Spy).to.be.calledOnce;
       expect(factory2Spy).to.be.calledOnce;
@@ -554,8 +547,8 @@ describes.sandboxed('Extensions', {}, () => {
 
     it('should load extension class via load extension', () => {
       const ctor = function() {};
-      registerExtension(extensions, 'amp-ext', () => {
-        addElementToExtension(extensions, 'amp-ext', ctor);
+      extensions.registerExtension('amp-ext', () => {
+        extensions.addElement('amp-ext', ctor);
       }, {});
       return extensions.loadElementClass('amp-ext').then(elementClass => {
         expect(elementClass).to.equal(ctor);
@@ -714,7 +707,7 @@ describes.sandboxed('Extensions', {}, () => {
       expect(win.customElements.elements['amp-test']).to.exist;
 
       // Resolve the promise.
-      registerExtension(extensions, 'amp-test', AMP => {
+      extensions.registerExtension('amp-test', AMP => {
         // Main extension with CSS.
         AMP.registerElement('amp-test', AmpTest, 'a{}');
         // Secondary extension w/o CSS.
@@ -739,7 +732,7 @@ describes.sandboxed('Extensions', {}, () => {
       expect(loadSpy).to.be.calledOnce;
 
       // Resolve.
-      registerExtension(extensions, 'amp-test', () => {});
+      extensions.registerExtension('amp-test', () => {});
       return promise1.then(() => {
         const promise3 = extensions.installExtensionForDoc(ampdoc, 'amp-test');
         expect(promise3).to.equal(promise1);
@@ -777,7 +770,7 @@ describes.sandboxed('Extensions', {}, () => {
       expect(factory2Spy).to.not.be.called;
 
       // Resolve the promise.
-      registerExtension(extensions, 'amp-test', AMP => {
+      extensions.registerExtension('amp-test', AMP => {
         AMP.registerServiceForDoc('service1', factory1);
         AMP.registerServiceForDoc('service2', factory2);
       }, win.AMP);
@@ -812,7 +805,7 @@ describes.sandboxed('Extensions', {}, () => {
       const extHolder = extensions.getExtensionHolder_('amp-test');
       extHolder.scriptPresent = true;
       const promise = extensions.installExtensionForDoc(ampdoc, 'amp-test');
-      registerExtension(extensions, 'amp-test', AMP => {
+      extensions.registerExtension('amp-test', AMP => {
         AMP.registerServiceForDoc('service1', factory1);
         AMP.registerServiceForDoc('service2', factory2);
         AMP.registerServiceForDoc('service3', factory3);
@@ -927,7 +920,7 @@ describes.sandboxed('Extensions', {}, () => {
           .to.be.instanceOf(ElementStub);
       expect(iframeWin.ampExtendedElements['amp-test-sub']).to.be.undefined;
       // Resolve the promise.
-      registerExtension(extensions, 'amp-test', AMP => {
+      extensions.registerExtension('amp-test', AMP => {
         // Main extension with CSS.
         AMP.registerElement('amp-test', AmpTest, 'a{}');
         // Secondary extension w/o CSS.
@@ -971,7 +964,7 @@ describes.sandboxed('Extensions', {}, () => {
       const promise =
           extensions.installExtensionsInChildWindow(iframeWin, ['amp-test']);
       // Resolve the promise.
-      registerExtension(extensions, 'amp-test', AMP => {
+      extensions.registerExtension('amp-test', AMP => {
         AMP.registerServiceForDoc('fake-service-foo', () => fakeServiceFoo);
       }, parentWin.AMP);
       return promise.then(() => {
@@ -1006,7 +999,7 @@ describes.sandboxed('Extensions', {}, () => {
       expect(iframeWin.ampExtendedElements['amp-test']).to.equal(ElementStub);
 
       // Resolve the promise.
-      registerExtension(extensions, 'amp-test', AMP => {
+      extensions.registerExtension('amp-test', AMP => {
         AMP.registerElement('amp-test', AmpTest);
       }, parentWin.AMP);
       return promise.then(() => {

--- a/test/functional/test-runtime.js
+++ b/test/functional/test-runtime.js
@@ -847,7 +847,7 @@ describes.realWin('runtime multidoc', {
       const shadowRoot = createShadowRoot(hostElement);
       ampdoc = new AmpDocShadow(win, docUrl, shadowRoot);
 
-      ampdocServiceMock.expects('installShadowDoc_')
+      ampdocServiceMock.expects('installShadowDoc')
           .withExactArgs(
               docUrl,
               sinon.match(arg => arg == getShadowRoot(hostElement)))
@@ -1171,7 +1171,7 @@ describes.realWin('runtime multidoc', {
       const shadowRoot = createShadowRoot(hostElement);
       ampdoc = new AmpDocShadow(win, docUrl, shadowRoot);
 
-      ampdocServiceMock.expects('installShadowDoc_')
+      ampdocServiceMock.expects('installShadowDoc')
           .withExactArgs(
               docUrl,
               sinon.match(arg => arg == getShadowRoot(hostElement)))
@@ -1518,7 +1518,7 @@ describes.realWin('runtime multidoc', {
       const shadowRoot = createShadowRoot(hostElement);
       const ampdoc = new AmpDocShadow(win, docUrl, shadowRoot);
 
-      ampdocServiceMock.expects('installShadowDoc_')
+      ampdocServiceMock.expects('installShadowDoc')
           .withExactArgs(
               docUrl,
               sinon.match(arg => arg == getShadowRoot(hostElement)))

--- a/testing/describes.js
+++ b/testing/describes.js
@@ -108,7 +108,6 @@ import {installDocService} from '../src/service/ampdoc-impl';
 import {
   installBuiltinElements,
   installExtensionsService,
-  registerExtension,
 } from '../src/service/extensions-impl';
 import {
   resetScheduledElementForTesting,
@@ -696,7 +695,7 @@ class AmpFixture {
           if (env.ampdoc) {
             env.ampdoc.declareExtension(extensionId);
           }
-          registerExtension(env.extensions, extensionId, installer, win.AMP);
+          env.extensions.registerExtension(extensionId, installer, win.AMP);
         }
       });
     }
@@ -727,7 +726,7 @@ class AmpFixture {
       if (env.ampdoc) {
         env.ampdoc.declareExtension(extensionId);
       }
-      registerExtension(env.extensions, extensionId, installer, win.AMP);
+      env.extensions.registerExtension(extensionId, installer, win.AMP);
     };
 
     /**
@@ -783,7 +782,7 @@ class AmpFixture {
       const ampdoc = ret.ampdoc;
       env.ampdoc = ampdoc;
       const promise = Promise.all([
-        env.extensions.installExtensionsInDoc_(ampdoc, extensionIds),
+        env.extensions.installExtensionsInDoc(ampdoc, extensionIds),
         ampdoc.whenReady(),
       ]);
       completePromise = completePromise ?


### PR DESCRIPTION
Lots of methods on AmpDoc and Extensions which were marked as private, but being called from exported functions (and potentially being broken by Closure Compiler optimisations). Marked affected methods as public, and removed redundant exported functions (which existed only to expose the private methods).

Issue identified in #14896.
Fixes part of #14761.