### PR TITLE
📖 JSDoc: Use @return instead of @returns

### DIFF
--- a/3p/ampcontext.js
+++ b/3p/ampcontext.js
@@ -148,7 +148,7 @@ export class AbstractAmpContext {
    *  Listen to page visibility changes.
    *  @param {function({hidden: boolean})} callback Function to call every time
    *    we receive a page visibility message.
-   *  @returns {function()} that when called stops triggering the callback
+   *  @return {function()} that when called stops triggering the callback
    *    every time we receive a page visibility message.
    */
   onPageVisibilityChange(callback) {
@@ -161,7 +161,7 @@ export class AbstractAmpContext {
    *  Send message to runtime to start sending intersection messages.
    *  @param {function(Array<Object>)} callback Function to call every time we
    *    receive an intersection message.
-   *  @returns {function()} that when called stops triggering the callback
+   *  @return {function()} that when called stops triggering the callback
    *    every time we receive an intersection message.
    */
   observeIntersection(callback) {

--- a/3p/iframe-transport-client.js
+++ b/3p/iframe-transport-client.js
@@ -86,7 +86,7 @@ export class IframeTransportClient {
    * Retrieves/creates a context object to pass events pertaining to a
    * particular creative.
    * @param {string} creativeId The ID of the creative
-   * @returns {!IframeTransportContext}
+   * @return {!IframeTransportContext}
    * @private
    */
   contextFor_(creativeId) {
@@ -98,7 +98,7 @@ export class IframeTransportClient {
 
   /**
    * Gets the IframeMessagingClient.
-   * @returns {!IframeMessagingClient}
+   * @return {!IframeMessagingClient}
    * @VisibleForTesting
    */
   getIframeMessagingClient() {

--- a/ads/google/a4a/performance.js
+++ b/ads/google/a4a/performance.js
@@ -198,7 +198,7 @@ export class GoogleAdLifecycleReporter extends BaseLifecycleReporter {
 
   /**
    * @param {string} name  Metric name to send.
-   * @returns {string}  URL to send metrics to.
+   * @return {string}  URL to send metrics to.
    * @private
    */
   buildPingAddress_(name) {

--- a/ads/google/a4a/traffic-experiments.js
+++ b/ads/google/a4a/traffic-experiments.js
@@ -234,7 +234,7 @@ function maybeSetExperimentFromUrl(win, element, experimentName,
  * that, use validateExperimentIds.
  *
  * @param {?string} idString  String to parse.
- * @returns {!Array<string>}  List of experiment IDs (possibly empty).
+ * @return {!Array<string>}  List of experiment IDs (possibly empty).
  * @see validateExperimentIds
  */
 export function parseExperimentIds(idString) {
@@ -268,7 +268,7 @@ export function isInExperiment(element, id) {
  * #maybeSetExperimentFromUrl has added it).
  *
  * @param {!Element} element  Element to check for manual experiment membership.
- * @returns {boolean}
+ * @return {boolean}
  */
 export function isInManualExperiment(element) {
   return isInExperiment(element, MANUAL_EXPERIMENT_ID);
@@ -282,7 +282,7 @@ export function isInManualExperiment(element) {
  *
  * @param {!Window} win  Host window for the ad.
  * @param {!Element} element  Element to check for pre-launch membership.
- * @returns {boolean}
+ * @return {boolean}
  */
 export function hasLaunched(win, element) {
   switch (element.getAttribute('type')) {
@@ -300,7 +300,7 @@ export function hasLaunched(win, element) {
  * (integer base 10).
  *
  * @param {!Array<string>} idList  List of experiment IDs.  Can be empty.
- * @returns {boolean} Whether all list elements are valid experiment IDs.
+ * @return {boolean} Whether all list elements are valid experiment IDs.
  */
 export function validateExperimentIds(idList) {
   return idList.every(id => { return !isNaN(parseInt(id, 10)); });

--- a/ads/google/a4a/utils.js
+++ b/ads/google/a4a/utils.js
@@ -112,7 +112,7 @@ function getNavStart(win) {
  * dev mode.
  *
  * @param {!Window} win  Host window for the ad.
- * @returns {boolean}  Whether Google Ads should attempt to render via the A4A
+ * @return {boolean}  Whether Google Ads should attempt to render via the A4A
  *   pathway.
  */
 export function isGoogleAdsA4AValidEnvironment(win) {
@@ -126,7 +126,7 @@ export function isGoogleAdsA4AValidEnvironment(win) {
 /**
  * Checks whether native crypto is supported for win.
  * @param {!Window} win  Host window for the ad.
- * @returns {boolean} Whether native crypto is supported.
+ * @return {boolean} Whether native crypto is supported.
  */
 export function supportsNativeCrypto(win) {
   return win.crypto && (win.crypto.subtle || win.crypto.webkitSubtle);
@@ -619,7 +619,7 @@ export function extractAmpAnalyticsConfig(a4a, responseHeaders) {
  *     integer (base 10) experiment IDs.
  * @param {?string} currentIdString  If present, a string containing a
  *   comma-separated list of integer experiment IDs.
- * @returns {string}  New experiment list string, including newId iff it is
+ * @return {string}  New experiment list string, including newId iff it is
  *   a valid (integer) experiment ID.
  * @see parseExperimentIds, validateExperimentIds
  */

--- a/ads/inabox/position-observer.js
+++ b/ads/inabox/position-observer.js
@@ -80,7 +80,7 @@ export class PositionObserver {
 
   /**
    * @param element {!Element}
-   * @returns {!PositionEntryDef}
+   * @return {!PositionEntryDef}
    * @private
    */
   getPositionEntry_(element) {
@@ -112,7 +112,7 @@ export class PositionObserver {
 
 /**
  * @param win {!Window}
- * @returns {!Element}
+ * @return {!Element}
  */
 function getScrollingElement(win) {
   const doc = win.document;

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -217,7 +217,7 @@ function isFlagConfig(filePath) {
  * Determines the targets that will be executed by the main method of
  * this script. The order within this function matters.
  * @param {!Array<string>} filePaths
- * @returns {!Set<string>}
+ * @return {!Set<string>}
  */
 function determineBuildTargets(filePaths) {
   if (filePaths.length == 0) {
@@ -513,7 +513,7 @@ function isGreenkeeperLockfilePushBuild() {
 /**
  * The main method for the script execution which much like a C main function
  * receives the command line arguments and returns an exit status.
- * @returns {number}
+ * @return {number}
  */
 function main() {
   const startTime = startTimer('pr-check.js');

--- a/builtins/amp-pixel.js
+++ b/builtins/amp-pixel.js
@@ -115,7 +115,7 @@ export class AmpPixel extends BaseElement {
 /**
  * @param {!Element} parentElement
  * @param {string} src
- * @returns {!Element}
+ * @return {!Element}
  */
 function createNoReferrerPixel(parentElement, src) {
   if (isReferrerPolicySupported()) {
@@ -138,7 +138,7 @@ function createNoReferrerPixel(parentElement, src) {
  * @param {!Window} win
  * @param {string} src
  * @param {boolean=} noReferrer
- * @returns {!Image}
+ * @return {!Image}
  */
 function createImagePixel(win, src, noReferrer) {
   const image = new win.Image();
@@ -153,7 +153,7 @@ function createImagePixel(win, src, noReferrer) {
  * Check if element attribute "referrerPolicy" is supported by the browser.
  * At this moment (4/14/2017), Safari does not support it yet.
  *
- * @returns {boolean}
+ * @return {boolean}
  */
 export function isReferrerPolicySupported() {
   return 'referrerPolicy' in Image.prototype;

--- a/extensions/amp-a4a/0.1/a4a-variable-source.js
+++ b/extensions/amp-a4a/0.1/a4a-variable-source.js
@@ -134,7 +134,7 @@ export class A4AVariableSource extends VariableSource {
    *     set, up to a max of 10. May be URI encoded.
    * @param {...string} var_args Additional params will be the names of
    *     attributes whose values will be returned. There should be at least 1.
-   * @returns {string} A stringified JSON array containing one member for each
+   * @return {string} A stringified JSON array containing one member for each
    *     matching element. Each member will contain the names and values of the
    *     specified attributes, if the corresponding element has that attribute.
    *     Note that if an element matches the cssSelected but has none of the

--- a/extensions/amp-access/0.1/amp-access-source.js
+++ b/extensions/amp-access/0.1/amp-access-source.js
@@ -146,7 +146,7 @@ export class AccessSource {
   }
 
   /**
-   * @returns {?string}
+   * @return {?string}
    */
   getNamespace() {
     return this.namespace_;

--- a/extensions/amp-accordion/0.1/amp-accordion.js
+++ b/extensions/amp-accordion/0.1/amp-accordion.js
@@ -295,7 +295,7 @@ class AmpAccordion extends AMP.BaseElement {
    * links or elements with tap targets, which should not have their default
    * behavior overidden.
    * @param {!Event} event
-   * @returns {boolean}
+   * @return {boolean}
    * @private
    */
   shouldHandleClick_(event) {

--- a/extensions/amp-ad-exit/0.1/amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/amp-ad-exit.js
@@ -223,7 +223,7 @@ export class AmpAdExit extends AMP.BaseElement {
    * passes.
    * @param {!Array<!./filters/filter.Filter>} filters
    * @param {!../../../src/service/action-impl.ActionEventDef} event
-   * @returns {boolean}
+   * @return {boolean}
    */
   filter_(filters, event) {
     return filters.every(filter => {
@@ -310,7 +310,7 @@ export class AmpAdExit extends AMP.BaseElement {
    * This is a pass-through for the version in service.js, solely because
    * the one in service.js isn't stubbable for testing, since only object
    * methods are stubbable.
-   * @returns {?string}
+   * @return {?string}
    * @private
    * @VisibleForTesting
    */

--- a/extensions/amp-ad-network-adsense-impl/0.1/adsense-a4a-config.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/adsense-a4a-config.js
@@ -45,7 +45,7 @@ export const URL_EXPERIMENT_MAPPING = {
  * @param {!Window} win
  * @param {!Element} element
  * @param {boolean} useRemoteHtml
- * @returns {boolean}
+ * @return {boolean}
  */
 export function adsenseIsA4AEnabled(win, element, useRemoteHtml) {
   if (useRemoteHtml || !isGoogleAdsA4AValidEnvironment(win) ||

--- a/extensions/amp-ad-network-cloudflare-impl/0.1/cloudflare-a4a-config.js
+++ b/extensions/amp-ad-network-cloudflare-impl/0.1/cloudflare-a4a-config.js
@@ -19,7 +19,7 @@
  * @param {!Window} win
  * @param {!Element} element
  * @param {boolean} useRemoteHtml
- * @returns {boolean}
+ * @return {boolean}
  */
 export function cloudflareIsA4AEnabled(win, element, useRemoteHtml) {
   // We assume fast fetch for all content, but this will gracefully degrade,

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/doubleclick-a4a-config.js
@@ -231,7 +231,7 @@ const singleton = new DoubleclickA4aEligibility();
  * @param {!Window} win
  * @param {!Element} element
  * @param {boolean} useRemoteHtml
- * @returns {boolean}
+ * @return {boolean}
  */
 export function doubleclickIsA4AEnabled(win, element, useRemoteHtml) {
   return singleton.isA4aEnabled(win, element, useRemoteHtml);

--- a/extensions/amp-ad-network-gmossp-impl/0.1/gmossp-a4a-config.js
+++ b/extensions/amp-ad-network-gmossp-impl/0.1/gmossp-a4a-config.js
@@ -26,7 +26,7 @@ const GMOSSP_SRC_A4A_PREFIX_ = 'https://amp.sp.gmossp-sp.jp/_a4a/';
  * @param {!Window} win
  * @param {!Element} element
  * @param {boolean} useRemoteHtml
- * @returns {boolean}
+ * @return {boolean}
  */
 export function gmosspIsA4AEnabled(win, element, useRemoteHtml) {
   let src;

--- a/extensions/amp-ad-network-triplelift-impl/0.1/triplelift-a4a-config.js
+++ b/extensions/amp-ad-network-triplelift-impl/0.1/triplelift-a4a-config.js
@@ -20,7 +20,7 @@ const SRC_PREFIX_ = 'https://ib.3lift.com/';
  * @param {!Window} win
  * @param {!Element} element
  * @param {boolean} useRemoteHtml
- * @returns {boolean}
+ * @return {boolean}
  */
 export function tripleliftIsA4AEnabled(win, element, useRemoteHtml) {
   let src;

--- a/extensions/amp-ad/0.1/amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/amp-ad-3p-impl.js
@@ -372,7 +372,7 @@ export class AmpAd3PImpl extends AMP.BaseElement {
   }
 
   /**
-   * @returns {!Promise<?CONSENT_POLICY_STATE>}
+   * @return {!Promise<?CONSENT_POLICY_STATE>}
    */
   getConsentState() {
     const consentPolicyId = super.getConsentPolicy();

--- a/extensions/amp-ad/0.1/amp-ad-custom.js
+++ b/extensions/amp-ad/0.1/amp-ad-custom.js
@@ -194,7 +194,7 @@ export class AmpAdCustom extends AMP.BaseElement {
   /**
    * @private getFullUrl_ Get a URL which includes a parameter indicating
    * all slots to be fetched from this web server URL
-   * @returns {string} The URL with the "ampslots" parameter appended
+   * @return {string} The URL with the "ampslots" parameter appended
    */
   getFullUrl_() {
     // If this ad doesn't have a slot defined, just return the base URL

--- a/extensions/amp-ad/0.1/test/test-amp-ad-custom.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-custom.js
@@ -38,7 +38,7 @@ describe('Amp custom ad', () => {
    * Get a custom amp-ad element
    * @param {string} url The url of the ad server
    * @param {string} slot The alphanumeric slot Id (optional)
-   * @returns {Element} The completed amp-ad element, which has been added to
+   * @return {Element} The completed amp-ad element, which has been added to
    *    the current document body.
    */
   function getCustomAd(url, slot, body = document.body) {

--- a/extensions/amp-addthis/0.1/addthis-utils/classify.js
+++ b/extensions/amp-addthis/0.1/addthis-utils/classify.js
@@ -59,7 +59,7 @@ const strictPornHash = rot13Array(['phz']);
  * @param {string} keywordString string of keywords (seperated by non alpha characters)
  * @param {boolean} nonStrictMatch true iff we can't use the list of strict keywords
  * @private
- * @returns {number}
+ * @return {number}
  */
 const classifyString = (keywordString = '', nonStrictMatch = false) => {
   let classification = 0;
@@ -80,7 +80,7 @@ const classifyString = (keywordString = '', nonStrictMatch = false) => {
  * Classify a meta RATING keyword.
  * @param {string} rating
  * @private
- * @returns {number}
+ * @return {number}
  */
 const classifyRating = (rating = '') => {
   let classification = 0;
@@ -101,7 +101,7 @@ const classifyRating = (rating = '') => {
  * Add keywords to the page based on the content.
  * @param {string} content
  * @private
- * @returns {Array<string>}
+ * @return {Array<string>}
  */
 const extractKeywordsFromContent = content => {
   const keywords = [];
@@ -129,7 +129,7 @@ const extractKeywordsFromContent = content => {
 /**
  * Guesses the search value from an url using a list of known search keys
  * @param {string} url
- * @returns {string|undefined}
+ * @return {string|undefined}
  */
 const getSearchString = url => {
   const terms = url.split('?').pop().toLowerCase().split('&');
@@ -149,7 +149,7 @@ const getSearchString = url => {
 /**
  * Return true if the url appears to be a search URL; false otherwise.
  * @param {string} url
- * @returns {boolean}
+ * @return {boolean}
  */
 const isSearchUrl = (url = '') => {
   const lowerUrl = url.toLowerCase();
@@ -191,7 +191,7 @@ const isSearchUrl = (url = '') => {
  * description.
  * @param {*} pageInfo
  * @param {Array} metaElements
- * @returns {number} classification bitmask (currently only setting a porn bit)
+ * @return {number} classification bitmask (currently only setting a porn bit)
  */
 export const classifyPage = (pageInfo, metaElements) => {
   let bitmask = classifyString(pageInfo.title) |
@@ -218,7 +218,7 @@ export const classifyPage = (pageInfo, metaElements) => {
  * @param {string} referrerString
  * @param {*} parsedReferrer
  * @param {*} parsedHref
- * @returns {number}
+ * @return {number}
  */
 export const classifyReferrer = (
   referrerString,
@@ -250,7 +250,7 @@ export const classifyReferrer = (
  * Return true if the url appears to be a product page; false otherwise.
  * @param {Document} doc
  * @param {Array} metaElements
- * @returns {boolean}
+ * @return {boolean}
  */
 export const isProductPage = (doc, metaElements) => {
   // if a single id or class enumerated below exists, return true
@@ -281,7 +281,7 @@ export const isProductPage = (doc, metaElements) => {
 /**
  * Gather the keywords gathered while classifying the page.
  * @param {Array} metaElements
- * @returns {string} csv containing keywords
+ * @return {string} csv containing keywords
  */
 export const getKeywordsString = metaElements => {
   const keywords = metaElements

--- a/extensions/amp-addthis/0.1/addthis-utils/cuid.js
+++ b/extensions/amp-addthis/0.1/addthis-utils/cuid.js
@@ -21,7 +21,7 @@ const CUID_SESSION_TIME = Date.now();
  * Get the date from the CUID (first 8 hex digits are the time from epoch in
  * seconds).
  * @param {string} cuid
- * @returns {Date}
+ * @return {Date}
  */
 const getDateFromCuid = cuid => {
   let date = new Date();
@@ -34,7 +34,7 @@ const getDateFromCuid = cuid => {
 /**
  * Check if the CUID is in the future (allowing for up to one day of jitter).
  * @param {string} cuid
- * @returns {boolean}
+ * @return {boolean}
  */
 const isCuidInFuture = cuid => {
   const date = getDateFromCuid(cuid);
@@ -62,7 +62,7 @@ export const isDateInFuture = date => {
 /**
  * Check that the CUID is a 16 digit hex number that is not in the future.
  * @param cuid
- * @returns {boolean}
+ * @return {boolean}
  */
 export const isValidCUID = cuid => {
   return Boolean(cuid && cuid.match(RE_CUID) && !isCuidInFuture(cuid));
@@ -72,7 +72,7 @@ export const isValidCUID = cuid => {
  * Create a 16 digit CUID.
  * 0-8 = The date the CUID was created in seconds in hex format, max 8 digits.
  * 9-15 = Random hex number
- * @returns {string}
+ * @return {string}
  */
 export const createCUID = () => {
   const suffix = '00000000' +

--- a/extensions/amp-addthis/0.1/addthis-utils/eng.js
+++ b/extensions/amp-addthis/0.1/addthis-utils/eng.js
@@ -24,7 +24,7 @@ import {pixelDrop} from './pixel';
 /**
  * Gets data to be passed along in request via params
  * @param {{monitors: *, loc: Location, ampDoc: !../../../../src/service/ampdoc-impl.AmpDoc, pubId: string}} params
- * @returns {{al: (string|undefined), amp: number, dc: number, dp: string, dt: string, fp: string, ict: string, ivh: number, pct: number, pfm: number, ph: number, pub: string, sh: number, sid: string}}
+ * @return {{al: (string|undefined), amp: number, dc: number, dp: string, dt: string, fp: string, ict: string, ivh: number, pct: number, pfm: number, ph: number, pub: string, sh: number, sid: string}}
  */
 const getEngData = ({monitors, loc, ampDoc, pubId}) => {
   const {

--- a/extensions/amp-addthis/0.1/addthis-utils/fragment.js
+++ b/extensions/amp-addthis/0.1/addthis-utils/fragment.js
@@ -20,7 +20,7 @@ const RE_ADDTHIS_FRAGMENT = /^\.[a-z0-9\-_]{11}(\.[a-z0-9_]+)?$/i;
 /**
  * Fetches the fragment if it is in the style of a modern AddThis fragment.
  * @param url
- * @returns (string|undefined)
+ * @return (string|undefined)
  */
 const getModernFragment = url => {
   let frag = url.split('#').pop();
@@ -39,7 +39,7 @@ const getModernFragment = url => {
 /**
  * Returns true if AddThis share fragment exists on URL
  * @param url
- * @returns {boolean}
+ * @return {boolean}
  */
 const isAddthisFragment = url => {
   if (getModernFragment(url)) {
@@ -58,7 +58,7 @@ const isAddthisFragment = url => {
 /**
  * Removes the fragment from the url if we classify it as an AddThis fragment.
  * @param {string} url
- * @returns {string}
+ * @return {string}
  */
 export const clearOurFragment = url => {
   if (isAddthisFragment(url)) {
@@ -70,7 +70,7 @@ export const clearOurFragment = url => {
 /**
  * Fetch the unique identifier portion of a modern fragment.
  * @param {string} url
- * @returns {string|undefined}
+ * @return {string|undefined}
  */
 export const getFragmentId = url => {
   const fragment = getModernFragment(url);
@@ -84,7 +84,7 @@ export const getFragmentId = url => {
 /**
  * Fetch the service name portion of a modern fragment.
  * @param {string} url
- * @returns {string|undefined}
+ * @return {string|undefined}
  */
 export const getServiceFromUrlFragment = url => {
   const fragment = getModernFragment(url);

--- a/extensions/amp-addthis/0.1/addthis-utils/meta.js
+++ b/extensions/amp-addthis/0.1/addthis-utils/meta.js
@@ -17,7 +17,7 @@
 /**
  * Returns a NodeList of Meta Elements (not an Array)
  * @param {Document} doc
- * @returns {NodeList}
+ * @return {NodeList}
  */
 export const getMetaElements = doc => doc.head.querySelectorAll('meta');
 

--- a/extensions/amp-addthis/0.1/addthis-utils/pjson.js
+++ b/extensions/amp-addthis/0.1/addthis-utils/pjson.js
@@ -41,7 +41,7 @@ const SHARE = 300;
   *   service: string
   * }
   * }} pjson
-  * @returns {{amp: number, cb: number, dc: number, dest: *, gen: number, mk: string, pub: *, rb: number, sid, url}}
+  * @return {{amp: number, cb: number, dc: number, dest: *, gen: number, mk: string, pub: *, rb: number, sid, url}}
   */
 const getPjsonData = ({loc, referrer, title, ampDoc, pubId, data}) => {
   const {href, hostname, search, pathname, hash, protocol, port} = loc;

--- a/extensions/amp-addthis/0.1/amp-addthis.js
+++ b/extensions/amp-addthis/0.1/amp-addthis.js
@@ -190,7 +190,7 @@ class AmpAddThis extends AMP.BaseElement {
   }
 
   /**
-   * @returns {Element}
+   * @return {Element}
    */
   createPlaceholderCallback() {
     const placeholder = createElementWithAttributes(

--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -358,7 +358,7 @@ export class AmpAnalytics extends AMP.BaseElement {
   /**
    * Gets the resourceID of the parent amp-ad element.
    * Throws an exception if no such element.
-   * @returns {string}
+   * @return {string}
    * @VisibleForTesting
    */
   assertAmpAdResourceId() {

--- a/extensions/amp-analytics/0.1/iframe-transport.js
+++ b/extensions/amp-analytics/0.1/iframe-transport.js
@@ -234,7 +234,7 @@ export class IframeTransport {
   /**
    * Create a unique value to differentiate messages from a particular
    * creative to the cross-domain iframe, or to identify the iframe itself.
-   * @returns {string}
+   * @return {string}
    * @private
    */
   static createUniqueId_() {
@@ -263,7 +263,7 @@ export class IframeTransport {
   /**
    * Gets the FrameData associated with a particular cross-domain frame type.
    * @param {string} type The type attribute of the amp-analytics tag
-   * @returns {FrameData}
+   * @return {FrameData}
    * @VisibleForTesting
    */
   static getFrameData(type) {
@@ -280,7 +280,7 @@ export class IframeTransport {
   }
 
   /**
-   * @returns {string} Unique ID of this instance of IframeTransport
+   * @return {string} Unique ID of this instance of IframeTransport
    * @VisibleForTesting
    */
   getCreativeId() {
@@ -288,7 +288,7 @@ export class IframeTransport {
   }
 
   /**
-   * @returns {string} Type attribute of parent amp-analytics instance
+   * @return {string} Type attribute of parent amp-analytics instance
    * @VisibleForTesting
    */
   getType() {

--- a/extensions/amp-analytics/0.1/variables.js
+++ b/extensions/amp-analytics/0.1/variables.js
@@ -102,7 +102,7 @@ function defaultMacro(value, defaultValue) {
  * @param {string} string input to be replaced
  * @param {string} matchPattern string representation of regex pattern
  * @param {string=} opt_newSubStr pattern to be substituted in
- * @returns {string}
+ * @return {string}
  */
 function replaceMacro(string, matchPattern, opt_newSubStr) {
   if (!matchPattern) {

--- a/extensions/amp-apester-media/0.1/utils.js
+++ b/extensions/amp-apester-media/0.1/utils.js
@@ -35,7 +35,7 @@ function isWebview(ua) {
 
 /**
  * Gets the user platform.
- * @returns {string}
+ * @return {string}
  */
 export function getPlatform() {
   const webview = isWebview(navigator.userAgent);

--- a/extensions/amp-audio/0.1/amp-audio.js
+++ b/extensions/amp-audio/0.1/amp-audio.js
@@ -117,7 +117,7 @@ export class AmpAudio extends AMP.BaseElement {
   /**
    * Returns the value of the attribute specified
    * @param {string} attr
-   * @returns {string}
+   * @return {string}
    */
   getElementAttribute_(attr) {
     return this.element.getAttribute(attr);
@@ -133,7 +133,7 @@ export class AmpAudio extends AMP.BaseElement {
 
   /**
    * Checks if the function is allowed to be called
-   * @returns {boolean}
+   * @return {boolean}
    */
   isInvocationValid_() {
     if (!this.audio_) {
@@ -181,7 +181,7 @@ export class AmpAudio extends AMP.BaseElement {
 
   /**
    * Returns whether `<amp-audio>` has an `<amp-story>` for an ancestor.
-   * @returns {?Element}
+   * @return {?Element}
    * @VisibleForTesting
    */
   isStoryDescendant_() {

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -232,7 +232,7 @@ export class Bind {
   /**
    * Executes an `AMP.setState()` or `AMP.pushState()` action.
    * @param {!../../../src/service/action-impl.ActionInvocation} invocation
-   * @returns {!Promise}
+   * @return {!Promise}
    */
   invoke(invocation) {
     const {args, event, method, sequenceId, tagOrTarget} = invocation;

--- a/extensions/amp-byside-content/0.1/amp-byside-content.js
+++ b/extensions/amp-byside-content/0.1/amp-byside-content.js
@@ -266,7 +266,7 @@ export class AmpBysideContent extends AMP.BaseElement {
   }
 
   /**
-   * @returns {!Element} Returns the overflow element
+   * @return {!Element} Returns the overflow element
    * @private
    */
   getOverflowElement_() {

--- a/extensions/amp-byside-content/0.1/utils.js
+++ b/extensions/amp-byside-content/0.1/utils.js
@@ -42,7 +42,7 @@ export function debounce(func, wait, immediate) {
  * Gets an element creator using a given document to create elements.
  * @export getElementCreator
  * @param {Document} document
- * @returns {!Function}
+ * @return {!Function}
  */
 export function getElementCreator(document) {
   return function createElement(name, className, children) {

--- a/extensions/amp-carousel/0.1/base-slides.js
+++ b/extensions/amp-carousel/0.1/base-slides.js
@@ -112,7 +112,7 @@ export class BaseSlides extends BaseCarousel {
 
   /**
   * Checks if a carousel is eligible to loop, regardless of the loop attribute.
-  * @returns {boolean}
+  * @return {boolean}
   * @protected
   */
   isLoopingEligible() {

--- a/extensions/amp-consent/0.1/consent-policy-manager.js
+++ b/extensions/amp-consent/0.1/consent-policy-manager.js
@@ -228,7 +228,7 @@ export class ConsentPolicyInstance {
     }
   }
 
-  /** @returns {Array<string>} */
+  /** @return {Array<string>} */
   getConsentInstanceIds() {
     return Object.keys(this.itemToConsentState_);
   }

--- a/extensions/amp-dynamic-css-classes/0.1/amp-dynamic-css-classes.js
+++ b/extensions/amp-dynamic-css-classes/0.1/amp-dynamic-css-classes.js
@@ -21,7 +21,7 @@ import {parseUrl} from '../../../src/url';
 /**
  * Strips everything but the domain from referrer string.
  * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
- * @returns {string}
+ * @return {string}
  */
 function referrerDomain(ampdoc) {
   const referrer = Services.viewerForDoc(ampdoc).getUnconfirmedReferrerUrl();
@@ -34,7 +34,7 @@ function referrerDomain(ampdoc) {
 /**
  * Grabs the User Agent string.
  * @param {!Window} win
- * @returns {string}
+ * @return {string}
  */
 function userAgent(win) {
   return win.navigator.userAgent;
@@ -64,7 +64,7 @@ export function referrers_(referrer) {
 /**
  * Normalizes certain referrers across devices.
  * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
- * @returns {!Array<string>}
+ * @return {!Array<string>}
  */
 function normalizedReferrers(ampdoc) {
   const referrer = referrerDomain(ampdoc);

--- a/extensions/amp-font/0.1/amp-font.js
+++ b/extensions/amp-font/0.1/amp-font.js
@@ -188,7 +188,7 @@ export class AmpFont extends AMP.BaseElement {
 
   /**
    * Computes and returns the time (in ms) to wait for font download.
-   * @returns {number} time (in ms) to wait for font download.
+   * @return {number} time (in ms) to wait for font download.
    * @private
    */
   getTimeout_() {

--- a/extensions/amp-fx-collection/0.1/amp-fx-collection.js
+++ b/extensions/amp-fx-collection/0.1/amp-fx-collection.js
@@ -117,7 +117,7 @@ export class AmpFxCollection {
    * e.g. `amp-fx="parallax fade-in"
    *
    * @param {!Element} fxElement
-   * @returns {!Array<!FxType>}
+   * @return {!Array<!FxType>}
    */
   getFxTypes_(fxElement) {
     dev().assert(fxElement.hasAttribute('amp-fx'));

--- a/extensions/amp-fx-collection/0.1/providers/fx-provider.js
+++ b/extensions/amp-fx-collection/0.1/providers/fx-provider.js
@@ -182,7 +182,7 @@ export class FxElement {
    * Normally, preset factor is spread across a whole viewport height however
    * for elements above the fold, we should only apply the animation after
    * between the element and top of the page.
-   * @returns {!Promise<number>}
+   * @return {!Promise<number>}
    * @private
    */
   getAdjustedViewportHeight_() {
@@ -200,56 +200,56 @@ export class FxElement {
   }
 
   /**
-   * @returns {number}
+   * @return {number}
    */
   getFactor() {
     return this.factor_;
   }
 
   /**
-   * @returns {string}
+   * @return {string}
    */
   getDuration() {
     return this.duration_;
   }
 
   /**
-   * @returns {number}
+   * @return {number}
    */
   getMarginStart() {
     return this.marginStart_;
   }
 
   /**
-   * @returns {number}
+   * @return {number}
    */
   getMarginEnd() {
     return this.marginEnd_;
   }
 
   /**
-   * @returns {string}
+   * @return {string}
    */
   getEasing() {
     return this.easing_;
   }
 
   /**
-   * @returns {Element}
+   * @return {Element}
    */
   getElement() {
     return this.element_;
   }
 
   /**
-   * @returns {!../../../../src/service/resources-impl.Resources}
+   * @return {!../../../../src/service/resources-impl.Resources}
    */
   getResources() {
     return this.resources_;
   }
 
   /**
-   * @returns {number}
+   * @return {number}
    */
   getOffset() {
     return this.offset_;
@@ -263,7 +263,7 @@ export class FxElement {
   }
 
   /**
-   * @returns {boolean}
+   * @return {boolean}
    */
   isMutateScheduled() {
     return this.mutateScheduled_;
@@ -273,7 +273,7 @@ export class FxElement {
    * Boolean dictating whether or not the amp-fx preset has the `repeat`
    * attribute set. The `repeat` attribute allows the animation to be fully
    * dependent on scroll.
-   * @returns {boolean}
+   * @return {boolean}
    */
   hasRepeat() {
     return this.hasRepeat_;

--- a/extensions/amp-geo/0.1/amp-geo.js
+++ b/extensions/amp-geo/0.1/amp-geo.js
@@ -178,7 +178,7 @@ export class AmpGeo extends AMP.BaseElement {
    * Returns a list of classes to remove if pre-render has
    * been invalidated by way of being on an amp cache
    * @param {Document} doc
-   * @returns {Array<string>}
+   * @return {Array<string>}
    */
   clearPreRender_(doc) {
     const {classList} = doc.body;

--- a/extensions/amp-image-viewer/0.1/amp-image-viewer.js
+++ b/extensions/amp-image-viewer/0.1/amp-image-viewer.js
@@ -268,7 +268,7 @@ export class AmpImageViewer extends AMP.BaseElement {
    * Initializes the image viewer to the target image element such as
    * "amp-img". The target image element may or may not yet have the img
    * element initialized.
-   * @returns {!Promise}
+   * @return {!Promise}
    */
   init_() {
     if (this.image_) {

--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -786,7 +786,7 @@ export class AmpLightboxGallery extends AMP.BaseElement {
    * associated with said element, updates the description, and initializes
    * the image viewer if the element is an amp-img.
    * @param {!Element} element
-   * @returns {!Promise}
+   * @return {!Promise}
    * @private
    */
   openLightboxForElement_(element) {
@@ -800,7 +800,7 @@ export class AmpLightboxGallery extends AMP.BaseElement {
   /**
    * Returns true if the element is loaded and contains an img.
    * @param {!Element} element
-   * @returns {boolean}
+   * @return {boolean}
    * @private
    */
   elementTypeCanBeAnimated_(element) {
@@ -860,7 +860,7 @@ export class AmpLightboxGallery extends AMP.BaseElement {
   /**
    *
    * @param {!Element} target
-   * @returns {boolean}
+   * @return {boolean}
    * @private
    */
   transitionTargetIsInViewport_(target) {
@@ -883,7 +883,7 @@ export class AmpLightboxGallery extends AMP.BaseElement {
    * lightbox.
    * @param {!Element} sourceElement
    * @private
-   * @returns {!Promise}
+   * @return {!Promise}
    */
   transitionIn_(sourceElement) {
     const anim = new Animation(this.element);
@@ -978,7 +978,7 @@ export class AmpLightboxGallery extends AMP.BaseElement {
    * If no transition image is applicable, fade the lightbox in and out.
    * @param {number} startOpacity
    * @param {number} endOpacity
-   * @returns {!Promise}
+   * @return {!Promise}
    * @private
    */
   fade_(startOpacity, endOpacity) {
@@ -1296,7 +1296,7 @@ export class AmpLightboxGallery extends AMP.BaseElement {
 
   /**
    * Close gallery view
-   * @returns {!Promise}
+   * @return {!Promise}
    * @private
    */
   closeGallery_() {
@@ -1414,7 +1414,7 @@ export class AmpLightboxGallery extends AMP.BaseElement {
   /**
    * Converts seconds to a timestamp formatted string.
    * @param {number} seconds
-   * @returns {string}
+   * @return {string}
    */
   secondsToTimestampString_(seconds) {
     const h = Math.floor(seconds / 3600);

--- a/extensions/amp-lightbox-gallery/0.1/service/lightbox-manager-impl.js
+++ b/extensions/amp-lightbox-gallery/0.1/service/lightbox-manager-impl.js
@@ -331,7 +331,7 @@ export class LightboxManager {
   /**
    * Gets the duration of a supported video element
    * @param {!Element} element
-   * @returns {!Promise<number>}
+   * @return {!Promise<number>}
    * @private
    */
   getVideoTimestamp_(element) {

--- a/extensions/amp-next-page/0.1/test/test-amp-next-page.js
+++ b/extensions/amp-next-page/0.1/test/test-amp-next-page.js
@@ -214,7 +214,7 @@ env => {
  * Creates an example document as a child of {@code doc} to be embedded as a
  * shadow document.
  * @param {!Document} doc Parent document to use to create new elements.
- * @returns {!Document} New {@code DocumentFragment} with example content.
+ * @return {!Document} New {@code DocumentFragment} with example content.
  */
 function createExampleDocument(doc) {
   const childDoc = doc.createDocumentFragment();

--- a/extensions/amp-pinterest/0.1/follow-button.js
+++ b/extensions/amp-pinterest/0.1/follow-button.js
@@ -58,7 +58,7 @@ export class FollowButton {
 
   /**
    * Render the follow button
-   * @returns {Element}
+   * @return {Element}
    */
   renderTemplate() {
     const followButton = Util.make(this.element.ownerDocument, {'a': {
@@ -73,7 +73,7 @@ export class FollowButton {
 
   /**
    * Prepare the render data, create the node and add handlers
-   * @returns {!Promise}
+   * @return {!Promise}
    */
   render() {
     // Add trailing slash?

--- a/extensions/amp-playbuzz/0.1/amp-playbuzz.js
+++ b/extensions/amp-playbuzz/0.1/amp-playbuzz.js
@@ -157,7 +157,7 @@ class AmpPlaybuzz extends AMP.BaseElement {
   /**
    *
    * Returns the overflow element
-   * @returns {!Element} overflowElement
+   * @return {!Element} overflowElement
    *
    */
   getOverflowElement_() {
@@ -257,7 +257,7 @@ class AmpPlaybuzz extends AMP.BaseElement {
   /**
    *
    * Returns the composed embed source url
-   * @returns {string} url
+   * @return {string} url
    *
    */
   generateEmbedSourceUrl_() {

--- a/extensions/amp-playbuzz/0.1/utils.js
+++ b/extensions/amp-playbuzz/0.1/utils.js
@@ -53,7 +53,7 @@ export function debounce(func, wait, immediate) {
  * Gets an element creator using a given document to create elements.
  * @export getElementCreator
  * @param {Document} document
- * @returns {!Function}
+ * @return {!Function}
  */
 export function getElementCreator(document) {
   return function createElement(name, className, children) {
@@ -103,7 +103,7 @@ function handlePlaybuzzItemEvent(event, eventName, handler) {
  * Parses Playbuzz Event Data
  *
  * @param {?JsonObject|string|undefined} data
- * @returns {?JsonObject|undefined} parsedObject
+ * @return {?JsonObject|undefined} parsedObject
  */
 function parsePlaybuzzEventData(data) {
   if (typeof data === 'object') {
@@ -127,7 +127,7 @@ function parsePlaybuzzEventData(data) {
 
 /**
  * @param {Object} options
- * @returns {string} playbuzzEmbedUrl
+ * @return {string} playbuzzEmbedUrl
  */
 export function composeEmbedUrl(options) {
   const embedUrl = options.itemUrl + '?' + serializeQueryString(dict({

--- a/extensions/amp-sidebar/0.1/amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.js
@@ -214,7 +214,7 @@ export class AmpSidebar extends AMP.BaseElement {
 
   /**
    * Returns true if the sidebar is opened.
-   * @returns {boolean}
+   * @return {boolean}
    * @private
    */
   isOpen_() {

--- a/extensions/amp-sidebar/0.1/toolbar.js
+++ b/extensions/amp-sidebar/0.1/toolbar.js
@@ -99,7 +99,7 @@ export class Toolbar {
 
   /**
    * Returns if the sidebar is currently in toolbar media query
-   * @returns {boolean}
+   * @return {boolean}
    * @private
    */
   isToolbarShown_() {
@@ -109,7 +109,7 @@ export class Toolbar {
   /**
    * Function to attempt to show the toolbar,
    * and hide toolbar-only element in the sidebar.
-   * @returns {Promise|undefined}
+   * @return {Promise|undefined}
    * @private
    */
   attemptShow_() {

--- a/extensions/amp-subscriptions-google/0.1/amp-subscriptions-google.js
+++ b/extensions/amp-subscriptions-google/0.1/amp-subscriptions-google.js
@@ -184,7 +184,7 @@ export class GoogleSubscriptionsPlatform {
 
   /**
    * Returns if pingback is enabled for this platform
-   * @returns {boolean}
+   * @return {boolean}
    */
   isPingbackEnabled() {
     return false;

--- a/extensions/amp-subscriptions/0.1/amp-subscriptions.js
+++ b/extensions/amp-subscriptions/0.1/amp-subscriptions.js
@@ -137,7 +137,7 @@ export class SubscriptionService {
 
   /**
    * @private
-   * @returns {!Promise<!JsonObject>}
+   * @return {!Promise<!JsonObject>}
    */
   getPlatformConfig_() {
     return new Promise((resolve, reject) => {
@@ -239,7 +239,7 @@ export class SubscriptionService {
 
   /**
    * Starts the amp-subscription Service
-   * @returns {SubscriptionService}
+   * @return {SubscriptionService}
    */
   start() {
     this.initialize_().then(() => {
@@ -325,7 +325,7 @@ export class SubscriptionService {
 
   /**
    * Returns the singleton Dialog instance
-   * @returns {!Dialog}
+   * @return {!Dialog}
    */
   getDialog() {
     return this.dialog_;
@@ -389,7 +389,7 @@ export class SubscriptionService {
 
   /**
    * Returns Page config
-   * @returns {!PageConfig}
+   * @return {!PageConfig}
    */
   getPageConfig() {
     const pageConfig = dev().assert(this.pageConfig_,

--- a/extensions/amp-subscriptions/0.1/local-subscription-platform.js
+++ b/extensions/amp-subscriptions/0.1/local-subscription-platform.js
@@ -104,7 +104,7 @@ export class LocalSubscriptionPlatform {
   /**
    * Validates the action map
    * @param {!JsonObject<string, string>} actionMap
-   * @returns {!JsonObject<string, string>}
+   * @return {!JsonObject<string, string>}
    */
   validateActionMap(actionMap) {
     user().assert(actionMap['login'],

--- a/extensions/amp-subscriptions/0.1/platform-store.js
+++ b/extensions/amp-subscriptions/0.1/platform-store.js
@@ -108,7 +108,7 @@ export class PlatformStore {
   /**
    * Returns the platform for the given id
    * @param {string} serviceId
-   * @returns {!./subscription-platform.SubscriptionPlatform}
+   * @return {!./subscription-platform.SubscriptionPlatform}
    */
   getPlatform(serviceId) {
     const platform = this.subscriptionPlatforms_[serviceId];
@@ -118,7 +118,7 @@ export class PlatformStore {
 
   /**
    * Returns the local platform;
-   * @returns {!./local-subscription-platform.LocalSubscriptionPlatform}
+   * @return {!./local-subscription-platform.LocalSubscriptionPlatform}
    */
   getLocalPlatform() {
     const localPlatform =
@@ -129,7 +129,7 @@ export class PlatformStore {
 
   /**
    * Returns all the platforms;
-   * @returns {!Array<!./subscription-platform.SubscriptionPlatform>}
+   * @return {!Array<!./subscription-platform.SubscriptionPlatform>}
    */
   getAllRegisteredPlatforms() {
     const platforms = [];
@@ -171,7 +171,7 @@ export class PlatformStore {
   /**
    * Returns entitlement for a platform
    * @param {string} serviceId
-   * @returns {!./entitlement.Entitlement} entitlement
+   * @return {!./entitlement.Entitlement} entitlement
    */
   getResolvedEntitlementFor(serviceId) {
     dev().assert(this.entitlements_[serviceId],
@@ -180,7 +180,7 @@ export class PlatformStore {
   }
 
   /**
-   * @returns {!Promise<boolean>}
+   * @return {!Promise<boolean>}
    */
   getGrantStatus() {
     if (this.grantStatusPromise_ !== null) {
@@ -236,7 +236,7 @@ export class PlatformStore {
 
   /**
    * Returns the entitlement which unlocked the document
-   * @returns {!Promise<?Entitlement>}
+   * @return {!Promise<?Entitlement>}
    */
   getGrantEntitlement() {
     if (this.grantStatusEntitlementPromise_) {
@@ -271,7 +271,7 @@ export class PlatformStore {
   /**
    * Returns entitlements when all services are done fetching them.
    * @private
-   * @returns {!Promise<!Array<!./entitlement.Entitlement>>}
+   * @return {!Promise<!Array<!./entitlement.Entitlement>>}
    */
   getAllPlatformsEntitlements_() {
     if (this.allResolvedPromise_) {
@@ -298,7 +298,7 @@ export class PlatformStore {
   /**
    * Returns entitlements for resolved platforms.
    * @private
-   * @returns {!Array<!./entitlement.Entitlement>}
+   * @return {!Array<!./entitlement.Entitlement>}
    */
   getAvailablePlatformsEntitlements_() {
     const entitlements = [];
@@ -312,7 +312,7 @@ export class PlatformStore {
 
   /**
    * Returns entitlements when all services are done fetching them.
-   * @returns {!Promise<!./subscription-platform.SubscriptionPlatform>}
+   * @return {!Promise<!./subscription-platform.SubscriptionPlatform>}
    */
   selectPlatform() {
 
@@ -325,7 +325,7 @@ export class PlatformStore {
 
   /**
    * Returns the number of entitlements resolved
-   * @returns {boolean}
+   * @return {boolean}
    * @private
    */
   areAllPlatformsResolved_() {
@@ -342,7 +342,7 @@ export class PlatformStore {
    *
    * In the end candidate with max weight is selected. However if candidate's
    * weight is equal to local platform, then local platform is selected.
-   * @returns {!./subscription-platform.SubscriptionPlatform}
+   * @return {!./subscription-platform.SubscriptionPlatform}
    * @private
    */
   selectApplicablePlatform_() {

--- a/extensions/amp-subscriptions/0.1/service-adapter.js
+++ b/extensions/amp-subscriptions/0.1/service-adapter.js
@@ -27,7 +27,7 @@ export class ServiceAdapter {
 
   /**
    * Returns the page config.
-   * @returns {!PageConfig}
+   * @return {!PageConfig}
    */
   getPageConfig() {
     return this.subscriptionService_.getPageConfig();
@@ -74,7 +74,7 @@ export class ServiceAdapter {
 
   /**
    * Returns the singleton Dialog instance
-   * @returns {!./dialog.Dialog}
+   * @return {!./dialog.Dialog}
    */
   getDialog() {
     return this.subscriptionService_.getDialog();

--- a/extensions/amp-subscriptions/0.1/subscription-platform.js
+++ b/extensions/amp-subscriptions/0.1/subscription-platform.js
@@ -26,7 +26,7 @@ export class SubscriptionPlatform {
 
   /**
    * Returns the service Id.
-   * @returns {string}
+   * @return {string}
    */
   getServiceId() {}
 
@@ -45,33 +45,33 @@ export class SubscriptionPlatform {
 
   /**
    * Returns if pingback is enabled for this platform.
-   * @returns {boolean}
+   * @return {boolean}
    */
   isPingbackEnabled() {}
 
   /**
    * Performs the pingback to the subscription platform.
    * @param {!./entitlement.Entitlement} unusedSelectedPlatform
-   * @returns {!Promise|undefined}
+   * @return {!Promise|undefined}
    */
   pingback(unusedSelectedPlatform) {}
 
   /**
    * Tells if this platform supports the current viewer.
-   * @returns {boolean}
+   * @return {boolean}
    */
   supportsCurrentViewer() {}
 
   /**
    * Executes action for the local platform.
    * @param {string} unusedAction
-   * @returns {!Promise<boolean>}
+   * @return {!Promise<boolean>}
    */
   executeAction(unusedAction) {}
 
   /**
    * Returns the base score configured for the platform.
-   * @returns {number}
+   * @return {number}
    */
   getBaseScore() {}
 

--- a/extensions/amp-subscriptions/0.1/viewer-tracker.js
+++ b/extensions/amp-subscriptions/0.1/viewer-tracker.js
@@ -44,7 +44,7 @@ export class ViewerTracker {
 
   /**
    * @param {time} timeToView
-   * @returns {!Promise}
+   * @return {!Promise}
    */
   scheduleView(timeToView) {
     this.reportViewPromise_ = null;

--- a/extensions/amp-web-push/0.1/web-push-service.js
+++ b/extensions/amp-web-push/0.1/web-push-service.js
@@ -140,7 +140,7 @@ export class WebPushService {
   /**
    * Occurs when the config element loads.
    * @param {!AmpWebPushConfig} configJson
-   * @returns {!Promise}
+   * @return {!Promise}
    */
   start(configJson) {
     dev().fine(TAG, 'amp-web-push extension starting up.');
@@ -937,7 +937,7 @@ export class WebPushService {
    * Returns true if the Service Worker API, Push API, and Notification API are
    * supported and the page is HTTPS.
    *
-   * @returns {boolean}
+   * @return {boolean}
    */
   environmentSupportsWebPush() {
     return this.arePushRelatedApisSupported_() && this.isAmpPageHttps_();
@@ -953,7 +953,7 @@ export class WebPushService {
    * that AMP, a mobile-only feature, won't be supporting Safari until Safari
    * actually develops mobile push support.
    *
-   * @returns {boolean}
+   * @return {boolean}
    * @private
    */
   arePushRelatedApisSupported_() {

--- a/extensions/amp-web-push/0.1/window-messenger.js
+++ b/extensions/amp-web-push/0.1/window-messenger.js
@@ -97,7 +97,7 @@ export class WindowMessenger {
    * @param {Array<string>} allowedOrigins A list of string origins to check
    *     against when receiving connection messages. A message from outside this
    *     list of origins won't be accepted.
-   * @returns {Promise} A Promise that resolves when another frame successfully
+   * @return {Promise} A Promise that resolves when another frame successfully
    *      establishes a messaging channel, or rejects on error.
    */
   listen(allowedOrigins) {
@@ -147,7 +147,7 @@ export class WindowMessenger {
    *
    * @param {string} origin
    * @param {Array<string>} allowedOrigins
-   * @returns {boolean}
+   * @return {boolean}
    * @private
    */
   isAllowedOrigin_(origin, allowedOrigins) {

--- a/src/3p-frame-messaging.js
+++ b/src/3p-frame-messaging.js
@@ -85,7 +85,7 @@ export function listen(element, eventType, listener, opt_evtListenerOpts) {
  * @param {string} sentinel
  * @param {JsonObject=} data
  * @param {?string=} rtvVersion
- * @returns {string}
+ * @return {string}
  */
 export function serializeMessage(type, sentinel, data = dict(),
   rtvVersion = null) {
@@ -102,7 +102,7 @@ export function serializeMessage(type, sentinel, data = dict(),
  * Returns null if it's not valid AMP message format.
  *
  * @param {*} message
- * @returns {?JsonObject|undefined}
+ * @return {?JsonObject|undefined}
  */
 export function deserializeMessage(message) {
   if (!isAmpMessage(message)) {

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -405,7 +405,7 @@ export class BaseElement {
    * Subclasses can override this method to create a dynamic placeholder
    * element and return it to be appended to the element. This will only
    * be called if the element doesn't already have a placeholder.
-   * @returns {?Element}
+   * @return {?Element}
    */
   createPlaceholderCallback() {
     return null;

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -902,7 +902,7 @@ function createBaseCustomElementClass(win) {
 
     /**
      * Creates a placeholder for the element.
-     * @returns {?Element}
+     * @return {?Element}
      * @final @this {!Element}
      */
     createPlaceholder() {

--- a/src/iframe-helper.js
+++ b/src/iframe-helper.js
@@ -373,7 +373,7 @@ export function postMessageToWindows(iframe, targets, type, object, opt_is3P) {
  * Gets the sentinel string.
  * @param {!Element} iframe The iframe.
  * @param {boolean=} opt_is3P set to true if the iframe is 3p.
- * @returns {string} Sentinel string.
+ * @return {string} Sentinel string.
  * @private
  */
 function getSentinel_(iframe, opt_is3P) {
@@ -383,7 +383,7 @@ function getSentinel_(iframe, opt_is3P) {
 /**
  * JSON parses event.data if it needs to be
  * @param {*} data
- * @returns {?JsonObject} object message
+ * @return {?JsonObject} object message
  * @private
  * @visibleForTesting
  */

--- a/src/inabox/inabox-iframe-messaging-client.js
+++ b/src/inabox/inabox-iframe-messaging-client.js
@@ -62,7 +62,7 @@ function createIframeMessagingClient(win) {
 
 /**
  * @param {!Window} win
- * @returns {string}
+ * @return {string}
  */
 function getRandom(win) {
   return String(win.Math.random()).substr(2);

--- a/src/inabox/inabox-viewport.js
+++ b/src/inabox/inabox-viewport.js
@@ -388,7 +388,7 @@ export function installInaboxViewportService(ampdoc) {
 /**
  * @param {!../layout-rect.LayoutRectDef} newRect
  * @param {!../layout-rect.LayoutRectDef} oldRect
- * @returns {boolean}
+ * @return {boolean}
  */
 function isChanged(newRect, oldRect) {
   return isMoved(newRect, oldRect) || isResized(newRect, oldRect);
@@ -397,7 +397,7 @@ function isChanged(newRect, oldRect) {
 /**
  * @param {!../layout-rect.LayoutRectDef} newRect
  * @param {!../layout-rect.LayoutRectDef} oldRect
- * @returns {boolean}
+ * @return {boolean}
  */
 function isMoved(newRect, oldRect) {
   return newRect.left != oldRect.left || newRect.top != oldRect.top;
@@ -406,7 +406,7 @@ function isMoved(newRect, oldRect) {
 /**
  * @param {!../layout-rect.LayoutRectDef} newRect
  * @param {!../layout-rect.LayoutRectDef} oldRect
- * @returns {boolean}
+ * @return {boolean}
  */
 function isResized(newRect, oldRect) {
   return newRect.width != oldRect.width || newRect.height != oldRect.height;

--- a/src/log.js
+++ b/src/log.js
@@ -593,7 +593,7 @@ export function user(opt_element) {
 /**
  * Getter for user logger
  * @param {string=} suffix
- * @returns {!Log}
+ * @return {!Log}
  */
 function getUserLogger(suffix) {
   if (!logConstructor) {
@@ -641,7 +641,7 @@ export function dev() {
 /**
  * @param {!Window} win
  * @param {!Element=} opt_element
- * @returns {boolean} isEmbed
+ * @return {boolean} isEmbed
  */
 export function isFromEmbed(win, opt_element) {
   if (!opt_element) {

--- a/src/polyfills/math-sign.js
+++ b/src/polyfills/math-sign.js
@@ -20,7 +20,7 @@
  * that parses to NaN, returns NaN.
  *
  * @param {number} x
- * @returns {number}
+ * @return {number}
  */
 export function sign(x) {
   x = Number(x);

--- a/src/polyfills/object-assign.js
+++ b/src/polyfills/object-assign.js
@@ -22,7 +22,7 @@ const hasOwnProperty = Object.prototype.hasOwnProperty;
  *
  * @param {!Object} target
  * @param {...Object} var_args
- * @returns {!Object}
+ * @return {!Object}
  */
 export function assign(target, var_args) {
   if (target == null) {

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -189,7 +189,7 @@ export class ActionInvocation {
    * Returns true if the trigger event has a trust equal to or greater than
    * `minimumTrust`. Otherwise, logs a user error and returns false.
    * @param {ActionTrust} minimumTrust
-   * @returns {boolean}
+   * @return {boolean}
    */
   satisfiesTrust(minimumTrust) {
     // Sanity check.
@@ -425,7 +425,7 @@ export class ActionService {
    * @param {!Element} target
    * @param {string} actionEventType
    * @param {!Element=} opt_stopAt
-   * @returns {boolean}
+   * @return {boolean}
    */
   hasAction(target, actionEventType, opt_stopAt) {
     return !!this.findAction_(target, actionEventType, opt_stopAt);

--- a/src/service/ampdoc-impl.js
+++ b/src/service/ampdoc-impl.js
@@ -71,7 +71,7 @@ export class AmpDocService {
 
   /**
    * Whether if an `AmpDocShell` has been installed for the runtime.
-   * @returns {boolean}
+   * @return {boolean}
    */
   hasAmpDocShell() {
     return !!this.shellShadowDoc_;

--- a/src/service/cache-cid-api.js
+++ b/src/service/cache-cid-api.js
@@ -66,7 +66,7 @@ export class CacheCidApi {
 
   /**
    * Returns true if the page is embedded in CCT and is served by a proxy.
-   * @returns {boolean}
+   * @return {boolean}
    */
   isSupported() {
     return this.viewer_.isCctEmbedded() && this.viewer_.isProxyOrigin();

--- a/src/service/jank-meter.js
+++ b/src/service/jank-meter.js
@@ -128,7 +128,7 @@ export class JankMeter {
 
   /**
    * Calculate Good Frame Probability, which is a value range from 0 to 100.
-   * @returns {number}
+   * @return {number}
    * @private
    */
   calculateGfp_() {
@@ -173,7 +173,7 @@ export class JankMeter {
 
 /**
  * @param {!Window} win
- * @returns {boolean}
+ * @return {boolean}
  */
 function isJankMeterEnabled(win) {
   return isExperimentOn(win, 'jank-meter');
@@ -181,7 +181,7 @@ function isJankMeterEnabled(win) {
 
 /**
  * @param {!Window} win
- * @returns {boolean}
+ * @return {boolean}
  */
 export function isLongTaskApiSupported(win) {
   return !!win.PerformanceObserver
@@ -191,7 +191,7 @@ export function isLongTaskApiSupported(win) {
 
 /**
  * @param {!Window} unusedWin
- * @returns {boolean}
+ * @return {boolean}
  */
 function isBatteryApiSupported(unusedWin) {
   // TODO: (@lannka, #9749)

--- a/src/service/platform-impl.js
+++ b/src/service/platform-impl.js
@@ -174,7 +174,7 @@ export class Platform {
    * Returns the minor ios version in string.
    * The ios version can contain two numbers (10.2) or three numbers (10.2.1).
    * Direct string equality check is not suggested, use startWith instead.
-   * @returns {string}
+   * @return {string}
    */
   getIosVersionString() {
     if (!this.navigator_.userAgent) {

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -935,7 +935,7 @@ export class Resource {
   /**
    * Returns the task ID for this resource.
    * @param localId
-   * @returns {string}
+   * @return {string}
    */
   getTaskId(localId) {
     return this.debugid + '#' + localId;

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -1416,7 +1416,7 @@ export class Resources {
    * @param {!./resource.Resource} resource
    * @param {!../layout-rect.LayoutRectDef=} opt_layoutBox
    * @param {!../layout-rect.LayoutRectDef=} opt_initialLayoutBox
-   * @returns {boolean}
+   * @return {boolean}
    * @private
    */
   elementNearBottom_(resource, opt_layoutBox, opt_initialLayoutBox) {

--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -1167,7 +1167,7 @@ export class UrlReplacements {
  * Extracts client ID from a _ga cookie.
  * https://developers.google.com/analytics/devguides/collection/analyticsjs/cookies-user-id
  * @param {string} gaCookie
- * @returns {string}
+ * @return {string}
  */
 export function extractClientIdFromGaCookie(gaCookie) {
   return gaCookie.replace(/^(GA1|1)\.[\d-]+\./, '');

--- a/src/service/viewer-cid-api.js
+++ b/src/service/viewer-cid-api.js
@@ -42,7 +42,7 @@ export class ViewerCidApi {
 
   /**
    * Resolves to true if Viewer is trusted and supports CID API.
-   * @returns {!Promise<boolean>}
+   * @return {!Promise<boolean>}
    */
   isSupported() {
     if (!this.viewer_.hasCapability('cid')) {

--- a/src/utils/math.js
+++ b/src/utils/math.js
@@ -66,7 +66,7 @@ export function mapRange(val, min1, max1, min2, max2) {
  *
  * @param {number} a
  * @param {number} b
- * @returns {number} returns the modulus of the two numbers.
+ * @return {number} returns the modulus of the two numbers.
  * @example
  *
  * _.min(10, 5);

--- a/src/utils/rate-limit.js
+++ b/src/utils/rate-limit.js
@@ -22,7 +22,7 @@
  * @param {!Window} win
  * @param {function(...*)} callback
  * @param {number} minInterval the minimum time interval in millisecond
- * @returns {function(...*)}
+ * @return {function(...*)}
  */
 export function throttle(win, callback, minInterval) {
   let locker = 0;
@@ -61,7 +61,7 @@ export function throttle(win, callback, minInterval) {
  * @param {!Window} win
  * @param {function(...*)} callback
  * @param {number} minInterval the minimum time interval in millisecond
- * @returns {function(...*)}
+ * @return {function(...*)}
  */
 export function debounce(win, callback, minInterval) {
   let locker = 0;

--- a/testing/iframe.js
+++ b/testing/iframe.js
@@ -310,7 +310,7 @@ const IFRAME_STUB_URL =
  * See /test/fixtures/served/iframe-stub.html for implementation.
  *
  * @param win {!Window}
- * @returns {!HTMLIFrameElement}
+ * @return {!HTMLIFrameElement}
  */
 export function createIframeWithMessageStub(win) {
   const element = win.document.createElement('iframe');
@@ -372,7 +372,7 @@ export function createIframeWithMessageStub(win) {
  * @param sourceWin {!Window}
  * @param targetwin {!Window}
  * @param msg {!Object}
- * @returns {!Promise<!Object>}
+ * @return {!Promise<!Object>}
  */
 export function expectPostMessage(sourceWin, targetwin, msg) {
   return new Promise(resolve => {
@@ -554,7 +554,7 @@ function maybeSwitchToCompiledJs(html) {
 
 /**
  * @param {*} data
- * @returns {?}
+ * @return {?}
  * @private
  */
 function parseMessageData(data) {

--- a/testing/yield.js
+++ b/testing/yield.js
@@ -29,7 +29,7 @@ export function installYieldIt(realIt) {
 /**
  * A convenient method so you can flush the event queue by doing
  * `yield macroTask()` in your test.
- * @returns {Promise}
+ * @return {Promise}
  */
 export function macroTask() {
   return new Promise(setTimeout);

--- a/third_party/timeagojs/timeago-locales.js
+++ b/third_party/timeagojs/timeago-locales.js
@@ -84,7 +84,7 @@ export const be = function(number, index) {
    * @param s - 2-4, 22-24, 32-34 ...
    * @param t - 5-20, 25-30, ...
    * @param n
-   * @returns {string}
+   * @return {string}
    */
   function formatNum(f1, f, s, t, n) {
     const n10 = n % 10;
@@ -741,7 +741,7 @@ export const ru = function(number, index) {
    * @param s - 2-4, 22-24, 32-34 ...
    * @param t - 5-20, 25-30, ...
    * @param n
-   * @returns {string}
+   * @return {string}
    */
   function formatNum(f1, f, s, t, n) {
     const n10 = n % 10;

--- a/validator/engine/parse-css_test.js
+++ b/validator/engine/parse-css_test.js
@@ -1238,7 +1238,7 @@ describe('parseMediaQueries', () => {
 
 /**
  * @param {string} selector
- * @returns {!Array<parse_css.Token>}
+ * @return {!Array<parse_css.Token>}
  */
 function parseSelectorForTest(selector) {
   const css = selector + '{}';

--- a/validator/engine/validator.js
+++ b/validator/engine/validator.js
@@ -3209,7 +3209,7 @@ function shouldRecordTagspecValidated(tag, tagSpecId, tagSpecIdsToTrack) {
  * @param {string} attrName
  * @param {string} attrValue
  * @param {string} mandatoryParent may be set to "$NOPARENT"
- * @returns {string} dispatch key
+ * @return {string} dispatch key
  */
 function makeDispatchKey(
     dispatchKeyType, attrName, attrValue, mandatoryParent) {

--- a/validator/nodejs/index.js
+++ b/validator/nodejs/index.js
@@ -36,7 +36,7 @@ var DEFAULT_USER_AGENT = 'amphtml-validator';
  * Determines if str begins with prefix.
  * @param {!string} str
  * @param {!string} prefix
- * @returns {!boolean}
+ * @return {!boolean}
  */
 function hasPrefix(str, prefix) {
   return str.indexOf(prefix) == 0;
@@ -46,7 +46,7 @@ function hasPrefix(str, prefix) {
  * Convenience function to detect whether an argument is a URL. If not,
  * it may be a local file.
  * @param {!string} url
- * @returns {!boolean}
+ * @return {!boolean}
  */
 function isHttpOrHttpsUrl(url) {
   return hasPrefix(url, 'http://') || hasPrefix(url, 'https://');
@@ -55,7 +55,7 @@ function isHttpOrHttpsUrl(url) {
 /**
  * Creates a promise which reads from a file.
  * @param {!string} name
- * @returns {!Promise<!string>}
+ * @return {!Promise<!string>}
  */
 function readFromFile(name) {
   return new Promise(function(resolve, reject) {
@@ -73,7 +73,7 @@ function readFromFile(name) {
  * Creates a promise which reads from a stream.
  * @param {!string} name
  * @param {!stream.Readable} readable
- * @returns {!Promise<!string>}
+ * @return {!Promise<!string>}
  */
 function readFromReadable(name, readable) {
   return new Promise(function(resolve, reject) {
@@ -95,7 +95,7 @@ function readFromReadable(name, readable) {
  * Creates a promise which reads from standard input. Even though it would
  * be easy to make a function that just returns the data, we return a promise
  * for consistency with readFromUrl and readFromFile.
- * @returns {!Promise<!string>}
+ * @return {!Promise<!string>}
  */
 function readFromStdin() {
   return readFromReadable('stdin', process.stdin).then(function(data) {
@@ -110,7 +110,7 @@ function readFromStdin() {
  * Any HTTP status other than 200 is interpreted as an error.
  * @param {!string} url
  * @param {!string} userAgent
- * @returns {!Promise<!string>}
+ * @return {!Promise<!string>}
  */
 function readFromUrl(url, userAgent) {
   return new Promise(function(resolve, reject) {
@@ -257,7 +257,7 @@ function Validator(scriptContents) {
  * 'AMP4ADS'; it defaults to 'AMP' if not specified.
  * @param {!string} inputString
  * @param {string=} htmlFormat
- * @returns {!ValidationResult}
+ * @return {!ValidationResult}
  * @export
  */
 Validator.prototype.validateString = function(inputString, htmlFormat) {
@@ -298,7 +298,7 @@ var instanceByValidatorJs = {};
  *
  * @param {string=} opt_validatorJs
  * @param {string=} opt_userAgent
- * @returns {!Promise<Validator>}
+ * @return {!Promise<Validator>}
  * @export
  */
 function getInstance(opt_validatorJs, opt_userAgent) {
@@ -337,7 +337,7 @@ exports.getInstance = getInstance;
  * from disk or the web, and caches them.
  *
  * @param {string} validatorJsContents
- * @returns {!Validator}
+ * @return {!Validator}
  * @export
  */
 function newInstance(validatorJsContents) {


### PR DESCRIPTION
Closure compiler [prefers](https://github.com/google/closure-compiler/wiki/Annotating-JavaScript-for-the-Closure-Compiler#return-type-description) the `@return` JSDoc annotation over `@returns`.

Partial fix for #15255
