### PR TITLE
Pause the story on background tabs.

### DIFF
--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -272,6 +272,12 @@ export class AmpStory extends AMP.BaseElement {
     /** @private @const {!../../../src/service/platform-impl.Platform} */
     this.platform_ = Services.platformFor(this.win);
 
+    /** @private @const {!../../../src/service/document-state.DocumentState} */
+    this.documentState_ = Services.documentStateFor(this.win);
+
+    /** @private {boolean} */
+    this.pausedStateToRestore_ = false;
+
     /** @private @const {!LocalizationService} */
     this.localizationService_ = new LocalizationService(this.win);
     this.localizationService_
@@ -344,16 +350,34 @@ export class AmpStory extends AMP.BaseElement {
   }
 
 
-  /** @private */
+  /** @override */
+  pauseCallback() {
+    // Store the current paused state, to make sure the story does not play on
+    // resume if it was previously paused.
+    this.pausedStateToRestore_ =
+        this.storeService_.get(StateProperty.PAUSED_STATE);
+    this.storeService_.dispatch(Action.TOGGLE_PAUSED, true);
+  }
+
+
+  /** @override */
+  resumeCallback() {
+    this.storeService_
+        .dispatch(Action.TOGGLE_PAUSED, this.pausedStateToRestore_);
+  }
+
+
+  /**
+   * Note: runs in the buildCallback vsync mutate context.
+   * @private
+   */
   initializeStandaloneStory_() {
     const html = this.win.document.documentElement;
-    this.mutateElement(() => {
-      html.classList.add('i-amphtml-story-standalone');
-      // Lock body to prevent overflow.
-      this.lockBody_();
-      // Standalone CSS affects sizing of the entire page.
-      this.onResize();
-    }, html);
+    html.classList.add('i-amphtml-story-standalone');
+    // Lock body to prevent overflow.
+    this.lockBody_();
+    // Standalone CSS affects sizing of the entire page.
+    this.onResize();
   }
 
 
@@ -512,6 +536,10 @@ export class AmpStory extends AMP.BaseElement {
     this.win.document.addEventListener('keydown', e => {
       this.onKeyDown_(e);
     }, true);
+
+    // TODO(#16795): Remove once the runtime triggers pause/resume callbacks
+    // on document visibility change (eg: user switches tab).
+    this.documentState_.onVisibilityChanged(() => this.onVisibilityChanged_());
 
     this.getViewport().onResize(debounce(this.win, () => this.onResize(), 300));
     this.installGestureRecognizers_();
@@ -1086,6 +1114,16 @@ export class AmpStory extends AMP.BaseElement {
         this.storeService_.dispatch(Action.TOGGLE_LANDSCAPE, state.isLandscape);
       },
     }, {});
+  }
+
+  /**
+   * Reacts to the browser tab becoming active/inactive.
+   * @private
+   */
+  onVisibilityChanged_() {
+    this.documentState_.isHidden() ?
+      this.pauseCallback() :
+      this.resumeCallback();
   }
 
   /**

--- a/extensions/amp-story/1.0/test/test-amp-story.js
+++ b/extensions/amp-story/1.0/test/test-amp-story.js
@@ -516,6 +516,101 @@ describes.realWin('amp-story', {
     });
   });
 
+  describe('amp-story pause/resume callbacks', () => {
+    it('should pause the story when tab becomes inactive', () => {
+      sandbox.stub(win.history, 'replaceState');
+      createPages(story.element, 2, ['cover', 'page-1']);
+
+      sandbox.stub(story.documentState_, 'isHidden').returns(true);
+      const onVisibilityChangedStub =
+          sandbox.stub(story.documentState_, 'onVisibilityChanged');
+
+      story.buildCallback();
+
+      return story.layoutCallback()
+          .then(() => {
+            // Execute the callback passed to onVisibilityChanged.
+            expect(onVisibilityChangedStub).to.have.been.calledOnce;
+            onVisibilityChangedStub.getCall(0).args[0]();
+
+            // Paused state has been changed to true.
+            expect(story.storeService_.get(StateProperty.PAUSED_STATE))
+                .to.be.true;
+          });
+    });
+
+    it('should play the story when tab becomes active', () => {
+      sandbox.stub(win.history, 'replaceState');
+      createPages(story.element, 2, ['cover', 'page-1']);
+
+      sandbox.stub(story.documentState_, 'isHidden').returns(false);
+      const onVisibilityChangedStub =
+          sandbox.stub(story.documentState_, 'onVisibilityChanged');
+
+      story.storeService_.dispatch(Action.TOGGLE_PAUSED, true);
+
+      story.buildCallback();
+
+      return story.layoutCallback()
+          .then(() => {
+            // Execute the callback passed to onVisibilityChanged.
+            expect(onVisibilityChangedStub).to.have.been.calledOnce;
+            onVisibilityChangedStub.getCall(0).args[0]();
+
+            // Paused state has been changed to false.
+            expect(story.storeService_.get(StateProperty.PAUSED_STATE))
+                .to.be.false;
+          });
+    });
+
+    it('should pause the story when viewer becomes inactive', () => {
+      sandbox.stub(win.history, 'replaceState');
+      createPages(story.element, 2, ['cover', 'page-1']);
+
+      story.buildCallback();
+
+      return story.layoutCallback()
+          .then(() => {
+            story.pauseCallback();
+            expect(story.storeService_.get(StateProperty.PAUSED_STATE))
+                .to.be.true;
+          });
+    });
+
+    it('should play the story when viewer becomes active', () => {
+      sandbox.stub(win.history, 'replaceState');
+      createPages(story.element, 2, ['cover', 'page-1']);
+
+      story.storeService_.dispatch(Action.TOGGLE_PAUSED, true);
+
+      story.buildCallback();
+
+      return story.layoutCallback()
+          .then(() => {
+            story.resumeCallback();
+            expect(story.storeService_.get(StateProperty.PAUSED_STATE))
+                .to.be.false;
+          });
+    });
+
+    it('should keep the story paused on resume when previously paused', () => {
+      sandbox.stub(win.history, 'replaceState');
+      createPages(story.element, 2, ['cover', 'page-1']);
+
+      story.storeService_.dispatch(Action.TOGGLE_PAUSED, true);
+
+      story.buildCallback();
+
+      return story.layoutCallback()
+          .then(() => {
+            story.pauseCallback();
+            story.resumeCallback();
+            expect(story.storeService_.get(StateProperty.PAUSED_STATE))
+                .to.be.true;
+          });
+    });
+  });
+
   describe('amp-story continue anyway', () => {
     it('should not display layout', () => {
       AmpStory.isBrowserSupported = () => false;


### PR DESCRIPTION
- Pause/play the story when the document visibility changes (user switches tab or app)
- Pause/play the story on runtime pause/resume callbacks
- Fix story pause/resume callbacks

Runtime was triggering the `pauseCallback` when rendering the story, without any later call to `resumeCallback`.
This was caused by the story having no size (height and width of 0) when the runtime was checking whether the story is visible.
It was due to a race condition, caused by the standalone CSS class being added too late. Adding this class was done in a `mutateElement`, which was unnecessary since `buildCallback` already runs in a vsync mutate state.
Removing this extra `mutateElement` ensured the story has a size, so the runtime doesn't trigger `pauseCallback` on render.

Fixes #16801, #15675