### PR TITLE
[DO NOT MERGE] Add a `CODEOWNERS` file for build-system

### DIFF
--- a/build-system/CODEOWNERS
+++ b/build-system/CODEOWNERS
@@ -1,0 +1,3 @@
+*       @rsimha
+*       @@erwinm
+*       @danielrozenberg


### PR DESCRIPTION
Testing auto-addition of reviewers based on `CODEOWNERS`
