### PR TITLE
Update bundle-size.js

### DIFF
--- a/build-system/tasks/bundle-size.js
+++ b/build-system/tasks/bundle-size.js
@@ -21,7 +21,7 @@ const gulp = require('gulp-help')(require('gulp'));
 const log = require('fancy-log');
 
 const runtimeFile = './dist/v0.js';
-const maxSize = '77.45KB';
+const maxSize = '77.49KB';
 
 const green = colors.green;
 const red = colors.red;


### PR DESCRIPTION
At commit 6b54f088298d578032592d5d6687fe6c6b009a60:
```
[17:34:01] Running npx bundlesize -f "./dist/v0.js" -s "77.45KB"...
[17:34:02] FAIL  ./dist/v0.js: 77.48KB > maxSize 77.45KB (gzip) 
[17:34:02] ERROR: bundlesize found that ./dist/v0.js has exceeded its size cap of 77.45KB.
```

/to @jridgewell @gmajoulet 