### PR TITLE
🏗 More error checking, fix doc links

### DIFF
--- a/build-system/check-package-manager.js
+++ b/build-system/check-package-manager.js
@@ -74,7 +74,7 @@ function checkNodeVersion() {
         const latestLtsVersion = getNodeLatestLtsVersion(distributionsJson);
         if (latestLtsVersion === '') {
           console.log(yellow('WARNING: Something went wrong. ' +
-              'Could not determine latest LTS version of node.'));
+              'Could not determine the latest LTS version of node.'));
         } else if (nodeVersion !== latestLtsVersion) {
           console.log(yellow('WARNING: Detected node version'),
               cyan(nodeVersion) +
@@ -123,7 +123,7 @@ function checkYarnVersion() {
   const stableVersion = getYarnStableVersion(yarnInfoJson);
   if (stableVersion === '') {
     console.log(yellow('WARNING: Something went wrong. ' +
-        'Could not determine stable version of yarn.'));
+        'Could not determine the stable version of yarn.'));
   } else if (yarnVersion !== stableVersion) {
     console.log(yellow('WARNING: Detected yarn version'),
         cyan(yarnVersion) + yellow('. Recommended (stable) version is'),
@@ -170,9 +170,14 @@ function checkGlobalGulp() {
         cyan('"yarn global add gulp-cli"') + yellow('.'));
   } else {
     const gulpVersions = getStdout(gulpExecutable + ' --version').trim();
-    const gulpVersion = gulpVersions.match(/Local version (.*?)$/)[1];
-    console.log(green('Detected'), cyan('gulp'), green('version'),
-        cyan(gulpVersion) + green('.'));
+    const gulpVersion = gulpVersions.match(/Local version (.*?)$/);
+    if (gulpVersion && gulpVersion.length == 2) {
+      console.log(green('Detected'), cyan('gulp'), green('version'),
+          cyan(gulpVersion[1]) + green('.'));
+    } else {
+      console.log(yellow('WARNING: Something went wrong. ' +
+          'Could not determine the local version of gulp.'));
+    }
   }
 }
 

--- a/contributing/getting-started-e2e.md
+++ b/contributing/getting-started-e2e.md
@@ -164,14 +164,14 @@ Now that you have all of the files copied locally you can actually build the cod
    nvm install --lts
    ```
 
-* Install the stable version of [Yarn](https://yarnpkg.com/) (Mac and Linux: [here](https://yarnpkg.com/en/docs/install), Windows: [here](https://yarnpkg.com/lang/en/docs/install/#windows-stable))
+* Install the stable version of [Yarn](https://yarnpkg.com/) (Mac and Linux: [here](https://yarnpkg.com/en/docs/install#alternatives-stable), Windows: [here](https://yarnpkg.com/lang/en/docs/install/#windows-stable))
 
    ```
    curl -o- -L https://yarnpkg.com/install.sh | bash
    ```
   An alternative to installing `yarn` is to invoke each Yarn command in this guide with `npx yarn` during local development. This will automatically use the current stable version of `yarn`.
 
-* If you have a global install of [Gulp](https://gulpjs.com/), uninstall it. (See [this article](https://github.com/gulpjs/gulp/blob/v3.9.1/docs/getting-started.md) for why.)
+* If you have a global install of [Gulp](https://gulpjs.com/), uninstall it. (Instructions [here](https://github.com/gulpjs/gulp/blob/v3.9.1/docs/getting-started.md). See [this article](https://medium.com/gulpjs/gulp-sips-command-line-interface-e53411d4467) for why.)
 
    ```
    yarn global remove gulp

--- a/contributing/getting-started-quick.md
+++ b/contributing/getting-started-quick.md
@@ -32,14 +32,14 @@ This Quick Start guide is the TL;DR version of the longer [end-to-end guide](get
    nvm install --lts
    ```
 
-* Install the stable version of [Yarn](https://yarnpkg.com/). (Mac and Linux: [here](https://yarnpkg.com/en/docs/install), Windows: [here](https://yarnpkg.com/lang/en/docs/install/#windows-stable))
+* Install the stable version of [Yarn](https://yarnpkg.com/). (Mac and Linux: [here](https://yarnpkg.com/en/docs/install#alternatives-stable), Windows: [here](https://yarnpkg.com/lang/en/docs/install/#windows-stable))
 
    ```
    curl -o- -L https://yarnpkg.com/install.sh | bash
    ```
   An alternative to installing `yarn` is to invoke each Yarn command in this guide with `npx yarn` during local development. This will automatically use the current stable version of `yarn`.
 
-* If you have a global install of [Gulp](https://gulpjs.com/), uninstall it. (See [this article](https://github.com/gulpjs/gulp/blob/v3.9.1/docs/getting-started.md) for why.)
+* If you have a global install of [Gulp](https://gulpjs.com/), uninstall it. (Instructions [here](https://github.com/gulpjs/gulp/blob/v3.9.1/docs/getting-started.md). See [this article](https://medium.com/gulpjs/gulp-sips-command-line-interface-e53411d4467) for why.)
 
    ```
    yarn global remove gulp


### PR DESCRIPTION
This PR:
1. Adds some error checking to `build-system/check-package-manager.js`, since it's run very often, and shouldn't ever fail.
2. Fixes some incorrect / missing links in the docs.

Follow up to #15092