### PR TITLE
Clean up incosistent hack to patch document-register-element.

### DIFF
--- a/build-system/tasks/compile.js
+++ b/build-system/tasks/compile.js
@@ -121,7 +121,6 @@ function compile(entryModuleFilenames, outputDir,
       wrapper = options.wrapper.replace('<%= contents %>', '%output%');
     }
     wrapper += '\n//# sourceMappingURL=' + outputFilename + '.map\n';
-    patchRegisterElement();
     if (fs.existsSync(intermediateFilename)) {
       fs.unlinkSync(intermediateFilename);
     }
@@ -195,8 +194,8 @@ function compile(entryModuleFilenames, outputDir,
       'node_modules/promise-pjs/promise.js',
       'node_modules/web-animations-js/web-animations.install.js',
       'node_modules/web-activities/activity-ports.js',
-      'build/patched-module/document-register-element/build/' +
-          'document-register-element.node.js',
+      'node_modules/document-register-element/build/' +
+          'document-register-element.patched.js',
       // 'node_modules/core-js/modules/**.js',
       // Not sure what these files are, but they seem to duplicate code
       // one level below and confuse the compiler.
@@ -394,37 +393,4 @@ function compile(entryModuleFilenames, outputDir,
     }
     return stream;
   });
-}
-
-function patchRegisterElement() {
-  let file;
-  // Copies document-register-element into a new file that has an export.
-  // This works around a bug in closure compiler, where without the
-  // export this module does not generate a goog.provide which fails
-  // compilation.
-  // Details https://github.com/google/closure-compiler/issues/1831
-  const patchedName = 'build/patched-module/document-register-element' +
-      '/build/document-register-element.node.js';
-  if (!fs.existsSync(patchedName)) {
-    file = fs.readFileSync(
-        'node_modules/document-register-element/build/' +
-        'document-register-element.node.js').toString();
-    if (argv.fortesting) {
-      // Need to switch global to self since closure doesn't wrap the module
-      // like CommonJS
-      file = file.replace('installCustomElements(global);',
-          'installCustomElements(self);');
-    } else {
-      // Get rid of the side effect the module has so we can tree shake it
-      // better and control installation, unless --fortesting flag
-      // is passed since we also treat `--fortesting` mode as "dev".
-      file = file.replace('installCustomElements(global);', '');
-    }
-    // Closure Compiler does not generate a `default` property even though
-    // to interop CommonJS and ES6 modules. This is the same issue typescript
-    // ran into here https://github.com/Microsoft/TypeScript/issues/2719
-    file = file.replace('module.exports = installCustomElements;',
-        'exports.default = installCustomElements;');
-    fs.writeFileSync(patchedName, file);
-  }
 }

--- a/build-system/tasks/update-packages.js
+++ b/build-system/tasks/update-packages.js
@@ -74,7 +74,7 @@ function patchRegisterElement() {
     // to interop CommonJS and ES6 modules. This is the same issue typescript
     // ran into here https://github.com/Microsoft/TypeScript/issues/2719
     file = file.replace('module.exports = installCustomElements;',
-        'exports.default = installCustomElements;');
+        'module.exports = exports.default = installCustomElements;');
     fs.writeFileSync(patchedName, file);
   }
 }

--- a/build-system/tasks/update-packages.js
+++ b/build-system/tasks/update-packages.js
@@ -69,13 +69,24 @@ function patchRegisterElement() {
         'node_modules/document-register-element/build/' +
         'document-register-element.node.js').toString();
     // Eliminate the immediate side effect.
+    if (!/installCustomElements\(global\);/.test(file)) {
+      throw new Error('Expected "installCustomElements(global);" ' +
+          'to appear in document-register-element');
+    }
     file = file.replace('installCustomElements(global);', '');
     // Closure Compiler does not generate a `default` property even though
     // to interop CommonJS and ES6 modules. This is the same issue typescript
     // ran into here https://github.com/Microsoft/TypeScript/issues/2719
+    if (!/module.exports = installCustomElements;/.test(file)) {
+      throw new Error('Expected "module.exports = installCustomElements;" ' +
+          'to appear in document-register-element');
+    }
     file = file.replace('module.exports = installCustomElements;',
         'module.exports = exports.default = installCustomElements;');
     fs.writeFileSync(patchedName, file);
+    if (!process.env.TRAVIS) {
+      log(colors.green('Patched'), colors.cyan(patchedName));
+    }
   }
 }
 

--- a/src/polyfills.js
+++ b/src/polyfills.js
@@ -26,7 +26,7 @@ import {install as installPromise} from './polyfills/promise';
 // Importing the document-register-element module has the side effect
 // of installing the custom elements polyfill if necessary.
 import installCustomElements from
-  'document-register-element/build/document-register-element.node';
+  'document-register-element/build/document-register-element.patched';
 
 /**
   Only install in closure binary and not in babel/browserify binary, since in
@@ -35,9 +35,7 @@ import installCustomElements from
   sure to not `install` it during dev since the `install` is done as a side
   effect in importing the module.
 */
-if (!getMode().localDev) {
-  installCustomElements(self, 'auto');
-}
+installCustomElements(self, 'auto');
 installDOMTokenListToggle(self);
 installMathSign(self);
 installObjectAssign(self);

--- a/src/polyfills.js
+++ b/src/polyfills.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import {getMode} from './mode';
 import {install as installArrayIncludes} from './polyfills/array-includes';
 import {
   install as installDOMTokenListToggle,
@@ -28,13 +27,6 @@ import {install as installPromise} from './polyfills/promise';
 import installCustomElements from
   'document-register-element/build/document-register-element.patched';
 
-/**
-  Only install in closure binary and not in babel/browserify binary, since in
-  the closure binary we strip out the `document-register-element` install side
-  effect so we can tree shake the dependency correctly and we have to make
-  sure to not `install` it during dev since the `install` is done as a side
-  effect in importing the module.
-*/
 installCustomElements(self, 'auto');
 installDOMTokenListToggle(self);
 installMathSign(self);

--- a/src/service/extensions-impl.js
+++ b/src/service/extensions-impl.js
@@ -43,7 +43,7 @@ import {installStylesForDoc, installStylesLegacy} from '../style-installer';
 import {map} from '../utils/object';
 import {toWin} from '../types';
 import installCustomElements from
-  'document-register-element/build/document-register-element.node';
+  'document-register-element/build/document-register-element.patched';
 
 const TAG = 'extensions';
 const UNKNOWN_EXTENSION = '_UNKNOWN_';

--- a/testing/describes.js
+++ b/testing/describes.js
@@ -113,7 +113,7 @@ import {setStyles} from '../src/style';
 import {stubService} from './test-helper';
 import fetchMock from 'fetch-mock';
 import installCustomElements from
-  'document-register-element/build/document-register-element.node';
+  'document-register-element/build/document-register-element.patched';
 
 /** Should have something in the name, otherwise nothing is shown. */
 const SUB = ' ';

--- a/testing/iframe.js
+++ b/testing/iframe.js
@@ -30,7 +30,7 @@ import {installExtensionsService} from '../src/service/extensions-impl';
 import {installStylesLegacy} from '../src/style-installer';
 import {parseIfNeeded} from '../src/iframe-helper';
 import installCustomElements from
-  'document-register-element/build/document-register-element.node';
+  'document-register-element/build/document-register-element.patched';
 
 let iframeCount = 0;
 


### PR DESCRIPTION
Now uses the patched file everywhere (instead of different local/testing/compiled code path) and avoids relying on closure compiler file shadowing (by renaming the file instead of copying to shadow dir).