### PR TITLE
🏗 Notify build cop when `master` goes red

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ node_js:
 python:
   - "2.7"
 notifications:
+  email:
+    recipients:
+      - amp-build-cop@grotations.appspotmail.com
+    on_success: change
   webhooks:
     - http://savage.nonblocking.io:8080/savage/travis
 before_install:
@@ -38,8 +42,8 @@ addons:
     - fonts.googleapis.com
   apt:
     packages:
-    - protobuf-compiler
-    - python-protobuf
+      - protobuf-compiler
+      - python-protobuf
 matrix:
   include:
     # For non-greenkeeper branches, use the normal environment.


### PR DESCRIPTION
This will cause Travis to send an email to the on-duty build cop (and the committer and author, if they have access to `ampproject/amphtml`) when the state of `master` changes. Pull requests will not generate notifications.

https://docs.travis-ci.com/user/notifications/#Configuring-email-notifications