### PR TITLE
Remove unused attribute controls from <amp-anim>

### DIFF
--- a/extensions/amp-anim/validator-amp-anim.protoascii
+++ b/extensions/amp-anim/validator-amp-anim.protoascii
@@ -47,7 +47,6 @@ tags: {  # <amp-anim>
   requires_extension: "amp-anim"
   attrs: { name: "alt" }
   attrs: { name: "attribution" }
-  attrs: { name: "controls" }
   attr_lists: "extended-amp-global"
   attr_lists: "mandatory-src-or-srcset"
   spec_url: "https://www.ampproject.org/docs/reference/components/amp-anim"


### PR DESCRIPTION
Fixes #16936 