### PR TITLE
🏗 Refactor `lint.js` and update `jsdoc/check-tag-names` rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -35,11 +35,24 @@
     "allowConsoleError": false
   },
   "settings": {
-      "jsdoc": {
-          "tagNamePreference": {
-              "returns": "return"
-          }
+    "jsdoc": {
+      "tagNamePreference": {
+        "returns": "return",
+        "constant": "const"
+      },
+      "additionalTagNames": {
+        "customTags": [
+          "deprecated",
+          "export",
+          "final",
+          "package",
+          "restricted",
+          "suppress",
+          "template",
+          "visibleForTesting"
+        ]
       }
+    }
   },
   "rules": {
     "amphtml-internal/closure-type-primitives": 2,

--- a/build-system/tasks/lint.js
+++ b/build-system/tasks/lint.js
@@ -132,12 +132,45 @@ function runLinter(path, stream, options) {
  *
  * @return {!Array<string>}
  */
-function filesInPr() {
+function jsFilesInPr() {
   const filesInPr =
         getStdout('git diff --name-only master...HEAD').trim().split('\n');
   return filesInPr.filter(function(file) {
     return path.extname(file) == '.js';
   });
+}
+
+/**
+ * Checks if there are .eslintrc changes in this PR, in which case we must lint
+ * all files.
+ *
+ * @return {boolean}
+ */
+function eslintrcChangesInPr() {
+  const filesInPr =
+        getStdout('git diff --name-only master...HEAD').trim().split('\n');
+  return filesInPr.filter(function(file) {
+    return path.basename(file).includes('.eslintrc');
+  }).length > 0;
+}
+
+/**
+ * Sets the list of files to be linted.
+ *
+ * @param {!Array<string>} files
+ */
+function setFiles(files) {
+  config.lintGlobs =
+      config.lintGlobs.filter(e => e !== '**/*.js').concat(files);
+}
+
+/**
+ * Enables linting in strict mode.
+ */
+function enableStrictMode() {
+  // TODO(#14761, #15255): Remove these overrides and make the rules errors by
+  // default in .eslintrc after all code is fixed.
+  options['configFile'] = '.eslintrc-strict';
 }
 
 /**
@@ -148,25 +181,20 @@ function lint() {
   if (argv.fix) {
     options.fix = true;
   }
-  if (argv.files ||
-      process.env.TRAVIS_EVENT_TYPE == 'pull_request' ||
-      process.env.LOCAL_PR_CHECK) {
-    if (argv.files) {
-      config.lintGlobs =
-          config.lintGlobs.filter(e => e !== '**/*.js').concat(argv.files);
+  if (argv.files) {
+    setFiles(argv.files);
+    enableStrictMode();
+  } else if (!eslintrcChangesInPr() &&
+      (process.env.TRAVIS_EVENT_TYPE == 'pull_request' ||
+       process.env.LOCAL_PR_CHECK)) {
+    const jsFiles = jsFilesInPr();
+    if (jsFiles.length == 0) {
+      log(colors.green('INFO: ') + 'No JS files in this PR.');
+      return Promise.resolve();
     } else {
-      const files = filesInPr();
-      if (files.length == 0) {
-        log(colors.green('INFO: ') + 'No JS files in this PR.');
-        return Promise.resolve();
-      } else {
-        config.lintGlobs =
-            config.lintGlobs.filter(e => e !== '**/*.js').concat(files);
-      }
+      setFiles(jsFiles);
+      enableStrictMode();
     }
-    // TODO(#14761, #15255): Remove these overrides and make the rules errors by
-    // default in .eslintrc after all code is fixed.
-    options['configFile'] = '.eslintrc-strict';
   }
   const stream = initializeStream(config.lintGlobs, {});
   return runLinter('.', stream, options);

--- a/build-system/tasks/lint.js
+++ b/build-system/tasks/lint.js
@@ -29,7 +29,7 @@ const path = require('path');
 const watch = require('gulp-watch');
 
 const isWatching = (argv.watch || argv.w) || false;
-
+const filesInARefactorPr = 15;
 const options = {
   fix: false,
 };
@@ -191,6 +191,9 @@ function lint() {
     if (jsFiles.length == 0) {
       log(colors.green('INFO: ') + 'No JS files in this PR.');
       return Promise.resolve();
+    } else if (jsFiles.length > filesInARefactorPr) {
+      // This is probably a refactor, don't enable strict mode.
+      setFiles(jsFiles);
     } else {
       setFiles(jsFiles);
       enableStrictMode();

--- a/build-system/tasks/lint.js
+++ b/build-system/tasks/lint.js
@@ -33,6 +33,7 @@ const filesInARefactorPr = 15;
 const options = {
   fix: false,
 };
+let collapseLintResults = !!process.env.TRAVIS;
 
 /**
  * Checks if current Vinyl file has been fixed by eslint.
@@ -83,8 +84,8 @@ function runLinter(path, stream, options) {
   if (!process.env.TRAVIS) {
     log(colors.green('Starting linter...'));
   }
-  if (process.env.TRAVIS_EVENT_TYPE == 'push') {
-    // TODO(jridgewell, #14761): Remove log folding after #14761 is fixed.
+  if (collapseLintResults) {
+    // TODO(#15255, #14761): Remove log folding after warnings are fixed.
     log(colors.bold(colors.yellow('Lint results: ')) + 'Expand this section');
     console./* OK*/log('travis_fold:start:lint_results\n');
   }
@@ -99,8 +100,8 @@ function runLinter(path, stream, options) {
         }
       }))
       .pipe(eslint.results(function(results) {
-        // TODO(jridgewell, #14761): Remove log folding after #14761 is fixed.
-        if (process.env.TRAVIS_EVENT_TYPE == 'push') {
+        // TODO(#15255, #14761): Remove log folding after warnings are fixed.
+        if (collapseLintResults) {
           console./* OK*/log('travis_fold:end:lint_results');
         }
         if (results.errorCount == 0 && results.warningCount == 0) {
@@ -171,6 +172,7 @@ function enableStrictMode() {
   // TODO(#14761, #15255): Remove these overrides and make the rules errors by
   // default in .eslintrc after all code is fixed.
   options['configFile'] = '.eslintrc-strict';
+  collapseLintResults = false;
 }
 
 /**


### PR DESCRIPTION
This PR:
1. [Exempts](https://github.com/rsimha/amphtml/blob/53e835949fb20c833a60bd4d0efd57caeaa991c7/.eslintrc#L37-L56) well known closure tags and custom JSDoc tags from the `jsdoc/check-tag-names` rule
2. Refactors the logic in `lint.js` so that:
    - All JS files are linted in warning mode when `.eslintrc` is changed
    - Only the JS files in the PR are linted in warning mode when more than 15 files are changed at a time (probably a refactor, see #15291)
    - Lint results are collapsed on Travis when a large number of files are linted (the logs are copious)

Follow up to #15294 
Follow up to #15256
Partial fix for #15255