### PR TITLE
🐛 Fix instances where `allowConsoleError` swallows return values

### DIFF
--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -596,6 +596,10 @@ const forbiddenTerms = {
       'extensions/amp-access/0.1/iframe-api/access-controller.js',
     ],
   },
+  '(?<!return) allowConsoleError\\(\\(\\) => \\{[\\n\\r\\s]*return': {
+    message: 'The return value of `allowConsoleError` must be returned ' +
+        'to enable Promise chaining.',
+  },
 };
 
 const ThreePTermsMessage = 'The 3p bootstrap iframe has no polyfills loaded' +

--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -596,10 +596,6 @@ const forbiddenTerms = {
       'extensions/amp-access/0.1/iframe-api/access-controller.js',
     ],
   },
-  '(?<!return) allowConsoleError\\(\\(\\) => \\{[\\n\\r\\s]*return': {
-    message: 'The return value of `allowConsoleError` must be returned ' +
-        'to enable Promise chaining.',
-  },
 };
 
 const ThreePTermsMessage = 'The 3p bootstrap iframe has no polyfills loaded' +

--- a/extensions/amp-3q-player/0.1/test/test-amp-3q-player.js
+++ b/extensions/amp-3q-player/0.1/test/test-amp-3q-player.js
@@ -64,7 +64,7 @@ describes.realWin('amp-3q-player', {
   });
 
   it('requires data-id', () => {
-    allowConsoleError(() => {
+    return allowConsoleError(() => {
       return get3QElement('').should.eventually.be.rejectedWith(
           /The data-id attribute is required/);
     });

--- a/extensions/amp-app-banner/0.1/test/test-amp-app-banner.js
+++ b/extensions/amp-app-banner/0.1/test/test-amp-app-banner.js
@@ -128,7 +128,7 @@ describes.realWin('amp-app-banner', {
   }
 
   function testButtonMissing() {
-    allowConsoleError(() => { return getAppBanner({
+    return allowConsoleError(() => { return getAppBanner({
       iosMeta,
       androidManifest,
       noOpenButton: true,
@@ -194,7 +194,7 @@ describes.realWin('amp-app-banner', {
     });
 
     it('should parse meta content and validate app-argument url', () => {
-      allowConsoleError(() => { return getAppBanner({
+      return allowConsoleError(() => { return getAppBanner({
         iosMeta: {content:
             'app-id=828256236, app-argument=javascript:alert("foo");'},
       }).should.eventually.be.rejectedWith(

--- a/extensions/amp-brid-player/0.1/test/test-amp-brid-player.js
+++ b/extensions/amp-brid-player/0.1/test/test-amp-brid-player.js
@@ -87,7 +87,7 @@ describes.realWin('amp-brid-player', {
   });
 
   it('requires data-partner', () => {
-    allowConsoleError(() => { return getBridPlayer({
+    return allowConsoleError(() => { return getBridPlayer({
       'data-player': '4144',
       'data-video': '13663',
     }).should.eventually.be.rejectedWith(
@@ -96,7 +96,7 @@ describes.realWin('amp-brid-player', {
   });
 
   it('requires data-player', () => {
-    allowConsoleError(() => { return getBridPlayer({
+    return allowConsoleError(() => { return getBridPlayer({
       'data-partner': '264',
       'data-video': '13663',
     }).should.eventually.be.rejectedWith(

--- a/extensions/amp-byside-content/0.1/test/test-amp-byside-content.js
+++ b/extensions/amp-byside-content/0.1/test/test-amp-byside-content.js
@@ -72,7 +72,7 @@ describes.realWin('amp-byside-content', {
   });
 
   it('requires data-label', () => {
-    allowConsoleError(() => { return getElement({
+    return allowConsoleError(() => { return getElement({
       'data-webcare-id': 'D6604AE5D0',
     }).should.eventually.be.rejectedWith(
         /The data-label attribute is required for/);
@@ -80,7 +80,7 @@ describes.realWin('amp-byside-content', {
   });
 
   it('requires data-webcare-id', () => {
-    allowConsoleError(() => { return getElement({
+    return allowConsoleError(() => { return getElement({
       'data-label': 'placeholder-label',
     }).should.eventually.be.rejectedWith(
         /The data-webcare-id attribute is required for/);

--- a/extensions/amp-dailymotion/0.1/test/test-amp-dailymotion.js
+++ b/extensions/amp-dailymotion/0.1/test/test-amp-dailymotion.js
@@ -75,7 +75,7 @@ describes.realWin('amp-dailymotion', {
   });
 
   it('requires data-videoid', () => {
-    allowConsoleError(() => {
+    return allowConsoleError(() => {
       return getDailymotion('').should.eventually.be.rejectedWith(
           /The data-videoid attribute is required for/);
     });

--- a/extensions/amp-gfycat/0.1/test/test-amp-gfycat.js
+++ b/extensions/amp-gfycat/0.1/test/test-amp-gfycat.js
@@ -109,7 +109,7 @@ describes.realWin('amp-gfycat', {
   }
 
   it('requires data-gfyid', () => {
-    allowConsoleError(() => {
+    return allowConsoleError(() => {
       return getGfycat('').should.eventually.be.rejectedWith(
           /The data-gfyid attribute is required for/);
     });

--- a/extensions/amp-google-vrview-image/0.1/test/test-amp-google-vrview-image.js
+++ b/extensions/amp-google-vrview-image/0.1/test/test-amp-google-vrview-image.js
@@ -80,14 +80,14 @@ describes.realWin('amp-google-vrview-image', {
   });
 
   it('requires src', () => {
-    allowConsoleError(() => {
+    return allowConsoleError(() => {
       return getVrImage({}).should.eventually.be.rejectedWith(
           /must be available/);
     });
   });
 
   it('requires https src', () => {
-    allowConsoleError(() => {
+    return allowConsoleError(() => {
       return getVrImage({'src': 'http://example.com/image1'})
           .should.eventually.be.rejectedWith(/https/);
     });

--- a/extensions/amp-hulu/0.1/test/test-amp-hulu.js
+++ b/extensions/amp-hulu/0.1/test/test-amp-hulu.js
@@ -60,7 +60,7 @@ describes.realWin('amp-hulu', {
   });
 
   it('requires data-eid', () => {
-    allowConsoleError(() => {
+    return allowConsoleError(() => {
       return getHulu('').should.eventually.be.rejectedWith(
           /The data-eid attribute is required for/);
     });

--- a/extensions/amp-izlesene/0.1/test/test-amp-izlesene.js
+++ b/extensions/amp-izlesene/0.1/test/test-amp-izlesene.js
@@ -62,7 +62,7 @@ describes.realWin('amp-izlesene', {
   });
 
   it('requires data-videoid', () => {
-    allowConsoleError(() => {
+    return allowConsoleError(() => {
       return getIzlesene('').should.eventually.be.rejectedWith(
           /The data-videoid attribute is required for/);
     });

--- a/extensions/amp-jwplayer/0.1/test/test-amp-jwplayer.js
+++ b/extensions/amp-jwplayer/0.1/test/test-amp-jwplayer.js
@@ -69,7 +69,7 @@ describes.realWin('amp-jwplayer', {
   });
 
   it('fails if no media is specified', () => {
-    allowConsoleError(() => { return getjwplayer({
+    return allowConsoleError(() => { return getjwplayer({
       'data-player-id': 'sDZEo0ea',
     }).should.eventually.be.rejectedWith(
         /Either the data-media-id or the data-playlist-id attributes must be/);
@@ -77,7 +77,7 @@ describes.realWin('amp-jwplayer', {
   });
 
   it('fails if no player is specified', () => {
-    allowConsoleError(() => { return getjwplayer({
+    return allowConsoleError(() => { return getjwplayer({
       'data-media-id': 'Wferorsv',
     }).should.eventually.be.rejectedWith(
         /The data-player-id attribute is required for/);

--- a/extensions/amp-kaltura-player/0.1/test/test-amp-kaltura-player.js
+++ b/extensions/amp-kaltura-player/0.1/test/test-amp-kaltura-player.js
@@ -72,7 +72,7 @@ describes.realWin('amp-kaltura-player', {
   });
 
   it('requires data-account', () => {
-    allowConsoleError(() => { return getKaltura({}).then(kp => {
+    return allowConsoleError(() => { return getKaltura({}).then(kp => {
       kp.build();
     }).should.eventually.be.rejectedWith(
         /The data-partner attribute is required for/);

--- a/extensions/amp-o2-player/0.1/test/test-amp-o2-player.js
+++ b/extensions/amp-o2-player/0.1/test/test-amp-o2-player.js
@@ -68,7 +68,7 @@ describes.realWin('amp-o2-player', {
   });
 
   it('requires data-pid', () => {
-    allowConsoleError(() => { return getO2player({
+    return allowConsoleError(() => { return getO2player({
       'data-bcid': '50d595ec0364e95588c77bd2',
     }).should.eventually.be.rejectedWith(
         /data-pid attribute is required for/);
@@ -76,7 +76,7 @@ describes.realWin('amp-o2-player', {
   });
 
   it('requires data-bcid', () => {
-    allowConsoleError(() => { return getO2player({
+    return allowConsoleError(() => { return getO2player({
       'data-pid': '573acb47e4b0564ec2e10011',
     }).should.eventually.be.rejectedWith(
         /data-bcid attribute is required for/);
@@ -84,7 +84,7 @@ describes.realWin('amp-o2-player', {
   });
 
   it('requires data-pid && data-bcid', () => {
-    allowConsoleError(() => {
+    return allowConsoleError(() => {
       return getO2player({}).should.eventually.be.rejectedWith(
           /data-pid attribute is required for/);
     });

--- a/extensions/amp-selector/0.1/test/test-amp-selector.js
+++ b/extensions/amp-selector/0.1/test/test-amp-selector.js
@@ -942,7 +942,7 @@ describes.realWin('amp-selector', {
             multiple: true,
           },
         });
-        allowConsoleError(() => {
+        return allowConsoleError(() => {
           return expect(ampSelector.build()).to.eventually.be.rejectedWith(
               /not supported for multiple selection amp-selector​​​/);
         });

--- a/extensions/amp-social-share/0.1/test/test-amp-social-share.js
+++ b/extensions/amp-social-share/0.1/test/test-amp-social-share.js
@@ -79,7 +79,7 @@ describes.realWin('amp-social-share', {
     const share = doc.createElement('amp-social-share');
     share.setAttribute('type', 'unknown-provider');
     doc.body.appendChild(share);
-    allowConsoleError(() => {
+    return allowConsoleError(() => {
       return expect(loaded(share)).to.eventually.be.rejectedWith(
           /data-share-endpoint attribute is required/);
     });
@@ -88,7 +88,7 @@ describes.realWin('amp-social-share', {
   it('errors if type is missing', () => {
     const share = doc.createElement('amp-social-share');
     doc.body.appendChild(share);
-    allowConsoleError(() => {
+    return allowConsoleError(() => {
       return expect(loaded(share)).to.eventually.be.rejectedWith(
           /type attribute is required/);
     });
@@ -98,7 +98,7 @@ describes.realWin('amp-social-share', {
     const share = doc.createElement('amp-social-share');
     share.setAttribute('type', 'hello world');
     doc.body.appendChild(share);
-    allowConsoleError(() => {
+    return allowConsoleError(() => {
       return expect(loaded(share)).to.eventually.be.rejectedWith(
           /Space characters are not allowed in type attribute value/);
     });

--- a/extensions/amp-story/1.0/test/test-amp-story-cta-layer.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-cta-layer.js
@@ -73,7 +73,7 @@ describes.realWin('amp-story-cta-layer', {
     pageElements[0].appendChild(ampStoryCtaLayer.element);
 
     ampStoryCtaLayer.layoutCallback().then(layer => {
-      allowConsoleError(() => {
+      return allowConsoleError(() => {
         return expect(layer).to.throw();
       });
     });

--- a/extensions/amp-vk/0.1/test/test-amp-vk.js
+++ b/extensions/amp-vk/0.1/test/test-amp-vk.js
@@ -70,7 +70,7 @@ describes.realWin('amp-vk', {
   it('requires data-embedtype', () => {
     const params = Object.assign({}, POST_PARAMS);
     delete params['embedtype'];
-    allowConsoleError(() => {
+    return allowConsoleError(() => {
       return createAmpVkElement(params).should.eventually.be.rejectedWith(
           /The data-embedtype attribute is required for/);
     });
@@ -93,7 +93,7 @@ describes.realWin('amp-vk', {
   it('post::requires data-hash', () => {
     const params = Object.assign({}, POST_PARAMS);
     delete params['hash'];
-    allowConsoleError(() => {
+    return allowConsoleError(() => {
       return createAmpVkElement(params).should.eventually.be.rejectedWith(
           /The data-hash attribute is required for/);
     });
@@ -102,7 +102,7 @@ describes.realWin('amp-vk', {
   it('post::requires data-owner-id', () => {
     const params = Object.assign({}, POST_PARAMS);
     delete params['owner-id'];
-    allowConsoleError(() => {
+    return allowConsoleError(() => {
       return createAmpVkElement(params).should.eventually.be.rejectedWith(
           /The data-owner-id attribute is required for/);
     });
@@ -111,7 +111,7 @@ describes.realWin('amp-vk', {
   it('post::requires data-post-id', () => {
     const params = Object.assign({}, POST_PARAMS);
     delete params['post-id'];
-    allowConsoleError(() => {
+    return allowConsoleError(() => {
       return createAmpVkElement(params).should.eventually.be.rejectedWith(
           /The data-post-id attribute is required for/);
     });
@@ -157,7 +157,7 @@ describes.realWin('amp-vk', {
   it('poll::requires data-api-id', () => {
     const params = Object.assign({}, POLL_PARAMS);
     delete params['api-id'];
-    allowConsoleError(() => {
+    return allowConsoleError(() => {
       return createAmpVkElement(params).should.eventually.be.rejectedWith(
           /The data-api-id attribute is required for/);
     });
@@ -166,7 +166,7 @@ describes.realWin('amp-vk', {
   it('poll::requires data-poll-id', () => {
     const params = Object.assign({}, POLL_PARAMS);
     delete params['poll-id'];
-    allowConsoleError(() => {
+    return allowConsoleError(() => {
       return createAmpVkElement(params).should.eventually.be.rejectedWith(
           /The data-poll-id attribute is required for/);
     });

--- a/extensions/amp-youtube/0.1/test/test-amp-youtube.js
+++ b/extensions/amp-youtube/0.1/test/test-amp-youtube.js
@@ -212,7 +212,7 @@ describes.realWin('amp-youtube', {
   });
 
   it('requires data-videoid or data-live-channelid', () => {
-    allowConsoleError(() => {
+    return allowConsoleError(() => {
       return getYt({}).should.eventually.be.rejectedWith(
           /Exactly one of data-videoid or data-live-channelid should/);
     });

--- a/test/_init_tests.js
+++ b/test/_init_tests.js
@@ -298,7 +298,7 @@ function warnForConsoleError() {
   });
   this.allowConsoleError = function(func) {
     dontWarnForConsoleError();
-    func();
+    const result = func();
     try {
       expect(consoleErrorStub).to.have.been.called;
     } catch (e) {
@@ -313,6 +313,7 @@ function warnForConsoleError() {
       }
     }
     warnForConsoleError();
+    return result;
   };
 }
 

--- a/test/functional/test-amp-pixel.js
+++ b/test/functional/test-amp-pixel.js
@@ -127,7 +127,7 @@ describes.realWin('amp-pixel', {amp: true}, env => {
 
   it('should throw for referrerpolicy with value other than ' +
       'no-referrer', () => {
-    allowConsoleError(() => {
+    return allowConsoleError(() => {
       return createPixel(
           'https://pubads.g.doubleclick.net/activity;dc_iu=1/abc;ord=1?',
           'origin')


### PR DESCRIPTION
https://github.com/ampproject/amphtml/pull/14592#discussion_r186501729 raised the issue that `allowConsoleError(func)` as written today will swallow the return value of `func` if it were to return something, like a Promise.

This PR does ~~three~~ two things:
1. Returns the result of `func` at the end of `allowConsoleError`.
2. Fixes all instances of tests that fail the above check.
3. ~~Adds a presubmit check to prevent tests from failing to return the value of `func` from `allowConsoleError` in cases where `func` does return something.~~ 
This will be added as a new `.eslint` plugin in a separate PR. See #15242.


Related to https://github.com/ampproject/amphtml/pull/14592#discussion_r186501729