### PR TITLE
📖Fix Typo: JSDoc typedef of ResourceSpecForHostDef

### DIFF
--- a/extensions/amp-analytics/0.1/resource-timing.js
+++ b/extensions/amp-analytics/0.1/resource-timing.js
@@ -43,7 +43,7 @@ let IndividualResourceSpecDef;
  * the hostPattern).
  * @typedef{{
  *   hostPattern: !RegExp,
- *   resouces: !Array<{
+ *   resources: !Array<{
  *     name: string,
  *     pathPattern: !RegExp,
  *     queryPattern: !RegExp,


### PR DESCRIPTION
Fixes typo in JSDoc of `ResourceSpecForHostDef`, where `resources` is mistyped as `resouces'`with a missing 'r'.
