### PR TITLE
Inform developers to run --update_tests.

### DIFF
--- a/validator/engine/validator_test.js
+++ b/validator/engine/validator_test.js
@@ -280,6 +280,9 @@ ValidatorTestCase.prototype.run = function() {
     message = '\n' + this.expectedOutputFile + ':1:0\n';
   }
   message += 'expected:\n' + this.expectedOutput + '\nsaw:\n' + observed;
+  message += '\n\nIf validator/' + absolutePathFor(this.expectedOutputFile) +
+             ' is incorrect, please run `gulp validator --update_tests` to ' +
+             'regenerate it based on its corresponding .html file.';
   assert.fail('', '', message, '');
 };
 


### PR DESCRIPTION
If a validator test fails that would be fixed by running --update_tests
first, include instructions to do so in the assertion failure message.

Fixes #14735 ✅🏗✨.