### PR TITLE
🏗 🐛 Add missing peer dependency `react-with-direction`

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,6 +150,7 @@
     "react-dates": "16.7.0",
     "react-dom": "16.3.2",
     "react-externs": "0.13.6",
+    "react-with-direction": "1.3.0",
     "request": "2.86.0",
     "rimraf": "2.6.2",
     "rocambole": "0.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8939,7 +8939,7 @@ react-portal@^4.1.2:
   dependencies:
     prop-types "^15.5.8"
 
-react-with-direction@^1.1.0:
+react-with-direction@1.3.0, react-with-direction@^1.1.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/react-with-direction/-/react-with-direction-1.3.0.tgz#9885f5941aa986be753db95a41e8f3d8f8de97ff"
   dependencies:


### PR DESCRIPTION
Running `yarn` results in a new warning:
```
warning "react-dates > react-with-styles@3.2.0" has unmet peer dependency "react-with-direction@^1.1.0".
```

The reason `yarn` complains while installing `react-dates` is because one of its dependencies `react-with-styles` lists `react-with-direction` as a required peer dependency in its `package.json`. See https://github.com/airbnb/react-with-styles/blob/master/package.json#L76.

This PR adds the missing peer dependency, which eliminates the warning.

**Note:** From past testing, there's no negative effect on the runtime, and no significant increase in the time taken to do a full run of `yarn`. Eliminating warnings of this sort is good, so that real problems are not masked. See https://yarnpkg.com/lang/en/docs/dependency-types/#toc-peerdependencies for more on this.

Follow up to #14954 