### PR TITLE
amp-consent: Allow 'checkConsentHref' response override 'promptIfUnknownForGeoGroup' result

### DIFF
--- a/build-system/app.js
+++ b/build-system/app.js
@@ -560,6 +560,12 @@ app.post('/get-consent-v1/', (req, res) => {
   res.json(body);
 });
 
+app.post('/get-consent-no-prompt/', (req, res) => {
+  assertCors(req, res, ['POST']);
+  const body = {};
+  res.json(body);
+});
+
 // Proxy with local JS.
 // Example:
 // http://localhost:8000/proxy/s/www.washingtonpost.com/amphtml/news/post-politics/wp/2016/02/21/bernie-sanders-says-lower-turnout-contributed-to-his-nevada-loss-to-hillary-clinton/

--- a/extensions/amp-consent/0.1/amp-consent.js
+++ b/extensions/amp-consent/0.1/amp-consent.js
@@ -335,7 +335,7 @@ export class AmpConsent extends AMP.BaseElement {
   /**
    * Blindly pass sharedData
    * @param {string} instanceId
-   * @param {!Promise<?JsonObject>} responsePromise
+   * @param {!Promise<!JsonObject>} responsePromise
    */
   passSharedData_(instanceId, responsePromise) {
     const sharedDataPromise = responsePromise.then(response => {
@@ -343,10 +343,10 @@ export class AmpConsent extends AMP.BaseElement {
         return null;
       }
       return response['sharedData'];
-    })
+    });
 
     this.consentStateManager_.setConsentInstanceSharedData(
-          instanceId, sharedDataPromise);
+        instanceId, sharedDataPromise);
   }
 
   /**

--- a/extensions/amp-consent/0.1/test/test-amp-consent.js
+++ b/extensions/amp-consent/0.1/test/test-amp-consent.js
@@ -188,7 +188,6 @@ describes.realWin('amp-consent', {
       yield macroTask();
       expect(parseSpy).to.be.calledWith('ABC', {
         'promptIfUnknown': true,
-        'prompt': true,
       });
     });
   });

--- a/extensions/amp-consent/0.1/test/test-amp-consent.js
+++ b/extensions/amp-consent/0.1/test/test-amp-consent.js
@@ -49,6 +49,7 @@ describes.realWin('amp-consent', {
     jsonMockResponses = {
       'response1': '{"promptIfUnknown": true}',
       'response2': '{}',
+      'response3': '{"promptIfUnknown": false}',
     };
 
     resetServiceForTesting(win, 'xhr');
@@ -250,6 +251,24 @@ describes.realWin('amp-consent', {
       expect(ampConsent.consentRequired_['ABC']).to.equal(true);
     });
 
+    it('promptIfUnknow override geo with false value', function* () {
+      ISOCountryGroups = ['unknown'];
+      defaultConfig = {
+        'consents': {
+          'ABC': {
+            'checkConsentHref': 'response3',
+            'promptIfUnknownForGeoGroup': 'unknown',
+          },
+        },
+      };
+      scriptElement.textContent = JSON.stringify(defaultConfig);
+      consentElement.appendChild(scriptElement);
+      ampConsent = new AmpConsent(consentElement);
+      ampConsent.buildCallback();
+      yield macroTask();
+      expect(ampConsent.consentRequired_['ABC']).to.equal(false);
+    });
+
     it('checkConsentHref w/o promptIfUnknow not override geo', function* () {
       ISOCountryGroups = ['testGroup'];
       defaultConfig = {
@@ -267,8 +286,6 @@ describes.realWin('amp-consent', {
       yield macroTask();
       expect(ampConsent.consentRequired_['ABC']).to.equal(true);
     });
-
-
   });
 
   describe('policy config', () => {

--- a/extensions/amp-consent/0.1/test/test-amp-consent.js
+++ b/extensions/amp-consent/0.1/test/test-amp-consent.js
@@ -183,7 +183,7 @@ describes.realWin('amp-consent', {
     });
 
     it('parse server response', function* () {
-      const parseSpy = sandbox.spy(ampConsent, 'parseConsentResponse_');
+      const parseSpy = sandbox.spy(ampConsent, 'isPromptRequired_');
       ampConsent.buildCallback();
       yield macroTask();
       expect(parseSpy).to.be.calledWith('ABC', {

--- a/test/manual/amp-consent-geo.html
+++ b/test/manual/amp-consent-geo.html
@@ -166,6 +166,7 @@
       <script type="application/json">{
         "consents": {
           "unknown": {
+            "checkConsentHref": "http://localhost:8000/get-consent-no-prompt",
             "promptIfUnknownForGeoGroup": "anz",
             "promptUI": "ui1"
           }


### PR DESCRIPTION
Given `checkConsentHref` can be used to fetch `sharedData` now, we need to support `promptIfUnknownForGeoGroup`  with presence of  `checkConsentHref`. 
'promptIfUnknown=true/false' from remote response can override geo decision. Otherwise respect geo decision and the default fallback is `false`.