### PR TITLE
Clean up "faster amp-list" measurements

### DIFF
--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -189,38 +189,37 @@ describes.realWin('amp-list component', {
       });
     });
 
-    // TODO(#14772): figure out why this test is flaky and unskip
-    it.skip('should only process one fetch result at a time for rendering',
-        () => {
-          const doRenderPassSpy = sandbox.spy(list, 'doRenderPass_');
-          const scheduleRenderSpy = sandbox.spy(list.renderPass_, 'schedule');
+    // TODO(#14772): Flaky.
+    it.skip('should only process one result at a time for rendering', () => {
+      const doRenderPassSpy = sandbox.spy(list, 'doRenderPass_');
+      const scheduleRenderSpy = sandbox.spy(list.renderPass_, 'schedule');
 
-          const items = [{title: 'foo'}];
-          const foo = doc.createElement('div');
-          const rendered = expectFetchAndRender(items, [foo]);
-          const layout = list.layoutCallback();
+      const items = [{title: 'foo'}];
+      const foo = doc.createElement('div');
+      const rendered = expectFetchAndRender(items, [foo]);
+      const layout = list.layoutCallback();
 
-          // Execute another fetch-triggering action immediately (actually on
-          // the next tick to avoid losing the layoutCallback() promise resolver).
-          Promise.resolve().then(() => {
-            element.setAttribute('src', 'https://new.com/list.json');
-            list.mutatedAttributesCallback({'src': 'https://new.com/list.json'});
-          });
-          // TODO(#14772): this expectation is sometimes not met.
-          listMock.expects('toggleLoading').withExactArgs(false).once();
-          listMock.expects('togglePlaceholder').withExactArgs(false).once();
+      // Execute another fetch-triggering action immediately (actually on
+      // the next tick to avoid losing the layoutCallback() promise resolver).
+      Promise.resolve().then(() => {
+        element.setAttribute('src', 'https://new.com/list.json');
+        list.mutatedAttributesCallback({'src': 'https://new.com/list.json'});
+      });
+      // TODO(#14772): this expectation is sometimes not met.
+      listMock.expects('toggleLoading').withExactArgs(false).once();
+      listMock.expects('togglePlaceholder').withExactArgs(false).once();
 
 
-          return layout.then(() => rendered).then(() => {
-            expect(list.container_.contains(foo)).to.be.true;
+      return layout.then(() => rendered).then(() => {
+        expect(list.container_.contains(foo)).to.be.true;
 
-            // Only one render pass should be invoked at a time.
-            expect(doRenderPassSpy).to.be.calledOnce;
-            // But the next render pass should be scheduled.
-            expect(scheduleRenderSpy).to.be.calledTwice;
-            expect(scheduleRenderSpy).to.be.calledWith(1);
-          });
-        });
+        // Only one render pass should be invoked at a time.
+        expect(doRenderPassSpy).to.be.calledOnce;
+        // But the next render pass should be scheduled.
+        expect(scheduleRenderSpy).to.be.calledTwice;
+        expect(scheduleRenderSpy).to.be.calledWith(1);
+      });
+    });
 
     it('should refetch if refresh action is called', () => {
       const items = [{title: 'foo'}];
@@ -261,7 +260,6 @@ describes.realWin('amp-list component', {
       });
     });
 
-    // TODO (#14772): fix console errors in this test
     it('fetch should resolve if `src` is empty', () => {
       const spy = sandbox.spy(list, 'fetchList_');
       element.setAttribute('src', '');
@@ -271,7 +269,6 @@ describes.realWin('amp-list component', {
       });
     });
 
-    // TODO (#14772): fix console errors in this test
     it('should fail to load b/c data array is absent', () => {
       listMock.expects('fetch_').returns(Promise.resolve({})).once();
       listMock.expects('toggleLoading').withExactArgs(false).once();

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -354,7 +354,7 @@ describes.realWin('amp-list component', {
         return list.layoutCallback().catch(() => {});
       });
 
-      it('should hide placeholder and display fallback on fetch failure', () => {
+      it('should hide placeholder and show fallback on fetch failure', () => {
         // Stub fetch_() to fail.
         listMock.expects('fetch_').returns(Promise.reject()).once();
 
@@ -424,7 +424,7 @@ describes.realWin('amp-list component', {
         toggleExperiment(win, 'fast-amp-list', true, true);
       });
 
-      it('should not call Bind.scanAndApply() before FIRST_MUTATE', function*() {
+      it('should not call scanAndApply() before FIRST_MUTATE', function*() {
         const items = [{title: 'Title1'}];
         const output = [doc.createElement('div')];
         const rendered = expectFetchAndRender(items, output);
@@ -433,7 +433,7 @@ describes.realWin('amp-list component', {
         expect(bind.scanAndApply).to.not.have.been.called;
       });
 
-      it('should call Bind.scanAndApply() after FIRST_MUTATE', function*() {
+      it('should call scanAndApply() after FIRST_MUTATE', function*() {
         bind.signals = () => {
           return {get: name => (name === 'FIRST_MUTATE')};
         };

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -18,6 +18,7 @@ import {AmpEvents} from '../../../../src/amp-events';
 import {AmpList} from '../amp-list';
 import {Deferred} from '../../../../src/utils/promise';
 import {Services} from '../../../../src/services';
+import {toggleExperiment} from '../../../../src/experiments';
 
 describes.realWin('amp-list component', {
   amp: {
@@ -45,10 +46,7 @@ describes.realWin('amp-list component', {
     element.getFallback = () => null;
 
     const {promise, resolve} = new Deferred();
-    // By default, don't resolve the promise returned by bindForDocOrNull().
-    // This tests that we don't block render on retrieval of the Bind service.
     sandbox.stub(Services, 'bindForDocOrNull').returns(promise);
-    // Tests can resolve the promise and set a mock by calling setBindService().
     setBindService = resolve;
 
     list = new AmpList(element);
@@ -102,341 +100,355 @@ describes.realWin('amp-list component', {
     return Promise.all([fetch, render]);
   }
 
-  it('should fetch and render', () => {
-    const items = [
-      {title: 'Title1'},
-    ];
-    const itemElement = doc.createElement('div');
-    const rendered = expectFetchAndRender(items, [itemElement]);
-    return list.layoutCallback().then(() => rendered).then(() => {
-      expect(list.container_.contains(itemElement)).to.be.true;
+  describe('without amp-bind', () => {
+    beforeEach(() => {
+      setBindService(null);
     });
-  });
 
-  it('should attemptChangeHeight after render', () => {
-    const items = [
-      {title: 'Title1'},
-    ];
-    const itemElement = doc.createElement('div');
-    itemElement.style.height = '1337px';
-
-    const rendered = expectFetchAndRender(items, [itemElement]);
-
-    let measureFunc;
-    listMock.expects('getVsync').returns({
-      measure: func => {
-        measureFunc = func;
-      },
-    }).once();
-
-    listMock.expects('attemptChangeHeight')
-        .withExactArgs(1337)
-        .returns(Promise.resolve());
-
-    return list.layoutCallback().then(() => rendered).then(() => {
-      expect(list.container_.contains(itemElement)).to.be.true;
-      expect(measureFunc).to.exist;
-      measureFunc();
-    });
-  });
-
-  it('should fetch and render non-array if single-item is set', () => {
-    const items = {title: 'Title1'};
-    const itemElement = doc.createElement('div');
-    element.setAttribute('single-item', 'true');
-
-    const rendered = expectFetchAndRender(
-        items, [itemElement], {expr: 'items', singleItem: true});
-
-    return list.layoutCallback().then(() => rendered).then(() => {
-      expect(list.container_.contains(itemElement)).to.be.true;
-    });
-  });
-
-  it('should trim the results to max-items', () => {
-    const items = [
-      {title: 'Title1'},
-      {title: 'Title2'},
-      {title: 'Title3'},
-    ];
-    const itemElement = doc.createElement('div');
-    element.setAttribute('max-items', '2');
-
-    const rendered = expectFetchAndRender(
-        items, [itemElement], {expr: 'items', maxItems: 2});
-
-    return list.layoutCallback().then(() => rendered).then(() => {
-      expect(list.container_.contains(itemElement)).to.be.true;
-    });
-  });
-
-  it('should dispatch DOM_UPDATE event after render', () => {
-    const spy = sandbox.spy(list.container_, 'dispatchEvent');
-
-    const items = [{title: 'Title1'}];
-    const itemElement = doc.createElement('div');
-    const rendered = expectFetchAndRender(items, [itemElement]);
-
-    return list.layoutCallback().then(() => rendered).then(() => {
-      expect(spy).to.have.been.calledOnce;
-      expect(spy).calledWithMatch({
-        type: AmpEvents.DOM_UPDATE,
-        bubbles: true,
+    it('should fetch and render', () => {
+      const items = [
+        {title: 'Title1'},
+      ];
+      const itemElement = doc.createElement('div');
+      const rendered = expectFetchAndRender(items, [itemElement]);
+      return list.layoutCallback().then(() => rendered).then(() => {
+        expect(list.container_.contains(itemElement)).to.be.true;
       });
     });
-  });
 
-  it('should not call Bind.scanAndApply() before FIRST_MUTATE', function*() {
-    const bind = {
-      scanAndApply: sandbox.stub().returns(Promise.resolve()),
-      signals: () => {
-        return {get: unusedName => false};
-      },
-    };
-    setBindService(bind);
+    it('should attemptChangeHeight after render', () => {
+      const items = [
+        {title: 'Title1'},
+      ];
+      const itemElement = doc.createElement('div');
+      itemElement.style.height = '1337px';
 
-    const items = [{title: 'Title1'}];
-    const output = [doc.createElement('div')];
-    const rendered = expectFetchAndRender(items, output);
-    yield list.layoutCallback().then(() => rendered);
+      const rendered = expectFetchAndRender(items, [itemElement]);
 
-    expect(bind.scanAndApply).to.not.have.been.called;
-  });
+      let measureFunc;
+      listMock.expects('getVsync').returns({
+        measure: func => {
+          measureFunc = func;
+        },
+      }).once();
 
-  it('should call Bind.scanAndApply() after FIRST_MUTATE', function*() {
-    const bind = {
-      scanAndApply: sandbox.stub().returns(Promise.resolve()),
-      signals: () => {
-        return {get: name => (name === 'FIRST_MUTATE')};
-      },
-    };
-    setBindService(bind);
+      listMock.expects('attemptChangeHeight')
+          .withExactArgs(1337)
+          .returns(Promise.resolve());
 
-    const items = [{title: 'Title1'}];
-    const output = [doc.createElement('div')];
-    const rendered = expectFetchAndRender(items, output);
-    yield list.layoutCallback().then(() => rendered);
+      return list.layoutCallback().then(() => rendered).then(() => {
+        expect(list.container_.contains(itemElement)).to.be.true;
+        expect(measureFunc).to.exist;
+        measureFunc();
+      });
+    });
 
-    expect(bind.scanAndApply).to.have.been.calledOnce;
-    expect(bind.scanAndApply).calledWithExactly(output, [list.container_]);
-  });
+    it('should fetch and render non-array if single-item is set', () => {
+      const items = {title: 'Title1'};
+      const itemElement = doc.createElement('div');
+      element.setAttribute('single-item', 'true');
 
-  it('should _not_ refetch if [src] attribute changes (before layout)', () => {
-    // Not allowed before layout.
-    listMock.expects('fetchList_').never();
+      const rendered = expectFetchAndRender(
+          items, [itemElement], {expr: 'items', singleItem: true});
 
-    element.setAttribute('src', 'https://new.com/list.json');
-    list.mutatedAttributesCallback({'src': 'https://new.com/list.json'});
-    expect(element.getAttribute('src')).to.equal('https://new.com/list.json');
-  });
+      return list.layoutCallback().then(() => rendered).then(() => {
+        expect(list.container_.contains(itemElement)).to.be.true;
+      });
+    });
 
-  it('should render and remove `src` if [src] points to local data', () => {
-    const items = [{title: 'foo'}];
-    const foo = doc.createElement('div');
-    const rendered = expectFetchAndRender(items, [foo]);
+    it('should trim the results to max-items', () => {
+      const items = [
+        {title: 'Title1'},
+        {title: 'Title2'},
+        {title: 'Title3'},
+      ];
+      const itemElement = doc.createElement('div');
+      element.setAttribute('max-items', '2');
 
-    return list.layoutCallback().then(() => rendered).then(() => {
-      expect(list.container_.contains(foo)).to.be.true;
+      const rendered = expectFetchAndRender(
+          items, [itemElement], {expr: 'items', maxItems: 2});
 
+      return list.layoutCallback().then(() => rendered).then(() => {
+        expect(list.container_.contains(itemElement)).to.be.true;
+      });
+    });
+
+    it('should dispatch DOM_UPDATE event after render', () => {
+      const spy = sandbox.spy(list.container_, 'dispatchEvent');
+
+      const items = [{title: 'Title1'}];
+      const itemElement = doc.createElement('div');
+      const rendered = expectFetchAndRender(items, [itemElement]);
+
+      return list.layoutCallback().then(() => rendered).then(() => {
+        expect(spy).to.have.been.calledOnce;
+        expect(spy).calledWithMatch({
+          type: AmpEvents.DOM_UPDATE,
+          bubbles: true,
+        });
+      });
+    });
+
+    // TODO(#14772): figure out why this test is flaky and unskip
+    it.skip('should only process one fetch result at a time for rendering',
+        () => {
+          const doRenderPassSpy = sandbox.spy(list, 'doRenderPass_');
+          const scheduleRenderSpy = sandbox.spy(list.renderPass_, 'schedule');
+
+          const items = [{title: 'foo'}];
+          const foo = doc.createElement('div');
+          const rendered = expectFetchAndRender(items, [foo]);
+          const layout = list.layoutCallback();
+
+          // Execute another fetch-triggering action immediately (actually on
+          // the next tick to avoid losing the layoutCallback() promise resolver).
+          Promise.resolve().then(() => {
+            element.setAttribute('src', 'https://new.com/list.json');
+            list.mutatedAttributesCallback({'src': 'https://new.com/list.json'});
+          });
+          // TODO(#14772): this expectation is sometimes not met.
+          listMock.expects('toggleLoading').withExactArgs(false).once();
+          listMock.expects('togglePlaceholder').withExactArgs(false).once();
+
+
+          return layout.then(() => rendered).then(() => {
+            expect(list.container_.contains(foo)).to.be.true;
+
+            // Only one render pass should be invoked at a time.
+            expect(doRenderPassSpy).to.be.calledOnce;
+            // But the next render pass should be scheduled.
+            expect(scheduleRenderSpy).to.be.calledTwice;
+            expect(scheduleRenderSpy).to.be.calledWith(1);
+          });
+        });
+
+    it('should refetch if refresh action is called', () => {
+      const items = [{title: 'foo'}];
+      const foo = doc.createElement('div');
+      const rendered = expectFetchAndRender(items, [foo]);
+
+      return list.layoutCallback().then(() => rendered).then(() => {
+        expect(list.container_.contains(foo)).to.be.true;
+
+        const renderedAgain = expectFetchAndRender(items, [foo]);
+
+        list.executeAction({
+          method: 'refresh',
+          satisfiesTrust: () => true,
+        });
+        return renderedAgain;
+      });
+    });
+
+    it('should show placeholder and loading while refreshing when ' +
+      'reset-on-refresh is set', () => {
+      element.setAttribute('reset-on-refresh', 'true');
+      const items = [{title: 'foo'}];
+      const foo = doc.createElement('div');
+      const opts = {expr: 'items', resetOnRefresh: true};
+      const rendered = expectFetchAndRender(items, [foo], opts);
+
+      return list.layoutCallback().then(() => rendered).then(() => {
+        expect(list.container_.contains(foo)).to.be.true;
+
+        const renderedAgain = expectFetchAndRender(items, [foo], opts);
+
+        list.executeAction({
+          method: 'refresh',
+          satisfiesTrust: () => true,
+        });
+        return renderedAgain;
+      });
+    });
+
+    // TODO (#14772): fix console errors in this test
+    it('fetch should resolve if `src` is empty', () => {
+      const spy = sandbox.spy(list, 'fetchList_');
+      element.setAttribute('src', '');
+
+      return list.layoutCallback().then(() => {
+        expect(spy).to.have.been.calledOnce;
+      });
+    });
+
+    // TODO (#14772): fix console errors in this test
+    it('should fail to load b/c data array is absent', () => {
+      listMock.expects('fetch_').returns(Promise.resolve({})).once();
+      listMock.expects('toggleLoading').withExactArgs(false).once();
+      templatesMock.expects('findAndRenderTemplateArray').never();
+      return expect(list.layoutCallback()).to.eventually.be
+          .rejectedWith(/Response must contain an array/);
+    });
+
+    it('should fail to load b/c data single-item object is absent', () => {
+      element.setAttribute('single-item', 'true');
+      listMock.expects('fetch_').returns(Promise.resolve()).once();
+      listMock.expects('toggleLoading').withExactArgs(false).once();
+      templatesMock.expects('findAndRenderTemplateArray').never();
+      return expect(list.layoutCallback()).to.eventually.be
+          .rejectedWith(/Response must contain an array or object/);
+    });
+
+    it('should load and render with a different root', () => {
+      const items = [{title: 'Title1'}];
+      const itemElement = doc.createElement('div');
+      element.setAttribute('items', 'different');
+      expectFetchAndRender(items, [itemElement], {expr: 'different'});
+
+      return list.layoutCallback().then(() => {
+        expect(list.container_.contains(itemElement)).to.be.true;
+      });
+    });
+
+    it('should set accessibility roles', () => {
+      const items = [{title: 'Title1'}];
+      const itemElement = doc.createElement('div');
+      const rendered = expectFetchAndRender(items, [itemElement]);
+
+      return list.layoutCallback().then(() => rendered).then(() => {
+        expect(list.container_.getAttribute('role')).to.equal('list');
+        expect(itemElement.getAttribute('role')).to.equal('listitem');
+      });
+    });
+
+    it('should preserve accessibility roles', () => {
+      const items = [{title: 'Title1'}];
+      element.setAttribute('role', 'list1');
+      const itemElement = doc.createElement('div');
+      itemElement.setAttribute('role', 'listitem1');
+      const rendered = expectFetchAndRender(items, [itemElement]);
+
+      return list.layoutCallback().then(() => rendered).then(() => {
+        expect(list.element.getAttribute('role')).to.equal('list1');
+        expect(itemElement.getAttribute('role')).to.equal('listitem1');
+      });
+    });
+
+    it('should show placeholder on fetch failure (w/o fallback)', () => {
+      // Stub fetch_() to fail.
+      listMock.expects('fetch_').returns(Promise.reject()).once();
+      listMock.expects('toggleLoading').withExactArgs(false).once();
+      listMock.expects('togglePlaceholder').never();
+      return list.layoutCallback().catch(() => {});
+    });
+
+    // TODO(aghassemi, #12476): Make this test work with sinon 4.0.
+    describe.skip('with fallback', () => {
+      beforeEach(() => {
+        // Stub getFallback() with fake truthy value.
+        listMock.expects('getFallback').returns(true);
+        // Stub getVsync().mutate() to execute immediately.
+        listMock.expects('getVsync').returns({
+          measure: () => {},
+          mutate: block => block(),
+        }).atLeast(1);
+      });
+
+      it('should hide fallback element on fetch success', () => {
+        // Stub fetch and render to succeed.
+        listMock.expects('fetch_').returns(Promise.resolve([])).once();
+        templatesMock.expects('findAndRenderTemplateArray')
+            .returns(Promise.resolve([]));
+        // Act as if a fallback is already displayed.
+        sandbox.stub(list, 'fallbackDisplayed_').callsFake(true);
+
+        listMock.expects('togglePlaceholder').never();
+        listMock.expects('toggleFallback').withExactArgs(false).once();
+        return list.layoutCallback().catch(() => {});
+      });
+
+      it('should hide placeholder and display fallback on fetch failure', () => {
+        // Stub fetch_() to fail.
+        listMock.expects('fetch_').returns(Promise.reject()).once();
+
+        listMock.expects('togglePlaceholder').withExactArgs(false).once();
+        listMock.expects('toggleFallback').withExactArgs(true).once();
+        return list.layoutCallback().catch(() => {});
+      });
+    });
+  }); // without amp-bind
+
+  describe('with amp-bind', () => {
+    let bind;
+
+    beforeEach(() => {
+      bind = {
+        scanAndApply: sandbox.stub().returns(Promise.resolve()),
+        signals: () => {
+          return {get: unusedName => false};
+        },
+      };
+      setBindService(bind);
+    });
+
+    it('should _not_ refetch if [src] attr changes (before layout)', () => {
+      // Not allowed before layout.
       listMock.expects('fetchList_').never();
 
       element.setAttribute('src', 'https://new.com/list.json');
-      list.mutatedAttributesCallback({'src': items});
-      expect(element.getAttribute('src')).to.equal('');
-    });
-  });
-
-  it('should refetch if [src] attribute changes (after layout)', () => {
-    const items = [{title: 'foo'}];
-    const foo = doc.createElement('div');
-    const rendered = expectFetchAndRender(items, [foo]);
-
-    return list.layoutCallback().then(() => rendered).then(() => {
-      expect(list.container_.contains(foo)).to.be.true;
-
-      // Allowed post-layout.
-      listMock.expects('fetchList_').once();
-
-      element.setAttribute('src', 'https://new.com/list.json');
       list.mutatedAttributesCallback({'src': 'https://new.com/list.json'});
+      expect(element.getAttribute('src')).to.equal('https://new.com/list.json');
     });
-  });
 
-  // TODO(#14772): figure out why this test is flaky and unskip
-  it.skip('should only process one fetch result at a time for rendering',
-      () => {
-        const doRenderPassSpy = sandbox.spy(list, 'doRenderPass_');
-        const scheduleRenderSpy = sandbox.spy(list.renderPass_, 'schedule');
+    it('should render and remove `src` if [src] points to local data', () => {
+      const items = [{title: 'foo'}];
+      const foo = doc.createElement('div');
+      const rendered = expectFetchAndRender(items, [foo]);
 
-        const items = [{title: 'foo'}];
-        const foo = doc.createElement('div');
-        const rendered = expectFetchAndRender(items, [foo]);
-        const layout = list.layoutCallback();
+      return list.layoutCallback().then(() => rendered).then(() => {
+        expect(list.container_.contains(foo)).to.be.true;
 
-        // Execute another fetch-triggering action immediately (actually on
-        // the next tick to avoid losing the layoutCallback() promise resolver).
-        Promise.resolve().then(() => {
-          element.setAttribute('src', 'https://new.com/list.json');
-          list.mutatedAttributesCallback({'src': 'https://new.com/list.json'});
-        });
-        // TODO(#14772): this expectation is sometimes not met.
-        listMock.expects('toggleLoading').withExactArgs(false).once();
-        listMock.expects('togglePlaceholder').withExactArgs(false).once();
+        listMock.expects('fetchList_').never();
 
+        element.setAttribute('src', 'https://new.com/list.json');
+        list.mutatedAttributesCallback({'src': items});
+        expect(element.getAttribute('src')).to.equal('');
+      });
+    });
 
-        return layout.then(() => rendered).then(() => {
-          expect(list.container_.contains(foo)).to.be.true;
+    it('should refetch if [src] attribute changes (after layout)', () => {
+      const items = [{title: 'foo'}];
+      const foo = doc.createElement('div');
+      const rendered = expectFetchAndRender(items, [foo]);
 
-          // Only one render pass should be invoked at a time.
-          expect(doRenderPassSpy).to.be.calledOnce;
-          // But the next render pass should be scheduled.
-          expect(scheduleRenderSpy).to.be.calledTwice;
-          expect(scheduleRenderSpy).to.be.calledWith(1);
-        });
+      return list.layoutCallback().then(() => rendered).then(() => {
+        expect(list.container_.contains(foo)).to.be.true;
+
+        // Allowed post-layout.
+        listMock.expects('fetchList_').once();
+
+        element.setAttribute('src', 'https://new.com/list.json');
+        list.mutatedAttributesCallback({'src': 'https://new.com/list.json'});
+      });
+    });
+
+    describe('`fast-amp-list` experiment', () => {
+      beforeEach(() => {
+        toggleExperiment(win, 'fast-amp-list', true, true);
       });
 
-  it('should refetch if refresh action is called', () => {
-    const items = [{title: 'foo'}];
-    const foo = doc.createElement('div');
-    const rendered = expectFetchAndRender(items, [foo]);
+      it('should not call Bind.scanAndApply() before FIRST_MUTATE', function*() {
+        const items = [{title: 'Title1'}];
+        const output = [doc.createElement('div')];
+        const rendered = expectFetchAndRender(items, output);
+        yield list.layoutCallback().then(() => rendered);
 
-    return list.layoutCallback().then(() => rendered).then(() => {
-      expect(list.container_.contains(foo)).to.be.true;
-
-      const renderedAgain = expectFetchAndRender(items, [foo]);
-
-      list.executeAction({
-        method: 'refresh',
-        satisfiesTrust: () => true,
+        expect(bind.scanAndApply).to.not.have.been.called;
       });
-      return renderedAgain;
-    });
-  });
 
-  it('should show placeholder and loading while refreshing when ' +
-    'reset-on-refresh is set', () => {
-    element.setAttribute('reset-on-refresh', 'true');
-    const items = [{title: 'foo'}];
-    const foo = doc.createElement('div');
-    const opts = {expr: 'items', resetOnRefresh: true};
-    const rendered = expectFetchAndRender(items, [foo], opts);
+      it('should call Bind.scanAndApply() after FIRST_MUTATE', function*() {
+        bind.signals = () => {
+          return {get: name => (name === 'FIRST_MUTATE')};
+        };
 
-    return list.layoutCallback().then(() => rendered).then(() => {
-      expect(list.container_.contains(foo)).to.be.true;
+        const items = [{title: 'Title1'}];
+        const output = [doc.createElement('div')];
+        const rendered = expectFetchAndRender(items, output);
+        yield list.layoutCallback().then(() => rendered);
 
-      const renderedAgain = expectFetchAndRender(items, [foo], opts);
-
-      list.executeAction({
-        method: 'refresh',
-        satisfiesTrust: () => true,
+        expect(bind.scanAndApply).to.have.been.calledOnce;
+        expect(bind.scanAndApply).calledWithExactly(output, [list.container_]);
       });
-      return renderedAgain;
     });
-  });
-
-  // TODO (#14772): fix console errors in this test
-  it('fetch should resolve if `src` is empty', () => {
-    const spy = sandbox.spy(list, 'fetchList_');
-    element.setAttribute('src', '');
-
-    return list.layoutCallback().then(() => {
-      expect(spy).to.have.been.calledOnce;
-    });
-  });
-
-  // TODO (#14772): fix console errors in this test
-  it('should fail to load b/c data array is absent', () => {
-    listMock.expects('fetch_').returns(Promise.resolve({})).once();
-    listMock.expects('toggleLoading').withExactArgs(false).once();
-    templatesMock.expects('findAndRenderTemplateArray').never();
-    return expect(list.layoutCallback()).to.eventually.be
-        .rejectedWith(/Response must contain an array/);
-  });
-
-  it('should fail to load b/c data single-item object is absent', () => {
-    element.setAttribute('single-item', 'true');
-    listMock.expects('fetch_').returns(Promise.resolve()).once();
-    listMock.expects('toggleLoading').withExactArgs(false).once();
-    templatesMock.expects('findAndRenderTemplateArray').never();
-    return expect(list.layoutCallback()).to.eventually.be
-        .rejectedWith(/Response must contain an array or object/);
-  });
-
-  it('should load and render with a different root', () => {
-    const items = [{title: 'Title1'}];
-    const itemElement = doc.createElement('div');
-    element.setAttribute('items', 'different');
-    expectFetchAndRender(items, [itemElement], {expr: 'different'});
-
-    return list.layoutCallback().then(() => {
-      expect(list.container_.contains(itemElement)).to.be.true;
-    });
-  });
-
-  it('should set accessibility roles', () => {
-    const items = [{title: 'Title1'}];
-    const itemElement = doc.createElement('div');
-    const rendered = expectFetchAndRender(items, [itemElement]);
-
-    return list.layoutCallback().then(() => rendered).then(() => {
-      expect(list.container_.getAttribute('role')).to.equal('list');
-      expect(itemElement.getAttribute('role')).to.equal('listitem');
-    });
-  });
-
-  it('should preserve accessibility roles', () => {
-    const items = [{title: 'Title1'}];
-    element.setAttribute('role', 'list1');
-    const itemElement = doc.createElement('div');
-    itemElement.setAttribute('role', 'listitem1');
-    const rendered = expectFetchAndRender(items, [itemElement]);
-
-    return list.layoutCallback().then(() => rendered).then(() => {
-      expect(list.element.getAttribute('role')).to.equal('list1');
-      expect(itemElement.getAttribute('role')).to.equal('listitem1');
-    });
-  });
-
-  it('should show placeholder on fetch failure (w/o fallback)', () => {
-    // Stub fetch_() to fail.
-    listMock.expects('fetch_').returns(Promise.reject()).once();
-    listMock.expects('toggleLoading').withExactArgs(false).once();
-    listMock.expects('togglePlaceholder').never();
-    return list.layoutCallback().catch(() => {});
-  });
-
-  // TODO(aghassemi, #12476): Make this test work with sinon 4.0.
-  describe.skip('with fallback', () => {
-    beforeEach(() => {
-      // Stub getFallback() with fake truthy value.
-      listMock.expects('getFallback').returns(true);
-      // Stub getVsync().mutate() to execute immediately.
-      listMock.expects('getVsync').returns({
-        measure: () => {},
-        mutate: block => block(),
-      }).atLeast(1);
-    });
-
-    it('should hide fallback element on fetch success', () => {
-      // Stub fetch and render to succeed.
-      listMock.expects('fetch_').returns(Promise.resolve([])).once();
-      templatesMock.expects('findAndRenderTemplateArray')
-          .returns(Promise.resolve([]));
-      // Act as if a fallback is already displayed.
-      sandbox.stub(list, 'fallbackDisplayed_').callsFake(true);
-
-      listMock.expects('togglePlaceholder').never();
-      listMock.expects('toggleFallback').withExactArgs(false).once();
-      return list.layoutCallback().catch(() => {});
-    });
-
-    it('should hide placeholder and display fallback on fetch failure', () => {
-      // Stub fetch_() to fail.
-      listMock.expects('fetch_').returns(Promise.reject()).once();
-
-      listMock.expects('togglePlaceholder').withExactArgs(false).once();
-      listMock.expects('toggleFallback').withExactArgs(true).once();
-      return list.layoutCallback().catch(() => {});
-    });
-  });
+  }); // with amp-bind
 });


### PR DESCRIPTION
Partial for #15610. Related: #15272, #15311

- Stop instrumenting pre-gesture `amp-list` verification fails.
- Switch experiment from "opt-out" to "opt-in".

Surprisingly, I didn't see *any* "Pre-gesture mismatch" errors reported in Stackdriver. I'm guessing that part of the reason is PWA use cases are underreported (#16078). Even if impact appears to be small, I think we should still avoid introducing a breaking change using either a new optional attribute or a version bump for `amp-list`.

/to @aghassemi 