### PR TITLE
Sidebar should not close  when toolbar is present

### DIFF
--- a/extensions/amp-sidebar/0.1/amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.js
@@ -196,17 +196,9 @@ export class AmpSidebar extends AMP.BaseElement {
     this.getAmpDoc().whenReady().then(() => {
       // Check our toolbars for changes
       this.toolbars_.forEach(toolbar => {
-        toolbar.onLayoutChange(() => this.onToolbarOpen_());
+        toolbar.onLayoutChange();
       });
     });
-  }
-
-  /**
-   * Function called whenever a tollbar is opened.
-   * @private
-   */
-  onToolbarOpen_() {
-    this.close_();
   }
 
   /**

--- a/extensions/amp-sidebar/0.1/amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.js
@@ -42,6 +42,9 @@ const SidebarEvents = {
   CLOSE: 'sidebarClose',
 };
 
+/**
+ * @extends {AMP.BaseElement}
+ */
 export class AmpSidebar extends AMP.BaseElement {
   /** @param {!AmpElement} element */
   constructor(element) {

--- a/extensions/amp-sidebar/0.1/toolbar.js
+++ b/extensions/amp-sidebar/0.1/toolbar.js
@@ -54,16 +54,15 @@ export class Toolbar {
 
   /**
    * Function called to check if we should show or hide the toolbar
-   * @param {!Function} onShowCallback - function called if toolbar is shown on check
    */
-  onLayoutChange(onShowCallback) {
+  onLayoutChange() {
     // Get if we match the current toolbar media
     const matchesMedia = this.ampdoc_.win
         .matchMedia(this.toolbarMedia_).matches;
 
     // Remove and add the toolbar dynamically
     if (matchesMedia) {
-      this.attemptShow_().then(onShowCallback);
+      this.attemptShow_();
     } else {
       this.hideToolbar_();
     }

--- a/extensions/amp-sidebar/0.1/toolbar.js
+++ b/extensions/amp-sidebar/0.1/toolbar.js
@@ -17,6 +17,9 @@
 import {toggle} from '../../../src/style';
 import {user} from '../../../src/log';
 
+/**
+ * Class representing toolbar behavior in sidebar
+ */
 export class Toolbar {
   /**
   * @param {!Element} element


### PR DESCRIPTION
Fixes https://github.com/ampproject/amphtml/issues/15907. 

### Background
1. We used to have logic that closes the sidebar on resize (aka `onLayoutMeasure`) IF the resize caused toolbars to open. Unsure if this was also intended to make sure we could never open the sidebar while toolbars are present. The original intention was to close the sidebar if resize caused all toolbar elements to move to sidebar, but this doesn't match what was implemented. 
2. Due to changes between 1527816702194 and 1527021682973, opening the sidebar will also trigger `onLayoutMeasure`, open the toolbar, and cause sidebar to close, resulting in an FOUC of sidebar opening / closing again. This is the bug in #15907, possibly caused by #15641. 

### This PR
1. We want to allow sidebar to open while toolbar is present, and not make these mutually exclusive. 
2. We don't want to close the sidebar if a toolbar opens. If toolbars open while the sidebar is open, the sidebar should remain open. 
This PR implements this behavior (1 and 2). 

### Reasoning
Per #15907, We're making this change to be backwards compatible with previous behavior, where we could actually toggle the sidebar while toolbars were present.

Follow up: 
File a follow-up FR to close the sidebar only after all elements in it have moved to the toolbar. We can discuss the specifics of this in a separate issue. 