### PR TITLE
Remove flaky/non-functional integration tests

### DIFF
--- a/extensions/amp-3d-gltf/0.1/test/integration/test-amp-3d-gltf.js
+++ b/extensions/amp-3d-gltf/0.1/test/integration/test-amp-3d-gltf.js
@@ -14,29 +14,12 @@
  * limitations under the License.
  */
 
-import {poll} from '../../../../../testing/iframe';
-
-describe('amp-3d-gltf', function() {
-  describes.integration('amp-3d-gltf iframe renders', {
-    body: '<amp-3d-gltf layout="fixed"' +
-                      ' width="200"' +
-                      ' height="200"' +
-                      ' src="/123"></amp-3d-gltf>',
-    extensions: ['amp-3d-gltf'],
-  }, () => {
-
-    it('iframe renders', () => {
-      const loadPromise = waitForAnimationLoad();
-      return loadPromise.then(iframeExists => {
-        expect(iframeExists).to.be.true;
-      });
-    });
-  });
+describes.integration('amp-3d-gltf', {
+  body: '<amp-3d-gltf layout="fixed"' +
+                    ' width="200"' +
+                    ' height="200"' +
+                    ' src="/123"></amp-3d-gltf>',
+  extensions: ['amp-3d-gltf'],
+}, () => {
+  // TODO(mixtur): Add tests.
 });
-
-function waitForAnimationLoad() {
-  return poll('wait for iframe to load', () => {
-    const iframe = document.getElementsByTagName('iframe')[0];
-    return iframe !== null;
-  });
-}

--- a/extensions/amp-bodymovin-animation/0.1/test/integration/test-amp-bodymovin-animation.js
+++ b/extensions/amp-bodymovin-animation/0.1/test/integration/test-amp-bodymovin-animation.js
@@ -14,9 +14,6 @@
  * limitations under the License.
  */
 
-import {AmpBodymovinAnimation} from '../../amp-bodymovin-animation';
-import {poll} from '../../../../../testing/iframe';
-
 describe.configure().ifNewChrome().run('amp-bodymovin-animation', function() {
   const extensions = ['amp-bodymovin-animation'];
   const bodymovinBody = `
@@ -25,17 +22,19 @@ describe.configure().ifNewChrome().run('amp-bodymovin-animation', function() {
       src="testresource.json">
     </amp-bodymovin-animation>
     <div id="stop" on="tap:anim.stop">Stop</div>`;
+
   describes.integration('amp-bodymovin-animation iframe renders', {
     body: bodymovinBody,
     extensions,
-  }, () => {
+  }, unusedEnv => {
+    // TODO(nainar): Add test.
+  });
 
-    it('iframe renders', () => {
-      const loadPromise = waitForAnimationLoad();
-      return loadPromise.then(iframeExists => {
-        expect(iframeExists).to.be.true;
-      });
-    });
+  describes.integration('amp-bodymovin-animation actions work', {
+    body: bodymovinBody,
+    extensions,
+  }, unusedEnv => {
+    // TODO(nainar): Add test.
   });
 
   const bodymovinNoAutoplayBody = `
@@ -50,53 +49,8 @@ describe.configure().ifNewChrome().run('amp-bodymovin-animation', function() {
   describes.integration('amp-bodymovin-animation actions work', {
     body: bodymovinNoAutoplayBody,
     extensions,
-  }, env => {
-
-    let playSpy;
-    let pauseSpy;
-
-    beforeEach(() => {
-      playSpy = sandbox.spy(AmpBodymovinAnimation.prototype, 'play_');
-      pauseSpy = sandbox.spy(AmpBodymovinAnimation.prototype, 'pause_');
-    });
-
-
-    it('play/pause actions work on `<amp-bodymovin-animation>` elements',
-        () => {
-          const loadPromise = waitForAnimationLoad();
-          return loadPromise.then(iframeExists => {
-            expect(iframeExists).to.be.true;
-            const playTrigger = env.win.document.querySelector('#play');
-            playTrigger.click();
-            expect(playSpy).to.not.have.been.called;
-            const pauseTrigger = env.win.document.querySelector('#pause');
-            pauseTrigger.click();
-            expect(pauseSpy).to.not.have.been.called;
-          });
-        });
-  });
-
-  describes.integration('amp-bodymovin-animation actions work', {
-    body: bodymovinBody,
-    extensions,
-  }, env => {
-
-    let stopSpy;
-
-    beforeEach(() => {
-      stopSpy = sandbox.spy(AmpBodymovinAnimation.prototype, 'stop_');
-    });
-
-
-    it('stop action works on `<amp-bodymovin-animation>` elements', () => {
-      const loadPromise = waitForAnimationLoad();
-      return loadPromise.then(iframeExists => {
-        expect(iframeExists).to.be.true;
-        const stopTrigger = env.win.document.querySelector('#stop');
-        stopTrigger.click();
-        expect(stopSpy).to.not.have.been.called;
-      });
-    });
+  }, unusedEnv => {
+    // TODO(nainar): Add test.
   });
 
   const bodymovinSeekToBody = `
@@ -110,30 +64,7 @@ describe.configure().ifNewChrome().run('amp-bodymovin-animation', function() {
   describes.integration('amp-bodymovin-animation actions work', {
     body: bodymovinSeekToBody,
     extensions,
-  }, env => {
-
-    let seekToSpy;
-
-    beforeEach(() => {
-      seekToSpy = sandbox.spy(AmpBodymovinAnimation.prototype, 'seekTo_');
-    });
-
-
-    it('seekTo action works on `<amp-bodymovin-animation>` elements', () => {
-      const loadPromise = waitForAnimationLoad();
-      return loadPromise.then(iframeExists => {
-        expect(iframeExists).to.be.true;
-        const seekToHalfTrigger = env.win.document.querySelector('#seekToHalf');
-        seekToHalfTrigger.click();
-        expect(seekToSpy).to.not.have.been.called;
-      });
-    });
+  }, unusedEnv => {
+    // TODO(nainar): Add test.
   });
 });
-
-function waitForAnimationLoad() {
-  return poll('wait for iframe to load', () => {
-    const iframe = document.getElementsByTagName('iframe')[0];
-    return iframe !== null;
-  });
-}


### PR DESCRIPTION
Apologies for my forwardness here. I noticed a test flake from `test-amp-3d-gltf.js` on one of my PRs and after some digging, noticed that it and `test-amp-bodymovin-animation.js` weren't really testing anything.

- document.getElementByTagName('iframe')[0] returns the test iframe, not the child iframe of the AMP element
- We should only be using function spies in unit tests, not integration tests. In fact, if you open the console logs while running `test-amp-bodymovin-animation` you'll notice that the AMP element fails to build (which is what an integration test should catch!)

Let's try to rewrite these in a way that tests observable behaviors (e.g. DOM structure) rather than function invocations, OR move them into unit tests.

/to @nainar @aghassemi /cc @mixtur 