### PR TITLE
✨ Adds an embed mode that removes sharing

### DIFF
--- a/extensions/amp-story/0.1/amp-story-bookend.js
+++ b/extensions/amp-story/0.1/amp-story-bookend.js
@@ -352,7 +352,7 @@ export class Bookend {
    */
   onCanShowSharingUisUpdate_(canShowSharingUis) {
     this.getShadowRoot()
-        .classList.toggle('i-amphtml-story-allow-sharing', canShowSharingUis);
+        .classList.toggle('i-amphtml-story-no-sharing', !canShowSharingUis);
   }
 
   /**

--- a/extensions/amp-story/0.1/amp-story-bookend.js
+++ b/extensions/amp-story/0.1/amp-story-bookend.js
@@ -351,8 +351,10 @@ export class Bookend {
    * @private
    */
   onCanShowSharingUisUpdate_(canShowSharingUis) {
-    this.getShadowRoot()
-        .classList.toggle('i-amphtml-story-no-sharing', !canShowSharingUis);
+    this.vsync_.mutate(() => {
+      this.getShadowRoot()
+          .classList.toggle('i-amphtml-story-no-sharing', !canShowSharingUis);
+    });
   }
 
   /**

--- a/extensions/amp-story/0.1/amp-story-bookend.js
+++ b/extensions/amp-story/0.1/amp-story-bookend.js
@@ -308,6 +308,10 @@ export class Bookend {
       this.onBookendStateUpdate_(isActive);
     });
 
+    this.storeService_.subscribe(StateProperty.CAN_SHOW_SHARING_UIS, show => {
+      this.onCanShowSharingUisUpdate_(show);
+    }, true /** callToInitialize */);
+
     this.storeService_.subscribe(StateProperty.DESKTOP_STATE, isDesktop => {
       this.onDesktopStateUpdate_(isDesktop);
     }, true /** callToInitialize */);
@@ -338,6 +342,17 @@ export class Bookend {
    */
   onBookendStateUpdate_(isActive) {
     this.toggle_(isActive);
+  }
+
+  /**
+   * Reacts to updates to whether sharing UIs may be shown, and updates the UI
+   * accordingly.
+   * @param {boolean} isActive
+   * @private
+   */
+  onCanShowSharingUisUpdate_(canShowSharingUis) {
+    this.getShadowRoot()
+        .classList.toggle('i-amphtml-story-allow-sharing', canShowSharingUis);
   }
 
   /**

--- a/extensions/amp-story/0.1/amp-story-bookend.js
+++ b/extensions/amp-story/0.1/amp-story-bookend.js
@@ -347,7 +347,7 @@ export class Bookend {
   /**
    * Reacts to updates to whether sharing UIs may be shown, and updates the UI
    * accordingly.
-   * @param {boolean} isActive
+   * @param {boolean} canShowSharingUis
    * @private
    */
   onCanShowSharingUisUpdate_(canShowSharingUis) {

--- a/extensions/amp-story/0.1/amp-story-share.css
+++ b/extensions/amp-story/0.1/amp-story-share.css
@@ -22,6 +22,10 @@
   margin: 16px 8px !important;
 }
 
+.i-amphtml-story-no-sharing .i-amphtml-story-share-widget {
+  display: none !important;
+}
+
 .i-amphtml-story-share-widget-scrollable {
   padding: 16px 0 !important;
   height: 66px !important;

--- a/extensions/amp-story/0.1/amp-story-store-service.js
+++ b/extensions/amp-story/0.1/amp-story-store-service.js
@@ -29,6 +29,7 @@ const TAG = 'amp-story';
  *    canshowbookend: boolean,
  *    canshownavigationoverlayhint: boolean,
  *    canshowpreviouspagehelp: boolean,
+ *    canshowsharinguis: boolean,
  *    canshowsystemlayerbuttons: boolean,
  *    bookendstate: boolean,
  *    desktopstate: boolean,
@@ -50,6 +51,7 @@ export const StateProperty = {
   CAN_SHOW_BOOKEND: 'canshowbookend',
   CAN_SHOW_NAVIGATION_OVERLAY_HINT: 'canshownavigationoverlayhint',
   CAN_SHOW_PREVIOUS_PAGE_HELP: 'canshowpreviouspagehelp',
+  CAN_SHOW_SHARING_UIS: 'canshowsharinguis',
   CAN_SHOW_SYSTEM_LAYER_BUTTONS: 'canshowsystemlayerbuttons',
 
   // App States.
@@ -225,6 +227,7 @@ export class AmpStoryStoreService {
       [StateProperty.CAN_SHOW_BOOKEND]: true,
       [StateProperty.CAN_SHOW_NAVIGATION_OVERLAY_HINT]: true,
       [StateProperty.CAN_SHOW_PREVIOUS_PAGE_HELP]: true,
+      [StateProperty.CAN_SHOW_SHARING_UIS]: true,
       [StateProperty.CAN_SHOW_SYSTEM_LAYER_BUTTONS]: true,
       [StateProperty.AD_STATE]: false,
       [StateProperty.BOOKEND_STATE]: false,
@@ -255,6 +258,10 @@ export class AmpStoryStoreService {
           [StateProperty.CAN_SHOW_PREVIOUS_PAGE_HELP]: true,
           [StateProperty.CAN_SHOW_SYSTEM_LAYER_BUTTONS]: false,
           [StateProperty.MUTED_STATE]: false,
+        };
+      case EmbedMode.NO_SHARING:
+        return {
+          [StateProperty.CAN_SHOW_SHARING_UIS]: false,
         };
       default:
         return {};

--- a/extensions/amp-story/0.1/amp-story-system-layer.css
+++ b/extensions/amp-story/0.1/amp-story-system-layer.css
@@ -136,6 +136,10 @@
   background-position-y: calc(50% - 2px) !important;
 }
 
+.i-amphtml-story-no-sharing .i-amphtml-story-share-control {
+  display: none !important;
+}
+
 [desktop].i-amphtml-story-system-layer {
   background: linear-gradient(to bottom, rgba(33,33,33,0) 0%, rgba(33,33,33,0.32) 100%)!important;
   top: auto!important;

--- a/extensions/amp-story/0.1/amp-story-system-layer.js
+++ b/extensions/amp-story/0.1/amp-story-system-layer.js
@@ -198,6 +198,10 @@ export class SystemLayer {
       this.onBookendStateUpdate_(isActive);
     });
 
+    this.storeService_.subscribe(StateProperty.CAN_SHOW_SHARING_UIS, show => {
+      this.onCanShowSharingUisUpdate_(show);
+    }, true /** callToInitialize */);
+
     this.storeService_.subscribe(StateProperty.DESKTOP_STATE, isDesktop => {
       this.onDesktopStateUpdate_(isDesktop);
     }, true /** callToInitialize */);
@@ -233,6 +237,17 @@ export class SystemLayer {
   onBookendStateUpdate_(isActive) {
     this.getShadowRoot()
         .classList.toggle('i-amphtml-story-bookend-active', isActive);
+  }
+
+  /**
+   * Reacts to updates to whether sharing UIs may be shown, and updates the UI
+   * accordingly.
+   * @param {boolean} isActive
+   * @private
+   */
+  onCanShowSharingUisUpdate_(canShowSharingUis) {
+    this.getShadowRoot()
+        .classList.toggle('i-amphtml-story-allow-sharing', canShowSharingUis);
   }
 
   /**

--- a/extensions/amp-story/0.1/amp-story-system-layer.js
+++ b/extensions/amp-story/0.1/amp-story-system-layer.js
@@ -242,7 +242,7 @@ export class SystemLayer {
   /**
    * Reacts to updates to whether sharing UIs may be shown, and updates the UI
    * accordingly.
-   * @param {boolean} isActive
+   * @param {boolean} canShowSharingUis
    * @private
    */
   onCanShowSharingUisUpdate_(canShowSharingUis) {

--- a/extensions/amp-story/0.1/amp-story-system-layer.js
+++ b/extensions/amp-story/0.1/amp-story-system-layer.js
@@ -247,7 +247,7 @@ export class SystemLayer {
    */
   onCanShowSharingUisUpdate_(canShowSharingUis) {
     this.getShadowRoot()
-        .classList.toggle('i-amphtml-story-allow-sharing', canShowSharingUis);
+        .classList.toggle('i-amphtml-story-no-sharing', !canShowSharingUis);
   }
 
   /**

--- a/extensions/amp-story/0.1/amp-story-system-layer.js
+++ b/extensions/amp-story/0.1/amp-story-system-layer.js
@@ -246,8 +246,10 @@ export class SystemLayer {
    * @private
    */
   onCanShowSharingUisUpdate_(canShowSharingUis) {
-    this.getShadowRoot()
-        .classList.toggle('i-amphtml-story-no-sharing', !canShowSharingUis);
+    this.vsync_.mutate(() => {
+      this.getShadowRoot()
+          .classList.toggle('i-amphtml-story-no-sharing', !canShowSharingUis);
+    });
   }
 
   /**

--- a/extensions/amp-story/0.1/embed-mode.js
+++ b/extensions/amp-story/0.1/embed-mode.js
@@ -38,6 +38,19 @@ export const EmbedMode = {
    * - Unmutes audio in the story by default
    */
   NAME_TBD: 1,
+
+  /**
+   * This mode is intended for embedders that natively handle sharing the story,
+   * thereby rendering the sharing functionality within the amp-story extension
+   * redundant.
+   *
+   * This differs from the NOT_EMBEDDED embed mode in the following ways:
+   * - Removes "share" pill from desktop UI
+   * - Removes "share" icon from mobile UI
+   * - Removes sharing section from bookend
+   * - TODO(#14923): Removes the link information from embedded UIs.
+   */
+  NO_SHARING: 2,
 };
 
 

--- a/extensions/amp-story/1.0/amp-story-share.css
+++ b/extensions/amp-story/1.0/amp-story-share.css
@@ -22,6 +22,10 @@
   margin: 16px 8px !important;
 }
 
+.i-amphtml-story-no-sharing .i-amphtml-story-share-widget {
+  display: none !important;
+}
+
 .i-amphtml-story-share-widget-scrollable {
   padding: 16px 0 !important;
   height: 66px !important;

--- a/extensions/amp-story/1.0/amp-story-store-service.js
+++ b/extensions/amp-story/1.0/amp-story-store-service.js
@@ -29,6 +29,7 @@ const TAG = 'amp-story';
  *    canshowbookend: boolean,
  *    canshownavigationoverlayhint: boolean,
  *    canshowpreviouspagehelp: boolean,
+ *    canshowsharinguis: boolean,
  *    canshowsystemlayerbuttons: boolean,
  *    bookendstate: boolean,
  *    desktopstate: boolean,
@@ -50,6 +51,7 @@ export const StateProperty = {
   CAN_SHOW_BOOKEND: 'canshowbookend',
   CAN_SHOW_NAVIGATION_OVERLAY_HINT: 'canshownavigationoverlayhint',
   CAN_SHOW_PREVIOUS_PAGE_HELP: 'canshowpreviouspagehelp',
+  CAN_SHOW_SHARING_UIS: 'canshowsharinguis',
   CAN_SHOW_SYSTEM_LAYER_BUTTONS: 'canshowsystemlayerbuttons',
 
   // App States.
@@ -225,6 +227,7 @@ export class AmpStoryStoreService {
       [StateProperty.CAN_SHOW_BOOKEND]: true,
       [StateProperty.CAN_SHOW_NAVIGATION_OVERLAY_HINT]: true,
       [StateProperty.CAN_SHOW_PREVIOUS_PAGE_HELP]: true,
+      [StateProperty.CAN_SHOW_SHARING_UIS]: true,
       [StateProperty.CAN_SHOW_SYSTEM_LAYER_BUTTONS]: true,
       [StateProperty.AD_STATE]: false,
       [StateProperty.BOOKEND_STATE]: false,
@@ -255,6 +258,10 @@ export class AmpStoryStoreService {
           [StateProperty.CAN_SHOW_PREVIOUS_PAGE_HELP]: true,
           [StateProperty.CAN_SHOW_SYSTEM_LAYER_BUTTONS]: false,
           [StateProperty.MUTED_STATE]: false,
+        };
+      case EmbedMode.NO_SHARING:
+        return {
+          [StateProperty.CAN_SHOW_SHARING_UIS]: false,
         };
       default:
         return {};

--- a/extensions/amp-story/1.0/amp-story-system-layer.css
+++ b/extensions/amp-story/1.0/amp-story-system-layer.css
@@ -144,6 +144,10 @@
   background-position-y: calc(50% - 2px) !important;
 }
 
+.i-amphtml-story-no-sharing .i-amphtml-story-share-control {
+  display: none !important;
+}
+
 [desktop].i-amphtml-story-system-layer {
   background: linear-gradient(to bottom, rgba(33,33,33,0) 0%, rgba(33,33,33,0.32) 100%)!important;
   top: auto!important;

--- a/extensions/amp-story/1.0/amp-story-system-layer.js
+++ b/extensions/amp-story/1.0/amp-story-system-layer.js
@@ -239,6 +239,10 @@ export class SystemLayer {
       this.onBookendStateUpdate_(isActive);
     });
 
+    this.storeService_.subscribe(StateProperty.CAN_SHOW_SHARING_UIS, show => {
+      this.onCanShowSharingUisUpdate_(show);
+    }, true /** callToInitialize */);
+
     this.storeService_.subscribe(StateProperty.DESKTOP_STATE, isDesktop => {
       this.onDesktopStateUpdate_(isDesktop);
     }, true /** callToInitialize */);
@@ -287,6 +291,17 @@ export class SystemLayer {
   onBookendStateUpdate_(isActive) {
     this.getShadowRoot()
         .classList.toggle('i-amphtml-story-bookend-active', isActive);
+  }
+
+  /**
+   * Reacts to updates to whether sharing UIs may be shown, and updates the UI
+   * accordingly.
+   * @param {boolean} isActive
+   * @private
+   */
+  onCanShowSharingUisUpdate_(canShowSharingUis) {
+    this.getShadowRoot()
+        .classList.toggle('i-amphtml-story-allow-sharing', canShowSharingUis);
   }
 
   /**

--- a/extensions/amp-story/1.0/amp-story-system-layer.js
+++ b/extensions/amp-story/1.0/amp-story-system-layer.js
@@ -296,7 +296,7 @@ export class SystemLayer {
   /**
    * Reacts to updates to whether sharing UIs may be shown, and updates the UI
    * accordingly.
-   * @param {boolean} isActive
+   * @param {boolean} canShowSharingUis
    * @private
    */
   onCanShowSharingUisUpdate_(canShowSharingUis) {

--- a/extensions/amp-story/1.0/amp-story-system-layer.js
+++ b/extensions/amp-story/1.0/amp-story-system-layer.js
@@ -300,8 +300,10 @@ export class SystemLayer {
    * @private
    */
   onCanShowSharingUisUpdate_(canShowSharingUis) {
-    this.getShadowRoot()
-        .classList.toggle('i-amphtml-story-no-sharing', !canShowSharingUis);
+    this.vsync_.mutate(() => {
+      this.getShadowRoot()
+          .classList.toggle('i-amphtml-story-no-sharing', !canShowSharingUis);
+    });
   }
 
   /**

--- a/extensions/amp-story/1.0/amp-story-system-layer.js
+++ b/extensions/amp-story/1.0/amp-story-system-layer.js
@@ -301,7 +301,7 @@ export class SystemLayer {
    */
   onCanShowSharingUisUpdate_(canShowSharingUis) {
     this.getShadowRoot()
-        .classList.toggle('i-amphtml-story-allow-sharing', canShowSharingUis);
+        .classList.toggle('i-amphtml-story-no-sharing', !canShowSharingUis);
   }
 
   /**

--- a/extensions/amp-story/1.0/bookend/amp-story-bookend.js
+++ b/extensions/amp-story/1.0/bookend/amp-story-bookend.js
@@ -359,8 +359,10 @@ export class Bookend {
    * @private
    */
   onCanShowSharingUisUpdate_(canShowSharingUis) {
-    this.getShadowRoot()
-        .classList.toggle('i-amphtml-story-no-sharing', !canShowSharingUis);
+    this.vsync_.mutate(() => {
+      this.getShadowRoot()
+          .classList.toggle('i-amphtml-story-no-sharing', !canShowSharingUis);
+    });
   }
 
   /**

--- a/extensions/amp-story/1.0/bookend/amp-story-bookend.js
+++ b/extensions/amp-story/1.0/bookend/amp-story-bookend.js
@@ -360,7 +360,7 @@ export class Bookend {
    */
   onCanShowSharingUisUpdate_(canShowSharingUis) {
     this.getShadowRoot()
-        .classList.toggle('i-amphtml-story-allow-sharing', canShowSharingUis);
+        .classList.toggle('i-amphtml-story-no-sharing', !canShowSharingUis);
   }
 
   /**

--- a/extensions/amp-story/1.0/bookend/amp-story-bookend.js
+++ b/extensions/amp-story/1.0/bookend/amp-story-bookend.js
@@ -355,7 +355,7 @@ export class Bookend {
   /**
    * Reacts to updates to whether sharing UIs may be shown, and updates the UI
    * accordingly.
-   * @param {boolean} isActive
+   * @param {boolean} canShowSharingUis
    * @private
    */
   onCanShowSharingUisUpdate_(canShowSharingUis) {

--- a/extensions/amp-story/1.0/bookend/amp-story-bookend.js
+++ b/extensions/amp-story/1.0/bookend/amp-story-bookend.js
@@ -316,6 +316,10 @@ export class Bookend {
       this.onBookendStateUpdate_(isActive);
     });
 
+    this.storeService_.subscribe(StateProperty.CAN_SHOW_SHARING_UIS, show => {
+      this.onCanShowSharingUisUpdate_(show);
+    }, true /** callToInitialize */);
+
     this.storeService_.subscribe(StateProperty.DESKTOP_STATE, isDesktop => {
       this.onDesktopStateUpdate_(isDesktop);
     }, true /** callToInitialize */);
@@ -346,6 +350,17 @@ export class Bookend {
    */
   onBookendStateUpdate_(isActive) {
     this.toggle_(isActive);
+  }
+
+  /**
+   * Reacts to updates to whether sharing UIs may be shown, and updates the UI
+   * accordingly.
+   * @param {boolean} isActive
+   * @private
+   */
+  onCanShowSharingUisUpdate_(canShowSharingUis) {
+    this.getShadowRoot()
+        .classList.toggle('i-amphtml-story-allow-sharing', canShowSharingUis);
   }
 
   /**

--- a/extensions/amp-story/1.0/embed-mode.js
+++ b/extensions/amp-story/1.0/embed-mode.js
@@ -38,6 +38,19 @@ export const EmbedMode = {
    * - Unmutes audio in the story by default
    */
   NAME_TBD: 1,
+
+  /**
+   * This mode is intended for embedders that natively handle sharing the story,
+   * thereby rendering the sharing functionality within the amp-story extension
+   * redundant.
+   *
+   * This differs from the NOT_EMBEDDED embed mode in the following ways:
+   * - Removes "share" pill from desktop UI
+   * - Removes "share" icon from mobile UI
+   * - Removes sharing section from bookend
+   * - TODO(#14923): Removes the link information from embedded UIs.
+   */
+  NO_SHARING: 2,
 };
 
 


### PR DESCRIPTION
Some embedding platforms handle sharing natively, which renders the sharing functionality within the amp-story runtime redundant.  This embed mode allows removing those sharing options from the runtime.