### PR TITLE
Maximizing bookend cta links width.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-bookend.css
+++ b/extensions/amp-story/1.0/amp-story-bookend.css
@@ -309,6 +309,10 @@
   margin-bottom: 12px;
 }
 
+.i-amphtml-story-bookend-cta-link:nth-child(2n+1):last-child {
+  width: 100% !important;
+}
+
 .i-amphtml-story-bookend-cta-link-text {
   color: #FFFFFF !important;
   text-transform: uppercase !important;


### PR DESCRIPTION
We saw this morning a use case where a publisher tried to add a link in the bookend for users to subscribe to their newsletter. The links width is very small and does not allow much text, and a "Subscribe to our newsletter" title [does not fit](https://user-images.githubusercontent.com/1492044/41796917-21d32f18-7636-11e8-862d-c948f4f78318.png).

This PR tries to maximize the width of links, by making the last link full width, if odd (not even):
- A single link is now full width [screenshot](https://user-images.githubusercontent.com/1492044/41797054-9f4cf8f2-7636-11e8-87b1-6b6764fe7f33.png)
- Two links are 50% width each: no change here
- Three links has the first two ones 50% and the last one 100% [screenshot](https://user-images.githubusercontent.com/1492044/41797048-97365ae6-7636-11e8-83b2-ac44e87ecb3b.png)
