### PR TITLE
✨ Add amp-geo-no-group

### DIFF
--- a/extensions/amp-geo/0.1/amp-geo.js
+++ b/extensions/amp-geo/0.1/amp-geo.js
@@ -225,6 +225,11 @@ export class AmpGeo extends AMP.BaseElement {
             return GROUP_PREFIX + group;
           });
 
+
+          if (!self.matchedGroups_.length) {
+            classesToAdd.push('amp-geo-no-group');
+          }
+
           states.ISOCountryGroups = self.matchedGroups_;
           classesToAdd.push(COUNTRY_PREFIX + this.country_);
 

--- a/extensions/amp-geo/0.1/amp-geo.js
+++ b/extensions/amp-geo/0.1/amp-geo.js
@@ -225,7 +225,6 @@ export class AmpGeo extends AMP.BaseElement {
             return GROUP_PREFIX + group;
           });
 
-
           if (!self.matchedGroups_.length) {
             classesToAdd.push('amp-geo-no-group');
           }

--- a/extensions/amp-geo/0.1/test/test-amp-geo.js
+++ b/extensions/amp-geo/0.1/test/test-amp-geo.js
@@ -174,6 +174,27 @@ describes.realWin('amp-geo', {
       expectBodyHasClass([
         'amp-iso-country-unknown',
         'amp-geo-group-nafta',
+        'amp-geo-no-group',
+      ], false);
+    });
+  });
+
+
+  it('should set amp-geo-no-group if no group matches', () => {
+    win.AMP_MODE.geoOverride = 'gb';
+    addConfigElement('script');
+    geo.buildCallback();
+
+    return Services.geoForDocOrNull(el).then(geo => {
+      expect(geo.ISOCountry).to.equal('gb');
+      expectBodyHasClass([
+        'amp-iso-country-gb',
+        'amp-geo-no-group',
+      ], true);
+      expectBodyHasClass([
+        'amp-iso-country-unknown',
+        'amp-geo-group-nafta',
+        'amp-geo-group-anz',
       ], false);
     });
   });

--- a/extensions/amp-geo/amp-geo.md
+++ b/extensions/amp-geo/amp-geo.md
@@ -92,7 +92,7 @@ The `ISOCountryGroups` key allows selections by groups of country codes.
 </amp-geo>
 ```
 
-If country groups are specified, `amp-geo` iterates through the groups. For any group that contains the current country, a class named `amp-geo-group-` followed by the group name is added to `<body>`. Group names may only contain a-z, A-Z and 0-9, and may not start with a digit.
+If country groups are specified, `amp-geo` iterates through the groups. For any group that contains the current country, a class named `amp-geo-group-` followed by the group name is added to `<body>`. Group names may only contain a-z, A-Z and 0-9, and may not start with a digit.  If no country group is matched the class `amp-geo-no-group` is added to `body`.
 
 ##### Example: Generated CSS classes
 


### PR DESCRIPTION
Adds `am-geo-no-group` to `body` if no group is matched.

Fixes #15554
