### PR TITLE
Whitelisting amp-access actions from amp-story-access.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-access.js
+++ b/extensions/amp-story/1.0/amp-story-access.js
@@ -20,6 +20,8 @@ import {StateProperty} from './amp-story-store-service';
 import {copyChildren, removeChildren} from '../../../src/dom';
 import {dev} from '../../../src/log';
 import {dict} from './../../../src/utils/object';
+import {isArray, isObject} from '../../../src/types';
+import {parseJson} from '../../../src/json';
 import {renderAsElement} from './simple-template';
 import {throttle} from '../../../src/utils/rate-limit';
 
@@ -74,11 +76,7 @@ export class AmpStoryAccess extends AMP.BaseElement {
 
     this.element.appendChild(drawerEl);
 
-    // Allow <amp-access> actions in STAMP (defaults to no actions allowed).
-    this.actions_.addToWhitelist('SCRIPT.login');
-
-    // TODO(gmajoulet): allow wildcard actions to enable login namespaces.
-    // this.actions_.addToWhitelist('SCRIPT.login.*');
+    this.whitelistActions_();
 
     this.initializeListeners_();
   }
@@ -136,5 +134,62 @@ export class AmpStoryAccess extends AMP.BaseElement {
 
     this.element.getResources()
         .measureMutateElement(this.element, measurer, mutator);
+  }
+
+  /**
+   * Whitelists the <amp-access> actions.
+   * Depending on the publisher configuration, actions can be:
+   *   - login
+   *   - login-<namespace>
+   *   - login-<namespace>-<type>
+   *
+   * Publishers can provide one (object) or multiple (array) configurations,
+   * identified by their "namespace" property.
+   * Each configuration can have one or multiple login URLs, called "type".
+   * All the namespace/type pairs have to be whitelisted.
+   * @private
+   */
+  whitelistActions_() {
+    const accessEl =
+        dev().assertElement(
+            this.win.document.getElementById('amp-access'),
+            'Cannot find the amp-access configuration');
+
+    // Configuration validation is handled by the amp-access extension.
+    let accessConfig = parseJson(accessEl.textContent);
+
+    if (!isArray(accessConfig)) {
+      accessConfig = [accessConfig];
+
+      // If there is only one configuration and the publisher provided a
+      // namespace, we want to allow actions with or without namespace.
+      if (accessConfig[0].namespace) {
+        accessConfig.push(
+            Object.assign({}, accessConfig[0], {namespace: undefined}));
+      }
+    }
+
+    accessConfig.forEach(config => {
+      const namespace = config.namespace;
+
+      if (isObject(config.login)) {
+        Object.keys(config.login).forEach(type => {
+          this.whitelistAction_(namespace, type);
+        })
+      } else {
+        this.whitelistAction_(namespace);
+      }
+    });
+  }
+
+  /**
+   * Whitelists an action for the given namespace / type pair.
+   * @param {string=} namespace
+   * @param {string=} type
+   * @private
+   */
+  whitelistAction_(namespace = undefined, type = undefined) {
+    const action = ['login', namespace, type].filter(s => !!s).join('-');
+    this.actions_.addToWhitelist(`SCRIPT.${action}`);
   }
 }

--- a/extensions/amp-story/1.0/amp-story-access.js
+++ b/extensions/amp-story/1.0/amp-story-access.js
@@ -156,7 +156,8 @@ export class AmpStoryAccess extends AMP.BaseElement {
             'Cannot find the amp-access configuration');
 
     // Configuration validation is handled by the amp-access extension.
-    let accessConfig = parseJson(accessEl.textContent);
+    let accessConfig =
+        /** @type {!Array|!Object} */ (parseJson(accessEl.textContent));
 
     if (!isArray(accessConfig)) {
       accessConfig = [accessConfig];
@@ -170,12 +171,11 @@ export class AmpStoryAccess extends AMP.BaseElement {
     }
 
     accessConfig.forEach(config => {
-      const namespace = config.namespace;
+      const {login, namespace} = /** @type {{login, namespace}} */ (config);
 
-      if (isObject(config.login)) {
-        Object.keys(config.login).forEach(type => {
-          this.whitelistAction_(namespace, type);
-        })
+      if (isObject(login)) {
+        const types = Object.keys(login);
+        types.forEach(type => this.whitelistAction_(namespace, type));
       } else {
         this.whitelistAction_(namespace);
       }

--- a/extensions/amp-story/1.0/test/test-amp-story-access.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-access.js
@@ -20,17 +20,32 @@ import {registerServiceBuilder} from '../../../../src/service';
 
 describes.realWin('amp-story-access', {amp: true}, env => {
   let win;
+  let accessConfigurationEl;
+  let defaultConfig;
   let storeService;
   let storyAccess;
+
+  const setConfig = config => {
+    accessConfigurationEl.textContent = JSON.stringify(config);
+  };
 
   beforeEach(() => {
     win = env.win;
     storeService = new AmpStoryStoreService(win);
     registerServiceBuilder(win, 'story-store', () => storeService);
 
+    accessConfigurationEl = win.document.createElement('script');
+    accessConfigurationEl.setAttribute('id', 'amp-access');
+    accessConfigurationEl.setAttribute('type', 'application/json');
+    defaultConfig = {
+      login: 'https://example.com'
+    };
+    setConfig(defaultConfig);
+
     const storyAccessEl = win.document.createElement('amp-story-access');
     storyAccessEl.getResources = () => win.services.resources.obj;
 
+    win.document.body.appendChild(accessConfigurationEl);
     win.document.body.appendChild(storyAccessEl);
 
     storyAccess = new AmpStoryAccess(storyAccessEl);
@@ -67,7 +82,7 @@ describes.realWin('amp-story-access', {amp: true}, env => {
     });
   });
 
-  it('should whitelist the <amp-access> actions', () => {
+  it('should whitelist the default <amp-access> actions', () => {
     const addToWhitelistStub =
         sandbox.stub(storyAccess.actions_, 'addToWhitelist');
 
@@ -75,5 +90,64 @@ describes.realWin('amp-story-access', {amp: true}, env => {
 
     expect(addToWhitelistStub).to.have.been.calledOnce;
     expect(addToWhitelistStub).to.have.been.calledWith('SCRIPT.login');
+  });
+
+  it('should whitelist the typed <amp-access> actions', () => {
+    defaultConfig.login = {
+      typefoo: 'https://example.com',
+      typebar: 'https://example.com',
+    };
+    setConfig(defaultConfig);
+
+    const addToWhitelistStub =
+        sandbox.stub(storyAccess.actions_, 'addToWhitelist');
+
+    storyAccess.buildCallback();
+
+    expect(addToWhitelistStub).to.have.been.calledTwice;
+    expect(addToWhitelistStub).to.have.been.calledWith('SCRIPT.login-typefoo');
+    expect(addToWhitelistStub).to.have.been.calledWith('SCRIPT.login-typebar');
+  });
+
+  it('should whitelist the namespaced and default <amp-access> actions', () => {
+    defaultConfig.namespace = 'foo';
+    setConfig(defaultConfig);
+
+    const addToWhitelistStub =
+        sandbox.stub(storyAccess.actions_, 'addToWhitelist');
+
+    storyAccess.buildCallback();
+
+    expect(addToWhitelistStub).to.have.been.calledTwice;
+    // Both namespaced and default actions are allowed.
+    expect(addToWhitelistStub).to.have.been.calledWith('SCRIPT.login');
+    expect(addToWhitelistStub).to.have.been.calledWith('SCRIPT.login-foo');
+  });
+
+  it('should whitelist namespaced and typed <amp-access> actions', () => {
+    const config = [{
+      namespace: 'namespace1',
+      login: {
+        type1: 'https://example.com',
+        type2: 'https://example.com',
+      },
+    }, {
+      namespace: 'namespace2',
+      login: 'https://example.com',
+    }];
+    setConfig(config);
+
+    const addToWhitelistStub =
+        sandbox.stub(storyAccess.actions_, 'addToWhitelist');
+
+    storyAccess.buildCallback();
+
+    expect(addToWhitelistStub).to.have.callCount(3);
+    expect(addToWhitelistStub)
+        .to.have.been.calledWith('SCRIPT.login-namespace1-type1');
+    expect(addToWhitelistStub)
+        .to.have.been.calledWith('SCRIPT.login-namespace1-type2');
+    expect(addToWhitelistStub)
+        .to.have.been.calledWith('SCRIPT.login-namespace2');
   });
 });

--- a/extensions/amp-story/1.0/test/test-amp-story-access.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-access.js
@@ -37,9 +37,7 @@ describes.realWin('amp-story-access', {amp: true}, env => {
     accessConfigurationEl = win.document.createElement('script');
     accessConfigurationEl.setAttribute('id', 'amp-access');
     accessConfigurationEl.setAttribute('type', 'application/json');
-    defaultConfig = {
-      login: 'https://example.com'
-    };
+    defaultConfig = {login: 'https://example.com'};
     setConfig(defaultConfig);
 
     const storyAccessEl = win.document.createElement('amp-story-access');


### PR DESCRIPTION
Whitelisting `amp-access` actions from `amp-story-access`.

A publisher access configuration can look like:

### 1. Simple login endpoint

This configuration takes one optional `namespace` parameter. If one is provided, user can either trigger `amp-access:login` or `amp-access:login-namespace`.

````
{
  login: "url",
  (namespace: "foo")?
}
````

### 2. Multiple endpoint

Publisher can pick which endpoint will be used by triggering `amp-access:login-login` or `amp-access:login-signup`.
Here too, we take into account the optional `namespace`, or register actions with and without it if one is provided.

````
{
  login: {
    login: "url",
    signup: "url"
  }
}
````

### 3. Multiple configurations

We whitelist all the login / namespace pairs `amp-access:login-namespace-type`: `amp-access:login-foo-login`, `amp-access:login-foo-signup`, ...

````
[{
  login: {
    login: "url",
    signup: "url"
  },
  namespace: "foo"
},
{
  login: "url",
  namespace: "bar"
}]
````

cc @choumx Doing this on the `amp-story-access` seems like a better idea, no need to support wildcard actions :)

#12180