### PR TITLE
Add play/pause actions on <amp-audio>

### DIFF
--- a/extensions/amp-audio/0.1/test/test-amp-audio.js
+++ b/extensions/amp-audio/0.1/test/test-amp-audio.js
@@ -64,6 +64,21 @@ describes.realWin('amp-audio', {
     }).then(() => ampAudio);
   }
 
+  function attachToAmpStoryAndRun(attributes) {
+    naturalDimensions_['AMP-AUDIO'] = {width: '300px', height: '30px'};
+    const ampAudio = doc.createElement('amp-audio');
+    const ampStory = doc.createElement('amp-story');
+    for (const key in attributes) {
+      ampAudio.setAttribute(key, attributes[key]);
+    }
+    ampStory.appendChild(ampAudio);
+    doc.body.appendChild(ampStory);
+
+    return ampAudio.build().then(() => {
+      return ampAudio.layoutCallback();
+    }).then(() => ampAudio);
+  }
+
   it('should load audio through attribute', () => {
     return attachAndRun({
       src: 'https://origin.com/audio.mp3',
@@ -193,4 +208,34 @@ describes.realWin('amp-audio', {
       expect(audio.getAttribute('aria-describedby')).to.equal('id3');
     });
   });
+
+  it('should play/pause when `play`/`pause` actions are called', () => {
+    return attachAndRun({
+      'width': '500',
+      src: 'https://origin.com/audio.mp3',
+    }).then(ampAudio => {
+      const impl = ampAudio.implementation_;
+      impl.executeAction({method: 'play', satisfiesTrust: () => true});
+      expect(impl.playerStatus()).to.be.true;
+
+      impl.executeAction({method: 'pause', satisfiesTrust: () => true});
+      expect(impl.playerStatus()).to.be.false;
+    });
+  });
+
+  it('should not play/pause when `amp-audio` is a direct descendant ' +
+    'of `amp-story`', () => {
+    return attachToAmpStoryAndRun({
+      'width': '500',
+      src: 'https://origin.com/audio.mp3',
+    }).then(ampAudio => {
+      const impl = ampAudio.implementation_;
+      impl.executeAction({method: 'play', satisfiesTrust: () => true});
+      expect(impl.playerStatus()).to.be.false;
+
+      impl.executeAction({method: 'pause', satisfiesTrust: () => true});
+      expect(impl.playerStatus()).to.be.false;
+    });
+  });
+
 });

--- a/spec/amp-actions-and-events.md
+++ b/spec/amp-actions-and-events.md
@@ -123,11 +123,11 @@ For example, the following is possible in AMP:
   </tr>
   <tr>
     <td><code>play</code></td>
-    <td>Plays the audio.</td>
+    <td>Plays the audio. Is a no-op if the `<amp-audio>` element is a descendant of `<amp-story>`.</td>
   </tr>
   <tr>
     <td><code>pause</code></td>
-    <td>Pauses the audio.</td>
+    <td>Pauses the audio. Is a no-op if the `<amp-audio>` element is a descendant of `<amp-story>`.</td>
   </tr>
 </table>
 

--- a/spec/amp-actions-and-events.md
+++ b/spec/amp-actions-and-events.md
@@ -114,6 +114,23 @@ For example, the following is possible in AMP:
   </tr>
 </table>
 
+## amp-audio
+
+<table>
+  <tr>
+    <th>Action</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td><code>play</code></td>
+    <td>Plays the audio.</td>
+  </tr>
+  <tr>
+    <td><code>pause</code></td>
+    <td>Pauses the audio.</td>
+  </tr>
+</table>
+
 ### Input elements
 <table>
   <tr>


### PR DESCRIPTION
This PR adds play and pause actions for `<amp-audio>`. 

We make sure that the play/pause actions only do something if the `<amp-audio>` element isn't a descendant of `<amp-story>`. 

Also adds tests to check for that. 