### PR TITLE
🏗🐛 Do not generate code during `gulp check-types`

### DIFF
--- a/build-system/tasks/compile.js
+++ b/build-system/tasks/compile.js
@@ -104,7 +104,8 @@ function compile(entryModuleFilenames, outputDir,
       entryModuleFilename = entryModuleFilenames;
       entryModuleFilenames = [entryModuleFilename];
     }
-    const checkTypes = options.checkTypes || argv.typecheck_only;
+    const checkTypes =
+        options.checkTypes || options.typeCheckOnly || argv.typecheck_only;
     const intermediateFilename = 'build/cc/' +
         entryModuleFilename.replace(/\//g, '_').replace(/^\./, '');
     // If undefined/null or false then we're ok executing the deletions
@@ -375,7 +376,7 @@ function compile(entryModuleFilenames, outputDir,
         });
 
     // If we're only doing type checking, no need to output the files.
-    if (!argv.typecheck_only) {
+    if (!argv.typecheck_only && !options.typeCheckOnly) {
       stream = stream
           .pipe(rename(outputFilename))
           .pipe(replace(/\$internalRuntimeVersion\$/g, internalRuntimeVersion))
@@ -388,6 +389,8 @@ function compile(entryModuleFilenames, outputDir,
                 .pipe(gulp.dest(outputDir))
                 .on('end', resolve);
           });
+    } else {
+      stream = stream.on('end', resolve);
     }
     return stream;
   });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -885,7 +885,7 @@ function checkTypes() {
             include3pDirectories: true,
             includePolyfills: true,
             extraGlobs: ['src/inabox/*.js'],
-            checkTypes: true,
+            typeCheckOnly: true,
           }),
       // Type check 3p/ads code.
       closureCompile(['./3p/integration.js'], './dist',
@@ -893,21 +893,21 @@ function checkTypes() {
             externs: ['ads/ads.extern.js'],
             include3pDirectories: true,
             includePolyfills: true,
-            checkTypes: true,
+            typeCheckOnly: true,
           }),
       closureCompile(['./3p/ampcontext-lib.js'], './dist',
           'ampcontext-check-types.js', {
             externs: ['ads/ads.extern.js'],
             include3pDirectories: true,
             includePolyfills: true,
-            checkTypes: true,
+            typeCheckOnly: true,
           }),
       closureCompile(['./3p/iframe-transport-client-lib.js'], './dist',
           'iframe-transport-client-check-types.js', {
             externs: ['ads/ads.extern.js'],
             include3pDirectories: true,
             includePolyfills: true,
-            checkTypes: true,
+            typeCheckOnly: true,
           }),
     ]);
   }).then(() => {


### PR DESCRIPTION
With this PR, we no longer generate code during `gulp check-types`. Specifically, all these files are no longer written to the `dist/` folder:
```
rsimha@rsimha-macbookpro2 (master):~/src/amphtml$ ls -lar dist/
total 15384
-rw-r--r--   1 rsimha  primarygroup   327472 Jul 17 10:25 integration-check-types.js.map
-rw-r--r--   1 rsimha  primarygroup   172418 Jul 17 10:25 integration-check-types.js
-rw-r--r--   1 rsimha  primarygroup    37574 Jul 17 10:25 iframe-transport-client-check-types.js.map
-rw-r--r--   1 rsimha  primarygroup    16709 Jul 17 10:25 iframe-transport-client-check-types.js
-rw-r--r--   1 rsimha  primarygroup  4144583 Jul 17 10:25 check-types.js.map
-rw-r--r--   1 rsimha  primarygroup  3070012 Jul 17 10:25 check-types.js
-rw-r--r--   1 rsimha  primarygroup    63058 Jul 17 10:25 ampcontext-check-types.js.map
-rw-r--r--   1 rsimha  primarygroup    27957 Jul 17 10:25 ampcontext-check-types.js
drwxr-xr-x  50 rsimha  primarygroup     1600 Jul 17 10:25 ../
drwxr-xr-x  10 rsimha  primarygroup      320 Jul 17 10:25 ./
```

**Notes:**
- I've confirmed that type errors are still correctly detected with this change
- The original issue suggests that we no longer run `SIMPLE_OPTIMIZATIONS` during type checking, but it turns out that we can't use `WHITESPACE_ONLY` optimization according to this comment:
https://github.com/ampproject/amphtml/blob/703aad74ebe0c045389c69e2d43041ffb2bbe9f8/build-system/tasks/compile.js#L344-L347


Fixes #5024
