### PR TITLE
✨  amp-sidebar: Remove 80vw restriction for amp-sidebar (#16635)

### DIFF
--- a/extensions/amp-sidebar/0.1/amp-sidebar.css
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.css
@@ -19,7 +19,7 @@ amp-sidebar {
   top: 0;
   max-height: 100vh !important;
   height: 100vh;
-  max-width: 80vw !important;
+  max-width: 80vw;
   background-color: #efefef;
   min-width: 45px !important;
   outline: none;

--- a/extensions/amp-sidebar/amp-sidebar.md
+++ b/extensions/amp-sidebar/amp-sidebar.md
@@ -58,7 +58,7 @@ for content within the sidebar to be displayed on other parts of the main conten
     - `<amp-live-list>`
     - `<amp-social-share>`
 - The max-height of the sidebar is 100vh, if the height exceeds 100vh then a vertical scrollbar appears. The default height is set to 100vh in CSS and is overridable in CSS.
-- The width of the sidebar can be set and adjusted between 45px and 80vw using CSS.
+- The width of the sidebar can be set and adjusted using CSS (minimum width is 45px).
 - Touch zoom is disabled on the `amp-sidebar` and it's mask when the sidebar is open.
 
 *Example:*


### PR DESCRIPTION
Not totally sure, but I think this is all that needs to happen to remove the 80vw restriction. (one of last two parts of https://github.com/ampproject/amphtml/issues/10587)