### PR TITLE
✨Add new unload analytics event

### DIFF
--- a/examples/analytics-unload.amp.html
+++ b/examples/analytics-unload.amp.html
@@ -1,0 +1,155 @@
+<!doctype html>
+<html ⚡>
+
+<head>
+  <meta charset="utf-8">
+  <title>AMP Analytics</title>
+  <link rel="canonical" href="www.google.com">
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <!-- TODO Change this back to 30 -->
+  <meta name="amp-ad-enable-refresh" content="doubleclick=5">
+  <!-- <meta name="amp-ad-enable-refresh" content="doubleclick=30"> -->
+  <style amp-custom>
+    .box {
+      background: #ccc;
+      border: 1px solid #aaa;
+      padding: 10px;
+      margin: 10px;
+    }
+
+    #container {
+      position: absolute;
+      top: 10000px;
+      height: 10px;
+    }
+
+  </style>
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
+</head>
+
+<body>
+  <p>Scroll down to see content</p>
+  <div id="container">
+    Container for analytics tags. Positioned far away from top to make sure that doesn't matter.
+
+    <amp-analytics id="analytics1">
+      <script type="application/json">
+        {
+          "requests": {
+            "endpoint": "/analytics",
+            "base": "${endpoint}/${type}?type=${type}&title=${title}"
+          },
+          "vars": {
+            "title": "Example Unload"
+          },
+          "triggers": {
+            "unload": {
+              "on": "unload",
+              "request": "base",
+              "selector": "amp-ad",
+              "vars": {
+                "type": "unload"
+              }
+            },
+            "refresh": {
+              "on": "ad-refresh",
+              "request": "base",
+              "selector": "amp-ad",
+              "vars": {
+                "type": "refresh"
+              }
+            }
+          }
+        }
+      </script>
+    </amp-analytics>
+
+    <div class="logo"></div>
+    <h1 id="top">AMP Analytics</h1>
+    <p>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam pellentesque augue quis elementum tempus. Pellentesque sit amet
+      neque bibendum, sagittis purus vitae, pellentesque magna. Vestibulum non viverra metus, eget feugiat lacus. Nulla in
+      maximus orci. Maecenas id turpis vel ipsum vestibulum bibendum ut sit amet magna. Nullam hendrerit ex at est eleifend,
+      nec dignissim nibh rutrum. Aliquam quis tellus et nibh faucibus laoreet in eget turpis. Nam quam nisl, porttitor vel
+      ex eget, dapibus placerat dui. Mauris commodo pellentesque leo, eu tempus quam. In hac habitasse platea dictumst. Suspendisse
+      non ante finibus, luctus augue non, luctus orci. Vestibulum ornare lacinia aliquam. In sollicitudin vehicula vulputate.
+      Sed mi elit, commodo nec sapien nec, pretium bibendum leo. Donec id justo tortor. Ut in mauris dapibus, laoreet metus
+      vitae, dictum nisi.
+    </p>
+    <p>
+      Integer dapibus egestas arcu. Nunc vitae velit congue, placerat augue quis, suscipit nisi. Donec suscipit imperdiet turpis
+      pharetra feugiat. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Phasellus
+      aliquam eleifend dolor, at lacinia orci semper vel. Nunc semper sem vel tincidunt posuere. Nunc lobortis velit vitae
+      condimentum mollis. Morbi eu ullamcorper mauris. Pellentesque ac eros maximus, pulvinar sapien vitae, semper nisi.
+      Curabitur imperdiet non mauris vitae sollicitudin.
+    </p>
+    <p>
+      Nam posuere velit euismod risus pulvinar, in sollicitudin sapien consectetur. Vestibulum nec ex odio. Quisque at elit nec
+      nunc ultricies lacinia nec non lorem. Maecenas porttitor consequat mauris, vitae porttitor ligula pellentesque ut.
+      Pellentesque rhoncus diam vel lacus lobortis imperdiet. Sed maximus dictum hendrerit. Vivamus ornare, purus in laoreet
+      sagittis, est ante pretium mauris, vel vulputate arcu erat eget mauris. Suspendisse eu lorem metus. Aliquam tempus
+      aliquet urna, vitae mollis lacus pretium vitae. Etiam semper gravida commodo. Maecenas at pulvinar quam. Nullam dolor
+      ipsum, ornare a sollicitudin et, sodales porttitor neque.
+    </p>
+    <p>
+      Integer in felis at lacus mattis facilisis. Curabitur tincidunt, felis porttitor mollis finibus, tortor elit elementum dolor,
+      vel vulputate lorem dui id ante. Vivamus in velit at lectus blandit gravida vitae quis arcu. Nam et magna magna. Fusce
+      condimentum diam lacus, ac ullamcorper purus malesuada eu. Mauris ullamcorper elit et venenatis faucibus. Nullam lobortis
+      molestie purus quis pellentesque. Sed at libero id nisi rhoncus tincidunt. Praesent vestibulum vehicula tristique.
+      Etiam rutrum, nunc id porta interdum, nulla nisi molestie leo, at fermentum justo dolor at lorem. Duis in egestas sapien.
+    </p>
+    <p>
+      Donec pharetra molestie sollicitudin. Duis mattis eleifend rutrum. Quisque luctus tincidunt lacus, vitae lobortis nisi malesuada
+      ac. Aliquam mattis leo vel elit rutrum, nec consequat massa vestibulum. Maecenas bibendum metus nec ante feugiat, eu
+      faucibus orci mattis. Cras tristique sem non elit congue malesuada. Proin ornare, lacus et porttitor consequat, sapien
+      urna rutrum diam, ac pellentesque ligula est eget nisi. Interdum et malesuada fames ac ante ipsum primis in faucibus.
+      Donec ultrices sollicitudin eros a placerat. Proin eget pulvinar est. Donec posuere ultrices odio at ultrices. Suspendisse
+      potenti. Phasellus id orci id purus porttitor consectetur a at erat. Nullam volutpat ultricies nisl id maximus. Morbi
+      porta ex ante, et egestas odio ultricies consequat.
+    </p>
+    <p>
+      <ul>
+        <li>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</li>
+        <li>Aliquam in ex porta, imperdiet elit sit amet, condimentum diam.</li>
+        <li>Etiam fermentum nisi at porta pulvinar.</li>
+      </ul>
+    </p>
+    <p>
+      <ul>
+        <li>Proin mattis neque vel elit posuere molestie.</li>
+        <li>Integer tincidunt sem sed nunc auctor elementum.</li>
+        <li>Integer a felis in ipsum aliquet auctor sit amet a neque.</li>
+      </ul>
+    </p>
+    <p>
+      <ul>
+        <li>Sed suscipit dolor molestie, rhoncus quam ac, lacinia ex.</li>
+        <li>Curabitur et tellus vel justo ultrices aliquet sed id turpis.</li>
+        <li>Nam finibus risus at justo elementum bibendum.</li>
+        <li>In non lacus non urna congue feugiat at vel diam.</li>
+      </ul>
+    </p>
+    <p>
+      <ul>
+        <li>Integer hendrerit augue interdum dui venenatis, sit amet tristique mauris cursus.</li>
+        <li>Etiam quis eros viverra, tincidunt justo in, facilisis nunc.</li>
+        <li>Aliquam at lacus faucibus, congue lorem interdum, semper mauris.</li>
+        <li>Ut vulputate erat vel feugiat pharetra.</li>
+        <li>Morbi id augue id orci sagittis tempus.</li>
+        <li>Vestibulum varius libero ac dignissim sodales.</li>
+      </ul>
+    </p>
+    <p>
+      <ul>
+        <li>Aenean ac sem eget libero varius viverra sit amet vitae nunc.</li>
+      </ul>
+    </p>
+    <amp-ad data-slot="/701/wpni.amp.opinions/blog/plum-line" height="250" layout="fixed" type="doubleclick" width="300"></amp-ad>
+    <amp-ad data-slot="/701/wpni.amp.opinions/blog/plum-line" height="250" layout="fixed" type="doubleclick" width="300"></amp-ad>
+    <amp-ad data-slot="/701/wpni.amp.opinions/blog/plum-line" height="250" layout="fixed" type="doubleclick" width="300"></amp-ad>
+  </div>
+</body>
+
+</html>

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -145,6 +145,7 @@ export const AnalyticsTrigger = {
   AD_RENDER_START: 'ad-render-start',
   AD_RENDER_END: 'ad-render-end',
   AD_IFRAME_LOADED: 'ad-iframe-loaded',
+  AD_REFRESH: 'ad-refresh',
 };
 
 /**
@@ -161,6 +162,7 @@ const LIFECYCLE_STAGE_TO_ANALYTICS_TRIGGER = {
   'renderCrossDomainEnd': AnalyticsTrigger.AD_RENDER_END,
   'friendlyIframeIniLoad': AnalyticsTrigger.AD_IFRAME_LOADED,
   'crossDomainIframeLoaded': AnalyticsTrigger.AD_IFRAME_LOADED,
+  'adRefresh': AnalyticsTrigger.AD_REFRESH,
 };
 
 /**
@@ -923,6 +925,9 @@ export class AmpA4A extends AMP.BaseElement {
         return;
       }
       return this.mutateElement(() => {
+        // Fire a event so that 3rd parties know an ad has changed.
+        this.maybeTriggerAnalyticsEvent_('adRefresh');
+
         this.togglePlaceholder(true);
         // This delay provides a 1 second buffer where the ad loader is
         // displayed in between the creatives.
@@ -1662,7 +1667,7 @@ export class AmpA4A extends AMP.BaseElement {
    * @private
    */
   maybeTriggerAnalyticsEvent_(lifecycleStage) {
-    if (!this.a4aAnalyticsConfig_) {
+    if (lifecycleStage !== 'adRefresh' && !this.a4aAnalyticsConfig_) {
       // No config exists that will listen to this event.
       return;
     }

--- a/extensions/amp-analytics/0.1/events.js
+++ b/extensions/amp-analytics/0.1/events.js
@@ -15,6 +15,7 @@
  */
 
 import {CommonSignals} from '../../../src/common-signals';
+import {Deferred} from '../../../src/utils/promise';
 import {Observable} from '../../../src/observable';
 import {
   PlayingStates,
@@ -97,6 +98,13 @@ const TRACKER_TYPE = Object.freeze({
     name: 'video',
     allowedFor: ALLOWED_FOR_ALL_ROOT_TYPES.concat(['timer']),
     klass: function(root) { return new VideoEventTracker(root); },
+  },
+  'unload': {
+    name: 'unload',
+    allowedFor: ALLOWED_FOR_ALL_ROOT_TYPES.concat(['timer', 'visible']),
+    klass: function(root) {
+      return new UnloadTracker(root);
+    },
   },
 });
 
@@ -519,6 +527,62 @@ export class IniLoadTracker extends EventTracker {
     return Promise.race([
       signals.whenSignal(CommonSignals.INI_LOAD),
       signals.whenSignal(CommonSignals.LOAD_END),
+    ]);
+  }
+}
+
+/**
+ * Tracks when the elements unlayoutCallback has been called or the
+ * window.beforeunload event has fired (lossy).
+ * @implements {SignalTrackerDef}
+ */
+export class UnloadTracker extends SignalTracker {
+  /** @override */
+  constructor(root) {
+    super(root);
+
+    // Create the promise to be resolved on the `beforeunload` event.
+    const deferred = new Deferred();
+    const {promise, resolve} = deferred;
+    this.beforeUnloadPromise = promise;
+
+    this.createUnloadListener_(resolve);
+  }
+
+  /**
+   * Creates a listener that resolves the `beforeUnloadPromise` on the
+   * `beforeunload` event.
+   * @param {Function} beforeUnloadResolver
+   */
+  createUnloadListener_(beforeUnloadResolver) {
+    const {ampdoc} = this.root;
+    const doc = ampdoc.getRootNode();
+    doc.addEventListener('beforeunload', () => {
+      beforeUnloadResolver();
+    });
+  }
+
+  /** @override */
+  getRootSignal(eventType) {
+    return Promise.race([
+      // `unload` signal sent by CumstomElement.unlayoutCallback.
+      this.root.signals().whenSignal(eventType),
+      // Listener for document.beforeunload event
+      this.beforeUnloadPromise,
+    ]);
+  }
+
+  /** @override */
+  getElementSignal(eventType, element) {
+    if (typeof element.signals != 'function') {
+      return Promise.resolve();
+    }
+    const signals = element.signals();
+    return Promise.race([
+      // `unload` signal sent by CumstomElement.unlayoutCallback.
+      signals.whenSignal(eventType),
+      // Listener for document.beforeunload event
+      this.beforeUnloadPromise,
     ]);
   }
 }

--- a/extensions/amp-analytics/0.1/test/test-events.js
+++ b/extensions/amp-analytics/0.1/test/test-events.js
@@ -24,6 +24,7 @@ import {
   IniLoadTracker,
   SignalTracker,
   TimerEventTracker,
+  UnloadTracker,
   VisibilityTracker,
 } from '../events';
 import {Signals} from '../../../../src/utils/signals';
@@ -535,6 +536,94 @@ describes.realWin('Events', {amp: 1}, env => {
       });
     });
   });
+
+
+  describe('UnloadTracker', () => {
+    let tracker;
+    let targetSignals;
+
+    beforeEach(() => {
+      tracker = root.getTracker('unload', UnloadTracker);
+      target.classList.add('i-amphtml-element');
+      targetSignals = new Signals();
+      target.signals = () => targetSignals;
+    });
+
+    it('should initalize, add listeners and dispose', () => {
+      expect(tracker.root).to.equal(root);
+    });
+
+    it('should add doc listener', () => {
+      let resolver;
+      const promise = new Promise(resolve => {
+        resolver = resolve;
+      });
+      tracker.add(analyticsElement, 'unload', {}, resolver);
+      root.signals().signal('unload');
+      return promise.then(event => {
+        expect(event.target).to.equal(root.getRootElement());
+        expect(event.type).to.equal('unload');
+      });
+    });
+
+    it('should add root listener', () => {
+      let resolver;
+      const promise = new Promise(resolve => {
+        resolver = resolve;
+      });
+      tracker.add(analyticsElement, 'unload', {selector: ':root'}, resolver);
+      root.signals().signal('unload');
+      return promise.then(event => {
+        expect(event.target).to.equal(root.getRootElement());
+        expect(event.type).to.equal('unload');
+      });
+    });
+
+    it('should add host listener equal to root', () => {
+      let resolver;
+      const promise = new Promise(resolve => {
+        resolver = resolve;
+      });
+      tracker.add(analyticsElement, 'unload', {selector: ':host'}, resolver);
+      root.signals().signal('unload');
+      return promise.then(event => {
+        expect(event.target).to.equal(root.getRootElement());
+        expect(event.type).to.equal('unload');
+      });
+    });
+
+    it('should add target listener', () => {
+      let resolver;
+      const promise = new Promise(resolve => {
+        resolver = resolve;
+      });
+      tracker.add(analyticsElement, 'unload', {selector: '.target'}, resolver);
+      targetSignals.signal('unload');
+      return promise.then(event => {
+        expect(event.target).to.equal(target);
+        expect(event.type).to.equal('unload');
+      });
+    });
+
+    it('should trigger via beforeunload event as well', () => {
+      let resolver;
+      const promise = new Promise(resolve => {
+        resolver = resolve;
+      });
+      tracker.add(analyticsElement, 'unload', {selector: ':root'},
+          resolver);
+
+      const e = new Event('beforeunload');
+      const doc = env.win.document;
+      doc.dispatchEvent(e);
+
+      return promise.then(event => {
+        expect(event.target).to.equal(tracker.root.getRootElement());
+        expect(event.type).to.equal('unload');
+      });
+    });
+  });
+
 
 
   describe('TimerEventTracker', () => {


### PR DESCRIPTION
Add new trigger that will fire on `CommonSignals.UNLOAD` (emitted during layoutCallback) and also `window.beforeunload` (best effort).

NOTE: when ads refresh `unlayoutCallback` is not executed. Therefore I added a new trigger called `ad-refresh` as well. I could make this part of the `unload` trigger, but it seemed different enough that I thought it deserved to be separate @zhouyx @lannka WDYT? 

Closes #14709