### PR TITLE
Add amp-ad-exit to ini-load element exclusion list

### DIFF
--- a/src/friendly-iframe-embed.js
+++ b/src/friendly-iframe-embed.js
@@ -38,7 +38,8 @@ import {toWin} from './types';
 const EMBED_PROP = '__AMP_EMBED__';
 
 /** @const {!Array<string>} */
-const EXCLUDE_INI_LOAD = ['AMP-AD', 'AMP-ANALYTICS', 'AMP-PIXEL'];
+const EXCLUDE_INI_LOAD =
+    ['AMP-AD', 'AMP-ANALYTICS', 'AMP-PIXEL', 'AMP-AD-EXIT'];
 
 
 /**

--- a/test/functional/test-friendly-iframe-embed.js
+++ b/test/functional/test-friendly-iframe-embed.js
@@ -329,6 +329,7 @@ describe('friendly-iframe-embed', () => {
     let blacklistedAd;
     let blacklistedAnalytics;
     let blacklistedPixel;
+    let blacklistedAmpAdExit;
 
     const context = document.createElement('div');
     document.body.appendChild(context);
@@ -341,6 +342,7 @@ describe('friendly-iframe-embed', () => {
           blacklistedAd = resource('amp-ad', 0),
           blacklistedAnalytics = resource('amp-analytics', 0),
           blacklistedPixel = resource('amp-pixel', 0),
+          blacklistedAmpAdExit = resource('amp-ad-exit', 0),
         ]))
         .once();
 
@@ -350,6 +352,7 @@ describe('friendly-iframe-embed', () => {
       expect(blacklistedAd.loadedComplete).to.be.false;
       expect(blacklistedAnalytics.loadedComplete).to.be.false;
       expect(blacklistedPixel.loadedComplete).to.be.false;
+      expect(blacklistedAmpAdExit.loadedComplete).to.be.false;
     });
   });
 


### PR DESCRIPTION
AMP ad exit exists to apply click protections and click behavior control for ad creatives.  Given it is not human perceivable it should not effect viewability and thus not delay ini-load (case already exists for amp-analytics, amp-pixel, and amp-ad)