### PR TITLE
Fix actions in amp-story-consent

### DIFF
--- a/extensions/amp-story/0.1/amp-story-consent.js
+++ b/extensions/amp-story/0.1/amp-story-consent.js
@@ -171,8 +171,11 @@ export class AmpStoryConsent extends AMP.BaseElement {
         this.win.document, getTemplate(storyConsentConfig, consentId, logoSrc));
     createShadowRootWithStyle(this.element, this.storyConsentEl_, CSS);
 
+    // Allow <amp-consent> actions in STAMP (defaults to no actions allowed).
+    this.actions_.addToWhitelist('AMP-CONSENT.accept');
+    this.actions_.addToWhitelist('AMP-CONSENT.reject');
+
     this.initializeListeners_();
-    this.addActionsToWhitelist_();
   }
 
   /** @override */
@@ -229,22 +232,6 @@ export class AmpStoryConsent extends AMP.BaseElement {
 
     this.element.getResources()
         .measureMutateElement(this.storyConsentEl_, measurer, mutator);
-  }
-
-  /**
-   * Allows the consent related actions.
-   * @private
-   */
-  addActionsToWhitelist_() {
-    dev().assert(this.consentConfig_, `${TAG}: Consent config must be parsed ` +
-        'before adding the actions to the whitelist.');
-
-    const consentIds = Object.keys(this.consentConfig_.consents);
-
-    consentIds.forEach(consentId => {
-      this.actions_.addToWhitelist(`${consentId}.accept`);
-      this.actions_.addToWhitelist(`${consentId}.reject`);
-    });
   }
 
   /**

--- a/extensions/amp-story/0.1/amp-story-consent.js
+++ b/extensions/amp-story/0.1/amp-story-consent.js
@@ -36,7 +36,11 @@ const TAG = 'amp-story-consent';
 // TODO(gmajoulet): switch to `htmlFor` static template helper.
 /**
  * Story consent template.
- * @private @const {function(!Object, string, ?string):!./simple-template.ElementDef}
+ * @param {!Object} config
+ * @param {string} consentId
+ * @param {?string} logoSrc
+ * @return {!./simple-template.ElementDef}
+ * @private @const
  */
 const getTemplate = (config, consentId, logoSrc) => ({
   tag: 'div',

--- a/extensions/amp-story/0.1/test/test-amp-story-consent.js
+++ b/extensions/amp-story/0.1/test/test-amp-story-consent.js
@@ -119,15 +119,15 @@ describes.fakeWin('amp-story-consent', {amp: true}, env => {
     });
   });
 
-  it('should whitelist the amp actions using the expected consent ID', () => {
+  it('should whitelist the <amp-consent> actions', () => {
     const addToWhitelistStub =
         sandbox.stub(storyConsent.actions_, 'addToWhitelist');
 
     storyConsent.buildCallback();
 
     expect(addToWhitelistStub).to.have.been.calledTwice;
-    expect(addToWhitelistStub).to.have.been.calledWith('ABC.accept');
-    expect(addToWhitelistStub).to.have.been.calledWith('ABC.reject');
+    expect(addToWhitelistStub).to.have.been.calledWith('AMP-CONSENT.accept');
+    expect(addToWhitelistStub).to.have.been.calledWith('AMP-CONSENT.reject');
   });
 
   it('should broadcast the amp actions', () => {

--- a/extensions/amp-story/1.0/amp-story-consent.js
+++ b/extensions/amp-story/1.0/amp-story-consent.js
@@ -171,8 +171,11 @@ export class AmpStoryConsent extends AMP.BaseElement {
         this.win.document, getTemplate(storyConsentConfig, consentId, logoSrc));
     createShadowRootWithStyle(this.element, this.storyConsentEl_, CSS);
 
+    // Allow <amp-consent> actions in STAMP (defaults to no actions allowed).
+    this.actions_.addToWhitelist('AMP-CONSENT.accept');
+    this.actions_.addToWhitelist('AMP-CONSENT.reject');
+
     this.initializeListeners_();
-    this.addActionsToWhitelist_();
   }
 
   /** @override */
@@ -229,22 +232,6 @@ export class AmpStoryConsent extends AMP.BaseElement {
 
     this.element.getResources()
         .measureMutateElement(this.storyConsentEl_, measurer, mutator);
-  }
-
-  /**
-   * Allows the consent related actions.
-   * @private
-   */
-  addActionsToWhitelist_() {
-    dev().assert(this.consentConfig_, `${TAG}: Consent config must be parsed ` +
-        'before adding the actions to the whitelist.');
-
-    const consentIds = Object.keys(this.consentConfig_.consents);
-
-    consentIds.forEach(consentId => {
-      this.actions_.addToWhitelist(`${consentId}.accept`);
-      this.actions_.addToWhitelist(`${consentId}.reject`);
-    });
   }
 
   /**

--- a/extensions/amp-story/1.0/amp-story-consent.js
+++ b/extensions/amp-story/1.0/amp-story-consent.js
@@ -36,7 +36,11 @@ const TAG = 'amp-story-consent';
 // TODO(gmajoulet): switch to `htmlFor` static template helper.
 /**
  * Story consent template.
- * @private @const {function(!Object, string, ?string):!./simple-template.ElementDef}
+ * @param {!Object} config
+ * @param {string} consentId
+ * @param {?string} logoSrc
+ * @return {!./simple-template.ElementDef}
+ * @private @const
  */
 const getTemplate = (config, consentId, logoSrc) => ({
   tag: 'div',

--- a/extensions/amp-story/1.0/test/test-amp-story-consent.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-consent.js
@@ -119,15 +119,15 @@ describes.fakeWin('amp-story-consent', {amp: true}, env => {
     });
   });
 
-  it('should whitelist the amp actions using the expected consent ID', () => {
+  it('should whitelist the <amp-consent> actions', () => {
     const addToWhitelistStub =
         sandbox.stub(storyConsent.actions_, 'addToWhitelist');
 
     storyConsent.buildCallback();
 
     expect(addToWhitelistStub).to.have.been.calledTwice;
-    expect(addToWhitelistStub).to.have.been.calledWith('ABC.accept');
-    expect(addToWhitelistStub).to.have.been.calledWith('ABC.reject');
+    expect(addToWhitelistStub).to.have.been.calledWith('AMP-CONSENT.accept');
+    expect(addToWhitelistStub).to.have.been.calledWith('AMP-CONSENT.reject');
   });
 
   it('should broadcast the amp actions', () => {


### PR DESCRIPTION
After #15178, action whitelist expects `<tag>.<action>` and not `<id>.<action>`.

Fixes #15429