### PR TITLE
Ensure divertExperiments() is called last in buildCallback().

### DIFF
--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -221,7 +221,6 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
   /** @override */
   buildCallback() {
     super.buildCallback();
-    this.divertExperiments();
     this.identityTokenPromise_ = Services.viewerForDoc(this.getAmpDoc())
         .whenFirstVisible()
         .then(() => getIdentityToken(this.win, this.getAmpDoc()));
@@ -238,6 +237,10 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
               viewportSize),
           viewportSize.width).catch(() => {});
     }
+
+    // This should happen last, as some diversion criteria rely on some of the
+    // preceding logic (specifically responsive logic).
+    this.divertExperiments();
   }
 
   /** @override */

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
@@ -90,6 +90,8 @@ describes.realWin('amp-ad-network-adsense-impl', {
     isResponsiveStub = sandbox.stub(impl, 'isResponsive_');
   });
 
+  afterEach(() => sandbox.restore());
+
   /**
    * Instantiates element and impl, adding the former to the document of the
    * iframe.

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
@@ -847,8 +847,8 @@ describes.realWin('amp-ad-network-adsense-impl', {
         width: '320',
         height: '150',
       });
-      const isResponsiveSpy = sinon.spy(impl, 'isResponsive_');
-      const divertExperimentsSpy = sinon.spy(impl, 'divertExperiments');
+      const isResponsiveSpy = sandbox.spy(impl, 'isResponsive_');
+      const divertExperimentsSpy = sandbox.spy(impl, 'divertExperiments');
       impl.buildCallback();
       expect(isResponsiveSpy.calledBefore(divertExperimentsSpy)).to.be.true;
     });

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
@@ -90,7 +90,7 @@ describes.realWin('amp-ad-network-adsense-impl', {
     isResponsiveStub = sandbox.stub(impl, 'isResponsive_');
   });
 
-  afterEach(() => sandbox.restore());
+  afterEach(() => env.sandbox.restore());
 
   /**
    * Instantiates element and impl, adding the former to the document of the
@@ -849,8 +849,8 @@ describes.realWin('amp-ad-network-adsense-impl', {
         width: '320',
         height: '150',
       });
-      const isResponsiveSpy = sandbox.spy(impl, 'isResponsive_');
-      const divertExperimentsSpy = sandbox.spy(impl, 'divertExperiments');
+      const isResponsiveSpy = env.sandbox.spy(impl, 'isResponsive_');
+      const divertExperimentsSpy = env.sandbox.spy(impl, 'divertExperiments');
       impl.buildCallback();
       expect(isResponsiveSpy.calledBefore(divertExperimentsSpy)).to.be.true;
     });

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
@@ -841,6 +841,17 @@ describes.realWin('amp-ad-network-adsense-impl', {
         expect(element.offsetWidth).to.equal(VIEWPORT_WIDTH);
       });
     });
+
+    it('should call divertExperiments after isResponsive', () => {
+      constructImpl({
+        width: '320',
+        height: '150',
+      });
+      const isResponsiveSpy = sinon.spy(impl, 'isResponsive_');
+      const divertExperimentsSpy = sinon.spy(impl, 'divertExperiments');
+      impl.buildCallback();
+      expect(isResponsiveSpy.calledBefore(divertExperimentsSpy)).to.be.true;
+    });
   });
 
   describe('#onLayoutMeasure', () => {


### PR DESCRIPTION
Prior to this change, `divertExperiments()` was called before the necessary information to determine whether `isResponsive()` returns true or false is set. This is a problem, since one of the experiments uses `isResponsive()` as part of its eligible traffic check.