### PR TITLE
♻️ Use tryResolve in URL Expander

### DIFF
--- a/src/service/url-expander/expander.js
+++ b/src/service/url-expander/expander.js
@@ -15,6 +15,7 @@
  */
 
 import {rethrowAsync, user} from '../../log';
+import {tryResolve} from '../../promise';
 
 export const PARSER_IGNORE_FLAG = '`';
 
@@ -206,7 +207,7 @@ export class Expander {
           value = Promise.all(opt_args)
               .then(args => binding.apply(null, args));
         } else {
-          value = Promise.resolve(binding.apply(null, opt_args));
+          value = tryResolve(binding);
         }
       } else {
         value = Promise.resolve(binding);


### PR DESCRIPTION
This accomplishes two things:
1. Sync errors thrown by `binding` will now be caught.
2. We no longer pass `undefined` as the second param
   - What was that about?

Part of #15110.