### PR TITLE
🐛 update element in fixed layer when height change

### DIFF
--- a/extensions/amp-consent/0.1/amp-consent.js
+++ b/extensions/amp-consent/0.1/amp-consent.js
@@ -538,6 +538,7 @@ export class AmpConsent extends AMP.BaseElement {
    * Handles the display of postPromptUI
    */
   handlePostPromptUI_() {
+    const classList = this.element.classList;
     this.notificationUiManager_.onQueueEmpty(() => {
       if (!this.postPromptUI_) {
         return;
@@ -547,8 +548,8 @@ export class AmpConsent extends AMP.BaseElement {
           this.uiInit_ = true;
           toggle(this.element, true);
         }
-        this.element.classList.add('amp-active');
-        this.element.classList.remove('amp-hidden');
+        classList.add('amp-active');
+        classList.remove('amp-hidden');
         this.getViewport().addToFixedLayer(this.element);
         setImportantStyles(dev().assertElement(this.postPromptUI_),
             {display: 'block'});
@@ -561,8 +562,8 @@ export class AmpConsent extends AMP.BaseElement {
       }
       this.vsync_.mutate(() => {
         if (!this.currentDisplayInstance_) {
-          this.element.classList.add('amp-hidden');
-          this.element.classList.remove('amp-active');
+          classList.add('amp-hidden');
+          classList.remove('amp-active');
         }
         this.getViewport().removeFromFixedLayer(this.element);
         toggle(dev().assertElement(this.postPromptUI_), false);

--- a/extensions/amp-consent/0.1/amp-consent.js
+++ b/extensions/amp-consent/0.1/amp-consent.js
@@ -216,11 +216,11 @@ export class AmpConsent extends AMP.BaseElement {
       if (!this.uiInit_) {
         this.uiInit_ = true;
         toggle(this.element, true);
-        this.getViewport().addToFixedLayer(this.element);
       }
 
       this.element.classList.remove('amp-hidden');
       this.element.classList.add('amp-active');
+      this.getViewport().addToFixedLayer(this.element);
 
       // Display the current instance
       this.currentDisplayInstance_ = instanceId;
@@ -242,10 +242,9 @@ export class AmpConsent extends AMP.BaseElement {
     this.vsync_.mutate(() => {
       this.element.classList.add('amp-hidden');
       this.element.classList.remove('amp-active');
-      // Do not remove from fixed layer because of invoke button
-      // this.getViewport().removeFromFixedLayer(this.element);
+      // Need to remove from fixed layer and add it back to update element's top
+      this.getViewport().removeFromFixedLayer(this.element);
       dev().assert(uiToHide, 'no consent UI to hide');
-
       toggle(uiToHide, false);
     });
     if (this.dialogResolver_[this.currentDisplayInstance_]) {
@@ -547,10 +546,10 @@ export class AmpConsent extends AMP.BaseElement {
         if (!this.uiInit_) {
           this.uiInit_ = true;
           toggle(this.element, true);
-          this.getViewport().addToFixedLayer(this.element);
         }
         this.element.classList.add('amp-active');
         this.element.classList.remove('amp-hidden');
+        this.getViewport().addToFixedLayer(this.element);
         setImportantStyles(dev().assertElement(this.postPromptUI_),
             {display: 'block'});
       });
@@ -565,6 +564,7 @@ export class AmpConsent extends AMP.BaseElement {
           this.element.classList.add('amp-hidden');
           this.element.classList.remove('amp-active');
         }
+        this.getViewport().removeFromFixedLayer(this.element);
         toggle(dev().assertElement(this.postPromptUI_), false);
       });
     });

--- a/test/manual/amp-consent.html
+++ b/test/manual/amp-consent.html
@@ -137,6 +137,10 @@
       background: #3f51b5;
     }
 
+    #ui1 {
+      height: 100vh;
+    }
+
     hr {
       margin: 0;
     }
@@ -175,7 +179,7 @@
           },
           "ABC": {
             "checkConsentHref": "http://localhost:8000/get-consent-v1",
-            "promptUI": "ui1"
+            "promptUI": "ui2"
           }
         },
         "policy": {
@@ -192,6 +196,12 @@
         "postPromptUI": "postPromptUI"
       }</script>
       <div id="ui1">
+        Please Accept to load image.
+        <button on="tap:ABC.accept" role="button">Accept</button>
+        <button on="tap:ABC.reject" role="button">Reject</button>
+        <button on="tap:ABC.dismiss" role="button">Dismiss</button>
+      </div>
+      <div id="ui2">
         Please Accept to load image.
         <button on="tap:ABC.accept" role="button">Accept</button>
         <button on="tap:ABC.reject" role="button">Reject</button>


### PR DESCRIPTION
AMP runtime adds style top to fixed layer element to adjust the viewer header. 
However the `top` value never gets updated after element height change. 
Force update element top in fixed layer by  calling `removeFromFixedLayer` and `addToFixedLayer`. 

cc @jridgewell 
Fix #15011 