### PR TITLE
✅ Skip `amp-bind` `in single ampdoc` tests since they cause the browser to crash

### DIFF
--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -334,7 +334,7 @@ const command = {
     }
     if (process.env.TRAVIS) {
       if (coverage) {
-        timedExecOrDie(cmd + ' --coverage');
+        timedExecOrDie(cmd + ' --headless --coverage');
       } else {
         startSauceConnect();
         timedExecOrDie(cmd + ' --saucelabs');

--- a/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
@@ -237,7 +237,8 @@ describe.configure().ifNewChrome().run('Bind', function() {
     });
   }); // in shadow ampdoc
 
-  describes.realWin('in single ampdoc', {
+  // TODO(choumx, #16721): These tests cause the browser to crash.
+  describes.realWin.skip('in single ampdoc', {
     amp: {
       ampdoc: 'single',
       runtimeOn: false,


### PR DESCRIPTION
Mitigates #16721

Also runs integration tests in headless mode, like everywhere else.