### PR TITLE
Update bundle size.

### DIFF
--- a/build-system/tasks/bundle-size.js
+++ b/build-system/tasks/bundle-size.js
@@ -21,7 +21,7 @@ const log = require('fancy-log');
 const {getStdout} = require('../exec');
 
 const runtimeFile = './dist/v0.js';
-const maxSize = '76.96KB';
+const maxSize = '76.98KB';
 
 const {green, red, cyan, yellow} = colors;
 


### PR DESCRIPTION
At commit a162de4b54717f5a9ed0fc1bdc41f06df910e514

````
FAIL  ./dist/v0.js: 76.97KB > maxSize 76.96KB (gzip) 
````