### PR TITLE
🏗 Switch from VMs to Container-based images on Travis (don't use `sudo`) (Redux)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-sudo: required  # See http://docs.travis-ci.com/user/trusty-ci-environment/
+sudo: false  # See http://docs.travis-ci.com/user/trusty-ci-environment/
 dist: trusty
 node_js:
   - "lts/*"

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -376,7 +376,7 @@ const command = {
           '. Skipping verification of visual diff tests.');
       return;
     }
-    timedExec('gulp visual-diff --puppeteer --verify');
+    timedExec('gulp visual-diff --puppeteer --verify_status');
   },
   runPresubmitTests: function() {
     timedExecOrDie('gulp presubmit');

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -352,7 +352,7 @@ const command = {
           colors.cyan('PERCY_TOKEN') + '. Skipping visual diff tests.');
       return;
     }
-    let cmd = 'gulp visual-diff --headless';
+    let cmd = 'gulp visual-diff --puppeteer --headless';
     if (opt_mode === 'skip') {
       cmd += ' --skip';
     } else if (opt_mode === 'master') {
@@ -376,7 +376,7 @@ const command = {
           '. Skipping verification of visual diff tests.');
       return;
     }
-    timedExec('gulp visual-diff --verify');
+    timedExec('gulp visual-diff --puppeteer --verify');
   },
   runPresubmitTests: function() {
     timedExecOrDie('gulp presubmit');

--- a/build-system/tasks/visual-diff.js
+++ b/build-system/tasks/visual-diff.js
@@ -498,7 +498,7 @@ async function createEmptyBuild(page) {
  * Simple wrapper around the JS (Percy-Puppeteer) based visual diff tests.
  */
 async function visualDiffPuppeteer() {
-  if (argv.verify) {
+  if (argv.verify_status) {
     const buildId = fs.readFileSync('PERCY_BUILD_ID', 'utf8');
     const status = await waitForBuildCompletion(buildId);
     verifyBuildStatus(status, buildId);
@@ -571,7 +571,8 @@ gulp.task(
     {
       options: {
         'master': '  Includes a blank snapshot (baseline for skipped builds)',
-        'verify': '  Verifies the status of the build ID in ./PERCY_BUILD_ID',
+        'verify_status':
+          '  Verifies the status of the build ID in ./PERCY_BUILD_ID',
         'skip': '  Creates a dummy Percy build with only a blank snapshot',
         'headless': '  Runs Chrome in headless mode',
         'percy_debug': '  Prints debug info from Percy-Capybara libraries',

--- a/build-system/tasks/visual-diff.rb
+++ b/build-system/tasks/visual-diff.rb
@@ -504,7 +504,7 @@ end
 
 # Launches a webserver, loads test pages, and generates Percy snapshots.
 def main
-  if ARGV.include? '--verify'
+  if ARGV.include? '--verify_status'
     build_id = File.open('PERCY_BUILD_ID', 'r').read
     status = wait_for_build_completion(build_id)
     verify_build_status(status, build_id)


### PR DESCRIPTION
This was explored last year in #9651, but we had to revert because builds and tests [took longer](https://github.com/ampproject/amphtml/pull/9666#issuecomment-306233088) on Container-based images.

Now that we no longer install Chrome, but use the `chrome` addon on Travis, and now that our builds and tests have significantly changed since last year, let's try once again and see how things go this time.
