### PR TITLE
 Carves out canonical pages from canary vs prod experiment

### DIFF
--- a/ads/google/a4a/test/test-utils.js
+++ b/ads/google/a4a/test/test-utils.js
@@ -236,30 +236,30 @@ describe('Google A4A utils', () => {
     it('should specify that this is canary', () => {
       expect(getAmpRuntimeTypeParameter({
         AMP_CONFIG: {type: 'canary'},
-        location: {href: 'https://www-example-com.cdn.ampproject.org'},
+        location: {origin: 'https://www-example-com.cdn.ampproject.org'},
       })).to.equal('2');
     });
     it('should specify that this is control', () => {
       expect(getAmpRuntimeTypeParameter({
         AMP_CONFIG: {type: 'control'},
-        location: {href: 'https://www-example-com.cdn.ampproject.org'},
+        location: {origin: 'https://www-example-com.cdn.ampproject.org'},
       })).to.equal('1');
     });
     it('should not have `art` parameter when AMP_CONFIG is undefined', () => {
       expect(getAmpRuntimeTypeParameter({
-        location: {href: 'https://www-example-com.cdn.ampproject.org'},
+        location: {origin: 'https://www-example-com.cdn.ampproject.org'},
       })).to.be.null;
     });
     it('should not have `art` parameter when binary type is production', () => {
       expect(getAmpRuntimeTypeParameter({
         AMP_CONFIG: {type: 'production'},
-        location: {href: 'https://www-example-com.cdn.ampproject.org'},
+        location: {origin: 'https://www-example-com.cdn.ampproject.org'},
       })).to.be.null;
     });
     it('should not have `art` parameter when canonical', () => {
       expect(getAmpRuntimeTypeParameter({
         AMP_CONFIG: {type: 'canary'},
-        location: {href: 'https://www.example.com'},
+        location: {origin: 'https://www.example.com'},
       })).to.be.null;
     });
   });

--- a/ads/google/a4a/test/test-utils.js
+++ b/ads/google/a4a/test/test-utils.js
@@ -236,30 +236,30 @@ describe('Google A4A utils', () => {
     it('should specify that this is canary', () => {
       expect(getAmpRuntimeTypeParameter({
         AMP_CONFIG: {type: 'canary'},
-        location: {href: 'https://www-pub-com.cdn.ampproject.org'},
+        location: {href: 'https://www-example-com.cdn.ampproject.org'},
       })).to.equal('2');
     });
     it('should specify that this is control', () => {
       expect(getAmpRuntimeTypeParameter({
         AMP_CONFIG: {type: 'control'},
-        location: {href: 'https://www-pub-com.cdn.ampproject.org'},
+        location: {href: 'https://www-example-com.cdn.ampproject.org'},
       })).to.equal('1');
     });
     it('should not have `art` parameter when AMP_CONFIG is undefined', () => {
       expect(getAmpRuntimeTypeParameter({
-        location: {href: 'https://www-pub-com.cdn.ampproject.org'},
+        location: {href: 'https://www-example-com.cdn.ampproject.org'},
       })).to.be.null;
     });
     it('should not have `art` parameter when binary type is production', () => {
       expect(getAmpRuntimeTypeParameter({
         AMP_CONFIG: {type: 'production'},
-        location: {href: 'https://www-pub-com.cdn.ampproject.org'},
+        location: {href: 'https://www-example-com.cdn.ampproject.org'},
       })).to.be.null;
     });
     it('should not have `art` parameter when canonical', () => {
       expect(getAmpRuntimeTypeParameter({
         AMP_CONFIG: {type: 'canary'},
-        location: {href: 'https://www.pub.com'},
+        location: {href: 'https://www.example.com'},
       })).to.be.null;
     });
   });

--- a/ads/google/a4a/test/test-utils.js
+++ b/ads/google/a4a/test/test-utils.js
@@ -24,6 +24,7 @@ import {
   addCsiSignalsToAmpAnalyticsConfig,
   additionalDimensions,
   extractAmpAnalyticsConfig,
+  getAmpRuntimeTypeParameter,
   getCsiAmpAnalyticsVariables,
   getEnclosingContainerTypes,
   getIdentityToken,
@@ -231,6 +232,38 @@ describe('Google A4A utils', () => {
     });
   });
 
+  describe('#getAmpRuntimeTypeParameter', () => {
+    it('should specify that this is canary', () => {
+      expect(getAmpRuntimeTypeParameter({
+        AMP_CONFIG: {type: 'canary'},
+        location: {href: 'https://www-pub-com.cdn.ampproject.org'},
+      })).to.equal('2');
+    });
+    it('should specify that this is control', () => {
+      expect(getAmpRuntimeTypeParameter({
+        AMP_CONFIG: {type: 'control'},
+        location: {href: 'https://www-pub-com.cdn.ampproject.org'},
+      })).to.equal('1');
+    });
+    it('should not have `art` parameter when AMP_CONFIG is undefined', () => {
+      expect(getAmpRuntimeTypeParameter({
+        location: {href: 'https://www-pub-com.cdn.ampproject.org'},
+      })).to.be.null;
+    });
+    it('should not have `art` parameter when binary type is production', () => {
+      expect(getAmpRuntimeTypeParameter({
+        AMP_CONFIG: {type: 'production'},
+        location: {href: 'https://www-pub-com.cdn.ampproject.org'},
+      })).to.be.null;
+    });
+    it('should not have `art` parameter when canonical', () => {
+      expect(getAmpRuntimeTypeParameter({
+        AMP_CONFIG: {type: 'canary'},
+        location: {href: 'https://www.pub.com'},
+      })).to.be.null;
+    });
+  });
+
   describe('#googleAdUrl', () => {
     let sandbox;
 
@@ -260,86 +293,6 @@ describe('Google A4A utils', () => {
           return googleAdUrl(impl, '', 0, [], []).then(url1 => {
             expect(url1).to.match(/ady=11/);
             expect(url1).to.match(/adx=12/);
-          });
-        });
-      });
-    });
-
-    it('should specify that this is canary', () => {
-      return createIframePromise().then(fixture => {
-        setupForAdTesting(fixture);
-        const {doc} = fixture;
-        doc.win = window;
-        const elem = createElementWithAttributes(doc, 'amp-a4a', {
-          'type': 'adsense',
-          'width': '320',
-          'height': '50',
-        });
-        const impl = new MockA4AImpl(elem);
-        noopMethods(impl, doc, sandbox);
-        impl.win.AMP_CONFIG = {type: 'canary'};
-        return fixture.addElement(elem).then(() => {
-          return googleAdUrl(impl, '', 0, [], []).then(url1 => {
-            expect(url1).to.match(/[&?]art=2/);
-          });
-        });
-      });
-    });
-    it('should specify that this is control', () => {
-      return createIframePromise().then(fixture => {
-        setupForAdTesting(fixture);
-        const {doc} = fixture;
-        doc.win = window;
-        const elem = createElementWithAttributes(doc, 'amp-a4a', {
-          'type': 'adsense',
-          'width': '320',
-          'height': '50',
-        });
-        const impl = new MockA4AImpl(elem);
-        noopMethods(impl, doc, sandbox);
-        impl.win.AMP_CONFIG = {type: 'control'};
-        return fixture.addElement(elem).then(() => {
-          return googleAdUrl(impl, '', 0, [], []).then(url1 => {
-            expect(url1).to.match(/[&?]art=1/);
-          });
-        });
-      });
-    });
-    it('should not have `art` parameter when AMP_CONFIG is undefined', () => {
-      return createIframePromise().then(fixture => {
-        setupForAdTesting(fixture);
-        const {doc} = fixture;
-        doc.win = window;
-        const elem = createElementWithAttributes(doc, 'amp-a4a', {
-          'type': 'adsense',
-          'width': '320',
-          'height': '50',
-        });
-        const impl = new MockA4AImpl(elem);
-        noopMethods(impl, doc, sandbox);
-        return fixture.addElement(elem).then(() => {
-          return googleAdUrl(impl, '', 0, [], []).then(url1 => {
-            expect(url1).to.not.match(/[&?]art=/);
-          });
-        });
-      });
-    });
-    it('should not have `art` parameter when binary type is production', () => {
-      return createIframePromise().then(fixture => {
-        setupForAdTesting(fixture);
-        const {doc} = fixture;
-        doc.win = window;
-        const elem = createElementWithAttributes(doc, 'amp-a4a', {
-          'type': 'adsense',
-          'width': '320',
-          'height': '50',
-        });
-        const impl = new MockA4AImpl(elem);
-        noopMethods(impl, doc, sandbox);
-        impl.win.AMP_CONFIG = {type: 'production'};
-        return fixture.addElement(elem).then(() => {
-          return googleAdUrl(impl, '', 0, [], []).then(url1 => {
-            expect(url1).to.not.match(/[&?]art=/);
           });
         });
       });

--- a/ads/google/a4a/test/test-utils.js
+++ b/ads/google/a4a/test/test-utils.js
@@ -154,8 +154,10 @@ describe('Google A4A utils', () => {
         });
         const a4a = new MockA4AImpl(element);
         url = 'not an array';
-        expect(extractAmpAnalyticsConfig(a4a, headers)).to.not.be.ok;
-        expect(extractAmpAnalyticsConfig(a4a, headers)).to.be.null;
+        allowConsoleError(() =>
+          expect(extractAmpAnalyticsConfig(a4a, headers)).to.not.be.ok);
+        allowConsoleError(() =>
+          expect(extractAmpAnalyticsConfig(a4a, headers)).to.be.null);
         url = [];
         expect(extractAmpAnalyticsConfig(a4a, headers)).to.not.be.ok;
         expect(extractAmpAnalyticsConfig(a4a, headers)).to.be.null;

--- a/ads/google/a4a/utils.js
+++ b/ads/google/a4a/utils.js
@@ -21,6 +21,7 @@ import {dev} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {
   escapeCssSelectorIdent,
+  scopedQuerySelector,
   whenUpgradedToCustomElement,
 } from '../../../src/dom';
 import {getBinaryType} from '../../../src/experiments';
@@ -212,8 +213,8 @@ export function groupAmpAdsByType(win, type, groupFn) {
         }
         const isAmpAdContainerElement =
           Object.keys(ValidAdContainerTypes).includes(r.element.tagName) &&
-          !!r.element.querySelector(
-              escapeCssSelectorIdent(`amp-ad[type=${type}]`));
+          !!scopedQuerySelector(
+              r.element, escapeCssSelectorIdent(`amp-ad[type=${type}]`));
         return isAmpAdContainerElement;
       })
       // Need to wait on any contained element resolution followed by build
@@ -227,7 +228,8 @@ export function groupAmpAdsByType(win, type, groupFn) {
             // be upgraded.
             return whenUpgradedToCustomElement(
                 dev().assertElement(
-                    resource.element.querySelector(
+                    scopedQuerySelector(
+                        resource.element,
                         escapeCssSelectorIdent(`amp-ad[type=${type}]`))));
           })))
       // Group by networkId.

--- a/ads/google/a4a/utils.js
+++ b/ads/google/a4a/utils.js
@@ -93,7 +93,7 @@ export let NameframeExperimentConfig;
 export const TRUNCATION_PARAM = {name: 'trunc', value: '1'};
 
 /** @const {Object} */
-const CDN_REGEXP = /^https:\/\/([a-zA-Z0-9_-]+\.)?cdn\.ampproject\.org/;
+const CDN_PROXY_REGEXP = /^https:\/\/([a-zA-Z0-9_-]+\.)?cdn\.ampproject\.org((\/.*)|($))+/;
 
 /**
  * Returns the value of navigation start using the performance API or 0 if not
@@ -119,11 +119,8 @@ function getNavStart(win) {
  *   pathway.
  */
 export function isGoogleAdsA4AValidEnvironment(win) {
-  const googleCdnProxyRegex =
-        /^https:\/\/([a-zA-Z0-9_-]+\.)?cdn\.ampproject\.org((\/.*)|($))+/;
   return supportsNativeCrypto(win) && (
-    !!googleCdnProxyRegex.test(win.location.origin) ||
-        getMode(win).localDev || getMode(win).test);
+    !!isCdnProxy(win) || getMode(win).localDev || getMode(win).test);
 }
 
 /**
@@ -836,9 +833,7 @@ export function getIdentityTokenRequestUrl(win, nodeOrDoc, domain = undefined) {
  * @return {boolean}
  */
 export function isCdnProxy(win) {
-  const googleCdnProxyRegex =
-    /^https:\/\/([a-zA-Z0-9_-]+\.)?cdn\.ampproject\.org((\/.*)|($))+/;
-  return googleCdnProxyRegex.test(win.location.origin);
+  return CDN_PROXY_REGEXP.test(win.location.origin);
 }
 
 /**
@@ -902,5 +897,5 @@ function getBrowserCapabilitiesBitmap(win) {
  */
 export function getAmpRuntimeTypeParameter(win) {
   const art = getBinaryTypeNumericalCode(getBinaryType(win));
-  return CDN_REGEXP.test(win.location.href) && art != '0' ? art : null;
+  return isCdnProxy(win) && art != '0' ? art : null;
 }

--- a/ads/google/a4a/utils.js
+++ b/ads/google/a4a/utils.js
@@ -29,7 +29,10 @@ import {
 import {makeCorrelator} from '../correlator';
 import {parseJson} from '../../../src/json';
 import {parseUrlDeprecated} from '../../../src/url';
-import {whenUpgradedToCustomElement} from '../../../src/dom';
+import {
+  escapeCssSelectorIdent,
+  whenUpgradedToCustomElement,
+} from '../../../src/dom';
 
 /** @type {string}  */
 const AMP_ANALYTICS_HEADER = 'X-AmpAnalytics';
@@ -209,7 +212,8 @@ export function groupAmpAdsByType(win, type, groupFn) {
         }
         const isAmpAdContainerElement =
           Object.keys(ValidAdContainerTypes).includes(r.element.tagName) &&
-          !!r.element.querySelector(`amp-ad[type=${type}]`);
+          !!r.element.querySelector(
+              escapeCssSelectorIdent(`amp-ad[type=${type}]`));
         return isAmpAdContainerElement;
       })
       // Need to wait on any contained element resolution followed by build
@@ -221,8 +225,10 @@ export function groupAmpAdsByType(win, type, groupFn) {
             }
             // Must be container element so need to wait for child amp-ad to
             // be upgraded.
-            return whenUpgradedToCustomElement(dev().assertElement(
-                resource.element.querySelector(`amp-ad[type=${type}]`)));
+            return whenUpgradedToCustomElement(
+                dev().assertElement(
+                    resource.element.querySelector(
+                        escapeCssSelectorIdent(`amp-ad[type=${type}]`))));
           })))
       // Group by networkId.
       .then(elements => elements.reduce((result, element) => {

--- a/ads/google/a4a/utils.js
+++ b/ads/google/a4a/utils.js
@@ -900,7 +900,7 @@ function getBrowserCapabilitiesBitmap(win) {
  * Returns an enum value representing the AMP binary type, or null if this is a
  * canonical page.
  * @param {!Window} win
- * @return {?string}
+ * @return {?string} The binary type enum.
  * @visibleForTesting
  */
 export function getAmpRuntimeTypeParameter(win) {

--- a/ads/google/a4a/utils.js
+++ b/ads/google/a4a/utils.js
@@ -92,6 +92,9 @@ export let NameframeExperimentConfig;
  */
 export const TRUNCATION_PARAM = {name: 'trunc', value: '1'};
 
+/** @const {Object} */
+const CDN_REGEXP = /^https:\/\/([a-zA-Z0-9_-]+\.)?cdn\.ampproject\.org/;
+
 /**
  * Returns the value of navigation start using the performance API or 0 if not
  * supported by the browser.
@@ -254,7 +257,6 @@ export function googlePageParameters(win, nodeOrDoc, startTime) {
         const viewportSize = viewport.getSize();
         const visibilityState = Services.viewerForDoc(nodeOrDoc)
             .getVisibilityState();
-        const art = getBinaryTypeNumericalCode(getBinaryType(win));
         return {
           'is_amp': AmpAdImplementation.AMP_AD_XHR_TO_IFRAME_OR_AMP,
           'amp_v': '$internalRuntimeVersion$',
@@ -274,7 +276,7 @@ export function googlePageParameters(win, nodeOrDoc, startTime) {
           'u_his': getHistoryLength(win),
           'isw': win != win.top ? viewportSize.width : null,
           'ish': win != win.top ? viewportSize.height : null,
-          'art': art == '0' ? null : art,
+          'art': getAmpRuntimeTypeParameter(win),
           'vis': visibilityStateCodes[visibilityState] || '0',
           'scr_x': viewport.getScrollLeft(),
           'scr_y': viewport.getScrollTop(),
@@ -889,4 +891,16 @@ function getBrowserCapabilitiesBitmap(win) {
     }
   }
   return browserCapabilities;
+}
+
+/**
+ * Returns an enum value representing the AMP binary type, or null if this is a
+ * canonical page.
+ *
+ * @return {?string}
+ * @visibleForTesting
+ */
+export function getAmpRuntimeTypeParameter(win) {
+  const art = getBinaryTypeNumericalCode(getBinaryType(win));
+  return CDN_REGEXP.test(win.location.href) && art != '0' ? art : null;
 }

--- a/ads/google/a4a/utils.js
+++ b/ads/google/a4a/utils.js
@@ -896,7 +896,7 @@ function getBrowserCapabilitiesBitmap(win) {
 /**
  * Returns an enum value representing the AMP binary type, or null if this is a
  * canonical page.
- *
+ * @param {!Window} win
  * @return {?string}
  * @visibleForTesting
  */

--- a/ads/google/a4a/utils.js
+++ b/ads/google/a4a/utils.js
@@ -19,6 +19,10 @@ import {Services} from '../../../src/services';
 import {buildUrl} from './url-builder';
 import {dev} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
+import {
+  escapeCssSelectorIdent,
+  whenUpgradedToCustomElement,
+} from '../../../src/dom';
 import {getBinaryType} from '../../../src/experiments';
 import {getMode} from '../../../src/mode';
 import {getOrCreateAdCid} from '../../../src/ad-cid';
@@ -29,10 +33,6 @@ import {
 import {makeCorrelator} from '../correlator';
 import {parseJson} from '../../../src/json';
 import {parseUrlDeprecated} from '../../../src/url';
-import {
-  escapeCssSelectorIdent,
-  whenUpgradedToCustomElement,
-} from '../../../src/dom';
 
 /** @type {string}  */
 const AMP_ANALYTICS_HEADER = 'X-AmpAnalytics';

--- a/build-system/tasks/clean.js
+++ b/build-system/tasks/clean.js
@@ -21,6 +21,11 @@ const gulp = require('gulp-help')(require('gulp'));
 
 /**
  * Clean up the build artifacts
+<<<<<<< HEAD
+=======
+ *
+ * @param {Function} done callback
+>>>>>>> Carves out canonical pages from canary vs prod experiment.
  */
 function clean() {
   return del([

--- a/build-system/tasks/clean.js
+++ b/build-system/tasks/clean.js
@@ -21,11 +21,6 @@ const gulp = require('gulp-help')(require('gulp'));
 
 /**
  * Clean up the build artifacts
-<<<<<<< HEAD
-=======
- *
- * @param {Function} done callback
->>>>>>> Carves out canonical pages from canary vs prod experiment.
  */
 function clean() {
   return del([


### PR DESCRIPTION
Canonical pages can do weird things like hardcode canary versions of the runtime, thereby biasing experiment data, and thus should be excluded from the experiment altogether.