### PR TITLE
🐛 fix purgeShadowRoots sometimes fails to recognize connected nodes as such

### DIFF
--- a/src/runtime.js
+++ b/src/runtime.js
@@ -20,7 +20,7 @@ import {BaseTemplate, registerExtendedTemplate} from './service/template-impl';
 import {CommonSignals} from './common-signals';
 import {Services} from './services';
 import {VisibilityState} from './visibility-state';
-import {childElementsByTag} from './dom';
+import {childElementsByTag, isConnectedNode} from './dom';
 import {
   createShadowDomWriter,
   createShadowRoot,
@@ -826,7 +826,7 @@ export class MultidocManager {
   purgeShadowRoots_() {
     this.shadowRoots_.forEach(shadowRoot => {
       // The shadow root has been disconnected. Force it closed.
-      if (!this.win.document.contains(shadowRoot.host)) {
+      if (!shadowRoot.host || !isConnectedNode(shadowRoot.host)) {
         user().warn(TAG, 'Shadow doc wasn\'t previously closed');
         this.removeShadowRoot_(shadowRoot);
         this.closeShadowRootAsync_(shadowRoot);

--- a/test/functional/test-runtime.js
+++ b/test/functional/test-runtime.js
@@ -1514,10 +1514,20 @@ describes.realWin('runtime multidoc', {
   });
 
 
-  describe('messaging', () => {
+  describes.repeated('messaging', {
+    'document.contains is the browser implementation': false,
+    'document.contains is a stubbed implementation': true,
+  }, (name, isStubbedDocumentContains) => {
     let doc1, doc2, doc3;
 
     beforeEach(() => {
+      if (isStubbedDocumentContains) {
+        // Some browsers implement document.contains wrong, and it returns
+        // `false` even when this is incorrect. Repeat these tests with the
+        // faulty implementation.
+        sandbox.stub(win.document, 'contains').returns(false);
+      }
+
       doc1 = attach('https://example.org/doc1');
       doc2 = attach('https://example.org/doc2');
       doc3 = attach('https://example.org/doc3');


### PR DESCRIPTION
The `purgeShadowRoots_` method looks to see whether shadow roots are attached by checking whether `this.win.document.contains(shadowroot.host)` which fails on occasion (for reasons.) This PR replaces this logic with the more predictable `isConnected` (more specifically with @jridgewell's `isConnectedNode` polyfill)

Fix is basically 99% from @dvoytenko, thanks!

This issue affects pages that have multiple shadow roots, and so it resolves #12645 
