### PR TITLE
Remove <amp-youtube> internal state tracking

### DIFF
--- a/extensions/amp-youtube/0.1/amp-youtube.js
+++ b/extensions/amp-youtube/0.1/amp-youtube.js
@@ -264,9 +264,6 @@ class AmpYoutube extends AMP.BaseElement {
 
   /** @override */
   pauseCallback() {
-    // Only send pauseVideo command if the player is playing. Otherwise
-    // The player breaks if the user haven't played the video yet specially
-    // on mobile.
     if (this.iframe_ && this.iframe_.contentWindow) {
       this.pause();
     }

--- a/extensions/amp-youtube/0.1/amp-youtube.js
+++ b/extensions/amp-youtube/0.1/amp-youtube.js
@@ -67,8 +67,6 @@ class AmpYoutube extends AMP.BaseElement {
   /** @param {!AmpElement} element */
   constructor(element) {
     super(element);
-    /** @private {number} */
-    this.playerState_ = PlayerStates.UNSTARTED;
 
     /** @private {?string}  */
     this.videoid_ = null;
@@ -257,7 +255,6 @@ class AmpYoutube extends AMP.BaseElement {
     if (this.unlistenMessage_) {
       this.unlistenMessage_();
     }
-    this.playerState_ = PlayerStates.PAUSED;
 
     this.playerReadyPromise_ = new Promise(resolve => {
       this.playerReadyResolver_ = resolve;
@@ -270,8 +267,7 @@ class AmpYoutube extends AMP.BaseElement {
     // Only send pauseVideo command if the player is playing. Otherwise
     // The player breaks if the user haven't played the video yet specially
     // on mobile.
-    if (this.iframe_ && this.iframe_.contentWindow &&
-        this.playerState_ == PlayerStates.PLAYING) {
+    if (this.iframe_ && this.iframe_.contentWindow) {
       this.pause();
     }
   }
@@ -357,14 +353,14 @@ class AmpYoutube extends AMP.BaseElement {
     }
     if (data['event'] == 'infoDelivery' &&
         data['info'] && data['info']['playerState'] !== undefined) {
-      this.playerState_ = data['info']['playerState'];
-      if (this.playerState_ == PlayerStates.PAUSED) {
+      const playerState = data['info']['playerState'];
+      if (playerState == PlayerStates.PAUSED) {
         this.element.dispatchCustomEvent(VideoEvents.PAUSE);
-      } else if (this.playerState_ == PlayerStates.ENDED) {
+      } else if (playerState == PlayerStates.ENDED) {
         // YT does not fire pause and ended together.
         this.element.dispatchCustomEvent(VideoEvents.PAUSE);
         this.element.dispatchCustomEvent(VideoEvents.ENDED);
-      } else if (this.playerState_ == PlayerStates.PLAYING) {
+      } else if (playerState == PlayerStates.PLAYING) {
         this.element.dispatchCustomEvent(VideoEvents.PLAYING);
       }
     } else if (data['event'] == 'infoDelivery' &&

--- a/extensions/amp-youtube/0.1/test/test-amp-youtube.js
+++ b/extensions/amp-youtube/0.1/test/test-amp-youtube.js
@@ -89,45 +89,8 @@ describes.realWin('amp-youtube', {
       });
     });
 
-    it('monitors the YouTube player state', () => {
-      return getYt({'data-videoid': datasource}).then(yt => {
-        const iframe = yt.querySelector('iframe');
-        expect(iframe).to.not.be.null;
-
-        expect(yt.implementation_.playerState_).to.equal(-1);
-
-        sendFakeInfoDeliveryMessage(yt, iframe, {playerState: 1});
-
-        expect(yt.implementation_.playerState_).to.equal(1);
-
-        // YouTube Player sometimes sends parsed-JSON data. Test that we're
-        // handling it correctly.
-        yt.implementation_.handleYoutubeMessages_({
-          origin: 'https://www.youtube.com',
-          source: iframe.contentWindow,
-          data: {
-            event: 'infoDelivery',
-            info: {playerState: 2},
-          },
-        });
-
-        expect(yt.implementation_.playerState_).to.equal(2);
-      });
-
-    });
-
-    it('should not pause when video not playing', () => {
-      return getYt({'data-videoid': datasource}).then(yt => {
-        sandbox.spy(yt.implementation_, 'pause');
-        yt.implementation_.pauseCallback();
-        expect(yt.implementation_.pause.called).to.be.false;
-      });
-
-    });
-
     it('should pause if the video is playing', () => {
       return getYt({'data-videoid': datasource}).then(yt => {
-        yt.implementation_.playerState_ = 1;
         sandbox.spy(yt.implementation_, 'pause');
         yt.implementation_.pauseCallback();
         expect(yt.implementation_.pause.called).to.be.true;
@@ -366,7 +329,6 @@ describes.realWin('amp-youtube', {
       expect(yt.querySelector('iframe')).to.be.null;
       expect(obj.iframe_).to.be.null;
       expect(placeholder.style.display).to.be.equal('');
-      expect(obj.playerState_).to.be.equal(2);
     });
   });
 

--- a/test/manual/amp-youtube-carousel.amp.html
+++ b/test/manual/amp-youtube-carousel.amp.html
@@ -1,0 +1,86 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>AMP #0</title>
+  <link rel="canonical" href="amps.html" >
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
+  <script async custom-element="amp-youtube" src="https://cdn.ampproject.org/v0/amp-youtube-0.1.js"></script>
+  <script async custom-element="amp-lightbox" src="https://cdn.ampproject.org/v0/amp-lightbox-0.1.js"></script>
+  <script async custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.1.js"></script>
+
+  <style amp-custom>
+    body {
+      max-width: 527px;
+      font-family: 'Questrial', Arial;
+    }
+
+    amp-youtube iframe {
+      margin: 30px;
+      padding: 30px;
+      border: 10px solid red;
+    }
+
+    .lightbox1 {
+      background: #222;
+    }
+
+    .lightbox1-content {
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      display: flex;
+      flex-direction: column;
+      flex-wrap: nowrap;
+      justify-content: center;
+      align-items: center;
+    }
+
+  </style>
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+
+  <h1>amp-youtube in carousel</h1>
+  <amp-carousel
+    width="800"
+    height="600"
+    layout="fixed"
+    type="slides">
+    <amp-youtube width="480"
+      height="270"
+      layout="responsive"
+      data-videoid="mGENRKrdoGY"
+      lightbox-thumbnail-id="non-existent-thumbnail-img">
+    </amp-youtube>
+    <amp-youtube width="480"
+      height="270"
+      layout="responsive"
+      data-videoid="mGENRKrdoGY"
+      autoplay>
+      <amp-img
+        src="https://i.ytimg.com/vi/OO9oKhs80aI/mqdefault.jpg"
+        placeholder
+        layout="fill"
+        />
+    </amp-youtube>
+    <amp-youtube width="480"
+      height="270"
+      layout="fill"
+      data-videoid="mGENRKrdoGY">
+    </amp-youtube>
+    <amp-youtube width="480"
+      height="270"
+      layout="fill"
+      autoplay
+      data-videoid="mGENRKrdoGY">
+    </amp-youtube>
+  </amp-carousel>
+</body>
+</html>
+
+


### PR DESCRIPTION
Closes https://github.com/ampproject/amphtml/issues/14887 by removing internal tracking of `<amp-youtube>`'s state since youtube no longer breaks if you issue pauses to a paused video. 