### PR TITLE
🏗 Exempt `build-system/` and `test/` from JSDoc requirements

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -166,5 +166,13 @@
     "space-infix-ops": 2,
     "space-unary-ops": [1, { "words": true, "nonwords": false }],
     "wrap-iife": [2, "any"]
-  }
+  },
+  "overrides": [
+    {
+      "files": ["test/**/*.js", "extensions/**/test/**/*.js"],
+      "rules": {
+        "require-jsdoc": 0
+      }
+    }
+  ]
 }

--- a/build-system/.eslintrc
+++ b/build-system/.eslintrc
@@ -6,5 +6,8 @@
     "require": false,
     "process": false,
     "exports": false
+  },
+  "rules": {
+    "require-jsdoc": 0
   }
 }


### PR DESCRIPTION
This PR makes #15977 less painful to deal with.