### PR TITLE
Fix amp-list w/o amp-bind with disable-faster-amp-list enabled

### DIFF
--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -306,6 +306,8 @@ export class AmpList extends AMP.BaseElement {
       return Services.bindForDocOrNull(this.element).then(bind => {
         if (bind) {
           return this.updateBindingsWith_(bind, elements);
+        } else {
+          return Promise.resolve(elements);
         }
       });
     } else {


### PR DESCRIPTION
Fixes #15716.

Verified locally this fixes pages various permutations: with/without `amp-bind`, with the experiment on/off.

/to @aghassemi 