### PR TITLE
✨Support twitter moments in amp-twitter.

### DIFF
--- a/3p/twitter.js
+++ b/3p/twitter.js
@@ -67,7 +67,7 @@ export function twitter(global, data) {
       twttr.widgets.createTweet(cleanupTweetId_(data.tweetid), tweet, data)
           ./*OK*/then(el => tweetCreated(twttr, el));
     } else if (data.momentid) {
-      twttr.widgets.createMoment(cleanupMomentId_(data.momentid), tweet, data)
+      twttr.widgets.createMoment(data.momentid, tweet, data)
           ./*OK*/then(el => tweetCreated(twttr, el));
     }
   });
@@ -107,31 +107,6 @@ export function twitter(global, data) {
         container./*OK*/offsetWidth,
         height + /* margins */ 20);
   }
-}
-
-/**
- * @param {*} momentid
- * @visibleForTesting
- */
-export function cleanupMomentId_(momentid) {
-  // 1)
-  // Handle malformed ids such as
-  // https://twitter.com/i/moments/
-  momentid = momentid.toLowerCase();
-  let match = momentid.match(/https:\/\/twitter.com\/[^\/]+\/moments\/(\d+)/);
-  if (match) {
-    return match[1];
-  }
-
-  // 2)
-  // Handle malformed ids such as
-  // 1009149991452135424?ref_src
-  match = momentid.match(/^(\d+)\?ref.*/);
-  if (match) {
-    return match[1];
-  }
-
-  return momentid;
 }
 
 /**

--- a/build-system/amp.extern.js
+++ b/build-system/amp.extern.js
@@ -272,6 +272,7 @@ twttr.events;
 twttr.events.bind;
 twttr.widgets;
 twttr.widgets.createTweet;
+twttr.widgets.createMoment;
 
 var FB;
 FB.init;

--- a/examples/twitter.amp.html
+++ b/examples/twitter.amp.html
@@ -45,6 +45,13 @@
       data-cards="hidden">
   </amp-twitter>
 
+  <h2>Moments</h2>
+  <amp-twitter width=486 height=1312
+      layout="responsive"
+      data-momentid="1009149991452135424"
+      data-limit="2">
+  </amp-twitter>
+
   <h2>Intentionally non-existing-tweet</h2>
   <amp-twitter width=390 height=330
       layout="fixed"

--- a/extensions/amp-twitter/0.1/test/test-amp-twitter.js
+++ b/extensions/amp-twitter/0.1/test/test-amp-twitter.js
@@ -15,7 +15,7 @@
  */
 
 import '../amp-twitter';
-import {cleanupTweetId_} from '../../../../3p/twitter';
+import {cleanupMomentId_, cleanupTweetId_} from '../../../../3p/twitter';
 import {twitter} from '../../../../3p/twitter';
 
 describes.realWin('amp-twitter', {
@@ -54,13 +54,28 @@ describes.realWin('amp-twitter', {
     });
   });
 
-  it('adds tweet element correctly', () => {
+  it('adds tweet element correctly for a tweet', () => {
     const div = doc.createElement('div');
     div.setAttribute('id', 'c');
     doc.body.appendChild(div);
 
     twitter(win, {
       tweetid: tweetId,
+      width: 111,
+      height: 222,
+    });
+    const tweet = doc.body.querySelector('#tweet');
+    expect(tweet).not.to.be.undefined;
+  });
+
+  it('adds tweet element correctly for a moment', () => {
+    const div = doc.createElement('div');
+    div.setAttribute('id', 'c');
+    doc.body.appendChild(div);
+
+    twitter(win, {
+      momentid: tweetId,
+      limit: 5,
       width: 111,
       height: 222,
     });
@@ -140,4 +155,20 @@ describes.realWin('amp-twitter', {
     });
   });
 
+  describe('cleanupMomentId_', () => {
+    const momentId = '1009149991452135424';
+
+    it('does not affect valid moment ids', () => {
+      expect(cleanupMomentId_(momentId)).to.equal(momentId);
+    });
+
+    it('cleans up bad moment full Url', () => {
+      const bad = `https://twitter.com/i/moments/${momentId}` +
+          '?ref_src=twsrc%5Etfw&ref_url=http%3A%2F%2Fads.localhost%3A8000%2F' +
+          'dist.3p%2Fcurrent%2Fframe.max.html';
+
+      expect(cleanupMomentId_(bad)).to.equal(momentId);
+    });
+
+  });
 });

--- a/extensions/amp-twitter/0.1/test/test-amp-twitter.js
+++ b/extensions/amp-twitter/0.1/test/test-amp-twitter.js
@@ -15,7 +15,7 @@
  */
 
 import '../amp-twitter';
-import {cleanupMomentId_, cleanupTweetId_} from '../../../../3p/twitter';
+import {cleanupTweetId_} from '../../../../3p/twitter';
 import {twitter} from '../../../../3p/twitter';
 
 describes.realWin('amp-twitter', {
@@ -153,22 +153,5 @@ describes.realWin('amp-twitter', {
 
       expect(cleanupTweetId_(bad)).to.equal(tweetId);
     });
-  });
-
-  describe('cleanupMomentId_', () => {
-    const momentId = '1009149991452135424';
-
-    it('does not affect valid moment ids', () => {
-      expect(cleanupMomentId_(momentId)).to.equal(momentId);
-    });
-
-    it('cleans up bad moment full Url', () => {
-      const bad = `https://twitter.com/i/moments/${momentId}` +
-          '?ref_src=twsrc%5Etfw&ref_url=http%3A%2F%2Fads.localhost%3A8000%2F' +
-          'dist.3p%2Fcurrent%2Fframe.max.html';
-
-      expect(cleanupMomentId_(bad)).to.equal(momentId);
-    });
-
   });
 });

--- a/extensions/amp-twitter/0.1/test/validator-amp-twitter.html
+++ b/extensions/amp-twitter/0.1/test/validator-amp-twitter.html
@@ -61,6 +61,13 @@
       data-cards="hidden">
   </amp-twitter>
 
+  <h2>Moment</h2>
+  <amp-twitter width=486 height=1312
+      layout="responsive"
+      data-momentid="1009149991452135424"
+      data-limit="2">
+  </amp-twitter>
+
   <h2>Intentionally non-existing-tweet</h2>
   <amp-twitter width=390 height=330
       layout="responsive"
@@ -69,5 +76,24 @@
       <blockquote placeholder class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">A new approach to web performance.<br><br>Today we are starting the AMP Project to make mobile web content fast again.<a href="https://t.co/b091YOzo5s">https://t.co/b091YOzo5s</a></p>&mdash; Malte Ubl (@cramforce) <a href="https://twitter.com/cramforce/status/651762967147483136">October 7, 2015</a></blockquote>
   </amp-twitter>
 
+  <h2>Missing tweet/momentid</h2>
+  <amp-twitter width=486 height=1312
+      layout="responsive"
+      data-mooomentid="1009149991452135424">
+  </amp-twitter>
+
+  <h2>Using cards with momentid</h2>
+  <amp-twitter width=486 height=1312
+      layout="responsive"
+      data-momentid="1009149991452135424"
+      data-cards="hidden">
+  </amp-twitter>
+
+  <h2>Using limit with tweetid</h2>  
+  <amp-twitter width=486 height=1312
+      layout="responsive"
+      data-tweetid="585110598171631616"
+      data-limit="42">
+  </amp-twitter>
 </body>
 </html>

--- a/extensions/amp-twitter/0.1/test/validator-amp-twitter.html
+++ b/extensions/amp-twitter/0.1/test/validator-amp-twitter.html
@@ -76,10 +76,15 @@
       <blockquote placeholder class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">A new approach to web performance.<br><br>Today we are starting the AMP Project to make mobile web content fast again.<a href="https://t.co/b091YOzo5s">https://t.co/b091YOzo5s</a></p>&mdash; Malte Ubl (@cramforce) <a href="https://twitter.com/cramforce/status/651762967147483136">October 7, 2015</a></blockquote>
   </amp-twitter>
 
-  <h2>Missing tweet/momentid</h2>
+  <h2>Missing tweetid/momentid</h2>
+  <amp-twitter width=486 height=1312
+      layout="responsive">
+  </amp-twitter>
+
+  <h2>Non-number momentid</h2>  
   <amp-twitter width=486 height=1312
       layout="responsive"
-      data-mooomentid="1009149991452135424">
+      data-momentid="https://twitter.com/i/moments/1009149991452135424">
   </amp-twitter>
 
   <h2>Using cards with momentid</h2>

--- a/extensions/amp-twitter/0.1/test/validator-amp-twitter.out
+++ b/extensions/amp-twitter/0.1/test/validator-amp-twitter.out
@@ -1,4 +1,4 @@
-PASS
+FAIL
 |  <!--
 |    Copyright 2017 The AMP HTML Authors. All Rights Reserved.
 |  
@@ -62,6 +62,13 @@ PASS
 |        data-cards="hidden">
 |    </amp-twitter>
 |  
+|    <h2>Moment</h2>
+|    <amp-twitter width=486 height=1312
+|        layout="responsive"
+|        data-momentid="1009149991452135424"
+|        data-limit="2">
+|    </amp-twitter>
+|  
 |    <h2>Intentionally non-existing-tweet</h2>
 |    <amp-twitter width=390 height=330
 |        layout="responsive"
@@ -70,5 +77,30 @@ PASS
 |        <blockquote placeholder class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">A new approach to web performance.<br><br>Today we are starting the AMP Project to make mobile web content fast again.<a href="https://t.co/b091YOzo5s">https://t.co/b091YOzo5s</a></p>&mdash; Malte Ubl (@cramforce) <a href="https://twitter.com/cramforce/status/651762967147483136">October 7, 2015</a></blockquote>
 |    </amp-twitter>
 |  
+|    <h2>Missing tweet/momentid</h2>
+|    <amp-twitter width=486 height=1312
+>>   ^~~~~~~~~
+amp-twitter/0.1/test/validator-amp-twitter.html:80:2 The tag 'amp-twitter' is missing a mandatory attribute - pick one of ['data-tweetid', 'data-momentid']. (see https://www.ampproject.org/docs/reference/components/amp-twitter) [AMP_TAG_PROBLEM]
+|        layout="responsive"
+|        data-mooomentid="1009149991452135424">
+|    </amp-twitter>
+|  
+|    <h2>Using cards with momentid</h2>
+|    <amp-twitter width=486 height=1312
+>>   ^~~~~~~~~
+amp-twitter/0.1/test/validator-amp-twitter.html:86:2 The attribute 'data-tweetid' in tag 'amp-twitter' is missing or incorrect, but required by attribute 'data-cards'. (see https://www.ampproject.org/docs/reference/components/amp-twitter) [DISALLOWED_HTML]
+|        layout="responsive"
+|        data-momentid="1009149991452135424"
+|        data-cards="hidden">
+|    </amp-twitter>
+|  
+|    <h2>Using limit with tweetid</h2>  
+|    <amp-twitter width=486 height=1312
+>>   ^~~~~~~~~
+amp-twitter/0.1/test/validator-amp-twitter.html:93:2 The attribute 'data-momentid' in tag 'amp-twitter' is missing or incorrect, but required by attribute 'data-limit'. (see https://www.ampproject.org/docs/reference/components/amp-twitter) [DISALLOWED_HTML]
+|        layout="responsive"
+|        data-tweetid="585110598171631616"
+|        data-limit="42">
+|    </amp-twitter>
 |  </body>
 |  </html>

--- a/extensions/amp-twitter/0.1/test/validator-amp-twitter.out
+++ b/extensions/amp-twitter/0.1/test/validator-amp-twitter.out
@@ -77,18 +77,25 @@ FAIL
 |        <blockquote placeholder class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">A new approach to web performance.<br><br>Today we are starting the AMP Project to make mobile web content fast again.<a href="https://t.co/b091YOzo5s">https://t.co/b091YOzo5s</a></p>&mdash; Malte Ubl (@cramforce) <a href="https://twitter.com/cramforce/status/651762967147483136">October 7, 2015</a></blockquote>
 |    </amp-twitter>
 |  
-|    <h2>Missing tweet/momentid</h2>
+|    <h2>Missing tweetid/momentid</h2>
 |    <amp-twitter width=486 height=1312
 >>   ^~~~~~~~~
 amp-twitter/0.1/test/validator-amp-twitter.html:80:2 The tag 'amp-twitter' is missing a mandatory attribute - pick one of ['data-tweetid', 'data-momentid']. (see https://www.ampproject.org/docs/reference/components/amp-twitter) [AMP_TAG_PROBLEM]
+|        layout="responsive">
+|    </amp-twitter>
+|  
+|    <h2>Non-number momentid</h2>  
+|    <amp-twitter width=486 height=1312
+>>   ^~~~~~~~~
+amp-twitter/0.1/test/validator-amp-twitter.html:85:2 The attribute 'data-momentid' in tag 'amp-twitter' is set to the invalid value 'https://twitter.com/i/moments/1009149991452135424'. (see https://www.ampproject.org/docs/reference/components/amp-twitter) [DISALLOWED_HTML]
 |        layout="responsive"
-|        data-mooomentid="1009149991452135424">
+|        data-momentid="https://twitter.com/i/moments/1009149991452135424">
 |    </amp-twitter>
 |  
 |    <h2>Using cards with momentid</h2>
 |    <amp-twitter width=486 height=1312
 >>   ^~~~~~~~~
-amp-twitter/0.1/test/validator-amp-twitter.html:86:2 The attribute 'data-tweetid' in tag 'amp-twitter' is missing or incorrect, but required by attribute 'data-cards'. (see https://www.ampproject.org/docs/reference/components/amp-twitter) [DISALLOWED_HTML]
+amp-twitter/0.1/test/validator-amp-twitter.html:91:2 The attribute 'data-tweetid' in tag 'amp-twitter' is missing or incorrect, but required by attribute 'data-cards'. (see https://www.ampproject.org/docs/reference/components/amp-twitter) [DISALLOWED_HTML]
 |        layout="responsive"
 |        data-momentid="1009149991452135424"
 |        data-cards="hidden">
@@ -97,7 +104,7 @@ amp-twitter/0.1/test/validator-amp-twitter.html:86:2 The attribute 'data-tweetid
 |    <h2>Using limit with tweetid</h2>  
 |    <amp-twitter width=486 height=1312
 >>   ^~~~~~~~~
-amp-twitter/0.1/test/validator-amp-twitter.html:93:2 The attribute 'data-momentid' in tag 'amp-twitter' is missing or incorrect, but required by attribute 'data-limit'. (see https://www.ampproject.org/docs/reference/components/amp-twitter) [DISALLOWED_HTML]
+amp-twitter/0.1/test/validator-amp-twitter.html:98:2 The attribute 'data-momentid' in tag 'amp-twitter' is missing or incorrect, but required by attribute 'data-limit'. (see https://www.ampproject.org/docs/reference/components/amp-twitter) [DISALLOWED_HTML]
 |        layout="responsive"
 |        data-tweetid="585110598171631616"
 |        data-limit="42">

--- a/extensions/amp-twitter/amp-twitter.md
+++ b/extensions/amp-twitter/amp-twitter.md
@@ -93,13 +93,16 @@ Visit the [Placeholders & fallbacks](https://www.ampproject.org/docs/guides/resp
 
 ## Attributes
 
-##### data-tweetid (required)
+##### data-tweetid / data-momentid (required)
 
-The ID of the Tweet. In a URL like https://twitter.com/joemccann/status/640300967154597888,  `640300967154597888` is the tweetID.
+The ID of the Tweet or Moment.
+In a URL like https://twitter.com/joemccann/status/640300967154597888,  `640300967154597888` is the tweet id.
+In a URL like https://twitter.com/i/moments/1009149991452135424, `1009149991452135424` is the moment id.
 
 ##### data-* (optional)
 
-You can specify options for the Tweet appearance by setting `data-` attributes. For example, `data-cards="hidden"` deactivates Twitter cards. For details on the available options, see [Twitter's docs](https://dev.twitter.com/web/javascript/creating-widgets#create-tweet).
+You can specify options for the Tweet appearance by setting `data-` attributes. For example, `data-cards="hidden"` deactivates Twitter cards.
+For details on the available options, see Twitter's docs [for tweets](https://developer.twitter.com/en/docs/twitter-for-websites/embedded-tweets/guides/embedded-tweet-parameter-reference) and [for moments](https://developer.twitter.com/en/docs/twitter-for-websites/moments/guides/parameter-reference0). 
 
 <div>
 <amp-iframe height="202"

--- a/extensions/amp-twitter/validator-amp-twitter.protoascii
+++ b/extensions/amp-twitter/validator-amp-twitter.protoascii
@@ -30,10 +30,47 @@ tags: {  # <amp-twitter>
   html_format: AMP
   tag_name: "AMP-TWITTER"
   requires_extension: "amp-twitter"
+  # Tweets
   attrs: {
     name: "data-tweetid"
-    mandatory: true
+    mandatory_oneof: "['data-tweetid', 'data-momentid']"
   }
+  attrs: {
+    name: "data-conversation"
+    trigger: {
+      also_requires_attr: "data-tweetid"
+    }
+  }
+  attrs: {
+    name: "data-cards"
+    trigger: {
+      also_requires_attr: "data-tweetid"
+    }
+  }
+  attrs: {
+    name: "data-theme"
+    trigger: {
+      also_requires_attr: "data-tweetid"
+    }
+  }
+  attrs: {
+    name: "data-link-color"
+    trigger: {
+      also_requires_attr: "data-tweetid"
+    }
+  }
+  # Moments
+  attrs: {
+    name: "data-momentid"
+    mandatory_oneof: "['data-tweetid', 'data-momentid']"
+  }
+  attrs: {
+    name: "data-limit"
+    trigger: {
+      also_requires_attr: "data-momentid"
+    }
+  }
+  # All
   attr_lists: "extended-amp-global"
   amp_layout: {
     supported_layouts: FILL

--- a/extensions/amp-twitter/validator-amp-twitter.protoascii
+++ b/extensions/amp-twitter/validator-amp-twitter.protoascii
@@ -30,10 +30,11 @@ tags: {  # <amp-twitter>
   html_format: AMP
   tag_name: "AMP-TWITTER"
   requires_extension: "amp-twitter"
-  # Tweets
   attrs: {
-    name: "data-tweetid"
-    mandatory_oneof: "['data-tweetid', 'data-momentid']"
+    name: "data-cards"
+    trigger: {
+      also_requires_attr: "data-tweetid"
+    }
   }
   attrs: {
     name: "data-conversation"
@@ -42,15 +43,9 @@ tags: {  # <amp-twitter>
     }
   }
   attrs: {
-    name: "data-cards"
+    name: "data-limit"
     trigger: {
-      also_requires_attr: "data-tweetid"
-    }
-  }
-  attrs: {
-    name: "data-theme"
-    trigger: {
-      also_requires_attr: "data-tweetid"
+      also_requires_attr: "data-momentid"
     }
   }
   attrs: {
@@ -59,16 +54,20 @@ tags: {  # <amp-twitter>
       also_requires_attr: "data-tweetid"
     }
   }
-  # Moments
   attrs: {
     name: "data-momentid"
     mandatory_oneof: "['data-tweetid', 'data-momentid']"
+    value_regex: "\\d+"
   }
   attrs: {
-    name: "data-limit"
+    name: "data-theme"
     trigger: {
-      also_requires_attr: "data-momentid"
+      also_requires_attr: "data-tweetid"
     }
+  }
+  attrs: {
+    name: "data-tweetid"
+    mandatory_oneof: "['data-tweetid', 'data-momentid']"
   }
   # All
   attr_lists: "extended-amp-global"


### PR DESCRIPTION
- Add data-momentid attribute support for `<amp-twitter>`, which embeds a moment instead of a tweet.
- Update validation  to enforce that either a `data-tweetid` or `data-momentid` is specified.
- Update validation to make sure options are specified correctly (e.g. `data-limit` is not used with `data-tweetid`).

Closes #13521

/cc @aghassemi 