### PR TITLE
show better stack traces on assertion errors

### DIFF
--- a/build-system/tasks/karma.conf.js
+++ b/build-system/tasks/karma.conf.js
@@ -30,6 +30,8 @@ const SAUCE_TIMEOUT_CONFIG = {
   idleTimeout: 5 * 60,
 };
 
+const preprocessors = ['browserify'];
+
 /**
  * @param {!Object} config
  */
@@ -40,14 +42,15 @@ module.exports = {
     'mocha',
     'sinon-chai',
     'chai',
+    'source-map-support',
   ],
 
   preprocessors: {
     './test/fixtures/*.html': ['html2js'],
-    './test/**/*.js': ['browserify'],
-    './ads/**/test/test-*.js': ['browserify'],
-    './extensions/**/test/**/*.js': ['browserify'],
-    './testing/**/*.js': ['browserify'],
+    './test/**/*.js': preprocessors,
+    './ads/**/test/test-*.js': preprocessors,
+    './extensions/**/test/**/*.js': preprocessors,
+    './testing/**/*.js': preprocessors,
   },
 
   // TODO(rsimha, #15510): Sauce labs on Safari doesn't reliably support
@@ -60,7 +63,7 @@ module.exports = {
     debug: true,
     basedir: __dirname + '/../../',
     transform: [
-      ['babelify', {compact: false}],
+      ['babelify', {compact: false, sourceMapsAbsolute: true}],
     ],
     bundleDelay: 1200,
   },
@@ -244,6 +247,7 @@ module.exports = {
   plugins: [
     'karma-browserify',
     'karma-chai',
+    'karma-source-map-support',
     'karma-chrome-launcher',
     'karma-edge-launcher',
     'karma-firefox-launcher',

--- a/package.json
+++ b/package.json
@@ -129,6 +129,7 @@
     "karma-sauce-launcher": "1.2.0",
     "karma-simple-reporter": "2.0.0",
     "karma-sinon-chai": "2.0.2",
+    "karma-source-map-support": "1.3.0",
     "karma-super-dots-reporter": "0.2.0",
     "lazypipe": "1.0.1",
     "lolex": "2.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7159,6 +7159,12 @@ karma-sinon-chai@2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/karma-sinon-chai/-/karma-sinon-chai-2.0.2.tgz#e28c109b989973abafc28a7c9f09ef24a05e07c2"
 
+karma-source-map-support@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/karma-source-map-support/-/karma-source-map-support-1.3.0.tgz#36dd4d8ca154b62ace95696236fae37caf0a7dde"
+  dependencies:
+    source-map-support "^0.5.5"
+
 karma-super-dots-reporter@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/karma-super-dots-reporter/-/karma-super-dots-reporter-0.2.0.tgz#71c3ac8ee0b7353ef2234fe43815f740d254544a"
@@ -11304,6 +11310,13 @@ source-map-support@^0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.0.tgz#2018a7ad2bdf8faf2691e5fddab26bed5a2bacab"
   dependencies:
+    source-map "^0.6.0"
+
+source-map-support@^0.5.5:
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.6.tgz#4435cee46b1aab62b8e8610ce60f788091c51c13"
+  dependencies:
+    buffer-from "^1.0.0"
     source-map "^0.6.0"
 
 source-map-url@^0.4.0:


### PR DESCRIPTION
before
<img width="883" alt="screen shot 2018-07-19 at 2 54 17 pm" src="https://user-images.githubusercontent.com/354746/42972464-65b9465c-8b64-11e8-9e46-7c9acf7230fd.png">

vs

after
<img width="800" alt="screen shot 2018-07-19 at 2 55 47 pm" src="https://user-images.githubusercontent.com/354746/42972471-6e8913ac-8b64-11e8-9b19-6301847cda64.png">

Fixes https://github.com/ampproject/amphtml/issues/16802