### PR TITLE
✨ amp-next-page: Support loading config from remote src

### DIFF
--- a/extensions/amp-next-page/0.1/amp-next-page.js
+++ b/extensions/amp-next-page/0.1/amp-next-page.js
@@ -18,6 +18,10 @@ import {CSS} from '../../../build/amp-next-page-0.1.css';
 import {Layout} from '../../../src/layout';
 import {NextPageService} from './next-page-service';
 import {Services} from '../../../src/services';
+import {
+  UrlReplacementPolicy,
+  batchFetchJsonFor,
+} from '../../../src/batched-json';
 import {assertConfig} from './config';
 import {
   childElementsByAttr,
@@ -57,22 +61,36 @@ export class AmpNextPage extends AMP.BaseElement {
     }
 
     const {element} = this;
-
     element.classList.add('i-amphtml-next-page');
 
-    // TODO(peterjosling): Read config from another source.
+    const src = element.getAttribute('src');
+    if (src) {
+      return this.fetchConfig_().then(config => this.register_(config),
+          error => user().error(TAG, 'error fetching config', error));
+    } else {
+      const scriptElements = childElementsByTag(element, 'SCRIPT');
+      user().assert(scriptElements.length === 1,
+          `${TAG} should contain only one <script> child, or a URL specified `
+          + 'in [src]');
+      const scriptElement = scriptElements[0];
+      user().assert(isJsonScriptTag(scriptElement),
+          `${TAG} config should ` +
+          'be inside a <script> tag with type="application/json"');
+      const configJson = tryParseJson(scriptElement.textContent, error => {
+        user().error(TAG, 'failed to parse config', error);
+      });
+      this.register_(configJson);
+    }
+  }
 
-    const scriptElements = childElementsByTag(element, 'SCRIPT');
-    user().assert(scriptElements.length == 1,
-        `${TAG} should contain only one <script> child.`);
-    const scriptElement = scriptElements[0];
-    user().assert(isJsonScriptTag(scriptElement),
-        `${TAG} config should ` +
-            'be inside a <script> tag with type="application/json"');
-    const configJson = tryParseJson(scriptElement.textContent, error => {
-      user().error(TAG, 'failed to parse config', error);
-    });
-
+  /**
+   * Verifies the specified config as a valid {@code NextPageConfig} and
+   * registers the {@link NextPageService} for this document.
+   * @param {*} configJson Config JSON object.
+   * @private
+   */
+  register_(configJson) {
+    const {element} = this;
     const docInfo = Services.documentInfoForDoc(element);
     const urlService = Services.urlForDoc(element);
 
@@ -106,6 +124,17 @@ export class AmpNextPage extends AMP.BaseElement {
    */
   appendPage_(element) {
     return this.mutateElement(() => this.element.appendChild(element));
+  }
+
+  /**
+   * Fetches the element config from the URL specified in [src].
+   * @private
+   */
+  fetchConfig_() {
+    const ampdoc = this.getAmpDoc();
+    const policy = UrlReplacementPolicy.ALL;
+    return batchFetchJsonFor(
+        ampdoc, this.element, /* opt_expr */ undefined, policy);
   }
 }
 

--- a/extensions/amp-next-page/0.1/next-page-service.js
+++ b/extensions/amp-next-page/0.1/next-page-service.js
@@ -42,7 +42,7 @@ const TAG = 'amp-next-page';
  * @typedef {{
  *   ampUrl: string,
  *   amp: ?Object,
- *   recUnit: ?Element,
+ *   recUnit: {el: ?Element, isObserving: boolean},
  *   cancelled: boolean
  * }}
  */
@@ -145,12 +145,9 @@ export class NextPageService {
     installPositionObserverServiceForDoc(ampDoc);
     this.positionObserver_ = getServiceForDoc(ampDoc, 'position-observer');
 
-    this.documentRefs_.push({
-      ampUrl: win.document.location.href,
-      amp: {title: win.document.title},
-      recUnit: null,
-      cancelled: false,
-    });
+    const documentRef =
+        createDocumentRef(win.document.location.url, win.document.title);
+    this.documentRefs_.push(documentRef);
     this.activeDocumentRef_ = this.documentRefs_[0];
 
     this.viewport_.onScroll(() => this.scrollHandler_());
@@ -219,12 +216,7 @@ export class NextPageService {
   appendNextArticle_() {
     if (this.nextArticle_ < this.config_.pages.length) {
       const next = this.config_.pages[this.nextArticle_];
-      const documentRef = {
-        ampUrl: next.ampUrl,
-        amp: null,
-        recUnit: null,
-        cancelled: false,
-      };
+      const documentRef = createDocumentRef(next.ampUrl);
       this.documentRefs_.push(documentRef);
 
       const container = this.win_.document.createElement('div');
@@ -235,7 +227,7 @@ export class NextPageService {
 
       const articleLinks = this.createArticleLinks_(this.nextArticle_);
       container.appendChild(articleLinks);
-      documentRef.recUnit = articleLinks;
+      documentRef.recUnit.el = articleLinks;
 
       const shadowRoot = this.win_.document.createElement('div');
       container.appendChild(shadowRoot);
@@ -265,13 +257,16 @@ export class NextPageService {
               return;
             }
 
-            this.positionObserver_.unobserve(articleLinks);
+            if (documentRef.recUnit.isObserving) {
+              this.positionObserver_.unobserve(articleLinks);
+              documentRef.recUnit.isObserving = true;
+            }
             this.resources_.mutateElement(container, () => {
               try {
                 const amp = this.attachShadowDoc_(shadowRoot, doc);
                 documentRef.amp = amp;
 
-                setStyle(documentRef.recUnit, 'display', 'none');
+                setStyle(documentRef.recUnit.el, 'display', 'none');
                 this.documentQueued_ = false;
                 resolve();
               } catch (e) {
@@ -415,8 +410,10 @@ export class NextPageService {
    */
   articleLinksPositionUpdate_(documentRef) {
     documentRef.cancelled = true;
-    if (documentRef.recUnit) {
-      this.positionObserver_.unobserve(documentRef.recUnit);
+    if (documentRef.recUnit.isObserving) {
+      this.positionObserver_.unobserve(
+          dev().assertElement(documentRef.recUnit.el));
+      documentRef.recUnit.isObserving = false;
     }
   }
 
@@ -463,4 +460,23 @@ export class NextPageService {
     const vars = {toURL, fromURL};
     triggerAnalyticsEvent(dev().assertElement(this.element_), eventType, vars);
   }
+}
+
+/**
+ * Creates a new {@link DocumentRef} for the specified URL.
+ * @param {string} ampUrl AMP URL of the document.
+ * @param {string=} title Document title, if known before loading.
+ * @return {!DocumentRef} Ref object initialised with the given URL.
+ */
+function createDocumentRef(ampUrl, title) {
+  const amp = (title) ? {title} : null;
+  return {
+    ampUrl,
+    amp,
+    recUnit: {
+      el: null,
+      isObserving: false,
+    },
+    cancelled: false,
+  };
 }

--- a/extensions/amp-next-page/0.1/test/test-amp-next-page.js
+++ b/extensions/amp-next-page/0.1/test/test-amp-next-page.js
@@ -41,11 +41,43 @@ env => {
     ampdoc = env.ampdoc;
     viewport = Services.viewportForDoc(ampdoc);
     sizes = viewport.getSize();
+    element = doc.createElement('div');
 
     toggleExperiment(win, 'amp-next-page', true);
 
-    element = doc.createElement('div');
-    element.innerHTML = `
+    // Ensure element is off screen when it renders.
+    setStyle(element, 'marginTop', '10000px');
+    element.getAmpDoc = () => ampdoc;
+    element.getFallback = () => null;
+    element.getResources = () => win.services.resources.obj;
+
+    doc.body.appendChild(element);
+    nextPage = new AmpNextPage(element);
+
+    // sourceUrl is set to about:srcdoc, which has no host.
+    sandbox.stub(Services.documentInfoForDoc(element), 'sourceUrl').value('/');
+
+    xhrMock = sandbox.mock(Services.xhrFor(win));
+
+    sandbox.stub(Services.resourcesForDoc(ampdoc), 'mutateElement')
+        .callsFake((unused, mutator) => {
+          mutator();
+          return Promise.resolve();
+        });
+    sandbox.stub(nextPage, 'mutateElement').callsFake(mutator => {
+      mutator();
+      return Promise.resolve();
+    });
+  });
+
+  afterEach(() => {
+    xhrMock.verify();
+    toggleExperiment(win, 'amp-next-page', false);
+  });
+
+  describe('valid inline config', () => {
+    beforeEach(() => {
+      element.innerHTML = `
           <script type="application/json">
             {
               "pages": [
@@ -66,146 +98,117 @@ env => {
               ]
             }
           </script>`;
-    // Ensure element is off screen when it renders.
-    setStyle(element, 'marginTop', '10000px');
-    element.getAmpDoc = () => ampdoc;
-    element.getFallback = () => null;
-    element.getResources = () => win.services.resources.obj;
-
-    doc.body.appendChild(element);
-    nextPage = new AmpNextPage(element);
-
-    // sourceUrl is set to about:srcdoc, which has no host.
-    sandbox.stub(Services.documentInfoForDoc(element), 'sourceUrl').value('/');
-    nextPage.buildCallback();
-
-    xhrMock = sandbox.mock(Services.xhrFor(win));
-
-    sandbox.stub(Services.resourcesForDoc(ampdoc), 'mutateElement')
-        .callsFake((unused, mutator) => {
-          mutator();
-          return Promise.resolve();
-        });
-    sandbox.stub(nextPage, 'mutateElement').callsFake(mutator => {
-      mutator();
-      return Promise.resolve();
+      nextPage.buildCallback();
     });
-  });
 
-  afterEach(() => {
-    xhrMock.verify();
-  });
+    it('does not fetch the next document before 3 viewports away',
+        function* () {
+          xhrMock.expects('fetchDocument').never();
+          sandbox.stub(viewport, 'getClientRectAsync').callsFake(() => {
+            // 4x viewports away
+            return Promise.resolve(
+                layoutRectLtwh(0, 0, sizes.width, sizes.height * 5));
+          });
 
-  afterEach(() => {
-    toggleExperiment(win, 'amp-next-page', false);
-  });
-
-  it('does not fetch the next document before 3 viewports away',
-      function* () {
-        xhrMock.expects('fetchDocument').never();
-        sandbox.stub(viewport, 'getClientRectAsync').callsFake(() => {
-          // 4x viewports away
-          return Promise.resolve(
-              layoutRectLtwh(0, 0, sizes.width, sizes.height * 5));
+          win.dispatchEvent(new Event('scroll'));
+          yield macroTask();
         });
 
-        win.dispatchEvent(new Event('scroll'));
-        yield macroTask();
+    it('fetches the next document within 3 viewports away', function* () {
+      xhrMock.expects('fetchDocument').returns(Promise.resolve());
+
+      sandbox.stub(viewport, 'getClientRectAsync').callsFake(() => {
+        // 1x viewport away
+        return Promise.resolve(
+            layoutRectLtwh(0, 0, sizes.width, sizes.height * 2));
       });
 
-  it('fetches the next document within 3 viewports away', function* () {
-    xhrMock.expects('fetchDocument').returns(Promise.resolve());
-
-    sandbox.stub(viewport, 'getClientRectAsync').callsFake(() => {
-      // 1x viewport away
-      return Promise.resolve(
-          layoutRectLtwh(0, 0, sizes.width, sizes.height * 2));
+      win.dispatchEvent(new Event('scroll'));
+      yield macroTask();
     });
 
-    win.dispatchEvent(new Event('scroll'));
-    yield macroTask();
-  });
+    it('only fetches the next document once', function*() {
+      xhrMock.expects('fetchDocument')
+          // Promise which is never resolved.
+          .returns(new Promise(() => {}))
+          .once();
 
-  it('only fetches the next document once', function*() {
-    xhrMock.expects('fetchDocument')
-        // Promise which is never resolved.
-        .returns(new Promise(() => {}))
-        .once();
+      sandbox.stub(viewport, 'getClientRectAsync').callsFake(() => {
+        // 1x viewport away
+        return Promise.resolve(
+            layoutRectLtwh(0, 0, sizes.width, sizes.height * 2));
+      });
 
-    sandbox.stub(viewport, 'getClientRectAsync').callsFake(() => {
-      // 1x viewport away
-      return Promise.resolve(
-          layoutRectLtwh(0, 0, sizes.width, sizes.height * 2));
+      win.dispatchEvent(new Event('scroll'));
+      yield macroTask();
+      win.dispatchEvent(new Event('scroll'));
+      yield macroTask();
     });
 
-    win.dispatchEvent(new Event('scroll'));
-    yield macroTask();
-    win.dispatchEvent(new Event('scroll'));
-    yield macroTask();
-  });
+    it('adds the hidden class to hideSelector elements', function* () {
+      const exampleDoc = createExampleDocument(doc);
+      xhrMock.expects('fetchDocument')
+          .returns(Promise.resolve(exampleDoc))
+          .once();
 
-  it('adds the hidden class to hideSelector elements', function* () {
-    const exampleDoc = createExampleDocument(doc);
-    xhrMock.expects('fetchDocument')
-        .returns(Promise.resolve(exampleDoc))
-        .once();
+      const nextPageService = getService(win, 'next-page');
+      const attachShadowDocSpy =
+          sandbox.spy(nextPageService.multidocManager_, 'attachShadowDoc');
 
-    const nextPageService = getService(win, 'next-page');
-    const attachShadowDocSpy =
-        sandbox.spy(nextPageService.multidocManager_, 'attachShadowDoc');
+      sandbox.stub(viewport, 'getClientRectAsync')
+          .onFirstCall().callsFake(() => {
+            // 1x viewport away
+            return Promise.resolve(
+                layoutRectLtwh(0, 0, sizes.width, sizes.height * 2));
+          });
 
-    sandbox.stub(viewport, 'getClientRectAsync').onFirstCall().callsFake(() => {
-      // 1x viewport away
-      return Promise.resolve(
-          layoutRectLtwh(0, 0, sizes.width, sizes.height * 2));
+      win.dispatchEvent(new Event('scroll'));
+      yield macroTask();
+
+      const shadowDoc = attachShadowDocSpy.firstCall.returnValue.ampdoc;
+      yield shadowDoc.whenReady();
+
+      const shadowRoot = shadowDoc.getRootNode();
+
+      expect(shadowRoot.querySelector('header'))
+          .to.have.class('i-amphtml-next-page-hidden');
+
+      expect(shadowRoot.querySelector('footer'))
+          .to.have.class('i-amphtml-next-page-hidden');
     });
 
-    win.dispatchEvent(new Event('scroll'));
-    yield macroTask();
+    it('removes amp-analytics tags from child documents', function* () {
+      const exampleDoc = createExampleDocument(doc);
+      exampleDoc.body.innerHTML +=
+          '<amp-analytics id="analytics1"></amp-analytics>';
+      exampleDoc.body.innerHTML +=
+          '<amp-analytics id="analytics2"></amp-analytics>';
+      xhrMock.expects('fetchDocument')
+          .returns(Promise.resolve(exampleDoc))
+          .once();
 
-    const shadowDoc = attachShadowDocSpy.firstCall.returnValue.ampdoc;
-    yield shadowDoc.whenReady();
+      const nextPageService = getService(win, 'next-page');
+      const attachShadowDocSpy =
+          sandbox.spy(nextPageService.multidocManager_, 'attachShadowDoc');
 
-    const shadowRoot = shadowDoc.getRootNode();
+      sandbox.stub(viewport, 'getClientRectAsync')
+          .onFirstCall().callsFake(() => {
+            // 1x viewport away
+            return Promise.resolve(
+                layoutRectLtwh(0, 0, sizes.width, sizes.height * 2));
+          });
 
-    expect(shadowRoot.querySelector('header'))
-        .to.have.class('i-amphtml-next-page-hidden');
+      win.dispatchEvent(new Event('scroll'));
+      yield macroTask();
 
-    expect(shadowRoot.querySelector('footer'))
-        .to.have.class('i-amphtml-next-page-hidden');
-  });
+      const shadowDoc = attachShadowDocSpy.firstCall.returnValue.ampdoc;
+      yield shadowDoc.whenReady();
 
-  it('removes amp-analytics tags from child documents', function* () {
-    const exampleDoc = createExampleDocument(doc);
-    exampleDoc.body.innerHTML +=
-        '<amp-analytics id="analytics1"></amp-analytics>';
-    exampleDoc.body.innerHTML +=
-        '<amp-analytics id="analytics2"></amp-analytics>';
-    xhrMock.expects('fetchDocument')
-        .returns(Promise.resolve(exampleDoc))
-        .once();
-
-    const nextPageService = getService(win, 'next-page');
-    const attachShadowDocSpy =
-      sandbox.spy(nextPageService.multidocManager_, 'attachShadowDoc');
-
-    sandbox.stub(viewport, 'getClientRectAsync').onFirstCall().callsFake(() => {
-      // 1x viewport away
-      return Promise.resolve(
-          layoutRectLtwh(0, 0, sizes.width, sizes.height * 2));
+      const shadowRoot = shadowDoc.getRootNode();
+      expect(shadowRoot.getElementById('analytics1')).to.be.null;
+      expect(shadowRoot.getElementById('analytics2')).to.be.null;
     });
-
-    win.dispatchEvent(new Event('scroll'));
-    yield macroTask();
-
-    const shadowDoc = attachShadowDocSpy.firstCall.returnValue.ampdoc;
-    yield shadowDoc.whenReady();
-
-    const shadowRoot = shadowDoc.getRootNode();
-    expect(shadowRoot.getElementById('analytics1')).to.be.null;
-    expect(shadowRoot.getElementById('analytics2')).to.be.null;
   });
-});
 
 /**
  * Creates an example document as a child of {@code doc} to be embedded as a

--- a/extensions/amp-next-page/0.1/test/validator-amp-next-page-inline.html
+++ b/extensions/amp-next-page/0.1/test/validator-amp-next-page-inline.html
@@ -17,10 +17,49 @@
 </head>
 <body>
   <h2>Content discovery</h2>
-  <amp-next-page src="https://foo.com/data.json">
+  <amp-next-page>
     <div separator>
-        READ ANOTHER ARTICLE FROM OUR SITE!
+      READ ANOTHER ARTICLE FROM OUR SITE!
     </div>
+    <script type='application/json'>
+      {
+        "pages": [
+          {
+            "image": "/examples/img/hero@1x.jpg",
+            "title": "This is one another article",
+            "ampUrl": "/examples/article-parallax.amp.html"
+          },
+          {
+            "image": "/examples/img/hero@1x.jpg",
+            "title": "This article has fixed position elements",
+            "ampUrl": "/examples/article-fixed-header.amp.html"
+          },
+          {
+            "image": "/examples/img/hero@1x.jpg",
+            "title": "This is one another article with a very very very very long title",
+            "ampUrl": "/examples/amp-next-page.amp.html"
+          },
+          {
+            "image": "/examples/img/hero@1x.jpg",
+            "title": "This is one article",
+            "ampUrl": "/examples/article.amp.html"
+          },
+          {
+            "image": "/examples/img/hero@1x.jpg",
+            "title": "This is some article",
+            "ampUrl": "/examples/article.amp.html"
+          },
+          {
+            "image": "/examples/img/hero@1x.jpg",
+            "title": "This is yet another article",
+            "ampUrl": "/examples/article.amp.html"
+          }
+        ],
+        "hideSelectors": [
+          ".title"
+        ]
+      }
+    </script>
   </amp-next-page>
   <footer>
     Footer

--- a/extensions/amp-next-page/0.1/test/validator-amp-next-page-inline.out
+++ b/extensions/amp-next-page/0.1/test/validator-amp-next-page-inline.out
@@ -18,10 +18,49 @@ PASS
 |  </head>
 |  <body>
 |    <h2>Content discovery</h2>
-|    <amp-next-page src="https://foo.com/data.json">
+|    <amp-next-page>
 |      <div separator>
-|          READ ANOTHER ARTICLE FROM OUR SITE!
+|        READ ANOTHER ARTICLE FROM OUR SITE!
 |      </div>
+|      <script type='application/json'>
+|        {
+|          "pages": [
+|            {
+|              "image": "/examples/img/hero@1x.jpg",
+|              "title": "This is one another article",
+|              "ampUrl": "/examples/article-parallax.amp.html"
+|            },
+|            {
+|              "image": "/examples/img/hero@1x.jpg",
+|              "title": "This article has fixed position elements",
+|              "ampUrl": "/examples/article-fixed-header.amp.html"
+|            },
+|            {
+|              "image": "/examples/img/hero@1x.jpg",
+|              "title": "This is one another article with a very very very very long title",
+|              "ampUrl": "/examples/amp-next-page.amp.html"
+|            },
+|            {
+|              "image": "/examples/img/hero@1x.jpg",
+|              "title": "This is one article",
+|              "ampUrl": "/examples/article.amp.html"
+|            },
+|            {
+|              "image": "/examples/img/hero@1x.jpg",
+|              "title": "This is some article",
+|              "ampUrl": "/examples/article.amp.html"
+|            },
+|            {
+|              "image": "/examples/img/hero@1x.jpg",
+|              "title": "This is yet another article",
+|              "ampUrl": "/examples/article.amp.html"
+|            }
+|          ],
+|          "hideSelectors": [
+|            ".title"
+|          ]
+|        }
+|      </script>
 |    </amp-next-page>
 |    <footer>
 |      Footer

--- a/extensions/amp-next-page/0.1/test/validator-amp-next-page.html
+++ b/extensions/amp-next-page/0.1/test/validator-amp-next-page.html
@@ -17,7 +17,7 @@
 </head>
 <body>
   <h2>Content discovery</h2>
-  <amp-next-page>
+  <amp-next-page src="https://foo.com/data.json">
     <div separator>
         READ ANOTHER ARTICLE FROM OUR SITE!
     </div>

--- a/extensions/amp-next-page/0.1/test/validator-amp-next-page.out
+++ b/extensions/amp-next-page/0.1/test/validator-amp-next-page.out
@@ -18,7 +18,7 @@ PASS
 |  </head>
 |  <body>
 |    <h2>Content discovery</h2>
-|    <amp-next-page>
+|    <amp-next-page src="https://foo.com/data.json">
 |      <div separator>
 |          READ ANOTHER ARTICLE FROM OUR SITE!
 |      </div>

--- a/extensions/amp-next-page/validator-amp-next-page.protoascii
+++ b/extensions/amp-next-page/validator-amp-next-page.protoascii
@@ -52,5 +52,13 @@ tags: {  # <amp-next-page>
   tag_name: "AMP-NEXT-PAGE"
   unique: true
   requires_extension: "amp-next-page"
+  attrs: {
+    name: "src"
+    value_url: {
+      allowed_protocol: "https"
+      allow_relative: true  # Will be set to false at a future date.
+    }
+    blacklisted_value_regex: "__amp_source_origin"
+  }
   spec_url: "https://www.ampproject.org/docs/reference/components/amp-next-page"
 }

--- a/extensions/amp-next-page/validator-amp-next-page.protoascii
+++ b/extensions/amp-next-page/validator-amp-next-page.protoascii
@@ -56,7 +56,7 @@ tags: {  # <amp-next-page>
     name: "src"
     value_url: {
       allowed_protocol: "https"
-      allow_relative: true  # Will be set to false at a future date.
+      allow_relative: false
     }
     blacklisted_value_regex: "__amp_source_origin"
   }


### PR DESCRIPTION
Allows for `amp-next-page` config to be specified dynamically from a URL specified in the `src` attribute.

The value of the `src` attribute will only be fetched at initial component build, so I've not required opt-in for URL variable replacements.

Fixes #15956