### PR TITLE
🐛 Remove Parsely heartbeat trigger from default config

### DIFF
--- a/extensions/amp-analytics/0.1/vendors.js
+++ b/extensions/amp-analytics/0.1/vendors.js
@@ -1434,15 +1434,6 @@ export const ANALYTICS_CONFIG = /** @type {!JsonObject} */ ({
         'on': 'visible',
         'request': 'pageview',
       },
-      'defaultHeartbeat': {
-        'on': 'timer',
-        'enabled': '${incrementalEngagedTime(parsely-js,false)}',
-        'timerSpec': {
-          'interval': 5,
-          'maxTimerLength': 7200,
-        },
-        'request': 'heartbeat',
-      },
     },
     'transport': {
       'beacon': false,


### PR DESCRIPTION
The default vendors.js for amp-analytics has the parsely heartbeat enabled by default. This removes it from the default config.