### PR TITLE
🐛 Increase `bundleDelay` setting of `karma-browserify`

### DIFF
--- a/build-system/tasks/karma.conf.js
+++ b/build-system/tasks/karma.conf.js
@@ -49,7 +49,7 @@ module.exports = {
     transform: [
       ['babelify', {compact: false}],
     ],
-    bundleDelay: 900,
+    bundleDelay: 1200,
   },
 
   reporters: ['super-dots', 'karmaSimpleReporter'],


### PR DESCRIPTION
We're still seeing transient errors with `karma-browserify` while running our unit tests. From [github.com/nikku/karma-browserify](https://github.com/nikku/karma-browserify/blob/dc49a26df0f493f2fdef68bb79a5dd19a6c9ede3/lib/bro.js#L35-L45), it appears that this can be fixed by increasing the `bundleDelay` timeout.

```
/**
 * The time to wait for additional file change nofifications
 * before performing a rebundling operation.
 *
 * This value must be chosen with care. The smaller it is, the
 * faster the rebundling + testing cycle is. At the same time
 * the chance increases karma-browserify performs bundling steps
 * twice because it triggers a rebundle before all file change
 * triggers have been transmitted.
 */
var DEFAULT_BUNDLE_DELAY = 700;
```

This PR increases the value from 900 to 1200 ms.

Speculative fix for #14166 based on the suggestion in https://github.com/nikku/karma-browserify/issues/114#issuecomment-78289776