### PR TITLE
🐛 amp-next-page: Fix PositionObserver error on loading failure

### DIFF
--- a/extensions/amp-next-page/0.1/next-page-service.js
+++ b/extensions/amp-next-page/0.1/next-page-service.js
@@ -241,14 +241,13 @@ export class NextPageService {
       Services.xhrFor(/** @type {!Window} */ (this.win_))
           .fetchDocument(next.ampUrl, {ampCors: false})
           .then(doc => new Promise((resolve, reject) => {
-            this.positionObserver_.unobserve(articleLinks);
-
             if (documentRef.cancelled) {
               // User has reached the end of the document already, don't render.
               resolve();
               return;
             }
 
+            this.positionObserver_.unobserve(articleLinks);
             this.resources_.mutateElement(container, () => {
               try {
                 const amp = this.attachShadowDoc_(shadowRoot, doc);


### PR DESCRIPTION
If next document loading fails `unobserve` gets called twice, which logs an error.