### PR TITLE
amp-date-picker: Flip the experiment flag to always on

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -37,5 +37,6 @@
   "expAdsenseUnconditionedCanonical": 0.01,
   "expAdsenseCanonical": 0.01,
   "adsense-delay-request": 0.01,
-  "doubleclick-delay-request":0.01
+  "doubleclick-delay-request":0.01,
+  "amp-date-picker": 1
 }

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -38,5 +38,6 @@
   "expAdsenseUnconditionedCanonical": 0.01,
   "expAdsenseCanonical": 0.01,
   "adsense-delay-request": 0.01,
-  "doubleclick-delay-request":0.01
+  "doubleclick-delay-request":0.01,
+  "amp-date-picker": 1
 }


### PR DESCRIPTION
Flipping the flag on since it would launch the component sooner than https://github.com/ampproject/amphtml/pull/16263 would. We can remove it after https://github.com/ampproject/amphtml/pull/16263 is in production.