### PR TITLE
🏗🐛 Patch `node_modules` during `gulp update-packages`  when contents change

### DIFF
--- a/build-system/tasks/update-packages.js
+++ b/build-system/tasks/update-packages.js
@@ -24,6 +24,20 @@ const {exec, getStderr} = require('../exec');
 const yarnExecutable = 'npx yarn';
 
 /**
+ * Returns true if the contents of the given file are equal to data.
+ * (Returns false if the file doesn't exist.)
+ * @param {string} filename
+ * @param {string} data
+ */
+function fileContentsMatch(filename, data) {
+  if (!fs.existsSync(filename)) {
+    return false;
+  }
+  const fileContents = fs.readFileSync(filename);
+  return fileContents == data;
+}
+
+/**
  * Patches Web Animations API by wrapping its body into `install` function.
  * This gives us an option to call polyfill directly on the main window
  * or a friendly iframe.
@@ -32,9 +46,6 @@ function patchWebAnimations() {
   // Copies web-animations-js into a new file that has an export.
   const patchedName = 'node_modules/web-animations-js/' +
       'web-animations.install.js';
-  if (fs.existsSync(patchedName)) {
-    return;
-  }
   let file = fs.readFileSync(
       'node_modules/web-animations-js/' +
       'web-animations.min.js').toString();
@@ -49,9 +60,11 @@ function patchWebAnimations() {
       }) +
       '\n' +
       '}\n';
-  fs.writeFileSync(patchedName, file);
-  if (!process.env.TRAVIS) {
-    log(colors.green('Patched'), colors.cyan(patchedName));
+  if (!fileContentsMatch(patchedName, file)) {
+    fs.writeFileSync(patchedName, file);
+    if (!process.env.TRAVIS) {
+      log(colors.green('Patched'), colors.cyan(patchedName));
+    }
   }
 }
 
@@ -68,25 +81,25 @@ function patchRegisterElement() {
   // Details https://github.com/google/closure-compiler/issues/1831
   const patchedName = 'node_modules/document-register-element' +
       '/build/document-register-element.patched.js';
-  if (!fs.existsSync(patchedName)) {
-    file = fs.readFileSync(
-        'node_modules/document-register-element/build/' +
-        'document-register-element.node.js').toString();
-    // Eliminate the immediate side effect.
-    if (!/installCustomElements\(global\);/.test(file)) {
-      throw new Error('Expected "installCustomElements(global);" ' +
-          'to appear in document-register-element');
-    }
-    file = file.replace('installCustomElements(global);', '');
-    // Closure Compiler does not generate a `default` property even though
-    // to interop CommonJS and ES6 modules. This is the same issue typescript
-    // ran into here https://github.com/Microsoft/TypeScript/issues/2719
-    if (!/module.exports = installCustomElements;/.test(file)) {
-      throw new Error('Expected "module.exports = installCustomElements;" ' +
-          'to appear in document-register-element');
-    }
-    file = file.replace('module.exports = installCustomElements;',
-        'exports.installCustomElements = installCustomElements;');
+  file = fs.readFileSync(
+      'node_modules/document-register-element/build/' +
+      'document-register-element.node.js').toString();
+  // Eliminate the immediate side effect.
+  if (!/installCustomElements\(global\);/.test(file)) {
+    throw new Error('Expected "installCustomElements(global);" ' +
+        'to appear in document-register-element');
+  }
+  file = file.replace('installCustomElements(global);', '');
+  // Closure Compiler does not generate a `default` property even though
+  // to interop CommonJS and ES6 modules. This is the same issue typescript
+  // ran into here https://github.com/Microsoft/TypeScript/issues/2719
+  if (!/module.exports = installCustomElements;/.test(file)) {
+    throw new Error('Expected "module.exports = installCustomElements;" ' +
+        'to appear in document-register-element');
+  }
+  file = file.replace('module.exports = installCustomElements;',
+      'exports.installCustomElements = installCustomElements;');
+  if (!fileContentsMatch(patchedName, file)) {
     fs.writeFileSync(patchedName, file);
     if (!process.env.TRAVIS) {
       log(colors.green('Patched'), colors.cyan(patchedName));
@@ -129,7 +142,7 @@ function runYarnCheck() {
 
 /**
  * Installs custom lint rules, updates node_modules (for local dev), and patches
- * web-animations-js if necessary.
+ * web-animations-js and document-register-element if necessary.
  */
 function updatePackages() {
   installCustomEslintRules();


### PR DESCRIPTION
In `gulp update-packages`, we create two new files `node_modules/web-animations-js/web-animations.install.js` and `node_modules/document-register-element/build/document-register-element.patched.js` if they don't exist. This breaks if the Travis cache of `node_modules` contains a stale file.

In this PR, we update the files if their contents have changed, thereby making `gulp update-packages` resilient in the presence of a stale cache.

For context, see https://github.com/ampproject/amphtml/pull/16857#issue-202325051

Fixes #16871