### PR TITLE
♻️ VideoInterface types cleanup

### DIFF
--- a/extensions/amp-video-service/0.1/amp-video-service.js
+++ b/extensions/amp-video-service/0.1/amp-video-service.js
@@ -26,6 +26,7 @@ import {CommonSignals} from '../../../src/common-signals';
 import {Observable} from '../../../src/observable';
 import {Services} from '../../../src/services';
 import {VideoEvents} from '../../../src/video-interface';
+import {asBaseElement} from '../../../src/video-interface';
 import {createCustomEvent} from '../../../src/event-helper';
 import {dev} from '../../../src/log';
 import {isFiniteNumber} from '../../../src/types';
@@ -91,7 +92,7 @@ export class VideoService {
 
   /** @param {!../../../src/video-interface.VideoInterface} video */
   register(video) {
-    const {element} = video;
+    const {element} = asBaseElement(video);
 
     if (this.getEntryOrNull(element)) {
       return dev().assert(this.getEntryOrNull(element));
@@ -155,6 +156,18 @@ export class VideoService {
 
 
 /**
+ * This union type allows the compiler to treat VideoInterface objects as
+ * `BaseElement`s, which they should be anyway.
+ *
+ * WARNING: Don't use this at the service level. Its `register` method should
+ * only allow `VideoInterface` as a guarding measure.
+ *
+ * @typedef {!../../../src/video-interface.VideoInterface|!AMP.BaseElement}
+ */
+let VideoOrBaseElementDef;
+
+
+/**
  * Handler for a registered video component.
  * @visibleForTesting
  */
@@ -163,7 +176,7 @@ export class VideoEntry {
   /**
    * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
    * @param {!VideoService} videoService
-   * @param {!../../../src/video-interface.VideoInterface} video
+   * @param {!VideoOrBaseElementDef} video
    */
   constructor(ampdoc, videoService, video) {
 
@@ -173,7 +186,7 @@ export class VideoEntry {
     /** @private @const {!VideoService} */
     this.service_ = videoService;
 
-    /** @private @const {!../../../src/video-interface.VideoInterface} */
+    /** @private @const {!VideoOrBaseElementDef} */
     this.video_ = video;
 
     /** @private {boolean} */
@@ -183,7 +196,7 @@ export class VideoEntry {
   /**
    * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
    * @param {!VideoService} videoService
-   * @param {!../../../src/video-interface.VideoInterface} video
+   * @param {!VideoOrBaseElementDef} video
    */
   static create(ampdoc, videoService, video) {
     const entry = new VideoEntry(ampdoc, videoService, video);

--- a/src/video-interface.js
+++ b/src/video-interface.js
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import {ActionTrust} from './action-trust'; // eslint-disable-line no-unused-vars
-
 /**
  * VideoInterface defines a common video API which any AMP component that plays
  * videos is expected to implement.
@@ -125,21 +123,6 @@ export class VideoInterface {
    */
   preimplementsMediaSessionAPI() {}
 
-
-  /**
-   * Automatically comes from {@link ./base-element.BaseElement}
-   *
-   * @return {!AmpElement}
-   */
-  get element() {}
-
-  /**
-   * Automatically comes from {@link ./base-element.BaseElement}
-   *
-   * @return {boolean}
-   */
-  isInViewport() {}
-
   /**
    * Enables fullscreen on the internal video element
    * NOTE: While implementing, keep in mind that Safari/iOS do not allow taking
@@ -161,16 +144,6 @@ export class VideoInterface {
    * @return {boolean}
    */
   isFullscreen() {}
-
-  /**
-   * Automatically comes from {@link ./base-element.BaseElement}
-   *
-   * @param {string} unusedMethod
-   * @param {function(!./service/action-impl.ActionInvocation)} unusedHandler
-   * @param {ActionTrust} unusedMinTrust
-   * @public
-   */
-  registerAction(unusedMethod, unusedHandler, unusedMinTrust) {}
 }
 
 
@@ -462,3 +435,14 @@ export const VideoAnalyticsEvents = {
  * }}
  */
 export let VideoAnalyticsDetailsDef;
+
+
+/**
+ * Helper function to be used internally to cast types from VideoInterface to
+ * the public AMP component interface.
+ * @param {!VideoInterface} video
+ * @return {!./base-element.BaseElement}
+ */
+export function asBaseElement(video) {
+  return /** @type {!./base-element.BaseElement} */ (video);
+}


### PR DESCRIPTION
There's no need to expose the entirety of `BaseElement` in `VideoInterface` :)

This will make it less confusing for future implementers.