### PR TITLE
🐛 amp-next-page: Fix recommendation box behavior after final page

### DIFF
--- a/extensions/amp-next-page/0.1/next-page-service.js
+++ b/extensions/amp-next-page/0.1/next-page-service.js
@@ -224,7 +224,6 @@ export class NextPageService {
         cancelled: false,
       };
       this.documentRefs_.push(documentRef);
-      this.nextArticle_++;
 
       const container = this.win_.document.createElement('div');
 
@@ -239,7 +238,7 @@ export class NextPageService {
       const shadowRoot = this.win_.document.createElement('div');
       container.appendChild(shadowRoot);
 
-      const page = this.nextArticle_ - 1;
+      const page = this.nextArticle_;
       this.appendPageHandler_(container).then(() => {
         this.positionObserver_.observe(separator, PositionObserverFidelity.LOW,
             position => this.positionUpdate_(page, position));
@@ -254,6 +253,7 @@ export class NextPageService {
         return;
       }
 
+      this.nextArticle_++;
       Services.xhrFor(/** @type {!Window} */ (this.win_))
           .fetchDocument(next.ampUrl, {ampCors: false})
           .then(doc => new Promise((resolve, reject) => {

--- a/extensions/amp-next-page/0.1/next-page-service.js
+++ b/extensions/amp-next-page/0.1/next-page-service.js
@@ -215,8 +215,7 @@ export class NextPageService {
    * Append a new article if still possible.
    */
   appendNextArticle_() {
-    if (this.nextArticle_ < MAX_ARTICLES &&
-        this.nextArticle_ < this.config_.pages.length) {
+    if (this.nextArticle_ < this.config_.pages.length) {
       const next = this.config_.pages[this.nextArticle_];
       const documentRef = {
         ampUrl: next.ampUrl,
@@ -248,6 +247,12 @@ export class NextPageService {
             PositionObserverFidelity.LOW,
             unused => this.articleLinksPositionUpdate_(documentRef));
       });
+
+      // Don't fetch the next article if we've rendered the maximum on screen.
+      // We just want the article links.
+      if (this.nextArticle_ >= MAX_ARTICLES) {
+        return;
+      }
 
       Services.xhrFor(/** @type {!Window} */ (this.win_))
           .fetchDocument(next.ampUrl, {ampCors: false})


### PR DESCRIPTION
- Restores previous behavior and shows a recommendation box after the last page
- Fixes the recommendation box skipping a recommendation