### PR TITLE
Extend RTL functionality in desktop ✨

### DIFF
--- a/extensions/amp-story/1.0/amp-story-desktop.css
+++ b/extensions/amp-story/1.0/amp-story-desktop.css
@@ -127,26 +127,18 @@ amp-story[standalone][desktop] {
   opacity: 0 !important;
 }
 
-[desktop] > .next-container::before {
-  right: 0 !important;
-  background: linear-gradient(to right, rgba(33,33,33,0) 0%, rgba(33,33,33,0.32) 100%)!important;
-}
-
-[dir=rtl] [desktop] > .next-container::before {
-  right: auto !important;
-  left: 0 !important;
-  background: linear-gradient(to right, rgba(33,33,33,0.32) 0%, rgba(33,33,33,0) 100%)!important;
-}
-
-[desktop] > .prev-container::before {
-  left: 0 !important;
-  background: linear-gradient(to right, rgba(33,33,33,0.32) 0%, rgba(33,33,33,0) 100%)!important;
-}
-
+[desktop] > .next-container::before,
 [dir=rtl] [desktop] > .prev-container::before {
-  left: auto !important;
   right: 0 !important;
+  left: auto !important;
   background: linear-gradient(to right, rgba(33,33,33,0) 0%, rgba(33,33,33,0.32) 100%)!important;
+}
+
+[desktop] > .prev-container::before,
+[dir=rtl] [desktop] > .next-container::before {
+  left: 0 !important;
+  right: auto !important;
+  background: linear-gradient(to right, rgba(33,33,33,0.32) 0%, rgba(33,33,33,0) 100%)!important;
 }
 
 [desktop] > .next-container > .i-amphtml-story-button-move {
@@ -163,15 +155,11 @@ amp-story[standalone][desktop] {
 }
 
 [desktop] amp-story-page[i-amphtml-previous-page],
-.prev-container > .i-amphtml-story-page-sentinel {
+.prev-container > .i-amphtml-story-page-sentinel,
+[dir=rtl] [desktop] amp-story-page[i-amphtml-next-page],
+[dir=rtl] .next-container > .i-amphtml-story-page-sentinel {
   /* -150% + 15% */
   transform: scale(0.9) translateX(calc(-150% - 64px)) translateY(0%) !important;
-}
-
-[dir=rtl] [desktop] amp-story-page[i-amphtml-previous-page],
-[dir=rtl] .prev-container > .i-amphtml-story-page-sentinel {
-  /* 50% - 15% */
-  transform: scale(0.9) translate(calc(50% + 64px), 0%) !important;
 }
 
 [desktop] amp-story-page[active] {
@@ -180,15 +168,11 @@ amp-story[standalone][desktop] {
 }
 
 [desktop] amp-story-page[i-amphtml-next-page],
-.next-container > .i-amphtml-story-page-sentinel {
+.next-container > .i-amphtml-story-page-sentinel,
+[dir=rtl] [desktop] amp-story-page[i-amphtml-previous-page],
+[dir=rtl] .prev-container > .i-amphtml-story-page-sentinel {
   /* 50% - 15% */
   transform: scale(0.9) translate(calc(50% + 64px), 0%) !important;
-}
-
-[dir=rtl] [desktop] amp-story-page[i-amphtml-next-page],
-[dir=rtl] .next-container > .i-amphtml-story-page-sentinel {
-  /* -150% + 15% */
-  transform: scale(0.9) translateX(calc(-150% - 64px)) translateY(0%) !important;
 }
 
 [desktop] > amp-story-page,
@@ -248,29 +232,20 @@ amp-story[standalone][desktop] {
   opacity: 0.3 !important;
 }
 
-.prev-container > .i-amphtml-story-button-move {
-  background-image: url('data:image/svg+xml;charset=utf-8,<svg width="16" height="25" xmlns="http://www.w3.org/2000/svg"><path d="M15.7 22l-9.5-9.5L15.7 3l-3-3L.4 12.6 12.8 25"/></svg>')!important;
-  background-position: 45% 50%!important;
-  left: 0!important;
-}
-
-[dir=rtl] .prev-container > .i-amphtml-story-button-move {
-  left: auto !important;
-  background-image: url('data:image/svg+xml;charset=utf-8,<svg width="16" height="25" xmlns="http://www.w3.org/2000/svg"><path d="M.3 3l9.5 9.5L.3 22l3 3 12.4-12.5L3.2 0"/></svg>')!important;
-  background-position: 55% 50%!important;
-  right: 0!important;
-}
-
-.i-amphtml-story-fwd-next > .i-amphtml-story-button-move {
-  background-image: url('data:image/svg+xml;charset=utf-8,<svg width="16" height="25" xmlns="http://www.w3.org/2000/svg"><path d="M.3 3l9.5 9.5L.3 22l3 3 12.4-12.5L3.2 0"/></svg>')!important;
-  background-position: 55% 50%!important;
-}
-
+.prev-container > .i-amphtml-story-button-move,
 [dir=rtl] .i-amphtml-story-fwd-next > .i-amphtml-story-button-move {
-  right: auto !important;
   background-image: url('data:image/svg+xml;charset=utf-8,<svg width="16" height="25" xmlns="http://www.w3.org/2000/svg"><path d="M15.7 22l-9.5-9.5L15.7 3l-3-3L.4 12.6 12.8 25"/></svg>')!important;
   background-position: 45% 50%!important;
   left: 0!important;
+  right: auto !important;
+}
+
+.i-amphtml-story-fwd-next > .i-amphtml-story-button-move,
+[dir=rtl] .prev-container > .i-amphtml-story-button-move {
+  background-image: url('data:image/svg+xml;charset=utf-8,<svg width="16" height="25" xmlns="http://www.w3.org/2000/svg"><path d="M.3 3l9.5 9.5L.3 22l3 3 12.4-12.5L3.2 0"/></svg>')!important;
+  background-position: 55% 50%!important;
+  left: auto !important;
+  right: 0 !important;
 }
 
 .i-amphtml-story-fwd-replay > .i-amphtml-story-button-move {

--- a/extensions/amp-story/1.0/amp-story-desktop.css
+++ b/extensions/amp-story/1.0/amp-story-desktop.css
@@ -145,6 +145,7 @@ amp-story[standalone][desktop] {
   right: 0 !important;
 }
 
+/** This is needed to overwrite position of replay and read more button at the end of the the story. */
 [dir=rtl] [desktop] > .next-container > .i-amphtml-story-button-move {
   right: auto !important;
   left: 0 !important;

--- a/extensions/amp-story/1.0/amp-story-desktop.css
+++ b/extensions/amp-story/1.0/amp-story-desktop.css
@@ -132,13 +132,30 @@ amp-story[standalone][desktop] {
   background: linear-gradient(to right, rgba(33,33,33,0) 0%, rgba(33,33,33,0.32) 100%)!important;
 }
 
+[dir=rtl] [desktop] > .next-container::before {
+  right: auto !important;
+  left: 0 !important;
+  background: linear-gradient(to right, rgba(33,33,33,0.32) 0%, rgba(33,33,33,0) 100%)!important;
+}
+
 [desktop] > .prev-container::before {
   left: 0 !important;
   background: linear-gradient(to right, rgba(33,33,33,0.32) 0%, rgba(33,33,33,0) 100%)!important;
 }
 
+[dir=rtl] [desktop] > .prev-container::before {
+  left: auto !important;
+  right: 0 !important;
+  background: linear-gradient(to right, rgba(33,33,33,0) 0%, rgba(33,33,33,0.32) 100%)!important;
+}
+
 [desktop] > .next-container > .i-amphtml-story-button-move {
   right: 0 !important;
+}
+
+[dir=rtl] [desktop] > .next-container > .i-amphtml-story-button-move {
+  right: auto !important;
+  left: 0 !important;
 }
 
 [desktop] amp-story-page[i-amphtml-visited] {
@@ -149,6 +166,12 @@ amp-story[standalone][desktop] {
 .prev-container > .i-amphtml-story-page-sentinel {
   /* -150% + 15% */
   transform: scale(0.9) translateX(calc(-150% - 64px)) translateY(0%) !important;
+}
+
+[dir=rtl] [desktop] amp-story-page[i-amphtml-previous-page],
+[dir=rtl] .prev-container > .i-amphtml-story-page-sentinel {
+  /* 50% - 15% */
+  transform: scale(0.9) translate(calc(50% + 64px), 0%) !important;
 }
 
 [desktop] amp-story-page[active] {
@@ -162,33 +185,10 @@ amp-story[standalone][desktop] {
   transform: scale(0.9) translate(calc(50% + 64px), 0%) !important;
 }
 
-
-/* NOTE: This css for rtl has not been refactored after desktop CSS changes.
-Perhaps better to delete and start over when RTL implementation begins. There be
-dragons here. */
-[dir=rtl] [desktop] amp-story-page {
-  transform: scale(0.9) translateX(calc(50vw * 1.1)) translateY(0%) !important;
-}
-
-[dir=rtl] [desktop] amp-story-page[i-amphtml-previous-page] {
-  /* 50% - 15% */
-  transform: scale(0.9) translateX(calc(50% + 64px)) translateY(0%) !important;
-  /*transform: scale(1.0) translateX(35%) translateY(0%) !important;*/
-}
-
-[dir=rtl] [desktop] amp-story-page[active] {
-  transform: scale(1.0) translateX(-50%) translateY(0%) !important;
-  opacity: 1!important;
-}
-
-[dir=rtl] [desktop] amp-story-page[active] + amp-story-page {
+[dir=rtl] [desktop] amp-story-page[i-amphtml-next-page],
+[dir=rtl] .next-container > .i-amphtml-story-page-sentinel {
   /* -150% + 15% */
   transform: scale(0.9) translateX(calc(-150% - 64px)) translateY(0%) !important;
-  /*transform: scale(0.9) translateX(-135%) translateY(0%) !important;*/
-}
-
-[dir=rtl] [desktop] amp-story-page[active] + amp-story-page ~ amp-story-page {
-  transform: scale(0.9) translateX(-200vw) translateY(0%) !important;
 }
 
 [desktop] > amp-story-page,
@@ -254,9 +254,23 @@ dragons here. */
   left: 0!important;
 }
 
+[dir=rtl] .prev-container > .i-amphtml-story-button-move {
+  left: auto !important;
+  background-image: url('data:image/svg+xml;charset=utf-8,<svg width="16" height="25" xmlns="http://www.w3.org/2000/svg"><path d="M.3 3l9.5 9.5L.3 22l3 3 12.4-12.5L3.2 0"/></svg>')!important;
+  background-position: 55% 50%!important;
+  right: 0!important;
+}
+
 .i-amphtml-story-fwd-next > .i-amphtml-story-button-move {
   background-image: url('data:image/svg+xml;charset=utf-8,<svg width="16" height="25" xmlns="http://www.w3.org/2000/svg"><path d="M.3 3l9.5 9.5L.3 22l3 3 12.4-12.5L3.2 0"/></svg>')!important;
   background-position: 55% 50%!important;
+}
+
+[dir=rtl] .i-amphtml-story-fwd-next > .i-amphtml-story-button-move {
+  right: auto !important;
+  background-image: url('data:image/svg+xml;charset=utf-8,<svg width="16" height="25" xmlns="http://www.w3.org/2000/svg"><path d="M15.7 22l-9.5-9.5L15.7 3l-3-3L.4 12.6 12.8 25"/></svg>')!important;
+  background-position: 45% 50%!important;
+  left: 0!important;
 }
 
 .i-amphtml-story-fwd-replay > .i-amphtml-story-button-move {


### PR DESCRIPTION
Part of #11647
Extending support for RTL in `amp-story`. 

In the desktop screen:
* Flips the navigational buttons. 
* Places the next page to the left of the active page.
* Places the previous page to the right of the active page.

More follow-ups to come.