### PR TITLE
🐛Change preconnect polyfill to work for non-Safari browsers on iOS.

### DIFF
--- a/src/preconnect.js
+++ b/src/preconnect.js
@@ -283,7 +283,8 @@ class PreconnectService {
     // Unfortunately there is no reliable way to feature detect whether
     // preconnect is supported, so we do this only in Safari, which is
     // the most important browser without support for it.
-    if (this.features_.preconnect || !this.platform_.isSafari()) {
+    if (this.features_.preconnect ||
+        !(this.platform_.isSafari() || this.platform_.isIos())) {
       return;
     }
 


### PR DESCRIPTION
These browsers are actually webviews, so they behave the same as Safari in terms of browser features.