### PR TITLE
🏗🐛 Fail Karma when zero tests are detected

### DIFF
--- a/build-system/tasks/runtime-test.js
+++ b/build-system/tasks/runtime-test.js
@@ -616,8 +616,13 @@ function runTests() {
       console./* OK*/log('travis_fold:start:console_errors_' + sectionMarker);
     }
   }).on('browser_complete', function(browser) {
+    const result = browser.lastResult;
+    // Prevent cases where Karma detects zero tests and still passes. #16851.
+    if (result.total == 0) {
+      log(red('ERROR: Zero tests detected by Karma. Something went wrong.'));
+      process.exit();
+    }
     if (shouldCollapseSummary) {
-      const result = browser.lastResult;
       let message = browser.name + ': ';
       message += 'Executed ' + (result.success + result.failed) +
           ' of ' + result.total + ' (Skipped ' + result.skipped + ') ';


### PR DESCRIPTION
In the past, Karma used to fail when zero tests were run (`failOnEmptyTestSuite` was `true`). However, with `gulp test --local-changes`, running zero tests became a valid case (like when all tests in a file were skipped), so `failOnEmptyTestSuite` was set to `false`. This resulted failures like the one in #16851 going undetected.

This PR introduces a new mechanism to flag a failure when the total number of tests in a suite (`browser.lastResult.total`) is detected as zero. Note that this still allows for cases where all tests in a suite are skipped on a particular browser (where `browser.lastResult.total` is non-zero).

Fixes #16851
