### PR TITLE
Run `gulp update-packages` just once on Travis

### DIFF
--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -389,11 +389,15 @@ const command = {
   buildValidator: function() {
     timedExecOrDie('gulp validator');
   },
+  updatePackages: function() {
+    timedExecOrDie('gulp update-packages');
+  },
 };
 
 function runAllCommands() {
   // Run different sets of independent tasks in parallel to reduce build time.
   if (process.env.BUILD_SHARD == 'unit_tests') {
+    command.updatePackages();
     command.testBuildSystem();
     command.cleanBuild();
     command.buildRuntime();
@@ -409,6 +413,7 @@ function runAllCommands() {
     command.buildValidator();
   }
   if (process.env.BUILD_SHARD == 'integration_tests') {
+    command.updatePackages();
     command.cleanBuild();
     command.buildRuntimeMinified(/* extensions */ true);
     // Disable bundle-size check on release branch builds.
@@ -544,6 +549,7 @@ function main() {
 
   // Run different sets of independent tasks in parallel to reduce build time.
   if (process.env.BUILD_SHARD == 'unit_tests') {
+    command.updatePackages();
     if (buildTargets.has('BUILD_SYSTEM') ||
         buildTargets.has('RUNTIME')) {
       command.testBuildSystem();
@@ -570,6 +576,7 @@ function main() {
   }
 
   if (process.env.BUILD_SHARD == 'integration_tests') {
+    command.updatePackages();
     if (buildTargets.has('INTEGRATION_TEST') ||
         buildTargets.has('RUNTIME') ||
         buildTargets.has('VISUAL_DIFF') ||

--- a/build-system/tasks/check-links.js
+++ b/build-system/tasks/check-links.js
@@ -25,6 +25,7 @@ const markdownLinkCheck = BBPromise.promisify(require('markdown-link-check'));
 const path = require('path');
 const {gitDiffAddedNameOnlyMaster, gitDiffNameOnlyMaster} = require('../git');
 
+const maybeUpdatePackages = process.env.TRAVIS ? [] : ['update-packages'];
 
 /**
  * Parses the list of files in argv, or extracts it from the commit log.
@@ -175,7 +176,7 @@ function runLinkChecker(markdownFile) {
 gulp.task(
     'check-links',
     'Detects dead links in markdown files',
-    ['update-packages'],
+    maybeUpdatePackages,
     checkLinks,
     {
       options: {

--- a/build-system/tasks/dep-check.js
+++ b/build-system/tasks/dep-check.js
@@ -35,6 +35,7 @@ const root = process.cwd();
 const absPathRegExp = new RegExp(`^${root}/`);
 const red = msg => log(colors.red(msg));
 
+const maybeUpdatePackages = process.env.TRAVIS ? [] : ['update-packages'];
 
 /**
  * @typedef {{
@@ -297,5 +298,5 @@ function flatten(arr) {
 gulp.task(
     'dep-check',
     'Runs a dependency check on each module',
-    ['update-packages', 'css'],
+    maybeUpdatePackages.concat(['css']),
     depCheck);

--- a/build-system/tasks/lint.js
+++ b/build-system/tasks/lint.js
@@ -34,6 +34,8 @@ const options = {
 };
 let collapseLintResults = !!process.env.TRAVIS;
 
+const maybeUpdatePackages = process.env.TRAVIS ? [] : ['update-packages'];
+
 /**
  * Initializes the linter stream based on globs
  * @param {!Object} globs
@@ -193,7 +195,7 @@ function lint() {
 gulp.task(
     'lint',
     'Validates against Google Closure Linter',
-    ['update-packages'],
+    maybeUpdatePackages,
     lint,
     {
       options: {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -65,6 +65,8 @@ const unminifiedRuntimeTarget = 'dist/amp.js';
 const unminifiedRuntimeEsmTarget = 'dist/amp-esm.js';
 const unminified3pTarget = 'dist.3p/current/integration.js';
 
+const maybeUpdatePackages = process.env.TRAVIS ? [] : ['update-packages'];
+
 extensionBundles.forEach(c => declareExtension(c.name, c.version, c.options));
 aliasBundles.forEach(c => {
   declareExtensionVersionAlias(c.name, c.version, c.latestVersion, c.options);
@@ -1509,7 +1511,7 @@ function toPromise(readable) {
 /**
  * Gulp tasks
  */
-gulp.task('build', 'Builds the AMP library', ['update-packages'], build, {
+gulp.task('build', 'Builds the AMP library', maybeUpdatePackages, build, {
   options: {
     config: '  Sets the runtime\'s AMP_CONFIG to one of "prod" or "canary"',
     extensions: '  Builds only the listed extensions.',
@@ -1518,16 +1520,16 @@ gulp.task('build', 'Builds the AMP library', ['update-packages'], build, {
 });
 gulp.task('check-all', 'Run through all presubmit checks',
     ['lint', 'dep-check', 'check-types', 'presubmit']);
-gulp.task('check-types', 'Check JS types', ['update-packages'], checkTypes);
-gulp.task('css', 'Recompile css to build directory', ['update-packages'], css);
+gulp.task('check-types', 'Check JS types', maybeUpdatePackages, checkTypes);
+gulp.task('css', 'Recompile css to build directory', maybeUpdatePackages, css);
 gulp.task('default', 'Runs "watch" and then "serve"',
-    ['update-packages', 'watch'], serve, {
+    maybeUpdatePackages.concat(['watch']), serve, {
       options: {
         extensions: '  Watches and builds only the listed extensions.',
         noextensions: '  Watches and builds with no extensions.',
       },
     });
-gulp.task('dist', 'Build production binaries', ['update-packages'], dist, {
+gulp.task('dist', 'Build production binaries', maybeUpdatePackages, dist, {
   options: {
     pseudo_names: '  Compiles with readable names. ' +
             'Great for profiling and debugging production code.',
@@ -1536,7 +1538,7 @@ gulp.task('dist', 'Build production binaries', ['update-packages'], dist, {
   },
 });
 gulp.task('watch', 'Watches for changes in files, re-builds when detected',
-    ['update-packages'], watch, {
+    maybeUpdatePackages, watch, {
       options: {
         with_inabox: '  Also watch and build the amp-inabox.js binary.',
         with_shadow: '  Also watch and build the amp-shadow.js binary.',


### PR DESCRIPTION
Several `gulp` tasks rely on the fact that all local dependencies are up to date, so they run `gulp update-packages` as a prerequisite. This is wasteful on Travis, since the task gets run multiple times.

This PR makes sure that `gulp update-packages` is run exactly once on Travis, at the start of each build shard.

Fixes #16839