### PR TITLE
Skip flaky test for `amp-nexxtv-player`

### DIFF
--- a/extensions/amp-nexxtv-player/0.1/test/test-amp-nexxtv-player.js
+++ b/extensions/amp-nexxtv-player/0.1/test/test-amp-nexxtv-player.js
@@ -66,7 +66,7 @@ describes.realWin('amp-nexxtv-player', {
     });
   });
 
-  it('fails without mediaid', () => {
+  it.skip('fails without mediaid', () => {
     expectAsyncConsoleError(/data-mediaid attribute is required/);
     return getNexxtv(null, '761').should.eventually.be.rejected;
   });


### PR DESCRIPTION
Test is failing often on master.

![image](https://user-images.githubusercontent.com/16087874/41303525-597738ae-6e22-11e8-8362-b378a37dcd4d.png)

