### PR TITLE
✨Add new `ad-refresh` trigger

### DIFF
--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -145,6 +145,8 @@ export const AnalyticsTrigger = {
   AD_RENDER_START: 'ad-render-start',
   AD_RENDER_END: 'ad-render-end',
   AD_IFRAME_LOADED: 'ad-iframe-loaded',
+  // This trigger is not part of the normal ads lifecycle and only fires when an
+  // ad is refreshed.
   AD_REFRESH: 'ad-refresh',
 };
 

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -162,7 +162,6 @@ const LIFECYCLE_STAGE_TO_ANALYTICS_TRIGGER = {
   'renderCrossDomainEnd': AnalyticsTrigger.AD_RENDER_END,
   'friendlyIframeIniLoad': AnalyticsTrigger.AD_IFRAME_LOADED,
   'crossDomainIframeLoaded': AnalyticsTrigger.AD_IFRAME_LOADED,
-  'adRefresh': AnalyticsTrigger.AD_REFRESH,
 };
 
 /**
@@ -927,7 +926,7 @@ export class AmpA4A extends AMP.BaseElement {
       return this.mutateElement(() => {
         // Fire an ad-refresh event so that 3rd parties can track when an ad
         // has changed.
-        this.maybeTriggerAnalyticsEvent_('adRefresh');
+        triggerAnalyticsEvent(AnalyticsTrigger.AD_REFRESH);
 
         this.togglePlaceholder(true);
         // This delay provides a 1 second buffer where the ad loader is
@@ -1668,9 +1667,8 @@ export class AmpA4A extends AMP.BaseElement {
    * @private
    */
   maybeTriggerAnalyticsEvent_(lifecycleStage) {
-    if (lifecycleStage !== 'adRefresh' && !this.a4aAnalyticsConfig_) {
-      // The ad-refesh analtyics will not be contained within the ad. Otherwise
-      // no config exists that will listen to this event.
+    if (!this.a4aAnalyticsConfig_) {
+      // No config exists that will listen to this event.
       return;
     }
     const analyticsEvent =

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -926,7 +926,7 @@ export class AmpA4A extends AMP.BaseElement {
       return this.mutateElement(() => {
         // Fire an ad-refresh event so that 3rd parties can track when an ad
         // has changed.
-        triggerAnalyticsEvent(AnalyticsTrigger.AD_REFRESH);
+        triggerAnalyticsEvent(this.element, AnalyticsTrigger.AD_REFRESH);
 
         this.togglePlaceholder(true);
         // This delay provides a 1 second buffer where the ad loader is

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -145,6 +145,7 @@ export const AnalyticsTrigger = {
   AD_RENDER_START: 'ad-render-start',
   AD_RENDER_END: 'ad-render-end',
   AD_IFRAME_LOADED: 'ad-iframe-loaded',
+  AD_REFRESH: 'ad-refresh',
 };
 
 /**
@@ -161,6 +162,7 @@ const LIFECYCLE_STAGE_TO_ANALYTICS_TRIGGER = {
   'renderCrossDomainEnd': AnalyticsTrigger.AD_RENDER_END,
   'friendlyIframeIniLoad': AnalyticsTrigger.AD_IFRAME_LOADED,
   'crossDomainIframeLoaded': AnalyticsTrigger.AD_IFRAME_LOADED,
+  'adRefresh': AnalyticsTrigger.AD_REFRESH,
 };
 
 /**
@@ -923,6 +925,10 @@ export class AmpA4A extends AMP.BaseElement {
         return;
       }
       return this.mutateElement(() => {
+        // Fire an ad-refresh event so that 3rd parties can track when an ad
+        // has changed.
+        this.maybeTriggerAnalyticsEvent_('adRefresh');
+
         this.togglePlaceholder(true);
         // This delay provides a 1 second buffer where the ad loader is
         // displayed in between the creatives.
@@ -1662,8 +1668,9 @@ export class AmpA4A extends AMP.BaseElement {
    * @private
    */
   maybeTriggerAnalyticsEvent_(lifecycleStage) {
-    if (!this.a4aAnalyticsConfig_) {
-      // No config exists that will listen to this event.
+    if (lifecycleStage !== 'adRefresh' && !this.a4aAnalyticsConfig_) {
+      // The ad-refesh analtyics will not be contained within the ad. Otherwise
+      // no config exists that will listen to this event.
       return;
     }
     const analyticsEvent =

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -2290,6 +2290,7 @@ describe('amp-a4a', () => {
         tearDownSlotMock.returns(undefined);
         const destroyFrameMock = sandbox.stub(AmpA4A.prototype, 'destroyFrame');
         destroyFrameMock.returns(undefined);
+        sandbox.stub(analytics, 'triggerAnalyticsEvent');
 
         expect(a4a.isRefreshing).to.be.false;
         return a4a.refresh(() => {}).then(() => {
@@ -2331,13 +2332,13 @@ describe('amp-a4a', () => {
         const destroyFrameMock = sandbox.stub(AmpA4A.prototype, 'destroyFrame');
         destroyFrameMock.returns(undefined);
 
-        const triggerAnalyticsEventSpy = sandbox.spy(analytics,
+        const triggerAnalyticsEventStub = sandbox.stub(analytics,
             'triggerAnalyticsEvent');
 
         expect(a4a.isRefreshing).to.be.false;
         return a4a.refresh(() => {}).then(() => {
-          expect(triggerAnalyticsEventSpy).calledWith(a4a.element, 'ad-refresh',
-              {time: sinon.match.number});
+          expect(triggerAnalyticsEventStub)
+              .calledWith(a4a.element, 'ad-refresh');
         });
       });
     });


### PR DESCRIPTION
Follow up to #16689 

It seems like the `unload` portion of the previous PR may not be necessary. This pulls out just the `ad-refresh` trigger which is fired on the `refresh()` method in `a4a`.  

Is this enough to satisfy our requirements?