### PR TITLE
🐛 Register localization service in amp-story 1.0 tests

### DIFF
--- a/extensions/amp-story/1.0/test/test-amp-story-hint.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-hint.js
@@ -16,6 +16,7 @@
 
 import {AmpStoryHint} from '../amp-story-hint';
 import {AmpStoryStoreService} from '../amp-story-store-service';
+import {LocalizationService} from '../localization';
 import {Services} from '../../../../src/services';
 import {registerServiceBuilder} from '../../../../src/service';
 
@@ -28,6 +29,9 @@ describes.fakeWin('amp-story hint layer', {}, env => {
 
   beforeEach(() => {
     win = env.win;
+
+    const localizationService = new LocalizationService(win);
+    registerServiceBuilder(win, 'localization', () => localizationService);
 
     const storeService = new AmpStoryStoreService(win);
     registerServiceBuilder(win, 'story-store', () => storeService);

--- a/extensions/amp-story/1.0/test/test-amp-story-share-menu.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-share-menu.js
@@ -59,7 +59,7 @@ describes.realWin('amp-story-share-menu', {amp: true}, env => {
     });
 
     const localizationService = new LocalizationService(win);
-    registerServiceBuilder(win, 'localization-v01', () => localizationService);
+    registerServiceBuilder(win, 'localization', () => localizationService);
 
     parentEl = win.document.createElement('div');
     win.document.body.appendChild(parentEl);

--- a/extensions/amp-story/1.0/test/test-amp-story.js
+++ b/extensions/amp-story/1.0/test/test-amp-story.js
@@ -74,7 +74,7 @@ describes.realWin('amp-story', {
     win.document.body.appendChild(element);
 
     const localizationService = new LocalizationService(win);
-    registerServiceBuilder(win, 'localization-v01', () => localizationService);
+    registerServiceBuilder(win, 'localization', () => localizationService);
 
     AmpStory.isBrowserSupported = () => true;
     story = new AmpStory(element);

--- a/extensions/amp-story/1.0/test/test-full-bleed-animations.js
+++ b/extensions/amp-story/1.0/test/test-full-bleed-animations.js
@@ -20,8 +20,10 @@
 
 import {AmpStory} from '../amp-story';
 import {AmpStoryPage} from '../amp-story-page';
+import {LocalizationService} from '../localization';
 import {PRESETS} from '../animation-presets';
 import {calculateTargetScalingFactor, targetFitsWithinPage} from '../animation-presets-utils';
+import {registerServiceBuilder} from '../../../../src/service';
 
 describes.realWin('amp-story-full-bleed-animations', {
   amp: {
@@ -37,6 +39,10 @@ describes.realWin('amp-story-full-bleed-animations', {
     win = env.win;
     storyElem = win.document.createElement('amp-story');
     win.document.body.appendChild(storyElem);
+
+    const localizationService = new LocalizationService(win);
+    registerServiceBuilder(win, 'localization', () => localizationService);
+
     AmpStory.isBrowserSupported = () => true;
     ampStory = new AmpStory(storyElem);
   });


### PR DESCRIPTION
#15743 updated the tests using the wrong service (it uses the LocalizationService from 0.1).  This fixes that.

It also registers the LocalizationService in more tests that were indirectly depending on it.