### PR TITLE
🐛 Fix amp-story-bookend tests

### DIFF
--- a/extensions/amp-story/1.0/bookend/amp-story-bookend.js
+++ b/extensions/amp-story/1.0/bookend/amp-story-bookend.js
@@ -190,7 +190,8 @@ export class AmpStoryBookend extends AMP.BaseElement {
 
     const innerContainer = this.getInnerContainer_();
     innerContainer.appendChild(this.replayButton_);
-    innerContainer.appendChild(this.shareWidget_.build(this.getAmpDoc()));
+    innerContainer.appendChild(
+        this.shareWidget_.build(getAmpdoc(this.win.document)));
     this.initializeListeners_();
 
     this.vsync_.mutate(() => {

--- a/extensions/amp-story/1.0/test/test-amp-story-bookend.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-bookend.js
@@ -95,10 +95,6 @@ describes.realWin('amp-story-bookend', {
     bookend = new AmpStoryBookend(bookendElem);
   });
 
-  afterEach(() => {
-    sandbox.restore();
-  });
-
   it('should build the users json', () => {
     const userJson = {
       'bookend-version': 'v1.0',

--- a/extensions/amp-story/1.0/test/test-amp-story-bookend.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-bookend.js
@@ -15,8 +15,12 @@
  */
 
 import {AmpStoryBookend} from '../bookend/amp-story-bookend';
+import {AmpStoryRequestService} from '../amp-story-request-service';
+import {AmpStoryStoreService} from '../amp-story-store-service';
 import {ArticleComponent} from '../bookend/components/article';
+import {LocalizationService} from '../localization';
 import {createElementWithAttributes} from '../../../../src/dom';
+import {registerServiceBuilder} from '../../../../src/service';
 import {user} from '../../../../src/log';
 
 describes.realWin('amp-story-bookend', {
@@ -78,7 +82,21 @@ describes.realWin('amp-story-bookend', {
     bookendElem = createElementWithAttributes(win.document,
         'amp-story-bookend', {'layout': 'nodisplay'});
     storyElem.appendChild(bookendElem);
+
+    const requestService = new AmpStoryRequestService(win, storyElem);
+    registerServiceBuilder(win, 'story-request', () => requestService);
+
+    const storeService = new AmpStoryStoreService(win);
+    registerServiceBuilder(win, 'story-store', () => storeService);
+
+    const localizationService = new LocalizationService(win);
+    registerServiceBuilder(win, 'localization', () => localizationService);
+
     bookend = new AmpStoryBookend(bookendElem);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
   });
 
   it('should build the users json', () => {
@@ -107,7 +125,6 @@ describes.realWin('amp-story-bookend', {
     sandbox.stub(bookend.requestService_, 'loadBookendConfig')
         .resolves(userJson);
 
-    bookend.buildCallback();
     bookend.build();
     return bookend.loadConfigAndMaybeRenderBookend().then(config => {
       config.components.forEach((currentComponent, index) => {
@@ -143,7 +160,6 @@ describes.realWin('amp-story-bookend', {
     sandbox.stub(bookend.requestService_, 'loadBookendConfig')
         .resolves(userJson);
 
-    bookend.buildCallback();
     bookend.build();
     return bookend.loadConfigAndMaybeRenderBookend().then(config => {
       config.components.forEach((currentComponent, index) => {


### PR DESCRIPTION
When merging #15033, I, **as well as Travis**, were able to run the amp-story-bookend tests without having to initialize an `AmpStory` object in the `beforeEach`. Weirdly enough, after merging  and starting to work on another PR, I got errors related to not having services registered (which were done in the `AmpStory` constructor). So I included those in the `beforeEach` of the tests and then it started complaining about `this.getAmpDoc` not being a function in  `AmpStoryBookend.build()`, so I ended up changing it to a `getAmpDoc(this.win.document)`.

This PR fixes those issues, but I'm a bit confused/concerned why I and especially Travis were able to run the tests successfully before.
