### PR TITLE
:bug: Ignore 'm' subdomain, too.

### DIFF
--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -49,7 +49,7 @@ const VIEWER_ORIGIN_TIMEOUT_ = 1000;
  * @private {!RegExp}
  */
 const TRIM_ORIGIN_PATTERN_ =
-  /^(https?:\/\/)((www[0-9]*|web|ftp|wap|home|mobile|amp)\.)+/i;
+  /^(https?:\/\/)((www[0-9]*|web|ftp|wap|home|mobile|amp|m)\.)+/i;
 
 /**
  * These domains are trusted with more sensitive viewer operations such as

--- a/test/functional/test-viewer.js
+++ b/test/functional/test-viewer.js
@@ -1099,6 +1099,8 @@ describe('Viewer', () => {
       testHasRoughlySameOrigin('https://www.amp.google.com', 'https://google.com');
       testHasRoughlySameOrigin('https://amp.www.google.com', 'https://google.com');
       testHasRoughlySameOrigin('https://mobile.google.com', 'https://google.com');
+      testHasRoughlySameOrigin('https://m.google.com', 'https://google.com');
+      testHasRoughlySameOrigin('https://amp.m.google.com', 'https://google.com');
       testHasRoughlySameOrigin('https://amp.mobile.google.com', 'https://google.com');
       testHasRoughlySameOrigin('https://amp.mobile.google.co.uk', 'https://google.co.uk');
       testHasRoughlySameOrigin('https://www1.www2.www3.google.com', 'https://google.com');


### PR DESCRIPTION
Simple patch to ignore "m" subdomain, in addition to the other common subdomains.