### PR TITLE
🐛 Rename `resolve-inside-promise-resolver` to `prefer-deferred-promise`

### DIFF
--- a/.eslintrc-strict
+++ b/.eslintrc-strict
@@ -1,6 +1,6 @@
 {
   "rules": {
-    "amphtml-internal/resolve-inside-promise-resolver": 2,
+    "amphtml-internal/prefer-deferred-promise": 2,
     "amphtml-internal/unused-private-field": 2,
     "amphtml-internal/vsync": 1,
     "jsdoc/check-param-names": 2,


### PR DESCRIPTION
#15364 renamed `resolve-inside-promise-resolver` to `prefer-deferred-promise` in `.eslintrc`, but not in `.eslintrc-strict`, resulting in lint errors on Travis.

https://github.com/ampproject/amphtml/blob/caf86f55485f1461459fc03fd247531e87f20f67/.eslintrc#L69

https://github.com/ampproject/amphtml/blob/caf86f55485f1461459fc03fd247531e87f20f67/.eslintrc-strict#L3

Fixes #15384
