### PR TITLE
remove commenting out of iframe sandbox attributes

### DIFF
--- a/examples/viewer-iframe-poll.html
+++ b/examples/viewer-iframe-poll.html
@@ -183,10 +183,9 @@
       this.container = document.getElementById(containerId);
       this.iframe = document.createElement('iframe');
       this.iframe.setAttribute('id', 'AMP_DOC_' + this.id);
-      // TODO(dvoytenko): Set to the final value when crbug/577330 is fixed:
-      // this.iframe.setAttribute('sandbox',
-      //     'allow-popups allow-scripts allow-forms allow-pointer-lock' +
-      //     ' allow-popups-to-escape-sandbox allow-same-origin');
+      this.iframe.setAttribute('sandbox',
+          'allow-popups allow-scripts allow-forms allow-pointer-lock' +
+          ' allow-popups-to-escape-sandbox allow-same-origin');
 
       this.visibilityToggle_ = document.getElementById('visibilityToggle');
       this.visibilityToggle_.addEventListener('click', function() {

--- a/examples/viewer-webview.html
+++ b/examples/viewer-webview.html
@@ -183,10 +183,9 @@
       this.container = document.getElementById(containerId);
       this.iframe = document.createElement('iframe');
       this.iframe.setAttribute('id', 'AMP_DOC_' + this.id);
-      // TODO(dvoytenko): Set to the final value when crbug/577330 is fixed:
-      // this.iframe.setAttribute('sandbox',
-      //     'allow-popups allow-scripts allow-forms allow-pointer-lock' +
-      //     ' allow-popups-to-escape-sandbox allow-same-origin');
+      this.iframe.setAttribute('sandbox',
+          'allow-popups allow-scripts allow-forms allow-pointer-lock' +
+          ' allow-popups-to-escape-sandbox allow-same-origin');
 
       this.visibilityToggle_ = document.getElementById('visibilityToggle');
       this.visibilityToggle_.addEventListener('click', function() {

--- a/examples/viewer.html
+++ b/examples/viewer.html
@@ -183,10 +183,9 @@
       this.container = document.getElementById(containerId);
       this.iframe = document.createElement('iframe');
       this.iframe.setAttribute('id', 'AMP_DOC_' + this.id);
-      // TODO(dvoytenko): Set to the final value when crbug/577330 is fixed:
-      // this.iframe.setAttribute('sandbox',
-      //     'allow-popups allow-scripts allow-forms allow-pointer-lock' +
-      //     ' allow-popups-to-escape-sandbox allow-same-origin');
+      this.iframe.setAttribute('sandbox',
+          'allow-popups allow-scripts allow-forms allow-pointer-lock' +
+          ' allow-popups-to-escape-sandbox allow-same-origin');
 
       this.visibilityToggle_ = document.getElementById('visibilityToggle');
       this.visibilityToggle_.addEventListener('click', function() {


### PR DESCRIPTION
allow-popups-to-escape-sandbox was not supported at the time thus was commented out. It is now supported.

https://bugs.chromium.org/p/chromium/issues/detail?id=577330