### PR TITLE
Check what the current slot size is before performing resizing, for safeframe.

### DIFF
--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -1308,8 +1308,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     dev().assert(creativeSize, 'this.getCreativeSize returned null');
     this.safeframeApi_ = this.safeframeApi_ ||
         new SafeframeHostApi(
-            this, this.isFluid_, this.initialSize_,
-            /** @type {{height, width}} */(creativeSize),
+            this, this.isFluid_, /** @type {{height, width}} */(creativeSize),
             this.fluidImpressionUrl_);
 
     return this.safeframeApi_.getSafeframeNameAttr();

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
@@ -559,9 +559,7 @@ export class SafeframeHostApi {
   handleSizeChange(height, width, messageType, optIsCollapse) {
     return this.viewport_.getClientRectAsync(
         this.baseInstance_.element).then(box => {
-      if (!optIsCollapse &&
-              width <= box.width &&
-              height <= box.height) {
+      if (!optIsCollapse && width <= box.width && height <= box.height) {
         this.resizeSafeframe(height, width, messageType);
       } else {
         this.resizeAmpAdAndSafeframe(height, width, messageType,

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
@@ -557,13 +557,15 @@ export class SafeframeHostApi {
    * @param {boolean=} optIsCollapse Whether this is a collapse attempt.
    */
   handleSizeChange(height, width, messageType, optIsCollapse) {
-    return this.viewport_.getClientRectAsync(this.baseInstance_.element).then(box => {
+    return this.viewport_.getClientRectAsync(
+        this.baseInstance_.element).then(box => {
       if (!optIsCollapse &&
-          width <= box.width &&
-          height <= box.height) {
+              width <= box.width &&
+              height <= box.height) {
         this.resizeSafeframe(height, width, messageType);
       } else {
-        this.resizeAmpAdAndSafeframe(height, width, messageType, optIsCollapse);
+        this.resizeAmpAdAndSafeframe(height, width, messageType,
+            optIsCollapse);
       }
     });
   }

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
@@ -122,12 +122,10 @@ export class SafeframeHostApi {
   /**
    * @param {!./amp-ad-network-doubleclick-impl.AmpAdNetworkDoubleclickImpl} baseInstance
    * @param {boolean} isFluid
-   * @param {?({width: number, height: number}|../../../src/layout-rect.LayoutRectDef)} initialSize
    * @param {{width:number, height:number}} creativeSize
    * @param {?string} fluidImpressionUrl
    */
-  constructor(baseInstance, isFluid, initialSize, creativeSize,
-    fluidImpressionUrl) {
+  constructor(baseInstance, isFluid, creativeSize, fluidImpressionUrl) {
     /** @private {!./amp-ad-network-doubleclick-impl.AmpAdNetworkDoubleclickImpl} */
     this.baseInstance_ = baseInstance;
 
@@ -154,9 +152,6 @@ export class SafeframeHostApi {
 
     /** @private {boolean} */
     this.isFluid_ = isFluid;
-
-    /** @private {?({width: number, height: number}|../../../src/layout-rect.LayoutRectDef)} */
-    this.slotSize_ = initialSize;
 
     /** @private {{width:number, height:number}} */
     this.creativeSize_ = creativeSize;
@@ -562,13 +557,15 @@ export class SafeframeHostApi {
    * @param {boolean=} optIsCollapse Whether this is a collapse attempt.
    */
   handleSizeChange(height, width, messageType, optIsCollapse) {
-    if (!optIsCollapse &&
-        width <= this.slotSize_.width &&
-        height <= this.slotSize_.height) {
-      this.resizeSafeframe(height, width, messageType);
-    } else {
-      this.resizeAmpAdAndSafeframe(height, width, messageType, optIsCollapse);
-    }
+    return this.viewport_.getClientRectAsync(this.baseInstance_.element).then(box => {
+      if (!optIsCollapse &&
+          width <= box.width &&
+          height <= box.height) {
+        this.resizeSafeframe(height, width, messageType);
+      } else {
+        this.resizeAmpAdAndSafeframe(height, width, messageType, optIsCollapse);
+      }
+    });
   }
 
   /**
@@ -635,11 +632,6 @@ export class SafeframeHostApi {
       // If this resize succeeded, we always resize the safeframe.
       // resizeSafeframe also sends the resize response.
       this.resizeSafeframe(height, width, messageType);
-      // Update our stored record of what the amp-ad's size is. This
-      // is just for caching. Setting it here doesn't actually change
-      // the size of the amp-ad, the attempt change size above did that.
-      this.slotSize_.height = height;
-      this.slotSize_.width = width;
     }, /** REJECT CALLBACK */ () => {
       // If the resize initially failed, it may have been queued
       // as a pendingChangeSize, which will cause the size change

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-fluid.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-fluid.js
@@ -205,7 +205,7 @@ describes.realWin('DoubleClick Fast Fetch Fluid', realWinConfig, env => {
     impl.sentinel = 'sentinel';
     impl.initiateAdRequest();
     impl.safeframeApi_ = new SafeframeHostApi(
-        impl, true, impl.initialSize_, impl.creativeSize_);
+        impl, true, impl.creativeSize_);
     sandbox./*OK*/stub(impl.safeframeApi_, 'setupGeom_');
     const connectMessagingChannelSpy =
           sandbox./*OK*/spy(impl.safeframeApi_,


### PR DESCRIPTION
Was using an incorrect cached amp-ad slot size. Instead, directly check. 