### PR TITLE
🐛🏗  Fix error reporting from `browserify`

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1176,8 +1176,11 @@ function compileJs(srcDir, srcFilename, destDir, options) {
     return toPromise(
         bundler.bundle()
             .on('error', function(err) {
-              // Drop the node_modules call stack, which begins with '    at'.
-              const message = err.stack.replace(/    at[^]*/, '').trim();
+              let message = err;
+              if (err.stack) {
+                // Drop the node_modules call stack, which begins with '    at'.
+                message = err.stack.replace(/    at[^]*/, '').trim();
+              }
               console.error(red(message));
               if (failOnError) {
                 process.exit(1);


### PR DESCRIPTION
Some categories of `browserify` errors, like `ParseError`s do not contain an error stack. This PR handles those cases by extracting the error stack only if one is present.

Fixes #15025