### PR TITLE
♻️ Remove `src/url` requirement from amp-video and VideoManager

### DIFF
--- a/extensions/amp-audio/0.1/amp-audio.js
+++ b/extensions/amp-audio/0.1/amp-audio.js
@@ -201,11 +201,7 @@ export class AmpAudio extends AMP.BaseElement {
 
     // Update the media session
     setMediaSession(
-        this.getAmpDoc().win,
-        this.metadata_,
-        playHandler,
-        pauseHandler
-    );
+        this.getAmpDoc(), this.metadata_, playHandler, pauseHandler);
   }
 }
 

--- a/extensions/amp-audio/0.1/amp-audio.js
+++ b/extensions/amp-audio/0.1/amp-audio.js
@@ -171,7 +171,8 @@ export class AmpAudio extends AMP.BaseElement {
 
   /**
    * Sets whether the audio is playing or not.
-   * @VisibleForTesting
+   * @param {boolean} isPlaying
+   * @private
    */
   setPlayingStateForTesting_(isPlaying) {
     if (getMode().test) {
@@ -182,13 +183,13 @@ export class AmpAudio extends AMP.BaseElement {
   /**
    * Returns whether `<amp-audio>` has an `<amp-story>` for an ancestor.
    * @return {?Element}
-   * @VisibleForTesting
+   * @private
    */
   isStoryDescendant_() {
     return closestByTag(this.element, 'AMP-STORY');
   }
 
-
+  /** @private */
   audioPlaying_() {
     const playHandler = () => {
       this.audio_.play();

--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -541,12 +541,7 @@ class VideoEntry {
         this.video.pause();
       };
       // Update the media session
-      setMediaSession(
-          this.ampdoc_.win,
-          this.metadata_,
-          playHandler,
-          pauseHandler
-      );
+      setMediaSession(this.ampdoc_, this.metadata_, playHandler, pauseHandler);
     }
 
     this.actionSessionManager_.beginSession();

--- a/test/functional/test-mediasession-helper.js
+++ b/test/functional/test-mediasession-helper.js
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import {Services} from '../../src/services';
+import {isProtocolValid} from '../../src/url';
 import {
   parseFavicon,
   parseOgImage,
@@ -62,6 +64,11 @@ describes.sandboxed('MediaSessionAPI Helper Functions', {}, () => {
   let head;
 
   beforeEach(() => {
+    // Stub only to work around the fact that there's no Ampdoc, so the service
+    // cannot be retrieved.
+    // Otherwise this test would barf because `form` is detached.
+    sandbox.stub(Services, 'urlForDoc').returns({isProtocolValid});
+
     head = document.querySelector('head');
     // Favicon
     favicon = document.createElement('link');
@@ -131,7 +138,7 @@ describes.sandboxed('MediaSessionAPI Helper Functions', {}, () => {
       ],
       'title': 'Some title',
     };
-    setMediaSession(ampdoc.win, fakeMetaData);
+    setMediaSession(ampdoc, fakeMetaData);
     const newMetaData = ampdoc.win.navigator.mediaSession.metadata;
     expect(newMetaData).to.deep.equal(fakeMetaData);
   });
@@ -147,7 +154,7 @@ describes.sandboxed('MediaSessionAPI Helper Functions', {}, () => {
       'title': '',
     };
     allowConsoleError(() => {
-      expect(() => {setMediaSession(ampdoc.win, fakeMetaData);}).to.throw();
+      expect(() => {setMediaSession(ampdoc, fakeMetaData);}).to.throw();
     });
   });
 
@@ -162,7 +169,7 @@ describes.sandboxed('MediaSessionAPI Helper Functions', {}, () => {
       'title': '',
     };
     allowConsoleError(() => {
-      expect(() => {setMediaSession(ampdoc.win, fakeMetaData);}).to.throw();
+      expect(() => {setMediaSession(ampdoc, fakeMetaData);}).to.throw();
     });
   });
 
@@ -174,7 +181,7 @@ describes.sandboxed('MediaSessionAPI Helper Functions', {}, () => {
       'title': '',
     };
     allowConsoleError(() => {
-      expect(() => {setMediaSession(ampdoc.win, fakeMetaData);}).to.throw();
+      expect(() => {setMediaSession(ampdoc, fakeMetaData);}).to.throw();
     });
   });
 });


### PR DESCRIPTION
`amp-video-0.1.js`
Size before: `50345` (before gzip)
Size after: `48467` (before gzip)

Should also have a reduced size impact on most other `VideoInterface` extensions.