### PR TITLE
🐛Fix trivial assert args error

### DIFF
--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -515,7 +515,7 @@ class VideoEntry {
       return false;
     }
     return user().assert(this.video.isInteractive(),
-        'Only interactive videos are allowed to enter fullscreen on rotate.',
+        'Only interactive videos are allowed to enter fullscreen on rotate.' +
         'Set the `controls` attribute on %s to enable.',
         element);
   }

--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -515,7 +515,7 @@ class VideoEntry {
       return false;
     }
     return user().assert(this.video.isInteractive(),
-        'Only interactive videos are allowed to enter fullscreen on rotate.' +
+        'Only interactive videos are allowed to enter fullscreen on rotate. ' +
         'Set the `controls` attribute on %s to enable.',
         element);
   }


### PR DESCRIPTION
Saw this when checking out the code. Replacing `,` with `+` to avoid confusing error message (on `assert` instead of the intended error)