### PR TITLE
Subscriptions: propagate URL vars for ACCESS_READER_ID and AUTHDATA

### DIFF
--- a/build-system/tasks/bundle-size.js
+++ b/build-system/tasks/bundle-size.js
@@ -22,7 +22,7 @@ const log = require('fancy-log');
 const {getStdout} = require('../exec');
 
 const runtimeFile = './dist/v0.js';
-const maxSize = '77.59KB';
+const maxSize = '77.61KB';
 
 const {green, red, cyan, yellow} = colors;
 

--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -356,7 +356,7 @@ const forbiddenTerms = {
       'src/service/standard-actions-impl.js',
       'src/service/url-replacements-impl.js',
       'extensions/amp-access/0.1/amp-access.js',
-      'extensions/amp-subscriptions/0.1/local-subscription-platform.js',
+      'extensions/amp-subscriptions/0.1/amp-subscriptions.js',
       'extensions/amp-experiment/0.1/variant.js',
       'extensions/amp-user-notification/0.1/amp-user-notification.js',
     ],
@@ -425,7 +425,9 @@ const forbiddenTerms = {
     whitelist: [
       'build-system/amp.extern.js',
       'extensions/amp-access/0.1/amp-access.js',
+      'extensions/amp-access/0.1/access-vars.js',
       'extensions/amp-access-scroll/0.1/scroll-impl.js',
+      'extensions/amp-subscriptions/0.1/amp-subscriptions.js',
       'src/service/url-replacements-impl.js',
     ],
   },
@@ -434,6 +436,8 @@ const forbiddenTerms = {
     whitelist: [
       'build-system/amp.extern.js',
       'extensions/amp-access/0.1/amp-access.js',
+      'extensions/amp-access/0.1/access-vars.js',
+      'extensions/amp-subscriptions/0.1/amp-subscriptions.js',
       'src/service/url-replacements-impl.js',
     ],
   },

--- a/examples/amp-subscriptions.amp.html
+++ b/examples/amp-subscriptions.amp.html
@@ -9,6 +9,7 @@
   <script async custom-element="amp-subscriptions" src="https://cdn.ampproject.org/v0/amp-subscriptions-0.1.js"></script>
   <script async custom-element="amp-subscriptions-google" src="https://cdn.ampproject.org/v0/amp-subscriptions-google-0.1.js"></script>
   <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.1.js"></script>
+  <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <script type="application/ld+json">
   {
@@ -163,6 +164,41 @@
   </style>
 </head>
 <body>
+<amp-analytics type="googleanalytics" id="analytics2">
+<script type="application/json">
+{
+  "vars": {
+    "account": "UA-YYYY-Y"
+  },
+  "triggers": {
+    "defaultPageview": {
+      "on": "visible",
+      "request": "pageview",
+      "vars": {
+        "title": "Example Pageview"
+      }
+    },
+    "authorizationReceived": {
+      "on": "subscriptions-entitlement-resolved",
+      "request": "event",
+      "vars": {
+        "eventCategory": "amp-subscriptions",
+        "eventAction": "subscriptions-entitlement-resolved",
+        "eventValue": "ACCESS_READER_ID/AUTHDATA(granted)/${serviceId}"
+      }
+    },
+    "pingbackSent": {
+      "on": "action-subscribe-started",
+      "request": "event",
+      "vars": {
+        "eventCategory": "amp-subscriptions",
+        "eventAction": "action-subscribe-started"
+      }
+    }
+  }
+}
+</script>
+</amp-analytics>
 
   <header>
     <div class="brand-logo">

--- a/extensions/amp-access/0.1/access-vars.js
+++ b/extensions/amp-access/0.1/access-vars.js
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+/**
+ * Exports the substitution variables for access services.
+ *
+ * @interface
+ */
+export class AccessVars {
+
+  /**
+   * Returns the promise that will yield the access READER_ID.
+   *
+   * This is a restricted API.
+   *
+   * @return {?Promise<string>}
+   */
+  getAccessReaderId() {}
+
+  /**
+   * Returns the promise that will yield the value of the specified field from
+   * the authorization response. This method will wait for the most recent
+   * authorization request to complete. It will return null values for failed
+   * requests with no fallback, but could be modified to block indefinitely.
+   *
+   * This is a restricted API.
+   *
+   * @param {string} unusedField
+   * @return {?Promise<*|null>}
+   */
+  getAuthdataField(unusedField) {}
+}

--- a/extensions/amp-access/0.1/amp-access.js
+++ b/extensions/amp-access/0.1/amp-access.js
@@ -15,6 +15,7 @@
  */
 
 import {AccessSource, AccessType} from './amp-access-source';
+import {AccessVars} from './access-vars';
 import {AmpEvents} from '../../../src/amp-events';
 import {CSS} from '../../../build/amp-access-0.1.css';
 import {Services} from '../../../src/services';
@@ -43,6 +44,7 @@ const TEMPLATE_PROP = '__AMP_ACCESS__TEMPLATE';
 
 /**
  * AccessService implements the complete lifecycle of the AMP Access system.
+ * @implements {AccessVars}
  */
 export class AccessService {
   /**
@@ -134,13 +136,7 @@ export class AccessService {
         this.onDomUpdate_.bind(this));
   }
 
-  /**
-   * Returns the promise that will yield the access READER_ID.
-   *
-   * This is a restricted API.
-   *
-   * @return {?Promise<string>}
-   */
+  /** @override from AccessVars */
   getAccessReaderId() {
     if (!this.enabled_) {
       return null;
@@ -265,6 +261,7 @@ export class AccessService {
   /**
    * @return {!AccessService}
    * @private
+   * @restricted
    */
   start_() {
     if (!this.enabled_) {
@@ -378,17 +375,7 @@ export class AccessService {
         });
   }
 
-  /**
-   * Returns the promise that will yield the value of the specified field from
-   * the authorization response. This method will wait for the most recent
-   * authorization request to complete. It will return null values for failed
-   * requests with no fallback, but could be modified to block indefinitely.
-   *
-   * This is a restricted API.
-   *
-   * @param {string} field
-   * @return {?Promise<*|null>}
-   */
+  /** @override from AccessVars */
   getAuthdataField(field) {
     if (!this.enabled_) {
       return null;
@@ -717,3 +704,9 @@ AMP.extension(TAG, '0.1', function(AMP) {
     return new AccessService(ampdoc).start_();
   });
 });
+
+
+/** @package Visible for testing only. */
+export function getAccessVarsClassForTesting() {
+  return AccessVars;
+}

--- a/extensions/amp-subscriptions/0.1/actions.js
+++ b/extensions/amp-subscriptions/0.1/actions.js
@@ -89,7 +89,7 @@ export class Actions {
     // URL should always be available at this time.
     const url = user().assert(this.builtActionUrlMap_[action],
         'Action URL is not ready: %s', action);
-    return this.execute_(url, 'action-' + action);
+    return this.execute_(url, 'subscriptions-action-' + action);
   }
 
   /**

--- a/extensions/amp-subscriptions/0.1/amp-subscriptions.js
+++ b/extensions/amp-subscriptions/0.1/amp-subscriptions.js
@@ -30,6 +30,7 @@ import {ViewerSubscriptionPlatform} from './viewer-subscription-platform';
 import {ViewerTracker} from './viewer-tracker';
 import {dev, user} from '../../../src/log';
 import {getMode} from '../../../src/mode';
+import {getValueForExpr} from '../../../src/json';
 import {getWinOrigin} from '../../../src/url';
 import {installStylesForDoc} from '../../../src/style-installer';
 import {tryParseJson} from '../../../src/json';
@@ -40,6 +41,10 @@ const TAG = 'amp-subscriptions';
 /** @const */
 const SERVICE_TIMEOUT = 3000;
 
+
+/**
+ * @implements {../../amp-access/0.1/access-vars.AccessVars}
+ */
 export class SubscriptionService {
   /**
    * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
@@ -95,6 +100,12 @@ export class SubscriptionService {
 
     /** @private @const {boolean} */
     this.doesViewerProvideAuth_ = this.viewer_.hasCapability('auth');
+
+    /** @private @const {!Promise<!../../../src/service/cid-impl.Cid>} */
+    this.cid_ = Services.cidForDoc(ampdoc);
+
+    /** @private {!Object<string, ?Promise<string>>} */
+    this.readerIdPromiseMap_ = {};
   }
 
   /**
@@ -323,6 +334,28 @@ export class SubscriptionService {
   }
 
   /**
+   * @param {string} serviceId
+   * @return {!Promise<string>}
+   */
+  getReaderId(serviceId) {
+    let readerId = this.readerIdPromiseMap_[serviceId];
+    if (!readerId) {
+      const consent = Promise.resolve();
+      // Scope is kept "amp-access" by default to avoid unnecessary CID
+      // rotation.
+      const scope =
+          'amp-access' + (serviceId == 'local' ? '' : '-' + serviceId);
+      readerId = this.cid_.then(cid => {
+        return cid.get(
+            {scope, createCookieIfNotPresent: true},
+            consent);
+      });
+      this.readerIdPromiseMap_[serviceId] = readerId;
+    }
+    return readerId;
+  }
+
+  /**
    * Returns the singleton Dialog instance
    * @return {!Dialog}
    */
@@ -361,8 +394,12 @@ export class SubscriptionService {
       selectedPlatform.activate(selectedEntitlement);
       this.subscriptionAnalytics_.serviceEvent(
           SubscriptionAnalyticsEvents.PLATFORM_ACTIVATED,
-          selectedPlatform.getServiceId()
-      );
+          selectedPlatform.getServiceId());
+      if (!selectedEntitlement.granted) {
+        this.subscriptionAnalytics_.serviceEvent(
+            SubscriptionAnalyticsEvents.PAYWALL_ACTIVATED,
+            selectedPlatform.getServiceId());
+      }
     });
   }
 
@@ -402,6 +439,8 @@ export class SubscriptionService {
    * @return {!Promise}
    */
   reAuthorizePlatform(subscriptionPlatform) {
+    this.platformStore_.resetEntitlementFor(
+        subscriptionPlatform.getServiceId());
     return this.fetchEntitlements_(subscriptionPlatform).then(() => {
       this.subscriptionAnalytics_.serviceEvent(
           SubscriptionAnalyticsEvents.PLATFORM_REAUTHORIZED,
@@ -463,6 +502,20 @@ export class SubscriptionService {
    */
   selectPlatformForLogin() {
     return this.platformStore_.selectPlatformForLogin();
+  }
+
+  /** @override from AccessVars */
+  getAccessReaderId() {
+    return this.initialize_().then(() => this.getReaderId('local'));
+  }
+
+  /** @override from AccessVars */
+  getAuthdataField(field) {
+    return this.initialize_().then(() => {
+      return this.platformStore_.getEntitlementPromiseFor('local');
+    }).then(entitlement => {
+      return getValueForExpr(entitlement.json(), field);
+    });
   }
 }
 

--- a/extensions/amp-subscriptions/0.1/analytics.js
+++ b/extensions/amp-subscriptions/0.1/analytics.js
@@ -18,6 +18,7 @@ import {triggerAnalyticsEvent} from '../../../src/analytics';
 
 export const SubscriptionAnalyticsEvents = {
   PLATFORM_ACTIVATED: 'subscriptions-platform-activated',
+  PAYWALL_ACTIVATED: 'subscriptions-paywall-activated',
   PLATFORM_REGISTERED: 'subscriptions-platform-registered',
   PLATFORM_REAUTHORIZED: 'subscriptions-platform-re-authorized',
   ACTION_DELEGATED: 'subscriptions-action-delegated',

--- a/extensions/amp-subscriptions/0.1/local-subscription-platform.js
+++ b/extensions/amp-subscriptions/0.1/local-subscription-platform.js
@@ -24,6 +24,7 @@ import {assertHttpsUrl} from '../../../src/url';
 import {closestBySelector} from '../../../src/dom';
 import {dev, user} from '../../../src/log';
 
+
 /**
  * This implements the methods to interact with various subscription platforms.
  *
@@ -62,11 +63,10 @@ export class LocalSubscriptionPlatform {
         'Authorization Url'
     );
 
-    /** @private @const {!Promise<!../../../src/service/cid-impl.Cid>} */
-    this.cid_ = Services.cidForDoc(ampdoc);
-
     /** @private {!UrlBuilder} */
-    this.urlBuilder_ = new UrlBuilder(this.ampdoc_, this.getReaderId_());
+    this.urlBuilder_ = new UrlBuilder(
+        this.ampdoc_,
+        this.serviceAdapter_.getReaderId('local'));
 
     /** @private {!./analytics.SubscriptionAnalytics} */
     this.subscriptionAnalytics_ = subscriptionAnalytics;
@@ -80,9 +80,6 @@ export class LocalSubscriptionPlatform {
         this.subscriptionAnalytics_,
         this.validateActionMap(this.serviceConfig_['actions'])
     );
-
-    /** @private {?Promise<string>} */
-    this.readerIdPromise_ = null;
 
     /** @private {!LocalSubscriptionPlatformRenderer}*/
     this.renderer_ = new LocalSubscriptionPlatformRenderer(this.ampdoc_,
@@ -112,23 +109,6 @@ export class LocalSubscriptionPlatform {
     user().assert(actionMap['subscribe'],
         'Action "subscribe" is not present in action map');
     return actionMap;
-  }
-
-  /**
-   * @return {!Promise<string>}
-   * @private
-   */
-  getReaderId_() {
-    if (!this.readerIdPromise_) {
-      const consent = Promise.resolve();
-      this.readerIdPromise_ = this.cid_.then(cid => {
-        return cid.get(
-            {scope: 'amp-access', createCookieIfNotPresent: true},
-            consent
-        );
-      });
-    }
-    return this.readerIdPromise_;
   }
 
   /**

--- a/extensions/amp-subscriptions/0.1/service-adapter.js
+++ b/extensions/amp-subscriptions/0.1/service-adapter.js
@@ -34,6 +34,15 @@ export class ServiceAdapter {
   }
 
   /**
+   * Returns the reader ID for the specified service.
+   * @param {string} serviceId
+   * @return {!Promise<string>}
+   */
+  getReaderId(serviceId) {
+    return this.subscriptionService_.getReaderId(serviceId);
+  }
+
+  /**
    * Delegates actions to local platform.
    * @param {string} action
    * @return {!Promise<boolean>}

--- a/extensions/amp-subscriptions/0.1/test/test-actions.js
+++ b/extensions/amp-subscriptions/0.1/test/test-actions.js
@@ -75,10 +75,10 @@ describes.realWin('Actions', {amp: true}, env => {
 
   it('should open the action popup window synchronously', () => {
     analyticsMock.expects('event')
-        .withExactArgs('action-login-started')
+        .withExactArgs('subscriptions-action-login-started')
         .once();
     analyticsMock.expects('event')
-        .withExactArgs('action-login-success')
+        .withExactArgs('subscriptions-action-login-success')
         .once();
     return actions.build().then(() => {
       const promise = actions.execute('login');
@@ -114,10 +114,10 @@ describes.realWin('Actions', {amp: true}, env => {
 
   it('should accept success=no', () => {
     analyticsMock.expects('event')
-        .withExactArgs('action-login-started')
+        .withExactArgs('subscriptions-action-login-started')
         .once();
     analyticsMock.expects('event')
-        .withExactArgs('action-login-rejected')
+        .withExactArgs('subscriptions-action-login-rejected')
         .once();
     return actions.build().then(() => {
       const promise = actions.execute('login');
@@ -154,10 +154,10 @@ describes.realWin('Actions', {amp: true}, env => {
 
   it('should handle failures', () => {
     analyticsMock.expects('event')
-        .withExactArgs('action-login-started')
+        .withExactArgs('subscriptions-action-login-started')
         .once();
     analyticsMock.expects('event')
-        .withExactArgs('action-login-failed')
+        .withExactArgs('subscriptions-action-login-failed')
         .once();
     return actions.build().then(() => {
       const promise = actions.execute('login');

--- a/extensions/amp-subscriptions/0.1/test/test-amp-subscriptions.js
+++ b/extensions/amp-subscriptions/0.1/test/test-amp-subscriptions.js
@@ -473,6 +473,7 @@ describes.fakeWin('AmpSubscriptions', {amp: true}, env => {
           .callsFake(() => Promise.resolve(entitlement));
       const resetStub = sandbox.stub(subscriptionService.platformStore_,
           'resetEntitlementFor');
+      sandbox.stub(subscriptionService, 'startAuthorizationFlow_');
       return subscriptionService.reAuthorizePlatform(platform).then(() => {
         expect(resetStub).to.be.calledOnce.calledWith('local');
       });

--- a/extensions/amp-subscriptions/0.1/test/test-amp-subscriptions.js
+++ b/extensions/amp-subscriptions/0.1/test/test-amp-subscriptions.js
@@ -22,6 +22,7 @@ import {
 } from '../../../../third_party/subscriptions-project/config';
 import {PlatformStore} from '../platform-store';
 import {ServiceAdapter} from '../service-adapter';
+import {Services} from '../../../../src/services';
 import {SubscriptionAnalyticsEvents} from '../analytics';
 import {SubscriptionPlatform} from '../subscription-platform';
 import {SubscriptionService} from '../amp-subscriptions';
@@ -173,6 +174,47 @@ describes.fakeWin('AmpSubscriptions', {amp: true}, env => {
     });
   });
 
+  describe('getReaderId', () => {
+    let cidGet;
+
+    beforeEach(() => {
+      return Services.cidForDoc(ampdoc).then(cid => {
+        cidGet = sandbox.stub(cid, 'get').callsFake(
+            () => Promise.resolve('cid1'));
+      });
+    });
+
+    it('should delegate to cid.get for local', () => {
+      return subscriptionService.getReaderId('local').then(value => {
+        expect(value).to.equal('cid1');
+        expect(cidGet).to.be.calledOnce.calledWith({
+          // Local service is default to "amp-access" scope.
+          scope: 'amp-access',
+          createCookieIfNotPresent: true,
+        });
+      });
+    });
+
+    it('should delegate to cid.get for non-local', () => {
+      return subscriptionService.getReaderId('service1').then(() => {
+        expect(cidGet).to.be.calledOnce.calledWith({
+          scope: 'amp-access-service1',
+          createCookieIfNotPresent: true,
+        });
+      });
+    });
+
+    it('should resolve reader ID only once', () => {
+      const local1 = subscriptionService.getReaderId('local');
+      const local2 = subscriptionService.getReaderId('local');
+      const service1 = subscriptionService.getReaderId('service');
+      const service2 = subscriptionService.getReaderId('service');
+      expect(local1).to.equal(local2);
+      expect(service1).to.equal(service2);
+      expect(local1).to.not.equal(service1);
+    });
+  });
+
   it('should discover page configuration', () => {
     return subscriptionService.initialize_().then(() => {
       expect(subscriptionService.pageConfig_).to.equal(pageConfig);
@@ -235,7 +277,7 @@ describes.fakeWin('AmpSubscriptions', {amp: true}, env => {
       subscriptionService.serviceAdapter_ =
         new ServiceAdapter(subscriptionService);
       subscriptionService.pageConfig_ = pageConfig;
-      subscriptionService.platformStore_ = new PlatformStore('local');
+      subscriptionService.platformStore_ = new PlatformStore(['local']);
       subscriptionService.initializeLocalPlatforms_(service);
       expect(subscriptionService.platformStore_.subscriptionPlatforms_['local'])
           .to.be.not.null;
@@ -250,7 +292,7 @@ describes.fakeWin('AmpSubscriptions', {amp: true}, env => {
       subscriptionService.start();
       subscriptionService.viewTrackerPromise_ = Promise.resolve();
       return subscriptionService.initialize_().then(() => {
-        resolveRequiredPromises(subscriptionService);
+        resolveRequiredPromises(subscriptionService, /* subscriber */ true);
         const localPlatform =
             subscriptionService.platformStore_.getLocalPlatform();
         const selectPlatformStub =
@@ -266,15 +308,18 @@ describes.fakeWin('AmpSubscriptions', {amp: true}, env => {
                 'serviceId': 'local',
               }
           );
+          expect(analyticsEventStub).to.not.be.calledWith(
+              SubscriptionAnalyticsEvents.PAYWALL_ACTIVATED);
         });
       });
     });
+
     it('should call selectPlatform with preferViewerSupport config', () => {
       sandbox.stub(subscriptionService, 'fetchEntitlements_');
       subscriptionService.start();
       subscriptionService.viewTrackerPromise_ = Promise.resolve();
       return subscriptionService.initialize_().then(() => {
-        resolveRequiredPromises(subscriptionService);
+        resolveRequiredPromises(subscriptionService, /* subscriber */ true);
         const selectPlatformStub =
           subscriptionService.platformStore_.selectPlatform;
         subscriptionService.platformConfig_['preferViewerSupport'] = false;
@@ -283,9 +328,39 @@ describes.fakeWin('AmpSubscriptions', {amp: true}, env => {
         });
       });
     });
-    function resolveRequiredPromises(subscriptionService) {
-      const entitlement = new Entitlement({source: 'local', raw: 'raw',
-        granted: true, grantReason: GrantReason.SUBSCRIBER});
+
+    it('should send paywall activation event', () => {
+      sandbox.stub(subscriptionService, 'fetchEntitlements_');
+      subscriptionService.start();
+      subscriptionService.viewTrackerPromise_ = Promise.resolve();
+      return subscriptionService.initialize_().then(() => {
+        resolveRequiredPromises(subscriptionService, /* subscriber */ false);
+        const localPlatform =
+            subscriptionService.platformStore_.getLocalPlatform();
+        sandbox.stub(localPlatform, 'activate');
+        return subscriptionService.selectAndActivatePlatform_().then(() => {
+          expect(analyticsEventStub).to.be.calledWith(
+              SubscriptionAnalyticsEvents.PLATFORM_ACTIVATED,
+              {
+                'serviceId': 'local',
+              }
+          );
+          expect(analyticsEventStub).to.be.calledWith(
+              SubscriptionAnalyticsEvents.PAYWALL_ACTIVATED,
+              {
+                'serviceId': 'local',
+              });
+        });
+      });
+    });
+
+    function resolveRequiredPromises(subscriptionService, subscriber) {
+      const entitlement = new Entitlement({
+        source: 'local',
+        raw: 'raw',
+        granted: subscriber,
+        grantReason: subscriber ? GrantReason.SUBSCRIBER : null,
+      });
       const localPlatform =
         subscriptionService.platformStore_.getLocalPlatform();
       sandbox.stub(subscriptionService.platformStore_, 'getGrantStatus')
@@ -388,6 +463,18 @@ describes.fakeWin('AmpSubscriptions', {amp: true}, env => {
               'serviceId': 'local',
             }
         );
+      });
+    });
+
+    it('should reset entitlement on re-authorization', () => {
+      const entitlement = new Entitlement({source: 'local', raw: 'raw',
+        granted: true, grantReason: GrantReason.SUBSCRIBER});
+      sandbox.stub(platform, 'getEntitlements')
+          .callsFake(() => Promise.resolve(entitlement));
+      const resetStub = sandbox.stub(subscriptionService.platformStore_,
+          'resetEntitlementFor');
+      return subscriptionService.reAuthorizePlatform(platform).then(() => {
+        expect(resetStub).to.be.calledOnce.calledWith('local');
       });
     });
   });
@@ -562,6 +649,52 @@ describes.fakeWin('AmpSubscriptions', {amp: true}, env => {
           subscriptionService.platformStore_, 'selectPlatformForLogin');
       subscriptionService.selectPlatformForLogin();
       expect(loginStub).to.be.called;
+    });
+  });
+
+  describe('AccessVars', () => {
+    let platformStore;
+    let entitlement;
+
+    beforeEach(() => {
+      platformStore = new PlatformStore(['local']);
+      subscriptionService.platformStore_ = platformStore;
+      entitlement = new Entitlement({
+        source: 'local',
+        raw: 'raw',
+        granted: true,
+        grantReason: GrantReason.SUBSCRIBER,
+        dataObject: {
+          test: 'a1',
+        },
+      });
+    });
+
+    it('should return local reader ID', () => {
+      const stub = sandbox.stub(subscriptionService, 'getReaderId').callsFake(
+          () => Promise.resolve('reader1'));
+      return subscriptionService.getAccessReaderId().then(readerId => {
+        expect(readerId).to.equal('reader1');
+        expect(stub).to.be.calledOnce.calledWith('local');
+      });
+    });
+
+    it('should resolve authdata from local service', () => {
+      platformStore.resolveEntitlement('local', entitlement);
+      return expect(subscriptionService.getAuthdataField('data.test'))
+          .to.eventually.equal('a1');
+    });
+
+    it('should resolve authdata for a standard field', () => {
+      platformStore.resolveEntitlement('local', entitlement);
+      return expect(subscriptionService.getAuthdataField('grantReason'))
+          .to.eventually.equal('SUBSCRIBER');
+    });
+
+    it('should resolve authdata for an unknown value', () => {
+      platformStore.resolveEntitlement('local', entitlement);
+      return expect(subscriptionService.getAuthdataField('data.other'))
+          .to.eventually.be.undefined;
     });
   });
 });

--- a/extensions/amp-subscriptions/0.1/test/test-analytics.js
+++ b/extensions/amp-subscriptions/0.1/test/test-analytics.js
@@ -29,4 +29,12 @@ describes.realWin('SubscriptionAnalytics', {amp: true}, env => {
     analytics.event('event1');
     analytics.serviceEvent('event1', 'serviceId');
   });
+
+  it('should trigger a service event', () => {
+    const stub = sandbox.stub(analytics, 'event');
+    analytics.serviceEvent('event1', 'service1');
+    expect(stub).to.be.calledOnce.calledWith('event1', {
+      'serviceId': 'service1',
+    });
+  });
 });

--- a/extensions/amp-subscriptions/0.1/test/test-platform-store.js
+++ b/extensions/amp-subscriptions/0.1/test/test-platform-store.js
@@ -45,6 +45,44 @@ describes.realWin('Platform store', {}, () => {
     expect(platformStore.serviceIds_).to.be.equal(serviceIds);
   });
 
+  it('should resolve entitlement', () => {
+    // Request entitlement promise even before it's resolved.
+    const p = platformStore.getEntitlementPromiseFor('service2');
+
+    // Resolve once.
+    const ent = new Entitlement({
+      service: 'service2',
+      granted: false,
+    });
+    platformStore.resolveEntitlement('service2', ent);
+    expect(platformStore.getResolvedEntitlementFor('service2')).to.equal(ent);
+    expect(platformStore.getEntitlementPromiseFor('service2')).to.equal(p);
+
+    // Additional resolution doesn't change anything without reset.
+    platformStore.resolveEntitlement('service2', new Entitlement({
+      service: 'service2',
+      granted: true,
+    }));
+    expect(platformStore.getEntitlementPromiseFor('service2')).to.equal(p);
+    return expect(p).to.eventually.equal(ent);
+  });
+
+  it('should reset entitlement', () => {
+    // Request entitlement promise even before it's resolved.
+    const p = platformStore.getEntitlementPromiseFor('service2');
+
+    // Resolve once.
+    platformStore.resolveEntitlement('service2', new Entitlement({
+      service: 'service2',
+      granted: false,
+    }));
+    expect(platformStore.getEntitlementPromiseFor('service2')).to.equal(p);
+
+    // Reset: new entitlement promise.
+    platformStore.resetEntitlementFor('service2');
+    expect(platformStore.getEntitlementPromiseFor('service2')).to.not.equal(p);
+  });
+
   it('should call onChange callbacks on every resolve', () => {
     const cb = sandbox.stub(platformStore.onEntitlementResolvedCallbacks_,
         'fire');

--- a/extensions/amp-subscriptions/0.1/test/test-service-adapter.js
+++ b/extensions/amp-subscriptions/0.1/test/test-service-adapter.js
@@ -99,4 +99,15 @@ env => {
       expect(stub).to.be.calledWith(element, serviceId, 'action');
     });
   });
+
+  describe('getReaderId', () => {
+    it('should delegate call to getReaderId', () => {
+      const readerIdPromise = Promise.resolve();
+      const stub = sandbox.stub(subscriptionService, 'getReaderId')
+          .returns(readerIdPromise);
+      const promise = serviceAdapter.getReaderId('service1');
+      expect(stub).to.be.calledOnce.calledWith('service1');
+      expect(promise).to.equal(readerIdPromise);
+    });
+  });
 });

--- a/extensions/amp-subscriptions/0.1/test/test-viewer-platform.js
+++ b/extensions/amp-subscriptions/0.1/test/test-viewer-platform.js
@@ -55,6 +55,8 @@ describes.fakeWin('ViewerSubscriptionPlatform', {amp: true}, env => {
         .callsFake(() => new PageConfig(currentProductId, true));
     sandbox.stub(serviceAdapter, 'getDialog')
         .callsFake(() => new Dialog(ampdoc));
+    sandbox.stub(serviceAdapter, 'getReaderId')
+        .callsFake(() => Promise.resolve('reader1'));
     viewerPlatform = new ViewerSubscriptionPlatform(
         ampdoc, serviceConfig, serviceAdapter, origin,
         new SubscriptionAnalytics(ampdoc.getRootNode()));

--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -115,12 +115,6 @@ export class GlobalVariableSource extends VariableSource {
   constructor(ampdoc) {
     super(ampdoc);
 
-    /**
-     * @private
-     * @const {function(!./ampdoc-impl.AmpDoc):!Promise<?../../extensions/amp-access/0.1/amp-access.AccessService>}
-     */
-    this.getAccessService_ = Services.accessServiceForDocOrNull;
-
     /** @private {?Promise<?Object<string, string>>} */
     this.variants_ = null;
 
@@ -608,20 +602,28 @@ export class GlobalVariableSource extends VariableSource {
   /**
    * Resolves the value via access service. If access service is not configured,
    * the resulting value is `null`.
-   * @param {function(!../../extensions/amp-access/0.1/amp-access.AccessService):(T|!Promise<T>)} getter
+   * @param {function(!../../extensions/amp-access/0.1/access-vars.AccessVars):(T|!Promise<T>)} getter
    * @param {string} expr
    * @return {T|null}
    * @template T
    * @private
    */
   getAccessValue_(getter, expr) {
-    return this.getAccessService_(this.ampdoc).then(accessService => {
-      if (!accessService) {
-        // Access service is not installed.
-        user().error(TAG, 'Access service is not installed to access: ', expr);
+    return Promise.all([
+      Services.accessServiceForDocOrNull(this.ampdoc),
+      Services.subscriptionsServiceForDocOrNull(this.ampdoc),
+    ]).then(services => {
+      const service = /** @type {?../../extensions/amp-access/0.1/access-vars.AccessVars} */ (
+        services[0] || services[1]);
+      if (!service) {
+        // Access/subscriptions service is not installed.
+        user().error(
+            TAG,
+            'Access or subsciptions service is not installed to access: ',
+            expr);
         return null;
       }
-      return getter(accessService);
+      return getter(service);
     });
   }
 

--- a/src/services.js
+++ b/src/services.js
@@ -50,17 +50,6 @@ export class Services {
   }
 
   /**
-   * Returns a promise for the Subscriptions service.
-   * @param {!Node|!./service/ampdoc-impl.AmpDoc} nodeOrDoc
-   * @return {!Promise<!SubscriptionService>}
-   */
-  static subscriptionsServiceForDoc(nodeOrDoc) {
-    return (/** @type {!Promise<SubscriptionService>} */ (
-      getElementServiceForDoc(nodeOrDoc, 'subscriptions',
-          'amp-subscriptions')));
-  }
-
-  /**
    * Returns a promise for the Access service or a promise for null if the
    * service is not available on the current page.
    * @param {!Node|!./service/ampdoc-impl.AmpDoc} nodeOrDoc
@@ -70,6 +59,28 @@ export class Services {
     return (/** @type {
         !Promise<?../extensions/amp-access/0.1/amp-access.AccessService>} */ (
         getElementServiceIfAvailableForDoc(nodeOrDoc, 'access', 'amp-access')));
+  }
+
+  /**
+   * Returns a promise for the Subscriptions service.
+   * @param {!Node|!./service/ampdoc-impl.AmpDoc} nodeOrDoc
+   * @return {!Promise<!SubscriptionService>}
+   */
+  static subscriptionsServiceForDoc(nodeOrDoc) {
+    return (/** @type {!Promise<!SubscriptionService>} */ (
+      getElementServiceForDoc(nodeOrDoc, 'subscriptions',
+          'amp-subscriptions')));
+  }
+
+  /**
+   * Returns a promise for the Subscriptions service.
+   * @param {!Node|!./service/ampdoc-impl.AmpDoc} nodeOrDoc
+   * @return {!Promise<?SubscriptionService>}
+   */
+  static subscriptionsServiceForDocOrNull(nodeOrDoc) {
+    return (/** @type {!Promise<?SubscriptionService>} */ (
+      getElementServiceIfAvailableForDoc(nodeOrDoc, 'subscriptions',
+          'amp-subscriptions')));
   }
 
   /**

--- a/test/_init_tests.js
+++ b/test/_init_tests.js
@@ -370,7 +370,9 @@ function stubConsoleInfoLogWarn() {
 
 // Used to restore info, log, and warn level logging after each test.
 function restoreConsoleInfoLogWarn() {
-  consoleInfoLogWarnSandbox.restore();
+  if (consoleInfoLogWarnSandbox) {
+    consoleInfoLogWarnSandbox.restore();
+  }
 }
 
 beforeEach(function() {

--- a/test/functional/test-url-replacements.js
+++ b/test/functional/test-url-replacements.js
@@ -433,8 +433,6 @@ describes.sandboxed('UrlReplacements', {}, () => {
   });
 
   it('should replace VARIANT', () => {
-    expectAsyncConsoleError(
-        'The value passed to VARIANT() is not a valid experiment name:x3');
     return expect(expandUrlAsync(
         '?x1=VARIANT(x1)&x2=VARIANT(x2)&x3=VARIANT(x3)',
         /*opt_bindings*/undefined, {withVariant: true}))

--- a/test/functional/test-url-replacements.js
+++ b/test/functional/test-url-replacements.js
@@ -433,6 +433,8 @@ describes.sandboxed('UrlReplacements', {}, () => {
   });
 
   it('should replace VARIANT', () => {
+    expectAsyncConsoleError(
+        'The value passed to VARIANT() is not a valid experiment name:x3');
     return expect(expandUrlAsync(
         '?x1=VARIANT(x1)&x2=VARIANT(x2)&x3=VARIANT(x3)',
         /*opt_bindings*/undefined, {withVariant: true}))


### PR DESCRIPTION
Additionally, action analytics event names have been fixed.