### PR TITLE
:sparkles: Add Criteo RTC callout URL

### DIFF
--- a/extensions/amp-a4a/0.1/callout-vendors.js
+++ b/extensions/amp-a4a/0.1/callout-vendors.js
@@ -82,6 +82,11 @@ export const RTC_VENDORS = {
     macros: ['PUB_ID', 'PARAMS'],
     disableKeyAppend: true,
   },
+  criteo: {
+    url: 'https://bidder.criteo.com/amp/rtc?zid=ZONE_ID&nid=NETWORK_ID&psubid=PUBLISHER_SUB_ID&lir=LINE_ITEM_RANGES&w=ATTR(width)&h=ATTR(height)&ow=ATTR(data-override-width)&oh=ATTR(data-override-height)&ms=ATTR(data-multi-size)&slot=ATTR(data-slot)&timeout=TIMEOUT&href=HREF',
+    macros: ['ZONE_ID', 'NETWORK_ID', 'PUBLISHER_SUB_ID', 'LINE_ITEM_RANGES'],
+    disableKeyAppend: true,
+  },
 };
 
 // DO NOT MODIFY: Setup for tests


### PR DESCRIPTION
This PR adds the Criteo RTC callout URL in `callout-vendors.js`.

_Note: in our case, some parameters are optional and therefore are passed to our endpoint as-is (i.e. `&nid=NETWORK_ID` in the called URL). Is there a way to have the macros replaced by empty strings in the URL when not provided by the publisher?
From what I see in [handleRtcForVendorUrls](https://github.com/ampproject/amphtml/blob/10ae1b0268defeb92b533a7baeb59baeda9292e0/extensions/amp-a4a/0.1/real-time-config-manager.js#L288), there doesn't seem to be a way to do this currently. Would a PR to change this behavior (if necessary behind a vendor setting in the same way as `disableKeyAppend`) be accepted?_