### PR TITLE
Updating the amp-experiment example to a valid JSON.

### DIFF
--- a/extensions/amp-experiment/amp-experiment.md
+++ b/extensions/amp-experiment/amp-experiment.md
@@ -47,16 +47,16 @@ The configuration of the experiments is specified in a JSON object.
 <amp-experiment>
   <script type="application/json">
     {
-      aExperiment: {
-        sticky: true,
-        consentNotificationId: "consent-notif",
-        variants: {
-          treatment1: 12.5,
-          treatment2: 12.5,
-          treatment3: 25.0,
-        },
+      "aExperiment": {
+        "sticky": true,
+        "consentNotificationId": "consent-notif",
+        "variants": {
+          "treatment1": 12.5,
+          "treatment2": 12.5,
+          "treatment3": 25.0
+        }
       },
-      bExperiment: {...}
+      "bExperiment": {...}
     }
   </script>
 </amp-experiment>


### PR DESCRIPTION
Updating the amp-experiment example to a valid JSON, so developers can copy/paste it without running into a `Unexpected token a in JSON at position 25` like error.