### PR TITLE
✅ Skip flaky `amp-next-page` tests

### DIFF
--- a/extensions/amp-next-page/0.1/test/test-amp-next-page.js
+++ b/extensions/amp-next-page/0.1/test/test-amp-next-page.js
@@ -21,7 +21,9 @@ import {layoutRectLtwh} from '../../../../src/layout-rect';
 import {macroTask} from '../../../../testing/yield';
 import {toggleExperiment} from '../../../../src/experiments';
 
-describes.realWin('amp-next-page component', {
+// TODO(@peterjosling, #15150): These tests fail on Travis.
+// See https://github.com/ampproject/amphtml/pull/15150#pullrequestreview-119563529
+describes.realWin.skip('amp-next-page component', {
   amp: {
     extensions: ['amp-next-page'],
   },


### PR DESCRIPTION
These tests are flaky on `master`. 

See https://github.com/ampproject/amphtml/pull/15150#pullrequestreview-119563529