### PR TITLE
🖍 amp-next-page: Improve default recommendation box styling

### DIFF
--- a/extensions/amp-next-page/0.1/amp-next-page.css
+++ b/extensions/amp-next-page/0.1/amp-next-page.css
@@ -52,6 +52,8 @@
   padding-bottom: 10px;
   height: 92px;
   width: 100%;
+  display: block;
+  text-decoration: none;
 }
 
 .i-amphtml-next-article-image {

--- a/extensions/amp-next-page/0.1/amp-next-page.css
+++ b/extensions/amp-next-page/0.1/amp-next-page.css
@@ -23,7 +23,6 @@
 
 .amp-next-page-text {
   color: #3c4043;
-  font-family: sans-serif;
   font-size: 17px;
 }
 
@@ -48,11 +47,9 @@
 }
 
 .i-amphtml-reco-holder-article {
-  padding-top: 10px;
-  padding-bottom: 10px;
-  height: 92px;
-  width: 100%;
   display: block;
+  height: 72px;
+  padding: 10px 0;
   text-decoration: none;
 }
 
@@ -60,18 +57,15 @@
   width: 72px;
   height: 72px;
   float: left;
-  margin-left: 10px;
+  margin: 0 10px;
   background-size: cover;
   background-position: center;
 }
 
 .i-amphtml-next-article-title {
   position: relative;
-  left: 10px;
   top: 5px;
   height: 60px;
-  text-overflow: ellipsis;
   overflow: hidden;
   margin-right: 30px;
-  text-align: left;
 }

--- a/extensions/amp-next-page/0.1/amp-next-page.css
+++ b/extensions/amp-next-page/0.1/amp-next-page.css
@@ -14,8 +14,16 @@
  * limitations under the License.
  */
 
-.amp-next-page-division {
-  border-bottom: 1px solid rgba(0,0,0,0.12);
+.amp-next-page-default-separator {
+  border-bottom: 1px solid rgba(0, 0, 0, 0.12);
+}
+
+.amp-next-page-links {
+  border-top: 1px solid rgba(0, 0, 0, 0.12);
+}
+
+.amp-next-page-link {
+  border-bottom: 1px solid rgba(0, 0, 0, 0.12);
 }
 
 .amp-next-page-image {

--- a/extensions/amp-next-page/0.1/next-page-service.js
+++ b/extensions/amp-next-page/0.1/next-page-service.js
@@ -126,7 +126,7 @@ export class NextPageService {
 
     this.config_ = config;
     this.win_ = win;
-    this.separator_ = separator || this.createDivider_();
+    this.separator_ = separator || this.createDefaultSeparator_();
     this.element_ = element;
 
     if (this.config_.hideSelectors) {
@@ -202,13 +202,13 @@ export class NextPageService {
   }
 
   /**
-   * Creates a divider between two recommendations or articles.
+   * Creates a default hairline separator element to go between two documents.
    * @return {!Element}
    */
-  createDivider_() {
-    const topDivision = this.win_.document.createElement('div');
-    topDivision.classList.add('amp-next-page-division');
-    return topDivision;
+  createDefaultSeparator_() {
+    const separator = this.win_.document.createElement('div');
+    separator.classList.add('amp-next-page-default-separator');
+    return separator;
   }
 
   /**
@@ -295,8 +295,7 @@ export class NextPageService {
     }
 
     const element = doc.createElement('div');
-    const divider = this.createDivider_();
-    element.appendChild(divider);
+    element.classList.add('amp-next-page-links');
 
     while (article < this.config_.pages.length &&
            article - nextPage < SEPARATOR_RECOS) {
@@ -305,7 +304,8 @@ export class NextPageService {
 
       const articleHolder = doc.createElement('a');
       articleHolder.href = next.ampUrl;
-      articleHolder.classList.add('i-amphtml-reco-holder-article');
+      articleHolder.classList.add(
+          'i-amphtml-reco-holder-article', 'amp-next-page-link');
       articleHolder.addEventListener('click', e => {
         this.triggerAnalyticsEvent_(
             'amp-next-page-click', next.ampUrl, currentAmpUrl);
@@ -331,7 +331,6 @@ export class NextPageService {
       articleHolder.appendChild(titleElement);
 
       element.appendChild(articleHolder);
-      element.appendChild(this.createDivider_());
     }
 
     return element;

--- a/extensions/amp-next-page/0.1/next-page-service.js
+++ b/extensions/amp-next-page/0.1/next-page-service.js
@@ -303,12 +303,18 @@ export class NextPageService {
       const next = this.config_.pages[article];
       article++;
 
-      const articleHolder = doc.createElement('button');
+      const articleHolder = doc.createElement('a');
+      articleHolder.href = next.ampUrl;
       articleHolder.classList.add('i-amphtml-reco-holder-article');
-      articleHolder.addEventListener('click', () => {
+      articleHolder.addEventListener('click', e => {
         this.triggerAnalyticsEvent_(
             'amp-next-page-click', next.ampUrl, currentAmpUrl);
-        this.viewer_.navigateToAmpUrl(next.ampUrl, 'content-discovery');
+        const a2a =
+            this.viewer_.navigateToAmpUrl(next.ampUrl, 'content-discovery');
+        if (a2a) {
+          // A2A is enabled, don't navigate the browser.
+          e.preventDefault();
+        }
       });
 
       const imageElement = doc.createElement('div');


### PR DESCRIPTION
Switch the recommendation box to use <a> instead of <button> 
- Fixes linking in viewers which don't support A2A.
- Probably better for accessibility
- Avoids bad default button styling

Improve default recommendation box styling
- Remove `font-family` so the parent document font can be used
- Remove `text-overflow: ellipsis` (it doesn't work without `white-space: nowrap`)
- General CSS cleanup