### PR TITLE
Fix action whitelist error message and minor refactoring

### DIFF
--- a/build-system/tasks/bundle-size.js
+++ b/build-system/tasks/bundle-size.js
@@ -21,7 +21,7 @@ const gulp = require('gulp-help')(require('gulp'));
 const log = require('fancy-log');
 
 const runtimeFile = './dist/v0.js';
-const maxSize = '77.71KB';
+const maxSize = '77.76KB';
 
 const green = colors.green;
 const red = colors.red;

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -1334,7 +1334,7 @@ function createBaseCustomElementClass(win) {
         this.implementation_.executeAction(invocation, deferred);
       } catch (e) {
         rethrowAsync('Action execution failed:', e,
-            invocation.target.tagName, invocation.method);
+            invocation.node.tagName, invocation.method);
       }
     }
 

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -147,30 +147,30 @@ export class ActionInvocation {
    *     <button id="btn">Submit</button>
    *   </div>
    *
-   * `target` is #myForm.
+   * `node` is #myForm.
    * `method` is "submit".
    * `args` is {'foo': 'bar'}.
    * `source` is #btn.
    * `caller` is #div.
    * `event` is a "click" Event object.
    * `trust` depends on whether this action was a result of a user gesture.
-   * `targetType` is "amp-form".
+   * `targetOrTag` is "amp-form".
    * `index` is 0.
    *
-   * @param {!Node} target Element whose action is being invoked.
+   * @param {!Node} node Element whose action is being invoked.
    * @param {string} method Name of the action being invoked.
    * @param {?JsonObject} args Named action arguments.
    * @param {?Element} source Element that generated the `event`.
    * @param {?Element} caller Element that contains the invoked handler.
    * @param {?ActionEventDef} event The event that triggered this action.
    * @param {ActionTrust} trust The trust level of this invocation's trigger.
-   * @param {?string} targetType The global target name or the element tagName.
+   * @param {?string} targetOrTag The global target name or the element tagName.
    * @param {number} index Position in a sequence of actions.
    */
-  constructor(target, method, args, source, caller, event, trust,
-    targetType = null, index = 0) {
+  constructor(node, method, args, source, caller, event, trust,
+    targetOrTag = null, index = 0) {
     /** @const {!Node} */
-    this.target = target;
+    this.node = node;
     /** @const {string} */
     this.method = method;
     /** @const {?JsonObject} */
@@ -184,7 +184,7 @@ export class ActionInvocation {
     /** @const {ActionTrust} */
     this.trust = trust;
     /** @const {string} */
-    this.targetType = targetType || target.tagName;
+    this.targetOrTag = targetOrTag || node.tagName;
     /** @const {number} */
     this.index = index;
   }
@@ -437,7 +437,7 @@ export class ActionService {
 
   /**
    * Overwrites the current action whitelist (if any). Takes an array of strings
-   * of the form "<targetType>.<method>", e.g. "amp-form.submit" or "AMP.print".
+   * of the form "<targetOrTag>.<method>" e.g. "amp-form.submit" or "AMP.print".
    * @param {!Array<string>} whitelist
    */
   setWhitelist(whitelist) {
@@ -446,7 +446,7 @@ export class ActionService {
 
   /**
    * Adds an action to the whitelist. Takes one string of the form
-   * "<targetType>.<method>", e.g. "amp-form.submit" or "AMP.print".
+   * "<targetOrTag>.<method>", e.g. "amp-form.submit" or "AMP.print".
    * @param {string} action
    */
   addToWhitelist(action) {
@@ -472,20 +472,22 @@ export class ActionService {
     // to complete. `currentPromise` is the i'th promise in the chain.
     let currentPromise = null;
     action.actionInfos.forEach((actionInfo, i) => {
-      const targetType = actionInfo.target;
       // Replace any variables in args with data in `event`.
       const args = dereferenceExprsInArgs(actionInfo.args, event);
       const invokeAction = () => {
-        // Use `this.root_` as the target for global targets e.g. "AMP".
-        // Otherwise, targetType should be an element id.
-        const target = (this.globalTargets_[targetType]) ?
-          this.root_ : this.root_.getElementById(targetType);
-        if (target) {
-          const invocation = new ActionInvocation(target, actionInfo.method,
-              args, source, action.node, event, trust, targetType, i);
+        // Document root is the target node for global targets e.g. "AMP".
+        const target = actionInfo.target;
+        // If it isn't a global target, it should be an element id.
+        // Find the corresponding element.
+        const node = (this.globalTargets_[target])
+          ? this.root_
+          : this.root_.getElementById(target);
+        if (node) {
+          const invocation = new ActionInvocation(node, actionInfo.method,
+              args, source, action.node, event, trust, node.tagName || target, i);
           return this.invoke_(invocation, action.actionInfos);
         } else {
-          this.error_(`Target "${targetType}" not found for action ` +
+          this.error_(`Target "${target}" not found for action ` +
               `[${actionInfo.str}].`);
         }
       };
@@ -523,11 +525,11 @@ export class ActionService {
    */
   invoke_(invocation, opt_actionInfos) {
     const method = invocation.method;
-    const targetType = invocation.targetType;
+    const targetOrTag = invocation.targetOrTag;
 
     // Check that this action is whitelisted (if a whitelist is set).
     if (this.whitelist_) {
-      const id = `${targetType}.${method}`;
+      const id = `${targetOrTag}.${method}`;
       if (!this.whitelist_.includes(id)) {
         this.error_(`"${id}" is not whitelisted (${this.whitelist_}).`);
         return null;
@@ -535,13 +537,13 @@ export class ActionService {
     }
 
     // Handle global targets e.g. "AMP".
-    const globalTarget = this.globalTargets_[targetType];
+    const globalTarget = this.globalTargets_[targetOrTag];
     if (globalTarget) {
       return globalTarget(invocation, invocation.index, opt_actionInfos);
     }
 
     // Subsequent handlers assume that invocation target is an Element.
-    const target = dev().assertElement(invocation.target);
+    const node = dev().assertElement(invocation.node);
 
     // Handle global actions e.g. "<any-element-id>.toggle".
     const globalMethod = this.globalMethodHandlers_[method];
@@ -550,12 +552,12 @@ export class ActionService {
     }
 
     // Handle element-specific actions.
-    const lowerTagName = target.tagName.toLowerCase();
+    const lowerTagName = node.tagName.toLowerCase();
     if (lowerTagName.substring(0, 4) == 'amp-') {
-      if (target.enqueAction) {
-        target.enqueAction(invocation);
+      if (node.enqueAction) {
+        node.enqueAction(invocation);
       } else {
-        this.error_(`Unrecognized AMP element "${lowerTagName}".`, target);
+        this.error_(`Unrecognized AMP element "${lowerTagName}".`, node);
       }
       return null;
     }
@@ -563,24 +565,24 @@ export class ActionService {
     // Special elements with AMP ID or known supported actions.
     const supportedActions = ELEMENTS_ACTIONS_MAP_[lowerTagName];
     // TODO(dvoytenko, #7063): switch back to `target.id` with form proxy.
-    const targetId = target.getAttribute('id') || '';
+    const targetId = node.getAttribute('id') || '';
     if ((targetId && targetId.substring(0, 4) == 'amp-') ||
         (supportedActions && supportedActions.indexOf(method) > -1)) {
-      const holder = target[ACTION_HANDLER_];
+      const holder = node[ACTION_HANDLER_];
       if (holder) {
         const {handler, minTrust} = holder;
         if (invocation.satisfiesTrust(minTrust)) {
           handler(invocation);
         }
       } else {
-        target[ACTION_QUEUE_] = target[ACTION_QUEUE_] || [];
-        target[ACTION_QUEUE_].push(invocation);
+        node[ACTION_QUEUE_] = node[ACTION_QUEUE_] || [];
+        node[ACTION_QUEUE_].push(invocation);
       }
       return null;
     }
 
     // Unsupported method.
-    this.error_(`Target (${targetType}) doesn't support "${method}" action.`,
+    this.error_(`Target (${targetOrTag}) doesn't support "${method}" action.`,
         invocation.caller);
 
     return null;

--- a/src/service/standard-actions-impl.js
+++ b/src/service/standard-actions-impl.js
@@ -139,7 +139,7 @@ export class StandardActions {
     if (!invocation.satisfiesTrust(ActionTrust.HIGH)) {
       return null;
     }
-    return Services.bindForDocOrNull(invocation.target).then(bind => {
+    return Services.bindForDocOrNull(invocation.node).then(bind => {
       user().assert(bind, 'AMP-BIND is not installed.');
 
       const objectString = invocation.args[OBJECT_STRING_ARGS_KEY];
@@ -171,7 +171,7 @@ export class StandardActions {
     if (!invocation.satisfiesTrust(ActionTrust.HIGH)) {
       return null;
     }
-    const node = invocation.target;
+    const node = invocation.node;
     const win = (node.ownerDocument || node).defaultView;
     const url = invocation.args['url'];
     const requestedBy = `AMP.${invocation.method}`;
@@ -200,7 +200,7 @@ export class StandardActions {
     if (!invocation.satisfiesTrust(ActionTrust.HIGH)) {
       return null;
     }
-    const node = invocation.target;
+    const node = invocation.node;
     const win = (node.ownerDocument || node).defaultView;
     win.print();
     return null;
@@ -231,7 +231,7 @@ export class StandardActions {
     if (!invocation.satisfiesTrust(ActionTrust.HIGH)) {
       return null;
     }
-    const node = dev().assertElement(invocation.target);
+    const node = dev().assertElement(invocation.node);
 
     // Duration for scroll animation
     const duration = invocation.args
@@ -260,7 +260,7 @@ export class StandardActions {
     if (!invocation.satisfiesTrust(ActionTrust.HIGH)) {
       return null;
     }
-    const node = dev().assertElement(invocation.target);
+    const node = dev().assertElement(invocation.node);
 
     // Set focus
     tryFocus(node);
@@ -275,7 +275,7 @@ export class StandardActions {
    * @return {?Promise}
    */
   handleHide(invocation) {
-    const target = dev().assertElement(invocation.target);
+    const target = dev().assertElement(invocation.node);
 
     this.resources_.mutateElement(target, () => {
       if (target.classList.contains('i-amphtml-element')) {
@@ -295,7 +295,7 @@ export class StandardActions {
    * @return {?Promise}
    */
   handleShow(invocation) {
-    const target = dev().assertElement(invocation.target);
+    const target = dev().assertElement(invocation.node);
     const ownerWindow = toWin(target.ownerDocument.defaultView);
 
     if (target.classList.contains(getLayoutClass(Layout.NODISPLAY))) {
@@ -336,7 +336,7 @@ export class StandardActions {
    * @return {?Promise}
    */
   handleToggle(invocation) {
-    if (isShowable(dev().assertElement(invocation.target))) {
+    if (isShowable(dev().assertElement(invocation.node))) {
       return this.handleShow(invocation);
     } else {
       return this.handleHide(invocation);

--- a/test/functional/test-action.js
+++ b/test/functional/test-action.js
@@ -53,10 +53,10 @@ function createExecElement(id, enqueAction) {
 }
 
 
-function assertInvocation(inv, target, method, source, caller, opt_event,
+function assertInvocation(inv, node, method, source, caller, opt_event,
   child, opt_args) {
 
-  expect(inv.target).to.equal(target);
+  expect(inv.node).to.equal(node);
   expect(inv.method).to.equal(method);
   expect(inv.caller).to.equal(caller);
 
@@ -674,7 +674,7 @@ describe('Action method', () => {
         'source1', 'caller1', 'event1'));
     expect(onEnqueue).to.be.calledOnce;
     const inv = onEnqueue.getCall(0).args[0];
-    expect(inv.target).to.equal(execElement);
+    expect(inv.node).to.equal(execElement);
     expect(inv.method).to.equal('method1');
     expect(inv.source).to.equal('source1');
     expect(inv.caller).to.equal('caller1');
@@ -687,7 +687,7 @@ describe('Action method', () => {
         'source1', 'caller1', 'event1'));
     expect(onEnqueue).to.be.calledOnce;
     const inv = onEnqueue.getCall(0).args[0];
-    expect(inv.target).to.equal(execElement);
+    expect(inv.node).to.equal(execElement);
     expect(inv.method).to.equal('method1');
     expect(inv.source).to.equal('source1');
     expect(inv.caller).to.equal('caller1');
@@ -715,7 +715,7 @@ describe('Action method', () => {
     action.trigger(child, 'tap', null);
     expect(onEnqueue).to.be.calledOnce;
     const inv = onEnqueue.getCall(0).args[0];
-    expect(inv.target).to.equal(execElement);
+    expect(inv.node).to.equal(execElement);
     expect(inv.method).to.equal('method1');
     expect(inv.source).to.equal(child);
     expect(inv.caller).to.equal(targetElement);
@@ -725,7 +725,7 @@ describe('Action method', () => {
     action.execute(execElement, 'method1', {'key1': 11}, child, null);
     expect(onEnqueue).to.be.calledOnce;
     const inv = onEnqueue.getCall(0).args[0];
-    expect(inv.target).to.equal(execElement);
+    expect(inv.node).to.equal(execElement);
     expect(inv.method).to.equal('method1');
     expect(inv.args['key1']).to.equal(11);
     expect(inv.source).to.equal(child);
@@ -753,7 +753,7 @@ describe('installActionHandler', () => {
         'button', 'button', 'tap', ActionTrust.HIGH));
     expect(handlerSpy).to.be.calledOnce;
     const callArgs = handlerSpy.getCall(0).args[0];
-    expect(callArgs.target).to.be.equal(target);
+    expect(callArgs.node).to.be.equal(target);
     expect(callArgs.method).to.be.equal('submit');
     expect(callArgs.args).to.be.equal(null);
     expect(callArgs.source).to.be.equal('button');
@@ -906,14 +906,14 @@ describe('Action interceptor', () => {
     expect(queue).to.have.length(2);
 
     const inv0 = queue[0];
-    expect(inv0.target).to.equal(target);
+    expect(inv0.node).to.equal(target);
     expect(inv0.method).to.equal('method1');
     expect(inv0.source).to.equal('source1');
     expect(inv0.caller).to.equal('caller1');
     expect(inv0.event).to.equal('event1');
 
     const inv1 = queue[1];
-    expect(inv1.target).to.equal(target);
+    expect(inv1.node).to.equal(target);
     expect(inv1.method).to.equal('method2');
     expect(inv1.source).to.equal('source2');
     expect(inv1.caller).to.equal('caller2');
@@ -939,14 +939,14 @@ describe('Action interceptor', () => {
     expect(handler).to.have.callCount(2);
 
     const inv0 = handler.getCall(0).args[0];
-    expect(inv0.target).to.equal(target);
+    expect(inv0.node).to.equal(target);
     expect(inv0.method).to.equal('method1');
     expect(inv0.source).to.equal('source1');
     expect(inv0.caller).to.equal('caller1');
     expect(inv0.event).to.equal('event1');
 
     const inv1 = handler.getCall(1).args[0];
-    expect(inv1.target).to.equal(target);
+    expect(inv1.node).to.equal(target);
     expect(inv1.method).to.equal('method2');
     expect(inv1.source).to.equal('source2');
     expect(inv1.caller).to.equal('caller2');
@@ -956,7 +956,7 @@ describe('Action interceptor', () => {
         'source3', 'caller3', 'event3', ActionTrust.HIGH));
     expect(handler).to.have.callCount(3);
     const inv2 = handler.getCall(2).args[0];
-    expect(inv2.target).to.equal(target);
+    expect(inv2.node).to.equal(target);
     expect(inv2.method).to.equal('method3');
     expect(inv2.source).to.equal('source3');
     expect(inv2.caller).to.equal('caller3');

--- a/test/functional/test-standard-actions.js
+++ b/test/functional/test-standard-actions.js
@@ -90,14 +90,14 @@ describes.sandboxed('StandardActions', {}, () => {
   describe('"hide" action', () => {
     it('should handle normal element', () => {
       const element = createElement();
-      const invocation = {target: element, satisfiesTrust: () => true};
+      const invocation = {node: element, satisfiesTrust: () => true};
       standardActions.handleHide(invocation);
       expectElementToHaveBeenHidden(element);
     });
 
     it('should handle AmpElement', () => {
       const element = createAmpElement();
-      const invocation = {target: element, satisfiesTrust: () => true};
+      const invocation = {node: element, satisfiesTrust: () => true};
       standardActions.handleHide(invocation);
       expectAmpElementToHaveBeenHidden(element);
     });
@@ -107,7 +107,7 @@ describes.sandboxed('StandardActions', {}, () => {
     it('should handle normal element (inline css)', () => {
       const element = createElement();
       element.style.display = 'none';
-      const invocation = {target: element, satisfiesTrust: () => true};
+      const invocation = {node: element, satisfiesTrust: () => true};
       standardActions.handleShow(invocation);
       expectElementToHaveBeenShown(element);
     });
@@ -115,7 +115,7 @@ describes.sandboxed('StandardActions', {}, () => {
     it('should handle normal element (hidden attribute)', () => {
       const element = createElement();
       element.setAttribute('hidden', '');
-      const invocation = {target: element, satisfiesTrust: () => true};
+      const invocation = {node: element, satisfiesTrust: () => true};
       standardActions.handleShow(invocation);
       expectElementToHaveBeenShown(element);
     });
@@ -123,7 +123,7 @@ describes.sandboxed('StandardActions', {}, () => {
     it('should handle AmpElement (inline css)', () => {
       const element = createAmpElement();
       element.style.display = 'none';
-      const invocation = {target: element, satisfiesTrust: () => true};
+      const invocation = {node: element, satisfiesTrust: () => true};
       standardActions.handleShow(invocation);
       expectAmpElementToHaveBeenShown(element);
     });
@@ -134,7 +134,7 @@ describes.sandboxed('StandardActions', {}, () => {
     it('should show normal element when hidden (inline css)', () => {
       const element = createElement();
       element.style.display = 'none';
-      const invocation = {target: element, satisfiesTrust: () => true};
+      const invocation = {node: element, satisfiesTrust: () => true};
       standardActions.handleToggle(invocation);
       expectElementToHaveBeenShown(element);
     });
@@ -142,14 +142,14 @@ describes.sandboxed('StandardActions', {}, () => {
     it('should show normal element when hidden (hidden attribute)', () => {
       const element = createElement();
       element.setAttribute('hidden', '');
-      const invocation = {target: element, satisfiesTrust: () => true};
+      const invocation = {node: element, satisfiesTrust: () => true};
       standardActions.handleToggle(invocation);
       expectElementToHaveBeenShown(element);
     });
 
     it('should hide normal element when shown', () => {
       const element = createElement();
-      const invocation = {target: element, satisfiesTrust: () => true};
+      const invocation = {node: element, satisfiesTrust: () => true};
       standardActions.handleToggle(invocation);
       expectElementToHaveBeenHidden(element);
     });
@@ -157,14 +157,14 @@ describes.sandboxed('StandardActions', {}, () => {
     it('should show AmpElement when hidden (inline css)', () => {
       const element = createAmpElement();
       element.style.display = 'none';
-      const invocation = {target: element, satisfiesTrust: () => true};
+      const invocation = {node: element, satisfiesTrust: () => true};
       standardActions.handleToggle(invocation);
       expectAmpElementToHaveBeenShown(element);
     });
 
     it('should hide AmpElement when shown', () => {
       const element = createAmpElement();
-      const invocation = {target: element, satisfiesTrust: () => true};
+      const invocation = {node: element, satisfiesTrust: () => true};
       standardActions.handleToggle(invocation);
       expectAmpElementToHaveBeenHidden(element);
     });
@@ -173,14 +173,14 @@ describes.sandboxed('StandardActions', {}, () => {
   describe('"scrollTo" action', () => {
     it('should handle normal element', () => {
       const element = createElement();
-      const invocation = {target: element, satisfiesTrust: () => true};
+      const invocation = {node: element, satisfiesTrust: () => true};
       standardActions.handleScrollTo(invocation);
       expectAmpElementToHaveBeenScrolledIntoView(element);
     });
 
     it('should handle AmpElement', () => {
       const element = createAmpElement();
-      const invocation = {target: element, satisfiesTrust: () => true};
+      const invocation = {node: element, satisfiesTrust: () => true};
       standardActions.handleScrollTo(invocation);
       expectAmpElementToHaveBeenScrolledIntoView(element);
     });
@@ -189,7 +189,7 @@ describes.sandboxed('StandardActions', {}, () => {
   describe('"focus" action', () => {
     it('should handle normal element', () => {
       const element = createElement();
-      const invocation = {target: element, satisfiesTrust: () => true};
+      const invocation = {node: element, satisfiesTrust: () => true};
       const focusStub = sandbox.stub(element, 'focus');
       standardActions.handleFocus(invocation);
       expect(focusStub).to.be.calledOnce;
@@ -197,7 +197,7 @@ describes.sandboxed('StandardActions', {}, () => {
 
     it('should handle AmpElement', () => {
       const element = createAmpElement();
-      const invocation = {target: element, satisfiesTrust: () => true};
+      const invocation = {node: element, satisfiesTrust: () => true};
       const focusStub = sandbox.stub(element, 'focus');
       standardActions.handleFocus(invocation);
       expect(focusStub).to.be.calledOnce;
@@ -215,7 +215,7 @@ describes.sandboxed('StandardActions', {}, () => {
         args: {
           url: 'http://bar.com',
         },
-        target: {
+        node: {
           ownerDocument: {
             defaultView: win,
           },
@@ -268,9 +268,9 @@ describes.sandboxed('StandardActions', {}, () => {
       const args = {
         [OBJECT_STRING_ARGS_KEY]: '{foo: 123}',
       };
-      const target = ampdoc;
+      const node = ampdoc;
       const satisfiesTrust = () => true;
-      const setState = {method: 'setState', args, target, satisfiesTrust};
+      const setState = {method: 'setState', args, node, satisfiesTrust};
 
       return standardActions.handleAmpTarget(setState, 0, []).then(result => {
         expect(result).to.equal('set-state-complete');
@@ -292,9 +292,9 @@ describes.sandboxed('StandardActions', {}, () => {
       const args = {
         [OBJECT_STRING_ARGS_KEY]: '{foo: 123}',
       };
-      const target = ampdoc;
+      const node = ampdoc;
       const satisfiesTrust = () => true;
-      const pushState = {method: 'pushState', args, target, satisfiesTrust};
+      const pushState = {method: 'pushState', args, node, satisfiesTrust};
 
       return standardActions.handleAmpTarget(pushState, 0, []).then(result => {
         expect(result).to.equal('push-state-complete');
@@ -314,13 +314,13 @@ describes.sandboxed('StandardActions', {}, () => {
       const firstSetState = {
         method: 'setState',
         args: {[OBJECT_STRING_ARGS_KEY]: '{foo: 123}'},
-        target: ampdoc,
+        node: ampdoc,
         satisfiesTrust: () => true,
       };
       const secondSetState = {
         method: 'setState',
         args: {[OBJECT_STRING_ARGS_KEY]: '{bar: 456}'},
-        target: ampdoc,
+        node: ampdoc,
         satisfiesTrust: () => true,
       };
       const actionInfos = [
@@ -328,7 +328,9 @@ describes.sandboxed('StandardActions', {}, () => {
         {target: 'AMP', method: 'setState'},
       ];
       standardActions.handleAmpTarget(firstSetState, 0, actionInfos);
-      standardActions.handleAmpTarget(secondSetState, 1, actionInfos);
+      allowConsoleError(() => {
+        standardActions.handleAmpTarget(secondSetState, 1, actionInfos);
+      });
 
       return Services.bindForDocOrNull(ampdoc).then(() => {
         // Only first setState call should be allowed.
@@ -346,7 +348,7 @@ describes.sandboxed('StandardActions', {}, () => {
       const invocation = {
         method: 'print',
         satisfiesTrust: () => true,
-        target: {
+        node: {
           ownerDocument: {
             defaultView: windowApi,
           },


### PR DESCRIPTION
Fixes #15177.

Other minor cleanup:
- The word "target" was overloaded between `ActionInfo` and `ActionInvocation` so I renamed the latter's usage of it to "node"
- Renamed `ActionInvocation`'s "targetType" to the clearer "tagOrTarget"

/to @alabiaga 