### PR TITLE
Support uppercase hash override in amp-geo.

### DIFF
--- a/extensions/amp-geo/0.1/amp-geo.js
+++ b/extensions/amp-geo/0.1/amp-geo.js
@@ -164,6 +164,7 @@ export class AmpGeo extends AMP.BaseElement {
         user().assert(
             isArray(ISOCountryGroups[group]),
             `${errorPrefix}[${group}] must be an array`);
+        ISOCountryGroups[group] = ISOCountryGroups[group].map(country => country.toLowerCase());
         if (ISOCountryGroups[group].includes(this.country_)) {
           this.matchedGroups_.push(group);
         }

--- a/extensions/amp-geo/0.1/amp-geo.js
+++ b/extensions/amp-geo/0.1/amp-geo.js
@@ -140,7 +140,7 @@ export class AmpGeo extends AMP.BaseElement {
       (isCanary(this.win) || getMode(this.win).localDev) &&
       /^\w+$/.test(getMode(this.win).geoOverride)) {
       this.mode_ = mode.GEO_OVERRIDE;
-      this.country_ = getMode(this.win).geoOverride;
+      this.country_ = getMode(this.win).geoOverride.toLowerCase();
     }
   }
   /**

--- a/extensions/amp-geo/0.1/amp-geo.js
+++ b/extensions/amp-geo/0.1/amp-geo.js
@@ -164,7 +164,8 @@ export class AmpGeo extends AMP.BaseElement {
         user().assert(
             isArray(ISOCountryGroups[group]),
             `${errorPrefix}[${group}] must be an array`);
-        ISOCountryGroups[group] = ISOCountryGroups[group].map(country => country.toLowerCase());
+        ISOCountryGroups[group] = ISOCountryGroups[group]
+            .map(country => country.toLowerCase());
         if (ISOCountryGroups[group].includes(this.country_)) {
           this.matchedGroups_.push(group);
         }

--- a/extensions/amp-geo/0.1/test/test-amp-geo.js
+++ b/extensions/amp-geo/0.1/test/test-amp-geo.js
@@ -45,6 +45,14 @@ describes.realWin('amp-geo', {
     },
   };
 
+  const configWithUppercase = {
+    ISOCountryGroups: {
+      nafta: ['CA', 'mx', 'us', 'unknown'],
+      unknown: ['unknown'],
+      anz: ['au', 'NZ'],
+    },
+  };
+
   let win, doc;
   let ampdoc;
   let geo;
@@ -173,6 +181,25 @@ describes.realWin('amp-geo', {
   it('should allow uppercase hash to override geo in test', () => {
     win.AMP_MODE.geoOverride = 'NZ';
     addConfigElement('script');
+    geo.buildCallback();
+
+    return Services.geoForOrNull(win).then(geo => {
+      expect(geo.ISOCountry).to.equal('nz');
+      expectBodyHasClass([
+        'amp-iso-country-nz',
+        'amp-geo-group-anz',
+      ], true);
+      expectBodyHasClass([
+        'amp-iso-country-unknown',
+        'amp-geo-group-nafta',
+      ], false);
+    });
+  });
+
+  it('should accept uppercase country codes in config', () => {
+    win.AMP_MODE.geoOverride = 'nz';
+    addConfigElement('script', 'application/json',
+        JSON.stringify(configWithUppercase));
     geo.buildCallback();
 
     return Services.geoForOrNull(win).then(geo => {

--- a/extensions/amp-geo/0.1/test/test-amp-geo.js
+++ b/extensions/amp-geo/0.1/test/test-amp-geo.js
@@ -170,6 +170,24 @@ describes.realWin('amp-geo', {
     });
   });
 
+  it('should allow uppercase hash to override geo in test', () => {
+    win.AMP_MODE.geoOverride = 'NZ';
+    addConfigElement('script');
+    geo.buildCallback();
+
+    return Services.geoForOrNull(win).then(geo => {
+      expect(geo.ISOCountry).to.equal('nz');
+      expectBodyHasClass([
+        'amp-iso-country-nz',
+        'amp-geo-group-anz',
+      ], true);
+      expectBodyHasClass([
+        'amp-iso-country-unknown',
+        'amp-geo-group-nafta',
+      ], false);
+    });
+  });
+
   it('should respect pre-rendered geo tags', () => {
     addConfigElement('script');
     doc.body.classList.add('amp-iso-country-nz', 'amp-geo-group-anz');

--- a/extensions/amp-geo/0.1/test/test-amp-geo.js
+++ b/extensions/amp-geo/0.1/test/test-amp-geo.js
@@ -183,7 +183,7 @@ describes.realWin('amp-geo', {
     addConfigElement('script');
     geo.buildCallback();
 
-    return Services.geoForOrNull(win).then(geo => {
+    return Services.geoForDocOrNull(el).then(geo => {
       expect(geo.ISOCountry).to.equal('nz');
       expectBodyHasClass([
         'amp-iso-country-nz',
@@ -202,7 +202,7 @@ describes.realWin('amp-geo', {
         JSON.stringify(configWithUppercase));
     geo.buildCallback();
 
-    return Services.geoForOrNull(win).then(geo => {
+    return Services.geoForDocOrNull(el).then(geo => {
       expect(geo.ISOCountry).to.equal('nz');
       expectBodyHasClass([
         'amp-iso-country-nz',


### PR DESCRIPTION
Support uppercase hash override in amp-geo to make sure both options work:
- ``https://foo.bar#amp-geo=de``
- ``https://foo.bar#amp-geo=DE``