### PR TITLE
♻️[amp-story] Change ad behavior on desktop

### DIFF
--- a/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.css
+++ b/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.css
@@ -88,10 +88,6 @@ amp-story[ad-showing] .i-amphtml-story-ad-attribution {
   visibility: visible !important;
 }
 
-amp-story[ad-showing][desktop] .i-amphtml-story-ad-attribution {
-  background-color: red !important;
-}
-
 .i-amphtml-glass-pane {
   height: 100% !important;
   width: 100% !important;

--- a/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.css
+++ b/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.css
@@ -14,6 +14,12 @@
  * limitations under the License.
  */
 
+
+[desktop] amp-story-page[i-amphtml-loading] {
+  /* Move below viewport so that ad preloads */
+  transform: scale(1.0) translateX(-100%) translateY(200%) !important;
+}
+
 .i-amphtml-story-ad-link {
   background-color: #FFFFFF !important;
   border-radius: 20px !important;
@@ -80,6 +86,10 @@ amp-story-page[active] .i-amphtml-story-ad-link {
 
 amp-story[ad-showing] .i-amphtml-story-ad-attribution {
   visibility: visible !important;
+}
+
+amp-story[ad-showing][desktop] .i-amphtml-story-ad-attribution {
+  background-color: red !important;
 }
 
 .i-amphtml-glass-pane {

--- a/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
+++ b/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
@@ -413,7 +413,7 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
 
 
   /**
-   * @param {StateChangeEventDef} stateChangeEvent
+   * @param {!StateChangeEventDef} stateChangeEvent
    * @private
    */
   handleStateChange_(stateChangeEvent) {

--- a/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
+++ b/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
@@ -17,15 +17,14 @@
 import {CSS} from '../../../build/amp-story-auto-ads-0.1.css';
 import {CommonSignals} from '../../../src/common-signals';
 import {Services} from '../../../src/services';
-import {StateChangeType} from '../../amp-story/0.1/navigation-state';
-import {StateProperty} from '../../amp-story/0.1/amp-story-store-service';
+import {StateChangeEventDef, StateChangeType} from '../../amp-story/1.0/navigation-state';
+import {StateProperty} from '../../amp-story/1.0/amp-story-store-service';
 import {createElementWithAttributes} from '../../../src/dom';
 import {dev, user} from '../../../src/log';
 import {dict, hasOwn, map} from '../../../src/utils/object';
 import {isJsonScriptTag} from '../../../src/dom';
 import {parseJson} from '../../../src/json';
 import {triggerAnalyticsEvent} from '../../../src/analytics';
-
 
 /** @const */
 const MIN_INTERVAL = 3;
@@ -44,6 +43,9 @@ const TIMEOUT_LIMIT = 10000; // 10 seconds
 
 /** @const */
 const GLASS_PANE_CLASS = 'i-amphtml-glass-pane';
+
+/** @const */
+const LOADING_ATTR = 'i-amphtml-loading';
 
 /** @const */
 const DATA_ATTR = {
@@ -296,6 +298,11 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
       const signals = impl.signals();
       return signals.whenSignal(CommonSignals.INI_LOAD);
     }).then(() => {
+      // remove loading attribute once loaded so that desktop CSS will position
+      // offscren with all other pages
+      const currentPageEl = this.adPageEls_[this.adPageEls_.length - 1];
+      currentPageEl.removeAttribute(LOADING_ATTR);
+
       this.analyticsEvent_(EVENTS.AD_LOADED,
           {[VARS.AD_LOADED]: Date.now()});
       this.isCurrentAdLoaded_ = true;
@@ -315,6 +322,7 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
       'id': `i-amphtml-ad-page-${id}`,
       'ad': '',
       'distance': '2',
+      'i-amphtml-loading': '',
     });
 
     return createElementWithAttributes(
@@ -405,6 +413,7 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
 
 
   /**
+   * @param {StateChangeEventDef} stateChangeEvent
    * @private
    */
   handleStateChange_(stateChangeEvent) {
@@ -462,21 +471,37 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
 
   /**
    * Place ad based on user config
-   * @param {string} currentPageId
+   * @param {string} pageBeforeAdId
    * @private
    */
-  tryToPlaceAdAfterPage_(currentPageId) {
+  tryToPlaceAdAfterPage_(pageBeforeAdId) {
     const nextAdPageEl = this.adPageEls_[this.adPageEls_.length - 1];
     if (!this.isCurrentAdLoaded_ && this.adTimedOut_()) {
       // timeout fail
       return AD_STATE.FAILED;
     }
 
-    const currentPage = this.ampStory_.getPageById(currentPageId);
-    const nextPage = this.ampStory_.getNextPage(currentPage);
+    let pageBeforeAd = this.ampStory_.getPageById(pageBeforeAdId);
+    let pageAfterAd = this.ampStory_.getNextPage(pageBeforeAd);
 
-    if (!this.isCurrentAdLoaded_ || currentPage.isAd() ||
-        (nextPage && nextPage.isAd())) {
+    if (!pageAfterAd) {
+      return AD_STATE.PENDING;
+    }
+
+    if (this.isDesktopView_()) {
+      // If we are in desktop view the ad must be inserted 2 pages away because
+      // the next page will already be in view
+      pageBeforeAd = pageAfterAd;
+      pageBeforeAdId = pageAfterAd.element.id;
+      pageAfterAd = this.ampStory_.getNextPage(pageAfterAd);
+    }
+
+    if (!pageAfterAd) {
+      return AD_STATE.PENDING;
+    }
+
+    if (!this.isCurrentAdLoaded_ || pageBeforeAd.isAd() ||
+        pageAfterAd.isAd()) {
       // if we are going to cause two consecutive ads or ad is still
       // loading we will try again on next user interaction
       return AD_STATE.PENDING;
@@ -488,8 +513,17 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
       return AD_STATE.FAILED;
     }
 
-    this.ampStory_.insertPage(currentPageId, nextAdPageEl.id);
+    this.ampStory_.insertPage(pageBeforeAdId, nextAdPageEl.id);
     return AD_STATE.INSERTED;
+  }
+
+
+  /**
+   * @private
+   * @return {boolean}
+   */
+  isDesktopView_() {
+    return this.storeService_.get(StateProperty.DESKTOP_STATE);
   }
 
 

--- a/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
+++ b/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
@@ -523,7 +523,7 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
    * @return {boolean}
    */
   isDesktopView_() {
-    return this.storeService_.get(StateProperty.DESKTOP_STATE);
+    return !!this.storeService_.get(StateProperty.DESKTOP_STATE);
   }
 
 

--- a/extensions/amp-story-auto-ads/0.1/test/test-amp-story-auto-ads.js
+++ b/extensions/amp-story-auto-ads/0.1/test/test-amp-story-auto-ads.js
@@ -97,6 +97,7 @@ describes.realWin('amp-story-auto-ads', {
       const ad = win.document.createElement('amp-ad');
       ad.getImpl = () => Promise.resolve(fakeImpl);
       sandbox.stub(autoAds, 'createAdElement_').returns(ad);
+      autoAds.adPageEls_ = [ad];
 
       const analyticsStub = sandbox.stub(autoAds, 'analyticsEvent_');
       autoAds.createAdPage_();

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -859,7 +859,7 @@ export class AmpStory extends AMP.BaseElement {
         pageIndex,
         this.getPageCount(),
         targetPage.element.id,
-        targetPage.getNextPageId() === null // isFinalPage
+        targetPage.getNextPageId() === null /* isFinalPage */
     );
 
     const oldPage = this.activePage_;

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -858,7 +858,9 @@ export class AmpStory extends AMP.BaseElement {
     this.navigationState_.updateActivePage(
         pageIndex,
         this.getPageCount(),
-        targetPage.element.id);
+        targetPage.element.id,
+        targetPage.getNextPageId() === null // isFinalPage
+    );
 
     const oldPage = this.activePage_;
 

--- a/extensions/amp-story/1.0/navigation-state.js
+++ b/extensions/amp-story/1.0/navigation-state.js
@@ -87,7 +87,7 @@ export class NavigationState {
    * @param {string=} pageId
    */
   // TODO(alanorozco): pass whether change was automatic or on user action
-  updateActivePage(pageIndex, totalPages, pageId) {
+  updateActivePage(pageIndex, totalPages, pageId, isFinalPage) {
     const changeValue = {
       pageIndex,
       pageId,
@@ -97,7 +97,7 @@ export class NavigationState {
 
     this.fire_(StateChangeType.ACTIVE_PAGE, changeValue);
 
-    if (pageIndex >= totalPages - 1) {
+    if (isFinalPage) {
       this.hasBookend_().then(hasBookend => {
         if (!hasBookend) {
           this.fire_(StateChangeType.END);

--- a/extensions/amp-story/1.0/navigation-state.js
+++ b/extensions/amp-story/1.0/navigation-state.js
@@ -84,7 +84,8 @@ export class NavigationState {
   /**
    * @param {number} pageIndex
    * @param {number} totalPages
-   * @param {string=} pageId
+   * @param {string} pageId
+   * @param {boolean} isFinalPage
    */
   // TODO(alanorozco): pass whether change was automatic or on user action
   updateActivePage(pageIndex, totalPages, pageId, isFinalPage) {

--- a/extensions/amp-story/1.0/test/test-navigation-state.js
+++ b/extensions/amp-story/1.0/test/test-navigation-state.js
@@ -75,6 +75,24 @@ describes.fakeWin('amp-story navigation state', {ampdoc: 'none'}, env => {
     });
   });
 
+  it('should NOT dispatch END if not on last page', () => {
+    const observer = sandbox.spy();
+
+    navigationState.observe(event => observer(event));
+
+    hasBookend = false;
+
+    navigationState.updateActivePage(1, 2, 'fake-id', false);
+
+    expect(observer).to.have.been.calledWith(sandbox.match(e =>
+      e.type == StateChangeType.ACTIVE_PAGE
+          && e.value.pageIndex === 1
+          && e.value.totalPages === 2));
+
+    expect(observer).to.not.have.been.calledWith(sandbox.match(e =>
+      e.type == StateChangeType.END));
+  });
+
   it('should dispatch END on last page if story does NOT have bookend', () => {
     const observer = sandbox.spy();
 
@@ -82,7 +100,7 @@ describes.fakeWin('amp-story navigation state', {ampdoc: 'none'}, env => {
 
     hasBookend = false;
 
-    navigationState.updateActivePage(1, 2);
+    navigationState.updateActivePage(1, 2, 'fake-id', true);
 
     expect(observer).to.have.been.calledWith(sandbox.match(e =>
       e.type == StateChangeType.ACTIVE_PAGE
@@ -100,7 +118,7 @@ describes.fakeWin('amp-story navigation state', {ampdoc: 'none'}, env => {
 
     hasBookend = true;
 
-    navigationState.updateActivePage(1, 2);
+    navigationState.updateActivePage(1, 2, 'fake-id', true);
 
     expect(observer).to.have.been.calledWith(sandbox.match(e =>
       e.type == StateChangeType.ACTIVE_PAGE


### PR DESCRIPTION
Set attribute to move ad below viewport so that it loads. (Right now pages only start loading when they appear on right side of desktop view). Remove this attribute after ad loads so that it will move to location of other pages.

Also change the logic to check if a page is the "last page" and replay button should be shown. Previously it checked if it was last item in `pages` array. Now we check if there is no `getNextPageId` This allows for non-linear stories.

