### PR TITLE
🏗 Add no-mixed-operators to eslint as warning

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -116,6 +116,7 @@
     "no-implied-eval": 2,
     "no-iterator": 2,
     "no-lone-blocks": 2,
+    "no-mixed-operators": 1,
     "no-multi-spaces": 2,
     "no-native-reassign": 2,
     "no-redeclare": 2,


### PR DESCRIPTION
There are 341 new warnings. I tried doing an automated refactor, but the tool I've been using (grasp) requires some more human oversight than I'm willing to give it at the moment.

For running `gulp lint` and finding which files have which mixed operators, I tried running (`grasp`)[http://www.graspjs.com/] using e.g., `grasp --context 2 --squery 'logic[op="||"][right.op="&&"]' --replace '{{.left}} || ({{.right}})' --in-place [list of .js files]`, but different mixed rules have different `squery` search strings and different replacement rules, and `grasp` messes with formatting, so really it means going through hundreds of files manually, which we can do later