### PR TITLE
Restrict `no-mixed-operators` lint rule to just `&&` and `||`

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -118,7 +118,7 @@
     "no-implied-eval": 2,
     "no-iterator": 2,
     "no-lone-blocks": 2,
-    "no-mixed-operators": 1,
+    "no-mixed-operators": [1, { "groups": [["&&", "||"]] }],
     "no-multi-spaces": 2,
     "no-native-reassign": 2,
     "no-redeclare": 2,


### PR DESCRIPTION
With this, the `no-mixed-operators` becomes less annoying, and the number of warnings goes down from ~170 to ~40

Fixes #16876