### PR TITLE
🏗 Add support for locally serving without caching extensions.

### DIFF
--- a/build-system/server.js
+++ b/build-system/server.js
@@ -36,6 +36,8 @@ const {
 const useHttps = process.env.SERVE_USEHTTPS == 'true';
 const quiet = process.env.SERVE_QUIET == 'true';
 const sendCachingHeaders = process.env.SERVE_CACHING_HEADERS == 'true';
+const noCachingExtensions = process.env.SERVE_EXTENSIONS_WITHOUT_CACHING ==
+    'true';
 const header = require('connect-header');
 
 // Exit if the port is in use.
@@ -65,6 +67,16 @@ if (sendCachingHeaders) {
   middleware.push(header({
     'cache-control': ' max-age=600',
   }));
+}
+
+if (noCachingExtensions) {
+  middleware.push(function(req, res, next) {
+    if (req.url.startsWith('/dist/v0/amp-')) {
+      log('Skipping caching for ', req.url);
+      res.header('Cache-Control', 'no-store');
+    }
+    next();
+  });
 }
 
 // Start gulp webserver

--- a/build-system/tasks/serve.js
+++ b/build-system/tasks/serve.js
@@ -26,6 +26,7 @@ const port = argv.port || process.env.PORT || 8000;
 const useHttps = argv.https != undefined;
 const quiet = argv.quiet != undefined;
 const sendCachingHeaders = argv.cache != undefined;
+const noCachingExtensions = argv.noCachingExtensions != undefined;
 
 /**
  * Starts a simple http server at the repository root
@@ -57,6 +58,7 @@ function serve() {
       'SERVE_PROCESS_ID': process.pid,
       'SERVE_QUIET': quiet,
       'SERVE_CACHING_HEADERS': sendCachingHeaders,
+      'SERVE_EXTENSIONS_WITHOUT_CACHING': noCachingExtensions,
     },
     stdout: !quiet,
   }).once('quit', function() {


### PR DESCRIPTION
Previously, you could either serve things cached or disable cache through devtools. However, in practice, v0.js may or will likely be cached, but an extension may not be. This change allows recreating that situation while developing which is useful when developing/testing around loading states.

- Add flag for disabling caching extensions:  `gulp --noCachingExtensions`
