### PR TITLE
✨Introduces new amp-story-bookend component: landscape card

### DIFF
--- a/examples/amp-story/bookendv1.json
+++ b/examples/amp-story/bookendv1.json
@@ -45,9 +45,10 @@
       "image": "http://placehold.it/312x416"
     },
     {
-      "type": "small",
-      "title": "This is an example article",
+      "type": "landscape",
+      "title": "TRAPPIST-1 Planets May Still Be Wet Enough for Life",
       "url": "http://example.com/article.html",
+      "category": "astronomy",
       "image": "http://placehold.it/256x128"
     },
     {

--- a/extensions/amp-story/1.0/amp-story-bookend.css
+++ b/extensions/amp-story/1.0/amp-story-bookend.css
@@ -85,8 +85,7 @@
   overflow: hidden !important;
 }
 
-.i-amphtml-story-bookend-article-meta,
-.i-amphtml-story-bookend-portrait-meta {
+.i-amphtml-story-bookend-component-meta {
   font-weight: 400 !important;
   font-size: 14px !important;
   text-overflow: ellipsis !important;
@@ -95,9 +94,6 @@
   line-height: 16px !important;
   width: 50% !important;
   color: rgba(255, 255, 255, 0.6) !important;
-}
-
-.i-amphtml-story-bookend-portrait-meta {
   margin-top: 8px !important;
 }
 
@@ -113,7 +109,8 @@
   padding: 0 32px !important;
 }
 
-.i-amphtml-story-bookend-portrait {
+.i-amphtml-story-bookend-portrait,
+.i-amphtml-story-bookend-landscape {
   box-sizing: border-box !important;
   display: flex !important;
   flex-direction: column !important;
@@ -128,16 +125,18 @@
 
 @media (min-width: 640px) {
   .i-amphtml-story-bookend-article,
-  .i-amphtml-story-bookend-portrait,
-  .i-amphtml-story-bookend-cta-link-wrapper {
+  .i-amphtml-story-bookend-cta-link-wrapper,
+  .i-amphtml-story-bookend-landscape,
+  .i-amphtml-story-bookend-portrait {
     max-width: 50% !important;
   }
 }
 
 @media (min-width: 960px) {
   .i-amphtml-story-bookend-article,
-  .i-amphtml-story-bookend-portrait,
-  .i-amphtml-story-bookend-cta-link-wrapper {
+  .i-amphtml-story-bookend-cta-link-wrapper,
+  .i-amphtml-story-bookend-landscape,
+  .i-amphtml-story-bookend-portrait {
     max-width: 33% !important;
   }
 }
@@ -152,7 +151,7 @@
   margin: 0 0 8px !important;
 }
 
-.i-amphtml-story-bookend-portrait-category {
+.i-amphtml-story-bookend-component-category {
   margin-top: 0px !important;
   font-weight: 400 !important;
   font-size: 12px !important;
@@ -176,35 +175,45 @@
 
 
 @media (max-width: 376px) {
-  .i-amphtml-story-bookend-portrait-image {
+  .i-amphtml-story-bookend-portrait-image
+  .i-amphtml-story-bookend-landscape-image {
     width: 100% !important;
   }
 }
 
 .i-amphtml-story-bookend-article-image.amp-notsupported,
-.i-amphtml-story-bookend-portrait-image.amp-notsupported, {
+.i-amphtml-story-bookend-portrait-image.amp-notsupported,
+.i-amphtml-story-bookend-landscape-image.amp-notsupported {
   display: none !important;
 }
 
-.i-amphtml-story-bookend-article-image > img {
+.i-amphtml-story-bookend-article-image > img,
+.i-amphtml-story-bookend-portrait-image > img,
+.i-amphtml-story-bookend-landscape-image > img  {
   object-fit: cover !important;
   width: 100% !important;
   height: 100% !important;
 }
 
-.i-amphtml-story-bookend-portrait-image {
+.i-amphtml-story-bookend-portrait-image,
+.i-amphtml-story-bookend-landscape-image {
   width: 100% !important;
-  padding-bottom: 125% !important;
   position: relative !important;
   border-radius: 8px !important;
   overflow: hidden !important;
 }
 
-.i-amphtml-story-bookend-portrait-image > img {
-  object-fit: cover !important;
+.i-amphtml-story-bookend-portrait-image {
+  padding-bottom: 125% !important;
+}
+
+.i-amphtml-story-bookend-landscape-image {
+  padding-bottom: 75% !important;
+}
+
+.i-amphtml-story-bookend-portrait-image > img,
+.i-amphtml-story-bookend-landscape-image > img {
   position: absolute !important;
-  width: 100% !important;
-  height: 100% !important;
 }
 
 .i-amphtml-story-bookend-replay-image {
@@ -369,7 +378,8 @@
 @media (min-width: 952px) {
   [desktop] .i-amphtml-story-bookend-article,
   [desktop] .i-amphtml-story-bookend-portrait,
-  [desktop] .i-amphtml-story-bookend-cta-link-wrapper {
+  [desktop] .i-amphtml-story-bookend-cta-link-wrapper,
+  [desktop] .i-amphtml-story-bookend-landscape {
     max-width: 50% !important;
   }
 }
@@ -377,7 +387,9 @@
 @media (min-width: 1272px) {
   [desktop] .i-amphtml-story-bookend-article,
   [desktop] .i-amphtml-story-bookend-portrait,
-  [desktop] .i-amphtml-story-bookend-cta-link-wrapper {
-  max-width: 33% !important;
+  [desktop] .i-amphtml-story-bookend-cta-link-wrapper,
+  [desktop] .i-amphtml-story-bookend-landscape {
+    max-width: 33% !important;
   }
 }
+

--- a/extensions/amp-story/1.0/amp-story-bookend.css
+++ b/extensions/amp-story/1.0/amp-story-bookend.css
@@ -109,8 +109,8 @@
   padding: 0 32px !important;
 }
 
-.i-amphtml-story-bookend-portrait,
-.i-amphtml-story-bookend-landscape {
+.i-amphtml-story-bookend-landscape,
+.i-amphtml-story-bookend-portrait {
   box-sizing: border-box !important;
   display: flex !important;
   flex-direction: column !important;
@@ -175,28 +175,28 @@
 
 
 @media (max-width: 376px) {
-  .i-amphtml-story-bookend-portrait-image
-  .i-amphtml-story-bookend-landscape-image {
+  .i-amphtml-story-bookend-landscape-image,
+  .i-amphtml-story-bookend-portrait-image {
     width: 100% !important;
   }
 }
 
 .i-amphtml-story-bookend-article-image.amp-notsupported,
-.i-amphtml-story-bookend-portrait-image.amp-notsupported,
-.i-amphtml-story-bookend-landscape-image.amp-notsupported {
+.i-amphtml-story-bookend-landscape-image.amp-notsupported,
+.i-amphtml-story-bookend-portrait-image.amp-notsupported {
   display: none !important;
 }
 
 .i-amphtml-story-bookend-article-image > img,
-.i-amphtml-story-bookend-portrait-image > img,
-.i-amphtml-story-bookend-landscape-image > img  {
+.i-amphtml-story-bookend-landscape-image > img,
+.i-amphtml-story-bookend-portrait-image > img {
   object-fit: cover !important;
   width: 100% !important;
   height: 100% !important;
 }
 
-.i-amphtml-story-bookend-portrait-image,
-.i-amphtml-story-bookend-landscape-image {
+.i-amphtml-story-bookend-landscape-image,
+.i-amphtml-story-bookend-portrait-image {
   width: 100% !important;
   position: relative !important;
   border-radius: 8px !important;
@@ -211,8 +211,8 @@
   padding-bottom: 75% !important;
 }
 
-.i-amphtml-story-bookend-portrait-image > img,
-.i-amphtml-story-bookend-landscape-image > img {
+.i-amphtml-story-bookend-landscape-image > img,
+.i-amphtml-story-bookend-portrait-image > img {
   position: absolute !important;
 }
 
@@ -377,19 +377,18 @@
 
 @media (min-width: 952px) {
   [desktop] .i-amphtml-story-bookend-article,
-  [desktop] .i-amphtml-story-bookend-portrait,
   [desktop] .i-amphtml-story-bookend-cta-link-wrapper,
-  [desktop] .i-amphtml-story-bookend-landscape {
+  [desktop] .i-amphtml-story-bookend-landscape,
+  [desktop] .i-amphtml-story-bookend-portrait {
     max-width: 50% !important;
   }
 }
 
 @media (min-width: 1272px) {
   [desktop] .i-amphtml-story-bookend-article,
-  [desktop] .i-amphtml-story-bookend-portrait,
   [desktop] .i-amphtml-story-bookend-cta-link-wrapper,
-  [desktop] .i-amphtml-story-bookend-landscape {
+  [desktop] .i-amphtml-story-bookend-landscape,
+  [desktop] .i-amphtml-story-bookend-portrait {
     max-width: 33% !important;
   }
 }
-

--- a/extensions/amp-story/1.0/bookend/amp-story-bookend.js
+++ b/extensions/amp-story/1.0/bookend/amp-story-bookend.js
@@ -111,7 +111,7 @@ function buildReplayButtonTemplate(doc, title, domainName, opt_imageUrl) {
       },
       {
         tag: 'div',
-        attrs: dict({'class': 'i-amphtml-story-bookend-article-meta'}),
+        attrs: dict({'class': 'i-amphtml-story-bookend-component-meta'}),
         unlocalizedString: domainName,
       },
     ],

--- a/extensions/amp-story/1.0/bookend/bookend-component.js
+++ b/extensions/amp-story/1.0/bookend/bookend-component.js
@@ -18,6 +18,7 @@
 import {ArticleComponent, ArticleComponentDef} from './components/article';
 import {CtaLinkComponent, CtaLinkDef} from './components/cta-link';
 import {HeadingComponent, HeadingComponentDef} from './components/heading';
+import {LandscapeComponent, LandscapeComponentDef} from './components/landscape';
 import {PortraitComponent, PortraitComponentDef} from './components/portrait';
 import {htmlFor} from '../../../../src/static-template';
 
@@ -36,24 +37,27 @@ export let BookendDataDef;
 /**
  * @typedef {
  *   (!ArticleComponentDef|
- *   !HeadingComponentDef|
- *   !PortraitComponentDef|
- *   !CtaLinkDef)
+ *    !CtaLinkDef|
+ *    !HeadingComponentDef|
+ *    !LandscapeComponentDef|
+ *    !PortraitComponentDef)
  * }
  */
 export let BookendComponentDef;
 
 const articleComponentBuilder = new ArticleComponent();
-const headingComponentBuilder = new HeadingComponent();
-const portraitComponentBuilder = new PortraitComponent();
 const ctaLinkComponentBuilder = new CtaLinkComponent();
+const headingComponentBuilder = new HeadingComponent();
+const landscapeComponentBuilder = new LandscapeComponent();
+const portraitComponentBuilder = new PortraitComponent();
 
 /**
  * @typedef {
  *   (!ArticleComponent|
+ *    !CtaLinkComponent|
  *    !HeadingComponent|
- *    !PortraitComponent|
- *    !CtaLinkComponent)
+ *    !LandscapeComponent|
+ *    !PortraitComponent)
  * }
  */
 export let BookendComponentClass;
@@ -67,12 +71,14 @@ function componentBuilderInstanceFor(componentType) {
   switch (componentType) {
     case 'small':
       return articleComponentBuilder;
-    case 'heading':
-      return headingComponentBuilder;
-    case 'portrait':
-      return portraitComponentBuilder;
     case 'cta-link':
       return ctaLinkComponentBuilder;
+    case 'heading':
+      return headingComponentBuilder;
+    case 'landscape':
+      return landscapeComponentBuilder;
+    case 'portrait':
+      return portraitComponentBuilder;
     default:
       return null;
   }

--- a/extensions/amp-story/1.0/bookend/components/article.js
+++ b/extensions/amp-story/1.0/bookend/components/article.js
@@ -107,7 +107,7 @@ export class ArticleComponent {
     template.appendChild(heading);
 
     const articleMeta =
-      html`<div class="i-amphtml-story-bookend-article-meta"></div>`;
+      html`<div class="i-amphtml-story-bookend-component-meta"></div>`;
     articleMeta.textContent = articleData.domainName;
     template.appendChild(articleMeta);
 

--- a/extensions/amp-story/1.0/bookend/components/landscape.js
+++ b/extensions/amp-story/1.0/bookend/components/landscape.js
@@ -1,0 +1,121 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {BookendComponentInterface} from './bookend-component-interface';
+import {addAttributesToElement} from '../../../../../src/dom';
+import {dict} from '../../../../../src/utils/object';
+import {htmlFor, htmlRefs} from '../../../../../src/static-template';
+import {isProtocolValid, parseUrl} from '../../../../../src/url';
+import {user} from '../../../../../src/log';
+
+/**
+ * @typedef {{
+ *   type: string,
+ *   category: string,
+ *   title: string,
+ *   url: string,
+ *   image: string
+ * }}
+ */
+export let LandscapeComponentDef;
+
+/**
+ * @struct @typedef {{
+ *   category: !Element,
+ *   title: !Element,
+ *   image: !Element,
+ *   meta: !Element,
+ * }}
+ */
+let landscapeElsDef;
+
+/**
+ * Builder class for the landscape component.
+ * @implements {BookendComponentInterface}
+ */
+export class LandscapeComponent {
+  /**
+   * @param {!../bookend-component.BookendComponentDef} landscapeJson
+   * @override
+   * */
+  assertValidity(landscapeJson) {
+    user().assert('category' in landscapeJson && 'image' in landscapeJson &&
+      'url' in landscapeJson && 'title' in landscapeJson, 'landscape ' +
+      'component must contain `title`, `category`, `image`, and `url` fields,' +
+      ' skipping invalid.');
+
+    user().assert(isProtocolValid(landscapeJson['url']), 'Unsupported' +
+    ` protocol for landscape URL ${landscapeJson['url']}`);
+
+    user().assert(isProtocolValid(landscapeJson['image']), 'Unsupported' +
+    `  protocol for landscape image URL ${landscapeJson['image']}`);
+  }
+
+  /**
+   * @param {!../bookend-component.BookendComponentDef} landscapeJson
+   * @return {!LandscapeComponentDef}
+   * @override
+   * */
+  build(landscapeJson) {
+    return {
+      type: landscapeJson['type'],
+      title: landscapeJson['title'],
+      category: landscapeJson['category'],
+      url: landscapeJson['url'],
+      domainName: parseUrl(landscapeJson['url']).hostname,
+      image: landscapeJson['image'],
+    };
+  }
+
+  /**
+   * @param {!../bookend-component.BookendComponentDef} landscapeData
+   * @param {!Document} doc
+   * @return {!Element}
+   * @override
+   * */
+  buildTemplate(landscapeData, doc) {
+    const html = htmlFor(doc);
+    const template =
+        html`
+        <a class="i-amphtml-story-bookend-landscape"
+          target="_top">
+          <h2 class="i-amphtml-story-bookend-component-category"
+            ref="category"></h2>
+          <h2 class="i-amphtml-story-bookend-article-heading"
+            ref="title"></h2>
+          <amp-img class="i-amphtml-story-bookend-landscape-image"
+            layout="fixed" width="0" height="0" ref="image"></amp-img>
+          <div class="i-amphtml-story-bookend-component-meta"
+            ref="meta"></div>
+        </a>`;
+    addAttributesToElement(template, dict({'href': landscapeData.url}));
+
+    const landscapeElements = htmlRefs(template);
+    const {
+      category,
+      title,
+      image,
+      meta,
+    } = /** @type {!landscapeElsDef} */ (landscapeElements);
+
+    category.textContent = landscapeData.category;
+    title.textContent = landscapeData.title;
+    addAttributesToElement(image, dict({'src': landscapeData.image}));
+    meta.textContent = landscapeData.domainName;
+
+    return template;
+  }
+}

--- a/extensions/amp-story/1.0/bookend/components/landscape.js
+++ b/extensions/amp-story/1.0/bookend/components/landscape.js
@@ -27,6 +27,7 @@ import {user} from '../../../../../src/log';
  *   category: string,
  *   title: string,
  *   url: string,
+ *   domainName: string,
  *   image: string
  * }}
  */
@@ -88,7 +89,7 @@ export class LandscapeComponent {
    * */
   buildTemplate(landscapeData, doc) {
     const html = htmlFor(doc);
-    const template =
+    const el =
         html`
         <a class="i-amphtml-story-bookend-landscape"
           target="_top">
@@ -101,21 +102,21 @@ export class LandscapeComponent {
           <div class="i-amphtml-story-bookend-component-meta"
             ref="meta"></div>
         </a>`;
-    addAttributesToElement(template, dict({'href': landscapeData.url}));
+    addAttributesToElement(el, dict({'href': landscapeData.url}));
 
-    const landscapeElements = htmlRefs(template);
+    const landscapeEls = htmlRefs(el);
     const {
       category,
       title,
       image,
       meta,
-    } = /** @type {!landscapeElsDef} */ (landscapeElements);
+    } = /** @type {!landscapeElsDef} */ (landscapeEls);
 
     category.textContent = landscapeData.category;
     title.textContent = landscapeData.title;
     addAttributesToElement(image, dict({'src': landscapeData.image}));
     meta.textContent = landscapeData.domainName;
 
-    return template;
+    return el;
   }
 }

--- a/extensions/amp-story/1.0/bookend/components/portrait.js
+++ b/extensions/amp-story/1.0/bookend/components/portrait.js
@@ -26,6 +26,7 @@ import {user} from '../../../../../src/log';
  *   type: string,
  *   category: string,
  *   url: string,
+ *   domainName: string,
  *   image: string
  * }}
  */

--- a/extensions/amp-story/1.0/bookend/components/portrait.js
+++ b/extensions/amp-story/1.0/bookend/components/portrait.js
@@ -88,11 +88,11 @@ export class PortraitComponent {
         html`
         <a class="i-amphtml-story-bookend-portrait"
           target="_top">
-          <h2 class="i-amphtml-story-bookend-portrait-category"
+          <h2 class="i-amphtml-story-bookend-component-category"
             ref="category"></h2>
           <amp-img class="i-amphtml-story-bookend-portrait-image"
             layout="fixed" width="0" height="0" ref="image"></amp-img>
-          <div class="i-amphtml-story-bookend-portrait-meta"
+          <div class="i-amphtml-story-bookend-component-meta"
             ref="meta"></div>
         </a>`;
     addAttributesToElement(template, dict({'href': portraitData.url}));

--- a/extensions/amp-story/1.0/test/test-amp-story-bookend.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-bookend.js
@@ -267,6 +267,7 @@ describes.realWin('amp-story-bookend', {
           'skipping invalid.​​​');
     });
   });
+
   it('should reject invalid user json for the cta links component', () => {
     const ctaLinkComponent = new CtaLinkComponent();
     const userJson = {

--- a/extensions/amp-story/1.0/test/test-amp-story-bookend.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-bookend.js
@@ -19,6 +19,7 @@ import {AmpStoryRequestService} from '../amp-story-request-service';
 import {AmpStoryStoreService} from '../amp-story-store-service';
 import {ArticleComponent} from '../bookend/components/article';
 import {CtaLinkComponent} from '../bookend/components/cta-link';
+import {LandscapeComponent} from '../bookend/components/landscape';
 import {LocalizationService} from '../localization';
 import {createElementWithAttributes} from '../../../../src/dom';
 import {registerServiceBuilder} from '../../../../src/service';
@@ -62,6 +63,14 @@ describes.realWin('amp-story-bookend', {
           'url': 'google.com',
         },
       ],
+    },
+    {
+      'type': 'landscape',
+      'title': 'TRAPPIST-1 Planets May Still Be Wet Enough for Life',
+      'domainName': 'example.com',
+      'url': 'http://example.com/article.html',
+      'category': 'astronomy',
+      'image': 'http://placehold.it/256x128',
     },
   ];
 
@@ -148,6 +157,13 @@ describes.realWin('amp-story-bookend', {
             },
           ],
         },
+        {
+          'type': 'landscape',
+          'title': 'TRAPPIST-1 Planets May Still Be Wet Enough for Life',
+          'url': 'http://example.com/article.html',
+          'category': 'astronomy',
+          'image': 'http://placehold.it/256x128',
+        },
       ],
     };
 
@@ -200,6 +216,13 @@ describes.realWin('amp-story-bookend', {
             },
           ],
         },
+        {
+          'type': 'landscape',
+          'title': 'TRAPPIST-1 Planets May Still Be Wet Enough for Life',
+          'url': 'http://example.com/article.html',
+          'category': 'astronomy',
+          'image': 'http://placehold.it/256x128',
+        },
       ],
     };
 
@@ -244,7 +267,6 @@ describes.realWin('amp-story-bookend', {
           'skipping invalid.​​​');
     });
   });
-
   it('should reject invalid user json for the cta links component', () => {
     const ctaLinkComponent = new CtaLinkComponent();
     const userJson = {
@@ -276,6 +298,41 @@ describes.realWin('amp-story-bookend', {
       expect(() => ctaLinkComponent.assertValidity(userJson)).to.throw(
           'CTA link component must be an array' +
           ' and contain at least one link inside it.');
+    });
+  });
+
+  it('should reject invalid user json for a landscape component', () => {
+    const landscapeComponent = new LandscapeComponent();
+    const userJson = {
+      'bookend-version': 'v1.0',
+      'share-providers': [
+        'email',
+        {'provider': 'facebook', 'app-id': '254325784911610'},
+        'whatsapp',
+      ],
+      'components': [
+        {
+          'type': 'heading',
+          'title': 'test',
+        },
+        {
+          'type': 'small',
+          'url': 'http://example.com/article.html',
+          'image': 'http://placehold.it/256x128',
+        },
+        {
+          'type': 'landscape',
+          'url': 'http://example.com/article.html',
+          'category': 'astronomy',
+          'image': 'http://placehold.it/256x128',
+        },
+      ],
+    };
+
+    allowConsoleError(() => {
+      expect(() => landscapeComponent.assertValidity(userJson)).to.throw(
+          'landscape component must contain `title`, `category`, `image`,' +
+          ' and `url` fields, skipping invalid.');
     });
   });
 });


### PR DESCRIPTION
Part of #12167
* Adds new landscape component for the bookend components.
* Renames some css classes so they can be reused between components. 
  * `...-portrait-meta`, `...-article-meta` -> `...-component-meta`
  * `...-portrait-category` -> `...-component-category` 
* Includes the new component in the unit tests and in the example bookend.

![image](https://user-images.githubusercontent.com/5449100/40142484-bc4ef590-5926-11e8-9aa6-8d710681c671.png)