### PR TITLE
Lower-case amp-3d-gltf attribute names.

### DIFF
--- a/extensions/amp-3d-gltf/0.1/test/validator-amp-3d-gltf.html
+++ b/extensions/amp-3d-gltf/0.1/test/validator-amp-3d-gltf.html
@@ -17,6 +17,13 @@
 <body>
   <!-- valid: has src -->
   <amp-3d-gltf src="/example.glb" layout="responsive" width="150" height="80"></amp-3d-gltf>
+  <amp-3d-gltf layout="fixed"
+             width="320"
+             height="240"
+             antialiasing="true"
+             autoRotate="true"
+             enableZoom="false"
+             src="https://webgears-3d.github.io/3d-gltf-static/m/DamagedHelmet.glb"></amp-3d-gltf>
 
   <!-- invalid: no src -->
   <amp-3d-gltf layout="responsive" width="150" height="80"></amp-3d-gltf>

--- a/extensions/amp-3d-gltf/0.1/test/validator-amp-3d-gltf.out
+++ b/extensions/amp-3d-gltf/0.1/test/validator-amp-3d-gltf.out
@@ -18,10 +18,17 @@ FAIL
 |  <body>
 |    <!-- valid: has src -->
 |    <amp-3d-gltf src="/example.glb" layout="responsive" width="150" height="80"></amp-3d-gltf>
+|    <amp-3d-gltf layout="fixed"
+|               width="320"
+|               height="240"
+|               antialiasing="true"
+|               autoRotate="true"
+|               enableZoom="false"
+|               src="https://webgears-3d.github.io/3d-gltf-static/m/DamagedHelmet.glb"></amp-3d-gltf>
 |  
 |    <!-- invalid: no src -->
 |    <amp-3d-gltf layout="responsive" width="150" height="80"></amp-3d-gltf>
 >>   ^~~~~~~~~
-amp-3d-gltf/0.1/test/validator-amp-3d-gltf.html:22:2 The mandatory attribute 'src' is missing in tag 'amp-3d-gltf'. (see https://www.ampproject.org/docs/reference/components/amp-3d-gltf) [AMP_TAG_PROBLEM]
+amp-3d-gltf/0.1/test/validator-amp-3d-gltf.html:29:2 The mandatory attribute 'src' is missing in tag 'amp-3d-gltf'. (see https://www.ampproject.org/docs/reference/components/amp-3d-gltf) [AMP_TAG_PROBLEM]
 |  </body>
 |  </html>

--- a/extensions/amp-3d-gltf/validator-amp-3d-gltf.protoascii
+++ b/extensions/amp-3d-gltf/validator-amp-3d-gltf.protoascii
@@ -37,15 +37,15 @@ tags: {  # <amp-3d-gltf>
     value_regex: "false|true"
   }
   attrs: {
-    name: "autoRotate"
+    name: "autorotate"
     value_regex: "false|true"
   }
   attrs: {
-    name: "enableZoom"
+    name: "enablezoom"
     value_regex: "false|true"
   }
   attrs: {
-    name: "maxPixelRatio"
+    name: "maxpixelratio"
     value_regex: "[+-]?(\\d*\\.)?\\d+"
   }
   attrs: {

--- a/validator/engine/validator_test.js
+++ b/validator/engine/validator_test.js
@@ -647,12 +647,14 @@ function compareAttrNames(a, b) {
  * @param {!amp.validator.ValidatorRules} rules
  */
 function attrRuleShouldMakeSense(attrSpec, rules) {
-  const attrSpecNameRegex = new RegExp('[^A-Z]+');
   // name
   it('attr_spec name defined', () => {
     expect(attrSpec.name).toBeDefined();
+  });
+  it('attr_spec name is lower case', () => {
     // Attribute Spec names are matched against lowercased attributes,
     // so the rules *must* also be lower case or non-cased.
+    const attrSpecNameRegex = new RegExp('^[^A-Z]+$');
     expect(attrSpecNameRegex.test(attrSpec.name)).toBe(true);
   });
   if (attrSpec.valueUrl !== null) {


### PR DESCRIPTION
Lower-case amp-3d-gltf attribute names.

Fix test which was supposed to catch upper-case attribute names. The
regex was not anchored, so would pass if there was at least one
non-upper case character in the attribute name.

Resolves 2 of the 3 validation errors in #15793.