### PR TITLE
🏗 Exclude `ads/` and `third_party/` from code coverage analysis

### DIFF
--- a/build-system/tasks/runtime-test.js
+++ b/build-system/tasks/runtime-test.js
@@ -505,8 +505,9 @@ function runTests() {
         plugins: [
           ['babel-plugin-istanbul', {
             exclude: [
+              './ads/**/*.js',
+              './third_party/**/*.js',
               './test/**/*.js',
-              './ads/**/test/test-*.js',
               './extensions/**/test/**/*.js',
               './testing/**/*.js',
             ],


### PR DESCRIPTION
The AMP unit tests don't explicitly cover these directories, so we should exclude them from the overall report as they skew the numbers.

Follow up to #16417 and #16432
Fixes #16396

