### PR TITLE
🐛 amp-next-page: Fix rendering within shadow documents

### DIFF
--- a/extensions/amp-next-page/0.1/amp-next-page.js
+++ b/extensions/amp-next-page/0.1/amp-next-page.js
@@ -60,36 +60,34 @@ export class AmpNextPage extends AMP.BaseElement {
       removeElement(separator);
     }
 
-    return getServicePromiseForDoc(this.getAmpDoc(), SERVICE_ID)
-        .then(service => {
-          if (service.isActive()) {
-            return;
-          }
+    return nextPageServiceForDoc(this.getAmpDoc()).then(service => {
+      if (service.isActive()) {
+        return;
+      }
 
-          const {element} = this;
-          element.classList.add('i-amphtml-next-page');
+      const {element} = this;
+      element.classList.add('i-amphtml-next-page');
 
-          const src = element.getAttribute('src');
-          if (src) {
-            return this.fetchConfig_().then(
-                config => this.register_(service, config, separator),
-                error => user().error(TAG, 'error fetching config', error));
-          } else {
-            const scriptElements = childElementsByTag(element, 'SCRIPT');
-            user().assert(scriptElements.length === 1,
-                `${TAG} should contain only one <script> child, or a URL `
-            + 'specified in [src]');
-            const scriptElement = scriptElements[0];
-            user().assert(isJsonScriptTag(scriptElement),
-                `${TAG} config should ` +
+      const src = element.getAttribute('src');
+      if (src) {
+        return this.fetchConfig_().then(
+            config => this.register_(service, config, separator),
+            error => user().error(TAG, 'error fetching config', error));
+      } else {
+        const scriptElements = childElementsByTag(element, 'SCRIPT');
+        user().assert(scriptElements.length === 1,
+            `${TAG} should contain only one <script> child, or a URL specified `
+            + 'in [src]');
+        const scriptElement = scriptElements[0];
+        user().assert(isJsonScriptTag(scriptElement),
+            `${TAG} config should ` +
             'be inside a <script> tag with type="application/json"');
-            const configJson = tryParseJson(
-                scriptElement.textContent, error => {
-                  user().error(TAG, 'failed to parse config', error);
-                });
-            this.register_(service, configJson, separator);
-          }
+        const configJson = tryParseJson(scriptElement.textContent, error => {
+          user().error(TAG, 'failed to parse config', error);
         });
+        this.register_(service, configJson, separator);
+      }
+    });
   }
 
   /**
@@ -138,6 +136,15 @@ export class AmpNextPage extends AMP.BaseElement {
     return batchFetchJsonFor(
         ampdoc, this.element, /* opt_expr */ undefined, policy);
   }
+}
+
+/**
+ * @param {!Element|!../../../src/service/ampdoc-impl.AmpDoc} elementOrAmpDoc
+ * @return {!Promise<!NextPageService>}
+ */
+function nextPageServiceForDoc(elementOrAmpDoc) {
+  return /** @type {!Promise<!NextPageService>} */ (
+    getServicePromiseForDoc(elementOrAmpDoc, SERVICE_ID));
 }
 
 AMP.extension(TAG, '0.1', AMP => {

--- a/extensions/amp-next-page/0.1/amp-next-page.js
+++ b/extensions/amp-next-page/0.1/amp-next-page.js
@@ -60,38 +60,36 @@ export class AmpNextPage extends AMP.BaseElement {
       removeElement(separator);
     }
 
-    if (this.service_.isActive()) {
-      return;
-    }
+    return getServicePromiseForDoc(this.getAmpDoc(), SERVICE_ID)
+        .then(service => {
+          if (service.isActive()) {
+            return;
+          }
 
-    getServicePromiseForDoc(this.getAmpDoc(), SERVICE_ID).then(service => {
-      if (service.isActive()) {
-        return;
-      }
+          const {element} = this;
+          element.classList.add('i-amphtml-next-page');
 
-      const {element} = this;
-      element.classList.add('i-amphtml-next-page');
-
-      const src = element.getAttribute('src');
-      if (src) {
-        return this.fetchConfig_().then(
-            config => this.register_(service, config, separator),
-            error => user().error(TAG, 'error fetching config', error));
-      } else {
-        const scriptElements = childElementsByTag(element, 'SCRIPT');
-        user().assert(scriptElements.length === 1,
-            `${TAG} should contain only one <script> child, or a URL specified `
-            + 'in [src]');
-        const scriptElement = scriptElements[0];
-        user().assert(isJsonScriptTag(scriptElement),
-            `${TAG} config should ` +
+          const src = element.getAttribute('src');
+          if (src) {
+            return this.fetchConfig_().then(
+                config => this.register_(service, config, separator),
+                error => user().error(TAG, 'error fetching config', error));
+          } else {
+            const scriptElements = childElementsByTag(element, 'SCRIPT');
+            user().assert(scriptElements.length === 1,
+                `${TAG} should contain only one <script> child, or a URL `
+            + 'specified in [src]');
+            const scriptElement = scriptElements[0];
+            user().assert(isJsonScriptTag(scriptElement),
+                `${TAG} config should ` +
             'be inside a <script> tag with type="application/json"');
-        const configJson = tryParseJson(scriptElement.textContent, error => {
-          user().error(TAG, 'failed to parse config', error);
+            const configJson = tryParseJson(
+                scriptElement.textContent, error => {
+                  user().error(TAG, 'failed to parse config', error);
+                });
+            this.register_(service, configJson, separator);
+          }
         });
-        this.register_(service, configJson, separator);
-      }
-    });
   }
 
   /**

--- a/extensions/amp-next-page/0.1/amp-next-page.js
+++ b/extensions/amp-next-page/0.1/amp-next-page.js
@@ -29,7 +29,7 @@ import {
   isJsonScriptTag,
   removeElement,
 } from '../../../src/dom';
-import {getService} from '../../../src/service';
+import {getServicePromiseForDoc} from '../../../src/service';
 import {isExperimentOn} from '../../../src/experiments';
 import {tryParseJson} from '../../../src/json';
 import {user} from '../../../src/log';
@@ -39,14 +39,6 @@ const TAG = 'amp-next-page';
 const SERVICE_ID = 'next-page';
 
 export class AmpNextPage extends AMP.BaseElement {
-
-  /** @param {!AmpElement} element */
-  constructor(element) {
-    super(element);
-
-    /** @private {!./next-page-service.NextPageService} */
-    this.service_ = getService(this.win, SERVICE_ID);
-  }
 
   /** @override */
   isLayoutSupported(layout) {
@@ -72,38 +64,45 @@ export class AmpNextPage extends AMP.BaseElement {
       return;
     }
 
-    const {element} = this;
-    element.classList.add('i-amphtml-next-page');
+    getServicePromiseForDoc(this.getAmpDoc(), SERVICE_ID).then(service => {
+      if (service.isActive()) {
+        return;
+      }
 
-    const src = element.getAttribute('src');
-    if (src) {
-      return this.fetchConfig_().then(
-          config => this.register_(config, separator),
-          error => user().error(TAG, 'error fetching config', error));
-    } else {
-      const scriptElements = childElementsByTag(element, 'SCRIPT');
-      user().assert(scriptElements.length === 1,
-          `${TAG} should contain only one <script> child, or a URL specified `
-          + 'in [src]');
-      const scriptElement = scriptElements[0];
-      user().assert(isJsonScriptTag(scriptElement),
-          `${TAG} config should ` +
-          'be inside a <script> tag with type="application/json"');
-      const configJson = tryParseJson(scriptElement.textContent, error => {
-        user().error(TAG, 'failed to parse config', error);
-      });
-      this.register_(configJson, separator);
-    }
+      const {element} = this;
+      element.classList.add('i-amphtml-next-page');
+
+      const src = element.getAttribute('src');
+      if (src) {
+        return this.fetchConfig_().then(
+            config => this.register_(service, config, separator),
+            error => user().error(TAG, 'error fetching config', error));
+      } else {
+        const scriptElements = childElementsByTag(element, 'SCRIPT');
+        user().assert(scriptElements.length === 1,
+            `${TAG} should contain only one <script> child, or a URL specified `
+            + 'in [src]');
+        const scriptElement = scriptElements[0];
+        user().assert(isJsonScriptTag(scriptElement),
+            `${TAG} config should ` +
+            'be inside a <script> tag with type="application/json"');
+        const configJson = tryParseJson(scriptElement.textContent, error => {
+          user().error(TAG, 'failed to parse config', error);
+        });
+        this.register_(service, configJson, separator);
+      }
+    });
   }
 
   /**
    * Verifies the specified config as a valid {@code NextPageConfig} and
    * registers the {@link NextPageService} for this document.
+   * @param {!NextPageService} service Service to register with.
    * @param {*} configJson Config JSON object.
    * @param {?Element} separator Optional custom separator element.
    * @private
    */
-  register_(configJson, separator) {
+  register_(service, configJson, separator) {
     const {element} = this;
     const docInfo = Services.documentInfoForDoc(element);
     const urlService = Services.urlForDoc(element);
@@ -119,8 +118,8 @@ export class AmpNextPage extends AMP.BaseElement {
       });
     }
 
-    this.service_.register(element, config, separator);
-    this.service_.setAppendPageHandler(element => this.appendPage_(element));
+    service.register(element, config, separator);
+    service.setAppendPageHandler(element => this.appendPage_(element));
   }
 
   /**


### PR DESCRIPTION
If `amp-next-page` tries to load in a shadow document, the service gets registered against the AmpDoc rather than the window, and `getService()` tries to read it from the window.

Fixes #16666