### PR TITLE
fix lint errors on resource.js

### DIFF
--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -364,8 +364,7 @@ export class Resource {
    * @param {boolean} overflown
    * @param {number|undefined} requestedHeight
    * @param {number|undefined} requestedWidth
-   * @param {!../layout-rect.LayoutMarginsChangeDef|undefined}
-   *     requestedMargins
+   * @param {!../layout-rect.LayoutMarginsChangeDef|undefined} requestedMargins
    */
   overflowCallback(overflown, requestedHeight, requestedWidth,
     requestedMargins) {
@@ -934,7 +933,7 @@ export class Resource {
 
   /**
    * Returns the task ID for this resource.
-   * @param localId
+   * @param {string} localId
    * @return {string}
    */
   getTaskId(localId) {


### PR DESCRIPTION

[11:42:01] /usr/local/google/home/alabiaga/amphtml/src/service/resource.js
  362:3  error  Expected @param names to be "overflown, requestedHeight, requestedWidth, requestedMargins". Got "overflown, requestedHeight, requestedWidth, 
requestedMargins"  jsdoc/check-param-names
  935:3  error  Missing JSDoc @param "localId" type                                                                                                                              jsdoc/require-param-type

✖ 2 problems (2 errors, 0 warnings)
