### PR TITLE
Temporarily disable console error check in test-amp-analytics.js unti…

### DIFF
--- a/extensions/amp-analytics/0.1/test/test-amp-analytics.js
+++ b/extensions/amp-analytics/0.1/test/test-amp-analytics.js
@@ -77,6 +77,9 @@ describes.realWin('amp-analytics', {
   };
 
   beforeEach(() => {
+    // Temporarily disable console error check until we have a solution
+    // to catch async console errors.
+    dontWarnForConsoleError();
     win = env.win;
     doc = win.document;
     ampdoc = env.ampdoc;
@@ -114,6 +117,10 @@ describes.realWin('amp-analytics', {
     return Services.userNotificationManagerForDoc(ampdoc).then(manager => {
       uidService = manager;
     });
+  });
+
+  afterEach(() => {
+    warnForConsoleError();
   });
 
   function getAnalyticsTag(config, attrs) {

--- a/test/_init_tests.js
+++ b/test/_init_tests.js
@@ -52,6 +52,8 @@ let initialWindowState;
 
 // All exposed describes.
 global.describes = describes;
+global.dontWarnForConsoleError = dontWarnForConsoleError;
+global.warnForConsoleError = warnForConsoleError;
 
 // Increase the before/after each timeout since certain times they have timedout
 // during the normal 2000 allowance.


### PR DESCRIPTION
…l we have a solution to catch async console errors.

