### PR TITLE
AMP4Email ban amp-form support for submitting state

### DIFF
--- a/validator/testdata/amp4ads_feature_tests/amp_form.html
+++ b/validator/testdata/amp4ads_feature_tests/amp_form.html
@@ -55,6 +55,9 @@
     <input type="password" name="password">
     <input type="file" name="file">
     <input [type]="state.value" name="name">
+    <div submitting>
+      Submitting form...
+    </div>
   </form>
 </body>
 </html>

--- a/validator/testdata/amp4ads_feature_tests/amp_form.out
+++ b/validator/testdata/amp4ads_feature_tests/amp_form.out
@@ -64,6 +64,9 @@ amp4ads_feature_tests/amp_form.html:55:4 The attribute 'type' in tag 'input' is 
 >>     ^~~~~~~~~
 amp4ads_feature_tests/amp_form.html:56:4 The attribute 'type' in tag 'input' is set to the invalid value 'file'. (see https://www.ampproject.org/docs/reference/components/amp-form) [DISALLOWED_HTML]
 |      <input [type]="state.value" name="name">
+|      <div submitting>
+|        Submitting form...
+|      </div>
 |    </form>
 |  </body>
 |  </html>

--- a/validator/testdata/amp4email_feature_tests/amp_form.html
+++ b/validator/testdata/amp4email_feature_tests/amp_form.html
@@ -66,5 +66,11 @@
   <form method="get" action-xhr="https://example.com/subscribe">
     <input [type]="state.type" name="name">
   </form>
+  <!-- Invalid: invalid usage of submitting attribute -->
+  <form method="get" action-xhr="https://example.com/subscribe">
+    <div submitting>
+      Submitting form...
+    </div>
+  </form>
 </body>
 </html>

--- a/validator/testdata/amp4email_feature_tests/amp_form.out
+++ b/validator/testdata/amp4email_feature_tests/amp_form.out
@@ -81,5 +81,13 @@ amp4email_feature_tests/amp_form.html:62:2 The attribute 'xhr-verify' may not ap
 >>     ^~~~~~~~~
 amp4email_feature_tests/amp_form.html:67:4 The attribute '[type]' may not appear in tag 'INPUT (AMP4EMAIL)'. (see https://www.ampproject.org/docs/reference/components/amp-form) [DISALLOWED_HTML]
 |    </form>
+|    <!-- Invalid: invalid usage of submitting attribute -->
+|    <form method="get" action-xhr="https://example.com/subscribe">
+|      <div submitting>
+>>     ^~~~~~~~~
+amp4email_feature_tests/amp_form.html:71:4 The attribute 'submitting' may not appear in tag 'div'. [DISALLOWED_HTML]
+|        Submitting form...
+|      </div>
+|    </form>
 |  </body>
 |  </html>

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -3254,6 +3254,7 @@ tags {  # <form method=POST ...>
 tags {
   html_format: AMP
   html_format: AMP4ADS
+  html_format: EXPERIMENTAL
   tag_name: "DIV"
   spec_name: "FORM > DIV [submitting]"
   mandatory_parent: "FORM"

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -26,7 +26,7 @@ min_validator_revision_required: 328
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 658
+spec_file_revision: 662
 
 styles_spec_url: "https://www.ampproject.org/docs/guides/author-develop/responsive/style_pages"
 script_spec_url: "https://www.ampproject.org/docs/reference/spec#html-tags"
@@ -3511,7 +3511,7 @@ tags: {
   attr_lists: "input-name-attr"
   # Note that this amp-bind attribute is not available for the AMP4Email format
   # thus we add this manually for the formats that should.
-  attrs: {name: "[type]"}
+  attrs: { name: "[type]" }
   spec_url: "https://www.ampproject.org/docs/reference/components/amp-form"
 }
 tags: {

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -26,7 +26,7 @@ min_validator_revision_required: 328
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 662
+spec_file_revision: 658
 
 styles_spec_url: "https://www.ampproject.org/docs/guides/author-develop/responsive/style_pages"
 script_spec_url: "https://www.ampproject.org/docs/reference/spec#html-tags"
@@ -3252,6 +3252,8 @@ tags {  # <form method=POST ...>
   attrs: { name: "novalidate" }
 }
 tags {
+  html_format: AMP
+  html_format: AMP4ADS
   tag_name: "DIV"
   spec_name: "FORM > DIV [submitting]"
   mandatory_parent: "FORM"
@@ -3509,7 +3511,7 @@ tags: {
   attr_lists: "input-name-attr"
   # Note that this amp-bind attribute is not available for the AMP4Email format
   # thus we add this manually for the formats that should.
-  attrs: { name: "[type]" }
+  attrs: {name: "[type]"}
   spec_url: "https://www.ampproject.org/docs/reference/components/amp-form"
 }
 tags: {


### PR DESCRIPTION
Rather than supporting this intermediary state of a form submit and dealing with the additional RPC call, we are banning it for AMP4Email.