### PR TITLE
AdSense/Doubleclick amp-consent integration documentation

### DIFF
--- a/extensions/amp-ad-network-adsense-impl/amp-ad-network-adsense-impl-internal.md
+++ b/extensions/amp-ad-network-adsense-impl/amp-ad-network-adsense-impl-internal.md
@@ -45,7 +45,7 @@ The `<amp-consent>` element can be used to block the ad request until the user o
 
 If the user has responded negatively to the amp-consent component (user rejects the consent prompt), RTC call-outs will not be made and [non-personalized ads](https://support.google.com/dfp_premium/answer/9005435) will be requested.  
 
-If the user’s response to the amp-consent is unknown (user dismisses the consent prompt).  By default, no ad requests are sent at all.  If `data-npa-on-unknown-consent` is set to true, non-personalized ads will be requested.
+If the user’s response to the amp-consent is unknown (user dismisses the consent prompt), by default, no ad requests are sent.  If `data-npa-on-unknown-consent` is set to true, non-personalized ads will be requested.
 
 See [AdSense Help Center article](https://support.google.com/dfp_premium/answer/7678538) for more information.
 

--- a/extensions/amp-ad-network-adsense-impl/amp-ad-network-adsense-impl-internal.md
+++ b/extensions/amp-ad-network-adsense-impl/amp-ad-network-adsense-impl-internal.md
@@ -41,9 +41,9 @@ limitations under the License.
 
 #### AMP Consent integration
 
-The `<amp-consent>` element can be used to block the ad request until the user or AMP consent (checkConsentHref)[https://github.com/ampproject/amphtml/blob/master/extensions/amp-consent/amp-consent.md#consent-configuration] end point provide consent state.  After the amp-consent extension has been configured (please refer to its [documentation](https://github.com/ampproject/amphtml/blob/master/extensions/amp-consent/amp-consent.md)), it can be linked to the amp-ad element via the `data-block-on-consent` attribute.
+The `<amp-consent>` element can be used to block the ad request until the user or AMP consent [checkConsentHref](https://github.com/ampproject/amphtml/blob/master/extensions/amp-consent/amp-consent.md#consent-configuration) end point provide consent state.  After the amp-consent extension has been configured (please refer to its [documentation](https://github.com/ampproject/amphtml/blob/master/extensions/amp-consent/amp-consent.md)), it can be linked to the amp-ad element via the `data-block-on-consent` attribute.
 
-If the user has responded negatively to the amp-consent component (user rejects the consent prompt), RTC call-outs will not be made and (non-personalized ads)[https://support.google.com/dfp_premium/answer/9005435] will be requested.  
+If the user has responded negatively to the amp-consent component (user rejects the consent prompt), RTC call-outs will not be made and [non-personalized ads](https://support.google.com/dfp_premium/answer/9005435) will be requested.  
 
 If the user’s response to the amp-consent is unknown (user dismisses the consent prompt).  By default, no ad requests are sent at all.  If `data-npa-on-unknown-consent` is set to true, non-personalized ads will be requested.
 

--- a/extensions/amp-ad-network-adsense-impl/amp-ad-network-adsense-impl-internal.md
+++ b/extensions/amp-ad-network-adsense-impl/amp-ad-network-adsense-impl-internal.md
@@ -45,7 +45,8 @@ The `<amp-consent>` element can be used to block the ad request until the user o
 
 If the user has responded negatively to the amp-consent component (user rejects the consent prompt), RTC call-outs will not be made and [non-personalized ads](https://support.google.com/dfp_premium/answer/9005435) will be requested.  
 
-If the user’s response to the amp-consent is unknown (user dismisses the consent prompt), by default, no ad requests are sent.  If `data-npa-on-unknown-consent` is set to true, non-personalized ads will be requested.
+If the user’s response to the amp-consent is unknown (user dismisses the consent prompt), by default, no ad requests are sent.  
+If `data-npa-on-unknown-consent` is set to true, non-personalized ads will be requested.
 
 See [AdSense Help Center article](https://support.google.com/dfp_premium/answer/7678538) for more information.
 

--- a/extensions/amp-ad-network-adsense-impl/amp-ad-network-adsense-impl-internal.md
+++ b/extensions/amp-ad-network-adsense-impl/amp-ad-network-adsense-impl-internal.md
@@ -27,7 +27,7 @@ limitations under the License.
   </tr>
   <tr>
     <td width="40%"><strong>Availability</strong></td>
-    <td>In Development</td>
+    <td>General Availability</td>
   </tr>
   <tr>
     <td width="40%"><strong>Required Script</strong></td>
@@ -38,6 +38,16 @@ limitations under the License.
     <td>TBD</td>
   </tr>
 </table>
+
+#### AMP Consent integration
+
+The `<amp-consent>` element can be used to block the ad request until the user or AMP consent (checkConsentHref)[https://github.com/ampproject/amphtml/blob/master/extensions/amp-consent/amp-consent.md#consent-configuration] end point provide consent state.  After the amp-consent extension has been configured (please refer to its [documentation](https://github.com/ampproject/amphtml/blob/master/extensions/amp-consent/amp-consent.md)), it can be linked to the amp-ad element via the `data-block-on-consent` attribute.
+
+If the user has responded negatively to the amp-consent component (user rejects the consent prompt), RTC call-outs will not be made and (non-personalized ads)[https://support.google.com/dfp_premium/answer/9005435] will be requested.  
+
+If the user’s response to the amp-consent is unknown (user dismisses the consent prompt).  By default, no ad requests are sent at all.  If `data-npa-on-unknown-consent` is set to true, non-personalized ads will be requested.
+
+See [AdSense Help Center article](https://support.google.com/dfp_premium/answer/7678538) for more information.
 
 #### Examples
 Example - AdSense Ad

--- a/extensions/amp-ad-network-doubleclick-impl/amp-ad-network-doubleclick-impl-internal.md
+++ b/extensions/amp-ad-network-doubleclick-impl/amp-ad-network-doubleclick-impl-internal.md
@@ -85,7 +85,7 @@ limitations under the License.
     <td>When enabled, all eligible slots on the page will be serviced by a single ad request.</td>
     <td>Beta</td>
   </tr>
-  <td>
+  <tr>
     <td><a href="amp-consent.md">AMP Consent Integration</a></td>
     <td>Integration with AMP Consent extension.</td>
     <td>Launched</td>

--- a/extensions/amp-ad-network-doubleclick-impl/amp-ad-network-doubleclick-impl-internal.md
+++ b/extensions/amp-ad-network-doubleclick-impl/amp-ad-network-doubleclick-impl-internal.md
@@ -85,6 +85,11 @@ limitations under the License.
     <td>When enabled, all eligible slots on the page will be serviced by a single ad request.</td>
     <td>Beta</td>
   </tr>
+  <td>
+    <td><a href="amp-consent.md">AMP Consent Integration</a></td>
+    <td>Integration with AMP Consent extension.</td>
+    <td>Launched</td>
+  </tr>
 </table>
 
 #### Examples
@@ -135,7 +140,7 @@ See the TFCD article for <a href="https://support.google.com/dfp_sb/answer/37219
   - `"<key_string>":"<value_string>"` or
   - `"<key_string>":["<value1>", "<value2>", ...]`. See below for example.
 
-Example with json attribute: 
+Example with json attribute:
 
 ```html
 <amp-ad width=320 height=50

--- a/extensions/amp-ad-network-doubleclick-impl/amp-consent.md
+++ b/extensions/amp-ad-network-doubleclick-impl/amp-consent.md
@@ -16,9 +16,9 @@ limitations under the License.
 
 # AMP Consent integration
 
-The `<amp-consent>` element can be used to block the ad request and any [RTC](./doubleclick-rtc.md) requests from being sent until the user or AMP consent (checkConsentHref)[https://github.com/ampproject/amphtml/blob/master/extensions/amp-consent/amp-consent.md#consent-configuration] end point provide consent state.  After the amp-consent extension has been configured (please refer to its [documentation](https://github.com/ampproject/amphtml/blob/master/extensions/amp-consent/amp-consent.md)), it can be linked to the amp-ad element via the `data-block-on-consent` attribute.
+The `<amp-consent>` element can be used to block the ad request and any [RTC](./doubleclick-rtc.md) requests from being sent until the user or AMP consent [checkConsentHref](https://github.com/ampproject/amphtml/blob/master/extensions/amp-consent/amp-consent.md#consent-configuration) end point provide consent state.  After the amp-consent extension has been configured (please refer to its [documentation](https://github.com/ampproject/amphtml/blob/master/extensions/amp-consent/amp-consent.md)), it can be linked to the amp-ad element via the `data-block-on-consent` attribute.
 
-If the user has responded negatively to the amp-consent component (user rejects the consent prompt), RTC call-outs will not be made and (non-personalized ads)[https://support.google.com/dfp_premium/answer/9005435] will be requested.  
+If the user has responded negatively to the amp-consent component (user rejects the consent prompt), RTC call-outs will not be made and [non-personalized ads](https://support.google.com/dfp_premium/answer/9005435) will be requested.  
 If the user’s response to the amp-consent is unknown (user dismisses the consent prompt).  By default, no ad requests or RTC call-outs are sent at all.  If `data-npa-on-unknown-consent` is set to true, non-personalized ads will be requested but RTC call-outs are not sent.
 
 See [AdSense Help Center article](https://support.google.com/dfp_premium/answer/7678538) for more information.

--- a/extensions/amp-ad-network-doubleclick-impl/amp-consent.md
+++ b/extensions/amp-ad-network-doubleclick-impl/amp-consent.md
@@ -21,4 +21,4 @@ The `<amp-consent>` element can be used to block the ad request and any [RTC](./
 If the user has responded negatively to the amp-consent component (user rejects the consent prompt), RTC call-outs will not be made and [non-personalized ads](https://support.google.com/dfp_premium/answer/9005435) will be requested.  
 If the user’s response to the amp-consent is unknown (user dismisses the consent prompt).  By default, no ad requests or RTC call-outs are sent at all.  If `data-npa-on-unknown-consent` is set to true, non-personalized ads will be requested but RTC call-outs are not sent.
 
-See [AdSense Help Center article](https://support.google.com/dfp_premium/answer/7678538) for more information.
+See [Doubleclick Help Center article](https://support.google.com/dfp_premium/answer/7678538) for more information.

--- a/extensions/amp-ad-network-doubleclick-impl/amp-consent.md
+++ b/extensions/amp-ad-network-doubleclick-impl/amp-consent.md
@@ -19,6 +19,6 @@ limitations under the License.
 The `<amp-consent>` element can be used to block the ad request and any [RTC](./doubleclick-rtc.md) requests from being sent until the user or AMP consent [checkConsentHref](https://github.com/ampproject/amphtml/blob/master/extensions/amp-consent/amp-consent.md#consent-configuration) end point provide consent state.  After the amp-consent extension has been configured (please refer to its [documentation](https://github.com/ampproject/amphtml/blob/master/extensions/amp-consent/amp-consent.md)), it can be linked to the amp-ad element via the `data-block-on-consent` attribute.
 
 If the user has responded negatively to the amp-consent component (user rejects the consent prompt), RTC call-outs will not be made and [non-personalized ads](https://support.google.com/dfp_premium/answer/9005435) will be requested.  
-If the user’s response to the amp-consent is unknown (user dismisses the consent prompt).  By default, no ad requests or RTC call-outs are sent at all.  If `data-npa-on-unknown-consent` is set to true, non-personalized ads will be requested but RTC call-outs are not sent.
+If the user’s response to the amp-consent is unknown (user dismisses the consent prompt), by default, no ad requests or RTC call-outs are sent.  If `data-npa-on-unknown-consent` is set to true, non-personalized ads will be requested but RTC call-outs are not sent.
 
 See [Doubleclick Help Center article](https://support.google.com/dfp_premium/answer/7678538) for more information.

--- a/extensions/amp-ad-network-doubleclick-impl/amp-consent.md
+++ b/extensions/amp-ad-network-doubleclick-impl/amp-consent.md
@@ -19,6 +19,7 @@ limitations under the License.
 The `<amp-consent>` element can be used to block the ad request and any [RTC](./doubleclick-rtc.md) requests from being sent until the user or AMP consent [checkConsentHref](https://github.com/ampproject/amphtml/blob/master/extensions/amp-consent/amp-consent.md#consent-configuration) end point provide consent state.  After the amp-consent extension has been configured (please refer to its [documentation](https://github.com/ampproject/amphtml/blob/master/extensions/amp-consent/amp-consent.md)), it can be linked to the amp-ad element via the `data-block-on-consent` attribute.
 
 If the user has responded negatively to the amp-consent component (user rejects the consent prompt), RTC call-outs will not be made and [non-personalized ads](https://support.google.com/dfp_premium/answer/9005435) will be requested.  
-If the user’s response to the amp-consent is unknown (user dismisses the consent prompt), by default, no ad requests or RTC call-outs are sent.  If `data-npa-on-unknown-consent` is set to true, non-personalized ads will be requested but RTC call-outs are not sent.
+If the user’s response to the amp-consent is unknown (user dismisses the consent prompt), by default, no ad requests or RTC call-outs are sent.  
+If `data-npa-on-unknown-consent` is set to true, non-personalized ads will be requested but RTC call-outs are not sent.
 
 See [Doubleclick Help Center article](https://support.google.com/dfp_premium/answer/7678538) for more information.

--- a/extensions/amp-ad-network-doubleclick-impl/amp-consent.md
+++ b/extensions/amp-ad-network-doubleclick-impl/amp-consent.md
@@ -1,0 +1,24 @@
+<!---
+Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS-IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# AMP Consent integration
+
+The `<amp-consent>` element can be used to block the ad request and any [RTC](./doubleclick-rtc.md) requests from being sent until the user or AMP consent (checkConsentHref)[https://github.com/ampproject/amphtml/blob/master/extensions/amp-consent/amp-consent.md#consent-configuration] end point provide consent state.  After the amp-consent extension has been configured (please refer to its [documentation](https://github.com/ampproject/amphtml/blob/master/extensions/amp-consent/amp-consent.md)), it can be linked to the amp-ad element via the `data-block-on-consent` attribute.
+
+If the user has responded negatively to the amp-consent component (user rejects the consent prompt), RTC call-outs will not be made and (non-personalized ads)[https://support.google.com/dfp_premium/answer/9005435] will be requested.  
+If the user’s response to the amp-consent is unknown (user dismisses the consent prompt).  By default, no ad requests or RTC call-outs are sent at all.  If `data-npa-on-unknown-consent` is set to true, non-personalized ads will be requested but RTC call-outs are not sent.
+
+See [AdSense Help Center article](https://support.google.com/dfp_premium/answer/7678538) for more information.


### PR DESCRIPTION
Provide documentation on how to integrate `<amp-ad type=doubleclick>` and `<amp-ad type=adsense>' with `<amp-consent>`