### PR TITLE
Add prev and next buttons to dom in correct order for lightbox-gallery

### DIFF
--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -519,8 +519,8 @@ export class AmpLightboxGallery extends AMP.BaseElement {
       prevButton.classList.add('i-amphtml-screen-reader');
       nextButton.classList.add('i-amphtml-screen-reader');
     }
-    this.navControls_.appendChild(nextButton);
     this.navControls_.appendChild(prevButton);
+    this.navControls_.appendChild(nextButton);
     this.controlsContainer_.appendChild(this.navControls_);
   }
   /**


### PR DESCRIPTION
Addresses accessibility issue from QA so that talkback and voiceover announce the buttons in correct order. 