### PR TITLE
amp-facebook-page resize to container width

### DIFF
--- a/3p/facebook.js
+++ b/3p/facebook.js
@@ -88,6 +88,12 @@ function getPageContainer(global, data) {
   container.setAttribute('data-hide-cta', data.hideCta);
   container.setAttribute('data-small-header', data.smallHeader);
   container.setAttribute('data-adapt-container-width', true);
+
+  const c = global.document.getElementById('c');
+  // Note: The facebook embed  allows a maximum width of 500px.
+  // If the container's width exceeds that, the embed's width will
+  // be clipped to 500px.
+  container.setAttribute('data-width', c.offsetWidth);
   return container;
 }
 

--- a/3p/facebook.js
+++ b/3p/facebook.js
@@ -93,7 +93,7 @@ function getPageContainer(global, data) {
   // Note: The facebook embed  allows a maximum width of 500px.
   // If the container's width exceeds that, the embed's width will
   // be clipped to 500px.
-  container.setAttribute('data-width', c.offsetWidth);
+  container.setAttribute('data-width', c./*OK*/offsetWidth);
   return container;
 }
 


### PR DESCRIPTION
Currently the `<amp-facebook-page>` doesn't respect the container's width. Hence on smaller screens the `<amp-facebook-page>` component is cut off. 

Note: The facebook embed API allows a maximum width of 500px if the container's width exceeds that, the embed's width will be clipped to 500px.

Fixes #15858