### PR TITLE
Fix email spec regarding allowance of inline styles

### DIFF
--- a/spec/amp-email-format.md
+++ b/spec/amp-email-format.md
@@ -210,7 +210,7 @@ The following is a proposed list of AMP components that are supported in AMP ema
 
 ### Specifying CSS in an AMP document
 
-All CSS in any AMP document must be included in a `<style amp-custom>` tag within the header. Inline style attributes are not allowed in AMP.
+All CSS in any AMP document must be included in a `<style amp-custom>` tag within the header or as inline `style` attributes.
 
 ```html
 ...


### PR DESCRIPTION
Now fixing this in the right place, not in the doc repo, as the prev change would get overwritten by this one.