### PR TITLE
🏗 Explicitly navigate to a blank page when running `gulp visual-diff --puppeteer --master`

### DIFF
--- a/build-system/tasks/visual-diff.js
+++ b/build-system/tasks/visual-diff.js
@@ -324,6 +324,7 @@ function applyAmpConfig(config) {
  */
 async function generateSnapshots(percy, page, webpages) {
   if (argv.master) {
+    await page.goto(`${BASE_URL}/examples/visual-tests/blank-page/blank.html`);
     await percy.snapshot('Blank page', page, SNAPSHOT_EMPTY_BUILD_OPTIONS);
   }
   cleanupAmpConfig();


### PR DESCRIPTION
Percy-Puppeteer can only perform a snapshot when the browser has a URL to give, which it did not when we run it with `--master` (it attempts to run a snapshot against an implicit blank page, i.e., when the browser hasn't navigated to any page yet.) This PR fixes this small bug.