### PR TITLE
✨ adds title to portrait component in amp-story-bookend and change expected fields in articles

### DIFF
--- a/examples/amp-story/bookendv1.json
+++ b/examples/amp-story/bookendv1.json
@@ -41,6 +41,7 @@
     },
     {
       "type": "portrait",
+      "title": "Heading for portrait",
       "category": "This is an example portrait",
       "url": "http://example.com/article.html",
       "image": "http://placehold.it/312x416"

--- a/extensions/amp-story/1.0/amp-story-bookend.css
+++ b/extensions/amp-story/1.0/amp-story-bookend.css
@@ -153,6 +153,7 @@
 
 .i-amphtml-story-bookend-component-category {
   margin-top: 0px !important;
+  margin-bottom: 8px !important;
   font-weight: 400 !important;
   font-size: 12px !important;
   text-transform: uppercase !important;

--- a/extensions/amp-story/1.0/bookend/components/article.js
+++ b/extensions/amp-story/1.0/bookend/components/article.js
@@ -40,8 +40,15 @@ export class ArticleComponent {
 
   /** @override */
   assertValidity(articleJson, element) {
-    user().assert('title' in articleJson && 'url' in articleJson,
-        'Articles must contain `title` and `url` fields, skipping invalid.');
+
+    const requiredFields = ['title', 'url'];
+    const hasAllRequiredFields =
+        !requiredFields.some(field => !(field in articleJson));
+    user().assert(
+        hasAllRequiredFields,
+        'Small article component must contain ' +
+            requiredFields.map(field => '`' + field + '`').join(', ') +
+            ' fields, skipping invalid.');
 
     userAssertValidProtocol(element, articleJson['url']);
 

--- a/extensions/amp-story/1.0/bookend/components/landscape.js
+++ b/extensions/amp-story/1.0/bookend/components/landscape.js
@@ -52,10 +52,15 @@ export class LandscapeComponent {
 
   /** @override */
   assertValidity(landscapeJson, element) {
-    user().assert('category' in landscapeJson && 'image' in landscapeJson &&
-      'url' in landscapeJson && 'title' in landscapeJson, 'landscape ' +
-      'component must contain `title`, `category`, `image`, and `url` fields,' +
-      ' skipping invalid.');
+
+    const requiredFields = ['title', 'image', 'url'];
+    const hasAllRequiredFields =
+        !requiredFields.some(field => !(field in landscapeJson));
+    user().assert(
+        hasAllRequiredFields,
+        'Landscape component must contain ' +
+        requiredFields.map(field => '`' + field + '`').join(', ') +
+        ' fields, skipping invalid.');
 
     userAssertValidProtocol(element, landscapeJson['url']);
     userAssertValidProtocol(element, landscapeJson['image']);

--- a/extensions/amp-story/1.0/bookend/components/portrait.js
+++ b/extensions/amp-story/1.0/bookend/components/portrait.js
@@ -52,10 +52,15 @@ export class PortraitComponent {
 
   /** @override */
   assertValidity(portraitJson, element) {
-    user().assert('category' in portraitJson && 'title' in portraitJson &&
-      'image' in portraitJson && 'url' in portraitJson, 'Portrait component ' +
-      'must contain `category`, `title`, `image`, and `url` fields, skipping ' +
-      'invalid.');
+
+    const requiredFields = ['title', 'image', 'url'];
+    const hasAllRequiredFields =
+        !requiredFields.some(field => !(field in portraitJson));
+    user().assert(
+        hasAllRequiredFields,
+        'Portrait component must contain ' +
+        requiredFields.map(field => '`' + field + '`').join(', ') +
+        ' fields, skipping invalid.');
 
     userAssertValidProtocol(element, portraitJson['url']);
     userAssertValidProtocol(element, portraitJson['image']);

--- a/extensions/amp-story/1.0/bookend/components/portrait.js
+++ b/extensions/amp-story/1.0/bookend/components/portrait.js
@@ -26,6 +26,7 @@ import {userAssertValidProtocol} from '../../utils';
  * @typedef {{
  *   type: string,
  *   category: string,
+ *   title: string,
  *   url: string,
  *   domainName: string,
  *   image: string
@@ -36,6 +37,7 @@ export let PortraitComponentDef;
 /**
  * @struct @typedef {{
  *   category: !Element,
+ *   title: !Element,
  *   image: !Element,
  *   meta: !Element,
  * }}
@@ -50,9 +52,10 @@ export class PortraitComponent {
 
   /** @override */
   assertValidity(portraitJson, element) {
-    user().assert('category' in portraitJson && 'image' in portraitJson &&
-      'url' in portraitJson, 'Portrait component must contain `category`, ' +
-      '`image`, and `url` fields, skipping invalid.');
+    user().assert('category' in portraitJson && 'title' in portraitJson &&
+      'image' in portraitJson && 'url' in portraitJson, 'Portrait component ' +
+      'must contain `category`, `title`, `image`, and `url` fields, skipping ' +
+      'invalid.');
 
     userAssertValidProtocol(element, portraitJson['url']);
     userAssertValidProtocol(element, portraitJson['image']);
@@ -68,6 +71,7 @@ export class PortraitComponent {
       domainName,
       type: portraitJson['type'],
       category: portraitJson['category'],
+      title: portraitJson['title'],
       image: portraitJson['image'],
     };
   }
@@ -82,6 +86,8 @@ export class PortraitComponent {
           target="_top">
           <h2 class="i-amphtml-story-bookend-component-category"
             ref="category"></h2>
+          <h2 class="i-amphtml-story-bookend-article-heading"
+            ref="title"></h2>
           <amp-img class="i-amphtml-story-bookend-portrait-image"
             layout="fixed" width="0" height="0" ref="image"></amp-img>
           <div class="i-amphtml-story-bookend-component-meta"
@@ -89,10 +95,11 @@ export class PortraitComponent {
         </a>`;
     addAttributesToElement(template, dict({'href': portraitData.url}));
 
-    const {category, image, meta} =
+    const {category, title, image, meta} =
       /** @type {!portraitElsDef} */ (htmlRefs(template));
 
     category.textContent = portraitData.category;
+    title.textContent = portraitData.title;
     addAttributesToElement(image, dict({'src': portraitData.image}));
     meta.textContent = portraitData.domainName;
 

--- a/extensions/amp-story/1.0/test/test-amp-story-bookend.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-bookend.js
@@ -21,6 +21,7 @@ import {ArticleComponent} from '../bookend/components/article';
 import {CtaLinkComponent} from '../bookend/components/cta-link';
 import {LandscapeComponent} from '../bookend/components/landscape';
 import {LocalizationService} from '../localization';
+import {PortraitComponent} from '../bookend/components/portrait';
 import {TextBoxComponent} from '../bookend/components/text-box';
 import {createElementWithAttributes} from '../../../../src/dom';
 import {registerServiceBuilder} from '../../../../src/service';
@@ -45,6 +46,14 @@ describes.realWin('amp-story-bookend', {
     {
       'type': 'small',
       'title': 'This is an example article',
+      'domainName': 'example.com',
+      'url': 'http://example.com/article.html',
+      'image': 'http://placehold.it/256x128',
+    },
+    {
+      'type': 'portrait',
+      'title': 'This is an example article',
+      'category': 'This is an example article',
       'domainName': 'example.com',
       'url': 'http://example.com/article.html',
       'image': 'http://placehold.it/256x128',
@@ -130,6 +139,9 @@ describes.realWin('amp-story-bookend', {
     registerServiceBuilder(win, 'localization', () => localizationService);
 
     bookend = new AmpStoryBookend(bookendElem);
+
+    // Force sync mutateElement.
+    sandbox.stub(bookend, 'mutateElement').callsArg(0);
   });
 
   it('should build the users json', () => {
@@ -148,6 +160,13 @@ describes.realWin('amp-story-bookend', {
         {
           'type': 'small',
           'title': 'This is an example article',
+          'url': 'http://example.com/article.html',
+          'image': 'http://placehold.it/256x128',
+        },
+        {
+          'type': 'portrait',
+          'title': 'This is an example article',
+          'category': 'This is an example article',
           'url': 'http://example.com/article.html',
           'image': 'http://placehold.it/256x128',
         },
@@ -216,6 +235,14 @@ describes.realWin('amp-story-bookend', {
         {
           'type': 'small',
           'title': 'This is an example article',
+          'url': 'http://example.com/article.html',
+          'image': 'http://placehold.it/256x128',
+        },
+        {
+          'type': 'portrait',
+          'title': 'This is an example article',
+          'category': 'This is an example article',
+          'domainName': 'example.com',
           'url': 'http://example.com/article.html',
           'image': 'http://placehold.it/256x128',
         },
@@ -400,6 +427,32 @@ describes.realWin('amp-story-bookend', {
       expect(() => articleComponent.assertValidity(userJson)).to.throw(
           'Articles must contain `title` and `url` fields, ' +
           'skipping invalid.​​​');
+    });
+  });
+
+  it('should reject invalid user json for portrait article', () => {
+    const portraitComponant = new PortraitComponent();
+    const userJson = {
+      'bookend-version': 'v1.0',
+      'share-providers': [
+        'email',
+        {'provider': 'facebook', 'app_id': '254325784911610'},
+        'whatsapp',
+      ],
+      'components': [
+        {
+          'type': 'portrait',
+          'category': 'sample',
+          'url': 'http://example.com/article.html',
+          'image': 'http://placehold.it/256x128',
+        },
+      ],
+    };
+
+    allowConsoleError(() => {
+      expect(() => portraitComponant.assertValidity(userJson)).to.throw(
+          'Portrait component must contain `category`, `title`, `image`, and ' +
+          '`url` fields, skipping invalid.');
     });
   });
 

--- a/extensions/amp-story/1.0/test/test-amp-story-bookend.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-bookend.js
@@ -425,7 +425,7 @@ describes.realWin('amp-story-bookend', {
 
     allowConsoleError(() => {
       expect(() => articleComponent.assertValidity(userJson)).to.throw(
-          'Articles must contain `title` and `url` fields, ' +
+          'Small article component must contain `title`, `url` fields, ' +
           'skipping invalid.​​​');
     });
   });
@@ -451,7 +451,7 @@ describes.realWin('amp-story-bookend', {
 
     allowConsoleError(() => {
       expect(() => portraitComponant.assertValidity(userJson)).to.throw(
-          'Portrait component must contain `category`, `title`, `image`, and ' +
+          'Portrait component must contain `title`, `image`, ' +
           '`url` fields, skipping invalid.');
     });
   });
@@ -519,8 +519,8 @@ describes.realWin('amp-story-bookend', {
 
     allowConsoleError(() => {
       expect(() => landscapeComponent.assertValidity(userJson)).to.throw(
-          'landscape component must contain `title`, `category`, `image`, ' +
-          'and `url` fields, skipping invalid.');
+          'Landscape component must contain `title`, `image`, ' +
+          '`url` fields, skipping invalid.');
     });
   });
 


### PR DESCRIPTION
* add title to portrait component
* make `title` **required** in `portrait` and `landscape` components
* make `category` **optional** in `portrait` and `landscape` components

Should be added in documentation (#15465) too.
