### PR TITLE
🐛 make amp-geo use user().error() on bad json

### DIFF
--- a/extensions/amp-geo/0.1/amp-geo.js
+++ b/extensions/amp-geo/0.1/amp-geo.js
@@ -42,7 +42,7 @@ import {getMode} from '../../../src/mode';
 import {isArray, isObject} from '../../../src/types';
 import {isCanary} from '../../../src/experiments';
 import {isJsonScriptTag} from '../../../src/dom';
-import {parseJson} from '../../../src/json';
+import {tryParseJson} from '../../../src/json';
 import {user} from '../../../src/log';
 import {waitForBodyPromise} from '../../../src/dom';
 
@@ -111,10 +111,14 @@ export class AmpGeo extends AMP.BaseElement {
       `${TAG} can only have one <script type="application/json"> child`);
     }
 
+    const config = children.length ?
+      tryParseJson(
+          children[0].textContent,
+          e => user().error(TAG,'Unable to parse JSON', e)
+      ) : {};
+
     /** @type {!Promise<!Object<string, (string|Array<string>)>>} */
-    const geo = this.addToBody_(
-        children.length ?
-          parseJson(children[0].textContent) : {});
+    const geo = this.addToBody_(config || {});
 
     /* resolve the service promise singleton we stashed earlier */
     geoDeferred.resolve(geo);

--- a/extensions/amp-geo/0.1/test/test-amp-geo.js
+++ b/extensions/amp-geo/0.1/test/test-amp-geo.js
@@ -16,6 +16,7 @@
 
 import {AmpGeo, GEO_IN_GROUP} from '../amp-geo';
 import {Services} from '../../../../src/services';
+import {user} from '../../../../src/log';
 import {vsyncForTesting} from '../../../../src/service/vsync-impl';
 
 
@@ -57,13 +58,16 @@ describes.realWin('amp-geo', {
   let ampdoc;
   let geo;
   let el;
+  let userErrorStub;
 
 
   beforeEach(() => {
+    userErrorStub = sandbox.stub(user(), 'error');
     win = env.win;
     doc = win.document;
     ampdoc = env.ampdoc;
     el = doc.createElement('amp-geo');
+    el.setAttribute('layout', 'nodisplay');
     doc.body.appendChild(el);
     el.ampdoc_ = ampdoc;
     const vsync = vsyncForTesting(win);
@@ -92,17 +96,19 @@ describes.realWin('amp-geo', {
     }
   }
 
-  it('should not throw on empty config', () => {
+  it('should not throw or error on empty config', () => {
     expect(() => {
       geo.buildCallback();
     }).to.not.throw();
+    expect(userErrorStub).to.not.be.called;
   });
 
-  it('should not throw on valid config', () => {
+  it('should not throw or error on valid config', () => {
     expect(() => {
       addConfigElement('script');
       geo.buildCallback();
     }).to.not.throw();
+    expect(userErrorStub).to.not.be.called;
   });
 
   it('should add classes to body element for the geo', () => {
@@ -351,13 +357,12 @@ describes.realWin('amp-geo', {
     }).to.throw(/application\/json/);
   });
 
-  it('should throw if the child script element has non-JSON content', () => {
+  it('should error if the child script element has non-JSON content', () => {
     expect(() => {
       addConfigElement('script', 'application/json', '{not json}');
-      allowConsoleError(() => {
-        geo.buildCallback();
-      });
-    }).to.throw();
+      geo.buildCallback();
+    }).to.not.throw();
+    expect(userErrorStub).to.be.calledOnce;
   });
 
   it('should throw if the group name is not valid', () => {


### PR DESCRIPTION
Use `tryParseJson()` and `user().error()` when it fails to avoid logging hundreds of errors when publisher get the config wrong.

Fixes #15885

