### PR TITLE
♻️Add restricted and visibleForTesting annotations to private gesture methods.

### DIFF
--- a/src/gesture.js
+++ b/src/gesture.js
@@ -323,9 +323,11 @@ export class Gestures {
    * recognizer to proceed.
    * @param {!GestureRecognizer} recognizer
    * @param {number} offset
+   * @private
    * @restricted
+   * @visibleForTesting
    */
-  signalReady(recognizer, offset) {
+  signalReady_(recognizer, offset) {
     // Somebody got here first.
     if (this.eventing_) {
       recognizer.acceptCancel();
@@ -351,8 +353,11 @@ export class Gestures {
    * will be canceled.
    * @param {!GestureRecognizer} recognizer
    * @param {number} timeLeft
+   * @private
+   * @restricted
+   * @visibleForTesting
    */
-  signalPending(recognizer, timeLeft) {
+  signalPending_(recognizer, timeLeft) {
     // Somebody got here first.
     if (this.eventing_) {
       recognizer.acceptCancel();
@@ -371,9 +376,11 @@ export class Gestures {
    * Callback for a gesture recognizer to communicate that it's done
    * emitting gestures.
    * @param {!GestureRecognizer} recognizer
+   * @private
    * @restricted
+   * @visibleForTesting
    */
-  signalEnd(recognizer) {
+  signalEnd_(recognizer) {
     if (this.eventing_ == recognizer) {
       this.eventing_ = null;
       this.wasEventing_ = true;
@@ -386,9 +393,11 @@ export class Gestures {
    * @param {!GestureRecognizer} recognizer
    * @param {*} data
    * @param {?Event} event
+   * @private
    * @restricted
+   * @visibleForTesting
    */
-  signalEmit(recognizer, data, event) {
+  signalEmit_(recognizer, data, event) {
     dev().assert(this.eventing_ == recognizer,
         'Recognizer is not currently allowed: %s', recognizer.getType());
     const overserver = this.overservers_[recognizer.getType()];
@@ -584,7 +593,7 @@ export class GestureRecognizer {
    * @param {time} offset
    */
   signalReady(offset) {
-    this.manager_.signalReady(this, offset);
+    this.manager_.signalReady_(this, offset);
   }
 
   /**
@@ -596,7 +605,7 @@ export class GestureRecognizer {
    * @param {time} timeLeft
    */
   signalPending(timeLeft) {
-    this.manager_.signalPending(this, timeLeft);
+    this.manager_.signalPending_(this, timeLeft);
   }
 
   /**
@@ -606,7 +615,7 @@ export class GestureRecognizer {
    * {@link acceptStart} call.
    */
   signalEnd() {
-    this.manager_.signalEnd(this);
+    this.manager_.signalEnd_(this);
   }
 
   /**
@@ -617,7 +626,7 @@ export class GestureRecognizer {
    * @param {?Event} event
    */
   signalEmit(data, event) {
-    this.manager_.signalEmit(this, data, event);
+    this.manager_.signalEmit_(this, data, event);
   }
 
   /**

--- a/src/gesture.js
+++ b/src/gesture.js
@@ -323,9 +323,9 @@ export class Gestures {
    * recognizer to proceed.
    * @param {!GestureRecognizer} recognizer
    * @param {number} offset
-   * @private
+   * @restricted
    */
-  signalReady_(recognizer, offset) {
+  signalReady(recognizer, offset) {
     // Somebody got here first.
     if (this.eventing_) {
       recognizer.acceptCancel();
@@ -351,9 +351,8 @@ export class Gestures {
    * will be canceled.
    * @param {!GestureRecognizer} recognizer
    * @param {number} timeLeft
-   * @private
    */
-  signalPending_(recognizer, timeLeft) {
+  signalPending(recognizer, timeLeft) {
     // Somebody got here first.
     if (this.eventing_) {
       recognizer.acceptCancel();
@@ -372,9 +371,9 @@ export class Gestures {
    * Callback for a gesture recognizer to communicate that it's done
    * emitting gestures.
    * @param {!GestureRecognizer} recognizer
-   * @private
+   * @restricted
    */
-  signalEnd_(recognizer) {
+  signalEnd(recognizer) {
     if (this.eventing_ == recognizer) {
       this.eventing_ = null;
       this.wasEventing_ = true;
@@ -387,9 +386,9 @@ export class Gestures {
    * @param {!GestureRecognizer} recognizer
    * @param {*} data
    * @param {?Event} event
-   * @private
+   * @restricted
    */
-  signalEmit_(recognizer, data, event) {
+  signalEmit(recognizer, data, event) {
     dev().assert(this.eventing_ == recognizer,
         'Recognizer is not currently allowed: %s', recognizer.getType());
     const overserver = this.overservers_[recognizer.getType()];
@@ -585,7 +584,7 @@ export class GestureRecognizer {
    * @param {time} offset
    */
   signalReady(offset) {
-    this.manager_.signalReady_(this, offset);
+    this.manager_.signalReady(this, offset);
   }
 
   /**
@@ -597,7 +596,7 @@ export class GestureRecognizer {
    * @param {time} timeLeft
    */
   signalPending(timeLeft) {
-    this.manager_.signalPending_(this, timeLeft);
+    this.manager_.signalPending(this, timeLeft);
   }
 
   /**
@@ -607,7 +606,7 @@ export class GestureRecognizer {
    * {@link acceptStart} call.
    */
   signalEnd() {
-    this.manager_.signalEnd_(this);
+    this.manager_.signalEnd(this);
   }
 
   /**
@@ -618,7 +617,7 @@ export class GestureRecognizer {
    * @param {?Event} event
    */
   signalEmit(data, event) {
-    this.manager_.signalEmit_(this, data, event);
+    this.manager_.signalEmit(this, data, event);
   }
 
   /**

--- a/test/functional/test-gesture.js
+++ b/test/functional/test-gesture.js
@@ -178,14 +178,14 @@ describe('Gestures', () => {
   it('should deny ready state if already eventing', () => {
     gestures.eventing_ = {};
     recognizerMock.expects('acceptCancel').once();
-    gestures.signalReady_(recognizer, 0);
+    gestures.signalReady(recognizer, 0);
   });
 
   it('should enter ready state', () => {
     clock.tick(1);
     recognizerMock.expects('acceptCancel').never();
     gestures.pending_[0] = 10;
-    gestures.signalReady_(recognizer, 0);
+    gestures.signalReady(recognizer, 0);
     expect(gestures.ready_[0]).to.equal(1);
     expect(gestures.pending_[0]).to.equal(0);
     expect(gestures.passAfterEvent_).to.equal(true);
@@ -196,21 +196,21 @@ describe('Gestures', () => {
     gestures.eventing_ = {};
     gestures.pending_[0] = 0;
     recognizerMock.expects('acceptCancel').once();
-    gestures.signalPending_(recognizer, 10);
+    gestures.signalPending(recognizer, 10);
     expect(gestures.pending_[0]).to.equal(0);
   });
 
   it('should enter ready state', () => {
     clock.tick(1);
     recognizerMock.expects('acceptCancel').never();
-    gestures.signalPending_(recognizer, 10);
+    gestures.signalPending(recognizer, 10);
     expect(gestures.pending_[0]).to.equal(11);
   });
 
 
   it('should stop eventing', () => {
     gestures.eventing_ = recognizer;
-    gestures.signalEnd_(recognizer);
+    gestures.signalEnd(recognizer);
     expect(gestures.eventing_).to.equal(null);
   });
 
@@ -218,7 +218,7 @@ describe('Gestures', () => {
   it('should deny emit if another eventing', () => {
     gestures.eventing_ = {};
     allowConsoleError(() => { expect(() => {
-      gestures.signalEmit_(recognizer, {}, null);
+      gestures.signalEmit(recognizer, {}, null);
     }).to.throw(/Recognizer is not currently allowed/); });
     expect(onGesture).to.have.not.been.called;
   });
@@ -228,7 +228,7 @@ describe('Gestures', () => {
     const event = {};
     clock.tick(1);
     gestures.eventing_ = recognizer;
-    gestures.signalEmit_(recognizer, data, event);
+    gestures.signalEmit(recognizer, data, event);
     expect(onGesture).to.be.calledOnce;
     const gesture = onGesture.getCall(0).args[0];
     expect(gesture.type).to.equal('test');
@@ -306,7 +306,7 @@ describe('Gestures', () => {
 
   it('should cancel event after eventing stopped', () => {
     gestures.eventing_ = recognizer;
-    gestures.signalEnd_(recognizer);
+    gestures.signalEnd(recognizer);
     expect(gestures.eventing_).to.equal(null);
     expect(gestures.wasEventing_).to.equal(true);
 
@@ -432,7 +432,7 @@ describe('Gestures', () => {
 
     it('should cancel event after eventing stopped', () => {
       gestures.eventing_ = recognizer;
-      gestures.signalEnd_(recognizer);
+      gestures.signalEnd(recognizer);
       expect(gestures.eventing_).to.equal(null);
       expect(gestures.wasEventing_).to.equal(true);
 

--- a/test/functional/test-gesture.js
+++ b/test/functional/test-gesture.js
@@ -178,14 +178,14 @@ describe('Gestures', () => {
   it('should deny ready state if already eventing', () => {
     gestures.eventing_ = {};
     recognizerMock.expects('acceptCancel').once();
-    gestures.signalReady(recognizer, 0);
+    gestures.signalReady_(recognizer, 0);
   });
 
   it('should enter ready state', () => {
     clock.tick(1);
     recognizerMock.expects('acceptCancel').never();
     gestures.pending_[0] = 10;
-    gestures.signalReady(recognizer, 0);
+    gestures.signalReady_(recognizer, 0);
     expect(gestures.ready_[0]).to.equal(1);
     expect(gestures.pending_[0]).to.equal(0);
     expect(gestures.passAfterEvent_).to.equal(true);
@@ -196,21 +196,21 @@ describe('Gestures', () => {
     gestures.eventing_ = {};
     gestures.pending_[0] = 0;
     recognizerMock.expects('acceptCancel').once();
-    gestures.signalPending(recognizer, 10);
+    gestures.signalPending_(recognizer, 10);
     expect(gestures.pending_[0]).to.equal(0);
   });
 
   it('should enter ready state', () => {
     clock.tick(1);
     recognizerMock.expects('acceptCancel').never();
-    gestures.signalPending(recognizer, 10);
+    gestures.signalPending_(recognizer, 10);
     expect(gestures.pending_[0]).to.equal(11);
   });
 
 
   it('should stop eventing', () => {
     gestures.eventing_ = recognizer;
-    gestures.signalEnd(recognizer);
+    gestures.signalEnd_(recognizer);
     expect(gestures.eventing_).to.equal(null);
   });
 
@@ -218,7 +218,7 @@ describe('Gestures', () => {
   it('should deny emit if another eventing', () => {
     gestures.eventing_ = {};
     allowConsoleError(() => { expect(() => {
-      gestures.signalEmit(recognizer, {}, null);
+      gestures.signalEmit_(recognizer, {}, null);
     }).to.throw(/Recognizer is not currently allowed/); });
     expect(onGesture).to.have.not.been.called;
   });
@@ -228,7 +228,7 @@ describe('Gestures', () => {
     const event = {};
     clock.tick(1);
     gestures.eventing_ = recognizer;
-    gestures.signalEmit(recognizer, data, event);
+    gestures.signalEmit_(recognizer, data, event);
     expect(onGesture).to.be.calledOnce;
     const gesture = onGesture.getCall(0).args[0];
     expect(gesture.type).to.equal('test');
@@ -306,7 +306,7 @@ describe('Gestures', () => {
 
   it('should cancel event after eventing stopped', () => {
     gestures.eventing_ = recognizer;
-    gestures.signalEnd(recognizer);
+    gestures.signalEnd_(recognizer);
     expect(gestures.eventing_).to.equal(null);
     expect(gestures.wasEventing_).to.equal(true);
 
@@ -432,7 +432,7 @@ describe('Gestures', () => {
 
     it('should cancel event after eventing stopped', () => {
       gestures.eventing_ = recognizer;
-      gestures.signalEnd(recognizer);
+      gestures.signalEnd_(recognizer);
       expect(gestures.eventing_).to.equal(null);
       expect(gestures.wasEventing_).to.equal(true);
 


### PR DESCRIPTION
This silences the linter warning about unused privates in `gestures.js`.