### PR TITLE
Validator rollup

### DIFF
--- a/extensions/amp-story/0.1/test/validator-amp-story-reference-point.out
+++ b/extensions/amp-story/0.1/test/validator-amp-story-reference-point.out
@@ -31,10 +31,6 @@ FAIL
 |  </head>
 |  <body>
 |    <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/poster.jpg" bookend-config-src="./related.json" background-audio="path/to/my.mp3">
->>   ^~~~~~~~~
-amp-story/0.1/test/validator-amp-story-reference-point.html:32:2 The relative URL 'path/to/my.mp3' for attribute 'background-audio' in tag 'amp-story' is disallowed. (see https://www.ampproject.org/docs/reference/components/amp-story) [AMP_TAG_PROBLEM]
->>   ^~~~~~~~~
-amp-story/0.1/test/validator-amp-story-reference-point.html:32:2 The relative URL './related.json' for attribute 'bookend-config-src' in tag 'amp-story' is disallowed. (see https://www.ampproject.org/docs/reference/components/amp-story) [AMP_TAG_PROBLEM]
 |      <amp-story-page id="1" background-audio="path/to/my.mp3" auto-advance-after="any-value">
 |        <amp-story-grid-layer template="horizontal">
 |          <img class="footer-logo" src="img/foot-logo.svg" width="40" height="40" /> <!-- The real error here is that <img/> tag is not allowed. But this is a weird use case where the validator error will comment about reference points. This needs to be fixed in the near future. -->

--- a/extensions/amp-story/0.1/test/validator-amp-story-video-error.out
+++ b/extensions/amp-story/0.1/test/validator-amp-story-video-error.out
@@ -33,10 +33,6 @@ FAIL
 |  </head>
 |  <body>
 |    <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/poster.jpg" bookend-config-src="./related.json" background-audio="path/to/my.mp3">
->>   ^~~~~~~~~
-amp-story/0.1/test/validator-amp-story-video-error.html:34:2 The relative URL 'path/to/my.mp3' for attribute 'background-audio' in tag 'amp-story' is disallowed. (see https://www.ampproject.org/docs/reference/components/amp-story) [AMP_TAG_PROBLEM]
->>   ^~~~~~~~~
-amp-story/0.1/test/validator-amp-story-video-error.html:34:2 The relative URL './related.json' for attribute 'bookend-config-src' in tag 'amp-story' is disallowed. (see https://www.ampproject.org/docs/reference/components/amp-story) [AMP_TAG_PROBLEM]
 |      <amp-story-page id="1" background-audio="path/to/my.mp3" auto-advance-after="any-value">
 |        <amp-story-grid-layer template="horizontal">
 |          <!-- This should fail because amp-video doesn't have the [poster] attribute. -->

--- a/extensions/amp-story/1.0/test/validator-amp-story-reference-point.out
+++ b/extensions/amp-story/1.0/test/validator-amp-story-reference-point.out
@@ -31,10 +31,6 @@ FAIL
 |  </head>
 |  <body>
 |    <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/poster.jpg" bookend-config-src="./related.json" background-audio="path/to/my.mp3">
->>   ^~~~~~~~~
-amp-story/1.0/test/validator-amp-story-reference-point.html:32:2 The relative URL 'path/to/my.mp3' for attribute 'background-audio' in tag 'amp-story' is disallowed. (see https://www.ampproject.org/docs/reference/components/amp-story) [AMP_TAG_PROBLEM]
->>   ^~~~~~~~~
-amp-story/1.0/test/validator-amp-story-reference-point.html:32:2 The relative URL './related.json' for attribute 'bookend-config-src' in tag 'amp-story' is disallowed. (see https://www.ampproject.org/docs/reference/components/amp-story) [AMP_TAG_PROBLEM]
 |      <amp-story-page id="1" background-audio="path/to/my.mp3" auto-advance-after="any-value">
 |        <amp-story-grid-layer template="horizontal">
 |          <img class="footer-logo" src="img/foot-logo.svg" width="40" height="40" /> <!-- The real error here is that <img/> tag is not allowed. But this is a weird use case where the validator error will comment about reference points. This needs to be fixed in the near future. -->

--- a/extensions/amp-story/1.0/test/validator-amp-story-video-error.out
+++ b/extensions/amp-story/1.0/test/validator-amp-story-video-error.out
@@ -33,10 +33,6 @@ FAIL
 |  </head>
 |  <body>
 |    <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/poster.jpg" bookend-config-src="./related.json" background-audio="path/to/my.mp3">
->>   ^~~~~~~~~
-amp-story/1.0/test/validator-amp-story-video-error.html:34:2 The relative URL 'path/to/my.mp3' for attribute 'background-audio' in tag 'amp-story' is disallowed. (see https://www.ampproject.org/docs/reference/components/amp-story) [AMP_TAG_PROBLEM]
->>   ^~~~~~~~~
-amp-story/1.0/test/validator-amp-story-video-error.html:34:2 The relative URL './related.json' for attribute 'bookend-config-src' in tag 'amp-story' is disallowed. (see https://www.ampproject.org/docs/reference/components/amp-story) [AMP_TAG_PROBLEM]
 |      <amp-story-page id="1" background-audio="path/to/my.mp3" auto-advance-after="any-value">
 |        <amp-story-grid-layer template="horizontal">
 |          <!-- This should fail because amp-video doesn't have the [poster] attribute. -->

--- a/extensions/amp-story/validator-amp-story.protoascii
+++ b/extensions/amp-story/validator-amp-story.protoascii
@@ -40,7 +40,6 @@ tags: {  # <amp-story>
     value_url: {
       allowed_protocol: "http"
       allowed_protocol: "https"
-      allow_relative: false
     }
   }
   attrs: {
@@ -48,7 +47,6 @@ tags: {  # <amp-story>
     value_url: {
       allowed_protocol: "http"
       allowed_protocol: "https"
-      allow_relative: false
     }
   }
   attrs: {
@@ -56,7 +54,6 @@ tags: {  # <amp-story>
     value_url: {
       allowed_protocol: "http"
       allowed_protocol: "https"
-      allow_relative: false
     }
   }
   attrs: {
@@ -65,7 +62,6 @@ tags: {  # <amp-story>
     value_url: {
       allowed_protocol: "http"
       allowed_protocol: "https"
-      allow_relative: false
     }
   }
   attrs: {
@@ -73,7 +69,6 @@ tags: {  # <amp-story>
     value_url: {
       allowed_protocol: "http"
       allowed_protocol: "https"
-      allow_relative: false
     }
   }
   attrs: {
@@ -86,7 +81,6 @@ tags: {  # <amp-story>
     value_url: {
       allowed_protocol: "http"
       allowed_protocol: "https"
-      allow_relative: false
     }
   }
   attrs: {

--- a/validator/engine/parse-url_test.js
+++ b/validator/engine/parse-url_test.js
@@ -289,8 +289,8 @@ describe('parse_url', () => {
     assertStrictEqual('', url.host);
   });
 
-  it('rejects http:/// (empty host)', () => {
-    const urlString = 'http:///';
+  it('rejects http:/// (empty host)', () => {  // NOTYPO
+    const urlString = 'http:///';  // NOTYPO
     const url = new parse_url.URL(urlString);
     assertStrictEqual(false, url.isValid);
     assertStrictEqual('', url.host);

--- a/validator/engine/validator.js
+++ b/validator/engine/validator.js
@@ -3578,7 +3578,7 @@ function checkForReferencePointCollision(
 function validateAncestorTags(parsedTagSpec, context, validationResult) {
   const spec = parsedTagSpec.getSpec();
   if (spec.mandatoryAncestor !== null) {
-    const {mandatoryAncestor} = spec;
+    const mandatoryAncestor = /** @type {string} */ (spec.mandatoryAncestor);
     if (!context.getTagStack().hasAncestor(mandatoryAncestor)) {
       if (amp.validator.LIGHT) {
         validationResult.status = amp.validator.ValidationResult.Status.FAIL;

--- a/validator/engine/validator_test.js
+++ b/validator/engine/validator_test.js
@@ -657,6 +657,20 @@ function attrRuleShouldMakeSense(attrSpec, rules) {
         }
       });
     }
+    // If allowed_protocol is http then allow_relative should not be false
+    // except for `data-` attributes.
+    if (!attrSpec.name.startsWith('data-')) {
+      for (const allowedProtocol of attrSpec.valueUrl.allowedProtocol) {
+        if ((allowedProtocol === 'http') &&
+            (attrSpec.valueUrl.allowRelative !== null)) {
+          it('allow_relative can not be false if allowed_protocol is http: ' +
+                 attrSpec.name,
+             () => {
+               expect(attrSpec.valueUrl.allowRelative).toEqual(true);
+             });
+        }
+      }
+    }
   }
   if (attrSpec.valueRegex !== null) {
     it('value_regex valid', () => {

--- a/validator/engine/validator_test.js
+++ b/validator/engine/validator_test.js
@@ -665,9 +665,9 @@ function attrRuleShouldMakeSense(attrSpec, rules) {
             (attrSpec.valueUrl.allowRelative !== null)) {
           it('allow_relative can not be false if allowed_protocol is http: ' +
                  attrSpec.name,
-             () => {
-               expect(attrSpec.valueUrl.allowRelative).toEqual(true);
-             });
+          () => {
+            expect(attrSpec.valueUrl.allowRelative).toEqual(true);
+          });
         }
       }
     }

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -26,7 +26,7 @@ min_validator_revision_required: 328
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 636
+spec_file_revision: 637
 
 styles_spec_url: "https://www.ampproject.org/docs/guides/author-develop/responsive/style_pages"
 script_spec_url: "https://www.ampproject.org/docs/reference/spec#html-tags"
@@ -4580,7 +4580,13 @@ attr_lists: {
   # https://www.ampproject.org/docs/reference/components/amp-fx-collection
   attrs: {
     name: "amp-fx"
-    value_regex_casei: "fade-in|fade-in-scroll|fly-in-bottom|fly-in-left|fly-in-right|fly-in-top|parallax"
+    value_regex_casei: "fade-in|"
+                       "fade-in-scroll|"
+                       "fly-in-bottom|"
+                       "fly-in-left|"
+                       "fly-in-right|"
+                       "fly-in-top|"
+                       "parallax"
     requires_extension: "amp-fx-collection"
   }
   # amp-subscriptions specific attributes, see

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -26,7 +26,7 @@ min_validator_revision_required: 328
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 635
+spec_file_revision: 636
 
 styles_spec_url: "https://www.ampproject.org/docs/guides/author-develop/responsive/style_pages"
 script_spec_url: "https://www.ampproject.org/docs/reference/spec#html-tags"

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -20,13 +20,13 @@
 # in production from crashing. This id is not relevant to validator.js
 # because thus far, engine (validator.js) and spec file
 # (validator-main.protoascii) are always released together.
-min_validator_revision_required: 327
+min_validator_revision_required: 328
 
 # The spec file revision allows the validator engine to distinguish
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 634
+spec_file_revision: 635
 
 styles_spec_url: "https://www.ampproject.org/docs/guides/author-develop/responsive/style_pages"
 script_spec_url: "https://www.ampproject.org/docs/reference/spec#html-tags"
@@ -34,6 +34,7 @@ script_spec_url: "https://www.ampproject.org/docs/reference/spec#html-tags"
 css_length_spec: {
   html_format: AMP
   max_bytes: 50000
+  max_bytes_per_inline_style: 1000
   spec_url: "https://www.ampproject.org/docs/guides/author-develop/responsive/style_pages"
 }
 

--- a/validator/validator.proto
+++ b/validator/validator.proto
@@ -515,8 +515,13 @@ message CssLengthSpec {
   // (ie: (<html ⚡> vs <html a4⚡>) this CssLengthSpec is defined for.
   optional HtmlFormat.Code html_format = 1;
 
-  // If set, the cdata contents cannot be greater than this length, in bytes.
+  // If set, the combined style amp-custom cdata contents and all inline style
+  // contents cannot be greater than this length, in bytes.
   optional int32 max_bytes = 2 [default = -1];
+
+  // If set, the inline style content (per use) cannot be greater than this
+  // length, in bytes.
+  optional int32 max_bytes_per_inline_style = 4 [default = -1];
 
   // If provided, a URL which linking to a section / sentence in the
   // AMP HTML spec.


### PR DESCRIPTION
 - Revision bump for #14782
 - Linter tweaks for #15444
 - Test allowed_protocol:http and !allow_relative:false
 - Allow relative URLs for amp-story attributes
 - Restrict CSS to 1000 bytes per inline style