### PR TITLE
🐛Add default htmlAccessAllowed to allowed 3p attributes

### DIFF
--- a/3p/3p.js
+++ b/3p/3p.js
@@ -276,6 +276,7 @@ function validateAllowedFields(data, allowedFields) {
     ampSlotIndex: true,
     adHolderText: true,
     loadingStrategy: true,
+    htmlAccessAllowed: true,
   };
 
   for (const field in data) {

--- a/ads/yandex.js
+++ b/ads/yandex.js
@@ -26,7 +26,7 @@ export function yandex(global, data) {
   validateData(
       data,
       ['blockId'],
-      ['data', 'htmlAccessAllowed', 'onRender', 'onError']
+      ['data', 'onRender', 'onError']
   );
 
   addToQueue(global, data);


### PR DESCRIPTION
Found the bug from #16132 
`data-html-access-allowed` is an AMP supported attribute, and should be allowed by default. 