### PR TITLE
✨amp-auto-ads: Adds experimental support for doubleclick

### DIFF
--- a/extensions/amp-auto-ads/0.1/ad-network-config.js
+++ b/extensions/amp-auto-ads/0.1/ad-network-config.js
@@ -25,7 +25,7 @@ import {parseUrlDeprecated} from '../../../src/url';
 import {tryParseJson} from '../../../src/json';
 
 
-/** @typedef {{width: string, height: string}} */
+/** @typedef {{width: (number|undefined), height: (number|undefined)}} */
 export let SizeInfoDef;
 
 /**
@@ -204,8 +204,10 @@ class DoubleclickNetworkConfig {
         this.autoAmpAdsElement_.getAttribute('data-experiment'));
     if (experimentJson) {
       return {
-        height: experimentJson['height'] ? experimentJson['height'] : '250',
-        width: experimentJson['width'],
+        height: experimentJson['height'] ?
+          Number(experimentJson['height']) : 250,
+        width: experimentJson['width'] ?
+          Number(experimentJson['width']) : undefined,
       };
     }
     return {};

--- a/extensions/amp-auto-ads/0.1/ad-network-config.js
+++ b/extensions/amp-auto-ads/0.1/ad-network-config.js
@@ -95,9 +95,9 @@ class AdSenseNetworkConfig {
   }
 
   /**
-   * @param {!Window} win
+   * @param {!Window} unused
    */
-  isEnabled(win) {
+  isEnabled(unused) {
     return true;
   }
 

--- a/extensions/amp-auto-ads/0.1/ad-network-config.js
+++ b/extensions/amp-auto-ads/0.1/ad-network-config.js
@@ -98,8 +98,7 @@ class AdSenseNetworkConfig {
    * @param {!Window} win
    */
   isEnabled(win) {
-    const branch = getAdSenseAmpAutoAdsExpBranch(win);
-    return branch != AdSenseAmpAutoAdsHoldoutBranches.CONTROL;
+    return true;
   }
 
   /** @override */

--- a/extensions/amp-auto-ads/0.1/ad-network-config.js
+++ b/extensions/amp-auto-ads/0.1/ad-network-config.js
@@ -164,12 +164,12 @@ class DoubleclickNetworkConfig {
     let experimentJson = {};
     try {
       experimentJson = JSON.parse(
-        this.autoAmpAdsElement_.getAttribute('data-experiment'));
+          this.autoAmpAdsElement_.getAttribute('data-experiment'));
     } catch (e) {}
     const attributes = dict({
       'type': 'doubleclick',
       'data-slot': this.autoAmpAdsElement_.getAttribute('data-slot'),
-      'json': this.autoAmpAdsElement_.getAttribute('data-json')
+      'json': this.autoAmpAdsElement_.getAttribute('data-json'),
     });
     if (experimentJson['height']) {
       attributes['height'] = experimentJson['height'];

--- a/extensions/amp-auto-ads/0.1/ad-network-config.js
+++ b/extensions/amp-auto-ads/0.1/ad-network-config.js
@@ -25,6 +25,9 @@ import {parseUrlDeprecated} from '../../../src/url';
 import {tryParseJson} from '../../../src/json';
 
 
+/** @typedef {{width: string, height: string}} */
+export let SizeInfoDef;
+
 /**
  * An interface intended to be implemented by any ad-networks wishing to support
  * amp-auto-ads.
@@ -56,6 +59,12 @@ class AdNetworkConfigDef {
    * @return {!./ad-tracker.AdConstraints}
    */
   getDefaultAdConstraints() {}
+
+  /**
+   * Network specific sizing information.
+   * @return {!SizeInfoDef}
+   */
+  getSizing() {}
 }
 
 /**
@@ -126,6 +135,11 @@ class AdSenseNetworkConfig {
       maxAdCount: 8,
     };
   }
+
+  /** @override */
+  getSizing() {
+    return {};
+  }
 }
 
 
@@ -167,19 +181,6 @@ class DoubleclickNetworkConfig {
       'data-slot': this.autoAmpAdsElement_.getAttribute('data-slot'),
       'json': this.autoAmpAdsElement_.getAttribute('data-json'),
     });
-    const experimentJson = tryParseJson(
-        this.autoAmpAdsElement_.getAttribute('data-experiment'));
-    if (experimentJson) {
-      if (experimentJson['height']) {
-        attributes['height'] = experimentJson['height'];
-      }
-      if (experimentJson['width']) {
-        attributes['width'] = experimentJson['width'];
-      }
-      if (experimentJson['layout']) {
-        attributes['layout'] = experimentJson['layout'];
-      }
-    }
     return attributes;
   }
 
@@ -195,5 +196,18 @@ class DoubleclickNetworkConfig {
       ],
       maxAdCount: 8,
     };
+  }
+
+  /** @override */
+  getSizing() {
+    const experimentJson = tryParseJson(
+        this.autoAmpAdsElement_.getAttribute('data-experiment'));
+    if (experimentJson) {
+      return {
+        height: experimentJson['height'] ? experimentJson['height'] : '250',
+        width: experimentJson['width'],
+      };
+    }
+    return {};
   }
 }

--- a/extensions/amp-auto-ads/0.1/ad-network-config.js
+++ b/extensions/amp-auto-ads/0.1/ad-network-config.js
@@ -95,10 +95,11 @@ class AdSenseNetworkConfig {
   }
 
   /**
-   * @param {!Window} unused
+   * @param {!Window} win
    */
-  isEnabled(unused) {
-    return true;
+  isEnabled(win) {
+    const branch = getAdSenseAmpAutoAdsExpBranch(win);
+    return branch != AdSenseAmpAutoAdsHoldoutBranches.CONTROL;
   }
 
   /** @override */
@@ -154,11 +155,10 @@ class DoubleclickNetworkConfig {
   }
 
   /**
-   * @param {!Window} win
+   * @param {!Window} unused
    */
-  isEnabled(win) {
-    const branch = getAdSenseAmpAutoAdsExpBranch(win);
-    return branch != AdSenseAmpAutoAdsHoldoutBranches.CONTROL;
+  isEnabled(unused) {
+    return true;
   }
 
   /** @override */

--- a/extensions/amp-auto-ads/0.1/ad-network-config.js
+++ b/extensions/amp-auto-ads/0.1/ad-network-config.js
@@ -22,6 +22,7 @@ import {Services} from '../../../src/services';
 import {buildUrl} from '../../../ads/google/a4a/url-builder';
 import {dict} from '../../../src/utils/object';
 import {parseUrlDeprecated} from '../../../src/url';
+import {tryParseJson} from '../../../src/json';
 
 
 /**
@@ -161,24 +162,23 @@ class DoubleclickNetworkConfig {
 
   /** @override */
   getAttributes() {
-    let experimentJson = {};
-    try {
-      experimentJson = JSON.parse(
-          this.autoAmpAdsElement_.getAttribute('data-experiment'));
-    } catch (e) {}
     const attributes = dict({
       'type': 'doubleclick',
       'data-slot': this.autoAmpAdsElement_.getAttribute('data-slot'),
       'json': this.autoAmpAdsElement_.getAttribute('data-json'),
     });
-    if (experimentJson['height']) {
-      attributes['height'] = experimentJson['height'];
-    }
-    if (experimentJson['width']) {
-      attributes['width'] = experimentJson['width'];
-    }
-    if (experimentJson['layout']) {
-      attributes['layout'] = experimentJson['layout'];
+    const experimentJson = tryParseJson(
+        this.autoAmpAdsElement_.getAttribute('data-experiment'));
+    if (experimentJson) {
+      if (experimentJson['height']) {
+        attributes['height'] = experimentJson['height'];
+      }
+      if (experimentJson['width']) {
+        attributes['width'] = experimentJson['width'];
+      }
+      if (experimentJson['layout']) {
+        attributes['layout'] = experimentJson['layout'];
+      }
     }
     return attributes;
   }

--- a/extensions/amp-auto-ads/0.1/ad-strategy.js
+++ b/extensions/amp-auto-ads/0.1/ad-strategy.js
@@ -15,6 +15,7 @@
  */
 
 import {DataAttributeDef, PlacementState} from './placement';
+import {SizeInfoDef} from './ad-network-config';
 import {tryResolve} from '../../../src/utils/promise';
 import {user} from '../../../src/log';
 
@@ -36,13 +37,17 @@ export class AdStrategy {
    * @param {!JsonObject<string, string>} baseAttributes Any attributes that
    *     should be added to any inserted ads. These will be combined with any
    *     additional data atrributes specified by the placement.
+   * @param {!SizeInfoDef} sizing
    * @param {!./ad-tracker.AdTracker} adTracker
    */
-  constructor(placements, baseAttributes, adTracker) {
+  constructor(placements, baseAttributes, sizing, adTracker) {
     this.availablePlacements_ = placements.slice(0);
 
     /** @private {!JsonObject<string, string>} */
     this.baseAttributes_ = baseAttributes;
+
+    /** @private {!SizeInfoDef} sizing */
+    this.sizing_ = sizing;
 
     /** @type {!./ad-tracker.AdTracker} */
     this.adTracker_ = adTracker;
@@ -90,7 +95,8 @@ export class AdStrategy {
       user().warn(TAG, 'unable to fulfill ad strategy');
       return Promise.resolve(false);
     }
-    return nextPlacement.placeAd(this.baseAttributes_, this.adTracker_)
+    return nextPlacement.placeAd(
+        this.baseAttributes_, this.sizing_, this.adTracker_)
         .then(state => {
           if (state == PlacementState.PLACED) {
             this.adTracker_.addAd(nextPlacement.getAdElement());

--- a/extensions/amp-auto-ads/0.1/amp-auto-ads.js
+++ b/extensions/amp-auto-ads/0.1/amp-auto-ads.js
@@ -74,10 +74,11 @@ export class AmpAutoAds extends AMP.BaseElement {
       const attributes = /** @type {!JsonObject} */ (
         Object.assign(adNetwork.getAttributes(),
             getAttributesFromConfigObj(configObj)));
+      const sizing = adNetwork.getSizing();
       const adConstraints = getAdConstraintsFromConfigObj(ampdoc, configObj) ||
           adNetwork.getDefaultAdConstraints();
       const adTracker = new AdTracker(getExistingAds(ampdoc), adConstraints);
-      new AdStrategy(placements, attributes, adTracker).run();
+      new AdStrategy(placements, attributes, sizing, adTracker).run();
       new AnchorAdStrategy(ampdoc, attributes, configObj).run();
     });
   }

--- a/extensions/amp-auto-ads/0.1/placement.js
+++ b/extensions/amp-auto-ads/0.1/placement.js
@@ -205,7 +205,7 @@ export class Placement {
       'layout': 'fixed-height',
       'class': 'i-amphtml-layout-awaiting-size',
     }), baseAttributes, this.attributes_));
-    attributes['height'] = 0;
+    attributes['height'] = '0';
     return createElementWithAttributes(
         this.ampdoc.win.document, 'amp-ad', attributes);
   }

--- a/extensions/amp-auto-ads/0.1/placement.js
+++ b/extensions/amp-auto-ads/0.1/placement.js
@@ -180,11 +180,11 @@ export class Placement {
           this.state_ = PlacementState.TOO_NEAR_EXISTING_AD;
           return this.state_;
         }
-        this.adElement_ = this.createAdElement_(baseAttributes, sizing);
+        this.adElement_ = this.createAdElement_(baseAttributes, sizing.width);
         this.injector_(this.anchorElement_, this.adElement_);
         return this.resources_.attemptChangeSize(this.adElement_,
             sizing.height || TARGET_AD_HEIGHT_PX,
-            sizing.width, this.margins_)
+            undefined, this.margins_)
             .then(() => {
               this.state_ = PlacementState.PLACED;
               return this.state_;
@@ -198,15 +198,15 @@ export class Placement {
 
   /**
    * @param {!JsonObject<string, string>} baseAttributes
-   * @param {!./ad-network-config.SizeInfoDef} sizing
+   * @param {number|undefined} width
    * @return {!Element}
    * @private
    */
-  createAdElement_(baseAttributes, sizing) {
+  createAdElement_(baseAttributes, width) {
     const attributes = /** @type {!JsonObject} */ (Object.assign(dict({
-      'layout': sizing.width ? 'fixed' : 'fixed-height',
+      'layout': width ? 'fixed' : 'fixed-height',
       'height': '0',
-      'width': sizing.width ? sizing.width : 'auto',
+      'width': width ? width : 'auto',
       'class': 'i-amphtml-layout-awaiting-size',
     }), baseAttributes, this.attributes_));
     return createElementWithAttributes(

--- a/extensions/amp-auto-ads/0.1/placement.js
+++ b/extensions/amp-auto-ads/0.1/placement.js
@@ -182,7 +182,8 @@ export class Placement {
         this.adElement_ = this.createAdElement_(baseAttributes);
         this.injector_(this.anchorElement_, this.adElement_);
         return this.resources_.attemptChangeSize(this.adElement_,
-            TARGET_AD_HEIGHT_PX, undefined, this.margins_)
+            baseAttributes['height'] || TARGET_AD_HEIGHT_PX,
+            baseAttributes['width'], this.margins_)
             .then(() => {
               this.state_ = PlacementState.PLACED;
               return this.state_;
@@ -202,9 +203,9 @@ export class Placement {
   createAdElement_(baseAttributes) {
     const attributes = /** @type {!JsonObject} */ (Object.assign(dict({
       'layout': 'fixed-height',
-      'height': '0',
       'class': 'i-amphtml-layout-awaiting-size',
     }), baseAttributes, this.attributes_));
+    attributes['height'] = 0;
     return createElementWithAttributes(
         this.ampdoc.win.document, 'amp-ad', attributes);
   }

--- a/extensions/amp-auto-ads/0.1/test/test-ad-network-config.js
+++ b/extensions/amp-auto-ads/0.1/test/test-ad-network-config.js
@@ -135,13 +135,15 @@ describes.realWin('ad-network-config', {
 
     const TARGETING_JSON = {'Categories': 'A'};
 
-    const EXPERIMENT_SETTINGS = {'layout': 'fixed', 'width': 300, 'height': 250};
+    const EXPERIMENT_SETTINGS =
+        {'layout': 'fixed', 'width': 300, 'height': 250};
 
     const AD_SLOT = '1234/example.com/SLOT_1';
 
     beforeEach(() => {
       ampAutoAdsElem.setAttribute('data-ad-legacy-client', AD_LEGACY_CLIENT);
-      ampAutoAdsElem.setAttribute('data-experiment', JSON.stringify(EXPERIMENT_SETTINGS));
+      ampAutoAdsElem.setAttribute('data-experiment',
+          JSON.stringify(EXPERIMENT_SETTINGS));
       ampAutoAdsElem.setAttribute('data-json', JSON.stringify(TARGETING_JSON));
       ampAutoAdsElem.setAttribute('data-slot', AD_SLOT);
     });
@@ -203,7 +205,7 @@ describes.realWin('ad-network-config', {
         'data-slot': AD_SLOT,
         'layout': 'fixed',
         'width': 300,
-        'height': 250
+        'height': 250,
       });
     });
 

--- a/extensions/amp-auto-ads/0.1/test/test-ad-network-config.js
+++ b/extensions/amp-auto-ads/0.1/test/test-ad-network-config.js
@@ -135,8 +135,7 @@ describes.realWin('ad-network-config', {
 
     const TARGETING_JSON = {'Categories': 'A'};
 
-    const EXPERIMENT_SETTINGS =
-        {'layout': 'fixed', 'width': 300, 'height': 250};
+    const EXPERIMENT_SETTINGS = {'width': 300, 'height': 250};
 
     const AD_SLOT = '1234/example.com/SLOT_1';
 
@@ -203,9 +202,6 @@ describes.realWin('ad-network-config', {
         'type': 'doubleclick',
         'json': JSON.stringify(TARGETING_JSON),
         'data-slot': AD_SLOT,
-        'layout': 'fixed',
-        'width': 300,
-        'height': 250,
       });
     });
 

--- a/extensions/amp-auto-ads/0.1/test/test-ad-network-config.js
+++ b/extensions/amp-auto-ads/0.1/test/test-ad-network-config.js
@@ -147,29 +147,9 @@ describes.realWin('ad-network-config', {
       ampAutoAdsElem.setAttribute('data-slot', AD_SLOT);
     });
 
-    it('should report enabled when holdout experiment not on', () => {
-      toggleExperiment(
-          env.win, ADSENSE_AMP_AUTO_ADS_HOLDOUT_EXPERIMENT_NAME, false);
+    it('should report enabled always', () => {
       const adNetwork = getAdNetworkConfig('doubleclick', ampAutoAdsElem);
       expect(adNetwork.isEnabled(env.win)).to.equal(true);
-    });
-
-    it('should report enabled when holdout experiment on and experiment ' +
-        'branch picked', () => {
-      forceExperimentBranch(env.win,
-          ADSENSE_AMP_AUTO_ADS_HOLDOUT_EXPERIMENT_NAME,
-          AdSenseAmpAutoAdsHoldoutBranches.EXPERIMENT);
-      const adNetwork = getAdNetworkConfig('doubleclick', ampAutoAdsElem);
-      expect(adNetwork.isEnabled(env.win)).to.equal(true);
-    });
-
-    it('should report disabled when holdout experiment on and control ' +
-        'branch picked', () => {
-      forceExperimentBranch(env.win,
-          ADSENSE_AMP_AUTO_ADS_HOLDOUT_EXPERIMENT_NAME,
-          AdSenseAmpAutoAdsHoldoutBranches.CONTROL);
-      const adNetwork = getAdNetworkConfig('doubleclick', ampAutoAdsElem);
-      expect(adNetwork.isEnabled(env.win)).to.equal(false);
     });
 
     it('should generate the config fetch URL', () => {

--- a/extensions/amp-auto-ads/0.1/test/test-ad-network-config.js
+++ b/extensions/amp-auto-ads/0.1/test/test-ad-network-config.js
@@ -129,6 +129,102 @@ describes.realWin('ad-network-config', {
     });
   });
 
+  describe('Doubleclick', () => {
+
+    const AD_LEGACY_CLIENT = 'ca-pub-1234';
+
+    const TARGETING_JSON = {'Categories': 'A'};
+
+    const EXPERIMENT_SETTINGS = {'layout': 'fixed', 'width': 300, 'height': 250};
+
+    const AD_SLOT = '1234/example.com/SLOT_1';
+
+    beforeEach(() => {
+      ampAutoAdsElem.setAttribute('data-ad-legacy-client', AD_LEGACY_CLIENT);
+      ampAutoAdsElem.setAttribute('data-experiment', JSON.stringify(EXPERIMENT_SETTINGS));
+      ampAutoAdsElem.setAttribute('data-json', JSON.stringify(TARGETING_JSON));
+      ampAutoAdsElem.setAttribute('data-slot', AD_SLOT);
+    });
+
+    it('should report enabled when holdout experiment not on', () => {
+      toggleExperiment(
+          env.win, ADSENSE_AMP_AUTO_ADS_HOLDOUT_EXPERIMENT_NAME, false);
+      const adNetwork = getAdNetworkConfig('doubleclick', ampAutoAdsElem);
+      expect(adNetwork.isEnabled(env.win)).to.equal(true);
+    });
+
+    it('should report enabled when holdout experiment on and experiment ' +
+        'branch picked', () => {
+      forceExperimentBranch(env.win,
+          ADSENSE_AMP_AUTO_ADS_HOLDOUT_EXPERIMENT_NAME,
+          AdSenseAmpAutoAdsHoldoutBranches.EXPERIMENT);
+      const adNetwork = getAdNetworkConfig('doubleclick', ampAutoAdsElem);
+      expect(adNetwork.isEnabled(env.win)).to.equal(true);
+    });
+
+    it('should report disabled when holdout experiment on and control ' +
+        'branch picked', () => {
+      forceExperimentBranch(env.win,
+          ADSENSE_AMP_AUTO_ADS_HOLDOUT_EXPERIMENT_NAME,
+          AdSenseAmpAutoAdsHoldoutBranches.CONTROL);
+      const adNetwork = getAdNetworkConfig('doubleclick', ampAutoAdsElem);
+      expect(adNetwork.isEnabled(env.win)).to.equal(false);
+    });
+
+    it('should generate the config fetch URL', () => {
+      const adNetwork = getAdNetworkConfig('doubleclick', ampAutoAdsElem);
+      expect(adNetwork.getConfigUrl()).to.equal(
+          '//pagead2.googlesyndication.com/getconfig/ama?client=' +
+          AD_LEGACY_CLIENT + '&plah=foo.bar&ama_t=amp&' +
+          'url=https%3A%2F%2Ffoo.bar%2Fbaz');
+    });
+
+    // TODO(bradfrizzell, #12476): Make this test work with sinon 4.0.
+    it.skip('should truncate the URL if it\'s too long', () => {
+      const adNetwork = getAdNetworkConfig('doubleclick', ampAutoAdsElem);
+
+      const canonicalUrl = 'http://foo.bar/' + 'a'.repeat(4050)
+          + 'shouldnt_be_included';
+
+      const docInfo = Services.documentInfoForDoc(ampAutoAdsElem);
+      sandbox.stub(docInfo, 'canonicalUrl').callsFake(canonicalUrl);
+
+      const url = adNetwork.getConfigUrl();
+      expect(url).to.contain('ama_t=amp');
+      expect(url).to.contain('url=http%3A%2F%2Ffoo.bar');
+      expect(url).not.to.contain('shouldnt_be_included');
+    });
+
+    it('should generate the attributes', () => {
+      const adNetwork = getAdNetworkConfig('doubleclick', ampAutoAdsElem);
+      expect(adNetwork.getAttributes()).to.deep.equal({
+        'type': 'doubleclick',
+        'json': JSON.stringify(TARGETING_JSON),
+        'data-slot': AD_SLOT,
+        'layout': 'fixed',
+        'width': 300,
+        'height': 250
+      });
+    });
+
+    it('should get the default ad constraints', () => {
+      const viewportMock =
+          sandbox.mock(Services.viewportForDoc(env.win.document));
+      viewportMock.expects('getSize').returns(
+          {width: 320, height: 500}).atLeast(1);
+
+      const adNetwork = getAdNetworkConfig('doubleclick', ampAutoAdsElem);
+      expect(adNetwork.getDefaultAdConstraints()).to.deep.equal({
+        initialMinSpacing: 500,
+        subsequentMinSpacing: [
+          {adCount: 3, spacing: 1000},
+          {adCount: 6, spacing: 1500},
+        ],
+        maxAdCount: 8,
+      });
+    });
+  });
+
   it('should return null for unknown type', () => {
     expect(getAdNetworkConfig('unknowntype', ampAutoAdsElem)).to.be.null;
   });

--- a/extensions/amp-auto-ads/0.1/test/test-ad-strategy.js
+++ b/extensions/amp-auto-ads/0.1/test/test-ad-strategy.js
@@ -82,12 +82,15 @@ describes.realWin('amp-strategy', {
           'data-custom-att-2': 'val-2',
         };
 
+        const sizing = {};
+
         const adTracker = new AdTracker([], {
           initialMinSpacing: 0,
           subsequentMinSpacing: [],
           maxAdCount: 1,
         });
-        const adStrategy = new AdStrategy(placements, attributes, adTracker);
+        const adStrategy = new AdStrategy(
+            placements, attributes, sizing, adTracker);
 
         return adStrategy.run().then(result => {
           expect(result).to.deep.equal({adsPlaced: 1, totalAdsOnPage: 1});
@@ -141,12 +144,15 @@ describes.realWin('amp-strategy', {
       'data-custom-att-2': 'val-2',
     };
 
+    const sizing = {};
+
     const adTracker = new AdTracker([], {
       initialMinSpacing: 0,
       subsequentMinSpacing: [],
       maxAdCount: 1,
     });
-    const adStrategy = new AdStrategy(placements, attributes, adTracker);
+    const adStrategy = new AdStrategy(
+        placements, attributes, sizing, adTracker);
 
     return adStrategy.run().then(result => {
       expect(result).to.deep.equal({adsPlaced: 1, totalAdsOnPage: 1});
@@ -205,12 +211,15 @@ describes.realWin('amp-strategy', {
       'data-custom-att-2': 'val-2',
     };
 
+    const sizing = {};
+
     const adTracker = new AdTracker([], {
       initialMinSpacing: 200,
       subsequentMinSpacing: [],
       maxAdCount: 2,
     });
-    const adStrategy = new AdStrategy(placements, attributes, adTracker);
+    const adStrategy = new AdStrategy(
+        placements, attributes, sizing, adTracker);
 
     return adStrategy.run().then(result => {
       expect(result).to.deep.equal({adsPlaced: 1, totalAdsOnPage: 1});
@@ -269,12 +278,15 @@ describes.realWin('amp-strategy', {
       'data-custom-att-2': 'val-2',
     };
 
+    const sizing = {};
+
     const adTracker = new AdTracker([], {
       initialMinSpacing: 200,
       subsequentMinSpacing: [],
       maxAdCount: 2,
     });
-    const adStrategy = new AdStrategy(placements, attributes, adTracker);
+    const adStrategy = new AdStrategy(
+        placements, attributes, sizing, adTracker);
 
     return adStrategy.run().then(result => {
       expect(result).to.deep.equal({adsPlaced: 2, totalAdsOnPage: 2});
@@ -341,12 +353,15 @@ describes.realWin('amp-strategy', {
       'data-custom-att-2': 'val-2',
     };
 
+    const sizing = {};
+
     const adTracker = new AdTracker([fakeExistingAd], {
       initialMinSpacing: 200,
       subsequentMinSpacing: [],
       maxAdCount: 2,
     });
-    const adStrategy = new AdStrategy(placements, attributes, adTracker);
+    const adStrategy = new AdStrategy(
+        placements, attributes, sizing, adTracker);
 
     return adStrategy.run().then(result => {
       expect(result).to.deep.equal({adsPlaced: 1, totalAdsOnPage: 2});
@@ -401,12 +416,15 @@ describes.realWin('amp-strategy', {
       'type': 'adsense',
     };
 
+    const sizing = {};
+
     const adTracker = new AdTracker([], {
       initialMinSpacing: 0,
       subsequentMinSpacing: [],
       maxAdCount: 1,
     });
-    const adStrategy = new AdStrategy(placements, attributes, adTracker);
+    const adStrategy = new AdStrategy(
+        placements, attributes, sizing, adTracker);
 
     return adStrategy.run().then(result => {
       expect(result).to.deep.equal({adsPlaced: 0, totalAdsOnPage: 0});

--- a/extensions/amp-auto-ads/0.1/test/test-placement.js
+++ b/extensions/amp-auto-ads/0.1/test/test-placement.js
@@ -250,6 +250,54 @@ describes.realWin('placement', {
           });
     });
 
+    it('should place an ad with fixed layouts', () => {
+      const anchor = doc.createElement('div');
+      anchor.id = 'anId';
+      container.appendChild(anchor);
+
+      const placements = getPlacementsFromConfigObj(ampdoc, {
+        placements: [
+          {
+            anchor: {
+              selector: 'DIV#anId',
+            },
+            pos: 2,
+            type: 1,
+          },
+        ],
+      });
+      expect(placements).to.have.lengthOf(1);
+
+      const baseAttributes = {
+        'type': 'ad-network-type',
+        'layout': 'fixed',
+        'width': 300, 
+        'height': 250,
+        'data-custom-att-1': 'val-1',
+        'data-custom-att-2': 'val-2',
+      };
+
+      const adTracker = new AdTracker([], {
+        initialMinSpacing: 0,
+        subsequentMinSpacing: [],
+        maxAdCount: 10,
+      });
+      return placements[0].placeAd(baseAttributes, adTracker)
+          .then(() => {
+            const adElement = anchor.firstChild;
+            expect(adElement.tagName).to.equal('AMP-AD');
+            expect(adElement.getAttribute('type')).to.equal('ad-network-type');
+            expect(adElement.getAttribute('layout')).to.equal('fixed');
+            expect(adElement.getAttribute('height')).to.equal('250');
+            expect(adElement.getAttribute('width')).to.equal('300');
+            expect(adElement.getAttribute('data-custom-att-1'))
+                .to.equal('val-1');
+            expect(adElement.getAttribute('data-custom-att-2'))
+                .to.equal('val-2');
+          });
+    });
+
+
     it('should place an ad with the correct placement attributes', () => {
       const anchor = doc.createElement('div');
       anchor.id = 'anId';

--- a/extensions/amp-auto-ads/0.1/test/test-placement.js
+++ b/extensions/amp-auto-ads/0.1/test/test-placement.js
@@ -288,8 +288,10 @@ describes.realWin('placement', {
             expect(adElement.tagName).to.equal('AMP-AD');
             expect(adElement.getAttribute('type')).to.equal('ad-network-type');
             expect(adElement.getAttribute('layout')).to.equal('fixed');
-            expect(adElement.getAttribute('height')).to.equal('250');
+            expect(adElement.getAttribute('height')).to.equal('0');
             expect(adElement.getAttribute('width')).to.equal('300');
+            expect(adElement.getAttribute('style'))
+                .to.equal('width: 300px; height: 250px;');
             expect(adElement.getAttribute('data-custom-att-1'))
                 .to.equal('val-1');
             expect(adElement.getAttribute('data-custom-att-2'))

--- a/extensions/amp-auto-ads/0.1/test/test-placement.js
+++ b/extensions/amp-auto-ads/0.1/test/test-placement.js
@@ -65,12 +65,14 @@ describes.realWin('placement', {
         'type': 'ad-network-type',
       };
 
+      const sizing = {};
+
       const adTracker = new AdTracker([], {
         initialMinSpacing: 0,
         subsequentMinSpacing: [],
         maxAdCount: 10,
       });
-      return placements[0].placeAd(attributes, adTracker)
+      return placements[0].placeAd(attributes, sizing, adTracker)
           .then(() => {
             expect(placements[0].getAdElement()).to.equal(anchor.childNodes[0]);
           });
@@ -231,12 +233,14 @@ describes.realWin('placement', {
         'data-custom-att-2': 'val-2',
       };
 
+      const sizing = {};
+
       const adTracker = new AdTracker([], {
         initialMinSpacing: 0,
         subsequentMinSpacing: [],
         maxAdCount: 10,
       });
-      return placements[0].placeAd(baseAttributes, adTracker)
+      return placements[0].placeAd(baseAttributes, sizing, adTracker)
           .then(() => {
             const adElement = anchor.firstChild;
             expect(adElement.tagName).to.equal('AMP-AD');
@@ -270,11 +274,13 @@ describes.realWin('placement', {
 
       const baseAttributes = {
         'type': 'ad-network-type',
-        'layout': 'fixed',
-        'width': 300,
-        'height': 250,
         'data-custom-att-1': 'val-1',
         'data-custom-att-2': 'val-2',
+      };
+
+      const sizing = {
+        width: '300',
+        height: '250',
       };
 
       const adTracker = new AdTracker([], {
@@ -282,7 +288,7 @@ describes.realWin('placement', {
         subsequentMinSpacing: [],
         maxAdCount: 10,
       });
-      return placements[0].placeAd(baseAttributes, adTracker)
+      return placements[0].placeAd(baseAttributes, sizing, adTracker)
           .then(() => {
             const adElement = anchor.firstChild;
             expect(adElement.tagName).to.equal('AMP-AD');
@@ -329,12 +335,14 @@ describes.realWin('placement', {
         'data-custom-att-3': 'val-4',
       };
 
+      const sizing = {};
+
       const adTracker = new AdTracker([], {
         initialMinSpacing: 0,
         subsequentMinSpacing: [],
         maxAdCount: 10,
       });
-      return placements[0].placeAd(baseAttributes, adTracker)
+      return placements[0].placeAd(baseAttributes, sizing, adTracker)
           .then(() => {
             const adElement = anchor.firstChild;
             expect(adElement.tagName).to.equal('AMP-AD');
@@ -372,6 +380,8 @@ describes.realWin('placement', {
         'type': 'ad-network-type',
       };
 
+      const sizing = {};
+
       const adTracker = new AdTracker([], {
         initialMinSpacing: 0,
         subsequentMinSpacing: [],
@@ -383,7 +393,7 @@ describes.realWin('placement', {
         return Promise.reject();
       });
 
-      return placements[0].placeAd(baseAttributes, adTracker)
+      return placements[0].placeAd(baseAttributes, sizing, adTracker)
           .then(() => {
             const adElement = anchor.firstChild;
             expect(adElement.tagName).to.equal('AMP-AD');
@@ -421,12 +431,14 @@ describes.realWin('placement', {
         'type': 'ad-network-type',
       };
 
+      const sizing = {};
+
       const adTracker = new AdTracker([], {
         initialMinSpacing: 0,
         subsequentMinSpacing: [],
         maxAdCount: 10,
       });
-      return placements[0].placeAd(attributes, adTracker)
+      return placements[0].placeAd(attributes, sizing, adTracker)
           .then(() => {
             const adElement = anchor.firstChild;
             expect(adElement.tagName).to.equal('AMP-AD');
@@ -465,12 +477,14 @@ describes.realWin('placement', {
         'type': 'ad-network-type',
       };
 
+      const sizing = {};
+
       const adTracker = new AdTracker([], {
         initialMinSpacing: 0,
         subsequentMinSpacing: [],
         maxAdCount: 10,
       });
-      return placements[0].placeAd(attributes, adTracker)
+      return placements[0].placeAd(attributes, sizing, adTracker)
           .then(() => {
             const adElement = anchor.firstChild;
             expect(adElement.tagName).to.equal('AMP-AD');
@@ -509,12 +523,14 @@ describes.realWin('placement', {
         'type': 'ad-network-type',
       };
 
+      const sizing = {};
+
       const adTracker = new AdTracker([], {
         initialMinSpacing: 0,
         subsequentMinSpacing: [],
         maxAdCount: 10,
       });
-      return placements[0].placeAd(attributes, adTracker)
+      return placements[0].placeAd(attributes, sizing, adTracker)
           .then(() => {
             const adElement = anchor.firstChild;
             expect(adElement.tagName).to.equal('AMP-AD');
@@ -551,12 +567,14 @@ describes.realWin('placement', {
         'type': 'ad-network-type',
       };
 
+      const sizing = {};
+
       const adTracker = new AdTracker([], {
         initialMinSpacing: 0,
         subsequentMinSpacing: [],
         maxAdCount: 10,
       });
-      return placements[0].placeAd(attributes, adTracker)
+      return placements[0].placeAd(attributes, sizing, adTracker)
           .then(() => {
             const adElement = anchor.firstChild;
             expect(adElement.tagName).to.equal('AMP-AD');
@@ -597,12 +615,14 @@ describes.realWin('placement', {
         'type': 'ad-network-type',
       };
 
+      const sizing = {};
+
       const adTracker = new AdTracker([], {
         initialMinSpacing: 0,
         subsequentMinSpacing: [],
         maxAdCount: 10,
       });
-      return placements[0].placeAd(attributes, adTracker)
+      return placements[0].placeAd(attributes, sizing, adTracker)
           .then(placementState => {
             expect(resource.attemptChangeSize).to.have.been.calledWith(
                 anchor.firstChild, 250, undefined);
@@ -637,12 +657,14 @@ describes.realWin('placement', {
         'type': 'ad-network-type',
       };
 
+      const sizing = {};
+
       const adTracker = new AdTracker([], {
         initialMinSpacing: 0,
         subsequentMinSpacing: [],
         maxAdCount: 10,
       });
-      return placements[0].placeAd(attributes, adTracker)
+      return placements[0].placeAd(attributes, sizing, adTracker)
           .then(placementState => {
             expect(resource.attemptChangeSize).to.have.been.calledWith(
                 anchor.firstChild, 250, undefined);
@@ -677,11 +699,13 @@ describes.realWin('placement', {
         maxAdCount: 10,
       });
 
+      const sizing = {};
+
       const attributes = {
         'type': 'ad-network-type',
       };
 
-      return placements[0].placeAd(attributes, adTracker)
+      return placements[0].placeAd(attributes, sizing, adTracker)
           .then(placementState => {
             expect(placementState).to.equal(
                 PlacementState.TOO_NEAR_EXISTING_AD);
@@ -712,12 +736,14 @@ describes.realWin('placement', {
         'type': 'ad-network-type',
       };
 
+      const sizing = {};
+
       const adTracker = new AdTracker([], {
         initialMinSpacing: 0,
         subsequentMinSpacing: [],
         maxAdCount: 10,
       });
-      return placements[0].placeAd(attributes, adTracker)
+      return placements[0].placeAd(attributes, sizing, adTracker)
           .then(placementState => {
             expect(placementState).to.equal(PlacementState.PLACED);
             expect(container.childNodes).to.have.lengthOf(2);
@@ -747,12 +773,14 @@ describes.realWin('placement', {
         'type': 'ad-network-type',
       };
 
+      const sizing = {};
+
       const adTracker = new AdTracker([], {
         initialMinSpacing: 0,
         subsequentMinSpacing: [],
         maxAdCount: 10,
       });
-      return placements[0].placeAd(attributes, adTracker)
+      return placements[0].placeAd(attributes, sizing, adTracker)
           .then(placementState => {
             expect(placementState).to.equal(PlacementState.PLACED);
             expect(container.childNodes).to.have.lengthOf(2);
@@ -783,12 +811,14 @@ describes.realWin('placement', {
         'type': 'ad-network-type',
       };
 
+      const sizing = {};
+
       const adTracker = new AdTracker([], {
         initialMinSpacing: 0,
         subsequentMinSpacing: [],
         maxAdCount: 10,
       });
-      return placements[0].placeAd(attributes, adTracker)
+      return placements[0].placeAd(attributes, sizing, adTracker)
           .then(placementState => {
             expect(placementState).to.equal(PlacementState.PLACED);
             expect(container.childNodes).to.have.lengthOf(1);
@@ -819,12 +849,14 @@ describes.realWin('placement', {
         'type': 'ad-network-type',
       };
 
+      const sizing = {};
+
       const adTracker = new AdTracker([], {
         initialMinSpacing: 0,
         subsequentMinSpacing: [],
         maxAdCount: 10,
       });
-      return placements[0].placeAd(attributes, adTracker)
+      return placements[0].placeAd(attributes, sizing, adTracker)
           .then(placementState => {
             expect(placementState).to.equal(PlacementState.PLACED);
             expect(container.childNodes).to.have.lengthOf(1);
@@ -859,12 +891,14 @@ describes.realWin('placement', {
         'type': 'ad-network-type',
       };
 
+      const sizing = {};
+
       const adTracker = new AdTracker([], {
         initialMinSpacing: 0,
         subsequentMinSpacing: [],
         maxAdCount: 10,
       });
-      return placements[0].placeAd(attributes, adTracker)
+      return placements[0].placeAd(attributes, sizing, adTracker)
           .then(placementState => {
             expect(placementState).to.equal(PlacementState.PLACED);
             expect(anchor1.childNodes).to.have.lengthOf(0);

--- a/extensions/amp-auto-ads/0.1/test/test-placement.js
+++ b/extensions/amp-auto-ads/0.1/test/test-placement.js
@@ -271,7 +271,7 @@ describes.realWin('placement', {
       const baseAttributes = {
         'type': 'ad-network-type',
         'layout': 'fixed',
-        'width': 300, 
+        'width': 300,
         'height': 250,
         'data-custom-att-1': 'val-1',
         'data-custom-att-2': 'val-2',

--- a/extensions/amp-auto-ads/amp-auto-ads.md
+++ b/extensions/amp-auto-ads/amp-auto-ads.md
@@ -74,6 +74,7 @@ should be specified on the tag.
 
 ## Supported ad networks
 - [AdSense](../../ads/google/adsense.md)
+- [DoubleClick (experimental)](../../ads/google/doubleclick.md)
 
 ## Attributes
 


### PR DESCRIPTION
# Adds **experimental** support for doubleclick for amp-auto-ads extension

This implements support for a new ad network (doubleclick) in amp-auto-ads.

It uses some experimental parameters:
 - _data-ad-legacy-client_: refers to the AdSense id linked to the double-click account, used for legacy purposes in the experiment.
 - _data-experiment_: a json object with experimental attributes, to be used by the network. In particular, it allows fixed width, height and layout of the auto placed amp-ad units.
 - _data-json_: used to configure the amp-ad units set on the page (could be moved to _data-experiment_ for now).

Users will need to do the following:
`<amp-auto-ads
     type="doubleclick"
     data-ad-legacy-client='pub-1233'
     data-experiment='{width: "200"}'
     data-slot='slot-id'
     data-json='{tagetting: "value'}'>
</amp-auto-ads>`

/cc @lannka @wjfang @tlong2 