### PR TITLE
🏗 Update regexes in `check-links.js`

### DIFF
--- a/build-system/tasks/check-links.js
+++ b/build-system/tasks/check-links.js
@@ -140,10 +140,10 @@ function filterWhitelistedLinks(markdown) {
   filteredMarkdown = filteredMarkdown.replace(/src="http.*?"/g, '');
 
   // Links inside a <code> block (illustrative, and not always valid)
-  filteredMarkdown = filteredMarkdown.replace(/<code>(.*?)<\/code>/gs, '');
+  filteredMarkdown = filteredMarkdown.replace(/<code>([^]*?)<\/code>/g, '');
 
   // Links inside a <pre> block (illustrative, and not always valid)
-  filteredMarkdown = filteredMarkdown.replace(/<pre>(.*?)<\/pre>/gs, '');
+  filteredMarkdown = filteredMarkdown.replace(/<pre>([^]*?)<\/pre>/g, '');
 
   // The heroku nightly build page is not always acccessible by the checker.
   filteredMarkdown = filteredMarkdown.replace(


### PR DESCRIPTION
The `/.../.../s` syntax is incompatible with slightly older versions of `node` that have the current LTS major version.