### PR TITLE
Fix flaky performance test on Safari

### DIFF
--- a/test/functional/test-performance.js
+++ b/test/functional/test-performance.js
@@ -544,7 +544,7 @@ describes.realWin('performance', {amp: true}, env => {
             expect(viewerSendMessageStub.withArgs(
                 'prerenderComplete').firstCall.args[1].value).to.equal(400);
 
-            expect(getPerformanceMarks()).to.deep.equal(
+            expect(getPerformanceMarks()).to.have.members(
                 ['ol', 'ofv', 'pc']);
           });
         });


### PR DESCRIPTION
```
pr-check.js: Running gulp test --unit --nobuild --saucelabs_lite...

DESCRIBE => performance
  DESCRIBE =>  
    DESCRIBE => coreServicesAvailable
      DESCRIBE => document started in prerender
        IT => should call prerenderComplete on viewer
          ✗ expected [ 'ol', 'pc', 'ofv' ] to deeply equal [ 'ol', 'ofv', 'pc' ]

[16:25:43] Safari 11.0.3 (Mac OS X 10.12.6): Executed 3278 of 3578 (Skipped 300) 1 FAILED
```