### PR TITLE
🏗 Don't fail tests with `console.error`s during `gulp test --local-changes` if there are too many of them

### DIFF
--- a/build-system/tasks/runtime-test.js
+++ b/build-system/tasks/runtime-test.js
@@ -39,7 +39,7 @@ const {green, yellow, cyan, red, bold} = colors;
 const preTestTasks = argv.nobuild ? [] : (
   (argv.unit || argv.a4a || argv['local-changes']) ? ['css'] : ['build']);
 const ampConfig = (argv.config === 'canary') ? 'canary' : 'prod';
-
+const tooManyTestsToFix = 15;
 
 /**
  * Read in and process the configuration settings for karma
@@ -377,7 +377,9 @@ function runTests() {
       });
     }
     c.files = c.files.concat(config.commonUnitTestPaths, testsToRun);
-    c.client.failOnConsoleError = true;
+    if (testsToRun.length < tooManyTestsToFix) {
+      c.client.failOnConsoleError = true;
+    }
   } else if (argv.integration) {
     c.files = c.files.concat(
         config.commonIntegrationTestPaths, config.integrationTestPaths);


### PR DESCRIPTION
With #15585, we started running tests related to a source file change during `gulp test --local-changes`. This is causing trouble on Travis when lots of tests end up being run for a given source file change.

See https://travis-ci.org/ampproject/amphtml/jobs/383837321

In this PR, we no longer fail tests with errors when more than a certain number of tests are run.

Follow up to #15585
