### PR TITLE
Allowing multiline sharing option titles.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-share.css
+++ b/extensions/amp-story/1.0/amp-story-share.css
@@ -28,7 +28,6 @@
 
 .i-amphtml-story-share-widget-scrollable {
   padding: 16px 0 !important;
-  height: 66px !important;
   overflow: auto !important;
 }
 


### PR DESCRIPTION
Allowing multiline sharing option titles.
[Before](https://user-images.githubusercontent.com/1492044/41378251-819ed2a0-6f2c-11e8-95ff-2b2a106038dc.png) / [After](https://user-images.githubusercontent.com/1492044/41378255-85fe749a-6f2c-11e8-9498-88bc797e4743.png)




Fixes #15926