### PR TITLE
Implement fixed transfer layer for shadow embed mode

### DIFF
--- a/build-system/tasks/bundle-size.js
+++ b/build-system/tasks/bundle-size.js
@@ -22,7 +22,7 @@ const log = require('fancy-log');
 const {getStdout} = require('../exec');
 
 const runtimeFile = './dist/v0.js';
-const maxSize = '79.06KB';
+const maxSize = '79.18KB';
 
 const {green, red, cyan, yellow} = colors;
 

--- a/examples/everything.amp.html
+++ b/examples/everything.amp.html
@@ -36,7 +36,7 @@
       opacity: 0.7;
       position: fixed;
       z-index: 1000;
-      top: 100px;
+      top: 0px;
       right: 10px;
       width: 40px;
       height: 40px;

--- a/src/service/fixed-layer.js
+++ b/src/service/fixed-layer.js
@@ -24,7 +24,6 @@ import {
 } from '../style';
 import {dev, user} from '../log';
 import {endsWith} from '../string';
-import {htmlFor} from '../static-template';
 import {isExperimentOn} from '../experiments';
 
 const TAG = 'FixedLayer';
@@ -71,7 +70,7 @@ export class FixedLayer {
     /** @private @const {boolean} */
     this.transfer_ = transfer && ampdoc.isSingleDoc();
 
-    /** @private {?Element} */
+    /** @private {?TransferLayerDef} */
     this.transferLayer_ = null;
 
     /** @private {number} */
@@ -87,7 +86,9 @@ export class FixedLayer {
   setVisible(visible) {
     if (this.transferLayer_) {
       this.vsync_.mutate(() => {
-        setStyle(this.transferLayer_, 'visibility',
+        setStyle(
+            this.transferLayer_.getRoot(),
+            'visibility',
             visible ? 'visible' : 'hidden');
       });
     }
@@ -220,7 +221,7 @@ export class FixedLayer {
         for (let i = 0; i < removed.length; i++) {
           const fe = removed[i];
           if (fe.position == 'fixed') {
-            this.returnFromTransferLayer_(fe);
+            this.transferLayer_.returnFrom(fe);
           }
         }
       });
@@ -375,10 +376,7 @@ export class FixedLayer {
       },
       mutate: state => {
         if (hasTransferables && this.transfer_) {
-          const transferLayer = this.getTransferLayer_();
-          if (transferLayer.className != this.ampdoc.getBody().className) {
-            transferLayer.className = this.ampdoc.getBody().className;
-          }
+          this.getTransferLayer_().update();
         }
         const elements = this.elements_;
         for (let i = 0; i < elements.length; i++) {
@@ -590,8 +588,9 @@ export class FixedLayer {
     fe.transform = state.transform;
 
     // Move back to the BODY layer and reset transfer z-index.
-    if (oldFixed && (!state.fixed || !state.transferrable)) {
-      this.returnFromTransferLayer_(fe);
+    if (oldFixed && (!state.fixed || !state.transferrable) &&
+        this.transferLayer_) {
+      this.transferLayer_.returnFrom(fe);
     }
 
     // Update `top`. This is necessary to adjust position to the viewer's
@@ -602,7 +601,7 @@ export class FixedLayer {
         // non iOS Safari.
         setStyle(element, 'top', `calc(${state.top} + ${this.paddingTop_}px)`);
       } else {
-        // On iOS Safari (this.transfer_ = true), stickies need to be cannot
+        // On iOS Safari (this.transfer_ = true), stickies cannot
         // have an offset because they are already offset by the padding-top.
         if (this.committedPaddingTop_ === this.paddingTop_) {
           // So, when the header is shown, just use top.
@@ -616,96 +615,13 @@ export class FixedLayer {
     }
 
     // Move element to the fixed layer.
-    if (this.transfer_ && state.fixed && !oldFixed && state.transferrable) {
-      this.transferToTransferLayer_(fe, index, state);
+    if (this.transfer_ && state.fixed && state.transferrable) {
+      this.getTransferLayer_().transferTo(fe, index, state);
     }
   }
 
   /**
-   * @param {!ElementDef} fe
-   * @param {number} index
-   * @param {!ElementStateDef} state
-   * @private
-   */
-  transferToTransferLayer_(fe, index, state) {
-    const {element} = fe;
-    if (element.parentElement == this.transferLayer_) {
-      return;
-    }
-
-    dev().fine(TAG, 'transfer to fixed:', fe.id, fe.element);
-    user().warn(TAG, 'In order to improve scrolling performance in Safari,' +
-        ' we now move the element to a fixed positioning layer:', fe.element);
-
-    if (!fe.placeholder) {
-      // Never been transfered before: ensure that it's properly configured.
-      setStyle(element, 'pointer-events', 'initial');
-      const placeholder = fe.placeholder = htmlFor(element)`
-          <i-amphtml-fpa style="display: none"></i-amphtml-fpa>`;
-      placeholder.setAttribute('i-amphtml-fixedid', fe.id);
-    }
-
-    // Calculate z-index based on the declared z-index and DOM position.
-    setStyle(element, 'zIndex',
-        `calc(${10000 + index} + ${state.zIndex || 0})`);
-
-    element.parentElement.replaceChild(fe.placeholder, element);
-    this.getTransferLayer_().appendChild(element);
-
-    // Test if the element still matches one of the `fixed` selectors. If not
-    // return it back to BODY.
-    const matches = fe.selectors.some(
-        selector => this.matches_(element, selector));
-    if (!matches) {
-      user().warn(TAG,
-          'Failed to move the element to the fixed position layer.' +
-          ' This is most likely due to the compound CSS selector:',
-          fe.element);
-      this.returnFromTransferLayer_(fe);
-    }
-  }
-
-  /**
-   * @param {!Element} element
-   * @param {string} selector
-   * @return {boolean}
-   */
-  matches_(element, selector) {
-    try {
-      const matcher = element.matches ||
-          element.webkitMatchesSelector ||
-          element.mozMatchesSelector ||
-          element.msMatchesSelector ||
-          element.oMatchesSelector;
-      if (matcher) {
-        return matcher.call(element, selector);
-      }
-    } catch (e) {
-      // Fail silently.
-      dev().error(TAG, 'Failed to test query match:', e);
-    }
-    return false;
-  }
-
-  /**
-   * @param {!ElementDef} fe
-   * @private
-   */
-  returnFromTransferLayer_(fe) {
-    if (!fe.placeholder || !this.ampdoc.contains(fe.placeholder)) {
-      return;
-    }
-    dev().fine(TAG, 'return from fixed:', fe.id, fe.element);
-    if (this.ampdoc.contains(fe.element)) {
-      setStyle(fe.element, 'zIndex', '');
-      fe.placeholder.parentElement.replaceChild(fe.element, fe.placeholder);
-    } else {
-      fe.placeholder.parentElement.removeChild(fe.placeholder);
-    }
-  }
-
-  /**
-   * @return {?Element}
+   * @return {?TransferLayerDef}
    */
   getTransferLayer_() {
     // This mode is only allowed for a single-doc case.
@@ -713,35 +629,10 @@ export class FixedLayer {
       return this.transferLayer_;
     }
     const doc = this.ampdoc.win.document;
-    this.transferLayer_ = doc.body.cloneNode(/* deep */ false);
-    this.transferLayer_.removeAttribute('style');
-    setStyles(this.transferLayer_, {
-      position: 'absolute',
-      top: 0,
-      left: 0,
-      height: 0,
-      width: 0,
-      pointerEvents: 'none',
-      overflow: 'hidden',
-
-      // Reset possible BODY styles.
-      animation: 'none',
-      background: 'none',
-      border: 'none',
-      borderImage: 'none',
-      boxSizing: 'border-box',
-      boxShadow: 'none',
-      display: 'block',
-      float: 'none',
-      margin: 0,
-      opacity: 1,
-      outline: 'none',
-      padding: 'none',
-      transform: 'none',
-      transition: 'none',
-      visibility: 'visible',
-    });
-    doc.documentElement.appendChild(this.transferLayer_);
+    this.transferLayer_ =
+        doc.body.shadowRoot ?
+          new TransferLayerShadow(doc) :
+          new TransferLayerBody(doc);
     return this.transferLayer_;
   }
 
@@ -789,6 +680,7 @@ export class FixedLayer {
  */
 let ElementDef;
 
+
 /**
  * @typedef {{
  *   fixed: boolean,
@@ -799,3 +691,237 @@ let ElementDef;
  * }}
  */
 let ElementStateDef;
+
+
+/**
+ * The contract for transfer layer.
+ * @interface
+ */
+class TransferLayerDef {
+
+  /**
+   * @return {!Element}
+   */
+  getRoot() {}
+
+  /**
+   * Update most current styles for the transfer layer.
+   */
+  update() {}
+
+  /**
+   * Transfer the element from the body into the transfer layer.
+   * @param {!ElementDef} unusedFe
+   * @param {number} unusedIndex
+   * @param {!ElementStateDef} unusedState
+   */
+  transferTo(unusedFe, unusedIndex, unusedState) {}
+
+  /**
+   * Return the element from the transfer layer back to the body.
+   * @param {!ElementDef} unusedFe
+   */
+  returnFrom(unusedFe) {}
+}
+
+
+/**
+ * The parallel `<body>` element is created and fixed elements are moved into
+ * this element.
+ * @implements {TransferLayerDef}
+ */
+class TransferLayerBody {
+  /**
+   * @param {!Document} doc
+   */
+  constructor(doc) {
+    /** @private @const {!Document} */
+    this.doc_ = doc;
+
+    /** @private @const {!Element} */
+    this.layer_ = doc.body.cloneNode(/* deep */ false);
+    this.layer_.removeAttribute('style');
+    setStyles(this.layer_, {
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      height: 0,
+      width: 0,
+      pointerEvents: 'none',
+      overflow: 'hidden',
+
+      // Reset possible BODY styles.
+      animation: 'none',
+      background: 'none',
+      border: 'none',
+      borderImage: 'none',
+      boxSizing: 'border-box',
+      boxShadow: 'none',
+      display: 'block',
+      float: 'none',
+      margin: 0,
+      opacity: 1,
+      outline: 'none',
+      padding: 'none',
+      transform: 'none',
+      transition: 'none',
+      visibility: 'visible',
+    });
+    doc.documentElement.appendChild(this.layer_);
+  }
+
+  /** @override */
+  getRoot() {
+    return this.layer_;
+  }
+
+  /** @override */
+  update() {
+    if (this.layer_.className != this.doc_.body.className) {
+      this.layer_.className = this.doc_.body.className;
+    }
+  }
+
+  /** @override */
+  transferTo(fe, index, state) {
+    const {element} = fe;
+    if (element.parentElement == this.layer_) {
+      return;
+    }
+
+    dev().fine(TAG, 'transfer to fixed:', fe.id, fe.element);
+    user().warn(TAG, 'In order to improve scrolling performance in Safari,' +
+        ' we now move the element to a fixed positioning layer:', fe.element);
+
+    if (!fe.placeholder) {
+      // Never been transfered before: ensure that it's properly configured.
+      setStyle(element, 'pointer-events', 'initial');
+      const placeholder = fe.placeholder = this.doc_.createElement(
+          'i-amphtml-fpa');
+      setStyle(placeholder, 'display', 'none');
+      placeholder.setAttribute('i-amphtml-fixedid', fe.id);
+    }
+
+    // Calculate z-index based on the declared z-index and DOM position.
+    setStyle(element, 'zIndex',
+        `calc(${10000 + index} + ${state.zIndex || 0})`);
+
+    element.parentElement.replaceChild(fe.placeholder, element);
+    this.layer_.appendChild(element);
+
+    // Test if the element still matches one of the `fixed` selectors. If not
+    // return it back to BODY.
+    const matches = fe.selectors.some(
+        selector => this.matches_(element, selector));
+    if (!matches) {
+      user().warn(TAG,
+          'Failed to move the element to the fixed position layer.' +
+          ' This is most likely due to the compound CSS selector:',
+          fe.element);
+      this.returnFrom(fe);
+    }
+  }
+
+  /** @override */
+  returnFrom(fe) {
+    if (!fe.placeholder || !this.doc_.contains(fe.placeholder)) {
+      return;
+    }
+    dev().fine(TAG, 'return from fixed:', fe.id, fe.element);
+    if (this.doc_.contains(fe.element)) {
+      setStyle(fe.element, 'zIndex', '');
+      fe.placeholder.parentElement.replaceChild(fe.element, fe.placeholder);
+    } else {
+      fe.placeholder.parentElement.removeChild(fe.placeholder);
+    }
+  }
+
+  /**
+   * @param {!Element} element
+   * @param {string} selector
+   * @return {boolean}
+   * @private
+   */
+  matches_(element, selector) {
+    try {
+      const matcher = element.matches ||
+          element.webkitMatchesSelector ||
+          element.mozMatchesSelector ||
+          element.msMatchesSelector ||
+          element.oMatchesSelector;
+      if (matcher) {
+        return matcher.call(element, selector);
+      }
+    } catch (e) {
+      // Fail silently.
+      dev().error(TAG, 'Failed to test query match:', e);
+    }
+    return false;
+  }
+}
+
+
+const FIXED_LAYER_SLOT = 'i-amphtml-fixed';
+
+
+/**
+ * The fixed layer is created inside the shadow root of the `<body>` element
+ * and fixed elements are distributed into this element via slots.
+ * @implements {TransferLayerDef}
+ */
+class TransferLayerShadow {
+  /**
+   * @param {!Document} doc
+   */
+  constructor(doc) {
+    /** @private @const {!Document} */
+    this.doc_ = doc;
+
+    /** @private @const {!Element} */
+    this.layer_ = doc.createElement('div');
+    this.layer_.id = 'i-amphtml-fixed-layer';
+    setImportantStyles(this.layer_, {
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      height: 0,
+      width: 0,
+      overflow: 'hidden',
+    });
+
+    // The slot where all fixed elements will be distributed.
+    const slot = doc.createElement('slot');
+    slot.setAttribute('name', FIXED_LAYER_SLOT);
+    this.layer_.appendChild(slot);
+
+    doc.body.shadowRoot.appendChild(this.layer_);
+  }
+
+  /** @override */
+  getRoot() {
+    return this.layer_;
+  }
+
+  /** @override */
+  update() {
+    // Nothing to do.
+  }
+
+  /** @override */
+  transferTo(fe) {
+    const {element} = fe;
+
+    dev().fine(TAG, 'transfer to fixed:', fe.id, fe.element);
+    user().warn(TAG, 'In order to improve scrolling performance in Safari,' +
+        ' we now move the element to a fixed positioning layer:', fe.element);
+
+    // Distribute to the slot.
+    element.setAttribute('slot', FIXED_LAYER_SLOT);
+  }
+
+  /** @override */
+  returnFrom(fe) {
+    dev().fine(TAG, 'return from fixed:', fe.id, fe.element);
+    fe.element.removeAttribute('slot');
+  }
+}

--- a/src/service/viewport/viewport-binding-ios-embed-sd.js
+++ b/src/service/viewport/viewport-binding-ios-embed-sd.js
@@ -284,7 +284,7 @@ export class ViewportBindingIosEmbedShadowRoot_ {
 
   /** @override */
   requiresFixedLayerTransfer() {
-    return false;
+    return true;
   }
 
   /** @override */

--- a/test/functional/test-viewport-binding.js
+++ b/test/functional/test-viewport-binding.js
@@ -479,7 +479,7 @@ describes.realWin('ViewportBindingIosEmbedShadowRoot_', {ampCss: true}, env => {
   });
 
   it('should NOT require fixed layer transferring', () => {
-    expect(binding.requiresFixedLayerTransfer()).to.be.false;
+    expect(binding.requiresFixedLayerTransfer()).to.be.true;
   });
 
   it('should start w/o overscroll and set it on doc ready', () => {


### PR DESCRIPTION
Closes #16755.

Refactoring is done to make this implementation possible. The transfer layer is extracted from FixedLayer class into a separate interface and two implementations provided: the current body-based, and the new shadow-based.
