### PR TITLE
[DO NOT MERGE] Remove reference points in lightbox to allow nesting amp-carousel in amp-selector

### DIFF
--- a/extensions/amp-carousel/validator-amp-carousel.protoascii
+++ b/extensions/amp-carousel/validator-amp-carousel.protoascii
@@ -53,6 +53,7 @@ tags: {  # <amp-carousel>
     name: "type"
     value_regex: "slides|carousel"
   }
+  attr_lists: "lightboxable-elements"
   # <amp-bind>
   attrs: { name: "[slide]" }
   attr_lists: "extended-amp-global"
@@ -67,73 +68,4 @@ tags: {  # <amp-carousel>
     supported_layouts: RESPONSIVE
   }
 }
-tags: {  # <amp-carousel> lightbox
-  tag_name: "AMP-CAROUSEL"
-  spec_name: "AMP-CAROUSEL [lightbox]"
-  requires_extension: "amp-carousel"
-  requires_extension: "amp-lightbox-gallery"
-  attrs: {
-    name: "arrows"
-    value: ""
-  }
-  attrs: {
-    name: "autoplay"
-    value: ""
-  }
-  attrs: { name: "controls" }
-  attrs: {
-    name: "delay"
-    value_regex: "[0-9]+"
-  }
-  attrs: {
-    name: "dots"
-    value: ""
-  }
-  attrs: {
-    name: "lightbox"
-    mandatory: true
-  }
-  attrs: {
-    name: "loop"
-    value: ""
-  }
-  attrs: {
-    name: "type"
-    value_regex: "slides|carousel"
-  }
-  # <amp-bind>
-  attrs: { name: "[slide]" }
-  attr_lists: "extended-amp-global"
-  spec_url: "https://www.ampproject.org/docs/reference/components/amp-carousel"
-  amp_layout: {
-    supported_layouts: FILL
-    supported_layouts: FIXED
-    supported_layouts: FIXED_HEIGHT
-    supported_layouts: FLEX_ITEM
-    supported_layouts: INTRINSIC
-    supported_layouts: NODISPLAY
-    supported_layouts: RESPONSIVE
-  }
-  reference_points: {
-    tag_spec_name: "AMP-CAROUSEL lightbox [lightbox-exclude]"
-  }
-  reference_points: {
-    tag_spec_name: "AMP-CAROUSEL lightbox [child]"
-  }
-}
-tags: {
-  tag_name: "$REFERENCE_POINT"
-  spec_name: "AMP-CAROUSEL lightbox [lightbox-exclude]"
-  attrs: {
-    name: "lightbox-exclude"
-    mandatory: true
-  }
-}
-tags: {
-  tag_name: "$REFERENCE_POINT"
-  spec_name: "AMP-CAROUSEL lightbox [child]"
-  attrs: {
-    name: "lightbox-thumbnail-id"
-    value_regex_casei: "^[a-z][a-z\\d_-]*"
-  }
-}
+

--- a/extensions/amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.html
+++ b/extensions/amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.html
@@ -26,6 +26,7 @@
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <script async custom-element="amp-lightbox-gallery" src="https://cdn.ampproject.org/v0/amp-lightbox-gallery-0.1.js"></script>
+  <script async custom-element="amp-selector" src="https://cdn.ampproject.org/v0/amp-selector-0.1.js"></script>
   <script async custom-element="amp-youtube" src="https://cdn.ampproject.org/v0/amp-youtube-0.1.js"></script>
   <script async custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.1.js"></script>
   <script async custom-element="amp-video" src="https://cdn.ampproject.org/v0/amp-video-0.1.js"></script>
@@ -37,11 +38,6 @@
   <amp-img src="/awesome.png" width="300" height="300" lightbox></amp-img>
   <amp-img src="/awesome.png" width="300" height="300" lightbox="a"></amp-img>
   <amp-img src="/awesome.png" width="300" height="300" lightbox lightbox-thumbnail-id="a"></amp-img>
-
-  <!-- Invalid: missing value for lightbox-thumbnail-id -->
-  <amp-img src="/awesome.png" width="300" height="300" lightbox lightbox-thumbnail-id></amp-img>
-  <!-- Invalid: missing lightbox attribute for element with lightbox-thumbnail-id -->
-  <amp-img src="/awesome.png" width="300" height="300" lightbox-thumbnail-id="a"></amp-img>
 
   <!-- Valid -->
   <amp-video
@@ -92,12 +88,19 @@
       data-aax_src="302">
     </amp-ad>
   </amp-carousel>
- 
+
+  <!-- Valid: <amp-selector> with the options as lightboxed carousel images -->
+  <amp-selector layout="container" name="multi_image_select_1" multiple>
+    <amp-carousel id="carousel-1" width=200 height=60 controls lightbox>
+      <amp-img src="/img1.png" width=80 height=60 option="a"></amp-img>
+      <amp-img src="/img2.png" width=80 height=60 option="b" selected></amp-img>
+      <amp-img src="/img3.png" width=80 height=60 option="c"></amp-img>
+      <amp-img src="/img4.png" width=80 height=60 option="d" disabled></amp-img>
+    </amp-carousel>
+  </amp-selector>
+
   <!-- Invalid: missing value for lightbox-thumbnail-id -->
   <amp-img src="/awesome.png" width="300" height="300" lightbox lightbox-thumbnail-id></amp-img>
-  <!-- Invalid: missing lightbox attribute for element with lightbox-thumbnail-id -->
-  <amp-img src="/awesome.png" width="300" height="300" lightbox-thumbnail-id="a"></amp-img>
-  <!-- Invalid: invalid use of lightbox-exclude -->
-  <amp-img src="/awesome.png" width="300" height="300" lightbox-exclude></amp-img>
+
 </body>
 </html>

--- a/extensions/amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.out
+++ b/extensions/amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.out
@@ -27,6 +27,7 @@ FAIL
 |    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
 |    <script async src="https://cdn.ampproject.org/v0.js"></script>
 |    <script async custom-element="amp-lightbox-gallery" src="https://cdn.ampproject.org/v0/amp-lightbox-gallery-0.1.js"></script>
+|    <script async custom-element="amp-selector" src="https://cdn.ampproject.org/v0/amp-selector-0.1.js"></script>
 |    <script async custom-element="amp-youtube" src="https://cdn.ampproject.org/v0/amp-youtube-0.1.js"></script>
 |    <script async custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.1.js"></script>
 |    <script async custom-element="amp-video" src="https://cdn.ampproject.org/v0/amp-video-0.1.js"></script>
@@ -38,13 +39,6 @@ FAIL
 |    <amp-img src="/awesome.png" width="300" height="300" lightbox></amp-img>
 |    <amp-img src="/awesome.png" width="300" height="300" lightbox="a"></amp-img>
 |    <amp-img src="/awesome.png" width="300" height="300" lightbox lightbox-thumbnail-id="a"></amp-img>
-|  
-|    <!-- Invalid: missing value for lightbox-thumbnail-id -->
-|    <amp-img src="/awesome.png" width="300" height="300" lightbox lightbox-thumbnail-id></amp-img>
->>   ^~~~~~~~~
-amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.html:42:2 The attribute 'lightbox-thumbnail-id' in tag 'amp-img' is set to the invalid value ''. (see https://www.ampproject.org/docs/reference/components/amp-img) [DISALLOWED_HTML]
-|    <!-- Invalid: missing lightbox attribute for element with lightbox-thumbnail-id -->
-|    <amp-img src="/awesome.png" width="300" height="300" lightbox-thumbnail-id="a"></amp-img>
 |  
 |    <!-- Valid -->
 |    <amp-video
@@ -95,16 +89,21 @@ amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.html:42:2 The attri
 |        data-aax_src="302">
 |      </amp-ad>
 |    </amp-carousel>
-|   
+|  
+|    <!-- Valid: <amp-selector> with the options as lightboxed carousel images -->
+|    <amp-selector layout="container" name="multi_image_select_1" multiple>
+|      <amp-carousel id="carousel-1" width=200 height=60 controls lightbox>
+|        <amp-img src="/img1.png" width=80 height=60 option="a"></amp-img>
+|        <amp-img src="/img2.png" width=80 height=60 option="b" selected></amp-img>
+|        <amp-img src="/img3.png" width=80 height=60 option="c"></amp-img>
+|        <amp-img src="/img4.png" width=80 height=60 option="d" disabled></amp-img>
+|      </amp-carousel>
+|    </amp-selector>
+|  
 |    <!-- Invalid: missing value for lightbox-thumbnail-id -->
 |    <amp-img src="/awesome.png" width="300" height="300" lightbox lightbox-thumbnail-id></amp-img>
 >>   ^~~~~~~~~
-amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.html:97:2 The attribute 'lightbox-thumbnail-id' in tag 'amp-img' is set to the invalid value ''. (see https://www.ampproject.org/docs/reference/components/amp-img) [DISALLOWED_HTML]
-|    <!-- Invalid: missing lightbox attribute for element with lightbox-thumbnail-id -->
-|    <amp-img src="/awesome.png" width="300" height="300" lightbox-thumbnail-id="a"></amp-img>
-|    <!-- Invalid: invalid use of lightbox-exclude -->
-|    <amp-img src="/awesome.png" width="300" height="300" lightbox-exclude></amp-img>
->>   ^~~~~~~~~
-amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.html:101:2 The attribute 'lightbox-exclude' may not appear in tag 'amp-img'. (see https://www.ampproject.org/docs/reference/components/amp-img) [DISALLOWED_HTML]
+amp-lightbox-gallery/0.1/test/validator-amp-lightbox-gallery.html:103:2 The attribute 'lightbox-thumbnail-id' in tag 'amp-img' is set to the invalid value ''. (see https://www.ampproject.org/docs/reference/components/amp-img) [DISALLOWED_HTML]
+|  
 |  </body>
 |  </html>

--- a/extensions/amp-lightbox-gallery/validator-amp-lightbox-gallery.protoascii
+++ b/extensions/amp-lightbox-gallery/validator-amp-lightbox-gallery.protoascii
@@ -32,4 +32,7 @@ attr_lists: {
     name: "lightbox-thumbnail-id"
     value_regex_casei: "^[a-z][a-z\\d_-]*"
   }
+  attrs: {
+    name: "lightbox-exclude"
+  }
 }

--- a/validator/testdata/feature_tests/mandatory_dimensions.out
+++ b/validator/testdata/feature_tests/mandatory_dimensions.out
@@ -125,11 +125,7 @@ feature_tests/mandatory_dimensions.html:96:4 The tag 'amp-iframe' requires inclu
 feature_tests/mandatory_dimensions.html:100:4 The tag 'amp-fit-text' requires including the 'amp-fit-text' extension JavaScript. (see https://www.ampproject.org/docs/reference/components/amp-fit-text) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
 |      <amp-carousel height="42"></amp-carousel>
 >>     ^~~~~~~~~
-feature_tests/mandatory_dimensions.html:101:4 The mandatory attribute 'lightbox' is missing in tag 'AMP-CAROUSEL [lightbox]'. (see https://www.ampproject.org/docs/reference/components/amp-carousel) [DISALLOWED_HTML]
->>     ^~~~~~~~~
-feature_tests/mandatory_dimensions.html:101:4 The tag 'AMP-CAROUSEL [lightbox]' requires including the 'amp-carousel' extension JavaScript. (see https://www.ampproject.org/docs/reference/components/amp-carousel) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
->>     ^~~~~~~~~
-feature_tests/mandatory_dimensions.html:101:4 The tag 'AMP-CAROUSEL [lightbox]' requires including the 'amp-lightbox-gallery' extension JavaScript. (see https://www.ampproject.org/docs/reference/components/amp-carousel) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
+feature_tests/mandatory_dimensions.html:101:4 The tag 'amp-carousel' requires including the 'amp-carousel' extension JavaScript. (see https://www.ampproject.org/docs/reference/components/amp-carousel) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
 |      <amp-youtube data-videoid="dQw4w9WgXcQ" height="42"></amp-youtube>
 >>     ^~~~~~~~~
 feature_tests/mandatory_dimensions.html:102:4 The tag 'amp-youtube' requires including the 'amp-youtube' extension JavaScript. (see https://www.ampproject.org/docs/reference/components/amp-youtube) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]


### PR DESCRIPTION
Closes https://github.com/ampproject/amphtml/issues/15725. This is sad, but the problem here boils down to the fact that we can't have the same element have two reference points, and somehow having things inside an `<amp-selector>` is a common enough pattern that ABE uses it. Ideally, validator would support use cases to validate different reference points on the same element, but I don't think it currently can. 

The error: 
```
The tag 'AMP-CAROUSEL [lightbox]' conflicts with reference point 'AMP-SELECTOR child' because both define reference points.
```