### PR TITLE
Fix getAdContainer potential crash when the body element is called <amp-body>

### DIFF
--- a/src/ad-helper.js
+++ b/src/ad-helper.js
@@ -98,6 +98,8 @@ export function getAdContainer(element) {
  * Gets the resource ID of the amp-ad element containing the passed node.
  * If there is no containing amp-ad tag, then null will be returned.
  * TODO(jonkeller): Investigate whether non-A4A use case is needed. Issue 11436
+ * @param {!Element} node
+ * @param {!Window} topWin
  * @return {?string}
  */
 export function getAmpAdResourceId(node, topWin) {

--- a/src/ad-helper.js
+++ b/src/ad-helper.js
@@ -82,13 +82,13 @@ export function isAdPositionAllowed(element, win) {
  */
 export function getAdContainer(element) {
   if (element[AD_CONTAINER_PROP] === undefined) {
-    let el = element;
-    do {
-      el = el.parentElement;
+    let el = element.parentElement;
+    while (el && el.tagName != 'BODY') {
       if (CONTAINERS[el.tagName]) {
         return element[AD_CONTAINER_PROP] = el.tagName;
       }
-    } while (el && el.tagName != 'BODY');
+      el = el.parentElement;
+    }
     element[AD_CONTAINER_PROP] = null;
   }
   return element[AD_CONTAINER_PROP];


### PR DESCRIPTION
Fixes #12912

The function `getAdContainer` in `ad-helper.js` crashes when the `<body>` tag is renamed to `<amp-body>`, which happens when the AMP document is embedded in a shadow root in Firefox (I'm not sure why this function works in Chrome. Do we not rename the tag to `<amp-body>` in that case?)

In any case, rewriting the while loop that goes up the tree until it finds a "blessed" container element, body, or "ran out of elements" would fix this behaviour.

PATAL at the above function, `isAdPositionAllowed`, which I haven't modified, and let me know if you think this also needs to be fixed to catch that case.