### PR TITLE
🐛 amp-next-page: Fix handling of documents which are shorter than the viewport

### DIFF
--- a/extensions/amp-next-page/0.1/next-page-service.js
+++ b/extensions/amp-next-page/0.1/next-page-service.js
@@ -155,6 +155,10 @@ export class NextPageService {
 
     this.viewport_.onScroll(() => this.scrollHandler_());
     this.viewport_.onResize(() => this.scrollHandler_());
+
+    // Check scroll position immediately to handle documents which are shorter
+    // than the viewport.
+    this.scrollHandler_();
   }
 
   /**


### PR DESCRIPTION
Immediately renders the recommendation links and checks if they're in the viewport, then aborts loading the next document.

Current behaviour doesn't check/render the links unless the window is resized.