### PR TITLE
🏗 Switch default `gulp visual-diff` mode to Puppeteer

### DIFF
--- a/build-system/tasks/visual-diff.js
+++ b/build-system/tasks/visual-diff.js
@@ -499,6 +499,9 @@ async function createEmptyBuild(page) {
 
 /**
  * Simple wrapper around the JS (Percy-Puppeteer) based visual diff tests.
+ *
+ * This is the current default mode, which is actively deprecating the Ruby
+ * (Capybara) implementation.
  */
 async function visualDiffPuppeteer() {
   if (argv.verify) {
@@ -541,8 +544,7 @@ async function visualDiffPuppeteer() {
 /**
  * Simple wrapper around the ruby (Percy-Capybara) based visual diff tests.
  *
- * This is the current default mode, which is actively being replaced with a
- * pure JS implementation.
+ * This mode is being actively deprecated and will be removed soon.
  */
 function visualDiffCapybara() {
   let cmd = 'ruby build-system/tasks/visual-diff.rb';
@@ -560,7 +562,7 @@ function visualDiffCapybara() {
 async function visualDiff() {
   setPercyBranch();
 
-  if (argv.puppeteer) {
+  if (!argv.capybara) {
     await visualDiffPuppeteer();
   } else {
     visualDiffCapybara();
@@ -581,7 +583,7 @@ gulp.task(
         'chrome_debug': '  Prints debug info from Chrome',
         'webserver_debug': '  Prints debug info from the local gulp webserver',
         'debug': '  Prints all the above debug info',
-        'puppeteer': '  [EXPERIMENTAL] Use Percy-Puppeteer (work in progress)',
+        'capybara': '  [DEPRECATED] Use Capybara (Ruby) instead of Puppeteer',
       },
     }
 );


### PR DESCRIPTION
Tested with my separate Percy project:
* Baseline before making the change: https://percy.io/ampproject/danielrozenberg/builds/836021
* After making the switch, running with `--capybara` to ensure that it behaves the same way as the baseline: https://percy.io/ampproject/danielrozenberg/builds/836050
* Running _without_ `--capybara` (meaning it now uses to Puppeteer) for the first time after the Capybara baseline: https://percy.io/ampproject/danielrozenberg/builds/836063 (note that there are some changes, but they are all expected and better than the baseline)
* Running again to ensure there are no flakes: https://percy.io/ampproject/danielrozenberg/builds/836086
* And once more for good measure: https://percy.io/ampproject/danielrozenberg/builds/836099