### PR TITLE
Do not XHR intercept first party (1P) CDN resources

### DIFF
--- a/src/service/xhr-impl.js
+++ b/src/service/xhr-impl.js
@@ -30,6 +30,7 @@ import {getService, registerServiceBuilder} from '../service';
 import {isArray, isObject} from '../types';
 import {isFormDataWrapper} from '../form-data-wrapper';
 import {parseJson} from '../json';
+import {urls} from '../config';
 import {utf8Encode} from '../utils/bytes';
 
 /**
@@ -166,6 +167,7 @@ export class Xhr {
    *
    * XHRs are intercepted if all of the following are true:
    * - The AMP doc is in single doc mode
+   * - The requested resource is not a 1p request.
    * - The viewer has the `xhrInterceptor` capability
    * - The Viewer is a trusted viewer or AMP is currently in developement mode
    * - The AMP doc is opted-in for XHR interception (`<html>` tag has
@@ -185,7 +187,8 @@ export class Xhr {
     }
     const viewer = Services.viewerForDoc(this.ampdocSingle_);
     const whenFirstVisible = viewer.whenFirstVisible();
-    if (!viewer.hasCapability('xhrInterceptor')) {
+    const firstPartyResource = urls.cdnProxyRegex.test(new URL(input).origin);
+    if (firstPartyResource || !viewer.hasCapability('xhrInterceptor')) {
       return whenFirstVisible;
     }
     const htmlElement = this.ampdocSingle_.getRootNode().documentElement;

--- a/src/service/xhr-impl.js
+++ b/src/service/xhr-impl.js
@@ -187,7 +187,8 @@ export class Xhr {
     }
     const viewer = Services.viewerForDoc(this.ampdocSingle_);
     const whenFirstVisible = viewer.whenFirstVisible();
-    const firstPartyResource = urls.cdnProxyRegex.test(new URL(input).origin);
+    const firstPartyResource =
+        urls.cdnProxyRegex.test(parseUrlDeprecated(input).origin);
     if (firstPartyResource || !viewer.hasCapability('xhrInterceptor')) {
       return whenFirstVisible;
     }

--- a/src/service/xhr-impl.js
+++ b/src/service/xhr-impl.js
@@ -22,6 +22,7 @@ import {
   getCorsUrl,
   getSourceOrigin,
   getWinOrigin,
+  isProxyOrigin,
   parseUrlDeprecated,
   serializeQueryString,
 } from '../url';
@@ -30,7 +31,6 @@ import {getService, registerServiceBuilder} from '../service';
 import {isArray, isObject} from '../types';
 import {isFormDataWrapper} from '../form-data-wrapper';
 import {parseJson} from '../json';
-import {urls} from '../config';
 import {utf8Encode} from '../utils/bytes';
 
 /**
@@ -187,9 +187,7 @@ export class Xhr {
     }
     const viewer = Services.viewerForDoc(this.ampdocSingle_);
     const whenFirstVisible = viewer.whenFirstVisible();
-    const firstPartyResource =
-        urls.cdnProxyRegex.test(parseUrlDeprecated(input).origin);
-    if (firstPartyResource || !viewer.hasCapability('xhrInterceptor')) {
+    if (isProxyOrigin(input) || !viewer.hasCapability('xhrInterceptor')) {
       return whenFirstVisible;
     }
     const htmlElement = this.ampdocSingle_.getRootNode().documentElement;

--- a/test/functional/test-xhr.js
+++ b/test/functional/test-xhr.js
@@ -890,13 +890,33 @@ describe.configure().skipSafari().run('XHR', function() {
           .then(() => expect(sendMessageStub).to.not.have.been.called);
     });
 
+    it('should not intercept a 1p cdn from subdomain', () => {
+      sandbox.stub(viewer, 'isTrustedViewer').returns(Promise.resolve(true));
+      interceptionEnabledWin.AMP_DEV_MODE = true;
+
+      const xhr = xhrServiceForTesting(interceptionEnabledWin);
+
+      return xhr.fetch('https://subdomain-model.cdn.ampproject.org/ww.js')
+          .then(() => expect(sendMessageStub).to.not.have.been.called);
+    });
+
+    it('should not intercept a 1p cdn resource', () => {
+      sandbox.stub(viewer, 'isTrustedViewer').returns(Promise.resolve(true));
+      interceptionEnabledWin.AMP_DEV_MODE = true;
+
+      const xhr = xhrServiceForTesting(interceptionEnabledWin);
+
+      return xhr.fetch('https://cdn.ampproject.org/ww.js')
+          .then(() => expect(sendMessageStub).to.not.have.been.called);
+    });
+
     it('should intercept if viewer untrusted but dev mode', () => {
       sandbox.stub(viewer, 'isTrustedViewer').returns(Promise.resolve(false));
       interceptionEnabledWin.AMP_DEV_MODE = true;
 
       const xhr = xhrServiceForTesting(interceptionEnabledWin);
 
-      return xhr.fetch('https://cdn.ampproject.org')
+      return xhr.fetch('https://www.some-url.org/some-resource/')
           .then(() => expect(sendMessageStub).to.have.been.called);
     });
 
@@ -906,14 +926,14 @@ describe.configure().skipSafari().run('XHR', function() {
 
       const xhr = xhrServiceForTesting(interceptionEnabledWin);
 
-      return xhr.fetch('https://cdn.ampproject.org')
+      return xhr.fetch('https://www.some-url.org/some-resource/')
           .then(() => expect(sendMessageStub).to.have.been.called);
     });
 
     it('should send viewer message named `xhr`', () => {
       const xhr = xhrServiceForTesting(interceptionEnabledWin);
 
-      return xhr.fetch('https://cdn.ampproject.org')
+      return xhr.fetch('https://www.some-url.org/some-resource/')
           .then(() =>
             expect(sendMessageStub).to.have.been.calledWithMatch(
                 'xhr', sinon.match.any));
@@ -922,12 +942,12 @@ describe.configure().skipSafari().run('XHR', function() {
     it('should post correct structurally-cloneable GET request', () => {
       const xhr = xhrServiceForTesting(interceptionEnabledWin);
 
-      return xhr.fetch('https://cdn.ampproject.org')
+      return xhr.fetch('https://www.some-url.org/some-resource/')
           .then(() =>
             expect(sendMessageStub).to.have.been.calledWithMatch(
                 sinon.match.any, {
                   originalRequest: {
-                    input: 'https://cdn.ampproject.org' +
+                    input: 'https://www.some-url.org/some-resource/' +
                           '?__amp_source_origin=https%3A%2F%2Facme.com',
                     init: {
                       headers: {},
@@ -942,7 +962,7 @@ describe.configure().skipSafari().run('XHR', function() {
       const xhr = xhrServiceForTesting(interceptionEnabledWin);
 
       return xhr
-          .fetch('https://cdn.ampproject.org', {
+          .fetch('https://www.some-url.org/some-resource/', {
             method: 'POST',
             headers: {'Content-Type': 'application/json;charset=utf-8'},
             body: JSON.stringify({a: 42, b: [24, true]}),
@@ -951,7 +971,7 @@ describe.configure().skipSafari().run('XHR', function() {
             expect(sendMessageStub).to.have.been.calledWithMatch(
                 sinon.match.any, {
                   originalRequest: {
-                    input: 'https://cdn.ampproject.org' +
+                    input: 'https://www.some-url.org/some-resource/' +
                           '?__amp_source_origin=https%3A%2F%2Facme.com',
                     init: {
                       headers: {
@@ -975,7 +995,7 @@ describe.configure().skipSafari().run('XHR', function() {
       formData.append('b', true);
 
       return xhr
-          .fetch('https://cdn.ampproject.org', {
+          .fetch('https://www.some-url.org/some-resource/', {
             method: 'POST',
             body: formData,
           })
@@ -983,7 +1003,7 @@ describe.configure().skipSafari().run('XHR', function() {
             expect(sendMessageStub).to.have.been.calledWithMatch(
                 sinon.match.any, {
                   originalRequest: {
-                    input: 'https://cdn.ampproject.org' +
+                    input: 'https://www.some-url.org/some-resource/' +
                           '?__amp_source_origin=https%3A%2F%2Facme.com',
                     init: {
                       headers: {
@@ -1002,7 +1022,7 @@ describe.configure().skipSafari().run('XHR', function() {
       sendMessageStub.returns(Promise.resolve());
       const xhr = xhrServiceForTesting(interceptionEnabledWin);
 
-      return expect(xhr.fetch('https://cdn.ampproject.org'))
+      return expect(xhr.fetch('https://www.some-url.org/some-resource/'))
           .to.eventually.be.rejectedWith(Error, 'Object expected: undefined');
     });
 
@@ -1010,7 +1030,7 @@ describe.configure().skipSafari().run('XHR', function() {
       sendMessageStub.returns(Promise.resolve(null));
       const xhr = xhrServiceForTesting(interceptionEnabledWin);
 
-      return expect(xhr.fetch('https://cdn.ampproject.org'))
+      return expect(xhr.fetch('https://www.some-url.org/some-resource/'))
           .to.eventually.be.rejectedWith(Error, 'Object expected: null');
     });
 
@@ -1018,7 +1038,7 @@ describe.configure().skipSafari().run('XHR', function() {
       sendMessageStub.returns(Promise.resolve('response text'));
       const xhr = xhrServiceForTesting(interceptionEnabledWin);
 
-      return expect(xhr.fetch('https://cdn.ampproject.org')).to.eventually
+      return expect(xhr.fetch('https://www.some-url.org/some-resource/')).to.eventually
           .be.rejectedWith(Error, 'Object expected: response text');
     });
 
@@ -1041,7 +1061,7 @@ describe.configure().skipSafari().run('XHR', function() {
             }));
         const xhr = xhrServiceForTesting(interceptionEnabledWin);
 
-        return xhr.fetch('https://cdn.ampproject.org').then(response => {
+        return xhr.fetch('https://www.some-url.org/some-resource/').then(response => {
           expect(response.headers.get('a')).to.equal('2');
           expect(response.headers.get('b')).to.equal('false');
           expect(response.headers.get('Amp-Access-Control-Allow-source-origin'))
@@ -1067,7 +1087,7 @@ describe.configure().skipSafari().run('XHR', function() {
             }));
         const xhr = xhrServiceForTesting(interceptionEnabledWin);
 
-        return xhr.fetchDocument('https://cdn.ampproject.org').then(doc => {
+        return xhr.fetchDocument('https://www.some-url.org/some-resource/').then(doc => {
           expect(doc).to.have.nested.property('body.textContent')
               .that.equals('Foo');
         });
@@ -1116,7 +1136,7 @@ describe.configure().skipSafari().run('XHR', function() {
             }));
         const xhr = xhrServiceForTesting(interceptionEnabledWin);
 
-        return xhr.fetchDocument('https://cdn.ampproject.org')
+        return xhr.fetchDocument('https://www.some-url.org/some-resource/')
             .then(doc => expect(doc.body.textContent).to.equal('Foo'));
       });
 
@@ -1124,7 +1144,7 @@ describe.configure().skipSafari().run('XHR', function() {
         sendMessageStub.returns(Promise.resolve({}));
         const xhr = xhrServiceForTesting(interceptionEnabledWin);
 
-        return xhr.fetch('https://cdn.ampproject.org', {ampCors: false})
+        return xhr.fetch('https://www.some-url.org/some-resource/', {ampCors: false})
             .then(response => {
               expect(response.headers.get('a')).to.be.null;
               expect(response.headers.has('a')).to.be.false;
@@ -1138,7 +1158,7 @@ describe.configure().skipSafari().run('XHR', function() {
         sendMessageStub.returns(Promise.resolve({body: '', init: {}}));
         const xhr = xhrServiceForTesting(interceptionEnabledWin);
 
-        return xhr.fetch('https://cdn.ampproject.org', {ampCors: false})
+        return xhr.fetch('https://www.some-url.org/some-resource/', {ampCors: false})
             .then(response => {
               expect(response.headers.get('a')).to.be.null;
               expect(response.headers.has('a')).to.be.false;
@@ -1150,7 +1170,7 @@ describe.configure().skipSafari().run('XHR', function() {
         sendMessageStub.returns(Promise.resolve({body: 32}));
         const xhr = xhrServiceForTesting(interceptionEnabledWin);
 
-        return xhr.fetch('https://cdn.ampproject.org', {ampCors: false})
+        return xhr.fetch('https://www.some-url.org/some-resource/', {ampCors: false})
             .then(response => {
               return expect(response.text()).to.eventually.equal('32');
             });
@@ -1160,7 +1180,7 @@ describe.configure().skipSafari().run('XHR', function() {
         sendMessageStub.returns(Promise.resolve({init: {status: '209.6'}}));
         const xhr = xhrServiceForTesting(interceptionEnabledWin);
 
-        return xhr.fetch('https://cdn.ampproject.org', {ampCors: false})
+        return xhr.fetch('https://www.some-url.org/some-resource/', {ampCors: false})
             .then(response => {
               return expect(response).to.have.property('status')
                   .that.equals(209);
@@ -1176,7 +1196,7 @@ describe.configure().skipSafari().run('XHR', function() {
             }));
         const xhr = xhrServiceForTesting(interceptionEnabledWin);
 
-        return xhr.fetch('https://cdn.ampproject.org', {ampCors: false})
+        return xhr.fetch('https://www.some-url.org/some-resource/', {ampCors: false})
             .then(response => {
               expect(response.headers.get(1)).to.equal('true');
               expect(response.headers.get('false')).to.equal('NaN');
@@ -1197,7 +1217,7 @@ describe.configure().skipSafari().run('XHR', function() {
             }));
         const xhr = xhrServiceForTesting(interceptionEnabledWin);
 
-        return xhr.fetch('https://cdn.ampproject.org', {ampCors: false})
+        return xhr.fetch('https://www.some-url.org/some-resource/', {ampCors: false})
             .then(response => {
               expect(response.headers.get('content-type'))
                   .to.equal('text/plain');

--- a/test/functional/test-xhr.js
+++ b/test/functional/test-xhr.js
@@ -891,9 +891,6 @@ describe.configure().skipSafari().run('XHR', function() {
     });
 
     it('should not intercept a 1p cdn from subdomain', () => {
-      sandbox.stub(viewer, 'isTrustedViewer').returns(Promise.resolve(true));
-      interceptionEnabledWin.AMP_DEV_MODE = true;
-
       const xhr = xhrServiceForTesting(interceptionEnabledWin);
 
       return xhr.fetch('https://subdomain-model.cdn.ampproject.org/ww.js')
@@ -901,9 +898,6 @@ describe.configure().skipSafari().run('XHR', function() {
     });
 
     it('should not intercept a 1p cdn resource', () => {
-      sandbox.stub(viewer, 'isTrustedViewer').returns(Promise.resolve(true));
-      interceptionEnabledWin.AMP_DEV_MODE = true;
-
       const xhr = xhrServiceForTesting(interceptionEnabledWin);
 
       return xhr.fetch('https://cdn.ampproject.org/ww.js')
@@ -1113,7 +1107,7 @@ describe.configure().skipSafari().run('XHR', function() {
             }));
         const xhr = xhrServiceForTesting(interceptionEnabledWin);
 
-        return xhr.fetch('https://cdn.ampproject.org').then(response => {
+        return xhr.fetch('https://www.some-url.org/some-resource/').then(response => {
           expect(response.headers.get('a')).to.equal('2');
           expect(response.headers.get('b')).to.equal('false');
           expect(response.headers.get('Amp-Access-Control-Allow-Source-Origin'))

--- a/testing/test-helper.js
+++ b/testing/test-helper.js
@@ -112,7 +112,7 @@ export function assertScreenReaderElement(element) {
 /////////////////
 
 /** @const {string} */
-const REQUEST_URL = '//localhost:9876/amp4test/request-bank/';
+const REQUEST_URL = 'localhost:9876/amp4test/request-bank/';
 
 /**
  * Append user agent to request-bank deposit/withdraw IDs to avoid

--- a/testing/test-helper.js
+++ b/testing/test-helper.js
@@ -112,7 +112,7 @@ export function assertScreenReaderElement(element) {
 /////////////////
 
 /** @const {string} */
-const REQUEST_URL = 'localhost:9876/amp4test/request-bank/';
+const REQUEST_URL = '//localhost:9876/amp4test/request-bank/';
 
 /**
  * Append user agent to request-bank deposit/withdraw IDs to avoid


### PR DESCRIPTION
fixes #16601 

- fetch URLs to a AMP HTML CDN will not be xhr intercepted to the viewer.