### PR TITLE
throws error when using invalid component type in the config.

### DIFF
--- a/examples/amp-story/json/bookend.json
+++ b/examples/amp-story/json/bookend.json
@@ -7,8 +7,8 @@
   ],
   "components": [
     {
-      "type": "article-set-title",
-      "title": "Getting Started"
+      "type": "heading",
+      "text": "Getting Started"
     },
     {
       "type": "small",
@@ -24,8 +24,8 @@
     },
 
     {
-      "type": "article-set-title",
-      "title": "Animation Examples"
+      "type": "heading",
+      "text": "Animation Examples"
     },
     {
       "type": "small",
@@ -47,8 +47,8 @@
     },
 
     {
-      "type": "article-set-title",
-      "title": "Bookend Examples"
+      "type": "heading",
+      "text": "Bookend Examples"
     },
     {
       "type": "small",
@@ -64,8 +64,8 @@
     },
 
     {
-      "type": "article-set-title",
-      "title": "Layers"
+      "type": "heading",
+      "text": "Layers"
     },
     {
       "type": "small",
@@ -81,8 +81,8 @@
     },
 
     {
-      "type": "article-set-title",
-      "title": "Miscellaneous"
+      "type": "heading",
+      "text": "Miscellaneous"
     },
     {
       "type": "small",

--- a/extensions/amp-story/1.0/bookend/bookend-component.js
+++ b/extensions/amp-story/1.0/bookend/bookend-component.js
@@ -22,6 +22,7 @@ import {LandscapeComponent, LandscapeComponentDef} from './components/landscape'
 import {PortraitComponent, PortraitComponentDef} from './components/portrait';
 import {TextBoxComponent, TextBoxComponentDef} from './components/text-box';
 import {htmlFor} from '../../../../src/static-template';
+import {user} from '../../../../src/log';
 
 /** @type {string} */
 export const TAG = 'amp-story-bookend';
@@ -116,9 +117,8 @@ export class BookendComponent {
   static buildFromJson(components, el) {
     return components.reduce((builtComponents, component) => {
       const componentBuilder = componentBuilderInstanceFor(component.type);
-      if (!componentBuilder) {
-        return;
-      }
+      user().assert(componentBuilder, 'Component type `' + component.type +
+      '` is not supported.');
       componentBuilder.assertValidity(component, el);
       builtComponents.push(componentBuilder.build(component, el));
       return builtComponents;

--- a/extensions/amp-story/1.0/bookend/bookend-component.js
+++ b/extensions/amp-story/1.0/bookend/bookend-component.js
@@ -21,8 +21,8 @@ import {HeadingComponent, HeadingComponentDef} from './components/heading';
 import {LandscapeComponent, LandscapeComponentDef} from './components/landscape';
 import {PortraitComponent, PortraitComponentDef} from './components/portrait';
 import {TextBoxComponent, TextBoxComponentDef} from './components/text-box';
+import {dev} from '../../../../src/log';
 import {htmlFor} from '../../../../src/static-template';
-import {user} from '../../../../src/log';
 
 /** @type {string} */
 export const TAG = 'amp-story-bookend';
@@ -117,8 +117,11 @@ export class BookendComponent {
   static buildFromJson(components, el) {
     return components.reduce((builtComponents, component) => {
       const componentBuilder = componentBuilderInstanceFor(component.type);
-      user().assert(componentBuilder, 'Component type `' + component.type +
-      '` is not supported.');
+      if (!componentBuilder) {
+        dev().error('Component type `' + component.type +
+        '` is not supported. Skipping invalid.');
+        return builtComponents;
+      }
       componentBuilder.assertValidity(component, el);
       builtComponents.push(componentBuilder.build(component, el));
       return builtComponents;

--- a/extensions/amp-story/1.0/bookend/bookend-component.js
+++ b/extensions/amp-story/1.0/bookend/bookend-component.js
@@ -118,7 +118,7 @@ export class BookendComponent {
     return components.reduce((builtComponents, component) => {
       const componentBuilder = componentBuilderInstanceFor(component.type);
       if (!componentBuilder) {
-        dev().error('Component type `' + component.type +
+        dev().error(TAG, 'Component type `' + component.type +
         '` is not supported. Skipping invalid.');
         return builtComponents;
       }

--- a/extensions/amp-story/1.0/test/test-amp-story-bookend.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-bookend.js
@@ -865,7 +865,7 @@ describes.realWin('amp-story-bookend', {amp: true}, env => {
     expect(promptButtonEl).to.be.null;
   });
 
-  it('should reject invalid component name', () => {
+  it('should skip invalid component name and continue building', () => {
     const userJson = {
       'bookendVersion': 'v1.0',
       'shareProviders': [
@@ -880,8 +880,9 @@ describes.realWin('amp-story-bookend', {amp: true}, env => {
         },
         {
           'type': 'small',
+          'title': 'This is an example article',
+          'domainName': 'example.com',
           'url': 'http://example.com/article.html',
-          'title': 'example',
           'image': 'http://placehold.it/256x128',
         },
       ],
@@ -893,6 +894,9 @@ describes.realWin('amp-story-bookend', {amp: true}, env => {
     bookend.build();
     expectAsyncConsoleError(/[Component `invalid-type` is not supported. Skipping invalid]/);
 
-    return bookend.loadConfigAndMaybeRenderBookend();
+    return bookend.loadConfigAndMaybeRenderBookend().then(config => {
+      // Still builds rest of valid components.
+      expect(config.components[0]).to.deep.equal(userJson.components[1]);
+    });
   });
 });

--- a/extensions/amp-story/1.0/test/test-amp-story-bookend.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-bookend.js
@@ -27,12 +27,7 @@ import {createElementWithAttributes} from '../../../../src/dom';
 import {registerServiceBuilder} from '../../../../src/service';
 import {user} from '../../../../src/log';
 
-describes.realWin('amp-story-bookend', {
-  amp: {
-    runtimeOn: true,
-    extensions: ['amp-story:1.0'],
-  },
-}, env => {
+describes.realWin('amp-story-bookend', {amp: true}, env => {
   let win;
   let storyElem;
   let bookend;
@@ -868,5 +863,36 @@ describes.realWin('amp-story-bookend', {
         bookend.getShadowRoot().querySelector('[on$=".prompt"]');
 
     expect(promptButtonEl).to.be.null;
+  });
+
+  it('should reject invalid component name', () => {
+    const userJson = {
+      'bookendVersion': 'v1.0',
+      'shareProviders': [
+        'email',
+        {'provider': 'facebook', 'app-id': '254325784911610'},
+        'whatsapp',
+      ],
+      'components': [
+        {
+          'type': 'invalid-type',
+          'title': 'test',
+        },
+        {
+          'type': 'small',
+          'url': 'http://example.com/article.html',
+          'title': 'example',
+          'image': 'http://placehold.it/256x128',
+        },
+      ],
+    };
+
+    sandbox.stub(bookend.requestService_, 'loadBookendConfig')
+        .resolves(userJson);
+
+    bookend.build();
+    expectAsyncConsoleError(/[Component `invalid-type` is not supported. Skipping invalid]/);
+
+    return bookend.loadConfigAndMaybeRenderBookend();
   });
 });


### PR DESCRIPTION
Fixes #15669

Whenever an invalid `type` of `component` inside a bookend config was used, the error: `Error fetching bookend configuration Cannot read property 'push' of undefined` was thrown.

We should at least let the user know what is wrong with their configuration.

I tried adding a test with the help of @gmajoulet but decided to leave it for a follow-up since it has some level of complexity.