### PR TITLE
📖 amp-app-banner: Warn on missing app-argument.

### DIFF
--- a/extensions/amp-app-banner/0.1/amp-app-banner.js
+++ b/extensions/amp-app-banner/0.1/amp-app-banner.js
@@ -288,6 +288,11 @@ export class AmpIosAppBanner extends AbstractAppBanner {
     if (openUrl) {
       user().assert(Services.urlForDoc(this.element).isProtocolValid(openUrl),
           'The url in app-argument has invalid protocol: %s', openUrl);
+    } else {
+      user().error(TAG,
+          '<meta name="apple-itunes-app">\'s content should contain ' +
+          'app-argument to allow opening an already installed application ' +
+          'on iOS.');
     }
 
     const installAppUrl = `https://itunes.apple.com/us/app/id${appId}`;

--- a/extensions/amp-app-banner/0.1/test/test-amp-app-banner.js
+++ b/extensions/amp-app-banner/0.1/test/test-amp-app-banner.js
@@ -184,6 +184,10 @@ describes.realWin('amp-app-banner', {
 
     it('should parse meta content and setup hrefs if app-argument is ' +
         'not provided', () => {
+      expectAsyncConsoleError(
+          '[amp-app-banner] <meta name="apple-itunes-app">\'s content ' +
+          'should contain app-argument to allow opening an already ' +
+          'installed application on iOS.');
       sandbox.spy(AbstractAppBanner.prototype, 'setupOpenButton_');
       return getAppBanner({
         iosMeta: {content: 'app-id=828256236'},


### PR DESCRIPTION
If the '<meta name="apple-itunes-app">' is missing app-argument in the
content attribute, then the app will not open as expected if already
installed. Instead, the user will be taken to the app store.

Add a console error so that developers are aware of this.

Context: https://github.com/ampproject/amphtml/issues/15006#issuecomment-400125498. Found that several sites are missing this and as a result, the open in app button is not working correctly.

/cc @aghassemi 