### PR TITLE
🏗 Check for latest  LTS version of `node` and stable version of `yarn` during `preinstall`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ before_install:
   - export DISPLAY=:99.0
   - unset _JAVA_OPTIONS  # JVM heap sizes break closure compiler. #11203.
   - sh -e /etc/init.d/xvfb start
+  - curl -o- -L https://yarnpkg.com/install.sh | bash
+  - export PATH="$HOME/.yarn/bin:$HOME/.config/yarn/global/node_modules/.bin:$PATH"
 before_script:
   - pip install --user protobuf
   - gem install percy-capybara capybara selenium-webdriver chromedriver-helper rspec-retry

--- a/contributing/getting-started-e2e.md
+++ b/contributing/getting-started-e2e.md
@@ -168,7 +168,13 @@ amphtml uses Node.js, the Yarn package manager and the Gulp build system to buil
    nvm install --lts
    ```
 
-* Install [Yarn](https://yarnpkg.com/) version >= 1.2.0 (instructions [here](https://yarnpkg.com/en/docs/install), this may require elevated privileges using `sudo` on some platforms)
+* Install the stable version of [Yarn](https://yarnpkg.com/) (instructions [here](https://yarnpkg.com/en/docs/install), this may require elevated privileges using `sudo` on some platforms)
+
+  On Mac and Linux, you can do so like this.
+
+   ```
+   curl -o- -L https://yarnpkg.com/install.sh | bash
+   ```
 
 * In your local repository directory (e.g. `~/src/ampproject/amphtml`), install the packages that AMP uses by running
    ```

--- a/contributing/getting-started-quick.md
+++ b/contributing/getting-started-quick.md
@@ -27,7 +27,19 @@ This Quick Start guide is the TL;DR version of the longer [end-to-end guide](get
 
 * Install the latest LTS version of [Node.js](https://nodejs.org/) (which includes npm). [nvm](https://github.com/creationix/nvm) is a convenient way to do this on Mac and Linux
 
-* Install [Yarn](https://yarnpkg.com/) version >= 1.2.0 (instructions [here](https://yarnpkg.com/en/docs/install), this may require elevated privileges using `sudo` on some platforms)
+  On Mac and Linux, you can use [nvm](https://github.com/creationix/nvm), especially if you have other projects that require different versions of Node.
+
+   ```
+   nvm install --lts
+   ```
+
+* Install the stable version of [Yarn](https://yarnpkg.com/) (instructions [here](https://yarnpkg.com/en/docs/install), this may require elevated privileges using `sudo` on some platforms)
+
+  On Mac and Linux, you can do so like this.
+
+   ```
+   curl -o- -L https://yarnpkg.com/install.sh | bash
+   ```
 
 * Add this line to your hosts file (`/etc/hosts` on Mac or Linux, `%SystemRoot%\System32\drivers\etc\hosts` on Windows):
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "engines": {
     "node": "^8.0.0",
-    "yarn": ">=1.2.0"
+    "yarn": "^1.6.0"
   },
   "author": "The AMP HTML Authors",
   "license": "Apache-2.0",


### PR DESCRIPTION
**This PR enforces the following in the `presubmit` step of `package.json`:**
- `node` version [^8.0.0](https://nodejs.org/dist/) (this check is already in place)
- `yarn` version [^1.6.0](https://github.com/yarnpkg/yarn/releases) (several [bug fixes](https://github.com/yarnpkg/yarn/releases/tag/v1.6.0) have gone in since the old version we were using)

**It also upgrades `build-system/check-package-manager.js` to do the following:**
- Fetch the full _current_ latest LTS version number instead of just the major version number.
- Determine the _current_ stable version of `yarn` by looking it up via `yarn info yarn`, instead of using a hard-coded value.

**With this PR, there are two levels of checks:**
- The `engines` section of `package.json` enforces minimum versions of `node` and `yarn`. Newer versions are okay. (This section must be updated if and when an old version breaks one of our tools, but not otherwise.)
- The `presubmit` script `check-package-manager.js` determines the _current_ latest LTS version of `node` and the _current_ stable version of `yarn`. If older versions are detected, the script will print warnings,  but allow the install to proceed, allowing developers to upgrade at their convenience. (This script no longer needs to be updated as new versions appear, since it is capable of determining current versions of `node` and `yarn` on the fly.)

Initiated by #14980