### PR TITLE
🏗 Set minimum `yarn` version to 1.3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,6 @@ before_install:
   - export DISPLAY=:99.0
   - unset _JAVA_OPTIONS  # JVM heap sizes break closure compiler. #11203.
   - sh -e /etc/init.d/xvfb start
-  - curl -o- -L https://yarnpkg.com/install.sh | bash
-  - export PATH="$HOME/.yarn/bin:$HOME/.config/yarn/global/node_modules/.bin:$PATH"
 before_script:
   - pip install --user protobuf
   - gem install percy-capybara capybara selenium-webdriver chromedriver-helper rspec-retry

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "engines": {
     "node": "^8.0.0",
-    "yarn": "^1.6.0"
+    "yarn": "^1.3.2"
   },
   "author": "The AMP HTML Authors",
   "license": "Apache-2.0",


### PR DESCRIPTION
#14983 bumped up the minimum `yarn` version for AMP development from 1.2.0 to 1.6.0 because 1.2.0 had gotten quite old, and 1.6.0 contains several desirable bug fixes.

However, Travis' native version of yarn is 1.3.2, so we had to install 1.6.0 at the start of every run. It turns out that this isn't 100% reliable, and results in the odd failed build.

This PR reduces the minimum `yarn` version to 1.3.2 to match what Travis provides. Developers will still be encouraged to upgrade to the stable version (currently 1.6.0) for local development.

When Travis upgrades the natively available version of `yarn`, we can bump up the minimum version in `package.json`.