### PR TITLE
🏗 Use `eslint-plugin-jsdoc` instead of the built in `valid-jsdoc`

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,6 +4,7 @@
     "chai-expect",
     "eslint-plugin-amphtml-internal",
     "eslint-plugin-google-camelcase",
+    "jsdoc",
     "sort-imports-es6-autofix",
     "sort-requires"
   ],
@@ -32,6 +33,13 @@
     "global": false,
     "describes": true,
     "allowConsoleError": false
+  },
+  "settings": {
+      "jsdoc": {
+          "tagNamePreference": {
+              "returns": "return"
+          }
+      }
   },
   "rules": {
     "amphtml-internal/closure-type-primitives": 2,
@@ -63,6 +71,13 @@
     "eol-last": 2,
     "google-camelcase/google-camelcase": 2,
     "indent": [2, 2, { "SwitchCase": 1, "VariableDeclarator": 2, "MemberExpression": 2, "ObjectExpression": 1, "CallExpression": { "arguments": 2 } }],
+    "jsdoc/check-param-names": 1,
+    "jsdoc/check-tag-names": 1,
+    "jsdoc/check-types": 0,
+    "jsdoc/require-param": 1,
+    "jsdoc/require-param-name": 1,
+    "jsdoc/require-param-type": 1,
+    "jsdoc/require-returns-type": 1,
     "key-spacing": 2,
     "max-len": [2, 80, 4, {
       "ignoreTrailingComments": true,
@@ -123,13 +138,6 @@
     "space-in-parens": 2,
     "space-infix-ops": 2,
     "space-unary-ops": [1, { "words": true, "nonwords": false }],
-    "valid-jsdoc": [1, {
-      "prefer": {"return": "return"},
-      "requireParamDescription": false,
-      "requireReturn": false,
-      "requireReturnType": true,
-      "requireReturnDescription": false
-    }],
     "wrap-iife": [2, "any"]
   }
 }

--- a/.eslintrc-strict
+++ b/.eslintrc-strict
@@ -3,12 +3,12 @@
     "amphtml-internal/resolve-inside-promise-resolver": 2,
     "amphtml-internal/unused-private-field": 2,
     "amphtml-internal/vsync": 2,
-    "valid-jsdoc": [2, {
-      "prefer": {"return": "return"},
-      "requireParamDescription": false,
-      "requireReturn": false,
-      "requireReturnType": true,
-      "requireReturnDescription": false
-    }]
+    "jsdoc/check-param-names": 2,
+    "jsdoc/check-tag-names": 2,
+    "jsdoc/check-types": 0,
+    "jsdoc/require-param": 2,
+    "jsdoc/require-param-name": 2,
+    "jsdoc/require-param-type": 2,
+    "jsdoc/require-returns-type": 2
   }
 }

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "eslint-plugin-amphtml-internal": "file:build-system/eslint-rules",
     "eslint-plugin-chai-expect": "1.1.1",
     "eslint-plugin-google-camelcase": "0.0.2",
+    "eslint-plugin-jsdoc": "3.6.3",
     "eslint-plugin-sort-imports-es6-autofix": "0.3.0",
     "eslint-plugin-sort-requires": "2.1.0",
     "esprima": "4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2392,6 +2392,12 @@ commander@~2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.1.0.tgz#d121bbae860d9992a3d517ba96f56588e47c6781"
 
+comment-parser@^0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/comment-parser/-/comment-parser-0.4.2.tgz#fa5a3f78013070114866dc7b8e9cf317a9635f74"
+  dependencies:
+    readable-stream "^2.0.4"
+
 common-path-prefix@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/common-path-prefix/-/common-path-prefix-1.0.0.tgz#cd52f6f0712e0baab97d6f9732874f22f47752c0"
@@ -3567,6 +3573,14 @@ eslint-plugin-chai-expect@1.1.1:
 eslint-plugin-google-camelcase@0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-google-camelcase/-/eslint-plugin-google-camelcase-0.0.2.tgz#0c27555e4782073442d034a3db1f214ee0b37401"
+
+eslint-plugin-jsdoc@3.6.3:
+  version "3.6.3"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-3.6.3.tgz#8ac4b962964c2893fb0f58c621904203f07bd462"
+  dependencies:
+    comment-parser "^0.4.2"
+    jsdoctypeparser "^2.0.0-alpha-8"
+    lodash "^4.17.4"
 
 eslint-plugin-sort-imports-es6-autofix@0.3.0:
   version "0.3.0"
@@ -6049,6 +6063,10 @@ js-yaml@~3.7.0:
 jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
+
+jsdoctypeparser@^2.0.0-alpha-8:
+  version "2.0.0-alpha-8"
+  resolved "https://registry.yarnpkg.com/jsdoctypeparser/-/jsdoctypeparser-2.0.0-alpha-8.tgz#baf137fb8e2a558810adcf19d2d2a2f680e90a5f"
 
 jsdom@11.10.0:
   version "11.10.0"
@@ -8564,6 +8582,10 @@ process-nextick-args@^1.0.6, process-nextick-args@~1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
 
+process-nextick-args@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
+
 process@^0.11.1, process@~0.11.0:
   version "0.11.10"
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
@@ -8981,6 +9003,18 @@ readable-stream@2, readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stre
     inherits "~2.0.1"
     isarray "0.0.1"
     string_decoder "~0.10.x"
+
+readable-stream@^2.0.4:
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.3"
+    isarray "~1.0.0"
+    process-nextick-args "~2.0.0"
+    safe-buffer "~5.1.1"
+    string_decoder "~1.1.1"
+    util-deprecate "~1.0.1"
 
 readable-stream@~2.0.0, readable-stream@~2.0.5:
   version "2.0.6"
@@ -10170,7 +10204,7 @@ string-width@^2.0.0, string-width@^2.1.0, string-width@^2.1.1:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
 
-string_decoder@^1.1.1:
+string_decoder@^1.1.1, string_decoder@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
   dependencies:


### PR DESCRIPTION
The `valid-jsdoc` rule built in to `eslint` (we started using it in #15256) has a few problems:

- Complains about return types when run against interfaces (#15293)
- Complains about syntax errors with type names that are from relative paths (#15295)
- Complains about syntax errors with type names that are function types (#15296)

This PR does the following:
- Mitigates the problems above by using `eslint-plugin-jsdoc`, which is more sophisticated than the built in `valid-jsdoc`. See https://github.com/gajus/eslint-plugin-jsdoc
- Fixes [the case](https://travis-ci.org/ampproject/amphtml/jobs/379014493#L649) where `eslint` was being executed on an empty glob when there are no `.js` files in the PR / commit being tested.

Fixes #15293
Fixes #15295
Fixes #15296

Follow up to #15256
