### PR TITLE
Moves files that can be into intermediate bundles.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ PERCY_BUILD_ID
 chromedriver.log
 sc-*-linux*
 EXTENSIONS_CSS_MAP
+deps.txt
+flags-array.txt
+out/


### PR DESCRIPTION
With this we don't need to rely on CrossModuleCodeMotion to move this code. Reduces base.js by 31K.

Probably even more with
https://github.com/ampproject/amphtml/pull/16653/commits/a0e0d2aac0007747927c82c973adc87237c6a663
landed.