### PR TITLE
🏗 Remove strict enforcement of the `require-jsdoc` rule

### DIFF
--- a/.eslintrc-strict
+++ b/.eslintrc-strict
@@ -11,15 +11,6 @@
     "jsdoc/require-param-name": 2,
     "jsdoc/require-param-type": 2,
     "jsdoc/require-returns-type": 2,
-    "no-mixed-operators": 2,
-    "require-jsdoc": [2, {
-      "require": {
-        "FunctionDeclaration": true,
-        "MethodDefinition": true,
-        "ClassDeclaration": false,
-        "ArrowFunctionExpression": false,
-        "FunctionExpression": false
-      }
-    }]
+    "no-mixed-operators": 2
   }
 }


### PR DESCRIPTION
The `require-jsdoc` rule turned out to cause too much friction during normal development. This PR removes it from `.eslintrc-strict`, thereby downgrading it to a warning-only rule.

Partial fix for #16024
Follow up to #15977
