### PR TITLE
amp-consent: use dev().error to report error

### DIFF
--- a/extensions/amp-consent/0.1/amp-consent.js
+++ b/extensions/amp-consent/0.1/amp-consent.js
@@ -194,8 +194,9 @@ export class AmpConsent extends AMP.BaseElement {
    * @param {string} instanceId
    */
   scheduleDisplay_(instanceId) {
-    dev().assert(this.notificationUiManager_,
-        'notification ui manager not found');
+    if (!this.notificationUiManager_) {
+      dev().error(TAG, 'notification ui manager not found');
+    }
 
     if (this.consentUIPendingMap_[instanceId]) {
       // Already pending to be shown. Do nothing.
@@ -217,8 +218,11 @@ export class AmpConsent extends AMP.BaseElement {
    * @return {!Promise}
    */
   show_(instanceId) {
-    dev().assert(!this.currentDisplayInstance_,
-        'Other consent instance on display');
+    if (this.currentDisplayInstance_) {
+      dev().error(TAG,
+          `other consent instance on display ${this.currentDisplayInstance_}`);
+    }
+
     this.vsync_.mutate(() => {
       if (!this.uiInit_) {
         this.uiInit_ = true;
@@ -255,7 +259,10 @@ export class AmpConsent extends AMP.BaseElement {
       this.element.classList.remove('amp-active');
       // Need to remove from fixed layer and add it back to update element's top
       this.getViewport().removeFromFixedLayer(this.element);
-      dev().assert(uiToHide, 'no consent UI to hide');
+      if (!uiToHide) {
+        dev().error(TAG,
+            `${this.currentDisplayInstance_} no consent ui to hide`);
+      }
       toggle(uiToHide, false);
     });
     if (this.dialogResolver_[this.currentDisplayInstance_]) {
@@ -271,8 +278,16 @@ export class AmpConsent extends AMP.BaseElement {
    * @param {ACTION_TYPE} action
    */
   handleAction_(action) {
-    dev().assert(this.currentDisplayInstance_, 'No consent is displaying');
-    dev().assert(this.consentStateManager_, 'No consent state manager');
+    if (!this.currentDisplayInstance_) {
+      dev().error(TAG, 'No consent ui is displaying, ' +
+          `consent id ${this.currentDisplayInstance_}`);
+      return;
+    }
+
+    if (!this.consentStateManager_) {
+      dev().error(TAG, 'No consent state manager');
+      return;
+    }
     if (action == ACTION_TYPE.ACCEPT) {
       //accept
       this.consentStateManager_.updateConsentInstanceState(

--- a/extensions/amp-consent/0.1/consent-policy-manager.js
+++ b/extensions/amp-consent/0.1/consent-policy-manager.js
@@ -77,8 +77,9 @@ export class ConsentPolicyManager {
    * @param {!JsonObject} config
    */
   registerConsentPolicyInstance(policyId, config) {
-    dev().assert(!this.instances_[policyId],
-        `${TAG}: instance already registered`);
+    if (this.instances_[policyId]) {
+      dev().error(TAG, `policy ${policyId} already registered`);
+    }
 
     const waitFor = Object.keys(config['waitFor'] || {});
 
@@ -283,8 +284,10 @@ export class ConsentPolicyInstance {
   consentStateChangeHandler(consentId, state) {
     // TODO: Keeping an array can have performance issue, change to using a map
     // if necessary.
-    dev().assert(hasOwn(this.itemToConsentState_, consentId),
-        `cannot find ${consentId} in policy state`);
+    if (!hasOwn(this.itemToConsentState_, consentId)) {
+      dev().error(TAG, `cannot find ${consentId} in policy state`);
+      return;
+    }
 
     if (state == CONSENT_ITEM_STATE.UNKNOWN) {
       // consent state has not been resolved yet.

--- a/extensions/amp-consent/0.1/consent-state-manager.js
+++ b/extensions/amp-consent/0.1/consent-state-manager.js
@@ -59,8 +59,10 @@ export class ConsentStateManager {
    * @param {string} instanceId
    */
   registerConsentInstance(instanceId) {
-    dev().assert(!this.instances_[instanceId],
-        `${TAG}: instance already registered`);
+    if (this.instances_[instanceId]) {
+      dev().error(TAG, `instance ${instanceId} already registered`);
+      return;
+    }
     this.instances_[instanceId] = new ConsentInstance(this.ampdoc_, instanceId);
     this.consentChangeObservables_[instanceId] = new Observable();
     if (this.consentReadyResolvers_[instanceId]) {
@@ -76,10 +78,11 @@ export class ConsentStateManager {
    * @param {CONSENT_ITEM_STATE} state
    */
   updateConsentInstanceState(instanceId, state) {
-    dev().assert(this.instances_[instanceId],
-        `${TAG}: cannot find this instance`);
-    dev().assert(this.consentChangeObservables_[instanceId],
-        `${TAG}: should not update ignored consent`);
+    if (!this.instances_[instanceId] ||
+        !this.consentChangeObservables_[instanceId]) {
+      dev().error(TAG, `instance ${instanceId} not registered`);
+      return;
+    }
     this.consentChangeObservables_[instanceId].fire(state);
     this.instances_[instanceId].update(state);
   }

--- a/extensions/amp-consent/0.1/test/test-amp-consent.js
+++ b/extensions/amp-consent/0.1/test/test-amp-consent.js
@@ -18,6 +18,7 @@ import {ACTION_TYPE, AMP_CONSENT_EXPERIMENT, AmpConsent} from '../amp-consent';
 import {CONSENT_ITEM_STATE} from '../consent-state-manager';
 import {MULTI_CONSENT_EXPERIMENT} from '../consent-policy-manager';
 import {computedStyle} from '../../../../src/style';
+import {dev} from '../../../../src/log';
 import {macroTask} from '../../../../testing/yield';
 
 import {
@@ -435,10 +436,10 @@ describes.realWin('amp-consent', {
       yield macroTask();
       ampConsent.handleAction_(ACTION_TYPE.DISMISS);
       yield macroTask();
-      allowConsoleError(() => {
-        expect(() => ampConsent.handleAction_(ACTION_TYPE.DISMISS)).to.throw(
-            /No consent is displaying/);
-      });
+      const errorSpy = sandbox.stub(dev(), 'error');
+      ampConsent.handleAction_(ACTION_TYPE.DISMISS);
+      expect(errorSpy).to.be.calledWith('amp-consent',
+          'No consent ui is displaying, consent id null');
     });
 
     describe('schedule display', () => {

--- a/extensions/amp-consent/0.1/test/test-consent-state-manager.js
+++ b/extensions/amp-consent/0.1/test/test-consent-state-manager.js
@@ -18,6 +18,7 @@ import {
   ConsentInstance,
   ConsentStateManager,
 } from '../consent-state-manager';
+import {dev} from '../../../../src/log';
 import {macroTask} from '../../../../testing/yield';
 import {
   registerServiceBuilder,
@@ -201,15 +202,16 @@ describes.realWin('ConsentStateManager', {amp: 1}, env => {
         expect(value).to.equal(CONSENT_ITEM_STATE.REJECTED);
       });
 
-      it('should return unknown value with error', function* () {
-        let value;
+      it('should return unknown value with error', () => {
         storageGetSpy = () => {
           const e = new Error('intentional');
           throw e;
         };
+        sandbox.stub(dev(), 'error');
         storageValue['amp-consent:test'] = true;
-        yield instance.get().then(v => value = v);
-        expect(value).to.equal(CONSENT_ITEM_STATE.UNKNOWN);
+        return instance.get().then(value => {
+          expect(value).to.equal(CONSENT_ITEM_STATE.UNKNOWN);
+        });
       });
 
       it('should handle race condition return latest value', function* () {


### PR DESCRIPTION
`dev().assert()` gets stripped out after compilation. Use `dev().error()` to report instead. 