### PR TITLE
amp-auto-ads: Allows ad constraints to be specified by the over-the-wire config

### DIFF
--- a/extensions/amp-auto-ads/0.1/ad-network-config.js
+++ b/extensions/amp-auto-ads/0.1/ad-network-config.js
@@ -51,10 +51,12 @@ class AdNetworkConfigDef {
   getAttributes() {}
 
   /**
-   * Network specific constraints on the placement of ads on the page.
+   * Network specific constraints on the placement of ads on the page. Used
+   * when no ad constraints are specified in the over-the-wire config supplied
+   * by the ad network.
    * @return {!./ad-tracker.AdConstraints}
    */
-  getAdConstraints() {}
+  getDefaultAdConstraints() {}
 }
 
 /**
@@ -110,7 +112,7 @@ class AdSenseNetworkConfig {
   }
 
   /** @override */
-  getAdConstraints() {
+  getDefaultAdConstraints() {
     const viewportHeight =
         Services.viewportForDoc(this.autoAmpAdsElement_).getSize().height;
     return {

--- a/extensions/amp-auto-ads/0.1/amp-auto-ads.js
+++ b/extensions/amp-auto-ads/0.1/amp-auto-ads.js
@@ -15,7 +15,11 @@
  */
 
 import {AdStrategy} from './ad-strategy';
-import {AdTracker, getExistingAds} from './ad-tracker';
+import {
+  AdTracker,
+  getAdConstraintsFromConfigObj,
+  getExistingAds,
+} from './ad-tracker';
 import {AnchorAdStrategy} from './anchor-ad-strategy';
 import {Services} from '../../../src/services';
 import {getAdNetworkConfig} from './ad-network-config';
@@ -65,8 +69,9 @@ export class AmpAutoAds extends AMP.BaseElement {
       const attributes = /** @type {!JsonObject} */ (
         Object.assign(adNetwork.getAttributes(),
             getAttributesFromConfigObj(configObj)));
-      const adTracker =
-          new AdTracker(getExistingAds(ampdoc), adNetwork.getAdConstraints());
+      const adConstraints = getAdConstraintsFromConfigObj(configObj) ||
+          adNetwork.getDefaultAdConstraints();
+      const adTracker = new AdTracker(getExistingAds(ampdoc), adConstraints);
       new AdStrategy(placements, attributes, adTracker).run();
       new AnchorAdStrategy(ampdoc, attributes, configObj).run();
     });

--- a/extensions/amp-auto-ads/0.1/test/test-ad-network-config.js
+++ b/extensions/amp-auto-ads/0.1/test/test-ad-network-config.js
@@ -111,14 +111,14 @@ describes.realWin('ad-network-config', {
       });
     });
 
-    it('should get the ad constraints', () => {
+    it('should get the default ad constraints', () => {
       const viewportMock =
           sandbox.mock(Services.viewportForDoc(env.win.document));
       viewportMock.expects('getSize').returns(
           {width: 320, height: 500}).atLeast(1);
 
       const adNetwork = getAdNetworkConfig('adsense', ampAutoAdsElem);
-      expect(adNetwork.getAdConstraints()).to.deep.equal({
+      expect(adNetwork.getDefaultAdConstraints()).to.deep.equal({
         initialMinSpacing: 500,
         subsequentMinSpacing: [
           {adCount: 3, spacing: 1000},

--- a/extensions/amp-auto-ads/0.1/test/test-ad-tracker.js
+++ b/extensions/amp-auto-ads/0.1/test/test-ad-tracker.js
@@ -15,7 +15,11 @@
  */
 
 
-import {AdTracker, getExistingAds} from '../ad-tracker';
+import {
+  AdTracker,
+  getAdConstraintsFromConfigObj,
+  getExistingAds,
+} from '../ad-tracker';
 import {Services} from '../../../../src/services';
 import {layoutRectLtwh} from '../../../../src/layout-rect';
 
@@ -251,5 +255,147 @@ describes.realWin('getExistingAds', {amp: true}, env => {
     expect(ads[0]).to.equal(ad1);
     expect(ads[1]).to.equal(ad2);
     expect(ads[2]).to.equal(ad3);
+  });
+});
+
+
+describes.realWin('getAdConstraintsFromConfigObj', {amp: true}, env => {
+  let win;
+  let doc;
+  let ampdoc;
+
+  beforeEach(() => {
+    win = env.win;
+    doc = win.document;
+    ampdoc = env.ampdoc;
+  });
+
+  it('should get from pixel values', () => {
+    const configObj = {
+      adConstraints: {
+        initialMinSpacing: '150px',
+        subsequentMinSpacing: [
+          {
+            adCount: 2,
+            spacing: '160px',
+          },
+          {
+            adCount: 4,
+            spacing: '170px',
+          },
+        ],
+        maxAdCount: 8,
+      },
+    };
+
+    expect(getAdConstraintsFromConfigObj(ampdoc, configObj)).to.deep.equal({
+      initialMinSpacing: 150,
+      subsequentMinSpacing: [
+        {
+          adCount: 2,
+          spacing: 160,
+        },
+        {
+          adCount: 4,
+          spacing: 170
+        },
+      ],
+      maxAdCount: 8,
+    });
+  });
+
+  it('should get from viewport values', () => {
+    const viewportMock = sandbox.mock(Services.viewportForDoc(ampdoc));
+    viewportMock.expects('getSize').returns(
+        {width: 320, height: 500}).atLeast(1);
+
+    const configObj = {
+      adConstraints: {
+        initialMinSpacing: '0.4vp',
+        subsequentMinSpacing: [
+          {
+            adCount: 2,
+            spacing: '0.5vp',
+          },
+          {
+            adCount: 4,
+            spacing: '1.5vp',
+          },
+        ],
+        maxAdCount: 8,
+      },
+    };
+
+    expect(getAdConstraintsFromConfigObj(ampdoc, configObj)).to.deep.equal({
+      initialMinSpacing: 200,
+      subsequentMinSpacing: [
+        {
+          adCount: 2,
+          spacing: 250,
+        },
+        {
+          adCount: 4,
+          spacing: 750
+        },
+      ],
+      maxAdCount: 8,
+    });
+  });
+
+  it('should handle no subsequentMinSpacing', () => {
+    const configObj = {
+      adConstraints: {
+        initialMinSpacing: '150px',
+        maxAdCount: 8,
+      },
+    };
+
+    expect(getAdConstraintsFromConfigObj(ampdoc, configObj)).to.deep.equal({
+      initialMinSpacing: 150,
+      subsequentMinSpacing: [],
+      maxAdCount: 8,
+    });
+  });
+
+  it('should return null when initialMinSpacing unparsable', () => {
+    const configObj = {
+      adConstraints: {
+        initialMinSpacing: '150em',
+        subsequentMinSpacing: [
+          {
+            adCount: 2,
+            spacing: '160px',
+          },
+          {
+            adCount: 4,
+            spacing: '170px',
+          },
+        ],
+        maxAdCount: 8,
+      },
+    };
+
+    expect(getAdConstraintsFromConfigObj(ampdoc, configObj)).to.be.null;
+  });
+
+  it('should return null when subsequentMinSpacing unparsable', () => {
+    const configObj = {
+      adConstraints: {
+        initialMinSpacing: '150px',
+        subsequentMinSpacing: [
+          {
+            adCount: 2,
+            spacing: '160px',
+          },
+          {
+            adCount: 4,
+            spacing: '170em',
+          },
+        ],
+        maxAdCount: 8,
+      },
+    };
+
+    expect(getAdConstraintsFromConfigObj(ampdoc, configObj)).to.be.null;
   });
 });

--- a/extensions/amp-auto-ads/0.1/test/test-amp-auto-ads.js
+++ b/extensions/amp-auto-ads/0.1/test/test-amp-auto-ads.js
@@ -433,4 +433,52 @@ describes.realWin('amp-auto-ads', {
       });
     });
   });
+
+  describe('ad constraints', () => {
+    it('should insert 3 ads when using the default ad contraints', () => {
+      ampAutoAdsElem.setAttribute('data-ad-client', AD_CLIENT);
+      ampAutoAdsElem.setAttribute('type', 'adsense');
+      ampAutoAds.buildCallback();
+
+      return new Promise(resolve => {
+        waitForChild(anchor4, parent => {
+          return parent.childNodes.length > 0;
+        }, () => {
+          expect(anchor1.childNodes).to.have.lengthOf(1);
+          expect(anchor2.childNodes).to.have.lengthOf(1);
+          expect(anchor3.childNodes).to.have.lengthOf(0);
+          expect(anchor4.childNodes).to.have.lengthOf(1);
+          verifyAdElement(anchor1.childNodes[0]);
+          verifyAdElement(anchor2.childNodes[0]);
+          verifyAdElement(anchor4.childNodes[0]);
+          resolve();
+        });
+      });
+    });
+
+    it('should insert 2 ads when using the config ad constraints', () => {
+      configObj.adConstraints = {
+        initialMinSpacing: '501px',
+        maxAdCount: 8,
+      };
+
+      ampAutoAdsElem.setAttribute('data-ad-client', AD_CLIENT);
+      ampAutoAdsElem.setAttribute('type', 'adsense');
+      ampAutoAds.buildCallback();
+
+      return new Promise(resolve => {
+        waitForChild(anchor2, parent => {
+          return parent.childNodes.length > 0;
+        }, () => {
+          expect(anchor1.childNodes).to.have.lengthOf(1);
+          expect(anchor2.childNodes).to.have.lengthOf(1);
+          expect(anchor3.childNodes).to.have.lengthOf(0);
+          expect(anchor4.childNodes).to.have.lengthOf(0);
+          verifyAdElement(anchor1.childNodes[0]);
+          verifyAdElement(anchor2.childNodes[0]);
+          resolve();
+        });
+      });
+    });
+  });
 });

--- a/extensions/amp-auto-ads/amp-auto-ads.md
+++ b/extensions/amp-auto-ads/amp-auto-ads.md
@@ -1,5 +1,5 @@
 <!---
-Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+Copyright 2018 The AMP HTML Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -147,6 +147,11 @@ The fields to specify in the configuration object:
         <li>data-* (i.e. any data attribute)</li>
       </ul>
     </td>
+  </tr>
+  <tr>
+    <td><code>adConstraints</code></td>
+    <td>AdConstraintsObj</td>
+    <td>An <em>optional</em> field that specifies the contraints that should be used when placing ads on the page.</td>
   </tr>
 </table>
 
@@ -305,6 +310,78 @@ The ENUM values for the `type` field in the `placements` configuration object:
     <td>BANNER</td>
     <td>1</td>
     <td>Placement describes a banner ad position.</td>
+  </tr>
+</table>
+
+#### AdConstraintsObj
+
+The fields to specify in the `adConstraints` configuration object: 
+
+<table>
+  <tr>
+    <th class="col-twenty">Field Name</th>
+    <th class="col-twenty">Type</th>
+    <th class="col-fourty" >Description</th>
+  </tr>
+  <tr>
+    <td><code>initialMinSpacing</code></td>
+    <td>string</td>
+    <td>
+      A <strong>required</strong> field that indicates the minimum distance that an ad should be from any ads already on the page (either manually placed or previously placed by amp-auto-ads) at the time of insertion.
+      Values are expressed as a number with a units prefix. E.g. "10px" means 10 pixels, or "0.5vp" means half a viewport. The supported units are:
+      <ul>
+        <li>px - pixels</li>
+        <li>vp - viewports</li>
+      </ul>
+      This value applies only when the number of ads already on the page is less than any <code>adCount</code> matcher specified in the subsequentMinSpacing field.
+    </td>
+  </tr>
+  <tr>
+    <td><code>subsequentMinSpacing</code></td>
+    <td>Array&lt;!SubsequentMinSpacingObj&gt;</td>
+    <td>
+      An <em>optional</em> field that specifies the ad spacings that should apply based on how many ads are already on the page at the time of insertion.
+    </td>
+  </tr>
+  <tr>
+    <td><code>maxAdCount</code></td>
+    <td>number</td>
+    <td>
+      A <strong>required</strong> field that specifies the maximum number of ads that <code>amp-auto-ads</code> can cause there to be on a page. Both manually placed ads, as well as those placed by <code>amp-auto-ads</code> count towards this total.
+      E.g. if this field were set to 5 and there were 3 manually placed ads on the page, then <code>amp-auto-ads</code> would place a maximum of 2 additional ads.
+    </td>
+  </tr>
+</table>
+
+#### SubsequentMinSpacingObj
+
+The fields to specify in the `subsequentMinSpacing` configuration object: 
+
+<table>
+  <tr>
+    <th class="col-twenty">Field Name</th>
+    <th class="col-twenty">Type</th>
+    <th class="col-fourty" >Description</th>
+  </tr>
+  <tr>
+    <td><code>adCount</code></td>
+    <td>number</td>
+    <td>
+      A <strong>required</strong> field.
+      If the next ad to be inserted would make the total ad count for the page n, then this rule applies where <code>adCount</code> &lt;= n, but no other <code>SubsequentMinSpacingObj</code> in the parent <code>Array</code> has an <code>adCount</code> that is greater and also &lt;= n.
+    </td>
+  </tr>
+  <tr>
+    <td><code>spacing</code></td>
+    <td>string</td>
+    <td>
+      A <strong>required</strong> field that specifies the minimum ad spacing that applies when this rule is matched based on the <code>adCount</code>.
+      Values are expressed as a number with a units prefix. E.g. "10px" means 10 pixels, or "0.5vp" means half a viewport. The supported units are:
+      <ul>
+        <li>px - pixels</li>
+        <li>vp - viewports</li>
+      </ul>
+    </td>
   </tr>
 </table>
 


### PR DESCRIPTION
The ad constraints allow the spacing of inserted ads to be controlled. Currently this is hard-coded for each ad network inside the amp-auto-ads.js binary. With this PR ad networks can optionally specify the ad constraints to use in the over-the-wire config that they return.