### PR TITLE
🏗 Use npx when executing commands

### DIFF
--- a/build-system/check-package-manager.js
+++ b/build-system/check-package-manager.js
@@ -122,8 +122,8 @@ function performNodeVersionCheck(latestLtsVersion) {
 
 // If yarn is being run, perform a version check and proceed with the install.
 function performYarnVersionCheck() {
-  const yarnVersion = getStdout('yarn --version').trim();
-  const yarnInfo = getStdout('yarn info --json yarn').trim();
+  const yarnVersion = getStdout('npx yarn --version').trim();
+  const yarnInfo = getStdout('npx yarn info --json yarn').trim();
   const yarnInfoJson = JSON.parse(yarnInfo.split('\n')[0]); // First line
   const stableVersion = getYarnStableVersion(yarnInfoJson);
   if (stableVersion === '') {

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -437,7 +437,7 @@ function runAllCommandsLocally() {
  * Makes sure package.json and yarn.lock are in sync.
  */
 function runYarnIntegrityCheck() {
-  const yarnIntegrityCheck = getStderr('yarn check --integrity').trim();
+  const yarnIntegrityCheck = getStderr('npx yarn check --integrity').trim();
   if (yarnIntegrityCheck.includes('error')) {
     console.error(fileLogPrefix, colors.red('ERROR:'),
         'Found the following', colors.cyan('yarn'), 'errors:\n' +


### PR DESCRIPTION
This allows you to avoid installing yarn globally.