### PR TITLE
✨ geo service enhancement

### DIFF
--- a/extensions/amp-geo/0.1/amp-geo.js
+++ b/extensions/amp-geo/0.1/amp-geo.js
@@ -314,14 +314,14 @@ export class AmpGeo extends AMP.BaseElement {
       return GEO_IN_GROUP.NOT_DEFINED;
     }
 
-    // If any of the groups match it'sa a match
+    // If any of the groups match it's a match
     if (targets.filter(group => {
       return this.matchedGroups_.indexOf(group) >= 0;
     }).length > 0) {
       return GEO_IN_GROUP.IN;
     }
 
-    // If we got here noting matched
+    // If we got here nothing matched
     return GEO_IN_GROUP.NOT_IN;
   }
 }

--- a/extensions/amp-geo/0.1/amp-geo.js
+++ b/extensions/amp-geo/0.1/amp-geo.js
@@ -302,6 +302,7 @@ export class AmpGeo extends AMP.BaseElement {
    * isInCountryGroup API
    * @param {string} targetGroup group or comma delimited list of groups
    * @return {GEO_IN_GROUP}
+   * @public
    */
   isInCountryGroup(targetGroup) {
     const targets = targetGroup.trim().split(/,\s*/);

--- a/extensions/amp-geo/0.1/amp-geo.js
+++ b/extensions/amp-geo/0.1/amp-geo.js
@@ -46,6 +46,14 @@ import {parseJson} from '../../../src/json';
 import {user} from '../../../src/log';
 import {waitForBodyPromise} from '../../../src/dom';
 
+/**
+ * @enum {number}
+ */
+export const GEO_IN_GROUP = {
+  NOT_DEFINED: 0,
+  IN: 1,
+  NOT_IN: 2,
+};
 
 /** @const */
 const TAG = 'amp-geo';
@@ -86,6 +94,8 @@ export class AmpGeo extends AMP.BaseElement {
     this.country_ = 'unknown';
     /** @private {Array<string>} */
     this.matchedGroups_ = [];
+    /** @private {Array<string>} */
+    this.definedGroups_ = [];
     /** @Private {} */
   }
 
@@ -153,11 +163,13 @@ export class AmpGeo extends AMP.BaseElement {
     const ISOCountryGroups = /** @type {!Object<string, Array<string>>} */(
       config.ISOCountryGroups);
     const errorPrefix = '<amp-geo> ISOCountryGroups'; // code size
+
     if (ISOCountryGroups) {
       user().assert(
           isObject(ISOCountryGroups),
           `${errorPrefix} must be an object`);
-      Object.keys(ISOCountryGroups).forEach(group => {
+      this.definedGroups_ = Object.keys(ISOCountryGroups);
+      this.definedGroups_.forEach(group => {
         user().assert(
             /^[a-z]+[a-z0-9]*$/i.test(group) &&
             !/^amp/.test(group),
@@ -270,10 +282,43 @@ export class AmpGeo extends AMP.BaseElement {
 
       return {
         ISOCountry: self.country_,
+        matchedISOCountryGroups: self.matchedGroups_,
+        allISOCountryGroups: Object.keys(config.ISOCountryGroups || {}),
+        isInCountryGroup: this.isInCountryGroup.bind(this),
+        /**
+         * Temp still return old interface to avoid version skew
+         * with consuming extensions.  This will go away don't use it!
+         */
         ISOCountryGroups: self.matchedGroups_,
-        AllCountryGroups: Object.keys(config.ISOCountryGroups || {}),
       };
     });
+  }
+
+
+  /**
+   * isInCountryGroup API
+   * @param {string} targetGroup group or comma delimited list of groups
+   * @return {GEO_IN_GROUP}
+   */
+  isInCountryGroup(targetGroup) {
+    const targets = targetGroup.trim().split(/,\s*/);
+
+    // If any of the group are missing it's an error
+    if (targets.filter(group => {
+      return this.definedGroups_.indexOf(group) >= 0;
+    }).length !== targets.length) {
+      return GEO_IN_GROUP.NOT_DEFINED;
+    }
+
+    // If any of the groups match it'sa a match
+    if (targets.filter(group => {
+      return this.matchedGroups_.indexOf(group) >= 0;
+    }).length > 0) {
+      return GEO_IN_GROUP.IN;
+    }
+
+    // If we got here noting matched
+    return GEO_IN_GROUP.NOT_IN;
   }
 }
 

--- a/extensions/amp-geo/0.1/amp-geo.js
+++ b/extensions/amp-geo/0.1/amp-geo.js
@@ -268,7 +268,11 @@ export class AmpGeo extends AMP.BaseElement {
           break;
       }
 
-      return {ISOCountry: self.country_, ISOCountryGroups: self.matchedGroups_};
+      return {
+        ISOCountry: self.country_,
+        ISOCountryGroups: self.matchedGroups_,
+        AllCountryGroups: Object.keys(config.ISOCountryGroups || {}),
+      };
     });
   }
 }

--- a/extensions/amp-geo/0.1/amp-geo.js
+++ b/extensions/amp-geo/0.1/amp-geo.js
@@ -50,9 +50,9 @@ import {waitForBodyPromise} from '../../../src/dom';
  * @enum {number}
  */
 export const GEO_IN_GROUP = {
-  NOT_DEFINED: 0,
-  IN: 1,
-  NOT_IN: 2,
+  NOT_DEFINED: 1,
+  IN: 2,
+  NOT_IN: 3,
 };
 
 /** @const */
@@ -283,7 +283,7 @@ export class AmpGeo extends AMP.BaseElement {
       return {
         ISOCountry: self.country_,
         matchedISOCountryGroups: self.matchedGroups_,
-        allISOCountryGroups: Object.keys(config.ISOCountryGroups || {}),
+        allISOCountryGroups: this.definedGroups_,
         /* API */
         isInCountryGroup: this.isInCountryGroup.bind(this),
         /**

--- a/extensions/amp-geo/0.1/amp-geo.js
+++ b/extensions/amp-geo/0.1/amp-geo.js
@@ -284,10 +284,13 @@ export class AmpGeo extends AMP.BaseElement {
         ISOCountry: self.country_,
         matchedISOCountryGroups: self.matchedGroups_,
         allISOCountryGroups: Object.keys(config.ISOCountryGroups || {}),
+        /* API */
         isInCountryGroup: this.isInCountryGroup.bind(this),
         /**
          * Temp still return old interface to avoid version skew
          * with consuming extensions.  This will go away don't use it!
+         * replace with matchedISOCountryGroups or use the isInCountryGroup
+         * API
          */
         ISOCountryGroups: self.matchedGroups_,
       };

--- a/extensions/amp-geo/0.1/test/test-amp-geo.js
+++ b/extensions/amp-geo/0.1/test/test-amp-geo.js
@@ -199,6 +199,27 @@ describes.realWin('amp-geo', {
     });
   });
 
+  it('should set return a list of configured group in `geo` service', () => {
+    win.AMP_MODE.geoOverride = 'gb';
+    addConfigElement('script');
+    geo.buildCallback();
+
+    return Services.geoForDocOrNull(el).then(geo => {
+      expect(geo.ISOCountry).to.equal('gb');
+      expect(geo.AllCountryGroups)
+          .to.deep.equal(Object.keys(config.ISOCountryGroups));
+      expectBodyHasClass([
+        'amp-iso-country-gb',
+        'amp-geo-no-group',
+      ], true);
+      expectBodyHasClass([
+        'amp-iso-country-unknown',
+        'amp-geo-group-nafta',
+        'amp-geo-group-anz',
+      ], false);
+    });
+  });
+
   it('should allow uppercase hash to override geo in test', () => {
     win.AMP_MODE.geoOverride = 'NZ';
     addConfigElement('script');

--- a/extensions/amp-geo/0.1/test/test-amp-geo.js
+++ b/extensions/amp-geo/0.1/test/test-amp-geo.js
@@ -230,7 +230,6 @@ describes.realWin('amp-geo', {
           .to.equal(GEO_IN_GROUP.NOT_DEFINED);
 
       /* multi group case */
-            
       expect(geo.isInCountryGroup('nafta, anz'))
           .to.equal(GEO_IN_GROUP.IN);
       expect(geo.isInCountryGroup('nafta, unknown'))

--- a/extensions/amp-geo/0.1/test/test-amp-geo.js
+++ b/extensions/amp-geo/0.1/test/test-amp-geo.js
@@ -213,7 +213,7 @@ describes.realWin('amp-geo', {
     });
   });
 
-  it('isInCountryGroup works single and multiple groups.', () => {
+  it('isInCountryGroup works with multiple group targets', () => {
     win.AMP_MODE.geoOverride = 'nz';
     addConfigElement('script');
     geo.buildCallback();
@@ -221,20 +221,30 @@ describes.realWin('amp-geo', {
     return Services.geoForDocOrNull(el).then(geo => {
       expect(geo.ISOCountry).to.equal('nz');
 
-      /* single gropup case */
-      expect(geo.isInCountryGroup('anz'))
-          .to.equal(GEO_IN_GROUP.IN);
-      expect(geo.isInCountryGroup('nafta'))
-          .to.equal(GEO_IN_GROUP.NOT_IN);
-      expect(geo.isInCountryGroup('foobar'))
-          .to.equal(GEO_IN_GROUP.NOT_DEFINED);
-
       /* multi group case */
       expect(geo.isInCountryGroup('nafta, anz'))
           .to.equal(GEO_IN_GROUP.IN);
       expect(geo.isInCountryGroup('nafta, unknown'))
           .to.equal(GEO_IN_GROUP.NOT_IN);
       expect(geo.isInCountryGroup('nafta, foobar'))
+          .to.equal(GEO_IN_GROUP.NOT_DEFINED);
+    });
+  });
+
+  it('isInCountryGroup works with single group targets', () => {
+    win.AMP_MODE.geoOverride = 'nz';
+    addConfigElement('script');
+    geo.buildCallback();
+
+    return Services.geoForDocOrNull(el).then(geo => {
+      expect(geo.ISOCountry).to.equal('nz');
+
+      /* single group case */
+      expect(geo.isInCountryGroup('anz'))
+          .to.equal(GEO_IN_GROUP.IN);
+      expect(geo.isInCountryGroup('nafta'))
+          .to.equal(GEO_IN_GROUP.NOT_IN);
+      expect(geo.isInCountryGroup('foobar'))
           .to.equal(GEO_IN_GROUP.NOT_DEFINED);
     });
   });


### PR DESCRIPTION
Adds functionality to `geo` service

1. `matchedCountryGroups` array replaces `ISOCountryGroups`.  The old name is deprecated but retained to avoid version skew and will be removed at a later date when consuming extensions are updated.
1. add `allISOCountryGroups` array to allow extension to detect if they are configured with an impossible group.
1. adds `isInCountryGroup()` api.  Accepts a country group or comma separated list of country groups and returns an enum `IN`, `NOT_IN` or `NOT_DEFINED`.  This removes the need for extensions to include their own group testing logic.
