### PR TITLE
Disallows `bookend-config-src` attr in `amp-story` tag

### DIFF
--- a/extensions/amp-story-auto-ads/0.1/test/validator-amp-story-auto-ads.out
+++ b/extensions/amp-story-auto-ads/0.1/test/validator-amp-story-auto-ads.out
@@ -34,7 +34,7 @@ PASS
 |  <body>
 |    <amp-story standalone>
 >>   ^~~~~~~~~
-amp-story-auto-ads/0.1/test/validator-amp-story-auto-ads.html:34:2 The tag 'AMP-STORY (beta)' is deprecated - use 'AMP-STORY' instead. (see https://www.ampproject.org/docs/reference/components/amp-story#announcements) [DEPRECATION]
+amp-story-auto-ads/0.1/test/validator-amp-story-auto-ads.html:34:2 The tag 'AMP-STORY (beta)' is deprecated - use 'AMP-STORY' instead. (see https://www.ampproject.org/docs/reference/components/amp-story#migrating-from-0.1-to-1.0) [DEPRECATION]
 |      <amp-story-page id="1">
 |        <amp-story-grid-layer template="horizontal">
 |        </amp-story-grid-layer>

--- a/extensions/amp-story/0.1/test/validator-amp-story-animations-error.out
+++ b/extensions/amp-story/0.1/test/validator-amp-story-animations-error.out
@@ -47,7 +47,7 @@ FAIL
 |  <body>
 |    <amp-story standalone>
 >>   ^~~~~~~~~
-amp-story/0.1/test/validator-amp-story-animations-error.html:47:2 The tag 'AMP-STORY (beta)' is deprecated - use 'AMP-STORY' instead. (see https://www.ampproject.org/docs/reference/components/amp-story#announcements) [DEPRECATION]
+amp-story/0.1/test/validator-amp-story-animations-error.html:47:2 The tag 'AMP-STORY (beta)' is deprecated - use 'AMP-STORY' instead. (see https://www.ampproject.org/docs/reference/components/amp-story#migrating-from-0.1-to-1.0) [DEPRECATION]
 |      <amp-story-page id="combining-animations">
 |          <amp-story-grid-layer template="thirds">
 |            <h1>invalid animation value + empty animation value</h1>

--- a/extensions/amp-story/0.1/test/validator-amp-story-animations.out
+++ b/extensions/amp-story/0.1/test/validator-amp-story-animations.out
@@ -45,7 +45,7 @@ PASS
 |  <body>
 |    <amp-story standalone>
 >>   ^~~~~~~~~
-amp-story/0.1/test/validator-amp-story-animations.html:45:2 The tag 'AMP-STORY (beta)' is deprecated - use 'AMP-STORY' instead. (see https://www.ampproject.org/docs/reference/components/amp-story#announcements) [DEPRECATION]
+amp-story/0.1/test/validator-amp-story-animations.html:45:2 The tag 'AMP-STORY (beta)' is deprecated - use 'AMP-STORY' instead. (see https://www.ampproject.org/docs/reference/components/amp-story#migrating-from-0.1-to-1.0) [DEPRECATION]
 |      <amp-story-page id="ken-burns-effect">
 |        <amp-story-grid-layer template="vertical">
 |          <h1>ken-burns-effect</h1>

--- a/extensions/amp-story/0.1/test/validator-amp-story-deprecated.out
+++ b/extensions/amp-story/0.1/test/validator-amp-story-deprecated.out
@@ -32,7 +32,7 @@ PASS
 |  <body>
 |    <amp-story standalone bookend-config-src="./bookend-config-src.json" background-audio="path/to/my.mp3">
 >>   ^~~~~~~~~
-amp-story/0.1/test/validator-amp-story-deprecated.html:32:2 The tag 'AMP-STORY (beta)' is deprecated - use 'AMP-STORY' instead. (see https://www.ampproject.org/docs/reference/components/amp-story#announcements) [DEPRECATION]
+amp-story/0.1/test/validator-amp-story-deprecated.html:32:2 The tag 'AMP-STORY (beta)' is deprecated - use 'AMP-STORY' instead. (see https://www.ampproject.org/docs/reference/components/amp-story#migrating-from-0.1-to-1.0) [DEPRECATION]
 |      <amp-story-page id="1" background-audio="path/to/my.mp3" auto-advance-after="any-value">
 |        <amp-story-grid-layer template="horizontal">
 |          <h5 animate-in="drop">

--- a/extensions/amp-story/0.1/test/validator-amp-story-reference-point.html
+++ b/extensions/amp-story/0.1/test/validator-amp-story-reference-point.html
@@ -29,7 +29,7 @@
   <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-0.1.js"></script>
 </head>
 <body>
-  <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/poster.jpg" bookend-config-src="./related.json" background-audio="path/to/my.mp3">
+  <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/poster.jpg" background-audio="path/to/my.mp3">
     <amp-story-page id="1" background-audio="path/to/my.mp3" auto-advance-after="any-value">
       <amp-story-grid-layer template="horizontal">
         <img class="footer-logo" src="img/foot-logo.svg" width="40" height="40" /> <!-- The real error here is that <img/> tag is not allowed. But this is a weird use case where the validator error will comment about reference points. This needs to be fixed in the near future. -->

--- a/extensions/amp-story/0.1/test/validator-amp-story-reference-point.out
+++ b/extensions/amp-story/0.1/test/validator-amp-story-reference-point.out
@@ -30,7 +30,7 @@ FAIL
 |    <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-0.1.js"></script>
 |  </head>
 |  <body>
-|    <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/poster.jpg" bookend-config-src="./related.json" background-audio="path/to/my.mp3">
+|    <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/poster.jpg" background-audio="path/to/my.mp3">
 |      <amp-story-page id="1" background-audio="path/to/my.mp3" auto-advance-after="any-value">
 |        <amp-story-grid-layer template="horizontal">
 |          <img class="footer-logo" src="img/foot-logo.svg" width="40" height="40" /> <!-- The real error here is that <img/> tag is not allowed. But this is a weird use case where the validator error will comment about reference points. This needs to be fixed in the near future. -->

--- a/extensions/amp-story/0.1/test/validator-amp-story-video-error.html
+++ b/extensions/amp-story/0.1/test/validator-amp-story-video-error.html
@@ -31,7 +31,7 @@
   <script async custom-element="amp-video" src="https://cdn.ampproject.org/v0/amp-video-0.1.js"></script>
 </head>
 <body>
-  <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/poster.jpg" bookend-config-src="./related.json" background-audio="path/to/my.mp3">
+  <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/poster.jpg" background-audio="path/to/my.mp3">
     <amp-story-page id="1" background-audio="path/to/my.mp3" auto-advance-after="any-value">
       <amp-story-grid-layer template="horizontal">
         <!-- This should fail because amp-video doesn't have the [poster] attribute. -->

--- a/extensions/amp-story/0.1/test/validator-amp-story-video-error.out
+++ b/extensions/amp-story/0.1/test/validator-amp-story-video-error.out
@@ -32,7 +32,7 @@ FAIL
 |    <script async custom-element="amp-video" src="https://cdn.ampproject.org/v0/amp-video-0.1.js"></script>
 |  </head>
 |  <body>
-|    <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/poster.jpg" bookend-config-src="./related.json" background-audio="path/to/my.mp3">
+|    <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/poster.jpg" background-audio="path/to/my.mp3">
 |      <amp-story-page id="1" background-audio="path/to/my.mp3" auto-advance-after="any-value">
 |        <amp-story-grid-layer template="horizontal">
 |          <!-- This should fail because amp-video doesn't have the [poster] attribute. -->

--- a/extensions/amp-story/0.1/test/validator-amp-story.html
+++ b/extensions/amp-story/0.1/test/validator-amp-story.html
@@ -29,7 +29,7 @@
   <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-0.1.js"></script>
 </head>
 <body>
-  <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/portrait.jpg" poster-square-src="http://me.com/square.jpg" poster-landscape-src="http://me.com/landscape.jpg" bookend-config-src="http://me.com/bookend-config-src.json" background-audio="http://me.com/path/to/my.mp3">
+  <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/portrait.jpg" poster-square-src="http://me.com/square.jpg" poster-landscape-src="http://me.com/landscape.jpg" background-audio="http://me.com/path/to/my.mp3">
     <amp-story-page id="1" background-audio="path/to/my.mp3" auto-advance-after="any-value">
       <amp-story-grid-layer template="horizontal">
         <h5 animate-in="drop">

--- a/extensions/amp-story/0.1/test/validator-amp-story.out
+++ b/extensions/amp-story/0.1/test/validator-amp-story.out
@@ -30,7 +30,7 @@ PASS
 |    <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-0.1.js"></script>
 |  </head>
 |  <body>
-|    <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/portrait.jpg" poster-square-src="http://me.com/square.jpg" poster-landscape-src="http://me.com/landscape.jpg" bookend-config-src="http://me.com/bookend-config-src.json" background-audio="http://me.com/path/to/my.mp3">
+|    <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/portrait.jpg" poster-square-src="http://me.com/square.jpg" poster-landscape-src="http://me.com/landscape.jpg" background-audio="http://me.com/path/to/my.mp3">
 |      <amp-story-page id="1" background-audio="path/to/my.mp3" auto-advance-after="any-value">
 |        <amp-story-grid-layer template="horizontal">
 |          <h5 animate-in="drop">

--- a/extensions/amp-story/1.0/test/validator-amp-story-animations-error.out
+++ b/extensions/amp-story/1.0/test/validator-amp-story-animations-error.out
@@ -47,7 +47,7 @@ FAIL
 |  <body>
 |    <amp-story standalone>
 >>   ^~~~~~~~~
-amp-story/1.0/test/validator-amp-story-animations-error.html:47:2 The tag 'AMP-STORY (beta)' is deprecated - use 'AMP-STORY' instead. (see https://www.ampproject.org/docs/reference/components/amp-story#announcements) [DEPRECATION]
+amp-story/1.0/test/validator-amp-story-animations-error.html:47:2 The tag 'AMP-STORY (beta)' is deprecated - use 'AMP-STORY' instead. (see https://www.ampproject.org/docs/reference/components/amp-story#migrating-from-0.1-to-1.0) [DEPRECATION]
 |      <amp-story-page id="combining-animations">
 |          <amp-story-grid-layer template="thirds">
 |            <h1>invalid animation value + empty animation value</h1>

--- a/extensions/amp-story/1.0/test/validator-amp-story-animations.out
+++ b/extensions/amp-story/1.0/test/validator-amp-story-animations.out
@@ -45,7 +45,7 @@ PASS
 |  <body>
 |    <amp-story standalone>
 >>   ^~~~~~~~~
-amp-story/1.0/test/validator-amp-story-animations.html:45:2 The tag 'AMP-STORY (beta)' is deprecated - use 'AMP-STORY' instead. (see https://www.ampproject.org/docs/reference/components/amp-story#announcements) [DEPRECATION]
+amp-story/1.0/test/validator-amp-story-animations.html:45:2 The tag 'AMP-STORY (beta)' is deprecated - use 'AMP-STORY' instead. (see https://www.ampproject.org/docs/reference/components/amp-story#migrating-from-0.1-to-1.0) [DEPRECATION]
 |      <amp-story-page id="ken-burns-effect">
 |        <amp-story-grid-layer template="vertical">
 |          <h1>ken-burns-effect</h1>

--- a/extensions/amp-story/1.0/test/validator-amp-story-bookend-error.html
+++ b/extensions/amp-story/1.0/test/validator-amp-story-bookend-error.html
@@ -64,7 +64,8 @@
   <amp-story standalone title="My Story"
     publisher="The AMP Team"
     publisher-logo-src="https://example.com/logo/1x1.png"
-    poster-portrait-src="https://example.com/my-story/poster/3x4.jpg">
+    poster-portrait-src="https://example.com/my-story/poster/3x4.jpg"
+    bookend-config-src="bookendv01.json">
     <amp-story-page id="cover">
       <amp-story-grid-layer template="vertical">
         <h1>Advance to see the bookend!</h1>

--- a/extensions/amp-story/1.0/test/validator-amp-story-bookend-error.out
+++ b/extensions/amp-story/1.0/test/validator-amp-story-bookend-error.out
@@ -63,9 +63,12 @@ FAIL
 |  </head>
 |  <body>
 |    <amp-story standalone title="My Story"
+>>   ^~~~~~~~~
+amp-story/1.0/test/validator-amp-story-bookend-error.html:64:2 The attribute 'bookend-config-src' in tag 'amp-story' is deprecated - use 'AMP-STORY-BOOKEND' instead. (see https://www.ampproject.org/docs/reference/components/amp-story#announcements) [DEPRECATION]
 |      publisher="The AMP Team"
 |      publisher-logo-src="https://example.com/logo/1x1.png"
-|      poster-portrait-src="https://example.com/my-story/poster/3x4.jpg">
+|      poster-portrait-src="https://example.com/my-story/poster/3x4.jpg"
+|      bookend-config-src="bookendv01.json">
 |      <amp-story-page id="cover">
 |        <amp-story-grid-layer template="vertical">
 |          <h1>Advance to see the bookend!</h1>
@@ -73,7 +76,7 @@ FAIL
 |      </amp-story-page>
 |      <amp-story-bookend src="bookendv1.json" layout=nodisplay>
 >>     ^~~~~~~~~
-amp-story/1.0/test/validator-amp-story-bookend-error.html:73:4 Tag 'amp-story-bookend' must have 0 child tags - saw 1 child tags. [AMP_TAG_PROBLEM]
+amp-story/1.0/test/validator-amp-story-bookend-error.html:74:4 Tag 'amp-story-bookend' must have 0 child tags - saw 1 child tags. [AMP_TAG_PROBLEM]
 |        <h1>Illegal child inside amp-story-bookend!</h1>
 |      </amp-story-bookend>
 |    </amp-story>

--- a/extensions/amp-story/1.0/test/validator-amp-story-bookend-error.out
+++ b/extensions/amp-story/1.0/test/validator-amp-story-bookend-error.out
@@ -64,7 +64,7 @@ FAIL
 |  <body>
 |    <amp-story standalone title="My Story"
 >>   ^~~~~~~~~
-amp-story/1.0/test/validator-amp-story-bookend-error.html:64:2 The attribute 'bookend-config-src' in tag 'amp-story' is deprecated - use 'AMP-STORY-BOOKEND' instead. (see https://www.ampproject.org/docs/reference/components/amp-story#announcements) [DEPRECATION]
+amp-story/1.0/test/validator-amp-story-bookend-error.html:64:2 The attribute 'bookend-config-src' in tag 'amp-story' is deprecated - use 'AMP-STORY-BOOKEND' instead. (see https://www.ampproject.org/docs/reference/components/amp-story#migrating-from-0.1-to-1.0) [DEPRECATION]
 |      publisher="The AMP Team"
 |      publisher-logo-src="https://example.com/logo/1x1.png"
 |      poster-portrait-src="https://example.com/my-story/poster/3x4.jpg"

--- a/extensions/amp-story/1.0/test/validator-amp-story-deprecated.out
+++ b/extensions/amp-story/1.0/test/validator-amp-story-deprecated.out
@@ -32,7 +32,7 @@ PASS
 |  <body>
 |    <amp-story standalone bookend-config-src="./bookend-config-src.json" background-audio="path/to/my.mp3">
 >>   ^~~~~~~~~
-amp-story/1.0/test/validator-amp-story-deprecated.html:32:2 The tag 'AMP-STORY (beta)' is deprecated - use 'AMP-STORY' instead. (see https://www.ampproject.org/docs/reference/components/amp-story#announcements) [DEPRECATION]
+amp-story/1.0/test/validator-amp-story-deprecated.html:32:2 The tag 'AMP-STORY (beta)' is deprecated - use 'AMP-STORY' instead. (see https://www.ampproject.org/docs/reference/components/amp-story#migrating-from-0.1-to-1.0) [DEPRECATION]
 |      <amp-story-page id="1" background-audio="path/to/my.mp3" auto-advance-after="any-value">
 |        <amp-story-grid-layer template="horizontal">
 |          <h5 animate-in="drop">

--- a/extensions/amp-story/1.0/test/validator-amp-story-reference-point.html
+++ b/extensions/amp-story/1.0/test/validator-amp-story-reference-point.html
@@ -29,12 +29,13 @@
   <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-1.0.js"></script>
 </head>
 <body>
-  <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/poster.jpg" bookend-config-src="./related.json" background-audio="path/to/my.mp3">
+  <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/poster.jpg" background-audio="path/to/my.mp3">
     <amp-story-page id="1" background-audio="path/to/my.mp3" auto-advance-after="any-value">
       <amp-story-grid-layer template="horizontal">
         <img class="footer-logo" src="img/foot-logo.svg" width="40" height="40" /> <!-- The real error here is that <img/> tag is not allowed. But this is a weird use case where the validator error will comment about reference points. This needs to be fixed in the near future. -->
       </amp-story-grid-layer>
     </amp-story-page>
+    <amp-story-bookend src="./related.json" layout="nodisplay"></amp-story-bookend>
   </amp-story>
 </body>
 </html>

--- a/extensions/amp-story/1.0/test/validator-amp-story-reference-point.out
+++ b/extensions/amp-story/1.0/test/validator-amp-story-reference-point.out
@@ -30,7 +30,7 @@ FAIL
 |    <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-1.0.js"></script>
 |  </head>
 |  <body>
-|    <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/poster.jpg" bookend-config-src="./related.json" background-audio="path/to/my.mp3">
+|    <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/poster.jpg" background-audio="path/to/my.mp3">
 |      <amp-story-page id="1" background-audio="path/to/my.mp3" auto-advance-after="any-value">
 |        <amp-story-grid-layer template="horizontal">
 |          <img class="footer-logo" src="img/foot-logo.svg" width="40" height="40" /> <!-- The real error here is that <img/> tag is not allowed. But this is a weird use case where the validator error will comment about reference points. This needs to be fixed in the near future. -->
@@ -42,6 +42,7 @@ amp-story/1.0/test/validator-amp-story-reference-point.html:35:8 The tag 'img' m
 amp-story/1.0/test/validator-amp-story-reference-point.html:35:8 The tag 'img' may not appear as a descendant of tag 'amp-story-grid-layer'. (see https://www.ampproject.org/docs/reference/components/amp-img) [AMP_TAG_PROBLEM]
 |        </amp-story-grid-layer>
 |      </amp-story-page>
+|      <amp-story-bookend src="./related.json" layout="nodisplay"></amp-story-bookend>
 |    </amp-story>
 |  </body>
 |  </html>

--- a/extensions/amp-story/1.0/test/validator-amp-story-video-error.html
+++ b/extensions/amp-story/1.0/test/validator-amp-story-video-error.html
@@ -31,7 +31,7 @@
   <script async custom-element="amp-video" src="https://cdn.ampproject.org/v0/amp-video-0.1.js"></script>
 </head>
 <body>
-  <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/poster.jpg" bookend-config-src="./related.json" background-audio="path/to/my.mp3">
+  <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/poster.jpg" background-audio="path/to/my.mp3">
     <amp-story-page id="1" background-audio="path/to/my.mp3" auto-advance-after="any-value">
       <amp-story-grid-layer template="horizontal">
         <!-- This should fail because amp-video doesn't have the [poster] attribute. -->

--- a/extensions/amp-story/1.0/test/validator-amp-story-video-error.out
+++ b/extensions/amp-story/1.0/test/validator-amp-story-video-error.out
@@ -32,7 +32,7 @@ FAIL
 |    <script async custom-element="amp-video" src="https://cdn.ampproject.org/v0/amp-video-0.1.js"></script>
 |  </head>
 |  <body>
-|    <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/poster.jpg" bookend-config-src="./related.json" background-audio="path/to/my.mp3">
+|    <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/poster.jpg" background-audio="path/to/my.mp3">
 |      <amp-story-page id="1" background-audio="path/to/my.mp3" auto-advance-after="any-value">
 |        <amp-story-grid-layer template="horizontal">
 |          <!-- This should fail because amp-video doesn't have the [poster] attribute. -->

--- a/extensions/amp-story/1.0/test/validator-amp-story.html
+++ b/extensions/amp-story/1.0/test/validator-amp-story.html
@@ -29,7 +29,7 @@
   <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-1.0.js"></script>
 </head>
 <body>
-  <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/portrait.jpg" poster-square-src="http://me.com/square.jpg" poster-landscape-src="http://me.com/landscape.jpg" bookend-config-src="http://me.com/bookend-config-src.json" background-audio="http://me.com/path/to/my.mp3">
+  <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/portrait.jpg" poster-square-src="http://me.com/square.jpg" poster-landscape-src="http://me.com/landscape.jpg" background-audio="http://me.com/path/to/my.mp3">
     <amp-story-page id="1" background-audio="path/to/my.mp3" auto-advance-after="any-value">
       <amp-story-grid-layer template="horizontal">
         <h5 animate-in="drop">
@@ -49,6 +49,7 @@
         <h1></h1>
       </amp-story-grid-layer>
     </amp-story-page>
+    <amp-story-bookend src="http://me.com/bookend-config-src.json" layout="nodisplay"></amp-story-bookend>
   </amp-story>
 </body>
 </html>

--- a/extensions/amp-story/1.0/test/validator-amp-story.out
+++ b/extensions/amp-story/1.0/test/validator-amp-story.out
@@ -30,7 +30,7 @@ PASS
 |    <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-1.0.js"></script>
 |  </head>
 |  <body>
-|    <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/portrait.jpg" poster-square-src="http://me.com/square.jpg" poster-landscape-src="http://me.com/landscape.jpg" bookend-config-src="http://me.com/bookend-config-src.json" background-audio="http://me.com/path/to/my.mp3">
+|    <amp-story standalone title="My Story" publisher="Me" publisher-logo-src="http://me.com/logo.png" poster-portrait-src="http://me.com/portrait.jpg" poster-square-src="http://me.com/square.jpg" poster-landscape-src="http://me.com/landscape.jpg" background-audio="http://me.com/path/to/my.mp3">
 |      <amp-story-page id="1" background-audio="path/to/my.mp3" auto-advance-after="any-value">
 |        <amp-story-grid-layer template="horizontal">
 |          <h5 animate-in="drop">
@@ -50,6 +50,7 @@ PASS
 |          <h1></h1>
 |        </amp-story-grid-layer>
 |      </amp-story-page>
+|      <amp-story-bookend src="http://me.com/bookend-config-src.json" layout="nodisplay"></amp-story-bookend>
 |    </amp-story>
 |  </body>
 |  </html>

--- a/extensions/amp-story/validator-amp-story.protoascii
+++ b/extensions/amp-story/validator-amp-story.protoascii
@@ -49,7 +49,7 @@ tags: {  # <amp-story>
       allowed_protocol: "https"
     }
     deprecation: "AMP-STORY-BOOKEND"
-    deprecation_url: "https://www.ampproject.org/docs/reference/components/amp-story#announcements"
+    deprecation_url: "https://www.ampproject.org/docs/reference/components/amp-story#migrating-from-0.1-to-1.0"
   }
   attrs: {
     name: "poster-landscape-src"
@@ -111,7 +111,7 @@ tags: {  # <amp-story> without metadata (deprecated)
   tag_name: "AMP-STORY"
   spec_name: "AMP-STORY (beta)"
   deprecation: "AMP-STORY"
-  deprecation_url: "https://www.ampproject.org/docs/reference/components/amp-story#announcements"
+  deprecation_url: "https://www.ampproject.org/docs/reference/components/amp-story#migrating-from-0.1-to-1.0"
   requires_extension: "amp-story"
   mandatory_parent: "BODY"
   requires: "amp-story-page"

--- a/extensions/amp-story/validator-amp-story.protoascii
+++ b/extensions/amp-story/validator-amp-story.protoascii
@@ -48,6 +48,8 @@ tags: {  # <amp-story>
       allowed_protocol: "http"
       allowed_protocol: "https"
     }
+    deprecation: "AMP-STORY-BOOKEND"
+    deprecation_url: "https://www.ampproject.org/docs/reference/components/amp-story#announcements"
   }
   attrs: {
     name: "poster-landscape-src"


### PR DESCRIPTION
Closes #15796

With the introduction of the bookend config API, we want to deprecate and eventually remove the ability to add a `bookend-config-src` attribute in the `amp-story` tag.