### PR TITLE
Throw user error when promptUI and postPromptUI are not scoped 

### DIFF
--- a/extensions/amp-consent/0.1/amp-consent.js
+++ b/extensions/amp-consent/0.1/amp-consent.js
@@ -524,6 +524,7 @@ export class AmpConsent extends AMP.BaseElement {
       const postPromptUI = config['postPromptUI'];
       this.postPromptUI_ = this.getAmpDoc().getElementById(postPromptUI);
       if (!this.postPromptUI_ || !this.element.contains(this.postPromptUI_)) {
+        this.postPromptUI_ = null;
         this.user().error(TAG, 'child element of <amp-consent> with ' +
           `postPromptUI id ${postPromptUI} not found`);
       }
@@ -564,8 +565,9 @@ export class AmpConsent extends AMP.BaseElement {
   initPromptUI_(instanceId) {
     const promptUI = this.consentConfig_[instanceId]['promptUI'];
     if (promptUI) {
-      const element = this.getAmpDoc().getElementById(promptUI);
+      let element = this.getAmpDoc().getElementById(promptUI);
       if (!element || !this.element.contains(element)) {
+        element = null;
         this.user().error(TAG, 'child element of <amp-consent> with ' +
           `promptUI id ${promptUI} not found`);
       }

--- a/extensions/amp-consent/0.1/amp-consent.js
+++ b/extensions/amp-consent/0.1/amp-consent.js
@@ -523,8 +523,8 @@ export class AmpConsent extends AMP.BaseElement {
       const postPromptUI = config['postPromptUI'];
       this.postPromptUI_ = this.getAmpDoc().getElementById(postPromptUI);
       if (!this.postPromptUI_) {
-        this.user().error(TAG, 'child element of <amp-consent> with ' +
-          `postPromptUI id ${postPromptUI} not found`);
+        this.user().error(TAG, 'postPromptUI element with ' +
+          `id=${postPromptUI} not found`);
       }
     }
     this.policyConfig_ = config['policy'] || this.policyConfig_;

--- a/extensions/amp-consent/0.1/amp-consent.js
+++ b/extensions/amp-consent/0.1/amp-consent.js
@@ -37,7 +37,6 @@ import {dict, map} from '../../../src/utils/object';
 import {getServicePromiseForDoc} from '../../../src/service';
 import {isExperimentOn} from '../../../src/experiments';
 import {parseJson} from '../../../src/json';
-import {scopedQuerySelector} from '../../../src/dom';
 import {setImportantStyles, toggle} from '../../../src/style';
 
 const CONSENT_STATE_MANAGER = 'consentStateManager';
@@ -523,8 +522,7 @@ export class AmpConsent extends AMP.BaseElement {
     if (config['postPromptUI']) {
       const postPromptUI = config['postPromptUI'];
       this.postPromptUI_ = this.getAmpDoc().getElementById(postPromptUI);
-      if (!this.postPromptUI_ || !this.element.contains(this.postPromptUI_)) {
-        this.postPromptUI_ = null;
+      if (!this.postPromptUI_) {
         this.user().error(TAG, 'child element of <amp-consent> with ' +
           `postPromptUI id ${postPromptUI} not found`);
       }

--- a/extensions/amp-consent/0.1/test/test-amp-consent.js
+++ b/extensions/amp-consent/0.1/test/test-amp-consent.js
@@ -419,6 +419,7 @@ describes.realWin('amp-consent', {
     let ampConsent;
     let updateConsentInstanceStateSpy;
     let consentElement;
+    let postPromptUI;
     beforeEach(() => {
       defaultConfig = {
         'consents': {
@@ -447,6 +448,9 @@ describes.realWin('amp-consent', {
       uiElement.setAttribute('id', '123');
       consentElement.appendChild(uiElement);
       consentElement.appendChild(scriptElement);
+      postPromptUI = document.createElement('div');
+      postPromptUI.setAttribute('id', 'test');
+      consentElement.appendChild(postPromptUI);
       doc.body.appendChild(consentElement);
       ampConsent = new AmpConsent(consentElement);
       sandbox.stub(ampConsent.vsync_, 'mutate').callsFake(fn => {
@@ -512,12 +516,7 @@ describes.realWin('amp-consent', {
     });
 
     describe('postPromptUI', () => {
-      let postPromptUI;
-
       beforeEach(() => {
-        postPromptUI = document.createElement('div');
-        postPromptUI.setAttribute('id', 'test');
-        consentElement.appendChild(postPromptUI);
         storageValue = {
           'amp-consent:ABC': CONSENT_ITEM_STATE.GRANTED,
           'amp-consent:DEF': CONSENT_ITEM_STATE.GRANTED,


### PR DESCRIPTION
As documented, `promptUI` and `postPromptUI` should be children of `<amp-consent>` element.
Fix https://github.com/ampproject/amphtml/issues/15361#issuecomment-392129351