### PR TITLE
Ramp up amp-img-native-srcset experiment to 1%

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -33,5 +33,6 @@
   "expUnconditionedAdxIdentity": 0.01,
   "expUnconditionedDfpIdentity": 0.01,
   "expUnconditionedCanonicalHoldback": 0.01,
-  "amp-consent": 1
+  "amp-consent": 1,
+  "amp-img-native-srcset": 1
 }

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -32,6 +32,5 @@
   "expUnconditionedAdxIdentity": 0.01,
   "expUnconditionedDfpIdentity": 0.01,
   "expUnconditionedCanonicalHoldback": 0.01,
-  "amp-consent": 1,
-  "amp-img-native-srcset": 0.01
+  "amp-consent": 1
 }

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -32,5 +32,6 @@
   "expUnconditionedAdxIdentity": 0.01,
   "expUnconditionedDfpIdentity": 0.01,
   "expUnconditionedCanonicalHoldback": 0.01,
-  "amp-consent": 1
+  "amp-consent": 1,
+  "amp-img-native-srcset": 0.01
 }


### PR DESCRIPTION
Ramp up `amp-img-native-srcset` experiment to 100% of canary and 1% of production. Related to https://github.com/ampproject/amphtml/issues/11575. 