### PR TITLE
Gate resetOnResize behavior behind an attribute tag for <amp-pan-zoom>

### DIFF
--- a/extensions/amp-pan-zoom/0.1/amp-pan-zoom.js
+++ b/extensions/amp-pan-zoom/0.1/amp-pan-zoom.js
@@ -139,6 +139,8 @@ export class AmpPanZoom extends AMP.BaseElement {
     /** @private {?../../../src/motion.Motion} */
     this.motion_ = null;
 
+    /** @private */
+    this.resetOnResize_ = false;
   }
 
   /** @override */
@@ -159,6 +161,7 @@ export class AmpPanZoom extends AMP.BaseElement {
     this.initialScale_ = this.getNumberAttributeOr_('initial-scale', 1);
     this.initialX_ = this.getNumberAttributeOr_('initial-x', 0);
     this.initialY_ = this.getNumberAttributeOr_('initial-y', 0);
+    this.resetOnResize_ = this.element.hasAttribute('reset-on-resize');
 
     this.registerAction('transform', invocation => {
       const {args} = invocation;
@@ -177,7 +180,9 @@ export class AmpPanZoom extends AMP.BaseElement {
 
   /** @override */
   onMeasureChanged() {
-    this.resetContentDimensions_();
+    if (this.resetOnResize_) {
+      this.resetContentDimensions_();
+    }
   }
 
   /** @override */

--- a/extensions/amp-pan-zoom/0.1/test/validator-amp-pan-zoom.html
+++ b/extensions/amp-pan-zoom/0.1/test/validator-amp-pan-zoom.html
@@ -51,6 +51,7 @@
   <amp-pan-zoom layout="responsive"
     width="1"
     height="1"
+    reset-on-resize
     initial-x="10"
     initial-y="2"
     initial-scale="2"

--- a/extensions/amp-pan-zoom/0.1/test/validator-amp-pan-zoom.out
+++ b/extensions/amp-pan-zoom/0.1/test/validator-amp-pan-zoom.out
@@ -52,6 +52,7 @@ FAIL
 |    <amp-pan-zoom layout="responsive"
 |      width="1"
 |      height="1"
+|      reset-on-resize
 |      initial-x="10"
 |      initial-y="2"
 |      initial-scale="2"
@@ -64,13 +65,13 @@ FAIL
 |      <!-- Invalid configuration example -->
 |      <amp-pan-zoom layout="responsive"
 >>     ^~~~~~~~~
-amp-pan-zoom/0.1/test/validator-amp-pan-zoom.html:64:4 The attribute 'initial-scale' in tag 'amp-pan-zoom' is set to the invalid value ''. (see https://www.ampproject.org/docs/reference/components/amp-pan-zoom) [DISALLOWED_HTML]
+amp-pan-zoom/0.1/test/validator-amp-pan-zoom.html:65:4 The attribute 'initial-scale' in tag 'amp-pan-zoom' is set to the invalid value ''. (see https://www.ampproject.org/docs/reference/components/amp-pan-zoom) [DISALLOWED_HTML]
 >>     ^~~~~~~~~
-amp-pan-zoom/0.1/test/validator-amp-pan-zoom.html:64:4 The attribute 'initial-x' in tag 'amp-pan-zoom' is set to the invalid value 'abc'. (see https://www.ampproject.org/docs/reference/components/amp-pan-zoom) [DISALLOWED_HTML]
+amp-pan-zoom/0.1/test/validator-amp-pan-zoom.html:65:4 The attribute 'initial-x' in tag 'amp-pan-zoom' is set to the invalid value 'abc'. (see https://www.ampproject.org/docs/reference/components/amp-pan-zoom) [DISALLOWED_HTML]
 >>     ^~~~~~~~~
-amp-pan-zoom/0.1/test/validator-amp-pan-zoom.html:64:4 The attribute 'initial-y' in tag 'amp-pan-zoom' is set to the invalid value ''. (see https://www.ampproject.org/docs/reference/components/amp-pan-zoom) [DISALLOWED_HTML]
+amp-pan-zoom/0.1/test/validator-amp-pan-zoom.html:65:4 The attribute 'initial-y' in tag 'amp-pan-zoom' is set to the invalid value ''. (see https://www.ampproject.org/docs/reference/components/amp-pan-zoom) [DISALLOWED_HTML]
 >>     ^~~~~~~~~
-amp-pan-zoom/0.1/test/validator-amp-pan-zoom.html:64:4 The attribute 'max-scale' in tag 'amp-pan-zoom' is set to the invalid value '3ex3'. (see https://www.ampproject.org/docs/reference/components/amp-pan-zoom) [DISALLOWED_HTML]
+amp-pan-zoom/0.1/test/validator-amp-pan-zoom.html:65:4 The attribute 'max-scale' in tag 'amp-pan-zoom' is set to the invalid value '3ex3'. (see https://www.ampproject.org/docs/reference/components/amp-pan-zoom) [DISALLOWED_HTML]
 |        width="1"
 |        height="1"
 |        initial-x="abc"

--- a/extensions/amp-pan-zoom/amp-pan-zoom.md
+++ b/extensions/amp-pan-zoom/amp-pan-zoom.md
@@ -61,6 +61,9 @@ Specifies a default zoom scale, otherwise set to 1.
 ##### initial-x, initial-y (optional)
 Specifies default translation coordinates, otherwise both set to 0. Expected to be a whole number.
 
+##### reset-on-resize (optional)
+Reset refers to centering the image and setting it back to scale = 1. Setting this attribute causes the component to reset the zoomable content on resize of the image itself.
+
 ## Events and Actions
 #### transformEnd (event)
 The `<amp-pan-zoom>` component triggers the `transformEnd` event whenever the pan or zoom animation is complete. This event will emit the parameters `scale`, `x`, and `y`. `scale` contains the current scale of the child content being zoomed. `x` and `y` respectively contain the `x` and `y` translation of the child content from center in pixels.

--- a/extensions/amp-pan-zoom/validator-amp-pan-zoom.protoascii
+++ b/extensions/amp-pan-zoom/validator-amp-pan-zoom.protoascii
@@ -46,6 +46,7 @@ tags: {  # <amp-pan-zoom>
   }
   attrs: {
     name: "reset-on-resize"
+    value: ""
   }
   attr_lists: "extended-amp-global"
    amp_layout: {

--- a/extensions/amp-pan-zoom/validator-amp-pan-zoom.protoascii
+++ b/extensions/amp-pan-zoom/validator-amp-pan-zoom.protoascii
@@ -44,6 +44,9 @@ tags: {  # <amp-pan-zoom>
     name: "max-scale"
     value_regex: "[0-9]+(\\.[0-9]+)?"
   }
+  attrs: {
+    name: "reset-on-resize"
+  }
   attr_lists: "extended-amp-global"
    amp_layout: {
     supported_layouts: FILL

--- a/test/manual/amp-pan-zoom-integration.amp.html
+++ b/test/manual/amp-pan-zoom-integration.amp.html
@@ -8,6 +8,11 @@
   <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
   <script async custom-element="amp-pan-zoom" src="https://cdn.ampproject.org/v0/amp-pan-zoom-0.1.js"></script>
   <script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script>
+  <script>
+    (self.AMP=self.AMP||[]).push(function(AMP){
+        AMP.toggleExperiment('amp-pan-zoom', true);
+    });
+  </script>
   <style amp-custom>
 
     .container {

--- a/test/manual/amp-pan-zoom.amp.html
+++ b/test/manual/amp-pan-zoom.amp.html
@@ -8,8 +8,12 @@
   <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
   <script async custom-element="amp-pan-zoom" src="https://cdn.ampproject.org/v0/amp-pan-zoom-0.1.js"></script>
   <script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script>
+  <script>
+    (self.AMP=self.AMP||[]).push(function(AMP){
+        AMP.toggleExperiment('amp-pan-zoom', true);
+    });
+  </script>
   <style amp-custom>
-
     .container {
       height: 600;
       width: 600;


### PR DESCRIPTION
Since this component can now be layout responsive as a component in the page instead of layout fill, it's possible that it will be resized without the intention to be reset. Changes the default behavior to not reset image dimensions on resize. Added some scripts to auto-toggle the experiment on for mobile testing. 