### PR TITLE
🐛 Fix amp-date-picker template with ID causing invalid AMP

### DIFF
--- a/extensions/amp-date-picker/0.1/test/validator-amp-date-picker.html
+++ b/extensions/amp-date-picker/0.1/test/validator-amp-date-picker.html
@@ -80,7 +80,25 @@
   <amp-date-picker layout="fixed-height" height="360"
       src="https://data.com/dates.json?ref=CANONICAL_URL">
   </amp-date-picker>
-
+  <!-- Valid: amp-date-picker with date template -->
+  <amp-date-picker layout="fixed-height" height="360">
+    <template type="amp-mustache" date-template default>{{D}}</template>
+  </amp-date-picker>
+  <!-- Valid: amp-date-picker with date-template and/or info-template -->
+  <amp-date-picker layout="fixed-height" height="360">
+    <template info-template type="amp-mustache"></template>
+    <template date-template default type="amp-mustache"></template>
+    <template date-template dates="2018-01-01" type="amp-mustache"></template>
+    <template date-template id="named" type="amp-mustache"></template>
+    <template date-template type="amp-mustache"></template>
+  </amp-date-picker>
+  <!-- Valid: amp-date-picker with date-template with mixed attributes -->
+  <amp-date-picker layout="fixed-height" height="360">
+    <template date-template default id="default-with-id" type="amp-mustache"></template>
+    <template date-template dates="2018-01-01" id="dates-with-id" type="amp-mustache"></template>
+    <template date-template dates="2018-01-01" default type="amp-mustache"></template>
+    <template date-template dates="2018-01-01" default id="dates-with-default-and-id" type="amp-mustache"></template>
+  </amp-date-picker>
 
   <!-- Invalid: single amp-date-picker with start-input-selector -->
   <amp-date-picker type="single" mode="static" start-input-selector="#a3" layout="fixed-height" height="360">
@@ -111,15 +129,6 @@
   <!-- Invalid: amp-date-picker with bad first-day-of-week -->
   <amp-date-picker type="range" layout="fixed-height" height="360"
       first-day-of-week="7">
-  </amp-date-picker>
-  <!-- Valid: amp-date-picker with date-template and/or info-template -->
-  <amp-date-picker layout="fixed-height" height="360">
-    <template info-template type="amp-mustache">
-    </template>
-    <template date-template default type="amp-mustache">
-    </template>
-    <template date-template dates="2018-01-01" type="amp-mustache" id="empty">
-    </template>
   </amp-date-picker>
   <!-- Invalid: amp-date-picker templates outside amp-date-picker -->
   <template info-template type="amp-mustache"></template>

--- a/extensions/amp-date-picker/0.1/test/validator-amp-date-picker.out
+++ b/extensions/amp-date-picker/0.1/test/validator-amp-date-picker.out
@@ -81,87 +81,96 @@ FAIL
 |    <amp-date-picker layout="fixed-height" height="360"
 |        src="https://data.com/dates.json?ref=CANONICAL_URL">
 |    </amp-date-picker>
-|  
+|    <!-- Valid: amp-date-picker with date template -->
+|    <amp-date-picker layout="fixed-height" height="360">
+|      <template type="amp-mustache" date-template default>{{D}}</template>
+|    </amp-date-picker>
+|    <!-- Valid: amp-date-picker with date-template and/or info-template -->
+|    <amp-date-picker layout="fixed-height" height="360">
+|      <template info-template type="amp-mustache"></template>
+|      <template date-template default type="amp-mustache"></template>
+|      <template date-template dates="2018-01-01" type="amp-mustache"></template>
+|      <template date-template id="named" type="amp-mustache"></template>
+|      <template date-template type="amp-mustache"></template>
+|    </amp-date-picker>
+|    <!-- Valid: amp-date-picker with date-template with mixed attributes -->
+|    <amp-date-picker layout="fixed-height" height="360">
+|      <template date-template default id="default-with-id" type="amp-mustache"></template>
+|      <template date-template dates="2018-01-01" id="dates-with-id" type="amp-mustache"></template>
+|      <template date-template dates="2018-01-01" default type="amp-mustache"></template>
+|      <template date-template dates="2018-01-01" default id="dates-with-default-and-id" type="amp-mustache"></template>
+|    </amp-date-picker>
 |  
 |    <!-- Invalid: single amp-date-picker with start-input-selector -->
 |    <amp-date-picker type="single" mode="static" start-input-selector="#a3" layout="fixed-height" height="360">
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:86:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=single][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:104:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=single][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:86:2 The attribute 'mode' in tag 'amp-date-picker[type=single][mode=overlay]' is set to the invalid value 'static'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:104:2 The attribute 'mode' in tag 'amp-date-picker[type=single][mode=overlay]' is set to the invalid value 'static'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:86:2 The attribute 'start-input-selector' may not appear in tag 'amp-date-picker[type=single][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:104:2 The attribute 'start-input-selector' may not appear in tag 'amp-date-picker[type=single][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
 |    </amp-date-picker>
 |    <!-- Invalid: range amp-date-picker with input-selector -->
 |    <amp-date-picker type="range" input-selector="#a4" layout="fixed-height" height="360">
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:89:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=single][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:107:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=single][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:89:2 The attribute 'type' in tag 'amp-date-picker[type=single][mode=overlay]' is set to the invalid value 'range'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:107:2 The attribute 'type' in tag 'amp-date-picker[type=single][mode=overlay]' is set to the invalid value 'range'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
 |      </amp-date-picker>
 |    <!-- Invalid: amp-date-picker with implicit mode="static" without layout -->
 |    <amp-date-picker></amp-date-picker>
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:92:2 The implied layout 'CONTAINER' is not supported by tag 'amp-date-picker[type=single][mode=static]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:110:2 The implied layout 'CONTAINER' is not supported by tag 'amp-date-picker[type=single][mode=static]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
 |    <!-- Invalid: amp-date-picker with explicit mode="static" without layout -->
 |    <amp-date-picker mode="static">
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:94:2 The implied layout 'CONTAINER' is not supported by tag 'amp-date-picker[type=single][mode=static]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:112:2 The implied layout 'CONTAINER' is not supported by tag 'amp-date-picker[type=single][mode=static]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
 |    </amp-date-picker>
 |    <!-- Invalid: overlay amp-date-picker with fullscreen attribute -->
 |    <amp-date-picker mode="overlay" fullscreen>
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:97:2 The implied layout 'CONTAINER' is not supported by tag 'amp-date-picker[type=single][mode=static]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:115:2 The implied layout 'CONTAINER' is not supported by tag 'amp-date-picker[type=single][mode=static]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:97:2 The attribute 'mode' in tag 'amp-date-picker[type=single][mode=static]' is set to the invalid value 'overlay'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:115:2 The attribute 'mode' in tag 'amp-date-picker[type=single][mode=static]' is set to the invalid value 'overlay'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
 |      <input type="text" name="date4">
 |    </amp-date-picker>
 |    <!-- Invalid: width is mistyped. -->
 |    <amp-date-picker height="360" wdith="360">
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:101:2 The implied layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=single][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:119:2 The implied layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=single][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:101:2 The attribute 'wdith' may not appear in tag 'amp-date-picker[type=single][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:119:2 The attribute 'wdith' may not appear in tag 'amp-date-picker[type=single][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
 |    </amp-date-picker>
 |    <!-- Invalid: amp-date-picker with bad day-size-->
 |    <amp-date-picker type="range" layout="fixed-height" height="360"
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:104:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=range][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:122:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=range][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:104:2 The attribute 'day-size' in tag 'amp-date-picker[type=range][mode=overlay]' is set to the invalid value 'five'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:122:2 The attribute 'day-size' in tag 'amp-date-picker[type=range][mode=overlay]' is set to the invalid value 'five'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
 |        day-size="five">
 |    </amp-date-picker>
 |    <!-- Invalid: amp-date-picker with bad number-of-months -->
 |    <amp-date-picker type="range" layout="fixed-height" height="360"
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:108:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=range][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:126:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=range][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:108:2 The attribute 'number-of-months' in tag 'amp-date-picker[type=range][mode=overlay]' is set to the invalid value 'twele'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:126:2 The attribute 'number-of-months' in tag 'amp-date-picker[type=range][mode=overlay]' is set to the invalid value 'twele'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
 |        number-of-months="twele">
 |    </amp-date-picker>
 |    <!-- Invalid: amp-date-picker with bad first-day-of-week -->
 |    <amp-date-picker type="range" layout="fixed-height" height="360"
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:112:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=range][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:130:2 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-date-picker[type=range][mode=overlay]'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [AMP_LAYOUT_PROBLEM]
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:112:2 The attribute 'first-day-of-week' in tag 'amp-date-picker[type=range][mode=overlay]' is set to the invalid value '7'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:130:2 The attribute 'first-day-of-week' in tag 'amp-date-picker[type=range][mode=overlay]' is set to the invalid value '7'. (see https://www.ampproject.org/docs/reference/components/amp-date-picker) [DISALLOWED_HTML]
 |        first-day-of-week="7">
-|    </amp-date-picker>
-|    <!-- Valid: amp-date-picker with date-template and/or info-template -->
-|    <amp-date-picker layout="fixed-height" height="360">
-|      <template info-template type="amp-mustache">
-|      </template>
-|      <template date-template default type="amp-mustache">
-|      </template>
-|      <template date-template dates="2018-01-01" type="amp-mustache" id="empty">
-|      </template>
 |    </amp-date-picker>
 |    <!-- Invalid: amp-date-picker templates outside amp-date-picker -->
 |    <template info-template type="amp-mustache"></template>
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:125:2 The parent tag of tag 'amp-date-picker > template [info-template]' is 'body', but it can only be 'amp-date-picker'. (see https://www.ampproject.org/docs/reference/components/amp-mustache) [AMP_TAG_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:134:2 The parent tag of tag 'amp-date-picker > template [info-template]' is 'body', but it can only be 'amp-date-picker'. (see https://www.ampproject.org/docs/reference/components/amp-mustache) [AMP_TAG_PROBLEM]
 |    <template date-template dates="2018-01-01" type="amp-mustache"></template>
 >>   ^~~~~~~~~
-amp-date-picker/0.1/test/validator-amp-date-picker.html:126:2 The parent tag of tag 'amp-date-picker > template [date-template] [dates]' is 'body', but it can only be 'amp-date-picker'. (see https://www.ampproject.org/docs/reference/components/amp-mustache) [AMP_TAG_PROBLEM]
+amp-date-picker/0.1/test/validator-amp-date-picker.html:135:2 The parent tag of tag 'amp-date-picker > template [date-template]' is 'body', but it can only be 'amp-date-picker'. (see https://www.ampproject.org/docs/reference/components/amp-mustache) [AMP_TAG_PROBLEM]
 |  </body>
 |  </html>

--- a/extensions/amp-date-picker/validator-amp-date-picker.protoascii
+++ b/extensions/amp-date-picker/validator-amp-date-picker.protoascii
@@ -198,41 +198,20 @@ attr_lists: {
 tags: {
   html_format: AMP
   tag_name: "TEMPLATE"
-  spec_name: "amp-date-picker > template [date-template] [dates]"
+  spec_name: "amp-date-picker > template [date-template]"
   mandatory_parent: "AMP-DATE-PICKER"
   requires_extension: "amp-mustache"
   attrs: {
     name: "date-template"
     mandatory: true
     value: ""
-  }
-  attrs: {
-    name: "dates"
-    mandatory: true
     dispatch_key: NAME_DISPATCH
-  }
-  attrs: {
-    name: "type"
-    mandatory: true
-    value: "amp-mustache"
-  }
-}
-tags: {
-  html_format: AMP
-  tag_name: "TEMPLATE"
-  spec_name: "amp-date-picker > template [date-template] [default]"
-  mandatory_parent: "AMP-DATE-PICKER"
-  requires_extension: "amp-mustache"
-  attrs: {
-    name: "date-template"
-    mandatory: true
-    value: ""
   }
   attrs: {
     name: "default"
-    mandatory: true
-    value: ""
-    dispatch_key: NAME_DISPATCH
+  }
+  attrs: {
+    name: "dates"
   }
   attrs: {
     name: "type"


### PR DESCRIPTION
The previous code tried to be too smart and make the different `date-template` types mutually exclusive, but I don't think that needs to be the case so I removed the extra tagspecs. This bug caused an ABE PR check to fail for https://github.com/ampproject/amp-by-example/pull/1328. So hooray for tests of real-world usage!

https://travis-ci.org/ampproject/amp-by-example/builds/395632518