### PR TITLE
Allow `<amp-social-share>` to specify the target in which to open anchor

### DIFF
--- a/examples/social-share.amp.html
+++ b/examples/social-share.amp.html
@@ -41,6 +41,13 @@
                         data-param-recipient="sample@xyz.com"
                         aria-label="Share by email">
       </amp-social-share>
+      <amp-social-share type="email"
+                        data-param-subject="Hello World"
+                        data-param-body="What's up?"
+                        data-param-recipient="sample@xyz.com"
+                        data-target="_self"
+                        aria-label="Share by email">
+      </amp-social-share>
       <amp-social-share type="whatsapp"
                         aria-label="Share to Whatsapp">
       </amp-social-share>

--- a/extensions/amp-social-share/0.1/amp-social-share.js
+++ b/extensions/amp-social-share/0.1/amp-social-share.js
@@ -110,7 +110,8 @@ class AmpSocialShare extends AMP.BaseElement {
       const isSms = protocol === 'sms:';
       const isIosSafari = this.platform_.isIos() && this.platform_.isSafari();
       this.target_ = (isIosSafari && (isMailTo || isSms))
-        ? '_top' : '_blank';
+        ? '_top' : (this.element.hasAttribute('data-target') ?
+          this.element.getAttribute('data-target') : '_blank');
       if (isSms) {
         // http://stackoverflow.com/a/19126326
         // This code path seems to be stable for both iOS and Android.

--- a/extensions/amp-social-share/0.1/test/test-amp-social-share.js
+++ b/extensions/amp-social-share/0.1/test/test-amp-social-share.js
@@ -51,7 +51,7 @@ describes.realWin('amp-social-share', {
     sandbox./*OK*/stub(win, 'open').returns(true);
   });
 
-  function getShare(type, opt_endpoint, opt_params) {
+  function getShare(type, opt_endpoint, opt_params, opt_target) {
     const share = doc.createElement('amp-social-share');
     share.addEventListener = sandbox.spy();
     if (opt_endpoint) {
@@ -60,6 +60,10 @@ describes.realWin('amp-social-share', {
 
     for (const key in opt_params) {
       share.setAttribute('data-param-' + key, opt_params[key]);
+    }
+
+    if (opt_target) {
+      share.setAttribute('data-target', opt_target);
     }
 
     share.setAttribute('type', type);
@@ -174,13 +178,29 @@ describes.realWin('amp-social-share', {
     });
   });
 
+  it('opens mailto: window in _self', () => {
+    const params = {
+      'recipient': 'sample@xyz.com',
+    };
+    return getShare('email', undefined, params, '_self').then(el => {
+      el.implementation_.handleClick_();
+      expect(el.implementation_.win.open).to.be.calledOnce;
+      expect(el.implementation_.win.open).to.be.calledWith(
+          'mailto:sample%40xyz.com?subject=doc%20title&' +
+            'body=https%3A%2F%2Fcanonicalexample.com%2F' +
+            '&recipient=sample%40xyz.com',
+          '_self', 'resizable,scrollbars,width=640,height=480'
+      );
+    });
+  });
+
   it('opens mailto: window in _top on iOS Safari with recipient', () => {
     const params = {
       'recipient': 'sample@xyz.com',
     };
     isIos = true;
     isSafari = true;
-    return getShare('email', undefined, params).then(el => {
+    return getShare('email', undefined, params, '_top').then(el => {
       el.implementation_.handleClick_();
       expect(el.implementation_.win.open).to.be.calledOnce;
       expect(el.implementation_.win.open).to.be.calledWith(
@@ -191,6 +211,26 @@ describes.realWin('amp-social-share', {
       );
     });
   });
+
+  it('opens mailto: window in _top on iOS Safari with recipient even if user ' +
+    'attempts to override with `data-target`', () => {
+    const params = {
+      'recipient': 'sample@xyz.com',
+    };
+    isIos = true;
+    isSafari = true;
+    return getShare('email', undefined, params, '_self').then(el => {
+      el.implementation_.handleClick_();
+      expect(el.implementation_.win.open).to.be.calledOnce;
+      expect(el.implementation_.win.open).to.be.calledWith(
+          'mailto:sample%40xyz.com?subject=doc%20title&' +
+            'body=https%3A%2F%2Fcanonicalexample.com%2F' +
+            '&recipient=sample%40xyz.com',
+          '_top', 'resizable,scrollbars,width=640,height=480'
+      );
+    });
+  });
+
 
   it('opens mailto: window in _top on iOS Safari without recipient', () => {
     isIos = true;

--- a/extensions/amp-social-share/amp-social-share.md
+++ b/extensions/amp-social-share/amp-social-share.md
@@ -73,6 +73,13 @@ Linkedin is one of the pre-configured providers, so you do not need to provide t
 
 Selects a provider type. This is required for both pre-configured and non-configured providers.
 
+##### data-target
+
+Specifies the target in which to open the target. The default is `_blank` for all cases other than email/SMS on iOS, in which case the target is set to `_top`.
+
+Please note that we only suggest using this override for email.
+
+
 ##### data-share-endpoint
 
 This attribute is **required for non-configured providers**.


### PR DESCRIPTION
Fixes #9157

Worth noting that currently you can set the anchor for any social-share. Do we want to restrict it to just  `email`?

Also currently you can set the anchor to any value `_self`, `_blank`, `_top`. Do we want to restrict this set?