### PR TITLE
🐛✅ Explicitly specify `browserify` module paths relative to a base directory while running tests

### DIFF
--- a/build-system/tasks/karma.conf.js
+++ b/build-system/tasks/karma.conf.js
@@ -35,16 +35,17 @@ module.exports = {
   ],
 
   preprocessors: {
-    'test/fixtures/*.html': ['html2js'],
-    'test/**/*.js': ['browserify'],
-    'ads/**/test/test-*.js': ['browserify'],
-    'extensions/**/test/**/*.js': ['browserify'],
-    'testing/**/*.js': ['browserify'],
+    './test/fixtures/*.html': ['html2js'],
+    './test/**/*.js': ['browserify'],
+    './ads/**/test/test-*.js': ['browserify'],
+    './extensions/**/test/**/*.js': ['browserify'],
+    './testing/**/*.js': ['browserify'],
   },
 
   browserify: {
     watch: true,
     debug: true,
+    basedir: __dirname + '/../../',
     transform: [
       ['babelify', {compact: false}],
     ],
@@ -128,7 +129,7 @@ module.exports = {
     },
     Chrome_no_extensions_headless: {
       base: 'ChromeHeadless',
-      flags: COMMON_CHROME_FLAGS,
+      flags: ['--no-sandbox'].concat(COMMON_CHROME_FLAGS),
     },
     // SauceLabs configurations.
     // New configurations can be created here:

--- a/build-system/tasks/runtime-test.js
+++ b/build-system/tasks/runtime-test.js
@@ -169,7 +169,7 @@ function printArgvMessages() {
     log(green('Run'), cyan('gulp help'),
         green('to see a list of all test flags.'));
     log(green('⤷ Use'), cyan('--nohelp'),
-        green('to silence these messages.)'));
+        green('to silence these messages.'));
     if (!argv.unit && !argv.integration && !argv.files && !argv.a4a) {
       log(green('Running all tests.'));
       log(green('⤷ Use'), cyan('--unit'), green('or'), cyan('--integration'),


### PR DESCRIPTION
The transient "module not found" errors described in #14166 are [still happening](https://travis-ci.org/ampproject/amphtml/jobs/375708551#L822).

According to https://github.com/browserify/browserify/issues/1271, it probably has to do with paths being specified incorrectly while passing files into `browserify`.

Error stems from [here](https://github.com/browserify/browser-pack/blob/1faef2d21d50d9bd949230955bbb1dd0e6431ce3/prelude.js#L25-L32).

This PR adds a `builddir` option to `browserify` while running tests.

Fixes #14166
