### PR TITLE
🐛Fix scroll animation not finishing if the viewer becomes inactive.

### DIFF
--- a/build-system/tasks/bundle-size.js
+++ b/build-system/tasks/bundle-size.js
@@ -22,7 +22,7 @@ const log = require('fancy-log');
 const {getStdout} = require('../exec');
 
 const runtimeFile = './dist/v0.js';
-const maxSize = '79.18KB';
+const maxSize = '79.19KB';
 
 const {green, red, cyan, yellow} = colors;
 

--- a/build-system/tasks/bundle-size.js
+++ b/build-system/tasks/bundle-size.js
@@ -22,7 +22,7 @@ const log = require('fancy-log');
 const {getStdout} = require('../exec');
 
 const runtimeFile = './dist/v0.js';
-const maxSize = '79.19KB';
+const maxSize = '79.20KB';
 
 const {green, red, cyan, yellow} = colors;
 

--- a/src/service/viewport/viewport-impl.js
+++ b/src/service/viewport/viewport-impl.js
@@ -594,7 +594,9 @@ export class Viewport {
     // transition experience when things are closer vs farther.
     return Animation.animate(parent, position => {
       this.setElementScrollTop_(parent, interpolate(position));
-    }, duration, curve).then();
+    }, duration, curve).thenAlways(() => {
+      this.setElementScrollTop_(parent, newScrollTop);
+    });
   }
 
   /**


### PR DESCRIPTION
- Use `.thenAlways` on the animation to make sure we end up in the right state if the animation gets cancelled due to visibility.

Fixes #16901