### PR TITLE
Enable 'inline-styles' in canary/prod

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -39,5 +39,6 @@
   "font-display-swap": 1,
   "adsense-delay-request": 0.01,
   "doubleclick-delay-request":0.01,
-  "amp-date-picker": 1
+  "amp-date-picker": 1,
+  "inline-styles": 1
 }

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -40,5 +40,6 @@
   "adsense-delay-request": 0.01,
   "doubleclick-delay-request":0.01,
   "amp-date-picker": 1,
-  "url-replacement-v2": 0.1
+  "url-replacement-v2": 0.1,
+  "inline-styles": 1
 }


### PR DESCRIPTION
Turns on support in runtime e.g. amp-mustache. ~Valid AMP pages won't be able to use this until validator changes roll out~ Inline styles are now valid AMP.

/to @jridgewell 