### PR TITLE
Deal with clashing presets in amp-fx gracefully

### DIFF
--- a/examples/article-invalid-presets.amp.html
+++ b/examples/article-invalid-presets.amp.html
@@ -1,0 +1,134 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>AMP Article with fade-in animations</title>
+  <link rel="canonical" href="amps.html">
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-fx-collection" src="https://cdn.ampproject.org/v0/amp-fx-collection-0.1.js"></script>
+  <style amp-custom>
+    .spacer {
+      margin-top: 10px;
+      height: 70vh;
+      width: 100%;
+      background-image: -webkit-linear-gradient(#EEE 50%, white 50%);
+      background-image: linear-gradient(#EEE 50%, white 50%);
+      background-size: 100% 3em;
+    }
+
+    header {
+      position: relative;
+    }
+
+    h1 {
+      margin: 0px 10px;
+    }
+
+    header h1 {
+      position: absolute;
+      top: 20vh;
+      padding: 5px;
+      z-index: 1;
+    }
+
+    header h1 span, .title {
+      background-color: black;
+      color: white;
+      line-height: 1.2em;
+    }
+
+    amp-img img {
+      object-fit: cover;
+    }
+
+    .overlay-top {
+      position: absolute;
+      top: 0;
+    }
+
+    .overlay-container {
+      position: relative;
+      overflow: hidden;
+    }
+
+    main {
+      font-family: Helvetica, sans-serif;
+      padding: 10px;
+      max-width: 412px;
+      margin: auto;
+    }
+
+    a, a:visited, a:active {
+      color: #2196F3;
+      text-decoration: none;
+      display: block;
+      padding: 5px;
+    }
+
+    .overflow-window {
+      overflow: hidden;
+    }
+
+    .overflow-window amp-img {
+      margin-bottom: -80%;
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <h1>
+          <span class="title">Lorem Ipsum Dolor Sit Lorem Ipsum<span>
+      </h1>
+      <amp-img height="50vh" layout="fixed-height" src="https://picsum.photos/1600/900?image=1069"></amp-img>
+    </header>
+
+    <article>
+      <div class="spacer"></div>
+      <div class="overflow-window">
+          <amp-img amp-fx="fade-in fade-in-scroll" data-duration="1000ms" layout=responsive width=900 height=1600 src="https://picsum.photos/900/1600?image=736"></amp-img>
+      </div>
+      <div class="spacer"></div>
+      <div class="overflow-window">
+          <amp-img amp-fx="fade-in-scroll fade-in" data-duration="1000ms" layout=responsive width=900 height=1600 src="https://picsum.photos/900/1600?image=736"></amp-img>
+      </div>
+      <div class="spacer"></div>
+      <div class="overflow-window">
+          <amp-img amp-fx="fly-in-bottom fly-in-top" data-duration="1000ms" layout=responsive width=900 height=1600 src="https://picsum.photos/900/1600?image=736"></amp-img>
+      </div>
+      <div class="spacer"></div>
+      <div class="overflow-window">
+          <amp-img amp-fx="fly-in-top fly-in-bottom" data-duration="1000ms" layout=responsive width=900 height=1600 src="https://picsum.photos/900/1600?image=736"></amp-img>
+      </div>
+      <div class="spacer"></div>
+      <div class="overflow-window">
+          <amp-img amp-fx="fly-in-left fly-in-right" data-duration="1000ms" layout=responsive width=900 height=1600 src="https://picsum.photos/900/1600?image=736"></amp-img>
+      </div>
+      <div class="spacer"></div>
+      <div class="overflow-window">
+          <amp-img amp-fx="fly-in-right fly-in-left" data-duration="1000ms" layout=responsive width=900 height=1600 src="https://picsum.photos/900/1600?image=736"></amp-img>
+      </div>
+      <div class="spacer"></div>
+      <div class="overflow-window">
+          <amp-img amp-fx="fly-in-bottom parallax" data-parallax-factor="1.3" layout=responsive width=900 height=1600 src="https://picsum.photos/900/1600?image=736"></amp-img>
+      </div>
+      <div class="spacer"></div>
+      <div class="overflow-window">
+          <amp-img amp-fx="parallax fly-in-bottom" data-parallax-factor="1.3" layout=responsive width=900 height=1600 src="https://picsum.photos/900/1600?image=736"></amp-img>
+      </div>
+      <div class="spacer"></div>
+      <div class="overflow-window">
+          <amp-img amp-fx="fly-in-top parallax" data-parallax-factor="1.3" layout=responsive width=900 height=1600 src="https://picsum.photos/900/1600?image=736"></amp-img>
+      </div>
+      <div class="spacer"></div>
+      <div class="overflow-window">
+          <amp-img amp-fx="parallax fly-in-top" data-parallax-factor="1.3" layout=responsive width=900 height=1600 src="https://picsum.photos/900/1600?image=736"></amp-img>
+      </div>
+      <div class="spacer"></div>
+    </article>
+  </main>
+</body>
+
+</html>

--- a/extensions/amp-fx-collection/0.1/amp-fx-collection.js
+++ b/extensions/amp-fx-collection/0.1/amp-fx-collection.js
@@ -39,6 +39,16 @@ const FxType = {
   FLY_IN_TOP: 'fly-in-top',
 };
 
+const restrictedFxTypes = {
+  'parallax' : ['fly-in-top', 'fly-in-bottom'],
+  'fly-in-top' : ['parallax', 'fly-in-bottom'],
+  'fly-in-bottom' : ['fly-in-top', 'parallax'],
+  'fly-in-right': ['fly-in-left'],
+  'fly-in-left': ['fly-in-right'],
+  'fade-in': ['fade-in-scroll'],
+  'fade-in-scroll': ['fade-in'],
+};
+
 /**
  * Bootstraps elements that have `amp-fx=<fx1 fx2>` attribute and installs
  * the specified effects on them.
@@ -138,6 +148,33 @@ export class AmpFxCollection {
       user().assertEnumValue(FxType, fxType, 'amp-fx');
     });
 
+    this.sanitizeFxTypes_(fxTypes);
+
+    return fxTypes;
+  }
+
+  /**
+   * Returns the array of fx types this component after checking that no 
+   * clashing fxTypes are present on the same element.
+   * e.g. `amp-fx="parallax fade-in"
+   *
+   * @param {!Array<!FxType>}
+   * @return {!Array<!FxType>}
+   */
+  sanitizeFxTypes_(fxTypes) {
+    for (let i = 0; i < fxTypes.length; i++) {
+      const currentType = fxTypes[i];
+      if (currentType in restrictedFxTypes) {
+        for (let j = i + 1; j < fxTypes.length; j++) {
+          if (restrictedFxTypes[currentType].includes(fxTypes[j])) {
+            user().warn( 
+              '%s preset can\'t be combined with %s preset as the resulting ' +
+              'animation isn\'t valid.', currentType, fxTypes[j]);
+            fxTypes.splice(j, 1);
+          }
+        }
+      }
+    }
     return fxTypes;
   }
 

--- a/extensions/amp-fx-collection/0.1/amp-fx-collection.js
+++ b/extensions/amp-fx-collection/0.1/amp-fx-collection.js
@@ -40,9 +40,9 @@ const FxType = {
 };
 
 const restrictedFxTypes = {
-  'parallax' : ['fly-in-top', 'fly-in-bottom'],
-  'fly-in-top' : ['parallax', 'fly-in-bottom'],
-  'fly-in-bottom' : ['fly-in-top', 'parallax'],
+  'parallax': ['fly-in-top', 'fly-in-bottom'],
+  'fly-in-top': ['parallax', 'fly-in-bottom'],
+  'fly-in-bottom': ['fly-in-top', 'parallax'],
   'fly-in-right': ['fly-in-left'],
   'fly-in-left': ['fly-in-right'],
   'fade-in': ['fade-in-scroll'],
@@ -154,11 +154,11 @@ export class AmpFxCollection {
   }
 
   /**
-   * Returns the array of fx types this component after checking that no 
+   * Returns the array of fx types this component after checking that no
    * clashing fxTypes are present on the same element.
    * e.g. `amp-fx="parallax fade-in"
    *
-   * @param {!Array<!FxType>}
+   * @param {!Array<!FxType>} fxTypes
    * @return {!Array<!FxType>}
    */
   sanitizeFxTypes_(fxTypes) {
@@ -166,10 +166,10 @@ export class AmpFxCollection {
       const currentType = fxTypes[i];
       if (currentType in restrictedFxTypes) {
         for (let j = i + 1; j < fxTypes.length; j++) {
-          if (restrictedFxTypes[currentType].includes(fxTypes[j])) {
-            user().warn( 
-              '%s preset can\'t be combined with %s preset as the resulting ' +
-              'animation isn\'t valid.', currentType, fxTypes[j]);
+          if (restrictedFxTypes[currentType].indexOf(fxTypes[j]) !== -1) {
+            user().warn(TAG,
+                '%s preset can\'t be combined with %s preset as the ' +
+                'resulting animation isn\'t valid.', currentType, fxTypes[j]);
             fxTypes.splice(j, 1);
           }
         }

--- a/extensions/amp-fx-collection/amp-fx-collection.md
+++ b/extensions/amp-fx-collection/amp-fx-collection.md
@@ -231,6 +231,34 @@ In the below example, the element is translated along the Y axis across `20%` of
 
 This parameter determines when to trigger the timed animation. The value specified in `<percent>` dictates that the animation should be triggered when the element has crossed that percentage of the viewport. The default value is `5%`.
 
+## Combining presets
+
+Developers can also combine `amp-fx` presets together to create combined animations. 
+
+
+In the below example, the element is both translated along the Y axis and has it's opacity changed from `0` to `1` over a duration of `1000ms`.
+
+```html
+  <div amp-fx="fade-in fly-in-bottom" data-duration="1000ms">
+    <amp-img width="1600" height="900" layout="responsive" src="https://picsum.photos/1600/900?image=1069"></amp-img>
+  </div>
+```
+
+However, there are some presets which don't combine together to create great results. In such cases, we accept the first preset listed and ignore the clashing preset and warn in the console. 
+
+In the below example, the element is being translated along the Y axis by two clashing presets `parallax` and `fly-in-bottom`. In this case we only allow the `parallax` animation and ignore the `fly-in-bottom` preset. 
+
+```html
+  <div amp-fx="parallax fly-in-bottom" data-parallax-factor="1.5">
+    <amp-img width="1600" height="900" layout="responsive" src="https://picsum.photos/1600/900?image=1069"></amp-img>
+  </div>
+```
+
+Below is a list of group of presets, AMP advises you don't combine:
+1. `parallax`, `fly-in-top`, `fly-in-bottom`,
+2. `fly-in-left`, `fly-in-right`,
+3. `fade-in`, `fade-in-scroll`.
+
 ## Validation
 
 See [amp-fx-collection rules](https://github.com/ampproject/amphtml/blob/master/extensions/amp-fx-collection/validator-amp-fx-collection.protoascii) in the AMP validator specification.


### PR DESCRIPTION
There are some `amp-fx` presets which don't combine together to create great results. In such cases, we accept the first preset listed and ignore the clashing presets and warn in the console. 

Below is a list of group of presets, that don't combine to yield good results:
1. `parallax`, `fly-in-top`, `fly-in-bottom`,
2. `fly-in-left`, `fly-in-right`,
3. `fade-in`, `fade-in-scroll`.

Markdown and example changes included. 
Will also add a note to ABE once this lands. 

Fixes #14697