### PR TITLE
Allow publisher defined consent policy

### DIFF
--- a/build-system/tasks/bundle-size.js
+++ b/build-system/tasks/bundle-size.js
@@ -22,7 +22,7 @@ const log = require('fancy-log');
 const {getStdout} = require('../exec');
 
 const runtimeFile = './dist/v0.js';
-const maxSize = '77.62KB';
+const maxSize = '77.67KB';
 
 const {green, red, cyan, yellow} = colors;
 

--- a/examples/amp-consent.amp.html
+++ b/examples/amp-consent.amp.html
@@ -153,14 +153,14 @@
     </div>
   </header>
   <main role="main">
-    <h3>Image that is blocked by '_if_responded' consent</h3>
+    <h3>Image that is blocked by '_till_responded' consent</h3>
     <amp-img
-        data-block-on-consent='_if_responded'
+        data-block-on-consent='_till_responded'
         src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w300-h200-no-n" width=300 height=200></amp-img>
 
-    <h3>Image that is blocked by '_if_accepted' consent</h3>
+    <h3>Image that is blocked by '_till_accepted' consent</h3>
     <amp-img
-        data-block-on-consent='_if_accepted'
+        data-block-on-consent='_till_accepted'
         src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w300-h200-no-n" width=300 height=200></amp-img>
 
     <h3>Image that is blocked by '_auto_reject' consent</h3>

--- a/extensions/amp-consent/0.1/amp-consent.js
+++ b/extensions/amp-consent/0.1/amp-consent.js
@@ -435,9 +435,9 @@ export class AmpConsent extends AMP.BaseElement {
       'unblockOn': unblockOnAll,
     };
 
-    this.policyConfig_['_if_responded'] = predefinedNone;
+    this.policyConfig_['_till_responded'] = predefinedNone;
 
-    this.policyConfig_['_if_accepted'] = defaultPolicy;
+    this.policyConfig_['_till_accepted'] = defaultPolicy;
 
     this.policyConfig_['_auto_reject'] = rejectAllOnZero;
 

--- a/extensions/amp-consent/0.1/consent-policy-manager.js
+++ b/extensions/amp-consent/0.1/consent-policy-manager.js
@@ -30,8 +30,8 @@ const TAG = 'consent-policy-manager';
 
 const WHITELIST_POLICY = {
   'default': true,
-  '_if_responded': true,
-  '_if_accepted': true,
+  '_till_responded': true,
+  '_till_accepted': true,
   '_auto_reject': true,
 };
 

--- a/extensions/amp-consent/0.1/test/test-amp-consent.js
+++ b/extensions/amp-consent/0.1/test/test-amp-consent.js
@@ -328,10 +328,10 @@ describes.realWin('amp-consent', {
       });
     });
 
-    it('create predefined _if_responded policy', function* () {
+    it('create predefined _till_responded policy', function* () {
       ampConsent.buildCallback();
       yield macroTask();
-      expect(ampConsent.policyConfig_['_if_responded']).to.deep.equal({
+      expect(ampConsent.policyConfig_['_till_responded']).to.deep.equal({
         'waitFor': {
           'ABC': undefined,
           'DEF': undefined,
@@ -345,10 +345,10 @@ describes.realWin('amp-consent', {
       });
     });
 
-    it('create predefined _if_accepted policy', function* () {
+    it('create predefined _till_accepted policy', function* () {
       ampConsent.buildCallback();
       yield macroTask();
-      expect(ampConsent.policyConfig_['_if_accepted']).to.deep.equal({
+      expect(ampConsent.policyConfig_['_till_accepted']).to.deep.equal({
         'waitFor': {
           'ABC': undefined,
           'DEF': undefined,
@@ -404,7 +404,7 @@ describes.realWin('amp-consent', {
           'ABC': [],
         },
       });
-      expect(ampConsent.policyConfig_['_if_accepted']).to.deep.equal({
+      expect(ampConsent.policyConfig_['_till_accepted']).to.deep.equal({
         'waitFor': {
           'ABC': undefined,
           'DEF': undefined,

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -1358,10 +1358,10 @@ function createBaseCustomElementClass(win) {
         // data-block-on-consent attribute not set
         return null;
       }
-      if (policyId == '') {
+      if (policyId == '' || policyId == 'default') {
         // data-block-on-consent value not set, up to individual element
         // Note: data-block-on-consent and data-block-on-consent='default' is
-        // treated differently
+        // treated exactly the same
         return this.implementation_.getConsentPolicy();
       }
       return policyId;

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -476,7 +476,7 @@ function createBaseCustomElementClass(win) {
         return this.buildingPromise_;
       }
       return this.buildingPromise_ = new Promise((resolve, reject) => {
-        const policyId = this.implementation_.getConsentPolicy();
+        const policyId = this.getConsentPolicy_();
         if (!policyId) {
           resolve(this.implementation_.buildCallback());
         } else {
@@ -1346,6 +1346,25 @@ function createBaseCustomElementClass(win) {
         rethrowAsync('Action execution failed:', e,
             invocation.node.tagName, invocation.method);
       }
+    }
+
+    /**
+     * Get the consent policy to follow.
+     * @return {?string}
+     */
+    getConsentPolicy_() {
+      const policyId = this.getAttribute('data-block-on-consent');
+      if (policyId === null) {
+        // data-block-on-consent attribute not set
+        return null;
+      }
+      if (policyId == '') {
+        // data-block-on-consent value not set, up to individual element
+        // Note: data-block-on-consent and data-block-on-consent='default' is
+        // treated differently
+        return this.implementation_.getConsentPolicy();
+      }
+      return policyId;
     }
 
     /**

--- a/test/functional/test-custom-element.js
+++ b/test/functional/test-custom-element.js
@@ -576,7 +576,7 @@ describes.realWin('CustomElement', {amp: true}, env => {
               },
             });
           });
-      sandbox.stub(element.implementation_, 'getConsentPolicy')
+      sandbox.stub(element, 'getConsentPolicy_')
           .callsFake(() => {
             return 'default';
           });
@@ -596,7 +596,7 @@ describes.realWin('CustomElement', {amp: true}, env => {
               },
             });
           });
-      sandbox.stub(element.implementation_, 'getConsentPolicy')
+      sandbox.stub(element, 'getConsentPolicy_')
           .callsFake(() => {
             return 'default';
           });
@@ -605,6 +605,15 @@ describes.realWin('CustomElement', {amp: true}, env => {
       container.appendChild(element);
       return expect(element.whenBuilt()).to.eventually.be.rejectedWith(
           /BLOCK_BY_CONSENT/);
+    });
+
+    it('should respect user specified consent policy', () => {
+      const element = new ElementClass();
+      expect(element.getConsentPolicy_()).to.equal(null);
+      element.setAttribute('data-block-on-consent', '');
+      expect(element.getConsentPolicy_()).to.equal('default');
+      element.setAttribute('data-block-on-consent', '_none');
+      expect(element.getConsentPolicy_()).to.equal('_none');
     });
 
 


### PR DESCRIPTION
For #15290 

#15325 introduced a list of predefined consent policy. They are `data-block-on-consent=_if_responded`, `data-block-on-consent=_if_accepted` and `data-block-on-consent=_auto_reject`. With those predefined consent policy, publisher can easily customize the consent blocking behavior of a given AMP component.

Individual AMP component can also overwrite the `#getConsentPolicy()` method to customize its own consent blocking behaviors. This PR allows publisher to customize blocking behaviors on top of that. So the order will be
publisher defined consent blocking behavior > AMP element defined consent blocking behaviors.