### PR TITLE
Fix yarn.lock

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2357,6 +2357,10 @@ caniuse-lite@^1.0.30000844:
   version "1.0.30000846"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000846.tgz#2092911eecad71a89dae1faa62bcc202fde7f959"
 
+caniuse-lite@^1.0.30000859:
+  version "1.0.30000865"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000865.tgz#70026616e8afe6e1442f8bb4e1092987d81a2f25"
+
 caniuse-lite@^1.0.30000864:
   version "1.0.30000864"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000864.tgz#7a08c78da670f23c06f11aa918831b8f2dd60ddc"


### PR DESCRIPTION
I just merged some Renovate PRs that hadn't been merged by previous build cops. This resulted in a conflict between two PRs that updated different packages with a shared dependency (at different versions).

This sometimes happens if PRs that update `yarn.lock` are allowed to become stale, and then merged later.

This PR fixes `yarn.lock` by running `yarn` and checking in the changes.