### PR TITLE
Unify iOS Viewports

### DIFF
--- a/css/amp.css
+++ b/css/amp.css
@@ -77,27 +77,6 @@ html.i-amphtml-fie > body {
 }
 
 /**
- * Set `body {overflow-x: hidden}` for iOS WebView. This is b/c iOS WebView
- * does NOT respect `html {overflow-x: hidden}`.
- * Note! For all other natural cases body's style is `body {overflow: visible}`
- * to avoid visibility issues with iframes.
- */
-html.i-amphtml-webview > body {
-  overflow-x: hidden !important;
-  overflow-y: visible !important;
-}
-
-
-/**
- * iOS-Embed mode (iOS <= 8). The `body` itself is scrollable.
- */
-html.i-amphtml-ios-embed-legacy > body {
-  overflow-x: hidden !important;
-  overflow-y: auto !important;
-  position: absolute !important;
-}
-
-/**
  * iOS-Embed Wrapper mode. The `body` is wrapped into `#i-amphtml-wrapper`
  * element.
  */

--- a/src/service/viewport/viewport-binding-ios-embed-wrapper.js
+++ b/src/service/viewport/viewport-binding-ios-embed-wrapper.js
@@ -18,9 +18,9 @@ import {Observable} from '../../observable';
 import {ViewportBindingDef} from './viewport-binding-def';
 import {dev} from '../../log';
 import {isExperimentOn} from '../../experiments';
+import {isIframed, waitForBody} from '../../dom';
 import {layoutRectLtwh} from '../../layout-rect';
 import {px, setImportantStyles} from '../../style';
-import {waitForBody} from '../../dom';
 import {whenDocumentReady} from '../../document-ready';
 
 const TAG_ = 'Viewport';
@@ -138,7 +138,8 @@ export class ViewportBindingIosEmbedWrapper_ {
 
   /** @override */
   requiresFixedLayerTransfer() {
-    return true;
+    const {win} = this;
+    return isIframed(win) || getMode(win).localDev || getMode(win).development;
   }
 
   /** @override */

--- a/src/service/viewport/viewport-impl.js
+++ b/src/service/viewport/viewport-impl.js
@@ -201,9 +201,6 @@ export class Viewport {
     if (isIframed(this.ampdoc.win)) {
       this.globalDoc_.documentElement.classList.add('i-amphtml-iframed');
     }
-    if (viewer.getParam('webview') === '1') {
-      this.globalDoc_.documentElement.classList.add('i-amphtml-webview');
-    }
 
     // To avoid browser restore scroll position when traverse history
     if (isIframed(this.ampdoc.win) &&

--- a/src/service/viewport/viewport-impl.js
+++ b/src/service/viewport/viewport-impl.js
@@ -1164,23 +1164,28 @@ const ViewportType = {
  */
 function getViewportType(win, viewer) {
   const viewportType = viewer.getParam('viewportType') || ViewportType.NATURAL;
-  if (!Services.platformFor(win).isIos() ||
-      viewportType != ViewportType.NATURAL) {
+  const isIos = Services.platformFor(win).isIos();
+  if (!isIos || viewportType != ViewportType.NATURAL) {
     return viewportType;
   }
+  // Experiment with giving all iOS viewers the poopy viewport type.
+  if (isIos && isExperimentOn(win, 'unified-ios-viewport')) {
+    return ViewportType.NATURAL_IOS_EMBED;
+  }
+  const isInIframe = isIframed(win);
   // Enable iOS Embedded mode so that it's easy to test against a more
   // realistic iOS environment w/o an iframe.
-  if (!isIframed(win) && (getMode(win).localDev || getMode(win).development)) {
+  if (!isInIframe && (getMode(win).localDev || getMode(win).development)) {
     return ViewportType.NATURAL_IOS_EMBED;
   }
 
   // Enable iOS Embedded mode for iframed tests (e.g. integration tests).
-  if (isIframed(win) && getMode(win).test) {
+  if (isInIframe && getMode(win).test) {
     return ViewportType.NATURAL_IOS_EMBED;
   }
 
   // Override to ios-embed for iframe-viewer mode.
-  if (isIframed(win) && viewer.isEmbedded()) {
+  if (isInIframe && viewer.isEmbedded()) {
     return ViewportType.NATURAL_IOS_EMBED;
   }
   return viewportType;

--- a/tools/experiments/experiments.js
+++ b/tools/experiments/experiments.js
@@ -300,6 +300,12 @@ const EXPERIMENTS = [
     spec: 'https://github.com/ampproject/amphtml/issues/14150',
     cleanupissue: 'https://github.com/ampproject/amphtml/issues/14325',
   },
+  {
+    id: 'unified-ios-viewport',
+    name: 'Use a unified iOS Embeded Viewport in all viewers',
+    spec: 'https://github.com/ampproject/amphtml/issues/11445',
+    cleanupIssue: 'https://github.com/ampproject/amphtml/issues/14940',
+  },
 ];
 
 if (getMode().localDev) {


### PR DESCRIPTION
We'll be discussing this in the next [design review](https://github.com/ampproject/amphtml/issues/14594).

Re: https://github.com/ampproject/amphtml/issues/11445

This forces the `ViewportBindingIosEmbedWrapper_` viewport (with all its DOM hacks) onto all iOS viewer environments (Origin, Iframe, and Webview) to achieve consistency during development.

This also fixes several bugs we've received of Webview viewports cropping/disappearing page content due to the styles it applies on top of the normal Origin viewport.

Additionally, FixedLayer transfer of fixed-position elements is disabled unless needed. We can discuss enabling it for all cases if we want.