### PR TITLE
🐛Fix date picker hanging when manually editing year

### DIFF
--- a/extensions/amp-date-picker/0.1/amp-date-picker.js
+++ b/extensions/amp-date-picker/0.1/amp-date-picker.js
@@ -176,6 +176,8 @@ const INFO_TEMPLATE_AREA_CSS = 'i-amphtml-date-picker-info';
 
 const FULLSCREEN_CSS = 'i-amphtml-date-picker-fullscreen';
 
+const MIN_PICKER_YEAR = 1900;
+
 export class AmpDatePicker extends AMP.BaseElement {
   /** @param {!AmpElement} element */
   constructor(element) {
@@ -759,8 +761,10 @@ export class AmpDatePicker extends AMP.BaseElement {
           (target === this.startDateField_ ? 'startDate' :
             (target === this.endDateField_ ? 'endDate' : '')));
     const moment = this.createMoment_(target.value);
-    const value = moment.isValid() ? moment : null;
-    this.setState_({[property]: value});
+    const isValid = (moment &&
+        moment.isValid() &&
+        moment.year() > MIN_PICKER_YEAR);
+    this.setState_({[property]: isValid ? moment : null});
   }
 
   /**

--- a/third_party/moment/moment.extern.js
+++ b/third_party/moment/moment.extern.js
@@ -73,6 +73,11 @@ moment.prototype.startOf = function(unit) {};
 moment.prototype.add = function(amount, unit) {};
 
 /**
+ * @return {number}
+ */
+moment.prototype.year = function() {};
+
+/**
  * @struct
  * @constructor
  */


### PR DESCRIPTION
The date picker currently hangs if you chang the date in the text box from "05/05/2018" to "05/05/201". This PR resolves that issue by preventing the widget from attempting to render thousands of dates in the past. Once the root cause for the poor perfomance is found, this restriction can be lifted. I expect this will improve the experience for the vast majority of use-cases, while negatively impacting very few.

The user may still manually click month after month to select a date in the distant past beyond 1900, or may type a date in the distant past beyond 1900. If the user types the date beyond 1900 they will not see it reflected in the picker.