### PR TITLE
Add simple test to run during local-changes test

### DIFF
--- a/build-system/tasks/runtime-test.js
+++ b/build-system/tasks/runtime-test.js
@@ -305,6 +305,7 @@ function unitTestsToRun() {
   const filesChanged = gitDiffNameOnlyMaster();
   const testsToRun = [];
   const srcFiles = [];
+  testsToRun.push('test/simple-test.js');
   filesChanged.forEach(file => {
     if (isUnitTest(file)) {
       testsToRun.push(file);


### PR DESCRIPTION
For certain extensions, we are now focusing on writing integration tests instead of unit tests, so some components have no unit tests. Local changes will fail when no unit tests are ran. This is to add a dummy test to run during local changes so that it changes won't fail due to no tests being ran. 