### PR TITLE
Fixing an error message when getting the share providers with no bookend config.

### DIFF
--- a/extensions/amp-story/0.1/amp-story-share.js
+++ b/extensions/amp-story/0.1/amp-story-share.js
@@ -468,23 +468,24 @@ export class ScrollableShareWidget extends ShareWidget {
 
         // Total width that the buttons will occupy with minimum padding.
         const totalItemWidth =
-            (iconWidth * items.length + 2 * MIN_BUTTON_PADDING *
+            (iconWidth * items.length) + ((2 * MIN_BUTTON_PADDING) *
                 (items.length - 1));
 
         // If buttons don't fit within the available area, calculate padding so
         // that there will be an element cut-off.
-        if (totalItemWidth > (containerWidth - leftMargin * 2)) {
-          const availableWidth = containerWidth - leftMargin - iconWidth / 2;
+        if (totalItemWidth > (containerWidth - (leftMargin * 2))) {
+          const availableWidth = containerWidth - leftMargin - (iconWidth / 2);
           const amountVisible =
-              Math.floor(availableWidth / (iconWidth + MIN_BUTTON_PADDING * 2));
+              Math.floor(
+                  availableWidth / (iconWidth + (MIN_BUTTON_PADDING * 2)));
 
-          state.padding = 0.5 * (availableWidth / amountVisible - iconWidth);
+          state.padding = 0.5 * ((availableWidth / amountVisible) - iconWidth);
         } else {
           // Otherwise, calculate padding in from MIN_PADDING to DEFAULT_PADDING
           // so that all elements fit and take as much area as possible.
           const totalPadding =
-              ((containerWidth - leftMargin * 2) - iconWidth * items.length) /
-              (items.length - 1);
+              ((containerWidth - (leftMargin * 2)) -
+              (iconWidth * items.length)) / (items.length - 1);
 
           state.padding = Math.min(DEFAULT_BUTTON_PADDING, 0.5 * totalPadding);
         }

--- a/extensions/amp-story/0.1/animation.js
+++ b/extensions/amp-story/0.1/animation.js
@@ -241,8 +241,8 @@ class AnimationRunner {
   /** @return {boolean} */
   hasStarted() {
     return this.isActivityScheduled_(PlaybackActivity.START) ||
-        !!this.runner_ && dev().assert(this.runner_)
-            .getPlayState() == WebAnimationPlayState.RUNNING;
+        (!!this.runner_ && dev().assert(this.runner_)
+            .getPlayState() == WebAnimationPlayState.RUNNING);
   }
 
   /** Force-finishes all animations. */

--- a/extensions/amp-story/0.1/page-scaling.js
+++ b/extensions/amp-story/0.1/page-scaling.js
@@ -81,8 +81,8 @@ function targetDimensionsFor(sizer) {
 function scaleTransform(factor, width, height, matrix) {
   // TODO(alanorozco, #12934): Translate values are not correctly calculated if
   // `scale`, `skew` or `rotate` have been user-defined.
-  const translateX = width * factor / 2 - width / 2;
-  const translateY = height * factor / 2 - height / 2;
+  const translateX = ((width * factor) / 2) - (width / 2);
+  const translateY = ((height * factor) / 2) - (height / 2);
   return [
     matrix[0] * factor,
     matrix[1],

--- a/extensions/amp-story/0.1/utils.js
+++ b/extensions/amp-story/0.1/utils.js
@@ -158,7 +158,7 @@ export function getTextColorForRGB({r, g, b}) {
   const linearG = getLinearRGBValue(g);
   const linearB = getLinearRGBValue(b);
 
-  const L = 0.2126 * linearR + 0.7152 * linearG + 0.0722 * linearB;
+  const L = (0.2126 * linearR) + (0.7152 * linearG) + (0.0722 * linearB);
 
   // Determines which one of the white and black text have a better contrast
   // ratio against the used background color.

--- a/extensions/amp-story/1.0/amp-story-share.js
+++ b/extensions/amp-story/1.0/amp-story-share.js
@@ -318,8 +318,8 @@ export class ShareWidget {
     this.loadRequiredExtensions();
 
     this.requestService_.loadBookendConfig().then(config => {
-      const providers = config && config[SHARE_PROVIDERS_KEY] ||
-        config[DEPRECATED_SHARE_PROVIDERS_KEY];
+      const providers = config && (config[SHARE_PROVIDERS_KEY] ||
+        config[DEPRECATED_SHARE_PROVIDERS_KEY]);
       if (!providers) {
         return;
       }

--- a/extensions/amp-story/1.0/amp-story-share.js
+++ b/extensions/amp-story/1.0/amp-story-share.js
@@ -446,23 +446,24 @@ export class ScrollableShareWidget extends ShareWidget {
 
         // Total width that the buttons will occupy with minimum padding.
         const totalItemWidth =
-            (iconWidth * items.length + 2 * MIN_BUTTON_PADDING *
+            (iconWidth * items.length) + ((2 * MIN_BUTTON_PADDING) *
                 (items.length - 1));
 
         // If buttons don't fit within the available area, calculate padding so
         // that there will be an element cut-off.
-        if (totalItemWidth > (containerWidth - leftMargin * 2)) {
-          const availableWidth = containerWidth - leftMargin - iconWidth / 2;
+        if (totalItemWidth > (containerWidth - (leftMargin * 2))) {
+          const availableWidth = containerWidth - leftMargin - (iconWidth / 2);
           const amountVisible =
-              Math.floor(availableWidth / (iconWidth + MIN_BUTTON_PADDING * 2));
+              Math.floor(
+                  availableWidth / (iconWidth + (MIN_BUTTON_PADDING * 2)));
 
-          state.padding = 0.5 * (availableWidth / amountVisible - iconWidth);
+          state.padding = 0.5 * ((availableWidth / amountVisible) - iconWidth);
         } else {
           // Otherwise, calculate padding in from MIN_PADDING to DEFAULT_PADDING
           // so that all elements fit and take as much area as possible.
           const totalPadding =
-              ((containerWidth - leftMargin * 2) - iconWidth * items.length) /
-              (items.length - 1);
+              ((containerWidth - (leftMargin * 2)) -
+              (iconWidth * items.length)) / (items.length - 1);
 
           state.padding = Math.min(DEFAULT_BUTTON_PADDING, 0.5 * totalPadding);
         }

--- a/extensions/amp-story/1.0/animation.js
+++ b/extensions/amp-story/1.0/animation.js
@@ -241,8 +241,8 @@ class AnimationRunner {
   /** @return {boolean} */
   hasStarted() {
     return this.isActivityScheduled_(PlaybackActivity.START) ||
-        !!this.runner_ && dev().assert(this.runner_)
-            .getPlayState() == WebAnimationPlayState.RUNNING;
+        (!!this.runner_ && dev().assert(this.runner_)
+            .getPlayState() == WebAnimationPlayState.RUNNING);
   }
 
   /** Force-finishes all animations. */

--- a/extensions/amp-story/1.0/page-scaling.js
+++ b/extensions/amp-story/1.0/page-scaling.js
@@ -81,8 +81,8 @@ function targetDimensionsFor(sizer) {
 function scaleTransform(factor, width, height, matrix) {
   // TODO(alanorozco, #12934): Translate values are not correctly calculated if
   // `scale`, `skew` or `rotate` have been user-defined.
-  const translateX = width * factor / 2 - width / 2;
-  const translateY = height * factor / 2 - height / 2;
+  const translateX = ((width * factor) / 2) - (width / 2);
+  const translateY = ((height * factor) / 2) - (height / 2);
   return [
     matrix[0] * factor,
     matrix[1],

--- a/extensions/amp-story/1.0/utils.js
+++ b/extensions/amp-story/1.0/utils.js
@@ -157,7 +157,7 @@ export function getTextColorForRGB({r, g, b}) {
   const linearG = getLinearRGBValue(g);
   const linearB = getLinearRGBValue(b);
 
-  const L = 0.2126 * linearR + 0.7152 * linearG + 0.0722 * linearB;
+  const L = (0.2126 * linearR) + (0.7152 * linearG) + (0.0722 * linearB);
 
   // Determines which one of the white and black text have a better contrast
   // ratio against the used background color.


### PR DESCRIPTION
We were getting a "can't get property `share-providers` of null" error when no config is specified.

TIL

````
// Obvious:
false && (false || true) === false 

// Not obvious:
false && false || true === true
````