### PR TITLE
🏗 During PR checks, first run the tests changed by the PR (if any)

### DIFF
--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -321,6 +321,9 @@ const command = {
     //   stopSauceConnect();
     // }
   },
+  runUnitTestsOnLocalChanges: function() {
+    timedExecOrDie('gulp test --nobuild --headless --local-changes');
+  },
   runIntegrationTests: function(compiled) {
     // Integration tests on chrome, or on all saucelabs browsers if set up
     let cmd = 'gulp test --integration --nobuild';
@@ -598,6 +601,8 @@ function main() {
       command.runDepAndTypeChecks();
       // Run unit tests only if the PR contains runtime changes.
       if (buildTargets.has('RUNTIME')) {
+        // Before running all tests, run tests modified by the PR. (Fail early.)
+        command.runUnitTestsOnLocalChanges();
         command.runUnitTests();
       }
     }

--- a/build-system/tasks/runtime-test.js
+++ b/build-system/tasks/runtime-test.js
@@ -175,7 +175,7 @@ function printArgvMessages() {
       log(green('⤷ Use'), cyan('--local-changes'),
           green('to run unit tests from files commited to the local branch.'));
     }
-    if (!argv.testnames && !argv.files) {
+    if (!argv.testnames && !argv.files && !argv['local-changes']) {
       log(green('⤷ Use'), cyan('--testnames'),
           green('to see the names of all tests being run.'));
     }
@@ -266,7 +266,7 @@ function runTests() {
     c.client.captureConsole = true;
   }
 
-  if (argv.testnames || argv['local-changes']) {
+  if (!process.env.TRAVIS && (argv.testnames || argv['local-changes'])) {
     c.reporters = ['mocha'];
   }
 
@@ -379,9 +379,10 @@ function runTests() {
   refreshKarmaWdCache();
 
   // On Travis, collapse the summary printed by the 'karmaSimpleReporter'
-  // reporter, since it likely contains copious amounts of logs.
-  const shouldCollapseSummary =
-      process.env.TRAVIS && c.reporters.includes('karmaSimpleReporter');
+  // reporter for full unit test runs, since it likely contains copious amounts
+  // of logs.
+  const shouldCollapseSummary = process.env.TRAVIS &&
+      c.reporters.includes('karmaSimpleReporter') && !argv['local-changes'];
   const sectionMarker =
       (argv.saucelabs || argv.saucelabs_lite) ? 'saucelabs' : 'local';
 


### PR DESCRIPTION
During PR checks, we run about 8000 unit tests. This typically leads to a long wait to see results from the unit tests that were added / modified by the PR.

In this PR, we add a call to `gulp test --local-changes` before the call to `gulp test --unit`, so that we can fail early if a bad unit test is checked in. Note that `gulp test --local-changes` will fail (instead of just warning) if the unit tests contain unhandled `console.error`s, and provide early feedback that they must be fixed.

Coming up: Add this to a pre-push hook so that developers don't need to wait for Travis builds.

Partial fix for #15369