### PR TITLE
✅ Fail tests with unnecessary use of `allowConsoleError`

### DIFF
--- a/test/_init_tests.js
+++ b/test/_init_tests.js
@@ -305,12 +305,7 @@ function warnForConsoleError() {
       const helpMessage =
           'The test "' + testName + '" contains an "allowConsoleError" block ' +
           'that didn\'t result in a call to console.error.';
-      // TODO(rsimha, #14406): Simply throw here after all tests are fixed.
-      if (window.__karma__.config.failOnConsoleError) {
-        throw new Error(helpMessage);
-      } else {
-        originalConsoleError(helpMessage);
-      }
+      throw new Error(helpMessage);
     }
     warnForConsoleError();
   };


### PR DESCRIPTION
All existing instances of unnecessary use of `allowConsoleError` were removed in #15128. This PR will now fail tests that contain useless calls.

Follow up to #15128
Related to #14406