### PR TITLE
🐛Add date-template and info-template to amp-date-picker validation.

### DIFF
--- a/extensions/amp-date-picker/0.1/test/validator-amp-date-picker.html
+++ b/extensions/amp-date-picker/0.1/test/validator-amp-date-picker.html
@@ -27,6 +27,8 @@
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <script async custom-element="amp-date-picker"
     src="https://cdn.ampproject.org/v0/amp-date-picker-0.1.js"></script>
+  <script async custom-template="amp-mustache"
+    src="https://cdn.ampproject.org/v0/amp-mustache-0.1.js"></script>
 </head>
 <body>
   <!-- Valid: amp-date-picker with only layout attributes -->
@@ -110,5 +112,17 @@
   <amp-date-picker type="range" layout="fixed-height" height="360"
       first-day-of-week="7">
   </amp-date-picker>
+  <!-- Valid: amp-date-picker with date-template and/or info-template -->
+  <amp-date-picker layout="fixed-height" height="360">
+    <template info-template type="amp-mustache">
+    </template>
+    <template date-template default type="amp-mustache">
+    </template>
+    <template date-template dates="2018-01-01" type="amp-mustache" id="empty">
+    </template>
+  </amp-date-picker>
+  <!-- Invalid: amp-date-picker templates outside amp-date-picker -->
+  <template info-template type="amp-mustache"></template>
+  <template date-template dates="2018-01-01" type="amp-mustache"></template>
 </body>
 </html>

--- a/extensions/amp-date-picker/0.1/test/validator-amp-date-picker.out
+++ b/extensions/amp-date-picker/0.1/test/validator-amp-date-picker.out
@@ -28,6 +28,8 @@ FAIL
 |    <script async src="https://cdn.ampproject.org/v0.js"></script>
 |    <script async custom-element="amp-date-picker"
 |      src="https://cdn.ampproject.org/v0/amp-date-picker-0.1.js"></script>
+|    <script async custom-template="amp-mustache"
+|      src="https://cdn.ampproject.org/v0/amp-mustache-0.1.js"></script>
 |  </head>
 |  <body>
 |    <!-- Valid: amp-date-picker with only layout attributes -->
@@ -84,66 +86,82 @@ FAIL
 |    <!-- Invalid: single amp-date-picker with start-input-selector -->
 |    <amp-date-picker type="single" mode="static" start-input-selector="#a3" layout="fixed-height" height="360">
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:84:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=single][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:86:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=single][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:84:2 The attribute 'mode' in tag 'amp-date-picker[type=single][mode=overlay]' is set to the invalid value 'static'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_TAG_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:86:2 The attribute 'mode' in tag 'amp-date-picker[type=single][mode=overlay]' is set to the invalid value 'static'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_TAG_PROBLEM]
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:84:2 The attribute 'start-input-selector' may not appear in tag 'amp-date-picker[type=single][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_TAG_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:86:2 The attribute 'start-input-selector' may not appear in tag 'amp-date-picker[type=single][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_TAG_PROBLEM]
 |    </amp-date-picker>
 |    <!-- Invalid: range amp-date-picker with input-selector -->
 |    <amp-date-picker type="range" input-selector="#a4" layout="fixed-height" height="360">
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:87:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=single][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:89:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=single][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:87:2 The attribute 'type' in tag 'amp-date-picker[type=single][mode=overlay]' is set to the invalid value 'range'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_TAG_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:89:2 The attribute 'type' in tag 'amp-date-picker[type=single][mode=overlay]' is set to the invalid value 'range'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_TAG_PROBLEM]
 |      </amp-date-picker>
 |    <!-- Invalid: amp-date-picker with implicit mode="static" without layout -->
 |    <amp-date-picker></amp-date-picker>
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:90:2 The implied layout 'CONTAINER' is not supported by tag 'amp-date-picker[type=single][mode=static]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:92:2 The implied layout 'CONTAINER' is not supported by tag 'amp-date-picker[type=single][mode=static]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
 |    <!-- Invalid: amp-date-picker with explicit mode="static" without layout -->
 |    <amp-date-picker mode="static">
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:92:2 The implied layout 'CONTAINER' is not supported by tag 'amp-date-picker[type=single][mode=static]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:94:2 The implied layout 'CONTAINER' is not supported by tag 'amp-date-picker[type=single][mode=static]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
 |    </amp-date-picker>
 |    <!-- Invalid: overlay amp-date-picker with fullscreen attribute -->
 |    <amp-date-picker mode="overlay" fullscreen>
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:95:2 The implied layout 'CONTAINER' is not supported by tag 'amp-date-picker[type=single][mode=static]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:97:2 The implied layout 'CONTAINER' is not supported by tag 'amp-date-picker[type=single][mode=static]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:95:2 The attribute 'mode' in tag 'amp-date-picker[type=single][mode=static]' is set to the invalid value 'overlay'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_TAG_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:97:2 The attribute 'mode' in tag 'amp-date-picker[type=single][mode=static]' is set to the invalid value 'overlay'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_TAG_PROBLEM]
 |      <input type="text" name="date4">
 |    </amp-date-picker>
 |    <!-- Invalid: width is mistyped. -->
 |    <amp-date-picker height="360" wdith="360">
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:99:2 The implied layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=single][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:101:2 The implied layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=single][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:99:2 The attribute 'wdith' may not appear in tag 'amp-date-picker[type=single][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_TAG_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:101:2 The attribute 'wdith' may not appear in tag 'amp-date-picker[type=single][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_TAG_PROBLEM]
 |    </amp-date-picker>
 |    <!-- Invalid: amp-date-picker with bad day-size-->
 |    <amp-date-picker type="range" layout="fixed-height" height="360"
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:102:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=range][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:104:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=range][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:102:2 The attribute 'day-size' in tag 'amp-date-picker[type=range][mode=overlay]' is set to the invalid value 'five'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_TAG_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:104:2 The attribute 'day-size' in tag 'amp-date-picker[type=range][mode=overlay]' is set to the invalid value 'five'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_TAG_PROBLEM]
 |        day-size="five">
 |    </amp-date-picker>
 |    <!-- Invalid: amp-date-picker with bad number-of-months -->
 |    <amp-date-picker type="range" layout="fixed-height" height="360"
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:106:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=range][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:108:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=range][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:106:2 The attribute 'number-of-months' in tag 'amp-date-picker[type=range][mode=overlay]' is set to the invalid value 'twele'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_TAG_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:108:2 The attribute 'number-of-months' in tag 'amp-date-picker[type=range][mode=overlay]' is set to the invalid value 'twele'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_TAG_PROBLEM]
 |        number-of-months="twele">
 |    </amp-date-picker>
 |    <!-- Invalid: amp-date-picker with bad first-day-of-week -->
 |    <amp-date-picker type="range" layout="fixed-height" height="360"
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:110:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=range][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:112:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=range][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:110:2 The attribute 'first-day-of-week' in tag 'amp-date-picker[type=range][mode=overlay]' is set to the invalid value '7'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_TAG_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:112:2 The attribute 'first-day-of-week' in tag 'amp-date-picker[type=range][mode=overlay]' is set to the invalid value '7'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_TAG_PROBLEM]
 |        first-day-of-week="7">
 |    </amp-date-picker>
+|    <!-- Valid: amp-date-picker with date-template and/or info-template -->
+|    <amp-date-picker layout="fixed-height" height="360">
+|      <template info-template type="amp-mustache">
+|      </template>
+|      <template date-template default type="amp-mustache">
+|      </template>
+|      <template date-template dates="2018-01-01" type="amp-mustache" id="empty">
+|      </template>
+|    </amp-date-picker>
+|    <!-- Invalid: amp-date-picker templates outside amp-date-picker -->
+|    <template info-template type="amp-mustache"></template>
+>>   ^~~~~~~~~
+amp-date-picker/0.1/test/validator-amp-date-picker.html:125:2 The parent tag of tag 'amp-date-picker > template [info-template]' is 'body', but it can only be 'amp-date-picker'. (see https://www.ampproject.org/docs/reference/components/amp-mustache) [AMP_TAG_PROBLEM]
+|    <template date-template dates="2018-01-01" type="amp-mustache"></template>
+>>   ^~~~~~~~~
+amp-date-picker/0.1/test/validator-amp-date-picker.html:126:2 The parent tag of tag 'amp-date-picker > template [date-template] [dates]' is 'body', but it can only be 'amp-date-picker'. (see https://www.ampproject.org/docs/reference/components/amp-mustache) [AMP_TAG_PROBLEM]
 |  </body>
 |  </html>

--- a/extensions/amp-date-picker/validator-amp-date-picker.protoascii
+++ b/extensions/amp-date-picker/validator-amp-date-picker.protoascii
@@ -191,3 +191,69 @@ attr_lists: {
     value: ""
   }
 }
+
+# HTML5, 4.11.3 The template element
+tags: {
+  html_format: AMP
+  tag_name: "TEMPLATE"
+  spec_name: "amp-date-picker > template [date-template] [dates]"
+  mandatory_parent: "AMP-DATE-PICKER"
+  requires_extension: "amp-mustache"
+  attrs: {
+    name: "type"
+    mandatory: true
+    value: "amp-mustache"
+  }
+  attrs: {
+    name: "date-template"
+    mandatory: true
+    value: ""
+  }
+  attrs: {
+    name: "dates"
+    mandatory: true
+    dispatch_key: NAME_DISPATCH
+  }
+}
+tags: {
+  html_format: AMP
+  tag_name: "TEMPLATE"
+  spec_name: "amp-date-picker > template [date-template] [default]"
+  mandatory_parent: "AMP-DATE-PICKER"
+  requires_extension: "amp-mustache"
+  attrs: {
+    name: "type"
+    mandatory: true
+    value: "amp-mustache"
+  }
+  attrs: {
+    name: "date-template"
+    mandatory: true
+    value: ""
+  }
+  attrs: {
+    name: "default"
+    mandatory: true
+    value: ""
+    dispatch_key: NAME_DISPATCH
+  }
+}
+
+# HTML5, 4.11.3 The template element
+tags: {
+  html_format: AMP
+  tag_name: "TEMPLATE"
+  spec_name: "amp-date-picker > template [info-template]"
+  mandatory_parent: "AMP-DATE-PICKER"
+  requires_extension: "amp-mustache"
+  attrs: {
+    name: "type"
+    mandatory: true
+    value: "amp-mustache"
+  }
+  attrs: {
+    name: "info-template"
+    mandatory: true
+    dispatch_key: NAME_DISPATCH
+  }
+}

--- a/extensions/amp-date-picker/validator-amp-date-picker.protoascii
+++ b/extensions/amp-date-picker/validator-amp-date-picker.protoascii
@@ -193,17 +193,14 @@ attr_lists: {
 }
 
 # HTML5, 4.11.3 The template element
+# The template element is also defined at
+# extensions/amp-mustache/validator-amp-mustache.protoascii
 tags: {
   html_format: AMP
   tag_name: "TEMPLATE"
   spec_name: "amp-date-picker > template [date-template] [dates]"
   mandatory_parent: "AMP-DATE-PICKER"
   requires_extension: "amp-mustache"
-  attrs: {
-    name: "type"
-    mandatory: true
-    value: "amp-mustache"
-  }
   attrs: {
     name: "date-template"
     mandatory: true
@@ -214,6 +211,11 @@ tags: {
     mandatory: true
     dispatch_key: NAME_DISPATCH
   }
+  attrs: {
+    name: "type"
+    mandatory: true
+    value: "amp-mustache"
+  }
 }
 tags: {
   html_format: AMP
@@ -221,11 +223,6 @@ tags: {
   spec_name: "amp-date-picker > template [date-template] [default]"
   mandatory_parent: "AMP-DATE-PICKER"
   requires_extension: "amp-mustache"
-  attrs: {
-    name: "type"
-    mandatory: true
-    value: "amp-mustache"
-  }
   attrs: {
     name: "date-template"
     mandatory: true
@@ -237,9 +234,12 @@ tags: {
     value: ""
     dispatch_key: NAME_DISPATCH
   }
+  attrs: {
+    name: "type"
+    mandatory: true
+    value: "amp-mustache"
+  }
 }
-
-# HTML5, 4.11.3 The template element
 tags: {
   html_format: AMP
   tag_name: "TEMPLATE"
@@ -247,13 +247,13 @@ tags: {
   mandatory_parent: "AMP-DATE-PICKER"
   requires_extension: "amp-mustache"
   attrs: {
-    name: "type"
-    mandatory: true
-    value: "amp-mustache"
-  }
-  attrs: {
     name: "info-template"
     mandatory: true
     dispatch_key: NAME_DISPATCH
+  }
+  attrs: {
+    name: "type"
+    mandatory: true
+    value: "amp-mustache"
   }
 }

--- a/extensions/amp-mustache/validator-amp-mustache.protoascii
+++ b/extensions/amp-mustache/validator-amp-mustache.protoascii
@@ -47,6 +47,8 @@ tags: {  # amp-mustache
   attr_lists: "common-extension-attrs"
 }
 # HTML5, 4.11.3 The template element
+# The template element is also defined at
+# extensions/amp-date-picker/validator-amp-date-picker.protoascii
 tags: {
   tag_name: "TEMPLATE"
   # <template> tags may not be nested inside other <template> tags.


### PR DESCRIPTION
These were missing, making the date picker example on amp-by-example invalid.