### PR TITLE
Better debugging for amp-bind, amp-list

### DIFF
--- a/build-system/tasks/bundle-size.js
+++ b/build-system/tasks/bundle-size.js
@@ -22,7 +22,7 @@ const log = require('fancy-log');
 const {getStdout} = require('../exec');
 
 const runtimeFile = './dist/v0.js';
-const maxSize = '78.4KB';
+const maxSize = '78.46KB';
 
 const {green, red, cyan, yellow} = colors;
 

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -128,9 +128,6 @@ export class Bind {
     /** @private {!Array<BoundElementDef>} */
     this.boundElements_ = [];
 
-    /** @const @private {!Function} */
-    this.boundOnDomUpdate_ = this.onDomUpdate_.bind(this);
-
     /**
      * Maps expression string to the element(s) that contain it.
      * @private @const {!Object<string, !Array<!Element>>}
@@ -201,7 +198,7 @@ export class Bind {
     this.signals_ = new Signals();
 
     // Expose for debugging in the console.
-    AMP.printState = this.printState_.bind(this);
+    global.AMP.printState = this.printState_.bind(this);
   }
 
   /** @override */
@@ -226,18 +223,17 @@ export class Bind {
    * @return {!Promise}
    */
   setState(state, opt_skipEval, opt_isAmpStateMutation) {
-    // TODO(choumx): What if `state` contains references to globals?
     try {
       deepMerge(this.state_, state, MAX_MERGE_DEPTH);
     } catch (e) {
       user().error(TAG, 'Failed to merge result from AMP.setState().', e);
     }
 
+    dev().fine(TAG, 'state:', this.state_);
+
     if (opt_skipEval) {
       return Promise.resolve();
     }
-
-    user().fine(TAG, 'State updated; re-evaluating expressions...');
 
     const promise = this.initializePromise_
         .then(() => this.evaluate_())
@@ -308,6 +304,7 @@ export class Bind {
    * @return {!Promise}
    */
   setStateWithExpression(expression, scope) {
+    dev().fine(TAG, 'setState:', `"${expression}"`);
     this.setStatePromise_ = this.evaluateExpression_(expression, scope)
         .then(result => this.setState(result))
         .then(() => {
@@ -330,6 +327,7 @@ export class Bind {
    * @return {!Promise}
    */
   pushStateWithExpression(expression, scope) {
+    dev().fine(TAG, 'pushState:', expression);
     return this.evaluateExpression_(expression, scope).then(result => {
       // Store the current values of each referenced variable in `expression`
       // so that we can restore them on history-pop.
@@ -368,11 +366,11 @@ export class Bind {
    * @return {!Promise}
    */
   scanAndApply(added, removed, timeout = 2000) {
-    const promise = this.removeBindingsForNodes_(removed)
-        .then(() => this.addBindingsForNodes_(added))
-        .then(numberOfBindingsAdded => {
+    dev().fine(TAG, 'rescan:', added, removed);
+    const promise = this.removeThenAdd_(added, removed)
+        .then(bindingsAdded => {
           // Don't reevaluate/apply if there are no bindings.
-          if (numberOfBindingsAdded > 0) {
+          if (bindingsAdded > 0) {
             return this.evaluate_().then(results =>
               this.applyElements_(results, added));
           }
@@ -403,13 +401,14 @@ export class Bind {
    * @private
    */
   initialize_(root) {
-    dev().fine(TAG, 'Scanning DOM for bindings and macros...');
+    dev().fine(TAG, 'init');
     let promise = Promise.all([
       this.addMacros_(),
       this.addBindingsForNodes_([root])]
-    ).then(() => {
+    ).then(results => {
+      dev().fine(TAG, '⤷', 'Δ:', results);
       // Listen for DOM updates (e.g. template render) to rescan for bindings.
-      root.addEventListener(AmpEvents.DOM_UPDATE, this.boundOnDomUpdate_);
+      root.addEventListener(AmpEvents.DOM_UPDATE, e => this.onDomUpdate_(e));
     });
     if (getMode().development) {
       // Check default values against initial expression results.
@@ -525,7 +524,8 @@ export class Bind {
    * For each node in an array, scans it and its descendants for bindings.
    * This function is not idempotent.
    *
-   * Returns a promise that resolves after bindings have been added.
+   * Returns a promise that resolves with the number of bindings added upon
+   * completion.
    *
    * @param {!Array<!Node>} nodes
    * @return {!Promise<number>}
@@ -563,12 +563,9 @@ export class Bind {
       // `results` is a 2D array where results[i] is an array of bindings.
       // Flatten this into a 1D array of bindings via concat.
       const bindings = Array.prototype.concat.apply([], results);
-      dev().fine(TAG, `Scanned ${bindings.length} bindings from ` +
-          `${nodes.length} elements and their descendants.`);
       if (bindings.length == 0) {
         return bindings.length;
       } else {
-        dev().fine(TAG, 'Asking worker to parse expressions...');
         return this.ww_('bind.addBindings', [bindings]).then(parseErrors => {
           // Report each parse error.
           Object.keys(parseErrors).forEach(expressionString => {
@@ -579,8 +576,6 @@ export class Bind {
                   elements[0]);
             }
           });
-          dev().fine(TAG, 'Finished parsing expressions with ' +
-              `${Object.keys(parseErrors).length} errors.`);
           return bindings.length;
         });
       }
@@ -590,14 +585,14 @@ export class Bind {
   /**
    * For each node in an array, removes all bindings for it and its descendants.
    *
-   * Returns a promise that resolves after bindings have been removed.
+   * Returns a promise that resolves with the number of removed bindings upon
+   * completion.
    *
    * @param {!Array<!Node>} nodes
-   * @return {!Promise}
+   * @return {!Promise<number>}
    * @private
    */
   removeBindingsForNodes_(nodes) {
-    const before = (getMode().development) ? this.numberOfBindings() : 0;
     // Eliminate bound elements that are descendants of `nodes`.
     filterSplice(this.boundElements_, boundElement => {
       for (let i = 0; i < nodes.length; i++) {
@@ -607,11 +602,6 @@ export class Bind {
       }
       return true;
     });
-    const after = (getMode().development) ? this.numberOfBindings() : 0;
-    if (after < before) {
-      dev().fine(TAG, `Removed ${before - after} bindings from ${nodes.length} `
-          + 'elements and their descendants.');
-    }
     // Eliminate elements from the expression to elements map that
     // have node as an ancestor. Delete expressions that are no longer
     // bound to elements.
@@ -633,12 +623,12 @@ export class Bind {
     }
 
     // Remove the bindings from the evaluator.
-    if (deletedExpressions.length > 0) {
-      dev().fine(TAG, 'Asking worker to remove expressions...');
-      return this.ww_(
-          'bind.removeBindingsWithExpressionStrings', [deletedExpressions]);
+    const removed = deletedExpressions.length;
+    if (removed > 0) {
+      return this.ww_('bind.removeBindingsWithExpressionStrings',
+          [deletedExpressions]).then(() => removed);
     } else {
-      return Promise.resolve();
+      return Promise.resolve(0);
     }
   }
 
@@ -805,6 +795,7 @@ export class Bind {
         // Throw to reject promise.
         throw this.reportWorkerError_(error, `${TAG}: Expression eval failed.`);
       } else {
+        dev().fine(TAG, '⤷', result);
         return result;
       }
     });
@@ -816,7 +807,6 @@ export class Bind {
    * @private
    */
   evaluate_() {
-    user().fine(TAG, 'Asking worker to re-evaluate expressions...');
     const evaluatePromise = this.ww_('bind.evaluateBindings', [this.state_]);
     return evaluatePromise.then(returnValue => {
       const {results, errors} = returnValue;
@@ -832,6 +822,7 @@ export class Bind {
           reportError(userError, elements[0]);
         }
       });
+      dev().fine(TAG, 'bindings:', results);
       return results;
     });
   }
@@ -923,12 +914,8 @@ export class Bind {
       // Useful for rendering amp-list with amp-bind state via [src].
       if (newValue === undefined ||
           recursiveEquals(newValue, previousResult, /* depth */ 5)) {
-        user().fine(TAG, 'Expression result unchanged or missing: ' +
-            `"${expressionString}"`);
       } else {
         boundProperty.previousResult = newValue;
-        user().fine(TAG, 'New expression result: ' +
-            `"${expressionString}" -> ${newValue}`);
         updates.push({boundProperty, newValue});
       }
     });
@@ -952,7 +939,9 @@ export class Bind {
       }
       return this.applyBoundElement_(results, boundElement);
     });
-    return Promise.all(promises);
+    return Promise.all(promises).then(() => {
+      dev().fine(TAG, 'updated:', promises.length, 'elements');
+    });
   }
 
   /**
@@ -970,7 +959,9 @@ export class Bind {
         }
       });
     });
-    return Promise.all(promises);
+    return Promise.all(promises).then(() => {
+      dev().fine(TAG, 'updated:', promises.length, 'elements');
+    });
   }
 
   /**
@@ -1213,19 +1204,36 @@ export class Bind {
    */
   onDomUpdate_(event) {
     const target = dev().assertElement(event.target);
-
     // Skip amp-list since there's already a custom integration for it.
     const parent = target.parentNode;
     if (parent && parent.tagName == 'AMP-LIST') {
-      dev().info(TAG, 'Skipping DOM_UPDATE rescan of:', target);
       return;
     }
-
-    this.removeBindingsForNodes_([target]).then(() => {
-      return this.addBindingsForNodes_([target]);
-    }).then(() => {
+    dev().fine(TAG, 'dom_update:', target);
+    this.removeThenAdd_([target], [target]).then(() => {
       this.dispatchEventForTesting_(BindEvents.RESCAN_TEMPLATE);
     });
+  }
+
+  /**
+   * Removes bindings for nodes in `remove`, then scans for bindings in `add`.
+   * Return promise that resolves upon completion.
+   * @param {!Array<!Node>} remove
+   * @param {!Array<!Node>} add
+   * @return {!Promise}
+   * @private
+   */
+  removeThenAdd_(remove, add) {
+    let sum = 0;
+    return this.removeBindingsForNodes_(remove)
+        .then(removed => {
+          sum -= removed;
+          return this.addBindingsForNodes_(add);
+        })
+        .then(added => {
+          sum += added;
+          dev().fine(TAG, '⤷', 'Δ:', sum, ', ∑:', this.numberOfBindings());
+        });
   }
 
   /**
@@ -1294,21 +1302,16 @@ export class Bind {
 
   /**
    * Print out the current state in the console.
+   * @param {string=} opt_expression
    * @private
    */
-  printState_() {
-    const seen = [];
-    const s = JSON.stringify(this.state_, (key, value) => {
-      if (isObject(value)) {
-        if (seen.includes(value)) {
-          return '[Circular]';
-        } else {
-          seen.push(value);
-        }
-      }
-      return value;
-    });
-    user().info(TAG, s);
+  printState_(opt_expression) {
+    if (opt_expression) {
+      const value = getValueForExpr(this.state_, opt_expression);
+      user().info(TAG, value);
+    } else {
+      user().info(TAG, this.state_);
+    }
   }
 
   /**

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -197,8 +197,10 @@ export class Bind {
     /** @private @const {!../../../src/utils/signals.Signals} */
     this.signals_ = new Signals();
 
-    // Expose for debugging in the console.
-    global.AMP.printState = this.printState_.bind(this);
+    // AMP.printState() for debugging in the console.
+    if (!self.AMP.printState) {
+      self.AMP.printState = this.printState_.bind(this);
+    }
   }
 
   /** @override */
@@ -1307,6 +1309,11 @@ export class Bind {
    */
   printState_(opt_expression) {
     if (opt_expression) {
+      if (typeof opt_expression !== 'string') {
+        user().error(TAG, 'Invalid JSON expression. Example: ' +
+            'AMP.printState("foo.bar") to print current value of "foo.bar".');
+        return;
+      }
       const value = getValueForExpr(this.state_, opt_expression);
       user().info(TAG, value);
     } else {

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -131,9 +131,9 @@ export class AmpList extends AMP.BaseElement {
 
   /** @override */
   mutatedAttributesCallback(mutations) {
+    dev().fine(TAG, 'mutate:', mutations);
     const src = mutations['src'];
     const state = mutations['state'];
-
     if (src !== undefined) {
       const typeOfSrc = typeof src;
       if (typeOfSrc === 'string') {
@@ -250,9 +250,9 @@ export class AmpList extends AMP.BaseElement {
    * @private
    */
   scheduleRender_(items) {
+    dev().fine(TAG, 'schedule:', items);
     const deferred = new Deferred();
     const {promise, resolve: resolver, reject: rejecter} = deferred;
-
     // If there's nothing currently being rendered, schedule a render pass.
     if (!this.renderItems_) {
       this.renderPass_.schedule();
@@ -267,8 +267,9 @@ export class AmpList extends AMP.BaseElement {
    * @private
    */
   doRenderPass_() {
-    dev().assert(this.renderItems_, 'Nothing to render.');
     const current = this.renderItems_;
+    dev().assert(current, 'Nothing to render.');
+    dev().fine(TAG, 'pass:', current);
     const scheduleNextPass = () => {
       // If there's a new `renderItems_`, schedule it for render.
       if (this.renderItems_ !== current) {
@@ -334,6 +335,8 @@ export class AmpList extends AMP.BaseElement {
    * @private
    */
   rendered_(elements) {
+    dev().fine(TAG, 'render:', elements);
+
     removeChildren(dev().assertElement(this.container_));
     elements.forEach(element => {
       if (!element.hasAttribute('role')) {

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -224,7 +224,7 @@ function adoptShared(global, callback) {
   /**
    * @param {!./log.LogLevel} level
    */
-  global.AMP.setLogLevel = overrideLogLevel.bind(null, global);
+  global.AMP.setLogLevel = overrideLogLevel.bind(null);
 
   /**
    * Sets the function to forward tick events to.

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -18,6 +18,7 @@ import * as config from './config';
 import {BaseElement} from './base-element';
 import {BaseTemplate, registerExtendedTemplate} from './service/template-impl';
 import {CommonSignals} from './common-signals';
+import {LogLevel, overrideLogLevel} from './log'; // eslint-disable-line no-unused-vars
 import {Services} from './services';
 import {VisibilityState} from './visibility-state';
 import {childElementsByTag, isConnectedNode} from './dom';
@@ -69,7 +70,6 @@ import {
   isExperimentOn,
   toggleExperiment,
 } from './experiments';
-import {overrideLogLevel} from './log';
 import {parseUrlDeprecated} from './url';
 import {reportErrorForWin} from './error';
 import {setStyle} from './style';
@@ -222,7 +222,7 @@ function adoptShared(global, callback) {
   global.AMP.toggleExperiment = toggleExperiment.bind(null, global);
 
   /**
-   * @param {!./log.LogLevel} level
+   * @param {!LogLevel} level
    */
   global.AMP.setLogLevel = overrideLogLevel.bind(null);
 

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -69,6 +69,7 @@ import {
   isExperimentOn,
   toggleExperiment,
 } from './experiments';
+import {overrideLogLevel} from './log';
 import {parseUrlDeprecated} from './url';
 import {reportErrorForWin} from './error';
 import {setStyle} from './style';
@@ -212,12 +213,18 @@ function adoptShared(global, callback) {
    * @return {boolean}
    */
   global.AMP.isExperimentOn = isExperimentOn.bind(null, global);
+
   /**
    * @param {string} experimentId
    * @param {boolean=} opt_on
    * @return {boolean}
    */
   global.AMP.toggleExperiment = toggleExperiment.bind(null, global);
+
+  /**
+   * @param {!./log.LogLevel} level
+   */
+  global.AMP.setLogLevel = overrideLogLevel.bind(null, global);
 
   /**
    * Sets the function to forward tick events to.


### PR DESCRIPTION
- Add `AMP.setLogLevel(<number>)` for embedded cases where adding `#log=<number>` is not possible.
- Improve `AMP.printState()` and support passing JSON expressions, e.g. `AMP.printState(foo.bar)`.
- Add a bunch of fine-grained dev logging to amp-bind and amp-list.