### PR TITLE
🐛 Fix CSP value to allow loading amp-crypto-polyfill

### DIFF
--- a/examples/csp.amp.html
+++ b/examples/csp.amp.html
@@ -6,7 +6,7 @@
   <link rel="canonical" href="analytics.amp.html" >
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
 
-  <meta http-equiv="Content-Security-Policy" content="default-src * data: blob:; script-src blob: https://cdn.ampproject.org/v0.js https://cdn.ampproject.org/v0/ https://cdn.ampproject.org/viewer/; object-src 'none'; style-src 'unsafe-inline' https://cdn.ampproject.org/rtv/ https://cdn.materialdesignicons.com https://cloud.typography.com https://fast.fonts.net https://fonts.googleapis.com https://maxcdn.bootstrapcdn.com https://p.typekit.net https://use.fontawesome.com https://use.typekit.net; report-uri https://csp-collector.appspot.com/csp/amp">
+  <meta http-equiv="Content-Security-Policy" content="default-src * data: blob:; script-src blob: https://cdn.ampproject.org/v0.js https://cdn.ampproject.org/v0/ https://cdn.ampproject.org/viewer/ https://cdn.ampproject.org/rtv/; object-src 'none'; style-src 'unsafe-inline' https://cdn.ampproject.org/rtv/ https://cdn.materialdesignicons.com https://cloud.typography.com https://fast.fonts.net https://fonts.googleapis.com https://maxcdn.bootstrapcdn.com https://p.typekit.net https://use.fontawesome.com https://use.typekit.net; report-uri https://csp-collector.appspot.com/csp/amp">
   <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="https://use.typekit.net/oeg4hgb.css">
   <script async custom-element="amp-ad" src="https://cdn.ampproject.org/v0/amp-ad-0.1.js"></script>


### PR DESCRIPTION
Edit the CSP value to allow amp-crypto-polyfill to be loaded.

As discussed in #1316 y'all rely on this file to be the "definitive article" on what CSP headers should be set. However using this value as a HTTP header response (i.e. not part of `<head />`) results in failing the Mobile Friendly Test from google. Painfully this is not detected when in development mode (i.e. `#development=1`).

The errors:
> Source: https://www.famfi.co/:0
> Message: Refused to load the script 'https://cdn.ampproject.org/rtv/011528391646530/v0/amp-crypto-polyfill-0.1.js' because it violates the following Content Security Policy directive: "script-src blob: https:/...

Note that the elided message is rendered by https://search.google.com/test/mobile-friendly as such, not a decision on my part.

There are other errors, which you can see here: https://search.google.com/test/mobile-friendly?view=fetch-info&id=gVPxQTzXbSU42zbqng8xUA which do not block MFT from successfully acknowledging the page content.