### PR TITLE
Fix carousel duplicate thumbnail bug

### DIFF
--- a/extensions/amp-lightbox-gallery/0.1/service/lightbox-manager-impl.js
+++ b/extensions/amp-lightbox-gallery/0.1/service/lightbox-manager-impl.js
@@ -188,6 +188,10 @@ export class LightboxManager {
                 && slide.getAttribute('lightbox') !== lightboxGroupId);
         if (!shouldExcludeSlide) {
           slide.setAttribute('lightbox', lightboxGroupId);
+          if (this.seen_.includes(slide)) {
+            return;
+          }
+          this.seen_.push(slide);
           this.processBaseLightboxElement_(slide, lightboxGroupId);
         }
       });
@@ -253,8 +257,7 @@ export class LightboxManager {
       this.lightboxGroups_[lightboxGroupId] = [];
     }
 
-    this.lightboxGroups_[lightboxGroupId]
-        .push(dev().assertElement(element));
+    this.lightboxGroups_[lightboxGroupId].push(dev().assertElement(element));
     if (this.meetsHeuristicsForTap_(element)) {
       const gallery = elementByTag(this.ampdoc_.getRootNode(), GALLERY_TAG);
       element.setAttribute('on', `tap:${gallery.id}.activate`);

--- a/extensions/amp-lightbox-gallery/0.1/service/lightbox-manager-impl.js
+++ b/extensions/amp-lightbox-gallery/0.1/service/lightbox-manager-impl.js
@@ -187,10 +187,10 @@ export class LightboxManager {
             || (slide.hasAttribute('lightbox')
                 && slide.getAttribute('lightbox') !== lightboxGroupId);
         if (!shouldExcludeSlide) {
-          slide.setAttribute('lightbox', lightboxGroupId);
           if (this.seen_.includes(slide)) {
             return;
           }
+          slide.setAttribute('lightbox', lightboxGroupId);
           this.seen_.push(slide);
           this.processBaseLightboxElement_(slide, lightboxGroupId);
         }

--- a/test/manual/amp-lightbox-gallery-launch.amp.html
+++ b/test/manual/amp-lightbox-gallery-launch.amp.html
@@ -1,310 +1,2365 @@
-<!doctype html>
-<html ⚡>
+<!DOCTYPE html>
+<html amp>
 <head>
-  <meta charset="utf-8">
-  <title>Lightbox Gallery Launch Tests</title>
-  <link rel="canonical" href="amps.html" >
-  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
-  <script async src="https://cdn.ampproject.org/v0.js"></script>
-  <script async custom-element="amp-lightbox-gallery" src="https://cdn.ampproject.org/v0/amp-lightbox-gallery-0.1.js"></script>
-  <script async custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.1.js"></script>
-  <script async custom-element="amp-video" src="https://cdn.ampproject.org/v0/amp-video-0.1.js"></script>
-  <script async custom-element="amp-youtube" src="https://cdn.ampproject.org/v0/amp-youtube-0.1.js"></script>
-  <script async custom-element="amp-ad" src="https://cdn.ampproject.org/v0/amp-ad-0.1.js"></script>
-  <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
+    <meta charset="utf-8">
+<script async src="https://cdn.ampproject.org/v0.js"></script>
+<title>Online Shop SMJEL Fashion Trendy Open Leaf Cuff Bracelet Bangles for Women Simple Plant Bracelet Femme Boho Jewelry Birthday Gift SYSZ014 | Aliexpress Mobile</title>
+<meta name="description" content="bangles fashion on sale at reasonable prices, buy SMJEL Fashion Trendy Open Leaf Cuff Bracelet Bangles for Women Simple Plant Bracelet Femme Boho Jewelry Birthday Gift SYSZ014 from mobile site on Aliexpress Now!" />
+<meta name="keywords" content="bangles fashion" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+<meta name="format-detection" content="telephone=no" />
+<meta name="data-spm" content="a2g0n" />
+<meta name="robots" content="follow,index" />
 
-  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
-  <style amp-custom>
-    body {
-      font-family: sans-serif;
-    }
+    <link rel="shortcut icon" href="https://m.aliexpress.com/img/logo/favicon.ico" />
+<link rel="alternate" href="android-app://com.alibaba.aliexpresshd/aliexpress/deeplink/list/msite/en//main" />    <link rel="canonical" href="https://fr.aliexpress.com/item/-/32751800685.html"/>
+        <link rel="alternate" hreflang="en" href="https://m.aliexpress.com/item/32751800685.html"/>
+        <link rel="alternate" hreflang="ru" href="https://m.ru.aliexpress.com/item/32751800685.html"/>
+        <link rel="alternate" hreflang="pt" href="https://m.pt.aliexpress.com/item/32751800685.html"/>
+        <link rel="alternate" hreflang="in" href="https://m.id.aliexpress.com/item/32751800685.html"/>
+        <link rel="alternate" hreflang="es" href="https://m.es.aliexpress.com/item/32751800685.html"/>
+        <link rel="alternate" hreflang="fr" href="https://m.fr.aliexpress.com/item/32751800685.html"/>
+        <link rel="alternate" hreflang="de" href="https://m.de.aliexpress.com/item/32751800685.html"/>
+        <link rel="alternate" hreflang="it" href="https://m.it.aliexpress.com/item/32751800685.html"/>
+        <link rel="alternate" hreflang="ja" href="https://m.ja.aliexpress.com/item/32751800685.html"/>
+        <link rel="alternate" hreflang="ko" href="https://m.ko.aliexpress.com/item/32751800685.html"/>
+        <link rel="alternate" hreflang="nl" href="https://m.nl.aliexpress.com/item/32751800685.html"/>
+        <link rel="alternate" hreflang="vi" href="https://m.vi.aliexpress.com/item/32751800685.html"/>
+        <link rel="alternate" hreflang="th" href="https://m.th.aliexpress.com/item/32751800685.html"/>
+        <link rel="alternate" hreflang="tr" href="https://m.tr.aliexpress.com/item/32751800685.html"/>
+            <script type="application/ld+json">
+                {"@context":"http://schema.org/","@type":"Product","aggregateRating":{"@type":"AggregateRating","ratingCount":585,"ratingValue":4.8},"image":"https://ae01.alicdn.com/kf/HTB1zvRtSFXXXXX1aXXXq6xXFXXXO/SMJEL-Fashion-Trendy-Open-Leaf-Cuff-Bracelet-Bangles-for-Women-Simple-Plant-Bracelet-Femme-Boho-Jewelry.jpg","name":"SMJEL Fashion Trendy Open Leaf Cuff Bracelet Bangles for Women Simple Plant Bracelet Femme Boho Jewelry Birthday Gift SYSZ014","offers":{"@type":"Offer","price":"1.79","priceCurrency":"USD"}}
+    </script>
 
-  </style>
-</head>
-<body>
-  <script>
-    // Enable amp-lightbox-viewer experiment automatically if it is not enabled.
-    // Disable amp-lightbox-viewer-auto experiment if it is enabled.
-    setTimeout(function() {
-        if (!AMP.isExperimentOn('amp-lightbox-gallery')) {
-          AMP.toggleExperiment('amp-lightbox-gallery');
-          location.reload();
-        }
+    <style amp-boilerplate>
+    body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}
+</style>
+<noscript>
+    <style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style>
+</noscript>
+<script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
+<script async custom-element="amp-form" src="https://cdn.ampproject.org/v0/amp-form-0.1.js"></script>
+<script async custom-element="amp-sidebar" src="https://cdn.ampproject.org/v0/amp-sidebar-0.1.js"></script>
+<script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script>
+<script async custom-element="amp-list" src="https://cdn.ampproject.org/v0/amp-list-0.1.js"></script>
+<script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.1.js"></script>
+<script async custom-element="amp-lightbox" src="https://cdn.ampproject.org/v0/amp-lightbox-0.1.js"></script>
+<script async custom-element="amp-position-observer" src="https://cdn.ampproject.org/v0/amp-position-observer-0.1.js"></script>
+<script async custom-element="amp-animation" src="https://cdn.ampproject.org/v0/amp-animation-0.1.js"></script>
+<script async custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.1.js"></script>
+<script async custom-element="amp-lightbox-gallery" src="https://cdn.ampproject.org/v0/amp-lightbox-gallery-0.1.js"></script>
+
+<style amp-custom>
+        *{-webkit-tap-highlight-color:transparent;box-sizing:border-box;outline:0}html{-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%}body{font-size:12px;color:#3A3E4A;font-family:Roboto,Open Sans,Helvetica,Arial;line-height:1.3;background-color:#f2f2f2}a{-webkit-touch-callout:none;text-decoration:none;color:#3A3E4A}a:active,a:hover{outline:0}img{max-width:100%;border:0}button,input,select,textarea{margin:0;padding:0;color:inherit;font:inherit;text-transform:none;line-height:normal;background:0;border:0;border-radius:0;overflow:visible}button,input[type=button],input[type=reset],input[type=submit]{-webkit-appearance:button;cursor:pointer}button[disabled],input[disabled]{cursor:default}button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0}input[type=checkbox],input[type=radio]{box-sizing:border-box;padding:0}input[type=number]::-webkit-inner-spin-button,input[type=number]::-webkit-outer-spin-button{height:auto}input[type=search]{-webkit-appearance:textfield;box-sizing:content-box}input[type=search]::-webkit-search-cancel-button,input[type=search]::-webkit-search-decoration{-webkit-appearance:none}input:-webkit-autofill{-webkit-box-shadow:0 0 0 1000px #fff inset}input::-webkit-input-placeholder,textarea::-webkit-input-placeholder{color:#B0B2B7}a,address,article,aside,blockquote,body,code,dd,del,div,dl,dt,footer,form,h1,h2,h3,h4,h5,h6,header,html,iframe,img,label,li,nav,object,p,pre,section,span,ul{margin:0;padding:0}ul{list-style:none}@font-face{font-family:icmd;src:url(https://i.alicdn.com/ae-msite-ui/common/font/iconfont.c9a05b18.ttf) format("truetype")}.ic-md{position:relative;display:inline-block;font-family:icmd;font-size:16px;line-height:1;font-style:normal;-webkit-font-smoothing:antialiased;-webkit-text-stroke-width:.2px;-moz-osx-font-smoothing:grayscale}.ic-attribute-md:before{content:"\E600"}.ic-backarrow-md:before{content:"\E601"}.ic-cancel-md:before{content:"\E602"}.ic-close-md:before{content:"\E603"}.ic-coupon-md:before{content:"\e6b8"}.ic-download-md:before{content:"\E605"}.ic-drawer-md:before{content:"\E606"}.ic-filter-md:before{content:"\E607"}.ic-helpcenter-md:before{content:"\E608"}.ic-home-md:before{content:"\E609"}.ic-insert-md:before{content:"\E60A"}.ic-order-md:before{content:"\E60B"}.ic-questionnaire-md:before{content:"\E60C"}.ic-search-md:before{content:"\E60D"}.ic-shoppingcart-md:before{content:"\E60E"}.ic-star-md:before{content:"\E60F"}.ic-time-md:before{content:"\E610"}.ic-translation-md:before{content:"\E611"}.ic-viewgallery-md:before{content:"\E612"}.ic-viewgrid-md:before{content:"\E613"}.ic-wishlist-md:before{content:"\E614"}.ic-signout-md:before{content:"\E615"}.ic-arrowdown-md:before{content:"\E616"}.ic-arrowright-md:before{content:"\E617"}.ic-category-md:before{content:"\E619"}.ic-apponly-md:before{content:"\E618"}.ic-image-md:before{content:"\E61A"}.ic-addtohomescreen-md:before{content:"\E61B"}.ic-add-md:before{content:"\E61C"}.ic-arrowup-md:before{content:"\E61D"}.ic-remove-md:before{content:"\E61E"}.ic-appendfeedback-md:before{content:"\E61F"}.ic-delete-md:before{content:"\E621"}.ic-morevert-md:before{content:"\E620"}.ic-followupfeedback-md:before{content:"\E61F"}.ic-reduce-md:before{content:"\E622"}.ic-error-md:before{content:"\E623"}.ic-chevronleft-md:before{content:"\E624"}.ic-chevronright-md:before{content:"\E625"}.ic-translate-md:before{content:"\E626"}.ic-message-md:before{content:"\E627"}.ic-store-md:before{content:"\E628"}.ic-storecategory-md:before{content:"\E629"}.ic-following-md:before{content:"\E62A"}.ic-follow-md:before{content:"\E62B"}.ic-404-md:before{content:"\E62C"}.ic-building-md:before{content:"\E62D"}.ic-feedback-md:before{content:"\E62F"}.ic-pc-site-md:before{content:"\E630"}.ic-unhappy-md:before{content:"\E631"}.ic-happy-md:before{content:"\E632"}.ic-network-md:before{content:"\E633"}.ic-snapshot-md:before{content:"\E62E"}.ic-mobile-view-md:before{content:"\E635"}.ic-pc-view-md:before{content:"\E634"}.ic-more-md:before{content:"\E63F"}.ic-despatched-md:before{content:"\E63E"}.ic-take-off-md:before{content:"\E63D"}.ic-landing-md:before{content:"\E63C"}.ic-delivered-md:before{content:"\E63B"}.ic-seller-discount-md:before{content:"\E63A"}.ic-bonus-coupon-sign-md:before{content:"\E639"}.ic-bonus-coupon-md:before{content:"\E638"}.ic-about-md:before{content:"\E637"}.ic-seller-coupon-md:before{content:"\E636"}.ic-path-md:before{content:"\E640"}.ic-share-md:before{content:"\E6C0"}.ic-comment-md:before{content:"\E6C2"}.ic-zan-md:before{content:"\E6C3"}.ic-camera-md:before{content:"\E6C4"}.ic-cross-md:before{content:"\e6b4"}.ic-right-md:before{content:"\e6b7"}.ic-answer-md:before{content:"\e6b5"}.ic-ask-md:before{content:"\e6b6"}.ic-size-md:before{content:"\e6b9"}.ic-reply-md:before{content:"\e6ba"}.icon-ic_all_category_md:before{content:"\e6e0"}.icon-ic_womens_clothing_:before{content:"\e6de"}.icon-ic_mens_clothing_md:before{content:"\e6dc"}.icon-ic_phones__accessor:before{content:"\e6db"}.icon-ic_consumer_lectroni:before{content:"\e6da"}.icon-ic_computer__office:before{content:"\e6d7"}.icon-ic_automobiles__mot:before{content:"\e6d8"}.icon-ic_home__gardenfur:before{content:"\e6dd"}.icon-ic_sports__outdoors:before{content:"\e6df"}.icon-ic_toyskids__baby_:before{content:"\e6d6"}.icon-ic_jewelry__watches:before{content:"\e6d4"}.icon-ic_bags__shoes_md:before{content:"\e6d9"}.icon-ic_health__beautyh:before{content:"\e6d5"}.icon-ic_tool_md:before{content:"\e6e2"}.icon-ic_home_appliances_m:before{content:"\e6e3"}.icon-ic_home_improvement_:before{content:"\e6e1"}.md-loading{position:absolute;left:50%;top:60%;transform:translate(-50%,-50%)}.preloader-wrapper{display:inline-block;position:relative;width:20px;height:20px;font-size:0}.preloader-wrapper.small{width:36px;height:36px}.preloader-wrapper.big{width:64px;height:64px}.preloader-wrapper.active{-webkit-animation:container-rotate 1568ms linear infinite;animation:container-rotate 1568ms linear infinite}@-webkit-keyframes container-rotate{to{-webkit-transform:rotate(360deg)}}@keyframes container-rotate{to{-webkit-transform:rotate(360deg);transform:rotate(360deg)}}.spinner-layer{position:absolute;width:100%;height:100%;opacity:0;border-color:#26a69a}.spinner-blue,.spinner-blue-only{border-color:#4285f4}.spinner-red,.spinner-red-only{border-color:#F44336}.spinner-yellow,.spinner-yellow-only{border-color:#f4b400}.spinner-green,.spinner-green-only{border-color:#0f9d58}.active .spinner-layer.spinner-red{-webkit-animation:fill-unfill-rotate 5332ms cubic-bezier(.4,0,.2,1) infinite both,red-fade-in-out 5332ms cubic-bezier(.4,0,.2,1) infinite both;animation:fill-unfill-rotate 5332ms cubic-bezier(.4,0,.2,1) infinite both,red-fade-in-out 5332ms cubic-bezier(.4,0,.2,1) infinite both}.active .spinner-layer,.active .spinner-layer.spinner-blue-only,.active .spinner-layer.spinner-green-only,.active .spinner-layer.spinner-red-only,.active .spinner-layer.spinner-yellow-only{opacity:1;-webkit-animation:fill-unfill-rotate 5332ms cubic-bezier(.4,0,.2,1) infinite both;animation:fill-unfill-rotate 5332ms cubic-bezier(.4,0,.2,1) infinite both}@keyframes fill-unfill-rotate{12.5%{-webkit-transform:rotate(135deg);transform:rotate(135deg)}25%{-webkit-transform:rotate(270deg);transform:rotate(270deg)}37.5%{-webkit-transform:rotate(405deg);transform:rotate(405deg)}50%{-webkit-transform:rotate(540deg);transform:rotate(540deg)}62.5%{-webkit-transform:rotate(675deg);transform:rotate(675deg)}75%{-webkit-transform:rotate(810deg);transform:rotate(810deg)}87.5%{-webkit-transform:rotate(945deg);transform:rotate(945deg)}to{-webkit-transform:rotate(1080deg);transform:rotate(1080deg)}}.gap-patch{position:absolute;top:0;left:45%;width:10%;height:100%;overflow:hidden;border-color:inherit}.gap-patch .circle{width:1000%;left:-450%}.circle-clipper{display:inline-block;position:relative;width:50%;height:100%;overflow:hidden;border-color:inherit}.circle-clipper .circle{width:200%;height:100%;border-width:2px;border-style:solid;border-color:inherit;border-bottom-color:transparent;border-radius:50%;-webkit-animation:none;animation:none;position:absolute;top:0;right:0;bottom:0}.circle-clipper.left .circle{left:0;border-right-color:transparent;-webkit-transform:rotate(129deg);transform:rotate(129deg)}.circle-clipper.right .circle{left:-100%;border-left-color:transparent;-webkit-transform:rotate(-129deg);transform:rotate(-129deg)}.active .circle-clipper.left .circle{-webkit-animation:left-spin 1333ms cubic-bezier(.4,0,.2,1) infinite both;animation:left-spin 1333ms cubic-bezier(.4,0,.2,1) infinite both}.active .circle-clipper.right .circle{-webkit-animation:right-spin 1333ms cubic-bezier(.4,0,.2,1) infinite both;animation:right-spin 1333ms cubic-bezier(.4,0,.2,1) infinite both}@keyframes left-spin{from{-webkit-transform:rotate(130deg);transform:rotate(130deg)}50%{-webkit-transform:rotate(-5deg);transform:rotate(-5deg)}to{-webkit-transform:rotate(130deg);transform:rotate(130deg)}}@keyframes right-spin{from{-webkit-transform:rotate(-130deg);transform:rotate(-130deg)}50%{-webkit-transform:rotate(5deg);transform:rotate(5deg)}to{-webkit-transform:rotate(-130deg);transform:rotate(-130deg)}}.star-rank{position:relative;display:inline-block;font-family:icmd}.ms-star-bottom::before{display:inline-block;color:#e8e8e8;content:"\e60f\e60f\e60f\e60f\e60f"}.ms-star-top::before{color:#F44336;display:inline-block;content:"\e60f\e60f\e60f\e60f\e60f";overflow:hidden}.ms-star-top{position:absolute;left:0;top:0;display:inline-block;width:0;overflow:hidden}[role=button]{outline:0}.fill-list{position:static}.fill-list>div[role=list]{position:static;height:auto;min-height:1px}.flex{display:-webkit-box;display:-webkit-flex;display:flex}.align-center{-webkit-box-align:center;-webkit-align-items:center;align-items:center}.justify-end{justify-content:flex-end;-webkit-justify-content:flex-end}.justify-center{-webkit-box-pack:center;-webkit-justify-content:center;justify-content:center}.justify-space-between{-webkit-box-pack:justify;-webkit-justify-content:space-between;justify-content:space-between}.ellipsis{overflow:hidden;text-overflow:ellipsis;white-space:nowrap}        #ms-header{width:100%;background:#fff;z-index:12;top:0;position:fixed}#ms-header .download-bar{height:56px;overflow:hidden;border-bottom:1px solid #EBEBEC}#ms-header .download-bar a{display:block}main{padding-top:112px}#marker{top:813px;width:0;height:100%;position:absolute;height:100%}.header-toolbar{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:flex;display:-webkit-flex;height:56px;-webkit-box-align:center;-moz-box-align:center;-ms-flex-align:center;align-items:center;background-color:#fff;-webkit-box-shadow:0 1px 2px 0 rgba(0,0,0,.24);box-shadow:0 1px 2px 0 rgba(0,0,0,.24)}#search-input-layer{background:#fff}#search-input-layer .autosuggest{height:90%;overflow-y:auto}#search-input-layer .search-box{width:100%;padding-left:24px;font-size:18px;outline:0;border:none}#search-reset{position:absolute;top:0;right:-60px}#autosuggest amp-list{position:relative;height:auto}#autosuggest amp-list>div{position:relative;height:auto}.auto-suggest-prom .auto-prom{display:block;position:relative;height:48px}.auto-suggest-prom .auto-prom .prom{margin-left:8px;width:100%;display:flex;align-items:center}.auto-suggest-prom .auto-prom .prom-txt{position:relative;font-size:12px;line-height:48px;color:#E62E04;margin-left:8px}.auto-suggest-prom .auto-prom .prom-image{box-shadow:0 0 2px 0 rgba(0,0,0,.24)}.auto-suggest-cat .auto-cat{display:block;position:relative;padding:19px 16px 19px 8px}.auto-suggest-cat .auto-cat .cat .ic-md{position:absolute;right:16px;top:19px}.auto-suggest-cat .cate-txt{font-size:16px;line-height:14px;margin-bottom:4px}.auto-suggest-cat .category{font-size:12px;color:#B0B2B7;line-height:12px}.suggest{position:relative;-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box;height:64px;padding:14px 0}.suggest .txt-wrap{display:block;margin-left:8px;margin-right:48px;color:#555}.suggest .ic-md{position:absolute;right:16px;top:50%;margin-top:-12px}#autosuggest .go-icon{font-size:20px}.suggest .txt-wrap .sug-txt{display:block;white-space:nowrap;word-wrap:normal;text-overflow:ellipsis;overflow:hidden;text-align:left;font-size:14px;line-height:20px;margin-bottom:4px;width:60%}.suggest .txt-wrap .categroy-name{font-size:11px;color:#B0B2B7;line-height:12px}.ic-wp{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:flex;display:-webkit-flex;width:48px;height:56px;-webkit-box-pack:center;-moz-box-pack:center;-ms-flex-pack:center;justify-content:center;-webkit-justify-content:center;-webkit-box-align:center;-moz-box-align:center;-ms-flex-align:center;align-items:center;-webkit-align-items:center}.ic-wp .ic-md{font-size:24px}.ic-close{position:absolute;right:0;display:flex;display:-webkit-flex;width:48px;height:56px;align-items:center;-webkit-align-items:center}.ic-close .ic-close-md{background-color:#ccc;border-radius:50%;font-size:20px}.clear-hide{display:none}.clear-show{display:block}#ms-drawer{-webkit-box-ordinal-group:1;-moz-box-ordinal-group:1;-ms-flex-order:0;order:0;-webkit-order:0}#ms-back{-webkit-box-ordinal-group:2;-moz-box-ordinal-group:2;-ms-flex-order:1;order:1;-webkit-order:1}#ms-close{-webkit-box-ordinal-group:3;-moz-box-ordinal-group:3;-ms-flex-order:2;order:2;-webkit-order:2}#ms-title{-webkit-box-ordinal-group:4;-moz-box-ordinal-group:4;-ms-flex-order:3;order:3;-webkit-order:3;-webkit-box-flex:1;-moz-box-flex:1;-ms-flex-positive:1;flex-grow:1;-webkit-flex-grow:1;-webkit-box-pack:start;-moz-box-pack:start;-ms-flex-pack:start;justify-content:flex-start;-webkit-justify-content:flex-start;font-size:18px;font-weight:600;overflow-x:auto;margin-left:16px}#ms-title::-webkit-scrollbar{display:none}#ms-title span:nth-child(1){display:inline-block;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}#ms-title span:nth-child(2){display:inline-block;padding-left:10px;white-space:nowrap}#ms-logo{-webkit-box-ordinal-group:5;-moz-box-ordinal-group:5;-ms-flex-order:4;order:4;-webkit-order:4;-webkit-box-flex:1;-moz-box-flex:1;-ms-flex-positive:1;flex-grow:1;-webkit-flex-grow:1;padding-left:16px;-webkit-box-pack:start;-moz-box-pack:start;-ms-flex-pack:start;justify-content:flex-start;-webkit-justify-content:flex-start}#ms-logo h1{width:0;height:0;overflow:hidden}#ms-search{-webkit-box-ordinal-group:6;-moz-box-ordinal-group:6;-ms-flex-order:5;order:5;-webkit-order:5}#ms-cart{position:relative;-webkit-box-ordinal-group:7;-moz-box-ordinal-group:7;-ms-flex-order:6;order:6;-webkit-order:6}#ms-cart>div{position:absolute;width:100%;height:100%;z-index:2}#ms-cart form input{position:absolute;top:10px;right:10px;min-width:14px;height:14px;line-height:14px;background-color:#e62e04;border-radius:14px;color:#fff;text-align:center}#ms-minidrawer{-webkit-box-ordinal-group:8;-moz-box-ordinal-group:8;-ms-flex-order:7;order:7;-webkit-order:7}#mini-drawer-list{width:100%;height:100%;position:relative;z-index:2}.mini-drawer-layer{width:100vw;height:100vh;position:absolute;z-index:1;right:0}.mini-drawer-list{position:absolute;top:15px;right:15px;z-index:2;padding:8px 0;background-color:#FBFBFB;-webkit-box-shadow:0 1px 4px 0 rgba(0,0,0,.24);box-shadow:0 1px 4px 0 rgba(0,0,0,.24)}.mini-drawer-list li{min-width:120px;max-width:228px;height:48px;line-height:48px;padding-left:16px;font-size:14px}.mini-drawer-list li a{display:block}.none{display:none}.drawer-privacy-box{border-top:1px solid #EBEBEC}.cookie-box a{text-decoration:underline}.cookie-box{padding:10px 50px 0;position:fixed;z-index:1000;bottom:0;left:0;width:100%;font-size:10px;text-align:center;line-height:16px;color:#333;letter-spacing:0;border:0;background-color:#fff}.cookie-choice-box{margin:15px 0;display:flex;display:-webkit-flex;justify-content:space-around;-webkit-justify-content:space-around;align-items:center;-webkit-align-items:center}.cookie-choice{width:100px;height:35px;text-transform:uppercase;text-align:center;line-height:35px;font-size:14px;font-weight:600;border:1px solid #B9B9B9;border-radius:4px}        .country-flag{background-image:url(https://gw.alicdn.com/tps/TB1MaiTKpXXXXb4aXXXXXXXXXXX-405-396.png);background-repeat:no-repeat;display:inline-block;overflow:hidden;outline:.5px solid #B0B2B7;width:17px;height:12px}.country-flag.mright{margin-right:16px}.c_AD{background-position:-5px -5px}.c_AE{background-position:-32px -5px}.c_AF{background-position:-59px -5px}.c_AG{background-position:-86px -5px}.c_AI{background-position:-113px -5px}.c_AL{background-position:-140px -5px}.c_ALA{background-position:-167px -5px}.c_AM{background-position:-194px -5px}.c_AN{background-position:-221px -5px}.c_AO{background-position:-248px -5px}.c_AQ{background-position:-275px -5px}.c_AR{background-position:-302px -5px}.c_AS{background-position:-329px -5px}.c_ASC{height:9px;background-position:-356px -5px}.c_AT{background-position:-356px -24px}.c_AU{background-position:-5px -46px}.c_AW{background-position:-32px -46px}.c_AZ{background-position:-59px -46px}.c_BA{background-position:-86px -46px}.c_BB{background-position:-113px -46px}.c_BD{background-position:-140px -46px}.c_BE{background-position:-167px -46px}.c_BF{background-position:-194px -46px}.c_BG{background-position:-221px -46px}.c_BH{background-position:-248px -46px}.c_BI{background-position:-275px -46px}.c_BJ{background-position:-302px -46px}.c_BLM{background-position:-329px -46px}.c_BM{background-position:-356px -46px}.c_BN{background-position:-5px -68px}.c_BO{background-position:-32px -68px}.c_BR{background-position:-59px -68px}.c_BS{background-position:-86px -68px}.c_BT{background-position:-113px -68px}.c_BW{background-position:-140px -68px}.c_BY{background-position:-167px -68px}.c_BZ{background-position:-194px -68px}.c_CA{background-position:-221px -68px}.c_CC{background-position:-248px -68px}.c_CF{background-position:-275px -68px}.c_CG{background-position:-302px -68px}.c_CH{width:12px;background-position:-329px -68px}.c_CI{background-position:-351px -68px}.c_CK{background-position:-5px -90px}.c_CL{background-position:-32px -90px}.c_CM{background-position:-59px -90px}.c_CN{background-position:-86px -90px}.c_CO{background-position:-113px -90px}.c_CR{background-position:-140px -90px}.c_CU{background-position:-167px -90px}.c_CV{background-position:-194px -90px}.c_CX{background-position:-221px -90px}.c_CY{background-position:-248px -90px}.c_CZ{background-position:-275px -90px}.c_DE{background-position:-302px -90px}.c_DJ{background-position:-329px -90px}.c_DK{background-position:-356px -90px}.c_DM{background-position:-5px -112px}.c_DODIV{background-position:-32px -112px}.c_DZ{background-position:-59px -112px}.c_EAZ{background-position:-86px -112px}.c_EC{background-position:-113px -112px}.c_EE{background-position:-140px -112px}.c_EG{background-position:-167px -112px}.c_EH{background-position:-194px -112px}.c_ER{background-position:-221px -112px}.c_ES{background-position:-248px -112px}.c_ET{background-position:-275px -112px}.c_FI{background-position:-302px -112px}.c_FJ{background-position:-329px -112px}.c_FK{background-position:-356px -112px}.c_FM{background-position:-5px -134px}.c_FO{background-position:-32px -134px}.c_FR{background-position:-59px -134px}.c_GA{background-position:-86px -134px}.c_GBA{background-position:-113px -134px}.c_GD{background-position:-140px -134px}.c_GE{background-position:-167px -134px}.c_GF{background-position:-194px -134px}.c_GGY{background-position:-221px -134px}.c_GH{background-position:-248px -134px}.c_GI{background-position:-275px -134px}.c_GL{background-position:-302px -134px}.c_GM{background-position:-329px -134px}.c_GN{background-position:-356px -134px}.c_GP{background-position:-5px -156px}.c_GQ{background-position:-32px -156px}.c_GR{background-position:-59px -156px}.c_GT{background-position:-86px -156px}.c_GU{background-position:-113px -156px}.c_GW{background-position:-140px -156px}.c_GY{background-position:-167px -156px}.c_HK{background-position:-194px -156px}.c_HN{background-position:-221px -156px}.c_HR{height:11px;background-position:-248px -156px}.c_HT{background-position:-275px -156px}.c_HU{background-position:-302px -156px}.c_ID{background-position:-329px -156px}.c_IE{background-position:-356px -156px}.c_IL{background-position:-5px -178px}.c_IM{background-position:-32px -178px}.c_IN{background-position:-59px -178px}.c_IO{height:9px;background-position:-86px -178px}.c_IQ{background-position:-113px -178px}.c_IR{background-position:-140px -178px}.c_IS{background-position:-167px -178px}.c_IT{background-position:-194px -178px}.c_JEY{background-position:-221px -178px}.c_JM{background-position:-248px -178px}.c_JO{background-position:-275px -178px}.c_JP{background-position:-302px -178px}.c_KE{background-position:-329px -178px}.c_KG{background-position:-356px -178px}.c_KH{background-position:-5px -200px}.c_KI{background-position:-32px -200px}.c_KM{background-position:-59px -200px}.c_KN{background-position:-86px -200px}.c_KP{background-position:-113px -200px}.c_KR{background-position:-140px -200px}.c_KS{background-position:-167px -200px}.c_KW{background-position:-194px -200px}.c_KY{background-position:-221px -200px}.c_KZ{background-position:-248px -200px}.c_LA{background-position:-275px -200px}.c_LB{background-position:-302px -200px}.c_LC{background-position:-329px -200px}.c_LI{background-position:-356px -200px}.c_LK{background-position:-5px -222px}.c_LR{background-position:-32px -222px}.c_LS{background-position:-59px -222px}.c_LT{background-position:-86px -222px}.c_LU{background-position:-113px -222px}.c_LV{background-position:-140px -222px}.c_LY{background-position:-167px -222px}.c_MA{background-position:-194px -222px}.c_MF{background-position:-221px -222px}.c_MC{background-position:-248px -222px}.c_MD{background-position:-275px -222px}.c_MG{background-position:-302px -222px}.c_MH{background-position:-329px -222px}.c_MK{background-position:-356px -222px}.c_ML{background-position:-5px -244px}.c_MM{background-position:-32px -244px}.c_MN{background-position:-59px -244px}.c_MNE{background-position:-86px -244px}.c_MO{background-position:-113px -244px}.c_MP{background-position:-140px -244px}.c_MQ{background-position:-167px -244px}.c_MR{background-position:-194px -244px}.c_MS{background-position:-221px -244px}.c_MT{background-position:-248px -244px}.c_MU{background-position:-275px -244px}.c_MV{background-position:-302px -244px}.c_MW{background-position:-329px -244px}.c_MX{background-position:-356px -244px}.c_MY{background-position:-5px -266px}.c_MZ{background-position:-32px -266px}.c_NA{background-position:-59px -266px}.c_NC{background-position:-86px -266px}.c_NE{background-position:-113px -266px}.c_NF{background-position:-140px -266px}.c_NG{background-position:-167px -266px}.c_NI{background-position:-194px -266px}.c_NL{background-position:-221px -266px}.c_NO{background-position:-248px -266px}.c_NP{height:15px;background-position:-275px -266px}.c_NR{background-position:-297px -266px}.c_NU{background-position:-324px -266px}.c_NZ{background-position:-351px -266px}.c_OM{background-position:-5px -288px}.c_PA{background-position:-32px -288px}.c_PE{background-position:-59px -288px}.c_PF{background-position:-86px -288px}.c_PG{background-position:-113px -288px}.c_PH{background-position:-140px -288px}.c_PK{background-position:-167px -288px}.c_PL{background-position:-194px -288px}.c_PM{background-position:-221px -288px}.c_PN{background-position:-248px -288px}.c_PR{background-position:-297px -288px}.c_PS{background-position:-324px -288px}.c_PT{background-position:-351px -288px}.c_PW{background-position:-5px -310px}.c_PY{background-position:-32px -310px}.c_QA{background-position:-59px -310px}.c_RE{background-position:-86px -310px}.c_RO{background-position:-113px -310px}.c_RU{background-position:-140px -310px}.c_RW{background-position:-167px -310px}.c_SA{background-position:-194px -310px}.c_SB{background-position:-221px -310px}.c_SC{background-position:-248px -310px}.c_SCT{background-position:-275px -310px}.c_SD{background-position:-302px -310px}.c_SE{background-position:-329px -310px}.c_SG{background-position:-356px -310px}.c_SGS{background-position:-5px -332px}.c_SH{height:10px;background-position:-32px -332px}.c_SI{background-position:-59px -332px}.c_SK{background-position:-86px -332px}.c_SL{background-position:-113px -332px}.c_SM{background-position:-140px -332px}.c_SN{background-position:-167px -332px}.c_SO{background-position:-194px -332px}.c_SR{background-position:-221px -332px}.c_SRB{background-position:-248px -332px}.c_SS{background-position:-275px -332px}.c_ST{background-position:-302px -332px}.c_SV{background-position:-329px -332px}.c_SY{background-position:-356px -332px}.c_SZ{background-position:-5px -354px}.c_TC{background-position:-32px -354px}.c_TD{background-position:-59px -354px}.c_TF{background-position:-86px -354px}.c_TG{background-position:-113px -354px}.c_TH{background-position:-140px -354px}.c_TJ{background-position:-167px -354px}.c_TK{background-position:-194px -354px}.c_TLS{background-position:-221px -354px}.c_TM{background-position:-248px -354px}.c_TN{background-position:-275px -354px}.c_TO{background-position:-302px -354px}.c_TP{background-position:-329px -354px}.c_TR{background-position:-356px -354px}.c_TT{background-position:-383px -5px}.c_TV{background-position:-383px -27px}.c_TW{background-position:-383px -49px}.c_TZ{background-position:-383px -71px}.c_UA{background-position:-383px -93px}.c_UG{background-position:-383px -115px}.c_UK{background-position:-383px -137px}.c_BQ,.c_CW,.c_DO,.c_OTHER,.c_Other,.c_SX{background-position:-383px -159px}.c_US{background-position:-383px -181px}.c_UY{background-position:-383px -203px}.c_UZ{background-position:-383px -225px}.c_VA{width:12px;background-position:-383px -247px}.c_VC{background-position:-378px -269px}.c_VE{background-position:-383px -291px}.c_VG{background-position:-383px -313px}.c_VI{background-position:-383px -335px}.c_VN{background-position:-383px -357px}.c_VU{background-position:-5px -379px}.c_WF{background-position:-32px -379px}.c_WS{background-position:-59px -379px}.c_YE{background-position:-86px -379px}.c_YT{background-position:-113px -379px}.c_YU{background-position:-140px -379px}.c_ZA{background-position:-167px -379px}.c_ZM{background-position:-194px -379px}.c_ZR{background-position:-221px -379px}.c_ZW{background-position:-248px -379px}        .w0{width:1%}.w1{width:1%}.w2{width:2%}.w3{width:3%}.w4{width:4%}.w5{width:5%}.w6{width:6%}.w7{width:7%}.w8{width:8%}.w9{width:9%}.w10{width:10%}.w11{width:11%}.w12{width:12%}.w13{width:13%}.w14{width:14%}.w15{width:15%}.w16{width:16%}.w17{width:17%}.w18{width:18%}.w19{width:19%}.w20{width:20%}.w21{width:21%}.w22{width:22%}.w23{width:23%}.w24{width:24%}.w25{width:25%}.w26{width:26%}.w27{width:27%}.w28{width:28%}.w29{width:29%}.w30{width:30%}.w31{width:31%}.w32{width:32%}.w33{width:33%}.w34{width:34%}.w35{width:35%}.w36{width:36%}.w37{width:37%}.w38{width:38%}.w39{width:39%}.w40{width:40%}.w41{width:41%}.w42{width:42%}.w43{width:43%}.w44{width:44%}.w45{width:45%}.w46{width:46%}.w47{width:47%}.w48{width:48%}.w49{width:49%}.w50{width:50%}.w51{width:51%}.w52{width:52%}.w53{width:53%}.w54{width:54%}.w55{width:55%}.w56{width:56%}.w57{width:57%}.w58{width:58%}.w59{width:59%}.w60{width:60%}.w61{width:61%}.w62{width:62%}.w63{width:63%}.w64{width:64%}.w65{width:65%}.w66{width:66%}.w67{width:67%}.w68{width:68%}.w69{width:69%}.w70{width:70%}.w71{width:71%}.w72{width:72%}.w73{width:73%}.w74{width:74%}.w75{width:75%}.w76{width:76%}.w77{width:77%}.w78{width:78%}.w79{width:79%}.w80{width:80%}.w81{width:81%}.w82{width:82%}.w83{width:83%}.w84{width:84%}.w85{width:85%}.w86{width:86%}.w87{width:87%}.w88{width:88%}.w89{width:89%}.w90{width:90%}.w91{width:91%}.w92{width:92%}.w93{width:93%}.w94{width:94%}.w95{width:95%}.w96{width:96%}.w97{width:97%}.w98{width:98%}.w99{width:99%}.w100{width:100%}.ms-block{margin-bottom:12px;font-size:14px;line-height:1.5;border-radius:2px;box-shadow:0 2px 2px 0 rgba(0,0,0,.24);background-color:#fff}.md-loading{top:55%}.ms-border-bottom{border-bottom:1px solid #F2F2F2}.detail-block-title{font-size:16px;font-weight:400;margin-right:24px}.detail-sub-title{min-height:18px;padding-right:24px;font-size:12px;color:#999}.subtitle{padding:12px 0;margin:0 16px;line-height:24px;font-weight:400}.detail-action-button{display:block;padding-top:6px;font-size:18px;color:#2E9CC3}.float-wrap{background-color:#fff}.float-wrap header{position:fixed;top:0;left:0;width:100%;z-index:19}#detail-sku-lb .float-content,#shipping-lb .float-content{padding-bottom:65px}.float-content{min-height:100vh;padding-top:56px}.tip-info{position:fixed;bottom:0;width:100%;height:42px;color:#fff;background-color:rgba(50,50,50,.9);z-index:999}.show-more-button-wrap{position:relative;width:100%;height:80px;padding:16px}.show-more-button{width:100%;height:100%;background-color:#FFF;color:#2E9CC3;font-size:14px;font-weight:600}.show-more-button:disabled{opacity:.3}.cover img{object-fit:cover}#detail-sku-lb{z-index:1001}#country-lb,#shipping-lb{z-index:1002}.count-down-iframe{vertical-align:middle}body{padding-bottom:64px}.hide{-webkit-transform:translateY(300%);transform:translateY(300%)}.dialog-wrap{position:fixed;bottom:50%;left:50%;padding:10px;width:80%;min-height:44px;-webkit-transform:translate(-50%,200%);transform:translate(-50%,200%);opacity:0;visibility:hidden;background-color:#31343E;color:#FFF;border-radius:4px;z-index:999999}.back-top-button{position:fixed;bottom:72px;right:6px;width:68px;height:68px;padding:10px;-webkit-transform:translateY(300%);transform:translateY(300%);z-index:999}.back-top-button>div{width:100%;height:100%;border-radius:50%;border:1px solid #F5F5F5;background-color:#EBEBEB}.chevron-up{position:relative;margin-top:-8px;border:8px solid transparent;border-bottom-color:#3A3E4A}.chevron-up>span{position:absolute;top:-7px;left:-8px;border:8px solid transparent;border-bottom-color:#EBEBEB}#detail-marker{position:absolute;top:110vh;width:0;height:0}#detail-fixed-toolbar{position:absolute;top:240vh;width:0;height:100%}#detail-back-top{position:absolute;top:340vh;width:0;height:100%}#ms-header{background-color:transparent}#header-toolbar{position:absolute;top:56px;left:0;width:100%;background-color:transparent;box-shadow:none}#header-toolbar .ic-md{color:#fff;padding:4px;border-radius:50%;background-color:rgba(51,51,51,.6)}#header-toolbar-detail{position:absolute;top:56px;left:0;width:100%;opacity:0;z-index:1} main{padding-top:56px}.ms-error{position:fixed;top:0;bottom:0;left:0;right:0;flex-flow:column wrap}.error-info{max-width:75%;text-align:center;font-size:17px;color:#999}.error-icon{font-size:110px;color:#CCC}.carousel-wrap{position:relative}.carousel-points{position:absolute;left:10px;bottom:10px}.carousel-points li{display:inline-block;width:8px;height:8px;margin:4px;border-radius:50%;background-color:rgba(51,51,51,.1)}.carousel-points .current{background-color:#333}.collection{position:absolute;right:12px;bottom:12px;width:48px;height:48px;border-radius:50%;background-color:#fff;box-shadow:0 2px 5px 0 rgba(0,0,0,.26)}.collection i{top:2px;font-size:30px;color:#898B92}.collection.wished i{color:#FF4747}.middle-banner-wrap{position:relative}.middle-banner-info{position:absolute;top:0;left:0;width:100%;height:100%;overflow:hidden}.banner-icon-info{padding-left:20px}.banner-text-info{-webkit-box-flex:1;-webkit-flex-grow:1;flex-grow:1;padding-left:10px;font-size:12px;color:#FFF;overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:2}.banner-action-info{font-size:0}.deals-title{padding:0 8px 0 16px;color:#FFF;font-size:22px;font-weight:600;max-width:70%}.deals-description{padding:0 16px;line-height:24px;font-weight:400;font-size:14px;color:#FFF;background-color:#C50B1D}.detail-description{display:-webkit-box;-webkit-line-clamp:3;-webkit-box-orient:vertical;padding:12px 16px 0 16px;font-size:16px;font-weight:400;overflow:hidden}.detail-price-wrap{padding:12px 16px 0}.current-price{font-size:20px;font-weight:600}.original-price{font-size:12px;color:#999;text-decoration:line-through}.discount-price{padding:2px 4px;font-size:12px;color:#FF4747;background-color:#FFF0F2}.big-sale-price{padding:2px 6px;font-size:13px}.big-sale-discount{display:inline-block;padding:0 6px;line-height:20px;font-size:13px;color:#FF4747;background-color:#fff0f2;border-radius:2px}.big-sale-discount>span{padding:0 4px;background:#FFF;color:#000;border:1px solid #FB0039;border-radius:4px}.count-down-wrap{display:inline-block;height:20px;vertical-align:top}.detail-sumary{padding:12px 16px;font-size:0}.detail-sumary li{width:33.3333%;overflow:hidden}.detail-sumary li:nth-child(2){text-align:center}.detail-sumary li:nth-child(3){text-align:right}.detail-sumary li>span{display:block;font-size:16px}.detail-sumary li>span:nth-child(2n){font-size:12px;color:#999}.detail-coupon-discount,.detail-free-shipping,.detail-group,.detail-sku{position:relative;padding:10px 0;margin:0 16px}.detail-coupon-discount>span,.detail-free-shipping>span,.detail-sku>span{position:absolute;top:50%;right:0;-webkit-transform:translateY(-50%);transform:translateY(-50%);font-size:12px;color:#2E9CC3}.detail-coupon-discount>span,.detail-free-shipping>span{right:-2%}.detail-coupon-discount .ic-md,.detail-free-shipping .ic-md{font-size:26px;color:#ccc}.coupon-icon>.ic-md{color:#F44336}.coupon-info{padding-left:10px;color:#999}.new-user-coupon-wrap{padding-top:6px}.new-user-coupon{display:inline-block;width:64px;height:32px;line-height:32px;text-align:center;background-image:url(//ae01.alicdn.com/kf/HTB1qYK9kDTI8KJjSsph763FppXaS.png);background-size:cover;color:#FFF}.coupon-content{position:relative;margin:0 16px;padding:12px 0;border-bottom:1px solid #EBEBEB}.coupon-content li{position:relative;padding:12px 0}.coupon-content p{max-width:60%}.coupon-price{padding-bottom:6px;line-height:24px;font-size:16px;font-weight:600}.coupon-price .new-user-coupon{width:80px;height:40px;line-height:40px}.coupon-description{padding-bottom:4px;color:#999}.coupon-expires{color:#ccc}.get-coupon{position:absolute;top:50%;right:0;width:35%;-webkit-transform:translateY(-50%);transform:translateY(-50%);font-size:14px;text-align:center;overflow:hidden}.get-coupon input[type=submit],.get-coupon>a{display:block;width:100%;padding:10px;background-color:#FF4747;box-shadow:0 0 2px 0 rgba(0,0,0,.12),0 2px 2px 0 rgba(0,0,0,.24),0 0 8px 0 rgba(0,0,0,.12);border:0;color:#fff}.get-coupon input[type=submit].geted{background-color:#B0B2B7}.fixedDiscount-coupon-wrap p{padding:12px 16px;font-size:14px;line-height:24px}.select-coupon-wrap .ic-md{padding-right:12px;font-size:24px;color:#F44336}.fixedDiscount-coupon-wrap .ic-md,.store-coupon-wrap .ic-md{padding-right:12px;font-size:24px;color:#FF7605}.ship-quantity,.ship-to{padding:12px 0;margin:0 16px;line-height:24px;border-bottom:1px solid #EBEBEB}.ship-method-content{margin:0 16px;font-size:12px}.ship-method-content li{position:relative;height:72px}.ship-method-content li>p{color:#FFAA54}.ship-method-content li+li{border-top:1px solid #EBEBEB}.ship-method-content li>span{width:20%;padding:0 2px;text-align:center;overflow:hidden}.ship-method-content .ic-md{font-size:22px}.ship-check-button input{position:absolute;top:0;left:0;width:100%;height:100%;opacity:0}.ship-check-button span{width:20px;height:20px;padding:2px;border:2px solid #B0B2B7;border-radius:50%}.ship-check-button span::after{content:'';display:block;width:100%;height:100%;border-radius:50%}.ship-check-button input:checked+span{border-color:#F44336}.ship-check-button input:checked+span::after{background-color:#F44336}.apply-button-wrap{position:fixed;bottom:0;right:0;width:100%;height:68px;padding:16px;border-top:1px solid #F2F2F2}.apply-button{width:156px;line-height:36px;text-align:center;color:#FFF;background-color:#FF4747;border-radius:2px}#country-lb{position:fixed;top:0;bottom:0;left:0;right:0;background-color:#FFF}#country-lb ul{margin:0 16px;border-bottom:1px solid #B0B2B7}#country-lb li{position:relative;line-height:48px;font-size:14px}.country-group{color:#999}.country-item{color:#666}.country-name{padding-left:16px;-webkit-box-flex:1;-webkit-flex-grow:1;flex-grow:1}.detail-qa-wrap{padding:10px 16px}.detail-qa-wrap .detail-action-button{padding-top:0}.detail-qa{padding-top:12px}.detail-qa li{padding-bottom:16px;overflow:hidden}.detail-qa li .ic-md{font-size:24px;padding-right:12px}#questions-answer-lb{background-color:#EBEBEB}#questions-answer-lb .header-toolbar{margin-bottom:2px}.qa-wrap{padding:0 16px;margin-bottom:8px;background-color:#FFF}.questioner-info{padding-top:16px;line-height:24px;font-size:14px}.questioner-info .country-flag{margin-left:12px}.qa-dete{padding:2px 0;font-size:12px;color:#999}.question-description{padding:12px 0;line-height:24px;font-size:14px}.answer-title{padding-bottom:16px;line-height:24px;font-size:14px;font-weight:600}.question-title{font-weight:600}.answer-item{padding-bottom:12px}.answer-wrap .answer-item:nth-child(n+2){display:none}.answer-wrap.show-all-awser .answer-item{display:block}.answer-description{line-height:24px;font-size:14px;color:#666}.qa-button{display:inline-block;padding-bottom:16px;line-height:20px;font-size:14px;color:#2E9CC3}.more-to-love .detail-block-title,.seller-recommendation .detail-block-title{padding:12px 16px}.sku-carousel-wrap{padding:12px 0}.sku-carousel-wrap li{display:inline-block}.sku-price{padding-bottom:12px;margin:-10px 16px 0;font-size:16px;font-weight:600;line-height:24px;text-align:center;border-bottom:1px solid #EBEBEB}.property-list{margin:0 16px;padding-bottom:12px;font-size:0;border-bottom:1px solid #EBEBEB}.sku-property-title{padding:12px 16px}.property-list li{position:relative;display:inline-block;padding:4px}.property-list li>input{position:absolute;top:0;left:0;width:100%;height:100%;opacity:0;z-index:1}.property-list li>span{display:block;width:100%;height:100%;line-height:30px;padding:2px 10px;font-size:14px}.color-list li>input:checked+span>span{border-color:#FF4747}.color-list li>input:disabled+span>span{color:rgba(0,0,0,.3);opacity:.3}.other-list li>input:checked+span{border-color:#FF4747}.other-list li>input:disabled+span{color:rgba(0,0,0,.3);opacity:.3}.color-list li{position:relative;width:16.66%}.color-list li::after{content:'';display:block;padding-bottom:100%}.color-list li>span{position:absolute;top:0;left:0;width:100%;height:100%;padding:2px}.color-list li>span>span{position:relative;display:block;height:100%;border:1px solid #CCC;overflow:hidden}.other-list li{min-width:25%;height:44px;line-height:28px;text-align:center;color:#000}.other-list li>span{border:1px solid #CCC}.detail-quantity-wrap .stock-form{padding:0 0 10px;margin:0 16px;border-bottom:1px solid #F2F2F2}.stock-form{padding:0 16px;color:#999}.stock-form button{width:24px;height:24px;line-height:24px;text-align:center;border-radius:50%;background-color:#F2F2F2;color:#333;outline:0}.stock-form button:disabled{background-color:#F2F2F2;color:#ccc}.stock-num{padding-left:12px}.quantity{display:inline-block;width:30px;min-width:30px;font-size:14px;text-align:center;color:#2E9CC3;background-color:#fff;outline:0}#detail-sku-lb .add-to-cart,#detail-sku-lb .buy-now{margin:0 5px}.detail-action-bar{width:100%;height:65px;padding:10px 16px;background-color:#FFF;border-top:1px solid #f2f2f2}.fixed-tool-bar{position:fixed;left:0;bottom:0;z-index:999}.detail-store-link{width:44px;height:44px;color:#FF7605;border:1px solid #EBEBEB}.detail-action-bar .ic-md{width:100%;height:100%;line-height:44px;font-size:36px;text-align:center}.add-to-cart,.buy-now{position:relative;-webkit-box-flex:1;-webkit-flex-grow:1;flex-grow:1;max-width:50%;line-height:22px;margin-left:10px;text-align:center;border-radius:2%}.add-to-cart .copy,.buy-now .copy{display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);width:100%;padding:0 10px;overflow:hidden}.add-to-cart{color:#FF4747;background-color:#FFF1F1}.buy-now{color:#fff;background-color:#FF4747}.add-to-cart>button,.buy-now>button{width:100%;height:100%}.buy-now>button:disabled{opacity:.3}.buy-now.item-available>button:disabled{opacity:1}.item-available{background-color:#D7D7D7;color:#AAA}.sku-submit-button{display:none}.sku-submit-button.show-button{display:block}.sku-float-button{display:block}.sku-float-button.hide-button{display:none}.feedback-wrap{padding:10px 16px}.thumbnails-wrap{margin-top:4px;margin-bottom:4px;border-bottom:1px solid #f2f2f2;border-top:1px solid #f2f2f2}.feedback-imgs{flex-wrap:wrap;-webkit-flex-wrap:wrap;padding:6px 0}.feedback-imgs li{position:relative}.feedback-imgs li:after{content:'';display:block;padding-bottom:100%}.feedback-imgs li>span{position:absolute;top:0;left:0;width:100%;height:100%;padding:3px}.feedback-imgs li>span>span{position:relative;display:block;height:100%}.feedback-featured-img li{width:16.66%}.feedback-buyer-img li{width:33.33%}.image-totalnum{color:#2E9CC3;border:1px solid #2E9CC3}.image-totalnum>span{position:absolute;top:50%;left:50%;-webkit-transform:translate(-50%,-50%);transform:translate(-50%,-50%);white-space:nowrap}.feedback-star{padding-bottom:10px}.feedback-info-buyer{padding-bottom:8px;color:#999}.feedback-info-buyer .country-flag{margin-left:12px}.feedback-info-buyer span:last-child{float:right}.feedback-info-sku{line-height:18px;padding:4px 0 4px 12px;border-left:3px solid #F2F2F2;color:#999}.feedback-info-sku span{display:block}.feedback-info-description{padding:6px 0}.feedback-seller-reply{margin-top:12px;padding:8px;font-size:12px;line-height:16px;color:#898B92;background-color:#f4f4f4}.feedback-seller-reply>span{color:#B0B2B7}.feedback-buyer-add-days{padding-top:12px;font-size:12px;color:#999}.rating-wrap{height:148px;padding:25px;-webkit-box-pack:justify;-webkit-justify-content:space-between;justify-content:space-between}.rating-score span{font-size:36px}.rating-star{font-family:icmd;width:25px;font-style:normal}.feedback-select-list .rating-star::after,.rating-detail .rating-star::before{content:"\e60f";display:inline;padding:0 4px;color:#e8e8e8}.rating-detail>p{-webkit-box-align:center;-webkit-align-items:center;align-items:center}.rating-total{color:#3A3E4A;line-height:36px}.rating-progress-wrap{position:relative;width:150px;height:4px;margin:0 10px;border-radius:4px;background-color:#E2E2E4}.rating-progress-content{position:absolute;top:0;left:0;height:100%;background-color:#B0B2B7;border-radius:4px}.feedback-select-list{-webkit-flex-wrap:wrap;flex-wrap:wrap;padding:12px 16px;background-color:#FBFBFB;border:1px solid #EBEBEC}.feedback-select-item{background:#FFF;border:1px solid #DDD;border-radius:4px;padding:6px 8px;margin:4px}.feedback-select-item .ic-md{font-size:22px}.feedback-select-item i{font-style:normal}.feedback-select-item span{margin-left:4px}.feedback-select-item.active{border-color:#F44336;color:#F44336}.feedback-select-item.active .rating-star::after{color:#F44336}#feedback-lb{background-color:#F2F2F2}#feedback-lb .fill-list{background-color:#FFF}.feedback-close-button{position:absolute;top:24px;left:24px;width:48px;height:48px;justify-content:center;align-items:center;z-index:999}.feedback-close-button .ic-md{font-size:24px;color:#FFF}#feedback-big-images{background-color:#3A3E4A}.feedback-big-images-wrap{position:absolute;top:50%;left:0;width:100%;transform:translateY(-50%)}.description-list{position:relative;padding-top:10px}.description-item{height:36px;line-height:36px;font-size:0;border-radius:2%}.description-item:nth-child(2n+1){background-color:#F9F9F9}.description-item span{display:inline-block;width:50%;padding-left:10px;font-size:14px}.description-item span:first-child{color:#999}.description-item:nth-child(n+5){display:none}.detail-description-wrap .description-list-auto-height .description-item{display:block}.description-show-button{height:36px;border-radius:2%;background:#F9F9F9}.description-show-button .ic-md{font-size:22px}.white-bg-color{background:#FFF}.description-props{min-height:144px}.detail-description-wrap{padding:10px 16px}.detail-description-wrap p{padding:10px 0;font-size:16px}.buyer-protection{padding:10px 16px}.buyer-protection p{padding:10px 0}.buyer-protection p:last-of-type{padding:0 0 10px;font-size:12px;color:#999}.stroe-info{padding:10px 16px}.stroe-info p:last-of-type{font-size:12px;color:#999}.stroe-info .detail-sumary{border:0;padding:10px 0}.stroe-info .detail-block-title{padding-bottom:10px}.top-brands{height:24px;font-size:12px;color:#999}.top-brands span{padding-left:10px}.crosslink{position:relative;width:100%;height:108px;padding:0 12px;background-color:#fff;overflow:hidden}.crosslink-title{font-size:15px;line-height:24px;color:#666;padding:12px 0}.crosslink-item{margin-bottom:12px}.crosslink-item h3{font-size:15px;line-height:18px;padding:4px 0 8px;margin:0;font-weight:400}.crosslink-link a{display:inline-block;width:49%;vertical-align:top;margin-bottom:12px;color:#999;font-size:12px;text-decoration:none;line-height:18px}.crosslink-auto{height:auto}.crosslink-auto .show-more{-webkit-transform:rotate(-45deg);transform:rotate(-45deg)}.show-more{display:block;width:8px;height:8px;border-top:1px solid #999;border-right:1px solid #999;-webkit-transform:rotate(135deg);transform:rotate(135deg);margin-left:5px;position:absolute;top:18px;right:22px}.detail-product-list{flex-wrap:wrap;-webkit-flex-wrap:wrap}.detail-product-list h4{display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;padding:8px 12px 0;font-weight:400;color:#666;overflow:hidden;background-color:#fff;height:50px}.detail-product-list p{padding:8px 12px;font-weight:600;background-color:#fff}.detail-product-item{width:50%;padding:1px 0 0 1px;background-color:#F5F5F5}    </style>
+
+            <script async custom-element="amp-iframe" src="https://cdn.ampproject.org/v0/amp-iframe-0.1.js"></script>
+    <script async custom-element="amp-selector" src="https://cdn.ampproject.org/v0/amp-selector-0.1.js"></script>
+
+    <script>
+    // Enable amp-lightbox-gallery experiment automatically if it is not enabled.
+    setTimeout(function () {
+      if (!AMP.isExperimentOn('amp-lightbox-gallery')) {
+        AMP.toggleExperiment('amp-lightbox-gallery');
+        location.reload();
+      }
     }, 1000);
   </script>
 
-  <h1>Lightbox Carousel Description Test</h1>
-  <p>The following images belong to the default lightbox group. </p>
-  <amp-img src="https://picsum.photos/1600/900?image=107"
-    aria-describedby="longest-description"
-    lightbox
-    width="400"
-    height="225"
-    alt="a beautiful cat"></amp-img>
+</head>
+<body  data-spm="detail-amp" ><amp-pixel src="https://gj.mmstat.com/g.gif?ae_u_p_s=&cna=KIh3E2S7PGUCAWiEAVwzg9SZ&spm-cnt=a2g0n.detail%2damp.0.0.NAV_TIMING(navigationStart)&pre=DOCUMENT_REFERRER&aplus&ali_apache_track=&dmtrack_c={ali%5fresin%5ftrace%3dws%5fab%5ftest%3d%7caep%5fusuc%5ff%3dsite%3dglo%26c%5ftp%3dUSD%26region%3dUS%26b%5flocale%3den%5fUS}&hn=ae%2dmsite010177205113%2eus%2eot7&pageid=PAGE_VIEW_IDCLIENT_ID(aefeMsite)NAV_TIMING(navigationStart)&s=VIEWPORT_WIDTHxVIEWPORT_HEIGHT&viewer=VIEWER">
+</amp-pixel>
 
-  <amp-img src="https://picsum.photos/1600/900?image=108"
-    aria-describedby="medium-description"
-    lightbox
-    width="400"
-    height="225"
-    alt="a beautiful cat"></amp-img>
 
-  <amp-img src="https://picsum.photos/1600/900?image=109"
-    alt="short description short description short description short description three lines worth of stuff coming up on 4 lines what if we actually have four"
-    lightbox
-    width="400"
-    height="225"></amp-img>
+        <header id="ms-header">
+            <section class="ms-downloadbar-wrap " id="ms-downloadbar-wrap">
+        <div class="download-bar">
+        <a href="//m.aliexpress.com/d.do?p=a4&ck=in_msite_top">
+            <amp-img class="ms_topbanner_image_pic" src="http://ae01.alicdn.com/kf/HTB1KkyyeXmWBuNjSspdq6zugXXav.jpg" layout="fixed-height" height="56" noloading alt="image"></amp-img>
+        </a>
+    </div>
+    </section>
+        <div id="header-toolbar" class="header-toolbar">
+                                </div>
+            <div id="header-toolbar" class="header-toolbar">
+            <a href="/" id="ms-back" class="ic-wp">
+    <i class="ic-md ic-backarrow-md"></i>
+</a>
+<span role="button" tabindex="-1" id="category-back" hidden on='tap: AMP.setState({
+        category: {
+            stateId: "8888",
+            stateGlobal: "show",
+            categoryTitle: category.categoryTwoTitle
+        }
+    }), ms-back.show, category-back.hide, category-sync.show'>
+    <i class="ic-md ic-backarrow-md"></i>
+</span>                <p id="ms-title" class="ic-wp">
+        <span></span>
+    </p>
+            <a href="/shopcart/list.html" id="ms-cart" class="ic-wp">
+    <div></div>
+    <i class="ic-md ic-shoppingcart-md"></i>
+</a>            <span role="button" tabindex="-1" id="ms-minidrawer" class="ic-wp" on="tap:mini-drawer-list.show">
+                <i class="ic-md ic-morevert-md"></i>
+            </span>
+        </div>
+        <div id="header-toolbar-detail" class="header-toolbar">
+            <a href="/" id="ms-back" class="ic-wp">
+    <i class="ic-md ic-backarrow-md"></i>
+</a>
+<span role="button" tabindex="-1" id="category-back" hidden on='tap: AMP.setState({
+        category: {
+            stateId: "8888",
+            stateGlobal: "show",
+            categoryTitle: category.categoryTwoTitle
+        }
+    }), ms-back.show, category-back.hide, category-sync.show'>
+    <i class="ic-md ic-backarrow-md"></i>
+</span>                <p id="ms-title" class="ic-wp">
+        <span></span>
+    </p>
+            <a href="/shopcart/list.html" id="ms-cart" class="ic-wp">
+    <div></div>
+    <i class="ic-md ic-shoppingcart-md"></i>
+</a>            <span role="button" tabindex="-1" id="ms-minidrawer" class="ic-wp" on="tap:mini-drawer-list.show">
+                <i class="ic-md ic-morevert-md"></i>
+            </span>
+        </div>
+        <div id="mini-drawer-list" hidden>
+            <div role="button" tabindex="-1" class="mini-drawer-layer" on="tap:mini-drawer-list.hide"></div>
+            <ul class="mini-drawer-list">
+                <li>
+                    <a id="minidrawer-home" href="/">Home</a>
+                </li>
+                <li>
+                    <a id="minidrawer-wish" href="/wishlist.html">Wish List</a>
+                </li>
+            </ul>
+        </div>
+    </header>
 
-  <amp-carousel
-    width="400"
-    height="300"
-    layout="fixed"
-    type="slides"
-    lightbox>
-    <amp-img src="https://picsum.photos/1600/900?image=110"
-      width="400"
-      height="225"
-      alt="a beautiful cat"></amp-img>
-    <figure>
-        <amp-img src="https://picsum.photos/1600/900?image=111"
-        width="400"
-        height="225"
-        alt="another beautiful cat"></amp-img>
-        <figcaption>This is a figure with a figcaption.</figcaption>
-    </figure>
-    <amp-img src="https://picsum.photos/1600/900?image=110"
-      width="400"
-      height="225"
-      aria-label="Aria labels are cool."></amp-img>
-    <amp-img src="https://picsum.photos/1600/900?image=112"
-      width="400"
-      height="225"
-      aria-describedby="my-aria-describe"></amp-img>
-    <amp-img src="https://picsum.photos/1600/900?image=113"
-      width="400"
-      height="225"
-      aria-labelledby="my-aria-label"></amp-img>
-  </amp-carousel>
+            <amp-animation id="shrinkAnim" layout="nodisplay">
+            <script type="application/json">
+                {
+                    "duration": "200ms",
+                    "fill": "both",
+                    "iterations": "1",
+                    "direction": "alternate",
+                    "animations": [
+                        {
+                            "selector": "#ms-header",
+                            "keyframes": [
+                                { "transform": "translateY(-112px)" }
+                            ]
+                        },
+                        {
+                            "selector": "#ms-header .header-toolbar",
+                            "keyframes": [
+                                { "transform": "translateY(56px)" }
+                            ]
+                        }
+                                                ,
+                        {
+                            "selector": "#ms-header #mini-drawer-list",
+                            "keyframes": [
+                                { "transform": "translateY(56px)" }
+                            ]
+                        }
+                                            ]
+                }
+            </script>
+        </amp-animation>
+        <amp-animation id="expandAnim" layout="nodisplay">
+            <script type="application/json">
+                {
+                    "duration": "50ms",
+                    "fill": "both",
+                    "iterations": "1",
+                    "direction": "alternate",
+                    "animations": [
+                        {
+                            "selector": "#ms-header",
+                            "keyframes": [
+                                { "transform": "translateY(0)"}
+                            ]
+                        },
+                        {
+                            "selector": "#ms-header .header-toolbar",
+                            "keyframes": [
+                                { "transform": "translateY(0)" }
+                            ]
+                        }
+                                                ,
+                        {
+                            "selector": "#ms-header #mini-drawer-list",
+                            "keyframes": [
+                                { "transform": "translateY(0)" }
+                            ]
+                        }
+                                            ]
+                }
+            </script>
+        </amp-animation>
+        <main>
+            <div id="marker">
+                <amp-position-observer
+                    on="enter:shrinkAnim.start; exit:expandAnim.start;"
+                    layout="nodisplay">
+                </amp-position-observer>
+            </div>
+        </main>
 
-  <h1>Lightbox Carousel with Video Test</h1>
-  <h2>AMP-VIDEO Layout Test</h2>
-  <p>This carousel includes amp-video with the following layouts: </p>
-  <ul>
-    <li>Responsive</li>
-    <li>Responsive with autoplay</li>
-    <li>Fill</li>
-    <li>Fixed Height</li>
-    <li>Fixed</li>
-  </ul>
-  <amp-carousel
-    width="800"
-    height="450"
-    layout="fixed"
-    type="slides"
-    lightbox>
-    <amp-img src="https://picsum.photos/1600/900?image=114"
-      width="800"
-      height="450"
-      alt="a beautiful cat"></amp-img>
-    <amp-video
-      src="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4"
-      width="358"
-      height="204"
-      layout="responsive"
-      poster="https://i.ytimg.com/vi/5Yjoe54vzwE/mqdefault.jpg"
-      controls>
-    </amp-video>
-    <amp-video
-      src="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4"
-      width="358"
-      height="204"
-      layout="responsive"
-      autoplay
-      poster="https://i.ytimg.com/vi/5Yjoe54vzwE/mqdefault.jpg"
-      controls>
-    </amp-video>
-    <amp-video
-      src="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4"
-      width="358"
-      height="204"
-      layout="fill"
-      poster="https://i.ytimg.com/vi/5Yjoe54vzwE/mqdefault.jpg"
-      controls>
-    </amp-video>
-    <amp-video
-      src="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4"
-      height="204"
-      layout="fixed-height"
-      poster="https://i.ytimg.com/vi/5Yjoe54vzwE/mqdefault.jpg"
-      controls>
-    </amp-video>
-    <amp-video
-      src="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4"
-      width="358"
-      height="204"
-      layout="fixed"
-      poster="https://i.ytimg.com/vi/5Yjoe54vzwE/mqdefault.jpg"
-      controls>
-    </amp-video>
-  </amp-carousel>
 
-  <h2>AMP-YOUTUBE Layout Test</h2>
-  <p>This carousel includes amp-video with the following layouts: </p>
-  <ul>
-    <li>Responsive</li>
-    <li>Responsive with autoplay</li>
-    <li>Fill</li>
-    <li>Fixed Height</li>
-    <li>Fixed</li>
-  </ul>
-  <amp-carousel
-    width="800"
-    height="600"
-    layout="fixed"
-    type="slides"
-    lightbox>
-    <amp-img src="https://picsum.photos/1600/900?image=115"
-      width="800"
-      height="450"
-      alt="a beautiful cat"></amp-img>
-    <amp-youtube width="480"
-      height="270"
-      layout="responsive"
-      data-videoid="lBTCB7yLs8Y"
-      lightbox-thumbnail-id="non-existent-thumbnail-img">
-    </amp-youtube>
-    <amp-youtube width="480"
-      height="270"
-      layout="responsive"
-      data-videoid="lBTCB7yLs8Y"
-      autoplay>
-      <amp-img
-        src="https://i.ytimg.com/vi/OO9oKhs80aI/mqdefault.jpg"
-        placeholder
-        layout="fill"
-        />
-    </amp-youtube>
-    <amp-youtube width="480"
-      height="270"
-      layout="fill"
-      data-videoid="lBTCB7yLs8Y">
-    </amp-youtube>
-    <amp-youtube
-      height="270"
-      layout="fixed-height"
-      data-videoid="lBTCB7yLs8Y">
-    </amp-youtube>
-    <amp-youtube width="480"
-      height="270"
-      layout="fixed"
-      data-videoid="lBTCB7yLs8Y">
-    </amp-youtube>
-  </amp-carousel>
+    <amp-lightbox id="search-input-layer" layout="nodisplay" on="lightboxOpen: input-focus.focus" scrollable>
+        <header class="header-toolbar">
+            <span role="button" tabindex="-1" id="search-back" class="ic-wp" on="tap:search-input-layer.close">
+                <i class="ic-md ic-backarrow-md"></i>
+            </span>
+            <form id="autoSearch" method="GET" action="https://m.aliexpress.com/search.htm" target="_top">
+                <input type="hidden" name="keywords" [value]="encodeURIComponent(searchState.inputValue.split(' ').join('-')) || 'search'">
+                <input type="text" id="input-focus" [value]="searchState.inputValue" class="search-box" autofocus autocomplete="off"
+                on="input-throttled:AMP.setState({
+                    searchState: {
+                                    inputValue: event.value
+                                }
+                    })"
+                                        placeholder="I&#39;m shopping for..." />
+            </form>
+            <span class="ic-close"
+                on="tap: AMP.setState({
+                    searchState: {
+                        inputValue: ''
+                    }
+                })">
+                <i class="ic-md ic-close-md" id="search-clear" [class]="searchState.inputValue == '' ? 'ic-md ic-close-md clear-hide' : 'ic-md ic-close-md clear-show'"></i>
+            </span>
+        </header>
+        <div class="autosuggest" id="autosuggest">
+            <div class="auto-suggest-prom">
+                <amp-list credentials="include" src="https://m.aliexpress.com/api/search/auto-suggests/" [src]="searchState.inputValue ? autosuggest.autoSuggestSearch + encodeURIComponent(searchState.inputValue) : autosuggest.emptyAndInitialTemplateJson" layout="fill" items="data.autoSuggestPromList" id="auto-prom-suggest" noloading>
+                    <template type="amp-mustache">
+                        {{#.}}
+                            <a href="{{action}}" class="auto-prom">
+                                <div class="prom">
+                                    {{#icon}}<amp-img src="{{icon}}" class="prom-image" alt="image" width="60" height="30" layout="fixed"></amp-img>{{/icon}}
+                                    <span class="prom-txt">{{keyWord}}</span>
+                                </div>
+                            </a>
+                        {{/.}}
+                    </template>
+                </amp-list>
+            </div>
+            <div class="auto-suggest-cat">
+                <amp-list credentials="include" src="https://m.aliexpress.com/api/search/auto-suggests/" [src]="searchState.inputValue ? autosuggest.autoSuggestSearch + encodeURIComponent(searchState.inputValue) : autosuggest.emptyAndInitialTemplateJson" layout="fill" items="data.autoSuggestCatList" id="auto-cat-suggest" noloading>
+                    <template type="amp-mustache">
+                        {{#.}}
+                            <a href={{mainSearchURL}} class="auto-cat">
+                                <div class="cat">
+                                    <div>
+                                        <div class="cate-txt">{{keyWord}}</div>
+                                        <span class="category">{{catName}}</span>
+                                    </div>
+                                    {{#keyWord}}<div class="go-icon ic-md ic-insert-md"></div>{{/keyWord}}
+                                </div>
+                            </a>
+                        {{/.}}
+                    </template>
+                </amp-list>
+            </div>
+            <div class="auto-suggest">
+                <amp-list credentials="include" src="https://m.aliexpress.com/api/search/auto-suggests/" [src]="searchState.inputValue ? autosuggest.autoSuggestSearch + encodeURIComponent(searchState.inputValue) : autosuggest.emptyAndInitialTemplateJson" layout="fill" items="data.autoSuggestList" id="auto-suggest" noloading>
+                    <template type="amp-mustache">
+                        {{#.}}
+                            <a href={{mainSearchURL}}>
+                                <div class="suggest">
+                                    <div class="txt-wrap">
+                                        <div class="sug-txt">{{keyWord}}</div>
+                                    </div>
+                                    {{#keyWord}}<div class="go-icon ic-md ic-insert-md"></div>{{/keyWord}}
+                                </div>
+                            </a>
+                        {{/.}}
+                    </template>
+                </amp-list>
+            </div>
+        </div>
+    </amp-lightbox>
 
-  <h1>Lightbox Carousel Ads Support Test</h1>
-  <amp-carousel
-    width="800"
-    height="600"
-    layout="fixed"
-    type="slides"
-    lightbox>
-    <amp-img src="https://picsum.photos/1600/900?image=300"
-      width="800"
-      height="450"
-      alt="a beautiful cat"></amp-img>
-    <amp-ad width="300"
-      height="250"
-      type="a9"
-      data-aax_size="300x250"
-      data-aax_pubname="test123"
-      data-aax_src="302">
-    </amp-ad>
-    <amp-ad data-slot="/30497360/a4a/a4a_native"
-      height="250"
-      type="doubleclick"
-      width="300">
-    </amp-ad>
-  </amp-carousel>
+<form method="GET" id="cookie-set"
+    action="https://m.aliexpress.com/api/privacy/select"
+    action-xhr="https://m.aliexpress.com/api/privacy/select" target="_top">
+    <input type="hidden" value="" [value]="cookieState.isAgree" name="isAgree">
+</form>
 
-  <h1>Lightbox API Tests</h1>
-  <h2>Lightbox Group Test</h2>
-  <h3>Test 1</h3>
-  <p>The following image and youtube video should belong to the same lightbox group. The lightbox group should include a third image from the carousel in Test 3 below. </p>
-  <amp-img src="https://picsum.photos/1600/900?image=118"
-    width="400"
-    height="225"
-    lightbox="group-1"
-    alt="a beautiful cat"></amp-img>
-  <amp-youtube lightbox="group-1"
-    width="480"
-    height="270"
-    layout="fixed"
-    data-videoid="lBTCB7yLs8Y">
-  </amp-youtube>
-  <h3>Test 2</h3>
-  <p>The following image should belong to the default lightbox group. </p>
-  <amp-img src="https://picsum.photos/1600/900?image=119"
-    width="400"
-    height="225"
-    lightbox
-    aria-label="Aria labels are cool."></amp-img>
-  <h3>Test 3</h3>
-  <p>In the following carousel, images 2 and 4 should be excluded from the lightbox. Image 4 should belong to the lightbox group in Test 1.</p>
-  <amp-carousel
-    width="400"
-    height="300"
-    layout="fixed"
-    type="slides"
-    lightbox>
-    <amp-img src="https://picsum.photos/1600/900?image=120"
-      width="400"
-      height="225"
-      alt="a beautiful cat"></amp-img>
-    <amp-img src="https://picsum.photos/1600/900?image=121"
-      width="400"
-      height="225"
-      lightbox-exclude
-      aria-label="Aria labels are cool."></amp-img>
-    <amp-img src="https://picsum.photos/1600/900?image=122"
-      width="400"
-      height="225"
-      aria-describedby="my-aria-describe"></amp-img>
-    <amp-img src="https://picsum.photos/1600/900?image=123"
-      width="400"
-      height="225"
-      lightbox="group-1"
-      aria-labelledby="my-aria-label"></amp-img>
-  </amp-carousel>
+<amp-list credentials="include" class="fill-list" src="https://m.aliexpress.com/api/privacy/judge" items="." single-item="." layout="fill" noloading>
+    <template type="amp-mustache">
+        <div class="{{#data.openPrivacyDialog}}show{{/data.openPrivacyDialog}}{{^data.openPrivacyDialog}}none{{/data.openPrivacyDialog}}" [class]="cookieState.isShow || '{{#data.openPrivacyDialog}}show{{/data.openPrivacyDialog}}{{^data.openPrivacyDialog}}none{{/data.openPrivacyDialog}}'">
+            <div class="cookie-box">
+                <span>
+                    AliExpress uses cookies to offer you a personalized service. By continuing to browse this site, you agree to our Cookies Section of our
+                </span>
+                <a href="https://rule.alibaba.com/rule/detail/2034.htm">Privacy Policy .</a>
+                <span>
+                    You may furthur adjust your cookie access in your privacy setting.
+                </span>
+                <div class="cookie-choice-box">
+                    <span class="cookie-choice"
+                        on="tap:AMP.setState({
+                            cookieState: {
+                                isAgree: 'true',
+                                isShow: 'none'
+                            }
+                        }), cookie-set.submit">yes</span>
+                    <span class="cookie-choice"
+                        on="tap:AMP.setState({
+                            cookieState: {
+                                isAgree: 'false',
+                                isShow: 'none'
+                            }
+                        }), cookie-set.submit">no</span>
+                </div>
+            </div>
+        </div>
+    </template>
+</amp-list>
 
-  <amp-img id="fb-thumbnail-img"
-    width="200"
-    height="200"
-    layout="nodisplay"
-    src="https://picsum.photos/200/200?image=1074">
-  </amp-img>
+<amp-state id="autosuggest">
+    <script type="application/json">
+        {
+            "autoSuggestSearch": "https://m.aliexpress.com/api/search/auto-suggests/",
+            "emptyAndInitialTemplateJson": [{
+                "query": "",
+                "results": []
+            }]
+        }
+    </script>
+</amp-state>
+<amp-state id="searchState">
+    <script type="application/json">
+        {
+            "inputValue": ""
+        }
+    </script>
+</amp-state>
+<amp-state id="language">
+    <script type="application/json">
+        {
+            "taggle": "language-choice-close"
+        }
+    </script>
+</amp-state>
 
-  <amp-img id="yt-thumbnail-img"
-    width="200"
-    height="200"
-    layout="nodisplay"
-    src="https://picsum.photos/200/200?image=1074">
-  </amp-img>
+<amp-state credentials="include" id="privacySetting" src="https://m.aliexpress.com/api/privacy/judge"></amp-state>
 
-  <div id='my-aria-describe' layout="nodisplay">
-    This is an aria described by a div. <br/>
-    I have a linebreak.
-  </div>
-  <div id='my-aria-label' layout="nodisplay">
-    This is an aria labelled by a div. <br/>
-    I also have a newline.
-  </div>
-  <div id='longest-description' layout="nodisplay">
-    Guess what the actual text of lorem ipsum is?
-    But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure. To take a trivial example, which of us ever undertakes laborious physical exercise, except to obtain some advantage from it? But who has any right to find fault with a man who chooses to enjoy a pleasure that has no annoying consequences, or one who avoids a pain that produces no resultant pleasure?
-    On the other hand, we denounce with righteous indignation and dislike men who are so beguiled and demoralized by the charms of pleasure of the moment, so blinded by desire, that they cannot foresee the pain and trouble that are bound to ensue; and equal blame belongs to those who fail in their duty through weakness of will, which is the same as saying through shrinking from toil and pain. These cases are perfectly simple and easy to distinguish. In a free hour, when our power of choice is untrammelled and when nothing prevents our being able to do what we like best, every pleasure is to be welcomed and every pain avoided. But in certain circumstances and owing to the claims of duty or the obligations of business it will frequently occur that pleasures have to be repudiated and annoyances accepted. The wise man therefore always holds in these matters to this principle of selection: he rejects pleasures to secure other greater pleasures, or else he endures pains to avoid worse pains.
-  </div>
-  <div id='medium-description' layout="nodisplay">
-    But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful. Nor again is there anyone who loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally circumstances occur in which toil and pain can procure him some great pleasure. To take a trivial example, which of us ever undertakes laborious physical exercise, except to obtain some advantage from it? But who has any right to find fault with a man who chooses to enjoy a pleasure that has no annoying consequences, or one who avoids a pain that produces no resultant pleasure?
-  </div>
+
+
+<amp-analytics>
+    <script type="application/json">
+        {
+            "requests": {
+                "clkServer": "https://gj.mmstat.com/ae.pc_click.statweb_ae_click?gmkey=CLK&spm-cnt=a2g0n.detail-amp.0.0.amp",
+                "ctrServer": "https://gj.mmstat.com/ae.pc_ctr.statweb_ae_ctr?gmkey=EXP&spm-cnt=a2g0n.detail-amp.0.0.amp"
+            },
+            "transport": {
+                "beacon": false,
+                "xhrpost": false,
+                "image": true
+            },
+            "triggers": {
+                "headerDownloadBar": {
+                    "on": "click",
+                    "request": "clkServer",
+                    "selector": ".download-bar",
+                    "extraUrlParams": {
+                        "gokey": "ae_project_id=180139&ae_page_type=in_msite_download&ae_page_area=menu_download&ae_button_type=&ae_object_type=download_button&ae_object_value=&st_page_id=PAGE_VIEW_IDCLIENT_ID(aefeMsite)NAV_TIMING(navigationStart)"
+                    }
+                },
+                "headerMenu": {
+                    "on": "click",
+                    "request": "clkServer",
+                    "selector": "#ms-drawer",
+                    "extraUrlParams": {
+                        "gokey": "ae_project_id=180139&ae_page_type=m_all_page&ae_page_area=m_menu&ae_button_type=&ae_object_type=menu_button&ae_object_value=&st_page_id=PAGE_VIEW_IDCLIENT_ID(aefeMsite)NAV_TIMING(navigationStart)"
+                    }
+                },
+                "headerLogo": {
+                    "on": "click",
+                    "request": "clkServer",
+                    "selector": "#ms-logo",
+                    "extraUrlParams": {
+                        "gokey": "ae_project_id=180139&ae_page_type=menu_page&ae_page_area=menu_home&ae_button_type=&ae_object_type=home_button&ae_object_value=&st_page_id=PAGE_VIEW_IDCLIENT_ID(aefeMsite)NAV_TIMING(navigationStart)"
+                    }
+                },
+                "headerSearch": {
+                    "on": "click",
+                    "request": "clkServer",
+                    "selector": "#ms-search",
+                    "extraUrlParams": {
+                        "gokey": "ae_project_id=180139&ae_page_type=all_page&ae_page_area=m_search&ae_button_type=&ae_object_type=search_button&ae_object_value=&st_page_id=PAGE_VIEW_IDCLIENT_ID(aefeMsite)NAV_TIMING(navigationStart)"
+                    }
+                },
+                "headerSearchCancel": {
+                    "on": "click",
+                    "request": "clkServer",
+                    "selector": "#search-back",
+                    "extraUrlParams": {
+                        "gokey": "ae_project_id=180139&ae_page_type=m_search_page&ae_page_area=m_search&ae_button_type=&ae_object_type=search_cancel_button&ae_object_value=&st_page_id=PAGE_VIEW_IDCLIENT_ID(aefeMsite)NAV_TIMING(navigationStart)"
+                    }
+                },
+                "homeCart": {
+                    "on": "click",
+                    "request": "clkServer",
+                    "selector": "#ms-cart",
+                    "extraUrlParams": {
+                        "gokey": "ae_project_id=180139&ae_page_type=all_page&ae_page_area=shoppingcart&ae_button_type=&ae_object_type=shoppingcart_button&ae_object_value=&st_page_id=PAGE_VIEW_IDCLIENT_ID(aefeMsite)NAV_TIMING(navigationStart)"
+                    }
+                },
+                "homeMiniDrawer": {
+                    "on": "click",
+                    "request": "clkServer",
+                    "selector": "#ms-minidrawer",
+                    "extraUrlParams": {
+                        "gokey": "ae_project_id=180139&ae_page_type=all_page&ae_page_area=m_minidrawer&ae_button_type=&ae_object_type=minidrawer_button&ae_object_value=&st_page_id=PAGE_VIEW_IDCLIENT_ID(aefeMsite)NAV_TIMING(navigationStart)"
+                    }
+                }
+            }
+        }
+    </script>
+</amp-analytics>
+
+                <amp-animation id="show-detail-header" layout="nodisplay">
+    <script type="application/json">
+        {
+            "duration": "200ms",
+            "fill": "both",
+            "selector": "#header-toolbar-detail",
+            "keyframes": { "opacity": "0.95"}
+        }
+    </script>
+</amp-animation>
+
+<amp-animation id="hide-detail-header" layout="nodisplay">
+    <script type="application/json">
+        {
+            "duration": "200ms",
+            "fill": "both",
+            "selector": "#header-toolbar-detail",
+            "keyframes": { "opacity": "0"}
+        }
+    </script>
+</amp-animation>
+
+<amp-animation id="show-action-toolbar" layout="nodisplay">
+    <script type="application/json">
+        {
+            "duration": "200ms",
+            "fill": "both",
+            "selector": "#fixed-tool-bar",
+            "keyframes": { "transform": "translateY(0)"}
+        }
+    </script>
+</amp-animation>
+
+<amp-animation id="hide-action-toolbar" layout="nodisplay">
+    <script type="application/json">
+        {
+            "duration": "200ms",
+            "fill": "both",
+            "selector": "#fixed-tool-bar",
+            "keyframes": { "transform": "translateY(300%)"}
+        }
+    </script>
+</amp-animation>
+
+<amp-animation id="show-back-top" layout="nodisplay">
+    <script type="application/json">
+        {
+            "duration": "200ms",
+            "fill": "both",
+            "selector": "#back-top-button",
+            "keyframes": { "transform": "translateY(0)"}
+        }
+    </script>
+</amp-animation>
+
+<amp-animation id="hide-back-top" layout="nodisplay">
+    <script type="application/json">
+        {
+            "duration": "200ms",
+            "fill": "both",
+            "selector": "#back-top-button",
+            "keyframes": { "transform": "translateY(300%)"}
+        }
+    </script>
+</amp-animation>
+
+<amp-animation id="dialog-anima" layout="nodisplay">
+    <script type="application/json">
+        {
+            "duration": "3s",
+            "animations": [
+                {
+                    "selector": "#dialog",
+                    "keyframes": [
+                        {"transform": "translate(-50%,200%)","opacity": 0,"visibility":"hidden"},
+                        {"transform": "translate(-50%,-50%)","opacity": 1,"visibility":"visible"},
+                        {"transform": "translate(-50%,-50%)","opacity": 1,"visibility":"visible"},
+                        {"transform": "translate(-50%,-50%)","opacity": 1,"visibility":"visible"},
+                        {"transform": "translate(-50%,200%)","opacity": 0,"visibility":"hidden"}
+                    ]
+                }
+            ]
+        }
+    </script>
+</amp-animation>
+
+<div id="detail-marker">
+    <amp-position-observer
+        on="scroll:show-detail-header.seekTo(percent=event.percent)"
+        layout="nodisplay">
+    </amp-position-observer>
+</div>
+
+<div id="detail-fixed-toolbar">
+    <amp-position-observer
+        on="enter:show-action-toolbar.start;exit:hide-action-toolbar.start"
+        layout="nodisplay">
+    </amp-position-observer>
+</div>
+
+<div id="detail-back-top">
+    <amp-position-observer
+        on="enter:show-back-top.start;exit:hide-back-top.start"
+        layout="nodisplay">
+    </amp-position-observer>
+</div>
+
+<div id="dialog" class="dialog-wrap flex justify-center align-center">
+    <p [text]="dialogContent || ''"></p>
+</div>
+
+<div id="back-top-button" class="back-top-button flex justify-center align-center" on="tap:detail-carousel.scrollTo()" tabindex="-1" role="button">
+    <div class="flex justify-center align-center">
+        <span class="chevron-up">
+            <span></span>
+        </span>
+    </div>
+</div>
+
+        <section class="ms-block">
+                            <div class="carousel-wrap">
+        <amp-carousel id="detail-carousel" width="640" height="640" layout="responsive" type="slides" delay="2500" loop lightbox autoplay controls
+        on="slideChange:AMP.setState({
+            carouselState: {
+                currentIndex: event.index
+            }
+        })">
+                            <amp-img src="https://ae01.alicdn.com/kf/HTB1zvRtSFXXXXX1aXXXq6xXFXXXO/SMJEL-Fashion-Trendy-Open-Leaf-Cuff-Bracelet-Bangles-for-Women-Simple-Plant-Bracelet-Femme-Boho-Jewelry.jpg_640x640q90.jpg_.webp" alt="image" width="640" height="640" layout="responsive" tabindex="-1" role="button"></amp-img>
+                            <amp-img src="https://ae01.alicdn.com/kf/HTB1pVhESFXXXXa4XVXXq6xXFXXXZ/SMJEL-Fashion-Trendy-Open-Leaf-Cuff-Bracelet-Bangles-for-Women-Simple-Plant-Bracelet-Femme-Boho-Jewelry.jpg_640x640q90.jpg_.webp" alt="image" width="640" height="640" layout="responsive" tabindex="-1" role="button"></amp-img>
+                            <amp-img src="https://ae01.alicdn.com/kf/HTB1rjFySFXXXXbzXVXXq6xXFXXXs/SMJEL-Fashion-Trendy-Open-Leaf-Cuff-Bracelet-Bangles-for-Women-Simple-Plant-Bracelet-Femme-Boho-Jewelry.jpg_640x640q90.jpg_.webp" alt="image" width="640" height="640" layout="responsive" tabindex="-1" role="button"></amp-img>
+                            <amp-img src="https://ae01.alicdn.com/kf/HTB191pASFXXXXcnXVXXq6xXFXXXa/SMJEL-Fashion-Trendy-Open-Leaf-Cuff-Bracelet-Bangles-for-Women-Simple-Plant-Bracelet-Femme-Boho-Jewelry.jpg_640x640q90.jpg_.webp" alt="image" width="640" height="640" layout="responsive" tabindex="-1" role="button"></amp-img>
+                            <amp-img src="https://ae01.alicdn.com/kf/HTB17jxySFXXXXcRXVXXq6xXFXXX0/SMJEL-Fashion-Trendy-Open-Leaf-Cuff-Bracelet-Bangles-for-Women-Simple-Plant-Bracelet-Femme-Boho-Jewelry.jpg_640x640q90.jpg_.webp" alt="image" width="640" height="640" layout="responsive" tabindex="-1" role="button"></amp-img>
+                            <amp-img src="https://ae01.alicdn.com/kf/HTB1JCx1SFXXXXccXXXXq6xXFXXXV/SMJEL-Fashion-Trendy-Open-Leaf-Cuff-Bracelet-Bangles-for-Women-Simple-Plant-Bracelet-Femme-Boho-Jewelry.jpg_640x640q90.jpg_.webp" alt="image" width="640" height="640" layout="responsive" tabindex="-1" role="button"></amp-img>
+                    </amp-carousel>
+
+        <ul class="carousel-points">
+                            <li class="current"[class]="carouselState.currentIndex == 0 ? 'current' : ''" tabindex="-1" role="button"
+                class="current"                on="tap:AMP.setState({
+                    carouselState: {
+                        currentIndex: 0
+                    }
+                }), detail-carousel.goToSlide(index=0)"></li>
+                            <li [class]="carouselState.currentIndex == 1 ? 'current' : ''" tabindex="-1" role="button"
+                                on="tap:AMP.setState({
+                    carouselState: {
+                        currentIndex: 1
+                    }
+                }), detail-carousel.goToSlide(index=1)"></li>
+                            <li [class]="carouselState.currentIndex == 2 ? 'current' : ''" tabindex="-1" role="button"
+                                on="tap:AMP.setState({
+                    carouselState: {
+                        currentIndex: 2
+                    }
+                }), detail-carousel.goToSlide(index=2)"></li>
+                            <li [class]="carouselState.currentIndex == 3 ? 'current' : ''" tabindex="-1" role="button"
+                                on="tap:AMP.setState({
+                    carouselState: {
+                        currentIndex: 3
+                    }
+                }), detail-carousel.goToSlide(index=3)"></li>
+                            <li [class]="carouselState.currentIndex == 4 ? 'current' : ''" tabindex="-1" role="button"
+                                on="tap:AMP.setState({
+                    carouselState: {
+                        currentIndex: 4
+                    }
+                }), detail-carousel.goToSlide(index=4)"></li>
+                            <li [class]="carouselState.currentIndex == 5 ? 'current' : ''" tabindex="-1" role="button"
+                                on="tap:AMP.setState({
+                    carouselState: {
+                        currentIndex: 5
+                    }
+                }), detail-carousel.goToSlide(index=5)"></li>
+                    </ul>
+
+                                        <a href="https://m.aliexpress.com/login.html" class="collection flex align-center justify-center">
+                <i class="ic-md ic-wishlist-md"></i>
+            </a>
+            </div>
+
+<form id="wishdForm" method="POST" action-xhr="https://m.aliexpress.com/api/user/wished/" target="_top" hidden
+on="submit-success:AMP.setState({
+        wished: {
+            operateType: wished.operateType == 'add' ? 'remove' : 'add'
+        }
+    });
+    submit-error:AMP.setState({
+        dialogContent: event.response.message
+    }),dialog.show,dialog-anima.start">
+
+    <input type="hidden" name="_csrf_token_" value="124_ro0xv81b7">
+    <input type="hidden" name="productId" value="32751800685" />
+            <input type="hidden" name="operate" value="add" [value]="wished.operateType || 'add'"/>
+    </form>
+
+<amp-state id="wished">
+    <script type="application/json">
+    {
+                "operateType": "add"
+            }
+    </script>
+</amp-state>
+
+                        <h1 class="detail-description">SMJEL Fashion Trendy Open Leaf Cuff Bracelet Bangles for Women Simple Plant Bracelet Femme Boho Jewelry Birthday Gift SYSZ014</h1>
+
+                        <div class="detail-price-wrap">
+
+                                    <p class="current-price">US $1.79</p>
+            <p>
+                <span class="original-price">US $2.99</span>
+                                                            <span class="discount-price">-40%</span>
+                                                </p>
+                                </div>
+                                        <ul class="detail-sumary ms-border-bottom flex">
+                    <li class="sumary-stars">
+                        <span>4.8</span>
+                        <span>
+                            <span class="star-rank">
+                                <span class="ms-star-bottom"></span>
+                                                                <span class="ms-star-top w96"></span>
+                            </span>
+                        </span>
+                    </li>
+                    <li class="sumary-orders">
+                        <span>2534</span>
+                        <span>Orders</span>
+                    </li>
+                    <li class="sumary-wishlist">
+                        <span>7430</span>
+                        <span>Wish List</span>
+                    </li>
+                </ul>
+
+                                    <div class="detail-coupon-discount ms-border-bottom" on="tap:discounts-coupons-lb" tabindex="-1" role="button">
+        <h3 class="detail-block-title ellipsis">Discounts & Coupons</h3>
+                                                                                                                                                            <p class="detail-sub-title flex align-center">
+                    <span class="coupon-icon">
+                        <i class="ic-md ic-coupon-md"></i>
+                    </span>
+                    <span class="coupon-info">Save up to US $35.00 on orders over US $400.00</span>
+                </p>
+                    <span>
+            <i class="ic-md ic-chevronright-md"></i>
+        </span>
+    </div>
+
+
+<amp-lightbox id="discounts-coupons-lb" class="float-wrap" layout="nodisplay" scrollable>
+
+    <header class="header-toolbar">
+        <span id="ms-close" class="ic-wp" tabindex="-1" role="button"
+        on="tap:discounts-coupons-lb.close">
+            <i class="ic-md ic-close-md"></i>
+        </span>
+        <p id="ms-title" class="ic-wp">
+            <span>Discounts & Coupons</span>
+        </p>
+    </header>
+
+    <div class="float-content">
+
+
+                <div class="store-coupon-wrap">
+            <h4 class="subtitle flex">
+                <i class="ic-md ic-seller-coupon-md"></i>
+                <span>Store Coupon</span>
+            </h4>
+
+            <ul class="coupon-content">
+                                <li>
+                    <p class="coupon-price">US $35.00</p>
+                    <p class="coupon-description">Spend US $400.00, Get US $35.00 off</p>
+                    <p class="coupon-expires">Expires 2018/05/17</p>
+                    <form id="coupon110310950" action="https://m.aliexpress.com/api/coupons/seller/assgin" action-xhr="https://m.aliexpress.com/api/coupons/seller/assgin" method="get" class="get-coupon" target="_top"
+                    on="submit-success:AMP.setState({
+                        u110310950: true,
+                        dialogContent: 'A coupon has been added to your account.'
+                    }),dialog.show,dialog-anima.start;
+                    submit-error:AMP.setState({
+                        dialogContent: 'Sorry, this coupon is no longer available'
+                    }),dialog.show,dialog-anima.start">
+
+                        <input type="hidden" name="activityId" value="110310950"/>
+                        <input type="hidden" name="sellerAdminSeq" value="120337986"/>
+
+                                                <a href="https://m.aliexpress.com/login.html" class="ellipsis">Get It Now</a>
+                                            </form>
+                </li>
+                                <li>
+                    <p class="coupon-price">US $15.00</p>
+                    <p class="coupon-description">Spend US $200.00, Get US $15.00 off</p>
+                    <p class="coupon-expires">Expires 2018/05/17</p>
+                    <form id="coupon110320069" action="https://m.aliexpress.com/api/coupons/seller/assgin" action-xhr="https://m.aliexpress.com/api/coupons/seller/assgin" method="get" class="get-coupon" target="_top"
+                    on="submit-success:AMP.setState({
+                        u110320069: true,
+                        dialogContent: 'A coupon has been added to your account.'
+                    }),dialog.show,dialog-anima.start;
+                    submit-error:AMP.setState({
+                        dialogContent: 'Sorry, this coupon is no longer available'
+                    }),dialog.show,dialog-anima.start">
+
+                        <input type="hidden" name="activityId" value="110320069"/>
+                        <input type="hidden" name="sellerAdminSeq" value="120337986"/>
+
+                                                <a href="https://m.aliexpress.com/login.html" class="ellipsis">Get It Now</a>
+                                            </form>
+                </li>
+                                <li>
+                    <p class="coupon-price">US $6.00</p>
+                    <p class="coupon-description">Spend US $80.00, Get US $6.00 off</p>
+                    <p class="coupon-expires">Expires 2018/05/17</p>
+                    <form id="coupon110473049" action="https://m.aliexpress.com/api/coupons/seller/assgin" action-xhr="https://m.aliexpress.com/api/coupons/seller/assgin" method="get" class="get-coupon" target="_top"
+                    on="submit-success:AMP.setState({
+                        u110473049: true,
+                        dialogContent: 'A coupon has been added to your account.'
+                    }),dialog.show,dialog-anima.start;
+                    submit-error:AMP.setState({
+                        dialogContent: 'Sorry, this coupon is no longer available'
+                    }),dialog.show,dialog-anima.start">
+
+                        <input type="hidden" name="activityId" value="110473049"/>
+                        <input type="hidden" name="sellerAdminSeq" value="120337986"/>
+
+                                                <a href="https://m.aliexpress.com/login.html" class="ellipsis">Get It Now</a>
+                                            </form>
+                </li>
+                                <li>
+                    <p class="coupon-price">US $20.00</p>
+                    <p class="coupon-description">Spend US $300.00, Get US $20.00 off</p>
+                    <p class="coupon-expires">Expires 2018/05/17</p>
+                    <form id="coupon110542065" action="https://m.aliexpress.com/api/coupons/seller/assgin" action-xhr="https://m.aliexpress.com/api/coupons/seller/assgin" method="get" class="get-coupon" target="_top"
+                    on="submit-success:AMP.setState({
+                        u110542065: true,
+                        dialogContent: 'A coupon has been added to your account.'
+                    }),dialog.show,dialog-anima.start;
+                    submit-error:AMP.setState({
+                        dialogContent: 'Sorry, this coupon is no longer available'
+                    }),dialog.show,dialog-anima.start">
+
+                        <input type="hidden" name="activityId" value="110542065"/>
+                        <input type="hidden" name="sellerAdminSeq" value="120337986"/>
+
+                                                <a href="https://m.aliexpress.com/login.html" class="ellipsis">Get It Now</a>
+                                            </form>
+                </li>
+                            </ul>
+        </div>
+
+                <div class="fixedDiscount-coupon-wrap">
+            <h4 class="subtitle flex">
+                <i class="ic-md ic-seller-discount-md"></i>
+                <span>Seller Discount</span>
+            </h4>
+                                        <p>US $1.00 off per US $14.00</p>
+                            <p>US $2.00 off per US $27.00</p>
+                            <p>US $4.00 off per US $50.00</p>
+                    </div>
+            </div>
+</amp-lightbox>
+                                <div class="detail-free-shipping " on="tap:shipping-lb" tabindex="-1" role="button">
+    <h3 class="detail-block-title"
+    [text]="detailSkuState.shipPrice > 0 ? 'Shipping: ' + detailSkuState.shipPriceFormatedAmount : 'Free shipping '">
+                    Free shipping
+            </h3>
+                    <p class="detail-sub-title">
+            To <span [text]="detailSkuState.countryName">United States</span> via <span [text]="detailSkuState.shipCompany">Seller's Shipping Method</span>
+        </p>
+        <span>
+        <i class="ic-md ic-chevronright-md"></i>
+    </span>
+</div>
+
+<amp-lightbox id="shipping-lb" class="float-wrap" layout="nodisplay" scrollable>
+    <header class="header-toolbar">
+        <span id="ms-close" class="ic-wp" tabindex="-1" role="button" on="tap:shipping-lb.close">
+            <i class="ic-md ic-close-md"></i>
+        </span>
+        <p id="ms-title" class="ic-wp">
+            <span>Shipping</span>
+        </p>
+    </header>
+
+    <div class="float-content">
+        <div class="ship-to flex align-center justify-space-between" on="tap:country-lb" tabindex="-1" role="button">
+            <span>Ship to</span>
+            <span class="country-flag c_US" [class]="'country-flag ' + 'c_' + detailSkuState.countryCode"></span>
+        </div>
+
+        <div class="ship-quantity flex justify-space-between">
+            <div>
+                <span>Quantity </span>
+                <span class="stock-num"
+                    [text]="skuPriceList[detailSkuState.curPropertyIds.join('')].skuStock ? skuPriceList[detailSkuState.curPropertyIds.join('')].skuStock : 670"
+                >670</span>
+                <span>available</span>
+            </div>
+            <div class="stock-form">
+                <button [disabled]="detailSkuState.skuquantity > 1 ? false : true"
+                on="tap:AMP.setState({
+                    detailSkuState: {
+                        skuquantity: detailSkuState.skuquantity - 1 > 0 ? detailSkuState.skuquantity - 1 : 1,
+                    }
+                })"> - </button>
+
+                <input type="number" class="quantity" value="1" [value]="detailSkuState.skuquantity || 1"
+                on="change:AMP.setState({
+                    detailSkuState: {
+                                                    skuquantity: event.valueAsNumber <= (skuPriceList[detailSkuState.curPropertyIds.join('')].skuStock || 670) ? event.valueAsNumber : (skuPriceList[detailSkuState.curPropertyIds.join('')].skuStock || 670)
+                                            }
+                })"/>
+
+                <button
+                                    [disabled]="detailSkuState.skuquantity < (skuPriceList[detailSkuState.curPropertyIds.join('')].skuStock || 670) ? false : true"
+                                on="tap:AMP.setState({
+                    detailSkuState:{
+                                                    skuquantity: detailSkuState.skuquantity + 1 <= (skuPriceList[detailSkuState.curPropertyIds.join('')].skuStock || 670) ? detailSkuState.skuquantity + 1 : detailSkuState.skuquantity
+                                            }
+                })"> + </button>
+            </div>
+        </div>
+
+        <div class="ship-method-wrap">
+            <h4 class="subtitle ms-border-bottom flex">Shipping Methods</h4>
+            <amp-list layout="fill" class="fill-list" single-item="data" items="data" width="auto" height="400" noloading src="https://m.aliexpress.com/api/products/32751800685/fees"
+            [src]="'https://m.aliexpress.com/api/products/32751800685/fees?count=' + detailSkuState.skuquantity + '&country=' + detailSkuState.countryCode + '&sendGoodsCountry=' + detailSkuState.SendGoodsCountryCode">
+                <template type="amp-mustache">
+                    <ul class="ship-method-content">
+                        <li class="flex align-center">
+                            <span class="flex align-center justify-center">Delivery Time  (days)</span>
+                            <span class="flex align-center justify-center">Shipping Cost</span>
+                            <span class="flex align-center justify-center">Tracking</span>
+                            <span class="flex align-center justify-center">Carrier</span>
+                        </li>
+                        {{#freightResult}}
+                        <li class="flex align-center">
+                            <span class="flex align-center justify-center">{{time}}</span>
+                            <span class="flex align-center justify-center">{{freightAmount.formatedAmount}}</span>
+                            <span [class]="{{tracking}} ? 'right flex align-center justify-center' : 'no-right flex align-center justify-center'">
+                                <i [class]="{{tracking}} ? 'ic-md ic-right-md' : 'ic-md ic-cross-md'"></i>
+                            </span>
+                            <span class="flex align-center justify-center">{{company}}</span>
+                            <span class="ship-check-button flex justify-center align-center" tabindex="-1" role="button"
+                            on='tap:AMP.setState({
+                                    tempShipstate:{
+                                        shipPrice: {{freightAmount.value}},
+                                        shipPriceFormatedAmount: "{{freightAmount.formatedAmount}}",
+                                        shipCompany: "{{company}}"
+                                    },
+                                    detailSkuState: {
+                                        logisticsCompany: "{{serviceName}}"
+                                    }
+                                })'>
+                                <input type="radio" name="ship-method" [checked]="detailSkuState.logisticsCompany == '{{serviceName}}' ? true : false">
+                                <span></span>
+                            </span>
+                        </li>
+                        {{/freightResult}}
+                        {{^freightResult}}
+                        <li>
+                            <p>
+                                Unable to ship your selected address. Use the Filter on the list page to choose the product which can be ship to your country.
+                            </p>
+                        </li>
+                        {{/freightResult}}
+                    </ul>
+                </template>
+            </amp-list>
+        </div>
+    </div>
+
+    <div class="apply-button-wrap flex justify-end">
+        <span class="apply-button" tabindex="-1" role="button"
+        on="tap:AMP.setState({
+            detailSkuState:{
+                shipPrice: tempShipstate.shipPrice != null ? tempShipstate.shipPrice : detailSkuState.shipPrice,
+                shipPriceFormatedAmount: tempShipstate.shipPriceFormatedAmount || detailSkuState.shipPriceFormatedAmount,
+                shipCompany: tempShipstate.shipCompany || detailSkuState.shipCompany
+            }
+        }),shipping-lb.close">Apply</span>
+    </div>
+
+</amp-lightbox>
+
+<amp-lightbox id="country-lb" class="float-wrap" layout="nodisplay" scrollable>
+    <header class="header-toolbar">
+        <span id="ms-close" class="ic-wp" on="tap:country-lb.close" tabindex="-1" role="button">
+            <i class="ic-md ic-close-md"></i>
+        </span>
+        <p id="ms-title" class="ic-wp">
+            <span>Ship to</span>
+        </p>
+    </header>
+    <div class="float-content">
+        <ul>
+            <li class="country-group flex align-center">Popular Countries</li>
+                                                <li tabindex="-1" role="button" on="tap:AMP.setState({
+                        detailSkuState: {
+                            countryCode: 'US',
+                            countryName: 'United States'
+                        }
+                    }),country-lb.close" class="country-item flex align-center">
+                        <span class="country-flag c_US"></span>
+                        <span class="country-name">United States</span>
+                        <span class="ship-check-button flex justify-center">
+                            <input type="radio" name="ship-country">
+                            <span></span>
+                        </span>
+                    </li>
+                                    <li tabindex="-1" role="button" on="tap:AMP.setState({
+                        detailSkuState: {
+                            countryCode: 'RU',
+                            countryName: 'Russian Federation'
+                        }
+                    }),country-lb.close" class="country-item flex align-center">
+                        <span class="country-flag c_RU"></span>
+                        <span class="country-name">Russian Federation</span>
+                        <span class="ship-check-button flex justify-center">
+                            <input type="radio" name="ship-country">
+                            <span></span>
+                        </span>
+                    </li>
+                                    <li tabindex="-1" role="button" on="tap:AMP.setState({
+                        detailSkuState: {
+                            countryCode: 'ES',
+                            countryName: 'Spain'
+                        }
+                    }),country-lb.close" class="country-item flex align-center">
+                        <span class="country-flag c_ES"></span>
+                        <span class="country-name">Spain</span>
+                        <span class="ship-check-button flex justify-center">
+                            <input type="radio" name="ship-country">
+                            <span></span>
+                        </span>
+                    </li>
+                                    <li tabindex="-1" role="button" on="tap:AMP.setState({
+                        detailSkuState: {
+                            countryCode: 'FR',
+                            countryName: 'France'
+                        }
+                    }),country-lb.close" class="country-item flex align-center">
+                        <span class="country-flag c_FR"></span>
+                        <span class="country-name">France</span>
+                        <span class="ship-check-button flex justify-center">
+                            <input type="radio" name="ship-country">
+                            <span></span>
+                        </span>
+                    </li>
+                                    <li tabindex="-1" role="button" on="tap:AMP.setState({
+                        detailSkuState: {
+                            countryCode: 'UK',
+                            countryName: 'United Kingdom'
+                        }
+                    }),country-lb.close" class="country-item flex align-center">
+                        <span class="country-flag c_UK"></span>
+                        <span class="country-name">United Kingdom</span>
+                        <span class="ship-check-button flex justify-center">
+                            <input type="radio" name="ship-country">
+                            <span></span>
+                        </span>
+                    </li>
+                                    <li tabindex="-1" role="button" on="tap:AMP.setState({
+                        detailSkuState: {
+                            countryCode: 'BR',
+                            countryName: 'Brazil'
+                        }
+                    }),country-lb.close" class="country-item flex align-center">
+                        <span class="country-flag c_BR"></span>
+                        <span class="country-name">Brazil</span>
+                        <span class="ship-check-button flex justify-center">
+                            <input type="radio" name="ship-country">
+                            <span></span>
+                        </span>
+                    </li>
+                                    <li tabindex="-1" role="button" on="tap:AMP.setState({
+                        detailSkuState: {
+                            countryCode: 'IL',
+                            countryName: 'Israel'
+                        }
+                    }),country-lb.close" class="country-item flex align-center">
+                        <span class="country-flag c_IL"></span>
+                        <span class="country-name">Israel</span>
+                        <span class="ship-check-button flex justify-center">
+                            <input type="radio" name="ship-country">
+                            <span></span>
+                        </span>
+                    </li>
+                                    <li tabindex="-1" role="button" on="tap:AMP.setState({
+                        detailSkuState: {
+                            countryCode: 'NL',
+                            countryName: 'Netherlands'
+                        }
+                    }),country-lb.close" class="country-item flex align-center">
+                        <span class="country-flag c_NL"></span>
+                        <span class="country-name">Netherlands</span>
+                        <span class="ship-check-button flex justify-center">
+                            <input type="radio" name="ship-country">
+                            <span></span>
+                        </span>
+                    </li>
+                                    <li tabindex="-1" role="button" on="tap:AMP.setState({
+                        detailSkuState: {
+                            countryCode: 'CA',
+                            countryName: 'Canada'
+                        }
+                    }),country-lb.close" class="country-item flex align-center">
+                        <span class="country-flag c_CA"></span>
+                        <span class="country-name">Canada</span>
+                        <span class="ship-check-button flex justify-center">
+                            <input type="radio" name="ship-country">
+                            <span></span>
+                        </span>
+                    </li>
+                                    <li tabindex="-1" role="button" on="tap:AMP.setState({
+                        detailSkuState: {
+                            countryCode: 'IT',
+                            countryName: 'Italy'
+                        }
+                    }),country-lb.close" class="country-item flex align-center">
+                        <span class="country-flag c_IT"></span>
+                        <span class="country-name">Italy</span>
+                        <span class="ship-check-button flex justify-center">
+                            <input type="radio" name="ship-country">
+                            <span></span>
+                        </span>
+                    </li>
+                                    <li tabindex="-1" role="button" on="tap:AMP.setState({
+                        detailSkuState: {
+                            countryCode: 'CL',
+                            countryName: 'Chile'
+                        }
+                    }),country-lb.close" class="country-item flex align-center">
+                        <span class="country-flag c_CL"></span>
+                        <span class="country-name">Chile</span>
+                        <span class="ship-check-button flex justify-center">
+                            <input type="radio" name="ship-country">
+                            <span></span>
+                        </span>
+                    </li>
+                                    <li tabindex="-1" role="button" on="tap:AMP.setState({
+                        detailSkuState: {
+                            countryCode: 'UA',
+                            countryName: 'Ukraine'
+                        }
+                    }),country-lb.close" class="country-item flex align-center">
+                        <span class="country-flag c_UA"></span>
+                        <span class="country-name">Ukraine</span>
+                        <span class="ship-check-button flex justify-center">
+                            <input type="radio" name="ship-country">
+                            <span></span>
+                        </span>
+                    </li>
+                                    <li tabindex="-1" role="button" on="tap:AMP.setState({
+                        detailSkuState: {
+                            countryCode: 'PL',
+                            countryName: 'Poland'
+                        }
+                    }),country-lb.close" class="country-item flex align-center">
+                        <span class="country-flag c_PL"></span>
+                        <span class="country-name">Poland</span>
+                        <span class="ship-check-button flex justify-center">
+                            <input type="radio" name="ship-country">
+                            <span></span>
+                        </span>
+                    </li>
+                                    <li tabindex="-1" role="button" on="tap:AMP.setState({
+                        detailSkuState: {
+                            countryCode: 'AU',
+                            countryName: 'Australia'
+                        }
+                    }),country-lb.close" class="country-item flex align-center">
+                        <span class="country-flag c_AU"></span>
+                        <span class="country-name">Australia</span>
+                        <span class="ship-check-button flex justify-center">
+                            <input type="radio" name="ship-country">
+                            <span></span>
+                        </span>
+                    </li>
+                                    <li tabindex="-1" role="button" on="tap:AMP.setState({
+                        detailSkuState: {
+                            countryCode: 'DE',
+                            countryName: 'Germany'
+                        }
+                    }),country-lb.close" class="country-item flex align-center">
+                        <span class="country-flag c_DE"></span>
+                        <span class="country-name">Germany</span>
+                        <span class="ship-check-button flex justify-center">
+                            <input type="radio" name="ship-country">
+                            <span></span>
+                        </span>
+                    </li>
+                                    <li tabindex="-1" role="button" on="tap:AMP.setState({
+                        detailSkuState: {
+                            countryCode: 'BE',
+                            countryName: 'Belgium'
+                        }
+                    }),country-lb.close" class="country-item flex align-center">
+                        <span class="country-flag c_BE"></span>
+                        <span class="country-name">Belgium</span>
+                        <span class="ship-check-button flex justify-center">
+                            <input type="radio" name="ship-country">
+                            <span></span>
+                        </span>
+                    </li>
+                                    </ul>
+        <amp-list layout="fixed-height" items="data" width="auto" height="800" noloading
+        src="https://m.aliexpress.com/api/countries/sorted">
+            <template type="amp-mustache">
+                <ul>
+                    <li class="country-group flex align-center">{{group}}</li>
+                    {{#countryList}}
+                        <li tabindex="-1" role="button" on="tap:AMP.setState({
+                            detailSkuState: {
+                                countryCode: '{{code}}',
+                                countryName: '{{name}}'
+                            }
+                        }),country-lb.close" class="country-item flex align-center">
+                            <span class="country-flag c_{{code}}"></span>
+                            <span class="country-name">{{name}}</span>
+                            <span class="ship-check-button flex justify-center">
+                                <input type="radio" name="ship-country">
+                                <span></span>
+                            </span>
+                        </li>
+                    {{/countryList}}
+                </ul>
+            </template>
+        </amp-list>
+    </div>
+</amp-lightbox>
+        </section>
+
+                    <section class="ms-block">
+                                    <div class="detail-sku" tabindex="-1" role="button"
+    on="tap:AMP.setState({
+        resetInputState: 'o'
+    }),detail-sku-lb">
+                            <h3 class="detail-block-title">
+                                    Metal Color                            </h3>
+            <p class="detail-sub-title" [text]="detailSkuState.skuProperty.filter(item => item != null).join(' ') || '
+                            Metal Color            '"></p>
+                <span>Select</span>
+    </div>
+<amp-lightbox id="detail-sku-lb" class="float-wrap" layout="nodisplay" scrollable>
+    <header class="header-toolbar">
+        <span id="ms-close" class="ic-wp" tabindex="-1" role="button" on="tap:detail-sku-lb.close">
+            <i class="ic-md ic-close-md"></i>
+        </span>
+        <p id="ms-title" class="ic-wp">
+            <span>product options </span>
+        </p>
+    </header>
+
+    <div class="float-content">
+        <div class="sku-carousel-wrap">
+            <amp-carousel width="auto" height="300" id="sku-carousel" layout="fixed-height" type="slides">
+
+                                    <amp-img src="https://ae01.alicdn.com/kf/HTB1zvRtSFXXXXX1aXXXq6xXFXXXO/SMJEL-Fashion-Trendy-Open-Leaf-Cuff-Bracelet-Bangles-for-Women-Simple-Plant-Bracelet-Femme-Boho-Jewelry.jpg" width="70vw" height="70vw"></amp-img>
+                                        </amp-carousel>
+        </div>
+
+        <p class="sku-price"
+            [text]="skuPriceList[detailSkuState.curPropertyIds.join('')].skuAmount ? skuPriceList[detailSkuState.curPropertyIds.join('')].skuAmount : 'US $1.79'">
+            US $1.79
+        </p>
+
+                                    <h3 class="detail-block-title sku-property-title" [text]="detailSkuState.skuProperty[0] ? 'Metal Color ' + detailSkuState.skuProperty[0] : 'Metal Color'">
+                    Metal Color
+                </h3>
+
+                                                                                                        <ul class="other-list property-list">
+
+                                                                                                                    <li tabindex="-1" role="button" on="tap:AMP.setState({
+                            detailSkuState: {
+                                curPropertyIds: detailSkuState.curPropertyIds.map((item,index) => index == 0 ? 'u361188' : item),
+                                                                    skuProperty: detailSkuState.skuProperty.map((item,index) => index == 0 ? '925 silver' : item),
+                                                                                                skuquantity: 1
+                            }
+                        })">
+                            <input type="radio" name="sku-Metal Color"
+                            on="change:AMP.setState({
+                                cid: cid.map((item,index) => index == 0 ? 361188 : item)
+                            })"
+                            [checked]="curPropertyIds[0] == 361188 ? true : false"
+                            [disabled]="skuPropertyIdList.filter(item => cid.map((PropertyId,PropertyIndex) => PropertyIndex == 0 ? 361188 : PropertyId).filter(curPropertyId => item.includes(curPropertyId)).length == cid.map((PropertyId,PropertyIndex) => PropertyIndex == 0 ? 361188 : PropertyId).filter(item => item).length).length ? false : true">
+
+                                                            <span><span>925 silver</span></span>
+
+                        </li>
+                                                    </ul>
+
+                <div class="detail-quantity-wrap">
+            <h3 class="detail-block-title sku-property-title">Quantity </h3>
+            <div class="stock-form">
+                <button [disabled]="detailSkuState.skuquantity > 1 ? false : true"
+                    on="tap:AMP.setState({
+                        detailSkuState: {
+                            skuquantity: detailSkuState.skuquantity - 1 > 0 ? detailSkuState.skuquantity - 1 : 1,
+                        }
+                    })"> - </button>
+
+                <input type="number" class="quantity" value="1" [value]="detailSkuState.skuquantity || 1"
+                on="change:AMP.setState({
+                    detailSkuState: {
+                                                    skuquantity: event.valueAsNumber <= (skuPriceList[detailSkuState.curPropertyIds.join('')].skuStock || 670) ? event.valueAsNumber : (skuPriceList[detailSkuState.curPropertyIds.join('')].skuStock || 670)
+                                            }
+                })"/>
+
+                <button
+                                    [disabled]="detailSkuState.skuquantity < (skuPriceList[detailSkuState.curPropertyIds.join('')].skuStock || 670) ? false : true"
+                                    on="tap:AMP.setState({
+                        detailSkuState:{
+                                                            skuquantity: detailSkuState.skuquantity + 1 <= (skuPriceList[detailSkuState.curPropertyIds.join('')].skuStock || 670) ? detailSkuState.skuquantity + 1 : detailSkuState.skuquantity
+                                                    }
+                    })"> + </button>
+
+                <span class="stock-num"
+                    [text]="skuPriceList[detailSkuState.curPropertyIds.join('')].skuStock ? skuPriceList[detailSkuState.curPropertyIds.join('')].skuStock : 670"
+                >670</span>
+                <span>available</span>
+
+                            </div>
+        </div>
+
+                <div class="detail-free-shipping" on="tap:shipping-lb" tabindex="-1" role="button">
+                            <h3 class="detail-block-title"
+                [text]="detailSkuState.shipPrice > 0 ? 'Shipping: ' + detailSkuState.shipPriceFormatedAmount : 'Free shipping '">
+                    Free shipping
+                </h3>
+                                                        <p class="detail-sub-title">
+                    To <span [text]="detailSkuState.countryName">United States</span> via <span [text]="detailSkuState.shipCompany">Seller's Shipping Method</span>
+                </p>
+                        <span>
+                <i class="ic-md ic-chevronright-md"></i>
+            </span>
+        </div>
+    </div>
+
+        <div class="detail-action-bar flex justify-end fixed-tool-bar  " >
+
+                <span class="add-to-cart">
+                                        <button type="button" class="sku-submit-button" [class]="skuPriceList[detailSkuState.curPropertyIds.join('')].skuAttr ? 'show-button sku-submit-button' : 'sku-submit-button'"
+                on="tap:add-cart.submit">
+                    <span  class="copy">Add to cart </span>
+                </button>
+                                    <button type="button" class="sku-float-button" [class]="skuPriceList[detailSkuState.curPropertyIds.join('')].skuAttr ? 'hide-button sku-float-button' : 'sku-float-button'"
+                    on="tap:AMP.setState({
+                        dialogContent:  'Please select product options first'
+                    }),dialog.show,dialog-anima.start">
+                        <span  class="copy">Add to cart </span>
+                    </button>
+                                    </span>
+
+                <a href="https://m.aliexpress.com/login.html" class="buy-now">
+            <span class="copy">Buy now </span>
+        </a>
+    </div>
+
+
+
+</amp-lightbox>
+
+
+                    <amp-state id="skuPriceList">
+    <script type="application/json">
+                {
+            "u361188": {"skuAttr": "200001034:361188#925 silver","skuStock": "900","skuAmount": "US $1.79"}
+        }
+    </script>
+</amp-state>
+
+<amp-state id="skuPropertyIdList">
+    <script type="application/json">
+        [
+            [361188]
+        ]
+    </script>
+</amp-state>
+
+
+<amp-state id="detailSkuState">
+    <script type="application/json">
+        {
+            "skuquantity": 1,
+            "logisticsCompany": "Other",
+            "countryCode": "US",
+            "countryName": "United States",
+            "shipPrice": "0.0",
+            "shipPriceFormatedAmount": "US $0.00",
+            "shipCompany": "Seller's Shipping Method",
+            "curPropertyIds": [null],
+            "skuProperty": [null],
+            "SendGoodsCountryCode": ""
+        }
+    </script>
+</amp-state>
+<amp-state id="cid">
+    <script type="application/json">
+        [
+            null
+        ]
+    </script>
+</amp-state>
+                                <div class="detail-action-bar flex justify-end  " >
+            <a href="https://m.aliexpress.com/store/storeHome.htm?sellerAdminSeq=120337986" class="detail-store-link"><i class="ic-md ic-store-md"></i></a>
+
+                <span class="add-to-cart">
+                                        <button type="button" class="sku-submit-button" [class]="skuPriceList[detailSkuState.curPropertyIds.join('')].skuAttr ? 'show-button sku-submit-button' : 'sku-submit-button'"
+                on="tap:add-cart.submit">
+                    <span  class="copy">Add to cart </span>
+                </button>
+                                    <button type="button" class="sku-float-button" [class]="skuPriceList[detailSkuState.curPropertyIds.join('')].skuAttr ? 'hide-button sku-float-button' : 'sku-float-button'"
+                    on="tap:detail-sku-lb">
+                        <span  class="copy">Add to cart </span>
+                    </button>
+                                    </span>
+
+                <a href="https://m.aliexpress.com/login.html" class="buy-now">
+            <span class="copy">Buy now </span>
+        </a>
+    </div>
+
+        <form id="add-cart" action-xhr="https://m.aliexpress.com/api/products/32751800685/cart/add" target="_top" method="POST" hidden
+    on="submit-success:AMP.setState({
+        dialogContent: 'Item Added to Cart'
+    }),detail-sku-lb.close,dialog.show,dialog-anima.start;
+    submit-error:AMP.setState({
+        dialogContent: event.response.message
+    }),detail-sku-lb">
+        <input type="hidden" name="_csrf_token_" value="124_ro0xv81b7"/>
+        <input type="hidden" name="productId" value="32751800685">
+        <input type="hidden" name="logisticsCompany" value="Other" [value]="detailSkuState.logisticsCompany || 'Other'">
+        <input type="hidden" name="productCount" value="1" [value]="detailSkuState.skuquantity || 1">
+        <input type="hidden" name="shipToCountry" value="US" [value]="detailSkuState.countryCode || 'US'">
+        <input type="hidden" name="skuAttr" value="200001034:361188#925 silver" [value]="skuPriceList[detailSkuState.curPropertyIds.join('')].skuAttr || '200001034:361188#925 silver'">
+    </form>
+
+        <form id="buy-now" action="https://m.aliexpress.com/order/createNewOrderForCombine.htm" method="GET" target="_top" hidden>
+        <input type="hidden" name="_csrf_token_" value="124_ro0xv81b7">
+        <input type="hidden" name="productId" value="32751800685">
+        <input type="hidden" name="sellerAdminSeq" value="120337986">
+        <input type="hidden" name="logisticsCompany" value="Other" [value]="detailSkuState.logisticsCompany || 'Other'">
+        <input type="hidden" name="quantity" value="1" [value]="detailSkuState.skuquantity || 1">
+        <input type="hidden" name="country" value="US" [value]="detailSkuState.countryCode || 'US'">
+        <input type="hidden" name="skuAttr" value="200001034:361188#925 silver" [value]="skuPriceList[detailSkuState.curPropertyIds.join('')].skuAttr || '200001034:361188#925 silver'">
+
+            </form>
+                                                    <div class="detail-action-bar flex justify-end fixed-tool-bar   hide " id="fixed-tool-bar">
+            <a href="https://m.aliexpress.com/store/storeHome.htm?sellerAdminSeq=120337986" class="detail-store-link"><i class="ic-md ic-store-md"></i></a>
+
+                <span class="add-to-cart">
+                                        <button type="button" class="sku-submit-button" [class]="skuPriceList[detailSkuState.curPropertyIds.join('')].skuAttr ? 'show-button sku-submit-button' : 'sku-submit-button'"
+                on="tap:add-cart.submit">
+                    <span  class="copy">Add to cart </span>
+                </button>
+                                    <button type="button" class="sku-float-button" [class]="skuPriceList[detailSkuState.curPropertyIds.join('')].skuAttr ? 'hide-button sku-float-button' : 'sku-float-button'"
+                    on="tap:detail-sku-lb">
+                        <span  class="copy">Add to cart </span>
+                    </button>
+                                    </span>
+
+                <a href="https://m.aliexpress.com/login.html" class="buy-now">
+            <span class="copy">Buy now </span>
+        </a>
+    </div>
+
+
+                                            </section>
+
+
+
+    <section class="ms-block">
+
+        <div class="feedback-wrap">
+            <h3 class="detail-block-title">Feedback (708)</h3>
+                            <ul class="feedback-imgs feedback-featured-img flex thumbnails-wrap" tabindex="-1" role="button"
+                on="tap:AMP.setState({
+                    filterCode: 'image'
+                }),feedback-form.submit,feedback-lb,feedback-submit-button.hide,feedback-data-loading.show">
+                                                                        <li>
+                                <span><span>
+                                    <amp-img src="//ae01.alicdn.com/kf/UTB8KieMxVfFXKJk43Otq6xIPFXaT.jpg_220x220.jpg" layout="fill" class="cover"></amp-img>
+                                </span></span>
+                            </li>
+                                                                                                <li>
+                                <span><span>
+                                    <amp-img src="//ae01.alicdn.com/kf/UTB8Se4HwRahduJk43Jaq6zM8FXaM.jpg_220x220.jpg" layout="fill" class="cover"></amp-img>
+                                </span></span>
+                            </li>
+                                                                                                <li>
+                                <span><span>
+                                    <amp-img src="//ae01.alicdn.com/kf/UTB8ut4KwlahduJk43Jaq6zM8FXa3.jpg_220x220.jpg" layout="fill" class="cover"></amp-img>
+                                </span></span>
+                            </li>
+                                                                                                <li>
+                                <span><span>
+                                    <amp-img src="//ae01.alicdn.com/kf/UTB8SQ8nrarFXKJk43Ovq6ybnpXav.jpg_220x220.jpg" layout="fill" class="cover"></amp-img>
+                                </span></span>
+                            </li>
+                                                                                                <li>
+                                <span><span>
+                                    <amp-img src="//ae01.alicdn.com/kf/UTB8a5W0tiDEXKJk43Oqq6Az3XXag.jpg_220x220.jpg" layout="fill" class="cover"></amp-img>
+                                </span></span>
+                            </li>
+                                                                <li>
+                        <span><span class="image-totalnum">
+                            <span>+ 49</span>
+                        </span></span>
+                    </li>
+                </ul>
+                                    <div class="feedback-info">
+                                <p class="feedback-star">
+                    <span class="star-rank">
+                        <span class="ms-star-bottom"></span>
+                        <span class="ms-star-top w100"></span>
+                    </span>
+                </p>
+                                <p class="feedback-info-buyer">
+                    <span>J***l</span>
+                    <span class="country-flag c_PL"></span>
+                    <span>04 May 2018</span>
+                </p>
+                                <p class="feedback-info-sku">
+                    <span>Metal Color:925 silver </span>
+                    <span></span>
+                    <span></span>
+                </p>
+                                                <p class="feedback-info-description">presents the better than i expected. is very nice</p>
+                                                                                                                                                                                                                                                                                                            <span class="detail-action-button" [hidden]="hideFeedBtn"
+                on="tap:AMP.setState({
+                    filterCode: 'all',
+                    hideFeedBtn: true
+                }),feedback-form.submit,feedback-lb,feedback-submit-button.hide,feedback-data-loading.show">View More</span>
+                <span class="detail-action-button" hidden [hidden]="!hideFeedBtn"
+                on="tap:AMP.setState({
+                    filterCode: 'all'
+                }),feedback-lb">View More</span>
+            </div>
+        </div>
+    </section>
+
+    <amp-lightbox id="feedback-lb" class="float-wrap" layout="nodisplay" scrollable>
+        <header class="header-toolbar">
+            <span id="ms-close" class="ic-wp" tabindex="-1" role="button"
+            on="tap:feedback-lb.close">
+                <i class="ic-md ic-close-md"></i>
+            </span>
+            <p id="ms-title" class="ic-wp">
+                <span>Feedback</span>
+            </p>
+        </header>
+
+        <div class="float-content">
+            <div class="rating-wrap flex align-center">
+                <div class="rating-summary">
+                    <div class="rating-score">
+                        <span [text]="feedbackData.productEvaluationStatistic.evarageStar || 0">0</span>/5
+                    </div>
+                    <div class="rating-total" [text]="feedbackData.productEvaluationStatistic.totalNum != null ? feedbackData.productEvaluationStatistic.totalNum + ' ratings' : '0 ratings'">0 ratings</div>
+                </div>
+
+                <div class="rating-detail">
+                    <p class="flex">
+                        <span class="rating-star">5</span>
+                        <span class="rating-progress-wrap">
+                            <span class="rating-progress-content" [class]="feedbackData.productEvaluationStatistic.fiveStarRate != null ? 'rating-progress-content w' + feedbackData.productEvaluationStatistic.fiveStarRate.toFixed() : 'rating-progress-content'"></span>
+                        </span>
+                        <span class="rating-star-number" [text]="feedbackData.productEvaluationStatistic.fiveStarNum || 0">0</span>
+                    </p>
+                    <p class="flex">
+                        <span class="rating-star">4</span>
+                        <span class="rating-progress-wrap">
+                            <span class="rating-progress-content" [class]="feedbackData.productEvaluationStatistic.fourStarRate != null ? 'rating-progress-content w' + feedbackData.productEvaluationStatistic.fourStarRate.toFixed() : 'rating-progress-content'"></span>
+                        </span>
+                        <span class="rating-star-number" [text]="feedbackData.productEvaluationStatistic.fourStarNum || 0">0</span>
+                    </p>
+                    <p class="flex">
+                        <span class="rating-star">3</span>
+                        <span class="rating-progress-wrap">
+                            <span class="rating-progress-content" [class]="feedbackData.productEvaluationStatistic.threeStarRate != null ? 'rating-progress-content w' + feedbackData.productEvaluationStatistic.threeStarRate.toFixed() : 'rating-progress-content'"></span>
+                        </span>
+                        <span class="rating-star-number" [text]="feedbackData.productEvaluationStatistic.threeStarNum || 0">0</span>
+                    </p>
+                    <p class="flex">
+                        <span class="rating-star">2</span>
+                        <span class="rating-progress-wrap">
+                            <span class="rating-progress-content" [class]="feedbackData.productEvaluationStatistic.twoStarRate != null ? 'rating-progress-content w' + feedbackData.productEvaluationStatistic.twoStarRate.toFixed() : 'rating-progress-content'"></span>
+                        </span>
+                        <span class="rating-star-number" [text]="feedbackData.productEvaluationStatistic.twoStarNum || 0">0</span>
+                    </p>
+                    <p class="flex">
+                        <span class="rating-star">1</span>
+                        <span class="rating-progress-wrap">
+                            <span class="rating-progress-content" [class]="feedbackData.productEvaluationStatistic.oneStarRate != null ? 'rating-progress-content w' + feedbackData.productEvaluationStatistic.oneStarRate.toFixed() : 'rating-progress-content'"></span>
+                        </span>
+                        <span class="rating-star-number" [text]="feedbackData.productEvaluationStatistic.oneStarNum || 0">0</span>
+                    </p>
+                </div>
+            </div>
+
+            <ul class="feedback-select-list flex">
+                <li class="feedback-select-item flex align-center" [class]="filterCode == 'all' ? 'feedback-select-item active flex align-center' : 'feedback-select-item flex align-center'" tabindex="-1" role="button"
+                on="tap:AMP.setState({
+                    evaViewList: [],
+                    allImageListData: {
+                        allImageList: []
+                    },
+                    filterCode: 'all',
+                    feedBackListPage: 1
+                }),feedback-form.submit,feedback-submit-button.hide,feedback-data-loading.show">
+                    <i>ALL</i>
+                    <span [text]="feedbackData.filterInfo ? '(' + feedbackData.filterInfo.filterStatistic.filter(item => item.filterCode == 'all')[0].filterCount + ')' : '(0)'">(0)</span>
+                </li>
+                <li class="feedback-select-item flex align-center" [class]="filterCode == 'image' ? 'feedback-select-item active flex align-center' : 'feedback-select-item flex align-center'" tabindex="-1" role="button" on="tap:AMP.setState({
+                    evaViewList: [],
+                    allImageListData: {
+                        allImageList: []
+                    },
+                    filterCode: 'image',
+                    feedBackListPage: 1
+                }),feedback-form.submit,feedback-submit-button.hide,feedback-data-loading.show">
+                    <i class="ic-md ic-image-md"></i>
+                    <span [text]="feedbackData.filterInfo ? '(' + feedbackData.filterInfo.filterStatistic.filter(item => item.filterCode == 'image')[0].filterCount + ')' : '(0)'">(0)</span>
+                </li>
+                <li class="feedback-select-item flex align-center" [class]="filterCode == 'local' ? 'feedback-select-item active flex align-center' : 'feedback-select-item flex align-center'" tabindex="-1" role="button" on="tap:AMP.setState({
+                    evaViewList: [],
+                    allImageListData: {
+                        allImageList: []
+                    },
+                    filterCode: 'local',
+                    feedBackListPage: 1
+                }),feedback-form.submit,feedback-submit-button.hide,feedback-data-loading.show">
+                    <i class="country-flag" [class]="detailSkuState.countryCode ? 'country-flag c_' + detailSkuState.countryCode : 'country-flag'"></i>
+                    <span [text]="feedbackData.filterInfo ? '(' + feedbackData.filterInfo.filterStatistic.filter(item => item.filterCode == 'local')[0].filterCount + ')' : '(0)'">(0)</span>
+                </li>
+                <li class="feedback-select-item flex align-center" [class]="filterCode == 'additional' ? 'feedback-select-item active flex align-center' : 'feedback-select-item flex align-center'" tabindex="-1" role="button" on="tap:AMP.setState({
+                    evaViewList: [],
+                    allImageListData: {
+                        allImageList: []
+                    },
+                    filterCode: 'additional',
+                    feedBackListPage: 1
+                }),feedback-form.submit,feedback-submit-button.hide,feedback-data-loading.show">
+                    <i class="ic-md ic-reply-md"></i>
+                    <span [text]="feedbackData.filterInfo ? '(' + feedbackData.filterInfo.filterStatistic.filter(item => item.filterCode == 'additional')[0].filterCount + ')' : '(0)'">(0)</span>
+                </li>
+                <li class="feedback-select-item flex align-center" [class]="filterCode == 'with_personal' ? 'feedback-select-item active flex align-center' : 'feedback-select-item flex align-center'" tabindex="-1" role="button" on="tap:AMP.setState({
+                    evaViewList: [],
+                    allImageListData: {
+                        allImageList: []
+                    },
+                    filterCode: 'with_personal',
+                    feedBackListPage: 1
+                }),feedback-form.submit,feedback-submit-button.hide,feedback-data-loading.show">
+                    <i class="ic-md ic-size-md"></i>
+                    <span [text]="feedbackData.filterInfo ? '(' + feedbackData.filterInfo.filterStatistic.filter(item => item.filterCode == 'with_personal')[0].filterCount + ')' : '(0)'">(0)</span>
+                </li>
+                <li class="feedback-select-item flex align-center" [class]="filterCode == '5' ? 'feedback-select-item active flex align-center' : 'feedback-select-item flex align-center'" tabindex="-1" role="button" on="tap:AMP.setState({
+                    evaViewList: [],
+                    allImageListData: {
+                        allImageList: []
+                    },
+                    filterCode: '5',
+                    feedBackListPage: 1
+                }),feedback-form.submit,feedback-submit-button.hide,feedback-data-loading.show">
+                    <i class="rating-star">5</i>
+                </li>
+                <li class="feedback-select-item flex align-center" [class]="filterCode == '4' ? 'feedback-select-item active flex align-center' : 'feedback-select-item flex align-center'" tabindex="-1" role="button" on="tap:AMP.setState({
+                    evaViewList: [],
+                    allImageListData: {
+                        allImageList: []
+                    },
+                    filterCode: '4',
+                    feedBackListPage: 1
+                }),feedback-form.submit,feedback-submit-button.hide,feedback-data-loading.show">
+                    <i class="rating-star">4</i>
+                </li>
+                <li class="feedback-select-item flex align-center" [class]="filterCode == '3' ? 'feedback-select-item active flex align-center' : 'feedback-select-item flex align-center'" tabindex="-1" role="button" on="tap:AMP.setState({
+                    evaViewList: [],
+                    allImageListData: {
+                        allImageList: []
+                    },
+                    filterCode: '3',
+                    feedBackListPage: 1
+                }),feedback-form.submit,feedback-submit-button.hide,feedback-data-loading.show">
+                    <i class="rating-star">3</i>
+                </li>
+                <li class="feedback-select-item flex align-center" [class]="filterCode == '2' ? 'feedback-select-item active flex align-center' : 'feedback-select-item flex align-center'" tabindex="-1" role="button" on="tap:AMP.setState({
+                    evaViewList: [],
+                    allImageListData: {
+                        allImageList: []
+                    },
+                    filterCode: '2',
+                    feedBackListPage: 1
+                }),feedback-form.submit,feedback-submit-button.hide,feedback-data-loading.show">
+                    <i class="rating-star">2</i>
+                </li>
+                <li class="feedback-select-item flex align-center" [class]="filterCode == '1' ? 'feedback-select-item active flex align-center' : 'feedback-select-item flex align-center'" tabindex="-1" role="button" on="tap:AMP.setState({
+                    evaViewList: [],
+                    allImageListData: {
+                        allImageList: []
+                    },
+                    filterCode: '1',
+                    feedBackListPage: 1
+                }),feedback-form.submit,feedback-submit-button.hide,feedback-data-loading.show">
+                    <i class="rating-star">1</i>
+                </li>
+            </ul>
+
+            <amp-list layout="fill" class="fill-list" src="https://m.aliexpress.com/api/products/32751800685/feedbacks" [src]="evaViewList" noloading>
+
+                <template type="amp-mustache">
+                    <div class="feedback-wrap">
+                        <p class="feedback-star">
+                            <span class="star-rank">
+                                <span class="ms-star-bottom"></span>
+                                <span class="ms-star-top w{{buyerEval}}"></span>
+                            </span>
+                        </p>
+                        <p class="feedback-info-buyer">
+                            <span>{{buyerName}}</span>
+                            <span class="country-flag c_{{buyerCountry}}"></span>
+                            <span>{{evalDate}}</span>
+                        </p>
+                        <p class="feedback-info-sku">
+                            <span>{{skuInfo}}</span>
+                            <span>{{buyerPersonInfo}}</span>
+                            <span>{{buyerProductFeedBack}}</span>
+                        </p>
+                                                {{#buyerTranslationFeedback}}
+                            <p class="feedback-info-description">{{buyerTranslationFeedback}}</p>
+                        {{/buyerTranslationFeedback}}
+                                                {{^buyerTranslationFeedback}}
+                            <p class="feedback-info-description">{{buyerFeedback}}</p>
+                        {{/buyerTranslationFeedback}}
+                                                {{#thumbnails.length}}
+                            <ul class="feedback-imgs feedback-buyer-img flex">
+                            {{#thumbnails}}
+                                <li on="tap:AMP.setState({
+                                    curIndex: allImageListData.allImageList.map((item,index) => 'https:{{.}}'.indexOf(item) != -1 ? index : null).join('')
+                                }),feedback-big-images" tabindex="-1" role="button">
+                                    <span><span>
+                                        <amp-img layout="fill" class="cover" src="{{.}}"></amp-img>
+                                    </span></span>
+                                </li>
+                            {{/thumbnails}}
+                            </ul>
+                        {{/thumbnails.length}}
+                                                {{#buyerFbSellerReplyTranslation}}
+                            <p class="feedback-seller-reply"><span>Seller’s Reply: </span>{{buyerFbSellerReplyTranslation}}</p>
+                        {{/buyerFbSellerReplyTranslation}}
+                                                {{^buyerFbSellerReplyTranslation}}
+                            {{#sellerReply}}
+                                <p class="feedback-seller-reply"><span>Seller’s Reply: </span>{{sellerReply}}</p>
+                            {{/sellerReply}}
+                        {{/buyerFbSellerReplyTranslation}}
+                                                {{#buyerAddFbTranslation}}
+                            <p class="feedback-buyer-add-days" [text]="'Additional feedback after #num# days'.split('#num#')[0] + {{buyerAddFbDays}} + 'Additional feedback after #num# days'.split('#num#')[1]">
+                                Additional feedback after #num# days
+                            </p>
+                            <p class="feedback-info-description">{{buyerAddFbTranslation}}</p>
+                        {{/buyerAddFbTranslation}}
+                                                {{^buyerAddFbTranslation}}
+                            {{#buyerAddFbContent}}
+                                <p class="feedback-buyer-add-days" [text]="'Additional feedback after #num# days'.split('#num#')[0] + {{buyerAddFbDays}} + 'Additional feedback after #num# days'.split('#num#')[1]">
+                                    Additional feedback after #num# days
+                                </p>
+                                <p class="feedback-info-description">{{buyerAddFbContent}}</p>
+                            {{/buyerAddFbContent}}
+                        {{/buyerAddFbTranslation}}
+                                                {{#buyerAddFbThumbnails.length}}
+                            <ul class="feedback-imgs feedback-buyer-img flex">
+                                {{#buyerAddFbThumbnails}}
+                                    <li on="tap:AMP.setState({
+                                        curIndex: allImageListData.allImageList.map((item,index) => 'https:{{.}}'.indexOf(item) != -1 ? index : null).join('')
+                                    }),feedback-big-images" tabindex="-1" role="button">
+                                        <span><span>
+                                            <amp-img layout="fill" class="cover" src="{{.}}"></amp-img>
+                                        </span></span>
+                                    </li>
+                                {{/buyerAddFbThumbnails}}
+                            </ul>
+                        {{/buyerAddFbThumbnails.length}}
+                                                {{#buyerAddFbSellerReplyTranslation}}
+                            <p class="feedback-seller-reply"><span>Seller’s Reply: </span>{{buyerAddFbSellerReplyTranslation}}</p>
+                        {{/buyerAddFbSellerReplyTranslation}}
+                        {{^buyerAddFbSellerReplyTranslation}}
+                            {{#buyerAddFbSellerReplyContent}}
+                                <p class="feedback-seller-reply"><span>Seller’s Reply: </span>{{buyerAddFbSellerReplyContent}}</p>
+                            {{/buyerAddFbSellerReplyContent}}
+                        {{/buyerAddFbSellerReplyTranslation}}
+                    </div>
+                </template>
+            </amp-list>
+
+            <div class="show-more-button-wrap">
+                <button type="button" id="feedback-button" class="show-more-button" tabindex="-1" role="button"
+                [disabled]="feedbackData.currentPage >= feedbackData.totalPage ? true : false"
+                on="tap:feedback-form.submit, feedback-submit-button.hide,feedback-data-loading.show">
+                    <span id="feedback-submit-button">View More</span>
+                    <div class="md-loading" id="feedback-data-loading" hidden>
+                        <div class="preloader-wrapper active">
+                            <div class="spinner-layer spinner-red-only">
+                                <div class="circle-clipper left">
+                                    <div class="circle"></div>
+                                </div>
+                                <div class="gap-patch">
+                                    <div class="circle"></div>
+                                </div>
+                                <div class="circle-clipper right">
+                                    <div class="circle"></div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </button>
+            </div>
+
+            <form id="feedback-form" class="feedback-form" method="get" action="https://m.aliexpress.com/api/products/32751800685/feedbacks" target="_top" action-xhr="https://m.aliexpress.com/api/products/32751800685/feedbacks"
+            on="submit:AMP.setState({
+                feedBackListPage: (feedBackListPage || 1) + 1
+            });
+            submit-success:AMP.setState({
+                feedbackData: event.response.data,
+                evaViewList: evaViewList.concat(event.response.data.evaViewList),
+                allImageListData: {
+                    allImageList: allImageListData.allImageList.concat(event.response.data.allImageList)
+                }
+            }),feedback-submit-button.show,feedback-data-loading.hide;
+            submit-error:AMP.setState({
+                feedbackData: {
+                    currentPage: 1,
+                    totalPage: 1
+                }
+            }),feedback-submit-button.show,feedback-data-loading.hide">
+                <input type="hidden" name="page" value="1" [value]="feedBackListPage || 1"/>
+                <input type="hidden" name="filter" value="all" [value]="filterCode || ''"/>
+                <input type="hidden" name="country" value="US" [value]="detailSkuState.countryCode || 'US'"/>
+            </form>
+
+        </div>
+    </amp-lightbox>
+
+    <amp-lightbox id="feedback-big-images" layout="nodisplay">
+        <div class="feedback-close-button flex" on="tap:feedback-big-images.close" tabindex="-1" role="button">
+            <i class="ic-md ic-close-md"></i>
+        </div>
+        <amp-list layout="fill" src="https://m.aliexpress.com/api/products/32751800685/feedbacks" [src]="allImageListData" single-item="allImageListData" >
+            <template type="amp-mustache">
+                <div class="feedback-big-images-wrap">
+                <amp-carousel  id="feedback-big-images-carousel" width="450" height="450" layout="responsive" type="slides" controls [slide]="curIndex || 0">
+                    {{#allImageList}}
+                    <amp-img src="{{.}}" width="450" height="450" layout="responsive"></amp-img>
+                    {{/allImageList}}
+                </amp-carousel>
+                </div>
+            </template>
+        </amp-list>
+    </amp-lightbox>
+
+    <amp-state id="evaViewList">
+        <script type="application/json">
+        []
+        </script>
+    </amp-state>
+
+    <amp-state id="allImageListData">
+        <script type="application/json">
+        {
+            "allImageList": []
+        }
+        </script>
+    </amp-state>
+
+                    <section class="ms-block">
+        <div class="detail-qa-wrap">
+            <h3 class="detail-block-title">Questions & Answer (12)</h3>
+                        <ul class="detail-qa">
+                <li class="flex">
+                    <i class="ic-md ic-ask-md"></i>
+                    <span>
+                                                    extra income. or other intercropping декрете moms in work. only girls from 25. remotely, chart ☺пишите free
+ватсап 7 922 477 43 20.
+вайбер 66 7 961 780 44
+here can&#39;t reply
+                                            </span>
+                </li>
+                <li class="flex">
+                    <i class="ic-md ic-answer-md"></i>
+                    <span>
+                                                    ненужно
+                                            </span>
+                </li>
+            </ul>
+            <span [hidden]="hideQaBtn" class="detail-action-button" tabindex="-1" role="button"
+            on="tap:AMP.setState({
+                hideQaBtn: true
+            }),questions-answer-lb, qa-form.submit,qa-submit-button.hide,qa-data-loading.show">View More</span>
+            <span hidden [hidden]="!hideQaBtn" class="detail-action-button" tabindex="-1" role="button" on="tap:questions-answer-lb">View More</span>
+        </div>
+    </section>
+
+<amp-lightbox id="questions-answer-lb" class="float-wrap" layout="nodisplay" scrollable>
+    <header class="header-toolbar">
+        <span id="ms-close" class="ic-wp" tabindex="-1" role="button"
+        on="tap:questions-answer-lb.close">
+            <i class="ic-md ic-close-md"></i>
+        </span>
+        <p id="ms-title" class="ic-wp">
+            <span>Buyer Questions & Answers</span>
+        </p>
+    </header>
+
+    <div class="float-content">
+        <amp-list layout="fill" class="fill-list" src="https://m.aliexpress.com/api/products/32751800685/qas" [src]="productQuestionItemList || []" noloading >
+            <template type="amp-mustache">
+                <div class="qa-wrap">
+
+                    <p class="questioner-info">
+                        {{#question.user}}
+                            <span>{{question.user.name}}</span>
+                            <span class="country-flag c_{{question.user.country}}"></span>
+                        {{/question.user}}
+                    </p>
+
+                    <p class="qa-dete">{{question.question.gmtCreate}}</p>
+                    <p class="question-description">
+                        <span class="question-title">{{question.question.questionPrefix}}：</span>
+                        {{#question.question.translateContent}}{{question.question.translateContent}}{{/question.question.translateContent}}
+                        {{^question.question.translateContent}}{{question.question.content}}{{/question.question.translateContent}}
+                    </p>
+                    <p class="answer-title">{{question.answer.answerPrefix}}: </p>
+                    <ul class="answer-wrap" [class]="u{{question.question.id}} ? 'answer-wrap show-all-awser' : 'answer-wrap'">
+                    {{#questionDetail.answerList}}
+                        <li class="answer-item">
+                            <p class="qa-dete">{{answer.gmtCreate}}</p>
+                            <p class="answer-description">
+                                {{#answer.translateContent}}
+                                    {{answer.translateContent}}
+                                {{/answer.translateContent}}
+                                {{^answer.translateContent}}
+                                    {{answer.content}}
+                                {{/answer.translateContent}}
+                            </p>
+                        </li>
+                    {{/questionDetail.answerList}}
+                    </ul>
+                    {{#question.question.viewAllTip}}
+                    <span class="qa-button" tabindex="-1" role="button" on="tap:AMP.setState({
+                        u{{question.question.id}}: true
+                    })" [hidden]="u{{question.question.id}} || false">{{question.question.viewAllTip}}
+                        <i class="ic-md ic-arrowdown-md"></i>
+                    </span>
+                    {{/question.question.viewAllTip}}
+                </div>
+            </template>
+        </amp-list>
+
+        <div class="show-more-button-wrap">
+            <button type="button" id="qa-button" class="show-more-button" [disabled]="!qadata" tabindex="-1" role="button"
+            on="tap:qa-form.submit,qa-submit-button.hide,qa-data-loading.show">
+                <span id="qa-submit-button">View More</span>
+                <div class="md-loading" id="qa-data-loading" hidden>
+                    <div class="preloader-wrapper active">
+                        <div class="spinner-layer spinner-red-only">
+                            <div class="circle-clipper left">
+                                <div class="circle"></div>
+                            </div>
+                            <div class="gap-patch">
+                                <div class="circle"></div>
+                            </div>
+                            <div class="circle-clipper right">
+                                <div class="circle"></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </button>
+        </div>
+
+        <form id="qa-form" class="qa-form" method="get" action-xhr="https://m.aliexpress.com/api/products/32751800685/qas" action="https://m.aliexpress.com/api/products/32751800685/qas" target="_top"
+        on="submit-success:AMP.setState({
+            productQuestionItemList: event.response.data.productQuestionItemList.length > 0 ? productQuestionItemList.concat(event.response.data.productQuestionItemList) : productQuestionItemList,
+            qaListPage: (qaListPage || 1) + 1,
+            qadata: event.response.data.hasNextPage || false
+        }),qa-submit-button.show, qa-data-loading.hide;
+        submit-error:AMP.setState({
+            qadata: false
+        }),qa-submit-button.show, qa-data-loading.hide">
+            <input type="hidden" name="currentPage" value="1" [value]="qaListPage || 1"/>
+        </form>
+    </div>
+</amp-lightbox>
+
+<amp-state id="productQuestionItemList">
+    <script type="application/json">
+    []
+    </script>
+</amp-state>
+                <section class="ms-block">
+            <div class="detail-description-wrap">
+                <h3 class="detail-block-title">Item Description</h3>
+                                    <ul class="description-list"  [class]="descriptionShowMore ? 'description-list description-list-auto-height' : 'description-list '">
+                                                    <li class="description-item">
+                                <span class="ellipsis">Bracelets Type</span>
+                                <span class="ellipsis">Bangles</span>
+                            </li>
+                                                    <li class="description-item">
+                                <span class="ellipsis">Fine or Fashion</span>
+                                <span class="ellipsis">Fashion</span>
+                            </li>
+                                                    <li class="description-item">
+                                <span class="ellipsis">Compatibility</span>
+                                <span class="ellipsis">All Compatible</span>
+                            </li>
+                                                    <li class="description-item">
+                                <span class="ellipsis">Setting Type</span>
+                                <span class="ellipsis">None</span>
+                            </li>
+                                                    <li class="description-item">
+                                <span class="ellipsis">Model Number</span>
+                                <span class="ellipsis">SYSZ014</span>
+                            </li>
+                                                    <li class="description-item">
+                                <span class="ellipsis">Gender</span>
+                                <span class="ellipsis">Women</span>
+                            </li>
+                                                    <li class="description-item">
+                                <span class="ellipsis">Plating</span>
+                                <span class="ellipsis">Silver Plated</span>
+                            </li>
+                                                    <li class="description-item">
+                                <span class="ellipsis">Brand Name</span>
+                                <span class="ellipsis">SMJEL</span>
+                            </li>
+                                                    <li class="description-item">
+                                <span class="ellipsis">Style</span>
+                                <span class="ellipsis">Trendy</span>
+                            </li>
+                                                    <li class="description-item">
+                                <span class="ellipsis">Material</span>
+                                <span class="ellipsis">Metal</span>
+                            </li>
+                                                    <li class="description-item">
+                                <span class="ellipsis">Shape\pattern</span>
+                                <span class="ellipsis">Plant</span>
+                            </li>
+                                                    <li class="description-item">
+                                <span class="ellipsis">Metals Type</span>
+                                <span class="ellipsis">Copper</span>
+                            </li>
+                                                    <li class="description-item">
+                                <span class="ellipsis">Function</span>
+                                <span class="ellipsis">jewelry</span>
+                            </li>
+                                                    <li class="description-item">
+                                <span class="ellipsis">shape</span>
+                                <span class="ellipsis">leaf</span>
+                            </li>
+                                                    <li class="description-item">
+                                <span class="ellipsis">style</span>
+                                <span class="ellipsis">boho</span>
+                            </li>
+                                                    <li class="description-item">
+                                <span class="ellipsis">Eco-Friendly Material</span>
+                                <span class="ellipsis">lead&nickel free</span>
+                            </li>
+                                                    <li class="description-item">
+                                <span class="ellipsis">Wearing Accasion</span>
+                                <span class="ellipsis">Dating,Daily,Party</span>
+                            </li>
+                                                    <li class="description-item">
+                                <span class="ellipsis">material</span>
+                                <span class="ellipsis">925 silver</span>
+                            </li>
+                                                    <li class="description-item">
+                                <span class="ellipsis">sale way </span>
+                                <span class="ellipsis">retail/wholesale/dropshipping</span>
+                            </li>
+                                            </ul>
+                                                                <div class="description-show-button flex justify-center align-center" [class]="changeBgc ? 'description-show-button white-bg-color flex justify-center align-center' : 'description-show-button flex justify-center align-center'" tabindex="-1" role="button"
+                        on="tap:AMP.setState({
+                            descriptionShowMore: !descriptionShowMore,
+                                                        changeBgc: !changeBgc
+                                                    })">
+                            <i class="ic-md ic-arrowdown-md" [class]="descriptionShowMore ? 'ic-md ic-arrowup-md' : 'ic-md ic-arrowdown-md'"></i>
+                        </div>
+                                                                        <amp-iframe width="200" height="100" sandbox="allow-scripts allow-same-origin allow-popups" layout="responsive" frameborder="0" resizable src="https://aeproductsourcesite.alicdn.com/product/description/msite/v2/en_US/desc.htm?productId=32751800685&key=HTB1Nsriif9TBuNjy1zbM7NpepXac.zip&token=24e4accc6e60f19f746f9685c78eae85">
+                        <div overflow></div>
+                    </amp-iframe>
+                            </div>
+        </section>
+
+                            <section class="ms-block">
+                <div class="buyer-protection">
+                    <h3 class="detail-block-title">Buyer Protection</h3>
+                    <p>Returns accepted if product not as described, buyer pays return shipping fee; or keep the product & agree refund with seller.</p>
+                                        <p>On-time Delivery 60 days</p>
+                                        <p>Full refund if product isn&#39;t received in 60 days</p>
+                    <a href="https://sale.aliexpress.com/GMZRauYGbD.htm" class="detail-action-button">View Details</a>
+                </div>
+            </section>
+
+                <section class="ms-block">
+            <div class="stroe-info detail-wrap">
+                <h3 class="detail-block-title">Store Info</h3>
+                <p>SMJEL Official Store</p>
+                                                <p>98.6% Positive feedback</p>
+                <ul class="detail-sumary flex">
+                    <li class="sumary-items">
+                        <span>1374</span>
+                        <span>Items</span>
+                    </li>
+                    <li class="sumary-orders">
+                        <span>23258</span>
+                        <span>Orders</span>
+                    </li>
+                    <li class="sumary-wishlist">
+                        <span>11090</span>
+                        <span>Wish List</span>
+                    </li>
+                </ul>
+                <a href="https://m.aliexpress.com/store/storeHome.htm?sellerAdminSeq=120337986" class="detail-action-button">Go To Store</a>
+            </div>
+        </section>
+
+                <amp-list layout="fill" class="fill-list" items="." single-item="." noloading
+        src="https://gpsfront.aliexpress.com/getI2iRecommendingResults.do?scenario=storeRecommendH5&limit=4&offset=0&currentItemList=32751800685">
+            <template type="amp-mustache">
+            {{#results.length}}
+                <section class="ms-block">
+                    <amp-selector class="seller-recommendation" data-vars-page-area="seller_recommendations" data-vars-result-cnt="4" data-vars-page-size="4"
+                    data-vars-pin="{{pin}}" data-vars-product-id="{{#results}}item_id={{productId}}|{{/results}}">
+                        <h3 class="detail-block-title">Seller Recommendations</h3>
+                        <div class="detail-product-list flex">
+                            {{#results}}
+                            <div class="detail-product-item">
+                                <a href="{{productDetailUrl}}">
+                                    <amp-img src="{{productImage}}" alt="{{productTitle}}"
+                                    width="45" height="45" layout="responsive"></amp-img>
+                                    <h4>{{productTitle}}</h4>
+                                    <p>{{minPrice}}</p>
+                                </a>
+                            </div>
+                            {{/results}}
+                        </div>
+                        <amp-analytics config="https://m.aliexpress.com/api/stat/detail/async"></amp-analytics>
+                    </amp-selector>
+                </section>
+            {{/results.length}}
+            </template>
+        </amp-list>
+
+                <amp-list layout="fill" class="fill-list" items="." single-item="." noloading
+        src="https://gpsfront.aliexpress.com/getI2iRecommendingResults.do?scenario=platformRecommendH5&limit=6&offset=0&currentItemList=32751800685">
+            <template type="amp-mustache">
+                {{#results.length}}
+                    <section class="ms-block">
+                        <amp-selector class="more-to-love" data-vars-page-area="more_to_love" data-vars-result-cnt="6" data-vars-page-size="6" data-vars-pin="{{pin}}"
+                        data-vars-product-id="{{#results}}item_id={{productId}}|{{/results}}">
+                            <h3 class="detail-block-title">More To Love</h3>
+                            <div class="detail-product-list flex">
+                                {{#results}}
+                                <div class="detail-product-item">
+                                    <a href="{{productDetailUrl}}">
+                                        <amp-img src="{{productImage}}" alt="{{productTitle}}"
+                                        width="45" height="45" layout="responsive"></amp-img>
+                                        <h4>{{productTitle}}</h4>
+                                        <p>{{minPrice}}</p>
+                                    </a>
+                                </div>
+                                {{/results}}
+                            </div>
+                            <amp-analytics config="https://m.aliexpress.com/api/stat/detail/async"></amp-analytics>
+                        </amp-selector>
+                    </section>
+                {{/results.length}}
+            </template>
+        </amp-list>
+
+                            <section class="ms-block">
+                <div class="crosslink" tabindex="-1" role="button" [class]="crossLinkShowMore ? 'crosslink crosslink-auto' : 'crosslink'"
+                on="tap: AMP.setState({
+                    crossLinkShowMore: !crossLinkShowMore
+                })">
+                    <h3 class="crosslink-title">Related Searches</h3>
+                    <p class="show-more"></p>
+                    <div class="crosslink-container">
+                                                    <div class="crosslink-item">
+                                <h3 class="crosslink-title">Wholesale:</h3>
+                                <div class="crosslink-link">
+                                                                        <a class="cross-child" href="https://m.aliexpress.com/wholesale/carter.-bracelet.html">carter. bracelet</a>
+                                                                        <a class="cross-child" href="https://m.aliexpress.com/wholesale/boho.html"> boho</a>
+                                                                        <a class="cross-child" href="https://m.aliexpress.com/wholesale/architecturally-jewelry.html">architecturally jewelry</a>
+                                                                        <a class="cross-child" href="https://m.aliexpress.com/wholesale/jewellery.html"> jewellery</a>
+                                                                        <a class="cross-child" href="https://m.aliexpress.com/wholesale/women-bracelets-for.html">women bracelets for</a>
+                                                                        <a class="cross-child" href="https://m.aliexpress.com/wholesale/bangles.html">bangles </a>
+                                                                        <a class="cross-child" href="https://m.aliexpress.com/wholesale/bracelets-hommed.html">bracelets hommed</a>
+                                                                        <a class="cross-child" href="https://m.aliexpress.com/wholesale/women-bracelet.html">women  bracelet</a>
+                                                                        <a class="cross-child" href="https://m.aliexpress.com/wholesale/bangle-braceller.html">bangle braceller</a>
+                                                                    </div>
+                            </div>
+                                                    <div class="crosslink-item">
+                                <h3 class="crosslink-title">Popular:</h3>
+                                <div class="crosslink-link">
+                                                                        <a class="cross-child" href="https://m.aliexpress.com/popular/jewelry-boho.html">jewelry boho</a>
+                                                                        <a class="cross-child" href="https://m.aliexpress.com/popular/jewelry-sets-lm4pc.html">jewelry sets lm4pc</a>
+                                                                        <a class="cross-child" href="https://m.aliexpress.com/popular/midofare-bracelets-bangles.html">midofare bracelets bangles</a>
+                                                                        <a class="cross-child" href="https://m.aliexpress.com/popular/silver-bracelet.html">silver  bracelet</a>
+                                                                        <a class="cross-child" href="https://m.aliexpress.com/popular/bracelet-hommes.html">bracelet hommes</a>
+                                                                        <a class="cross-child" href="https://m.aliexpress.com/popular/925-silver-jewelry.html">925 silver jewelry</a>
+                                                                        <a class="cross-child" href="https://m.aliexpress.com/popular/jewelry-men.html">jewelry men</a>
+                                                                        <a class="cross-child" href="https://m.aliexpress.com/popular/7811-women.html">7811 women</a>
+                                                                        <a class="cross-child" href="https://m.aliexpress.com/popular/composants-bijoux.html">composants bijoux</a>
+                                                                    </div>
+                            </div>
+                                                    <div class="crosslink-item">
+                                <h3 class="crosslink-title">Price:</h3>
+                                <div class="crosslink-link">
+                                                                        <a class="cross-child" href="https://m.aliexpress.com/price/bracelets-%26-bangles-f5341.html">bracelets & bangles f5341</a>
+                                                                        <a class="cross-child" href="https://m.aliexpress.com/price/wandkleed-bohemian.html">wandkleed bohemian</a>
+                                                                        <a class="cross-child" href="https://m.aliexpress.com/price/sterling-silver-aquamarinering.html">sterling silver aquamarinering</a>
+                                                                        <a class="cross-child" href="https://m.aliexpress.com/price/bracelets-cuff.html">bracelets cuff</a>
+                                                                        <a class="cross-child" href="https://m.aliexpress.com/price/pandora-bracelet.html">pandora bracelet </a>
+                                                                        <a class="cross-child" href="https://m.aliexpress.com/price/bangles-for-womens.html">bangles for womens</a>
+                                                                        <a class="cross-child" href="https://m.aliexpress.com/price/cuff.html">cuff </a>
+                                                                        <a class="cross-child" href="https://m.aliexpress.com/price/bangle-bracelet.html">bangle bracelet </a>
+                                                                        <a class="cross-child" href="https://m.aliexpress.com/price/cuff-bracelet-slippy.html">cuff bracelet slippy</a>
+                                                                    </div>
+                            </div>
+                                                    <div class="crosslink-item">
+                                <h3 class="crosslink-title">Cheap:</h3>
+                                <div class="crosslink-link">
+                                                                        <a class="cross-child" href="https://m.aliexpress.com/cheap/hand%26leg-cuffs.html">hand&leg cuffs</a>
+                                                                        <a class="cross-child" href="https://m.aliexpress.com/cheap/bracelet-love.html">bracelet love </a>
+                                                                        <a class="cross-child" href="https://m.aliexpress.com/cheap/jewelry-women.html">jewelry women</a>
+                                                                        <a class="cross-child" href="https://m.aliexpress.com/cheap/bracelet-and-bangles-women.html">bracelet and bangles women</a>
+                                                                        <a class="cross-child" href="https://m.aliexpress.com/cheap/braclets-gold.html">braclets gold</a>
+                                                                        <a class="cross-child" href="https://m.aliexpress.com/cheap/bracelet-metal.html">bracelet metal</a>
+                                                                        <a class="cross-child" href="https://m.aliexpress.com/cheap/bracelet-woman.html"> bracelet woman</a>
+                                                                        <a class="cross-child" href="https://m.aliexpress.com/cheap/womens-bracelets-bangle.html">womens bracelets bangle</a>
+                                                                        <a class="cross-child" href="https://m.aliexpress.com/cheap/hammerered-copper-bracelet.html">hammerered copper bracelet</a>
+                                                                    </div>
+                            </div>
+                                                    <div class="crosslink-item">
+                                <h3 class="crosslink-title">Promotion:</h3>
+                                <div class="crosslink-link">
+                                                                        <a class="cross-child" href="https://m.aliexpress.com/promotion/silver-bracelet.html">silver  bracelet</a>
+                                                                        <a class="cross-child" href="https://m.aliexpress.com/promotion/silver-jewellery.html">silver jewellery</a>
+                                                                        <a class="cross-child" href="https://m.aliexpress.com/promotion/femme.html"> femme</a>
+                                                                        <a class="cross-child" href="https://m.aliexpress.com/promotion/creed-assassins.html">creed assassins</a>
+                                                                        <a class="cross-child" href="https://m.aliexpress.com/promotion/gift.html"> gift</a>
+                                                                        <a class="cross-child" href="https://m.aliexpress.com/promotion/women-birthday-gifts.html">women birthday gifts</a>
+                                                                        <a class="cross-child" href="https://m.aliexpress.com/promotion/armbandjes-woman.html">armbandjes woman</a>
+                                                                        <a class="cross-child" href="https://m.aliexpress.com/promotion/cuff-bracelet.html">cuff bracelet</a>
+                                                                        <a class="cross-child" href="https://m.aliexpress.com/promotion/white-tunnels-plugs.html">white tunnels plugs</a>
+                                                                    </div>
+                            </div>
+                                                    <div class="crosslink-item">
+                                <h3 class="crosslink-title">Reviews:</h3>
+                                <div class="crosslink-link">
+                                                                        <a class="cross-child" href="https://m.aliexpress.com/reviews/b013-silver-bangle.html">b013 silver bangle</a>
+                                                                        <a class="cross-child" href="https://m.aliexpress.com/reviews/boho-bracelet.html">boho bracelet </a>
+                                                                        <a class="cross-child" href="https://m.aliexpress.com/reviews/bangles-and-bracelet.html">bangles and bracelet</a>
+                                                                        <a class="cross-child" href="https://m.aliexpress.com/reviews/crytall-bracelet-women.html">crytall bracelet women</a>
+                                                                        <a class="cross-child" href="https://m.aliexpress.com/reviews/jewelry-bohemian.html">jewelry bohemian</a>
+                                                                        <a class="cross-child" href="https://m.aliexpress.com/reviews/cuff-bracelets.html">cuff bracelets</a>
+                                                                        <a class="cross-child" href="https://m.aliexpress.com/reviews/womens-bracelets.html">womens bracelets </a>
+                                                                        <a class="cross-child" href="https://m.aliexpress.com/reviews/jewellery-fashion.html">jewellery fashion</a>
+                                                                        <a class="cross-child" href="https://m.aliexpress.com/reviews/bangles-women.html">bangles women</a>
+                                                                    </div>
+                            </div>
+                                            </div>
+                </div>
+            </section>
+                        <amp-analytics>
+    <script type="application/json">
+        {
+            "requests": {
+                "clkServer": "https://gj.mmstat.com/ae.pc_click.statweb_ae_click?gmkey=CLK&spm-cnt=a2g0n.detail-amp.0.0.amp"
+            },
+            "transport": {
+                "beacon": false,
+                "xhrpost": false,
+                "image": true
+            },
+            "triggers": {
+                "addToWishlist": {
+                    "on": "click",
+                    "selector": "#collection-button",
+                    "request": "clkServer",
+                    "extraUrlParams": {
+                        "gokey": "ae_project_id=180139&ae_page_type=detail_page&ae_page_area=&ae_button_type=add_to_wish_list&ae_object_type=1&ae_object_value=32751800685&st_page_id=PAGE_VIEW_IDCLIENT_ID(aefeMsite)NAV_TIMING(navigationStart)"
+                    }
+                },
+                "addToCart": {
+                    "on": "click",
+                    "selector": ".add-to-cart",
+                    "request": "clkServer",
+                    "extraUrlParams": {
+                        "gokey": "ae_project_id=180139&ae_page_type=detail_page&ae_page_area=&ae_button_type=add_to_cart&ae_object_type=1&ae_object_value=32751800685&st_page_id=PAGE_VIEW_IDCLIENT_ID(aefeMsite)NAV_TIMING(navigationStart)"
+                    }
+                },
+                "buyNow": {
+                    "on": "click",
+                    "selector": ".buy-now",
+                    "request": "clkServer",
+                    "extraUrlParams": {
+                        "gokey": "ae_project_id=180139&ae_page_type=detail_page&ae_page_area=&ae_button_type=buy_now&ae_object_type=1&ae_object_value=32751800685&st_page_id=PAGE_VIEW_IDCLIENT_ID(aefeMsite)NAV_TIMING(navigationStart)"
+                    }
+                }
+                                                        ,
+                                                    "getCoupon110310950": {
+                                "on": "click",
+                                "selector": "#coupon110310950",
+                                "request": "clkServer",
+                                "extraUrlParams": {
+                                    "gokey": "ae_project_id=180139&ae_page_type=detail_page&ae_page_area=&ae_button_type=coupon&ae_object_type=coupon&ae_object_value=110310950&st_page_id=PAGE_VIEW_IDCLIENT_ID(aefeMsite)NAV_TIMING(navigationStart)"
+                                }
+                            },                                                    "getCoupon110320069": {
+                                "on": "click",
+                                "selector": "#coupon110320069",
+                                "request": "clkServer",
+                                "extraUrlParams": {
+                                    "gokey": "ae_project_id=180139&ae_page_type=detail_page&ae_page_area=&ae_button_type=coupon&ae_object_type=coupon&ae_object_value=110320069&st_page_id=PAGE_VIEW_IDCLIENT_ID(aefeMsite)NAV_TIMING(navigationStart)"
+                                }
+                            },                                                    "getCoupon110473049": {
+                                "on": "click",
+                                "selector": "#coupon110473049",
+                                "request": "clkServer",
+                                "extraUrlParams": {
+                                    "gokey": "ae_project_id=180139&ae_page_type=detail_page&ae_page_area=&ae_button_type=coupon&ae_object_type=coupon&ae_object_value=110473049&st_page_id=PAGE_VIEW_IDCLIENT_ID(aefeMsite)NAV_TIMING(navigationStart)"
+                                }
+                            },                                                    "getCoupon110542065": {
+                                "on": "click",
+                                "selector": "#coupon110542065",
+                                "request": "clkServer",
+                                "extraUrlParams": {
+                                    "gokey": "ae_project_id=180139&ae_page_type=detail_page&ae_page_area=&ae_button_type=coupon&ae_object_type=coupon&ae_object_value=110542065&st_page_id=PAGE_VIEW_IDCLIENT_ID(aefeMsite)NAV_TIMING(navigationStart)"
+                                }
+                            }
+            }
+        }
+    </script>
+</amp-analytics>
+
+<amp-pixel src="https://m.aliexpress.com/img/1x1.gif?type=amp-performance&pageType=detail&cid=CLIENT_ID(AMP_ECID_GOOGLE)&content_load_time=CONTENT_LOAD_TIME&domain_lookup_time=DOMAIN_LOOKUP_TIME&dom_interactive_time=DOM_INTERACTIVE_TIME&nav_redirect_count=NAV_REDIRECT_COUNT&nav_type=NAV_TYPE&page_download_time=PAGE_DOWNLOAD_TIME&page_load_time=PAGE_LOAD_TIME&redirect_time=REDIRECT_TIME&server_response_time=SERVER_RESPONSE_TIME&tcp_connect_time=TCP_CONNECT_TIME"></amp-pixel>
+<amp-analytics type="googleanalytics">
+    <script type="application/json">
+        {
+            "vars": {
+                "account": "UA-17640202-1"
+            },
+            "triggers": {
+                "trackPageview": {
+                    "on": "visible",
+                    "request": "pageview"
+                },
+                "trackClickOnCart" : {
+                    "on": "click",
+                    "selector": "#add-cart",
+                    "request": "event",
+                    "vars": {
+                        "eventCategory": "amp-detail-addcart",
+                        "eventAction": "amp-addcart-click"
+                    },
+                    "extraUrlParams":{
+                        "productId": "32751800685"
+                    }
+                },
+                "trackClickOnBuy" : {
+                    "on": "click",
+                    "selector": "#buy-now",
+                    "request": "event",
+                    "vars": {
+                        "eventCategory": "amp-detail-buy",
+                        "eventAction": "amp-buy-click"
+                    },
+                    "extraUrlParams":{
+                        "productId": "32751800685"
+                    }
+                }
+            }
+        }
+    </script>
+</amp-analytics>
+  <!--ams-region-start 901--><amp-analytics>
+<script type="application/json">
+{
+  "requests": {
+    "base": "https://perf.mmstat.com/p.gif?site=${site}&memberSeq=${cid}",
+    "event": "${base}&pageType=${pageType}"
+  },
+  "transport": {
+    "beacon":false,
+    "xhrpost":false,
+    "image": true
+  },
+  "vars": {
+    "site": "m",
+    "cid": "${clientId(AMP_ECID_GOOGLE)}",
+    "pageType": "amp-detail"
+  },
+  "triggers": {
+    "trackTiming": {
+      "on": "visible",
+      "request": "event",
+      "extraUrlParams":{
+        "ns": "${navTiming(navigationStart)}",
+        "ules": "${navTiming(unloadEventStart)}",
+        "ulee": "${navTiming(unloadEventEnd)}",
+        "rs": "${navTiming(redirectStart)}",
+        "re": "${navTiming(redirectEnd)}",
+        "fs": "${navTiming(fetchStart)}",
+        "dls": "${navTiming(domainLookupStart)}",
+        "dle": "${navTiming(domainLookupEnd)}",
+        "cs": "${navTiming(connectStart)}",
+        "ce": "${navTiming(connectEnd)}",
+        "scs": "${navTiming(secureConnectionStart)}",
+        "resqs": "${navTiming(requestStart)}",
+        "resps": "${navTiming(responseStart)}",
+        "respe": "${navTiming(responseEnd)}",
+        "dl": "${navTiming(domLoading)}",
+        "di": "${navTiming(domInteractive)}",
+        "dcles": "${navTiming(domContentLoadedEventStart)}",
+        "dclee": "${navTiming(domContentLoadedEventEnd)}",
+        "domc": "${navTiming(domComplete)}",
+        "les": "${navTiming(loadEventStart)}",
+        "lee": "${navTiming(loadEventEnd)}",
+        "srt": "${navTiming(domInteractive)}",
+        "fst": 0
+      }
+    }
+  }
+}</script>
+</amp-analytics> <!--ams-region-end 901-->
+
 </body>
 </html>


### PR DESCRIPTION
Fixes a bug where lightbox manager processes carousels by adding lightbox group ids to the carousel. However, we rescan lightboxes on DOM update, so carousel contents are scanned twice, resulting in duplicate thumbnails. 

Part of QA-ing lightbox with AliExpress. 
Closes https://github.com/ampproject/amphtml/issues/15139. 