### PR TITLE
🐛 Prevent double / async errors from being thrown during tests

### DIFF
--- a/test/_init_tests.js
+++ b/test/_init_tests.js
@@ -281,6 +281,7 @@ function warnForConsoleError() {
   expectedAsyncErrors = [];
   consoleErrorSandbox = sinon.sandbox.create();
   const originalConsoleError = console/*OK*/.error;
+  setReportError(() => {});
   consoleErrorSandbox.stub(console, 'error').callsFake((...messages) => {
     const message = messages.join(' ');
     if (expectedAsyncErrors.includes(message)) {
@@ -342,6 +343,7 @@ function dontWarnForConsoleError() {
   consoleErrorSandbox = sinon.sandbox.create();
   consoleErrorStub =
       consoleErrorSandbox.stub(console, 'error').callsFake(() => {});
+  setReportError(reportError);
 }
 
 // Used to restore error level logging after each test.


### PR DESCRIPTION
Re: #15658: After some investigation, it turns out that functions like `user().error` and `user().assert` call `reportError`, which asynchronously throws the same error that we're throwing during tests when `console.error` is called.

This PR stubs out `reportError` during tests at times when `console.error` will throw an error. This means the normal `reportError` behavior is restored inside `allowConsoleError` blocks, where `console.error` will not throw an error.

Partial fix for #15658 (while I look for a more general mocha solution)