### PR TITLE
Launch amp-fx='fade-in'/'fade-in-scroll'

### DIFF
--- a/extensions/amp-fx-collection/0.1/providers/amp-fx-presets.js
+++ b/extensions/amp-fx-collection/0.1/providers/amp-fx-presets.js
@@ -15,7 +15,6 @@
  */
 
 import {dev, user} from '../../../../src/log';
-import {isExperimentOn} from '../../../../src/experiments';
 import {setStyles} from '../../../../src/style';
 
 export const Presets = {
@@ -67,7 +66,7 @@ export const Presets = {
     },
   },
   'fade-in': {
-    isFxTypeSupported(win) {
+    isFxTypeSupported(unusedWin) {
       return true;
     },
     userAsserts(element) {
@@ -107,7 +106,7 @@ export const Presets = {
     },
   },
   'fade-in-scroll': {
-    isFxTypeSupported(win) {
+    isFxTypeSupported(unusedWin) {
       return true;
     },
     userAsserts(element) {

--- a/extensions/amp-fx-collection/0.1/providers/amp-fx-presets.js
+++ b/extensions/amp-fx-collection/0.1/providers/amp-fx-presets.js
@@ -68,7 +68,7 @@ export const Presets = {
   },
   'fade-in': {
     isFxTypeSupported(win) {
-      return isExperimentOn(win, 'amp-fx-fade-in');
+      return true;
     },
     userAsserts(element) {
       const marginStart = parseFloat(element.getAttribute('data-margin-start'));
@@ -108,7 +108,7 @@ export const Presets = {
   },
   'fade-in-scroll': {
     isFxTypeSupported(win) {
-      return isExperimentOn(win, 'amp-fx-fade-in-scroll');
+      return true;
     },
     userAsserts(element) {
       const marginStart = parseFloat(element.getAttribute('data-margin-start'));

--- a/extensions/amp-fx-collection/0.1/test/integration/test-amp-fx-fade-in-scroll.js
+++ b/extensions/amp-fx-collection/0.1/test/integration/test-amp-fx-fade-in-scroll.js
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import {toggleExperiment} from '../../../../../src/experiments';
-
 const config = describe.configure().ifNewChrome();
 config.run('amp-fx-collection', function() {
   this.timeout(100000);
@@ -54,7 +52,6 @@ config.run('amp-fx-collection', function() {
     let win;
     beforeEach(() => {
       win = env.win;
-      toggleExperiment(win, 'amp-fx-fade-in-scroll', true, false);
     });
 
     it('runs fade-in-scroll animation with default parameters', () => {
@@ -104,7 +101,6 @@ config.run('amp-fx-collection', function() {
     let win;
     beforeEach(() => {
       win = env.win;
-      toggleExperiment(win, 'amp-fx-fade-in-scroll', true, false);
     });
 
     it('runs fade-in-scroll animation with margins specified', () => {
@@ -143,7 +139,6 @@ config.run('amp-fx-collection', function() {
     let win;
     beforeEach(() => {
       win = env.win;
-      toggleExperiment(win, 'amp-fx-fade-in-scroll', true, false);
     });
 
     it('runs fade-in-scroll animation with repeat specified', () => {

--- a/extensions/amp-fx-collection/0.1/test/integration/test-amp-fx-fade-in.js
+++ b/extensions/amp-fx-collection/0.1/test/integration/test-amp-fx-fade-in.js
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import {toggleExperiment} from '../../../../../src/experiments';
-
 const config = describe.configure().ifNewChrome();
 config.run('amp-fx-collection', function() {
   this.timeout(100000);
@@ -54,7 +52,6 @@ config.run('amp-fx-collection', function() {
     let win;
     beforeEach(() => {
       win = env.win;
-      toggleExperiment(win, 'amp-fx-fade-in', true, false);
     });
 
     it('runs fade-in animation with default parameters', () => {
@@ -86,7 +83,6 @@ config.run('amp-fx-collection', function() {
     let win;
     beforeEach(() => {
       win = env.win;
-      toggleExperiment(win, 'amp-fx-fade-in', true, false);
     });
 
     it('margin-start specified', () => {
@@ -118,7 +114,6 @@ config.run('amp-fx-collection', function() {
     let win;
     beforeEach(() => {
       win = env.win;
-      toggleExperiment(win, 'amp-fx-fade-in', true, false);
     });
 
     it('duration specified', () => {

--- a/extensions/amp-fx-collection/0.1/test/test-amp-fx-collection.js
+++ b/extensions/amp-fx-collection/0.1/test/test-amp-fx-collection.js
@@ -16,7 +16,6 @@
 
 import {AmpFxCollection} from '../amp-fx-collection';
 import {createElementWithAttributes} from '../../../../src/dom';
-import {isExperimentOn, toggleExperiment} from '../../../../src/experiments';
 
 describes.realWin('Creates the relevant fx presets correctly', {
   amp: {
@@ -30,8 +29,6 @@ describes.realWin('Creates the relevant fx presets correctly', {
   beforeEach(() => {
     win = env.win;
     ampdoc = env.ampdoc;
-    toggleExperiment(win, 'amp-fx-fade-in', true, false);
-    toggleExperiment(win, 'amp-fx-fade-in-scroll', true, false);
   });
 
   function createAmpFx(fxType, opt_attrs) {
@@ -48,12 +45,10 @@ describes.realWin('Creates the relevant fx presets correctly', {
     expect(ampFx).to.not.be.null;
     expect(ampFx.getFxProvider_()).to.not.be.null;
 
-    expect(isExperimentOn(win, 'amp-fx-fade-in')).to.be.true;
     ampFx = createAmpFx('fade-in');
     expect(ampFx).to.not.be.null;
     expect(ampFx.getFxProvider_()).to.not.be.null;
 
-    expect(isExperimentOn(win, 'amp-fx-fade-in-scroll')).to.be.true;
     ampFx = createAmpFx('fade-in-scroll');
     expect(ampFx).to.not.be.null;
     expect(ampFx.getFxProvider_()).to.not.be.null;

--- a/extensions/amp-fx-collection/amp-fx-collection.md
+++ b/extensions/amp-fx-collection/amp-fx-collection.md
@@ -43,7 +43,7 @@ The `amp-fx-collection` extension provides a collection of preset visual effects
 such as parallax that can be easily enabled on any element via attributes.
 
 Currently, the `parallax` and `fade-in` effects are supported.
-More effects such as `slide-in` are planned to be supported soon.
+More effects such as `fly-in` are planned to be supported soon.
 
 To specify a visual effect for an element, add the `amp-fx` attribute with the value of the visual effect.
 
@@ -79,7 +79,7 @@ In this example, as the user scrolls the page, the h1 element scrolls faster rel
 </h1>
 ```
 
-### fade-in (experimental)
+### fade-in
 
 The `fade-in` effect allows an element to fade in once the element being targetted is visible in the viewport.
 
@@ -124,7 +124,7 @@ In the below example, the animation doesn't start until the element has crossed 
   </div>
 ```
 
-### fade-in-scroll (experimental)
+### fade-in-scroll
 
 The `fade-in-scroll` effect allows you to change the opacity of an element as it scrolls within the viewport. This creates a scroll dependent fade animation. By default once the element is fully visible we don't animate the opacity anymore. 
 

--- a/tools/experiments/experiments.js
+++ b/tools/experiments/experiments.js
@@ -289,18 +289,6 @@ const EXPERIMENTS = [
     cleanupIssue: 'https://github.com/ampproject/amphtml/issues/14263',
   },
   {
-    id: 'amp-fx-fade-in',
-    name: 'Enables amp-fx="fade-in" - scroll triggered timed fade in animation',
-    spec: 'https://github.com/ampproject/amphtml/issues/14150',
-    cleanupIssue: 'https://github.com/ampproject/amphtml/issues/14325',
-  },
-  {
-    id: 'amp-fx-fade-in-scroll',
-    name: 'Enables amp-fx="fade-in-scroll" - a scroll dependent fade animation',
-    spec: 'https://github.com/ampproject/amphtml/issues/14150',
-    cleanupIssue: 'https://github.com/ampproject/amphtml/issues/14325',
-  },
-  {
     id: 'amp-img-native-srcset',
     name: 'Enables native browser implementation of srcset and sizes',
     cleanupIssue: 'https://github.com/ampproject/amphtml/issues/11575',


### PR DESCRIPTION
This turns on `<amp-fx="fade-in">` and `<amp-fx="fade-in-scroll">`. 

Before landing need the following:
- [x] ABE for fade-in-scroll to land: https://github.com/ampproject/amp-by-example/pull/1263
- [x] Code clean up PR to land: https://github.com/ampproject/amphtml/pull/15246
- [x] UX approval