### PR TITLE
🐛Support fullscreening <video>s in <amp-twitter>

### DIFF
--- a/extensions/amp-ad/0.1/amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/amp-ad-3p-impl.js
@@ -364,7 +364,7 @@ export class AmpAd3PImpl extends AMP.BaseElement {
       this.emitLifecycleEvent('adRequestStart');
       const iframe = getIframe(toWin(this.element.ownerDocument.defaultView),
           this.element, this.type_, opt_context,
-          this.config.remoteHTMLDisabled);
+          {disallowCustom: this.config.remoteHTMLDisabled});
       this.xOriginIframeHandler_ = new AmpAdXOriginIframeHandler(
           this);
       return this.xOriginIframeHandler_.init(iframe);

--- a/extensions/amp-ima-video/0.1/amp-ima-video.js
+++ b/extensions/amp-ima-video/0.1/amp-ima-video.js
@@ -169,9 +169,7 @@ class AmpImaVideo extends AMP.BaseElement {
     return consentPromise.then(initialConsentState => {
       const {element, win} = this;
       const iframe = getIframe(win, element, 'ima-video',
-          {initialConsentState});
-
-      iframe.setAttribute('allowfullscreen', 'true');
+          {initialConsentState}, {allowFullscreen: true});
 
       this.applyFillContent(iframe);
 

--- a/extensions/amp-reddit/0.1/amp-reddit.js
+++ b/extensions/amp-reddit/0.1/amp-reddit.js
@@ -58,7 +58,8 @@ class AmpReddit extends AMP.BaseElement {
         'The data-embedtype attribute is required for <amp-reddit> %s',
         this.element);
 
-    const iframe = getIframe(this.win, this.element, 'reddit');
+    const iframe = getIframe(this.win, this.element, 'reddit', null,
+        {allowFullscreen: true});
     this.applyFillContent(iframe);
     listenFor(iframe, 'embed-size', data => {
       this./*OK*/changeHeight(data['height']);

--- a/extensions/amp-twitter/0.1/amp-twitter.js
+++ b/extensions/amp-twitter/0.1/amp-twitter.js
@@ -59,7 +59,8 @@ class AmpTwitter extends AMP.BaseElement {
 
   /** @override */
   layoutCallback() {
-    const iframe = getIframe(this.win, this.element, 'twitter');
+    const iframe = getIframe(this.win, this.element, 'twitter', null,
+        {allowFullscreen: true});
     this.applyFillContent(iframe);
     listenFor(iframe, 'embed-size', data => {
       // We only get the message if and when there is a tweet to display,

--- a/extensions/amp-twitter/0.1/test/test-amp-twitter.js
+++ b/extensions/amp-twitter/0.1/test/test-amp-twitter.js
@@ -50,6 +50,7 @@ describes.realWin('amp-twitter', {
       expect(iframe.tagName).to.equal('IFRAME');
       expect(iframe.getAttribute('width')).to.equal('111');
       expect(iframe.getAttribute('height')).to.equal('222');
+      expect(iframe.getAttribute('allowfullscreen')).to.equal('true');
     });
   });
 

--- a/src/3p-frame.js
+++ b/src/3p-frame.js
@@ -69,11 +69,13 @@ function getFrameAttributes(parentWindow, element, opt_type, opt_context) {
  * @param {Object=} opt_context
  * @param {!{
  *   disallowCustom,
+ *   allowFullscreen,
  * }=} opt_options Options for the created iframe.
  * @return {!Element} The iframe.
  */
 export function getIframe(
-  parentWindow, parentElement, opt_type, opt_context, {disallowCustom} = {}) {
+  parentWindow, parentElement, opt_type, opt_context,
+  {disallowCustom, allowFullscreen} = {}) {
   // Check that the parentElement is already in DOM. This code uses a new and
   // fast `isConnected` API and thus only used when it's available.
   dev().assert(
@@ -116,6 +118,9 @@ export function getIframe(
   }
   if (attributes['title']) {
     iframe.title = attributes['title'];
+  }
+  if (allowFullscreen) {
+    iframe.setAttribute('allowfullscreen', 'true');
   }
   iframe.setAttribute('scrolling', 'no');
   setStyle(iframe, 'border', 'none');

--- a/src/3p-frame.js
+++ b/src/3p-frame.js
@@ -257,6 +257,7 @@ function getAdsLocalhost(win) {
  * Sub domain on which the 3p iframe will be hosted.
  * Because we only calculate the URL once per page, this function is only
  * called once and hence all frames on a page use the same URL.
+ * @param {!Window} win
  * @return {string}
  * @visibleForTesting
  */

--- a/src/3p-frame.js
+++ b/src/3p-frame.js
@@ -67,11 +67,13 @@ function getFrameAttributes(parentWindow, element, opt_type, opt_context) {
  * @param {!AmpElement} parentElement
  * @param {string=} opt_type
  * @param {Object=} opt_context
- * @param {boolean=} opt_disallowCustom whether 3p url should not use meta tag.
+ * @param {!{
+ *   disallowCustom,
+ * }=} opt_options Options for the created iframe.
  * @return {!Element} The iframe.
  */
 export function getIframe(
-  parentWindow, parentElement, opt_type, opt_context, opt_disallowCustom) {
+  parentWindow, parentElement, opt_type, opt_context, {disallowCustom} = {}) {
   // Check that the parentElement is already in DOM. This code uses a new and
   // fast `isConnected` API and thus only used when it's available.
   dev().assert(
@@ -88,7 +90,7 @@ export function getIframe(
   count[attributes['type']] += 1;
 
   const baseUrl = getBootstrapBaseUrl(
-      parentWindow, undefined, opt_type, opt_disallowCustom);
+      parentWindow, undefined, opt_type, disallowCustom);
   const host = parseUrlDeprecated(baseUrl).hostname;
   // This name attribute may be overwritten if this frame is chosen to
   // be the master frame. That is ok, as we will read the name off


### PR DESCRIPTION
- Replaces `getIframe`'s opt_disallowCustom with an options object argument
- Make an explicit API for `allowfullscreen` to encourage users of `getIframe` to consider whether they need fullscreen support
- Adds the `fullscreen` attribute to the iframe created for `<amp-twitter>`

Fixes #15650