### PR TITLE
📖 Adds command to avoid "the requested upstream branch 'upstream/master…

### DIFF
--- a/contributing/getting-started-e2e.md
+++ b/contributing/getting-started-e2e.md
@@ -151,6 +151,7 @@ Now run `git remote -v` again and notice that you have set up your upstream alia
 Each branch of your local Git repository can track a branch of a remote repository.  Right now, your local `master` branch is tracking `origin/master`, which corresponds to the `master` branch of your GitHub fork.  You don't actually want this, though; the upstream `master` branch is constantly being updated, and your fork's `master` branch will rapidly become outdated.  Instead, it's best to make your local `master` branch track the upstream `master` branch.  You can do this like so:
 
 ```
+git fetch upstream
 git branch -u upstream/master master
 ```
 

--- a/contributing/getting-started-e2e.md
+++ b/contributing/getting-started-e2e.md
@@ -151,7 +151,7 @@ Now run `git remote -v` again and notice that you have set up your upstream alia
 Each branch of your local Git repository can track a branch of a remote repository.  Right now, your local `master` branch is tracking `origin/master`, which corresponds to the `master` branch of your GitHub fork.  You don't actually want this, though; the upstream `master` branch is constantly being updated, and your fork's `master` branch will rapidly become outdated.  Instead, it's best to make your local `master` branch track the upstream `master` branch.  You can do this like so:
 
 ```
-git fetch upstream
+git fetch upstream master
 git branch -u upstream/master master
 ```
 


### PR DESCRIPTION
-Explicitly tells people to run git fetch upstream so they don't run into an error when running "git branch -u upstream/master master"