### PR TITLE
♿Change <amp-selector> to maintain existing `role` attributes.

### DIFF
--- a/extensions/amp-selector/0.1/amp-selector.js
+++ b/extensions/amp-selector/0.1/amp-selector.js
@@ -83,7 +83,9 @@ export class AmpSelector extends AMP.BaseElement {
     this.isMultiple_ = this.element.hasAttribute('multiple');
     this.isDisabled_ = this.element.hasAttribute('disabled');
 
-    this.element.setAttribute('role', 'listbox');
+    if (!this.element.hasAttribute('role')) {
+      this.element.setAttribute('role', 'listbox');
+    }
 
     if (this.isMultiple_) {
       this.element.setAttribute('aria-multiselectable', 'true');
@@ -225,7 +227,9 @@ export class AmpSelector extends AMP.BaseElement {
   init_() {
     const options = [].slice.call(this.element.querySelectorAll('[option]'));
     options.forEach(option => {
-      option.setAttribute('role', 'option');
+      if (!option.hasAttribute('role')) {
+        option.setAttribute('role', 'option');
+      }
       if (option.hasAttribute('disabled')) {
         option.setAttribute('aria-disabled', 'true');
       }
@@ -244,7 +248,7 @@ export class AmpSelector extends AMP.BaseElement {
   /**
    * Creates inputs for the currently selected elements and returns a string
    * array of their option values.
-   * @note Ignores elements that have `disabled` attribute set.
+   * Note: Ignores elements that have `disabled` attribute set.
    * @return {!Array<string>}
    * @private
    */
@@ -477,7 +481,7 @@ export class AmpSelector extends AMP.BaseElement {
 
   /**
    * Clears a given element from the list of selected options.
-   * @param {!Element} element.
+   * @param {!Element} element
    * @private
    */
   clearSelection_(element) {
@@ -504,7 +508,7 @@ export class AmpSelector extends AMP.BaseElement {
 
   /**
    * Marks a given element as selected and clears the others if required.
-   * @param {!Element} element.
+   * @param {!Element} element
    * @private
    */
   setSelection_(element) {

--- a/extensions/amp-selector/0.1/test/test-amp-selector.js
+++ b/extensions/amp-selector/0.1/test/test-amp-selector.js
@@ -35,11 +35,9 @@ describes.realWin('amp-selector', {
       const attributes = options.attributes || {};
       const ampSelector = win.document.createElement('amp-selector');
       ampSelector.setAttribute('layout', 'container');
-      if (attributes) {
-        Object.keys(attributes).forEach(key => {
-          ampSelector.setAttribute(key, attributes[key]);
-        });
-      }
+      Object.keys(attributes).forEach(key => {
+        ampSelector.setAttribute(key, attributes[key]);
+      });
 
       const config = options.config || {};
       let noOfSelectables = 3;
@@ -75,6 +73,12 @@ describes.realWin('amp-selector', {
             disabledCount--;
           }
         }
+
+        const optionAttributes = options.optionAttributes || {};
+        Object.keys(optionAttributes).forEach(key => {
+          img.setAttribute(key, optionAttributes[key]);
+        });
+
         ampSelector.appendChild(img);
       }
       win.document.body.appendChild(ampSelector);
@@ -130,6 +134,25 @@ describes.realWin('amp-selector', {
       yield ampSelector.build();
       expect(impl.isMultiple_).to.be.true;
       expect(initSpy).to.be.calledOnce;
+    });
+
+    it('should retain existing roles', function* () {
+      const ampSelector = getSelector({
+        attributes: {
+          role: 'tablist',
+        },
+        optionAttributes: {
+          role: 'tab',
+        },
+        config: {
+          count: 4,
+          selectedCount: 2,
+        },
+      });
+      const impl = ampSelector.implementation_;
+      yield ampSelector.build();
+      expect(impl.element.getAttribute('role')).to.equal('tablist');
+      expect(impl.options_[0].getAttribute('role')).to.equal('tab');
     });
 
     it('should init properly for single select', function* () {


### PR DESCRIPTION
This allows the consumer of `<amp-selector>` to use it as a tablist instead of
as a listbox.

Fixes #16000