### PR TITLE
✨ amp-next-page: Start preloading next document as soon as one finishes

### DIFF
--- a/extensions/amp-next-page/0.1/next-page-service.js
+++ b/extensions/amp-next-page/0.1/next-page-service.js
@@ -279,7 +279,9 @@ export class NextPageService {
           }),
           e => dev().error(TAG, `failed to fetch ${next.ampUrl}`, e))
           .catch(e => dev().error(TAG,
-              `failed to attach shadow document for ${next.ampUrl}`, e));
+              `failed to attach shadow document for ${next.ampUrl}`, e))
+          // The new page may be short and the next may already need fetching.
+          .then(() => this.scrollHandler_());
     }
   }
 

--- a/extensions/amp-next-page/0.1/test/test-amp-next-page.js
+++ b/extensions/amp-next-page/0.1/test/test-amp-next-page.js
@@ -154,7 +154,7 @@ env => {
     const attachShadowDocSpy =
         sandbox.spy(nextPageService.multidocManager_, 'attachShadowDoc');
 
-    sandbox.stub(viewport, 'getClientRectAsync').callsFake(() => {
+    sandbox.stub(viewport, 'getClientRectAsync').onFirstCall().callsFake(() => {
       // 1x viewport away
       return Promise.resolve(
           layoutRectLtwh(0, 0, sizes.width, sizes.height * 2));
@@ -192,7 +192,7 @@ env => {
     const attachShadowDocSpy =
       sandbox.spy(nextPageService.multidocManager_, 'attachShadowDoc');
 
-    sandbox.stub(viewport, 'getClientRectAsync').callsFake(() => {
+    sandbox.stub(viewport, 'getClientRectAsync').onFirstCall().callsFake(() => {
       // 1x viewport away
       return Promise.resolve(
           layoutRectLtwh(0, 0, sizes.width, sizes.height * 2));


### PR DESCRIPTION
Handles the case where the next page loaded in is short and another document needs loading immediately.