### PR TITLE
🐛 amp-next-page: Fix canonical -> cache URL rewriting

### DIFF
--- a/extensions/amp-next-page/0.1/config.js
+++ b/extensions/amp-next-page/0.1/config.js
@@ -88,6 +88,9 @@ function assertReco(reco, origin, sourceOrigin) {
   user().assertString(reco.title, 'title must be a string');
 
   if (sourceOrigin) {
-    reco.ampUrl = reco.ampUrl.replace(url.origin, origin);
+    reco.ampUrl = `${origin}/c/` +
+        (url.protocol === 'https:' ? 's/' : '') +
+        encodeURIComponent(url.host) +
+        url.pathname + (url.search || '') + (url.hash || '');
   }
 }

--- a/extensions/amp-next-page/0.1/test/test-config.js
+++ b/extensions/amp-next-page/0.1/test/test-config.js
@@ -52,7 +52,7 @@ describe('amp-next-page config', () => {
           .to.not.throw();
     });
 
-    it('allows canonical URLs when served from the cache', () => {
+    it('rewrites canonical URLs when served from the cache', () => {
       const cdnOrigin = 'https://example-com.cdn.ampproject.org';
       const config = {
         pages: [
@@ -62,13 +62,33 @@ describe('amp-next-page config', () => {
             title: 'Article 1',
           },
           {
-            ampUrl: 'https://example.com/article2',
+            ampUrl: 'https://example.com/art2?x=1',
             image: 'https://example.com/image.png',
             title: 'Article 1',
           },
         ],
       };
       expect(() => assertConfig(config, cdnOrigin, origin)).to.not.throw();
+      expect(config.pages[1].ampUrl).to.equal(
+          'https://example-com.cdn.ampproject.org/c/s/example.com/art2?x=1');
+    });
+
+    it('rewrites non-HTTPS canonical URLs when served from the cache', () => {
+      const insecureOrigin = 'http://example.com';
+      const cdnOrigin = 'https://example-com.cdn.ampproject.org';
+      const config = {
+        pages: [
+          {
+            ampUrl: 'http://example.com/art2?x=1',
+            image: 'http://example.com/image.png',
+            title: 'Article 1',
+          },
+        ],
+      };
+      expect(() => assertConfig(config, cdnOrigin, insecureOrigin))
+          .to.not.throw();
+      expect(config.pages[0].ampUrl).to.equal(
+          'https://example-com.cdn.ampproject.org/c/example.com/art2?x=1');
     });
 
     it('throws on null config', () => {


### PR DESCRIPTION
Completely forgot what the format of cache URLs was when I wrote the code initially, so it doesn't work at all.

I couldn't see anything in the runtime for constructing cache URLs from canonical besides the image URL code in: https://github.com/ampproject/amphtml/blob/4dee698e59e205b604ab145cf60178aba65b1157/src/sanitizer.js#L719 so I just copied the same format as that.

Also realised image URLs aren't being rewritten to cache versions, filed #15700