### PR TITLE
Re-enable svg-in-mustache in canary

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -37,7 +37,7 @@
   "amp-animation": 1,
   "amp-live-list-sorting": 1,
   "amp-sidebar toolbar": 1,
-  "svg-in-mustache": 0,
+  "svg-in-mustache": 1,
   "a4a-safeframe-preloading-off": 0.01,
   "expUnconditionedAdxIdentity": 0.01,
   "expUnconditionedDfpIdentity": 0.01,


### PR DESCRIPTION
Re-enable now that #15649 is merged. Will try to run this through more visual tests before enabling in prod.

/to @aghassemi 