### PR TITLE
[amp-story] ♻️Refactor Desktop Logic

### DIFF
--- a/extensions/amp-story/1.0/amp-story-desktop.css
+++ b/extensions/amp-story/1.0/amp-story-desktop.css
@@ -82,7 +82,7 @@ amp-story[standalone][desktop] {
 }
 
 [desktop] amp-story-page {
-  transform: scale(1.0) translateX(250vw) translateY(0%) !important;
+  transform: scale(1.0) translateX(300%) translateY(0%) !important;
   opacity: .05 !important;
   transform-origin: left !important;
   border-radius: 16px !important;
@@ -142,7 +142,7 @@ amp-story[standalone][desktop] {
 }
 
 [desktop] amp-story-page[i-amphtml-visited] {
-  transform: scale(0.9) translateX(-250vw) translateY(0%) !important;
+  transform: scale(0.9) translateX(-350%) translateY(0%) !important;
 }
 
 [desktop] amp-story-page[i-amphtml-previous-page],
@@ -167,7 +167,7 @@ amp-story[standalone][desktop] {
 Perhaps better to delete and start over when RTL implementation begins. There be
 dragons here. */
 [dir=rtl] [desktop] amp-story-page {
-  transform: scale(0.9) translateX(250vw) translateY(0%) !important;
+  transform: scale(0.9) translateX(300%) translateY(0%) !important;
 }
 
 [dir=rtl] [desktop] amp-story-page[i-amphtml-previous-page] {

--- a/extensions/amp-story/1.0/amp-story-desktop.css
+++ b/extensions/amp-story/1.0/amp-story-desktop.css
@@ -82,10 +82,10 @@ amp-story[standalone][desktop] {
 }
 
 [desktop] amp-story-page {
-  transform: scale(1.0) translateX(-350%) translateY(0%) !important;
-  opacity: .05!important;
-  transform-origin: left!important;
-  border-radius: 16px!important;
+  transform: scale(1.0) translateX(250vw) translateY(0%) !important;
+  opacity: .05 !important;
+  transform-origin: left !important;
+  border-radius: 16px !important;
 }
 
 [desktop] amp-story-page[distance="0"],
@@ -141,7 +141,11 @@ amp-story[standalone][desktop] {
   right: 0 !important;
 }
 
-[desktop] amp-story-page[pre-active],
+[desktop] amp-story-page[i-amphtml-visited] {
+  transform: scale(0.9) translateX(-250vw) translateY(0%) !important;
+}
+
+[desktop] amp-story-page[i-amphtml-previous-page],
 .prev-container > .i-amphtml-story-page-sentinel {
   /* -150% + 15% */
   transform: scale(0.9) translateX(calc(-150% - 64px)) translateY(0%) !important;
@@ -149,24 +153,24 @@ amp-story[standalone][desktop] {
 
 [desktop] amp-story-page[active] {
   transform: scale(1.0) translateX(-50%) translateY(0%) !important;
-  opacity: 1!important;;
+  opacity: 1 !important;;
 }
 
-[desktop] amp-story-page[active] + amp-story-page,
+[desktop] amp-story-page[i-amphtml-next-page],
 .next-container > .i-amphtml-story-page-sentinel {
   /* 50% - 15% */
   transform: scale(0.9) translate(calc(50% + 64px), 0%) !important;
 }
 
-[desktop] amp-story-page[active] + amp-story-page ~ amp-story-page {
-  transform: scale(0.9) translateX(250vw) translateY(0%) !important;
-}
 
+/* NOTE: This css for rtl has not been refactored after desktop CSS changes.
+Perhaps better to delete and start over when RTL implementation begins. There be
+dragons here. */
 [dir=rtl] [desktop] amp-story-page {
   transform: scale(0.9) translateX(250vw) translateY(0%) !important;
 }
 
-[dir=rtl] [desktop] amp-story-page[pre-active] {
+[dir=rtl] [desktop] amp-story-page[i-amphtml-previous-page] {
   /* 50% - 15% */
   transform: scale(0.9) translateX(calc(50% + 64px)) translateY(0%) !important;
   /*transform: scale(1.0) translateX(35%) translateY(0%) !important;*/
@@ -236,7 +240,7 @@ amp-story[standalone][desktop] {
   outline: none!important;
 }
 
-.i-amphtml-story-prev-hover > amp-story-page[pre-active] {
+.i-amphtml-story-prev-hover > amp-story-page[i-amphtml-previous-page] {
   opacity: 0.3 !important;
 }
 

--- a/extensions/amp-story/1.0/amp-story-desktop.css
+++ b/extensions/amp-story/1.0/amp-story-desktop.css
@@ -153,7 +153,7 @@ amp-story[standalone][desktop] {
 
 [desktop] amp-story-page[active] {
   transform: scale(1.0) translateX(-50%) translateY(0%) !important;
-  opacity: 1 !important;;
+  opacity: 1 !important;
 }
 
 [desktop] amp-story-page[i-amphtml-next-page],

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -595,7 +595,7 @@ export class AmpStoryPage extends AMP.BaseElement {
         this.getNextPageId(true /* opt_isAutomaticAdvance */);
     const manualAdvanceNext =
         this.getNextPageId(false /* opt_isAutomaticAdvance */);
-    const previous = this.getPreviousPageId_();
+    const previous = this.getPreviousPageId();
 
     if (autoAdvanceNext) {
       adjacentPageIds.push(autoAdvanceNext);
@@ -617,9 +617,8 @@ export class AmpStoryPage extends AMP.BaseElement {
    * Gets the ID of the previous page in the story (before the current page).
    * @return {?string} Returns the ID of the next page in the story, or null if
    *     there isn't one.
-   * @private
    */
-  getPreviousPageId_() {
+  getPreviousPageId() {
     if (this.element.hasAttribute('i-amphtml-return-to')) {
       return this.element.getAttribute('i-amphtml-return-to');
     }
@@ -663,7 +662,7 @@ export class AmpStoryPage extends AMP.BaseElement {
    * Navigates to the previous page in the story.
    */
   previous() {
-    const targetPageId = this.getPreviousPageId_();
+    const targetPageId = this.getPreviousPageId();
 
     if (targetPageId === null) {
       dispatch(this.element, EventType.SHOW_NO_PREVIOUS_PAGE_HELP, true);

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -909,8 +909,7 @@ export class AmpStory extends AMP.BaseElement {
       this.nextPage_ = null;
     }
 
-    const prevPageId = targetPage.getPreviousPageId(
-        /* opt_isAutomaticAdvance */ false);
+    const prevPageId = targetPage.getPreviousPageId();
     if (prevPageId) {
       this.previousPage_ = this.getPageById(prevPageId);
       setAtributeInMutate(this.previousPage_, Attributes.PREVIOUS);

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -74,8 +74,6 @@ import {
   childElements,
   closest,
   createElementWithAttributes,
-  escapeCssSelectorIdent,
-  matches,
   removeElement,
   scopedQuerySelectorAll,
 } from '../../../src/dom';
@@ -93,6 +91,7 @@ import {getMode} from '../../../src/mode';
 import {getSourceOrigin, parseUrlDeprecated} from '../../../src/url';
 import {isExperimentOn, toggleExperiment} from '../../../src/experiments';
 import {registerServiceBuilder} from '../../../src/service';
+import {removeAttributeInMutate, setAtributeInMutate} from './utils';
 import {stringHash32} from '../../../src/string';
 import {upgradeBackgroundAudio} from './audio';
 import LocalizedStringsDe from './_locales/de';
@@ -118,12 +117,6 @@ import LocalizedStringsVi from './_locales/vi';
 import LocalizedStringsZh from './_locales/zh';
 import LocalizedStringsZhTw from './_locales/zh-TW';
 
-/** @private @const {string} */
-const PRE_ACTIVE_PAGE_ATTRIBUTE_NAME = 'pre-active';
-
-/** @private @const {string} */
-const AMP_STORY_STANDALONE_ATTRIBUTE = 'standalone';
-
 /** @private @const {number} */
 const DESKTOP_WIDTH_THRESHOLD = 1024;
 
@@ -133,17 +126,18 @@ const DESKTOP_HEIGHT_THRESHOLD = 550;
 /** @private @const {number} */
 const MIN_SWIPE_FOR_HINT_OVERLAY_PX = 50;
 
-/** @private @const {string} */
-const ADVANCE_TO_ATTR = 'i-amphtml-advance-to';
-
-/** @private @const {string} */
-const RETURN_TO_ATTR = 'i-amphtml-return-to';
-
-/** @private @const {string} */
-const AUTO_ADVANCE_TO_ATTR = 'auto-advance-to';
-
-/** @private @const {string} */
-const AD_SHOWING_ATTR = 'ad-showing';
+/** @enum {string} */
+const Attributes = {
+  STANDALONE: 'standalone',
+  ADVANCE_TO: 'i-amphtml-advance-to',
+  RETURN_TO: 'i-amphtml-return-to',
+  AUTO_ADVANCE_TO: 'auto-advance-to',
+  AD_SHOWING: 'ad-showing',
+  // Attributes that desktop css looks for to decide where pages will be placed
+  PREVIOUS: 'i-amphtml-previous-page', // shown in left pane
+  NEXT: 'i-amphtml-next-page', // shown in right pane
+  VISITED: 'i-amphtml-visited', // stacked offscreen to left
+};
 
 /**
  * The duration of time (in milliseconds) to wait for a page to be loaded,
@@ -241,6 +235,12 @@ export class AmpStory extends AMP.BaseElement {
     /** @private {?./amp-story-page.AmpStoryPage} */
     this.activePage_ = null;
 
+    /** @private {?./amp-story-page.AmpStoryPage} */
+    this.previousPage_ = null;
+
+    /** @private {?./amp-story-page.AmpStoryPage} */
+    this.nextPage_ = null;
+
     /** @private @const */
     this.desktopMedia_ = this.win.matchMedia(
         `(min-width: ${DESKTOP_WIDTH_THRESHOLD}px) and ` +
@@ -317,7 +317,7 @@ export class AmpStory extends AMP.BaseElement {
   buildCallback() {
     this.assertAmpStoryExperiment_();
 
-    if (this.element.hasAttribute(AMP_STORY_STANDALONE_ATTRIBUTE)) {
+    if (this.element.hasAttribute(Attributes.STANDALONE)) {
       this.initializeStandaloneStory_();
     }
 
@@ -783,7 +783,7 @@ export class AmpStory extends AMP.BaseElement {
         'No active page set when navigating to next page.');
 
     const lastPage = this.pages_[this.getPageCount() - 1];
-    if (activePage.element.hasAttribute(ADVANCE_TO_ATTR) ||
+    if (activePage.element.hasAttribute(Attributes.ADVANCE_TO) ||
         activePage !== lastPage) {
       activePage.next(opt_isAutomaticAdvance);
     } else {
@@ -837,18 +837,16 @@ export class AmpStory extends AMP.BaseElement {
     const targetPage = this.getPageById(targetPageId);
     const pageIndex = this.getPageIndex(targetPage);
 
+    this.handlePreviewAttributes(targetPage);
+
     this.updateBackground_(targetPage.element, /* initial */ !this.activePage_);
 
     if (targetPage.isAd()) {
       this.storeService_.dispatch(Action.TOGGLE_AD, true);
-      this.vsync_.mutate(() => {
-        this.element.setAttribute(AD_SHOWING_ATTR, '');
-      });
+      setAtributeInMutate(this, Attributes.AD_SHOWING);
     } else {
       this.storeService_.dispatch(Action.TOGGLE_AD, false);
-      this.vsync_.mutate(() => {
-        this.element.removeAttribute(AD_SHOWING_ATTR);
-      });
+      removeAttributeInMutate(this, Attributes.AD_SHOWING);
       // TODO(alanorozco): decouple this using NavigationState
       this.systemLayer_.setActivePageId(targetPageId);
     }
@@ -861,34 +859,22 @@ export class AmpStory extends AMP.BaseElement {
 
     const oldPage = this.activePage_;
 
-    // TODO(cvializ): Move this to the page class?
-    const activePriorSibling = targetPage.element.previousElementSibling;
-    const previousActivePriorSibling = this.element.querySelector(
-        `[${escapeCssSelectorIdent(PRE_ACTIVE_PAGE_ATTRIBUTE_NAME)}]`);
-
     this.activePage_ = targetPage;
 
     this.systemLayer_.resetDeveloperLogs();
     this.systemLayer_.setDeveloperLogContextString(
         this.activePage_.element.id);
 
+    if (oldPage) {
+      oldPage.setActive(false);
+      // indication that this should be offscreen to left in desktop view
+      setAtributeInMutate(oldPage, Attributes.VISITED);
+    }
+
     return targetPage.beforeVisible().then(() => {
       this.triggerActiveEventForPage_();
 
-      if (oldPage) {
-        oldPage.setActive(false);
-      }
-
       targetPage.setActive(true);
-
-      if (activePriorSibling &&
-          matches(activePriorSibling, 'amp-story-page')) {
-        activePriorSibling.setAttribute(PRE_ACTIVE_PAGE_ATTRIBUTE_NAME, '');
-      }
-      if (previousActivePriorSibling) {
-        previousActivePriorSibling.removeAttribute(
-            PRE_ACTIVE_PAGE_ATTRIBUTE_NAME);
-      }
 
       // If first navigation.
       if (!oldPage) {
@@ -904,6 +890,38 @@ export class AmpStory extends AMP.BaseElement {
       this.forceRepaintForSafari_();
       this.maybePreloadBookend_();
     });
+  }
+
+
+  /**
+   * Clear existing preview attributes, Check to see if there is a next or
+   * previous page, set new attributes.
+   * @param {!./amp-story-page.AmpStoryPage} targetPage
+   */
+  handlePreviewAttributes(targetPage) {
+    if (this.previousPage_) {
+      removeAttributeInMutate(this.previousPage_, Attributes.PREVIOUS);
+      this.previousPage_ = null;
+    }
+
+    if (this.nextPage_) {
+      removeAttributeInMutate(this.nextPage_, Attributes.NEXT);
+      this.nextPage_ = null;
+    }
+
+    const prevPageId = targetPage.getPreviousPageId(
+        /* opt_isAutomaticAdvance */ false);
+    if (prevPageId) {
+      this.previousPage_ = this.getPageById(prevPageId);
+      setAtributeInMutate(this.previousPage_, Attributes.PREVIOUS);
+    }
+
+    const nextPageId = targetPage.getNextPageId(
+        /* opt_isAutomaticAdvance */ false);
+    if (nextPageId) {
+      this.nextPage_ = this.getPageById(nextPageId);
+      setAtributeInMutate(this.nextPage_, Attributes.NEXT);
+    }
   }
 
 
@@ -1599,6 +1617,11 @@ export class AmpStory extends AMP.BaseElement {
       this.hideBookend_();
     }
     this.switchTo_(dev().assertElement(this.pages_[0].element).id);
+
+    // reset all pages so that they are offscren to right instead of left in
+    // desktop view
+    this.pages_.forEach(page =>
+      removeAttributeInMutate(page, Attributes.VISITED));
   }
 
   /** @return {!NavigationState} */
@@ -1647,15 +1670,15 @@ export class AmpStory extends AMP.BaseElement {
       return false;
     }
 
-    pageBeforeEl.setAttribute(ADVANCE_TO_ATTR, pageToBeInsertedId);
-    pageBeforeEl.setAttribute(AUTO_ADVANCE_TO_ATTR, pageToBeInsertedId);
-    pageToBeInsertedEl.setAttribute(RETURN_TO_ATTR, pageBeforeId);
+    pageBeforeEl.setAttribute(Attributes.ADVANCE_TO, pageToBeInsertedId);
+    pageBeforeEl.setAttribute(Attributes.AUTO_ADVANCE_TO, pageToBeInsertedId);
+    pageToBeInsertedEl.setAttribute(Attributes.RETURN_TO, pageBeforeId);
 
     const nextPageEl = nextPage.element;
     const nextPageId = nextPageEl.id;
-    pageToBeInsertedEl.setAttribute(ADVANCE_TO_ATTR, nextPageId);
-    pageToBeInsertedEl.setAttribute(AUTO_ADVANCE_TO_ATTR, nextPageId);
-    nextPageEl.setAttribute(RETURN_TO_ATTR, pageToBeInsertedId);
+    pageToBeInsertedEl.setAttribute(Attributes.ADVANCE_TO, nextPageId);
+    pageToBeInsertedEl.setAttribute(Attributes.AUTO_ADVANCE_TO, nextPageId);
+    nextPageEl.setAttribute(Attributes.RETURN_TO, pageToBeInsertedId);
 
     return true;
   }

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -837,7 +837,7 @@ export class AmpStory extends AMP.BaseElement {
     const targetPage = this.getPageById(targetPageId);
     const pageIndex = this.getPageIndex(targetPage);
 
-    this.handlePreviewAttributes(targetPage);
+    this.handlePreviewAttributes_(targetPage);
 
     this.updateBackground_(targetPage.element, /* initial */ !this.activePage_);
 
@@ -865,14 +865,14 @@ export class AmpStory extends AMP.BaseElement {
     this.systemLayer_.setDeveloperLogContextString(
         this.activePage_.element.id);
 
-    if (oldPage) {
-      oldPage.setActive(false);
-      // indication that this should be offscreen to left in desktop view
-      setAttributeInMutate(oldPage, Attributes.VISITED);
-    }
-
     return targetPage.beforeVisible().then(() => {
       this.triggerActiveEventForPage_();
+
+      if (oldPage) {
+        oldPage.setActive(false);
+        // indication that this should be offscreen to left in desktop view
+        setAttributeInMutate(oldPage, Attributes.VISITED);
+      }
 
       targetPage.setActive(true);
 
@@ -897,8 +897,9 @@ export class AmpStory extends AMP.BaseElement {
    * Clear existing preview attributes, Check to see if there is a next or
    * previous page, set new attributes.
    * @param {!./amp-story-page.AmpStoryPage} targetPage
+   * @private
    */
-  handlePreviewAttributes(targetPage) {
+  handlePreviewAttributes_(targetPage) {
     if (this.previousPage_) {
       removeAttributeInMutate(this.previousPage_, Attributes.PREVIOUS);
       this.previousPage_ = null;
@@ -1615,12 +1616,15 @@ export class AmpStory extends AMP.BaseElement {
     if (this.storeService_.get(StateProperty.BOOKEND_STATE)) {
       this.hideBookend_();
     }
-    this.switchTo_(dev().assertElement(this.pages_[0].element).id);
+    const switchPromise = this.switchTo_(
+        dev().assertElement(this.pages_[0].element).id);
 
     // Reset all pages so that they are offscreen to right instead of left in
     // desktop view.
-    this.pages_.forEach(page =>
-      removeAttributeInMutate(page, Attributes.VISITED));
+    switchPromise.then((() => {
+      this.pages_.forEach(page =>
+        removeAttributeInMutate(page, Attributes.VISITED));
+    }));
   }
 
   /** @return {!NavigationState} */

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -91,7 +91,7 @@ import {getMode} from '../../../src/mode';
 import {getSourceOrigin, parseUrlDeprecated} from '../../../src/url';
 import {isExperimentOn, toggleExperiment} from '../../../src/experiments';
 import {registerServiceBuilder} from '../../../src/service';
-import {removeAttributeInMutate, setAtributeInMutate} from './utils';
+import {removeAttributeInMutate, setAttributeInMutate} from './utils';
 import {stringHash32} from '../../../src/string';
 import {upgradeBackgroundAudio} from './audio';
 import LocalizedStringsDe from './_locales/de';
@@ -843,7 +843,7 @@ export class AmpStory extends AMP.BaseElement {
 
     if (targetPage.isAd()) {
       this.storeService_.dispatch(Action.TOGGLE_AD, true);
-      setAtributeInMutate(this, Attributes.AD_SHOWING);
+      setAttributeInMutate(this, Attributes.AD_SHOWING);
     } else {
       this.storeService_.dispatch(Action.TOGGLE_AD, false);
       removeAttributeInMutate(this, Attributes.AD_SHOWING);
@@ -868,7 +868,7 @@ export class AmpStory extends AMP.BaseElement {
     if (oldPage) {
       oldPage.setActive(false);
       // indication that this should be offscreen to left in desktop view
-      setAtributeInMutate(oldPage, Attributes.VISITED);
+      setAttributeInMutate(oldPage, Attributes.VISITED);
     }
 
     return targetPage.beforeVisible().then(() => {
@@ -912,14 +912,14 @@ export class AmpStory extends AMP.BaseElement {
     const prevPageId = targetPage.getPreviousPageId();
     if (prevPageId) {
       this.previousPage_ = this.getPageById(prevPageId);
-      setAtributeInMutate(this.previousPage_, Attributes.PREVIOUS);
+      setAttributeInMutate(this.previousPage_, Attributes.PREVIOUS);
     }
 
     const nextPageId = targetPage.getNextPageId(
         /* opt_isAutomaticAdvance */ false);
     if (nextPageId) {
       this.nextPage_ = this.getPageById(nextPageId);
-      setAtributeInMutate(this.nextPage_, Attributes.NEXT);
+      setAttributeInMutate(this.nextPage_, Attributes.NEXT);
     }
   }
 
@@ -1617,8 +1617,8 @@ export class AmpStory extends AMP.BaseElement {
     }
     this.switchTo_(dev().assertElement(this.pages_[0].element).id);
 
-    // reset all pages so that they are offscren to right instead of left in
-    // desktop view
+    // Reset all pages so that they are offscreen to right instead of left in
+    // desktop view.
     this.pages_.forEach(page =>
       removeAttributeInMutate(page, Attributes.VISITED));
   }

--- a/extensions/amp-story/1.0/test/test-amp-story.js
+++ b/extensions/amp-story/1.0/test/test-amp-story.js
@@ -363,20 +363,6 @@ describes.realWin('amp-story', {
 
 
   describe('desktop attributes', () => {
-    it('should ad next page attribute', function() {
-      sandbox.stub(win.history, 'replaceState');
-      sandbox.stub(utils, 'setAtributeInMutate').callsFake(
-          (el, attr) => el.element.setAttribute(attr, ''));
-
-      const pages = createPages(story.element, 3, ['page-1', 'page-2']);
-      const page2 = pages[1];
-      story.buildCallback();
-      return story.layoutCallback()
-          .then(() => {
-            expect(page2.hasAttribute('i-amphtml-next-page')).to.be.true;
-          });
-    });
-
     it('should add next page attribute', () => {
       sandbox.stub(win.history, 'replaceState');
       sandbox.stub(utils, 'setAtributeInMutate').callsFake(

--- a/extensions/amp-story/1.0/test/test-amp-story.js
+++ b/extensions/amp-story/1.0/test/test-amp-story.js
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import * as utils from '../utils';
 import {Action} from '../amp-story-store-service';
 import {AmpStory} from '../amp-story';
 import {EventType} from '../events';
@@ -358,6 +359,69 @@ describes.realWin('amp-story', {
         .then(() => {
           return expect(replaceStub).to.not.have.been.called;
         });
+  });
+
+
+  describe('desktop attributes', () => {
+    it('should ad next page attribute', function() {
+      sandbox.stub(win.history, 'replaceState');
+      sandbox.stub(utils, 'setAtributeInMutate').callsFake(
+          (el, attr) => el.element.setAttribute(attr, ''));
+
+      const pages = createPages(story.element, 3, ['page-1', 'page-2']);
+      const page2 = pages[1];
+      story.buildCallback();
+      return story.layoutCallback()
+          .then(() => {
+            expect(page2.hasAttribute('i-amphtml-next-page')).to.be.true;
+          });
+    });
+
+    it('should add next page attribute', () => {
+      sandbox.stub(win.history, 'replaceState');
+      sandbox.stub(utils, 'setAtributeInMutate').callsFake(
+          (el, attr) => el.element.setAttribute(attr, ''));
+
+      const pages = createPages(story.element, 2, ['page-0', 'page-1']);
+      const page1 = pages[1];
+      story.buildCallback();
+      return story.layoutCallback()
+          .then(() => {
+            expect(page1.hasAttribute('i-amphtml-next-page')).to.be.true;
+          });
+    });
+
+    it('should add previous page attribute', () => {
+      sandbox.stub(win.history, 'replaceState');
+      sandbox.stub(story, 'maybePreloadBookend_').returns();
+      sandbox.stub(utils, 'setAtributeInMutate').callsFake(
+          (el, attr) => el.element.setAttribute(attr, ''));
+
+      const pages = createPages(story.element, 2, ['page-0', 'page-1']);
+      const page0 = pages[0];
+      story.buildCallback();
+      return story.layoutCallback()
+          .then(() => story.switchTo_('page-1'))
+          .then(() => {
+            expect(page0.hasAttribute('i-amphtml-previous-page')).to.be.true;
+          });
+    });
+
+    it('should add previous visited attribute', () => {
+      sandbox.stub(win.history, 'replaceState');
+      sandbox.stub(story, 'maybePreloadBookend_').returns();
+      sandbox.stub(utils, 'setAtributeInMutate').callsFake(
+          (el, attr) => el.element.setAttribute(attr, ''));
+
+      const pages = createPages(story.element, 2, ['page-0', 'page-1']);
+      const page0 = pages[0];
+      story.buildCallback();
+      return story.layoutCallback()
+          .then(() => story.switchTo_('page-1'))
+          .then(() => {
+            expect(page0.hasAttribute('i-amphtml-visited')).to.be.true;
+          });
+    });
   });
 
   describe('amp-story audio', () => {

--- a/extensions/amp-story/1.0/test/test-amp-story.js
+++ b/extensions/amp-story/1.0/test/test-amp-story.js
@@ -365,7 +365,7 @@ describes.realWin('amp-story', {
   describe('desktop attributes', () => {
     it('should add next page attribute', () => {
       sandbox.stub(win.history, 'replaceState');
-      sandbox.stub(utils, 'setAtributeInMutate').callsFake(
+      sandbox.stub(utils, 'setAttributeInMutate').callsFake(
           (el, attr) => el.element.setAttribute(attr, ''));
 
       const pages = createPages(story.element, 2, ['page-0', 'page-1']);
@@ -380,7 +380,7 @@ describes.realWin('amp-story', {
     it('should add previous page attribute', () => {
       sandbox.stub(win.history, 'replaceState');
       sandbox.stub(story, 'maybePreloadBookend_').returns();
-      sandbox.stub(utils, 'setAtributeInMutate').callsFake(
+      sandbox.stub(utils, 'setAttributeInMutate').callsFake(
           (el, attr) => el.element.setAttribute(attr, ''));
 
       const pages = createPages(story.element, 2, ['page-0', 'page-1']);
@@ -396,7 +396,7 @@ describes.realWin('amp-story', {
     it('should add previous visited attribute', () => {
       sandbox.stub(win.history, 'replaceState');
       sandbox.stub(story, 'maybePreloadBookend_').returns();
-      sandbox.stub(utils, 'setAtributeInMutate').callsFake(
+      sandbox.stub(utils, 'setAttributeInMutate').callsFake(
           (el, attr) => el.element.setAttribute(attr, ''));
 
       const pages = createPages(story.element, 2, ['page-0', 'page-1']);

--- a/extensions/amp-story/1.0/utils.js
+++ b/extensions/amp-story/1.0/utils.js
@@ -175,7 +175,7 @@ export function getTextColorForRGB({r, g, b}) {
  * @param {string} name
  * @param {string=} opt_value
  */
-export function setAtributeInMutate(elementImpl, name, opt_value) {
+export function setAttributeInMutate(elementImpl, name, opt_value) {
   const value = opt_value || '';
   elementImpl.mutateElement(() => {
     elementImpl.element.setAttribute(name, value);

--- a/extensions/amp-story/1.0/utils.js
+++ b/extensions/amp-story/1.0/utils.js
@@ -136,7 +136,6 @@ export function getRGBFromCssColorValue(cssValue) {
   };
 }
 
-
 /**
  * Returns the color, either black or white, that has the best contrast ratio
  * against the provided RGB 8bit values.
@@ -167,4 +166,30 @@ export function getTextColorForRGB({r, g, b}) {
   // 1 is L for #FFF, and 0 is L for #000.
   // (1 + 0.05) / (L + 0.05) > (L + 0.05) / (0 + 0.05) toggles for L = 0.179.
   return L > 0.179 ? '#000' : '#FFF';
+}
+
+
+/**
+ * Sets given attribute to the given element in next `mutate` phase.
+ * @param {!AMP.BaseElement} elementImpl
+ * @param {string} name
+ * @param {string=} opt_value
+ */
+export function setAtributeInMutate(elementImpl, name, opt_value) {
+  const value = opt_value || '';
+  elementImpl.mutateElement(() => {
+    elementImpl.element.setAttribute(name, value);
+  });
+}
+
+
+/**
+ * Removes given attribute from the given element in next `mutate` phase.
+ * @param {!AMP.BaseElement} elementImpl
+ * @param {string} name
+ */
+export function removeAttributeInMutate(elementImpl, name) {
+  elementImpl.mutateElement(() => {
+    elementImpl.element.removeAttribute(name);
+  });
 }


### PR DESCRIPTION
The desktop view currently runs off of css selectors selecting the siblings of the `active` `amp-story-page`. This does not work for non linear stories or pages dynamically inserted like ads.

This has the runtime add a new attribute for the previous and next pages. It also ads a `visited` attribute so that we know to transform those pages offscreen to the left, instead of the right.