### PR TITLE
🏗 During PR checks, lint only the files in the PR, and flag errors instead of warnings

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -49,7 +49,7 @@
     "amphtml-internal/resolve-inside-promise-resolver": 1,
     "amphtml-internal/todo-format": 0,
     "amphtml-internal/unused-private-field": 1,
-    "amphtml-internal/vsync": 0,
+    "amphtml-internal/vsync": 1,
     "array-bracket-spacing": [2, "never"],
     "arrow-parens": [2, "as-needed"],
     "arrow-spacing": 2,

--- a/.eslintrc
+++ b/.eslintrc
@@ -124,9 +124,10 @@
     "space-infix-ops": 2,
     "space-unary-ops": [1, { "words": true, "nonwords": false }],
     "valid-jsdoc": [1, {
+      "prefer": {"return": "return"},
       "requireParamDescription": false,
       "requireReturn": false,
-      "requireReturnType": false,
+      "requireReturnType": true,
       "requireReturnDescription": false
     }],
     "wrap-iife": [2, "any"]

--- a/.eslintrc
+++ b/.eslintrc
@@ -123,6 +123,12 @@
     "space-in-parens": 2,
     "space-infix-ops": 2,
     "space-unary-ops": [1, { "words": true, "nonwords": false }],
+    "valid-jsdoc": [1, {
+      "requireParamDescription": false,
+      "requireReturn": false,
+      "requireReturnType": false,
+      "requireReturnDescription": false
+    }],
     "wrap-iife": [2, "any"]
   }
 }

--- a/.eslintrc-strict
+++ b/.eslintrc-strict
@@ -1,0 +1,14 @@
+{
+  "rules": {
+    "amphtml-internal/resolve-inside-promise-resolver": 2,
+    "amphtml-internal/unused-private-field": 2,
+    "amphtml-internal/vsync": 2,
+    "valid-jsdoc": [2, {
+      "prefer": {"return": "return"},
+      "requireParamDescription": false,
+      "requireReturn": false,
+      "requireReturnType": true,
+      "requireReturnDescription": false
+    }]
+  }
+}

--- a/build-system/tasks/lint.js
+++ b/build-system/tasks/lint.js
@@ -158,20 +158,9 @@ function lint() {
       config.lintGlobs =
           config.lintGlobs.filter(e => e !== '**/*.js').concat(getLintFiles());
     }
-    // Override .eslintrc settings here.
-    options['rules'] = {
-      // TODO(rsimha, #15255): Make this error by default in .eslintrc.
-      'valid-jsdoc': [2, {
-        'prefer': {'return': 'return'},
-        'requireParamDescription': false,
-        'requireReturn': false,
-        'requireReturnType': true,
-        'requireReturnDescription': false,
-      }],
-      // TODO(jridgewell, #14761): Make these error by default in .eslintrc.
-      'amphtml-internal/resolve-inside-promise-resolver': 2,
-      'amphtml-internal/unused-private-field': 2,
-    };
+    // TODO(#14761, #15255): Remove these overrides and make the rules errors by
+    // default in .eslintrc after all code is fixed.
+    options['configFile'] = '.eslintrc-strict';
   }
   const stream = initializeStream(config.lintGlobs, {});
   return runLinter('.', stream, options);

--- a/build-system/tasks/lint.js
+++ b/build-system/tasks/lint.js
@@ -157,7 +157,11 @@ function lint() {
         config.lintGlobs.filter(e => e !== '**/*.js').concat(getLintFiles());
     // Override .eslintrc settings here.
     options['rules'] = {
+      // TODO(rsimha, #15255): This should error by default in .eslintrc.
       'valid-jsdoc': 2,
+      // TODO(jridgewell, #14761): These should error by default in .eslintrc.
+      'amphtml-internal/resolve-inside-promise-resolver': 2,
+      'amphtml-internal/unused-private-field': 2,
     };
   }
   const stream = initializeStream(config.lintGlobs, {});

--- a/build-system/tasks/lint.js
+++ b/build-system/tasks/lint.js
@@ -148,13 +148,16 @@ function lint() {
   if (argv.fix) {
     options.fix = true;
   }
-  if (argv.files) {
-    config.lintGlobs =
-        config.lintGlobs.filter(e => e !== '**/*.js').concat(argv.files);
-  }
-  if (process.env.TRAVIS_PULL_REQUEST || process.env.LOCAL_PR_CHECK) {
-    config.lintGlobs =
-        config.lintGlobs.filter(e => e !== '**/*.js').concat(getLintFiles());
+  if (argv.files ||
+      process.env.TRAVIS_PULL_REQUEST ||
+      process.env.LOCAL_PR_CHECK) {
+    if (argv.files) {
+      config.lintGlobs =
+          config.lintGlobs.filter(e => e !== '**/*.js').concat(argv.files);
+    } else {
+      config.lintGlobs =
+          config.lintGlobs.filter(e => e !== '**/*.js').concat(getLintFiles());
+    }
     // Override .eslintrc settings here.
     options['rules'] = {
       // TODO(rsimha, #15255): Make this error by default in .eslintrc.

--- a/build-system/tasks/lint.js
+++ b/build-system/tasks/lint.js
@@ -157,9 +157,15 @@ function lint() {
         config.lintGlobs.filter(e => e !== '**/*.js').concat(getLintFiles());
     // Override .eslintrc settings here.
     options['rules'] = {
-      // TODO(rsimha, #15255): This should error by default in .eslintrc.
-      'valid-jsdoc': 2,
-      // TODO(jridgewell, #14761): These should error by default in .eslintrc.
+      // TODO(rsimha, #15255): Make this error by default in .eslintrc.
+      'valid-jsdoc': [2, {
+        'prefer': {'return': 'return'},
+        'requireParamDescription': false,
+        'requireReturn': false,
+        'requireReturnType': true,
+        'requireReturnDescription': false,
+      }],
+      // TODO(jridgewell, #14761): Make these error by default in .eslintrc.
       'amphtml-internal/resolve-inside-promise-resolver': 2,
       'amphtml-internal/unused-private-field': 2,
     };

--- a/src/.eslintrc
+++ b/src/.eslintrc
@@ -1,6 +1,5 @@
 {
   "rules": {
-    "amphtml-internal/no-global": 2,
-    "amphtml-internal/vsync": 1
+    "amphtml-internal/no-global": 2
   }
 }


### PR DESCRIPTION
There are upwards of 1300 JSDoc [errors](https://gist.github.com/rsimha/eaad0ef917f0c10dfe000b5d9bcaf698) in the AMP source code. There's no easy way to fix all of them in one go.

This PR changes the way `gulp lint` works during PR checks and when it is run locally via `gulp lint --files` or as part of `gulp pr-check`:
1. During PR checks and local runs of `gulp pr-check`, instead of linting the entire code base, we now lint only the JS files touched by the PR, with file-level [exemptions](https://github.com/ampproject/amphtml/blob/master/build-system/config.js#L121-L133) in place.
2. For the [categories](https://github.com/ampproject/amphtml/pull/15256/files#diff-fcf3705e9a51ecc9ba1c8af1e90b95aeR159) of lint errors that haven't been fully fixed and were therefore only showing as warnings, we now flag errors during PR checks via the rules in `.eslint-strict`.
3. The behavior during push builds remains unchanged.

With this, if someone were to touch a file, they will be required to fix the existing JSDoc errors before `gulp lint` will pass for the PR check. This way, widespread errors in our code will be gradually fixed as more files are touched.

Partial fix for #15255
Required in order to fix #14392 
Required in order to fix #10277
Follow up to #15247