### PR TITLE
🐛 VK validator add requires_usage: GRANDFATHERED

### DIFF
--- a/extensions/amp-vk/validator-amp-vk.protoascii
+++ b/extensions/amp-vk/validator-amp-vk.protoascii
@@ -21,6 +21,7 @@ tags: {  # amp-vk
     name: "amp-vk"
     allowed_versions: "0.1"
     allowed_versions: "latest"
+    requires_usage: GRANDFATHERED
   }
   attr_lists: "common-extension-attrs"
 }


### PR DESCRIPTION
We can't use VK extension without VK components. But in our case, we have to use it without components. Because we don't know when VK posts will be in page, but we have to guess that it will be some day and we want to use this extension in our template without component. It's work in right way in YouTube, Facebook e.t.c. extensions.

![screenshot_12](https://user-images.githubusercontent.com/16609819/42315386-fccaa0b0-804f-11e8-8b00-519ede6aafd7.png)

