### PR TITLE
🏗 Add missing dependencies that were resulting in yarn warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
       "babel-polyfill",
       "document-register-element",
       "promise-pjs",
-      "react-dates",
+      "web-activities",
       "web-animations-js"
     ]
   },
@@ -142,8 +142,10 @@
     "preact-compat": "3.17.0",
     "pretty-bytes": "4.0.2",
     "prop-types": "15.6.1",
+    "react": "16.3.2",
     "react-addons-shallow-compare": "15.6.2",
     "react-dates": "15.5.3",
+    "react-dom": "16.3.2",
     "react-externs": "0.13.6",
     "request": "2.84.0",
     "rimraf": "2.6.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6786,7 +6786,7 @@ longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
-loose-envify@^1.0.0, loose-envify@^1.3.1:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
@@ -8775,6 +8775,15 @@ react-dates@15.5.3:
     react-with-styles "=2.2.0"
     react-with-styles-interface-css "^3.0.0"
 
+react-dom@16.3.2:
+  version "16.3.2"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.3.2.tgz#cb90f107e09536d683d84ed5d4888e9640e0e4df"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
+
 react-externs@0.13.6:
   version "0.13.6"
   resolved "https://registry.yarnpkg.com/react-externs/-/react-externs-0.13.6.tgz#75ccab88e9c8a6a9d0ae2647c368af8d94bd0160"
@@ -8806,6 +8815,15 @@ react-with-styles@=2.2.0:
     deepmerge "^1.5.2"
     global-cache "^1.2.1"
     hoist-non-react-statics "^2.3.1"
+    prop-types "^15.6.0"
+
+react@16.3.2:
+  version "16.3.2"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.3.2.tgz#fdc8420398533a1e58872f59091b272ce2f91ea9"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
     prop-types "^15.6.0"
 
 read-cache@^1.0.0:


### PR DESCRIPTION
This PR fixes the warnings that show up whenever you run `yarn`:

```
warning " > react-dates@15.5.3" has unmet peer dependency "react@^0.14 || ^15.5.4 || ^16.1.1".
warning " > react-dates@15.5.3" has unmet peer dependency "react-dom@^0.14 || ^15.5.4 || ^16.1.1".
warning "react-dates > airbnb-prop-types@2.8.1" has unmet peer dependency "react@^0.14 || ^15.0.0 || ^16.0.0-alpha".
warning "react-dates > react-portal@4.1.2" has unmet peer dependency "react@^15.0.0-0 || ^16.0.0-0 || ^17.0.0-0".
warning "react-dates > react-with-styles@2.2.0" has unmet peer dependency "react@>=0.14".
```

To test this, add a new dependency. You should no longer see the above warnings during the `Linking dependencies...` phase.

For example, running commands like...
```
yarn add --dev --exact chalk
yarn remove chalk
```
... will result in clean output and no warnings...
```
[1/5] 🔍  Validating package.json...
[2/5] 🔍  Resolving packages...
[3/5] 🚚  Fetching packages...
[4/5] 🔗  Linking dependencies...
[5/5] 📃  Building fresh packages...
success Saved lockfile.
```
Follow up to https://github.com/ampproject/amphtml/pull/12784#issuecomment-356998517