### PR TITLE
Making sure the amp-story-consent buttons always have labels.

### DIFF
--- a/extensions/amp-story/0.1/_locales/default.js
+++ b/extensions/amp-story/0.1/_locales/default.js
@@ -21,6 +21,12 @@ import {LocalizedStringBundleDef, LocalizedStringId} from '../localization';
  * @const {!LocalizedStringBundleDef}
  */
 export default {
+  [LocalizedStringId.AMP_STORY_CONSENT_ACCEPT_BUTTON_LABEL]: {
+    string: 'Accept',
+  },
+  [LocalizedStringId.AMP_STORY_CONSENT_DECLINE_BUTTON_LABEL]: {
+    string: 'Decline',
+  },
   [LocalizedStringId.AMP_STORY_EXPERIMENT_ENABLE_BUTTON_LABEL]: {
     string: 'Enable',
   },

--- a/extensions/amp-story/1.0/_locales/default.js
+++ b/extensions/amp-story/1.0/_locales/default.js
@@ -21,6 +21,12 @@ import {LocalizedStringBundleDef, LocalizedStringId} from '../localization';
  * @const {!LocalizedStringBundleDef}
  */
 export default {
+  [LocalizedStringId.AMP_STORY_CONSENT_ACCEPT_BUTTON_LABEL]: {
+    string: 'Accept',
+  },
+  [LocalizedStringId.AMP_STORY_CONSENT_DECLINE_BUTTON_LABEL]: {
+    string: 'Decline',
+  },
   [LocalizedStringId.AMP_STORY_EXPERIMENT_ENABLE_BUTTON_LABEL]: {
     string: 'Enable',
   },


### PR DESCRIPTION
Making sure ``amp-story-consent`` action buttons always have labels, even when using the ``default`` language.

- STAMP 1.0 will fallback to ``default`` instead of ``en`` if the language requested is not supported
- STAMP 0.1 will fallback to ``default`` if no ``lang`` is specified, or if the ``lang`` is set to anything else than English

Adding the english i18n strings to ``default`` ensures the story consent action buttons are never empty. 