### PR TITLE
Remove inline installation

### DIFF
--- a/validator/webui/@polymer/ampproject-toolbar/ampproject-toolbar.html
+++ b/validator/webui/@polymer/ampproject-toolbar/ampproject-toolbar.html
@@ -74,26 +74,11 @@
            target="_blank">PRIVACY</a>
         &nbsp;&nbsp;&nbsp;
         <a href="https://chrome.google.com/webstore/detail/amp-validator/nmoffdblmcmgeicmolmhobpoocbbmknc"
-           id="install-extension" onclick="return false;" target="_blank">CHROME EXTENSION</a>
+           target="_blank">CHROME EXTENSION</a>
         &nbsp;&nbsp;&nbsp;
         <a href="https://www.npmjs.com/package/amphtml-validator"
            target="_blank">NPM</a>
       </div>
     </paper-toolbar>
   </template>
-  <script>
-    Polymer({
-      is: 'ampproject-toolbar',
-      listeners: {
-        'install-extension.tap': 'installExtension'
-      },
-      installExtension: function(e) {
-        if (document.domain === 'validator.ampproject.org') {
-          chrome.webstore.install('https://chrome.google.com/webstore/detail/nmoffdblmcmgeicmolmhobpoocbbmknc');
-        } else {
-          window.open('https://chrome.google.com/webstore/detail/amp-validator/nmoffdblmcmgeicmolmhobpoocbbmknc', '_blank');
-        }
-      }
-    });
-  </script>
 </dom-module>

--- a/validator/webui/@polymer/ampproject-toolbar/ampproject-toolbar.html
+++ b/validator/webui/@polymer/ampproject-toolbar/ampproject-toolbar.html
@@ -81,4 +81,9 @@
       </div>
     </paper-toolbar>
   </template>
+  <script>
+    Polymer({
+      is: 'ampproject-toolbar',
+    });
+  </script>
 </dom-module>

--- a/validator/webui/@polymer/ampproject-toolbar/ampproject-toolbar.html
+++ b/validator/webui/@polymer/ampproject-toolbar/ampproject-toolbar.html
@@ -17,8 +17,6 @@
      lot of styling, so we isolate it to keep the source for other parts of
      the page easier to read. -->
 <link rel="import" href="../paper-toolbar/paper-toolbar.html">
-<link rel="import" href="../polymer/polymer.html">
-<link rel="import" href="../iron-flex-layout/iron-flex-layout.html">
 <dom-module id="ampproject-toolbar">
   <style scope="ampproject-toolbar">
     paper-toolbar {

--- a/validator/webui/app.yaml
+++ b/validator/webui/app.yaml
@@ -1,4 +1,3 @@
-version: 1
 runtime: go
 api_version: go1
 


### PR DESCRIPTION
Remove the [inline installation](https://developer.chrome.com/webstore/inline_installation) of the AMP Validator Chrome Extension from the Validator WebUI.