### PR TITLE
Bump size limit to 78.15KB

### DIFF
--- a/build-system/tasks/bundle-size.js
+++ b/build-system/tasks/bundle-size.js
@@ -22,7 +22,7 @@ const log = require('fancy-log');
 const {getStdout} = require('../exec');
 
 const runtimeFile = './dist/v0.js';
-const maxSize = '78.14KB';
+const maxSize = '78.15KB';
 
 const {green, red, cyan, yellow} = colors;
 


### PR DESCRIPTION
Fixes #16391.

/to @jridgewell 