### PR TITLE
Skip flaky 3d-gltf test

### DIFF
--- a/extensions/amp-3d-gltf/0.1/test/test-amp-3d-gltf.js
+++ b/extensions/amp-3d-gltf/0.1/test/test-amp-3d-gltf.js
@@ -95,7 +95,8 @@ describes.realWin('amp-3d-gltf', {
         });
   });
 
-  it('sends toggleAmpViewport(true) when entering viewport', () => {
+  // TODO (#16080): this test times out on Travis. Re-enable when fixed.
+  it.skip('sends toggleAmpViewport(true) when entering viewport', () => {
     return createElement()
         .then(amp3dGltf => {
           const postMessageSpy = sandbox.spy(amp3dGltf, 'postMessage_');


### PR DESCRIPTION
Apparently ALL the tests for `3d-gltf` are flaky. Somehow they were just not flaky at the same time. 