### PR TITLE
✨Disable auto-fullscreen for iframe players in iOS

### DIFF
--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -913,15 +913,16 @@ const AUTO_FULLSCREEN_ID_PROP = '__AMP_AUTO_FULLSCREEN_ID__';
 
 
 /**
+ * @param {!Window} win
  * @param {!AmpElement} video
  * @return {boolean}
  * @restricted
  */
 function canFullScreen(win, video) {
   // Safari and iOS can only fullscreen <video> elements directly. In cases
-  // where the player component is implemented via an iframe, we need to rely
+  // where the player component is implemented via an <iframe>, we need to rely
   // on a postMessage API to fullscreen. Such an API is not necessarily provided
-  // by all players.
+  // by every player.
   const internalElement = getInternalElementFor(video);
   if (internalElement.tagName.toLowerCase() == 'video') {
     return true;

--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -922,15 +922,15 @@ function canFullScreen(win, video) {
   // where the player component is implemented via an iframe, we need to rely
   // on a postMessage API to fullscreen. Such an API is not necessarily provided
   // by all players.
+  const internalElement = getInternalElementFor(video);
+  if (internalElement.tagName.toLowerCase() == 'video') {
+    return true;
+  }
   const platform = Services.platformFor(win);
   if (!(platform.isIos() || platform.isSafari())) {
     return true;
   }
-  if (supportsFullscreenViaApi(video)) {
-    return true;
-  }
-  const internalElement = getInternalElementFor(video);
-  return internalElement.tagName.toLowerCase() == 'video';
+  return supportsFullscreenViaApi(video);
 }
 
 

--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -913,29 +913,6 @@ const AUTO_FULLSCREEN_ID_PROP = '__AMP_AUTO_FULLSCREEN_ID__';
 
 
 /**
- * @param {!Window} win
- * @param {!AmpElement} video
- * @return {boolean}
- * @restricted
- */
-function canFullScreen(win, video) {
-  // Safari and iOS can only fullscreen <video> elements directly. In cases
-  // where the player component is implemented via an <iframe>, we need to rely
-  // on a postMessage API to fullscreen. Such an API is not necessarily provided
-  // by every player.
-  const internalElement = getInternalElementFor(video);
-  if (internalElement.tagName.toLowerCase() == 'video') {
-    return true;
-  }
-  const platform = Services.platformFor(win);
-  if (!(platform.isIos() || platform.isSafari())) {
-    return true;
-  }
-  return supportsFullscreenViaApi(video);
-}
-
-
-/**
  * @param {!AmpElement} video
  * @return {boolean}
  * @restricted
@@ -988,7 +965,7 @@ export class AutoFullscreenManager {
 
   /** @param {!VideoEntry} entry */
   register(entry) {
-    if (!canFullScreen(this.ampdoc_.win, entry.video.element)) {
+    if (!this.canFullscreen_(entry.video.element)) {
       return;
     }
 
@@ -1020,6 +997,27 @@ export class AutoFullscreenManager {
     listen(root, 'mozfullscreenchange', exitHandler);
     listen(root, 'fullscreenchange', exitHandler);
     listen(root, 'MSFullscreenChange', exitHandler);
+  }
+
+  /**
+   * @param {!AmpElement} video
+   * @return {boolean}
+   * @private
+   */
+  canFullscreen_(video) {
+    // Safari and iOS can only fullscreen <video> elements directly. In cases
+    // where the player component is implemented via an <iframe>, we need to
+    // rely on a postMessage API to fullscreen. Such an API is not necessarily
+    // provided by every player.
+    const internalElement = getInternalElementFor(video);
+    if (internalElement.tagName.toLowerCase() == 'video') {
+      return true;
+    }
+    const platform = Services.platformFor(this.ampdoc_.win);
+    if (!(platform.isIos() || platform.isSafari())) {
+      return true;
+    }
+    return supportsFullscreenViaApi(video);
   }
 
   /** @private */

--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -369,6 +369,16 @@ let VideoOrBaseElementDef;
 
 
 /**
+ * @param {!Element} element
+ * @return {!Element}
+ * @restricted
+ */
+function getInternalElementFor(element) {
+  return dev().assertElement(element.querySelector('video, iframe'));
+}
+
+
+/**
  * VideoEntry represents an entry in the VideoManager's list.
  */
 class VideoEntry {
@@ -551,7 +561,7 @@ class VideoEntry {
   videoLoaded() {
     this.loaded_ = true;
 
-    this.internalElement_ = this.video.element.querySelector('video, iframe');
+    this.internalElement_ = getInternalElementFor(this.video.element);
 
     this.fillMediaSessionMetadata_();
 
@@ -902,6 +912,39 @@ class VideoEntry {
 const AUTO_FULLSCREEN_ID_PROP = '__AMP_AUTO_FULLSCREEN_ID__';
 
 
+/**
+ * @param {!AmpElement} video
+ * @return {boolean}
+ * @restricted
+ */
+function canFullScreen(win, video) {
+  // Safari and iOS can only fullscreen <video> elements directly. In cases
+  // where the player component is implemented via an iframe, we need to rely
+  // on a postMessage API to fullscreen. Such an API is not necessarily provided
+  // by all players.
+  const platform = Services.platformFor(win);
+  if (!(platform.isIos() || platform.isSafari())) {
+    return true;
+  }
+  if (supportsFullscreenViaApi(video)) {
+    return true;
+  }
+  const internalElement = getInternalElementFor(video);
+  return internalElement.tagName.toLowerCase() == 'video';
+}
+
+
+/**
+ * @param {!AmpElement} video
+ * @return {boolean}
+ * @restricted
+ */
+function supportsFullscreenViaApi(video) {
+  // TODO(alanorozco): Determine this via a flag in the component itself.
+  return video.tagName.toLowerCase() == 'amp-dailymotion';
+}
+
+
 /** Manages rotate-to-fullscreen video. */
 export class AutoFullscreenManager {
 
@@ -944,6 +987,10 @@ export class AutoFullscreenManager {
 
   /** @param {!VideoEntry} entry */
   register(entry) {
+    if (!canFullScreen(this.ampdoc_.win, entry.video.element)) {
+      return;
+    }
+
     const id = this.nextId_++;
     const {element} = entry.video;
 

--- a/test/functional/test-video-rotate-to-fullscreen.js
+++ b/test/functional/test-video-rotate-to-fullscreen.js
@@ -45,6 +45,7 @@ describes.fakeWin('Rotate-to-fullscreen', {amp: true}, env => {
   beforeEach(() => {
     ampdoc = env.ampdoc;
     autoFullscreenManager = new AutoFullscreenManager(ampdoc);
+    sandbox.stub(autoFullscreenManager, 'canFullscreen_').returns(true);
   });
 
   it('should enter fullscreen if a video is centered in portrait', () => {


### PR DESCRIPTION
Safari and iOS can only fullscreen `<video>` elements directly. In cases where the player component is implemented via an `<iframe>`, we need to rely on a postMessage API to fullscreen. Such an API is not necessarily provided by all players.