### PR TITLE
🏗🐛 Consolidate the hostname used by `karma` and `gulp serve` to `127.0.0.1`

### DIFF
--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -594,13 +594,15 @@ function main() {
       command.testDocumentLinks();
     }
     if (buildTargets.has('RUNTIME') ||
-        buildTargets.has('INTEGRATION_TEST')) {
+        buildTargets.has('INTEGRATION_TEST') ||
+        buildTargets.has('BUILD_SYSTEM')) {
       command.cleanBuild();
       command.buildCss();
       command.runJsonCheck();
       command.runDepAndTypeChecks();
-      // Run unit tests only if the PR contains runtime changes.
-      if (buildTargets.has('RUNTIME')) {
+      // Run unit tests if the PR doesn't contain only integration test changes.
+      if (buildTargets.has('RUNTIME') ||
+          buildTargets.has('BUILD_SYSTEM')) {
         // Before running all tests, run tests modified by the PR. (Fail early.)
         command.runUnitTestsOnLocalChanges();
         command.runUnitTests();
@@ -612,7 +614,8 @@ function main() {
     if (buildTargets.has('INTEGRATION_TEST') ||
         buildTargets.has('RUNTIME') ||
         buildTargets.has('VISUAL_DIFF') ||
-        buildTargets.has('FLAG_CONFIG')) {
+        buildTargets.has('FLAG_CONFIG') ||
+        buildTargets.has('BUILD_SYSTEM')) {
       command.cleanBuild();
       command.buildRuntime();
       command.buildRuntimeMinified(/* extensions */ false);
@@ -624,17 +627,17 @@ function main() {
     }
     command.runPresubmitTests();
     if (buildTargets.has('INTEGRATION_TEST') ||
-        buildTargets.has('RUNTIME')) {
+        buildTargets.has('RUNTIME') ||
+        buildTargets.has('BUILD_SYSTEM')) {
       command.runIntegrationTests(/* compiled */ false);
     }
     // TODO(rsimha, #14851): Failing due to long proessing times.
     // if (buildTargets.has('INTEGRATION_TEST') ||
     //     buildTargets.has('RUNTIME') ||
-    //     buildTargets.has('VISUAL_DIFF')) {
+    //     buildTargets.has('VISUAL_DIFF') ||
+    //     buildTargets.has('FLAG_CONFIG') ||
+    //     buildTargets.has('BUILD_SYSTEM')) {
     //   command.verifyVisualDiffTests();
-    // } else {
-    //   // Generates a blank Percy build to satisfy the required Github check.
-    //   command.runVisualDiffTests(/* opt_mode */ 'skip');
     // }
     if (buildTargets.has('VALIDATOR_WEBUI')) {
       command.buildValidatorWebUI();

--- a/build-system/tasks/karma.conf.js
+++ b/build-system/tasks/karma.conf.js
@@ -44,7 +44,7 @@ module.exports = {
 
   // Sauce labs on Safari doesn't support 'localhost' addresses. See #14848.
   // Details: https://support.saucelabs.com/hc/en-us/articles/115010079868
-  hostname: process.platform === 'darwin' ? '127.0.0.1' : 'localhost',
+  hostname: '127.0.0.1',
 
   browserify: {
     watch: true,

--- a/build-system/tasks/serve.js
+++ b/build-system/tasks/serve.js
@@ -21,7 +21,7 @@ const gulp = require('gulp-help')(require('gulp'));
 const log = require('fancy-log');
 const nodemon = require('nodemon');
 
-const host = argv.host || 'localhost';
+const host = argv.host || '127.0.0.1';
 const port = argv.port || process.env.PORT || 8000;
 const useHttps = argv.https != undefined;
 const quiet = argv.quiet != undefined;


### PR DESCRIPTION
We've always used the hostname `localhost` for local testing. This doesn't work well with Safari, so we changed the `karma` hostname to `127.0.0.1` in #15510. However, this didn't work well with some tests that hard-code the hostname as `localhost` during checks. 

In this PR, we consolidate the hostname used for testing to `127.0.0.1` on all platforms. We also trigger unit and integration tests for changes to `build-system/` so that changes like this can be fully tested.

Fixes #15751
Fixes #15801
Follow up to #15510
