### PR TITLE
🐛🖍 Do not use display: grid for story body

### DIFF
--- a/extensions/amp-story/0.1/amp-story.css
+++ b/extensions/amp-story/0.1/amp-story.css
@@ -70,10 +70,6 @@ html.i-amphtml-story-standalone body {
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0) !important;
 }
 
-html.i-amphtml-story-standalone body {
-  display: grid !important;
-}
-
 html.i-amphtml-story-standalone #i-amphtml-wrapper body {
   /** AMP runtime adds a 1px border on iOS iframes, causing the body to be
       1px bigger than the viewport. */

--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -97,10 +97,6 @@ amp-story h6 {
   font-size: 0.67rem;
 }
 
-html.i-amphtml-story-standalone body {
-  display: grid !important;
-}
-
 html.i-amphtml-story-standalone #i-amphtml-wrapper body {
   /** AMP runtime adds a 1px border on iOS iframes, causing the body to be
       1px bigger than the viewport. */


### PR DESCRIPTION
`display: grid` was causing the story to split the body equally with any other element(s) contained in the body, such as those added at runtime by browser extensions.  Removing this defaults back to `display: block` which does not have this problem.

Fixes #12140.