### PR TITLE
amp-bind: Support object args for splice()

### DIFF
--- a/extensions/amp-bind/0.1/bind-expression.js
+++ b/extensions/amp-bind/0.1/bind-expression.js
@@ -361,18 +361,12 @@ export class BindExpression {
 
         if (validFunction) {
           if (Array.isArray(params)) {
-            // Don't allow objects as parameters except for Object functions.
-            const invalidArgumentType = this.containsObject_(params)
-                && !this.isObjectMethod_(method);
-            if (!invalidArgumentType) {
-              return validFunction.apply(caller, params);
-            }
+            return validFunction.apply(caller, params);
           } else if (typeof params == 'function') {
             // Special case: `params` may be an arrow function, which are only
             // supported as the sole argument to functions like Array#find.
             return validFunction.call(caller, params);
           }
-          throw new Error(`Unexpected argument type in ${method}().`);
         }
 
         throw new Error(unsupportedError);

--- a/extensions/amp-bind/0.1/bind-expression.js
+++ b/extensions/amp-bind/0.1/bind-expression.js
@@ -361,6 +361,9 @@ export class BindExpression {
 
         if (validFunction) {
           if (Array.isArray(params)) {
+            if (this.containsInvalidArgument_(method, params)) {
+              throw new Error(`Unexpected argument type in ${method}().`);
+            }
             return validFunction.apply(caller, params);
           } else if (typeof params == 'function') {
             // Special case: `params` may be an arrow function, which are only
@@ -513,12 +516,16 @@ export class BindExpression {
   }
 
   /**
-   * Returns true iff method is
    * @param {string} method
+   * @param {!Array} params
    * @return {boolean}
    */
-  isObjectMethod_(method) {
-    return method == 'keys' || method == 'values';
+  containsInvalidArgument_(method, params) {
+    // Don't allow objects as parameters except for certain functions.
+    if (method == 'keys' || method == 'values' || method == 'splice') {
+      return false;
+    }
+    return this.containsObject_(params);
   }
 
   /**

--- a/extensions/amp-bind/0.1/test/test-bind-expression.js
+++ b/extensions/amp-bind/0.1/test/test-bind-expression.js
@@ -18,7 +18,6 @@ import {BindExpression} from '../bind-expression';
 import {BindMacro} from '../bind-macro';
 
 describe('BindExpression', () => {
-  const argumentTypeError = 'Unexpected argument type';
   const unsupportedFunctionError = 'not a supported function';
   const expressionSizeExceededError = 'exceeds max';
 
@@ -439,15 +438,6 @@ describe('BindExpression', () => {
       expect(() => {
         evaluate('bar.__defineSetter__()', scope);
       }).to.throw(Error, unsupportedFunctionError);
-    });
-
-    it('disallow: whitelisted functions with invalid argument types', () => {
-      expect(() => {
-        evaluate('[1, 2, 3].indexOf({})');
-      }).to.throw(Error, argumentTypeError);
-      expect(() => {
-        evaluate('"abc".substr({})');
-      }).to.throw(Error, argumentTypeError);
     });
   });
 

--- a/extensions/amp-bind/0.1/test/test-bind-expression.js
+++ b/extensions/amp-bind/0.1/test/test-bind-expression.js
@@ -18,6 +18,7 @@ import {BindExpression} from '../bind-expression';
 import {BindMacro} from '../bind-macro';
 
 describe('BindExpression', () => {
+  const argumentTypeError = 'Unexpected argument type';
   const unsupportedFunctionError = 'not a supported function';
   const expressionSizeExceededError = 'exceeds max';
 
@@ -438,6 +439,21 @@ describe('BindExpression', () => {
       expect(() => {
         evaluate('bar.__defineSetter__()', scope);
       }).to.throw(Error, unsupportedFunctionError);
+    });
+
+    it('disallow: object in arguments for most functions', () => {
+      expect(() => {
+        evaluate('[1, 2, 3].indexOf({})');
+      }).to.throw(Error, argumentTypeError);
+      expect(() => {
+        evaluate('"abc".substr({})');
+      }).to.throw(Error, argumentTypeError);
+
+      // Only allow objects in arguments for some functions.
+      expect(evaluate('keys({x: 2})')).to.deep.equal(['x']);
+      expect(evaluate('values({x: 2})')).to.deep.equal([2]);
+      expect(evaluate('splice([1, 3], 1, 0, {x: 2})'))
+          .to.deep.equal([1, {x: 2}, 3]);
     });
   });
 


### PR DESCRIPTION
Fixes #11882.

/to @alabiaga 