### PR TITLE
Fixing the consent ID used by amp-story-consent.

### DIFF
--- a/examples/amp-story/consent.html
+++ b/examples/amp-story/consent.html
@@ -57,7 +57,7 @@
       <amp-consent id='ABC' layout='nodisplay'>
         <script type="application/json">{
           "consents": {
-            "ABC": {
+            "DEF": {
               "checkConsentHref": "http://localhost:8000/get-consent-v1",
               "promptUI": "ui0"
             }

--- a/extensions/amp-story/0.1/amp-story-consent.js
+++ b/extensions/amp-story/0.1/amp-story-consent.js
@@ -160,9 +160,6 @@ export class AmpStoryConsent extends AMP.BaseElement {
     /** @const @private {!../../../src/service/action-impl.ActionService} */
     this.actions_ = Services.actionServiceForDoc(this.element);
 
-    /** @private {?Object} */
-    this.consentConfig_ = null;
-
     /** @private {?Element} */
     this.scrollableEl_ = null;
 
@@ -178,6 +175,7 @@ export class AmpStoryConsent extends AMP.BaseElement {
     this.assertAndParseConfig_();
 
     const storyEl = closestByTag(this.element, 'AMP-STORY');
+    const consentEl = closestByTag(this.element, 'AMP-CONSENT');
     const logoSrc = storyEl && storyEl.getAttribute('publisher-logo-src');
 
     if (!logoSrc) {
@@ -185,13 +183,11 @@ export class AmpStoryConsent extends AMP.BaseElement {
           TAG, 'Expected "publisher-logo-src" attribute on <amp-story>');
     }
 
-    const consentId = Object.keys(this.consentConfig_.consents)[0];
-
     // Story consent config is set by the `assertAndParseConfig_` method.
     if (this.storyConsentConfig_) {
       this.storyConsentEl_ = renderAsElement(
           this.win.document,
-          getTemplate(this.storyConsentConfig_, consentId, logoSrc));
+          getTemplate(this.storyConsentConfig_, consentEl.id, logoSrc));
       createShadowRootWithStyle(this.element, this.storyConsentEl_, CSS);
 
       // Allow <amp-consent> actions in STAMP (defaults to no actions allowed).
@@ -266,12 +262,6 @@ export class AmpStoryConsent extends AMP.BaseElement {
    * @private
    */
   assertAndParseConfig_() {
-    // Validation of the amp-consent config is handled by the amp-consent
-    // javascript.
-    const parentEl = dev().assertElement(this.element.parentElement);
-    const consentScript = childElementByTag(parentEl, 'script');
-    this.consentConfig_ = parseJson(consentScript.textContent);
-
     const storyConsentScript = childElementByTag(this.element, 'script');
 
     user().assert(

--- a/extensions/amp-story/0.1/test/test-amp-story-consent.js
+++ b/extensions/amp-story/0.1/test/test-amp-story-consent.js
@@ -20,6 +20,7 @@ import {computedStyle} from '../../../../src/style';
 import {registerServiceBuilder} from '../../../../src/service';
 
 describes.realWin('amp-story-consent', {amp: true}, env => {
+  const CONSENT_ID = 'CONSENT_ID';
   let win;
   let defaultConfig;
   let getComputedStyleStub;
@@ -33,10 +34,6 @@ describes.realWin('amp-story-consent', {amp: true}, env => {
 
   beforeEach(() => {
     win = env.win;
-
-    const consentConfig = {
-      consents: {ABC: {}},
-    };
 
     defaultConfig = {
       title: 'Foo title.',
@@ -53,17 +50,13 @@ describes.realWin('amp-story-consent', {amp: true}, env => {
     registerServiceBuilder(win, 'localization-v01', () => localizationService);
 
     // Test DOM structure:
-    // <fake-amp-consent>
-    //   <script type="application/json">{JSON Config}</script>
+    // <amp-consent>
     //   <amp-story-consent>
     //     <script type="application/json">{JSON Config}</script>
     //   </amp-story-consent>
-    // </fake-amp-consent>
-    const consentEl = win.document.createElement('fake-amp-consent');
-
-    const consentConfigEl = win.document.createElement('script');
-    consentConfigEl.setAttribute('type', 'application/json');
-    consentConfigEl.textContent = JSON.stringify(consentConfig);
+    // </amp-consent>
+    const consentEl = win.document.createElement('amp-consent');
+    consentEl.setAttribute('id', CONSENT_ID);
 
     storyConsentConfigEl = win.document.createElement('script');
     storyConsentConfigEl.setAttribute('type', 'application/json');
@@ -72,7 +65,6 @@ describes.realWin('amp-story-consent', {amp: true}, env => {
     storyConsentEl = win.document.createElement('amp-story-consent');
     storyConsentEl.appendChild(storyConsentConfigEl);
 
-    consentEl.appendChild(consentConfigEl);
     consentEl.appendChild(storyConsentEl);
     win.document.body.appendChild(consentEl);
 
@@ -196,6 +188,15 @@ describes.realWin('amp-story-consent', {amp: true}, env => {
 
     expect(storyConsent.actions_.trigger).to.have.been.calledOnce;
     expect(storyConsent.actions_.trigger).to.have.been.calledWith(buttonEl);
+  });
+
+  it('should render an accept button with the proper amp action', () => {
+    storyConsent.buildCallback();
+
+    const buttonEl =
+        storyConsent.storyConsentEl_
+            .querySelector(`button[on="tap:${CONSENT_ID}.accept"]`);
+    expect(buttonEl).to.exist;
   });
 
   it('should set the font color to black if background is white', () => {

--- a/extensions/amp-story/1.0/amp-story-consent.js
+++ b/extensions/amp-story/1.0/amp-story-consent.js
@@ -160,9 +160,6 @@ export class AmpStoryConsent extends AMP.BaseElement {
     /** @const @private {!../../../src/service/action-impl.ActionService} */
     this.actions_ = Services.actionServiceForDoc(this.element);
 
-    /** @private {?Object} */
-    this.consentConfig_ = null;
-
     /** @private {?Element} */
     this.scrollableEl_ = null;
 
@@ -178,6 +175,7 @@ export class AmpStoryConsent extends AMP.BaseElement {
     this.assertAndParseConfig_();
 
     const storyEl = closestByTag(this.element, 'AMP-STORY');
+    const consentEl = closestByTag(this.element, 'AMP-CONSENT');
     const logoSrc = storyEl && storyEl.getAttribute('publisher-logo-src');
 
     if (!logoSrc) {
@@ -185,13 +183,11 @@ export class AmpStoryConsent extends AMP.BaseElement {
           TAG, 'Expected "publisher-logo-src" attribute on <amp-story>');
     }
 
-    const consentId = Object.keys(this.consentConfig_.consents)[0];
-
     // Story consent config is set by the `assertAndParseConfig_` method.
     if (this.storyConsentConfig_) {
       this.storyConsentEl_ = renderAsElement(
           this.win.document,
-          getTemplate(this.storyConsentConfig_, consentId, logoSrc));
+          getTemplate(this.storyConsentConfig_, consentEl.id, logoSrc));
       createShadowRootWithStyle(this.element, this.storyConsentEl_, CSS);
 
       // Allow <amp-consent> actions in STAMP (defaults to no actions allowed).
@@ -266,12 +262,6 @@ export class AmpStoryConsent extends AMP.BaseElement {
    * @private
    */
   assertAndParseConfig_() {
-    // Validation of the amp-consent config is handled by the amp-consent
-    // javascript.
-    const parentEl = dev().assertElement(this.element.parentElement);
-    const consentScript = childElementByTag(parentEl, 'script');
-    this.consentConfig_ = parseJson(consentScript.textContent);
-
     const storyConsentScript = childElementByTag(this.element, 'script');
 
     user().assert(

--- a/extensions/amp-story/1.0/test/test-amp-story-consent.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-consent.js
@@ -20,6 +20,7 @@ import {computedStyle} from '../../../../src/style';
 import {registerServiceBuilder} from '../../../../src/service';
 
 describes.realWin('amp-story-consent', {amp: true}, env => {
+  const CONSENT_ID = 'CONSENT_ID';
   let win;
   let defaultConfig;
   let getComputedStyleStub;
@@ -33,10 +34,6 @@ describes.realWin('amp-story-consent', {amp: true}, env => {
 
   beforeEach(() => {
     win = env.win;
-
-    const consentConfig = {
-      consents: {ABC: {}},
-    };
 
     defaultConfig = {
       title: 'Foo title.',
@@ -53,17 +50,13 @@ describes.realWin('amp-story-consent', {amp: true}, env => {
     registerServiceBuilder(win, 'localization', () => localizationService);
 
     // Test DOM structure:
-    // <fake-amp-consent>
-    //   <script type="application/json">{JSON Config}</script>
+    // <amp-consent>
     //   <amp-story-consent>
     //     <script type="application/json">{JSON Config}</script>
     //   </amp-story-consent>
-    // </fake-amp-consent>
-    const consentEl = win.document.createElement('fake-amp-consent');
-
-    const consentConfigEl = win.document.createElement('script');
-    consentConfigEl.setAttribute('type', 'application/json');
-    consentConfigEl.textContent = JSON.stringify(consentConfig);
+    // </amp-consent>
+    const consentEl = win.document.createElement('amp-consent');
+    consentEl.setAttribute('id', CONSENT_ID);
 
     storyConsentConfigEl = win.document.createElement('script');
     storyConsentConfigEl.setAttribute('type', 'application/json');
@@ -72,7 +65,6 @@ describes.realWin('amp-story-consent', {amp: true}, env => {
     storyConsentEl = win.document.createElement('amp-story-consent');
     storyConsentEl.appendChild(storyConsentConfigEl);
 
-    consentEl.appendChild(consentConfigEl);
     consentEl.appendChild(storyConsentEl);
     win.document.body.appendChild(consentEl);
 
@@ -196,6 +188,15 @@ describes.realWin('amp-story-consent', {amp: true}, env => {
 
     expect(storyConsent.actions_.trigger).to.have.been.calledOnce;
     expect(storyConsent.actions_.trigger).to.have.been.calledWith(buttonEl);
+  });
+
+  it('should render an accept button with the proper amp action', () => {
+    storyConsent.buildCallback();
+
+    const buttonEl =
+        storyConsent.storyConsentEl_
+            .querySelector(`button[on="tap:${CONSENT_ID}.accept"]`);
+    expect(buttonEl).to.exist;
   });
 
   it('should set the font color to black if background is white', () => {


### PR DESCRIPTION
Given the following code:

````
<amp-consent id="ABC">
  <script type="application/json">{
    "consents": {
      "DEF": {
        "checkConsentHref": "http://localhost:8000/get-consent-v1",
        "promptUI": "ui0"
      }
    }
  }</script>
</amp-consent>
````

The ``amp-story-consent`` was using ``DEF``, instead of ``ABC``.
We have been lucky since we use the same ID (``ABC``) in all our examples and documentation, getting a false positive.