### PR TITLE
amp-next-page: allow doc-level optin

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -1,8 +1,7 @@
 {
   "allow-doc-opt-in": [
-    "amp-animation",
     "amp-date-picker",
-    "amp-ima-video",
+    "amp-next-page",
     "ampdoc-shell",
     "inabox-rov",
     "inline-styles",

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -1,8 +1,7 @@
 {
   "allow-doc-opt-in": [
-    "amp-animation",
     "amp-date-picker",
-    "amp-ima-video",
+    "amp-next-page",
     "ampdoc-shell",
     "inabox-rov",
     "inline-styles",

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -565,8 +565,8 @@ function main() {
   const files = filesInPr();
   const buildTargets = determineBuildTargets(files);
 
-  // Exit early if flag-config files are mixed with non-flag-config files.
-  if (buildTargets.has('FLAG_CONFIG') && buildTargets.size !== 1) {
+  // Exit early if flag-config files are mixed with runtime files.
+  if (buildTargets.has('FLAG_CONFIG') && buildTargets.has('RUNTIME')) {
     console.log(fileLogPrefix, colors.red('ERROR:'),
         'Looks like your PR contains',
         colors.cyan('{prod|canary}-config.json'),

--- a/extensions/amp-next-page/amp-next-page.md
+++ b/extensions/amp-next-page/amp-next-page.md
@@ -24,7 +24,7 @@ limitations under the License.
   </tr>
   <tr>
     <td class="col-fourty"><strong>Availability</strong></td>
-    <td>Experimental</td>
+    <td><a href="https://www.ampproject.org/docs/reference/experimental.html">Experimental</a> <a href="https://github.com/ampproject/amphtml/blob/3a06c99f259b66998b61935a5ee5f0075481bfd2/tools/experiments/README.md#enable-an-experiment-for-a-particular-document"> (Document opt-in allowed)</a></td>
   </tr>
   <tr>
     <td width="40%"><strong>Required Script</strong></td>


### PR DESCRIPTION
`+` Clean up of old ones.
`+` Allow the presubmit check to have config and non-runtime files mixed together. 