### PR TITLE
🏗🐛 Lint the contents of `validator/`

### DIFF
--- a/build-system/config.js
+++ b/build-system/config.js
@@ -125,8 +125,7 @@ module.exports = {
     '!{node_modules,build,dist,dist.3p,dist.tools,' +
         'third_party}/**/*.*',
     '!examples/**/*.*',
-    // TODO: temporary, remove when validator is up to date
-    '!validator/**/*.*',
+    '!{validator/dist,validator/node_modules,validator/nodejs/node_modules}',
     '!eslint-rules/**/*.*',
     '!karma.conf.js',
     '!**/local-amp-chrome-extension/background.js',

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "eslint-plugin-chai-expect": "1.1.1",
     "eslint-plugin-eslint-plugin": "1.4.0",
     "eslint-plugin-google-camelcase": "0.0.2",
+    "eslint-plugin-jasmine": "2.10.1",
     "eslint-plugin-jsdoc": "3.7.0",
     "eslint-plugin-sort-imports-es6-autofix": "0.3.0",
     "eslint-plugin-sort-requires": "2.1.0",

--- a/validator/.eslintrc
+++ b/validator/.eslintrc
@@ -1,0 +1,51 @@
+{
+  "env": {
+    "node": true,
+    "jasmine": true
+  },
+  "plugins": [
+    "jasmine"
+  ],
+  "extends": [
+    "plugin:jasmine/recommended"
+  ],
+  "globals": {
+    "amp": false,
+    "chrome": false,
+    "goog": false,
+    "json_testutil": false,
+    "parse_css": false,
+    "parse_srcset": false,
+    "parse_url": false,
+    "fs": false
+  },
+  "rules": {
+    "amphtml-internal/no-for-of-statement": 0,
+    "chai-expect/missing-assertion": 1,
+    "google-camelcase/google-camelcase": 0,
+    "jsdoc/check-param-names": 0,
+    "jsdoc/check-tag-names": 0,
+    "jsdoc/check-types": 0,
+    "jsdoc/require-param": 0,
+    "jsdoc/require-param-name": 0,
+    "jsdoc/require-param-type": 0,
+    "jsdoc/require-returns-type": 0,
+    "max-len": [1, 80, 4, {
+      "ignoreTrailingComments": true,
+      "ignoreRegExpLiterals": true,
+      "ignorePattern": "^import.*';|}\\ from.*;|.*require\\(.*;$|@typedef|@param|@return|@private|@const|@type|@implements",
+      "ignoreUrls": true
+    }],
+    "no-cond-assign": 1,
+    "no-div-regex": 1,
+    "no-throw-literal": 1,
+    "no-undef": 1,
+    "no-unused-vars": [1, {
+      "argsIgnorePattern": "^var_|opt_|unused",
+      "varsIgnorePattern": "AmpElement|Def|Interface$"
+    }],
+    "no-useless-concat": 1,
+    "no-var": 1,
+    "prefer-const": 1
+  }
+}

--- a/validator/chromeextension/background.js
+++ b/validator/chromeextension/background.js
@@ -14,27 +14,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the license.
  */
-var globals = {};
-globals.ampCacheBgcolor = "#ffffff";
-globals.ampCacheIconPrefix = "amp-link";
-globals.ampCacheTitle = chrome.i18n.getMessage("pageFromAmpCacheTitle");
-globals.invalidAmpBgcolor = "#8b0000";
-globals.invalidAmpIconPrefix = "invalid";
-globals.invalidAmpTitle = chrome.i18n.getMessage("pageFailsValidationTitle");
-globals.linkToAmpBgColor = "#ffffff";
-globals.linkToAmpIconPrefix = "amp-link";
-globals.linkToAmpTitle = chrome.i18n.getMessage("pageHasAmpAltTitle");
+const globals = {};
+globals.ampCacheBgcolor = '#ffffff';
+globals.ampCacheIconPrefix = 'amp-link';
+globals.ampCacheTitle = chrome.i18n.getMessage('pageFromAmpCacheTitle');
+globals.invalidAmpBgcolor = '#8b0000';
+globals.invalidAmpIconPrefix = 'invalid';
+globals.invalidAmpTitle = chrome.i18n.getMessage('pageFailsValidationTitle');
+globals.linkToAmpBgColor = '#ffffff';
+globals.linkToAmpIconPrefix = 'amp-link';
+globals.linkToAmpTitle = chrome.i18n.getMessage('pageHasAmpAltTitle');
 globals.tabToUrl = {};
 globals.userAgentHeader = 'X-AMP-Validator-UA';
-globals.validAmpBgcolor = "#ffd700";
-globals.validAmpIconPrefix = "valid";
-globals.validAmpTitle = chrome.i18n.getMessage("pagePassesValidationTitle");
-globals.validatorNotPresentBadge = chrome.i18n.getMessage("validatorNotPresentBadge");
-globals.validatorNotPresentBgColor = "#b71c1c";
-globals.validatorNotPresentIconPrefix = "validator-not-present";
-globals.validatorNotPresentPopup = "popup-validator-not-present.build.html";
-globals.validatorNotPresentTitle = chrome.i18n.getMessage("validatorNotPresentTitle");
-globals.validatorPopup = "popup-validator.build.html";
+globals.validAmpBgcolor = '#ffd700';
+globals.validAmpIconPrefix = 'valid';
+globals.validAmpTitle = chrome.i18n.getMessage('pagePassesValidationTitle');
+globals.validatorNotPresentBadge = chrome.i18n.getMessage('validatorNotPresentBadge');
+globals.validatorNotPresentBgColor = '#b71c1c';
+globals.validatorNotPresentIconPrefix = 'validator-not-present';
+globals.validatorNotPresentPopup = 'popup-validator-not-present.build.html';
+globals.validatorNotPresentTitle = chrome.i18n.getMessage('validatorNotPresentTitle');
+globals.validatorPopup = 'popup-validator.build.html';
 
 /**
  * Format a hex value (HTML colors such as #ffffff) as an RGBA.
@@ -44,9 +44,9 @@ globals.validatorPopup = "popup-validator.build.html";
  */
 function hex2rgba(hex) {
   // Remove the '#' char if necessary.
-  if (hex.charAt(0) === "#") { hex = hex.slice(1); }
+  if (hex.charAt(0) === '#') { hex = hex.slice(1); }
   hex = hex.toUpperCase();
-  var hexAlpha = "0123456789ABCDEF", value = new Array(4), k = 0, int1, int2, i;
+  let hexAlpha = '0123456789ABCDEF', value = new Array(4), k = 0, int1, int2, i;
   for (i = 0; i < 6; i += 2) {
     int1 = hexAlpha.indexOf(hex.charAt(i));
     int2 = hexAlpha.indexOf(hex.charAt(i + 1));
@@ -65,11 +65,11 @@ function hex2rgba(hex) {
  * @return {Object}
  */
 function getErrorSeverityCounts(errors) {
-  var numErrors = 0;
-  var numWarnings = 0;
-  for (var error in errors) {
-    if (errors[error].severity == 'ERROR') numErrors += 1;
-    if (errors[error].severity == 'WARNING') numWarnings += 1;
+  let numErrors = 0;
+  let numWarnings = 0;
+  for (const error in errors) {
+    if (errors[error].severity == 'ERROR') {numErrors += 1;}
+    if (errors[error].severity == 'WARNING') {numWarnings += 1;}
   }
   return {'ERROR': numErrors, 'WARNING': numWarnings};
 }
@@ -123,7 +123,7 @@ function handleAmpCache(tabId, ampHref) {
  * @param {!Object<!ValidationResult>} validationResult
  */
 function handleAmpFail(tabId, validationResult) {
-  var numErrors = getNumberOfErrors(validationResult.errors);
+  const numErrors = getNumberOfErrors(validationResult.errors);
   updateTabStatus(
       tabId, globals.invalidAmpIconPrefix, globals.invalidAmpTitle,
       numErrors.toString(), globals.invalidAmpBgcolor);
@@ -158,13 +158,13 @@ function handleAmpLink(tabId, ampHref) {
  * @param {!Object<!ValidationResult>} validationResult
  */
 function handleAmpPass(tabId, validationResult) {
-  var badgeTitle = '';
-  var numWarnings = getNumberOfWarnings(validationResult.errors);
-  if (numWarnings > 0) badgeTitle = numWarnings.toString();
+  let badgeTitle = '';
+  const numWarnings = getNumberOfWarnings(validationResult.errors);
+  if (numWarnings > 0) {badgeTitle = numWarnings.toString();}
   updateTabStatus(
       tabId, globals.validAmpIconPrefix, globals.validAmpTitle,
       badgeTitle, globals.validAmpBgcolor);
-  if (numWarnings > 0) updateTabPopup(tabId);
+  if (numWarnings > 0) {updateTabPopup(tabId);}
 }
 
 function handleValidatorNotPresent(tabId) {
@@ -174,7 +174,7 @@ function handleValidatorNotPresent(tabId) {
   chrome.tabs.get(tabId, function(tab) {
     if (!chrome.runtime.lastError) {
       chrome.browserAction.setPopup(
-          {tabId: tabId, popup: globals.validatorNotPresentPopup});
+          {tabId, popup: globals.validatorNotPresentPopup});
     }
   });
 }
@@ -197,17 +197,17 @@ function isForbiddenUrl(url) {
  */
 function updateTab(tab) {
   if (!isForbiddenUrl(tab.url))
-    chrome.tabs.sendMessage(
-        tab.id, {'getAmpDetails': true}, function(response) {
-          if (response && response.fromAmpCache && response.ampHref) {
-            handleAmpCache(tab.id, response.ampHref);
-          } else if (response && response.isAmp) {
-            validateUrlFromTab(tab, response.userAgent);
-          } else if (response && !response.isAmp && response.ampHref) {
-            handleAmpLink(tab.id, response.ampHref);
-          }
+  {chrome.tabs.sendMessage(
+      tab.id, {'getAmpDetails': true}, function(response) {
+        if (response && response.fromAmpCache && response.ampHref) {
+          handleAmpCache(tab.id, response.ampHref);
+        } else if (response && response.isAmp) {
+          validateUrlFromTab(tab, response.userAgent);
+        } else if (response && !response.isAmp && response.ampHref) {
+          handleAmpLink(tab.id, response.ampHref);
         }
-    );
+      }
+  );}
 }
 
 /**
@@ -220,7 +220,7 @@ function updateTabPopup(tabId) {
   chrome.tabs.get(tabId, function(tab) {
     if (!chrome.runtime.lastError) {
       chrome.browserAction.setPopup(
-          {tabId: tabId, popup: globals.validatorPopup});
+          {tabId, popup: globals.validatorPopup});
     }
   });
 }
@@ -238,16 +238,16 @@ function updateTabStatus(tabId, iconPrefix, title, text, color) {
   // Verify tab still exists
   chrome.tabs.get(tabId, function(tab) {
     if (!chrome.runtime.lastError) {
-      chrome.browserAction.setIcon({path: {"19": iconPrefix + "-128.png",
-                                           "38": iconPrefix + "-38.png"},
-                                    tabId: tabId});
+      chrome.browserAction.setIcon({path: {'19': iconPrefix + '-128.png',
+        '38': iconPrefix + '-38.png'},
+      tabId});
       if (title !== undefined)
-        chrome.browserAction.setTitle({title: title, tabId: tabId});
+      {chrome.browserAction.setTitle({title, tabId});}
       if (text !== undefined)
-        chrome.browserAction.setBadgeText({text: text, tabId: tabId});
+      {chrome.browserAction.setBadgeText({text, tabId});}
       if (color !== undefined)
-        chrome.browserAction.setBadgeBackgroundColor(
-            {color: hex2rgba(color), tabId: tabId});
+      {chrome.browserAction.setBadgeBackgroundColor(
+          {color: hex2rgba(color), tabId});}
     }
   });
 }
@@ -265,8 +265,8 @@ function validateUrlFromTab(tab, userAgent) {
     handleValidatorNotPresent(tab.id);
     return;
   }
-  var xhr = new XMLHttpRequest();
-  var url = tab.url.split('#')[0];
+  const xhr = new XMLHttpRequest();
+  const url = tab.url.split('#')[0];
   xhr.open('GET', url, true);
 
   // We can't set the User-Agent header directly, but we can set this header
@@ -276,9 +276,9 @@ function validateUrlFromTab(tab, userAgent) {
   // traffic, so this approach will interfere as little as possible with the
   // 99.9% of requests which aren't for AMP validation.
   chrome.webRequest.onBeforeSendHeaders.addListener(
-    updateSendHeadersUserAgent,
-    {urls: [url], types: ["xmlhttprequest"], tabId: -1},
-    ["requestHeaders", "blocking"]
+      updateSendHeadersUserAgent,
+      {urls: [url], types: ['xmlhttprequest'], tabId: -1},
+      ['requestHeaders', 'blocking']
   );
   // Add the temporary header to the request
   xhr.setRequestHeader(globals.userAgentHeader, userAgent);
@@ -313,7 +313,7 @@ function validateUrlFromTab(tab, userAgent) {
  */
 function updateSendHeadersUserAgent(details) {
   let newUserAgent,
-    headers = details.requestHeaders;
+      headers = details.requestHeaders;
   // Using var instead of let keeps the index in scope for later
   for (var i = 0; i < headers.length; i++) {
     if (headers[i].name === globals.userAgentHeader) {
@@ -371,4 +371,4 @@ chrome.tabs.onReplaced.addListener(function(addedTabId, removedTabId) {
 /**
  * Reload every hour to retrieve the most recent AMP Validator.
  */
-window.setTimeout(() => { location.reload(); } , 60*60*1000);
+window.setTimeout(() => { location.reload(); } , 60 * 60 * 1000);

--- a/validator/chromeextension/content_script.js
+++ b/validator/chromeextension/content_script.js
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the license.
  */
-var globals = {};
+const globals = {};
 globals.amphtmlRegex = new RegExp('(^\s*)amphtml(\s*$)');
 globals.ampCaches = [
   {
@@ -32,7 +32,7 @@ globals.ampCaches = [
     'isAmpCache': function() {
       return window.location.hostname.endsWith('cdn.ampproject.org');
     },
-  }
+  },
 ];
 
 /**
@@ -42,8 +42,8 @@ globals.ampCaches = [
  * @private
  */
 function getAmpCacheHref() {
-  for (var index in globals.ampCaches) {
-    var ampCache = globals.ampCaches[index];
+  for (const index in globals.ampCaches) {
+    const ampCache = globals.ampCaches[index];
     if (ampCache.isAmpCache()) {
       return ampCache.getAmpHref();
     }
@@ -59,17 +59,17 @@ function getAmpCacheHref() {
  * @private
  */
 function getAmpHtmlLinkHref() {
-  var ampHtmlLinkHref = '';
-  var headLinks = document.head.getElementsByTagName('link');
+  let ampHtmlLinkHref = '';
+  const headLinks = document.head.getElementsByTagName('link');
   if (headLinks.length > 0) {
-    for (var index in headLinks) {
-      var link = headLinks[index];
+    for (const index in headLinks) {
+      const link = headLinks[index];
       if (link instanceof HTMLLinkElement &&
           link.hasAttribute('rel') &&
           globals.amphtmlRegex.test(link.getAttribute('rel')) &&
           link.hasAttribute('href')) {
-            ampHtmlLinkHref = link.getAttribute('href');
-            break;
+        ampHtmlLinkHref = link.getAttribute('href');
+        break;
       }
     }
   }
@@ -83,8 +83,8 @@ function getAmpHtmlLinkHref() {
  * @private
  */
 function isAmpCache() {
-  for (var index in globals.ampCaches) {
-    var ampCache = globals.ampCaches[index];
+  for (const index in globals.ampCaches) {
+    const ampCache = globals.ampCaches[index];
     if (ampCache.isAmpCache()) {
       return true;
     }
@@ -120,9 +120,9 @@ chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
   if (request.getAmpDetails) {
     const isAmp = isAmpDocument();
     const fromAmpCache = isAmpCache();
-    var ampHref = '';
-    if (!isAmp) ampHref = getAmpHtmlLinkHref();
-    if (fromAmpCache) ampHref = getAmpCacheHref();
+    let ampHref = '';
+    if (!isAmp) {ampHref = getAmpHtmlLinkHref();}
+    if (fromAmpCache) {ampHref = getAmpCacheHref();}
     sendResponse({
       'isAmp': isAmp, 'fromAmpCache': fromAmpCache, 'ampHref': ampHref,
       'userAgent': navigator.userAgent,

--- a/validator/engine/amp4ads-parse-css.js
+++ b/validator/engine/amp4ads-parse-css.js
@@ -89,7 +89,7 @@ class Amp4AdsVisitor extends parse_css.RuleVisitor {
       }
       this.errors.push(createParseErrorTokenAt(
           declaration, amp.validator.ValidationError.Code
-                           .CSS_SYNTAX_DISALLOWED_PROPERTY_VALUE,
+              .CSS_SYNTAX_DISALLOWED_PROPERTY_VALUE,
           ['style', 'position', ident]));
     }
   }
@@ -112,10 +112,10 @@ class Amp4AdsVisitor extends parse_css.RuleVisitor {
           }
           this.errors.push(createParseErrorTokenAt(
               decl, amp.validator.ValidationError.Code
-                        .CSS_SYNTAX_DISALLOWED_PROPERTY_VALUE_WITH_HINT,
+                  .CSS_SYNTAX_DISALLOWED_PROPERTY_VALUE_WITH_HINT,
               [
                 'style', 'transition', transitionedProperty,
-                '[\'opacity\', \'transform\']'
+                '[\'opacity\', \'transform\']',
               ]));
         }
       }
@@ -130,10 +130,10 @@ class Amp4AdsVisitor extends parse_css.RuleVisitor {
         }
         this.errors.push(createParseErrorTokenAt(
             decl, amp.validator.ValidationError.Code
-                      .CSS_SYNTAX_PROPERTY_DISALLOWED_WITHIN_AT_RULE,
+                .CSS_SYNTAX_PROPERTY_DISALLOWED_WITHIN_AT_RULE,
             [
               'style', decl.name, this.inKeyframes.name,
-              '[\'animation-timing-function\', \'opacity\', \'transform\']'
+              '[\'animation-timing-function\', \'opacity\', \'transform\']',
             ]));
       }
     }

--- a/validator/engine/amp4ads-parse-css_test.js
+++ b/validator/engine/amp4ads-parse-css_test.js
@@ -105,15 +105,15 @@ describe('validateAmp4AdsCss', () => {
             'col': 7,
             'tokenType': 'ERROR',
             'code': 'CSS_SYNTAX_DISALLOWED_PROPERTY_VALUE',
-            'params': ['style', 'position', 'fixed']
+            'params': ['style', 'position', 'fixed'],
           },
           {
             'line': 1,
             'col': 24,
             'tokenType': 'ERROR',
             'code': 'CSS_SYNTAX_DISALLOWED_PROPERTY_VALUE',
-            'params': ['style', 'position', 'sticky']
-          }
+            'params': ['style', 'position', 'sticky'],
+          },
         ],
         errors);
   });
@@ -137,23 +137,23 @@ describe('validateAmp4AdsCss', () => {
   });
 
   it('validates non-animation properties in animation selectors (vendor prefixed)',
-     () => {
-       // The non-animation property (in this case color) is allowed in an
-       // animation selector.
-       const css = '.amp-animate .box { ' +
+      () => {
+        // The non-animation property (in this case color) is allowed in an
+        // animation selector.
+        const css = '.amp-animate .box { ' +
            '    color: red; ' +
            '    -o-transform: rotate(180deg);' +
            '    -ms-transition: -webkit-transform 2s;' +
            '}';
-       const errors = [];
-       const tokens = parse_css.tokenize(css, 1, 0, errors);
-       const sheet = parse_css.parseAStylesheet(
-           tokens, amp4AdsCssParsingSpec, parse_css.BlockType.PARSE_AS_IGNORE,
-           errors);
-       assertJSONEquals([], errors);
-       parse_css.validateAmp4AdsCss(sheet, errors);
-       assertJSONEquals([], errors);
-     });
+        const errors = [];
+        const tokens = parse_css.tokenize(css, 1, 0, errors);
+        const sheet = parse_css.parseAStylesheet(
+            tokens, amp4AdsCssParsingSpec, parse_css.BlockType.PARSE_AS_IGNORE,
+            errors);
+        assertJSONEquals([], errors);
+        parse_css.validateAmp4AdsCss(sheet, errors);
+        assertJSONEquals([], errors);
+      });
 
   it('No longer an error when .amp-animate is missing', () => {
     const css = '.box { ' +
@@ -171,29 +171,29 @@ describe('validateAmp4AdsCss', () => {
   });
 
   it('allows only opacity and transform to be transitioned', () => {
-       const css = '.amp-animate .box { ' +
+    const css = '.amp-animate .box { ' +
            '    transition: background-color 2s; ' +
            '}';
-       const errors = [];
-       const tokens = parse_css.tokenize(css, 1, 0, errors);
-       const sheet = parse_css.parseAStylesheet(
-           tokens, amp4AdsCssParsingSpec, parse_css.BlockType.PARSE_AS_IGNORE,
-           errors);
-       assertJSONEquals([], errors);
-       parse_css.validateAmp4AdsCss(sheet, errors);
-       assertJSONEquals(
-           [{
-             'line': 1,
-             'col': 24,
-             'tokenType': 'ERROR',
-             'code': 'CSS_SYNTAX_DISALLOWED_PROPERTY_VALUE_WITH_HINT',
-             'params': [
-               'style', 'transition', 'background-color',
-               '[\'opacity\', \'transform\']'
-             ]
-           }],
-           errors);
-     });
+    const errors = [];
+    const tokens = parse_css.tokenize(css, 1, 0, errors);
+    const sheet = parse_css.parseAStylesheet(
+        tokens, amp4AdsCssParsingSpec, parse_css.BlockType.PARSE_AS_IGNORE,
+        errors);
+    assertJSONEquals([], errors);
+    parse_css.validateAmp4AdsCss(sheet, errors);
+    assertJSONEquals(
+        [{
+          'line': 1,
+          'col': 24,
+          'tokenType': 'ERROR',
+          'code': 'CSS_SYNTAX_DISALLOWED_PROPERTY_VALUE_WITH_HINT',
+          'params': [
+            'style', 'transition', 'background-color',
+            '[\'opacity\', \'transform\']',
+          ],
+        }],
+        errors);
+  });
 
   it('allows keyframes as a mechanism for transitions', () => {
     const css = '@keyframes turn { ' +
@@ -211,154 +211,154 @@ describe('validateAmp4AdsCss', () => {
   });
 
   it('allows keyframes as a mechanism for transitions (vendor prefixed)',
-     () => {
-       const css = '@-moz-keyframes turn { ' +
+      () => {
+        const css = '@-moz-keyframes turn { ' +
            '  from { -webkit-transform: rotate(180deg); } ' +
            '  to { -o-transform: rotate(90deg); } ' +
            '}';
-       const errors = [];
-       const tokens = parse_css.tokenize(css, 1, 0, errors);
-       const sheet = parse_css.parseAStylesheet(
-           tokens, amp4AdsCssParsingSpec, parse_css.BlockType.PARSE_AS_IGNORE,
-           errors);
-       assertJSONEquals([], errors);
-       parse_css.validateAmp4AdsCss(sheet, errors);
-       assertJSONEquals([], errors);
-     });
+        const errors = [];
+        const tokens = parse_css.tokenize(css, 1, 0, errors);
+        const sheet = parse_css.parseAStylesheet(
+            tokens, amp4AdsCssParsingSpec, parse_css.BlockType.PARSE_AS_IGNORE,
+            errors);
+        assertJSONEquals([], errors);
+        parse_css.validateAmp4AdsCss(sheet, errors);
+        assertJSONEquals([], errors);
+      });
 
   it('allows animation-timing-function within keyframes',
-     () => {
-       const css = '@-moz-keyframes turn { ' +
+      () => {
+        const css = '@-moz-keyframes turn { ' +
            '  from { transform: rotate(180deg); ' +
            '         animation-timing-function: linear; } ' +
            '  to { transform: rotate(90deg); } ' +
            '}';
-       const errors = [];
-       const tokens = parse_css.tokenize(css, 1, 0, errors);
-       const sheet = parse_css.parseAStylesheet(
-           tokens, amp4AdsCssParsingSpec, parse_css.BlockType.PARSE_AS_IGNORE,
-           errors);
-       assertJSONEquals([], errors);
-       parse_css.validateAmp4AdsCss(sheet, errors);
-       assertJSONEquals([], errors);
-     });
+        const errors = [];
+        const tokens = parse_css.tokenize(css, 1, 0, errors);
+        const sheet = parse_css.parseAStylesheet(
+            tokens, amp4AdsCssParsingSpec, parse_css.BlockType.PARSE_AS_IGNORE,
+            errors);
+        assertJSONEquals([], errors);
+        parse_css.validateAmp4AdsCss(sheet, errors);
+        assertJSONEquals([], errors);
+      });
 
   it('allows only animation-timing-function, opacity, ' +
      'transform in keyframe transitions',
-     () => {
-       const css = '@keyframes slidein { ' +
+  () => {
+    const css = '@keyframes slidein { ' +
            '  from { margin-left:100%; width:300%; } ' +
            '  to { margin-left:0%; width:100%; } ' +
            '}';
-       const errors = [];
-       const tokens = parse_css.tokenize(css, 1, 0, errors);
-       const sheet = parse_css.parseAStylesheet(
-           tokens, amp4AdsCssParsingSpec, parse_css.BlockType.PARSE_AS_IGNORE,
-           errors);
-       assertJSONEquals([], errors);
-       parse_css.validateAmp4AdsCss(sheet, errors);
-       assertJSONEquals(
-           [
-             {
-               'line': 1,
-               'col': 30,
-               'tokenType': 'ERROR',
-               'code': 'CSS_SYNTAX_PROPERTY_DISALLOWED_WITHIN_AT_RULE',
-               'params': [
-                 'style', 'margin-left', 'keyframes',
-                 '[\'animation-timing-function\', \'opacity\', \'transform\']'
-               ]
-             },
-             {
-               'line': 1,
-               'col': 48,
-               'tokenType': 'ERROR',
-               'code': 'CSS_SYNTAX_PROPERTY_DISALLOWED_WITHIN_AT_RULE',
-               'params': [
-                 'style', 'width', 'keyframes',
-                 '[\'animation-timing-function\', \'opacity\', \'transform\']'
-               ]
-             },
-             {
-               'line': 1,
-               'col': 69,
-               'tokenType': 'ERROR',
-               'code': 'CSS_SYNTAX_PROPERTY_DISALLOWED_WITHIN_AT_RULE',
-               'params': [
-                 'style', 'margin-left', 'keyframes',
-                 '[\'animation-timing-function\', \'opacity\', \'transform\']'
-               ]
-             },
-             {
-               'line': 1,
-               'col': 85,
-               'tokenType': 'ERROR',
-               'code': 'CSS_SYNTAX_PROPERTY_DISALLOWED_WITHIN_AT_RULE',
-               'params': [
-                 'style', 'width', 'keyframes',
-                 '[\'animation-timing-function\', \'opacity\', \'transform\']'
-               ]
-             }
-           ],
-           errors);
-     });
+    const errors = [];
+    const tokens = parse_css.tokenize(css, 1, 0, errors);
+    const sheet = parse_css.parseAStylesheet(
+        tokens, amp4AdsCssParsingSpec, parse_css.BlockType.PARSE_AS_IGNORE,
+        errors);
+    assertJSONEquals([], errors);
+    parse_css.validateAmp4AdsCss(sheet, errors);
+    assertJSONEquals(
+        [
+          {
+            'line': 1,
+            'col': 30,
+            'tokenType': 'ERROR',
+            'code': 'CSS_SYNTAX_PROPERTY_DISALLOWED_WITHIN_AT_RULE',
+            'params': [
+              'style', 'margin-left', 'keyframes',
+              '[\'animation-timing-function\', \'opacity\', \'transform\']',
+            ],
+          },
+          {
+            'line': 1,
+            'col': 48,
+            'tokenType': 'ERROR',
+            'code': 'CSS_SYNTAX_PROPERTY_DISALLOWED_WITHIN_AT_RULE',
+            'params': [
+              'style', 'width', 'keyframes',
+              '[\'animation-timing-function\', \'opacity\', \'transform\']',
+            ],
+          },
+          {
+            'line': 1,
+            'col': 69,
+            'tokenType': 'ERROR',
+            'code': 'CSS_SYNTAX_PROPERTY_DISALLOWED_WITHIN_AT_RULE',
+            'params': [
+              'style', 'margin-left', 'keyframes',
+              '[\'animation-timing-function\', \'opacity\', \'transform\']',
+            ],
+          },
+          {
+            'line': 1,
+            'col': 85,
+            'tokenType': 'ERROR',
+            'code': 'CSS_SYNTAX_PROPERTY_DISALLOWED_WITHIN_AT_RULE',
+            'params': [
+              'style', 'width', 'keyframes',
+              '[\'animation-timing-function\', \'opacity\', \'transform\']',
+            ],
+          },
+        ],
+        errors);
+  });
 
   it('allows only opacity, transform in keyframe transitions (vendor prefixed)',
-     () => {
-       const css = '@-moz-keyframes slidein { ' +
+      () => {
+        const css = '@-moz-keyframes slidein { ' +
            '  from { margin-left:100%; width:300%; } ' +
            '  to { margin-left:0%; width:100%; } ' +
            '}';
-       const errors = [];
-       const tokens = parse_css.tokenize(css, 1, 0, errors);
-       const sheet = parse_css.parseAStylesheet(
-           tokens, amp4AdsCssParsingSpec, parse_css.BlockType.PARSE_AS_IGNORE,
-           errors);
-       assertJSONEquals([], errors);
-       parse_css.validateAmp4AdsCss(sheet, errors);
-       assertJSONEquals(
-           [
-             {
-               'line': 1,
-               'col': 35,
-               'tokenType': 'ERROR',
-               'code': 'CSS_SYNTAX_PROPERTY_DISALLOWED_WITHIN_AT_RULE',
-               'params': [
-                 'style', 'margin-left', '-moz-keyframes',
-                 '[\'animation-timing-function\', \'opacity\', \'transform\']'
-               ]
-             },
-             {
-               'line': 1,
-               'col': 53,
-               'tokenType': 'ERROR',
-               'code': 'CSS_SYNTAX_PROPERTY_DISALLOWED_WITHIN_AT_RULE',
-               'params': [
-                 'style', 'width', '-moz-keyframes',
-                 '[\'animation-timing-function\', \'opacity\', \'transform\']'
-               ]
-             },
-             {
-               'line': 1,
-               'col': 74,
-               'tokenType': 'ERROR',
-               'code': 'CSS_SYNTAX_PROPERTY_DISALLOWED_WITHIN_AT_RULE',
-               'params': [
-                 'style', 'margin-left', '-moz-keyframes',
-                 '[\'animation-timing-function\', \'opacity\', \'transform\']'
-               ]
-             },
-             {
-               'line': 1,
-               'col': 90,
-               'tokenType': 'ERROR',
-               'code': 'CSS_SYNTAX_PROPERTY_DISALLOWED_WITHIN_AT_RULE',
-               'params': [
-                 'style', 'width', '-moz-keyframes',
-                 '[\'animation-timing-function\', \'opacity\', \'transform\']'
-               ]
-             }
-           ],
-           errors);
-     });
+        const errors = [];
+        const tokens = parse_css.tokenize(css, 1, 0, errors);
+        const sheet = parse_css.parseAStylesheet(
+            tokens, amp4AdsCssParsingSpec, parse_css.BlockType.PARSE_AS_IGNORE,
+            errors);
+        assertJSONEquals([], errors);
+        parse_css.validateAmp4AdsCss(sheet, errors);
+        assertJSONEquals(
+            [
+              {
+                'line': 1,
+                'col': 35,
+                'tokenType': 'ERROR',
+                'code': 'CSS_SYNTAX_PROPERTY_DISALLOWED_WITHIN_AT_RULE',
+                'params': [
+                  'style', 'margin-left', '-moz-keyframes',
+                  '[\'animation-timing-function\', \'opacity\', \'transform\']',
+                ],
+              },
+              {
+                'line': 1,
+                'col': 53,
+                'tokenType': 'ERROR',
+                'code': 'CSS_SYNTAX_PROPERTY_DISALLOWED_WITHIN_AT_RULE',
+                'params': [
+                  'style', 'width', '-moz-keyframes',
+                  '[\'animation-timing-function\', \'opacity\', \'transform\']',
+                ],
+              },
+              {
+                'line': 1,
+                'col': 74,
+                'tokenType': 'ERROR',
+                'code': 'CSS_SYNTAX_PROPERTY_DISALLOWED_WITHIN_AT_RULE',
+                'params': [
+                  'style', 'margin-left', '-moz-keyframes',
+                  '[\'animation-timing-function\', \'opacity\', \'transform\']',
+                ],
+              },
+              {
+                'line': 1,
+                'col': 90,
+                'tokenType': 'ERROR',
+                'code': 'CSS_SYNTAX_PROPERTY_DISALLOWED_WITHIN_AT_RULE',
+                'params': [
+                  'style', 'width', '-moz-keyframes',
+                  '[\'animation-timing-function\', \'opacity\', \'transform\']',
+                ],
+              },
+            ],
+            errors);
+      });
 });

--- a/validator/engine/css-selectors.js
+++ b/validator/engine/css-selectors.js
@@ -47,7 +47,7 @@ goog.require('parse_css.extractAFunction');
  * class inherits from, has line, col, and tokenType fields.
  */
 parse_css.Selector = class extends parse_css.Token {
-  /** @param {!function(!parse_css.Selector)} lambda */
+  /** @param {function(!parse_css.Selector)} lambda */
   forEachChild(lambda) {}
 
   /** @param {!parse_css.SelectorVisitor} visitor */
@@ -170,7 +170,7 @@ if (!amp.validator.LIGHT) {
  */
 function isDelim(token, delimChar) {
   return token.tokenType === parse_css.TokenType.DELIM &&
-      /** @type {!parse_css.DelimToken} */ (token).value === delimChar;
+  /** @type {!parse_css.DelimToken} */ (token).value === delimChar;
 }
 
 /**
@@ -189,12 +189,12 @@ parse_css.parseATypeSelector = function(tokenStream) {
     namespacePrefix = '';
     tokenStream.consume();
   } else if (
-      isDelim(tokenStream.current(), '*') && isDelim(tokenStream.next(), '|')) {
+    isDelim(tokenStream.current(), '*') && isDelim(tokenStream.next(), '|')) {
     namespacePrefix = '*';
     tokenStream.consume();
     tokenStream.consume();
   } else if (
-      tokenStream.current().tokenType === parse_css.TokenType.IDENT &&
+    tokenStream.current().tokenType === parse_css.TokenType.IDENT &&
       isDelim(tokenStream.next(), '|')) {
     const ident = /** @type {!parse_css.IdentToken} */ (tokenStream.current());
     namespacePrefix = ident.value;
@@ -334,7 +334,7 @@ parse_css.parseAnAttrSelector = function(tokenStream) {
       tokenStream.current().tokenType === parse_css.TokenType.OPEN_SQUARE,
       'Precondition violated: must be an OpenSquareToken');
   const start = tokenStream.current();
-  tokenStream.consume();  // Consumes '['.
+  tokenStream.consume(); // Consumes '['.
   if (tokenStream.current().tokenType === parse_css.TokenType.WHITESPACE) {
     tokenStream.consume();
   }
@@ -345,12 +345,12 @@ parse_css.parseAnAttrSelector = function(tokenStream) {
     namespacePrefix = '';
     tokenStream.consume();
   } else if (
-      isDelim(tokenStream.current(), '*') && isDelim(tokenStream.next(), '|')) {
+    isDelim(tokenStream.current(), '*') && isDelim(tokenStream.next(), '|')) {
     namespacePrefix = '*';
     tokenStream.consume();
     tokenStream.consume();
   } else if (
-      tokenStream.current().tokenType === parse_css.TokenType.IDENT &&
+    tokenStream.current().tokenType === parse_css.TokenType.IDENT &&
       isDelim(tokenStream.next(), '|')) {
     const ident = /** @type {!parse_css.IdentToken} */ (tokenStream.current());
     namespacePrefix = ident.value;
@@ -405,7 +405,7 @@ parse_css.parseAnAttrSelector = function(tokenStream) {
   }
   /** @type {string} */
   let value = '';
-  if (matchOperator !== '') {  // If we saw an operator, parse the value.
+  if (matchOperator !== '') { // If we saw an operator, parse the value.
     const current = tokenStream.current().tokenType;
     if (current === parse_css.TokenType.IDENT) {
       const ident =
@@ -514,7 +514,7 @@ parse_css.parseAPseudoSelector = function(tokenStream) {
     return firstColon.copyPosTo(
         new parse_css.PseudoSelector(isClass, name, []));
   } else if (
-      tokenStream.current().tokenType === parse_css.TokenType.FUNCTION_TOKEN) {
+    tokenStream.current().tokenType === parse_css.TokenType.FUNCTION_TOKEN) {
     const funcToken =
         /** @type {!parse_css.FunctionToken} */ (tokenStream.current());
     const func = parse_css.extractAFunction(tokenStream);
@@ -655,11 +655,11 @@ parse_css.parseASimpleSelectorSequence = function(tokenStream) {
     if (tokenStream.current().tokenType === parse_css.TokenType.HASH) {
       otherSelectors.push(parse_css.parseAnIdSelector(tokenStream));
     } else if (
-        isDelim(tokenStream.current(), '.') &&
+      isDelim(tokenStream.current(), '.') &&
         tokenStream.next().tokenType === parse_css.TokenType.IDENT) {
       otherSelectors.push(parse_css.parseAClassSelector(tokenStream));
     } else if (
-        tokenStream.current().tokenType === parse_css.TokenType.OPEN_SQUARE) {
+      tokenStream.current().tokenType === parse_css.TokenType.OPEN_SQUARE) {
       const maybeAttrSelector = parse_css.parseAnAttrSelector(tokenStream);
       if (maybeAttrSelector.tokenType === parse_css.TokenType.ERROR) {
         return /** @type {!parse_css.ErrorToken} */ (maybeAttrSelector);
@@ -701,7 +701,7 @@ parse_css.CombinatorType = {
   'DESCENDANT': 'DESCENDANT',
   'CHILD': 'CHILD',
   'ADJACENT_SIBLING': 'ADJACENT_SIBLING',
-  'GENERAL_SIBLING': 'GENERAL_SIBLING'
+  'GENERAL_SIBLING': 'GENERAL_SIBLING',
 };
 
 /**
@@ -846,7 +846,7 @@ parse_css.parseASelector = function(tokenStream) {
     }
     const right = parse_css.parseASimpleSelectorSequence(tokenStream);
     if (right.tokenType === parse_css.TokenType.ERROR) {
-      return right;  // TODO(johannes): more than one error / partial tree.
+      return right; // TODO(johannes): more than one error / partial tree.
     }
     left = combinatorToken.copyPosTo(new parse_css.Combinator(
         combinatorTypeForToken(combinatorToken), left,

--- a/validator/engine/htmlparser-interface.js
+++ b/validator/engine/htmlparser-interface.js
@@ -48,18 +48,18 @@ amp.htmlparser.ParsedHtmlTag = class {
     // Convert attribute names to lower case, not values, which are
     // case-sensitive.
     for (let i = 0; i < attrs.length; i += 2) {
-      let attr = Object.create(null);
+      const attr = Object.create(null);
       attr.name = amp.htmlparser.toLowerCase(attrs[i]);
       attr.value = attrs[i + 1];
       // Our html parser repeats the key as the value if there is no value. We
       // replace the value with an empty string instead in this case.
-      if (attr.name === attr.value) attr.value = '';
+      if (attr.name === attr.value) {attr.value = '';}
       this.attrs_.push(attr);
     }
     // Sort the attribute array by (lower case) name.
     goog.array.sort(this.attrs_, function(a, b) {
-      if (a.name > b.name) return 1;
-      if (a.name < b.name) return -1;
+      if (a.name > b.name) {return 1;}
+      if (a.name < b.name) {return -1;}
       // No need to sub-sort by attr values, just names will do.
       return 0;
     });
@@ -103,7 +103,7 @@ amp.htmlparser.ParsedHtmlTag = class {
   attrsByKey() {
     if (this.attrsByKey_ === null) {
       this.attrsByKey_ = Object.create(null);
-      for (let attr of this.attrs()) {
+      for (const attr of this.attrs()) {
         this.attrsByKey_[attr.name] = attr.value;
       }
     }
@@ -121,7 +121,7 @@ amp.htmlparser.ParsedHtmlTag = class {
     let lastAttrName = '';
     /** @type {string} */
     let lastAttrValue = '';
-    for (let attr of this.attrs()) {
+    for (const attr of this.attrs()) {
       if (lastAttrName === attr.name && lastAttrValue !== attr.value) {
         return attr.name;
       }
@@ -138,10 +138,10 @@ amp.htmlparser.ParsedHtmlTag = class {
    */
   dedupeAttrs() {
     /** @type {!Array<!Object>} */
-    let newAttrs = [];
+    const newAttrs = [];
     /** @type {string} */
     let lastAttrName = '';
-    for (let attr of this.attrs_) {
+    for (const attr of this.attrs_) {
       if (lastAttrName !== attr.name) {
         newAttrs.push(attr);
       }
@@ -256,13 +256,13 @@ amp.htmlparser.DocLocator = class {
  */
 amp.htmlparser.HtmlSaxHandlerWithLocation =
     class extends amp.htmlparser.HtmlSaxHandler {
-  constructor() { super(); }
+      constructor() { super(); }
 
-  /**
+      /**
    * Called prior to parsing a document, that is, before `startTag`.
    * @param {amp.htmlparser.DocLocator} locator A locator instance which
    *   provides access to the line/column information while SAX events
    *   are being received by the handler.
    */
-  setDocLocator(locator) {}
-};
+      setDocLocator(locator) {}
+    };

--- a/validator/engine/htmlparser.js
+++ b/validator/engine/htmlparser.js
@@ -140,7 +140,7 @@ const ElementsWhichClosePTag = {
 const TagRegion = {
   PRE_HEAD: 0,
   IN_HEAD: 1,
-  PRE_BODY: 2,  // After closing head tag, but before open body tag.
+  PRE_BODY: 2, // After closing head tag, but before open body tag.
   IN_BODY: 3,
   IN_SVG: 4,
   // We don't track the region after the closing body tag.
@@ -247,7 +247,7 @@ class TagNameStack {
             this.startTag(new amp.htmlparser.ParsedHtmlTag('HEAD'));
           } else {
             if (this.handler_.markManufacturedBody)
-              this.handler_.markManufacturedBody();
+            {this.handler_.markManufacturedBody();}
             this.startTag(new amp.htmlparser.ParsedHtmlTag('BODY'));
           }
         }
@@ -257,7 +257,7 @@ class TagNameStack {
           this.endTag(new amp.htmlparser.ParsedHtmlTag('HEAD'));
           if (tag.upperName() !== 'BODY') {
             if (this.handler_.markManufacturedBody)
-              this.handler_.markManufacturedBody();
+            {this.handler_.markManufacturedBody();}
             this.startTag(new amp.htmlparser.ParsedHtmlTag('BODY'));
           } else {
             this.region_ = TagRegion.IN_BODY;
@@ -267,7 +267,7 @@ class TagNameStack {
       case TagRegion.PRE_BODY:
         if (tag.upperName() !== 'BODY') {
           if (this.handler_.markManufacturedBody)
-            this.handler_.markManufacturedBody();
+          {this.handler_.markManufacturedBody();}
           this.startTag(new amp.htmlparser.ParsedHtmlTag('BODY'));
         } else {
           this.region_ = TagRegion.IN_BODY;
@@ -294,7 +294,7 @@ class TagNameStack {
             // <dd> and <dt> tags can be implicitly closed by other <dd> and
             // <dt> tags. See https://www.w3.org/TR/html-markup/dd.html
           } else if (
-              (tag.upperName() == 'DD' || tag.upperName() == 'DT') &&
+            (tag.upperName() == 'DD' || tag.upperName() == 'DT') &&
               (parentTagName == 'DD' || parentTagName == 'DT')) {
             this.endTag(new amp.htmlparser.ParsedHtmlTag(parentTagName));
             // <li> tags can be implicitly closed by other <li> tags.
@@ -338,13 +338,13 @@ class TagNameStack {
         case TagRegion.PRE_HEAD:
         case TagRegion.PRE_BODY:
           if (this.handler_.markManufacturedBody)
-            this.handler_.markManufacturedBody();
+          {this.handler_.markManufacturedBody();}
           this.startTag(new amp.htmlparser.ParsedHtmlTag('BODY'));
           break;
         case TagRegion.IN_HEAD:
           this.endTag(new amp.htmlparser.ParsedHtmlTag('HEAD'));
           if (this.handler_.markManufacturedBody)
-            this.handler_.markManufacturedBody();
+          {this.handler_.markManufacturedBody();}
           this.startTag(new amp.htmlparser.ParsedHtmlTag('BODY'));
           break;
         default:
@@ -361,14 +361,14 @@ class TagNameStack {
    */
   endTag(tag) {
     if (this.region_ == TagRegion.IN_HEAD && tag.upperName() === 'HEAD')
-      this.region_ = TagRegion.PRE_BODY;
+    {this.region_ = TagRegion.PRE_BODY;}
 
     // We ignore close body tags (</body) and instead insert them when their
     // outer scope is closed (/html). This is closer to how a browser parser
     // works. The idea here is if other tags are found after the <body>,
     // (ex: <div>) which are only allowed in the <body>, we will effectively
     // move them into the body section.
-    if (tag.upperName() === 'BODY') return;
+    if (tag.upperName() === 'BODY') {return;}
 
     // We look for tag.upperName() from the end. If we can find it, we pop
     // everything from thereon off the stack. If we can't find it,
@@ -431,12 +431,12 @@ amp.htmlparser.HtmlParser = class {
    */
   parse(handler, htmlText) {
     let htmlUpper = null;
-    let inTag = false;   // True iff we're currently processing a tag.
-    const attribs = [];  // Accumulates attribute names and values.
-    let tagName;         // The name of the tag currently being processed.
-    let eflags;          // The element flags for the current tag.
-    let openTag;         // True if the current tag is an open tag.
-    let tagStack = new TagNameStack(handler);
+    let inTag = false; // True iff we're currently processing a tag.
+    const attribs = []; // Accumulates attribute names and values.
+    let tagName; // The name of the tag currently being processed.
+    let eflags; // The element flags for the current tag.
+    let openTag; // True if the current tag is an open tag.
+    const tagStack = new TagNameStack(handler);
 
     // Only provide location information if the handler implements the
     // setDocLocator method.
@@ -453,7 +453,7 @@ amp.htmlparser.HtmlParser = class {
     // processed.
     while (htmlText) {
       const regex = inTag ? amp.htmlparser.HtmlParser.INSIDE_TAG_TOKEN_ :
-                            amp.htmlparser.HtmlParser.OUTSIDE_TAG_TOKEN_;
+        amp.htmlparser.HtmlParser.OUTSIDE_TAG_TOKEN_;
       // Gets the next token
       const m = htmlText.match(regex);
       if (locator) {
@@ -464,7 +464,7 @@ amp.htmlparser.HtmlParser = class {
 
       // TODO(goto): cleanup this code breaking it into separate methods.
       if (inTag) {
-        if (m[1]) {  // Attribute.
+        if (m[1]) { // Attribute.
           // SetAttribute with uppercase names doesn't work on IE6.
           const attribName = amp.htmlparser.toLowerCase(m[1]);
           // Use empty string as value for valueless attribs, so
@@ -473,9 +473,9 @@ amp.htmlparser.HtmlParser = class {
           let decodedValue = '';
           if (m[2]) {
             let encodedValue = m[3];
-            switch (encodedValue.charCodeAt(0)) {  // Strip quotes.
-              case 34:                             // double quote "
-              case 39:                             // single quote '
+            switch (encodedValue.charCodeAt(0)) { // Strip quotes.
+              case 34: // double quote "
+              case 39: // single quote '
                 encodedValue =
                     encodedValue.substring(1, encodedValue.length - 1);
                 break;
@@ -485,7 +485,7 @@ amp.htmlparser.HtmlParser = class {
           }
           attribs.push(attribName, decodedValue);
         } else if (m[4]) {
-          if (eflags !== void 0) {  // False if not in whitelist.
+          if (eflags !== void 0) { // False if not in whitelist.
             if (openTag) {
               tagStack.startTag(new amp.htmlparser.ParsedHtmlTag(
                   /** @type {string} */ (tagName), attribs));
@@ -529,9 +529,9 @@ amp.htmlparser.HtmlParser = class {
           inTag = false;
         }
       } else {
-        if (m[1]) {  // Entity.
+        if (m[1]) { // Entity.
           tagStack.pcdata(m[0]);
-        } else if (m[3]) {  // Tag.
+        } else if (m[3]) { // Tag.
           openTag = !m[2];
           if (locator) {
             locator.snapshotPos();
@@ -539,14 +539,14 @@ amp.htmlparser.HtmlParser = class {
           inTag = true;
           tagName = amp.htmlparser.toUpperCase(m[3]);
           eflags = amp.htmlparser.HtmlParser.Elements.hasOwnProperty(tagName) ?
-              amp.htmlparser.HtmlParser.Elements[tagName] :
-              amp.htmlparser.HtmlParser.EFlags.UNKNOWN_OR_CUSTOM;
-        } else if (m[4]) {  // Text.
+            amp.htmlparser.HtmlParser.Elements[tagName] :
+            amp.htmlparser.HtmlParser.EFlags.UNKNOWN_OR_CUSTOM;
+        } else if (m[4]) { // Text.
           if (locator) {
             locator.snapshotPos();
           }
           tagStack.pcdata(m[4]);
-        } else if (m[5]) {  // Cruft.
+        } else if (m[5]) { // Cruft.
           switch (m[5]) {
             case '<':
               tagStack.pcdata('&lt;');
@@ -645,7 +645,7 @@ amp.htmlparser.HtmlParser.Entities = {
   'amp': '&',
   'nbsp': '\u00a0',
   'quot': '"',
-  'apos': '\''
+  'apos': '\'',
 };
 
 
@@ -660,7 +660,7 @@ amp.htmlparser.HtmlParser.EFlags = {
   RCDATA: 8,
   UNSAFE: 16,
   FOLDABLE: 32,
-  UNKNOWN_OR_CUSTOM: 64
+  UNKNOWN_OR_CUSTOM: 64,
 };
 
 /**
@@ -789,7 +789,7 @@ amp.htmlparser.HtmlParser.Elements = {
   'TT': 0,
   'U': 0,
   'UL': 0,
-  'VAR': 0
+  'VAR': 0,
 };
 
 
@@ -898,9 +898,9 @@ amp.htmlparser.HtmlParser.INSIDE_TAG_TOKEN_ = new RegExp(
         ('(?:' +
          // Allow attribute names to start with /, avoiding assigning the / in
          // close-tag syntax */>.
-         '([^\\t\\r\\n /=>][^\\t\\r\\n =>]*|' +  // e.g. "href"
-         '[^\\t\\r\\n =>]+[^ >]|' +              // e.g. "/asdfs/asd"
-         '\/+(?!>))' +                           // e.g. "/"
+         '([^\\t\\r\\n /=>][^\\t\\r\\n =>]*|' + // e.g. "href"
+         '[^\\t\\r\\n =>]+[^ >]|' + // e.g. "/asdfs/asd"
+         '\/+(?!>))' + // e.g. "/"
          // Optionally followed by:
          ('(' +
           '\\s*=\\s*' +
@@ -960,73 +960,73 @@ amp.htmlparser.HtmlParser.OUTSIDE_TAG_TOKEN_ = new RegExp(
  */
 amp.htmlparser.HtmlParser.DocLocatorImpl =
     class extends amp.htmlparser.DocLocator {
-  /**
+      /**
    * @param {string} htmlText text of the entire HTML document to be processed.
    */
-  constructor(htmlText) {
-    super();
-    // Precomputes a mapping from positions within htmlText to line /
-    // column numbers. TODO(johannes): This uses a fair amount of
-    // space and we can probably do better, but it's also quite simple
-    // so here we are for now.
-    this.lineByPos_ = [];
-    this.colByPos_ = [];
-    let currentLine = 1;
-    let currentCol = 0;
-    for (let i = 0; i < htmlText.length; ++i) {
-      this.lineByPos_[i] = currentLine;
-      this.colByPos_[i] = currentCol;
-      if (htmlText.charAt(i) == '\n') {
-        ++currentLine;
-        currentCol = 0;
-      } else {
-        ++currentCol;
+      constructor(htmlText) {
+        super();
+        // Precomputes a mapping from positions within htmlText to line /
+        // column numbers. TODO(johannes): This uses a fair amount of
+        // space and we can probably do better, but it's also quite simple
+        // so here we are for now.
+        this.lineByPos_ = [];
+        this.colByPos_ = [];
+        let currentLine = 1;
+        let currentCol = 0;
+        for (let i = 0; i < htmlText.length; ++i) {
+          this.lineByPos_[i] = currentLine;
+          this.colByPos_[i] = currentCol;
+          if (htmlText.charAt(i) == '\n') {
+            ++currentLine;
+            currentCol = 0;
+          } else {
+            ++currentCol;
+          }
+        }
+
+        // The current position in the htmlText.
+        this.pos_ = 0;
+        // The previous position in the htmlText - we need this to know where a
+        // tag or attribute etc. started.
+        this.previousPos_ = 0;
+
+        // This gets computed from the maps above and the previousPos in
+        // snapshotPos, and it's what client code of the DocLocator will
+        // see.
+        this.line_ = 1;
+        this.col_ = 0;
       }
-    }
-
-    // The current position in the htmlText.
-    this.pos_ = 0;
-    // The previous position in the htmlText - we need this to know where a
-    // tag or attribute etc. started.
-    this.previousPos_ = 0;
-
-    // This gets computed from the maps above and the previousPos in
-    // snapshotPos, and it's what client code of the DocLocator will
-    // see.
-    this.line_ = 1;
-    this.col_ = 0;
-  }
 
 
-  /**
+      /**
    * Advances the internal position by the characters in {code tokenText}.
    * This method is to be called only from within the parser.
    * @param {string} tokenText The token text which we examine to advance the
    *   line / column location within the doc.
    */
-  advancePos(tokenText) {
-    this.previousPos_ = this.pos_;
-    this.pos_ += tokenText.length;
-  }
+      advancePos(tokenText) {
+        this.previousPos_ = this.pos_;
+        this.pos_ += tokenText.length;
+      }
 
-  /**
+      /**
    * Snapshots the previous internal position so that getLine / getCol will
    * return it. These snapshots happen as the parser enter / exits a tag.
    * This method is to be called only from within the parser.
    */
-  snapshotPos() {
-    if (this.previousPos_ < this.lineByPos_.length) {
-      this.line_ = this.lineByPos_[this.previousPos_];
-      this.col_ = this.colByPos_[this.previousPos_];
-    }
-  }
+      snapshotPos() {
+        if (this.previousPos_ < this.lineByPos_.length) {
+          this.line_ = this.lineByPos_[this.previousPos_];
+          this.col_ = this.colByPos_[this.previousPos_];
+        }
+      }
 
-  /** @inheritDoc */
-  getLine() { return this.line_; }
+      /** @inheritDoc */
+      getLine() { return this.line_; }
 
-  /** @inheritDoc */
-  getCol() { return this.col_; }
-};
+      /** @inheritDoc */
+      getCol() { return this.col_; }
+    };
 
 /**
  * @param {string} str The string to lower case.

--- a/validator/engine/htmlparser_test.js
+++ b/validator/engine/htmlparser_test.js
@@ -80,11 +80,11 @@ class LoggingHandler extends amp.htmlparser.HtmlSaxHandler {
   attrsToString(attrs) {
     let str = '[';
     let first = true;
-    for (let attr of attrs) {
+    for (const attr of attrs) {
       if (first)
-        first = false;
+      {first = false;}
       else
-        str += ',';
+      {str += ',';}
       str += attr.name + ',' + attr.value;
     }
     str += ']';
@@ -97,10 +97,11 @@ describe('HtmlParser', () => {
     const handler = new LoggingHandler();
     const parser = new amp.htmlparser.HtmlParser();
     parser.parse(handler, 'hello world');
+
     expect(handler.log).toEqual([
       'startDoc()', 'markManufacturedBody()', 'startTag(BODY,[])',
       'pcdata("hello world")', 'endTag(BODY)', 'effectiveBodyTag([])',
-      'endDoc()'
+      'endDoc()',
     ]);
   });
 
@@ -108,10 +109,11 @@ describe('HtmlParser', () => {
     const handler = new LoggingHandler();
     const parser = new amp.htmlparser.HtmlParser();
     parser.parse(handler, '<img src="hello.gif">');
+
     expect(handler.log).toEqual([
       'startDoc()', 'markManufacturedBody()', 'startTag(BODY,[])',
       'startTag(IMG,[src,hello.gif])', 'endTag(IMG)', 'endTag(BODY)',
-      'effectiveBodyTag([])', 'endDoc()'
+      'effectiveBodyTag([])', 'endDoc()',
     ]);
   });
 
@@ -119,11 +121,12 @@ describe('HtmlParser', () => {
     const handler = new LoggingHandler();
     const parser = new amp.htmlparser.HtmlParser();
     parser.parse(handler, '<div><span>hello world</span></div>');
+
     expect(handler.log).toEqual([
       'startDoc()', 'markManufacturedBody()', 'startTag(BODY,[])',
       'startTag(DIV,[])', 'startTag(SPAN,[])', 'pcdata("hello world")',
       'endTag(SPAN)', 'endTag(DIV)', 'endTag(BODY)', 'effectiveBodyTag([])',
-      'endDoc()'
+      'endDoc()',
     ]);
   });
 
@@ -131,10 +134,11 @@ describe('HtmlParser', () => {
     const handler = new LoggingHandler();
     const parser = new amp.htmlparser.HtmlParser();
     parser.parse(handler, '<img src="hello.gif" width="400px">');
+
     expect(handler.log).toEqual([
       'startDoc()', 'markManufacturedBody()', 'startTag(BODY,[])',
       'startTag(IMG,[src,hello.gif,width,400px])', 'endTag(IMG)',
-      'endTag(BODY)', 'effectiveBodyTag([])', 'endDoc()'
+      'endTag(BODY)', 'effectiveBodyTag([])', 'endDoc()',
     ]);
   });
 
@@ -142,10 +146,11 @@ describe('HtmlParser', () => {
     const handler = new LoggingHandler();
     const parser = new amp.htmlparser.HtmlParser();
     parser.parse(handler, '<a class=foo class=bar>');
+
     expect(handler.log).toEqual([
       'startDoc()', 'markManufacturedBody()', 'startTag(BODY,[])',
       'startTag(A,[class,foo])', 'endTag(A)', 'endTag(BODY)',
-      'effectiveBodyTag([])', 'endDoc()'
+      'effectiveBodyTag([])', 'endDoc()',
     ]);
   });
 
@@ -153,10 +158,11 @@ describe('HtmlParser', () => {
     const handler = new LoggingHandler();
     const parser = new amp.htmlparser.HtmlParser();
     parser.parse(handler, '<input type=checkbox checked>');
+
     expect(handler.log).toEqual([
       'startDoc()', 'markManufacturedBody()', 'startTag(BODY,[])',
       'startTag(INPUT,[checked,,type,checkbox])', 'endTag(INPUT)',
-      'endTag(BODY)', 'effectiveBodyTag([])', 'endDoc()'
+      'endTag(BODY)', 'effectiveBodyTag([])', 'endDoc()',
     ]);
   });
 
@@ -164,10 +170,11 @@ describe('HtmlParser', () => {
     const handler = new LoggingHandler();
     const parser = new amp.htmlparser.HtmlParser();
     parser.parse(handler, '<span>');
+
     expect(handler.log).toEqual([
       'startDoc()', 'markManufacturedBody()', 'startTag(BODY,[])',
       'startTag(SPAN,[])', 'endTag(SPAN)', 'endTag(BODY)',
-      'effectiveBodyTag([])', 'endDoc()'
+      'effectiveBodyTag([])', 'endDoc()',
     ]);
   });
 
@@ -175,10 +182,11 @@ describe('HtmlParser', () => {
     const handler = new LoggingHandler();
     const parser = new amp.htmlparser.HtmlParser();
     parser.parse(handler, '<span style="background-color: black;"></span>');
+
     expect(handler.log).toEqual([
       'startDoc()', 'markManufacturedBody()', 'startTag(BODY,[])',
       'startTag(SPAN,[style,background-color: black;])', 'endTag(SPAN)',
-      'endTag(BODY)', 'effectiveBodyTag([])', 'endDoc()'
+      'endTag(BODY)', 'effectiveBodyTag([])', 'endDoc()',
     ]);
   });
 
@@ -186,10 +194,11 @@ describe('HtmlParser', () => {
     const handler = new LoggingHandler();
     const parser = new amp.htmlparser.HtmlParser();
     parser.parse(handler, '<script><![CDATA[alert("hey");]]><\/script>');
+
     expect(handler.log).toEqual([
       'startDoc()', 'startTag(HEAD,[])', 'startTag(SCRIPT,[])',
       'cdata("<![CDATA[alert("hey");]]>")', 'endTag(SCRIPT)', 'endTag(HEAD)',
-      'effectiveBodyTag([])', 'endDoc()'
+      'effectiveBodyTag([])', 'endDoc()',
     ]);
   });
 
@@ -197,11 +206,12 @@ describe('HtmlParser', () => {
     const handler = new LoggingHandler();
     const parser = new amp.htmlparser.HtmlParser();
     parser.parse(handler, '<img><p>hello<img><div/></p>');
+
     expect(handler.log).toEqual([
       'startDoc()', 'markManufacturedBody()', 'startTag(BODY,[])',
       'startTag(IMG,[])', 'endTag(IMG)', 'startTag(P,[])', 'pcdata("hello")',
       'startTag(IMG,[])', 'endTag(IMG)', 'startTag(DIV,[])', 'endTag(DIV)',
-      'endTag(P)', 'endTag(BODY)', 'effectiveBodyTag([])', 'endDoc()'
+      'endTag(P)', 'endTag(BODY)', 'effectiveBodyTag([])', 'endDoc()',
     ]);
   });
 
@@ -210,12 +220,13 @@ describe('HtmlParser', () => {
     const parser = new amp.htmlparser.HtmlParser();
     parser.parse(handler, '<div/>');
     parser.parse(handler, '<div/>');
+
     expect(handler.log).toEqual([
       'startDoc()', 'markManufacturedBody()', 'startTag(BODY,[])',
       'startTag(DIV,[])', 'endTag(DIV)', 'endTag(BODY)', 'effectiveBodyTag([])',
       'endDoc()', 'startDoc()', 'markManufacturedBody()', 'startTag(BODY,[])',
       'startTag(DIV,[])', 'endTag(DIV)', 'endTag(BODY)', 'effectiveBodyTag([])',
-      'endDoc()'
+      'endDoc()',
     ]);
   });
 
@@ -223,10 +234,11 @@ describe('HtmlParser', () => {
     const handler = new LoggingHandler();
     const parser = new amp.htmlparser.HtmlParser();
     parser.parse(handler, '<div><!-- this is a comment --></div>');
+
     expect(handler.log).toEqual([
       'startDoc()', 'markManufacturedBody()', 'startTag(BODY,[])',
       'startTag(DIV,[])', 'endTag(DIV)', 'endTag(BODY)', 'effectiveBodyTag([])',
-      'endDoc()'
+      'endDoc()',
     ]);
   });
 
@@ -236,12 +248,13 @@ describe('HtmlParser', () => {
     parser.parse(
         handler, '<a-tag><more-tags>' +
             '<custom foo="Hello">world.</more-tags></a-tag>');
+
     expect(handler.log).toEqual([
       'startDoc()', 'markManufacturedBody()', 'startTag(BODY,[])',
       'startTag(A-TAG,[])', 'startTag(MORE-TAGS,[])',
       'startTag(CUSTOM,[foo,Hello])', 'pcdata("world.")', 'endTag(CUSTOM)',
       'endTag(MORE-TAGS)', 'endTag(A-TAG)', 'endTag(BODY)',
-      'effectiveBodyTag([])', 'endDoc()'
+      'effectiveBodyTag([])', 'endDoc()',
     ]);
   });
 
@@ -250,10 +263,11 @@ describe('HtmlParser', () => {
     const parser = new amp.htmlparser.HtmlParser();
     // Note the two double quotes at the end of the tag.
     parser.parse(handler, '<a href="foo.html""></a>');
+
     expect(handler.log).toEqual([
       'startDoc()', 'markManufacturedBody()', 'startTag(BODY,[])',
       'startTag(A,[",,href,foo.html])', 'endTag(A)', 'endTag(BODY)',
-      'effectiveBodyTag([])', 'endDoc()'
+      'effectiveBodyTag([])', 'endDoc()',
     ]);
   });
 
@@ -263,11 +277,12 @@ describe('HtmlParser', () => {
     const parser = new amp.htmlparser.HtmlParser();
     // Note the two double quotes at the end of the tag.
     parser.parse(handler, '<p>I am not closed!<p>I am closed!</p>');
+
     expect(handler.log).toEqual([
       'startDoc()', 'markManufacturedBody()', 'startTag(BODY,[])',
       'startTag(P,[])', 'pcdata("I am not closed!")', 'endTag(P)',
       'startTag(P,[])', 'pcdata("I am closed!")', 'endTag(P)', 'endTag(BODY)',
-      'effectiveBodyTag([])', 'endDoc()'
+      'effectiveBodyTag([])', 'endDoc()',
     ]);
   });
 
@@ -277,12 +292,13 @@ describe('HtmlParser', () => {
     const parser = new amp.htmlparser.HtmlParser();
     // Note the two double quotes at the end of the tag.
     parser.parse(handler, '<dl><dd><dd><dt><dd></dl>');
+
     expect(handler.log).toEqual([
       'startDoc()', 'markManufacturedBody()', 'startTag(BODY,[])',
       'startTag(DL,[])', 'startTag(DD,[])', 'endTag(DD)', 'startTag(DD,[])',
       'endTag(DD)', 'startTag(DT,[])', 'endTag(DT)', 'startTag(DD,[])',
       'endTag(DD)', 'endTag(DL)', 'endTag(BODY)', 'effectiveBodyTag([])',
-      'endDoc()'
+      'endDoc()',
     ]);
   });
 
@@ -292,11 +308,12 @@ describe('HtmlParser', () => {
     const parser = new amp.htmlparser.HtmlParser();
     // Note the two double quotes at the end of the tag.
     parser.parse(handler, '<ul><li><li></ul>');
+
     expect(handler.log).toEqual([
       'startDoc()', 'markManufacturedBody()', 'startTag(BODY,[])',
       'startTag(UL,[])', 'startTag(LI,[])', 'endTag(LI)', 'startTag(LI,[])',
       'endTag(LI)', 'endTag(UL)', 'endTag(BODY)', 'effectiveBodyTag([])',
-      'endDoc()'
+      'endDoc()',
     ]);
   });
 
@@ -304,9 +321,10 @@ describe('HtmlParser', () => {
     const handler = new LoggingHandler();
     const parser = new amp.htmlparser.HtmlParser();
     parser.parse(handler, '<body foo=bar><body baz=bang><body foo=poo>');
+
     expect(handler.log).toEqual([
       'startDoc()', 'startTag(BODY,[foo,bar])', 'endTag(BODY)',
-      'effectiveBodyTag([foo,bar,baz,bang,foo,poo])', 'endDoc()'
+      'effectiveBodyTag([foo,bar,baz,bang,foo,poo])', 'endDoc()',
     ]);
   });
 });
@@ -315,7 +333,7 @@ describe('HtmlParser', () => {
  * @private
  */
 class LoggingHandlerWithLocation extends
-    amp.htmlparser.HtmlSaxHandlerWithLocation {
+  amp.htmlparser.HtmlSaxHandlerWithLocation {
   constructor() {
     super();
     /** @type {amp.htmlparser.DocLocator} */
@@ -389,11 +407,11 @@ class LoggingHandlerWithLocation extends
   attrsToString(attrs) {
     let str = '[';
     let first = true;
-    for (let attr of attrs) {
+    for (const attr of attrs) {
       if (first)
-        first = false;
+      {first = false;}
       else
-        str += ',';
+      {str += ',';}
       str += attr.name + ',' + attr.value;
     }
     str += ']';
@@ -412,12 +430,13 @@ describe('HtmlParser with location', () => {
             '    <div style=foo>Oh hi!</div>\n' +
             '  </body>\n' +
             '</html>');
+
     expect(handler.log).toEqual([
       ':1:0: startDoc()', ':1:0: startTag(HTML,[])', ':1:6: pcdata("\n  ")',
       ':2:2: startTag(BODY,[])', ':2:8: pcdata("\n    ")',
       ':3:4: startTag(DIV,[style,foo])', ':3:19: pcdata("Oh hi!")',
       ':3:25: endTag(DIV)', ':3:31: pcdata("\n  ")', ':4:9: pcdata("\n")',
-      ':5:0: endTag(BODY)', ':5:0: endTag(HTML)', ':5:6: endDoc()'
+      ':5:0: endTag(BODY)', ':5:0: endTag(HTML)', ':5:6: endDoc()',
     ]);
   });
 
@@ -443,6 +462,7 @@ describe('HtmlParser with location', () => {
             '    </p>\n' +
             '  </body>\n' +
             '</html>');
+
     expect(handler.log).toEqual([
       ':1:0: startDoc()',
       ':1:0: startTag(HTML,[])',
@@ -464,7 +484,7 @@ describe('HtmlParser with location', () => {
       ':8:9: pcdata("\n")',
       ':9:0: endTag(BODY)',
       ':9:0: endTag(HTML)',
-      ':9:6: endDoc()'
+      ':9:6: endDoc()',
     ]);
   });
 
@@ -491,6 +511,7 @@ describe('HtmlParser with location', () => {
             '<amp-analytics></amp-analytics>\n' +
             '</body>\n' +
             '</html>');
+
     expect(handler.log).toEqual([
       ':1:0: startDoc()', ':1:0: startTag(HTML,[])', ':1:6: pcdata("\n")',
       ':2:0: startTag(BODY,[])', ':2:6: pcdata("\n")',
@@ -509,7 +530,7 @@ describe('HtmlParser with location', () => {
       ':14:0: endTag(SCRIPT)', ':14:9: pcdata("\n")',
       ':15:0: startTag(AMP-ANALYTICS,[])', ':15:15: endTag(AMP-ANALYTICS)',
       ':15:31: pcdata("\n")', ':16:7: pcdata("\n")', ':17:0: endTag(BODY)',
-      ':17:0: endTag(HTML)', ':17:6: endDoc()'
+      ':17:0: endTag(HTML)', ':17:6: endDoc()',
     ]);
   });
 
@@ -530,6 +551,7 @@ describe('HtmlParser with location', () => {
             '</head>\n' +
             '<body>İ</body>\n' +
             '</html>');
+
     expect(handler.log).toEqual([
       ':1:0: startDoc()',
       ':1:0: startTag(!DOCTYPE,[html,])',
@@ -557,7 +579,7 @@ describe('HtmlParser with location', () => {
       ':9:0: endTag(BODY)',
       ':9:0: endTag(HTML)',
       ':9:6: endTag(!DOCTYPE)',
-      ':9:6: endDoc()'
+      ':9:6: endDoc()',
     ]);
   });
 
@@ -565,6 +587,7 @@ describe('HtmlParser with location', () => {
     const handler = new LoggingHandlerWithLocation();
     const parser = new amp.htmlparser.HtmlParser();
     parser.parse(handler, '<html><body><svg><foo/></svg></body></html>');
+
     expect(handler.log).toEqual([
       ':1:0: startDoc()',
       ':1:0: startTag(HTML,[])',

--- a/validator/engine/json-testutil.js
+++ b/validator/engine/json-testutil.js
@@ -58,7 +58,7 @@ function objToJsonSegments(obj, out, cmpFn) {
       out.push(']');
       return;
     } else if (
-        obj instanceof String || obj instanceof Number ||
+      obj instanceof String || obj instanceof Number ||
         obj instanceof Boolean) {
       obj = obj.valueOf();
       // Fall through to switch below.
@@ -67,7 +67,7 @@ function objToJsonSegments(obj, out, cmpFn) {
       const keys = [];
       for (const key in obj) {
         if (Object.prototype.hasOwnProperty.call(
-                /** @type {Object}*/ (obj), key)) {
+            /** @type {Object}*/ (obj), key)) {
           keys.push(key);
         }
       }
@@ -115,8 +115,8 @@ function objToJsonSegments(obj, out, cmpFn) {
  * @param {string} b
  * @return {number} */
 json_testutil.defaultCmpFn = function(a, b) {
-  if (a < b) return -1;
-  if (a > b) return 1;
+  if (a < b) {return -1;}
+  if (a > b) {return 1;}
   return 0;
 };
 
@@ -132,7 +132,7 @@ json_testutil.defaultCmpFn = function(a, b) {
 json_testutil.makeJsonKeyCmpFn = function(keyOrder) {
   /** @type {!Object<string, number>} */
   const keyPriority = {};
-  for (var ii = 0; ii < keyOrder.length; ++ii) {
+  for (let ii = 0; ii < keyOrder.length; ++ii) {
     keyPriority[keyOrder[ii]] = ii;
   }
 
@@ -195,8 +195,8 @@ function endsWithChar(str, ch) {
  * @return {string}
  */
 json_testutil.renderJSON = function(obj, cmpFn, offset) {
-  if (cmpFn === undefined) cmpFn = json_testutil.defaultCmpFn;
-  if (offset === undefined) offset = 0;
+  if (cmpFn === undefined) {cmpFn = json_testutil.defaultCmpFn;}
+  if (offset === undefined) {offset = 0;}
   // First, let objToJsonSegments emit the json into
   // segments. Conveniently, special characters such as '{', ',',
   // etc. are - unless inside a string - emitted as individual strings
@@ -205,8 +205,8 @@ json_testutil.renderJSON = function(obj, cmpFn, offset) {
   objToJsonSegments(obj, segments, cmpFn);
 
   const lines = [];
-  let current = '';      // current line
-  let nesting = offset;  // Keep track of how deep inside {[]} etc.
+  let current = ''; // current line
+  let nesting = offset; // Keep track of how deep inside {[]} etc.
 
   // Walk over the segments emitted by objToJsonSegments.
   for (const segment of segments) {
@@ -220,7 +220,7 @@ json_testutil.renderJSON = function(obj, cmpFn, offset) {
             !endsWithChar(current, '[')) {
       lines.push(current);
       current = '';
-      for (let i = 0; i < nesting; i++) {  // Emit indentation.
+      for (let i = 0; i < nesting; i++) { // Emit indentation.
         current += ' ';
       }
     }

--- a/validator/engine/keyframes-parse-css.js
+++ b/validator/engine/keyframes-parse-css.js
@@ -65,7 +65,7 @@ class KeyframesVisitor extends parse_css.RuleVisitor {
       }
       return;
     }
-    if (qualifiedRule.declarations.length > 0) return;
+    if (qualifiedRule.declarations.length > 0) {return;}
     if (amp.validator.LIGHT) {
       this.errors.push(parse_css.TRIVIAL_ERROR_TOKEN);
     } else {

--- a/validator/engine/keyframes-parse-css_test.js
+++ b/validator/engine/keyframes-parse-css_test.js
@@ -145,7 +145,7 @@ describe('validateKeyframesCss', () => {
           'tokenType': 'ERROR',
           'code':
               'CSS_SYNTAX_DISALLOWED_QUALIFIED_RULE_MUST_BE_INSIDE_KEYFRAME',
-          'params': ['style', 'amp-img']
+          'params': ['style', 'amp-img'],
         }],
         errors);
   });
@@ -168,7 +168,7 @@ describe('validateKeyframesCss', () => {
           'tokenType': 'ERROR',
           'code':
               'CSS_SYNTAX_DISALLOWED_QUALIFIED_RULE_MUST_BE_INSIDE_KEYFRAME',
-          'params': ['style', '100']
+          'params': ['style', '100'],
         }],
         errors);
   });
@@ -189,7 +189,7 @@ describe('validateKeyframesCss', () => {
           'tokenType': 'ERROR',
           'code':
               'CSS_SYNTAX_DISALLOWED_QUALIFIED_RULE_MUST_BE_INSIDE_KEYFRAME',
-          'params': ['style', 'a.underlined']
+          'params': ['style', 'a.underlined'],
         }],
         errors);
   });
@@ -210,7 +210,7 @@ describe('validateKeyframesCss', () => {
           'tokenType': 'ERROR',
           'code':
               'CSS_SYNTAX_DISALLOWED_QUALIFIED_RULE_MUST_BE_INSIDE_KEYFRAME',
-          'params': ['style', 'a']
+          'params': ['style', 'a'],
         }],
         errors);
   });
@@ -234,7 +234,7 @@ describe('validateKeyframesCss', () => {
           'col': 18,
           'tokenType': 'ERROR',
           'code': 'CSS_SYNTAX_DISALLOWED_KEYFRAME_INSIDE_KEYFRAME',
-          'params': ['style']
+          'params': ['style'],
         }],
         errors);
   });

--- a/validator/engine/parse-css.js
+++ b/validator/engine/parse-css.js
@@ -93,7 +93,7 @@ parse_css.TokenStream = class {
     // line / col!) so any request past the length of the array
     // fetches that.
     return (num < this.tokens.length) ? this.tokens[num] :
-                                        this.tokens[this.tokens.length - 1];
+      this.tokens[this.tokens.length - 1];
   }
 
   /**
@@ -135,13 +135,13 @@ parse_css.stripVendorPrefix = function(prefixedString) {
   // Checking for '-' is an optimization.
   if (prefixedString !== '' && prefixedString[0] === '-') {
     if (goog.string./*OK*/ startsWith(prefixedString, '-o-'))
-      return prefixedString.substr('-o-'.length);
+    {return prefixedString.substr('-o-'.length);}
     if (goog.string./*OK*/ startsWith(prefixedString, '-moz-'))
-      return prefixedString.substr('-moz-'.length);
+    {return prefixedString.substr('-moz-'.length);}
     if (goog.string./*OK*/ startsWith(prefixedString, '-ms-'))
-      return prefixedString.substr('-ms-'.length);
+    {return prefixedString.substr('-ms-'.length);}
     if (goog.string./*OK*/ startsWith(prefixedString, '-webkit-'))
-      return prefixedString.substr('-webkit-'.length);
+    {return prefixedString.substr('-webkit-'.length);}
   }
   return prefixedString;
 };
@@ -161,7 +161,7 @@ parse_css.stripVendorPrefix = function(prefixedString) {
  * @return {!parse_css.Stylesheet}
  */
 parse_css.parseAStylesheet = function(
-    tokenList, atRuleSpec, defaultSpec, errors) {
+  tokenList, atRuleSpec, defaultSpec, errors) {
   const canonicalizer = new Canonicalizer(atRuleSpec, defaultSpec);
   const stylesheet = new parse_css.Stylesheet();
 
@@ -304,7 +304,7 @@ if (!amp.validator.LIGHT) {
     for (let i = 0; i < this.prelude.length; ++i) {
       const prelude =
           /** @type {!parse_css.IdentToken} */ (this.prelude[i]);
-      if (prelude.value) ruleName += prelude.value;
+      if (prelude.value) {ruleName += prelude.value;}
     }
     return ruleName;
   };
@@ -389,7 +389,7 @@ parse_css.BlockType = {
   'PARSE_AS_DECLARATIONS': 'PARSE_AS_DECLARATIONS',
   // Ignore this simple block, do not parse. This is generally used
   // in conjunction with a later step emitting an error for this rule.
-  'PARSE_AS_IGNORE': 'PARSE_AS_IGNORE'
+  'PARSE_AS_IGNORE': 'PARSE_AS_IGNORE',
 };
 
 /**
@@ -451,7 +451,7 @@ class Canonicalizer {
       } else if (current === parse_css.TokenType.EOF_TOKEN) {
         return rules;
       } else if (
-          current === parse_css.TokenType.CDO ||
+        current === parse_css.TokenType.CDO ||
           current === parse_css.TokenType.CDC) {
         if (topLevel) {
           continue;
@@ -622,7 +622,7 @@ class Canonicalizer {
             ['style'])));
         tokenStream.reconsume();
         while (
-            !(tokenStream.next().tokenType === parse_css.TokenType.SEMICOLON ||
+          !(tokenStream.next().tokenType === parse_css.TokenType.SEMICOLON ||
               tokenStream.next().tokenType === parse_css.TokenType.EOF_TOKEN)) {
           tokenStream.consume();
           const dummyTokenList = [];
@@ -668,7 +668,7 @@ class Canonicalizer {
           ['style'])));
       tokenStream.reconsume();
       while (
-          !(tokenStream.next().tokenType === parse_css.TokenType.SEMICOLON ||
+        !(tokenStream.next().tokenType === parse_css.TokenType.SEMICOLON ||
             tokenStream.next().tokenType === parse_css.TokenType.EOF_TOKEN)) {
         tokenStream.consume();
       }
@@ -676,7 +676,7 @@ class Canonicalizer {
     }
 
     while (
-        !(tokenStream.next().tokenType === parse_css.TokenType.SEMICOLON ||
+      !(tokenStream.next().tokenType === parse_css.TokenType.SEMICOLON ||
           tokenStream.next().tokenType === parse_css.TokenType.EOF_TOKEN)) {
       tokenStream.consume();
       consumeAComponentValue(tokenStream, decl.value);
@@ -688,14 +688,14 @@ class Canonicalizer {
       if (decl.value[i].tokenType === parse_css.TokenType.WHITESPACE) {
         continue;
       } else if (
-          decl.value[i].tokenType === parse_css.TokenType.IDENT &&
+        decl.value[i].tokenType === parse_css.TokenType.IDENT &&
           /** @type {parse_css.IdentToken} */
           (decl.value[i]).ASCIIMatch('important')) {
         foundImportant = true;
       } else if (
-          foundImportant &&
+        foundImportant &&
           decl.value[i].tokenType === parse_css.TokenType.DELIM &&
-          /** @type {parse_css.DelimToken} */ (decl.value[i]).value === '!') {
+      /** @type {parse_css.DelimToken} */ (decl.value[i]).value === '!') {
         decl.value.splice(i, decl.value.length);
         decl.important = true;
         break;
@@ -744,7 +744,7 @@ function consumeASimpleBlock(tokenStream, tokenList) {
 
   const startToken =
       /** @type {!parse_css.GroupingToken} */ (tokenStream.current());
-  const mirror = startToken.mirror;
+  const {mirror} = startToken;
 
   tokenList.push(startToken);
   while (true) {
@@ -754,10 +754,10 @@ function consumeASimpleBlock(tokenStream, tokenList) {
       tokenList.push(tokenStream.current());
       return;
     } else if (
-        (current === parse_css.TokenType.CLOSE_CURLY ||
+      (current === parse_css.TokenType.CLOSE_CURLY ||
          current === parse_css.TokenType.CLOSE_SQUARE ||
          current === parse_css.TokenType.CLOSE_PAREN) &&
-        /** @type {parse_css.GroupingToken} */ (tokenStream.current()).value ===
+    /** @type {parse_css.GroupingToken} */ (tokenStream.current()).value ===
             mirror) {
       tokenList.push(tokenStream.current());
       return;
@@ -784,8 +784,8 @@ parse_css.extractASimpleBlock = function(tokenStream) {
   // Exclude the start token. Convert end token to EOF.
   const end = consumedTokens.length - 1;
   consumedTokens[end] = amp.validator.LIGHT ?
-      parse_css.TRIVIAL_EOF_TOKEN :
-      consumedTokens[end].copyPosTo(new parse_css.EOFToken());
+    parse_css.TRIVIAL_EOF_TOKEN :
+    consumedTokens[end].copyPosTo(new parse_css.EOFToken());
   return consumedTokens.slice(1);
 };
 
@@ -832,8 +832,8 @@ parse_css.extractAFunction = function(tokenStream) {
   // Convert end token to EOF.
   const end = consumedTokens.length - 1;
   consumedTokens[end] = amp.validator.LIGHT ?
-      parse_css.TRIVIAL_EOF_TOKEN :
-      consumedTokens[end].copyPosTo(new parse_css.EOFToken());
+    parse_css.TRIVIAL_EOF_TOKEN :
+    consumedTokens[end].copyPosTo(new parse_css.EOFToken());
   return consumedTokens;
 };
 
@@ -908,7 +908,7 @@ function parseUrlFunction(tokens, tokenIdx, parsed) {
   goog.asserts.assert(
       tokens[tokens.length - 1].tokenType === parse_css.TokenType.EOF_TOKEN);
   token.copyPosTo(parsed);
-  ++tokenIdx;  // We've digested the function token above.
+  ++tokenIdx; // We've digested the function token above.
   // Safe: tokens ends w/ EOF_TOKEN.
   goog.asserts.assert(tokenIdx < tokens.length);
 
@@ -924,7 +924,7 @@ function parseUrlFunction(tokens, tokenIdx, parsed) {
     return -1;
   }
   parsed.utf8Url =
-      /** @type {parse_css.StringToken} */ (tokens[tokenIdx]).value;
+    /** @type {parse_css.StringToken} */ (tokens[tokenIdx]).value;
 
   ++tokenIdx;
   // Safe: tokens ends w/ EOF_TOKEN.
@@ -999,7 +999,7 @@ class UrlFunctionVisitor extends parse_css.RuleVisitor {
         continue;
       }
       if (token.tokenType === parse_css.TokenType.FUNCTION_TOKEN &&
-          /** @type {!parse_css.FunctionToken} */ (token).value === 'url') {
+      /** @type {!parse_css.FunctionToken} */ (token).value === 'url') {
         const parsedUrl = new parse_css.ParsedCssUrl();
         ii = parseUrlFunction(declaration.value, ii, parsedUrl);
         if (ii === -1) {
@@ -1063,10 +1063,10 @@ class MediaQueryVisitor extends parse_css.RuleVisitor {
 
   /** @inheritDoc */
   visitAtRule(atRule) {
-    if (atRule.name.toLowerCase() !== 'media') return;
+    if (atRule.name.toLowerCase() !== 'media') {return;}
 
-    let tokenStream = new parse_css.TokenStream(atRule.prelude);
-    tokenStream.consume();  // Advance to first token.
+    const tokenStream = new parse_css.TokenStream(atRule.prelude);
+    tokenStream.consume(); // Advance to first token.
     if (!this.parseAMediaQueryList_(tokenStream)) {
       if (amp.validator.LIGHT) {
         this.errors.push(parse_css.TRIVIAL_ERROR_TOKEN);
@@ -1088,7 +1088,7 @@ class MediaQueryVisitor extends parse_css.RuleVisitor {
     // our tokenizer already collapses whitespace so only one token can ever
     // be present.
     if (tokenStream.current().tokenType === parse_css.TokenType.WHITESPACE)
-      tokenStream.consume();
+    {tokenStream.consume();}
   }
 
   /**
@@ -1103,11 +1103,11 @@ class MediaQueryVisitor extends parse_css.RuleVisitor {
     // ;
     this.maybeConsumeAWhitespaceToken_(tokenStream);
     if (tokenStream.current().tokenType !== parse_css.TokenType.EOF_TOKEN) {
-      if (!this.parseAMediaQuery_(tokenStream)) return false;
+      if (!this.parseAMediaQuery_(tokenStream)) {return false;}
       while (tokenStream.current().tokenType === parse_css.TokenType.COMMA) {
-        tokenStream.consume();  // ','
+        tokenStream.consume(); // ','
         this.maybeConsumeAWhitespaceToken_(tokenStream);
-        if (!this.parseAMediaQuery_(tokenStream)) return false;
+        if (!this.parseAMediaQuery_(tokenStream)) {return false;}
       }
     }
     return tokenStream.current().tokenType === parse_css.TokenType.EOF_TOKEN;
@@ -1133,26 +1133,26 @@ class MediaQueryVisitor extends parse_css.RuleVisitor {
     // '(', so it's simpler to use as a check to distinguis the expression case
     // from the media type case.
     if (tokenStream.current().tokenType === parse_css.TokenType.OPEN_PAREN) {
-      if (!this.parseAMediaExpression_(tokenStream)) return false;
+      if (!this.parseAMediaExpression_(tokenStream)) {return false;}
     } else {
       if (tokenStream.current().tokenType === parse_css.TokenType.IDENT &&
           (
-              /** @type {parse_css.IdentToken} */
-              (tokenStream.current()).ASCIIMatch('only') ||
+            /** @type {parse_css.IdentToken} */
+            (tokenStream.current()).ASCIIMatch('only') ||
               /** @type {parse_css.IdentToken} */
               (tokenStream.current()).ASCIIMatch('not'))) {
-        tokenStream.consume();  // 'ONLY' | 'NOT'
+        tokenStream.consume(); // 'ONLY' | 'NOT'
       }
       this.maybeConsumeAWhitespaceToken_(tokenStream);
-      if (!this.parseAMediaType_(tokenStream)) return false;
+      if (!this.parseAMediaType_(tokenStream)) {return false;}
       this.maybeConsumeAWhitespaceToken_(tokenStream);
     }
     while (tokenStream.current().tokenType === parse_css.TokenType.IDENT &&
            /** @type {parse_css.IdentToken} */
            (tokenStream.current()).ASCIIMatch('and')) {
-      tokenStream.consume();  // 'AND'
+      tokenStream.consume(); // 'AND'
       this.maybeConsumeAWhitespaceToken_(tokenStream);
-      if (!this.parseAMediaExpression_(tokenStream)) return false;
+      if (!this.parseAMediaExpression_(tokenStream)) {return false;}
     }
     return true;
   }
@@ -1185,13 +1185,13 @@ class MediaQueryVisitor extends parse_css.RuleVisitor {
     //  : '(' S* media_feature S* [ ':' S* expr ]? ')' S*
     //  ;
     if (tokenStream.current().tokenType !== parse_css.TokenType.OPEN_PAREN)
-      return false;
-    tokenStream.consume();  // '('
+    {return false;}
+    tokenStream.consume(); // '('
     this.maybeConsumeAWhitespaceToken_(tokenStream);
-    if (!this.parseAMediaFeature_(tokenStream)) return false;
+    if (!this.parseAMediaFeature_(tokenStream)) {return false;}
     this.maybeConsumeAWhitespaceToken_(tokenStream);
     if (tokenStream.current().tokenType === parse_css.TokenType.COLON) {
-      tokenStream.consume();  // '('
+      tokenStream.consume(); // '('
       this.maybeConsumeAWhitespaceToken_(tokenStream);
       // The CSS3 grammar at this point just tells us to expect some
       // expr. Which tokens are accepted here are defined by the media
@@ -1205,13 +1205,13 @@ class MediaQueryVisitor extends parse_css.RuleVisitor {
       // or a number with a unit identifier. (The only exceptions are the
       // ‘aspect-ratio’ and ‘device-aspect-ratio’ media features.)
       while (
-          tokenStream.current().tokenType !== parse_css.TokenType.EOF_TOKEN &&
+        tokenStream.current().tokenType !== parse_css.TokenType.EOF_TOKEN &&
           tokenStream.current().tokenType !== parse_css.TokenType.CLOSE_PAREN)
-        tokenStream.consume();
+      {tokenStream.consume();}
     }
     if (tokenStream.current().tokenType !== parse_css.TokenType.CLOSE_PAREN)
-      return false;
-    tokenStream.consume();  // ')'
+    {return false;}
+    tokenStream.consume(); // ')'
     this.maybeConsumeAWhitespaceToken_(tokenStream);
     return true;
   }
@@ -1246,7 +1246,7 @@ class MediaQueryVisitor extends parse_css.RuleVisitor {
  * @param {!Array<!parse_css.ErrorToken>} errors
  */
 parse_css.parseMediaQueries = function(
-    stylesheet, mediaTypes, mediaFeatures, errors) {
+  stylesheet, mediaTypes, mediaFeatures, errors) {
   const visitor = new MediaQueryVisitor(mediaTypes, mediaFeatures, errors);
   stylesheet.accept(visitor);
 };

--- a/validator/engine/parse-css_test.js
+++ b/validator/engine/parse-css_test.js
@@ -75,7 +75,7 @@ describe('stripVendorPrefix', () => {
  */
 const jsonKeyCmp = json_testutil.makeJsonKeyCmpFn([
   'line', 'col', 'tokenType', 'name', 'prelude', 'declarations', 'rules',
-  'errorType', 'msg', 'type', 'value', 'repr', 'unit', 'eof'
+  'errorType', 'msg', 'type', 'value', 'repr', 'unit', 'eof',
 ]);
 
 /**
@@ -91,7 +91,7 @@ function assertJSONEquals(left, right) {
 /** @type {!Object<string,parse_css.BlockType>} */
 const ampAtRuleParsingSpec = {
   'font-face': parse_css.BlockType.PARSE_AS_DECLARATIONS,
-  'media': parse_css.BlockType.PARSE_AS_RULES
+  'media': parse_css.BlockType.PARSE_AS_RULES,
 };
 
 describe('tokenize', () => {
@@ -112,7 +112,7 @@ describe('tokenize', () => {
           {'line': 1, 'col': 14, 'tokenType': 'SEMICOLON'},
           {'line': 1, 'col': 15, 'tokenType': 'WHITESPACE'},
           {'line': 1, 'col': 16, 'tokenType': 'CLOSE_CURLY'},
-          {'line': 1, 'col': 17, 'tokenType': 'EOF_TOKEN'}
+          {'line': 1, 'col': 17, 'tokenType': 'EOF_TOKEN'},
         ],
         tokenlist);
     assertStrictEqual(0, errors.length);
@@ -127,7 +127,7 @@ describe('tokenize', () => {
           {'line': 1, 'col': 0, 'tokenType': 'WHITESPACE'},
           {'line': 1, 'col': 2, 'tokenType': 'WHITESPACE'},
           {'line': 2, 'col': 1, 'tokenType': 'STRING', 'value': ''},
-          {'line': 2, 'col': 2, 'tokenType': 'EOF_TOKEN'}
+          {'line': 2, 'col': 2, 'tokenType': 'EOF_TOKEN'},
         ],
         tokenlist);
     assertJSONEquals(
@@ -136,7 +136,7 @@ describe('tokenize', () => {
           'col': 1,
           'tokenType': 'ERROR',
           'code': 'CSS_SYNTAX_UNTERMINATED_STRING',
-          'params': ['style']
+          'params': ['style'],
         }],
         errors);
   });
@@ -153,15 +153,15 @@ describe('tokenize', () => {
             'col': 7,
             'tokenType': 'ERROR',
             'code': 'CSS_SYNTAX_UNTERMINATED_STRING',
-            'params': ['style']
+            'params': ['style'],
           },
           {
             'line': 2,
             'col': 7,
             'tokenType': 'ERROR',
             'code': 'CSS_SYNTAX_UNTERMINATED_STRING',
-            'params': ['style']
-          }
+            'params': ['style'],
+          },
         ],
         errors);
     errors = [];
@@ -173,15 +173,15 @@ describe('tokenize', () => {
             'col': 12,
             'tokenType': 'ERROR',
             'code': 'CSS_SYNTAX_UNTERMINATED_STRING',
-            'params': ['style']
+            'params': ['style'],
           },
           {
             'line': 6,
             'col': 7,
             'tokenType': 'ERROR',
             'code': 'CSS_SYNTAX_UNTERMINATED_STRING',
-            'params': ['style']
-          }
+            'params': ['style'],
+          },
         ],
         errors);
   });
@@ -197,7 +197,7 @@ describe('tokenize', () => {
           'col': 11,
           'tokenType': 'ERROR',
           'code': 'CSS_SYNTAX_STRAY_TRAILING_BACKSLASH',
-          'params': ['style']
+          'params': ['style'],
         }],
         errors);
 
@@ -209,7 +209,7 @@ describe('tokenize', () => {
           'col': 17,
           'tokenType': 'ERROR',
           'code': 'CSS_SYNTAX_UNTERMINATED_COMMENT',
-          'params': ['style']
+          'params': ['style'],
         }],
         errors);
 
@@ -221,7 +221,7 @@ describe('tokenize', () => {
           'col': 6,
           'tokenType': 'ERROR',
           'code': 'CSS_SYNTAX_BAD_URL',
-          'params': ['style']
+          'params': ['style'],
         }],
         errors);
   });
@@ -304,7 +304,7 @@ describe('parseAStylesheet', () => {
             'prelude': [
               {'line': 1, 'col': 0, 'tokenType': 'IDENT', 'value': 'foo'},
               {'line': 1, 'col': 3, 'tokenType': 'WHITESPACE'},
-              {'line': 1, 'col': 4, 'tokenType': 'EOF_TOKEN'}
+              {'line': 1, 'col': 4, 'tokenType': 'EOF_TOKEN'},
             ],
             'declarations': [{
               'line': 1,
@@ -316,7 +316,7 @@ describe('parseAStylesheet', () => {
                   'line': 1,
                   'col': 11,
                   'tokenType': 'FUNCTION_TOKEN',
-                  'value': 'rgb'
+                  'value': 'rgb',
                 },
                 {
                   'line': 1,
@@ -324,7 +324,7 @@ describe('parseAStylesheet', () => {
                   'tokenType': 'NUMBER',
                   'type': 'integer',
                   'value': 255,
-                  'repr': '255'
+                  'repr': '255',
                 },
                 {'line': 1, 'col': 18, 'tokenType': 'COMMA'},
                 {'line': 1, 'col': 19, 'tokenType': 'WHITESPACE'}, {
@@ -333,7 +333,7 @@ describe('parseAStylesheet', () => {
                   'tokenType': 'NUMBER',
                   'type': 'integer',
                   'value': 0,
-                  'repr': '0'
+                  'repr': '0',
                 },
                 {'line': 1, 'col': 21, 'tokenType': 'COMMA'},
                 {'line': 1, 'col': 22, 'tokenType': 'WHITESPACE'}, {
@@ -342,15 +342,15 @@ describe('parseAStylesheet', () => {
                   'tokenType': 'NUMBER',
                   'type': 'integer',
                   'value': 127,
-                  'repr': '127'
+                  'repr': '127',
                 },
                 {'line': 1, 'col': 26, 'tokenType': 'CLOSE_PAREN'},
-                {'line': 1, 'col': 27, 'tokenType': 'EOF_TOKEN'}
+                {'line': 1, 'col': 27, 'tokenType': 'EOF_TOKEN'},
               ],
-              'important': false
-            }]
+              'important': false,
+            }],
           }],
-          'eof': {'line': 1, 'col': 30, 'tokenType': 'EOF_TOKEN'}
+          'eof': {'line': 1, 'col': 30, 'tokenType': 'EOF_TOKEN'},
         },
         sheet);
     // Some assertions about the line/cols of nodes, which we use to test the
@@ -388,14 +388,14 @@ describe('parseAStylesheet', () => {
                 'col': 0,
                 'tokenType': 'HASH',
                 'type': 'id',
-                'value': 'foo'
+                'value': 'foo',
               },
               {'line': 1, 'col': 4, 'tokenType': 'WHITESPACE'},
-              {'line': 1, 'col': 5, 'tokenType': 'EOF_TOKEN'}
+              {'line': 1, 'col': 5, 'tokenType': 'EOF_TOKEN'},
             ],
-            'declarations': []
+            'declarations': [],
           }],
-          'eof': {'line': 1, 'col': 7, 'tokenType': 'EOF_TOKEN'}
+          'eof': {'line': 1, 'col': 7, 'tokenType': 'EOF_TOKEN'},
         },
         sheet);
   });
@@ -419,19 +419,19 @@ describe('parseAStylesheet', () => {
             'name': 'media',
             'prelude': [
               {'line': 1, 'col': 6, 'tokenType': 'WHITESPACE'},
-              {'line': 1, 'col': 7, 'tokenType': 'EOF_TOKEN'}
+              {'line': 1, 'col': 7, 'tokenType': 'EOF_TOKEN'},
             ],
             'declarations': [],
-            'rules': []
+            'rules': [],
           }],
-          'eof': {'line': 1, 'col': 9, 'tokenType': 'EOF_TOKEN'}
+          'eof': {'line': 1, 'col': 9, 'tokenType': 'EOF_TOKEN'},
         },
         sheet);
   });
 
   it('parses nested media rules and declarations',
-     () => {
-       const css = 'h1 { color: red; }\n' +
+      () => {
+        const css = 'h1 { color: red; }\n' +
            '@media print {\n' +
            '  @media print {\n' +
            '    h2.bar { size: 4px; }\n' +
@@ -441,249 +441,249 @@ describe('parseAStylesheet', () => {
            '  font-family: \'MyFont\';\n' +
            '  src: url(\'foo.ttf\');\n' +
            '}';
-       const errors = [];
-       const tokenlist = parse_css.tokenize(css, 1, 0, errors);
-       assertJSONEquals(
-           [
-             {'line': 1, 'col': 0, 'tokenType': 'IDENT', 'value': 'h1'},
-             {'line': 1, 'col': 2, 'tokenType': 'WHITESPACE'},
-             {'line': 1, 'col': 3, 'tokenType': 'OPEN_CURLY'},
-             {'line': 1, 'col': 4, 'tokenType': 'WHITESPACE'},
-             {'line': 1, 'col': 5, 'tokenType': 'IDENT', 'value': 'color'},
-             {'line': 1, 'col': 10, 'tokenType': 'COLON'},
-             {'line': 1, 'col': 11, 'tokenType': 'WHITESPACE'},
-             {'line': 1, 'col': 12, 'tokenType': 'IDENT', 'value': 'red'},
-             {'line': 1, 'col': 15, 'tokenType': 'SEMICOLON'},
-             {'line': 1, 'col': 16, 'tokenType': 'WHITESPACE'},
-             {'line': 1, 'col': 17, 'tokenType': 'CLOSE_CURLY'},
-             {'line': 1, 'col': 18, 'tokenType': 'WHITESPACE'},
-             {'line': 2, 'col': 0, 'tokenType': 'AT_KEYWORD', 'value': 'media'},
-             {'line': 2, 'col': 6, 'tokenType': 'WHITESPACE'},
-             {'line': 2, 'col': 7, 'tokenType': 'IDENT', 'value': 'print'},
-             {'line': 2, 'col': 12, 'tokenType': 'WHITESPACE'},
-             {'line': 2, 'col': 13, 'tokenType': 'OPEN_CURLY'},
-             {'line': 2, 'col': 14, 'tokenType': 'WHITESPACE'},
-             {'line': 3, 'col': 2, 'tokenType': 'AT_KEYWORD', 'value': 'media'},
-             {'line': 3, 'col': 8, 'tokenType': 'WHITESPACE'},
-             {'line': 3, 'col': 9, 'tokenType': 'IDENT', 'value': 'print'},
-             {'line': 3, 'col': 14, 'tokenType': 'WHITESPACE'},
-             {'line': 3, 'col': 15, 'tokenType': 'OPEN_CURLY'},
-             {'line': 3, 'col': 16, 'tokenType': 'WHITESPACE'},
-             {'line': 4, 'col': 4, 'tokenType': 'IDENT', 'value': 'h2'},
-             {'line': 4, 'col': 6, 'tokenType': 'DELIM', 'value': '.'},
-             {'line': 4, 'col': 7, 'tokenType': 'IDENT', 'value': 'bar'},
-             {'line': 4, 'col': 10, 'tokenType': 'WHITESPACE'},
-             {'line': 4, 'col': 11, 'tokenType': 'OPEN_CURLY'},
-             {'line': 4, 'col': 12, 'tokenType': 'WHITESPACE'},
-             {'line': 4, 'col': 13, 'tokenType': 'IDENT', 'value': 'size'},
-             {'line': 4, 'col': 17, 'tokenType': 'COLON'},
-             {'line': 4, 'col': 18, 'tokenType': 'WHITESPACE'},
-             {
-               'line': 4,
-               'col': 19,
-               'tokenType': 'DIMENSION',
-               'type': 'integer',
-               'value': 4,
-               'repr': '4',
-               'unit': 'px'
-             },
-             {'line': 4, 'col': 22, 'tokenType': 'SEMICOLON'},
-             {'line': 4, 'col': 23, 'tokenType': 'WHITESPACE'},
-             {'line': 4, 'col': 24, 'tokenType': 'CLOSE_CURLY'},
-             {'line': 4, 'col': 25, 'tokenType': 'WHITESPACE'},
-             {'line': 5, 'col': 2, 'tokenType': 'CLOSE_CURLY'},
-             {'line': 5, 'col': 3, 'tokenType': 'WHITESPACE'},
-             {'line': 6, 'col': 0, 'tokenType': 'CLOSE_CURLY'},
-             {'line': 6, 'col': 1, 'tokenType': 'WHITESPACE'},
-             {
-               'line': 7,
-               'col': 0,
-               'tokenType': 'AT_KEYWORD',
-               'value': 'font-face'
-             },
-             {'line': 7, 'col': 10, 'tokenType': 'WHITESPACE'},
-             {'line': 7, 'col': 11, 'tokenType': 'OPEN_CURLY'},
-             {'line': 7, 'col': 12, 'tokenType': 'WHITESPACE'},
-             {
-               'line': 8,
-               'col': 2,
-               'tokenType': 'IDENT',
-               'value': 'font-family'
-             },
-             {'line': 8, 'col': 13, 'tokenType': 'COLON'},
-             {'line': 8, 'col': 14, 'tokenType': 'WHITESPACE'},
-             {'line': 8, 'col': 15, 'tokenType': 'STRING', 'value': 'MyFont'},
-             {'line': 8, 'col': 23, 'tokenType': 'SEMICOLON'},
-             {'line': 8, 'col': 24, 'tokenType': 'WHITESPACE'},
-             {'line': 9, 'col': 2, 'tokenType': 'IDENT', 'value': 'src'},
-             {'line': 9, 'col': 5, 'tokenType': 'COLON'},
-             {'line': 9, 'col': 6, 'tokenType': 'WHITESPACE'},
-             {
-               'line': 9,
-               'col': 7,
-               'tokenType': 'FUNCTION_TOKEN',
-               'value': 'url'
-             },
-             {'line': 9, 'col': 11, 'tokenType': 'STRING', 'value': 'foo.ttf'},
-             {'line': 9, 'col': 20, 'tokenType': 'CLOSE_PAREN'},
-             {'line': 9, 'col': 21, 'tokenType': 'SEMICOLON'},
-             {'line': 9, 'col': 22, 'tokenType': 'WHITESPACE'},
-             {'line': 10, 'col': 0, 'tokenType': 'CLOSE_CURLY'},
-             {'line': 10, 'col': 1, 'tokenType': 'EOF_TOKEN'}
-           ],
-           tokenlist);
-       const sheet = parse_css.parseAStylesheet(
-           tokenlist, ampAtRuleParsingSpec, parse_css.BlockType.PARSE_AS_IGNORE,
-           errors);
-       assertStrictEqual(0, errors.length);
-       assertJSONEquals(
-        {
-          'line': 1,
-          'col': 0,
-          'tokenType': 'STYLESHEET',
-          'rules': [
+        const errors = [];
+        const tokenlist = parse_css.tokenize(css, 1, 0, errors);
+        assertJSONEquals(
+            [
+              {'line': 1, 'col': 0, 'tokenType': 'IDENT', 'value': 'h1'},
+              {'line': 1, 'col': 2, 'tokenType': 'WHITESPACE'},
+              {'line': 1, 'col': 3, 'tokenType': 'OPEN_CURLY'},
+              {'line': 1, 'col': 4, 'tokenType': 'WHITESPACE'},
+              {'line': 1, 'col': 5, 'tokenType': 'IDENT', 'value': 'color'},
+              {'line': 1, 'col': 10, 'tokenType': 'COLON'},
+              {'line': 1, 'col': 11, 'tokenType': 'WHITESPACE'},
+              {'line': 1, 'col': 12, 'tokenType': 'IDENT', 'value': 'red'},
+              {'line': 1, 'col': 15, 'tokenType': 'SEMICOLON'},
+              {'line': 1, 'col': 16, 'tokenType': 'WHITESPACE'},
+              {'line': 1, 'col': 17, 'tokenType': 'CLOSE_CURLY'},
+              {'line': 1, 'col': 18, 'tokenType': 'WHITESPACE'},
+              {'line': 2, 'col': 0, 'tokenType': 'AT_KEYWORD', 'value': 'media'},
+              {'line': 2, 'col': 6, 'tokenType': 'WHITESPACE'},
+              {'line': 2, 'col': 7, 'tokenType': 'IDENT', 'value': 'print'},
+              {'line': 2, 'col': 12, 'tokenType': 'WHITESPACE'},
+              {'line': 2, 'col': 13, 'tokenType': 'OPEN_CURLY'},
+              {'line': 2, 'col': 14, 'tokenType': 'WHITESPACE'},
+              {'line': 3, 'col': 2, 'tokenType': 'AT_KEYWORD', 'value': 'media'},
+              {'line': 3, 'col': 8, 'tokenType': 'WHITESPACE'},
+              {'line': 3, 'col': 9, 'tokenType': 'IDENT', 'value': 'print'},
+              {'line': 3, 'col': 14, 'tokenType': 'WHITESPACE'},
+              {'line': 3, 'col': 15, 'tokenType': 'OPEN_CURLY'},
+              {'line': 3, 'col': 16, 'tokenType': 'WHITESPACE'},
+              {'line': 4, 'col': 4, 'tokenType': 'IDENT', 'value': 'h2'},
+              {'line': 4, 'col': 6, 'tokenType': 'DELIM', 'value': '.'},
+              {'line': 4, 'col': 7, 'tokenType': 'IDENT', 'value': 'bar'},
+              {'line': 4, 'col': 10, 'tokenType': 'WHITESPACE'},
+              {'line': 4, 'col': 11, 'tokenType': 'OPEN_CURLY'},
+              {'line': 4, 'col': 12, 'tokenType': 'WHITESPACE'},
+              {'line': 4, 'col': 13, 'tokenType': 'IDENT', 'value': 'size'},
+              {'line': 4, 'col': 17, 'tokenType': 'COLON'},
+              {'line': 4, 'col': 18, 'tokenType': 'WHITESPACE'},
+              {
+                'line': 4,
+                'col': 19,
+                'tokenType': 'DIMENSION',
+                'type': 'integer',
+                'value': 4,
+                'repr': '4',
+                'unit': 'px',
+              },
+              {'line': 4, 'col': 22, 'tokenType': 'SEMICOLON'},
+              {'line': 4, 'col': 23, 'tokenType': 'WHITESPACE'},
+              {'line': 4, 'col': 24, 'tokenType': 'CLOSE_CURLY'},
+              {'line': 4, 'col': 25, 'tokenType': 'WHITESPACE'},
+              {'line': 5, 'col': 2, 'tokenType': 'CLOSE_CURLY'},
+              {'line': 5, 'col': 3, 'tokenType': 'WHITESPACE'},
+              {'line': 6, 'col': 0, 'tokenType': 'CLOSE_CURLY'},
+              {'line': 6, 'col': 1, 'tokenType': 'WHITESPACE'},
+              {
+                'line': 7,
+                'col': 0,
+                'tokenType': 'AT_KEYWORD',
+                'value': 'font-face',
+              },
+              {'line': 7, 'col': 10, 'tokenType': 'WHITESPACE'},
+              {'line': 7, 'col': 11, 'tokenType': 'OPEN_CURLY'},
+              {'line': 7, 'col': 12, 'tokenType': 'WHITESPACE'},
+              {
+                'line': 8,
+                'col': 2,
+                'tokenType': 'IDENT',
+                'value': 'font-family',
+              },
+              {'line': 8, 'col': 13, 'tokenType': 'COLON'},
+              {'line': 8, 'col': 14, 'tokenType': 'WHITESPACE'},
+              {'line': 8, 'col': 15, 'tokenType': 'STRING', 'value': 'MyFont'},
+              {'line': 8, 'col': 23, 'tokenType': 'SEMICOLON'},
+              {'line': 8, 'col': 24, 'tokenType': 'WHITESPACE'},
+              {'line': 9, 'col': 2, 'tokenType': 'IDENT', 'value': 'src'},
+              {'line': 9, 'col': 5, 'tokenType': 'COLON'},
+              {'line': 9, 'col': 6, 'tokenType': 'WHITESPACE'},
+              {
+                'line': 9,
+                'col': 7,
+                'tokenType': 'FUNCTION_TOKEN',
+                'value': 'url',
+              },
+              {'line': 9, 'col': 11, 'tokenType': 'STRING', 'value': 'foo.ttf'},
+              {'line': 9, 'col': 20, 'tokenType': 'CLOSE_PAREN'},
+              {'line': 9, 'col': 21, 'tokenType': 'SEMICOLON'},
+              {'line': 9, 'col': 22, 'tokenType': 'WHITESPACE'},
+              {'line': 10, 'col': 0, 'tokenType': 'CLOSE_CURLY'},
+              {'line': 10, 'col': 1, 'tokenType': 'EOF_TOKEN'},
+            ],
+            tokenlist);
+        const sheet = parse_css.parseAStylesheet(
+            tokenlist, ampAtRuleParsingSpec, parse_css.BlockType.PARSE_AS_IGNORE,
+            errors);
+        assertStrictEqual(0, errors.length);
+        assertJSONEquals(
             {
               'line': 1,
               'col': 0,
-              'tokenType': 'QUALIFIED_RULE',
-              'prelude': [
-                {'line': 1, 'col': 0, 'tokenType': 'IDENT', 'value': 'h1'},
-                {'line': 1, 'col': 2, 'tokenType': 'WHITESPACE'},
-                {'line': 1, 'col': 3, 'tokenType': 'EOF_TOKEN'}
-              ],
-              'declarations': [{
-                'line': 1,
-                'col': 5,
-                'tokenType': 'DECLARATION',
-                'name': 'color',
-                'value': [
-                  {'line': 1, 'col': 11, 'tokenType': 'WHITESPACE'},
-                  {'line': 1, 'col': 12, 'tokenType': 'IDENT', 'value': 'red'},
-                  {'line': 1, 'col': 15, 'tokenType': 'EOF_TOKEN'}
-                ],
-                'important': false
-              }]
-            },
-            {
-              'line': 2,
-              'col': 0,
-              'tokenType': 'AT_RULE',
-              'name': 'media',
-              'prelude': [
-                {'line': 2, 'col': 6, 'tokenType': 'WHITESPACE'},
-                {'line': 2, 'col': 7, 'tokenType': 'IDENT', 'value': 'print'},
-                {'line': 2, 'col': 12, 'tokenType': 'WHITESPACE'},
-                {'line': 2, 'col': 13, 'tokenType': 'EOF_TOKEN'}
-              ],
-              'declarations': [],
-              'rules': [{
-                'line': 3,
-                'col': 2,
-                'tokenType': 'AT_RULE',
-                'name': 'media',
-                'prelude': [
-                  {'line': 3, 'col': 8, 'tokenType': 'WHITESPACE'},
-                  {'line': 3, 'col': 9, 'tokenType': 'IDENT', 'value': 'print'},
-                  {'line': 3, 'col': 14, 'tokenType': 'WHITESPACE'},
-                  {'line': 3, 'col': 15, 'tokenType': 'EOF_TOKEN'}
-                ],
-                'declarations': [],
-                'rules': [{
-                  'line': 4,
-                  'col': 4,
+              'tokenType': 'STYLESHEET',
+              'rules': [
+                {
+                  'line': 1,
+                  'col': 0,
                   'tokenType': 'QUALIFIED_RULE',
                   'prelude': [
-                    {'line': 4, 'col': 4, 'tokenType': 'IDENT', 'value': 'h2'},
-                    {'line': 4, 'col': 6, 'tokenType': 'DELIM', 'value': '.'},
-                    {'line': 4, 'col': 7, 'tokenType': 'IDENT', 'value': 'bar'},
-                    {'line': 4, 'col': 10, 'tokenType': 'WHITESPACE'},
-                    {'line': 4, 'col': 11, 'tokenType': 'EOF_TOKEN'}
+                    {'line': 1, 'col': 0, 'tokenType': 'IDENT', 'value': 'h1'},
+                    {'line': 1, 'col': 2, 'tokenType': 'WHITESPACE'},
+                    {'line': 1, 'col': 3, 'tokenType': 'EOF_TOKEN'},
                   ],
                   'declarations': [{
-                    'line': 4,
-                    'col': 13,
+                    'line': 1,
+                    'col': 5,
                     'tokenType': 'DECLARATION',
-                    'name': 'size',
+                    'name': 'color',
                     'value': [
-                      {'line': 4, 'col': 18, 'tokenType': 'WHITESPACE'}, {
-                        'line': 4,
-                        'col': 19,
-                        'tokenType': 'DIMENSION',
-                        'type': 'integer',
-                        'value': 4,
-                        'repr': '4',
-                        'unit': 'px'
-                      },
-                      {'line': 4, 'col': 22, 'tokenType': 'EOF_TOKEN'}
+                      {'line': 1, 'col': 11, 'tokenType': 'WHITESPACE'},
+                      {'line': 1, 'col': 12, 'tokenType': 'IDENT', 'value': 'red'},
+                      {'line': 1, 'col': 15, 'tokenType': 'EOF_TOKEN'},
                     ],
-                    'important': false
-                  }]
-                }]
-              }]
-            },
-            {
-              'line': 7,
-              'col': 0,
-              'tokenType': 'AT_RULE',
-              'name': 'font-face',
-              'prelude': [
-                {'line': 7, 'col': 10, 'tokenType': 'WHITESPACE'},
-                {'line': 7, 'col': 11, 'tokenType': 'EOF_TOKEN'}
-              ],
-              'declarations': [
-                {
-                  'line': 8,
-                  'col': 2,
-                  'tokenType': 'DECLARATION',
-                  'name': 'font-family',
-                  'value': [
-                    {'line': 8, 'col': 14, 'tokenType': 'WHITESPACE'}, {
-                      'line': 8,
-                      'col': 15,
-                      'tokenType': 'STRING',
-                      'value': 'MyFont'
-                    },
-                    {'line': 8, 'col': 23, 'tokenType': 'EOF_TOKEN'}
-                  ],
-                  'important': false
+                    'important': false,
+                  }],
                 },
                 {
-                  'line': 9,
-                  'col': 2,
-                  'tokenType': 'DECLARATION',
-                  'name': 'src',
-                  'value': [
-                    {'line': 9, 'col': 6, 'tokenType': 'WHITESPACE'}, {
-                      'line': 9,
-                      'col': 7,
-                      'tokenType': 'FUNCTION_TOKEN',
-                      'value': 'url'
+                  'line': 2,
+                  'col': 0,
+                  'tokenType': 'AT_RULE',
+                  'name': 'media',
+                  'prelude': [
+                    {'line': 2, 'col': 6, 'tokenType': 'WHITESPACE'},
+                    {'line': 2, 'col': 7, 'tokenType': 'IDENT', 'value': 'print'},
+                    {'line': 2, 'col': 12, 'tokenType': 'WHITESPACE'},
+                    {'line': 2, 'col': 13, 'tokenType': 'EOF_TOKEN'},
+                  ],
+                  'declarations': [],
+                  'rules': [{
+                    'line': 3,
+                    'col': 2,
+                    'tokenType': 'AT_RULE',
+                    'name': 'media',
+                    'prelude': [
+                      {'line': 3, 'col': 8, 'tokenType': 'WHITESPACE'},
+                      {'line': 3, 'col': 9, 'tokenType': 'IDENT', 'value': 'print'},
+                      {'line': 3, 'col': 14, 'tokenType': 'WHITESPACE'},
+                      {'line': 3, 'col': 15, 'tokenType': 'EOF_TOKEN'},
+                    ],
+                    'declarations': [],
+                    'rules': [{
+                      'line': 4,
+                      'col': 4,
+                      'tokenType': 'QUALIFIED_RULE',
+                      'prelude': [
+                        {'line': 4, 'col': 4, 'tokenType': 'IDENT', 'value': 'h2'},
+                        {'line': 4, 'col': 6, 'tokenType': 'DELIM', 'value': '.'},
+                        {'line': 4, 'col': 7, 'tokenType': 'IDENT', 'value': 'bar'},
+                        {'line': 4, 'col': 10, 'tokenType': 'WHITESPACE'},
+                        {'line': 4, 'col': 11, 'tokenType': 'EOF_TOKEN'},
+                      ],
+                      'declarations': [{
+                        'line': 4,
+                        'col': 13,
+                        'tokenType': 'DECLARATION',
+                        'name': 'size',
+                        'value': [
+                          {'line': 4, 'col': 18, 'tokenType': 'WHITESPACE'}, {
+                            'line': 4,
+                            'col': 19,
+                            'tokenType': 'DIMENSION',
+                            'type': 'integer',
+                            'value': 4,
+                            'repr': '4',
+                            'unit': 'px',
+                          },
+                          {'line': 4, 'col': 22, 'tokenType': 'EOF_TOKEN'},
+                        ],
+                        'important': false,
+                      }],
+                    }],
+                  }],
+                },
+                {
+                  'line': 7,
+                  'col': 0,
+                  'tokenType': 'AT_RULE',
+                  'name': 'font-face',
+                  'prelude': [
+                    {'line': 7, 'col': 10, 'tokenType': 'WHITESPACE'},
+                    {'line': 7, 'col': 11, 'tokenType': 'EOF_TOKEN'},
+                  ],
+                  'declarations': [
+                    {
+                      'line': 8,
+                      'col': 2,
+                      'tokenType': 'DECLARATION',
+                      'name': 'font-family',
+                      'value': [
+                        {'line': 8, 'col': 14, 'tokenType': 'WHITESPACE'}, {
+                          'line': 8,
+                          'col': 15,
+                          'tokenType': 'STRING',
+                          'value': 'MyFont',
+                        },
+                        {'line': 8, 'col': 23, 'tokenType': 'EOF_TOKEN'},
+                      ],
+                      'important': false,
                     },
                     {
                       'line': 9,
-                      'col': 11,
-                      'tokenType': 'STRING',
-                      'value': 'foo.ttf'
+                      'col': 2,
+                      'tokenType': 'DECLARATION',
+                      'name': 'src',
+                      'value': [
+                        {'line': 9, 'col': 6, 'tokenType': 'WHITESPACE'}, {
+                          'line': 9,
+                          'col': 7,
+                          'tokenType': 'FUNCTION_TOKEN',
+                          'value': 'url',
+                        },
+                        {
+                          'line': 9,
+                          'col': 11,
+                          'tokenType': 'STRING',
+                          'value': 'foo.ttf',
+                        },
+                        {'line': 9, 'col': 20, 'tokenType': 'CLOSE_PAREN'},
+                        {'line': 9, 'col': 21, 'tokenType': 'EOF_TOKEN'},
+                      ],
+                      'important': false,
                     },
-                    {'line': 9, 'col': 20, 'tokenType': 'CLOSE_PAREN'},
-                    {'line': 9, 'col': 21, 'tokenType': 'EOF_TOKEN'}
                   ],
-                  'important': false
-                }
+                  'rules': [],
+                },
               ],
-              'rules': []
-            }
-          ],
-          'eof': {'line': 10, 'col': 1, 'tokenType': 'EOF_TOKEN'}
-        },
-        sheet);
-     });
+              'eof': {'line': 10, 'col': 1, 'tokenType': 'EOF_TOKEN'},
+            },
+            sheet);
+      });
 
   it('generates errors not assertions for invalid css', () => {
-    const css = '#foo { foo.bar {} }\n' +  // qual. rule inside declarations
-        '@font-face { @media {} }\n' +     // @rule inside declarations
-        '@media { @gregable }\n' +         // unrecognized @rule, ignored
-        'color: red;\n';  // declaration outside qualified rule.
+    const css = '#foo { foo.bar {} }\n' + // qual. rule inside declarations
+        '@font-face { @media {} }\n' + // @rule inside declarations
+        '@media { @gregable }\n' + // unrecognized @rule, ignored
+        'color: red;\n'; // declaration outside qualified rule.
     const errors = [];
     const tokenlist = parse_css.tokenize(css, 1, 0, errors);
     parse_css.parseAStylesheet(
@@ -696,22 +696,22 @@ describe('parseAStylesheet', () => {
             'col': 7,
             'tokenType': 'ERROR',
             'code': 'CSS_SYNTAX_INCOMPLETE_DECLARATION',
-            'params': ['style']
+            'params': ['style'],
           },
           {
             'line': 2,
             'col': 13,
             'tokenType': 'ERROR',
             'code': 'CSS_SYNTAX_INVALID_AT_RULE',
-            'params': ['style', 'media']
+            'params': ['style', 'media'],
           },
           {
             'line': 4,
             'col': 0,
             'tokenType': 'ERROR',
             'code': 'CSS_SYNTAX_EOF_IN_PRELUDE_OF_QUALIFIED_RULE',
-            'params': ['style']
-          }
+            'params': ['style'],
+          },
         ],
         errors);
   });
@@ -730,7 +730,7 @@ describe('parseAStylesheet', () => {
           'col': 5,
           'tokenType': 'ERROR',
           'code': 'CSS_SYNTAX_INCOMPLETE_DECLARATION',
-          'params': ['style']
+          'params': ['style'],
         }],
         errors);
     assertJSONEquals(
@@ -746,10 +746,10 @@ describe('parseAStylesheet', () => {
               'name': 'gregable',
               'prelude': [
                 {'line': 1, 'col': 9, 'tokenType': 'WHITESPACE'},
-                {'line': 1, 'col': 10, 'tokenType': 'EOF_TOKEN'}
+                {'line': 1, 'col': 10, 'tokenType': 'EOF_TOKEN'},
               ],
               'declarations': [],
-              'rules': []
+              'rules': [],
             },
             {
               'line': 2,
@@ -758,12 +758,12 @@ describe('parseAStylesheet', () => {
               'prelude': [
                 {'line': 2, 'col': 0, 'tokenType': 'DELIM', 'value': '.'},
                 {'line': 2, 'col': 1, 'tokenType': 'IDENT', 'value': 'foo'},
-                {'line': 2, 'col': 4, 'tokenType': 'EOF_TOKEN'}
+                {'line': 2, 'col': 4, 'tokenType': 'EOF_TOKEN'},
               ],
-              'declarations': []
-            }
+              'declarations': [],
+            },
           ],
-          'eof': {'line': 2, 'col': 10, 'tokenType': 'EOF_TOKEN'}
+          'eof': {'line': 2, 'col': 10, 'tokenType': 'EOF_TOKEN'},
         },
         sheet);
   });
@@ -787,54 +787,54 @@ describe('parseAStylesheet', () => {
          [{'line': 1, 'col': 0, 'tokenType': 'AT_RULE', 'name': 'media',
            'prelude':
            [{'line': 1, 'col': 6, 'tokenType': 'WHITESPACE'},
-            {'line': 1, 'col': 7, 'tokenType': 'IDENT', 'value': 'print'},
-            {'line': 1, 'col': 12, 'tokenType': 'WHITESPACE'},
-            {'line': 1, 'col': 13, 'tokenType': 'EOF_TOKEN'}], 'declarations':
+             {'line': 1, 'col': 7, 'tokenType': 'IDENT', 'value': 'print'},
+             {'line': 1, 'col': 12, 'tokenType': 'WHITESPACE'},
+             {'line': 1, 'col': 13, 'tokenType': 'EOF_TOKEN'}], 'declarations':
            [], 'rules':
            [{'line': 3, 'col': 0, 'tokenType': 'QUALIFIED_RULE', 'prelude':
              [{'line': 3, 'col': 0, 'tokenType': 'HASH', 'type': 'id',
                'value': 'navigation'},
-              {'line': 3, 'col': 11, 'tokenType': 'WHITESPACE'},
-              {'line': 3, 'col': 12, 'tokenType': 'EOF_TOKEN'}],
-             'declarations':
+             {'line': 3, 'col': 11, 'tokenType': 'WHITESPACE'},
+             {'line': 3, 'col': 12, 'tokenType': 'EOF_TOKEN'}],
+           'declarations':
              [{'line': 3, 'col': 14, 'tokenType': 'DECLARATION', 'name':
                'display', 'value':
                [{'line': 3, 'col': 22, 'tokenType': 'WHITESPACE'},
-                {'line': 3, 'col': 23, 'tokenType': 'IDENT', 'value':
+                 {'line': 3, 'col': 23, 'tokenType': 'IDENT', 'value':
                  'none'},
-                {'line': 3, 'col': 27, 'tokenType': 'WHITESPACE'},
-                {'line': 3, 'col': 28, 'tokenType': 'EOF_TOKEN'}],
-               'important': false}]},
-            {'line': 4, 'col': 0, 'tokenType': 'AT_RULE', 'name':
+                 {'line': 3, 'col': 27, 'tokenType': 'WHITESPACE'},
+                 {'line': 3, 'col': 28, 'tokenType': 'EOF_TOKEN'}],
+             'important': false}]},
+           {'line': 4, 'col': 0, 'tokenType': 'AT_RULE', 'name':
              'media', 'prelude':
              [{'line': 4, 'col': 6, 'tokenType': 'WHITESPACE'},
-              {'line': 4, 'col': 7, 'tokenType': 'OPEN_PAREN'},
-              {'line': 4, 'col': 8, 'tokenType': 'IDENT', 'value':
+               {'line': 4, 'col': 7, 'tokenType': 'OPEN_PAREN'},
+               {'line': 4, 'col': 8, 'tokenType': 'IDENT', 'value':
                'max-width'},
-              {'line': 4, 'col': 17, 'tokenType': 'COLON'},
-              {'line': 4, 'col': 18, 'tokenType': 'WHITESPACE'},
-              {'line': 4, 'col': 19, 'tokenType': 'DIMENSION', 'type':
+               {'line': 4, 'col': 17, 'tokenType': 'COLON'},
+               {'line': 4, 'col': 18, 'tokenType': 'WHITESPACE'},
+               {'line': 4, 'col': 19, 'tokenType': 'DIMENSION', 'type':
                'integer', 'value': 12, 'repr': '12', 'unit': 'cm'},
-              {'line': 4, 'col': 23, 'tokenType': 'CLOSE_PAREN'},
-              {'line': 4, 'col': 24, 'tokenType': 'WHITESPACE'},
-              {'line': 4, 'col': 25, 'tokenType': 'EOF_TOKEN'}],
-             'declarations': [], 'rules':
+               {'line': 4, 'col': 23, 'tokenType': 'CLOSE_PAREN'},
+               {'line': 4, 'col': 24, 'tokenType': 'WHITESPACE'},
+               {'line': 4, 'col': 25, 'tokenType': 'EOF_TOKEN'}],
+           'declarations': [], 'rules':
              [{'line': 6, 'col': 2, 'tokenType': 'QUALIFIED_RULE',
                'prelude':
                [{'line': 6, 'col': 2, 'tokenType': 'DELIM', 'value':
                  '.'},
-                {'line': 6, 'col': 3, 'tokenType': 'IDENT', 'value':
+               {'line': 6, 'col': 3, 'tokenType': 'IDENT', 'value':
                  'note'},
-                {'line': 6, 'col': 7, 'tokenType': 'WHITESPACE'},
-                {'line': 6, 'col': 8, 'tokenType': 'EOF_TOKEN'}],
+               {'line': 6, 'col': 7, 'tokenType': 'WHITESPACE'},
+               {'line': 6, 'col': 8, 'tokenType': 'EOF_TOKEN'}],
                'declarations':
                [{'line': 6, 'col': 10, 'tokenType': 'DECLARATION',
                  'name': 'float', 'value':
                  [{'line': 6, 'col': 16, 'tokenType': 'WHITESPACE'},
-                  {'line': 6, 'col': 17, 'tokenType': 'IDENT', 'value':
+                   {'line': 6, 'col': 17, 'tokenType': 'IDENT', 'value':
                    'none'},
-                  {'line': 6, 'col': 21, 'tokenType': 'WHITESPACE'},
-                  {'line': 6, 'col': 22, 'tokenType': 'EOF_TOKEN'}],
+                   {'line': 6, 'col': 21, 'tokenType': 'WHITESPACE'},
+                   {'line': 6, 'col': 22, 'tokenType': 'EOF_TOKEN'}],
                  'important': false}]}]}]}], 'eof':
          {'line': 7, 'col': 1, 'tokenType': 'EOF_TOKEN'}},
         sheet);
@@ -861,7 +861,7 @@ describe('parseAStylesheet', () => {
             'prelude': [
               {'line': 1, 'col': 1, 'tokenType': 'IDENT', 'value': 'h1'},
               {'line': 1, 'col': 3, 'tokenType': 'WHITESPACE'},
-              {'line': 1, 'col': 4, 'tokenType': 'EOF_TOKEN'}
+              {'line': 1, 'col': 4, 'tokenType': 'EOF_TOKEN'},
             ],
             'declarations': [{
               'line': 1,
@@ -871,12 +871,12 @@ describe('parseAStylesheet', () => {
               'value': [
                 {'line': 1, 'col': 12, 'tokenType': 'WHITESPACE'},
                 {'line': 1, 'col': 13, 'tokenType': 'IDENT', 'value': 'blue'},
-                {'line': 1, 'col': 17, 'tokenType': 'EOF_TOKEN'}
+                {'line': 1, 'col': 17, 'tokenType': 'EOF_TOKEN'},
               ],
-              'important': false
-            }]
+              'important': false,
+            }],
           }],
-          'eof': {'line': 1, 'col': 21, 'tokenType': 'EOF_TOKEN'}
+          'eof': {'line': 1, 'col': 21, 'tokenType': 'EOF_TOKEN'},
         },
         sheet);
     assertStrictEqual(0, errors.length);
@@ -892,7 +892,7 @@ describe('parseAStylesheet', () => {
     assertJSONEquals(
         [
           {'line': 1, 'col': 0, 'tokenType': 'DELIM', 'value': '*'},
-          {'line': 1, 'col': 1, 'tokenType': 'EOF_TOKEN'}
+          {'line': 1, 'col': 1, 'tokenType': 'EOF_TOKEN'},
         ],
         parseSelectorForTest('*'));
   });
@@ -901,7 +901,7 @@ describe('parseAStylesheet', () => {
     assertJSONEquals(
         [
           {'line': 1, 'col': 0, 'tokenType': 'IDENT', 'value': 'E'},
-          {'line': 1, 'col': 1, 'tokenType': 'EOF_TOKEN'}
+          {'line': 1, 'col': 1, 'tokenType': 'EOF_TOKEN'},
         ],
         parseSelectorForTest('E'));
   });
@@ -913,7 +913,7 @@ describe('parseAStylesheet', () => {
           {'line': 1, 'col': 1, 'tokenType': 'OPEN_SQUARE'},
           {'line': 1, 'col': 2, 'tokenType': 'IDENT', 'value': 'foo'},
           {'line': 1, 'col': 5, 'tokenType': 'CLOSE_SQUARE'},
-          {'line': 1, 'col': 6, 'tokenType': 'EOF_TOKEN'}
+          {'line': 1, 'col': 6, 'tokenType': 'EOF_TOKEN'},
         ],
         parseSelectorForTest('E[foo]'));
   });
@@ -927,7 +927,7 @@ describe('parseAStylesheet', () => {
           {'line': 1, 'col': 5, 'tokenType': 'DELIM', 'value': '='},
           {'line': 1, 'col': 6, 'tokenType': 'STRING', 'value': 'bar'},
           {'line': 1, 'col': 11, 'tokenType': 'CLOSE_SQUARE'},
-          {'line': 1, 'col': 12, 'tokenType': 'EOF_TOKEN'}
+          {'line': 1, 'col': 12, 'tokenType': 'EOF_TOKEN'},
         ],
         parseSelectorForTest('E[foo="bar"]'));
   });
@@ -953,7 +953,7 @@ describe('extractUrls', () => {
           'col': 37,
           'tokenType': 'PARSED_CSS_URL',
           'atRuleScope': 'font-face',
-          'utf8Url': 'http://foo.com/bar.ttf'
+          'utf8Url': 'http://foo.com/bar.ttf',
         }],
         parsedUrls);
   });
@@ -977,7 +977,7 @@ describe('extractUrls', () => {
           'col': 23,
           'tokenType': 'PARSED_CSS_URL',
           'atRuleScope': '',
-          'utf8Url': 'http://a.com/b/c=d&e=f_g*h'
+          'utf8Url': 'http://a.com/b/c=d&e=f_g*h',
         }],
         parsedUrls);
   });
@@ -1005,36 +1005,36 @@ describe('extractUrls', () => {
             'col': 33,
             'tokenType': 'PARSED_CSS_URL',
             'atRuleScope': '',
-            'utf8Url': '4.png'
+            'utf8Url': '4.png',
           },
           {
             'line': 1,
             'col': 80,
             'tokenType': 'PARSED_CSS_URL',
             'atRuleScope': '',
-            'utf8Url': 'http://a.com/b.png'
+            'utf8Url': 'http://a.com/b.png',
           },
           {
             'line': 1,
             'col': 147,
             'tokenType': 'PARSED_CSS_URL',
             'atRuleScope': 'font-face',
-            'utf8Url': 'http://a.com/1.woff'
+            'utf8Url': 'http://a.com/1.woff',
           },
           {
             'line': 1,
             'col': 189,
             'tokenType': 'PARSED_CSS_URL',
             'atRuleScope': 'font-face',
-            'utf8Url': 'http://b.com/1.ttf'
+            'utf8Url': 'http://b.com/1.ttf',
           },
           {
             'line': 1,
             'col': 238,
             'tokenType': 'PARSED_CSS_URL',
             'atRuleScope': 'font-face',
-            'utf8Url': ''
-          }
+            'utf8Url': '',
+          },
         ],
         parsedUrls);
   });
@@ -1058,15 +1058,15 @@ describe('extractUrls', () => {
             'col': 30,
             'tokenType': 'PARSED_CSS_URL',
             'atRuleScope': '',
-            'utf8Url': '4.png'
+            'utf8Url': '4.png',
           },
           {
             'line': 4,
             'col': 17,
             'tokenType': 'PARSED_CSS_URL',
             'atRuleScope': '',
-            'utf8Url': 'http://a.com/b.png'
-          }
+            'utf8Url': 'http://a.com/b.png',
+          },
         ],
         parsedUrls);
   });
@@ -1095,7 +1095,7 @@ describe('extractUrls', () => {
           'col': 11,
           'tokenType': 'ERROR',
           'code': 'CSS_SYNTAX_BAD_URL',
-          'params': ['style']
+          'params': ['style'],
         }],
         errors);
     assertJSONEquals([], parsedUrls);
@@ -1133,7 +1133,7 @@ describe('parseMediaQueries', () => {
           'col': 0,
           'code': 'CSS_SYNTAX_MALFORMED_MEDIA_QUERY',
           'params': ['style'],
-          'tokenType': 'ERROR'
+          'tokenType': 'ERROR',
         }],
         errors);
   });
@@ -1197,7 +1197,7 @@ describe('parseMediaQueries', () => {
       ['screen and (color), braille', 'screen,braille', 'color'],
       [
         'screen and (min-width: 50px) and (max-width:51px)', 'screen',
-        'min-width,max-width'
+        'min-width,max-width',
       ],
       ['(color) and (max-width:abc)', '', 'color,max-width'],
       ['only screen', 'screen', ''],
@@ -1221,12 +1221,12 @@ describe('parseMediaQueries', () => {
 
       let seenTypes = '';
       for (const token of mediaTypes) {
-        if (seenTypes !== '') seenTypes += ',';
+        if (seenTypes !== '') {seenTypes += ',';}
         seenTypes += token.value;
       }
       let seenFeatures = '';
       for (const token of mediaFeatures) {
-        if (seenFeatures !== '') seenFeatures += ',';
+        if (seenFeatures !== '') {seenFeatures += ',';}
         seenFeatures += token.value;
       }
 
@@ -1234,7 +1234,7 @@ describe('parseMediaQueries', () => {
       assertStrictEqual(expectedFeatures, seenFeatures);
     }
   });
-});  // describe('parseMediaQueries')
+}); // describe('parseMediaQueries')
 
 /**
  * @param {string} selector
@@ -1260,7 +1260,7 @@ describe('css_selectors', () => {
     assertJSONEquals(
         [
           {'line': 1, 'col': 0, 'tokenType': 'DELIM', 'value': '*'},
-          {'line': 1, 'col': 1, 'tokenType': 'EOF_TOKEN'}
+          {'line': 1, 'col': 1, 'tokenType': 'EOF_TOKEN'},
         ],
         tokens);
     let tokenStream = new parse_css.TokenStream(tokens);
@@ -1303,9 +1303,9 @@ describe('css_selectors', () => {
             'col': 0,
             'tokenType': 'HASH',
             'type': 'id',
-            'value': 'hello-world'
+            'value': 'hello-world',
           },
-          {'line': 1, 'col': 12, 'tokenType': 'EOF_TOKEN'}
+          {'line': 1, 'col': 12, 'tokenType': 'EOF_TOKEN'},
         ],
         tokens);
     const tokenStream = new parse_css.TokenStream(tokens);
@@ -1322,7 +1322,7 @@ describe('css_selectors', () => {
         [
           {'line': 1, 'col': 0, 'tokenType': 'DELIM', 'value': '.'},
           {'line': 1, 'col': 1, 'tokenType': 'IDENT', 'value': 'hello-world'},
-          {'line': 1, 'col': 12, 'tokenType': 'EOF_TOKEN'}
+          {'line': 1, 'col': 12, 'tokenType': 'EOF_TOKEN'},
         ],
         tokens);
     const tokenStream = new parse_css.TokenStream(tokens);
@@ -1344,9 +1344,9 @@ describe('css_selectors', () => {
             'col': 3,
             'tokenType': 'HASH',
             'type': 'id',
-            'value': 'c'
+            'value': 'c',
           },
-          {'line': 1, 'col': 5, 'tokenType': 'EOF_TOKEN'}
+          {'line': 1, 'col': 5, 'tokenType': 'EOF_TOKEN'},
         ],
         tokens);
     let tokenStream = new parse_css.TokenStream(tokens);
@@ -1364,8 +1364,8 @@ describe('css_selectors', () => {
             'col': 0,
             'elementName': 'b',
             'namespacePrefix': 'a',
-            'tokenType': 'TYPE_SELECTOR'
-          }
+            'tokenType': 'TYPE_SELECTOR',
+          },
         },
         sequence);
     tokens = parseSelectorForTest('a|foo#bar.baz');
@@ -1382,16 +1382,16 @@ describe('css_selectors', () => {
               'line': 1,
               'col': 9,
               'value': 'baz',
-              'tokenType': 'CLASS_SELECTOR'
-            }
+              'tokenType': 'CLASS_SELECTOR',
+            },
           ],
           'typeSelector': {
             'line': 1,
             'col': 0,
             'elementName': 'foo',
             'namespacePrefix': 'a',
-            'tokenType': 'TYPE_SELECTOR'
-          }
+            'tokenType': 'TYPE_SELECTOR',
+          },
         },
         sequence);
   });
@@ -1405,7 +1405,7 @@ describe('css_selectors', () => {
           {'line': 1, 'col': 4, 'tokenType': 'IDENT', 'value': 'bar'},
           {'line': 1, 'col': 7, 'tokenType': 'WHITESPACE'},
           {'line': 2, 'col': 1, 'tokenType': 'IDENT', 'value': 'baz'},
-          {'line': 2, 'col': 4, 'tokenType': 'EOF_TOKEN'}
+          {'line': 2, 'col': 4, 'tokenType': 'EOF_TOKEN'},
         ],
         tokens);
     const tokenStream = new parse_css.TokenStream(tokens);
@@ -1430,8 +1430,8 @@ describe('css_selectors', () => {
                 'col': 0,
                 'elementName': 'foo',
                 'namespacePrefix': null,
-                'tokenType': 'TYPE_SELECTOR'
-              }
+                'tokenType': 'TYPE_SELECTOR',
+              },
             },
             'tokenType': 'COMBINATOR',
             'right': {
@@ -1444,9 +1444,9 @@ describe('css_selectors', () => {
                 'col': 4,
                 'elementName': 'bar',
                 'namespacePrefix': null,
-                'tokenType': 'TYPE_SELECTOR'
-              }
-            }
+                'tokenType': 'TYPE_SELECTOR',
+              },
+            },
           },
           'tokenType': 'COMBINATOR',
           'right': {
@@ -1459,9 +1459,9 @@ describe('css_selectors', () => {
               'col': 1,
               'elementName': 'baz',
               'namespacePrefix': null,
-              'tokenType': 'TYPE_SELECTOR'
-            }
-          }
+              'tokenType': 'TYPE_SELECTOR',
+            },
+          },
         },
         selector);
   });
@@ -1478,7 +1478,7 @@ describe('css_selectors', () => {
           {'line': 2, 'col': 0, 'tokenType': 'COMMA'},
           {'line': 2, 'col': 1, 'tokenType': 'WHITESPACE'},
           {'line': 2, 'col': 2, 'tokenType': 'IDENT', 'value': 'baz'},
-          {'line': 2, 'col': 5, 'tokenType': 'EOF_TOKEN'}
+          {'line': 2, 'col': 5, 'tokenType': 'EOF_TOKEN'},
         ],
         tokens);
     const tokenStream = new parse_css.TokenStream(tokens);
@@ -1499,8 +1499,8 @@ describe('css_selectors', () => {
                 'col': 0,
                 'elementName': 'foo',
                 'namespacePrefix': null,
-                'tokenType': 'TYPE_SELECTOR'
-              }
+                'tokenType': 'TYPE_SELECTOR',
+              },
             },
             {
               'line': 1,
@@ -1512,8 +1512,8 @@ describe('css_selectors', () => {
                 'col': 5,
                 'elementName': 'bar',
                 'namespacePrefix': null,
-                'tokenType': 'TYPE_SELECTOR'
-              }
+                'tokenType': 'TYPE_SELECTOR',
+              },
             },
             {
               'line': 2,
@@ -1525,11 +1525,11 @@ describe('css_selectors', () => {
                 'col': 2,
                 'elementName': 'baz',
                 'namespacePrefix': null,
-                'tokenType': 'TYPE_SELECTOR'
-              }
-            }
+                'tokenType': 'TYPE_SELECTOR',
+              },
+            },
           ],
-          'tokenType': 'SELECTORS_GROUP'
+          'tokenType': 'SELECTORS_GROUP',
         },
         selector);
   });
@@ -1545,10 +1545,10 @@ describe('css_selectors', () => {
             'line': 1,
             'col': 7,
             'tokenType': 'STRING',
-            'value': 'http://www.w3.org/'
+            'value': 'http://www.w3.org/',
           },
           {'line': 1, 'col': 27, 'tokenType': 'CLOSE_SQUARE'},
-          {'line': 1, 'col': 28, 'tokenType': 'EOF_TOKEN'}
+          {'line': 1, 'col': 28, 'tokenType': 'EOF_TOKEN'},
         ],
         tokens);
     const tokenStream = new parse_css.TokenStream(tokens);
@@ -1566,15 +1566,15 @@ describe('css_selectors', () => {
             'value': 'http://www.w3.org/',
             'attrName': 'href',
             'matchOperator': '=',
-            'namespacePrefix': null
+            'namespacePrefix': null,
           }],
           'typeSelector': {
             'line': 1,
             'col': 0,
             'elementName': 'a',
             'namespacePrefix': null,
-            'tokenType': 'TYPE_SELECTOR'
-          }
+            'tokenType': 'TYPE_SELECTOR',
+          },
         },
         selector);
   });
@@ -1600,7 +1600,7 @@ describe('css_selectors', () => {
               'value': 'v1',
               'attrName': 'attr1',
               'matchOperator': '=',
-              'namespacePrefix': null
+              'namespacePrefix': null,
             },
             {
               'line': 1,
@@ -1609,7 +1609,7 @@ describe('css_selectors', () => {
               'value': 'value2',
               'attrName': 'attr2',
               'matchOperator': '=',
-              'namespacePrefix': null
+              'namespacePrefix': null,
             },
             {
               'line': 2,
@@ -1618,7 +1618,7 @@ describe('css_selectors', () => {
               'value': 'foo',
               'attrName': 'attr3',
               'matchOperator': '~=',
-              'namespacePrefix': null
+              'namespacePrefix': null,
             },
             {
               'line': 2,
@@ -1627,7 +1627,7 @@ describe('css_selectors', () => {
               'value': 'bar',
               'attrName': 'attr4',
               'matchOperator': '|=',
-              'namespacePrefix': null
+              'namespacePrefix': null,
             },
             {
               'line': 2,
@@ -1636,7 +1636,7 @@ describe('css_selectors', () => {
               'value': 'baz',
               'attrName': 'attr5',
               'matchOperator': '|=',
-              'namespacePrefix': null
+              'namespacePrefix': null,
             },
             {
               'line': 2,
@@ -1645,7 +1645,7 @@ describe('css_selectors', () => {
               'value': 'boo',
               'attrName': 'attr6',
               'matchOperator': '$=',
-              'namespacePrefix': null
+              'namespacePrefix': null,
             },
             {
               'line': 2,
@@ -1654,7 +1654,7 @@ describe('css_selectors', () => {
               'value': 'bang',
               'attrName': 'attr7',
               'matchOperator': '*=',
-              'namespacePrefix': null
+              'namespacePrefix': null,
             },
             {
               'line': 2,
@@ -1663,16 +1663,16 @@ describe('css_selectors', () => {
               'value': '',
               'attrName': 'attr8',
               'matchOperator': '',
-              'namespacePrefix': null
-            }
+              'namespacePrefix': null,
+            },
           ],
           'typeSelector': {
             'line': 1,
             'col': 0,
             'tokenType': 'TYPE_SELECTOR',
             'elementName': 'elem',
-            'namespacePrefix': null
-          }
+            'namespacePrefix': null,
+          },
         },
         selector);
   });
@@ -1689,7 +1689,7 @@ describe('css_selectors', () => {
           {'line': 1, 'col': 5, 'tokenType': 'FUNCTION_TOKEN', 'value': 'lang'},
           {'line': 1, 'col': 10, 'tokenType': 'IDENT', 'value': 'fr-be'},
           {'line': 1, 'col': 15, 'tokenType': 'CLOSE_PAREN'},
-          {'line': 1, 'col': 16, 'tokenType': 'EOF_TOKEN'}
+          {'line': 1, 'col': 16, 'tokenType': 'EOF_TOKEN'},
         ],
         tokens);
     const tokenStream = new parse_css.TokenStream(tokens);
@@ -1706,7 +1706,7 @@ describe('css_selectors', () => {
               'col': 1,
               'name': 'b',
               'isClass': false,
-              'tokenType': 'PSEUDO_SELECTOR'
+              'tokenType': 'PSEUDO_SELECTOR',
             },
             {
               'line': 1,
@@ -1717,22 +1717,22 @@ describe('css_selectors', () => {
                   'line': 1,
                   'col': 5,
                   'tokenType': 'FUNCTION_TOKEN',
-                  'value': 'lang'
+                  'value': 'lang',
                 },
                 {'line': 1, 'col': 10, 'tokenType': 'IDENT', 'value': 'fr-be'},
-                {'line': 1, 'col': 15, 'tokenType': 'EOF_TOKEN'}
+                {'line': 1, 'col': 15, 'tokenType': 'EOF_TOKEN'},
               ],
               'isClass': true,
-              'tokenType': 'PSEUDO_SELECTOR'
-            }
+              'tokenType': 'PSEUDO_SELECTOR',
+            },
           ],
           'typeSelector': {
             'line': 1,
             'col': 0,
             'elementName': 'a',
             'namespacePrefix': null,
-            'tokenType': 'TYPE_SELECTOR'
-          }
+            'tokenType': 'TYPE_SELECTOR',
+          },
         },
         selector);
   });
@@ -1761,13 +1761,13 @@ describe('css_selectors', () => {
                   'line': 1,
                   'col': 7,
                   'tokenType': 'FUNCTION_TOKEN',
-                  'value': 'not'
+                  'value': 'not',
                 },
                 {'line': 1, 'col': 11, 'tokenType': 'COLON'},
                 {'line': 1, 'col': 12, 'tokenType': 'IDENT', 'value': 'link'},
-                {'line': 1, 'col': 16, 'tokenType': 'EOF_TOKEN'}
+                {'line': 1, 'col': 16, 'tokenType': 'EOF_TOKEN'},
               ],
-              'isClass': true
+              'isClass': true,
             },
             {
               'line': 1,
@@ -1779,26 +1779,26 @@ describe('css_selectors', () => {
                   'line': 1,
                   'col': 18,
                   'tokenType': 'FUNCTION_TOKEN',
-                  'value': 'not'
+                  'value': 'not',
                 },
                 {'line': 1, 'col': 22, 'tokenType': 'COLON'}, {
                   'line': 1,
                   'col': 23,
                   'tokenType': 'IDENT',
-                  'value': 'visited'
+                  'value': 'visited',
                 },
-                {'line': 1, 'col': 30, 'tokenType': 'EOF_TOKEN'}
+                {'line': 1, 'col': 30, 'tokenType': 'EOF_TOKEN'},
               ],
-              'isClass': true
-            }
+              'isClass': true,
+            },
           ],
           'typeSelector': {
             'line': 1,
             'col': 0,
             'tokenType': 'TYPE_SELECTOR',
             'elementName': '*',
-            'namespacePrefix': 'html'
-          }
+            'namespacePrefix': 'html',
+          },
         },
         selector);
   });
@@ -1814,7 +1814,7 @@ describe('css_selectors', () => {
           'col': 8,
           'line': 1,
           'params': ['style'],
-          'tokenType': 'ERROR'
+          'tokenType': 'ERROR',
         },
         selector);
   });
@@ -1863,8 +1863,8 @@ describe('css_selectors', () => {
                 'col': 0,
                 'elementName': 'a',
                 'namespacePrefix': null,
-                'tokenType': 'TYPE_SELECTOR'
-              }
+                'tokenType': 'TYPE_SELECTOR',
+              },
             },
             'tokenType': 'COMBINATOR',
             'right': {
@@ -1877,9 +1877,9 @@ describe('css_selectors', () => {
                 'col': 4,
                 'elementName': 'b',
                 'namespacePrefix': null,
-                'tokenType': 'TYPE_SELECTOR'
-              }
-            }
+                'tokenType': 'TYPE_SELECTOR',
+              },
+            },
           },
           'tokenType': 'COMBINATOR',
           'right': {
@@ -1892,9 +1892,9 @@ describe('css_selectors', () => {
               'col': 6,
               'elementName': 'c',
               'namespacePrefix': null,
-              'tokenType': 'TYPE_SELECTOR'
-            }
-          }
+              'tokenType': 'TYPE_SELECTOR',
+            },
+          },
         },
         visitor.combinatorNodes[2]);
   });

--- a/validator/engine/parse-srcset.js
+++ b/validator/engine/parse-srcset.js
@@ -92,16 +92,16 @@ parse_srcset.parseSrcset = function(srcset) {
       'g');
   let remainingSrcset = srcset;
   /** @type {!goog.structs.Set<string>} */
-  let seenWidthOrPixelDensity = new goog.structs.Set();
+  const seenWidthOrPixelDensity = new goog.structs.Set();
   /** @type {!parse_srcset.SrcsetParsingResult} */
   const result = new parse_srcset.SrcsetParsingResult();
   /** @type {!Array<parse_srcset.SrcsetSourceDef>} */
-  const srcsetImages = result.srcsetImages;
+  const {srcsetImages} = result;
   let source;
   while (source = imageCandidateRegex.exec(srcset)) {
-    let url = source[1];
+    const url = source[1];
     let widthOrPixelDensity = source[2];
-    let comma = source[3];
+    const comma = source[3];
     if (widthOrPixelDensity === undefined) {
       widthOrPixelDensity = '1x';
     }
@@ -113,7 +113,7 @@ parse_srcset.parseSrcset = function(srcset) {
       return result;
     }
     seenWidthOrPixelDensity.add(widthOrPixelDensity);
-    srcsetImages.push({url: url, widthOrPixelDensity: widthOrPixelDensity});
+    srcsetImages.push({url, widthOrPixelDensity});
     remainingSrcset = srcset.substr(imageCandidateRegex.lastIndex);
     // If no more srcset, break.
     if (srcset.length <= imageCandidateRegex.lastIndex) {

--- a/validator/engine/parse-srcset_test.js
+++ b/validator/engine/parse-srcset_test.js
@@ -98,8 +98,9 @@ describe('Srcset parseSrcset', () => {
   });
 
   it('should not accept multiple sources with duplicate width', () => {
-    let result = parse_srcset.parseSrcset(
+    const result = parse_srcset.parseSrcset(
         'image1 10w, image2 100w, image3 1000w, image4 10w');
+
     expect(result.success).toBe(false);
   });
 
@@ -140,7 +141,7 @@ describe('Srcset parseSrcset', () => {
     ]);
     test(' \n image,1x , \n  image,2x 2x\n', [
       {url: 'image,1x', widthOrPixelDensity: '1x'},
-      {url: 'image,2x', widthOrPixelDensity: '2x'}
+      {url: 'image,2x', widthOrPixelDensity: '2x'},
     ]);
     test(' \n image,1 \n ', [
       {url: 'image,1', widthOrPixelDensity: '1x'},
@@ -225,36 +226,46 @@ describe('Srcset parseSrcset', () => {
 
   it('should reject urls with spaces', () => {
     let result = parse_srcset.parseSrcset('image 1x png 1x');
+
     expect(result.success).toBe(false);
     result = parse_srcset.parseSrcset('image 1x png 1x, image-2x.png 2x');
+
     expect(result.success).toBe(false);
   });
 
   it('should reject width or pixel density with negatives', () => {
     let result = parse_srcset.parseSrcset('image.png -1x');
+
     expect(result.success).toBe(false);
     result = parse_srcset.parseSrcset('image.png 1x, image2.png -2x');
+
     expect(result.success).toBe(false);
     result = parse_srcset.parseSrcset('image.png -480w');
+
     expect(result.success).toBe(false);
     result = parse_srcset.parseSrcset('image.png 1x, image2.png -100w');
+
     expect(result.success).toBe(false);
   });
 
   it('should reject empty srcsets', () => {
     let result = parse_srcset.parseSrcset('');
+
     expect(result.success).toBe(false);
     result = parse_srcset.parseSrcset(' \n\t\f\r');
+
     expect(result.success).toBe(false);
   });
 
   it('should reject invalid text after valid srcsets', () => {
-    let result = parse_srcset.parseSrcset('image1, image2, ,,,');
+    const result = parse_srcset.parseSrcset('image1, image2, ,,,');
+
     expect(result.success).toBe(false);
   });
 
   it('should reject no comma between sources', () => {
-    let result = parse_srcset.parseSrcset('image1 100w image2 50w');
+    const result = parse_srcset.parseSrcset('image1 100w image2 50w');
+
     expect(result.success).toBe(false);
   });
 });

--- a/validator/engine/parse-url.js
+++ b/validator/engine/parse-url.js
@@ -69,36 +69,36 @@ function hostCharIsEnd(code) {
 function hostCharIsValid(code) {
   return (!isNaN(code) &&
           code > /* unprintable */ 0x1F &&
-          code !== /* ' ' */ 0x20  &&
-          code !== /* '!' */ 0x21  &&
-          code !== /* '"' */ 0x22  &&
-          code !== /* '#' */ 0x23  &&
-          code !== /* '$' */ 0x24  &&
-          code !== /* '%' */ 0x25  &&
-          code !== /* '&' */ 0x26  &&
-          code !== /* ''' */ 0x27  &&
-          code !== /* '(' */ 0x28  &&
-          code !== /* ')' */ 0x29  &&
-          code !== /* '*' */ 0x2A  &&
-          code !== /* '+' */ 0x2B  &&
-          code !== /* ',' */ 0x2C  &&
-          code !== /* '/' */ 0x2F  &&
-          code !== /* ':' */ 0x3A  &&
-          code !== /* ';' */ 0x3B  &&
-          code !== /* '<' */ 0x3C  &&
-          code !== /* '=' */ 0x3D  &&
-          code !== /* '>' */ 0x3E  &&
-          code !== /* '?' */ 0x3F  &&
-          code !== /* '@' */ 0x3A  &&
-          code !== /* '[' */ 0x5B  &&
-          code !== /* '\' */ 0x5C  &&
-          code !== /* ']' */ 0x5D  &&
-          code !== /* '^' */ 0x5E  &&
-          code !== /* '`' */ 0x60  &&
-          code !== /* '{' */ 0x7B  &&
-          code !== /* '|' */ 0x7C  &&
-          code !== /* '}' */ 0x7D  &&
-          code !== /* '~' */ 0x7E  &&
+          code !== /* ' ' */ 0x20 &&
+          code !== /* '!' */ 0x21 &&
+          code !== /* '"' */ 0x22 &&
+          code !== /* '#' */ 0x23 &&
+          code !== /* '$' */ 0x24 &&
+          code !== /* '%' */ 0x25 &&
+          code !== /* '&' */ 0x26 &&
+          code !== /* ''' */ 0x27 &&
+          code !== /* '(' */ 0x28 &&
+          code !== /* ')' */ 0x29 &&
+          code !== /* '*' */ 0x2A &&
+          code !== /* '+' */ 0x2B &&
+          code !== /* ',' */ 0x2C &&
+          code !== /* '/' */ 0x2F &&
+          code !== /* ':' */ 0x3A &&
+          code !== /* ';' */ 0x3B &&
+          code !== /* '<' */ 0x3C &&
+          code !== /* '=' */ 0x3D &&
+          code !== /* '>' */ 0x3E &&
+          code !== /* '?' */ 0x3F &&
+          code !== /* '@' */ 0x3A &&
+          code !== /* '[' */ 0x5B &&
+          code !== /* '\' */ 0x5C &&
+          code !== /* ']' */ 0x5D &&
+          code !== /* '^' */ 0x5E &&
+          code !== /* '`' */ 0x60 &&
+          code !== /* '{' */ 0x7B &&
+          code !== /* '|' */ 0x7C &&
+          code !== /* '}' */ 0x7D &&
+          code !== /* '~' */ 0x7E &&
           code !== /*     */ 0x7B);
 }
 
@@ -112,10 +112,10 @@ function hostIsIPv6Literal(host) {
   const hexRe = /^[0-9A-Fa-f]{1,4}$/;
   // IPv4 address
   const ipv4Re = /^([0-9]{1,3}\.){3}[0-9]{1,3}$/;
-  var hasEmpty = false;
+  let hasEmpty = false;
   const parts = host.split(':');
-  var numParts = parts.length;
-  for (var i = 0; i < parts.length; ++i) {
+  let numParts = parts.length;
+  for (let i = 0; i < parts.length; ++i) {
     const part = parts[i];
 
     // Look for empty parts, caused abbreviating contiguous zero values with
@@ -123,7 +123,7 @@ function hostIsIPv6Literal(host) {
     if (part === '') {
       // There can be exactly one empty 'part'
       if (hasEmpty)
-        return false;
+      {return false;}
       hasEmpty = true;
       // Leading and trailing empty parts are written as '::' resulting in
       // host.split returning two empty parts. We skip these in this case.
@@ -153,9 +153,9 @@ function hostIsIPv6Literal(host) {
   // There should be 8 parts, with an empty part possibly counting as more than
   // one.
   if (numParts > 8)
-    return false;
+  {return false;}
   if (numParts < 8 && !hasEmpty)
-    return false;
+  {return false;}
   return true;
 }
 
@@ -172,9 +172,9 @@ parse_url.URL = class {
     /** @type {boolean} */
     this.hasProtocol = false;
     /** @type {string} */
-    this.protocol = '';  // Guaranteed to be lower case.
+    this.protocol = ''; // Guaranteed to be lower case.
     /** @type {string} */
-    this.defaultProtocol = 'https';  // Must be set to a lower case value.
+    this.defaultProtocol = 'https'; // Must be set to a lower case value.
     /** @type {string} */
     this.schemeSpecificPart = '';
     /** @type {boolean} */
@@ -243,12 +243,12 @@ parse_url.URL = class {
     if (goog.string./*OK*/ startsWith(unparsed, 'https:')) {
       this.hasProtocol = true;
       this.protocol = 'https';
-      return unparsed.substr(6);  // skip over 'https:' prefix
+      return unparsed.substr(6); // skip over 'https:' prefix
     }
     if (goog.string./*OK*/ startsWith(unparsed, 'http:')) {
       this.hasProtocol = true;
       this.protocol = 'http';
-      return unparsed.substr(5);  // skip over 'http:' prefix
+      return unparsed.substr(5); // skip over 'http:' prefix
     }
 
     const colon = unparsed.indexOf(':');
@@ -271,8 +271,8 @@ parse_url.URL = class {
     this.protocol = unparsed.substr(0, colon).toLowerCase();
     unparsed = unparsed.substr(colon + 1);
 
-    if (this.protocol != "http" && this.protocol != "https" &&
-        this.protocol != "ftp" && this.protocol != "sftp") {
+    if (this.protocol != 'http' && this.protocol != 'https' &&
+        this.protocol != 'ftp' && this.protocol != 'sftp') {
       // For protocols like "foo:bar", we don't parse up the part after the
       // protocol, we just record it, eg "bar".
       this.schemeSpecificPart = unparsed;
@@ -315,7 +315,7 @@ parse_url.URL = class {
     if (goog.string./*OK*/ startsWith(host, '.') ||
         host.indexOf('..') !== -1) {
       this.isValid = false;
-    } else if (host.substr(-1) === '.') {  // strip trailing '.'.
+    } else if (host.substr(-1) === '.') { // strip trailing '.'.
       host = host.substr(0, host.length - 1);
     }
     return host;
@@ -335,7 +335,7 @@ parse_url.URL = class {
     let skipColons = false;
     if (unparsed !== '' && unparsed.charCodeAt(0) === /* '[' */ 0x5B) {
       skipColons = true;
-      idx++;  // skip over the '['
+      idx++; // skip over the '['
     }
 
     // look for '@' and ':', e.g. user:password@example.com:1234
@@ -347,9 +347,9 @@ parse_url.URL = class {
     for (; !hostCharIsEnd(charCode); charCode = unparsed.charCodeAt(++idx)) {
       switch (charCode) {
         case /* '@' */ 0x40:
-          atIdx = idx;  // save the last occurrence of '@'
+          atIdx = idx; // save the last occurrence of '@'
           passwordIdx = portIdx;
-          portIdx = -1;  // we have a login, so reset the port
+          portIdx = -1; // we have a login, so reset the port
 
           // Any [ before here must have been junk, or part of the password
           // so we reset.
@@ -362,7 +362,7 @@ parse_url.URL = class {
           break;
         case /* ':' */ 0x3A:
           if ((portIdx === -1) && !skipColons) {
-            portIdx = idx + 1;  // might be password; save as port anyway
+            portIdx = idx + 1; // might be password; save as port anyway
           }
           break;
         case /* '[' */ 0x5B:
@@ -401,7 +401,7 @@ parse_url.URL = class {
         unparsed.charCodeAt(hostEndIdx - 1) === /* ']' */ 0x5D &&
         hostBeginIdx != hostEndIdx) {
       isIPv6Literal = hostIsIPv6Literal(unparsed.substr(hostBeginIdx + 1,
-                                        hostEndIdx - hostBeginIdx - 2));
+          hostEndIdx - hostBeginIdx - 2));
       if (isIPv6Literal) {
         ++hostBeginIdx;
         --hostEndIdx;
@@ -416,7 +416,7 @@ parse_url.URL = class {
     }
     this.host = this.processHostDots_(host);
     if (this.host === '')
-      this.isValid = false;
+    {this.isValid = false;}
 
     // Extract the port, if present.
     if (portIdx !== -1) {
@@ -438,10 +438,10 @@ parse_url.URL = class {
       // 0 indicates a default port.
       if (this.port === 0) {
         this.port = {
-          "http": 80,
-          "https": 443,
-          "ftp": 21,
-          "sftp": 22}[this.protocol];
+          'http': 80,
+          'https': 443,
+          'ftp': 21,
+          'sftp': 22}[this.protocol];
       }
     }
 

--- a/validator/engine/parse-url_test.js
+++ b/validator/engine/parse-url_test.js
@@ -44,12 +44,12 @@ describe('parse_url', () => {
   });
 
   it('ignores Tab/CR/LF bytes', () => {
-    let urlString = ' f\ro\to\n:bar ';
-    let url = new parse_url.URL(urlString);
+    const urlString = ' f\ro\to\n:bar ';
+    const url = new parse_url.URL(urlString);
     assertStrictEqual('foo', url.protocol);
   });
 
-  it ('parses simple protocols',  () => {
+  it('parses simple protocols', () => {
     let urlString = 'http://example.com/';
     let url = new parse_url.URL(urlString);
     assertStrictEqual('http', url.protocol);
@@ -59,245 +59,246 @@ describe('parse_url', () => {
     assertStrictEqual('https', url.protocol);
   });
 
-  it ('parses with missing protocol', () => {
-    let urlString = 'example.com';
-    let url = new parse_url.URL(urlString);
+  it('parses with missing protocol', () => {
+    const urlString = 'example.com';
+    const url = new parse_url.URL(urlString);
     assertStrictEqual(true, url.isValid);
     assertStrictEqual(false, url.hasProtocol);
     assertStrictEqual(url.defaultProtocol, url.protocol);
-    assertStrictEqual('', url.host);  // example.com is a relative path
+    assertStrictEqual('', url.host); // example.com is a relative path
   });
 
-  it ('parses with invalid protocol characters',  () => {
-    let urlString = 'foo bar:baz';
-    let url = new parse_url.URL(urlString);
+  it('parses with invalid protocol characters', () => {
+    const urlString = 'foo bar:baz';
+    const url = new parse_url.URL(urlString);
     assertStrictEqual(false, url.hasProtocol);
     assertStrictEqual('https', url.protocol);
   });
 
-  it ('parses with utf8 protocol characters',  () => {
-    let urlString = '⚡:amp';
-    let url = new parse_url.URL(urlString);
+  it('parses with utf8 protocol characters', () => {
+    const urlString = '⚡:amp';
+    const url = new parse_url.URL(urlString);
     assertStrictEqual(false, url.hasProtocol);
     assertStrictEqual('https', url.protocol);
   });
 
-  it ('parses protocol with non-alpha protocol characters', () => {
-    let urlString = 'foo+bar-baz:baz';
-    let url = new parse_url.URL(urlString);
+  it('parses protocol with non-alpha protocol characters', () => {
+    const urlString = 'foo+bar-baz:baz';
+    const url = new parse_url.URL(urlString);
     assertStrictEqual(true, url.hasProtocol);
     assertStrictEqual('foo+bar-baz', url.protocol);
   });
 
-  it ('parses uncommon protocols, but not URLs', () => {
-    let urlString = 'whatsapp:i have no idea what this should contain';
-    let url = new parse_url.URL(urlString);
+  it('parses uncommon protocols, but not URLs', () => {
+    const urlString = 'whatsapp:i have no idea what this should contain';
+    const url = new parse_url.URL(urlString);
     assertStrictEqual(true, url.hasProtocol);
     assertStrictEqual('whatsapp', url.protocol);
     assertStrictEqual('i have no idea what this should contain',
         url.schemeSpecificPart);
   });
 
-  it ('parses basic login', () => {
-    let urlString = 'https://user:password@example.com/';
-    let url = new parse_url.URL(urlString);
+  it('parses basic login', () => {
+    const urlString = 'https://user:password@example.com/';
+    const url = new parse_url.URL(urlString);
     assertStrictEqual('user:password', url.login);
   });
 
-  it ('parses login with ipv6 host that has colons to confuse things', () => {
-    let urlString = 'https://user:password@[2001:0db8::85a3]/';
-    let url = new parse_url.URL(urlString);
+  it('parses login with ipv6 host that has colons to confuse things', () => {
+    const urlString = 'https://user:password@[2001:0db8::85a3]/';
+    const url = new parse_url.URL(urlString);
     assertStrictEqual('user:password', url.login);
   });
 
-  it ('parses login with ipv6 host and [ character in password', () => {
-    let urlString = 'https://user:pas[word@[2001:0db8::85a3]/';
-    let url = new parse_url.URL(urlString);
+  it('parses login with ipv6 host and [ character in password', () => {
+    const urlString = 'https://user:pas[word@[2001:0db8::85a3]/';
+    const url = new parse_url.URL(urlString);
     assertStrictEqual('user:pas[word', url.login);
   });
 
-  it ('parses login with port to confuse things', () => {
-    let urlString = 'https://user:password@example.com:8000/';
-    let url = new parse_url.URL(urlString);
+  it('parses login with port to confuse things', () => {
+    const urlString = 'https://user:password@example.com:8000/';
+    const url = new parse_url.URL(urlString);
     assertStrictEqual('user:password', url.login);
   });
 
-  it ('parses login with @ to confuse things', () => {
-    let urlString = 'https://user:p@ssword@example.com/';
-    let url = new parse_url.URL(urlString);
+  it('parses login with @ to confuse things', () => {
+    const urlString = 'https://user:p@ssword@example.com/';
+    const url = new parse_url.URL(urlString);
     assertStrictEqual('user:p@ssword', url.login);
   });
 
-  it ('parses login with : to confuse things', () => {
-    let urlString = 'https://user:passwo:d@example.com/';
-    let url = new parse_url.URL(urlString);
+  it('parses login with : to confuse things', () => {
+    const urlString = 'https://user:passwo:d@example.com/';
+    const url = new parse_url.URL(urlString);
     assertStrictEqual('user:passwo:d', url.login);
   });
 
-  it ('parses valid IPv6 hostname', () => {
-    for (let urlString of [
-        "https://[2001:0db8::85a3]/",
-        "https://[::1]/",
-        "https://[::]/",
-        "https://[0:0:0:0:0:0:0:1]/",
-        "https://[0:0:0:0:0:0:8.8.8.8]/",
-        "https://[0:0:0:0:0:0:8.124.8.8]/",
-        "https://[0:0:0:0:0:0:8.8.8.22]/",
-        "https://[::8.8.8.8]/"]) {
-      let url = new parse_url.URL(urlString);
-      assert.ok(url.isValid, "Expected " + urlString + " to be valid.");
+  it('parses valid IPv6 hostname', () => {
+    for (const urlString of [
+      'https://[2001:0db8::85a3]/',
+      'https://[::1]/',
+      'https://[::]/',
+      'https://[0:0:0:0:0:0:0:1]/',
+      'https://[0:0:0:0:0:0:8.8.8.8]/',
+      'https://[0:0:0:0:0:0:8.124.8.8]/',
+      'https://[0:0:0:0:0:0:8.8.8.22]/',
+      'https://[::8.8.8.8]/']) {
+      const url = new parse_url.URL(urlString);
+      assert.ok(url.isValid, 'Expected ' + urlString + ' to be valid.');
     }
   });
 
-  it ('fails on invalid IPv6 hostname', () => {
-    for (let urlString of [
-        "https://[2001:0db8:85a3]/",
-        "https://[20012:0db8::85a3]/",
-        "https://[200g:0db8:85a3]/",
-        "https://[:::1]/",
-        "https://[0:0:0:0:0:0:1]/",
-        "https://[0:0:0:0:0:0:0:0:1]/",
-        "https://[0:0:0:0:0:0:8.8.8.1024]/",
-        "https://[0:0:0:0:0:0:8.8.8]/",
-        "https://[0:0:0:0:0:0:8.8.8.8.8]/",
-        "https://[0:0:0:0:0:0:0:8.8.8.8]/",
-        "https://[0:0:0:0:0:8.8.8.8]/",
-        "https://[0:0:0:0:0:8.8.8.8:1]/"]) {
-      let url = new parse_url.URL(urlString);
-      assert.ok(!url.isValid, "Expected " + urlString + " to be invalid.");
+  it('fails on invalid IPv6 hostname', () => {
+    for (const urlString of [
+      'https://[2001:0db8:85a3]/',
+      'https://[20012:0db8::85a3]/',
+      'https://[200g:0db8:85a3]/',
+      'https://[:::1]/',
+      'https://[0:0:0:0:0:0:1]/',
+      'https://[0:0:0:0:0:0:0:0:1]/',
+      'https://[0:0:0:0:0:0:8.8.8.1024]/',
+      'https://[0:0:0:0:0:0:8.8.8]/',
+      'https://[0:0:0:0:0:0:8.8.8.8.8]/',
+      'https://[0:0:0:0:0:0:0:8.8.8.8]/',
+      'https://[0:0:0:0:0:8.8.8.8]/',
+      'https://[0:0:0:0:0:8.8.8.8:1]/']) {
+      const url = new parse_url.URL(urlString);
+      assert.ok(!url.isValid, 'Expected ' + urlString + ' to be invalid.');
     }
   });
 
-  it ('fails on invalid port characters', () => {
-    let urlString = 'https://example.com:123abc/';
-    let url = new parse_url.URL(urlString);
+  it('fails on invalid port characters', () => {
+    const urlString = 'https://example.com:123abc/';
+    const url = new parse_url.URL(urlString);
     assertStrictEqual(false, url.isValid);
   });
 
-  it ('fails on port with decimal', () => {
-    let urlString = 'https://example.com:80.0/';
-    let url = new parse_url.URL(urlString);
+  it('fails on port with decimal', () => {
+    const urlString = 'https://example.com:80.0/';
+    const url = new parse_url.URL(urlString);
     assertStrictEqual(false, url.isValid);
   });
 
-  it ('fails on port with negative', () => {
-    let urlString = 'https://example.com:-80/';
-    let url = new parse_url.URL(urlString);
+  it('fails on port with negative', () => {
+    const urlString = 'https://example.com:-80/';
+    const url = new parse_url.URL(urlString);
     assertStrictEqual(false, url.isValid);
   });
 
-  it ('allows high port values', () => {
-    let urlString = 'https://example.com:65535/';
-    let url = new parse_url.URL(urlString);
+  it('allows high port values', () => {
+    const urlString = 'https://example.com:65535/';
+    const url = new parse_url.URL(urlString);
     assertStrictEqual(true, url.isValid);
     assertStrictEqual(65535, url.port);
   });
 
-  it ('fails on invalid port values', () => {
-    let urlString = 'https://example.com:65536/';
-    let url = new parse_url.URL(urlString);
+  it('fails on invalid port values', () => {
+    const urlString = 'https://example.com:65536/';
+    const url = new parse_url.URL(urlString);
     assertStrictEqual(false, url.isValid);
   });
 
-  it ('parses empty port strings', () => {
-    let urlString = 'https://example.com:/';
-    let url = new parse_url.URL(urlString);
+  it('parses empty port strings', () => {
+    const urlString = 'https://example.com:/';
+    const url = new parse_url.URL(urlString);
     assertStrictEqual(true, url.isValid);
     assertStrictEqual(443, url.port);
   });
 
-  it ('replaces 0 port with default port', () => {
-    let urlString = 'http://example.com:0/';
-    let url = new parse_url.URL(urlString);
+  it('replaces 0 port with default port', () => {
+    const urlString = 'http://example.com:0/';
+    const url = new parse_url.URL(urlString);
     assertStrictEqual(true, url.isValid);
     assertStrictEqual(80, url.port);
   });
 
-  it ('fails on invalid character ! in hostname', () => {
-    let urlString = 'http://example!.com/';
-    let url = new parse_url.URL(urlString);
+  it('fails on invalid character ! in hostname', () => {
+    const urlString = 'http://example!.com/';
+    const url = new parse_url.URL(urlString);
     assertStrictEqual(false, url.isValid);
   });
 
-  it ('fails on invalid character 0x10 in hostname', () => {
-    let urlString = 'http://example\x10.com/';
-    let url = new parse_url.URL(urlString);
+  it('fails on invalid character 0x10 in hostname', () => {
+    const urlString = 'http://example\x10.com/';
+    const url = new parse_url.URL(urlString);
     assertStrictEqual(false, url.isValid);
   });
 
-  it ('fails on invalid character & in hostname', () => {
-    let urlString = 'http://example.com&/';
-    let url = new parse_url.URL(urlString);
+  it('fails on invalid character & in hostname', () => {
+    const urlString = 'http://example.com&/';
+    const url = new parse_url.URL(urlString);
     assertStrictEqual(false, url.isValid);
   });
 
-  it ('fails on invalid characters in hostname', () => {
-    let urlString = 'http://example!.com/';
-    let url = new parse_url.URL(urlString);
+  it('fails on invalid characters in hostname', () => {
+    const urlString = 'http://example!.com/';
+    const url = new parse_url.URL(urlString);
     assertStrictEqual(false, url.isValid);
   });
 
-  it ('fails on invalid utf8 percent-escape in hostname', () => {
-    let urlString = 'http://example-%FF.com/';
-    let url = new parse_url.URL(urlString);
+  it('fails on invalid utf8 percent-escape in hostname', () => {
+    const urlString = 'http://example-%FF.com/';
+    const url = new parse_url.URL(urlString);
     assertStrictEqual(false, url.isValid);
   });
 
-  it ('fails on dot host', () => {
-    let urlString = 'http://./';
-    let url = new parse_url.URL(urlString);
+  it('fails on dot host', () => {
+    const urlString = 'http://./';
+    const url = new parse_url.URL(urlString);
     assertStrictEqual(false, url.isValid);
   });
 
-  it ('fails on host with consecutive dots', () => {
-    let urlString = 'http://example..com/';
-    let url = new parse_url.URL(urlString);
+  it('fails on host with consecutive dots', () => {
+    const urlString = 'http://example..com/';
+    const url = new parse_url.URL(urlString);
     assertStrictEqual(false, url.isValid);
   });
 
-  it ('strips trailing . from host', () => {
-    let urlString = 'http://example.com./';
-    let url = new parse_url.URL(urlString);
+  it('strips trailing . from host', () => {
+    const urlString = 'http://example.com./';
+    const url = new parse_url.URL(urlString);
     assertStrictEqual(true, url.isValid);
     assertStrictEqual('example.com', url.host);
   });
 
-  it ('accepts relative urls', () => {
-    let urlString = '/foo';
-    let url = new parse_url.URL(urlString);
+  it('accepts relative urls', () => {
+    const urlString = '/foo';
+    const url = new parse_url.URL(urlString);
     assertStrictEqual(true, url.isValid);
   });
 
-  it ('parses relative URL with : character', () => {
-    let urlString = '/image:foo.jpg-bar';
-    let url = new parse_url.URL(urlString);
+  it('parses relative URL with : character', () => {
+    const urlString = '/image:foo.jpg-bar';
+    const url = new parse_url.URL(urlString);
     assertStrictEqual(true, url.isValid);
     assertStrictEqual(false, url.hasProtocol);
   });
 
-  it ('accepts utf8 characters in hostname', () => {
-    let urlString = 'http://⚡.com/';
-    let url = new parse_url.URL(urlString);
+  it('accepts utf8 characters in hostname', () => {
+    const urlString = 'http://⚡.com/';
+    const url = new parse_url.URL(urlString);
     assertStrictEqual(true, url.isValid);
     assertStrictEqual('⚡.com', url.host);
   });
 
-  it ('rejects http://', () => {
-    let urlString = 'http://';
-    let url = new parse_url.URL(urlString);
+  it('rejects http://', () => {
+    const urlString = 'http://';
+    const url = new parse_url.URL(urlString);
     assertStrictEqual(false, url.isValid);
     assertStrictEqual('', url.host);
   });
 
-  it ('rejects http:/// (empty host)', () => {
-    let urlString = 'http:///';
-    let url = new parse_url.URL(urlString);
+  it('rejects http:/// (empty host)', () => {
+    const urlString = 'http:///';
+    const url = new parse_url.URL(urlString);
     assertStrictEqual(false, url.isValid);
     assertStrictEqual('', url.host);
   });
-  it ('accepts \\x10 in hostname', () => {
-    let urlString = 'http://example.com\\x10.com/';
-    let url = new parse_url.URL(urlString);
+
+  it('accepts \\x10 in hostname', () => {
+    const urlString = 'http://example.com\\x10.com/';
+    const url = new parse_url.URL(urlString);
     assertStrictEqual(true, url.isValid);
     assertStrictEqual('example.com', url.host);
   });

--- a/validator/engine/tokenize-css.js
+++ b/validator/engine/tokenize-css.js
@@ -228,7 +228,7 @@ function preprocess(str) {
       code = /* '\n' */ 0xa;
       i++;
     }
-    if (code === /* '\r' */ 0xd || code === 0xc) code = /* '\n' */ 0xa;
+    if (code === /* '\r' */ 0xd || code === 0xc) {code = /* '\n' */ 0xa;}
     if (code === 0x0) {
       code = 0xfffd;
     }
@@ -443,7 +443,7 @@ class Tokenizer {
           this.areAValidEscape(this.next(1), this.next(2))) {
         let type = null;
         if (this.wouldStartAnIdentifier(
-                this.next(1), this.next(2), this.next(3))) {
+            this.next(1), this.next(2), this.next(3))) {
           type = 'id';
         }
         const token = new parse_css.HashToken();
@@ -516,7 +516,7 @@ class Tokenizer {
         this.reconsume();
         return mark.copyPosTo(this.consumeANumericToken());
       } else if (
-          this.next(1) === /* '-' */ 0x2d && this.next(2) === /* '>' */ 0x3e) {
+        this.next(1) === /* '-' */ 0x2d && this.next(2) === /* '>' */ 0x3e) {
         this.consume(2);
         if (amp.validator.LIGHT) {
           return TRIVIAL_CDC_TOKEN;
@@ -567,7 +567,7 @@ class Tokenizer {
       }
     } else if (this.code_ === /* '@' */ 0x40) {
       if (this.wouldStartAnIdentifier(
-              this.next(1), this.next(2), this.next(3))) {
+          this.next(1), this.next(2), this.next(3))) {
         const token = new parse_css.AtKeywordToken();
         token.value = this.consumeAName();
         return mark.copyPosTo(token);
@@ -755,7 +755,7 @@ class Tokenizer {
         token.value = name;
         return token;
       } else if (
-          whitespace(this.next()) &&
+        whitespace(this.next()) &&
           (this.next(2) === /* '"' */ 0x22 ||
            this.next(2) === /* ''' */ 0x27)) {
         const token = new parse_css.FunctionToken();
@@ -850,7 +850,7 @@ class Tokenizer {
               amp.validator.ValidationError.Code.CSS_SYNTAX_BAD_URL, ['style']);
         }
       } else if (
-          this.code_ === /* '"' */ 0x22 || this.code_ === /* ''' */ 0x27 ||
+        this.code_ === /* '"' */ 0x22 || this.code_ === /* ''' */ 0x27 ||
           this.code_ === /* '(' */ 0x28 || nonPrintable(this.code_)) {
         this.consumeTheRemnantsOfABadURL();
         if (amp.validator.LIGHT) {
@@ -884,7 +884,7 @@ class Tokenizer {
   consumeEscape() {
     // Assume the the current character is the \
     // and the next code point is not a newline.
-    this.consume();  // '\'
+    this.consume(); // '\'
     if (hexDigit(this.code_)) {
       // Consume 1-6 hex digits
       const digits = [this.code_];
@@ -1039,19 +1039,19 @@ class Tokenizer {
     let type = 'integer';
     if (this.next() === /* '+' */ 0x2b || this.next() === /* '-' */ 0x2d) {
       this.consume();
-      repr += stringFromCode(this.code_);  // + or -
+      repr += stringFromCode(this.code_); // + or -
     }
     while (digit(this.next())) {
       this.consume();
-      repr += stringFromCode(this.code_);  // 0-9
+      repr += stringFromCode(this.code_); // 0-9
     }
     if (this.next(1) === /* '.' */ 0x2e && digit(this.next(2))) {
       this.consume();
-      repr += stringFromCode(this.code_);  // '.'
+      repr += stringFromCode(this.code_); // '.'
       type = 'number';
       while (digit(this.next())) {
         this.consume();
-        repr += stringFromCode(this.code_);  // 0-9
+        repr += stringFromCode(this.code_); // 0-9
       }
     }
     const c1 = this.next(1);
@@ -1059,23 +1059,23 @@ class Tokenizer {
     const c3 = this.next(3);
     if ((c1 === /* 'E' */ 0x45 || c1 === /* 'e' */ 0x65) && digit(c2)) {
       this.consume();
-      repr += stringFromCode(this.code_);  // E or e
+      repr += stringFromCode(this.code_); // E or e
       type = 'number';
       while (digit(this.next())) {
         this.consume();
-        repr += stringFromCode(this.code_);  // 0-9
+        repr += stringFromCode(this.code_); // 0-9
       }
     } else if (
-        (c1 === /* 'E' */ 0x45 || c1 === /* 'e' */ 0x65) &&
+      (c1 === /* 'E' */ 0x45 || c1 === /* 'e' */ 0x65) &&
         (c2 === /* '+' */ 0x2b || c2 === /* '-' */ 0x2d) && digit(c3)) {
       this.consume();
-      repr += stringFromCode(this.code_);  // E or e
+      repr += stringFromCode(this.code_); // E or e
       this.consume();
-      repr += stringFromCode(this.code_);  // + or -
+      repr += stringFromCode(this.code_); // + or -
       type = 'number';
       while (digit(this.next())) {
         this.consume();
-        repr += stringFromCode(this.code_);  // 0-9
+        repr += stringFromCode(this.code_); // 0-9
       }
     }
     const numberToken = new parse_css.NumberToken();
@@ -1092,7 +1092,7 @@ class Tokenizer {
    */
   convertAStringToANumber(string) {
     // CSS's number rules are identical to JS, afaik.
-    return +string;
+    return Number(string);
   }
 
   /**
@@ -1118,33 +1118,33 @@ class Tokenizer {
 parse_css.TokenType = {
   UNKNOWN: 0,
   AT_KEYWORD: 1,
-  CDC: 2,  // -->
-  CDO: 3,  // <!--
+  CDC: 2, // -->
+  CDO: 3, // <!--
   CLOSE_CURLY: 4,
   CLOSE_PAREN: 5,
   CLOSE_SQUARE: 6,
   COLON: 7,
-  COLUMN: 8,  // ||
+  COLUMN: 8, // ||
   COMMA: 9,
-  DASH_MATCH: 10,  // |=
+  DASH_MATCH: 10, // |=
   DELIM: 11,
   DIMENSION: 12,
-  EOF_TOKEN: 13,  // Can't call this EOF due to symbol conflict in C.
+  EOF_TOKEN: 13, // Can't call this EOF due to symbol conflict in C.
   ERROR: 14,
   FUNCTION_TOKEN: 15,
-  HASH: 16,  // #
+  HASH: 16, // #
   IDENT: 17,
-  INCLUDE_MATCH: 18,  // ~=
+  INCLUDE_MATCH: 18, // ~=
   NUMBER: 19,
   OPEN_CURLY: 20,
   OPEN_PAREN: 21,
   OPEN_SQUARE: 22,
   PERCENTAGE: 23,
-  PREFIX_MATCH: 24,  // ^=
+  PREFIX_MATCH: 24, // ^=
   SEMICOLON: 25,
   STRING: 26,
-  SUBSTRING_MATCH: 27,  // *=
-  SUFFIX_MATCH: 28,     // $=
+  SUBSTRING_MATCH: 27, // *=
+  SUFFIX_MATCH: 28, // $=
   WHITESPACE: 29,
   URL: 30,
 
@@ -1167,7 +1167,7 @@ parse_css.TokenType = {
   CLASS_SELECTOR: 42,
   SIMPLE_SELECTOR_SEQUENCE: 43,
   COMBINATOR: 44,
-  SELECTORS_GROUP: 45
+  SELECTORS_GROUP: 45,
 };
 
 /** @type {!Array<string>} */
@@ -1256,7 +1256,7 @@ if (!amp.validator.LIGHT) {
     return {
       'tokenType': TokenType_NamesById[this.tokenType],
       'line': this.line,
-      'col': this.col
+      'col': this.col,
     };
   };
 }

--- a/validator/engine/validator-in-browser.js
+++ b/validator/engine/validator-in-browser.js
@@ -75,9 +75,9 @@ amp.validator.validateInBrowser = function(doc) {
  * @export
  */
 amp.validator.validateUrlAndLog = function(
-    url, opt_doc, opt_errorCategoryFilter) {
+  url, opt_doc, opt_errorCategoryFilter) {
   getUrl(url).then(
-      function(html) {  // Success
+      function(html) { // Success
         const validationResult = amp.validator.validateString(html);
         if (opt_doc) {
           const browserResult = amp.validator.validateInBrowser(opt_doc);
@@ -86,7 +86,7 @@ amp.validator.validateUrlAndLog = function(
         validationResult.outputToTerminal(
             url, undefined, opt_errorCategoryFilter);
       },
-      function(reason) {  // Failure
+      function(reason) { // Failure
         console.error(reason);
       });
 };

--- a/validator/engine/validator.js
+++ b/validator/engine/validator.js
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the license.
  */
-goog.provide('amp.validator.CssLength');  // Only for testing.
+goog.provide('amp.validator.CssLength'); // Only for testing.
 goog.provide('amp.validator.Terminal');
 goog.provide('amp.validator.ValidationHandler');
 goog.provide('amp.validator.annotateWithErrorCategories');
@@ -69,14 +69,14 @@ goog.require('parse_url.URL');
  * @template T
  */
 function sortAndUniquify(arrayValue) {
-  if (arrayValue.length < 2) return;
+  if (arrayValue.length < 2) {return;}
 
   goog.array.sort(arrayValue);
-  var uniqIdx = 0;
-  for (var i = 1; i < arrayValue.length; ++i) {
-    if (arrayValue[i] === arrayValue[uniqIdx]) continue;
+  let uniqIdx = 0;
+  for (let i = 1; i < arrayValue.length; ++i) {
+    if (arrayValue[i] === arrayValue[uniqIdx]) {continue;}
     uniqIdx++;
-    if (uniqIdx !== i) arrayValue[uniqIdx] = arrayValue[i];
+    if (uniqIdx !== i) {arrayValue[uniqIdx] = arrayValue[i];}
   }
   arrayValue.splice(uniqIdx + 1);
 }
@@ -149,7 +149,7 @@ const DOCUMENT_START = new LineCol(1, 0);
  * @return {!amp.validator.ValidationError}
  */
 function populateError(
-    severity, validationErrorCode, lineCol, params, specUrl) {
+  severity, validationErrorCode, lineCol, params, specUrl) {
   const error = new amp.validator.ValidationError();
   error.severity = severity;
   error.code = validationErrorCode;
@@ -218,7 +218,7 @@ class ParsedUrlSpec {
         // 3) domain === 'someexample.com'  ->  isDisallowedDomain = false
         //
         // Case 1:
-        if (domain === disallowedDomain) return true;
+        if (domain === disallowedDomain) {return true;}
 
         // Case 2/3, determine if the character before the matching suffix
         // is a '.':
@@ -331,7 +331,7 @@ class ParsedAttrSpec {
    * @return {ParsedValueProperties}
    */
   getValuePropertiesOrNull() {
-    if (this.spec_.valueProperties === null) return null;
+    if (this.spec_.valueProperties === null) {return null;}
     if (this.valueProperties_ === null) {
       this.valueProperties_ =
           new ParsedValueProperties(this.spec_.valueProperties);
@@ -350,7 +350,7 @@ class ParsedAttrSpec {
  */
 function getTagSpecName(tagSpec) {
   return (tagSpec.specName !== null) ? tagSpec.specName :
-                                       tagSpec.tagName.toLowerCase();
+    tagSpec.tagName.toLowerCase();
 }
 
 /**
@@ -364,14 +364,14 @@ function getTagSpecUrl(tagSpec) {
   // Handle a ParsedTagSpec as well as a tag spec.
   // TODO(gregable): This is a bit hacky, we should improve on this approach
   // in the future.
-  if (tagSpec.getSpec !== undefined) return getTagSpecUrl(tagSpec.getSpec());
+  if (tagSpec.getSpec !== undefined) {return getTagSpecUrl(tagSpec.getSpec());}
 
-  if (tagSpec.specUrl !== null) return tagSpec.specUrl;
+  if (tagSpec.specUrl !== null) {return tagSpec.specUrl;}
 
   const extensionSpecUrlPrefix =
       'https://www.ampproject.org/docs/reference/components/';
   if (tagSpec.extensionSpec !== null && tagSpec.extensionSpec.name !== null)
-    return extensionSpecUrlPrefix + tagSpec.extensionSpec.name;
+  {return extensionSpecUrlPrefix + tagSpec.extensionSpec.name;}
   if (tagSpec.requiresExtension.length > 0) {
     // Return the first |requires_extension|, which should be the most
     // representitive.
@@ -482,7 +482,7 @@ class ParsedAttrSpecs {
 
   /**
    * @param {number} id
-   * @return {!string}
+   * @return {string}
    */
   getNameByAttrSpecId(id) {
     if (id < 0) {
@@ -596,14 +596,14 @@ class ParsedTagSpec {
    * fields in the tag spec.
    */
   expandExtensionSpec() {
-    const extensionSpec = this.spec_.extensionSpec;
+    const {extensionSpec} = this.spec_;
     if (this.spec_.specName === null)
-      this.spec_.specName = extensionSpec.name + ' extension .js script';
+    {this.spec_.specName = extensionSpec.name + ' extension .js script';}
     this.spec_.mandatoryParent = 'HEAD';
     if (this.spec_.extensionSpec.deprecatedAllowDuplicates)
-      this.spec_.uniqueWarning = true;
+    {this.spec_.uniqueWarning = true;}
     else
-      this.spec_.unique = true;
+    {this.spec_.unique = true;}
 
     if (amp.validator.VALIDATE_CSS) {
       this.spec_.cdata = new amp.validator.CdataSpec();
@@ -624,7 +624,7 @@ class ParsedTagSpec {
         continue;
       }
       this.attrsByName_[name] = attrId;
-      if (attrId < 0) {  // negative attr ids are simple attrs (only name set).
+      if (attrId < 0) { // negative attr ids are simple attrs (only name set).
         continue;
       }
       const attr = parsedAttrSpecs.getByAttrSpecId(attrId);
@@ -670,7 +670,7 @@ class ParsedTagSpec {
    * @return {?CdataMatcher}
    */
   cdataMatcher(lineCol) {
-    if (this.spec_.cdata !== null) return new CdataMatcher(this.spec_, lineCol);
+    if (this.spec_.cdata !== null) {return new CdataMatcher(this.spec_, lineCol);}
     return null;
   }
 
@@ -681,7 +681,7 @@ class ParsedTagSpec {
    */
   childTagMatcher(lineCol) {
     if (this.spec_.childTags !== null)
-      return new ChildTagMatcher(this.spec_, lineCol);
+    {return new ChildTagMatcher(this.spec_, lineCol);}
     return null;
   }
 
@@ -694,7 +694,7 @@ class ParsedTagSpec {
    */
   referencePointMatcher(rules, lineCol) {
     if (this.hasReferencePoints())
-      return new ReferencePointMatcher(rules, this.referencePoints_, lineCol);
+    {return new ReferencePointMatcher(rules, this.referencePoints_, lineCol);}
     return null;
   }
 
@@ -845,7 +845,7 @@ amp.validator.ValidationResult.prototype.mergeFrom = function(other) {
   goog.asserts.assert(other.status !== null);
   // Copy status only if fail. Failing is a terminal state.
   if (other.status === amp.validator.ValidationResult.Status.FAIL)
-    this.status = amp.validator.ValidationResult.Status.FAIL;
+  {this.status = amp.validator.ValidationResult.Status.FAIL;}
   if (!amp.validator.LIGHT) {
     Array.prototype.push.apply(this.errors, other.errors);
   }
@@ -860,7 +860,7 @@ amp.validator.ValidationResult.prototype.copyFrom = function(other) {
   goog.asserts.assert(other.status !== null);
   this.status = other.status;
   if (!amp.validator.LIGHT) {
-    let newErrors = [];
+    const newErrors = [];
     Array.prototype.push.apply(newErrors, other.errors);
     this.errors = newErrors;
   }
@@ -898,7 +898,7 @@ class ChildTagMatcher {
 
   /** @return {!LineCol} */
   getLineCol() {
-    if (amp.validator.LIGHT) return DOCUMENT_START;
+    if (amp.validator.LIGHT) {return DOCUMENT_START;}
     return this.lineCol_;
   }
 
@@ -908,7 +908,7 @@ class ChildTagMatcher {
    * @param {!amp.validator.ValidationResult} result
    */
   matchChildTagName(encounteredTag, context, result) {
-    const childTags = this.parentSpec_.childTags;
+    const {childTags} = this.parentSpec_;
     // Enforce child_tag_name_oneof: If at least one tag name is specified,
     // then the child tags of the parent tag must have one of the provided
     // tag names.
@@ -923,7 +923,7 @@ class ChildTagMatcher {
               /* params */
               [
                 encounteredTag.lowerName(), getTagSpecName(this.parentSpec_),
-                allowedNames.toLowerCase()
+                allowedNames.toLowerCase(),
               ],
               getTagSpecUrl(this.parentSpec_), result);
         } else {
@@ -948,7 +948,7 @@ class ChildTagMatcher {
               /* params */
               [
                 encounteredTag.lowerName(), getTagSpecName(this.parentSpec_),
-                allowedNames.toLowerCase()
+                allowedNames.toLowerCase(),
               ],
               getTagSpecUrl(this.parentSpec_), result);
         } else {
@@ -978,7 +978,7 @@ class ChildTagMatcher {
             /* params */
             [
               getTagSpecName(this.parentSpec_), expectedNumChildTags.toString(),
-              context.getTagStack().parentChildCount().toString()
+              context.getTagStack().parentChildCount().toString(),
             ],
             getTagSpecUrl(this.parentSpec_), result);
         return;
@@ -1000,7 +1000,7 @@ class ChildTagMatcher {
             [
               getTagSpecName(this.parentSpec_),
               expectedMinNumChildTags.toString(),
-              context.getTagStack().parentChildCount().toString()
+              context.getTagStack().parentChildCount().toString(),
             ],
             getTagSpecUrl(this.parentSpec_), result);
         return;
@@ -1062,7 +1062,7 @@ class ReferencePointMatcher {
    * @return {!LineCol}
    */
   getLineCol() {
-    if (amp.validator.LIGHT) return DOCUMENT_START;
+    if (amp.validator.LIGHT) {return DOCUMENT_START;}
     return this.lineCol_;
   }
 
@@ -1077,23 +1077,23 @@ class ReferencePointMatcher {
    */
   validateTag(tag, context) {
     // Look for a matching reference point, if we find one, record and exit.
-    let resultForBestAttempt = new amp.validator.ValidationResult();
+    const resultForBestAttempt = new amp.validator.ValidationResult();
     resultForBestAttempt.status = amp.validator.ValidationResult.Status.UNKNOWN;
     for (const p of this.parsedReferencePoints_.iterate()) {
       // p.tagSpecName here is actually a number, which was replaced in
       // validator_gen_js.py from the name string, so this works.
       const parsedTagSpec = context.getRules().getByTagSpecId(
-          /** @type {!number} */ (p.tagSpecName));
+          /** @type {number} */ (p.tagSpecName));
       const resultForAttempt = validateTagAgainstSpec(
           parsedTagSpec, /*bestMatchReferencePoint=*/null, context, tag);
       if (context.getRules().betterValidationResultThan(
-              resultForAttempt, resultForBestAttempt))
-        resultForBestAttempt.copyFrom(resultForAttempt);
+          resultForAttempt, resultForBestAttempt))
+      {resultForBestAttempt.copyFrom(resultForAttempt);}
       if (resultForBestAttempt.status ===
           amp.validator.ValidationResult.Status.PASS) {
         return {
           validationResult: resultForBestAttempt,
-          bestMatchTagSpec: parsedTagSpec
+          bestMatchTagSpec: parsedTagSpec,
         };
       }
     }
@@ -1115,7 +1115,7 @@ class ReferencePointMatcher {
           [
             tag.lowerName(), this.parsedReferencePoints_.parentTagSpecName(),
             this.parsedValidatorRules_.getReferencePointName(
-                this.parsedReferencePoints_.iterate()[0])
+                this.parsedReferencePoints_.iterate()[0]),
           ],
           this.parsedReferencePoints_.parentSpecUrl(), resultForBestAttempt);
       return {validationResult: resultForBestAttempt, bestMatchTagSpec: null};
@@ -1126,7 +1126,7 @@ class ReferencePointMatcher {
     for (const p of this.parsedReferencePoints_.iterate()) {
       acceptable.push(this.parsedValidatorRules_.getReferencePointName(p));
     }
-    let resultForMultipleAttempts = new amp.validator.ValidationResult();
+    const resultForMultipleAttempts = new amp.validator.ValidationResult();
     context.addError(
         amp.validator.ValidationError.Code
             .CHILD_TAG_DOES_NOT_SATISFY_REFERENCE_POINT,
@@ -1134,12 +1134,12 @@ class ReferencePointMatcher {
         /*params*/
         [
           tag.lowerName(), this.parsedReferencePoints_.parentTagSpecName(),
-          acceptable.join(', ')
+          acceptable.join(', '),
         ],
         this.parsedReferencePoints_.parentSpecUrl(), resultForMultipleAttempts);
     return {
       validationResult: resultForMultipleAttempts,
-      bestMatchTagSpec: null
+      bestMatchTagSpec: null,
     };
   }
 
@@ -1162,8 +1162,8 @@ class ReferencePointMatcher {
     const referencePointByCount = [];
     for (const r of this.referencePointsMatched_) {
       referencePointByCount[r] = referencePointByCount.hasOwnProperty(r) ?
-          (referencePointByCount[r] + 1) :
-          1;
+        (referencePointByCount[r] + 1) :
+        1;
     }
     for (const p of this.parsedReferencePoints_.iterate()) {
       // p.tagSpecName here is actually a number, which was replaced in
@@ -1182,7 +1182,7 @@ class ReferencePointMatcher {
             /*params*/
             [
               this.parsedValidatorRules_.getReferencePointName(p),
-              this.parsedReferencePoints_.parentTagSpecName()
+              this.parsedReferencePoints_.parentTagSpecName(),
             ],
             this.parsedReferencePoints_.parentSpecUrl(), result);
       }
@@ -1198,7 +1198,7 @@ class ReferencePointMatcher {
             /*params*/
             [
               this.parsedValidatorRules_.getReferencePointName(p),
-              this.parsedReferencePoints_.parentTagSpecName()
+              this.parsedReferencePoints_.parentTagSpecName(),
             ],
             this.parsedReferencePoints_.parentSpecUrl(), result);
       }
@@ -1285,7 +1285,7 @@ class TagStack {
    */
   createNewTagStackEntry(tagName) {
     return {
-      tagName: tagName,
+      tagName,
       tagSpec: null,
       referencePoint: null,
       hasDescendantConstraintLists: false,
@@ -1298,7 +1298,7 @@ class TagStack {
       lastChildErrorLineCol: null,
       cdataMatcher: null,
       childTagMatcher: null,
-      referencePointMatcher: null
+      referencePointMatcher: null,
     };
   }
 
@@ -1309,7 +1309,7 @@ class TagStack {
    * @param {!ValidateTagResult} tagResult
    */
   enterTag(tagName, referencePointResult, tagResult) {
-    let stackEntry = this.createNewTagStackEntry(tagName);
+    const stackEntry = this.createNewTagStackEntry(tagName);
     stackEntry.referencePoint = referencePointResult.bestMatchTagSpec;
     stackEntry.tagSpec = tagResult.bestMatchTagSpec;
     this.stack_.push(stackEntry);
@@ -1346,7 +1346,7 @@ class TagStack {
    * @private
    */
   updateStackEntryFromTagResult_(result, parsedRules, lineCol) {
-    if (result.bestMatchTagSpec === null) return;
+    if (result.bestMatchTagSpec === null) {return;}
     const parsedTagSpec = result.bestMatchTagSpec;
 
     this.setReferencePointMatcher(
@@ -1372,7 +1372,7 @@ class TagStack {
    * @param {!LineCol} lineCol
    */
   updateFromTagResults(
-      encounteredTag, referencePointResult, tagResult, parsedRules, lineCol) {
+    encounteredTag, referencePointResult, tagResult, parsedRules, lineCol) {
     // Keep track of the number of direct children this tag has, even as we
     // pop in and out of them on the stack.
     this.parentStackEntry_().numChildren++;
@@ -1427,7 +1427,7 @@ class TagStack {
    * @param {?ChildTagMatcher} matcher
    */
   setChildTagMatcher(matcher) {
-    if (matcher !== null) this.back_().childTagMatcher = matcher;
+    if (matcher !== null) {this.back_().childTagMatcher = matcher;}
   }
 
   /**
@@ -1442,7 +1442,7 @@ class TagStack {
    * @param {?CdataMatcher} matcher
    */
   setCdataMatcher(matcher) {
-    if (matcher !== null) this.back_().cdataMatcher = matcher;
+    if (matcher !== null) {this.back_().cdataMatcher = matcher;}
   }
 
   /**
@@ -1459,7 +1459,7 @@ class TagStack {
    * @param {?ReferencePointMatcher} matcher
    */
   setReferencePointMatcher(matcher) {
-    if (matcher !== null) this.back_().referencePointMatcher = matcher;
+    if (matcher !== null) {this.back_().referencePointMatcher = matcher;}
   }
 
   /**
@@ -1479,7 +1479,7 @@ class TagStack {
   matchChildTagName(encounteredTag, context, result) {
     const matcher = this.parentStackEntry_().childTagMatcher;
     if (matcher !== null)
-      matcher.matchChildTagName(encounteredTag, context, result);
+    {matcher.matchChildTagName(encounteredTag, context, result);}
   }
 
   /**
@@ -1526,7 +1526,7 @@ class TagStack {
    */
   parentOnlyChildErrorLineCol() {
     return /** @type {!LineCol} */ (
-        this.parentStackEntry_().onlyChildErrorLineCol);
+      this.parentStackEntry_().onlyChildErrorLineCol);
   }
 
   /**
@@ -1563,7 +1563,7 @@ class TagStack {
    */
   parentLastChildErrorLineCol() {
     return /** @type {!LineCol} */ (
-        this.parentStackEntry_().lastChildErrorLineCol);
+      this.parentStackEntry_().lastChildErrorLineCol);
   }
 
   /**
@@ -1624,9 +1624,9 @@ class TagStack {
    * tagName.
    */
   setDescendantConstraintList(parsedTagSpec, parsedRules) {
-    if (parsedTagSpec.getSpec().descendantTagList === null) return;
+    if (parsedTagSpec.getSpec().descendantTagList === null) {return;}
 
-    let allowedDescendantsForThisTag = [];
+    const allowedDescendantsForThisTag = [];
     for (const descendantTagList of parsedRules.getDescendantTagLists()) {
       // Get the list matching this tag's descendant tag name.
       if (parsedTagSpec.getSpec().descendantTagList ===
@@ -1639,7 +1639,7 @@ class TagStack {
 
     this.allowedDescendantsList_.push(
         {tagName: getTagSpecName(parsedTagSpec.getSpec()),
-         allowedTags: allowedDescendantsForThisTag});
+          allowedTags: allowedDescendantsForThisTag});
     this.setHasDescendantConstraintLists(true);
   }
 
@@ -1699,9 +1699,9 @@ function isAtRuleValid(cssSpec, atRuleName) {
  * @return {boolean}
  */
 function IsDeclarationValid(cssSpec, declarationName) {
-  if (cssSpec.allowedDeclarations.length === 0) return true;
+  if (cssSpec.allowedDeclarations.length === 0) {return true;}
   return cssSpec.allowedDeclarations.indexOf(
-             parse_css.stripVendorPrefix(declarationName)) > -1;
+      parse_css.stripVendorPrefix(declarationName)) > -1;
 }
 
 /**
@@ -1710,7 +1710,7 @@ function IsDeclarationValid(cssSpec, declarationName) {
  * @return {string}
  */
 function AllowedDeclarationsString(cssSpec) {
-  if (cssSpec.allowedDeclarations.length > 5) return '';
+  if (cssSpec.allowedDeclarations.length > 5) {return '';}
   return '[\'' + cssSpec.allowedDeclarations.join('\', \'') + '\']';
 }
 
@@ -1771,7 +1771,7 @@ class InvalidRuleVisitor extends parse_css.RuleVisitor {
               /* params */
               [
                 getTagSpecName(this.tagSpec), declaration.name,
-                AllowedDeclarationsString(this.cssSpec)
+                AllowedDeclarationsString(this.cssSpec),
               ],
               /* url */ '', this.result);
         }
@@ -1801,11 +1801,11 @@ function computeCssParsingConfig(cssSpec) {
       ampAtRuleParsingSpec[atRuleSpec.name] =
           parse_css.BlockType.PARSE_AS_IGNORE;
     } else if (
-        atRuleSpec.type === amp.validator.AtRuleSpec.BlockType.PARSE_AS_RULES) {
+      atRuleSpec.type === amp.validator.AtRuleSpec.BlockType.PARSE_AS_RULES) {
       ampAtRuleParsingSpec[atRuleSpec.name] =
           parse_css.BlockType.PARSE_AS_RULES;
     } else if (
-        atRuleSpec.type ===
+      atRuleSpec.type ===
         amp.validator.AtRuleSpec.BlockType.PARSE_AS_DECLARATIONS) {
       ampAtRuleParsingSpec[atRuleSpec.name] =
           parse_css.BlockType.PARSE_AS_DECLARATIONS;
@@ -1815,7 +1815,7 @@ function computeCssParsingConfig(cssSpec) {
   }
   const config = {
     atRuleSpec: ampAtRuleParsingSpec,
-    defaultSpec: parse_css.BlockType.PARSE_AS_IGNORE
+    defaultSpec: parse_css.BlockType.PARSE_AS_IGNORE,
   };
   if (cssSpec.atRuleSpec.length > 0) {
     config.defaultSpec = ampAtRuleParsingSpec['$DEFAULT'];
@@ -1878,7 +1878,7 @@ class CdataMatcher {
               /* params */
               [
                 getTagSpecName(this.tagSpec_), bytes.toString(),
-                cdataSpec.maxBytes.toString()
+                cdataSpec.maxBytes.toString(),
               ],
               cdataSpec.maxBytesSpecUrl, validationResult);
         }
@@ -1912,8 +1912,8 @@ class CdataMatcher {
       return;
     } else if (this.tagSpec_.cdata.cdataRegex !== null) {
       if (!context.getRules()
-               .getFullMatchRegex(this.tagSpec_.cdata.cdataRegex)
-               .test(cdata)) {
+          .getFullMatchRegex(this.tagSpec_.cdata.cdataRegex)
+          .test(cdata)) {
         if (amp.validator.LIGHT) {
           validationResult.status = amp.validator.ValidationResult.Status.FAIL;
         } else {
@@ -1954,11 +1954,11 @@ class CdataMatcher {
     // We use a combined regex as a fast test. If it matches, we re-match
     // against each individual regex so that we can generate better error
     // messages.
-    if (cdataSpec.combinedBlacklistedCdataRegex === null) return;
+    if (cdataSpec.combinedBlacklistedCdataRegex === null) {return;}
     if (!context.getRules()
-             .getPartialMatchCaseiRegex(cdataSpec.combinedBlacklistedCdataRegex)
-             .test(cdata))
-      return;
+        .getPartialMatchCaseiRegex(cdataSpec.combinedBlacklistedCdataRegex)
+        .test(cdata))
+    {return;}
     if (amp.validator.LIGHT) {
       validationResult.status = amp.validator.ValidationResult.Status.FAIL;
       return;
@@ -2029,7 +2029,7 @@ class CdataMatcher {
     } else {
       for (const errorToken of cssErrors) {
         // Override the first parameter with the name of this style tag.
-        let params = errorToken.params;
+        const {params} = errorToken;
         // Override the first parameter with the name of this style tag.
         params[0] = getTagSpecName(this.tagSpec_);
         context.addError(
@@ -2041,11 +2041,11 @@ class CdataMatcher {
     const parsedImageUrlSpec = new ParsedUrlSpec(cssSpec.imageUrlSpec);
     for (const url of parsedUrls) {
       const adapter = amp.validator.LIGHT ?
-          null :
-          new UrlErrorInStylesheetAdapter(url.line, url.col);
+        null :
+        new UrlErrorInStylesheetAdapter(url.line, url.col);
       validateUrlAndProtocol(
           ((url.atRuleScope === 'font-face') ? parsedFontUrlSpec :
-                                               parsedImageUrlSpec),
+            parsedImageUrlSpec),
           adapter, context, url.utf8Url, this.tagSpec_, validationResult);
     }
     const visitor = new InvalidRuleVisitor(
@@ -2055,7 +2055,7 @@ class CdataMatcher {
 
   /** @return {!LineCol} */
   getLineCol() {
-    if (amp.validator.LIGHT) return DOCUMENT_START;
+    if (amp.validator.LIGHT) {return DOCUMENT_START;}
     return this.lineCol_;
   }
 }
@@ -2141,13 +2141,13 @@ class ExtensionsContext {
    */
   recordFutureErrorsIfMissing(parsedTagSpec, lineCol) {
     const tagSpec = parsedTagSpec.getSpec();
-    for (let requiredExtension of tagSpec.requiresExtension) {
+    for (const requiredExtension of tagSpec.requiresExtension) {
       if (!this.isExtensionLoaded(requiredExtension)) {
         // Record a possible failure once we have collected all extensions
         // in the document. If the given extension is missing, then report
         // a failure. This is used only in the LIGHT validator.
         if (!amp.validator.LIGHT) {
-          let error = new amp.validator.ValidationError();
+          const error = new amp.validator.ValidationError();
           error.severity = amp.validator.ValidationError.Severity.ERROR;
           error.code =
               amp.validator.ValidationError.Code.MISSING_REQUIRED_EXTENSION;
@@ -2158,7 +2158,7 @@ class ExtensionsContext {
 
           this.extensionMissingErrors_.push(
               {missingExtension: requiredExtension, maybeError: error});
-        } else {  // amp.validator.LIGHT
+        } else { // amp.validator.LIGHT
           this.extensionMissingFailures_.push(requiredExtension);
         }
       }
@@ -2171,10 +2171,10 @@ class ExtensionsContext {
    * @return {!Array<!amp.validator.ValidationError>}
    */
   missingExtensionErrors() {
-    var out = [];
+    const out = [];
     for (const err of this.extensionMissingErrors_) {
       if (!this.isExtensionLoaded(err.missingExtension))
-        out.push(err.maybeError);
+      {out.push(err.maybeError);}
     }
 
     return out;
@@ -2187,7 +2187,7 @@ class ExtensionsContext {
    */
   hasMissingExtensionFailures() {
     for (const missingExtension of this.extensionMissingFailures_) {
-      if (!this.isExtensionLoaded(missingExtension)) return true;
+      if (!this.isExtensionLoaded(missingExtension)) {return true;}
     }
     return false;
   }
@@ -2199,9 +2199,9 @@ class ExtensionsContext {
    */
   unusedExtensionsRequired() {
     // Compute Difference: extensionsUnusedRequired_ - extensionsUsed_
-    var out = [];
+    const out = [];
     for (const extension of this.extensionsUnusedRequired_)
-      if (!(extension in this.extensionsUsed_)) out.push(extension);
+    {if (!(extension in this.extensionsUsed_)) {out.push(extension);}}
     out.sort();
     return out;
   }
@@ -2212,13 +2212,13 @@ class ExtensionsContext {
    * @param {!ValidateTagResult} result
    */
   updateFromTagResult(result) {
-    if (result.bestMatchTagSpec === null) return;
+    if (result.bestMatchTagSpec === null) {return;}
     const parsedTagSpec = result.bestMatchTagSpec;
     const tagSpec = parsedTagSpec.getSpec();
 
     // Keep track of which extensions are loaded.
     if (tagSpec.extensionSpec !== null) {
-      const extensionSpec = tagSpec.extensionSpec;
+      const {extensionSpec} = tagSpec;
       // This is an always present field if extension spec is set.
       const extensionName = /** @type{string} */ (extensionSpec.name);
 
@@ -2227,7 +2227,7 @@ class ExtensionsContext {
       this.extensionsLoaded_[extensionName] = true;
       switch (extensionSpec.requiresUsage) {
         case amp.validator.ExtensionSpec.ExtensionUsageRequirement
-            .GRANDFATHERED:  // Fallthrough intended:
+            .GRANDFATHERED: // Fallthrough intended:
         case amp.validator.ExtensionSpec.ExtensionUsageRequirement.NONE:
           // This extension does not have usage demonstrated by a tag, for
           // example: amp-dynamic-css-classes
@@ -2235,7 +2235,7 @@ class ExtensionsContext {
         case amp.validator.ExtensionSpec.ExtensionUsageRequirement.ERROR:
         // TODO(powdercloud): Make enum proto defaults work in generated
         // javascript.
-        default:  // Default is error
+        default: // Default is error
           // Record that a loaded extension indicates a new requirement:
           // namely that some tag must make use of this extension.
           this.extensionsUnusedRequired_.push(extensionName);
@@ -2245,8 +2245,8 @@ class ExtensionsContext {
 
     // Record presence of a tag, such as <amp-foo> which requires the usage
     // of an amp extension.
-    for (let requiredExtension of tagSpec.requiresExtension)
-      this.extensionsUsed_[requiredExtension] = true;
+    for (const requiredExtension of tagSpec.requiresExtension)
+    {this.extensionsUsed_[requiredExtension] = true;}
   }
 }
 
@@ -2414,7 +2414,7 @@ class Context {
    * @private
    */
   updateFromTagResult_(result) {
-    if (result.bestMatchTagSpec === null) return;
+    if (result.bestMatchTagSpec === null) {return;}
     const parsedTagSpec = result.bestMatchTagSpec;
 
     this.extensions_.updateFromTagResult(result);
@@ -2484,7 +2484,7 @@ class Context {
    */
   markUrlSeenFromMatchingTagSpec_(parsedTagSpec) {
     if (!this.hasSeenUrl() && parsedTagSpec.containsUrl())
-      this.firstUrlSeenTag_ = parsedTagSpec.getSpec();
+    {this.firstUrlSeenTag_ = parsedTagSpec.getSpec();}
   }
 
   /**
@@ -2512,7 +2512,7 @@ class Context {
    */
   recordValidatedFromTagSpec_(parsedTagSpec) {
     if (!this.tagspecsValidated_.hasOwnProperty(parsedTagSpec.id()))
-      this.tagspecsValidated_[parsedTagSpec.id()] = true;
+    {this.tagspecsValidated_[parsedTagSpec.id()] = true;}
   }
 
   /**
@@ -2781,7 +2781,7 @@ class UrlErrorInAttrAdapter {
  */
 function validateAttrValueUrl(parsedAttrSpec, context, attr, tagSpec, result) {
   /** @type {!Array<string>} */
-  let maybeUris = [];
+  const maybeUris = [];
   if (attr.name !== 'srcset') {
     maybeUris.push(attr.value);
   } else {
@@ -2860,9 +2860,9 @@ function validateAttrValueUrl(parsedAttrSpec, context, attr, tagSpec, result) {
  * @param {!amp.validator.ValidationResult} result
  */
 function validateUrlAndProtocol(
-    parsedUrlSpec, adapter, context, urlStr, tagSpec, result) {
+  parsedUrlSpec, adapter, context, urlStr, tagSpec, result) {
   const spec = parsedUrlSpec.getSpec();
-  const onlyWhitespaceRe = /^[\s\xa0]*$/;  // includes non-breaking space
+  const onlyWhitespaceRe = /^[\s\xa0]*$/; // includes non-breaking space
   if (urlStr.match(onlyWhitespaceRe) !== null &&
       (spec.allowEmpty === null || spec.allowEmpty === false)) {
     if (amp.validator.LIGHT) {
@@ -2933,7 +2933,7 @@ function validateUrlAndProtocol(
  * @param {!amp.validator.ValidationResult} result
  */
 function validateAttrValueProperties(
-    parsedValueProperties, context, attr, tagSpec, result) {
+  parsedValueProperties, context, attr, tagSpec, result) {
   // TODO(johannes): Replace this hack with a parser.
   const segments = attr.value.split(/[,;]/);
   /** @type {!Object<string, string>} */
@@ -3020,7 +3020,7 @@ function validateAttrValueProperties(
  * @param {!amp.validator.ValidationResult} result
  */
 function validateNonTemplateAttrValueAgainstSpec(
-    parsedAttrSpec, context, attr, tagSpec, result) {
+  parsedAttrSpec, context, attr, tagSpec, result) {
   // The value, value_regex, value_url, and value_properties fields are treated
   // like a oneof, but we're not using oneof because it's a feature that was
   // added after protobuf 2.5.0 (which our open-source version uses).
@@ -3054,9 +3054,9 @@ function validateNonTemplateAttrValueAgainstSpec(
         getTagSpecUrl(tagSpec), result);
   } else if (spec.valueRegex !== null || spec.valueRegexCasei !== null) {
     const valueRegex = (spec.valueRegex !== null) ?
-        context.getRules().getFullMatchRegex(spec.valueRegex) :
-        context.getRules().getFullMatchCaseiRegex(
-            /** @type {number} */ (spec.valueRegexCasei));
+      context.getRules().getFullMatchRegex(spec.valueRegex) :
+      context.getRules().getFullMatchCaseiRegex(
+          /** @type {number} */ (spec.valueRegexCasei));
     if (!valueRegex.test(attr.value)) {
       if (amp.validator.LIGHT) {
         result.status = amp.validator.ValidationResult.Status.FAIL;
@@ -3226,7 +3226,7 @@ function CalculateLayout(inputLayout, width, height, sizesAttr, heightsAttr) {
   } else if (height.isSet && (!width.isSet || width.isAuto)) {
     return amp.validator.AmpLayout.Layout.FIXED_HEIGHT;
   } else if (
-      height.isSet && width.isSet &&
+    height.isSet && width.isSet &&
       (sizesAttr !== undefined || heightsAttr !== undefined)) {
     return amp.validator.AmpLayout.Layout.RESPONSIVE;
   } else {
@@ -3268,7 +3268,7 @@ function shouldRecordTagspecValidated(tag, tagSpecId, tagSpecIdsToTrack) {
  * @return {string} dispatch key
  */
 function makeDispatchKey(
-    dispatchKeyType, attrName, attrValue, mandatoryParent) {
+  dispatchKeyType, attrName, attrValue, mandatoryParent) {
   switch (dispatchKeyType) {
     case amp.validator.AttrSpec.DispatchKeyType.NAME_DISPATCH:
       return attrName;
@@ -3280,7 +3280,7 @@ function makeDispatchKey(
     default:
       goog.asserts.assert(false);
   }
-  return '';  // To make closure happy.
+  return ''; // To make closure happy.
 }
 
 /**
@@ -3348,7 +3348,7 @@ function validateParentTag(parsedTagSpec, context, validationResult) {
         [
           getTagSpecName(spec),
           context.getTagStack().parentTagName().toLowerCase(),
-          spec.mandatoryParent.toLowerCase()
+          spec.mandatoryParent.toLowerCase(),
         ],
         getTagSpecUrl(spec), validationResult);
   }
@@ -3363,15 +3363,15 @@ function validateParentTag(parsedTagSpec, context, validationResult) {
  * @param {!amp.validator.ValidationResult} validationResult
  */
 function validateDescendantTags(
-    encounteredTag, parsedTagSpec, context, validationResult) {
+  encounteredTag, parsedTagSpec, context, validationResult) {
   const tagStack = context.getTagStack();
 
-  for (var ii = 0; ii < tagStack.allowedDescendantsList().length; ++ii) {
+  for (let ii = 0; ii < tagStack.allowedDescendantsList().length; ++ii) {
     const allowedDescendantsList = tagStack.allowedDescendantsList()[ii];
     // If the tag we're validating is not whitelisted for a specific ancestor,
     // then throw an error.
     if (!allowedDescendantsList.allowedTags.includes(
-            encounteredTag.upperName())) {
+        encounteredTag.upperName())) {
       if (amp.validator.LIGHT) {
         validationResult.status = amp.validator.ValidationResult.Status.FAIL;
         return;
@@ -3382,7 +3382,7 @@ function validateDescendantTags(
             /* params */
             [
               encounteredTag.lowerName(),
-              allowedDescendantsList.tagName.toLowerCase()
+              allowedDescendantsList.tagName.toLowerCase(),
             ],
             getTagSpecUrl(parsedTagSpec), validationResult);
         return;
@@ -3398,7 +3398,7 @@ function validateDescendantTags(
  * @param {!amp.validator.ValidationResult} validationResult
  */
 function validateNoSiblingsAllowedTags(
-    parsedTagSpec, context, validationResult) {
+  parsedTagSpec, context, validationResult) {
   const spec = parsedTagSpec.getSpec();
   const tagStack = context.getTagStack();
 
@@ -3428,7 +3428,7 @@ function validateNoSiblingsAllowedTags(
           /* params */
           [
             tagStack.parentOnlyChildTagName().toLowerCase(),
-            tagStack.parentTagName().toLowerCase()
+            tagStack.parentTagName().toLowerCase(),
           ],
           getTagSpecUrl(spec), validationResult);
     }
@@ -3454,7 +3454,7 @@ function validateLastChildTags(context, validationResult) {
           /* params */
           [
             tagStack.parentLastChildTagName().toLowerCase(),
-            tagStack.parentTagName().toLowerCase()
+            tagStack.parentTagName().toLowerCase(),
           ],
           tagStack.parentLastChildUrl(), validationResult);
     }
@@ -3471,7 +3471,7 @@ function validateLastChildTags(context, validationResult) {
 function validateRequiredExtensions(parsedTagSpec, context, validationResult) {
   const tagSpec = parsedTagSpec.getSpec();
   const extensionsCtx = context.getExtensions();
-  for (let requiredExtension of tagSpec.requiresExtension) {
+  for (const requiredExtension of tagSpec.requiresExtension) {
     if (!extensionsCtx.isExtensionLoaded(requiredExtension)) {
       if (amp.validator.LIGHT) {
         validationResult.status = amp.validator.ValidationResult.Status.FAIL;
@@ -3496,10 +3496,10 @@ function validateRequiredExtensions(parsedTagSpec, context, validationResult) {
  * @param {!amp.validator.ValidationResult} validationResult
  */
 function validateAttrRequiredExtensions(
-    parsedAttrSpec, context, validationResult) {
+  parsedAttrSpec, context, validationResult) {
   const attrSpec = parsedAttrSpec.getSpec();
   const extensionsCtx = context.getExtensions();
-  for (let requiredExtension of attrSpec.requiresExtension) {
+  for (const requiredExtension of attrSpec.requiresExtension) {
     if (!extensionsCtx.isExtensionLoaded(requiredExtension)) {
       if (amp.validator.LIGHT) {
         validationResult.status = amp.validator.ValidationResult.Status.FAIL;
@@ -3550,9 +3550,9 @@ function validateUniqueness(parsedTagSpec, context, validationResult) {
  * @param {!amp.validator.ValidationResult} validationResult
  */
 function checkForReferencePointCollision(
-    refPointSpec, tagSpec, context, validationResult) {
-  if (refPointSpec === null || !refPointSpec.hasReferencePoints()) return;
-  if (tagSpec === null || !tagSpec.hasReferencePoints()) return;
+  refPointSpec, tagSpec, context, validationResult) {
+  if (refPointSpec === null || !refPointSpec.hasReferencePoints()) {return;}
+  if (tagSpec === null || !tagSpec.hasReferencePoints()) {return;}
 
   if (amp.validator.LIGHT) {
     validationResult.status = amp.validator.ValidationResult.Status.FAIL;
@@ -3563,7 +3563,7 @@ function checkForReferencePointCollision(
         /* params */
         [
           getTagSpecName(tagSpec.getSpec()),
-          refPointSpec.getReferencePoints().parentTagSpecName()
+          refPointSpec.getReferencePoints().parentTagSpecName(),
         ],
         refPointSpec.getReferencePoints().parentSpecUrl(), validationResult);
   }
@@ -3578,7 +3578,7 @@ function checkForReferencePointCollision(
 function validateAncestorTags(parsedTagSpec, context, validationResult) {
   const spec = parsedTagSpec.getSpec();
   if (spec.mandatoryAncestor !== null) {
-    const mandatoryAncestor = spec.mandatoryAncestor;
+    const {mandatoryAncestor} = spec;
     if (!context.getTagStack().hasAncestor(mandatoryAncestor)) {
       if (amp.validator.LIGHT) {
         validationResult.status = amp.validator.ValidationResult.Status.FAIL;
@@ -3591,7 +3591,7 @@ function validateAncestorTags(parsedTagSpec, context, validationResult) {
               /* params */
               [
                 getTagSpecName(spec), mandatoryAncestor.toLowerCase(),
-                spec.mandatoryAncestorSuggestedAlternative.toLowerCase()
+                spec.mandatoryAncestorSuggestedAlternative.toLowerCase(),
               ],
               getTagSpecUrl(spec), validationResult);
         } else {
@@ -3651,7 +3651,7 @@ function validateLayout(parsedTagSpec, context, encounteredTag, result) {
        attrValueHasTemplateSyntax(heightAttr) ||
        attrValueHasTemplateSyntax(sizesAttr) ||
        attrValueHasTemplateSyntax(heightsAttr)))
-    return;
+  {return;}
 
   // Parse the input layout attributes which we found for this tag.
   const inputLayout = parseLayout(layoutAttr);
@@ -3724,8 +3724,8 @@ function validateLayout(parsedTagSpec, context, encounteredTag, result) {
       result.status = amp.validator.ValidationResult.Status.FAIL;
     } else {
       const code = layoutAttr === undefined ?
-          amp.validator.ValidationError.Code.IMPLIED_LAYOUT_INVALID :
-          amp.validator.ValidationError.Code.SPECIFIED_LAYOUT_INVALID;
+        amp.validator.ValidationError.Code.IMPLIED_LAYOUT_INVALID :
+        amp.validator.ValidationError.Code.SPECIFIED_LAYOUT_INVALID;
       context.addError(
           code, context.getLineCol(),
           /* params */[layout, getTagSpecName(spec)], getTagSpecUrl(spec),
@@ -3818,9 +3818,9 @@ function validateLayout(parsedTagSpec, context, encounteredTag, result) {
       result.status = amp.validator.ValidationResult.Status.FAIL;
     } else {
       const code = layoutAttr === undefined ?
-          amp.validator.ValidationError.Code.ATTR_DISALLOWED_BY_IMPLIED_LAYOUT :
-          amp.validator.ValidationError.Code
-              .ATTR_DISALLOWED_BY_SPECIFIED_LAYOUT;
+        amp.validator.ValidationError.Code.ATTR_DISALLOWED_BY_IMPLIED_LAYOUT :
+        amp.validator.ValidationError.Code
+            .ATTR_DISALLOWED_BY_SPECIFIED_LAYOUT;
       context.addError(
           code, context.getLineCol(),
           /* params */['heights', getTagSpecName(spec), layout],
@@ -3849,7 +3849,7 @@ function validateAttrNotFoundInSpec(parsedTagSpec, context, attrName, result) {
   // However, to avoid parsing differences, we restrict the set of allowed
   // characters in the document.
   const dataAttrRe = /^data-[A-Za-z0-9-_:.]*$/;
-  if (attrName.match(dataAttrRe) !== null) return;
+  if (attrName.match(dataAttrRe) !== null) {return;}
 
   // At this point, it's an error either way, but we try to give a
   // more specific error in the case of Mustache template characters.
@@ -3885,7 +3885,7 @@ function validateAttrNotFoundInSpec(parsedTagSpec, context, attrName, result) {
  * @param {!amp.validator.ValidationResult} result
  */
 function validateAttrValueBelowTemplateTag(
-    parsedTagSpec, context, attr, result) {
+  parsedTagSpec, context, attr, result) {
   if (attrValueHasUnescapedTemplateSyntax(attr.value)) {
     if (amp.validator.LIGHT) {
       result.status = amp.validator.ValidationResult.Status.FAIL;
@@ -3926,7 +3926,7 @@ function validateAttrValueBelowTemplateTag(
 function validateAttributeInExtension(tagSpec, context, attr, result) {
   goog.asserts.assert(tagSpec.extensionSpec !== null);
 
-  const extensionSpec = tagSpec.extensionSpec;
+  const {extensionSpec} = tagSpec;
   // TagSpecs with extensions will only be evaluated if their dispatch_key
   // matches, which is based on this custom-element/custom-template field
   // attribute value. The dispatch key matching is case-insensitive for
@@ -3939,7 +3939,7 @@ function validateAttributeInExtension(tagSpec, context, attr, result) {
     }
     return true;
   } else if (
-      extensionSpec.isCustomTemplate && attr.name === 'custom-template') {
+    extensionSpec.isCustomTemplate && attr.name === 'custom-template') {
     if (extensionSpec.name !== attr.value) {
       goog.asserts.assert(extensionSpec.name === attr.value.toLowerCase());
       return false;
@@ -3948,7 +3948,7 @@ function validateAttributeInExtension(tagSpec, context, attr, result) {
   } else if (attr.name === 'src') {
     const srcUrlRe =
         /^https:\/\/cdn\.ampproject\.org\/v0\/(amp-[a-z0-9-]*)-([a-z0-9.]*)\.js$/;
-    let reResult = srcUrlRe.exec(attr.value);
+    const reResult = srcUrlRe.exec(attr.value);
     // If the src URL matches this regex and the base name of the file matches
     // the extension, look to see if the version matches.
     if (reResult !== null && reResult[1] === extensionSpec.name) {
@@ -3966,7 +3966,7 @@ function validateAttributeInExtension(tagSpec, context, attr, result) {
         }
       }
       if (extensionSpec.allowedVersions.indexOf(encounteredVersion) !== -1)
-        return true;
+      {return true;}
     }
     if (amp.validator.LIGHT) {
       result.status = amp.validator.ValidationResult.Status.FAIL;
@@ -3994,7 +3994,7 @@ function validateAttributeInExtension(tagSpec, context, attr, result) {
  * @param {!amp.validator.ValidationResult} result
  */
 function validateAttributes(
-    parsedTagSpec, bestMatchReferencePoint, context, encounteredTag, result) {
+  parsedTagSpec, bestMatchReferencePoint, context, encounteredTag, result) {
   const spec = parsedTagSpec.getSpec();
   if (spec.ampLayout !== null) {
     validateLayout(parsedTagSpec, context, encounteredTag, result);
@@ -4008,9 +4008,9 @@ function validateAttributes(
   let seenExtensionSrcAttr = false;
   const hasTemplateAncestor = context.getTagStack().hasAncestor('TEMPLATE');
   /** @type {!Array<boolean>} */
-  let mandatoryAttrsSeen = [];  // This is a set of attr ids.
+  const mandatoryAttrsSeen = []; // This is a set of attr ids.
   /** @type {!Array<number>} */
-  const mandatoryOneofsSeen = [];  // This is small list of interned strings.
+  const mandatoryOneofsSeen = []; // This is small list of interned strings.
   /** @type {!Array<!amp.validator.AttrSpec>} */
   const triggersToCheck = [];
   /**
@@ -4025,17 +4025,17 @@ function validateAttributes(
   // Our html parser delivers attributes as an array of alternating keys and
   // values. We skip over this array 2 at a time to iterate over the keys.
   const attrsByName = parsedTagSpec.getAttrsByName();
-  for (let attr of encounteredTag.attrs()) {
+  for (const attr of encounteredTag.attrs()) {
     if (!(attr.name in attrsByName)) {
       // While validating a reference point, we skip attributes that
       // we don't have a spec for. They will be validated when the
       // TagSpec itself gets validated.
-      if (parsedTagSpec.isReferencePoint()) continue;
+      if (parsedTagSpec.isReferencePoint()) {continue;}
       // On the other hand, if we did just validate a reference point for
       // this tag, we check whether that reference point covers the attribute.
       if (bestMatchReferencePoint !== null &&
           bestMatchReferencePoint.hasAttrWithName(attr.name))
-        continue;
+      {continue;}
 
       // If |spec| is an extension, then we ad-hoc validate 'custom-element',
       // 'custom-templa'te, and 'src' attributes by calling this method.
@@ -4043,23 +4043,23 @@ function validateAttributes(
       // (seen_src_attr), since it's a mandatory attr.
       if (spec.extensionSpec !== null &&
           validateAttributeInExtension(spec, context, attr, result)) {
-        if (attr.name === 'src') seenExtensionSrcAttr = true;
+        if (attr.name === 'src') {seenExtensionSrcAttr = true;}
         continue;
       }
       validateAttrNotFoundInSpec(parsedTagSpec, context, attr.name, result);
       if (result.status === amp.validator.ValidationResult.Status.FAIL) {
         if (amp.validator.LIGHT)
-          return;
+        {return;}
         else
-          continue;
+        {continue;}
       }
       if (hasTemplateAncestor) {
         validateAttrValueBelowTemplateTag(parsedTagSpec, context, attr, result);
         if (result.status === amp.validator.ValidationResult.Status.FAIL) {
           if (amp.validator.LIGHT)
-            return;
+          {return;}
           else
-            continue;
+          {continue;}
         }
       }
       continue;
@@ -4068,9 +4068,9 @@ function validateAttributes(
       validateAttrValueBelowTemplateTag(parsedTagSpec, context, attr, result);
       if (result.status === amp.validator.ValidationResult.Status.FAIL) {
         if (amp.validator.LIGHT)
-          return;
+        {return;}
         else
-          continue;
+        {continue;}
       }
     }
     const attrId = attrsByName[attr.name];
@@ -4098,9 +4098,9 @@ function validateAttributes(
           parsedAttrSpec, context, attr, spec, result);
       if (result.status === amp.validator.ValidationResult.Status.FAIL) {
         if (amp.validator.LIGHT)
-          return;
+        {return;}
         else
-          continue;
+        {continue;}
       }
     }
     if (attrSpec.blacklistedValueRegex !== null) {
@@ -4138,7 +4138,7 @@ function validateAttributes(
         continue;
       }
     }
-    const mandatoryOneof = attrSpec.mandatoryOneof;
+    const {mandatoryOneof} = attrSpec;
     if (mandatoryOneof !== null) {
       // The "at most 1" part of mandatory_oneof: mandatory_oneof
       // wants exactly one of the alternatives, so here
@@ -4154,7 +4154,7 @@ function validateAttributes(
               /* params */
               [
                 getTagSpecName(spec),
-                context.getRules().getInternedString(mandatoryOneof)
+                context.getRules().getInternedString(mandatoryOneof),
               ],
               getTagSpecUrl(spec), result);
           continue;
@@ -4166,8 +4166,8 @@ function validateAttributes(
     // If the trigger does not have an if_value_regex, then proceed to add the
     // spec. If it does have an if_value_regex, then test the regex to see
     // if it should add the spec.
-    if (attrSpec.trigger === null) continue;
-    const trigger = attrSpec.trigger;
+    if (attrSpec.trigger === null) {continue;}
+    const {trigger} = attrSpec;
     if (trigger.ifValueRegex === null ||
         context.getRules()
             .getFullMatchRegex(trigger.ifValueRegex)
@@ -4175,7 +4175,7 @@ function validateAttributes(
       triggersToCheck.push(attrSpec);
     }
   }
-  if (result.status === amp.validator.ValidationResult.Status.FAIL) return;
+  if (result.status === amp.validator.ValidationResult.Status.FAIL) {return;}
   // The "at least 1" part of mandatory_oneof: If none of the
   // alternatives were present, we report that an attribute is missing.
   for (const mandatoryOneof of parsedTagSpec.getMandatoryOneofs()) {
@@ -4190,7 +4190,7 @@ function validateAttributes(
             /* params */
             [
               getTagSpecName(spec),
-              context.getRules().getInternedString(mandatoryOneof)
+              context.getRules().getInternedString(mandatoryOneof),
             ],
             getTagSpecUrl(spec), result);
       }
@@ -4213,7 +4213,7 @@ function validateAttributes(
               [
                 context.getRules().getParsedAttrSpecs().getNameByAttrSpecId(
                     attrId),
-                getTagSpecName(spec), attrSpec.name
+                getTagSpecName(spec), attrSpec.name,
               ],
               getTagSpecUrl(spec), result);
         }
@@ -4233,7 +4233,7 @@ function validateAttributes(
             [
               context.getRules().getParsedAttrSpecs().getNameByAttrSpecId(
                   mandatory),
-              getTagSpecName(spec)
+              getTagSpecName(spec),
             ],
             getTagSpecUrl(spec), result);
       }
@@ -4320,7 +4320,7 @@ class TagSpecDispatch {
    * @return {number}
    */
   matchingDispatchKey(attrName, attrValue, mandatoryParent) {
-    if (!this.hasDispatchKeys()) return -1;
+    if (!this.hasDispatchKeys()) {return -1;}
 
     // Try first to find a key with the given parent.
     const dispatchKey = makeDispatchKey(
@@ -4351,7 +4351,7 @@ class TagSpecDispatch {
     // Special case for foo=foo. We consider this a match for a dispatch key of
     // foo="" or just <tag foo>.
     if (attrName === attrValue)
-      return this.matchingDispatchKey(attrName, '', mandatoryParent);
+    {return this.matchingDispatchKey(attrName, '', mandatoryParent);}
 
     return -1;
   }
@@ -4381,8 +4381,8 @@ class TagSpecDispatch {
  * @return {!amp.validator.ValidationResult}
  */
 function validateTagAgainstSpec(
-    parsedTagSpec, bestMatchReferencePoint, context, encounteredTag) {
-  let resultForAttempt = new amp.validator.ValidationResult();
+  parsedTagSpec, bestMatchReferencePoint, context, encounteredTag) {
+  const resultForAttempt = new amp.validator.ValidationResult();
   resultForAttempt.status = amp.validator.ValidationResult.Status.PASS;
   validateParentTag(parsedTagSpec, context, resultForAttempt);
   validateAncestorTags(parsedTagSpec, context, resultForAttempt);
@@ -4450,19 +4450,19 @@ function validateTagAgainstSpec(
  * @return {ValidateTagResult}
  */
 function validateTag(encounteredTag, bestMatchReferencePoint, context) {
-  let tagSpecDispatch =
+  const tagSpecDispatch =
       context.getRules().dispatchForTagName(encounteredTag.upperName());
   // If there are no dispatch keys matching the tag name, ex: tag name is
   // "foo", set a disallowed tag error.
   if (tagSpecDispatch === undefined) {
-    let result = new amp.validator.ValidationResult();
+    const result = new amp.validator.ValidationResult();
     if (amp.validator.LIGHT) {
       result.status = amp.validator.ValidationResult.Status.FAIL;
     } else {
       let specUrl = '';
       // Special case the spec_url for font tags to be slightly more useful.
       if (encounteredTag.upperName() === 'FONT')
-        specUrl = context.getRules().getStylesSpecUrl();
+      {specUrl = context.getRules().getStylesSpecUrl();}
       context.addError(
           amp.validator.ValidationError.Code.DISALLOWED_TAG,
           context.getLineCol(),
@@ -4483,7 +4483,7 @@ function validateTag(encounteredTag, bestMatchReferencePoint, context) {
   // over encountered attributes in the case where we have no dispatches.
   let bestMatchTagSpec = null;
   if (tagSpecDispatch.hasDispatchKeys()) {
-    for (let attr of encounteredTag.attrs()) {
+    for (const attr of encounteredTag.attrs()) {
       const maybeTagSpecId = tagSpecDispatch.matchingDispatchKey(
           attr.name,
           // Attribute values are case-sensitive by default, but we
@@ -4493,10 +4493,10 @@ function validateTag(encounteredTag, bestMatchReferencePoint, context) {
       if (maybeTagSpecId !== -1) {
         bestMatchTagSpec = context.getRules().getByTagSpecId(maybeTagSpecId);
         return {
-          bestMatchTagSpec: bestMatchTagSpec,
+          bestMatchTagSpec,
           validationResult: validateTagAgainstSpec(
               bestMatchTagSpec, bestMatchReferencePoint, context,
-              encounteredTag)
+              encounteredTag),
         };
       }
     }
@@ -4505,7 +4505,7 @@ function validateTag(encounteredTag, bestMatchReferencePoint, context) {
     // which gives an error that reads "tag foo is disallowed except in
     // specific forms".
     if (!tagSpecDispatch.hasTagSpecs()) {
-      let result = new amp.validator.ValidationResult();
+      const result = new amp.validator.ValidationResult();
       if (amp.validator.LIGHT) {
         result.status = amp.validator.ValidationResult.Status.FAIL;
       } else if (encounteredTag.upperName() === 'SCRIPT') {
@@ -4529,28 +4529,28 @@ function validateTag(encounteredTag, bestMatchReferencePoint, context) {
   // return errors from a single tagspec, not all of them. We keep around
   // the 'best' attempt until we have found a matching TagSpec or have
   // tried them all.
-  let resultForBestAttempt = new amp.validator.ValidationResult();
+  const resultForBestAttempt = new amp.validator.ValidationResult();
   resultForBestAttempt.status = amp.validator.ValidationResult.Status.UNKNOWN;
   for (const tagSpecId of tagSpecDispatch.allTagSpecs()) {
     const parsedTagSpec = context.getRules().getByTagSpecId(tagSpecId);
     const resultForAttempt = validateTagAgainstSpec(
         parsedTagSpec, bestMatchReferencePoint, context, encounteredTag);
     if (context.getRules().betterValidationResultThan(
-            resultForAttempt, resultForBestAttempt)) {
+        resultForAttempt, resultForBestAttempt)) {
       resultForBestAttempt.copyFrom(resultForAttempt);
       bestMatchTagSpec = parsedTagSpec;
       if (resultForBestAttempt.status ===
           amp.validator.ValidationResult.Status.PASS) {
         return {
-          bestMatchTagSpec: bestMatchTagSpec,
-          validationResult: resultForBestAttempt
+          bestMatchTagSpec,
+          validationResult: resultForBestAttempt,
         };
       }
     }
   }
   return {
-    bestMatchTagSpec: bestMatchTagSpec,
-    validationResult: resultForBestAttempt
+    bestMatchTagSpec,
+    validationResult: resultForBestAttempt,
   };
 }
 
@@ -4616,13 +4616,13 @@ class ParsedValidatorRules {
 
     if (!amp.validator.LIGHT) {
       /**
-       * @type {!function(!amp.validator.TagSpec) : boolean}
+       * @type {function(!amp.validator.TagSpec) : boolean}
        * @private
        */
       this.isTagSpecCorrectHtmlFormat_ = function(tagSpec) {
         const castedHtmlFormat =
             /** @type {amp.validator.HtmlFormat.Code<string>} */ (
-                /** @type {*} */ (htmlFormat));
+          /** @type {*} */ (htmlFormat));
         return tagSpec.htmlFormat.length === 0 ||
             tagSpec.htmlFormat.indexOf(castedHtmlFormat) !== -1;
       };
@@ -4634,7 +4634,7 @@ class ParsedValidatorRules {
       this.isCssLengthSpecCorrectHtmlFormat_ = function(cssLengthSpec) {
         const castedHtmlFormat =
             /** @type {amp.validator.HtmlFormat.Code<string>} */ (
-                /** @type {*} */ (htmlFormat));
+          /** @type {*} */ (htmlFormat));
         return cssLengthSpec.htmlFormat == castedHtmlFormat;
       };
     }
@@ -4647,8 +4647,8 @@ class ParsedValidatorRules {
 
     /** @private @type {!Array<boolean>} */
     this.tagSpecIdsToTrack_ = [];
-    var numTags = this.rules_.tags.length;
-    for (var tagSpecId = 0; tagSpecId < numTags; ++tagSpecId) {
+    const numTags = this.rules_.tags.length;
+    for (let tagSpecId = 0; tagSpecId < numTags; ++tagSpecId) {
       const tag = this.rules_.tags[tagSpecId];
       if (!amp.validator.LIGHT) {
         if (!this.isTagSpecCorrectHtmlFormat_(tag)) {
@@ -4670,9 +4670,9 @@ class ParsedValidatorRules {
           // This tag is an extension. Compute and register a dispatch key
           // for it.
           var dispatchKey;
-          var attrName = tag.extensionSpec.isCustomTemplate ?
-              'custom-template' :
-              'custom-element';
+          const attrName = tag.extensionSpec.isCustomTemplate ?
+            'custom-template' :
+            'custom-element';
           dispatchKey = makeDispatchKey(
               amp.validator.AttrSpec.DispatchKeyType.NAME_VALUE_DISPATCH,
               attrName, /** @type {string} */ (tag.extensionSpec.name), '');
@@ -4698,7 +4698,7 @@ class ParsedValidatorRules {
         // extension, we prefer to use the one that lists the extension first
         // (i === 0) as an example of that extension.
         if (!this.exampleUsageByExtension_.hasOwnProperty(extension) || i === 0)
-          this.exampleUsageByExtension_[extension] = getTagSpecName(tag);
+        {this.exampleUsageByExtension_[extension] = getTagSpecName(tag);}
       }
     }
     // The amp-ad tag doesn't require amp-ad javascript for historical
@@ -4790,7 +4790,7 @@ class ParsedValidatorRules {
 
   /**
    * @param {amp.validator.ValidationError.Code} errorCode
-   * @return {!string}
+   * @return {string}
    */
   getFormatByCode(errorCode) {
     return this.errorCodes_[errorCode].format;
@@ -4832,7 +4832,7 @@ class ParsedValidatorRules {
       max = Math.max(this.specificity(error.code), max);
     }
     return max;
-  };
+  }
 
   /**
    * Returns true iff statusA is a better status than statusB
@@ -4843,12 +4843,12 @@ class ParsedValidatorRules {
    */
   betterValidationStatusThan_(statusA, statusB) {
     // Equal, so not better than.
-    if (statusA === statusB) return false;
+    if (statusA === statusB) {return false;}
 
     // PASS > FAIL > UNKNOWN
-    if (statusA === amp.validator.ValidationResult.Status.PASS) return true;
-    if (statusB === amp.validator.ValidationResult.Status.PASS) return false;
-    if (statusA === amp.validator.ValidationResult.Status.FAIL) return true;
+    if (statusA === amp.validator.ValidationResult.Status.PASS) {return true;}
+    if (statusB === amp.validator.ValidationResult.Status.PASS) {return false;}
+    if (statusA === amp.validator.ValidationResult.Status.FAIL) {return true;}
     goog.asserts.assert(
         statusA === amp.validator.ValidationResult.Status.UNKNOWN);
     return false;
@@ -4862,22 +4862,22 @@ class ParsedValidatorRules {
    */
   betterValidationResultThan(resultA, resultB) {
     if (resultA.status !== resultB.status)
-      return this.betterValidationStatusThan_(resultA.status, resultB.status);
+    {return this.betterValidationStatusThan_(resultA.status, resultB.status);}
 
     // In the light mode, we only have status values.
     if (!amp.validator.LIGHT) {
       // Prefer the most specific error found in either set.
       if (this.maxSpecificity(resultA.errors) >
           this.maxSpecificity(resultB.errors))
-        return true;
+      {return true;}
       if (this.maxSpecificity(resultB.errors) >
           this.maxSpecificity(resultA.errors))
-        return false;
+      {return false;}
 
       // Prefer the attempt with the fewest errors if the most specific errors
       // are the same.
-      if (resultA.errors.length < resultB.errors.length) return true;
-      if (resultB.errors.length < resultA.errors.length) return false;
+      if (resultA.errors.length < resultB.errors.length) {return true;}
+      if (resultB.errors.length < resultA.errors.length) {return false;}
     }
 
     // Equal, so not better than.
@@ -4892,8 +4892,8 @@ class ParsedValidatorRules {
    */
   exampleTagForExtension(extensionName) {
     return this.exampleUsageByExtension_.hasOwnProperty(extensionName) ?
-        this.exampleUsageByExtension_[extensionName] :
-        '';
+      this.exampleUsageByExtension_[extensionName] :
+      '';
   }
 
   /**
@@ -4945,13 +4945,13 @@ class ParsedValidatorRules {
               /* params */
               [
                 context.getRules().getInternedString(condition),
-                getTagSpecName(spec.getSpec())
+                getTagSpecName(spec.getSpec()),
               ],
               getTagSpecUrl(spec), validationResult);
         }
       }
       for (const condition of spec.excludes()) {
-       if (context.satisfiesCondition(condition)) {
+        if (context.satisfiesCondition(condition)) {
           if (amp.validator.LIGHT) {
             validationResult.status =
                 amp.validator.ValidationResult.Status.FAIL;
@@ -4963,7 +4963,7 @@ class ParsedValidatorRules {
               /* params */
               [
                 getTagSpecName(spec.getSpec()),
-                context.getRules().getInternedString(condition)
+                context.getRules().getInternedString(condition),
               ],
               getTagSpecUrl(spec), validationResult);
         }
@@ -4979,7 +4979,7 @@ class ParsedValidatorRules {
                 /* params */
                 [
                   getTagSpecName(alsoRequiresTagspec.getSpec()),
-                  getTagSpecName(spec.getSpec())
+                  getTagSpecName(spec.getSpec()),
                 ],
                 getTagSpecUrl(spec), validationResult);
           }
@@ -4987,13 +4987,13 @@ class ParsedValidatorRules {
       }
     }
 
-    var extensionsCtx = context.getExtensions();
-    let unusedRequired = extensionsCtx.unusedExtensionsRequired();
+    const extensionsCtx = context.getExtensions();
+    const unusedRequired = extensionsCtx.unusedExtensionsRequired();
     for (const unusedExtensionName of unusedRequired) {
       if (amp.validator.LIGHT) {
         validationResult.status = amp.validator.ValidationResult.Status.FAIL;
         return;
-      } else {  // !amp.validator.LIGHT
+      } else { // !amp.validator.LIGHT
         context.addError(
             amp.validator.ValidationError.Code.EXTENSION_UNUSED,
             context.getLineCol(),
@@ -5012,7 +5012,7 @@ class ParsedValidatorRules {
   maybeEmitMandatoryAlternativesSatisfiedErrors(context, validationResult) {
     const satisfied = context.getMandatoryAlternativesSatisfied();
     /** @type {!Array<string>} */
-    let missing = [];
+    const missing = [];
     const specUrlsByMissing = Object.create(null);
     for (const tagSpec of this.rules_.tags) {
       if (tagSpec.mandatoryAlternatives === null ||
@@ -5052,7 +5052,7 @@ class ParsedValidatorRules {
     // Only emit an error if there have been inline styles used. Otherwise
     // if there was to be an error it would have been caught by
     // CdataMatcher::Match().
-    if (context.getInlineStyleByteSize() == 0) return;
+    if (context.getInlineStyleByteSize() == 0) {return;}
 
     const bytesUsed =
         context.getInlineStyleByteSize() + context.getStyleAmpCustomByteSize();
@@ -5111,7 +5111,7 @@ class ParsedValidatorRules {
   }
 
   /**
-   * @param {!string} tagName
+   * @param {string} tagName
    * @return {TagSpecDispatch|undefined}
    */
   dispatchForTagName(tagName) {
@@ -5148,7 +5148,7 @@ class ParsedValidatorRules {
   getReferencePointName(referencePoint) {
     // tagSpecName here is actually a number, which was replaced in
     // validator_gen_js.py from the name string, so this works.
-    const tagSpecId = /** @type {!number} */ (referencePoint.tagSpecName);
+    const tagSpecId = /** @type {number} */ (referencePoint.tagSpecName);
     const refPointSpec = this.getByTagSpecId(tagSpecId);
     return getTagSpecName(refPointSpec.getSpec());
   }
@@ -5192,258 +5192,258 @@ function byteLength(utf8Str) {
  */
 amp.validator.ValidationHandler =
     class extends amp.htmlparser.HtmlSaxHandlerWithLocation {
-  /**
+      /**
    * Creates a new handler.
    * @param {string} htmlFormat
    */
-  constructor(htmlFormat) {
-    super();
+      constructor(htmlFormat) {
+        super();
 
-    this.validationResult_ = new amp.validator.ValidationResult();
-    this.validationResult_.status =
+        this.validationResult_ = new amp.validator.ValidationResult();
+        this.validationResult_.status =
         amp.validator.ValidationResult.Status.UNKNOWN;
-    /**
+        /**
      * Rules from parsed JSON configuration.
      * @type {!ParsedValidatorRules}
      * @private
      */
-    this.rules_ = getParsedValidatorRules(htmlFormat);
-    /**
+        this.rules_ = getParsedValidatorRules(htmlFormat);
+        /**
      * Validation Context.
      * @type {!Context}
      * @private
      */
-    this.context_ = new Context(this.rules_);
-  }
+        this.context_ = new Context(this.rules_);
+      }
 
-  /**
+      /**
    * @return {!amp.validator.ValidationResult} Validation Result at the current
    *     step.
    */
-  Result() {
-    return this.validationResult_;
-  }
+      Result() {
+        return this.validationResult_;
+      }
 
-  /**
+      /**
    * Callback before startDoc which gives us a document locator.
    * @param {amp.htmlparser.DocLocator} locator
    * @override
    */
-  setDocLocator(locator) {
-    if (locator === null) {
-      goog.asserts.fail('Null DocLocator set');
-    } else {
-      this.context_.setDocLocator(locator);
-    }
-  }
+      setDocLocator(locator) {
+        if (locator === null) {
+          goog.asserts.fail('Null DocLocator set');
+        } else {
+          this.context_.setDocLocator(locator);
+        }
+      }
 
-  /**
+      /**
    * Callback for the start of a new HTML document.
    * @override
    */
-  startDoc() {
-    this.validationResult_ = new amp.validator.ValidationResult();
-    this.validationResult_.status =
+      startDoc() {
+        this.validationResult_ = new amp.validator.ValidationResult();
+        this.validationResult_.status =
         amp.validator.ValidationResult.Status.UNKNOWN;
-  }
+      }
 
-  /**
+      /**
    * Callback for the attributes from all the body tags encountered
    * within the document.
    * @override
    */
-  effectiveBodyTag(attributes) {
-    var encounteredAttrs = this.context_.getEncounteredBodyAttrs();
-    // If we never recorded a body tag with attributes, it was manufactured.
-    // In which case we've already logged an error for that. Doing more here
-    // would be confusing.
-    if (encounteredAttrs === null) return;
-    // So now we compare the attributes from the tag that we encountered
-    // (HtmlParser sent us a startTag event for it earlier) with the attributes
-    // from the effective body tag that we're just receiving now, which contains
-    // all attributes on body tags within the doc. It's correct to think of this
-    // synthetic tag simply as a concatenation - there is in general no
-    // elimination of duplicate attributes or overriding behavior. Thus, if the
-    // second body tag has any attribute this will result in an error.
-    var differenceSeen = attributes.length !== encounteredAttrs.length;
-    if (!differenceSeen) {
-      for (var ii = 0; ii < attributes.length; ii++) {
-        if (attributes[ii] !== encounteredAttrs[ii]) {
-          differenceSeen = true;
-          break;
+      effectiveBodyTag(attributes) {
+        const encounteredAttrs = this.context_.getEncounteredBodyAttrs();
+        // If we never recorded a body tag with attributes, it was manufactured.
+        // In which case we've already logged an error for that. Doing more here
+        // would be confusing.
+        if (encounteredAttrs === null) {return;}
+        // So now we compare the attributes from the tag that we encountered
+        // (HtmlParser sent us a startTag event for it earlier) with the attributes
+        // from the effective body tag that we're just receiving now, which contains
+        // all attributes on body tags within the doc. It's correct to think of this
+        // synthetic tag simply as a concatenation - there is in general no
+        // elimination of duplicate attributes or overriding behavior. Thus, if the
+        // second body tag has any attribute this will result in an error.
+        let differenceSeen = attributes.length !== encounteredAttrs.length;
+        if (!differenceSeen) {
+          for (let ii = 0; ii < attributes.length; ii++) {
+            if (attributes[ii] !== encounteredAttrs[ii]) {
+              differenceSeen = true;
+              break;
+            }
+          }
         }
-      }
-    }
-    if (!differenceSeen) return;
-    if (amp.validator.LIGHT) {
-      this.validationResult_.status =
+        if (!differenceSeen) {return;}
+        if (amp.validator.LIGHT) {
+          this.validationResult_.status =
           amp.validator.ValidationResult.Status.FAIL;
-      return;
-    }
-    this.context_.addError(
-        amp.validator.ValidationError.Code.DUPLICATE_UNIQUE_TAG,
-        this.context_.getEncounteredBodyLineCol(),
-        /* params */['BODY'], /* url */ '', this.validationResult_);
-  }
+          return;
+        }
+        this.context_.addError(
+            amp.validator.ValidationError.Code.DUPLICATE_UNIQUE_TAG,
+            this.context_.getEncounteredBodyLineCol(),
+            /* params */['BODY'], /* url */ '', this.validationResult_);
+      }
 
-  /**
+      /**
    * Callback for the end of a new HTML document. Triggers validation of
    * mandatory
    * tag presence.
    */
-  endDoc() {
-    this.rules_.maybeEmitGlobalTagValidationErrors(
-        this.context_, this.validationResult_);
-    if (this.validationResult_.status ===
+      endDoc() {
+        this.rules_.maybeEmitGlobalTagValidationErrors(
+            this.context_, this.validationResult_);
+        if (this.validationResult_.status ===
         amp.validator.ValidationResult.Status.UNKNOWN) {
-      this.validationResult_.status =
+          this.validationResult_.status =
           amp.validator.ValidationResult.Status.PASS;
-    }
-    // As some errors can be inserted out of order, sort errors at the
-    // end based on their line/col numbers.
-    if (!amp.validator.LIGHT) {
-      goog.array.stableSort(this.validationResult_.errors, function(lhs, rhs) {
-        if (lhs.line != rhs.line) return lhs.line - rhs.line;
-        return lhs.col - rhs.col;
-      });
-    }
-  }
+        }
+        // As some errors can be inserted out of order, sort errors at the
+        // end based on their line/col numbers.
+        if (!amp.validator.LIGHT) {
+          goog.array.stableSort(this.validationResult_.errors, function(lhs, rhs) {
+            if (lhs.line != rhs.line) {return lhs.line - rhs.line;}
+            return lhs.col - rhs.col;
+          });
+        }
+      }
 
-  /**
+      /**
    * Callback for informing that the parser is manufacturing a <body> tag not
    * actually found on the page. This will be followed by a startTag() with the
    * actual body tag in question.
    * @override
    */
-  markManufacturedBody() {
-    if (amp.validator.LIGHT) {
-      this.validationResult_.status =
+      markManufacturedBody() {
+        if (amp.validator.LIGHT) {
+          this.validationResult_.status =
           amp.validator.ValidationResult.Status.FAIL;
-      return;
-    }
-    this.context_.addError(
-        amp.validator.ValidationError.Code.DISALLOWED_MANUFACTURED_BODY,
-        this.context_.getLineCol(),
-        /* params */[], /* url */ '', this.validationResult_);
-  }
+          return;
+        }
+        this.context_.addError(
+            amp.validator.ValidationError.Code.DISALLOWED_MANUFACTURED_BODY,
+            this.context_.getLineCol(),
+            /* params */[], /* url */ '', this.validationResult_);
+      }
 
-  /**
+      /**
    * While parsing the document HEAD, we may accumulate errors which depend
    * on seeing later extension <script> tags.
    */
-  emitMissingExtensionErrors() {
-    let extensionsCtx = this.context_.getExtensions();
-    if (amp.validator.LIGHT) {
-      if (extensionsCtx.hasMissingExtensionFailures()) {
-        this.validationResult_.status =
+      emitMissingExtensionErrors() {
+        const extensionsCtx = this.context_.getExtensions();
+        if (amp.validator.LIGHT) {
+          if (extensionsCtx.hasMissingExtensionFailures()) {
+            this.validationResult_.status =
             amp.validator.ValidationResult.Status.FAIL;
-        return;
+            return;
+          }
+        } else { // !amp.validator.LIGHT
+          for (const error of extensionsCtx.missingExtensionErrors())
+          {this.context_.addBuiltError(error, this.validationResult_);}
+        }
       }
-    } else {  // !amp.validator.LIGHT
-      for (const error of extensionsCtx.missingExtensionErrors())
-        this.context_.addBuiltError(error, this.validationResult_);
-    }
-  }
 
-  /**
+      /**
    * Callback for a start HTML tag.
    * @param {!amp.htmlparser.ParsedHtmlTag} encounteredTag
    * @override
    */
-  startTag(encounteredTag) {
-    /** @type {?string} */
-    let maybeDuplicateAttrName = encounteredTag.hasDuplicateAttrs();
-    if (maybeDuplicateAttrName !== null) {
-      if (!amp.validator.LIGHT) {
-        this.context_.addWarning(
-            amp.validator.ValidationError.Code.DUPLICATE_ATTRIBUTE,
-            this.context_.getLineCol(),
-            /* params */[encounteredTag.lowerName(), maybeDuplicateAttrName],
-            /* specUrl */ '', this.validationResult_);
-      }
-      encounteredTag.dedupeAttrs();
-    }
+      startTag(encounteredTag) {
+        /** @type {?string} */
+        const maybeDuplicateAttrName = encounteredTag.hasDuplicateAttrs();
+        if (maybeDuplicateAttrName !== null) {
+          if (!amp.validator.LIGHT) {
+            this.context_.addWarning(
+                amp.validator.ValidationError.Code.DUPLICATE_ATTRIBUTE,
+                this.context_.getLineCol(),
+                /* params */[encounteredTag.lowerName(), maybeDuplicateAttrName],
+                /* specUrl */ '', this.validationResult_);
+          }
+          encounteredTag.dedupeAttrs();
+        }
 
-    if ('BODY' === encounteredTag.upperName()) {
-      this.context_.recordBodyTag(encounteredTag.attrs());
-      this.emitMissingExtensionErrors();
-    }
+        if ('BODY' === encounteredTag.upperName()) {
+          this.context_.recordBodyTag(encounteredTag.attrs());
+          this.emitMissingExtensionErrors();
+        }
 
-    const attrsByKey = encounteredTag.attrsByKey();
-    const styleAttr = attrsByKey['style'];
-    if (styleAttr !== undefined) {
-      this.context_.addInlineStyleByteSize(byteLength(styleAttr));
-    }
+        const attrsByKey = encounteredTag.attrsByKey();
+        const styleAttr = attrsByKey['style'];
+        if (styleAttr !== undefined) {
+          this.context_.addInlineStyleByteSize(byteLength(styleAttr));
+        }
 
-    /** @type {ValidateTagResult} */
-    let resultForReferencePoint = {
-      bestMatchTagSpec: null,
-      validationResult: new amp.validator.ValidationResult()
-    };
-    resultForReferencePoint.validationResult.status =
+        /** @type {ValidateTagResult} */
+        let resultForReferencePoint = {
+          bestMatchTagSpec: null,
+          validationResult: new amp.validator.ValidationResult(),
+        };
+        resultForReferencePoint.validationResult.status =
         amp.validator.ValidationResult.Status.UNKNOWN;
-    const referencePointMatcher =
+        const referencePointMatcher =
         this.context_.getTagStack().parentReferencePointMatcher();
-    if (referencePointMatcher !== null) {
-      resultForReferencePoint =
+        if (referencePointMatcher !== null) {
+          resultForReferencePoint =
           referencePointMatcher.validateTag(encounteredTag, this.context_);
-      this.validationResult_.mergeFrom(
-          resultForReferencePoint.validationResult);
-    }
+          this.validationResult_.mergeFrom(
+              resultForReferencePoint.validationResult);
+        }
 
-    const resultForTag = validateTag(
-        encounteredTag, resultForReferencePoint.bestMatchTagSpec,
-        this.context_);
-    checkForReferencePointCollision(
-        resultForReferencePoint.bestMatchTagSpec, resultForTag.bestMatchTagSpec,
-        this.context_, resultForTag.validationResult);
-    this.validationResult_.mergeFrom(resultForTag.validationResult);
+        const resultForTag = validateTag(
+            encounteredTag, resultForReferencePoint.bestMatchTagSpec,
+            this.context_);
+        checkForReferencePointCollision(
+            resultForReferencePoint.bestMatchTagSpec, resultForTag.bestMatchTagSpec,
+            this.context_, resultForTag.validationResult);
+        this.validationResult_.mergeFrom(resultForTag.validationResult);
 
-    this.context_.updateFromTagResults(
-        encounteredTag, resultForReferencePoint, resultForTag);
-  }
+        this.context_.updateFromTagResults(
+            encounteredTag, resultForReferencePoint, resultForTag);
+      }
 
-  /**
+      /**
    * Callback for an end HTML tag.
    * @param {!amp.htmlparser.ParsedHtmlTag} tag
    * @override
    */
-  endTag(tag) {
-    this.context_.getTagStack().exitTag(this.context_, this.validationResult_);
-  };
+      endTag(tag) {
+        this.context_.getTagStack().exitTag(this.context_, this.validationResult_);
+      }
 
-  /**
+      /**
    * Callback for pcdata. I'm not sure what this is supposed to include, but it
    * seems to be called for contents of <p> tags, looking at a few examples.
    * @param {string} text
    * @override
    */
-  pcdata(text) {}
+      pcdata(text) {}
 
-  /**
+      /**
    * Callback for rcdata text. rcdata text includes contents of title or
    * textarea
    * tags. The validator has no specific rules regarding these text blobs.
    * @param {string} text
    * @override
    */
-  rcdata(text) {}
+      rcdata(text) {}
 
-  /**
+      /**
    * Callback for cdata.
    * @param {string} text
    * @override
    */
-  cdata(text) {
-    // Record <style amp-custom> byte size
-    if (this.context_.getTagStack().isStyleAmpCustomChild()) {
-      this.context_.addStyleAmpCustomByteSize(byteLength(text));
-    }
-    const matcher = this.context_.getTagStack().cdataMatcher();
-    if (matcher !== null)
-      matcher.match(text, this.context_, this.validationResult_);
-  }
-};
+      cdata(text) {
+        // Record <style amp-custom> byte size
+        if (this.context_.getTagStack().isStyleAmpCustomChild()) {
+          this.context_.addStyleAmpCustomByteSize(byteLength(text));
+        }
+        const matcher = this.context_.getTagStack().cdataMatcher();
+        if (matcher !== null)
+        {matcher.match(text, this.context_, this.validationResult_);}
+      }
+    };
 
 /**
  * Convenience function which informs caller if given ValidationError is
@@ -5537,15 +5537,15 @@ if (!amp.validator.LIGHT) {
    * @param {string=} opt_errorCategoryFilter
    */
   amp.validator.ValidationResult.prototype.outputToTerminal = function(
-      url, opt_terminal, opt_errorCategoryFilter) {
+    url, opt_terminal, opt_errorCategoryFilter) {
 
     const terminal = opt_terminal || new amp.validator.Terminal();
     const errorCategoryFilter = opt_errorCategoryFilter || null;
 
-    const status = this.status;
+    const {status} = this;
     if (status === amp.validator.ValidationResult.Status.PASS) {
       terminal.info('AMP validation successful.');
-      if (this.errors.length === 0) return;
+      if (this.errors.length === 0) {return;}
     } else if (status !== amp.validator.ValidationResult.Status.FAIL) {
       terminal.error(
           'AMP validation had unknown results. This indicates a validator ' +
@@ -5564,7 +5564,7 @@ if (!amp.validator.LIGHT) {
     } else {
       errors = [];
       for (const error of this.errors) {
-        if (('' + amp.validator.categorizeError(error)) ===
+        if ((String(amp.validator.categorizeError(error))) ===
             errorCategoryFilter) {
           errors.push(error);
         }
@@ -5738,7 +5738,7 @@ amp.validator.categorizeError = function(error) {
   // E.g. "The tag 'picture' is disallowed."
   if (error.code === amp.validator.ValidationError.Code.DISALLOWED_TAG) {
     if (error.params[0] === 'font')
-      return amp.validator.ErrorCategory.Code.AUTHOR_STYLESHEET_PROBLEM;
+    {return amp.validator.ErrorCategory.Code.AUTHOR_STYLESHEET_PROBLEM;}
     return amp.validator.ErrorCategory.Code.DISALLOWED_HTML;
   }
   // E.g. The tag 'div' contains the attribute 'width' repeated multiple times.
@@ -5821,7 +5821,7 @@ amp.validator.categorizeError = function(error) {
   // E.g. "The inline 'style' attribute is not allowed in AMP documents. Use
   // 'style amp-custom' tag instead."
   if (error.code === amp.validator.ValidationError.Code.DISALLOWED_STYLE_ATTR)
-    return amp.validator.ErrorCategory.Code.AUTHOR_STYLESHEET_PROBLEM;
+  {return amp.validator.ErrorCategory.Code.AUTHOR_STYLESHEET_PROBLEM;}
 
   // E.g. "CSS syntax error in tag 'style amp-custom' - unterminated string."
   if ((error.code ===
@@ -5891,7 +5891,7 @@ amp.validator.categorizeError = function(error) {
            amp.validator.ValidationError.Code
                .MANDATORY_CDATA_MISSING_OR_INCORRECT &&
        (goog.string./*OK*/ startsWith(
-            error.params[0], 'head > style[amp-boilerplate]') ||
+           error.params[0], 'head > style[amp-boilerplate]') ||
         goog.string./*OK*/ startsWith(
             error.params[0], 'noscript > style[amp-boilerplate]')))) {
     return amp.validator.ErrorCategory.Code

--- a/validator/engine/validator_test.js
+++ b/validator/engine/validator_test.js
@@ -61,7 +61,7 @@ function isdir(dir) {
   try {
     return fs.lstatSync(dir).isDirectory();
   } catch (e) {
-    return false;  // If there's neither a file nor a directory.
+    return false; // If there's neither a file nor a directory.
   }
 }
 
@@ -70,7 +70,7 @@ function isdir(dir) {
  * @return {boolean}
  */
 function isValidRegex(regex) {
-  var testRegex = null;
+  let testRegex = null;
   try {
     testRegex = new RegExp(regex);
   } catch (e) {
@@ -86,7 +86,7 @@ function isValidRegex(regex) {
  * @return {boolean}
  */
 function isMissingUnicodeGroup(regex) {
-  var wordGroupRegex = new RegExp("\\\\w(?!\\\\p{L}\\\\p{N}_)");
+  const wordGroupRegex = new RegExp('\\\\w(?!\\\\p{L}\\\\p{N}_)');
   return wordGroupRegex.test(regex);
 }
 
@@ -112,13 +112,13 @@ function findHtmlFilesRelativeToTestdata() {
         for (const possibleVersion of readdir(extensionFolder)) {
           const testPath = path.join(extension, possibleVersion, 'test');
           if (isdir(path.join(root, testPath))) {
-            testSubdirs.push({root: root, subdir: testPath});
+            testSubdirs.push({root, subdir: testPath});
           }
         }
       }
     } else {
       for (const subdir of readdir(root)) {
-        testSubdirs.push({root: root, subdir: subdir});
+        testSubdirs.push({root, subdir});
       }
     }
   }
@@ -223,12 +223,12 @@ function renderInlineResult(validationResult, filename, filecontents) {
     // Emit a carat showing the column of the following error.
     rendered += '\n>>';
     for (let i = 0; i < error.col + 1; ++i)
-      rendered += ' ';
+    {rendered += ' ';}
     rendered += '^~~~~~~~~\n';
     rendered += renderErrorWithPosition(filename, error);
   }
   while (linesEmitted < lines.length) {
-    rendered += '\n|  '+ lines[linesEmitted++];
+    rendered += '\n|  ' + lines[linesEmitted++];
   }
   return rendered;
 }
@@ -242,15 +242,15 @@ ValidatorTestCase.prototype.run = function() {
       amp.validator.validateString(this.ampHtmlFileContents, this.htmlFormat);
   amp.validator.annotateWithErrorCategories(results);
   const observed = this.inlineOutput ?
-      renderInlineResult(results, this.ampUrl, this.ampHtmlFileContents) :
-      amp.validator.renderValidationResult(results, this.ampUrl).join('\n');
+    renderInlineResult(results, this.ampUrl, this.ampHtmlFileContents) :
+    amp.validator.renderValidationResult(results, this.ampUrl).join('\n');
 
   if (observed === this.expectedOutput) {
     return;
   }
   if (process.env['UPDATE_VALIDATOR_TEST'] === '1' &&
       this.expectedOutputFile !== null) {
-    console/*OK*/.log('Updating ' +  this.expectedOutputFile + ' ...');
+    console/*OK*/.log('Updating ' + this.expectedOutputFile + ' ...');
     fs.writeFileSync(absolutePathFor(this.expectedOutputFile), observed);
     return;
   }
@@ -296,9 +296,9 @@ describe('ValidatorOutput', () => {
         amp.validator.renderValidationResult(results, test.ampUrl).join('\n');
     const expectedSubstr = 'http://google.com/foo.html:28:3';
     if (observed.indexOf(expectedSubstr) === -1)
-      assert.fail(
-          '', '', 'expectedSubstr:\n' + expectedSubstr +
-          '\nsaw:\n' + observed, '');
+    {assert.fail(
+        '', '', 'expectedSubstr:\n' + expectedSubstr +
+          '\nsaw:\n' + observed, '');}
   });
 });
 
@@ -333,18 +333,18 @@ describe('ValidatorCssLengthValidation', () => {
   });
 
   it('will not accept 50001 bytes in author stylesheet and 0 bytes in inline style',
-     () => {
-       const stylesheet = Array(5001).join(validStyleBlob) + ' ';
-       assertStrictEqual(50001, stylesheet.length);
-       const test = new ValidatorTestCase('feature_tests/css_length.html');
-       test.inlineOutput = false;
-       test.ampHtmlFileContents =
+      () => {
+        const stylesheet = Array(5001).join(validStyleBlob) + ' ';
+        assertStrictEqual(50001, stylesheet.length);
+        const test = new ValidatorTestCase('feature_tests/css_length.html');
+        test.inlineOutput = false;
+        test.ampHtmlFileContents =
            test.ampHtmlFileContents
                .replace('.replace_amp_custom {}', stylesheet)
                .replace('replace_inline_style', '');
-       test.expectedOutputFile = null;
-       // TODO(honeybadgerdontcare): Once inline style is allowed, update test.
-       test.expectedOutput = 'FAIL\n' +
+        test.expectedOutputFile = null;
+        // TODO(honeybadgerdontcare): Once inline style is allowed, update test.
+        test.expectedOutput = 'FAIL\n' +
            'feature_tests/css_length.html:28:2 The author stylesheet ' +
            'specified in tag \'style amp-custom\' is too long - we saw ' +
            '50001 bytes whereas the limit is 50000 bytes. ' +
@@ -355,22 +355,22 @@ describe('ValidatorCssLengthValidation', () => {
            'amp-custom\' tag instead. (see https://www.ampproject.org/' +
            'docs/guides/author-develop/responsive/style_pages) ' +
            '[AUTHOR_STYLESHEET_PROBLEM]';
-       test.run();
-     });
+        test.run();
+      });
 
   it('knows utf8 and rejects file with 50002 bytes but 49999 characters and 0 bytes in inline style',
-     () => {
-       const stylesheet = Array(5000).join(validStyleBlob) + 'h {a: 😺}';
-       assertStrictEqual(49999, stylesheet.length);  // character length
-       const test = new ValidatorTestCase('feature_tests/css_length.html');
-       test.inlineOutput = false;
-       test.ampHtmlFileContents =
+      () => {
+        const stylesheet = Array(5000).join(validStyleBlob) + 'h {a: 😺}';
+        assertStrictEqual(49999, stylesheet.length); // character length
+        const test = new ValidatorTestCase('feature_tests/css_length.html');
+        test.inlineOutput = false;
+        test.ampHtmlFileContents =
            test.ampHtmlFileContents
                .replace('.replace_amp_custom {}', stylesheet)
                .replace('replace_inline_style', '');
-       test.expectedOutputFile = null;
-       // TODO(honeybadgerdontcare): Once inline style is allowed, update test.
-       test.expectedOutput = 'FAIL\n' +
+        test.expectedOutputFile = null;
+        // TODO(honeybadgerdontcare): Once inline style is allowed, update test.
+        test.expectedOutput = 'FAIL\n' +
            'feature_tests/css_length.html:28:2 The author stylesheet ' +
            'specified in tag \'style amp-custom\' is too long - we saw ' +
            '50002 bytes whereas the limit is 50000 bytes. ' +
@@ -381,40 +381,40 @@ describe('ValidatorCssLengthValidation', () => {
            'amp-custom\' tag instead. (see https://www.ampproject.org/' +
            'docs/guides/author-develop/responsive/style_pages) ' +
            '[AUTHOR_STYLESHEET_PROBLEM]';
-       test.run();
-     });
+        test.run();
+      });
 
   it('accepts 0 bytes in author stylesheet and 50000 bytes in inline style',
-     () => {
-       const inlineStyle = Array(5001).join(validInlineStyleBlob);
-       assertStrictEqual(50000, inlineStyle.length);
-       const test = new ValidatorTestCase('feature_tests/css_length.html');
-       test.inlineOutput = false;
-       test.ampHtmlFileContents =
+      () => {
+        const inlineStyle = Array(5001).join(validInlineStyleBlob);
+        assertStrictEqual(50000, inlineStyle.length);
+        const test = new ValidatorTestCase('feature_tests/css_length.html');
+        test.inlineOutput = false;
+        test.ampHtmlFileContents =
            test.ampHtmlFileContents.replace('.replace_amp_custom {}', '')
                .replace('replace_inline_style', inlineStyle);
-       // TODO(honeybadgerdontcare): Once inline style is allowed, update test.
-       test.expectedOutput = 'FAIL\n' +
+        // TODO(honeybadgerdontcare): Once inline style is allowed, update test.
+        test.expectedOutput = 'FAIL\n' +
            'feature_tests/css_length.html:34:0 The inline \'style\' ' +
            'attribute is not allowed in AMP documents. Use \'style ' +
            'amp-custom\' tag instead. (see https://www.ampproject.org/' +
            'docs/guides/author-develop/responsive/style_pages) ' +
            '[AUTHOR_STYLESHEET_PROBLEM]';
-       test.run();
-     });
+        test.run();
+      });
 
   it('will not accept 0 bytes in author stylesheet and 50001 bytes in inline style',
-     () => {
-       const inlineStyle = Array(5001).join(validInlineStyleBlob) + ' ';
-       assertStrictEqual(50001, inlineStyle.length);
-       const test = new ValidatorTestCase('feature_tests/css_length.html');
-       test.inlineOutput = false;
-       test.ampHtmlFileContents =
+      () => {
+        const inlineStyle = Array(5001).join(validInlineStyleBlob) + ' ';
+        assertStrictEqual(50001, inlineStyle.length);
+        const test = new ValidatorTestCase('feature_tests/css_length.html');
+        test.inlineOutput = false;
+        test.ampHtmlFileContents =
            test.ampHtmlFileContents.replace('.replace_amp_custom {}', '')
                .replace('replace_inline_style', inlineStyle);
-       test.expectedOutputFile = null;
-       // TODO(honeybadgerdontcare): Once inline style is allowed, update test.
-       test.expectedOutput = 'FAIL\n' +
+        test.expectedOutputFile = null;
+        // TODO(honeybadgerdontcare): Once inline style is allowed, update test.
+        test.expectedOutput = 'FAIL\n' +
            'feature_tests/css_length.html:34:0 The inline \'style\' ' +
            'attribute is not allowed in AMP documents. Use \'style ' +
            'amp-custom\' tag instead. (see https://www.ampproject.org/' +
@@ -425,21 +425,21 @@ describe('ValidatorCssLengthValidation', () => {
            'styles is too large - we saw 50001 bytes whereas the limit is ' +
            '50000 bytes. (see https://www.ampproject.org/docs/guides/' +
            'author-develop/responsive/style_pages) [AUTHOR_STYLESHEET_PROBLEM]';
-       test.run();
-     });
+        test.run();
+      });
 
   it('will not accept 50000 bytes in author stylesheet and 14 bytes in inline style',
-     () => {
-       const stylesheet = Array(5001).join(validStyleBlob);
-       assertStrictEqual(50000, stylesheet.length);
-       const test = new ValidatorTestCase('feature_tests/css_length.html');
-       test.inlineOutput = false;
-       test.ampHtmlFileContents =
+      () => {
+        const stylesheet = Array(5001).join(validStyleBlob);
+        assertStrictEqual(50000, stylesheet.length);
+        const test = new ValidatorTestCase('feature_tests/css_length.html');
+        test.inlineOutput = false;
+        test.ampHtmlFileContents =
            test.ampHtmlFileContents
                .replace('.replace_amp_custom {}', stylesheet)
                .replace('replace_inline_style', 'display:block;');
-       // TODO(honeybadgerdontcare): Once inline style is allowed, update test.
-       test.expectedOutput = 'FAIL\n' +
+        // TODO(honeybadgerdontcare): Once inline style is allowed, update test.
+        test.expectedOutput = 'FAIL\n' +
            'feature_tests/css_length.html:5034:0 The inline \'style\' ' +
            'attribute is not allowed in AMP documents. Use \'style ' +
            'amp-custom\' tag instead. (see https://www.ampproject.org/' +
@@ -450,14 +450,15 @@ describe('ValidatorCssLengthValidation', () => {
            'styles is too large - we saw 50014 bytes whereas the limit is ' +
            '50000 bytes. (see https://www.ampproject.org/docs/guides/' +
            'author-develop/responsive/style_pages) [AUTHOR_STYLESHEET_PROBLEM]';
-       test.run();
-     });
+        test.run();
+      });
 });
 
 describe('CssLength', () => {
   it('parses a basic example', () => {
     const parsed = new amp.validator.CssLength(
         '10.1em', /* allowAuto */ false, /* allowFluid */ false);
+
     expect(parsed.isSet).toBe(true);
     expect(parsed.isValid).toBe(true);
     expect(parsed.numeral).toEqual(10.1);
@@ -470,6 +471,7 @@ describe('CssLength', () => {
       const example = '10' + allowedUnit;
       const parsed = new amp.validator.CssLength(
           example, /* allowAuto */ false, /* allowFluid */ false);
+
       expect(parsed.isSet).toBe(true);
       expect(parsed.isValid).toBe(true);
       expect(parsed.numeral).toEqual(10);
@@ -481,6 +483,7 @@ describe('CssLength', () => {
   it('understands empty unit as "px"', () => {
     const parsed = new amp.validator.CssLength(
         '10', /* allowAuto */ false, /* allowFluid */ false);
+
     expect(parsed.isSet).toBe(true);
     expect(parsed.isValid).toBe(true);
     expect(parsed.numeral).toEqual(10);
@@ -491,6 +494,7 @@ describe('CssLength', () => {
   it('understands undefined input as valid (means attr is not set)', () => {
     const parsed = new amp.validator.CssLength(
         undefined, /* allowAuto */ false, /* allowFluid */ false);
+
     expect(parsed.isSet).toBe(false);
     expect(parsed.isValid).toBe(true);
     expect(parsed.unit).toEqual('px');
@@ -500,86 +504,101 @@ describe('CssLength', () => {
   it('understands empty string as invalid (means attr value is empty)', () => {
     const parsed = new amp.validator.CssLength(
         '', /* allowAuto */ false, /* allowFluid */ false);
+
     expect(parsed.isValid).toBe(false);
   });
 
   it('considers other garbage as invalid', () => {
     expect(new amp.validator
-               .CssLength('100%', /* allowAuto */ false, /* allowFluid */ false)
-               .isValid)
+        .CssLength('100%', /* allowAuto */ false, /* allowFluid */ false)
+        .isValid)
         .toBe(false);
+
     expect(
         new amp.validator
             .CssLength(
                 'not a number', /* allowAuto */ false, /* allowFluid */ false)
             .isValid)
         .toBe(false);
+
     expect(
         new amp.validator
             .CssLength('1.1.1', /* allowAuto */ false, /* allowFluid */ false)
             .isValid)
         .toBe(false);
+
     expect(new amp.validator
-               .CssLength(
-                   '5 inches', /* allowAuto */ false, /* allowFluid */ false)
-               .isValid)
+        .CssLength(
+            '5 inches', /* allowAuto */ false, /* allowFluid */ false)
+        .isValid)
         .toBe(false);
+
     expect(new amp.validator
-               .CssLength(
-                   'fahrenheit', /* allowAuto */ false, /* allowFluid */ false)
-               .isValid)
+        .CssLength(
+            'fahrenheit', /* allowAuto */ false, /* allowFluid */ false)
+        .isValid)
         .toBe(false);
+
     expect(new amp.validator
-               .CssLength('px', /* allowAuto */ false, /* allowFluid */ false)
-               .isValid)
+        .CssLength('px', /* allowAuto */ false, /* allowFluid */ false)
+        .isValid)
         .toBe(false);
+
     expect(new amp.validator
-               .CssLength(  // screen size in ancient Rome.
-                   'ix unciae', /* allowAuto */ false, /* allowFluid */ false)
-               .isValid)
+        .CssLength( // screen size in ancient Rome.
+            'ix unciae', /* allowAuto */ false, /* allowFluid */ false)
+        .isValid)
         .toBe(false);
   });
 
   it('recognizes auto if allowed', () => {
-    {  // allow_auto = false with input != auto
+    { // allow_auto = false with input != auto
       const parsed = new amp.validator.CssLength(
           '1', /* allowAuto */ false, /* allowFluid */ false);
+
       expect(parsed.isValid).toBe(true);
       expect(parsed.isAuto).toBe(false);
     } {// allow_auto = true with input != auto
-       const parsed = new amp.validator.CssLength(
-           '1', /* allowAuto */ true, /* allowFluid */ false);
-       expect(parsed.isValid).toBe(true);
-       expect(parsed.isAuto)
-           .toBe(false);} {  // allow_auto = false with input = auto
+      const parsed = new amp.validator.CssLength(
+          '1', /* allowAuto */ true, /* allowFluid */ false);
+
+      expect(parsed.isValid).toBe(true);
+      expect(parsed.isAuto)
+          .toBe(false);} { // allow_auto = false with input = auto
       const parsed = new amp.validator.CssLength(
           'auto', /* allowAuto */ false, /* allowFluid */ false);
+
       expect(parsed.isValid).toBe(false);
     } {// allow_auto = true with input = auto
-       const parsed = new amp.validator.CssLength(
-           'auto', /* allowAuto */ true, /* allowFluid */ false);
-       expect(parsed.isValid).toBe(true); expect(parsed.isAuto).toBe(true);}
+      const parsed = new amp.validator.CssLength(
+          'auto', /* allowAuto */ true, /* allowFluid */ false);
+
+      expect(parsed.isValid).toBe(true); expect(parsed.isAuto).toBe(true);}
   });
 
   it('recognizes fluid if allowed', () => {
-    {  // allow_fluid = false with input != fluid
+    { // allow_fluid = false with input != fluid
       const parsed = new amp.validator.CssLength(
           '1', /* allowAuto */ false, /* allowFluid */ false);
+
       expect(parsed.isValid).toBe(true);
       expect(parsed.isFluid).toBe(false);
     } {// allow_fluid = true with input != fluid
-       const parsed = new amp.validator.CssLength(
-           '1', /* allowAuto */ false, /* allowFluid */ true);
-       expect(parsed.isValid).toBe(true);
-       expect(parsed.isFluid)
-           .toBe(false);} {  // allow_fluid = false with input = fluid
+      const parsed = new amp.validator.CssLength(
+          '1', /* allowAuto */ false, /* allowFluid */ true);
+
+      expect(parsed.isValid).toBe(true);
+      expect(parsed.isFluid)
+          .toBe(false);} { // allow_fluid = false with input = fluid
       const parsed = new amp.validator.CssLength(
           'fluid', /* allowAuto */ false, /* allowFluid */ false);
+
       expect(parsed.isValid).toBe(false);
     } {// allow_fluid = true with input = fluid
-       const parsed = new amp.validator.CssLength(
-           'fluid', /* allowAuto */ false, /* allowFluid */ true);
-       expect(parsed.isValid).toBe(true); expect(parsed.isFluid).toBe(true);}
+      const parsed = new amp.validator.CssLength(
+          'fluid', /* allowAuto */ false, /* allowFluid */ true);
+
+      expect(parsed.isValid).toBe(true); expect(parsed.isFluid).toBe(true);}
   });
 });
 
@@ -591,10 +610,10 @@ describe('CssLength', () => {
  */
 function compareAttrNames(a, b) {
   // amp-bind attributes (e.g. "[name]") should be after other attributes.
-  if (a.startsWith('[') && !b.startsWith('[')) return 1;
-  if (!a.startsWith('[') && b.startsWith('[')) return -1;
-  if (a < b) return -1;
-  if (a > b) return 1;
+  if (a.startsWith('[') && !b.startsWith('[')) {return 1;}
+  if (!a.startsWith('[') && b.startsWith('[')) {return -1;}
+  if (a < b) {return -1;}
+  if (a > b) {return 1;}
   return 0;
 }
 
@@ -632,40 +651,46 @@ function attrRuleShouldMakeSense(attrSpec, rules) {
       // disallowed_domain.
       it('allow_relative can not be true if ' +
           'disallowed_domain is whatever.ampproject.org',
-         () => {
-           for (const disallowedDomain of attrSpec.valueUrl.disallowedDomain) {
-             expect(disallowedDomain !== 'whatever.ampproject.org');
-           }
-         });
+      () => {
+        for (const disallowedDomain of attrSpec.valueUrl.disallowedDomain) {
+          expect(disallowedDomain !== 'whatever.ampproject.org');
+        }
+      });
     }
   }
   if (attrSpec.valueRegex !== null) {
     it('value_regex valid', () => {
       const regex = rules.internedStrings[-1 - attrSpec.valueRegex];
+
       expect(isValidRegex(regex)).toBe(true);
     });
     it('value_regex must have unicode named groups', () => {
       const regex = rules.internedStrings[-1 - attrSpec.valueRegex];
+
       expect(isMissingUnicodeGroup(regex)).toBe(false);
     });
   }
   if (attrSpec.valueRegexCasei !== null) {
     it('value_regex_casei valid', () => {
       const regex = rules.internedStrings[-1 - attrSpec.valueRegexCasei];
+
       expect(isValidRegex(regex)).toBe(true);
     });
     it('value_regex_casei must have unicode named groups', () => {
       const regex = rules.internedStrings[-1 - attrSpec.valueRegexCasei];
+
       expect(isMissingUnicodeGroup(regex)).toBe(false);
     });
   }
   if (attrSpec.blacklistedValueRegex !== null) {
     it('blacklisted_value_regex valid', () => {
       const regex = rules.internedStrings[-1 - attrSpec.blacklistedValueRegex];
+
       expect(isValidRegex(regex)).toBe(true);
     });
     it('blacklisted_value_regex must have unicode named groups', () => {
       const regex = rules.internedStrings[-1 - attrSpec.blacklistedValueRegex];
+
       expect(isMissingUnicodeGroup(regex)).toBe(false);
     });
   }
@@ -677,22 +702,22 @@ function attrRuleShouldMakeSense(attrSpec, rules) {
   }
   // only has one of value set.
   let numValues = 0;
-  if (attrSpec.value !== null) numValues += 1;
-  if (attrSpec.valueCasei !== null) numValues += 1;
-  if (attrSpec.valueRegex !== null) numValues += 1;
-  if (attrSpec.valueRegexCasei !== null) numValues += 1;
-  if (attrSpec.valueUrl !== null) numValues += 1;
-  if (attrSpec.valueProperties !== null) numValues += 1;
+  if (attrSpec.value !== null) {numValues += 1;}
+  if (attrSpec.valueCasei !== null) {numValues += 1;}
+  if (attrSpec.valueRegex !== null) {numValues += 1;}
+  if (attrSpec.valueRegexCasei !== null) {numValues += 1;}
+  if (attrSpec.valueUrl !== null) {numValues += 1;}
+  if (attrSpec.valueProperties !== null) {numValues += 1;}
   it('attr_spec only has one value set', () => {
     expect(numValues).toBeLessThan(2);
   });
   // deprecation
   if ((attrSpec.deprecation !== null) || (attrSpec.deprecationUrl !== null)) {
     it('deprecation and deprecation_url must both be defined if one is defined',
-       () => {
-         expect(attrSpec.deprecation).toBeDefined();
-         expect(attrSpec.deprecationUrl).toBeDefined();
-       });
+        () => {
+          expect(attrSpec.deprecation).toBeDefined();
+          expect(attrSpec.deprecationUrl).toBeDefined();
+        });
   }
   // dispatch_key
   if (attrSpec.dispatchKey !== null && attrSpec.dispatchKey) {
@@ -703,7 +728,7 @@ function attrRuleShouldMakeSense(attrSpec, rules) {
   }
   // Value property names must be unique.
   if (attrSpec.valueProperties !== null) {
-    var seenPropertySpecNames = {};
+    const seenPropertySpecNames = {};
     it('value_properties must be unique', () => {
       for (const propertySpec of attrSpec.valueProperties.properties) {
         expect(seenPropertySpecNames.hasOwnProperty(propertySpec.name))
@@ -723,18 +748,23 @@ describe('ValidatorRulesMakeSense', () => {
   it('tags defined', () => {
     expect(rules.tags.length).toBeGreaterThan(0);
   });
+
   it('direct_attr_lists defined', () => {
     expect(rules.directAttrLists.length).toBeGreaterThan(0);
   });
+
   it('global_attrs defined', () => {
     expect(rules.globalAttrs.length).toBeGreaterThan(0);
   });
+
   it('amp_layout_attrs defined', () => {
     expect(rules.ampLayoutAttrs.length).toBeGreaterThan(0);
   });
+
   it('min_validator_revision_required defined', () => {
     expect(rules.minValidatorRevisionRequired).toBeGreaterThan(0);
   });
+
   it('template_spec_url is set', () => {
     expect(rules.templateSpecUrl === null).toBe(false);
   });
@@ -797,6 +827,7 @@ describe('ValidatorRulesMakeSense', () => {
         specNameIsUnique[tagSpec.specName] = 0;
       } else if (tagSpec.extensionSpec !== null) {
         const specName = tagSpec.extensionSpec.name + ' extension .js script';
+
         expect(specNameIsUnique.hasOwnProperty(specName)).toBe(false);
         specNameIsUnique[specName] = 0;
       } else {
@@ -809,7 +840,7 @@ describe('ValidatorRulesMakeSense', () => {
     if ((tagSpec.tagName.indexOf('SCRIPT') === 0) && tagSpec.extensionSpec &&
         ((tagSpec.htmlFormat.length === 0) ||
          (tagSpec.htmlFormat.indexOf(
-              amp.validator.HtmlFormat.Code.AMP4ADS) !== -1))) {
+             amp.validator.HtmlFormat.Code.AMP4ADS) !== -1))) {
       // AMP4ADS Creative Format document is the source of this whitelist.
       // https://github.com/ampproject/amphtml/blob/master/extensions/amp-a4a/amp-a4a-format.md#amp-extensions-and-builtins
       const whitelistedAmp4AdsExtensions = {
@@ -832,7 +863,7 @@ describe('ValidatorRulesMakeSense', () => {
         'amp-position-observer': 0,
         'amp-social-share': 0,
         'amp-video': 0,
-        'amp-youtube': 0
+        'amp-youtube': 0,
       };
       const extension = tagSpec.extensionSpec.name;
       it(extension + ' has html_format either explicitly or implicitly' +
@@ -846,7 +877,7 @@ describe('ValidatorRulesMakeSense', () => {
     if ((tagSpec.tagName.indexOf('AMP-') === 0) &&
         ((tagSpec.htmlFormat.length === 0) ||
          (tagSpec.htmlFormat.indexOf(
-              amp.validator.HtmlFormat.Code.AMP4EMAIL) !== -1))) {
+             amp.validator.HtmlFormat.Code.AMP4EMAIL) !== -1))) {
       // AMP4EMAIL format is the source of this whitelist.
       const whitelistedAmp4EmailExtensions = {
         'AMP-ACCORDION': 0,
@@ -866,11 +897,11 @@ describe('ValidatorRulesMakeSense', () => {
              ' set for AMP4EMAIL but ' + tagSpec.tagName +
              ' is not whitelisted' +
              ' for AMP4EMAIL',
-         () => {
-           expect(
-               whitelistedAmp4EmailExtensions.hasOwnProperty(tagSpec.tagName))
-               .toBe(true);
-         });
+      () => {
+        expect(
+            whitelistedAmp4EmailExtensions.hasOwnProperty(tagSpec.tagName))
+            .toBe(true);
+      });
     }
     // mandatory_parent
     if (tagSpec.mandatoryParent !== null) {
@@ -900,6 +931,7 @@ describe('ValidatorRulesMakeSense', () => {
       if (attrSpecId < 0) {
         it('unique attr_name within tag_spec \'' + tagSpecName + '\'', () => {
           const attrName = rules.internedStrings[-1 - attrSpecId];
+
           expect(attrNameIsUnique.hasOwnProperty(attrName)).toBe(false);
           attrNameIsUnique[attrName] = 0;
         });
@@ -917,50 +949,50 @@ describe('ValidatorRulesMakeSense', () => {
       // whitelist check on the attribute value.
       if (tagSpec.tagName === 'SCRIPT' && attrSpec.name === 'src') {
         it('every <script> tag with a src attribute has a whitelist check',
-           () => {
-             expect(attrSpec.value !== null ||
+            () => {
+              expect(attrSpec.value !== null ||
                     attrSpec.valueRegex !== null).toBe(true);
-           });
+            });
       }
       // TagSpecs with an ExtensionSpec are extensions. We have a few
       // additional checks for these.
       if (tagSpec.extensionSpec !== null) {
-        const extensionSpec = tagSpec.extensionSpec;
+        const {extensionSpec} = tagSpec;
         it('extension must have a name field value', () => {
           expect(extensionSpec.name).toBeDefined();
         });
         it('extension ' + extensionSpec.name + ' must have at least two ' +
                'allowed_versions, latest and a numeric version, e.g `1.0`',
-           () => {
-             expect(extensionSpec.allowedVersions).toBeGreaterThan(1);
-           });
+        () => {
+          expect(extensionSpec.allowedVersions).toBeGreaterThan(1);
+        });
         it('extension ' + extensionSpec.name + ' versions must be `latest` ' +
                'or a numeric value',
-           () => {
-             for (const versionString of extensionSpec.allowedVersions) {
-               expect(versionString).toMatch(/^(latest|[0-9.])$/);
-             }
-             for (const versionString of extensionSpec.deprecatedVersions) {
-               expect(versionString).toMatch(/^(latest|[0-9.])$/);
-             }
-           });
+        () => {
+          for (const versionString of extensionSpec.allowedVersions) {
+            expect(versionString).toMatch(/^(latest|[0-9.])$/);
+          }
+          for (const versionString of extensionSpec.deprecatedVersions) {
+            expect(versionString).toMatch(/^(latest|[0-9.])$/);
+          }
+        });
         it('extension ' + extensionSpec.name + ' deprecated_versions must be ' +
                'subset of allowed_versions',
-           () => {
-             var allowedVersions = {};
-             for (const versionString of extensionSpec.allowedVersions) {
-               expect(versionString).toMatch(/^(latest|[0-9.])$/);
-             }
-             for (const versionString of extensionSpec.deprecatedVersions) {
-               expect(allowedVersions.hasOwnProperty(versionString)).toBe(true);
-             }
-           });
+        () => {
+          const allowedVersions = {};
+          for (const versionString of extensionSpec.allowedVersions) {
+            expect(versionString).toMatch(/^(latest|[0-9.])$/);
+          }
+          for (const versionString of extensionSpec.deprecatedVersions) {
+            expect(allowedVersions.hasOwnProperty(versionString)).toBe(true);
+          }
+        });
         it('extension ' + extensionSpec.name + ' must include the ' +
                'attr_list: "common-extension-attrs"` attr_list ',
-           () => {
-             expect(tagSpec.attrLists.length).toEqual(1);
-             expect(tagSpec.attrLists[0]).toEqual('common-extension-attrs');
-           });
+        () => {
+          expect(tagSpec.attrLists.length).toEqual(1);
+          expect(tagSpec.attrLists[0]).toEqual('common-extension-attrs');
+        });
       }
 
       if (attrSpec.dispatchKey) {
@@ -972,7 +1004,8 @@ describe('ValidatorRulesMakeSense', () => {
     }
 
     it('\'' + tagSpecName + '\' has attrs not sorted alphabetically by name', () => {
-      var sortedAttrs = Object.keys(attrNameIsUnique).sort(compareAttrNames);
+      const sortedAttrs = Object.keys(attrNameIsUnique).sort(compareAttrNames);
+
       expect(Object.keys(attrNameIsUnique)).toEqual(sortedAttrs);
     });
 
@@ -993,12 +1026,14 @@ describe('ValidatorRulesMakeSense', () => {
       for (const blacklistedCdataRegex of tagSpec.cdata.blacklistedCdataRegex) {
         it('blacklisted_cdata_regex valid and error_message defined', () => {
           usefulCdataSpec = true;
+
           expect(blacklistedCdataRegex.regex).toBeDefined();
           expect(isValidRegex(blacklistedCdataRegex.regex)).toBe(true);
           expect(blacklistedCdataRegex.errorMessage).toBeDefined();
         });
         it('blacklisted_cdata_regex must have unicode named groups', () => {
           const regex = rules.internedStrings[-1 - blacklistedCdataRegex.regex];
+
           expect(isMissingUnicodeGroup(regex)).toBe(false);
         });
       }
@@ -1058,6 +1093,7 @@ describe('ValidatorRulesMakeSense', () => {
       });
       it('cdata_regex must have unicode named groups', () => {
         const regex = rules.internedStrings[-1 - tagSpec.cdata.cdataRegex];
+
         expect(isMissingUnicodeGroup(regex)).toBe(false);
       });
 
@@ -1072,8 +1108,8 @@ describe('ValidatorRulesMakeSense', () => {
   }
 
   // satisfies needs to match up with requires and excludes
-  var allSatisfies = [];
-  var allRequiresAndExcludes = [];
+  const allSatisfies = [];
+  const allRequiresAndExcludes = [];
   for (const tagSpec of rules.tags) {
     for (const condition of tagSpec.requires) {
       allRequiresAndExcludes.push(condition);
@@ -1087,7 +1123,7 @@ describe('ValidatorRulesMakeSense', () => {
   }
   sortAndUniquify(allSatisfies);
   sortAndUniquify(allRequiresAndExcludes);
-  it('all conditions are both required and satisfied', ()=> {
+  it('all conditions are both required and satisfied', () => {
     expect(subtractDiff(allSatisfies, allRequiresAndExcludes)).toEqual([]);
     expect(subtractDiff(allRequiresAndExcludes, allSatisfies)).toEqual([]);
   });
@@ -1113,6 +1149,7 @@ describe('ValidatorRulesMakeSense', () => {
       numErrorSpecificity += 1;
     }
   });
+
   it('Some error codes are missing specificity rules', () => {
     expect(numValidCodes == numErrorSpecificity).toBe(true);
   });
@@ -1125,6 +1162,7 @@ describe('ValidatorRulesMakeSense', () => {
       numErrorFormat += 1;
     }
   });
+
   it('Some error codes are missing format strings', () => {
     expect(numValidCodes == numErrorFormat).toBe(true);
   });

--- a/validator/gulpjs/index.js
+++ b/validator/gulpjs/index.js
@@ -17,10 +17,10 @@
 
 'use strict';
 
-const through = require('through2');
 const amphtmlValidator = require('amphtml-validator');
 const colors = require('ansi-colors');
 const log = require('fancy-log');
+const through = require('through2');
 
 const PLUGIN_NAME = 'gulp-amphtml-validator';
 const PluginError = require('plugin-error');
@@ -47,26 +47,26 @@ module.exports.validate = function(validator) {
     }
     if (file.isStream()) {
       this.emit('error', new PluginError(PLUGIN_NAME,
-        'Streams not supported!'));
+          'Streams not supported!'));
     }
     if (file.isBuffer()) {
       validator.getInstance()
-        .then(function(validatorInstance) {
-          const inputString = file.contents.toString();
-          file.ampValidationResult = validatorInstance.validateString(inputString);
-          return callback(null, file);
-        })
-        .catch(function(err) {
+          .then(function(validatorInstance) {
+            const inputString = file.contents.toString();
+            file.ampValidationResult = validatorInstance.validateString(inputString);
+            return callback(null, file);
+          })
+          .catch(function(err) {
           // This happens if the validator download failed. We don't fail the
           // build, but map the exception to an validation error instead. This
           // makes it possible to configure via failAfterError whether this
           // should fail the build or not.
-          log(colors.red(err.message));
-          file.ampValidationResult = {
-            status: STATUS_UNKNOWN,
-          };
-          return callback(null, file);
-        });
+            log(colors.red(err.message));
+            file.ampValidationResult = {
+              status: STATUS_UNKNOWN,
+            };
+            return callback(null, file);
+          });
     }
   }
   return through.obj(runValidation);
@@ -126,7 +126,7 @@ module.exports.format = function(logger) {
  * Fail when the stream ends if for any AMP validation results,
  * isFailure(ampValidationResult) returns true.
  *
- * @param {!function(amphtmlValidator.ValidationResult): boolean} isFailure
+ * @param {function(amphtmlValidator.ValidationResult): boolean} isFailure
  * @return {!stream} gulp file stream
  */
 function failAfter(isFailure) {
@@ -145,7 +145,7 @@ function failAfter(isFailure) {
   function failOnError(callback) {
     if (failedFiles > 0) {
       this.emit('error', new PluginError(PLUGIN_NAME,
-        '\nAMPHTML Validation failed for ' + failedFiles + ' files.'));
+          '\nAMPHTML Validation failed for ' + failedFiles + ' files.'));
     }
     callback();
   }

--- a/validator/gulpjs/sample/gulpfile.js
+++ b/validator/gulpjs/sample/gulpfile.js
@@ -20,16 +20,16 @@ const gulpAmpHtmlValidator = require('gulp-amphtml-validator');
 
 gulp.task('amphtml:validate', () => {
   return gulp.src('../../testdata/feature_tests/*.html')
-    // Valide the input and attach the validation result to the "amp" property
-    // of the file object. 
-    .pipe(gulpAmpHtmlValidator.validate())
-    // Print the validation results to the console.
-    .pipe(gulpAmpHtmlValidator.format())
-    // Exit the process with error code (1) if an AMP validation error
-    // occurred.
-    .pipe(gulpAmpHtmlValidator.failAfterError());
+  // Valide the input and attach the validation result to the "amp" property
+  // of the file object.
+      .pipe(gulpAmpHtmlValidator.validate())
+  // Print the validation results to the console.
+      .pipe(gulpAmpHtmlValidator.format())
+  // Exit the process with error code (1) if an AMP validation error
+  // occurred.
+      .pipe(gulpAmpHtmlValidator.failAfterError());
 });
 
-gulp.task('default', ['amphtml:validate'], function () {
+gulp.task('default', ['amphtml:validate'], function() {
   // This will only run if the validation task is successful...
 });

--- a/validator/light/dom-walker.js
+++ b/validator/light/dom-walker.js
@@ -79,7 +79,7 @@ amp.domwalker.NodeProcessingState_ = class {
    */
   nextChild() {
     if (this.numChildren_ > this.nextChildIdx_) {
-      var thisChild = this.node_.children[this.nextChildIdx_];
+      const thisChild = this.node_.children[this.nextChildIdx_];
       this.nextChildIdx_ += 1;
       return new amp.domwalker.NodeProcessingState_(thisChild);
     }
@@ -93,8 +93,8 @@ amp.domwalker.NodeProcessingState_ = class {
  * @return {Array<string>} attributes as alternating key/value pairs
  */
 function attrList(namedNodeMap) {
-  var ret = [];
-  for (var i = 0; i < namedNodeMap.length; ++i) {
+  const ret = [];
+  for (let i = 0; i < namedNodeMap.length; ++i) {
     // The attribute name is always lower cased when returned by the browser.
     ret.push(namedNodeMap[i].name);
     ret.push(namedNodeMap[i].value);
@@ -172,7 +172,7 @@ amp.domwalker.DomWalker = class {
         const tagName = nextChild.node().nodeName;
         calls.push([
           amp.domwalker.HandlerCalls.START_TAG, tagName,
-          attrList(nextChild.node().attributes)
+          attrList(nextChild.node().attributes),
         ]);
         if (CdataTagsToValidate.hasOwnProperty(tagName)) {
           calls.push(
@@ -186,7 +186,7 @@ amp.domwalker.DomWalker = class {
           calls.push([
             amp.domwalker.HandlerCalls.END_TAG,
             // The browser always returns upper case tag names.
-            curState.node().nodeName
+            curState.node().nodeName,
           ]);
         }
         tagStack.pop();

--- a/validator/light/saxasjson.js
+++ b/validator/light/saxasjson.js
@@ -61,10 +61,10 @@ class JsonOutHandler extends amp.htmlparser.HtmlSaxHandler {
 
   /** @override */
   startTag(tag) {
-    let newArray = [];
+    const newArray = [];
     newArray.push('startTag');
     newArray.push(tag.upperName());
-    for (let attr of tag.attrs()) {
+    for (const attr of tag.attrs()) {
       newArray.push(attr.name);
       newArray.push(attr.value);
     }

--- a/validator/light/validator-light_test.js
+++ b/validator/light/validator-light_test.js
@@ -54,7 +54,7 @@ function isdir(dir) {
   try {
     return fs.lstatSync(dir).isDirectory();
   } catch (e) {
-    return false;  // If there's neither a file nor a directory.
+    return false; // If there's neither a file nor a directory.
   }
 }
 
@@ -80,13 +80,13 @@ function findHtmlFilesRelativeToTestdata() {
         for (const possibleVersion of readdir(extensionFolder)) {
           const testPath = path.join(extension, possibleVersion, 'test');
           if (isdir(path.join(root, testPath))) {
-            testSubdirs.push({root: root, subdir: testPath});
+            testSubdirs.push({root, subdir: testPath});
           }
         }
       }
     } else {
       for (const subdir of readdir(root)) {
-        testSubdirs.push({root: root, subdir: subdir});
+        testSubdirs.push({root, subdir});
       }
     }
   }
@@ -201,92 +201,93 @@ describe('ValidatorCssLengthValidation', () => {
   assertStrictEqual(10, validInlineStyleBlob.length);
 
   it('accepts 50000 bytes in author stylesheet and 0 bytes in inline style',
-     () => {
-       const stylesheet = Array(5001).join(validStyleBlob);
-       assertStrictEqual(50000, stylesheet.length);
-       const test = new ValidatorTestCase('feature_tests/css_length.html');
-       test.ampHtmlFileContents =
+      () => {
+        const stylesheet = Array(5001).join(validStyleBlob);
+        assertStrictEqual(50000, stylesheet.length);
+        const test = new ValidatorTestCase('feature_tests/css_length.html');
+        test.ampHtmlFileContents =
            test.ampHtmlFileContents
                .replace('.replace_amp_custom {}', stylesheet)
                .replace('replace_inline_style', '');
-       test.expectedOutputFile = null;
-       test.expectedOutput = 'FAIL';
-       test.run();
-     });
+        test.expectedOutputFile = null;
+        test.expectedOutput = 'FAIL';
+        test.run();
+      });
 
   it('will not accept 50001 bytes in author stylesheet and 0 bytes in inline style',
-     () => {
-       const stylesheet = Array(5001).join(validStyleBlob) + ' ';
-       assertStrictEqual(50001, stylesheet.length);
-       const test = new ValidatorTestCase('feature_tests/css_length.html');
-       test.ampHtmlFileContents =
+      () => {
+        const stylesheet = Array(5001).join(validStyleBlob) + ' ';
+        assertStrictEqual(50001, stylesheet.length);
+        const test = new ValidatorTestCase('feature_tests/css_length.html');
+        test.ampHtmlFileContents =
            test.ampHtmlFileContents
                .replace('.replace_amp_custom {}', stylesheet)
                .replace('replace_inline_style', '');
-       test.expectedOutputFile = null;
-       test.expectedOutput = 'FAIL';
-       test.run();
-     });
+        test.expectedOutputFile = null;
+        test.expectedOutput = 'FAIL';
+        test.run();
+      });
 
   it('knows utf8 and rejects file with 50002 bytes but 49999 characters and 0 bytes in inline style',
-     () => {
-       const stylesheet = Array(5000).join(validStyleBlob) + 'h {a: 😺}';
-       assertStrictEqual(49999, stylesheet.length);  // character length
-       const test = new ValidatorTestCase('feature_tests/css_length.html');
-       test.ampHtmlFileContents =
+      () => {
+        const stylesheet = Array(5000).join(validStyleBlob) + 'h {a: 😺}';
+        assertStrictEqual(49999, stylesheet.length); // character length
+        const test = new ValidatorTestCase('feature_tests/css_length.html');
+        test.ampHtmlFileContents =
            test.ampHtmlFileContents
                .replace('.replace_amp_custom {}', stylesheet)
                .replace('replace_inline_style', '');
-       test.expectedOutputFile = null;
-       test.expectedOutput = 'FAIL';
-       test.run();
-     });
+        test.expectedOutputFile = null;
+        test.expectedOutput = 'FAIL';
+        test.run();
+      });
 
   it('accepts 0 bytes in author stylesheet and 50000 bytes in inline style',
-     () => {
-       const inlineStyle = Array(5001).join(validInlineStyleBlob);
-       assertStrictEqual(50000, inlineStyle.length);
-       const test = new ValidatorTestCase('feature_tests/css_length.html');
-       test.ampHtmlFileContents =
+      () => {
+        const inlineStyle = Array(5001).join(validInlineStyleBlob);
+        assertStrictEqual(50000, inlineStyle.length);
+        const test = new ValidatorTestCase('feature_tests/css_length.html');
+        test.ampHtmlFileContents =
            test.ampHtmlFileContents.replace('.replace_amp_custom {}', '')
                .replace('replace_inline_style', inlineStyle);
-       test.expectedOutputFile = null;
-       test.expectedOutput = 'FAIL';
-       test.run();
-     });
+        test.expectedOutputFile = null;
+        test.expectedOutput = 'FAIL';
+        test.run();
+      });
 
   it('will not accept 0 bytes in author stylesheet and 50001 bytes in inline style',
-     () => {
-       const inlineStyle = Array(5001).join(validInlineStyleBlob) + ' ';
-       assertStrictEqual(50001, inlineStyle.length);
-       const test = new ValidatorTestCase('feature_tests/css_length.html');
-       test.ampHtmlFileContents =
+      () => {
+        const inlineStyle = Array(5001).join(validInlineStyleBlob) + ' ';
+        assertStrictEqual(50001, inlineStyle.length);
+        const test = new ValidatorTestCase('feature_tests/css_length.html');
+        test.ampHtmlFileContents =
            test.ampHtmlFileContents.replace('.replace_amp_custom {}', '')
                .replace('replace_inline_style', inlineStyle);
-       test.expectedOutputFile = null;
-       test.expectedOutput = 'FAIL';
-       test.run();
-     });
+        test.expectedOutputFile = null;
+        test.expectedOutput = 'FAIL';
+        test.run();
+      });
 
   it('will not accept 50000 bytes in author stylesheet and 14 bytes in inline style',
-     () => {
-       const stylesheet = Array(5001).join(validStyleBlob);
-       assertStrictEqual(50000, stylesheet.length);
-       const test = new ValidatorTestCase('feature_tests/css_length.html');
-       test.ampHtmlFileContents =
+      () => {
+        const stylesheet = Array(5001).join(validStyleBlob);
+        assertStrictEqual(50000, stylesheet.length);
+        const test = new ValidatorTestCase('feature_tests/css_length.html');
+        test.ampHtmlFileContents =
            test.ampHtmlFileContents
                .replace('.replace_amp_custom {}', stylesheet)
                .replace('replace_inline_style', 'display:block;');
-       test.expectedOutputFile = null;
-       test.expectedOutput = 'FAIL';
-       test.run();
-     });
+        test.expectedOutputFile = null;
+        test.expectedOutput = 'FAIL';
+        test.run();
+      });
 });
 
 describe('CssLength', () => {
   it('parses a basic example', () => {
     const parsed = new amp.validator.CssLength(
         '10.1em', /* allowAuto */ false, /* allowFluid */ false);
+
     expect(parsed.isSet).toBe(true);
     expect(parsed.isValid).toBe(true);
     expect(parsed.numeral).toEqual(10.1);
@@ -299,6 +300,7 @@ describe('CssLength', () => {
       const example = '10' + allowedUnit;
       const parsed = new amp.validator.CssLength(
           example, /* allowAuto */ false, /* allowFluid */ false);
+
       expect(parsed.isSet).toBe(true);
       expect(parsed.isValid).toBe(true);
       expect(parsed.numeral).toEqual(10);
@@ -310,6 +312,7 @@ describe('CssLength', () => {
   it('understands empty unit as "px"', () => {
     const parsed = new amp.validator.CssLength(
         '10', /* allowAuto */ false, /* allowFluid */ false);
+
     expect(parsed.isSet).toBe(true);
     expect(parsed.isValid).toBe(true);
     expect(parsed.numeral).toEqual(10);
@@ -320,6 +323,7 @@ describe('CssLength', () => {
   it('understands undefined input as valid (means attr is not set)', () => {
     const parsed = new amp.validator.CssLength(
         undefined, /* allowAuto */ false, /* allowFluid */ false);
+
     expect(parsed.isSet).toBe(false);
     expect(parsed.isValid).toBe(true);
     expect(parsed.unit).toEqual('px');
@@ -329,83 +333,98 @@ describe('CssLength', () => {
   it('understands empty string as invalid (means attr value is empty)', () => {
     const parsed = new amp.validator.CssLength(
         '', /* allowAuto */ false, /* allowFluid */ false);
+
     expect(parsed.isValid).toBe(false);
   });
 
   it('considers other garbage as invalid', () => {
     expect(new amp.validator
-               .CssLength('100%', /* allowAuto */ false, /* allowFluid */ false)
-               .isValid)
+        .CssLength('100%', /* allowAuto */ false, /* allowFluid */ false)
+        .isValid)
         .toBe(false);
+
     expect(
         new amp.validator
             .CssLength(
                 'not a number', /* allowAuto */ false, /* allowFluid */ false)
             .isValid)
         .toBe(false);
+
     expect(
         new amp.validator
             .CssLength('1.1.1', /* allowAuto */ false, /* allowFluid */ false)
             .isValid)
         .toBe(false);
+
     expect(new amp.validator
-               .CssLength(
-                   '5 inches', /* allowAuto */ false, /* allowFluid */ false)
-               .isValid)
+        .CssLength(
+            '5 inches', /* allowAuto */ false, /* allowFluid */ false)
+        .isValid)
         .toBe(false);
+
     expect(new amp.validator
-               .CssLength(
-                   'fahrenheit', /* allowAuto */ false, /* allowFluid */ false)
-               .isValid)
+        .CssLength(
+            'fahrenheit', /* allowAuto */ false, /* allowFluid */ false)
+        .isValid)
         .toBe(false);
+
     expect(new amp.validator
-               .CssLength('px', /* allowAuto */ false, /* allowFluid */ false)
-               .isValid)
+        .CssLength('px', /* allowAuto */ false, /* allowFluid */ false)
+        .isValid)
         .toBe(false);
+
     expect(new amp.validator
-               .CssLength(  // screen size in ancient Rome.
-                   'ix unciae', /* allowAuto */ false, /* allowFluid */ false)
-               .isValid)
+        .CssLength( // screen size in ancient Rome.
+            'ix unciae', /* allowAuto */ false, /* allowFluid */ false)
+        .isValid)
         .toBe(false);
   });
 
   it('recongizes auto if allowed', () => {
-    {  // allow_auto = false with input != auto
+    { // allow_auto = false with input != auto
       const parsed = new amp.validator.CssLength(
           '1', /* allowAuto */ false, /* allowFluid */ false);
+
       expect(parsed.isValid).toBe(true);
       expect(parsed.isAuto).toBe(false);
     } {// allow_auto = true with input != auto
-       const parsed = new amp.validator.CssLength(
-           '1', /* allowAuto */ true, /* allowFluid */ false);
-       expect(parsed.isValid).toBe(true); expect(parsed.isAuto).toBe(false);} {
+      const parsed = new amp.validator.CssLength(
+          '1', /* allowAuto */ true, /* allowFluid */ false);
+
+      expect(parsed.isValid).toBe(true); expect(parsed.isAuto).toBe(false);} {
       // allow_auto = false with input = auto
       const parsed = new amp.validator.CssLength(
           'auto', /* allowAuto */ false, /* allowFluid */ false);
+
       expect(parsed.isValid).toBe(false);
     } {// allow_auto = true with input = auto
-       const parsed = new amp.validator.CssLength(
-           'auto', /* allowAuto */ true, /* allowFluid */ false);
-       expect(parsed.isValid).toBe(true); expect(parsed.isAuto).toBe(true);}
+      const parsed = new amp.validator.CssLength(
+          'auto', /* allowAuto */ true, /* allowFluid */ false);
+
+      expect(parsed.isValid).toBe(true); expect(parsed.isAuto).toBe(true);}
   });
 
   it('recongizes fluid if allowed', () => {
-    {  // allow_fluid = false with input != fluid
+    { // allow_fluid = false with input != fluid
       const parsed = new amp.validator.CssLength(
           '1', /* allowAuto */ false, /* allowFluid */ false);
+
       expect(parsed.isValid).toBe(true);
       expect(parsed.isFluid).toBe(false);
     } {// allow_fluid = true with input != fluid
-       const parsed = new amp.validator.CssLength(
-           '1', /* allowAuto */ false, /* allowFluid */ true);
-       expect(parsed.isValid).toBe(true); expect(parsed.isFluid).toBe(false);} {
+      const parsed = new amp.validator.CssLength(
+          '1', /* allowAuto */ false, /* allowFluid */ true);
+
+      expect(parsed.isValid).toBe(true); expect(parsed.isFluid).toBe(false);} {
       // allow_fluid = false with input = fluid
       const parsed = new amp.validator.CssLength(
           'fluid', /* allowAuto */ false, /* allowFluid */ false);
+
       expect(parsed.isValid).toBe(false);
     } {// allow_fluid = true with input = fluid
-       const parsed = new amp.validator.CssLength(
-           'fluid', /* allowAuto */ false, /* allowFluid */ true);
-       expect(parsed.isValid).toBe(true); expect(parsed.isFluid).toBe(true);}
+      const parsed = new amp.validator.CssLength(
+          'fluid', /* allowAuto */ false, /* allowFluid */ true);
+
+      expect(parsed.isValid).toBe(true); expect(parsed.isFluid).toBe(true);}
   });
 });

--- a/validator/nodejs/index.js
+++ b/validator/nodejs/index.js
@@ -18,24 +18,24 @@
 
 'use strict';
 
-var Promise = require('promise');
-var colors = require('colors');
-var fs = require('fs');
-var http = require('http');
-var https = require('https');
-var path = require('path');
-var program = require('commander');
-var querystring = require('querystring');
-var url = require('url');
-var util = require('util');
-var vm = require('vm');
+const colors = require('colors');
+const fs = require('fs');
+const http = require('http');
+const https = require('https');
+const path = require('path');
+const program = require('commander');
+const Promise = require('promise');
+const querystring = require('querystring');
+const url = require('url');
+const util = require('util');
+const vm = require('vm');
 
-var DEFAULT_USER_AGENT = 'amphtml-validator';
+const DEFAULT_USER_AGENT = 'amphtml-validator';
 
 /**
  * Determines if str begins with prefix.
- * @param {!string} str
- * @param {!string} prefix
+ * @param {string} str
+ * @param {string} prefix
  * @return {boolean}
  */
 function hasPrefix(str, prefix) {
@@ -45,7 +45,7 @@ function hasPrefix(str, prefix) {
 /**
  * Convenience function to detect whether an argument is a URL. If not,
  * it may be a local file.
- * @param {!string} url
+ * @param {string} url
  * @return {boolean}
  */
 function isHttpOrHttpsUrl(url) {
@@ -54,7 +54,7 @@ function isHttpOrHttpsUrl(url) {
 
 /**
  * Creates a promise which reads from a file.
- * @param {!string} name
+ * @param {string} name
  * @return {Promise<string>}
  */
 function readFromFile(name) {
@@ -71,13 +71,13 @@ function readFromFile(name) {
 
 /**
  * Creates a promise which reads from a stream.
- * @param {!string} name
+ * @param {string} name
  * @param {!stream.Readable} readable
  * @return {Promise<string>}
  */
 function readFromReadable(name, readable) {
   return new Promise(function(resolve, reject) {
-    var chunks = [];
+    const chunks = [];
     readable.setEncoding('utf8');
     readable.on('data', function(chunk) {
       chunks.push(chunk);
@@ -108,36 +108,36 @@ function readFromStdin() {
  * Creates a promise which reads from a URL or more precisely, fetches
  * the contents located at the URL by using the 'http' or 'https' module.
  * Any HTTP status other than 200 is interpreted as an error.
- * @param {!string} url
- * @param {!string} userAgent
+ * @param {string} url
+ * @param {string} userAgent
  * @return {Promise<string>}
  */
 function readFromUrl(url, userAgent) {
   return new Promise(function(resolve, reject) {
-           var clientModule = hasPrefix(url, 'http://') ? http : https;
-           var req = clientModule.request(url, function(response) {
-             if (response.statusCode !== 200) {
-               // https://nodejs.org/api/http.html says: "[...] However, if
-               // you add a 'response' event handler, then you must consume
-               // the data from the response object, either by calling
-               // response.read() whenever there is a 'readable' event, or by
-               // adding a 'data' handler, or by calling the .resume()
-               // method."
-               response.resume();
-               reject(new Error(
-                   'Unable to fetch ' + url + ' - HTTP Status ' +
+    const clientModule = hasPrefix(url, 'http://') ? http : https;
+    const req = clientModule.request(url, function(response) {
+      if (response.statusCode !== 200) {
+        // https://nodejs.org/api/http.html says: "[...] However, if
+        // you add a 'response' event handler, then you must consume
+        // the data from the response object, either by calling
+        // response.read() whenever there is a 'readable' event, or by
+        // adding a 'data' handler, or by calling the .resume()
+        // method."
+        response.resume();
+        reject(new Error(
+            'Unable to fetch ' + url + ' - HTTP Status ' +
                    response.statusCode));
-             } else {
-               resolve(response);
-             }
-           });
-           req.setHeader('User-Agent', userAgent);
-           req.on('error', function(error) {  // E.g., DNS resolution errors.
-             reject(
-                 new Error('Unable to fetch ' + url + ' - ' + error.message));
-           });
-           req.end();
-         })
+      } else {
+        resolve(response);
+      }
+    });
+    req.setHeader('User-Agent', userAgent);
+    req.on('error', function(error) { // E.g., DNS resolution errors.
+      reject(
+          new Error('Unable to fetch ' + url + ' - ' + error.message));
+    });
+    req.end();
+  })
       .then(readFromReadable.bind(null, url));
 }
 
@@ -152,7 +152,7 @@ function readFromUrl(url, userAgent) {
 function ValidationResult() {
   /**
    * Possible values are 'UNKNOWN', 'PASS', and 'FAIL'.
-   * @type {!string}
+   * @type {string}
    */
   this.status = 'UNKNOWN';
   /** @type {!Array<!ValidationError>} */
@@ -185,14 +185,14 @@ function ValidationError() {
    * If you find yourself trying to write a parser against this string
    * to scrape out some detail, consider looking at the code and params
    * fields below.
-   * @type {!string}
+   * @type {string}
    */
   this.message = '';
   /**
    * The spec URL is often added by the validator to provide additional
    * context for the error. In a user interface this would be shown
    * as a "Learn more" link.
-   * @type {!string}
+   * @type {string}
    */
   this.specUrl = null;
   /**
@@ -200,7 +200,7 @@ function ValidationError() {
    * easier to create error statistics across a site and give advice based
    * on the most common problems for a set of pages.
    * See the ErrorCategory.Code enum in validator.proto for possible values.
-   * @type {!string}
+   * @type {string}
    */
   this.category = 'UNKNOWN';
   /**
@@ -212,14 +212,14 @@ function ValidationError() {
    * 'TAG_REQUIRED_BY_MISSING'. For each of these codes there is a
    * format string in validator-main.protoascii (look for error_formats),
    * which is used to assemble the message from the strings in params.
-   * @type {!string}
+   * @type {string}
    */
   this.code = 'UNKNOWN_CODE';
   /**
    * This field is only useful when scripting against the validator,
    * it should not be displayed in a user interface as it adds nothing
    * for humans to read over the message field (see above).
-   * @type {!Array<!string>}
+   * @type {!Array<string>}
    */
   this.params = [];
 }
@@ -229,7 +229,7 @@ function ValidationError() {
  * validator.js script - in practice the script was either downloaded
  * from 'https://cdn.ampproject.org/v0/validator.js' or read from a
  * local file.
- * @param {!string} scriptContents
+ * @param {string} scriptContents
  * @throws {!Error}
  * @constructor
  */
@@ -255,19 +255,19 @@ function Validator(scriptContents) {
 /**
  * Validates the provided inputString; the htmlFormat can be 'AMP' or
  * 'AMP4ADS'; it defaults to 'AMP' if not specified.
- * @param {!string} inputString
+ * @param {string} inputString
  * @param {string=} htmlFormat
  * @return {!ValidationResult}
  * @export
  */
 Validator.prototype.validateString = function(inputString, htmlFormat) {
-  var internalResult =
+  const internalResult =
       this.sandbox.amp.validator.validateString(inputString, htmlFormat);
-  var result = new ValidationResult();
+  const result = new ValidationResult();
   result.status = internalResult.status;
-  for (var ii = 0; ii < internalResult.errors.length; ii++) {
-    var internalError = internalResult.errors[ii];
-    var error = new ValidationError();
+  for (let ii = 0; ii < internalResult.errors.length; ii++) {
+    const internalError = internalResult.errors[ii];
+    const error = new ValidationError();
     error.severity = internalError.severity;
     error.line = internalError.line;
     error.col = internalError.col;
@@ -287,7 +287,7 @@ Validator.prototype.validateString = function(inputString, htmlFormat) {
  * AMP Validators more than once.
  * @type {!Object<string, Validator>}
  */
-var instanceByValidatorJs = {};
+const instanceByValidatorJs = {};
 
 /**
  * Provided a URL or a filename from which to fetch the validator.js
@@ -302,17 +302,17 @@ var instanceByValidatorJs = {};
  * @export
  */
 function getInstance(opt_validatorJs, opt_userAgent) {
-  var validatorJs =
+  const validatorJs =
       opt_validatorJs || 'https://cdn.ampproject.org/v0/validator.js';
-  var userAgent = opt_userAgent || DEFAULT_USER_AGENT;
+  const userAgent = opt_userAgent || DEFAULT_USER_AGENT;
   if (instanceByValidatorJs.hasOwnProperty(validatorJs)) {
     return Promise.resolve(instanceByValidatorJs[validatorJs]);
   }
-  var validatorJsPromise = isHttpOrHttpsUrl(validatorJs) ?
-      readFromUrl(validatorJs, userAgent) :
-      readFromFile(validatorJs);
+  const validatorJsPromise = isHttpOrHttpsUrl(validatorJs) ?
+    readFromUrl(validatorJs, userAgent) :
+    readFromFile(validatorJs);
   return validatorJsPromise.then(function(scriptContents) {
-    var instance;
+    let instance;
     try {
       instance = new Validator(scriptContents);
     } catch (error) {
@@ -358,7 +358,7 @@ exports.newInstance = newInstance;
 /**
  * Logs a validation result to the console using process.stdout and
  * process.stderr as is appropriate.
- * @param {!string} filename
+ * @param {string} filename
  * @param {!ValidationResult} validationResult
  * @param {boolean} color
  */
@@ -367,9 +367,9 @@ function logValidationResult(filename, validationResult, color) {
     process.stdout.write(
         filename + ': ' + (color ? colors.green('PASS') : 'PASS') + '\n');
   }
-  for (var ii = 0; ii < validationResult.errors.length; ii++) {
-    var error = validationResult.errors[ii];
-    var msg = filename + ':' + error.line + ':' + error.col + ' ';
+  for (let ii = 0; ii < validationResult.errors.length; ii++) {
+    const error = validationResult.errors[ii];
+    let msg = filename + ':' + error.line + ':' + error.col + ' ';
     if (color) {
       msg += (error.severity === 'ERROR' ? colors.red : colors.magenta)(
           error.message);
@@ -440,9 +440,9 @@ function main() {
           process.exit(1);
         });
   }
-  var inputs = [];
-  for (var ii = 0; ii < program.args.length; ii++) {
-    var item = program.args[ii];
+  const inputs = [];
+  for (let ii = 0; ii < program.args.length; ii++) {
+    const item = program.args[ii];
     if (item === '-') {
       inputs.push(readFromStdin());
     } else if (isHttpOrHttpsUrl(item)) {
@@ -455,10 +455,10 @@ function main() {
       .then(function(validator) {
         Promise.all(inputs)
             .then(function(resolvedInputs) {
-              var jsonOut = {};
-              var hasError = false;
-              for (var ii = 0; ii < resolvedInputs.length; ii++) {
-                var validationResult = validator.validateString(
+              const jsonOut = {};
+              let hasError = false;
+              for (let ii = 0; ii < resolvedInputs.length; ii++) {
+                const validationResult = validator.validateString(
                     resolvedInputs[ii], program.html_format);
                 if (program.format === 'json') {
                   jsonOut[program.args[ii]] = validationResult;
@@ -489,7 +489,7 @@ function main() {
             .catch(function(error) {
               process.stderr.write(
                   (program.format == 'color' ? colors.red(error.message) :
-                                               error.message) +
+                    error.message) +
                       '\n',
                   function() {
                     process.exit(1);
@@ -499,7 +499,7 @@ function main() {
       .catch(function(error) {
         process.stderr.write(
             (program.format == 'color' ? colors.red(error.message) :
-                                         error.message) +
+              error.message) +
                 '\n',
             function() {
               process.exit(1);

--- a/validator/nodejs/index_test.js
+++ b/validator/nodejs/index_test.js
@@ -19,14 +19,14 @@
 'use strict';
 
 global.assert = require('assert');
-var fs = require('fs');
+const fs = require('fs');
 global.path = require('path');
 
-var execFile = require('child_process').execFile;
-var JasmineRunner = require('jasmine');
-var jasmine = new JasmineRunner();
+const JasmineRunner = require('jasmine');
+const {execFile} = require('child_process');
+const jasmine = new JasmineRunner();
 
-var ampValidator = require('./index.js');
+const ampValidator = require('./index.js');
 
 it('deployed validator rejects the empty file', function(done) {
   // Note: This will fetch and use the validator from
@@ -34,7 +34,8 @@ it('deployed validator rejects the empty file', function(done) {
   // is supplied to validateString.
   ampValidator.getInstance()
       .then(function(instance) {
-        var validationResult = instance.validateString('');
+        const validationResult = instance.validateString('');
+
         expect(validationResult.status).toBe('FAIL');
         done();
       })
@@ -52,7 +53,8 @@ it('built validator rejects the empty file', function(done) {
   // Note: This will use the validator that was built with build.py.
   ampValidator.getInstance(/*validatorJs*/ '../dist/validator_minified.js')
       .then(function(instance) {
-        var validationResult = instance.validateString('');
+        const validationResult = instance.validateString('');
+
         expect(validationResult.status).toBe('FAIL');
         done();
       })
@@ -64,11 +66,12 @@ it('built validator rejects the empty file', function(done) {
 
 it('accepts the minimum valid AMP file', function(done) {
   // Note: This will use the validator that was built with build.py.
-  var mini = fs.readFileSync(
+  const mini = fs.readFileSync(
       '../testdata/feature_tests/minimum_valid_amp.html', 'utf-8').trim();
   ampValidator.getInstance(/*validatorJs*/ '../dist/validator_minified.js')
       .then(function(instance) {
-        var validationResult = instance.validateString(mini);
+        const validationResult = instance.validateString(mini);
+
         expect(validationResult.status).toBe('PASS');
         done();
       })
@@ -80,12 +83,13 @@ it('accepts the minimum valid AMP file', function(done) {
 
 it('accepts the minimum valid AMP4ADS file', function(done) {
   // Note: This will use the validator that was built with build.py.
-  var mini = fs.readFileSync(
+  const mini = fs.readFileSync(
       '../testdata/amp4ads_feature_tests/min_valid_amp4ads.html', 'utf-8')
       .trim();
   ampValidator.getInstance(/*validatorJs*/ '../dist/validator_minified.js')
       .then(function(instance) {
-        var validationResult = instance.validateString(mini, 'AMP4ADS');
+        const validationResult = instance.validateString(mini, 'AMP4ADS');
+
         expect(validationResult.status).toBe('PASS');
         done();
       })
@@ -107,10 +111,10 @@ function isErrorLine(line) {
 
 it('rejects a specific file that is known to have errors', function(done) {
   // Note: This will use the validator that was built with build.py.
-  var severalErrorsHtml =
+  const severalErrorsHtml =
       fs.readFileSync('../testdata/feature_tests/several_errors.html', 'utf-8')
           .trim();
-  var severalErrorsOut =
+  const severalErrorsOut =
       fs.readFileSync('../testdata/feature_tests/several_errors.out', 'utf-8')
           .split('\n')
           .filter(isErrorLine)
@@ -118,13 +122,14 @@ it('rejects a specific file that is known to have errors', function(done) {
 
   ampValidator.getInstance(/*validatorJs*/ '../dist/validator_minified.js')
       .then(function(instance) {
-        var validationResult = instance.validateString(severalErrorsHtml);
+        const validationResult = instance.validateString(severalErrorsHtml);
+
         expect(validationResult.status).toBe('FAIL');
         // Here, we assemble the output from the validationResult that was
         // computed by the validator and compare it with the golden file.
-        var out = 'FAIL\n';
-        for (var ii = 0; ii < validationResult.errors.length; ii++) {
-          var error = validationResult.errors[ii];
+        let out = 'FAIL\n';
+        for (let ii = 0; ii < validationResult.errors.length; ii++) {
+          const error = validationResult.errors[ii];
           out += 'feature_tests/several_errors.html';
           out += ':' + error.line + ':' + error.col + ' ' + error.message;
           if (error.specUrl) {
@@ -132,6 +137,7 @@ it('rejects a specific file that is known to have errors', function(done) {
           }
           out += ' [' + error.category + ']\n';
         }
+
         expect(out).toBe(severalErrorsOut);
         done();
       })
@@ -157,41 +163,43 @@ it('handles syntax errors in validator file', function(done) {
 });
 
 it('also works with newInstance', function() {
-  var mini = fs.readFileSync(
+  const mini = fs.readFileSync(
       '../testdata/feature_tests/minimum_valid_amp.html', 'utf-8').trim();
-  var validatorJsContents =
+  const validatorJsContents =
       fs.readFileSync('../dist/validator_minified.js', 'utf-8');
-  var resultForMini =
+  const resultForMini =
       ampValidator.newInstance(validatorJsContents).validateString(mini);
+
   expect(resultForMini.status).toBe('PASS');
 
-  var severalErrorsHtml =
+  const severalErrorsHtml =
       fs.readFileSync('../testdata/feature_tests/several_errors.html', 'utf-8')
           .trim();
-  var resultForSeveralErrors = ampValidator.newInstance(validatorJsContents)
-                                   .validateString(severalErrorsHtml);
+  const resultForSeveralErrors = ampValidator.newInstance(validatorJsContents)
+      .validateString(severalErrorsHtml);
+
   expect(resultForSeveralErrors.status).toBe('FAIL');
 });
 
 it('emits text if --format=text is specified on command line', function(done) {
-  var severalErrorsOut =
+  const severalErrorsOut =
       fs.readFileSync('../testdata/feature_tests/several_errors.out', 'utf-8')
           .split('\n')
           .filter(isErrorLine)
-          .splice(1)  // trim 1st line
+          .splice(1) // trim 1st line
           .join('\n')
-          .replace(/ \[[A-Z_]+\]/g, '');  // trim error categories
+          .replace(/ \[[A-Z_]+\]/g, ''); // trim error categories
   execFile(
       process.execPath,
       [
         '../nodejs/index.js', '--format=text',
         '--validator_js=../dist/validator_minified.js',
         'feature_tests/several_errors.html',
-        'feature_tests/minimum_valid_amp.html'
+        'feature_tests/minimum_valid_amp.html',
       ],
-      {'cwd': '../testdata'},  // Run inside the testdata dir to match paths.
-      function (error, stdout, stderr) {
-        expect(error).toBeDefined();  // At least one file had errors.
+      {'cwd': '../testdata'}, // Run inside the testdata dir to match paths.
+      function(error, stdout, stderr) {
+        expect(error).toBeDefined(); // At least one file had errors.
         expect(stderr).toBe(severalErrorsOut);
         expect(stdout).toBe('feature_tests/minimum_valid_amp.html: PASS\n');
         done();
@@ -205,22 +213,25 @@ it('emits json if --format=json is specified on command line', function(done) {
         '../nodejs/index.js', '--format=json',
         '--validator_js=../dist/validator_minified.js',
         'feature_tests/several_errors.html',
-        'feature_tests/minimum_valid_amp.html'
+        'feature_tests/minimum_valid_amp.html',
       ],
-      {'cwd': '../testdata'},  // Run inside the testdata dir to match paths.
-      function (error, stdout, stderr) {
-        expect(error).toBeDefined();  // At least one file had errors
-        expect(stderr).toBe('');      // entire json results will be on stdout
+      {'cwd': '../testdata'}, // Run inside the testdata dir to match paths.
+      function(error, stdout, stderr) {
+        expect(error).toBeDefined(); // At least one file had errors
+        expect(stderr).toBe(''); // entire json results will be on stdout
 
         // We inspect the parsed JSON but not very deep, to keep this test
         // relatively robust. We don't want it to churn if the validator
         // changes its outputs slightly.
-        var parsedJson = JSON.parse(stdout);
+        const parsedJson = JSON.parse(stdout);
+
         expect(parsedJson['feature_tests/minimum_valid_amp.html'])
             .toBeDefined();
+
         expect(parsedJson['feature_tests/several_errors.html']).toBeDefined();
         expect(parsedJson['feature_tests/minimum_valid_amp.html'].status)
             .toBe('PASS');
+
         expect(parsedJson['feature_tests/several_errors.html'].status)
             .toBe('FAIL');
         done();
@@ -228,26 +239,26 @@ it('emits json if --format=json is specified on command line', function(done) {
 }, 5000);
 
 it('supports AMP4ADS with --html_format command line option', function(done) {
-  var severalErrorsOut =
+  const severalErrorsOut =
       fs.readFileSync(
-            '../testdata/amp4ads_feature_tests/style-amp-custom.out',
-            'utf-8')
+          '../testdata/amp4ads_feature_tests/style-amp-custom.out',
+          'utf-8')
           .split('\n')
           .filter(isErrorLine)
-          .splice(1)  // trim 1st line
+          .splice(1) // trim 1st line
           .join('\n')
-          .replace(/ \[[A-Z_]+\]/g, '');  // trim error categories
+          .replace(/ \[[A-Z_]+\]/g, ''); // trim error categories
   execFile(
       process.execPath,
       [
         '../nodejs/index.js', '--format=text', '--html_format=AMP4ADS',
         '--validator_js=../dist/validator_minified.js',
         'amp4ads_feature_tests/style-amp-custom.html',
-        'amp4ads_feature_tests/min_valid_amp4ads.html'
+        'amp4ads_feature_tests/min_valid_amp4ads.html',
       ],
-      {'cwd': '../testdata'},  // Run inside the testdata dir to match paths.
+      {'cwd': '../testdata'}, // Run inside the testdata dir to match paths.
       function(error, stdout, stderr) {
-        expect(error).toBeDefined();  // At least one file had errors.
+        expect(error).toBeDefined(); // At least one file had errors.
         expect(stderr).toBe(severalErrorsOut);
         expect(stdout).toBe(
             'amp4ads_feature_tests/min_valid_amp4ads.html: PASS\n');

--- a/validator/webui/webui.js
+++ b/validator/webui/webui.js
@@ -17,13 +17,13 @@
 
 // Extracts a dictionary of parameters from window.location.hash.
 function getLocationHashParams() {
-  var paramStrings = window.location.hash.substr(1).split('&');
-  var params = {};
-  for (var ii = 0; ii < paramStrings.length; ii++) {
-    var keyValue = paramStrings[ii].split('=');
+  const paramStrings = window.location.hash.substr(1).split('&');
+  const params = {};
+  for (let ii = 0; ii < paramStrings.length; ii++) {
+    const keyValue = paramStrings[ii].split('=');
     if (keyValue[0].length > 0) {
       params[keyValue[0]] = keyValue[1]
-          ? decodeURIComponent(keyValue[1]) : undefined;
+        ? decodeURIComponent(keyValue[1]) : undefined;
     }
   }
   return params;
@@ -31,15 +31,15 @@ function getLocationHashParams() {
 
 // Removes given parameter from window.location.hash.
 function removeParamFromLocationHashParams(param) {
-  var params = getLocationHashParams();
+  const params = getLocationHashParams();
   delete params[param];
   setLocationHashParams(params);
 }
 
 // Sets window.location hash based on a dictionary of parameters.
 function setLocationHashParams(params) {
-  var out = [];
-  for (var key in params) {
+  const out = [];
+  for (const key in params) {
     if (params.hasOwnProperty(key)) {
       out.push(key + '=' + encodeURIComponent(params[key]));
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3608,6 +3608,10 @@ eslint-plugin-google-camelcase@0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-google-camelcase/-/eslint-plugin-google-camelcase-0.0.2.tgz#0c27555e4782073442d034a3db1f214ee0b37401"
 
+eslint-plugin-jasmine@2.10.1:
+  version "2.10.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jasmine/-/eslint-plugin-jasmine-2.10.1.tgz#5733b709e751f4bc40e31e1c16989bd2cdfbec97"
+
 eslint-plugin-jsdoc@3.7.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-3.7.0.tgz#b7ce206f99efdc4c0a31b492ae5aedfb06f03dc6"


### PR DESCRIPTION
This PR does the following:
1. Enables `eslint` linting for the contents of `validator/`
2. Adds a custom `.eslintrc` file for `validator/` that supports `node` and `jasmine` code
3. Auto-fixes as many lint errors as possible using `gulp lint --files=validator/**/*.js --fix`
4. Switches all the lint rules for which failures remain to warning mode (so they can be fixed whenever possible)
