### PR TITLE
🚮Restrict comments to 80 columns (exempt JSDoc annotations)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -67,7 +67,7 @@
     "max-len": [2, 80, 4, {
       "ignoreTrailingComments": true,
       "ignoreRegExpLiterals": true,
-      "ignorePattern": "^import.*';|}\\ from.*;|.*require\\(.*;$|@typedef|@param|@return",
+      "ignorePattern": "^import.*';|}\\ from.*;|.*require\\(.*;$|@typedef|@param|@return|@private|@const|@type|@implements",
       "ignoreUrls": true
     }],
     "no-alert": 2,

--- a/.eslintrc
+++ b/.eslintrc
@@ -65,9 +65,9 @@
     "indent": [2, 2, { "SwitchCase": 1, "VariableDeclarator": 2, "MemberExpression": 2, "ObjectExpression": 1, "CallExpression": { "arguments": 2 } }],
     "key-spacing": 2,
     "max-len": [2, 80, 4, {
-      "ignoreComments": true,
+      "ignoreTrailingComments": true,
       "ignoreRegExpLiterals": true,
-      "ignorePattern": "^import.*';|}\\ from.*;|.*require\\(.*;$",
+      "ignorePattern": "^import.*';|}\\ from.*;|.*require\\(.*;$|@typedef|@param|@return",
       "ignoreUrls": true
     }],
     "no-alert": 2,

--- a/3p/ampcontext-lib.js
+++ b/3p/ampcontext-lib.js
@@ -37,7 +37,8 @@ setReportError(() => {});
 try {
   const windowContextCreated = new Event('amp-windowContextCreated');
   window.context = new AmpContext(window);
-  // Allows for pre-existence, consider validating correct window.context lib instance?
+  // Allows for pre-existence, consider validating correct window.context lib
+  // instance?
   window.dispatchEvent(windowContextCreated);
 } catch (err) {
   // do nothing with error

--- a/3p/facebook.js
+++ b/3p/facebook.js
@@ -60,8 +60,9 @@ function getPostContainer(global, data) {
   if (data.href.match(/\/videos\/\d+\/?$/) && !data.embedAs) {
     embedAs = 'video';
     container.setAttribute('data-embed-as', 'video');
-    // Since 'data-embed-as="video"' disables post text, setting the 'data-show-text'
-    // to 'true' enables the ability to see the text (changed from the default 'false')
+    // Since 'data-embed-as="video"' disables post text, setting the
+    // 'data-show-text' to 'true' enables the ability to see the text (changed
+    // from the default 'false')
     container.setAttribute('data-show-text', 'true');
   }
   container.className = 'fb-' + embedAs;

--- a/3p/github.js
+++ b/3p/github.js
@@ -43,7 +43,8 @@ export function github(global, data) {
       'The data-gistid attribute is required for <amp-gist> %s',
       data.element);
 
-  let gistUrl = 'https://gist.github.com/' + encodeURIComponent(data.gistid) + '.js';
+  let gistUrl =
+      'https://gist.github.com/' + encodeURIComponent(data.gistid) + '.js';
 
   if (data.file) {
     gistUrl += '?file=' + encodeURIComponent(data.file);

--- a/3p/twitter.js
+++ b/3p/twitter.js
@@ -66,7 +66,8 @@ export function twitter(global, data) {
 
     let twitterWidgetSandbox;
     twttr.events.bind('resize', event => {
-      // To be safe, make sure the resize event was triggered for the widget we created below.
+      // To be safe, make sure the resize event was triggered for the widget we
+      // created below.
       if (twitterWidgetSandbox === event.target) {
         resize(twitterWidgetSandbox);
       }

--- a/ads/_a4a-config.js
+++ b/ads/_a4a-config.js
@@ -63,10 +63,11 @@ export function getA4ARegistry() {
       'cloudflare': cloudflareIsA4AEnabled,
       'gmossp': gmosspIsA4AEnabled,
       'fake': () => true,
-      // TODO: Add new ad network implementation "is enabled" functions here.  Note:
-      // if you add a function here that requires a new "import", above, you'll
-      // probably also need to add a whitelist exception to
-      // build-system/dep-check-config.js in the "filesMatching: 'ads/**/*.js' rule.
+      // TODO: Add new ad network implementation "is enabled" functions here.
+      // Note: if you add a function here that requires a new "import", above,
+      // you'll probably also need to add a whitelist exception to
+      // build-system/dep-check-config.js in the "filesMatching: 'ads/**/*.js'
+      // rule.
     });
   }
 

--- a/ads/appnexus.js
+++ b/ads/appnexus.js
@@ -40,7 +40,8 @@ export function appnexus(global, data) {
   }
 
   /**
-   * Construct the TTJ URL. Note params should be properly encoded first (use encodeURIComponent);
+   * Construct the TTJ URL. Note params should be properly encoded first (use
+   * encodeURIComponent);
    * @param  {!Array<string>} args query string params to add to the base URL.
    * @return {string}      Formated TTJ URL.
    */

--- a/ads/google/a4a/google-data-reporter.js
+++ b/ads/google/a4a/google-data-reporter.js
@@ -139,10 +139,10 @@ function setupPageLoadMetricsReporter_(ampElement) {
       'requests': {
         'fvt': 'https://csi.gstatic.com/csi?s=a4a' +
             `&c=${correlator}&met.a4a=` +
-	    'makeBodyVisible.${makeBodyVisible}~' +
-	    'firstVisibleTime.${firstVisibleTime}~' +
-	    'firstContentfulPaint.${firstContentfulPaint}~' +
-	    'firstViewportReady.${firstViewportReady}',
+      'makeBodyVisible.${makeBodyVisible}~' +
+      'firstVisibleTime.${firstVisibleTime}~' +
+      'firstContentfulPaint.${firstContentfulPaint}~' +
+      'firstViewportReady.${firstViewportReady}',
       },
       'transport': {
         'beacon': false,

--- a/ads/google/a4a/google-data-reporter.js
+++ b/ads/google/a4a/google-data-reporter.js
@@ -135,27 +135,28 @@ function setupPageLoadMetricsReporter_(ampElement) {
   const win = ampElement.win;
   const correlator = getCorrelator(win);
   win.ampAnalyticsPageLoadMetricsConfig =
-      win.ampAnalyticsPageLoadMetricsConfig || dict({
-      'requests': {
-        'fvt': 'https://csi.gstatic.com/csi?s=a4a' +
-            `&c=${correlator}&met.a4a=` +
-      'makeBodyVisible.${makeBodyVisible}~' +
-      'firstVisibleTime.${firstVisibleTime}~' +
-      'firstContentfulPaint.${firstContentfulPaint}~' +
-      'firstViewportReady.${firstViewportReady}',
-      },
-      'transport': {
-        'beacon': false,
-        'xhrpost': false,
-      },
-      'triggers': {
-        'iniLoad': {
-          'on': 'visible',
-          'request': 'fvt',
-          'selector': 'body',
+      win.ampAnalyticsPageLoadMetricsConfig ||
+      dict({
+        'requests': {
+          'fvt': 'https://csi.gstatic.com/csi?s=a4a' +
+              `&c=${correlator}&met.a4a=` +
+              'makeBodyVisible.${makeBodyVisible}~' +
+              'firstVisibleTime.${firstVisibleTime}~' +
+              'firstContentfulPaint.${firstContentfulPaint}~' +
+              'firstViewportReady.${firstViewportReady}',
         },
-      },
-    });
+        'transport': {
+          'beacon': false,
+          'xhrpost': false,
+        },
+        'triggers': {
+          'iniLoad': {
+            'on': 'visible',
+            'request': 'fvt',
+            'selector': 'body',
+          },
+        },
+      });
 
   // Load amp-analytics extensions
   win.ampAnalyticsPageLoadMetricsElement =

--- a/ads/medianet.js
+++ b/ads/medianet.js
@@ -26,7 +26,8 @@ const mandatoryParams = ['tagtype', 'cid'],
       'consentNotificationId', 'useSameDomainRenderingUntilDeprecated',
       'experimentId', 'multiSize', 'multiSizeValidation',
     ];
-//useSameDomainRenderingUntilDeprecated is included to ensure publisher amp-tags don't break before 29th March
+// useSameDomainRenderingUntilDeprecated is included to ensure publisher
+// amp-tags don't break before 29th March
 
 /**
  * @param {!Window} global

--- a/ads/nativo.js
+++ b/ads/nativo.js
@@ -45,12 +45,8 @@ export function nativo(global, data) {
       global.context.observeIntersection(function(positions) {
         const coordinates = getLastPositionCoordinates(positions);
         if (typeof coordinates.rootBounds != 'undefined'
-            && (coordinates
-                .intersectionRect
-                .top == (coordinates
-                  .rootBounds.top + coordinates
-                    .boundingClientRect
-                    .y))) {
+            && (coordinates.intersectionRect.top == (
+              coordinates.rootBounds.top + coordinates.boundingClientRect.y))) {
           if (isDelayedViewStart(data) && !delayedAdLoad) {
             g.PostRelease.Start();
             delayedAdLoad = true;
@@ -71,7 +67,8 @@ export function nativo(global, data) {
     function setPercentageOfadViewed(percentage) {
       percentageOfadViewed = percentage;
     }
-    // Used to track ad during scrolling event and trigger checkIsAdVisible method on PostRelease instance
+    // Used to track ad during scrolling event and trigger checkIsAdVisible
+    // method on PostRelease instance
     function viewabilityConfiguration(positions) {
       const coordinates = getLastPositionCoordinates(positions);
       setPercentageOfadViewed(
@@ -88,7 +85,8 @@ export function nativo(global, data) {
     ntvAd.getScriptURL = function() {
       return 'https://s.ntv.io/serve/load.js';
     };
-    // Configuration setup is based on the parameters/attributes associated with the amp-ad node
+    // Configuration setup is based on the parameters/attributes associated with
+    // the amp-ad node
     ntvAd.setupAd = function() {
       global._prx = [['cfg.Amp']];
       global._prx.push(['cfg.RequestUrl', data['requestUrl'] || loc.href]);
@@ -102,7 +100,8 @@ export function nativo(global, data) {
         }
       }
     };
-    // Used to Delay Start and Initalize Tracking. This is a callback AMP will use once script is loaded
+    // Used to Delay Start and Initalize Tracking. This is a callback AMP will
+    // use once script is loaded
     ntvAd.Start = function() {
       if (isDelayedTimeStart(data)) {
         loadAdWhenTimedout();

--- a/ads/smartadserver.js
+++ b/ads/smartadserver.js
@@ -21,7 +21,8 @@ import {loadScript} from '../3p/3p';
  * @param {!Object} data
  */
 export function smartadserver(global, data) {
-  // For more flexibility, we construct the call to SmartAdServer's URL in the external loader, based on the data received from the AMP tag.
+  // For more flexibility, we construct the call to SmartAdServer's URL in the
+  // external loader, based on the data received from the AMP tag.
   loadScript(global, 'https://ec-ns.sascdn.com/diff/js/amp.v0.js', () => {
     global.sas.callAmpAd(data);
   });

--- a/ads/sovrn.js
+++ b/ads/sovrn.js
@@ -15,8 +15,9 @@
 */
 /*
  *********
- * Existing sovrn customers feel free to contact amp-implementations@sovrn.com for assistance with setting up your amp-ad tagid
- * New customers please see www.sovrn.com to sign up and get started!
+ * Existing sovrn customers feel free to contact amp-implementations@sovrn.com
+ * for assistance with setting up your amp-ad tagid New customers please see
+ * www.sovrn.com to sign up and get started!
  *********
  */
 import {writeScript} from '../3p/3p';

--- a/ads/spotx.js
+++ b/ads/spotx.js
@@ -47,7 +47,8 @@ export function spotx(global, data) {
     }
   };
 
-  // TODO(KenneyE): Implement AdLoaded callback in script to accurately trigger renderStart()
+  // TODO(KenneyE): Implement AdLoaded callback in script to accurately trigger
+  // renderStart()
   script.onload = global.context.renderStart;
 
   script.src = `//js.spotx.tv/easi/v1/${data['spotx_channel_id']}.js`;

--- a/ads/trugaze.js
+++ b/ads/trugaze.js
@@ -20,6 +20,7 @@ import {loadScript} from '../3p/3p';
  * @param {!Window} global
  */
 export function trugaze(global) {
-  // For simplicity and flexibility, all validations are performed in the Trugaze's URL based on the data received
+  // For simplicity and flexibility, all validations are performed in the
+  // Trugaze's URL based on the data received
   loadScript(global, 'https://cdn.trugaze.io/amp-init-v1.js');
 }

--- a/ads/weborama.js
+++ b/ads/weborama.js
@@ -72,7 +72,9 @@ export function weboramaDisplay(global, data) {
     publisherclick: data.wbo_publisherclick,
     // clicktrackers: data.wbo_clicktrackers,
     // imptrackers: data.wbo_imptrackers,
-    // zindex: data.wbo_zindex, // This is actually quite useless for now, since we are launced in a non-friendly iframe.
+    // This is actually quite useless for now, since we are launced in a
+    // non-friendly iframe.
+    // zindex: data.wbo_zindex,
     disable_unload_event: data.wbo_disable_unload_event,
     donottrack: data.wbo_donottrack,
     script_variant: data.wbo_script_variant,

--- a/build-system/app.js
+++ b/build-system/app.js
@@ -701,9 +701,10 @@ app.use(['/examples/*', '/extensions/*'], (req, res, next) => {
 });
 
 /**
- * Append ?sleep=5 to any included JS file in examples to emulate delay in loading that
- * file. This allows you to test issues with your extension being late to load
- * and testing user interaction with your element before your code loads.
+ * Append ?sleep=5 to any included JS file in examples to emulate delay in
+ * loading that file. This allows you to test issues with your extension being
+ * late to load and testing user interaction with your element before your code
+ * loads.
  *
  * Example delay loading amp-form script by 5 seconds:
  * <script async custom-element="amp-form"

--- a/build-system/eslint-rules/closure-type-primitives.js
+++ b/build-system/eslint-rules/closure-type-primitives.js
@@ -41,7 +41,7 @@ module.exports = function(context) {
     },
     Program: function() {
       const comments =
-          /** @type {!Array<!EslintNodeDef>} */ (sourceCode.getAllComments());
+        /** @type {!Array<!EslintNodeDef>} */ (sourceCode.getAllComments());
       comments
           .map(node => parseClosureComments(context, node))
           .forEach(comment => checkClosureComments(context, comment));
@@ -116,7 +116,8 @@ const PRIMITIVE_WRAPPER_NAMES = [
 ];
 
 /**
- * Disallowed primitives wrappers, from go/es6-style#disallowed-features-wrapper-objects
+ * Disallowed primitives wrappers, from
+ * go/es6-style#disallowed-features-wrapper-objects
  * @param {string} name
  * @return {boolean}
  */

--- a/build-system/scope-require.js
+++ b/build-system/scope-require.js
@@ -26,8 +26,9 @@ const fs = require('fs');
 const program = require('commander');
 
 /**
- * Changes global `require` calls to be referenced from a given global namespace.
- * e.g. if scopeName is `AMP`, calls will be transformed to `AMP.require`.
+ * Changes global `require` calls to be referenced from a given global
+ * namespace. e.g. if scopeName is `AMP`, calls will be transformed to
+ * `AMP.require`.
  * @param {string} src The contents of a JavaScript source file.
  * @param {string} scopeName The name to prepend to `require` calls.
  * @return {string} The transformed source code

--- a/build-system/tasks/jsify-css.js
+++ b/build-system/tasks/jsify-css.js
@@ -42,7 +42,8 @@ const cssNanoDefaultOptions = {
   convertValues: false,
   discardUnused: false,
   cssDeclarationSorter: false,
-  // `mergeIdents` this is only unsafe if you rely on those animation names in JavaScript.
+  // `mergeIdents` this is only unsafe if you rely on those animation names in
+  // JavaScript.
   mergeIdents: true,
   reduceIdents: false,
   reduceInitial: false,

--- a/build-system/test-server.js
+++ b/build-system/test-server.js
@@ -16,7 +16,8 @@
 'use strict';
 
 /**
- * @fileoverview Creates an http server to handle responses for different test cases.
+ * @fileoverview Creates an http server to handle responses for different test
+ * cases.
  */
 const app = require('express')();
 const bodyParser = require('body-parser');

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -700,8 +700,9 @@ export class AmpA4A extends AMP.BaseElement {
           this.handleLifecycleStage_('urlBuilt');
           return adUrl && this.sendXhrRequest(adUrl);
         })
-        // The following block returns either the response (as a {bytes, headers}
-        // object), or null if no response is available / response is empty.
+        // The following block returns either the response (as a
+        // {bytes, headers} object), or null if no response is available /
+        // response is empty.
         /** @return {?Promise<?{bytes: !ArrayBuffer, headers: !Headers}>} */
         .then(fetchResponse => {
           checkStillCurrent();
@@ -1562,8 +1563,8 @@ export class AmpA4A extends AMP.BaseElement {
           // Name will be set for real below in nameframe case.
           break;
         default:
-          // Shouldn't be able to get here, but...  Because of the assert, above,
-          // we can only get here in non-dev mode, so give user feedback.
+          // Shouldn't be able to get here, but...  Because of the assert,
+          // above, we can only get here in non-dev mode, so give user feedback.
           user().error('A4A', 'A4A received unrecognized cross-domain name'
               + ' attribute iframe rendering mode request: %s.  Unable to'
               + ' render a creative for'
@@ -1805,8 +1806,8 @@ export class AmpA4A extends AMP.BaseElement {
   }
 
   /**
-   * Whether preferential render should still be utilized if web crypto is unavailable,
-   * and crypto signature header is present.
+   * Whether preferential render should still be utilized if web crypto is
+   * unavailable, and crypto signature header is present.
    * @return {boolean}
    */
   shouldPreferentialRenderWithoutCrypto() {

--- a/extensions/amp-a4a/0.1/real-time-config-manager.js
+++ b/extensions/amp-a4a/0.1/real-time-config-manager.js
@@ -61,7 +61,8 @@ export const RTC_ERROR_ENUM = {
   UNKNOWN_VENDOR: '9',
   // Occurs when request took longer than timeout
   TIMEOUT: '10',
-  // Occurs when URL expansion time exceeded allowed timeout, request never sent.
+  // Occurs when URL expansion time exceeded allowed timeout, request never
+  // sent.
   MACRO_EXPAND_TIMEOUT: '11',
 };
 

--- a/extensions/amp-a4a/0.1/test/fetch-mock.js
+++ b/extensions/amp-a4a/0.1/test/fetch-mock.js
@@ -37,8 +37,8 @@ export let MockResponseTiming;
 export let MockResponse;
 
 /**
- * A stub for `window.fetch`, facilitating hermetic testing of code that uses it.
- * The window is stubbed when this class's constructor is called.
+ * A stub for `window.fetch`, facilitating hermetic testing of code that uses
+ * it. The window is stubbed when this class's constructor is called.
  */
 export class FetchMock {
 

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -717,7 +717,8 @@ describe('amp-a4a', () => {
           headerVal => {
             it(`should not attach a NameFrame when header is ${headerVal}`,
                 () => {
-                  // Make sure there's no signature, so that we go down the 3p iframe path.
+                  // Make sure there's no signature, so that we go down the 3p
+                  // iframe path.
                   delete adResponse.headers['AMP-Fast-Fetch-Signature'];
                   delete adResponse.headers[AMP_SIGNATURE_HEADER];
                   // If rendering type is anything but nameframe, we SHOULD NOT
@@ -808,8 +809,8 @@ describe('amp-a4a', () => {
           headerVal => {
             it(`should not attach a SafeFrame when header is ${headerVal}`,
                 () => {
-                  // If rendering type is anything but safeframe, we SHOULD NOT attach a
-                  // SafeFrame.
+                  // If rendering type is anything but safeframe, we SHOULD NOT
+                  // attach a SafeFrame.
                   adResponse.headers[RENDERING_TYPE_HEADER] = headerVal;
                   a4a.onLayoutMeasure();
                   return a4a.layoutCallback().then(() => {

--- a/extensions/amp-access-laterpay/0.1/laterpay-impl.js
+++ b/extensions/amp-access-laterpay/0.1/laterpay-impl.js
@@ -211,8 +211,8 @@ export class LaterpayVendor {
           }
           return response.json().catch(() => undefined).then(responseJson => {
             this.purchaseConfig_ = responseJson;
-            // empty before rendering, in case authorization is being called again
-            // with the same state
+            // empty before rendering, in case authorization is being called
+            // again with the same state
             this.emptyContainer_()
                 .then(this.renderPurchaseOverlay_.bind(this));
             return {access: false};

--- a/extensions/amp-access-laterpay/0.2/laterpay-impl.js
+++ b/extensions/amp-access-laterpay/0.2/laterpay-impl.js
@@ -243,8 +243,8 @@ export class LaterpayVendor {
             this.purchaseConfig_ = responseJson;
             this.purchaseOptions_ = this.parseConfigIntoOptions_(
                 responseJson.purchase_options);
-            // empty before rendering, in case authorization is being called again
-            // with the same state
+            // empty before rendering, in case authorization is being called
+            // again with the same state
             this.emptyContainer_()
                 .then(this.renderPurchaseOverlay_.bind(this));
             return {access: false};

--- a/extensions/amp-access/0.1/amp-access-source.js
+++ b/extensions/amp-access/0.1/amp-access-source.js
@@ -50,8 +50,9 @@ export const AccessType = {
 
 
 /**
- * AccessSource represents a single source of authentication information for a page.
- * These sources are constructed, unified and attached to the document by AccessService.
+ * AccessSource represents a single source of authentication information for a
+ * page. These sources are constructed, unified and attached to the document by
+ * AccessService.
  */
 export class AccessSource {
   /**
@@ -420,7 +421,8 @@ export class AccessSource {
   }
 
   /**
-   * Runs the login flow using one of the predefined urls in the amp-access config
+   * Runs the login flow using one of the predefined urls in the amp-access
+   * config
    *
    * @param {string} type Type of login defined in the config
    * @return {!Promise}

--- a/extensions/amp-access/0.1/amp-access.js
+++ b/extensions/amp-access/0.1/amp-access.js
@@ -667,7 +667,8 @@ export class AccessService {
   }
 
   /**
-   * Runs the login flow using one of the predefined urls in the amp-access config
+   * Runs the login flow using one of the predefined urls in the amp-access
+   * config
    *
    * @private
    * @param {string} type Type of login defined in the config

--- a/extensions/amp-accordion/0.1/amp-accordion.js
+++ b/extensions/amp-accordion/0.1/amp-accordion.js
@@ -234,7 +234,8 @@ class AmpAccordion extends AMP.BaseElement {
       if (toExpand) {
         section.setAttribute('expanded', '');
         header.setAttribute('aria-expanded', 'true');
-        // if expand-single-section is set, only allow one <section> to be expanded at a time
+        // if expand-single-section is set, only allow one <section> to be
+        // expanded at a time
         if (this.element.hasAttribute('expand-single-section')) {
           this.sections_.forEach(sectionIter => {
             if (sectionIter != section) {

--- a/extensions/amp-ad-exit/0.1/test/test-amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/test/test-amp-ad-exit.js
@@ -519,7 +519,8 @@ describes.realWin('amp-ad-exit', {
 
     expect(open).to.not.have.been.called;
 
-    // The click is within the left border but left border protection is not set.
+    // The click is within the left border but left border protection is not
+    // set.
     element.implementation_.executeAction({
       method: 'exit',
       args: {target: 'borderProtection'},
@@ -576,7 +577,8 @@ describes.realWin('amp-ad-exit', {
 
     expect(open).to.not.have.been.called;
 
-    // The click is within the left border but left border protection is not set.
+    // The click is within the left border but left border protection is not
+    // set.
     element.implementation_.executeAction({
       method: 'exit',
       args: {target: 'borderProtectionRelativeTo'},

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
@@ -276,8 +276,8 @@ describes.realWin('amp-ad-network-adsense-impl', {
             }
           },
         };
-        // Next two lines are to ensure that internal parts not relevant for this
-        // test are properly set.
+        // Next two lines are to ensure that internal parts not relevant for
+        // this test are properly set.
         impl.size_ = {width: 200, height: 50};
         impl.iframe = impl.win.document.createElement('iframe');
         if (exp) {

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -155,8 +155,7 @@ let LayoutRectOrDimsDef;
 /**
  * Array of functions used to combine block level request parameters for SRA
  * request.
- * @private @const
- * {!Array<!function(!Array<AmpAdNetworkDoubleclickImpl>):?Object<string,string>}
+ * @private @const {!Array<!function(!Array<AmpAdNetworkDoubleclickImpl>):?Object<string,string>>}
  */
 const BLOCK_SRA_COMBINERS_ = [
   instances => {
@@ -446,8 +445,8 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
       // TODO(keithwrightbos,glevitzy) - determine behavior for correlator
       // interaction with refresh.
       const experimentInfoMap =
-          /** @type {!Object<string,
-          !../../../src/experiments.ExperimentInfo>} */ ({});
+        /** @type {!Object<string,
+        !../../../src/experiments.ExperimentInfo>} */ ({});
       experimentInfoMap[CORRELATOR_CLEAR_EXP_NAME] = {
         isTrafficEligible: () => true,
         branches: ['22302764','22302765'],
@@ -459,8 +458,8 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
         // requests.
         addExperimentIdToElement(expId, this.element);
         if (expId === CORRELATOR_CLEAR_EXP_BRANCHES.EXPERIMENT) {
-          // TODO(keithwrightbos) - do not clear if at least one slot on the page
-          // is an AMP creative that survived unlayoutCallback in order to
+          // TODO(keithwrightbos) - do not clear if at least one slot on the
+          // page is an AMP creative that survived unlayoutCallback in order to
           // ensure competitive exclusion/roadblocking.  Note this only applies
           // to non-backfill inventory.
           dev().info(TAG, 'resetting page correlator');
@@ -1134,9 +1133,9 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
               // Only contained invalid elements.
                 return;
               }
-              // Determine if more than one block for this element, if not do not
-              // set sra request promise which results in sending as
-              // non-SRA request (benefit is it allows direct cache method).
+              // Determine if more than one block for this element, if not do
+              // not set sra request promise which results in sending as non-SRA
+              // request (benefit is it allows direct cache method).
               if (typeInstances.length == 1) {
                 dev().info(TAG, `single block in network ${networkId}`);
                 typeInstances[0].sraDeferred.resolve(null);
@@ -1232,8 +1231,9 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
                       // Publisher explicitly wants SRA so do not attempt to
                       // recover as SRA guarantees cannot be enforced.
                       typeInstances.forEach(instance => {
-                        // Reset ad url to ensure layoutCallback does not fallback to
-                        // frame get which would lose SRA guarantees.
+                        // Reset ad url to ensure layoutCallback does not
+                        // fallback to frame get which would lose SRA
+                        // guarantees.
                         instance.resetAdUrl();
                         instance.attemptCollapse();
                         instance.sraDeferred.reject(error);

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
@@ -158,8 +158,8 @@ export class DoubleclickA4aEligibility {
           (getMode(win).localDev || getMode(win).test)) {
         experimentId = MANUAL_EXPERIMENT_ID;
       } else {
-        // For unconditioned canonical holdback, in the control branch
-        // we allow Fast Fetch on non-CDN pages, but in the experiment we do not.
+        // For unconditioned canonical holdback, in the control branch we allow
+        // Fast Fetch on non-CDN pages, but in the experiment we do not.
         if (getExperimentBranch(
             win, UNCONDITIONED_CANONICAL_FF_HOLDBACK_EXP_NAME) !=
             DOUBLECLICK_UNCONDITIONED_EXPERIMENTS.CANONICAL_HLDBK_EXP) {
@@ -192,8 +192,9 @@ export class DoubleclickA4aEligibility {
       forceExperimentBranch(win, DOUBLECLICK_A4A_EXPERIMENT_NAME, experimentId);
     }
 
-    // If we need to rollback the launch, or we are in the launch's holdback experiment,
-    // still use Delayed Fetch if USDRUD or custom remote.html in use
+    // If we need to rollback the launch, or we are in the launch's holdback
+    // experiment, still use Delayed Fetch if USDRUD or custom remote.html in
+    // use
     if (isExperimentOn(win, dfDepRollbackExperiment) ||
         experimentId ==
         DOUBLECLICK_EXPERIMENT_FEATURE.DF_DEP_HOLDBACK_EXPERIMENT) {
@@ -213,7 +214,7 @@ export class DoubleclickA4aEligibility {
    */
   maybeSelectExperiment(win, element, selectionBranches, experimentName) {
     const experimentInfoMap =
-        /** @type {!Object<string, !ExperimentInfo>} */ ({});
+      /** @type {!Object<string, !ExperimentInfo>} */ ({});
     experimentInfoMap[experimentName] = {
       isTrafficEligible: () => true,
       branches: selectionBranches,

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
@@ -66,9 +66,9 @@ const TAG = 'AMP-DOUBLECLICK-SAFEFRAME';
 export const SAFEFRAME_ORIGIN = 'https://tpc.googlesyndication.com';
 
 /**
- * Event listener callback for message events. If message is a Safeframe message,
- * handles the message.
- * This listener is registered within SafeframeHostApi.
+ * Event listener callback for message events. If message is a Safeframe
+ * message, handles the message. This listener is registered within
+ * SafeframeHostApi.
  * @param {!Event} event
  */
 export function safeframeListener(event) {
@@ -102,20 +102,20 @@ export function safeframeListener(event) {
  * Safeframe container APIs to work:
  *   - $sf.ext.expand()
  *   - $sf.ext.collapse()
- *   - $sf.ext.geom()
- * Expand and collapse are both implemented utilizing AMP's built in element
- * resizing.
+ *   - $sf.ext.geom() Expand and collapse are both implemented utilizing AMP's
+ *     built in element resizing.
  *
- * For geom, the host needs to send geometry updates into the container
- *  whenever a position change happens, at a max frequency of 1 message/second.
- *  To implement this messaging, we are leveraging the existing IntersectionObserver
- *  class that works with AMP elements. However, the safeframe iframe that we
- *  need to monitor is not an AMP element, but rather contained within an amp-ad.
- *  So, we are doing intersection observing on the amp-ad, and calculating
- *  the correct position for the iframe whenever we get an update.
+ * For geom, the host needs to send geometry updates into the container whenever
+ *  a position change happens, at a max frequency of 1 message/second. To
+ *  implement this messaging, we are leveraging the existing
+ *  IntersectionObserver class that works with AMP elements. However, the
+ *  safeframe iframe that we need to monitor is not an AMP element, but rather
+ *  contained within an amp-ad. So, we are doing intersection observing on the
+ *  amp-ad, and calculating the correct position for the iframe whenever we get
+ *  an update.
  *
- * We pass an instance of this class into the IntersectionObserver class, which then
- *  calls the instance of send() below whenever an update occurs.
+ * We pass an instance of this class into the IntersectionObserver class, which
+ *  then calls the instance of send() below whenever an update occurs.
  */
 export class SafeframeHostApi {
 

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -544,8 +544,8 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
       impl.buildCallback();
       impl.onLayoutMeasure();
       return impl.getAdUrl().then(url =>
-          // With exp dc-use-attr-for-format off, we can't test for specific
-          // numbers, but we know that the values should be numeric.
+        // With exp dc-use-attr-for-format off, we can't test for specific
+        // numbers, but we know that the values should be numeric.
         expect(url).to.match(/sz=[0-9]+x[0-9]+/));
     });
     it('has correct format when width == "auto"',
@@ -556,7 +556,7 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
           impl.buildCallback();
           impl.onLayoutMeasure();
           return impl.getAdUrl().then(url =>
-              // Ensure that "auto" doesn't appear anywhere here:
+            // Ensure that "auto" doesn't appear anywhere here:
             expect(url).to.match(/sz=[0-9]+x[0-9]+/));
         });
     it('has correct format with height/width override',
@@ -591,7 +591,7 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
           impl.buildCallback();
           impl.onLayoutMeasure();
           return impl.getAdUrl().then(url =>
-              // Ensure that "auto" doesn't appear anywhere here:
+            // Ensure that "auto" doesn't appear anywhere here:
             expect(url).to.match(/sz=[0-9]+x[0-9]+%7C1x2%7C3x4&/));
         });
     it('should have the correct ifi numbers - no refresh', function() {
@@ -1321,10 +1321,10 @@ describes.realWin('additional amp-ad-network-doubleclick-impl',
           expect(style.left).to.equal('50%');
           expect(style.width).to.equal(expectedSize.width);
           expect(style.height).to.equal(expectedSize.height);
-          // We don't know the exact values by which the frame will be translated,
-          // as this can vary depending on whether we use the height/width
-          // attributes, or the actual size of the frame. To make this less of a
-          // hassle, we'll just match against regexp.
+          // We don't know the exact values by which the frame will be
+          // translated, as this can vary depending on whether we use the
+          // height/width attributes, or the actual size of the frame. To make
+          // this less of a hassle, we'll just match against regexp.
           expect(style.transform).to.match(new RegExp(
               'matrix\\(1, 0, 0, 1, -[0-9]+, -[0-9]+\\)'));
         }

--- a/extensions/amp-ad/0.1/amp-ad-custom.js
+++ b/extensions/amp-ad/0.1/amp-ad-custom.js
@@ -112,10 +112,10 @@ export class AmpAdCustom extends AMP.BaseElement {
         Services.templatesFor(this.win)
             .findAndRenderTemplate(this.element, templateData)
             .then(renderedElement => {
-              // Get here when the template has been rendered
-              // Clear out the child template and replace it by the rendered version
-              // Note that we can't clear templates that's not ad's child because
-              // they maybe used by other ad component.
+              // Get here when the template has been rendered Clear out the
+              // child template and replace it by the rendered version Note that
+              // we can't clear templates that's not ad's child because they
+              // maybe used by other ad component.
               removeChildren(this.element);
               this.element.appendChild(renderedElement);
               this.signals().signal(CommonSignals.INI_LOAD);

--- a/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
@@ -120,7 +120,8 @@ export class AmpAdXOriginIframeHandler {
     if (isExperimentOn(this.win_, 'inabox-position-api')) {
       this.inaboxPositionApi_ = new SubscriptionApi(
           this.iframe, MessageType.SEND_POSITIONS, true, () => {
-            // TODO(@zhouyx): Make sendPosition_ only send to message origin iframe
+            // TODO(@zhouyx): Make sendPosition_ only send to message origin
+            // iframe
             this.sendPosition_();
             this.registerPosition_();
           });

--- a/extensions/amp-addthis/0.1/addthis-utils/classify.js
+++ b/extensions/amp-addthis/0.1/addthis-utils/classify.js
@@ -187,7 +187,8 @@ const isSearchUrl = (url = '') => {
 };
 
 /**
- * Classifies the present page based on title, hostname, meta keywords and meta description.
+ * Classifies the present page based on title, hostname, meta keywords and meta
+ * description.
  * @param {*} pageInfo
  * @param {Array} metaElements
  * @returns {number} classification bitmask (currently only setting a porn bit)

--- a/extensions/amp-addthis/0.1/addthis-utils/cuid.js
+++ b/extensions/amp-addthis/0.1/addthis-utils/cuid.js
@@ -18,7 +18,8 @@ const MAX_HEX = 0xffffffff;
 const CUID_SESSION_TIME = Date.now();
 
 /**
- * Get the date from the CUID (first 8 hex digits are the time from epoch in seconds).
+ * Get the date from the CUID (first 8 hex digits are the time from epoch in
+ * seconds).
  * @param {string} cuid
  * @returns {Date}
  */

--- a/extensions/amp-addthis/0.1/addthis-utils/rot13.js
+++ b/extensions/amp-addthis/0.1/addthis-utils/rot13.js
@@ -27,10 +27,12 @@ const rot13 = input => {
   return input.replace(RE_ALPHA, match => {
     const code = match.charCodeAt(0);
 
-    // Get the z character code based on whether the character is upper/lowercase.
+    // Get the z character code based on whether the character is
+    // upper/lowercase.
     const zChar = code <= CHAR_Z_UPPER ? CHAR_Z_UPPER : CHAR_Z_LOWER;
 
-    // Add/subtract 13 to rotate the character so it doesn't exceed the alphabet bounds.
+    // Add/subtract 13 to rotate the character so it doesn't exceed the alphabet
+    // bounds.
     return String.fromCharCode(zChar >= code + 13 ? code + 13 : code - 13);
   });
 };

--- a/extensions/amp-addthis/0.1/amp-addthis.js
+++ b/extensions/amp-addthis/0.1/amp-addthis.js
@@ -16,7 +16,8 @@
 
 /**
  * @fileoverview Embeds an AddThis widget.
- * The data-pub-id and data-widget-id can be found easily in the AddThis dashboard at addthis.com.
+ * The data-pub-id and data-widget-id can be found easily in the AddThis
+ * dashboard at addthis.com.
  * Example:
  * <code>
  * <amp-addthis
@@ -62,16 +63,18 @@ import {parseUrl} from '../../../src/url';
 import {setStyle} from '../../../src/style';
 import {user} from '../../../src/log';
 
-// The following items will be shared by all AmpAddThis elements on a page, to prevent unnecessary
-// HTTP requests, get accurate analytics, etc., and hence are defined outside of the class.
+// The following items will be shared by all AmpAddThis elements on a page, to
+// prevent unnecessary HTTP requests, get accurate analytics, etc., and hence
+// are defined outside of the class.
 const configManager = new ConfigManager();
 const scrollMonitor = new ScrollMonitor();
 const dwellMonitor = new DwellMonitor();
 const clickMonitor = new ClickMonitor();
 const activeToolsMonitor = new ActiveToolsMonitor();
 
-// `shouldRegisterView` is a shared flag that should be true only for the first built element on the
-// page, to prevent registering more than one view per page.
+// `shouldRegisterView` is a shared flag that should be true only for the first
+// built element on the page, to prevent registering more than one view per
+// page.
 let shouldRegisterView = true;
 
 // Redirection to prevent eslint issues.
@@ -165,7 +168,8 @@ class AmpAddThis extends AMP.BaseElement {
             clickMonitor.startForDoc(ampDoc);
           });
 
-      // Only the component that registers the page view listens for x-frame events.
+      // Only the component that registers the page view listens for x-frame
+      // events.
       this.setupListeners_({ampDoc, loc, pubId: this.pubId_});
     }
   }

--- a/extensions/amp-addthis/0.1/config-manager.js
+++ b/extensions/amp-addthis/0.1/config-manager.js
@@ -28,14 +28,16 @@ const RequestStatus = {
 };
 
 /**
- * The ConfigManager manages requests for publishers' dashboard configurations from addthis.com,
- * ensuring that a configuration is requested for a given publisher id at most once, that
- * all relevant amp-addthis iframes are notified when configs are received, etc. The exposed API
- * is specified in the typedef, below; everything else is private. When an AMPElement registers
- * with the ConfigManager, this kicks off a request for the relevant dashboard configuration, if
- * necessary, and eventually delivers that configuration to the AMPElement's iframe. When an
- * AMPElement unregisters, the ConfigManager destroys its references to that AMPElement's iframe and
- * performs other cleanup when necessary (such as removing event listeners and destroying other
+ * The ConfigManager manages requests for publishers' dashboard configurations
+ * from addthis.com, ensuring that a configuration is requested for a given
+ * publisher id at most once, that all relevant amp-addthis iframes are notified
+ * when configs are received, etc. The exposed API is specified in the typedef,
+ * below; everything else is private. When an AMPElement registers with the
+ * ConfigManager, this kicks off a request for the relevant dashboard
+ * configuration, if necessary, and eventually delivers that configuration to
+ * the AMPElement's iframe. When an AMPElement unregisters, the ConfigManager
+ * destroys its references to that AMPElement's iframe and performs other
+ * cleanup when necessary (such as removing event listeners and destroying other
  * element references).
  */
 export class ConfigManager {
@@ -60,8 +62,8 @@ export class ConfigManager {
   }
 
   /**
-   * Store the configuration received for the provided pubId, mark the request for the config as
-   * completed, and broadcast the config to relevant iframes.
+   * Store the configuration received for the provided pubId, mark the request
+   * for the config as completed, and broadcast the config to relevant iframes.
    */
   receiveConfiguration({config, pubId, source}) {
     // Check that the configuration event is coming from an iframe that
@@ -109,16 +111,16 @@ export class ConfigManager {
     iframe.contentWindow./*OK*/postMessage(JSON.stringify(jsonToSend), ORIGIN);
 
     if (configRequestStatus === RequestStatus.NOT_REQUESTED) {
-      // If a config for this pubId has not been requested yet, then this iframe will be the one
-      // responsible for requesting it and sending it back here.
+      // If a config for this pubId has not been requested yet, then this iframe
+      // will be the one responsible for requesting it and sending it back here.
       this.configProviderIframes_.push(iframe);
       pubData.requestStatus = RequestStatus.REQUESTED;
     }
   }
 
   /**
-   * Register relevant data with the configuration manager and prepare request/response cycle
-   * between frames.
+   * Register relevant data with the configuration manager and prepare
+   * request/response cycle between frames.
    * @param {{
    * pubId: string,
    * activeToolsMonitor: Object<string,string>,

--- a/extensions/amp-addthis/0.1/post-message-dispatcher.js
+++ b/extensions/amp-addthis/0.1/post-message-dispatcher.js
@@ -60,7 +60,8 @@ export class PostMessageDispatcher {
   }
 
   /**
-   * Handles messages posted from amp-addthis iframes, ensuring the correct origin, etc.
+   * Handles messages posted from amp-addthis iframes, ensuring the correct
+   * origin, etc.
    */
   handleAddThisMessage(event) {
     if (event.origin !== ORIGIN || !getData(event)) {

--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -495,7 +495,8 @@ export class AmpAnalytics extends AMP.BaseElement {
     }
     const typeConfig = expandConfigRequest(this.predefinedConfig_[type] || {});
     if (this.predefinedConfig_[type]) {
-      // TODO(zhouyx, #7096) Track overwrite percentage. Prevent transport overwriting
+      // TODO(zhouyx, #7096) Track overwrite percentage. Prevent transport
+      // overwriting
       if (inlineConfig['transport'] || this.remoteConfig_['transport']) {
         const TAG = this.getName_();
         this.user().error(TAG, 'Inline or remote config should not ' +
@@ -776,11 +777,13 @@ export class AmpAnalytics extends AMP.BaseElement {
   }
 
   /**
-   * Checks result of 'enabled' spec evaluation. Returns false if spec is provided and value
-   * resolves to a falsey value (empty string, 0, false, null, NaN or undefined).
+   * Checks result of 'enabled' spec evaluation. Returns false if spec is
+   * provided and value resolves to a falsey value (empty string, 0, false,
+   * null, NaN or undefined).
    * @param {string} spec Expression that will be evaluated.
    * @param {!ExpansionOptions} expansionOptions Expansion options.
-   * @return {!Promise<boolean>} False only if spec is provided and value is falsey.
+   * @return {!Promise<boolean>} False only if spec is provided and value is
+   * falsey.
    * @private
    */
   checkSpecEnabled_(spec, expansionOptions) {
@@ -797,7 +800,8 @@ export class AmpAnalytics extends AMP.BaseElement {
   }
 
   /**
-   * Expands spec using provided expansion options and applies url replacement if necessary.
+   * Expands spec using provided expansion options and applies url replacement
+   * if necessary.
    * @param {string} spec Expression that needs to be expanded.
    * @param {!ExpansionOptions} expansionOptions Expansion options.
    * @return {!Promise<string>} expanded spec.

--- a/extensions/amp-analytics/0.1/batching-plugins.js
+++ b/extensions/amp-analytics/0.1/batching-plugins.js
@@ -35,11 +35,11 @@ export const BatchingPluginFunctions = {
 
 
 /**
- * Please add your batch plugin function below in alphabetic order.
- * All batch plugin function should accept input of a string, an array of batchSegment
- * Then return a string.
- * Note: extraUrlParams passed in are not encoded. Please make sure to proper
- * encode segments and make sure the final output url is valid.
+ * Please add your batch plugin function below in alphabetic order. All batch
+ * plugin function should accept input of a string, an array of batchSegment
+ * Then return a string. Note: extraUrlParams passed in are not encoded. Please
+ * make sure to proper encode segments and make sure the final output url is
+ * valid.
  */
 
 // Below is a function prototype for easy copy

--- a/extensions/amp-analytics/0.1/events.js
+++ b/extensions/amp-analytics/0.1/events.js
@@ -239,8 +239,9 @@ export class CustomEventTracker extends EventTracker {
 
     /**
      * Sandbox events get their own buffer, because handler to those events will
-     * be added after parent element's layout. (Time varies, can be later than 10s)
-     * sandbox events buffer will never expire but will cleared when handler is ready.
+     * be added after parent element's layout. (Time varies, can be later than
+     * 10s) sandbox events buffer will never expire but will cleared when
+     * handler is ready.
      * @private {!Object<string, !Array<!AnalyticsEvent>|undefined>|undefined}
      */
     this.sandboxBuffer_ = {};

--- a/extensions/amp-analytics/0.1/instrumentation.js
+++ b/extensions/amp-analytics/0.1/instrumentation.js
@@ -84,7 +84,7 @@ export class InstrumentationService {
     this.scrollHandlerRegistered_ = false;
 
     /** @private {!Observable<
-        !../../../src/service/viewport/viewport-impl.ViewportChangedEventDef>} */
+      !../../../src/service/viewport/viewport-impl.ViewportChangedEventDef>} */
     this.scrollObservable_ = new Observable();
   }
 
@@ -399,9 +399,9 @@ export class AnalyticsGroup {
 
 
 /**
- * It's important to resolve instrumentation asynchronously in elements that depends on
- * it in multi-doc scope. Otherwise an element life-cycle could resolve way before we
- * have the service available.
+ * It's important to resolve instrumentation asynchronously in elements that
+ * depends on it in multi-doc scope. Otherwise an element life-cycle could
+ * resolve way before we have the service available.
  *
  * @param {!Node|!../../../src/service/ampdoc-impl.AmpDoc} nodeOrDoc
  * @return {!Promise<InstrumentationService>}

--- a/extensions/amp-analytics/0.1/requests.js
+++ b/extensions/amp-analytics/0.1/requests.js
@@ -158,7 +158,8 @@ export class RequestHandler {
     const extraUrlParamsPromise = this.expandExtraUrlParams_(
         configParams, triggerParams, expansionOption)
         .then(expandExtraUrlParams => {
-          // Construct the extraUrlParamsString: Remove null param and encode component
+          // Construct the extraUrlParamsString: Remove null param and encode
+          // component
           const expandedExtraUrlParamsStr =
               this.getExtraUrlParamsString_(expandExtraUrlParams);
           return this.urlReplacementService_.expandUrlAsync(

--- a/extensions/amp-animation/0.1/web-animations.js
+++ b/extensions/amp-animation/0.1/web-animations.js
@@ -304,7 +304,8 @@ class Scanner {
       return false;
     }
 
-    // WebAnimationDef: (!WebMultiAnimationDef|!WebSpecAnimationDef|!WebCompAnimationDef|!WebKeyframeAnimationDef)
+    // WebAnimationDef: (!WebMultiAnimationDef|!WebSpecAnimationDef|
+    //                   !WebCompAnimationDef|!WebKeyframeAnimationDef)
     if (spec.animations) {
       this.onMultiAnimation(/** @type {!WebMultiAnimationDef} */ (spec));
     } else if (spec.switch) {

--- a/extensions/amp-apester-media/0.1/utils.js
+++ b/extensions/amp-apester-media/0.1/utils.js
@@ -21,8 +21,8 @@ const rules = [
   'WebView',
   // iOS webview will be the same as safari but missing "Safari"
   '(iPhone|iPod|iPad)(?!.*Safari)',
-  // Android Lollipop and Above: webview will be the same as native but it will contain "wv"
-  // Android KitKat to lollipop webview will put {version}.0.0.0
+  // Android Lollipop and Above: webview will be the same as native but it will
+  // contain "wv" Android KitKat to lollipop webview will put {version}.0.0.0
   'Android.*(wv|\.0\.0\.0)',
   // old chrome android webview agent
   'Linux; U; Android',

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -340,7 +340,8 @@ export class Bind {
   }
 
   /**
-   * Calls setState(s), where s is data.state with the non-overridable keys removed.
+   * Calls setState(s), where s is data.state with the non-overridable keys
+   * removed.
    * @param {*} data
    * @return {!Promise}
    * @private
@@ -384,7 +385,7 @@ export class Bind {
   addMacros_() {
     const elements = this.ampdoc.getBody().querySelectorAll('AMP-BIND-MACRO');
     const macros =
-        /** @type {!Array<!./amp-bind-macro.AmpBindMacroDef>} */ ([]);
+      /** @type {!Array<!./amp-bind-macro.AmpBindMacroDef>} */ ([]);
     iterateCursor(elements, element => {
       const argumentNames = (element.getAttribute('arguments') || '')
           .split(',')

--- a/extensions/amp-brightcove/0.1/amp-brightcove.js
+++ b/extensions/amp-brightcove/0.1/amp-brightcove.js
@@ -103,8 +103,9 @@ class AmpBrightcove extends AMP.BaseElement {
 
   /** @private */
   encodeId_(id) {
-    /* id is either a Brightcove-assigned id, or a customer-generated reference id.
-      reference ids are prefixed 'ref:' and the colon must be preserved unencoded */
+    /* id is either a Brightcove-assigned id, or a customer-generated reference
+      id. reference ids are prefixed 'ref:' and the colon must be preserved
+      unencoded */
     if (id.substring(0,4) === 'ref:') {
       return `ref:${encodeURIComponent(id.substring(4))}`;
     } else {
@@ -138,8 +139,8 @@ class AmpBrightcove extends AMP.BaseElement {
   /**
    * To prevent improperly setup videos (do not include the pauseCallback
    * listener script) from playing after being told to pause, we destroy the
-   * iframe. Once the listener script is updated to inform AMP that it is listening,
-   * we can prevent the unlayout.
+   * iframe. Once the listener script is updated to inform AMP that it is
+   * listening, we can prevent the unlayout.
    *
    * See https://github.com/ampproject/amphtml/issues/2224 for information.
    * @override

--- a/extensions/amp-byside-content/0.1/amp-byside-content.js
+++ b/extensions/amp-byside-content/0.1/amp-byside-content.js
@@ -16,8 +16,8 @@
 
 /**
  * @fileoverview Displays BySide placeholder content.
- * The client settings and placeholder content label should be added as component
- * attributes as seen in the following example:
+ * The client settings and placeholder content label should be added as
+ * component attributes as seen in the following example:
  * <code>
  * <amp-byside-content
  * 	 data-webcare-id="<<<webcare_id>>>"

--- a/extensions/amp-carousel/0.1/test/test-slidescroll.js
+++ b/extensions/amp-carousel/0.1/test/test-slidescroll.js
@@ -1031,7 +1031,8 @@ describes.realWin('SlideScroll', {
           const showSlideSpy = sandbox.spy(impl, 'showSlide_');
           const satisfiesTrust = () => true;
 
-          // Test that showSlide_ due to goToSlide(index=1) is not called before layout.
+          // Test that showSlide_ due to goToSlide(index=1) is not called before
+          // layout.
           let args = {'index': '1'};
           impl.executeAction({method: 'goToSlide', args, satisfiesTrust});
           expect(showSlideSpy).to.not.have.been.called;
@@ -1047,7 +1048,8 @@ describes.realWin('SlideScroll', {
           showSlideSpy.reset();
           impl.unlayoutCallback();
 
-          // Test that showSlide_ due to goToSlide(index=4) is not called before layout.
+          // Test that showSlide_ due to goToSlide(index=4) is not called before
+          // layout.
           args = {'index': '4'};
           impl.executeAction({method: 'goToSlide', args, satisfiesTrust});
           expect(showSlideSpy).to.not.have.been.called;

--- a/extensions/amp-consent/0.1/amp-consent.js
+++ b/extensions/amp-consent/0.1/amp-consent.js
@@ -526,8 +526,8 @@ export class AmpConsent extends AMP.BaseElement {
               return;
             }
             // TODO(@zhouyx):
-            // 1. Race condition on consent state change between
-            // schedule to display and display. Add one more check before display
+            // 1. Race condition on consent state change between schedule to
+            //    display and display. Add one more check before display
             // 2. Should not schedule display with DISMISSED UNKNOWN state
             this.scheduleDisplay_(instanceId);
           }

--- a/extensions/amp-consent/0.1/consent-policy-manager.js
+++ b/extensions/amp-consent/0.1/consent-policy-manager.js
@@ -60,7 +60,8 @@ export class ConsentPolicyManager {
    * Example policy config format:
    * {
    *   "waitFor": {
-   *     "consentABC": [], // Can't support array now. All items will be treated as an empty array
+   *     "consentABC": [], // Can't support array now.
+   *                       // All items will be treated as an empty array
    *     "consentDEF": [],
    *   }
    *   "timeout": {
@@ -325,8 +326,8 @@ export class ConsentPolicyInstance {
     // A single consent instance is unknown
     let isUnknown = false;
 
-    // Decide to traverse item list every time instead of keeping reject/pending counts
-    // Performance should be OK since we expect item list to be small.
+    // Decide to traverse item list every time instead of keeping reject/pending
+    // counts Performance should be OK since we expect item list to be small.
     const items = Object.keys(this.itemToConsentState_);
     for (let i = 0; i < items.length; i++) {
       const consentId = items[i];

--- a/extensions/amp-consent/0.1/consent-state-manager.js
+++ b/extensions/amp-consent/0.1/consent-state-manager.js
@@ -30,9 +30,9 @@ export const CONSENT_ITEM_STATE = {
   REJECTED: 2,
   DISMISSED: 3,
   NOT_REQUIRED: 4,
-  // TODO(@zhouyx): Seperate UI state from consent state. Add consent requirement state
-  // ui_state = {pending, active, complete}
-  // consent_state = {unknown, granted, rejected}
+  // TODO(@zhouyx): Seperate UI state from consent state. Add consent
+  // requirement state ui_state = {pending, active, complete} consent_state =
+  // {unknown, granted, rejected}
 };
 
 export class ConsentStateManager {

--- a/extensions/amp-date-picker/0.1/amp-date-picker.js
+++ b/extensions/amp-date-picker/0.1/amp-date-picker.js
@@ -481,9 +481,9 @@ export class AmpDatePicker extends AMP.BaseElement {
     this.registerAction('clear', () => this.handleClear_());
 
     return this.mutateElement(() => {
-      // NOTE(cvializ): There is no standard date format for just the first letter
-      // of the week-day. So we hack it in with this CSS class and don't apply the
-      // CSS class if there is a week-day-format specified.
+      // NOTE(cvializ): There is no standard date format for just the first
+      // letter of the week-day. So we hack it in with this CSS class and don't
+      // apply the CSS class if there is a week-day-format specified.
       this.element.classList.toggle(
           DEFAULT_WEEK_DAY_FORMAT_CSS,
           this.weekDayFormat_ == DEFAULT_WEEK_DAY_FORMAT);
@@ -1473,9 +1473,10 @@ export class AmpDatePicker extends AMP.BaseElement {
 
     return this.mutateElement(() => {
       if (Picker) {
-        // TODO(cvializ): When rendered with React, the picker expands to fit the number of
-        // weeks for that month. When rendered with Preact, the picker expands 1 behind where it
-        // should for the number of weeks in the month. Fix this.
+        // TODO(cvializ): When rendered with React, the picker expands to fit
+        // the number of weeks for that month. When rendered with Preact, the
+        // picker expands 1 behind where it should for the number of weeks in
+        // the month. Fix this.
         this.reactRender_(
             this.react_.createElement(Picker, Object.assign({}, {
               date: props.date,

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -237,8 +237,9 @@ export class AmpForm {
   }
 
   /**
-   * Returns a promise that will be resolved when all dependencies used inside the form
-   * tag are loaded and built (e.g. amp-selector) or 2 seconds timeout - whichever is first.
+   * Returns a promise that will be resolved when all dependencies used inside
+   * the form tag are loaded and built (e.g. amp-selector) or 2 seconds timeout
+   * - whichever is first.
    * @return {!Promise}
    * @private
    */
@@ -360,12 +361,13 @@ export class AmpForm {
   }
 
   /**
-   * Note on stopImmediatePropagation usage here, it is important to emulate native
-   * browser submit event blocking. Otherwise any other submit listeners would get the
-   * event.
+   * Note on stopImmediatePropagation usage here, it is important to emulate
+   * native browser submit event blocking. Otherwise any other submit listeners
+   * would get the event.
    *
-   * For example, action service shouldn't trigger 'submit' event if form is actually
-   * invalid. stopImmediatePropagation allows us to make sure we don't trigger it.
+   * For example, action service shouldn't trigger 'submit' event if form is
+   * actually invalid. stopImmediatePropagation allows us to make sure we don't
+   * trigger it.
    *
    * This prevents the default submission event in any of following cases:
    *   - The form is still finishing a previous submission.
@@ -857,19 +859,20 @@ function removeValidityStateClasses(form) {
 }
 
 /**
- * Checks user validity which applies .user-valid and .user-invalid AFTER the user
- * interacts with the input by moving away from the input (blur) or by changing its
- * value (input).
+ * Checks user validity which applies .user-valid and .user-invalid AFTER the
+ * user interacts with the input by moving away from the input (blur) or by
+ * changing its value (input).
  *
  * See :user-invalid spec for more details:
  *   https://drafts.csswg.org/selectors-4/#user-pseudos
  *
- * The specs are still not fully specified. The current solution tries to follow a common
- * sense approach for when to apply these classes. As the specs gets clearer, we should
- * strive to match it as much as possible.
+ * The specs are still not fully specified. The current solution tries to follow
+ * a common sense approach for when to apply these classes. As the specs gets
+ * clearer, we should strive to match it as much as possible.
  *
  * @param {!Element} element
- * @param {boolean=} propagate Whether to propagate the user validity to ancestors.
+ * @param {boolean=} propagate Whether to propagate the user validity to
+ * ancestors.
  * @return {boolean} Whether the element is valid or not.
  */
 function checkUserValidity(element, propagate = false) {
@@ -915,8 +918,8 @@ function checkUserValidity(element, propagate = false) {
 
 
 /**
- * Responds to user interaction with an input by checking user validity of the input
- * and possibly its input-related ancestors (e.g. feildset, form).
+ * Responds to user interaction with an input by checking user validity of the
+ * input and possibly its input-related ancestors (e.g. feildset, form).
  * @param {!Element} input
  * @private visible for testing.
  */

--- a/extensions/amp-form/0.1/test/test-amp-form.js
+++ b/extensions/amp-form/0.1/test/test-amp-form.js
@@ -574,7 +574,8 @@ describes.repeated('', {
           // Template should have rendered an error
           expect(findTemplateStub).to.have.been.calledWith(
               errorContainer, {message: 'hello there'});
-          // Check that form has a rendered div with class .submit-error-message.
+          // Check that form has a rendered div with class
+          // .submit-error-message.
           renderedTemplate = form.querySelector('[i-amphtml-rendered]');
           expect(renderedTemplate).to.not.be.null;
         });

--- a/extensions/amp-fx-collection/0.1/providers/amp-fx-presets.js
+++ b/extensions/amp-fx-collection/0.1/providers/amp-fx-presets.js
@@ -142,7 +142,8 @@ export const Presets = {
         return;
       }
 
-      // Early exit if the animation doesn't need to repeat and it is fully opaque.
+      // Early exit if the animation doesn't need to repeat and it is fully
+      // opaque.
       if (!fxElement.hasRepeat() && fxElement.getOffset() >= 1) {
         return;
       }

--- a/extensions/amp-geo/0.1/amp-geo.js
+++ b/extensions/amp-geo/0.1/amp-geo.js
@@ -16,7 +16,8 @@
 
 
 /**
- * @fileoverview Sets location specific CSS, bind variables, and attributes on AMP pages
+ * @fileoverview Sets location specific CSS, bind variables, and attributes on
+ * AMP pages
  * Example:
  * <code>
  * <amp-geo>
@@ -147,7 +148,8 @@ export class AmpGeo extends AMP.BaseElement {
    * @param {Object} config
    */
   matchCountryGroups_(config) {
-    /* ISOCountryGroups are optional but if specified at least one must exist  */
+    /* ISOCountryGroups are optional but if specified at least one must exist
+    */
     /** @private @const {!Object<string, Array<string>>} */
     const ISOCountryGroups = config.ISOCountryGroups;
     const errorPrefix = '<amp-geo> ISOCountryGroups'; // code size

--- a/extensions/amp-ima-video/0.1/amp-ima-video.js
+++ b/extensions/amp-ima-video/0.1/amp-ima-video.js
@@ -332,8 +332,8 @@ class AmpImaVideo extends AMP.BaseElement {
    * @override
    */
   fullscreenEnter() {
-    // TODO(@aghassemi, #10597) Make internal <video> element go fullscreen instead
-    // using postMessages
+    // TODO(@aghassemi, #10597) Make internal <video> element go fullscreen
+    // instead using postMessages
     if (!this.iframe_) {
       return;
     }

--- a/extensions/amp-instagram/0.1/amp-instagram.js
+++ b/extensions/amp-instagram/0.1/amp-instagram.js
@@ -16,28 +16,18 @@
 
 
 /**
- * @fileoverview Embeds an instagram photo.
- * The data-shortcode attribute can be easily copied from a normal instagram
- * URL.
- * Example:
- * <code>
- * <amp-instagram
- *   data-shortcode="fBwFP"
- *   data-captioned
- *   data-default-framing
- *   alt="Fastest page in the west."
- *   width="320"
- *   height="392"
- *   layout="responsive">
- * </amp-instagram>
+ * @fileoverview Embeds an instagram photo. The data-shortcode attribute can be
+ * easily copied from a normal instagram URL. Example: <code> <amp-instagram
+ * data-shortcode="fBwFP" data-captioned data-default-framing alt="Fastest page
+ * in the west." width="320" height="392" layout="responsive"> </amp-instagram>
  * </code>
  *
- * For responsive embedding the width and height can be left unchanged from
- * the example above and should produce the correct aspect ratio. amp-instagram
- * will attempt to resize on load based on the height reported by the embedded
- * frame. If captions are specified (data-captioned) then a resize will be
- * requested every time due to the fact that it's not possible to know the height
- * of the caption in advance.
+ * For responsive embedding the width and height can be left unchanged from the
+ * example above and should produce the correct aspect ratio. amp-instagram will
+ * attempt to resize on load based on the height reported by the embedded frame.
+ * If captions are specified (data-captioned) then a resize will be requested
+ * every time due to the fact that it's not possible to know the height of the
+ * caption in advance.
  *
  * If captions are included it is stringly reccomended that an overflow element
  * is also included.  See description of overflow in amp-iframe.

--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -424,10 +424,10 @@ export class AmpLightboxGallery extends AMP.BaseElement {
       };
 
       this.vsync_.mutatePromise(() => {
-        // The problem with setting innerText is that it not only removes
-        // child nodes from the element, but also permanently destroys all
-        // descendant text nodes. It is okay in this case because the description
-        // text area is a div that does not contain descendant elements.
+        // The problem with setting innerText is that it not only removes child
+        // nodes from the element, but also permanently destroys all descendant
+        // text nodes. It is okay in this case because the description text area
+        // is a div that does not contain descendant elements.
         this.descriptionTextArea_./*OK*/innerText = descText;
 
         // Avoid flickering out if transitioning from a slide with no text
@@ -1349,8 +1349,8 @@ export class AmpLightboxGallery extends AMP.BaseElement {
       thumbnails.forEach(thumbnail => {
         thumbnail.timestampPromise.then(ts => {
           // Many video players (e.g. amp-youtube) that don't support this API
-          // will often return 1. So sometimes we will erroneously show a timestamp
-          // of 1 second instead of no timestamp.
+          // will often return 1. So sometimes we will erroneously show a
+          // timestamp of 1 second instead of no timestamp.
           if (!ts || isNaN(ts)) {
             return;
           }
@@ -1470,8 +1470,8 @@ export class AmpLightboxGallery extends AMP.BaseElement {
       timestampDiv.appendChild(playButtonSpan);
       thumbnailObj.timestampPromise.then(ts => {
         // Many video players (e.g. amp-youtube) that don't support this API
-        // will often return 1. This will sometimes result in erroneous values of
-        // 1 second for video players that don't support getDuration.
+        // will often return 1. This will sometimes result in erroneous values
+        // of 1 second for video players that don't support getDuration.
         if (!ts || isNaN(ts)) {
           return;
         }
@@ -1496,7 +1496,8 @@ export class AmpLightboxGallery extends AMP.BaseElement {
 export function installLightboxManager(win) {
   if (isExperimentOn(win, TAG)) {
     // TODO (#12859): This only works for singleDoc mode. We will move
-    // installation of LightboxManager to core after the experiment, okay for now.
+    // installation of LightboxManager to core after the experiment, okay for
+    // now.
     const ampdoc = Services.ampdocServiceFor(win).getAmpDoc();
     manager_ = new LightboxManager(ampdoc);
   }

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -148,7 +148,8 @@ export class AmpList extends AMP.BaseElement {
   }
 
   /**
-   * amp-list reuses the loading indicator when the list is fetched again via bind mutation or refresh action
+   * amp-list reuses the loading indicator when the list is fetched again via
+   * bind mutation or refresh action
    * @override
    */
   isLoadingReused() {

--- a/extensions/amp-next-page/0.1/next-page-service.js
+++ b/extensions/amp-next-page/0.1/next-page-service.js
@@ -273,7 +273,7 @@ export class NextPageService {
    * one.
    * @param {number} nextPage Index of the next unseen page to use as the first
    *     recommendation in the list.
-   * @return {Element} Container element for the recommendations.
+   * @return {!Element} Container element for the recommendations.
    */
   createArticleLinks_(nextPage) {
     const doc = this.win_.document;
@@ -355,12 +355,12 @@ export class NextPageService {
    * the position of a page separator in the viewport.
    * @param {number} i Index of the documentRef this recommendation unit is
    *     attached to.
-   * @param {!../../../src/service/position-observer/position-observer-worker.PositionInViewportEntryDef}
+   * @param {?../../../src/service/position-observer/position-observer-worker.PositionInViewportEntryDef}
    *     position Position of the current recommendation unit in the viewport.
    */
   positionUpdate_(i, position) {
     // We're only interested when the recommendations exit the viewport
-    if (position.positionRect !== null) {
+    if (!position || position.positionRect !== null) {
       return;
     }
 
@@ -386,7 +386,9 @@ export class NextPageService {
    */
   articleLinksPositionUpdate_(documentRef) {
     documentRef.cancelled = true;
-    this.positionObserver_.unobserve(documentRef.recUnit);
+    if (documentRef.recUnit) {
+      this.positionObserver_.unobserve(documentRef.recUnit);
+    }
   }
 
   /**

--- a/extensions/amp-next-page/0.1/next-page-service.js
+++ b/extensions/amp-next-page/0.1/next-page-service.js
@@ -88,10 +88,7 @@ export class NextPageService {
     /** @private {?../../../src/service/viewport/viewport-impl.Viewport} */
     this.viewport_ = null;
 
-    /**
-     * @private
-     * {?../../../../src/service/position-observer/position-observer-impl.PositionObserver}
-     */
+    /** @private {?../../../src/service/position-observer/position-observer-impl.PositionObserver} */
     this.positionObserver_ = null;
 
     /** @private @const {!Array<!DocumentRef>} */
@@ -358,8 +355,7 @@ export class NextPageService {
    * the position of a page separator in the viewport.
    * @param {number} i Index of the documentRef this recommendation unit is
    *     attached to.
-   * @param
-   * {!../../../src/service/position-observer/position-observer-worker.PositionInViewportEntryDef}
+   * @param {!../../../src/service/position-observer/position-observer-worker.PositionInViewportEntryDef}
    *     position Position of the current recommendation unit in the viewport.
    */
   positionUpdate_(i, position) {

--- a/extensions/amp-position-observer/0.1/amp-position-observer.js
+++ b/extensions/amp-position-observer/0.1/amp-position-observer.js
@@ -269,8 +269,8 @@ export class AmpVisibilityObserver extends AMP.BaseElement {
    * @private
    */
   parseAttributes_() {
-    // Ratio is either "<top-bottom:{0,1}>" or "<top:{0,1}> <bottom:{0,1}>"
-    // e.g, "0.5 1": use 50% visibility at top and 100% at the bottom of viewport.
+    // Ratio is either "<top-bottom:{0,1}>" or "<top:{0,1}> <bottom:{0,1}>" e.g,
+    // "0.5 1": use 50% visibility at top and 100% at the bottom of viewport.
     const ratios = this.element.getAttribute('intersection-ratios');
     if (ratios) {
       const topBottom = ratios.trim().split(' ');
@@ -281,8 +281,9 @@ export class AmpVisibilityObserver extends AMP.BaseElement {
       }
     }
 
-    // Margin is either "<top-bottom:{px,vh}>" or "<top:{px,vh}> <bottom:{px,vh}>"
-    // e.g, "100px 10vh": exclude 100px from top and 10vh from bottom of viewport.
+    // Margin is either "<top-bottom:{px,vh}>" or "<top:{px,vh}>
+    // <bottom:{px,vh}>" e.g, "100px 10vh": exclude 100px from top and 10vh from
+    // bottom of viewport.
     const margins = this.element.getAttribute('viewport-margins');
     if (margins) {
       const topBottom = margins.trim().split(' ');

--- a/extensions/amp-sidebar/0.1/test/test-amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/test/test-amp-sidebar.js
@@ -143,15 +143,15 @@ describes.realWin('amp-sidebar 0.1 version', {
       });
     });
 
-    it('should replace text to screen reader \
-    button in data-close-button-aria-label', () => {
-          return getAmpSidebar({'closeText':
-        'data-close-button-aria-label'}).then(sidebarElement => {
+    it('should replace text to screen reader ' +
+        'button in data-close-button-aria-label', () => {
+      return getAmpSidebar({'closeText': 'data-close-button-aria-label'})
+          .then(sidebarElement => {
             const closeButton = sidebarElement.lastElementChild;
             expect(closeButton.textContent)
                 .to.equal('data-close-button-aria-label');
           });
-        });
+    });
 
     it('should open from left is side is not specified', () => {
       return getAmpSidebar().then(sidebarElement => {
@@ -175,21 +175,21 @@ describes.realWin('amp-sidebar 0.1 version', {
           });
     });
 
-    it('should create an invisible close \
-    button for screen readers only', () => {
-          return getAmpSidebar().then(sidebarElement => {
-            const impl = sidebarElement.implementation_;
-            impl.close_ = sandbox.spy();
-            const closeButton = sidebarElement.lastElementChild;
-            expect(closeButton).to.exist;
-            expect(closeButton.tagName).to.equal('BUTTON');
-            assertScreenReaderElement(closeButton);
-            expect(closeButton.textContent).to.equal('Close the sidebar');
-            expect(impl.close_).to.have.not.been.called;
-            closeButton.click();
-            expect(impl.close_).to.be.calledOnce;
-          });
-        });
+    it('should create an invisible close ' +
+        'button for screen readers only', () => {
+      return getAmpSidebar().then(sidebarElement => {
+        const impl = sidebarElement.implementation_;
+        impl.close_ = sandbox.spy();
+        const closeButton = sidebarElement.lastElementChild;
+        expect(closeButton).to.exist;
+        expect(closeButton.tagName).to.equal('BUTTON');
+        assertScreenReaderElement(closeButton);
+        expect(closeButton.textContent).to.equal('Close the sidebar');
+        expect(impl.close_).to.have.not.been.called;
+        closeButton.click();
+        expect(impl.close_).to.be.calledOnce;
+      });
+    });
 
     it('should open sidebar on button click', () => {
       return getAmpSidebar().then(sidebarElement => {
@@ -229,7 +229,8 @@ describes.realWin('amp-sidebar 0.1 version', {
         expect(sidebarElement.style.display).to.equal('');
         expect(impl.scheduleLayout).to.be.calledOnce;
 
-        // second call to open_() should be a no-op and not increase call counts.
+        // second call to open_() should be a no-op and not increase call
+        // counts.
         impl.open_();
         expect(impl.scheduleLayout).to.be.calledOnce;
         expect(historyPushSpy).to.be.calledOnce;
@@ -272,7 +273,8 @@ describes.realWin('amp-sidebar 0.1 version', {
             expect(historyPopSpy).to.be.calledOnce;
             expect(impl.historyId_).to.equal(-1);
 
-            // second call to close_() should be a no-op and not increase call counts.
+            // second call to close_() should be a no-op and not increase call
+            // counts.
             impl.close_();
             expect(impl.schedulePause).to.be.calledOnce;
             expect(historyPopSpy).to.be.calledOnce;
@@ -439,46 +441,46 @@ describes.realWin('amp-sidebar 0.1 version', {
       });
     });
 
-    it('should not close sidebar if \
-       clicked on a new origin navigation', () => {
-          return getAmpSidebar({stubHistory: true}).then(sidebarElement => {
-            const anchor = sidebarElement.getElementsByTagName('a')[0];
-            anchor.href = '#newloc';
-            const impl = sidebarElement.implementation_;
-            impl.schedulePause = sandbox.spy();
-            sandbox.stub(timer, 'delay').callsFake(function(callback) {
-              callback();
-            });
-            expect(sidebarElement.hasAttribute('open')).to.be.false;
-            impl.open_();
-            expect(sidebarElement.hasAttribute('open')).to.be.true;
-            expect(sidebarElement.getAttribute('aria-hidden')).to.equal(
-                'false');
-            const eventObj = doc.createEventObject ?
-              doc.createEventObject() : doc.createEvent('Events');
-            if (eventObj.initEvent) {
-              eventObj.initEvent('click', true, true);
-            }
-            sandbox.stub(sidebarElement, 'getAmpDoc').callsFake(() => {
-              return {
-                win: {
-                  location: {
-                    // Mocking navigating from example.com -> localhost:9876
-                    href: 'http://example.com',
-                  },
-                },
-              };
-            });
-            anchor.dispatchEvent ?
-              anchor.dispatchEvent(eventObj) :
-              anchor.fireEvent('onkeydown', eventObj);
-            expect(sidebarElement.hasAttribute('open')).to.be.true;
-            expect(sidebarElement.getAttribute('aria-hidden')).to.equal(
-                'false');
-            expect(sidebarElement.style.display).to.equal('');
-            expect(impl.schedulePause).to.have.not.been.called;
-          });
+    it('should not close sidebar if clicked on a new origin ' +
+        'navigation', () => {
+      return getAmpSidebar({stubHistory: true}).then(sidebarElement => {
+        const anchor = sidebarElement.getElementsByTagName('a')[0];
+        anchor.href = '#newloc';
+        const impl = sidebarElement.implementation_;
+        impl.schedulePause = sandbox.spy();
+        sandbox.stub(timer, 'delay').callsFake(function(callback) {
+          callback();
         });
+        expect(sidebarElement.hasAttribute('open')).to.be.false;
+        impl.open_();
+        expect(sidebarElement.hasAttribute('open')).to.be.true;
+        expect(sidebarElement.getAttribute('aria-hidden')).to.equal(
+            'false');
+        const eventObj = doc.createEventObject ?
+          doc.createEventObject() : doc.createEvent('Events');
+        if (eventObj.initEvent) {
+          eventObj.initEvent('click', true, true);
+        }
+        sandbox.stub(sidebarElement, 'getAmpDoc').callsFake(() => {
+          return {
+            win: {
+              location: {
+                // Mocking navigating from example.com -> localhost:9876
+                href: 'http://example.com',
+              },
+            },
+          };
+        });
+        anchor.dispatchEvent ?
+          anchor.dispatchEvent(eventObj) :
+          anchor.fireEvent('onkeydown', eventObj);
+        expect(sidebarElement.hasAttribute('open')).to.be.true;
+        expect(sidebarElement.getAttribute('aria-hidden')).to.equal(
+            'false');
+        expect(sidebarElement.style.display).to.equal('');
+        expect(impl.schedulePause).to.have.not.been.called;
+      });
+    });
 
     it('should not close sidebar if clicked on new page navigation', () => {
       return getAmpSidebar({stubHistory: true}).then(sidebarElement => {
@@ -589,18 +591,18 @@ describes.realWin('amp-sidebar 0.1 version', {
       });
     });
 
-    it('should create multiple toolbar elements, \
-     within their respective containers', () => {
-          return getAmpSidebar({
-            toolbars: [{},
-              {
-                media: '(min-width: 1024px)',
-              },
-            ],
-          }).then(sidebarElement => {
-            expect(sidebarElement.implementation_.toolbars_.length)
-                .to.be.equal(2);
-          });
-        });
+    it('should create multiple toolbar elements, ' +
+        'within their respective containers', () => {
+      return getAmpSidebar({
+        toolbars: [{},
+          {
+            media: '(min-width: 1024px)',
+          },
+        ],
+      }).then(sidebarElement => {
+        expect(sidebarElement.implementation_.toolbars_.length)
+            .to.be.equal(2);
+      });
+    });
   });
 });

--- a/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
+++ b/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
@@ -140,8 +140,7 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
     /**
      * Version of the story store service depends on which version of amp-story
      * the publisher is loading. They all have the same implementation.
-     * @private {?../../amp-story/0.1/amp-story-store-service.AmpStoryStoreService|
-     *           ?../../amp-story/1.0/amp-story-store-service.AmpStoryStoreService}
+     * @private {?../../amp-story/0.1/amp-story-store-service.AmpStoryStoreService|?../../amp-story/1.0/amp-story-store-service.AmpStoryStoreService}
      */
     this.storeService_ = null;
   }

--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -920,7 +920,8 @@ export class AmpStory extends AMP.BaseElement {
       return;
     }
     if (this.isDesktop_()) {
-      // Force repaint is only needed when transitioning from invisible to visible
+      // Force repaint is only needed when transitioning from invisible to
+      // visible
       return;
     }
 
@@ -1260,7 +1261,8 @@ export class AmpStory extends AMP.BaseElement {
         return;
       }
 
-      // TODO(newmuis): Remove the assignment and return, as they're unnecessary.
+      // TODO(newmuis): Remove the assignment and return, as they're
+      // unnecessary.
       map = this.getPageDistanceMapHelper_(distance + 1, map, adjacentPageId);
     });
 
@@ -1577,7 +1579,8 @@ export class AmpStory extends AMP.BaseElement {
    * @return {boolean} was page inserted
    */
   insertPage(pageBeforeId, pageToBeInsertedId) {
-    // TODO(ccordry): make sure this method moves to PageManager when implemented
+    // TODO(ccordry): make sure this method moves to PageManager when
+    // implemented
     const pageToBeInserted = this.getPageById(pageToBeInsertedId);
     const pageToBeInsertedEl = pageToBeInserted.element;
 

--- a/extensions/amp-story/0.1/animation-presets-utils.js
+++ b/extensions/amp-story/0.1/animation-presets-utils.js
@@ -94,7 +94,8 @@ export function targetFitsWithinPage(dimensions) {
 }
 
 /**
- * Calculate target scaling factor so that it is at least 25% larger than the page.
+ * Calculate target scaling factor so that it is at least 25% larger than the
+ * page.
  * @param {StoryAnimationDimsDef} dimensions Dimensions of page and target.
  * @return {number}
  */

--- a/extensions/amp-story/0.1/background.js
+++ b/extensions/amp-story/0.1/background.js
@@ -136,7 +136,8 @@ export class AmpStoryBackground {
   }
 
   /**
-   * Rotates the classes on page background to bring the new bacground in foreground.
+   * Rotates the classes on page background to bring the new bacground in
+   * foreground.
    * @private
    */
   rotateActiveBackground_() {

--- a/extensions/amp-story/0.1/page-advancement.js
+++ b/extensions/amp-story/0.1/page-advancement.js
@@ -303,7 +303,8 @@ class ManualAdvancement extends AdvancementConfig {
   }
 
   /**
-   * We want clicks on certain elements to be exempted from normal page navigation
+   * We want clicks on certain elements to be exempted from normal page
+   * navigation
    * @param {!Event} event
    * @return {boolean}
    */

--- a/extensions/amp-story/0.1/test/test-amp-story.js
+++ b/extensions/amp-story/0.1/test/test-amp-story.js
@@ -74,7 +74,8 @@ describes.realWin('amp-story', {
     story = new AmpStory(element);
     // TODO(alanorozco): Test active page event triggers once the stubbable
     // `Services` module is part of the amphtml-story repo.
-    // sandbox.stub(element.implementation_, 'triggerActiveEventForPage_').callsFake(NOOP);
+    // sandbox.stub(element.implementation_,
+    // 'triggerActiveEventForPage_').callsFake(NOOP);
   });
 
   afterEach(() => {

--- a/extensions/amp-story/1.0/amp-story-share.js
+++ b/extensions/amp-story/1.0/amp-story-share.js
@@ -322,8 +322,8 @@ export class ShareWidget {
   }
 
   /**
-   * TODO(#14591): Remove when bookend API v0.1 is deprecated.
-   * If using the bookend API v1.0, converts the contents to match with the bookend API v0.1.
+   * TODO(#14591): Remove when bookend API v0.1 is deprecated. If using the
+   * bookend API v1.0, converts the contents to match with the bookend API v0.1.
    * @param {!Array<!Object|string>} providers
    * @return {!Object<string, (!JsonObject|boolean)>}
    */
@@ -351,7 +351,8 @@ export class ShareWidget {
    */
   // TODO(alanorozco): Set story metadata in share config
   setProviders_(providers) {
-    // TODO(#14591): Check if using bookend API v1.0 and convert it to be v0.1 compatible if so.
+    // TODO(#14591): Check if using bookend API v1.0 and convert it to be v0.1
+    // compatible if so.
     if (providers && isArray(providers)) {
       providers = this.parseToClassicApi_(
           /** @type !Array<!Object|string> */ (providers));

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -917,7 +917,8 @@ export class AmpStory extends AMP.BaseElement {
       return;
     }
     if (this.isDesktop_()) {
-      // Force repaint is only needed when transitioning from invisible to visible
+      // Force repaint is only needed when transitioning from invisible to
+      // visible
       return;
     }
 
@@ -1254,7 +1255,8 @@ export class AmpStory extends AMP.BaseElement {
         return;
       }
 
-      // TODO(newmuis): Remove the assignment and return, as they're unnecessary.
+      // TODO(newmuis): Remove the assignment and return, as they're
+      // unnecessary.
       map = this.getPageDistanceMapHelper_(distance + 1, map, adjacentPageId);
     });
 
@@ -1593,7 +1595,8 @@ export class AmpStory extends AMP.BaseElement {
    * @return {boolean} was page inserted
    */
   insertPage(pageBeforeId, pageToBeInsertedId) {
-    // TODO(ccordry): make sure this method moves to PageManager when implemented
+    // TODO(ccordry): make sure this method moves to PageManager when
+    // implemented
     const pageToBeInserted = this.getPageById(pageToBeInsertedId);
     const pageToBeInsertedEl = pageToBeInserted.element;
 

--- a/extensions/amp-story/1.0/animation-presets-utils.js
+++ b/extensions/amp-story/1.0/animation-presets-utils.js
@@ -94,7 +94,8 @@ export function targetFitsWithinPage(dimensions) {
 }
 
 /**
- * Calculate target scaling factor so that it is at least 25% larger than the page.
+ * Calculate target scaling factor so that it is at least 25% larger than the
+ * page.
  * @param {StoryAnimationDimsDef} dimensions Dimensions of page and target.
  * @return {number}
  */

--- a/extensions/amp-story/1.0/background.js
+++ b/extensions/amp-story/1.0/background.js
@@ -136,7 +136,8 @@ export class AmpStoryBackground {
   }
 
   /**
-   * Rotates the classes on page background to bring the new bacground in foreground.
+   * Rotates the classes on page background to bring the new bacground in
+   * foreground.
    * @private
    */
   rotateActiveBackground_() {

--- a/extensions/amp-story/1.0/page-advancement.js
+++ b/extensions/amp-story/1.0/page-advancement.js
@@ -296,7 +296,8 @@ class ManualAdvancement extends AdvancementConfig {
   }
 
   /**
-   * We want clicks on certain elements to be exempted from normal page navigation
+   * We want clicks on certain elements to be exempted from normal page
+   * navigation
    * @param {!Event} event
    * @return {boolean}
    */

--- a/extensions/amp-story/1.0/test/test-amp-story.js
+++ b/extensions/amp-story/1.0/test/test-amp-story.js
@@ -73,7 +73,8 @@ describes.realWin('amp-story', {
     story = new AmpStory(element);
     // TODO(alanorozco): Test active page event triggers once the stubbable
     // `Services` module is part of the amphtml-story repo.
-    // sandbox.stub(element.implementation_, 'triggerActiveEventForPage_').callsFake(NOOP);
+    // sandbox.stub(element.implementation_,
+    // 'triggerActiveEventForPage_').callsFake(NOOP);
   });
 
   afterEach(() => {

--- a/extensions/amp-subscriptions/0.1/amp-subscriptions.js
+++ b/extensions/amp-subscriptions/0.1/amp-subscriptions.js
@@ -149,10 +149,12 @@ export class SubscriptionService {
   }
 
   /**
-   * This method registers an auto initialized subcription platform with this service.
+   * This method registers an auto initialized subcription platform with this
+   * service.
    *
    * @param {string} serviceId
-   * @param {function(!JsonObject, !ServiceAdapter):!SubscriptionPlatform} subscriptionPlatformFactory
+   * @param {function(!JsonObject, !ServiceAdapter):!SubscriptionPlatform}
+   * subscriptionPlatformFactory
    */
   registerPlatform(serviceId, subscriptionPlatformFactory) {
     return this.initialize_().then(() => {
@@ -251,8 +253,8 @@ export class SubscriptionService {
         this.startAuthorizationFlow_(false);
         return;
       } else if (this.platformConfig_['alwaysGrant']) {
-        // If service config has `alwaysGrant` key as true,
-        // publisher wants it to be open always until a sviewer decides otherwise.
+        // If service config has `alwaysGrant` key as true, publisher wants it
+        // to be open always until a sviewer decides otherwise.
         this.processGrantState_(true);
         return;
       }

--- a/extensions/amp-subscriptions/0.1/local-subscription-platform-renderer.js
+++ b/extensions/amp-subscriptions/0.1/local-subscription-platform-renderer.js
@@ -116,7 +116,8 @@ export class LocalSubscriptionPlatformRenderer {
    */
   renderActionsInNode_(renderState, rootNode) {
     return this.ampdoc_.whenReady().then(() => {
-      // Find the matching actions and sections and make them visible if evalutes to true.
+      // Find the matching actions and sections and make them visible if
+      // evalutes to true.
       const querySelectors =
           '[subscriptions-action], [subscriptions-section="actions"],'
               + ' [subscriptions-actions]';

--- a/extensions/amp-subscriptions/0.1/platform-store.js
+++ b/extensions/amp-subscriptions/0.1/platform-store.js
@@ -142,7 +142,8 @@ export class PlatformStore {
   }
 
   /**
-   * This registers a callback which is called whenever a service id is resolved with an entitlement.
+   * This registers a callback which is called whenever a service id is resolved
+   * with an entitlement.
    * @param {function(!EntitlementChangeEventDef):void} callback
    */
   onChange(callback) {
@@ -316,7 +317,8 @@ export class PlatformStore {
   selectPlatform() {
 
     return this.getAllPlatformsEntitlements_().then(() => {
-      // TODO(@prateekbh): explain why sometimes a quick resolve is possible vs waiting for all entitlement.
+      // TODO(@prateekbh): explain why sometimes a quick resolve is possible vs
+      // waiting for all entitlement.
       return this.selectApplicablePlatform_();
     });
   }
@@ -332,14 +334,14 @@ export class PlatformStore {
   }
 
   /**
-   * Returns most qualified platform.
-   * Qualification of a platform is based on an integer weight.
-   * Every platform starts with weight 0 and evaluated against the following parameters,
+   * Returns most qualified platform. Qualification of a platform is based on an
+   * integer weight. Every platform starts with weight 0 and evaluated against
+   * the following parameters,
    * - user is subscribed with platform (Gives weight 10)
    * - supports the current viewer (Gives weight 9)
    *
-   * In the end candidate with max weight is selected.
-   * However if candidate's weight is equal to local platform, then local platform is selected.
+   * In the end candidate with max weight is selected. However if candidate's
+   * weight is equal to local platform, then local platform is selected.
    * @returns {!./subscription-platform.SubscriptionPlatform}
    * @private
    */

--- a/extensions/amp-subscriptions/0.1/subscription-platform.js
+++ b/extensions/amp-subscriptions/0.1/subscription-platform.js
@@ -37,7 +37,8 @@ export class SubscriptionPlatform {
   getEntitlements() {}
 
   /**
-   * Activates the subscription platform and hands over the control for rendering.
+   * Activates the subscription platform and hands over the control for
+   * rendering.
    * @param {!./entitlement.Entitlement} unusedEntitlement
    */
   activate(unusedEntitlement) {}

--- a/extensions/amp-subscriptions/0.1/test/test-viewer-platform.js
+++ b/extensions/amp-subscriptions/0.1/test/test-viewer-platform.js
@@ -132,7 +132,8 @@ describes.fakeWin('ViewerSubscriptionPlatform', {amp: true}, env => {
                   !== -1);
             expect(resolvedEntitlement.grantReason).to.be
                 .equal(GrantReason.SUBSCRIBER);
-            // raw should be the data which was resolved via sendMessageAwaitResponse.
+            // raw should be the data which was resolved via
+            // sendMessageAwaitResponse.
             expect(resolvedEntitlement.raw).to
                 .equal('faketoken');
           });
@@ -155,7 +156,8 @@ describes.fakeWin('ViewerSubscriptionPlatform', {amp: true}, env => {
             expect(resolvedEntitlement.granted).to.be.equal(true);
             expect(resolvedEntitlement.grantReason).to.be
                 .equal(GrantReason.METERING);
-            // raw should be the data which was resolved via sendMessageAwaitResponse.
+            // raw should be the data which was resolved via
+            // sendMessageAwaitResponse.
             expect(resolvedEntitlement.data).to.deep.equal({
               left: 3,
             });

--- a/extensions/amp-web-push/0.1/web-push-service.js
+++ b/extensions/amp-web-push/0.1/web-push-service.js
@@ -547,8 +547,8 @@ export class WebPushService {
           } else {
           /*
             The site is running our initial AMP web push release and the helper
-            frame does not support retrieving the remote storage value. Assume the
-            permission is default to provide the best user experience.
+            frame does not support retrieving the remote storage value. Assume
+            the permission is default to provide the best user experience.
           */
             return Promise.resolve(NotificationPermission.DEFAULT);
           }
@@ -557,8 +557,8 @@ export class WebPushService {
           /*
             If the canonical notification permission is:
               - Blocked
-                - If the publisher has defined a blocked widget section, show it,
-                  otherwise show the unsubscribed widget.
+                - If the publisher has defined a blocked widget section, show
+                  it, otherwise show the unsubscribed widget.
               - Default or Granted
                 - Resume flow
           */

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -278,10 +278,10 @@ function declareExtension(name, version, options) {
 }
 
 /**
- * This function is used for declaring deprecated extensions. It simply places the current
- * version code in place of the latest versions.
- * This has the ability to break an extension verison, so please be sure that this is
- * the correct one to use.
+ * This function is used for declaring deprecated extensions. It simply places
+ * the current version code in place of the latest versions. This has the
+ * ability to break an extension verison, so please be sure that this is the
+ * correct one to use.
  * @param {string} name
  * @param {string} version E.g. 0.1
  * @param {string} latestVersion

--- a/src/animation.js
+++ b/src/animation.js
@@ -39,8 +39,8 @@ export class Animation {
    * @param {!Node} contextNode The context node.
    * @param {!TransitionDef<?>} transition Transition to animate.
    * @param {./time.timeDef} duration Duration in milliseconds.
-   * @param {(!./curve.CurveDef|string)=} opt_curve Optional curve to use for animation.
-   *   Default is the linear animation.
+   * @param {(!./curve.CurveDef|string)=} opt_curve Optional curve to use for
+   *   animation. Default is the linear animation.
    * @return {!AnimationPlayer}
    */
   static animate(contextNode, transition, duration, opt_curve) {
@@ -85,9 +85,9 @@ export class Animation {
   }
 
   /**
-   * Adds a segment to the animation. Each segment starts at offset (delay)
-   * and runs for a portion of the overall animation (duration). Note that
-   * both delay and duration and normtimeDef types which accept values from 0 to 1.
+   * Adds a segment to the animation. Each segment starts at offset (delay) and
+   * runs for a portion of the overall animation (duration). Note that both
+   * delay and duration and normtimeDef types which accept values from 0 to 1.
    * Optionally, the time is pushed through a curve. If curve is not specified,
    * the default animation curve will be used. The specified transition is
    * animated over the specified duration from 0 to 1.

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -119,7 +119,7 @@ export class BaseElement {
     /** @public @const {!Element} */
     this.element = element;
     /*
-    \   \  /  \  /   / /   \     |   _  \     |  \ |  | |  | |  \ |  |  /  _____|
+    \   \  /  \  /   / /   \     |   _  \     |  \ |  | |  | |  \ |  |  /  ____|
      \   \/    \/   / /  ^  \    |  |_)  |    |   \|  | |  | |   \|  | |  |  __
       \            / /  /_\  \   |      /     |  . `  | |  | |  . `  | |  | |_ |
        \    /\    / /  _____  \  |  |\  \----.|  |\   | |  | |  |\   | |  |__| |
@@ -729,7 +729,8 @@ export class BaseElement {
   }
 
   /**
-   * Returns whether the loading indicator is reused again after the first render.
+   * Returns whether the loading indicator is reused again after the first
+   * render.
    * @return {boolean}
    * @public
    */

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -600,11 +600,12 @@ function createBaseCustomElementClass(win) {
     /**
      * If the element has a media attribute, evaluates the value as a media
      * query and based on the result adds or removes the class
-     * `i-amphtml-hidden-by-media-query`. The class adds display:none to the element
-     * which in turn prevents any of the resource loading to happen for the
-     * element.
+     * `i-amphtml-hidden-by-media-query`. The class adds display:none to the
+     * element which in turn prevents any of the resource loading to happen for
+     * the element.
      *
-     * This method is called by Resources and shouldn't be called by anyone else.
+     * This method is called by Resources and shouldn't be called by anyone
+     * else.
      *
      * @final
      * @package @this {!Element}
@@ -650,8 +651,8 @@ function createBaseCustomElementClass(win) {
     /**
      * Changes the size of the element.
      *
-     * This method is called by Resources and shouldn't be called by anyone else.
-     * This method must always be called in the mutation context.
+     * This method is called by Resources and shouldn't be called by anyone
+     * else. This method must always be called in the mutation context.
      *
      * @param {number|undefined} newHeight
      * @param {number|undefined} newWidth
@@ -1165,9 +1166,10 @@ function createBaseCustomElementClass(win) {
     }
 
     /**
-     * Requests the resource to resume its activity when the document returns from
-     * an inactive state. The scope is up to the actual component. Among other
-     * things the active playback of video or audio content may be resumed.
+     * Requests the resource to resume its activity when the document returns
+     * from an inactive state. The scope is up to the actual component. Among
+     * other things the active playback of video or audio content may be
+     * resumed.
      *
      * @package @final @this {!Element}
      */
@@ -1339,9 +1341,9 @@ function createBaseCustomElementClass(win) {
     }
 
     /**
-     * Returns the original nodes of the custom element without any service nodes
-     * that could have been added for markup. These nodes can include Text,
-     * Comment and other child nodes.
+     * Returns the original nodes of the custom element without any service
+     * nodes that could have been added for markup. These nodes can include
+     * Text, Comment and other child nodes.
      * @return {!Array<!Node>}
      * @package @final @this {!Element}
      */
@@ -1433,10 +1435,10 @@ function createBaseCustomElementClass(win) {
           resourceState == ResourceState.READY_FOR_LAYOUT)) {
         return;
       }
-      // This implementation is notably less efficient then placeholder toggling.
-      // The reasons for this are: (a) "not supported" is the state of the whole
-      // element, (b) some relayout is expected and (c) fallback condition would
-      // be rare.
+      // This implementation is notably less efficient then placeholder
+      // toggling. The reasons for this are: (a) "not supported" is the state of
+      // the whole element, (b) some relayout is expected and (c) fallback
+      // condition would be rare.
       this.classList.toggle('amp-notsupported', show);
       if (show == true) {
         const fallbackElement = this.getFallback();
@@ -1463,12 +1465,13 @@ function createBaseCustomElementClass(win) {
      * @private @this {!Element}
      */
     isLoadingEnabled_() {
-      // No loading indicator will be shown if either one of these
-      // conditions true:
+      // No loading indicator will be shown if either one of these conditions
+      // true:
       // 1. `noloading` attribute is specified;
       // 2. The element has not been whitelisted;
       // 3. The element is too small or has not yet been measured;
-      // 4. The element has already been laid out (include having loading error);
+      // 4. The element has already been laid out (include having loading
+      //    error);
       // 5. The element is a `placeholder` or a `fallback`;
       // 6. The element's layout is not a size-defining layout.
       // 7. The document is A4A.
@@ -1710,8 +1713,7 @@ function isInternalOrServiceNode(node) {
  *
  * @param {!Window} win The window in which to register the custom element.
  * @param {string} name The name of the custom element.
- * @param {function(new:./base-element.BaseElement, !Element)=} opt_implementationClass For
- *     testing only.
+ * @param {function(new:./base-element.BaseElement, !Element)=} opt_implementationClass For testing only.
  * @return {!Object} Prototype of element.
  */
 export function createAmpElementProtoForTesting(

--- a/src/dom.js
+++ b/src/dom.js
@@ -547,8 +547,8 @@ export function scopedQuerySelectorAll(root, selector) {
  * Returns element data-param- attributes as url parameters key-value pairs.
  * e.g. data-param-some-attr=value -> {someAttr: value}.
  * @param {!Element} element
- * @param {function(string):string=} opt_computeParamNameFunc to compute the parameter
- *    name, get passed the camel-case parameter name.
+ * @param {function(string):string=} opt_computeParamNameFunc to compute the
+ *    parameter name, get passed the camel-case parameter name.
  * @param {!RegExp=} opt_paramPattern Regex pattern to match data attributes.
  * @return {!JsonObject}
  */

--- a/src/element-service.js
+++ b/src/element-service.js
@@ -30,18 +30,17 @@ import {toWin} from './types';
 import {user} from './log';
 
 /**
- * Returns a promise for a service for the given id and window. Also expects
- * an element that has the actual implementation. The promise resolves when
- * the implementation loaded.
- * Users should typically wrap this as a special purpose function (e.g.
- * Services.viewportForDoc(...)) for type safety and because the factory should not be
- * passed around.
+ * Returns a promise for a service for the given id and window. Also expects an
+ * element that has the actual implementation. The promise resolves when the
+ * implementation loaded. Users should typically wrap this as a special purpose
+ * function (e.g. Services.viewportForDoc(...)) for type safety and because the
+ * factory should not be passed around.
  * @param {!Window} win
  * @param {string} id of the service.
  * @param {string} extension Name of the custom extension that provides the
  *     implementation of this service.
- * @param {boolean=} opt_element Whether this service is provided by an
- *     element, not the extension.
+ * @param {boolean=} opt_element Whether this service is provided by an element,
+ *     not the extension.
  * @return {!Promise<*>}
  */
 export function getElementService(win, id, extension, opt_element) {
@@ -83,18 +82,17 @@ function isElementScheduled(win, elementName) {
 
 
 /**
- * Returns a promise for a service for the given id and window. Also expects
- * an element that has the actual implementation. The promise resolves when
- * the implementation loaded.
- * Users should typically wrap this as a special purpose function (e.g.
- * Services.viewportForDoc(...)) for type safety and because the factory should not be
- * passed around.
+ * Returns a promise for a service for the given id and window. Also expects an
+ * element that has the actual implementation. The promise resolves when the
+ * implementation loaded. Users should typically wrap this as a special purpose
+ * function (e.g. Services.viewportForDoc(...)) for type safety and because the
+ * factory should not be passed around.
  * @param {!Node|!./service/ampdoc-impl.AmpDoc} nodeOrDoc
  * @param {string} id of the service.
  * @param {string} extension Name of the custom extension that provides the
  *     implementation of this service.
- * @param {boolean=} opt_element Whether this service is provided by an
- *     element, not the extension.
+ * @param {boolean=} opt_element Whether this service is provided by an element,
+ *     not the extension.
  * @return {!Promise<*>}
  */
 export function getElementServiceForDoc(nodeOrDoc, id, extension, opt_element) {
@@ -125,8 +123,8 @@ export function getElementServiceIfAvailableForDoc(
   return ampdoc.whenBodyAvailable()
       .then(() => waitForExtensionIfStubbed(ampdoc.win, extension))
       .then(() => {
-        // If this service is provided by an element, then we can't depend on the
-        // service (they may not use the element).
+        // If this service is provided by an element, then we can't depend on
+        // the service (they may not use the element).
         if (opt_element) {
           return getServicePromiseOrNullForDoc(nodeOrDoc, id);
         } else if (isElementScheduled(ampdoc.win, extension)) {
@@ -223,8 +221,8 @@ function getElementServicePromiseOrNull(win, id, extension, opt_element) {
   return dom.waitForBodyPromise(win.document)
       .then(() => waitForExtensionIfStubbed(win, extension))
       .then(() => {
-        // If this service is provided by an element, then we can't depend on the
-        // service (they may not use the element).
+        // If this service is provided by an element, then we can't depend on
+        // the service (they may not use the element).
         if (opt_element) {
           return getServicePromiseOrNull(win, id);
         } else if (isElementScheduled(win, extension)) {

--- a/src/extension-analytics.js
+++ b/src/extension-analytics.js
@@ -70,9 +70,9 @@ export function insertAnalyticsElement(
 
 /**
  * A class that handles customEvent reporting of extension element through
- * amp-analytics.
- * This class is not exposed to extension element directly to restrict the genration of the config
- * Please use CustomEventReporterBuilder to build a CustomEventReporter instance.
+ * amp-analytics. This class is not exposed to extension element directly to
+ * restrict the genration of the config Please use CustomEventReporterBuilder to
+ * build a CustomEventReporter instance.
  */
 class CustomEventReporter {
   /**
@@ -124,9 +124,10 @@ class CustomEventReporter {
 
 
 /**
- * A builder class that enable extension elements to easily build and get a CustomEventReporter instance.
- * Its constructor requires the parent AMP element.
- * It provides two methods #track() and #build() to build the CustomEventReporter instance.
+ * A builder class that enable extension elements to easily build and get a
+ * CustomEventReporter instance. Its constructor requires the parent AMP
+ * element. It provides two methods #track() and #build() to build the
+ * CustomEventReporter instance.
  */
 export class CustomEventReporterBuilder {
   /** @param {!AmpElement} parent */
@@ -143,8 +144,10 @@ export class CustomEventReporterBuilder {
   }
 
   /**
-   * The #track() method takes in a unique custom-event name, and the corresponding request url (or an array of request urls).
-   * One can call #track() multiple times with different eventType name (order doesn't matter) before #build() is called.
+   * The #track() method takes in a unique custom-event name, and the
+   * corresponding request url (or an array of request urls). One can call
+   * #track() multiple times with different eventType name (order doesn't
+   * matter) before #build() is called.
    * @param {string} eventType
    * @param {string|!Array<string>} request
    */
@@ -167,8 +170,8 @@ export class CustomEventReporterBuilder {
 
   /**
    * Call the #build() method to build and get the CustomEventReporter instance.
-   * One CustomEventReporterBuilder instance can only build one reporter,
-   * which means #build() should only be called once after all eventType are added.
+   * One CustomEventReporterBuilder instance can only build one reporter, which
+   * means #build() should only be called once after all eventType are added.
    */
   build() {
     dev().assert(this.config_, 'CustomEventReporter already built');
@@ -181,8 +184,9 @@ export class CustomEventReporterBuilder {
 
 
 /**
- * A helper method that should be used by all extension elements to add their sandbox analytics tracking.
- * This method takes care of insert and remove the analytics tracker at the right time of the element lifecycle.
+ * A helper method that should be used by all extension elements to add their
+ * sandbox analytics tracking. This method takes care of insert and remove the
+ * analytics tracker at the right time of the element lifecycle.
  * @param {!AmpElement} element
  * @param {!Promise<!JsonObject>} promise
  */

--- a/src/get-html.js
+++ b/src/get-html.js
@@ -32,7 +32,8 @@ const allowedAttributes = ['action', 'alt', 'class', 'disabled', 'height',
  * Returns content of HTML node
  * @param {!Window} win
  * @param {string} selector - CSS selector of the node to take content from
- * @param {!Array<string>} attrs - tag attributes to be left in the stringified HTML
+ * @param {!Array<string>} attrs - tag attributes to be left in the stringified
+ * HTML
  * @return {string}
  */
 export function getHtml(win, selector, attrs) {

--- a/src/iframe-helper.js
+++ b/src/iframe-helper.js
@@ -37,7 +37,8 @@ const UNLISTEN_SENTINEL = 'unlisten';
 let WindowEventsDef;
 
 /**
- * Returns a mapping from a URL's origin to an array of windows and their listenFor listeners.
+ * Returns a mapping from a URL's origin to an array of windows and their
+ * listenFor listeners.
  * @param {!Window} parentWin the window that created the iframe
  * @param {boolean=} opt_create create the mapping if it does not exist
  * @return {?Object<string, !Array<!WindowEventsDef>>}
@@ -52,7 +53,8 @@ function getListenFors(parentWin, opt_create) {
 }
 
 /**
- * Returns an array of WindowEventsDef that have had any listenFor listeners registered for this sentinel.
+ * Returns an array of WindowEventsDef that have had any listenFor listeners
+ * registered for this sentinel.
  * @param {!Window} parentWin the window that created the iframe
  * @param {string} sentinel the sentinel of the message
  * @param {boolean=} opt_create create the array if it does not exist

--- a/src/impression.js
+++ b/src/impression.js
@@ -76,8 +76,8 @@ export function maybeTrackImpression(win) {
   ]).then(results => {
     const isTrustedViewer = results[0];
     const isTrustedReferrer = results[1];
-    // Currently this feature is launched for trusted viewer and trusted referrer,
-    // but still experiment guarded for all AMP docs.
+    // Currently this feature is launched for trusted viewer and trusted
+    // referrer, but still experiment guarded for all AMP docs.
     if (!isTrustedViewer && !isTrustedReferrer && !isExperimentOn(win, 'alp')) {
       resolveImpression();
       return;
@@ -100,13 +100,13 @@ export function doNotTrackImpression() {
 }
 
 /**
- * Handle the getReplaceUrl and return a promise when url is replaced
- * Only handles replaceUrl when viewer indicates AMP to do so. Viewer should indicate
- * by setting the legacy replaceUrl init param and add `replaceUrl` to its capability param.
- * Future plan is to change the type of legacy init replaceUrl param from url string
- * to boolean value.
- * Please NOTE replaceUrl and adLocation will never arrive at same time,
- * so there is no race condition on the order of handling url replacement.
+ * Handle the getReplaceUrl and return a promise when url is replaced Only
+ * handles replaceUrl when viewer indicates AMP to do so. Viewer should indicate
+ * by setting the legacy replaceUrl init param and add `replaceUrl` to its
+ * capability param. Future plan is to change the type of legacy init replaceUrl
+ * param from url string to boolean value. Please NOTE replaceUrl and adLocation
+ * will never arrive at same time, so there is no race condition on the order of
+ * handling url replacement.
  * @param {!Window} win
  * @return {!Promise}
  */
@@ -245,7 +245,8 @@ function applyResponse(win, response) {
 }
 
 /**
- * Return a promise that whether appending extra url params to outgoing link is required.
+ * Return a promise that whether appending extra url params to outgoing link is
+ * required.
  * @param {!./service/ampdoc-impl.AmpDoc} ampdoc
  * @return {!Promise<boolean>}
  */

--- a/src/intersection-observer.js
+++ b/src/intersection-observer.js
@@ -95,22 +95,20 @@ export function getIntersectionChangeEntry(element, owner, viewport) {
 /**
  * The IntersectionObserver class lets any element share its viewport
  * intersection data with an iframe of its choice (most likely contained within
- * the element itself.). When instantiated the class will start listening for
- * a 'send-intersections' postMessage from the iframe, and only then  would start
+ * the element itself.). When instantiated the class will start listening for a
+ * 'send-intersections' postMessage from the iframe, and only then  would start
  * sending intersection data to the iframe. The intersection data would be sent
- * when the element is moved inside or outside the viewport as well as on
- * scroll and resize.
- * The element should create an IntersectionObserver instance once the Iframe
- * element is created.
- * The IntersectionObserver class exposes a `fire` method that would send the
- * intersection data to the iframe.
- * The IntersectionObserver class exposes a `onViewportCallback` method that
- * should be called inside if the viewportCallback of the element. This would
- * let the element sent intersection data automatically when there element comes
- * inside or goes outside the viewport and also manage sending intersection data
- * onscroll and resize.
- * Note: The IntersectionObserver would not send any data over to the iframe if
- * it had not requested the intersection data already via a postMessage.
+ * when the element is moved inside or outside the viewport as well as on scroll
+ * and resize. The element should create an IntersectionObserver instance once
+ * the Iframe element is created. The IntersectionObserver class exposes a
+ * `fire` method that would send the intersection data to the iframe. The
+ * IntersectionObserver class exposes a `onViewportCallback` method that should
+ * be called inside if the viewportCallback of the element. This would let the
+ * element sent intersection data automatically when there element comes inside
+ * or goes outside the viewport and also manage sending intersection data
+ * onscroll and resize. Note: The IntersectionObserver would not send any data
+ * over to the iframe if it had not requested the intersection data already via
+ * a postMessage.
  */
 export class IntersectionObserver {
   /**

--- a/src/layout.js
+++ b/src/layout.js
@@ -338,9 +338,9 @@ export function applyStaticLayout(element) {
     return layout;
   }
 
-  // If the layout was already done by server-side rendering (SSR), then the code
-  // below will not run. Any changes below will necessitate a change to SSR and must
-  // be coordinated with caches that implement SSR. See bit.ly/amp-ssr.
+  // If the layout was already done by server-side rendering (SSR), then the
+  // code below will not run. Any changes below will necessitate a change to SSR
+  // and must be coordinated with caches that implement SSR. See bit.ly/amp-ssr.
 
   // Parse layout from the element.
   const layoutAttr = element.getAttribute('layout');
@@ -447,8 +447,9 @@ export function applyStaticLayout(element) {
     element.insertBefore(sizer, element.firstChild);
     element.sizerElement = sizer;
   } else if (layout == Layout.INTRINSIC) {
-    // Intrinsic uses an svg inside the sizer element rather than the padding trick
-    // Note a naked svg won't work becasue other thing expect the i-amphtml-sizer element
+    // Intrinsic uses an svg inside the sizer element rather than the padding
+    // trick Note a naked svg won't work becasue other thing expect the
+    // i-amphtml-sizer element
     const sizer = htmlFor(element)`
       <i-amphtml-sizer class="i-amphtml-sizer">
         <img class="i-amphtml-intrinsic-sizer" />

--- a/src/log.js
+++ b/src/log.js
@@ -75,20 +75,22 @@ export function setReportError(fn) {
 }
 
 /**
- * Logging class.
- * Use of sentinel string instead of a boolean to check user/dev errors
- * because errors could be rethrown by some native code as a new error, and only a message would survive.
- * Also, some browser don’t support a 5th error object argument in window.onerror. List of supporting browser can be found
- * here: https://blog.sentry.io/2016/01/04/client-javascript-reporting-window-onerror.html
+ * Logging class. Use of sentinel string instead of a boolean to check user/dev
+ * errors because errors could be rethrown by some native code as a new error,
+ * and only a message would survive. Also, some browser don’t support a 5th
+ * error object argument in window.onerror. List of supporting browser can be
+ * found here:
+ * https://blog.sentry.io/2016/01/04/client-javascript-reporting-window-onerror.html
  * @final
  * @private Visible for testing only.
  */
 export class Log {
   /**
-   * opt_suffix will be appended to error message to identify the type of the error message.
-   * We can't rely on the error object to pass along the type because
-   * some browsers do not have this param in its window.onerror API.
-   * See: https://blog.sentry.io/2016/01/04/client-javascript-reporting-window-onerror.html
+   * opt_suffix will be appended to error message to identify the type of the
+   * error message. We can't rely on the error object to pass along the type
+   * because some browsers do not have this param in its window.onerror API.
+   * See:
+   * https://blog.sentry.io/2016/01/04/client-javascript-reporting-window-onerror.html
    *
    * @param {!Window} win
    * @param {function(!./mode.ModeDef):!LogLevel} levelFunc
@@ -394,8 +396,8 @@ export class Log {
   }
 
   /**
-   * Asserts and returns the enum value. If the enum doesn't contain such a value,
-   * the error is thrown.
+   * Asserts and returns the enum value. If the enum doesn't contain such a
+   * value, the error is thrown.
    *
    * @param {!Object<T>} enumObj
    * @param {string} s
@@ -548,14 +550,13 @@ let logConstructor = null;
 export function initLogConstructor() {
   logConstructor = Log;
   // Initialize instances for use. If a binary (an extension for example) that
-  // does not call `initLogConstructor` invokes `dev()` or `user()` earlier
-  // than the binary that does call `initLogConstructor` (amp.js), the extension
-  // will throw an error as that extension will never be able to initialize
-  // the log instances and we also don't want it to call `initLogConstructor`
-  // either (since that will cause the Log implementation to be bundled into that
-  // binary). So we must initialize the instances eagerly so that they are
-  // ready for use (stored globally) after the main binary calls
-  // `initLogConstructor`.
+  // does not call `initLogConstructor` invokes `dev()` or `user()` earlier than
+  // the binary that does call `initLogConstructor` (amp.js), the extension will
+  // throw an error as that extension will never be able to initialize the log
+  // instances and we also don't want it to call `initLogConstructor` either
+  // (since that will cause the Log implementation to be bundled into that
+  // binary). So we must initialize the instances eagerly so that they are ready
+  // for use (stored globally) after the main binary calls `initLogConstructor`.
   dev();
   user();
 }
@@ -608,8 +609,9 @@ function getUserLogger(suffix) {
 }
 
 /**
- * AMP development log. Calls to `devLog().assert` and `dev.fine` are stripped in
- * the PROD binary. However, `devLog().assert` result is preserved in either case.
+ * AMP development log. Calls to `devLog().assert` and `dev.fine` are stripped
+ * in the PROD binary. However, `devLog().assert` result is preserved in either
+ * case.
  *
  * Enabled in the following conditions:
  *  1. Not disabled using `#log=0`.

--- a/src/polyfills/domtokenlist-toggle.js
+++ b/src/polyfills/domtokenlist-toggle.js
@@ -1,24 +1,24 @@
 /**
  * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS-IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * distributed under the License is distributed on an "AS-IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
 
 
 /**
- * Polyfill for `DOMTokenList.prototype.toggle(token, opt_force)` method.
- * This is specially important because IE does not support `opt_force` attribute.
- * See https://goo.gl/hgKNYY for details.
+ * Polyfill for `DOMTokenList.prototype.toggle(token, opt_force)` method. This
+ * is specially important because IE does not support `opt_force` attribute. See
+ * https://goo.gl/hgKNYY for details.
  * @param {string} token
  * @param {boolean=} opt_force
  * @this {DOMTokenList}

--- a/src/polyfills/domtokenlist-toggle.js
+++ b/src/polyfills/domtokenlist-toggle.js
@@ -1,17 +1,17 @@
 /**
  * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS-IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 

--- a/src/render-delaying-services.js
+++ b/src/render-delaying-services.js
@@ -49,11 +49,11 @@ const SERVICES = {
 const LOAD_TIMEOUT = 3000;
 
 /**
- * Detects any render delaying services that are required on the page,
- * and returns a promise with a timeout.
+ * Detects any render delaying services that are required on the page, and
+ * returns a promise with a timeout.
  * @param {!Window} win
- * @return {!Promise<!Array<*>>} resolves to an Array that has the same length as
- *     the detected render delaying services
+ * @return {!Promise<!Array<*>>} resolves to an Array that has the same length
+ *     as the detected render delaying services
  */
 export function waitForServices(win) {
   const promises = includedServices(win).map(service => {

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -130,8 +130,8 @@ export function installBuiltins(global) {
 
 
 /**
- * Applies the runtime to a given global scope for a single-doc mode.
- * Multi frame support is currently incomplete.
+ * Applies the runtime to a given global scope for a single-doc mode. Multi
+ * frame support is currently incomplete.
  * @param {!Window} global Global scope to adopt.
  * @param {function(!Window, !./service/extensions-impl.Extensions):!Promise} callback
  * @return {!Promise}
@@ -430,7 +430,8 @@ export class MultidocManager {
    * @param {!Element} hostElement
    * @param {string} url
    * @param {!Object<string, string>|undefined} initParams
-   * @param {function(!Object, !ShadowRoot, !./service/ampdoc-impl.AmpDocShadow):!Promise} builder
+   * @param {function(!Object, !ShadowRoot,
+   * !./service/ampdoc-impl.AmpDocShadow):!Promise} builder
    * @return {!Object}
    * @private
    */

--- a/src/service.js
+++ b/src/service.js
@@ -199,10 +199,10 @@ export function registerServiceBuilderForDoc(nodeOrDoc,
 
 
 /**
- * Returns a service for the given id and window (a per-window singleton).
- * Users should typically wrap this as a special purpose function (e.g.
- * `Services.vsyncFor(win)`) for type safety and because the factory should not be
- * passed around.
+ * Returns a service for the given id and window (a per-window singleton). Users
+ * should typically wrap this as a special purpose function (e.g.
+ * `Services.vsyncFor(win)`) for type safety and because the factory should not
+ * be passed around.
  * @param {!Window} win
  * @param {string} id of the service.
  * @template T
@@ -215,12 +215,11 @@ export function getService(win, id) {
 
 
 /**
- * Returns a promise for a service for the given id and window. Also expects
- * an element that has the actual implementation. The promise resolves when
- * the implementation loaded.
- * Users should typically wrap this as a special purpose function (e.g.
- * `Services.vsyncFor(win)`) for type safety and because the factory should not be
- * passed around.
+ * Returns a promise for a service for the given id and window. Also expects an
+ * element that has the actual implementation. The promise resolves when the
+ * implementation loaded. Users should typically wrap this as a special purpose
+ * function (e.g. `Services.vsyncFor(win)`) for type safety and because the
+ * factory should not be passed around.
  * @param {!Window} win
  * @param {string} id of the service.
  * @return {!Promise<!Object>}

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -947,7 +947,7 @@ export function dereferenceExprsInArgs(args, event) {
     let value = args[key];
     if (typeof value == 'object' && value.expression) {
       const expr =
-          /** @type {ActionInfoArgExpressionDef} */ (value).expression;
+        /** @type {ActionInfoArgExpressionDef} */ (value).expression;
       const exprValue = getValueForExpr(data, expr);
       // If expr can't be found in data, use null instead of undefined.
       value = (exprValue === undefined) ? null : exprValue;

--- a/src/service/cid-api.js
+++ b/src/service/cid-api.js
@@ -104,8 +104,9 @@ export class GoogleCidApi {
           .then(response => {
             const cid = this.handleResponse_(response);
             if (!cid && response['alternateUrl']) {
-              // If an alternate url is provided, try again with the alternate url
-              // The client is still responsible for appending API keys to the URL.
+              // If an alternate url is provided, try again with the alternate
+              // url The client is still responsible for appending API keys to
+              // the URL.
               const altUrl = `${response['alternateUrl']}?key=${apiKey}`;
               return this.fetchCid_(dev().assertString(altUrl), scope, token)
                   .then(this.handleResponse_.bind(this));

--- a/src/service/history-impl.js
+++ b/src/service/history-impl.js
@@ -128,8 +128,9 @@ export class History {
   }
 
   /**
-   * Helper method to handle navigation to a local target, e.g. When a user clicks an
-   * anchor link to a local hash - <a href="#section1">Go to section 1</a>.
+   * Helper method to handle navigation to a local target, e.g. When a user
+   * clicks an anchor link to a local hash - <a href="#section1">Go to section
+   * 1</a>.
    *
    * @param {string} target
    * @return {!Promise}

--- a/src/service/layers-impl.js
+++ b/src/service/layers-impl.js
@@ -447,9 +447,9 @@ export class LayoutElement {
     /**
      * Whether the layout is a descendant of the most recently scrolled layer.
      *
-     * Note: This attribute is `undefined`, unless the ancestry tree is currently
-     * being iterated with #iterateAncestry. This is the only time it can be
-     * determined without a ton of DOM checks.
+     * Note: This attribute is `undefined`, unless the ancestry tree is
+     * currently being iterated with #iterateAncestry. This is the only time it
+     * can be determined without a ton of DOM checks.
      *
      * @private {boolean|undefined}
      */
@@ -1049,7 +1049,8 @@ export class LayoutElement {
   }
 
   /**
-   * Remeasures the element, and all children, since this element was marked dirty.
+   * Remeasures the element, and all children, since this element was marked
+   * dirty.
    *
    * @param {!PositionDef=} opt_relativeTo A performance optimization used when
    *     recursively measuring the child nodes of the layer.

--- a/src/service/navigation.js
+++ b/src/service/navigation.js
@@ -418,15 +418,14 @@ export class Navigation {
   scrollToElement_(elem, hash) {
     // Scroll to the element if found.
     if (elem) {
-      // The first call to scrollIntoView overrides browsers' default
-      // scrolling behavior. The second call insides setTimeout allows us to
-      // scroll to that element properly.
-      // Without doing this, the viewport will not catch the updated scroll
-      // position on iOS Safari and hence calculate the wrong scrollTop for
-      // the scrollbar jumping the user back to the top for failing to calculate
-      // the new jumped offset.
-      // Without the first call there will be a visual jump due to browser scroll.
-      // See https://github.com/ampproject/amphtml/issues/5334 for more details.
+      // The first call to scrollIntoView overrides browsers' default scrolling
+      // behavior. The second call insides setTimeout allows us to scroll to
+      // that element properly. Without doing this, the viewport will not catch
+      // the updated scroll position on iOS Safari and hence calculate the wrong
+      // scrollTop for the scrollbar jumping the user back to the top for
+      // failing to calculate the new jumped offset. Without the first call
+      // there will be a visual jump due to browser scroll. See
+      // https://github.com/ampproject/amphtml/issues/5334 for more details.
       this.viewport_./*OK*/scrollIntoView(elem);
       Services.timerFor(this.ampdoc.win).delay(() =>
         this.viewport_./*OK*/scrollIntoView(dev().assertElement(elem)), 1);

--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -322,7 +322,8 @@ export class Performance {
       this.mark(label);
     }
 
-    // Store certain page visibility metrics to be exposed as analytics variables.
+    // Store certain page visibility metrics to be exposed as analytics
+    // variables.
     const storedVal = Math.round(opt_delta != null ? Math.max(opt_delta, 0)
 				 : value - this.initTime_);
     switch (label) {
@@ -453,9 +454,9 @@ export class Performance {
   }
 
   /**
-   * Identifies if the viewer is able to track performance.
-   * If the document is not embedded, there is no messaging channel,
-   * so no performance tracking is needed since there is nobody to forward the events.
+   * Identifies if the viewer is able to track performance. If the document is
+   * not embedded, there is no messaging channel, so no performance tracking is
+   * needed since there is nobody to forward the events.
    * @return {boolean}
    */
   isPerformanceTrackingOn() {

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -539,7 +539,8 @@ export class Resources {
   }
 
   /**
-   * Builds the element if ready to be built, otherwise adds it to pending resources.
+   * Builds the element if ready to be built, otherwise adds it to pending
+   * resources.
    * @param {!Resource} resource
    * @param {boolean=} checkForDupes
    * @param {boolean=} scheduleWhenBuilt
@@ -1012,9 +1013,9 @@ export class Resources {
     return this.vsync_.runPromise({
       measure: measurer || undefined,
       mutate: () => {
-        // TODO(jridgewell): Audit this system. Did this cause a layer invalidation (new
-        // layer, or removal of old layer)? Right now, we're only dirtying
-        // the measurements.
+        // TODO(jridgewell): Audit this system. Did this cause a layer
+        // invalidation (new layer, or removal of old layer)? Right now, we're
+        // only dirtying the measurements.
         mutator();
         this.dirtyElement(element);
       },

--- a/src/service/template-impl.js
+++ b/src/service/template-impl.js
@@ -278,8 +278,8 @@ export class Templates {
   }
 
   /**
-   * Returns the promise that will eventually yield the template class. This will
-   * wait until the actual template script has been downloaded and parsed.
+   * Returns the promise that will eventually yield the template class. This
+   * will wait until the actual template script has been downloaded and parsed.
    * @param {!Element} element
    * @param {string} type
    * @return {!Promise<!TemplateClassDef>}

--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -374,7 +374,8 @@ export class GlobalVariableSource extends VariableSource {
     // Returns the number of milliseconds since 1 Jan 1970 00:00:00 UTC.
     this.set('TIMESTAMP', dateMethod('getTime'));
 
-    //Returns the human readable timestamp in format of 2011-01-01T11:11:11.612Z.
+    // Returns the human readable timestamp in format of
+    // 2011-01-01T11:11:11.612Z.
     this.set('TIMESTAMP_ISO', dateMethod('toISOString'));
 
     // Returns the user's time-zone offset from UTC, in minutes.
@@ -752,14 +753,15 @@ export class UrlReplacements {
 
 
   /**
-   * Synchronously expands the provided source by replacing all known variables with
-   * their resolved values. Optional `opt_bindings` can be used to add new
+   * Synchronously expands the provided source by replacing all known variables
+   * with their resolved values. Optional `opt_bindings` can be used to add new
    * variables or override existing ones.  Any async bindings are ignored.
    * @param {string} source
-   * @param {!Object<string, (ResolverReturnDef|!SyncResolverDef)>=} opt_bindings
+   * @param {!Object<string, (ResolverReturnDef|!SyncResolverDef)>=}
+   * opt_bindings
    * @param {!Object<string, ResolverReturnDef>=} opt_collectVars
-   * @param {!Object<string, boolean>=} opt_whiteList Optional white list of names
-   *     that can be substituted.
+   * @param {!Object<string, boolean>=} opt_whiteList Optional white list of
+   *     names that can be substituted.
    * @return {string}
    */
   expandStringSync(source, opt_bindings, opt_collectVars, opt_whiteList) {
@@ -781,14 +783,15 @@ export class UrlReplacements {
   }
 
   /**
-   * Synchronously expands the provided URL by replacing all known variables with
-   * their resolved values. Optional `opt_bindings` can be used to add new
+   * Synchronously expands the provided URL by replacing all known variables
+   * with their resolved values. Optional `opt_bindings` can be used to add new
    * variables or override existing ones.  Any async bindings are ignored.
    * @param {string} url
-   * @param {!Object<string, (ResolverReturnDef|!SyncResolverDef)>=} opt_bindings
+   * @param {!Object<string, (ResolverReturnDef|!SyncResolverDef)>=}
+   * opt_bindings
    * @param {!Object<string, ResolverReturnDef>=} opt_collectVars
-   * @param {!Object<string, boolean>=} opt_whiteList Optional white list of names
-   *     that can be substituted.
+   * @param {!Object<string, boolean>=} opt_whiteList Optional white list of
+   *     names that can be substituted.
    * @return {string}
    */
   expandUrlSync(url, opt_bindings, opt_collectVars, opt_whiteList) {
@@ -966,13 +969,13 @@ export class UrlReplacements {
       return element.href = href;
     }
 
-    // Note that defaultUrlParams is treated differently than additionalUrlParameters in two ways
-    // #1: If the outgoing url origin is not whitelisted:
-    // additionalUrlParameters are always appended by not expanded,
-    // defaultUrlParams will not be appended.
-    // #2: If the expansion function is not whitelisted:
-    // additionalUrlParamters will not be expanded,
-    // defaultUrlParams will by default support QUERY_PARAM, and will still be expanded.
+    // Note that defaultUrlParams is treated differently than
+    // additionalUrlParameters in two ways #1: If the outgoing url origin is not
+    // whitelisted: additionalUrlParameters are always appended by not expanded,
+    // defaultUrlParams will not be appended. #2: If the expansion function is
+    // not whitelisted: additionalUrlParamters will not be expanded,
+    // defaultUrlParams will by default support QUERY_PARAM, and will still be
+    // expanded.
     if (defaultUrlParams) {
       if (!whitelist || !whitelist['QUERY_PARAM']) {
         // override whitelist and expand defaultUrlParams;
@@ -1011,7 +1014,8 @@ export class UrlReplacements {
     const isV2ExperimentOn = isExperimentOn(this.ampdoc.win,
         REPLACEMENT_EXP_NAME);
     if (isV2ExperimentOn && !opt_collectVars && !opt_sync) {
-      // not supporting syncronous version (yet) or collect_vars with this new structure
+      // not supporting syncronous version (yet) or collect_vars with this new
+      // structure
       return this.expander_./*OK*/expand(url, opt_bindings, opt_whiteList);
     }
 

--- a/src/service/viewport/viewport-binding-natural.js
+++ b/src/service/viewport/viewport-binding-natural.js
@@ -26,8 +26,8 @@ import {px, setImportantStyles} from '../../style';
 const TAG_ = 'Viewport';
 
 /**
- * Implementation of ViewportBindingDef based on the native window. It assumes that
- * the native window is sized properly and events represent the actual
+ * Implementation of ViewportBindingDef based on the native window. It assumes
+ * that the native window is sized properly and events represent the actual
  * scroll/resize events. This mode is applicable to a standalone document
  * display or when an iframe has a fixed size.
  *

--- a/src/service/xhr-impl.js
+++ b/src/service/xhr-impl.js
@@ -144,9 +144,9 @@ export class Xhr {
           if (interceptorResponse) {
             return interceptorResponse;
           }
-          // After this point, both the native `fetch` and the `fetch` polyfill will
-          // expect a native `FormData` object in the `body` property, so the native
-          // `FormData` object needs to be unwrapped.
+          // After this point, both the native `fetch` and the `fetch` polyfill
+          // will expect a native `FormData` object in the `body` property, so
+          // the native `FormData` object needs to be unwrapped.
           if (isFormDataWrapper(init.body)) {
             init.body = init.body.getFormData();
           }

--- a/src/services.js
+++ b/src/services.js
@@ -61,8 +61,8 @@ export class Services {
   }
 
   /**
-   * Returns a promise for the Access service or a promise for null if the service
-   * is not available on the current page.
+   * Returns a promise for the Access service or a promise for null if the
+   * service is not available on the current page.
    * @param {!Node|!./service/ampdoc-impl.AmpDoc} nodeOrDoc
    * @return {!Promise<?../extensions/amp-access/0.1/amp-access.AccessService>}
    */
@@ -124,9 +124,10 @@ export class Services {
       Services.extensionsFor(ampdoc.win)./*OK*/installExtensionForDoc(
           ampdoc, 'amp-analytics');
     }
-    return (/** @type {!Promise<
-              !../extensions/amp-analytics/0.1/instrumentation.InstrumentationService
-            >} */ (getElementServiceForDoc(
+    return (
+      /** @type {!Promise<
+        !../extensions/amp-analytics/0.1/instrumentation.InstrumentationService
+      >} */ (getElementServiceForDoc(
           nodeOrDoc, 'amp-analytics-instrumentation', 'amp-analytics')));
   }
 
@@ -135,9 +136,10 @@ export class Services {
    * @return {!Promise<?../extensions/amp-analytics/0.1/instrumentation.InstrumentationService>}
    */
   static analyticsForDocOrNull(nodeOrDoc) {
-    return (/** @type {!Promise<
-              ?../extensions/amp-analytics/0.1/instrumentation.InstrumentationService
-            >} */ (getElementServiceIfAvailableForDoc(
+    return (
+      /** @type {!Promise<
+        ?../extensions/amp-analytics/0.1/instrumentation.InstrumentationService
+      >} */ (getElementServiceIfAvailableForDoc(
           nodeOrDoc, 'amp-analytics-instrumentation', 'amp-analytics')));
   }
 
@@ -302,13 +304,11 @@ export class Services {
    * Version of the story store service depends on which version of amp-story
    * the publisher is loading. They all have the same implementation.
    * @param {!Window} win
-   * @return {?Promise<?../extensions/amp-story/1.0/amp-story-store-service.AmpStoryStoreService|
-   *                   ?../extensions/amp-story/0.1/amp-story-store-service.AmpStoryStoreService>}
+   * @return {?Promise<?../extensions/amp-story/1.0/amp-story-store-service.AmpStoryStoreService|?../extensions/amp-story/0.1/amp-story-store-service.AmpStoryStoreService>}
    */
   static storyStoreServiceForOrNull(win) {
     return (
-    /** @type {!Promise<?../extensions/amp-story/1.0/amp-story-store-service.AmpStoryStoreService|
-                        ?../extensions/amp-story/0.1/amp-story-store-service.AmpStoryStoreService>} */
+    /** @type {!Promise<?../extensions/amp-story/1.0/amp-story-store-service.AmpStoryStoreService|?../extensions/amp-story/0.1/amp-story-store-service.AmpStoryStoreService>} */
       (getElementServiceIfAvailable(win, 'story-store', 'amp-story')));
   }
 
@@ -401,8 +401,7 @@ export class Services {
    * @return {!Promise<!../extensions/amp-animation/0.1/web-animation-service.WebAnimationService>}
    */
   static webAnimationServiceFor(nodeOrDoc) {
-    return (/** @type {
-        !Promise<!../extensions/amp-animation/0.1/web-animation-service.WebAnimationService>} */
+    return (/** @type {!Promise<!../extensions/amp-animation/0.1/web-animation-service.WebAnimationService>} */
       (getElementServiceForDoc(nodeOrDoc, 'web-animation', 'amp-animation')));
   }
 
@@ -477,8 +476,8 @@ export class Services {
   }
 
   /**
-   * Returns a promise for the experiment variants or a promise for null if it is
-   * not available on the current page.
+   * Returns a promise for the experiment variants or a promise for null if it
+   * is not available on the current page.
    * @param {!Window} win
    * @return {!Promise<?Object<string>>}
    */

--- a/src/shadow-embed.js
+++ b/src/shadow-embed.js
@@ -697,14 +697,13 @@ export class ShadowDomWriterBulk {
 }
 
 /*
- * Remove any noscript elements.
- * @param {!Element} parent
+ * Remove any noscript elements. @param {!Element} parent
  *
- * According to the spec (https://w3c.github.io/DOM-Parsing/#the-domparser-interface),
- * with `DOMParser().parseFromString`, contents of `noscript` get parsed as markup,
- * so we need to remove them manually.
- * Why? ¯\_(ツ)_/¯
- * `createHTMLDocument()` seems to behave the same way.
+ * According to the spec
+ * (https://w3c.github.io/DOM-Parsing/#the-domparser-interface), with
+ * `DOMParser().parseFromString`, contents of `noscript` get parsed as markup,
+ * so we need to remove them manually. Why? ¯\_(ツ)_/¯ `createHTMLDocument()`
+ * seems to behave the same way.
  */
 function removeNoScriptElements(parent) {
   const noscriptElements = childElementsByTag(parent, 'noscript');

--- a/src/style-installer.js
+++ b/src/style-installer.js
@@ -78,13 +78,14 @@ export function installStylesForDoc(
 
 /**
  * Adds the given css text to the given document.
- * TODO(dvoytenko, #10705): Remove this method once FIE/ampdoc migration is done.
+ * TODO(dvoytenko, #10705): Remove this method once FIE/ampdoc migration is
+ * done.
  *
  * @param {!Document} doc The document that should get the new styles.
  * @param {string} cssText
- * @param {?function(!Element)|undefined} cb Called when the new styles are available.
- *     Not using a promise, because this is synchronous when possible.
- *     for better performance.
+ * @param {?function(!Element)|undefined} cb Called when the new styles are
+ *     available. Not using a promise, because this is synchronous when
+ *     possible. for better performance.
  * @param {boolean=} opt_isRuntimeCss If true, this style tag will be inserted
  *     as the first element in head and all style elements will be positioned
  *     after.

--- a/src/url.js
+++ b/src/url.js
@@ -379,8 +379,8 @@ export function isProtocolValid(url) {
 }
 
 /**
- * Removes parameters that start with amp js parameter pattern and returns the new
- * search string.
+ * Removes parameters that start with amp js parameter pattern and returns the
+ * new search string.
  * @param {string} urlSearch
  * @return {string}
  */

--- a/src/web-components.js
+++ b/src/web-components.js
@@ -76,8 +76,10 @@ export function isShadowCssSupported() {
 }
 
 /**
- * Returns `true` if the passed function is native to the browser, and is not polyfilled
- * @param {function()|undefined} func A function that is attatched to a JS object.
+ * Returns `true` if the passed function is native to the browser, and is not
+ * polyfilled
+ * @param {function()|undefined} func A function that is attatched to a JS
+ * object.
  * @return {boolean}
  */
 function isNative(func) {

--- a/test/functional/test-srcset.js
+++ b/test/functional/test-srcset.js
@@ -379,11 +379,13 @@ describe('Srcset', () => {
       expect(srcset.select(740, 1)).to.equal('image-1000');
       expect(srcset.select(370, 2)).to.equal('image-1000');
 
-      // Lower than threshold but difference ratio (730/500 = 1.46) too high -> higher value
+      // Lower than threshold but difference ratio (730/500 = 1.46) too high ->
+      // higher value
       expect(srcset.select(730, 1)).to.equal('image-1000');
       expect(srcset.select(365, 2)).to.equal('image-1000');
 
-      // Lower than threshold and difference ratio (600/500 = 1.2) is low enough -> lower value
+      // Lower than threshold and difference ratio (600/500 = 1.2) is low enough
+      // -> lower value
       expect(srcset.select(600, 1)).to.equal('image-500');
       expect(srcset.select(300, 2)).to.equal('image-500');
     });

--- a/test/integration/test-amp-ad-3p.js
+++ b/test/integration/test-amp-ad-3p.js
@@ -74,8 +74,8 @@ describe.configure().retryOnSaucelabs().run('amp-ad 3P', () => {
         htmlAccessAllowed: '',
       });
 
-      // make sure the context.data is the same instance as the data param passed
-      // into the vendor function. see #10628
+      // make sure the context.data is the same instance as the data param
+      // passed into the vendor function. see #10628
       expect(context.data).to.equal(
           iframe.contentWindow.networkIntegrationDataParamForTesting);
 

--- a/test/integration/test-amp-ad-doubleclick.js
+++ b/test/integration/test-amp-ad-doubleclick.js
@@ -49,7 +49,8 @@ describe.configure().enableIe().retryOnSaucelabs().run('Rendering of' +
   });
 
   // TODO(lannka, #3561): unmute the test.
-  // it.configure().skipEdge().run('should create an iframe loaded', function() {
+  // it.configure().skipEdge().run(
+  // 'should create an iframe loaded', function() {
   it.skip('should create an iframe loaded', function() {
     this.timeout(20000);
     let iframe;


### PR DESCRIPTION
This PR does the following:
- Replaces `"ignoreComments": true` in `.eslintrc` with `"ignoreTrailingComments": true`
- Fixes all instances of long text comments using https://github.com/stkb/Rewrap
- Adds exemptions for long single-line JSDoc type annotations via `ignorePattern`
- Fixes a few incorrect type annotations ([here](https://travis-ci.org/ampproject/amphtml/jobs/378165206#L2090-L2099) and [here](https://travis-ci.org/ampproject/amphtml/jobs/378170756#L2090-L2159)) that were not being caught by `gulp check-types` because they were [split across lines](https://github.com/ampproject/amphtml/pull/14439/files#r188090503)

I've kicked off a separate effort to find and fix all JSDoc errors in our code: #15255

Fixes #15127 
To be followed by #15256
