### PR TITLE
🐛 Make amp-selector update options on amp-list update (e.g. under template)

### DIFF
--- a/extensions/amp-selector/0.1/amp-selector.js
+++ b/extensions/amp-selector/0.1/amp-selector.js
@@ -246,7 +246,7 @@ export class AmpSelector extends AMP.BaseElement {
   }
 
   /**
-   * @param {Array<Element>|undefined} opt_options
+   * @param {?Array<Element>} opt_options
    * @private
    */
   init_(opt_options) {

--- a/extensions/amp-selector/0.1/amp-selector.js
+++ b/extensions/amp-selector/0.1/amp-selector.js
@@ -15,6 +15,7 @@
  */
 
 import {ActionTrust} from '../../../src/action-constants';
+import {AmpEvents} from '../../../src/amp-events';
 import {CSS} from '../../../build/amp-selector-0.1.css';
 import {KeyCodes} from '../../../src/utils/key-codes';
 import {Services} from '../../../src/services';
@@ -137,6 +138,16 @@ export class AmpSelector extends AMP.BaseElement {
         this.toggle_(args['index'], args['value']);
       }
     }, ActionTrust.LOW);
+
+    // Listening to this event
+    // Simply listening for mutation would not work
+    this.element.addEventListener(AmpEvents.DOM_UPDATE, unusedEvent => {
+      // Clear prev states
+      this.options_ = [];
+      this.selectedOptions_ = [];
+      this.inputs_ = [];
+      this.init_();
+    });
   }
 
   /** @override */

--- a/extensions/amp-selector/0.1/amp-selector.js
+++ b/extensions/amp-selector/0.1/amp-selector.js
@@ -24,6 +24,7 @@ import {closestBySelector, isRTL, tryFocus} from '../../../src/dom';
 import {createCustomEvent} from '../../../src/event-helper';
 import {dev, user} from '../../../src/log';
 import {mod} from '../../../src/utils/math';
+import {toArray} from '../../../src/types';
 const TAG = 'amp-selector';
 
 /**
@@ -233,8 +234,7 @@ export class AmpSelector extends AMP.BaseElement {
    * @private
    */
   maybeRefreshOnUpdate_(unusedEvent) {
-    const newOptions =
-        [].slice.call(this.element.querySelectorAll('[option]'));
+    const newOptions = toArray(this.element.querySelectorAll('[option]'));
     if (areEqual(this.options_, newOptions)) { // no updates
       return;
     }
@@ -246,7 +246,7 @@ export class AmpSelector extends AMP.BaseElement {
   }
 
   /**
-   * @param {?Array<Element>} opt_options
+   * @param {Array<Element>=} opt_options
    * @private
    */
   init_(opt_options) {

--- a/extensions/amp-selector/0.1/amp-selector.js
+++ b/extensions/amp-selector/0.1/amp-selector.js
@@ -19,7 +19,7 @@ import {AmpEvents} from '../../../src/amp-events';
 import {CSS} from '../../../build/amp-selector-0.1.css';
 import {KeyCodes} from '../../../src/utils/key-codes';
 import {Services} from '../../../src/services';
-import {areEqual} from '../../../src/utils/array';
+import {areEqualOrdered} from '../../../src/utils/array';
 import {closestBySelector, isRTL, tryFocus} from '../../../src/dom';
 import {createCustomEvent} from '../../../src/event-helper';
 import {dev, user} from '../../../src/log';
@@ -235,7 +235,7 @@ export class AmpSelector extends AMP.BaseElement {
    */
   maybeRefreshOnUpdate_(unusedEvent) {
     const newOptions = toArray(this.element.querySelectorAll('[option]'));
-    if (areEqual(this.options_, newOptions)) { // no updates
+    if (areEqualOrdered(this.options_, newOptions)) { // no updates
       return;
     }
     // Clear prev states
@@ -252,7 +252,7 @@ export class AmpSelector extends AMP.BaseElement {
   init_(opt_options) {
     const options = opt_options ?
       opt_options :
-      [].slice.call(this.element.querySelectorAll('[option]'));
+      toArray(this.element.querySelectorAll('[option]'));
     options.forEach(option => {
       if (!option.hasAttribute('role')) {
         option.setAttribute('role', 'option');

--- a/extensions/amp-selector/0.1/test/test-selector-list.js
+++ b/extensions/amp-selector/0.1/test/test-selector-list.js
@@ -1,0 +1,113 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {AmpEvents} from '../../../../src/amp-events';
+import {AmpList} from '../../../amp-list/0.1/amp-list';
+import {AmpMustache} from '../../../amp-mustache/0.1/amp-mustache';
+import {AmpSelector} from '../amp-selector';
+import {Deferred} from '../../../../src/utils/promise';
+import {poll} from '../../../../testing/iframe';
+
+describes.realWin('amp-selector amp-list interaction', {
+  amp: {
+    extensions: ['amp-list', 'amp-selector', 'amp-mustache'],
+  },
+}, function(env) {
+  let win, doc, ampdoc;
+  let parent;
+  let selector;
+  let listElement;
+  let list;
+  let templateElement;
+  let updateDeferred;
+
+  let layoutPromise;
+
+  beforeEach(() => {
+    win = env.win;
+    win.AMP.registerTemplate('amp-mustache', AmpMustache);
+
+    doc = win.document;
+    ampdoc = env.ampdoc;
+
+    updateDeferred = new Deferred();
+
+    parent = doc.createElement('div');
+    doc.body.appendChild(parent);
+    parent.addEventListener(AmpEvents.DOM_UPDATE, () => {
+      updateDeferred.resolve();
+    });
+    const selectorElement = doc.createElement('div');
+    selectorElement.getAmpDoc = () => ampdoc;
+    selector = new AmpSelector(selectorElement);
+    parent.appendChild(selector.element);
+    selector.buildCallback();
+
+    listElement = doc.createElement('div');
+    listElement.setAttribute('src', '/list.json');
+    listElement.getAmpDoc = () => ampdoc;
+    listElement.getFallback = () => null;
+    listElement.toggleLoading = () => null;
+    listElement.togglePlaceholder = () => null;
+    listElement.getResources = () => win.services.resources.obj;
+
+    templateElement = doc.createElement('template');
+    templateElement.setAttribute('type', 'amp-mustache');
+    templateElement.innerHTML = '<div option="{{value}}">{{text}}</div>';
+    listElement.appendChild(templateElement);
+
+    selectorElement.appendChild(listElement);
+
+    AmpList.prototype.mutateElement = function(cb) { cb(); };
+    list = new AmpList(listElement);
+    list.fetch_ = () => {
+      return new Promise(resolve => {
+        setTimeout(() => {
+          resolve([
+            {value: 0, text: 'ZERO'},
+            {value: 1, text: 'ONE'},
+          ]);
+        }, 100);
+      });
+    };
+
+    list.scheduleRender_ = items => {
+      const deferred = new Deferred();
+      list.renderItems_ = {
+        items,
+        resolver: deferred.resolve,
+        rejecter: deferred.reject,
+      };
+      list.doRenderPass_();
+      return deferred.promise;
+    };
+    list.buildCallback();
+    layoutPromise = list.layoutCallback();
+  });
+
+  it('should load selector options correctly with template', function() {
+    return layoutPromise.then(() => {
+      return poll('wait for options to construct', () => {
+        return selector.options_.length > 0;
+      }, () => {}, 1000);
+    })
+        .then(() => {
+          expect(selector.options_.length).to.equal(2);
+          expect(selector.options_[0].getAttribute('option')).to.equal('0');
+          expect(selector.options_[1].getAttribute('option')).to.equal('1');
+        });
+  });
+});

--- a/extensions/amp-selector/0.1/test/test-selector-list.js
+++ b/extensions/amp-selector/0.1/test/test-selector-list.js
@@ -96,16 +96,6 @@ describes.realWin('amp-selector amp-list interaction', {
       });
     };
 
-    list.scheduleRender_ = items => {
-      const deferred = new Deferred();
-      list.renderItems_ = {
-        items,
-        resolver: deferred.resolve,
-        rejecter: deferred.reject,
-      };
-      list.doRenderPass_();
-      return deferred.promise;
-    };
     list.buildCallback();
     layoutPromise = list.layoutCallback();
   });

--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -510,7 +510,7 @@ class VideoEntry {
       return false;
     }
     return user().assert(this.video.isInteractive(),
-        'Only interactive videos are allowed to enter fullscreen on rotate.' +
+        'Only interactive videos are allowed to enter fullscreen on rotate.',
         'Set the `controls` attribute on %s to enable.',
         element);
   }

--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -510,7 +510,7 @@ class VideoEntry {
       return false;
     }
     return user().assert(this.video.isInteractive(),
-        'Only interactive videos are allowed to enter fullscreen on rotate.',
+        'Only interactive videos are allowed to enter fullscreen on rotate.' +
         'Set the `controls` attribute on %s to enable.',
         element);
   }

--- a/src/utils/array.js
+++ b/src/utils/array.js
@@ -15,6 +15,34 @@
  */
 
 /**
+  * Compares if two arrays contains exactly same elements (of same number)
+  * It will NOT step into array elements if ever seen, simply compare current
+  * level references.
+  * Notice it does NOT handle NaN case as expected.
+  *
+  * @param {!Array<T>} arr1
+  * @param {!Array<T>} arr2
+  * @return {boolean}
+  * @template T
+  */
+export function areEqual(arr1, arr2) {
+  if (arr1.length !== arr2.length) {
+    return false;
+  }
+
+  const arr2Copy = arr2.slice();
+  for (let i = 0; i < arr1.length; i++) {
+    const index = arr2Copy.indexOf(arr1[i]);
+    if (index < 0) {
+      return false;
+    }
+    arr2Copy.splice(index, 1);
+  }
+
+  return arr2Copy.length === 0;
+}
+
+/**
  * A bit like Array#filter, but removes elements that filter false from the
  * array. Returns the filtered items.
  *

--- a/src/utils/array.js
+++ b/src/utils/array.js
@@ -14,32 +14,29 @@
  * limitations under the License.
  */
 
+
 /**
-  * Compares if two arrays contains exactly same elements (of same number)
-  * It will NOT step into array elements if ever seen, simply compare current
-  * level references.
-  * Notice it does NOT handle NaN case as expected.
-  *
-  * @param {!Array<T>} arr1
-  * @param {!Array<T>} arr2
-  * @return {boolean}
-  * @template T
-  */
-export function areEqual(arr1, arr2) {
+ * Compares if two arrays contains exactly same elements of same number
+ * of same order.
+ * Notice that it does NOT handle NaN case as expected
+ *
+ * @param {!Array<T>} arr1
+ * @param {!Array<T>} arr2
+ * @return {boolean}
+ * @template T
+ */
+export function areEqualOrdered(arr1, arr2) {
   if (arr1.length !== arr2.length) {
     return false;
   }
 
-  const arr2Copy = arr2.slice();
   for (let i = 0; i < arr1.length; i++) {
-    const index = arr2Copy.indexOf(arr1[i]);
-    if (index < 0) {
+    if (arr1[i] !== arr2[i]) {
       return false;
     }
-    arr2Copy.splice(index, 1);
   }
 
-  return arr2Copy.length === 0;
+  return true;
 }
 
 /**

--- a/test/functional/utils/test-array.js
+++ b/test/functional/utils/test-array.js
@@ -15,33 +15,24 @@
  */
 
 import {
-  areEqual,
+  areEqualOrdered,
   filterSplice,
   findIndex,
   fromIterator,
   pushIfNotExist,
 } from '../../../src/utils/array';
 
-describe('areEqual', function() {
+describe('areEqualOrdered', function() {
   it('should return true on empty arrays',
       () => {
-        const result = areEqual([], []);
+        const result = areEqualOrdered([], []);
         expect(result).to.be.true;
       });
 
   it('should return true on same array with primitive types of same seq',
       () => {
-        const result = areEqual(
+        const result = areEqualOrdered(
             [1, 'string', true, undefined, null],
-            [1, 'string', true, undefined, null]
-        );
-        expect(result).to.be.true;
-      });
-
-  it('should return true on same array with primitive types of different seq',
-      () => {
-        const result = areEqual(
-            [null, true, 'string', undefined, 1],
             [1, 'string', true, undefined, null]
         );
         expect(result).to.be.true;
@@ -54,75 +45,38 @@ describe('areEqual', function() {
         const o3 = new Function('whatever');
         const o4 = {};
         const o5 = [];
-        const result = areEqual(
+        const result = areEqualOrdered(
             [o1, o2, o3, o4, o5],
             [o1, o2, o3, o4, o5]
         );
         expect(result).to.be.true;
       });
 
-  it('should return true on same array with objects of different seq',
+  it('should return false on same array with primitive types of different seq',
+      () => {
+        const result = areEqualOrdered(
+            [null, true, 'string', undefined, 1],
+            [1, 'string', true, undefined, null]
+        );
+        expect(result).to.be.false;
+      });
+
+  it('should return false on same array with objects of different seq',
       () => {
         const o1 = {a: 1};
         const o2 = () => { return 'arrow func'; };
         const o3 = new Function('whatever');
         const o4 = {};
         const o5 = [];
-        const result = areEqual(
+        const result = areEqualOrdered(
             [o4, o5, o3, o2, o1],
             [o1, o2, o3, o4, o5]
         );
-        expect(result).to.be.true;
-      });
-
-  it('should return true on same array with objects of repeated occurrence',
-      () => {
-        const o1 = {a: 1};
-        const o2 = () => { return 'arrow func'; };
-        const o3 = new Function('whatever');
-        const o4 = {};
-        const o5 = [];
-        const result = areEqual(
-            [o1, o2, o3, o4, o5, o1, o2],
-            [o1, o2, o3, o4, o5, o1, o2]
-        );
-        expect(result).to.be.true;
+        expect(result).to.be.false;
       });
 
   it('should return false on array of different length', () => {
-    const result = areEqual([1, 2, 3], [1, 2, 3, 3]);
-    expect(result).to.be.false;
-  });
-
-  it('should return false on array of different primitive elements', () => {
-    const result = areEqual(
-        [null, true, 'string', undefined, 1],
-        [1, 'something else', true, undefined, null]
-    );
-    expect(result).to.be.false;
-  });
-
-  it('should return false on array of different object elements', () => {
-    const o1 = {a: 1};
-    const o2 = () => { return 'arrow func'; };
-    const o3 = new Function('whatever');
-    const o4 = {};
-    const o5 = [];
-    const result = areEqual(
-        [o1, o2, o3, o4],
-        [o1, o2, o3, o5]
-    );
-    expect(result).to.be.false;
-  });
-
-  it('should return false on array of different object references', () => {
-    const o1 = {a: 1};
-    const o2 = () => { return 'arrow func'; };
-    const o3 = new Function('whatever');
-    const result = areEqual(
-        [o1, o2, o3, {a: 1}, []],
-        [o1, o2, o3, {a: 1}, []]
-    );
+    const result = areEqualOrdered([1, 2, 3], [1, 2, 3, 3]);
     expect(result).to.be.false;
   });
 });

--- a/test/functional/utils/test-array.js
+++ b/test/functional/utils/test-array.js
@@ -15,11 +15,117 @@
  */
 
 import {
+  areEqual,
   filterSplice,
   findIndex,
   fromIterator,
   pushIfNotExist,
 } from '../../../src/utils/array';
+
+describe('areEqual', function() {
+  it('should return true on empty arrays',
+      () => {
+        const result = areEqual([], []);
+        expect(result).to.be.true;
+      });
+
+  it('should return true on same array with primitive types of same seq',
+      () => {
+        const result = areEqual(
+            [1, 'string', true, undefined, null],
+            [1, 'string', true, undefined, null]
+        );
+        expect(result).to.be.true;
+      });
+
+  it('should return true on same array with primitive types of different seq',
+      () => {
+        const result = areEqual(
+            [null, true, 'string', undefined, 1],
+            [1, 'string', true, undefined, null]
+        );
+        expect(result).to.be.true;
+      });
+
+  it('should return true on same array with objects of same seq',
+      () => {
+        const o1 = {a: 1};
+        const o2 = () => { return 'arrow func'; };
+        const o3 = new Function('whatever');
+        const o4 = {};
+        const o5 = [];
+        const result = areEqual(
+            [o1, o2, o3, o4, o5],
+            [o1, o2, o3, o4, o5]
+        );
+        expect(result).to.be.true;
+      });
+
+  it('should return true on same array with objects of different seq',
+      () => {
+        const o1 = {a: 1};
+        const o2 = () => { return 'arrow func'; };
+        const o3 = new Function('whatever');
+        const o4 = {};
+        const o5 = [];
+        const result = areEqual(
+            [o4, o5, o3, o2, o1],
+            [o1, o2, o3, o4, o5]
+        );
+        expect(result).to.be.true;
+      });
+
+  it('should return true on same array with objects of repeated occurrence',
+      () => {
+        const o1 = {a: 1};
+        const o2 = () => { return 'arrow func'; };
+        const o3 = new Function('whatever');
+        const o4 = {};
+        const o5 = [];
+        const result = areEqual(
+            [o1, o2, o3, o4, o5, o1, o2],
+            [o1, o2, o3, o4, o5, o1, o2]
+        );
+        expect(result).to.be.true;
+      });
+
+  it('should return false on array of different length', () => {
+    const result = areEqual([1, 2, 3], [1, 2, 3, 3]);
+    expect(result).to.be.false;
+  });
+
+  it('should return false on array of different primitive elements', () => {
+    const result = areEqual(
+        [null, true, 'string', undefined, 1],
+        [1, 'something else', true, undefined, null]
+    );
+    expect(result).to.be.false;
+  });
+
+  it('should return false on array of different object elements', () => {
+    const o1 = {a: 1};
+    const o2 = () => { return 'arrow func'; };
+    const o3 = new Function('whatever');
+    const o4 = {};
+    const o5 = [];
+    const result = areEqual(
+        [o1, o2, o3, o4],
+        [o1, o2, o3, o5]
+    );
+    expect(result).to.be.false;
+  });
+
+  it('should return false on array of different object references', () => {
+    const o1 = {a: 1};
+    const o2 = () => { return 'arrow func'; };
+    const o3 = new Function('whatever');
+    const result = areEqual(
+        [o1, o2, o3, {a: 1}, []],
+        [o1, o2, o3, {a: 1}, []]
+    );
+    expect(result).to.be.false;
+  });
+});
 
 describe('filterSplice', function() {
   let array;


### PR DESCRIPTION
Resets `amp-selector` saved states on `amp-list` emitting `AmpEvents.DOM_UPDATE`. Since `amp-list` is reconstructing container from scratch on refresh, it should be reasonable to simply clear selector state and call `init_()` again.

Closes #9536 