### PR TITLE
Correct syntax

### DIFF
--- a/extensions/amp-audio/amp-audio.md
+++ b/extensions/amp-audio/amp-audio.md
@@ -67,7 +67,7 @@ Required if no `<source>` children are present. Must be HTTPS.
 
 ##### preload
 
-If present, sets the preload attribute in the html <audio> tag which specifies if the author thinks that the audio file should be loaded when the page loads.
+If present, sets the preload attribute in the html `<audio>` tag which specifies if the author thinks that the audio file should be loaded when the page loads.
 
 ##### autoplay
 


### PR DESCRIPTION
Correct syntax (escape the code) so it renders correctly in ampproject.org without validator errors, which is [what's currently happening](https://www.ampproject.org/docs/reference/components/amp-audio).

