### PR TITLE
Prevent video ads from autoplaying in the background.

### DIFF
--- a/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
+++ b/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
@@ -328,6 +328,11 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
       const signals = impl.signals();
       return signals.whenSignal(CommonSignals.INI_LOAD);
     }).then(() => {
+      // Ensures the video-manager does not follow the autoplay attribute on
+      // amp-video tags, which would play the ad in the background before it is
+      // displayed.
+      ampStoryAdPage.getImpl().then(impl => impl.delegateVideoAutoplay());
+
       // remove loading attribute once loaded so that desktop CSS will position
       // offscren with all other pages
       const currentPageEl = this.adPageEls_[this.adPageEls_.length - 1];

--- a/extensions/amp-story-auto-ads/0.1/test/test-amp-story-auto-ads.js
+++ b/extensions/amp-story-auto-ads/0.1/test/test-amp-story-auto-ads.js
@@ -99,6 +99,10 @@ describes.realWin('amp-story-auto-ads', {
       sandbox.stub(autoAds, 'createAdElement_').returns(ad);
       autoAds.adPageEls_ = [ad];
 
+      const page = win.document.createElement('amp-story-page');
+      sandbox.stub(autoAds, 'createPageElement_').returns(page);
+      page.getImpl = () => Promise.resolve({delegateVideoAutoplay: () => {}});
+
       const analyticsStub = sandbox.stub(autoAds, 'analyticsEvent_');
       autoAds.createAdPage_();
       yield macroTask();

--- a/extensions/amp-story/0.1/amp-story-page.js
+++ b/extensions/amp-story/0.1/amp-story-page.js
@@ -147,7 +147,7 @@ export class AmpStoryPage extends AMP.BaseElement {
   /** @override */
   buildCallback() {
     upgradeBackgroundAudio(this.element);
-    this.configureVideo_();
+    this.delegateVideoAutoplay();
     this.markMediaElementsWithPreload_();
     this.initializeMediaPool_();
     this.maybeCreateAnimationManager_();
@@ -161,8 +161,12 @@ export class AmpStoryPage extends AMP.BaseElement {
   }
 
 
-  /** @private */
-  configureVideo_() {
+  /**
+   * Delegates video autoplay so the video manager does not follow the
+   * autoplay attribute that may have been set by a publisher, which could
+   * play videos from an inactive page.
+   */
+  delegateVideoAutoplay() {
     const videos = this.element.querySelectorAll('amp-video');
     if (videos.length < 1) {
       return;

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -164,7 +164,7 @@ export class AmpStoryPage extends AMP.BaseElement {
   /** @override */
   buildCallback() {
     upgradeBackgroundAudio(this.element);
-    this.configureVideo_();
+    this.delegateVideoAutoplay();
     this.markMediaElementsWithPreload_();
     this.initializeMediaPool_();
     this.maybeCreateAnimationManager_();
@@ -178,8 +178,12 @@ export class AmpStoryPage extends AMP.BaseElement {
   }
 
 
-  /** @private */
-  configureVideo_() {
+  /**
+   * Delegates video autoplay so the video manager does not follow the
+   * autoplay attribute that may have been set by a publisher, which could
+   * play videos from an inactive page.
+   */
+  delegateVideoAutoplay() {
     const videos = this.element.querySelectorAll('amp-video');
     if (videos.length < 1) {
       return;


### PR DESCRIPTION
The `amp-story-page.buildCallback` is executed before the ad loads, while the video is not rendered yet.

A better fix would be to create the `amp-story-page` element after the ad is loaded, so the `buildCallback` can handle the media elements just like for any other page.
But that would require some refactoring in the `amp-story-auto-ads` extension, to support asynchronous ad pages creation without breaking the analytics.

This fix simply ensures the general `video-manager` won't follow the `autoplay` attribute once the ad loads and the `amp-video` is appended in the DOM.

Fixes #16880