### PR TITLE
Validator rollup

### DIFF
--- a/extensions/amp-accordion/validator-amp-accordion.protoascii
+++ b/extensions/amp-accordion/validator-amp-accordion.protoascii
@@ -14,6 +14,10 @@
 # limitations under the license.
 #
 tags: {  # amp-accordion
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "SCRIPT"
   extension_spec: {
     name: "amp-accordion"
@@ -25,6 +29,10 @@ tags: {  # amp-accordion
   attr_lists: "common-extension-attrs"
 }
 tags: {  # <amp-accordion>
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "AMP-ACCORDION"
   requires_extension: "amp-accordion"
   attrs: { name: "animate" value: "" }
@@ -40,6 +48,10 @@ tags: {  # <amp-accordion>
   }
 }
 tags: {  # <amp-accordion> > <section>
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "SECTION"
   spec_name: "amp-accordion > section"
   mandatory_parent: "AMP-ACCORDION"

--- a/extensions/amp-carousel/validator-amp-carousel.protoascii
+++ b/extensions/amp-carousel/validator-amp-carousel.protoascii
@@ -15,6 +15,10 @@
 #
 
 tags: {  # amp-carousel
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "SCRIPT"
   extension_spec: {
     name: "amp-carousel"
@@ -26,6 +30,10 @@ tags: {  # amp-carousel
   attr_lists: "common-extension-attrs"
 }
 tags: {  # <amp-carousel>
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "AMP-CAROUSEL"
   requires_extension: "amp-carousel"
   attrs: {
@@ -123,6 +131,10 @@ tags: {  # <amp-carousel> lightbox
   }
 }
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "$REFERENCE_POINT"
   spec_name: "AMP-CAROUSEL lightbox [lightbox-exclude]"
   attrs: {
@@ -131,6 +143,10 @@ tags: {
   }
 }
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "$REFERENCE_POINT"
   spec_name: "AMP-CAROUSEL lightbox [child]"
   attrs: {

--- a/extensions/amp-fit-text/validator-amp-fit-text.protoascii
+++ b/extensions/amp-fit-text/validator-amp-fit-text.protoascii
@@ -15,6 +15,10 @@
 #
 
 tags: {  # amp-fit-text
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "SCRIPT"
   extension_spec: {
     name: "amp-fit-text"
@@ -26,6 +30,10 @@ tags: {  # amp-fit-text
   attr_lists: "common-extension-attrs"
 }
 tags: {  # <amp-fit-text>
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "AMP-FIT-TEXT"
   requires_extension: "amp-fit-text"
   attrs: { name: "max-font-size" }

--- a/extensions/amp-form/validator-amp-form.protoascii
+++ b/extensions/amp-form/validator-amp-form.protoascii
@@ -16,6 +16,10 @@
 tags: {  # amp-form
   # Accepted form elements can be found in validator-main.protoascii
   # under section "4.10 Forms"
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "SCRIPT"
   extension_spec: {
     name: "amp-form"

--- a/extensions/amp-mustache/validator-amp-mustache.protoascii
+++ b/extensions/amp-mustache/validator-amp-mustache.protoascii
@@ -48,6 +48,10 @@ tags: {  # amp-mustache
 }
 # HTML5, 4.11.3 The template element
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "TEMPLATE"
   # <template> tags may not be nested inside other <template> tags.
   disallowed_ancestor: "TEMPLATE"

--- a/validator/engine/parse-css.js
+++ b/validator/engine/parse-css.js
@@ -33,6 +33,7 @@ goog.provide('parse_css.extractAFunction');
 goog.provide('parse_css.extractASimpleBlock');
 goog.provide('parse_css.extractUrls');
 goog.provide('parse_css.parseAStylesheet');
+goog.provide('parse_css.parseInlineStyle');
 goog.provide('parse_css.parseMediaQueries');
 goog.provide('parse_css.stripVendorPrefix');
 goog.require('amp.validator.LIGHT');
@@ -161,7 +162,7 @@ parse_css.stripVendorPrefix = function(prefixedString) {
  * @return {!parse_css.Stylesheet}
  */
 parse_css.parseAStylesheet = function(
-  tokenList, atRuleSpec, defaultSpec, errors) {
+    tokenList, atRuleSpec, defaultSpec, errors) {
   const canonicalizer = new Canonicalizer(atRuleSpec, defaultSpec);
   const stylesheet = new parse_css.Stylesheet();
 
@@ -173,6 +174,19 @@ parse_css.parseAStylesheet = function(
   stylesheet.eof = eof;
 
   return stylesheet;
+};
+
+/**
+ * Returns a array of Declaration objects.
+ *
+ * @param {!Array<!parse_css.Token>} tokenList
+ * @param {!Array<!parse_css.ErrorToken>} errors output array for the errors.
+ * @return {!Array<!parse_css.Declaration>}
+ */
+parse_css.parseInlineStyle = function(tokenList, errors) {
+  const canonicalizer =
+      new Canonicalizer({}, parse_css.BlockType.PARSE_AS_DECLARATIONS);
+  return canonicalizer.parseAListOfDeclarations(tokenList, errors);
 };
 
 /**
@@ -324,6 +338,26 @@ parse_css.Declaration = class extends parse_css.Rule {
     this.important = false;
     /** @type {parse_css.TokenType} */
     this.tokenType = parse_css.TokenType.DECLARATION;
+  }
+
+  /**
+   * For a declaration, if the first non-whitespace token is an identifier,
+   * returns its string value. Otherwise, returns the empty string.
+   * @return {string}
+   */
+  firstIdent() {
+    if (this.value.length === 0) {
+      return '';
+    }
+    if (this.value[0].tokenType === parse_css.TokenType.IDENT) {
+      return /** @type {!parse_css.StringValuedToken} */ (this.value[0]).value;
+    }
+    if (this.value.length >= 2 &&
+        (this.value[0].tokenType === parse_css.TokenType.WHITESPACE) &&
+        this.value[1].tokenType === parse_css.TokenType.IDENT) {
+      return /** @type {!parse_css.StringValuedToken} */ (this.value[1]).value;
+    }
+    return '';
   }
 
   /** @inheritDoc */

--- a/validator/engine/parse-css.js
+++ b/validator/engine/parse-css.js
@@ -162,7 +162,7 @@ parse_css.stripVendorPrefix = function(prefixedString) {
  * @return {!parse_css.Stylesheet}
  */
 parse_css.parseAStylesheet = function(
-    tokenList, atRuleSpec, defaultSpec, errors) {
+  tokenList, atRuleSpec, defaultSpec, errors) {
   const canonicalizer = new Canonicalizer(atRuleSpec, defaultSpec);
   const stylesheet = new parse_css.Stylesheet();
 

--- a/validator/engine/validator.js
+++ b/validator/engine/validator.js
@@ -3956,8 +3956,8 @@ function validateAttributeInExtension(tagSpec, context, attr, result) {
  * @param {!amp.validator.ValidationResult} validationResult
  */
 function validateAttrDeclaration(
-    parsedAttrSpec, context, tagSpecName, attrName, attrValue,
-    validationResult) {
+  parsedAttrSpec, context, tagSpecName, attrName, attrValue,
+  validationResult) {
   /** @type {!Array<!parse_css.ErrorToken>} */
   const cssErrors = [];
   /** @type {!Array<!parse_css.Token>} */

--- a/validator/engine/validator.js
+++ b/validator/engine/validator.js
@@ -3996,7 +3996,8 @@ function validateAttrDeclaration(
   const cssDeclarationByName = parsedAttrSpec.getCssDeclarationByName();
 
   for (const declaration of declarations) {
-    const declarationName = declaration.name.toLowerCase();
+    const declarationName =
+        parse_css.stripVendorPrefix(declaration.name.toLowerCase());
     if (!(declarationName in cssDeclarationByName)) {
       // Declaration not allowed.
       if (amp.validator.LIGHT) {

--- a/validator/engine/validator.js
+++ b/validator/engine/validator.js
@@ -3991,7 +3991,7 @@ function validateAttrDeclaration(
   }
 
   // If there were errors parsing, exit from validating further.
-  if (cssErrors.length > 0) { return };
+  if (cssErrors.length > 0) { return; }
 
   const cssDeclarationByName = parsedAttrSpec.getCssDeclarationByName();
 

--- a/validator/engine/validator.js
+++ b/validator/engine/validator.js
@@ -207,30 +207,6 @@ class ParsedUrlSpec {
   isAllowedProtocol(protocol) {
     return protocol in this.allowedProtocols_;
   }
-
-  /**
-   * @param {string} domain
-   * @return {boolean}
-   */
-  isDisallowedDomain(domain) {
-    for (const disallowedDomain of this.spec_.disallowedDomain) {
-      if (goog.string./*OK*/ endsWith(domain, disallowedDomain)) {
-        // If here, then we have three possibilities. For example purposes,
-        // consider 'example.com' as the disallowedDomain.
-        // 1) domain === 'example.com'      ->  isDisallowedDomain = true
-        // 2) domain === 'www.example.com'  ->  isDisallowedDomain = true
-        // 3) domain === 'someexample.com'  ->  isDisallowedDomain = false
-        //
-        // Case 1:
-        if (domain === disallowedDomain) {return true;}
-
-        // Case 2/3, determine if the character before the matching suffix
-        // is a '.':
-        return domain[domain.length - 1 - disallowedDomain.length] === '.';
-      }
-    }
-    return false;
-  }
 }
 
 /** @private */
@@ -2671,20 +2647,6 @@ class UrlErrorInStylesheetAdapter {
 
   /**
    * @param {!Context} context
-   * @param {string} domain
-   * @param {!amp.validator.TagSpec} tagSpec
-   * @param {!amp.validator.ValidationResult} result
-   */
-  disallowedDomain(context, domain, tagSpec, result) {
-    context.addError(
-        amp.validator.ValidationError.Code.CSS_SYNTAX_DISALLOWED_DOMAIN,
-        this.lineCol_,
-        /* params */[getTagSpecName(tagSpec), domain], getTagSpecUrl(tagSpec),
-        result);
-  }
-
-  /**
-   * @param {!Context} context
    * @param {string} url
    * @param {!amp.validator.TagSpec} tagSpec
    * @param {!amp.validator.ValidationResult} result
@@ -2743,20 +2705,6 @@ class UrlErrorInAttrAdapter {
         amp.validator.ValidationError.Code.INVALID_URL_PROTOCOL,
         context.getLineCol(),
         /* params */[this.attrName_, getTagSpecName(tagSpec), protocol],
-        getTagSpecUrl(tagSpec), result);
-  }
-
-  /**
-   * @param {!Context} context
-   * @param {string} domain
-   * @param {!amp.validator.TagSpec} tagSpec
-   * @param {!amp.validator.ValidationResult} result
-   */
-  disallowedDomain(context, domain, tagSpec, result) {
-    context.addError(
-        amp.validator.ValidationError.Code.DISALLOWED_DOMAIN,
-        context.getLineCol(),
-        /* params */[this.attrName_, getTagSpecName(tagSpec), domain],
         getTagSpecUrl(tagSpec), result);
   }
 
@@ -2914,15 +2862,6 @@ function validateUrlAndProtocol(
       result.status = amp.validator.ValidationResult.Status.FAIL;
     } else {
       adapter.disallowedRelativeUrl(context, urlStr, tagSpec, result);
-    }
-    return;
-  }
-  const domain = url.host.toLowerCase();
-  if (domain.length > 0 && parsedUrlSpec.isDisallowedDomain(domain)) {
-    if (amp.validator.LIGHT) {
-      result.status = amp.validator.ValidationResult.Status.FAIL;
-    } else {
-      adapter.disallowedDomain(context, domain, tagSpec, result);
     }
     return;
   }

--- a/validator/engine/validator.js
+++ b/validator/engine/validator.js
@@ -3991,7 +3991,7 @@ function validateAttrDeclaration(
   }
 
   // If there were errors parsing, exit from validating further.
-  if (cssErrors.length > 0) return;
+  if (cssErrors.length > 0) { return };
 
   const cssDeclarationByName = parsedAttrSpec.getCssDeclarationByName();
 

--- a/validator/engine/validator.js
+++ b/validator/engine/validator.js
@@ -4678,8 +4678,7 @@ class ParsedValidatorRules {
         const castedHtmlFormat =
             /** @type {amp.validator.HtmlFormat.Code<string>} */ (
           /** @type {*} */ (htmlFormat));
-        return tagSpec.htmlFormat.length === 0 ||
-            tagSpec.htmlFormat.indexOf(castedHtmlFormat) !== -1;
+        return tagSpec.htmlFormat.indexOf(castedHtmlFormat) !== -1;
       };
 
       /**

--- a/validator/engine/validator_test.js
+++ b/validator/engine/validator_test.js
@@ -667,22 +667,6 @@ function attrRuleShouldMakeSense(attrSpec, rules) {
         expect(allowedProtocolRegex.test(allowedProtocol)).toBe(true);
       }
     });
-    // If disallowed_domain is whatever.ampproject.org then
-    // allow_relative must be false. Otherwise relative URLs would be
-    // rejected for domain whatever.ampproject.org because that is
-    // used as the base URL to parse the relative URL.
-    if ((attrSpec.valueUrl.allowRelative !== null) &&
-        attrSpec.valueUrl.allowRelative) {
-      // allow_relative is true, check to see if whatever.ampproject.org is a
-      // disallowed_domain.
-      it('allow_relative can not be true if ' +
-          'disallowed_domain is whatever.ampproject.org',
-      () => {
-        for (const disallowedDomain of attrSpec.valueUrl.disallowedDomain) {
-          expect(disallowedDomain !== 'whatever.ampproject.org');
-        }
-      });
-    }
     // If allowed_protocol is http then allow_relative should not be false
     // except for `data-` attributes.
     if (!attrSpec.name.startsWith('data-')) {

--- a/validator/engine/validator_test.js
+++ b/validator/engine/validator_test.js
@@ -831,6 +831,10 @@ describe('ValidatorRulesMakeSense', () => {
     const tagSpecName =
         tagSpec.specName || tagSpec.tagName || 'UNKNOWN_TAGSPEC';
 
+    // html_format must be set.
+    it('\'' + tagSpecName + '\' must have at least one htmlFormat set', () => {
+      expect(tagSpec.htmlFormat.length).toBeGreaterThan(0);
+    });
     // html_format is never UNKNOWN_CODE.
     it('tagSpec.htmlFormat should never contain UNKNOWN_CODE', () => {
       expect(tagSpec.htmlFormat.indexOf(
@@ -859,9 +863,8 @@ describe('ValidatorRulesMakeSense', () => {
     });
     // Verify AMP4ADS extensions are whitelisted.
     if ((tagSpec.tagName.indexOf('SCRIPT') === 0) && tagSpec.extensionSpec &&
-        ((tagSpec.htmlFormat.length === 0) ||
-         (tagSpec.htmlFormat.indexOf(
-             amp.validator.HtmlFormat.Code.AMP4ADS) !== -1))) {
+        (tagSpec.htmlFormat.indexOf(
+            amp.validator.HtmlFormat.Code.AMP4ADS) !== -1)) {
       // AMP4ADS Creative Format document is the source of this whitelist.
       // https://github.com/ampproject/amphtml/blob/master/extensions/amp-a4a/amp-a4a-format.md#amp-extensions-and-builtins
       const whitelistedAmp4AdsExtensions = {
@@ -896,9 +899,8 @@ describe('ValidatorRulesMakeSense', () => {
     }
     // Verify AMP4EMAIL extensions are whitelisted.
     if ((tagSpec.tagName.indexOf('AMP-') === 0) &&
-        ((tagSpec.htmlFormat.length === 0) ||
-         (tagSpec.htmlFormat.indexOf(
-             amp.validator.HtmlFormat.Code.AMP4EMAIL) !== -1))) {
+        (tagSpec.htmlFormat.indexOf(
+            amp.validator.HtmlFormat.Code.AMP4EMAIL) !== -1)) {
       // AMP4EMAIL format is the source of this whitelist.
       const whitelistedAmp4EmailExtensions = {
         'AMP-ACCORDION': 0,

--- a/validator/testdata/feature_tests/svg.html
+++ b/validator/testdata/feature_tests/svg.html
@@ -90,7 +90,7 @@
 
   <!-- Valid: style attribute allowed in svgs. -->
   <svg>
-    <g style="display: block;"/>
+    <g style="display: block; -webkit-box-shadow: 4px 6px 6px 4px #ccc"/>
   </svg>
 
   <!-- Invalid: these declarations are not allowed in style attributes. -->

--- a/validator/testdata/feature_tests/svg.html
+++ b/validator/testdata/feature_tests/svg.html
@@ -88,6 +88,19 @@
     <a href="#"><circle r="10"></a>
   </svg>
 
+  <!-- Valid: style attribute allowed in svgs. -->
+  <svg>
+    <g style="display: block;"/>
+  </svg>
+
+  <!-- Invalid: these declarations are not allowed in style attributes. -->
+  <svg>
+    <g style="display: block; position: sticky;"/>
+    <g style="DISPLAY:BLOCK;POSITION:STICKY;"/>
+    <g style="foo:bar;"/>
+    <g style="@media only screen and (max-width: 600px)"/>
+  </svg>
+
   <!-- Invalid: style tag isn't allowed. Note this is really testing the
         parsing of a self closing style tag in an svg, not validity. -->
   <svg>

--- a/validator/testdata/feature_tests/svg.out
+++ b/validator/testdata/feature_tests/svg.out
@@ -101,7 +101,7 @@ feature_tests/svg.html:87:2 The attribute 'xml:base' may not appear in tag 'svg'
 |  
 |    <!-- Valid: style attribute allowed in svgs. -->
 |    <svg>
-|      <g style="display: block;"/>
+|      <g style="display: block; -webkit-box-shadow: 4px 6px 6px 4px #ccc"/>
 |    </svg>
 |  
 |    <!-- Invalid: these declarations are not allowed in style attributes. -->

--- a/validator/testdata/feature_tests/svg.out
+++ b/validator/testdata/feature_tests/svg.out
@@ -99,12 +99,33 @@ feature_tests/svg.html:87:2 The attribute 'xml:base' may not appear in tag 'svg'
 |      <a href="#"><circle r="10"></a>
 |    </svg>
 |  
+|    <!-- Valid: style attribute allowed in svgs. -->
+|    <svg>
+|      <g style="display: block;"/>
+|    </svg>
+|  
+|    <!-- Invalid: these declarations are not allowed in style attributes. -->
+|    <svg>
+|      <g style="display: block; position: sticky;"/>
+>>     ^~~~~~~~~
+feature_tests/svg.html:98:4 CSS syntax error in tag 'g' - the property 'position' is set to the disallowed value 'sticky'. (see https://www.ampproject.org/docs/guides/author-develop/responsive/style_pages) [GENERIC]
+|      <g style="DISPLAY:BLOCK;POSITION:STICKY;"/>
+>>     ^~~~~~~~~
+feature_tests/svg.html:99:4 CSS syntax error in tag 'g' - the property 'POSITION' is set to the disallowed value 'STICKY'. (see https://www.ampproject.org/docs/guides/author-develop/responsive/style_pages) [GENERIC]
+|      <g style="foo:bar;"/>
+>>     ^~~~~~~~~
+feature_tests/svg.html:100:4 The property 'foo' in attribute 'style' in tag 'g' is disallowed. (see https://www.ampproject.org/docs/guides/author-develop/responsive/style_pages) [GENERIC]
+|      <g style="@media only screen and (max-width: 600px)"/>
+>>     ^~~~~~~~~
+feature_tests/svg.html:101:4 CSS syntax error in tag 'g' - saw invalid at rule '@media'. [AUTHOR_STYLESHEET_PROBLEM]
+|    </svg>
+|  
 |    <!-- Invalid: style tag isn't allowed. Note this is really testing the
 |          parsing of a self closing style tag in an svg, not validity. -->
 |    <svg>
 |      <style/>
 >>     ^~~~~~~~~
-feature_tests/svg.html:94:4 The parent tag of tag 'style amp-custom' is 'svg', but it can only be 'head'. (see https://www.ampproject.org/docs/reference/spec#stylesheets) [DISALLOWED_HTML]
+feature_tests/svg.html:107:4 The parent tag of tag 'style amp-custom' is 'svg', but it can only be 'head'. (see https://www.ampproject.org/docs/reference/spec#stylesheets) [DISALLOWED_HTML]
 |    </svg>
 |  </body>
 |  </html>

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -20,13 +20,13 @@
 # in production from crashing. This id is not relevant to validator.js
 # because thus far, engine (validator.js) and spec file
 # (validator-main.protoascii) are always released together.
-min_validator_revision_required: 333
+min_validator_revision_required: 334
 
 # The spec file revision allows the validator engine to distinguish
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 665
+spec_file_revision: 666
 
 styles_spec_url: "https://www.ampproject.org/docs/guides/author-develop/responsive/style_pages"
 script_spec_url: "https://www.ampproject.org/docs/reference/spec#html-tags"
@@ -2244,6 +2244,269 @@ attr_lists: {
   name: "svg-style-attr"
   attrs: {
     name: "style"
+    # From https://www.w3schools.com/cssref/default.asp
+    # Disallowed:
+    # css_declaration: { name: "@charset" }
+    # css_declaration: { name: "@font-face" }
+    # css_declaration: { name: "@font-feature-values" }
+    # css_declaration: { name: "@import" }
+    # css_declaration: { name: "@keyframes" }
+    # css_declaration: { name: "@media" }
+    # Allowed:
+    css_declaration: { name: "align-content" }
+    css_declaration: { name: "align-items" }
+    css_declaration: { name: "align-self" }
+    css_declaration: { name: "all" }
+    css_declaration: { name: "animation" }
+    css_declaration: { name: "animation-delay" }
+    css_declaration: { name: "animation-direction" }
+    css_declaration: { name: "animation-duration" }
+    css_declaration: { name: "animation-fill-mode" }
+    css_declaration: { name: "animation-iteration-count" }
+    css_declaration: { name: "animation-name" }
+    css_declaration: { name: "animation-play-state" }
+    css_declaration: { name: "animation-timing-function" }
+    css_declaration: { name: "backface-visibility" }
+    css_declaration: { name: "background" }
+    css_declaration: { name: "background-attachment" }
+    css_declaration: { name: "background-blend-mode" }
+    css_declaration: { name: "background-clip" }
+    css_declaration: { name: "background-color" }
+    css_declaration: { name: "background-image" }
+    css_declaration: { name: "background-origin" }
+    css_declaration: { name: "background-position" }
+    css_declaration: { name: "background-repeat" }
+    css_declaration: { name: "background-size" }
+    css_declaration: { name: "border" }
+    css_declaration: { name: "border-bottom" }
+    css_declaration: { name: "border-bottom-color" }
+    css_declaration: { name: "border-bottom-left-radius" }
+    css_declaration: { name: "border-bottom-right-radius" }
+    css_declaration: { name: "border-bottom-style" }
+    css_declaration: { name: "border-bottom-width" }
+    css_declaration: { name: "border-collapse" }
+    css_declaration: { name: "border-color" }
+    css_declaration: { name: "border-image" }
+    css_declaration: { name: "border-image-outset" }
+    css_declaration: { name: "border-image-repeat" }
+    css_declaration: { name: "border-image-slice" }
+    css_declaration: { name: "border-image-source" }
+    css_declaration: { name: "border-image-width" }
+    css_declaration: { name: "border-left" }
+    css_declaration: { name: "border-left-color" }
+    css_declaration: { name: "border-left-style" }
+    css_declaration: { name: "border-left-width" }
+    css_declaration: { name: "border-radius" }
+    css_declaration: { name: "border-right" }
+    css_declaration: { name: "border-right-color" }
+    css_declaration: { name: "border-right-style" }
+    css_declaration: { name: "border-right-width" }
+    css_declaration: { name: "border-spacing" }
+    css_declaration: { name: "border-style" }
+    css_declaration: { name: "border-top" }
+    css_declaration: { name: "border-top-color" }
+    css_declaration: { name: "border-top-left-radius" }
+    css_declaration: { name: "border-top-right-radius" }
+    css_declaration: { name: "border-top-style" }
+    css_declaration: { name: "border-top-width" }
+    css_declaration: { name: "border-width" }
+    css_declaration: { name: "bottom" }
+    css_declaration: { name: "box-decoration-break" }
+    css_declaration: { name: "box-shadow" }
+    css_declaration: { name: "box-sizing" }
+    css_declaration: { name: "break-after" }
+    css_declaration: { name: "break-before" }
+    css_declaration: { name: "break-inside" }
+    css_declaration: { name: "caption-side" }
+    css_declaration: { name: "caret-color" }
+    css_declaration: { name: "clear" }
+    css_declaration: { name: "clip" }
+    # https://www.w3.org/TR/css-masking-1/#the-clip-rule
+    css_declaration: { name: "clip-rule" }
+    css_declaration: { name: "color" }
+    css_declaration: { name: "column-count" }
+    css_declaration: { name: "column-fill" }
+    css_declaration: { name: "column-gap" }
+    css_declaration: { name: "column-rule" }
+    css_declaration: { name: "column-rule-color" }
+    css_declaration: { name: "column-rule-style" }
+    css_declaration: { name: "column-rule-width" }
+    css_declaration: { name: "column-span" }
+    css_declaration: { name: "column-width" }
+    css_declaration: { name: "columns" }
+    css_declaration: { name: "content" }
+    css_declaration: { name: "counter-increment" }
+    css_declaration: { name: "counter-reset" }
+    css_declaration: { name: "cursor" }
+    css_declaration: { name: "direction" }
+    css_declaration: { name: "display" }
+    css_declaration: { name: "empty-cells" }
+    # https://www.w3.org/TR/SVG11/filters.html#AccessingBackgroundImage
+    css_declaration: { name: "enable-background" }
+    # https://www.w3.org/TR/fill-stroke-3/#fill-shorthand
+    css_declaration: { name: "fill" }
+    # https://www.w3.org/TR/fill-stroke-3/#fill-opacity
+    css_declaration: { name: "fill-opacity" }
+    # https://www.w3.org/TR/fill-stroke-3/#fill-rule
+    css_declaration: { name: "fill-rule" }
+    css_declaration: { name: "filter" }
+    css_declaration: { name: "flex" }
+    css_declaration: { name: "flex-basis" }
+    css_declaration: { name: "flex-direction" }
+    css_declaration: { name: "flex-flow" }
+    css_declaration: { name: "flex-grow" }
+    css_declaration: { name: "flex-shrink" }
+    css_declaration: { name: "flex-wrap" }
+    css_declaration: { name: "float" }
+    css_declaration: { name: "font" }
+    css_declaration: { name: "font-family" }
+    css_declaration: { name: "font-feature-settings" }
+    css_declaration: { name: "font-kerning" }
+    css_declaration: { name: "font-language-override" }
+    css_declaration: { name: "font-size" }
+    css_declaration: { name: "font-size-adjust" }
+    css_declaration: { name: "font-stretch" }
+    css_declaration: { name: "font-style" }
+    css_declaration: { name: "font-synthesis" }
+    css_declaration: { name: "font-variant" }
+    css_declaration: { name: "font-variant-alternates" }
+    css_declaration: { name: "font-variant-caps" }
+    css_declaration: { name: "font-variant-east-asian" }
+    css_declaration: { name: "font-variant-ligatures" }
+    css_declaration: { name: "font-variant-numeric" }
+    css_declaration: { name: "font-variant-position" }
+    css_declaration: { name: "font-weight" }
+    css_declaration: { name: "grid" }
+    css_declaration: { name: "grid-area" }
+    css_declaration: { name: "grid-auto-columns" }
+    css_declaration: { name: "grid-auto-flow" }
+    css_declaration: { name: "grid-auto-rows" }
+    css_declaration: { name: "grid-column" }
+    css_declaration: { name: "grid-column-end" }
+    css_declaration: { name: "grid-column-gap" }
+    css_declaration: { name: "grid-column-start" }
+    css_declaration: { name: "grid-gap" }
+    css_declaration: { name: "grid-row" }
+    css_declaration: { name: "grid-row-end" }
+    css_declaration: { name: "grid-row-gap" }
+    css_declaration: { name: "grid-row-start" }
+    css_declaration: { name: "grid-template" }
+    css_declaration: { name: "grid-template-areas" }
+    css_declaration: { name: "grid-template-columns" }
+    css_declaration: { name: "grid-template-rows" }
+    css_declaration: { name: "hanging-punctuation" }
+    css_declaration: { name: "height" }
+    css_declaration: { name: "hyphens" }
+    css_declaration: { name: "image-rendering" }
+    css_declaration: { name: "isolation" }
+    css_declaration: { name: "justify-content" }
+    css_declaration: { name: "left" }
+    css_declaration: { name: "letter-spacing" }
+    css_declaration: { name: "line-break" }
+    css_declaration: { name: "line-height" }
+    css_declaration: { name: "list-style" }
+    css_declaration: { name: "list-style-image" }
+    css_declaration: { name: "list-style-position" }
+    css_declaration: { name: "list-style-type" }
+    css_declaration: { name: "margin" }
+    css_declaration: { name: "margin-bottom" }
+    css_declaration: { name: "margin-left" }
+    css_declaration: { name: "margin-right" }
+    css_declaration: { name: "margin-top" }
+    css_declaration: { name: "max-height" }
+    css_declaration: { name: "max-width" }
+    css_declaration: { name: "min-height" }
+    css_declaration: { name: "min-width" }
+    css_declaration: { name: "mix-blend-mode" }
+    css_declaration: { name: "object-fit" }
+    css_declaration: { name: "object-position" }
+    css_declaration: { name: "opacity" }
+    css_declaration: { name: "order" }
+    css_declaration: { name: "orphans" }
+    css_declaration: { name: "outline" }
+    css_declaration: { name: "outline-color" }
+    css_declaration: { name: "outline-offset" }
+    css_declaration: { name: "outline-style" }
+    css_declaration: { name: "outline-width" }
+    css_declaration: { name: "overflow" }
+    css_declaration: { name: "overflow-wrap" }
+    css_declaration: { name: "overflow-x" }
+    css_declaration: { name: "overflow-y" }
+    css_declaration: { name: "padding" }
+    css_declaration: { name: "padding-bottom" }
+    css_declaration: { name: "padding-left" }
+    css_declaration: { name: "padding-right" }
+    css_declaration: { name: "padding-top" }
+    css_declaration: { name: "page-break-after" }
+    css_declaration: { name: "page-break-before" }
+    css_declaration: { name: "page-break-inside" }
+    css_declaration: { name: "perspective" }
+    css_declaration: { name: "perspective-origin" }
+    css_declaration: { name: "pointer-events" }
+    # CSS Property `position` with values `fixed` and `sticky are not allowed.
+    # From https://www.w3schools.com/cssref/pr_class_position.asp
+    css_declaration: {
+      name: "position"
+      value_casei: "absolute"
+    }
+    css_declaration: {
+      name: "position"
+      value_casei: "inherit"
+    }
+    css_declaration: {
+      name: "position"
+      value_casei: "initial"
+    }
+    css_declaration: {
+      name: "position"
+      value_casei: "relative"
+    }
+    css_declaration: {
+      name: "position"
+      value_casei: "static"
+    }
+    css_declaration: { name: "quotes" }
+    css_declaration: { name: "resize" }
+    css_declaration: { name: "right" }
+    # https://www.w3.org/TR/SVG/pservers.html#StopColorProperty
+    css_declaration: { name: "stop-color" }
+    css_declaration: { name: "tab-size" }
+    css_declaration: { name: "table-layout" }
+    css_declaration: { name: "text-align" }
+    css_declaration: { name: "text-align-last" }
+    css_declaration: { name: "text-combine-upright" }
+    css_declaration: { name: "text-decoration" }
+    css_declaration: { name: "text-decoration-color" }
+    css_declaration: { name: "text-decoration-line" }
+    css_declaration: { name: "text-decoration-style" }
+    css_declaration: { name: "text-indent" }
+    css_declaration: { name: "text-justify" }
+    css_declaration: { name: "text-orientation" }
+    css_declaration: { name: "text-overflow" }
+    css_declaration: { name: "text-shadow" }
+    css_declaration: { name: "text-transform" }
+    css_declaration: { name: "text-underline-position" }
+    css_declaration: { name: "top" }
+    css_declaration: { name: "transform" }
+    css_declaration: { name: "transform-origin" }
+    css_declaration: { name: "transform-style" }
+    css_declaration: { name: "transition" }
+    css_declaration: { name: "transition-delay" }
+    css_declaration: { name: "transition-duration" }
+    css_declaration: { name: "transition-property" }
+    css_declaration: { name: "transition-timing-function" }
+    css_declaration: { name: "unicode-bidi" }
+    css_declaration: { name: "user-select" }
+    css_declaration: { name: "vertical-align" }
+    css_declaration: { name: "visibility" }
+    css_declaration: { name: "white-space" }
+    css_declaration: { name: "widows" }
+    css_declaration: { name: "width" }
+    css_declaration: { name: "word-break" }
+    css_declaration: { name: "word-spacing" }
+    css_declaration: { name: "word-wrap" }
+    css_declaration: { name: "writing-mode" }
+    css_declaration: { name: "z-index" }
     blacklisted_value_regex: "!important"
   }
 }

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -26,7 +26,7 @@ min_validator_revision_required: 334
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 667
+spec_file_revision: 668
 
 styles_spec_url: "https://www.ampproject.org/docs/guides/author-develop/responsive/style_pages"
 script_spec_url: "https://www.ampproject.org/docs/reference/spec#html-tags"

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -26,7 +26,7 @@ min_validator_revision_required: 334
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 666
+spec_file_revision: 667
 
 styles_spec_url: "https://www.ampproject.org/docs/guides/author-develop/responsive/style_pages"
 script_spec_url: "https://www.ampproject.org/docs/reference/spec#html-tags"
@@ -2244,7 +2244,8 @@ attr_lists: {
   name: "svg-style-attr"
   attrs: {
     name: "style"
-    # From https://www.w3schools.com/cssref/default.asp
+    # CSS proprities: https://www.w3schools.com/cssref/default.asp
+    # SVG specific properties: https://www.w3.org/TR/SVG11/styling.html#SVGStylingProperties
     # Disallowed:
     # css_declaration: { name: "@charset" }
     # css_declaration: { name: "@font-face" }
@@ -2256,6 +2257,7 @@ attr_lists: {
     css_declaration: { name: "align-content" }
     css_declaration: { name: "align-items" }
     css_declaration: { name: "align-self" }
+    css_declaration: { name: "alignment-baseline" } # SVG
     css_declaration: { name: "all" }
     css_declaration: { name: "animation" }
     css_declaration: { name: "animation-delay" }
@@ -2277,6 +2279,7 @@ attr_lists: {
     css_declaration: { name: "background-position" }
     css_declaration: { name: "background-repeat" }
     css_declaration: { name: "background-size" }
+    css_declaration: { name: "baseline-shift" } # SVG
     css_declaration: { name: "border" }
     css_declaration: { name: "border-bottom" }
     css_declaration: { name: "border-bottom-color" }
@@ -2321,9 +2324,13 @@ attr_lists: {
     css_declaration: { name: "caret-color" }
     css_declaration: { name: "clear" }
     css_declaration: { name: "clip" }
-    # https://www.w3.org/TR/css-masking-1/#the-clip-rule
-    css_declaration: { name: "clip-rule" }
+    css_declaration: { name: "clip-path" } # SVG
+    css_declaration: { name: "clip-rule" } # SVG
     css_declaration: { name: "color" }
+    css_declaration: { name: "color-interpolation" } # SVG
+    css_declaration: { name: "color-interpolation-filters" } # SVG
+    css_declaration: { name: "color-profile" } # SVG
+    css_declaration: { name: "color-rendering" } # SVG
     css_declaration: { name: "column-count" }
     css_declaration: { name: "column-fill" }
     css_declaration: { name: "column-gap" }
@@ -2340,15 +2347,12 @@ attr_lists: {
     css_declaration: { name: "cursor" }
     css_declaration: { name: "direction" }
     css_declaration: { name: "display" }
+    css_declaration: { name: "dominant-baseline" } # SVG
     css_declaration: { name: "empty-cells" }
-    # https://www.w3.org/TR/SVG11/filters.html#AccessingBackgroundImage
-    css_declaration: { name: "enable-background" }
-    # https://www.w3.org/TR/fill-stroke-3/#fill-shorthand
-    css_declaration: { name: "fill" }
-    # https://www.w3.org/TR/fill-stroke-3/#fill-opacity
-    css_declaration: { name: "fill-opacity" }
-    # https://www.w3.org/TR/fill-stroke-3/#fill-rule
-    css_declaration: { name: "fill-rule" }
+    css_declaration: { name: "enable-background" } # SVG
+    css_declaration: { name: "fill" } # SVG
+    css_declaration: { name: "fill-opacity" } # SVG
+    css_declaration: { name: "fill-rule" } # SVG
     css_declaration: { name: "filter" }
     css_declaration: { name: "flex" }
     css_declaration: { name: "flex-basis" }
@@ -2358,6 +2362,8 @@ attr_lists: {
     css_declaration: { name: "flex-shrink" }
     css_declaration: { name: "flex-wrap" }
     css_declaration: { name: "float" }
+    css_declaration: { name: "flood-color" } # SVG
+    css_declaration: { name: "flood-opacity" } # SVG
     css_declaration: { name: "font" }
     css_declaration: { name: "font-family" }
     css_declaration: { name: "font-feature-settings" }
@@ -2376,6 +2382,8 @@ attr_lists: {
     css_declaration: { name: "font-variant-numeric" }
     css_declaration: { name: "font-variant-position" }
     css_declaration: { name: "font-weight" }
+    css_declaration: { name: "glyph-orientation-horizontal" } # SVG
+    css_declaration: { name: "glyph-orientation-vertical" } # SVG
     css_declaration: { name: "grid" }
     css_declaration: { name: "grid-area" }
     css_declaration: { name: "grid-auto-columns" }
@@ -2400,8 +2408,10 @@ attr_lists: {
     css_declaration: { name: "image-rendering" }
     css_declaration: { name: "isolation" }
     css_declaration: { name: "justify-content" }
+    css_declaration: { name: "kerning" } # SVG
     css_declaration: { name: "left" }
     css_declaration: { name: "letter-spacing" }
+    css_declaration: { name: "lighting-color" } # SVG
     css_declaration: { name: "line-break" }
     css_declaration: { name: "line-height" }
     css_declaration: { name: "list-style" }
@@ -2413,6 +2423,11 @@ attr_lists: {
     css_declaration: { name: "margin-left" }
     css_declaration: { name: "margin-right" }
     css_declaration: { name: "margin-top" }
+    css_declaration: { name: "marker" } # SVG
+    css_declaration: { name: "marker-end" } # SVG
+    css_declaration: { name: "marker-mid" } # SVG
+    css_declaration: { name: "marker-start" } # SVG
+    css_declaration: { name: "mask" } # SVG
     css_declaration: { name: "max-height" }
     css_declaration: { name: "max-width" }
     css_declaration: { name: "min-height" }
@@ -2443,7 +2458,7 @@ attr_lists: {
     css_declaration: { name: "perspective" }
     css_declaration: { name: "perspective-origin" }
     css_declaration: { name: "pointer-events" }
-    # CSS Property `position` with values `fixed` and `sticky are not allowed.
+    # CSS property `position` with values `fixed` and `sticky are not allowed.
     # From https://www.w3schools.com/cssref/pr_class_position.asp
     css_declaration: {
       name: "position"
@@ -2468,12 +2483,22 @@ attr_lists: {
     css_declaration: { name: "quotes" }
     css_declaration: { name: "resize" }
     css_declaration: { name: "right" }
-    # https://www.w3.org/TR/SVG/pservers.html#StopColorProperty
-    css_declaration: { name: "stop-color" }
+    css_declaration: { name: "shape-rendering" } # SVG
+    css_declaration: { name: "stop-color" } # SVG
+    css_declaration: { name: "stop-opacity" } # SVG
+    css_declaration: { name: "stroke" } # SVG
+    css_declaration: { name: "stroke-dasharray" } # SVG
+    css_declaration: { name: "stroke-dashoffset" } # SVG
+    css_declaration: { name: "stroke-linecap" } # SVG
+    css_declaration: { name: "stroke-linejoin" } # SVG
+    css_declaration: { name: "stroke-miterlimit" } # SVG
+    css_declaration: { name: "stroke-opacity" } # SVG
+    css_declaration: { name: "stroke-width" } # SVG
     css_declaration: { name: "tab-size" }
     css_declaration: { name: "table-layout" }
     css_declaration: { name: "text-align" }
     css_declaration: { name: "text-align-last" }
+    css_declaration: { name: "text-anchor" } # SVG
     css_declaration: { name: "text-combine-upright" }
     css_declaration: { name: "text-decoration" }
     css_declaration: { name: "text-decoration-color" }
@@ -2483,6 +2508,7 @@ attr_lists: {
     css_declaration: { name: "text-justify" }
     css_declaration: { name: "text-orientation" }
     css_declaration: { name: "text-overflow" }
+    css_declaration: { name: "text-rendering" } # SVG
     css_declaration: { name: "text-shadow" }
     css_declaration: { name: "text-transform" }
     css_declaration: { name: "text-underline-position" }

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -26,7 +26,7 @@ min_validator_revision_required: 328
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 662
+spec_file_revision: 663
 
 styles_spec_url: "https://www.ampproject.org/docs/guides/author-develop/responsive/style_pages"
 script_spec_url: "https://www.ampproject.org/docs/reference/spec#html-tags"

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -26,7 +26,7 @@ min_validator_revision_required: 334
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 668
+spec_file_revision: 669
 
 styles_spec_url: "https://www.ampproject.org/docs/guides/author-develop/responsive/style_pages"
 script_spec_url: "https://www.ampproject.org/docs/reference/spec#html-tags"
@@ -3787,6 +3787,7 @@ tags: {
 tags: {
   html_format: AMP
   html_format: AMP4ADS
+  html_format: EXPERIMENTAL
   tag_name: "INPUT"
   attrs: {
     name: "type"

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -20,13 +20,13 @@
 # in production from crashing. This id is not relevant to validator.js
 # because thus far, engine (validator.js) and spec file
 # (validator-main.protoascii) are always released together.
-min_validator_revision_required: 328
+min_validator_revision_required: 333
 
 # The spec file revision allows the validator engine to distinguish
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 663
+spec_file_revision: 664
 
 styles_spec_url: "https://www.ampproject.org/docs/guides/author-develop/responsive/style_pages"
 script_spec_url: "https://www.ampproject.org/docs/reference/spec#html-tags"

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -26,7 +26,7 @@ min_validator_revision_required: 334
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 669
+spec_file_revision: 670
 
 styles_spec_url: "https://www.ampproject.org/docs/guides/author-develop/responsive/style_pages"
 script_spec_url: "https://www.ampproject.org/docs/reference/spec#html-tags"
@@ -49,6 +49,10 @@ css_length_spec: {
 # (https://www.ampproject.org/docs/reference/spec)
 
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "!DOCTYPE"
   spec_name: "html doctype"
   mandatory_parent: "$ROOT"
@@ -117,6 +121,10 @@ tags: {  # AMP4EMAIL
 # 4.2 Document metadata
 # 4.2.1 The head element
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "HEAD"
   mandatory: true
   mandatory_parent: "HTML"
@@ -125,6 +133,10 @@ tags: {
 }
 # 4.2.2 The title element
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "TITLE"
   spec_name: "title"
   attrs: { name: "[text]" }
@@ -374,6 +386,10 @@ tags: {
 # 4.2.5 the meta element
 # Charset must be utf8, and a specific viewport is required.
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "META"
   spec_name: "meta charset=utf-8"
   mandatory: true
@@ -1269,6 +1285,10 @@ tags: {
 # 4.3 Sections
 # 4.3.1 The body element
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "BODY"
   mandatory: true
   unique: true
@@ -1277,71 +1297,135 @@ tags: {
 }
 # 4.3.2 The article element
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "ARTICLE"
 }
 # 4.3.3 The section element
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "SECTION"
   disallowed_ancestor: "AMP-ACCORDION"
 }
 # 4.3.4 The nav element
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "NAV"
 }
 # 4.3.5 The aside element
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "ASIDE"
 }
 # 4.3.6 The h1, h2, h3, h4, h5, and h6 elements
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "H1"
   attrs: { name: "align" }
 }
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "H2"
   attrs: { name: "align" }
 }
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "H3"
   attrs: { name: "align" }
 }
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "H4"
   attrs: { name: "align" }
 }
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "H5"
   attrs: { name: "align" }
 }
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "H6"
   attrs: { name: "align" }
 }
 # 4.3 7 The header element
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "HEADER"
 }
 # 4.3 7 The footer element
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "FOOTER"
 }
 # 4.3 7 The address element
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "ADDRESS"
 }
 
 # 4.4 Grouping Content
 # 4.4.1 The p element
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "P"
   attrs: { name: "align" }
 }
 # 4.4.2 The hr element
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "HR"
 }
 # 4.4.3 The pre element
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "PRE"
 }
 # 4.4.4 The blockquote element
@@ -1359,12 +1443,20 @@ attr_lists: {
   }
 }
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "BLOCKQUOTE"
   attrs: { name: "align" }
   attr_lists: "cite-attr"
 }
 # 4.4.5 The ol element
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "OL"
   attrs: {
     name: "reversed"
@@ -1381,10 +1473,18 @@ tags: {
 }
 # 4.4.6 The ul element
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "UL"
 }
 # 4.4.7 The li element
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "LI"
   attrs: {
     name: "value"
@@ -1393,31 +1493,59 @@ tags: {
 }
 # 4.4.8 The dl element
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "DL"
 }
 # 4.4.9 The dt element
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "DT"
 }
 # 4.4.10 The dd element
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "DD"
 }
 # 4.4.11 The figure element
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "FIGURE"
 }
 # 4.4.12 The figcaption element
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "FIGCAPTION"
 }
 # 4.4.13 The div element
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "DIV"
   attrs: { name: "align" }
 }
 # 4.4.14 The main element
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "MAIN"
 }
 
@@ -1571,43 +1699,83 @@ tags: {
 
 # 4.5.2 The em element
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "EM"
 }
 # 4.5.3 The strong element
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "STRONG"
 }
 # 4.5.4 The small element
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "SMALL"
 }
 # 4.5.5 The s element
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "S"
 }
 # 4.5.6 The cite element
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "CITE"
 }
 # 4.5.7 The q element
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "Q"
   attr_lists: "cite-attr"
 }
 # 4.5.8 The dfn element
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "DFN"
 }
 # 4.5.9 The abbr element
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "ABBR"
 }
 # 4.5.10 The data element
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "DATA"
 }
 # 4.5.11 The time element
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "TIME"
   attrs: {
     name: "datetime"
@@ -1615,88 +1783,172 @@ tags: {
 }
 # 4.5.12 The code element
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "CODE"
 }
 # 4.5.13 The var element
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "VAR"
 }
 # 4.5.14 The samp element
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "SAMP"
 }
 # 4.5.15 The kbd element
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "KBD"
 }
 # 4.5.16 The sub and sup elements
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "SUB"
 }
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "SUP"
 }
 # 4.5.17 The i element
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "I"
 }
 # 4.5.18 The b element
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "B"
 }
 # 4.5.19 The u element
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "U"
 }
 # 4.5.20 The mark element
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "MARK"
 }
 # 4.5.21 The ruby element
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "RUBY"
 }
 # 4.5.22 The rb element
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "RB"
 }
 # 4.5.23 The rt element
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "RT"
 }
 # 4.5.24 The rtc element
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "RTC"
 }
 # 4.5.25 The rp element
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "RP"
 }
 # 4.5.26 The bdi element
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "BDI"
 }
 # 4.5.27 The bdo element
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "BDO"
   attrs: { name: "dir" }
 }
 # 4.5.28 The span element
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "SPAN"
 }
 # 4.5.29 The br element
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "BR"
 }
 # 4.5.30 The wbr element
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "WBR"
 }
 
 # 4.6 Edits
 # 4.6.1 The ins element
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "INS"
   # https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ins
   # These attributes have specific formatting, but as they are metadata
@@ -1707,6 +1959,10 @@ tags: {
 }
 # 4.6.2 The del element
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "DEL"
   # https://developer.mozilla.org/en-US/docs/Web/HTML/Element/del
   # These attributes have specific formatting, but as they are metadata
@@ -3275,6 +3531,10 @@ tags: {
 # 4.9 Tabular data
 # 4.9.1 The table element
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "TABLE"
   attrs: { name: "align" }  # Not valid html5 but commonly used and supported.
   attrs: { name: "bgcolor" }  # Not valid html5 but commonly used and supported.
@@ -3289,32 +3549,60 @@ tags: {
 }
 # 4.9.2 The caption element
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "CAPTION"
 }
 # 4.9.3 The colgroup element
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "COLGROUP"
   attrs: { name: "span" }
 }
 # 4.9.4 The col element
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "COL"
   attrs: { name: "span" }
 }
 # 4.9.5 The tbody element
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "TBODY"
 }
 # 4.9.6 The thead element
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "THEAD"
 }
 # 4.9.7 The tfoot element
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "TFOOT"
 }
 # 4.9.8 The tr element
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "TR"
   # These attributes are not supported in HTML5, but are widely supported and
   # commonly found.
@@ -3325,6 +3613,10 @@ tags: {
 }
 # 4.9.9 The td element
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "TD"
   attrs: { name: "align" }  # Not valid html5 but commonly used and supported.
   attrs: { name: "bgcolor" }  # Not valid html5 but commonly used and supported.
@@ -3337,6 +3629,10 @@ tags: {
 }
 # 4.9.10 The th element
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "TH"
   attrs: { name: "abbr" }
   attrs: { name: "align" }  # Not valid html5 but commonly used and supported.
@@ -3556,6 +3852,10 @@ tags {
   }
 }
 tags {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "DIV"
   spec_name: "FORM > DIV [submit-success]"
   mandatory_parent: "FORM"
@@ -3566,6 +3866,10 @@ tags {
   }
 }
 tags {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "DIV"
   spec_name: "FORM > DIV [submit-success][template]"
   mandatory_parent: "FORM"
@@ -3580,6 +3884,10 @@ tags {
   }
 }
 tags {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "DIV"
   spec_name: "FORM > DIV [submit-error]"
   mandatory_parent: "FORM"
@@ -3590,6 +3898,10 @@ tags {
   }
 }
 tags {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "DIV"
   spec_name: "FORM > DIV [submit-error][template]"
   mandatory_parent: "FORM"
@@ -3779,6 +4091,10 @@ attr_lists: {
 }
 # 4.10.4 The label element
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "LABEL"
   attrs: { name: "for" }
   spec_url: "https://www.ampproject.org/docs/reference/components/amp-form"
@@ -3855,6 +4171,10 @@ tags: {
 }
 # 4.10.6 The button element
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "BUTTON"
   attrs: {
     name: "disabled"
@@ -3903,6 +4223,10 @@ tags: {
 }
 # 4.10.7 The select element
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "SELECT"
   attrs: { name: "autofocus" }
   attrs: { name: "disabled" }
@@ -3920,11 +4244,19 @@ tags: {
 }
 # 4.10.8 The datalist element
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "DATALIST"
   spec_url: "https://www.ampproject.org/docs/reference/components/amp-form"
 }
 # 4.10.9 The optgroup element
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "OPTGROUP"
   mandatory_parent: "SELECT"
   attrs: { name: "disabled" }
@@ -3936,6 +4268,10 @@ tags: {
 }
 # 4.10.10 The option element
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "OPTION"
   attrs: { name: "disabled" }
   attrs: { name: "label" }
@@ -3950,6 +4286,10 @@ tags: {
 }
 # 4.10.11 The textarea element
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "TEXTAREA"
   attrs: { name: "autocomplete" }
   attrs: { name: "autofocus" }
@@ -3987,6 +4327,10 @@ tags: {
 }
 # 4.10.13 The output element
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "OUTPUT"
   attrs: { name: "for" }
   attrs: { name: "form" }
@@ -3994,12 +4338,20 @@ tags: {
 }
 # 4.10.14 The progress element
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "PROGRESS"
   attrs: { name: "max" }
   attrs: { name: "value" }
 }
 # 4.10.15 The meter element
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "METER"
   attrs: { name: "high" }
   attrs: { name: "low" }
@@ -4010,6 +4362,10 @@ tags: {
 }
 # 4.10.16 The fieldset element
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "FIELDSET"
   attrs: { name: "disabled" }
   # <amp-bind>
@@ -4018,6 +4374,10 @@ tags: {
 }
 # 4.10.17 The legend element
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "LEGEND"
 }
 
@@ -4091,6 +4451,10 @@ tags: {
 }
 # JSON Linked Data
 tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: EXPERIMENTAL
   tag_name: "SCRIPT"
   spec_name: "script type=application/ld+json"
   attrs: { name: "nonce" }

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -26,7 +26,7 @@ min_validator_revision_required: 333
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 664
+spec_file_revision: 665
 
 styles_spec_url: "https://www.ampproject.org/docs/guides/author-develop/responsive/style_pages"
 script_spec_url: "https://www.ampproject.org/docs/reference/spec#html-tags"

--- a/validator/validator.proto
+++ b/validator/validator.proto
@@ -58,10 +58,8 @@ message UrlSpec {
   optional bool allow_relative = 2 [default = true];
   // Whether the empty string '' is allowed for this URL value.
   optional bool allow_empty = 3 [default = false];
-  // Must be lowercase. Subdomains of disallowed domains are also disallowed,
-  // so if 'example.com' is disallowed then 'www.example.com' is also disallowed
-  // but 'some-example.com' is allowed.
-  repeated string disallowed_domain = 4;
+
+  reserved 4;
 }
 
 // Attributes that are not covered by at least one of these specs are

--- a/validator/validator.proto
+++ b/validator/validator.proto
@@ -59,7 +59,7 @@ message UrlSpec {
   // Whether the empty string '' is allowed for this URL value.
   optional bool allow_empty = 3 [default = false];
 
-  reserved 4;
+  // reserved 4;
 }
 
 // NEXT AVAILABLE TAG: 3

--- a/validator/validator.proto
+++ b/validator/validator.proto
@@ -396,8 +396,8 @@ message HtmlFormat {
 message TagSpec {
   // The html_format field tells the validator for which html formats
   // (ie: (<html ⚡> vs <html a4⚡>) this HTML TagSpec is allowed to validate.
-  // If the repeated field is empty, this indicates that the TagSpec is allowed
-  // for all formats, rather than none.
+  // The repeated field is not allowed to be empty, it must have at least one
+  // HtmlFormat.
   repeated HtmlFormat.Code html_format = 21;
 
   // Use UPPER-CASE tag names only. If adding the same tag twice, then they must

--- a/validator/validator.proto
+++ b/validator/validator.proto
@@ -62,10 +62,19 @@ message UrlSpec {
   reserved 4;
 }
 
+// NEXT AVAILABLE TAG: 3
+message CssDeclaration {
+  // The name of the declaration (e.g. display). Use lower-case attribute names
+  // only.
+  optional string name = 1;
+  // The value of the declaration (e.g. block).
+  optional string value_casei = 2 [default = ""];
+}
+
 // Attributes that are not covered by at least one of these specs are
 // disallowed. Within a given context (e.g., for a given TagSpec),
 // names are unique.
-// NEXT AVAILABLE TAG: 20
+// NEXT AVAILABLE TAG: 21
 message AttrSpec {
   // Use lower-case attribute names only.
   optional string name = 1;
@@ -105,6 +114,9 @@ message AttrSpec {
   optional string deprecation = 7;
   // If provided, a URL which links to the AMP HTML spec for this deprecation.
   optional string deprecation_url = 8;
+
+  // Valid CSS declarations.
+  repeated CssDeclaration css_declaration = 20;
 
   enum DispatchKeyType {
     // Indicates that the attribute does not form a dispatch key.
@@ -716,9 +728,9 @@ message ValidationError {
     CSS_SYNTAX_MALFORMED_MEDIA_QUERY = 98;
     CSS_SYNTAX_DISALLOWED_MEDIA_TYPE = 99;
     CSS_SYNTAX_DISALLOWED_MEDIA_FEATURE = 100;
+    CSS_SYNTAX_DISALLOWED_PROPERTY_VALUE = 71;
 
     // The following codes are currently used only by A4A CSS validation.
-    CSS_SYNTAX_DISALLOWED_PROPERTY_VALUE = 71;
     CSS_SYNTAX_DISALLOWED_PROPERTY_VALUE_WITH_HINT = 72;
     CSS_SYNTAX_PROPERTY_DISALLOWED_WITHIN_AT_RULE = 73;
     CSS_SYNTAX_PROPERTY_DISALLOWED_TOGETHER_WITH = 74;


### PR DESCRIPTION
 - Revision bump for #15924
 - Remove disallowed domain
 - Revision bump for #16320
 - Adds parsing of inline style
 - Expand css declarations for SVG inline style
 - Revision bump for #16371
 - Strip vendor prefix for inline style
 - Add EXPERIMENTAL back for tag input
 - TagSpecs must have at least one html_