### PR TITLE
Force set amp-lightbox-gallery buttons to content-box sizing

### DIFF
--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.css
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.css
@@ -87,6 +87,7 @@ amp-lightbox-gallery .amp-carousel-button {
   width: 24px;
   height: 24px;
   padding: 16px;
+  box-sizing: content-box;
 }
 
 .i-amphtml-lbg {

--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.css
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.css
@@ -32,7 +32,7 @@ amp-lightbox-gallery .amp-carousel-button {
 }
 
 .i-amphtml-lbg-button-close .i-amphtml-lbg-icon {
-  background-image: url('data:image/svg+xml;charset=utf-8,<svg viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd"><g id="close" fill="#fff" fill-rule="nonzero"><path d="M18.295,5.705 L18.295,5.705 C17.9056393,5.31563925 17.2743607,5.31563925 16.885,5.705 L12,10.59 L7.115,5.705 C6.72563925,5.31563925 6.09436075,5.31563925 5.705,5.705 L5.705,5.705 C5.31563925,6.09436075 5.31563925,6.72563925 5.705,7.115 L10.59,12 L5.705,16.885 C5.31563925,17.2743607 5.31563925,17.9056393 5.705,18.295 L5.705,18.295 C6.09436075,18.6843607 6.72563925,18.6843607 7.115,18.295 L12,13.41 L16.885,18.295 C17.2743607,18.6843607 17.9056393,18.6843607 18.295,18.295 L18.295,18.295 C18.6843607,17.9056393 18.6843607,17.2743607 18.295,16.885 L13.41,12 L18.295,7.115 C18.6843607,6.72563925 18.6843607,6.09436075 18.295,5.705 Z" id="Shape"></path></g></g></svg>');
+  background-image: url("data:image/svg+xml;charset=utf-8,<svg viewBox='0 0 24 24' version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink'><g stroke='none' stroke-width='1' fill='none' fill-rule='evenodd'><g id='close' fill='#fff' fill-rule='nonzero'><path d='M18.295,5.705 L18.295,5.705 C17.9056393,5.31563925 17.2743607,5.31563925 16.885,5.705 L12,10.59 L7.115,5.705 C6.72563925,5.31563925 6.09436075,5.31563925 5.705,5.705 L5.705,5.705 C5.31563925,6.09436075 5.31563925,6.72563925 5.705,7.115 L10.59,12 L5.705,16.885 C5.31563925,17.2743607 5.31563925,17.9056393 5.705,18.295 L5.705,18.295 C6.09436075,18.6843607 6.72563925,18.6843607 7.115,18.295 L12,13.41 L16.885,18.295 C17.2743607,18.6843607 17.9056393,18.6843607 18.295,18.295 L18.295,18.295 C18.6843607,17.9056393 18.6843607,17.2743607 18.295,16.885 L13.41,12 L18.295,7.115 C18.6843607,6.72563925 18.6843607,6.09436075 18.295,5.705 Z' id='Shape'></path></g></g></svg>");
 }
 
 .i-amphtml-lbg-button-gallery {
@@ -41,7 +41,7 @@ amp-lightbox-gallery .amp-carousel-button {
 }
 
 .i-amphtml-lbg-button-gallery .i-amphtml-lbg-icon {
-  background-image: url('data:image/svg+xml;charset=utf-8,<svg viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd"><g id="grid" fill="#fff"><path d="M4,3 L8,3 C8.55228475,3 9,3.44771525 9,4 L9,10 C9,10.5522847 8.55228475,11 8,11 L4,11 C3.44771525,11 3,10.5522847 3,10 L3,4 C3,3.44771525 3.44771525,3 4,3 Z M12,3 L20,3 C20.5522847,3 21,3.44771525 21,4 L21,10 C21,10.5522847 20.5522847,11 20,11 L12,11 C11.4477153,11 11,10.5522847 11,10 L11,4 C11,3.44771525 11.4477153,3 12,3 Z M4,13 L12,13 C12.5522847,13 13,13.4477153 13,14 L13,20 C13,20.5522847 12.5522847,21 12,21 L4,21 C3.44771525,21 3,20.5522847 3,20 L3,14 C3,13.4477153 3.44771525,13 4,13 Z M16,13 L20,13 C20.5522847,13 21,13.4477153 21,14 L21,20 C21,20.5522847 20.5522847,21 20,21 L16,21 C15.4477153,21 15,20.5522847 15,20 L15,14 C15,13.4477153 15.4477153,13 16,13 Z" id="Combined-Shape"></path></g></g></svg>');
+  background-image: url("data:image/svg+xml;charset=utf-8,<svg viewBox='0 0 24 24' version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink'><g stroke='none' stroke-width='1' fill='none' fill-rule='evenodd'><g id='grid' fill='#fff'><path d='M4,3 L8,3 C8.55228475,3 9,3.44771525 9,4 L9,10 C9,10.5522847 8.55228475,11 8,11 L4,11 C3.44771525,11 3,10.5522847 3,10 L3,4 C3,3.44771525 3.44771525,3 4,3 Z M12,3 L20,3 C20.5522847,3 21,3.44771525 21,4 L21,10 C21,10.5522847 20.5522847,11 20,11 L12,11 C11.4477153,11 11,10.5522847 11,10 L11,4 C11,3.44771525 11.4477153,3 12,3 Z M4,13 L12,13 C12.5522847,13 13,13.4477153 13,14 L13,20 C13,20.5522847 12.5522847,21 12,21 L4,21 C3.44771525,21 3,20.5522847 3,20 L3,14 C3,13.4477153 3.44771525,13 4,13 Z M16,13 L20,13 C20.5522847,13 21,13.4477153 21,14 L21,20 C21,20.5522847 20.5522847,21 20,21 L16,21 C15.4477153,21 15,20.5522847 15,20 L15,14 C15,13.4477153 15.4477153,13 16,13 Z' id='Combined-Shape'></path></g></g></svg>");
 }
 
 .i-amphtml-lbg-button-slide {
@@ -51,7 +51,7 @@ amp-lightbox-gallery .amp-carousel-button {
 }
 
 .i-amphtml-lbg-button-slide .i-amphtml-lbg-icon {
-  background-image: url('data:image/svg+xml;charset=utf-8,<svg viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd"><g id="image" fill="#fff"><path d="M5,3 L19,3 C20.1045695,3 21,3.8954305 21,5 L21,19 C21,20.1045695 20.1045695,21 19,21 L5,21 C3.8954305,21 3,20.1045695 3,19 L3,5 C3,3.8954305 3.8954305,3 5,3 Z M19,15 L19,5 L5,5 L5,13.0000896 L8,10.0003584 L13,15 L16,12 L19,15 Z M15.5,10 C14.6715729,10 14,9.32842712 14,8.5 C14,7.67157288 14.6715729,7 15.5,7 C16.3284271,7 17,7.67157288 17,8.5 C17,9.32842712 16.3284271,10 15.5,10 Z" id="Combined-Shape"></path></g></g></svg>');
+  background-image: url("data:image/svg+xml;charset=utf-8,<svg viewBox='0 0 24 24' version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink'><g stroke='none' stroke-width='1' fill='none' fill-rule='evenodd'><g id='image' fill='#fff'><path d='M5,3 L19,3 C20.1045695,3 21,3.8954305 21,5 L21,19 C21,20.1045695 20.1045695,21 19,21 L5,21 C3.8954305,21 3,20.1045695 3,19 L3,5 C3,3.8954305 3.8954305,3 5,3 Z M19,15 L19,5 L5,5 L5,13.0000896 L8,10.0003584 L13,15 L16,12 L19,15 Z M15.5,10 C14.6715729,10 14,9.32842712 14,8.5 C14,7.67157288 14.6715729,7 15.5,7 C16.3284271,7 17,7.67157288 17,8.5 C17,9.32842712 16.3284271,10 15.5,10 Z' id='Combined-Shape'></path></g></g></svg>");
 }
 
 .i-amphtml-lbg-button.i-amphtml-lbg-button-next,
@@ -70,7 +70,7 @@ amp-lightbox-gallery .amp-carousel-button {
 }
 
 .i-amphtml-lbg-button-next .i-amphtml-lbg-icon {
-  background-image: url('data:image/svg+xml;charset=utf-8,<svg viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><defs></defs><g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd"><g id="arrow_right_03" fill="#ffffff"><path d="M7.75,9.75 L7.75,15.25 C7.75,15.8022847 7.30228475,16.25 6.75,16.25 C6.19771525,16.25 5.75,15.8022847 5.75,15.25 L5.75,8.75 C5.75,8.19771525 6.19771525,7.75 6.75,7.75 L13.25,7.75 C13.8022847,7.75 14.25,8.19771525 14.25,8.75 C14.25,9.30228475 13.8022847,9.75 13.25,9.75 L7.75,9.75 Z" id="Combined-Shape" transform="translate(10.000000, 12.000000) rotate(-225.000000) translate(-10.000000, -12.000000) "></path></g></g></svg>');
+  background-image: url("data:image/svg+xml;charset=utf-8,<svg viewBox='0 0 24 24' version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink'><defs></defs><g stroke='none' stroke-width='1' fill='none' fill-rule='evenodd'><g id='arrow_right_03' fill='#ffffff'><path d='M7.75,9.75 L7.75,15.25 C7.75,15.8022847 7.30228475,16.25 6.75,16.25 C6.19771525,16.25 5.75,15.8022847 5.75,15.25 L5.75,8.75 C5.75,8.19771525 6.19771525,7.75 6.75,7.75 L13.25,7.75 C13.8022847,7.75 14.25,8.19771525 14.25,8.75 C14.25,9.30228475 13.8022847,9.75 13.25,9.75 L7.75,9.75 Z' id='Combined-Shape' transform='translate(10.000000, 12.000000) rotate(-225.000000) translate(-10.000000, -12.000000) '></path></g></g></svg>");
 }
 
 .i-amphtml-lbg-button-prev {
@@ -78,7 +78,7 @@ amp-lightbox-gallery .amp-carousel-button {
 }
 
 .i-amphtml-lbg-button-prev .i-amphtml-lbg-icon {
-  background-image: url('data:image/svg+xml;charset=utf-8,<svg viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd"><g id="arrow_left_03" fill="#ffffff"><path d="M11.7604076,9.75 L11.7604076,15.25 C11.7604076,15.8022847 11.3126924,16.25 10.7604076,16.25 C10.2081229,16.25 9.76040764,15.8022847 9.76040764,15.25 L9.76040764,8.75 C9.76040764,8.19771525 10.2081229,7.75 10.7604076,7.75 L17.2604076,7.75 C17.8126924,7.75 18.2604076,8.19771525 18.2604076,8.75 C18.2604076,9.30228475 17.8126924,9.75 17.2604076,9.75 L11.7604076,9.75 Z" id="Combined-Shape" transform="translate(14.010408, 12.000000) rotate(-45.000000) translate(-14.010408, -12.000000) "></path></g></g></svg>');
+  background-image: url("data:image/svg+xml;charset=utf-8,<svg viewBox='0 0 24 24' version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink'><g stroke='none' stroke-width='1' fill='none' fill-rule='evenodd'><g id='arrow_left_03' fill='#ffffff'><path d='M11.7604076,9.75 L11.7604076,15.25 C11.7604076,15.8022847 11.3126924,16.25 10.7604076,16.25 C10.2081229,16.25 9.76040764,15.8022847 9.76040764,15.25 L9.76040764,8.75 C9.76040764,8.19771525 10.2081229,7.75 10.7604076,7.75 L17.2604076,7.75 C17.8126924,7.75 18.2604076,8.19771525 18.2604076,8.75 C18.2604076,9.30228475 17.8126924,9.75 17.2604076,9.75 L11.7604076,9.75 Z' id='Combined-Shape' transform='translate(14.010408, 12.000000) rotate(-45.000000) translate(-14.010408, -12.000000) '></path></g></g></svg>");
 }
 
 .i-amphtml-lbg-button {
@@ -253,7 +253,7 @@ amp-lightbox-gallery .amp-carousel-button {
 }
 
 .i-amphtml-lbg-thumbnail-play-icon {
-  background-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#ffffff"><path d="M8 5v14l11-7z"/><path d="M0 0h24v24H0z" fill="none"/></svg>');
+  background-image: url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='#ffffff'><path d='M8 5v14l11-7z'/><path d='M0 0h24v24H0z' fill='none'/></svg>");
   height: 16px;
   width: 16px;
   position: absolute;

--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.css
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.css
@@ -32,7 +32,7 @@ amp-lightbox-gallery .amp-carousel-button {
 }
 
 .i-amphtml-lbg-button-close .i-amphtml-lbg-icon {
-  background-image: url("data:image/svg+xml;charset=utf-8,<svg viewBox='0 0 24 24' version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink'><g stroke='none' stroke-width='1' fill='none' fill-rule='evenodd'><g id='close' fill='#fff' fill-rule='nonzero'><path d='M18.295,5.705 L18.295,5.705 C17.9056393,5.31563925 17.2743607,5.31563925 16.885,5.705 L12,10.59 L7.115,5.705 C6.72563925,5.31563925 6.09436075,5.31563925 5.705,5.705 L5.705,5.705 C5.31563925,6.09436075 5.31563925,6.72563925 5.705,7.115 L10.59,12 L5.705,16.885 C5.31563925,17.2743607 5.31563925,17.9056393 5.705,18.295 L5.705,18.295 C6.09436075,18.6843607 6.72563925,18.6843607 7.115,18.295 L12,13.41 L16.885,18.295 C17.2743607,18.6843607 17.9056393,18.6843607 18.295,18.295 L18.295,18.295 C18.6843607,17.9056393 18.6843607,17.2743607 18.295,16.885 L13.41,12 L18.295,7.115 C18.6843607,6.72563925 18.6843607,6.09436075 18.295,5.705 Z' id='Shape'></path></g></g></svg>");
+  background-image: url('data:image/svg+xml;charset=utf-8,<svg viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd"><g id="close" fill="#fff" fill-rule="nonzero"><path d="M18.295,5.705 L18.295,5.705 C17.9056393,5.31563925 17.2743607,5.31563925 16.885,5.705 L12,10.59 L7.115,5.705 C6.72563925,5.31563925 6.09436075,5.31563925 5.705,5.705 L5.705,5.705 C5.31563925,6.09436075 5.31563925,6.72563925 5.705,7.115 L10.59,12 L5.705,16.885 C5.31563925,17.2743607 5.31563925,17.9056393 5.705,18.295 L5.705,18.295 C6.09436075,18.6843607 6.72563925,18.6843607 7.115,18.295 L12,13.41 L16.885,18.295 C17.2743607,18.6843607 17.9056393,18.6843607 18.295,18.295 L18.295,18.295 C18.6843607,17.9056393 18.6843607,17.2743607 18.295,16.885 L13.41,12 L18.295,7.115 C18.6843607,6.72563925 18.6843607,6.09436075 18.295,5.705 Z" id="Shape"></path></g></g></svg>');
 }
 
 .i-amphtml-lbg-button-gallery {
@@ -41,7 +41,7 @@ amp-lightbox-gallery .amp-carousel-button {
 }
 
 .i-amphtml-lbg-button-gallery .i-amphtml-lbg-icon {
-  background-image: url("data:image/svg+xml;charset=utf-8,<svg viewBox='0 0 24 24' version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink'><g stroke='none' stroke-width='1' fill='none' fill-rule='evenodd'><g id='grid' fill='#fff'><path d='M4,3 L8,3 C8.55228475,3 9,3.44771525 9,4 L9,10 C9,10.5522847 8.55228475,11 8,11 L4,11 C3.44771525,11 3,10.5522847 3,10 L3,4 C3,3.44771525 3.44771525,3 4,3 Z M12,3 L20,3 C20.5522847,3 21,3.44771525 21,4 L21,10 C21,10.5522847 20.5522847,11 20,11 L12,11 C11.4477153,11 11,10.5522847 11,10 L11,4 C11,3.44771525 11.4477153,3 12,3 Z M4,13 L12,13 C12.5522847,13 13,13.4477153 13,14 L13,20 C13,20.5522847 12.5522847,21 12,21 L4,21 C3.44771525,21 3,20.5522847 3,20 L3,14 C3,13.4477153 3.44771525,13 4,13 Z M16,13 L20,13 C20.5522847,13 21,13.4477153 21,14 L21,20 C21,20.5522847 20.5522847,21 20,21 L16,21 C15.4477153,21 15,20.5522847 15,20 L15,14 C15,13.4477153 15.4477153,13 16,13 Z' id='Combined-Shape'></path></g></g></svg>");
+  background-image: url('data:image/svg+xml;charset=utf-8,<svg viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd"><g id="grid" fill="#fff"><path d="M4,3 L8,3 C8.55228475,3 9,3.44771525 9,4 L9,10 C9,10.5522847 8.55228475,11 8,11 L4,11 C3.44771525,11 3,10.5522847 3,10 L3,4 C3,3.44771525 3.44771525,3 4,3 Z M12,3 L20,3 C20.5522847,3 21,3.44771525 21,4 L21,10 C21,10.5522847 20.5522847,11 20,11 L12,11 C11.4477153,11 11,10.5522847 11,10 L11,4 C11,3.44771525 11.4477153,3 12,3 Z M4,13 L12,13 C12.5522847,13 13,13.4477153 13,14 L13,20 C13,20.5522847 12.5522847,21 12,21 L4,21 C3.44771525,21 3,20.5522847 3,20 L3,14 C3,13.4477153 3.44771525,13 4,13 Z M16,13 L20,13 C20.5522847,13 21,13.4477153 21,14 L21,20 C21,20.5522847 20.5522847,21 20,21 L16,21 C15.4477153,21 15,20.5522847 15,20 L15,14 C15,13.4477153 15.4477153,13 16,13 Z" id="Combined-Shape"></path></g></g></svg>');
 }
 
 .i-amphtml-lbg-button-slide {
@@ -51,7 +51,7 @@ amp-lightbox-gallery .amp-carousel-button {
 }
 
 .i-amphtml-lbg-button-slide .i-amphtml-lbg-icon {
-  background-image: url("data:image/svg+xml;charset=utf-8,<svg viewBox='0 0 24 24' version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink'><g stroke='none' stroke-width='1' fill='none' fill-rule='evenodd'><g id='image' fill='#fff'><path d='M5,3 L19,3 C20.1045695,3 21,3.8954305 21,5 L21,19 C21,20.1045695 20.1045695,21 19,21 L5,21 C3.8954305,21 3,20.1045695 3,19 L3,5 C3,3.8954305 3.8954305,3 5,3 Z M19,15 L19,5 L5,5 L5,13.0000896 L8,10.0003584 L13,15 L16,12 L19,15 Z M15.5,10 C14.6715729,10 14,9.32842712 14,8.5 C14,7.67157288 14.6715729,7 15.5,7 C16.3284271,7 17,7.67157288 17,8.5 C17,9.32842712 16.3284271,10 15.5,10 Z' id='Combined-Shape'></path></g></g></svg>");
+  background-image: url('data:image/svg+xml;charset=utf-8,<svg viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd"><g id="image" fill="#fff"><path d="M5,3 L19,3 C20.1045695,3 21,3.8954305 21,5 L21,19 C21,20.1045695 20.1045695,21 19,21 L5,21 C3.8954305,21 3,20.1045695 3,19 L3,5 C3,3.8954305 3.8954305,3 5,3 Z M19,15 L19,5 L5,5 L5,13.0000896 L8,10.0003584 L13,15 L16,12 L19,15 Z M15.5,10 C14.6715729,10 14,9.32842712 14,8.5 C14,7.67157288 14.6715729,7 15.5,7 C16.3284271,7 17,7.67157288 17,8.5 C17,9.32842712 16.3284271,10 15.5,10 Z" id="Combined-Shape"></path></g></g></svg>');
 }
 
 .i-amphtml-lbg-button.i-amphtml-lbg-button-next,
@@ -70,7 +70,7 @@ amp-lightbox-gallery .amp-carousel-button {
 }
 
 .i-amphtml-lbg-button-next .i-amphtml-lbg-icon {
-  background-image: url("data:image/svg+xml;charset=utf-8,<svg viewBox='0 0 24 24' version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink'><defs></defs><g stroke='none' stroke-width='1' fill='none' fill-rule='evenodd'><g id='arrow_right_03' fill='#ffffff'><path d='M7.75,9.75 L7.75,15.25 C7.75,15.8022847 7.30228475,16.25 6.75,16.25 C6.19771525,16.25 5.75,15.8022847 5.75,15.25 L5.75,8.75 C5.75,8.19771525 6.19771525,7.75 6.75,7.75 L13.25,7.75 C13.8022847,7.75 14.25,8.19771525 14.25,8.75 C14.25,9.30228475 13.8022847,9.75 13.25,9.75 L7.75,9.75 Z' id='Combined-Shape' transform='translate(10.000000, 12.000000) rotate(-225.000000) translate(-10.000000, -12.000000) '></path></g></g></svg>");
+  background-image: url('data:image/svg+xml;charset=utf-8,<svg viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><defs></defs><g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd"><g id="arrow_right_03" fill="#ffffff"><path d="M7.75,9.75 L7.75,15.25 C7.75,15.8022847 7.30228475,16.25 6.75,16.25 C6.19771525,16.25 5.75,15.8022847 5.75,15.25 L5.75,8.75 C5.75,8.19771525 6.19771525,7.75 6.75,7.75 L13.25,7.75 C13.8022847,7.75 14.25,8.19771525 14.25,8.75 C14.25,9.30228475 13.8022847,9.75 13.25,9.75 L7.75,9.75 Z" id="Combined-Shape" transform="translate(10.000000, 12.000000) rotate(-225.000000) translate(-10.000000, -12.000000) "></path></g></g></svg>');
 }
 
 .i-amphtml-lbg-button-prev {
@@ -78,7 +78,7 @@ amp-lightbox-gallery .amp-carousel-button {
 }
 
 .i-amphtml-lbg-button-prev .i-amphtml-lbg-icon {
-  background-image: url("data:image/svg+xml;charset=utf-8,<svg viewBox='0 0 24 24' version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink'><g stroke='none' stroke-width='1' fill='none' fill-rule='evenodd'><g id='arrow_left_03' fill='#ffffff'><path d='M11.7604076,9.75 L11.7604076,15.25 C11.7604076,15.8022847 11.3126924,16.25 10.7604076,16.25 C10.2081229,16.25 9.76040764,15.8022847 9.76040764,15.25 L9.76040764,8.75 C9.76040764,8.19771525 10.2081229,7.75 10.7604076,7.75 L17.2604076,7.75 C17.8126924,7.75 18.2604076,8.19771525 18.2604076,8.75 C18.2604076,9.30228475 17.8126924,9.75 17.2604076,9.75 L11.7604076,9.75 Z' id='Combined-Shape' transform='translate(14.010408, 12.000000) rotate(-45.000000) translate(-14.010408, -12.000000) '></path></g></g></svg>");
+  background-image: url('data:image/svg+xml;charset=utf-8,<svg viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd"><g id="arrow_left_03" fill="#ffffff"><path d="M11.7604076,9.75 L11.7604076,15.25 C11.7604076,15.8022847 11.3126924,16.25 10.7604076,16.25 C10.2081229,16.25 9.76040764,15.8022847 9.76040764,15.25 L9.76040764,8.75 C9.76040764,8.19771525 10.2081229,7.75 10.7604076,7.75 L17.2604076,7.75 C17.8126924,7.75 18.2604076,8.19771525 18.2604076,8.75 C18.2604076,9.30228475 17.8126924,9.75 17.2604076,9.75 L11.7604076,9.75 Z" id="Combined-Shape" transform="translate(14.010408, 12.000000) rotate(-45.000000) translate(-14.010408, -12.000000) "></path></g></g></svg>');
 }
 
 .i-amphtml-lbg-button {
@@ -254,7 +254,7 @@ amp-lightbox-gallery .amp-carousel-button {
 }
 
 .i-amphtml-lbg-thumbnail-play-icon {
-  background-image: url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='#ffffff'><path d='M8 5v14l11-7z'/><path d='M0 0h24v24H0z' fill='none'/></svg>");
+  background-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#ffffff"><path d="M8 5v14l11-7z"/><path d="M0 0h24v24H0z" fill="none"/></svg>');
   height: 16px;
   width: 16px;
   position: absolute;


### PR DESCRIPTION
Force buttons to be `content-size`, since sometimes people will do 
```
* {
   box-sizing: border-box;
}
```
As a pattern. 