### PR TITLE
Add predefined consent policy consent-unblock-on-all

### DIFF
--- a/examples/amp-consent.amp.html
+++ b/examples/amp-consent.amp.html
@@ -153,15 +153,24 @@
     </div>
   </header>
   <main role="main">
-    <h3>Image that is blocked by consent</h3>
+    <h3>Image that is blocked by _none consent</h3>
     <amp-img
         data-block-on-consent='_none'
         src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w300-h200-no-n" width=300 height=200></amp-img>
 
+    <h3>Image that is blocked by _all consent</h3>
      <amp-img
-        data-block-on-consent
+        data-block-on-consent='_all'
         src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w300-h200-no-n" width=300 height=200></amp-img>
 
+        <h3>Image that is blocked by consent</h3>
+     <amp-img
+        data-block-on-consent='default'
+        src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w300-h200-no-n" width=300 height=200></amp-img>
+<h3>Image that is blocked by default consent</h3>
+         <amp-img
+        data-block-on-consent
+        src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w300-h200-no-n" width=300 height=200></amp-img>
     <h3>Image that is NOT blocked by consent</h3>
     <amp-img
         src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w300-h200-no-n" width=300 height=200></amp-img>

--- a/examples/amp-consent.amp.html
+++ b/examples/amp-consent.amp.html
@@ -153,24 +153,31 @@
     </div>
   </header>
   <main role="main">
-    <h3>Image that is blocked by _none consent</h3>
+    <h3>Image that is blocked by '_none' consent</h3>
     <amp-img
         data-block-on-consent='_none'
         src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w300-h200-no-n" width=300 height=200></amp-img>
 
-    <h3>Image that is blocked by _all consent</h3>
-     <amp-img
+    <h3>Image that is blocked by '_all' consent</h3>
+    <amp-img
         data-block-on-consent='_all'
         src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w300-h200-no-n" width=300 height=200></amp-img>
 
-        <h3>Image that is blocked by consent</h3>
-     <amp-img
+    <h3>Image that is blocked by '_reject_all' consent</h3>
+    <amp-img
+        data-block-on-consent='_reject_all'
+        src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w300-h200-no-n" width=300 height=200></amp-img>
+
+    <h3>Image that is blocked by 'default' consent</h3>
+    <amp-img
         data-block-on-consent='default'
         src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w300-h200-no-n" width=300 height=200></amp-img>
-<h3>Image that is blocked by default consent</h3>
-         <amp-img
+
+    <h3>Image that is blocked by default (not specified) consent</h3>
+    <amp-img
         data-block-on-consent
         src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w300-h200-no-n" width=300 height=200></amp-img>
+
     <h3>Image that is NOT blocked by consent</h3>
     <amp-img
         src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w300-h200-no-n" width=300 height=200></amp-img>

--- a/examples/amp-consent.amp.html
+++ b/examples/amp-consent.amp.html
@@ -153,19 +153,19 @@
     </div>
   </header>
   <main role="main">
-    <h3>Image that is blocked by '_none' consent</h3>
+    <h3>Image that is blocked by '_if_responded' consent</h3>
     <amp-img
-        data-block-on-consent='_none'
+        data-block-on-consent='_if_responded'
         src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w300-h200-no-n" width=300 height=200></amp-img>
 
-    <h3>Image that is blocked by '_all' consent</h3>
+    <h3>Image that is blocked by '_if_accepted' consent</h3>
     <amp-img
-        data-block-on-consent='_all'
+        data-block-on-consent='_if_accepted'
         src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w300-h200-no-n" width=300 height=200></amp-img>
 
-    <h3>Image that is blocked by '_reject_all' consent</h3>
+    <h3>Image that is blocked by '_auto_reject' consent</h3>
     <amp-img
-        data-block-on-consent='_reject_all'
+        data-block-on-consent='_auto_reject'
         src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w300-h200-no-n" width=300 height=200></amp-img>
 
     <h3>Image that is blocked by 'default' consent</h3>

--- a/examples/amp-consent.amp.html
+++ b/examples/amp-consent.amp.html
@@ -155,6 +155,10 @@
   <main role="main">
     <h3>Image that is blocked by consent</h3>
     <amp-img
+        data-block-on-consent='_none'
+        src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w300-h200-no-n" width=300 height=200></amp-img>
+
+     <amp-img
         data-block-on-consent
         src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w300-h200-no-n" width=300 height=200></amp-img>
 

--- a/extensions/amp-consent/0.1/amp-consent.js
+++ b/extensions/amp-consent/0.1/amp-consent.js
@@ -433,11 +433,11 @@ export class AmpConsent extends AMP.BaseElement {
       'unblockOn': unblockOnAll,
     };
 
-    this.policyConfig_['_none'] = predefinedNone;
+    this.policyConfig_['_if_responded'] = predefinedNone;
 
-    this.policyConfig_['_all'] = defaultPolicy;
+    this.policyConfig_['_if_accepted'] = defaultPolicy;
 
-    this.policyConfig_['_reject_all'] = rejectAllOnZero;
+    this.policyConfig_['_auto_reject'] = rejectAllOnZero;
 
     if (this.policyConfig_ && this.policyConfig_['default']) {
       return;

--- a/extensions/amp-consent/0.1/amp-consent.js
+++ b/extensions/amp-consent/0.1/amp-consent.js
@@ -408,16 +408,30 @@ export class AmpConsent extends AMP.BaseElement {
     const defaultPolicy = {
       'waitFor': defaultWaitForItems,
     };
+
+    const unblockOnAll = ['unknown', 'sufficient',
+        'insufficient', 'unknown_not_required'];
+
     const predefinedNone = {
       'waitFor': defaultWaitForItems,
       // Experimental config, do not expose
-      'unblockOn': ['unknown', 'sufficient',
-          'insufficient', 'unknown_not_required'],
+      'unblockOn': unblockOnAll,
+    };
+
+    const rejectAllOnZero = {
+      'waitFor': defaultWaitForItems,
+      'timeout': {
+        'seconds': 0,
+        'fallbackAction': 'reject',
+      },
+      'unblockOn': unblockOnAll,
     };
 
     this.policyConfig_['_none'] = predefinedNone;
 
     this.policyConfig_['_all'] = defaultPolicy;
+
+    this.policyConfig_['_reject_all'] = rejectAllOnZero;
 
     if (this.policyConfig_ && this.policyConfig_['default']) {
       return;

--- a/extensions/amp-consent/0.1/amp-consent.js
+++ b/extensions/amp-consent/0.1/amp-consent.js
@@ -398,9 +398,6 @@ export class AmpConsent extends AMP.BaseElement {
    * Generate default consent policy if not defined
    */
   generateDefaultPolicy_() {
-    if (this.policyConfig_ && this.policyConfig_['default']) {
-      return;
-    }
     // Generate default policy
     const instanceKeys = Object.keys(this.consentConfig_);
     const defaultWaitForItems = {};
@@ -411,6 +408,21 @@ export class AmpConsent extends AMP.BaseElement {
     const defaultPolicy = {
       'waitFor': defaultWaitForItems,
     };
+    const predefinedNone = {
+      'waitFor': defaultWaitForItems,
+      // Experimental config, do not expose
+      'unblockOn': ['unknown', 'sufficient',
+          'insufficient', 'unknown_not_required'],
+    };
+
+    this.policyConfig_['_none'] = predefinedNone;
+
+    this.policyConfig_['_all'] = defaultPolicy;
+
+    if (this.policyConfig_ && this.policyConfig_['default']) {
+      return;
+    }
+
     this.policyConfig_['default'] = defaultPolicy;
   }
 

--- a/extensions/amp-consent/0.1/amp-consent.js
+++ b/extensions/amp-consent/0.1/amp-consent.js
@@ -15,6 +15,7 @@
  */
 
 import {CONSENT_ITEM_STATE, ConsentStateManager} from './consent-state-manager';
+import {CONSENT_POLICY_STATE} from '../../../src/consent-state';
 import {CSS} from '../../../build/amp-consent-0.1.css';
 import {
   ConsentPolicyManager,
@@ -409,8 +410,13 @@ export class AmpConsent extends AMP.BaseElement {
       'waitFor': defaultWaitForItems,
     };
 
-    const unblockOnAll = ['unknown', 'sufficient',
-        'insufficient', 'unknown_not_required'];
+    // TODO(@zhouyx): unblockOn is internal now.
+    const unblockOnAll = [
+      CONSENT_POLICY_STATE.UNKNOWN,
+      CONSENT_POLICY_STATE.SUFFICIENT,
+      CONSENT_POLICY_STATE.INSUFFICIENT,
+      CONSENT_POLICY_STATE.UNKNOWN_NOT_REQUIRED,
+    ];
 
     const predefinedNone = {
       'waitFor': defaultWaitForItems,

--- a/extensions/amp-consent/0.1/consent-policy-manager.js
+++ b/extensions/amp-consent/0.1/consent-policy-manager.js
@@ -246,8 +246,9 @@ export class ConsentPolicyInstance {
     this.status_ = CONSENT_POLICY_STATE.UNKNOWN;
 
     /** @private {!Array<CONSENT_POLICY_STATE>} */
-    this.unblockStateLists_ =
-        config['unblockOn'] || ['sufficient', 'unknown_not_required'];
+    this.unblockStateLists_ = config['unblockOn'] ||
+        [CONSENT_POLICY_STATE.SUFFICIENT,
+          CONSENT_POLICY_STATE.UNKNOWN_NOT_REQUIRED];
 
     this.init_(pendingItems);
   }
@@ -437,22 +438,6 @@ export class ConsentPolicyInstance {
    * @return {boolean}
    */
   shouldBlock() {
-    let state;
-    //console.error(this.unblockStateLists_);
-    switch (this.status_) {
-      case CONSENT_POLICY_STATE.UNKNOWN:
-        state = 'unknown';
-        break;
-      case CONSENT_POLICY_STATE.UNKNOWN_NOT_REQUIRED:
-        state = 'unknown_not_required';
-        break;
-      case CONSENT_POLICY_STATE.INSUFFICIENT:
-        state = 'insufficient';
-        break;
-      case CONSENT_POLICY_STATE.SUFFICIENT:
-        state = 'sufficient';
-        break;
-    }
-    return (this.unblockStateLists_.indexOf(state) > -1);
+    return (this.unblockStateLists_.indexOf(this.status_) > -1);
   }
 }

--- a/extensions/amp-consent/0.1/consent-policy-manager.js
+++ b/extensions/amp-consent/0.1/consent-policy-manager.js
@@ -30,9 +30,9 @@ const TAG = 'consent-policy-manager';
 
 const WHITELIST_POLICY = {
   'default': true,
-  '_none': true,
-  '_all': true,
-  '_reject_all': true,
+  '_if_responded': true,
+  '_if_accepted': true,
+  '_auto_reject': true,
 };
 
 

--- a/extensions/amp-consent/0.1/consent-policy-manager.js
+++ b/extensions/amp-consent/0.1/consent-policy-manager.js
@@ -28,12 +28,11 @@ export const MULTI_CONSENT_EXPERIMENT = 'multi-consent';
 const CONSENT_STATE_MANAGER = 'consentStateManager';
 const TAG = 'consent-policy-manager';
 
-const UNBLOCK_ON_DEFAULT_POLICY = 'default';
-const UNBLOCK_ON_ALL_POLICY = '_none';
 const WHITELIST_POLICY = {
   'default': true,
   '_none': true,
   '_all': true,
+  '_reject_all': true,
 };
 
 
@@ -149,11 +148,9 @@ export class ConsentPolicyManager {
       // If customized policy is not supported
       if (!WHITELIST_POLICY[policyId]) {
         user().error(TAG, `can not find defined policy ${policyId}, ` +
-          `only ${UNBLOCK_ON_DEFAULT_POLICY} and ${UNBLOCK_ON_ALL_POLICY} ` +
-          'is supported now');
+          'only supported predefined policy supported now');
         return Promise.resolve(CONSENT_POLICY_STATE.UNKNOWN);
       }
-      policyId = UNBLOCK_ON_DEFAULT_POLICY;
     }
     return this.whenPolicyInstanceReady_(policyId).then(() => {
       return this.instances_[policyId].getReadyPromise().then(() => {
@@ -169,13 +166,10 @@ export class ConsentPolicyManager {
    */
   whenPolicyUnblock(policyId) {
     if (!isExperimentOn(this.ampdoc_.win, MULTI_CONSENT_EXPERIMENT)) {
-      // NOTE: UNBLOCK_ON_ALL_POLICY won't work after toggle on flag.
-      // Need to register and real consent policy and not reuse default one.
       // If customized policy is not supported
       if (!WHITELIST_POLICY[policyId]) {
         user().error(TAG, `can not find defined policy ${policyId}, ` +
-          `only ${UNBLOCK_ON_DEFAULT_POLICY} and ${UNBLOCK_ON_ALL_POLICY} ` +
-          'is supported now');
+          'only supported predefined policy supported now');
         return Promise.resolve(false);
       }
     }
@@ -444,9 +438,10 @@ export class ConsentPolicyInstance {
    */
   shouldBlock() {
     let state;
+    //console.error(this.unblockStateLists_);
     switch (this.status_) {
       case CONSENT_POLICY_STATE.UNKNOWN:
-        state = 'unknown'
+        state = 'unknown';
         break;
       case CONSENT_POLICY_STATE.UNKNOWN_NOT_REQUIRED:
         state = 'unknown_not_required';

--- a/extensions/amp-consent/0.1/test/test-amp-consent.js
+++ b/extensions/amp-consent/0.1/test/test-amp-consent.js
@@ -328,10 +328,10 @@ describes.realWin('amp-consent', {
       });
     });
 
-    it('create predefined _none policy', function* () {
+    it('create predefined _if_responded policy', function* () {
       ampConsent.buildCallback();
       yield macroTask();
-      expect(ampConsent.policyConfig_['_none']).to.deep.equal({
+      expect(ampConsent.policyConfig_['_if_responded']).to.deep.equal({
         'waitFor': {
           'ABC': undefined,
           'DEF': undefined,
@@ -345,10 +345,10 @@ describes.realWin('amp-consent', {
       });
     });
 
-    it('create predefined _all policy', function* () {
+    it('create predefined _if_accepted policy', function* () {
       ampConsent.buildCallback();
       yield macroTask();
-      expect(ampConsent.policyConfig_['_all']).to.deep.equal({
+      expect(ampConsent.policyConfig_['_if_accepted']).to.deep.equal({
         'waitFor': {
           'ABC': undefined,
           'DEF': undefined,
@@ -356,10 +356,10 @@ describes.realWin('amp-consent', {
       });
     });
 
-    it('create default _reject_all policy', function* () {
+    it('create default _auto_reject policy', function* () {
       ampConsent.buildCallback();
       yield macroTask();
-      expect(ampConsent.policyConfig_['_reject_all']).to.deep.equal({
+      expect(ampConsent.policyConfig_['_auto_reject']).to.deep.equal({
         'waitFor': {
           'ABC': undefined,
           'DEF': undefined,
@@ -404,7 +404,7 @@ describes.realWin('amp-consent', {
           'ABC': [],
         },
       });
-      expect(ampConsent.policyConfig_['_all']).to.deep.equal({
+      expect(ampConsent.policyConfig_['_if_accepted']).to.deep.equal({
         'waitFor': {
           'ABC': undefined,
           'DEF': undefined,

--- a/extensions/amp-consent/0.1/test/test-amp-consent.js
+++ b/extensions/amp-consent/0.1/test/test-amp-consent.js
@@ -16,6 +16,7 @@
 
 import {ACTION_TYPE, AMP_CONSENT_EXPERIMENT, AmpConsent} from '../amp-consent';
 import {CONSENT_ITEM_STATE} from '../consent-state-manager';
+import {CONSENT_POLICY_STATE} from '../../../../src/consent-state';
 import {MULTI_CONSENT_EXPERIMENT} from '../consent-policy-manager';
 import {computedStyle} from '../../../../src/style';
 import {dev} from '../../../../src/log';
@@ -289,7 +290,7 @@ describes.realWin('amp-consent', {
     });
   });
 
-  describe.only('policy config', () => {
+  describe('policy config', () => {
     let defaultConfig;
     let ampConsent;
     let scriptElement;
@@ -323,7 +324,7 @@ describes.realWin('amp-consent', {
         'waitFor': {
           'ABC': undefined,
           'DEF': undefined,
-        }
+        },
       });
     });
 
@@ -335,8 +336,12 @@ describes.realWin('amp-consent', {
           'ABC': undefined,
           'DEF': undefined,
         },
-        'unblockOn': ['unknown', 'sufficient',
-          'insufficient', 'unknown_not_required'],
+        'unblockOn': [
+          CONSENT_POLICY_STATE.UNKNOWN,
+          CONSENT_POLICY_STATE.SUFFICIENT,
+          CONSENT_POLICY_STATE.INSUFFICIENT,
+          CONSENT_POLICY_STATE.UNKNOWN_NOT_REQUIRED,
+        ],
       });
     });
 
@@ -347,7 +352,7 @@ describes.realWin('amp-consent', {
         'waitFor': {
           'ABC': undefined,
           'DEF': undefined,
-        }
+        },
       });
     });
 
@@ -363,8 +368,12 @@ describes.realWin('amp-consent', {
           'seconds': 0,
           'fallbackAction': 'reject',
         },
-        'unblockOn': ['unknown', 'sufficient',
-            'insufficient', 'unknown_not_required'],
+        'unblockOn': [
+          CONSENT_POLICY_STATE.UNKNOWN,
+          CONSENT_POLICY_STATE.SUFFICIENT,
+          CONSENT_POLICY_STATE.INSUFFICIENT,
+          CONSENT_POLICY_STATE.UNKNOWN_NOT_REQUIRED,
+        ],
       });
     });
 
@@ -393,13 +402,13 @@ describes.realWin('amp-consent', {
       expect(ampConsent.policyConfig_['default']).to.deep.equal({
         'waitFor': {
           'ABC': [],
-        }
+        },
       });
       expect(ampConsent.policyConfig_['_all']).to.deep.equal({
         'waitFor': {
           'ABC': undefined,
           'DEF': undefined,
-        }
+        },
       });
     });
   });

--- a/extensions/amp-consent/0.1/test/test-amp-consent.js
+++ b/extensions/amp-consent/0.1/test/test-amp-consent.js
@@ -289,7 +289,7 @@ describes.realWin('amp-consent', {
     });
   });
 
-  describe('policy config', () => {
+  describe.only('policy config', () => {
     let defaultConfig;
     let ampConsent;
     let scriptElement;
@@ -319,13 +319,52 @@ describes.realWin('amp-consent', {
     it('create default policy', function* () {
       ampConsent.buildCallback();
       yield macroTask();
-      expect(ampConsent.policyConfig_).to.deep.equal({
-        'default': {
-          'waitFor': {
-            'ABC': undefined,
-            'DEF': undefined,
-          },
+      expect(ampConsent.policyConfig_['default']).to.deep.equal({
+        'waitFor': {
+          'ABC': undefined,
+          'DEF': undefined,
+        }
+      });
+    });
+
+    it('create predefined _none policy', function* () {
+      ampConsent.buildCallback();
+      yield macroTask();
+      expect(ampConsent.policyConfig_['_none']).to.deep.equal({
+        'waitFor': {
+          'ABC': undefined,
+          'DEF': undefined,
         },
+        'unblockOn': ['unknown', 'sufficient',
+          'insufficient', 'unknown_not_required'],
+      });
+    });
+
+    it('create predefined _all policy', function* () {
+      ampConsent.buildCallback();
+      yield macroTask();
+      expect(ampConsent.policyConfig_['_all']).to.deep.equal({
+        'waitFor': {
+          'ABC': undefined,
+          'DEF': undefined,
+        }
+      });
+    });
+
+    it('create default _reject_all policy', function* () {
+      ampConsent.buildCallback();
+      yield macroTask();
+      expect(ampConsent.policyConfig_['_reject_all']).to.deep.equal({
+        'waitFor': {
+          'ABC': undefined,
+          'DEF': undefined,
+        },
+        'timeout': {
+          'seconds': 0,
+          'fallbackAction': 'reject',
+        },
+        'unblockOn': ['unknown', 'sufficient',
+            'insufficient', 'unknown_not_required'],
       });
     });
 
@@ -351,12 +390,16 @@ describes.realWin('amp-consent', {
       ampConsent = new AmpConsent(consentElement);
       ampConsent.buildCallback();
       yield macroTask();
-      expect(ampConsent.policyConfig_).to.deep.equal({
-        'default': {
-          'waitFor': {
-            'ABC': [],
-          },
-        },
+      expect(ampConsent.policyConfig_['default']).to.deep.equal({
+        'waitFor': {
+          'ABC': [],
+        }
+      });
+      expect(ampConsent.policyConfig_['_all']).to.deep.equal({
+        'waitFor': {
+          'ABC': undefined,
+          'DEF': undefined,
+        }
       });
     });
   });

--- a/extensions/amp-consent/0.1/test/test-consent-policy-manager.js
+++ b/extensions/amp-consent/0.1/test/test-consent-policy-manager.js
@@ -90,6 +90,24 @@ describes.realWin('ConsentStateManager', {amp: 1}, env => {
         return promise;
       });
     });
+
+    describe('whenPolicyUnblock', () => {
+      it('when policy is not consent-unblock-on-all', () => {
+        const promise = manager.whenPolicyUnblock('default');
+        manager.registerConsentPolicyInstance('default', {});
+        return promise.then(unblock => {
+          expect(unblock).to.be.false;
+        });
+      });
+
+      it('when policy is consent-unblock-on-all', () => {
+        const promise = manager.whenPolicyUnblock('consent-unblock-on-all');
+        manager.registerConsentPolicyInstance('default', {});
+        return promise.then(unblock => {
+          expect(unblock).to.be.true;
+        });
+      });
+    });
   });
 
   describe('Consent Policy Instance', () => {

--- a/extensions/amp-consent/0.1/test/test-consent-policy-manager.js
+++ b/extensions/amp-consent/0.1/test/test-consent-policy-manager.js
@@ -90,28 +90,6 @@ describes.realWin('ConsentStateManager', {amp: 1}, env => {
         return promise;
       });
     });
-
-    describe('whenPolicyUnblock', () => {
-      beforeEach(() => {
-        toggleExperiment(win, MULTI_CONSENT_EXPERIMENT, false);
-      });
-
-      it('when policy is not _none', () => {
-        const promise = manager.whenPolicyUnblock('default');
-        manager.registerConsentPolicyInstance('default', {});
-        return promise.then(unblock => {
-          expect(unblock).to.be.false;
-        });
-      });
-
-      it('when policy is _none', () => {
-        const promise = manager.whenPolicyUnblock('_none');
-        manager.registerConsentPolicyInstance('default', {});
-        return promise.then(unblock => {
-          expect(unblock).to.be.true;
-        });
-      });
-    });
   });
 
   describe('Consent Policy Instance', () => {
@@ -340,6 +318,38 @@ describes.realWin('ConsentStateManager', {amp: 1}, env => {
             CONSENT_ITEM_STATE.NOT_REQUIRED);
         expect(instance.getCurrentPolicyStatus()).to.equal(
             CONSENT_POLICY_STATE.SUFFICIENT);
+      });
+    });
+
+    describe('shouldBlock', () => {
+      it('default should block list', () => {
+        instance = new ConsentPolicyInstance({
+          'waitFor': {
+            'ABC': [],
+          },
+        });
+        instance.consentStateChangeHandler('ABC', CONSENT_ITEM_STATE.DISMISSED);
+        expect(instance.shouldBlock()).to.equal(false);
+        instance.consentStateChangeHandler('ABC', CONSENT_ITEM_STATE.REJECTED);
+        expect(instance.shouldBlock()).to.equal(false);
+        instance.consentStateChangeHandler('ABC', CONSENT_ITEM_STATE.GRANTED);
+        expect(instance.shouldBlock()).to.equal(true);
+      });
+
+      it('customized should block list', () => {
+        instance = new ConsentPolicyInstance({
+          'waitFor': {
+            'ABC': [],
+          },
+          'unblockOn': ['unknown', 'sufficient',
+              'insufficient', 'unknown_not_required'],
+        });
+        instance.consentStateChangeHandler('ABC', CONSENT_ITEM_STATE.DISMISSED);
+        expect(instance.shouldBlock()).to.equal(true);
+        instance.consentStateChangeHandler('ABC', CONSENT_ITEM_STATE.REJECTED);
+        expect(instance.shouldBlock()).to.equal(true);
+        instance.consentStateChangeHandler('ABC', CONSENT_ITEM_STATE.GRANTED);
+        expect(instance.shouldBlock()).to.equal(true);
       });
     });
 

--- a/extensions/amp-consent/0.1/test/test-consent-policy-manager.js
+++ b/extensions/amp-consent/0.1/test/test-consent-policy-manager.js
@@ -92,7 +92,11 @@ describes.realWin('ConsentStateManager', {amp: 1}, env => {
     });
 
     describe('whenPolicyUnblock', () => {
-      it('when policy is not consent-unblock-on-all', () => {
+      beforeEach(() => {
+        toggleExperiment(win, MULTI_CONSENT_EXPERIMENT, false);
+      });
+
+      it('when policy is not _none', () => {
         const promise = manager.whenPolicyUnblock('default');
         manager.registerConsentPolicyInstance('default', {});
         return promise.then(unblock => {
@@ -100,8 +104,8 @@ describes.realWin('ConsentStateManager', {amp: 1}, env => {
         });
       });
 
-      it('when policy is consent-unblock-on-all', () => {
-        const promise = manager.whenPolicyUnblock('consent-unblock-on-all');
+      it('when policy is _none', () => {
+        const promise = manager.whenPolicyUnblock('_none');
         manager.registerConsentPolicyInstance('default', {});
         return promise.then(unblock => {
           expect(unblock).to.be.true;

--- a/extensions/amp-consent/0.1/test/test-consent-policy-manager.js
+++ b/extensions/amp-consent/0.1/test/test-consent-policy-manager.js
@@ -341,8 +341,12 @@ describes.realWin('ConsentStateManager', {amp: 1}, env => {
           'waitFor': {
             'ABC': [],
           },
-          'unblockOn': ['unknown', 'sufficient',
-              'insufficient', 'unknown_not_required'],
+          'unblockOn': [
+            CONSENT_POLICY_STATE.UNKNOWN,
+            CONSENT_POLICY_STATE.SUFFICIENT,
+            CONSENT_POLICY_STATE.INSUFFICIENT,
+            CONSENT_POLICY_STATE.UNKNOWN_NOT_REQUIRED,
+          ],
         });
         instance.consentStateChangeHandler('ABC', CONSENT_ITEM_STATE.DISMISSED);
         expect(instance.shouldBlock()).to.equal(true);

--- a/src/consent-state.js
+++ b/src/consent-state.js
@@ -49,6 +49,24 @@ export function getConsentPolicyState(ampdoc, policyId) {
 }
 
 /**
+ * Returns a promise that resolve when the consent policy is resolve,
+ * and if it should be unblocked.
+ * @param {!./service/ampdoc-impl.AmpDoc} ampdoc
+ * @param {string} policyId
+ * @return {!Promise<boolean>}
+ */
+export function getConsentPolicyUnblockState(ampdoc, policyId) {
+  return Services.consentPolicyServiceForDocOrNull(ampdoc)
+      .then(consentPolicy => {
+        if (!consentPolicy) {
+          return true;
+        }
+        return consentPolicy.whenPolicyUnblock(
+            /** @type {string} */ (policyId));
+      });
+}
+
+/**
  * Returns a promise that resolves to a sharedData retrieved from consent
  * remote endpoint.
  * @param {!./service/ampdoc-impl.AmpDoc} ampdoc

--- a/src/consent-state.js
+++ b/src/consent-state.js
@@ -49,24 +49,6 @@ export function getConsentPolicyState(ampdoc, policyId) {
 }
 
 /**
- * Returns a promise that resolve when the consent policy is resolve,
- * and if it should be unblocked.
- * @param {!./service/ampdoc-impl.AmpDoc} ampdoc
- * @param {string} policyId
- * @return {!Promise<boolean>}
- */
-export function getConsentPolicyUnblockState(ampdoc, policyId) {
-  return Services.consentPolicyServiceForDocOrNull(ampdoc)
-      .then(consentPolicy => {
-        if (!consentPolicy) {
-          return true;
-        }
-        return consentPolicy.whenPolicyUnblock(
-            /** @type {string} */ (policyId));
-      });
-}
-
-/**
  * Returns a promise that resolves to a sharedData retrieved from consent
  * remote endpoint.
  * @param {!./service/ampdoc-impl.AmpDoc} ampdoc

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -16,10 +16,7 @@
 
 import * as dom from './dom';
 import {AmpEvents} from './amp-events';
-import {
-  CONSENT_POLICY_STATE,
-  getConsentPolicyState,
-} from './consent-state';
+
 import {CommonSignals} from './common-signals';
 import {ElementStub} from './element-stub';
 import {
@@ -36,6 +33,7 @@ import {Signals} from './utils/signals';
 import {blockedByConsentError, isBlockedByConsent, reportError} from './error';
 import {createLoaderElement} from '../src/loader';
 import {dev, rethrowAsync, user} from './log';
+import {getConsentPolicyUnblockState} from './consent-state';
 import {
   getIntersectionChangeEntry,
 } from '../src/intersection-observer-polyfill';
@@ -486,15 +484,14 @@ function createBaseCustomElementClass(win) {
         if (!policyId) {
           resolve(this.implementation_.buildCallback());
         } else {
-          getConsentPolicyState(this.getAmpDoc(), policyId).then(state => {
-            if (state == CONSENT_POLICY_STATE.INSUFFICIENT ||
-                state == CONSENT_POLICY_STATE.UNKNOWN) {
-              // Need to change after support more policy state
-              reject(blockedByConsentError());
-            } else {
-              resolve(this.implementation_.buildCallback());
-            }
-          });
+          getConsentPolicyUnblockState(this.getAmpDoc(), policyId).then(
+              state => {
+                if (state == true) {
+                  resolve(this.implementation_.buildCallback());
+                } else {
+                  reject(blockedByConsentError());
+                }
+              });
         }
       }).then(() => {
         this.preconnect(/* onLayout */false);

--- a/test/functional/test-custom-element.js
+++ b/test/functional/test-custom-element.js
@@ -17,7 +17,6 @@
 import * as lolex from 'lolex';
 import {AmpEvents} from '../../src/amp-events';
 import {BaseElement} from '../../src/base-element';
-import {CONSENT_POLICY_STATE} from '../../src/consent-state';
 import {ElementStub} from '../../src/element-stub';
 import {LOADING_ELEMENTS_, Layout} from '../../src/layout';
 import {ResourceState} from '../../src/service/resource';

--- a/test/functional/test-custom-element.js
+++ b/test/functional/test-custom-element.js
@@ -572,8 +572,8 @@ describes.realWin('CustomElement', {amp: true}, env => {
       sandbox.stub(Services, 'consentPolicyServiceForDocOrNull')
           .callsFake(() => {
             return Promise.resolve({
-              whenPolicyResolved: () => {
-                return Promise.resolve(CONSENT_POLICY_STATE.SUFFICIENT);
+              whenPolicyUnblock: () => {
+                return Promise.resolve(true);
               },
             });
           });
@@ -592,8 +592,8 @@ describes.realWin('CustomElement', {amp: true}, env => {
       sandbox.stub(Services, 'consentPolicyServiceForDocOrNull')
           .callsFake(() => {
             return Promise.resolve({
-              whenPolicyResolved: () => {
-                return Promise.resolve(CONSENT_POLICY_STATE.INSUFFICIENT);
+              whenPolicyUnblock: () => {
+                return Promise.resolve(false);
               },
             });
           });


### PR DESCRIPTION
As discussed in #15290 We will be adding more predefined consent policy. 
`consent-unblock-on-all` is the first one that will unblock element even user reject/dismiss. And individual component (like amp-iframe) can make the decision within. 