### PR TITLE
Use performance.now over Date.now in performance metrics

### DIFF
--- a/extensions/amp-access/0.1/amp-access-source.js
+++ b/extensions/amp-access/0.1/amp-access-source.js
@@ -353,10 +353,9 @@ export class AccessSource {
   /**
    * Returns the promise that resolves when authorization call has completed.
    * Note that this promise never fails.
-   * @param {boolean=} opt_disableFallback
    * @return {!Promise}
    */
-  runAuthorization(opt_disableFallback) {
+  runAuthorization() {
     if (!this.adapter_.isAuthorizationEnabled()) {
       dev().fine(TAG, 'Ignore authorization for type=', this.type_);
       this.firstAuthorizationResolver_();

--- a/extensions/amp-access/0.1/amp-access-source.js
+++ b/extensions/amp-access/0.1/amp-access-source.js
@@ -353,9 +353,10 @@ export class AccessSource {
   /**
    * Returns the promise that resolves when authorization call has completed.
    * Note that this promise never fails.
+   * @param {boolean=} opt_disableFallback
    * @return {!Promise}
    */
-  runAuthorization() {
+  runAuthorization(opt_disableFallback) {
     if (!this.adapter_.isAuthorizationEnabled()) {
       dev().fine(TAG, 'Ignore authorization for type=', this.type_);
       this.firstAuthorizationResolver_();

--- a/extensions/amp-access/0.1/amp-access.js
+++ b/extensions/amp-access/0.1/amp-access.js
@@ -336,11 +336,10 @@ export class AccessService {
    * Returns the promise that resolves when all authorization work has
    * completed, including authorization endpoint call and UI update.
    * Note that this promise never fails.
-   * @param {boolean=} opt_disableFallback
    * @return {!Promise}
    * @private
    */
-  runAuthorization_(opt_disableFallback) {
+  runAuthorization_() {
     this.toggleTopClass_('amp-access-loading', true);
 
     const authorizations = this.viewer_.whenFirstVisible().then(() => {

--- a/extensions/amp-access/0.1/test/test-amp-access.js
+++ b/extensions/amp-access/0.1/test/test-amp-access.js
@@ -26,7 +26,7 @@ import {installPerformanceService} from
 import {toggleExperiment} from '../../../../src/experiments';
 
 
-describes.realWin('AccessService', {
+describes.fakeWin('AccessService', {
   amp: true,
   location: 'https://pub.com/doc1',
 }, env => {
@@ -38,7 +38,9 @@ describes.realWin('AccessService', {
     win = env.win;
     ampdoc = env.ampdoc;
     document = win.document;
-
+    // Polyfill performance.now() method as it is not available in fakeWin
+    // environment.
+    win.performance = {now: () => Date.now()};
     cidServiceForDocForTesting(ampdoc);
     installPerformanceService(win);
 
@@ -241,7 +243,7 @@ describes.realWin('AccessService', {
 });
 
 
-describes.realWin('AccessService authorization', {
+describes.fakeWin('AccessService authorization', {
   amp: true,
   location: 'https://pub.com/doc1',
 }, env => {
@@ -259,7 +261,9 @@ describes.realWin('AccessService authorization', {
     document = win.document;
     clock = sandbox.useFakeTimers();
     clock.tick(0);
-
+    // Polyfill performance.now() method as it is not available in fakeWin
+    // environment.
+    win.performance = {now: () => Date.now()};
     cidServiceForDocForTesting(ampdoc);
     installPerformanceService(win);
 
@@ -492,7 +496,7 @@ describes.realWin('AccessService authorization', {
 });
 
 
-describes.realWin('AccessService applyAuthorizationToElement_', {
+describes.fakeWin('AccessService applyAuthorizationToElement_', {
   amp: true,
   location: 'https://pub.com/doc1',
 }, env => {
@@ -506,7 +510,9 @@ describes.realWin('AccessService applyAuthorizationToElement_', {
     win = env.win;
     ampdoc = env.ampdoc;
     document = win.document;
-
+    // Polyfill performance.now() method as it is not available in fakeWin
+    // environment.
+    win.performance = {now: () => Date.now()};
     cidServiceForDocForTesting(ampdoc);
     installPerformanceService(win);
 
@@ -637,7 +643,7 @@ describes.realWin('AccessService applyAuthorizationToElement_', {
 });
 
 
-describes.realWin('AccessService pingback', {
+describes.fakeWin('AccessService pingback', {
   amp: true,
   location: 'https://pub.com/doc1',
 }, env => {
@@ -655,7 +661,9 @@ describes.realWin('AccessService pingback', {
     ampdoc = env.ampdoc;
     document = win.document;
     clock = sandbox.useFakeTimers();
-
+    // Polyfill performance.now() method as it is not available in fakeWin
+    // environment.
+    win.performance = {now: () => Date.now()};
     cidServiceForDocForTesting(ampdoc);
     installPerformanceService(win);
 
@@ -953,7 +961,7 @@ describes.realWin('AccessService pingback', {
 });
 
 
-describes.realWin('AccessService login', {
+describes.fakeWin('AccessService login', {
   amp: true,
   location: 'https://pub.com/doc1',
 }, env => {
@@ -970,7 +978,9 @@ describes.realWin('AccessService login', {
     ampdoc = env.ampdoc;
     document = win.document;
     clock = sandbox.useFakeTimers();
-
+    // Polyfill performance.now() method as it is not available in fakeWin
+    // environment.
+    win.performance = {now: () => Date.now()};
     cidServiceForDocForTesting(ampdoc);
     installPerformanceService(win);
 
@@ -1328,7 +1338,7 @@ describes.realWin('AccessService login', {
 });
 
 
-describes.realWin('AccessService analytics', {
+describes.fakeWin('AccessService analytics', {
   amp: true,
   location: 'https://pub.com/doc1',
 }, env => {
@@ -1340,7 +1350,9 @@ describes.realWin('AccessService analytics', {
     win = env.win;
     ampdoc = env.ampdoc;
     document = win.document;
-
+    // Polyfill performance.now() method as it is not available in fakeWin
+    // environment.
+    win.performance = {now: () => Date.now()};
     cidServiceForDocForTesting(ampdoc);
     installPerformanceService(win);
 
@@ -1439,7 +1451,7 @@ describes.realWin('AccessService analytics', {
 });
 
 
-describes.realWin('AccessService multiple sources', {
+describes.fakeWin('AccessService multiple sources', {
   amp: true,
   location: 'https://pub.com/doc1',
 }, env => {
@@ -1458,7 +1470,9 @@ describes.realWin('AccessService multiple sources', {
     document = win.document;
     clock = sandbox.useFakeTimers();
     clock.tick(0);
-
+    // Polyfill performance.now() method as it is not available in fakeWin
+    // environment.
+    win.performance = {now: () => Date.now()};
     cidServiceForDocForTesting(ampdoc);
     installPerformanceService(win);
 

--- a/extensions/amp-access/0.1/test/test-amp-access.js
+++ b/extensions/amp-access/0.1/test/test-amp-access.js
@@ -38,9 +38,7 @@ describes.fakeWin('AccessService', {
     win = env.win;
     ampdoc = env.ampdoc;
     document = win.document;
-    // Polyfill performance.now() method as it is not available in fakeWin
-    // environment.
-    win.performance = {now: () => Date.now()};
+
     cidServiceForDocForTesting(ampdoc);
     installPerformanceService(win);
 
@@ -261,9 +259,7 @@ describes.fakeWin('AccessService authorization', {
     document = win.document;
     clock = sandbox.useFakeTimers();
     clock.tick(0);
-    // Polyfill performance.now() method as it is not available in fakeWin
-    // environment.
-    win.performance = {now: () => Date.now()};
+
     cidServiceForDocForTesting(ampdoc);
     installPerformanceService(win);
 
@@ -659,9 +655,7 @@ describes.fakeWin('AccessService pingback', {
     ampdoc = env.ampdoc;
     document = win.document;
     clock = sandbox.useFakeTimers();
-    // Polyfill performance.now() method as it is not available in fakeWin
-    // environment.
-    win.performance = {now: () => Date.now()};
+
     cidServiceForDocForTesting(ampdoc);
     installPerformanceService(win);
 
@@ -976,9 +970,7 @@ describes.fakeWin('AccessService login', {
     ampdoc = env.ampdoc;
     document = win.document;
     clock = sandbox.useFakeTimers();
-    // Polyfill performance.now() method as it is not available in fakeWin
-    // environment.
-    win.performance = {now: () => Date.now()};
+
     cidServiceForDocForTesting(ampdoc);
     installPerformanceService(win);
 
@@ -1348,9 +1340,7 @@ describes.fakeWin('AccessService analytics', {
     win = env.win;
     ampdoc = env.ampdoc;
     document = win.document;
-    // Polyfill performance.now() method as it is not available in fakeWin
-    // environment.
-    win.performance = {now: () => Date.now()};
+
     cidServiceForDocForTesting(ampdoc);
     installPerformanceService(win);
 
@@ -1468,9 +1458,7 @@ describes.fakeWin('AccessService multiple sources', {
     document = win.document;
     clock = sandbox.useFakeTimers();
     clock.tick(0);
-    // Polyfill performance.now() method as it is not available in fakeWin
-    // environment.
-    win.performance = {now: () => Date.now()};
+
     cidServiceForDocForTesting(ampdoc);
     installPerformanceService(win);
 

--- a/extensions/amp-access/0.1/test/test-amp-access.js
+++ b/extensions/amp-access/0.1/test/test-amp-access.js
@@ -510,9 +510,7 @@ describes.fakeWin('AccessService applyAuthorizationToElement_', {
     win = env.win;
     ampdoc = env.ampdoc;
     document = win.document;
-    // Polyfill performance.now() method as it is not available in fakeWin
-    // environment.
-    win.performance = {now: () => Date.now()};
+
     cidServiceForDocForTesting(ampdoc);
     installPerformanceService(win);
 

--- a/extensions/amp-access/0.1/test/test-amp-access.js
+++ b/extensions/amp-access/0.1/test/test-amp-access.js
@@ -26,7 +26,7 @@ import {installPerformanceService} from
 import {toggleExperiment} from '../../../../src/experiments';
 
 
-describes.fakeWin('AccessService', {
+describes.realWin('AccessService', {
   amp: true,
   location: 'https://pub.com/doc1',
 }, env => {
@@ -158,7 +158,6 @@ describes.fakeWin('AccessService', {
     });
     const service = new AccessService(ampdoc);
     expect(service.pubOrigin_).to.exist;
-    expect(service.pubOrigin_).to.match(/^http.*/);
   });
 
   it('should find and register vendor', () => {
@@ -242,7 +241,7 @@ describes.fakeWin('AccessService', {
 });
 
 
-describes.fakeWin('AccessService authorization', {
+describes.realWin('AccessService authorization', {
   amp: true,
   location: 'https://pub.com/doc1',
 }, env => {
@@ -527,7 +526,7 @@ describes.fakeWin('AccessService authorization', {
 });
 
 
-describes.fakeWin('AccessService applyAuthorizationToElement_', {
+describes.realWin('AccessService applyAuthorizationToElement_', {
   amp: true,
   location: 'https://pub.com/doc1',
 }, env => {
@@ -672,7 +671,7 @@ describes.fakeWin('AccessService applyAuthorizationToElement_', {
 });
 
 
-describes.fakeWin('AccessService pingback', {
+describes.realWin('AccessService pingback', {
   amp: true,
   location: 'https://pub.com/doc1',
 }, env => {
@@ -988,7 +987,7 @@ describes.fakeWin('AccessService pingback', {
 });
 
 
-describes.fakeWin('AccessService login', {
+describes.realWin('AccessService login', {
   amp: true,
   location: 'https://pub.com/doc1',
 }, env => {
@@ -1363,7 +1362,7 @@ describes.fakeWin('AccessService login', {
 });
 
 
-describes.fakeWin('AccessService analytics', {
+describes.realWin('AccessService analytics', {
   amp: true,
   location: 'https://pub.com/doc1',
 }, env => {
@@ -1474,7 +1473,7 @@ describes.fakeWin('AccessService analytics', {
 });
 
 
-describes.fakeWin('AccessService multiple sources', {
+describes.realWin('AccessService multiple sources', {
   amp: true,
   location: 'https://pub.com/doc1',
 }, env => {

--- a/extensions/amp-access/0.1/test/test-amp-access.js
+++ b/extensions/amp-access/0.1/test/test-amp-access.js
@@ -467,40 +467,6 @@ describes.realWin('AccessService authorization', {
     });
   });
 
-  it('should use fallback on authorization failure when available', () => {
-    expectGetReaderId('reader1');
-    adapterMock.expects('authorize')
-        .withExactArgs()
-        .returns(Promise.reject('intentional'))
-        .once();
-    service.sources_[0].authorizationFallbackResponse_ = {'error': true};
-    const promise = service.runAuthorization_();
-    expect(document.documentElement).to.have.class('amp-access-loading');
-    expect(document.documentElement).not.to.have.class('amp-access-error');
-    return promise.then(() => {
-      expect(document.documentElement).not.to.have.class('amp-access-loading');
-      expect(document.documentElement).not.to.have.class('amp-access-error');
-      expect(elementOn).to.have.attribute('amp-access-hide');
-      expect(elementOff).not.to.have.attribute('amp-access-hide');
-      expect(elementError).not.to.have.attribute('amp-access-hide');
-    });
-  });
-
-  it('should NOT fallback on authorization failure when disabled', () => {
-    expectGetReaderId('reader1');
-    adapterMock.expects('authorize')
-        .withExactArgs()
-        .returns(Promise.reject('intentional'))
-        .once();
-    service.authorizationFallbackResponse_ = {'error': true};
-    const promise = service.runAuthorization_(/* disableFallback */ true);
-    expect(document.documentElement).to.have.class('amp-access-loading');
-    expect(document.documentElement).not.to.have.class('amp-access-error');
-    return promise.then(() => {
-      expect(document.documentElement).to.have.class('amp-access-error');
-    });
-  });
-
   it('should run authorization for broadcast events on same origin', () => {
     let broadcastHandler;
     sandbox.stub(service.viewer_, 'onBroadcast').callsFake(handler => {

--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -165,6 +165,9 @@ export class Performance {
     });
   }
 
+  /**
+   * Fired on document ready.
+   */
   onload_() {
     this.tick('ol');
     this.tickLegacyFirstPaintTime_();
@@ -172,7 +175,7 @@ export class Performance {
   }
 
   /**
-   * Reports first pain and first contentful paint timings.
+   * Reports first paint and first contentful paint timings.
    * See https://github.com/WICG/paint-timing
    */
   registerPaintTimingObserver_() {
@@ -303,7 +306,8 @@ export class Performance {
    *     this directly.
    */
   tick(label, opt_delta) {
-    const value = (opt_delta == undefined) ? this.win.performance.now() : undefined;
+    const value = (opt_delta == undefined)
+      ? this.win.performance.now() : undefined;
 
     const data = dict({
       'label': label,

--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -225,8 +225,8 @@ export class Performance {
     if (!this.win.PerformancePaintTiming
         && this.win.chrome
         && typeof this.win.chrome.loadTimes == 'function') {
-      const fpTime = this.win.chrome.loadTimes().firstPaintTime
-          * 1000 - this.win.performance.timing.navigationStart;
+      const fpTime = (this.win.chrome.loadTimes().firstPaintTime
+          * 1000) - this.win.performance.timing.navigationStart;
       if (fpTime <= 1) {
         // Throw away bad data generated from an apparent Chrome bug
         // that is fixed in later Chrome versions.
@@ -467,14 +467,23 @@ export class Performance {
     return this.isPerformanceTrackingOn_;
   }
 
+  /**
+   * @return {number|null}
+   */
   getFirstContentfulPaint() {
     return this.firstContentfulPaint_;
   }
 
+  /**
+   * @return {number|null}
+   */
   getMakeBodyVisible() {
     return this.makeBodyVisible_;
   }
 
+  /**
+   * @return {number|null}
+   */
   getFirstViewportReady() {
     return this.firstViewportReady_;
   }

--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -75,7 +75,7 @@ export class Performance {
     this.win = win;
 
     /** @private @const {number} */
-    this.initTime_ = this.win.Date.now();
+    this.initTime_ = this.win.performance.now();
 
     /** @const @private {!Array<TickEventDef>} */
     this.events_ = [];
@@ -154,7 +154,7 @@ export class Performance {
       this.isMessagingReady_ = true;
 
       // Tick the "messaging ready" signal.
-      this.tickDelta('msr', this.win.Date.now() - this.initTime_);
+      this.tickDelta('msr', this.win.performance.now() - this.initTime_);
 
       // Forward all queued ticks to the viewer since messaging
       // is now ready.
@@ -246,14 +246,14 @@ export class Performance {
     // (hasn't been visible yet, ever at this point)
     if (didStartInPrerender) {
       this.viewer_.whenFirstVisible().then(() => {
-        docVisibleTime = this.win.Date.now();
+        docVisibleTime = this.win.performance.now();
       });
     }
 
     this.whenViewportLayoutComplete_().then(() => {
       if (didStartInPrerender) {
         const userPerceivedVisualCompletenesssTime = docVisibleTime > -1
-          ? (this.win.Date.now() - docVisibleTime)
+          ? (this.win.performance.now() - docVisibleTime)
           //  Prerender was complete before visibility.
           : 0;
         this.viewer_.whenFirstVisible().then(() => {
@@ -273,7 +273,7 @@ export class Performance {
         this.tick('pc');
         // We don't have the actual csi timer's clock start time,
         // so we just have to use `docVisibleTime`.
-        this.prerenderComplete_(this.win.Date.now() - docVisibleTime);
+        this.prerenderComplete_(this.win.performance.now() - docVisibleTime);
       }
       this.flush();
     });
@@ -303,7 +303,7 @@ export class Performance {
    *     this directly.
    */
   tick(label, opt_delta) {
-    const value = (opt_delta == undefined) ? this.win.Date.now() : undefined;
+    const value = (opt_delta == undefined) ? this.win.performance.now() : undefined;
 
     const data = dict({
       'label': label,
@@ -368,7 +368,7 @@ export class Performance {
    * @param {string} label The variable name as it will be reported.
    */
   tickSinceVisible(label) {
-    const now = this.win.Date.now();
+    const now = this.win.performance.now();
     const visibleTime = this.viewer_ ? this.viewer_.getFirstVisibleTime() : 0;
     const v = visibleTime ? Math.max(now - visibleTime, 0) : 0;
     this.tickDelta(label, v);

--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -41,6 +41,7 @@ import {
 } from '../service';
 import {isExperimentOn} from '../experiments';
 import {isProtocolValid} from '../url';
+import {tryResolve} from '../utils/promise';
 
 /** @private @const {string} */
 const TAG = 'UrlReplacements';
@@ -559,15 +560,18 @@ export class GlobalVariableSource extends VariableSource {
         'STORY_PAGE_ID'));
 
     this.setAsync('FIRST_CONTENTFUL_PAINT', () => {
-      return Services.performanceFor(this.ampdoc.win).getFirstContentfulPaint();
+      return tryResolve(() =>
+        Services.performanceFor(this.ampdoc.win).getFirstContentfulPaint());
     });
 
     this.setAsync('FIRST_VIEWPORT_READY', () => {
-      return Services.performanceFor(this.ampdoc.win).getFirstViewportReady();
+      return tryResolve(() =>
+        Services.performanceFor(this.ampdoc.win).getFirstViewportReady());
     });
 
     this.setAsync('MAKE_BODY_VISIBLE', () => {
-      return Services.performanceFor(this.ampdoc.win).getMakeBodyVisible();
+      return tryResolve(() =>
+        Services.performanceFor(this.ampdoc.win).getMakeBodyVisible());
     });
 
     this.setAsync('AMP_STATE', key => {

--- a/test/functional/test-performance.js
+++ b/test/functional/test-performance.js
@@ -34,8 +34,8 @@ describes.realWin('performance', {amp: true}, env => {
     ampdoc = env.ampdoc;
     clock = lolex.install({
       target: win, toFake: ['Date', 'setTimeout', 'clearTimeout']});
-    // Bind performance with the clock's implementation so that
-    // we can use date.now to manipulate it's value.
+    // Bind performance with the clock's implementation so that we can use
+    // date.now or click.tick to manipulate it's value.
     // See https://www.npmjs.com/package/lolex
     win.performance.now = clock.performance.now;
     installPerformanceService(env.win);

--- a/test/functional/test-performance.js
+++ b/test/functional/test-performance.js
@@ -34,6 +34,10 @@ describes.realWin('performance', {amp: true}, env => {
     ampdoc = env.ampdoc;
     clock = lolex.install({
       target: win, toFake: ['Date', 'setTimeout', 'clearTimeout']});
+    // Bind performance with the clock's implementation so that
+    // we can use date.now to manipulate it's value.
+    // See https://www.npmjs.com/package/lolex 
+    win.performance.now = clock.performance.now;
     installPerformanceService(env.win);
     perf = Services.performanceFor(env.win);
   });
@@ -109,6 +113,7 @@ describes.realWin('performance', {amp: true}, env => {
     it('should add default optional relative start time on the ' +
        'queued tick event', () => {
       clock.tick(150);
+      const now = clock.performance.now();
       perf.tick('start0');
 
       expect(perf.events_[0]).to.be.jsonEqual({

--- a/test/functional/test-performance.js
+++ b/test/functional/test-performance.js
@@ -36,7 +36,7 @@ describes.realWin('performance', {amp: true}, env => {
       target: win, toFake: ['Date', 'setTimeout', 'clearTimeout']});
     // Bind performance with the clock's implementation so that
     // we can use date.now to manipulate it's value.
-    // See https://www.npmjs.com/package/lolex 
+    // See https://www.npmjs.com/package/lolex
     win.performance.now = clock.performance.now;
     installPerformanceService(env.win);
     perf = Services.performanceFor(env.win);
@@ -113,7 +113,6 @@ describes.realWin('performance', {amp: true}, env => {
     it('should add default optional relative start time on the ' +
        'queued tick event', () => {
       clock.tick(150);
-      const now = clock.performance.now();
       perf.tick('start0');
 
       expect(perf.events_[0]).to.be.jsonEqual({

--- a/test/functional/test-performance.js
+++ b/test/functional/test-performance.js
@@ -35,7 +35,7 @@ describes.realWin('performance', {amp: true}, env => {
     clock = lolex.install({
       target: win, toFake: ['Date', 'setTimeout', 'clearTimeout']});
     // Bind performance with the clock's implementation so that we can use
-    // date.now or click.tick to manipulate it's value.
+    // date.now or clock.tick to manipulate it's value.
     // See https://www.npmjs.com/package/lolex
     win.performance.now = clock.performance.now;
     installPerformanceService(env.win);

--- a/test/functional/test-performance.js
+++ b/test/functional/test-performance.js
@@ -35,7 +35,7 @@ describes.realWin('performance', {amp: true}, env => {
     clock = lolex.install({
       target: win, toFake: ['Date', 'setTimeout', 'clearTimeout']});
     // Bind performance with the clock's implementation so that we can use
-    // date.now or clock.tick to manipulate it's value.
+    // date.now or clock.tick to manipulate it's value in this test.
     // See https://www.npmjs.com/package/lolex
     win.performance.now = clock.performance.now;
     installPerformanceService(env.win);

--- a/test/functional/test-performance.js
+++ b/test/functional/test-performance.js
@@ -34,8 +34,8 @@ describes.realWin('performance', {amp: true}, env => {
     ampdoc = env.ampdoc;
     clock = lolex.install({
       target: win, toFake: ['Date', 'setTimeout', 'clearTimeout']});
-    // Bind performance with the clock's implementation so that we can use
-    // date.now or clock.tick to manipulate it's value in this test.
+    // Bind window performance with the clock's implementation so that we can
+    // use date.now or clock.tick to manipulate its value in this test.
     // See https://www.npmjs.com/package/lolex
     win.performance.now = clock.performance.now;
     installPerformanceService(env.win);

--- a/testing/fake-dom.js
+++ b/testing/fake-dom.js
@@ -142,9 +142,7 @@ export class FakeWindow {
         }
       },
     });
-    // Polyfill performance.now() method as it would normally not be available
-    // in a non document environment. Used for tests using fakeWin that rely on
-    // the performance-impl service.
+    // Polyfill performance.now() with Date.now().
     this.performance = {now: () => Date.now()};
 
     // Create element to enhance test elements.
@@ -189,44 +187,23 @@ export class FakeWindow {
     /** @const */
     this.Date = window.Date;
 
+    /** polyfill setTimeout. */
     this.setTimeout = function() {
-    /**
-     * @param {function()} handler
-     * @param {number=} timeout
-     * @param {...*} var_args
-     * @return {number}
-     * @const
-     */
       return window.setTimeout.apply(window, arguments);
     };
 
     /** polyfill clearTimeout. */
     this.clearTimeout = function() {
-      /**
-       * @param {number} id
-       * @const
-       */
       return window.clearTimeout.apply(window, arguments);
     };
 
     /** polyfill setInterval. */
     this.setInterval = function() {
-      /**
-       * @param {function()} handler
-       * @param {number=} timeout
-       * @param {...*} var_args
-       * @return {number}
-       * @const
-       */
       return window.setInterval.apply(window, arguments);
     };
 
     /** polyfill clearInterval. */
     this.clearInterval = function() {
-    /**
-     * @param {number} id
-     * @const
-     */
       return window.clearInterval.apply(window, arguments);
     };
 

--- a/testing/fake-dom.js
+++ b/testing/fake-dom.js
@@ -142,6 +142,10 @@ export class FakeWindow {
         }
       },
     });
+    // Polyfill performance.now() method as it would normally not be available
+    // in a non document environment. Used for tests using fakeWin that rely on
+    // the performance-impl service.
+    this.performance = {now: () => Date.now()};
 
     // Create element to enhance test elements.
     const nativeDocumentCreate = this.document.createElement;

--- a/testing/fake-dom.js
+++ b/testing/fake-dom.js
@@ -176,7 +176,7 @@ export class FakeWindow {
     // Navigator.
     /** @const {!Navigator} */
     this.navigator = {
-      userAgent: spec.navigator && spec.navigator.userAgent ||
+      userAgent: (spec.navigator && spec.navigator.userAgent) ||
           window.navigator.userAgent,
     };
 
@@ -189,6 +189,7 @@ export class FakeWindow {
     /** @const */
     this.Date = window.Date;
 
+    this.setTimeout = function() {
     /**
      * @param {function()} handler
      * @param {number=} timeout
@@ -196,34 +197,36 @@ export class FakeWindow {
      * @return {number}
      * @const
      */
-    this.setTimeout = function() {
       return window.setTimeout.apply(window, arguments);
     };
 
-    /**
-     * @param {number} id
-     * @const
-     */
+    /** polyfill clearTimeout. */
     this.clearTimeout = function() {
+      /**
+       * @param {number} id
+       * @const
+       */
       return window.clearTimeout.apply(window, arguments);
     };
 
-    /**
-     * @param {function()} handler
-     * @param {number=} timeout
-     * @param {...*} var_args
-     * @return {number}
-     * @const
-     */
+    /** polyfill setInterval. */
     this.setInterval = function() {
+      /**
+       * @param {function()} handler
+       * @param {number=} timeout
+       * @param {...*} var_args
+       * @return {number}
+       * @const
+       */
       return window.setInterval.apply(window, arguments);
     };
 
+    /** polyfill clearInterval. */
+    this.clearInterval = function() {
     /**
      * @param {number} id
      * @const
      */
-    this.clearInterval = function() {
       return window.clearInterval.apply(window, arguments);
     };
 
@@ -243,18 +246,10 @@ export class FakeWindow {
     this.requestAnimationFrame = raf;
   }
 
-  /**
-   * @param {string} type
-   * @param {function(!Event)} handler
-   * @param {(boolean|!Object)=} captureOrOpts
-   */
+  /** polyfill addEventListener. */
   addEventListener() {}
 
-  /**
-   * @param {string} type
-   * @param {function(!Event)} handler
-   * @param {(boolean|!Object)=} captureOrOpts
-   */
+  /** polyfill removeEventListener. */
   removeEventListener() {}
 }
 
@@ -299,6 +294,7 @@ class EventListeners {
     };
   }
 
+  /** Creates an empty instance. */
   constructor() {
     /** @const {!Array<!EventListener>} */
     this.listeners = [];


### PR DESCRIPTION
Fixes #16042 

- use performance.now in metrics
- fix missing jsdocs in performance-impl
- fix corresponding return types in url-replacements-impl due to jsdoc doc change
- update amp-access tests to polyfill performance.now as it is not present in a fakeWin
- update amp-access test to remove pubOrigin expect for 'http' as the pubOrigin for the iframe is now about:src since the fakeLocation is on win.testLocation as opposed to win.location when setting, as win.location on an iframe is not configurable. see describes.js#setup(env)
- remove opt_disableFallback param in amp-access.js#runAuthorization_() method as it is not used and remove related tests. This change was required as one of the test was failing, and not due to my changes as it fails on master.