### PR TITLE
🏗 Exempt classes from JSDoc requirements

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -147,7 +147,7 @@
       "require": {
         "FunctionDeclaration": true,
         "MethodDefinition": true,
-        "ClassDeclaration": true,
+        "ClassDeclaration": false,
         "ArrowFunctionExpression": false,
         "FunctionExpression": false
       }

--- a/.eslintrc-strict
+++ b/.eslintrc-strict
@@ -15,7 +15,7 @@
       "require": {
         "FunctionDeclaration": true,
         "MethodDefinition": true,
-        "ClassDeclaration": true,
+        "ClassDeclaration": false,
         "ArrowFunctionExpression": false,
         "FunctionExpression": false
       }


### PR DESCRIPTION
Addresses the issue mentioned in https://github.com/ampproject/amphtml/pull/15977#issuecomment-396753647

It turns out that Closure compiler doesn't really need classes to have JSDoc comments, it just needs methods and functions to have JSDoc comments with full type info.

Follow up to #15977

