### PR TITLE
🏗 Add a 100 ms delay before Percy-Puppeteer snapshots to let the page load settle

### DIFF
--- a/build-system/tasks/visual-diff.js
+++ b/build-system/tasks/visual-diff.js
@@ -43,7 +43,7 @@ const WEBSERVER_TIMEOUT_RETRIES = 10;
 const NAVIGATE_TIMEOUT_MS = 12000;
 const CONFIGS = ['canary', 'prod'];
 const CSS_SELECTOR_TIMEOUT_MS = 5000;
-const PAGE_REST_TIMEOUT_MS = 100;
+const PAGE_REST_TIMEOUT_MS = 100; // TODO(danielrozenberg): remove once our expectations regarding page.waitForSelector are met.
 const AMP_RUNTIME_TARGET_FILES = [
   'dist/amp.js', 'dist.3p/current/integration.js'];
 const BUILD_STATUS_URL = 'https://amphtml-percy-status-checker.appspot.com/status';

--- a/build-system/tasks/visual-diff.js
+++ b/build-system/tasks/visual-diff.js
@@ -43,6 +43,7 @@ const WEBSERVER_TIMEOUT_RETRIES = 10;
 const NAVIGATE_TIMEOUT_MS = 12000;
 const CONFIGS = ['canary', 'prod'];
 const CSS_SELECTOR_TIMEOUT_MS = 5000;
+const PAGE_REST_TIMEOUT_MS = 100;
 const AMP_RUNTIME_TARGET_FILES = [
   'dist/amp.js', 'dist.3p/current/integration.js'];
 const BUILD_STATUS_URL = 'https://amphtml-percy-status-checker.appspot.com/status';
@@ -363,6 +364,7 @@ async function snapshotWebpages(percy, page, webpages, config) {
 
     await verifyCssElements(page, url, webpage.forbidden_css,
         webpage.loading_incomplete_css, webpage.loading_complete_css);
+    await sleep(PAGE_REST_TIMEOUT_MS);
     await percy.snapshot(name, page, SNAPSHOT_OPTIONS);
     await clearExperiments(page);
   }

--- a/test/visual-diff/visual-tests
+++ b/test/visual-diff/visual-tests
@@ -144,7 +144,8 @@
     },
     {
       "url": "examples/visual-tests/video/rotate-to-fullscreen.html",
-      "name": "Video rotate-to-fullscreen"
+      "name": "Video rotate-to-fullscreen",
+      "loading_complete_css": ["video.i-amphtml-replaced-content"]
     },
     /**
       * AMP by Example pages go below this.


### PR DESCRIPTION
I tried a few values and it seems that 100 ms make all of the flakes disappear. I'm not super happy about having an explicit time delay, but it's not an unreasonable choice.

I still don't entirely understand why `percy.page.waitForSelector` doesn't wait until all the CSS selectors are visible/invisible, something to check with the Puppeteer team. Until then, this is a stopgap to make `--puppeteer` a working drop-in for the Capybara impl.