### PR TITLE
✨Amazon Publisher Services: RTC Integration

### DIFF
--- a/extensions/amp-a4a/0.1/callout-vendors.js
+++ b/extensions/amp-a4a/0.1/callout-vendors.js
@@ -76,6 +76,11 @@ export const RTC_VENDORS = {
     macros: ['PLACEMENT_ID', 'DIV_ID'],
     disableKeyAppend: true,
   },
+  aps: {
+    url: 'https://aax.amazon-adsystem.com/e/dtb/bid?src=PUB_ID&amp=1&u=HREF&slots=%5B%7B%22sd%22%3A%22ATTR(data-slot)%22%2C%22s%22%3A%5B%22ATTR(width)xATTR(height)%22%5D%7D%5D&pj=PARAMS&gdpre=GDPRE&gdprc=GDPRC',
+    macros: ['PUB_ID', 'PARAMS', 'GDPRE', 'GDPRC'],
+    disableKeyAppend: true,
+  },
 };
 
 // DO NOT MODIFY: Setup for tests


### PR DESCRIPTION
## Initiating pull request to implement Amazon Publisher Services callout URL for Doubleclick RTC feature.

**There are 4 publisher populated macros**
1. PUB_ID: Your publisher ID.
2. PARAMS: JSON object containing additional information.
3. GDPRE: GDPR flag to indicate if the IAB GDPR Consent Framework needs to be applied to this ad request.
     - 1 for yes
     - 0 for no

4. GDPRC: the value of the IAB GDPR Consent Framework consent string to be applied to this ad request.

For all macros, and prior to going live, please contact your account manager for validation of information to be used. 

