### PR TITLE
Check if event target is an element before asserting that it is (focus-history)

### DIFF
--- a/src/focus-history.js
+++ b/src/focus-history.js
@@ -43,6 +43,7 @@ export class FocusHistory {
 
     /** @private @const {function(!Event)} */
     this.captureFocus_ = e => {
+      // Hack (#15079) due to Firefox firing focus events on the entire page
       if (e.target && e.target.nodeType == 1) {
         this.pushFocus_(dev().assertElement(e.target));
       }

--- a/src/focus-history.js
+++ b/src/focus-history.js
@@ -43,7 +43,7 @@ export class FocusHistory {
 
     /** @private @const {function(!Event)} */
     this.captureFocus_ = e => {
-      if (e.target) {
+      if (e.target && e.target.nodeType == 1) {
         this.pushFocus_(dev().assertElement(e.target));
       }
     };


### PR DESCRIPTION
Temporary workaround for https://github.com/ampproject/amphtml/issues/15079. TLDR: Firefox sometimes fires focus events where the target is the entire page, not an element.