### PR TITLE
🐛Prepends heading to amp-story-bookend components if first is not a heading

### DIFF
--- a/extensions/amp-story/1.0/_locales/default.js
+++ b/extensions/amp-story/1.0/_locales/default.js
@@ -21,6 +21,9 @@ import {LocalizedStringBundleDef, LocalizedStringId} from '../localization';
  * @const {!LocalizedStringBundleDef}
  */
 export default {
+  [LocalizedStringId.AMP_STORY_BOOKEND_MORE_TO_READ_LABEL]: {
+    string: 'More to read',
+  },
   [LocalizedStringId.AMP_STORY_BOOKEND_PRIVACY_SETTINGS_TITLE]: {
     string: 'Privacy settings',
   },

--- a/extensions/amp-story/1.0/_locales/en.js
+++ b/extensions/amp-story/1.0/_locales/en.js
@@ -21,6 +21,11 @@ import {LocalizedStringBundleDef, LocalizedStringId} from '../localization';
  * @const {!LocalizedStringBundleDef}
  */
 export default {
+  [LocalizedStringId.AMP_STORY_BOOKEND_MORE_TO_READ_LABEL]: {
+    string: 'More to read',
+    description: 'Label to be placed as a title on top of related articles ' +
+        'at the end of a story.',
+  },
   [LocalizedStringId.AMP_STORY_BOOKEND_PRIVACY_SETTINGS_TITLE]: {
     string: 'Privacy settings',
     description: 'Title for a section that allows the user to configure ' +

--- a/extensions/amp-story/1.0/bookend/amp-story-bookend.js
+++ b/extensions/amp-story/1.0/bookend/amp-story-bookend.js
@@ -495,7 +495,7 @@ export class AmpStoryBookend extends AMP.BaseElement {
 
   /**
    * @param {!./bookend-component.BookendDataDef} bookendConfig
-   * @return {!Promise<!../localization.LocalizationService>}
+   * @return {!Promise<?../localization.LocalizationService>|undefined}
    * @private
    */
   renderBookend_(bookendConfig) {
@@ -511,7 +511,7 @@ export class AmpStoryBookend extends AMP.BaseElement {
 
   /**
    * @param {!Array<!../bookend/bookend-component.BookendComponentDef>} components
-   * @return {!Promise<!../localization.LocalizationService>}
+   * @return {!Promise<?../localization.LocalizationService>}
    * @private
    */
   renderComponents_(components) {
@@ -526,6 +526,10 @@ export class AmpStoryBookend extends AMP.BaseElement {
               BookendComponent.buildContainer(this.getInnerContainer_(),
                   this.win.document));
           this.mutateElement(() => container.appendChild(bookendEls));
+          return localizationService;
+        }).catch(e => {
+          user().error(TAG, 'Unable to fetch localization service.', e.message);
+          return null;
         });
   }
 

--- a/extensions/amp-story/1.0/bookend/amp-story-bookend.js
+++ b/extensions/amp-story/1.0/bookend/amp-story-bookend.js
@@ -395,7 +395,7 @@ export class AmpStoryBookend extends AMP.BaseElement {
   loadConfigAndMaybeRenderBookend(renderBookend = true) {
     return this.loadConfig().then(config => {
       if (renderBookend && config) {
-        this.renderBookend_(config);
+        return this.renderBookend_(config).then(() => config);
       }
       return config;
     });
@@ -495,6 +495,7 @@ export class AmpStoryBookend extends AMP.BaseElement {
 
   /**
    * @param {!./bookend-component.BookendDataDef} bookendConfig
+   * @return {!Promise<!../localization.LocalizationService>}
    * @private
    */
   renderBookend_(bookendConfig) {
@@ -505,21 +506,27 @@ export class AmpStoryBookend extends AMP.BaseElement {
     this.assertBuilt_();
     this.isBookendRendered_ = true;
 
-    this.renderComponents_(bookendConfig.components);
+    return this.renderComponents_(bookendConfig.components);
   }
 
   /**
    * @param {!Array<!../bookend/bookend-component.BookendComponentDef>} components
+   * @return {!Promise<!../localization.LocalizationService>}
    * @private
    */
   renderComponents_(components) {
     dev().assertElement(this.bookendEl_, 'Error rendering amp-story-bookend.');
-    const fragment = BookendComponent
-        .buildElements(components, this.win.document);
-    const container = dev().assertElement(
-        BookendComponent.buildContainer(this.getInnerContainer_(),
-            this.win.document));
-    this.mutateElement(() => container.appendChild(fragment));
+
+    return Services
+        .localizationServiceForOrNull(this.win).then(localizationService => {
+          const bookendEls = BookendComponent
+              .buildElements(
+                  components, this.win.document, localizationService);
+          const container = dev().assertElement(
+              BookendComponent.buildContainer(this.getInnerContainer_(),
+                  this.win.document));
+          this.mutateElement(() => container.appendChild(bookendEls));
+        });
   }
 
   /** @return {!Element} */

--- a/extensions/amp-story/1.0/bookend/amp-story-bookend.js
+++ b/extensions/amp-story/1.0/bookend/amp-story-bookend.js
@@ -394,7 +394,7 @@ export class AmpStoryBookend extends AMP.BaseElement {
    */
   loadConfigAndMaybeRenderBookend(renderBookend = true) {
     return this.loadConfig().then(config => {
-      if (renderBookend && config) {
+      if (renderBookend && !this.isBookendRendered_ && config) {
         return this.renderBookend_(config).then(() => config);
       }
       return config;
@@ -495,14 +495,10 @@ export class AmpStoryBookend extends AMP.BaseElement {
 
   /**
    * @param {!./bookend-component.BookendDataDef} bookendConfig
-   * @return {!Promise<?../localization.LocalizationService>|undefined}
+   * @return {!Promise}
    * @private
    */
   renderBookend_(bookendConfig) {
-    if (this.isBookendRendered_) {
-      return;
-    }
-
     this.assertBuilt_();
     this.isBookendRendered_ = true;
 
@@ -510,8 +506,11 @@ export class AmpStoryBookend extends AMP.BaseElement {
   }
 
   /**
+   * Renders the configurable components of the bookend in the page. It returns
+   * a promise to ensure loadConfigAndMaybeRenderBookend renders the components
+   * first before proceeding. This is needed for our unit tests.
    * @param {!Array<!../bookend/bookend-component.BookendComponentDef>} components
-   * @return {!Promise<?../localization.LocalizationService>}
+   * @return {!Promise}
    * @private
    */
   renderComponents_(components) {
@@ -526,7 +525,6 @@ export class AmpStoryBookend extends AMP.BaseElement {
               BookendComponent.buildContainer(this.getInnerContainer_(),
                   this.win.document));
           this.mutateElement(() => container.appendChild(bookendEls));
-          return localizationService;
         }).catch(e => {
           user().error(TAG, 'Unable to fetch localization service.', e.message);
           return null;

--- a/extensions/amp-story/1.0/bookend/bookend-component.js
+++ b/extensions/amp-story/1.0/bookend/bookend-component.js
@@ -15,17 +15,15 @@
  */
 
 
-import {ArticleComponent, ArticleComponentDef} from './components/article';
-import {CtaLinkComponent, CtaLinkDef} from './components/cta-link';
-import {HeadingComponent, HeadingComponentDef} from './components/heading';
-import {LandscapeComponent, LandscapeComponentDef} from './components/landscape';
+import {ArticleComponent} from './components/article';
+import {CtaLinkComponent} from './components/cta-link';
+import {HeadingComponent} from './components/heading';
+import {LandscapeComponent} from './components/landscape';
 import {LocalizedStringId} from '../localization';
-import {PortraitComponent, PortraitComponentDef} from './components/portrait';
-import {Services} from '../../../../src/services';
-import {TextBoxComponent, TextBoxComponentDef} from './components/text-box';
+import {PortraitComponent} from './components/portrait';
+import {TextBoxComponent} from './components/text-box';
 import {dev} from '../../../../src/log';
 import {htmlFor} from '../../../../src/static-template';
-import {toWin} from '../../../../src/types';
 
 /** @type {string} */
 export const TAG = 'amp-story-bookend';
@@ -109,23 +107,19 @@ function componentBuilderInstanceFor(type) {
  * Prepend a heading to the related articles section if first component is not a
  * heading already.
  * @param {!Array<BookendComponentDef>} components
- * @param {!DocumentFragment} container
- * @param {!Document} doc
+ * @param {!../../localization.LocalizationService>} localizationService
+ * @return {!Array<BookendComponentDef>}
  */
-function prependTitle(components, container, doc) {
-  if (components[0] && components[0].type != 'heading') {
-    const win = toWin(doc.defaultView);
-    Services.localizationServiceForOrNull(win).then(localizationService => {
-      dev().assert(localizationService,
-          'Could not retrieve LocalizationService.');
-      const title = localizationService
-          .getLocalizedString(
-              LocalizedStringId.AMP_STORY_BOOKEND_MORE_TO_READ_LABEL);
-      container.insertBefore(
-          componentBuilderInstanceFor('heading')
-              .buildElement({'text': title}, doc), container.firstChild);
-    });
+function prependTitle(components, localizationService) {
+  if (components[0] && components[0].type == 'heading') {
+    return components;
   }
+
+  const title = localizationService
+      .getLocalizedString(
+          LocalizedStringId.AMP_STORY_BOOKEND_MORE_TO_READ_LABEL);
+  components.unshift({'type': 'heading', 'text': title});
+  return components;
 }
 
 /**
@@ -159,12 +153,13 @@ export class BookendComponent {
    * class and appending the elements to the container.
    * @param {!Array<BookendComponentDef>} components
    * @param {!Document} doc
+   * @param {!../../localization.LocalizationService>} localizationService
    * @return {!DocumentFragment}
    */
-  static buildElements(components, doc) {
+  static buildElements(components, doc, localizationService) {
     const fragment = doc.createDocumentFragment();
 
-    prependTitle(components, fragment, doc);
+    components = prependTitle(components, localizationService);
 
     components.forEach(component => {
       const {type} = component;

--- a/extensions/amp-story/1.0/bookend/bookend-component.js
+++ b/extensions/amp-story/1.0/bookend/bookend-component.js
@@ -39,12 +39,12 @@ export let BookendDataDef;
 
 /**
  * @typedef {
- *   (!ArticleComponentDef|
- *    !CtaLinkDef|
- *    !HeadingComponentDef|
- *    !LandscapeComponentDef|
- *    !PortraitComponentDef|
- *    !TextBoxComponentDef)
+ *   (!./components/article.ArticleComponentDef|
+ *    !./components/cta-link.CtaLinkDef|
+ *    !./components/heading.HeadingComponentDef|
+ *    !./components/landscape.LandscapeComponentDef|
+ *    !./components/portrait.PortraitComponentDef|
+ *    !./components/text-box.TextBoxComponentDef)
  * }
  */
 export let BookendComponentDef;
@@ -107,7 +107,7 @@ function componentBuilderInstanceFor(type) {
  * Prepend a heading to the related articles section if first component is not a
  * heading already.
  * @param {!Array<BookendComponentDef>} components
- * @param {!../../localization.LocalizationService>} localizationService
+ * @param {?../localization.LocalizationService} localizationService
  * @return {!Array<BookendComponentDef>}
  */
 function prependTitle(components, localizationService) {
@@ -153,7 +153,7 @@ export class BookendComponent {
    * class and appending the elements to the container.
    * @param {!Array<BookendComponentDef>} components
    * @param {!Document} doc
-   * @param {!../../localization.LocalizationService>} localizationService
+   * @param {?../localization.LocalizationService} localizationService
    * @return {!DocumentFragment}
    */
   static buildElements(components, doc, localizationService) {

--- a/extensions/amp-story/1.0/bookend/components/heading.js
+++ b/extensions/amp-story/1.0/bookend/components/heading.js
@@ -21,7 +21,7 @@ import {user} from '../../../../../src/log';
 /**
  * @typedef {{
  *   type: string,
- *   text: string
+ *   text: string,
  * }}
  */
 export let HeadingComponentDef;

--- a/extensions/amp-story/1.0/bookend/components/landscape.js
+++ b/extensions/amp-story/1.0/bookend/components/landscape.js
@@ -29,7 +29,7 @@ import {userAssertValidProtocol} from '../../utils';
  *   title: string,
  *   url: string,
  *   domainName: string,
- *   image: string
+ *   image: string,
  * }}
  */
 export let LandscapeComponentDef;

--- a/extensions/amp-story/1.0/localization.js
+++ b/extensions/amp-story/1.0/localization.js
@@ -25,12 +25,13 @@ import {parseJson} from '../../../src/json';
  *   - NOT be reused; to deprecate an ID, comment it out and prefix its key with
  *     the string "DEPRECATED_"
  *
- * Next ID: 30
+ * Next ID: 31
  *
  * @const @enum {string}
  */
 export const LocalizedStringId = {
   // amp-story
+  AMP_STORY_BOOKEND_MORE_TO_READ_LABEL: '30',
   AMP_STORY_BOOKEND_PRIVACY_SETTINGS_TITLE: '29',
   AMP_STORY_BOOKEND_PRIVACY_SETTINGS_BUTTON_LABEL: '28',
   AMP_STORY_CONSENT_ACCEPT_BUTTON_LABEL: '22',

--- a/extensions/amp-story/1.0/test/test-amp-story-bookend.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-bookend.js
@@ -896,7 +896,10 @@ describes.realWin('amp-story-bookend', {amp: true}, env => {
 
     return bookend.loadConfigAndMaybeRenderBookend().then(config => {
       // Still builds rest of valid components.
-      expect(config.components[0]).to.deep.equal(userJson.components[1]);
+
+      // We use config.components[1] because config.components[0] is a heading
+      // that we prepend when there is no heading present in the user config.
+      expect(config.components[1]).to.deep.equal(userJson.components[1]);
     });
   });
 });


### PR DESCRIPTION
Fixes #15089