### PR TITLE
Add a prompt consent button in the v0.1 bookend.

### DIFF
--- a/extensions/amp-story/0.1/amp-story-bookend.css
+++ b/extensions/amp-story/0.1/amp-story-bookend.css
@@ -84,6 +84,15 @@
   line-height: 1 !important;
 }
 
+.i-amphtml-story-bookend-consent {
+  margin: 0 32px 32px !important;
+}
+
+.i-amphtml-story-bookend-consent .i-amphtml-story-bookend-heading {
+  margin-left: 0 !important;
+  margin-right: 0 !important;
+}
+
 .i-amphtml-story-bookend-article-meta {
   font-family: 'Roboto', sans-serif;
   font-weight: 400 !important;
@@ -116,7 +125,8 @@
   }
 }
 
-.i-amphtml-story-bookend-article-heading {
+.i-amphtml-story-bookend-article-heading,
+.i-amphtml-story-bookend-consent-button {
   font-family: 'Roboto', sans-serif !important;
   font-weight: 400 !important;
   font-size: 16px !important;

--- a/extensions/amp-story/0.1/amp-story-consent.js
+++ b/extensions/amp-story/0.1/amp-story-consent.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {Action} from './amp-story-store-service';
 import {ActionTrust} from '../../../src/action-constants';
 import {CSS} from '../../../build/amp-story-consent-0.1.css';
 import {Layout} from '../../../src/layout';
@@ -163,6 +164,9 @@ export class AmpStoryConsent extends AMP.BaseElement {
     /** @private {?Element} */
     this.scrollableEl_ = null;
 
+    /** @private @const {!./amp-story-store-service.AmpStoryStoreService} */
+    this.storeService_ = Services.storyStoreServiceV01(this.win);
+
     /** @private {?Object} */
     this.storyConsentConfig_ = null;
 
@@ -176,6 +180,9 @@ export class AmpStoryConsent extends AMP.BaseElement {
 
     const storyEl = closestByTag(this.element, 'AMP-STORY');
     const consentEl = closestByTag(this.element, 'AMP-CONSENT');
+    const consentId = consentEl.id;
+    this.storeService_.dispatch(Action.SET_CONSENT_ID, consentId);
+
     const logoSrc = storyEl && storyEl.getAttribute('publisher-logo-src');
 
     if (!logoSrc) {
@@ -187,11 +194,12 @@ export class AmpStoryConsent extends AMP.BaseElement {
     if (this.storyConsentConfig_) {
       this.storyConsentEl_ = renderAsElement(
           this.win.document,
-          getTemplate(this.storyConsentConfig_, consentEl.id, logoSrc));
+          getTemplate(this.storyConsentConfig_, consentId, logoSrc));
       createShadowRootWithStyle(this.element, this.storyConsentEl_, CSS);
 
       // Allow <amp-consent> actions in STAMP (defaults to no actions allowed).
       this.actions_.addToWhitelist('AMP-CONSENT.accept');
+      this.actions_.addToWhitelist('AMP-CONSENT.prompt');
       this.actions_.addToWhitelist('AMP-CONSENT.reject');
 
       this.setAcceptButtonFontColor_();

--- a/extensions/amp-story/0.1/amp-story-store-service.js
+++ b/extensions/amp-story/0.1/amp-story-store-service.js
@@ -40,6 +40,7 @@ const TAG = 'amp-story';
  *    mutedstate: boolean,
  *    sharemenustate: boolean,
  *    supportedbrowserstate: boolean,
+ *    consentid: ?string,
  *    currentpageid: string,
  * }}
  */
@@ -66,6 +67,9 @@ export const StateProperty = {
   MUTED_STATE: 'mutedstate',
   SHARE_MENU_STATE: 'sharemenustate',
   SUPPORTED_BROWSER_STATE: 'supportedbrowserstate',
+
+  // App data.
+  CONSENT_ID: 'consentid',
   CURRENT_PAGE_ID: 'currentpageid',
   CURRENT_PAGE_INDEX: 'currentpageindex',
 };
@@ -73,6 +77,8 @@ export const StateProperty = {
 
 /** @private @const @enum {string} */
 export const Action = {
+  CHANGE_PAGE: 'changepage',
+  SET_CONSENT_ID: 'setconsentid',
   TOGGLE_AD: 'togglead',
   TOGGLE_BOOKEND: 'togglebookend',
   TOGGLE_DESKTOP: 'toggledesktop',
@@ -82,7 +88,6 @@ export const Action = {
   TOGGLE_MUTED: 'togglemuted',
   TOGGLE_SHARE_MENU: 'togglesharemenu',
   TOGGLE_SUPPORTED_BROWSER: 'togglesupportedbrowser',
-  CHANGE_PAGE: 'changepage',
 };
 
 
@@ -145,6 +150,9 @@ const actions = (state, action, data) => {
     case Action.TOGGLE_SHARE_MENU:
       return /** @type {!State} */ (Object.assign(
           {}, state, {[StateProperty.SHARE_MENU_STATE]: !!data}));
+    case Action.SET_CONSENT_ID:
+      return /** @type {!State} */ (Object.assign(
+          {}, state, {[StateProperty.CONSENT_ID]: data}));
     case Action.CHANGE_PAGE:
       return /** @type {!State} */ (Object.assign(
           {}, state, {
@@ -250,6 +258,7 @@ export class AmpStoryStoreService {
       [StateProperty.MUTED_STATE]: true,
       [StateProperty.SHARE_MENU_STATE]: false,
       [StateProperty.SUPPORTED_BROWSER_STATE]: true,
+      [StateProperty.CONSENT_ID]: null,
       [StateProperty.CURRENT_PAGE_ID]: '',
       [StateProperty.CURRENT_PAGE_INDEX]: 0,
     });

--- a/extensions/amp-story/0.1/test/test-amp-story-consent.js
+++ b/extensions/amp-story/0.1/test/test-amp-story-consent.js
@@ -15,6 +15,7 @@
  */
 
 import {AmpStoryConsent} from '../amp-story-consent';
+import {AmpStoryStoreService, StateProperty} from '../amp-story-store-service';
 import {LocalizationService} from '../localization';
 import {computedStyle} from '../../../../src/style';
 import {registerServiceBuilder} from '../../../../src/service';
@@ -34,6 +35,8 @@ describes.realWin('amp-story-consent', {amp: true}, env => {
 
   beforeEach(() => {
     win = env.win;
+    const storeService = new AmpStoryStoreService(win);
+    registerServiceBuilder(win, 'story-store', () => storeService);
 
     defaultConfig = {
       title: 'Foo title.',
@@ -168,8 +171,9 @@ describes.realWin('amp-story-consent', {amp: true}, env => {
 
     storyConsent.buildCallback();
 
-    expect(addToWhitelistStub).to.have.been.calledTwice;
+    expect(addToWhitelistStub).to.have.callCount(3);
     expect(addToWhitelistStub).to.have.been.calledWith('AMP-CONSENT.accept');
+    expect(addToWhitelistStub).to.have.been.calledWith('AMP-CONSENT.prompt');
     expect(addToWhitelistStub).to.have.been.calledWith('AMP-CONSENT.reject');
   });
 
@@ -197,6 +201,13 @@ describes.realWin('amp-story-consent', {amp: true}, env => {
         storyConsent.storyConsentEl_
             .querySelector(`button[on="tap:${CONSENT_ID}.accept"]`);
     expect(buttonEl).to.exist;
+  });
+
+  it('should set the consent ID in the store', () => {
+    storyConsent.buildCallback();
+
+    expect(storyConsent.storeService_.get(StateProperty.CONSENT_ID))
+        .to.equal(CONSENT_ID);
   });
 
   it('should set the font color to black if background is white', () => {


### PR DESCRIPTION
Porting #15897 to ``v0.1``.

> - Stores the consent ID if there is one (works also if already accepted/rejected)
> - If there is a consent ID, display a link to prompt again in the bookend
> - Bookend forwards the proper AMP actions

Partial for #15870