### PR TITLE
Allow amp-geo in stories.

### DIFF
--- a/examples/amp-story/consent-geo.html
+++ b/examples/amp-story/consent-geo.html
@@ -1,0 +1,94 @@
+<!doctype html>
+<html amp lang="en">
+  <head>
+    <meta charset="utf-8">
+    <script async src="https://cdn.ampproject.org/v0.js"></script>
+    <script async custom-element="amp-story"
+        src="https://cdn.ampproject.org/v0/amp-story-1.0.js"></script>
+    <script async custom-element="amp-consent"
+        src="https://cdn.ampproject.org/v0/amp-consent-0.1.js"></script>
+    <script async custom-element="amp-geo"
+        src="https://cdn.ampproject.org/v0/amp-geo-0.1.js"></script>
+    <title>My Story with geo consent</title>
+    <meta name="viewport"
+          content="width=device-width,minimum-scale=1,initial-scale=1">
+    <link rel="canonical" href="geoconsent.html">
+    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+    <style amp-custom>
+      body {
+        font-family: 'Roboto', sans-serif;
+      }
+      amp-story {
+        --primary-color: #0379c4;
+      }
+      amp-story-page {
+        background-color: white;
+      }
+    </style>
+    <script type="application/ld+json">
+      {
+        "@context": "http://schema.org",
+        "@type": "NewsArticle",
+        "mainEntityOfPage": {
+          "@type": "WebPage",
+          "@id": "./consent.html"
+        },
+        "headline": "My Story",
+        "image":["http://placehold.it/420x740"],
+        "datePublished": "2018-01-01T00:00:00+00:00",
+        "dateModified": "2018-01-01T00:00:00+00:00",
+        "author": {
+          "@type": "Organization",
+          "name": "AMP Project"
+        },
+        "publisher": {
+          "@type": "Organization",
+          "name": "AMP Project",
+          "logo": {
+            "@type": "ImageObject",
+            "url": "http://placehold.it/128x128"
+          }
+        },
+        "description": "My Story"
+      }
+    </script>
+  </head>
+
+  <body>
+    <amp-story standalone publisher-logo-src="https://placekitten.com/g/64/64">
+      <amp-geo layout="nodisplay">
+        <script type="application/json">{
+          "ISOCountryGroups": {
+            "eea": [ "at", "be", "bg", "cy", "cz", "de", "dk", "ee", "es", "fi", "fr",
+            "gb", "gr", "hr", "hu", "ie", "is", "it", "li", "lt", "lu", "lv", "mt", "nl",
+            "no", "pl", "pt", "ro", "se", "si", "sk"]
+          }
+        }</script>
+      </amp-geo>
+
+      <amp-consent id='ABC' layout='nodisplay'>
+        <script type="application/json">{
+          "consents": {
+            "ABC": {
+              "promptIfUnknownForGeoGroup": "eea",
+              "promptUI": "ui0"
+            }
+          }
+        }</script>
+        <amp-story-consent id="ui0" layout="nodisplay">
+          <script type="application/json">{
+            "title": "Headline.",
+            "message": "This is some more information about this choice. Here's a list of items related to this choice.",
+            "vendors": ["Item 1", "Item 2", "Item 3", "Item 4", "Item 5", "Item 6", "Item 7", "Item 8", "Item 9", "Item 10"]
+          }</script>
+        </amp-story-consent>
+      </amp-consent>
+
+      <amp-story-page id="cover">
+        <amp-story-grid-layer template="vertical">
+          <h1>You just accepted or rejected the consent!</h1>
+        </amp-story-grid-layer>
+      </amp-story-page>
+    </amp-story>
+  </body>
+</html>

--- a/extensions/amp-story/0.1/test/validator-amp-story-consent-geo.html
+++ b/extensions/amp-story/0.1/test/validator-amp-story-consent-geo.html
@@ -1,0 +1,66 @@
+<!--
+  Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS-IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the license.
+-->
+<!--
+  Test Description:
+  Tests for the amp-geo tag.
+-->
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-0.1.js"></script>
+  <script async custom-element="amp-consent" src="https://cdn.ampproject.org/v0/amp-consent-0.1.js"></script>
+  <script async custom-element="amp-geo" src="https://cdn.ampproject.org/v0/amp-geo-0.1.js"></script>
+  <title>My Story</title>
+  <meta name="description" content="Get started with amp-story">
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <link rel="canonical" href="grid-layer-templates.html">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+</head>
+<body>
+  <amp-story standalone title="Foo" publisher="AMP" publisher-logo-src="http://example.com/foo.png" poster-portrait-src="http://example.com/foo.png">
+    <amp-geo layout="nodisplay">
+      <script type="application/json">{
+        "ISOCountryGroups": {
+          "eea": [ "at", "be", "bg", "cy", "cz", "de", "dk", "ee", "es", "fi", "fr",
+          "gb", "gr", "hr", "hu", "ie", "is", "it", "li", "lt", "lu", "lv", "mt", "nl",
+          "no", "pl", "pt", "ro", "se", "si", "sk"]
+        }
+      }</script>
+    </amp-geo>
+    <amp-consent id='ABC' layout='nodisplay'>
+      <script type="application/json">{
+        "consents": {
+          "ABC": {
+            "checkConsentHref": "http://localhost:8000/get-consent-v1",
+            "promptUI": "ui0"
+          }
+        }
+      }</script>
+      <amp-story-consent id="ui0" layout="nodisplay">
+        <script type="application/json">{
+          "title": "A message from AMP",
+          "message": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis pulvinar a quam non tincidunt. Nam dictum non nisi eu consectetur.",
+          "vendors": ["Example Vendor One", "Example Vendor Two", "Example Vendor Three", "Google Adwords"]
+        }</script>
+      </amp-story-consent>
+    </amp-consent>
+    <amp-story-page id="fill-template-title">
+      <amp-story-grid-layer template="vertical">
+        <h1>fill</h1>
+      </amp-story-grid-layer>
+    </amp-story-page>
+  </amp-story>
+</body>
+</html>

--- a/extensions/amp-story/0.1/test/validator-amp-story-consent-geo.out
+++ b/extensions/amp-story/0.1/test/validator-amp-story-consent-geo.out
@@ -1,4 +1,4 @@
-FAIL
+PASS
 |  <!--
 |    Copyright 2018 The AMP HTML Authors. All Rights Reserved.
 |    Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,7 @@ FAIL
 |  -->
 |  <!--
 |    Test Description:
-|    Tests for the amp-story tag.
+|    Tests for the amp-geo tag.
 |  -->
 |  <!doctype html>
 |  <html ⚡>
@@ -21,53 +21,47 @@ FAIL
 |    <meta charset="utf-8">
 |    <script async src="https://cdn.ampproject.org/v0.js"></script>
 |    <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-0.1.js"></script>
+|    <script async custom-element="amp-consent" src="https://cdn.ampproject.org/v0/amp-consent-0.1.js"></script>
+|    <script async custom-element="amp-geo" src="https://cdn.ampproject.org/v0/amp-geo-0.1.js"></script>
 |    <title>My Story</title>
 |    <meta name="description" content="Get started with amp-story">
 |    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
 |    <link rel="canonical" href="grid-layer-templates.html">
 |    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
-|    <style amp-custom>
-|      body {
-|        font-family: 'Roboto', sans-serif;
-|      }
-|      amp-story-page {
-|        background: white;
-|      }
-|      .button {
-|        font: bold 20px Arial;
-|        text-decoration: none;
-|        background-color: rgba(0, 240, 248, 0.63);
-|        color: #333333;
-|        padding: 2px 6px 2px 6px;
-|        border-top: 1px solid #CCCCCC;
-|        border-right: 1px solid #333333;
-|        border-bottom: 1px solid #333333;
-|        border-left: 1px solid #CCCCCC;
-|        width: 100%;
-|        height: 100%;
-|        position: absolute;
-|      }
-|    </style>
 |  </head>
 |  <body>
-|    <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/poster.jpg">
+|    <amp-story standalone title="Foo" publisher="AMP" publisher-logo-src="http://example.com/foo.png" poster-portrait-src="http://example.com/foo.png">
+|      <amp-geo layout="nodisplay">
+|        <script type="application/json">{
+|          "ISOCountryGroups": {
+|            "eea": [ "at", "be", "bg", "cy", "cz", "de", "dk", "ee", "es", "fi", "fr",
+|            "gb", "gr", "hr", "hu", "ie", "is", "it", "li", "lt", "lu", "lv", "mt", "nl",
+|            "no", "pl", "pt", "ro", "se", "si", "sk"]
+|          }
+|        }</script>
+|      </amp-geo>
+|      <amp-consent id='ABC' layout='nodisplay'>
+|        <script type="application/json">{
+|          "consents": {
+|            "ABC": {
+|              "checkConsentHref": "http://localhost:8000/get-consent-v1",
+|              "promptUI": "ui0"
+|            }
+|          }
+|        }</script>
+|        <amp-story-consent id="ui0" layout="nodisplay">
+|          <script type="application/json">{
+|            "title": "A message from AMP",
+|            "message": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis pulvinar a quam non tincidunt. Nam dictum non nisi eu consectetur.",
+|            "vendors": ["Example Vendor One", "Example Vendor Two", "Example Vendor Three", "Google Adwords"]
+|          }</script>
+|        </amp-story-consent>
+|      </amp-consent>
 |      <amp-story-page id="fill-template-title">
-|        <amp-story-cta-layer>
->>       ^~~~~~~~~
-amp-story/0.1/test/validator-amp-story-cta-layer-error.html:54:6 Tag 'amp-story-cta-layer', if present, must be the last child of tag 'amp-story-page'. [AMP_TAG_PROBLEM]
-|          <a href="http://www.google.com" class="button"> Illegal CTA layer above grid layer! </a>
-|        </amp-story-cta-layer>
 |        <amp-story-grid-layer template="vertical">
 |          <h1>fill</h1>
 |        </amp-story-grid-layer>
 |      </amp-story-page>
-|      <amp-story-cta-layer>
->>     ^~~~~~~~~
-amp-story/0.1/test/validator-amp-story-cta-layer-error.html:61:4 The tag 'amp-story-cta-layer' may only appear as a descendant of tag 'amp-story-page'. [AMP_TAG_PROBLEM]
->>     ^~~~~~~~~
-amp-story/0.1/test/validator-amp-story-cta-layer-error.html:61:4 Tag 'amp-story-cta-layer' is disallowed as child of tag 'amp-story'. Child tag must be one of ['amp-analytics', 'amp-consent', 'amp-geo', 'amp-pixel', 'amp-story-auto-ads', 'amp-story-bookend', 'amp-story-page']. (see https://www.ampproject.org/docs/reference/components/amp-story) [AMP_TAG_PROBLEM]
-|        <a href="http://www.google.com" class="button"> Illegal CTA layer outside of amp-story-page! </a>
-|      </amp-story-cta-layer>
 |    </amp-story>
 |  </body>
 |  </html>

--- a/extensions/amp-story/1.0/test/validator-amp-story-consent-geo.html
+++ b/extensions/amp-story/1.0/test/validator-amp-story-consent-geo.html
@@ -1,0 +1,66 @@
+<!--
+  Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS-IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the license.
+-->
+<!--
+  Test Description:
+  Tests for the amp-geo tag.
+-->
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-1.0.js"></script>
+  <script async custom-element="amp-consent" src="https://cdn.ampproject.org/v0/amp-consent-0.1.js"></script>
+  <script async custom-element="amp-geo" src="https://cdn.ampproject.org/v0/amp-geo-0.1.js"></script>
+  <title>My Story</title>
+  <meta name="description" content="Get started with amp-story">
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <link rel="canonical" href="grid-layer-templates.html">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+</head>
+<body>
+  <amp-story standalone title="Foo" publisher="AMP" publisher-logo-src="http://example.com/foo.png" poster-portrait-src="http://example.com/foo.png">
+    <amp-geo layout="nodisplay">
+      <script type="application/json">{
+        "ISOCountryGroups": {
+          "eea": [ "at", "be", "bg", "cy", "cz", "de", "dk", "ee", "es", "fi", "fr",
+          "gb", "gr", "hr", "hu", "ie", "is", "it", "li", "lt", "lu", "lv", "mt", "nl",
+          "no", "pl", "pt", "ro", "se", "si", "sk"]
+        }
+      }</script>
+    </amp-geo>
+    <amp-consent id='ABC' layout='nodisplay'>
+      <script type="application/json">{
+        "consents": {
+          "ABC": {
+            "checkConsentHref": "http://localhost:8000/get-consent-v1",
+            "promptUI": "ui0"
+          }
+        }
+      }</script>
+      <amp-story-consent id="ui0" layout="nodisplay">
+        <script type="application/json">{
+          "title": "A message from AMP",
+          "message": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis pulvinar a quam non tincidunt. Nam dictum non nisi eu consectetur.",
+          "vendors": ["Example Vendor One", "Example Vendor Two", "Example Vendor Three", "Google Adwords"]
+        }</script>
+      </amp-story-consent>
+    </amp-consent>
+    <amp-story-page id="fill-template-title">
+      <amp-story-grid-layer template="vertical">
+        <h1>fill</h1>
+      </amp-story-grid-layer>
+    </amp-story-page>
+  </amp-story>
+</body>
+</html>

--- a/extensions/amp-story/1.0/test/validator-amp-story-consent-geo.out
+++ b/extensions/amp-story/1.0/test/validator-amp-story-consent-geo.out
@@ -1,4 +1,4 @@
-FAIL
+PASS
 |  <!--
 |    Copyright 2018 The AMP HTML Authors. All Rights Reserved.
 |    Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,61 +13,55 @@ FAIL
 |  -->
 |  <!--
 |    Test Description:
-|    Tests for the amp-story tag.
+|    Tests for the amp-geo tag.
 |  -->
 |  <!doctype html>
 |  <html ⚡>
 |  <head>
 |    <meta charset="utf-8">
 |    <script async src="https://cdn.ampproject.org/v0.js"></script>
-|    <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-0.1.js"></script>
+|    <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-1.0.js"></script>
+|    <script async custom-element="amp-consent" src="https://cdn.ampproject.org/v0/amp-consent-0.1.js"></script>
+|    <script async custom-element="amp-geo" src="https://cdn.ampproject.org/v0/amp-geo-0.1.js"></script>
 |    <title>My Story</title>
 |    <meta name="description" content="Get started with amp-story">
 |    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
 |    <link rel="canonical" href="grid-layer-templates.html">
 |    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
-|    <style amp-custom>
-|      body {
-|        font-family: 'Roboto', sans-serif;
-|      }
-|      amp-story-page {
-|        background: white;
-|      }
-|      .button {
-|        font: bold 20px Arial;
-|        text-decoration: none;
-|        background-color: rgba(0, 240, 248, 0.63);
-|        color: #333333;
-|        padding: 2px 6px 2px 6px;
-|        border-top: 1px solid #CCCCCC;
-|        border-right: 1px solid #333333;
-|        border-bottom: 1px solid #333333;
-|        border-left: 1px solid #CCCCCC;
-|        width: 100%;
-|        height: 100%;
-|        position: absolute;
-|      }
-|    </style>
 |  </head>
 |  <body>
-|    <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/poster.jpg">
+|    <amp-story standalone title="Foo" publisher="AMP" publisher-logo-src="http://example.com/foo.png" poster-portrait-src="http://example.com/foo.png">
+|      <amp-geo layout="nodisplay">
+|        <script type="application/json">{
+|          "ISOCountryGroups": {
+|            "eea": [ "at", "be", "bg", "cy", "cz", "de", "dk", "ee", "es", "fi", "fr",
+|            "gb", "gr", "hr", "hu", "ie", "is", "it", "li", "lt", "lu", "lv", "mt", "nl",
+|            "no", "pl", "pt", "ro", "se", "si", "sk"]
+|          }
+|        }</script>
+|      </amp-geo>
+|      <amp-consent id='ABC' layout='nodisplay'>
+|        <script type="application/json">{
+|          "consents": {
+|            "ABC": {
+|              "checkConsentHref": "http://localhost:8000/get-consent-v1",
+|              "promptUI": "ui0"
+|            }
+|          }
+|        }</script>
+|        <amp-story-consent id="ui0" layout="nodisplay">
+|          <script type="application/json">{
+|            "title": "A message from AMP",
+|            "message": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis pulvinar a quam non tincidunt. Nam dictum non nisi eu consectetur.",
+|            "vendors": ["Example Vendor One", "Example Vendor Two", "Example Vendor Three", "Google Adwords"]
+|          }</script>
+|        </amp-story-consent>
+|      </amp-consent>
 |      <amp-story-page id="fill-template-title">
-|        <amp-story-cta-layer>
->>       ^~~~~~~~~
-amp-story/0.1/test/validator-amp-story-cta-layer-error.html:54:6 Tag 'amp-story-cta-layer', if present, must be the last child of tag 'amp-story-page'. [AMP_TAG_PROBLEM]
-|          <a href="http://www.google.com" class="button"> Illegal CTA layer above grid layer! </a>
-|        </amp-story-cta-layer>
 |        <amp-story-grid-layer template="vertical">
 |          <h1>fill</h1>
 |        </amp-story-grid-layer>
 |      </amp-story-page>
-|      <amp-story-cta-layer>
->>     ^~~~~~~~~
-amp-story/0.1/test/validator-amp-story-cta-layer-error.html:61:4 The tag 'amp-story-cta-layer' may only appear as a descendant of tag 'amp-story-page'. [AMP_TAG_PROBLEM]
->>     ^~~~~~~~~
-amp-story/0.1/test/validator-amp-story-cta-layer-error.html:61:4 Tag 'amp-story-cta-layer' is disallowed as child of tag 'amp-story'. Child tag must be one of ['amp-analytics', 'amp-consent', 'amp-geo', 'amp-pixel', 'amp-story-auto-ads', 'amp-story-bookend', 'amp-story-page']. (see https://www.ampproject.org/docs/reference/components/amp-story) [AMP_TAG_PROBLEM]
-|        <a href="http://www.google.com" class="button"> Illegal CTA layer outside of amp-story-page! </a>
-|      </amp-story-cta-layer>
 |    </amp-story>
 |  </body>
 |  </html>

--- a/extensions/amp-story/1.0/test/validator-amp-story-cta-layer-error.out
+++ b/extensions/amp-story/1.0/test/validator-amp-story-cta-layer-error.out
@@ -65,7 +65,7 @@ amp-story/1.0/test/validator-amp-story-cta-layer-error.html:54:6 Tag 'amp-story-
 >>     ^~~~~~~~~
 amp-story/1.0/test/validator-amp-story-cta-layer-error.html:61:4 The tag 'amp-story-cta-layer' may only appear as a descendant of tag 'amp-story-page'. [AMP_TAG_PROBLEM]
 >>     ^~~~~~~~~
-amp-story/1.0/test/validator-amp-story-cta-layer-error.html:61:4 Tag 'amp-story-cta-layer' is disallowed as child of tag 'amp-story'. Child tag must be one of ['amp-analytics', 'amp-consent', 'amp-pixel', 'amp-story-auto-ads', 'amp-story-bookend', 'amp-story-page']. (see https://www.ampproject.org/docs/reference/components/amp-story) [AMP_TAG_PROBLEM]
+amp-story/1.0/test/validator-amp-story-cta-layer-error.html:61:4 Tag 'amp-story-cta-layer' is disallowed as child of tag 'amp-story'. Child tag must be one of ['amp-analytics', 'amp-consent', 'amp-geo', 'amp-pixel', 'amp-story-auto-ads', 'amp-story-bookend', 'amp-story-page']. (see https://www.ampproject.org/docs/reference/components/amp-story) [AMP_TAG_PROBLEM]
 |        <a href="http://www.google.com" class="button"> Illegal CTA layer outside of amp-story-page! </a>
 |      </amp-story-cta-layer>
 |    </amp-story>

--- a/extensions/amp-story/validator-amp-story.protoascii
+++ b/extensions/amp-story/validator-amp-story.protoascii
@@ -97,6 +97,7 @@ tags: {  # <amp-story>
     mandatory_min_num_child_tags: 1
     child_tag_name_oneof: "AMP-ANALYTICS"
     child_tag_name_oneof: "AMP-CONSENT"
+    child_tag_name_oneof: "AMP-GEO"
     child_tag_name_oneof: "AMP-PIXEL"
     child_tag_name_oneof: "AMP-STORY-AUTO-ADS"
     child_tag_name_oneof: "AMP-STORY-BOOKEND"


### PR DESCRIPTION
Allow ``amp-geo`` in stories so publishers can use it with ``amp-consent``.

Related to #14538