### PR TITLE
🏗 Prevent the use of mixed operators

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -116,6 +116,7 @@
     "no-implied-eval": 2,
     "no-iterator": 2,
     "no-lone-blocks": 2,
+    "no-mixed-operators": 1,
     "no-multi-spaces": 2,
     "no-native-reassign": 2,
     "no-redeclare": 2,

--- a/.eslintrc-strict
+++ b/.eslintrc-strict
@@ -11,6 +11,7 @@
     "jsdoc/require-param-name": 2,
     "jsdoc/require-param-type": 2,
     "jsdoc/require-returns-type": 2,
+    "no-mixed-operators": 2,
     "require-jsdoc": [2, {
       "require": {
         "FunctionDeclaration": true,


### PR DESCRIPTION
Warning mode on `master`, error mode for PR checks.

Fixes #16002
