### PR TITLE
♻️ Replace direct `hasOwnProperty` with `src/utils/object.js#hasOwn` [extensions/amp-[e-s]*]

### DIFF
--- a/extensions/amp-experiment/0.1/test/test-amp-experiment.js
+++ b/extensions/amp-experiment/0.1/test/test-amp-experiment.js
@@ -17,6 +17,7 @@
 import * as variant from '../variant';
 import {AmpExperiment} from '../amp-experiment';
 import {Services} from '../../../../src/services';
+import {hasOwn} from '../../../../src/utils/object';
 
 
 describes.realWin('amp-experiment', {
@@ -67,7 +68,7 @@ describes.realWin('amp-experiment', {
 
   function expectBodyHasAttributes(attributes) {
     for (const attributeName in attributes) {
-      if (attributes.hasOwnProperty(attributeName)) {
+      if (hasOwn(attributes, attributeName)) {
         expect(doc.body.getAttribute(attributeName))
             .to.equal(attributes[attributeName]);
       }

--- a/extensions/amp-experiment/0.1/variant.js
+++ b/extensions/amp-experiment/0.1/variant.js
@@ -16,6 +16,7 @@
 
 import {Services} from '../../../src/services';
 import {dev, user} from '../../../src/log';
+import {hasOwn} from '../../../src/utils/object';
 import {isObject} from '../../../src/types';
 
 const ATTR_PREFIX = 'amp-x-';
@@ -36,7 +37,7 @@ export function allocateVariant(ampdoc, experimentName, config) {
   // Variant can be overridden from URL fragment.
   const viewer = Services.viewerForDoc(ampdoc);
   const override = viewer.getParam(ATTR_PREFIX + experimentName);
-  if (override && config['variants'].hasOwnProperty(override)) {
+  if (override && hasOwn(config['variants'], override)) {
     return Promise.resolve(/** @type {?string} */ (override));
   }
 
@@ -93,7 +94,7 @@ function validateConfig(config) {
   }
   let totalPercentage = 0;
   for (const variantName in variants) {
-    if (variants.hasOwnProperty(variantName)) {
+    if (hasOwn(variants, variantName)) {
       assertName(variantName);
       const percentage = variants[variantName];
       user().assert(

--- a/extensions/amp-gwd-animation/0.1/amp-gwd-animation-impl.js
+++ b/extensions/amp-gwd-animation/0.1/amp-gwd-animation-impl.js
@@ -15,6 +15,7 @@
  */
 import {createCustomEvent} from '../../../src/event-helper';
 import {escapeCssSelectorIdent} from '../../../src/dom';
+import {hasOwn} from '../../../src/utils/object';
 import {toArray} from '../../../src/types';
 import {user} from '../../../src/log';
 
@@ -100,7 +101,7 @@ const LOG_ID = 'GWD';
  */
 function getCounter(receiver, counterName) {
   if (receiver[GOTO_COUNTER_PROP] &&
-      receiver[GOTO_COUNTER_PROP].hasOwnProperty(counterName)) {
+      hasOwn(receiver[GOTO_COUNTER_PROP], counterName)) {
     return receiver[GOTO_COUNTER_PROP][counterName];
   }
   return 0;
@@ -118,7 +119,7 @@ function setCounter(receiver, counterName, counterValue) {
   if (!receiver[GOTO_COUNTER_PROP]) {
     receiver[GOTO_COUNTER_PROP] = {};
   }
-  if (!receiver[GOTO_COUNTER_PROP].hasOwnProperty(counterName)) {
+  if (!hasOwn(receiver[GOTO_COUNTER_PROP], counterName)) {
     receiver[GOTO_COUNTER_PROP][counterName] = 0;
   }
   receiver[GOTO_COUNTER_PROP][counterName] = counterValue;

--- a/extensions/amp-story/0.1/amp-story-store-service.js
+++ b/extensions/amp-story/0.1/amp-story-store-service.js
@@ -17,6 +17,7 @@
 import {EmbedMode, parseEmbedMode} from './embed-mode';
 import {Observable} from '../../../src/observable';
 import {dev} from '../../../src/log';
+import {hasOwn} from '../../../src/utils/object';
 
 
 /** @type {string} */
@@ -191,7 +192,7 @@ export class AmpStoryStoreService {
    * @return {*}
    */
   get(key) {
-    if (!this.state_.hasOwnProperty(key)) {
+    if (!hasOwn(this.state_, key)) {
       dev().error(TAG, `Unknown state ${key}.`);
       return;
     }
@@ -206,7 +207,7 @@ export class AmpStoryStoreService {
    *                                     triggered with current value.
    */
   subscribe(key, listener, callToInitialize = false) {
-    if (!this.state_.hasOwnProperty(key)) {
+    if (!hasOwn(this.state_, key)) {
       dev().error(TAG, `Can't subscribe to unknown state ${key}.`);
       return;
     }

--- a/extensions/amp-story/1.0/amp-story-store-service.js
+++ b/extensions/amp-story/1.0/amp-story-store-service.js
@@ -17,6 +17,7 @@
 import {EmbedMode, parseEmbedMode} from './embed-mode';
 import {Observable} from '../../../src/observable';
 import {dev} from '../../../src/log';
+import {hasOwn} from '../../../src/utils/object';
 
 
 /** @type {string} */
@@ -206,7 +207,7 @@ export class AmpStoryStoreService {
    * @return {*}
    */
   get(key) {
-    if (!this.state_.hasOwnProperty(key)) {
+    if (!hasOwn(this.state_, key)) {
       dev().error(TAG, `Unknown state ${key}.`);
       return;
     }
@@ -221,7 +222,7 @@ export class AmpStoryStoreService {
    *                                     triggered with current value.
    */
   subscribe(key, listener, callToInitialize = false) {
-    if (!this.state_.hasOwnProperty(key)) {
+    if (!hasOwn(this.state_, key)) {
       dev().error(TAG, `Can't subscribe to unknown state ${key}.`);
       return;
     }

--- a/extensions/amp-subscriptions/0.1/platform-store.js
+++ b/extensions/amp-subscriptions/0.1/platform-store.js
@@ -18,7 +18,7 @@ import {Deferred} from '../../../src/utils/promise';
 import {Entitlement} from './entitlement';
 import {Observable} from '../../../src/observable';
 import {dev, user} from '../../../src/log';
-import {dict} from '../../../src/utils/object';
+import {dict, hasOwn} from '../../../src/utils/object';
 
 
 /** @typedef {{serviceId: string, entitlement: (!./entitlement.Entitlement|undefined)}} */
@@ -335,7 +335,7 @@ export class PlatformStore {
   getAvailablePlatformsEntitlements_() {
     const entitlements = [];
     for (const platform in this.entitlements_) {
-      if (this.entitlements_.hasOwnProperty(platform)) {
+      if (hasOwn(this.entitlements_, platform)) {
         entitlements.push(this.entitlements_[platform]);
       }
     }


### PR DESCRIPTION
Related to #6548