### PR TITLE
Add basic integration tests for button controls and text description

### DIFF
--- a/extensions/amp-lightbox-gallery/0.1/test/integration/test-amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/test/integration/test-amp-lightbox-gallery.js
@@ -42,9 +42,9 @@ describe.configure().ifNewChrome().run('amp-lightbox-gallery', function() {
       win.AMP_MODE.localDev = true;
     });
 
-    it('should open and close correctly', done => {
+    it('should open and close correctly', () => {
       const lightbox = win.document.getElementById('amp-lightbox-gallery');
-      openLightbox(win.document).then(() => {
+      return openLightbox(win.document).then(() => {
         expect(lightbox.style.display).to.not.equal('none');
         const carouselQuery = lightbox.getElementsByTagName('AMP-CAROUSEL');
         expect(carouselQuery.length).to.equal(1);
@@ -63,12 +63,11 @@ describe.configure().ifNewChrome().run('amp-lightbox-gallery', function() {
         return lightboxClose;
       }).then(() => {
         expect(lightbox.style.display).to.equal('none');
-        done();
       });
     });
 
-    it('should show close button only for one lightboxed item', done => {
-      openLightbox(win.document).then(() => {
+    it('should show close button only for one lightboxed item', () => {
+      return openLightbox(win.document).then(() => {
         const controlsContainerQuery =
           win.document.getElementsByClassName('i-amphtml-lbg-controls');
         expect(controlsContainerQuery.length).to.equal(1);
@@ -93,11 +92,10 @@ describe.configure().ifNewChrome().run('amp-lightbox-gallery', function() {
         const nextButton = getButton(win.document, 'i-amphtml-lbg-button-next');
         expect(nextButton.getAttribute('aria-label')).to.equal('Next');
         expect(win.getComputedStyle(nextButton).display).to.equal('none');
-        done();
       });
     });
 
-    it('should display text description', done => {
+    it('should display text description', () => {
       openLightbox(win.document).then(() => {
         const descBoxQuery =
           win.document.getElementsByClassName('i-amphtml-lbg-desc-box');
@@ -113,7 +111,6 @@ describe.configure().ifNewChrome().run('amp-lightbox-gallery', function() {
         expect(descriptionText.classList.contains('i-amphtml-lbg-desc-text'))
             .to.be.true;
         expect(descriptionText.textContent).to.equal('This is a figcaption.');
-        done();
       });
     });
   });
@@ -137,7 +134,6 @@ function openLightbox(document) {
 
 function getButton(document, className) {
   const buttonQuery = document.getElementsByClassName(className);
-  expect(buttonQuery.length).to.equal(1);
   const button = buttonQuery[0];
   return button;
 }

--- a/extensions/amp-lightbox-gallery/0.1/test/integration/test-amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/test/integration/test-amp-lightbox-gallery.js
@@ -17,7 +17,7 @@
 import {poll} from '../../../../../testing/iframe';
 
 describe.configure().ifNewChrome().run('amp-lightbox-gallery', function() {
-  this.timeout(5000);
+  this.timeout(10000);
   const extensions = ['amp-lightbox-gallery'];
   const body = `
   <figure>
@@ -31,7 +31,7 @@ describe.configure().ifNewChrome().run('amp-lightbox-gallery', function() {
   </figcaption>
 </figure>
   `;
-  describes.integration('amp-lightbox-gallery opens', {
+  describes.integration('amp-lightbox-gallery with one image', {
     body,
     extensions,
   }, env => {
@@ -42,20 +42,9 @@ describe.configure().ifNewChrome().run('amp-lightbox-gallery', function() {
       win.AMP_MODE.localDev = true;
     });
 
-    it('should open and close correctly', () => {
+    it('should open and close correctly', done => {
       const lightbox = win.document.getElementById('amp-lightbox-gallery');
-      expect(lightbox.style.display).to.equal('none');
-      const ampImage = win.document.getElementById('img0');
-      const imageLoadedPromise = waitForImageToLoad(ampImage);
-      return imageLoadedPromise.then(() => {
-        const ampImage = win.document.getElementById('img0');
-        // Simulate a click on the img inside the amp-img, because this is
-        // what people tend to actually click on.
-        const openerImage = ampImage.querySelector('img[amp-img-id="img0"]');
-        const openedPromise = waitForLightboxOpen(lightbox);
-        openerImage.click();
-        return openedPromise;
-      }).then(() => {
+      openLightbox(win.document).then(() => {
         expect(lightbox.style.display).to.not.equal('none');
         const carouselQuery = lightbox.getElementsByTagName('AMP-CAROUSEL');
         expect(carouselQuery.length).to.equal(1);
@@ -74,10 +63,84 @@ describe.configure().ifNewChrome().run('amp-lightbox-gallery', function() {
         return lightboxClose;
       }).then(() => {
         expect(lightbox.style.display).to.equal('none');
+        done();
+      });
+    });
+
+    it('should show close button only for one lightboxed item', done => {
+      openLightbox(win.document).then(() => {
+        const controlsContainerQuery =
+          win.document.getElementsByClassName('i-amphtml-lbg-controls');
+        expect(controlsContainerQuery.length).to.equal(1);
+        const controlsContainer = controlsContainerQuery[0];
+        expect(controlsContainer.classList
+            .contains('i-amphtml-lbg-single')).to.be.true;
+
+        const closeButton = getButton(win.document,
+            'i-amphtml-lbg-button-close');
+        expect(closeButton.getAttribute('aria-label')).to.equal('Close');
+        expect(win.getComputedStyle(closeButton).display).to.equal('block');
+
+        const galleryButton = getButton(win.document,
+            'i-amphtml-lbg-button-gallery');
+        expect(galleryButton.getAttribute('aria-label')).to.equal('Gallery');
+        expect(win.getComputedStyle(galleryButton).display).to.equal('none');
+
+        const prevButton = getButton(win.document, 'i-amphtml-lbg-button-prev');
+        expect(prevButton.getAttribute('aria-label')).to.equal('Prev');
+        expect(win.getComputedStyle(prevButton).display).to.equal('none');
+
+        const nextButton = getButton(win.document, 'i-amphtml-lbg-button-next');
+        expect(nextButton.getAttribute('aria-label')).to.equal('Next');
+        expect(win.getComputedStyle(nextButton).display).to.equal('none');
+        done();
+      });
+    });
+
+    it('should display text description', done => {
+      openLightbox(win.document).then(() => {
+        const descBoxQuery =
+          win.document.getElementsByClassName('i-amphtml-lbg-desc-box');
+        expect(descBoxQuery.length).to.equal(1);
+        const descBox = descBoxQuery[0];
+        expect(descBox.classList.contains('i-amphtml-lbg-standard')).to.be.true;
+        expect(descBox.children.length).to.equal(2);
+        const descriptionMask = descBox.children[0];
+        expect(descriptionMask.classList.contains('i-amphtml-lbg-desc-mask'))
+            .to.be.true;
+
+        const descriptionText = descBox.children[1];
+        expect(descriptionText.classList.contains('i-amphtml-lbg-desc-text'))
+            .to.be.true;
+        expect(descriptionText.textContent).to.equal('This is a figcaption.');
+        done();
       });
     });
   });
 });
+
+function openLightbox(document) {
+  const lightbox = document.getElementById('amp-lightbox-gallery');
+  expect(lightbox.style.display).to.equal('none');
+  const ampImage = document.getElementById('img0');
+  const imageLoadedPromise = waitForImageToLoad(ampImage);
+  return imageLoadedPromise.then(() => {
+    const ampImage = document.getElementById('img0');
+    // Simulate a click on the img inside the amp-img, because this is
+    // what people tend to actually click on.
+    const openerImage = ampImage.querySelector('img[amp-img-id="img0"]');
+    const openedPromise = waitForLightboxOpen(lightbox);
+    openerImage.click();
+    return openedPromise;
+  });
+}
+
+function getButton(document, className) {
+  const buttonQuery = document.getElementsByClassName(className);
+  expect(buttonQuery.length).to.equal(1);
+  const button = buttonQuery[0];
+  return button;
+}
 
 function waitForLightboxOpen(lightbox) {
   return poll('wait for amp-lightbox-gallery to open', () => {


### PR DESCRIPTION
For a single item lightbox, verify that: 
1. The description shows
2. The close button shows, and the remaining 3 buttons do not show. 