### PR TITLE
Fix AMP.navigateTo()

### DIFF
--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -156,7 +156,7 @@ export class ActionInvocation {
    * @param {string} method Name of the action being invoked.
    * @param {?JsonObject} args Named action arguments.
    * @param {?Element} source Element that generated the `event`.
-   * @param {?Element} caller Element that contains the invoked handler.
+   * @param {?Element} caller Element containing the on="..." action handler.
    * @param {?ActionEventDef} event The event that triggered this action.
    * @param {ActionTrust} trust The trust level of this invocation's trigger.
    * @param {?string} tagOrTarget The global target name or the element tagName.
@@ -517,7 +517,6 @@ export class ActionService {
    * @param {!ActionInvocation} invocation
    * @return {?Promise}
    * @private
-   * @visibleForTesting
    */
   invoke_(invocation) {
     const {method, tagOrTarget} = invocation;
@@ -955,7 +954,7 @@ export function dereferenceExprsInArgs(args, event) {
  * @param {!Element} context
  * @param {?T} condition
  * @param {string=} opt_message
- * @return T
+ * @return {T}
  * @template T
  * @private
  */

--- a/src/service/standard-actions-impl.js
+++ b/src/service/standard-actions-impl.js
@@ -100,7 +100,7 @@ export class StandardActions {
     if (!invocation.satisfiesTrust(ActionTrust.HIGH)) {
       return null;
     }
-    const {node, method, args} = invocation;
+    const {node, caller, method, args} = invocation;
     const win = (node.ownerDocument || node).defaultView;
     switch (method) {
       case 'pushState':
@@ -113,8 +113,8 @@ export class StandardActions {
       case 'navigateTo':
         // Some components have additional constraints on allowing navigation.
         let permission = Promise.resolve();
-        if (startsWith(node.tagName, 'AMP-')) {
-          permission = node.getImpl().then(impl => {
+        if (startsWith(caller.tagName, 'AMP-')) {
+          permission = caller.getImpl().then(impl => {
             if (typeof impl.throwIfCannotNavigate == 'function') {
               impl.throwIfCannotNavigate();
             }

--- a/test/functional/test-standard-actions.js
+++ b/test/functional/test-standard-actions.js
@@ -232,7 +232,7 @@ describes.sandboxed('StandardActions', {}, () => {
         invocation.args = {
           url: 'http://bar.com',
         };
-        invocation.node.tagName = 'DIV';
+        invocation.caller = {tagName: 'DIV'};
       });
 
       it('should be implemented', () => {
@@ -251,8 +251,8 @@ describes.sandboxed('StandardActions', {}, () => {
       });
 
       it('should pass if node does not have throwIfCannotNavigate()', () => {
-        invocation.node.tagName = 'AMP-FOO';
-        invocation.node.getImpl = () => Promise.resolve({});
+        invocation.caller.tagName = 'AMP-FOO';
+        invocation.caller.getImpl = () => Promise.resolve({});
 
         return standardActions.handleAmpTarget(invocation).then(() => {
           expect(navigator.navigateTo).to.be.calledOnce;
@@ -264,17 +264,17 @@ describes.sandboxed('StandardActions', {}, () => {
       it('should check throwIfCannotNavigate() for AMP elements', function*() {
         const userError = sandbox.stub(user(), 'error');
 
-        invocation.node.tagName = 'AMP-FOO';
+        invocation.caller.tagName = 'AMP-FOO';
 
         // Should succeed if throwIfCannotNavigate() is not implemented.
-        invocation.node.getImpl = () => Promise.resolve({});
+        invocation.caller.getImpl = () => Promise.resolve({});
         yield standardActions.handleAmpTarget(invocation);
         expect(navigator.navigateTo).to.be.calledOnce;
         expect(navigator.navigateTo).to.be.calledWithExactly(
             win, 'http://bar.com', 'AMP.navigateTo');
 
         // Should succeed if throwIfCannotNavigate() returns null.
-        invocation.node.getImpl = () => Promise.resolve({
+        invocation.caller.getImpl = () => Promise.resolve({
           throwIfCannotNavigate: () => null,
         });
         yield standardActions.handleAmpTarget(invocation);
@@ -283,7 +283,7 @@ describes.sandboxed('StandardActions', {}, () => {
             win, 'http://bar.com', 'AMP.navigateTo');
 
         // Should fail if throwIfCannotNavigate() throws an error.
-        invocation.node.getImpl = () => Promise.resolve({
+        invocation.caller.getImpl = () => Promise.resolve({
           throwIfCannotNavigate: () => { throw new Error('Fake error.'); },
         });
         yield standardActions.handleAmpTarget(invocation);


### PR DESCRIPTION
Fixes #15684.

Caused by #15162, I believe after a bad merge with refactoring in #15178. ☹️Tested all code paths on `examples/standard-actions.amp.html`.

/to @aghassemi 