### PR TITLE
Doc improvement for support resources

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -9,7 +9,7 @@ If you are looking for help to get started using AMP on your site or you are hav
 *   [ampproject.org](https://www.ampproject.org/docs) provides guides and tutorials to help you learn about AMP.
 *   [AMP by Example](https://ampbyexample.com/) provides hands-on samples and demos for using AMP components.
 *   [AMP Start](https://ampstart.com/) provides pre-styled templates and components that you can use to create styled AMP sites from scratch.
-*   [Stack Overflow](http://stackoverflow.com/questions/tagged/amp-html) is our recommended way to find answers to questions about AMP; since members of the AMP Project community regularly monitor Stack Overflow you will probably receive the fastest response to your questions there. If you can't find answers there, the [#using-amp](https://amphtml.slack.com/messages/C9HPA6HGB/details/) Slack channel is available for discussions and questions.  
+*   [Stack Overflow](http://stackoverflow.com/questions/tagged/amp-html) is our recommended way to find answers to questions about AMP; since members of the AMP Project community regularly monitor Stack Overflow you will probably receive the fastest response to your questions there. If you can't find answers there, the [#using-amp](https://amphtml.slack.com/messages/C9HPA6HGB/details/) Slack channel<a href="#note1"><sup>[1]</sup></a> is available for discussions and questions.  
 *   For AMP on Google Search questions or issues, please use [Google's AMP forum](https://goo.gl/utQ1KZ).
 *   To check the status of AMP serving and its related services, see the [AMP Status](https://status.ampproject.org/) page.
 
@@ -20,4 +20,9 @@ If you encounter a bug in AMP or have a feature request for AMP, see [Reporting 
 **Contributing to AMP?**
 
 *   Read [Contributing to AMP HTML](https://github.com/ampproject/amphtml/blob/master/CONTRIBUTING.md#ongoing-participation), which provides details on ways you can contribute to the AMP Project.
-*   For questions and discussions about about *contributing to the open source project*, reach out to the [#contributing](https://amphtml.slack.com/messages/C9HRJ1GPN/details/) Slack channel.
+*   For questions and discussions about about *contributing to the open source project*, reach out to the [#contributing](https://amphtml.slack.com/messages/C9HRJ1GPN/details/) Slack channel<a href="#note1"><sup>[1]</sup></a> .
+
+
+
+
+<span id="note1"><sup>[1]</sup></span>To access our AMP Slack channels, you must first [sign up](https://bit.ly/amp-slack-signup).

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -2,12 +2,22 @@
 
 There are many ways to get help for questions and issues related to AMP:
 
-- If you are looking for help **getting started using AMP on your site** or are **having issues using AMP**:
-    - The [ampproject.org FAQ](https://www.ampproject.org/support/faqs/) provides answers to common questions about AMP.
-    - [Stack Overflow](http://stackoverflow.com/questions/tagged/amp-html) is our recommended way to find answers to questions about AMP; since members of the AMP Project community regularly monitor Stack Overflow you will probably receive the fastest response to your questions there.
-    - [AMP by Example](https://ampbyexample.com) provides hands-on samples and demos for using AMP components.
-    - [AMP Start](https://ampstart.com) provides pre-styled templates and components that you can use to create styled AMP sites from scratch.
-- If you **encounter a bug in AMP or have a feature request for AMP**, see [Reporting issues with AMP](CONTRIBUTING.md#reporting-issues-with-amp) for information on filing an issue.
-- For **AMP on Google Search** questions or issues, please use [Google's AMP forum](https://goo.gl/utQ1KZ).
-- If you are **contributing code to the AMP Project**, the ["Contributing code" section of CONTRIBUTING.md](CONTRIBUTING.md#contributing-code) provides ways to get help.
-- To check the status of AMP serving and its related services, see the [AMP Status](https://status.ampproject.org/) page.
+**Need help with AMP?**
+
+If you are looking for help to get started using AMP on your site or you are having issues using AMP, consult these resources:
+
+*   [ampproject.org](https://www.ampproject.org/docs) provides guides and tutorials to help you learn about AMP.
+*   [AMP by Example](https://ampbyexample.com/) provides hands-on samples and demos for using AMP components.
+*   [AMP Start](https://ampstart.com/) provides pre-styled templates and components that you can use to create styled AMP sites from scratch.
+*   [Stack Overflow](http://stackoverflow.com/questions/tagged/amp-html) is our recommended way to find answers to questions about AMP; since members of the AMP Project community regularly monitor Stack Overflow you will probably receive the fastest response to your questions there. If you can't find answers there, the [#using-amp](https://amphtml.slack.com/messages/C9HPA6HGB/details/) Slack channel is available for discussions and questions.  
+*   For AMP on Google Search questions or issues, please use [Google's AMP forum](https://goo.gl/utQ1KZ).
+*   To check the status of AMP serving and its related services, see the [AMP Status](https://status.ampproject.org/) page.
+
+**Found a bug? Suggest a feature?**
+
+If you encounter a bug in AMP or have a feature request for AMP, see [Reporting issues with AMP](https://github.com/ampproject/amphtml/blob/master/CONTRIBUTING.md#reporting-issues-with-amp) for information on filing an issue or requesting features.
+
+**Contributing to AMP?**
+
+*   Read [Contributing to AMP HTML](https://github.com/ampproject/amphtml/blob/master/CONTRIBUTING.md#ongoing-participation), which provides details on ways you can contribute to the AMP Project.
+*   For questions and discussions about about *contributing to the open source project*, reach out to the [#contributing](https://amphtml.slack.com/messages/C9HRJ1GPN/details/) Slack channel.


### PR DESCRIPTION
Making support.md the canonical resource for documented support channels and resources.

- Improved formatting with grouped titles
- Revising what to look at on ampproject.org
- Adding slack channels for contributing and using-amp