### PR TITLE
Fix Dev Channel link on the experiments page

### DIFF
--- a/tools/experiments/experiments.js
+++ b/tools/experiments/experiments.js
@@ -55,7 +55,7 @@ const EXPERIMENTS = [
     id: CANARY_EXPERIMENT_ID,
     name: 'AMP Dev Channel (more info)',
     spec: 'https://github.com/ampproject/amphtml/blob/master/' +
-        'README.md#amp-dev-channel',
+        'contributing/release-schedule.md#amp-dev-channel',
   },
   {
     id: 'alp',


### PR DESCRIPTION
Fixes the link on the experiments page to point to the correct Dev Channel documentation.