### PR TITLE
Doubleclick Fast Fetch SRA Experiment fix race condition and add no recover branch

### DIFF
--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -169,7 +169,7 @@ export function combineInventoryUnits(instances) {
   });
   return {
     'iu_parts': Object.keys(uniqueIuNames).sort((a, b) =>
-      uniqueIuNames[a] - uniqueIuNames[b] > 0).join(),
+      uniqueIuNames[a] - uniqueIuNames[b]).join(),
     'enc_prev_ius': prevIusEncoded.join(),
   };
 }

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -111,6 +111,7 @@ const DOUBLECLICK_EXPERIMENT_FEATURE = {
   DELAYED_REQUEST: '21060729',
   SRA_CONTROL: '117152666',
   SRA: '117152667',
+  SRA_NO_RECOVER: '21062235',
 };
 
 /**
@@ -141,6 +142,38 @@ let windowLocationQueryParameters;
  */
 let LayoutRectOrDimsDef;
 
+/**
+ * @param {!Array<AmpAdNetworkDoubleclickImpl>} instances
+ * @return {?Object<string,string>}
+ * @visibleForTesting
+ */
+export function combineInventoryUnits(instances) {
+  const uniqueIuNames = {};
+  let uniqueIuNamesCount = 0;
+  const prevIusEncoded = [];
+  instances.forEach(instance => {
+    const iu = dev().assert(instance.element.getAttribute('data-slot'));
+    const componentNames = (iu || '').split('/');
+    const encodedNames = [];
+    for (let i = 0; i < componentNames.length; i++) {
+      if (componentNames[i] == '') {
+        continue;
+      }
+      let index = uniqueIuNames[componentNames[i]];
+      if (index == undefined) {
+        uniqueIuNames[componentNames[i]] = (index = uniqueIuNamesCount++);
+      }
+      encodedNames.push(index);
+    }
+    prevIusEncoded.push(encodedNames.join('/'));
+  });
+  return {
+    'iu_parts': Object.keys(uniqueIuNames).sort((a, b) =>
+      uniqueIuNames[a] - uniqueIuNames[b] > 0).join(),
+    'enc_prev_ius': prevIusEncoded.join(),
+  };
+}
+
 /* eslint-disable jsdoc/require-param */
 /**
  * Array of functions used to combine block level request parameters for SRA
@@ -148,31 +181,7 @@ let LayoutRectOrDimsDef;
  * @private @const {!Array<!function(!Array<AmpAdNetworkDoubleclickImpl>):?Object<string,string>>}
  */
 const BLOCK_SRA_COMBINERS_ = [
-  instances => {
-    const uniqueIuNames = {};
-    let uniqueIuNamesCount = 0;
-    const prevIusEncoded = [];
-    instances.forEach(instance => {
-      const iu = dev().assert(instance.element.getAttribute('data-slot'));
-      const componentNames = (iu || '').split('/');
-      const encodedNames = [];
-      for (let i = 0; i < componentNames.length; i++) {
-        if (componentNames[i] == '') {
-          continue;
-        }
-        let index = uniqueIuNames[componentNames[i]];
-        if (index == undefined) {
-          uniqueIuNames[componentNames[i]] = (index = uniqueIuNamesCount++);
-        }
-        encodedNames.push(index);
-      }
-      prevIusEncoded.push(encodedNames.join('/'));
-    });
-    return {
-      'iu_parts': Object.keys(uniqueIuNames).join(),
-      'enc_prev_ius': prevIusEncoded.join(),
-    };
-  },
+  combineInventoryUnits,
   // Although declared at a block-level, this is actually page level so
   // return true if ANY indicate cookie opt out.
   instances => getFirstInstanceValue_(instances, instance => {
@@ -200,12 +209,12 @@ const BLOCK_SRA_COMBINERS_ = [
   instances => {
     const scps = [];
     instances.forEach(instance => {
-      if (!instance.jsonTargeting_) {
-        return;
+      if (instance.jsonTargeting_ && instance.jsonTargeting_['targeting'] &&
+        instance.jsonTargeting_['categoryExclusions']) {
+        scps.push(serializeTargeting_(
+            instance.jsonTargeting_['targeting'] || null,
+            instance.jsonTargeting_['categoryExclusions'] || null));
       }
-      scps.push(serializeTargeting_(
-          instance.jsonTargeting_['targeting'] || null,
-          instance.jsonTargeting_['categoryExclusions'] || null));
     });
     return scps.length ? {'prev_scp': scps.join('|')} : null;
   },
@@ -353,6 +362,9 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
 
     /** @protected {?CONSENT_POLICY_STATE} */
     this.consentState = null;
+
+    /** @protected {!Deferred<string>} */
+    this.getAdUrlDeferred = new Deferred();
   }
 
   /** @override */
@@ -412,12 +424,14 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
       // SRA
       '7': DOUBLECLICK_EXPERIMENT_FEATURE.SRA_CONTROL,
       '8': DOUBLECLICK_EXPERIMENT_FEATURE.SRA,
+      '9': DOUBLECLICK_EXPERIMENT_FEATURE.SRA_NO_RECOVER,
     }[urlExperimentId];
     switch (experimentId) {
       case undefined:
         break;
       case DOUBLECLICK_EXPERIMENT_FEATURE.SRA_CONTROL:
       case DOUBLECLICK_EXPERIMENT_FEATURE.SRA:
+      case DOUBLECLICK_EXPERIMENT_FEATURE.SRA_NO_RECOVER:
         // For SRA experiments, do not include pages that are using refresh.
         if (this.win.document./*OK*/querySelector(
             'meta[name=amp-ad-enable-refresh], ' +
@@ -462,7 +476,9 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
         this.win.location.search)) ||
         !!this.win.document.querySelector(
             'meta[name=amp-ad-doubleclick-sra]') ||
-        this.experimentIds.includes(DOUBLECLICK_EXPERIMENT_FEATURE.SRA);
+        !!this.experimentIds.filter(exp =>
+          exp == DOUBLECLICK_EXPERIMENT_FEATURE.SRA ||
+          exp == DOUBLECLICK_EXPERIMENT_FEATURE.SRA_NO_RECOVER).length;
     this.identityTokenPromise_ = Services.viewerForDoc(this.getAmpDoc())
         .whenFirstVisible()
         .then(() => getIdentityToken(this.win, this.getAmpDoc()));
@@ -611,19 +627,20 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
           // On error/timeout, proceed.
           return /**@type {!../../../ads/google/a4a/utils.IdentityToken}*/({});
         });
-    const urlPromise = Promise.all([opt_rtcResponsesPromise, identityPromise])
+    Promise.all([opt_rtcResponsesPromise, identityPromise])
         .then(results => {
           this.verifyStillCurrent();
           const rtcParams = this.mergeRtcResponses_(results[0]);
           this.identityToken = results[1];
-          return googleAdUrl(
+          googleAdUrl(
               this, DOUBLECLICK_BASE_URL, startTime, Object.assign(
                   this.getBlockParameters_(), this.buildIdentityParams_(),
                   this.getPageParameters(consentState), rtcParams),
-              this.experimentIds);
+              this.experimentIds)
+              .then(adUrl => this.getAdUrlDeferred.resolve(adUrl));
         });
-    this.troubleshootData_.adUrl = urlPromise;
-    return urlPromise;
+    this.troubleshootData_.adUrl = this.getAdUrlDeferred.promise;
+    return this.getAdUrlDeferred.promise;
   }
 
   /**
@@ -854,6 +871,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     this.sraDeferred = new Deferred();
     this.qqid_ = null;
     this.consentState = null;
+    this.getAdUrlDeferred = new Deferred();
   }
 
   /** @override */
@@ -1147,7 +1165,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
                 return;
               }
               // Construct and send SRA request.
-              // Chunk hanlder called with metadata and creative for each slot
+              // Chunk handler called with metadata and creative for each slot
               // in order of URLs given.  Construct promise for each slot
               // such that its resolver will be called.
               const sraRequestAdUrlResolvers =
@@ -1229,7 +1247,9 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
                       typeInstances.forEach(instance =>
                         instance.sraDeferred.reject(error));
                     } else if (!!this.win.document.querySelector(
-                        'meta[name=amp-ad-doubleclick-sra]')) {
+                        'meta[name=amp-ad-doubleclick-sra]') ||
+                        this.experimentIds.includes(
+                            DOUBLECLICK_EXPERIMENT_FEATURE.SRA_NO_RECOVER)) {
                       assignAdUrlToError(/** @type {!Error} */(error), sraUrl);
                       this.warnOnError('SRA request failure', error);
                       // Publisher explicitly wants SRA so do not attempt to
@@ -1390,7 +1410,9 @@ function constructSRARequest_(a4a, instances) {
   // TODO(bradfrizzell): Need to add support for RTC.
   dev().assert(instances && instances.length);
   const startTime = Date.now();
-  return googlePageParameters(a4a, startTime)
+  return Promise.all(
+      instances.map(instance => instance.getAdUrlDeferred.promise))
+      .then(() => googlePageParameters(a4a, startTime))
       .then(googPageLevelParameters => {
         const blockParameters = constructSRABlockParameters(instances);
         return truncAndTimeUrl(DOUBLECLICK_BASE_URL,

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -629,10 +629,13 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
       // Reset counter for purpose of this test.
       delete env.win['ampAdGoogleIfiCounter'];
       new AmpAd(element).upgradeCallback();
+      sandbox.stub(AmpA4A.prototype, 'tearDownSlot').callsFake(() => {});
       return impl.getAdUrl().then(url1 => {
         expect(url1).to.match(/ifi=1/);
+        impl.tearDownSlot();
         return impl.getAdUrl().then(url2 => {
           expect(url2).to.match(/ifi=2/);
+          impl.tearDownSlot();
           return impl.getAdUrl().then(url3 => {
             expect(url3).to.match(/ifi=3/);
           });

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-sra.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-sra.js
@@ -24,6 +24,7 @@ import {
 import {
   AmpAdNetworkDoubleclickImpl,
   TFCD,
+  combineInventoryUnits,
   constructSRABlockParameters,
   getNetworkId,
   resetSraStateForTesting,
@@ -479,4 +480,23 @@ describes.realWin('Doubleclick SRA', config , env => {
           {networkId: 8901, instances: 3, invalidInstances: 1}]));
   });
 
+  describe('#combineInventoryUnits', () => {
+    it('should sort by index correctly for iu_parts', () => {
+      const instances = [];
+      for (let i = 0; i < 2; i++) {
+        instances.push({
+          element: {
+            getAttribute: name => {
+              expect(name).to.equal('data-slot');
+              return '/1234/foo.com/news/world/2018/06/17/article';
+            },
+          },
+        });
+      }
+      expect(combineInventoryUnits(instances)).to.jsonEqual({
+        'iu_parts': '1234,foo.com,news,world,2018,06,17,article',
+        'enc_prev_ius': '0/1/2/3/4/5/6/7,0/1/2/3/4/5/6/7',
+      });
+    });
+  });
 });


### PR DESCRIPTION
Fix race condition with Doubleclick Fast Fetch SRA not explicitly waiting on getAdUrl results prior to building SRA ad request.  Add experiment branch that does not attempt to recover from SRA failure by sending non-SRA requests.