### PR TITLE
🏗 Eliminate unnecessary global tools from the AMP toolchain 

### DIFF
--- a/ads/README.md
+++ b/ads/README.md
@@ -218,11 +218,11 @@ window.context.renderStart({width: 200, height: 100});
 Note that if the creative needs to resize on user interaction, the creative can continue to do that by calling the `window.context.requestResize(width, height)` API. Details in [Ad Resizing](#ad-resizing).
 
 ### amp-consent integration
-If [amp-consent](https://github.com/ampproject/amphtml/blob/master/extensions/amp-consent/amp-consent.md) extension is used on the page, `data-block-on-consent` attribute 
+If [amp-consent](https://github.com/ampproject/amphtml/blob/master/extensions/amp-consent/amp-consent.md) extension is used on the page, `data-block-on-consent` attribute
 can be added to `amp-ad` element to respect the corresponding `amp-consent` policy.
-In that case, the `amp-ad` element will be blocked for loading until the consent 
-responded. Once `amp-ad` is unblocked, 3rd party ad scripts can access the consent 
-related information via the following 
+In that case, the `amp-ad` element will be blocked for loading until the consent
+responded. Once `amp-ad` is unblocked, 3rd party ad scripts can access the consent
+related information via the following
 `window.context` APIs.
 
 <dl>
@@ -254,7 +254,7 @@ Add the JS URLs that an ad **always** fetches or always connects to (if you know
 This triggers prefetch/preconnect when the ad is first seen, so that loads are faster when they come into view.
 
 ### Ad markup
-Ads are loaded using the `<amp-ad>` tag containing the specified `type`  for the ad netowkr, and name value pairs of configuration. 
+Ads are loaded using the `<amp-ad>` tag containing the specified `type`  for the ad netowkr, and name value pairs of configuration.
 
 This is an example for the A9 network:
 
@@ -314,7 +314,7 @@ If you're adding support for a new third-party ad service, changes to the follow
 
 To verify the examples that you have put in `/examples/ads.amp.html`:
 
-1. Start a local gulp web server by running command `npx gulp`.
+1. Start a local gulp web server by running command `gulp`.
 2. Visit `http://localhost:8000/examples/ads.amp.html?type=yournetwork` in your browser to make sure the examples load ads.
 
 Please consider having the example consistently load a fake ad (with ad targeting disabled). Not only will it be a more confident example for publishers to follow, but also allows the AMP team to catch any regression bug during AMP releases.
@@ -328,14 +328,15 @@ Please verify your ad is fully functioning, for example, by clicking on an ad. W
 Please make sure your changes pass the tests:
 
 ```
-npx gulp test --watch --nobuild --files=test/functional/{test-ads-config.js,test-integration.js}
+gulp test --watch --nobuild --files=test/functional/{test-ads-config.js,test-integration.js}
+
 ```
 
 If you have non-trivial logic in `/ads/yournetwork.js`, adding a unit test at `/test/functional/ads/test-yournetwork.js` is highly recommended.
 
 ### Lint and type-check
 
-To speed up the review process, please run `npx gulp lint` and `npx gulp check-types`, then fix errors, if any, before sending out the PR.
+To speed up the review process, please run `gulp lint` and `gulp check-types`, then fix errors, if any, before sending out the PR.
 
 ### Other tips
 
@@ -344,6 +345,6 @@ To speed up the review process, please run `npx gulp lint` and `npx gulp check-t
   1. Using a different email address in the git commit.
   2. Not providing the exact company name in the PR thread.
 
-## Developer announcements for ads related API changes 
+## Developer announcements for ads related API changes
 
-For any major Ads API related changes that introduce new functionality or cause backwards compatible changes, the AMP Project will notify the [amp-ads-announce@googlegroups.com](https://groups.google.com/d/forum/amp-ads-announce) at least 2 weeks in advance to make sure you have enough time to absorb those changes. 
+For any major Ads API related changes that introduce new functionality or cause backwards compatible changes, the AMP Project will notify the [amp-ads-announce@googlegroups.com](https://groups.google.com/d/forum/amp-ads-announce) at least 2 weeks in advance to make sure you have enough time to absorb those changes.

--- a/build-system/check-package-manager.js
+++ b/build-system/check-package-manager.js
@@ -20,6 +20,7 @@ const https = require('https');
 
 const setupInstructionsUrl = 'https://github.com/ampproject/amphtml/blob/master/contributing/getting-started-quick.md#one-time-setup';
 const nodeDistributionsUrl = 'https://nodejs.org/dist/index.json';
+const yarnExecutable = 'npx yarn';
 
 // Color formatting libraries may not be available when this script is run.
 function red(text) {return '\x1b[31m' + text + '\x1b[0m';}
@@ -122,8 +123,8 @@ function performNodeVersionCheck(latestLtsVersion) {
 
 // If yarn is being run, perform a version check and proceed with the install.
 function performYarnVersionCheck() {
-  const yarnVersion = getStdout('yarn --version').trim();
-  const yarnInfo = getStdout('yarn info --json yarn').trim();
+  const yarnVersion = getStdout(yarnExecutable + ' --version').trim();
+  const yarnInfo = getStdout(yarnExecutable + ' info --json yarn').trim();
   const yarnInfoJson = JSON.parse(yarnInfo.split('\n')[0]); // First line
   const stableVersion = getYarnStableVersion(yarnInfoJson);
   if (stableVersion === '') {

--- a/build-system/check-package-manager.js
+++ b/build-system/check-package-manager.js
@@ -20,7 +20,10 @@ const https = require('https');
 
 const setupInstructionsUrl = 'https://github.com/ampproject/amphtml/blob/master/contributing/getting-started-quick.md#one-time-setup';
 const nodeDistributionsUrl = 'https://nodejs.org/dist/index.json';
+const gulpHelpUrl = 'https://medium.com/gulpjs/gulp-sips-command-line-interface-e53411d4467';
+
 const yarnExecutable = 'npx yarn';
+const gulpExecutable = 'npx gulp';
 
 // Color formatting libraries may not be available when this script is run.
 function red(text) {return '\x1b[31m' + text + '\x1b[0m';}
@@ -29,51 +32,8 @@ function green(text) {return '\x1b[32m' + text + '\x1b[0m';}
 function yellow(text) {return '\x1b[33m' + text + '\x1b[0m';}
 
 /**
- * @fileoverview Makes sure that packages are being installed via yarn
+ * @fileoverview Perform checks on the AMP toolchain.
  */
-
-function startVersionChecks() {
-  https.get(nodeDistributionsUrl, res => {
-    res.setEncoding('utf8');
-    let distributions = '';
-    res.on('data', data => {
-      distributions += data;
-    });
-    res.on('end', () => {
-      continueVersionChecks(distributions);
-    });
-  });
-}
-
-function continueVersionChecks(distributions) {
-  const distributionsJson = JSON.parse(distributions);
-  const latestLtsVersion = getNodeLatestLtsVersion(distributionsJson);
-  performNodeVersionCheck(latestLtsVersion);
-  performYarnVersionCheck();
-}
-
-function getNodeLatestLtsVersion(distributionsJson) {
-  if (distributionsJson) {
-    // Versions are in descending order, so the first match is the latest lts.
-    return distributionsJson.find(function(distribution) {
-      return distribution.hasOwnProperty('version') &&
-          distribution.hasOwnProperty('lts') &&
-          distribution.lts;
-    }).version;
-  } else {
-    return '';
-  }
-}
-
-function getYarnStableVersion(infoJson) {
-  if (infoJson &&
-      infoJson.hasOwnProperty('data') &&
-      infoJson.data.hasOwnProperty('version')) {
-    return infoJson.data.version;
-  } else {
-    return '';
-  }
-}
 
 // If npm is being run, print a message and cause 'npm install' to fail.
 function ensureYarn() {
@@ -100,29 +60,63 @@ function ensureYarn() {
 }
 
 // Check the node version and print a warning if it is not the latest LTS.
-function performNodeVersionCheck(latestLtsVersion) {
+function checkNodeVersion() {
   const nodeVersion = getStdout('node --version').trim();
-  if (latestLtsVersion === '') {
-    console.log(yellow('WARNING: Something went wrong. ' +
-        'Could not determine latest LTS version of node.'));
-  } else if (nodeVersion !== latestLtsVersion) {
-    console.log(yellow('WARNING: Detected node version'),
-        cyan(nodeVersion) +
-        yellow('. Recommended (latest LTS) version is'),
-        cyan(latestLtsVersion) + yellow('.'));
-    console.log(yellow('To fix this, run'),
-        cyan('"nvm install --lts"'), yellow('or see'),
-        cyan('https://nodejs.org/en/download/package-manager'),
-        yellow('for instructions.'));
+  return new Promise(resolve => {
+    https.get(nodeDistributionsUrl, res => {
+      res.setEncoding('utf8');
+      let distributions = '';
+      res.on('data', data => {
+        distributions += data;
+      });
+      res.on('end', () => {
+        const distributionsJson = JSON.parse(distributions);
+        const latestLtsVersion = getNodeLatestLtsVersion(distributionsJson);
+        if (latestLtsVersion === '') {
+          console.log(yellow('WARNING: Something went wrong. ' +
+              'Could not determine latest LTS version of node.'));
+        } else if (nodeVersion !== latestLtsVersion) {
+          console.log(yellow('WARNING: Detected node version'),
+              cyan(nodeVersion) +
+              yellow('. Recommended (latest LTS) version is'),
+              cyan(latestLtsVersion) + yellow('.'));
+          console.log(yellow('⤷ To fix this, run'),
+              cyan('"nvm install --lts"'), yellow('or see'),
+              cyan('https://nodejs.org/en/download/package-manager'),
+              yellow('for instructions.'));
+        } else {
+          console.log(green('Detected'), cyan('node'), green('version'),
+              cyan(nodeVersion + ' (latest LTS)') +
+              green('.'));
+        }
+        resolve();
+      });
+    }).on('error', () => {
+      console.log(yellow('WARNING: Something went wrong. ' +
+          'Could not download node version info from ' +
+          cyan(nodeDistributionsUrl) + yellow('.')));
+      console.log(yellow('⤷ Detected node version'), cyan(nodeVersion) +
+          yellow('.'));
+      resolve();
+    });
+  });
+}
+
+function getNodeLatestLtsVersion(distributionsJson) {
+  if (distributionsJson) {
+    // Versions are in descending order, so the first match is the latest lts.
+    return distributionsJson.find(function(distribution) {
+      return distribution.hasOwnProperty('version') &&
+          distribution.hasOwnProperty('lts') &&
+          distribution.lts;
+    }).version;
   } else {
-    console.log(green('Detected node version'),
-        cyan(nodeVersion + ' (latest LTS)') +
-        green('.'));
+    return '';
   }
 }
 
 // If yarn is being run, perform a version check and proceed with the install.
-function performYarnVersionCheck() {
+function checkYarnVersion() {
   const yarnVersion = getStdout(yarnExecutable + ' --version').trim();
   const yarnInfo = getStdout(yarnExecutable + ' info --json yarn').trim();
   const yarnInfoJson = JSON.parse(yarnInfo.split('\n')[0]); // First line
@@ -134,15 +128,45 @@ function performYarnVersionCheck() {
     console.log(yellow('WARNING: Detected yarn version'),
         cyan(yarnVersion) + yellow('. Recommended (stable) version is'),
         cyan(stableVersion) + yellow('.'));
-    console.log(yellow('To fix this, run'),
+    console.log(yellow('⤷ To fix this, run'),
         cyan('"curl -o- -L https://yarnpkg.com/install.sh | bash"'),
         yellow('or see'), cyan('https://yarnpkg.com/docs/install'),
         yellow('for instructions.'));
     console.log(yellow('Attempting to install packages...'));
   } else {
-    console.log(green('Detected yarn version'),
+    console.log(green('Detected'), cyan('yarn'), green('version'),
         cyan(yarnVersion + ' (stable)') +
         green('. Installing packages...'));
+  }
+}
+
+function getYarnStableVersion(infoJson) {
+  if (infoJson &&
+      infoJson.hasOwnProperty('data') &&
+      infoJson.data.hasOwnProperty('version')) {
+    return infoJson.data.version;
+  } else {
+    return '';
+  }
+}
+
+function checkGlobalGulp() {
+  const globalPackages = getStdout(yarnExecutable + ' global list').trim();
+  const globalGulp = globalPackages.match(/"gulp@.*" has binaries/);
+  if (globalGulp) {
+    console.log(yellow('WARNING: Detected a global install of'),
+        cyan('gulp') + yellow('. It is recommended that you use'),
+        cyan('gulp-cli'), yellow('instead.'));
+    console.log(yellow('⤷ To fix this, run'),
+        cyan('"yarn global remove gulp"'), yellow('followed by'),
+        cyan('"yarn global add gulp-cli"') + yellow('.'));
+    console.log(yellow('⤷ See'), cyan(gulpHelpUrl),
+        yellow('for more information.'));
+  } else {
+    const gulpVersions = getStdout(gulpExecutable + ' --version').trim();
+    const gulpVersion = gulpVersions.match(/Local version (.*?)$/)[1];
+    console.log(green('Detected'), cyan('gulp'), green('version'),
+        cyan(gulpVersion) + green('.'));
   }
 }
 
@@ -152,7 +176,10 @@ function main() {
     return 0;
   }
   ensureYarn();
-  startVersionChecks();
+  return checkNodeVersion().then(() => {
+    checkGlobalGulp();
+    checkYarnVersion();
+  });
 }
 
 main();

--- a/build-system/check-package-manager.js
+++ b/build-system/check-package-manager.js
@@ -153,6 +153,7 @@ function getYarnStableVersion(infoJson) {
 function checkGlobalGulp() {
   const globalPackages = getStdout(yarnExecutable + ' global list').trim();
   const globalGulp = globalPackages.match(/"gulp@.*" has binaries/);
+  const globalGulpCli = globalPackages.match(/"gulp-cli@.*" has binaries/);
   if (globalGulp) {
     console.log(yellow('WARNING: Detected a global install of'),
         cyan('gulp') + yellow('. It is recommended that you use'),
@@ -162,6 +163,11 @@ function checkGlobalGulp() {
         cyan('"yarn global add gulp-cli"') + yellow('.'));
     console.log(yellow('⤷ See'), cyan(gulpHelpUrl),
         yellow('for more information.'));
+  } else if (!globalGulpCli) {
+    console.log(yellow('WARNING: Could not find'),
+        cyan('gulp-cli') + yellow('.'));
+    console.log(yellow('⤷ To install it, run'),
+        cyan('"yarn global add gulp-cli"') + yellow('.'));
   } else {
     const gulpVersions = getStdout(gulpExecutable + ' --version').trim();
     const gulpVersion = gulpVersions.match(/Local version (.*?)$/)[1];

--- a/build-system/tasks/update-packages.js
+++ b/build-system/tasks/update-packages.js
@@ -22,6 +22,8 @@ const getStderr = require('../exec').getStderr;
 const gulp = require('gulp-help')(require('gulp'));
 const log = require('fancy-log');
 
+const yarnExecutable = 'npx yarn';
+
 /**
  * Patches Web Animations API by wrapping its body into `install` function.
  * This gives us an option to call polyfill directly on the main window
@@ -54,8 +56,8 @@ function patchWebAnimations() {
 function installCustomEslintRules() {
   const customRuleDir = 'build-system/eslint-rules';
   const customRuleName = 'eslint-plugin-amphtml-internal';
-  exec('yarn link', {'stdio': 'ignore', 'cwd': customRuleDir});
-  exec('yarn link ' + customRuleName, {'stdio': 'ignore'});
+  exec(yarnExecutable + ' link', {'stdio': 'ignore', 'cwd': customRuleDir});
+  exec(yarnExecutable + ' link ' + customRuleName, {'stdio': 'ignore'});
   if (!process.env.TRAVIS) {
     log(colors.green('Installed lint rules from'), colors.cyan(customRuleDir));
   }
@@ -65,16 +67,15 @@ function installCustomEslintRules() {
  * Does a yarn check on node_modules, and if it is outdated, runs yarn.
  */
 function runYarnCheck() {
-  const integrityCmd = 'yarn check --integrity';
+  const integrityCmd = yarnExecutable + ' check --integrity';
   if (getStderr(integrityCmd).trim() != '') {
     log(colors.yellow('WARNING:'), 'The packages in',
         colors.cyan('node_modules'), 'do not match',
         colors.cyan('package.json.'));
-    const verifyTreeCmd = 'yarn check --verify-tree';
+    const verifyTreeCmd = yarnExecutable + ' check --verify-tree';
     exec(verifyTreeCmd);
     log('Running', colors.cyan('yarn'), 'to update packages...');
-    const yarnCmd = 'yarn';
-    exec(yarnCmd);
+    exec(yarnExecutable);
   } else {
     log(colors.green('All packages in'),
         colors.cyan('node_modules'), colors.green('are up to date.'));

--- a/contributing/DEVELOPING.md
+++ b/contributing/DEVELOPING.md
@@ -30,7 +30,7 @@ Before you start developing in AMP, check out these resources:
 
 For most developers the instructions in the [Getting Started Quick Start Guide](getting-started-quick.md) will be sufficient for building/running/testing during development.  This section provides a more detailed reference.
 
-The Quick Start Guide's  [One-time setup](getting-started-quick.md#one-time-setup) has instructions for installing Node.js, yarn, and Gulp which you'll need before running these commands. You can prefix `gulp` with `npx` to use it without installing Gulp globally.
+The Quick Start Guide's  [One-time setup](getting-started-quick.md#one-time-setup) has instructions for installing Node.js, yarn, and Gulp which you'll need before running these commands.
 
 | Command                                                                 | Description                                                           |
 | ----------------------------------------------------------------------- | --------------------------------------------------------------------- |

--- a/contributing/DEVELOPING.md
+++ b/contributing/DEVELOPING.md
@@ -32,47 +32,53 @@ For most developers the instructions in the [Getting Started Quick Start Guide](
 
 The Quick Start Guide's  [One-time setup](getting-started-quick.md#one-time-setup) has instructions for installing Node.js, yarn, and Gulp which you'll need before running these commands.
 
+Note that if you don't install
+
 | Command                                                                 | Description                                                           |
 | ----------------------------------------------------------------------- | --------------------------------------------------------------------- |
-| **`gulp`**<sup>[[1]](#footnote-1)</sup>                                 | Runs "watch" and "serve". Use this for standard local dev.            |
+| **`gulp`**                                                              | Runs "watch" and "serve". Use this for standard local dev.            |
 | `gulp --extensions=<amp-foo,amp-bar>`                                   | Runs "watch" and "serve", after building only the listed extensions.
 | `gulp --extensions=minimal_set`                                         | Runs "watch" and "serve", after building the extensions needed to load `article.amp.html`.
 | `gulp --noextensions`                                                   | Runs "watch" and "serve" without building any extensions.
-| `gulp dist`<sup>[[1]](#footnote-1)</sup>                                | Builds production binaries.                                           |
+| `gulp dist`                                                             | Builds production binaries.                                           |
 | `gulp dist --extensions=<amp-foo,amp-bar>`                              | Builds production binaries, with only the listed extensions.
 | `gulp dist --extensions=minimal_set`                                    | Builds production binaries, with only the extensions needed to load `article.amp.html`.
 | `gulp dist --noextensions`                                              | Builds production binaries without building any extensions.
-| `gulp dist --fortesting`<sup>[[1]](#footnote-1)</sup>                   | Builds production binaries for local testing. (Allows use cases like ads, tweets, etc. to work with minified sources. Overrides `TESTING_HOST` if specified. Uses the production `AMP_CONFIG` by default.) |
-| `gulp dist --fortesting --config=<config>`<sup>[[1]](#footnote-1)</sup> | Builds production binaries for local testing, with the specified `AMP_CONFIG`. `config` can be `prod` or `canary`. (Defaults to `prod`.) |
-| `gulp lint`                                                             | Validates against Google Closure Linter.                              |
-| `gulp lint --watch`                                                     | Watches for changes in files, Validates against Google Closure Linter.|
+| `gulp dist --fortesting`                                                | Builds production binaries for local testing. (Allows use cases like ads, tweets, etc. to work with minified sources. Overrides `TESTING_HOST` if specified. Uses the production `AMP_CONFIG` by default.) |
+| `gulp dist --fortesting --config=<config>`                              | Builds production binaries for local testing, with the specified `AMP_CONFIG`. `config` can be `prod` or `canary`. (Defaults to `prod`.) |
+| `gulp lint`                                                             | Validates against the ESLint linter.                              |
+| `gulp lint --watch`                                                     | Watches for changes in files, and validates against the ESLint linter. |
 | `gulp lint --fix`                                                       | Fixes simple lint warnings/errors automatically.                      |
 | `gulp lint --files=<files-path-glob>`                                   | Lints just the files provided.                                         |
-| `gulp build`<sup>[[1]](#footnote-1)</sup>                               | Builds the AMP library.                                               |
+| `gulp build`                                                            | Builds the AMP library.                                               |
 | `gulp build --extensions=<amp-foo,amp-bar>`                             | Builds the AMP library, with only the listed extensions.
 | `gulp build --extensions=minimal_set`                                   | Builds the AMP library, with only the extensions needed to load `article.amp.html`.
 | `gulp build --noextensions`                                             | Builds the AMP library with no extensions.
 | `gulp check-links --files foo.md,bar.md`                                | Reports dead links in `.md` files.                                                 |
 | `gulp clean`                                                            | Removes build output.                                                 |
-| `gulp css`<sup>[[1]](#footnote-1)</sup>                                 | Recompiles css to build directory and builds the embedded css into js files for the AMP library. |
-| `gulp watch`<sup>[[1]](#footnote-1)</sup>                               | Watches for changes in files, re-builds.                               |
+| `gulp css`                                                              | Recompiles css to build directory and builds the embedded css into js files for the AMP library. |
+| `gulp watch`                                                            | Watches for changes in files, re-builds.                               |
 | `gulp watch --extensions=<amp-foo,amp-bar>`                             | Watches for changes in files, re-builds only the listed extensions.
 | `gulp watch --extensions=minimal_set`                                   | Watches for changes in files, re-builds only the extensions needed to load `article.amp.html`.
 | `gulp watch --noextensions`                                             | Watches for changes in files, re-builds with no extensions.
-| `gulp pr-check`<sup>[[1]](#footnote-1)</sup>                            | Runs all the Travis CI checks locally.         |
-| `gulp pr-check --nobuild`<sup>[[1]](#footnote-1)</sup>                  | Runs all the Travis CI checks locally, but skips the `gulp build` step.         |
-| `gulp pr-check --files=<test-files-path-glob>`<sup>[[1]](#footnote-1)</sup>   | Runs all the Travis CI checks locally, and restricts tests to the files provided.  |
-| `gulp test`<sup>[[1]](#footnote-1)</sup>                                | Runs tests in Chrome.                                                 |
-| `gulp test --verbose`<sup>[[1]](#footnote-1)</sup>                      | Runs tests in Chrome with logging enabled.                            |
-| `gulp test --nobuild`                                                   | Runs tests without re-build.                                          |
-| `gulp test --coverage`                                                  | Runs code coverage tests. After running, the report will be available at test/coverage/report-html/index.html |
-| `gulp test --watch`<sup>[[1]](#footnote-1)</sup>                        | Watches for changes in files, runs corresponding test(s) in Chrome.   |
-| `gulp test --watch --verbose`<sup>[[1]](#footnote-1)</sup>              | Same as `watch`, with logging enabled.                                 |
-| `gulp test --saucelabs`<sup>[[1]](#footnote-1)</sup>                    | Runs test on saucelabs (requires [setup](#testing-on-sauce-labs)).                |
-| `gulp test --safari`<sup>[[1]](#footnote-1)</sup>                       | Runs tests in Safari.                                                 |
-| `gulp test --firefox`<sup>[[1]](#footnote-1)</sup>                      | Runs tests in Firefox.                                                |
-| `gulp test --files=<test-files-path-glob>`<sup>[[1]](#footnote-1)</sup> | Runs specific test files.                                             |
-| `gulp test --testnames`<sup>[[1]](#footnote-1)</sup>                    | Lists the name of each test being run, and prints a summary at the end.  |
+| `gulp pr-check`                                                         | Runs all the Travis CI checks locally.         |
+| `gulp pr-check --nobuild`                                               | Runs all the Travis CI checks locally, but skips the `gulp build` step.         |
+| `gulp pr-check --files=<test-files-path-glob>`                          | Runs all the Travis CI checks locally, and restricts tests to the files provided.  |
+| `gulp test --unit`                                                      | Runs the unit tests in Chrome (doesn't require the AMP library to be built).                                                 |
+| `gulp test --unit --files=<test-files-path-glob>`                       | Runs the unit tests from the specified files in Chrome.                                                 |
+| `gulp test --integration`                                               | Runs the integration tests in Chrome (requires the AMP library to be built).                                                 |
+| `gulp test --integration --files=<test-files-path-glob>`                | Runs the integration tests from the specified files in Chrome.                                                 |
+| `gulp test [--unit\|--integration] --verbose`                           | Runs tests in Chrome with logging enabled.                            |
+| `gulp test [--unit\|--integration] --nobuild`                           | Runs tests without re-build.                                          |
+| `gulp test [--unit\|--integration] --coverage`                          | Runs code coverage tests. After running, the report will be available at test/coverage/report-html/index.html |
+| `gulp test [--unit\|--integration] --watch`                             | Watches for changes in files, runs corresponding test(s) in Chrome.   |
+| `gulp test [--unit\|--integration] --watch --verbose`                   | Same as `watch`, with logging enabled.                                 |
+| `gulp test [--integration] --saucelabs`                                 | Runs integration tests on saucelabs (requires [setup](#testing-on-sauce-labs)).                |
+| `gulp test [--unit] --saucelabs_lite`                                   | Runs unit tests on a subset of saucelabs browsers (requires [setup](#testing-on-sauce-labs)).                |
+| `gulp test [--unit\|--integration] --safari`                            | Runs tests in Safari.                                                 |
+| `gulp test [--unit\|--integration] --firefox`                           | Runs tests in Firefox.                                                |
+| `gulp test [--unit\|--integration] --files=<test-files-path-glob>`      | Runs specific test files.                                             |
+| `gulp test [--unit\|--integration] --testnames`                         | Lists the name of each test being run, and prints a summary at the end.  |
 | `gulp serve`                                                            | Serves content in repo root dir over http://localhost:8000/. Examples live in http://localhost:8000/examples/. Serve unminified AMP by default. |
 | `gulp serve --quiet`                                                    | Same as `serve`, with logging silenced. |
 | `gulp serve --port 9000`                                                | Same as `serve`, but uses a port number other than the default of 8000. |
@@ -81,13 +87,11 @@ The Quick Start Guide's  [One-time setup](getting-started-quick.md#one-time-setu
 | `gulp presubmit`                                                        | Run validation against files to check for forbidden and required terms. Run automatically upon push.  |
 | `gulp validator`                                                        | Builds and tests the AMP validator. Run automatically upon push.  |
 | `node build-system/pr-check.js`                                         | Runs all tests that will be run upon pushing a CL.                     |
-| `gulp ava`<sup>[[1]](#footnote-1)</sup>                                 | Run node tests for tasks and offline/node code using [ava](https://github.com/avajs/ava). |
+| `gulp ava`                                                              | Run node tests for tasks and offline/node code using [ava](https://github.com/avajs/ava). |
 | `gulp todos:find-closed`                                                | Find `TODO`s in code for issues that have been closed. |
 | `gulp visual-diff`                                                      | Runs all visual diff tests on local Chrome. Requires `gulp build` to have been run. Also requires `PERCY_PROJECT` and `PERCY_TOKEN` to be set as environment variables. |
 | `gulp visual-diff --headless`                                           | Same as above, but launches local Chrome in headless mode. |
 | `gulp visual-diff --percy_debug --chrome_debug --webserver_debug`       | Same as above, with additional logging. Debug flags can be used independently.  |
-
-<a id="footnote-1">[1]</a> On Windows, this command must be run as administrator.
 
 ## Manual testing
 

--- a/contributing/DEVELOPING.md
+++ b/contributing/DEVELOPING.md
@@ -32,8 +32,6 @@ For most developers the instructions in the [Getting Started Quick Start Guide](
 
 The Quick Start Guide's  [One-time setup](getting-started-quick.md#one-time-setup) has instructions for installing Node.js, yarn, and Gulp which you'll need before running these commands.
 
-Note that if you don't install
-
 | Command                                                                 | Description                                                           |
 | ----------------------------------------------------------------------- | --------------------------------------------------------------------- |
 | **`gulp`**                                                              | Runs "watch" and "serve". Use this for standard local dev.            |

--- a/contributing/building-an-amp-extension.md
+++ b/contributing/building-an-amp-extension.md
@@ -751,7 +751,7 @@ For faster testing during development, consider using --files argument
 to only run your extensions' tests.
 
 ```shell
-$ npx gulp test --files=extensions/amp-my-element/0.1/test/test-amp-my-element.js --watch
+$ gulp test --files=extensions/amp-my-element/0.1/test/test-amp-my-element.js --watch
 ```
 
 ## Type checking
@@ -764,7 +764,7 @@ your code. The following command should be run to ensure no type
 violations are introduced by your extension.
 
 ```shell
-$ npx gulp check-types
+$ gulp check-types
 ```
 
 ## Example PRs

--- a/contributing/getting-started-e2e.md
+++ b/contributing/getting-started-e2e.md
@@ -95,24 +95,24 @@ If you are new to Git it may seem surprising that there are three different repo
 
 * When you're done you'll push these changes to your fork on GitHub so that others can see your changes and review them before they become part of the amphtml repository.
 
-* When the changes have been approved by someone with permission to do so that person will handle merging your changes from your GitHub fork to the amphtml repository.
+* When the changes have been approved by someone with permission to do so, that person will handle merging your changes from your GitHub fork to the amphtml repository.
 
 Note that each of these repositories has a complete copy of the entire amphtml codebase.  If your local repository is on your computer and you lose your internet connection you'll still be able to make changes to any file in your local repository.  Part of the workflow for Git that we'll go through is how you keep these three repositories in sync.
 
-One thing that might put your mind at ease:  if you aren't currently a [core committer](https://github.com/ampproject/amphtml/blob/master/GOVERNANCE.md) to the amphtml project you can't actually make changes to the amphtml repository directly--so go ahead and try out different Git commands without worrying you're going to break things for other people.
+One thing that might put your mind at ease:  if you aren't currently a [core committer](https://github.com/ampproject/amphtml/blob/master/GOVERNANCE.md) to the amphtml project, you can't actually make changes to the amphtml repository directly. So go ahead and try out different Git commands without worrying you're going to break things for other people!
 
 ## Creating your GitHub fork and your local repository
 To create your fork on GitHub and your local copy of that fork:
 
-* Create a fork of the amphtml repository on GitHub by going to [https://github.com/ampproject/amphtml](https://github.com/ampproject/amphtml) and clicking the "Fork" button near the top.  Your GitHub fork will now be visible at `https://github.com/<your username>/amphtml`.
+* Create a fork of the amphtml repository on GitHub by going to [https://github.com/ampproject/amphtml](https://github.com/ampproject/amphtml) and clicking the "Fork" button near the top.  Your GitHub fork will now be visible at `https://github.com/<your username>/amphtml`. During local development, this will be referred to by `git` as `origin`.
 
 * Create your local copy (or *clone*) of your fork:
 
     * go to a local directory on your computer where you want to put a copy of the code, e.g. `~/src/ampproject`
 
-    * run the `git clone` command using the address for your remote repository (your GitHub fork)
+    * run the `git clone` command using the address for your remote repository (your GitHub fork):
 
-       ```shell
+       ```
        git clone git@github.com:<your username>/amphtml.git
        ```
 
@@ -156,39 +156,39 @@ git branch -u upstream/master master
 
 # Building AMP and starting a local server
 
-Now that you have all of the files copied locally you can actually build the code and run a local server to try things out.
+Now that you have all of the files copied locally you can actually build the code and run a local server to try things out. We use Node.js, the Yarn package manager, and the Gulp build system to build amphtml and start up a local server that lets you try out your changes.
 
-amphtml uses Node.js, the Yarn package manager and the Gulp build system to build amphtml and start up a local server that lets you try out your changes.  Installing these and getting amphtml built is straightforward:
-
-* Install the latest LTS version of [Node.js](https://nodejs.org/) (which includes npm).
-
-  On Mac and Linux, you can use [nvm](https://github.com/creationix/nvm), especially if you have other projects that require different versions of Node.
+* Install the latest LTS version of [Node.js](https://nodejs.org/) (which includes npm). An easy way to do so is with `nvm` (Mac and Linux: [here](https://github.com/creationix/nvm), Windows: [here](https://github.com/coreybutler/nvm-windows))
 
    ```
    nvm install --lts
    ```
 
-* Install the stable version of [Yarn](https://yarnpkg.com/) (instructions [here](https://yarnpkg.com/en/docs/install), this may require elevated privileges using `sudo` on some platforms)
-
-  On Mac and Linux, you can do so like this.
+* Install the stable version of [Yarn](https://yarnpkg.com/) (Mac and Linux: [here](https://yarnpkg.com/en/docs/install), Windows: [here](https://yarnpkg.com/lang/en/docs/install/#windows-stable))
 
    ```
    curl -o- -L https://yarnpkg.com/install.sh | bash
    ```
+  An alternative to installing `yarn` is to invoke each Yarn command in this guide with `npx yarn` during local development. This will automatically use the current stable version of `yarn`.
+
+* If you have a global install of [Gulp](https://gulpjs.com/), uninstall it. (See [this article](https://github.com/gulpjs/gulp/blob/v3.9.1/docs/getting-started.md) for why.)
+
+   ```
+   yarn global remove gulp
+   ```
+
+* Install the [Gulp](https://gulpjs.com/) command line tool, which will automatically use the version of `gulp` packaged with the the amphtml repository. (instructions [here](https://github.com/gulpjs/gulp/blob/v3.9.1/docs/getting-started.md))
+
+   ```
+   yarn global add gulp-cli
+   ```
+  An alternative to installing `gulp-cli` is to invoke each Gulp command in this guide with `npx gulp` during local development. This will also use the version of `gulp` packaged with the amphtml repository.
 
 * In your local repository directory (e.g. `~/src/ampproject/amphtml`), install the packages that AMP uses by running
    ```
    yarn
    ```
    You should see a progress indicator and some messages scrolling by.  You may see some warnings about optional dependencies, which are generally safe to ignore.
-
-* For some local testing we refer to fake local URLs in order to simulate referencing third party URLs.  This requires extra setup so your browser will know that these URLs actually point to your local server.
-
-   You can do this by adding this line to your hosts file (`/etc/hosts` on Mac or Linux, `%SystemRoot%\System32\drivers\etc\hosts` on Windows):
-
-    ```
-    127.0.0.1 ads.localhost iframe.localhost
-    ```
 
 * The AMP Project uses Gulp as our build system.   Gulp uses a configuration file ([gulpfile.js](https://github.com/ampproject/amphtml/blob/master/gulpfile.js)) to build amphtml (including the amphtml javascript) and to start up the Node.js server with the proper settings.  You don't really have to understand exactly what it is doing at this point--you just have to install it and use it.
 

--- a/contributing/getting-started-e2e.md
+++ b/contributing/getting-started-e2e.md
@@ -190,16 +190,6 @@ Now that you have all of the files copied locally you can actually build the cod
    ```
    You should see a progress indicator and some messages scrolling by.  You may see some warnings about optional dependencies, which are generally safe to ignore.
 
-* The AMP Project uses Gulp as our build system.   Gulp uses a configuration file ([gulpfile.js](https://github.com/ampproject/amphtml/blob/master/gulpfile.js)) to build amphtml (including the amphtml javascript) and to start up the Node.js server with the proper settings.  You don't really have to understand exactly what it is doing at this point--you just have to install it and use it.
-
-   You can install Gulp using Yarn:
-
-   ```
-   yarn global add gulp
-   ```
-
-   The preceding command might require elevated privileges using `sudo` on some platforms.
-
 Now whenever you're ready to build amphtml and start up your local server, simply go to your local repository directory and run:
 
 ```

--- a/contributing/getting-started-e2e.md
+++ b/contributing/getting-started-e2e.md
@@ -190,13 +190,23 @@ amphtml uses Node.js, the Yarn package manager and the Gulp build system to buil
     127.0.0.1 ads.localhost iframe.localhost
     ```
 
+* The AMP Project uses Gulp as our build system.   Gulp uses a configuration file ([gulpfile.js](https://github.com/ampproject/amphtml/blob/master/gulpfile.js)) to build amphtml (including the amphtml javascript) and to start up the Node.js server with the proper settings.  You don't really have to understand exactly what it is doing at this point--you just have to install it and use it.
+
+   You can install Gulp using Yarn:
+
+   ```
+   yarn global add gulp
+   ```
+
+   The preceding command might require elevated privileges using `sudo` on some platforms.
+
 Now whenever you're ready to build amphtml and start up your local server, simply go to your local repository directory and run:
 
 ```
-npx gulp
+gulp
 ```
 
-`npx` is a command that comes with Node.js that runs a command installed locally with `yarn`, as `gulp` is. Running the `npx gulp` command will compile the code and start up a Node.js server listening on port 8000.  Once you see a message like `Finished 'default'` you can access the local server in your browser at [http://localhost:8000](http://localhost:8000)
+Running the `gulp` command will compile the code and start up a Node.js server listening on port 8000.  Once you see a message like `Finished 'default'` you can access the local server in your browser at [http://localhost:8000](http://localhost:8000)
 
 You can browse the [http://localhost:8000/examples](http://localhost:8000/examples) directory to see some demo pages for various AMP components and combination of components.
 
@@ -208,7 +218,7 @@ Note that by default each of the pages in the /examples directory uses the unmin
 
 - [http://localhost:8000/serve_mode=compiled](http://localhost:8000/serve_mode=compiled)
 
-  Minified AMP JavaScript is served from the local server. This is only available after running `npx gulp dist --fortesting`.
+  Minified AMP JavaScript is served from the local server. This is only available after running `gulp dist --fortesting`.
 
 - [http://localhost:8000/serve_mode=cdn](http://localhost:8000/serve_mode=cdn)
 
@@ -344,12 +354,12 @@ Before sending your code changes for review, you will want to make sure that all
 Make sure you are in the branch that has your changes (`git checkout <branch name>`), pull in the latest changes from the remote amphtml repository and then simply run:
 
 ```
-npx gulp test
+gulp test
 ```
 
-You'll see some messages about stuff being compiled and then after a short time you will see a new Chrome window open up that says "Karma" at the top.  In the window where you ran `npx gulp test`, you'll see a bunch of tests scrolling by (`Executed NNNN of MMMM`) and hopefully a lot of `SUCCESS` messages.
+You'll see some messages about stuff being compiled and then after a short time you will see a new Chrome window open up that says "Karma" at the top.  In the window where you ran `gulp test`, you'll see a bunch of tests scrolling by (`Executed NNNN of MMMM`) and hopefully a lot of `SUCCESS` messages.
 
-By default `gulp test` runs tests on Chrome.  Depending on what your tests affect (e.g. if you're fixing a bug in a different browser), you may need to run `npx gulp test --firefox` or `npx gulp test --safari` to run in other browsers.
+By default `gulp test` runs tests on Chrome.  Depending on what your tests affect (e.g. if you're fixing a bug in a different browser), you may need to run `gulp test --firefox` or `gulp test --safari` to run in other browsers.
 
 If the tests have failed you will need to determine whether the failure is related to your change.
 
@@ -362,26 +372,26 @@ Fixing the tests will depend heavily on the change you are making and what tests
 Sometimes, it can be useful to pre-emptively eliminate errors in your pull request by running all the Travis CI checks on your local machine. You can do so by running:
 
 ```
-npx gulp pr-check
+gulp pr-check
 ```
 
 To run all Travis CI checks, but skip the `gulp build` step, you can run:
 
 ```
-npx gulp pr-check --nobuild
+gulp pr-check --nobuild
 ```
 
 To run all Travis CI checks, and restrict the unit tests and integration tests to just a subset of files, you can run:
 
 ```
-npx gulp pr-check --files=<test-files-path-glob>
+gulp pr-check --files=<test-files-path-glob>
 ```
 
 Notes:
 
 * This will force a clean build and run all the PR checks one by one.
 * Just like on Travis, a failing check will prevent subsequent checks from being run.
-* The `npx gulp visual-diff` check will be skipped unless you have set up a Percy account as described [here](https://github.com/ampproject/amphtml/blob/master/contributing/DEVELOPING.md#running-visual-diff-tests-locally).
+* The `gulp visual-diff` check will be skipped unless you have set up a Percy account as described [here](https://github.com/ampproject/amphtml/blob/master/contributing/DEVELOPING.md#running-visual-diff-tests-locally).
 * The AMP unit and integration tests will be run on local Chrome unless you have set up a Sauce Labs account as described [here](https://github.com/ampproject/amphtml/blob/master/contributing/DEVELOPING.md#testing-on-sauce-labs).
 
 ## Adding tests for your change
@@ -390,15 +400,15 @@ If your change was not already covered by existing tests, you will generally be 
 
 The amphtml unit tests use the [Mocha](https://mochajs.org/) framework, the [Chai](http://chaijs.com/) assertion library and the [Sinon](http://sinonjs.org/) mocking library.  The specifics of the tests you will need to add will vary depending on the issue/feature you are working on.  If you are fixing a bug in an existing component there should already be tests in the test directory for that component that you can look at for guidance.  For example the [amp-video](https://github.com/ampproject/amphtml/blob/master/extensions/amp-video/amp-video.md) component has [tests](https://github.com/ampproject/amphtml/blob/master/extensions/amp-video/0.1/test/test-amp-video.js).
 
-You can run the tests in a single file by running `npx gulp test --files=<file to test>`, e.g. for amp-video:
+You can run the tests in a single file by running `gulp test --files=<file to test>`, e.g. for amp-video:
 
 ```
-npx gulp test --files=extensions/amp-youtube/0.1/test/test-amp-youtube.js
+gulp test --files=extensions/amp-youtube/0.1/test/test-amp-youtube.js
 ```
 
-Alternatively you can take advantage of a Mocha feature that allows for running only certain tests--`describe.only`.  Simply replace the `describe` in the Mocha tests you want to run with `describe.only` and only those tests will be run when you run `npx gulp test`.  Make sure to remove the `.only` and run all tests before sending your code for review.
+Alternatively you can take advantage of a Mocha feature that allows for running only certain tests--`describe.only`.  Simply replace the `describe` in the Mocha tests you want to run with `describe.only` and only those tests will be run when you run `gulp test`.  Make sure to remove the `.only` and run all tests before sending your code for review.
 
-To make running the tests more convenient you can also use the `--watch` flag in any `npx gulp test` command.  This will cause the tests you've indicated to automatically be rerun whenever a file is modified.
+To make running the tests more convenient you can also use the `--watch` flag in any `gulp test` command.  This will cause the tests you've indicated to automatically be rerun whenever a file is modified.
 
 If you are not sure how to create these tests you can ask on the GitHub issue you're working on or reach out to the community as described in [How to get help](#how-to-get-help).
 

--- a/contributing/getting-started-quick.md
+++ b/contributing/getting-started-quick.md
@@ -41,6 +41,8 @@ This Quick Start guide is the TL;DR version of the longer [end-to-end guide](get
    curl -o- -L https://yarnpkg.com/install.sh | bash
    ```
 
+* Install Gulp by running `yarn global add gulp` (this may require elevated privileges using `sudo` on some platforms)
+
 * Add this line to your hosts file (`/etc/hosts` on Mac or Linux, `%SystemRoot%\System32\drivers\etc\hosts` on Windows):
 
     ```
@@ -59,19 +61,19 @@ This Quick Start guide is the TL;DR version of the longer [end-to-end guide](get
 # Build AMP & run a local server
 
 * Make sure you have the latest packages (after you pull): `yarn`
-* Start the server: `npx gulp`
+* Start the server: `gulp`
 * Access your server at [http://localhost:8000](http://localhost:8000)
 * Access your sample pages at [http://localhost:8000/examples](http://localhost:8000/examples)
 
 # Test AMP
 
-* Run all tests: `npx gulp test`
-* Run only the unit tests: `npx gulp test --unit` (doesn't build the runtime)
-* Run only the integration tests: `npx gulp test --integration` (builds the runtime)
-* Run tests, but skip building after having done so previously: `npx gulp test --nobuild`
-* Run the tests in a specified set of files: `npx gulp test --files=<filename>`
-* Add the `--watch` flag to any `npx gulp test` command to automatically re-run the tests when a file changes
-* To run only a certain set of Mocha tests change  `describe` to `describe.only` for the tests you want to run; combine this with `npx gulp test --watch` to automatically rerun your test when files are changed   (but make sure to run all the tests before sending your change for review)
+* Run all tests: `gulp test`
+* Run only the unit tests: `gulp test --unit` (doesn't build the runtime)
+* Run only the integration tests: `gulp test --integration` (builds the runtime)
+* Run tests, but skip building after having done so previously: `gulp test --nobuild`
+* Run the tests in a specified set of files: `gulp test --files=<filename>`
+* Add the `--watch` flag to any `gulp test` command to automatically re-run the tests when a file changes
+* To run only a certain set of Mocha tests change  `describe` to `describe.only` for the tests you want to run; combine this with `gulp test --watch` to automatically rerun your test when files are changed   (but make sure to run all the tests before sending your change for review)
 
 # Create commits to contain your changes
 

--- a/contributing/getting-started-quick.md
+++ b/contributing/getting-started-quick.md
@@ -20,39 +20,57 @@ This Quick Start guide is the TL;DR version of the longer [end-to-end guide](get
 
 # One-time Setup
 
-* [Create a GitHub account](https://help.github.com/articles/signing-up-for-a-new-github-account/) if you don't already have one
-* Set up [2 factor auth](https://help.github.com/articles/about-two-factor-authentication/) for your GitHub account
+* [Create a GitHub account](https://help.github.com/articles/signing-up-for-a-new-github-account/) if you don't already have one.
 
-* [Install and set up Git](https://help.github.com/articles/set-up-git/); in the "Authenticating" step of that page use SSH instead of HTTPS
+* Set up [2 factor auth](https://help.github.com/articles/about-two-factor-authentication/) for your GitHub account.
 
-* Install the latest LTS version of [Node.js](https://nodejs.org/) (which includes npm). [nvm](https://github.com/creationix/nvm) is a convenient way to do this on Mac and Linux
+* [Install and set up Git](https://help.github.com/articles/set-up-git/); in the "Authenticating" step of that page use SSH instead of HTTPS.
 
-  On Mac and Linux, you can use [nvm](https://github.com/creationix/nvm), especially if you have other projects that require different versions of Node.
+* Install the latest LTS version of [Node.js](https://nodejs.org/) (which includes npm). An easy way to do so is with `nvm`. (Mac and Linux: [here](https://github.com/creationix/nvm), Windows: [here](https://github.com/coreybutler/nvm-windows))
 
    ```
    nvm install --lts
    ```
 
-* Install the stable version of [Yarn](https://yarnpkg.com/) (instructions [here](https://yarnpkg.com/en/docs/install), this may require elevated privileges using `sudo` on some platforms)
-
-  On Mac and Linux, you can do so like this.
+* Install the stable version of [Yarn](https://yarnpkg.com/). (Mac and Linux: [here](https://yarnpkg.com/en/docs/install), Windows: [here](https://yarnpkg.com/lang/en/docs/install/#windows-stable))
 
    ```
    curl -o- -L https://yarnpkg.com/install.sh | bash
    ```
+  An alternative to installing `yarn` is to invoke each Yarn command in this guide with `npx yarn` during local development. This will automatically use the current stable version of `yarn`.
 
-* Install Gulp by running `yarn global add gulp` (this may require elevated privileges using `sudo` on some platforms)
+* If you have a global install of [Gulp](https://gulpjs.com/), uninstall it. (See [this article](https://github.com/gulpjs/gulp/blob/v3.9.1/docs/getting-started.md) for why.)
 
-* Add this line to your hosts file (`/etc/hosts` on Mac or Linux, `%SystemRoot%\System32\drivers\etc\hosts` on Windows):
+   ```
+   yarn global remove gulp
+   ```
 
-    ```
-    127.0.0.1 ads.localhost iframe.localhost
-    ```
+* Install the [Gulp](https://gulpjs.com/) command line tool, which will automatically use the version of `gulp` packaged with the the amphtml repository. (Instructions [here](https://github.com/gulpjs/gulp/blob/v3.9.1/docs/getting-started.md))
 
-* Fork the [amphtml repository](https://github.com/ampproject/amphtml) by clicking "Fork" in the Web UI.
+   ```
+   yarn global add gulp-cli
+   ```
+  An alternative to installing `gulp-cli` is to invoke each Gulp command in this guide with `npx gulp` during local development. This will also use the version of `gulp` packaged with the amphtml repository.
 
-* Create your local repository: `git clone git@github.com:<your username>/amphtml.git`
-* Add an alias:  Go to the newly created local repository directory and run `git remote add upstream git@github.com:ampproject/amphtml.git` and then `git branch -u upstream/master master`
+* Create your own fork of the [amphtml repository](https://github.com/ampproject/amphtml) by clicking "Fork" in the Web UI. During local development, this will be referred to by `git` as `origin`.
+
+* Download your fork to a local repository.
+
+  ```
+  git clone git@github.com:<your username>/amphtml.git
+  ```
+
+* Add an alias called `upstream` to refer to the main `ampproject/amphtml` repository. Go to the root directory of the newly created local repository directory and run:
+
+  ```
+  git remote add upstream git@github.com:ampproject/amphtml.git
+  ```
+
+* Set up your local `master` branch to track `upstream/master` instead of `origin/master` (which will rapidly become outdated).
+
+  ```
+  git branch -u upstream/master master
+  ```
 
 # Branch (do this each time you want a new branch)
 
@@ -67,22 +85,21 @@ This Quick Start guide is the TL;DR version of the longer [end-to-end guide](get
 
 # Test AMP
 
-* Run all tests: `gulp test`
-* Run only the unit tests: `gulp test --unit` (doesn't build the runtime)
-* Run only the integration tests: `gulp test --integration` (builds the runtime)
-* Run tests, but skip building after having done so previously: `gulp test --nobuild`
-* Run the tests in a specified set of files: `gulp test --files=<filename>`
+* Run the unit tests: `gulp test --unit` (doesn't build the runtime)
+* Run the integration tests: `gulp test --integration` (builds the runtime)
+* Run tests, but skip building after having done so previously: `gulp test [--unit|--integration] --nobuild`
+* Run the tests in a specified set of files: `gulp test [--unit|--integration] --files=<test-files-path-glob>`
 * Add the `--watch` flag to any `gulp test` command to automatically re-run the tests when a file changes
-* To run only a certain set of Mocha tests change  `describe` to `describe.only` for the tests you want to run; combine this with `gulp test --watch` to automatically rerun your test when files are changed   (but make sure to run all the tests before sending your change for review)
+* To run only a certain set of Mocha tests, change  `describe` to `describe.only` for the tests you want to run; combine this with `gulp test --watch` to automatically rerun your test when files are changed   (but make sure to run all the tests before sending your change for review)
 
 # Create commits to contain your changes
 
 * Edit files in your favorite editor
 * if your code requires a new dependency, run `yarn add --dev --exact [packagename]`, which will automatically update `package.json` and `yarn.lock`
-* if you manually edited `package.json`, run `yarn install` to install the dependency and generate an updated `yarn.lock` file
+* if you manually edited `package.json`, run `yarn` to install the dependency and generate an updated `yarn.lock` file
 * Add each file you change: `git add <file>`
 * Create a commit: `git commit -m "<your commit message>"`
-* Instead of `add`ing each file individually you can use the `-a` flag on the commit instead
+* To avoid having to run `git add` on each file, you can use `git commit -a -m "<your commit message>"` instead
 
 # Pull the latest changes
 
@@ -103,19 +120,18 @@ This Quick Start guide is the TL;DR version of the longer [end-to-end guide](get
 * For pushes after the first, just use `git push`
 * If you don't get a new review within 2 business days, feel free to ping the pull request by adding a comment
 * If you see visual diffs reported by [Percy](http://percy.io/ampproject/amphtml), and want to access the results, fill out this [form](https://docs.google.com/forms/d/e/1FAIpQLScZma6qVJtYUTqSm4KtiF3Zc-n5ukNe2GXNFqnaHxospsz0sQ/viewform).
-
 * Once approved your changes are merged into the amphtml repository by a core committer (you don't do this merge)
 
 # Delete your branch after your changes are merged (optional)
 
 * Go to the master branch: `git checkout master`
 * Delete your local branch: `git branch -D <branch name>`
-* Delete the GitHub fork branch: `git push -d origin <branch name>`
+* Delete the corresponding GitHub fork branch: `git push -d origin <branch name>`
 
 # See your changes in production
 
 * If your change affected internal documentation, tests, the build process, etc. you can generally see your changes right after they're merged.
-* If your change was to the code that runs on AMP pages across the web, you'll have to wait for the change to be included in a production release. Generally, it takes about 1-2 weeks for a change to be live for all users. Reference our [release schedule](release-schedule.md) for more specific details.
-* The [amphtml Releases page](https://github.com/ampproject/amphtml/releases) will list your PR in the first build that contains it.  `Pre-release` is the build on the Dev Channel, `Latest Release` is the build in production.
-* Opt-in to using the Dev Channel in a browser by enabling `dev-channel` on the [AMP Experiments](https://cdn.ampproject.org/experiments.html) page.
-* Find the AMP version being used on a page in the developer console, i.e. `Powered by AMP ⚡ HTML – Version <build number>`).
+* If your change was to the code that runs on AMP pages across the web, you'll have to wait for the change to be included in a production release. Generally, it takes about 1-2 weeks for a change to be live for all users. See the [release schedule](release-schedule.md) for more specific details.
+* The [amphtml Releases page](https://github.com/ampproject/amphtml/releases) will list your PR in the first build that contains it. `Pre-release` is the build on the Dev Channel, `Latest Release` is the build in production.
+* Opt in to using the Dev Channel in a browser by enabling `dev-channel` on the [AMP Experiments](https://cdn.ampproject.org/experiments.html) page.
+* Find the AMP version being used on a page in the developer console, i.e. `Powered by AMP ⚡ HTML – Version <build number>`.

--- a/contributing/good-first-issues-template.md
+++ b/contributing/good-first-issues-template.md
@@ -40,7 +40,7 @@ Step-by-step instructions for the contributor to follow as they work through the
 - [ ] [Create a Git branch](https://github.com/ampproject/amphtml/blob/master/contributing/getting-started-e2e.md#create-a-git-branch) for making your changes.
 - [ ] [Sign the Contributor License Agreement](https://github.com/ampproject/amphtml/blob/master/CONTRIBUTING.md#contributor-license-agreement) before creating a Pull Request.  (If you are contributing code on behalf of a corporation start this process as early as possible.)
 <!--
-Add steps that are specific to the issue here, e.g. perhaps they should edit a test, run gulp test to see it fails, change a file and then run gulp test again to see that the new test succeeds?  Adjust the level of detail for the background you indicated the contributor should have.
+Add steps that are specific to the issue here, e.g. perhaps they should edit a test, run `gulp test --unt` or `gulp test --integration` to see it fails, change a file and then run test again to see that the new test succeeds?  Adjust the level of detail for the background you indicated the contributor should have.
 -->
 - [ ] [Commit your changes](https://github.com/ampproject/amphtml/blob/master/contributing/getting-started-e2e.md#edit-files-and-commit-them) frequently.
 - [ ] [Push your changes to GitHub](https://github.com/ampproject/amphtml/blob/master/contributing/getting-started-e2e.md#push-your-changes-to-your-github-fork).
@@ -62,4 +62,4 @@ Thanks, and we hope to see more contributions from you soon.
 <!--
 Ideally provide a specific contact to @mention here as well
 -->
-If you have questions ask in this issue or on your Pull Request (if you've created one) or see the [How to get help](https://github.com/ampproject/amphtml/blob/master/contributing/getting-started-e2e.md#how-to-get-help) section of the Getting Started guide.  
+If you have questions ask in this issue or on your Pull Request (if you've created one) or see the [How to get help](https://github.com/ampproject/amphtml/blob/master/contributing/getting-started-e2e.md#how-to-get-help) section of the Getting Started guide.

--- a/contributing/good-first-issues-template.md
+++ b/contributing/good-first-issues-template.md
@@ -40,7 +40,7 @@ Step-by-step instructions for the contributor to follow as they work through the
 - [ ] [Create a Git branch](https://github.com/ampproject/amphtml/blob/master/contributing/getting-started-e2e.md#create-a-git-branch) for making your changes.
 - [ ] [Sign the Contributor License Agreement](https://github.com/ampproject/amphtml/blob/master/CONTRIBUTING.md#contributor-license-agreement) before creating a Pull Request.  (If you are contributing code on behalf of a corporation start this process as early as possible.)
 <!--
-Add steps that are specific to the issue here, e.g. perhaps they should edit a test, run npx gulp test to see it fails, change a file and then run npx gulp test again to see that the new test succeeds?  Adjust the level of detail for the background you indicated the contributor should have.
+Add steps that are specific to the issue here, e.g. perhaps they should edit a test, run gulp test to see it fails, change a file and then run gulp test again to see that the new test succeeds?  Adjust the level of detail for the background you indicated the contributor should have.
 -->
 - [ ] [Commit your changes](https://github.com/ampproject/amphtml/blob/master/contributing/getting-started-e2e.md#edit-files-and-commit-them) frequently.
 - [ ] [Push your changes to GitHub](https://github.com/ampproject/amphtml/blob/master/contributing/getting-started-e2e.md#push-your-changes-to-your-github-fork).


### PR DESCRIPTION
This PR does the following:

- Updates the AMP dev docs to describe the problem with global `gulp` and how to avoid it (https://github.com/ampproject/amphtml/pull/14022#issue-175323521)
  - ... and gives the Quick Start and E2E docs a good spring cleaning.
- Updates the docs with instructions for how to install `gulp-cli` (or alternatively, use `npx gulp`) during local development (https://github.com/ampproject/amphtml/pull/14022#issuecomment-386123316)
- Adds a mechanism to `build-system/check-package-manager.js` to detect the presence of a global `gulp` install, and suggests the use of `gulp-cli` for local development 
- Changes internal invocations of `yarn` to `npx yarn` to make `gulp update-packages` work in the absence of a global installation of `yarn` (#15073)

Follow up to #14022
Follow up to #15073
