### PR TITLE
Doubleclick SRA fix size parameter for invalid multisize options

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,7 @@ Follow this process for contributing new features:
 * Familiarize yourself with the [AMP Design Principles](contributing/DESIGN_PRINCIPLES.md)
 * [Create a new GitHub issue](https://github.com/ampproject/amphtml/issues/new) to start discussion of the new feature.
 * Before starting on the code get approval for your feature from an [OWNER](https://github.com/ampproject/amphtml/search?utf8=%E2%9C%93&q=filename%3AOWNERS.yaml&type=Code) of your feature's area and a [core committer](https://github.com/ampproject/amphtml/blob/master/GOVERNANCE.md#core-committers).  In most cases the people who can give this approval and are most familiar with your feature's area will get involved proactively or someone else in the community will add them.  If you are having trouble finding the right people add a comment on the issue or reach out on one of the channels in [How to get help](contributing/getting-started-e2e.md#how-to-get-help).
-* Consider bringing the eng design for your feature to our [weekly design review](#weekly-design-review).
+* Consider bringing the eng design for your feature to our [weekly design review](#weekly-design-reviews).
 * Follow the guidelines for [Contributing code](#contributing-code) described above.
 
 ## Contributing extended components

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -1252,12 +1252,12 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
   }
 
   /**
-   * @param {string} messages
-   * @param {!Error} error
+   * @param {string} message
+   * @param {*} error
    * @visibleForTesting
    */
   warnOnError(message, error) {
-    this.dev().warn(TAG, message, error);
+    dev().warn(TAG, message, error);
   }
 
   /** @override */

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -1247,7 +1247,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
                     } else if (!!this.win.document.querySelector(
                         'meta[name=amp-ad-doubleclick-sra]')) {
                       assignAdUrlToError(/** @type {!Error} */(error), sraUrl);
-                      this.user().error(TAG, 'SRA request failure', error);
+                      this.warnOnError('SRA request failure', error);
                       // Publisher explicitly wants SRA so do not attempt to
                       // recover as SRA guarantees cannot be enforced.
                       typeInstances.forEach(instance => {
@@ -1266,6 +1266,15 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
             });
           });
         });
+  }
+
+  /**
+   * @param {string} messages
+   * @param {!Error} error
+   * @visibleForTesting
+   */
+  warnOnError(message, error) {
+    this.dev().warn(TAG, message, error);
   }
 
   /** @override */

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -589,9 +589,11 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
           this.initialSize_.height,
           multiSizeValidation == 'true',
           this.isFluid_);
-      this.parameterSize_ += '|' + dimensions
-          .map(dimension => dimension.join('x'))
-          .join('|');
+      if (dimensions.length) {
+        this.parameterSize_ += '|' + dimensions
+            .map(dimension => dimension.join('x'))
+            .join('|');
+      }
     }
   }
 

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-sra.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-sra.js
@@ -202,7 +202,7 @@ describes.realWin('amp-ad-network-doubleclick-impl', config , env => {
     });
   });
 
-  describe('#initiateSraRequests', () => {
+  describe.only('#initiateSraRequests', () => {
     let xhrMock;
 
     function createA4aSraInstance(networkId) {
@@ -339,6 +339,7 @@ describes.realWin('amp-ad-network-doubleclick-impl', config , env => {
             const impl = createA4aSraInstance(network.networkId);
             doubleclickInstances.push(impl);
             sandbox.stub(impl, 'isValidElement').returns(!invalid);
+            sandbox.stub(impl, 'promiseErrorHandler_');
             if (invalid) {
               impl.element.setAttribute('data-test-invalid', 'true');
             }

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-sra.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-sra.js
@@ -202,7 +202,7 @@ describes.realWin('amp-ad-network-doubleclick-impl', config , env => {
     });
   });
 
-  describe.only('#initiateSraRequests', () => {
+  describe('#initiateSraRequests', () => {
     let xhrMock;
 
     function createA4aSraInstance(networkId) {
@@ -340,6 +340,7 @@ describes.realWin('amp-ad-network-doubleclick-impl', config , env => {
             doubleclickInstances.push(impl);
             sandbox.stub(impl, 'isValidElement').returns(!invalid);
             sandbox.stub(impl, 'promiseErrorHandler_');
+            sandbox.stub(impl, 'warnOnError');
             if (invalid) {
               impl.element.setAttribute('data-test-invalid', 'true');
             }

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-sra.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-sra.js
@@ -138,6 +138,7 @@ describes.realWin('amp-ad-network-doubleclick-impl', config , env => {
           'data-slot': '/1234/abc/def',
           'json': JSON.stringify(targeting1),
           'data-force-safeframe': forceSafeFrame ? '1' : '0',
+          'data-multi-size': '9999x9999',
         };
         const element1 =
           createElementWithAttributes(doc, 'amp-ad', config1);


### PR DESCRIPTION
Correct issue where amp-ad with invalid multisize options (sizes that are larger than the current slot) cause a dangling '|' for sz parameter.  This is tolerated for standard requests but causes 400 for SRA.