### PR TITLE
✅🐛 Skip date picker integration tests to unflake master

### DIFF
--- a/extensions/amp-date-picker/0.1/test/integration/test-integration-amp-date-picker-actions.js
+++ b/extensions/amp-date-picker/0.1/test/integration/test-integration-amp-date-picker-actions.js
@@ -19,7 +19,8 @@ import {poll} from '../../../../../testing/iframe';
 import {toggleExperiment} from '../../../../../src/experiments';
 
 const config = describe.configure().ifNewChrome();
-config.run('amp-date-picker', function() {
+config.skip('amp-date-picker', function() {
+  this.skip(); // TODO(cvializ): unskip
   this.timeout(10000);
 
   const extensions = ['amp-date-picker'];


### PR DESCRIPTION
@cathyxz Looks like it was flaking on Chrome Windows, which @choumx suggested may be an especially flaky platform. If these tests are still flaking more, feel free to merge this PR