### PR TITLE
amp-consent: workaround to safari 10 set style bug

### DIFF
--- a/extensions/amp-consent/0.1/amp-consent.js
+++ b/extensions/amp-consent/0.1/amp-consent.js
@@ -264,7 +264,10 @@ export class AmpConsent extends AMP.BaseElement {
         dev().error(TAG,
             `${this.currentDisplayInstance_} no consent ui to hide`);
       }
-      toggle(uiToHide, false);
+      // Cannot use #toggle() because Safari bug with version older than 10.3
+      // element.style['display] = 'none' cannot overwrite style set with
+      // !important.
+      setImportantStyles(dev().assertElement(uiToHide), {display: 'none'});
     });
     if (this.dialogResolver_[this.currentDisplayInstance_]) {
       this.dialogResolver_[this.currentDisplayInstance_]();
@@ -615,7 +618,11 @@ export class AmpConsent extends AMP.BaseElement {
           classList.remove('amp-active');
         }
         this.getViewport().removeFromFixedLayer(this.element);
-        toggle(dev().assertElement(this.postPromptUI_), false);
+        // Cannot use #toggle() because Safari bug with version older than 10.3
+        // element.style['display] = 'none' cannot overwrite style set with
+        // !important.
+        setImportantStyles(dev().assertElement(this.postPromptUI_),
+            {display: 'none'});
       });
     });
   }


### PR DESCRIPTION
Fix #15636 

Set style doesn't work as expected in Safari. If an element style was set with inline css `display: block !important`. Setting its style by 
`element.style['display'] = 'none'` won't be able to override its previous 'block' value. 

This was fixed after version 10.3

