### PR TITLE
🐛Report if defaultView is null in preconnect

### DIFF
--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -540,6 +540,16 @@ function createBaseCustomElementClass(win) {
         // an unfortunate trade off, but it seems faster, because the DOM
         // operations themselves are not free and might delay
         Services.timerFor(toWin(this.ownerDocument.defaultView)).delay(() => {
+          const TAG = this.tagName;
+          if (!this.ownerDocument) {
+            dev().error(TAG, 'preconnectCallback called on element without ' +
+                'owner docuent');
+            return;
+          } else if (!this.ownerDocument.defaultView) {
+            dev().error(TAG, 'preconnectCallback called on element without ' +
+                'default view');
+            return;
+          }
           this.implementation_.preconnectCallback(onLayout);
         }, 1);
       }


### PR DESCRIPTION
This is an attempt at fixing #15883.

The current suspicion is that the setTimeout call inside
`CustomElement#preconnect` delays the call to
`BaseElement#preconnectCallback`. During this delay, the parent window
is destroyed (maybe the iframe is removed from the DOM?), causing
`element.ownerDocument.defaultView` to return `null`.

It's frankly very surprising that timers would fire after a window is
destroyed, so we're only guarding `#preconnectCallback` for now. We may
later extend this to all timers if it fixes the bug.