### PR TITLE
🐛 Fix usage of `browserify` while running tests with `karma`

### DIFF
--- a/build-system/tasks/karma.conf.js
+++ b/build-system/tasks/karma.conf.js
@@ -36,7 +36,6 @@ module.exports = {
 
   preprocessors: {
     'test/fixtures/*.html': ['html2js'],
-    'src/**/*.js': ['browserify'],
     'test/**/*.js': ['browserify'],
     'ads/**/test/test-*.js': ['browserify'],
     'extensions/**/test/**/*.js': ['browserify'],


### PR DESCRIPTION
We occasionally see errors like this while running tests:
```
Error: Cannot find module '/home/travis/build/ampproject/amphtml/test/integration/test-3p-frame.js'
    at s (/tmp/node_modules/browser-pack/_prelude.js:1:0 <- /tmp/8becd7461efca26aa257836e8d3ad98c.browserify:1:156)
    at s (/tmp/node_modules/browser-pack/_prelude.js:1:0 <- /tmp/8becd7461efca26aa257836e8d3ad98c.browserify:1:122)
    at test/integration/test-3p-frame.js:1:34"
```
See https://travis-ci.org/ampproject/amphtml/jobs/373705973#L710-L714

We use the `browserify` transform on all the runtime code in `src` while running tests with `karma`, and it turns out that this is incorrect usage. See https://github.com/nikku/karma-browserify/issues/50#issuecomment-63108293 and https://github.com/nikku/karma-browserify#usage for more details.

This PR runs `browserify` only on the test `js` files.

Fixes #14166