### PR TITLE
🚀♻️Delegate autoplay using signal

### DIFF
--- a/build-system/dep-check-config.js
+++ b/build-system/dep-check-config.js
@@ -249,10 +249,9 @@ exports.rules = [
       'extensions/amp-consent/0.1/amp-consent.js->' +
           'src/service/notification-ui-manager.js',
       // For autoplay delegation.
-      // TODO(alanorozco, #13674): Use async service.
-      'extensions/amp-story/0.1/amp-story-page.js->' +
-          'src/service/video-manager-impl.js',
       'extensions/amp-story/1.0/amp-story-page.js->' +
+          'src/service/video-service-sync-impl.js',
+      'extensions/amp-story/0.1/amp-story-page.js->' +
           'src/service/video-manager-impl.js',
       'extensions/amp-story/1.0/page-advancement.js->' +
           'src/service/action-impl.js',

--- a/build-system/dep-check-config.js
+++ b/build-system/dep-check-config.js
@@ -249,10 +249,10 @@ exports.rules = [
       'extensions/amp-consent/0.1/amp-consent.js->' +
           'src/service/notification-ui-manager.js',
       // For autoplay delegation.
+      'extensions/amp-story/0.1/amp-story-page.js->' +
+          'src/service/video-service-sync-impl.js',
       'extensions/amp-story/1.0/amp-story-page.js->' +
           'src/service/video-service-sync-impl.js',
-      'extensions/amp-story/0.1/amp-story-page.js->' +
-          'src/service/video-manager-impl.js',
       'extensions/amp-story/1.0/page-advancement.js->' +
           'src/service/action-impl.js',
       'extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js->' +

--- a/extensions/amp-story/0.1/amp-story-page.js
+++ b/extensions/amp-story/0.1/amp-story-page.js
@@ -35,6 +35,7 @@ import {LoadingSpinner} from './loading-spinner';
 import {MediaPool} from './media-pool';
 import {PageScalingService} from './page-scaling';
 import {Services} from '../../../src/services';
+import {VideoServiceSync} from '../../../src/service/video-service-sync-impl';
 import {
   closestBySelector,
   matches,
@@ -44,9 +45,6 @@ import {debounce} from '../../../src/utils/rate-limit';
 import {dev} from '../../../src/log';
 import {getLogEntries} from './logging';
 import {getMode} from '../../../src/mode';
-import {
-  installVideoManagerForDoc,
-} from '../../../src/service/video-manager-impl';
 import {listen} from '../../../src/event-helper';
 import {toArray} from '../../../src/types';
 import {upgradeBackgroundAudio} from './audio';
@@ -149,7 +147,7 @@ export class AmpStoryPage extends AMP.BaseElement {
   /** @override */
   buildCallback() {
     upgradeBackgroundAudio(this.element);
-    this.ownVideoAutoplay_();
+    this.configureVideo_();
     this.markMediaElementsWithPreload_();
     this.initializeMediaPool_();
     this.maybeCreateAnimationManager_();
@@ -164,20 +162,13 @@ export class AmpStoryPage extends AMP.BaseElement {
 
 
   /** @private */
-  ownVideoAutoplay_() {
+  configureVideo_() {
     const videos = this.element.querySelectorAll('amp-video');
     if (videos.length < 1) {
       return;
     }
-
-    // This service gets installed by all video instances.
-    // Executions of `installVideoManagerForDoc` following the first are NOOPs,
-    // so this only takes care of a race condition when the service has not yet
-    // been installed.
-    installVideoManagerForDoc(this.getAmpDoc());
-
     toArray(videos).forEach(el => {
-      Services.videoManagerForDoc(this.element).delegateAutoplay(el);
+      VideoServiceSync.delegateAutoplay(/** @type {!AmpElement} */ (el));
     });
   }
 

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -35,6 +35,7 @@ import {LoadingSpinner} from './loading-spinner';
 import {MediaPool} from './media-pool';
 import {PageScalingService} from './page-scaling';
 import {Services} from '../../../src/services';
+import {VideoServiceSync} from '../../../src/service/video-service-sync-impl';
 import {
   closestBySelector,
   iterateCursor,
@@ -45,9 +46,6 @@ import {debounce} from '../../../src/utils/rate-limit';
 import {dev} from '../../../src/log';
 import {getLogEntries} from './logging';
 import {getMode} from '../../../src/mode';
-import {
-  installVideoManagerForDoc,
-} from '../../../src/service/video-manager-impl';
 import {listen} from '../../../src/event-helper';
 import {toArray} from '../../../src/types';
 import {upgradeBackgroundAudio} from './audio';
@@ -165,7 +163,7 @@ export class AmpStoryPage extends AMP.BaseElement {
   /** @override */
   buildCallback() {
     upgradeBackgroundAudio(this.element);
-    this.ownVideoAutoplay_();
+    this.configureVideo_();
     this.markMediaElementsWithPreload_();
     this.initializeMediaPool_();
     this.maybeCreateAnimationManager_();
@@ -180,21 +178,12 @@ export class AmpStoryPage extends AMP.BaseElement {
 
 
   /** @private */
-  ownVideoAutoplay_() {
+  configureVideo_() {
     const videos = this.element.querySelectorAll('amp-video');
     if (videos.length < 1) {
       return;
     }
-
-    // This service gets installed by all video instances.
-    // Executions of `installVideoManagerForDoc` following the first are NOOPs,
-    // so this only takes care of a race condition when the service has not yet
-    // been installed.
-    installVideoManagerForDoc(this.getAmpDoc());
-
-    toArray(videos).forEach(el => {
-      Services.videoManagerForDoc(this.element).delegateAutoplay(el);
-    });
+    toArray(videos).forEach(el => VideoServiceSync.delegateAutoplay(el));
   }
 
 

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -183,7 +183,9 @@ export class AmpStoryPage extends AMP.BaseElement {
     if (videos.length < 1) {
       return;
     }
-    toArray(videos).forEach(el => VideoServiceSync.delegateAutoplay(el));
+    toArray(videos).forEach(el => {
+      VideoServiceSync.delegateAutoplay(/** @type {!AmpElement} */ (el));
+    });
   }
 
 

--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -202,14 +202,6 @@ export class VideoManager {
     element.classList.add('i-amphtml-video-interface');
   }
 
-  /** @override */
-  delegateAutoplay(videoElement, opt_unusedObservable) {
-    videoElement.signals().whenSignal(VideoEvents.REGISTERED).then(() => {
-      const entry = this.getEntryForElement_(videoElement);
-      entry.delegateAutoplay();
-    });
-  }
-
   /**
    * Register common actions such as play, pause, etc... on the video element
    * so they can be called using AMP Actions.
@@ -466,15 +458,20 @@ class VideoEntry {
       const actions = Services.actionServiceForDoc(this.ampdoc_);
       actions.trigger(this.video.element, firstPlay, event, trust);
     });
+
+    this.listenForAutoplayDelegation_();
   }
 
-  /** Delegates autoplay to a different module. */
-  delegateAutoplay() {
-    this.allowAutoplay_ = false;
+  /** Listens for signals to delegate autoplay to a different module. */
+  listenForAutoplayDelegation_() {
+    const signals = this.video.signals();
+    signals.whenSignal(VideoServiceSignals.AUTOPLAY_DELEGATED).then(() => {
+      this.allowAutoplay_ = false;
 
-    if (this.isPlaying_) {
-      this.video.pause();
-    }
+      if (this.isPlaying_) {
+        this.video.pause();
+      }
+    });
   }
 
   /** @return {boolean} */

--- a/src/service/video-service-interface.js
+++ b/src/service/video-service-interface.js
@@ -34,14 +34,6 @@ export class VideoServiceInterface {
   getAnalyticsDetails(unusedVideo) {}
 
   /**
-   * Delegates autoplay.
-   * @param {!AmpElement} unusedVideo
-   * @param {?../observable.Observable<boolean>=} opt_unusedObservable
-   *    If provided, video will be played or paused when this observable fires.
-   */
-  delegateAutoplay(unusedVideo, opt_unusedObservable) {}
-
-  /**
    * @param {!../video-interface.VideoInterface} unusedVideo
    * @return {boolean}
    */
@@ -58,4 +50,5 @@ export class VideoServiceInterface {
 /** @enum {string} */
 export const VideoServiceSignals = {
   USER_INTERACTED: 'user-interacted',
+  AUTOPLAY_DELEGATED: 'autoplay-delegated',
 };

--- a/src/service/video-service-sync-impl.js
+++ b/src/service/video-service-sync-impl.js
@@ -130,7 +130,7 @@ export class VideoServiceSync {
   }
 
   /**
-   * @param {!AmpElement|!BaseElement} video
+   * @param {!AmpElement|!../base-element.BaseElement} video
    */
   static delegateAutoplay(video) {
     video.signals().signal(VideoServiceSignals.AUTOPLAY_DELEGATED);

--- a/src/service/video-service-sync-impl.js
+++ b/src/service/video-service-sync-impl.js
@@ -18,6 +18,7 @@ import {Autoplay, AutoplayEvents} from './video/autoplay';
 import {Deferred} from '../utils/promise';
 import {PlayingStates, VideoAttributes, VideoEvents} from '../video-interface';
 import {Services} from '../services';
+import {VideoServiceSignals} from './video-service-interface';
 import {dev} from '../log';
 import {getAmpdoc} from '../service';
 import {getElementServiceForDoc} from '../element-service';
@@ -114,18 +115,25 @@ export class VideoServiceSync {
     if (!video.element.hasAttribute(VideoAttributes.AUTOPLAY)) {
       return;
     }
-    this.getAutoplay_().register(video);
-  }
+    const signals = video.signals();
+    const autoplayDelegated = VideoServiceSignals.AUTOPLAY_DELEGATED;
 
-  /** @override */
-  delegateAutoplay(video, optObservable = null) {
-    // TODO(alanorozco): Make observable required once implementation of
-    // `VideoService` finalizes.
-    if (optObservable == null) {
-      dev().assert(false, 'Autoplay delegation requires an observable.');
+    if (signals.get(autoplayDelegated)) {
       return;
     }
-    this.getAutoplay_().delegate(video, optObservable);
+
+    this.getAutoplay_().register(video);
+
+    signals.whenSignal(autoplayDelegated).then(() => {
+      this.getAutoplay_().delegate(video.element);
+    });
+  }
+
+  /**
+   * @param {!AmpElement|!BaseElement} video
+   */
+  static delegateAutoplay(video) {
+    video.signals().signal(VideoServiceSignals.AUTOPLAY_DELEGATED);
   }
 
   /** @override */

--- a/src/service/video/autoplay.js
+++ b/src/service/video/autoplay.js
@@ -177,14 +177,13 @@ export class Autoplay {
 
   /**
    * @param {!Element} element
-   * @param {!../../observable.Observable<boolean>} observable
    */
-  delegate(element, observable) {
+  delegate(element) {
     const entry = this.getEntryFor_(element);
     if (!entry) {
       return;
     }
-    entry.delegateTo(observable);
+    entry.delegate();
   }
 
   /**
@@ -253,15 +252,15 @@ export class AutoplayEntry {
   }
 
   /**
-   * @param {!../../observable.Observable<boolean>} playbackObservable
+   * Delegates autoplay so that it's triggered by a different module.
    * @public
    */
-  delegateTo(playbackObservable) {
+  delegate() {
     if (this.unlistener_) {
       this.unlistener_();
     }
-    this.unlistener_ =
-        playbackObservable.add(isPlaying => this.trigger_(isPlaying));
+    this.video.pause();
+    this.unlistener_ = null;
   }
 
   /** @private */

--- a/src/service/video/autoplay.js
+++ b/src/service/video/autoplay.js
@@ -227,7 +227,7 @@ export class AutoplayEntry {
     /** @private {boolean} */
     this.isVisible_ = false;
 
-    /** @private {!UnlistenDef} */
+    /** @private {!UnlistenDef|null} */
     this.unlistener_ = this.observeOn_(positionObserver);
 
     // Only muted videos are allowed to autoplay


### PR DESCRIPTION
- Keeps interfaces cleaner
- Fixes race condition where `amp-story` loads before `amp-video`, so `amp-story` needed to install the `VideoManager` service.
- Since the `VideoManager` service no longer has to be bundled in the `amp-story` binary, its size reduces from `340134` to `303611` bytes before gzip.