### PR TITLE
:bug: Prefer originalTitle for analytics, if set.

### DIFF
--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -195,7 +195,8 @@ export class GlobalVariableSource extends VariableSource {
 
     // Returns the title of this AMP document.
     this.set('TITLE', () => {
-      return this.ampdoc.win.document.originalTitle || this.ampdoc.win.document.title;
+      return this.ampdoc.win.document.originalTitle ||
+          this.ampdoc.win.document.title;
     });
 
     // Returns the URL for this AMP document.

--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -195,7 +195,7 @@ export class GlobalVariableSource extends VariableSource {
 
     // Returns the title of this AMP document.
     this.set('TITLE', () => {
-      return this.ampdoc.win.document.title;
+      return this.ampdoc.win.document.originalTitle || this.ampdoc.win.document.title;
     });
 
     // Returns the URL for this AMP document.

--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -195,7 +195,9 @@ export class GlobalVariableSource extends VariableSource {
 
     // Returns the title of this AMP document.
     this.set('TITLE', () => {
-      return this.ampdoc.win.document.originalTitle ||
+      // The environment may override the title and set originalTitle. Prefer
+      // that if available.
+      return this.ampdoc.win.document['originalTitle'] ||
           this.ampdoc.win.document.title;
     });
 

--- a/test/functional/test-url-replacements.js
+++ b/test/functional/test-url-replacements.js
@@ -116,6 +116,9 @@ describes.sandboxed('UrlReplacements', {}, () => {
                     opt_options.withViewerIntegrationVariableService);
               });
         }
+        if (opt_options.withOriginalTitle) {
+          iframe.doc.originalTitle = 'Original Pixel Test';
+        }
       }
       viewerService = Services.viewerForDoc(iframe.ampdoc);
       replacements = Services.urlReplacementsForDoc(iframe.ampdoc);
@@ -279,6 +282,12 @@ describes.sandboxed('UrlReplacements', {}, () => {
   it('should replace TITLE', () => {
     return expandUrlAsync('?title=TITLE').then(res => {
       expect(res).to.equal('?title=Pixel%20Test');
+    });
+  });
+
+  it('should prefer original title for TITLE', () => {
+    return expandUrlAsync('?title=TITLE', /*opt_bindings*/undefined, {withOriginalTitle: true}).then(res => {
+      expect(res).to.equal('?title=Original%20Pixel%20Test');
     });
   });
 

--- a/test/functional/test-url-replacements.js
+++ b/test/functional/test-url-replacements.js
@@ -286,7 +286,8 @@ describes.sandboxed('UrlReplacements', {}, () => {
   });
 
   it('should prefer original title for TITLE', () => {
-    return expandUrlAsync('?title=TITLE', /*opt_bindings*/undefined, {withOriginalTitle: true}).then(res => {
+    return expandUrlAsync('?title=TITLE',
+        /*opt_bindings*/undefined, {withOriginalTitle: true}).then(res => {
       expect(res).to.equal('?title=Original%20Pixel%20Test');
     });
   });


### PR DESCRIPTION
Prefers "document.originalTitle" over "document.title" for analytics, if set. This addresses a regression with analytics.