### PR TITLE
✨Add `expand` and `collapse` events on <amp-accordion> sections

### DIFF
--- a/examples/accordion.amp.html
+++ b/examples/accordion.amp.html
@@ -7,8 +7,60 @@
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <script async custom-element="amp-accordion" src="https://cdn.ampproject.org/v0/amp-accordion-0.1.js"></script>
+  <style amp-custom>
+    .menu {
+      padding: 1em;
+    }
+
+    .menu h3 {
+      display: inline-block;
+    }
+
+    .menu nav {
+      display: inline-block;
+    }
+
+    .menu li {
+      display: inline-block;
+    }
+
+    .menu amp-accordion h1 {
+      background-color: transparent;
+      border: transparent;
+    }
+  </style>
 </head>
 <body>
+  <header class="menu">
+    <h3>MENU</h3>
+    <nav>
+      <ul>
+        <li>
+          <amp-accordion id="ac1" animate>
+            <section id="item1" on="expand:ac2.collapse(section='item2')">
+              <h1>Item 1 (Expanding it closes Item 2)</h1>
+              <div>
+                <p>1A</p>
+                <p>1B</p>
+              </div>
+            </section>
+          </amp-accordion>
+        </li>
+        <li>
+          <amp-accordion id="ac2" animate>
+            <section id="item2" on="expand:ac1.collapse(section='item1')">
+              <h1>Item 2 (Expanding it closes Item 1)</h1>
+              <div>
+                <p>2A</p>
+                <p>2B</p>
+              </div>
+            </section>
+          </amp-accordion>
+        </li>
+      </ul>
+    </nav>
+  </header>
+
   <amp-accordion expand-single-section>
     <section>
       <h2>Section 1</h2>

--- a/extensions/amp-accordion/amp-accordion.md
+++ b/extensions/amp-accordion/amp-accordion.md
@@ -68,6 +68,15 @@ In this example, we display three sections, where the third section is expanded 
 To see more demos of the `amp-accordion`, visit [AMP By Example](https://ampbyexample.com/components/amp-accordion/).
 {% endcall %}
 
+### Events
+The events below will be triggered on `section`s of `accordion`.
+
+#### `expand`
+This event is triggered on the target `section` that changes from collapsed state to expanded state. Notice that calling `expand` on an already expanded `section` would not trigger this event.
+
+#### `collapse`
+This event is triggered on the target `section` that changes from expanded state to collapsed state. Notice that calling `collapse` on an already collapsed `section` would not trigger this event.
+
 ### Actions
 
 #### `toggle`


### PR DESCRIPTION
Adds `expand` and `collapse` events on `<amp-accordion>`. This somehow resolves scenario in #15165 . 

```html
<!-- ensures that only one of the 2 accordions would have sections expanded -->
<amp-accordion id="acc1">
  <section on="expand:acc2.collapse()">
  </section>
</amp-accordion>
<amp-accordion id="acc2">
  <section on="expand:acc1.collapse()">
  </section>
</amp-accordion>
```

