### PR TITLE
🐛Add amp-access-scroll element to fixed layer

### DIFF
--- a/extensions/amp-access-scroll/0.1/amp-access-scroll.css
+++ b/extensions/amp-access-scroll/0.1/amp-access-scroll.css
@@ -15,21 +15,20 @@
  */
 
 .amp-access-scroll-bar {
-    height: 44px;
-    position: fixed;
-    left: 0;
-    width: 100%;
-    background: transparent;
-    z-index: 2147483647;
-    bottom: 0;
+  height: 44px;
+  position: fixed;
+  left: 0;
+  width: 100%;
+  background: transparent;
+  z-index: 2147483647;
+  bottom: 0;
 }
 
 .amp-access-scroll-placeholder {
-  padding-top: 8px;
+  padding-top: 7px;
   padding-left: 8px;
   background-color: #fff;
-  z-index: 11;
-  height: 100%;
   border-top: 1px solid #eee;
   border-bottom: 1px solid #eee;
+  box-sizing: border-box;
 }

--- a/extensions/amp-access-scroll/0.1/scroll-impl.js
+++ b/extensions/amp-access-scroll/0.1/scroll-impl.js
@@ -129,15 +129,9 @@ class ScrollElement {
     this.ampdoc_ = ampdoc;
 
     /** @const {!Element} */
-    this.wrapper_ = document.createElement('div');
-    this.wrapper_.classList.add('amp-access-scroll-bar');
-    ampdoc.getBody().appendChild(this.wrapper_);
-
-    /** @const {!Element} */
     this.placeholder_ = document.createElement('div');
+    this.placeholder_.classList.add('amp-access-scroll-bar');
     this.placeholder_.classList.add('amp-access-scroll-placeholder');
-    this.wrapper_.appendChild(this.placeholder_);
-
     const img = document.createElement('img');
     img.setAttribute('src',
         'https://static.scroll.com/assets/icn-scroll-logo.svg');
@@ -145,7 +139,12 @@ class ScrollElement {
     img.setAttribute('width', 26);
     img.setAttribute('height', 26);
     this.placeholder_.appendChild(img);
+    ampdoc.getBody().appendChild(this.placeholder_);
 
+
+    /** @const {!Element} */
+    this.scrollBar_ = document.createElement('div');
+    this.scrollBar_.classList.add('amp-access-scroll-bar');
     /** @const {!Element} */
     this.iframe_ = document.createElement('iframe');
     this.iframe_.setAttribute('scrolling', 'no');
@@ -157,18 +156,19 @@ class ScrollElement {
     this.iframe_.setAttribute('sandbox', 'allow-scripts allow-same-origin ' +
                                          'allow-top-navigation allow-popups ' +
                                          'allow-popups-to-escape-sandbox');
-    this.wrapper_.appendChild(this.iframe_);
-
+    this.scrollBar_.appendChild(this.iframe_);
+    ampdoc.getBody().appendChild(this.scrollBar_);
   }
 
   /**
    * @param {!../../amp-access/0.1/amp-access.AccessService} accessService
    */
   show(accessService) {
-    accessService.getAccessReaderId()
+    Services.viewportForDoc(this.ampdoc_).addToFixedLayer(this.scrollBar_)
+        .then(() => accessService.getAccessReaderId())
         .then(readerId => {
           this.iframe_.onload = () => {
-            this.wrapper_.removeChild(this.placeholder_);
+            this.ampdoc_.getBody().removeChild(this.placeholder_);
           };
           const docInfo = Services.documentInfoForDoc(this.ampdoc_);
           this.iframe_.setAttribute('src',

--- a/extensions/amp-access-scroll/OWNERS.yaml
+++ b/extensions/amp-access-scroll/OWNERS.yaml
@@ -1,1 +1,2 @@
 - kushal
+- dbow


### PR DESCRIPTION
Fixes position:fixed scrolling flicker ([described here](https://bugs.webkit.org/show_bug.cgi?id=154399)) by moving the amp-access-scroll iframe into the fixed layer.

Also splits up rendering of the placeholder and iframe and only puts the iframe into the fixed layer (as there seemed to be a slight flicker as the element is transferred between layers).
