### PR TITLE
🐛 amp-bodymovin-animation: Fix the logic for setting the percentage in `seekTo`

### DIFF
--- a/3p/bodymovinanimation.js
+++ b/3p/bodymovinanimation.js
@@ -46,7 +46,8 @@ function parseMessage(event) {
     if (eventMessage['valueType'] === 'time') {
       animationHandler.goToAndStop(eventMessage['value']);
     } else {
-      animationHandler.goToAndStop(eventMessage['value'] * animationHandler.totalFrames, true);
+      const frameNumber = Math.round(eventMessage['value'] * animationHandler.totalFrames);
+      animationHandler.goToAndStop(frameNumber, true);
     }
   }
 }

--- a/3p/bodymovinanimation.js
+++ b/3p/bodymovinanimation.js
@@ -43,8 +43,11 @@ function parseMessage(event) {
   } else if (action == 'stop') {
     animationHandler.stop();
   } else if (action == 'seekTo') {
-    animationHandler.goToAndStop(eventMessage['value'],
-        eventMessage['valueType'] !== 'time');
+    if (eventMessage['valueType'] === 'time') {
+      animationHandler.goToAndStop(eventMessage['value']);
+    } else {
+      animationHandler.goToAndStop(eventMessage['value'] * animationHandler.totalFrames, true);
+    }
   }
 }
 

--- a/3p/bodymovinanimation.js
+++ b/3p/bodymovinanimation.js
@@ -46,7 +46,8 @@ function parseMessage(event) {
     if (eventMessage['valueType'] === 'time') {
       animationHandler.goToAndStop(eventMessage['value']);
     } else {
-      const frameNumber = Math.round(eventMessage['value'] * animationHandler.totalFrames);
+      const frameNumber =
+        Math.round(eventMessage['value'] * animationHandler.totalFrames);
       animationHandler.goToAndStop(frameNumber, true);
     }
   }

--- a/build-system/amp.extern.js
+++ b/build-system/amp.extern.js
@@ -286,6 +286,7 @@ animationHandler.play;
 animationHandler.pause;
 animationHandler.stop;
 animationHandler.goToAndStop;
+animationHandler.totalFrames;
 
 // Validator
 var amp;

--- a/examples/bodymovin-animation.amp.html
+++ b/examples/bodymovin-animation.amp.html
@@ -6,10 +6,10 @@
     <link rel="canonical" href="amps.html" >
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
     <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
+    <script async custom-element="amp-bodymovin-animation" src="https://cdn.ampproject.org/v0/amp-bodymovin-animation-0.1.js"></script>
+    <script async custom-element="amp-position-observer" src="https://cdn.ampproject.org/v0/amp-position-observer-0.1.js"></script>
     <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
-    <script async src="/dist/amp.js"></script>
-    <script async custom-element="amp-bodymovin-animation" src="/dist/v0/amp-bodymovin-animation-0.1.max.js"></script>
-    <script async custom-element="amp-bodymovin-animation" src="/dist/v0/amp-position-observer-0.1.max.js"></script>
+    <script async src="https://cdn.ampproject.org/v0.js"></script>
 </head>
 <body>
   <h2>Examples of animations that loops infinitely</h2>
@@ -34,7 +34,7 @@
   <h2>Example of a bodymovin animation controlled by scroll position</h2>
   <amp-bodymovin-animation layout="fixed" width="200" height="200" src="https://nainar.github.io/loader.json" loop="true" id="bodymovin-scrollable">
   </amp-bodymovin-animation>
-  <amp-position-observer intersection-ratios="0" on="scroll:bodymovin-scrollable.seekTo(percent=event.percent)" layout="nodisplay">
+  <amp-position-observer intersection-ratios="1" on="scroll:bodymovin-scrollable.seekTo(percent=event.percent)" layout="nodisplay">
   </amp-position-observer>
 
   <h2>Example of a responsive layout animation</h2>

--- a/examples/bodymovin-animation.amp.html
+++ b/examples/bodymovin-animation.amp.html
@@ -31,15 +31,15 @@
   <amp-bodymovin-animation id="anim" layout="fixed" width="200" height="200" src="https://nainar.github.io/loader.json" loop="true" name="ripple_1" noautoplay>
   </amp-bodymovin-animation>
 
-  <h2>Example of a responsive layout animation</h2>
-  <amp-bodymovin-animation layout="responsive" width="200" height="200" src="https://nainar.github.io/loader.json" loop="true">
-  </amp-bodymovin-animation>
-
   <h2>Example of a bodymovin animation controlled by scroll position</h2>
-  <amp-bodymovin-animation layout="responsive" width="200" height="200" src="https://nainar.github.io/loader.json" loop="true" id="bodymovin-scrollable">
+  <amp-bodymovin-animation layout="fixed" width="200" height="200" src="https://nainar.github.io/loader.json" loop="true" id="bodymovin-scrollable">
   </amp-bodymovin-animation>
   <amp-position-observer intersection-ratios="0" on="scroll:bodymovin-scrollable.seekTo(percent=event.percent)" layout="nodisplay">
   </amp-position-observer>
+
+  <h2>Example of a responsive layout animation</h2>
+  <amp-bodymovin-animation layout="responsive" width="200" height="200" src="https://nainar.github.io/loader.json" loop="true">
+  </amp-bodymovin-animation>
 </body>
 
 </html>

--- a/examples/bodymovin-animation.amp.html
+++ b/examples/bodymovin-animation.amp.html
@@ -6,9 +6,10 @@
     <link rel="canonical" href="amps.html" >
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
     <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
-    <script async custom-element="amp-bodymovin-animation" src="https://cdn.ampproject.org/v0/amp-bodymovin-animation-0.1.js"></script>
     <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
-    <script async src="https://cdn.ampproject.org/v0.js"></script>
+    <script async src="/dist/amp.js"></script>
+    <script async custom-element="amp-bodymovin-animation" src="/dist/v0/amp-bodymovin-animation-0.1.max.js"></script>
+    <script async custom-element="amp-bodymovin-animation" src="/dist/v0/amp-position-observer-0.1.max.js"></script>
 </head>
 <body>
   <h2>Examples of animations that loops infinitely</h2>
@@ -34,6 +35,11 @@
   <amp-bodymovin-animation layout="responsive" width="200" height="200" src="https://nainar.github.io/loader.json" loop="true">
   </amp-bodymovin-animation>
 
+  <h2>Example of a bodymovin animation controlled by scroll position</h2>
+  <amp-bodymovin-animation layout="responsive" width="200" height="200" src="https://nainar.github.io/loader.json" loop="true" id="bodymovin-scrollable">
+  </amp-bodymovin-animation>
+  <amp-position-observer intersection-ratios="0" on="scroll:bodymovin-scrollable.seekTo(percent=event.percent)" layout="nodisplay">
+  </amp-position-observer>
 </body>
 
 </html>


### PR DESCRIPTION
Currently, the `seekTo` action seeks to a percentage. However, Lottie doesn't handle percentages; it can either handle frame numbers or timestamps. (You can see that in [their documentation for `goToAndStop()`](https://github.com/airbnb/lottie-web#gotoandstopvalue-isframe), which is used by `seekTo`.)

See my [jsfiddle](https://jsfiddle.net/qb3bc9mx/2/) example. If you enter a number between 0 and 1, it will simply go to the beginning of the animation. But if you set it to something closer to 69 (which appears to be the total number of frames), it actually progresses through the animation.

The solution is to multiply the percentage by the total number of frames in the animation to get the correct frame number. That's what this PR does.

CC @nainar 