### PR TITLE
`console.error` cleanup: Remove unnecessary usage of `allowConsoleError`

### DIFF
--- a/build-system/tasks/runtime-test.js
+++ b/build-system/tasks/runtime-test.js
@@ -374,9 +374,13 @@ function runTests() {
           yellow('Karma test failed with exit code ' + exitCode));
     }
     // TODO(rsimha, 14814): Remove after Karma / Sauce ticket is resolved.
-    setTimeout(() => {
-      process.exit(exitCode);
-    }, 5000);
+    if (process.env.TRAVIS) {
+      setTimeout(() => {
+        process.exit(exitCode);
+      }, 5000);
+    } else {
+      process.exitCode = exitCode;
+    }
     resolver();
   }).on('run_start', function() {
     if (argv.saucelabs || argv.saucelabs_lite) {

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -2045,9 +2045,9 @@ describe('amp-a4a', () => {
     });
 
     it('should rethrow cancellation', () => {
-      allowConsoleError(() => { expect(() => {
+      expect(() => {
         a4a.promiseErrorHandler_(cancellation());
-      }).to.throw(/CANCELLED/); });
+      }).to.throw(/CANCELLED/);
     });
 
     it('should create an error if needed', () => {

--- a/extensions/amp-a4a/0.1/test/test-real-time-config-manager.js
+++ b/extensions/amp-a4a/0.1/test/test-real-time-config-manager.js
@@ -536,11 +536,9 @@ describes.realWin('real-time-config-manager', {amp: true}, env => {
       {'vendors': {}, 'urls': []},
       {'vendors': 'incorrect', 'urls': 'incorrect'}].forEach(rtcConfig => {
       it('should return null for rtcConfig missing required values', () => {
-        allowConsoleError(() => {
-          setRtcConfig(rtcConfig);
-          validatedRtcConfig = validateRtcConfig_(element);
-          expect(validatedRtcConfig).to.be.null;
-        });
+        setRtcConfig(rtcConfig);
+        validatedRtcConfig = validateRtcConfig_(element);
+        expect(validatedRtcConfig).to.be.null;
       });
     });
 

--- a/extensions/amp-access/0.1/test/test-access-expr.js
+++ b/extensions/amp-access/0.1/test/test-access-expr.js
@@ -20,9 +20,9 @@ import {evaluateAccessExpr} from '../access-expr';
 describe('evaluateAccessExpr', () => {
 
   it('should NOT allow double equal', () => {
-    allowConsoleError(() => { expect(() => {
+    expect(() => {
       evaluateAccessExpr('access == true', {});
-    }).to.throw(/\"\=\=\" is not allowed, use \"\=\"/); });
+    }).to.throw(/\"\=\=\" is not allowed, use \"\=\"/);
   });
 
   it('should evaluate simple boolean expressions', () => {
@@ -256,18 +256,18 @@ describe('evaluateAccessExpr', () => {
 
     expect(evaluateAccessExpr('obj.other = NULL', {obj: 11})).to.be.true;
 
-    allowConsoleError(() => { expect(() => {
+    expect(() => {
       evaluateAccessExpr('obj.NULL', {});
-    }).to.throw(); });
-    allowConsoleError(() => { expect(() => {
+    }).to.throw();
+    expect(() => {
       evaluateAccessExpr('NULL.obj', {});
-    }).to.throw(); });
-    allowConsoleError(() => { expect(() => {
+    }).to.throw();
+    expect(() => {
       evaluateAccessExpr('1.obj', {});
-    }).to.throw(); });
-    allowConsoleError(() => { expect(() => {
+    }).to.throw();
+    expect(() => {
       evaluateAccessExpr('TRUE.obj', {});
-    }).to.throw(); });
+    }).to.throw();
   });
 
   it('should evaluate nested expressions securely', () => {
@@ -280,14 +280,14 @@ describe('evaluateAccessExpr', () => {
     expect(evaluateAccessExpr('num_ = 10', {num_: 10})).to.be.true;
     expect(evaluateAccessExpr('_num = 10', {_num: 10})).to.be.true;
 
-    allowConsoleError(() => { expect(() => {
+    expect(() => {
       evaluateAccessExpr('1num = 10', {'1num': 10});
-    }).to.throw(); });
-    allowConsoleError(() => { expect(() => {
+    }).to.throw();
+    expect(() => {
       evaluateAccessExpr('num-a = 10', {'num-a': 10});
-    }).to.throw(); });
-    allowConsoleError(() => { expect(() => {
+    }).to.throw();
+    expect(() => {
       evaluateAccessExpr('num-1 = 10', {'num-1': 10});
-    }).to.throw(); });
+    }).to.throw();
   });
 });

--- a/extensions/amp-access/0.1/test/test-amp-access.js
+++ b/extensions/amp-access/0.1/test/test-amp-access.js
@@ -61,9 +61,9 @@ describes.fakeWin('AccessService', {
   });
 
   it('should fail if config is malformed', () => {
-    allowConsoleError(() => { expect(() => {
+    expect(() => {
       new AccessService(ampdoc);
-    }).to.throw(Error); });
+    }).to.throw(Error);
   });
 
   it('should default to "client" and fail if authorization is missing', () => {

--- a/extensions/amp-access/0.1/test/test-iframe-messenger.js
+++ b/extensions/amp-access/0.1/test/test-iframe-messenger.js
@@ -43,9 +43,9 @@ describes.fakeWin('Messenger', {}, env => {
     });
 
     it('should now allow connecting twice', () => {
-      allowConsoleError(() => { expect(() => {
+      expect(() => {
         messenger.connect(onCommand);
-      }).to.throw(/already connected/); });
+      }).to.throw(/already connected/);
     });
 
     it('should add and remove message listener', () => {
@@ -62,9 +62,9 @@ describes.fakeWin('Messenger', {}, env => {
     });
 
     it('should fail target until connected', () => {
-      allowConsoleError(() => { expect(() => {
+      expect(() => {
         messenger.getTarget();
-      }).to.throw(/not connected/); });
+      }).to.throw(/not connected/);
     });
 
     it('should succeed target once connected', () => {
@@ -78,9 +78,9 @@ describes.fakeWin('Messenger', {}, env => {
     });
 
     it('should fail sending a command until connected', () => {
-      allowConsoleError(() => { expect(() => {
+      expect(() => {
         messenger.sendCommand('start', {});
-      }).to.throw(/not connected/); });
+      }).to.throw(/not connected/);
     });
 
     it('should send a command once connected', () => {
@@ -214,9 +214,7 @@ describes.fakeWin('Messenger', {}, env => {
       return promise.then(() => {
         throw new Error('must have failed');
       }, reason => {
-        allowConsoleError(() => {
-          expect(() => {throw reason;}).to.throw(/intentional/);
-        });
+        expect(() => {throw reason;}).to.throw(/intentional/);
       });
     });
 
@@ -321,15 +319,15 @@ describes.fakeWin('Messenger', {}, env => {
 
     it('should fail to return origin until connected', () => {
       expect(messenger.isConnected()).to.be.false;
-      allowConsoleError(() => { expect(() => {
+      expect(() => {
         messenger.getTargetOrigin();
-      }).to.throw(/not connected/); });
+      }).to.throw(/not connected/);
     });
 
     it('should disallow other commands before connect', () => {
-      allowConsoleError(() => { expect(() => {
+      expect(() => {
         messenger.sendCommand('other', {});
-      }).to.throw(/not connected/); });
+      }).to.throw(/not connected/);
       expect(target.postMessage).to.not.be.called;
     });
 
@@ -378,9 +376,9 @@ describes.fakeWin('Messenger', {}, env => {
         data: {sentinel: '__AMP__', cmd: 'other', payload: {a: 1}},
       });
       expect(messenger.isConnected()).to.be.false;
-      allowConsoleError(() => { expect(() => {
+      expect(() => {
         messenger.getTargetOrigin();
-      }).to.throw(/not connected/); });
+      }).to.throw(/not connected/);
       expect(onCommand).to.not.be.called;
     });
   });

--- a/extensions/amp-access/0.1/test/test-jwt.js
+++ b/extensions/amp-access/0.1/test/test-jwt.js
@@ -63,23 +63,23 @@ describe('JwtHelper', () => {
     });
 
     it('should fail on invalid format', () => {
-      allowConsoleError(() => { expect(() => {
+      expect(() => {
         helper.decodeInternal_('ABC');
-      }).to.throw(/Invalid token/); });
+      }).to.throw(/Invalid token/);
     });
 
     it('should fail on invalid JSON in header', () => {
-      allowConsoleError(() => { expect(() => {
+      expect(() => {
         helper.decodeInternal_(
             `${TOKEN_HEADER.substring(1)}.${TOKEN_PAYLOAD}.${TOKEN_SIG}`);
-      }).to.throw(/Invalid token/); });
+      }).to.throw(/Invalid token/);
     });
 
     it('should fail on invalid JSON in payload', () => {
-      allowConsoleError(() => { expect(() => {
+      expect(() => {
         helper.decodeInternal_(
             `${TOKEN_HEADER}.${TOKEN_PAYLOAD.substring(1)}.${TOKEN_SIG}`);
-      }).to.throw(/Invalid token/); });
+      }).to.throw(/Invalid token/);
     });
 
     it('should decode web safe and non-web-safe base64', () => {

--- a/extensions/amp-analytics/0.1/test/test-iframe-transport-client.js
+++ b/extensions/amp-analytics/0.1/test/test-iframe-transport-client.js
@@ -64,10 +64,10 @@ describe('iframe-transport-client', () => {
 
   it('fails to create iframeTransportClient if no window.name ', () => {
     const oldWindowName = window.name;
-    allowConsoleError(() => { expect(() => {
+    expect(() => {
       window.name = '';
       new IframeTransportClient(window);
-    }).to.throw(/Cannot read property/); });
+    }).to.throw(/Cannot read property/);
     window.name = oldWindowName;
   });
 

--- a/extensions/amp-analytics/0.1/test/test-instrumentation.js
+++ b/extensions/amp-analytics/0.1/test/test-instrumentation.js
@@ -116,9 +116,9 @@ describes.realWin('InstrumentationService', {amp: 1}, env => {
       sandbox.stub(root, 'getTracker').callsFake(() => {
         throw new Error('intentional');
       });
-      allowConsoleError(() => { expect(() => {
+      expect(() => {
         group.addTrigger({on: 'click', selector: '*'});
-      }).to.throw(/intentional/); });
+      }).to.throw(/intentional/);
     });
 
     it('should delegate to deprecated addListener', () => {

--- a/extensions/amp-animation/0.1/test/test-css-expr.js
+++ b/extensions/amp-animation/0.1/test/test-css-expr.js
@@ -596,9 +596,9 @@ describes.sandboxed('CSS resolve', {}, () => {
           .throws(new Error('intentional'))
           .once();
       const node = new ast.CssUrlNode('http://acme.org/non-secure');
-      allowConsoleError(() => { expect(() => {
+      expect(() => {
         node.calc(context);
-      }).to.throw(/intentional/); });
+      }).to.throw(/intentional/);
     });
   });
 
@@ -712,23 +712,21 @@ describes.sandboxed('CSS resolve', {}, () => {
     });
 
     it('should disallow a real-length node', () => {
-      allowConsoleError(() => {
-        expect(() => {
-          new ast.CssLengthNode(1, 'cm').norm(context);
-        }).to.throw(/unknown/);
-        expect(() => {
-          new ast.CssLengthNode(1, 'mm').norm(context);
-        }).to.throw(/unknown/);
-        expect(() => {
-          new ast.CssLengthNode(1, 'in').norm(context);
-        }).to.throw(/unknown/);
-        expect(() => {
-          new ast.CssLengthNode(1, 'pt').norm(context);
-        }).to.throw(/unknown/);
-        expect(() => {
-          new ast.CssLengthNode(1, 'q').norm(context);
-        }).to.throw(/unknown/);
-      });
+      expect(() => {
+        new ast.CssLengthNode(1, 'cm').norm(context);
+      }).to.throw(/unknown/);
+      expect(() => {
+        new ast.CssLengthNode(1, 'mm').norm(context);
+      }).to.throw(/unknown/);
+      expect(() => {
+        new ast.CssLengthNode(1, 'in').norm(context);
+      }).to.throw(/unknown/);
+      expect(() => {
+        new ast.CssLengthNode(1, 'pt').norm(context);
+      }).to.throw(/unknown/);
+      expect(() => {
+        new ast.CssLengthNode(1, 'q').norm(context);
+      }).to.throw(/unknown/);
     });
 
     it('should resolve a percent-length in w-direction', () => {
@@ -1080,7 +1078,7 @@ describes.sandboxed('CSS resolve', {}, () => {
     it('should be always a non-const and no css', () => {
       const node = new ast.CssDimSizeNode('?');
       expect(node.isConst()).to.be.false;
-      allowConsoleError(() => { expect(() => node.css()).to.throw(/no css/); });
+      expect(() => node.css()).to.throw(/no css/);
     });
 
     it('should resolve width on the current node', () => {
@@ -1123,7 +1121,7 @@ describes.sandboxed('CSS resolve', {}, () => {
     it('should always be a non-const and no css', () => {
       const node = new ast.CssNumConvertNode();
       expect(node.isConst()).to.equal(false);
-      allowConsoleError(() => { expect(() => node.css()).to.throw(/no css/); });
+      expect(() => node.css()).to.throw(/no css/);
     });
 
     it('should resolve num from a number', () => {
@@ -1216,7 +1214,7 @@ describes.sandboxed('CSS resolve', {}, () => {
     it('should always be a non-const and no css', () => {
       const node = new ast.CssRandNode();
       expect(node.isConst()).to.equal(false);
-      allowConsoleError(() => { expect(() => node.css()).to.throw(/no css/); });
+      expect(() => node.css()).to.throw(/no css/);
     });
 
     it('should resolve a no-arg rand', () => {
@@ -1299,18 +1297,18 @@ describes.sandboxed('CSS resolve', {}, () => {
       const node = new ast.CssRandNode(
           new ast.CssPassthroughNode('A'),
           new ast.CssPassthroughNode('B'));
-      allowConsoleError(() => { expect(() => {
+      expect(() => {
         resolvedCss(node);
-      }).to.throw(/both numerical/); });
+      }).to.throw(/both numerical/);
     });
 
     it('should only allow same-type', () => {
       const node = new ast.CssRandNode(
           new ast.CssLengthNode(30, 'px'),
           new ast.CssTimeNode(20, 's'));
-      allowConsoleError(() => { expect(() => {
+      expect(() => {
         resolvedCss(node);
-      }).to.throw(/same type/); });
+      }).to.throw(/same type/);
     });
 
     it('should normalize units', () => {
@@ -1333,7 +1331,7 @@ describes.sandboxed('CSS resolve', {}, () => {
       const node = new ast.CssIndexNode();
       expect(node.isConst()).to.be.false;
       expect(node.isConst(normalize)).to.be.false;
-      allowConsoleError(() => { expect(() => node.css()).to.throw(/no css/); });
+      expect(() => node.css()).to.throw(/no css/);
     });
 
     it('should resolve a no-arg', () => {
@@ -1540,9 +1538,9 @@ describes.sandboxed('CSS resolve', {}, () => {
             new ast.CssPassthroughNode('A'),
             new ast.CssPassthroughNode('B'),
             '+');
-        allowConsoleError(() => { expect(() => {
+        expect(() => {
           resolvedCss(node);
-        }).to.throw(/both numerical/); });
+        }).to.throw(/both numerical/);
       });
 
       it('should only allow same-type', () => {
@@ -1550,9 +1548,9 @@ describes.sandboxed('CSS resolve', {}, () => {
             new ast.CssLengthNode(30, 'px'),
             new ast.CssTimeNode(20, 's'),
             '+');
-        allowConsoleError(() => { expect(() => {
+        expect(() => {
           resolvedCss(node);
-        }).to.throw(/same type/); });
+        }).to.throw(/same type/);
       });
 
       it('should normalize units', () => {
@@ -1633,9 +1631,9 @@ describes.sandboxed('CSS resolve', {}, () => {
             new ast.CssPassthroughNode('A'),
             new ast.CssPassthroughNode('B'),
             '*');
-        allowConsoleError(() => { expect(() => {
+        expect(() => {
           resolvedCss(node);
-        }).to.throw(/both numerical/); });
+        }).to.throw(/both numerical/);
       });
 
       it('should multiply with right number', () => {
@@ -1683,9 +1681,9 @@ describes.sandboxed('CSS resolve', {}, () => {
             new ast.CssLengthNode(10, 'px'),
             new ast.CssLengthNode(20, 'px'),
             '*');
-        allowConsoleError(() => { expect(() => {
+        expect(() => {
           resolvedCss(node);
-        }).to.throw(/one of sides in multiplication must be a number/); });
+        }).to.throw(/one of sides in multiplication must be a number/);
       });
 
       it('should divide with right number', () => {
@@ -1723,9 +1721,9 @@ describes.sandboxed('CSS resolve', {}, () => {
             new ast.CssTimeNode(10, 's'),
             new ast.CssTimeNode(2, 's'),
             '/');
-        allowConsoleError(() => { expect(() => {
+        expect(() => {
           resolvedCss(node);
-        }).to.throw(/denominator must be a number/); });
+        }).to.throw(/denominator must be a number/);
       });
 
       it('should resolve divide-by-zero as null', () => {

--- a/extensions/amp-bind/0.1/test/test-bind-expression.js
+++ b/extensions/amp-bind/0.1/test/test-bind-expression.js
@@ -74,29 +74,27 @@ describe('BindExpression', () => {
     });
 
     it('disallow: operators with side effects', () => {
-      allowConsoleError(() => {
-        expect(() => { evaluate('foo = 1', {foo: 0}); }).to.throw();
-        expect(() => { evaluate('foo += 1', {foo: 0}); }).to.throw();
-        expect(() => { evaluate('foo -= 1', {foo: 0}); }).to.throw();
-        expect(() => { evaluate('foo *= 1', {foo: 0}); }).to.throw();
-        expect(() => { evaluate('foo /= 1', {foo: 0}); }).to.throw();
-        expect(() => { evaluate('foo %= 1', {foo: 0}); }).to.throw();
-        expect(() => { evaluate('foo **= 1', {foo: 0}); }).to.throw();
-        expect(() => { evaluate('foo <<= 1', {foo: 0}); }).to.throw();
-        expect(() => { evaluate('foo >>= 1', {foo: 0}); }).to.throw();
-        expect(() => { evaluate('foo >>>= 1', {foo: 0}); }).to.throw();
-        expect(() => { evaluate('foo &= 1', {foo: 0}); }).to.throw();
-        expect(() => { evaluate('foo ^= 1', {foo: 0}); }).to.throw();
-        expect(() => { evaluate('foo |= 1', {foo: 0}); }).to.throw();
-        expect(() => { evaluate('foo++', {foo: 0}); }).to.throw();
-        expect(() => { evaluate('foo--', {foo: 0}); }).to.throw();
-        expect(() => { evaluate('~foo', {foo: 0}); }).to.throw();
-        expect(() => { evaluate('foo << 1', {foo: 0}); }).to.throw();
-        expect(() => { evaluate('foo >> 1', {foo: 0}); }).to.throw();
-        expect(() => { evaluate('foo >>> 1', {foo: 0}); }).to.throw();
-        expect(() => { evaluate('new Object()', {foo: 0}); }).to.throw();
-        expect(() => { evaluate('delete foo', {foo: 0}); }).to.throw();
-      });
+      expect(() => { evaluate('foo = 1', {foo: 0}); }).to.throw();
+      expect(() => { evaluate('foo += 1', {foo: 0}); }).to.throw();
+      expect(() => { evaluate('foo -= 1', {foo: 0}); }).to.throw();
+      expect(() => { evaluate('foo *= 1', {foo: 0}); }).to.throw();
+      expect(() => { evaluate('foo /= 1', {foo: 0}); }).to.throw();
+      expect(() => { evaluate('foo %= 1', {foo: 0}); }).to.throw();
+      expect(() => { evaluate('foo **= 1', {foo: 0}); }).to.throw();
+      expect(() => { evaluate('foo <<= 1', {foo: 0}); }).to.throw();
+      expect(() => { evaluate('foo >>= 1', {foo: 0}); }).to.throw();
+      expect(() => { evaluate('foo >>>= 1', {foo: 0}); }).to.throw();
+      expect(() => { evaluate('foo &= 1', {foo: 0}); }).to.throw();
+      expect(() => { evaluate('foo ^= 1', {foo: 0}); }).to.throw();
+      expect(() => { evaluate('foo |= 1', {foo: 0}); }).to.throw();
+      expect(() => { evaluate('foo++', {foo: 0}); }).to.throw();
+      expect(() => { evaluate('foo--', {foo: 0}); }).to.throw();
+      expect(() => { evaluate('~foo', {foo: 0}); }).to.throw();
+      expect(() => { evaluate('foo << 1', {foo: 0}); }).to.throw();
+      expect(() => { evaluate('foo >> 1', {foo: 0}); }).to.throw();
+      expect(() => { evaluate('foo >>> 1', {foo: 0}); }).to.throw();
+      expect(() => { evaluate('new Object()', {foo: 0}); }).to.throw();
+      expect(() => { evaluate('delete foo', {foo: 0}); }).to.throw();
     });
 
     /** @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators */
@@ -111,12 +109,10 @@ describe('BindExpression', () => {
       expect(evaluate('new')).to.be.null;
       expect(evaluate('super')).to.be.null;
 
-      allowConsoleError(() => {
-        expect(() => { evaluate('function*'); }).to.throw();
-        expect(() => { evaluate('/ab+c/i'); }).to.throw();
-        expect(() => { evaluate('yield*'); }).to.throw();
-        expect(() => { evaluate('async function*'); }).to.throw();
-      });
+      expect(() => { evaluate('function*'); }).to.throw();
+      expect(() => { evaluate('/ab+c/i'); }).to.throw();
+      expect(() => { evaluate('yield*'); }).to.throw();
+      expect(() => { evaluate('async function*'); }).to.throw();
     });
   });
 
@@ -304,9 +300,7 @@ describe('BindExpression', () => {
       expect(evaluate('{null: "b"}')).to.deep.equal({null: 'b'});
       // Unquoted string keys should _not_ be evaluated as expressions.
       expect(evaluate('{a: "b"}', {a: 'foo'})).to.deep.equal({a: 'b'});
-      allowConsoleError(() => {
-        expect(() => evaluate('{1+1: "b"}')).to.throw();
-      });
+      expect(() => evaluate('{1+1: "b"}')).to.throw();
     });
 
     it('computed property names', () => {
@@ -350,17 +344,17 @@ describe('BindExpression', () => {
       expect(evaluate('abs(-2) + abs', {abs: 2})).to.equal(4);
 
       // Don't support non-whitelisted functions.
-      allowConsoleError(() => { expect(() => {
+      expect(() => {
         evaluate('sin(0.5)');
-      }).to.throw(unsupportedFunctionError); });
-      allowConsoleError(() => { expect(() => {
+      }).to.throw(unsupportedFunctionError);
+      expect(() => {
         evaluate('pow(3, 2)');
-      }).to.throw(unsupportedFunctionError); });
+      }).to.throw(unsupportedFunctionError);
 
       // Don't support calling functions with `Math.` prefix.
-      allowConsoleError(() => { expect(() => {
+      expect(() => {
         evaluate('Math.abs(-1)', {Math});
-      }).to.throw(unsupportedFunctionError); });
+      }).to.throw(unsupportedFunctionError);
     });
 
     it('encodeURI and encodeURIComponent', () => {
@@ -372,10 +366,8 @@ describe('BindExpression', () => {
 
     it('splice()', () => {
       const a = [1, 2, 3];
-      allowConsoleError(() => {
-        expect(() => evaluate('splice()')).to.throw(/not an array/);
-        expect(() => evaluate('splice(x)', {x: 8472})).to.throw(/not an array/);
-      });
+      expect(() => evaluate('splice()')).to.throw(/not an array/);
+      expect(() => evaluate('splice(x)', {x: 8472})).to.throw(/not an array/);
       expect(evaluate('splice(a)', {a})).to.not.equal(a);
       expect(evaluate('splice(a)', {a})).to.deep.equal(a);
       expect(evaluate('splice(a, 1)', {a})).to.deep.equal([1]);
@@ -385,10 +377,8 @@ describe('BindExpression', () => {
 
     it('sort()', () => {
       const a = [2, 3, 1];
-      allowConsoleError(() => {
-        expect(() => evaluate('sort()')).to.throw(/not an array/);
-        expect(() => evaluate('sort("abc")')).to.throw(/not an array/);
-      });
+      expect(() => evaluate('sort()')).to.throw(/not an array/);
+      expect(() => evaluate('sort("abc")')).to.throw(/not an array/);
       expect(evaluate('sort(a)', {a})).to.not.equal(a);
       expect(evaluate('sort(a)', {a})).to.deep.equal([1, 2, 3]);
     });
@@ -418,16 +408,12 @@ describe('BindExpression', () => {
         qux: window.Function,
       };
       // baz() throws a parse error because functions must have a caller.
-      allowConsoleError(() => {
-        expect(() => { evaluate('baz()', scope); }).to.throw();
-      });
+      expect(() => { evaluate('baz()', scope); }).to.throw();
       expect(() => { evaluate('foo.bar()', scope); })
           .to.throw(Error, unsupportedFunctionError);
-      allowConsoleError(() => {
-        expect(() => {
-          evaluate('foo.qux("a", "return a")', scope);
-        }).to.throw(unsupportedFunctionError);
-      });
+      expect(() => {
+        evaluate('foo.qux("a", "return a")', scope);
+      }).to.throw(unsupportedFunctionError);
     });
 
     it('disallow: invocation of prototype functions', () => {
@@ -512,21 +498,19 @@ describe('BindExpression', () => {
     });
 
     it('disallow: loops', () => {
-      allowConsoleError(() => {
-        expect(() => { evaluate('if (foo) "bar"', {foo: 0}); }).to.throw();
-        expect(() => {
-          evaluate('switch (foo) { case 0: "bar" }', {foo: 0});
-        }).to.throw();
-        expect(() => { evaluate('for (;;) {}'); }).to.throw();
-        expect(() => { evaluate('while (true) {}'); }).to.throw();
-        expect(() => { evaluate('do {} while (true)'); }).to.throw();
-        expect(() => {
-          evaluate('for (var i in foo) {}', {foo: [1, 2, 3]});
-        }).to.throw();
-        expect(() => {
-          evaluate('for (var i of foo) {}', {foo: [1, 2, 3]});
-        }).to.throw();
-      });
+      expect(() => { evaluate('if (foo) "bar"', {foo: 0}); }).to.throw();
+      expect(() => {
+        evaluate('switch (foo) { case 0: "bar" }', {foo: 0});
+      }).to.throw();
+      expect(() => { evaluate('for (;;) {}'); }).to.throw();
+      expect(() => { evaluate('while (true) {}'); }).to.throw();
+      expect(() => { evaluate('do {} while (true)'); }).to.throw();
+      expect(() => {
+        evaluate('for (var i in foo) {}', {foo: [1, 2, 3]});
+      }).to.throw();
+      expect(() => {
+        evaluate('for (var i of foo) {}', {foo: [1, 2, 3]});
+      }).to.throw();
     });
 
     /** @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects */
@@ -538,18 +522,16 @@ describe('BindExpression', () => {
       expect(evaluate('NaN')).to.be.null;
       expect(evaluate('undefined')).to.be.null;
 
-      allowConsoleError(() => {
-        expect(() => { evaluate('eval()'); }).to.throw();
-        expect(() => { evaluate('uneval()'); }).to.throw();
-        expect(() => { evaluate('isFinite()'); }).to.throw();
-        expect(() => { evaluate('isNaN()'); }).to.throw();
-        expect(() => { evaluate('parseFloat()'); }).to.throw();
-        expect(() => { evaluate('parseInt()'); }).to.throw();
-        expect(() => { evaluate('decodeURI()'); }).to.throw();
-        expect(() => { evaluate('decodeURIComponent()'); }).to.throw();
-        expect(() => { evaluate('escape()'); }).to.throw();
-        expect(() => { evaluate('unescape()'); }).to.throw();
-      });
+      expect(() => { evaluate('eval()'); }).to.throw();
+      expect(() => { evaluate('uneval()'); }).to.throw();
+      expect(() => { evaluate('isFinite()'); }).to.throw();
+      expect(() => { evaluate('isNaN()'); }).to.throw();
+      expect(() => { evaluate('parseFloat()'); }).to.throw();
+      expect(() => { evaluate('parseInt()'); }).to.throw();
+      expect(() => { evaluate('decodeURI()'); }).to.throw();
+      expect(() => { evaluate('decodeURIComponent()'); }).to.throw();
+      expect(() => { evaluate('escape()'); }).to.throw();
+      expect(() => { evaluate('unescape()'); }).to.throw();
 
       expect(evaluate('Object')).to.be.null;
       expect(evaluate('Function')).to.be.null;
@@ -614,9 +596,9 @@ describe('BindExpression', () => {
 
       // The expression '1 + 1' should have an AST size of 3 -- one for each
       // literal, and a PLUS expression wrapping them.
-      allowConsoleError(() => { expect(() => {
+      expect(() => {
         new BindExpression('1 + 1', {}, /* maxAstSize */ 2);
-      }).to.throw(expressionSizeExceededError); });
+      }).to.throw(expressionSizeExceededError);
 
       // Test size computation for macros.
       const add = new BindMacro({
@@ -630,26 +612,24 @@ describe('BindExpression', () => {
       expect(new BindExpression('add(1, 1)', {add}, /* maxAstSize */ 3))
           .to.not.be.null;
 
-      allowConsoleError(() => { expect(() => {
+      expect(() => {
         new BindExpression('add(1, 1)', {add}, /* maxAstSize */ 2);
-      }).to.throw(expressionSizeExceededError); });
+      }).to.throw(expressionSizeExceededError);
 
       // The expression add(1, 1 + 1) should have an AST size of 5.
       expect(new BindExpression('add(1, 1 + 1)', {add}, /* maxAstSize */ 5))
           .to.not.be.null;
 
-      allowConsoleError(() => { expect(() => {
+      expect(() => {
         new BindExpression('add(1, 1 + 1)', {add}, /* maxAstSize */ 4);
-      }).to.throw(expressionSizeExceededError); });
+      }).to.throw(expressionSizeExceededError);
     });
   });
 
   describe('arrow functions', () => {
     it('known issue: single parameters with parentheses are ambiguous', () => {
       // Single parameters in parentheses are ambiguous to the parser.
-      allowConsoleError(() => {
-        expect(() => evaluate('[1, 2, 3].map((x) => x * x)')).to.throw();
-      });
+      expect(() => evaluate('[1, 2, 3].map((x) => x * x)')).to.throw();
     });
 
     it('Array#map()', () => {
@@ -668,9 +648,7 @@ describe('BindExpression', () => {
 
       // Only support arrow functions as the only parameter in applicable
       // function invocations (don't support optional `thisArg`, etc.).
-      allowConsoleError(() => {
-        expect(() => evaluate('a.reduce((x, y)) => x + y, 0)', {a})).to.throw();
-      });
+      expect(() => evaluate('a.reduce((x, y)) => x + y, 0)', {a})).to.throw();
     });
 
     it('Array#filter', () => {
@@ -685,19 +663,17 @@ describe('BindExpression', () => {
     });
 
     it('disallow: usage other than as function parameter', () => {
-      allowConsoleError(() => {
-        expect(() => { evaluate('() => 123'); }).to.throw();
-        expect(() => { evaluate('x => 123'); }).to.throw();
-        expect(() => { evaluate('(x, y) => 123'); }).to.throw();
+      expect(() => { evaluate('() => 123'); }).to.throw();
+      expect(() => { evaluate('x => 123'); }).to.throw();
+      expect(() => { evaluate('(x, y) => 123'); }).to.throw();
 
-        expect(() => { evaluate('(() => 123).constructor()'); }).to.throw();
-        expect(() => { evaluate('(x => 123).constructor()'); }).to.throw();
-        expect(() => { evaluate('((x, y) => 123).constructor()'); }).to.throw();
+      expect(() => { evaluate('(() => 123).constructor()'); }).to.throw();
+      expect(() => { evaluate('(x => 123).constructor()'); }).to.throw();
+      expect(() => { evaluate('((x, y) => 123).constructor()'); }).to.throw();
 
-        expect(() => { evaluate('(() => 123).name'); }).to.throw();
-        expect(() => { evaluate('(x => 123).name'); }).to.throw();
-        expect(() => { evaluate('((x, y) => 123).name'); }).to.throw();
-      });
+      expect(() => { evaluate('(() => 123).name'); }).to.throw();
+      expect(() => { evaluate('(x => 123).name'); }).to.throw();
+      expect(() => { evaluate('((x, y) => 123).name'); }).to.throw();
     });
 
     it('disallow: `arguments` or `this`', () => {

--- a/extensions/amp-brightcove/0.1/test/test-amp-brightcove.js
+++ b/extensions/amp-brightcove/0.1/test/test-amp-brightcove.js
@@ -69,10 +69,8 @@ describes.realWin('amp-brightcove', {
   });
 
   it('requires data-account', () => {
-    allowConsoleError(() => {
-      return getBrightcove({}).should.eventually.be.rejectedWith(
-          /The data-account attribute is required for/);
-    });
+    return getBrightcove({}).should.eventually.be.rejectedWith(
+        /The data-account attribute is required for/);
   });
 
   it('removes iframe after unlayoutCallback', () => {

--- a/extensions/amp-experiment/0.1/test/test-amp-experiment.js
+++ b/extensions/amp-experiment/0.1/test/test-amp-experiment.js
@@ -110,10 +110,10 @@ describes.realWin('amp-experiment', {
   });
 
   it('should throw if the child script element has non-JSON content', () => {
-    allowConsoleError(() => { expect(() => {
+    expect(() => {
       addConfigElement('script', 'application/json', '{not json}');
       experiment.buildCallback();
-    }).to.throw(); });
+    }).to.throw();
   });
 
   it('should add attributes to body element for the allocated variants', () => {

--- a/extensions/amp-experiment/0.1/test/test-variant.js
+++ b/extensions/amp-experiment/0.1/test/test-variant.js
@@ -50,13 +50,13 @@ describes.sandboxed('allocateVariant', {}, () => {
   });
 
   it('should throw for invalid config', () => {
-    allowConsoleError(() => { expect(() => {
+    expect(() => {
       allocateVariant(ampdoc, 'name', null);
-    }).to.throw(); });
+    }).to.throw();
 
-    allowConsoleError(() => { expect(() => {
+    expect(() => {
       allocateVariant(ampdoc, 'name', undefined);
-    }).to.throw(); });
+    }).to.throw();
 
     allowConsoleError(() => { expect(() => {
       allocateVariant(ampdoc, 'name', {});
@@ -270,13 +270,13 @@ describes.sandboxed('allocateVariant', {}, () => {
     getNotificationStub.withArgs('notif-1')
         .returns(Promise.resolve(null));
 
-    allowConsoleError(() => { return expect(allocateVariant(ampdoc, 'name', {
+    return expect(allocateVariant(ampdoc, 'name', {
       consentNotificationId: 'notif-1',
       variants: {
         '-Variant_1': 50,
         '-Variant_2': 50,
       },
-    })).to.eventually.be.rejectedWith('Notification not found: notif-1'); });
+    })).to.eventually.be.rejectedWith('Notification not found: notif-1');
   });
 
   it('should have no variant allocated if consent is missing', () => {

--- a/extensions/amp-gist/0.1/test/test-amp-gist.js
+++ b/extensions/amp-gist/0.1/test/test-amp-gist.js
@@ -58,9 +58,7 @@ describes.realWin('amp-gist', {
   });
 
   it('Rejects because data-gistid is missing', () => {
-    allowConsoleError(() => {
-      expect(getIns('')).to.be.rejectedWith(
-          /The data-gistid attribute is required for/);
-    });
+    expect(getIns('')).to.be.rejectedWith(
+        /The data-gistid attribute is required for/);
   });
 });

--- a/extensions/amp-install-serviceworker/0.1/test/test-amp-install-serviceworker.js
+++ b/extensions/amp-install-serviceworker/0.1/test/test-amp-install-serviceworker.js
@@ -367,9 +367,9 @@ describes.fakeWin('url rewriter', {
     it('should fail when mask is an invalid expression', () => {
       element.setAttribute('data-no-service-worker-fallback-url-match',
           '?');
-      allowConsoleError(() => { expect(() => {
+      expect(() => {
         implementation.maybeInstallUrlRewrite_();
-      }).to.throw(/Invalid/); });
+      }).to.throw(/Invalid/);
     });
   });
 

--- a/extensions/amp-mustache/0.1/test/test-amp-mustache.js
+++ b/extensions/amp-mustache/0.1/test/test-amp-mustache.js
@@ -209,14 +209,12 @@ describe('amp-mustache template', () => {
             'value = <input value="myid">');
       });
 
-      allowConsoleError(() => {
-        const result = template.render({
-          value: 'myid',
-          type: 'password',
-        });
-        expect(result./*OK*/innerHTML).to.equal(
-            'value = <input value="myid" type="password">');
+      const result = template.render({
+        value: 'myid',
+        type: 'password',
       });
+      expect(result./*OK*/innerHTML).to.equal(
+          'value = <input value="myid" type="password">');
     });
 
     it('should allow text input type rendering', () => {

--- a/extensions/amp-nexxtv-player/0.1/test/test-amp-nexxtv-player.js
+++ b/extensions/amp-nexxtv-player/0.1/test/test-amp-nexxtv-player.js
@@ -67,18 +67,14 @@ describes.realWin('amp-nexxtv-player', {
   });
 
   it('fails without mediaid', () => {
-    allowConsoleError(() => {
-      return getNexxtv(null, '761').should.eventually.be.rejectedWith(
-          /The data-mediaid attribute is required/);
-    });
+    return getNexxtv(null, '761').should.eventually.be.rejectedWith(
+        /The data-mediaid attribute is required/);
   });
 
   it('fails without client', () => {
-    allowConsoleError(() => {
-      return getNexxtv('71QQG852413DU7J', null)
-          .should.eventually.be.rejectedWith(
-              /The data-client attribute is required/);
-    });
+    return getNexxtv('71QQG852413DU7J', null)
+        .should.eventually.be.rejectedWith(
+            /The data-client attribute is required/);
   });
 
   it('should forward events from nexxtv-player to the amp element', () => {

--- a/extensions/amp-ooyala-player/0.1/test/test-amp-ooyala.js
+++ b/extensions/amp-ooyala-player/0.1/test/test-amp-ooyala.js
@@ -88,28 +88,22 @@ describes.realWin('amp-ooyala-player', {
   });
 
   it('fails without an embed code', () => {
-    allowConsoleError(() => {
-      return getOoyalaElement(null, '6440813504804d76ba35c8c787a4b33c',
-          '5zb2wxOlZcNCe_HVT3a6cawW298X').should.eventually.be.rejectedWith(
-          /The data-embedcode attribute is required/);
-    });
+    return getOoyalaElement(null, '6440813504804d76ba35c8c787a4b33c',
+        '5zb2wxOlZcNCe_HVT3a6cawW298X').should.eventually.be.rejectedWith(
+        /The data-embedcode attribute is required/);
   });
 
   it('fails without a player ID', () => {
-    allowConsoleError(() => {
-      return getOoyalaElement('Vxc2k0MDE6Y_C7J5podo3UDxlFxGaZrQ', null,
-          '5zb2wxOlZcNCe_HVT3a6cawW298X').should.eventually.be.rejectedWith(
-          /The data-playerid attribute is required/);
-    });
+    return getOoyalaElement('Vxc2k0MDE6Y_C7J5podo3UDxlFxGaZrQ', null,
+        '5zb2wxOlZcNCe_HVT3a6cawW298X').should.eventually.be.rejectedWith(
+        /The data-playerid attribute is required/);
   });
 
   it('fails without a p-code', () => {
-    allowConsoleError(() => {
-      return getOoyalaElement('Vxc2k0MDE6Y_C7J5podo3UDxlFxGaZrQ',
-          '6440813504804d76ba35c8c787a4b33c', null)
-          .should.eventually.be.rejectedWith(
-              /The data-pcode attribute is required/);
-    });
+    return getOoyalaElement('Vxc2k0MDE6Y_C7J5podo3UDxlFxGaZrQ',
+        '6440813504804d76ba35c8c787a4b33c', null)
+        .should.eventually.be.rejectedWith(
+            /The data-pcode attribute is required/);
   });
 
 });

--- a/extensions/amp-reddit/0.1/test/test-amp-reddit.js
+++ b/extensions/amp-reddit/0.1/test/test-amp-reddit.js
@@ -100,17 +100,13 @@ describes.realWin('amp-reddit', {
   });
 
   it('requires data-src', () => {
-    allowConsoleError(() => {
-      return getReddit('', 'post').should.eventually.be.rejectedWith(
-          /The data-src attribute is required for/);
-    });
+    return getReddit('', 'post').should.eventually.be.rejectedWith(
+        /The data-src attribute is required for/);
   });
 
   it('requires data-embedtype', () => {
-    allowConsoleError(() => {
-      return getReddit('https://www.reddit.com/r/me_irl/comments/52rmir/me_irl/?ref=share&amp;ref_source=embed', '')
-          .should.eventually.be.rejectedWith(
-              /The data-embedtype attribute is required for/);
-    });
+    return getReddit('https://www.reddit.com/r/me_irl/comments/52rmir/me_irl/?ref=share&amp;ref_source=embed', '')
+        .should.eventually.be.rejectedWith(
+            /The data-embedtype attribute is required for/);
   });
 });

--- a/extensions/amp-soundcloud/0.1/test/test-amp-soundcloud.js
+++ b/extensions/amp-soundcloud/0.1/test/test-amp-soundcloud.js
@@ -105,9 +105,7 @@ describes.realWin('amp-soundcloud', {
   });
 
   it('renders data-trackid', () => {
-    allowConsoleError(() => {
-      expect(getIns('')).to.be.rejectedWith(
-          /The data-trackid attribute is required for/);
-    });
+    expect(getIns('')).to.be.rejectedWith(
+        /The data-trackid attribute is required for/);
   });
 });

--- a/extensions/amp-subscriptions/0.1/test/test-actions.js
+++ b/extensions/amp-subscriptions/0.1/test/test-actions.js
@@ -167,9 +167,9 @@ describes.realWin('Actions', {amp: true}, env => {
     }).then(() => {
       throw new Error('must have failed');
     }, reason => {
-      allowConsoleError(() => { expect(() => {
+      expect(() => {
         throw reason;
-      }).to.throw(/broken/); });
+      }).to.throw(/broken/);
       expect(actions.actionPromise_).to.be.null;
     });
   });

--- a/extensions/amp-video/0.1/test/test-amp-video.js
+++ b/extensions/amp-video/0.1/test/test-amp-video.js
@@ -188,7 +188,7 @@ describes.realWin('amp-video', {
   });
 
   it('should not load a video with http src', () => {
-    allowConsoleError(() => { return expect(getVideo({
+    return expect(getVideo({
       src: 'http://example.com/video.mp4',
       width: 160,
       height: 90,
@@ -196,7 +196,7 @@ describes.realWin('amp-video', {
       'autoplay': '',
       'muted': '',
       'loop': '',
-    })).to.be.rejectedWith(/start with/); });
+    })).to.be.rejectedWith(/start with/);
   });
 
   it('should not load a video with http source children', () => {
@@ -209,7 +209,7 @@ describes.realWin('amp-video', {
       source.setAttribute('type', mediatype);
       sources.push(source);
     }
-    allowConsoleError(() => { return expect(getVideo({
+    return expect(getVideo({
       src: 'video.mp4',
       width: 160,
       height: 90,
@@ -217,7 +217,7 @@ describes.realWin('amp-video', {
       'autoplay': '',
       'muted': '',
       'loop': '',
-    }, sources)).to.be.rejectedWith(/start with/); });
+    }, sources)).to.be.rejectedWith(/start with/);
   });
 
   it('should set poster, controls, controlsList in prerender mode', () => {

--- a/extensions/amp-vimeo/0.1/test/test-amp-vimeo.js
+++ b/extensions/amp-vimeo/0.1/test/test-amp-vimeo.js
@@ -62,9 +62,7 @@ describes.realWin('amp-vimeo', {
   });
 
   it('requires data-videoid', () => {
-    allowConsoleError(() => {
-      return getVimeo('').should.eventually.be.rejectedWith(
-          /The data-videoid attribute is required for/);
-    });
+    return getVimeo('').should.eventually.be.rejectedWith(
+        /The data-videoid attribute is required for/);
   });
 });

--- a/extensions/amp-vine/0.1/test/test-amp-vine.js
+++ b/extensions/amp-vine/0.1/test/test-amp-vine.js
@@ -59,9 +59,7 @@ describes.realWin('amp-vine', {
   });
 
   it('requires data-vineid', () => {
-    allowConsoleError(() => {
-      return getVine('').should.eventually.be.rejectedWith(
-          /The data-vineid attribute is required for/);
-    });
+    return getVine('').should.eventually.be.rejectedWith(
+        /The data-vineid attribute is required for/);
   });
 });

--- a/extensions/amp-web-push/0.1/test/test-web-push-config.js
+++ b/extensions/amp-web-push/0.1/test/test-web-push-config.js
@@ -65,9 +65,9 @@ describes.realWin('web-push-config', {
     return env.ampdoc.whenReady().then(() => {
       const element = createConfigElementWithAttributes(webPushConfig);
       element.removeAttribute('id');
-      allowConsoleError(() => { expect(() => {
+      expect(() => {
         element.implementation_.validate();
-      }).to.throw(/must have an id attribute with value/); });
+      }).to.throw(/must have an id attribute with value/);
     });
   });
 
@@ -75,9 +75,9 @@ describes.realWin('web-push-config', {
     return env.ampdoc.whenReady().then(() => {
       createConfigElementWithAttributes(webPushConfig);
       const element = createConfigElementWithAttributes(webPushConfig);
-      allowConsoleError(() => { expect(() => {
+      expect(() => {
         element.implementation_.validate();
-      }).to.throw(/only one .* element may exist on a page/i); });
+      }).to.throw(/only one .* element may exist on a page/i);
     });
   });
 
@@ -90,11 +90,10 @@ describes.realWin('web-push-config', {
         webPushConfig = setDefaultWebPushConfig();
         delete webPushConfig[configName];
         const element = createConfigElementWithAttributes(webPushConfig);
-        allowConsoleError(() => { expect(() => {
+        expect(() => {
           element.implementation_.validate();
         }).to.throw(
             new RegExp('must have a valid ' + configName + ' attribute'));
-        });
       });
       promises.push(promise);
     }
@@ -109,9 +108,9 @@ describes.realWin('web-push-config', {
         removeAllWebPushConfigElements();
         webPushConfig[configName] = 'http://example.com/test';
         const element = createConfigElementWithAttributes(webPushConfig);
-        allowConsoleError(() => { expect(() => {
+        expect(() => {
           element.implementation_.validate();
-        }).to.throw(/should begin with the https:\/\/ protocol/); });
+        }).to.throw(/should begin with the https:\/\/ protocol/);
       });
       promises.push(promise);
     }
@@ -126,9 +125,9 @@ describes.realWin('web-push-config', {
         removeAllWebPushConfigElements();
         webPushConfig[configName] = 'http://example.com/';
         const element = createConfigElementWithAttributes(webPushConfig);
-        allowConsoleError(() => { expect(() => {
+        expect(() => {
           element.implementation_.validate();
-        }).to.throw(/and point to the/); });
+        }).to.throw(/and point to the/);
       });
       promises.push(promise);
     }
@@ -143,9 +142,9 @@ describes.realWin('web-push-config', {
         removeAllWebPushConfigElements();
         webPushConfig[configName] = 'www.example.com/test';
         const element = createConfigElementWithAttributes(webPushConfig);
-        allowConsoleError(() => { expect(() => {
+        expect(() => {
           element.implementation_.validate();
-        }).to.throw(/should begin with the https:\/\/ protocol/); });
+        }).to.throw(/should begin with the https:\/\/ protocol/);
       });
       promises.push(promise);
     }
@@ -157,9 +156,9 @@ describes.realWin('web-push-config', {
       'https://another-origin.com/test';
     return env.ampdoc.whenReady().then(() => {
       const element = createConfigElementWithAttributes(webPushConfig);
-      allowConsoleError(() => { expect(() => {
+      expect(() => {
         element.implementation_.validate();
-      }).to.throw(/must all share the same origin/); });
+      }).to.throw(/must all share the same origin/);
     });
   });
 

--- a/extensions/amp-wistia-player/0.1/test/test-amp-wistia-player.js
+++ b/extensions/amp-wistia-player/0.1/test/test-amp-wistia-player.js
@@ -49,9 +49,7 @@ describes.realWin('amp-wistia-player', {
   });
 
   it('requires data-media-hashed-id', () => {
-    allowConsoleError(() => {
-      return getWistiaEmbed('').should.eventually.be.rejectedWith(
-          /The data-media-hashed-id attribute is required for/);
-    });
+    return getWistiaEmbed('').should.eventually.be.rejectedWith(
+        /The data-media-hashed-id attribute is required for/);
   });
 });

--- a/test/functional/test-3p-environment.js
+++ b/test/functional/test-3p-environment.js
@@ -225,11 +225,9 @@ describe('3p environment', () => {
     expect(win.prompt()).to.equal('');
     expect(win.confirm()).to.be.false;
     // We only allow 3 calls to these functions.
-    allowConsoleError(() => {
-      expect(() => win.alert()).to.throw(/security error/);
-      expect(() => win.prompt()).to.throw(/security error/);
-      expect(() => win.confirm()).to.throw(/security error/);
-    });
+    expect(() => win.alert()).to.throw(/security error/);
+    expect(() => win.prompt()).to.throw(/security error/);
+    expect(() => win.confirm()).to.throw(/security error/);
   }
 
   function waitForMutationObserver(iframe) {

--- a/test/functional/test-3p.js
+++ b/test/functional/test-3p.js
@@ -42,15 +42,15 @@ describe('3p', () => {
   describe('validateSrcPrefix()', () => {
 
     it('should throw when a string prefix does not match', () => {
-      allowConsoleError(() => { expect(() => {
+      expect(() => {
         validateSrcPrefix('https:', 'http://example.org');
-      }).to.throw(/Invalid src/); });
+      }).to.throw(/Invalid src/);
     });
 
     it('should throw when array prefixes do not match', () => {
-      allowConsoleError(() => { expect(() => {
+      expect(() => {
         validateSrcPrefix(['https:', 'ftp:'], 'http://example.org');
-      }).to.throw(/Invalid src/); });
+      }).to.throw(/Invalid src/);
     });
 
     it('should not throw when a string prefix matches', () => {
@@ -64,9 +64,9 @@ describe('3p', () => {
   });
 
   it('should throw an error if src does not contain addyn', () => {
-    allowConsoleError(() => { expect(() => {
+    expect(() => {
       validateSrcContains('/addyn/', 'http://adserver.adtechus.com/');
-    }).to.throw(/Invalid src/); });
+    }).to.throw(/Invalid src/);
   });
 
   it('should not throw if source contains /addyn/', () => {

--- a/test/functional/test-ad-cid.js
+++ b/test/functional/test-ad-cid.js
@@ -112,8 +112,6 @@ describes.realWin('ad-cid', {amp: true}, env => {
     sandbox.stub(cidService, 'get').callsFake(() => {
       return Promise.reject(new Error('nope'));
     });
-    allowConsoleError(() => {
-      return expect(getAdCid(adElement)).to.eventually.be.undefined;
-    });
+    return expect(getAdCid(adElement)).to.eventually.be.undefined;
   });
 });

--- a/test/functional/test-amp-context.js
+++ b/test/functional/test-amp-context.js
@@ -158,10 +158,8 @@ describe('3p ampcontext.js', () => {
   it('should throw error if metadata missing', () => {
     win.name = generateIncorrectAttributes();
     const platform = new Platform(window);
-    allowConsoleError(() => {
-      expect(() => new AmpContext(win)).to.throw(platform.isSafari() ?
-        /undefined is not an object/ : /Cannot read property/);
-    });
+    expect(() => new AmpContext(win)).to.throw(platform.isSafari() ?
+      /undefined is not an object/ : /Cannot read property/);
   });
 
   it('should be able to send an intersection observer request', () => {

--- a/test/functional/test-amp-pixel.js
+++ b/test/functional/test-amp-pixel.js
@@ -100,26 +100,20 @@ describes.realWin('amp-pixel', {amp: true}, env => {
 
   it('should disallow http URLs', () => {
     const url = 'http://pubads.g.doubleclick.net/activity;dc_iu=1/abc;ord=2';
-    allowConsoleError(() => {
-      return expect(trigger(url)).to.eventually.be.rejectedWith(
-          /src attribute must start with/);
-    });
+    return expect(trigger(url)).to.eventually.be.rejectedWith(
+        /src attribute must start with/);
   });
 
   it('should disallow relative URLs', () => {
     const url = '/activity;dc_iu=1/abc;ord=2';
-    allowConsoleError(() => {
-      return expect(trigger(url)).to.eventually.be.rejectedWith(
-          /src attribute must start with/);
-    });
+    return expect(trigger(url)).to.eventually.be.rejectedWith(
+        /src attribute must start with/);
   });
 
   it('should disallow fake-protocol URLs', () => {
     const url = 'https/activity;dc_iu=1/abc;ord=2';
-    allowConsoleError(() => {
-      return expect(trigger(url)).to.eventually.be.rejectedWith(
-          /src attribute must start with/);
-    });
+    return expect(trigger(url)).to.eventually.be.rejectedWith(
+        /src attribute must start with/);
   });
 
   it('should replace URL parameters', () => {

--- a/test/functional/test-ampdoc.js
+++ b/test/functional/test-ampdoc.js
@@ -128,9 +128,9 @@ describe('AmpDocService', () => {
       if (!shadowRoot) {
         return;
       }
-      allowConsoleError(() => { expect(() => {
+      expect(() => {
         service.getAmpDoc(content);
-      }).to.throw(/No ampdoc found/); });
+      }).to.throw(/No ampdoc found/);
 
       const newAmpDoc = service.installShadowDoc('https://a.org/', shadowRoot);
       const ampDoc = service.getAmpDoc(content);
@@ -146,9 +146,9 @@ describe('AmpDocService', () => {
       if (!shadowRoot) {
         return;
       }
-      allowConsoleError(() => { expect(() => {
+      expect(() => {
         service.getAmpDoc(host);
-      }).to.throw(/No ampdoc found/); });
+      }).to.throw(/No ampdoc found/);
     });
 
     it('should fail to install shadow doc twice', () => {

--- a/test/functional/test-batched-json.js
+++ b/test/functional/test-batched-json.js
@@ -82,14 +82,12 @@ describe('batchFetchJsonFor', () => {
       urlReplacements.collectUnwhitelistedVars
           .withArgs(el)
           .returns(Promise.resolve(['BAR']));
-      allowConsoleError(() => {
-        const userError = sandbox.stub(user(), 'error');
-        const optIn = UrlReplacementPolicy.OPT_IN;
-        return batchFetchJsonFor(ampdoc, el, null, optIn).then(() => {
-          expect(fetchJson).to.be.calledWith('https://data.com?x=abc&y=BAR');
-          expect(userError).calledWithMatch(
-              'AMP-LIST', /data-amp-replace="BAR"/);
-        });
+      const userError = sandbox.stub(user(), 'error');
+      const optIn = UrlReplacementPolicy.OPT_IN;
+      return batchFetchJsonFor(ampdoc, el, null, optIn).then(() => {
+        expect(fetchJson).to.be.calledWith('https://data.com?x=abc&y=BAR');
+        expect(userError).calledWithMatch(
+            'AMP-LIST', /data-amp-replace="BAR"/);
       });
     });
 
@@ -99,14 +97,12 @@ describe('batchFetchJsonFor', () => {
       urlReplacements.expandUrlAsync
           .withArgs('https://data.com?x=FOO&y=BAR')
           .returns(Promise.resolve('https://data.com?x=abc&y=BAR'));
-      allowConsoleError(() => {
-        const userError = sandbox.stub(user(), 'error');
-        const all = UrlReplacementPolicy.ALL;
-        return batchFetchJsonFor(ampdoc, el, null, all).then(() => {
-          expect(fetchJson).to.be.calledWith('https://data.com?x=abc&y=BAR');
-          expect(urlReplacements.collectUnwhitelistedVars).to.not.be.called;
-          expect(userError).to.not.be.called;
-        });
+      const userError = sandbox.stub(user(), 'error');
+      const all = UrlReplacementPolicy.ALL;
+      return batchFetchJsonFor(ampdoc, el, null, all).then(() => {
+        expect(fetchJson).to.be.calledWith('https://data.com?x=abc&y=BAR');
+        expect(urlReplacements.collectUnwhitelistedVars).to.not.be.called;
+        expect(userError).to.not.be.called;
       });
     });
   });

--- a/test/functional/test-cid.js
+++ b/test/functional/test-cid.js
@@ -913,9 +913,7 @@ describes.fakeWin('cid optout:', {amp: true}, env => {
 
     it('should reject promise if storage set fails', () => {
       storageSetStub.returns(Promise.reject('failed!'));
-      allowConsoleError(() => {
-        return optOutOfCid(ampdoc).should.eventually.be.rejectedWith('failed!');
-      });
+      return optOutOfCid(ampdoc).should.eventually.be.rejectedWith('failed!');
     });
   });
 

--- a/test/functional/test-cookies.js
+++ b/test/functional/test-cookies.js
@@ -107,32 +107,28 @@ describe('cookies', () => {
     test('www.example.net', 'example.com', true);
     test('example.net', 'example.com', true);
     test('cdn.ampproject.org', 'ampproject.org', true, true);
-    allowConsoleError(() => {
-      expect(() => {
-        test('cdn.ampproject.org', 'ampproject.org', true);
-      }).to.throw(/Should never attempt to set cookie on proxy origin\: c\&1/);
-      expect(() => {
-        test('CDN.ampproject.org', 'ampproject.org', true);
-      }).to.throw(/Should never attempt to set cookie on proxy origin\: c\&1/);
-      expect(() => {
-        test('CDN.ampproject.org', 'AMPproject.org', true);
-      }).to.throw(/Should never attempt to set cookie on proxy origin\: c\&1/);
-    });
+    expect(() => {
+      test('cdn.ampproject.org', 'ampproject.org', true);
+    }).to.throw(/Should never attempt to set cookie on proxy origin\: c\&1/);
+    expect(() => {
+      test('CDN.ampproject.org', 'ampproject.org', true);
+    }).to.throw(/Should never attempt to set cookie on proxy origin\: c\&1/);
+    expect(() => {
+      test('CDN.ampproject.org', 'AMPproject.org', true);
+    }).to.throw(/Should never attempt to set cookie on proxy origin\: c\&1/);
     test('www.ampproject.org', 'www.ampproject.org');
     test('cdn.ampproject.org', 'cdn.ampproject.org', false, true);
-    allowConsoleError(() => {
-      expect(() => {
-        test('cdn.ampproject.org', 'cdn.ampproject.org', false);
-      }).to.throw(/Should never attempt to set cookie on proxy origin\: c\&1/);
-      expect(() => {
-        test('foo.bar.cdn.ampproject.org', 'foo.bar.cdn.ampproject.org', false);
-      }).to.throw(/in depth check/);
-      expect(() => {
-        test('&&&.cdn.ampproject.org', '&&&.cdn.ampproject.org', false);
-      }).to.throw(/in depth check/);
-      expect(() => {
-        test('&&&.CDN.ampproject.org', '&&&.cdn.AMPproject.org', false);
-      }).to.throw(/in depth check/);
-    });
+    expect(() => {
+      test('cdn.ampproject.org', 'cdn.ampproject.org', false);
+    }).to.throw(/Should never attempt to set cookie on proxy origin\: c\&1/);
+    expect(() => {
+      test('foo.bar.cdn.ampproject.org', 'foo.bar.cdn.ampproject.org', false);
+    }).to.throw(/in depth check/);
+    expect(() => {
+      test('&&&.cdn.ampproject.org', '&&&.cdn.ampproject.org', false);
+    }).to.throw(/in depth check/);
+    expect(() => {
+      test('&&&.CDN.ampproject.org', '&&&.cdn.AMPproject.org', false);
+    }).to.throw(/in depth check/);
   });
 });

--- a/test/functional/test-custom-element.js
+++ b/test/functional/test-custom-element.js
@@ -568,10 +568,8 @@ describes.realWin('CustomElement', {amp: true}, env => {
 
       clock.tick(1);
       container.appendChild(element);
-      allowConsoleError(() => {
-        return expect(element.whenBuilt()).to.eventually.be.rejectedWith(
-            /BLOCK_BY_CONSENT/);
-      });
+      return expect(element.whenBuilt()).to.eventually.be.rejectedWith(
+          /BLOCK_BY_CONSENT/);
     });
 
 
@@ -584,10 +582,8 @@ describes.realWin('CustomElement', {amp: true}, env => {
       expect(element.isBuilt()).to.be.false;
       expect(element).to.have.class('i-amphtml-notbuilt');
       expect(element).to.have.class('amp-notbuilt');
-      allowConsoleError(() => {
-        return expect(element.whenBuilt()).to.eventually.be.rejectedWith(
-            /intentional/);
-      });
+      return expect(element.whenBuilt()).to.eventually.be.rejectedWith(
+          /intentional/);
     });
 
     it('Element - build creates a placeholder if one does not exist' , () => {

--- a/test/functional/test-error.js
+++ b/test/functional/test-error.js
@@ -543,9 +543,9 @@ describes.sandboxed('reportError', {}, () => {
     expect(result.message).to.contain('error');
     expect(result.origError).to.be.equal('error');
     expect(result.reported).to.be.true;
-    allowConsoleError(() => { expect(() => {
+    expect(() => {
       clock.tick();
-    }).to.throw(/_reported_ Error reported incorrectly/); });
+    }).to.throw(/_reported_ Error reported incorrectly/);
   });
 
   it('should accept number and report incorrect use', () => {
@@ -555,9 +555,9 @@ describes.sandboxed('reportError', {}, () => {
     expect(result.message).to.contain('101');
     expect(result.origError).to.be.equal(101);
     expect(result.reported).to.be.true;
-    allowConsoleError(() => { expect(() => {
+    expect(() => {
       clock.tick();
-    }).to.throw(/_reported_ Error reported incorrectly/); });
+    }).to.throw(/_reported_ Error reported incorrectly/);
   });
 
   it('should accept null and report incorrect use', () => {
@@ -567,9 +567,9 @@ describes.sandboxed('reportError', {}, () => {
     expect(result.message).to.contain('Unknown error');
     expect(result.origError).to.be.undefined;
     expect(result.reported).to.be.true;
-    allowConsoleError(() => { expect(() => {
+    expect(() => {
       clock.tick();
-    }).to.throw(/_reported_ Error reported incorrectly/); });
+    }).to.throw(/_reported_ Error reported incorrectly/);
   });
 });
 

--- a/test/functional/test-extensions.js
+++ b/test/functional/test-extensions.js
@@ -837,9 +837,7 @@ describes.sandboxed('Extensions', {}, () => {
         expect(getServiceForDoc(ampdoc, 'service3').a).to.equal(3);
         // Erroneous
         expect(factory3Spy).to.be.calledOnce;
-        allowConsoleError(() => {
-          expect(() => getServiceForDoc(ampdoc, 'service2')).to.throw();
-        });
+        expect(() => getServiceForDoc(ampdoc, 'service2')).to.throw();
         // Extension is marked as declared.
         expect(ampdoc.declaresExtension('amp-test')).to.be.true;
       });

--- a/test/functional/test-integration.js
+++ b/test/functional/test-integration.js
@@ -70,13 +70,13 @@ describe('3p integration.js', () => {
         const parent = {
           origin: 'abc',
         };
-        allowConsoleError(() => { expect(() => {
+        expect(() => {
           validateParentOrigin({
             location: {
               ancestorOrigins: ['xyz'],
             },
           }, parent);
-        }).to.throw(/Parent origin mismatch/); });
+        }).to.throw(/Parent origin mismatch/);
       });
 
   it('should parse JSON from fragment unencoded (most browsers)', () => {
@@ -185,9 +185,9 @@ describe('3p integration.js', () => {
         tagName: 'AMP-EMBED',
       },
     };
-    allowConsoleError(() => { expect(() => {
+    expect(() => {
       draw3p(win, data);
-    }).to.throw(/Embed type testAction not allowed with tag AMP-EMBED/); });
+    }).to.throw(/Embed type testAction not allowed with tag AMP-EMBED/);
   });
 
   it('should allow all types on localhost', () => {
@@ -225,9 +225,9 @@ describe('3p integration.js', () => {
     validateAllowedTypes(get('d-123.ampproject.net'), 'twitter');
     validateAllowedTypes(get('d-46851196780996873.ampproject.net'), 'adtech');
     validateAllowedTypes(get('d-46851196780996873.ampproject.net'), 'a9');
-    allowConsoleError(() => { expect(() => {
+    expect(() => {
       validateAllowedTypes(get('d-124.ampproject.net.com'), 'not present');
-    }).to.throw(/Non-whitelisted 3p type for custom iframe/); });
+    }).to.throw(/Non-whitelisted 3p type for custom iframe/);
   });
 
   it('should validate types on custom host', () => {
@@ -239,12 +239,12 @@ describe('3p integration.js', () => {
     validateAllowedTypes(defaultHost, 'twitter');
     validateAllowedTypes(defaultHost, 'facebook');
     validateAllowedTypes(defaultHost, 'doubleclick');
-    allowConsoleError(() => { expect(() => {
+    expect(() => {
       validateAllowedTypes(defaultHost, 'not present');
-    }).to.throw(/Non-whitelisted 3p type for custom iframe/); });
-    allowConsoleError(() => { expect(() => {
+    }).to.throw(/Non-whitelisted 3p type for custom iframe/);
+    expect(() => {
       validateAllowedTypes(defaultHost, 'adtech');
-    }).to.throw(/Non-whitelisted 3p type for custom iframe/); });
+    }).to.throw(/Non-whitelisted 3p type for custom iframe/);
     validateAllowedTypes(defaultHost, 'adtech', ['adtech']);
   });
 
@@ -259,9 +259,9 @@ describe('3p integration.js', () => {
       },
     };
     win.parent = win;
-    allowConsoleError(() => { expect(() => {
+    expect(() => {
       ensureFramed(win);
-    }).to.throw(/Must be framed: sentinel/); });
+    }).to.throw(/Must be framed: sentinel/);
   });
 
   it('should validateAllowedEmbeddingOrigins: non-cache', () => {
@@ -274,9 +274,7 @@ describe('3p integration.js', () => {
       },
     };
     function invalid(fn) {
-      allowConsoleError(() => {
-        expect(fn).to.throw(/Invalid embedding hostname/);
-      });
+      expect(fn).to.throw(/Invalid embedding hostname/);
     }
     validateAllowedEmbeddingOrigins(win, ['foo.com']);
     validateAllowedEmbeddingOrigins(win, ['foo.net', 'foo.com']);
@@ -296,9 +294,7 @@ describe('3p integration.js', () => {
       },
     };
     function invalid(fn) {
-      allowConsoleError(() => {
-        expect(fn).to.throw(/Invalid embedding hostname/);
-      });
+      expect(fn).to.throw(/Invalid embedding hostname/);
     }
     validateAllowedEmbeddingOrigins(win, ['foo.com']);
     validateAllowedEmbeddingOrigins(win, ['www.foo.com']);
@@ -318,9 +314,7 @@ describe('3p integration.js', () => {
       },
     };
     function invalid(fn) {
-      allowConsoleError(() => {
-        expect(fn).to.throw(/Invalid embedding hostname/);
-      });
+      expect(fn).to.throw(/Invalid embedding hostname/);
     }
     validateAllowedEmbeddingOrigins(win, ['foo.com']);
     validateAllowedEmbeddingOrigins(win, ['www.foo.com']);
@@ -338,9 +332,7 @@ describe('3p integration.js', () => {
       },
     };
     function invalid(fn) {
-      allowConsoleError(() => {
-        expect(fn).to.throw(/Invalid embedding hostname/);
-      });
+      expect(fn).to.throw(/Invalid embedding hostname/);
     }
     validateAllowedEmbeddingOrigins(win, ['foo.com']);
     validateAllowedEmbeddingOrigins(win, ['www.foo.com']);

--- a/test/functional/test-json.js
+++ b/test/functional/test-json.js
@@ -168,9 +168,9 @@ describe('json', () => {
 
   describe('recursiveEquals', () => {
     it('should throw on non-finite depth arg', () => {
-      allowConsoleError(() => { expect(() => {
+      expect(() => {
         recursiveEquals({}, {}, Number.POSITIVE_INFINITY);
-      }).to.throw(/must be finite/); });
+      }).to.throw(/must be finite/);
     });
 
     it('should handle null and empty objects', () => {

--- a/test/functional/test-log.js
+++ b/test/functional/test-log.js
@@ -298,9 +298,9 @@ describe('Logging', () => {
     });
 
     it('should fail', () => {
-      allowConsoleError(() => { expect(function() {
+      expect(function() {
         log.assert(false, 'xyz');
-      }).to.throw(/xyz/); });
+      }).to.throw(/xyz/);
       try {
         log.assert(false, '123');
       } catch (e) {
@@ -318,18 +318,18 @@ describe('Logging', () => {
     });
 
     it('should substitute', () => {
-      allowConsoleError(() => { expect(function() {
+      expect(function() {
         log.assert(false, 'should fail %s', 'XYZ');
-      }).to.throw(/should fail XYZ/); });
-      allowConsoleError(() => { expect(function() {
+      }).to.throw(/should fail XYZ/);
+      expect(function() {
         log.assert(false, 'should fail %s %s', 'XYZ', 'YYY');
-      }).to.throw(/should fail XYZ YYY/); });
+      }).to.throw(/should fail XYZ YYY/);
       const div = document.createElement('div');
       div.id = 'abc';
       div.textContent = 'foo';
-      allowConsoleError(() => { expect(function() {
+      expect(function() {
         log.assert(false, 'should fail %s', div);
-      }).to.throw(/should fail div#abc/); });
+      }).to.throw(/should fail div#abc/);
 
       let error;
       try {
@@ -430,15 +430,15 @@ describe('Logging', () => {
     });
 
     it('should should identify non-elements', () => {
-      allowConsoleError(() => { expect(() => {
+      expect(() => {
         log.assertElement(document);
-      }).to.throw(/Element expected: /); });
-      allowConsoleError(() => { expect(() => {
+      }).to.throw(/Element expected: /);
+      expect(() => {
         log.assertElement(null);
-      }).to.throw(/Element expected: null/); });
-      allowConsoleError(() => { expect(() => {
+      }).to.throw(/Element expected: null/);
+      expect(() => {
         log.assertElement(null, 'custom error');
-      }).to.throw(/custom error: null/); });
+      }).to.throw(/custom error: null/);
     });
   });
 
@@ -458,13 +458,11 @@ describe('Logging', () => {
     });
 
     it('should fail with on non string', () => {
-      allowConsoleError(() => {
-        expect(() => log.assertString({})).to.throw('String expected: ');
-        expect(() => log.assertString(3)).to.throw('String expected: ');
-        expect(() => log.assertString(null)).to.throw('String expected: ');
-        expect(() => log.assertString(undefined)).to.throw('String expected: ');
-        expect(() => log.assertString([])).to.throw('String expected: ');
-      });
+      expect(() => log.assertString({})).to.throw('String expected: ');
+      expect(() => log.assertString(3)).to.throw('String expected: ');
+      expect(() => log.assertString(null)).to.throw('String expected: ');
+      expect(() => log.assertString(undefined)).to.throw('String expected: ');
+      expect(() => log.assertString([])).to.throw('String expected: ');
     });
   });
 
@@ -488,13 +486,11 @@ describe('Logging', () => {
     });
 
     it('should fail with on non number', () => {
-      allowConsoleError(() => {
-        expect(() => log.assertNumber({})).to.throw('Number expected: ');
-        expect(() => log.assertNumber('a')).to.throw('Number expected: ');
-        expect(() => log.assertNumber(null)).to.throw('Number expected: ');
-        expect(() => log.assertNumber(undefined)).to.throw('Number expected: ');
-        expect(() => log.assertNumber([])).to.throw('Number expected: ');
-      });
+      expect(() => log.assertNumber({})).to.throw('Number expected: ');
+      expect(() => log.assertNumber('a')).to.throw('Number expected: ');
+      expect(() => log.assertNumber(null)).to.throw('Number expected: ');
+      expect(() => log.assertNumber(undefined)).to.throw('Number expected: ');
+      expect(() => log.assertNumber([])).to.throw('Number expected: ');
     });
   });
 
@@ -514,20 +510,16 @@ describe('Logging', () => {
 
     it('should fail with unknown enum value', () => {
       const enum1 = {a: 'value1', b: 'value2'};
-      allowConsoleError(() => {
-        expect(() => log.assertEnumValue(enum1, 'value3')).to.throw(
-            'Unknown enum value: "value3"');
-        expect(() => log.assertEnumValue(enum1, 'value3', 'MyEnum')).to.throw(
-            'Unknown MyEnum value: "value3"');
-      });
+      expect(() => log.assertEnumValue(enum1, 'value3')).to.throw(
+          'Unknown enum value: "value3"');
+      expect(() => log.assertEnumValue(enum1, 'value3', 'MyEnum')).to.throw(
+          'Unknown MyEnum value: "value3"');
     });
 
     it('should fail with values of different case', () => {
       const enum1 = {a: 'value1', b: 'value2'};
-      allowConsoleError(() => {
-        expect(() => log.assertEnumValue(enum1, 'VALUE1')).to.throw(
-            'Unknown enum value: "VALUE1"');
-      });
+      expect(() => log.assertEnumValue(enum1, 'VALUE1')).to.throw(
+          'Unknown enum value: "VALUE1"');
     });
   });
 

--- a/test/functional/test-object.js
+++ b/test/functional/test-object.js
@@ -149,10 +149,8 @@ describe('Object', () => {
       destObject.a = {};
       const fromObject = {};
       fromObject.a = fromObject;
-      allowConsoleError(() => {
-        expect(() => object.deepMerge(destObject, fromObject)).to.throw(
-            /Source object has a circular reference./);
-      });
+      expect(() => object.deepMerge(destObject, fromObject)).to.throw(
+          /Source object has a circular reference./);
     });
 
     it('should merge null and undefined correctly', () => {

--- a/test/functional/test-origin-experiments.js
+++ b/test/functional/test-origin-experiments.js
@@ -72,46 +72,36 @@ describe('OriginExperiments', () => {
   it('should throw for an unknown token version number', () => {
     const verify = originExperiments.verifyToken(
         tokenWithBadVersion, 'https://origin.com', publicKey);
-    allowConsoleError(() => {
-      return expect(verify).to.eventually.be.rejectedWith(
-          'Unrecognized token version: 42');
-    });
+    return expect(verify).to.eventually.be.rejectedWith(
+        'Unrecognized token version: 42');
   });
 
   it('should throw if config length exceeds byte length', () => {
     const verify = originExperiments.verifyToken(
         tokenWithBadConfigLength, 'https://origin.com', publicKey);
-    allowConsoleError(() => {
-      return expect(verify).to.eventually.be.rejectedWith(
-          'Unexpected config length: 999');
-    });
+    return expect(verify).to.eventually.be.rejectedWith(
+        'Unexpected config length: 999');
   });
 
   it('should throw if signature cannot be verified', () => {
     const verify = originExperiments.verifyToken(
         tokenWithBadSignature, 'https://origin.com', publicKey);
-    allowConsoleError(() => {
-      return expect(verify).to.eventually.be.rejectedWith(
-          'Failed to verify token signature.');
-    });
+    return expect(verify).to.eventually.be.rejectedWith(
+        'Failed to verify token signature.');
   });
 
   it('should throw if approved origin is not current origin', () => {
     const verify = originExperiments.verifyToken(
         token, 'https://not-origin.com', publicKey);
-    allowConsoleError(() => {
-      return expect(verify).to.eventually.be.rejectedWith(
-          /does not match window/);
-    });
+    return expect(verify).to.eventually.be.rejectedWith(
+        /does not match window/);
   });
 
   it('should return false if trial has expired', () => {
     const verify = originExperiments.verifyToken(
         tokenWithExpiredExperiment, 'https://origin.com', publicKey);
-    allowConsoleError(() => {
-      return expect(verify).to.eventually.be.rejectedWith(
-          'Experiment "expired" has expired.');
-    });
+    return expect(verify).to.eventually.be.rejectedWith(
+        'Experiment "expired" has expired.');
   });
 
   it('should return true for a well-formed, unexpired token', () => {

--- a/test/functional/test-polyfill-object-assign.js
+++ b/test/functional/test-polyfill-object-assign.js
@@ -18,12 +18,10 @@ import {assign} from '../../src/polyfills/object-assign';
 
 describe('Object.assign', () => {
   it('should throw an error if target is null or undefined', () => {
-    allowConsoleError(() => {
-      expect(() => assign(null, {a: 1})).to.throw(
-          /Cannot convert undefined or null to object/);
-      expect(() => assign(undefined, {a: 1})).to.throw(
-          /Cannot convert undefined or null to object/);
-    });
+    expect(() => assign(null, {a: 1})).to.throw(
+        /Cannot convert undefined or null to object/);
+    expect(() => assign(undefined, {a: 1})).to.throw(
+        /Cannot convert undefined or null to object/);
   });
 
   it('should ignore null or undefined sources', () => {

--- a/test/functional/test-render-delaying-services.js
+++ b/test/functional/test-render-delaying-services.js
@@ -67,9 +67,7 @@ describe('waitForServices', () => {
     dynamicCssResolve();
     experimentResolve(); // 'amp-experiment' is actually blocked by 'variant'
     clock.tick(3000);
-    allowConsoleError(() => {
-      return expect(promise).to.eventually.be.rejectedWith('variant');
-    });
+    return expect(promise).to.eventually.be.rejectedWith('variant');
   });
 
   it('should resolve when all extensions are ready', () => {

--- a/test/functional/test-template.js
+++ b/test/functional/test-template.js
@@ -254,9 +254,9 @@ describes.fakeWin('BaseTemplate', {}, env => {
   });
 
   it('should require render override', () => {
-    allowConsoleError(() => { expect(() => {
+    expect(() => {
       new BaseTemplate(templateElement).render();
-    }).to.throw(/Not implemented/); });
+    }).to.throw(/Not implemented/);
   });
 
   it('should unwrap single element', () => {

--- a/test/functional/test-viewer-cid-api.js
+++ b/test/functional/test-viewer-cid-api.js
@@ -104,10 +104,8 @@ describes.realWin('viewerCidApi', {amp: true}, env => {
     it('should reject if Viewer rejects', () => {
       viewerMock.sendMessageAwaitResponse
           .returns(Promise.reject('Client API error'));
-      allowConsoleError(() => {
-        return expect(api.getScopedCid('api-key', 'AMP_ECID_GOOGLE'))
-            .to.eventually.be.rejectedWith(/Client API error/);
-      });
+      return expect(api.getScopedCid('api-key', 'AMP_ECID_GOOGLE'))
+          .to.eventually.be.rejectedWith(/Client API error/);
     });
   });
 });

--- a/test/functional/test-viewer.js
+++ b/test/functional/test-viewer.js
@@ -920,9 +920,9 @@ describe('Viewer', () => {
       windowApi.parent = {};
       windowApi.location.ancestorOrigins = null;
       const viewer = new Viewer(ampdoc);
-      allowConsoleError(() => { expect(() => {
+      expect(() => {
         viewer.setMessageDeliverer(() => {});
-      }).to.throw(/message channel must have an origin/); });
+      }).to.throw(/message channel must have an origin/);
     });
 
     it('should allow channel without origin thats an empty string', () => {
@@ -971,9 +971,9 @@ describe('Viewer', () => {
         windowApi.location.hash = '#webview=1';
         windowApi.location.ancestorOrigins = [];
         const viewer = new Viewer(ampdoc);
-        allowConsoleError(() => { expect(() => {
+        expect(() => {
           viewer.setMessageDeliverer(() => {});
-        }).to.throw(/message channel must have an origin/); });
+        }).to.throw(/message channel must have an origin/);
       });
 
       it('should decide non-trusted on connection with wrong origin', () => {
@@ -1043,9 +1043,9 @@ describe('Viewer', () => {
         windowApi.location.hash = '#origin=g.com&webview=1';
         windowApi.location.ancestorOrigins = null;
         const viewer = new Viewer(ampdoc);
-        allowConsoleError(() => { expect(() => {
+        expect(() => {
           viewer.setMessageDeliverer(() => {});
-        }).to.throw(/message channel must have an origin/); });
+        }).to.throw(/message channel must have an origin/);
       });
 
       it('should decide non-trusted on connection with wrong origin', () => {

--- a/test/functional/utils/test-base64.js
+++ b/test/functional/utils/test-base64.js
@@ -105,15 +105,11 @@ describe('base64UrlDecodeToBytes', () => {
   });
 
   it('should signal an error with bad input characters', () => {
-    allowConsoleError(() => {
-      expect(() => base64UrlDecodeToBytes('@#*#')).to.throw();
-    });
+    expect(() => base64UrlDecodeToBytes('@#*#')).to.throw();
   });
 
   it('should signal an error with bad padding', () => {
-    allowConsoleError(() => {
-      expect(() => base64UrlDecodeToBytes('c3Vy.')).to.throw();
-    });
+    expect(() => base64UrlDecodeToBytes('c3Vy.')).to.throw();
   });
 });
 
@@ -136,15 +132,11 @@ describe('base64DecodeToBytes', () => {
   });
 
   it('should signal an error with bad input characters', () => {
-    allowConsoleError(() => {
-      expect(() => base64DecodeToBytes('@#*#')).to.throw();
-    });
+    expect(() => base64DecodeToBytes('@#*#')).to.throw();
   });
 
   it('should signal an error with bad padding', () => {
-    allowConsoleError(() => {
-      expect(() => base64DecodeToBytes('c3Vy=')).to.throw();
-    });
+    expect(() => base64DecodeToBytes('c3Vy=')).to.throw();
   });
 });
 

--- a/test/functional/utils/test-priority-queue.js
+++ b/test/functional/utils/test-priority-queue.js
@@ -85,8 +85,6 @@ describe('PriorityQueue', function() {
   });
 
   it('should throw error when priority is NaN', () => {
-    allowConsoleError(() => {
-      expect(() => { pq.enqueue(NaN); }).to.throw(Error);
-    });
+    expect(() => { pq.enqueue(NaN); }).to.throw(Error);
   });
 });

--- a/test/functional/web-worker/test-amp-worker.js
+++ b/test/functional/web-worker/test-amp-worker.js
@@ -70,10 +70,8 @@ describe('invokeWebWorker', () => {
 
   it('should check if Worker is supported', () => {
     fakeWin.Worker = undefined;
-    allowConsoleError(() => {
-      return expect(invokeWebWorker(fakeWin, 'foo'))
-          .to.eventually.be.rejectedWith('not supported');
-    });
+    return expect(invokeWebWorker(fakeWin, 'foo'))
+        .to.eventually.be.rejectedWith('not supported');
   });
 
   it('should send and receive a message', () => {


### PR DESCRIPTION
These were test sections that didn't need calls to `allowConsoleError`, and were warning as a result.

There still are [~800 instances](https://travis-ci.org/ampproject/amphtml/jobs/375998513#L1277) of real errors that need to be fixed or wrapped in `allowConsoleError`.

Partial fix for #14406