### PR TITLE
Refactor amp-pan-zoom integration test and address style comments

### DIFF
--- a/extensions/amp-pan-zoom/0.1/amp-pan-zoom.js
+++ b/extensions/amp-pan-zoom/0.1/amp-pan-zoom.js
@@ -181,11 +181,7 @@ export class AmpPanZoom extends AMP.BaseElement {
 
   /** @override */
   layoutCallback() {
-    return this.resetContentDimensions_().then(() => {
-      if (!this.gestures_) {
-        this.setupGestures_();
-      }
-    });
+    return this.resetContentDimensions_().then(this.setupGestures_());
   }
 
   /** @override */
@@ -199,9 +195,7 @@ export class AmpPanZoom extends AMP.BaseElement {
     if (this.content_) {
       this.scheduleLayout(this.content_);
     }
-    if (!this.gestures_) {
-      this.setupGestures_();
-    }
+    this.setupGestures_();
   }
 
   /** @override */
@@ -238,10 +232,9 @@ export class AmpPanZoom extends AMP.BaseElement {
    */
   getNumberAttributeOr_(attribute, defaultValue) {
     const {element} = this;
-    if (!element.hasAttribute(attribute)) {
-      return defaultValue;
-    }
-    return parseInt(element.getAttribute(attribute), 10);
+    return element.hasAttribute(attribute)
+      ? parseInt(element.getAttribute(attribute), 10)
+      : defaultValue;
   }
 
   /**
@@ -327,8 +320,8 @@ export class AmpPanZoom extends AMP.BaseElement {
    * @param {number} clientX
    */
   getOffsetX_(clientX) {
-    return (this.elementBox_.left - this.getViewport().getScrollLeft())
-      - clientX;
+    const {left} = this.elementBox_;
+    return (left - this.getViewport().getScrollLeft()) - clientX;
   }
 
   /**
@@ -337,12 +330,15 @@ export class AmpPanZoom extends AMP.BaseElement {
    * @param {number} clientY
    */
   getOffsetY_(clientY) {
-    return (this.elementBox_.top - this.getViewport().getScrollTop())
-        - clientY;
+    const {top} = this.elementBox_;
+    return (top - this.getViewport().getScrollTop()) - clientY;
   }
 
   /** @private */
   setupGestures_() {
+    if (this.gestures_) {
+      return;
+    }
     // TODO (#12881): this and the subsequent use of event.preventDefault
     // is a temporary solution to #12362. We should revisit this problem after
     // resolving #12881 or change the use of window.event to the specific event
@@ -450,8 +446,8 @@ export class AmpPanZoom extends AMP.BaseElement {
    * @private
    */
   boundScale_(s, allowExtent) {
-    return this.boundValue_(s, this.minScale_, this.maxScale_,
-        allowExtent ? 0.25 : 0);
+    const extent = allowExtent ? 0.25 : 0;
+    return this.boundValue_(s, this.minScale_, this.maxScale_, extent);
   }
 
   /**
@@ -462,8 +458,9 @@ export class AmpPanZoom extends AMP.BaseElement {
    * @private
    */
   boundX_(x, allowExtent) {
-    return this.boundValue_(x, this.minX_, this.maxX_,
-        allowExtent && this.scale_ > 1 ? this.elementBox_.width * 0.25 : 0);
+    const maxExtent = this.elementBox_.width * 0.25;
+    const extent = allowExtent && this.scale_ > 1 ? maxExtent : 0;
+    return this.boundValue_(x, this.minX_, this.maxX_, extent);
   }
 
   /**
@@ -474,8 +471,9 @@ export class AmpPanZoom extends AMP.BaseElement {
    * @private
    */
   boundY_(y, allowExtent) {
-    return this.boundValue_(y, this.minY_, this.maxY_,
-        allowExtent ? this.elementBox_.height * 0.25 : 0);
+    const maxExtent = this.elementBox_.height * 0.25;
+    const extent = allowExtent && this.scale_ > 1 ? maxExtent : 0;
+    return this.boundValue_(y, this.minY_, this.maxY_, extent);
   }
 
   /**

--- a/extensions/amp-pan-zoom/0.1/test/integration/test-amp-pan-zoom.js
+++ b/extensions/amp-pan-zoom/0.1/test/integration/test-amp-pan-zoom.js
@@ -14,41 +14,29 @@
  * limitations under the License.
  */
 
+import {AmpEvents} from '../../../../../src/amp-events';
+import {createFixtureIframe} from '../../../../../testing/iframe';
+import {toggleExperiment} from '../../../../../src/experiments';
 
 describe.configure().ifNewChrome().run('amp-pan-zoom', function() {
-  this.timeout(10000);
-  const extensions = ['amp-pan-zoom'];
-  const experiments = ['amp-pan-zoom'];
-  const body = `
-  <amp-pan-zoom id="amp-pan-zoom" layout="fixed" width="300" height="241">
-    <amp-img id="img0"
-      src="/examples/img/sample.jpg"
-      width="641" height="481" layout="fixed"></amp-img>
-  </amp-pan-zoom>
-  `;
-  describes.integration('amp-pan-zoom basic functionality', {
-    body,
-    extensions,
-    experiments,
-  }, env => {
-    let win, doc, panZoom;
-    beforeEach(() => {
-      win = env.win;
-      win.AMP_MODE.localDev = true;
-      doc = win.document;
-      panZoom = doc.getElementById('amp-pan-zoom');
-      return panZoom.build().then(() => {
-        return panZoom.layoutCallback();
-      });
-    });
+  this.timeout(100000);
+  let fixture;
+  beforeEach(() => {
+    return createFixtureIframe('test/fixtures/amp-pan-zoom.html', 1000)
+        .then(f => {
+          fixture = f;
+          toggleExperiment(fixture.win, 'amp-pan-zoom', true, true);
+        });
+  });
 
-    it('should build correctly', () => {
-      expect(panZoom.children.length).to.equal(1);
-      const content = panZoom.children[0];
-      expect(content.classList.contains('i-amphtml-pan-zoom-child')).to.be.true;
-    });
+  it('two amp-pan-zoom should exist', () => {
+    expect(fixture.doc.querySelectorAll('amp-pan-zoom'))
+        .to.have.length.above(0);
+  });
 
-    it('should resize and center content', () => {
+  it('should resize and center content', () => {
+    return fixture.awaitEvent(AmpEvents.LOAD_END, 2).then(() => {
+      const panZoom = fixture.doc.querySelector('#amp-pan-zoom-1');
       const content = panZoom.children[0];
       expect(content.style.width).to.equal('300px');
       // 481 / 641 * 300 = 225
@@ -57,42 +45,14 @@ describe.configure().ifNewChrome().run('amp-pan-zoom', function() {
       expect(content.style.top).to.equal('8px');
       expect(content.style.left).to.equal('0px');
     });
-
   });
 
-  const bodyWithConfigs = `
-    <amp-pan-zoom id="amp-pan-zoom"
-      initial-x="10"
-      initial-y="5"
-      initial-scale="2"
-      max-scale="5"
-      layout="fixed"
-      width="300"
-      height="240">
-      <amp-img id="img0"
-        src="/examples/img/sample.jpg"
-        width="641" height="481" layout="fixed"></amp-img>
-    </amp-pan-zoom>`;
-
-  describes.integration('amp-pan-zoom basic functionality', {
-    body: bodyWithConfigs,
-    extensions,
-    experiments,
-  }, env => {
-    let win, doc, panZoom;
-    beforeEach(() => {
-      win = env.win;
-      win.AMP_MODE.localDev = true;
-      doc = win.document;
-      panZoom = doc.getElementById('amp-pan-zoom');
-      return panZoom.build().then(() => {
-        return panZoom.layoutCallback();
-      });
-    });
-
-    it('should apply initial configurations correctly', () => {
+  it('should apply initial configurations correctly', () => {
+    return fixture.awaitEvent(AmpEvents.LOAD_END, 4).then(() => {
+      const panZoom = fixture.doc.querySelector('#amp-pan-zoom-2');
       const content = panZoom.children[0];
-      expect(content.style.transform).to.equal('translate(10px, 5px) scale(2)');
+      expect(content.style.transform).to
+          .equal('translate(50px, 100px) scale(2)');
     });
   });
 });

--- a/test/fixtures/amp-pan-zoom.html
+++ b/test/fixtures/amp-pan-zoom.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>AMP Pan Zoom Demo</title>
+  <link rel="canonical" href="amps.html" >
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
+  <script async custom-element="amp-pan-zoom" src="/dist/v0/amp-pan-zoom-0.1.max.js"></script>
+  <script async src="/dist/amp.js"></script>
+</head>
+<body>
+  <amp-pan-zoom id="amp-pan-zoom-1" layout="fixed" width="300" height="241">
+    <amp-img id="img1"
+      src="/examples/img/sample.jpg"
+      width="641" height="481" layout="fixed"></amp-img>
+  </amp-pan-zoom>
+  <amp-pan-zoom id="amp-pan-zoom-2"
+    initial-x="50"
+    initial-y="100"
+    initial-scale="2"
+    max-scale="5"
+    layout="fixed"
+    width="300"
+    height="240">
+    <amp-img id="img2"
+      src="/examples/img/sample.jpg"
+      width="641" height="481" layout="fixed"></amp-img>
+  </amp-pan-zoom>
+
+</body>
+</html>
+


### PR DESCRIPTION
Refactored the integration test to use a fixture to avoid race condition flakes. Addressed style comments from https://github.com/ampproject/amphtml/pull/16257. 