### PR TITLE
✅Fix console errors in test-amp-sidebar

### DIFF
--- a/extensions/amp-sidebar/0.1/test/test-amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/test/test-amp-sidebar.js
@@ -167,6 +167,9 @@ describes.realWin('amp-sidebar 0.1 version', {
             callback();
           },
         };
+        impl.getHistory_ = () => ({
+          push: sandbox.stub().resolves(11),
+        });
         impl.open_();
         expect(doc.querySelectorAll('.i-amphtml-sidebar-mask').length)
             .to.equal(1);
@@ -298,6 +301,11 @@ describes.realWin('amp-sidebar 0.1 version', {
           },
         };
 
+        impl.getHistory_ = () => ({
+          push: sandbox.stub().resolves(11),
+          pop: sandbox.stub().resolves(11),
+        });
+
         expect(sidebarElement.hasAttribute('open')).to.be.false;
         expect(sidebarElement.getAttribute('aria-hidden')).to.equal('true');
         expect(sidebarElement.getAttribute('role')).to.equal('menu');
@@ -329,6 +337,10 @@ describes.realWin('amp-sidebar 0.1 version', {
             callback();
           },
         };
+        impl.getHistory_ = () => ({
+          push: sandbox.stub().resolves(11),
+          pop: sandbox.stub().resolves(11),
+        });
         expect(sidebarElement.hasAttribute('open')).to.be.false;
         impl.open_();
         expect(sidebarElement.hasAttribute('open')).to.be.true;
@@ -363,6 +375,11 @@ describes.realWin('amp-sidebar 0.1 version', {
             callback();
           },
         };
+
+        impl.getHistory_ = () => ({
+          push: sandbox.stub().resolves(11),
+          pop: sandbox.stub().resolves(11),
+        });
 
         expect(impl.isOpen_()).to.be.false;
         clock.tick(600);
@@ -447,6 +464,10 @@ describes.realWin('amp-sidebar 0.1 version', {
             callback();
           },
         };
+        impl.getHistory_ = () => ({
+          push: sandbox.stub().resolves(11),
+          pop: sandbox.stub().resolves(11),
+        });
         expect(sidebarElement.hasAttribute('open')).to.be.false;
         impl.open_();
         expect(sidebarElement.hasAttribute('open')).to.be.true;
@@ -488,6 +509,9 @@ describes.realWin('amp-sidebar 0.1 version', {
                 callback();
               },
             };
+            impl.getHistory_ = () => ({
+              push: sandbox.stub().resolves(11),
+            });
             sandbox.stub(timer, 'delay').callsFake(function(callback) {
               callback();
             });
@@ -533,6 +557,9 @@ describes.realWin('amp-sidebar 0.1 version', {
             callback();
           },
         };
+        impl.getHistory_ = () => ({
+          push: sandbox.stub().resolves(11),
+        });
         sandbox.stub(timer, 'delay').callsFake(function(callback) {
           callback();
         });
@@ -576,6 +603,9 @@ describes.realWin('amp-sidebar 0.1 version', {
             callback();
           },
         };
+        impl.getHistory_ = () => ({
+          push: sandbox.stub().resolves(11),
+        });
         sandbox.stub(timer, 'delay').callsFake(function(callback) {
           callback();
         });

--- a/extensions/amp-sidebar/0.1/test/test-amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/test/test-amp-sidebar.js
@@ -76,9 +76,24 @@ describes.realWin('amp-sidebar 0.1 version', {
     return ampSidebar.build().then(() => {
       return ampSidebar.layoutCallback();
     }).then(() => {
+      const impl = ampSidebar.implementation_;
       if (options.toolbars) {
         sandbox.stub(timer, 'delay').callsFake(function(callback) {
           callback();
+        });
+        sandbox.stub(impl.vsync_, 'mutatePromise').callsFake(callback => {
+          callback();
+          return Promise.resolve();
+        });
+      }
+      sandbox.stub(impl.vsync_, 'mutate').callsFake(callback => {
+        callback();
+      });
+
+      if (options.stubHistory) {
+        sandbox.stub(impl, 'getHistory_').returns({
+          push: sandbox.stub().resolves(11),
+          pop: sandbox.stub().resolves(11),
         });
       }
       return ampSidebar;
@@ -86,16 +101,7 @@ describes.realWin('amp-sidebar 0.1 version', {
   }
 
   function getToolbars(options, ampSidebar) {
-    // Stub our sidebar operations, doing this here as it will
-    // Ease testing our media queries
-    const impl = ampSidebar.implementation_;
-    sandbox.stub(impl.vsync_, 'mutate').callsFake(callback => {
-      callback();
-    });
-    sandbox.stub(impl.vsync_, 'mutatePromise').callsFake(callback => {
-      callback();
-      return Promise.resolve();
-    });
+
     // Create our individual toolbars
     options.toolbars.forEach(toolbarObj => {
       const navToolbar = doc.createElement('nav');
@@ -160,20 +166,13 @@ describes.realWin('amp-sidebar 0.1 version', {
     });
 
     it('should create mask element in DOM', () => {
-      return getAmpSidebar().then(sidebarElement => {
-        const impl = sidebarElement.implementation_;
-        impl.vsync_ = {
-          mutate(callback) {
-            callback();
-          },
-        };
-        impl.getHistory_ = () => ({
-          push: sandbox.stub().resolves(11),
-        });
-        impl.open_();
-        expect(doc.querySelectorAll('.i-amphtml-sidebar-mask').length)
-            .to.equal(1);
-      });
+      return getAmpSidebar({'stubHistory': true})
+          .then(sidebarElement => {
+            const impl = sidebarElement.implementation_;
+            impl.open_();
+            expect(doc.querySelectorAll('.i-amphtml-sidebar-mask').length)
+                .to.equal(1);
+          });
     });
 
     it('should create an invisible close \
@@ -212,11 +211,7 @@ describes.realWin('amp-sidebar 0.1 version', {
             },
           };
         };
-        impl.vsync_ = {
-          mutate(callback) {
-            callback();
-          },
-        };
+
         impl.openOrCloseTimeOut_ = 10;
 
         impl.open_();
@@ -244,67 +239,53 @@ describes.realWin('amp-sidebar 0.1 version', {
     });
 
     it('should close sidebar on button click', () => {
-      return getAmpSidebar({'open': true}).then(sidebarElement => {
-        const impl = sidebarElement.implementation_;
-        clock = lolex.install(
-            {target: impl.win, toFake: ['Date', 'setTimeout']});
-        impl.schedulePause = sandbox.spy();
-        const historyPushSpy = sandbox.spy();
-        const historyPopSpy = sandbox.spy();
-        impl.scheduleLayout = sandbox.spy();
-        impl.getHistory_ = function() {
-          return {
-            push() {
-              historyPushSpy();
-              return Promise.resolve(11);
-            },
-            pop() {
-              historyPopSpy();
-              return Promise.resolve(11);
-            },
-          };
-        };
-        impl.historyId_ = 100;
-        impl.vsync_ = {
-          mutate(callback) {
-            callback();
-          },
-        };
+      return getAmpSidebar({'open': true, 'stubHistory': true})
+          .then(sidebarElement => {
+            const impl = sidebarElement.implementation_;
+            clock = lolex.install(
+                {target: impl.win, toFake: ['Date', 'setTimeout']});
+            impl.schedulePause = sandbox.spy();
+            const historyPushSpy = sandbox.spy();
+            const historyPopSpy = sandbox.spy();
+            impl.scheduleLayout = sandbox.spy();
+            impl.getHistory_ = function() {
+              return {
+                push() {
+                  historyPushSpy();
+                  return Promise.resolve(11);
+                },
+                pop() {
+                  historyPopSpy();
+                  return Promise.resolve(11);
+                },
+              };
+            };
+            impl.historyId_ = 100;
 
-        impl.openOrCloseTimeOut_ = 10;
-        impl.close_();
-        expect(sidebarElement.hasAttribute('open')).to.be.false;
-        expect(sidebarElement.getAttribute('aria-hidden')).to.equal('true');
-        clock.tick(600);
-        expect(sidebarElement.style.display).to.equal('none');
-        expect(impl.schedulePause).to.be.calledOnce;
-        expect(historyPopSpy).to.be.calledOnce;
-        expect(impl.historyId_).to.equal(-1);
+            impl.openOrCloseTimeOut_ = 10;
+            impl.close_();
+            expect(sidebarElement.hasAttribute('open')).to.be.false;
+            expect(sidebarElement.getAttribute('aria-hidden')).to.equal('true');
+            clock.tick(600);
+            expect(sidebarElement.style.display).to.equal('none');
+            expect(impl.schedulePause).to.be.calledOnce;
+            expect(historyPopSpy).to.be.calledOnce;
+            expect(impl.historyId_).to.equal(-1);
 
-        // second call to close_() should be a no-op and not increase call counts.
-        impl.close_();
-        expect(impl.schedulePause).to.be.calledOnce;
-        expect(historyPopSpy).to.be.calledOnce;
-      });
+            // second call to close_() should be a no-op and not increase call counts.
+            impl.close_();
+            expect(impl.schedulePause).to.be.calledOnce;
+            expect(historyPopSpy).to.be.calledOnce;
+          });
     });
 
     it('should toggle sidebar on button click', () => {
-      return getAmpSidebar().then(sidebarElement => {
+      return getAmpSidebar({stubHistory: true}).then(sidebarElement => {
         const impl = sidebarElement.implementation_;
         clock = lolex.install(
             {target: impl.win, toFake: ['Date', 'setTimeout']});
         impl.scheduleLayout = sandbox.spy();
         impl.schedulePause = sandbox.spy();
-        impl.vsync_ = {
-          mutate(callback) {
-            callback();
-          },
-        };
-
-        impl.getHistory_ = () => ({
-          push: sandbox.stub().resolves(11),
-          pop: sandbox.stub().resolves(11),
-        });
 
         expect(sidebarElement.hasAttribute('open')).to.be.false;
         expect(sidebarElement.getAttribute('aria-hidden')).to.equal('true');
@@ -327,20 +308,12 @@ describes.realWin('amp-sidebar 0.1 version', {
     });
 
     it('should close sidebar on escape', () => {
-      return getAmpSidebar().then(sidebarElement => {
+      return getAmpSidebar({stubHistory: true}).then(sidebarElement => {
         const impl = sidebarElement.implementation_;
         clock = lolex.install(
             {target: impl.win, toFake: ['Date', 'setTimeout']});
         impl.schedulePause = sandbox.spy();
-        impl.vsync_ = {
-          mutate(callback) {
-            callback();
-          },
-        };
-        impl.getHistory_ = () => ({
-          push: sandbox.stub().resolves(11),
-          pop: sandbox.stub().resolves(11),
-        });
+
         expect(sidebarElement.hasAttribute('open')).to.be.false;
         impl.open_();
         expect(sidebarElement.hasAttribute('open')).to.be.true;
@@ -364,22 +337,12 @@ describes.realWin('amp-sidebar 0.1 version', {
     });
 
     it('should reflect state of the sidebar', () => {
-      return getAmpSidebar().then(sidebarElement => {
+      return getAmpSidebar({stubHistory: true}).then(sidebarElement => {
         const impl = sidebarElement.implementation_;
         clock = lolex.install(
             {target: impl.win, toFake: ['Date', 'setTimeout']});
         impl.schedulePause = sandbox.spy();
         impl.scheduleResume = sandbox.spy();
-        impl.vsync_ = {
-          mutate(callback) {
-            callback();
-          },
-        };
-
-        impl.getHistory_ = () => ({
-          push: sandbox.stub().resolves(11),
-          pop: sandbox.stub().resolves(11),
-        });
 
         expect(impl.isOpen_()).to.be.false;
         clock.tick(600);
@@ -413,11 +376,6 @@ describes.realWin('amp-sidebar 0.1 version', {
       sandbox.stub(platform, 'isSafari').returns(true);
       return getAmpSidebar().then(sidebarElement => {
         const impl = sidebarElement.implementation_;
-        impl.vsync_ = {
-          mutate(callback) {
-            callback();
-          },
-        };
         sandbox.stub(timer, 'delay').callsFake(function(callback) {
           callback();
         });
@@ -432,11 +390,6 @@ describes.realWin('amp-sidebar 0.1 version', {
       sandbox.stub(platform, 'isSafari').returns(true);
       return getAmpSidebar().then(sidebarElement => {
         const impl = sidebarElement.implementation_;
-        impl.vsync_ = {
-          mutate(callback) {
-            callback();
-          },
-        };
         sandbox.stub(timer, 'delay').callsFake(function(callback) {
           callback();
         });
@@ -452,22 +405,13 @@ describes.realWin('amp-sidebar 0.1 version', {
     });
 
     it('should close sidebar if clicked on a non-local anchor', () => {
-      return getAmpSidebar().then(sidebarElement => {
+      return getAmpSidebar({stubHistory: true}).then(sidebarElement => {
         const anchor = sidebarElement.getElementsByTagName('a')[0];
         anchor.href = '#newloc';
         const impl = sidebarElement.implementation_;
         clock = lolex.install(
             {target: impl.win, toFake: ['Date', 'setTimeout']});
         impl.schedulePause = sandbox.spy();
-        impl.vsync_ = {
-          mutate(callback) {
-            callback();
-          },
-        };
-        impl.getHistory_ = () => ({
-          push: sandbox.stub().resolves(11),
-          pop: sandbox.stub().resolves(11),
-        });
         expect(sidebarElement.hasAttribute('open')).to.be.false;
         impl.open_();
         expect(sidebarElement.hasAttribute('open')).to.be.true;
@@ -477,14 +421,12 @@ describes.realWin('amp-sidebar 0.1 version', {
         if (eventObj.initEvent) {
           eventObj.initEvent('click', true, true);
         }
-        sandbox.stub(sidebarElement, 'getAmpDoc').callsFake(() => {
-          return {
-            win: {
-              location: {
-                href: window.location.href,
-              },
+        sandbox.stub(sidebarElement, 'getAmpDoc').returns({
+          win: {
+            location: {
+              href: window.location.href,
             },
-          };
+          },
         });
         anchor.dispatchEvent ?
           anchor.dispatchEvent(eventObj) :
@@ -499,19 +441,11 @@ describes.realWin('amp-sidebar 0.1 version', {
 
     it('should not close sidebar if \
        clicked on a new origin navigation', () => {
-          return getAmpSidebar().then(sidebarElement => {
+          return getAmpSidebar({stubHistory: true}).then(sidebarElement => {
             const anchor = sidebarElement.getElementsByTagName('a')[0];
             anchor.href = '#newloc';
             const impl = sidebarElement.implementation_;
             impl.schedulePause = sandbox.spy();
-            impl.vsync_ = {
-              mutate(callback) {
-                callback();
-              },
-            };
-            impl.getHistory_ = () => ({
-              push: sandbox.stub().resolves(11),
-            });
             sandbox.stub(timer, 'delay').callsFake(function(callback) {
               callback();
             });
@@ -547,19 +481,12 @@ describes.realWin('amp-sidebar 0.1 version', {
         });
 
     it('should not close sidebar if clicked on new page navigation', () => {
-      return getAmpSidebar().then(sidebarElement => {
+      return getAmpSidebar({stubHistory: true}).then(sidebarElement => {
         const anchor = sidebarElement.getElementsByTagName('a')[0];
         anchor.href = '#newloc';
         const impl = sidebarElement.implementation_;
         impl.schedulePause = sandbox.spy();
-        impl.vsync_ = {
-          mutate(callback) {
-            callback();
-          },
-        };
-        impl.getHistory_ = () => ({
-          push: sandbox.stub().resolves(11),
-        });
+
         sandbox.stub(timer, 'delay').callsFake(function(callback) {
           callback();
         });
@@ -594,18 +521,11 @@ describes.realWin('amp-sidebar 0.1 version', {
     });
 
     it('should not close sidebar if clicked on non-anchor', () => {
-      return getAmpSidebar().then(sidebarElement => {
+      return getAmpSidebar({stubHistory: true}).then(sidebarElement => {
         const li = sidebarElement.getElementsByTagName('li')[0];
         const impl = sidebarElement.implementation_;
         impl.schedulePause = sandbox.spy();
-        impl.vsync_ = {
-          mutate(callback) {
-            callback();
-          },
-        };
-        impl.getHistory_ = () => ({
-          push: sandbox.stub().resolves(11),
-        });
+
         sandbox.stub(timer, 'delay').callsFake(function(callback) {
           callback();
         });
@@ -629,24 +549,14 @@ describes.realWin('amp-sidebar 0.1 version', {
     });
 
     it('should call onAnimationEnd after open and close', () => {
-      return getAmpSidebar().then(sidebarElement => {
+      return getAmpSidebar({stubHistory: true}).then(sidebarElement => {
         const impl = sidebarElement.implementation_;
         clock = lolex.install(
             {target: impl.win, toFake: ['Date', 'setTimeout']});
         impl.boundOnAnimationEnd_ = sandbox.spy();
         impl.buildCallback();
-        impl.vsync_ = {
-          mutate(callback) {
-            callback();
-          },
-        };
 
         impl.scheduleLayout = sandbox.stub();
-
-        impl.getHistory_ = () => ({
-          push: sandbox.stub().resolves(11),
-          pop: sandbox.stub().resolves(11),
-        });
 
         impl.open_();
         expect(impl.boundOnAnimationEnd_).to.be.calledOnce;


### PR DESCRIPTION
The console errors were due to a missing definition for `impl.getHistory_`.