### PR TITLE
✨ Adds hint overlay when user tries to swipe up on a story.

### DIFF
--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -469,8 +469,7 @@ export class AmpStory extends AMP.BaseElement {
 
     // Shows "tap to navigate" hint when swiping.
     gestures.onGesture(SwipeXYRecognizer, gesture => {
-      const {deltaX} = gesture.data;
-      const {deltaY} = gesture.data;
+      const {deltaX, deltaY} = gesture.data;
       if (this.storeService_.get(StateProperty.BOOKEND_STATE)) {
         return;
       }
@@ -488,13 +487,14 @@ export class AmpStory extends AMP.BaseElement {
 
   /**
    * @param {number} deltaX
+   * @param {number} deltaY
    * @return {boolean}
    * @private
    */
   isSwipeLargeEnoughForHint_(deltaX, deltaY) {
-    const sideSwipe = (Math.abs(deltaX) >= MIN_SWIPE_FOR_HINT_OVERLAY_PX);
-    const upSwipe = ((-1 * deltaY) >= MIN_SWIPE_FOR_HINT_OVERLAY_PX);
-    return (sideSwipe || upSwipe);
+    const sideSwipe = Math.abs(deltaX) >= MIN_SWIPE_FOR_HINT_OVERLAY_PX;
+    const upSwipe = (-1 * deltaY) >= MIN_SWIPE_FOR_HINT_OVERLAY_PX;
+    return sideSwipe || upSwipe;
   }
 
   /** @private */

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -492,13 +492,9 @@ export class AmpStory extends AMP.BaseElement {
    * @private
    */
   isSwipeLargeEnoughForHint_(deltaX, deltaY) {
-    //console.log("x: " +deltaX + " y: " +deltaY);
-    const sideSwipe  = (Math.abs(deltaX) >= MIN_SWIPE_FOR_HINT_OVERLAY_PX);
-    const upSwipe  = ((-1 * deltaY) >= MIN_SWIPE_FOR_HINT_OVERLAY_PX);
-    if(upSwipe && !sideSwipe){
-      console.log("x: " +deltaX + " y: " +deltaY);
-    }
-    return (sideSwipe||upSwipe);
+    const sideSwipe = (Math.abs(deltaX) >= MIN_SWIPE_FOR_HINT_OVERLAY_PX);
+    const upSwipe = ((-1 * deltaY) >= MIN_SWIPE_FOR_HINT_OVERLAY_PX);
+    return (sideSwipe || upSwipe);
   }
 
   /** @private */

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -470,10 +470,11 @@ export class AmpStory extends AMP.BaseElement {
     // Shows "tap to navigate" hint when swiping.
     gestures.onGesture(SwipeXYRecognizer, gesture => {
       const {deltaX} = gesture.data;
+      const {deltaY} = gesture.data;
       if (this.storeService_.get(StateProperty.BOOKEND_STATE)) {
         return;
       }
-      if (!this.isSwipeLargeEnoughForHint_(deltaX)) {
+      if (!this.isSwipeLargeEnoughForHint_(deltaX, deltaY)) {
         return;
       }
       if (!this.storeService_
@@ -490,8 +491,14 @@ export class AmpStory extends AMP.BaseElement {
    * @return {boolean}
    * @private
    */
-  isSwipeLargeEnoughForHint_(deltaX) {
-    return (Math.abs(deltaX) >= MIN_SWIPE_FOR_HINT_OVERLAY_PX);
+  isSwipeLargeEnoughForHint_(deltaX, deltaY) {
+    //console.log("x: " +deltaX + " y: " +deltaY);
+    const sideSwipe  = (Math.abs(deltaX) >= MIN_SWIPE_FOR_HINT_OVERLAY_PX);
+    const upSwipe  = ((-1 * deltaY) >= MIN_SWIPE_FOR_HINT_OVERLAY_PX);
+    if(upSwipe && !sideSwipe){
+      console.log("x: " +deltaX + " y: " +deltaY);
+    }
+    return (sideSwipe||upSwipe);
   }
 
   /** @private */


### PR DESCRIPTION
- Detects when a user swipes us, and provides the educational overlay to fix it
- Addresses issue #15404 
- Talked with @gmajoulet to push despite lack of unit testing since currently we don't have a method to test swipes, and we couldn't find tests for the overlay resulting from side swipes either