### PR TITLE
Separate the experiment for amp-story 0.1 and 1.0

### DIFF
--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -671,7 +671,7 @@ export class AmpStory extends AMP.BaseElement {
 
   /** @private */
   isAmpStoryEnabled_() {
-    if (isExperimentOn(this.win, TAG) || getMode().test ||
+    if (isExperimentOn(this.win, 'amp-story-v1') || getMode().test ||
         this.win.location.protocol === 'file:') {
       return true;
     }

--- a/tools/experiments/experiments.js
+++ b/tools/experiments/experiments.js
@@ -218,8 +218,14 @@ const EXPERIMENTS = [
   },
   {
     id: 'amp-story',
-    name: 'Visual storytelling in AMP',
+    name: 'Visual storytelling in AMP (v0.1)',
     spec: 'https://github.com/ampproject/amphtml/issues/11329',
+    cleanupIssue: 'https://github.com/ampproject/amphtml/issues/14357',
+  },
+  {
+    id: 'amp-story-v1',
+    name: 'Visual storytelling in AMP (v1.0)',
+    spec: 'https://github.com/ampproject/amphtml/issues/14357',
     cleanupIssue: 'https://github.com/ampproject/amphtml/issues/11475',
   },
   {


### PR DESCRIPTION
Related to #14357

This allows the experiments to be configured differently between the versions.