### PR TITLE
Remove obsolete experiments

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -3,7 +3,6 @@
     "amp-date-picker",
     "amp-next-page",
     "ampdoc-shell",
-    "disable-faster-amp-list",
     "inabox-rov",
     "inline-styles",
     "url-replacement-v2"
@@ -30,7 +29,6 @@
   "amp-animation": 1,
   "amp-live-list-sorting": 1,
   "amp-sidebar toolbar": 1,
-  "svg-in-mustache": 1,
   "amp-consent": 1,
   "amp-img-native-srcset": 1,
   "amp-story-v1": 1,

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -3,7 +3,6 @@
     "amp-date-picker",
     "amp-next-page",
     "ampdoc-shell",
-    "disable-faster-amp-list",
     "inabox-rov",
     "inline-styles",
     "url-replacement-v2"
@@ -30,8 +29,6 @@
   "amp-animation": 1,
   "amp-live-list-sorting": 1,
   "amp-sidebar toolbar": 1,
-  "svg-in-mustache": 0,
-  "disable-faster-amp-list": 1,
   "amp-consent": 1,
   "amp-img-native-srcset": 1,
   "amp-story-v1": 1,


### PR DESCRIPTION
**Do NOT submit until #16330 hits production.**

- Removes `disable-faster-amp-list` and `svg-in-mustache`.