### PR TITLE
Pause the story until the consent prompt is resolved.

### DIFF
--- a/examples/amp-story/consent.html
+++ b/examples/amp-story/consent.html
@@ -73,7 +73,7 @@
         </amp-story-consent>
       </amp-consent>
 
-      <amp-story-page id="cover">
+      <amp-story-page id="cover" auto-advance-after="5s">
         <amp-story-grid-layer template="vertical">
           <h1>You just accepted or rejected the consent!</h1>
         </amp-story-grid-layer>

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -88,6 +88,7 @@ import {debounce} from '../../../src/utils/rate-limit';
 import {dev, user} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {findIndex} from '../../../src/utils/array';
+import {getConsentPolicyState} from '../../../src/consent';
 import {getMode} from '../../../src/mode';
 import {isExperimentOn, toggleExperiment} from '../../../src/experiments';
 import {registerServiceBuilder} from '../../../src/service';
@@ -617,7 +618,7 @@ export class AmpStory extends AMP.BaseElement {
     storyLayoutPromise.then(() => this.whenPagesLoaded_(PAGE_LOAD_TIMEOUT_MS))
         .then(() => this.markStoryAsLoaded_());
 
-    this.validateConsent_();
+    this.handleConsent_();
 
     return storyLayoutPromise;
   }
@@ -650,16 +651,48 @@ export class AmpStory extends AMP.BaseElement {
     });
   }
 
+
   /**
-   * Ensures publishers using amp-consent use amp-story-consent.
+   * Handles story consent.
    * @private
    */
-  validateConsent_() {
+  handleConsent_() {
     const consentEl = this.element.querySelector('amp-consent');
     if (!consentEl) {
       return;
     }
 
+    this.pauseStoryUntilConsentIsResolved_();
+    this.validateConsent_(consentEl);
+  }
+
+
+  /**
+   * Pauses the story until the consent is resolved (accepted or rejected).
+   * @private
+   */
+  pauseStoryUntilConsentIsResolved_() {
+    const policyId = this.getConsentPolicy() || 'default';
+    const consentPromise = getConsentPolicyState(this.getAmpDoc(), policyId);
+
+    if (!consentPromise) {
+      return;
+    }
+
+    this.storeService_.dispatch(Action.TOGGLE_PAUSED, true);
+
+    consentPromise.then(() => {
+      this.storeService_.dispatch(Action.TOGGLE_PAUSED, false);
+    });
+  }
+
+
+  /**
+   * Ensures publishers using amp-consent use amp-story-consent.
+   * @param {!Element} consentEl
+   * @private
+   */
+  validateConsent_(consentEl) {
     if (!childElementByTag(consentEl, 'amp-story-consent')) {
       dev().error(TAG, 'amp-consent must have an amp-story-consent child');
     }
@@ -903,7 +936,12 @@ export class AmpStory extends AMP.BaseElement {
         setAttributeInMutate(oldPage, Attributes.VISITED);
       }
 
-      targetPage.setState(PageState.ACTIVE);
+      // Starts playing the page, if the story is not paused.
+      // Note: navigation is prevented when the story is paused, this test
+      // covers the case where the story is rendered paused (eg: consent).
+      if (!this.storeService_.get(StateProperty.PAUSED_STATE)) {
+        targetPage.setState(PageState.ACTIVE);
+      }
 
       // If first navigation.
       if (!oldPage) {
@@ -1142,6 +1180,10 @@ export class AmpStory extends AMP.BaseElement {
    * @private
    */
   onPausedStateUpdate_(isPaused) {
+    if (!this.activePage_) {
+      return;
+    }
+
     const pageState = isPaused ? PageState.PAUSED : PageState.ACTIVE;
     this.activePage_.setState(pageState);
   }

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -618,7 +618,7 @@ export class AmpStory extends AMP.BaseElement {
     storyLayoutPromise.then(() => this.whenPagesLoaded_(PAGE_LOAD_TIMEOUT_MS))
         .then(() => this.markStoryAsLoaded_());
 
-    this.handleConsent_();
+    this.handleConsentExtension_();
 
     return storyLayoutPromise;
   }
@@ -653,10 +653,10 @@ export class AmpStory extends AMP.BaseElement {
 
 
   /**
-   * Handles story consent.
+   * Handles the story consent extension.
    * @private
    */
-  handleConsent_() {
+  handleConsentExtension_() {
     const consentEl = this.element.querySelector('amp-consent');
     if (!consentEl) {
       return;

--- a/extensions/amp-story/1.0/test/test-amp-story.js
+++ b/extensions/amp-story/1.0/test/test-amp-story.js
@@ -418,10 +418,21 @@ describes.realWin('amp-story', {
 
       story.buildCallback();
 
-      return story.layoutCallback()
+      const coverEl = element.querySelector('amp-story-page');
+      let setStateStub;
+
+      return coverEl.getImpl()
+          .then(cover => {
+            setStateStub = sandbox.stub(cover, 'setState');
+            return story.layoutCallback();
+          })
           .then(() => {
-            const coverPage = story.getPageById('cover');
-            expect(coverPage.state_).to.equal(PageState.NOT_ACTIVE);
+            // These assertions ensure we don't spam the page state. We want to
+            // avoid a situation where we set the page to active, then paused,
+            // which would spam the media pool with expensive operations.
+            expect(setStateStub).to.have.been.calledOnce;
+            expect(setStateStub.getCall(0))
+                .to.have.been.calledWithExactly(PageState.NOT_ACTIVE);
           });
     });
 
@@ -446,11 +457,25 @@ describes.realWin('amp-story', {
 
       story.buildCallback();
 
-      return story.layoutCallback()
+      const coverEl = element.querySelector('amp-story-page');
+      let setStateStub;
+
+      return coverEl.getImpl()
+          .then(cover => {
+            setStateStub = sandbox.stub(cover, 'setState');
+            return story.layoutCallback();
+          })
           .then(() => resolver()) // Resolving the consent.
           .then(() => {
-            const coverPage = story.getPageById('cover');
-            expect(coverPage.state_).to.equal(PageState.ACTIVE);
+            // These assertions ensure we don't spam the page state. We want to
+            // avoid a situation where we set the page to active, then paused,
+            // then back to active, which would spam the media pool with
+            // expensive operations.
+            expect(setStateStub).to.have.been.calledTwice;
+            expect(setStateStub.getCall(0))
+                .to.have.been.calledWithExactly(PageState.NOT_ACTIVE);
+            expect(setStateStub.getCall(1))
+                .to.have.been.calledWithExactly(PageState.ACTIVE);
           });
     });
 
@@ -470,10 +495,24 @@ describes.realWin('amp-story', {
 
       story.buildCallback();
 
-      return story.layoutCallback()
+      const coverEl = element.querySelector('amp-story-page');
+      let setStateStub;
+
+      return coverEl.getImpl()
+          .then(cover => {
+            setStateStub = sandbox.stub(cover, 'setState');
+            return story.layoutCallback();
+          })
           .then(() => {
-            const coverPage = story.getPageById('cover');
-            expect(coverPage.state_).to.equal(PageState.ACTIVE);
+            // These assertions ensure we don't spam the page state. We want to
+            // avoid a situation where we set the page to active, then paused,
+            // then back to active, which would spam the media pool with
+            // expensive operations.
+            expect(setStateStub).to.have.been.calledTwice;
+            expect(setStateStub.getCall(0))
+                .to.have.been.calledWithExactly(PageState.NOT_ACTIVE);
+            expect(setStateStub.getCall(1))
+                .to.have.been.calledWithExactly(PageState.ACTIVE);
           });
     });
   });


### PR DESCRIPTION
Pause the story until the consent prompt is resolved.

I tested a lot of different cases: videos, mobile, desktop, rendering the story to page 3, etc...

I was worried about setting the ``PAUSED_STATE`` to ``true`` even if the consent promise resolves instantly, and toggles the state back to ``false``.
But this code will actually run before the ``activePage_`` is set, so it will be a no-op since there is no page to pause.

What actually happens is that the ``activePage_`` will be set to ``ACTIVE`` only when the consent is resolved by the user: there is no media operation spam (pause then play).

Partial for #15651
Partial for #14538
Fixes #15430