### PR TITLE
amp-access onApplyAuthorizations callbacks.

### DIFF
--- a/extensions/amp-access/0.1/amp-access.js
+++ b/extensions/amp-access/0.1/amp-access.js
@@ -18,6 +18,7 @@ import {AccessSource, AccessType} from './amp-access-source';
 import {AccessVars} from './access-vars';
 import {AmpEvents} from '../../../src/amp-events';
 import {CSS} from '../../../build/amp-access-0.1.css';
+import {Observable} from '../../../src/observable';
 import {Services} from '../../../src/services';
 import {cancellation} from '../../../src/error';
 import {dev, user} from '../../../src/log';
@@ -119,6 +120,9 @@ export class AccessService {
     /** @private {?Promise} */
     this.reportViewPromise_ = null;
 
+    /** @private @const {!Observable} */
+    this.applyAuthorizationsObservable_ = new Observable();
+
     // This will fire after the first received authorization, even if
     // there are multiple sources.
     this.lastAuthorizationPromises_.then(() => {
@@ -158,6 +162,21 @@ export class AccessService {
       });
     }
     return this.readerIdPromise_;
+  }
+
+  /**
+   * @return {boolean}
+   */
+  areFirstAuthorizationsCompleted() {
+    return this.firstAuthorizationsCompleted_;
+  }
+
+  /**
+   * Registers a callback to be triggered when the document gets (re)authorized.
+   * @param {!Function} callback
+   */
+  onApplyAuthorizations(callback) {
+    this.applyAuthorizationsObservable_.add(callback);
   }
 
   /**
@@ -399,7 +418,9 @@ export class AccessService {
     for (let i = 0; i < elements.length; i++) {
       promises.push(this.applyAuthorizationToElement_(elements[i], response));
     }
-    return Promise.all(promises);
+    return Promise.all(promises).then(() => {
+      this.applyAuthorizationsObservable_.fire();
+    });
   }
 
   /**

--- a/extensions/amp-access/0.1/test/test-amp-access.js
+++ b/extensions/amp-access/0.1/test/test-amp-access.js
@@ -465,6 +465,21 @@ describes.fakeWin('AccessService authorization', {
     });
   });
 
+  it('should execute the onApplyAuthorizations registered callbacks', () => {
+    expectGetReaderId('reader1');
+    adapterMock.expects('authorize')
+        .withExactArgs()
+        .returns(Promise.resolve({access: true}))
+        .once();
+
+    const applyAuthorizationsStub = sandbox.stub();
+    service.onApplyAuthorizations(applyAuthorizationsStub);
+
+    return service.runAuthorization_().then(() => {
+      expect(applyAuthorizationsStub).to.have.been.calledOnce;
+    });
+  });
+
   it('should run authorization for broadcast events on same origin', () => {
     let broadcastHandler;
     sandbox.stub(service.viewer_, 'onBroadcast').callsFake(handler => {


### PR DESCRIPTION
The STAMP implementation of `amp-access` prevents the user from navigating to a protected page (`amp-access=<condition>`).
It waits for the user to log in, and the document to be reauthorized before actually displaying the next page.

This PR implements a way for `amp-story` to know when the document has been reauthorized, so it can maybe navigate to the next page, if unblocked.

#12180 