### PR TITLE
use canonical url instead of HREF 🐛

### DIFF
--- a/extensions/amp-a4a/0.1/callout-vendors.js
+++ b/extensions/amp-a4a/0.1/callout-vendors.js
@@ -78,7 +78,7 @@ export const RTC_VENDORS = {
     disableKeyAppend: true,
   },
   aps: {
-    url: 'https://aax.amazon-adsystem.com/e/dtb/bid?src=PUB_ID&amp=1&u=HREF&slots=%5B%7B%22sd%22%3A%22ATTR(data-slot)%22%2C%22s%22%3A%5B%22ATTR(width)xATTR(height)%22%5D%7D%5D&pj=PARAMS',
+    url: 'https://aax.amazon-adsystem.com/e/dtb/bid?src=PUB_ID&amp=1&u=CANONICAL_URL&slots=%5B%7B%22sd%22%3A%22ATTR(data-slot)%22%2C%22s%22%3A%5B%22ATTR(width)xATTR(height)%22%5D%7D%5D&pj=PARAMS',
     macros: ['PUB_ID', 'PARAMS'],
     disableKeyAppend: true,
   },


### PR DESCRIPTION
Description:

- Implemented CANONICAL_URL in aps callout vendor url instead of HREF

