### PR TITLE
Reduce AdSense/Doubleclick Fast Fetch CSI collection to 1%

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -12,7 +12,7 @@
 
   "canary": 1,
   "expAdsenseA4A": 0.01,
-  "a4aProfilingRate": 1,
+  "a4aProfilingRate": 0.1,
   "ad-type-custom": 1,
   "ios-embed-wrapper": 1,
   "amp-apester-media": 1,

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -12,7 +12,7 @@
 
   "canary": 0,
   "expAdsenseA4A": 0.01,
-  "a4aProfilingRate": 0.1,
+  "a4aProfilingRate": 0.01,
   "ad-type-custom": 1,
   "ios-embed-wrapper": 1,
   "amp-apester-media": 1,


### PR DESCRIPTION
See https://github.com/ampproject/amphtml/issues/16200 reducing CSI collection rate from 10% to 1% for production and 100% to 10% for canary.  Will consider removing unnecessary pings in separate PR.