### PR TITLE
🚀 Story navigation performance improvements.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -235,19 +235,18 @@ export class AmpStoryPage extends AMP.BaseElement {
       case PageState.ACTIVE:
         if (this.state_ === PageState.NOT_ACTIVE) {
           this.element.setAttribute('active', '');
-          this.beforeVisible();
           this.resumeCallback();
         }
 
         if (this.state_ === PageState.PAUSED) {
-          this.advancement_.start();
+          this.startListeningToNavigationEvents();
           this.playAllMedia_();
         }
 
         this.state_ = state;
         break;
       case PageState.PAUSED:
-        this.advancement_.stop();
+        this.stopListeningToNavigationEvents();
         this.pauseAllMedia_(false /** rewindToBeginning */);
         this.state_ = state;
         break;
@@ -260,7 +259,7 @@ export class AmpStoryPage extends AMP.BaseElement {
 
   /** @override */
   pauseCallback() {
-    this.advancement_.stop();
+    this.stopListeningToNavigationEvents();
 
     this.stopListeningToVideoEvents_();
     this.pauseAllMedia_(true /** rewindToBeginning */);
@@ -276,7 +275,7 @@ export class AmpStoryPage extends AMP.BaseElement {
     this.registerAllMedia_();
 
     if (this.isActive()) {
-      this.advancement_.start();
+      this.startListeningToNavigationEvents();
       this.maybeStartAnimations();
       this.preloadAllMedia_()
           .then(() => this.startListeningToVideoEvents_())
@@ -302,6 +301,22 @@ export class AmpStoryPage extends AMP.BaseElement {
   /** @return {!Promise} */
   beforeVisible() {
     return this.scale_().then(() => this.maybeApplyFirstAnimationFrame());
+  }
+
+
+  /**
+   * Listens to navigation events.
+   */
+  startListeningToNavigationEvents() {
+    this.advancement_.start();
+  }
+
+
+  /**
+   * Stops listening to navigation events.
+   */
+  stopListeningToNavigationEvents() {
+    this.advancement_.stop();
   }
 
 

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -239,14 +239,14 @@ export class AmpStoryPage extends AMP.BaseElement {
         }
 
         if (this.state_ === PageState.PAUSED) {
-          this.startListeningToNavigationEvents();
+          this.advancement_.start();
           this.playAllMedia_();
         }
 
         this.state_ = state;
         break;
       case PageState.PAUSED:
-        this.stopListeningToNavigationEvents();
+        this.advancement_.stop();
         this.pauseAllMedia_(false /** rewindToBeginning */);
         this.state_ = state;
         break;
@@ -259,7 +259,7 @@ export class AmpStoryPage extends AMP.BaseElement {
 
   /** @override */
   pauseCallback() {
-    this.stopListeningToNavigationEvents();
+    this.advancement_.stop();
 
     this.stopListeningToVideoEvents_();
     this.pauseAllMedia_(true /** rewindToBeginning */);
@@ -275,7 +275,7 @@ export class AmpStoryPage extends AMP.BaseElement {
     this.registerAllMedia_();
 
     if (this.isActive()) {
-      this.startListeningToNavigationEvents();
+      this.advancement_.start();
       this.maybeStartAnimations();
       this.preloadAllMedia_()
           .then(() => this.startListeningToVideoEvents_())
@@ -301,22 +301,6 @@ export class AmpStoryPage extends AMP.BaseElement {
   /** @return {!Promise} */
   beforeVisible() {
     return this.scale_().then(() => this.maybeApplyFirstAnimationFrame());
-  }
-
-
-  /**
-   * Listens to navigation events.
-   */
-  startListeningToNavigationEvents() {
-    this.advancement_.start();
-  }
-
-
-  /**
-   * Stops listening to navigation events.
-   */
-  stopListeningToNavigationEvents() {
-    this.advancement_.stop();
   }
 
 

--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -188,12 +188,14 @@ amp-story:not([desktop]) >
 
 amp-story-page[active],
 amp-story:not([desktop]) >
+    amp-story-page[active].i-amphtml-layout-container[distance],
+amp-story:not([desktop]) >
     amp-story-page.i-amphtml-layout-container[distance="0"] {
   transform: translateY(0) !important;
 }
 
 amp-story:not([desktop]) >
-    amp-story-page:not[active].i-amphtml-layout-container[distance="1"] {
+    amp-story-page.i-amphtml-layout-container[distance="1"] {
   transform: translateY(100%) !important;
 }
 

--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -193,7 +193,7 @@ amp-story:not([desktop]) >
 }
 
 amp-story:not([desktop]) >
-    amp-story-page.i-amphtml-layout-container[distance="1"] {
+    amp-story-page:not[active].i-amphtml-layout-container[distance="1"] {
   transform: translateY(100%) !important;
 }
 

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -894,7 +894,6 @@ export class AmpStory extends AMP.BaseElement {
     const steps = [
       () => {
         oldPage && oldPage.element.removeAttribute('active');
-        oldPage && oldPage.stopListeningToNavigationEvents();
 
         this.systemLayer_.setActivePageId(targetPageId);
 

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -972,8 +972,9 @@ export class AmpStory extends AMP.BaseElement {
 
     // Each step will run in a requestAnimationFrame, and wait for the next
     // frame before executing the following step.
-    // First step contains the bare minimum the display and play the next page.
     const steps = [
+      // First step contains the minimum amount of code to display and play the
+      // target page as fast as possible.
       () => {
         oldPage && oldPage.element.removeAttribute('active');
 
@@ -988,6 +989,8 @@ export class AmpStory extends AMP.BaseElement {
 
         this.forceRepaintForSafari_();
       },
+      // Second step does all the operations that impact the UI/UX: media sound,
+      // progress bar, ...
       () => {
         if (oldPage) {
           oldPage.setState(PageState.NOT_ACTIVE);
@@ -1031,6 +1034,9 @@ export class AmpStory extends AMP.BaseElement {
 
         this.updateBackground_(targetPage.element, /* initial */ !oldPage);
       },
+      // Third and last step contains all the actions that can be delayed after
+      // the navigation happened, like preloading the following pages, or
+      // sending analytics events.
       () => {
         this.preloadPagesByDistance_();
         this.maybePreloadBookend_();

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -882,6 +882,88 @@ export class AmpStory extends AMP.BaseElement {
    * @return {!Promise}
    */
   switchTo_(targetPageId) {
+    if (isExperimentOn(this.win, 'amp-story-navigation-performance')) {
+      return this.experimentalSwitchTo_(targetPageId);
+    }
+
+    const targetPage = this.getPageById(targetPageId);
+    const pageIndex = this.getPageIndex(targetPage);
+
+    this.storeService_.dispatch(Action.CHANGE_PAGE, {
+      id: targetPageId,
+      index: pageIndex,
+    });
+
+    this.handlePreviewAttributes_(targetPage);
+
+    this.updateBackground_(targetPage.element, /* initial */ !this.activePage_);
+
+    if (targetPage.isAd()) {
+      this.storeService_.dispatch(Action.TOGGLE_AD, true);
+      setAttributeInMutate(this, Attributes.AD_SHOWING);
+    } else {
+      this.storeService_.dispatch(Action.TOGGLE_AD, false);
+      removeAttributeInMutate(this, Attributes.AD_SHOWING);
+      // TODO(alanorozco): decouple this using NavigationState
+      this.systemLayer_.setActivePageId(targetPageId);
+    }
+
+    // TODO(alanorozco): check if autoplay
+    this.navigationState_.updateActivePage(
+        pageIndex,
+        this.getPageCount(),
+        targetPage.element.id,
+        targetPage.getNextPageId() === null /* isFinalPage */
+    );
+
+    const oldPage = this.activePage_;
+
+    this.activePage_ = targetPage;
+
+    this.systemLayer_.resetDeveloperLogs();
+    this.systemLayer_.setDeveloperLogContextString(this.activePage_.element.id);
+
+    return targetPage.beforeVisible().then(() => {
+      this.triggerActiveEventForPage_();
+
+      if (oldPage) {
+        oldPage.setState(PageState.NOT_ACTIVE);
+
+        // Indication that this should be offscreen to left in desktop view.
+        setAttributeInMutate(oldPage, Attributes.VISITED);
+      }
+
+      // Starts playing the page, if the story is not paused.
+      // Note: navigation is prevented when the story is paused, this test
+      // covers the case where the story is rendered paused (eg: consent).
+      if (!this.storeService_.get(StateProperty.PAUSED_STATE)) {
+        targetPage.setState(PageState.ACTIVE);
+      }
+
+      // If first navigation.
+      if (!oldPage) {
+        this.registerAndPreloadBackgroundAudio_();
+      }
+
+      if (!this.storeService_.get(StateProperty.MUTED_STATE)) {
+        oldPage && oldPage.muteAllMedia();
+        this.activePage_.unmuteAllMedia();
+      }
+
+      this.preloadPagesByDistance_();
+      this.forceRepaintForSafari_();
+      this.maybePreloadBookend_();
+    });
+  }
+
+
+  /**
+   * Switches to a particular page.
+   * Protected behing the 'amp-story-navigation-performance' experiment.
+   * @param {string} targetPageId
+   * @return {!Promise}
+   */
+  experimentalSwitchTo_(targetPageId) {
     const targetPage = this.getPageById(targetPageId);
     const pageIndex = this.getPageIndex(targetPage);
 

--- a/tools/experiments/experiments.js
+++ b/tools/experiments/experiments.js
@@ -230,6 +230,12 @@ const EXPERIMENTS = [
     cleanupIssue: 'https://github.com/ampproject/amphtml/issues/15960',
   },
   {
+    id: 'amp-story-navigation-performance',
+    name: 'amp-story page to page navigation performance improvements',
+    spec: 'https://github.com/ampproject/amphtml/issues/17017',
+    cleanupIssue: 'https://github.com/ampproject/amphtml/issues/17018',
+  },
+  {
     id: 'inline-styles',
     name: 'Enables the usage of inline styles for non fixed elements',
     spec: 'https://github.com/ampproject/amphtml/issues/11881',


### PR DESCRIPTION
Organizes the page navigation method in three steps.
Each step runs in its own browser frame: we execute the first step, and wait for the next frame before executing the second step, etc.

The time measured is the time needed for the next page to be displayed, with its media elements playing.

| Device  | Avg navigation time before | Avg navigation time after | % improvement |
| :-------------: | :-------------: | :-------------: | :-------------: |
| BLU 4.0  | 1742.71ms | 832.15ms | +109.42% |
| Nexus 5  | 272.14ms | 89.28ms | +204.84% |
| iPhone 5  | 580.38ms | 279.12ms | +107.93% |
| Chrome mobile emulation  | 77.36ms | 29.42ms | +107.93% |
| **Average**  | **-** | **-** | **+146.29%** |

I've been testing a lot of stories with media / no media / auto-advance / etc, on both mobile and desktop versions, hopefully this comes bug free :)))