### PR TITLE
🏗 Publish code coverage reports to https://codecov.io from Travis builds

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,6 @@
+# Settings for code coverage PR comments from https://codecov.io
+comment:
+  layout: "header, diff, footer"
+  behavior: default
+  require_base: no
+  require_head: yes

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -310,8 +310,8 @@ const command = {
     if (argv.files) {
       cmd = cmd + ' --files ' + argv.files;
     }
-    // Unit tests with Travis' default chromium
-    timedExecOrDie(cmd + ' --headless');
+    // Unit tests with Travis' default chromium in coverage mode.
+    timedExecOrDie(cmd + ' --headless --coverage');
     if (process.env.TRAVIS) {
       // A subset of unit tests on other browsers via sauce labs
       cmd = cmd + ' --saucelabs_lite';

--- a/build-system/tasks/runtime-test.js
+++ b/build-system/tasks/runtime-test.js
@@ -519,7 +519,7 @@ function runTests() {
     c.reporters = c.reporters.concat(['coverage-istanbul']);
     c.coverageIstanbulReporter = {
       dir: 'test/coverage',
-      reports: ['html', 'text', 'text-summary'],
+      reports: ['html', 'text', 'text-summary', 'lcov'],
     };
   }
 
@@ -562,11 +562,17 @@ function runTests() {
           yellow('Karma test failed with exit code ' + exitCode));
     }
     if (argv.coverage) {
-      const coverageReportUrl =
-          'file://' + path.resolve('test/coverage/index.html');
-      log(green('INFO: ') + 'Generated code coverage report at ' +
-          cyan(coverageReportUrl));
-      opn(coverageReportUrl, {wait: false});
+      if (process.env.TRAVIS) {
+        log(green('INFO: ') + 'Uploading code coverage report to' +
+            cyan('https://codecov.io/gh/ampproject/amphtml') + '...');
+        exec('./node_modules/.bin/codecov');
+      } else {
+        const coverageReportUrl =
+            'file://' + path.resolve('test/coverage/index.html');
+        log(green('INFO: ') + 'Generated code coverage report at ' +
+            cyan(coverageReportUrl));
+        opn(coverageReportUrl, {wait: false});
+      }
     }
     // TODO(rsimha, 14814): Remove after Karma / Sauce ticket is resolved.
     if (process.env.TRAVIS) {

--- a/build-system/tasks/runtime-test.js
+++ b/build-system/tasks/runtime-test.js
@@ -499,6 +499,7 @@ function runTests() {
   }
 
   if (argv.coverage) {
+    c.client.captureConsole = false;
     c.browserify.transform = [
       ['babelify', {
         compact: false,
@@ -544,7 +545,7 @@ function runTests() {
   // On Travis, collapse the summary printed by the 'karmaSimpleReporter'
   // reporter for full unit test runs, since it likely contains copious amounts
   // of logs.
-  const shouldCollapseSummary = process.env.TRAVIS &&
+  const shouldCollapseSummary = process.env.TRAVIS && c.client.captureConsole &&
       c.reporters.includes('karmaSimpleReporter') && !argv['local-changes'];
   const sectionMarker =
       (argv.saucelabs || argv.saucelabs_lite) ? 'saucelabs' : 'local';

--- a/build-system/tasks/runtime-test.js
+++ b/build-system/tasks/runtime-test.js
@@ -32,7 +32,7 @@ const webserver = require('gulp-webserver');
 const {applyConfig, removeConfig} = require('./prepend-global/index.js');
 const {app} = require('../test-server');
 const {createCtrlcHandler, exitCtrlcHandler} = require('../ctrlcHandler');
-const {exec} = require('../exec');
+const {exec, getStdout} = require('../exec');
 const {gitDiffNameOnlyMaster} = require('../git');
 
 const {green, yellow, cyan, red, bold} = colors;
@@ -520,7 +520,7 @@ function runTests() {
     c.reporters = c.reporters.concat(['coverage-istanbul']);
     c.coverageIstanbulReporter = {
       dir: 'test/coverage',
-      reports: ['html', 'text', 'text-summary', 'lcov'],
+      reports: process.env.TRAVIS ? ['lcov'] : ['html', 'text', 'text-summary'],
     };
   }
 
@@ -564,9 +564,21 @@ function runTests() {
     }
     if (argv.coverage) {
       if (process.env.TRAVIS) {
-        log(green('INFO: ') + 'Uploading code coverage report to' +
+        log(green('INFO: ') + 'Uploading code coverage report to ' +
             cyan('https://codecov.io/gh/ampproject/amphtml') + '...');
-        exec('./node_modules/.bin/codecov');
+        const codecovCmd =
+            './node_modules/.bin/codecov --file=test/coverage/lcov.info';
+        const output = getStdout(codecovCmd);
+        const viewReportPrefix = 'View report at: ';
+        const viewReport = output.match(viewReportPrefix + '.*');
+        if (viewReport && viewReport.length > 0) {
+          log(green('INFO: ') + viewReportPrefix +
+              cyan(viewReport[0].replace(viewReportPrefix, '')));
+        } else {
+          log(yellow('WARNING: ') +
+              'Code coverage report upload may have failed:\n' +
+              yellow(output));
+        }
       } else {
         const coverageReportUrl =
             'file://' + path.resolve('test/coverage/index.html');

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "chai": "4.1.2",
     "chai-as-promised": "7.1.1",
     "cli-highlight": "2.0.0",
+    "codecov": "3.0.2",
     "connect-header": "0.0.5",
     "cssnano": "4.0.0-rc.2",
     "del": "3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -558,6 +558,10 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+argv@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/argv/-/argv-0.0.2.tgz#ecbd16f8949b157183711b1bda334f37840185ab"
+
 arr-diff@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-1.1.0.tgz#687c32758163588fef7de7b36fabe495eb1a399a"
@@ -2679,6 +2683,14 @@ code-excerpt@^2.1.1:
 code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
+
+codecov@3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/codecov/-/codecov-3.0.2.tgz#aea43843a5cd2fb6b7e488b2eff25d367ab70b12"
+  dependencies:
+    argv "0.0.2"
+    request "^2.81.0"
+    urlgrey "0.4.4"
 
 collection-visit@^1.0.0:
   version "1.0.0"
@@ -10402,7 +10414,7 @@ request@2.81.0:
     tunnel-agent "^0.6.0"
     uuid "^3.0.0"
 
-request@2.87.0, request@^2.85.0, request@^2.87.0:
+request@2.87.0, request@^2.81.0, request@^2.85.0, request@^2.87.0:
   version "2.87.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.87.0.tgz#32f00235cd08d482b4d0d68db93a829c0ed5756e"
   dependencies:
@@ -12177,6 +12189,10 @@ url@~0.11.0:
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"
+
+urlgrey@0.4.4:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/urlgrey/-/urlgrey-0.4.4.tgz#892fe95960805e85519f1cd4389f2cb4cbb7652f"
 
 use@^2.0.0:
   version "2.0.2"


### PR DESCRIPTION
With this, we should see code coverage results from PR builds and push builds at https://codecov.io/gh/ampproject/amphtml

According to https://www.npmjs.com/package/codecov#upload-repo-tokens, there's no need for a special upload token if the upload is being done from Travis CI.

Fixes #16429
