### PR TITLE
✅ amp-next-page: Improve validator spec

### DIFF
--- a/extensions/amp-next-page/validator-amp-next-page.protoascii
+++ b/extensions/amp-next-page/validator-amp-next-page.protoascii
@@ -39,8 +39,8 @@ tags: {  # amp-next-page: json config
 }
 tags: {
   html_format: AMP
-  tag_name: "DIV"
-  spec_name: "AMP-NEXT-PAGE > DIV [separator]"
+  tag_name: "$REFERENCE_POINT"
+  spec_name: "AMP-NEXT-PAGE > [separator]"
   mandatory_parent: "AMP-NEXT-PAGE"
   attrs: {
     name: "separator"
@@ -50,15 +50,38 @@ tags: {
 tags: {  # <amp-next-page>
   html_format: AMP
   tag_name: "AMP-NEXT-PAGE"
+  spec_name: "amp-next-page with inline config"
+  unique: true
+  requires_extension: "amp-next-page"
+  reference_points: {
+    tag_spec_name: "AMP-NEXT-PAGE > [separator]"
+    unique: true
+  }
+  reference_points: {
+    tag_spec_name: "amp-next-page extension .json configuration"
+    mandatory: true
+    unique: true
+  }
+  spec_url: "https://www.ampproject.org/docs/reference/components/amp-next-page"
+}
+tags: {  # <amp-next-page src>
+  html_format: AMP
+  tag_name: "AMP-NEXT-PAGE"
+  spec_name: "amp-next-page with src attribute"
   unique: true
   requires_extension: "amp-next-page"
   attrs: {
     name: "src"
+    mandatory: true
     value_url: {
       protocol: "https"
       allow_relative: false
     }
     blacklisted_value_regex: "__amp_source_origin"
+  }
+  reference_points: {
+    tag_spec_name: "AMP-NEXT-PAGE > [separator]"
+    unique: true
   }
   spec_url: "https://www.ampproject.org/docs/reference/components/amp-next-page"
 }


### PR DESCRIPTION
Split the validator spec in two: one for inline config, one for src. Makes it more robust, requires that you can't specify both, and you have to specify one or the other.

Also allows for `[separator]` to be specified on any element, not just a div.