### PR TITLE
Provide an option to hide the amp-story-consent reject button.

### DIFF
--- a/extensions/amp-story/0.1/amp-story-consent.css
+++ b/extensions/amp-story/0.1/amp-story-consent.css
@@ -163,6 +163,10 @@
   text-transform: uppercase !important;
 }
 
+.i-amphtml-story-consent-action.i-amphtml-hidden {
+  display: none !important;
+}
+
 .i-amphtml-story-consent-action-accept {
   background: var(--primary-color, #000000) !important;
   color: #FFFFFF !important;

--- a/extensions/amp-story/0.1/amp-story-consent.js
+++ b/extensions/amp-story/0.1/amp-story-consent.js
@@ -35,8 +35,16 @@ import {renderAsElement} from './simple-template';
 import {throttle} from '../../../src/utils/rate-limit';
 
 
-/** @private @const {string} */
+/** @const {string} */
 const TAG = 'amp-story-consent';
+
+/**
+ * Default optional config parameters.
+ * @const {!Object}
+ */
+const DEFAULT_OPTIONAL_PARAMETERS = {
+  onlyAccept: false,
+};
 
 // TODO(gmajoulet): switch to `htmlFor` static template helper.
 /**
@@ -115,7 +123,8 @@ const getTemplate = (config, consentId, logoSrc) => ({
               tag: 'button',
               attrs: dict({
                 'class': 'i-amphtml-story-consent-action ' +
-                    'i-amphtml-story-consent-action-reject',
+                    'i-amphtml-story-consent-action-reject' +
+                    (config.onlyAccept === true ? ' i-amphtml-hidden' : ''),
                 'on': `tap:${consentId}.reject`,
               }),
               children: [],
@@ -271,7 +280,10 @@ export class AmpStoryConsent extends AMP.BaseElement {
         'type="application/json"');
 
     this.storyConsentConfig_ =
-      /** @type {Object} */ (parseJson(storyConsentScript.textContent));
+        Object.assign(
+            {},
+            DEFAULT_OPTIONAL_PARAMETERS,
+            /** @type {Object} */ (parseJson(storyConsentScript.textContent)));
 
     user().assertString(
         this.storyConsentConfig_.title, `${TAG}: config requires a title`);
@@ -281,6 +293,9 @@ export class AmpStoryConsent extends AMP.BaseElement {
         this.storyConsentConfig_.vendors &&
             isArray(this.storyConsentConfig_.vendors),
         `${TAG}: config requires an array of vendors`);
+    user().assertBoolean(
+        this.storyConsentConfig_.onlyAccept,
+        `${TAG}: config requires "onlyAccept" to be a boolean`);
   }
 
   /**

--- a/extensions/amp-story/0.1/test/test-amp-story-consent.js
+++ b/extensions/amp-story/0.1/test/test-amp-story-consent.js
@@ -16,6 +16,7 @@
 
 import {AmpStoryConsent} from '../amp-story-consent';
 import {LocalizationService} from '../localization';
+import {computedStyle} from '../../../../src/style';
 import {registerServiceBuilder} from '../../../../src/service';
 
 describes.realWin('amp-story-consent', {amp: true}, env => {
@@ -41,6 +42,7 @@ describes.realWin('amp-story-consent', {amp: true}, env => {
       title: 'Foo title.',
       message: 'Foo message about the consent.',
       vendors: ['Item 1', 'Item 2'],
+      onlyAccept: false,
     };
 
     const styles = {'background-color': 'rgb(0, 0, 0)'};
@@ -125,6 +127,47 @@ describes.realWin('amp-story-consent', {amp: true}, env => {
         storyConsent.buildCallback();
       }).to.throw('config requires an array of vendors');
     });
+  });
+
+  it('should require onlyAccept to be a boolean', () => {
+    defaultConfig.onlyAccept = 'foo';
+    setConfig(defaultConfig);
+
+    allowConsoleError(() => {
+      expect(() => {
+        storyConsent.buildCallback();
+      }).to.throw('config requires "onlyAccept" to be a boolean');
+    });
+  });
+
+  it('should show the decline button by default', () => {
+    delete defaultConfig.onlyAccept;
+    setConfig(defaultConfig);
+
+    storyConsent.buildCallback();
+
+    const buttonEl = storyConsent.storyConsentEl_
+        .querySelector('.i-amphtml-story-consent-action-reject');
+
+    // For some reason the win object provided by the test environment does not
+    // return all the styles.
+    const styles = computedStyle(window, buttonEl);
+    expect(styles.display).to.equal('block');
+  });
+
+  it('should hide the decline button if onlyAccept is true', () => {
+    defaultConfig.onlyAccept = true;
+    setConfig(defaultConfig);
+
+    storyConsent.buildCallback();
+
+    const buttonEl = storyConsent.storyConsentEl_
+        .querySelector('.i-amphtml-story-consent-action-reject');
+
+    // For some reason the win object provided by the test environment does not
+    // return all the styles.
+    const styles = computedStyle(window, buttonEl);
+    expect(styles.display).to.equal('none');
   });
 
   it('should whitelist the <amp-consent> actions', () => {

--- a/extensions/amp-story/1.0/amp-story-consent.css
+++ b/extensions/amp-story/1.0/amp-story-consent.css
@@ -163,6 +163,10 @@
   text-transform: uppercase !important;
 }
 
+.i-amphtml-story-consent-action.i-amphtml-hidden {
+  display: none !important;
+}
+
 .i-amphtml-story-consent-action-accept {
   background: var(--primary-color, #000000) !important;
   color: #FFFFFF !important;

--- a/extensions/amp-story/1.0/amp-story-consent.js
+++ b/extensions/amp-story/1.0/amp-story-consent.js
@@ -35,8 +35,16 @@ import {renderAsElement} from './simple-template';
 import {throttle} from '../../../src/utils/rate-limit';
 
 
-/** @private @const {string} */
+/** @const {string} */
 const TAG = 'amp-story-consent';
+
+/**
+ * Default optional config parameters.
+ * @const {!Object}
+ */
+const DEFAULT_OPTIONAL_PARAMETERS = {
+  onlyAccept: false,
+};
 
 // TODO(gmajoulet): switch to `htmlFor` static template helper.
 /**
@@ -115,7 +123,8 @@ const getTemplate = (config, consentId, logoSrc) => ({
               tag: 'button',
               attrs: dict({
                 'class': 'i-amphtml-story-consent-action ' +
-                    'i-amphtml-story-consent-action-reject',
+                    'i-amphtml-story-consent-action-reject' +
+                    (config.onlyAccept === true ? ' i-amphtml-hidden' : ''),
                 'on': `tap:${consentId}.reject`,
               }),
               children: [],
@@ -271,7 +280,10 @@ export class AmpStoryConsent extends AMP.BaseElement {
         'type="application/json"');
 
     this.storyConsentConfig_ =
-      /** @type {Object} */ (parseJson(storyConsentScript.textContent));
+        Object.assign(
+            {},
+            DEFAULT_OPTIONAL_PARAMETERS,
+            /** @type {Object} */ (parseJson(storyConsentScript.textContent)));
 
     user().assertString(
         this.storyConsentConfig_.title, `${TAG}: config requires a title`);
@@ -281,6 +293,9 @@ export class AmpStoryConsent extends AMP.BaseElement {
         this.storyConsentConfig_.vendors &&
             isArray(this.storyConsentConfig_.vendors),
         `${TAG}: config requires an array of vendors`);
+    user().assertBoolean(
+        this.storyConsentConfig_.onlyAccept,
+        `${TAG}: config requires "onlyAccept" to be a boolean`);
   }
 
   /**

--- a/extensions/amp-story/1.0/test/test-amp-story-consent.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-consent.js
@@ -16,6 +16,7 @@
 
 import {AmpStoryConsent} from '../amp-story-consent';
 import {LocalizationService} from '../localization';
+import {computedStyle} from '../../../../src/style';
 import {registerServiceBuilder} from '../../../../src/service';
 
 describes.realWin('amp-story-consent', {amp: true}, env => {
@@ -41,6 +42,7 @@ describes.realWin('amp-story-consent', {amp: true}, env => {
       title: 'Foo title.',
       message: 'Foo message about the consent.',
       vendors: ['Item 1', 'Item 2'],
+      onlyAccept: false,
     };
 
     const styles = {'background-color': 'rgb(0, 0, 0)'};
@@ -125,6 +127,47 @@ describes.realWin('amp-story-consent', {amp: true}, env => {
         storyConsent.buildCallback();
       }).to.throw('config requires an array of vendors');
     });
+  });
+
+  it('should require onlyAccept to be a boolean', () => {
+    defaultConfig.onlyAccept = 'foo';
+    setConfig(defaultConfig);
+
+    allowConsoleError(() => {
+      expect(() => {
+        storyConsent.buildCallback();
+      }).to.throw('config requires "onlyAccept" to be a boolean');
+    });
+  });
+
+  it('should show the decline button by default', () => {
+    delete defaultConfig.onlyAccept;
+    setConfig(defaultConfig);
+
+    storyConsent.buildCallback();
+
+    const buttonEl = storyConsent.storyConsentEl_
+        .querySelector('.i-amphtml-story-consent-action-reject');
+
+    // For some reason the win object provided by the test environment does not
+    // return all the styles.
+    const styles = computedStyle(window, buttonEl);
+    expect(styles.display).to.equal('block');
+  });
+
+  it('should hide the decline button if onlyAccept is true', () => {
+    defaultConfig.onlyAccept = true;
+    setConfig(defaultConfig);
+
+    storyConsent.buildCallback();
+
+    const buttonEl = storyConsent.storyConsentEl_
+        .querySelector('.i-amphtml-story-consent-action-reject');
+
+    // For some reason the win object provided by the test environment does not
+    // return all the styles.
+    const styles = computedStyle(window, buttonEl);
+    expect(styles.display).to.equal('none');
   });
 
   it('should whitelist the <amp-consent> actions', () => {


### PR DESCRIPTION
Context and usage: #15570

Related to #14538