### PR TITLE
✅Fix slidescroll tests.

### DIFF
--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -504,7 +504,7 @@ export class AmpSlideScroll extends BaseSlides {
     const index = parseInt(value, 10);
 
     if (!isFinite(index) || index < 0 || index >= this.noOfSlides_) {
-      this.user().error(TAG, 'Invalid [slide] value: %s', value);
+      this.user().error(TAG, 'Invalid [slide] value: ', value);
       return;
     }
 

--- a/extensions/amp-carousel/0.1/test/test-slidescroll.js
+++ b/extensions/amp-carousel/0.1/test/test-slidescroll.js
@@ -926,6 +926,8 @@ describes.realWin('SlideScroll', {
 
     it('should update slide when `slide` attribute is mutated', () => {
       return getAmpSlideScroll(true).then(ampSlideScroll => {
+        expectAsyncConsoleError(/Invalid \[slide\] value:/, 1);
+
         const impl = ampSlideScroll.implementation_;
         const showSlideSpy = sandbox.spy(impl, 'showSlide_');
 
@@ -963,6 +965,8 @@ describes.realWin('SlideScroll', {
 
     it('should goToSlide on action', () => {
       return getAmpSlideScroll(true).then(ampSlideScroll => {
+        expectAsyncConsoleError(/Invalid \[slide\] value:/, 4);
+
         const impl = ampSlideScroll.implementation_;
         const showSlideSpy = sandbox.spy(impl, 'showSlide_');
         const satisfiesTrust = () => true;


### PR DESCRIPTION
- Fix error message for invalid slide index having a %s where it should not.
- Fix tests by adding allowConsoleError when calling a function that reports a console error.
