### PR TITLE
Add a prompt consent button in the bookend.

### DIFF
--- a/examples/amp-story/consent.html
+++ b/examples/amp-story/consent.html
@@ -78,6 +78,9 @@
           <h1>You just accepted or rejected the consent!</h1>
         </amp-story-grid-layer>
       </amp-story-page>
+
+      <amp-story-bookend src="bookendv1.json" layout="nodisplay">
+      </amp-story-bookend>
     </amp-story>
   </body>
 </html>

--- a/extensions/amp-story/1.0/amp-story-bookend.css
+++ b/extensions/amp-story/1.0/amp-story-bookend.css
@@ -86,6 +86,15 @@
   overflow: hidden !important;
 }
 
+.i-amphtml-story-bookend-consent {
+  margin: 0 32px !important;
+}
+
+.i-amphtml-story-bookend-consent .i-amphtml-story-bookend-heading {
+  margin-left: 0 !important;
+  margin-right: 0 !important;
+}
+
 .i-amphtml-story-bookend-component-meta {
   font-weight: 400 !important;
   font-size: 14px !important;
@@ -137,7 +146,8 @@
 }
 
 .i-amphtml-story-bookend-article-heading,
-.i-amphtml-story-bookend-text {
+.i-amphtml-story-bookend-text,
+.i-amphtml-story-bookend-consent-button {
   font-weight: 400 !important;
   font-size: 16px !important;
   overflow: hidden !important;
@@ -257,10 +267,6 @@
   background-color: rgba(60, 60, 60, 0.5) !important;
   position: static !important; /* independent when no image is rendered */
   border-radius: 4px !important;
-}
-
-.i-amphtml-story-bookend-component-set > .i-amphtml-story-bookend-heading {
-  border-top: none !important;
 }
 
 .i-amphtml-story-bookend-component-set {

--- a/extensions/amp-story/1.0/amp-story-consent.js
+++ b/extensions/amp-story/1.0/amp-story-consent.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {Action} from './amp-story-store-service';
 import {ActionTrust} from '../../../src/action-constants';
 import {CSS} from '../../../build/amp-story-consent-1.0.css';
 import {Layout} from '../../../src/layout';
@@ -163,6 +164,9 @@ export class AmpStoryConsent extends AMP.BaseElement {
     /** @private {?Element} */
     this.scrollableEl_ = null;
 
+    /** @private @const {!./amp-story-store-service.AmpStoryStoreService} */
+    this.storeService_ = Services.storyStoreService(this.win);
+
     /** @private {?Object} */
     this.storyConsentConfig_ = null;
 
@@ -176,6 +180,9 @@ export class AmpStoryConsent extends AMP.BaseElement {
 
     const storyEl = closestByTag(this.element, 'AMP-STORY');
     const consentEl = closestByTag(this.element, 'AMP-CONSENT');
+    const consentId = consentEl.id;
+    this.storeService_.dispatch(Action.SET_CONSENT_ID, consentId);
+
     const logoSrc = storyEl && storyEl.getAttribute('publisher-logo-src');
 
     if (!logoSrc) {
@@ -187,11 +194,12 @@ export class AmpStoryConsent extends AMP.BaseElement {
     if (this.storyConsentConfig_) {
       this.storyConsentEl_ = renderAsElement(
           this.win.document,
-          getTemplate(this.storyConsentConfig_, consentEl.id, logoSrc));
+          getTemplate(this.storyConsentConfig_, consentId, logoSrc));
       createShadowRootWithStyle(this.element, this.storyConsentEl_, CSS);
 
       // Allow <amp-consent> actions in STAMP (defaults to no actions allowed).
       this.actions_.addToWhitelist('AMP-CONSENT.accept');
+      this.actions_.addToWhitelist('AMP-CONSENT.prompt');
       this.actions_.addToWhitelist('AMP-CONSENT.reject');
 
       this.setAcceptButtonFontColor_();

--- a/extensions/amp-story/1.0/amp-story-store-service.js
+++ b/extensions/amp-story/1.0/amp-story-store-service.js
@@ -41,6 +41,7 @@ const TAG = 'amp-story';
  *    pausedstate: boolean,
  *    sharemenustate: boolean,
  *    supportedbrowserstate: boolean,
+ *    consentid: ?string,
  *    currentpageid: string,
  * }}
  */
@@ -68,6 +69,9 @@ export const StateProperty = {
   PAUSED_STATE: 'pausedstate',
   SHARE_MENU_STATE: 'sharemenustate',
   SUPPORTED_BROWSER_STATE: 'supportedbrowserstate',
+
+  // App data.
+  CONSENT_ID: 'consentid',
   CURRENT_PAGE_ID: 'currentpageid',
   CURRENT_PAGE_INDEX: 'currentpageindex',
 };
@@ -75,6 +79,8 @@ export const StateProperty = {
 
 /** @private @const @enum {string} */
 export const Action = {
+  CHANGE_PAGE: 'setcurrentpageid',
+  SET_CONSENT_ID: 'setconsentid',
   TOGGLE_AD: 'togglead',
   TOGGLE_BOOKEND: 'togglebookend',
   TOGGLE_DESKTOP: 'toggledesktop',
@@ -85,7 +91,6 @@ export const Action = {
   TOGGLE_PAUSED: 'togglepaused',
   TOGGLE_SHARE_MENU: 'togglesharemenu',
   TOGGLE_SUPPORTED_BROWSER: 'togglesupportedbrowser',
-  CHANGE_PAGE: 'changepage',
 };
 
 
@@ -152,6 +157,9 @@ const actions = (state, action, data) => {
     case Action.TOGGLE_SHARE_MENU:
       return /** @type {!State} */ (Object.assign(
           {}, state, {[StateProperty.SHARE_MENU_STATE]: !!data}));
+    case Action.SET_CONSENT_ID:
+      return /** @type {!State} */ (Object.assign(
+          {}, state, {[StateProperty.CONSENT_ID]: data}));
     case Action.CHANGE_PAGE:
       return /** @type {!State} */ (Object.assign(
           {}, state, {
@@ -258,6 +266,7 @@ export class AmpStoryStoreService {
       [StateProperty.PAUSED_STATE]: false,
       [StateProperty.SHARE_MENU_STATE]: false,
       [StateProperty.SUPPORTED_BROWSER_STATE]: true,
+      [StateProperty.CONSENT_ID]: null,
       [StateProperty.CURRENT_PAGE_ID]: '',
       [StateProperty.CURRENT_PAGE_INDEX]: 0,
     });

--- a/extensions/amp-story/1.0/bookend/amp-story-bookend.js
+++ b/extensions/amp-story/1.0/bookend/amp-story-bookend.js
@@ -15,6 +15,7 @@
  */
 
 import {Action, StateProperty} from '../amp-story-store-service';
+import {ActionTrust} from '../../../../src/action-constants';
 import {BookendComponent} from './bookend-component';
 import {CSS} from '../../../../build/amp-story-bookend-1.0.css';
 import {EventType, dispatch} from '../events';
@@ -37,10 +38,8 @@ import {throttle} from '../../../../src/utils/rate-limit';
  */
 const FULLBLEED_THRESHOLD = 88;
 
-
 /** @private @const {string} */
 const FULLBLEED_CLASSNAME = 'i-amphtml-story-bookend-fullbleed';
-
 
 /** @private @const {string} */
 const HIDDEN_CLASSNAME = 'i-amphtml-hidden';
@@ -79,27 +78,25 @@ const REPLAY_ICON_TEMPLATE = {
   attrs: dict({'class': 'i-amphtml-story-bookend-replay-icon'}),
 };
 
-
 /** @type {string} */
 const TAG = 'amp-story';
 
 /**
- * @param {!Document} doc
  * @param {string} title
  * @param {string} domainName
- * @param {string=} opt_imageUrl
+ * @param {string=} imageUrl
  * @return {!../simple-template.ElementDef}
  */
-function buildReplayButtonTemplate(doc, title, domainName, opt_imageUrl) {
+const buildReplayButtonTemplate = (title, domainName, imageUrl = undefined) => {
   return /** @type {!../simple-template.ElementDef} */ ({
     tag: 'div',
     attrs: dict({'class': 'i-amphtml-story-bookend-replay'}),
     children: [
-      !opt_imageUrl ? REPLAY_ICON_TEMPLATE : {
+      !imageUrl ? REPLAY_ICON_TEMPLATE : {
         tag: 'div',
         attrs: dict({
           'class': 'i-amphtml-story-bookend-replay-image',
-          'style': `background-image: url(${opt_imageUrl}) !important`,
+          'style': `background-image: url(${imageUrl}) !important`,
         }),
         children: [REPLAY_ICON_TEMPLATE],
       },
@@ -115,7 +112,35 @@ function buildReplayButtonTemplate(doc, title, domainName, opt_imageUrl) {
       },
     ],
   });
-}
+};
+
+/**
+ * @param {?string} consentId
+ * @return {!../simple-template.ElementDef}
+ */
+const buildPromptConsentTemplate = consentId => {
+  return /** @type {!../simple-template.ElementDef} */ ({
+    tag: 'div',
+    attrs: dict({'class': 'i-amphtml-story-bookend-consent'}),
+    children: [
+      {
+        tag: 'h3',
+        attrs: dict({'class': 'i-amphtml-story-bookend-heading'}),
+        unlocalizedString: 'Privacy settings',
+      },
+      {
+        tag: 'h2',
+        attrs: dict({
+          'class': 'i-amphtml-story-bookend-consent-button',
+          'on': `tap:${consentId}.prompt`,
+          'role': 'button',
+          'aria-label': 'Change data privacy settings',
+        }),
+        unlocalizedString: 'Change data privacy settings',
+      },
+    ],
+  });
+};
 
 
 /**
@@ -188,6 +213,16 @@ export class AmpStoryBookend extends AMP.BaseElement {
     innerContainer.appendChild(this.replayButton_);
     innerContainer.appendChild(
         this.shareWidget_.build(getAmpdoc(this.win.document)));
+
+    const consentId = this.storeService_.get(StateProperty.CONSENT_ID);
+
+    if (consentId) {
+      const promptConsentEl =
+          renderAsElement(
+              this.win.document, buildPromptConsentTemplate(String(consentId)));
+      innerContainer.appendChild(promptConsentEl);
+    }
+
     this.initializeListeners_();
 
     this.mutateElement(() => {
@@ -200,9 +235,9 @@ export class AmpStoryBookend extends AMP.BaseElement {
    */
   initializeListeners_() {
     this.getShadowRoot()
-        .addEventListener('click', event => this.maybeClose_(event));
-    this.replayButton_.addEventListener(
-        'click', event => this.onReplayButtonClick_(event));
+        .addEventListener('click', event => this.onClick_(event));
+    this.replayButton_
+        .addEventListener('click', event => this.onReplayButtonClick_(event));
 
     this.getOverflowContainer_().addEventListener('scroll',
         // minInterval is high since this is a step function that does not
@@ -335,19 +370,30 @@ export class AmpStoryBookend extends AMP.BaseElement {
   }
 
   /**
-   * Closes bookend if tapping outside usable area.
+   * Handles click events on the bookend:
+   *   - Closes bookend if tapping outside usable area
+   *   - Forwards AMP actions
    * @param {!Event} event
    * @private
    */
-  maybeClose_(event) {
-    if (this.elementOutsideUsableArea_(dev().assertElement(event.target))) {
+  onClick_(event) {
+    const target = dev().assertElement(event.target);
+
+    if (this.elementOutsideUsableArea_(target)) {
       event.stopPropagation();
       this.close_();
+      return;
+    }
+
+    if (target.hasAttribute('on')) {
+      const actionService = Services.actionServiceForDoc(this.element);
+      actionService.trigger(target, 'tap', event, ActionTrust.HIGH);
     }
   }
 
   /**
    * Closes the bookend.
+   * @private
    */
   close_() {
     this.storeService_.dispatch(Action.TOGGLE_BOOKEND, false);
@@ -356,6 +402,7 @@ export class AmpStoryBookend extends AMP.BaseElement {
   /**
    * @param {!Element} el
    * @return {boolean}
+   * @private
    */
   elementOutsideUsableArea_(el) {
     return !closest(el, el => el == this.getInnerContainer_());
@@ -514,7 +561,6 @@ export class AmpStoryBookend extends AMP.BaseElement {
   buildReplayButton_() {
     const metadata = this.getStoryMetadata_();
     return renderAsElement(this.win.document, buildReplayButtonTemplate(
-        this.win.document,
         metadata.title,
         metadata.domainName,
         metadata.imageUrl));

--- a/extensions/amp-story/1.0/test/test-amp-story-bookend.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-bookend.js
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
+import {Action, AmpStoryStoreService} from '../amp-story-store-service';
 import {AmpStoryBookend} from '../bookend/amp-story-bookend';
 import {AmpStoryRequestService} from '../amp-story-request-service';
-import {AmpStoryStoreService} from '../amp-story-store-service';
 import {ArticleComponent} from '../bookend/components/article';
 import {CtaLinkComponent} from '../bookend/components/cta-link';
 import {LandscapeComponent} from '../bookend/components/landscape';
@@ -846,5 +846,27 @@ describes.realWin('amp-story-bookend', {
           '`text` array and at least one element inside it, ' +
           'skipping invalid.');
     });
+  });
+
+  it('should have a button to re-prompt the consent if story has one', () => {
+    const consentId = 'CONSENT_ID';
+    bookend.storeService_.dispatch(Action.SET_CONSENT_ID, consentId);
+
+    bookend.build();
+
+    const promptButtonEl =
+        bookend.getShadowRoot().querySelector(`[on="tap:${consentId}.prompt"]`);
+
+    expect(promptButtonEl).to.exist;
+  });
+
+  it('should not have a button to re-prompt the consent by default', () => {
+    bookend.build();
+
+    // No element with an "on" attribute ending with ".prompt".
+    const promptButtonEl =
+        bookend.getShadowRoot().querySelector('[on$=".prompt"]');
+
+    expect(promptButtonEl).to.be.null;
   });
 });

--- a/extensions/amp-story/1.0/test/test-amp-story-consent.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-consent.js
@@ -15,6 +15,7 @@
  */
 
 import {AmpStoryConsent} from '../amp-story-consent';
+import {AmpStoryStoreService, StateProperty} from '../amp-story-store-service';
 import {LocalizationService} from '../localization';
 import {computedStyle} from '../../../../src/style';
 import {registerServiceBuilder} from '../../../../src/service';
@@ -34,6 +35,8 @@ describes.realWin('amp-story-consent', {amp: true}, env => {
 
   beforeEach(() => {
     win = env.win;
+    const storeService = new AmpStoryStoreService(win);
+    registerServiceBuilder(win, 'story-store', () => storeService);
 
     defaultConfig = {
       title: 'Foo title.',
@@ -168,8 +171,9 @@ describes.realWin('amp-story-consent', {amp: true}, env => {
 
     storyConsent.buildCallback();
 
-    expect(addToWhitelistStub).to.have.been.calledTwice;
+    expect(addToWhitelistStub).to.have.callCount(3);
     expect(addToWhitelistStub).to.have.been.calledWith('AMP-CONSENT.accept');
+    expect(addToWhitelistStub).to.have.been.calledWith('AMP-CONSENT.prompt');
     expect(addToWhitelistStub).to.have.been.calledWith('AMP-CONSENT.reject');
   });
 
@@ -197,6 +201,13 @@ describes.realWin('amp-story-consent', {amp: true}, env => {
         storyConsent.storyConsentEl_
             .querySelector(`button[on="tap:${CONSENT_ID}.accept"]`);
     expect(buttonEl).to.exist;
+  });
+
+  it('should set the consent ID in the store', () => {
+    storyConsent.buildCallback();
+
+    expect(storyConsent.storeService_.get(StateProperty.CONSENT_ID))
+        .to.equal(CONSENT_ID);
   });
 
   it('should set the font color to black if background is white', () => {


### PR DESCRIPTION
- Stores the consent ID if there is one (works also if already accepted/rejected)
- If there is a consent ID, display a link to prompt again in the bookend
- Bookend forwards the proper AMP actions
- ``v1.0`` only

Partial for #15870 