### PR TITLE
Resize `<amp-reddit>` component in response to 3p resize event

### DIFF
--- a/3p/ampcontext-integration.js
+++ b/3p/ampcontext-integration.js
@@ -70,7 +70,8 @@ export class IntegrationAmpContext extends AbstractAmpContext {
     return (this.embedType_ === 'facebook'
         || this.embedType_ === 'twitter'
         || this.embedType_ === 'github'
-        || this.embedType_ === 'mathml');
+        || this.embedType_ === 'mathml'
+        || this.embedType_ === 'reddit');
   }
 
   /** @return {!Window} */

--- a/3p/reddit.js
+++ b/3p/reddit.js
@@ -82,4 +82,10 @@ export function reddit(global, data) {
   global.document.getElementById('c').appendChild(container);
 
   getContainerScript(global, scriptSource);
+
+  global.addEventListener('resize', event => {
+    global.context.updateDimensions(
+      event.target.outerWidth,
+      event.target.outerHeight);
+  });
 }

--- a/3p/reddit.js
+++ b/3p/reddit.js
@@ -85,7 +85,7 @@ export function reddit(global, data) {
 
   global.addEventListener('resize', event => {
     global.context.updateDimensions(
-      event.target.outerWidth,
-      event.target.outerHeight);
+        event.target.outerWidth,
+        event.target.outerHeight);
   });
 }

--- a/extensions/amp-reddit/0.1/amp-reddit.js
+++ b/extensions/amp-reddit/0.1/amp-reddit.js
@@ -60,9 +60,9 @@ class AmpReddit extends AMP.BaseElement {
 
     const iframe = getIframe(this.win, this.element, 'reddit');
     this.applyFillContent(iframe);
-     listenFor(iframe, 'embed-size', data => {
+    listenFor(iframe, 'embed-size', data => {
       this./*OK*/changeHeight(data['height']);
-     }, /* opt_is3P */true);
+    }, /* opt_is3P */true);
     this.element.appendChild(iframe);
     return this.loadPromise(iframe);
   }

--- a/extensions/amp-reddit/0.1/amp-reddit.js
+++ b/extensions/amp-reddit/0.1/amp-reddit.js
@@ -16,6 +16,7 @@
 
 import {getIframe, preloadBootstrap} from '../../../src/3p-frame';
 import {isLayoutSizeDefined} from '../../../src/layout';
+import {listenFor} from '../../../src/iframe-helper';
 import {user} from '../../../src/log';
 
 class AmpReddit extends AMP.BaseElement {
@@ -59,6 +60,9 @@ class AmpReddit extends AMP.BaseElement {
 
     const iframe = getIframe(this.win, this.element, 'reddit');
     this.applyFillContent(iframe);
+     listenFor(iframe, 'embed-size', data => {
+      this./*OK*/changeHeight(data['height']);
+     }, /* opt_is3P */true);
     this.element.appendChild(iframe);
     return this.loadPromise(iframe);
   }


### PR DESCRIPTION
Fix for #11869 

Embedly sends an event on resize, propagate the height provided by event to allow AMP to change the component's height. 