### PR TITLE
✨amp-consent: support consent policy timeout

### DIFF
--- a/extensions/amp-consent/0.1/amp-consent.js
+++ b/extensions/amp-consent/0.1/amp-consent.js
@@ -38,7 +38,7 @@ import {parseJson} from '../../../src/json';
 import {setImportantStyles, toggle} from '../../../src/style';
 
 const CONSENT_STATE_MANAGER = 'consentStateManager';
-const CONSENT_POLICY_MANGER = 'consentPolicyManager';
+const CONSENT_POLICY_MANAGER = 'consentPolicyManager';
 const TAG = 'amp-consent';
 
 export const AMP_CONSENT_EXPERIMENT = 'amp-consent';
@@ -131,28 +131,29 @@ export class AmpConsent extends AMP.BaseElement {
     // TODO: Decide what to do with incorrect configuration.
     this.assertAndParseConfig_();
 
-    getServicePromiseForDoc(this.getAmpDoc(), CONSENT_POLICY_MANGER)
-        .then(manager => {
-          this.consentPolicyManager_ = manager;
-          this.generateDefaultPolicy_();
-          const policyKeys = Object.keys(this.policyConfig_);
-          for (let i = 0; i < policyKeys.length; i++) {
-            this.consentPolicyManager_.registerConsentPolicyInstance(
-                policyKeys[i], this.policyConfig_[policyKeys[i]]);
-          }
-        });
+    const consentPolicyManagerPromise =
+        getServicePromiseForDoc(this.getAmpDoc(), CONSENT_POLICY_MANAGER)
+            .then(manager => {
+              this.consentPolicyManager_ = manager;
+              this.generateDefaultPolicy_();
+            });
 
     const consentStateManagerPromise =
         getServicePromiseForDoc(this.getAmpDoc(), CONSENT_STATE_MANAGER)
             .then(manager => {
               this.consentStateManager_ = manager;
             });
+
     const notificationUiManagerPromise =
         getServicePromiseForDoc(this.getAmpDoc(), NOTIFICATION_UI_MANAGER)
             .then(manager => {
               this.notificationUiManager_ = manager;
             });
-    Promise.all([consentStateManagerPromise, notificationUiManagerPromise])
+
+    Promise.all([
+      consentStateManagerPromise,
+      notificationUiManagerPromise,
+      consentPolicyManagerPromise])
         .then(() => {
           this.init_();
         });
@@ -310,7 +311,7 @@ export class AmpConsent extends AMP.BaseElement {
             });
       }
       const handlePromptPromise = isConsentRequiredPromise.then(() => {
-        this.handlePromptUI_(instanceId);
+        return this.initPromptUI_(instanceId);
       }).catch(unusedError => {
         // TODO: Handle errors
       });
@@ -319,6 +320,7 @@ export class AmpConsent extends AMP.BaseElement {
     }
 
     Promise.all(initPromptPromises).then(() => {
+      this.initConsentPolicy_();
       this.handlePostPromptUI_();
     });
 
@@ -336,6 +338,17 @@ export class AmpConsent extends AMP.BaseElement {
           'requires <amp-geo> to use promptIfUnknownForGeoGroup');
       return (geo.ISOCountryGroups.indexOf(geoGroup) >= 0);
     });
+  }
+
+  /**
+   * Init consent policy instances
+   */
+  initConsentPolicy_() {
+    const policyKeys = Object.keys(this.policyConfig_);
+    for (let i = 0; i < policyKeys.length; i++) {
+      this.consentPolicyManager_.registerConsentPolicyInstance(
+          policyKeys[i], this.policyConfig_[policyKeys[i]]);
+    }
   }
 
   /**
@@ -419,9 +432,15 @@ export class AmpConsent extends AMP.BaseElement {
       user().assert(Object.keys(consents).length <= 1,
           `${TAG}: only single consent instance is supported`);
       if (config['policy']) {
-        // Ignore policy setting, and only have default policy.
-        user().warn(TAG, 'policy is not supported, and will be ignored');
-        delete config['policy'];
+        // Only respect 'default' consent policy;
+        const keys = Object.keys(config['policy']);
+        for (let i = 0; i < keys.length; i++) {
+          if (keys[i] != 'default') {
+            user().warn(TAG, `policy ${keys[i]} is currently not supported` +
+              'and will be ignored');
+            delete config['policy'][keys[i]];
+          }
+        }
       }
     }
 
@@ -456,15 +475,16 @@ export class AmpConsent extends AMP.BaseElement {
   /**
    * Handle Prompt UI.
    * @param {string} instanceId
+   * @return {Promise}
    */
-  handlePromptUI_(instanceId) {
+  initPromptUI_(instanceId) {
 
     const promptUI = this.consentConfig_[instanceId]['promptUI'];
     const element = this.getAmpDoc().getElementById(promptUI);
     this.consentUI_[instanceId] = element;
 
     // Get current consent state
-    this.consentStateManager_.getConsentInstanceState(instanceId)
+    return this.consentStateManager_.getConsentInstanceState(instanceId)
         .then(state => {
           if (state == CONSENT_ITEM_STATE.UNKNOWN) {
             if (!this.consentRequired_[instanceId]) {
@@ -521,5 +541,5 @@ AMP.extension('amp-consent', '0.1', AMP => {
   AMP.registerElement('amp-consent', AmpConsent, CSS);
   AMP.registerServiceForDoc(NOTIFICATION_UI_MANAGER, NotificationUiManager);
   AMP.registerServiceForDoc(CONSENT_STATE_MANAGER, ConsentStateManager);
-  AMP.registerServiceForDoc(CONSENT_POLICY_MANGER, ConsentPolicyManager);
+  AMP.registerServiceForDoc(CONSENT_POLICY_MANAGER, ConsentPolicyManager);
 });

--- a/extensions/amp-consent/0.1/amp-consent.js
+++ b/extensions/amp-consent/0.1/amp-consent.js
@@ -131,12 +131,16 @@ export class AmpConsent extends AMP.BaseElement {
     // TODO: Decide what to do with incorrect configuration.
     this.assertAndParseConfig_();
 
-    const consentPolicyManagerPromise =
-        getServicePromiseForDoc(this.getAmpDoc(), CONSENT_POLICY_MANAGER)
-            .then(manager => {
-              this.consentPolicyManager_ = manager;
-              this.generateDefaultPolicy_();
-            });
+    const consentPolicyManagerPromise = getServicePromiseForDoc(this.getAmpDoc(), CONSENT_POLICY_MANAGER)
+        .then(manager => {
+          this.consentPolicyManager_ = manager;
+          this.generateDefaultPolicy_();
+          const policyKeys = Object.keys(this.policyConfig_);
+          for (let i = 0; i < policyKeys.length; i++) {
+            this.consentPolicyManager_.registerConsentPolicyInstance(
+                policyKeys[i], this.policyConfig_[policyKeys[i]]);
+          }
+        });
 
     const consentStateManagerPromise =
         getServicePromiseForDoc(this.getAmpDoc(), CONSENT_STATE_MANAGER)
@@ -320,8 +324,8 @@ export class AmpConsent extends AMP.BaseElement {
     }
 
     Promise.all(initPromptPromises).then(() => {
-      this.initConsentPolicy_();
       this.handlePostPromptUI_();
+      this.consentPolicyManager_.enableTimeout();
     });
 
     this.enableInteractions_();

--- a/extensions/amp-consent/0.1/amp-consent.js
+++ b/extensions/amp-consent/0.1/amp-consent.js
@@ -131,16 +131,17 @@ export class AmpConsent extends AMP.BaseElement {
     // TODO: Decide what to do with incorrect configuration.
     this.assertAndParseConfig_();
 
-    const consentPolicyManagerPromise = getServicePromiseForDoc(this.getAmpDoc(), CONSENT_POLICY_MANAGER)
-        .then(manager => {
-          this.consentPolicyManager_ = manager;
-          this.generateDefaultPolicy_();
-          const policyKeys = Object.keys(this.policyConfig_);
-          for (let i = 0; i < policyKeys.length; i++) {
-            this.consentPolicyManager_.registerConsentPolicyInstance(
-                policyKeys[i], this.policyConfig_[policyKeys[i]]);
-          }
-        });
+    const consentPolicyManagerPromise =
+        getServicePromiseForDoc(this.getAmpDoc(), CONSENT_POLICY_MANAGER)
+            .then(manager => {
+              this.consentPolicyManager_ = manager;
+              this.generateDefaultPolicy_();
+              const policyKeys = Object.keys(this.policyConfig_);
+              for (let i = 0; i < policyKeys.length; i++) {
+                this.consentPolicyManager_.registerConsentPolicyInstance(
+                    policyKeys[i], this.policyConfig_[policyKeys[i]]);
+              }
+            });
 
     const consentStateManagerPromise =
         getServicePromiseForDoc(this.getAmpDoc(), CONSENT_STATE_MANAGER)

--- a/extensions/amp-consent/0.1/consent-policy-manager.js
+++ b/extensions/amp-consent/0.1/consent-policy-manager.js
@@ -64,8 +64,8 @@ export class ConsentPolicyManager {
    *     "consentDEF": [],
    *   }
    *   "timeout": {
-   *     "interval": 1,
-   *     "defaultState": 'rejected'/'unknown'
+   *     "seconds": 1,
+   *     "fallbackState": 'rejected'
    *   }
    * }
    *
@@ -237,7 +237,7 @@ export class ConsentPolicyInstance {
   startTimeout(win) {
     const timeoutConfig = this.config_['timeout'];
 
-    let timeoutInterval = null;
+    let timeoutSecond = null;
     let fallbackState;
 
     if (timeoutConfig != undefined) {
@@ -245,29 +245,29 @@ export class ConsentPolicyInstance {
       if (isObject(timeoutConfig)) {
         /**
          * "timeout": {
-         *   "interval" : 1,
-         *   "defaultState": "rejected"/"unknown"
+         *   "seconds" : 1,
+         *   "fallbackState": "rejected"
          * }
          */
-        if (timeoutConfig['defaultState'] &&
-            timeoutConfig['defaultState'] == 'rejected') {
+        if (timeoutConfig['fallbackState'] &&
+            timeoutConfig['fallbackState'] == 'rejected') {
           fallbackState = CONSENT_ITEM_STATE.REJECTED;
         } else {
           user().error(TAG,
-              `unsupported defaultState ${timeoutConfig['defaultState']}`);
+              `unsupported fallbackState ${timeoutConfig['fallbackState']}`);
         }
-        timeoutInterval = timeoutConfig['interval'];
+        timeoutSecond = timeoutConfig['seconds'];
       } else {
-        timeoutInterval = timeoutConfig;
+        timeoutSecond = timeoutConfig;
       }
-      user().assert(isFiniteNumber(timeoutInterval),
-          `invalid timeout value ${timeoutInterval}`);
+      user().assert(isFiniteNumber(timeoutSecond),
+          `invalid timeout value ${timeoutSecond}`);
     }
 
-    if (timeoutInterval != null) {
+    if (timeoutSecond != null) {
       win.setTimeout(() => {
         this.evaluate_(true, fallbackState);
-      }, timeoutInterval * 1000);
+      }, timeoutSecond * 1000);
     }
 
   }

--- a/extensions/amp-consent/0.1/consent-policy-manager.js
+++ b/extensions/amp-consent/0.1/consent-policy-manager.js
@@ -92,7 +92,6 @@ export class ConsentPolicyManager {
     const initPromises = [];
 
     this.ConsentStateManagerPromise_.then(manager => {
-      console.error("dafsdf");
       for (let i = 0; i < waitFor.length; i++) {
         const consentId = waitFor[i];
         let resolver;
@@ -105,7 +104,6 @@ export class ConsentPolicyManager {
             if (resolver) {
               resolver();
               resolver = null;
-              console.error('rightrightright');
             }
             instance.consentStateChangeHandler(consentId, state);
           });
@@ -255,7 +253,7 @@ export class ConsentPolicyInstance {
             timeoutConfig['defaultState'] == 'rejected') {
           fallbackState = CONSENT_ITEM_STATE.REJECTED;
         } else {
-          user().error(
+          user().error(TAG,
               `unsupported defaultState ${timeoutConfig['defaultState']}`);
         }
         timeoutInterval = timeoutConfig['interval'];

--- a/extensions/amp-consent/0.1/consent-policy-manager.js
+++ b/extensions/amp-consent/0.1/consent-policy-manager.js
@@ -20,6 +20,8 @@ import {dev, user} from '../../../src/log';
 import {getServicePromiseForDoc} from '../../../src/service';
 import {hasOwn, map} from '../../../src/utils/object';
 import {isExperimentOn} from '../../../src/experiments';
+import {isFiniteNumber} from '../../../src/types';
+import {isObject} from '../../../src/types';
 
 export const MULTI_CONSENT_EXPERIMENT = 'multi-consent';
 const CONSENT_STATE_MANAGER = 'consentStateManager';
@@ -51,7 +53,11 @@ export class ConsentPolicyManager {
    * {
    *   "waitFor": {
    *     "consentABC": [], // Can't support array now. All items will be treated as an empty array
-   *     "consentDEF": []
+   *     "consentDEF": [],
+   *   }
+   *   "timeout": {
+   *     "interval": 1,
+   *     "defaultState": 'rejected'/'unknown'
    *   }
    * }
    *
@@ -65,7 +71,7 @@ export class ConsentPolicyManager {
 
     const waitFor = Object.keys(config['waitFor'] || {});
 
-    const instance = new ConsentPolicyInstance(waitFor);
+    const instance = new ConsentPolicyInstance(config);
 
     this.instances_[policyId] = instance;
 
@@ -75,18 +81,33 @@ export class ConsentPolicyManager {
       this.policyInstancePromises_[policyId] = null;
     }
 
+    const initPromises = [];
+
     this.ConsentStateManagerPromise_.then(manager => {
       for (let i = 0; i < waitFor.length; i++) {
         const consentId = waitFor[i];
+        let resolver;
+        const instanceInitValuePromise = new Promise(resolve => {
+          resolver = resolve;
+        });
+
         manager.whenConsentReady(consentId).then(() => {
           manager.onConsentStateChange(consentId, state => {
+            if (resolver) {
+              resolver();
+              resolver = null;
+            }
             instance.consentStateChangeHandler(consentId, state);
           });
         });
+        initPromises.push(instanceInitValuePromise);
       }
+    }).then(() => {
+      Promise.all(initPromises).then(() => {
+        instance.startTimeout(this.ampdoc_.win);
+      });
     });
   }
-
 
   /**
    * Used to wait for policy to resolve;
@@ -153,7 +174,12 @@ export class ConsentPolicyManager {
 }
 
 export class ConsentPolicyInstance {
-  constructor(pendingItems) {
+  constructor(config) {
+    /** !Array<string> */
+    const pendingItems = Object.keys(config['waitFor'] || {});
+
+    /** @private {!JsonObject} */
+    this.config_ = config;
 
     /** @private {!Object<string, ?CONSENT_ITEM_STATE>} */
     this.itemToConsentState_ = map();
@@ -168,6 +194,7 @@ export class ConsentPolicyInstance {
 
     /** @private {CONSENT_POLICY_STATE} */
     this.status_ = CONSENT_POLICY_STATE.UNKNOWN;
+
     this.init_(pendingItems);
   }
 
@@ -183,6 +210,48 @@ export class ConsentPolicyInstance {
   /** @returns {Array<string>} */
   getConsentInstanceIds() {
     return Object.keys(this.itemToConsentState_);
+  }
+
+  /**
+   * @param {Window} win
+   */
+  startTimeout(win) {
+    const timeoutConfig = this.config_['timeout'];
+
+    let timeoutInterval = null;
+    let fallbackState;
+
+    if (timeoutConfig != undefined) {
+      // timeoutConfig could equal to 0;
+      if (isObject(timeoutConfig)) {
+        /**
+         * "timeout": {
+         *   "interval" : 1,
+         *   "defaultState": "rejected"/"unknown"
+         * }
+         */
+        timeoutInterval = timeoutConfig['interval'];
+        if (timeoutConfig['defaultState'] &&
+            timeoutConfig['defaultState'] == 'rejected') {
+          fallbackState = CONSENT_ITEM_STATE.REJECTED;
+        } else {
+          user().error(
+              `unsupported defaultState ${timeoutConfig['defaultState']}`);
+        }
+        timeoutInterval = timeoutConfig['interval'];
+      } else {
+        timeoutInterval = timeoutConfig;
+      }
+      user().assert(isFiniteNumber(timeoutInterval),
+          `invalid timeout value ${timeoutInterval}`);
+    }
+
+    if (timeoutInterval != null) {
+      win.setTimeout(() => {
+        this.evaluate_(true, fallbackState);
+      }, timeoutInterval * 1000);
+    }
+
   }
 
   /**
@@ -222,8 +291,12 @@ export class ConsentPolicyInstance {
     this.evaluate_();
   }
 
-
-  evaluate_() {
+  /**
+   *
+   * @param {boolean} isForce
+   * @param {CONSENT_ITEM_STATE=} opt_fallbackState
+   */
+  evaluate_(isForce = false, opt_fallbackState) {
     // All consent instances need to be granted
     let isSufficient = true;
 
@@ -239,7 +312,13 @@ export class ConsentPolicyInstance {
     for (let i = 0; i < items.length; i++) {
       const consentId = items[i];
       if (this.itemToConsentState_[consentId] === null) {
-        return;
+        if (isForce) {
+          // Force evaluate on timeout
+          const fallbackState = opt_fallbackState || CONSENT_ITEM_STATE.UNKNOWN;
+          this.itemToConsentState_[consentId] = fallbackState;
+        } else {
+          return;
+        }
       }
 
       if (this.itemToConsentState_[consentId] ==

--- a/extensions/amp-consent/0.1/test/test-amp-consent.js
+++ b/extensions/amp-consent/0.1/test/test-amp-consent.js
@@ -232,6 +232,8 @@ describes.realWin('amp-consent', {
   describe('policy config', () => {
     let defaultConfig;
     let ampConsent;
+    let scriptElement;
+    let consentElement;
     beforeEach(() => {
       defaultConfig = {
         'consents': {
@@ -243,10 +245,10 @@ describes.realWin('amp-consent', {
           },
         },
       };
-      const consentElement = doc.createElement('amp-consent');
+      consentElement = doc.createElement('amp-consent');
       consentElement.setAttribute('id', 'amp-consent');
       consentElement.setAttribute('layout', 'nodisplay');
-      const scriptElement = doc.createElement('script');
+      scriptElement = doc.createElement('script');
       scriptElement.setAttribute('type', 'application/json');
       scriptElement.textContent = JSON.stringify(defaultConfig);
       consentElement.appendChild(scriptElement);
@@ -262,6 +264,37 @@ describes.realWin('amp-consent', {
           'waitFor': {
             'ABC': undefined,
             'DEF': undefined,
+          },
+        },
+      });
+    });
+
+    it('override default policy', function* () {
+      defaultConfig = {
+        'consents': {
+          'ABC': {
+            'checkConsentHref': 'response1',
+          },
+          'DEF': {
+            'checkConsentHref': 'response1',
+          },
+        },
+        'policy': {
+          'default': {
+            'waitFor': {
+              'ABC': [],
+            },
+          },
+        },
+      };
+      scriptElement.textContent = JSON.stringify(defaultConfig);
+      ampConsent = new AmpConsent(consentElement);
+      ampConsent.buildCallback();
+      yield macroTask();
+      expect(ampConsent.policyConfig_).to.deep.equal({
+        'default': {
+          'waitFor': {
+            'ABC': [],
           },
         },
       });

--- a/extensions/amp-consent/0.1/test/test-consent-policy-manager.js
+++ b/extensions/amp-consent/0.1/test/test-consent-policy-manager.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import * as lolex from 'lolex';
 import {CONSENT_ITEM_STATE} from '../consent-state-manager';
 import {CONSENT_POLICY_STATE} from '../../../../src/consent-state';
 import {
@@ -94,7 +95,13 @@ describes.realWin('ConsentStateManager', {amp: 1}, env => {
   describe('Consent Policy Instance', () => {
     let instance;
     beforeEach(() => {
-      instance = new ConsentPolicyInstance(['ABC', 'DEF']);
+      const config = {
+        'waitFor': {
+          'ABC': [],
+          'DEF': [],
+        },
+      };
+      instance = new ConsentPolicyInstance(config);
     });
 
     it('on consent state change', () => {
@@ -174,8 +181,18 @@ describes.realWin('ConsentStateManager', {amp: 1}, env => {
     });
 
     describe('getReadyPromise', () => {
+      let config;
+
+      beforeEach(() => {
+        config = {
+          'waitFor': {
+            'ABC': [],
+          },
+        };
+      });
+
       it('promise should resolve when all consents are gathered', function* () {
-        instance = new ConsentPolicyInstance(['ABC']);
+        instance = new ConsentPolicyInstance(config);
         let ready = false;
         instance.getReadyPromise().then(() => ready = true);
         yield macroTask();
@@ -184,7 +201,7 @@ describes.realWin('ConsentStateManager', {amp: 1}, env => {
         yield macroTask();
         expect(ready).to.be.true;
         ready = false;
-        instance = new ConsentPolicyInstance(['ABC']);
+        instance = new ConsentPolicyInstance(config);
         instance.getReadyPromise().then(() => ready = true);
         instance.consentStateChangeHandler('ABC', CONSENT_ITEM_STATE.GRANTED);
         yield macroTask();
@@ -192,7 +209,7 @@ describes.realWin('ConsentStateManager', {amp: 1}, env => {
       });
 
       it('promise should resolve when consents are dimissed', function* () {
-        instance = new ConsentPolicyInstance(['ABC']);
+        instance = new ConsentPolicyInstance(config);
         let ready = false;
         instance.getReadyPromise().then(() => ready = true);
         yield macroTask();
@@ -208,9 +225,77 @@ describes.realWin('ConsentStateManager', {amp: 1}, env => {
       });
     });
 
+    describe('timeout', () => {
+      let config1;
+      let config2;
+      let clock;
+
+      beforeEach(() => {
+        config1 = {
+          'waitFor': {
+            'ABC': [],
+          },
+          'timeout': 1,
+        };
+
+        config2 = {
+          'waitFor': {
+            'ABC': [],
+          },
+          'timeout': {
+            'interval': 2,
+            'defaultState': 'rejected',
+          },
+        };
+
+        clock = lolex.install({target: ampdoc.win});
+      });
+
+      it('consent policy should resolve after timeout', function* () {
+        instance = new ConsentPolicyInstance(config1);
+        let ready = false;
+        instance.getReadyPromise().then(() => ready = true);
+        instance.consentStateChangeHandler('ABC', CONSENT_ITEM_STATE.UNKNOWN);
+        instance.startTimeout(ampdoc.win);
+        yield macroTask();
+        expect(ready).to.be.false;
+        clock.tick(999);
+        yield macroTask();
+        expect(ready).to.be.false;
+        clock.tick(1);
+        yield macroTask();
+        expect(ready).to.be.true;
+        expect(instance.getCurrentPolicyStatus()).to.equal(
+            CONSENT_POLICY_STATE.UNKNOWN);
+      });
+
+      it('promise should resolve when consents are dimissed', function* () {
+        instance = new ConsentPolicyInstance(config2);
+        let ready = false;
+        instance.getReadyPromise().then(() => ready = true);
+        instance.consentStateChangeHandler('ABC', CONSENT_ITEM_STATE.UNKNOWN);
+        instance.startTimeout(ampdoc.win);
+        yield macroTask();
+        expect(ready).to.be.false;
+        clock.tick(1999);
+        yield macroTask();
+        expect(ready).to.be.false;
+        clock.tick(1);
+        yield macroTask();
+        expect(ready).to.be.true;
+        expect(instance.getCurrentPolicyStatus()).to.equal(
+            CONSENT_POLICY_STATE.INSUFFICIENT);
+      });
+    });
+
+
     describe('getCurrentPolicyStatus', () => {
       it('should return current policy state', function* () {
-        instance = new ConsentPolicyInstance(['ABC']);
+        instance = new ConsentPolicyInstance({
+          'waitFor': {
+            'ABC': [],
+          },
+        });
         expect(instance.getCurrentPolicyStatus()).to.equal(
             CONSENT_ITEM_STATE.UNKNOWN);
         instance.consentStateChangeHandler('ABC', CONSENT_ITEM_STATE.DISMISSED);
@@ -237,7 +322,12 @@ describes.realWin('ConsentStateManager', {amp: 1}, env => {
     });
 
     it('policy status when there are multiple items to wait', () => {
-      instance = new ConsentPolicyInstance(['ABC', 'DEF']);
+      instance = new ConsentPolicyInstance({
+        'waitFor': {
+          'ABC': [],
+          'DEF': [],
+        },
+      });
       // single unknown
       instance.consentStateChangeHandler('ABC',
           CONSENT_ITEM_STATE.NOT_REQUIRED);

--- a/extensions/amp-consent/0.1/test/test-consent-policy-manager.js
+++ b/extensions/amp-consent/0.1/test/test-consent-policy-manager.js
@@ -243,8 +243,8 @@ describes.realWin('ConsentStateManager', {amp: 1}, env => {
             'ABC': [],
           },
           'timeout': {
-            'interval': 2,
-            'defaultState': 'rejected',
+            'seconds': 2,
+            'fallbackState': 'rejected',
           },
         };
 

--- a/test/manual/amp-consent.html
+++ b/test/manual/amp-consent.html
@@ -182,6 +182,10 @@
           "Policy_DEF": {
             "waitFor": {
               "DEF": []
+            },
+            "timeout": {
+              "interval": 5,
+              "defaultState": "rejected"
             }
           }
         },

--- a/test/manual/amp-consent.html
+++ b/test/manual/amp-consent.html
@@ -184,8 +184,8 @@
               "DEF": []
             },
             "timeout": {
-              "interval": 5,
-              "defaultState": "rejected"
+              "seconds": 5,
+              "fallbackState": "rejected"
             }
           }
         },


### PR DESCRIPTION
for #13716 
Support timeout on `default` consent policy. Allow customizing default consent state at timeout. The only supported value is "rejected" which convert consent instance with CONSENT_ITEM_STATE.UNKNOWN state to CONSENT_ITEM_STATE.REJECTED

