### PR TITLE
Fix width auto bug in amp-image-lightbox

### DIFF
--- a/extensions/amp-image-lightbox/0.1/amp-image-lightbox.js
+++ b/extensions/amp-image-lightbox/0.1/amp-image-lightbox.js
@@ -223,7 +223,7 @@ export class ImageViewer {
     this.motion_ = null;
   }
 
-    /**
+  /**
    * Sets the source width and height based the natural dimensions of the
    * source image if loaded, and the offset dimensions of amp-img element
    * if not.

--- a/extensions/amp-image-lightbox/0.1/amp-image-lightbox.js
+++ b/extensions/amp-image-lightbox/0.1/amp-image-lightbox.js
@@ -48,6 +48,10 @@ const SUPPORTED_ELEMENTS_ = {
   'amp-anim': true,
 };
 
+/** @private @const */
+const ARIA_ATTRIBUTES = ['aria-label', 'aria-describedby',
+  'aria-labelledby'];
+
 /** @private @const {!../../../src/curve.CurveDef} */
 const ENTER_CURVE_ = bezierCurve(0.4, 0, 0.2, 1);
 
@@ -94,13 +98,6 @@ export class ImageViewer {
 
     /** @private {?../../../src/srcset.Srcset} */
     this.srcset_ = null;
-
-    /** @private {!Object} */
-    this.ariaAttributes_ = {
-      'alt': null,
-      'aria-label': null,
-      'aria-labelledby': null,
-    };
 
     /** @private {number} */
     this.sourceWidth_ = 0;
@@ -197,9 +194,8 @@ export class ImageViewer {
    */
   reset() {
     this.image_.setAttribute('src', '');
-    Object.keys(this.ariaAttributes_).forEach(key => {
+    ARIA_ATTRIBUTES.forEach(key => {
       this.image_.removeAttribute(key);
-      this.ariaAttributes_[key] = null;
     });
     this.image_.removeAttribute('aria-describedby');
     this.srcset_ = null;
@@ -227,33 +223,21 @@ export class ImageViewer {
     this.motion_ = null;
   }
 
-  /**
-   * @param {!Element} sourceElement
-   * @param {?Element} sourceImage
-   * @return {number}
+    /**
+   * Sets the source width and height based the natural dimensions of the
+   * source image if loaded, and the offset dimensions of amp-img element
+   * if not.
+   * @param {!Element} ampImg
+   * @param {?Element} img
    * @private
    */
-  getSourceWidth_(sourceElement, sourceImage) {
-    if (sourceElement.hasAttribute('width')) {
-      return parseInt(sourceElement.getAttribute('width'), 10);
+  setSourceDimensions_(ampImg, img) {
+    if (img) {
+      this.sourceWidth_ = img.naturalWidth || ampImg./*OK*/offsetWidth;
+      this.sourceHeight_ = img.naturalHeight || ampImg./*OK*/offsetHeight;
     } else {
-      return sourceImage ? sourceImage.naturalWidth
-        : sourceElement./*OK*/offsetWidth;
-    }
-  }
-
-  /**
-   * @param {!Element} sourceElement
-   * @param {?Element} sourceImage
-   * @return {number}
-   * @private
-   */
-  getSourceHeight_(sourceElement, sourceImage) {
-    if (sourceElement.hasAttribute('height')) {
-      return parseInt(sourceElement.getAttribute('height'), 10);
-    } else {
-      return sourceImage ? sourceImage.naturalHeight
-        : sourceElement./*OK*/offsetHeight;
+      this.sourceWidth_ = ampImg./*OK*/offsetWidth;
+      this.sourceHeight_ = ampImg./*OK*/offsetHeight;
     }
   }
 
@@ -265,15 +249,11 @@ export class ImageViewer {
    * @param {?Element} sourceImage
    */
   init(sourceElement, sourceImage) {
-    this.sourceWidth_ = this.getSourceWidth_(sourceElement, sourceImage);
-    this.sourceHeight_ = this.getSourceHeight_(sourceElement, sourceImage);
+    this.setSourceDimensions_(sourceElement, sourceImage);
     this.srcset_ = srcsetFromElement(sourceElement);
 
-    Object.keys(this.ariaAttributes_).forEach(key => {
-      this.ariaAttributes_[key] = sourceElement.getAttribute(key);
-      if (this.ariaAttributes_[key]) {
-        this.image_.setAttribute(key, this.ariaAttributes_[key]);
-      }
+    sourceElement.getImpl().then(e => {
+      e.propagateAttributes(ARIA_ATTRIBUTES, this.image_);
     });
 
     if (sourceImage && isLoaded(sourceImage) && sourceImage.src) {

--- a/extensions/amp-image-lightbox/0.1/amp-image-lightbox.js
+++ b/extensions/amp-image-lightbox/0.1/amp-image-lightbox.js
@@ -252,8 +252,8 @@ export class ImageViewer {
     this.setSourceDimensions_(sourceElement, sourceImage);
     this.srcset_ = srcsetFromElement(sourceElement);
 
-    sourceElement.getImpl().then(e => {
-      e.propagateAttributes(ARIA_ATTRIBUTES, this.image_);
+    sourceElement.getImpl().then(elem => {
+      elem.propagateAttributes(ARIA_ATTRIBUTES, this.image_);
     });
 
     if (sourceImage && isLoaded(sourceImage) && sourceImage.src) {

--- a/extensions/amp-image-lightbox/0.1/test/test-amp-image-lightbox.js
+++ b/extensions/amp-image-lightbox/0.1/test/test-amp-image-lightbox.js
@@ -238,6 +238,19 @@ describes.realWin('amp-image-lightbox image viewer', {
   let imageViewer;
   let loadPromiseStub;
 
+  const sourceElement = {
+    offsetWidth: 101,
+    offsetHeight: 201,
+    getAttribute: name => {
+      if (name == 'src') {
+        return 'image1';
+      }
+      return undefined;
+    },
+    hasAttribute: () => undefined,
+    getImpl: () => Promise.resolve(sourceElement.implementation_),
+  };
+
   beforeEach(() => {
     win = env.win;
     doc = win.document;
@@ -275,64 +288,27 @@ describes.realWin('amp-image-lightbox image viewer', {
 
 
   it('should init to the source element without image', () => {
-    const sourceElement = {
-      offsetWidth: 101,
-      offsetHeight: 201,
-      getAttribute: name => {
-        if (name == 'src') {
-          return 'image1';
-        }
-        return undefined;
-      },
-      hasAttribute: () => undefined,
-    };
-
     imageViewer.init(sourceElement, null);
-
     expect(imageViewer.sourceWidth_).to.equal(101);
     expect(imageViewer.sourceHeight_).to.equal(201);
     expect(imageViewer.getImage().src).to.equal('');
   });
 
   it('should init to the source element with unloaded image', () => {
-    const sourceElement = {
-      offsetWidth: 101,
-      offsetHeight: 201,
-      getAttribute: name => {
-        if (name == 'src') {
-          return 'image1';
-        }
-        return undefined;
-      },
-      hasAttribute: () => undefined,
-    };
     const sourceImage = {
       complete: false,
       src: 'image1-smaller',
     };
-
     imageViewer.init(sourceElement, sourceImage);
 
     expect(imageViewer.getImage().src).to.equal('');
   });
 
   it('should init to the source element with loaded image', () => {
-    const sourceElement = {
-      offsetWidth: 101,
-      offsetHeight: 201,
-      getAttribute: name => {
-        if (name == 'src') {
-          return 'image1';
-        }
-        return undefined;
-      },
-      hasAttribute: () => undefined,
-    };
     const sourceImage = {
       complete: true,
       src: 'image1-smaller',
     };
-
     imageViewer.init(sourceElement, sourceImage);
 
     expect(imageViewer.getImage().getAttribute('src')).to

--- a/test/manual/amp-image-lightbox.amp.html
+++ b/test/manual/amp-image-lightbox.amp.html
@@ -134,12 +134,12 @@
   <div>
     <amp-img
       src="https://picsum.photos/300/256"
-      layout='fixed-height'
-      width='auto'
-      height='256'
-      on='tap:image-lightbox1'
-      role='button'
-      tabindex='0'
+      layout="fixed-height"
+      width="auto"
+      height="256"
+      on="tap:image-lightbox1"
+      role="button"
+      tabindex="0"
       ></amp-img>
   </div>
 

--- a/test/manual/amp-image-lightbox.amp.html
+++ b/test/manual/amp-image-lightbox.amp.html
@@ -92,10 +92,6 @@
     Lorem ipsum dolor sit amet, has nisl nihil convenire et, vim at aeque inermis reprehendunt. Propriae tincidunt id nec, elit nusquam te mea, ius noster platonem in. Mea an idque minim, sit sale deleniti apeirian et. Omnium legendos tractatos cu mea. Vix in stet dolorem accusamus. Iisque rationibus consetetur in cum, quo unum nulla legere ut. Simul numquam saperet no sit.
   </p>
 
-  <p>
-    Lorem ipsum dolor sit amet, has nisl nihil convenire et, vim at aeque inermis reprehendunt. Propriae tincidunt id nec, elit nusquam te mea, ius noster platonem in. Mea an idque minim, sit sale deleniti apeirian et. Omnium legendos tractatos cu mea. Vix in stet dolorem accusamus. Iisque rationibus consetetur in cum, quo unum nulla legere ut. Simul numquam saperet no sit.
-  </p>
-
   <div class="row">
     <div>
       <amp-img id="img1"
@@ -132,6 +128,19 @@
       width=300 height=4000 layout="responsive"
       aria-describedby="img1-desc" role="button" tabindex="0"
       on="tap:image-lightbox1"></amp-img>
+  </div>
+
+
+  <div>
+    <amp-img
+      src="https://picsum.photos/300/256"
+      layout='fixed-height'
+      width='auto'
+      height='256'
+      on='tap:image-lightbox1'
+      role='button'
+      tabindex='0'
+      ></amp-img>
   </div>
 
   <p>


### PR DESCRIPTION
Fix bug in `<amp-image-viewer>` where it refuses to `parseInt` when width is set to auto. 