### PR TITLE
Trigger transformEnd when zoom finishes and not during animation

### DIFF
--- a/extensions/amp-pan-zoom/0.1/amp-pan-zoom.js
+++ b/extensions/amp-pan-zoom/0.1/amp-pan-zoom.js
@@ -510,7 +510,6 @@ export class AmpPanZoom extends AMP.BaseElement {
         transform: translate(x, y) + ' ' + scale(s),
       });
     }, content);
-    this.triggerTransformEnd_(s, x, y);
   }
 
   /**
@@ -683,12 +682,14 @@ export class AmpPanZoom extends AMP.BaseElement {
         this.posX_ = newPosX;
         this.posY_ = newPosY;
         this.updatePanZoom_();
+        this.triggerTransformEnd_(newScale, newPosX, newPosY);
       });
     } else {
       this.scale_ = newScale;
       this.posX_ = newPosX;
       this.posY_ = newPosY;
       this.updatePanZoom_();
+      this.triggerTransformEnd_(newScale, newPosX, newPosY);
       return Promise.resolve();
     }
   }


### PR DESCRIPTION
Right now we're triggering the `transformEnd` on every animation, which is redundant. Change this so it only triggers after animation has ended. 