### PR TITLE
🐛Fix broken test for postmessage origin in amp-brightcove

### DIFF
--- a/extensions/amp-analytics/amp-video-analytics.md
+++ b/extensions/amp-analytics/amp-video-analytics.md
@@ -26,6 +26,7 @@ AMP video analytics gathers data about how users interact with videos in AMP doc
 | `<amp-video>` | Full support |
 | `<amp-3q-player>` | Partial support<sup>[1]</sup> |
 | `<amp-brid-player>` | Partial support<sup>[1]</sup> |
+| `<amp-brightcove>` | Partial support<sup>[1]</sup> |
 | `<amp-dailymotion>` | Partial support<sup>[1]</sup> |
 | `<amp-ima-video>` | Partial support<sup>[1]</sup> |
 | `<amp-nexxtv-player>` | Partial support<sup>[1]</sup> |

--- a/extensions/amp-brightcove/0.1/amp-brightcove.js
+++ b/extensions/amp-brightcove/0.1/amp-brightcove.js
@@ -23,7 +23,6 @@ import {
   isJsonOrObj,
   mutedOrUnmutedEvent,
   objOrParseJson,
-  originMatches,
   redispatch,
 } from '../../../src/iframe-video';
 import {dev, user} from '../../../src/log';
@@ -154,7 +153,7 @@ class AmpBrightcove extends AMP.BaseElement {
   handlePlayerMessage_(event) {
     const {element} = this;
 
-    if (originMatches(event, this.iframe_, 'https://players.brightcove.net')) {
+    if (event.source != this.iframe_.contentWindow) {
       return;
     }
 


### PR DESCRIPTION
The refactor in #15527 breaks the test for the postmessage source in amp-brightcove. Instead of matching if the message source is the player iframe and the origin is as expected, [it now erroneously matches only if the origin is anything other than what is expected].(https://github.com/ampproject/amphtml/commit/5c6f19991f9938fb707742afd0943830b6da1489#diff-4d51c1b168f56d58518c97a3115effddL159).

This changes the test to checking whether the source is the component's frame. The origin check is superfluous.

Also adds amp-brightcove to the documentation for video analytics support, as this will work with this fix.
