### PR TITLE
Improvement to Postprompt UI behavior

### DIFF
--- a/extensions/amp-consent/0.1/amp-consent.js
+++ b/extensions/amp-consent/0.1/amp-consent.js
@@ -106,6 +106,9 @@ export class AmpConsent extends AMP.BaseElement {
 
     /** @const @private {!../../../src/service/vsync-impl.Vsync} */
     this.vsync_ = this.getVsync();
+
+    /** @private {boolean} */
+    this.isPostPromptUIRequired_ = false;
   }
 
   /** @override */
@@ -630,12 +633,18 @@ export class AmpConsent extends AMP.BaseElement {
     // Get current consent state
     return this.consentStateManager_.getConsentInstanceState(instanceId)
         .then(state => {
+          if (state == CONSENT_ITEM_STATE.ACCEPTED ||
+              state == CONSENT_ITEM_STATE.REJECTED) {
+            // Need to display post prompt ui if user previous made a decision
+            this.isPostPromptUIRequired_ = true;
+          }
           if (state == CONSENT_ITEM_STATE.UNKNOWN) {
             if (!this.consentRequired_[instanceId]) {
               this.consentStateManager_.updateConsentInstanceState(
                   instanceId, CONSENT_ITEM_STATE.NOT_REQUIRED);
               return;
             }
+            this.isPostPromptUIRequired_ = true;
             // TODO(@zhouyx):
             // 1. Race condition on consent state change between schedule to
             //    display and display. Add one more check before display
@@ -649,6 +658,10 @@ export class AmpConsent extends AMP.BaseElement {
    * Handles the display of postPromptUI
    */
   handlePostPromptUI_() {
+    if (!this.isPostPromptUIRequired_) {
+      return;
+    }
+
     const {classList} = this.element;
     this.notificationUiManager_.onQueueEmpty(() => {
       if (!this.postPromptUI_) {

--- a/extensions/amp-consent/0.1/test/test-amp-consent.js
+++ b/extensions/amp-consent/0.1/test/test-amp-consent.js
@@ -576,16 +576,13 @@ describes.realWin('amp-consent', {
     });
 
     describe('postPromptUI', () => {
-      beforeEach(() => {
+      it('handle postPromptUI', function* () {
         storageValue = {
           'amp-consent:ABC': CONSENT_ITEM_STATE.ACCEPTED,
           'amp-consent:DEF': CONSENT_ITEM_STATE.ACCEPTED,
           'amp-consent:GH': CONSENT_ITEM_STATE.ACCEPTED,
         };
         ampConsent.buildCallback();
-      });
-
-      it('handle postPromptUI', function* () {
         expect(ampConsent.postPromptUI_).to.not.be.null;
         expect(computedStyle(ampConsent.win, ampConsent.element)['display'])
             .to.equal('none');
@@ -602,6 +599,50 @@ describes.realWin('amp-consent', {
         ampConsent.scheduleDisplay_('ABC');
         expect(computedStyle(ampConsent.win, ampConsent.postPromptUI_)
             ['display']).to.equal('none');
+      });
+
+      describe('hide/show postPromptUI', () => {
+        beforeEach(() => {
+          defaultConfig = {
+            'consents': {
+              'ABC': {
+                'checkConsentHref': '//response3',
+              },
+            },
+            'postPromptUI': 'test',
+          };
+          consentElement = doc.createElement('amp-consent');
+          consentElement.setAttribute('id', 'amp-consent');
+          consentElement.setAttribute('layout', 'nodisplay');
+          const scriptElement = doc.createElement('script');
+          scriptElement.setAttribute('type', 'application/json');
+          scriptElement.textContent = JSON.stringify(defaultConfig);
+          consentElement.appendChild(scriptElement);
+          postPromptUI = doc.createElement('div');
+          postPromptUI.setAttribute('id', 'test');
+          consentElement.appendChild(postPromptUI);
+          doc.body.appendChild(consentElement);
+          ampConsent = new AmpConsent(consentElement);
+        });
+
+        it('hide postPromptUI', function* () {
+          ampConsent.buildCallback();
+          expect(ampConsent.postPromptUI_).to.not.be.null;
+          yield macroTask();
+          expect(computedStyle(ampConsent.win, ampConsent.postPromptUI_)
+              ['display']).to.equal('none');
+        });
+
+        it('show postPromptUI', function* () {
+          storageValue = {
+            'amp-consent:ABC': CONSENT_ITEM_STATE.ACCEPTED,
+          };
+          ampConsent.buildCallback();
+          expect(ampConsent.postPromptUI_).to.not.be.null;
+          yield macroTask();
+          expect(computedStyle(ampConsent.win, ampConsent.postPromptUI_)
+              ['display']).to.not.equal('none');
+        });
       });
     });
   });

--- a/test/manual/amp-consent-geo.html
+++ b/test/manual/amp-consent-geo.html
@@ -170,13 +170,18 @@
             "promptIfUnknownForGeoGroup": "anz",
             "promptUI": "ui1"
           }
-        }
+        },
+        "postPromptUI": "postPromptUI"
       }</script>
       <div id="ui1">
         Can I load the image??
         <button on="tap:ABC.accept" role="button">Accept</button>
         <button on="tap:ABC.reject" role="button">Reject</button>
         <button on="tap:ABC.dismiss" role="button">Dismiss</button>
+      </div>
+      <div id="postPromptUI">
+        Post Prompt UI
+        <button on="tap:ABC.prompt" role="button">Manage</button>
       </div>
     </amp-consent>
 


### PR DESCRIPTION
For #15361 

As we agreed the logic is 
```
if (consent required) {
  display postPromptUI
}
if (consent not required) {
  if (has local stored state) {
    display postPromptUI
  } else {
    do not display postPromptUI
  }
}
```