### PR TITLE
✨ Relax the iOS fixed-position transfer requirements

### DIFF
--- a/src/service/fixed-layer.js
+++ b/src/service/fixed-layer.js
@@ -346,20 +346,13 @@ export class FixedLayer {
             }
           }
 
-          // Transferability requires element to be fixed and top or bottom to
-          // be styled with `0`. Also, do not transfer transparent
-          // elements - that's a lot of work for no benefit.  Additionally,
-          // transparent elements used for "service" needs and thus
-          // best kept in the original tree. The visibility, however, is not
-          // considered because `visibility` CSS is inherited. Also, the
-          // `height` is constrained to at most 300px. This is to avoid
-          // transfering of more substantial sections for now. Likely to be
-          // relaxed in the future.
+          // Transferability requires element to be opaque (not 100%
+          // transparent) - that's a lot of work for no benefit. Additionally,
+          // transparent elements used for "service" needs and thus best kept
+          // in the original tree. The visibility, however, is not considered
+          // because `visibility` CSS is inherited.
           const isTransferrable = isFixed && (
-            fe.forceTransfer || (
-              opacity > 0 &&
-                  offsetHeight < 300 &&
-                  (this.isAllowedCoord_(top) || this.isAllowedCoord_(bottom))));
+            fe.forceTransfer || (opacity > 0 && !!(top || bottom)));
           if (isTransferrable) {
             hasTransferables = true;
           }
@@ -401,15 +394,6 @@ export class FixedLayer {
       // Fail silently.
       dev().error(TAG, 'Failed to mutate fixed elements:', error);
     });
-  }
-
-  /**
-   * We currently only allow elements with `top: 0` or `bottom: 0`.
-   * @param {string} s
-   * @return {boolean}
-   */
-  isAllowedCoord_(s) {
-    return (!!s && parseInt(s, 10) == 0);
   }
 
   /**

--- a/test/functional/test-fixed-layer.js
+++ b/test/functional/test-fixed-layer.js
@@ -1096,7 +1096,7 @@ describes.sandboxed('FixedLayer', {}, () => {
       expect(state['F4'].top).to.equal('0px');
     });
 
-    it('should collect turn off transferrable with top != 0', () => {
+    it('should collect turn on transferrable with top != 0', () => {
       element1.computedStyle['position'] = 'fixed';
       element1.offsetWidth = 10;
       element1.offsetHeight = 10;
@@ -1109,7 +1109,7 @@ describes.sandboxed('FixedLayer', {}, () => {
       vsyncTasks[0].measure(state);
 
       expect(state['F0'].fixed).to.be.true;
-      expect(state['F0'].transferrable).to.be.false;
+      expect(state['F0'].transferrable).to.be.true;
       expect(state['F0'].top).to.equal('2px');
 
       expect(state['F4'].sticky).to.be.true;
@@ -1162,7 +1162,7 @@ describes.sandboxed('FixedLayer', {}, () => {
       expect(state['F0'].transferrable).to.be.true;
     });
 
-    it('should collect turn off transferrable with bottom != 0', () => {
+    it('should collect turn on transferrable with bottom != 0', () => {
       element1.computedStyle['position'] = 'fixed';
       element1.offsetWidth = 10;
       element1.offsetHeight = 10;
@@ -1179,7 +1179,7 @@ describes.sandboxed('FixedLayer', {}, () => {
       vsyncTasks[0].measure(state);
 
       expect(state['F0'].fixed).to.be.true;
-      expect(state['F0'].transferrable).to.be.false;
+      expect(state['F0'].transferrable).to.be.true;
 
       expect(state['F4'].sticky).to.be.true;
       expect(state['F4'].transferrable).to.be.false;


### PR DESCRIPTION
Removes the max element height restriction, and allows any declared top or bottom to be transferred.

Fixes https://github.com/ampproject/amphtml/issues/15809.
Starts work on https://github.com/ampproject/amphtml/issues/14788.