### PR TITLE
Fix amp-pan-zoom zoom target bug and relayout bug

### DIFF
--- a/extensions/amp-pan-zoom/0.1/amp-pan-zoom.js
+++ b/extensions/amp-pan-zoom/0.1/amp-pan-zoom.js
@@ -154,7 +154,7 @@ export class AmpPanZoom extends AMP.BaseElement {
         children[0].tagName + ` is not supported by ${TAG}`
     );
     this.content_ = children[0];
-
+    this.content_.classList.add('i-amphtml-pan-zoom-child');
     this.maxScale_ = this.getNumberAttributeOr_('max-scale', DEFAULT_MAX_SCALE);
     this.initialScale_ = this.getNumberAttributeOr_('initial-scale', 1);
     this.initialX_ = this.getNumberAttributeOr_('initial-x', 0);
@@ -181,13 +181,11 @@ export class AmpPanZoom extends AMP.BaseElement {
 
   /** @override */
   layoutCallback() {
-    this.content_.classList.add('i-amphtml-pan-zoom-child');
-    return this.resetContentDimensions_()
-        .then(() => {
-          if (!this.gestures_) {
-            this.setupGestures_();
-          }
-        });
+    return this.resetContentDimensions_().then(() => {
+      if (!this.gestures_) {
+        this.setupGestures_();
+      }
+    });
   }
 
   /** @override */
@@ -218,11 +216,6 @@ export class AmpPanZoom extends AMP.BaseElement {
       layout == Layout.FIXED_HEIGHT ||
       layout == Layout.FILL ||
       layout == Layout.RESPONSIVE;
-  }
-
-  /** @override */
-  isRelayoutNeeded() {
-    return true;
   }
 
   /**

--- a/test/manual/amp-pan-zoom-integration.amp.html
+++ b/test/manual/amp-pan-zoom-integration.amp.html
@@ -1,0 +1,137 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>AMP Pan Zoom Demo</title>
+  <link rel="canonical" href="amps.html" >
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
+  <script async custom-element="amp-pan-zoom" src="https://cdn.ampproject.org/v0/amp-pan-zoom-0.1.js"></script>
+  <script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script>
+  <style amp-custom>
+
+    .container {
+      height: 600;
+      width: 600;
+    }
+
+    .seat-free,
+    .seat-taken,
+    .seat-selected {
+      width: 10px;
+      height: 10px;
+      transition: fill .4s ease;
+    }
+
+    .area-free,
+    .area-half,
+    .area-full {
+      width: 40px;
+      height: 40px;
+      fill: black;
+    }
+
+    .area-free {
+      opacity: 0.1;
+    }
+
+    .area-half {
+      opacity: 0.5;
+    }
+
+    .area-full {
+      opacity: 0.8;
+    }
+
+    .hide {
+      display: none;
+    }
+
+    .seat-free {
+      fill: #ccc;
+    }
+    .seat-free:hover {
+      fill: #999;
+      cursor: pointer;
+    }
+    .seat-taken {
+      fill: #000;
+    }
+    .seat-selected {
+      fill: red;
+    }
+
+    #square {
+      height: 300px;
+      width: 300px;
+      background-color: green;
+      border: 20px red solid;
+      box-sizing: border-box;
+    }
+
+    amp-pan-zoom {
+      border: #000 2px solid;
+    }
+  </style>
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+  <amp-state id="seat">
+    <script type="application/json">
+      1
+    </script>
+  </amp-state>
+
+  <amp-state id="scale">
+    <script type="application/json">
+      1
+    </script>
+  </amp-state>
+<article>
+  <h1>AMP Pan Zoom</h1>
+
+    <h1>AMP Pan-Zoom with other content on page</h1>
+    <p [text]="'Current scale: ' + scale">Current scale: 1</p>
+    <amp-img [hidden]="scale > 1" id="img1"
+        src="/examples/img/sample.jpg"
+        width="641" height="481" layout="fixed"></amp-img>
+    <amp-pan-zoom layout="responsive" width="1" height="1" on="transformEnd:AMP.setState({scale: event.scale})">
+      <svg viewBox="0 0 190 110" preserveAspectRatio="xMidYMin slice">
+        <rect class="area-half" x="5" y="5" />
+        <g class="hide" [class]="scale < 2 ? 'hide' : ''" >
+            <rect class="seat-selected" [class]="seat == 1 ? 'seat-selected' : 'seat-free'" on="tap:AMP.setState({seat: 1})" x="10" y="10" tabindex="0" role="button" />
+          <rect class="seat-free" [class]="seat == 2 ? 'seat-selected' : 'seat-free'" on="tap:AMP.setState({seat: 2})" x="30" y="10" tabindex="0" role="button" />
+          <rect class="seat-taken" x="10" y="30" />
+          <rect class="seat-free" [class]="seat == 3 ? 'seat-selected' : 'seat-free'" on="tap:AMP.setState({seat: 3})" x="30" y="30" tabindex="0" role="button" />
+        </g>
+
+        <rect class="area-full" x="55" y="5" />
+        <g class="hide" [class]="scale < 2 ? 'hide' : ''" >
+          <rect class="seat-taken" x="60" y="10" />
+          <rect class="seat-taken" x="80" y="10" />
+          <rect class="seat-taken" x="60" y="30" />
+          <rect class="seat-taken" x="80" y="30" />
+        </g>
+
+        <rect class="area-free" x="5" y="55" />
+        <g class="hide" [class]="scale < 2 ? 'hide' : ''" >
+            <rect class="seat-free" [class]="seat == 4 ? 'seat-selected' : 'seat-free'" on="tap:AMP.setState({seat: 4})" x="10" y="60" tabindex="0" role="button" />
+            <rect class="seat-free" [class]="seat == 6 ? 'seat-selected' : 'seat-free'" on="tap:AMP.setState({seat: 6})" x="30" y="60" tabindex="0" role="button" />
+            <rect class="seat-free" [class]="seat == 7 ? 'seat-selected' : 'seat-free'" on="tap:AMP.setState({seat: 7})" x="10" y="80" tabindex="0" role="button" />
+            <rect class="seat-free" [class]="seat == 10 ? 'seat-selected' : 'seat-free'" on="tap:AMP.setState({seat: 10})" x="30" y="80" tabindex="0" role="button" />
+        </g>
+
+        <rect class="area-free" x="55" y="55" />
+        <g class="hide" [class]="scale < 2 ? 'hide' : ''" >
+            <rect class="seat-free" [class]="seat == 5 ? 'seat-selected' : 'seat-free'" on="tap:AMP.setState({seat: 5})" x="60" y="60" tabindex="0" role="button" />
+            <rect class="seat-free" [class]="seat == 8 ? 'seat-selected' : 'seat-free'" on="tap:AMP.setState({seat: 8})" x="80" y="60" tabindex="0" role="button" />
+            <rect class="seat-free" [class]="seat == 11 ? 'seat-selected' : 'seat-free'" on="tap:AMP.setState({seat: 11})" x="60" y="80" tabindex="0" role="button" />
+            <rect class="seat-free" [class]="seat == 12 ? 'seat-selected' : 'seat-free'" on="tap:AMP.setState({seat: 12})" x="80" y="80" tabindex="0" role="button" />
+        </g>
+      </svg>
+    </amp-pan-zoom>
+</article>
+</body>
+</html>
+

--- a/test/manual/amp-pan-zoom.amp.html
+++ b/test/manual/amp-pan-zoom.amp.html
@@ -108,9 +108,9 @@
   </amp-pan-zoom>
 
   <h2>AMP Pan-Zoom Advanced Example</h2>
-  <p>Double tap or pinch to zoom in and out.</p>
+  <p>Double tap or pinch to zoom in and out. This tests all initial configurations. </p>
   <p [text]="'Current scale: ' + scale">Current scale: 1</p>
-      <amp-pan-zoom layout="responsive" height="3" width="4" max-scale="2" on="transformEnd:AMP.setState({scale: event.scale})">
+      <amp-pan-zoom layout="responsive" height="3" width="4" max-scale="5" initial-scale="2" initial-x="150" initial-y="100">
       <svg viewBox="0 0 190 110" preserveAspectRatio="xMidYMin slice">
 
           <rect class="area-half" x="5" y="5" />

--- a/test/manual/amp-pan-zoom.amp.html
+++ b/test/manual/amp-pan-zoom.amp.html
@@ -92,6 +92,12 @@
         }
       </script>
     </amp-state>
+
+    <amp-state id="scale">
+      <script type="application/json">
+        1
+      </script>
+    </amp-state>
 <article>
   <h1>AMP Pan Zoom</h1>
   <h2>AMP Pan Zoom Basic Example</h2>

--- a/test/manual/amp-pan-zoom.amp.html
+++ b/test/manual/amp-pan-zoom.amp.html
@@ -83,9 +83,13 @@
     </script>
   </amp-state>
 
-  <amp-state id="scale">
+  <amp-state id="transform">
       <script type="application/json">
-        1
+        {
+          "scale": "1",
+          "y": "0",
+          "x": "0"
+        }
       </script>
     </amp-state>
 <article>
@@ -100,7 +104,7 @@
   <h2>AMP Pan-Zoom Advanced Example</h2>
   <p>Double tap or pinch to zoom in and out.</p>
   <p [text]="'Current scale: ' + scale">Current scale: 1</p>
-      <amp-pan-zoom layout="responsive" height="3" width="4" max-scale="5" initial-scale="2" initial-x="150" initial-y="100" on="transformEnd:AMP.setState({scale: event.scale})">
+      <amp-pan-zoom layout="responsive" height="3" width="4" max-scale="2" on="transformEnd:AMP.setState({scale: event.scale})">
       <svg viewBox="0 0 190 110" preserveAspectRatio="xMidYMin slice">
 
           <rect class="area-half" x="5" y="5" />
@@ -215,6 +219,47 @@
               <rect class="seat-free" [class]="seat == 12 ? 'seat-selected' : 'seat-free'" on="tap:AMP.setState({seat: 12})" x="80" y="80" tabindex="0" role="button" />
           </g>
         </svg>
+    </amp-pan-zoom>
+
+    <h1>AMP Pan-Zoom with other content on page</h1>
+    <p [text]="'Current scale: ' + transform.scale + ', ' + transform.x + ', ' + transform.y">Current transform: 1, 0, 0</p>
+    <amp-img [hidden]="scale > 1" id="img1"
+        src="/examples/img/sample.jpg"
+        width="641" height="481" layout="fixed"></amp-img>
+    <amp-pan-zoom layout="responsive" width="1" height="1" on="transformEnd:AMP.setState({transform: {scale: event.scale, y: event.y, x: event.x} })">
+      <svg viewBox="0 0 190 110" preserveAspectRatio="xMidYMin slice">
+        <rect class="area-half" x="5" y="5" />
+        <g class="hide" [class]="scale < 2 ? 'hide' : ''" >
+            <rect class="seat-selected" [class]="seat == 1 ? 'seat-selected' : 'seat-free'" on="tap:AMP.setState({seat: 1})" x="10" y="10" tabindex="0" role="button" />
+          <rect class="seat-free" [class]="seat == 2 ? 'seat-selected' : 'seat-free'" on="tap:AMP.setState({seat: 2})" x="30" y="10" tabindex="0" role="button" />
+          <rect class="seat-taken" x="10" y="30" />
+          <rect class="seat-free" [class]="seat == 3 ? 'seat-selected' : 'seat-free'" on="tap:AMP.setState({seat: 3})" x="30" y="30" tabindex="0" role="button" />
+        </g>
+
+        <rect class="area-full" x="55" y="5" />
+        <g class="hide" [class]="scale < 2 ? 'hide' : ''" >
+          <rect class="seat-taken" x="60" y="10" />
+          <rect class="seat-taken" x="80" y="10" />
+          <rect class="seat-taken" x="60" y="30" />
+          <rect class="seat-taken" x="80" y="30" />
+        </g>
+
+        <rect class="area-free" x="5" y="55" />
+        <g class="hide" [class]="scale < 2 ? 'hide' : ''" >
+            <rect class="seat-free" [class]="seat == 4 ? 'seat-selected' : 'seat-free'" on="tap:AMP.setState({seat: 4})" x="10" y="60" tabindex="0" role="button" />
+            <rect class="seat-free" [class]="seat == 6 ? 'seat-selected' : 'seat-free'" on="tap:AMP.setState({seat: 6})" x="30" y="60" tabindex="0" role="button" />
+            <rect class="seat-free" [class]="seat == 7 ? 'seat-selected' : 'seat-free'" on="tap:AMP.setState({seat: 7})" x="10" y="80" tabindex="0" role="button" />
+            <rect class="seat-free" [class]="seat == 10 ? 'seat-selected' : 'seat-free'" on="tap:AMP.setState({seat: 10})" x="30" y="80" tabindex="0" role="button" />
+        </g>
+
+        <rect class="area-free" x="55" y="55" />
+        <g class="hide" [class]="scale < 2 ? 'hide' : ''" >
+            <rect class="seat-free" [class]="seat == 5 ? 'seat-selected' : 'seat-free'" on="tap:AMP.setState({seat: 5})" x="60" y="60" tabindex="0" role="button" />
+            <rect class="seat-free" [class]="seat == 8 ? 'seat-selected' : 'seat-free'" on="tap:AMP.setState({seat: 8})" x="80" y="60" tabindex="0" role="button" />
+            <rect class="seat-free" [class]="seat == 11 ? 'seat-selected' : 'seat-free'" on="tap:AMP.setState({seat: 11})" x="60" y="80" tabindex="0" role="button" />
+            <rect class="seat-free" [class]="seat == 12 ? 'seat-selected' : 'seat-free'" on="tap:AMP.setState({seat: 12})" x="80" y="80" tabindex="0" role="button" />
+        </g>
+      </svg>
     </amp-pan-zoom>
 </article>
 </body>


### PR DESCRIPTION
Bug 1: The tap target x,y coordinates for zoom are taken relative to viewport instead of relative to element. Fixed by subtracting the viewport x,y coordinates. 
Bug 2: Relayout shouldn't be happening on resize. 