### PR TITLE
Select media through iframe boundary

### DIFF
--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -267,13 +267,14 @@ export class AmpStoryPage extends AMP.BaseElement {
    * @private
    */
   waitForMediaLayout_() {
-    let mediaSet = scopedQuerySelectorAll(this.element, PAGE_MEDIA_SELECTOR);
+    let mediaSet = Array.from(
+        scopedQuerySelectorAll(this.element, PAGE_MEDIA_SELECTOR));
     const iframe = this.element.querySelector('iframe');
     const iframeDoc = iframe && iframe.contentDocument;
     if (iframeDoc) {
-      mediaSet = Array.from(mediaSet);
-      const fieMedia = scopedQuerySelectorAll(iframeDoc, PAGE_MEDIA_SELECTOR);
-      fieMedia.forEach(el => mediaSet.push(el));
+      const fieMedia = Array.from(
+          scopedQuerySelectorAll(iframeDoc, PAGE_MEDIA_SELECTOR));
+      mediaSet = mediaSet.concat(fieMedia);
     }
 
     const mediaPromises = Array.prototype.map.call(mediaSet, mediaEl => {
@@ -332,30 +333,39 @@ export class AmpStoryPage extends AMP.BaseElement {
 
   /**
    * Gets all media elements on this page.
-   * @return {!NodeList<!Element>}
+   * @return {!Array<!Element>}
    * @private
    */
   getAllMedia_() {
     const iframe = this.element.querySelector('iframe');
     const iframeDoc = iframe && iframe.contentDocument;
-    let mediaSet = this.element.querySelectorAll('audio, video');
+    const mediaSet = Array.from(
+        this.element.querySelectorAll('audio, video'));
     if (!iframeDoc) {
       return mediaSet;
     }
-    mediaSet = Array.from(mediaSet);
-    const fieMedia = iframeDoc.querySelectorAll('audio, video');
-    fieMedia.forEach(el => mediaSet.push(el));
-    return mediaSet;
+    const fieMedia = Array.from(
+        iframeDoc.querySelectorAll('audio, video'));
+    return mediaSet.concat(fieMedia);
   }
 
 
   /**
    * Gets all video elements on this page.
-   * @return {!NodeList<!Element>}
+   * @return {!Array<!Element>}
    * @private
    */
   getAllVideos_() {
-    return this.element.querySelectorAll('video');
+    const iframe = this.element.querySelector('iframe');
+    const iframeDoc = iframe && iframe.contentDocument;
+    const mediaSet = Array.from(
+        this.element.querySelectorAll('video'));
+    if (!iframeDoc) {
+      return mediaSet;
+    }
+    const fieMedia = Array.from(
+        iframeDoc.querySelectorAll('video'));
+    return mediaSet.concat(fieMedia);
   }
 
 

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -62,7 +62,7 @@ const PAGE_LOADED_CLASS_NAME = 'i-amphtml-story-page-loaded';
  * Selectors for media elements
  * @enum {string}
  */
-const SELECTORS = {
+const Selectors = {
   // which media to wait for on page layout.
   ALL_AMP_MEDIA: 'amp-audio, amp-video, amp-img, amp-anim',
   ALL_MEDIA: 'audio, video',
@@ -273,7 +273,7 @@ export class AmpStoryPage extends AMP.BaseElement {
    * @private
    */
   waitForMediaLayout_() {
-    const mediaSet = this.getMediaBySelector_(SELECTORS.ALL_AMP_MEDIA);
+    const mediaSet = this.getMediaBySelector_(Selectors.ALL_AMP_MEDIA);
 
     const mediaPromises = Array.prototype.map.call(mediaSet, mediaEl => {
       return new Promise(resolve => {
@@ -331,21 +331,21 @@ export class AmpStoryPage extends AMP.BaseElement {
 
   /**
    * Gets all media elements on this page.
-   * @return {Array<!Element>}
+   * @return {!Array<?Element>}
    * @private
    */
   getAllMedia_() {
-    return this.getMediaBySelector_(SELECTORS.ALL_MEDIA);
+    return this.getMediaBySelector_(Selectors.ALL_MEDIA);
   }
 
 
   /**
    * Gets all video elements on this page.
-   * @return {Array<!Element>}
+   * @return {!Array<?Element>}
    * @private
    */
   getAllVideos_() {
-    return this.getMediaBySelector_(SELECTORS.ALL_VIDEO);
+    return this.getMediaBySelector_(Selectors.ALL_VIDEO);
   }
 
 
@@ -353,7 +353,7 @@ export class AmpStoryPage extends AMP.BaseElement {
    * Gets media on page by given selector. Finds elements through friendly
    * iframe (if one exists).
    * @param {string} selector
-   * @return {Array<!Element>}
+   * @return {!Array<?Element>}
    */
   getMediaBySelector_(selector) {
     const iframe = this.element.querySelector('iframe');

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -331,7 +331,7 @@ export class AmpStoryPage extends AMP.BaseElement {
 
   /**
    * Gets all media elements on this page.
-   * @return {!Array<!Element>}
+   * @return {Array<!Element>}
    * @private
    */
   getAllMedia_() {
@@ -341,7 +341,7 @@ export class AmpStoryPage extends AMP.BaseElement {
 
   /**
    * Gets all video elements on this page.
-   * @return {!Array<!Element>}
+   * @return {Array<!Element>}
    * @private
    */
   getAllVideos_() {
@@ -353,6 +353,7 @@ export class AmpStoryPage extends AMP.BaseElement {
    * Gets media on page by given selector. Finds elements through friendly
    * iframe (if one exists).
    * @param {string} selector
+   * @return {Array<!Element>}
    */
   getMediaBySelector_(selector) {
     const iframe = this.element.querySelector('iframe');

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -267,7 +267,15 @@ export class AmpStoryPage extends AMP.BaseElement {
    * @private
    */
   waitForMediaLayout_() {
-    const mediaSet = scopedQuerySelectorAll(this.element, PAGE_MEDIA_SELECTOR);
+    let mediaSet = scopedQuerySelectorAll(this.element, PAGE_MEDIA_SELECTOR);
+    const iframe = this.element.querySelector('iframe');
+    const iframeDoc = iframe && iframe.contentDocument;
+    if (iframeDoc) {
+      mediaSet = Array.from(mediaSet);
+      const fieMedia = scopedQuerySelectorAll(iframeDoc, PAGE_MEDIA_SELECTOR);
+      fieMedia.forEach(el => mediaSet.push(el));
+    }
+
     const mediaPromises = Array.prototype.map.call(mediaSet, mediaEl => {
       return new Promise(resolve => {
         switch (mediaEl.tagName.toLowerCase()) {
@@ -328,7 +336,16 @@ export class AmpStoryPage extends AMP.BaseElement {
    * @private
    */
   getAllMedia_() {
-    return this.element.querySelectorAll('audio, video');
+    const iframe = this.element.querySelector('iframe');
+    const iframeDoc = iframe && iframe.contentDocument;
+    let mediaSet = this.element.querySelectorAll('audio, video');
+    if (!iframeDoc) {
+      return mediaSet;
+    }
+    mediaSet = Array.from(mediaSet);
+    const fieMedia = iframeDoc.querySelectorAll('audio, video');
+    fieMedia.forEach(el => mediaSet.push(el));
+    return mediaSet;
   }
 
 


### PR DESCRIPTION
In `amp-story` we want to make sure that any media existing inside of a `friendly-iframe` also gets added to the`media-pool` and managed by the story runtime.

