### PR TITLE
Remove the story scrollbar on iOS iframes.

### DIFF
--- a/extensions/amp-story/0.1/amp-story.css
+++ b/extensions/amp-story/0.1/amp-story.css
@@ -74,6 +74,12 @@ html.i-amphtml-story-standalone body {
   display: grid !important;
 }
 
+html#i-amphtml-wrapper > body {
+  /** AMP runtime adds a 1px border on iOS iframes, causing the body to be
+      1px bigger than the viewport. */
+  border-top: none !important;
+}
+
 amp-story[standalone] {
   align-self: center !important;
   box-shadow: 2px 2px 20px rgba(0, 0, 0, 0.5) !important;

--- a/extensions/amp-story/0.1/amp-story.css
+++ b/extensions/amp-story/0.1/amp-story.css
@@ -74,10 +74,11 @@ html.i-amphtml-story-standalone body {
   display: grid !important;
 }
 
-html#i-amphtml-wrapper > body {
+html.i-amphtml-story-standalone #i-amphtml-wrapper body {
   /** AMP runtime adds a 1px border on iOS iframes, causing the body to be
       1px bigger than the viewport. */
   border-top: none !important;
+  overflow: hidden !important;
 }
 
 amp-story[standalone] {

--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -63,6 +63,7 @@ html.i-amphtml-story-standalone body {
   margin: 0 !important;
   padding: 0 !important;
   width: 100% !important;
+  border: 0 !important;
   /** Remove the cursor: pointer; style set by the runtime, to avoid wrong
       touch feedback on mobile, like a flashing overlay on page transitions. */
   cursor: auto !important;

--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -73,6 +73,12 @@ html.i-amphtml-story-standalone body {
   display: grid !important;
 }
 
+html#i-amphtml-wrapper > body {
+  /** AMP runtime adds a 1px border on iOS iframes, causing the body to be
+      1px bigger than the viewport. */
+  border-top: none !important;
+}
+
 amp-story[standalone] {
   align-self: center !important;
   box-shadow: 2px 2px 20px rgba(0, 0, 0, 0.5) !important;

--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -73,10 +73,11 @@ html.i-amphtml-story-standalone body {
   display: grid !important;
 }
 
-html#i-amphtml-wrapper > body {
+html.i-amphtml-story-standalone #i-amphtml-wrapper body {
   /** AMP runtime adds a 1px border on iOS iframes, causing the body to be
       1px bigger than the viewport. */
   border-top: none !important;
+  overflow: hidden !important;
 }
 
 amp-story[standalone] {


### PR DESCRIPTION
AMP runtime [adds a 1px border top](https://github.com/ampproject/amphtml/blob/master/css/amp.css#L139) on iOS iframes, which causes the body to be 1px bigger than the viewport and a scrollbar to appear.
For example, emulating an iPhone with Chrome and clicking on a STAMP from the SERP will [display a scrollbar](https://screenshot.googleplex.com/HasVyQZAy3Y.png).

This border-top seems to address two issues, but I think we're fine with removing it:
- Scroll freeze problems: we don't have scrolling
- Fixing absolute positioned items that are relative to the body: our top element ``<amp-story>`` is ``position: relative``, so we won't experience this issue

If you think it's too risky to remove this border, another solution would be to set the ``body`` to ``box-sizing: border-box;`` to include the border-top into the body height.