### PR TITLE
Remove references to Slack on the support page

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -9,7 +9,7 @@ If you are looking for help to get started using AMP on your site or you are hav
 *   [ampproject.org](https://www.ampproject.org/docs) provides guides and tutorials to help you learn about AMP.
 *   [AMP by Example](https://ampbyexample.com/) provides hands-on samples and demos for using AMP components.
 *   [AMP Start](https://ampstart.com/) provides pre-styled templates and components that you can use to create styled AMP sites from scratch.
-*   [Stack Overflow](http://stackoverflow.com/questions/tagged/amp-html) is our recommended way to find answers to questions about AMP; since members of the AMP Project community regularly monitor Stack Overflow you will probably receive the fastest response to your questions there. If you can't find answers there, the [#using-amp](https://amphtml.slack.com/messages/C9HPA6HGB/details/) Slack channel<a href="#note1"><sup>[1]</sup></a> is available for discussions and questions.  
+*   [Stack Overflow](http://stackoverflow.com/questions/tagged/amp-html) is our recommended way to find answers to questions about AMP; since members of the AMP Project community regularly monitor Stack Overflow you will probably receive the fastest response to your questions there.
 *   For AMP on Google Search questions or issues, please use [Google's AMP forum](https://goo.gl/utQ1KZ).
 *   To check the status of AMP serving and its related services, see the [AMP Status](https://status.ampproject.org/) page.
 
@@ -19,10 +19,4 @@ If you encounter a bug in AMP or have a feature request for AMP, see [Reporting 
 
 **Contributing to AMP?**
 
-*   Read [Contributing to AMP HTML](https://github.com/ampproject/amphtml/blob/master/CONTRIBUTING.md#ongoing-participation), which provides details on ways you can contribute to the AMP Project.
-*   For questions and discussions about about *contributing to the open source project*, reach out to the [#contributing](https://amphtml.slack.com/messages/C9HRJ1GPN/details/) Slack channel<a href="#note1"><sup>[1]</sup></a> .
-
-
-
-
-<span id="note1"><sup>[1]</sup></span>To access our AMP Slack channels, you must first [sign up](https://bit.ly/amp-slack-signup).
+[Contributing to AMP HTML](https://github.com/ampproject/amphtml/blob/master/CONTRIBUTING.md#ongoing-participation) is a great place to find out how you can make contributions to the AMP open source project and how you can get help if you run into questions when contributing to AMP.


### PR DESCRIPTION
This PR removes references to Slack from our support page:

- For users of AMP we've found Slack is not providing a great experience when they have questions because it is not actively monitored and many questions go unanswered.  Stack Overflow has better support overall for these questions (with the added benefit that answers to questions there benefit everyone using AMP).
- For people contributing to AMP we will continue using Slack, but the linked "Contributing to AMP HTML" page has instructions for joining Slack and using the channels.  To avoid confusion with people looking for support using AMP we'll remove that reference from this page.

/cc @pbakaus @rudygalfi