### PR TITLE
AmpA4A catch getConsentPolicyState errors

### DIFF
--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -701,14 +701,12 @@ export class AmpA4A extends AMP.BaseElement {
         .then(() => {
           checkStillCurrent();
           const consentPolicyId = super.getConsentPolicy();
-          if (consentPolicyId) {
-            return getConsentPolicyState(this.getAmpDoc(), consentPolicyId)
+          return consentPolicyId ?
+            getConsentPolicyState(this.getAmpDoc(), consentPolicyId)
                 .catch(err => {
                   user().error(TAG, 'Error determining consent state', err);
                   return CONSENT_POLICY_STATE.UNKNOWN;
-                });
-          }
-          return Promise.resolve(null);
+                }) : Promise.resolve(null);
         })
         // This block returns the ad URL, if one is available.
         /** @return {!Promise<?string>} */

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -701,9 +701,14 @@ export class AmpA4A extends AMP.BaseElement {
         .then(() => {
           checkStillCurrent();
           const consentPolicyId = super.getConsentPolicy();
-          return consentPolicyId ?
-            getConsentPolicyState(this.getAmpDoc(), consentPolicyId) :
-            Promise.resolve(null);
+          if (consentPolicyId) {
+            return getConsentPolicyState(this.getAmpDoc(), consentPolicyId)
+                .catch(err => {
+                  user().error(TAG, 'Error determining consent state', err);
+                  return CONSENT_POLICY_STATE.UNKNOWN;
+                });
+          }
+          return Promise.resolve(null);
         })
         // This block returns the ad URL, if one is available.
         /** @return {!Promise<?string>} */

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -2097,6 +2097,23 @@ describe('amp-a4a', () => {
               .calledOnce;
         });
       });
+
+      it('should return UNKNOWN if consent exception', () => {
+        expectAsyncConsoleError(/Error determining consent state.*consent err/);
+        sandbox.stub(AMP.BaseElement.prototype, 'getConsentPolicy')
+            .returns('default');
+        sandbox.stub(Services, 'consentPolicyServiceForDocOrNull')
+            .returns(Promise.resolve({
+              whenPolicyResolved: () => {throw new Error('consent err!');},
+            }));
+        const getAdUrlSpy = sandbox.spy(a4a, 'getAdUrl');
+        a4a.buildCallback();
+        a4a.onLayoutMeasure();
+        return a4a.layoutCallback().then(() => {
+          expect(getAdUrlSpy.withArgs(CONSENT_POLICY_STATE.UNKNOWN))
+              .calledOnce;
+        });
+      });
     });
 
     describe('protectFunctionWrapper', () => {

--- a/validator/engine/validator_test.js
+++ b/validator/engine/validator_test.js
@@ -655,6 +655,7 @@ function attrRuleShouldMakeSense(attrSpec, rules) {
     // Attribute Spec names are matched against lowercased attributes,
     // so the rules *must* also be lower case or non-cased.
     const attrSpecNameRegex = new RegExp('^[^A-Z]+$');
+
     expect(attrSpecNameRegex.test(attrSpec.name)).toBe(true);
   });
   if (attrSpec.valueUrl !== null) {

--- a/validator/engine/validator_test.js
+++ b/validator/engine/validator_test.js
@@ -655,7 +655,6 @@ function attrRuleShouldMakeSense(attrSpec, rules) {
     // Attribute Spec names are matched against lowercased attributes,
     // so the rules *must* also be lower case or non-cased.
     const attrSpecNameRegex = new RegExp('^[^A-Z]+$');
-
     expect(attrSpecNameRegex.test(attrSpec.name)).toBe(true);
   });
   if (attrSpec.valueUrl !== null) {


### PR DESCRIPTION
AmpA4A if getConsentPolicyState throws (i.e. href network fetch fails) pass UNKNOWN to getAdUrl otherwise slot will just be collapsed.  See https://github.com/ampproject/amphtml/issues/16104