### PR TITLE
🏗 Generate a consistent version number when building/disting

### DIFF
--- a/build-system/exec.js
+++ b/build-system/exec.js
@@ -73,7 +73,6 @@ exports.execOrDie = function(cmd, options) {
 
 /**
  * Executes the provided command, returning the process object.
- * This will throw an exception if something goes wrong.
  * @param {string} cmd
  * @return {!Object}
  */

--- a/build-system/git.js
+++ b/build-system/git.js
@@ -86,7 +86,7 @@ exports.gitCommitterEmail = function() {
 
 /**
  * Returns the timestamp of the latest commit on the local branch.
- * @return {int}
+ * @return {number}
  */
 exports.gitCommitFormattedTime = function() {
   return getStdout(

--- a/build-system/git.js
+++ b/build-system/git.js
@@ -83,3 +83,22 @@ exports.gitBranchName = function() {
 exports.gitCommitterEmail = function() {
   return getStdout('git log -1 --pretty=format:"%ae"').trim();
 };
+
+/**
+ * Returns the timestamp of the latest commit on the local branch.
+ * @return {int}
+ */
+exports.gitCommitFormattedTime = function() {
+  return getStdout(
+      'TZ=UTC git log -1 --pretty="%cd" --date=format-local:%y%m%d%H%M%S')
+      .trim();
+};
+
+/**
+ * Returns machine parsable list of uncommitted changed files, or an empty
+ * string if no files were changed.
+ * @return {string}
+ */
+exports.gitStatusPorcelain = function() {
+  return getStdout('git status --porcelain').trim();
+};

--- a/build-system/internal-version.js
+++ b/build-system/internal-version.js
@@ -16,8 +16,33 @@
 'use strict';
 
 const argv = require('minimist')(process.argv.slice(2));
+const {gitCommitFormattedTime, gitStatusPorcelain} = require('./git');
 
-// Used to e.g. references the ads binary from the runtime to get
-// version lock.
-exports.VERSION = argv.version ?
-  String(argv.version) : String(Date.now());
+function getVersion() {
+  if (argv.version) {
+    return String(argv.version);
+  } else {
+    // Generate a consistent version number by using the commit* time of the
+    // latest commit on the active branch as the twelve digits, and use the
+    // state of the working directory as the last digit: 0 for a "clean" tree, 1
+    // if there are uncommited changes in the working directory.
+    //
+    // e.g., the version number of a clean (no uncommited changes) tree that was
+    // commited on August 1, 2018 at 14:31:11 EDT would be `1808011831110`
+    // (notice that due to timezone shift, the hour value changes from EDT's 14
+    // to UTC's 18. The last digit denotes that this is a clean tree.)
+    //
+    // *Commit time is different from author time! Commit time is the time that
+    // the PR was merged into master; author time is when the author ran the
+    // "git commit" command.
+    const lastCommitFormattedTime = gitCommitFormattedTime();
+    if (gitStatusPorcelain()) {
+      return `${lastCommitFormattedTime}1`;
+    } else {
+      return `${lastCommitFormattedTime}0`;
+    }
+  }
+}
+
+// Used to e.g. references the ads binary from the runtime to get version lock.
+exports.VERSION = getVersion();


### PR DESCRIPTION
@choumx and I discussed the idea of changing the way we generate version numbers from relying on the timestamp of when the user hit enter on `gulp [build|dist]` to have a consistent version number, so that running `gulp [build|dist]` on the exact same commit would create the exact same output.

Our current version numbers are 13 digits long, where the 13 digits represent a timestamp in milliseconds.

My proposal is this formula:
```
`${ten-digits-commit-timestamp-in-seconds}${unique-identifier-derived-from-commit-hash}`
```

For the first 10 digits we continue to use the timestamp, which we take from the commit time (_not_ author time.) Git only stores the seconds, not milliseconds, so we cannot rely on a 13 digits timestamp as the version number.

For the last 3 digits we take the short commit hash (e.g., `a2a6e4ad5`) and convert it back into a number, then modulo 1,000 to get 3 digits, then left-pad with 0's. This is to avoid the (highly unlikely) case in which two commits were committed at the _exact_ same second.

If there are any uncommitted files in the working directory (staged or otherwise,) the last 3 digits will be replaced with 000, to indicate that.

This PR is a proof-of-concept and a place to start a discussion around this. What do you all think?