### PR TITLE
Ensure delayed impression is fired for multi-size creatives

### DIFF
--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -798,7 +798,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     }
     // If this is a multi-size creative, fire delayed impression now. If it's
     // fluid, wait until after resize.
-    if (this.isFluid_ && !size) {
+    if (this.isFluid_ && !this.returnedSize_) {
       this.fluidImpressionUrl_ = responseHeaders.get('X-AmpImps');
     } else {
       this.fireDelayedImpressions(responseHeaders.get('X-AmpImps'));

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -572,9 +572,11 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
           this.initialSize_.height,
           multiSizeValidation == 'true',
           this.isFluidRequest_);
-      this.parameterSize_ += '|' + dimensions
-          .map(dimension => dimension.join('x'))
-          .join('|');
+      if (dimensions.length) {
+        this.parameterSize_ += '|' + dimensions
+            .map(dimension => dimension.join('x'))
+            .join('|');
+      }
     }
   }
 

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -787,12 +787,6 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
       this.extensions_./*OK*/installExtensionForDoc(
           this.getAmpDoc(), 'amp-analytics');
     }
-    if (this.isFluid_) {
-      this.fluidImpressionUrl_ = responseHeaders.get('X-AmpImps');
-    } else {
-      this.fireDelayedImpressions(responseHeaders.get('X-AmpImps'));
-      this.fireDelayedImpressions(responseHeaders.get('X-AmpRSImps'), true);
-    }
     // If the server returned a size, use that, otherwise use the size that we
     // sent in the ad request.
     let size = super.extractSize(responseHeaders);
@@ -802,6 +796,15 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     } else {
       size = this.getSlotSize();
     }
+    // If this is a multi-size creative, fire delayed impression now. If it's
+    // fluid, wait until after resize.
+    if (this.isFluid_ && !size) {
+      this.fluidImpressionUrl_ = responseHeaders.get('X-AmpImps');
+    } else {
+      this.fireDelayedImpressions(responseHeaders.get('X-AmpImps'));
+      this.fireDelayedImpressions(responseHeaders.get('X-AmpRSImps'), true);
+    }
+
     return size;
   }
 

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -802,7 +802,6 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
       this.fluidImpressionUrl_ = responseHeaders.get('X-AmpImps');
     } else {
       this.fireDelayedImpressions(responseHeaders.get('X-AmpImps'));
-      this.fireDelayedImpressions(responseHeaders.get('X-AmpRSImps'), true);
     }
 
     return size;

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -330,7 +330,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     this.ifi_ = 0;
 
     /** @private {boolean} */
-    this.isFluid_ = false;
+    this.isFluidRequest_ = false;
 
     /** @private {?string} */
     this.fluidImpressionUrl_ = null;
@@ -397,8 +397,8 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
 
   /** @override */
   isLayoutSupported(layout) {
-    this.isFluid_ = layout == Layout.FLUID;
-    return this.isFluid_ || isLayoutSizeDefined(layout);
+    this.isFluidRequest_ = layout == Layout.FLUID;
+    return this.isFluidRequest_ || isLayoutSizeDefined(layout);
   }
 
   /** @override */
@@ -521,7 +521,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
       'ifi': this.ifi_,
       'rc': this.refreshCount_ || null,
       'frc': Number(this.fromResumeCallback) || null,
-      'fluid': this.isFluid_ ? 'height' : null,
+      'fluid': this.isFluidRequest_ ? 'height' : null,
       'fsf': this.forceSafeframe_ ? '1' : null,
       'scp': serializeTargeting_(
           (this.jsonTargeting_ && this.jsonTargeting_['targeting']) || null,
@@ -544,7 +544,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
       Number(this.element.getAttribute('width'));
     const height = Number(this.element.getAttribute('data-override-height')) ||
       Number(this.element.getAttribute('height'));
-    this.initialSize_ = this.isFluid_ ? {width: 0, height: 0} :
+    this.initialSize_ = this.isFluidRequest_ ? {width: 0, height: 0} :
       (width && height ?
         // width/height could be 'auto' in which case we fallback to measured.
         {width, height} : this.getIntersectionElementLayoutBox());
@@ -552,7 +552,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
       tryParseJson(this.element.getAttribute('json')) || {};
     this.adKey_ = this.generateAdKey_(
         `${this.initialSize_.width}x${this.initialSize_.height}`);
-    this.parameterSize_ = this.isFluid_ ?
+    this.parameterSize_ = this.isFluidRequest_ ?
       '320x50' : `${this.initialSize_.width}x${this.initialSize_.height}`;
     const multiSizeDataStr = this.element.getAttribute('data-multi-size');
     if (multiSizeDataStr) {
@@ -571,12 +571,10 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
           this.initialSize_.width,
           this.initialSize_.height,
           multiSizeValidation == 'true',
-          this.isFluid_);
-      if (dimensions.length) {
-        this.parameterSize_ += '|' + dimensions
-            .map(dimension => dimension.join('x'))
-            .join('|');
-      }
+          this.isFluidRequest_);
+      this.parameterSize_ += '|' + dimensions
+          .map(dimension => dimension.join('x'))
+          .join('|');
     }
   }
 
@@ -798,7 +796,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     }
     // If this is a multi-size creative, fire delayed impression now. If it's
     // fluid, wait until after resize.
-    if (this.isFluid_ && !this.returnedSize_) {
+    if (this.isFluidRequest_ && !this.returnedSize_) {
       this.fluidImpressionUrl_ = responseHeaders.get('X-AmpImps');
     } else {
       this.fireDelayedImpressions(responseHeaders.get('X-AmpImps'));
@@ -971,7 +969,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     // the slot. This ensures that the creative is centered in the former case,
     // and not truncated in the latter.
     const size = this.returnedSize_ || this.getSlotSize();
-    const isMultiSizeFluid = this.isFluid_ && this.returnedSize_ &&
+    const isMultiSizeFluid = this.isFluidRequest_ && this.returnedSize_ &&
         // TODO(@glevitzky, 11583) Remove this clause once we stop sending back
         // the size header for fluid ads. Fluid size headers always come back as
         // 0x0.
@@ -1036,7 +1034,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     // We want to resize only if neither returned dimension is larger than its
     // primary counterpart, and if at least one of the returned dimensions
     // differ from its primary counterpart.
-    if ((this.isFluid_ && width && height) ||
+    if ((this.isFluidRequest_ && width && height) ||
         (width != pWidth || height != pHeight) &&
         (width <= pWidth && height <= pHeight)) {
       this.attemptChangeSize(height, width).catch(() => {});
@@ -1270,8 +1268,9 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
 
   /** @override */
   getNonAmpCreativeRenderingMethod(headerValue) {
-    return this.forceSafeframe_ || this.isFluid_ ? XORIGIN_MODE.SAFEFRAME :
-      super.getNonAmpCreativeRenderingMethod(headerValue);
+    return this.forceSafeframe_ || this.isFluidRequest_
+      ? XORIGIN_MODE.SAFEFRAME
+      : super.getNonAmpCreativeRenderingMethod(headerValue);
   }
 
 
@@ -1289,14 +1288,15 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
 
   /** @override */
   getAdditionalContextMetadata(isSafeFrame = false) {
-    if (!this.isFluid_ && !isSafeFrame) {
+    if (!this.isFluidRequest_ && !isSafeFrame) {
       return;
     }
     const creativeSize = this.getCreativeSize();
     dev().assert(creativeSize, 'this.getCreativeSize returned null');
     this.safeframeApi_ = this.safeframeApi_ ||
         new SafeframeHostApi(
-            this, this.isFluid_, /** @type {{height, width}} */(creativeSize),
+            this, this.isFluidRequest_,
+            /** @type {{height, width}} */(creativeSize),
             this.fluidImpressionUrl_);
 
     return this.safeframeApi_.getSafeframeNameAttr();

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -248,6 +248,57 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
       expect(fireDelayedImpressionsSpy.withArgs(
           'https://c.com?e=f,https://d.com?g=h', true)).to.be.calledOnce;
     });
+    it('shouldnt load delayed impression amp-pixels with fluid', () => {
+      const fireDelayedImpressionsSpy =
+          sandbox.spy(impl, 'fireDelayedImpressions');
+      impl.isFluid_ = true; debugger;
+      expect(impl.extractSize({
+        get(name) {
+          switch (name) {
+            case 'X-AmpImps':
+              return 'https://a.com?a=b,https://b.com?c=d';
+            case 'X-AmpRSImps':
+              return 'https://c.com?e=f,https://d.com?g=h';
+            default:
+              return undefined;
+          }
+        },
+        has(name) {
+          return !!this.get(name);
+        },
+      })).to.deep.equal(size);
+      expect(fireDelayedImpressionsSpy.withArgs(
+          'https://a.com?a=b,https://b.com?c=d')).to.not.be.called;
+      expect(fireDelayedImpressionsSpy.withArgs(
+          'https://c.com?e=f,https://d.com?g=h', true)).to.not.be.called;
+    });
+    it('should load delayed impression amp-pixels with fluid + multi-size', () => {
+      const fireDelayedImpressionsSpy =
+          sandbox.spy(impl, 'fireDelayedImpressions');
+      sandbox.stub(impl, 'handleResize_');
+      impl.isFluid_ = true;
+      expect(impl.extractSize({
+        get(name) {
+          switch (name) {
+            case 'X-AmpImps':
+              return 'https://a.com?a=b,https://b.com?c=d';
+            case 'X-AmpRSImps':
+              return 'https://c.com?e=f,https://d.com?g=h';
+            case 'X-CreativeSize':
+              return '200x50';
+            default:
+              return undefined;
+          }
+        },
+        has(name) {
+          return !!this.get(name);
+        },
+      })).to.deep.equal(size);
+      expect(fireDelayedImpressionsSpy.withArgs(
+          'https://a.com?a=b,https://b.com?c=d')).to.be.calledOnce;
+      expect(fireDelayedImpressionsSpy.withArgs(
+          'https://c.com?e=f,https://d.com?g=h', true)).to.be.calledOnce;
+    });
   });
 
   describe('#onCreativeRender', () => {

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -251,7 +251,7 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
     it('shouldnt load delayed impression amp-pixels with fluid', () => {
       const fireDelayedImpressionsSpy =
           sandbox.spy(impl, 'fireDelayedImpressions');
-      impl.isFluid_ = true; debugger;
+      impl.isFluid_ = true;
       expect(impl.extractSize({
         get(name) {
           switch (name) {
@@ -272,33 +272,34 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
       expect(fireDelayedImpressionsSpy.withArgs(
           'https://c.com?e=f,https://d.com?g=h', true)).to.not.be.called;
     });
-    it('should load delayed impression amp-pixels with fluid + multi-size', () => {
-      const fireDelayedImpressionsSpy =
-          sandbox.spy(impl, 'fireDelayedImpressions');
-      sandbox.stub(impl, 'handleResize_');
-      impl.isFluid_ = true;
-      expect(impl.extractSize({
-        get(name) {
-          switch (name) {
-            case 'X-AmpImps':
-              return 'https://a.com?a=b,https://b.com?c=d';
-            case 'X-AmpRSImps':
-              return 'https://c.com?e=f,https://d.com?g=h';
-            case 'X-CreativeSize':
-              return '200x50';
-            default:
-              return undefined;
-          }
-        },
-        has(name) {
-          return !!this.get(name);
-        },
-      })).to.deep.equal(size);
-      expect(fireDelayedImpressionsSpy.withArgs(
-          'https://a.com?a=b,https://b.com?c=d')).to.be.calledOnce;
-      expect(fireDelayedImpressionsSpy.withArgs(
-          'https://c.com?e=f,https://d.com?g=h', true)).to.be.calledOnce;
-    });
+    it('should load delayed impression amp-pixels with fluid + multi-size',
+        () => {
+          const fireDelayedImpressionsSpy =
+              sandbox.spy(impl, 'fireDelayedImpressions');
+          sandbox.stub(impl, 'handleResize_');
+          impl.isFluid_ = true;
+          expect(impl.extractSize({
+            get(name) {
+              switch (name) {
+                case 'X-AmpImps':
+                  return 'https://a.com?a=b,https://b.com?c=d';
+                case 'X-AmpRSImps':
+                  return 'https://c.com?e=f,https://d.com?g=h';
+                case 'X-CreativeSize':
+                  return '200x50';
+                default:
+                  return undefined;
+              }
+            },
+            has(name) {
+              return !!this.get(name);
+            },
+          })).to.deep.equal(size);
+          expect(fireDelayedImpressionsSpy.withArgs(
+              'https://a.com?a=b,https://b.com?c=d')).to.be.calledOnce;
+          expect(fireDelayedImpressionsSpy.withArgs(
+              'https://c.com?e=f,https://d.com?g=h', true)).to.be.calledOnce;
+        });
   });
 
   describe('#onCreativeRender', () => {

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -233,8 +233,6 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
           switch (name) {
             case 'X-AmpImps':
               return 'https://a.com?a=b,https://b.com?c=d';
-            case 'X-AmpRSImps':
-              return 'https://c.com?e=f,https://d.com?g=h';
             default:
               return undefined;
           }
@@ -245,8 +243,6 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
       })).to.deep.equal(size);
       expect(fireDelayedImpressionsSpy.withArgs(
           'https://a.com?a=b,https://b.com?c=d')).to.be.calledOnce;
-      expect(fireDelayedImpressionsSpy.withArgs(
-          'https://c.com?e=f,https://d.com?g=h', true)).to.be.calledOnce;
     });
     it('shouldnt load delayed impression amp-pixels with fluid', () => {
       const fireDelayedImpressionsSpy =
@@ -257,8 +253,6 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
           switch (name) {
             case 'X-AmpImps':
               return 'https://a.com?a=b,https://b.com?c=d';
-            case 'X-AmpRSImps':
-              return 'https://c.com?e=f,https://d.com?g=h';
             default:
               return undefined;
           }
@@ -269,8 +263,6 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
       })).to.deep.equal(size);
       expect(fireDelayedImpressionsSpy.withArgs(
           'https://a.com?a=b,https://b.com?c=d')).to.not.be.called;
-      expect(fireDelayedImpressionsSpy.withArgs(
-          'https://c.com?e=f,https://d.com?g=h', true)).to.not.be.called;
     });
     it('should load delayed impression amp-pixels with fluid + multi-size',
         () => {
@@ -283,8 +275,6 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
               switch (name) {
                 case 'X-AmpImps':
                   return 'https://a.com?a=b,https://b.com?c=d';
-                case 'X-AmpRSImps':
-                  return 'https://c.com?e=f,https://d.com?g=h';
                 case 'X-CreativeSize':
                   return '200x50';
                 default:
@@ -297,8 +287,6 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
           })).to.deep.equal(size);
           expect(fireDelayedImpressionsSpy.withArgs(
               'https://a.com?a=b,https://b.com?c=d')).to.be.calledOnce;
-          expect(fireDelayedImpressionsSpy.withArgs(
-              'https://c.com?e=f,https://d.com?g=h', true)).to.be.calledOnce;
         });
   });
 

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -251,7 +251,7 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
     it('shouldnt load delayed impression amp-pixels with fluid', () => {
       const fireDelayedImpressionsSpy =
           sandbox.spy(impl, 'fireDelayedImpressions');
-      impl.isFluid_ = true;
+      impl.isFluidRequest_ = true;
       expect(impl.extractSize({
         get(name) {
           switch (name) {

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-fluid.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-fluid.js
@@ -101,7 +101,7 @@ describes.realWin('DoubleClick Fast Fetch Fluid', realWinConfig, env => {
   });
 
   it('should be fluid enabled', () => {
-    expect(impl.isFluid_).to.be.true;
+    expect(impl.isFluidRequest_).to.be.true;
   });
 
   it('should have a supported layout', () => {


### PR DESCRIPTION
On slots that are both fluid and multi-size, delayed impressions will not fire because the firing logic is gated by the isFluid_ boolean, which is true even when the returned creative is multi-size (and not fluid). This change ensures the impression fires if the returned creative is multi-size by checking for the presence of a returned creative size. E.g., we are going from:

```javascript
if (this.isFluid_) {
  // Wait to fire
} else {
  // Fire right away
}
```

to 

```javascript
if (this.isFluid_ && !this.returnedSize_) {
  // Wait to fire
} else {
  // Fire right away
}
```