### PR TITLE
✨ 🏗 Add a script to enable a pre-push hook that tests local changes before `git push`

### DIFF
--- a/build-system/default-pre-push
+++ b/build-system/default-pre-push
@@ -1,0 +1,50 @@
+#!/bin/bash
+#
+# Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the license.
+#
+# This script adds a pre-push hook to .git/hooks/, which runs some basic tests
+# before running "git push".
+#
+# Default pre-push hook for AMPHTML. To enable, run:
+#     "./build-system/enable-git-pre-push.sh"
+#
+# Note: The checks in this file must not take more than a few seconds to run.
+# Time consuming checks that call gulp build, or run all the tests are
+# forbidden. If you'd like to add something like that to your pre-push, do so
+# by directly editing .git/hooks/pre-push instead of editing this default hook.
+
+GREEN() { echo -e "\033[0;32m$1\033[0m"; }
+CYAN() { echo -e "\033[0;36m$1\033[0m"; }
+
+GULP_BUNDLE_SIZE="gulp bundle-size"
+GULP_LINT_LOCAL="gulp lint --local-changes"
+GULP_TEST_LOCAL="gulp test --local-changes"
+
+echo $(GREEN "Running") $(CYAN "pre-push") $(GREEN "hooks. (Run") $(CYAN "git push --no-verify") $(GREEN "or") $(CYAN "git push -n") $(GREEN "to skip them.)")
+echo -e "\n"
+
+echo $(GREEN "Running") $(CYAN "$GULP_BUNDLE_SIZE")
+eval $GULP_BUNDLE_SIZE || exit 1
+echo -e "\n"
+
+echo $(GREEN "Running") $(CYAN "$GULP_LINT_LOCAL")
+eval $GULP_LINT_LOCAL || exit 1
+echo -e "\n"
+
+echo $(GREEN "Running") $(CYAN "$GULP_TEST_LOCAL")
+eval $GULP_TEST_LOCAL || exit 1
+echo -e "\n"
+
+echo $(GREEN "Done with") $(CYAN "pre-push") $(GREEN "hooks. Pushing commits to GitHub...")

--- a/build-system/enable-git-pre-push.sh
+++ b/build-system/enable-git-pre-push.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+#
+# Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the license.
+#
+# This script adds a pre-push hook to .git/hooks/, which runs some basic tests
+# before running "git push".
+#
+# To enable it, run this script: "./build-system/enable-git-pre-push.sh"
+
+
+SCRIPT=`realpath $0`
+BUILD_SYSTEM_DIR=$(dirname "$SCRIPT")
+AMPHTML_DIR=$(dirname "$BUILD_SYSTEM_DIR")
+PRE_PUSH_SRC="build-system/default-pre-push"
+GIT_HOOKS_DIR=".git/hooks"
+PRE_PUSH_DEST="$GIT_HOOKS_DIR/pre-push"
+PRE_PUSH_BACKUP="$GIT_HOOKS_DIR/pre-push.backup"
+
+GREEN() { echo -e "\033[0;32m$1\033[0m"; }
+CYAN() { echo -e "\033[0;36m$1\033[0m"; }
+YELLOW() { echo -e "\033[0;33m$1\033[0m"; }
+
+
+echo $(YELLOW "-----------------------------------------------------------------------------------------------------------------")
+echo $(GREEN "Running") $(CYAN $SCRIPT)
+echo $(GREEN "This script does the following:")
+echo $(GREEN "  1. If already present, makes a backup of") $(CYAN "$PRE_PUSH_DEST") $(GREEN "at") $(CYAN "$PRE_PUSH_BACKUP")
+echo $(GREEN "  2. Creates a new file") $(CYAN "$PRE_PUSH_DEST") $(GREEN "which calls") $(CYAN "$PRE_PUSH_SRC")
+echo $(GREEN "  3. With this,")  $(CYAN "git push") $(GREEN "will first run the checks in") $(CYAN "$PRE_PUSH_SRC")
+echo $(GREEN "  4. You can edit") $(CYAN "$PRE_PUSH_DEST") $(GREEN "to change the pre-push hooks that are run before") $(CYAN "git push")
+echo $(GREEN "  5. To skip the hook, run") $(CYAN "git push --no-verify") $(GREEN "or") $(CYAN "git push -n")
+echo $(GREEN "  6. To remove the hook, delete the file") $(CYAN "$PRE_PUSH_DEST")
+echo $(YELLOW "-----------------------------------------------------------------------------------------------------------------")
+echo -e "\n"
+
+read -n 1 -s -r -p "$(GREEN 'Press any key to continue...')"
+echo -e "\n"
+
+if [ -f "$AMPHTML_DIR/$PRE_PUSH_DEST" ]; then
+  echo $(GREEN "Found") $(CYAN $PRE_PUSH_DEST)
+  mv $AMPHTML_DIR/$PRE_PUSH_DEST $AMPHTML_DIR/$PRE_PUSH_BACKUP
+  echo $(GREEN "Moved it to") $(CYAN $PRE_PUSH_BACKUP)
+fi
+
+cat > $AMPHTML_DIR/$PRE_PUSH_DEST <<- EOM
+#!/bin/bash
+# Pre-push hook for AMPHTML
+eval $AMPHTML_DIR/$PRE_PUSH_SRC
+EOM
+chmod 755 $AMPHTML_DIR/$PRE_PUSH_DEST
+
+echo $(GREEN "Successfully wrote") $(CYAN "$PRE_PUSH_DEST")

--- a/build-system/tasks/bundle-size.js
+++ b/build-system/tasks/bundle-size.js
@@ -16,6 +16,7 @@
 'use strict';
 
 const colors = require('ansi-colors');
+const fs = require('fs-extra');
 const gulp = require('gulp-help')(require('gulp'));
 const log = require('fancy-log');
 const {getStdout} = require('../exec');
@@ -27,6 +28,15 @@ const {green, red, cyan, yellow} = colors;
 
 
 function checkBundleSize() {
+  if (!fs.existsSync(runtimeFile)) {
+    log(green('Could not find'), cyan(runtimeFile) +
+        green('. Skipping bundlesize check.'));
+    log(green('To include this check, run'),
+        cyan('gulp dist --fortesting [--noextensions]'),
+        green('before'), cyan('gulp bundle-size') + yellow('.'));
+    return;
+  }
+
   const cmd = `npx bundlesize -f "${runtimeFile}" -s "${maxSize}"`;
   log('Running ' + cyan(cmd) + '...');
   const output = getStdout(cmd);
@@ -35,11 +45,6 @@ function checkBundleSize() {
   const error = output.match(/ERROR .*/);
   if (error && error.length > 0) {
     log(yellow(error[0]));
-    if (!process.env.TRAVIS) {
-      log(yellow('You must run'),
-          cyan('gulp dist --fortesting [--noextensions]'),
-          yellow('before running'), cyan('gulp bundle-size') + yellow('.'));
-    }
   } else if (fail && fail.length > 0) {
     log(red(fail[0]));
     log(red('ERROR:'), cyan('bundlesize'), red('found that'),

--- a/build-system/tasks/runtime-test.js
+++ b/build-system/tasks/runtime-test.js
@@ -203,7 +203,9 @@ function applyAmpConfig() {
   if (argv.unit || argv.a4a) {
     return Promise.resolve();
   }
-  log(green('Setting the runtime\'s AMP config to'), cyan(ampConfig));
+  if (!process.env.TRAVIS) {
+    log(green('Setting the runtime\'s AMP config to'), cyan(ampConfig));
+  }
   return writeConfig('dist/amp.js').then(() => {
     return writeConfig('dist/v0.js');
   });
@@ -282,8 +284,8 @@ function runTests() {
   } else if (argv['local-changes']) {
     const filesChanged = unitTestFilesChanged();
     if (filesChanged.length == 0) {
-      log(green('No unit test files were changed. Exiting.'));
-      process.exit(0);
+      log(green('INFO: ') + 'No unit test files were changed.');
+      return Promise.resolve();
     }
     c.files = c.files.concat(config.commonUnitTestPaths, filesChanged);
     c.client.failOnConsoleError = true;


### PR DESCRIPTION
This PR does the following:
1. Adds a default pre-push hook for AMP at `build-system/default-pre-push`, which runs:
    - `gulp bundle-size` (if `dist/v0.js` was built) (~2 sec)
    - `gulp lint --local-changes` (~3 sec)
    - `gulp test --local-changes` (~5 sec)
2. Adds a script called `build-system/enable-git-pre-push.sh`, which when run, will install a shortcut to `build-system/default-pre-push` at `.git/hooks/pre-push`
3. Once enabled, whenever a developer runs `git push`, the pre-push hook will first run, and if it fails, the push is canceled
4. Makes minor updates to `gulp test --local-changes` and `gulp bundle-size` so they work well as pre-push hooks

**Usage:**
- To opt in, simply run `./build-system/enable-git-pre-push.sh` from the root directory.
- Every call to `git push` will first run `.git/hooks/pre-push`
- The total time to run all pre-push hooks is ~10 seconds
- To skip the hook, run `git push --no-verify`
- To remove the hook, simply delete `.git/hooks/pre-push`

Note: We use a level of indirection instead of copying `build-system/default-pre-push` to `.git/hooks/pre-push` so that the default behavior can be changed at a later time, and developers who have opted in don't have to reinstall the hook to get the new behavior.

Fixes #15369
