### PR TITLE
Stop AdSense/Doubleclick delay request experiments

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -25,8 +25,6 @@
   "expAdsenseUnconditionedCanonical": 0.01,
   "expAdsenseCanonical": 0.01,
   "font-display-swap": 1,
-  "adsense-delay-request": 0.01,
-  "doubleclick-delay-request":0.01,
   "amp-date-picker": 1,
   "inline-styles": 1
 }

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -25,8 +25,6 @@
   "amp-img-native-srcset": 1,
   "expAdsenseUnconditionedCanonical": 0.01,
   "expAdsenseCanonical": 0.01,
-  "adsense-delay-request": 0.01,
-  "doubleclick-delay-request":0.01,
   "amp-date-picker": 1,
   "url-replacement-v2": 0.1,
   "inline-styles": 1


### PR DESCRIPTION
Introduced in #16146, experiment results did not show change to be launchable.