### PR TITLE
✨ amp-next-page: Reuse amp-analytics config from parent document on all children

### DIFF
--- a/extensions/amp-next-page/0.1/next-page-service.js
+++ b/extensions/amp-next-page/0.1/next-page-service.js
@@ -26,6 +26,7 @@ import {
 import {installStylesForDoc} from '../../../src/style-installer';
 import {layoutRectLtwh} from '../../../src/layout-rect';
 import {parseUrl} from '../../../src/url';
+import {removeElement} from '../../../src/dom';
 import {setStyle} from '../../../src/style';
 import {triggerAnalyticsEvent} from '../../../src/analytics';
 
@@ -182,6 +183,14 @@ export class NextPageService {
       for (let i = 0; i < elements.length; i++) {
         elements[i].classList.add('i-amphtml-next-page-hidden');
       }
+    }
+
+    // Drop any amp-analytics tags from the child doc. We want to reuse the
+    // parent config instead.
+    const analytics = doc.querySelectorAll('amp-analytics');
+    for (let i = 0; i < analytics.length; i++) {
+      const item = analytics[i];
+      removeElement(item);
     }
 
     const amp =

--- a/extensions/amp-next-page/0.1/test/test-amp-next-page.js
+++ b/extensions/amp-next-page/0.1/test/test-amp-next-page.js
@@ -177,6 +177,37 @@ env => {
             'i-amphtml-next-page-hidden'))
         .to.be.true;
   });
+
+  it('removes amp-analytics tags from child documents', function* () {
+    const exampleDoc = createExampleDocument(doc);
+    exampleDoc.body.innerHTML +=
+        '<amp-analytics id="analytics1"></amp-analytics>';
+    exampleDoc.body.innerHTML +=
+        '<amp-analytics id="analytics2"></amp-analytics>';
+    xhrMock.expects('fetchDocument')
+        .returns(Promise.resolve(exampleDoc))
+        .once();
+
+    const nextPageService = getService(win, 'next-page');
+    const attachShadowDocSpy =
+      sandbox.spy(nextPageService.multidocManager_, 'attachShadowDoc');
+
+    sandbox.stub(viewport, 'getClientRectAsync').callsFake(() => {
+      // 1x viewport away
+      return Promise.resolve(
+          layoutRectLtwh(0, 0, sizes.width, sizes.height * 2));
+    });
+
+    win.dispatchEvent(new Event('scroll'));
+    yield macroTask();
+
+    const shadowDoc = attachShadowDocSpy.firstCall.returnValue.ampdoc;
+    yield shadowDoc.whenReady();
+
+    const shadowRoot = shadowDoc.getRootNode();
+    expect(shadowRoot.getElementById('analytics1')).to.be.null;
+    expect(shadowRoot.getElementById('analytics2')).to.be.null;
+  });
 });
 
 /**


### PR DESCRIPTION
Removes any `amp-analytics` tags from the child document before attaching it. 