### PR TITLE
✅ Fail tests that call `console error` when they are run during local dev

### DIFF
--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -533,6 +533,7 @@ function main() {
 
   // Run the local version of all tests.
   if (!process.env.TRAVIS) {
+    process.env['LOCAL_PR_CHECK'] = true;
     console.log(fileLogPrefix, 'Running all pr-check commands locally.');
     runAllCommandsLocally();
     stopTimer('pr-check.js', startTime);

--- a/build-system/tasks/karma.conf.js
+++ b/build-system/tasks/karma.conf.js
@@ -202,6 +202,7 @@ module.exports = {
       // Longer timeout on Travis; fail quickly at local.
       timeout: process.env.TRAVIS ? 10000 : 2000,
     },
+    travis: !!process.env.TRAVIS,
     // TODO(rsimha, #14432): Set to false after all tests are fixed.
     captureConsole: true,
   },

--- a/build-system/tasks/karma.conf.js
+++ b/build-system/tasks/karma.conf.js
@@ -202,7 +202,8 @@ module.exports = {
       // Longer timeout on Travis; fail quickly at local.
       timeout: process.env.TRAVIS ? 10000 : 2000,
     },
-    travis: !!process.env.TRAVIS,
+    // TODO(rsimha, #14406): Remove this after all tests are fixed.
+    failOnConsoleError: !process.env.TRAVIS && !process.env.LOCAL_PR_CHECK,
     // TODO(rsimha, #14432): Set to false after all tests are fixed.
     captureConsole: true,
   },

--- a/test/_init_tests.js
+++ b/test/_init_tests.js
@@ -289,8 +289,12 @@ function warnForConsoleError() {
             'test code that generated the error:\n' +
         '        \'allowConsoleError(() => { <code that generated the ' +
             'error> });';
-    // TODO(rsimha, #14432): Throw an error here after all tests are fixed.
-    originalConsoleError(errorMessage + '\'\n' + helpMessage);
+    // TODO(rsimha, #14406): Simply throw here after all tests are fixed.
+    if (window.__karma__.config.travis) {
+      originalConsoleError(errorMessage + '\'\n' + helpMessage);
+    } else {
+      throw new Error(errorMessage + '\'\n' + helpMessage);
+    }
   });
   this.allowConsoleError = function(func) {
     dontWarnForConsoleError();
@@ -301,8 +305,12 @@ function warnForConsoleError() {
       const helpMessage =
           'The test "' + testName + '" contains an "allowConsoleError" block ' +
           'that didn\'t result in a call to console.error.';
-      // TODO(rsimha, #14432): Throw an error here after all tests are fixed.
-      originalConsoleError(helpMessage);
+      // TODO(rsimha, #14406): Simply throw here after all tests are fixed.
+      if (window.__karma__.config.travis) {
+        originalConsoleError(helpMessage);
+      } else {
+        throw new Error(helpMessage);
+      }
     }
     warnForConsoleError();
   };

--- a/test/_init_tests.js
+++ b/test/_init_tests.js
@@ -290,10 +290,10 @@ function warnForConsoleError() {
         '        \'allowConsoleError(() => { <code that generated the ' +
             'error> });';
     // TODO(rsimha, #14406): Simply throw here after all tests are fixed.
-    if (window.__karma__.config.travis) {
-      originalConsoleError(errorMessage + '\'\n' + helpMessage);
-    } else {
+    if (window.__karma__.config.failOnConsoleError) {
       throw new Error(errorMessage + '\'\n' + helpMessage);
+    } else {
+      originalConsoleError(errorMessage + '\'\n' + helpMessage);
     }
   });
   this.allowConsoleError = function(func) {
@@ -306,10 +306,10 @@ function warnForConsoleError() {
           'The test "' + testName + '" contains an "allowConsoleError" block ' +
           'that didn\'t result in a call to console.error.';
       // TODO(rsimha, #14406): Simply throw here after all tests are fixed.
-      if (window.__karma__.config.travis) {
-        originalConsoleError(helpMessage);
-      } else {
+      if (window.__karma__.config.failOnConsoleError) {
         throw new Error(helpMessage);
+      } else {
+        originalConsoleError(helpMessage);
       }
     }
     warnForConsoleError();


### PR DESCRIPTION
#14406 is tracking the effort to fix AMP tests that result in unexpected calls to `console.error`. For the past month, tests would warn on unexpected errors, but continue to pass. Now it's time to start failing tests during local development, so that these errors are fixed.

Tests will continue to pass on Travis and when `gulp pr-check` is run locally.

Related to #14406