### PR TITLE
✅🐛 Replace explicitly failing promise in `test-base-element.js` with equivalent chai-as-promised code

### DIFF
--- a/test/functional/test-base-element.js
+++ b/test/functional/test-base-element.js
@@ -205,9 +205,7 @@ describes.realWin('BaseElement', {amp: true}, env => {
 
       return Promise.all([
         event1Promise,
-        event2Promise
-            .then(() => { assert.fail('Blur should not have been forwarded'); })
-            .catch(() => { /* timed-out, all good */ }),
+        expect(event2Promise).to.eventually.be.rejectedWith(/timeout/),
       ]);
     });
 


### PR DESCRIPTION
This test doesn't really do what you expect it to do. If `event2promise` is fulfilled, the `assert.fail` line will raise an exception, at which point it will get passed to that promise's `catch`er, and the test will pass regardless.

This PR replaces that with a more explicit expectation, which essentially "reversed" the rejection of `event2promise` with a fulfillment.