### PR TITLE
Allows ad constraints to be specified by the over-the-wire config

### DIFF
--- a/extensions/amp-auto-ads/0.1/ad-network-config.js
+++ b/extensions/amp-auto-ads/0.1/ad-network-config.js
@@ -54,7 +54,7 @@ class AdNetworkConfigDef {
    * Network specific constraints on the placement of ads on the page.
    * @return {!./ad-tracker.AdConstraints}
    */
-  getAdConstraints() {}
+  getDefaultAdConstraints() {}
 }
 
 /**
@@ -110,7 +110,7 @@ class AdSenseNetworkConfig {
   }
 
   /** @override */
-  getAdConstraints() {
+  getDefaultAdConstraints() {
     const viewportHeight =
         Services.viewportForDoc(this.autoAmpAdsElement_).getSize().height;
     return {

--- a/extensions/amp-auto-ads/0.1/amp-auto-ads.js
+++ b/extensions/amp-auto-ads/0.1/amp-auto-ads.js
@@ -15,7 +15,11 @@
  */
 
 import {AdStrategy} from './ad-strategy';
-import {AdTracker, getExistingAds} from './ad-tracker';
+import {
+  AdTracker,
+  getAdConstraintsFromConfigObj,
+  getExistingAds,
+} from './ad-tracker';
 import {AnchorAdStrategy} from './anchor-ad-strategy';
 import {Services} from '../../../src/services';
 import {getAdNetworkConfig} from './ad-network-config';
@@ -65,8 +69,9 @@ export class AmpAutoAds extends AMP.BaseElement {
       const attributes = /** @type {!JsonObject} */ (
         Object.assign(adNetwork.getAttributes(),
             getAttributesFromConfigObj(configObj)));
-      const adTracker =
-          new AdTracker(getExistingAds(ampdoc), adNetwork.getAdConstraints());
+      const adConstraints = getAdConstraintsFromConfigObj(ampdoc, configObj) ||
+          adNetwork.getDefaultAdConstraints();
+      const adTracker = new AdTracker(getExistingAds(ampdoc), adConstraints);
       new AdStrategy(placements, attributes, adTracker).run();
       new AnchorAdStrategy(ampdoc, attributes, configObj).run();
     });

--- a/extensions/amp-auto-ads/0.1/test/test-ad-network-config.js
+++ b/extensions/amp-auto-ads/0.1/test/test-ad-network-config.js
@@ -111,14 +111,14 @@ describes.realWin('ad-network-config', {
       });
     });
 
-    it('should get the ad constraints', () => {
+    it('should get the default ad constraints', () => {
       const viewportMock =
           sandbox.mock(Services.viewportForDoc(env.win.document));
       viewportMock.expects('getSize').returns(
           {width: 320, height: 500}).atLeast(1);
 
       const adNetwork = getAdNetworkConfig('adsense', ampAutoAdsElem);
-      expect(adNetwork.getAdConstraints()).to.deep.equal({
+      expect(adNetwork.getDefaultAdConstraints()).to.deep.equal({
         initialMinSpacing: 500,
         subsequentMinSpacing: [
           {adCount: 3, spacing: 1000},

--- a/extensions/amp-auto-ads/0.1/test/test-amp-auto-ads.js
+++ b/extensions/amp-auto-ads/0.1/test/test-amp-auto-ads.js
@@ -433,4 +433,54 @@ describes.realWin('amp-auto-ads', {
       });
     });
   });
+
+  describe('ad constraints', () => {
+    it('should insert 3 ads when using the default ad contraints', () => {
+      ampAutoAdsElem.setAttribute('data-ad-client', AD_CLIENT);
+      ampAutoAdsElem.setAttribute('type', 'adsense');
+      ampAutoAds.buildCallback();
+
+      return new Promise(resolve => {
+        waitForChild(anchor4, parent => {
+          return parent.childNodes.length > 0;
+        }, () => {
+          expect(anchor1.childNodes).to.have.lengthOf(1);
+          expect(anchor2.childNodes).to.have.lengthOf(1);
+          expect(anchor3.childNodes).to.have.lengthOf(0);
+          expect(anchor4.childNodes).to.have.lengthOf(1);
+          verifyAdElement(anchor1.childNodes[0]);
+          verifyAdElement(anchor2.childNodes[0]);
+          verifyAdElement(anchor4.childNodes[0]);
+          resolve();
+        });
+      });
+    });
+
+    it('should insert 4 ads when using the config ad constraints', () => {
+      configObj.adConstraints = {
+        initialMinSpacing: '499px',
+        maxAdCount: 8,
+      };
+
+      ampAutoAdsElem.setAttribute('data-ad-client', AD_CLIENT);
+      ampAutoAdsElem.setAttribute('type', 'adsense');
+      ampAutoAds.buildCallback();
+
+      return new Promise(resolve => {
+        waitForChild(anchor4, parent => {
+          return parent.childNodes.length > 0;
+        }, () => {
+          expect(anchor1.childNodes).to.have.lengthOf(1);
+          expect(anchor2.childNodes).to.have.lengthOf(1);
+          expect(anchor3.childNodes).to.have.lengthOf(1);
+          expect(anchor4.childNodes).to.have.lengthOf(1);
+          verifyAdElement(anchor1.childNodes[0]);
+          verifyAdElement(anchor2.childNodes[0]);
+          verifyAdElement(anchor3.childNodes[0]);
+          verifyAdElement(anchor4.childNodes[0]);
+          resolve();
+        });
+      });
+    });
+  });
 });

--- a/extensions/amp-auto-ads/amp-auto-ads.md
+++ b/extensions/amp-auto-ads/amp-auto-ads.md
@@ -148,6 +148,14 @@ The fields to specify in the configuration object:
       </ul>
     </td>
   </tr>
+  <tr>
+    <td><code>adConstraints</code></td>
+    <td>AdConstraintsObj</td>
+    <td>
+      An <em>optional</em> field that specifies the contraints that should be used when placing ads on the page. If not specified then
+      <code>amp-auto-ads</code> will attempt to use the default constraints specified in [ad-network-config.js](0.1/ad-network-config.js).
+    </td>
+  </tr>
 </table>
 
 #### PlacementObj
@@ -305,6 +313,101 @@ The ENUM values for the `type` field in the `placements` configuration object:
     <td>BANNER</td>
     <td>1</td>
     <td>Placement describes a banner ad position.</td>
+  </tr>
+</table>
+
+#### AdConstraintsObj
+
+The fields to specify in the `adConstraints` configuration object: 
+
+<table>
+  <tr>
+    <th class="col-twenty">Field Name</th>
+    <th class="col-twenty">Type</th>
+    <th class="col-fourty" >Description</th>
+  </tr>
+  <tr>
+    <td><code>initialMinSpacing</code></td>
+    <td>string</td>
+    <td>
+      A <strong>required</strong> field that indicates the minimum distance that an ad should be from any ads already on the page (either manually placed or previously placed by amp-auto-ads) at the time of insertion.
+      Values are expressed as a number with a units prefix. E.g. "10px" means 10 pixels, or "0.5vp" means half a viewport height. Negative values are invalid. The supported units are:
+      <ul>
+        <li>px - pixels</li>
+        <li>vp - multiple of viewport height</li>
+      </ul>
+      This value applies only when the number of ads already on the page is less than any <code>adCount</code> matcher specified in the subsequentMinSpacing field.
+    </td>
+  </tr>
+  <tr>
+    <td><code>subsequentMinSpacing</code></td>
+    <td>Array&lt;!SubsequentMinSpacingObj&gt;</td>
+    <td>
+      An <em>optional</em> field that specifies the ad spacings that should apply based on how many ads are already on the page at the time of insertion.
+    </td>
+  </tr>
+  <tr>
+    <td><code>maxAdCount</code></td>
+    <td>number</td>
+    <td>
+      A <strong>required</strong> field that specifies the maximum number of ads that <code>amp-auto-ads</code> can cause there to be on a page. Both manually placed ads, as well as those placed by <code>amp-auto-ads</code> count towards this total.
+      E.g. if this field were set to 5 and there were 3 manually placed ads on the page, then <code>amp-auto-ads</code> would place a maximum of 2 additional ads.
+    </td>
+  </tr>
+</table>
+
+#### SubsequentMinSpacingObj
+
+The fields to specify in the `subsequentMinSpacing` configuration object. `subsequentMinSpacing` entries
+can be used to change the spacing required between any additional ads based on the number of ads already on
+the page. As an example, consider the following scenario:
+<ul>
+  <li>2 existing ads on the page</li>
+  <li>subsequentMinSpacing field is:
+    <code>
+      [
+        {adCount: 3, spacing: "500px"},
+        {adCount: 5, spacing: "1000px"},
+      ]
+    </code>
+  </li>
+</ul>
+Initially there are 2 existing ads on the page, so no mapping matches.
+The minimum spacing therefore defaults to initialMinSpacing in the `AdConstraints` object.
+`amp-auto-ads` will recursively try to place ads until it runs out of placements that
+could be used without breaking the `adContraints`.
+After `amp-auto-ads` has placed its first ad, there are now 3 ads on the page, since
+there is a mapping for 3 (or more) ads in `subsequentMinSpacing`, the min spacing now becomes 500px.
+This applies up until the point where there are 5 ads on the page, since
+there is a rule for 5 ads. Inserting the 6+th ad would then require
+it to be clear of other ads by at least 1000px.
+
+<table>
+  <tr>
+    <th class="col-twenty">Field Name</th>
+    <th class="col-twenty">Type</th>
+    <th class="col-fourty" >Description</th>
+  </tr>
+  <tr>
+    <td><code>adCount</code></td>
+    <td>number</td>
+    <td>
+      A <strong>required</strong> field.
+      The minimum number of ads already on the page that cause this rule to apply (assuming no other rule is a better match). See description above
+      for a more detailed explanation.
+    </td>
+  </tr>
+  <tr>
+    <td><code>spacing</code></td>
+    <td>string</td>
+    <td>
+      A <strong>required</strong> field that specifies the minimum ad spacing that applies when this rule is matched based on the <code>adCount</code>.
+      Values are expressed as a number with a units prefix. E.g. "10px" means 10 pixels, or "0.5vp" means half a viewport height. Negative values are invalid. The supported units are:
+      <ul>
+        <li>px - pixels</li>
+        <li>vp - multiple of viewport height</li>
+      </ul>
+    </td>
   </tr>
 </table>
 


### PR DESCRIPTION
The ad constraints allow the spacing of inserted ads to be controlled. Currently this is hard-coded for each ad network inside the amp-auto-ads.js binary. With this PR ad networks can optionally specify the ad constraints to use in the over-the-wire config that they return.