### PR TITLE
🐛 amp-next-page: Update URL with query string when switching documents

### DIFF
--- a/extensions/amp-next-page/0.1/next-page-service.js
+++ b/extensions/amp-next-page/0.1/next-page-service.js
@@ -447,10 +447,8 @@ export class NextPageService {
 
     const urlService = Services.urlForDoc(dev().assertElement(this.element_));
     const {title} = documentRef.amp;
-    const url = urlService.parse(documentRef.ampUrl);
-    // Strip the origin from the URL to get the path with query string.
-    const fullPath = documentRef.ampUrl.substr(url.origin.length);
-    this.win_.history.replaceState({}, title, fullPath);
+    const {pathname, search} = urlService.parse(documentRef.ampUrl);
+    this.win_.history.replaceState({}, title, pathname + search);
   }
 
   /**

--- a/extensions/amp-next-page/0.1/next-page-service.js
+++ b/extensions/amp-next-page/0.1/next-page-service.js
@@ -447,8 +447,10 @@ export class NextPageService {
 
     const urlService = Services.urlForDoc(dev().assertElement(this.element_));
     const {title} = documentRef.amp;
-    const {pathname} = urlService.parse(documentRef.ampUrl);
-    this.win_.history.replaceState({}, title, pathname);
+    const url = urlService.parse(documentRef.ampUrl);
+    // Strip the origin from the URL to get the path with query string.
+    const fullPath = documentRef.ampUrl.substr(url.origin.length);
+    this.win_.history.replaceState({}, title, fullPath);
   }
 
   /**


### PR DESCRIPTION
Currently calling `history.replaceState` with `url.pathname`, which doesn't include query parameters.

Fixes #16682