### PR TITLE
Invalidate AMP stories with a child inside amp-story-bookend

### DIFF
--- a/extensions/amp-story/1.0/test/validator-amp-story-bookend-error.html
+++ b/extensions/amp-story/1.0/test/validator-amp-story-bookend-error.html
@@ -1,0 +1,78 @@
+<!--
+  Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS-IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the license.
+-->
+<!--
+  Test Description:
+  Tests for the amp-story-bookend tag.
+-->
+<!doctype html>
+<html amp lang="en">
+<head>
+  <meta charset="utf-8">
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-1.0.js"></script>
+  <title>My Story</title>
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <link rel="canonical" href="bookend.html">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <style amp-custom>
+    body {
+      font-family: 'Roboto', sans-serif;
+    }
+    amp-story-page {
+      background-color: white;
+    }
+  </style>
+  <script type="application/ld+json">
+    {
+      "@context": "http://schema.org",
+      "@type": "NewsArticle",
+      "mainEntityOfPage": {
+        "@type": "WebPage",
+        "@id": "./bookend.html"
+      },
+      "headline": "My Story",
+      "image":["http://placehold.it/420x740"],
+      "datePublished": "2018-01-01T00:00:00+00:00",
+      "dateModified": "2018-01-01T00:00:00+00:00",
+      "author": {
+        "@type": "Organization",
+        "name": "AMP Project"
+      },
+      "publisher": {
+        "@type": "Organization",
+        "name": "AMP Project",
+        "logo": {
+          "@type": "ImageObject",
+          "url": "http://placehold.it/128x128"
+        }
+      },
+      "description": "My Story"
+    }
+  </script>
+</head>
+<body>
+  <amp-story standalone title="My Story"
+    publisher="The AMP Team"
+    publisher-logo-src="https://example.com/logo/1x1.png"
+    poster-portrait-src="https://example.com/my-story/poster/3x4.jpg">
+    <amp-story-page id="cover">
+      <amp-story-grid-layer template="vertical">
+        <h1>Advance to see the bookend!</h1>
+      </amp-story-grid-layer>
+    </amp-story-page>
+    <amp-story-bookend src="https://google.com/bookendv1.json">
+      <h1>Illegal child inside amp-story-bookend!</h1>
+    </amp-story-bookend>
+  </amp-story>
+</body>
+</html>

--- a/extensions/amp-story/1.0/test/validator-amp-story-bookend-error.out
+++ b/extensions/amp-story/1.0/test/validator-amp-story-bookend-error.out
@@ -1,0 +1,81 @@
+FAIL
+|  <!--
+|    Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|        http://www.apache.org/licenses/LICENSE-2.0
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests for the amp-story-bookend tag.
+|  -->
+|  <!doctype html>
+|  <html amp lang="en">
+|  <head>
+|    <meta charset="utf-8">
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-1.0.js"></script>
+|    <title>My Story</title>
+|    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+|    <link rel="canonical" href="bookend.html">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <style amp-custom>
+|      body {
+|        font-family: 'Roboto', sans-serif;
+|      }
+|      amp-story-page {
+|        background-color: white;
+|      }
+|    </style>
+|    <script type="application/ld+json">
+|      {
+|        "@context": "http://schema.org",
+|        "@type": "NewsArticle",
+|        "mainEntityOfPage": {
+|          "@type": "WebPage",
+|          "@id": "./bookend.html"
+|        },
+|        "headline": "My Story",
+|        "image":["http://placehold.it/420x740"],
+|        "datePublished": "2018-01-01T00:00:00+00:00",
+|        "dateModified": "2018-01-01T00:00:00+00:00",
+|        "author": {
+|          "@type": "Organization",
+|          "name": "AMP Project"
+|        },
+|        "publisher": {
+|          "@type": "Organization",
+|          "name": "AMP Project",
+|          "logo": {
+|            "@type": "ImageObject",
+|            "url": "http://placehold.it/128x128"
+|          }
+|        },
+|        "description": "My Story"
+|      }
+|    </script>
+|  </head>
+|  <body>
+|    <amp-story standalone title="My Story"
+|      publisher="The AMP Team"
+|      publisher-logo-src="https://example.com/logo/1x1.png"
+|      poster-portrait-src="https://example.com/my-story/poster/3x4.jpg">
+|      <amp-story-page id="cover">
+|        <amp-story-grid-layer template="vertical">
+|          <h1>Advance to see the bookend!</h1>
+|        </amp-story-grid-layer>
+|      </amp-story-page>
+|      <amp-story-bookend src="https://google.com/bookendv1.json">
+>>     ^~~~~~~~~
+amp-story/1.0/test/validator-amp-story-bookend-error.html:73:4 Tag 'amp-story-bookend' must have 0 child tags - saw 1 child tags. [AMP_TAG_PROBLEM]
+|        <h1>Illegal child inside amp-story-bookend!</h1>
+|      </amp-story-bookend>
+|    </amp-story>
+|  </body>
+|  </html>

--- a/extensions/amp-story/validator-amp-story.protoascii
+++ b/extensions/amp-story/validator-amp-story.protoascii
@@ -318,6 +318,9 @@ tags: {  # <amp-story-bookend>
       allowed_protocol: "https"
     }
   }
+  child_tags: {
+    mandatory_num_child_tags: 0
+  }
 }
 tags: {  # <amp-story-consent>
   html_format: AMP


### PR DESCRIPTION
Right now publishers could specify arbitrary html inside the new amp-story-bookend HTML tag. Although we might want to let that happen later on, we might want to restrict that for now.
