### PR TITLE
✨Add support for noConfigReason messages in <amp-auto-ads>.

### DIFF
--- a/extensions/amp-auto-ads/0.1/amp-auto-ads.js
+++ b/extensions/amp-auto-ads/0.1/amp-auto-ads.js
@@ -60,6 +60,11 @@ export class AmpAutoAds extends AMP.BaseElement {
       if (!configObj) {
         return;
       }
+      const noConfigReason = configObj['noConfigReason'];
+      if (noConfigReason) {
+        this.user().warn(TAG, noConfigReason);
+        return;
+      }
 
       const placements = getPlacementsFromConfigObj(ampdoc, configObj);
       const attributes = /** @type {!JsonObject} */ (


### PR DESCRIPTION
This feature allows ad servers to return a message that contains reason why server didn't return config for auto ads. For example if publisher didn't enable auto ads on ad server then the message might contain info like "Auto ads not enabled for publisher XYZ. To enable Auto ads follow instructions on xyz.com". 