### PR TITLE
Changing the font color depending on the customized background color.

### DIFF
--- a/extensions/amp-story/0.1/amp-story-consent.js
+++ b/extensions/amp-story/0.1/amp-story-consent.js
@@ -286,6 +286,7 @@ export class AmpStoryConsent extends AMP.BaseElement {
   /**
    * Sets the accept button font color to either white or black, depending on
    * the publisher custom background color.
+   * Must be called from the `buildCallback` or in another vsync mutate state.
    * @private
    */
   setAcceptButtonFontColor_() {

--- a/extensions/amp-story/0.1/amp-story-consent.js
+++ b/extensions/amp-story/0.1/amp-story-consent.js
@@ -28,6 +28,7 @@ import {computedStyle, setImportantStyles} from '../../../src/style';
 import {createShadowRootWithStyle} from './utils';
 import {dev, user} from '../../../src/log';
 import {dict} from './../../../src/utils/object';
+import {getRGBFromCssColorValue, getTextColorForRGB} from './utils';
 import {isArray} from '../../../src/types';
 import {parseJson} from '../../../src/json';
 import {renderAsElement} from './simple-template';
@@ -293,28 +294,8 @@ export class AmpStoryConsent extends AMP.BaseElement {
             .querySelector('.i-amphtml-story-consent-action-accept'));
     const styles = computedStyle(this.win, buttonEl);
 
-    const regexPattern = /rgba?\((\d{1,3}), (\d{1,3}), (\d{1,3})/;
-    const matches = regexPattern.exec(styles['background-color']);
-
-    // Calculates the relative luminance L.
-    // https://www.w3.org/TR/2008/REC-WCAG20-20081211/#relativeluminancedef
-    const eightBitToSRGBColorspace = x => {
-      x /= 255;
-      return x <= 0.03928 ? x / 12.92 : Math.pow((x + 0.055) / 1.055, 2.4);
-    };
-
-    const R = eightBitToSRGBColorspace(matches[1]);
-    const G = eightBitToSRGBColorspace(matches[2]);
-    const B = eightBitToSRGBColorspace(matches[3]);
-
-    const L = 0.2126 * R + 0.7152 * G + 0.0722 * B;
-
-    // Determines which one of the white and black text have a better contrast
-    // ratio against the used background color..
-    // https://www.w3.org/TR/2008/REC-WCAG20-20081211/#contrast-ratiodef
-    // 1 is L for #FFF, and 0 is L for #000.
-    // (1 + 0.05) / (L + 0.05) > (L + 0.05) / (0 + 0.05) toggles for L = 0.179.
-    const color = L > 0.179 ? '#000' : '#FFF';
+    const rgb = getRGBFromCssColorValue(styles['background-color']);
+    const color = getTextColorForRGB(rgb);
 
     setImportantStyles(buttonEl, {color});
   }

--- a/extensions/amp-story/0.1/amp-story-consent.js
+++ b/extensions/amp-story/0.1/amp-story-consent.js
@@ -19,8 +19,12 @@ import {CSS} from '../../../build/amp-story-consent-0.1.css';
 import {Layout} from '../../../src/layout';
 import {LocalizedStringId} from './localization';
 import {Services} from '../../../src/services';
-import {childElementByTag} from '../../../src/dom';
-import {closestByTag, isJsonScriptTag} from '../../../src/dom';
+import {
+  childElementByTag,
+  closestByTag,
+  isJsonScriptTag,
+} from '../../../src/dom';
+import {computedStyle, setImportantStyles} from '../../../src/style';
 import {createShadowRootWithStyle} from './utils';
 import {dev, user} from '../../../src/log';
 import {dict} from './../../../src/utils/object';
@@ -184,6 +188,8 @@ export class AmpStoryConsent extends AMP.BaseElement {
       this.actions_.addToWhitelist('AMP-CONSENT.accept');
       this.actions_.addToWhitelist('AMP-CONSENT.reject');
 
+      this.setAcceptButtonFontColor_();
+
       this.initializeListeners_();
     }
   }
@@ -274,5 +280,42 @@ export class AmpStoryConsent extends AMP.BaseElement {
         this.storyConsentConfig_.vendors &&
             isArray(this.storyConsentConfig_.vendors),
         `${TAG}: config requires an array of vendors`);
+  }
+
+  /**
+   * Sets the accept button font color to either white or black, depending on
+   * the publisher custom background color.
+   * @private
+   */
+  setAcceptButtonFontColor_() {
+    const buttonEl =
+        dev().assertElement(this.storyConsentEl_
+            .querySelector('.i-amphtml-story-consent-action-accept'));
+    const styles = computedStyle(this.win, buttonEl);
+
+    const regexPattern = /rgba?\((\d{1,3}), (\d{1,3}), (\d{1,3})/;
+    const matches = regexPattern.exec(styles['background-color']);
+
+    // Calculates the relative luminance L.
+    // https://www.w3.org/TR/2008/REC-WCAG20-20081211/#relativeluminancedef
+    const eightBitToSRGBColorspace = x => {
+      x /= 255;
+      return x <= 0.03928 ? x / 12.92 : Math.pow((x + 0.055) / 1.055, 2.4);
+    };
+
+    const R = eightBitToSRGBColorspace(matches[1]);
+    const G = eightBitToSRGBColorspace(matches[2]);
+    const B = eightBitToSRGBColorspace(matches[3]);
+
+    const L = 0.2126 * R + 0.7152 * G + 0.0722 * B;
+
+    // Determines which one of the white and black text have a better contrast
+    // ratio against the used background color..
+    // https://www.w3.org/TR/2008/REC-WCAG20-20081211/#contrast-ratiodef
+    // 1 is L for #FFF, and 0 is L for #000.
+    // (1 + 0.05) / (L + 0.05) > (L + 0.05) / (0 + 0.05) toggles for L = 0.179.
+    const color = L > 0.179 ? '#000' : '#FFF';
+
+    setImportantStyles(buttonEl, {color});
   }
 }

--- a/extensions/amp-story/0.1/test/test-utils.js
+++ b/extensions/amp-story/0.1/test/test-utils.js
@@ -72,7 +72,7 @@ describes.fakeWin('amp-story utils', {}, () => {
     it('should return a default value if wrong parameters', () => {
       allowConsoleError(() => {
         expect(getRGBFromCssColorValue('who dis'))
-            .to.deep.equal({r:0, g: 0, b: 0});
+            .to.deep.equal({r: 0, g: 0, b: 0});
       });
     });
   });

--- a/extensions/amp-story/0.1/test/test-utils.js
+++ b/extensions/amp-story/0.1/test/test-utils.js
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import {timeStrToMillis} from '../utils';
+import {
+  getRGBFromCssColorValue,
+  getTextColorForRGB,
+  timeStrToMillis,
+} from '../utils';
 
 describes.fakeWin('amp-story utils', {}, () => {
   describe('timeStrToMillis', () => {
@@ -45,6 +49,41 @@ describes.fakeWin('amp-story utils', {}, () => {
     it('should return undefined for invalid types', () => {
       const convertedMillis = timeStrToMillis('10kg');
       expect(convertedMillis).to.be.NaN;
+    });
+  });
+
+  describe('getRGBFromCssColorValue', () => {
+    it('should accept rgb parameters', () => {
+      expect(getRGBFromCssColorValue('rgb(0, 10, 100)'))
+          .to.deep.equal({r: 0, g: 10, b: 100});
+    });
+
+    it('should accept rgba parameters', () => {
+      expect(getRGBFromCssColorValue('rgba(0, 10, 100, 0.1)'))
+          .to.deep.equal({r: 0, g: 10, b: 100});
+    });
+
+    it('should throw an error if wrong parameters', () => {
+      allowConsoleError(() => {
+        getRGBFromCssColorValue('who dis');
+      });
+    });
+
+    it('should return a default value if wrong parameters', () => {
+      allowConsoleError(() => {
+        expect(getRGBFromCssColorValue('who dis'))
+            .to.deep.equal({r:0, g: 0, b: 0});
+      });
+    });
+  });
+
+  describe('getTextColorForRGB', () => {
+    it('should return white for a dark background', () => {
+      expect(getTextColorForRGB({r: 10, g: 10, b: 10})).to.equal('#FFF');
+    });
+
+    it('should return white for a light background', () => {
+      expect(getTextColorForRGB({r: 200, g: 200, b: 200})).to.equal('#000');
     });
   });
 });

--- a/extensions/amp-story/0.1/utils.js
+++ b/extensions/amp-story/0.1/utils.js
@@ -163,6 +163,7 @@ export function getTextColorForRGB({r, g, b}) {
   // Determines which one of the white and black text have a better contrast
   // ratio against the used background color.
   // https://www.w3.org/TR/2008/REC-WCAG20-20081211/#contrast-ratiodef
+  // @TODO(gmajoulet): Improve the text color for high contrast ratio.
   // 1 is L for #FFF, and 0 is L for #000.
   // (1 + 0.05) / (L + 0.05) > (L + 0.05) / (0 + 0.05) toggles for L = 0.179.
   return L > 0.179 ? '#000' : '#FFF';

--- a/extensions/amp-story/0.1/utils.js
+++ b/extensions/amp-story/0.1/utils.js
@@ -106,3 +106,64 @@ export function createShadowRootWithStyle(container, element, css) {
 
   return shadowRoot;
 }
+
+
+/**
+ * Parses the resolved CSS color property, that is always in the form of
+ * `rgba(0, 0, 0, 1)` or `rgb(0, 0, 0)`, that can be retrieved using
+ * `getComputedStyle`.
+ * Returns an object containing the R, G, and B 8bit numbers.
+ * @param  {string} cssValue
+ * @return {!Object<string, number>}
+ */
+export function getRGBFromCssColorValue(cssValue) {
+  const regexPattern = /rgba?\((\d{1,3}), (\d{1,3}), (\d{1,3})/;
+
+  if (!cssValue.match(regexPattern)) {
+    user().error('UTILS', 'getRGBFromCssColorValue expects a parameter in ' +
+        `the form of 'rgba(0, 0, 0, 1)' or 'rgb(0, 0, 0)' but got ${cssValue}`);
+    // Returns a fallback value, to fail 'gracefully' in case a browser we don't
+    // know about gave an unexpected value.
+    return {r: 0, g: 0, b: 0};
+  }
+
+  const matches = regexPattern.exec(cssValue);
+
+  return {
+    r: +matches[1],
+    g: +matches[2],
+    b: +matches[3],
+  };
+}
+
+
+/**
+ * Returns the color, either black or white, that has the best contrast ratio
+ * against the provided RGB 8bit values.
+ * @param  {!Object<string, number>} rgb  ie: {r: 0, g: 0, b: 0}
+ * @return {string} '#fff' or '#000'
+ */
+export function getTextColorForRGB({r, g, b}) {
+  // Calculates the relative luminance L.
+  // https://www.w3.org/TR/2008/REC-WCAG20-20081211/#relativeluminancedef
+  const getLinearRGBValue = x => {
+    // 8bit to sRGB.
+    x /= 255;
+
+    // Converts the gamma-compressed RGB values to linear RGB.
+    return x <= 0.03928 ? x / 12.92 : Math.pow((x + 0.055) / 1.055, 2.4);
+  };
+
+  const linearR = getLinearRGBValue(r);
+  const linearG = getLinearRGBValue(g);
+  const linearB = getLinearRGBValue(b);
+
+  const L = 0.2126 * linearR + 0.7152 * linearG + 0.0722 * linearB;
+
+  // Determines which one of the white and black text have a better contrast
+  // ratio against the used background color.
+  // https://www.w3.org/TR/2008/REC-WCAG20-20081211/#contrast-ratiodef
+  // 1 is L for #FFF, and 0 is L for #000.
+  // (1 + 0.05) / (L + 0.05) > (L + 0.05) / (0 + 0.05) toggles for L = 0.179.
+  return L > 0.179 ? '#000' : '#FFF';
+}

--- a/extensions/amp-story/0.1/utils.js
+++ b/extensions/amp-story/0.1/utils.js
@@ -58,7 +58,7 @@ export function hasTapAction(el) {
 
 /**
  * Calculates a client rect without applying scaling transformations.
- * @note Must be run in a vsync measure context.
+ * Note: must be run in a vsync measure context.
  * @param {!Element} el
  * @return {!ClientRect}
  */
@@ -130,9 +130,9 @@ export function getRGBFromCssColorValue(cssValue) {
   const matches = regexPattern.exec(cssValue);
 
   return {
-    r: +matches[1],
-    g: +matches[2],
-    b: +matches[3],
+    r: Number(matches[1]),
+    g: Number(matches[2]),
+    b: Number(matches[3]),
   };
 }
 

--- a/extensions/amp-story/1.0/amp-story-consent.js
+++ b/extensions/amp-story/1.0/amp-story-consent.js
@@ -286,6 +286,7 @@ export class AmpStoryConsent extends AMP.BaseElement {
   /**
    * Sets the accept button font color to either white or black, depending on
    * the publisher custom background color.
+   * Must be called from the `buildCallback` or in another vsync mutate state.
    * @private
    */
   setAcceptButtonFontColor_() {

--- a/extensions/amp-story/1.0/amp-story-consent.js
+++ b/extensions/amp-story/1.0/amp-story-consent.js
@@ -28,6 +28,7 @@ import {computedStyle, setImportantStyles} from '../../../src/style';
 import {createShadowRootWithStyle} from './utils';
 import {dev, user} from '../../../src/log';
 import {dict} from './../../../src/utils/object';
+import {getRGBFromCssColorValue, getTextColorForRGB} from './utils';
 import {isArray} from '../../../src/types';
 import {parseJson} from '../../../src/json';
 import {renderAsElement} from './simple-template';
@@ -293,28 +294,8 @@ export class AmpStoryConsent extends AMP.BaseElement {
             .querySelector('.i-amphtml-story-consent-action-accept'));
     const styles = computedStyle(this.win, buttonEl);
 
-    const regexPattern = /rgba?\((\d{1,3}), (\d{1,3}), (\d{1,3})/;
-    const matches = regexPattern.exec(styles['background-color']);
-
-    // Calculates the relative luminance L.
-    // https://www.w3.org/TR/2008/REC-WCAG20-20081211/#relativeluminancedef
-    const eightBitToSRGBColorspace = x => {
-      x /= 255;
-      return x <= 0.03928 ? x / 12.92 : Math.pow((x + 0.055) / 1.055, 2.4);
-    };
-
-    const R = eightBitToSRGBColorspace(matches[1]);
-    const G = eightBitToSRGBColorspace(matches[2]);
-    const B = eightBitToSRGBColorspace(matches[3]);
-
-    const L = 0.2126 * R + 0.7152 * G + 0.0722 * B;
-
-    // Determines which one of the white and black text have a better contrast
-    // ratio against the used background color..
-    // https://www.w3.org/TR/2008/REC-WCAG20-20081211/#contrast-ratiodef
-    // 1 is L for #FFF, and 0 is L for #000.
-    // (1 + 0.05) / (L + 0.05) > (L + 0.05) / (0 + 0.05) toggles for L = 0.179.
-    const color = L > 0.179 ? '#000' : '#FFF';
+    const rgb = getRGBFromCssColorValue(styles['background-color']);
+    const color = getTextColorForRGB(rgb);
 
     setImportantStyles(buttonEl, {color});
   }

--- a/extensions/amp-story/1.0/test/test-amp-story-consent.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-consent.js
@@ -15,12 +15,13 @@
  */
 
 import {AmpStoryConsent} from '../amp-story-consent';
-import {Services} from '../../../../src/services';
+import {LocalizationService} from '../localization';
+import {registerServiceBuilder} from '../../../../src/service';
 
-describes.fakeWin('amp-story-consent', {amp: true}, env => {
+describes.realWin('amp-story-consent', {amp: true}, env => {
   let win;
   let defaultConfig;
-  let sandbox;
+  let getComputedStyleStub;
   let storyConsent;
   let storyConsentConfigEl;
   let storyConsentEl;
@@ -31,7 +32,6 @@ describes.fakeWin('amp-story-consent', {amp: true}, env => {
 
   beforeEach(() => {
     win = env.win;
-    sandbox = sinon.sandbox.create();
 
     const consentConfig = {
       consents: {ABC: {}},
@@ -43,9 +43,12 @@ describes.fakeWin('amp-story-consent', {amp: true}, env => {
       vendors: ['Item 1', 'Item 2'],
     };
 
-    sandbox.stub(Services, 'localizationService').returns({
-      getLocalizedString: localizedStringId => `string(${localizedStringId})`,
-    });
+    const styles = {'background-color': 'rgb(0, 0, 0)'};
+    getComputedStyleStub =
+        sandbox.stub(win, 'getComputedStyle').returns(styles);
+
+    const localizationService = new LocalizationService(win);
+    registerServiceBuilder(win, 'localization', () => localizationService);
 
     // Test DOM structure:
     // <fake-amp-consent>
@@ -72,10 +75,6 @@ describes.fakeWin('amp-story-consent', {amp: true}, env => {
     win.document.body.appendChild(consentEl);
 
     storyConsent = new AmpStoryConsent(storyConsentEl);
-  });
-
-  afterEach(() => {
-    sandbox.restore();
   });
 
   it('should parse the config', () => {
@@ -154,5 +153,27 @@ describes.fakeWin('amp-story-consent', {amp: true}, env => {
 
     expect(storyConsent.actions_.trigger).to.have.been.calledOnce;
     expect(storyConsent.actions_.trigger).to.have.been.calledWith(buttonEl);
+  });
+
+  it('should set the font color to black if background is white', () => {
+    const styles = {'background-color': 'rgb(255, 255, 255)'};
+    getComputedStyleStub.returns(styles);
+    storyConsent.buildCallback();
+
+    const buttonEl = storyConsent.storyConsentEl_
+        .querySelector('.i-amphtml-story-consent-action-accept');
+    expect(buttonEl.getAttribute('style'))
+        .to.equal('color: rgb(0, 0, 0) !important;');
+  });
+
+  it('should set the font color to white if background is black', () => {
+    const styles = {'background-color': 'rgba(0, 0, 0, 1)'};
+    getComputedStyleStub.returns(styles);
+    storyConsent.buildCallback();
+
+    const buttonEl = storyConsent.storyConsentEl_
+        .querySelector('.i-amphtml-story-consent-action-accept');
+    expect(buttonEl.getAttribute('style'))
+        .to.equal('color: rgb(255, 255, 255) !important;');
   });
 });

--- a/extensions/amp-story/1.0/test/test-utils.js
+++ b/extensions/amp-story/1.0/test/test-utils.js
@@ -72,7 +72,7 @@ describes.fakeWin('amp-story utils', {}, () => {
     it('should return a default value if wrong parameters', () => {
       allowConsoleError(() => {
         expect(getRGBFromCssColorValue('who dis'))
-            .to.deep.equal({r:0, g: 0, b: 0});
+            .to.deep.equal({r: 0, g: 0, b: 0});
       });
     });
   });

--- a/extensions/amp-story/1.0/test/test-utils.js
+++ b/extensions/amp-story/1.0/test/test-utils.js
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import {timeStrToMillis} from '../utils';
+import {
+  getRGBFromCssColorValue,
+  getTextColorForRGB,
+  timeStrToMillis,
+} from '../utils';
 
 describes.fakeWin('amp-story utils', {}, () => {
   describe('timeStrToMillis', () => {
@@ -45,6 +49,41 @@ describes.fakeWin('amp-story utils', {}, () => {
     it('should return undefined for invalid types', () => {
       const convertedMillis = timeStrToMillis('10kg');
       expect(convertedMillis).to.be.NaN;
+    });
+  });
+
+  describe('getRGBFromCssColorValue', () => {
+    it('should accept rgb parameters', () => {
+      expect(getRGBFromCssColorValue('rgb(0, 10, 100)'))
+          .to.deep.equal({r: 0, g: 10, b: 100});
+    });
+
+    it('should accept rgba parameters', () => {
+      expect(getRGBFromCssColorValue('rgba(0, 10, 100, 0.1)'))
+          .to.deep.equal({r: 0, g: 10, b: 100});
+    });
+
+    it('should throw an error if wrong parameters', () => {
+      allowConsoleError(() => {
+        getRGBFromCssColorValue('who dis');
+      });
+    });
+
+    it('should return a default value if wrong parameters', () => {
+      allowConsoleError(() => {
+        expect(getRGBFromCssColorValue('who dis'))
+            .to.deep.equal({r:0, g: 0, b: 0});
+      });
+    });
+  });
+
+  describe('getTextColorForRGB', () => {
+    it('should return white for a dark background', () => {
+      expect(getTextColorForRGB({r: 10, g: 10, b: 10})).to.equal('#FFF');
+    });
+
+    it('should return white for a light background', () => {
+      expect(getTextColorForRGB({r: 200, g: 200, b: 200})).to.equal('#000');
     });
   });
 });

--- a/extensions/amp-story/1.0/utils.js
+++ b/extensions/amp-story/1.0/utils.js
@@ -163,6 +163,7 @@ export function getTextColorForRGB({r, g, b}) {
   // Determines which one of the white and black text have a better contrast
   // ratio against the used background color.
   // https://www.w3.org/TR/2008/REC-WCAG20-20081211/#contrast-ratiodef
+  // @TODO(gmajoulet): Improve the text color for high contrast ratio.
   // 1 is L for #FFF, and 0 is L for #000.
   // (1 + 0.05) / (L + 0.05) > (L + 0.05) / (0 + 0.05) toggles for L = 0.179.
   return L > 0.179 ? '#000' : '#FFF';

--- a/extensions/amp-story/1.0/utils.js
+++ b/extensions/amp-story/1.0/utils.js
@@ -106,3 +106,64 @@ export function createShadowRootWithStyle(container, element, css) {
 
   return shadowRoot;
 }
+
+
+/**
+ * Parses the resolved CSS color property, that is always in the form of
+ * `rgba(0, 0, 0, 1)` or `rgb(0, 0, 0)`, that can be retrieved using
+ * `getComputedStyle`.
+ * Returns an object containing the R, G, and B 8bit numbers.
+ * @param  {string} cssValue
+ * @return {!Object<string, number>}
+ */
+export function getRGBFromCssColorValue(cssValue) {
+  const regexPattern = /rgba?\((\d{1,3}), (\d{1,3}), (\d{1,3})/;
+
+  if (!cssValue.match(regexPattern)) {
+    user().error('UTILS', 'getRGBFromCssColorValue expects a parameter in ' +
+        `the form of 'rgba(0, 0, 0, 1)' or 'rgb(0, 0, 0)' but got ${cssValue}`);
+    // Returns a fallback value, to fail 'gracefully' in case a browser we don't
+    // know about gave an unexpected value.
+    return {r: 0, g: 0, b: 0};
+  }
+
+  const matches = regexPattern.exec(cssValue);
+
+  return {
+    r: +matches[1],
+    g: +matches[2],
+    b: +matches[3],
+  };
+}
+
+
+/**
+ * Returns the color, either black or white, that has the best contrast ratio
+ * against the provided RGB 8bit values.
+ * @param  {!Object<string, number>} rgb  ie: {r: 0, g: 0, b: 0}
+ * @return {string} '#fff' or '#000'
+ */
+export function getTextColorForRGB({r, g, b}) {
+  // Calculates the relative luminance L.
+  // https://www.w3.org/TR/2008/REC-WCAG20-20081211/#relativeluminancedef
+  const getLinearRGBValue = x => {
+    // 8bit to sRGB.
+    x /= 255;
+
+    // Converts the gamma-compressed RGB values to linear RGB.
+    return x <= 0.03928 ? x / 12.92 : Math.pow((x + 0.055) / 1.055, 2.4);
+  };
+
+  const linearR = getLinearRGBValue(r);
+  const linearG = getLinearRGBValue(g);
+  const linearB = getLinearRGBValue(b);
+
+  const L = 0.2126 * linearR + 0.7152 * linearG + 0.0722 * linearB;
+
+  // Determines which one of the white and black text have a better contrast
+  // ratio against the used background color.
+  // https://www.w3.org/TR/2008/REC-WCAG20-20081211/#contrast-ratiodef
+  // 1 is L for #FFF, and 0 is L for #000.
+  // (1 + 0.05) / (L + 0.05) > (L + 0.05) / (0 + 0.05) toggles for L = 0.179.
+  return L > 0.179 ? '#000' : '#FFF';
+}

--- a/extensions/amp-story/1.0/utils.js
+++ b/extensions/amp-story/1.0/utils.js
@@ -58,7 +58,7 @@ export function hasTapAction(el) {
 
 /**
  * Calculates a client rect without applying scaling transformations.
- * @note Must be run in a vsync measure context.
+ * Note: must be run in a vsync measure context.
  * @param {!Element} el
  * @return {!ClientRect}
  */
@@ -130,9 +130,9 @@ export function getRGBFromCssColorValue(cssValue) {
   const matches = regexPattern.exec(cssValue);
 
   return {
-    r: +matches[1],
-    g: +matches[2],
-    b: +matches[3],
+    r: Number(matches[1]),
+    g: Number(matches[2]),
+    b: Number(matches[3]),
   };
 }
 


### PR DESCRIPTION
Changes the font color for the ``amp-story-consent`` component accept button based on its customizable background color.

Uses the [relative luminance](https://www.w3.org/TR/2008/REC-WCAG20-20081211/#relativeluminancedef) and [contrast ratio](https://www.w3.org/TR/2008/REC-WCAG20-20081211/#contrast-ratiodef) formulas to determine which one of black or white text have the best contrast ratio.

To retrieve the actual background color of the button, I used the ``computedStyle`` function, that always retrieve the ``background-color`` in the form of ``rgba(0, 0, 0, 1)`` or ``rgb(0, 0, 0)``. I used [this snippet](https://codepen.io/gmajoulet/pen/NMBXNv) to make sure it works consistently across browsers (Android / iOS / Safari / Chrome / Firefox).

Related to #14538