### PR TITLE
amp-3d-gltf: fix src attribute

### DIFF
--- a/3p/3d-gltf/viewer.js
+++ b/3p/3d-gltf/viewer.js
@@ -19,19 +19,6 @@
 import {setStyle} from '../../src/style';
 import AnimationLoop from './animation-loop';
 
-const resolveURL = (url, path) => {
-  // Invalid URL
-  if (typeof url !== 'string' || url === '') {return '';}
-  // Absolute URL http://,https://,//
-  if (/^(https?:)?\/\//i.test(url)) {return url;}
-  // Data URI
-  if (/^data:.*,.*$/i.test(url)) {return url;}
-  // Blob URL
-  if (/^blob:.*$/i.test(url)) {return url;}
-  // Relative URL
-  return path + url;
-};
-
 const CAMERA_DISTANCE_FACTOR = 1;
 const CAMERA_FAR_FACTOR = 50;
 const CAMERA_NEAR_FACTOR = .1;
@@ -198,20 +185,11 @@ export default class GltfViewer {
 
   /** @private */
   loadObject_() {
-    const baseUrl = THREE.LoaderUtils.extractUrlBase(
-        this.options_['hostUrl']);
-
-    const resolvedUrl = resolveURL(this.options_['src'], baseUrl);
-
-    if (resolvedUrl === '') {
-      return this.handlers_.onerror(new Error('invalid url'));
-    }
-
     const loader = new THREE.GLTFLoader();
     loader.crossOrigin = true;
 
     loader.load(
-        resolvedUrl,
+        this.options_['src'],
         /** @param {{scene: !THREE.Scene}} gltfData */
         gltfData => {
           this.setupCameraForObject_(gltfData.scene);

--- a/extensions/amp-3d-gltf/0.1/amp-3d-gltf.js
+++ b/extensions/amp-3d-gltf/0.1/amp-3d-gltf.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import {Deferred} from '../../../src/utils/promise';
-import {assertHttpsUrl} from '../../../src/url';
+import {assertHttpsUrl, resolveRelativeUrl} from '../../../src/url';
 import {dev} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {getIframe, preloadBootstrap} from '../../../src/3p-frame';
@@ -96,7 +96,7 @@ export class Amp3dGltf extends AMP.BaseElement {
         this.element);
 
     this.context_ = dict({
-      'src': src,
+      'src': resolveRelativeUrl(src, this.win.location),
       'renderer': {
         'alpha': getOption('alpha', bool, false),
         'antialias': getOption('antialiasing', bool, true),

--- a/extensions/amp-3d-gltf/0.1/amp-3d-gltf.js
+++ b/extensions/amp-3d-gltf/0.1/amp-3d-gltf.js
@@ -96,7 +96,7 @@ export class Amp3dGltf extends AMP.BaseElement {
         this.element);
 
     this.context_ = dict({
-      'src': resolveRelativeUrl(src, this.getAmpdoc().getUrl()),
+      'src': resolveRelativeUrl(src, this.getAmpDoc().getUrl()),
       'renderer': {
         'alpha': getOption('alpha', bool, false),
         'antialias': getOption('antialiasing', bool, true),

--- a/extensions/amp-3d-gltf/0.1/amp-3d-gltf.js
+++ b/extensions/amp-3d-gltf/0.1/amp-3d-gltf.js
@@ -96,7 +96,7 @@ export class Amp3dGltf extends AMP.BaseElement {
         this.element);
 
     this.context_ = dict({
-      'src': resolveRelativeUrl(src, this.win.location),
+      'src': resolveRelativeUrl(src, this.getAmpdoc().getUrl()),
       'renderer': {
         'alpha': getOption('alpha', bool, false),
         'antialias': getOption('antialiasing', bool, true),

--- a/extensions/amp-3d-gltf/0.1/amp-3d-gltf.js
+++ b/extensions/amp-3d-gltf/0.1/amp-3d-gltf.js
@@ -107,7 +107,6 @@ export class Amp3dGltf extends AMP.BaseElement {
         'enableZoom': getOption('enableZoom', bool, true),
         'autoRotate': getOption('autoRotate', bool, false),
       },
-      'hostUrl': this.win.location.href,
     });
   }
 


### PR DESCRIPTION
Use `resolveRelativeUrl` instead of custom `resolveURL`. Should fix `/`-based urls in src, like `/abc/efg.glb`.