### PR TITLE
Don't show nav or gallery controls if there is only one lightboxed image

### DIFF
--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.css
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.css
@@ -137,6 +137,12 @@ amp-lightbox-gallery .amp-carousel-button {
   }
 }
 
+.i-amphtml-lbg-controls.i-amphtml-lbg-single .i-amphtml-lbg-button-prev,
+.i-amphtml-lbg-controls.i-amphtml-lbg-single .i-amphtml-lbg-button-next,
+.i-amphtml-lbg-controls.i-amphtml-lbg-single .i-amphtml-lbg-button-gallery {
+  display: none;
+}
+
 .i-amphtml-lbg-controls.i-amphtml-lbg-hidden {
   opacity: 0;
   visibility: hidden;

--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -316,8 +316,11 @@ export class AmpLightboxGallery extends AMP.BaseElement {
         }]`);
     if (existingCarousel) {
       this.carousel_ = existingCarousel;
-      return this.mutateElement(() => {
-        toggle(dev().assertElement(this.carousel_), true);
+      return this.carousel_.getImpl().then(impl => {
+        return this.mutateElement(() => {
+          this.toggleNavControls_(impl.noOfSlides_);
+          toggle(dev().assertElement(this.carousel_), true);
+        });
       });
     } else {
       return this.buildCarousel_(lightboxGroupId);
@@ -347,8 +350,21 @@ export class AmpLightboxGallery extends AMP.BaseElement {
       this.buildCarouselSlides_(list);
       return this.mutateElement(() => {
         this.carouselContainer_.appendChild(this.carousel_);
+        this.toggleNavControls_(list.length);
       });
     });
+  }
+
+  /**
+   * @param {number} noOfChildren
+   * @private
+   */
+  toggleNavControls_(noOfChildren) {
+    if (noOfChildren > 1) {
+      this.controlsContainer_.classList.remove('i-amphtml-lbg-single');
+    } else {
+      this.controlsContainer_.classList.add('i-amphtml-lbg-single');
+    }
   }
 
   /**


### PR DESCRIPTION
Closes https://github.com/ampproject/amphtml/issues/15198, since `<amp-lightbox-gallery>` is now launched, and this covers the single-image usecase. 
