### PR TITLE
✨ add amp-geo-pending support

### DIFF
--- a/ads/google/csa.js
+++ b/ads/google/csa.js
@@ -107,11 +107,10 @@ function orientationChangeHandler(global, containerDiv) {
   // Save the height of the container before the event listener triggers
   const oldHeight = getStyle(containerDiv, 'height');
   global.setTimeout(() => {
-    // Force DOM reflow and repaint
-    /*eslint-disable no-unused-vars*/
+    // Force DOM reflow and repaint.
+    // eslint-disable-next-line no-unused-vars
     const ignore = global.document.body./*OK*/offsetHeight;
-    /*eslint-enable no-unused-vars*/
-    // Capture new height
+    // Capture new height.
     let newHeight = getStyle(containerDiv, 'height');
     // In older versions of iOS, this height will be different because the
     // container height is resized.
@@ -124,9 +123,9 @@ function orientationChangeHandler(global, containerDiv) {
       const overflow = global.document.getElementById('overflow');
       if (overflow) {
         overflow.onclick =
-            global.context.requestResize.bind(null, undefined, newHeight);
+            () => global.context.requestResize(undefined, newHeight);
       }
-      // Resize the container to the correct height
+      // Resize the container to the correct height.
       global.context.requestResize(undefined, newHeight);
     }
   }, 250); /* 250 is time in ms to wait before executing orientation */
@@ -292,7 +291,7 @@ export function resizeIframe(global, containerName) {
 function createOverflow(global, container, height) {
   const overflow = getOverflowElement(global);
   // When overflow is clicked, resize to full height
-  overflow.onclick = global.context.requestResize.bind(null, undefined, height);
+  overflow.onclick = () => global.context.requestResize(undefined, height);
   global.document.getElementById('c').appendChild(overflow);
   // Resize the CSA container to not conflict with overflow
   resizeCsa(container, currentAmpHeight - overflowHeight);

--- a/extensions/amp-geo/0.1/amp-geo.js
+++ b/extensions/amp-geo/0.1/amp-geo.js
@@ -111,6 +111,7 @@ export class AmpGeo extends AMP.BaseElement {
 
   /**
    * findCountry_, sets this.country_ and this.mode_
+   * @param {Document} doc
    */
   findCountry_(doc) {
     // First see if we've been pre-rendered with a country, if so set it
@@ -173,6 +174,7 @@ export class AmpGeo extends AMP.BaseElement {
    * clearPreRender_()
    * Removes classes and amp-state block addred by server side
    * pre-render when debug override is in effect
+   * @param {Document} doc
    */
   clearPreRender_(doc) {
     const klasses = doc.body.classList;

--- a/extensions/amp-geo/0.1/amp-geo.js
+++ b/extensions/amp-geo/0.1/amp-geo.js
@@ -106,7 +106,7 @@ export class AmpGeo extends AMP.BaseElement {
           parseJson(children[0].textContent) : {});
 
     /* resolve the service promise singleton we stashed earlier */
-    geoPromise.resolve(geo);
+    geoDeferred.resolve(geo);
   }
 
   /**
@@ -252,11 +252,11 @@ export class AmpGeo extends AMP.BaseElement {
  */
 
 /** singleton */
-let geoPromise = null;
+let geoDeferred = null;
 
 AMP.extension('amp-geo', '0.1', AMP => {
-  geoPromise = new Deferred();
+  geoDeferred = new Deferred();
 
   AMP.registerElement(TAG, AmpGeo);
-  AMP.registerServiceForDoc(SERVICE_TAG, () => geoPromise.promise);
+  AMP.registerServiceForDoc(SERVICE_TAG, () => geoDeferred.promise);
 });

--- a/extensions/amp-geo/0.1/amp-geo.js
+++ b/extensions/amp-geo/0.1/amp-geo.js
@@ -35,6 +35,7 @@
  * the amp-geo element's layout type is nodisplay.
  */
 
+import {Deferred} from '../../../src/utils/promise';
 import {getMode} from '../../../src/mode';
 import {isArray, isObject} from '../../../src/types';
 import {isCanary} from '../../../src/experiments';
@@ -105,7 +106,7 @@ export class AmpGeo extends AMP.BaseElement {
           parseJson(children[0].textContent) : {});
 
     /* resolve the service promise singleton we stashed earlier */
-    geoResolver(geo);
+    geoPromise.resolve(geo);
   }
 
   /**
@@ -218,6 +219,7 @@ export class AmpGeo extends AMP.BaseElement {
             states[self.matchedGroups_[group]] = true;
           }
           doc.body.classList.add(COUNTRY_PREFIX + this.country_);
+          doc.body.classList.remove('amp-geo-pending');
           states.ISOCountryGroups = self.matchedGroups_;
 
           // Only include amp state if user requests it to avoid validator issue
@@ -247,15 +249,12 @@ export class AmpGeo extends AMP.BaseElement {
  * Create the service promise at load time to prevent race between extensions
  */
 
-/** singleton @type {?Promise<!Object<string, (string|Array<string>)>>} */
-let geoResolver = null;
+/** singleton */
+let geoPromise = null;
 
 AMP.extension('amp-geo', '0.1', AMP => {
-  /** @type {Promise<!Object<string, (string|Array<string>)>>} */
-  const geoPromise = new Promise(resolve => {
-    geoResolver = resolve;
-  });
-  AMP.registerElement(TAG, AmpGeo);
-  AMP.registerServiceForDoc(SERVICE_TAG, () => geoPromise);
-});
+  geoPromise = new Deferred();
 
+  AMP.registerElement(TAG, AmpGeo);
+  AMP.registerServiceForDoc(SERVICE_TAG, () => geoPromise.promise);
+});

--- a/extensions/amp-geo/0.1/test/test-amp-geo.js
+++ b/extensions/amp-geo/0.1/test/test-amp-geo.js
@@ -106,6 +106,23 @@ describes.realWin('amp-geo', {
     });
   });
 
+  it('should remove amp-geo-pending class from body element', () => {
+    addConfigElement('script');
+    doc.body.classList.add('amp-geo-pending');
+
+    expectBodyHasClass([
+      'amp-geo-pending',
+    ], true);
+
+    geo.buildCallback();
+    return Services.geoForOrNull(win).then(geo => {
+      expect(geo.ISOCountry).to.equal('unknown');
+      expectBodyHasClass([
+        'amp-geo-pending',
+      ], false);
+    });
+  });
+
   it('should insert an amp-state if enabled', () => {
     addConfigElement('script', 'application/json',
         JSON.stringify(configWithState));

--- a/extensions/amp-geo/amp-geo.md
+++ b/extensions/amp-geo/amp-geo.md
@@ -131,6 +131,24 @@ The game is called <span class='football'></span>!
 </div>
 ```
 
+### Render Blocking
+
+By default `amp-geo` is not render blocking. That is, the page will load and elements will render even if `amp-geo` has not yet loaded and executed. If it is important that certain elements are never rendered in a specifc geography the `amp-geo-pending` class may be used to provide selective render blocking. 
+
+This is implmented by the publisher adding `amp-geo-pending` to the `<body>` element. When it loads `amp-geo` will remove this class at the same time as it adds the `amp-iso-country...` and `amp-geo-group-...` classes.
+
+Example: To always suppress an element with the class `foo` in the United States a publisher would set `<body class="amp-geo-pending">` and in the CSS include
+
+```css
+.amp-geo-pending .foo,
+.amp-iso-country-us .foo {
+  display: none;
+}
+```
+
+This would hide the element until `amp-geo` has loaded and continue to hide it if the country is `us`. Note: Elements such as `amp-ad` and `amp-iframe` do not make external network requests when set to `display: none`.
+
+
 ### Integration with amp-bind
 
 If the `AMPBind` key is present in the configuration, `amp-geo` inserts an `amp-state` tag containing the current country and group information.  Using the football example above, set the  `AMPBind` flag to true to enable `amp-bind` integration.

--- a/extensions/amp-geo/amp-geo.md
+++ b/extensions/amp-geo/amp-geo.md
@@ -133,7 +133,7 @@ The game is called <span class='football'></span>!
 
 ### Render Blocking
 
-By default, the `amp-geo` component is not render blocking. That is, the page will load and elements will render even if `amp-geo` has not yet loaded and executed. If it's important that certain elements are never rendered in a specific geography, use the `amp-geo-pending` class to provide selective render blocking. This is implemented by the publisher by adding `amp-geo-pending` to the `<body>` element. When it loads, `amp-geo` removes this class at the same time as it adds the `amp-iso-country...` and `amp-geo-group-...` classes.
+By default, the `amp-geo` component is not render blocking. That is, the page will load and elements will render even if `amp-geo` has not yet loaded and executed. If it's important that certain elements are never rendered in a specific geography, use the `amp-geo-pending` class to provide selective render blocking. This is implemented by the publisher by adding `amp-geo-pending` to the `<body>` element. When the `amp-geo` script loads it removes this class at the same time as it adds the `amp-iso-country...` and `amp-geo-group-...` classes.
 
 *Example*: To always suppress an element that has the `foo` class in the United States, set `<body class="amp-geo-pending">`, and in the CSS include the following:
 

--- a/extensions/amp-geo/amp-geo.md
+++ b/extensions/amp-geo/amp-geo.md
@@ -133,11 +133,9 @@ The game is called <span class='football'></span>!
 
 ### Render Blocking
 
-By default `amp-geo` is not render blocking. That is, the page will load and elements will render even if `amp-geo` has not yet loaded and executed. If it is important that certain elements are never rendered in a specifc geography the `amp-geo-pending` class may be used to provide selective render blocking. 
+By default, the `amp-geo` component is not render blocking. That is, the page will load and elements will render even if `amp-geo` has not yet loaded and executed. If it's important that certain elements are never rendered in a specific geography, use the `amp-geo-pending` class to provide selective render blocking. This is implemented by the publisher by adding `amp-geo-pending` to the `<body>` element. When it loads, `amp-geo` removes this class at the same time as it adds the `amp-iso-country...` and `amp-geo-group-...` classes.
 
-This is implmented by the publisher adding `amp-geo-pending` to the `<body>` element. When it loads `amp-geo` will remove this class at the same time as it adds the `amp-iso-country...` and `amp-geo-group-...` classes.
-
-Example: To always suppress an element with the class `foo` in the United States a publisher would set `<body class="amp-geo-pending">` and in the CSS include
+*Example*: To always suppress an element that has the `foo` class in the United States, set `<body class="amp-geo-pending">`, and in the CSS include the following:
 
 ```css
 .amp-geo-pending .foo,
@@ -146,7 +144,9 @@ Example: To always suppress an element with the class `foo` in the United States
 }
 ```
 
-This would hide the element until `amp-geo` has loaded and continue to hide it if the country is `us`. Note: Elements such as `amp-ad` and `amp-iframe` do not make external network requests when set to `display: none`.
+This CSS hides the element that has the `foo` class until `amp-geo` has loaded and continues to hide it if the country is `us`. 
+
+**Note**: Elements such as `amp-ad` and `amp-iframe` do not make external network requests when set to `display: none`.
 
 
 ### Integration with amp-bind


### PR DESCRIPTION
Adds support for `amp-geo-pending` class. This provides selective render blocking until amp-geo has resolved.

Also updates amp-geo to use Deferred instead of a raw Promise (fixes lint warning)

Related to #14846 

Fixes #15229 #15227