### PR TITLE
🏗 Enable amp-story-v1 experiment in canary and production

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -43,5 +43,6 @@
   "expUnconditionedDfpIdentity": 0.01,
   "expUnconditionedCanonicalHoldback": 0.01,
   "amp-consent": 1,
-  "amp-img-native-srcset": 1
+  "amp-img-native-srcset": 1,
+  "amp-story-v1": 1
 }

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -44,5 +44,6 @@
   "expUnconditionedDfpIdentity": 0.01,
   "expUnconditionedCanonicalHoldback": 0.01,
   "amp-consent": 1,
-  "amp-img-native-srcset": 0.7
+  "amp-img-native-srcset": 0.7,
+  "amp-story-v1": 1
 }

--- a/build-system/tasks/bundle-size.js
+++ b/build-system/tasks/bundle-size.js
@@ -22,7 +22,7 @@ const log = require('fancy-log');
 const {getStdout} = require('../exec');
 
 const runtimeFile = './dist/v0.js';
-const maxSize = '77.61KB';
+const maxSize = '77.62KB';
 
 const {green, red, cyan, yellow} = colors;
 


### PR DESCRIPTION
This enables the `amp-story-v1` experiment in canary and production.  As a result, the origin whitelist will be bypassed in amp-story 1.0.

Part of #14357 

/cc @flaviori 