### PR TITLE
Word change for "media" attribute

### DIFF
--- a/spec/amp-html-layout.md
+++ b/spec/amp-html-layout.md
@@ -179,7 +179,7 @@ In the following example, the height of the image will default to 80% of the wid
 
 ### `media`
 
-All AMP elements support the `media` attribute. The value of `media` is a media query. If the query does not match, the element is not rendered at all and its resources and potentially its child resources will not be fetched. If the browser window changes size or orientation, the media queries are re-evaluated and elements are hidden and shown based on the new results.
+Most AMP elements support the `media` attribute. The value of `media` is a media query. If the query does not match, the element is not rendered at all and its resources and potentially its child resources will not be fetched. If the browser window changes size or orientation, the media queries are re-evaluated and elements are hidden and shown based on the new results.
 
 **Example**: Using the `media` attribute
 


### PR DESCRIPTION
Changing this from "all" to "most" as it turns out not **all** amp components include `media` in validation (a rare few and it's not just amp-accordion).

(Leaving the Component Validator Rules doc alone)