### PR TITLE
✨ Allow multiple comma separated deids to be passed in.

### DIFF
--- a/ads/google/a4a/test/test-utils.js
+++ b/ads/google/a4a/test/test-utils.js
@@ -373,10 +373,10 @@ describe('Google A4A utils', () => {
         const impl = new MockA4AImpl(elem);
         noopMethods(impl, doc, sandbox);
         impl.win.AMP_CONFIG = {type: 'production'};
-        impl.win.location.hash = 'foo,deid=123456,bar';
+        impl.win.location.hash = 'foo,deid=123456,654321,bar';
         return fixture.addElement(elem).then(() => {
           return googleAdUrl(impl, '', 0, [], []).then(url1 => {
-            expect(url1).to.match(/[&?]debug_experiment_id=123456/);
+            expect(url1).to.match(/[&?]debug_experiment_id=123456%2C654321/);
           });
         });
       });

--- a/ads/google/a4a/utils.js
+++ b/ads/google/a4a/utils.js
@@ -289,8 +289,8 @@ export function googlePageParameters(a4a, startTime) {
                   null,
           'url': documentInfo.canonicalUrl,
           'top': win != win.top ? topWindowUrlOrDomain(win) : null,
-          'loc': win.location.href == documentInfo.canonicalUrl
-            ? null
+          'loc': win.location.href == documentInfo.canonicalUrl ?
+            null
             : win.location.href,
           'ref': promiseResults[1] || null,
         };

--- a/ads/google/a4a/utils.js
+++ b/ads/google/a4a/utils.js
@@ -259,40 +259,40 @@ export function googlePageParameters(a4a, startTime) {
         const visibilityState = Services.viewerForDoc(ampDoc)
             .getVisibilityState();
         return {
-          'is_amp' : a4a.isXhrAllowed()
+          'is_amp': a4a.isXhrAllowed()
                          ? AmpAdImplementation.AMP_AD_XHR_TO_IFRAME_OR_AMP
                          : AmpAdImplementation.AMP_AD_IFRAME_GET,
-          'amp_v' : '$internalRuntimeVersion$',
-          'd_imp' : '1',
-          'c' : getCorrelator(win, ampDoc, clientId),
-          'ga_cid' : win.gaGlobal.cid || null,
-          'ga_hid' : win.gaGlobal.hid || null,
-          'dt' : startTime,
-          'biw' : viewportRect.width,
-          'bih' : viewportRect.height,
-          'u_aw' : screen ? screen.availWidth : null,
-          'u_ah' : screen ? screen.availHeight : null,
-          'u_cd' : screen ? screen.colorDepth : null,
-          'u_w' : screen ? screen.width : null,
-          'u_h' : screen ? screen.height : null,
-          'u_tz' : -new Date().getTimezoneOffset(),
-          'u_his' : getHistoryLength(win),
-          'isw' : win != win.top ? viewportSize.width : null,
-          'ish' : win != win.top ? viewportSize.height : null,
-          'art' : getAmpRuntimeTypeParameter(win),
-          'vis' : visibilityStateCodes[visibilityState] || '0',
-          'scr_x' : viewport.getScrollLeft(),
-          'scr_y' : viewport.getScrollTop(),
-          'bc' : getBrowserCapabilitiesBitmap(win) || null,
-          'debug_experiment_id' :
+          'amp_v': '$internalRuntimeVersion$',
+          'd_imp': '1',
+          'c': getCorrelator(win, ampDoc, clientId),
+          'ga_cid': win.gaGlobal.cid || null,
+          'ga_hid': win.gaGlobal.hid || null,
+          'dt': startTime,
+          'biw': viewportRect.width,
+          'bih': viewportRect.height,
+          'u_aw': screen ? screen.availWidth : null,
+          'u_ah': screen ? screen.availHeight : null,
+          'u_cd': screen ? screen.colorDepth : null,
+          'u_w': screen ? screen.width : null,
+          'u_h': screen ? screen.height : null,
+          'u_tz': -new Date().getTimezoneOffset(),
+          'u_his': getHistoryLength(win),
+          'isw': win != win.top ? viewportSize.width : null,
+          'ish': win != win.top ? viewportSize.height : null,
+          'art': getAmpRuntimeTypeParameter(win),
+          'vis': visibilityStateCodes[visibilityState] || '0',
+          'scr_x': viewport.getScrollLeft(),
+          'scr_y': viewport.getScrollTop(),
+          'bc': getBrowserCapabilitiesBitmap(win) || null,
+          'debug_experiment_id':
               (/(?:#|,)deid=([\d,]+)/i.exec(win.location.hash) || [])[1] ||
                   null,
-          'url' : documentInfo.canonicalUrl,
-          'top' : win != win.top ? topWindowUrlOrDomain(win) : null,
-          'loc' : win.location.href == documentInfo.canonicalUrl
+          'url': documentInfo.canonicalUrl,
+          'top': win != win.top ? topWindowUrlOrDomain(win) : null,
+          'loc': win.location.href == documentInfo.canonicalUrl
                       ? null
                       : win.location.href,
-          'ref' : promiseResults[1] || null,
+          'ref': promiseResults[1] || null,
         };
       });
 }

--- a/ads/google/a4a/utils.js
+++ b/ads/google/a4a/utils.js
@@ -259,38 +259,40 @@ export function googlePageParameters(a4a, startTime) {
         const visibilityState = Services.viewerForDoc(ampDoc)
             .getVisibilityState();
         return {
-          'is_amp': a4a.isXhrAllowed() ?
-            AmpAdImplementation.AMP_AD_XHR_TO_IFRAME_OR_AMP :
-            AmpAdImplementation.AMP_AD_IFRAME_GET,
-          'amp_v': '$internalRuntimeVersion$',
-          'd_imp': '1',
-          'c': getCorrelator(win, ampDoc, clientId),
-          'ga_cid': win.gaGlobal.cid || null,
-          'ga_hid': win.gaGlobal.hid || null,
-          'dt': startTime,
-          'biw': viewportRect.width,
-          'bih': viewportRect.height,
-          'u_aw': screen ? screen.availWidth : null,
-          'u_ah': screen ? screen.availHeight : null,
-          'u_cd': screen ? screen.colorDepth : null,
-          'u_w': screen ? screen.width : null,
-          'u_h': screen ? screen.height : null,
-          'u_tz': -new Date().getTimezoneOffset(),
-          'u_his': getHistoryLength(win),
-          'isw': win != win.top ? viewportSize.width : null,
-          'ish': win != win.top ? viewportSize.height : null,
-          'art': getAmpRuntimeTypeParameter(win),
-          'vis': visibilityStateCodes[visibilityState] || '0',
-          'scr_x': viewport.getScrollLeft(),
-          'scr_y': viewport.getScrollTop(),
-          'bc': getBrowserCapabilitiesBitmap(win) || null,
-          'debug_experiment_id':
-              (/(?:#|,)deid=(\d+)/i.exec(win.location.hash) || [])[1] || null,
-          'url': documentInfo.canonicalUrl,
-          'top': win != win.top ? topWindowUrlOrDomain(win) : null,
-          'loc': win.location.href == documentInfo.canonicalUrl ?
-            null : win.location.href,
-          'ref': promiseResults[1] || null,
+          'is_amp' : a4a.isXhrAllowed()
+                         ? AmpAdImplementation.AMP_AD_XHR_TO_IFRAME_OR_AMP
+                         : AmpAdImplementation.AMP_AD_IFRAME_GET,
+          'amp_v' : '$internalRuntimeVersion$',
+          'd_imp' : '1',
+          'c' : getCorrelator(win, ampDoc, clientId),
+          'ga_cid' : win.gaGlobal.cid || null,
+          'ga_hid' : win.gaGlobal.hid || null,
+          'dt' : startTime,
+          'biw' : viewportRect.width,
+          'bih' : viewportRect.height,
+          'u_aw' : screen ? screen.availWidth : null,
+          'u_ah' : screen ? screen.availHeight : null,
+          'u_cd' : screen ? screen.colorDepth : null,
+          'u_w' : screen ? screen.width : null,
+          'u_h' : screen ? screen.height : null,
+          'u_tz' : -new Date().getTimezoneOffset(),
+          'u_his' : getHistoryLength(win),
+          'isw' : win != win.top ? viewportSize.width : null,
+          'ish' : win != win.top ? viewportSize.height : null,
+          'art' : getAmpRuntimeTypeParameter(win),
+          'vis' : visibilityStateCodes[visibilityState] || '0',
+          'scr_x' : viewport.getScrollLeft(),
+          'scr_y' : viewport.getScrollTop(),
+          'bc' : getBrowserCapabilitiesBitmap(win) || null,
+          'debug_experiment_id' :
+              (/(?:#|,)deid=([\d,]+)/i.exec(win.location.hash) || [])[1] ||
+                  null,
+          'url' : documentInfo.canonicalUrl,
+          'top' : win != win.top ? topWindowUrlOrDomain(win) : null,
+          'loc' : win.location.href == documentInfo.canonicalUrl
+                      ? null
+                      : win.location.href,
+          'ref' : promiseResults[1] || null,
         };
       });
 }

--- a/ads/google/a4a/utils.js
+++ b/ads/google/a4a/utils.js
@@ -290,8 +290,7 @@ export function googlePageParameters(a4a, startTime) {
           'url': documentInfo.canonicalUrl,
           'top': win != win.top ? topWindowUrlOrDomain(win) : null,
           'loc': win.location.href == documentInfo.canonicalUrl ?
-            null
-            : win.location.href,
+            null : win.location.href,
           'ref': promiseResults[1] || null,
         };
       });

--- a/ads/google/a4a/utils.js
+++ b/ads/google/a4a/utils.js
@@ -259,9 +259,9 @@ export function googlePageParameters(a4a, startTime) {
         const visibilityState = Services.viewerForDoc(ampDoc)
             .getVisibilityState();
         return {
-          'is_amp': a4a.isXhrAllowed()
-                         ? AmpAdImplementation.AMP_AD_XHR_TO_IFRAME_OR_AMP
-                         : AmpAdImplementation.AMP_AD_IFRAME_GET,
+          'is_amp': a4a.isXhrAllowed() ?
+            AmpAdImplementation.AMP_AD_XHR_TO_IFRAME_OR_AMP :
+            AmpAdImplementation.AMP_AD_IFRAME_GET,
           'amp_v': '$internalRuntimeVersion$',
           'd_imp': '1',
           'c': getCorrelator(win, ampDoc, clientId),
@@ -290,8 +290,8 @@ export function googlePageParameters(a4a, startTime) {
           'url': documentInfo.canonicalUrl,
           'top': win != win.top ? topWindowUrlOrDomain(win) : null,
           'loc': win.location.href == documentInfo.canonicalUrl
-                      ? null
-                      : win.location.href,
+            ? null
+            : win.location.href,
           'ref': promiseResults[1] || null,
         };
       });


### PR DESCRIPTION
Changes the regex in the a4a utils file to match on commas so that more than one eid can be included in the deid hash param.