### PR TITLE
Update the cherry pick template to handle cherry picks that need to go into prod&canary

### DIFF
--- a/.github/ISSUE_TEMPLATE/cherry_pick_template.md
+++ b/.github/ISSUE_TEMPLATE/cherry_pick_template.md
@@ -21,7 +21,7 @@ PR #<PR_NUMBER>
 
 Production Release? <YES/NO>  If yes, Type: Release Issue #<PRODUCTION_RELEASE_ISSUE>
 
-Canary release? <YES/NO>  If yes, Type: Release Issue #<CANARY_RELEASE_ISSUE>
+Canary release? <YES/NO>  If yes, Type: Release Issue #<CANARY_RELEASE_ISSUE>, otherwise <WHY_THIS_IS_NOT_NEEDED>
 
 
 *Why does this issue meet the [cherry pick criteria](https://github.com/ampproject/amphtml/blob/master/contributing/release-schedule.md#cherry-pick-criteria)?  Be specific.*

--- a/.github/ISSUE_TEMPLATE/cherry_pick_template.md
+++ b/.github/ISSUE_TEMPLATE/cherry_pick_template.md
@@ -5,18 +5,21 @@
 Issue #<ISSUE_NUMBER>
 
 *PR that you are requesting a cherry pick for:*
+
 *(Put N/A if you do not yet have a PR with a fix if you are seeking pre-approval for a cherry pick.  Edit this issue's body to add the PR number once it is available.)*
 
 PR #<PR_NUMBER>
 
 *[Type: Release](https://github.com/ampproject/amphtml/labels/Type%3A%20Release) issue for the release build you are requesting a cherry pick into:*
 
+*(If you need to cherry pick into production AND the current canary please list both issues here.)*
+
 Release Issue #<RELEASE_ISSUE_NUMBER>
 
-*Is this request for a cherry pick into a canary or a production release?*
-*(If you are requesting a cherry pick into a production release you may need to file a separate cherry pick request for the current canary as well.  See the [cherry pick documentation](https://github.com/ampproject/amphtml/blob/master/contributing/release-schedule.md#cherry-picks).)*
+*Is this request for a cherry pick into the current production release, a canary release or both?*
+*(If you are requesting a cherry pick into a production release you will most likely need to cherry pick into canary as well, otherwise when the canary is pushed to production your fix will be lost.  See the [cherry pick documentation](https://github.com/ampproject/amphtml/blob/master/contributing/release-schedule.md#cherry-picks).)*
 
-<CANARY_OR_PRODUCTION>
+<PRODUCTION_CANARY_OR_BOTH>
 
 *Why does this issue meet the [cherry pick criteria](https://github.com/ampproject/amphtml/blob/master/contributing/release-schedule.md#cherry-pick-criteria)?  Be specific.*
 

--- a/.github/ISSUE_TEMPLATE/cherry_pick_template.md
+++ b/.github/ISSUE_TEMPLATE/cherry_pick_template.md
@@ -1,29 +1,33 @@
 **Replace *everything* in angle brackets in the title AND body of this issue.  If you have any questions see the [cherry pick documentation](https://github.com/ampproject/amphtml/blob/master/contributing/release-schedule.md#cherry-picks).**
 
-*GitHub issue your cherry pick is fixing:*
+
+**GitHub issue your cherry pick is fixing:**
 
 Issue #<ISSUE_NUMBER>
 
-*PR that you are requesting a cherry pick for:*
 
-*(Put N/A if you do not yet have a PR with a fix if you are seeking pre-approval for a cherry pick.  Edit this issue's body to add the PR number once it is available.)*
+**PR that you are requesting a cherry pick for:**
+
+*(Put N/A if you do not yet have a PR with a fix; edit this issue to add it when the PR is ready.)*
 
 PR #<PR_NUMBER>
 
-*[Type: Release](https://github.com/ampproject/amphtml/labels/Type%3A%20Release) issue for the release build you are requesting a cherry pick into:*
 
-*(If you need to cherry pick into production AND the current canary please list both issues here.)*
+**Release(s) you requesting this cherry pick into:**
 
-Release Issue #<RELEASE_ISSUE_NUMBER>
+*Release issues can be found at https://github.com/ampproject/amphtml/labels/Type%3A%20Release*
 
-*Is this request for a cherry pick into the current production release, a canary release or both?*
-*(If you are requesting a cherry pick into a production release you will most likely need to cherry pick into canary as well, otherwise when the canary is pushed to production your fix will be lost.  See the [cherry pick documentation](https://github.com/ampproject/amphtml/blob/master/contributing/release-schedule.md#cherry-picks).)*
+*If you are requesting a cherry pick into a production release you will most likely need to cherry pick into canary as well, otherwise when the canary is pushed to production your fix will be lost.  See the [cherry pick documentation](https://github.com/ampproject/amphtml/blob/master/contributing/release-schedule.md#cherry-picks).)*
 
-<PRODUCTION_CANARY_OR_BOTH>
+Production Release? <YES/NO>  If yes, Type: Release Issue #<PRODUCTION_RELEASE_ISSUE>
+
+Canary release? <YES/NO>  If yes, Type: Release Issue #<CANARY_RELEASE_ISSUE>
+
 
 *Why does this issue meet the [cherry pick criteria](https://github.com/ampproject/amphtml/blob/master/contributing/release-schedule.md#cherry-pick-criteria)?  Be specific.*
 
 <YOUR_REASONS>
 
 *Assign this issue to the current TL (cramforce) if you have permission to, otherwise leave this cc line in.*
+
 /cc @cramforce


### PR DESCRIPTION
Updates the cherry pick template to handle the case where a cherry pick needs to go into production and canary.

Initially I had thought having separate issues for a production cherry pick and a canary cherry pick would be easier to keep track of, but since in most cases a cherry pick to production will also need a cherry pick to canary keeping track of them both in one issue is easier (and likely to be less confusing to the filer and onduty).

There is a corner case where the TL wants to approve the cherry pick to canary release build but not to the production release build, but we can handle that through a clear comment.

/cc @zhouyx @choumx @erwinmombay 