### PR TITLE
✅Bump up bundle size again

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -823,7 +823,7 @@ function performBuild(watch) {
  */
 function checkBinarySize(compiled) {
   const file = compiled ? './dist/v0.js' : './dist/amp.js';
-  const size = compiled ? '77.02KB' : '336.66KB';
+  const size = compiled ? '77.05KB' : '336.66KB';
   const cmd = `npx bundlesize -f "${file}" -s "${size}"`;
   log(green('Running ') + cyan(cmd) + green('...\n'));
   const p = exec(cmd);


### PR DESCRIPTION
`master` is red again: https://travis-ci.org/ampproject/amphtml/jobs/373281851#L642

```
~/src/amphtml$ git log --pretty=oneline --abbrev-commit  -L826,826:gulpfile.js
c1f704a2e (HEAD -> 2018-04-30-BundleSize, origin/2018-04-30-BundleSize) Bump up bundle size again

diff --git a/gulpfile.js b/gulpfile.js
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -826,1 +826,1 @@
-  const size = compiled ? '77.02KB' : '336.66KB';
+  const size = compiled ? '77.05KB' : '336.66KB';
3fd30b062 ✅ Increase expected minified bundle size (#14976)

diff --git a/gulpfile.js b/gulpfile.js
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -826,1 +826,1 @@
-  const size = compiled ? '76.96KB' : '336.66KB';
+  const size = compiled ? '77.02KB' : '336.66KB';
19187a747 🏗 Bump the compiled bundle size by 0.01KB to fix build (#14907)

diff --git a/gulpfile.js b/gulpfile.js
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -826,1 +826,1 @@
-  const size = compiled ? '76.95KB' : '336.66KB';
+  const size = compiled ? '76.96KB' : '336.66KB';
6ea8ef7c4 Refactor action whitelisting and apply to amp-story (#14628)

diff --git a/gulpfile.js b/gulpfile.js
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -825,1 +825,1 @@
-  const size = compiled ? '76.85KB' : '336.10KB';
+  const size = compiled ? '76.95KB' : '336.66KB';
43243f932 Allow tap targets to trigger inside accordion header (#14717)

diff --git a/gulpfile.js b/gulpfile.js
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -825,1 +825,1 @@
-  const size = compiled ? '76.85KB' : '336.00KB';
+  const size = compiled ? '76.85KB' : '336.10KB';
333a47cb3 Static HTML Template helper (#14623)

diff --git a/gulpfile.js b/gulpfile.js
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -823,1 +823,1 @@
-  const size = compiled ? '76.79KB' : '334.55KB';
+  const size = compiled ? '76.85KB' : '336.00KB';
7461ac7c4 Copy amp-story 1.0 back to 0.1 (#14626)

diff --git a/gulpfile.js b/gulpfile.js
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -823,1 +823,1 @@
-  const size = compiled ? '76.79KB' : '334.46KB';
+  const size = compiled ? '76.79KB' : '334.55KB';
e4350f9ab Fix amp-bind tests and elementByTag() (#14603)

diff --git a/gulpfile.js b/gulpfile.js
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -811,1 +811,1 @@
-  const size = compiled ? '76.81KB' : '334.41KB';
+  const size = compiled ? '76.79KB' : '334.46KB';
f88bf6cd6 Consent API introduce UNKNOWN & IGNORED state (#14508)

diff --git a/gulpfile.js b/gulpfile.js
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -811,1 +811,1 @@
-  const size = compiled ? '76.81KB' : '334.39KB';
+  const size = compiled ? '76.81KB' : '334.41KB';
82fd3a165 Add support for cache:getClientId (#14450)

diff --git a/gulpfile.js b/gulpfile.js
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -811,1 +811,1 @@
-  const size = compiled ? '76.5KB' : '333.28KB';
+  const size = compiled ? '76.81KB' : '334.39KB';
828392660 Add 0.01KB buffer to current size cap. (#14511)

diff --git a/gulpfile.js b/gulpfile.js
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -811,1 +811,1 @@
-  const size = compiled ? '76.49KB' : '333.27KB';
+  const size = compiled ? '76.5KB' : '333.28KB';
87cbad7d1 ✨ Add support for custom tabs. (#14224)

diff --git a/gulpfile.js b/gulpfile.js
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -811,1 +811,1 @@
-  const size = compiled ? '76.2kB' : '332.6kB';
+  const size = compiled ? '76.49KB' : '333.27KB';
c2d580f0c ✨ amp-geo pre-release integration (#14464)

diff --git a/gulpfile.js b/gulpfile.js
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -810,1 +811,1 @@
-  const size = compiled ? '76.1kB' : '332.3kB';
+  const size = compiled ? '76.2kB' : '332.6kB';
75cdb4a7a Bundlesize follow-up (#14459)

diff --git a/gulpfile.js b/gulpfile.js
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -809,1 +809,1 @@
-  const size = compiled ? '75.1kB' : '332.3kB';
+  const size = compiled ? '76.1kB' : '332.3kB';
3abc40172 Integrate `bundlesize` and cap main binary size (#14405)

diff --git a/gulpfile.js b/gulpfile.js
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -804,0 +809,1 @@
+  const size = compiled ? '75.1kB' : '332.3kB';
```
