### PR TITLE
✨ amp-next-page: Allow hiding of arbitrary elements in child pages

### DIFF
--- a/examples/amp-next-page.amp.html
+++ b/examples/amp-next-page.amp.html
@@ -141,6 +141,9 @@ Donec vehicula nisi eget metus blandit, at semper nunc porttitor. Vestibulum sit
             "title": "This is yet another article",
             "ampUrl": "/examples/article.amp.html"
           }
+        ],
+        "hideSelectors": [
+          ".title"
         ]
       }
     </script>

--- a/extensions/amp-next-page/0.1/amp-next-page.css
+++ b/extensions/amp-next-page/0.1/amp-next-page.css
@@ -35,6 +35,10 @@
   display: none;
 }
 
+.i-amphtml-next-page-hidden {
+  display: none !important;
+}
+
 .i-amphtml-next-page {
   background: #FFFFFF;
 }

--- a/extensions/amp-next-page/0.1/config.js
+++ b/extensions/amp-next-page/0.1/config.js
@@ -20,7 +20,8 @@ import {user} from '../../../src/log';
 
 /**
  * @typedef {{
- *   pages: (!Array<!AmpNextPageItem>|undefined),
+ *   pages: !Array<!AmpNextPageItem>,
+ *   hideSelectors: (!Array<string>|undefined)
  * }}
  */
 export let AmpNextPageConfig;
@@ -35,9 +36,7 @@ export let AmpNextPageConfig;
 export let AmpNextPageItem;
 
 /**
- * Checks whether the object conforms to the AmpNextPageConfig
- * spec.
- *
+ * Checks whether the object conforms to the AmpNextPageConfig spec.
  * @param {*} config The config to validate.
  * @param {string} origin The origin of the current document
  *     (document.location.origin). All recommendations must be for the same
@@ -51,11 +50,33 @@ export function assertConfig(config, origin, sourceOrigin) {
   user().assert(config, 'amp-next-page config must be specified');
   user().assert(isArray(config.pages), 'pages must be an array');
   assertRecos(config.pages, origin, sourceOrigin);
+
+  if ('hideSelectors' in config) {
+    user().assert(isArray(config['hideSelectors']),
+        'amp-next-page hideSelectors should be an array');
+    assertSelectors(config['hideSelectors']);
+  }
+
   return /** @type {!AmpNextPageConfig} */ (config);
 }
 
 function assertRecos(recos, origin, sourceOrigin) {
   recos.forEach(reco => assertReco(reco, origin, sourceOrigin));
+}
+
+const BANNED_SELECTOR_PATTERNS = [
+  /(^|\W)i-amphtml-/,
+];
+
+function assertSelectors(selectors) {
+  selectors.forEach(selector => {
+    BANNED_SELECTOR_PATTERNS.forEach(pattern => {
+      user().assert(typeof selector === 'string',
+          `amp-next-page hideSelector value ${selector} is not a string`);
+      user().assert(!pattern.test(selector),
+          `amp-next-page hideSelector '${selector}' not allowed`);
+    });
+  });
 }
 
 function assertReco(reco, origin, sourceOrigin) {

--- a/extensions/amp-next-page/0.1/config.js
+++ b/extensions/amp-next-page/0.1/config.js
@@ -71,7 +71,7 @@ const BANNED_SELECTOR_PATTERNS = [
 function assertSelectors(selectors) {
   selectors.forEach(selector => {
     BANNED_SELECTOR_PATTERNS.forEach(pattern => {
-      user().assert(typeof selector === 'string',
+      user().assertString(selector,
           `amp-next-page hideSelector value ${selector} is not a string`);
       user().assert(!pattern.test(selector),
           `amp-next-page hideSelector '${selector}' not allowed`);
@@ -81,11 +81,11 @@ function assertSelectors(selectors) {
 
 function assertReco(reco, origin, sourceOrigin) {
   const url = parseUrl(reco.ampUrl);
-  user().assert(typeof reco.ampUrl == 'string', 'ampUrl must be a string');
+  user().assertString(reco.ampUrl, 'ampUrl must be a string');
   user().assert(url.origin === origin || url.origin === sourceOrigin,
       'pages must be from the same origin as the current document');
-  user().assert(typeof reco.image == 'string', 'image must be a string');
-  user().assert(typeof reco.title == 'string', 'title must be a string');
+  user().assertString(reco.image, 'image must be a string');
+  user().assertString(reco.title, 'title must be a string');
 
   if (sourceOrigin) {
     reco.ampUrl = reco.ampUrl.replace(url.origin, origin);

--- a/extensions/amp-next-page/0.1/next-page-service.js
+++ b/extensions/amp-next-page/0.1/next-page-service.js
@@ -64,6 +64,9 @@ export class NextPageService {
     /** @private {?./config.AmpNextPageConfig} */
     this.config_ = null;
 
+    /** @private {string} */
+    this.hideSelector_;
+
     /** @private {?Element} */
     this.separator_ = null;
 
@@ -128,6 +131,10 @@ export class NextPageService {
     this.separator_ = separator || this.createDivider_();
     this.element_ = element;
 
+    if (this.config_.hideSelectors) {
+      this.hideSelector_ = this.config_.hideSelectors.join(',');
+    }
+
     this.viewer_ = Services.viewerForDoc(ampDoc);
     this.viewport_ = Services.viewportForDoc(ampDoc);
     this.resources_ = Services.resourcesForDoc(ampDoc);
@@ -166,6 +173,13 @@ export class NextPageService {
    * @return {?Object} Return value of {@link MultidocManager#attachShadowDoc}
    */
   attachShadowDoc_(shadowRoot, doc) {
+    if (this.hideSelector_) {
+      const elements = doc.querySelectorAll(this.hideSelector_);
+      for (let i = 0; i < elements.length; i++) {
+        elements[i].classList.add('i-amphtml-next-page-hidden');
+      }
+    }
+
     const amp =
         this.multidocManager_.attachShadowDoc(shadowRoot, doc, '', {});
     installStylesForDoc(amp.ampdoc, CSS, null, false, TAG);

--- a/extensions/amp-next-page/0.1/test/test-amp-next-page.js
+++ b/extensions/amp-next-page/0.1/test/test-amp-next-page.js
@@ -16,6 +16,7 @@
 
 import {AmpNextPage} from '../amp-next-page';
 import {Services} from '../../../../src/services';
+import {getService} from '../../../../src/service';
 import {layoutRectLtwh} from '../../../../src/layout-rect';
 import {macroTask} from '../../../../testing/yield';
 import {toggleExperiment} from '../../../../src/experiments';
@@ -57,6 +58,10 @@ env => {
                   "title": "Title 2",
                   "ampUrl": "/document2"
                 }
+              ],
+              "hideSelectors": [
+                "header",
+                "footer"
               ]
             }
           </script>`;
@@ -72,6 +77,16 @@ env => {
     nextPage.buildCallback();
 
     xhrMock = sandbox.mock(Services.xhrFor(win));
+
+    sandbox.stub(Services.resourcesForDoc(ampdoc), 'mutateElement')
+        .callsFake((unused, mutator) => {
+          mutator();
+          return Promise.resolve();
+        });
+    sandbox.stub(nextPage, 'mutateElement').callsFake(mutator => {
+      mutator();
+      return Promise.resolve();
+    });
   });
 
   afterEach(() => {
@@ -124,4 +139,60 @@ env => {
     win.dispatchEvent(new Event('scroll'));
     yield macroTask();
   });
+
+  it('adds the hidden class to hideSelector elements', function* () {
+    const exampleDoc = createExampleDocument(doc);
+    xhrMock.expects('fetchDocument')
+        .returns(Promise.resolve(exampleDoc))
+        .once();
+
+    const nextPageService = getService(win, 'next-page');
+    const attachShadowDocSpy =
+        sandbox.spy(nextPageService.multidocManager_, 'attachShadowDoc');
+
+    sandbox.stub(viewport, 'getClientRectAsync').callsFake(() => {
+      // 1x viewport away
+      return Promise.resolve(
+          layoutRectLtwh(0, 0, sizes.width, sizes.height * 2));
+    });
+
+    win.dispatchEvent(new Event('scroll'));
+    yield macroTask();
+
+    const shadowDoc = attachShadowDocSpy.firstCall.returnValue.ampdoc;
+    yield shadowDoc.whenReady();
+
+    const shadowRoot = shadowDoc.getRootNode();
+
+    expect(
+        shadowRoot.querySelector('header').classList.contains(
+            'i-amphtml-next-page-hidden'))
+        .to.be.true;
+    expect(
+        shadowRoot.querySelector('footer').classList.contains(
+            'i-amphtml-next-page-hidden'))
+        .to.be.true;
+  });
 });
+
+/**
+ * Creates an example document as a child of {@code doc} to be embedded as a
+ * shadow document.
+ * @param {!Document} doc Parent document to use to create new elements.
+ * @returns {!Document} New {@code DocumentFragment} with example content.
+ */
+function createExampleDocument(doc) {
+  const childDoc = doc.createDocumentFragment();
+  const head = doc.createElement('head');
+  const body = doc.createElement('body');
+  childDoc.appendChild(head);
+  childDoc.appendChild(body);
+  childDoc.head = head;
+  childDoc.body = body;
+
+  childDoc.body.innerHTML = `
+      <header>Header</header>
+      <div style="height:1000px"></div>
+      <footer>Footer</footer>`;
+  return childDoc;
+}

--- a/extensions/amp-next-page/0.1/test/test-config.js
+++ b/extensions/amp-next-page/0.1/test/test-config.js
@@ -27,6 +27,10 @@ describe('amp-next-page config', () => {
           image: 'https://example.com/image.png',
           title: 'Article 1',
         }],
+        hideSelectors: [
+          '.header',
+          'footer',
+        ],
       };
       expect(() => assertConfig(config, origin, origin)).to.not.throw();
     });
@@ -192,6 +196,40 @@ describe('amp-next-page config', () => {
         expect(() => assertConfig(config, origin, origin))
             .to.throw(
                 'pages must be from the same origin as the current document');
+      });
+    });
+
+    it('throws on config with non-array "hideSelectors" key', () => {
+      const config = {
+        pages: [],
+        hideSelectors: {},
+      };
+      allowConsoleError(() => {
+        expect(() => assertConfig(config, origin, origin))
+            .to.throw('amp-next-page hideSelectors should be an array');
+      });
+    });
+
+    it('throws for non-string hideSelector values', () => {
+      const config = {
+        pages: [],
+        hideSelectors: ['a', 2],
+      };
+      allowConsoleError(() => {
+        expect(() => assertConfig(config, origin, origin))
+            .to.throw('amp-next-page hideSelector value 2 is not a string');
+      });
+    });
+
+    it('throws for hideSelector values for i-amphtml selectors', () => {
+      const config = {
+        pages: [],
+        hideSelectors: ['   .i-amphtml-something'],
+      };
+      allowConsoleError(() => {
+        expect(() => assertConfig(config, origin, origin)).to.throw(
+            'amp-next-page hideSelector \'   .i-amphtml-something\' ' +
+            'not allowed');
       });
     });
   });


### PR DESCRIPTION
Primary use case is hiding repeated page headers/footers.

- Reads from hideSelectors key in config
- Blacklists i-amphtml-* selectors, like the validator
- Runs querySelectorAll() for all the selectors when the shadow document is attached. Generating and injecting CSS would presumably be more efficient but would need more validation/sanitisation on the selectors. AFAIK passing user input directly to `querySelectorAll` should be safe.