### PR TITLE
🏗 Changes to `gulp visual-diff` to lower flaky visual tests

### DIFF
--- a/build-system/tasks/visual-diff.js
+++ b/build-system/tasks/visual-diff.js
@@ -40,10 +40,12 @@ const HOST = 'localhost';
 const PORT = 8000;
 const BASE_URL = `http://${HOST}:${PORT}`;
 const WEBSERVER_TIMEOUT_RETRIES = 10;
-const NAVIGATE_TIMEOUT_MS = 12000;
+const NAVIGATE_TIMEOUT_MS = 3000;
 const CONFIGS = ['canary', 'prod'];
-const CSS_SELECTOR_TIMEOUT_MS = 5000;
-const PAGE_REST_TIMEOUT_MS = 100; // TODO(danielrozenberg): remove once our expectations regarding page.waitForSelector are met.
+const CSS_SELECTOR_RETRY_MS = 100;
+const CSS_SELECTOR_RETRY_ATTEMPTS = 50;
+const CSS_SELECTOR_TIMEOUT_MS =
+    CSS_SELECTOR_RETRY_MS * CSS_SELECTOR_RETRY_ATTEMPTS;
 const AMP_RUNTIME_TARGET_FILES = [
   'dist/amp.js', 'dist.3p/current/integration.js'];
 const BUILD_STATUS_URL = 'https://amphtml-percy-status-checker.appspot.com/status';
@@ -251,7 +253,7 @@ async function launchBrowser() {
     height: VIEWPORT_HEIGHT,
   });
   page.setDefaultNavigationTimeout(NAVIGATE_TIMEOUT_MS);
-  page.setJavaScriptEnabled(true);
+  await page.setJavaScriptEnabled(true);
 
   return page;
 }
@@ -349,7 +351,7 @@ async function generateSnapshots(percy, page, webpages) {
  * @param {!puppeteer.Page} page a Puppeteer control browser tab/page.
  * @param {!JsonObject} webpages a JSON objects containing details about the
  *     pages to snapshot.
- * @param {*} config Config being used. One of 'canary' or 'prod'.
+ * @param {string} config Config being used. One of 'canary' or 'prod'.
  */
 async function snapshotWebpages(percy, page, webpages, config) {
   webpages = webpages.filter(webpage => (!webpage.flaky &&
@@ -362,9 +364,13 @@ async function snapshotWebpages(percy, page, webpages, config) {
     log('verbose', 'Navigating to page', colors.yellow(`${BASE_URL}/${url}`));
     await page.goto(`${BASE_URL}/${url}`);
 
+    // Try to wait until there are no more network requests. This method is
+    // flaky since Puppeteer doesn't always understand Chrome's network
+    // activity, so ignore timeouts.
+    await page.waitForNavigation({waitUntil: 'networkidle0'}).catch(() => {});
+
     await verifyCssElements(page, url, webpage.forbidden_css,
         webpage.loading_incomplete_css, webpage.loading_complete_css);
-    await sleep(PAGE_REST_TIMEOUT_MS);
     await percy.snapshot(name, page, SNAPSHOT_OPTIONS);
     await clearExperiments(page);
   }
@@ -384,56 +390,142 @@ async function snapshotWebpages(percy, page, webpages, config) {
  */
 async function verifyCssElements(page, url, forbiddenCss, loadingIncompleteCss,
   loadingCompleteCss) {
-  // Wait for loader dot to be hidden.
-  await page.waitForSelector('.i-amphtml-loader-dot', {
-    hidden: true,
-    timeout: CSS_SELECTOR_TIMEOUT_MS,
-  }).catch(() => {
-    log('fatal', colors.cyan(url),
-        `still has the AMP loader dot after ${CSS_SELECTOR_TIMEOUT_MS} ms`);
-  });
+  // Begin by waiting for all loader dots to disappear.
+  await waitForLoaderDot(page, url);
 
   if (forbiddenCss) {
     for (const css of forbiddenCss) {
       if (await page.$(css) !== null) {
-        log('fatal', colors.cyan(url), 'has forbidden CSS element',
-            colors.cyan(css));
+        log('fatal', colors.cyan(url), '| The forbidden CSS element',
+            colors.cyan(css), 'exists in the page');
       }
     }
   }
 
   if (loadingIncompleteCss) {
+    log('verbose', 'Waiting for invisibility of all:',
+        colors.cyan(loadingIncompleteCss.join(', ')));
     for (const css of loadingIncompleteCss) {
-      log('verbose', `Waiting for invisibility of ${css}`);
-      await page.waitForSelector(css, {
-        hidden: true,
-        timeout: CSS_SELECTOR_TIMEOUT_MS,
-      }).catch(() => {
-        log('fatal', colors.cyan(url), 'still has CSS element',
-            colors.cyan(css), `after ${CSS_SELECTOR_TIMEOUT_MS} ms`);
-      });
+      if (!(await waitForElementVisibility(page, css, {hidden: true}))) {
+        log('fatal', colors.cyan(url), '| An element with the CSS selector',
+            colors.cyan(css),
+            `is still visible after ${CSS_SELECTOR_RETRY_MS} ms`);
+      }
     }
   }
 
   if (loadingCompleteCss) {
+    log('verbose', 'Waiting for existence of all:',
+        colors.cyan(loadingCompleteCss.join(', ')));
     for (const css of loadingCompleteCss) {
-      log('verbose', 'Waiting for visibility of', css);
-      await page.waitForSelector(css, {
-        visible: true,
-        timeout: CSS_SELECTOR_TIMEOUT_MS,
-      }).catch(() => {
-        log('fatal', colors.cyan(url), 'does not yet have CSS element',
-            colors.cyan(css), `after ${CSS_SELECTOR_TIMEOUT_MS} ms`);
-      });
+      if (await !waitForSelectorExistence(page, css)) {
+        log('fatal', colors.cyan(url), '| The CSS selector', colors.cyan(css),
+            'does not match any elements in the page');
+      }
+    }
+
+    log('verbose', 'Waiting for visibility of all:',
+        colors.cyan(loadingCompleteCss.join(', ')));
+    for (const css of loadingCompleteCss) {
+      if (!(await waitForElementVisibility(page, css, {visible: true}))) {
+        log('fatal', colors.cyan(url), '| An element with the CSS selector',
+            colors.cyan(css),
+            `is still invisible after ${CSS_SELECTOR_RETRY_MS} ms`);
+      }
     }
   }
+
+  // Again, wait for all loader dots to disappear. Sometimes components are
+  // still loading images, videos, etc.
+  await waitForLoaderDot(page);
+}
+
+/**
+ * Wait for all AMP loader dot to disappear.
+ *
+ * @param {!puppeteer.Page} page page to wait on.
+ * @param {string} url URL being snapshotted.
+ */
+async function waitForLoaderDot(page, url) {
+  // Wait for loader dot to be hidden.
+  await waitForElementVisibility(
+      page, '.i-amphtml-loader-dot', {hidden: true}).catch(() => {
+    log('fatal', colors.cyan(url),
+        `still has the AMP loader dot after ${CSS_SELECTOR_TIMEOUT_MS} ms`);
+  });
+}
+
+/**
+ * Wait until the element is either hidden or visible or until timed out.
+ *
+ * @param {!puppeteer.Page} page page to check the visibility of elements in.
+ * @param {string} selector CSS selector for elements to wait on.
+ * @param {!Object} options with key 'visible' OR 'hidden' set to true.
+ * @return {boolean} true if the expectation is met before the timeout.
+ */
+async function waitForElementVisibility(page, selector, options) {
+  const waitForVisible = Boolean(options['visible']);
+  const waitForHidden = Boolean(options['hidden']);
+  if (waitForVisible == waitForHidden) {
+    log('fatal', 'waitForElementVisibility must be called with exactly one of',
+        "'visible' or 'hidden' set to true.");
+  }
+
+  let attempt = 0;
+  do {
+    const elementsAreVisible = [];
+
+    for (const elementHandle of await page.$$(selector)) {
+      const boundingBox = await elementHandle.boundingBox();
+      const elementIsVisible = boundingBox != null && boundingBox.height > 0 &&
+          boundingBox.width > 0;
+      elementsAreVisible.push(elementIsVisible);
+    }
+
+    log('verbose', 'Found', colors.cyan(elementsAreVisible.length),
+        'element(s) matching the CSS selector', colors.cyan(selector));
+    if (elementsAreVisible.length) {
+      log('verbose', 'Expecting all element visibilities to be',
+          colors.cyan(waitForVisible), '; they are',
+          colors.cyan(elementsAreVisible));
+    }
+    // Since we assert that waitForVisible == !waitForHidden, there is no need
+    // to check equality to both waitForVisible and waitForHidden.
+    if (elementsAreVisible.every(
+        elementIsVisible => elementIsVisible == waitForVisible)) {
+      return true;
+    }
+
+    await sleep(CSS_SELECTOR_RETRY_MS);
+    attempt++;
+  } while (attempt < CSS_SELECTOR_RETRY_ATTEMPTS);
+  return false;
+}
+
+/**
+ * Wait until the CSS selector exists in the page or until timed out.
+ *
+ * @param {!puppeteer.Page} page page to check the existence of the selector in.
+ * @param {string} selector CSS selector.
+ * @return {boolean} true if the element exists before the timeout.
+ */
+async function waitForSelectorExistence(page, selector) {
+  let attempt = 0;
+  do {
+    if (await page.$(selector)) {
+      return true;
+    }
+    await sleep(CSS_SELECTOR_RETRY_MS);
+    attempt++;
+  } while (attempt < CSS_SELECTOR_RETRY_ATTEMPTS);
+  return false;
 }
 
 /**
  * Enables the given AMP experiments.
  *
  * @param {!puppeteer.Page} page a Puppeteer control browser tab/page.
- * @param {*} experiments List of experiments to enable.
+ * @param {!Array<string>} experiments List of experiments to enable.
  */
 async function enableExperiments(page, experiments) {
   if (experiments) {

--- a/build-system/tasks/visual-diff.js
+++ b/build-system/tasks/visual-diff.js
@@ -434,10 +434,6 @@ async function verifyCssElements(page, url, forbiddenCss, loadingIncompleteCss,
       }
     }
   }
-
-  // Again, wait for all loader dots to disappear. Sometimes components are
-  // still loading images, videos, etc.
-  await waitForLoaderDot(page);
 }
 
 /**

--- a/test/visual-diff/visual-tests
+++ b/test/visual-diff/visual-tests
@@ -42,20 +42,22 @@
    *   // Name used to identify snapshots of webpage on Percy.
    *   "name": "Foo test",
    *
-   *   // [optional] CSS elements that must never appear on the webpage.
+   *   // [optional] CSS selectors for elements that must never appear on the
+   *   // webpage.
    *   "forbidden_css": [
    *     ".invalid-css-class",
    *     ".another-invalid-css-class"
    *   ],
    *
-   *   // [optional] CSS elements that may initially appear on the page, but must
-   *   // eventually disappear.
+   *   // [optional] CSS selectors for elements that may initially appear on the
+   *   // page, but must eventually be removed from it or become invisible.
    *   "loading_incomplete_css": [
    *     ".loading-in-progress-css-class",
    *     ".another-loading-in-progress-css-class"
    *   ],
    *
-   *   // [optional] CSS elements that must eventually appear on the page.
+   *   // [optional] CSS selectors for elements that must eventually exist on
+   *   // the page and be visible.
    *   "loading_complete_css": [
    *     ".loading-complete-css-class",
    *     ".another-loading-complete-css-class"
@@ -76,12 +78,8 @@
     {
       "url": "examples/visual-tests/article-access.amp/article-access.amp.html",
       "name": "AMP Article Access",
-      "loading_complete_css": [
-        ".login-section"
-      ],
-      "loading_incomplete_css": [
-        ".article-body"
-      ]
+      "loading_incomplete_css": [".article-body"],
+      "loading_complete_css": [".login-section"]
     },
     {
       "url": "examples/visual-tests/font.amp/font.amp.html",
@@ -134,8 +132,7 @@
       "loading_complete_css": [
         ".list1",
         ".list2"
-      ],
-      "loading_incomplete_css": [".i-amphtml-loading-container"]
+      ]
     },
     {
       "url": "examples/visual-tests/amp-lightbox-gallery.html",


### PR DESCRIPTION
This PR makes multiple modifications to `gulp visual-diff` to prevent flakes and unexpected behaviours:
* Replace puppeteer.page.waitForSelector with an explicit waiting function that waits for _all_ matches, not just the first one that matches the expectation
* Wait for all loader dots to disappear at the end as well, not just at the beginning of page verification (since some components might still be wrapping up loading images, videos, etc.)
* Shorten navigation timeout, but add awaiting until there is zero network activity
* Add missing `await`s that caused code to run unexpectedly asynchronously

Backwards incompatible change:
* The "loading_complete_css" field on the `visual-tests` JSON file will now also ensure that each selector matches at least one element in the page, as well as ensure that all matching elements are visible

I ran this 5 times in a row to ensure no flakes exist, with pleasant results:
* https://percy.io/ampproject/danielrozenberg/builds/837355
* https://percy.io/ampproject/danielrozenberg/builds/837359
* https://percy.io/ampproject/danielrozenberg/builds/837368
* https://percy.io/ampproject/danielrozenberg/builds/837372
* https://percy.io/ampproject/danielrozenberg/builds/837381