### PR TITLE
🏗 Allow duplicate error messages in `expectAsyncConsoleError`

### DIFF
--- a/extensions/amp-user-notification/0.1/test/test-amp-user-notification.js
+++ b/extensions/amp-user-notification/0.1/test/test-amp-user-notification.js
@@ -341,8 +341,6 @@ describes.realWin('amp-user-notification', {
     const showEndpointStub = sandbox.stub(impl, 'getShowEndpoint_')
         .returns(Promise.resolve({showNotification: true}));
 
-    expectAsyncConsoleError(
-        '[amp-user-notification] Failed to read storage intentional');
     return impl.shouldShow().then(shouldShow => {
       expect(shouldShow).to.equal(true);
       expect(cidStub).to.be.calledOnce;
@@ -363,8 +361,6 @@ describes.realWin('amp-user-notification', {
         .withExactArgs('amp-user-notification:n1')
         .returns(Promise.reject('intentional'))
         .once();
-    expectAsyncConsoleError(
-        '[amp-user-notification] Failed to read storage intentional');
     return impl.shouldShow().then(shouldShow => {
       expect(shouldShow).to.equal(true);
       storageMock.verify();
@@ -811,7 +807,7 @@ describes.realWin('amp-user-notification', {
       });
     });
 
-    it('should dissmiss without persistence if cid.optOut() fails', () => {
+    it('should dismiss without persistence if cid.optOut() fails', () => {
       expectAsyncConsoleError(
           '[amp-user-notification] Failed to opt out of Cid failed');
 
@@ -822,8 +818,6 @@ describes.realWin('amp-user-notification', {
       impl.getCidService_ = () => { return Promise.resolve(cidMock); };
       dismissSpy = sandbox.spy(impl, 'dismiss');
 
-      expectAsyncConsoleError(
-          '[amp-user-notification] Failed to opt out of Cid failed');
       return impl.optoutOfCid_().then(() => {
         expect(dismissSpy).to.be.calledWithExactly(true);
         expect(optOutOfCidStub).to.be.calledOnce;

--- a/test/_init_tests.js
+++ b/test/_init_tests.js
@@ -328,10 +328,9 @@ function warnForConsoleError() {
       originalConsoleError(errorMessage + separator + helpMessage);
     }
   });
-  this.expectAsyncConsoleError = function(message) {
-    if (!expectedAsyncErrors.includes(message)) {
-      expectedAsyncErrors.push(message);
-    }
+  this.expectAsyncConsoleError = function(message, repeat = 1) {
+    expectedAsyncErrors.push.apply(
+        expectedAsyncErrors, Array(repeat).fill(message));
   };
   this.allowConsoleError = function(func) {
     dontWarnForConsoleError();

--- a/test/_init_tests.js
+++ b/test/_init_tests.js
@@ -320,7 +320,8 @@ function warnForConsoleError() {
             'error> });\'\n' +
         '    ⤷ If the error is expected (and asynchronous), use the ' +
             'following pattern at the top of the test:\n' +
-        '        \'expectAsyncConsoleError(<string or regex>);' + terminator;
+        '        \'expectAsyncConsoleError(<string or regex>[, number of' +
+        ' times the error message repeats]);' + terminator;
     // TODO(rsimha, #14406): Simply throw here after all tests are fixed.
     if (failOnConsoleError) {
       throw new Error(errorMessage + separator + helpMessage);


### PR DESCRIPTION
Split this off from #15906 because each PR should focus on one thing only :)