### PR TITLE
Update sra.md

### DIFF
--- a/extensions/amp-ad-network-doubleclick-impl/sra.md
+++ b/extensions/amp-ad-network-doubleclick-impl/sra.md
@@ -19,7 +19,7 @@ limitations under the License.
 Enabling SRA allows a publisher to make a single request for all ad slots on the AMP page which gives a publisher the ability to do roadblocking and competitive exclusions. This very similar to the behavior achieved on non-AMP pages when using [this](https://developers.google.com/doubleclick-gpt/reference#googletag.PubAdsService_enableSingleRequest) method in GPT.
 
 In order to use this feature, add the following meta tag to the head of the AMP page:
-`<meta name=”amp-ad-doubleclick-sra”/>`
+`<meta name="amp-ad-doubleclick-sra"/>`
 
 Note that SRA is only available if:
 1. The AMP page is served from a valid AMP cache, and


### PR DESCRIPTION
Fixes the name of the SRA meta tag so that it can be copied and pasted into a document and work correctly.

Previously, in the docs for enabling SRA on Amp pages, the meta tag as provided would not correctly trigger SRA. I changed the name attribute of the tag so that the quotes correctly match what is expected to trigger it. This means that the tag can now be copy and pasted on to a page and SRA will correctly trigger.
