### PR TITLE
fix amp-pan-zoom transform examples and documentation 

### DIFF
--- a/extensions/amp-pan-zoom/0.1/amp-pan-zoom.js
+++ b/extensions/amp-pan-zoom/0.1/amp-pan-zoom.js
@@ -167,9 +167,9 @@ export class AmpPanZoom extends AMP.BaseElement {
       }
       const scale = args['scale'] || 1;
       this.updatePanZoomBounds_(scale);
-      const x = this.boundX_(args['x'] || 0);
-      const y = this.boundY_(args['y'] || 0);
-      this.set_(scale, x, y, /*animate*/true).then(() => {
+      const x = this.boundX_(args['x'] || 0, /*allowExtent*/ false);
+      const y = this.boundY_(args['y'] || 0, /*allowExtent*/ false);
+      return this.set_(scale, x, y, /*animate*/ true).then(() => {
         this.onZoomRelease_();
       });
     });

--- a/extensions/amp-pan-zoom/0.1/amp-pan-zoom.js
+++ b/extensions/amp-pan-zoom/0.1/amp-pan-zoom.js
@@ -166,11 +166,10 @@ export class AmpPanZoom extends AMP.BaseElement {
         return;
       }
       const scale = args['scale'] || 1;
-      const x = args['x'] || 0;
-      const y = args['y'] || 0;
-      const deltaX = x - this.posX_;
-      const deltaY = y - this.posY_;
-      this.onZoom_(scale, deltaX, deltaY, true);
+      this.updatePanZoomBounds_(scale);
+      const x = this.boundX_(args['x'] || 0);
+      const y = this.boundY_(args['y'] || 0);
+      this.set_(scale, x, y, /*animate*/true);
     });
   }
 
@@ -614,21 +613,20 @@ export class AmpPanZoom extends AMP.BaseElement {
    * @param {number} deltaX
    * @param {number} deltaY
    * @param {boolean} animate
-   * @return {!Promise|undefined}
+   * @return {!Promise}
    * @private
    */
   onZoom_(scale, deltaX, deltaY, animate) {
     const newScale = this.boundScale_(scale, true);
     if (newScale == this.scale_) {
-      return;
+      return Promise.resolve();
     }
 
     this.updatePanZoomBounds_(newScale);
 
     const newPosX = this.boundX_(this.startX_ + (deltaX * newScale), false);
     const newPosY = this.boundY_(this.startY_ + (deltaY * newScale), false);
-    return /** @type {!Promise|undefined} */ (
-      this.set_(newScale, newPosX, newPosY, animate));
+    return this.set_(newScale, newPosX, newPosY, animate);
   }
 
   /**

--- a/extensions/amp-pan-zoom/0.1/amp-pan-zoom.js
+++ b/extensions/amp-pan-zoom/0.1/amp-pan-zoom.js
@@ -169,7 +169,9 @@ export class AmpPanZoom extends AMP.BaseElement {
       this.updatePanZoomBounds_(scale);
       const x = this.boundX_(args['x'] || 0);
       const y = this.boundY_(args['y'] || 0);
-      this.set_(scale, x, y, /*animate*/true);
+      this.set_(scale, x, y, /*animate*/true).then(() => {
+        this.onZoomRelease_();
+      });
     });
   }
 

--- a/extensions/amp-pan-zoom/amp-pan-zoom.md
+++ b/extensions/amp-pan-zoom/amp-pan-zoom.md
@@ -62,6 +62,30 @@ Specifies a default zoom scale, otherwise set to 1.
 Specifies default translation coordinates, otherwise both set to 0. Expected to be a whole number.
 
 ## Events and Actions
-The `<amp-pan-zoom>` component triggers the `transformEnd` event whenever the pan or zoom animation is complete. This event will emit the parameters `scale`, `x`, and `y`. `scale` contains the current scale of the child content being zoomed. `x` and `y` respectively contain the `x` and `y` translation of the child content in pixels.
+#### transformEnd (event)
+The `<amp-pan-zoom>` component triggers the `transformEnd` event whenever the pan or zoom animation is complete. This event will emit the parameters `scale`, `x`, and `y`. `scale` contains the current scale of the child content being zoomed. `x` and `y` respectively contain the `x` and `y` translation of the child content from center in pixels.
 
-We also have the `transform` action, which takes `scale`, `x`, `y` as paramters and sets the CSS transform property of the child content.
+##### Example
+This example contains an amp-pan-zoom component that will update `amp-state` on `transformEnd`.
+```
+  <amp-state id="transform">
+    <script type="application/json">
+      {
+        "scale": 1,
+        "y": 0,
+        "x": 0
+      }
+    </script>
+  </amp-state>
+  <p [text]="'Current scale: ' + transform.scale + ', x: ' + transform.x + ', y: ' + transform.y">Current scale: 1</p>
+  <amp-pan-zoom layout="responsive" width="1" height="1" id="pan-zoom"
+    on="transformEnd:AMP.setState({transform: {scale: event.scale, x: event.x, y: event.y}})">
+    ...
+  </amp-pan-zoom>
+```
+
+#### transform (action)
+We also have the `transform` action, which takes `scale`, `x`, `y` as paramters and sets the CSS transform property of the child content. If no `x` or `y` is specified, it zooms to center.
+
+##### Example
+Assuming that there is an `<amp-pan-zoom>` component with the id `pan-zoom` on the page, a button with `on="tap:pan-zoom.transform(scale=3)"` will zoom to scale 3x at the center of the content, a button with `on="tap:pan-zoom.transform(scale=3, x=50, y=10)"` will first scale the content to 3x scale, and then shift the content 50 pixels towards the left, and 10 pixels upwards. Consider the `scale`, `x`, and `y` attributes directly applied to the content's CSS transform attribute after animation.

--- a/test/manual/amp-pan-zoom-integration.amp.html
+++ b/test/manual/amp-pan-zoom-integration.amp.html
@@ -83,20 +83,31 @@
     </script>
   </amp-state>
 
-  <amp-state id="scale">
+  <amp-state id="transform">
     <script type="application/json">
-      1
+      {
+        "scale": 1,
+        "y": 0,
+        "x": 0
+      }
     </script>
   </amp-state>
+
 <article>
   <h1>AMP Pan Zoom</h1>
-
     <h1>AMP Pan-Zoom with other content on page</h1>
-    <p [text]="'Current scale: ' + scale">Current scale: 1</p>
-    <amp-img [hidden]="scale > 1" id="img1"
+    <button class="zoom-button" on="tap:pan-zoom.transform(scale=1)" hidden [hidden]="transform.scale == 1">
+      -
+    </button>
+    <button class="zoom-button" on="tap:pan-zoom.transform(scale=3, x=50, y=10)" [hidden]="transform.scale > 1">
+      +
+    </button>
+    <p [text]="'Current scale: ' + transform.scale + ', x: ' + transform.x + ', y: ' + transform.y">Current scale: 1</p>
+    <amp-img [hidden]="transform.scale > 1" id="img1"
         src="/examples/img/sample.jpg"
         width="641" height="481" layout="fixed"></amp-img>
-    <amp-pan-zoom layout="responsive" width="1" height="1" on="transformEnd:AMP.setState({scale: event.scale})">
+    <amp-pan-zoom layout="responsive" width="1" height="1" id="pan-zoom"
+      on="transformEnd:AMP.setState({transform: {scale: event.scale, x: event.x, y: event.y}})">
       <svg viewBox="0 0 190 110" preserveAspectRatio="xMidYMin slice">
         <rect class="area-half" x="5" y="5" />
         <g class="hide" [class]="scale < 2 ? 'hide' : ''" >

--- a/test/manual/amp-pan-zoom.amp.html
+++ b/test/manual/amp-pan-zoom.amp.html
@@ -84,14 +84,14 @@
   </amp-state>
 
   <amp-state id="transform">
-      <script type="application/json">
-        {
-          "scale": "1",
-          "y": "0",
-          "x": "0"
-        }
-      </script>
-    </amp-state>
+    <script type="application/json">
+      {
+        "scale": 1,
+        "y": 0,
+        "x": 0
+      }
+    </script>
+  </amp-state>
 
     <amp-state id="scale">
       <script type="application/json">
@@ -109,8 +109,16 @@
 
   <h2>AMP Pan-Zoom Advanced Example</h2>
   <p>Double tap or pinch to zoom in and out. This tests all initial configurations. </p>
-  <p [text]="'Current scale: ' + scale">Current scale: 1</p>
-      <amp-pan-zoom layout="responsive" height="3" width="4" max-scale="5" initial-scale="2" initial-x="150" initial-y="100">
+  <p [text]="'Current scale: ' + transform.scale + ', x: ' + transform.x + ', y: ' + transform.y">Current scale: 1</p>
+      <amp-pan-zoom
+        layout="responsive"
+        on="transformEnd:AMP.setState({transform: {scale: event.scale, x: event.x, y: event.y}})"
+        height="3"
+        width="4"
+        max-scale="5"
+        initial-scale="2"
+        initial-x="150"
+        initial-y="100">
       <svg viewBox="0 0 190 110" preserveAspectRatio="xMidYMin slice">
 
           <rect class="area-half" x="5" y="5" />


### PR DESCRIPTION
1. Fix bug where transform is applied before scale instead of after scale.
2. Add `onZoomRelease_` logic for zooming via action, so that pan is properly enabled / disabled. 
3. Update manual tests to include example usage of `transform` and `transformEnd`. 
4. Update documentation to be more explicit about the usage of `transform` and `transformEnd`. 
