### PR TITLE
add json script for amp-story-consent

### DIFF
--- a/extensions/amp-story/validator-amp-story.protoascii
+++ b/extensions/amp-story/validator-amp-story.protoascii
@@ -175,6 +175,7 @@ tags: {  # <amp-story-page>
 tags: {  # <amp-story-grid-layer>
   html_format: AMP
   tag_name: "AMP-STORY-GRID-LAYER"
+  requires_extension: "amp-story"
   mandatory_ancestor: "AMP-STORY-PAGE"
   attrs: {
     name: "template"
@@ -309,6 +310,7 @@ tags: {
 tags: {  # <amp-story-bookend>
   html_format: AMP
   tag_name: "AMP-STORY-BOOKEND"
+  requires_extension: "amp-story"
   mandatory_ancestor: "AMP-STORY"
   mandatory_last_child: true
   attrs: {
@@ -319,17 +321,43 @@ tags: {  # <amp-story-bookend>
     }
   }
 }
+tags: {  # amp-story-consent (json)
+  html_format: AMP
+  tag_name: "SCRIPT"
+  spec_name: "amp-story-consent extension .json script"
+  requires_extension: "amp-consent"
+  requires_extension: "amp-story"
+  mandatory_parent: "AMP-STORY-CONSENT"
+  unique: true
+  satisfies: "amp-story-consent extension .json script"
+  attrs: { name: "nonce" }
+  attrs: {
+    name: "type"
+    mandatory: true
+    value_casei: "application/json"
+    dispatch_key: NAME_VALUE_PARENT_DISPATCH
+  }
+  cdata: {
+    blacklisted_cdata_regex: {
+      regex: "<!--"
+      error_message: "html comments"
+    }
+  }
+}
 tags: {  # <amp-story-consent>
   html_format: AMP
   tag_name: "AMP-STORY-CONSENT"
   requires_extension: "amp-consent"
+  requires_extension: "amp-story"
   mandatory_parent: "AMP-CONSENT"
+  requires: "amp-story-consent extension .json script"
   attrs: {
     name: "id"
     mandatory: true
   }
   child_tags: {
-    mandatory_num_child_tags: 0
+    mandatory_num_child_tags: 1
+    child_tag_name_oneof: "SCRIPT"
   }
   amp_layout: {
     supported_layouts: NODISPLAY
@@ -338,6 +366,7 @@ tags: {  # <amp-story-consent>
 tags: {  # <amp-story-cta-layer>
   html_format: AMP
   tag_name: "AMP-STORY-CTA-LAYER"
+  requires_extension: "amp-story"
   mandatory_ancestor: "AMP-STORY-PAGE"
   descendant_tag_list: "amp-story-cta-layer-allowed-descendants"
   mandatory_last_child: true


### PR DESCRIPTION
Allow a JSON script as a child of `<amp-story-consent>`.