### PR TITLE
Temporarily downgrade `jsdoc/require-param` to warning mode

### DIFF
--- a/.eslintrc-strict
+++ b/.eslintrc-strict
@@ -6,7 +6,7 @@
     "jsdoc/check-param-names": 2,
     "jsdoc/check-tag-names": 2,
     "jsdoc/check-types": 0,
-    "jsdoc/require-param": 2,
+    "jsdoc/require-param": 1,
     "jsdoc/require-param-name": 2,
     "jsdoc/require-param-type": 2,
     "jsdoc/require-returns-type": 2

--- a/build-system/tasks/lint.js
+++ b/build-system/tasks/lint.js
@@ -166,7 +166,10 @@ function eslintrcChangesInPr() {
 function setFilesToLint(files) {
   config.lintGlobs =
       config.lintGlobs.filter(e => e !== '**/*.js').concat(files);
-  log(colors.green('INFO: ') + 'Running lint on ' + colors.cyan(files));
+  if (!process.env.TRAVIS) {
+    log(colors.green('INFO: ') + 'Running lint on ' +
+        colors.cyan(files.join(',')));
+  }
 }
 
 /**


### PR DESCRIPTION
As described in #15297, the [Google JS style guide](https://google.github.io/styleguide/jsguide.html): clearly prefers `@override` over `@inheritdoc`.

From [here](https://google.github.io/styleguide/jsguide.html#features-functions-parameters):

> Function parameters must be typed with JSDoc annotations in the JSDoc preceding the function’s definition, except in the case of same-signature `@override`s, where all types are omitted.

From [here](https://google.github.io/styleguide/jsguide.html#jsdoc-method-and-function-comments):

> Overridden methods must include all `@param` and `@return` annotations if any types are refined, but should omit them if the types are all the same.

And from [here](https://google.github.io/styleguide/jsguide.html#appendices-notes-about-standard-closure-compiler-annotations):

> `@inheritDoc` | Deprecated. Do not use. Use `@override` instead.

However, the source code of the `jsdoc/require-param` rule [clearly shows](https://github.com/gajus/eslint-plugin-jsdoc/blob/master/src/rules/requireParam.js#L11-L14) that it only exempts `@inheritdoc` tags from having `@param`.

This PR temporarily mitigates #15297 while we pursue a fix via https://github.com/gajus/eslint-plugin-jsdoc/issues/73
