### PR TITLE
Amp-ad-exit / amp-analytics transport frame integration improperly referencing win.top

### DIFF
--- a/extensions/amp-ad-exit/0.1/amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/amp-ad-exit.js
@@ -27,6 +27,7 @@ import {dev, user} from '../../../src/log';
 import {getAmpAdResourceId} from '../../../src/ad-helper';
 import {getData} from '../../../src/event-helper';
 import {getMode} from '../../../src/mode';
+import {getTopWindow} from '../../../src/service';
 import {isJsonScriptTag, openWindowDialog} from '../../../src/dom';
 import {isObject} from '../../../src/types';
 import {makeClickDelaySpec} from './filters/click-delay';
@@ -314,7 +315,7 @@ export class AmpAdExit extends AMP.BaseElement {
    * @private
    */
   getAmpAdResourceId_() {
-    return getAmpAdResourceId(this.element, this.win.top);
+    return getAmpAdResourceId(this.element, getTopWindow(this.win));
   }
 
   /** @override */

--- a/extensions/amp-ad-exit/0.1/test/test-amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/test/test-amp-ad-exit.js
@@ -674,7 +674,7 @@ describes.realWin('amp-ad-exit', {
 
   it('getAmpAdResourceId_ should reference AMP top window', () => {
     const frame = win.document.createElement('iframe');
-    win.document.body. appendChild(frame);
+    win.document.body.appendChild(frame);
     const doc = frame.contentDocument;
     const ampAd = doc.createElement('amp-ad');
     ampAd.getResourceId = () => 12345;

--- a/extensions/amp-ad-exit/0.1/test/test-amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/test/test-amp-ad-exit.js
@@ -20,6 +20,9 @@ import {
 } from '../../../amp-analytics/0.1/iframe-transport-vendors';
 import {AmpAdExit} from '../amp-ad-exit';
 import {FilterType} from '../filters/filter';
+import {installPlatformService} from '../../../../src/service/platform-impl';
+import {installTimerService} from '../../../../src/service/timer-impl';
+import {setParentWindow} from '../../../../src/service';
 import {toggleExperiment} from '../../../../src/experiments';
 
 const TEST_3P_VENDOR = '3p-vendor';
@@ -160,10 +163,6 @@ describes.realWin('amp-ad-exit', {
     adDiv.style.width = '200px';
     adDiv.style.height = '200px';
     win.document.body.appendChild(adDiv);
-    // TODO(jonkeller): Long-term, test with amp-ad-exit enclosed inside amp-ad,
-    // so we don't have to do this hack.
-    sandbox.stub(AmpAdExit.prototype, 'getAmpAdResourceId_').callsFake(
-        () => String(Math.round(Math.random() * 10000)));
   }
 
   beforeEach(() => {
@@ -171,8 +170,6 @@ describes.realWin('amp-ad-exit', {
     win = env.win;
     toggleExperiment(win, 'amp-ad-exit', true);
     addAdDiv();
-    // TODO(jonkeller): Remove after rebase
-    win.top.document.body.getResourceId = () => '6789';
     // TEST_3P_VENDOR must be in ANALYTICS_IFRAME_TRANSPORT_CONFIG
     // *before* makeElementWithConfig
     ANALYTICS_IFRAME_TRANSPORT_CONFIG[TEST_3P_VENDOR] =
@@ -673,5 +670,24 @@ describes.realWin('amp-ad-exit', {
 
     expect(makeElementWithConfig(unkVendor))
         .to.eventually.be.rejectedWith(/Unknown vendor/);
+  });
+
+  it('getAmpAdResourceId_ should reference AMP top window', () => {
+    const frame = win.document.createElement('iframe');
+    win.document.body. appendChild(frame);
+    const doc = frame.contentDocument;
+    const ampAd = doc.createElement('amp-ad');
+    ampAd.getResourceId = () => 12345;
+    doc.body.appendChild(ampAd);
+    const adFrame = doc.createElement('iframe');
+    ampAd.appendChild(adFrame);
+    const ampAdExitElement =
+        adFrame.contentDocument.createElement('amp-ad-exit');
+    adFrame.contentDocument.body.appendChild(ampAdExitElement);
+    installTimerService(frame.contentWindow);
+    installPlatformService(frame.contentWindow);
+    setParentWindow(adFrame.contentWindow, frame.contentWindow);
+    expect(new AmpAdExit(ampAdExitElement).getAmpAdResourceId_())
+        .to.equal('12345');
   });
 });


### PR DESCRIPTION
Causes breakage when AMP page is not at window.top (e.g. when within the viewer).  Fix is to reference src/service#getTopWindow