### PR TITLE
Only ship "faster amp list" in canary

### DIFF
--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -37,6 +37,7 @@
   "amp-live-list-sorting": 1,
   "amp-sidebar toolbar": 1,
   "svg-in-mustache": 0,
+  "disable-faster-amp-list": 1,
   "a4a-safeframe-preloading-off": 0.01,
   "expUnconditionedAdxIdentity": 0.01,
   "expUnconditionedDfpIdentity": 0.01,


### PR DESCRIPTION
Context: https://github.com/ampproject/amphtml/pull/15613#issuecomment-392955670

I'll add an expected error to see how often this could break pages before launching to prod.

/to @aghassemi /cc @ericlindley-g 