### PR TITLE
Add amp-fx to the whitelist of attributes allowed on amp-list templates

### DIFF
--- a/src/purifier.js
+++ b/src/purifier.js
@@ -101,6 +101,7 @@ export const TRIPLE_MUSTACHE_WHITELISTED_TAGS = [
  */
 export const WHITELISTED_ATTRS = [
   // AMP-only attributes that don't exist in HTML.
+  'amp-fx',
   'fallback',
   'heights',
   'layout',


### PR DESCRIPTION
Fixes #16838 

