### PR TITLE
Adding translation keys for the bookend prompt consent link.

### DIFF
--- a/extensions/amp-story/0.1/_locales/default.js
+++ b/extensions/amp-story/0.1/_locales/default.js
@@ -21,6 +21,12 @@ import {LocalizedStringBundleDef, LocalizedStringId} from '../localization';
  * @const {!LocalizedStringBundleDef}
  */
 export default {
+  [LocalizedStringId.AMP_STORY_BOOKEND_PRIVACY_SETTINGS_TITLE]: {
+    string: 'Privacy settings',
+  },
+  [LocalizedStringId.AMP_STORY_BOOKEND_PRIVACY_SETTINGS_BUTTON_LABEL]: {
+    string: 'Change data privacy settings',
+  },
   [LocalizedStringId.AMP_STORY_CONSENT_ACCEPT_BUTTON_LABEL]: {
     string: 'Accept',
   },

--- a/extensions/amp-story/0.1/_locales/en.js
+++ b/extensions/amp-story/0.1/_locales/en.js
@@ -21,6 +21,16 @@ import {LocalizedStringBundleDef, LocalizedStringId} from '../localization';
  * @const {!LocalizedStringBundleDef}
  */
 export default {
+  [LocalizedStringId.AMP_STORY_BOOKEND_PRIVACY_SETTINGS_TITLE]: {
+    string: 'Privacy settings',
+    description: 'Title for a section that allows the user to configure ' +
+        'their privacy settings',
+  },
+  [LocalizedStringId.AMP_STORY_BOOKEND_PRIVACY_SETTINGS_BUTTON_LABEL]: {
+    string: 'Change data privacy settings',
+    description: 'Label for a button that allows the user to change their ' +
+        'choice to consent to providing their cookie access.',
+  },
   [LocalizedStringId.AMP_STORY_CONSENT_ACCEPT_BUTTON_LABEL]: {
     string: 'Accept',
     description: 'Label for a button that allows the user to consent to ' +

--- a/extensions/amp-story/0.1/amp-story-bookend.js
+++ b/extensions/amp-story/0.1/amp-story-bookend.js
@@ -18,6 +18,7 @@ import {ActionTrust} from '../../../src/action-constants';
 import {CSS} from '../../../build/amp-story-bookend-0.1.css';
 import {EventType, dispatch} from './events';
 import {KeyCodes} from '../../../src/utils/key-codes';
+import {LocalizedStringId} from './localization';
 import {ScrollableShareWidget} from './amp-story-share';
 import {Services} from '../../../src/services';
 import {closest} from '../../../src/dom';
@@ -107,7 +108,8 @@ const buildPromptConsentTemplate = consentId => {
       {
         tag: 'h3',
         attrs: dict({'class': 'i-amphtml-story-bookend-heading'}),
-        unlocalizedString: 'Privacy settings',
+        localizedStringId:
+            LocalizedStringId.AMP_STORY_BOOKEND_PRIVACY_SETTINGS_TITLE,
       },
       {
         tag: 'h2',
@@ -117,7 +119,8 @@ const buildPromptConsentTemplate = consentId => {
           'role': 'button',
           'aria-label': 'Change data privacy settings',
         }),
-        unlocalizedString: 'Change data privacy settings',
+        localizedStringId:
+            LocalizedStringId.AMP_STORY_BOOKEND_PRIVACY_SETTINGS_BUTTON_LABEL,
       },
     ],
   });

--- a/extensions/amp-story/0.1/localization.js
+++ b/extensions/amp-story/0.1/localization.js
@@ -26,12 +26,14 @@ import {parseJson} from '../../../src/json';
  *   - NOT be reused; to deprecate an ID, comment it out and prefix its key with
  *     the string "DEPRECATED_"
  *
- * Next ID: 27
+ * Next ID: 29
  *
  * @const @enum {string}
  */
 export const LocalizedStringId = {
   // amp-story
+  AMP_STORY_BOOKEND_PRIVACY_SETTINGS_TITLE: '28',
+  AMP_STORY_BOOKEND_PRIVACY_SETTINGS_BUTTON_LABEL: '27',
   AMP_STORY_CONSENT_ACCEPT_BUTTON_LABEL: '22',
   AMP_STORY_CONSENT_DECLINE_BUTTON_LABEL: '23',
   AMP_STORY_CONSENT_DISMISS_DIALOG_BUTTON_LABEL: '24',

--- a/extensions/amp-story/1.0/_locales/default.js
+++ b/extensions/amp-story/1.0/_locales/default.js
@@ -21,17 +21,23 @@ import {LocalizedStringBundleDef, LocalizedStringId} from '../localization';
  * @const {!LocalizedStringBundleDef}
  */
 export default {
+  [LocalizedStringId.AMP_STORY_BOOKEND_PRIVACY_SETTINGS_TITLE]: {
+    string: 'Privacy settings',
+  },
+  [LocalizedStringId.AMP_STORY_BOOKEND_PRIVACY_SETTINGS_BUTTON_LABEL]: {
+    string: 'Change data privacy settings',
+  },
   [LocalizedStringId.AMP_STORY_CONSENT_ACCEPT_BUTTON_LABEL]: {
     string: 'Accept',
-  },
-  [LocalizedStringId.AMP_STORY_CONTINUE_ANYWAY_BUTTON_LABEL]: {
-    string: 'Continue Anyway',
   },
   [LocalizedStringId.AMP_STORY_CONSENT_DECLINE_BUTTON_LABEL]: {
     string: 'Decline',
   },
   [LocalizedStringId.AMP_STORY_CONSENT_DISMISS_DIALOG_BUTTON_LABEL]: {
     string: 'Ok',
+  },
+  [LocalizedStringId.AMP_STORY_CONTINUE_ANYWAY_BUTTON_LABEL]: {
+    string: 'Continue Anyway',
   },
   [LocalizedStringId.AMP_STORY_DOMAIN_DIALOG_HEADING_LABEL]: {
     string: 'View on original domain:',

--- a/extensions/amp-story/1.0/_locales/en.js
+++ b/extensions/amp-story/1.0/_locales/en.js
@@ -21,6 +21,16 @@ import {LocalizedStringBundleDef, LocalizedStringId} from '../localization';
  * @const {!LocalizedStringBundleDef}
  */
 export default {
+  [LocalizedStringId.AMP_STORY_BOOKEND_PRIVACY_SETTINGS_TITLE]: {
+    string: 'Privacy settings',
+    description: 'Title for a section that allows the user to configure ' +
+        'their privacy settings',
+  },
+  [LocalizedStringId.AMP_STORY_BOOKEND_PRIVACY_SETTINGS_BUTTON_LABEL]: {
+    string: 'Change data privacy settings',
+    description: 'Label for a button that allows the user to change their ' +
+        'choice to consent to providing their cookie access.',
+  },
   [LocalizedStringId.AMP_STORY_CONSENT_ACCEPT_BUTTON_LABEL]: {
     string: 'Accept',
     description: 'Label for a button that allows the user to consent to ' +

--- a/extensions/amp-story/1.0/bookend/amp-story-bookend.js
+++ b/extensions/amp-story/1.0/bookend/amp-story-bookend.js
@@ -20,6 +20,7 @@ import {BookendComponent} from './bookend-component';
 import {CSS} from '../../../../build/amp-story-bookend-1.0.css';
 import {EventType, dispatch} from '../events';
 import {KeyCodes} from '../../../../src/utils/key-codes';
+import {LocalizedStringId} from '../localization';
 import {ScrollableShareWidget} from '../amp-story-share';
 import {Services} from '../../../../src/services';
 import {closest} from '../../../../src/dom';
@@ -126,7 +127,8 @@ const buildPromptConsentTemplate = consentId => {
       {
         tag: 'h3',
         attrs: dict({'class': 'i-amphtml-story-bookend-heading'}),
-        unlocalizedString: 'Privacy settings',
+        localizedStringId:
+            LocalizedStringId.AMP_STORY_BOOKEND_PRIVACY_SETTINGS_TITLE,
       },
       {
         tag: 'h2',
@@ -136,7 +138,8 @@ const buildPromptConsentTemplate = consentId => {
           'role': 'button',
           'aria-label': 'Change data privacy settings',
         }),
-        unlocalizedString: 'Change data privacy settings',
+        localizedStringId:
+            LocalizedStringId.AMP_STORY_BOOKEND_PRIVACY_SETTINGS_BUTTON_LABEL,
       },
     ],
   });

--- a/extensions/amp-story/1.0/localization.js
+++ b/extensions/amp-story/1.0/localization.js
@@ -25,12 +25,14 @@ import {parseJson} from '../../../src/json';
  *   - NOT be reused; to deprecate an ID, comment it out and prefix its key with
  *     the string "DEPRECATED_"
  *
- * Next ID: 28
+ * Next ID: 30
  *
  * @const @enum {string}
  */
 export const LocalizedStringId = {
   // amp-story
+  AMP_STORY_BOOKEND_PRIVACY_SETTINGS_TITLE: '29',
+  AMP_STORY_BOOKEND_PRIVACY_SETTINGS_BUTTON_LABEL: '28',
   AMP_STORY_CONSENT_ACCEPT_BUTTON_LABEL: '22',
   AMP_STORY_CONSENT_DECLINE_BUTTON_LABEL: '23',
   AMP_STORY_CONSENT_DISMISS_DIALOG_BUTTON_LABEL: '24',


### PR DESCRIPTION
Adding translation keys for the bookend prompt consent link.

Partial for, and fixes #15870