### PR TITLE
🚀 Turn on font display experiment in canary.

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -36,6 +36,7 @@
   "amp-story-v1": 1,
   "expAdsenseUnconditionedCanonical": 0.01,
   "expAdsenseCanonical": 0.01,
+  "font-display-swap": 1,
   "adsense-delay-request": 0.01,
   "doubleclick-delay-request":0.01,
   "amp-date-picker": 1


### PR DESCRIPTION
This previously caused an ad regression. After #14721 there is no longer a chance of this interrupting page load.