### PR TITLE
🏗 Disable unit tests on Sauce until we have enough VMs

### DIFF
--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -312,13 +312,14 @@ const command = {
     }
     // Unit tests with Travis' default chromium
     timedExecOrDie(cmd + ' --headless');
-    if (process.env.TRAVIS) {
-      // A subset of unit tests on other browsers via sauce labs
-      cmd = cmd + ' --saucelabs_lite';
-      startSauceConnect();
-      timedExecOrDie(cmd);
-      stopSauceConnect();
-    }
+    // TODO(amphtml): Disabled until we have as many Sauce VMs as Travis VMs.
+    // if (process.env.TRAVIS) {
+    //   // A subset of unit tests on other browsers via sauce labs
+    //   cmd = cmd + ' --saucelabs_lite';
+    //   startSauceConnect();
+    //   timedExecOrDie(cmd);
+    //   stopSauceConnect();
+    // }
   },
   runUnitTestsOnLocalChanges: function() {
     timedExecOrDie('gulp test --nobuild --headless --local-changes');


### PR DESCRIPTION
After the impending Travis upgrade, we'll have way more Travis VMs than Sauce Labs VMs. If that results in failures due to rate limiting on Sauce Labs, this PR can be merged to temporarily mitigate things.

We should eventually have as many Sauce VMs as Travis VMs, so this shouldn't be a problem for long.

NOTE: Merge this only if required.