### PR TITLE
🏗✨ Enhance AMP tooling so developers can run tests on local changes only

### DIFF
--- a/build-system/config.js
+++ b/build-system/config.js
@@ -56,7 +56,9 @@ const builtRuntimePaths = [
   },
 ];
 
-const commonTestPaths =
+const commonUnitTestPaths = initTestsPath.concat(fixturesExamplesPaths);
+
+const commonIntegrationTestPaths =
     initTestsPath.concat(fixturesExamplesPaths, builtRuntimePaths);
 
 const coveragePaths = [
@@ -72,7 +74,7 @@ const simpleTestPath = [
   'test/simple-test.js',
 ];
 
-const testPaths = commonTestPaths.concat([
+const testPaths = commonIntegrationTestPaths.concat([
   'test/**/*.js',
   'ads/**/test/test-*.js',
   'extensions/**/test/**/*.js',
@@ -88,30 +90,31 @@ const chaiAsPromised = [
   'test/chai-as-promised/chai-as-promised.js',
 ];
 
-const unitTestPaths = initTestsPath.concat(fixturesExamplesPaths, [
+const unitTestPaths = [
   'test/functional/**/*.js',
   'ads/**/test/test-*.js',
   'extensions/**/test/*.js',
-]);
+];
 
-const unitTestOnSaucePaths = initTestsPath.concat(fixturesExamplesPaths, [
+const unitTestOnSaucePaths = [
   'test/functional/**/*.js',
   'ads/**/test/test-*.js',
-]);
+];
 
-const integrationTestPaths = commonTestPaths.concat([
+const integrationTestPaths = [
   'test/integration/**/*.js',
   'test/functional/test-error.js',
   'extensions/**/test/integration/**/*.js',
-]);
+];
 
 /** @const  */
 module.exports = {
-  commonTestPaths,
   simpleTestPath,
   testPaths,
   a4aTestPaths,
   chaiAsPromised,
+  commonUnitTestPaths,
+  commonIntegrationTestPaths,
   unitTestPaths,
   unitTestOnSaucePaths,
   integrationTestPaths,

--- a/build-system/git.js
+++ b/build-system/git.js
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+/**
+ * @fileoverview Provides functions for executing various git commands.
+ */
+
+const {getStdout} = require('./exec');
+
+/**
+ * Returns the list of files changed on the local branch relative to master,
+ * one on each line.
+ * @return {!Array<string>}
+ */
+exports.gitDiffNameOnlyMaster = function() {
+  return getStdout('git diff --name-only master').trim().split('\n');
+};
+
+/**
+ * Returns the list of files changed on the local branch relative to master,
+ * in diffstat format.
+ * @return {string}
+ */
+exports.gitDiffStatMaster = function() {
+  return getStdout('git -c color.ui=always diff --stat master');
+};
+
+/**
+ * Returns the list of files added by the local branch relative to master,
+ * one on each line.
+ * @return {!Array<string>}
+ */
+exports.gitDiffAddedNameOnlyMaster = function() {
+  return getStdout(
+      'git diff --name-only --diff-filter=ARC master').trim().split('\n');
+};
+
+/**
+ * Returns the full color diff of the changes on the local branch.
+ * @return {string}
+ */
+exports.gitDiffColor = function() {
+  return getStdout('git -c color.ui=always diff').trim();
+};
+
+/**
+ * Returns the name of the local branch.
+ * @return {string}
+ */
+exports.gitBranchName = function() {
+  return getStdout('git rev-parse --abbrev-ref HEAD').trim();
+};
+
+/**
+ * Returns the email of the author of the latest commit on the local branch.
+ * @return {string}
+ */
+exports.gitCommitterEmail = function() {
+  return getStdout('git log -1 --pretty=format:"%ae"').trim();
+};

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -29,6 +29,7 @@ const atob = require('atob');
 const colors = require('ansi-colors');
 const path = require('path');
 const {execOrDie, exec, getStderr, getStdout} = require('./exec');
+const {gitDiffColor, gitDiffNameOnlyMaster, gitDiffStatMaster} = require('./git');
 
 const fileLogPrefix = colors.bold(colors.yellow('pr-check.js:'));
 
@@ -47,6 +48,7 @@ function startTimer(functionName) {
 /**
  * Stops the timer for the given function and prints the execution time.
  * @param {string} functionName
+ * @param {DOMHighResTimeStamp} startTime
  * @return {number}
  */
 function stopTimer(functionName, startTime) {
@@ -88,10 +90,8 @@ function timedExecOrDie(cmd) {
  * @return {!Array<string>}
  */
 function filesInPr() {
-  const files =
-      getStdout('git diff --name-only master...HEAD').trim().split('\n');
-  const changeSummary =
-      getStdout('git -c color.ui=always diff --stat master...HEAD');
+  const files = gitDiffNameOnlyMaster();
+  const changeSummary = gitDiffStatMaster();
   console.log(fileLogPrefix,
       'Testing the following changes at commit',
       colors.cyan(process.env.TRAVIS_PULL_REQUEST_SHA));
@@ -467,8 +467,8 @@ function runYarnIntegrityCheck() {
  * Makes sure that yarn.lock was properly updated.
  */
 function runYarnLockfileCheck() {
-  const yarnLockfileCheck = getStdout('git -c color.ui=always diff').trim();
-  if (yarnLockfileCheck.includes('yarn.lock')) {
+  const localChanges = gitDiffColor();
+  if (localChanges.includes('yarn.lock')) {
     console.error(fileLogPrefix, colors.red('ERROR:'),
         'This PR did not properly update', colors.cyan('yarn.lock') + '.');
     console.error(fileLogPrefix, colors.yellow('NOTE:'),
@@ -476,7 +476,7 @@ function runYarnLockfileCheck() {
         ', run', colors.cyan('gulp update-packages') +
         ', and push a new commit containing the changes.');
     console.error(fileLogPrefix, 'Expected changes:');
-    console.log(yarnLockfileCheck);
+    console.log(localChanges);
     process.exit(1);
   }
 }

--- a/build-system/tasks/check-links.js
+++ b/build-system/tasks/check-links.js
@@ -23,7 +23,7 @@ const gulp = require('gulp-help')(require('gulp'));
 const log = require('fancy-log');
 const markdownLinkCheck = BBPromise.promisify(require('markdown-link-check'));
 const path = require('path');
-const {getStdout} = require('../exec');
+const {gitDiffAddedNameOnlyMaster, gitDiffNameOnlyMaster} = require('../git');
 
 
 /**
@@ -35,9 +35,7 @@ function getMarkdownFiles() {
   if (!!argv.files) {
     return argv.files.split(',');
   }
-  const filesInPr =
-        getStdout('git diff --name-only master...HEAD').trim().split('\n');
-  return filesInPr.filter(function(file) {
+  return gitDiffNameOnlyMaster().filter(function(file) {
     return path.extname(file) == '.md' && !file.startsWith('examples/');
   });
 }
@@ -115,10 +113,7 @@ function checkLinks() {
  * @return {boolean} True if the link points to a file introduced by the PR.
  */
 function isLinkToFileIntroducedByPR(link) {
-  const filesAdded =
-      getStdout('git diff --name-only --diff-filter=ARC master...HEAD')
-          .trim().split('\n');
-  return filesAdded.some(function(file) {
+  return gitDiffAddedNameOnlyMaster().some(function(file) {
     return (file.length > 0 && link.includes(path.parse(file).base));
   });
 }

--- a/build-system/tasks/lint.js
+++ b/build-system/tasks/lint.js
@@ -26,7 +26,7 @@ const lazypipe = require('lazypipe');
 const log = require('fancy-log');
 const path = require('path');
 const watch = require('gulp-watch');
-const {getStdout} = require('../exec');
+const {gitDiffNameOnlyMaster} = require('../git');
 
 const isWatching = (argv.watch || argv.w) || false;
 const filesInARefactorPr = 15;
@@ -125,10 +125,8 @@ function runLinter(path, stream, options) {
  *
  * @return {!Array<string>}
  */
-function jsFilesInPr() {
-  const filesInPr =
-        getStdout('git diff --name-only master...HEAD').trim().split('\n');
-  return filesInPr.filter(function(file) {
+function jsFilesChanged() {
+  return gitDiffNameOnlyMaster().filter(function(file) {
     return path.extname(file) == '.js';
   });
 }
@@ -139,13 +137,11 @@ function jsFilesInPr() {
  *
  * @return {boolean}
  */
-function eslintrcChangesInPr() {
+function eslintrcChanged() {
   if (process.env.TRAVIS_EVENT_TYPE === 'push') {
     return false;
   }
-  const filesInPr =
-        getStdout('git diff --name-only master...HEAD').trim().split('\n');
-  return filesInPr.filter(function(file) {
+  return gitDiffNameOnlyMaster().filter(function(file) {
     return path.basename(file).includes('.eslintrc');
   }).length > 0;
 }
@@ -159,8 +155,10 @@ function setFilesToLint(files) {
   config.lintGlobs =
       config.lintGlobs.filter(e => e !== '**/*.js').concat(files);
   if (!process.env.TRAVIS) {
-    log(colors.green('INFO: ') + 'Running lint on ' +
-        colors.cyan(files.join(',')));
+    log(colors.green('INFO: ') + 'Running lint on the following files:');
+    files.forEach(file => {
+      log(colors.cyan(file));
+    });
   }
 }
 
@@ -185,11 +183,11 @@ function lint() {
   if (argv.files) {
     setFilesToLint(argv.files.split(','));
     enableStrictLinting();
-  } else if (!eslintrcChangesInPr() &&
+  } else if (!eslintrcChanged() &&
       (process.env.TRAVIS_EVENT_TYPE === 'pull_request' ||
        process.env.LOCAL_PR_CHECK ||
        argv['local-changes'])) {
-    const jsFiles = jsFilesInPr();
+    const jsFiles = jsFilesChanged();
     if (jsFiles.length == 0) {
       log(colors.green('INFO: ') + 'No JS files in this PR');
       return Promise.resolve();

--- a/build-system/tasks/visual-diff.js
+++ b/build-system/tasks/visual-diff.js
@@ -17,8 +17,8 @@
 
 const argv = require('minimist')(process.argv.slice(2));
 const gulp = require('gulp-help')(require('gulp'));
-const {execOrDie, getStdout} = require('../exec');
-
+const {execOrDie} = require('../exec');
+const {gitBranchName, gitCommitterEmail} = require('../git');
 
 /**
  * Disambiguates branch names by decorating them with the commit author name.
@@ -27,11 +27,9 @@ const {execOrDie, getStdout} = require('../exec');
  */
 function setPercyBranch() {
   if (!argv.master || !process.env['TRAVIS']) {
-    const userName = getStdout(
-        'git log -1 --pretty=format:"%ae"').trim();
+    const userName = gitCommitterEmail();
     const branchName = process.env['TRAVIS'] ?
-      process.env['TRAVIS_PULL_REQUEST_BRANCH'] :
-      getStdout('git rev-parse --abbrev-ref HEAD').trim();
+      process.env['TRAVIS_PULL_REQUEST_BRANCH'] : gitBranchName();
     process.env['PERCY_BRANCH'] = userName + '-' + branchName;
   }
 }

--- a/contributing/DEVELOPING.md
+++ b/contributing/DEVELOPING.md
@@ -48,7 +48,7 @@ The Quick Start Guide's  [One-time setup](getting-started-quick.md#one-time-setu
 | `gulp lint --watch`                                                     | Watches for changes in files, and validates against the ESLint linter. |
 | `gulp lint --fix`                                                       | Fixes simple lint warnings/errors automatically.                      |
 | `gulp lint --files=<files-path-glob>`                                   | Lints just the files provided. Can be used with `--fix`.              |
-| `gulp lint --local-changes`                                             | Lints just the changes commited to the local branch. Can be used with `--fix`.   |
+| `gulp lint --local-changes`                                             | Lints just the files changed in the local branch. Can be used with `--fix`.   |
 | `gulp build`                                                            | Builds the AMP library.                                               |
 | `gulp build --extensions=<amp-foo,amp-bar>`                             | Builds the AMP library, with only the listed extensions.
 | `gulp build --extensions=minimal_set`                                   | Builds the AMP library, with only the extensions needed to load `article.amp.html`.
@@ -65,6 +65,7 @@ The Quick Start Guide's  [One-time setup](getting-started-quick.md#one-time-setu
 | `gulp pr-check --files=<test-files-path-glob>`                          | Runs all the Travis CI checks locally, and restricts tests to the files provided.  |
 | `gulp test --unit`                                                      | Runs the unit tests in Chrome (doesn't require the AMP library to be built).                                                 |
 | `gulp test --unit --files=<test-files-path-glob>`                       | Runs the unit tests from the specified files in Chrome.                                                 |
+| `gulp test --local-changes`                                             | Runs the unit tests from just the files changed in the local branch in Chrome.   |
 | `gulp test --integration`                                               | Runs the integration tests in Chrome (requires the AMP library to be built).                                                 |
 | `gulp test --integration --files=<test-files-path-glob>`                | Runs the integration tests from the specified files in Chrome.                                                 |
 | `gulp test [--unit\|--integration] --verbose`                           | Runs tests in Chrome with logging enabled.                            |


### PR DESCRIPTION
This PR does a few things:
1. Adds a `--local-changes` mode to `gulp test`, which runs only unit tests from files changed in the local branch. (Works with `--nobuild` and `--headless`.)
2. Adds the file `build-system/git.js` to consolidate all the `git` commands run in various places in `build-system/`.
3. Updates `gulp lint --local-changes` so it runs on any files changed in the local branch. They no longer need to be committed to show up in the list.
4. Does a minor clean up / refactor of `build-system/config.js`
5. Updates AMP dev docs to reflect the new testing flags

Note that we can only run unit tests with `--local-changes`, since they are self contained, don't require the entire AMP runtime to be built, and can start up in very little time. Any changes to integration tests will require the runtime to be built, so these tests are better off being run on Travis.


Once this is in place, it will become feasible to add an opt-in pre-push hook that will be run before a local branch is pushed to GitHub. Commands like `gulp lint --local-changes` and `gulp test --local-changes` should only take a few seconds to run. 


Fixes #15369 