### PR TITLE
Unskip most bind-impl.js tests

### DIFF
--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -774,7 +774,7 @@ export class Bind {
       } else {
         const err = user().createError(
             `${TAG}: Binding to [${property}] on <${tag}> is not allowed.`);
-        reportError(err, element);
+        this.reportError_(err, element);
       }
     }
     return null;
@@ -821,7 +821,7 @@ export class Bind {
               `${TAG}: Expression evaluation error in "${expressionString}". `
               + evalError.message);
           userError.stack = evalError.stack;
-          reportError(userError, elements[0]);
+          this.reportError_(userError, elements[0]);
         }
       });
       dev().fine(TAG, 'bindings:', results);
@@ -1011,7 +1011,7 @@ export class Bind {
         } catch (e) {
           const error = user().createError(`${TAG}: Applying expression ` +
               `results (${JSON.stringify(mutations)}) failed with error`, e);
-          reportError(error, element);
+          this.reportError_(error, element);
         }
       }
     });
@@ -1061,7 +1061,7 @@ export class Bind {
         } else {
           const err = user().createError(
               `${TAG}: "${newValue}" is not a valid result for [class].`);
-          reportError(err, element);
+          this.reportError_(err, element);
         }
         break;
 
@@ -1123,7 +1123,7 @@ export class Bind {
     } catch (e) {
       const error = user().createError(`${TAG}: "${value}" is not a ` +
           `valid result for [${attrName}]`, e);
-      reportError(error, element);
+      this.reportError_(error, element);
     }
     return false;
   }
@@ -1180,7 +1180,7 @@ export class Bind {
         } else {
           const err = user().createError(
               `${TAG}: "${expectedValue}" is not a valid result for [class].`);
-          reportError(err, element);
+          this.reportError_(err, element);
         }
         match = this.compareStringArrays_(initialValue, classes);
         break;
@@ -1258,8 +1258,19 @@ export class Bind {
   reportWorkerError_(e, message, opt_element) {
     const userError = user().createError(message + ' ' + e.message);
     userError.stack = e.stack;
-    reportError(userError, opt_element);
+    this.reportError_(userError, opt_element);
     return userError;
+  }
+
+  /**
+   * @param {!Error} error
+   * @param {!Element=} opt_element
+   */
+  reportError_(error, opt_element) {
+    if (getMode().test) {
+      return;
+    }
+    reportError(error, opt_element);
   }
 
   /**

--- a/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
@@ -237,8 +237,7 @@ describe.configure().ifNewChrome().run('Bind', function() {
     });
   }); // in shadow ampdoc
 
-  // TODO(choumx, #16721): These tests cause the browser to crash.
-  describes.realWin.skip('in single ampdoc', {
+  describes.realWin('in single ampdoc', {
     amp: {
       ampdoc: 'single',
       runtimeOn: false,
@@ -565,11 +564,11 @@ describe.configure().ifNewChrome().run('Bind', function() {
           '{foo: bar}', sinon.match({event: {bar: 123}}));
     });
 
-    it('should only allow one action per event in invoke()', () => {
+    // TODO(choumx, #16721): Causes browser crash for some reason.
+    it.skip('should only allow one action per event in invoke()', () => {
       const {sandbox} = env;
       sandbox.stub(bind, 'setStateWithExpression');
       const userError = sandbox.stub(user(), 'error');
-
 
       const invocation = {
         method: 'setState',


### PR DESCRIPTION
Found the one test that was causing the browser crash. Also avoid async errors due to calls to `reportError()` during testing.

/to @rsimha 