### PR TITLE
Revert "Ensure `toggleLoading()` respects `isLoadingEnabled()` (#14982)"

### DIFF
--- a/src/base-element.js
+++ b/src/base-element.js
@@ -725,7 +725,7 @@ export class BaseElement {
    * @public @final
    */
   toggleLoading(state) {
-    this.element.toggleLoading(state);
+    this.element.toggleLoading(state, {force: true});
   }
 
   /**

--- a/test/functional/test-custom-element.js
+++ b/test/functional/test-custom-element.js
@@ -1643,28 +1643,11 @@ describes.realWin('CustomElement', {amp: true}, env => {
     it('should be enabled by default', () => {
       stubInA4A(false);
       expect(element.isLoadingEnabled_()).to.be.true;
-      // If loading is enabled, we should be able to toggle the classes
-      element.toggleLoading(true);
-      expect(
-          element.loadingContainer_.classList.contains(
-              'amp-hidden')).to.be.false;
-      expect(
-          element.loadingElement_.classList.contains('amp-active')).to.be.true;
-      element.toggleLoading(false);
-      expect(
-          element.loadingContainer_.classList.contains(
-              'amp-hidden')).to.be.true;
-      expect(
-          element.loadingElement_.classList.contains('amp-active')).to.be.false;
     });
 
     it('should be disabled in A4A', () => {
       stubInA4A(true);
       expect(element.isLoadingEnabled_()).to.be.false;
-      // If loading is disabled, we should not be able to toggle the classes
-      element.toggleLoading(true);
-      expect(element.loadingContainer_).to.be.null;
-      expect(element.loadingElement_).to.be.null;
     });
 
     it('should disable when explicitly disabled by the attribute', () => {
@@ -1677,12 +1660,6 @@ describes.realWin('CustomElement', {amp: true}, env => {
       stubInA4A(false);
       LOADING_ELEMENTS_['amp-test-loader'.toUpperCase()] = false;
       expect(element.isLoadingEnabled_()).to.be.false;
-      element.toggleLoading(true);
-      expect(element.loadingContainer_).to.be.null;
-      expect(element.loadingElement_).to.be.null;
-      element.toggleLoading(false);
-      expect(element.loadingContainer_).to.be.null;
-      expect(element.loadingElement_).to.be.null;
     });
 
     it('should disable when not measured or too small', () => {

--- a/test/functional/test-layout.js
+++ b/test/functional/test-layout.js
@@ -16,7 +16,7 @@
 
 import {Layout, applyStaticLayout,
   assertLength, assertLengthOrPercent, getLengthNumeral, getLengthUnits,
-  isLoadingAllowed, parseLayout, parseLength} from '../../src/layout';
+  parseLayout, parseLength} from '../../src/layout';
 
 
 describe('Layout', () => {
@@ -35,47 +35,6 @@ describe('Layout', () => {
     expect(parseLayout('fill')).to.equal('fill');
     expect(parseLayout('fluid')).to.equal('fluid');
   });
-
-  it('are loading components allowed', () => {
-    const el = {
-      tagName: 'hold',
-    };
-    const elementsValidTagNames = [
-      'AMP-AD',
-      'AMP-ANIM',
-      'AMP-BRIGHTCOVE',
-      'AMP-EMBED',
-      'AMP-IFRAME',
-      'AMP-IMG',
-      'AMP-INSTAGRAM',
-      'AMP-LIST',
-      'AMP-OOYALA-PLAYER',
-      'AMP-PINTEREST',
-      'AMP-PLAYBUZZ',
-      'AMP-VIDEO',
-      'AMP-YOUTUBE',
-    ];
-    elementsValidTagNames.forEach(function(tag) {
-      el.tagName = tag;
-      expect(isLoadingAllowed(el)).to.be.true;
-    });
-
-    // This isn't an exhaustive list of elements that aren't allowed
-    // to have loading indicators.
-    const elementsInvalidTagNames = [
-      'AMP-POSITION-OBSERVER',
-      'AMP-BODYMOVIN-ANIMATION',
-      'AMP-TWITTER',
-      'AMP-REDDIT',
-      'AMP-GITHUB',
-    ];
-    elementsInvalidTagNames.forEach(function(tag) {
-      el.tagName = tag;
-      expect(isLoadingAllowed(el)).to.be.false;
-    });
-
-  });
-
 
   it('parseLayout - failure', () => {
     expect(parseLayout('abc')).to.be.undefined;


### PR DESCRIPTION
This is as it breaks the forced loading icons for <amp-list>. Pointed out here: https://github.com/ampproject/amphtml/pull/14982#issuecomment-385791856

This reverts commit bef86e8c1a211579c34fc46461ad9120a1609544.

Thinking about a better solution but want to submit this before a canary is cut.