### PR TITLE
🐛📖Fix <amp-youtube> load error & Update documentation on `rotate-to-fullscreen`

### DIFF
--- a/extensions/amp-youtube/0.1/amp-youtube.js
+++ b/extensions/amp-youtube/0.1/amp-youtube.js
@@ -157,7 +157,6 @@ class AmpYoutube extends AMP.BaseElement {
     }
 
     installVideoManagerForDoc(this.element);
-    Services.videoManagerForDoc(this.element).register(this);
   }
 
   /**
@@ -234,6 +233,10 @@ class AmpYoutube extends AMP.BaseElement {
     const iframe = createFrameFor(this, this.getVideoIframeSrc_());
 
     this.iframe_ = iframe;
+
+    // Listening for VideoEvents.LOAD in AutoFullscreenManager.register may
+    // introduce race conditions which may break elements e.g. amp-ima-video
+    Services.videoManagerForDoc(this.element).register(this);
 
     this.unlistenMessage_ = listen(
         this.win,

--- a/extensions/amp-youtube/validator-amp-youtube.protoascii
+++ b/extensions/amp-youtube/validator-amp-youtube.protoascii
@@ -50,6 +50,10 @@ tags: {  # <amp-youtube>
     mandatory_oneof: "['data-live-channelid', 'data-videoid']"
     value_regex: "[^=/?:]+"
   }
+  attrs: {
+    name: "rotate-to-fullscreen"
+    value: ""
+  }
   # <amp-bind>
   attrs: { name: "[data-videoid]" }
   attr_lists: "extended-amp-global"

--- a/extensions/amp-youtube/validator-amp-youtube.protoascii
+++ b/extensions/amp-youtube/validator-amp-youtube.protoascii
@@ -50,10 +50,6 @@ tags: {  # <amp-youtube>
     mandatory_oneof: "['data-live-channelid', 'data-videoid']"
     value_regex: "[^=/?:]+"
   }
-  attrs: {
-    name: "rotate-to-fullscreen"
-    value: ""
-  }
   # <amp-bind>
   attrs: { name: "[data-videoid]" }
   attr_lists: "extended-amp-global"

--- a/spec/amp-video-interface.md
+++ b/spec/amp-video-interface.md
@@ -118,6 +118,8 @@ Represents the `fullscreen` button.
 
 attribute: **`rotate-to-fullscreen`**
 
+This attribute is currently only supported for `amp-video`, `amp-ima-video` and `amp-dailymotion`.
+
 If this attribute is present and a video is playing manually (i.e. user initiated playback, or tapped on the video after autoplay), the video displays fullscreen after the user rotates their device into landscape mode, provided that the video is visible.
 
 When multiple videos with the `rotate-to-fullscreen` attribute set are visible


### PR DESCRIPTION
Moves video registration from `buildCallback` to `layoutCallback` after the creation of iframe to avoid failed user assertion.

Currently there is no YouTube API support for fullscreen.

Update `spec/amp-video-interface.md` to specially highlight actual extensions that supports `rotate-to-fullscreen`.

