### PR TITLE
♻️ Rename `hasOwn` to `hasOwnProperty`

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -69,7 +69,7 @@
     "amphtml-internal/no-export-side-effect": 2,
     "amphtml-internal/no-for-of-statement": 2,
     "amphtml-internal/no-global": 0,
-    "amphtml-internal/no-has-own-property-method": 1,
+    "amphtml-internal/no-has-own-property-method": 2,
     "amphtml-internal/no-mixed-operators": 2,
     "amphtml-internal/no-spread": 2,
     "amphtml-internal/no-style-property-setting": 2,

--- a/3p/3p.js
+++ b/3p/3p.js
@@ -23,7 +23,7 @@
 
 
 import {dev, user} from '../src/log';
-import {hasOwn, map} from '../src/utils/object';
+import {hasOwnProperty, map} from '../src/utils/object';
 import {isArray} from '../src/types';
 import {rethrowAsync} from '../src/log';
 
@@ -280,7 +280,7 @@ function validateAllowedFields(data, allowedFields) {
   };
 
   for (const field in data) {
-    if (!hasOwn(data, field) || field in defaultAvailableFields) {
+    if (!hasOwnProperty(data, field) || field in defaultAvailableFields) {
       continue;
     }
     if (allowedFields.indexOf(field) < 0) {

--- a/3p/embedly.js
+++ b/3p/embedly.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {hasOwn} from '../src/utils/object';
+import {hasOwnProperty} from '../src/utils/object';
 import {loadScript} from './3p';
 import {setStyle} from '../src/style';
 
@@ -85,7 +85,7 @@ export function embedly(global, data) {
   // when these are provided by component.
   for (const key in CardOptions) {
     if (
-      hasOwn(CardOptions, key) &&
+      hasOwnProperty(CardOptions, key) &&
       typeof data[key] !== 'undefined'
     ) {
       card.setAttribute(`data-${CardOptions[key]}`, data[key]);

--- a/ads/adincube.js
+++ b/ads/adincube.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {hasOwn} from '../src/utils/object';
+import {hasOwnProperty} from '../src/utils/object';
 import {loadScript, validateData} from '../3p/3p';
 
 /**
@@ -51,7 +51,7 @@ function parseParams(data) {
     const params = JSON.parse(data);
     let queryParams = '';
     for (const p in params) {
-      if (hasOwn(params, p)) {
+      if (hasOwnProperty(params, p)) {
         queryParams += '&' + p + '=' + encodeURIComponent(params[p]);
       }
     }

--- a/ads/adplugg.js
+++ b/ads/adplugg.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {hasOwn} from '../src/utils/object';
+import {hasOwnProperty} from '../src/utils/object';
 import {loadScript, validateData} from '../3p/3p';
 
 /**
@@ -59,10 +59,10 @@ export function adplugg(global,data) {
         function(event) {
           // Create the opt_data object.
           const optData = {};
-          if (hasOwn(event, 'width')) {
+          if (hasOwnProperty(event, 'width')) {
             optData.width = event.width;
           }
-          if (hasOwn(event, 'height')) {
+          if (hasOwnProperty(event, 'height')) {
             optData.height = event.height;
           }
           global.context.renderStart(optData);

--- a/ads/adventive.js
+++ b/ads/adventive.js
@@ -15,7 +15,7 @@
  */
 
 import {addParamsToUrl} from '../src/url.js';
-import {dict, hasOwn} from '../src/utils/object';
+import {dict, hasOwnProperty} from '../src/utils/object';
 import {endsWith, startsWith} from '../src/string';
 import {loadScript, validateData, writeScript} from '../3p/3p';
 
@@ -24,7 +24,7 @@ import {loadScript, validateData, writeScript} from '../3p/3p';
  * @param {!Object} data
  */
 export function adventive(global, data) {
-  if (hasOwn(data, 'isDev')) {
+  if (hasOwnProperty(data, 'isDev')) {
     adventive_(global, data);
   } else {
     validateData(data, ['src'], ['isDev']);
@@ -73,9 +73,9 @@ const adv = {
 function adventive_(global, data) {
   validateData(data, requiredData, optionalData);
 
-  if (!hasOwn(global, 'adventive')) { global.adventive = adv; }
+  if (!hasOwnProperty(global, 'adventive')) { global.adventive = adv; }
   const ns = global.adventive;
-  if (!hasOwn(ns, 'context')) { ns.context = global.context; }
+  if (!hasOwnProperty(ns, 'context')) { ns.context = global.context; }
 
   if (!Object.isFrozen(ns.mode)) {
     updateMode(ns.mode, global.context.location.hostname);
@@ -83,8 +83,9 @@ function adventive_(global, data) {
 
   const cb = callback.bind(this, data.pid, ns),
       url = getUrl(global.context, data, ns);
-  url ?
-    (hasOwn(data, 'async') ? loadScript : writeScript)(global, url, cb) : cb();
+  url ? (
+    hasOwnProperty(data, 'async') ? loadScript : writeScript)(
+      global, url, cb) : cb();
 }
 
 /**
@@ -117,7 +118,7 @@ function callback(id, ns) { ns.addInstance(id); }
  */
 function getUrl(context, data, ns) {
   const {mode} = ns,
-      isDev = hasOwn(data, 'isDev'),
+      isDev = hasOwnProperty(data, 'isDev'),
       sld_ = sld[!mode.dev],
       thld_ = thld[isDev && !mode.live],
       search = reduceSearch(ns, data.pid, data.click, context.referrer),
@@ -139,7 +140,7 @@ function getUrl(context, data, ns) {
  *    representation of the url search query.
  */
 function reduceSearch(ns, placementId, click, referrer) {
-  const isRecipeLoaded = hasOwn(ns.args, 'placementId'),
+  const isRecipeLoaded = hasOwnProperty(ns.args, 'placementId'),
       isRecipeStale = !isRecipeLoaded ? true :
         (Date.now() - ns.args[placementId].requestTime) > (60 * cacheTime),
       needsRequest = !isRecipeLoaded || isRecipeStale;

--- a/ads/connatix.js
+++ b/ads/connatix.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {hasOwn} from '../src/utils/object.js';
+import {hasOwnProperty} from '../src/utils/object.js';
 import {tryParseJson} from '../src/json.js';
 import {validateData} from '../3p/3p';
 
@@ -32,7 +32,7 @@ export function connatix(global, data) {
   const cnxData = Object.assign(Object(tryParseJson(data['connatix'])));
   global.cnxAmpAd = true;
   for (const key in cnxData) {
-    if (hasOwn(cnxData, key)) {
+    if (hasOwnProperty(cnxData, key)) {
       script.setAttribute(key, cnxData[key]);
     }
   }

--- a/ads/google/adsense.js
+++ b/ads/google/adsense.js
@@ -17,7 +17,7 @@
 import {ADSENSE_RSPV_WHITELISTED_HEIGHT} from './utils';
 import {CONSENT_POLICY_STATE} from '../../src/consent-state';
 import {camelCaseToDash} from '../../src/string';
-import {hasOwn} from '../../src/utils/object';
+import {hasOwnProperty} from '../../src/utils/object';
 import {setStyles} from '../../src/style';
 import {user} from '../../src/log';
 import {validateData} from '../../3p/3p';
@@ -36,7 +36,7 @@ export function adsense(global, data) {
         'matchedContentColumnsNum']);
 
   if (data['autoFormat'] == 'rspv') {
-    user().assert(hasOwn(data, 'fullWidth'),
+    user().assert(hasOwnProperty(data, 'fullWidth'),
         'Responsive AdSense ad units require the attribute data-full-width.');
 
     user().assert(data['height'] == ADSENSE_RSPV_WHITELISTED_HEIGHT,

--- a/ads/imonomy.js
+++ b/ads/imonomy.js
@@ -15,7 +15,7 @@
  */
 
 import {doubleclick} from '../ads/google/doubleclick';
-import {hasOwn} from '../src/utils/object';
+import {hasOwnProperty} from '../src/utils/object';
 import {loadScript, writeScript} from '../3p/3p';
 
 const DEFAULT_TIMEOUT = 500; // ms
@@ -73,7 +73,7 @@ export function imonomy(global, data) {
  */
 function prepareData(data) {
   for (const attr in data) {
-    if (hasOwn(data, attr) && imonomyData.indexOf(attr) >= 0) {
+    if (hasOwnProperty(data, attr) && imonomyData.indexOf(attr) >= 0) {
       delete data[attr];
     }
   }

--- a/ads/ix.js
+++ b/ads/ix.js
@@ -15,7 +15,7 @@
  */
 
 import {doubleclick} from '../ads/google/doubleclick';
-import {hasOwn} from '../src/utils/object';
+import {hasOwnProperty} from '../src/utils/object';
 import {loadScript, writeScript} from '../3p/3p';
 
 const DEFAULT_TIMEOUT = 500; // ms
@@ -72,7 +72,7 @@ export function ix(global, data) {
  */
 function prepareData(data) {
   for (const attr in data) {
-    if (hasOwn(data, attr) && /^ix[A-Z]/.test(attr)) {
+    if (hasOwnProperty(data, attr) && /^ix[A-Z]/.test(attr)) {
       delete data[attr];
     }
   }

--- a/ads/kiosked.js
+++ b/ads/kiosked.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {hasOwn} from '../src/utils/object';
+import {hasOwnProperty} from '../src/utils/object';
 import {validateData, writeScript} from '../3p/3p';
 
 /**
@@ -24,7 +24,7 @@ import {validateData, writeScript} from '../3p/3p';
 export function kiosked(global, data) {
   let scriptId;
   validateData(data, ['scriptid'], []);
-  if (hasOwn(data, 'scriptid')) {
+  if (hasOwnProperty(data, 'scriptid')) {
     scriptId = data['scriptid'];
   }
   window.addEventListener('kioskedAdRender', function() {

--- a/ads/medianet.js
+++ b/ads/medianet.js
@@ -16,7 +16,7 @@
 
 import {computeInMasterFrame, validateData, writeScript} from '../3p/3p';
 import {getSourceUrl, parseUrlDeprecated} from '../src/url';
-import {hasOwn} from '../src/utils/object';
+import {hasOwnProperty} from '../src/utils/object';
 
 const mandatoryParams = ['tagtype', 'cid'],
     optionalParams = [
@@ -83,7 +83,7 @@ function loadCMTag(global, data, publisherUrl, referrerUrl) {
       return;
     }
     const name = 'medianet_' + type;
-    if (hasOwn(data, type)) {
+    if (hasOwnProperty(data, type)) {
       global[name] = data[type];
     }
   }

--- a/ads/sekindo.js
+++ b/ads/sekindo.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {hasOwn} from '../src/utils/object';
+import {hasOwnProperty} from '../src/utils/object';
 import {loadScript, validateData} from '../3p/3p';
 
 /**
@@ -30,7 +30,7 @@ export function sekindo(global, data) {
   global.context.startTime + '&';
   let getParam = '';
   for (const key in data) {
-    if (hasOwn(data, key)) {
+    if (hasOwnProperty(data, key)) {
       if (typeof excludesSet[key] == 'undefined') {
         getParam = (typeof customParamMap[key] == 'undefined') ?
           key : customParamMap[key];

--- a/ads/spotx.js
+++ b/ads/spotx.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {hasOwn} from '../src/utils/object';
+import {hasOwnProperty} from '../src/utils/object';
 import {startsWith} from '../src/string';
 import {validateData} from '../3p/3p';
 
@@ -37,7 +37,7 @@ export function spotx(global, data) {
 
   // Add data-* attribute for each data value passed in.
   for (const key in data) {
-    if (hasOwn(data, key) && startsWith(key, 'spotx_')) {
+    if (hasOwnProperty(data, key) && startsWith(key, 'spotx_')) {
       script.setAttribute(`data-${key}`, data[key]);
     }
   }

--- a/ads/uas.js
+++ b/ads/uas.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {hasOwn} from '../src/utils/object';
+import {hasOwnProperty} from '../src/utils/object';
 import {loadScript, validateData} from '../3p/3p';
 import {setStyles} from '../src/style';
 
@@ -26,7 +26,7 @@ function forEachOnObject(theObject, callback) {
   if (typeof theObject === 'object' && theObject !== null) {
     if (typeof callback === 'function') {
       for (const key in theObject) {
-        if (hasOwn(theObject, key)) {
+        if (hasOwnProperty(theObject, key)) {
           callback(key, theObject[key]);
         }
       }

--- a/build-system/eslint-rules/no-has-own-property-method.js
+++ b/build-system/eslint-rules/no-has-own-property-method.js
@@ -24,7 +24,7 @@ module.exports = {
           context.report({
             node,
             message: 'Do not use hasOwnProperty directly. ' +
-                'Use hasOwn from src/utils/object.js instead.',
+                'Use hasOwnProperty from src/utils/object.js instead.',
           });
         }
       },

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
@@ -16,7 +16,7 @@
 
 import {Services} from '../../../src/services';
 import {dev} from '../../../src/log';
-import {dict, hasOwn} from '../../../src/utils/object';
+import {dict, hasOwnProperty} from '../../../src/utils/object';
 import {getData} from '../../../src/event-helper';
 import {getStyle} from '../../../src/style';
 import {parseUrlDeprecated} from '../../../src/url';
@@ -185,11 +185,11 @@ export class SafeframeHostApi {
         this.baseInstance_.element.getAttribute(
             'data-safeframe-config')) || {});
     /** @private {boolean} */
-    this.expandByOverlay_ = hasOwn(sfConfig, 'expandByOverlay') ?
+    this.expandByOverlay_ = hasOwnProperty(sfConfig, 'expandByOverlay') ?
       sfConfig['expandByOverlay'] : true;
 
     /** @private {boolean} */
-    this.expandByPush_ = hasOwn(sfConfig, 'expandByPush') ?
+    this.expandByPush_ = hasOwnProperty(sfConfig, 'expandByPush') ?
       sfConfig['expandByPush'] : true;
 
     /** @private {?Function} */

--- a/extensions/amp-ad/0.1/amp-ad-custom.js
+++ b/extensions/amp-ad/0.1/amp-ad-custom.js
@@ -24,7 +24,7 @@ import {
   childElementByTag,
   removeChildren,
 } from '../../../src/dom';
-import {hasOwn} from '../../../src/utils/object';
+import {hasOwnProperty} from '../../../src/utils/object';
 import {isLayoutSizeDefined} from '../../../src/layout';
 import {user} from '../../../src/log';
 
@@ -99,7 +99,7 @@ export class AmpAdCustom extends AMP.BaseElement {
       // We will get here when the data has been fetched from the server
       let templateData = data;
       if (this.slot_ !== null) {
-        templateData = hasOwn(data, this.slot_) ? data[this.slot_] :
+        templateData = hasOwnProperty(data, this.slot_) ? data[this.slot_] :
           null;
       }
 

--- a/extensions/amp-ad/0.1/amp-ad.js
+++ b/extensions/amp-ad/0.1/amp-ad.js
@@ -19,7 +19,7 @@ import {CSS} from '../../../build/amp-ad-0.1.css';
 import {Services} from '../../../src/services';
 import {adConfig} from '../../../ads/_config';
 import {getA4ARegistry} from '../../../ads/_a4a-config';
-import {hasOwn} from '../../../src/utils/object';
+import {hasOwnProperty} from '../../../src/utils/object';
 import {user} from '../../../src/log';
 
 
@@ -58,8 +58,8 @@ export class AmpAd extends AMP.BaseElement {
     const type = this.element.getAttribute('type');
     return consent.then(() => {
       const isCustom = type === 'custom';
-      user().assert(isCustom || hasOwn(adConfig, type)
-          || hasOwn(a4aRegistry, type), `Unknown ad type "${type}"`);
+      user().assert(isCustom || hasOwnProperty(adConfig, type)
+          || hasOwnProperty(a4aRegistry, type), `Unknown ad type "${type}"`);
 
       // Check for the custom ad type (no ad network, self-service)
       if (isCustom) {

--- a/extensions/amp-analytics/0.1/activity-impl.js
+++ b/extensions/amp-analytics/0.1/activity-impl.js
@@ -20,7 +20,7 @@
  */
 
 import {Services} from '../../../src/services';
-import {hasOwn} from '../../../src/utils/object';
+import {hasOwnProperty} from '../../../src/utils/object';
 import {listen} from '../../../src/event-helper';
 import {registerServiceBuilderForDoc} from '../../../src/service';
 
@@ -329,7 +329,7 @@ export class Activity {
    * @return {number}
    */
   getIncrementalEngagedTime(name, reset = true) {
-    if (!hasOwn(this.totalEngagedTimeByTrigger_, name)) {
+    if (!hasOwnProperty(this.totalEngagedTimeByTrigger_, name)) {
       if (reset) {
         this.totalEngagedTimeByTrigger_[name] = this.getTotalEngagedTime();
       }

--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -33,7 +33,7 @@ import {
 } from './requests';
 import {Services} from '../../../src/services';
 import {dev, rethrowAsync, user} from '../../../src/log';
-import {dict, hasOwn, map} from '../../../src/utils/object';
+import {dict, hasOwnProperty, map} from '../../../src/utils/object';
 import {expandTemplate} from '../../../src/string';
 import {getAmpAdResourceId} from '../../../src/ad-helper';
 import {getMode} from '../../../src/mode';
@@ -249,7 +249,7 @@ export class AmpAnalytics extends AMP.BaseElement {
     const promises = [];
     // Trigger callback can be synchronous. Do the registration at the end.
     for (const k in this.config_['triggers']) {
-      if (hasOwn(this.config_['triggers'], k)) {
+      if (hasOwnProperty(this.config_['triggers'], k)) {
         const trigger = this.config_['triggers'][k];
         const expansionOptions = this.expansionOptions_(
             {}, trigger, undefined, true);
@@ -449,7 +449,7 @@ export class AmpAnalytics extends AMP.BaseElement {
 
     if (this.config_['requests']) {
       for (const k in this.config_['requests']) {
-        if (hasOwn(this.config_['requests'], k)) {
+        if (hasOwnProperty(this.config_['requests'], k)) {
           const request = this.config_['requests'][k];
           if (!request['baseUrl']) {
             this.user().error(TAG, 'request must have a baseUrl');
@@ -471,7 +471,7 @@ export class AmpAnalytics extends AMP.BaseElement {
 
       const requests = {};
       for (const k in this.config_['requests']) {
-        if (hasOwn(this.config_['requests'], k)) {
+        if (hasOwnProperty(this.config_['requests'], k)) {
           const request = this.config_['requests'][k];
           requests[k] = new RequestHandler(
               this.element, request, this.preconnect,

--- a/extensions/amp-analytics/0.1/config.js
+++ b/extensions/amp-analytics/0.1/config.js
@@ -18,7 +18,7 @@ import {ANALYTICS_CONFIG} from './vendors';
 import {Services} from '../../../src/services';
 import {assertHttpsUrl} from '../../../src/url';
 import {dev, user} from '../../../src/log';
-import {dict, hasOwn} from '../../../src/utils/object';
+import {dict, hasOwnProperty} from '../../../src/utils/object';
 import {getMode} from '../../../src/mode';
 import {isArray, isObject} from '../../../src/types';
 import {isJsonScriptTag} from '../../../src/dom';
@@ -307,7 +307,7 @@ export function mergeObjects(from, to, opt_predefinedConfig) {
     user().assert(opt_predefinedConfig || property != 'iframePing',
         'iframePing config is only available to vendor config.');
     // Only deal with own properties.
-    if (hasOwn(from, property)) {
+    if (hasOwnProperty(from, property)) {
       if (isArray(from[property])) {
         if (!isArray(to[property])) {
           to[property] = [];
@@ -338,7 +338,7 @@ export function expandConfigRequest(config) {
     return config;
   }
   for (const k in config['requests']) {
-    if (hasOwn(config['requests'], k)) {
+    if (hasOwnProperty(config['requests'], k)) {
       config['requests'][k] = expandRequestStr(config['requests'][k]);
     }
   }

--- a/extensions/amp-analytics/0.1/events.js
+++ b/extensions/amp-analytics/0.1/events.js
@@ -24,7 +24,7 @@ import {
 import {dev, user} from '../../../src/log';
 import {getData} from '../../../src/event-helper';
 import {getDataParamsFromAttributes} from '../../../src/dom';
-import {hasOwn} from '../../../src/utils/object';
+import {hasOwnProperty} from '../../../src/utils/object';
 import {isEnumValue} from '../../../src/types';
 import {startsWith} from '../../../src/string';
 
@@ -129,7 +129,7 @@ export function getTrackerKeyName(eventType) {
   if (!isReservedTriggerType(eventType)) {
     return 'custom';
   }
-  return hasOwn(TRACKER_TYPE, eventType) ?
+  return hasOwnProperty(TRACKER_TYPE, eventType) ?
     TRACKER_TYPE[eventType].name : eventType;
 }
 
@@ -140,7 +140,7 @@ export function getTrackerKeyName(eventType) {
 export function getTrackerTypesForParentType(parentType) {
   const filtered = {};
   Object.keys(TRACKER_TYPE).forEach(key => {
-    if (hasOwn(TRACKER_TYPE, key) &&
+    if (hasOwnProperty(TRACKER_TYPE, key) &&
         TRACKER_TYPE[key].allowedFor.indexOf(parentType) != -1) {
       filtered[key] = TRACKER_TYPE[key].klass;
     }

--- a/extensions/amp-analytics/0.1/iframe-transport.js
+++ b/extensions/amp-analytics/0.1/iframe-transport.js
@@ -18,7 +18,7 @@ import {IframeTransportMessageQueue} from './iframe-transport-message-queue';
 import {createElementWithAttributes} from '../../../src/dom';
 import {dev, user} from '../../../src/log';
 import {getMode} from '../../../src/mode';
-import {hasOwn} from '../../../src/utils/object';
+import {hasOwnProperty} from '../../../src/utils/object';
 import {isLongTaskApiSupported} from '../../../src/service/jank-meter';
 import {setStyles} from '../../../src/style';
 import {urls} from '../../../src/config';
@@ -227,7 +227,7 @@ export class IframeTransport {
    * @visibleForTesting
    */
   static hasCrossDomainIframe(type) {
-    return hasOwn(IframeTransport.crossDomainIframes_, type);
+    return hasOwnProperty(IframeTransport.crossDomainIframes_, type);
   }
 
   /**

--- a/extensions/amp-analytics/0.1/instrumentation.js
+++ b/extensions/amp-analytics/0.1/instrumentation.js
@@ -37,7 +37,7 @@ import {
   getServicePromiseForDoc,
   registerServiceBuilderForDoc,
 } from '../../../src/service';
-import {hasOwn} from '../../../src/utils/object';
+import {hasOwnProperty} from '../../../src/utils/object';
 
 const SCROLL_PRECISION_PERCENT = 5;
 const VAR_H_SCROLL_BOUNDARY = 'horizontalScrollBoundary';
@@ -254,7 +254,7 @@ export class InstrumentationService {
       // Goes through each of the boundaries and fires an event if it has not
       // been fired so far and it should be.
       for (const b in bounds) {
-        if (!hasOwn(bounds, b)) {
+        if (!hasOwnProperty(bounds, b)) {
           continue;
         }
         const bound = parseInt(b, 10);

--- a/extensions/amp-analytics/0.1/test/test-vendors.js
+++ b/extensions/amp-analytics/0.1/test/test-vendors.js
@@ -16,7 +16,7 @@
 
 import {ANALYTICS_CONFIG} from '../vendors';
 import {ANALYTICS_IFRAME_TRANSPORT_CONFIG} from '../iframe-transport-vendors';
-import {hasOwn} from '../../../../src/utils/object';
+import {hasOwnProperty} from '../../../../src/utils/object';
 import {isSecureUrlDeprecated} from '../../../../src/url';
 
 describe('analytics vendors', () => {
@@ -37,8 +37,8 @@ describe('analytics vendors', () => {
       ' those in ANALYTICS_IFRAME_TRANSPORT_CONFIG)', () => {
     for (const vendor in ANALYTICS_CONFIG) {
       const vendorEntry = ANALYTICS_CONFIG[vendor];
-      if (hasOwn(vendorEntry, 'transport') &&
-          hasOwn(vendorEntry.transport, 'iframe')) {
+      if (hasOwnProperty(vendorEntry, 'transport') &&
+          hasOwnProperty(vendorEntry.transport, 'iframe')) {
         const vendorITEntry = ANALYTICS_IFRAME_TRANSPORT_CONFIG[vendor];
         expect(vendorITEntry).to.exist;
       }

--- a/extensions/amp-bind/0.1/bind-expression.js
+++ b/extensions/amp-bind/0.1/bind-expression.js
@@ -16,7 +16,7 @@
 
 import {AstNodeType} from './bind-expr-defines';
 import {dev, user} from '../../../src/log';
-import {dict, hasOwn, map} from '../../../src/utils/object';
+import {dict, hasOwnProperty, map} from '../../../src/utils/object';
 import {getMode} from '../../../src/mode';
 import {isArray, isObject} from '../../../src/types';
 import {parser} from './bind-expr-impl';
@@ -90,7 +90,7 @@ function generateFunctionWhitelist() {
   function values(object) {
     const v = [];
     for (const key in object) {
-      if (hasOwn(object, key)) {
+      if (hasOwnProperty(object, key)) {
         v.push(object[key]);
       }
     }

--- a/extensions/amp-bind/0.1/bind-validator.js
+++ b/extensions/amp-bind/0.1/bind-validator.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {hasOwn, ownProperty} from '../../../src/utils/object';
+import {hasOwnProperty, ownProperty} from '../../../src/utils/object';
 import {parseSrcset} from '../../../src/srcset';
 import {startsWith} from '../../../src/string';
 import {user} from '../../../src/log';
@@ -165,7 +165,7 @@ export class BindValidator {
       if (match !== null) {
         const protocol = match[1].toLowerCase().trim();
         // hasOwnProperty() needed since nested objects are not prototype-less.
-        if (!hasOwn(allowedProtocols, protocol)) {
+        if (!hasOwnProperty(allowedProtocols, protocol)) {
           return false;
         }
       }

--- a/extensions/amp-consent/0.1/consent-policy-manager.js
+++ b/extensions/amp-consent/0.1/consent-policy-manager.js
@@ -19,7 +19,7 @@ import {CONSENT_POLICY_STATE} from '../../../src/consent-state';
 import {Deferred} from '../../../src/utils/promise';
 import {dev, user} from '../../../src/log';
 import {getServicePromiseForDoc} from '../../../src/service';
-import {hasOwn, map} from '../../../src/utils/object';
+import {hasOwnProperty, map} from '../../../src/utils/object';
 import {isExperimentOn} from '../../../src/experiments';
 import {isFiniteNumber} from '../../../src/types';
 import {isObject} from '../../../src/types';
@@ -336,7 +336,7 @@ export class ConsentPolicyInstance {
   consentStateChangeHandler(consentId, state) {
     // TODO: Keeping an array can have performance issue, change to using a map
     // if necessary.
-    if (!hasOwn(this.itemToConsentState_, consentId)) {
+    if (!hasOwnProperty(this.itemToConsentState_, consentId)) {
       dev().error(TAG, `cannot find ${consentId} in policy state`);
       return;
     }

--- a/extensions/amp-experiment/0.1/test/test-amp-experiment.js
+++ b/extensions/amp-experiment/0.1/test/test-amp-experiment.js
@@ -17,7 +17,7 @@
 import * as variant from '../variant';
 import {AmpExperiment} from '../amp-experiment';
 import {Services} from '../../../../src/services';
-import {hasOwn} from '../../../../src/utils/object';
+import {hasOwnProperty} from '../../../../src/utils/object';
 
 
 describes.realWin('amp-experiment', {
@@ -68,7 +68,7 @@ describes.realWin('amp-experiment', {
 
   function expectBodyHasAttributes(attributes) {
     for (const attributeName in attributes) {
-      if (hasOwn(attributes, attributeName)) {
+      if (hasOwnProperty(attributes, attributeName)) {
         expect(doc.body.getAttribute(attributeName))
             .to.equal(attributes[attributeName]);
       }

--- a/extensions/amp-experiment/0.1/variant.js
+++ b/extensions/amp-experiment/0.1/variant.js
@@ -16,7 +16,7 @@
 
 import {Services} from '../../../src/services';
 import {dev, user} from '../../../src/log';
-import {hasOwn} from '../../../src/utils/object';
+import {hasOwnProperty} from '../../../src/utils/object';
 import {isObject} from '../../../src/types';
 
 const ATTR_PREFIX = 'amp-x-';
@@ -37,7 +37,7 @@ export function allocateVariant(ampdoc, experimentName, config) {
   // Variant can be overridden from URL fragment.
   const viewer = Services.viewerForDoc(ampdoc);
   const override = viewer.getParam(ATTR_PREFIX + experimentName);
-  if (override && hasOwn(config['variants'], override)) {
+  if (override && hasOwnProperty(config['variants'], override)) {
     return Promise.resolve(/** @type {?string} */ (override));
   }
 
@@ -94,7 +94,7 @@ function validateConfig(config) {
   }
   let totalPercentage = 0;
   for (const variantName in variants) {
-    if (hasOwn(variants, variantName)) {
+    if (hasOwnProperty(variants, variantName)) {
       assertName(variantName);
       const percentage = variants[variantName];
       user().assert(

--- a/extensions/amp-gwd-animation/0.1/amp-gwd-animation-impl.js
+++ b/extensions/amp-gwd-animation/0.1/amp-gwd-animation-impl.js
@@ -15,7 +15,7 @@
  */
 import {createCustomEvent} from '../../../src/event-helper';
 import {escapeCssSelectorIdent} from '../../../src/dom';
-import {hasOwn} from '../../../src/utils/object';
+import {hasOwnProperty} from '../../../src/utils/object';
 import {toArray} from '../../../src/types';
 import {user} from '../../../src/log';
 
@@ -101,7 +101,7 @@ const LOG_ID = 'GWD';
  */
 function getCounter(receiver, counterName) {
   if (receiver[GOTO_COUNTER_PROP] &&
-      hasOwn(receiver[GOTO_COUNTER_PROP], counterName)) {
+      hasOwnProperty(receiver[GOTO_COUNTER_PROP], counterName)) {
     return receiver[GOTO_COUNTER_PROP][counterName];
   }
   return 0;
@@ -119,7 +119,7 @@ function setCounter(receiver, counterName, counterValue) {
   if (!receiver[GOTO_COUNTER_PROP]) {
     receiver[GOTO_COUNTER_PROP] = {};
   }
-  if (!hasOwn(receiver[GOTO_COUNTER_PROP], counterName)) {
+  if (!hasOwnProperty(receiver[GOTO_COUNTER_PROP], counterName)) {
     receiver[GOTO_COUNTER_PROP][counterName] = 0;
   }
   receiver[GOTO_COUNTER_PROP][counterName] = counterValue;

--- a/extensions/amp-lightbox/0.1/amp-lightbox.js
+++ b/extensions/amp-lightbox/0.1/amp-lightbox.js
@@ -26,7 +26,7 @@ import {computedStyle, setImportantStyles} from '../../../src/style';
 import {createCustomEvent} from '../../../src/event-helper';
 import {debounce} from '../../../src/utils/rate-limit';
 import {dev, user} from '../../../src/log';
-import {dict, hasOwn} from '../../../src/utils/object';
+import {dict, hasOwnProperty} from '../../../src/utils/object';
 import {getMode} from '../../../src/mode';
 import {isInFie} from '../../../src/friendly-iframe-embed';
 import {toArray} from '../../../src/types';
@@ -129,7 +129,7 @@ class AmpLightbox extends AMP.BaseElement {
   /** @override */
   buildCallback() {
     this.user().assert(
-        hasOwn(AnimationPresets, this.animationPreset_),
+        hasOwnProperty(AnimationPresets, this.animationPreset_),
         'Invalid `animate-in` value %s',
         this.animationPreset_);
 

--- a/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
+++ b/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
@@ -21,7 +21,7 @@ import {StateChangeEventDef, StateChangeType} from '../../amp-story/1.0/navigati
 import {StateProperty} from '../../amp-story/1.0/amp-story-store-service';
 import {createElementWithAttributes} from '../../../src/dom';
 import {dev, user} from '../../../src/log';
-import {dict, hasOwn, map} from '../../../src/utils/object';
+import {dict, hasOwnProperty, map} from '../../../src/utils/object';
 import {getUniqueId} from './utils';
 import {isJsonScriptTag} from '../../../src/dom';
 import {parseJson} from '../../../src/json';
@@ -518,7 +518,7 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
       this.idOfAdShowing_ = adIndex;
     }
 
-    if (!hasOwn(this.uniquePageIds_, pageId)) {
+    if (!hasOwnProperty(this.uniquePageIds_, pageId)) {
       this.uniquePagesCount_++;
       this.uniquePageIds_[pageId] = true;
     }

--- a/extensions/amp-story/0.1/amp-story-store-service.js
+++ b/extensions/amp-story/0.1/amp-story-store-service.js
@@ -17,7 +17,7 @@
 import {EmbedMode, parseEmbedMode} from './embed-mode';
 import {Observable} from '../../../src/observable';
 import {dev} from '../../../src/log';
-import {hasOwn} from '../../../src/utils/object';
+import {hasOwnProperty} from '../../../src/utils/object';
 
 
 /** @type {string} */
@@ -192,7 +192,7 @@ export class AmpStoryStoreService {
    * @return {*}
    */
   get(key) {
-    if (!hasOwn(this.state_, key)) {
+    if (!hasOwnProperty(this.state_, key)) {
       dev().error(TAG, `Unknown state ${key}.`);
       return;
     }
@@ -207,7 +207,7 @@ export class AmpStoryStoreService {
    *                                     triggered with current value.
    */
   subscribe(key, listener, callToInitialize = false) {
-    if (!hasOwn(this.state_, key)) {
+    if (!hasOwnProperty(this.state_, key)) {
       dev().error(TAG, `Can't subscribe to unknown state ${key}.`);
       return;
     }

--- a/extensions/amp-story/0.1/progress-bar.js
+++ b/extensions/amp-story/0.1/progress-bar.js
@@ -17,7 +17,7 @@ import {POLL_INTERVAL_MS} from './page-advancement';
 import {Services} from '../../../src/services';
 import {dev} from '../../../src/log';
 import {escapeCssSelectorNth, scopedQuerySelector} from '../../../src/dom';
-import {hasOwn, map} from '../../../src/utils/object';
+import {hasOwnProperty, map} from '../../../src/utils/object';
 import {scale, setImportantStyles} from '../../../src/style';
 
 
@@ -139,7 +139,7 @@ export class ProgressBar {
    * @private
    */
   assertVaildSegmentId_(segmentId) {
-    dev().assert(hasOwn(this.segmentIdMap_, segmentId),
+    dev().assert(hasOwnProperty(this.segmentIdMap_, segmentId),
         'Invalid segment-id passed to progress-bar');
   }
 

--- a/extensions/amp-story/1.0/amp-story-store-service.js
+++ b/extensions/amp-story/1.0/amp-story-store-service.js
@@ -17,7 +17,7 @@
 import {EmbedMode, parseEmbedMode} from './embed-mode';
 import {Observable} from '../../../src/observable';
 import {dev} from '../../../src/log';
-import {hasOwn} from '../../../src/utils/object';
+import {hasOwnProperty} from '../../../src/utils/object';
 
 
 /** @type {string} */
@@ -207,7 +207,7 @@ export class AmpStoryStoreService {
    * @return {*}
    */
   get(key) {
-    if (!hasOwn(this.state_, key)) {
+    if (!hasOwnProperty(this.state_, key)) {
       dev().error(TAG, `Unknown state ${key}.`);
       return;
     }
@@ -222,7 +222,7 @@ export class AmpStoryStoreService {
    *                                     triggered with current value.
    */
   subscribe(key, listener, callToInitialize = false) {
-    if (!hasOwn(this.state_, key)) {
+    if (!hasOwnProperty(this.state_, key)) {
       dev().error(TAG, `Can't subscribe to unknown state ${key}.`);
       return;
     }

--- a/extensions/amp-story/1.0/progress-bar.js
+++ b/extensions/amp-story/1.0/progress-bar.js
@@ -17,7 +17,7 @@ import {POLL_INTERVAL_MS} from './page-advancement';
 import {Services} from '../../../src/services';
 import {dev} from '../../../src/log';
 import {escapeCssSelectorNth, scopedQuerySelector} from '../../../src/dom';
-import {hasOwn, map} from '../../../src/utils/object';
+import {hasOwnProperty, map} from '../../../src/utils/object';
 import {scale, setImportantStyles} from '../../../src/style';
 
 
@@ -139,7 +139,7 @@ export class ProgressBar {
    * @private
    */
   assertVaildSegmentId_(segmentId) {
-    dev().assert(hasOwn(this.segmentIdMap_, segmentId),
+    dev().assert(hasOwnProperty(this.segmentIdMap_, segmentId),
         'Invalid segment-id passed to progress-bar');
   }
 

--- a/extensions/amp-story/1.0/simple-template.js
+++ b/extensions/amp-story/1.0/simple-template.js
@@ -17,7 +17,7 @@ import {LocalizedStringId} from './localization'; // eslint-disable-line no-unus
 import {Services} from '../../../src/services';
 import {createElementWithAttributes} from '../../../src/dom';
 import {dev} from '../../../src/log';
-import {hasOwn} from '../../../src/utils/object';
+import {hasOwnProperty} from '../../../src/utils/object';
 import {isArray, toWin} from '../../../src/types';
 
 
@@ -75,12 +75,12 @@ function renderMulti(doc, elementsDef) {
  * @return {!Element}
  */
 function renderSingle(doc, elementDef) {
-  const el = hasOwn(elementDef, 'attrs') ?
+  const el = hasOwnProperty(elementDef, 'attrs') ?
     createElementWithAttributes(doc, elementDef.tag,
         /** @type {!JsonObject} */ (elementDef.attrs)) :
     doc.createElement(elementDef.tag);
 
-  if (hasOwn(elementDef, 'localizedStringId')) {
+  if (hasOwnProperty(elementDef, 'localizedStringId')) {
     const win = toWin(doc.defaultView);
     Services.localizationServiceForOrNull(win).then(localizationService => {
       dev().assert(localizationService,
@@ -91,11 +91,11 @@ function renderSingle(doc, elementDef) {
     });
   }
 
-  if (hasOwn(elementDef, 'unlocalizedString')) {
+  if (hasOwnProperty(elementDef, 'unlocalizedString')) {
     el.textContent = elementDef.unlocalizedString;
   }
 
-  if (hasOwn(elementDef, 'children')) {
+  if (hasOwnProperty(elementDef, 'children')) {
     el.appendChild(renderMulti(doc,
         /** @type {!Array<!ElementDef>} */ (elementDef.children)));
   }

--- a/extensions/amp-subscriptions/0.1/platform-store.js
+++ b/extensions/amp-subscriptions/0.1/platform-store.js
@@ -18,7 +18,7 @@ import {Deferred} from '../../../src/utils/promise';
 import {Entitlement} from './entitlement';
 import {Observable} from '../../../src/observable';
 import {dev, user} from '../../../src/log';
-import {dict, hasOwn} from '../../../src/utils/object';
+import {dict, hasOwnProperty} from '../../../src/utils/object';
 
 
 /** @typedef {{serviceId: string, entitlement: (!./entitlement.Entitlement|undefined)}} */
@@ -335,7 +335,7 @@ export class PlatformStore {
   getAvailablePlatformsEntitlements_() {
     const entitlements = [];
     for (const platform in this.entitlements_) {
-      if (hasOwn(this.entitlements_, platform)) {
+      if (hasOwnProperty(this.entitlements_, platform)) {
         entitlements.push(this.entitlements_[platform]);
       }
     }

--- a/src/experiments.js
+++ b/src/experiments.js
@@ -22,7 +22,7 @@
  */
 
 import {getCookie, setCookie} from './cookies';
-import {hasOwn} from './utils/object';
+import {hasOwnProperty} from './utils/object';
 import {parseQueryString} from './url';
 
 /** @const {string} */
@@ -298,10 +298,10 @@ export function randomlySelectUnsetExperiments(win, experiments) {
   for (const experimentName in experiments) {
     // Skip experimentName if it is not a key of experiments object or if it
     // has already been populated by some other property.
-    if (!hasOwn(experiments, experimentName)) {
+    if (!hasOwnProperty(experiments, experimentName)) {
       continue;
     }
-    if (hasOwn(win.experimentBranches, experimentName)) {
+    if (hasOwnProperty(win.experimentBranches, experimentName)) {
       selectedExperiments[experimentName] =
           win.experimentBranches[experimentName];
       continue;

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -22,7 +22,7 @@ import {debounce, throttle} from '../utils/rate-limit';
 import {dev, user} from '../log';
 import {getMode} from '../mode';
 import {getValueForExpr} from '../json';
-import {hasOwn, map} from '../utils/object';
+import {hasOwnProperty, map} from '../utils/object';
 import {
   installServiceInEmbedScope,
   registerServiceBuilderForDoc,
@@ -283,7 +283,7 @@ export class ActionService {
         if (keyCode == KeyCodes.ENTER || keyCode == KeyCodes.SPACE) {
           const role = element.getAttribute('role');
           const isTapEventRole =
-              (role && hasOwn(TAPPABLE_ARIA_ROLES, role.toLowerCase()));
+              (role && hasOwnProperty(TAPPABLE_ARIA_ROLES, role.toLowerCase()));
           if (!event.defaultPrevented && isTapEventRole) {
             event.preventDefault();
             this.trigger(element, name, event, ActionTrust.HIGH);

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -26,7 +26,7 @@ import {areMarginsChanged} from '../layout-rect';
 import {closest, hasNextNodeInDocumentOrder} from '../dom';
 import {computedStyle} from '../style';
 import {dev} from '../log';
-import {dict, hasOwn} from '../utils/object';
+import {dict, hasOwnProperty} from '../utils/object';
 import {expandLayoutRect} from '../layout-rect';
 import {filterSplice} from '../utils/array';
 import {getSourceUrl} from '../url';
@@ -1791,7 +1791,7 @@ export class Resources {
    */
   calcLayoutScore_(currentScore, layout, depth, cache) {
     const id = layout.getId();
-    if (hasOwn(cache, id)) {
+    if (hasOwnProperty(cache, id)) {
       return dev().assertNumber(cache[id]);
     }
 

--- a/src/service/url-expander/expander.js
+++ b/src/service/url-expander/expander.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {hasOwn} from '../../utils/object';
+import {hasOwnProperty} from '../../utils/object';
 import {rethrowAsync, user} from '../../log';
 import {tryResolve} from '../../utils/promise';
 
@@ -119,7 +119,7 @@ export class Expander {
         if (match && urlIndex === match.start) {
           let binding;
           // find out where this keyword is coming from
-          if (opt_bindings && hasOwn(opt_bindings, match.name)) {
+          if (opt_bindings && hasOwnProperty(opt_bindings, match.name)) {
             // the optional bindings
             binding = {
               // This construction helps us save the match name and determine

--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -37,7 +37,7 @@ import {
 } from '../url';
 import {dev, rethrowAsync, user} from '../log';
 import {getTrackImpressionPromise} from '../impression.js';
-import {hasOwn} from '../utils/object';
+import {hasOwnProperty} from '../utils/object';
 import {
   installServiceInEmbedScope,
   registerServiceBuilderForDoc,
@@ -920,7 +920,7 @@ export class UrlReplacements {
     const requestedReplacements = {};
     whitelist.trim().split(/\s+/).forEach(replacement => {
       if (!opt_supportedReplacement ||
-          hasOwn(opt_supportedReplacement, replacement)) {
+          hasOwnProperty(opt_supportedReplacement, replacement)) {
         requestedReplacements[replacement] = true;
       } else {
         user().warn('URL', 'Ignoring unsupported replacement', replacement);

--- a/src/utils/object.js
+++ b/src/utils/object.js
@@ -17,7 +17,7 @@
 import {isObject} from '../types';
 
 /* @const */
-const hasOwn_ = Object.prototype.hasOwnProperty;
+const hasOwnProperty_ = Object.prototype.hasOwnProperty;
 
 /**
  * Returns a map-like object.
@@ -60,8 +60,8 @@ export function dict(opt_initial) {
  * @return {boolean}
  * @template T
  */
-export function hasOwn(obj, key) {
-  return hasOwn_.call(obj, key);
+export function hasOwnProperty(obj, key) {
+  return hasOwnProperty_.call(obj, key);
 }
 
 /**
@@ -73,7 +73,7 @@ export function hasOwn(obj, key) {
  * @return {*}
  */
 export function ownProperty(obj, key) {
-  if (hasOwn(obj, key)) {
+  if (hasOwnProperty(obj, key)) {
     return obj[key];
   } else {
     return undefined;
@@ -117,7 +117,7 @@ export function deepMerge(target, source, depth = 10) {
       const newValue = s[key];
       // Perform a deep merge IFF both target and source have the same key
       // whose corresponding values are objects.
-      if (hasOwn(t, key)) {
+      if (hasOwnProperty(t, key)) {
         const oldValue = t[key];
         if (isObject(newValue) && isObject(oldValue)) {
           queue.push({t: oldValue, s: newValue, d: d + 1});

--- a/test/functional/test-ads-config.js
+++ b/test/functional/test-ads-config.js
@@ -15,7 +15,7 @@
  */
 
 import {adConfig} from '../../ads/_config';
-import {hasOwn} from '../../src/utils/object';
+import {hasOwnProperty} from '../../src/utils/object';
 
 describe('test-ads-config', () => {
 
@@ -37,7 +37,7 @@ describe('test-ads-config', () => {
 
   it('preconnect should have no duplicates with prefetch', () => {
     for (const adNetwork in adConfig) {
-      if (!hasOwn(adConfig, adNetwork)) {
+      if (!hasOwnProperty(adConfig, adNetwork)) {
         continue;
       }
 
@@ -51,7 +51,7 @@ describe('test-ads-config', () => {
 
   it('should use HTTPS URLs', () => {
     for (const adNetwork in adConfig) {
-      if (!hasOwn(adConfig, adNetwork)) {
+      if (!hasOwnProperty(adConfig, adNetwork)) {
         continue;
       }
 

--- a/test/functional/test-object.js
+++ b/test/functional/test-object.js
@@ -14,36 +14,36 @@
  * limitations under the License.
  */
 
-import * as object from '../../src/utils/object';
+import {deepMerge, hasOwnProperty, map, ownProperty} from '../../src/utils/object';
 
 describe('Object', () => {
-  it('hasOwn', () => {
-    expect(object.hasOwn(object.map(), 'a')).to.be.false;
-    expect(object.hasOwn(object.map({'a': 'b'}), 'b')).to.be.false;
-    expect(object.hasOwn(object.map({'a': {}}), 'a')).to.be.true;
+  it('hasOwnProperty', () => {
+    expect(hasOwnProperty(map(), 'a')).to.be.false;
+    expect(hasOwnProperty(map({'a': 'b'}), 'b')).to.be.false;
+    expect(hasOwnProperty(map({'a': {}}), 'a')).to.be.true;
   });
 
   it('ownProperty', () => {
-    expect(object.ownProperty({}, '__proto__')).to.be.undefined;
-    expect(object.ownProperty({}, 'constructor')).to.be.undefined;
-    expect(object.ownProperty({foo: 'bar'}, 'foo')).to.equal('bar');
+    expect(ownProperty({}, '__proto__')).to.be.undefined;
+    expect(ownProperty({}, 'constructor')).to.be.undefined;
+    expect(ownProperty({foo: 'bar'}, 'foo')).to.equal('bar');
   });
 
   describe('map', () => {
     it('should make map like objects', () => {
-      expect(object.map().prototype).to.be.undefined;
-      expect(object.map().__proto__).to.be.undefined;
-      expect(object.map().toString).to.be.undefined;
+      expect(map().prototype).to.be.undefined;
+      expect(map().__proto__).to.be.undefined;
+      expect(map().toString).to.be.undefined;
     });
 
     it('should make map like objects from objects', () => {
-      expect(object.map({}).prototype).to.be.undefined;
-      expect(object.map({}).__proto__).to.be.undefined;
-      expect(object.map({}).toString).to.be.undefined;
-      expect(object.map({foo: 'bar'}).foo).to.equal('bar');
+      expect(map({}).prototype).to.be.undefined;
+      expect(map({}).__proto__).to.be.undefined;
+      expect(map({}).toString).to.be.undefined;
+      expect(map({foo: 'bar'}).foo).to.equal('bar');
       const obj = {foo: 'bar', test: 1};
-      expect(object.map(obj).test).to.equal(1);
-      expect(object.map(obj)).to.not.equal(obj);
+      expect(map(obj).test).to.equal(1);
+      expect(map(obj)).to.not.equal(obj);
     });
   });
 
@@ -68,7 +68,7 @@ describe('Object', () => {
           },
         },
       };
-      expect(object.deepMerge(destObject, fromObject)).to.deep.equal({
+      expect(deepMerge(destObject, fromObject)).to.deep.equal({
         a: 'hello world',
         b: 'hello world',
         c: {
@@ -93,7 +93,7 @@ describe('Object', () => {
           c: ['h', 'i'],
         },
       };
-      expect(object.deepMerge(destObject, fromObject)).to.deep.equal({
+      expect(deepMerge(destObject, fromObject)).to.deep.equal({
         a: [1,2,3,4,5],
         b: {
           c: ['h', 'i'],
@@ -122,7 +122,7 @@ describe('Object', () => {
           },
         },
       };
-      expect(object.deepMerge(destObject, fromObject, 1)).to.deep.equal({
+      expect(deepMerge(destObject, fromObject, 1)).to.deep.equal({
         a: {
           b: {
             c: {
@@ -139,7 +139,7 @@ describe('Object', () => {
       destObject.a = destObject;
       const fromObject = {};
       fromObject.a = {};
-      expect(object.deepMerge(destObject, fromObject)).to.deep.equal({
+      expect(deepMerge(destObject, fromObject)).to.deep.equal({
         a: destObject,
       });
     });
@@ -149,7 +149,7 @@ describe('Object', () => {
       destObject.a = {};
       const fromObject = {};
       fromObject.a = fromObject;
-      expect(() => object.deepMerge(destObject, fromObject)).to.throw(
+      expect(() => deepMerge(destObject, fromObject)).to.throw(
           /Source object has a circular reference./);
     });
 
@@ -174,7 +174,7 @@ describe('Object', () => {
         },
         f: undefined,
       };
-      expect(object.deepMerge(destObject, fromObject)).to.deep.equal({
+      expect(deepMerge(destObject, fromObject)).to.deep.equal({
         a: {
           i: 'j',
         },
@@ -192,7 +192,7 @@ describe('Object', () => {
           throw new Error('deep merge tried to merge object with itself');
         },
       };
-      expect(object.deepMerge(destObject, destObject)).to.not.throw;
+      expect(deepMerge(destObject, destObject)).to.not.throw;
     });
   });
 });


### PR DESCRIPTION
\+ set the `no-has-own-property-method` lint rule to produce an error

Related to #6548 and based on https://github.com/ampproject/amphtml/pull/16762#discussion_r202844633