### PR TITLE
✨ Initial pass at rewriting viewport units in amp-story

### DIFF
--- a/examples/amp-story/ampconf.html
+++ b/examples/amp-story/ampconf.html
@@ -21,20 +21,16 @@
       font-family: 'Helvitica Nueve', sans-serif;
       color: white;
     }
-    amp-story {
-      font-size: 3.67vmin;
-    }
     amp-story-page {
       background: white;
     }
     amp-story h1 {
-      font-size: 2.875em;
+      font-size: 2.875rem;
     }
     amp-story h2 {
-      font-size: 2.25em;
+      font-size: 2.25rem;
     }
     amp-story p {
-      font-size: 1em;
       line-height: 1.5;
     }
     .bold {
@@ -56,7 +52,7 @@
       color: #4285F4;
     }
     .twenty-px {
-      font-size: 1.25em;
+      font-size: 1.25rem;
     }
     .center {
       text-align: center;
@@ -64,10 +60,10 @@
     .icon {
       background-image: url('./img/AMP-Brand-White-Icon.svg');
       background-repeat: no-repeat;
-      background-size: 4.25em 4.25em;
-      height: 4.25em;
+      background-size: 4.25rem 4.25rem;
+      height: 4.25rem;
       object-fit: contain;
-      width: 4.25em;
+      width: 4.25rem;
     }
     .byline {
       letter-spacing: 1.28px;

--- a/examples/amp-story/ampconf.html
+++ b/examples/amp-story/ampconf.html
@@ -105,7 +105,7 @@
   </style>
 </head>
   <body>
-    <amp-story standalone
+    <amp-story standalone id="cats"
         title="Key Highlights of AMP Conf 2018" publisher="The AMP team"
         publisher-logo-src="./img/AMP-Brand-White-Icon.svg"
         poster-portrait-src="./img/overview.jpg">

--- a/examples/amp-story/ampconf.html
+++ b/examples/amp-story/ampconf.html
@@ -21,18 +21,21 @@
       font-family: 'Helvitica Nueve', sans-serif;
       color: white;
     }
+    amp-story {
+      font-size: 3.67vmin;
+    }
     amp-story-page {
       background: white;
     }
     amp-story h1 {
-      font-size: 46px;
+      font-size: 2.875em;
     }
     amp-story h2 {
-      font-size: 36px;
+      font-size: 2.25em;
     }
     amp-story p {
-      font-size: 16px;
-      line-height: 24px;
+      font-size: 1em;
+      line-height: 1.5;
     }
     .bold {
       font-weight: bold;
@@ -44,53 +47,50 @@
       font-weight: 600;
     }
     .first {
-      padding-top: 65px;
+      padding-top: 8.83vh;
     }
     .last {
-      padding-bottom: 65px;
+      padding-bottom: 8.83vh;
     }
     .blue {
       color: #4285F4;
     }
     .twenty-px {
-      font-size: 20px;
+      font-size: 1.25em;
     }
     .center {
       text-align: center;
     }
-    .lh30 {
-      line-height: 30px;
-    }
     .icon {
       background-image: url('./img/AMP-Brand-White-Icon.svg');
       background-repeat: no-repeat;
-      background-size: 50px 50px;
-      height: 50px;
+      background-size: 4.25em 4.25em;
+      height: 4.25em;
       object-fit: contain;
-      width: 50px;
+      width: 4.25em;
     }
     .byline {
       letter-spacing: 1.28px;
-      padding-bottom: 58px;
+      padding-bottom: 7.88vh;
     }
     .introducing * {
-      line-height: 42px;
+      line-height: 2.625em;
     }
     .subtitle-page {
-      padding-top: 80px;
+      padding-top: 10.87vh;
     }
     .button {
       align-items: center;
       border: 4px solid #FFFFFF;
       color: #FFFFFF;
       display: flex;
-      height: 60px;
+      height: 3em;
+      line-height: 3em;
       margin: 0 auto;
       max-width: 240px;
       text-decoration:none;
     }
     .button p {
-      font-size: 20px;
       width: 100%;
     }
     amp-ad[template="image-template"] img {
@@ -297,7 +297,7 @@
         </amp-story-grid-layer>
         <amp-story-cta-layer>
           <a href="https://www.ampproject.org/amp-roadshow/" class="button medium center">
-            <p class="20px">Sign up Now</p>
+            <p class="twenty-px">Sign up Now</p>
           </a>
         </amp-story-cta-layer>
       </amp-story-page>

--- a/examples/amp-story/ampconf.html
+++ b/examples/amp-story/ampconf.html
@@ -73,8 +73,11 @@
       letter-spacing: 1.28px;
       padding-bottom: 7.88vh;
     }
-    .introducing * {
+    .introducing p {
       line-height: 2.625em;
+    }
+    .introducing h2 {
+      line-height: 1.17em;
     }
     .subtitle-page {
       padding-top: 10.87vh;
@@ -84,8 +87,6 @@
       border: 4px solid #FFFFFF;
       color: #FFFFFF;
       display: flex;
-      height: 3em;
-      line-height: 3em;
       margin: 0 auto;
       max-width: 240px;
       text-decoration:none;

--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -60,6 +60,7 @@ amp-story {
 
 html.i-amphtml-story-standalone,
 html.i-amphtml-story-standalone body {
+  font-size: calc(2 * var(--i-amphtml-story-vh, 8px));
   height: 100% !important;
   margin: 0 !important;
   padding: 0 !important;
@@ -69,6 +70,31 @@ html.i-amphtml-story-standalone body {
       touch feedback on mobile, like a flashing overlay on page transitions. */
   cursor: auto !important;
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0) !important;
+}
+
+amp-story p,
+amp-story h4 {
+  font-size: 1rem;
+}
+
+amp-story h1 {
+  font-size: 2rem;
+}
+
+amp-story h2 {
+  font-size: 1.5rem;
+}
+
+amp-story h3 {
+  font-size: 1.17rem;
+}
+
+amp-story h5 {
+  font-size: 0.83rem;
+}
+
+amp-story h6 {
+  font-size: 0.67rem;
 }
 
 html.i-amphtml-story-standalone body {

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -395,8 +395,8 @@ export class AmpStory extends AMP.BaseElement {
   updateViewportSizeStyles_() {
     this.vsync_.run({
       measure: state => {
-        state.vh = this.activePage_.element.clientHeight / 100;
-        state.vw = this.activePage_.element.clientWidth / 100;
+        state.vh = this.activePage_.element./*OK*/clientHeight / 100;
+        state.vw = this.activePage_.element./*OK*/clientWidth / 100;
         state.vmin = Math.min(state.vh, state.vw);
         state.vmax = Math.max(state.vh, state.vw);
       },

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -367,30 +367,12 @@ export class AmpStory extends AMP.BaseElement {
 
   /** @private */
   initializeStyles_() {
-    const storyId = this.getId();
-    const storyIdClassName = `i-amphtml-story-id-${storyId}`;
-    const pageEls = this.element.querySelectorAll('amp-story-page') || [];
-    const isStandalone = this.isStandalone_();
-    let styleEl;
-
-    if (isStandalone) {
-      styleEl = document.querySelector('style[amp-custom]');
-    } else {
-      styleEl = document.querySelector(
-          `style[amp-story="${escapeCssSelectorIdent(storyId)}"]`);
-    }
-
+    const styleEl = document.querySelector('style[amp-custom]');
     if (!styleEl) {
       return;
     }
 
-    this.mutateElement(() => {
-      styleEl.setAttribute('amp-story', storyId);
-      this.rewriteStyles_(styleEl);
-      Array.prototype.forEach.call(pageEls, pageEl => {
-        pageEl.classList.add(storyIdClassName);
-      });
-    });
+    this.rewriteStyles_(styleEl);
   }
 
 
@@ -405,11 +387,13 @@ export class AmpStory extends AMP.BaseElement {
 
     // TODO(#15955): Update this to use CssContext from
     // ../../../extensions/amp-animation/0.1/web-animations.js
-    styleEl.textContent = styleEl.textContent
-        .replace(/([\d.]+)vh/gmi, 'calc($1 * var(--i-amphtml-story-vh))')
-        .replace(/([\d.]+)vw/gmi, 'calc($1 * var(--i-amphtml-story-vw))')
-        .replace(/([\d.]+)vmin/gmi, 'calc($1 * var(--i-amphtml-story-vmin))')
-        .replace(/([\d.]+)vmax/gmi, 'calc($1 * var(--i-amphtml-story-vmax))');
+    this.mutateElement(() => {
+      styleEl.textContent = styleEl.textContent
+          .replace(/([\d.]+)vh/gmi, 'calc($1 * var(--i-amphtml-story-vh))')
+          .replace(/([\d.]+)vw/gmi, 'calc($1 * var(--i-amphtml-story-vw))')
+          .replace(/([\d.]+)vmin/gmi, 'calc($1 * var(--i-amphtml-story-vmin))')
+          .replace(/([\d.]+)vmax/gmi, 'calc($1 * var(--i-amphtml-story-vmax))');
+    });
   }
 
 
@@ -1619,13 +1603,6 @@ export class AmpStory extends AMP.BaseElement {
   /** @override */
   getElement() {
     return this.element;
-  }
-
-  /**
-   * @return {string}
-   */
-  getId() {
-    return this.element.id || STANDALONE_STORY_ID;
   }
 
   /**

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -399,6 +399,12 @@ export class AmpStory extends AMP.BaseElement {
    * @private
    */
   rewriteStyles_(styleEl) {
+    if (!isExperimentOn(this.win, 'amp-story-responsive-units')) {
+      return;
+    }
+
+    // TODO(#15955): Update this to use CssContext from
+    // ../../../extensions/amp-animation/0.1/web-animations.js
     styleEl.textContent = styleEl.textContent
         .replace(/([\d.]+)vh/gmi, 'calc($1 * var(--i-amphtml-story-vh))')
         .replace(/([\d.]+)vw/gmi, 'calc($1 * var(--i-amphtml-story-vw))')

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -74,7 +74,6 @@ import {
   childElements,
   closest,
   createElementWithAttributes,
-  escapeCssSelectorIdent,
   isRTL,
   scopedQuerySelectorAll,
 } from '../../../src/dom';
@@ -84,7 +83,6 @@ import {
   resetStyles,
   setImportantStyles,
   setStyle,
-  setStyles,
 } from '../../../src/style';
 import {debounce} from '../../../src/utils/rate-limit';
 import {dev, user} from '../../../src/log';
@@ -140,12 +138,6 @@ const Attributes = {
   NEXT: 'i-amphtml-next-page', // shown in right pane
   VISITED: 'i-amphtml-visited', // stacked offscreen to left
 };
-
-/**
- * The string used to identify a story that is standalone within a document.
- * @const {string}
- */
-const STANDALONE_STORY_ID = 'standalone';
 
 /**
  * The duration of time (in milliseconds) to wait for a page to be loaded,


### PR DESCRIPTION
This PR does three things:

1. Outside of any experiment, exposes four CSS custom properties:
  - `--i-amphtml-story-vh`: Equivalent to the `vh` where the viewport is defined as the `amp-story-page`
  - `--i-amphtml-story-vw`: Equivalent to the `vw` where the viewport is defined as the `amp-story-page`
  - `--i-amphtml-story-vmin`: Equivalent to the `vmin` where the viewport is defined as the `amp-story-page`
  - `--i-amphtml-story-vmax`: Equivalent to the `vmax` where the viewport is defined as the `amp-story-page`

2. Outside of any experiment, changes the base font size of `amp-story` documents from undefined (which would inherit the browser default, usually `16px`) to `calc(var(--i-amphtml-story-vh, 8px))` (i.e. `2vh`)

3. In the `amp-story-responsive-units` experiment, rewrites any publisher-specified styles in `<style amp-custom>` to use the custom properties defined above, by using regular expressions.

Partial fix for #15955 
TODO: Switch from using regular expressions to parsing the CSSOM.