### PR TITLE
Story consent component.

### DIFF
--- a/examples/amp-story/consent.html
+++ b/examples/amp-story/consent.html
@@ -50,26 +50,26 @@
   </head>
 
   <body>
-    <amp-consent id='ABC' layout='nodisplay'>
-      <script type="application/json">{
-        "consents": {
-          "ABC": {
-            "checkConsentHref": "http://localhost:8000/get-consent-v1",
-            "promptUI": "ui0"
-          }
-        },
-        "story-consent": {
-          "color": "#0379c4",
-          "title": "Headline.",
-          "message": "This is some more information about this choice. Here's a list of items related to this choice.",
-          "vendors": ["Item 1", "Item 2", "Item 3", "Item 4", "Item 5", "Item 6", "Item 7", "Item 8", "Item 9", "Item 10"]
-        },
-        "postPromptUI": "postPromptUI"
-      }</script>
-      <amp-story-consent id="ui0" layout="nodisplay"></amp-story-consent>
-    </amp-consent>
+    <amp-story standalone publisher-logo-src="https://placekitten.com/g/64/64">
+      <amp-consent id='ABC' layout='nodisplay'>
+        <script type="application/json">{
+          "consents": {
+            "ABC": {
+              "checkConsentHref": "http://localhost:8000/get-consent-v1",
+              "promptUI": "ui0"
+            }
+          },
+          "story-consent": {
+            "color": "#0379c4",
+            "title": "Headline.",
+            "message": "This is some more information about this choice. Here's a list of items related to this choice.",
+            "vendors": ["Item 1", "Item 2", "Item 3", "Item 4", "Item 5", "Item 6", "Item 7", "Item 8", "Item 9", "Item 10"]
+          },
+          "postPromptUI": "postPromptUI"
+        }</script>
+        <amp-story-consent id="ui0" layout="nodisplay"></amp-story-consent>
+      </amp-consent>
 
-    <amp-story standalone publisher-logo-src="https://freshux.googleplex.com/amp/imgs/AMP-Brand-Blue-Icon@10x.png">
       <amp-story-page id="cover">
         <amp-story-grid-layer template="vertical">
           <h1>You just accepted or rejected the consent!</h1>

--- a/examples/amp-story/consent.html
+++ b/examples/amp-story/consent.html
@@ -1,0 +1,80 @@
+<!doctype html>
+<html amp lang="en">
+  <head>
+    <meta charset="utf-8">
+    <script async src="https://cdn.ampproject.org/v0.js"></script>
+    <script async custom-element="amp-story"
+        src="https://cdn.ampproject.org/v0/amp-story-1.0.js"></script>
+    <script async custom-element="amp-consent"
+        src="https://cdn.ampproject.org/v0/amp-consent-0.1.js"></script>
+    <title>My Story with consent</title>
+    <meta name="viewport"
+          content="width=device-width,minimum-scale=1,initial-scale=1">
+    <link rel="canonical" href="consent.html">
+    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+    <style amp-custom>
+      body {
+        font-family: 'Roboto', sans-serif;
+      }
+      amp-story-page {
+        background-color: white;
+      }
+    </style>
+    <script type="application/ld+json">
+      {
+        "@context": "http://schema.org",
+        "@type": "NewsArticle",
+        "mainEntityOfPage": {
+          "@type": "WebPage",
+          "@id": "./consent.html"
+        },
+        "headline": "My Story",
+        "image":["http://placehold.it/420x740"],
+        "datePublished": "2018-01-01T00:00:00+00:00",
+        "dateModified": "2018-01-01T00:00:00+00:00",
+        "author": {
+          "@type": "Organization",
+          "name": "AMP Project"
+        },
+        "publisher": {
+          "@type": "Organization",
+          "name": "AMP Project",
+          "logo": {
+            "@type": "ImageObject",
+            "url": "http://placehold.it/128x128"
+          }
+        },
+        "description": "My Story"
+      }
+    </script>
+  </head>
+
+  <body>
+    <amp-consent id='ABC' layout='nodisplay'>
+      <script type="application/json">{
+        "consents": {
+          "ABC": {
+            "checkConsentHref": "http://localhost:8000/get-consent-v1",
+            "promptUI": "ui0"
+          }
+        },
+        "story-consent": {
+          "color": "#0379c4",
+          "title": "Headline.",
+          "message": "This is some more information about this choice. Here's a list of items related to this choice.",
+          "vendors": ["Item 1", "Item 2", "Item 3", "Item 4", "Item 5", "Item 6", "Item 7", "Item 8", "Item 9", "Item 10"]
+        },
+        "postPromptUI": "postPromptUI"
+      }</script>
+      <amp-story-consent id="ui0" layout="nodisplay"></amp-story-consent>
+    </amp-consent>
+
+    <amp-story standalone publisher-logo-src="https://freshux.googleplex.com/amp/imgs/AMP-Brand-Blue-Icon@10x.png">
+      <amp-story-page id="cover">
+        <amp-story-grid-layer template="vertical">
+          <h1>You just accepted or rejected the consent!</h1>
+        </amp-story-grid-layer>
+      </amp-story-page>
+    </amp-story>
+  </body>
+</html>

--- a/extensions/amp-story/1.0/amp-story-consent.css
+++ b/extensions/amp-story/1.0/amp-story-consent.css
@@ -48,8 +48,7 @@
 
 .i-amphtml-story-consent-container {
   position: relative !important;
-  margin: 88px auto 72px !important;
-  width: calc(100vw - 16px) !important;
+  margin: 88px 8px 72px !important;
   background: #FFFFFF !important;
   border-radius: 8px 8px 0 0 !important;
   color: rgba(0, 0, 0, 0.87) !important;
@@ -59,6 +58,7 @@
 }
 
 .i-amphtml-story-consent-fullbleed .i-amphtml-story-consent-container {
+  margin: 88px 0px 72px !important;
   padding: 0 8px !important;
   border-radius: initial !important;
 }
@@ -79,7 +79,8 @@
 .i-amphtml-story-consent-logo {
   position: absolute !important;
   bottom: -32px !important;
-  left: calc(50% - 32px) !important;
+  margin-left: -32px !important;
+  left: 50% !important;
   height: 64px !important;
   width: 64px !important;
   background: #F0F0F0 !important;

--- a/extensions/amp-story/1.0/amp-story-consent.css
+++ b/extensions/amp-story/1.0/amp-story-consent.css
@@ -1,0 +1,218 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* TODO(#15057): Move away from position: fixed; */
+.i-amphtml-story-consent {
+  position: fixed !important;
+  display: flex !important;
+  flex-direction: column !important;
+  top: 0 !important;
+  left: 0 !important;
+  height: 100% !important;
+  width: 100% !important;
+  z-index: 100001 !important;
+}
+
+/** Black opacity overlay. */
+.i-amphtml-story-consent::before {
+  content: "" !important;
+  position: absolute !important;
+  top: 0 !important;
+  left: 0 !important;
+  height: 100% !important;
+  width: 100% !important;
+  background: #000000 !important;
+  opacity: 0.4 !important;
+}
+
+.i-amphtml-story-consent-overflow {
+  margin-top: auto !important;
+  overflow-y: auto !important;
+  overflow-x: hidden !important;
+  /* Enable iOS momentum scrolling. */
+  -webkit-overflow-scrolling: touch !important;
+}
+
+.i-amphtml-story-consent-container {
+  position: relative !important;
+  margin: 88px auto 72px !important;
+  width: calc(100vw - 16px) !important;
+  background: #FFFFFF !important;
+  border-radius: 8px 8px 0 0 !important;
+  color: rgba(0, 0, 0, 0.87) !important;
+  font-family: 'Roboto', sans-serif !important;
+  text-align: left !important;
+  overflow: hidden !important;
+}
+
+.i-amphtml-story-consent-fullbleed .i-amphtml-story-consent-container {
+  padding: 0 8px !important;
+  border-radius: initial !important;
+}
+
+/** Consent header. */
+
+.i-amphtml-story-consent-header {
+  position: relative !important;
+  height: 80px !important;
+  min-height: 80px !important;
+  background: #F0F0F0 !important;
+  z-index: 2 !important;
+
+  /* Making sure the background color fills the container in full bleed mode. */
+  margin: 0 -8px !important;
+}
+
+.i-amphtml-story-consent-logo {
+  position: absolute !important;
+  bottom: -32px !important;
+  left: calc(50% - 32px) !important;
+  height: 64px !important;
+  width: 64px !important;
+  background: #F0F0F0 !important;
+  background-position: center !important;
+  background-repeat: no-repeat !important;
+  background-size: contain !important;
+  border-radius: 5px !important;
+}
+
+.i-amphtml-story-consent-logo::before {
+  content: "" !important;
+  position: absolute !important;
+  top: -6px !important;
+  bottom: -6px !important;
+  left: -6px !important;
+  right: -6px !important;
+  background: #FFFFFF !important;
+  border-radius: 6px !important;
+  box-shadow: 0 2px 3px rgba(0, 0, 0, 0.12) !important;
+  z-index: -1 !important;
+}
+
+/** Consent content. */
+
+.i-amphtml-story-consent-content {
+  padding: 42px 16px 16px !important;
+  font-size: 14px !important;
+  z-index: 0 !important;
+}
+
+.i-amphtml-story-consent-vendors {
+  margin: 0 !important;
+  padding: 0 !important;
+  list-style: none !important;
+}
+
+.i-amphtml-story-consent-vendor {
+  height: 40px !important;
+  border-bottom: 1px solid #F0F0F0 !important;
+  line-height: 40px !important;
+  text-overflow: ellipsis !important;
+  overflow: hidden !important;
+}
+
+/** Consent actions. */
+
+.i-amphtml-story-consent-actions {
+  position: fixed !important;
+  display: flex !important;
+  justify-content: center !important;
+  align-items: center !important;
+  bottom: 0 !important;
+  left: 8px !important;
+  right: 8px !important;
+  height: 72px !important;
+  min-height: 72px !important;
+  background: #FFFFFF !important;
+  box-shadow: 0 -2px 3px rgba(0, 0, 0, 0.12) !important;
+  z-index: 1 !important;
+}
+
+.i-amphtml-story-consent-fullbleed .i-amphtml-story-consent-actions {
+  left: 0px !important;
+  right: 0px !important;
+}
+
+.i-amphtml-story-consent-action {
+  position: relative !important;
+  padding: 0 24px !important;
+  margin: 0 12px !important;
+  height: 40px !important;
+  width: 40vw !important;
+  max-width: 200px !important;
+  background: #FFFFFF !important;
+  border: none !important;
+  border-radius: 40px !important;
+  box-sizing: border-box !important;
+  cursor: pointer !important;
+  font-size: 13px !important;
+  font-weight: bold !important;
+  line-height: 40px !important;
+  text-transform: uppercase !important;
+}
+
+.i-amphtml-story-consent-action-accept {
+  background: #000000 !important;
+  color: #FFFFFF !important;
+}
+
+.i-amphtml-story-consent-action-reject {
+  border: 1px solid #000000 !important;
+}
+
+/**
+ * Tablets and desktop UI overrides.
+ * Basically triggers for anything bigger than a Pixel XL / iPhone Plus.
+ */
+
+@media (min-width: 420px) {
+  .i-amphtml-story-consent {
+    align-items: center !important;
+    justify-content: center !important;
+  }
+
+  .i-amphtml-story-consent-overflow {
+    margin-top: 0 !important;
+  }
+
+  .i-amphtml-story-consent-container {
+    display: flex !important;
+    flex-direction: column !important;
+    margin: 0 !important;
+    max-height: 80vh !important;
+    min-height: 40vh !important;
+    width: calc(100vw - 80px) !important;
+    max-width: 800px !important;
+  }
+
+  .i-amphtml-story-consent-content {
+    margin: 0 auto !important;
+    max-width: 424px !important; /** Width of the consent-actions block. */
+    flex-grow: 1 !important;
+    overflow-y: auto !important;
+  }
+
+  .i-amphtml-story-consent-content::-webkit-scrollbar {
+    width: 0px !important;
+    background: transparent !important;
+  }
+
+  .i-amphtml-story-consent-actions {
+    position: relative !important;
+    left: 0px !important;
+    right: 0px !important;
+  }
+}

--- a/extensions/amp-story/1.0/amp-story-consent.js
+++ b/extensions/amp-story/1.0/amp-story-consent.js
@@ -19,6 +19,7 @@ import {CSS} from '../../../build/amp-story-consent-1.0.css';
 import {Layout} from '../../../src/layout';
 import {Services} from '../../../src/services';
 import {childElementByTag} from '../../../src/dom';
+import {closestByTag} from '../../../src/dom';
 import {createShadowRootWithStyle} from './utils';
 import {dev, user} from '../../../src/log';
 import {dict} from './../../../src/utils/object';
@@ -160,8 +161,8 @@ export class AmpStoryConsent extends AMP.BaseElement {
   buildCallback() {
     this.assertAndParseConfig_();
 
-    const el = this.win.document.querySelector('[publisher-logo-src]');
-    const logoSrc = el && el.getAttribute('publisher-logo-src');
+    const storyEl = closestByTag(this.element, 'AMP-STORY');
+    const logoSrc = storyEl && storyEl.getAttribute('publisher-logo-src');
 
     if (!logoSrc) {
       user().warn(
@@ -186,7 +187,7 @@ export class AmpStoryConsent extends AMP.BaseElement {
 
   /** @override */
   prerenderAllowed() {
-    return true;
+    return false;
   }
 
   /**

--- a/extensions/amp-story/1.0/amp-story-consent.js
+++ b/extensions/amp-story/1.0/amp-story-consent.js
@@ -1,0 +1,275 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {ActionTrust} from '../../../src/action-trust';
+import {CSS} from '../../../build/amp-story-consent-1.0.css';
+import {Layout} from '../../../src/layout';
+import {Services} from '../../../src/services';
+import {childElementByTag} from '../../../src/dom';
+import {createShadowRootWithStyle} from './utils';
+import {dev, user} from '../../../src/log';
+import {dict} from './../../../src/utils/object';
+import {isArray} from '../../../src/types';
+import {parseJson} from '../../../src/json';
+import {renderAsElement} from './simple-template';
+import {throttle} from '../../../src/utils/rate-limit';
+
+
+/** @private @const {string} */
+const TAG = 'amp-story-consent';
+
+// TODO(gmajoulet): switch to `htmlFor` static template helper.
+// TODO(gmajoulet): use a CSS variable for the `color` config parameter.
+/**
+ * Story consent template.
+ * @private @const {function(!Object, string, ?string):!./simple-template.ElementDef}
+ */
+const getTemplate = (config, consentId, logoSrc) => ({
+  tag: 'div',
+  attrs: dict({
+    'class': 'i-amphtml-story-consent i-amphtml-story-system-reset'}),
+  children: [
+    {
+      tag: 'div',
+      attrs: dict({'class': 'i-amphtml-story-consent-overflow'}),
+      children: [
+        {
+          tag: 'div',
+          attrs: dict({'class': 'i-amphtml-story-consent-container'}),
+          children: [
+            {
+              tag: 'div',
+              attrs: dict({
+                'class': 'i-amphtml-story-consent-header',
+                'style': config.color ?
+                  `background-color: ${config.color} !important;` : '',
+              }),
+              children: [
+                {
+                  tag: 'div',
+                  attrs: dict({
+                    'class': 'i-amphtml-story-consent-logo',
+                    'style': logoSrc ?
+                      `background-image: url('${logoSrc}') !important;` : '',
+                  }),
+                  children: [],
+                },
+              ],
+            },
+            {
+              tag: 'div',
+              attrs: dict({'class': 'i-amphtml-story-consent-content'}),
+              children: [
+                {
+                  tag: 'h3',
+                  attrs: dict({}),
+                  children: [],
+                  unlocalizedString: config.title,
+                },
+                {
+                  tag: 'p',
+                  attrs: dict({}),
+                  children: [],
+                  unlocalizedString: config.message,
+                },
+                {
+                  tag: 'ul',
+                  attrs: dict({'class': 'i-amphtml-story-consent-vendors'}),
+                  children: config.vendors && config.vendors.map(vendor => (
+                    {
+                      tag: 'li',
+                      attrs: dict({'class': 'i-amphtml-story-consent-vendor'}),
+                      children: [],
+                      unlocalizedString: vendor,
+                    })
+                  ),
+                },
+              ],
+            },
+            {
+              tag: 'div',
+              attrs: dict({'class': 'i-amphtml-story-consent-actions'}),
+              children: [
+                {
+                  tag: 'button',
+                  attrs: dict({
+                    'class': 'i-amphtml-story-consent-action ' +
+                        'i-amphtml-story-consent-action-reject',
+                    'on': `tap:${consentId}.reject`,
+                  }),
+                  children: [],
+                  unlocalizedString: 'Decline',
+                },
+                {
+                  tag: 'button',
+                  attrs: dict({
+                    'class': 'i-amphtml-story-consent-action ' +
+                        'i-amphtml-story-consent-action-accept',
+                    'style': config.color ?
+                      `background-color: ${config.color} !important; ` +
+                          `border-color: ${config.color} !important;` : '',
+                    'on': `tap:${consentId}.accept`,
+                  }),
+                  children: [],
+                  unlocalizedString: 'Agree',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+});
+
+/**
+ * The <amp-story-consent> custom element.
+ */
+export class AmpStoryConsent extends AMP.BaseElement {
+  /** @param {!AmpElement} element */
+  constructor(element) {
+    super(element);
+
+    /** @const @private {!../../../src/service/action-impl.ActionService} */
+    this.actions_ = Services.actionServiceForDoc(this.element);
+
+    /** @private {?Object} */
+    this.consentConfig_ = null;
+
+    /** @private {?Element} */
+    this.scrollableEl_ = null;
+
+    /** @private {?Element} */
+    this.storyConsentEl_ = null;
+  }
+
+  /** @override */
+  buildCallback() {
+    this.assertAndParseConfig_();
+
+    const el = this.win.document.querySelector('[publisher-logo-src]');
+    const logoSrc = el && el.getAttribute('publisher-logo-src');
+
+    if (!logoSrc) {
+      user().warn(
+          TAG, 'Expected "publisher-logo-src" attribute on <amp-story>');
+    }
+
+    const storyConsentConfig =
+        this.consentConfig_ && this.consentConfig_['story-consent'];
+    const consentId = Object.keys(this.consentConfig_.consents)[0];
+    this.storyConsentEl_ = renderAsElement(
+        this.win.document, getTemplate(storyConsentConfig, consentId, logoSrc));
+    createShadowRootWithStyle(this.element, this.storyConsentEl_, CSS);
+
+    this.initializeListeners_();
+    this.addActionsToWhitelist_();
+  }
+
+  /** @override */
+  isLayoutSupported(layout) {
+    return layout == Layout.NODISPLAY;
+  }
+
+  /** @override */
+  prerenderAllowed() {
+    return true;
+  }
+
+  /**
+   * @private
+   */
+  initializeListeners_() {
+    this.storyConsentEl_.addEventListener(
+        'click', event => this.onClick_(event), true /** useCapture */);
+
+    this.scrollableEl_ =
+        this.storyConsentEl_.querySelector('.i-amphtml-story-consent-overflow');
+    this.scrollableEl_.addEventListener(
+        'scroll', throttle(this.win, () => this.onScroll_(), 100));
+  }
+
+  /**
+   * Listens to click events to trigger the actions programatically.
+   * Since events bubble up from the Shadow DOM but their target is updated to
+   * the Shadow root, the top level actions event listeners would not detect
+   * and trigger the actions upon click events.
+   * @param {!Event} event
+   * @private
+   */
+  onClick_(event) {
+    if (event.target && event.target.hasAttribute('on')) {
+      const targetEl = dev().assertElement(event.target);
+      this.actions_.trigger(targetEl, 'tap', event, ActionTrust.HIGH);
+    }
+  }
+
+  /**
+   * Toggles the fullbleed UI on scroll.
+   * @private
+   */
+  onScroll_() {
+    let isFullBleed;
+
+    const measurer =
+        () => isFullBleed = this.scrollableEl_./*OK*/scrollTop > 88;
+    const mutator = () => {
+      this.storyConsentEl_
+          .classList.toggle('i-amphtml-story-consent-fullbleed', isFullBleed);
+    };
+
+    this.element.getResources()
+        .measureMutateElement(this.storyConsentEl_, measurer, mutator);
+  }
+
+  /**
+   * Allows the consent related actions.
+   * @private
+   */
+  addActionsToWhitelist_() {
+    dev().assert(this.consentConfig_, `${TAG}: Consent config must be parsed ` +
+        'before adding the actions to the whitelist.');
+
+    const consentIds = Object.keys(this.consentConfig_.consents);
+
+    consentIds.forEach(consentId => {
+      this.actions_.addToWhitelist(`${consentId}.accept`);
+      this.actions_.addToWhitelist(`${consentId}.reject`);
+    });
+  }
+
+  /**
+   * Validates the story-consent config. `story-consent` is a new parameter
+   * specific to stories, added on the `amp-consent` JSON config.
+   * @private
+   */
+  assertAndParseConfig_() {
+    const parentEl = dev().assertElement(this.element.parentElement);
+    const script = childElementByTag(parentEl, 'script');
+    this.consentConfig_ = parseJson(script.textContent);
+
+    const storyConsent = this.consentConfig_['story-consent'];
+
+    user().assert(storyConsent, `${TAG}: story-consent config is required`);
+    user().assertString(
+        storyConsent.title, `${TAG}: story-consent requires a title`);
+    user().assertString(
+        storyConsent.message, `${TAG}: story-consent requires a message`);
+    user().assert(
+        storyConsent.vendors && isArray(storyConsent.vendors),
+        `${TAG}: story-consent requires an array of vendors`);
+  }
+}

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -36,6 +36,7 @@ import {ActionTrust} from '../../../src/action-trust';
 import {AmpStoryAnalytics} from './analytics';
 import {AmpStoryBackground} from './background';
 import {AmpStoryBookend} from './bookend/bookend-element';
+import {AmpStoryConsent} from './amp-story-consent';
 import {AmpStoryCtaLayer} from './amp-story-cta-layer';
 import {AmpStoryGridLayer} from './amp-story-grid-layer';
 import {AmpStoryHint} from './amp-story-hint';
@@ -332,6 +333,7 @@ export class AmpStory extends AMP.BaseElement {
     });
 
     // Disallow all actions in a (standalone) story.
+    // Components then add their own actions.
     const actions = Services.actionServiceForDoc(this.getAmpDoc());
     actions.setWhitelist([]);
   }
@@ -1610,4 +1612,5 @@ AMP.extension('amp-story', '1.0', AMP => {
   AMP.registerElement('amp-story-grid-layer', AmpStoryGridLayer);
   AMP.registerElement('amp-story-cta-layer', AmpStoryCtaLayer);
   AMP.registerElement('amp-story-bookend', AmpStoryBookend);
+  AMP.registerElement('amp-story-consent', AmpStoryConsent);
 });

--- a/extensions/amp-story/1.0/test/test-amp-story-consent.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-consent.js
@@ -1,0 +1,138 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {AmpStoryConsent} from '../amp-story-consent';
+
+describes.realWin('amp-story-consent', {amp: true}, env => {
+  let win;
+  let consentConfigEl;
+  let defaultConfig;
+  let storyConsent;
+  let storyConsentEl;
+
+  const setConfig = config => {
+    consentConfigEl.textContent = JSON.stringify(config);
+  };
+
+  beforeEach(() => {
+    win = env.win;
+
+    defaultConfig = {
+      consents: {ABC: {}},
+      'story-consent': {
+        title: 'Foo title.',
+        message: 'Foo message about the consent.',
+        'vendors': ['Item 1', 'Item 2'],
+      },
+    };
+
+    // Test DOM structure:
+    // <fake-amp-consent>
+    //   <script type="application/json">{JSON Config}</script>
+    //   <amp-story-consent></amp-story-consent>
+    // </fake-amp-consent>
+    const consentEl = win.document.createElement('fake-amp-consent');
+
+    consentConfigEl = win.document.createElement('script');
+    consentConfigEl.setAttribute('type', 'application/json');
+    setConfig(defaultConfig);
+
+    storyConsentEl = win.document.createElement('amp-story-consent');
+
+    consentEl.appendChild(consentConfigEl);
+    consentEl.appendChild(storyConsentEl);
+    win.document.body.appendChild(consentEl);
+
+    storyConsent = new AmpStoryConsent(storyConsentEl);
+  });
+
+  it('should parse the config', () => {
+    storyConsent.buildCallback();
+    expect(storyConsent.consentConfig_).to.deep.equal(defaultConfig);
+  });
+
+  it('should require a story-consent title', () => {
+    delete defaultConfig['story-consent'].title;
+    setConfig(defaultConfig);
+
+    allowConsoleError(() => {
+      expect(() => {
+        storyConsent.buildCallback();
+      }).to.throw('story-consent requires a title');
+    });
+  });
+
+  it('should require a story-consent message', () => {
+    delete defaultConfig['story-consent'].message;
+    setConfig(defaultConfig);
+
+    allowConsoleError(() => {
+      expect(() => {
+        storyConsent.buildCallback();
+      }).to.throw('story-consent requires a message');
+    });
+  });
+
+  it('should require a story-consent vendors', () => {
+    delete defaultConfig['story-consent'].vendors;
+    setConfig(defaultConfig);
+
+    allowConsoleError(() => {
+      expect(() => {
+        storyConsent.buildCallback();
+      }).to.throw('story-consent requires an array of vendors');
+    });
+  });
+
+  it('should require a story-consent vendors of type array', () => {
+    defaultConfig['story-consent'].vendors = 'foo';
+    setConfig(defaultConfig);
+
+    allowConsoleError(() => {
+      expect(() => {
+        storyConsent.buildCallback();
+      }).to.throw('story-consent requires an array of vendors');
+    });
+  });
+
+  it('should whitelist the amp actions using the expected consent ID', () => {
+    const addToWhitelistStub =
+        sandbox.stub(storyConsent.actions_, 'addToWhitelist');
+
+    storyConsent.buildCallback();
+
+    expect(addToWhitelistStub).to.have.been.calledTwice;
+    expect(addToWhitelistStub).to.have.been.calledWith('ABC.accept');
+    expect(addToWhitelistStub).to.have.been.calledWith('ABC.reject');
+  });
+
+  it('should broadcast the amp actions', () => {
+    sandbox.stub(storyConsent.actions_, 'trigger');
+
+    storyConsent.buildCallback();
+
+    // Builds and appends a fake button directly in the storyConsent Shadow DOM.
+    const buttonEl = win.document.createElement('button');
+    buttonEl.setAttribute('on', 'tap:ABC.accept');
+    storyConsent.storyConsentEl_.appendChild(buttonEl);
+
+    const clickEvent = new Event('click');
+    buttonEl.dispatchEvent(clickEvent);
+
+    expect(storyConsent.actions_.trigger).to.have.been.calledOnce;
+    expect(storyConsent.actions_.trigger).to.have.been.calledWith(buttonEl);
+  });
+});

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -165,6 +165,7 @@ declareExtension('amp-story', '1.0', {
   hasCss: true,
   cssBinaries: [
     'amp-story-bookend',
+    'amp-story-consent',
     'amp-story-hint',
     'amp-story-unsupported-browser-layer',
     'amp-story-viewport-warning-layer',

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -444,6 +444,18 @@ export class ActionService {
   }
 
   /**
+   * Adds an action to the whitelist. Takes one string of the form
+   * "<targetType>.<method>", e.g. "amp-form.submit" or "AMP.print".
+   * @param {string} action
+   */
+  addToWhitelist(action) {
+    if (!this.whitelist_) {
+      this.whitelist_ = [];
+    }
+    this.whitelist_.push(action);
+  }
+
+  /**
    * @param {!Element} source
    * @param {string} actionEventType
    * @param {?ActionEventDef} event

--- a/test/functional/test-action.js
+++ b/test/functional/test-action.js
@@ -1363,4 +1363,12 @@ describes.realWin('whitelist', {
           '(AMP.pushState,AMP.setState).');
     });
   });
+
+  it('should allow adding actions to the whitelist', () => {
+    const i = new ActionInvocation(target, 'print', /* args */ null,
+        'source', 'caller', 'event', 0, 'AMP');
+    action.addToWhitelist('AMP.print');
+    action.invoke_(i);
+    expect(target.enqueAction).to.be.calledWithExactly(i);
+  });
 });


### PR DESCRIPTION
This PR introduces a new ``<amp-story-consent>`` component. It has to be nested in the ``<amp-consent>`` component, and provides a UI stories publishers can use.
Publishers can provide the content and a main color to this component through the JSON config provided to ``<amp-consent>``, by adding a new ``story-consent`` property. This property accepts a ``title``, a ``message``, an array of ``vendors``, and an optional ``color`` to tweak the UI.

## Usage:

````
  <amp-consent>
   <script type='application/json'>{
     “consents”: {
        “consentInstanceABC”: {
           “checkConsentHref”: “endpointABC.com”,
           “promptUI”: “template1”
         },
      },
     “story-consent”: {
         “title”: "Foo",
         “message”: "Bar",
         “vendors”: ["Item 1", "Item 2", "Item 3", "Item 4"],
         “color”: "#0379c4"
     }
   }</script>
   <amp-story-consent id=”template1”></amp-story-consent>
 </amp-consent>
````

Partial for #14538
