### PR TITLE
videos: various fixes and cleanups

### DIFF
--- a/examples/brightcove.amp.html
+++ b/examples/brightcove.amp.html
@@ -9,21 +9,52 @@
   <script async custom-element="amp-brightcove" src="https://cdn.ampproject.org/v0/amp-brightcove-0.1.js"></script>
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <style amp-custom>
+    body {
+      max-width: 527px;
+      font-family: 'Questrial', Arial;
+    }
+    .spacer {
+      height: 100vh;
+    }
+  </style>
 </head>
 <body>
   <h2>Brightcove Player</h2>
-  <p>With amp support configured</p>
   <amp-brightcove
     id="myPlayer"
-    dock fullscreen-on-landscape
     data-account="1290862519001"
     data-video-id="ref:amp-docs-sample"
     data-player-id="SyIOV8yWM"
     layout="responsive" width="480" height="270">
   </amp-brightcove>
+  <h2>Actions</h2>
   <button on="tap:myPlayer.play">Play</button>
   <button on="tap:myPlayer.pause">Pause</button>
   <button on="tap:myPlayer.mute">Mute</button>
   <button on="tap:myPlayer.unmute">Unmute</button>
+  <button on="tap:myPlayer.fullscreen">Fullscreen</button>
+
+  <p>Autoplay</p>
+  <amp-brightcove
+    id="myPlayer"
+    autoplay
+    data-account="1290862519001"
+    data-video-id="ref:amp-docs-sample"
+    data-player-id="SyIOV8yWM"
+    layout="responsive" width="480" height="270">
+  </amp-brightcove>
+
+  <p>Dock<p>
+    <amp-brightcove
+      id="myPlayer"
+      dock
+      data-account="1290862519001"
+      data-video-id="ref:amp-docs-sample"
+      data-player-id="SyIOV8yWM"
+      layout="responsive" width="480" height="270">
+    </amp-brightcove>
+
+  <div class="spacer"></div>
 </body>
 </html>

--- a/examples/vimeo.amp.html
+++ b/examples/vimeo.amp.html
@@ -7,25 +7,54 @@
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
     <link href="https://fonts.googleapis.com/css?family=Questrial" rel="stylesheet" type="text/css">
     <script async custom-element="amp-vimeo" src="https://cdn.ampproject.org/v0/amp-vimeo-0.1.js"></script>
-     <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
     <script async src="https://cdn.ampproject.org/v0.js"></script>
+    <style amp-custom>
+        body {
+          max-width: 527px;
+          font-family: 'Questrial', Arial;
+        }
+        .spacer {
+          height: 100vh;
+        }
+      </style>
 </head>
 <body>
 <h2>Vimeo</h2>
 
 
 <amp-vimeo
-        data-videoid="27246366"
-        width="500"
-        height="281">
-</amp-vimeo>
-
-<amp-vimeo
+        id="myVideo"
         data-videoid="27246366"
         width="500"
         height="281"
         layout="responsive">
 </amp-vimeo>
+<h3>Actions</h3>
+<button on="tap:myVideo.play">Play</button>
+<button on="tap:myVideo.pause">Pause</button>
+<button on="tap:myVideo.mute">Mute</button>
+<button on="tap:myVideo.unmute">Unmute</button>
+<button on="tap:myVideo.fullscreen">Fullscreen</button>
+
+<h2>Autoplay</h2>
+<amp-vimeo
+        autoplay
+        data-videoid="27246366"
+        width="500"
+        height="281"
+        layout="responsive">
+</amp-vimeo>
+
+<h2>Dock</h2>
+<amp-vimeo
+        dock
+        data-videoid="27246366"
+        width="500"
+        height="281"
+        layout="responsive">
+</amp-vimeo>
+<div class=spacer></div>
 
 </body>
 </html>

--- a/extensions/amp-brightcove/0.1/amp-brightcove.js
+++ b/extensions/amp-brightcove/0.1/amp-brightcove.js
@@ -139,10 +139,16 @@ class AmpBrightcove extends AMP.BaseElement {
    * @private
    * */
   sendCommand_(command, arg) {
-    this.iframe_.contentWindow. /*OK*/ postMessage(JSON.stringify(dict({
-      'command': command,
-      'args': arg,
-    })), 'https://players.brightcove.net');
+    this.playerReadyPromise_.then(() => {
+      // We still need to check this.iframe_ as the component may have
+      // been unlaid out by now.
+      if (this.iframe_ && this.iframe_.contentWindow) {
+        this.iframe_.contentWindow. /*OK*/ postMessage(JSON.stringify(dict({
+          'command': command,
+          'args': arg,
+        })), 'https://players.brightcove.net');
+      }
+    });
   }
 
   /** @private */
@@ -335,45 +341,35 @@ class AmpBrightcove extends AMP.BaseElement {
    * @override
    */
   play(unusedIsAutoplay) {
-    this.playerReadyPromise_.then(() => {
-      this.sendCommand_('play');
-    });
+    this.sendCommand_('play');
   }
 
   /**
    * @override
    */
   pause() {
-    this.playerReadyPromise_.then(() => {
-      this.sendCommand_('pause');
-    });
+    this.sendCommand_('pause');
   }
 
   /**
    * @override
    */
   mute() {
-    this.playerReadyPromise_.then(() => {
-      this.sendCommand_('muted', true);
-    });
+    this.sendCommand_('muted', true);
   }
 
   /**
    * @override
    */
   unmute() {
-    this.playerReadyPromise_.then(() => {
-      this.sendCommand_('muted', false);
-    });
+    this.sendCommand_('muted', false);
   }
 
   /**
    * @override
    */
   showControls() {
-    this.playerReadyPromise_.then(() => {
-      this.sendCommand_('controls', true);
-    });
+    this.sendCommand_('controls', true);
   }
 
   /**

--- a/extensions/amp-brightcove/0.1/test/validator-amp-brightcove.html
+++ b/extensions/amp-brightcove/0.1/test/validator-amp-brightcove.html
@@ -30,6 +30,7 @@
 <body>
   <!-- Valid: Example of a valid amp-brightcove. -->
   <amp-brightcove
+      autoplay
       data-account="1290862519001"
       data-video-id="ref:amp-docs-sample"
       data-player-id="SyIOV8yWM"

--- a/extensions/amp-brightcove/0.1/test/validator-amp-brightcove.out
+++ b/extensions/amp-brightcove/0.1/test/validator-amp-brightcove.out
@@ -31,6 +31,7 @@ FAIL
 |  <body>
 |    <!-- Valid: Example of a valid amp-brightcove. -->
 |    <amp-brightcove
+|        autoplay
 |        data-account="1290862519001"
 |        data-video-id="ref:amp-docs-sample"
 |        data-player-id="SyIOV8yWM"
@@ -54,7 +55,7 @@ FAIL
 |         leaving them out results in an error. -->
 |    <amp-brightcove
 >>   ^~~~~~~~~
-amp-brightcove/0.1/test/validator-amp-brightcove.html:54:2 The mandatory attribute 'data-account' is missing in tag 'amp-brightcove'. (see https://www.ampproject.org/docs/reference/components/amp-brightcove) [AMP_TAG_PROBLEM]
+amp-brightcove/0.1/test/validator-amp-brightcove.html:55:2 The mandatory attribute 'data-account' is missing in tag 'amp-brightcove'. (see https://www.ampproject.org/docs/reference/components/amp-brightcove) [AMP_TAG_PROBLEM]
 |        layout="responsive" width="480" height="270">
 |    </amp-brightcove>
 |  </body>

--- a/extensions/amp-brightcove/amp-brightcove.md
+++ b/extensions/amp-brightcove/amp-brightcove.md
@@ -91,13 +91,19 @@ Keys and values will be URI encoded. Keys will be camel cased.
 - `data-param-language="de"` becomes `&language=de`
 - `data-param-custom-ad-data="key:value;key2:value2"` becomes `&customAdData=key%3Avalue%3Bkey2%3Avalue2`
 
+##### autoplay
+
+If this attribute is present, and the browser supports autoplay, the video will be automatically
+played as soon as it becomes visible. There are some conditions that the component needs to meet
+to be played, [which are outlined in the Video in AMP spec](https://github.com/ampproject/amphtml/blob/master/spec/amp-video-interface.md#autoplay).
+
 ##### common attributes
 
 This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.
 
 ## Player configuration
 
-To support AMP's video interface, which is recommended, make sure you configure players used with the AMP Support plugin. See [Brightcove's support documentation](https://support.brightcove.com/amp) for player configuration instructions. 
+To support AMP's video interface, which is recommended, make sure you configure players used with the AMP Support plugin. See [Brightcove's support documentation](https://support.brightcove.com/amp) for player configuration instructions.
 
 ## Validation
 

--- a/extensions/amp-brightcove/validator-amp-brightcove.protoascii
+++ b/extensions/amp-brightcove/validator-amp-brightcove.protoascii
@@ -31,6 +31,10 @@ tags: {  # <amp-brightcove>
   tag_name: "AMP-BRIGHTCOVE"
   requires_extension: "amp-brightcove"
   attrs: {
+    name: "autoplay"
+    value: ""
+  }
+  attrs: {
     name: "data-account"
     mandatory: true
   }

--- a/extensions/amp-vimeo/0.1/test/validator-amp-vimeo.html
+++ b/extensions/amp-vimeo/0.1/test/validator-amp-vimeo.html
@@ -36,7 +36,7 @@
 <amp-vimeo data-videoid="27246366" width="500" height="281"></amp-vimeo>
 
 <!-- valid -->
-<amp-vimeo data-videoid="27246366" width="500" height="281" layout="responsive" noloading></amp-vimeo>
+<amp-vimeo data-videoid="27246366" width="500" height="281" layout="responsive" noloading autoplay></amp-vimeo>
 
 <!-- valid -->
 <amp-vimeo data-videoid="27246366" width="500" height="281" layout="responsive" noloading="noloading"></amp-vimeo>

--- a/extensions/amp-vimeo/0.1/test/validator-amp-vimeo.out
+++ b/extensions/amp-vimeo/0.1/test/validator-amp-vimeo.out
@@ -37,7 +37,7 @@ FAIL
 |  <amp-vimeo data-videoid="27246366" width="500" height="281"></amp-vimeo>
 |  
 |  <!-- valid -->
-|  <amp-vimeo data-videoid="27246366" width="500" height="281" layout="responsive" noloading></amp-vimeo>
+|  <amp-vimeo data-videoid="27246366" width="500" height="281" layout="responsive" noloading autoplay></amp-vimeo>
 |  
 |  <!-- valid -->
 |  <amp-vimeo data-videoid="27246366" width="500" height="281" layout="responsive" noloading="noloading"></amp-vimeo>

--- a/extensions/amp-vimeo/amp-vimeo.md
+++ b/extensions/amp-vimeo/amp-vimeo.md
@@ -54,6 +54,12 @@ With responsive layout, the width and height from the example should yield corre
 
 The Vimeo video id found in every Vimeo video page URL For example, `27246366` is the video id for the following url: `https://vimeo.com/27246366`.
 
+##### autoplay
+
+If this attribute is present, and the browser supports autoplay, the video will be automatically
+played as soon as it becomes visible. There are some conditions that the component needs to meet
+to be played, [which are outlined in the Video in AMP spec](https://github.com/ampproject/amphtml/blob/master/spec/amp-video-interface.md#autoplay).
+
 ##### common attributes
 
 This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.

--- a/extensions/amp-vimeo/validator-amp-vimeo.protoascii
+++ b/extensions/amp-vimeo/validator-amp-vimeo.protoascii
@@ -31,6 +31,10 @@ tags: {  # <amp-vimeo>
   tag_name: "AMP-VIMEO"
   requires_extension: "amp-vimeo"
   attrs: {
+    name: "autoplay"
+    value: ""
+  }
+  attrs: {
     name: "data-videoid"
     mandatory: true
     value_regex: "[0-9]+"


### PR DESCRIPTION
1- refactor amp-brightcove so it does not throw errors if unlaidout between async calls. Fixes #15765
2- add `autoplay` in `amp-brighcove` and `amp-vimeo` validators now that both support video-interface
3- document `autoplay` for `amp-brighcove` and `amp-vimeo`
4- Clean up example pages to show `autoplay`, actions and  the experimental `dock`
