### PR TITLE
Fixing bookend prompt consent margin when no config.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-bookend.css
+++ b/extensions/amp-story/1.0/amp-story-bookend.css
@@ -90,6 +90,10 @@
   margin: 0 32px !important;
 }
 
+.i-amphtml-story-bookend-consent:last-child {
+  margin-bottom: 32px !important;
+}
+
 .i-amphtml-story-bookend-consent .i-amphtml-story-bookend-heading {
   margin-left: 0 !important;
   margin-right: 0 !important;


### PR DESCRIPTION
Bookend privacy settings margin looked wrong when no bookend config is provided.

Fixes #15923