### PR TITLE
Allow <amp-story-consent> to have children

### DIFF
--- a/extensions/amp-story/validator-amp-story.protoascii
+++ b/extensions/amp-story/validator-amp-story.protoascii
@@ -328,9 +328,6 @@ tags: {  # <amp-story-consent>
     name: "id"
     mandatory: true
   }
-  child_tags: {
-    mandatory_num_child_tags: 0
-  }
   amp_layout: {
     supported_layouts: NODISPLAY
   }


### PR DESCRIPTION
Stepping stone for moving story consent UI template data to its own child `<script>` tag.

Context: https://github.com/ampproject/amphtml/pull/15366/files/f48b29ca4203dd4cfce001b9555128d307551c7b#r189401119