### PR TITLE
🚀 Use Data URLs instead of Blobs

### DIFF
--- a/src/web-worker/amp-worker.js
+++ b/src/web-worker/amp-worker.js
@@ -97,9 +97,7 @@ class AmpWorker {
       ampCors: false,
     }).then(res => res.text()).then(text => {
       // Workaround since Worker constructor only accepts same origin URLs.
-      const blob = new win.Blob([text], {type: 'text/javascript'});
-      const blobUrl = win.URL.createObjectURL(blob);
-      this.worker_ = new win.Worker(blobUrl);
+      this.worker_ = new win.Worker('data:,' + text);
       this.worker_.onmessage = this.receiveMessage_.bind(this);
     });
 


### PR DESCRIPTION
Benefits: simpler, smaller, easier CSP, better browser support.