### PR TITLE
Using CSS Variables for the amp-story-consent component.

### DIFF
--- a/examples/amp-story/consent.html
+++ b/examples/amp-story/consent.html
@@ -16,6 +16,9 @@
       body {
         font-family: 'Roboto', sans-serif;
       }
+      amp-story {
+        --primary-color: #0379c4;
+      }
       amp-story-page {
         background-color: white;
       }
@@ -60,7 +63,6 @@
             }
           },
           "story-consent": {
-            "color": "#0379c4",
             "title": "Headline.",
             "message": "This is some more information about this choice. Here's a list of items related to this choice.",
             "vendors": ["Item 1", "Item 2", "Item 3", "Item 4", "Item 5", "Item 6", "Item 7", "Item 8", "Item 9", "Item 10"]

--- a/extensions/amp-story/0.1/amp-story-consent.css
+++ b/extensions/amp-story/0.1/amp-story-consent.css
@@ -68,7 +68,7 @@
   position: relative !important;
   height: 80px !important;
   min-height: 80px !important;
-  background: #F0F0F0 !important;
+  background: var(--primary-color, #F0F0F0) !important;
   z-index: 2 !important;
 
   /* Making sure the background color fills the container in full bleed mode. */
@@ -164,7 +164,7 @@
 }
 
 .i-amphtml-story-consent-action-accept {
-  background: #000000 !important;
+  background: var(--primary-color, #000000) !important;
   color: #FFFFFF !important;
 }
 

--- a/extensions/amp-story/0.1/amp-story-consent.js
+++ b/extensions/amp-story/0.1/amp-story-consent.js
@@ -34,7 +34,6 @@ import {throttle} from '../../../src/utils/rate-limit';
 const TAG = 'amp-story-consent';
 
 // TODO(gmajoulet): switch to `htmlFor` static template helper.
-// TODO(gmajoulet): use a CSS variable for the `color` config parameter.
 /**
  * Story consent template.
  * @private @const {function(!Object, string, ?string):!./simple-template.ElementDef}
@@ -54,11 +53,7 @@ const getTemplate = (config, consentId, logoSrc) => ({
           children: [
             {
               tag: 'div',
-              attrs: dict({
-                'class': 'i-amphtml-story-consent-header',
-                'style': config.color ?
-                  `background-color: ${config.color} !important;` : '',
-              }),
+              attrs: dict({'class': 'i-amphtml-story-consent-header'}),
               children: [
                 {
                   tag: 'div',
@@ -123,9 +118,6 @@ const getTemplate = (config, consentId, logoSrc) => ({
               attrs: dict({
                 'class': 'i-amphtml-story-consent-action ' +
                     'i-amphtml-story-consent-action-accept',
-                'style': config.color ?
-                  `background-color: ${config.color} !important; ` +
-                      `border-color: ${config.color} !important;` : '',
                 'on': `tap:${consentId}.accept`,
               }),
               children: [],

--- a/extensions/amp-story/1.0/amp-story-consent.css
+++ b/extensions/amp-story/1.0/amp-story-consent.css
@@ -68,7 +68,7 @@
   position: relative !important;
   height: 80px !important;
   min-height: 80px !important;
-  background: #F0F0F0 !important;
+  background: var(--primary-color, #F0F0F0) !important;
   z-index: 2 !important;
 
   /* Making sure the background color fills the container in full bleed mode. */
@@ -164,7 +164,7 @@
 }
 
 .i-amphtml-story-consent-action-accept {
-  background: #000000 !important;
+  background: var(--primary-color, #000000) !important;
   color: #FFFFFF !important;
 }
 

--- a/extensions/amp-story/1.0/amp-story-consent.js
+++ b/extensions/amp-story/1.0/amp-story-consent.js
@@ -34,7 +34,6 @@ import {throttle} from '../../../src/utils/rate-limit';
 const TAG = 'amp-story-consent';
 
 // TODO(gmajoulet): switch to `htmlFor` static template helper.
-// TODO(gmajoulet): use a CSS variable for the `color` config parameter.
 /**
  * Story consent template.
  * @private @const {function(!Object, string, ?string):!./simple-template.ElementDef}
@@ -54,11 +53,7 @@ const getTemplate = (config, consentId, logoSrc) => ({
           children: [
             {
               tag: 'div',
-              attrs: dict({
-                'class': 'i-amphtml-story-consent-header',
-                'style': config.color ?
-                  `background-color: ${config.color} !important;` : '',
-              }),
+              attrs: dict({'class': 'i-amphtml-story-consent-header'}),
               children: [
                 {
                   tag: 'div',
@@ -123,9 +118,6 @@ const getTemplate = (config, consentId, logoSrc) => ({
               attrs: dict({
                 'class': 'i-amphtml-story-consent-action ' +
                     'i-amphtml-story-consent-action-accept',
-                'style': config.color ?
-                  `background-color: ${config.color} !important; ` +
-                      `border-color: ${config.color} !important;` : '',
                 'on': `tap:${consentId}.accept`,
               }),
               children: [],


### PR DESCRIPTION
Using CSS Variables for the amp-story-consent component.

Publishers can now style the amp-story-consent component using the following CSS variable: 
````
<style amp-custom>
  amp-story {
    --primary-color: #C55;
  }
</style>
````

Fixes #15217