### PR TITLE
🔥 Install core services before installing builtins

### DIFF
--- a/src/amp.js
+++ b/src/amp.js
@@ -81,12 +81,12 @@ startupChunk(self.document, function initial() {
       perf.coreServicesAvailable();
       maybeTrackImpression(self);
     });
+    startupChunk(self.document, function adoptWindow() {
+      adopt(self);
+    });
     startupChunk(self.document, function builtins() {
       // Builtins.
       installBuiltins(self);
-    });
-    startupChunk(self.document, function adoptWindow() {
-      adopt(self);
     });
     startupChunk(self.document, function stub() {
       // Pre-stub already known elements.


### PR DESCRIPTION
Fixes #15759.

The core issue is a race condition between the startup chunking, and the
`buildCallback` of any of the builtin elements. In certain
circumstances, the `buildCallback` can actually be called sync after
installing the custom element. Then, it's a race between the adoption
chunk and `whenBodyAvailable`. If `whenBodyAvailable` wins, we get the
error.

So, let's just install the needed `extensions` service before installing
any of the builtins.