### PR TITLE
Turn on the no-sync-xhr-in-ads experiment in canary.

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -27,6 +27,7 @@
   "a4aFastFetchDoubleclickLaunched": 0,
   "a4aFastFetchAdSenseLaunched": 0,
   "3p-use-ampcontext": 1,
+  "no-sync-xhr-in-ads": 1,
   "amp-animation": 1,
   "amp-live-list-sorting": 1,
   "amp-sidebar toolbar": 1,


### PR DESCRIPTION
See #14481 for context.

Submission should wait a week after #16523 to avoid issues that might overlap.

