### PR TITLE
Bump bundle size to fix master

### DIFF
--- a/build-system/tasks/bundle-size.js
+++ b/build-system/tasks/bundle-size.js
@@ -22,7 +22,7 @@ const log = require('fancy-log');
 const {getStdout} = require('../exec');
 
 const runtimeFile = './dist/v0.js';
-const maxSize = '77.2KB';
+const maxSize = '77.3KB';
 
 const {green, red, cyan, yellow} = colors;
 


### PR DESCRIPTION
Latest master failure bundle size is 77.21 KB. Bumping to 77.3 KB to fix master. 