### PR TITLE
🏗 Run code coverage for integration tests on Travis

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,6 +1,6 @@
 # Settings for code coverage PR comments from https://codecov.io
 comment:
-  layout: "header, diff, footer"
+  layout: "header, diff, flags, footer"
   behavior: default
   require_base: no
   require_head: yes

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -333,13 +333,12 @@ const command = {
       cmd += ' --compiled';
     }
     if (process.env.TRAVIS) {
+      timedExecOrDie(cmd + ' --coverage');
       startSauceConnect();
-      cmd += ' --saucelabs';
-      timedExecOrDie(cmd);
+      timedExecOrDie(cmd + ' --saucelabs');
       stopSauceConnect();
     } else {
-      cmd += ' --headless';
-      timedExecOrDie(cmd);
+      timedExecOrDie(cmd + ' --headless');
     }
   },
   runVisualDiffTests: function(opt_mode) {

--- a/build-system/tasks/runtime-test.js
+++ b/build-system/tasks/runtime-test.js
@@ -568,7 +568,13 @@ function runTests() {
             cyan('https://codecov.io/gh/ampproject/amphtml') + '...');
         const codecovCmd =
             './node_modules/.bin/codecov --file=test/coverage/lcov.info';
-        const output = getStdout(codecovCmd);
+        let flags = ' --flags=';
+        if (argv.unit) {
+          flags = flags + 'unit_tests';
+        } else if (argv.integration) {
+          flags = flags + 'integration_tests';
+        }
+        const output = getStdout(codecovCmd + flags);
         const viewReportPrefix = 'View report at: ';
         const viewReport = output.match(viewReportPrefix + '.*');
         if (viewReport && viewReport.length > 0) {

--- a/build-system/tasks/runtime-test.js
+++ b/build-system/tasks/runtime-test.js
@@ -568,11 +568,11 @@ function runTests() {
             cyan('https://codecov.io/gh/ampproject/amphtml') + '...');
         const codecovCmd =
             './node_modules/.bin/codecov --file=test/coverage/lcov.info';
-        let flags = ' --flags=';
+        let flags = '';
         if (argv.unit) {
-          flags = flags + 'unit_tests';
+          flags = ' --flags=unit_tests';
         } else if (argv.integration) {
-          flags = flags + 'integration_tests';
+          flags = ' --flags=integration_tests';
         }
         const output = getStdout(codecovCmd + flags);
         const viewReportPrefix = 'View report at: ';


### PR DESCRIPTION
This PR runs integration tests in coverage mode on the version of Chrome local to Travis.

To run this locally, you can use:
```
gulp test --integration --coverage
```