### PR TITLE
🐛 Ensure the active amp-story-page is always on top

### DIFF
--- a/extensions/amp-story/0.1/amp-story.css
+++ b/extensions/amp-story/0.1/amp-story.css
@@ -142,6 +142,11 @@ amp-story-page {
   right: 0 !important;
   top: 0 !important;
   transition: none !important;
+  z-index: 0 !important;
+}
+
+amp-story-page[active] {
+  z-index: 1 !important;
 }
 
 .i-amphtml-story-fallback amp-story-page {

--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -169,6 +169,11 @@ amp-story-page {
   right: 0 !important;
   top: 0 !important;
   transition: none !important;
+  z-index: 0 !important;
+}
+
+amp-story-page[active] {
+  z-index: 1 !important;
 }
 
 .i-amphtml-story-fallback amp-story-page {


### PR DESCRIPTION
It is possible for the active page not to be on top if there is ever more than one story with a distance of `0`.  This currently happens for bot user agents.  Because there is no z-index, the last page in DOM order will be on top (before this PR).