### PR TITLE
🐛Ad refresh:  relayout ad only when doc is visible

### DIFF
--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -959,8 +959,11 @@ export class AmpA4A extends AMP.BaseElement {
         return Services.timerFor(this.win).promise(1000).then(() => {
           this.isRelayoutNeededFlag = true;
           this.getResource().layoutCanceled();
-          Services.resourcesForDoc(this.getAmpDoc())
-              ./*OK*/requireLayout(this.element);
+          // Only Require relayout after page visible
+          Services.viewerForDoc(this.getAmpDoc()).whenNextVisible().then(() => {
+            Services.resourcesForDoc(this.getAmpDoc())
+                ./*OK*/requireLayout(this.element);
+          });
         });
       });
     });

--- a/test/functional/test-xhr.js
+++ b/test/functional/test-xhr.js
@@ -24,6 +24,7 @@ import {
 import {FormDataWrapper} from '../../src/form-data-wrapper';
 import {Services} from '../../src/services';
 import {getCookie} from '../../src/cookies';
+import {user} from '../../src/log';
 import {utf8FromArrayBuffer} from '../../extensions/amp-a4a/0.1/amp-a4a';
 
 // TODO(jridgewell, #11827): Make this test work on Safari.
@@ -381,6 +382,7 @@ describe.configure().skipSafari().run('XHR', function() {
       });
 
       it('should do simple JSON fetch', () => {
+        sandbox.stub(user(), 'assert');
         return xhr.fetchJson('http://localhost:31862/get?k=v1')
             .then(res => res.json())
             .then(res => {


### PR DESCRIPTION
Fix #15502 

As discussed offline. Attempt to relayout an ad will fail when document is not visible. This is ok for regular ads, because after unlaid out, runtime will handle layout again after document becomes visible again. But it breaks auto refresh ad that's wrapped in container. 

Delay relayout until document is visible. 

cc @keithwrightbos @lannka 