### PR TITLE
Disable svg-in-mustache in canary/prod

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -36,7 +36,7 @@
   "amp-animation": 1,
   "amp-live-list-sorting": 1,
   "amp-sidebar toolbar": 1,
-  "svg-in-mustache": 1,
+  "svg-in-mustache": 0,
   "a4a-safeframe-preloading-off": 0.01,
   "expUnconditionedAdxIdentity": 0.01,
   "expUnconditionedDfpIdentity": 0.01,

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -35,7 +35,7 @@
   "amp-animation": 1,
   "amp-live-list-sorting": 1,
   "amp-sidebar toolbar": 1,
-  "svg-in-mustache": 0.1,
+  "svg-in-mustache": 0,
   "a4a-safeframe-preloading-off": 0.01,
   "expUnconditionedAdxIdentity": 0.01,
   "expUnconditionedDfpIdentity": 0.01,


### PR DESCRIPTION
Appears to strip the `layout` attribute from AMP elements.

Follow-up TODO: Why didn't we catch this in visual tests?

/to @jpettitt @aghassemi 