### PR TITLE
`.eslintrc-strict` should extend `.eslintrc`

### DIFF
--- a/.eslintrc-strict
+++ b/.eslintrc-strict
@@ -1,4 +1,5 @@
 {
+  "extends": ".eslintrc",
   "rules": {
     "amphtml-internal/prefer-deferred-promise": 2,
     "amphtml-internal/unused-private-field": 2,


### PR DESCRIPTION
Before this PR, running `gulp lint` on a specific directory would cause `.eslintrc-strict` to disregard the directory specific rules. For example, `gulp lint --files=build-system/eslint-rules/*.js` would result in spurious errors.

With this PR, directory specific rules are taken into consideration, while the global rules in `.eslintrc-strict` are still applied. So `gulp lint --files=build-system/eslint-rules/*.js` will respect the directory specific rules in `build-system/eslint-rules/.eslintrc`.

Follow up to #15256