### PR TITLE
✨🏗 Add `expectAsyncConsoleError`, which enables tests to check for async errors

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -33,8 +33,7 @@
     "global": false,
     "describes": true,
     "allowConsoleError": false,
-    "dontWarnForConsoleError": false,
-    "warnForConsoleError": false
+    "expectAsyncConsoleError": false
   },
   "settings": {
     "jsdoc": {

--- a/test/_init_tests.js
+++ b/test/_init_tests.js
@@ -45,6 +45,7 @@ let consoleErrorSandbox;
 let consoleErrorStub;
 let consoleInfoLogWarnSandbox;
 let testName;
+let expectedAsyncErrors;
 
 // Used to clean up global state between tests.
 let initialGlobalState;
@@ -52,8 +53,6 @@ let initialWindowState;
 
 // All exposed describes.
 global.describes = describes;
-global.dontWarnForConsoleError = dontWarnForConsoleError;
-global.warnForConsoleError = warnForConsoleError;
 
 // Increase the before/after each timeout since certain times they have timedout
 // during the normal 2000 allowance.
@@ -279,25 +278,46 @@ function warnForConsoleError() {
   if (consoleErrorSandbox) {
     consoleErrorSandbox.restore();
   }
+  expectedAsyncErrors = [];
   consoleErrorSandbox = sinon.sandbox.create();
   const originalConsoleError = console/*OK*/.error;
   consoleErrorSandbox.stub(console, 'error').callsFake((...messages) => {
-    const errorMessage = messages.join(' ').split('\n', 1)[0]; // First line.
-    const helpMessage = '    The test "' + testName + '"' +
-        ' resulted in a call to console.error.\n' +
-        '    ⤷ If this is not expected, fix the code that generated ' +
-            'the error.\n' +
-        '    ⤷ If this is expected, use the following pattern to wrap the ' +
-            'test code that generated the error:\n' +
-        '        \'allowConsoleError(() => { <code that generated the ' +
-            'error> });';
-    // TODO(rsimha, #14406): Simply throw here after all tests are fixed.
-    if (window.__karma__.config.failOnConsoleError) {
-      throw new Error(errorMessage + '\'\n' + helpMessage);
+    const message = messages.join(' ');
+    if (expectedAsyncErrors.includes(message)) {
+      expectedAsyncErrors.splice(expectedAsyncErrors.indexOf(message), 1);
+      return;
     } else {
-      originalConsoleError(errorMessage + '\'\n' + helpMessage);
+      // We're throwing an error. Clean up other expected errors since they will
+      // never appear.
+      expectedAsyncErrors = [];
+    }
+    const errorMessage = message.split('\n', 1)[0]; // First line.
+    const {failOnConsoleError} = window.__karma__.config;
+    const terminator = failOnConsoleError ? '\'' : '';
+    const separator = failOnConsoleError ? '\n' : '\'\n';
+    const helpMessage = '    The test "' + testName + '"' +
+        ' resulted in a call to console.error. (See above line.)\n' +
+        '    ⤷ If the error is not expected, fix the code that generated ' +
+            'the error.\n' +
+        '    ⤷ If the error is expected (and synchronous), use the following ' +
+            'pattern to wrap the test code that generated the error:\n' +
+        '        \'allowConsoleError(() => { <code that generated the ' +
+            'error> });\'\n' +
+        '    ⤷ If the error is expected (and asynchronous), use the ' +
+            'following pattern at the top of the test:\n' +
+        '        \'expectAsyncConsoleError(<error text>);' + terminator;
+    // TODO(rsimha, #14406): Simply throw here after all tests are fixed.
+    if (failOnConsoleError) {
+      throw new Error(errorMessage + separator + helpMessage);
+    } else {
+      originalConsoleError(errorMessage + separator + helpMessage);
     }
   });
+  this.expectAsyncConsoleError = function(message) {
+    if (!expectedAsyncErrors.includes(message)) {
+      expectedAsyncErrors.push(message);
+    }
+  };
   this.allowConsoleError = function(func) {
     dontWarnForConsoleError();
     const result = func();
@@ -327,6 +347,14 @@ function dontWarnForConsoleError() {
 // Used to restore error level logging after each test.
 function restoreConsoleError() {
   consoleErrorSandbox.restore();
+  if (expectedAsyncErrors.length > 0) {
+    const helpMessage =
+        'The test "' + testName + '" called "expectAsyncConsoleError", ' +
+        'but there were no call(s) to console.error with these message(s): ' +
+        '"' + expectedAsyncErrors.join('", "') + '"';
+    throw new Error(helpMessage);
+  }
+  expectedAsyncErrors = [];
 }
 
 // Used to silence info, log, and warn level logging during each test.


### PR DESCRIPTION
The `allowConsoleError` construct lets you capture synchronous calls to `console.error` in tests, and indicate that they are expected and shouldn't fail a test. However, when test code results in asynchronous errors, there's no good way to use `allowConsoleError` as written today.

This PR does the following:
- Introduces a new construct called `expectAsyncConsoleError`, which lets you specify that a given asynchronous `console.error` is expected at some point during the test.
    - When the error eventually appears in the test, it is ignored.
    - If the expected error doesn't appear by the time the test completed, an error is thrown.
- Adds an `expectAsyncConsoleError` annotation to all tests in `extensions/amp-analytics/0.1/test/test-amp-analytics.js` that were resulting in async errors
- Undoes the temporary workaround added by #15606

Fixes #15609
Required for #14406