### PR TITLE
🐛  Exempt Validator's `dist` and `node_modules` dirs from lint

### DIFF
--- a/build-system/config.js
+++ b/build-system/config.js
@@ -125,7 +125,9 @@ module.exports = {
     '!{node_modules,build,dist,dist.3p,dist.tools,' +
         'third_party}/**/*.*',
     '!examples/**/*.*',
-    '!{validator/dist,validator/node_modules,validator/nodejs/node_modules}',
+    '!{validator/dist,validator/webui/dist,' +
+        'validator/node_modules,validator/nodejs/node_modules,' +
+        'validator/webui/node_modules}/**/*.*',
     '!eslint-rules/**/*.*',
     '!karma.conf.js',
     '!**/local-amp-chrome-extension/background.js',


### PR DESCRIPTION
This is an old bug, that got exposed by #15602
