### PR TITLE
🐛Change order of binding updating attributes / properties.

### DIFF
--- a/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
@@ -428,6 +428,14 @@ describe.configure().ifNewChrome().run('Bind', function() {
       });
     });
 
+    it('should update properties for empty strings', function* () {
+      const element = createElement(env, container, '[value]="foo"', 'input');
+      yield onBindReadyAndSetState(env, bind, {'foo': 'bar'});
+      expect(element.value).to.equal('bar');
+      yield onBindReadyAndSetState(env, bind, {'foo': ''});
+      expect(element.value).to.equal('');
+    });
+
     it('should support binding to Node.textContent', () => {
       const element = createElement(
           env, container, '[text]="\'a\' + \'b\' + \'c\'"');

--- a/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
@@ -413,6 +413,21 @@ describe.configure().ifNewChrome().run('Bind', function() {
       });
     });
 
+    it('should update values first, then attributes', () => {
+      const {sandbox} = env;
+      const spy = sandbox.spy();
+      const element = createElement(env, container, '[value]="foo"', 'input');
+      sandbox.stub(element, 'value').set(spy);
+      sandbox.stub(element, 'setAttribute').callsFake(spy);
+      return onBindReadyAndSetState(env, bind, {'foo': '2'}).then(() => {
+        // Note: This tests a workaround for a browser bug. There is nothing
+        // about the element itself we can verify. Only the order of operations
+        // matters.
+        expect(spy.firstCall).to.be.calledWithExactly('2');
+        expect(spy.secondCall).to.be.calledWithExactly('value', '2');
+      });
+    });
+
     it('should support binding to Node.textContent', () => {
       const element = createElement(
           env, container, '[text]="\'a\' + \'b\' + \'c\'"');

--- a/src/sanitizer.js
+++ b/src/sanitizer.js
@@ -376,6 +376,9 @@ function sanitizeWithCaja(html) {
   const output = [];
   let ignore = 0;
 
+  /**
+   * @param {string} content
+   */
   function emit(content) {
     if (ignore == 0) {
       output.push(content);
@@ -597,10 +600,11 @@ export function isValidAttr(tagName, attrName, attrValue, opt_purify = false) {
  * @param {string} attrName
  * @param {string} attrValue
  * @param {!Location=} opt_location
+ * @param {boolean=} opt_updateProperty
  * @return {string}
  */
 export function rewriteAttributesForElement(
-  element, attrName, attrValue, opt_location)
+  element, attrName, attrValue, opt_location, opt_updateProperty)
 {
   const tag = element.tagName.toLowerCase();
   const attr = attrName.toLowerCase();
@@ -624,6 +628,11 @@ export function rewriteAttributesForElement(
       // Restore the original value of `target` or default to `_top`.
       element.setAttribute('target', element[ORIGINAL_TARGET_VALUE] || '_top');
     }
+  }
+  if (opt_updateProperty) {
+    // Must be done first for <input> elements to correctly update the UI for
+    // the first change on Safari and Chrome.
+    element[attr] = rewrittenValue;
   }
   element.setAttribute(attr, rewrittenValue);
   return rewrittenValue;


### PR DESCRIPTION
When updating both an attribute and a property (e.g. for `<input>`), update the property first to workaround a Chrome/Safari bug.

- Also fixes bind not updating the associated property if the new bind value is an empty string.

https://bugs.chromium.org/p/chromium/issues/detail?id=852938

Fixes #15698
Fixed #14514
