### PR TITLE
🏗 Skip PR builds on `master` from greenkeeper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,10 +42,10 @@ addons:
     - python-protobuf
 matrix:
   include:
-    # For non-greenkeeper branches, use the normal environment.
-    - if: NOT branch =~ ^greenkeeper/.*$
+    # For non-greenkeeper branches, use the normal environment (but skip PR builds on master from greenkeeper).
+    - if: NOT branch =~ ^greenkeeper/.*$ AND NOT sender =~ greenkeeper
       env: BUILD_SHARD="unit_tests"
-    - if: NOT branch =~ ^greenkeeper/.*$
+    - if: NOT branch =~ ^greenkeeper/.*$ AND NOT sender =~ greenkeeper
       env: BUILD_SHARD="integration_tests"
     # For greenkeeper branches, add a secure GH token for the lockfile upload.
     - if: branch =~ ^greenkeeper/.*$

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -475,14 +475,6 @@ function runYarnLockfileCheck() {
 }
 
 /**
- * Returns true if this is a PR build for a greenkeeper branch.
- */
-function isGreenkeeperPrBuild() {
-  return (process.env.TRAVIS_EVENT_TYPE == 'pull_request') &&
-      (process.env.TRAVIS_PULL_REQUEST_BRANCH.startsWith('greenkeeper/'));
-}
-
-/**
  * Returns true if this is a push build for a greenkeeper branch.
  */
 function isGreenkeeperPushBuild() {
@@ -507,14 +499,6 @@ function isGreenkeeperLockfilePushBuild() {
  */
 function main() {
   const startTime = startTimer('pr-check.js');
-
-  if (isGreenkeeperPrBuild()) {
-    console.log(fileLogPrefix,
-        'This is a greenkeeper PR build. Tests will be run for the push ' +
-        'build with the lockfile update.');
-    stopTimer('pr-check.js', startTime);
-    return 0;
-  }
 
   if (isGreenkeeperPushBuild() && !isGreenkeeperLockfilePushBuild()) {
     console.log(fileLogPrefix,


### PR DESCRIPTION
This PR further eliminates unnecessary use of 4 Travis VMs per incoming greenkeeper PR by altogether skipping PR builds on `master` that are triggered by greenkeeper. (All useful stuff is done during push builds.)

This logic works because for PR builds from greenkeeper, `branch` == `master` but `TRAVIS_PULL_REQUEST_BRANCH` == `greenkeeper/*`.

Follow up to #14890 
