### PR TITLE
Fix for instagram API not returning height=height+padding values anymore

### DIFF
--- a/extensions/amp-instagram/0.1/amp-instagram.js
+++ b/extensions/amp-instagram/0.1/amp-instagram.js
@@ -64,7 +64,7 @@ import {user} from '../../../src/log';
 const PADDING_LEFT = 0;
 const PADDING_RIGHT = 0;
 const PADDING_BOTTOM = 0;
-const PADDING_TOP = 64;
+const PADDING_TOP = 0;
 
 class AmpInstagram extends AMP.BaseElement {
 
@@ -211,8 +211,6 @@ class AmpInstagram extends AMP.BaseElement {
       const height = data['details']['height'];
       this.getVsync().measure(() => {
         if (this.iframe_ && this.iframe_./*OK*/offsetHeight !== height) {
-          // Height returned by Instagram includes header, so
-          // subtract 48px top padding
           this./*OK*/changeHeight(height - (PADDING_TOP + PADDING_BOTTOM));
         }
       });

--- a/extensions/amp-instagram/0.1/amp-instagram.js
+++ b/extensions/amp-instagram/0.1/amp-instagram.js
@@ -56,16 +56,6 @@ import {startsWith} from '../../../src/string';
 import {tryParseJson} from '../../../src/json';
 import {user} from '../../../src/log';
 
-/*
- * These padding values are specifc to intagram embeds with
- * ?cr=1&v=7 if you change to a different version of the embed
- * these will need to be recalculated.
- */
-const PADDING_LEFT = 0;
-const PADDING_RIGHT = 0;
-const PADDING_BOTTOM = 0;
-const PADDING_TOP = 0;
-
 class AmpInstagram extends AMP.BaseElement {
 
   /** @param {!AmpElement} element */
@@ -144,10 +134,10 @@ class AmpInstagram extends AMP.BaseElement {
     // This makes the non-iframe image appear in the exact same spot
     // where it will be inside of the iframe.
     setStyles(image, {
-      'top': PADDING_TOP + 'px',
-      'bottom': PADDING_BOTTOM + 'px',
-      'left': PADDING_LEFT + 'px',
-      'right': PADDING_RIGHT + 'px',
+      'top': '0 px',
+      'bottom': '0 px',
+      'left': '0 px',
+      'right': '0 px',
     });
     placeholder.appendChild(image);
     return placeholder;
@@ -211,7 +201,7 @@ class AmpInstagram extends AMP.BaseElement {
       const height = data['details']['height'];
       this.getVsync().measure(() => {
         if (this.iframe_ && this.iframe_./*OK*/offsetHeight !== height) {
-          this./*OK*/changeHeight(height - (PADDING_TOP + PADDING_BOTTOM));
+          this./*OK*/changeHeight(height);
         }
       });
     }

--- a/extensions/amp-instagram/0.1/test/test-amp-instagram.js
+++ b/extensions/amp-instagram/0.1/test/test-amp-instagram.js
@@ -174,7 +174,7 @@ describes.realWin('amp-instagram', {
 
       expect(changeHeight).to.be.calledOnce;
       // Height minus padding
-      expect(changeHeight.firstCall.args[0]).to.equal(newHeight - 64);
+      expect(changeHeight.firstCall.args[0]).to.equal(newHeight);
     });
   });
 


### PR DESCRIPTION
The instagram API doesn't seem to be returning the height of the embed with the padding-{top,bottom} values which we used to compensate for. Setting the padding-top value to 0 to fix this so that components don't appear cut off anymore. 

Fixes https://github.com/ampproject/ampstart/issues/815