### PR TITLE
Add a line to cherry picks doc letting requesters know it is a lot of work

### DIFF
--- a/contributing/release-schedule.md
+++ b/contributing/release-schedule.md
@@ -36,7 +36,10 @@ We have a well-defined process for handling requests for changes to the canary r
 
 ### Cherry pick criteria
 
-**The bar for getting a cherry pick into canary or production is very high** because our goal is to produce high quality launches on a predictable schedule:
+**The bar for getting a cherry pick into canary or production is very high** because our goal is to produce high quality launches on a predictable schedule.
+
+**Keep in mind that performing a cherry pick requires a significant amount of work from you and the onduty person** and they can take a long time to process.
+
 - In general only fixes for [P0 issues](https://github.com/ampproject/amphtml/blob/master/contributing/issue-priorities.md) (causing "an outage or a critical production issue") may be cherry picked.  P0 issues are those that:
   - cause privacy or security issues
   - cause user data loss


### PR DESCRIPTION
The current cherry pick documentation doesn't make it clear that getting a cherry pick in requires a lot of work (both from the requester and from the onduty person), so let's make this explicit.