### PR TITLE
amp-ad-exit click delay interval start based on preformance timing event

### DIFF
--- a/extensions/amp-ad-exit/0.1/config.js
+++ b/extensions/amp-ad-exit/0.1/config.js
@@ -55,7 +55,8 @@ export let VariablesDef;
 /**
  * @typedef {{
  *   type: !FilterType,
- *   delay: number
+ *   delay: number,
+ *   startTimingEvent: (string|undefined)
  * }}
  */
 export let ClickDelayConfig;

--- a/extensions/amp-ad-exit/0.1/filters/click-delay.js
+++ b/extensions/amp-ad-exit/0.1/filters/click-delay.js
@@ -48,7 +48,7 @@ export class ClickDelayFilter extends Filter {
             `Invalid performance timing event type ${spec.startTimingEvent}` +
             ', falling back to now');
       } else {
-        this.intervalStart_ =
+        this.intervalStart =
           win['performance']['timing'][spec.startTimingEvent];
       }
     }
@@ -59,7 +59,7 @@ export class ClickDelayFilter extends Filter {
 
   /** @override */
   filter() {
-    return (Date.now() - this.intervalStart_) >= this.delay_;
+    return (Date.now() - this.intervalStart) >= this.delay_;
   }
 }
 

--- a/extensions/amp-ad-exit/0.1/filters/factory.js
+++ b/extensions/amp-ad-exit/0.1/filters/factory.js
@@ -28,12 +28,12 @@ export function createFilter(name, spec, adExitInstance) {
   switch (spec.type) {
     case FilterType.CLICK_DELAY:
       return new ClickDelayFilter(name,
-        /** @type {!../config.ClickDelayConfig} **/(spec), adExitInstance.win);
+          /** @type {!../config.ClickDelayConfig} **/(spec), adExitInstance.win);
     case FilterType.CLICK_LOCATION:
       return new ClickLocationFilter(name, spec, adExitInstance);
     case FilterType.INACTIVE_ELEMENT:
       return new InactiveElementFilter(
-        name, /** @type {!../config.InactiveElementConfig} */(spec));
+          name, /** @type {!../config.InactiveElementConfig} */(spec));
     default:
       return undefined;
   }

--- a/extensions/amp-ad-exit/0.1/filters/factory.js
+++ b/extensions/amp-ad-exit/0.1/filters/factory.js
@@ -27,8 +27,10 @@ import {InactiveElementFilter} from './inactive-element';
 export function createFilter(name, spec, adExitInstance) {
   switch (spec.type) {
     case FilterType.CLICK_DELAY:
-      return new ClickDelayFilter(name,
-          /** @type {!../config.ClickDelayConfig} **/(spec), adExitInstance.win);
+      return new ClickDelayFilter(
+          name,
+          /** @type {!../config.ClickDelayConfig} **/(spec),
+          adExitInstance.win);
     case FilterType.CLICK_LOCATION:
       return new ClickLocationFilter(name, spec, adExitInstance);
     case FilterType.INACTIVE_ELEMENT:

--- a/extensions/amp-ad-exit/0.1/filters/factory.js
+++ b/extensions/amp-ad-exit/0.1/filters/factory.js
@@ -19,14 +19,21 @@ import {ClickLocationFilter} from './click-location';
 import {FilterType} from './filter';
 import {InactiveElementFilter} from './inactive-element';
 
-export function createFilter(name, spec, adExitElement) {
+/**
+ * @param {string} name
+ * @param {!../config.FilterConfig} spec
+ * @param {!../amp-ad-exit.AmpAdExit} adExitInstance
+ */
+export function createFilter(name, spec, adExitInstance) {
   switch (spec.type) {
     case FilterType.CLICK_DELAY:
-      return new ClickDelayFilter(name, spec);
+      return new ClickDelayFilter(name,
+        /** @type {!../config.ClickDelayConfig} **/(spec), adExitInstance.win);
     case FilterType.CLICK_LOCATION:
-      return new ClickLocationFilter(name, spec, adExitElement);
+      return new ClickLocationFilter(name, spec, adExitInstance);
     case FilterType.INACTIVE_ELEMENT:
-      return new InactiveElementFilter(name, spec);
+      return new InactiveElementFilter(
+        name, /** @type {!../config.InactiveElementConfig} */(spec));
     default:
       return undefined;
   }

--- a/extensions/amp-ad-exit/0.1/test/filters/test-click-delay.js
+++ b/extensions/amp-ad-exit/0.1/test/filters/test-click-delay.js
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as sinon from 'sinon';
+import {ClickDelayFilter} from '../../filters/click-delay';
+import {FilterType} from '../../filters/filter';
+
+describe('click-delay', () => {
+  const DEFAULT_CONFIG = {
+    type: FilterType.CLICK_DELAY,
+    delay: 123,
+    startTimingEvent: 'navigationStart',
+  };
+
+  describe('should fail on invalid configs', () => {
+    const invalid = 'Invalid ClickDelay spec';
+    const browserSupport = 'Browser does not support performance timing';
+    const win = {performance: {timing: {'navigationStart': 456}}};
+    const tests = [
+      {config: {type: 'bar', delay: 123}, win, err: invalid},
+      {config: {type: FilterType.CLICK_DELAY}, win, err: invalid},
+      {config: {type: FilterType.CLICK_DELAY, delay: 0}, win, err: invalid},
+      {config: {type: FilterType.CLICK_DELAY, delay: -1}, win, err: invalid},
+      {config: {type: FilterType.CLICK_DELAY, delay: 'ac'}, win, err: invalid},
+      {config: DEFAULT_CONFIG, win: {}, err: browserSupport},
+      {config: DEFAULT_CONFIG, win: {performance: {}}, err: browserSupport},
+      {config: DEFAULT_CONFIG, win: {performance: {timing: {}}}, err:
+          'Invalid performance timing event type navigationStart​​​'},
+    ];
+    tests.forEach(test => {
+      it(`should throw ${test.err} with config ` +
+         `${JSON.stringify(test.config)} and win ${JSON.stringify(test.win)}`,
+      () => allowConsoleError(() => expect(() => new ClickDelayFilter(
+          'foo', test.config, test.win)).to.throw(test.err)));
+    });
+  });
+
+  describe('#filter', () => {
+    let sandbox;
+    beforeEach(() => sandbox = sinon.sandbox.create());
+    afterEach(() => sandbox.restore());
+
+    it('should filter based on timing event', () => {
+      const nowStub = sandbox.stub(Date, 'now');
+      nowStub.onFirstCall().returns(2);
+      nowStub.onSecondCall().returns(125);
+      const filter = new ClickDelayFilter(
+          'foo', DEFAULT_CONFIG, {performance: {timing: {navigationStart: 1}}});
+      expect(filter.filter()).to.be.false;
+      expect(filter.filter()).to.be.true;
+    });
+  });
+});

--- a/extensions/amp-ad-exit/0.1/test/filters/test-click-delay.js
+++ b/extensions/amp-ad-exit/0.1/test/filters/test-click-delay.js
@@ -32,7 +32,7 @@ describe('click-delay', () => {
     const win = {performance: {timing: {'navigationStart': 456}}};
     sandbox.stub(Date, 'now').returns(123);
     expect(new ClickDelayFilter('foo', DEFAULT_CONFIG, win).intervalStart)
-        .to.equal(123);
+        .to.equal(456);
   });
 
   describe('spec validation', () => {
@@ -67,6 +67,14 @@ describe('click-delay', () => {
 
   describe('#filter', () => {
     it('should filter based on timing event', () => {
+      const filter = new ClickDelayFilter(
+          'foo', DEFAULT_CONFIG, {performance: {timing: {navigationStart: 1}}});
+      const nowStub = sandbox.stub(Date, 'now');
+      nowStub.onFirstCall().returns(1001);
+      expect(filter.filter()).to.be.true;
+    });
+
+    it('should filter based on timing event, second call', () => {
       const filter = new ClickDelayFilter(
           'foo', DEFAULT_CONFIG, {performance: {timing: {navigationStart: 1}}});
       const nowStub = sandbox.stub(Date, 'now');

--- a/extensions/amp-ad-exit/0.1/test/test-amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/test/test-amp-ad-exit.js
@@ -198,22 +198,20 @@ describes.realWin('amp-ad-exit', {
     const el = win.document.createElement('amp-ad-exit');
     el.appendChild(win.document.createElement('p'));
     win.document.body.appendChild(el);
-    return el.build().then(() => {
-      throw new Error('must have failed');
-    }, error => {
-      expect(error.message).to.match(/application\/json/);
-    });
+    let promise;
+    allowConsoleError(() => promise = el.build());
+    return promise.should.be.rejectedWith(/application\/json/);
   });
 
   it('should do nothing for missing targets', () => {
     const open = sandbox.stub(win, 'open');
     try {
-      element.implementation_.executeAction({
+      allowConsoleError(() => element.implementation_.executeAction({
         method: 'exit',
         args: {target: 'not-a-real-target'},
         event: makeClickEvent(1001),
         satisfiesTrust: () => true,
-      });
+      }));
       expect(open).to.not.have.been.called;
     } catch (expected) {}
   });
@@ -647,4 +645,3 @@ describes.realWin('amp-ad-exit', {
         .to.eventually.be.rejectedWith(/Unknown vendor/);
   });
 });
-


### PR DESCRIPTION
Currently click delay interval starts at extension initialization which can depend on cache hit rate and other factors.  Allow for basing on performance timing events (e.g. navigationStart) via startTimingEvent in the config.  If browser does not support performance timing or event given does not exist in timing object, click protection will not be applied.