### PR TITLE
Amp ad exit vendor dependency

### DIFF
--- a/extensions/amp-ad-exit/0.1/config.js
+++ b/extensions/amp-ad-exit/0.1/config.js
@@ -16,7 +16,7 @@
 
 import {
   ANALYTICS_IFRAME_TRANSPORT_CONFIG,
-} from '../../amp-analytics/0.1/vendors';
+} from '../../amp-analytics/0.1/iframe-transport-vendors';
 import {FilterType} from './filters/filter';
 import {user} from '../../../src/log';
 

--- a/extensions/amp-ad-exit/0.1/test/test-amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/test/test-amp-ad-exit.js
@@ -17,7 +17,7 @@
 import * as sinon from 'sinon';
 import {
   ANALYTICS_IFRAME_TRANSPORT_CONFIG,
-} from '../../../amp-analytics/0.1/vendors';
+} from '../../../amp-analytics/0.1/iframe-transport-vendors';
 import {AmpAdExit} from '../amp-ad-exit';
 import {FilterType} from '../filters/filter';
 import {toggleExperiment} from '../../../../src/experiments';

--- a/extensions/amp-ad-network-fake-impl/0.1/data/fake_amp_ad_with_iframe_transport.html
+++ b/extensions/amp-ad-network-fake-impl/0.1/data/fake_amp_ad_with_iframe_transport.html
@@ -11,7 +11,7 @@
   </head>
   <body>
     Before using this example ad, please add the following to
-    ANALYTICS_IFRAME_TRANSPORT_CONFIG in extensions/amp-analytics/0.1/vendors.js:
+    ANALYTICS_IFRAME_TRANSPORT_CONFIG in extensions/amp-analytics/0.1/iframe-transport-vendors.js:
     <pre>
       'example-3p-vendor': {
         'transport': {

--- a/extensions/amp-analytics/0.1/iframe-transport-vendors.js
+++ b/extensions/amp-analytics/0.1/iframe-transport-vendors.js
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Vendors who have IAB viewability certification may use iframe transport
+ * (see ../amp-analytics.md and ../integrating-analytics.md). In this case,
+ * put only the specification of the iframe location in the object below,
+ * and put everything else (requests, triggers, etc.) in the object above.
+ * @const {!JsonObject}
+ */
+export const ANALYTICS_IFRAME_TRANSPORT_CONFIG = /** @type {!JsonObject} */ ({
+  'bg': {
+    'transport': {
+      'iframe': 'https://tpc.googlesyndication.com/b4a/b4a-runner.html',
+    },
+  },
+});

--- a/extensions/amp-analytics/0.1/test/test-vendors.js
+++ b/extensions/amp-analytics/0.1/test/test-vendors.js
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import {ANALYTICS_CONFIG, ANALYTICS_IFRAME_TRANSPORT_CONFIG} from '../vendors';
+import {ANALYTICS_CONFIG} from '../vendors';
+import {ANALYTICS_IFRAME_TRANSPORT_CONFIG} from '../iframe-transport-vendors';
 import {isSecureUrl} from '../../../../src/url';
 
 describe('analytics vendors', () => {

--- a/extensions/amp-analytics/0.1/vendors.js
+++ b/extensions/amp-analytics/0.1/vendors.js
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+ import {ANALYTICS_IFRAME_TRANSPORT_CONFIG} from './iframe-transport-vendors';
+
 /**
  * @const {!JsonObject}
  */
@@ -2073,21 +2075,6 @@ ANALYTICS_CONFIG['adobeanalytics_nativeConfig']
 
 ANALYTICS_CONFIG['oewa']['triggers']['pageview']['iframe' +
 /* TEMPORARY EXCEPTION */ 'Ping'] = true;
-
-/**
- * Vendors who have IAB viewability certification may use iframe transport
- * (see ../amp-analytics.md and ../integrating-analytics.md). In this case,
- * put only the specification of the iframe location in the object below,
- * and put everything else (requests, triggers, etc.) in the object above.
- * @const {!JsonObject}
- */
-export const ANALYTICS_IFRAME_TRANSPORT_CONFIG = /** @type {!JsonObject} */ ({
-  'bg': {
-    'transport': {
-      'iframe': 'https://tpc.googlesyndication.com/b4a/b4a-runner.html',
-    },
-  },
-});
 
 // Merge ANALYTICS_IFRAME_TRANSPORT_CONFIG into ANALYTICS_CONFIG
 Object.assign(ANALYTICS_CONFIG, ANALYTICS_IFRAME_TRANSPORT_CONFIG);

--- a/extensions/amp-analytics/0.1/vendors.js
+++ b/extensions/amp-analytics/0.1/vendors.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
- import {ANALYTICS_IFRAME_TRANSPORT_CONFIG} from './iframe-transport-vendors';
+import {ANALYTICS_IFRAME_TRANSPORT_CONFIG} from './iframe-transport-vendors';
 
 /**
  * @const {!JsonObject}

--- a/extensions/amp-analytics/integrating-analytics.md
+++ b/extensions/amp-analytics/integrating-analytics.md
@@ -26,7 +26,7 @@ Before you can add your analytics service to AMP HTML runtime, you may need to:
         1. ```"vars": {}``` for additional default variables.
         1. ```"requests": {}``` for requests that your service will use.
         1. ```"optout":``` if needed.  We currently don't have a great opt-out system, so please reach out to help us design one that works well for you.
-    1. If you are using iframe transport, add a new block to ANALYTICS_IFRAME_TRANSPORT_CONFIG in vendors.js containing ```"transport": { "iframe": *url* }```
+    1. If you are using iframe transport, add a new block to ANALYTICS_IFRAME_TRANSPORT_CONFIG in iframe-transport-vendors.js containing ```"transport": { "iframe": *url* }```
     1. An example in the [examples/analytics-vendors.amp.html](../../examples/analytics-vendors.amp.html)
 reference.
     1. A new batch plugin if required. Please refer to [Add Batch Plugin](#add-batch-plugin) for instructions.

--- a/extensions/amp-analytics/integrating-analytics.md
+++ b/extensions/amp-analytics/integrating-analytics.md
@@ -32,7 +32,7 @@ reference.
     1. A new batch plugin if required. Please refer to [Add Batch Plugin](#add-batch-plugin) for instructions.
 1. Test the new example you put in [examples/analytics-vendors.amp.html](../../examples/analytics-vendors.amp.html) to ensure the hits from the example are working as expected. For example, the data needed is being collected and displayed in your analytics dashboard.
 1. Submit a Pull Request with this patch, referencing the Intent-To-Implement issue.
-1. Add your analytics service to the [list of supported Analytics Vendors](https://github.com/ampproject/docs/blob/master/content/docs/ads_analytics/analytics-vendors.md) by submitting a Pull Request to the [ampproject/docs](https://github.com/ampproject/docs) repo. Include the type, description, and link to your usage documentation.
+1. Add your analytics service to the [list of supported Analytics Vendors](https://github.com/ampproject/docs/blob/master/content/docs/analytics/analytics-vendors.md) by submitting a Pull Request to the [ampproject/docs](https://github.com/ampproject/docs) repo. Include the type, description, and link to your usage documentation.
 1. Update your service's usage documentation and inform your customers.
 
 


### PR DESCRIPTION
amp-ad-exit has dependency on amp-analytics iframe transport iframes but is unintentionally pulling in the entire amp-analytics vendor config.  Moving transport config to separate file corrected this inadvertent include reducing file size from ~50k to 12k.