### PR TITLE
Pause the story when the share menu or the info dialog are displayed.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-store-service.js
+++ b/extensions/amp-story/1.0/amp-story-store-service.js
@@ -121,7 +121,10 @@ const actions = (state, action, data) => {
     // Shows or hides the info dialog.
     case Action.TOGGLE_INFO_DIALOG:
       return /** @type {!State} */ (Object.assign(
-          {}, state, {[StateProperty.INFO_DIALOG_STATE]: !!data}));
+          {}, state, {
+            [StateProperty.INFO_DIALOG_STATE]: !!data,
+            [StateProperty.PAUSED_STATE]: !!data,
+          }));
     // Shows or hides the audio controls.
     case Action.TOGGLE_HAS_AUDIO:
       return /** @type {!State} */ (Object.assign(
@@ -141,7 +144,10 @@ const actions = (state, action, data) => {
           {}, state, {[StateProperty.SUPPORTED_BROWSER_STATE]: !!data}));
     case Action.TOGGLE_SHARE_MENU:
       return /** @type {!State} */ (Object.assign(
-          {}, state, {[StateProperty.SHARE_MENU_STATE]: !!data}));
+          {}, state, {
+            [StateProperty.PAUSED_STATE]: !!data,
+            [StateProperty.SHARE_MENU_STATE]: !!data,
+          }));
     case Action.SET_CONSENT_ID:
       return /** @type {!State} */ (Object.assign(
           {}, state, {[StateProperty.CONSENT_ID]: data}));

--- a/extensions/amp-story/1.0/test/test-amp-story-store-service.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-store-service.js
@@ -162,4 +162,40 @@ describes.fakeWin('amp-story-store-service actions', {}, env => {
     expect(listenerSpy).to.have.been.calledOnce;
     expect(listenerSpy).to.have.been.calledWith(false);
   });
+
+  it('should pause the story when displaying the share menu', () => {
+    const pausedListenerSpy = sandbox.spy();
+    storeService.subscribe(StateProperty.PAUSED_STATE, pausedListenerSpy);
+    storeService.dispatch(Action.TOGGLE_SHARE_MENU, true);
+    expect(pausedListenerSpy).to.have.been.calledOnce;
+    expect(pausedListenerSpy).to.have.been.calledWith(true);
+  });
+
+  it('should unpause the story when hiding the share menu', () => {
+    storeService.dispatch(Action.TOGGLE_SHARE_MENU, true);
+
+    const pausedListenerSpy = sandbox.spy();
+    storeService.subscribe(StateProperty.PAUSED_STATE, pausedListenerSpy);
+    storeService.dispatch(Action.TOGGLE_SHARE_MENU, false);
+    expect(pausedListenerSpy).to.have.been.calledOnce;
+    expect(pausedListenerSpy).to.have.been.calledWith(false);
+  });
+
+  it('should pause the story when displaying the info dialog', () => {
+    const pausedListenerSpy = sandbox.spy();
+    storeService.subscribe(StateProperty.PAUSED_STATE, pausedListenerSpy);
+    storeService.dispatch(Action.TOGGLE_INFO_DIALOG, true);
+    expect(pausedListenerSpy).to.have.been.calledOnce;
+    expect(pausedListenerSpy).to.have.been.calledWith(true);
+  });
+
+  it('should unpause the story when hiding the info dialog', () => {
+    storeService.dispatch(Action.TOGGLE_INFO_DIALOG, true);
+
+    const pausedListenerSpy = sandbox.spy();
+    storeService.subscribe(StateProperty.PAUSED_STATE, pausedListenerSpy);
+    storeService.dispatch(Action.TOGGLE_INFO_DIALOG, false);
+    expect(pausedListenerSpy).to.have.been.calledOnce;
+    expect(pausedListenerSpy).to.have.been.calledWith(false);
+  });
 });


### PR DESCRIPTION
Pause the story when the share menu or the info dialog are displayed, to prevent from auto advancing in the background.