### PR TITLE
♻️Deprecate parseUrl

### DIFF
--- a/3p/ampcontext.js
+++ b/3p/ampcontext.js
@@ -20,7 +20,7 @@ import {dev} from '../src/log';
 import {dict} from '../src/utils/object';
 import {isObject} from '../src/types';
 import {nextTick} from './3p';
-import {parseUrl} from '../src/url';
+import {parseUrlDeprecated} from '../src/url';
 import {tryParseJson} from '../src/json';
 
 export class AbstractAmpContext {
@@ -294,7 +294,7 @@ export class AbstractAmpContext {
     this.initialConsentState = context.initialConsentState;
     this.initialLayoutRect = context.initialLayoutRect;
     this.initialIntersection = context.initialIntersection;
-    this.location = parseUrl(context.location.href);
+    this.location = parseUrlDeprecated(context.location.href);
     this.mode = context.mode;
     this.pageViewId = context.pageViewId;
     this.referrer = context.referrer;

--- a/3p/frame-metadata.js
+++ b/3p/frame-metadata.js
@@ -19,7 +19,7 @@ import {dict} from '../src/utils/object.js';
 import {getMode} from '../src/mode';
 import {once} from '../src/utils/function.js';
 import {parseJson} from '../src/json';
-import {parseUrl} from '../src/url';
+import {parseUrlDeprecated} from '../src/url';
 
 
 /**
@@ -117,7 +117,8 @@ export function getAttributeData() {
  * @return {!Location}
  */
 const getLocationImpl_ = once(() => {
-  return parseUrl(allMetadata()['attributes']['_context']['location']['href']);
+  const href = allMetadata()['attributes']['_context']['location']['href'];
+  return parseUrlDeprecated(href);
 });
 
 

--- a/3p/integration.js
+++ b/3p/integration.js
@@ -36,7 +36,7 @@ import {
   getLocation,
 } from './frame-metadata';
 import {getMode} from '../src/mode';
-import {getSourceUrl, isProxyOrigin, parseUrl} from '../src/url';
+import {getSourceUrl, isProxyOrigin, parseUrlDeprecated} from '../src/url';
 import {
   initLogConstructor,
   isUserErrorMessage,
@@ -574,7 +574,7 @@ export function validateParentOrigin(window, parentLocation) {
  * @visibleForTesting
  */
 export function validateAllowedTypes(window, type, allowedTypes) {
-  const thirdPartyHost = parseUrl(urls.thirdParty).hostname;
+  const thirdPartyHost = parseUrlDeprecated(urls.thirdParty).hostname;
 
   // Everything allowed in default iframe.
   if (window.location.hostname == thirdPartyHost) {
@@ -607,12 +607,13 @@ export function validateAllowedEmbeddingOrigins(window, allowedHostnames) {
   // We prefer the unforgable ancestorOrigins, but referrer is better than
   // nothing.
   const ancestor = ancestors ? ancestors[0] : window.document.referrer;
-  let hostname = parseUrl(ancestor).hostname;
+  let hostname = parseUrlDeprecated(ancestor).hostname;
   if (isProxyOrigin(ancestor)) {
     // If we are on the cache domain, parse the source hostname from
     // the referrer. The referrer is used because it should be
     // trustable.
-    hostname = parseUrl(getSourceUrl(window.document.referrer)).hostname;
+    hostname = parseUrlDeprecated(getSourceUrl(window.document.referrer))
+        .hostname;
   }
   for (let i = 0; i < allowedHostnames.length; i++) {
     // Either the hostname is exactly as whitelisted…

--- a/ads/alp/handler.js
+++ b/ads/alp/handler.js
@@ -21,7 +21,7 @@ import {
 import {closest, openWindowDialog} from '../../src/dom';
 import {dev} from '../../src/log';
 import {dict} from '../../src/utils/object';
-import {isLocalhostOrigin, isProxyOrigin, parseUrl} from '../../src/url';
+import {isLocalhostOrigin, isProxyOrigin, parseUrlDeprecated} from '../../src/url';
 import {startsWith} from '../../src/string';
 import {urls} from '../../src/config';
 
@@ -83,7 +83,7 @@ export function handleClick(e, opt_viewerNavigate) {
   const ancestors = win.location.ancestorOrigins;
   if (ancestors && ancestors[ancestors.length - 1] == 'http://localhost:8000') {
     destination = destination.replace(
-        `${parseUrl(link.eventualUrl).host}/c/`,
+        `${parseUrlDeprecated(link.eventualUrl).host}/c/`,
         'http://localhost:8000/max/');
   }
   e.preventDefault();
@@ -133,7 +133,7 @@ function getEventualUrl(a) {
     return;
   }
   if (!isProxyOrigin(eventualUrl) ||
-      !startsWith(parseUrl(eventualUrl).pathname, '/c/')) {
+      !startsWith(parseUrlDeprecated(eventualUrl).pathname, '/c/')) {
     return;
   }
   return eventualUrl;

--- a/ads/cedato.js
+++ b/ads/cedato.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {parseUrl} from '../src/url';
+import {parseUrlDeprecated} from '../src/url';
 import {setStyles} from '../src/style';
 import {validateData} from '../3p/3p';
 
@@ -39,7 +39,8 @@ export function cedato(global, data) {
   }
 
   const cb = Math.floor(Math.random() * 10000);
-  const domain = data.domain || parseUrl(global.context.sourceUrl).origin;
+  const domain = data.domain ||
+    parseUrlDeprecated(global.context.sourceUrl).origin;
 
   /* Create div for ad to target */
   const playerDiv = global.document.createElement('div');

--- a/ads/contentad.js
+++ b/ads/contentad.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {parseUrl} from '../src/url';
+import {parseUrlDeprecated} from '../src/url';
 import {validateData, writeScript} from '../3p/3p';
 
 /**
@@ -37,7 +37,7 @@ export function contentad(global, data) {
   let sourceUrl = window.context.sourceUrl;
   if (data.url) {
     const domain = data.url || window.atob(data.d);
-    sourceUrl = sourceUrl.replace(parseUrl(sourceUrl).host, domain);
+    sourceUrl = sourceUrl.replace(parseUrlDeprecated(sourceUrl).host, domain);
   }
 
   /* Build API URL */

--- a/ads/google/a4a/utils.js
+++ b/ads/google/a4a/utils.js
@@ -28,7 +28,7 @@ import {
 } from '../../../src/experiments';
 import {makeCorrelator} from '../correlator';
 import {parseJson} from '../../../src/json';
-import {parseUrl} from '../../../src/url';
+import {parseUrlDeprecated} from '../../../src/url';
 import {whenUpgradedToCustomElement} from '../../../src/dom';
 
 /** @type {string}  */
@@ -367,16 +367,16 @@ function topWindowUrlOrDomain(win) {
     const secondFromTop = secondWindowFromTop(win);
     if (secondFromTop == win ||
         origin == ancestorOrigins[ancestorOrigins.length - 2]) {
-      return parseUrl(secondFromTop./*OK*/document.referrer).hostname;
+      return parseUrlDeprecated(secondFromTop./*OK*/document.referrer).hostname;
     }
-    return parseUrl(topOrigin).hostname;
+    return parseUrlDeprecated(topOrigin).hostname;
   } else {
     try {
       return win.top.location.hostname;
     } catch (e) {}
     const secondFromTop = secondWindowFromTop(win);
     try {
-      return parseUrl(secondFromTop./*OK*/document.referrer).hostname;
+      return parseUrlDeprecated(secondFromTop./*OK*/document.referrer).hostname;
     } catch (e) {}
     return null;
   }
@@ -824,7 +824,8 @@ export function getIdentityTokenRequestUrl(win, nodeOrDoc, domain = undefined) {
   }
   domain = domain || '.google.com';
   const canonical =
-    parseUrl(Services.documentInfoForDoc(nodeOrDoc).canonicalUrl).hostname;
+    parseUrlDeprecated(Services.documentInfoForDoc(nodeOrDoc).canonicalUrl)
+        .hostname;
   return `https://adservice${domain}/adsid/integrator.json?domain=${canonical}`;
 }
 

--- a/ads/kixer.js
+++ b/ads/kixer.js
@@ -15,7 +15,7 @@
  */
 
 import {loadScript, validateData} from '../3p/3p';
-import {parseUrl} from '../src/url';
+import {parseUrlDeprecated} from '../src/url';
 
 /* global
 __kxamp: false,
@@ -82,7 +82,7 @@ export function kixer(global, data) {
   });
 
   loadScript(global, 'https://cdn.kixer.com/ad/load.js', () => {
-    global.__kx_domain = parseUrl(global.context.sourceUrl).hostname; // Get domain
+    global.__kx_domain = parseUrlDeprecated(global.context.sourceUrl).hostname; // Get domain
     __kxamp[data.adslot] = 1;
     __kx_ad_slots.push(data.adslot);
     __kx_ad_start();

--- a/ads/medianet.js
+++ b/ads/medianet.js
@@ -15,7 +15,7 @@
  */
 
 import {computeInMasterFrame, validateData, writeScript} from '../3p/3p';
-import {getSourceUrl, parseUrl} from '../src/url';
+import {getSourceUrl, parseUrlDeprecated} from '../src/url';
 
 const mandatoryParams = ['tagtype', 'cid'],
     optionalParams = [
@@ -175,7 +175,7 @@ function loadHBTag(global, data, publisherUrl, referrerUrl) {
       },
     };
     global.advBidxc.amp = getCallbacksObject();
-    const publisherDomain = parseUrl(publisherUrl).hostname;
+    const publisherDomain = parseUrlDeprecated(publisherUrl).hostname;
     writeScript(global, 'https://contextual.media.net/bidexchange.js?https=1&amp=1&cid=' + encodeURIComponent(data.cid) + '&dn=' + encodeURIComponent(publisherDomain), () => {
       done(null);
     });

--- a/examples/viewer-iframe-poll.html
+++ b/examples/viewer-iframe-poll.html
@@ -219,7 +219,7 @@
         paddingTop: this.header./*OK*/offsetHeight,
         visibilityState: this.visibilityState_,
         prerenderSize: this.prerenderSize_,
-        origin: parseUrl(window.location.href).origin,
+        origin: parseUrlDeprecated(window.location.href).origin,
         csi: this.csi_,
         cap: 'foo,a2a,swipe,handshakepoll'
       };
@@ -229,7 +229,7 @@
       if (window.location.hash && window.location.hash.length > 1) {
         inputUrl += '&' + window.location.hash.substring(1);
       }
-      var parsedUrl = parseUrl(inputUrl);
+      var parsedUrl = parseUrlDeprecated(inputUrl);
       var url = parsedUrl.href;
       this.frameOrigin_ = parsedUrl.origin;
       log('AMP URL = ', url);
@@ -442,7 +442,7 @@
     }
 
 
-    function parseUrl(urlString) {
+    function parseUrlDeprecated(urlString) {
       var a = document.createElement('a');
       a.href = urlString;
       return {

--- a/examples/viewer-webview.html
+++ b/examples/viewer-webview.html
@@ -219,7 +219,7 @@
         paddingTop: this.header./*OK*/offsetHeight,
         visibilityState: this.visibilityState_,
         prerenderSize: this.prerenderSize_,
-        origin: parseUrl(window.location.href).origin,
+        origin: parseUrlDeprecated(window.location.href).origin,
         csi: this.csi_,
         cap: 'foo,a2a,swipe',
         webview: 1, // mocking a webview
@@ -230,7 +230,7 @@
       if (window.location.hash && window.location.hash.length > 1) {
         inputUrl += '&' + window.location.hash.substring(1);
       }
-      var parsedUrl = parseUrl(inputUrl);
+      var parsedUrl = parseUrlDeprecated(inputUrl);
       var url = parsedUrl.href;
       this.frameOrigin_ = parsedUrl.origin;
       log('AMP URL = ', url);
@@ -443,7 +443,7 @@
     }
 
 
-    function parseUrl(urlString) {
+    function parseUrlDeprecated(urlString) {
       var a = document.createElement('a');
       a.href = urlString;
       return {

--- a/examples/viewer.html
+++ b/examples/viewer.html
@@ -219,7 +219,7 @@
         paddingTop: this.header./*OK*/offsetHeight,
         visibilityState: this.visibilityState_,
         prerenderSize: this.prerenderSize_,
-        origin: parseUrl(window.location.href).origin,
+        origin: parseUrlDeprecated(window.location.href).origin,
         csi: this.csi_,
         cap: 'foo,a2a,swipe',
       };
@@ -229,7 +229,7 @@
       if (window.location.hash && window.location.hash.length > 1) {
         inputUrl += '&' + window.location.hash.substring(1);
       }
-      var parsedUrl = parseUrl(inputUrl);
+      var parsedUrl = parseUrlDeprecated(inputUrl);
       var url = parsedUrl.href;
       this.frameOrigin_ = parsedUrl.origin;
       log('AMP URL = ', url);
@@ -441,7 +441,7 @@
       console/*OK*/.log.apply(console, var_args);
     }
 
-    function parseUrl(urlString) {
+    function parseUrlDeprecated(urlString) {
       var a = document.createElement('a');
       a.href = urlString;
       return {

--- a/extensions/amp-a4a/0.1/amp-ad-templates.js
+++ b/extensions/amp-a4a/0.1/amp-ad-templates.js
@@ -21,7 +21,7 @@ import {dev} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {getMode} from '../../../src/mode';
 import {isArray} from '../../../src/types';
-import {parseUrl} from '../../../src/url';
+import {parseUrlDeprecated} from '../../../src/url';
 import {urls} from '../../../src/config';
 
 /** @private {!Object<string, string|boolean>} */
@@ -115,7 +115,7 @@ export class AmpAdTemplates {
    */
   getTemplateProxyUrl_(url) {
     const cdnUrlSuffix = urls.cdn.slice(8);
-    const loc = parseUrl(url);
+    const loc = parseUrlDeprecated(url);
     return loc.origin.indexOf(cdnUrlSuffix) > 0 ? url :
       'https://' + loc.hostname.replace(/-/g, '--').replace(/\./g, '-') +
       '.' + cdnUrlSuffix + '/ad/s/' + loc.hostname + loc.pathname;

--- a/extensions/amp-a4a/0.1/real-time-config-manager.js
+++ b/extensions/amp-a4a/0.1/real-time-config-manager.js
@@ -21,7 +21,7 @@ import {getMode} from '../../../src/mode';
 import {isArray, isObject} from '../../../src/types';
 import {
   isSecureUrl,
-  parseUrl,
+  parseUrlDeprecated,
 } from '../../../src/url';
 import {tryParseJson} from '../../../src/json';
 
@@ -119,7 +119,7 @@ export function sendErrorMessage(errorType, errorReportingUrl, win, ampDoc) {
  * @visibleForTesting
  */
 export function getCalloutParam_(url) {
-  const parsedUrl = parseUrl(url);
+  const parsedUrl = parseUrlDeprecated(url);
   return (parsedUrl.hostname + parsedUrl.pathname).substr(0, 50);
 }
 

--- a/extensions/amp-access/0.1/amp-access-iframe.js
+++ b/extensions/amp-access/0.1/amp-access-iframe.js
@@ -23,7 +23,7 @@ import {dict} from '../../../src/utils/object';
 import {getMode} from '../../../src/mode';
 import {isArray} from '../../../src/types';
 import {parseJson} from '../../../src/json';
-import {parseUrl} from '../../../src/url';
+import {parseUrlDeprecated} from '../../../src/url';
 import {toggle} from '../../../src/style';
 
 const AUTHORIZATION_TIMEOUT = 3000;
@@ -69,7 +69,7 @@ export class AccessIframeAdapter {
         '"defaultResponse" must be specified');
 
     /** @private @const {string} */
-    this.targetOrigin_ = parseUrl(this.iframeSrc_).origin;
+    this.targetOrigin_ = parseUrlDeprecated(this.iframeSrc_).origin;
 
     /** @private {?function()} */
     this.connectedResolver_ = null;

--- a/extensions/amp-access/0.1/login-dialog.js
+++ b/extensions/amp-access/0.1/login-dialog.js
@@ -20,7 +20,7 @@ import {dict} from '../../../src/utils/object';
 import {getData, listen} from '../../../src/event-helper';
 import {getMode} from '../../../src/mode';
 import {openWindowDialog} from '../../../src/dom';
-import {parseUrl} from '../../../src/url';
+import {parseUrlDeprecated} from '../../../src/url';
 import {urls} from '../../../src/config';
 
 /** @const */
@@ -266,7 +266,7 @@ export class WebLoginDialog {
    * @private
    */
   setupDialog_(returnUrl) {
-    const returnOrigin = parseUrl(returnUrl).origin;
+    const returnOrigin = parseUrlDeprecated(returnUrl).origin;
 
     this.heartbeatInterval_ = this.win.setInterval(() => {
       if (this.dialog_.closed) {

--- a/extensions/amp-ad-exit/0.1/amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/amp-ad-exit.js
@@ -32,7 +32,7 @@ import {isObject} from '../../../src/types';
 import {makeClickDelaySpec} from './filters/click-delay';
 import {makeInactiveElementSpec} from './filters/inactive-element';
 import {parseJson} from '../../../src/json';
-import {parseUrl} from '../../../src/url';
+import {parseUrlDeprecated} from '../../../src/url';
 const TAG = 'amp-ad-exit';
 
 /**
@@ -290,7 +290,7 @@ export class AmpAdExit extends AMP.BaseElement {
             continue;
           }
           const vendor = matches[1];
-          const origin = parseUrl(assertVendor(vendor)).origin;
+          const origin = parseUrlDeprecated(assertVendor(vendor)).origin;
           this.expectedOriginToVendor_[origin] =
               this.expectedOriginToVendor_[origin] || vendor;
         }
@@ -392,7 +392,8 @@ export class AmpAdExit extends AMP.BaseElement {
     user().assert(responseMessage['vendor'],
         'Received malformed message from 3p analytics frame: ' +
         'vendor missing');
-    const vendorURL = parseUrl(assertVendor(responseMessage['vendor']));
+    const vendorURL = parseUrlDeprecated(assertVendor(
+        responseMessage['vendor']));
     user().assert(vendorURL && vendorURL.origin == eventOrigin,
         'Invalid origin for vendor ' +
         `${responseMessage['vendor']}: ${eventOrigin}`);

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-adsense-a4a-config.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-adsense-a4a-config.js
@@ -24,7 +24,7 @@ import {createIframePromise} from '../../../../testing/iframe';
 import {
   isInExperiment,
 } from '../../../../ads/google/a4a/traffic-experiments';
-import {isProxyOrigin, parseUrl} from '../../../../src/url';
+import {isProxyOrigin, parseUrlDeprecated} from '../../../../src/url';
 import {urls} from '../../../../src/config';
 
 describe('adsense-a4a-config', () => {
@@ -36,7 +36,7 @@ describe('adsense-a4a-config', () => {
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
     mockWin = {
-      location: parseUrl('https://nowhere.org/a/place/page.html?s=foo&q=bar'),
+      location: parseUrlDeprecated('https://nowhere.org/a/place/page.html?s=foo&q=bar'),
       document: {
         querySelector: unused => {return null;},
       },
@@ -54,7 +54,7 @@ describe('adsense-a4a-config', () => {
   describe('#adsenseIsA4AEnabled', () => {
 
     it('should not enable a4a when missing data-ad-client', () => {
-      mockWin.location = parseUrl(
+      mockWin.location = parseUrlDeprecated(
           'https://cdn.ampproject.org/some/path/to/content.html');
       const elem = testFixture.doc.createElement('div');
       testFixture.doc.body.appendChild(elem);
@@ -62,7 +62,7 @@ describe('adsense-a4a-config', () => {
     });
 
     it('should not enable a4a when useRemoteHtml is true', () => {
-      mockWin.location = parseUrl(
+      mockWin.location = parseUrlDeprecated(
           'https://cdn.ampproject.org/some/path/to/content.html');
       sandbox.stub(urls, 'cdnProxyRegex').callsFake(
           /^https:\/\/([a-zA-Z0-9_-]+\.)?cdn\.ampproject\.org/);
@@ -75,7 +75,7 @@ describe('adsense-a4a-config', () => {
 
     // TODO(bradfrizzell, #12476): Make this test work with sinon 4.0.
     it.skip('should not enable a4a when on a non-Google AMP cache', () => {
-      mockWin.location = parseUrl(
+      mockWin.location = parseUrlDeprecated(
           'https://amp.cloudflare.com/some/path/to/content.html');
       sandbox.stub(urls, 'cdnProxyRegex').callsFake(
           /^https:\/\/([a-zA-Z0-9_-]+\.)?amp\.cloudflare\.com/);
@@ -88,7 +88,7 @@ describe('adsense-a4a-config', () => {
 
     Object.keys(URL_EXPERIMENT_MAPPING).forEach(expFlagValue => {
       it(`exp flag=${expFlagValue} should set eid attribute`, () => {
-        mockWin.location = parseUrl(
+        mockWin.location = parseUrlDeprecated(
             'https://cdn.ampproject.org/some/path/to/content.html?exp=aa:' +
             String(expFlagValue));
         const elem = testFixture.doc.createElement('div');

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
@@ -19,7 +19,7 @@ import {dev} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {getData} from '../../../src/event-helper';
 import {getStyle} from '../../../src/style';
-import {parseUrl} from '../../../src/url';
+import {parseUrlDeprecated} from '../../../src/url';
 import {setStyles} from '../../../src/style';
 import {throttle} from '../../../src/utils/rate-limit';
 import {tryParseJson} from '../../../src/json';
@@ -258,7 +258,7 @@ export class SafeframeHostApi {
       case 'no-referrer':
         return;
       case 'origin':
-        return parseUrl(canonicalUrl).origin;
+        return parseUrlDeprecated(canonicalUrl).origin;
     }
     return canonicalUrl;
   }

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-a4a-config.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-a4a-config.js
@@ -31,7 +31,7 @@ import {
   isInExperiment,
 } from '../../../../ads/google/a4a/traffic-experiments';
 import {createIframePromise} from '../../../../testing/iframe';
-import {parseUrl} from '../../../../src/url';
+import {parseUrlDeprecated} from '../../../../src/url';
 import {toggleExperiment} from '../../../../src/experiments';
 
 describe('doubleclick-a4a-config', () => {
@@ -43,7 +43,7 @@ describe('doubleclick-a4a-config', () => {
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
     mockWin = {
-      location: parseUrl('https://nowhere.org/a/place/page.html?s=foo&q=bar'),
+      location: parseUrlDeprecated('https://nowhere.org/a/place/page.html?s=foo&q=bar'),
       crypto: {
         subtle: true,
         webkitSubtle: true,
@@ -63,7 +63,7 @@ describe('doubleclick-a4a-config', () => {
       // Ensure no selection in order to very experiment attribute.
       sandbox.stub(DoubleclickA4aEligibility.prototype, 'maybeSelectExperiment')
           .returns(null);
-      mockWin.location = parseUrl(
+      mockWin.location = parseUrlDeprecated(
           'https://cdn.ampproject.org/some/path/to/content.html');
       const elem = testFixture.doc.createElement('div');
       testFixture.doc.body.appendChild(elem);
@@ -75,7 +75,7 @@ describe('doubleclick-a4a-config', () => {
       // Ensure no selection in order to very experiment attribute.
       sandbox.stub(DoubleclickA4aEligibility.prototype, 'maybeSelectExperiment')
           .returns(null);
-      mockWin.location = parseUrl(
+      mockWin.location = parseUrlDeprecated(
           'https://cdn.ampproject.org/some/path/to/content.html');
       const elem = testFixture.doc.createElement('div');
       testFixture.doc.body.appendChild(elem);
@@ -92,7 +92,7 @@ describe('doubleclick-a4a-config', () => {
       // Ensure no selection in order to very experiment attribute.
       sandbox.stub(DoubleclickA4aEligibility.prototype, 'maybeSelectExperiment')
           .returns(null);
-      mockWin.location = parseUrl(
+      mockWin.location = parseUrlDeprecated(
           'https://cdn.ampproject.org/some/path/to/content.html');
       const elem = testFixture.doc.createElement('div');
       testFixture.doc.body.appendChild(elem);
@@ -109,7 +109,7 @@ describe('doubleclick-a4a-config', () => {
       sandbox.stub(DoubleclickA4aEligibility.prototype,
           'maybeSelectExperiment')
           .returns(null);
-      mockWin.location = parseUrl(
+      mockWin.location = parseUrlDeprecated(
           'https://cdn.ampproject.org/some/path/to/content.html');
       const elem = testFixture.doc.createElement('div');
       elem.setAttribute('rtc-config', '{"urls": ["https://www.foo.com/"]}');
@@ -127,7 +127,7 @@ describe('doubleclick-a4a-config', () => {
       sandbox.stub(DoubleclickA4aEligibility.prototype,
           'maybeSelectExperiment')
           .returns(null);
-      mockWin.location = parseUrl(
+      mockWin.location = parseUrlDeprecated(
           'https://cdn.ampproject.org/some/path/to/content.html');
       const elem = testFixture.doc.createElement('div');
       elem.setAttribute(
@@ -144,7 +144,7 @@ describe('doubleclick-a4a-config', () => {
       // Ensure no selection in order to very experiment attribute.
       sandbox.stub(DoubleclickA4aEligibility.prototype, 'maybeSelectExperiment')
           .returns(null);
-      mockWin.location = parseUrl(
+      mockWin.location = parseUrlDeprecated(
           'https://cdn.ampproject.org/some/path/to/content.html');
       const elem = testFixture.doc.createElement('div');
       elem.setAttribute('rtc-config', '{"urls": ["https://www.foo.com/"]}');
@@ -182,7 +182,7 @@ describe('doubleclick-a4a-config', () => {
 
     it('should honor url forced FF on non-CDN', () => {
       mockWin.AMP_MODE = {test: false, localDev: true};
-      mockWin.location = parseUrl(
+      mockWin.location = parseUrlDeprecated(
           'https://foo.com/some/path/to/content.html?exp=a4a:-1');
       sandbox.stub(DoubleclickA4aEligibility.prototype,
           'isCdnProxy').callsFake(() => false);
@@ -204,7 +204,7 @@ describe('doubleclick-a4a-config', () => {
       // Ensure no selection in order to very experiment attribute.
       sandbox.stub(DoubleclickA4aEligibility.prototype, 'maybeSelectExperiment')
           .returns(null);
-      mockWin.location = parseUrl(
+      mockWin.location = parseUrlDeprecated(
           'https://cdn.ampproject.org/some/path/to/content.html');
 
       const elem1 = testFixture.doc.createElement('div');
@@ -228,7 +228,7 @@ describe('doubleclick-a4a-config', () => {
       // Ensure no selection in order to very experiment attribute.
       sandbox.stub(DoubleclickA4aEligibility.prototype, 'maybeSelectExperiment')
           .returns(null);
-      mockWin.location = parseUrl(
+      mockWin.location = parseUrlDeprecated(
           'https://cdn.ampproject.org/some/path/to/content.html');
 
       const elem1 = testFixture.doc.createElement('div');
@@ -251,7 +251,7 @@ describe('doubleclick-a4a-config', () => {
       // Ensure no selection in order to very experiment attribute.
       sandbox.stub(DoubleclickA4aEligibility.prototype, 'maybeSelectExperiment')
           .returns(null);
-      mockWin.location = parseUrl(
+      mockWin.location = parseUrlDeprecated(
           'https://cdn.ampproject.org/content.html?exp=da:6');
       const useRemoteHtml = false;
       const elem1 = testFixture.doc.createElement('div');
@@ -267,7 +267,7 @@ describe('doubleclick-a4a-config', () => {
       // Ensure no selection in order to very experiment attribute.
       sandbox.stub(DoubleclickA4aEligibility.prototype, 'maybeSelectExperiment')
           .returns(null);
-      mockWin.location = parseUrl(
+      mockWin.location = parseUrlDeprecated(
           'https://cdn.ampproject.org/content.html?exp=da:6');
       const useRemoteHtml = false;
       const elem1 = testFixture.doc.createElement('div');
@@ -286,7 +286,7 @@ describe('doubleclick-a4a-config', () => {
       // Ensure no selection in order to very experiment attribute.
       sandbox.stub(DoubleclickA4aEligibility.prototype, 'maybeSelectExperiment')
           .returns(null);
-      mockWin.location = parseUrl(
+      mockWin.location = parseUrlDeprecated(
           'https://cdn.ampproject.org/content.html?exp=da:6');
       const useRemoteHtml = true;
       const elem1 = testFixture.doc.createElement('div');
@@ -303,7 +303,7 @@ describe('doubleclick-a4a-config', () => {
       // Ensure no selection in order to very experiment attribute.
       sandbox.stub(DoubleclickA4aEligibility.prototype, 'maybeSelectExperiment')
           .returns(null);
-      mockWin.location = parseUrl(
+      mockWin.location = parseUrlDeprecated(
           'https://cdn.ampproject.org/content.html?exp=da:6');
       const useRemoteHtml = true;
       const elem1 = testFixture.doc.createElement('div');
@@ -319,7 +319,7 @@ describe('doubleclick-a4a-config', () => {
 
     Object.keys(URL_EXPERIMENT_MAPPING).forEach(expFlagValue => {
       it(`exp flag=${expFlagValue} should set eid attribute`, () => {
-        mockWin.location = parseUrl(
+        mockWin.location = parseUrlDeprecated(
             'https://cdn.ampproject.org/some/path/to/content.html?exp=a4a:' +
             String(expFlagValue));
         const elem = testFixture.doc.createElement('div');
@@ -378,7 +378,7 @@ describe('doubleclick-a4a-config', () => {
         elem = testFixture.doc.createElement('amp-ad');
         elem.setAttribute('type', 'doubleclick');
         testFixture.doc.body.appendChild(elem);
-        mockWin.location = parseUrl(
+        mockWin.location = parseUrlDeprecated(
             'https://cdn.ampproject.org/some/path/to/content.html?exp=da:8');
       });
       it('should select SRA', () => {

--- a/extensions/amp-addthis/0.1/addthis-utils/lojson.js
+++ b/extensions/amp-addthis/0.1/addthis-utils/lojson.js
@@ -29,7 +29,7 @@ import {
 } from './fragment';
 import {getMetaElements} from './meta';
 import {getSessionId} from './session';
-import {parseUrl} from '../../../../src/url';
+import {parseUrlDeprecated} from '../../../../src/url';
 import {toArray} from '../../../../src/types';
 
 const VIEW_EVENT_CHANNEL = 100;
@@ -83,7 +83,7 @@ const getLojsonData = ({
     protocol,
     port,
   };
-  const parsedReferrer = referrer ? parseUrl(referrer) : {};
+  const parsedReferrer = referrer ? parseUrlDeprecated(referrer) : {};
   const langParts = atConfig.ui_language.split('-');
   const langWithoutLocale = langParts[0];
   const locale = langParts.slice(1);
@@ -109,7 +109,7 @@ const getLojsonData = ({
     dp: host,
     dr: host === parsedReferrer.host ? undefined : parsedReferrer.host,
     fcu: service ? '' : getFragmentId(pageInfo.du),
-    fp: parseUrl(clearOurFragment(pageInfo.du)).pathname,
+    fp: parseUrlDeprecated(clearOurFragment(pageInfo.du)).pathname,
     fr: parsedReferrer.pathname || '',
     gen: VIEW_EVENT_CHANNEL,
     ln: langWithoutLocale,
@@ -120,7 +120,8 @@ const getLojsonData = ({
         0,
     pd: isProductPage(win.document, metaElements) ? 1 : 0,
     pub: pubId,
-    rb: classifyReferrer(referrer, parsedReferrer, parseUrl(pageInfo.du)),
+    rb: classifyReferrer(referrer, parsedReferrer,
+        parseUrlDeprecated(pageInfo.du)),
     sid: getSessionId(),
     skipb: 1,
     sr: service,

--- a/extensions/amp-addthis/0.1/addthis-utils/pixel.js
+++ b/extensions/amp-addthis/0.1/addthis-utils/pixel.js
@@ -22,7 +22,7 @@ import {getData} from '../../../../src/event-helper';
 import {isObject} from '../../../../src/types';
 import {parseJson} from '../../../../src/json';
 
-import {parseUrl} from '../../../../src/url';
+import {parseUrlDeprecated} from '../../../../src/url';
 import {setStyles} from '../../../../src/style';
 
 const RE_IFRAME = /#iframe$/;
@@ -83,7 +83,7 @@ export const pixelDrop = (url, ampDoc) => {
   doc.body.appendChild(ampPixel);
 };
 
-const getIframeName = url => parseUrl(url).host
+const getIframeName = url => parseUrlDeprecated(url).host
     .split('.')
     .concat(pixelatorFrameTitle.toLowerCase().replace(/\s/, '_'));
 

--- a/extensions/amp-addthis/0.1/addthis-utils/pjson.js
+++ b/extensions/amp-addthis/0.1/addthis-utils/pjson.js
@@ -23,7 +23,7 @@ import {
 } from './classify';
 import {getMetaElements} from './meta';
 import {getSessionId} from './session';
-import {parseUrl} from '../../../../src/url';
+import {parseUrlDeprecated} from '../../../../src/url';
 import {toArray} from '../../../../src/types';
 
 // "gen" value for shares
@@ -69,7 +69,7 @@ const getPjsonData = ({loc, referrer, title, ampDoc, pubId, data}) => {
     protocol,
     port,
   };
-  const parsedReferrer = referrer ? parseUrl(referrer) : {};
+  const parsedReferrer = referrer ? parseUrlDeprecated(referrer) : {};
   const {win} = ampDoc;
   const metaElements = toArray(getMetaElements(win.document));
 
@@ -81,7 +81,8 @@ const getPjsonData = ({loc, referrer, title, ampDoc, pubId, data}) => {
     gen: SHARE,
     mk: getKeywordsString(metaElements),
     pub: pubId,
-    rb: classifyReferrer(referrer, parsedReferrer, parseUrl(pageInfo.du)),
+    rb: classifyReferrer(referrer, parsedReferrer,
+        parseUrlDeprecated(pageInfo.du)),
     sid: getSessionId(),
     url: data.url,
   };

--- a/extensions/amp-addthis/0.1/amp-addthis.js
+++ b/extensions/amp-addthis/0.1/amp-addthis.js
@@ -59,7 +59,7 @@ import {createElementWithAttributes, removeElement} from '../../../src/dom';
 import {dict} from '../../../src/utils/object';
 import {isLayoutSizeDefined} from '../../../src/layout';
 import {listen} from '../../../src/event-helper';
-import {parseUrl} from '../../../src/url';
+import {parseUrlDeprecated} from '../../../src/url';
 import {setStyle} from '../../../src/style';
 import {user} from '../../../src/log';
 
@@ -147,7 +147,7 @@ class AmpAddThis extends AMP.BaseElement {
       shouldRegisterView = false;
 
       const viewer = Services.viewerForDoc(ampDoc);
-      const loc = parseUrl(this.canonicalUrl_);
+      const loc = parseUrlDeprecated(this.canonicalUrl_);
 
       viewer.whenFirstVisible()
           .then(() => viewer.getReferrerUrl())

--- a/extensions/amp-analytics/0.1/resource-timing.js
+++ b/extensions/amp-analytics/0.1/resource-timing.js
@@ -17,7 +17,7 @@
 import {ExpansionOptions, variableServiceFor} from './variables';
 import {findIndex} from '../../../src/utils/array';
 import {isObject} from '../../../src/types';
-import {parseUrl} from '../../../src/url';
+import {parseUrlDeprecated} from '../../../src/url';
 import {user} from '../../../src/log';
 
 /**
@@ -153,7 +153,7 @@ function entryToExpansionOptions(entry, name, format) {
  * @return {?string} The name of the entry, or null if no matching name exists.
  */
 function nameForEntry(entry, resourcesByHost) {
-  const url = parseUrl(entry.name);
+  const url = parseUrlDeprecated(entry.name);
   for (let i = 0; i < resourcesByHost.length; ++i) {
     const {hostPattern, resources} = resourcesByHost[i];
     if (!hostPattern.test(url.host)) {

--- a/extensions/amp-analytics/0.1/transport.js
+++ b/extensions/amp-analytics/0.1/transport.js
@@ -18,7 +18,7 @@ import {Services} from '../../../src/services';
 import {
   assertHttpsUrl,
   checkCorsUrl,
-  parseUrl,
+  parseUrlDeprecated,
 } from '../../../src/url';
 import {dev, user} from '../../../src/log';
 import {loadPromise} from '../../../src/event-helper';
@@ -146,7 +146,8 @@ export function sendRequestUsingIframe(win, request) {
     }, 5000);
   };
   user().assert(
-      parseUrl(request).origin != parseUrl(win.location.href).origin,
+      parseUrlDeprecated(request).origin !=
+        parseUrlDeprecated(win.location.href).origin,
       'Origin of iframe request must not be equal to the document origin.' +
       ' See https://github.com/ampproject/' +
       ' amphtml/blob/master/spec/amp-iframe-origin-policy.md for details.');

--- a/extensions/amp-app-banner/0.1/amp-app-banner.js
+++ b/extensions/amp-app-banner/0.1/amp-app-banner.js
@@ -21,7 +21,7 @@ import {dev, rethrowAsync, user} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {isProtocolValid, isProxyOrigin} from '../../../src/url';
 import {openWindowDialog, removeElement} from '../../../src/dom';
-import {parseUrl} from '../../../src/url';
+import {parseUrlDeprecated} from '../../../src/url';
 
 const TAG = 'amp-app-banner';
 const OPEN_LINK_TIMEOUT = 1500;
@@ -427,7 +427,7 @@ export class AmpAndroidAppBanner extends AbstractAppBanner {
   /** @private */
   getAndroidIntentForUrl_(appId) {
     const canonicalUrl = Services.documentInfoForDoc(this.element).canonicalUrl;
-    const parsedUrl = parseUrl(canonicalUrl);
+    const parsedUrl = parseUrlDeprecated(canonicalUrl);
     const cleanProtocol = parsedUrl.protocol.replace(':', '');
     const host = parsedUrl.host;
     const pathname = parsedUrl.pathname;

--- a/extensions/amp-auto-ads/0.1/ad-network-config.js
+++ b/extensions/amp-auto-ads/0.1/ad-network-config.js
@@ -21,7 +21,7 @@ import {
 import {Services} from '../../../src/services';
 import {buildUrl} from '../../../ads/google/a4a/url-builder';
 import {dict} from '../../../src/utils/object';
-import {parseUrl} from '../../../src/url';
+import {parseUrlDeprecated} from '../../../src/url';
 
 
 /**
@@ -92,7 +92,7 @@ class AdSenseNetworkConfig {
   /** @override */
   getConfigUrl() {
     const docInfo = Services.documentInfoForDoc(this.autoAmpAdsElement_);
-    const canonicalHostname = parseUrl(docInfo.canonicalUrl).hostname;
+    const canonicalHostname = parseUrlDeprecated(docInfo.canonicalUrl).hostname;
     return buildUrl('//pagead2.googlesyndication.com/getconfig/ama', {
       'client': this.autoAmpAdsElement_.getAttribute('data-ad-client'),
       'plah': canonicalHostname,

--- a/extensions/amp-brightcove/0.1/test/test-amp-brightcove.js
+++ b/extensions/amp-brightcove/0.1/test/test-amp-brightcove.js
@@ -15,7 +15,7 @@
  */
 
 import '../amp-brightcove';
-import {parseUrl} from '../../../../src/url';
+import {parseUrlDeprecated} from '../../../../src/url';
 
 
 describes.realWin('amp-brightcove', {
@@ -94,7 +94,7 @@ describes.realWin('amp-brightcove', {
       'data-param-my-param': 'hello world',
     }).then(bc => {
       const iframe = bc.querySelector('iframe');
-      const params = parseUrl(iframe.src).search.split('&');
+      const params = parseUrlDeprecated(iframe.src).search.split('&');
       expect(params).to.contain('myParam=hello%20world');
     });
   });

--- a/extensions/amp-dynamic-css-classes/0.1/amp-dynamic-css-classes.js
+++ b/extensions/amp-dynamic-css-classes/0.1/amp-dynamic-css-classes.js
@@ -15,7 +15,7 @@
  */
 
 import {Services} from '../../../src/services';
-import {parseUrl} from '../../../src/url';
+import {parseUrlDeprecated} from '../../../src/url';
 
 
 /**
@@ -26,7 +26,7 @@ import {parseUrl} from '../../../src/url';
 function referrerDomain(ampdoc) {
   const referrer = Services.viewerForDoc(ampdoc).getUnconfirmedReferrerUrl();
   if (referrer) {
-    return parseUrl(referrer).hostname;
+    return parseUrlDeprecated(referrer).hostname;
   }
   return '';
 }

--- a/extensions/amp-form/0.1/form-proxy.js
+++ b/extensions/amp-form/0.1/form-proxy.js
@@ -15,7 +15,7 @@
  */
 
 import {dev} from '../../../src/log';
-import {parseUrl} from '../../../src/url';
+import {parseUrlDeprecated} from '../../../src/url';
 import {startsWith} from '../../../src/string';
 import {toWin} from '../../../src/types';
 
@@ -208,7 +208,7 @@ function setupLegacyProxy(form, proxy) {
             } else if (desc.type == LegacyPropDataType.URL) {
               // URLs, e.g. in `action` attribute are resolved against the
               // document's base.
-              value = parseUrl(/** @type {string} */ (value || '')).href;
+              value = parseUrlDeprecated(/** @type {string} */ (value || '')).href;
             }
             return value;
           },

--- a/extensions/amp-iframe/0.1/amp-iframe.js
+++ b/extensions/amp-iframe/0.1/amp-iframe.js
@@ -28,7 +28,7 @@ import {endsWith} from '../../../src/string';
 import {isAdPositionAllowed} from '../../../src/ad-helper';
 import {isExperimentOn} from '../../../src/experiments';
 import {isLayoutSizeDefined} from '../../../src/layout';
-import {isSecureUrl, parseUrl, removeFragment} from '../../../src/url';
+import {isSecureUrl, parseUrlDeprecated, removeFragment} from '../../../src/url';
 import {listenFor} from '../../../src/iframe-helper';
 import {moveLayoutRect} from '../../../src/layout-rect';
 import {parseJson} from '../../../src/json';
@@ -134,7 +134,7 @@ export class AmpIframe extends AMP.BaseElement {
   }
 
   assertSource(src, containerSrc, sandbox) {
-    const url = parseUrl(src);
+    const url = parseUrlDeprecated(src);
     // Some of these can be easily circumvented with redirects.
     // Checks are mostly there to prevent people easily do something
     // they did not mean to.
@@ -142,7 +142,7 @@ export class AmpIframe extends AMP.BaseElement {
         isSecureUrl(url) || url.protocol == 'data:',
         'Invalid <amp-iframe> src. Must start with https://. Found %s',
         this.element);
-    const containerUrl = parseUrl(containerSrc);
+    const containerUrl = parseUrlDeprecated(containerSrc);
     user().assert(
         !((' ' + sandbox + ' ').match(/\s+allow-same-origin\s+/i)) ||
         (url.origin != containerUrl.origin && url.protocol != 'data:'),
@@ -183,7 +183,7 @@ export class AmpIframe extends AMP.BaseElement {
     if (!src) {
       return;
     }
-    const url = parseUrl(src);
+    const url = parseUrlDeprecated(src);
     // data-URLs are not modified.
     if (url.protocol == 'data:') {
       return src;
@@ -575,7 +575,7 @@ export class AmpIframe extends AMP.BaseElement {
 
     const src = this.element.getAttribute('src');
     if (src) {
-      this.targetOrigin_ = parseUrl(src).origin;
+      this.targetOrigin_ = parseUrlDeprecated(src).origin;
     }
 
     // Register action (even if targetOrigin_ is not available so we can

--- a/extensions/amp-install-serviceworker/0.1/amp-install-serviceworker.js
+++ b/extensions/amp-install-serviceworker/0.1/amp-install-serviceworker.js
@@ -20,7 +20,7 @@ import {
   getSourceOrigin,
   isProxyOrigin,
   isSecureUrl,
-  parseUrl,
+  parseUrlDeprecated,
   removeFragment,
 } from '../../../src/url';
 import {closestByTag, removeElement} from '../../../src/dom';
@@ -65,10 +65,10 @@ export class AmpInstallServiceWorker extends AMP.BaseElement {
       const iframeSrc = this.element.getAttribute('data-iframe-src');
       if (iframeSrc) {
         assertHttpsUrl(iframeSrc, this.element);
-        const origin = parseUrl(iframeSrc).origin;
+        const origin = parseUrlDeprecated(iframeSrc).origin;
         const docInfo = Services.documentInfoForDoc(this.element);
-        const sourceUrl = parseUrl(docInfo.sourceUrl);
-        const canonicalUrl = parseUrl(docInfo.canonicalUrl);
+        const sourceUrl = parseUrlDeprecated(docInfo.sourceUrl);
+        const canonicalUrl = parseUrlDeprecated(docInfo.canonicalUrl);
         user().assert(
             origin == sourceUrl.origin ||
             origin == canonicalUrl.origin,
@@ -80,7 +80,8 @@ export class AmpInstallServiceWorker extends AMP.BaseElement {
           return this.insertIframe_();
         });
       }
-    } else if (parseUrl(win.location.href).origin == parseUrl(src).origin) {
+    } else if (parseUrlDeprecated(win.location.href).origin ==
+      parseUrlDeprecated(src).origin) {
       this.whenLoadedAndVisiblePromise_().then(() => {
         return install(this.win, src);
       });
@@ -127,7 +128,7 @@ export class AmpInstallServiceWorker extends AMP.BaseElement {
 
     const ampdoc = this.getAmpDoc();
     const win = this.win;
-    const winUrl = parseUrl(win.location.href);
+    const winUrl = parseUrlDeprecated(win.location.href);
 
     // Read the url-rewrite config.
     const urlMatch = this.element.getAttribute(
@@ -151,9 +152,10 @@ export class AmpInstallServiceWorker extends AMP.BaseElement {
       throw user().createError(
           'Invalid "data-no-service-worker-fallback-url-match" expression', e);
     }
-    user().assert(getSourceOrigin(winUrl) == parseUrl(shellUrl).origin,
-        'Shell source origin "%s" must be the same as source origin "%s"',
-        shellUrl, winUrl.href);
+    user().assert(getSourceOrigin(winUrl) ==
+      parseUrlDeprecated(shellUrl).origin,
+    'Shell source origin "%s" must be the same as source origin "%s"',
+    shellUrl, winUrl.href);
 
     // Install URL rewriter.
     this.urlRewriter_ = new UrlRewriter_(ampdoc, urlMatchExpr, shellUrl);
@@ -227,7 +229,7 @@ class UrlRewriter_ {
     this.shellUrl_ = shellUrl;
 
     /** @const @private {!Location} */
-    this.shellLoc_ = parseUrl(shellUrl);
+    this.shellLoc_ = parseUrlDeprecated(shellUrl);
 
     listen(ampdoc.getRootNode(), 'click', this.handle_.bind(this));
   }
@@ -247,7 +249,7 @@ class UrlRewriter_ {
     }
 
     // Check the URL matches the mask and doesn't match shell itself.
-    const tgtLoc = parseUrl(target.href);
+    const tgtLoc = parseUrlDeprecated(target.href);
     if (tgtLoc.origin != this.shellLoc_.origin ||
             tgtLoc.pathname == this.shellLoc_.pathname ||
             !this.urlMatchExpr_.test(tgtLoc.href)) {

--- a/extensions/amp-next-page/0.1/amp-next-page.js
+++ b/extensions/amp-next-page/0.1/amp-next-page.js
@@ -25,7 +25,7 @@ import {
   isJsonScriptTag,
 } from '../../../src/dom';
 import {getService} from '../../../src/service';
-import {getSourceOrigin, isProxyOrigin, parseUrl} from '../../../src/url';
+import {getSourceOrigin, isProxyOrigin, parseUrlDeprecated} from '../../../src/url';
 import {isExperimentOn} from '../../../src/experiments';
 import {tryParseJson} from '../../../src/json';
 import {user} from '../../../src/log';
@@ -72,7 +72,7 @@ export class AmpNextPage extends AMP.BaseElement {
     });
 
     const docInfo = Services.documentInfoForDoc(this.element);
-    const url = parseUrl(docInfo.url);
+    const url = parseUrlDeprecated(docInfo.url);
     const sourceOrigin = getSourceOrigin(url);
     const config = assertConfig(configJson, url.origin, sourceOrigin);
 

--- a/extensions/amp-next-page/0.1/config.js
+++ b/extensions/amp-next-page/0.1/config.js
@@ -15,7 +15,7 @@
  */
 
 import {isArray} from '../../../src/types';
-import {parseUrl} from '../../../src/url';
+import {parseUrlDeprecated} from '../../../src/url';
 import {user} from '../../../src/log';
 
 /**
@@ -80,7 +80,7 @@ function assertSelectors(selectors) {
 }
 
 function assertReco(reco, origin, sourceOrigin) {
-  const url = parseUrl(reco.ampUrl);
+  const url = parseUrlDeprecated(reco.ampUrl);
   user().assertString(reco.ampUrl, 'ampUrl must be a string');
   user().assert(url.origin === origin || url.origin === sourceOrigin,
       'pages must be from the same origin as the current document');

--- a/extensions/amp-next-page/0.1/next-page-service.js
+++ b/extensions/amp-next-page/0.1/next-page-service.js
@@ -25,7 +25,7 @@ import {
 } from '../../../src/service/position-observer/position-observer-impl';
 import {installStylesForDoc} from '../../../src/style-installer';
 import {layoutRectLtwh} from '../../../src/layout-rect';
-import {parseUrl} from '../../../src/url';
+import {parseUrlDeprecated} from '../../../src/url';
 import {removeElement} from '../../../src/dom';
 import {setStyle} from '../../../src/style';
 import {triggerAnalyticsEvent} from '../../../src/analytics';
@@ -409,7 +409,7 @@ export class NextPageService {
     const amp = documentRef.amp;
     this.win_.document.title = amp.title || '';
     if (this.win_.history.replaceState) {
-      const url = parseUrl(documentRef.ampUrl);
+      const url = parseUrlDeprecated(documentRef.ampUrl);
       this.win_.history.replaceState({}, amp.title, url.pathname);
     }
 

--- a/extensions/amp-playbuzz/0.1/amp-playbuzz.js
+++ b/extensions/amp-playbuzz/0.1/amp-playbuzz.js
@@ -45,7 +45,7 @@ import {Layout, isLayoutSizeDefined} from '../../../src/layout';
 import {Services} from '../../../src/services';
 import {
   assertAbsoluteHttpOrHttpsUrl,
-  parseUrl,
+  parseUrlDeprecated,
   removeFragment,
 } from '../../../src/url';
 import {dict} from '../../../src/utils/object';
@@ -262,10 +262,10 @@ class AmpPlaybuzz extends AMP.BaseElement {
    */
   generateEmbedSourceUrl_() {
     const canonicalUrl = Services.documentInfoForDoc(this.element).canonicalUrl;
-    const parsedPageUrl = parseUrl(canonicalUrl);
+    const parsedPageUrl = parseUrlDeprecated(canonicalUrl);
     const params = {
       itemUrl: this.iframeSrcUrl_,
-      relativeUrl: parseUrl(this.iframeSrcUrl_).pathname,
+      relativeUrl: parseUrlDeprecated(this.iframeSrcUrl_).pathname,
       displayItemInfo: this.displayItemInfo_,
       displayShareBar: this.displayShareBar_,
       displayComments: this.displayComments_,

--- a/extensions/amp-playbuzz/0.1/utils.js
+++ b/extensions/amp-playbuzz/0.1/utils.js
@@ -19,7 +19,7 @@ import {dict} from './../../../src/utils/object';
 import {getData} from './../../../src/event-helper';
 import {parseJson} from './../../../src/json';
 import {
-  parseUrl,
+  parseUrlDeprecated,
   removeFragment,
   serializeQueryString,
 } from '../../../src/url';
@@ -158,7 +158,7 @@ export function composeItemSrcUrl(src, itemId) {
 
   const iframeSrcUrl = itemId ?
     DEFAULT_BASE_URL + 'item/' + itemId :
-    sanitizeUrl(parseUrl(src));
+    sanitizeUrl(parseUrlDeprecated(src));
 
   return iframeSrcUrl;
 }

--- a/extensions/amp-sidebar/0.1/amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.js
@@ -23,7 +23,7 @@ import {closestByTag, isRTL, tryFocus} from '../../../src/dom';
 import {createCustomEvent} from '../../../src/event-helper';
 import {debounce} from '../../../src/utils/rate-limit';
 import {dev} from '../../../src/log';
-import {parseUrl, removeFragment} from '../../../src/url';
+import {parseUrlDeprecated, removeFragment} from '../../../src/url';
 import {setStyles, toggle} from '../../../src/style';
 import {toArray} from '../../../src/types';
 /** @const */
@@ -170,7 +170,7 @@ export class AmpSidebar extends AMP.BaseElement {
     this.element.addEventListener('click', e => {
       const target = closestByTag(dev().assertElement(e.target), 'A');
       if (target && target.href) {
-        const tgtLoc = parseUrl(target.href);
+        const tgtLoc = parseUrlDeprecated(target.href);
         const currentHref = this.getAmpDoc().win.location.href;
         // Important: Only close sidebar (and hence pop sidebar history entry)
         // when navigating locally, Chrome might cancel navigation request

--- a/extensions/amp-social-share/0.1/amp-social-share.js
+++ b/extensions/amp-social-share/0.1/amp-social-share.js
@@ -17,7 +17,7 @@
 import {CSS} from '../../../build/amp-social-share-0.1.css';
 import {KeyCodes} from '../../../src/utils/key-codes';
 import {Services} from '../../../src/services';
-import {addParamsToUrl, parseQueryString, parseUrl} from '../../../src/url';
+import {addParamsToUrl, parseQueryString, parseUrlDeprecated} from '../../../src/url';
 import {dev, user} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {getDataParamsFromAttributes} from '../../../src/dom';
@@ -105,7 +105,7 @@ class AmpSocialShare extends AMP.BaseElement {
     urlReplacements.expandUrlAsync(hrefWithVars, bindings).then(href => {
       this.href_ = href;
       // mailto:, sms: protocols breaks when opened in _blank on iOS Safari
-      const protocol = parseUrl(href).protocol;
+      const protocol = parseUrlDeprecated(href).protocol;
       const isMailTo = protocol === 'mailto:';
       const isSms = protocol === 'sms:';
       const isIosSafari = this.platform_.isIos() && this.platform_.isSafari();

--- a/extensions/amp-story/0.1/amp-story-bookend.js
+++ b/extensions/amp-story/0.1/amp-story-bookend.js
@@ -27,7 +27,7 @@ import {getAmpdoc} from '../../../src/service';
 import {getJsonLd} from './jsonld';
 import {isArray} from '../../../src/types';
 import {isProtocolValid} from '../../../src/url';
-import {parseUrl} from '../../../src/url';
+import {parseUrlDeprecated} from '../../../src/url';
 import {relatedArticlesFromJson} from './related-articles';
 import {renderAsElement, renderSimpleTemplate} from './simple-template';
 import {throttle} from '../../../src/utils/rate-limit';
@@ -565,7 +565,7 @@ export class Bookend {
             this.win_.document.head.querySelector('title'),
             'Please set <title> or structured data (JSON-LD).').textContent,
 
-      domainName: parseUrl(
+      domainName: parseUrlDeprecated(
           Services.documentInfoForDoc(ampdoc).canonicalUrl).hostname,
     };
 

--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -90,7 +90,7 @@ import {dev, user} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {findIndex} from '../../../src/utils/array';
 import {getMode} from '../../../src/mode';
-import {getSourceOrigin, parseUrl} from '../../../src/url';
+import {getSourceOrigin, parseUrlDeprecated} from '../../../src/url';
 import {isExperimentOn, toggleExperiment} from '../../../src/experiments';
 import {registerServiceBuilder} from '../../../src/service';
 import {renderSimpleTemplate} from './simple-template';
@@ -696,7 +696,7 @@ export class AmpStory extends AMP.BaseElement {
    * @private
    */
   isOriginWhitelisted_(origin) {
-    const hostName = parseUrl(origin).hostname;
+    const hostName = parseUrlDeprecated(origin).hostname;
     const domains = hostName.split('.');
 
     // Check all permutations of the domain to see if any level of the domain is

--- a/extensions/amp-story/0.1/related-articles.js
+++ b/extensions/amp-story/0.1/related-articles.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import {dev, user} from '../../../src/log';
-import {isProtocolValid, parseUrl} from '../../../src/url';
+import {isProtocolValid, parseUrlDeprecated} from '../../../src/url';
 
 
 const TAG = 'amp-story';
@@ -57,7 +57,7 @@ function buildArticleFromJson_(articleJson) {
   const article = {
     title: dev().assert(articleJson['title']),
     url: dev().assert(articleJson['url']),
-    domainName: parseUrl(dev().assert(articleJson['url'])).hostname,
+    domainName: parseUrlDeprecated(dev().assert(articleJson['url'])).hostname,
   };
 
   if (articleJson['image']) {

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -90,7 +90,7 @@ import {dev, user} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {findIndex} from '../../../src/utils/array';
 import {getMode} from '../../../src/mode';
-import {getSourceOrigin, parseUrl} from '../../../src/url';
+import {getSourceOrigin, parseUrlDeprecated} from '../../../src/url';
 import {isExperimentOn, toggleExperiment} from '../../../src/experiments';
 import {registerServiceBuilder} from '../../../src/service';
 import {stringHash32} from '../../../src/string';
@@ -696,7 +696,7 @@ export class AmpStory extends AMP.BaseElement {
    * @private
    */
   isOriginWhitelisted_(origin) {
-    const hostName = parseUrl(origin).hostname;
+    const hostName = parseUrlDeprecated(origin).hostname;
     const domains = hostName.split('.');
 
     // Check all permutations of the domain to see if any level of the domain is

--- a/extensions/amp-story/1.0/bookend/amp-story-bookend.js
+++ b/extensions/amp-story/1.0/bookend/amp-story-bookend.js
@@ -28,7 +28,7 @@ import {dict} from '../../../../src/utils/object';
 import {getAmpdoc} from '../../../../src/service';
 import {getJsonLd} from '../jsonld';
 import {isArray} from '../../../../src/types';
-import {isProtocolValid, parseUrl} from '../../../../src/url';
+import {isProtocolValid, parseUrlDeprecated} from '../../../../src/url';
 import {renderAsElement} from '../simple-template';
 import {throttle} from '../../../../src/utils/rate-limit';
 
@@ -498,7 +498,7 @@ export class AmpStoryBookend extends AMP.BaseElement {
             this.win.document.head.querySelector('title'),
             'Please set <title> or structured data (JSON-LD).').textContent,
 
-      domainName: parseUrl(
+      domainName: parseUrlDeprecated(
           Services.documentInfoForDoc(this.getAmpDoc()).canonicalUrl).hostname,
     };
 

--- a/extensions/amp-story/1.0/bookend/components/article.js
+++ b/extensions/amp-story/1.0/bookend/components/article.js
@@ -18,7 +18,7 @@ import {BookendComponentInterface} from './bookend-component-interface';
 import {addAttributesToElement} from '../../../../../src/dom';
 import {dict} from '../../../../../src/utils/object';
 import {htmlFor} from '../../../../../src/static-template';
-import {isProtocolValid, parseUrl} from '../../../../../src/url';
+import {isProtocolValid, parseUrlDeprecated} from '../../../../../src/url';
 import {user} from '../../../../../src/log';
 
 /**
@@ -63,7 +63,7 @@ export class ArticleComponent {
       type: articleJson['type'],
       title: articleJson['title'],
       url: articleJson['url'],
-      domainName: parseUrl(articleJson['url']).hostname,
+      domainName: parseUrlDeprecated(articleJson['url']).hostname,
     };
 
     if (articleJson['image']) {

--- a/extensions/amp-story/1.0/bookend/components/landscape.js
+++ b/extensions/amp-story/1.0/bookend/components/landscape.js
@@ -18,7 +18,7 @@ import {BookendComponentInterface} from './bookend-component-interface';
 import {addAttributesToElement} from '../../../../../src/dom';
 import {dict} from '../../../../../src/utils/object';
 import {htmlFor, htmlRefs} from '../../../../../src/static-template';
-import {isProtocolValid, parseUrl} from '../../../../../src/url';
+import {isProtocolValid, parseUrlDeprecated} from '../../../../../src/url';
 import {user} from '../../../../../src/log';
 
 /**
@@ -76,7 +76,7 @@ export class LandscapeComponent {
       title: landscapeJson['title'],
       category: landscapeJson['category'],
       url: landscapeJson['url'],
-      domainName: parseUrl(landscapeJson['url']).hostname,
+      domainName: parseUrlDeprecated(landscapeJson['url']).hostname,
       image: landscapeJson['image'],
     };
   }

--- a/extensions/amp-story/1.0/bookend/components/portrait.js
+++ b/extensions/amp-story/1.0/bookend/components/portrait.js
@@ -18,7 +18,7 @@ import {BookendComponentInterface} from './bookend-component-interface';
 import {addAttributesToElement} from '../../../../../src/dom';
 import {dict} from '../../../../../src/utils/object';
 import {htmlFor, htmlRefs} from '../../../../../src/static-template';
-import {isProtocolValid, parseUrl} from '../../../../../src/url';
+import {isProtocolValid, parseUrlDeprecated} from '../../../../../src/url';
 import {user} from '../../../../../src/log';
 
 /**
@@ -71,7 +71,7 @@ export class PortraitComponent {
       type: portraitJson['type'],
       category: portraitJson['category'],
       url: portraitJson['url'],
-      domainName: parseUrl(portraitJson['url']).hostname,
+      domainName: parseUrlDeprecated(portraitJson['url']).hostname,
       image: portraitJson['image'],
     };
   }

--- a/extensions/amp-story/1.0/related-articles.js
+++ b/extensions/amp-story/1.0/related-articles.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import {dev, user} from '../../../src/log';
-import {isProtocolValid, parseUrl} from '../../../src/url';
+import {isProtocolValid, parseUrlDeprecated} from '../../../src/url';
 
 
 const TAG = 'amp-story';
@@ -57,7 +57,7 @@ function buildArticleFromJson_(articleJson) {
   const article = {
     title: dev().assert(articleJson['title']),
     url: dev().assert(articleJson['url']),
-    domainName: parseUrl(dev().assert(articleJson['url'])).hostname,
+    domainName: parseUrlDeprecated(dev().assert(articleJson['url'])).hostname,
   };
 
   if (articleJson['image']) {

--- a/extensions/amp-subscriptions-google/0.1/amp-subscriptions-google.js
+++ b/extensions/amp-subscriptions-google/0.1/amp-subscriptions-google.js
@@ -23,7 +23,7 @@ import {DocImpl} from '../../amp-subscriptions/0.1/doc-impl';
 import {Entitlement} from '../../amp-subscriptions/0.1/entitlement';
 import {PageConfig} from '../../../third_party/subscriptions-project/config';
 import {Services} from '../../../src/services';
-import {parseUrl} from '../../../src/url';
+import {parseUrlDeprecated} from '../../../src/url';
 
 const TAG = 'amp-subscriptions-google';
 const PLATFORM_ID = 'subscribe.google.com';
@@ -210,7 +210,7 @@ export class GoogleSubscriptionsPlatform {
     const viewerUrl = viewer.getParam('viewerUrl');
     if (viewerUrl) {
       this.isGoogleViewer_ = GOOGLE_DOMAIN_RE.test(
-          parseUrl(viewerUrl).hostname);
+          parseUrlDeprecated(viewerUrl).hostname);
     } else {
       // This can only be resolved asynchronously in this case. However, the
       // action execution must be done synchronously. Thus we have to allow
@@ -218,7 +218,7 @@ export class GoogleSubscriptionsPlatform {
       viewer.getViewerOrigin().then(origin => {
         if (origin) {
           this.isGoogleViewer_ = GOOGLE_DOMAIN_RE.test(
-              parseUrl(origin).hostname);
+              parseUrlDeprecated(origin).hostname);
         }
       });
     }

--- a/extensions/amp-viewer-integration/0.1/test/viewer-for-testing.js
+++ b/extensions/amp-viewer-integration/0.1/test/viewer-for-testing.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {parseUrl, serializeQueryString} from '../../../../src/url';
+import {parseUrlDeprecated, serializeQueryString} from '../../../../src/url';
 
 const APP = '__AMPHTML__';
 
@@ -82,7 +82,7 @@ export class ViewerForTesting {
       height: this.containerEl./*OK*/offsetHeight,
       visibilityState: this.visibilityState_,
       prerenderSize: 1,
-      origin: parseUrl(window.location.href).origin,
+      origin: parseUrlDeprecated(window.location.href).origin,
       csi: 1,
       cap: 'foo,a2a',
     };
@@ -92,7 +92,7 @@ export class ViewerForTesting {
     if (window.location.hash && window.location.hash.length > 1) {
       ampdocUrl += '&' + window.location.hash.substring(1);
     }
-    const parsedUrl = parseUrl(ampdocUrl);
+    const parsedUrl = parseUrlDeprecated(ampdocUrl);
     const url = parsedUrl.href;
     this.iframe.setAttribute('src', url);
     this.frameOrigin_ = parsedUrl.origin;

--- a/extensions/amp-viewer-integration/0.1/test/viewer-initiated-handshake-viewer-for-testing.js
+++ b/extensions/amp-viewer-integration/0.1/test/viewer-initiated-handshake-viewer-for-testing.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {parseUrl, serializeQueryString} from '../../../../src/url';
+import {parseUrlDeprecated, serializeQueryString} from '../../../../src/url';
 
 const APP = '__AMPHTML__';
 const MessageType = {
@@ -86,7 +86,7 @@ export class WebviewViewerForTesting {
       height: this.containerEl./*OK*/offsetHeight,
       visibilityState: this.visibilityState_,
       prerenderSize: 1,
-      origin: parseUrl(window.location.href).origin,
+      origin: parseUrlDeprecated(window.location.href).origin,
       csi: 1,
       cap: 'foo,a2a,handshakepoll',
     };
@@ -96,7 +96,7 @@ export class WebviewViewerForTesting {
     if (window.location.hash && window.location.hash.length > 1) {
       ampdocUrl += '&' + window.location.hash.substring(1);
     }
-    const parsedUrl = parseUrl(ampdocUrl);
+    const parsedUrl = parseUrlDeprecated(ampdocUrl);
     const url = parsedUrl.href;
     this.iframe.setAttribute('src', url);
     this.frameOrigin_ = parsedUrl.origin;

--- a/extensions/amp-viewer-integration/0.1/test/webview-viewer-for-testing.js
+++ b/extensions/amp-viewer-integration/0.1/test/webview-viewer-for-testing.js
@@ -15,7 +15,7 @@
  */
 
 import {Messaging} from '../messaging/messaging';
-import {parseUrl, serializeQueryString} from '../../../../src/url';
+import {parseUrlDeprecated, serializeQueryString} from '../../../../src/url';
 
 const APP = '__AMPHTML__';
 const MessageType = {
@@ -95,7 +95,7 @@ export class WebviewViewerForTesting {
       height: this.containerEl./*OK*/offsetHeight,
       visibilityState: this.visibilityState_,
       prerenderSize: 1,
-      origin: parseUrl(window.location.href).origin,
+      origin: parseUrlDeprecated(window.location.href).origin,
       csi: 1,
       cap: 'foo,a2a',
       webview: 1,
@@ -106,7 +106,7 @@ export class WebviewViewerForTesting {
     if (window.location.hash && window.location.hash.length > 1) {
       ampdocUrl += '&' + window.location.hash.substring(1);
     }
-    const parsedUrl = parseUrl(ampdocUrl);
+    const parsedUrl = parseUrlDeprecated(ampdocUrl);
     const url = parsedUrl.href;
     this.iframe.setAttribute('src', url);
 

--- a/extensions/amp-web-push/0.1/amp-web-push-config.js
+++ b/extensions/amp-web-push/0.1/amp-web-push-config.js
@@ -18,7 +18,7 @@ import {CONFIG_TAG, SERVICE_TAG, TAG} from './vars';
 import {dev, user} from '../../../src/log';
 import {escapeCssSelectorIdent} from '../../../src/dom';
 import {getServiceForDoc} from '../../../src/service';
-import {parseUrl} from '../../../src/url';
+import {parseUrlDeprecated} from '../../../src/url';
 
 /** @enum {string} */
 export const WebPushConfigAttributes = {
@@ -104,7 +104,8 @@ export class WebPushConfig extends AMP.BaseElement {
       );
     }
 
-    if (parseUrl(config['service-worker-url']).protocol !== 'https:') {
+    if (parseUrlDeprecated(config['service-worker-url']).protocol
+      !== 'https:') {
       throw user().createError(
           `<${CONFIG_TAG}> must have a valid ` +
           'service-worker-url attribute. It should begin with the ' +
@@ -114,10 +115,10 @@ export class WebPushConfig extends AMP.BaseElement {
     }
 
     if (
-      parseUrl(config['service-worker-url']).origin !==
-        parseUrl(config['permission-dialog-url']).origin ||
-      parseUrl(config['permission-dialog-url']).origin !==
-        parseUrl(config['helper-iframe-url']).origin
+      parseUrlDeprecated(config['service-worker-url']).origin !==
+        parseUrlDeprecated(config['permission-dialog-url']).origin ||
+      parseUrlDeprecated(config['permission-dialog-url']).origin !==
+        parseUrlDeprecated(config['helper-iframe-url']).origin
     ) {
       throw user().createError(
           `<${CONFIG_TAG}> URL attributes ` +
@@ -243,7 +244,7 @@ export class WebPushConfig extends AMP.BaseElement {
   */
   isValidHelperOrPermissionDialogUrl_(url) {
     try {
-      const parsedUrl = parseUrl(url);
+      const parsedUrl = parseUrlDeprecated(url);
       /*
         The helper-iframe-url must be to a specific lightweight page on the
         user's site for handling AMP postMessage calls without loading push

--- a/extensions/amp-web-push/0.1/amp-web-push-permission-dialog.js
+++ b/extensions/amp-web-push/0.1/amp-web-push-permission-dialog.js
@@ -18,7 +18,7 @@ import {NotificationPermission, StorageKeys} from './vars';
 import {WindowMessenger} from './window-messenger';
 import {escapeCssSelectorIdent} from '../../../src/dom';
 import {getMode} from '../../../src/mode';
-import {parseQueryString, parseUrl, tryDecodeUriComponent} from '../../../src/url.js';
+import {parseQueryString, parseUrlDeprecated, tryDecodeUriComponent} from '../../../src/url.js';
 
 /** @typedef {{
  *    debug: boolean,
@@ -253,7 +253,7 @@ export class AmpWebPushPermissionDialog {
    * @param {string} url
    */
   redirectToUrl(url) {
-    const parsedUrl = parseUrl(url);
+    const parsedUrl = parseUrlDeprecated(url);
     if (parsedUrl &&
       (
         parsedUrl.protocol === 'http:' ||

--- a/extensions/amp-web-push/0.1/test/test-web-push-permission-dialog.js
+++ b/extensions/amp-web-push/0.1/test/test-web-push-permission-dialog.js
@@ -18,7 +18,7 @@ import {AmpWebPushPermissionDialog} from '../amp-web-push-permission-dialog';
 import {WebPushConfigAttributes} from '../amp-web-push-config';
 import {WebPushService} from '../web-push-service';
 import {WindowMessenger} from '../window-messenger';
-import {parseUrl} from '../../../../src/url';
+import {parseUrlDeprecated} from '../../../../src/url';
 
 const FAKE_IFRAME_URL =
   '//ads.localhost:9876/test/fixtures/served/iframe-stub.html#';
@@ -82,7 +82,7 @@ describes.realWin('web-push-permission-dialog', {
   it('should detect opened from redirect', () => {
     return setupPermissionDialogFrame().then(() => {
       sandbox./*OK*/stub(iframeWindow, 'opener').callsFake(false);
-      iframeWindow.fakeLocation = parseUrl('https://test.com/?return=' +
+      iframeWindow.fakeLocation = parseUrlDeprecated('https://test.com/?return=' +
         encodeURIComponent('https://another-site.com'));
       sandbox./*OK*/stub(
           iframeWindow._ampWebPushPermissionDialog,
@@ -125,7 +125,7 @@ describes.realWin('web-push-permission-dialog', {
           'isCurrentDialogPopup').callsFake(
           () => false
       );
-      iframeWindow.fakeLocation = parseUrl('https://test.com/?return=' +
+      iframeWindow.fakeLocation = parseUrlDeprecated('https://test.com/?return=' +
         encodeURIComponent('https://another-site.com'));
       const permissionStub = sandbox./*OK*/stub(
           iframeWindow.Notification,
@@ -146,7 +146,7 @@ describes.realWin('web-push-permission-dialog', {
           'isCurrentDialogPopup').callsFake(
           () => false
       );
-      iframeWindow.fakeLocation = parseUrl('https://test.com/?return=' +
+      iframeWindow.fakeLocation = parseUrlDeprecated('https://test.com/?return=' +
         encodeURIComponent('https://another-site.com'));
       sandbox./*OK*/stub(
           iframeWindow._ampWebPushPermissionDialog,

--- a/extensions/amp-web-push/0.1/web-push-service.js
+++ b/extensions/amp-web-push/0.1/web-push-service.js
@@ -24,7 +24,7 @@ import {dev, user} from '../../../src/log';
 import {escapeCssSelectorIdent, openWindowDialog} from '../../../src/dom';
 import {getMode} from '../../../src/mode';
 import {installStylesForDoc} from '../../../src/style-installer';
-import {parseQueryString, parseUrl} from '../../../src/url';
+import {parseQueryString, parseUrlDeprecated} from '../../../src/url';
 
 /** @typedef {{
  *    isControllingFrame: boolean,
@@ -165,7 +165,7 @@ export class WebPushService {
           );
           return this.frameMessenger_.connect(
               this.iframe_.getDomElement().contentWindow,
-              parseUrl(this.config_['helper-iframe-url']).origin
+              parseUrlDeprecated(this.config_['helper-iframe-url']).origin
           );
         })
         .then(() => {
@@ -400,9 +400,9 @@ export class WebPushService {
    * @return {boolean}
    */
   isUrlSimilarForQueryParams(originalUrlString, urlToTestString) {
-    const originalUrl = parseUrl(originalUrlString);
+    const originalUrl = parseUrlDeprecated(originalUrlString);
     const originalUrlQueryParams = parseQueryString(originalUrl.search);
-    const urlToTest = parseUrl(urlToTestString);
+    const urlToTest = parseUrlDeprecated(urlToTestString);
     const urlToTestQueryParams = parseQueryString(urlToTest.search);
 
     // The URL to test may have more query params than the original URL, but it

--- a/extensions/amp-web-push/0.1/window-messenger.js
+++ b/extensions/amp-web-push/0.1/window-messenger.js
@@ -17,7 +17,7 @@
 import {TAG} from './vars';
 import {dev} from '../../../src/log';
 import {getData} from '../../../src/event-helper';
-import {parseUrl} from '../../../src/url';
+import {parseUrlDeprecated} from '../../../src/url';
 
 /** @typedef {{
  *    CONNECT_HANDSHAKE: string,
@@ -151,12 +151,12 @@ export class WindowMessenger {
    * @private
    */
   isAllowedOrigin_(origin, allowedOrigins) {
-    const normalizedOrigin = parseUrl(origin).origin;
+    const normalizedOrigin = parseUrlDeprecated(origin).origin;
     for (let i = 0; i < allowedOrigins.length; i++) {
       const allowedOrigin = allowedOrigins[i];
       // A user might have mistyped the allowed origin, so let's normalize our
       // comparisons first
-      if (parseUrl(allowedOrigin).origin === normalizedOrigin) {
+      if (parseUrlDeprecated(allowedOrigin).origin === normalizedOrigin) {
         return true;
       }
     }
@@ -259,7 +259,8 @@ export class WindowMessenger {
             topic: WindowMessenger.Topics.CONNECT_HANDSHAKE,
           }), expectedRemoteOrigin === '*' ?
             '*' :
-            parseUrl(expectedRemoteOrigin).origin, [this.channel_.port2]);
+            parseUrlDeprecated(expectedRemoteOrigin).origin,
+          [this.channel_.port2]);
       dev().fine(TAG, `Opening channel to ${expectedRemoteOrigin}...`);
     });
   }

--- a/src/3p-frame.js
+++ b/src/3p-frame.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {assertHttpsUrl, parseUrl} from './url';
+import {assertHttpsUrl, parseUrlDeprecated} from './url';
 import {dev, user} from './log';
 import {dict} from './utils/object';
 import {getContextMetadata} from '../src/iframe-attributes';
@@ -89,7 +89,7 @@ export function getIframe(
 
   const baseUrl = getBootstrapBaseUrl(
       parentWindow, undefined, opt_type, opt_disallowCustom);
-  const host = parseUrl(baseUrl).hostname;
+  const host = parseUrlDeprecated(baseUrl).hostname;
   // This name attribute may be overwritten if this frame is chosen to
   // be the master frame. That is ok, as we will read the name off
   // for our uses before that would occur.
@@ -103,7 +103,7 @@ export function getIframe(
   }));
 
   iframe.src = baseUrl;
-  iframe.ampLocation = parseUrl(baseUrl);
+  iframe.ampLocation = parseUrlDeprecated(baseUrl);
   iframe.name = name;
   // Add the check before assigning to prevent IE throw Invalid argument error
   if (attributes['width']) {
@@ -303,9 +303,9 @@ function getCustomBootstrapBaseUrl(
   // This is not a security primitive, we just don't want this to happen in
   // practice. People could still redirect to the same origin, but they cannot
   // redirect to the proxy origin which is the important one.
-  const parsed = parseUrl(url);
+  const parsed = parseUrlDeprecated(url);
   user().assert((parsed.hostname == 'localhost' && !opt_strictForUnitTest) ||
-      parsed.origin != parseUrl(parentWindow.location.href).origin,
+      parsed.origin != parseUrlDeprecated(parentWindow.location.href).origin,
   '3p iframe url must not be on the same origin as the current document ' +
       '%s (%s) in element %s. See https://github.com/ampproject/amphtml' +
       '/blob/master/spec/amp-iframe-origin-policy.md for details.', url,

--- a/src/cookies.js
+++ b/src/cookies.js
@@ -17,7 +17,7 @@
 import {endsWith} from './string';
 import {
   isProxyOrigin,
-  parseUrl,
+  parseUrlDeprecated,
   tryDecodeUriComponent,
 } from './url';
 import {urls} from './config';
@@ -159,8 +159,8 @@ function checkOriginForSettingCookie(win, options, name) {
         + name);
   }
 
-  const current = parseUrl(win.location.href).hostname.toLowerCase();
-  const proxy = parseUrl(urls.cdn).hostname.toLowerCase();
+  const current = parseUrlDeprecated(win.location.href).hostname.toLowerCase();
+  const proxy = parseUrlDeprecated(urls.cdn).hostname.toLowerCase();
   if (current == proxy || endsWith(current, '.' + proxy)) {
     throw new Error('Should never attempt to set cookie on proxy origin.'
         + ' (in depth check): ' + name);

--- a/src/iframe-helper.js
+++ b/src/iframe-helper.js
@@ -19,7 +19,7 @@ import {dev} from './log';
 import {dict} from './utils/object';
 import {filterSplice} from './utils/array';
 import {getData} from './event-helper';
-import {parseUrl} from './url';
+import {parseUrlDeprecated} from './url';
 import {tryParseJson} from './json';
 
 /**
@@ -82,7 +82,7 @@ function getListenForSentinel(parentWin, sentinel, opt_create) {
  * @return {?Object<string, !Array<function(!JsonObject, !Window, string)>>}
  */
 function getOrCreateListenForEvents(parentWin, iframe, opt_is3P) {
-  const origin = parseUrl(iframe.src).origin;
+  const origin = parseUrlDeprecated(iframe.src).origin;
   const sentinel = getSentinel_(iframe, opt_is3P);
   const listenSentinel = getListenForSentinel(parentWin, sentinel, true);
 

--- a/src/impression.js
+++ b/src/impression.js
@@ -20,7 +20,7 @@ import {
   addParamsToUrl,
   isProxyOrigin,
   parseQueryString,
-  parseUrl,
+  parseUrlDeprecated,
 } from './url';
 import {dev, user} from './log';
 import {getMode} from './mode';
@@ -235,7 +235,7 @@ function applyResponse(win, response) {
 
     const viewer = Services.viewerForDoc(win.document);
     const currentHref = win.location.href;
-    const url = parseUrl(adLocation);
+    const url = parseUrlDeprecated(adLocation);
     const params = parseQueryString(url.search);
     const newHref = addParamsToUrl(currentHref, params);
     // TODO: Avoid overwriting the fragment parameter.
@@ -265,7 +265,7 @@ export function shouldAppendExtraParams(ampdoc) {
  */
 export function getExtraParamsUrl(win, target) {
   // Get an array with extra params that needs to append.
-  const url = parseUrl(win.location.href);
+  const url = parseUrlDeprecated(win.location.href);
   const params = parseQueryString(url.search);
   const appendParams = [];
   for (let i = 0; i < DEFAULT_APPEND_URL_PARAM.length; i++) {
@@ -281,7 +281,7 @@ export function getExtraParamsUrl(win, target) {
   if (additionalUrlParams) {
     href = addParamsToUrl(href, parseQueryString(additionalUrlParams));
   }
-  const loc = parseUrl(href);
+  const loc = parseUrlDeprecated(href);
   const existParams = parseQueryString(loc.search);
   for (let i = appendParams.length - 1; i >= 0; i--) {
     const param = appendParams[i];

--- a/src/preconnect.js
+++ b/src/preconnect.js
@@ -24,7 +24,7 @@ import {Services} from './services';
 import {dev} from './log';
 import {getService, registerServiceBuilder} from './service';
 import {htmlFor} from './static-template';
-import {parseUrl} from './url';
+import {parseUrlDeprecated} from './url';
 import {startsWith} from './string';
 import {toWin} from './types';
 
@@ -100,7 +100,7 @@ class PreconnectService {
     /** @private @const {!./service/platform-impl.Platform}  */
     this.platform_ = Services.platformFor(win);
     // Mark current origin as preconnected.
-    this.origins_[parseUrl(win.location.href).origin] = true;
+    this.origins_[parseUrlDeprecated(win.location.href).origin] = true;
 
     /**
      * Detect support for the given resource hints.
@@ -150,7 +150,7 @@ class PreconnectService {
     if (!this.isInterestingUrl_(url)) {
       return;
     }
-    const origin = parseUrl(url).origin;
+    const origin = parseUrlDeprecated(url).origin;
     const now = Date.now();
     const lastPreconnectTimeout = this.origins_[origin];
     if (lastPreconnectTimeout && now < lastPreconnectTimeout) {

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -68,7 +68,7 @@ import {
   isExperimentOn,
   toggleExperiment,
 } from './experiments';
-import {parseUrl} from './url';
+import {parseUrlDeprecated} from './url';
 import {reportErrorForWin} from './error';
 import {setStyle} from './style';
 import {startupChunk} from './chunk';
@@ -449,7 +449,7 @@ export class MultidocManager {
     const amp = {};
     shadowRoot.AMP = amp;
     amp.url = url;
-    const origin = parseUrl(url).origin;
+    const origin = parseUrlDeprecated(url).origin;
 
     const ampdoc = this.ampdocService_.installShadowDoc(url, shadowRoot);
     /** @const {!./service/ampdoc-impl.AmpDocShadow} */

--- a/src/sanitizer.js
+++ b/src/sanitizer.js
@@ -18,7 +18,7 @@ import {
   checkCorsUrl,
   getSourceUrl,
   isProxyOrigin,
-  parseUrl,
+  parseUrlDeprecated,
   resolveRelativeUrl,
 } from './url';
 import {dict, map} from './utils/object';
@@ -496,7 +496,7 @@ export function rewriteAttributeValue(tagName, attrName, attrValue) {
 export function resolveUrlAttr(tagName, attrName, attrValue, windowLocation) {
   checkCorsUrl(attrValue);
   const isProxyHost = isProxyOrigin(windowLocation);
-  const baseUrl = parseUrl(getSourceUrl(windowLocation));
+  const baseUrl = parseUrlDeprecated(getSourceUrl(windowLocation));
 
   if (attrName == 'href' && !startsWith(attrValue, '#')) {
     return resolveRelativeUrl(attrValue, baseUrl);
@@ -560,7 +560,7 @@ function tripleMustacheTagPolicy(tagName, attribs) {
  * @return {string}
  */
 function resolveImageUrlAttr(attrValue, baseUrl, isProxyHost) {
-  const src = parseUrl(resolveRelativeUrl(attrValue, baseUrl));
+  const src = parseUrlDeprecated(resolveRelativeUrl(attrValue, baseUrl));
 
   // URLs such as `data:` or proxy URLs are returned as is. Unsafe protocols
   // do not arrive here - already stripped by the sanitizer.

--- a/src/service-worker/install.js
+++ b/src/service-worker/install.js
@@ -19,7 +19,7 @@ import {calculateEntryPointScriptUrl} from '../service/extension-location';
 import {dev} from '../log';
 import {getMode} from '../mode';
 import {isExperimentOn} from '../experiments';
-import {parseUrl} from '../url';
+import {parseUrlDeprecated} from '../url';
 import {urls} from '../config';
 
 /** @const */
@@ -37,7 +37,7 @@ export function installCacheServiceWorker(win) {
       return;
     }
     if (!getMode().localDev &&
-        win.location.hostname !== parseUrl(urls.cdn).hostname) {
+        win.location.hostname !== parseUrlDeprecated(urls.cdn).hostname) {
       return;
     }
     // The kill experiment is really just a configuration that allows us to

--- a/src/service/cid-api.js
+++ b/src/service/cid-api.js
@@ -19,7 +19,7 @@ import {WindowInterface} from '../window-interface';
 import {dev} from '../log';
 import {dict} from '../utils/object';
 import {getCookie, setCookie} from '../cookies';
-import {isProxyOrigin, parseUrl} from '../url';
+import {isProxyOrigin, parseUrlDeprecated} from '../url';
 
 const GOOGLE_API_URL = 'https://ampcid.google.com/v1/publisher:getClientId?key=';
 
@@ -63,7 +63,9 @@ export class GoogleCidApi {
     const canonicalUrl = Services.documentInfoForDoc(ampdoc).canonicalUrl;
 
     /** @private {?string} */
-    this.canonicalOrigin_ = canonicalUrl ? parseUrl(canonicalUrl).origin : null;
+    this.canonicalOrigin_ = canonicalUrl
+      ? parseUrlDeprecated(canonicalUrl).origin
+      : null;
   }
 
   /**

--- a/src/service/cid-impl.js
+++ b/src/service/cid-impl.js
@@ -38,7 +38,7 @@ import {
 import {
   getSourceOrigin,
   isProxyOrigin,
-  parseUrl,
+  parseUrlDeprecated,
 } from '../url';
 import {isIframed} from '../dom';
 import {parseJson, tryParseJson} from '../json';
@@ -212,7 +212,7 @@ export class Cid {
   getExternalCid_(getCidStruct, persistenceConsent) {
     const scope = getCidStruct.scope;
     /** @const {!Location} */
-    const url = parseUrl(this.ampdoc.win.location.href);
+    const url = parseUrlDeprecated(this.ampdoc.win.location.href);
     if (!isProxyOrigin(url)) {
       const apiKey = this.isScopeOptedIn_(scope);
       if (apiKey) {

--- a/src/service/document-info-impl.js
+++ b/src/service/document-info-impl.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {getSourceUrl, parseUrl} from '../url';
+import {getSourceUrl, parseUrlDeprecated} from '../url';
 import {isArray} from '../types';
 import {map} from '../utils/object';
 import {registerServiceBuilderForDoc} from '../service';
@@ -78,7 +78,7 @@ export class DocInfo {
     if (!canonicalUrl) {
       const canonicalTag = rootNode.querySelector('link[rel=canonical]');
       canonicalUrl = canonicalTag
-        ? parseUrl(canonicalTag.href).href
+        ? parseUrlDeprecated(canonicalTag.href).href
         : sourceUrl;
     }
     const pageViewId = getPageViewId(ampdoc.win);

--- a/src/service/navigation.js
+++ b/src/service/navigation.js
@@ -33,7 +33,7 @@ import {
 } from '../service';
 import {
   isProtocolValid,
-  parseUrl,
+  parseUrlDeprecated,
   parseUrlWithA,
 } from '../url';
 import {toWin} from '../types';
@@ -245,7 +245,7 @@ export class Navigation {
   handleClick_(target, e) {
     this.expandVarsForAnchor_(target);
 
-    const location = this.parseUrl_(target.href);
+    const location = this.parseUrlDeprecated_(target.href);
 
     // Handle AMP-to-AMP navigation if rel=amphtml.
     if (this.handleA2AClick_(e, target, location)) {
@@ -356,7 +356,7 @@ export class Navigation {
    */
   handleNavClick_(e, target, tgtLoc) {
     /** @const {!Location} */
-    const curLoc = this.parseUrl_('');
+    const curLoc = this.parseUrlDeprecated_('');
     const tgtHref = `${tgtLoc.origin}${tgtLoc.pathname}${tgtLoc.search}`;
     const curHref = `${curLoc.origin}${curLoc.pathname}${curLoc.search}`;
 
@@ -440,7 +440,7 @@ export class Navigation {
    * @return {!Location}
    * @private
    */
-  parseUrl_(url) {
+  parseUrlDeprecated_(url) {
     if (this.isEmbed_) {
       let a = this.embedA_;
       if (!a) {
@@ -450,7 +450,7 @@ export class Navigation {
       }
       return parseUrlWithA(a, url);
     }
-    return parseUrl(url || this.ampdoc.win.location.href);
+    return parseUrlDeprecated(url || this.ampdoc.win.location.href);
   }
 }
 

--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -30,7 +30,7 @@ import {
   addParamsToUrl,
   getSourceUrl,
   parseQueryString,
-  parseUrl,
+  parseUrlDeprecated,
   removeFragment,
 } from '../url';
 import {dev, rethrowAsync, user} from '../log';
@@ -186,7 +186,8 @@ export class GlobalVariableSource extends VariableSource {
             if (!referrer) {
               return null;
             }
-            const referrerHostname = parseUrl(getSourceUrl(referrer)).hostname;
+            const referrerHostname = parseUrlDeprecated(getSourceUrl(referrer))
+                .hostname;
             const currentHostname =
                 WindowInterface.getHostname(this.ampdoc.win);
             return referrerHostname === currentHostname ? null : referrer;
@@ -208,13 +209,13 @@ export class GlobalVariableSource extends VariableSource {
 
     // Returns the host of the URL for this AMP document.
     this.set('AMPDOC_HOST', () => {
-      const url = parseUrl(this.ampdoc.win.location.href);
+      const url = parseUrlDeprecated(this.ampdoc.win.location.href);
       return url && url.host;
     });
 
     // Returns the hostname of the URL for this AMP document.
     this.set('AMPDOC_HOSTNAME', () => {
-      const url = parseUrl(this.ampdoc.win.location.href);
+      const url = parseUrlDeprecated(this.ampdoc.win.location.href);
       return url && url.hostname;
     });
 
@@ -592,7 +593,7 @@ export class GlobalVariableSource extends VariableSource {
     return () => {
       const docInfo = Services.documentInfoForDoc(this.ampdoc);
       const value = docInfo[field];
-      return opt_urlProp ? parseUrl(value)[opt_urlProp] : value;
+      return opt_urlProp ? parseUrlDeprecated(value)[opt_urlProp] : value;
     };
   }
 
@@ -629,7 +630,7 @@ export class GlobalVariableSource extends VariableSource {
         'The first argument to QUERY_PARAM, the query string ' +
         'param is required');
     user().assert(typeof param == 'string', 'param should be a string');
-    const url = parseUrl(this.ampdoc.win.location.href);
+    const url = parseUrlDeprecated(this.ampdoc.win.location.href);
     const params = parseQueryString(url.search);
     return (typeof params[param] !== 'undefined')
       ? params[param] : defaultValue;
@@ -902,8 +903,8 @@ export class UrlReplacements {
     */
   isAllowedOrigin_(url) {
     const docInfo = Services.documentInfoForDoc(this.ampdoc);
-    if (url.origin == parseUrl(docInfo.canonicalUrl).origin ||
-        url.origin == parseUrl(docInfo.sourceUrl).origin) {
+    if (url.origin == parseUrlDeprecated(docInfo.canonicalUrl).origin ||
+        url.origin == parseUrlDeprecated(docInfo.sourceUrl).origin) {
       return true;
     }
 
@@ -913,7 +914,7 @@ export class UrlReplacements {
     if (meta && meta.hasAttribute('content')) {
       const whitelist = meta.getAttribute('content').trim().split(/\s+/);
       for (let i = 0; i < whitelist.length; i++) {
-        if (url.origin == parseUrl(whitelist[i]).origin) {
+        if (url.origin == parseUrlDeprecated(whitelist[i]).origin) {
           return true;
         }
       }
@@ -949,7 +950,7 @@ export class UrlReplacements {
     // on subsequent replacements, so that each run gets a fresh value.
     let href = dev().assertString(
         element[ORIGINAL_HREF_PROPERTY] || element.getAttribute('href'));
-    const url = parseUrl(href);
+    const url = parseUrlDeprecated(href);
     if (element[ORIGINAL_HREF_PROPERTY] == null) {
       element[ORIGINAL_HREF_PROPERTY] = href;
     }
@@ -1143,8 +1144,10 @@ export class UrlReplacements {
    * @return {string}
    */
   ensureProtocolMatches_(url, replacement) {
-    const newProtocol = parseUrl(replacement, /* opt_nocache */ true).protocol;
-    const oldProtocol = parseUrl(url, /* opt_nocache */ true).protocol;
+    const newProtocol = parseUrlDeprecated(replacement, /* opt_nocache */ true)
+        .protocol;
+    const oldProtocol = parseUrlDeprecated(url, /* opt_nocache */ true)
+        .protocol;
     if (newProtocol != oldProtocol) {
       user().error(TAG, 'Illegal replacement of the protocol: ', url);
       return url;

--- a/src/service/viewer-cid-api.js
+++ b/src/service/viewer-cid-api.js
@@ -16,7 +16,7 @@
 
 import {Services} from '../services';
 import {dict} from '../utils/object';
-import {parseUrl} from '../url';
+import {parseUrlDeprecated} from '../url';
 
 /**
  * Exposes CID API if provided by the Viewer.
@@ -37,7 +37,9 @@ export class ViewerCidApi {
     const canonicalUrl = Services.documentInfoForDoc(this.ampdoc_).canonicalUrl;
 
     /** @private {?string} */
-    this.canonicalOrigin_ = canonicalUrl ? parseUrl(canonicalUrl).origin : null;
+    this.canonicalOrigin_ = canonicalUrl
+      ? parseUrlDeprecated(canonicalUrl).origin
+      : null;
   }
 
   /**

--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -26,7 +26,7 @@ import {
   getSourceOrigin,
   isProxyOrigin,
   parseQueryString,
-  parseUrl,
+  parseUrlDeprecated,
   removeFragment,
 } from '../url';
 import {isIframed} from '../dom';
@@ -282,7 +282,7 @@ export class Viewer {
     this.isCctEmbedded_ = !this.isIframed_ &&
         parseQueryString(this.win.location.search)['amp_gsa'] === '1';
 
-    const url = parseUrl(this.ampdoc.win.location.href);
+    const url = parseUrlDeprecated(this.ampdoc.win.location.href);
     /**
      * Whether the AMP document was served by a proxy.
      * @private @const {boolean}
@@ -795,7 +795,7 @@ export class Viewer {
    * @private
    */
   isTrustedReferrer_(referrer) {
-    const url = parseUrl(referrer);
+    const url = parseUrlDeprecated(referrer);
     if (url.protocol != 'https:') {
       return false;
     }
@@ -864,7 +864,7 @@ export class Viewer {
       return TRUSTED_VIEWER_HOSTS.some(th => th.test(urlString));
     }
     /** @const {!Location} */
-    const url = parseUrl(urlString);
+    const url = parseUrlDeprecated(urlString);
     if (url.protocol != 'https:') {
       // Non-https origins are never trusted.
       return false;
@@ -1132,8 +1132,8 @@ export class Viewer {
 
     try {
       // The origin and source origin must match.
-      const url = parseUrl(this.win.location.href);
-      const replaceUrl = parseUrl(
+      const url = parseUrlDeprecated(this.win.location.href);
+      const replaceUrl = parseUrlDeprecated(
           removeFragment(newUrl) + this.win.location.hash);
       if (url.origin == replaceUrl.origin &&
           getSourceOrigin(url) == getSourceOrigin(replaceUrl)) {

--- a/src/service/xhr-impl.js
+++ b/src/service/xhr-impl.js
@@ -22,7 +22,7 @@ import {
   getCorsUrl,
   getSourceOrigin,
   getWinOrigin,
-  parseUrl,
+  parseUrlDeprecated,
   serializeQueryString,
 } from '../url';
 import {getMode} from '../mode';
@@ -385,7 +385,7 @@ export class Xhr {
     // For some same origin requests, add AMP-Same-Origin: true header to allow
     // publishers to validate that this request came from their own origin.
     const currentOrigin = getWinOrigin(this.win);
-    const targetOrigin = parseUrl(input).origin;
+    const targetOrigin = parseUrlDeprecated(input).origin;
     if (currentOrigin == targetOrigin) {
       init['headers'] = init['headers'] || {};
       init['headers']['AMP-Same-Origin'] = 'true';

--- a/src/url.js
+++ b/src/url.js
@@ -76,7 +76,7 @@ export const SOURCE_ORIGIN_PARAM = '__amp_source_origin';
  * @return {string} origin
  */
 export function getWinOrigin(win) {
-  return win.origin || parseUrl(win.location.href).origin;
+  return win.origin || parseUrlDeprecated(win.location.href).origin;
 }
 
 /**
@@ -88,7 +88,7 @@ export function getWinOrigin(win) {
  * @param {boolean=} opt_nocache
  * @return {!Location}
  */
-export function parseUrl(url, opt_nocache) {
+export function parseUrlDeprecated(url, opt_nocache) {
   if (!a) {
     a = /** @type {!HTMLAnchorElement} */ (self.document.createElement('a'));
     cache = self.UrlCache || (self.UrlCache = new LRUCache(100));
@@ -251,7 +251,7 @@ export function serializeQueryString(params) {
  */
 export function isSecureUrl(url) {
   if (typeof url == 'string') {
-    url = parseUrl(url);
+    url = parseUrlDeprecated(url);
   }
   return (url.protocol == 'https:' ||
       url.hostname == 'localhost' ||
@@ -292,7 +292,7 @@ export function assertAbsoluteHttpOrHttpsUrl(urlString) {
   user().assert(/^https?\:/i.test(urlString),
       'URL must start with "http://" or "https://". Invalid value: %s',
       urlString);
-  return parseUrl(urlString).href;
+  return parseUrlDeprecated(urlString).href;
 }
 
 
@@ -345,7 +345,7 @@ export function getFragment(url) {
  */
 export function isProxyOrigin(url) {
   if (typeof url == 'string') {
-    url = parseUrl(url);
+    url = parseUrlDeprecated(url);
   }
   return urls.cdnProxyRegex.test(url.origin);
 }
@@ -357,7 +357,7 @@ export function isProxyOrigin(url) {
  */
 export function isLocalhostOrigin(url) {
   if (typeof url == 'string') {
-    url = parseUrl(url);
+    url = parseUrlDeprecated(url);
   }
   return urls.localhostRegex.test(url.origin);
 }
@@ -373,7 +373,7 @@ export function isProtocolValid(url) {
     return true;
   }
   if (typeof url == 'string') {
-    url = parseUrl(url);
+    url = parseUrlDeprecated(url);
   }
   return !INVALID_PROTOCOLS.includes(url.protocol);
 }
@@ -404,7 +404,7 @@ function removeAmpJsParams(urlSearch) {
  */
 export function getSourceUrl(url) {
   if (typeof url == 'string') {
-    url = parseUrl(url);
+    url = parseUrlDeprecated(url);
   }
 
   // Not a proxy URL - return the URL itself.
@@ -438,7 +438,7 @@ export function getSourceUrl(url) {
  * @return {string} The source origin of the URL.
  */
 export function getSourceOrigin(url) {
-  return parseUrl(getSourceUrl(url)).origin;
+  return parseUrlDeprecated(getSourceUrl(url)).origin;
 }
 
 /**
@@ -449,7 +449,7 @@ export function getSourceOrigin(url) {
  */
 export function resolveRelativeUrl(relativeUrlString, baseUrl) {
   if (typeof baseUrl == 'string') {
-    baseUrl = parseUrl(baseUrl);
+    baseUrl = parseUrlDeprecated(baseUrl);
   }
   if (typeof URL == 'function') {
     return new URL(relativeUrlString, baseUrl.href).toString();
@@ -466,10 +466,10 @@ export function resolveRelativeUrl(relativeUrlString, baseUrl) {
  */
 export function resolveRelativeUrlFallback_(relativeUrlString, baseUrl) {
   if (typeof baseUrl == 'string') {
-    baseUrl = parseUrl(baseUrl);
+    baseUrl = parseUrlDeprecated(baseUrl);
   }
   relativeUrlString = relativeUrlString.replace(/\\/g, '/');
-  const relativeUrl = parseUrl(relativeUrlString);
+  const relativeUrl = parseUrlDeprecated(relativeUrlString);
 
   // Absolute URL.
   if (startsWith(relativeUrlString.toLowerCase(), relativeUrl.protocol)) {
@@ -510,7 +510,7 @@ export function getCorsUrl(win, url) {
  * @param {string} url
  */
 export function checkCorsUrl(url) {
-  const parsedUrl = parseUrl(url);
+  const parsedUrl = parseUrlDeprecated(url);
   const query = parseQueryString(parsedUrl.search);
   user().assert(!(SOURCE_ORIGIN_PARAM in query),
       'Source origin is not allowed in %s', url);

--- a/test/functional/test-alp-handler.js
+++ b/test/functional/test-alp-handler.js
@@ -16,7 +16,7 @@
 
 import * as sinon from 'sinon';
 import {handleClick, warmupDynamic, warmupStatic} from '../../ads/alp/handler';
-import {parseUrl} from '../../src/url';
+import {parseUrlDeprecated} from '../../src/url';
 
 describe('alp-handler', () => {
 
@@ -74,7 +74,7 @@ describe('alp-handler', () => {
       ownerDocument: doc,
       getAttribute: sandbox.stub(),
       get search() {
-        return parseUrl(this.href).search;
+        return parseUrlDeprecated(this.href).search;
       },
     };
     event = {

--- a/test/functional/test-cid.js
+++ b/test/functional/test-cid.js
@@ -39,7 +39,7 @@ import {installPlatformService} from '../../src/service/platform-impl';
 import {installTimerService} from '../../src/service/timer-impl';
 import {installViewerServiceForDoc} from '../../src/service/viewer-impl';
 import {macroTask} from '../../testing/yield';
-import {parseUrl} from '../../src/url';
+import {parseUrlDeprecated} from '../../src/url';
 import {stubServiceForDoc} from '../../testing/test-helper';
 
 const DAY = 24 * 3600 * 1000;
@@ -708,7 +708,7 @@ describe('cid', () => {
 describe('getProxySourceOrigin', () => {
   it('should fail on non-proxy origin', () => {
     allowConsoleError(() => { expect(() => {
-      getProxySourceOrigin(parseUrl('https://abc.org/v/foo.com/'));
+      getProxySourceOrigin(parseUrlDeprecated('https://abc.org/v/foo.com/'));
     }).to.throw(/Expected proxy origin/); });
   });
 });

--- a/test/functional/test-history.js
+++ b/test/functional/test-history.js
@@ -25,7 +25,7 @@ import {
 import {Services} from '../../src/services';
 import {installTimerService} from '../../src/service/timer-impl';
 import {listenOncePromise} from '../../src/event-helper';
-import {parseUrl} from '../../src/url';
+import {parseUrlDeprecated} from '../../src/url';
 
 
 describes.fakeWin('History', {
@@ -198,7 +198,7 @@ describes.sandboxed('History install', {}, () => {
         body: {},
         querySelector: () => null,
       },
-      location: parseUrl('https://cdn.ampproject.org/c/s/www.example.com/path'),
+      location: parseUrlDeprecated('https://cdn.ampproject.org/c/s/www.example.com/path'),
       addEventListener: () => null,
     };
     ampdoc = new AmpDocSingle(win);

--- a/test/functional/test-mode.js
+++ b/test/functional/test-mode.js
@@ -20,12 +20,12 @@ import {
   getRtvVersionForTesting,
   resetRtvVersionForTesting,
 } from '../../src/mode';
-import {parseUrl} from '../../src/url';
+import {parseUrlDeprecated} from '../../src/url';
 
 describe('getMode', () => {
   function getWin(url) {
     const win = {
-      location: parseUrl(url),
+      location: parseUrlDeprecated(url),
     };
     return win;
   }
@@ -78,7 +78,7 @@ describe('getRtvVersion', () => {
       AMP_CONFIG: {
         v: '12345',
       },
-      location: parseUrl('https://acme.org/doc1'),
+      location: parseUrlDeprecated('https://acme.org/doc1'),
     };
     expect(getRtvVersionForTesting(win, true))
         .to.equal('$internalRuntimeVersion$');

--- a/test/functional/test-url-replacements.js
+++ b/test/functional/test-url-replacements.js
@@ -39,7 +39,7 @@ import {
   mockWindowInterface,
   stubServiceForDoc,
 } from '../../testing/test-helper';
-import {parseUrl} from '../../src/url';
+import {parseUrlDeprecated} from '../../src/url';
 import {registerServiceBuilder} from '../../src/service';
 import {setCookie} from '../../src/cookies';
 import {user} from '../../src/log';
@@ -332,10 +332,10 @@ describes.sandboxed('UrlReplacements', {}, () => {
 
   it('should update SOURCE_URL after track impression', () => {
     const win = getFakeWindow();
-    win.location = parseUrl('https://wrong.com');
+    win.location = parseUrlDeprecated('https://wrong.com');
     sandbox.stub(trackPromise, 'getTrackImpressionPromise').callsFake(() => {
       return new Promise(resolve => {
-        win.location = parseUrl('https://example.com?gclid=123456');
+        win.location = parseUrlDeprecated('https://example.com?gclid=123456');
         resolve();
       });
     });
@@ -1036,11 +1036,11 @@ describes.sandboxed('UrlReplacements', {}, () => {
 
   it('should replace QUERY_PARAM with foo', () => {
     const win = getFakeWindow();
-    win.location = parseUrl('https://example.com?query_string_param1=wrong');
+    win.location = parseUrlDeprecated('https://example.com?query_string_param1=wrong');
     sandbox.stub(trackPromise, 'getTrackImpressionPromise').callsFake(() => {
       return new Promise(resolve => {
         win.location =
-            parseUrl('https://example.com?query_string_param1=foo');
+            parseUrlDeprecated('https://example.com?query_string_param1=foo');
         resolve();
       });
     });
@@ -1053,7 +1053,7 @@ describes.sandboxed('UrlReplacements', {}, () => {
 
   it('should replace QUERY_PARAM with ""', () => {
     const win = getFakeWindow();
-    win.location = parseUrl('https://example.com');
+    win.location = parseUrlDeprecated('https://example.com');
     sandbox.stub(trackPromise, 'getTrackImpressionPromise').callsFake(() => {
       return Promise.resolve();
     });
@@ -1066,7 +1066,7 @@ describes.sandboxed('UrlReplacements', {}, () => {
 
   it('should replace QUERY_PARAM with default_value', () => {
     const win = getFakeWindow();
-    win.location = parseUrl('https://example.com');
+    win.location = parseUrlDeprecated('https://example.com');
     sandbox.stub(trackPromise, 'getTrackImpressionPromise').callsFake(() => {
       return Promise.resolve();
     });
@@ -1079,7 +1079,7 @@ describes.sandboxed('UrlReplacements', {}, () => {
 
   it('should collect vars', () => {
     const win = getFakeWindow();
-    win.location = parseUrl('https://example.com?p1=foo');
+    win.location = parseUrlDeprecated('https://example.com?p1=foo');
     sandbox.stub(trackPromise, 'getTrackImpressionPromise').callsFake(() => {
       return Promise.resolve();
     });
@@ -1266,7 +1266,7 @@ describes.sandboxed('UrlReplacements', {}, () => {
       a = document.createElement('a');
       win = getFakeWindow();
       win.location =
-          parseUrl('https://example.com/base?foo=bar&bar=abc&gclid=123');
+          parseUrlDeprecated('https://example.com/base?foo=bar&bar=abc&gclid=123');
       urlReplacements = Services.urlReplacementsForDoc(win.ampdoc);
     });
 

--- a/test/functional/test-url.js
+++ b/test/functional/test-url.js
@@ -28,7 +28,7 @@ import {
   isProxyOrigin,
   isSecureUrl,
   parseQueryString,
-  parseUrl,
+  parseUrlDeprecated,
   removeFragment,
   resolveRelativeUrl,
   resolveRelativeUrlFallback_,
@@ -85,14 +85,14 @@ describe('getWinOrigin', () => {
 });
 
 
-describe('parseUrl', () => {
+describe('parseUrlDeprecated', () => {
 
   const currentPort = location.port;
 
   function compareParse(url, result) {
     // Using JSON string comparison because Chai's deeply equal
     // errors are impossible to debug.
-    const parsed = JSON.stringify(parseUrl(url));
+    const parsed = JSON.stringify(parseUrlDeprecated(url));
     const expected = JSON.stringify(result);
     expect(parsed).to.equal(expected);
   }
@@ -112,31 +112,31 @@ describe('parseUrl', () => {
   });
   it('caches results', () => {
     const url = 'https://foo.com:123/abc?123#foo';
-    parseUrl(url);
-    const a1 = parseUrl(url);
-    const a2 = parseUrl(url);
+    parseUrlDeprecated(url);
+    const a1 = parseUrlDeprecated(url);
+    const a2 = parseUrlDeprecated(url);
     expect(a1).to.equal(a2);
   });
 
   // TODO(#14349): unskip flaky test
   it.skip('caches up to 100 results', () => {
     const url = 'https://foo.com:123/abc?123#foo';
-    const a1 = parseUrl(url);
+    const a1 = parseUrlDeprecated(url);
 
     // should grab url from the cache
-    expect(a1).to.equal(parseUrl(url));
+    expect(a1).to.equal(parseUrlDeprecated(url));
 
     // cache 99 more urls in order to reach max capacity of LRU cache: 100
     for (let i = 0; i < 100; i++) {
-      parseUrl(`${url}-${i}`);
+      parseUrlDeprecated(`${url}-${i}`);
     }
 
-    const a2 = parseUrl(url);
+    const a2 = parseUrlDeprecated(url);
 
     // the old cached url should not be in the cache anymore
     // the newer instance should
-    expect(a1).to.not.equal(parseUrl(url));
-    expect(a2).to.equal(parseUrl(url));
+    expect(a1).to.not.equal(parseUrlDeprecated(url));
+    expect(a2).to.equal(parseUrlDeprecated(url));
     expect(a1).to.not.equal(a2);
   });
   it('should handle ports', () => {
@@ -231,12 +231,12 @@ describe('parseUrl', () => {
     });
   });
   it('should parse origin https://twitter.com/path#abc', () => {
-    expect(parseUrl('https://twitter.com/path#abc').origin)
+    expect(parseUrlDeprecated('https://twitter.com/path#abc').origin)
         .to.equal('https://twitter.com');
   });
 
   it('should parse origin data:12345', () => {
-    expect(parseUrl('data:12345').origin)
+    expect(parseUrlDeprecated('data:12345').origin)
         .to.equal('data:12345');
   });
 });
@@ -495,7 +495,7 @@ describe('isProxyOrigin', () => {
   function testProxyOrigin(href, bool) {
     it('should return that ' + href + (bool ? ' is' : ' is not') +
         ' a proxy origin', () => {
-      expect(isProxyOrigin(parseUrl(href))).to.equal(bool);
+      expect(isProxyOrigin(parseUrlDeprecated(href))).to.equal(bool);
     });
   }
 
@@ -543,7 +543,7 @@ describe('isLocalhostOrigin', () => {
   function testLocalhostOrigin(href, bool) {
     it('should return that ' + href + (bool ? ' is' : ' is not') +
       ' a localhost origin', () => {
-      expect(isLocalhostOrigin(parseUrl(href))).to.equal(bool);
+      expect(isLocalhostOrigin(parseUrlDeprecated(href))).to.equal(bool);
     });
   }
 
@@ -589,7 +589,8 @@ describe('getSourceOrigin/Url', () => {
   function testOrigin(href, sourceHref) {
     it('should return the source origin/url from ' + href, () => {
       expect(getSourceUrl(href)).to.equal(sourceHref);
-      expect(getSourceOrigin(href)).to.equal(parseUrl(sourceHref).origin);
+      expect(getSourceOrigin(href)).to.equal(
+          parseUrlDeprecated(sourceHref).origin);
     });
   }
 
@@ -702,7 +703,7 @@ describe('getSourceOrigin/Url', () => {
 
   it('should fail on invalid source origin', () => {
     allowConsoleError(() => { expect(() => {
-      getSourceOrigin(parseUrl('https://cdn.ampproject.org/v/yyy/'));
+      getSourceOrigin(parseUrlDeprecated('https://cdn.ampproject.org/v/yyy/'));
     }).to.throw(/Expected a \. in origin http:\/\/yyy/); });
   });
 });
@@ -781,7 +782,7 @@ describe('resolveRelativeUrl', () => {
   // Accepts parsed URLs.
   testRelUrl(
       'file?f=0#h',
-      parseUrl('http://base.org/bfile?bf=0#bh'),
+      parseUrlDeprecated('http://base.org/bfile?bf=0#bh'),
       'http://base.org/file?f=0#h');
 });
 

--- a/test/functional/test-viewer.js
+++ b/test/functional/test-viewer.js
@@ -24,7 +24,7 @@ import {installDocumentInfoServiceForDoc} from
 import {installDocumentStateService} from '../../src/service/document-state';
 import {installPlatformService} from '../../src/service/platform-impl';
 import {installTimerService} from '../../src/service/timer-impl';
-import {parseUrl, removeFragment} from '../../src/url';
+import {parseUrlDeprecated, removeFragment} from '../../src/url';
 
 
 describe('Viewer', () => {
@@ -78,7 +78,7 @@ describe('Viewer', () => {
       body: {style: {}},
       documentElement: {style: {}},
       title: 'Awesome doc',
-      querySelector() { return parseUrl('http://www.example.com/'); },
+      querySelector() { return parseUrlDeprecated('http://www.example.com/'); },
     };
     windowApi.navigator = window.navigator;
     windowApi.history = {
@@ -292,7 +292,7 @@ describe('Viewer', () => {
 
   describe('replaceUrl', () => {
     function setUrl(href) {
-      const url = parseUrl(href);
+      const url = parseUrlDeprecated(href);
       windowApi.location.href = url.href;
       windowApi.location.hash = url.hash;
     }

--- a/testing/fake-dom.js
+++ b/testing/fake-dom.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {parseUrl, resolveRelativeUrl} from '../src/url';
+import {parseUrlDeprecated, resolveRelativeUrl} from '../src/url';
 
 
 /**
@@ -399,7 +399,7 @@ export class FakeLocation {
     this.changes = [];
 
     /** @private {!Location} */
-    this.url_ = parseUrl(href, true);
+    this.url_ = parseUrlDeprecated(href, true);
 
     // href
     Object.defineProperty(this, 'href', {
@@ -426,7 +426,7 @@ export class FakeLocation {
    */
   set_(href) {
     const oldHash = this.url_.hash;
-    this.url_ = parseUrl(resolveRelativeUrl(href, this.url_));
+    this.url_ = parseUrlDeprecated(resolveRelativeUrl(href, this.url_));
     if (this.url_.hash != oldHash) {
       this.win.eventListeners.fire({type: 'hashchange'});
     }
@@ -436,7 +436,7 @@ export class FakeLocation {
    * @param {!Object} args
    */
   change_(args) {
-    const change = parseUrl(this.url_.href);
+    const change = parseUrlDeprecated(this.url_.href);
     Object.assign({}, change, args);
     this.changes.push(change);
   }
@@ -478,7 +478,7 @@ export class FakeLocation {
    * @param {string} href
    */
   resetHref(href) {
-    this.url_ = parseUrl(resolveRelativeUrl(href, this.url_));
+    this.url_ = parseUrlDeprecated(resolveRelativeUrl(href, this.url_));
   }
 }
 


### PR DESCRIPTION
Imports of `parseUrl` are now deprecated in preparation of moving URL related functions into an `AmpDoc` registered service.

Part of https://github.com/ampproject/amphtml/issues/14753.