### PR TITLE
🏗 JSDoc: Enable the `jsdoc/check-types` rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -86,7 +86,7 @@
     "indent": [2, 2, { "SwitchCase": 1, "VariableDeclarator": 2, "MemberExpression": 2, "ObjectExpression": 1, "CallExpression": { "arguments": 2 } }],
     "jsdoc/check-param-names": 1,
     "jsdoc/check-tag-names": 1,
-    "jsdoc/check-types": 0,
+    "jsdoc/check-types": 1,
     "jsdoc/require-param": 1,
     "jsdoc/require-param-name": 1,
     "jsdoc/require-param-type": 1,

--- a/.eslintrc-strict
+++ b/.eslintrc-strict
@@ -5,7 +5,7 @@
     "amphtml-internal/vsync": 1,
     "jsdoc/check-param-names": 2,
     "jsdoc/check-tag-names": 2,
-    "jsdoc/check-types": 0,
+    "jsdoc/check-types": 2,
     "jsdoc/require-param": 1,
     "jsdoc/require-param-name": 2,
     "jsdoc/require-param-type": 2,

--- a/src/utils/function.js
+++ b/src/utils/function.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+// TODO(rsimha, #15334): Enable this rule.
 /* eslint jsdoc/check-types: 0 */
 
 /**
@@ -24,8 +25,8 @@
  * so it will return the same cached value even when the arguments are
  * different.
  *
- * @param {function(...):(T)} fn
- * @return {function(...):(T)}
+ * @param {function(...):T} fn
+ * @return {function(...):T}
  * @template T
  */
 export function once(fn) {

--- a/src/utils/function.js
+++ b/src/utils/function.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+/* eslint jsdoc/check-types: 0 */
 
 /**
  * Creates a function that is evaluated only once and returns the cached result
@@ -23,19 +24,19 @@
  * so it will return the same cached value even when the arguments are
  * different.
  *
- * @param {function(...):(T|undefined)} fn
- * @return {function(...):(T|undefined)}
+ * @param {function(...):(T)} fn
+ * @return {function(...):(T)}
  * @template T
- * @suppress {checkTypes} Compiler complains about "fn = null" for GC.
  */
 export function once(fn) {
   let evaluated = false;
   let retValue = null;
+  let callback = fn;
   return (...args) => {
     if (!evaluated) {
-      retValue = fn.apply(self, args);
+      retValue = callback.apply(self, args);
       evaluated = true;
-      fn = null; // GC
+      callback = null; // GC
     }
     return retValue;
   };


### PR DESCRIPTION
This PR enables type checking via the `jsdoc/check-types` lint rule. It also removes the `@suppress {checkTypes}` annotation from `src/utils/function.js` that prevented it from being type checked by the closure compiler via `gulp check-types`.

There still are a few remaining [instances](https://github.com/ampproject/amphtml/search?utf8=%E2%9C%93&q=%22%40suppress+%7BcheckTypes%7D%22&type=) of `@suppress {checkTypes}` in our code base that should probably be cleaned up.

Partial fix for #15255