### PR TITLE
🏗Add a mechanism to disable strict linting during PR checks

### DIFF
--- a/build-system/tasks/lint.js
+++ b/build-system/tasks/lint.js
@@ -158,9 +158,13 @@ function lint() {
       config.lintGlobs =
           config.lintGlobs.filter(e => e !== '**/*.js').concat(getLintFiles());
     }
-    // TODO(#14761, #15255): Remove these overrides and make the rules errors by
-    // default in .eslintrc after all code is fixed.
-    options['configFile'] = '.eslintrc-strict';
+    log('TRAVIS_COMMIT_MESSAGE: ' + process.env.TRAVIS_COMMIT_MESSAGE);
+    if (!process.env.TRAVIS ||
+        !process.env.TRAVIS_COMMIT_MESSAGE.includes('[disable strict lint]')) {
+      // TODO(#14761, #15255): Remove these overrides and make the rules errors
+      // by default in .eslintrc after all code is fixed.
+      options['configFile'] = '.eslintrc-strict';
+    }
   }
   const stream = initializeStream(config.lintGlobs, {});
   return runLinter('.', stream, options);


### PR DESCRIPTION
This PR adds a mechanism to disable strict linting during PR checks. Useful when you're refactoring code and end up editing a large number of files.

Note: If `process.env.TRAVIS_COMMIT_MESSAGE` doesn't work, we'll need to come up with a different way to disable strict linting, say by counting the number of files being edited and going back to warning mode if it's more than a certain number.

Follow up to #15256