### PR TITLE
✨ amp-next-page: Relax position requirements for component

### DIFF
--- a/extensions/amp-next-page/validator-amp-next-page.protoascii
+++ b/extensions/amp-next-page/validator-amp-next-page.protoascii
@@ -48,8 +48,7 @@ tags: {
 tags: {  # <amp-next-page>
   html_format: AMP
   tag_name: "AMP-NEXT-PAGE"
-  mandatory_parent: "BODY"
-  mandatory_last_child: true
+  unique: true
   requires_extension: "amp-next-page"
   spec_url: "https://www.ampproject.org/docs/reference/components/amp-next-page"
 }


### PR DESCRIPTION
- No longer needs to be last child as we have element hiding (#15150)
- I don't see any reason to force it to be a direct child of body, it just imposes arbitrary restrictions on page structure (what if their footer isn't a direct child of the body?). The tag could still be styled to have extra margin or padding around it either way.
- Set `unique = true` as we're already enforcing that only the first instance of the tag in a document (and all child documents) will work.