### PR TITLE
🐛Fix race condition when opening/closing amp-sidebar

### DIFF
--- a/extensions/amp-sidebar/0.1/amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.js
@@ -21,7 +21,6 @@ import {Services} from '../../../src/services';
 import {Toolbar} from './toolbar';
 import {closestByTag, isRTL, tryFocus} from '../../../src/dom';
 import {createCustomEvent} from '../../../src/event-helper';
-import {debounce} from '../../../src/utils/rate-limit';
 import {dev} from '../../../src/log';
 import {removeFragment} from '../../../src/url';
 import {setStyles, toggle} from '../../../src/style';
@@ -56,6 +55,9 @@ export class AmpSidebar extends AMP.BaseElement {
     /** @private {?../../../src/service/action-impl.ActionService} */
     this.action_ = null;
 
+    /** @private {?function()} */
+    this.updateFn_ = null;
+
     /** @private {?Element} */
     this.maskElement_ = null;
 
@@ -84,10 +86,6 @@ export class AmpSidebar extends AMP.BaseElement {
 
     /** @private {boolean} */
     this.bottomBarCompensated_ = false;
-
-    /** @const {function()} */
-    this.boundOnAnimationEnd_ =
-        debounce(this.win, this.onAnimationEnd_.bind(this), ANIMATION_TIMEOUT);
 
     /** @private {?Element} */
     this.openerElement_ = null;
@@ -227,6 +225,87 @@ export class AmpSidebar extends AMP.BaseElement {
   }
 
   /**
+   * Sets a function to update the state of the sidebar. If another one has
+   * been set before the function takes effect, it is ignored.
+   * @param {function()} updateFn A function to update the sidebar.
+   * @param {number=} delay An optional delay to wait before calling the update
+   *    function.
+   */
+  setUpdateFn_(updateFn, delay) {
+    this.updateFn_ = updateFn;
+
+    const runUpdate = () => {
+      // Make sure we haven't been replaced by another update function.
+      if (this.updateFn_ === updateFn) {
+        this.mutateElement(updateFn);
+      }
+    };
+
+    if (delay) {
+      Services.timerFor(this.win).delay(runUpdate, delay);
+    } else {
+      runUpdate();
+    }
+  }
+
+  /**
+   * Updates the sidebar before it opens. This needs to be done as a separate
+   * step from opening so that we can animate, as the sidebar is initially
+   * display: none.
+   */
+  updateForPreOpening_() {
+    toggle(this.element, /* display */true);
+    this.viewport_.addToFixedLayer(this.element, /* forceTransfer */ true);
+
+    if (this.isIos_ && this.isSafari_) {
+      this.compensateIosBottombar_();
+    }
+    this.element./*OK*/scrollTop = 1;
+    this.setUpdateFn_(() => this.updateForOpening_());
+  }
+
+  /**
+   * Updates the sidebar while it is animating to the opened state.
+   */
+  updateForOpening_() {
+    this.openMask_();
+    this.element.setAttribute('open', '');
+    this.element.setAttribute('aria-hidden', 'false');
+    this.setUpdateFn_(() => this.updateForOpened_(), ANIMATION_TIMEOUT);
+  }
+
+  /**
+   * Updates the sidebar for when it has finished opening.
+   */
+  updateForOpened_() {
+    // On open sidebar
+    const children = this.getRealChildren();
+    this.scheduleLayout(children);
+    this.scheduleResume(children);
+    tryFocus(this.element);
+    this.triggerEvent_(SidebarEvents.OPEN);
+  }
+
+  /**
+   * Updates the sidebar for when it is animating to the closed state.
+   */
+  updateForClosing_() {
+    this.closeMask_();
+    this.element.removeAttribute('open');
+    this.element.setAttribute('aria-hidden', 'true');
+    this.setUpdateFn_(() => this.updateForClosed_(), ANIMATION_TIMEOUT);
+  }
+
+  /**
+   * Updates the sidebar for when it has finished closing.
+   */
+  updateForClosed_() {
+    toggle(this.element, /* display */false);
+    this.schedulePause(this.getRealChildren());
+    this.triggerEvent_(SidebarEvents.CLOSE);
+  }
+
+  /**
    * Reveals the sidebar.
    * @param {?../../../src/service/action-impl.ActionInvocation=} opt_invocation
    * @private
@@ -236,22 +315,7 @@ export class AmpSidebar extends AMP.BaseElement {
       return;
     }
     this.viewport_.enterOverlayMode();
-    this.mutateElement(() => {
-      toggle(this.element, /* display */true);
-      this.viewport_.addToFixedLayer(this.element, /* forceTransfer */ true);
-
-      if (this.isIos_ && this.isSafari_) {
-        this.compensateIosBottombar_();
-      }
-      this.element./*OK*/scrollTop = 1;
-      // Start animation in a separate vsync due to display:block; set above.
-      this.mutateElement(() => {
-        this.openMask_();
-        this.element.setAttribute('open', '');
-        this.boundOnAnimationEnd_();
-        this.element.setAttribute('aria-hidden', 'false');
-      });
-    });
+    this.setUpdateFn_(() => this.updateForPreOpening_());
     this.getHistory_().push(this.close_.bind(this)).then(historyId => {
       this.historyId_ = historyId;
     });
@@ -274,12 +338,7 @@ export class AmpSidebar extends AMP.BaseElement {
       (this.initialScrollTop_ == this.viewport_.getScrollTop());
     const sidebarIsActive =
         this.element.contains(this.document_.activeElement);
-    this.mutateElement(() => {
-      this.closeMask_();
-      this.element.removeAttribute('open');
-      this.boundOnAnimationEnd_();
-      this.element.setAttribute('aria-hidden', 'true');
-    });
+    this.setUpdateFn_(() => this.updateForClosing_());
     if (this.historyId_ != -1) {
       this.getHistory_().pop(this.historyId_);
       this.historyId_ = -1;
@@ -359,28 +418,6 @@ export class AmpSidebar extends AMP.BaseElement {
    */
   getHistory_() {
     return Services.historyForDoc(this.getAmpDoc());
-  }
-
-  /**
-   * Get called when animation/transition end when open/close sidebar
-   * @private
-   */
-  onAnimationEnd_() {
-    if (this.isOpen_()) {
-      // On open sidebar
-      const children = this.getRealChildren();
-      this.scheduleLayout(children);
-      this.scheduleResume(children);
-      tryFocus(this.element);
-      this.triggerEvent_(SidebarEvents.OPEN);
-    } else {
-      // On close sidebar
-      this.mutateElement(() => {
-        toggle(this.element, /* display */false);
-        this.schedulePause(this.getRealChildren());
-        this.triggerEvent_(SidebarEvents.CLOSE);
-      });
-    }
   }
 
   /**

--- a/extensions/amp-sidebar/0.1/test/test-amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/test/test-amp-sidebar.js
@@ -547,21 +547,23 @@ describes.realWin('amp-sidebar 0.1 version', {
       });
     });
 
-    it('should call onAnimationEnd after open and close', () => {
+    it('should trigger actions on open and close', () => {
       return getAmpSidebar({stubHistory: true}).then(sidebarElement => {
         const impl = sidebarElement.implementation_;
-        clock = lolex.install(
-            {target: impl.win, toFake: ['Date', 'setTimeout']});
-        impl.boundOnAnimationEnd_ = sandbox.spy();
-        impl.buildCallback();
-
+        const triggerSpy = sandbox.spy(impl.action_, 'trigger');
+        sandbox.stub(timer, 'delay').callsFake(function(callback) {
+          callback();
+        });
         impl.scheduleLayout = sandbox.stub();
 
+        impl.buildCallback();
         impl.open_();
-        expect(impl.boundOnAnimationEnd_).to.be.calledOnce;
+        expect(triggerSpy).to.be.calledOnce;
+        expect(triggerSpy).to.be.calledWith(impl.element, 'sidebarOpen');
 
         impl.close_();
-        expect(impl.boundOnAnimationEnd_).to.be.calledTwice;
+        expect(triggerSpy).to.be.calledTwice;
+        expect(triggerSpy).to.be.calledWith(impl.element, 'sidebarClose');
       });
     });
   });


### PR DESCRIPTION
- Make the updating of the sidebar a bit more structured to ensure that we can never overwrite changes made by a later requested state.

Fixes #5730 