### PR TITLE
Add an optional external link to the story consent.

### DIFF
--- a/examples/amp-story/consent.html
+++ b/examples/amp-story/consent.html
@@ -69,8 +69,10 @@
             "title": "Headline.",
             "message": "This is some more information about this choice. Here's a list of items related to this choice.",
             "vendors": ["Item 1", "Item 2", "Item 3", "Item 4", "Item 5", "Item 6", "Item 7", "Item 8", "Item 9", "Item 10"],
-            "externalLinkTitle": "Privacy settings",
-            "externalLink": "https://example.com"
+            "externalLink": {
+              "title": "Data Privacy Settings",
+              "href": "https://example.com"
+            }
           }</script>
         </amp-story-consent>
       </amp-consent>

--- a/examples/amp-story/consent.html
+++ b/examples/amp-story/consent.html
@@ -68,7 +68,9 @@
           <script type="application/json">{
             "title": "Headline.",
             "message": "This is some more information about this choice. Here's a list of items related to this choice.",
-            "vendors": ["Item 1", "Item 2", "Item 3", "Item 4", "Item 5", "Item 6", "Item 7", "Item 8", "Item 9", "Item 10"]
+            "vendors": ["Item 1", "Item 2", "Item 3", "Item 4", "Item 5", "Item 6", "Item 7", "Item 8", "Item 9", "Item 10"],
+            "externalLinkTitle": "Privacy settings",
+            "externalLink": "https://example.com"
           }</script>
         </amp-story-consent>
       </amp-consent>

--- a/extensions/amp-story/0.1/amp-story-consent.css
+++ b/extensions/amp-story/0.1/amp-story-consent.css
@@ -124,6 +124,36 @@
   overflow: hidden !important;
 }
 
+.i-amphtml-story-consent-external-link {
+  position: relative !important;
+  display: inline-block !important;
+  margin: 24px 0 !important;
+  color: rgba(0, 0, 0, 0.87) !important;
+  font-size: 15px !important;
+  font-weight: bold !important;
+  text-decoration: none !important;
+}
+
+.i-amphtml-story-consent-external-link:hover {
+  text-decoration: underline !important;
+}
+
+.i-amphtml-story-consent-external-link::after {
+  content: "" !important;
+  position: absolute !important;
+  display: block !important;
+  height: 16px !important;
+  width: 16px !important;
+  top: 3px !important;
+  right: -20px !important;
+  background: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" viewBox="0 0 24 24" fill="rgba(0, 0, 0, 0.87)"><path d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"/><path d="M0 0h24v24H0z" fill="none"/></svg>')
+      center center no-repeat !important;
+}
+
+.i-amphtml-story-consent-external-link.i-amphtml-hidden {
+  display: none !important;
+}
+
 /** Consent actions. */
 
 .i-amphtml-story-consent-actions {

--- a/extensions/amp-story/0.1/amp-story-consent.js
+++ b/extensions/amp-story/0.1/amp-story-consent.js
@@ -20,6 +20,7 @@ import {CSS} from '../../../build/amp-story-consent-0.1.css';
 import {Layout} from '../../../src/layout';
 import {LocalizedStringId} from './localization';
 import {Services} from '../../../src/services';
+import {assertAbsoluteHttpOrHttpsUrl} from '../../../src/url';
 import {
   childElementByTag,
   closestByTag,
@@ -44,6 +45,8 @@ const TAG = 'amp-story-consent';
  * @const {!Object}
  */
 const DEFAULT_OPTIONAL_PARAMETERS = {
+  externalLinkTitle: null,
+  externalLink: null,
   onlyAccept: false,
 };
 
@@ -111,6 +114,19 @@ const getTemplate = (config, consentId, logoSrc) => ({
                       unlocalizedString: vendor,
                     })
                   ),
+                },
+                {
+                  tag: 'a',
+                  attrs: dict({
+                    'class': 'i-amphtml-story-consent-external-link ' +
+                        (!(config.externalLink && config.externalLinkTitle) ?
+                        'i-amphtml-hidden' : ''),
+                    'href': config.externalLink,
+                    'target': '_top',
+                    'title': config.externalLinkTitle,
+                  }),
+                  children: [],
+                  unlocalizedString: config.externalLinkTitle,
                 },
               ],
             },
@@ -294,6 +310,19 @@ export class AmpStoryConsent extends AMP.BaseElement {
     user().assertBoolean(
         this.storyConsentConfig_.onlyAccept,
         `${TAG}: config requires "onlyAccept" to be a boolean`);
+
+    // Runs the validation if any of the title or link are provided, since
+    // both have to be provided for the external link to be displayed.
+    if (this.storyConsentConfig_.externalLinkTitle ||
+        this.storyConsentConfig_.externalLink) {
+      user().assertString(
+          this.storyConsentConfig_.externalLinkTitle,
+          `${TAG}: config requires "externalLinkTitle" to be a string`);
+      user().assertString(
+          this.storyConsentConfig_.externalLink,
+          `${TAG}: config requires "externalLink" to be an absolute URL`);
+      assertAbsoluteHttpOrHttpsUrl(this.storyConsentConfig_.externalLink);
+    }
   }
 
   /**

--- a/extensions/amp-story/0.1/amp-story-consent.js
+++ b/extensions/amp-story/0.1/amp-story-consent.js
@@ -45,8 +45,7 @@ const TAG = 'amp-story-consent';
  * @const {!Object}
  */
 const DEFAULT_OPTIONAL_PARAMETERS = {
-  externalLinkTitle: null,
-  externalLink: null,
+  externalLink: {},
   onlyAccept: false,
 };
 
@@ -119,14 +118,15 @@ const getTemplate = (config, consentId, logoSrc) => ({
                   tag: 'a',
                   attrs: dict({
                     'class': 'i-amphtml-story-consent-external-link ' +
-                        (!(config.externalLink && config.externalLinkTitle) ?
-                        'i-amphtml-hidden' : ''),
-                    'href': config.externalLink,
+                        (!(config.externalLink.title &&
+                            config.externalLink.href) ?
+                          'i-amphtml-hidden' : ''),
+                    'href': config.externalLink.href,
                     'target': '_top',
-                    'title': config.externalLinkTitle,
+                    'title': config.externalLink.title,
                   }),
                   children: [],
-                  unlocalizedString: config.externalLinkTitle,
+                  unlocalizedString: config.externalLink.title,
                 },
               ],
             },
@@ -313,15 +313,15 @@ export class AmpStoryConsent extends AMP.BaseElement {
 
     // Runs the validation if any of the title or link are provided, since
     // both have to be provided for the external link to be displayed.
-    if (this.storyConsentConfig_.externalLinkTitle ||
-        this.storyConsentConfig_.externalLink) {
+    if (this.storyConsentConfig_.externalLink.href ||
+        this.storyConsentConfig_.externalLink.title) {
       user().assertString(
-          this.storyConsentConfig_.externalLinkTitle,
-          `${TAG}: config requires "externalLinkTitle" to be a string`);
+          this.storyConsentConfig_.externalLink.title,
+          `${TAG}: config requires "externalLink.title" to be a string`);
       user().assertString(
-          this.storyConsentConfig_.externalLink,
-          `${TAG}: config requires "externalLink" to be an absolute URL`);
-      assertAbsoluteHttpOrHttpsUrl(this.storyConsentConfig_.externalLink);
+          this.storyConsentConfig_.externalLink.href,
+          `${TAG}: config requires "externalLink.href" to be an absolute URL`);
+      assertAbsoluteHttpOrHttpsUrl(this.storyConsentConfig_.externalLink.href);
     }
   }
 

--- a/extensions/amp-story/0.1/test/test-amp-story-consent.js
+++ b/extensions/amp-story/0.1/test/test-amp-story-consent.js
@@ -43,6 +43,8 @@ describes.realWin('amp-story-consent', {amp: true}, env => {
       message: 'Foo message about the consent.',
       vendors: ['Item 1', 'Item 2'],
       onlyAccept: false,
+      externalLinkTitle: null,
+      externalLink: null,
     };
 
     const styles = {'background-color': 'rgb(0, 0, 0)'};
@@ -163,6 +165,64 @@ describes.realWin('amp-story-consent', {amp: true}, env => {
     // return all the styles.
     const styles = computedStyle(window, buttonEl);
     expect(styles.display).to.equal('none');
+  });
+
+  it('should hide the external link by default', () => {
+    storyConsent.buildCallback();
+
+    const linkEl = storyConsent.storyConsentEl_
+        .querySelector('.i-amphtml-story-consent-external-link');
+
+    const styles = computedStyle(window, linkEl);
+    expect(styles.display).to.equal('none');
+  });
+
+  it('should require an external link title if a URL is provided', () => {
+    defaultConfig.externalLink = 'https://example.com';
+    setConfig(defaultConfig);
+
+    allowConsoleError(() => {
+      expect(() => {
+        storyConsent.buildCallback();
+      }).to.throw('config requires "externalLinkTitle" to be a string');
+    });
+  });
+
+  it('should require an external URL if a title is provided', () => {
+    defaultConfig.externalLinkTitle = 'Privacy settings';
+    setConfig(defaultConfig);
+
+    allowConsoleError(() => {
+      expect(() => {
+        storyConsent.buildCallback();
+      }).to.throw('config requires "externalLink" to be an absolute URL');
+    });
+  });
+
+  it('should validate an external absolute URL', () => {
+    defaultConfig.externalLinkTitle = 'Privacy settings';
+    defaultConfig.externalLink = '/foo.html';
+    setConfig(defaultConfig);
+
+    allowConsoleError(() => {
+      expect(() => {
+        storyConsent.buildCallback();
+      }).to.throw('URL must start with "http://" or "https://"');
+    });
+  });
+
+  it('should show the external link', () => {
+    defaultConfig.externalLinkTitle = 'Privacy settings';
+    defaultConfig.externalLink = 'https://example.com';
+    setConfig(defaultConfig);
+
+    storyConsent.buildCallback();
+
+    const linkEl = storyConsent.storyConsentEl_
+        .querySelector('.i-amphtml-story-consent-external-link');
+
+    const styles = computedStyle(window, linkEl);
+    expect(styles.display).not.to.equal('none');
   });
 
   it('should whitelist the <amp-consent> actions', () => {

--- a/extensions/amp-story/0.1/test/test-amp-story-consent.js
+++ b/extensions/amp-story/0.1/test/test-amp-story-consent.js
@@ -43,8 +43,7 @@ describes.realWin('amp-story-consent', {amp: true}, env => {
       message: 'Foo message about the consent.',
       vendors: ['Item 1', 'Item 2'],
       onlyAccept: false,
-      externalLinkTitle: null,
-      externalLink: null,
+      externalLink: {},
     };
 
     const styles = {'background-color': 'rgb(0, 0, 0)'};
@@ -178,30 +177,30 @@ describes.realWin('amp-story-consent', {amp: true}, env => {
   });
 
   it('should require an external link title if a URL is provided', () => {
-    defaultConfig.externalLink = 'https://example.com';
+    defaultConfig.externalLink.href = 'https://example.com';
     setConfig(defaultConfig);
 
     allowConsoleError(() => {
       expect(() => {
         storyConsent.buildCallback();
-      }).to.throw('config requires "externalLinkTitle" to be a string');
+      }).to.throw('config requires "externalLink.title" to be a string');
     });
   });
 
   it('should require an external URL if a title is provided', () => {
-    defaultConfig.externalLinkTitle = 'Privacy settings';
+    defaultConfig.externalLink.title = 'Privacy settings';
     setConfig(defaultConfig);
 
     allowConsoleError(() => {
       expect(() => {
         storyConsent.buildCallback();
-      }).to.throw('config requires "externalLink" to be an absolute URL');
+      }).to.throw('config requires "externalLink.href" to be an absolute URL');
     });
   });
 
   it('should validate an external absolute URL', () => {
-    defaultConfig.externalLinkTitle = 'Privacy settings';
-    defaultConfig.externalLink = '/foo.html';
+    defaultConfig.externalLink.title = 'Privacy settings';
+    defaultConfig.externalLink.href = '/foo.html';
     setConfig(defaultConfig);
 
     allowConsoleError(() => {
@@ -212,8 +211,8 @@ describes.realWin('amp-story-consent', {amp: true}, env => {
   });
 
   it('should show the external link', () => {
-    defaultConfig.externalLinkTitle = 'Privacy settings';
-    defaultConfig.externalLink = 'https://example.com';
+    defaultConfig.externalLink.title = 'Privacy settings';
+    defaultConfig.externalLink.href = 'https://example.com';
     setConfig(defaultConfig);
 
     storyConsent.buildCallback();

--- a/extensions/amp-story/1.0/amp-story-consent.css
+++ b/extensions/amp-story/1.0/amp-story-consent.css
@@ -124,6 +124,36 @@
   overflow: hidden !important;
 }
 
+.i-amphtml-story-consent-external-link {
+  position: relative !important;
+  display: inline-block !important;
+  margin: 24px 0 !important;
+  color: rgba(0, 0, 0, 0.87) !important;
+  font-size: 15px !important;
+  font-weight: bold !important;
+  text-decoration: none !important;
+}
+
+.i-amphtml-story-consent-external-link:hover {
+  text-decoration: underline !important;
+}
+
+.i-amphtml-story-consent-external-link::after {
+  content: "" !important;
+  position: absolute !important;
+  display: block !important;
+  height: 16px !important;
+  width: 16px !important;
+  top: 3px !important;
+  right: -20px !important;
+  background: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" viewBox="0 0 24 24" fill="rgba(0, 0, 0, 0.87)"><path d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"/><path d="M0 0h24v24H0z" fill="none"/></svg>')
+      center center no-repeat !important;
+}
+
+.i-amphtml-story-consent-external-link.i-amphtml-hidden {
+  display: none !important;
+}
+
 /** Consent actions. */
 
 .i-amphtml-story-consent-actions {

--- a/extensions/amp-story/1.0/amp-story-consent.js
+++ b/extensions/amp-story/1.0/amp-story-consent.js
@@ -20,6 +20,7 @@ import {CSS} from '../../../build/amp-story-consent-1.0.css';
 import {Layout} from '../../../src/layout';
 import {LocalizedStringId} from './localization';
 import {Services} from '../../../src/services';
+import {assertAbsoluteHttpOrHttpsUrl} from '../../../src/url';
 import {
   childElementByTag,
   closestByTag,
@@ -44,6 +45,8 @@ const TAG = 'amp-story-consent';
  * @const {!Object}
  */
 const DEFAULT_OPTIONAL_PARAMETERS = {
+  externalLinkTitle: null,
+  externalLink: null,
   onlyAccept: false,
 };
 
@@ -111,6 +114,19 @@ const getTemplate = (config, consentId, logoSrc) => ({
                       unlocalizedString: vendor,
                     })
                   ),
+                },
+                {
+                  tag: 'a',
+                  attrs: dict({
+                    'class': 'i-amphtml-story-consent-external-link ' +
+                        (!(config.externalLink && config.externalLinkTitle) ?
+                        'i-amphtml-hidden' : ''),
+                    'href': config.externalLink,
+                    'target': '_top',
+                    'title': config.externalLinkTitle,
+                  }),
+                  children: [],
+                  unlocalizedString: config.externalLinkTitle,
                 },
               ],
             },
@@ -294,6 +310,19 @@ export class AmpStoryConsent extends AMP.BaseElement {
     user().assertBoolean(
         this.storyConsentConfig_.onlyAccept,
         `${TAG}: config requires "onlyAccept" to be a boolean`);
+
+    // Runs the validation if any of the title or link are provided, since
+    // both have to be provided for the external link to be displayed.
+    if (this.storyConsentConfig_.externalLinkTitle ||
+        this.storyConsentConfig_.externalLink) {
+      user().assertString(
+          this.storyConsentConfig_.externalLinkTitle,
+          `${TAG}: config requires "externalLinkTitle" to be a string`);
+      user().assertString(
+          this.storyConsentConfig_.externalLink,
+          `${TAG}: config requires "externalLink" to be an absolute URL`);
+      assertAbsoluteHttpOrHttpsUrl(this.storyConsentConfig_.externalLink);
+    }
   }
 
   /**

--- a/extensions/amp-story/1.0/amp-story-consent.js
+++ b/extensions/amp-story/1.0/amp-story-consent.js
@@ -45,8 +45,7 @@ const TAG = 'amp-story-consent';
  * @const {!Object}
  */
 const DEFAULT_OPTIONAL_PARAMETERS = {
-  externalLinkTitle: null,
-  externalLink: null,
+  externalLink: {},
   onlyAccept: false,
 };
 
@@ -119,14 +118,15 @@ const getTemplate = (config, consentId, logoSrc) => ({
                   tag: 'a',
                   attrs: dict({
                     'class': 'i-amphtml-story-consent-external-link ' +
-                        (!(config.externalLink && config.externalLinkTitle) ?
-                        'i-amphtml-hidden' : ''),
-                    'href': config.externalLink,
+                        (!(config.externalLink.title &&
+                            config.externalLink.href) ?
+                          'i-amphtml-hidden' : ''),
+                    'href': config.externalLink.href,
                     'target': '_top',
-                    'title': config.externalLinkTitle,
+                    'title': config.externalLink.title,
                   }),
                   children: [],
-                  unlocalizedString: config.externalLinkTitle,
+                  unlocalizedString: config.externalLink.title,
                 },
               ],
             },
@@ -313,15 +313,15 @@ export class AmpStoryConsent extends AMP.BaseElement {
 
     // Runs the validation if any of the title or link are provided, since
     // both have to be provided for the external link to be displayed.
-    if (this.storyConsentConfig_.externalLinkTitle ||
-        this.storyConsentConfig_.externalLink) {
+    if (this.storyConsentConfig_.externalLink.href ||
+        this.storyConsentConfig_.externalLink.title) {
       user().assertString(
-          this.storyConsentConfig_.externalLinkTitle,
-          `${TAG}: config requires "externalLinkTitle" to be a string`);
+          this.storyConsentConfig_.externalLink.title,
+          `${TAG}: config requires "externalLink.title" to be a string`);
       user().assertString(
-          this.storyConsentConfig_.externalLink,
-          `${TAG}: config requires "externalLink" to be an absolute URL`);
-      assertAbsoluteHttpOrHttpsUrl(this.storyConsentConfig_.externalLink);
+          this.storyConsentConfig_.externalLink.href,
+          `${TAG}: config requires "externalLink.href" to be an absolute URL`);
+      assertAbsoluteHttpOrHttpsUrl(this.storyConsentConfig_.externalLink.href);
     }
   }
 

--- a/extensions/amp-story/1.0/test/test-amp-story-consent.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-consent.js
@@ -43,6 +43,8 @@ describes.realWin('amp-story-consent', {amp: true}, env => {
       message: 'Foo message about the consent.',
       vendors: ['Item 1', 'Item 2'],
       onlyAccept: false,
+      externalLinkTitle: null,
+      externalLink: null,
     };
 
     const styles = {'background-color': 'rgb(0, 0, 0)'};
@@ -163,6 +165,64 @@ describes.realWin('amp-story-consent', {amp: true}, env => {
     // return all the styles.
     const styles = computedStyle(window, buttonEl);
     expect(styles.display).to.equal('none');
+  });
+
+  it('should hide the external link by default', () => {
+    storyConsent.buildCallback();
+
+    const linkEl = storyConsent.storyConsentEl_
+        .querySelector('.i-amphtml-story-consent-external-link');
+
+    const styles = computedStyle(window, linkEl);
+    expect(styles.display).to.equal('none');
+  });
+
+  it('should require an external link title if a URL is provided', () => {
+    defaultConfig.externalLink = 'https://example.com';
+    setConfig(defaultConfig);
+
+    allowConsoleError(() => {
+      expect(() => {
+        storyConsent.buildCallback();
+      }).to.throw('config requires "externalLinkTitle" to be a string');
+    });
+  });
+
+  it('should require an external URL if a title is provided', () => {
+    defaultConfig.externalLinkTitle = 'Privacy settings';
+    setConfig(defaultConfig);
+
+    allowConsoleError(() => {
+      expect(() => {
+        storyConsent.buildCallback();
+      }).to.throw('config requires "externalLink" to be an absolute URL');
+    });
+  });
+
+  it('should validate an external absolute URL', () => {
+    defaultConfig.externalLinkTitle = 'Privacy settings';
+    defaultConfig.externalLink = '/foo.html';
+    setConfig(defaultConfig);
+
+    allowConsoleError(() => {
+      expect(() => {
+        storyConsent.buildCallback();
+      }).to.throw('URL must start with "http://" or "https://"');
+    });
+  });
+
+  it('should show the external link', () => {
+    defaultConfig.externalLinkTitle = 'Privacy settings';
+    defaultConfig.externalLink = 'https://example.com';
+    setConfig(defaultConfig);
+
+    storyConsent.buildCallback();
+
+    const linkEl = storyConsent.storyConsentEl_
+        .querySelector('.i-amphtml-story-consent-external-link');
+
+    const styles = computedStyle(window, linkEl);
+    expect(styles.display).not.to.equal('none');
   });
 
   it('should whitelist the <amp-consent> actions', () => {

--- a/extensions/amp-story/1.0/test/test-amp-story-consent.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-consent.js
@@ -43,8 +43,7 @@ describes.realWin('amp-story-consent', {amp: true}, env => {
       message: 'Foo message about the consent.',
       vendors: ['Item 1', 'Item 2'],
       onlyAccept: false,
-      externalLinkTitle: null,
-      externalLink: null,
+      externalLink: {},
     };
 
     const styles = {'background-color': 'rgb(0, 0, 0)'};
@@ -178,30 +177,30 @@ describes.realWin('amp-story-consent', {amp: true}, env => {
   });
 
   it('should require an external link title if a URL is provided', () => {
-    defaultConfig.externalLink = 'https://example.com';
+    defaultConfig.externalLink.href = 'https://example.com';
     setConfig(defaultConfig);
 
     allowConsoleError(() => {
       expect(() => {
         storyConsent.buildCallback();
-      }).to.throw('config requires "externalLinkTitle" to be a string');
+      }).to.throw('config requires "externalLink.title" to be a string');
     });
   });
 
   it('should require an external URL if a title is provided', () => {
-    defaultConfig.externalLinkTitle = 'Privacy settings';
+    defaultConfig.externalLink.title = 'Privacy settings';
     setConfig(defaultConfig);
 
     allowConsoleError(() => {
       expect(() => {
         storyConsent.buildCallback();
-      }).to.throw('config requires "externalLink" to be an absolute URL');
+      }).to.throw('config requires "externalLink.href" to be an absolute URL');
     });
   });
 
   it('should validate an external absolute URL', () => {
-    defaultConfig.externalLinkTitle = 'Privacy settings';
-    defaultConfig.externalLink = '/foo.html';
+    defaultConfig.externalLink.title = 'Privacy settings';
+    defaultConfig.externalLink.href = '/foo.html';
     setConfig(defaultConfig);
 
     allowConsoleError(() => {
@@ -212,8 +211,8 @@ describes.realWin('amp-story-consent', {amp: true}, env => {
   });
 
   it('should show the external link', () => {
-    defaultConfig.externalLinkTitle = 'Privacy settings';
-    defaultConfig.externalLink = 'https://example.com';
+    defaultConfig.externalLink.title = 'Privacy settings';
+    defaultConfig.externalLink.href = 'https://example.com';
     setConfig(defaultConfig);
 
     storyConsent.buildCallback();


### PR DESCRIPTION
Allows adding an optional external link to the story consent UI, in both `0.1` and `1.0`.

### Config example:

Introducing one new key: `externalLink`, that is an object accepting two other keys `href` and `title`.
`externalLink` is optional.

````
<amp-consent id='ABC' layout='nodisplay'>
  <script type="application/json">{
    "consents": {
      "DEF": {
        "checkConsentHref": "http://localhost:8000/get-consent-v1",
        "promptUI": "ui0"
      }
    }
  }</script>

  <amp-story-consent id="ui0" layout="nodisplay">
    <script type="application/json">{
      "title": "Headline.",
      "message": "This is some more information about this choice. Here's a list of items related to this choice.",
      "vendors": ["Item 1", "Item 2", "Item 3", "Item 4", "Item 5", "Item 6", "Item 7", "Item 8", "Item 9", "Item 10"],
      "externalLink": {
        "title": "Privacy settings",
        "href": "https://example.com"
      }
    }</script>
  </amp-story-consent>
</amp-consent>
````

### Screenshot:

![image](https://user-images.githubusercontent.com/1492044/41627816-f2cf3ac4-73ef-11e8-8246-a465f6e8ef9c.png)


Fixes: #16053