### PR TITLE
Fixes style for ads in right-to-left oriented elements.

### DIFF
--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -509,8 +509,10 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
       // Nudge into the correct horizontal position by changing side margin.
       this.getVsync().run({
         measure: state => {
+          // Check the parent element because amp-ad is explicitly styled to
+          // have direction: ltr.
           state.direction =
-            computedStyle(this.win, this.element)['direction'];
+            computedStyle(this.win, this.element.parentElement)['direction'];
         },
         mutate: state => {
           if (state.direction == 'rtl') {

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -512,7 +512,8 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
           // Check the parent element because amp-ad is explicitly styled to
           // have direction: ltr.
           state.direction =
-            computedStyle(this.win, this.element.parentElement)['direction'];
+            computedStyle(this.win,
+                dev().assertElement(this.element.parentElement))['direction'];
         },
         mutate: state => {
           if (state.direction == 'rtl') {

--- a/extensions/amp-ad/0.1/amp-ad.css
+++ b/extensions/amp-ad/0.1/amp-ad.css
@@ -57,11 +57,8 @@ amp-ad[type="adsense"] > iframe {
   transform: translate(-50%, -50%);
 }
 
-[dir=rtl] amp-ad[data-a4a-upgrade-type="amp-ad-network-doubleclick-impl"] > iframe,
-[dir=rtl] amp-ad[type="adsense"] > iframe {
-  left: 0 !important;
-  right: 50% !important;
-  transform: translate(50%, -50%);
+amp-ad[type="adsense"], amp-ad[type="doubleclick"] {
+  direction: ltr;
 }
 
 amp-ad[data-a4a-upgrade-type="amp-ad-network-doubleclick-impl"] > iframe,


### PR DESCRIPTION
Creatives rendered in an iframe styled with `direction: rtl` appear half cut off. This PR fixes the issue by forcing `direction: ltr` on the amp-ad element. Given that we center the creative iframe within the div, this should be a safe catch-all fix.