### PR TITLE
Adds support for RTL navigation in amp-story pages ✨

### DIFF
--- a/extensions/amp-story/1.0/amp-story-store-service.js
+++ b/extensions/amp-story/1.0/amp-story-store-service.js
@@ -154,7 +154,7 @@ const actions = (state, action, data) => {
     // Triggers right to left experience.
     case Action.TOGGLE_RTL:
       return /** @type {!State} */ (Object.assign(
-          {}, state, {[StateProperty.RTL_STATE]: data}));
+          {}, state, {[StateProperty.RTL_STATE]: !!data}));
     case Action.SET_CONSENT_ID:
       return /** @type {!State} */ (Object.assign(
           {}, state, {[StateProperty.CONSENT_ID]: data}));
@@ -261,11 +261,11 @@ export class AmpStoryStoreService {
       [StateProperty.BOOKEND_STATE]: false,
       [StateProperty.DESKTOP_STATE]: false,
       [StateProperty.INFO_DIALOG_STATE]: false,
-      [StateProperty.RTL_STATE]: false,
       [StateProperty.HAS_AUDIO_STATE]: false,
       [StateProperty.LANDSCAPE_STATE]: false,
       [StateProperty.MUTED_STATE]: true,
       [StateProperty.PAUSED_STATE]: false,
+      [StateProperty.RTL_STATE]: false,
       [StateProperty.SHARE_MENU_STATE]: false,
       [StateProperty.SUPPORTED_BROWSER_STATE]: true,
       [StateProperty.CONSENT_ID]: null,

--- a/extensions/amp-story/1.0/amp-story-store-service.js
+++ b/extensions/amp-story/1.0/amp-story-store-service.js
@@ -35,6 +35,7 @@ const TAG = 'amp-story';
  *    bookendstate: boolean,
  *    desktopstate: boolean,
  *    infodialogstate: boolean,
+ *    isrtlstate: boolean,
  *    hasaudiostate: boolean,
  *    landscapestate: boolean,
  *    mutedstate: boolean,
@@ -64,6 +65,7 @@ export const StateProperty = {
   DESKTOP_STATE: 'desktopstate',
   HAS_AUDIO_STATE: 'hasaudiostate',
   INFO_DIALOG_STATE: 'infodialogstate',
+  IS_RTL_STATE: 'isrtlstate',
   LANDSCAPE_STATE: 'landscapestate',
   MUTED_STATE: 'mutedstate',
   PAUSED_STATE: 'pausedstate',
@@ -89,6 +91,7 @@ export const Action = {
   TOGGLE_LANDSCAPE: 'togglelandscape',
   TOGGLE_MUTED: 'togglemuted',
   TOGGLE_PAUSED: 'togglepaused',
+  TOGGLE_RTL: 'togglertl',
   TOGGLE_SHARE_MENU: 'togglesharemenu',
   TOGGLE_SUPPORTED_BROWSER: 'togglesupportedbrowser',
 };
@@ -148,6 +151,10 @@ const actions = (state, action, data) => {
             [StateProperty.PAUSED_STATE]: !!data,
             [StateProperty.SHARE_MENU_STATE]: !!data,
           }));
+    // Triggers right to left experience.
+    case Action.TOGGLE_RTL:
+      return /** @type {!State} */ (Object.assign(
+          {}, state, {[StateProperty.IS_RTL_STATE]: data}));
     case Action.SET_CONSENT_ID:
       return /** @type {!State} */ (Object.assign(
           {}, state, {[StateProperty.CONSENT_ID]: data}));
@@ -254,6 +261,7 @@ export class AmpStoryStoreService {
       [StateProperty.BOOKEND_STATE]: false,
       [StateProperty.DESKTOP_STATE]: false,
       [StateProperty.INFO_DIALOG_STATE]: false,
+      [StateProperty.IS_RTL_STATE]: false,
       [StateProperty.HAS_AUDIO_STATE]: false,
       [StateProperty.LANDSCAPE_STATE]: false,
       [StateProperty.MUTED_STATE]: true,

--- a/extensions/amp-story/1.0/amp-story-store-service.js
+++ b/extensions/amp-story/1.0/amp-story-store-service.js
@@ -35,11 +35,11 @@ const TAG = 'amp-story';
  *    bookendstate: boolean,
  *    desktopstate: boolean,
  *    infodialogstate: boolean,
- *    isrtlstate: boolean,
  *    hasaudiostate: boolean,
  *    landscapestate: boolean,
  *    mutedstate: boolean,
  *    pausedstate: boolean,
+ *    rtlstate: boolean,
  *    sharemenustate: boolean,
  *    supportedbrowserstate: boolean,
  *    consentid: ?string,
@@ -65,10 +65,10 @@ export const StateProperty = {
   DESKTOP_STATE: 'desktopstate',
   HAS_AUDIO_STATE: 'hasaudiostate',
   INFO_DIALOG_STATE: 'infodialogstate',
-  IS_RTL_STATE: 'isrtlstate',
   LANDSCAPE_STATE: 'landscapestate',
   MUTED_STATE: 'mutedstate',
   PAUSED_STATE: 'pausedstate',
+  RTL_STATE: 'rtlstate',
   SHARE_MENU_STATE: 'sharemenustate',
   SUPPORTED_BROWSER_STATE: 'supportedbrowserstate',
 
@@ -154,7 +154,7 @@ const actions = (state, action, data) => {
     // Triggers right to left experience.
     case Action.TOGGLE_RTL:
       return /** @type {!State} */ (Object.assign(
-          {}, state, {[StateProperty.IS_RTL_STATE]: data}));
+          {}, state, {[StateProperty.RTL_STATE]: data}));
     case Action.SET_CONSENT_ID:
       return /** @type {!State} */ (Object.assign(
           {}, state, {[StateProperty.CONSENT_ID]: data}));
@@ -261,7 +261,7 @@ export class AmpStoryStoreService {
       [StateProperty.BOOKEND_STATE]: false,
       [StateProperty.DESKTOP_STATE]: false,
       [StateProperty.INFO_DIALOG_STATE]: false,
-      [StateProperty.IS_RTL_STATE]: false,
+      [StateProperty.RTL_STATE]: false,
       [StateProperty.HAS_AUDIO_STATE]: false,
       [StateProperty.LANDSCAPE_STATE]: false,
       [StateProperty.MUTED_STATE]: true,

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -945,14 +945,14 @@ export class AmpStory extends AMP.BaseElement {
       return;
     }
 
-    const RtlState = this.storeService_.get(StateProperty.RTL_STATE);
+    const rtlState = this.storeService_.get(StateProperty.RTL_STATE);
 
     switch (e.keyCode) {
       case KeyCodes.LEFT_ARROW:
-        RtlState ? this.next_() : this.previous_();
+        rtlState ? this.next_() : this.previous_();
         break;
       case KeyCodes.RIGHT_ARROW:
-        RtlState ? this.previous_() : this.next_();
+        rtlState ? this.previous_() : this.next_();
         break;
     }
   }

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -73,6 +73,7 @@ import {
   childElements,
   closest,
   createElementWithAttributes,
+  isRTL,
   scopedQuerySelectorAll,
 } from '../../../src/dom';
 import {
@@ -580,6 +581,12 @@ export class AmpStory extends AMP.BaseElement {
 
     this.initializeBookend_();
 
+    const {document} = this.win;
+
+    if (isRTL(document)) {
+      this.storeService_.dispatch(Action.TOGGLE_RTL, true);
+    }
+
     const storyLayoutPromise = this.initializePages_()
         .then(() => this.buildSystemLayer_())
         .then(() => {
@@ -939,14 +946,15 @@ export class AmpStory extends AMP.BaseElement {
       return;
     }
 
-    switch (e.keyCode) {
-      // TODO(newmuis): This will need to be flipped for RTL.
-      case KeyCodes.LEFT_ARROW:
-        this.previous_();
-        break;
-      case KeyCodes.RIGHT_ARROW:
-        this.next_();
-        break;
+    const keyDirection = e.keyCode;
+    const isRtl = this.storeService_.get(StateProperty.IS_RTL_STATE);
+
+    if ((keyDirection == KeyCodes.LEFT_ARROW && isRtl) ||
+        (keyDirection == KeyCodes.RIGHT_ARROW && !isRtl)) {
+      this.next_();
+    } else if ((keyDirection == KeyCodes.RIGHT_ARROW && isRtl) ||
+        (keyDirection == KeyCodes.LEFT_ARROW && !isRtl)) {
+      this.previous_();
     }
   }
 

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -314,6 +314,11 @@ export class AmpStory extends AMP.BaseElement {
       this.initializeStandaloneStory_();
     }
 
+    // Check if story is RTL.
+    if (isRTL(this.win.document)) {
+      this.storeService_.dispatch(Action.TOGGLE_RTL, true);
+    }
+
     const pageEl = this.element.querySelector('amp-story-page');
     pageEl && pageEl.setAttribute('active', '');
 
@@ -580,12 +585,6 @@ export class AmpStory extends AMP.BaseElement {
     }
 
     this.initializeBookend_();
-
-    const {document} = this.win;
-
-    if (isRTL(document)) {
-      this.storeService_.dispatch(Action.TOGGLE_RTL, true);
-    }
 
     const storyLayoutPromise = this.initializePages_()
         .then(() => this.buildSystemLayer_())
@@ -946,15 +945,15 @@ export class AmpStory extends AMP.BaseElement {
       return;
     }
 
-    const keyDirection = e.keyCode;
-    const isRtl = this.storeService_.get(StateProperty.IS_RTL_STATE);
+    const RtlState = this.storeService_.get(StateProperty.RTL_STATE);
 
-    if ((keyDirection == KeyCodes.LEFT_ARROW && isRtl) ||
-        (keyDirection == KeyCodes.RIGHT_ARROW && !isRtl)) {
-      this.next_();
-    } else if ((keyDirection == KeyCodes.RIGHT_ARROW && isRtl) ||
-        (keyDirection == KeyCodes.LEFT_ARROW && !isRtl)) {
-      this.previous_();
+    switch (e.keyCode) {
+      case KeyCodes.LEFT_ARROW:
+        RtlState ? this.next_() : this.previous_();
+        break;
+      case KeyCodes.RIGHT_ARROW:
+        RtlState ? this.previous_() : this.next_();
+        break;
     }
   }
 

--- a/extensions/amp-story/1.0/page-advancement.js
+++ b/extensions/amp-story/1.0/page-advancement.js
@@ -271,6 +271,24 @@ class ManualAdvancement extends AdvancementConfig {
       this.storeService_ =
         Services.storyStoreService(element.ownerDocument.defaultView);
     }
+
+    const rtlState = this.storeService_.get(StateProperty.RTL_STATE);
+    this.sections_ = {
+      // Width and navigation direction of each section depend on whether the
+      // document is RTL or LTR.
+      left: {
+        widthRatio: rtlState ?
+          NEXT_SCREEN_AREA_RATIO : PREVIOUS_SCREEN_AREA_RATIO,
+        direction: rtlState ?
+          TapNavigationDirection.NEXT : TapNavigationDirection.PREVIOUS,
+      },
+      right: {
+        widthRatio: rtlState ?
+          PREVIOUS_SCREEN_AREA_RATIO : NEXT_SCREEN_AREA_RATIO,
+        direction: rtlState ?
+          TapNavigationDirection.PREVIOUS : TapNavigationDirection.NEXT,
+      },
+    };
   }
 
   /** @override */
@@ -343,7 +361,6 @@ class ManualAdvancement extends AdvancementConfig {
     // Using `left` as a fallback since Safari returns a ClientRect in some
     // cases.
     const offsetLeft = ('x' in pageRect) ? pageRect.x : pageRect.left;
-    const RtlState = this.storeService_.get(StateProperty.RTL_STATE);
 
     const page = {
       // Offset starting left of the page.
@@ -352,24 +369,7 @@ class ManualAdvancement extends AdvancementConfig {
       clickEventX: event.pageX,
     };
 
-    const sections = {
-      // Width and navigation direction of each section depend on whether the
-      // document is RTL or LTR.
-      left: {
-        widthRatio: RtlState ?
-          NEXT_SCREEN_AREA_RATIO : PREVIOUS_SCREEN_AREA_RATIO,
-        direction: RtlState ?
-          TapNavigationDirection.NEXT : TapNavigationDirection.PREVIOUS,
-      },
-      right: {
-        widthRatio: RtlState ?
-          PREVIOUS_SCREEN_AREA_RATIO : NEXT_SCREEN_AREA_RATIO,
-        direction: RtlState ?
-          TapNavigationDirection.PREVIOUS : TapNavigationDirection.NEXT,
-      },
-    };
-
-    this.onTapNavigation(this.getTapDirection_(page, sections));
+    this.onTapNavigation(this.getTapDirection_(page));
   }
 
   /**
@@ -378,10 +378,9 @@ class ManualAdvancement extends AdvancementConfig {
    * individual section has been previously defined depending on the language
    * settings.
    * @param {!Object} page
-   * @param {!Object} sections
    */
-  getTapDirection_(page, sections) {
-    const {left, right} = sections;
+  getTapDirection_(page) {
+    const {left, right} = this.sections_;
 
     if (page.clickEventX <= page.offset + (left.widthRatio * page.width)) {
       return left.direction;

--- a/extensions/amp-story/1.0/test/test-amp-story-page.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-page.js
@@ -16,7 +16,9 @@
 
 import {AmpDocSingle} from '../../../../src/service/ampdoc-impl';
 import {AmpStoryPage, PageState} from '../amp-story-page';
+import {AmpStoryStoreService} from '../amp-story-store-service';
 import {MediaType} from '../media-pool';
+import {registerServiceBuilder} from '../../../../src/service';
 
 
 describes.realWin('amp-story-page', {amp: true}, env => {
@@ -34,6 +36,9 @@ describes.realWin('amp-story-page', {amp: true}, env => {
         [MediaType.AUDIO]: 8,
       }),
     };
+
+    const storeService = new AmpStoryStoreService(win);
+    registerServiceBuilder(win, 'story-store', () => storeService);
 
     const story = win.document.createElement('amp-story');
     story.getImpl = () => Promise.resolve(mediaPoolRoot);


### PR DESCRIPTION
Part of #11647 

Flips the navigational click areas in an amp-story page when `dir="rtl"` is used in the document.

This means the next screen area that is positioned on the right for LTR languages will be on the left, and the previous screen area will be on the right. Same sizes of these areas will be taken into account.

A follow up PR will address the education overlay so that it matches these areas in RTL.
