### PR TITLE
Lightbox pre-launch fixes

### DIFF
--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -353,6 +353,7 @@ export class AmpLightboxGallery extends AMP.BaseElement {
 
   /**
    * Handles slide change.
+   * @param {!Event} event
    * @private
    */
   slideChangeHandler_(event) {
@@ -1241,6 +1242,7 @@ export class AmpLightboxGallery extends AMP.BaseElement {
   /**
    * Handles keyboard events for the lightbox.
    *  -Esc will close the lightbox.
+   * @param {!Event} event
    * @private
    */
   onKeyDown_(event) {
@@ -1491,6 +1493,7 @@ export class AmpLightboxGallery extends AMP.BaseElement {
 }
 
 /**
+ * @param {!Window} win
  * @private visible for testing.
  */
 export function installLightboxManager(win) {

--- a/extensions/amp-lightbox-gallery/0.1/service/lightbox-manager-impl.js
+++ b/extensions/amp-lightbox-gallery/0.1/service/lightbox-manager-impl.js
@@ -35,10 +35,7 @@ import {srcsetFromElement, srcsetFromSrc} from '../../../../src/srcset';
 import {toArray} from '../../../../src/types';
 
 const LIGHTBOX_ELIGIBLE_TAGS = {
-  'AMP-AD': true,
   'AMP-IMG': true,
-  'AMP-VIDEO': true,
-  'AMP-YOUTUBE': true,
 };
 
 export const ELIGIBLE_TAP_TAGS = {
@@ -308,23 +305,6 @@ export class LightboxManager {
         return descriptionElement./*OK*/innerText;
       }
     }
-    const alt = element.getAttribute('alt');
-    if (alt) {
-      return alt;
-    }
-    const ariaLabel = element.getAttribute('aria-label');
-    if (ariaLabel) {
-      return ariaLabel;
-    }
-    const ariaLabelledBy = element.getAttribute('aria-labelledby');
-    if (ariaLabelledBy) {
-      const descriptionElement = element.ownerDocument
-          .getElementById(ariaLabelledBy);
-      if (descriptionElement) {
-        return descriptionElement./*OK*/innerText;
-      }
-    }
-
     return null;
   }
 


### PR DESCRIPTION
1. Update description logic: only populate from figcaption and aria-describedby, not alt, aria-label, aria-labeledby. 
2. Add runtime validation to unlaunch amp-youtube, amp-ad, amp-video until iframe layout issue is resolved. 
3. Lint fixes. 