### PR TITLE
🐛 Make the use of `compact` mode for `babelify` consistent across all file sizes

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1142,6 +1142,7 @@ function compileJs(srcDir, srcFilename, destDir, options) {
   const startTime = Date.now();
   let bundler = browserify(entryPoint, {debug: true})
       .transform(babelify, {
+        compact: false,
         presets: [
           ['env', {
             targets: {


### PR DESCRIPTION
The default value of the `compact` option for `babelify` is `'auto'`, which treats files smaller than 500KB differently from those larger than 500KB. According to https://babeljs.io/docs/usage/api/, files smaller than 500KB use `compact == false` while those above 500KB use `compact == true`.

Due to the large size of [third_party/react-dates/bundle.js](https://github.com/ampproject/amphtml/blob/master/third_party/react-dates/bundle.js), we see this warning during `gulp build` and `gulp test`:

> Note: The code generator has deoptimised the styling of "/home/travis/build/ampproject/amphtml/third_party/react-dates/bundle.js" as it exceeds the max of "500KB".



This PR eliminates the warning by setting `compact`  to `false` during `babelify` for all files. (This is what we've always used for `dist/amp.js`.) It should be a no-op for `third_party/react-dates/bundle.js`, since the file is already compacted.

Fixes #14831
