### PR TITLE
✨ Experimental loader for intermediate bundles.

### DIFF
--- a/build-system/amp.extern.js
+++ b/build-system/amp.extern.js
@@ -41,6 +41,7 @@ Element.prototype.dataset;
  *   as early as possible. Currently this is primarily used
  *   for viewer communication setup.
  * - v is the release version
+ * - i Array of bundles to load before executing this extension.
  * @constructor @struct
  */
 function ExtensionPayload() {}
@@ -56,6 +57,9 @@ ExtensionPayload.prototype.p;
 
 /** @type {string} */
 ExtensionPayload.prototype.v;
+
+/** @type {!Array<string>|undefined} */
+ExtensionPayload.prototype.i;
 
 
 /**

--- a/src/intermediate-bundle-loader.js
+++ b/src/intermediate-bundle-loader.js
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {calculateExtensionScriptUrl} from './service/extension-location';
+import {getMode} from './mode';
+
+/**
+ * Promise for whether a bundle with given ID and it's dependencies
+ * (previous bundles invoked together) have been loaded.
+ * !Object<string, !Promise>
+ */
+const loadState = Object.create(null);
+
+/**
+ * Script load the intermediate bundles needed for an extension.
+ * Relies on runtime.js for the execution of the script. Returns a promise
+ * for runtime.js to use for delaying execution of an extension until
+ * these dependencies have been fulfilled.
+ * @param {!Window} win
+ * @param {!Array<string>} bundles Array of bundle ids to be loaded. Returned
+ *     promise resolves when all of these have been loaded.
+ * @param {!Promise=} opt_parentPromise Only for use in internal recursion.
+ * @return {!Promise}
+ */
+export function loadIntermediateBundles(win, bundles, opt_parentPromise) {
+  const bundleId = bundles.shift();
+  if (!loadState[bundleId]) {
+    const loadedScript = new Promise(resolve => {
+      const scriptUrl = calculateExtensionScriptUrl(win.location, bundleId,
+          undefined, getMode().localDev);
+      const s = win.document.createElement('script');
+      s.src = scriptUrl;
+      win.document.head.appendChild(s);
+      s.setAttribute('data-script', bundleId);
+      s.setAttribute('i-amphtml-inserted', 'intermediate');
+      s.onload = resolve;
+    });
+    let loadedAll = loadedScript;
+    if (opt_parentPromise) {
+      loadedAll = opt_parentPromise.then(() => {
+        return loadedScript;
+      });
+    }
+    loadState[bundleId] = loadedAll;
+  }
+  if (bundles.length > 0) {
+    return loadIntermediateBundles(win, bundles, loadState[bundleId]);
+  }
+  return loadState[bundleId];
+}

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -69,6 +69,7 @@ import {
   isExperimentOn,
   toggleExperiment,
 } from './experiments';
+import {loadIntermediateBundles} from './intermediate-bundle-loader';
 import {parseUrlDeprecated} from './url';
 import {reportErrorForWin} from './error';
 import {setStyle} from './style';
@@ -235,8 +236,13 @@ function adoptShared(global, callback) {
    * @param {function(!Object)|ExtensionPayload} fnOrStruct
    */
   function installExtension(fnOrStruct) {
+    let delayExecution = iniPromise;
+    if (fnOrStruct.i) {
+      delayExecution = Promise.all(
+          [iniPromise, loadIntermediateBundles(global, fnOrStruct.i)]);
+    }
     const register = () => {
-      iniPromise.then(() => {
+      delayExecution.then(() => {
         if (typeof fnOrStruct == 'function') {
           fnOrStruct(global.AMP);
         } else {


### PR DESCRIPTION
A better name for bundle may be chunk, but we already use chunk for something else in the project.

This expects that the build-system declares an array of required intermediate bundles for a given extension or intermediate bundle via the `i` key in the extension code payload (See `ExtensionPayload`).

The new file is closely coupled to `runtime.js` actually running the code. It may be better to inline the new function.