### PR TITLE
Rebalance amp-bind limits

### DIFF
--- a/extensions/amp-bind/0.1/bind-expression.js
+++ b/extensions/amp-bind/0.1/bind-expression.js
@@ -30,11 +30,10 @@ const TAG = 'amp-bind';
 export let BindExpressionResultDef;
 
 /**
- * Default maximum number of nodes in an expression AST.
- * Double size of a "typical" expression in examples/bind/performance.amp.html.
+ * Maximum number of nodes in an expression AST.
  * @const @private {number}
  */
-const DEFAULT_MAX_AST_SIZE = 50;
+const MAX_AST_SIZE = 100;
 
 /** @const @private {string} */
 const BUILT_IN_FUNCTIONS = 'built-in-functions';
@@ -210,7 +209,7 @@ export class BindExpression {
     this.expressionSize = this.numberOfNodesInAst_(this.ast_);
 
     // Check if this expression string is too large (for performance).
-    const maxSize = opt_maxAstSize || DEFAULT_MAX_AST_SIZE;
+    const maxSize = opt_maxAstSize || MAX_AST_SIZE;
     const skipConstraint = getMode().localDev && !getMode().test;
     if (this.expressionSize > maxSize && !skipConstraint) {
       throw new Error(`Expression size (${this.expressionSize}) exceeds max ` +

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -146,7 +146,7 @@ export class Bind {
      * Upper limit on number of bindings for performance.
      * @private {number}
      */
-    this.maxNumberOfBindings_ = 2000; // Based on ~1ms to parse an expression.
+    this.maxNumberOfBindings_ = 1000; // Based on ~2ms to parse an expression.
 
     /** @const @private {!../../../src/service/resources-impl.Resources} */
     this.resources_ = Services.resourcesForDoc(ampdoc);
@@ -502,12 +502,6 @@ export class Bind {
         : this.maxNumberOfBindings_ - this.numberOfBindings();
 
       return this.scanNode_(node, limit).then(results => {
-        // Measuring impact of possibly reducing the binding limit (#11434).
-        const numberOfBindings = this.numberOfBindings();
-        if (numberOfBindings > 1000) {
-          dev().expectedError(TAG, `Over 1000 bindings (${numberOfBindings}).`);
-        }
-
         const {
           boundElements, bindings, expressionToElements, limitExceeded,
         } = results;
@@ -516,7 +510,7 @@ export class Bind {
         Object.assign(this.expressionToElements_, expressionToElements);
 
         if (limitExceeded) {
-          user().error(TAG, 'Maximum number of bindings reached ' +
+          dev().expectedError(TAG, 'Maximum number of bindings reached ' +
               `(${this.maxNumberOfBindings_}). Additional elements with ` +
               'bindings will be ignored.');
         }

--- a/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
@@ -27,8 +27,8 @@ import {BindEvents} from '../../bind-events';
 import {RAW_OBJECT_ARGS_KEY} from '../../../../../src/action-constants';
 import {Services} from '../../../../../src/services';
 import {chunkInstanceForTesting} from '../../../../../src/chunk';
+import {dev, user} from '../../../../../src/log';
 import {toArray} from '../../../../../src/types';
-import {user} from '../../../../../src/log';
 
 /**
  * @param {!Object} env
@@ -723,7 +723,7 @@ describe.configure().ifNewChrome().run('Bind', function() {
 
     it('should stop scanning once max number of bindings is reached', () => {
       bind.setMaxNumberOfBindingsForTesting(2);
-      const errorStub = env.sandbox.stub(user(), 'error');
+      const errorStub = env.sandbox.stub(dev(), 'expectedError');
 
       const foo = createElement(env, container, '[text]="foo"');
       const bar = createElement(env, container, '[text]="bar" [class]="baz"');


### PR DESCRIPTION
Expression AST size: 50 -> 100
Max number of bindings: 2000 -> 1000

/to @alabiaga @aghassemi 