### PR TITLE
Update timeout and environment for basic integration tests lightbox

### DIFF
--- a/extensions/amp-lightbox-gallery/0.1/test/integration/test-amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/test/integration/test-amp-lightbox-gallery.js
@@ -16,7 +16,8 @@
 
 import {poll} from '../../../../../testing/iframe';
 
-describe.configure().run('amp-lightbox-gallery', function() {
+describe.configure().ifNewChrome().run('amp-lightbox-gallery', function() {
+  this.timeout(5000);
   const extensions = ['amp-lightbox-gallery'];
   const body = `
   <figure>


### PR DESCRIPTION
This should mitigate the flakes until we figure out why it's failing on Mobile Chrome Webview. 