### PR TITLE
Disable text highlighting when <amp-access> is used.

### DIFF
--- a/extensions/amp-viewer-integration/0.1/highlight-handler.js
+++ b/extensions/amp-viewer-integration/0.1/highlight-handler.js
@@ -161,6 +161,14 @@ export class HighlightHandler {
    * @private
    */
   initHighlight_(highlightInfo) {
+    if (!!this.ampdoc_.win.document.querySelector('script[id="amp-access"]')) {
+      // Disable highlighting if <amp-access> is used because highlighting
+      // interacts badily with UI reflows by <amp-access>.
+      // TODO(yunabe): Remove this once <amp-access> provides an API to delay
+      // code execution after DOM manipulation by <amp-access>.
+      this.sendHighlightState_('has_amp_access');
+      return;
+    }
     this.findHighlightedNodes_(highlightInfo);
     if (!this.highlightedNodes_) {
       this.sendHighlightState_('not_found');

--- a/extensions/amp-viewer-integration/0.1/highlight-handler.js
+++ b/extensions/amp-viewer-integration/0.1/highlight-handler.js
@@ -161,7 +161,7 @@ export class HighlightHandler {
    * @private
    */
   initHighlight_(highlightInfo) {
-    if (!!this.ampdoc_.win.document.querySelector('script[id="amp-access"]')) {
+    if (this.ampdoc_.win.document.querySelector('script[id="amp-access"]')) {
       // Disable highlighting if <amp-access> is used because highlighting
       // interacts badily with UI reflows by <amp-access>.
       // TODO(yunabe): Remove this once <amp-access> provides an API to delay

--- a/extensions/amp-viewer-integration/0.1/test/test-highlight-handler.js
+++ b/extensions/amp-viewer-integration/0.1/test/test-highlight-handler.js
@@ -179,6 +179,34 @@ describes.realWin('HighlightHandler', {
         'ed text</div>');
   });
 
+  it('initialize with amp-access', () => {
+    // Inject <script id="amp-access"> to emulate pages with <amp-access>.
+    const {document} = env.win;
+    const script = document.createElement('script');
+    script.id = 'amp-access';
+    document.body.appendChild(script);
+
+    const {ampdoc} = env;
+    const scrollStub = sandbox.stub(
+        Services.viewportForDoc(ampdoc), 'animateScrollIntoView');
+    scrollStub.returns(Promise.reject());
+    const sendMsgStub = sandbox.stub(
+        Services.viewerForDoc(ampdoc), 'sendMessage');
+
+    new HighlightHandler(ampdoc, {sentences: ['amp', 'highlight']});
+
+    expect(scrollStub).not.to.be.called;
+
+    // For some reason, expect(args).to.deep.equal does not work.
+    expect(sendMsgStub.callCount).to.equal(1);
+    expect(sendMsgStub.firstCall.args[0]).to.equal('highlightState');
+    expect(sendMsgStub.firstCall.args[1]).to.deep.equal(
+        {state: 'has_amp_access'});
+
+    expect(root.innerHTML).to.equal(
+        '<div>text in amp doc</div><div>highlighted text</div>');
+  });
+
   it('calcTopToCenterHighlightedNodes_ center elements', () => {
     const handler = new HighlightHandler(env.ampdoc, {sentences: ['amp']});
     expect(handler.highlightedNodes_).not.to.be.null;


### PR DESCRIPTION
Text highlighting interacts badly with UI reflow caused by <amp-access> (#13819). We want to disable text highlighting on pages with <amp-access> until we have a solution to resolve this interaction.