### PR TITLE
🐛 Fix get geo service for amp-consent in shadow amp

### DIFF
--- a/extensions/amp-consent/0.1/amp-consent.js
+++ b/extensions/amp-consent/0.1/amp-consent.js
@@ -372,7 +372,7 @@ export class AmpConsent extends AMP.BaseElement {
    * @return {Promise<boolean>}
    */
   isConsentRequiredGeo_(geoGroup) {
-    return Services.geoForOrNull(this.win).then(geo => {
+    return Services.geoForDocOrNull(this.element).then(geo => {
       user().assert(geo,
           'requires <amp-geo> to use promptIfUnknownForGeoGroup');
       return (geo.ISOCountryGroups.indexOf(geoGroup) >= 0);

--- a/extensions/amp-geo/0.1/test/test-amp-geo.js
+++ b/extensions/amp-geo/0.1/test/test-amp-geo.js
@@ -25,7 +25,7 @@ describes.realWin('amp-geo', {
   },
 }, env => {
 
-  const expectedState = '<amp-state id="ampGeo"><script type="application/json">{"ISOCountry":"unknown","nafta":true,"unknown":true,"ISOCountryGroups":["nafta","unknown"]}</script></amp-state>'; // eslint-disable-line  
+  const expectedState = '<amp-state id="ampGeo"><script type="application/json">{"ISOCountry":"unknown","nafta":true,"unknown":true,"ISOCountryGroups":["nafta","unknown"]}</script></amp-state>'; // eslint-disable-line
 
 
   const config = {
@@ -100,7 +100,7 @@ describes.realWin('amp-geo', {
     addConfigElement('script');
 
     geo.buildCallback();
-    return Services.geoForOrNull(win).then(geo => {
+    return Services.geoForDocOrNull(ampdoc).then(geo => {
       expect(geo.ISOCountry).to.equal('unknown');
       expectBodyHasClass([
         'amp-iso-country-unknown',
@@ -122,7 +122,7 @@ describes.realWin('amp-geo', {
     ], true);
 
     geo.buildCallback();
-    return Services.geoForOrNull(win).then(geo => {
+    return Services.geoForDocOrNull(ampdoc).then(geo => {
       expect(geo.ISOCountry).to.equal('unknown');
       expectBodyHasClass([
         'amp-geo-pending',
@@ -135,7 +135,7 @@ describes.realWin('amp-geo', {
         JSON.stringify(configWithState));
     geo.buildCallback();
 
-    return Services.geoForOrNull(win).then(() => {
+    return Services.geoForDocOrNull(ampdoc).then(() => {
       expect(win.document.getElementById('ampGeo').outerHTML)
           .to.equal(expectedState);
     });
@@ -145,7 +145,7 @@ describes.realWin('amp-geo', {
     addConfigElement('script');
     geo.buildCallback();
 
-    return Services.geoForOrNull(win).then(() => {
+    return Services.geoForDocOrNull(ampdoc).then(() => {
       expect(win.document.getElementById('ampGeo'))
           .to.equal(null);
     });
@@ -156,7 +156,7 @@ describes.realWin('amp-geo', {
     addConfigElement('script');
     geo.buildCallback();
 
-    return Services.geoForOrNull(win).then(geo => {
+    return Services.geoForDocOrNull(ampdoc).then(geo => {
       expect(geo.ISOCountry).to.equal('nz');
       expectBodyHasClass([
         'amp-iso-country-nz',
@@ -174,7 +174,7 @@ describes.realWin('amp-geo', {
     doc.body.classList.add('amp-iso-country-nz', 'amp-geo-group-anz');
     geo.buildCallback();
 
-    return Services.geoForOrNull(win).then(geo => {
+    return Services.geoForDocOrNull(ampdoc).then(geo => {
       expect(geo.ISOCountry).to.equal('nz');
       expectBodyHasClass([
         'amp-iso-country-nz',
@@ -193,7 +193,7 @@ describes.realWin('amp-geo', {
     addConfigElement('script');
     geo.buildCallback();
 
-    return Services.geoForOrNull(win).then(geo => {
+    return Services.geoForDocOrNull(ampdoc).then(geo => {
       expect(geo.ISOCountry).to.equal('nz');
       expectBodyHasClass([
         'amp-iso-country-nz',

--- a/extensions/amp-geo/0.1/test/test-amp-geo.js
+++ b/extensions/amp-geo/0.1/test/test-amp-geo.js
@@ -48,13 +48,14 @@ describes.realWin('amp-geo', {
   let win, doc;
   let ampdoc;
   let geo;
+  let el;
 
 
   beforeEach(() => {
     win = env.win;
     doc = win.document;
     ampdoc = env.ampdoc;
-    const el = doc.createElement('amp-geo');
+    el = doc.createElement('amp-geo');
     doc.body.appendChild(el);
     el.ampdoc_ = ampdoc;
     const vsync = vsyncForTesting(win);
@@ -100,7 +101,7 @@ describes.realWin('amp-geo', {
     addConfigElement('script');
 
     geo.buildCallback();
-    return Services.geoForDocOrNull(ampdoc).then(geo => {
+    return Services.geoForDocOrNull(el).then(geo => {
       expect(geo.ISOCountry).to.equal('unknown');
       expectBodyHasClass([
         'amp-iso-country-unknown',
@@ -122,7 +123,7 @@ describes.realWin('amp-geo', {
     ], true);
 
     geo.buildCallback();
-    return Services.geoForDocOrNull(ampdoc).then(geo => {
+    return Services.geoForDocOrNull(el).then(geo => {
       expect(geo.ISOCountry).to.equal('unknown');
       expectBodyHasClass([
         'amp-geo-pending',
@@ -135,7 +136,7 @@ describes.realWin('amp-geo', {
         JSON.stringify(configWithState));
     geo.buildCallback();
 
-    return Services.geoForDocOrNull(ampdoc).then(() => {
+    return Services.geoForDocOrNull(el).then(() => {
       expect(win.document.getElementById('ampGeo').outerHTML)
           .to.equal(expectedState);
     });
@@ -145,7 +146,7 @@ describes.realWin('amp-geo', {
     addConfigElement('script');
     geo.buildCallback();
 
-    return Services.geoForDocOrNull(ampdoc).then(() => {
+    return Services.geoForDocOrNull(el).then(() => {
       expect(win.document.getElementById('ampGeo'))
           .to.equal(null);
     });
@@ -156,7 +157,7 @@ describes.realWin('amp-geo', {
     addConfigElement('script');
     geo.buildCallback();
 
-    return Services.geoForDocOrNull(ampdoc).then(geo => {
+    return Services.geoForDocOrNull(el).then(geo => {
       expect(geo.ISOCountry).to.equal('nz');
       expectBodyHasClass([
         'amp-iso-country-nz',
@@ -174,7 +175,7 @@ describes.realWin('amp-geo', {
     doc.body.classList.add('amp-iso-country-nz', 'amp-geo-group-anz');
     geo.buildCallback();
 
-    return Services.geoForDocOrNull(ampdoc).then(geo => {
+    return Services.geoForDocOrNull(el).then(geo => {
       expect(geo.ISOCountry).to.equal('nz');
       expectBodyHasClass([
         'amp-iso-country-nz',
@@ -193,7 +194,7 @@ describes.realWin('amp-geo', {
     addConfigElement('script');
     geo.buildCallback();
 
-    return Services.geoForDocOrNull(ampdoc).then(geo => {
+    return Services.geoForDocOrNull(el).then(geo => {
       expect(geo.ISOCountry).to.equal('nz');
       expectBodyHasClass([
         'amp-iso-country-nz',

--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -672,7 +672,7 @@ export class GlobalVariableSource extends VariableSource {
    * @private
    */
   getGeo_(getter, expr) {
-    return Services.geoForOrNull(this.ampdoc.win)
+    return Services.geoForDocOrNull(this.ampdoc)
         .then(geo => {
           user().assert(geo,
               'To use variable %s, amp-geo should be configured',

--- a/src/services.js
+++ b/src/services.js
@@ -467,7 +467,7 @@ export class Services {
   /**
    * Returns a promise for the geo service or a promise for null if
    * the service is not available on the current page.
-   * @param {!Window} win
+   * @param {!Node|!./service/ampdoc-impl.AmpDoc} nodeOrDoc
    * @return {!Promise<?Object<string,(string|Array<string>)>>}
    */
   static geoForDocOrNull(nodeOrDoc) {

--- a/src/services.js
+++ b/src/services.js
@@ -470,9 +470,9 @@ export class Services {
    * @param {!Window} win
    * @return {!Promise<?Object<string,(string|Array<string>)>>}
    */
-  static geoForOrNull(win) {
+  static geoForDocOrNull(nodeOrDoc) {
     return /** @type {!Promise<?Object<string,(string|Array<string>)>>} */ (
-      getElementServiceIfAvailable(win, 'geo', 'amp-geo', true));
+      getElementServiceIfAvailableForDoc(nodeOrDoc, 'geo', 'amp-geo', true));
   }
 
   /**


### PR DESCRIPTION
Fixes #15440 by searching for the geo service in the node or ampdoc instead of the window.