### PR TITLE
Doubleclick SRA block param merge refactor and additional test coverage

### DIFF
--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -219,7 +219,7 @@ export const SRA_JOINER = {
     const eids = {};
     const deid = impls.length &&
       /(?:#|,)deid=([\d,]+)/i.exec(impls[0].win.location.hash) || [];
-    (deid[1] || '').split(',').forEach(eid => eids[eid] = 1);
+    (deid[1] || '').split(',').forEach(eid => eid && (eids[eid] = 1));
     impls.forEach(impl => impl.experimentIds.forEach(eid => eids[eid] = 1));
     const eidKeys = Object.keys(eids).join();
     return eidKeys ? {'eid': eidKeys} : null;

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -1132,7 +1132,6 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
                         this.win, response, slotCallback);
                   })
                   .catch(error => {
-                    console.log('error!', error);
                     const canceled = isCancellation(error);
                     if (canceled) {
                       typeInstances.forEach(instance =>

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/sra-utils.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/sra-utils.js
@@ -74,11 +74,12 @@ function getFirstInstanceValue_(impls, extractFn) {
  */
 export function combineInventoryUnits(impls) {
   const uniqueIuNames = {};
+  const iuNamesOutput = [];
   let uniqueIuNamesCount = 0;
   const prevIusEncoded = [];
   impls.forEach(instance => {
     const iu = dev().assert(instance.element.getAttribute('data-slot'));
-    const componentNames = (iu || '').split('/');
+    const componentNames = iu.split('/');
     const encodedNames = [];
     for (let i = 0; i < componentNames.length; i++) {
       if (componentNames[i] == '') {
@@ -86,6 +87,7 @@ export function combineInventoryUnits(impls) {
       }
       let index = uniqueIuNames[componentNames[i]];
       if (index == undefined) {
+        iuNamesOutput.push(componentNames[i]);
         uniqueIuNames[componentNames[i]] = (index = uniqueIuNamesCount++);
       }
       encodedNames.push(index);
@@ -93,8 +95,7 @@ export function combineInventoryUnits(impls) {
     prevIusEncoded.push(encodedNames.join('/'));
   });
   return {
-    'iu_parts': Object.keys(uniqueIuNames).sort((a, b) =>
-      uniqueIuNames[a] - uniqueIuNames[b]).join(),
+    'iu_parts': iuNamesOutput.join(),
     'enc_prev_ius': prevIusEncoded.join(),
   };
 }

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/sra-utils.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/sra-utils.js
@@ -43,13 +43,15 @@ export function constructSRABlockParameters(impls) {
 }
 
 /**
-  * @param {!Array<!./amp-ad-network-doubleclick-impl.AmpAdNetworkDoubleclickImpl>} impls
-  * @param {function(!./amp-ad-network-doubleclick-impl.AmpAdNetworkDoubleclickImpl):?T} extractFn
-  * @return {?T} value of first instance with non-null/undefined value or null
-  *    if none can be found
-  * @template T
-  * @private
-  */
+ * Given array of instances, execute extractFn on each and return first non-
+ * falsey value or null if none are truthy.
+ * @param {!Array<!./amp-ad-network-doubleclick-impl.AmpAdNetworkDoubleclickImpl>} impls
+ * @param {function(!./amp-ad-network-doubleclick-impl.AmpAdNetworkDoubleclickImpl):?T} extractFn
+ * @return {?T} value of first instance with non-null/undefined value or null
+ *    if none can be found
+ * @template T
+ * @private
+ */
 function getFirstInstanceValue_(impls, extractFn) {
   for (let i = 0; i < impls.length; i++) {
     const val = extractFn(impls[i]);
@@ -64,6 +66,8 @@ function getFirstInstanceValue_(impls, extractFn) {
  * Combines inventory unit paths for multiple blocks by building list of
  * unique path parts in iu_parts and then comma separated list of block
  * paths using index into iu_parts list.
+ * Example: /123/foo/bar and /blah/foo/bar/123 =>
+ *    iu_parts=123,foo,bar,blah & enc_prev_ius=/0/1/2,/3/1/2/0
  * @param {!Array<!./amp-ad-network-doubleclick-impl.AmpAdNetworkDoubleclickImpl>} impls
  * @return {?Object<string,string>}
  * @visibleForTesting

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/sra-utils.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/sra-utils.js
@@ -1,0 +1,292 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {dev} from '../../../src/log';
+import {getEnclosingContainerTypes} from '../../../ads/google/a4a/utils';
+import {
+  isInManualExperiment,
+} from '../../../ads/google/a4a/traffic-experiments';
+
+/**
+ * @const {string}
+ * @visibleForTesting
+ */
+export const TFCD = 'tagForChildDirectedTreatment';
+
+/** @private {!Array<function(!Array<!./amp-ad-network-doubleclick-impl.AmpAdNetworkDoubleclickImpl>):?Object<string,string>>} */
+const SRA_JOINERS = [
+  combineInventoryUnits, getCookieOptOut, getAdks, getSizes, getTfcd, isAdTest,
+  getTargetingAndExclusions, getExperimentIds, getIdentity, getForceSafeframe,
+  getPageOffsets, getContainers];
+
+/**
+  * @param {!Array<!./amp-ad-network-doubleclick-impl.AmpAdNetworkDoubleclickImpl>} impls
+  * @return {!Object<string, *>}
+  */
+export function constructSRABlockParameters(impls) {
+  const parameters = {'output': 'ldjh', 'impl': 'fifs'};
+  SRA_JOINERS.forEach(joiner => Object.assign(parameters, joiner(impls)));
+  return parameters;
+}
+
+/**
+  * @param {!Array<!./amp-ad-network-doubleclick-impl.AmpAdNetworkDoubleclickImpl>} impls
+  * @param {function(!./amp-ad-network-doubleclick-impl.AmpAdNetworkDoubleclickImpl):?T} extractFn
+  * @return {?T} value of first instance with non-null/undefined value or null
+  *    if none can be found
+  * @template T
+  * @private
+  */
+function getFirstInstanceValue_(impls, extractFn) {
+  for (let i = 0; i < impls.length; i++) {
+    const val = extractFn(impls[i]);
+    if (val) {
+      return val;
+    }
+  }
+  return null;
+}
+
+/**
+ * Combines inventory unit paths for multiple blocks by building list of
+ * unique path parts in iu_parts and then comma separated list of block
+ * paths using index into iu_parts list.
+ * @param {!Array<!./amp-ad-network-doubleclick-impl.AmpAdNetworkDoubleclickImpl>} impls
+ * @return {?Object<string,string>}
+ * @visibleForTesting
+ */
+export function combineInventoryUnits(impls) {
+  const uniqueIuNames = {};
+  let uniqueIuNamesCount = 0;
+  const prevIusEncoded = [];
+  impls.forEach(instance => {
+    const iu = dev().assert(instance.element.getAttribute('data-slot'));
+    const componentNames = (iu || '').split('/');
+    const encodedNames = [];
+    for (let i = 0; i < componentNames.length; i++) {
+      if (componentNames[i] == '') {
+        continue;
+      }
+      let index = uniqueIuNames[componentNames[i]];
+      if (index == undefined) {
+        uniqueIuNames[componentNames[i]] = (index = uniqueIuNamesCount++);
+      }
+      encodedNames.push(index);
+    }
+    prevIusEncoded.push(encodedNames.join('/'));
+  });
+  return {
+    'iu_parts': Object.keys(uniqueIuNames).sort((a, b) =>
+      uniqueIuNames[a] - uniqueIuNames[b]).join(),
+    'enc_prev_ius': prevIusEncoded.join(),
+  };
+}
+
+/**
+ * Indicates SRA request is cookie opt out if any of the blocks includes
+ * cookie opt out in targeting.
+ * @param {!Array<!./amp-ad-network-doubleclick-impl.AmpAdNetworkDoubleclickImpl>} impls
+ * @return {?Object<string,string>}
+ * @visibleForTesting
+ */
+export function getCookieOptOut(impls) {
+  return getFirstInstanceValue_(impls, impl =>
+    impl.jsonTargeting &&
+         impl.jsonTargeting['cookieOptOut'] ? {'co': '1'} : null);
+}
+
+/**
+ * Combine ad unit key of each block via comma separated values.
+ * @param {!Array<!./amp-ad-network-doubleclick-impl.AmpAdNetworkDoubleclickImpl>} impls
+ * @return {?Object<string,string>}
+ * @visibleForTesting
+ */
+export function getAdks(impls) {
+  return ({'adks': impls.map(impl => dev().assert(impl.adKey)).join()});
+}
+
+/**
+ * Combine block sizes via comma separated values.
+ * @param {!Array<!./amp-ad-network-doubleclick-impl.AmpAdNetworkDoubleclickImpl>} impls
+ * @return {?Object<string,string>}
+ * @visibleForTesting
+ */
+export function getSizes(impls) {
+  return ({'prev_iu_szs': impls.map(impl =>
+    dev().assert(impl.parameterSize)).join()});
+}
+
+/**
+ * Indicate SRA request is tagForChildDirectedTreatment if any blocks includes
+ * in targeting.
+ * @param {!Array<!./amp-ad-network-doubleclick-impl.AmpAdNetworkDoubleclickImpl>} impls
+ * @return {?Object<string,string>}
+ * @visibleForTesting
+ */
+export function getTfcd(impls) {
+  return getFirstInstanceValue_(impls, impl =>
+    impl.jsonTargeting && impl.jsonTargeting[TFCD] ?
+      {'tfcd': impl.jsonTargeting[TFCD]} : null);
+}
+
+/**
+ * Indicate SRA request should include adtest=on if any block includes the
+ * manual experiment id.
+ * @param {!Array<!./amp-ad-network-doubleclick-impl.AmpAdNetworkDoubleclickImpl>} impls
+ * @return {?Object<string,string>}
+ * @visibleForTesting
+ */
+export function isAdTest(impls) {
+  return getFirstInstanceValue_(impls, impl =>
+    isInManualExperiment(impl.element) ? {'adtest': 'on'} : null);
+}
+
+/**
+ * Join block targeting values by separating by pipes (each key/value pair for
+ * a given block is separated by =) and exclusions are given special excl_cat
+ * key (list of categories are comma separated).
+ * @param {!Array<!./amp-ad-network-doubleclick-impl.AmpAdNetworkDoubleclickImpl>} impls
+ * @return {?Object<string,string>}
+ * @visibleForTesting
+ */
+export function getTargetingAndExclusions(impls) {
+  let hasScp = false;
+  const scps = [];
+  impls.forEach(impl => {
+    if (impl.jsonTargeting && (impl.jsonTargeting['targeting'] ||
+       impl.jsonTargeting['categoryExclusions'])) {
+      hasScp = true;
+      scps.push(serializeTargeting(
+          impl.jsonTargeting['targeting'] || null,
+          impl.jsonTargeting['categoryExclusions'] || null));
+    } else {
+      scps.push('');
+    }
+  });
+  return hasScp ? {'prev_scp': scps.join('|')} : null;
+}
+
+/**
+ * Experiment ids are assumed to be page level given that is all that is
+ * supported for SRA requests therefore block values are combined by building
+ * the unique set of experiment ids which are comma separated (order does not
+ * matter).
+ * @param {!Array<!./amp-ad-network-doubleclick-impl.AmpAdNetworkDoubleclickImpl>} impls
+ * @return {?Object<string,string>}
+ * @visibleForTesting
+ */
+export function getExperimentIds(impls) {
+  const eids = {};
+  const deid = impls.length &&
+     /(?:#|,)deid=([\d,]+)/i.exec(impls[0].win.location.hash) || [];
+  (deid[1] || '').split(',').forEach(eid => eid && (eids[eid] = 1));
+  impls.forEach(impl => impl.experimentIds.forEach(eid => eids[eid] = 1));
+  const eidKeys = Object.keys(eids).join();
+  return eidKeys ? {'eid': eidKeys} : null;
+}
+
+/**
+ * Identity token is page level therefore SRA uses the value of the first
+ * block.
+ * @param {!Array<!./amp-ad-network-doubleclick-impl.AmpAdNetworkDoubleclickImpl>} impls
+ * @return {?Object<string,string>}
+ * @visibleForTesting
+ */
+export function getIdentity(impls) {
+  return getFirstInstanceValue_(impls, impl => impl.buildIdentityParams());
+}
+
+/**
+ * Combine force safeframe values for each block via comma separated numeric
+ * values based on boolean value (e.g. false = 0, true = 1).  If none of the
+ * blocks has force safeframe, parameter is not included in SRA request.
+ * @param {!Array<!./amp-ad-network-doubleclick-impl.AmpAdNetworkDoubleclickImpl>} impls
+ * @return {?Object<string,string>}
+ * @visibleForTesting
+ */
+export function getForceSafeframe(impls) {
+  let safeframeForced = false;
+  const forceSafeframes = [];
+  impls.forEach(impl => {
+    safeframeForced = safeframeForced || impl.forceSafeframe;
+    forceSafeframes.push(Number(impl.forceSafeframe));
+  });
+  return safeframeForced ? {'fsfs': forceSafeframes.join()} : null;
+}
+
+/**
+ * Combine page offset info for each block by constructing separate parameter
+ * for left (adxs) and top (adyx) via comma separated.
+ * @param {!Array<!./amp-ad-network-doubleclick-impl.AmpAdNetworkDoubleclickImpl>} impls
+ * @return {?Object<string,string>}
+ * @visibleForTesting
+ */
+export function getPageOffsets(impls) {
+  const adxs = [];
+  const adys = [];
+  impls.forEach(impl => {
+    const layoutBox = impl.getPageLayoutBox();
+    adxs.push(layoutBox.left);
+    adys.push(layoutBox.top);
+  });
+  return {'adxs': adxs.join(), 'adys': adys.join()};
+}
+
+/**
+ * Combine which containers exist for each block (e.g. sticky) via pipe
+ * separator (as block can have multiple values that are comma separated).  If
+ * none of the blocks have a container, then parameter is not sent.
+ * @param {!Array<!./amp-ad-network-doubleclick-impl.AmpAdNetworkDoubleclickImpl>} impls
+ * @return {?Object<string,string>}
+ * @visibleForTesting
+ */
+export function getContainers(impls) {
+  let hasAmpContainer = false;
+  const result = [];
+  impls.forEach(impl => {
+    const containers = getEnclosingContainerTypes(impl.element);
+    result.push(containers.join());
+    hasAmpContainer = hasAmpContainer || !!containers.length;
+  });
+  return hasAmpContainer ? {'acts': result.join('|')} : null;
+}
+
+/**
+ * @param {?Object<string, (!Array<string>|string)>} targeting
+ * @param {?(!Array<string>|string)} categoryExclusions
+ * @return {?string}
+ */
+export function serializeTargeting(targeting, categoryExclusions) {
+  const serialized = targeting ?
+    Object.keys(targeting).map(key => serializeItem_(key, targeting[key])) :
+    [];
+  if (categoryExclusions) {
+    serialized.push(serializeItem_('excl_cat', categoryExclusions));
+  }
+  return serialized.length ? serialized.join('&') : null;
+}
+
+/**
+ * @param {string} key
+ * @param {(!Array<string>|string)} value
+ * @return {string}
+ * @private
+ */
+function serializeItem_(key, value) {
+  const serializedValue =
+    (Array.isArray(value) ? value : [value]).map(encodeURIComponent).join();
+  return `${encodeURIComponent(key)}=${serializedValue}`;
+}

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-rtc.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-rtc.js
@@ -63,7 +63,7 @@ describes.realWin('DoubleClick Fast Fetch RTC', {amp: true}, env => {
       rtcResponseArray, expectedParams, expectedJsonTargeting) {
       const rtcUrlParams = impl.mergeRtcResponses_(rtcResponseArray);
       expect(rtcUrlParams).to.deep.equal(expectedParams);
-      expect(impl.jsonTargeting_).to.deep.equal(expectedJsonTargeting);
+      expect(impl.jsonTargeting).to.deep.equal(expectedJsonTargeting);
     }
     it('should properly merge RTC responses into jsonTargeting on impl', () => {
       const rtcResponseArray = [
@@ -195,7 +195,7 @@ describes.realWin('DoubleClick Fast Fetch RTC', {amp: true}, env => {
 
 
     it('should properly merge mix of success and errors', () => {
-      impl.jsonTargeting_ = {targeting:
+      impl.jsonTargeting = {targeting:
                             {'abc': [1,2,3], 'b': {n: 'm'}, 'a': 'TEST'},
       categoryExclusions: ['sports']};
       const rtcResponseArray = [

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-sra.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-sra.js
@@ -23,7 +23,6 @@ import {
 } from '../../../amp-a4a/0.1/amp-a4a';
 import {
   AmpAdNetworkDoubleclickImpl,
-  TFCD,
   getNetworkId,
   resetSraStateForTesting,
 } from '../amp-ad-network-doubleclick-impl';
@@ -37,6 +36,7 @@ import {
 } from '../../../../ads/google/a4a/traffic-experiments';
 import {SignatureVerifier} from '../../../amp-a4a/0.1/signature-verifier';
 import {
+  TFCD,
   combineInventoryUnits,
   constructSRABlockParameters,
   getAdks,
@@ -213,9 +213,12 @@ describes.realWin('Doubleclick SRA', config , env => {
           {'eid': '7,123,456,901,902,903'});
     });
     it('should determine identity', () => {
-      impls[0] = {identityToken: {a: 123, b: 456}};
-      impls[1] = {identityToken: {foo: 'bar'}};
-      expect(getIdentity(impls)).to.jsonEqual({a: 123, b: 456});
+      impls[0] = new AmpAdNetworkDoubleclickImpl(
+          env.win.document.createElement('span'));
+      impls[0].identityToken = {token: 'foo', jar: 'bar', pucrd: 'oof'};
+      impls[1] = {};
+      expect(getIdentity(impls)).to.jsonEqual(
+          {adsid: 'foo', jar: 'bar', pucrd: 'oof'});
     });
     it('should combine force safeframe', () => {
       expect(getForceSafeframe(impls)).to.be.null;


### PR DESCRIPTION
Change block combiners from array to enum allowing for easier testing (and added said test coverage).