### PR TITLE
amp-video: remove controls from video visual tests since it can cause flake

### DIFF
--- a/examples/visual-tests/video/rotate-to-fullscreen.html
+++ b/examples/visual-tests/video/rotate-to-fullscreen.html
@@ -21,8 +21,7 @@
       width="720"
       height="405"
       layout="responsive"
-      rotate-to-fullscreen
-      controls>
+      rotate-to-fullscreen>
     <div placeholder>
       This is a placeholder
     </div>


### PR DESCRIPTION
The controls for video players become hidden based on a timer depending on the platform and can cause flakes depending on when Percy takes a screenshot. Removing `controls` attribute so UI is consistent without dependency on time.