### PR TITLE
(`:sparkles:`)  amp-ad adocean: implements not personalized ads when no GDPR consent

### DIFF
--- a/ads/_config.js
+++ b/ads/_config.js
@@ -145,7 +145,9 @@ export const adConfig = {
     ],
   },
 
-  adocean: {},
+  adocean: {
+    consentHandlingOverride: true,
+  },
 
   adpicker: {
     renderStartImplemented: true,

--- a/ads/adocean.js
+++ b/ads/adocean.js
@@ -23,7 +23,7 @@ import {validateData, writeScript} from '../3p/3p';
  */
 const ADO_JS_PATHS = {
   'sync': '/files/js/ado.js',
-  'buffered': '/files/js/ado.FIF.0.99.3.js',
+  'buffered': '/files/js/ado.amp.js',
 };
 
 /**
@@ -37,8 +37,9 @@ function isFalseString(str) {
 /**
  * @param {string} mode
  * @param {!Window} global
+ * @param {boolean} noConsent
  */
-function setupAdoConfig(mode, global) {
+function setupAdoConfig(mode, global, noConsent) {
   if (global['ado']) {
     const config = {
       mode: (mode == 'sync') ? 'old' : 'new',
@@ -46,6 +47,7 @@ function setupAdoConfig(mode, global) {
       fif: {
         enabled: mode != 'sync',
       },
+      consent: !noConsent,
     };
 
     global['ado']['config'](config);
@@ -182,9 +184,21 @@ export function adocean(global, data) {
 
   const mode = (data['aoMode'] != 'sync') ? 'buffered' : 'sync';
   const adoUrl = 'https://' + data['aoEmitter'] + ADO_JS_PATHS[mode];
+  let noConsent = false;
+
+  switch (global.context.initialConsentState) {
+    case 0: // CONSENT_POLICY_STATE.UNKNOWN
+      if (data['npaOnUnknownConsent'] != 'true') {
+        // Unknown w/o NPA results in no ad request.
+        return;
+      }
+    case 2: // CONSENT_POLICY_STATE.SUFFICIENT
+      noConsent = true;
+      break;
+  }
 
   writeScript(global, adoUrl, () => {
-    setupAdoConfig(mode, global);
+    setupAdoConfig(mode, global, noConsent);
     setupPreview(global, data);
 
     appendPlacement(mode, global, data);

--- a/ads/adocean.md
+++ b/ads/adocean.md
@@ -22,7 +22,9 @@ limitations under the License.
 <amp-ad width="300" height="250"
     type="adocean"
     data-ao-id="ado-bIVMPpCJPX0.5tjQbNyrWpnws_dbbTJ1fUnGjLeSqJ3.K7"
-    data-ao-emitter="myao.adocean.pl">
+    data-ao-emitter="myao.adocean.pl"
+    data-block-on-consent
+    data-npa-on-unknown-consent="true">
 </amp-ad>
 ```
 


### PR DESCRIPTION
- Implements not personalized ads when no GDPR consnet
