### PR TITLE
New analytics for amp-story-auto-ads

### DIFF
--- a/examples/amp-story-auto-ads.amp.html
+++ b/examples/amp-story-auto-ads.amp.html
@@ -6,6 +6,7 @@
   <link rel="canonical" href="animations-presets.html">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-1.0.js"></script>
+  <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
   <script async custom-element="amp-story-auto-ads" src="https://cdn.ampproject.org/v0/amp-story-auto-ads-0.1.js"></script>
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
@@ -41,6 +42,59 @@
     </style>
 </head>
 <body>
+  <amp-analytics>
+    <script type="application/json">
+      {
+        "transport": {"beacon": "true", "xhrpost": "false", "image": "true"},
+        "requests": {
+          "endpoint": "https://www.example.com",
+          "base": "${endpoint}?id=${adId}zx=${timestamp}"
+        },
+        "triggers": {
+          "storyAdRequest": {
+            "on": "story-ad-request",
+            "request": "base",
+            "extraUrlParams": {"amp_stads": "request"}
+          },
+          "storyAdResponse": {
+            "on": "story-ad-response",
+            "request": "base",
+            "extraUrlParams": {"amp_stads": "response"}
+          },
+          "storyAdLoad": {
+            "on": "story-ad-load",
+            "request": "base",
+            "extraUrlParams": {"amp_stads": "load"}
+          },
+          "storyAdInsert": {
+            "on": "story-ad-insert",
+            "request": "base",
+            "extraUrlParams": {"amp_stads": "insert"}
+          },
+          "storyAdView": {
+            "on": "story-ad-view",
+            "request": "base",
+            "extraUrlParams": {"amp_stads": "view"}
+          },
+          "storyAdClick": {
+            "on": "story-ad-click",
+            "request": "base",
+            "extraUrlParams": {"amp_stads": "click"}
+          },
+          "storyAdExit": {
+            "on": "story-ad-exit",
+            "request": "base",
+            "extraUrlParams": {"amp_stads": "exit"}
+          },
+          "storyAdDestroy": {
+            "on": "story-ad-destroy",
+            "request": "base",
+            "extraUrlParams": {"amp_stads": "destroy"}
+          }
+        }
+      }
+    </script>
+  </amp-analytics>
   <amp-story standalone>
     <amp-story-auto-ads>
       <script type="application/json">
@@ -53,8 +107,7 @@
       </script>
 
       <template type="amp-mustache" id="template-1">
-            <amp-img class="fill-img" layout="fill" src="{{imgSrc}}"></amp-img>
-            <amp-pixel src="{{impressionUrl}}"></amp-pixel>
+        <amp-img class="fill-img" layout="fill" src="{{imgSrc}}"></amp-img>
       </template>
     </amp-story-auto-ads>
 

--- a/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
+++ b/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
@@ -62,7 +62,7 @@ const CTA_TYPES = {
 /** @const */
 const AD_STATE = {
   PENDING: 0,
-  PLACED: 1,
+  INSERTED: 1,
   FAILED: 2,
 };
 
@@ -510,13 +510,13 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
    */
   analyticsEvent_(eventType, vars) {
     const adIndex = this.adPagesCreated_;
-    if (!hasOwn(this.analyticsData_, adIndex.toString())) {
-      this.analyticsData_[adIndex] = {adIndex};
+    if (this.analyticsData_['adIndex'] !== adIndex) {
+      this.analyticsData_ = {adIndex};
     }
-    this.analyticsData_[adIndex] = Object.assign(this.analyticsData_[adIndex],
+    this.analyticsData_ = Object.assign(this.analyticsData_,
         vars);
     triggerAnalyticsEvent(this.element, eventType,
-        this.analyticsData_[adIndex]);
+        this.analyticsData_);
   }
 }
 

--- a/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
+++ b/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
@@ -509,8 +509,8 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
    * @private
    */
   analyticsEvent_(eventType, vars) {
-    const adIndex = this.adPagesCreated_.toString();
-    if (!hasOwn(this.analyticsData_, adIndex)) {
+    const adIndex = this.adPagesCreated_;
+    if (!hasOwn(this.analyticsData_, adIndex.toString())) {
       this.analyticsData_[adIndex] = {adIndex};
     }
     this.analyticsData_[adIndex] = Object.assign(this.analyticsData_[adIndex],

--- a/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
+++ b/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
@@ -80,18 +80,18 @@ const EVENTS = {
   AD_VIEWED: 'story-ad-view',
   AD_CLICKED: 'story-ad-click',
   AD_EXITED: 'story-ad-exit',
-  AD_DESTROYED: 'story-ad-destroy',
+  AD_DISCARDED: 'story-ad-discard',
 };
 
 /** @enum {string} */
 const VARS = {
-  AD_REQUESTED: 'requestTime',
-  AD_LOADED: 'loadTime',
-  AD_INSERTED: 'insertTime',
-  AD_VIEWED: 'viewTime',
-  AD_CLICKED: 'clickTime',
-  AD_EXITED: 'exitTime',
-  AD_DESTROYED: 'destroyTime',
+  AD_REQUESTED: 'requestTime', // when ad is requested
+  AD_LOADED: 'loadTime', // when ad emits `INI_LOAD` signal
+  AD_INSERTED: 'insertTime', // added as page after next
+  AD_VIEWED: 'viewTime', // page becomes active
+  AD_CLICKED: 'clickTime', // optional
+  AD_EXITED: 'exitTime', // page moves from active => inactive
+  AD_DISCARDED: 'discardTime', // discared due to bad metadata etc
 };
 
 export class AmpStoryAutoAds extends AMP.BaseElement {
@@ -434,7 +434,7 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
     if (this.uniquePagesCount_ > MIN_INTERVAL) {
       const adState = this.tryToPlaceAdAfterPage_(pageId);
 
-      if (adState === AD_STATE.PLACED) {
+      if (adState === AD_STATE.INSERTED) {
         this.analyticsEvent_(EVENTS.AD_INSERTED,
             {[VARS.AD_INSERTED]: Date.now()});
         this.adsPlaced_++;
@@ -443,8 +443,8 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
       }
 
       if (adState === AD_STATE.FAILED) {
-        this.analyticsEvent_(EVENTS.AD_DESTROYED,
-            {[VARS.AD_DESTROYED]: Date.now()});
+        this.analyticsEvent_(EVENTS.AD_DISCARDED,
+            {[VARS.AD_DISCARDED]: Date.now()});
         this.startNextPage_();
       }
     }
@@ -490,7 +490,7 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
     }
 
     this.ampStory_.insertPage(currentPageId, nextAdPageEl.id);
-    return AD_STATE.PLACED;
+    return AD_STATE.INSERTED;
   }
 
 

--- a/extensions/amp-story-auto-ads/0.1/test/test-amp-story-auto-ads.js
+++ b/extensions/amp-story-auto-ads/0.1/test/test-amp-story-auto-ads.js
@@ -80,15 +80,15 @@ describes.realWin('amp-story-auto-ads', {
           {'insertTime': sinon.match.number});
     });
 
-    it('should fire upon destroyed ad', () => {
+    it('should fire upon discarded ad', () => {
       autoAds.uniquePagesCount_ = 10;
       sandbox.stub(autoAds, 'startNextPage_');
-      sandbox.stub(autoAds, 'tryToPlaceAdAfterPage_').returns(/* placed */ 2);
+      sandbox.stub(autoAds, 'tryToPlaceAdAfterPage_').returns(/* discard */ 2);
       const analyticsStub = sandbox.stub(autoAds, 'analyticsEvent_');
       autoAds.handleActivePageChange_(3, 'fakePage');
       expect(analyticsStub).to.be.called;
-      expect(analyticsStub).to.have.been.calledWithMatch('story-ad-destroy',
-          {'destroyTime': sinon.match.number});
+      expect(analyticsStub).to.have.been.calledWithMatch('story-ad-discard',
+          {'discardTime': sinon.match.number});
     });
 
     it('should fire upon ad load', function* () {

--- a/extensions/amp-story-auto-ads/0.1/test/test-amp-story-auto-ads.js
+++ b/extensions/amp-story-auto-ads/0.1/test/test-amp-story-auto-ads.js
@@ -13,28 +13,34 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+import * as analytics from '../../../../src/analytics';
+import * as sinon from 'sinon';
 import {AmpStoryAutoAds} from '../amp-story-auto-ads';
+import {macroTask} from '../../../../testing/yield';
+
+const NOOP = () => {};
 
 describes.realWin('amp-story-auto-ads', {
   amp: {
-    extensions: ['amp-story-auto-ads'],
+    extensions: [
+      'amp-story-auto-ads',
+    ],
   },
 }, env => {
 
   let win;
-  let element;
+  let adElement;
   let storyElement;
-  let ASAAImpl;
+  let autoAds;
 
   beforeEach(() => {
     win = env.win;
-    element = win.document.createElement('amp-story-auto-ads');
+    adElement = win.document.createElement('amp-story-auto-ads');
     storyElement = win.document.createElement('amp-story');
     win.document.body.appendChild(storyElement);
-    storyElement.appendChild(element);
-    ASAAImpl = new AmpStoryAutoAds(element);
-    ASAAImpl.config_ = {
+    storyElement.appendChild(adElement);
+    autoAds = new AmpStoryAutoAds(adElement);
+    autoAds.config_ = {
       'ad-attributes': {
         type: 'doubleclick',
         'data-slot': '/30497360/samfrank_native_v2_a4a',
@@ -47,7 +53,7 @@ describes.realWin('amp-story-auto-ads', {
     let pane;
 
     beforeEach(() => {
-      page = ASAAImpl.createAdPage_();
+      page = autoAds.createAdPage_();
       pane = page.querySelector('.i-amphtml-glass-pane');
     });
 
@@ -59,6 +65,95 @@ describes.realWin('amp-story-auto-ads', {
       const parent = pane.parentElement;
       expect(parent.tagName).to.equal('AMP-STORY-GRID-LAYER');
       expect(parent.getAttribute('template')).to.equal('fill');
+    });
+  });
+
+  describe('analytics triggers', () => {
+    it('should fire upon insertion', () => {
+      autoAds.uniquePagesCount_ = 10;
+      sandbox.stub(autoAds, 'startNextPage_');
+      sandbox.stub(autoAds, 'tryToPlaceAdAfterPage_').returns(/* placed */ 1);
+      const analyticsStub = sandbox.stub(autoAds, 'analyticsEvent_');
+      autoAds.handleActivePageChange_(3, 'fakePage');
+      expect(analyticsStub).to.be.called;
+      expect(analyticsStub).to.have.been.calledWithMatch('story-ad-insert',
+          {'insertTime': sinon.match.number});
+    });
+
+    it('should fire upon destroyed ad', () => {
+      autoAds.uniquePagesCount_ = 10;
+      sandbox.stub(autoAds, 'startNextPage_');
+      sandbox.stub(autoAds, 'tryToPlaceAdAfterPage_').returns(/* placed */ 2);
+      const analyticsStub = sandbox.stub(autoAds, 'analyticsEvent_');
+      autoAds.handleActivePageChange_(3, 'fakePage');
+      expect(analyticsStub).to.be.called;
+      expect(analyticsStub).to.have.been.calledWithMatch('story-ad-destroy',
+          {'destroyTime': sinon.match.number});
+    });
+
+    it('should fire upon ad load', function* () {
+      const signals = {whenSignal: () => Promise.resolve()};
+      const fakeImpl = {signals: () => signals};
+      const ad = win.document.createElement('amp-ad');
+      ad.getImpl = () => Promise.resolve(fakeImpl);
+      sandbox.stub(autoAds, 'createAdElement_').returns(ad);
+
+      const analyticsStub = sandbox.stub(autoAds, 'analyticsEvent_');
+      autoAds.createAdPage_();
+      yield macroTask();
+
+      expect(analyticsStub).to.be.called;
+      expect(analyticsStub).to.have.been.calledWithMatch('story-ad-load',
+          {'loadTime': sinon.match.number});
+    });
+
+    it('should fire upon ad request', () => {
+      autoAds.ampStory_ = {
+        element: storyElement,
+        addPage: NOOP,
+      };
+      const page = win.document.createElement('amp-story-page');
+      sandbox.stub(autoAds, 'createAdPage_').returns(page);
+      page.getImpl = () => Promise.resolve();
+
+      const analyticsStub = sandbox.stub(autoAds, 'analyticsEvent_');
+      autoAds.schedulePage_();
+
+      expect(analyticsStub).to.be.called;
+      expect(analyticsStub).to.have.been.calledWithMatch('story-ad-request',
+          {'requestTime': sinon.match.number});
+    });
+  });
+
+  describe('analyticsEvent_', () => {
+    let triggerStub;
+
+    beforeEach(() => {
+      triggerStub = sandbox.stub(analytics, 'triggerAnalyticsEvent');
+    });
+
+    it('should trigger the appropriate event', () => {
+      const vars = {
+        adIndex: 0,
+        foo: 1,
+      };
+      autoAds.analyticsEvent_('my-event', vars);
+      expect(triggerStub).calledWith(sinon.match.any, 'my-event',
+          sinon.match(vars));
+    });
+
+    it('should aggregate data from previous events', () => {
+      autoAds.analyticsEvent_('event-1', {foo: 1});
+      autoAds.analyticsEvent_('event-2', {bar: 2});
+      autoAds.analyticsEvent_('event-3', {baz: 3});
+      expect(triggerStub).calledThrice;
+      expect(triggerStub).calledWith(sinon.match.any, 'event-3',
+          sinon.match({
+            adIndex: 0,
+            foo: 1,
+            bar: 2,
+            baz: 3,
+          }));
     });
   });
 });


### PR DESCRIPTION
Introduces a few new triggers around the ads lifecycle in stories:

Triggers:
- `story-ad-request`
- `story-ad-load`
- `story-ad-insert`
- `story-ad-destroy`

This also introduces a few new variables. `adIndex` will be the count of ads in the story and the camel case version of the lifecycle triggers will be available to any trigger thereafter.