### PR TITLE
🏗 Require JSDoc comments for all classes, methods, and functions in AMP code

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -143,6 +143,15 @@
     "prefer-const": 2,
     "quotes": [2, "single", "avoid-escape"],
     "radix": 2,
+    "require-jsdoc": [1, {
+      "require": {
+        "FunctionDeclaration": true,
+        "MethodDefinition": true,
+        "ClassDeclaration": true,
+        "ArrowFunctionExpression": false,
+        "FunctionExpression": false
+      }
+    }],
     "semi": 2,
     "keyword-spacing": [2, { "before": true, "after": true }],
     "sort-imports-es6-autofix/sort-imports-es6": [2, {

--- a/.eslintrc-strict
+++ b/.eslintrc-strict
@@ -10,6 +10,15 @@
     "jsdoc/require-param": 2,
     "jsdoc/require-param-name": 2,
     "jsdoc/require-param-type": 2,
-    "jsdoc/require-returns-type": 2
+    "jsdoc/require-returns-type": 2,
+    "require-jsdoc": [2, {
+      "require": {
+        "FunctionDeclaration": true,
+        "MethodDefinition": true,
+        "ClassDeclaration": true,
+        "ArrowFunctionExpression": false,
+        "FunctionExpression": false
+      }
+    }]
   }
 }

--- a/validator/.eslintrc
+++ b/validator/.eslintrc
@@ -47,6 +47,7 @@
     }],
     "no-useless-concat": 1,
     "no-var": 1,
-    "prefer-const": 1
+    "prefer-const": 1,
+    "require-jsdoc": 0
   }
 }


### PR DESCRIPTION
Until now, `gulp lint` used to check existing JSDoc comments for correctness, but it didn't complain if they were missing.

With this PR, we require JSDoc comments for all classes, methods, and functions in the AMP codebase. This is critical to our ability to speed up the compilation of the AMP runtime using closure compiler.

Since there are numerous instances of missing JSDoc comments, this rule will be run in warning mode for push builds on `master`, while it will run in error mode on files touched by a PR (large refactors are exempted).