### PR TITLE
amp-bind: Array.sort() with comparator

### DIFF
--- a/extensions/amp-bind/0.1/bind-expression.js
+++ b/extensions/amp-bind/0.1/bind-expression.js
@@ -36,7 +36,7 @@ export let BindExpressionResultDef;
 const MAX_AST_SIZE = 100;
 
 /** @const @private {string} */
-const BUILT_IN_FUNCTIONS = 'built-in-functions';
+const CUSTOM_FUNCTIONS = 'custom-functions';
 
 /**
  * Map of object type to function name to whitelisted function.
@@ -52,12 +52,12 @@ function generateFunctionWhitelist() {
   /**
    * Deprecated. Static, not-in-place variant of Array#splice.
    * @param {!Array} array
-   * @param {number=} start
-   * @param {number=} deleteCount
-   * @param {...?} items
+   * @param {number=} unusedStart
+   * @param {number=} unusedDeleteCount
+   * @param {...?} unusedItems
    * @return {!Array}
    */
-  function splice(array, start, deleteCount, items) { // eslint-disable-line no-unused-vars
+  function splice(array, unusedStart, unusedDeleteCount, unusedItems) {
     if (!isArray(array)) {
       throw new Error(`splice: ${array} is not an array.`);
     }
@@ -72,13 +72,13 @@ function generateFunctionWhitelist() {
    */
   function instanceSplice() {
     /**
-     * @param {number=} start
-     * @param {number=} deleteCount
-     * @param {...?} items
+     * @param {number=} unusedStart
+     * @param {number=} unusedDeleteCount
+     * @param {...?} unusedItems
      * @return {!Array}
      * @this {!Array}
      */
-    return function splice(start, deleteCount, items) { // eslint-disable-line no-unused-vars
+    return function splice(unusedStart, unusedDeleteCount, unusedItems) {
       const copy = Array.prototype.slice.call(this);
       Array.prototype.splice.apply(copy, arguments);
       return copy;
@@ -134,7 +134,7 @@ function generateFunctionWhitelist() {
   // Prototype functions.
   const whitelist = dict({
     '[object Array]': {
-      // TODO(choumx): Need polyfill for Array#find and Array#findIndex.
+      // TODO(choumx): Polyfill Array#find and Array#findIndex for IE.
       'concat': Array.prototype.concat,
       'filter': Array.prototype.filter,
       'indexOf': Array.prototype.indexOf,
@@ -170,7 +170,7 @@ function generateFunctionWhitelist() {
   });
 
   // Un-namespaced static functions.
-  whitelist[BUILT_IN_FUNCTIONS] = {
+  whitelist[CUSTOM_FUNCTIONS] = {
     'encodeURI': encodeURI,
     'encodeURIComponent': encodeURIComponent,
     'abs': Math.abs,
@@ -204,12 +204,12 @@ function generateFunctionWhitelist() {
     });
   });
 
-  // Custom functions (non-js-built-ins) must be added manually as their names
+  // Custom functions (non-JS-built-ins) must be added manually as their names
   // will be minified at compile time.
-  out[BUILT_IN_FUNCTIONS]['copyAndSplice'] = splice; // Deprecated.
-  out[BUILT_IN_FUNCTIONS]['sort'] = sort; // Deprecated.
-  out[BUILT_IN_FUNCTIONS]['splice'] = splice; // Deprecated.
-  out[BUILT_IN_FUNCTIONS]['values'] =
+  out[CUSTOM_FUNCTIONS]['copyAndSplice'] = splice; // Deprecated.
+  out[CUSTOM_FUNCTIONS]['sort'] = sort; // Deprecated.
+  out[CUSTOM_FUNCTIONS]['splice'] = splice; // Deprecated.
+  out[CUSTOM_FUNCTIONS]['values'] =
       (typeof Object.values == 'function') ? Object.values : values;
 
   return out;
@@ -271,7 +271,7 @@ export class BindExpression {
     if (this.isMacroInvocationNode_(ast)) {
       const macro = this.macros_[String(ast.value)];
       let nodes = macro.getExpressionSize();
-      this.getInvocationArgNodes_(ast).forEach(arg => {
+      this.argumentsForInvocation_(ast).forEach(arg => {
         if (arg) {
           nodes += this.numberOfNodesInAst_(arg) - 1;
         }
@@ -306,23 +306,29 @@ export class BindExpression {
   }
 
   /**
-   * Gets the array of nodes for the arguments of the provided INVOCATION
-   * node, without the wrapping ARGS node and ARRAY node.
+   * Given an INVOCATION node, returns an array containing its arguments.
+   * Also unwraps its ARGS child, if it has one.
    * @param {!./bind-expr-defines.AstNode} ast
    * @return {!Array<./bind-expr-defines.AstNode>}
    * @private
    */
-  getInvocationArgNodes_(ast) {
-    if (ast.args.length === 2 && ast.args[1].type === AstNodeType.ARGS) {
-      const argsNode = ast.args[1];
-      if (argsNode.args.length === 0) {
+  argumentsForInvocation_(ast) {
+    // The INVOCATION node may or may not contain an ARGS child node.
+    const argsNode =
+        (ast.args.length === 2 && ast.args[1].type === AstNodeType.ARGS)
+          ? ast.args[1] : null;
+    if (argsNode) {
+      // An ARGS node can either have an empty array or an ARRAY child.
+      const {args} = argsNode;
+      if (args.length === 0) {
         return [];
-      } else if (argsNode.args.length === 1 &&
-          argsNode.args[0].type === AstNodeType.ARRAY) {
-        const arrayNode = argsNode.args[0];
+      } else if (args.length === 1 && args[0].type === AstNodeType.ARRAY) {
+        // An ARRAY node contains an actual array.
+        const arrayNode = args[0];
         return arrayNode.args || [];
       }
     }
+    // Otherwise, just return the array of its non-ARGS arguments.
     return ast.args || [];
   }
 
@@ -369,7 +375,7 @@ export class BindExpression {
                   scope, Array.prototype.slice.call(arguments));
             };
           } else {
-            validFunction = FUNCTION_WHITELIST[BUILT_IN_FUNCTIONS][method];
+            validFunction = FUNCTION_WHITELIST[CUSTOM_FUNCTIONS][method];
           }
           if (!validFunction) {
             unsupportedError = `${method} is not a supported function.`;
@@ -386,7 +392,7 @@ export class BindExpression {
             const f = caller[method];
             if (f && f === whitelist[method]) {
               validFunction = f;
-            } else if (method === 'sort' || method === 'splice') {
+            } else if (this.isCustomInstanceFunction_(method)) {
               validFunction = whitelist[method];
             }
           }
@@ -550,6 +556,17 @@ export class BindExpression {
       default:
         throw new Error(`Unexpected AstNodeType: ${type}.`);
     }
+  }
+
+  /**
+   * Returns true if `method` is a non-standard instance function.
+   * We alter certain functions e.g. Array.sort to modify and return a copy
+   * instead of operating in-place.
+   * @param {string} method
+   * @return {boolean}
+   */
+  isCustomInstanceFunction_(method) {
+    return method === 'sort' || method === 'splice';
   }
 
   /**

--- a/extensions/amp-bind/0.1/bind-expression.js
+++ b/extensions/amp-bind/0.1/bind-expression.js
@@ -80,11 +80,12 @@ function generateFunctionWhitelist() {
      * @return {!Array}
      * @this {!Array}
      */
-    return function splice(unusedStart, unusedDeleteCount, unusedItems) {
+    function splice(unusedStart, unusedDeleteCount, unusedItems) {
       const copy = Array.prototype.slice.call(this);
       Array.prototype.splice.apply(copy, arguments);
       return copy;
-    };
+    }
+    return splice;
   }
 
   /**
@@ -112,11 +113,12 @@ function generateFunctionWhitelist() {
      * @return {!Array}
      * @this {!Array}
      */
-    return function sort(compareFunction) {
+    function sort(compareFunction) {
       const copy = Array.prototype.slice.call(this);
       Array.prototype.sort.call(copy, compareFunction);
       return copy;
-    };
+    }
+    return sort;
   }
 
   /**

--- a/extensions/amp-bind/0.1/bind-expression.js
+++ b/extensions/amp-bind/0.1/bind-expression.js
@@ -68,6 +68,8 @@ function generateFunctionWhitelist() {
   }
 
   /**
+   * Needs to be wrapped to avoid a duplicate name conflict with the deprecated
+   * splice function above.
    * @return {!Function}
    */
   function instanceSplice() {
@@ -100,6 +102,8 @@ function generateFunctionWhitelist() {
   }
 
   /**
+   * Needs to be wrapped to avoid a duplicate name conflict with the deprecated
+   * splice function above.
    * @return {!Function}
    */
   function instanceSort() {

--- a/extensions/amp-bind/0.1/bind-expression.js
+++ b/extensions/amp-bind/0.1/bind-expression.js
@@ -104,7 +104,7 @@ function generateFunctionWhitelist() {
 
   /**
    * Needs to be wrapped to avoid a duplicate name conflict with the deprecated
-   * splice function above.
+   * sort function above.
    * @return {!Function}
    */
   function instanceSort() {
@@ -570,6 +570,7 @@ export class BindExpression {
    * instead of operating in-place.
    * @param {string} method
    * @return {boolean}
+   * @private
    */
   isCustomInstanceFunction_(method) {
     return method === 'sort' || method === 'splice';
@@ -579,6 +580,7 @@ export class BindExpression {
    * @param {string} method
    * @param {!Array} params
    * @return {boolean}
+   * @private
    */
   containsInvalidArgument_(method, params) {
     // Don't allow objects as parameters except for certain functions.

--- a/extensions/amp-bind/0.1/test/test-bind-expression.js
+++ b/extensions/amp-bind/0.1/test/test-bind-expression.js
@@ -254,7 +254,7 @@ describe('BindExpression', () => {
       expect(evaluate('["a", {}][{}]')).to.be.null;
     });
 
-    it('whitelisted functions', () => {
+    it('prototype functions', () => {
       expect(evaluate('["a", "b"].concat(["c", "d"])'))
           .to.deep.equal(['a', 'b', 'c', 'd']);
       expect(evaluate('["a", "a"].indexOf("a")')).to.equal(0);
@@ -265,6 +265,38 @@ describe('BindExpression', () => {
       expect(evaluate('[1, 2, 3, 4, 5].includes(3)')).to.be.true;
     });
 
+    it('custom Array#sort()', () => {
+      expect(evaluate('[11, 1, 2].sort()')).to.deep.equal([1, 11, 2]);
+      expect(evaluate('[11, 1, 2].sort((x, y) => x > y)'))
+          .to.deep.equal([1, 2, 11]);
+
+      const a = [11, 1, 2];
+      expect(evaluate('a.sort()', {a})).to.deep.equal([1, 11, 2]);
+      expect(evaluate('a.sort((x, y) => x > y)', {a}))
+          .to.deep.equal([1, 2, 11]);
+
+      // Sort should be out-of-place i.e. does not sort the caller.
+      expect(evaluate('a.sort().concat(a)', {a}))
+          .to.deep.equal([1, 11, 2, 11, 1, 2]);
+    });
+
+    it('custom Array#splice()', () => {
+      expect(evaluate('[1, 2, 3].splice()')).to.deep.equal([1, 2, 3]);
+      expect(evaluate('[1, 2, 3].splice(1)')).to.deep.equal([1]);
+      expect(evaluate('[1, 2, 3].splice(1, 1)')).to.deep.equal([1, 3]);
+      expect(evaluate('[1, 2, 3].splice(1, 1, 47)')).to.deep.equal([1, 47, 3]);
+
+      const a = [1, 2, 3];
+      expect(evaluate('a.splice()', {a})).to.deep.equal([1, 2, 3]);
+      expect(evaluate('a.splice(1)', {a})).to.deep.equal([1]);
+      expect(evaluate('a.splice(1, 1)', {a})).to.deep.equal([1, 3]);
+      expect(evaluate('a.splice(1, 1, 47)', {a})).to.deep.equal([1, 47, 3]);
+
+      // Splice should be out-of-place i.e. does not splice the caller.
+      expect(evaluate('a.splice(1).concat(a)', {a}))
+          .to.deep.equal([1, 1, 2, 3]);
+    });
+
     it('non-whitelisted functions', () => {
       expect(() => {
         evaluate('["a", "b", "c"].find()');
@@ -272,18 +304,12 @@ describe('BindExpression', () => {
       expect(() => {
         evaluate('["a", "b", "c"].forEach()');
       }).to.throw(Error, unsupportedFunctionError);
-      expect(() => {
-        evaluate('["a", "b", "c"].splice(1, 1)');
-      }).to.throw(Error, unsupportedFunctionError);
 
       expect(() => {
         evaluate('foo.find()', {foo: ['a', 'b', 'c']});
       }).to.throw(Error, unsupportedFunctionError);
       expect(() => {
         evaluate('foo.forEach()', {foo: ['a', 'b', 'c']});
-      }).to.throw(Error, unsupportedFunctionError);
-      expect(() => {
-        evaluate('foo.splice(1, 1)', {foo: ['a', 'b', 'c']});
       }).to.throw(Error, unsupportedFunctionError);
     });
   });

--- a/extensions/amp-bind/amp-bind.md
+++ b/extensions/amp-bind/amp-bind.md
@@ -227,7 +227,7 @@ null || 'default' // 'default'
     <th>Example</th>
   </tr>
   <tr>
-    <td><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array#Methods"><code>Array</code><sup>2</sup></a></td>
+    <td><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array#Methods"><code>Array</code><sup>1</sup></a></td>
     <td class="col-thirty">
       <code>concat</code><br>
       <code>filter</code><br>
@@ -239,12 +239,12 @@ null || 'default' // 'default'
       <code>reduce</code><br>
       <code>slice</code><br>
       <code>some</code><br>
+      <code>sort</code> (not-in-place)<br>
+      <code>splice</code> (not-in-place)<br>
     </td>
     <td>
-      <pre>// Returns true.
-[1, 2, 3].includes(1)</pre>
-      <pre>// Returns [2, 3].
-[1, 2, 3].filter(x => x >= 2)</pre>
+      <pre>// Returns [1, 2, 3].
+[3, 2, 1].sort()</pre>
       <pre>// Returns [1, 3, 5].
 [1, 2, 3].map((x, i) => x + i)</pre>
       <pre>// Returns 6.
@@ -285,7 +285,7 @@ null || 'default' // 'default'
     </td>
   </tr>
   <tr>
-    <td><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math"><code>Math</code></a><sup>3</sup></td>
+    <td><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math"><code>Math</code></a><sup>2</sup></td>
     <td>
       <code>abs</code><br>
       <code>ceil</code><br>
@@ -301,7 +301,7 @@ abs(-1)</pre>
     </td>
   </tr>
   <tr>
-    <td><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object"><code>Object</code></a><sup>3</sup></td>
+    <td><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object"><code>Object</code></a><sup>2</sup></td>
     <td>
       <code>keys</code><br>
       <code>values</code>
@@ -314,7 +314,7 @@ values({a: 1, b: 2}</pre>
   </tr>
   <tr>
     <td>
-      <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects"><code>Global</code></a><sup>3</sup>
+      <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects"><code>Global</code></a><sup>2</sup>
     </td>
     <td>
       <code>encodeURI</code><br>
@@ -325,25 +325,10 @@ values({a: 1, b: 2}</pre>
 encodeURIComponent('Hello world')</pre>
     </td>
   </tr>
-  <tr>
-    <td>
-      <a href="#custom-built-in-functions">Custom built-ins</a><sup>3</sup>
-    </td>
-    <td>
-      <code>splice</code><br>
-      <code>sort</code>
-    </td>
-    <td>
-      <pre>// Returns a new array [1, 47 ,3]. Does not splice in-place.
-splice([1, 2, 3], 1, 1, 47)</pre>
-      <pre>// Returns a new array: [1, 2, 3]. Does not sort in-place.
-sort([2, 1, 3])</pre>
-    </td>
-  </tr>
 </table>
 
-<sup>2</sup>Single-parameter arrow functions can't have parentheses, e.g. use `x => x + 1` instead of `(x) => x + 1`.<br>
-<sup>3</sup>Static functions are not namespaced, e.g. use `abs(-1)` instead of `Math.abs(-1)`.
+<sup>1</sup>Single-parameter arrow functions can't have parentheses, e.g. use `x => x + 1` instead of `(x) => x + 1`. Also, `sort()` and `splice()` return modified copies instead of operating in-place.<br>
+<sup>2</sup>Static functions are not namespaced, e.g. use `abs(-1)` instead of `Math.abs(-1)`.
 
 #### Defining macros with `amp-bind-macro`
 


### PR DESCRIPTION
Fixes #13370.

- Deprecates static `sort(<array>)` and `splice(<array>)` functions in favor of custom instance functions e.g. `<array>.sort()`.

This also indirectly allows the use of comparator function argument for `Array.sort()`.