### PR TITLE
Run integration tests with coverage in non-compiled mode

### DIFF
--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -333,7 +333,10 @@ const command = {
       cmd += ' --compiled';
     }
     if (process.env.TRAVIS) {
-      timedExecOrDie(cmd + ' --coverage');
+      // TODO(rsimha, #16462): compiled + coverage is flaky
+      if (!compiled) {
+        timedExecOrDie(cmd + ' --coverage');
+      }
       startSauceConnect();
       timedExecOrDie(cmd + ' --saucelabs');
       stopSauceConnect();


### PR DESCRIPTION
Running with `--compiled` and `--coverage` is flaky on master: https://travis-ci.org/ampproject/amphtml/jobs/398431117#L659

In this PR, we switch to non-compiled mode while running coverage