### PR TITLE
Enable logging with verbose flag

### DIFF
--- a/build-system/tasks/karma.conf.js
+++ b/build-system/tasks/karma.conf.js
@@ -208,6 +208,7 @@ module.exports = {
     failOnConsoleError: !process.env.TRAVIS && !process.env.LOCAL_PR_CHECK,
     // TODO(rsimha, #14432): Set to false after all tests are fixed.
     captureConsole: true,
+    debugConsole: false,
   },
 
   singleRun: true,

--- a/build-system/tasks/karma.conf.js
+++ b/build-system/tasks/karma.conf.js
@@ -208,7 +208,7 @@ module.exports = {
     failOnConsoleError: !process.env.TRAVIS && !process.env.LOCAL_PR_CHECK,
     // TODO(rsimha, #14432): Set to false after all tests are fixed.
     captureConsole: true,
-    debugConsole: false,
+    verboseLogging: false,
   },
 
   singleRun: true,

--- a/build-system/tasks/runtime-test.js
+++ b/build-system/tasks/runtime-test.js
@@ -347,7 +347,7 @@ function runTests() {
 
   if (argv.verbose || argv.v) {
     c.client.captureConsole = true;
-    c.client.debugConsole = true;
+    c.client.verboseLogging = true;
   }
 
   if (!process.env.TRAVIS && (argv.testnames || argv['local-changes'])) {

--- a/build-system/tasks/runtime-test.js
+++ b/build-system/tasks/runtime-test.js
@@ -347,6 +347,7 @@ function runTests() {
 
   if (argv.verbose || argv.v) {
     c.client.captureConsole = true;
+    c.client.debugConsole = true;
   }
 
   if (!process.env.TRAVIS && (argv.testnames || argv['local-changes'])) {

--- a/test/_init_tests.js
+++ b/test/_init_tests.js
@@ -363,6 +363,10 @@ function stubConsoleInfoLogWarn() {
     consoleInfoLogWarnSandbox.restore();
   }
   consoleInfoLogWarnSandbox = sinon.sandbox.create();
+  const {debugConsole} = window.__karma__.config;
+  if (debugConsole) {
+    return;
+  }
   consoleInfoLogWarnSandbox.stub(console, 'info').callsFake(() => {});
   consoleInfoLogWarnSandbox.stub(console, 'log').callsFake(() => {});
   consoleInfoLogWarnSandbox.stub(console, 'warn').callsFake(() => {});

--- a/test/_init_tests.js
+++ b/test/_init_tests.js
@@ -363,10 +363,6 @@ function stubConsoleInfoLogWarn() {
     consoleInfoLogWarnSandbox.restore();
   }
   consoleInfoLogWarnSandbox = sinon.sandbox.create();
-  const {debugConsole} = window.__karma__.config;
-  if (debugConsole) {
-    return;
-  }
   consoleInfoLogWarnSandbox.stub(console, 'info').callsFake(() => {});
   consoleInfoLogWarnSandbox.stub(console, 'log').callsFake(() => {});
   consoleInfoLogWarnSandbox.stub(console, 'warn').callsFake(() => {});
@@ -381,7 +377,10 @@ beforeEach(function() {
   this.timeout(BEFORE_AFTER_TIMEOUT);
   beforeTest();
   testName = this.currentTest.fullTitle();
-  stubConsoleInfoLogWarn();
+  const {verboseLogging} = window.__karma__.config;
+  if (!verboseLogging) {
+    stubConsoleInfoLogWarn();
+  }
   warnForConsoleError();
   initialGlobalState = Object.keys(global);
   initialWindowState = Object.keys(window);


### PR DESCRIPTION
This fixes the logging to terminal feature as well as enables logging to the browser console. 
I believe the documentation for -verbose is sufficient already. 

Adding `-verbose` could lead to failure to throw test errors if there's `console.log/warn/info` involved, but I think that's really minor. 

I am also open to create a `-debug` flag and separate the log to terminal vs log to console feature. 