### PR TITLE
🖍Fix date picker drop shadow cutoff in static mode

### DIFF
--- a/examples/date-picker.amp.html
+++ b/examples/date-picker.amp.html
@@ -199,6 +199,7 @@
   <input type="date" id="end-date">
 </amp-date-picker>
 
+<h2>Lightbox date picker</h2>
 <button on="tap: lb.open">Show lightbox date picker</button>
 <amp-lightbox id="lb" layout="nodisplay">
   <amp-date-picker

--- a/extensions/amp-date-picker/0.1/amp-date-picker.css
+++ b/extensions/amp-date-picker/0.1/amp-date-picker.css
@@ -95,6 +95,27 @@ amp-date-picker[mode="overlay"] .i-amphtml-date-picker-container {
   font-size: 0;
 }
 
+.DayPicker {
+  background: #fdfdfd;
+}
+
+.DayPicker__withBorder {
+  background-color: #fdfdfd;
+  border: 1px solid rgba(0,0,0,0.07);
+  box-shadow: none;
+  overflow: hidden;
+}
+
+amp-date-picker[mode="overlay"] .DayPicker__withBorder {
+  box-shadow: 0 2px 6px rgba(0,0,0,0.05), 0 0 0 1px rgba(0,0,0,0.07);
+  border: 0;
+}
+
+.CalendarMonth,
+.CalendarMonthGrid {
+  background-color: transparent;
+}
+
 .CalendarDay__highlighted_calendar,
 .CalendarDay__highlighted_calendar:hover {
   background-color: #fff;
@@ -103,6 +124,7 @@ amp-date-picker[mode="overlay"] .i-amphtml-date-picker-container {
 
 .CalendarDay_container, /* remove after update to react-dates v16 */
 .CalendarDay__default {
+  background-color: transparent;
   border: 1px solid transparent;
 }
 
@@ -114,6 +136,7 @@ amp-date-picker[mode="overlay"] .i-amphtml-date-picker-container {
 
 .CalendarDay__blocked_calendar {
   border: 1px solid #cacccd;
+  background-color: #cacccd;
 }
 
 .CalendarDay__blocked_calendar.CalendarDay__hovered_span {
@@ -126,6 +149,7 @@ amp-date-picker[mode="overlay"] .i-amphtml-date-picker-container {
 .CalendarDay__blocked_out_of_range:hover {
   color: rgb(0, 0, 0, .1);
   border: 1px solid transparent;
+  background: transparent;
 }
 
 .CalendarDay__hovered_span,
@@ -227,6 +251,8 @@ amp-date-picker[mode="overlay"] .i-amphtml-date-picker-container {
  */
 .DayPicker_transitionContainer {
   min-height: 354px;
+  max-width: 100%;
+  border-radius: 0;
 }
 
 [data-date-tooltip] {

--- a/extensions/amp-date-picker/0.1/amp-date-picker.js
+++ b/extensions/amp-date-picker/0.1/amp-date-picker.js
@@ -1308,6 +1308,7 @@ export class AmpDatePicker extends AMP.BaseElement {
   /**
    * Render the template that corresponds to the date with its data.
    * @param {!moment} date
+   * @return {!Promise<string>}
    * @private
    */
   renderDayTemplate_(date) {


### PR DESCRIPTION
Also adds slight background color. Feedback welcome.

The drop shadow still appears in overlay mode, but in static mode there is no way to prevent cutting off the shadow inside the `overflow:hidden` amp element container with `layout="{fixed,fixed-height,responsive,etc}"`.

| before | after |
--|--
<img width="100%" alt="screen shot 2018-05-17 at 15 03 03" src="https://user-images.githubusercontent.com/2363700/40206075-6b399256-59e3-11e8-816b-e96c1f97502c.png">|<img width="100%" alt="screen shot 2018-05-17 at 15 02 03" src="https://user-images.githubusercontent.com/2363700/40206063-5f9c2d00-59e3-11e8-8424-361c4a1ba9fe.png">

