### PR TITLE
✨🏗 Make `gulp test --local-changes` detect and test local CSS changes in extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ yarn-error.log
 PERCY_BUILD_ID
 chromedriver.log
 sc-*-linux*
+EXTENSIONS_CSS_MAP

--- a/contributing/DEVELOPING.md
+++ b/contributing/DEVELOPING.md
@@ -65,7 +65,7 @@ The Quick Start Guide's  [One-time setup](getting-started-quick.md#one-time-setu
 | `gulp pr-check --files=<test-files-path-glob>`                          | Runs all the Travis CI checks locally, and restricts tests to the files provided.  |
 | `gulp test --unit`                                                      | Runs the unit tests in Chrome (doesn't require the AMP library to be built).                                                 |
 | `gulp test --unit --files=<test-files-path-glob>`                       | Runs the unit tests from the specified files in Chrome.                                                 |
-| `gulp test --local-changes`                                             | Runs the unit tests affected by the files changed in the local branch in Chrome.   |
+| `gulp test --local-changes`                                             | Runs the unit tests directly affected by the files changed in the local branch in Chrome.   |
 | `gulp test --integration`                                               | Runs the integration tests in Chrome (requires the AMP library to be built).                                                 |
 | `gulp test --integration --files=<test-files-path-glob>`                | Runs the integration tests from the specified files in Chrome.                                                 |
 | `gulp test [--unit\|--integration] --verbose`                           | Runs tests in Chrome with logging enabled.                            |

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -542,6 +542,9 @@ function compileCss(watch, opt_compileAll) {
         }));
   }
 
+  // Used by `gulp test --local-changes` to map CSS files to JS files.
+  fs.writeFileSync('EXTENSIONS_CSS_MAP', JSON.stringify(extensions));
+
   const startTime = Date.now();
   return jsifyCssAsync('css/amp.css')
       .then(css => writeCss(css, 'amp.css', 'css.js', 'v0.css'))


### PR DESCRIPTION
This PR enhances `gulp test --local-changes` to detect if an extension's CSS files have changed on the local branch, and if so, to run its corresponding unit tests.

**Design**
1. During `gulp css`, we now write the mapping of CSS to JS files for all extensions to a local-only file called `EXTENSIONS_CSS_MAP`
2. During `gulp test --local-changes`, we extract from the file written in step 1, a full one-to-one mapping of each `.css` file in `extensions/` to its corresponding `.css.js` output file in `build/`
3. For each `.css` file in `extensions/` that's modified on the local branch, we first get a listing of all the `.js` source files in the extension directory
4. The list of `.js` source files in step 3 are filtered down to files that directly import the `.css.js` output file for that `.css` file, as determined in step 2
5. We then use the existing mechanism to find which `test-*.js` files directly import each of the `.js` source files found in step 4
6. These `test-*.js` files are merged (de-duped) into the full list of tests to be run

Phew!

**Notes:**
- From local testing, this doesn't seem to add any noticeable amount of time to the `Determining which unit tests to run...` step.
- `--local-changes` was not 100% foolproof in the presence of multi-level imports. For example, if the import chain is `foo.js` → `bar.js` → `test-bar.js`, changing `foo.js` would not run the tests in `test-bar.js` (but it would run the tests in `test-foo.js`)
- This limitation remains with CSS files, so if the import chain is `foo.css` → `foo.css.js` → `foo.js` → `bar.js` → `test-bar.js`, changing `foo.css` will not run the tests in `test-bar.js` (but it will run the tests in `test-foo.js`)

Fixes #16387
