### PR TITLE
Add Mixi.Media AD network widgets extension 

### DIFF
--- a/3p/integration.js
+++ b/3p/integration.js
@@ -167,6 +167,7 @@ import {mediavine} from '../ads/mediavine';
 import {medyanet} from '../ads/medyanet';
 import {meg} from '../ads/meg';
 import {microad} from '../ads/microad';
+import {miximedia} from '../ads/miximedia';
 import {mixpo} from '../ads/mixpo';
 import {monetizer101} from '../ads/monetizer101';
 import {mytarget} from '../ads/mytarget';
@@ -253,6 +254,7 @@ const AMP_EMBED_ALLOWED = {
   epeex: true,
   kuadio: true,
   'mantis-recommend': true,
+  miximedia: true,
   mywidget: true,
   outbrain: true,
   plista: true,
@@ -377,6 +379,7 @@ register('mediavine', mediavine);
 register('medyanet', medyanet);
 register('meg', meg);
 register('microad', microad);
+register('miximedia', miximedia);
 register('mixpo', mixpo);
 register('monetizer101', monetizer101);
 register('mytarget', mytarget);

--- a/ads/_config.js
+++ b/ads/_config.js
@@ -609,6 +609,7 @@ export const adConfig = {
       'https://deb.send.microad.jp',
     ],
   },
+
   miximedia: {
     renderStartImplemented: true,
   },

--- a/ads/_config.js
+++ b/ads/_config.js
@@ -609,6 +609,9 @@ export const adConfig = {
       'https://deb.send.microad.jp',
     ],
   },
+  miximedia: {
+    renderStartImplemented: true,
+  },
 
   mixpo: {
     prefetch: 'https://cdn.mixpo.com/js/loader.js',

--- a/ads/miximedia.js
+++ b/ads/miximedia.js
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {loadScript, validateData} from '../3p/3p';
+
+/**
+ * @param {!Window} global
+ * @param {!Object} data
+ */
+export function miximedia(global, data) {
+  validateData(data, ['blockid']);
+  (global._miximedia = global._miximedia || {
+    viewId: global.context.pageViewId,
+    blockId: data['blockid'],
+    htmlURL: data['canonical'] || global.context.canonicalUrl,
+    ampURL: data['ampurl'] || global.context.sourceUrl,
+    testMode: data['testmode'] || 'false',
+    referrer: data['referrer'] || global.context.referrer,
+    hostname: global.window.context.location.hostname,
+    clientId: window.context.clientId,
+    domFingerprint: window.context.domFingerprint,
+    location: window.context.location,
+    startTime: window.context.startTime,
+
+  });
+  global._miximedia.AMPCallbacks = {
+    renderStart: global.context.renderStart,
+    noContentAvailable: global.context.noContentAvailable,
+  };
+  // load the miximedia  AMP JS file script asynchronously
+  const rand = Math.round(Math.random() * 100000000);
+  loadScript(global, 'https://static.mixi.media/static/amppages/ampclient/mixi.js?rand=' + rand, () => {},
+      global.context.noContentAvailable);
+}

--- a/ads/miximedia.js
+++ b/ads/miximedia.js
@@ -42,6 +42,6 @@ export function miximedia(global, data) {
   };
   // load the miximedia  AMP JS file script asynchronously
   const rand = Math.round(Math.random() * 100000000);
-  loadScript(global, 'https://static.mixi.media/static/amppages/ampclient/mixi.js?rand=' + rand, () => {},
+  loadScript(global, 'https://amp.mixi.media/ampclient/mixi.js?rand=' + rand, () => {},
       global.context.noContentAvailable);
 }

--- a/ads/miximedia.md
+++ b/ads/miximedia.md
@@ -1,0 +1,37 @@
+<!---
+Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS-IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Mixi.Media
+
+Mixi.Media is a service for personalizing content network. Please visit our [Mixi.Media](https://Mixi.Media/dashboard) for more information.
+
+## Example
+
+```html
+<amp-embed height="284"
+    type="miximedia"
+    data-blockid="91908">
+</amp-embed>
+```
+
+## Configuration
+
+For details on the configuration semantics, please contact the ad network or refer to their documentation. 
+
+### Required parameters
+
+- `data-blockid` - insert your block_id
+

--- a/examples/ads.amp.html
+++ b/examples/ads.amp.html
@@ -158,6 +158,7 @@
         <option>mediavine</option>
         <option>meg</option>
         <option>microad</option>
+        <option>miximedia</option>
         <option>mixpo</option>
         <option>monetizer101</option>
         <option>mytarget</option>
@@ -1157,6 +1158,12 @@
       data-appid="${COMPASS_EXT_APPID}"
       data-geo="${COMPASS_EXT_GEO}">
   </amp-ad>
+
+  <h2>MixiMedia</h2>
+  <amp-embed height="284"
+      type="miximedia"
+      data-blockid="91908">
+  </amp-embed>
 
   <h2>Mixpo</h2>
   <amp-ad width="300" height="250"

--- a/extensions/amp-ad/amp-ad.md
+++ b/extensions/amp-ad/amp-ad.md
@@ -284,6 +284,7 @@ See [amp-ad rules](https://github.com/ampproject/amphtml/blob/master/extensions/
 - [Medyanet](../../ads/medyanet.md)
 - [Meg](../../ads/meg.md)
 - [MicroAd](../../ads/microad.md)
+- [MixiMedia](../../ads/miximedia.md)
 - [Mixpo](../../ads/mixpo.md)
 - [Monetizer101](../../ads/monetizer101.md)
 - [myTarget](../../ads/mytarget.md)


### PR DESCRIPTION
# Overview:
✨ New feature 


Provides support for amp-embed type=miximedia
It will be widget with content recommendations for User.
Project site https://mixi.media/

Mixi.Media is a service for personalizing content and increasing user metrics ad network.



# Example horizontal block

![Example horizontal block Mixi.Media](https://api.monosnap.com/rpc/file/download?id=ZJT315ou1J5sktKxzvLXNvLvkH6NYp)

# Usage
```xml
<amp-embed height="284"
        type="miximedia"
        data-blockid="91908">
</amp-embed>
```