### PR TITLE
🏗 Add `gulp bundle-size` + assorted improvements

### DIFF
--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -294,8 +294,15 @@ const command = {
   buildRuntime: function() {
     timedExecOrDie('gulp build');
   },
-  buildRuntimeMinified: function() {
-    timedExecOrDie('gulp dist --fortesting');
+  buildRuntimeMinified: function(extensions) {
+    let cmd = 'gulp dist --fortesting';
+    if (!extensions) {
+      cmd = cmd + ' --noextensions';
+    }
+    timedExecOrDie(cmd);
+  },
+  runBundleSizeCheck: function() {
+    timedExecOrDie('gulp bundle-size');
   },
   runDepAndTypeChecks: function() {
     timedExecOrDie('gulp dep-check');
@@ -401,7 +408,8 @@ function runAllCommands() {
   }
   if (process.env.BUILD_SHARD == 'integration_tests') {
     command.cleanBuild();
-    command.buildRuntimeMinified();
+    command.buildRuntimeMinified(/* extensions */ true);
+    command.runBundleSizeCheck();
     command.runPresubmitTests();
     command.runIntegrationTests(/* compiled */ true);
   }
@@ -419,6 +427,8 @@ function runAllCommandsLocally() {
   if (!argv.nobuild) {
     command.cleanBuild();
     command.buildRuntime();
+    command.buildRuntimeMinified(/* extensions */ false);
+    command.runBundleSizeCheck();
   }
 
   // These tests need a build.
@@ -602,6 +612,8 @@ function main() {
         buildTargets.has('VISUAL_DIFF')) {
       command.cleanBuild();
       command.buildRuntime();
+      command.buildRuntimeMinified(/* extensions */ false);
+      command.runBundleSizeCheck();
       command.runVisualDiffTests();
     } else {
       // Generates a blank Percy build to satisfy the required Github check.

--- a/build-system/tasks/bundle-size.js
+++ b/build-system/tasks/bundle-size.js
@@ -21,7 +21,7 @@ const gulp = require('gulp-help')(require('gulp'));
 const log = require('fancy-log');
 
 const runtimeFile = './dist/v0.js';
-const maxSize = '77.05KB';
+const maxSize = '77.15KB';
 
 const green = colors.green;
 const red = colors.red;

--- a/build-system/tasks/bundle-size.js
+++ b/build-system/tasks/bundle-size.js
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+const colors = require('ansi-colors');
+const getStdout = require('../exec').getStdout;
+const gulp = require('gulp-help')(require('gulp'));
+const log = require('fancy-log');
+
+const runtimeFile = './dist/v0.js';
+const maxSize = '77.05KB';
+
+const green = colors.green;
+const red = colors.red;
+const cyan = colors.cyan;
+const yellow = colors.yellow;
+
+
+function checkBundleSize() {
+  const cmd = `npx bundlesize -f "${runtimeFile}" -s "${maxSize}"`;
+  log('Running ' + cyan(cmd) + '...');
+  const output = getStdout(cmd);
+  const pass = output.match(/PASS .*/);
+  const fail = output.match(/FAIL .*/);
+  const error = output.match(/ERROR .*/);
+  if (error) {
+    log(yellow(error));
+    if (!process.env.TRAVIS) {
+      log(yellow('You must run'), cyan('gulp dist'),
+          yellow('before running this task.'));
+    }
+  } else if (fail) {
+    log(red(fail));
+    log(red('ERROR:'), cyan('bundlesize'), red('found that'),
+        cyan(runtimeFile), red('has exceeded its size cap of'),
+        cyan(maxSize) + red('.'));
+    log(red(
+        'This is part of a new effort to reduce AMP\'s binary size (#14392).'));
+    log(red('Please contact @choumx or @jridgewell for assistance.'));
+    process.exitCode = 1;
+  } else if (pass) {
+    log(green(pass));
+  } else {
+    log(yellow(output));
+  }
+}
+
+
+gulp.task(
+    'bundle-size',
+    'Checks if the minified AMP binary has exceeded its size cap',
+    checkBundleSize);

--- a/build-system/tasks/index.js
+++ b/build-system/tasks/index.js
@@ -16,6 +16,7 @@
 'use strict';
 
 require('./ava');
+require('./bundle-size');
 require('./changelog');
 require('./check-links');
 require('./clean');


### PR DESCRIPTION
This PR does a few things:
1. Adds a new task `gulp bundle-size`
2. Cleans up `bundlesize` logging and adds actionable error messages
3. Silences the [annoying warning](https://travis-ci.org/ampproject/amphtml/jobs/374596886#L641-L645) about GitHub PR integration for `bundlesize` (not possible due to https://github.com/siddharthkp/bundlesize/issues/219)
4. For PR builds, runs `gulp dist --fortesting --noextensions` and `gulp bundle-size`
5. For push builds, adds a call to `gulp bundle-size` (we already run `gulp dist --fortesting`)
6. Bumps up the size cap, because guess what... this PR got blocked by the old size cap 😒

With this, we should greatly reduce the [noise](https://gist.github.com/rsimha/412f9494f55f4bde3aca9554c14d7646) on `master` due to failing size checks that haven't been able to do anything about until now.

This will still result in failures when there is a race between two commits to `master` that change the AMP bundle size, but that's a problem that needs to be solved separately (by rebasing PRs on `HEAD` before testing / merging them).

Fixes #14394