### PR TITLE
Introduce an intermediate bundle for single-run compiler build.

### DIFF
--- a/build-system/get-dep-graph.js
+++ b/build-system/get-dep-graph.js
@@ -137,6 +137,9 @@ exports.getBundleFlags = function(g) {
   const indexOfAmp = bundleKeys.indexOf('src/amp.js');
   bundleKeys.splice(indexOfAmp, 1);
   bundleKeys.splice(1, 0, 'src/amp.js');
+  const indexOfIntermedia = bundleKeys.indexOf('_intermediate');
+  bundleKeys.splice(indexOfIntermedia, 1);
+  bundleKeys.splice(1, 0, '_intermediate');
 
   bundleKeys.forEach(function(originalName) {
     const isBase = originalName == '_base';
@@ -179,8 +182,8 @@ exports.getBundleFlags = function(g) {
         cmd += `:${configEntry.type}`;
       } else {
         // All lower tier bundles depend on src-amp (v0.js)
-        if (name.includes(TYPES_VALUES)) {
-          cmd += ':src-amp';
+        if (TYPES_VALUES.includes(name)) {
+          cmd += ':_intermediate';
         } else {
           cmd += ':_base';
         }
@@ -237,6 +240,12 @@ exports.getGraph = function(entryModules, config) {
         // The modules in the bundle.
         modules: [],
       },
+      _intermediate: {
+        isBase: true,
+        name: '_intermediate',
+        // The modules in the bundle.
+        modules: [],
+      }
     },
     packages: {},
     browserMask: {},

--- a/build-system/get-dep-graph.js
+++ b/build-system/get-dep-graph.js
@@ -137,9 +137,9 @@ exports.getBundleFlags = function(g) {
   const indexOfAmp = bundleKeys.indexOf('src/amp.js');
   bundleKeys.splice(indexOfAmp, 1);
   bundleKeys.splice(1, 0, 'src/amp.js');
-  const indexOfIntermedia = bundleKeys.indexOf('_intermediate');
+  const indexOfIntermedia = bundleKeys.indexOf('_base_i');
   bundleKeys.splice(indexOfIntermedia, 1);
-  bundleKeys.splice(1, 0, '_intermediate');
+  bundleKeys.splice(1, 0, '_base_i');
 
   bundleKeys.forEach(function(originalName) {
     const isBase = originalName == '_base';
@@ -183,7 +183,7 @@ exports.getBundleFlags = function(g) {
       } else {
         // All lower tier bundles depend on src-amp (v0.js)
         if (TYPES_VALUES.includes(name)) {
-          cmd += ':_intermediate';
+          cmd += ':_base_i';
         } else {
           cmd += ':_base';
         }
@@ -240,9 +240,9 @@ exports.getGraph = function(entryModules, config) {
         // The modules in the bundle.
         modules: [],
       },
-      _intermediate: {
+      _base_i: {
         isBase: true,
-        name: '_intermediate',
+        name: '_base_i',
         // The modules in the bundle.
         modules: [],
       }
@@ -412,14 +412,17 @@ function setupBundles(graph) {
     // If a module is in more than 1 bundle, it must go into _base.
     if (bundleDestCandidates.length > 1) {
       const first = bundleDestCandidates[0];
-      const allTheSame = bundleDestCandidates.some(c => c == first);
+      const allTheSame = !bundleDestCandidates.some(c => c != first);
       const needsBase = bundleDestCandidates.some(c => c == '_base');
       dest = '_base';
+      // If all requested bundles are the same, then that is the right
+      // place.
       if (allTheSame) {
         dest = first;
       } else if (!needsBase) {
-        // Comment out when merging PR that introduces intermediate bundle.
-        // dest = '_intermediate'
+        // If multiple type-bundles want the file, but it doesn't have to be
+        // in base, move the file into the intermediate bundle.
+        dest = '_base_i';
       }
     }
     if (!graph.bundles[dest]) {

--- a/build-system/get-dep-graph.js
+++ b/build-system/get-dep-graph.js
@@ -245,7 +245,7 @@ exports.getGraph = function(entryModules, config) {
         name: '_base_i',
         // The modules in the bundle.
         modules: [],
-      }
+      },
     },
     packages: {},
     browserMask: {},


### PR DESCRIPTION
- All extension-type-based bundles depend on this bundle.
- Provides a place for code that is shared by multiple type-based bundle to go.
- Besides CrossModuleCodeMotion actually moves files there if possible/needed.
- 50K win for base module.