### PR TITLE
🐛 Toggle amp-story-v1 instead of amp-story

### DIFF
--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -742,7 +742,7 @@ export class AmpStory extends AMP.BaseElement {
         .getLocalizedString(
             LocalizedStringId.AMP_STORY_EXPERIMENT_ENABLE_BUTTON_LABEL);
     experimentsLinkEl.addEventListener('click', () => {
-      toggleExperiment(this.win, 'amp-story', true);
+      toggleExperiment(this.win, 'amp-story-v1', true);
       errorIconEl.classList.remove('i-amphtml-story-experiment-icon-error');
       errorIconEl.classList.add('i-amphtml-story-experiment-icon-done');
       errorMsgEl.textContent = this.localizationService_.getLocalizedString(


### PR DESCRIPTION
#15593 makes amp-story 1.0 read the `amp-story-v1` experiment instead of `amp-story`, but it still writes the `amp-story` experiment.  This PR fixes that.