### PR TITLE
🐛 make images in amp-story bookend take 100% width and height, use fit cover.

### DIFF
--- a/extensions/amp-story/0.1/amp-story-bookend.css
+++ b/extensions/amp-story/0.1/amp-story-bookend.css
@@ -138,7 +138,9 @@
 }
 
 .i-amphtml-story-bookend-article-image > img {
-  object-fit: cover;
+  object-fit: cover !important;
+  width: 100% !important;
+  height: 100% !important;
 }
 
 .i-amphtml-story-bookend-replay-image {


### PR DESCRIPTION
Fixes #15341 