### PR TITLE
♻️ Move isSecureUrl into URL Service

### DIFF
--- a/build-system/eslint-rules/vsync.js
+++ b/build-system/eslint-rules/vsync.js
@@ -32,6 +32,15 @@ module.exports = function(context) {
         return;
       }
 
+      if (property.leadingComments) {
+        const ok = property.leadingComments.some(comment => {
+          return comment.value === 'OK';
+        });
+        if (ok) {
+          return;
+        }
+      }
+
       context.report({
         node,
         message: [

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -24,7 +24,6 @@ import {Services} from '../../../src/services';
 import {SignatureVerifier, VerificationStatus} from './signature-verifier';
 import {
   assertHttpsUrl,
-  isSecureUrl,
   tryDecodeUriComponent,
 } from '../../../src/url';
 import {cancellation, isCancellation} from '../../../src/error';
@@ -829,9 +828,11 @@ export class AmpA4A extends AMP.BaseElement {
           // Preload any fonts.
           (creativeMetaDataDef.customStylesheets || []).forEach(font =>
             this.preconnect.preload(font.href));
+
+          const urls = Services.urlForDoc(this.getAmpDoc());
           // Preload any AMP images.
           (creativeMetaDataDef.images || []).forEach(image =>
-            isSecureUrl(image) && this.preconnect.preload(image));
+            urls.isSecure(image) && this.preconnect.preload(image));
           return creativeMetaDataDef;
         })
         .catch(error => {
@@ -1656,10 +1657,12 @@ export class AmpA4A extends AMP.BaseElement {
         if (!isArray(metaData.customStylesheets)) {
           throw new Error(errorMsg);
         }
+
+        const urls = Services.urlForDoc(this.getAmpDoc());
         metaData.customStylesheets.forEach(stylesheet => {
           if (!isObject(stylesheet) || !stylesheet['href'] ||
               typeof stylesheet['href'] !== 'string' ||
-              !isSecureUrl(stylesheet['href'])) {
+              !urls.isSecure(stylesheet['href'])) {
             throw new Error(errorMsg);
           }
         });

--- a/extensions/amp-a4a/0.1/amp-ad-utils.js
+++ b/extensions/amp-a4a/0.1/amp-ad-utils.js
@@ -16,7 +16,7 @@
 import {Services} from '../../../src/services';
 import {dev} from '../../../src/log';
 import {isArray, isObject} from '../../../src/types';
-import {isSecureUrl} from '../../../src/url';
+import {isSecureUrlDeprecated} from '../../../src/url';
 import {parseJson} from '../../../src/json';
 
 const TAG = 'amp-ad-util';
@@ -108,7 +108,7 @@ export function getAmpAdMetadata(creative) {
       metaData.customStylesheets.forEach(stylesheet => {
         if (!isObject(stylesheet) || !stylesheet['href'] ||
             typeof stylesheet['href'] !== 'string' ||
-            !isSecureUrl(stylesheet['href'])) {
+            !isSecureUrlDeprecated(stylesheet['href'])) {
           throw new Error(errorMsg);
         }
       });

--- a/extensions/amp-a4a/0.1/real-time-config-manager.js
+++ b/extensions/amp-a4a/0.1/real-time-config-manager.js
@@ -20,7 +20,6 @@ import {dev, user} from '../../../src/log';
 import {getMode} from '../../../src/mode';
 import {isArray, isObject} from '../../../src/types';
 import {
-  isSecureUrl,
   parseUrlDeprecated,
 } from '../../../src/url';
 import {tryParseJson} from '../../../src/json';
@@ -93,7 +92,8 @@ function buildErrorResponse_(
  */
 export function sendErrorMessage(errorType, errorReportingUrl, win, ampDoc) {
   if (ERROR_REPORTING_ENABLED || getMode(win).localDev || getMode(win).test) {
-    if (!isSecureUrl(errorReportingUrl)) {
+    const urls = Services.urlForDoc(ampDoc);
+    if (!urls.isSecure(errorReportingUrl)) {
       dev().warn(TAG, `Insecure RTC errorReportingUrl: ${errorReportingUrl}`);
       return;
     }
@@ -227,7 +227,9 @@ export function inflateAndSendRtc_(a4aElement, url, seenUrls, promiseArray,
           RTC_ERROR_ENUM.MAX_CALLOUTS_EXCEEDED,
           callout, errorReportingUrl, win, ampDoc);
     }
-    if (!isSecureUrl(url)) {
+
+    const urls = Services.urlForDoc(ampDoc);
+    if (!urls.isSecure(url)) {
       return buildErrorResponse_(RTC_ERROR_ENUM.INSECURE_URL,
           callout, errorReportingUrl, win, ampDoc);
     }

--- a/extensions/amp-a4a/0.1/real-time-config-manager.js
+++ b/extensions/amp-a4a/0.1/real-time-config-manager.js
@@ -68,6 +68,7 @@ export const RTC_ERROR_ENUM = {
 /**
  * @param {string} error
  * @param {string} callout
+ * @param {string} errorReportingUrl
  * @param {!Window} win
  * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampDoc
  * @param {number=} opt_rtcTime
@@ -215,12 +216,11 @@ export function inflateAndSendRtc_(a4aElement, url, seenUrls, promiseArray,
   const ampDoc = a4aElement.getAmpDoc();
   const callout = opt_vendor || getCalloutParam_(url);
   const checkStillCurrent = a4aElement.verifyStillCurrent.bind(a4aElement)();
-  /**
-   * The time that it takes to substitute the macros into the URL can vary
-   * depending on what the url requires to be substituted, i.e. a long
-   * async call. Thus, however long the URL replacement took is treated as a
-   * time penalty.
-   */
+
+  // The time that it takes to substitute the macros into the URL can vary
+  // depending on what the url requires to be substituted, i.e. a long
+  // async call. Thus, however long the URL replacement took is treated as a
+  // time penalty.
   const send = url => {
     if (Object.keys(seenUrls).length == MAX_RTC_CALLOUTS) {
       return buildErrorResponse_(
@@ -281,6 +281,7 @@ export function truncUrl_(url) {
  * @param {string} callout
  * @param {!Function} checkStillCurrent
  * @param {string} errorReportingUrl
+ * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampDoc
  * @return {!Promise<!rtcResponseDef>}
  * @private
  */

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -1120,7 +1120,7 @@ describe('amp-a4a', () => {
         const a4aElement = createA4aElement(doc);
         const a4a = new MockA4AImpl(a4aElement);
         sandbox.stub(a4a, 'getAmpAdMetadata').callsFake(creative => {
-          const metaData = AmpA4A.prototype.getAmpAdMetadata(creative);
+          const metaData = AmpA4A.prototype.getAmpAdMetadata.call(a4a, creative);
           metaData.images = ['https://prefetch.me.com?a=b', 'http://do.not.prefetch.me.com?c=d',
             'https://prefetch.metoo.com?e=f'];
           return metaData;

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -1120,9 +1120,13 @@ describe('amp-a4a', () => {
         const a4aElement = createA4aElement(doc);
         const a4a = new MockA4AImpl(a4aElement);
         sandbox.stub(a4a, 'getAmpAdMetadata').callsFake(creative => {
-          const metaData = AmpA4A.prototype.getAmpAdMetadata.call(a4a, creative);
-          metaData.images = ['https://prefetch.me.com?a=b', 'http://do.not.prefetch.me.com?c=d',
-            'https://prefetch.metoo.com?e=f'];
+          const metaData = AmpA4A.prototype.getAmpAdMetadata.call(a4a,
+              creative);
+          metaData.images = [
+            'https://prefetch.me.com?a=b',
+            'http://do.not.prefetch.me.com?c=d',
+            'https://prefetch.metoo.com?e=f',
+          ];
           return metaData;
         });
         a4a.buildCallback();

--- a/extensions/amp-a4a/0.1/test/test-callout-vendors.js
+++ b/extensions/amp-a4a/0.1/test/test-callout-vendors.js
@@ -15,7 +15,7 @@
  */
 
 import {RTC_VENDORS} from '../callout-vendors';
-import {isSecureUrl} from '../../../../src/url';
+import {isSecureUrlDeprecated} from '../../../../src/url';
 
 // The keys of RTC_VENDORS are not allowed to have any capital letters.
 // This test acts as a presubmit to enforce that.
@@ -26,8 +26,8 @@ describe('RTC_VENDORS', () => {
     ));
   it('should all use https', () =>
     Object.keys(RTC_VENDORS).forEach(key => {
-      expect(isSecureUrl(RTC_VENDORS[key].url)).to.be.true;
-      expect(!RTC_VENDORS[key].errorReportingUrl ||
-           isSecureUrl(RTC_VENDORS[key].errorReportingUrl)).to.be.true;
+      expect(isSecureUrlDeprecated(RTC_VENDORS[key].url)).to.be.true;
+      expect(!RTC_VENDORS[key].errorReportingUrl || isSecureUrlDeprecated(
+          RTC_VENDORS[key].errorReportingUrl)).to.be.true;
     }));
 });

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -94,11 +94,11 @@ import {
   isInManualExperiment,
 } from '../../../ads/google/a4a/traffic-experiments';
 import {isObject} from '../../../src/types';
+import {isSecureUrlDeprecated, parseQueryString} from '../../../src/url';
 import {
   lineDelimitedStreamer,
   metaJsonCreativeGrouper,
 } from '../../../ads/google/a4a/line-delimited-response-handler';
-import {parseQueryString} from '../../../src/url';
 import {setStyles} from '../../../src/style';
 import {stringHash32} from '../../../src/string';
 import {tryParseJson} from '../../../src/json';
@@ -1064,10 +1064,9 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     if (!impressions) {
       return;
     }
-    const urls = Services.urlForDoc(this.getAmpDoc());
     impressions.split(',').forEach(url => {
       try {
-        if (!urls.isSecure(url)) {
+        if (!isSecureUrlDeprecated(url)) {
           dev().warn(TAG, `insecure impression url: ${url}`);
           return;
         }

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -94,11 +94,11 @@ import {
   isInManualExperiment,
 } from '../../../ads/google/a4a/traffic-experiments';
 import {isObject} from '../../../src/types';
-import {isSecureUrl, parseQueryString} from '../../../src/url';
 import {
   lineDelimitedStreamer,
   metaJsonCreativeGrouper,
 } from '../../../ads/google/a4a/line-delimited-response-handler';
+import {parseQueryString} from '../../../src/url';
 import {setStyles} from '../../../src/style';
 import {stringHash32} from '../../../src/string';
 import {tryParseJson} from '../../../src/json';
@@ -1064,9 +1064,10 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     if (!impressions) {
       return;
     }
+    const urls = Services.urlForDoc(this.getAmpDoc());
     impressions.split(',').forEach(url => {
       try {
-        if (!isSecureUrl(url)) {
+        if (!urls.isSecure(url)) {
           dev().warn(TAG, `insecure impression url: ${url}`);
           return;
         }

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -79,7 +79,7 @@ const realWinConfig = {
 };
 
 const realWinConfigAmpAd = {
-  amp: {ampdoc: 'amp-ad'},
+  amp: true,
   ampAdCss: true,
   allowExternalResources: true,
 };
@@ -1344,9 +1344,11 @@ describes.realWin('additional amp-ad-network-doubleclick-impl',
       let doc;
       let impl;
       let element;
+      let ampdoc;
 
       beforeEach(() => {
         doc = env.win.document;
+        ampdoc = env.ampdoc;
       });
 
       describe('#onNetworkFailure', () => {
@@ -1444,6 +1446,7 @@ describes.realWin('additional amp-ad-network-doubleclick-impl',
             'type': 'doubleclick',
           });
           impl = new AmpAdNetworkDoubleclickImpl(element);
+          sandbox.stub(impl, 'getAmpDoc').callsFake(() => ampdoc);
         });
 
         it('should handle null impressions', () => {

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -79,7 +79,7 @@ const realWinConfig = {
 };
 
 const realWinConfigAmpAd = {
-  amp: true,
+  amp: {ampdoc: 'amp-ad'},
   ampAdCss: true,
   allowExternalResources: true,
 };
@@ -1344,11 +1344,9 @@ describes.realWin('additional amp-ad-network-doubleclick-impl',
       let doc;
       let impl;
       let element;
-      let ampdoc;
 
       beforeEach(() => {
         doc = env.win.document;
-        ampdoc = env.ampdoc;
       });
 
       describe('#onNetworkFailure', () => {
@@ -1446,7 +1444,6 @@ describes.realWin('additional amp-ad-network-doubleclick-impl',
             'type': 'doubleclick',
           });
           impl = new AmpAdNetworkDoubleclickImpl(element);
-          sandbox.stub(impl, 'getAmpDoc').callsFake(() => ampdoc);
         });
 
         it('should handle null impressions', () => {

--- a/extensions/amp-analytics/0.1/test/test-vendors.js
+++ b/extensions/amp-analytics/0.1/test/test-vendors.js
@@ -16,7 +16,7 @@
 
 import {ANALYTICS_CONFIG} from '../vendors';
 import {ANALYTICS_IFRAME_TRANSPORT_CONFIG} from '../iframe-transport-vendors';
-import {isSecureUrl} from '../../../../src/url';
+import {isSecureUrlDeprecated} from '../../../../src/url';
 
 describe('analytics vendors', () => {
   it('googleanalytics & googleanalytics-alpha should be identical', () => {
@@ -33,7 +33,7 @@ describe('analytics vendors', () => {
       expect(vendorITEntry.transport).to.exist;
       expect(Object.keys(vendorITEntry.transport).length).to.equal(1);
       expect(vendorITEntry.transport.iframe).to.exist;
-      expect(isSecureUrl(vendorITEntry.transport.iframe)).to.be.true;
+      expect(isSecureUrlDeprecated(vendorITEntry.transport.iframe)).to.be.true;
     }
   });
 

--- a/extensions/amp-iframe/0.1/amp-iframe.js
+++ b/extensions/amp-iframe/0.1/amp-iframe.js
@@ -121,12 +121,6 @@ export class AmpIframe extends AMP.BaseElement {
      * @private {?string}
      */
     this.targetOrigin_ = null;
-
-    /**
-     * @return {!../../../src/service/url-impl.Url}
-     * @private
-     */
-    this.getUrlService_ = once(() => Services.urlForDoc(this.element));
   }
 
   /** @override */
@@ -143,14 +137,14 @@ export class AmpIframe extends AMP.BaseElement {
    */
   assertSource_(src, containerSrc, sandbox = '') {
     const {element} = this;
-    const urlService = this.getUrlService_();
+    const urlService = Services.urlForDoc(this.element);
     const url = urlService.parse(src);
     const {hostname, protocol, origin} = url;
     // Some of these can be easily circumvented with redirects.
     // Checks are mostly there to prevent people easily do something
     // they did not mean to.
     user().assert(
-        urlService.isSecureUrl(url) || protocol == 'data:',
+        urlService.isSecure(src) || protocol == 'data:',
         'Invalid <amp-iframe> src. Must start with https://. Found %s',
         element);
     const containerUrl = urlService.parse(containerSrc);
@@ -206,7 +200,7 @@ export class AmpIframe extends AMP.BaseElement {
     if (!src) {
       return;
     }
-    const {protocol, hash} = this.getUrlService_().parse(src);
+    const {protocol, hash} = Services.urlForDoc(this.element).parse(src);
     // data-URLs are not modified.
     if (protocol == 'data:') {
       return src;

--- a/extensions/amp-iframe/0.1/amp-iframe.js
+++ b/extensions/amp-iframe/0.1/amp-iframe.js
@@ -30,7 +30,6 @@ import {isExperimentOn} from '../../../src/experiments';
 import {isLayoutSizeDefined} from '../../../src/layout';
 import {listenFor} from '../../../src/iframe-helper';
 import {moveLayoutRect} from '../../../src/layout-rect';
-import {once} from '../../../src/utils/function';
 import {parseJson} from '../../../src/json';
 import {removeFragment} from '../../../src/url';
 import {setStyle} from '../../../src/style';

--- a/extensions/amp-install-serviceworker/0.1/amp-install-serviceworker.js
+++ b/extensions/amp-install-serviceworker/0.1/amp-install-serviceworker.js
@@ -157,7 +157,7 @@ export class AmpInstallServiceWorker extends AMP.BaseElement {
     this.urlRewriter_ = new UrlRewriter_(ampdoc, urlMatchExpr, shellUrl);
 
     // Cache shell.
-    if (urlService.isSecureUrl(shellUrl)) {
+    if (urlService.isSecure(shellUrl)) {
       this.waitToPreloadShell_(shellUrl);
     }
   }

--- a/extensions/amp-install-serviceworker/0.1/test/test-amp-install-serviceworker.js
+++ b/extensions/amp-install-serviceworker/0.1/test/test-amp-install-serviceworker.js
@@ -20,7 +20,7 @@ import {
   assertHttpsUrl,
   getSourceOrigin,
   isProxyOrigin,
-  isSecureUrl,
+  isSecureUrlDeprecated,
   parseUrlDeprecated,
 } from '../../../../src/url';
 import {loadPromise} from '../../../../src/event-helper';
@@ -36,7 +36,7 @@ function stubUrlService(sandbox) {
     assertHttpsUrl,
     getSourceOrigin,
     isProxyOrigin,
-    isSecureUrl,
+    isSecure: isSecureUrlDeprecated,
     parse: parseUrlDeprecated,
   });
 }

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -198,7 +198,7 @@ export class Resources {
     this.viewport_ = Services.viewportForDoc(this.ampdoc);
 
     /** @private @const {!./vsync-impl.Vsync} */
-    this.vsync_ = Services.vsyncFor(this.win);
+    this.vsync_ = Services./*OK*/vsyncFor(this.win);
 
     /** @private @const {!FocusHistory} */
     this.activeHistory_ = new FocusHistory(this.win, FOCUS_HISTORY_TIMEOUT_);

--- a/src/service/url-impl.js
+++ b/src/service/url-impl.js
@@ -21,7 +21,7 @@ import {
   getSourceOrigin,
   isProtocolValid,
   isProxyOrigin,
-  isSecureUrl,
+  isSecureUrlDeprecated,
   parseUrlWithA,
 } from '../url';
 import {
@@ -91,14 +91,6 @@ export class Url {
   }
 
   /**
-   * @param {string|!Location} url
-   * @return {boolean}
-   */
-  isSecureUrl(url) {
-    return isSecureUrl(url);
-  }
-
-  /**
    * Asserts that a given url is HTTPS or protocol relative. It's a user-level
    * assert.
    *
@@ -129,6 +121,16 @@ export class Url {
    */
   isProxyOrigin(url) {
     return isProxyOrigin(url);
+  }
+
+  /*
+   * Returns `true` if the URL is secure: either HTTPS or localhost (for
+   * testing).
+   * @param {string} url
+   * @return {boolean}
+   */
+  isSecure(url) {
+    return isSecureUrlDeprecated(this.parse(url));
   }
 }
 

--- a/src/url.js
+++ b/src/url.js
@@ -247,7 +247,7 @@ export function serializeQueryString(params) {
  * @param {string|!Location} url
  * @return {boolean}
  */
-export function isSecureUrl(url) {
+export function isSecureUrlDeprecated(url) {
   if (typeof url == 'string') {
     url = parseUrlDeprecated(url);
   }
@@ -273,7 +273,7 @@ export function assertHttpsUrl(
       elementContext, sourceName);
   // (erwinm, #4560): type cast necessary until #4560 is fixed.
   const theUrlString = /** @type {string} */ (urlString);
-  user().assert(isSecureUrl(theUrlString) || /^(\/\/)/.test(theUrlString),
+  user().assert(isSecureUrlDeprecated(theUrlString) || /^(\/\/)/.test(theUrlString),
       '%s %s must start with ' +
       '"https://" or "//" or be relative and served from ' +
       'either https or from localhost. Invalid value: %s',

--- a/test/functional/test-url.js
+++ b/test/functional/test-url.js
@@ -26,7 +26,7 @@ import {
   isLocalhostOrigin,
   isProtocolValid,
   isProxyOrigin,
-  isSecureUrl,
+  isSecureUrlDeprecated,
   parseQueryString,
   parseUrlDeprecated,
   removeFragment,
@@ -337,34 +337,34 @@ describe('assertHttpsUrl/isSecureUrl', () => {
   });
   it('should allow https', () => {
     assertHttpsUrl('https://twitter.com', referenceElement);
-    expect(isSecureUrl('https://twitter.com')).to.be.true;
+    expect(isSecureUrlDeprecated('https://twitter.com')).to.be.true;
   });
   it('should allow protocol relative', () => {
     assertHttpsUrl('//twitter.com', referenceElement);
     // `isSecureUrl` always resolves relative URLs.
-    expect(isSecureUrl('//twitter.com'))
+    expect(isSecureUrlDeprecated('//twitter.com'))
         .to.be.equal(window.location.protocol == 'https:');
   });
   it('should allow localhost with http', () => {
     assertHttpsUrl('http://localhost:8000/sfasd', referenceElement);
-    expect(isSecureUrl('http://localhost:8000/sfasd')).to.be.true;
+    expect(isSecureUrlDeprecated('http://localhost:8000/sfasd')).to.be.true;
   });
   it('should allow localhost with http suffix', () => {
     assertHttpsUrl('http://iframe.localhost:8000/sfasd', referenceElement);
-    expect(isSecureUrl('http://iframe.localhost:8000/sfasd')).to.be.true;
+    expect(isSecureUrlDeprecated('http://iframe.localhost:8000/sfasd')).to.be.true;
   });
 
   it('should fail on http', () => {
     allowConsoleError(() => { expect(() => {
       assertHttpsUrl('http://twitter.com', referenceElement);
     }).to.throw(/source must start with/); });
-    expect(isSecureUrl('http://twitter.com')).to.be.false;
+    expect(isSecureUrlDeprecated('http://twitter.com')).to.be.false;
   });
   it('should fail on http with localhost in the name', () => {
     allowConsoleError(() => { expect(() => {
       assertHttpsUrl('http://foolocalhost', referenceElement);
     }).to.throw(/source must start with/); });
-    expect(isSecureUrl('http://foolocalhost')).to.be.false;
+    expect(isSecureUrlDeprecated('http://foolocalhost')).to.be.false;
   });
 });
 


### PR DESCRIPTION
This deprecates direct usage of the helper. The only remaining usage is
A4A's `extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js`, which has too many test changes necessary to support an ampdoc.

Builds on #15414.

/cc @bradfrizzell 