### PR TITLE
Clean up runtime code for launched exps

### DIFF
--- a/extensions/amp-live-list/0.1/amp-live-list.js
+++ b/extensions/amp-live-list/0.1/amp-live-list.js
@@ -216,9 +216,7 @@ export class AmpLiveList extends AMP.BaseElement {
     this.maxItemsPerPage_ = Math.max(getNumberMaxOrDefault(maxItems, 1),
         actualCount);
 
-    if (isExperimentOn(this.win, 'amp-live-list-sorting')) {
-      this.isReverseOrder_ = this.element.getAttribute('sort') === 'ascending';
-    }
+    this.isReverseOrder_ = this.element.getAttribute('sort') === 'ascending';
 
     this.manager_.register(this.liveListId_, this);
 

--- a/extensions/amp-live-list/0.1/test/test-amp-live-list.js
+++ b/extensions/amp-live-list/0.1/test/test-amp-live-list.js
@@ -1233,7 +1233,6 @@ describes.realWin('amp-live-list', {
       itemsSlot.appendChild(child1);
       itemsSlot.appendChild(child2);
       buildElement(elem, Object.assign({}, dftAttrs, {'sort': 'ascending'}));
-      toggleExperiment(liveList.win, 'amp-live-list-sorting', true);
       liveList.buildCallback();
       expect(liveList.itemsSlot_.childElementCount).to.equal(2);
       expect(elem.querySelector('[update]')).to.have.class('amp-hidden');
@@ -1285,7 +1284,6 @@ describes.realWin('amp-live-list', {
       buildElement(elem, Object.assign({}, dftAttrs,
           {'data-max-items-per-page': 2, 'sort': 'ascending'}));
       sandbox.stub(liveList, 'isElementAboveViewport_').returns(true);
-      toggleExperiment(liveList.win, 'amp-live-list-sorting', true);
       liveList.buildCallback();
       const removeChildSpy = sandbox.spy(liveList.itemsSlot_, 'removeChild');
 
@@ -1335,7 +1333,6 @@ describes.realWin('amp-live-list', {
       pred.onCall(0).returns(true);
       // Anything else
       pred.returns(false);
-      toggleExperiment(liveList.win, 'amp-live-list-sorting', true);
       liveList.buildCallback();
       const removeChildSpy = sandbox.spy(liveList.itemsSlot_, 'removeChild');
 

--- a/extensions/amp-live-list/0.1/test/test-amp-live-list.js
+++ b/extensions/amp-live-list/0.1/test/test-amp-live-list.js
@@ -19,7 +19,6 @@ import {AmpDocSingle} from '../../../../src/service/ampdoc-impl';
 import {AmpEvents} from '../../../../src/amp-events';
 import {AmpLiveList, getNumberMaxOrDefault} from '../amp-live-list';
 import {LiveListManager} from '../live-list-manager';
-import {toggleExperiment} from '../../../../src/experiments';
 
 
 describes.realWin('amp-live-list', {

--- a/extensions/amp-playbuzz/0.1/amp-playbuzz.js
+++ b/extensions/amp-playbuzz/0.1/amp-playbuzz.js
@@ -49,12 +49,9 @@ import {
   removeFragment,
 } from '../../../src/url';
 import {dict} from '../../../src/utils/object';
-import {isExperimentOn} from '../../../src/experiments';
 import {logo, showMoreArrow} from './images';
 import {removeElement} from '../../../src/dom';
 import {user} from '../../../src/log';
-/** @const */
-const EXPERIMENT = 'amp-playbuzz';
 
 class AmpPlaybuzz extends AMP.BaseElement {
 
@@ -103,11 +100,6 @@ class AmpPlaybuzz extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
-    // EXPERIMENT
-    // AMP.toggleExperiment(EXPERIMENT, true); //for dev
-    user().assert(isExperimentOn(this.win, EXPERIMENT),
-        `Enable ${EXPERIMENT} experiment`);
-
     const e = this.element;
     const src = e.getAttribute('src');
     const itemId = e.getAttribute('data-item');

--- a/extensions/amp-playbuzz/0.1/test/test-amp-playbuzz.js
+++ b/extensions/amp-playbuzz/0.1/test/test-amp-playbuzz.js
@@ -15,7 +15,6 @@
  */
 
 import '../amp-playbuzz';
-import {toggleExperiment} from '../../../../src/experiments';
 
 
 function startsWith(string, searchString) {
@@ -32,7 +31,6 @@ describes.realWin('amp-playbuzz', {
   beforeEach(() => {
     win = env.win;
     doc = win.document;
-    toggleExperiment(win, 'amp-playbuzz', true);
   });
 
   function createOptionalParams(displayInfo, displayShareBar, displayComments) {

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -843,18 +843,11 @@ export class MultidocManager {
  * If they are different, returns false, and initiates a load
  * of the respective extension via a versioned URL.
  *
- * This is currently guarded by the 'version-locking' experiment.
- * With this active, all scripts in a given page are guaranteed
- * to have the same AMP release version.
- *
  * @param {!Window} win
  * @param {function(!Object)|ExtensionPayload} fnOrStruct
  * @return {boolean}
  */
 function maybeLoadCorrectVersion(win, fnOrStruct) {
-  if (!isExperimentOn(win, 'version-locking')) {
-    return false;
-  }
   if (typeof fnOrStruct == 'function') {
     return false;
   }
@@ -888,10 +881,6 @@ function maybeLoadCorrectVersion(win, fnOrStruct) {
  *     pumped.
  */
 function maybePumpEarlyFrame(win, cb) {
-  if (!isExperimentOn(win, 'pump-early-frame')) {
-    cb();
-    return;
-  }
   // There is definitely nothing to draw yet, so we might as well
   // proceed.
   if (!win.document.body) {

--- a/test/functional/test-runtime.js
+++ b/test/functional/test-runtime.js
@@ -37,7 +37,6 @@ import {installDocumentStateService} from '../../src/service/document-state';
 import {installPlatformService} from '../../src/service/platform-impl';
 import {installTimerService} from '../../src/service/timer-impl';
 import {runChunksForTesting} from '../../src/chunk';
-import {toggleExperiment} from '../../src/experiments';
 import {vsyncForTesting} from '../../src/service/vsync-impl';
 
 

--- a/test/functional/test-runtime.js
+++ b/test/functional/test-runtime.js
@@ -189,7 +189,6 @@ describes.fakeWin('runtime', {
       extensionRegistrationTest);
 
   it('should not maybePumpEarlyFrame when body not yet present', () => {
-    toggleExperiment(win, 'pump-early-frame', true);
     // Make document.body be null on first invocation to simulate
     // JS executing before the rest of the doc has been parsed.
     const {body} = win.document;
@@ -208,14 +207,12 @@ describes.fakeWin('runtime', {
 
   it('should not maybePumpEarlyFrame ' +
       'when a renderDelayingExtension is present', () => {
-    toggleExperiment(win, 'pump-early-frame', true);
     win.document.body.appendChild(
         document.createElement('amp-experiment'));
     extensionRegistrationTest();
   });
 
   it('should maybePumpEarlyFrame and delay extension execution', () => {
-    toggleExperiment(win, 'pump-early-frame', true);
     let progress = '';
     const queueExtensions = win.AMP;
     const highPriority = regularExtension(amp => {
@@ -393,7 +390,6 @@ describes.fakeWin('runtime', {
     self.AMP_MODE = {
       rtvVersion: 'test-version',
     };
-    toggleExperiment(win, 'version-locking', true);
     function addExisting(index) {
       const s = document.createElement('script');
       s.setAttribute('custom-element', 'amp-test-element' + index);

--- a/tools/experiments/experiments.js
+++ b/tools/experiments/experiments.js
@@ -89,12 +89,6 @@ const EXPERIMENTS = [
     cleanupIssue: 'https://github.com/ampproject/amphtml/issues/4226',
   },
   {
-    id: 'amp-auto-ads',
-    name: 'AMP Auto Ads',
-    spec: 'https://github.com/ampproject/amphtml/issues/6196',
-    cleanupIssue: 'https://github.com/ampproject/amphtml/issues/6217',
-  },
-  {
     id: 'amp-auto-ads-adsense-holdout',
     name: 'AMP Auto Ads AdSense Holdout',
     spec: 'https://github.com/ampproject/amphtml/issues/6196',
@@ -108,85 +102,14 @@ const EXPERIMENTS = [
     cleanupIssue: 'https://github.com/ampproject/amphtml/issues/3996',
   },
   {
-    id: 'no-auth-in-prerender',
-    name: 'Delay amp-access auth request until doc becomes visible.',
-    spec: '',
-    cleanupIssue: 'https://github.com/ampproject/amphtml/issues/3824',
-  },
-  {
-    id: 'amp-share-tracking',
-    name: 'AMP Share Tracking',
-    spec: 'https://github.com/ampproject/amphtml/issues/3135',
-    cleanupIssue: 'https://github.com/ampproject/amphtml/issues/5167',
-  },
-  {
-    id: 'amp-viz-vega',
-    name: 'AMP Visualization using Vega grammar',
-    spec: 'https://github.com/ampproject/amphtml/issues/3991',
-    cleanupIssue: 'https://github.com/ampproject/amphtml/issues/4171',
-  },
-  {
-    id: 'amp-apester-media',
-    name: 'AMP extension for Apester media (launched)',
-    spec: 'https://github.com/ampproject/amphtml/issues/3233',
-    cleanupIssue: 'https://github.com/ampproject/amphtml/pull/4291',
-  },
-  {
-    id: 'cache-service-worker',
-    name: 'AMP Cache Service Worker',
-    spec: 'https://github.com/ampproject/amphtml/issues/1199',
-  },
-  {
     id: 'amp-lightbox-a4a-proto',
     name: 'Allows the new lightbox experience to be used in A4A (prototype).',
     spec: 'https://github.com/ampproject/amphtml/issues/7743',
   },
   {
-    id: 'amp-playbuzz',
-    name: 'AMP extension for playbuzz items (launched)',
-    spec: 'https://github.com/ampproject/amphtml/issues/6106',
-    cleanupIssue: 'https://github.com/ampproject/amphtml/pull/6351',
-  },
-  {
-    id: 'ios-embed-wrapper',
-    name: 'A new iOS embedded viewport model that wraps the body into' +
-        ' a synthetic root (launched)',
-    spec: '',
-    cleanupIssue: 'https://github.com/ampproject/amphtml/issues/5639',
-  },
-  {
-    id: 'chunked-amp',
-    name: 'Split AMP\'s loading phase into chunks',
-    cleanupIssue: 'https://github.com/ampproject/amphtml/issues/5535',
-  },
-  {
     id: 'font-display-swap',
     name: 'Use font-display: swap as the default for fonts.',
     cleanupIssue: 'https://github.com/ampproject/amphtml/issues/11165',
-  },
-  {
-    id: 'amp-animation',
-    name: 'High-performing keyframe animations in AMP (launched).',
-    spec: 'https://github.com/ampproject/amphtml/blob/master/extensions/' +
-        'amp-animation/amp-animation.md',
-    cleanupIssue: 'https://github.com/ampproject/amphtml/issues/5888',
-  },
-  {
-    id: 'pump-early-frame',
-    name: 'Force all extensions to have the same release ' +
-        'as the main JS binary',
-    cleanupIssue: 'https://github.com/ampproject/amphtml/issues/8237',
-  },
-  {
-    id: 'version-locking',
-    name: 'Force all extensions to have the same release ' +
-        'as the main JS binary',
-    cleanupIssue: 'https://github.com/ampproject/amphtml/issues/8236',
-  },
-  {
-    id: 'web-worker',
-    name: 'Web worker for background processing',
-    cleanupIssue: 'https://github.com/ampproject/amphtml/issues/7156',
   },
   {
     id: 'jank-meter',
@@ -197,31 +120,14 @@ const EXPERIMENTS = [
     name: 'Use slot width/height attribute for AdSense size format',
   },
   {
-    id: 'input-debounced',
-    name: 'A debounced input event for AMP actions',
-    cleanupIssue: 'https://github.com/ampproject/amphtml/issues/9413',
-    spec: 'https://github.com/ampproject/amphtml/issues/9277',
-  },
-  {
     id: 'user-error-reporting',
     name: 'Report error to publishers',
     spec: 'https://github.com/ampproject/amphtml/issues/6415',
   },
   {
-    id: 'disable-rtc',
-    name: 'Disable AMP RTC',
-    spec: 'https://github.com/ampproject/amphtml/issues/8551',
-  },
-  {
     id: 'inabox-position-api',
     name: 'Position API for foreign iframe',
     spec: 'https://github.com/ampproject/amphtml/issues/10995',
-  },
-  {
-    id: 'amp-story',
-    name: 'Visual storytelling in AMP (v0.1)',
-    spec: 'https://github.com/ampproject/amphtml/issues/11329',
-    cleanupIssue: 'https://github.com/ampproject/amphtml/issues/14357',
   },
   {
     id: 'amp-story-scaling',
@@ -263,14 +169,8 @@ const EXPERIMENTS = [
     name: 'Extensions layout independent of viewport location if inabox.',
   },
   {
-    id: 'amp-live-list-sorting',
-    name: 'Allows "newest last" insertion algorithm to be used',
-    spec: 'https://github.com/ampproject/amphtml/issues/5396',
-    cleanupIssue: 'https://github.com/ampproject/amphtml/issues/13552',
-  },
-  {
     id: 'amp-consent',
-    name: 'Enables the amp-consent extension',
+    name: 'Enables the amp-consent extension (launched)',
     spec: 'https://github.com/ampproject/amphtml/issues/13716',
   },
   {

--- a/tools/experiments/experiments.js
+++ b/tools/experiments/experiments.js
@@ -102,6 +102,12 @@ const EXPERIMENTS = [
     cleanupIssue: 'https://github.com/ampproject/amphtml/issues/3996',
   },
   {
+    id: 'amp-viz-vega',
+    name: 'AMP Visualization using Vega grammar',
+    spec: 'https://github.com/ampproject/amphtml/issues/3991',
+    cleanupIssue: 'https://github.com/ampproject/amphtml/issues/4171',
+  },
+  {
     id: 'amp-lightbox-a4a-proto',
     name: 'Allows the new lightbox experience to be used in A4A (prototype).',
     spec: 'https://github.com/ampproject/amphtml/issues/7743',
@@ -167,11 +173,6 @@ const EXPERIMENTS = [
   {
     id: 'inabox-rov',
     name: 'Extensions layout independent of viewport location if inabox.',
-  },
-  {
-    id: 'amp-consent',
-    name: 'Enables the amp-consent extension (launched)',
-    spec: 'https://github.com/ampproject/amphtml/issues/13716',
   },
   {
     id: 'no-sync-xhr-in-ads',


### PR DESCRIPTION
Remove runtime checks for launched experiments:
- amp-live-list-sorting
- amp-playbuzz
- version-locking
- pump-early-frame

Remove experiments.js config for a bunch of launched experiments.