### PR TITLE
🐛 Use `getDate()` and not `getDay()` in `isDateInFuture()`

### DIFF
--- a/extensions/amp-addthis/0.1/addthis-utils/cuid.js
+++ b/extensions/amp-addthis/0.1/addthis-utils/cuid.js
@@ -50,7 +50,7 @@ export const isDateInFuture = date => {
   const yearIsSame = date.getFullYear() === now.getFullYear();
   const monthIsLater = date.getMonth() > now.getMonth();
   const monthIsSame = date.getMonth() === now.getMonth();
-  const dateIsLater = date.getDay() > now.getDay();
+  const dateIsLater = date.getDate() > now.getDate();
   return (
     yearIsLater ||
     (yearIsSame && monthIsLater) ||


### PR DESCRIPTION
Fixes the logic error described in https://github.com/ampproject/amphtml/pull/11381#pullrequestreview-116151596

With this, the following test should pass (on all days including Saturday!):
https://github.com/ampproject/amphtml/blob/61eb131d8a6c48118b1cc401a59c71805c034f38/extensions/amp-addthis/0.1/test/test-amp-addthis.js#L359-L361
