### PR TITLE
🏗🐛 Make sauce connect scripts more robust

### DIFF
--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -259,14 +259,14 @@ function startSauceConnect() {
   const startScCmd = 'build-system/sauce_connect/start_sauce_connect.sh';
   console.log('\n' + fileLogPrefix,
       'Starting Sauce Connect Proxy:', colors.cyan(startScCmd));
-  exec(startScCmd);
+  execOrDie(startScCmd);
 }
 
 function stopSauceConnect() {
   const stopScCmd = 'build-system/sauce_connect/stop_sauce_connect.sh';
   console.log('\n' + fileLogPrefix,
       'Stopping Sauce Connect Proxy:', colors.cyan(stopScCmd));
-  exec(stopScCmd);
+  execOrDie(stopScCmd);
 }
 
 const command = {

--- a/build-system/sauce_connect/stop_sauce_connect.sh
+++ b/build-system/sauce_connect/stop_sauce_connect.sh
@@ -21,7 +21,6 @@ YELLOW() { echo -e "\033[1;33m$1\033[0m"; }
 
 PID_FILE="sauce_connect_pid"
 LOG_FILE="sauce_connect_log"
-STOP_MESSAGE="Goodbye."
 LOG_PREFIX=$(YELLOW "stop_sauce_connect.sh")
 
 # Early exit if there's no proxy running.
@@ -30,11 +29,10 @@ if [[ ! -f "$PID_FILE" ]]; then
   exit 0
 fi
 
-# Wait for clean exit.
+# Stop the sauce connect proxy.
 PID="$(cat "$PID_FILE")"
 echo "$LOG_PREFIX Stopping Sauce Connect Proxy pid $(CYAN "$PID")"
 kill "$PID"
-( tail -f -n0 "$LOG_FILE" & ) | grep -q "$STOP_MESSAGE"
 
 # Clean up files.
 if [[ -f "$LOG_FILE" ]]; then


### PR DESCRIPTION
In this PR, we no longer poll the sauce connect logs for well-known strings.

- During startup, we now look for the presence of a ready-file, something that sauce connect creates once the tunnel ready.
- If the file doesn't appear within 60 seconds, we fail and print the sauce connect logs.
- During shutdown, we exit the background process and delete the log files. There is no need to wait for the "goodbye" text, since Travis will clean up the tunnel anyway.

Fixes #16812