### PR TITLE
🐛 amp-next-page: Fix trying to rewrite canonical URLs to cache URLs when it shouldn't

### DIFF
--- a/extensions/amp-next-page/0.1/config.js
+++ b/extensions/amp-next-page/0.1/config.js
@@ -101,7 +101,7 @@ function assertReco(context, reco, origin, sourceOrigin) {
   user().assertString(reco.image, 'image must be a string');
   user().assertString(reco.title, 'title must be a string');
 
-  if (sourceOrigin) {
+  if (sourceOrigin !== origin) {
     reco.ampUrl = `${origin}/c/` +
         (url.protocol === 'https:' ? 's/' : '') +
         encodeURIComponent(url.host) +

--- a/extensions/amp-next-page/0.1/config.js
+++ b/extensions/amp-next-page/0.1/config.js
@@ -42,9 +42,10 @@ export let AmpNextPageItem;
  * @param {string} origin The origin of the current document
  *     (document.location.origin). All recommendations must be for the same
  *     origin as the current document so the URL can be updated safely.
- * @param {string=} sourceOrigin The source origin for the current document, if
- *     the current document is being served from the cache. Any recommendations
- *     pointing at {@code sourceOrigin} will be modified to point to the cache.
+ * @param {string} sourceOrigin The source origin for the current document.
+ *     Will match the value of {@code origin} unless served from the cache.
+ *     Any recommendations pointing at {@code sourceOrigin} will be modified
+ *     to point to the cache.
  * @return {!AmpNextPageConfig}
  */
 export function assertConfig(context, config, origin, sourceOrigin) {

--- a/extensions/amp-next-page/0.1/test/test-config.js
+++ b/extensions/amp-next-page/0.1/test/test-config.js
@@ -106,6 +106,21 @@ describe('amp-next-page config', () => {
           'https://example-com.cdn.ampproject.org/c/example.com/art2?x=1');
     });
 
+    it('doesn\'t rewrite URLs if sourceOrigin and origin match', () => {
+      const config = {
+        pages: [
+          {
+            ampUrl: 'https://example.com/article',
+            image: 'https://example.com/image.png',
+            title: 'Article 1',
+          },
+        ],
+      };
+      expect(() => assertConfig(/*ctx*/ null, config, origin, origin))
+          .to.not.throw();
+      expect(config.pages[0].ampUrl).to.equal('https://example.com/article');
+    });
+
     it('throws on null config', () => {
       allowConsoleError(() => {
         expect(() => assertConfig(/*ctx*/ null, null, origin, origin))


### PR DESCRIPTION
#15699 fixed the behaviour when serving from the cache, but accidentally made it start rewriting all URLs to point to the cache (including localhost argh). Corrected the check and added a test.

Tested locally, with canonical AMP and serving from the cache (proxying the requests for the runtime to a local build). For the last PR I only checked on the cache and didn't test locally.

@aghassemi 