### PR TITLE
Ignore resize failure when 3p iframe can handle overflow

### DIFF
--- a/3p/ampcontext.js
+++ b/3p/ampcontext.js
@@ -212,11 +212,13 @@ export class AbstractAmpContext {
    *    This is not guaranteed to succeed. All this does is make the request.
    *  @param {number} width The new width for the ad we are requesting.
    *  @param {number} height The new height for the ad we are requesting.
+   *  @param {boolean=} hasOverflow Whether the ad handles its own overflow ele
    */
-  requestResize(width, height) {
+  requestResize(width, height, hasOverflow) {
     this.client_.sendMessage(MessageType.EMBED_SIZE, dict({
       'width': width,
       'height': height,
+      'hasOverflow': hasOverflow,
     }));
   }
 

--- a/build-system/tasks/bundle-size.js
+++ b/build-system/tasks/bundle-size.js
@@ -22,7 +22,7 @@ const log = require('fancy-log');
 const {getStdout} = require('../exec');
 
 const runtimeFile = './dist/v0.js';
-const maxSize = '79.20KB';
+const maxSize = '79.23KB';
 
 const {green, red, cyan, yellow} = colors;
 

--- a/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
@@ -166,7 +166,7 @@ export class AmpAdXOriginIframeHandler {
     this.unlisteners_.push(listenFor(this.iframe, 'embed-size',
         (data, source, origin) => {
           if (!!data['hasOverflow']) {
-            this.element_.has3pOverflow = true;
+            this.element_.warnOnMissingOverflow = false;
           }
           this.handleResize_(data['height'], data['width'], source, origin);
         }, true, true));

--- a/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
@@ -165,6 +165,9 @@ export class AmpAdXOriginIframeHandler {
     // Install iframe resize API.
     this.unlisteners_.push(listenFor(this.iframe, 'embed-size',
         (data, source, origin) => {
+          if (!!data['hasOverflow']) {
+            this.element_.has3pOverflow = true;
+          }
           this.handleResize_(data['height'], data['width'], source, origin);
         }, true, true));
 

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -221,6 +221,9 @@ function createBaseCustomElementClass(win) {
       /** @private {!./size-list.SizeList|null|undefined} */
       this.heightsList_ = undefined;
 
+      /** @public {boolean} */
+      this.has3pOverflow = false;
+
       /**
        * This element can be assigned by the {@link applyStaticLayout} to a
        * child element that will be used to size this element.
@@ -1665,7 +1668,7 @@ function createBaseCustomElementClass(win) {
     overflowCallback(overflown, requestedHeight, requestedWidth) {
       this.getOverflowElement();
       if (!this.overflowElement_) {
-        if (overflown) {
+        if (overflown && !this.has3pOverflow) {
           user().warn(TAG,
               'Cannot resize element and overflow is not available', this);
         }

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -222,7 +222,7 @@ function createBaseCustomElementClass(win) {
       this.heightsList_ = undefined;
 
       /** @public {boolean} */
-      this.has3pOverflow = false;
+      this.warnOnMissingOverflow = true;
 
       /**
        * This element can be assigned by the {@link applyStaticLayout} to a
@@ -1668,7 +1668,7 @@ function createBaseCustomElementClass(win) {
     overflowCallback(overflown, requestedHeight, requestedWidth) {
       this.getOverflowElement();
       if (!this.overflowElement_) {
-        if (overflown && !this.has3pOverflow) {
+        if (overflown && this.warnOnMissingOverflow) {
           user().warn(TAG,
               'Cannot resize element and overflow is not available', this);
         }


### PR DESCRIPTION
Closes #11154 

This only allows 3p ad iframe to handle resize failure. We can easily expand the feature to other 3p iframes. 

Generally I don't like the idea of writing `this.element_.has3pOverflow = true` from a helper function, but using `setAttribute` is more expensive I guess. Happy to switch if there's better way to pass the boolean value to the customElement class

