### PR TITLE
AdSense Matched Content Parameters

### DIFF
--- a/ads/google/adsense.js
+++ b/ads/google/adsense.js
@@ -30,7 +30,8 @@ export function adsense(global, data) {
   validateData(data, [],
       ['adClient', 'adSlot', 'adHost', 'adtest', 'tagOrigin', 'experimentId',
         'ampSlotIndex', 'adChannel', 'autoFormat', 'fullWidth', 'package',
-        'npaOnUnknownConsent']);
+        'npaOnUnknownConsent', 'matchedContentUiType', 'matchedContentRowsNum',
+        'matchedContentColumnsNum']);
 
   if (data['autoFormat'] == 'rspv') {
     user().assert(data.hasOwnProperty('fullWidth'),
@@ -55,7 +56,8 @@ export function adsense(global, data) {
 
   const i = global.document.createElement('ins');
   ['adChannel', 'adClient', 'adSlot', 'adHost', 'adtest', 'tagOrigin',
-    'package']
+    'package', 'matchedContentUiType', 'matchedContentRowsNum',
+    'matchedContentColumnsNum']
       .forEach(datum => {
         if (data[datum]) {
           i.setAttribute('data-' + camelCaseToDash(datum), data[datum]);

--- a/ads/google/test/test-adsense.js
+++ b/ads/google/test/test-adsense.js
@@ -30,6 +30,9 @@ describes.realWin('adsenseDelayedFetch', {}, env => {
     'adtest': 'data-adtest',
     'tagOrigin': 'data-tag-origin',
     'package': 'data-package',
+    'matchedContentUiType': 'data-matched-content-ui-type',
+    'matchedContentRowsNum': 'data-matched-content-rows-num',
+    'matchedContentColumnsNum': 'data-matched-content-columns-num',
   };
 
   beforeEach(() => {

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -317,6 +317,10 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
       'rc': this.fromResumeCallback ? 1 : null,
       'rafmt': this.isResponsive_() ? 13 : null,
       'pfx': pfx ? '1' : '0',
+      // Matched content specific fields.
+      'crui': this.element.getAttribute('data-matched-content-ui-type'),
+      'cr_row': this.element.getAttribute('data-matched-content-rows-num'),
+      'cr_col': this.element.getAttribute('data-matched-content-columns-num'),
       // Package code (also known as URL group) that was used to
       // create ad.
       'pwprc': this.element.getAttribute('data-package'),

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
@@ -562,6 +562,16 @@ describes.realWin('amp-ad-network-adsense-impl', {
           expect(url).to.match(/(\?|&)ramft=13(&|$)/);
         });
       });
+      it('sets matched content specific fields', () => {
+        element.setAttribute('data-matched-content-ui-type', 'ui');
+        element.setAttribute('data-matched-content-rows-num', 'rows');
+        element.setAttribute('data-matched-content-columns-num', 'cols');
+        return impl.getAdUrl().then(url => {
+          expect(url).to.match(/(\?|&)crui=ui(&|$)/);
+          expect(url).to.match(/(\?|&)cr_row=rows(&|$)/);
+          expect(url).to.match(/(\?|&)cr_col=cols(&|$)/);
+        });
+      });
     });
 
     // Not using arrow function here because otherwise the way closure behaves


### PR DESCRIPTION
Fixes #13541 for both Delayed and Fast Fetch AdSense where matched content can be controlled via data-matched-content-ui-type
data-matched-content-rows-num
data-matched-content-columns-num