### PR TITLE
Fire amp-ini-load event/postMessage on inabox ini-load event

### DIFF
--- a/src/inabox/utils.js
+++ b/src/inabox/utils.js
@@ -34,7 +34,7 @@ export function registerIniLoadListener(ampdoc) {
         win.dispatchEvent(createCustomEvent(
             win, 'amp-ini-load', /* detail */ null, {bubbles: true}));
         if (win.parent) {
-          win.parent.postMessage('amp-ini-load', '*');
+          win.parent./*OK*/postMessage('amp-ini-load', '*');
         }
       });
 }

--- a/src/inabox/utils.js
+++ b/src/inabox/utils.js
@@ -14,10 +14,6 @@
  * limitations under the License.
  */
 
-/**
- * The entry point for AMP inabox runtime (inabox-v0.js).
- */
-
 import {Services} from '../services';
 import {createCustomEvent} from '../event-helper.js';
 import {whenContentIniLoad} from '../friendly-iframe-embed';

--- a/src/inabox/utils.js
+++ b/src/inabox/utils.js
@@ -25,7 +25,7 @@ import {whenContentIniLoad} from '../friendly-iframe-embed';
  * @param {!../service/ampdoc-impl.AmpDoc} ampdoc
  */
 export function registerIniLoadListener(ampdoc) {
-  const win = ampdoc.win;
+  const {win} = ampdoc;
   const root = ampdoc.getRootNode();
   whenContentIniLoad(ampdoc, win,
       Services.viewportForDoc(ampdoc).getLayoutRect(

--- a/src/inabox/utils.js
+++ b/src/inabox/utils.js
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The entry point for AMP inabox runtime (inabox-v0.js).
+ */
+
+import {Services} from '../services';
+import {createCustomEvent} from '../event-helper.js';
+import {whenContentIniLoad} from '../friendly-iframe-embed';
+
+/**
+ * Registers ini-load listener that will fire custom 'amp-ini-load' event
+ * on window (accessible if creative is friendly to ad tag) and postMessage to
+ * window parent.
+ * @param {!../service/ampdoc-impl.AmpDoc} ampdoc
+ */
+export function registerIniLoadListener(ampdoc) {
+  const win = ampdoc.win;
+  const root = ampdoc.getRootNode();
+  whenContentIniLoad(ampdoc, win,
+      Services.viewportForDoc(ampdoc).getLayoutRect(
+          root.documentElement || root.body || root))
+      .then(() => {
+        win.dispatchEvent(createCustomEvent(
+            win, 'amp-ini-load', /* detail */ null, {bubbles: true}));
+        if (win.parent) {
+          win.parent.postMessage('amp-ini-load', '*');
+        }
+      });
+}

--- a/test/functional/inabox/test-utils.js
+++ b/test/functional/inabox/test-utils.js
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Deferred} from '../../../src/utils/promise';
+import {Services} from '../../../src/services';
+import {registerIniLoadListener} from '../../../src/inabox/utils';
+
+describes.fakeWin('inabox-utils', {}, env => {
+  let getResourcesInRectStub;
+  let dispatchEventStub;
+  let parentPostMessageStub;
+  let initCustomEventStub;
+  let ampdoc;
+
+  beforeEach(() => {
+    ampdoc = {win: env.win, getRootNode: () => ({})};
+    getResourcesInRectStub = sandbox.stub();
+    sandbox.stub(Services, 'resourcesForDoc').withArgs(ampdoc).returns(
+        {getResourcesInRect: getResourcesInRectStub});
+    sandbox.stub(Services, 'viewportForDoc').withArgs(ampdoc).returns(
+        {getLayoutRect: () => ({})});
+    parentPostMessageStub = sandbox.stub();
+    dispatchEventStub = sandbox.stub();
+    initCustomEventStub = sandbox.stub();
+    env.win.parent = {postMessage: parentPostMessageStub};
+    env.win.document =
+      {createEvent: () => ({initCustomEvent: initCustomEventStub})};
+    env.win.dispatchEvent = dispatchEventStub;
+  });
+
+  it('should fire custom event and postMessage', () => {
+    const iniLoadDeferred = new Deferred();
+    getResourcesInRectStub.returns(iniLoadDeferred.promise);
+    registerIniLoadListener(ampdoc);
+    expect(dispatchEventStub).to.not.be.called;
+    expect(parentPostMessageStub).to.not.be.called;
+    iniLoadDeferred.resolve([]);
+    const timeDeferred = new Deferred();
+    setTimeout(() => timeDeferred.resolve(), 10);
+    return timeDeferred.promise.then(() => {
+      expect(dispatchEventStub).to.be.calledOnce;
+      expect(initCustomEventStub.withArgs('amp-ini-load', true, false, null))
+          .to.be.calledOnce;
+      expect(parentPostMessageStub.withArgs('amp-ini-load', '*'))
+          .to.be.calledOnce;
+    });
+  });
+});

--- a/validator/engine/validator_test.js
+++ b/validator/engine/validator_test.js
@@ -655,6 +655,7 @@ function attrRuleShouldMakeSense(attrSpec, rules) {
     // Attribute Spec names are matched against lowercased attributes,
     // so the rules *must* also be lower case or non-cased.
     const attrSpecNameRegex = new RegExp('^[^A-Z]+$');
+
     expect(attrSpecNameRegex.test(attrSpec.name)).toBe(true);
   });
   if (attrSpec.valueUrl !== null) {

--- a/validator/engine/validator_test.js
+++ b/validator/engine/validator_test.js
@@ -655,7 +655,6 @@ function attrRuleShouldMakeSense(attrSpec, rules) {
     // Attribute Spec names are matched against lowercased attributes,
     // so the rules *must* also be lower case or non-cased.
     const attrSpecNameRegex = new RegExp('^[^A-Z]+$');
-
     expect(attrSpecNameRegex.test(attrSpec.name)).toBe(true);
   });
   if (attrSpec.valueUrl !== null) {


### PR DESCRIPTION
Ad tags often use the load event to determine when a creative has completed rendering and resource fetch/execution however for AMP load is an "inaccurate" event.  For inabox, allow for parent window (both friendly and cross) to detect when ini-load fires by listening for custom 'amp-ini-load' event and/or postMessage with 'amp-ini-load' content.