### PR TITLE
✅✨ Allow <amp-video noaudio>

### DIFF
--- a/css/video-autoplay.css
+++ b/css/video-autoplay.css
@@ -19,6 +19,11 @@
 i-amphtml-video-mask {
   z-index: 1;
 }
+
+[noaudio] .amp-video-eq {
+  display: none !important;
+}
+
 .amp-video-eq {
   align-items: flex-end;
   bottom: 7px;

--- a/extensions/amp-video/validator-amp-video.protoascii
+++ b/extensions/amp-video/validator-amp-video.protoascii
@@ -60,6 +60,10 @@ attr_lists: {
     name: "muted"
     value: ""
   }
+  attrs: {
+    name: "noaudio"
+    value: ""
+  }
   attrs: { name: "placeholder" }
   attrs: {
     name: "preload"


### PR DESCRIPTION
This is merely an annotation for:

- hiding the equalizer icon
- allowing `<amp-story>` to implement its own UI semantics for mute/unmute