### PR TITLE
amp-consent: Improve console messages

### DIFF
--- a/extensions/amp-consent/0.1/amp-consent.js
+++ b/extensions/amp-consent/0.1/amp-consent.js
@@ -319,7 +319,7 @@ export class AmpConsent extends AMP.BaseElement {
     user().assert(config['checkConsentHref'] ||
         config['promptIfUnknownForGeoGroup'],
     'neither checkConsentHref nor ' +
-    'promptIfUnknownForGeoGroup is defined');
+    'promptIfUnknownForGeoGroup is defined in amp-consent tag');
     let remoteConfigPromise = Promise.resolve(null);
     if (config['checkConsentHref']) {
       remoteConfigPromise = this.getConsentRemote_(instanceId);
@@ -362,8 +362,8 @@ export class AmpConsent extends AMP.BaseElement {
    */
   isConsentRequiredGeo_(geoGroup) {
     return Services.geoForOrNull(this.win).then(geo => {
-      user().assert(geo,
-          'requires <amp-geo> to use promptIfUnknownForGeoGroup');
+      user().assert(geo, '<amp-geo> must be defined when using the ' +
+        'promptIfUnknownForGeoGroup attribute in <amp-consent>');
       return (geo.ISOCountryGroups.indexOf(geoGroup) >= 0);
     });
   }
@@ -448,7 +448,7 @@ export class AmpConsent extends AMP.BaseElement {
         `${TAG} should have (only) one <script> child`);
     const script = scripts[0];
     user().assert(isJsonScriptTag(script),
-        `${TAG} consent instance config should be put in a <script>` +
+        `${TAG} consent instance config should be put in a <script> ` +
         'tag with type= "application/json"');
     const config = parseJson(script.textContent);
     const consents = config['consents'];
@@ -464,7 +464,7 @@ export class AmpConsent extends AMP.BaseElement {
         const keys = Object.keys(config['policy']);
         for (let i = 0; i < keys.length; i++) {
           if (keys[i] != 'default') {
-            user().warn(TAG, `policy ${keys[i]} is currently not supported` +
+            user().warn(TAG, `policy ${keys[i]} is currently not supported ` +
               'and will be ignored');
             delete config['policy'][keys[i]];
           }

--- a/extensions/amp-consent/0.1/consent-policy-manager.js
+++ b/extensions/amp-consent/0.1/consent-policy-manager.js
@@ -139,8 +139,8 @@ export class ConsentPolicyManager {
     if (!isExperimentOn(this.ampdoc_.win, MULTI_CONSENT_EXPERIMENT)) {
       // If customized policy is not supported
       if (policyId != 'default') {
-        user().error(TAG, 'can not find policy, do not set value to ' +
-            'data-block-on-consent');
+        user().error(TAG, `cannot find policy ${policyId}, do not set value ` +
+            'to data-block-on-consent');
         return Promise.resolve(CONSENT_POLICY_STATE.UNKNOWN);
       }
     }

--- a/extensions/amp-consent/0.1/consent-policy-manager.js
+++ b/extensions/amp-consent/0.1/consent-policy-manager.js
@@ -139,8 +139,8 @@ export class ConsentPolicyManager {
     if (!isExperimentOn(this.ampdoc_.win, MULTI_CONSENT_EXPERIMENT)) {
       // If customized policy is not supported
       if (policyId != 'default') {
-        user().error(TAG, `cannot find policy ${policyId}, do not set value ` +
-            'to data-block-on-consent');
+        user().error(TAG, `cannot find policy ${policyId}, do not set a ` +
+            'value for data-block-on-consent');
         return Promise.resolve(CONSENT_POLICY_STATE.UNKNOWN);
       }
     }

--- a/extensions/amp-consent/0.1/test/test-amp-consent.js
+++ b/extensions/amp-consent/0.1/test/test-amp-consent.js
@@ -233,7 +233,7 @@ describes.realWin('amp-consent', {
       expect(ampConsent.consentRequired_['ABC']).to.equal(false);
     });
 
-    it('promptIfUnknow override geo', function* () {
+    it('promptIfUnknown override geo', function* () {
       ISOCountryGroups = ['unknown'];
       defaultConfig = {
         'consents': {
@@ -251,7 +251,7 @@ describes.realWin('amp-consent', {
       expect(ampConsent.consentRequired_['ABC']).to.equal(true);
     });
 
-    it('promptIfUnknow override geo with false value', function* () {
+    it('promptIfUnknown override geo with false value', function* () {
       ISOCountryGroups = ['unknown'];
       defaultConfig = {
         'consents': {
@@ -269,7 +269,7 @@ describes.realWin('amp-consent', {
       expect(ampConsent.consentRequired_['ABC']).to.equal(false);
     });
 
-    it('checkConsentHref w/o promptIfUnknow not override geo', function* () {
+    it('checkConsentHref w/o promptIfUnknown not override geo', function* () {
       ISOCountryGroups = ['testGroup'];
       defaultConfig = {
         'consents': {

--- a/extensions/amp-consent/amp-consent.md
+++ b/extensions/amp-consent/amp-consent.md
@@ -296,7 +296,7 @@ Right now only customizing the `default` policy instance is supported. The "defa
 #### timeout (optional)
 `timeout` can be used to inform components the current consent state status after specified time.
 
-When used as a single value, `timeout` equals the timeout value in second.
+When used as a single value, `timeout` equals the timeout value in seconds.
 
 ```html
   "default": {
@@ -308,7 +308,7 @@ When used as a single value, `timeout` equals the timeout value in second.
 ```
 
 When used as an object. `timeout` object supports two attributes
-* `seconds`: timeout value in second
+* `seconds`: timeout value in seconds
 * `fallbackAction` (optional): the fallback action at timeout if no user action is taken and no state has been stored. The fallback actions supported are `reject` and `dismiss`. Default action is `dismiss` if not configured. Note the consent state changed due to fallback action at timeout will not be stored on client side.
 
 ```html


### PR DESCRIPTION
Improves console warnings that were unclear or didn't provide adequate context. Also fixes minor spacing issues for the same.

