### PR TITLE
Always use the `app` middleware in server.js, regardless of quiet mode

### DIFF
--- a/build-system/server.js
+++ b/build-system/server.js
@@ -56,9 +56,9 @@ setInterval(function() {
   }
 }, 1000);
 
-const middleware = [];
+const middleware = [app];
 if (!quiet) {
-  middleware.push(morgan('dev'), app);
+  middleware.push(morgan('dev'));
 }
 if (sendCachingHeaders) {
   middleware.push(header({


### PR DESCRIPTION
Partial resolution for checkbox 1 in #15635

Originally changed in https://github.com/ampproject/amphtml/pull/11594#discussion_r143317962, but this causes visual diffs to use the CDN files instead of the local build. We can fix the noisy log issue that's mentioned in the above linked comment in a separate PR

(partially reverts commit ea2a8d3)