### PR TITLE
🐛 Use `compact=false` for `babelify` during `gulp dep-check` and `gulp test`

### DIFF
--- a/build-system/tasks/bundle-size.js
+++ b/build-system/tasks/bundle-size.js
@@ -21,7 +21,7 @@ const gulp = require('gulp-help')(require('gulp'));
 const log = require('fancy-log');
 
 const runtimeFile = './dist/v0.js';
-const maxSize = '77.21KB';
+const maxSize = '77.23KB';
 
 const green = colors.green;
 const red = colors.red;

--- a/build-system/tasks/dep-check.js
+++ b/build-system/tasks/dep-check.js
@@ -16,7 +16,7 @@
 'use strict';
 
 
-const babel = require('babelify');
+const babelify = require('babelify');
 const BBPromise = require('bluebird');
 const browserify = require('browserify');
 const colors = require('ansi-colors');
@@ -175,7 +175,7 @@ function getGraph(entryModule) {
   // TODO(erwinm): Try and work this in with `gulp build` so that
   // we're not running browserify twice on travis.
   const bundler = browserify(entryModule, {debug: true, deps: true})
-      .transform(babel.configure({}));
+      .transform(babelify, {compact: false});
 
   bundler.pipeline.get('deps').push(through.obj(function(row, enc, next) {
     module.deps.push({

--- a/build-system/tasks/karma.conf.js
+++ b/build-system/tasks/karma.conf.js
@@ -46,7 +46,7 @@ module.exports = {
     watch: true,
     debug: true,
     transform: [
-      ['babelify'],
+      ['babelify', {compact: false}],
     ],
     bundleDelay: 900,
   },


### PR DESCRIPTION
#15076 silenced an annoying `babelify` warning due to `third_party/react-dates/bundle.js`, seen during [`gulp build`](https://travis-ci.org/ampproject/amphtml/jobs/375008324#L638).

> Note: The code generator has deoptimised the styling of "/home/travis/build/ampproject/amphtml/third_party/react-dates/bundle.js" as it exceeds the max of "500KB".

This PR silences the same warning during [`gulp dep-check`](https://travis-ci.org/ampproject/amphtml/jobs/375132397#L1243) and [`gulp test`](https://travis-ci.org/ampproject/amphtml/jobs/375132397#L1263).

Follow up to #15076
Fixes #14831