### PR TITLE
Add `NOENCODE_WHITELIST` to new expander

### DIFF
--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -23,7 +23,7 @@ import {
   getTimingDataAsync,
   getTimingDataSync,
 } from './variable-source';
-import {Expander} from './url-expander/expander';
+import {Expander, NOENCODE_WHITELIST} from './url-expander/expander';
 import {Services} from '../services';
 import {WindowInterface} from '../window-interface';
 import {
@@ -49,10 +49,6 @@ const VARIANT_DELIMITER = '.';
 const GEO_DELIM = ',';
 const ORIGINAL_HREF_PROPERTY = 'amp-original-href';
 const ORIGINAL_VALUE_PROPERTY = 'amp-original-value';
-
-/** A whitelist for replacements whose values should not be %-encoded. */
-/** @private @const {Object<string, boolean>} */
-const NOENCODE_WHITELIST = {'ANCESTOR_ORIGIN': true};
 
 /** @const {string} */
 export const REPLACEMENT_EXP_NAME = 'url-replacement-v2';

--- a/test/functional/url-expander/test-expander.js
+++ b/test/functional/url-expander/test-expander.js
@@ -144,6 +144,7 @@ describes.realWin('Expander', {
       ASYNC: Promise.resolve('hello'),
       ASYNCFN: arg => Promise.resolve(arg),
       BROKEN: () => undefined,
+      ANCESTOR_ORIGIN: () => Promise.resolve('https://www.google.com@foo'),
     };
 
     const sharedTestCases = [
@@ -261,6 +262,13 @@ describes.realWin('Expander', {
         it('should handle tokens with parenthesis next to each other', () => {
           const url = 'http://www.google.com/?test=RANDOMCLIENT_ID(__ga)UPPERCASE(foo)';
           const expected = 'http://www.google.com/?test=123456amp-GA12345FOO';
+          return expect(expander.expand(url, mockBindings))
+              .to.eventually.equal(expected);
+        });
+
+        it('should not encode NOENCODE_WHITELIST', () => {
+          const url = 'ANCESTOR_ORIGIN';
+          const expected = 'https://www.google.com@foo';
           return expect(expander.expand(url, mockBindings))
               .to.eventually.equal(expected);
         });


### PR DESCRIPTION
The viewer uses this so that `ANCESTOR_ORIGIN` is not encoded.