### PR TITLE
🐛🏗 Indentation fixes based on the new (more accurate) `eslint` implementation of the `indent` rule

### DIFF
--- a/3p/iframe-transport-client.js
+++ b/3p/iframe-transport-client.js
@@ -93,7 +93,7 @@ export class IframeTransportClient {
     return this.creativeIdToContext_[creativeId] ||
         (this.creativeIdToContext_[creativeId] =
             new IframeTransportContext(this.win_, this.iframeMessagingClient_,
-              creativeId, this.vendor_));
+                creativeId, this.vendor_));
   }
 
   /**

--- a/ads/google/a4a/experiment-utils.js
+++ b/ads/google/a4a/experiment-utils.js
@@ -54,7 +54,7 @@ export class ExperimentUtils {
   maybeSelectExperiment(
     win, element, selectionBranches, experimentName) {
     const experimentInfoMap =
-        /** @type {!Object<string, !ExperimentInfo>} */ ({});
+    /** @type {!Object<string, !ExperimentInfo>} */ ({});
     experimentInfoMap[experimentName] = {
       isTrafficEligible: () => true,
       branches: selectionBranches,

--- a/ads/google/a4a/line-delimited-response-handler.js
+++ b/ads/google/a4a/line-delimited-response-handler.js
@@ -77,7 +77,7 @@ export function metaJsonCreativeGrouper(callback) {
   return function(line, done) {
     if (first) {
       const metadata =
-          /** @type {!Object<string, *>} */(tryParseJson(first) || {});
+      /** @type {!Object<string, *>} */(tryParseJson(first) || {});
       const lowerCasedMetadata =
           Object.keys(metadata).reduce((newObj, key) => {
             newObj[key.toLowerCase()] = metadata[key];

--- a/ads/google/a4a/url-builder.js
+++ b/ads/google/a4a/url-builder.js
@@ -55,7 +55,7 @@ export function buildUrl(
     if (fullLength > capacity) {
       const truncatedValue = encodedValue
           .substr(0, capacity - encodedNameAndSep.length - 1)
-        // Don't end with a partially truncated escape sequence
+      // Don't end with a partially truncated escape sequence
           .replace(/%\w?$/, '');
       if (truncatedValue) {
         encodedParams.push(encodedNameAndSep + truncatedValue);

--- a/ads/nativo.js
+++ b/ads/nativo.js
@@ -106,8 +106,8 @@ export function nativo(global, data) {
       setPercentageOfadViewed(
           (((coordinates.intersectionRect
               .height * 100) / coordinates
-                .boundingClientRect
-                .height) / 100));
+              .boundingClientRect
+              .height) / 100));
       global.PostRelease.checkIsAdVisible();
     }
     // Public

--- a/build-system/config.js
+++ b/build-system/config.js
@@ -108,7 +108,7 @@ module.exports = {
     '**/*.js',
     '!**/*.extern.js',
     '!{node_modules,build,dist,dist.3p,dist.tools,' +
-        'third_party}/**/*.*',
+        'third_party,test/coverage}/**/*.*',
     '!examples/**/*.*',
     '!{validator/dist,validator/webui/dist,' +
         'validator/node_modules,validator/nodejs/node_modules,' +

--- a/extensions/amp-a4a/0.1/template-validator.js
+++ b/extensions/amp-a4a/0.1/template-validator.js
@@ -73,7 +73,7 @@ export class TemplateValidator extends Validator {
     }
 
     const parsedResponseBody =
-        /** @type {!./amp-ad-type-defs.AmpTemplateCreativeDef} */ (
+    /** @type {!./amp-ad-type-defs.AmpTemplateCreativeDef} */ (
         tryParseJson(body) || {});
     return getAmpAdTemplateHelper(context.win)
         .fetch(parsedResponseBody.templateUrl)

--- a/extensions/amp-ad-exit/0.1/amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/amp-ad-exit.js
@@ -133,7 +133,7 @@ export class AmpAdExit extends AMP.BaseElement {
           continue;
         }
         const customVar =
-            /** @type {!./config.VariableDef} */ (target.vars[customVarName]);
+        /** @type {!./config.VariableDef} */ (target.vars[customVarName]);
         if (!customVar) {
           continue;
         }

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -237,7 +237,7 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
    */
   divertExperiments() {
     const experimentInfoMap =
-        /** @type {!Object<string,
+    /** @type {!Object<string,
         !../../../src/experiments.ExperimentInfo>} */ ({
         [FORMAT_EXP]: {
           isTrafficEligible: () => !this.isResponsive_() &&

--- a/extensions/amp-ad-network-fake-impl/0.1/amp-ad-network-fake-impl.js
+++ b/extensions/amp-ad-network-fake-impl/0.1/amp-ad-network-fake-impl.js
@@ -61,7 +61,7 @@ export class AmpAdNetworkFakeImpl extends AmpA4A {
         return null;
       }
       const {status, headers} =
-          /** @type {{status: number, headers: !Headers}} */ (response);
+      /** @type {{status: number, headers: !Headers}} */ (response);
 
       // In the convert creative mode the content is the plain AMP HTML.
       // This mode is primarily used for A4A Envelop for testing.

--- a/extensions/amp-analytics/0.1/iframe-transport.js
+++ b/extensions/amp-analytics/0.1/iframe-transport.js
@@ -174,22 +174,22 @@ export class IframeTransport {
     // TODO(jonkeller): Consider merging with jank-meter.js
     IframeTransport.performanceObservers_[this.type_] =
         new this.ampWin_.PerformanceObserver(entryList => {
-        if (!entryList) {
-          return;
-        }
-        entryList.getEntries().forEach(entry => {
-          if (entry && entry['entryType'] == 'longtask' &&
+          if (!entryList) {
+            return;
+          }
+          entryList.getEntries().forEach(entry => {
+            if (entry && entry['entryType'] == 'longtask' &&
               (entry['name'] == 'cross-origin-descendant') &&
               entry.attribution) {
-            entry.attribution.forEach(attrib => {
-              if (this.frameUrl_ == attrib.containerSrc &&
+              entry.attribution.forEach(attrib => {
+                if (this.frameUrl_ == attrib.containerSrc &&
                     ++this.numLongTasks_ % LONG_TASK_REPORTING_THRESHOLD == 0) {
-                user().error(TAG_, `Long Task: Vendor: "${this.type_}"`);
-              }
-            });
-          }
+                  user().error(TAG_, `Long Task: Vendor: "${this.type_}"`);
+                }
+              });
+            }
+          });
         });
-      });
     IframeTransport.performanceObservers_[this.type_].observe({
       entryTypes: ['longtask'],
     });

--- a/extensions/amp-analytics/0.1/vendors.js
+++ b/extensions/amp-analytics/0.1/vendors.js
@@ -2204,7 +2204,7 @@ ANALYTICS_CONFIG['infonline']['triggers']['pageview']['iframe' +
 
 ANALYTICS_CONFIG['adobeanalytics_nativeConfig']
     ['triggers']['pageLoad']['iframe' +
-      /* TEMPORARY EXCEPTION */ 'Ping'] = true;
+    /* TEMPORARY EXCEPTION */ 'Ping'] = true;
 
 ANALYTICS_CONFIG['oewa']['triggers']['pageview']['iframe' +
 /* TEMPORARY EXCEPTION */ 'Ping'] = true;

--- a/extensions/amp-next-page/0.1/next-page-service.js
+++ b/extensions/amp-next-page/0.1/next-page-service.js
@@ -140,7 +140,7 @@ export class NextPageService {
     this.resources_ = Services.resourcesForDoc(ampDoc);
     this.multidocManager_ =
         new MultidocManager(win, Services.ampdocServiceFor(win),
-          Services.extensionsFor(win), Services.timerFor(win));
+            Services.extensionsFor(win), Services.timerFor(win));
 
     installPositionObserverServiceForDoc(ampDoc);
     this.positionObserver_ = getServiceForDoc(ampDoc, 'position-observer');

--- a/extensions/amp-sidebar/0.1/test/test-toolbar.js
+++ b/extensions/amp-sidebar/0.1/test/test-toolbar.js
@@ -109,213 +109,213 @@ describe('amp-sidebar - toolbar', () => {
 
   it('toolbar header should error if target element \
    could not be found as it is required.', () => {
-        return getToolbars([{
-          targetError: true,
-        }]).then(() => {
-          expect(false).to.be.equal(true, 'Toolbar \
+    return getToolbars([{
+      targetError: true,
+    }]).then(() => {
+      expect(false).to.be.equal(true, 'Toolbar \
        should not be created when the target element is not found');
-        }).catch(() => {
-          expect(true).to.be.ok;
-        });
-      });
+    }).catch(() => {
+      expect(true).to.be.ok;
+    });
+  });
 
   it('toolbar header should be hidden for a \
    non-matching window size for (min-width: 768px)', () => {
-        return getToolbars([{}]).then(obj => {
-          const {toolbars} = obj;
-          resizeIframeToWidth(obj.iframe, '1024px', () => {
-            toolbars.forEach(toolbar => {
-              toolbar.onLayoutChange();
-            });
-            const toolbarElements =
+    return getToolbars([{}]).then(obj => {
+      const {toolbars} = obj;
+      resizeIframeToWidth(obj.iframe, '1024px', () => {
+        toolbars.forEach(toolbar => {
+          toolbar.onLayoutChange();
+        });
+        const toolbarElements =
                 toArray(obj.ampdoc.getRootNode()
                     .getElementsByClassName('i-amphtml-toolbar'));
-            resizeIframeToWidth(obj.iframe, '1px', () => {
-              toolbars.forEach(toolbar => {
-                toolbar.onLayoutChange();
-              });
-              expect(toolbarElements.length).to.be.above(0);
-              expect(toolbarElements[0].parentElement.style.display)
-                  .to.be.equal('none');
-            });
+        resizeIframeToWidth(obj.iframe, '1px', () => {
+          toolbars.forEach(toolbar => {
+            toolbar.onLayoutChange();
           });
+          expect(toolbarElements.length).to.be.above(0);
+          expect(toolbarElements[0].parentElement.style.display)
+              .to.be.equal('none');
         });
       });
+    });
+  });
 
   it('toolbar header should be shown for a \
    matching window size for (min-width: 768px)', () => {
-        return getToolbars([{}]).then(obj => {
-          const {toolbars} = obj;
-          resizeIframeToWidth(obj.iframe, '4000px', () => {
-            toolbars.forEach(toolbar => {
-              toolbar.onLayoutChange();
-            });
-            const toolbarElements =
+    return getToolbars([{}]).then(obj => {
+      const {toolbars} = obj;
+      resizeIframeToWidth(obj.iframe, '4000px', () => {
+        toolbars.forEach(toolbar => {
+          toolbar.onLayoutChange();
+        });
+        const toolbarElements =
                 toArray(obj.ampdoc.getRootNode()
                     .getElementsByClassName('i-amphtml-toolbar'));
-            expect(toolbarElements.length).to.be.above(0);
-            expect(toolbarElements[0].parentElement.style.display)
-                .to.be.equal('');
-          });
-        });
+        expect(toolbarElements.length).to.be.above(0);
+        expect(toolbarElements[0].parentElement.style.display)
+            .to.be.equal('');
       });
+    });
+  });
 
   it('toolbar should be placed into a target, with the \
    target attrbiute', () => {
-        const targetId = 'toolbar-target';
-        return getToolbars([{
-          'toolbar-target': targetId,
-        }]).then(obj => {
-          const {toolbars} = obj;
-          resizeIframeToWidth(obj.iframe, '1024px', () => {
-            toolbars.forEach(toolbar => {
-              toolbar.onLayoutChange();
-            });
-            const toolbarQuery = `#${targetId} > nav[toolbar]`;
-            const toolbarTargetElements =
+    const targetId = 'toolbar-target';
+    return getToolbars([{
+      'toolbar-target': targetId,
+    }]).then(obj => {
+      const {toolbars} = obj;
+      resizeIframeToWidth(obj.iframe, '1024px', () => {
+        toolbars.forEach(toolbar => {
+          toolbar.onLayoutChange();
+        });
+        const toolbarQuery = `#${targetId} > nav[toolbar]`;
+        const toolbarTargetElements =
                 toArray(obj.ampdoc.getRootNode()
                     .querySelectorAll(toolbarQuery));
-            expect(toolbars.length).to.be.equal(1);
-            expect(toolbarTargetElements.length).to.be.equal(1);
-          });
-        });
+        expect(toolbars.length).to.be.equal(1);
+        expect(toolbarTargetElements.length).to.be.equal(1);
       });
+    });
+  });
 
   it('toolbar should be placed into a target, and shown for a \
    matching window size for (min-width: 768px)', () => {
-        const targetId = 'toolbar-target';
-        return getToolbars([{
-          'toolbar-target': targetId,
-        }]).then(obj => {
-          const {toolbars} = obj;
-          const toolbarTargets =
+    const targetId = 'toolbar-target';
+    return getToolbars([{
+      'toolbar-target': targetId,
+    }]).then(obj => {
+      const {toolbars} = obj;
+      const toolbarTargets =
                 toArray(obj.ampdoc.getRootNode()
                     .querySelectorAll(`#${targetId}`));
-          resizeIframeToWidth(obj.iframe, '4000px', () => {
-            toolbars.forEach(toolbar => {
-              toolbar.onLayoutChange();
-            });
-            expect(toolbars.length).to.be.equal(1);
-            expect(toolbarTargets.length).to.be.equal(1);
-            expect(toolbarTargets[0].style.display)
-                .to.be.equal('');
-          });
+      resizeIframeToWidth(obj.iframe, '4000px', () => {
+        toolbars.forEach(toolbar => {
+          toolbar.onLayoutChange();
         });
+        expect(toolbars.length).to.be.equal(1);
+        expect(toolbarTargets.length).to.be.equal(1);
+        expect(toolbarTargets[0].style.display)
+            .to.be.equal('');
       });
+    });
+  });
 
   it('toolbar should be placed into a target, and hidden for a \
    non-matching window size for (min-width: 768px)', () => {
-        const targetId = 'toolbar-target';
-        return getToolbars([{
-          'toolbar-target': targetId,
-        }]).then(obj => {
-          const {toolbars} = obj;
-          const toolbarTargets =
+    const targetId = 'toolbar-target';
+    return getToolbars([{
+      'toolbar-target': targetId,
+    }]).then(obj => {
+      const {toolbars} = obj;
+      const toolbarTargets =
                 toArray(obj.ampdoc.getRootNode()
                     .querySelectorAll(`#${targetId}`));
-          resizeIframeToWidth(obj.iframe, '200px', () => {
-            toolbars.forEach(toolbar => {
-              toolbar.onLayoutChange();
-            });
-            expect(toolbars.length).to.be.equal(1);
-            expect(toolbarTargets.length).to.be.equal(1);
-            expect(toolbarTargets[0].style.display)
-                .to.be.equal('none');
-          });
+      resizeIframeToWidth(obj.iframe, '200px', () => {
+        toolbars.forEach(toolbar => {
+          toolbar.onLayoutChange();
         });
+        expect(toolbars.length).to.be.equal(1);
+        expect(toolbarTargets.length).to.be.equal(1);
+        expect(toolbarTargets[0].style.display)
+            .to.be.equal('none');
       });
+    });
+  });
 
   it('should add the "amp-sidebar-toolbar-target-shown" state class, \
    for matching window size of (min-width: 768px)', () => {
-        return getToolbars([{
-          toolbarOnlyOnNav: true,
-        }]).then(obj => {
-          const {toolbars} = obj;
-          resizeIframeToWidth(obj.iframe, '4000px', () => {
-            toolbars.forEach(toolbar => {
-              toolbar.onLayoutChange();
-            });
-            const toolbarNavElementsWithState =
+    return getToolbars([{
+      toolbarOnlyOnNav: true,
+    }]).then(obj => {
+      const {toolbars} = obj;
+      resizeIframeToWidth(obj.iframe, '4000px', () => {
+        toolbars.forEach(toolbar => {
+          toolbar.onLayoutChange();
+        });
+        const toolbarNavElementsWithState =
                 toArray(obj.ampdoc.getRootNode()
                     .querySelectorAll(
                         'nav[toolbar].amp-sidebar-toolbar-target-shown'
                     ));
-            expect(toolbarNavElementsWithState.length).to.be.equal(1);
-            expect(toolbars.length).to.be.equal(1);
-          });
-        });
+        expect(toolbarNavElementsWithState.length).to.be.equal(1);
+        expect(toolbars.length).to.be.equal(1);
       });
+    });
+  });
 
   it('should add the "amp-sidebar-toolbar-target-hidden" state class, \
    for non-matching window size of (min-width: 768px)', () => {
-        return getToolbars([{
-          toolbarOnlyOnNav: true,
-        }]).then(obj => {
-          const {toolbars} = obj;
-          resizeIframeToWidth(obj.iframe, '0px', () => {
-            toolbars.forEach(toolbar => {
-              toolbar.onLayoutChange();
-            });
-            const toolbarNavElementsWithState =
+    return getToolbars([{
+      toolbarOnlyOnNav: true,
+    }]).then(obj => {
+      const {toolbars} = obj;
+      resizeIframeToWidth(obj.iframe, '0px', () => {
+        toolbars.forEach(toolbar => {
+          toolbar.onLayoutChange();
+        });
+        const toolbarNavElementsWithState =
                 toArray(obj.ampdoc.getRootNode()
                     .querySelectorAll(
                         'nav[toolbar].amp-sidebar-toolbar-target-hidden'
                     ));
-            expect(toolbarNavElementsWithState.length).to.be.equal(1);
-            expect(toolbars.length).to.be.equal(1);
-          });
-        });
+        expect(toolbarNavElementsWithState.length).to.be.equal(1);
+        expect(toolbars.length).to.be.equal(1);
       });
+    });
+  });
 
   it('toolbar should be in the hidden state \
    when it is not being displayed', () => {
-        return getToolbars([{}]).then(obj => {
-          const {toolbars} = obj;
-          resizeIframeToWidth(obj.iframe, '1px', () => {
-            toolbars.forEach(toolbar => {
-              toolbar.onLayoutChange();
-              expect(toolbar.isToolbarShown_()).to.be.false;
-            });
-          });
+    return getToolbars([{}]).then(obj => {
+      const {toolbars} = obj;
+      resizeIframeToWidth(obj.iframe, '1px', () => {
+        toolbars.forEach(toolbar => {
+          toolbar.onLayoutChange();
+          expect(toolbar.isToolbarShown_()).to.be.false;
         });
       });
+    });
+  });
 
   it('toolbar should be in the shown state \
    when it is being displayed', () => {
-        return getToolbars([{}]).then(obj => {
-          const {toolbars} = obj;
-          resizeIframeToWidth(obj.iframe, '4000px', () => {
-            toolbars.forEach(toolbar => {
-              toolbar.onLayoutChange();
-              expect(toolbar.isToolbarShown_()).to.be.true;
-            });
-          });
+    return getToolbars([{}]).then(obj => {
+      const {toolbars} = obj;
+      resizeIframeToWidth(obj.iframe, '4000px', () => {
+        toolbars.forEach(toolbar => {
+          toolbar.onLayoutChange();
+          expect(toolbar.isToolbarShown_()).to.be.true;
         });
       });
+    });
+  });
 
   it('toolbar should not be able to be shown \
    if already in the shown state', () => {
-        return getToolbars([{}]).then(obj => {
-          const {toolbars} = obj;
-          resizeIframeToWidth(obj.iframe, '4000px', () => {
-            toolbars.forEach(toolbar => {
-              toolbar.onLayoutChange();
-              expect(toolbar.isToolbarShown_()).to.be.true;
-            });
-          });
+    return getToolbars([{}]).then(obj => {
+      const {toolbars} = obj;
+      resizeIframeToWidth(obj.iframe, '4000px', () => {
+        toolbars.forEach(toolbar => {
+          toolbar.onLayoutChange();
+          expect(toolbar.isToolbarShown_()).to.be.true;
         });
       });
+    });
+  });
 
   it('toolbar should be able to be shown \
    if not in the shown state, and return a promise', () => {
-        return getToolbars([{}]).then(obj => {
-          const {toolbars} = obj;
-          resizeIframeToWidth(obj.iframe, '1px', () => {
-            toolbars.forEach(toolbar => {
-              toolbar.onLayoutChange();
-              expect(toolbar).to.exist;
-            });
-          });
+    return getToolbars([{}]).then(obj => {
+      const {toolbars} = obj;
+      resizeIframeToWidth(obj.iframe, '1px', () => {
+        toolbars.forEach(toolbar => {
+          toolbar.onLayoutChange();
+          expect(toolbar).to.exist;
         });
       });
+    });
+  });
 });

--- a/extensions/amp-story/0.1/localization.js
+++ b/extensions/amp-story/0.1/localization.js
@@ -164,7 +164,7 @@ export function createPseudoLocale(localizedStringBundle, localizationFn) {
 
   Object.keys(pseudoLocaleStringBundle).forEach(localizedStringIdAsStr => {
     const localizedStringId =
-        /** @type {!LocalizedStringId} */ (localizedStringIdAsStr);
+    /** @type {!LocalizedStringId} */ (localizedStringIdAsStr);
     pseudoLocaleStringBundle[localizedStringId].string =
         localizationFn(localizedStringBundle[localizedStringId].string);
   });

--- a/extensions/amp-story/1.0/amp-story-access.js
+++ b/extensions/amp-story/1.0/amp-story-access.js
@@ -157,7 +157,7 @@ export class AmpStoryAccess extends AMP.BaseElement {
 
     // Configuration validation is handled by the amp-access extension.
     let accessConfig =
-        /** @type {!Array|!Object} */ (parseJson(accessEl.textContent));
+    /** @type {!Array|!Object} */ (parseJson(accessEl.textContent));
 
     if (!isArray(accessConfig)) {
       accessConfig = [accessConfig];

--- a/extensions/amp-story/1.0/localization.js
+++ b/extensions/amp-story/1.0/localization.js
@@ -164,7 +164,7 @@ export function createPseudoLocale(localizedStringBundle, localizationFn) {
 
   Object.keys(pseudoLocaleStringBundle).forEach(localizedStringIdAsStr => {
     const localizedStringId =
-        /** @type {!LocalizedStringId} */ (localizedStringIdAsStr);
+    /** @type {!LocalizedStringId} */ (localizedStringIdAsStr);
     pseudoLocaleStringBundle[localizedStringId].string =
         localizationFn(localizedStringBundle[localizedStringId].string);
   });

--- a/src/service/position-observer/position-observer-worker.js
+++ b/src/service/position-observer/position-observer-worker.js
@@ -90,7 +90,7 @@ export class PositionObserverWorker {
     dev().assert(position.positionRect,
         'PositionObserver should always trigger entry with clientRect');
     const positionRect =
-        /** @type {!../../layout-rect.LayoutRectDef} */ (position.positionRect);
+    /** @type {!../../layout-rect.LayoutRectDef} */ (position.positionRect);
     // Add the relative position of the element to its viewport
     position.relativePos = layoutRectsRelativePos(positionRect,
         position.viewportRect);

--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -592,7 +592,7 @@ export class GlobalVariableSource extends VariableSource {
    */
   addReplaceParamsIfMissing_(orig) {
     const {replaceParams} =
-        /** @type {!Object} */ (Services.documentInfoForDoc(this.ampdoc));
+    /** @type {!Object} */ (Services.documentInfoForDoc(this.ampdoc));
     const url = parseUrlDeprecated(removeAmpJsParamsFromUrl(orig));
     const params = parseQueryString(url.search);
     return addParamsToUrl(removeSearch(orig),

--- a/src/service/xhr-impl.js
+++ b/src/service/xhr-impl.js
@@ -645,7 +645,7 @@ function createXhrRequest(method, url) {
     xhr.open(method, url, true);
   } else if (typeof XDomainRequest != 'undefined') {
     // IE-specific object.
-    xhr = new XDomainRequest();
+    xhr = new XDomainRequest(); // eslint-disable-line no-undef
     xhr.open(method, url);
   } else {
     throw dev().createExpectedError('CORS is not supported');

--- a/src/web-worker/amp-worker.js
+++ b/src/web-worker/amp-worker.js
@@ -155,7 +155,7 @@ class AmpWorker {
    */
   receiveMessage_(event) {
     const {method, returnValue, id} =
-        /** @type {FromWorkerMessageDef} */ (event.data);
+    /** @type {FromWorkerMessageDef} */ (event.data);
 
     const message = this.messages_[id];
     if (!message) {

--- a/test/functional/test-shadow-embed.js
+++ b/test/functional/test-shadow-embed.js
@@ -129,22 +129,22 @@ describes.sandboxed('shadow-embed', {}, () => {
             // Test scenarios where Shadow Css is not supported
             it('Should add an id and class for CSS \
               encapsulation to the shadow root', () => {
-                  setShadowCssSupportedForTesting(false);
-                  const shadowRoot = createShadowRoot(hostElement);
-                  expect(shadowRoot.id).to.match(/i-amphtml-sd-\d+/);
-                  // Browserify does not support arrow functions with params.
-                  // Using Old School for
-                  const shadowRootClassListArray =
+              setShadowCssSupportedForTesting(false);
+              const shadowRoot = createShadowRoot(hostElement);
+              expect(shadowRoot.id).to.match(/i-amphtml-sd-\d+/);
+              // Browserify does not support arrow functions with params.
+              // Using Old School for
+              const shadowRootClassListArray =
                 toArray(shadowRoot.host.classList);
-                  let foundShadowCssClass = false;
-                  for (let i = 0; i < shadowRootClassListArray.length; i++) {
-                    if (shadowRootClassListArray[i].match(/i-amphtml-sd-\d+/)) {
-                      foundShadowCssClass = true;
-                      break;
-                    }
-                  }
-                  expect(foundShadowCssClass).to.be.ok;
-                });
+              let foundShadowCssClass = false;
+              for (let i = 0; i < shadowRootClassListArray.length; i++) {
+                if (shadowRootClassListArray[i].match(/i-amphtml-sd-\d+/)) {
+                  foundShadowCssClass = true;
+                  break;
+                }
+              }
+              expect(foundShadowCssClass).to.be.ok;
+            });
 
             it('Should transform CSS for the shadow root', () => {
               setShadowCssSupportedForTesting(false);

--- a/validator/engine/css-selectors.js
+++ b/validator/engine/css-selectors.js
@@ -409,7 +409,7 @@ parse_css.parseAnAttrSelector = function(tokenStream) {
     const current = tokenStream.current().tokenType;
     if (current === parse_css.TokenType.IDENT) {
       const ident =
-          /** @type {!parse_css.IdentToken} */ (tokenStream.current());
+      /** @type {!parse_css.IdentToken} */ (tokenStream.current());
       value = ident.value;
       tokenStream.consume();
     } else if (current === parse_css.TokenType.STRING) {
@@ -516,7 +516,7 @@ parse_css.parseAPseudoSelector = function(tokenStream) {
   } else if (
     tokenStream.current().tokenType === parse_css.TokenType.FUNCTION_TOKEN) {
     const funcToken =
-        /** @type {!parse_css.FunctionToken} */ (tokenStream.current());
+    /** @type {!parse_css.FunctionToken} */ (tokenStream.current());
     const func = parse_css.extractAFunction(tokenStream);
     tokenStream.consume();
     return firstColon.copyPosTo(

--- a/validator/engine/parse-css.js
+++ b/validator/engine/parse-css.js
@@ -317,7 +317,7 @@ if (!amp.validator.LIGHT) {
     let ruleName = '';
     for (let i = 0; i < this.prelude.length; ++i) {
       const prelude =
-          /** @type {!parse_css.IdentToken} */ (this.prelude[i]);
+      /** @type {!parse_css.IdentToken} */ (this.prelude[i]);
       if (prelude.value) {ruleName += prelude.value;}
     }
     return ruleName;
@@ -512,7 +512,7 @@ class Canonicalizer {
         'Internal Error: parseAnAtRule precondition not met');
 
     const startToken =
-        /** @type {!parse_css.AtKeywordToken} */ (tokenStream.current());
+    /** @type {!parse_css.AtKeywordToken} */ (tokenStream.current());
     const rule = new parse_css.AtRule(startToken.value);
     if (!amp.validator.LIGHT) {
       startToken.copyPosTo(rule);
@@ -683,7 +683,7 @@ class Canonicalizer {
     }
 
     const startToken =
-        /** @type {!parse_css.IdentToken} */ (tokenStream.current());
+    /** @type {!parse_css.IdentToken} */ (tokenStream.current());
     const decl =
         startToken.copyPosTo(new parse_css.Declaration(startToken.value));
 
@@ -729,7 +729,7 @@ class Canonicalizer {
       } else if (
         foundImportant &&
           decl.value[i].tokenType === parse_css.TokenType.DELIM &&
-      /** @type {parse_css.DelimToken} */ (decl.value[i]).value === '!') {
+        /** @type {parse_css.DelimToken} */ (decl.value[i]).value === '!') {
         decl.value.splice(i, decl.value.length);
         decl.important = true;
         break;
@@ -777,7 +777,7 @@ function consumeASimpleBlock(tokenStream, tokenList) {
       'Internal Error: consumeASimpleBlock precondition not met');
 
   const startToken =
-      /** @type {!parse_css.GroupingToken} */ (tokenStream.current());
+  /** @type {!parse_css.GroupingToken} */ (tokenStream.current());
   const {mirror} = startToken;
 
   tokenList.push(startToken);
@@ -791,7 +791,7 @@ function consumeASimpleBlock(tokenStream, tokenList) {
       (current === parse_css.TokenType.CLOSE_CURLY ||
          current === parse_css.TokenType.CLOSE_SQUARE ||
          current === parse_css.TokenType.CLOSE_PAREN) &&
-    /** @type {parse_css.GroupingToken} */ (tokenStream.current()).value ===
+      /** @type {parse_css.GroupingToken} */ (tokenStream.current()).value ===
             mirror) {
       tokenList.push(tokenStream.current());
       return;

--- a/validator/engine/validator.js
+++ b/validator/engine/validator.js
@@ -4297,7 +4297,7 @@ class ParsedValidatorRules {
      */
     this.isTagSpecCorrectHtmlFormat_ = function(tagSpec) {
       const castedHtmlFormat =
-          /** @type {amp.validator.HtmlFormat.Code<string>} */ (
+      /** @type {amp.validator.HtmlFormat.Code<string>} */ (
           /** @type {*} */ (htmlFormat));
       return tagSpec.htmlFormat.indexOf(castedHtmlFormat) !== -1;
     };
@@ -4308,7 +4308,7 @@ class ParsedValidatorRules {
      */
     this.isCssLengthSpecCorrectHtmlFormat_ = function(cssLengthSpec) {
       const castedHtmlFormat =
-          /** @type {amp.validator.HtmlFormat.Code<string>} */ (
+      /** @type {amp.validator.HtmlFormat.Code<string>} */ (
           /** @type {*} */ (htmlFormat));
       return cssLengthSpec.htmlFormat == castedHtmlFormat;
     };


### PR DESCRIPTION
With older versions of `gulp-eslint`, the `indent` rules were interpreted in weird ways in some corner cases. The new version of the engine that was checked in with #16571 has a more sophisticated implementation of `indent`. This PR makes all the necessary fixes using `gulp lint --fix`.

Follow up to #16571
Closes #16735
