### PR TITLE
Removed unused delayed impression code path.

### DIFF
--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -696,8 +696,6 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     // fluid, wait until after resize.
     if (this.isFluidRequest_ && !this.returnedSize_) {
       this.fluidImpressionUrl_ = responseHeaders.get('X-AmpImps');
-    } else {
-      this.fireDelayedImpressions(responseHeaders.get('X-AmpImps'));
     }
 
     return size;

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -693,7 +693,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
       size = this.getSlotSize();
     }
     // If this is a multi-size creative, fire delayed impression now. If it's
-    // fluid, wait until after resize.
+    // fluid, wait until after resize happens.
     if (this.isFluidRequest_ && !this.returnedSize_) {
       this.fluidImpressionUrl_ = responseHeaders.get('X-AmpImps');
     }

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -208,26 +208,7 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
       // ads/google/test/test-utils.js
     });
 
-    it('should load delayed impression amp-pixels', () => {
-      const fireDelayedImpressionsSpy =
-          sandbox.spy(impl, 'fireDelayedImpressions');
-      expect(impl.extractSize({
-        get(name) {
-          switch (name) {
-            case 'X-AmpImps':
-              return 'https://a.com?a=b,https://b.com?c=d';
-            default:
-              return undefined;
-          }
-        },
-        has(name) {
-          return !!this.get(name);
-        },
-      })).to.deep.equal(size);
-      expect(fireDelayedImpressionsSpy.withArgs(
-          'https://a.com?a=b,https://b.com?c=d')).to.be.calledOnce;
-    });
-    it('shouldnt load delayed impression amp-pixels with fluid', () => {
+    it('should load delayed impression amp-pixels with fluid', () => {
       const fireDelayedImpressionsSpy =
           sandbox.spy(impl, 'fireDelayedImpressions');
       impl.isFluidRequest_ = true;
@@ -244,10 +225,10 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
           return !!this.get(name);
         },
       })).to.deep.equal(size);
-      expect(fireDelayedImpressionsSpy.withArgs(
-          'https://a.com?a=b,https://b.com?c=d')).to.not.be.called;
+      expect(impl.fluidImpressionUrl_).to
+          .equal('https://a.com?a=b,https://b.com?c=d');
     });
-    it('should load delayed impression amp-pixels with fluid + multi-size',
+    it('should not load delayed impression amp-pixels with fluid + multi-size',
         () => {
           const fireDelayedImpressionsSpy =
               sandbox.spy(impl, 'fireDelayedImpressions');
@@ -268,8 +249,7 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
               return !!this.get(name);
             },
           })).to.deep.equal(size);
-          expect(fireDelayedImpressionsSpy.withArgs(
-              'https://a.com?a=b,https://b.com?c=d')).to.be.calledOnce;
+          expect(impl.fluidImpressionUrl_).to.not.be.ok;
         });
   });
 

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -209,8 +209,6 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
     });
 
     it('should load delayed impression amp-pixels with fluid', () => {
-      const fireDelayedImpressionsSpy =
-          sandbox.spy(impl, 'fireDelayedImpressions');
       impl.isFluidRequest_ = true;
       expect(impl.extractSize({
         get(name) {
@@ -230,8 +228,6 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
     });
     it('should not load delayed impression amp-pixels with fluid + multi-size',
         () => {
-          const fireDelayedImpressionsSpy =
-              sandbox.spy(impl, 'fireDelayedImpressions');
           sandbox.stub(impl, 'handleResize_');
           impl.isFluid_ = true;
           expect(impl.extractSize({


### PR DESCRIPTION
The removed code path fired erroneously when a fluid + multi-size request returned a multi-size creative, causing the impression to be double-counted.