### PR TITLE
✨Enable input type=file

### DIFF
--- a/build-system/app.js
+++ b/build-system/app.js
@@ -200,6 +200,18 @@ app.use('/form/json/poll1', (req, res) => {
   });
 });
 
+const upload = multer();
+
+app.post('/form/json/upload', upload.fields([{name: 'myFile'}]), (req, res) => {
+  assertCors(req, res, ['POST']);
+
+  const fileData = req.files['myFile'][0];
+  const contents = fileData.buffer.toString();
+
+  res.send({message: contents});
+  res.end();
+});
+
 app.use('/form/search-html/get', (req, res) => {
   res.setHeader('Content-Type', 'text/html');
   res.end(`

--- a/build-system/app.js
+++ b/build-system/app.js
@@ -208,8 +208,7 @@ app.post('/form/json/upload', upload.fields([{name: 'myFile'}]), (req, res) => {
   const fileData = req.files['myFile'][0];
   const contents = fileData.buffer.toString();
 
-  res.send({message: contents});
-  res.end();
+  res.json({message: contents});
 });
 
 app.use('/form/search-html/get', (req, res) => {

--- a/build-system/app.js
+++ b/build-system/app.js
@@ -26,6 +26,7 @@ const bodyParser = require('body-parser');
 const formidable = require('formidable');
 const fs = BBPromise.promisifyAll(require('fs'));
 const jsdom = require('jsdom');
+const multer = require('multer');
 const path = require('path');
 const request = require('request');
 const pc = process;

--- a/examples/forms.amp.html
+++ b/examples/forms.amp.html
@@ -779,3 +779,14 @@
 
     <div submit-success template="submit_success_template"></div>
 </form>
+
+<h4>File upload</h4>
+<form method="post" action-xhr="/form/json/upload" enctype="multipart/form-data" target="_blank">
+    <label>
+        <p>Upload a file:</p>
+        <input type="file" name="myFile" accept="text/plain">
+    </label>
+    <div><input type="submit"></div>
+    <div submit-success><template type="amp-mustache">Way to go 🎉 {{message}}</template></div>
+    <div submit-error>Way to fail</div>
+</form>

--- a/extensions/amp-bind/0.1/bind-validator.js
+++ b/extensions/amp-bind/0.1/bind-validator.js
@@ -322,7 +322,7 @@ function createElementRules_() {
       'spellcheck': null,
       'step': null,
       'type': {
-        blacklistedValueRegex: '(^|\\s)(button|file|image|)(\\s|$)',
+        blacklistedValueRegex: '(^|\\s)(button|image|)(\\s|$)',
       },
       'value': null,
       'width': null,

--- a/extensions/amp-bind/0.1/bind-validator.js
+++ b/extensions/amp-bind/0.1/bind-validator.js
@@ -78,7 +78,7 @@ export class BindValidator {
   /**
    * Returns true if (tag, property) binding is allowed.
    * Otherwise, returns false.
-   * @note `tag` and `property` are case-sensitive.
+   * NOTE: `tag` and `property` are case-sensitive.
    * @param {string} tag
    * @param {string} property
    * @return {boolean}
@@ -177,6 +177,8 @@ export class BindValidator {
    * Returns the property rules object for (tag, property), if it exists.
    * Returns null if binding is allowed without constraints.
    * Returns undefined if binding is not allowed.
+   * @param {string} tag
+   * @param {string} property
    * @return {(?PropertyRulesDef|undefined)}
    * @private
    */

--- a/extensions/amp-bind/0.1/test/test-bind-validator.js
+++ b/extensions/amp-bind/0.1/test/test-bind-validator.js
@@ -159,9 +159,10 @@ describe('BindValidator', () => {
     it('should NOT allow unsupported <input> "type" values', () => {
       expect(val.isResultValid('INPUT', 'type', 'checkbox')).to.be.true;
       expect(val.isResultValid('INPUT', 'type', 'email')).to.be.true;
+      expect(val.isResultValid('INPUT', 'type', 'file')).to.be.true;
+      expect(val.isResultValid('INPUT', 'type', 'password')).to.be.true;
 
       expect(val.isResultValid('INPUT', 'type', 'BUTTON')).to.be.false;
-      expect(val.isResultValid('INPUT', 'type', 'file')).to.be.false;
       expect(val.isResultValid('INPUT', 'type', 'image')).to.be.false;
     });
   });

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -507,7 +507,7 @@ export class AmpForm {
     const isHeadOrGet = method == 'GET' || method == 'HEAD';
 
     if (isHeadOrGet) {
-      this.assertNoPasswordFields_();
+      this.assertNoInsecureFields_();
       const values = this.getFormAsObject_();
       if (opt_extraFields) {
         deepMerge(values, opt_extraFields);
@@ -586,7 +586,7 @@ export class AmpForm {
    * @private
    */
   handleNonXhrGet_(varSubsFields) {
-    this.assertNoPasswordFields_();
+    this.assertNoInsecureFields_();
     // Non-xhr GET requests replacement should happen synchronously.
     for (let i = 0; i < varSubsFields.length; i++) {
       this.urlReplacement_.expandInputValueSync(varSubsFields[i]);
@@ -595,13 +595,16 @@ export class AmpForm {
   }
 
   /**
-   * Fail if there are password fields present when the function is called.
+   * Fail if there are password or file fields present when the function
+   * is called.
    * @private
    */
-  assertNoPasswordFields_() {
-    const passwordFields = this.form_.querySelectorAll('input[type=password]');
-    user().assert(passwordFields.length == 0,
-        'input[type=password] may only appear in form[method=post]');
+  assertNoInsecureFields_() {
+    const fields = this.form_.querySelectorAll(
+        'input[type=password],input[type=file]');
+    user().assert(fields.length == 0,
+        'input[type=password] or input[type=file] ' +
+        'may only appear in form[method=post]');
   }
 
   /**

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -507,7 +507,7 @@ export class AmpForm {
     const isHeadOrGet = method == 'GET' || method == 'HEAD';
 
     if (isHeadOrGet) {
-      this.assertNoInsecureFields_();
+      this.assertNoSensitiveFields_();
       const values = this.getFormAsObject_();
       if (opt_extraFields) {
         deepMerge(values, opt_extraFields);
@@ -586,7 +586,7 @@ export class AmpForm {
    * @private
    */
   handleNonXhrGet_(varSubsFields) {
-    this.assertNoInsecureFields_();
+    this.assertNoSensitiveFields_();
     // Non-xhr GET requests replacement should happen synchronously.
     for (let i = 0; i < varSubsFields.length; i++) {
       this.urlReplacement_.expandInputValueSync(varSubsFields[i]);
@@ -599,7 +599,7 @@ export class AmpForm {
    * is called.
    * @private
    */
-  assertNoInsecureFields_() {
+  assertNoSensitiveFields_() {
     const fields = this.form_.querySelectorAll(
         'input[type=password],input[type=file]');
     user().assert(fields.length == 0,

--- a/extensions/amp-form/0.1/form-validators.js
+++ b/extensions/amp-form/0.1/form-validators.js
@@ -13,11 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+import {Services} from '../../../src/services';
 import {ValidationBubble} from './validation-bubble';
 import {createCustomEvent} from '../../../src/event-helper';
 import {dev} from '../../../src/log';
-import {getAmpdoc} from '../../../src/service';
 import {toWin} from '../../../src/types';
 
 
@@ -72,7 +71,10 @@ export class FormValidator {
     this.form = form;
 
     /** @protected @const {!../../../src/service/ampdoc-impl.AmpDoc} */
-    this.ampdoc = getAmpdoc(form);
+    this.ampdoc = Services.ampdoc(form);
+
+    /** @const @protected {!../../../src/service/resources-impl.Resources} */
+    this.resources = Services.resourcesForDoc(form);
 
     /** @protected @const {!Document|!ShadowRoot} */
     this.root = this.ampdoc.getRootNode();
@@ -241,10 +243,12 @@ export class AbstractCustomValidator extends FormValidator {
     if (!validation.textContent.trim()) {
       validation.textContent = input.validationMessage;
     }
-
-    input.setAttribute('aria-invalid', 'true');
-    validation.classList.add('visible');
     this.inputVisibleValidationDict_[input.id] = validation;
+
+    this.resources.mutateElement(input,
+        () => input.setAttribute('aria-invalid', 'true'));
+    this.resources.mutateElement(validation,
+        () => validation.classList.add('visible'));
   }
 
   /**
@@ -255,9 +259,12 @@ export class AbstractCustomValidator extends FormValidator {
     if (!visibleValidation) {
       return;
     }
-    input.removeAttribute('aria-invalid');
-    visibleValidation.classList.remove('visible');
     delete this.inputVisibleValidationDict_[input.id];
+
+    this.resources.mutateElement(input,
+        () => input.removeAttribute('aria-invalid'));
+    this.resources.mutateElement(visibleValidation,
+        () => visibleValidation.classList.remove('visible'));
   }
 
   /**

--- a/extensions/amp-form/0.1/test/test-amp-form.js
+++ b/extensions/amp-form/0.1/test/test-amp-form.js
@@ -1793,6 +1793,27 @@ describes.repeated('', {
           expect(form.submit).to.have.not.been.called;
         });
       });
+
+      it('should not execute form submit with file field present', () => {
+        const form = getForm();
+        const input = document.createElement('input');
+        input.type = 'file';
+        form.appendChild(input);
+
+        return getAmpForm(form).then(ampForm => {
+          const form = ampForm.form_;
+          ampForm.method_ = 'GET';
+          ampForm.xhrAction_ = null;
+          sandbox.stub(form, 'submit');
+          sandbox.stub(form, 'checkValidity').returns(true);
+          sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
+          allowConsoleError(() => {
+            expect(() => ampForm.handleSubmitAction_(/* invocation */ {}))
+                .to.throw('input[type=file]');
+          });
+          expect(form.submit).to.have.not.been.called;
+        });
+      });
     });
 
     it('should trigger amp-form-submit analytics event with form data', () => {
@@ -1800,11 +1821,11 @@ describes.repeated('', {
         const form = ampForm.form_;
         form.id = 'registration';
 
-        const passwordInput = createElement('input');
-        passwordInput.setAttribute('name', 'email');
-        passwordInput.setAttribute('type', 'email');
-        passwordInput.setAttribute('value', 'j@hnmiller.com');
-        form.appendChild(passwordInput);
+        const emailInput = document.createElement('input');
+        emailInput.setAttribute('name', 'email');
+        emailInput.setAttribute('type', 'email');
+        emailInput.setAttribute('value', 'j@hnmiller.com');
+        form.appendChild(emailInput);
 
         const unnamedInput = createElement('input');
         unnamedInput.setAttribute('type', 'text');

--- a/extensions/amp-form/0.1/test/test-amp-form.js
+++ b/extensions/amp-form/0.1/test/test-amp-form.js
@@ -1796,7 +1796,7 @@ describes.repeated('', {
 
       it('should not execute form submit with file field present', () => {
         const form = getForm();
-        const input = document.createElement('input');
+        const input = createElement('input');
         input.type = 'file';
         form.appendChild(input);
 
@@ -1821,7 +1821,7 @@ describes.repeated('', {
         const form = ampForm.form_;
         form.id = 'registration';
 
-        const emailInput = document.createElement('input');
+        const emailInput = createElement('input');
         emailInput.setAttribute('name', 'email');
         emailInput.setAttribute('type', 'email');
         emailInput.setAttribute('value', 'j@hnmiller.com');

--- a/extensions/amp-form/0.1/test/test-amp-form.js
+++ b/extensions/amp-form/0.1/test/test-amp-form.js
@@ -62,6 +62,10 @@ describes.repeated('', {
       const ownerDoc = document.ownerDocument || document;
       createElement = ownerDoc.createElement.bind(ownerDoc);
       createTextNode = ownerDoc.createTextNode.bind(ownerDoc);
+
+      // Force sync mutateElement to make testing easier.
+      const resources = Services.resourcesForDoc(env.ampdoc);
+      sandbox.stub(resources, 'mutateElement').callsArg(1);
     });
 
     function getAmpForm(form, canonical = 'https://example.com/amps.html') {
@@ -258,16 +262,7 @@ describes.repeated('', {
         target: form,
         preventDefault: sandbox.spy(),
       };
-      ampForm.vsync_ = {
-        run: (task, state) => {
-          if (task.measure) {
-            task.measure(state);
-          }
-          if (task.mutate) {
-            task.mutate(state);
-          }
-        },
-      };
+
       sandbox.spy(form, 'checkValidity');
       sandbox.spy(emailInput, 'reportValidity');
       ampForm.handleSubmitEvent_(event);
@@ -319,16 +314,6 @@ describes.repeated('', {
         target: form,
         preventDefault: sandbox.spy(),
       };
-      ampForm.vsync_ = {
-        run: (task, state) => {
-          if (task.measure) {
-            task.measure(state);
-          }
-          if (task.mutate) {
-            task.mutate(state);
-          }
-        },
-      };
       sandbox.spy(form, 'checkValidity');
       sandbox.spy(emailInput, 'reportValidity');
 
@@ -353,22 +338,10 @@ describes.repeated('', {
         form.appendChild(emailInput);
         sandbox.spy(form, 'checkValidity');
         sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
-
         const event = {
           stopImmediatePropagation: sandbox.spy(),
           target: ampForm.form_,
           preventDefault: sandbox.spy(),
-        };
-
-        ampForm.vsync_ = {
-          run: (task, state) => {
-            if (task.measure) {
-              task.measure(state);
-            }
-            if (task.mutate) {
-              task.mutate(state);
-            }
-          },
         };
 
         const bubbleEl = env.ampdoc.getRootNode().querySelector(
@@ -429,23 +402,12 @@ describes.repeated('', {
         form.appendChild(emailInput);
         sandbox.spy(form, 'checkValidity');
         sandbox.stub(ampForm.xhr_, 'fetch').returns(Promise.resolve());
-
         const event = {
           stopImmediatePropagation: sandbox.spy(),
           target: ampForm.form_,
           preventDefault: sandbox.spy(),
         };
 
-        ampForm.vsync_ = {
-          run: (task, state) => {
-            if (task.measure) {
-              task.measure(state);
-            }
-            if (task.mutate) {
-              task.mutate(state);
-            }
-          },
-        };
 
         ampForm.handleSubmitEvent_(event);
         return whenCalled(ampForm.xhr_.fetch).then(() => {

--- a/extensions/amp-form/0.1/test/test-form-validators.js
+++ b/extensions/amp-form/0.1/test/test-form-validators.js
@@ -25,8 +25,8 @@ import {
   getFormValidator,
   setReportValiditySupportedForTesting,
 } from '../form-validators';
+import {Services} from '../../../../src/services';
 import {ValidationBubble} from '../validation-bubble';
-
 
 describes.realWin('form-validators', {amp: true}, env => {
   let sandbox;
@@ -91,6 +91,10 @@ describes.realWin('form-validators', {amp: true}, env => {
 
   beforeEach(() => {
     sandbox = env.sandbox;
+
+    // Force sync mutateElement to make testing easier.
+    const resources = Services.resourcesForDoc(env.ampdoc);
+    sandbox.stub(resources, 'mutateElement').callsArg(1);
   });
 
   describe('getFormValidator', () => {

--- a/extensions/amp-mustache/0.1/test/test-amp-mustache.js
+++ b/extensions/amp-mustache/0.1/test/test-amp-mustache.js
@@ -197,7 +197,7 @@ describe('amp-mustache template', () => {
           type: 'file',
         });
         expect(result./*OK*/innerHTML).to.equal(
-            'value = <input value="myid">');
+            'value = <input value="myid" type="file">');
       });
 
       allowConsoleError(() => {

--- a/extensions/amp-mustache/0.1/test/test-amp-mustache.js
+++ b/extensions/amp-mustache/0.1/test/test-amp-mustache.js
@@ -194,26 +194,24 @@ describe('amp-mustache template', () => {
       allowConsoleError(() => {
         const result = template.render({
           value: 'myid',
-          type: 'file',
-        });
-        expect(result./*OK*/innerHTML).to.equal(
-            'value = <input value="myid" type="file">');
-      });
-
-      allowConsoleError(() => {
-        const result = template.render({
-          value: 'myid',
           type: 'button',
         });
         expect(result./*OK*/innerHTML).to.equal(
             'value = <input value="myid">');
       });
 
-      const result = template.render({
+      const fileResult = template.render({
+        value: 'myid',
+        type: 'file',
+      });
+      expect(fileResult./*OK*/innerHTML).to.equal(
+          'value = <input value="myid" type="file">');
+
+      const passwordResult = template.render({
         value: 'myid',
         type: 'password',
       });
-      expect(result./*OK*/innerHTML).to.equal(
+      expect(passwordResult./*OK*/innerHTML).to.equal(
           'value = <input value="myid" type="password">');
     });
 

--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
     "mocha": "5.1.1",
     "moment": "2.22.0",
     "morgan": "1.9.0",
+    "multer": "1.3.0",
     "nodemon": "1.17.2",
     "path": "0.12.7",
     "plugin-error": "0.1.2",

--- a/src/sanitizer.js
+++ b/src/sanitizer.js
@@ -171,7 +171,7 @@ const BLACKLISTED_ATTR_VALUES = [
 /** @const {!Object<string, !Object<string, !RegExp>>} */
 const BLACKLISTED_TAG_SPECIFIC_ATTR_VALUES = dict({
   'input': {
-    'type': /(?:image|file|button)/i,
+    'type': /(?:image|button)/i,
   },
 });
 

--- a/validator/testdata/amp4ads_feature_tests/amp_form.html
+++ b/validator/testdata/amp4ads_feature_tests/amp_form.html
@@ -48,12 +48,12 @@
   <!-- Invalid: input can not be type="button|file|image". -->
   <form method="post" action-xhr="https://example.com/subscribe" target="_blank">
     <input type="button" name="button">
-    <input type="file" name="file">
     <input type="image" name="image">
   </form>
   <!-- Invalid: input can not be type="password" -->
   <form method="post" action-xhr="https://example.com/subscribe" target="_blank">
     <input type="password" name="password">
+    <input type="file" name="file">
   </form>
 </body>
 </html>

--- a/validator/testdata/amp4ads_feature_tests/amp_form.out
+++ b/validator/testdata/amp4ads_feature_tests/amp_form.out
@@ -51,18 +51,18 @@ FAIL
 |      <input type="button" name="button">
 >>     ^~~~~~~~~
 amp4ads_feature_tests/amp_form.html:50:4 The attribute 'type' in tag 'input' is set to the invalid value 'button'. (see https://www.ampproject.org/docs/reference/components/amp-form) [DISALLOWED_HTML]
-|      <input type="file" name="file">
->>     ^~~~~~~~~
-amp4ads_feature_tests/amp_form.html:51:4 The attribute 'type' in tag 'input' is set to the invalid value 'file'. (see https://www.ampproject.org/docs/reference/components/amp-form) [DISALLOWED_HTML]
 |      <input type="image" name="image">
 >>     ^~~~~~~~~
-amp4ads_feature_tests/amp_form.html:52:4 The attribute 'type' in tag 'input' is set to the invalid value 'image'. (see https://www.ampproject.org/docs/reference/components/amp-form) [DISALLOWED_HTML]
+amp4ads_feature_tests/amp_form.html:51:4 The attribute 'type' in tag 'input' is set to the invalid value 'image'. (see https://www.ampproject.org/docs/reference/components/amp-form) [DISALLOWED_HTML]
 |    </form>
 |    <!-- Invalid: input can not be type="password" -->
 |    <form method="post" action-xhr="https://example.com/subscribe" target="_blank">
 |      <input type="password" name="password">
 >>     ^~~~~~~~~
-amp4ads_feature_tests/amp_form.html:56:4 The attribute 'type' in tag 'input' is set to the invalid value 'password'. (see https://www.ampproject.org/docs/reference/components/amp-form) [DISALLOWED_HTML]
+amp4ads_feature_tests/amp_form.html:55:4 The attribute 'type' in tag 'input' is set to the invalid value 'password'. (see https://www.ampproject.org/docs/reference/components/amp-form) [DISALLOWED_HTML]
+|      <input type="file" name="file">
+>>     ^~~~~~~~~
+amp4ads_feature_tests/amp_form.html:56:4 The attribute 'type' in tag 'input' is set to the invalid value 'file'. (see https://www.ampproject.org/docs/reference/components/amp-form) [DISALLOWED_HTML]
 |    </form>
 |  </body>
 |  </html>

--- a/validator/testdata/amp4email_feature_tests/amp_form.html
+++ b/validator/testdata/amp4email_feature_tests/amp_form.html
@@ -47,12 +47,12 @@
   <!-- Invalid: input can not be type="button|file|image". -->
   <form method="post" action-xhr="https://example.com/subscribe">
     <input type="button" name="button">
-    <input type="file" name="file">
     <input type="image" name="image">
   </form>
   <!-- Invalid: input can not be type="password" -->
   <form method="post" action-xhr="https://example.com/subscribe">
     <input type="password" name="password">
+    <input type="file" name="file">
   </form>
 </body>
 </html>

--- a/validator/testdata/amp4email_feature_tests/amp_form.out
+++ b/validator/testdata/amp4email_feature_tests/amp_form.out
@@ -50,18 +50,18 @@ FAIL
 |      <input type="button" name="button">
 >>     ^~~~~~~~~
 amp4email_feature_tests/amp_form.html:49:4 The attribute 'type' in tag 'input' is set to the invalid value 'button'. (see https://www.ampproject.org/docs/reference/components/amp-form) [DISALLOWED_HTML]
-|      <input type="file" name="file">
->>     ^~~~~~~~~
-amp4email_feature_tests/amp_form.html:50:4 The attribute 'type' in tag 'input' is set to the invalid value 'file'. (see https://www.ampproject.org/docs/reference/components/amp-form) [DISALLOWED_HTML]
 |      <input type="image" name="image">
 >>     ^~~~~~~~~
-amp4email_feature_tests/amp_form.html:51:4 The attribute 'type' in tag 'input' is set to the invalid value 'image'. (see https://www.ampproject.org/docs/reference/components/amp-form) [DISALLOWED_HTML]
+amp4email_feature_tests/amp_form.html:50:4 The attribute 'type' in tag 'input' is set to the invalid value 'image'. (see https://www.ampproject.org/docs/reference/components/amp-form) [DISALLOWED_HTML]
 |    </form>
 |    <!-- Invalid: input can not be type="password" -->
 |    <form method="post" action-xhr="https://example.com/subscribe">
 |      <input type="password" name="password">
 >>     ^~~~~~~~~
-amp4email_feature_tests/amp_form.html:55:4 The attribute 'type' in tag 'input' is set to the invalid value 'password'. (see https://www.ampproject.org/docs/reference/components/amp-form) [DISALLOWED_HTML]
+amp4email_feature_tests/amp_form.html:54:4 The attribute 'type' in tag 'input' is set to the invalid value 'password'. (see https://www.ampproject.org/docs/reference/components/amp-form) [DISALLOWED_HTML]
+|      <input type="file" name="file">
+>>     ^~~~~~~~~
+amp4email_feature_tests/amp_form.html:55:4 The attribute 'type' in tag 'input' is set to the invalid value 'file'. (see https://www.ampproject.org/docs/reference/components/amp-form) [DISALLOWED_HTML]
 |    </form>
 |  </body>
 |  </html>

--- a/validator/testdata/feature_tests/forms.html
+++ b/validator/testdata/feature_tests/forms.html
@@ -108,15 +108,15 @@
     <option value="1">English</option>
   </select>
   <textarea name="comment"></textarea>
-  <!-- Invalid: input can not be type="button|file|image". -->
+  <!-- Invalid: input can not be type="button|image". -->
   <form method="post" action-xhr="https://example.com/subscribe" target="_blank">
     <input type="button" name="button">
-    <input type="file" name="file">
     <input type="image" name="image">
   </form>
-  <!-- Valid: input can be type="password" in a post xhr form. -->
+  <!-- Valid: input can be type="password" or type="file" in a post xhr form. -->
   <form method="post" action-xhr="https://example.com/subscribe" target="_blank">
     <input type="password" name="password">
+    <input type="file" name="file">
   </form>
   <!-- Invalid: password requires post and action-xhr -->
   <form method="get" action="https://example.com/subscribe" action-xhr="https://example.com/subscribe" target="_blank">

--- a/validator/testdata/feature_tests/forms.html
+++ b/validator/testdata/feature_tests/forms.html
@@ -116,7 +116,7 @@
   <!-- Valid: input can be type="password" or type="file" in a post xhr form. -->
   <form method="post" action-xhr="https://example.com/subscribe" target="_blank">
     <input type="password" name="password">
-    <input type="file" name="file">
+    <input type="file" name="file" accept="text/plain">
   </form>
   <!-- Invalid: password requires post and action-xhr -->
   <form method="get" action="https://example.com/subscribe" action-xhr="https://example.com/subscribe" target="_blank">

--- a/validator/testdata/feature_tests/forms.out
+++ b/validator/testdata/feature_tests/forms.out
@@ -125,7 +125,7 @@ feature_tests/forms.html:114:4 The attribute 'type' in tag 'input' is set to the
 |    <!-- Valid: input can be type="password" or type="file" in a post xhr form. -->
 |    <form method="post" action-xhr="https://example.com/subscribe" target="_blank">
 |      <input type="password" name="password">
-|      <input type="file" name="file">
+|      <input type="file" name="file" accept="text/plain">
 |    </form>
 |    <!-- Invalid: password requires post and action-xhr -->
 |    <form method="get" action="https://example.com/subscribe" action-xhr="https://example.com/subscribe" target="_blank">

--- a/validator/testdata/feature_tests/forms.out
+++ b/validator/testdata/feature_tests/forms.out
@@ -113,21 +113,19 @@ feature_tests/forms.html:102:2 The attribute 'target' in tag 'FORM [method=POST]
 |      <option value="1">English</option>
 |    </select>
 |    <textarea name="comment"></textarea>
-|    <!-- Invalid: input can not be type="button|file|image". -->
+|    <!-- Invalid: input can not be type="button|image". -->
 |    <form method="post" action-xhr="https://example.com/subscribe" target="_blank">
 |      <input type="button" name="button">
 >>     ^~~~~~~~~
 feature_tests/forms.html:113:4 The attribute 'type' in tag 'input' is set to the invalid value 'button'. (see https://www.ampproject.org/docs/reference/components/amp-form) [DISALLOWED_HTML]
-|      <input type="file" name="file">
->>     ^~~~~~~~~
-feature_tests/forms.html:114:4 The attribute 'type' in tag 'input' is set to the invalid value 'file'. (see https://www.ampproject.org/docs/reference/components/amp-form) [DISALLOWED_HTML]
 |      <input type="image" name="image">
 >>     ^~~~~~~~~
-feature_tests/forms.html:115:4 The attribute 'type' in tag 'input' is set to the invalid value 'image'. (see https://www.ampproject.org/docs/reference/components/amp-form) [DISALLOWED_HTML]
+feature_tests/forms.html:114:4 The attribute 'type' in tag 'input' is set to the invalid value 'image'. (see https://www.ampproject.org/docs/reference/components/amp-form) [DISALLOWED_HTML]
 |    </form>
-|    <!-- Valid: input can be type="password" in a post xhr form. -->
+|    <!-- Valid: input can be type="password" or type="file" in a post xhr form. -->
 |    <form method="post" action-xhr="https://example.com/subscribe" target="_blank">
 |      <input type="password" name="password">
+|      <input type="file" name="file">
 |    </form>
 |    <!-- Invalid: password requires post and action-xhr -->
 |    <form method="get" action="https://example.com/subscribe" action-xhr="https://example.com/subscribe" target="_blank">

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -3671,6 +3671,21 @@ tags: {
 tags: {
   html_format: AMP
   tag_name: "INPUT"
+  spec_name: "INPUT [type=file]"
+  attrs: {
+    name: "type"
+    value_casei: "file"
+    mandatory: true
+    dispatch_key: NAME_VALUE_DISPATCH
+  }
+  attr_lists: "input-common-attr"
+  attr_lists: "input-name-attr"
+  mandatory_ancestor: "FORM [method=POST]"
+  spec_url: "https://www.ampproject.org/docs/reference/components/amp-form"
+}
+tags: {
+  html_format: AMP
+  tag_name: "INPUT"
   spec_name: "INPUT [type=password]"
   attrs: {
     name: "type"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7370,7 +7370,7 @@ ms@^2.0.0, ms@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
 
-multer@^1.3.0:
+multer@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/multer/-/multer-1.3.0.tgz#092b2670f6846fa4914965efc8cf94c20fec6cd2"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -427,6 +427,10 @@ aphrodite@^1.2.5:
     inline-style-prefixer "^3.0.1"
     string-hash "^1.1.3"
 
+append-field@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/append-field/-/append-field-0.1.0.tgz#6ddc58fa083c7bc545d3c5995b2830cc2366d44a"
+
 aproba@^1.0.3:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
@@ -1840,6 +1844,10 @@ buffer-crc32@^0.2.1:
   version "0.2.13"
   resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
 
+buffer-from@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.0.0.tgz#4cb8832d23612589b0406e9e2956c17f06fdf531"
+
 buffer-xor@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/buffer-xor/-/buffer-xor-1.0.3.tgz#26e61ed1422fb70dd42e6e36729ed51d855fe8d9"
@@ -1891,6 +1899,13 @@ bundlesize@0.17.0:
     gzip-size "^4.0.0"
     prettycli "^1.4.3"
     read-pkg-up "^3.0.0"
+
+busboy@^0.2.11:
+  version "0.2.14"
+  resolved "https://registry.yarnpkg.com/busboy/-/busboy-0.2.14.tgz#6c2a622efcf47c57bbbe1e2a9c37ad36c7925453"
+  dependencies:
+    dicer "0.2.5"
+    readable-stream "1.1.x"
 
 bytes@1, bytes@1.0.0:
   version "1.0.0"
@@ -2456,6 +2471,15 @@ concat-stream@^1.4.6, concat-stream@^1.6.0, concat-stream@~1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.0.tgz#0aac662fd52be78964d5532f694784e70110acf7"
   dependencies:
+    inherits "^2.0.3"
+    readable-stream "^2.2.2"
+    typedarray "^0.0.6"
+
+concat-stream@^1.5.0:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.2.tgz#904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"
+  dependencies:
+    buffer-from "^1.0.0"
     inherits "^2.0.3"
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
@@ -3182,6 +3206,13 @@ detective@^5.0.2:
 di@^0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/di/-/di-0.0.1.tgz#806649326ceaa7caa3306d75d985ea2748ba913c"
+
+dicer@0.2.5:
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/dicer/-/dicer-0.2.5.tgz#5996c086bb33218c812c090bddc09cd12facb70f"
+  dependencies:
+    readable-stream "1.1.x"
+    streamsearch "0.1.2"
 
 diff@3.5.0:
   version "3.5.0"
@@ -7339,6 +7370,19 @@ ms@^2.0.0, ms@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
 
+multer@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/multer/-/multer-1.3.0.tgz#092b2670f6846fa4914965efc8cf94c20fec6cd2"
+  dependencies:
+    append-field "^0.1.0"
+    busboy "^0.2.11"
+    concat-stream "^1.5.0"
+    mkdirp "^0.5.1"
+    object-assign "^3.0.0"
+    on-finished "^2.3.0"
+    type-is "^1.6.4"
+    xtend "^4.0.0"
+
 multimatch@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/multimatch/-/multimatch-2.1.0.tgz#9c7906a22fb4c02919e2f5f75161b4cdbd4b2a2b"
@@ -7775,7 +7819,7 @@ on-finished@2.1.0:
   dependencies:
     ee-first "1.0.5"
 
-on-finished@~2.3.0:
+on-finished@^2.3.0, on-finished@~2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.3.0.tgz#20f1336481b083cd75337992a16971aa2d906947"
   dependencies:
@@ -10221,6 +10265,10 @@ streamroller@^0.7.0:
     mkdirp "^0.5.1"
     readable-stream "^2.3.0"
 
+streamsearch@0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/streamsearch/-/streamsearch-0.1.2.tgz#808b9d0e56fc273d809ba57338e929919a1a9f1a"
+
 strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
@@ -10751,6 +10799,13 @@ type-check@~0.3.2:
 type-detect@^4.0.0, type-detect@^4.0.5:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.5.tgz#d70e5bc81db6de2a381bcaca0c6e0cbdc7635de2"
+
+type-is@^1.6.4:
+  version "1.6.16"
+  resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.16.tgz#f89ce341541c672b25ee7ae3c73dee3b2be50194"
+  dependencies:
+    media-typer "0.3.0"
+    mime-types "~2.1.18"
 
 type-is@~1.5.1:
   version "1.5.7"


### PR DESCRIPTION
Fixes #9791

Similar to #14533 for allowing password inputs, this PR enables file inputs **only for** HTTPS POST `action-xhr` forms.

/to @aghassemi @nainar @honeybadgerdontcare 
/cc @choumx for a4email a4ads checks

<img alt="File upload example" src="https://user-images.githubusercontent.com/2363700/39726453-ead6bbde-5203-11e8-8d63-0b9778fdb9a0.gif" width="320">
