### PR TITLE
[WIP] Server side rendering template part 2

### DIFF
--- a/build-system/dep-check-config.js
+++ b/build-system/dep-check-config.js
@@ -274,6 +274,8 @@ exports.rules = [
           'src/service/navigation.js',
       'extensions/amp-list/0.1/amp-list.js->' +
           'src/service/xhr-impl.js',
+      'extensions/amp-form/0.1/amp-form.js->' +
+          'src/service/xhr-impl.js',
     ],
   },
   {

--- a/build-system/dep-check-config.js
+++ b/build-system/dep-check-config.js
@@ -272,6 +272,8 @@ exports.rules = [
           'src/service/navigation.js',
       'extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js->' +
           'src/service/navigation.js',
+      'extensions/amp-list/0.1/amp-list.js->' +
+          'src/service/xhr-impl.js',
     ],
   },
   {

--- a/build-system/tasks/bundle-size.js
+++ b/build-system/tasks/bundle-size.js
@@ -22,7 +22,7 @@ const log = require('fancy-log');
 const {getStdout} = require('../exec');
 
 const runtimeFile = './dist/v0.js';
-const maxSize = '79.28KB';
+const maxSize = '79.34KB';
 
 const {green, red, cyan, yellow} = colors;
 

--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -355,10 +355,10 @@ const forbiddenTerms = {
       'src/service/cid-impl.js',
       'src/service/history-impl.js',
       'src/service/storage-impl.js',
-      'src/ssr-template-helper.js',
       'src/service/viewer-impl.js',
       'src/service/viewer-cid-api.js',
       'src/service/xhr-impl.js',
+      'src/ssr-template-helper.js',
     ],
   },
   // Privacy sensitive

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -483,6 +483,28 @@ export class AmpForm {
   }
 
   /**
+   * If present, finds and returns the success and error response templates.
+   * Note that we do not render the submitting state template and only
+   * deal with submit-success or submit-error.
+   * @return {!../../../src/ssr-template-helper.SsrTemplateDef}
+   */
+  getResponseTemplates_() {
+    const successContainer =
+        this.form_.querySelector('div[submit-success]');
+    const errorContainer = this.form_.querySelector('div[submit-error]');
+    let successTemplate;
+    let errorTemplate;
+    if (successContainer) {
+      successTemplate =
+          this.templates_.maybeFindTemplate(successContainer);
+    }
+    if (errorContainer) {
+      errorTemplate = this.templates_.maybeFindTemplate(errorContainer);
+    }
+    return {successTemplate, errorTemplate};
+  }
+
+  /**
    * Handles viewer render template failure.
    * @param {!JsonObject} error
    */

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -277,7 +277,7 @@ export class AmpForm {
       this.validator_.onBlur(e);
     }, true);
 
-    // If the viewer can render templates, then form verifier is not applicable.
+    // Form verification is not supported when SSRing templates is enabled.
     if (!this.ssrTemplateHelper_.isSupported()) {
       this.form_.addEventListener('change', e => {
         this.verifier_.onCommit().then(({updatedElements, errors}) => {
@@ -472,11 +472,10 @@ export class AmpForm {
             this.submittingWithTrust_(trust);
             return this.doActionXhr_();
           })
-          .then(response => this.handleXhrSubmitSuccess_(
-              /* !../../../src/service/xhr-impl.FetchResponse */ response),
-          error => {
-            return this.handleXhrSubmitFailure_(/** @type {!Error} */(error));
-          });
+          .then(response => this.handleXhrSubmitSuccess_(response),
+              error => {
+                return this.handleXhrSubmitFailure_(/** @type {!Error} */(error));
+              });
     }
     if (getMode().test) {
       this.xhrSubmitPromise_ = p;
@@ -492,7 +491,7 @@ export class AmpForm {
     user().error(TAG, `Form submission failed: ${error}`);
     return tryResolve(() => {
       this.renderTemplate_(error || {}).then(() => {
-        this.triggerAction_(FormEvents.SUBMIT_ERROR, error); // do we need this?
+        this.triggerAction_(FormEvents.SUBMIT_ERROR, error);
       });
     });
   }
@@ -677,8 +676,7 @@ export class AmpForm {
   }
 
   /**
-   * Throws an error related to viewer render template handling.
-   * supported.
+   * Asserts that SSR support is the same as value.
    * @param {boolean} value
    * @param {string} msg
    * @private

--- a/extensions/amp-form/0.1/test/test-amp-form.js
+++ b/extensions/amp-form/0.1/test/test-amp-form.js
@@ -1240,7 +1240,7 @@ describes.repeated('', {
 
     describe('User Validity', () => {
       it('should manage valid/invalid on input/fieldset/form on submit', () => {
-        expectAsyncConsoleError(/Form submission failed.*/);
+        expectAsyncConsoleError(/Form submission failed/);
         setReportValiditySupportedForTesting(false);
         return getAmpForm(getForm(/*button1*/ true)).then(ampForm => {
           const form = ampForm.form_;
@@ -1479,7 +1479,7 @@ describes.repeated('', {
     });
 
     it('should submit after timeout of waiting for amp-selector', function() {
-      expectAsyncConsoleError(/Form submission failed.*/);
+      expectAsyncConsoleError(/Form submission failed/);
       this.timeout(3000);
       return getAmpForm(getForm()).then(ampForm => {
         const form = ampForm.form_;

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -263,7 +263,7 @@ export class AmpList extends AMP.BaseElement {
    * @return {!Promise}
    */
   ssrTemplate_() {
-    constructBatchFetchData(
+    return constructBatchFetchData(
         this.getAmpDoc(),
         this.element,
         this.element.getAttribute('src'),

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -264,6 +264,7 @@ export class AmpList extends AMP.BaseElement {
    */
   ssrTemplate_() {
     let fetchData;
+    const {win} = this;
     // Construct the fetch init data that would be called by the viewer
     // passed in as the 'originalRequest'.
     return constructBatchFetchData(
@@ -272,14 +273,14 @@ export class AmpList extends AMP.BaseElement {
         this.element.getAttribute('src'),
         this.getPolicy_()).then(batchFetchData => {
       fetchData =
-          setAmpCors(this.win, batchFetchData.xhrUrl, batchFetchData.fetchOpt);
+          setAmpCors(win, batchFetchData.xhrUrl, batchFetchData.fetchOpt);
       setupJsonFetchInit(batchFetchData.fetchOpt);
       return this.ssrTemplateHelper_.fetchAndRenderTemplate(
           this.element, fetchData);
     }).then(response => {
       const fetchResponse =
-          fromStructuredCloneable(this.win, response, fetchData.responseType);
-      validateFetchResponse(this.win, fetchResponse, fetchData.fetchOpt);
+          fromStructuredCloneable(win, response, fetchData.responseType);
+      validateFetchResponse(win, fetchResponse, fetchData.fetchOpt);
       return fetchResponse.json();
     }, error => {
       throw user().createError('Error proxying amp-list templates', error);

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -274,10 +274,11 @@ export class AmpList extends AMP.BaseElement {
         this.getPolicy_()).then(batchFetchData => {
       fetchData =
           setAmpCors(win, batchFetchData.xhrUrl, batchFetchData.fetchOpt);
-      setupJsonFetchInit(batchFetchData.fetchOpt);
+      setupJsonFetchInit(fetchData.fetchOpt);
       return this.ssrTemplateHelper_.fetchAndRenderTemplate(
           this.element, fetchData);
     }).then(response => {
+      // Construct the fetch response and validate.
       const fetchResponse =
           fromStructuredCloneable(win, response, fetchData.responseType);
       validateFetchResponse(win, fetchResponse, fetchData.fetchOpt);

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -27,7 +27,7 @@ import {
 } from '../../../src/batched-json';
 import {createCustomEvent} from '../../../src/event-helper';
 import {dev, user} from '../../../src/log';
-import {fromStructuredCloneable, setAmpCors, validateFetchResponse} from '../../../src/service/xhr-impl';
+import {fromStructuredCloneable, setAmpCors, setupJsonFetchInit, validateFetchResponse} from '../../../src/service/xhr-impl';
 import {getSourceOrigin} from '../../../src/url';
 import {isArray} from '../../../src/types';
 import {isLayoutSizeDefined} from '../../../src/layout';
@@ -264,14 +264,16 @@ export class AmpList extends AMP.BaseElement {
    */
   ssrTemplate_() {
     let fetchData;
+    // Construct the fetch init data that would be called by the viewer
+    // passed in as the 'originalRequest'.
     return constructBatchFetchData(
         this.getAmpDoc(),
         this.element,
         this.element.getAttribute('src'),
         this.getPolicy_()).then(batchFetchData => {
-      // TODO(alabiaga): add this to constructBatchFetchData.
       fetchData =
           setAmpCors(this.win, batchFetchData.xhrUrl, batchFetchData.fetchOpt);
+      setupJsonFetchInit(batchFetchData.fetchOpt);
       return this.ssrTemplateHelper_.fetchAndRenderTemplate(
           this.element, fetchData);
     }).then(response => {

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -231,7 +231,7 @@ export class AmpList extends AMP.BaseElement {
       return Promise.resolve();
     }
     if (this.ssrTemplateHelper_.isSupported()) {
-      return this.ssrTemplate_();
+      return this.ssrTemplate_(this.element.getAttribute('src'));
     } else {
       const itemsExpr = this.element.getAttribute('items') || 'items';
       return this.fetch_(itemsExpr).then(items => {
@@ -263,15 +263,19 @@ export class AmpList extends AMP.BaseElement {
    */
   ssrTemplate_() {
     return this.ssrTemplateHelper_.fetchAndRenderTemplate(
-        this.element).then(resp => {
-      const data = getData(resp);
-      user().assert(
-          resp && (typeof data !== 'undefined'),
-          'Response missing the \'data\' field');
-      return this.scheduleRender_(data);
-    }, error => {
-      throw user().createError('Error proxying amp-list templates', error);
-    }).then(() => this.onFetchSuccess_(), error => this.onFetchError_(error));
+        this.element,
+        // TODO(alabiaga): build fetch object here.
+        this.ssrTemplateHelper_.buildFetchDataObj_())
+        .then(resp => {
+          const data = getData(resp);
+          user().assert(
+              resp && (typeof data !== 'undefined'),
+              'Response missing the \'data\' field');
+          return this.scheduleRender_(data);
+        }, error => {
+          throw user().createError('Error proxying amp-list templates', error);
+        }).then(
+            () => this.onFetchSuccess_(), error => this.onFetchError_(error));
   }
 
   /**

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -27,7 +27,13 @@ import {
 } from '../../../src/batched-json';
 import {createCustomEvent} from '../../../src/event-helper';
 import {dev, user} from '../../../src/log';
-import {fromStructuredCloneable, setAmpCors, setupJsonFetchInit, validateFetchResponse} from '../../../src/service/xhr-impl';
+import {
+  fromStructuredCloneable,
+  setAmpCors,
+  setupInit,
+  setupJsonFetchInit,
+  validateFetchResponse,
+} from '../../../src/service/xhr-impl';
 import {getSourceOrigin} from '../../../src/url';
 import {isArray} from '../../../src/types';
 import {isLayoutSizeDefined} from '../../../src/layout';
@@ -270,11 +276,11 @@ export class AmpList extends AMP.BaseElement {
     return constructBatchFetchData(
         this.getAmpDoc(),
         this.element,
-        this.element.getAttribute('src'),
         this.getPolicy_()).then(batchFetchData => {
       fetchData =
           setAmpCors(win, batchFetchData.xhrUrl, batchFetchData.fetchOpt);
       setupJsonFetchInit(fetchData.fetchOpt);
+      setupInit(fetchData.fetchOpt);
       return this.ssrTemplateHelper_.fetchAndRenderTemplate(
           this.element, fetchData);
     }).then(response => {
@@ -282,7 +288,7 @@ export class AmpList extends AMP.BaseElement {
       const fetchResponse =
           fromStructuredCloneable(win, response, fetchData.responseType);
       validateFetchResponse(win, fetchResponse, fetchData.fetchOpt);
-      return fetchResponse.json();
+      return fetchResponse;
     }, error => {
       throw user().createError('Error proxying amp-list templates', error);
     }).then(json => this.scheduleRender_(json))

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -264,8 +264,6 @@ export class AmpList extends AMP.BaseElement {
   ssrTemplate_() {
     return this.ssrTemplateHelper_.fetchAndRenderTemplate(
         this.element).then(resp => {
-      // TODO(alabiaga): Since this is related to the viewer,
-      // this should be a 3rd log type?
       const data = getData(resp);
       user().assert(
           resp && (typeof data !== 'undefined'),

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -264,7 +264,8 @@ export class AmpList extends AMP.BaseElement {
   ssrTemplate_() {
     return this.ssrTemplateHelper_.fetchAndRenderTemplate(
         this.element,
-        // TODO(alabiaga): build fetch object here.
+        // TODO(alabiaga): build fetch object here...pull out logic from
+        // batchFetchJsonFor..
         this.ssrTemplateHelper_.buildFetchDataObj_())
         .then(resp => {
           const data = getData(resp);

--- a/src/batched-json.js
+++ b/src/batched-json.js
@@ -48,8 +48,8 @@ export function batchFetchJsonFor(
   opt_expr = '.',
   opt_urlReplacement = UrlReplacementPolicy.NONE)
 {
-  const url = assertHttpsUrl(element.getAttribute('src'), element);
-  return constructBatchFetchData(ampdoc, element, url, opt_urlReplacement)
+  assertHttpsUrl(element.getAttribute('src'), element);
+  return constructBatchFetchData(ampdoc, element, opt_urlReplacement)
       .then(data => {
         return Services.batchedXhrFor(ampdoc.win)
             .fetchJson(data['src'], data['fetchOpts']);
@@ -66,19 +66,17 @@ export function batchFetchJsonFor(
  * fetch.
  * @param {!./service/ampdoc-impl.AmpDoc} ampdoc
  * @param {!Element} element
- * @param {string} url
  * @param {!UrlReplacementPolicy} opt_urlReplacement If ALL, replaces all URL
  *     vars. If OPT_IN, replaces whitelisted URL vars. Otherwise, don't expand.
  * @return {!Promise<!./service/xhr-impl.FetchData>}
  */
 export function constructBatchFetchData(
-  ampdoc, element, url, opt_urlReplacement) {
+  ampdoc, element, opt_urlReplacement) {
+  const url = element.getAttribute('src');
   // Replace vars in URL if desired.
   const urlReplacements = Services.urlReplacementsForDoc(ampdoc);
   const srcPromise = (opt_urlReplacement >= UrlReplacementPolicy.OPT_IN)
-    ? urlReplacements.expandUrlAsync(url)
-    : Promise.resolve(url);
-
+    ? urlReplacements.expandUrlAsync(url) : Promise.resolve(url);
   return srcPromise.then(xhrUrl => {
     // Throw user error if this element is performing URL substitutions
     // without the soon-to-be-required opt-in (#12498).

--- a/src/batched-json.js
+++ b/src/batched-json.js
@@ -79,7 +79,7 @@ export function constructBatchFetchData(
     ? urlReplacements.expandUrlAsync(url)
     : Promise.resolve(url);
 
-  return srcPromise.then(src => {
+  return srcPromise.then(xhrUrl => {
     // Throw user error if this element is performing URL substitutions
     // without the soon-to-be-required opt-in (#12498).
     if (opt_urlReplacement == UrlReplacementPolicy.OPT_IN) {
@@ -91,13 +91,13 @@ export function constructBatchFetchData(
             `<${element.tagName}> element. See https://bit.ly/amp-var-subs.`);
       }
     }
-    const opts = {};
+    const fetchOpt = {};
     if (element.hasAttribute('credentials')) {
-      opts.credentials = element.getAttribute('credentials');
+      fetchOpt.credentials = element.getAttribute('credentials');
     } else {
-      opts.requireAmpResponseSourceOrigin = false;
+      fetchOpt.requireAmpResponseSourceOrigin = false;
     }
 
-    return {src, opts};
+    return {xhrUrl, fetchOpt};
   });
 }

--- a/src/batched-json.js
+++ b/src/batched-json.js
@@ -49,7 +49,30 @@ export function batchFetchJsonFor(
   opt_urlReplacement = UrlReplacementPolicy.NONE)
 {
   const url = assertHttpsUrl(element.getAttribute('src'), element);
+  return constructBatchFetchData(ampdoc, element, url, opt_urlReplacement)
+      .then(data => {
+        return Services.batchedXhrFor(ampdoc.win)
+            .fetchJson(data['src'], data['fetchOpts']);
+      }).then(res => res.json()).then(data => {
+        if (data == null) {
+          throw new Error('Response is undefined.');
+        }
+        return getValueForExpr(data, opt_expr || '.');
+      });
+}
 
+/**
+ * Handles url replacement and constructs the FetchInitiJsonDef required for a
+ * fetch.
+ * @param {!./service/ampdoc-impl.AmpDoc} ampdoc
+ * @param {!Element} element
+ * @param {string} url
+ * @param {!UrlReplacementPolicy} opt_urlReplacement If ALL, replaces all URL
+ *     vars. If OPT_IN, replaces whitelisted URL vars. Otherwise, don't expand.
+ * @return {!Promise<!./service/xhr-impl.FetchData>}
+ */
+export function constructBatchFetchData(
+  ampdoc, element, url, opt_urlReplacement) {
   // Replace vars in URL if desired.
   const urlReplacements = Services.urlReplacementsForDoc(ampdoc);
   const srcPromise = (opt_urlReplacement >= UrlReplacementPolicy.OPT_IN)
@@ -74,11 +97,7 @@ export function batchFetchJsonFor(
     } else {
       opts.requireAmpResponseSourceOrigin = false;
     }
-    return Services.batchedXhrFor(ampdoc.win).fetchJson(src, opts);
-  }).then(res => res.json()).then(data => {
-    if (data == null) {
-      throw new Error('Response is undefined.');
-    }
-    return getValueForExpr(data, opt_expr || '.');
+
+    return {src, opts};
   });
 }

--- a/src/batched-json.js
+++ b/src/batched-json.js
@@ -62,7 +62,7 @@ export function batchFetchJsonFor(
 }
 
 /**
- * Handles url replacement and constructs the FetchInitiJsonDef required for a
+ * Handles url replacement and constructs the FetchInitJsonDef required for a
  * fetch.
  * @param {!./service/ampdoc-impl.AmpDoc} ampdoc
  * @param {!Element} element

--- a/src/service/xhr-impl.js
+++ b/src/service/xhr-impl.js
@@ -366,7 +366,7 @@ function normalizeMethod_(method) {
  * @param {string=} opt_accept The HTTP Accept header value.
  * @return {!FetchInitDef}
  */
-function setupInit(opt_init, opt_accept) {
+export function setupInit(opt_init, opt_accept) {
   const init = opt_init || {};
   init.method = normalizeMethod_(init.method);
   init.headers = init.headers || dict({});

--- a/src/service/xhr-impl.js
+++ b/src/service/xhr-impl.js
@@ -377,7 +377,7 @@ function setupInit(opt_init, opt_accept) {
 }
 
 /**
- * @param {!FetchInitJsonDef} init
+ * @param {?FetchInitJsonDef=} init
  * @return {!FetchInitJsonDef}
  */
 export function setupJsonFetchInit(init) {

--- a/src/ssr-template-helper.js
+++ b/src/ssr-template-helper.js
@@ -100,7 +100,7 @@ export class SsrTemplateHelper {
   }
 
   /**
-   * Returns the element's attributes in json format.
+   * Returns the element's whitelisted attributes in json format.
    * @param {!Element} element
    * @return {!JsonObject}
    */

--- a/src/ssr-template-helper.js
+++ b/src/ssr-template-helper.js
@@ -15,9 +15,7 @@
  */
 
 import {Capability} from './service/viewer-impl';
-import {FormDataWrapper} from './form-data-wrapper';
-import {addParamsToUrl} from './url';
-import {deepMerge, dict, map} from './utils/object';
+import {dict, map} from './utils/object';
 import {iterateCursor} from './dom';
 import {toStructuredCloneable} from './service/xhr-impl';
 

--- a/src/ssr-template-helper.js
+++ b/src/ssr-template-helper.js
@@ -93,7 +93,8 @@ export class SsrTemplateHelper {
       }
     }
     const data = dict({
-      'originalRequest': toStructuredCloneable(fetchData.xhrUrl, fetchData.fetchOpt),
+      'originalRequest':
+          toStructuredCloneable(fetchData.xhrUrl, fetchData.fetchOpt),
       'data': elementAttrsAsJson,
       'sourceAmpComponent': this.sourceComponent_,
     });

--- a/src/ssr-template-helper.js
+++ b/src/ssr-template-helper.js
@@ -107,11 +107,10 @@ export class SsrTemplateHelper {
   getElementAttributesAsJson_(element) {
     const attrsAsJson = map();
     if (element.attributes.length > 0) {
-      const {attributes} = element;
       /** {!Array} */
       const whiteList = ATTRS_TO_SEND_TO_VIEWER[this.sourceComponent_];
-      iterateCursor(attributes, attribute => {
-        if (whiteList.indexOf(attribute.name) != -1) {
+      whiteList.forEach(attribute => {
+        if (element.hasAttribute(attribute)) {
           attrsAsJson[attribute.name] = attribute.value;
         }
       });

--- a/src/ssr-template-helper.js
+++ b/src/ssr-template-helper.js
@@ -69,7 +69,7 @@ export class SsrTemplateHelper {
   /**
    * Proxies xhr and template rendering to the viewer and renders the response.
    * @param {!Element} element
-   * @param {!./service/xhr-impl.FetchData} fetchData
+   * @param {!./service/xhr-impl.FetchData} fetchData The fetch/XHR related data.
    * @param {?SsrTemplateDef=} opt_templates Response templates to pass into
    *     the payload. If provided, finding the template in the passed in
    *     element is not attempted.


### PR DESCRIPTION
Address outstanding items from #15643

- amp-bind support for ssr template in amp-list.
- add "originalRequest" in message/payload to viewer as does the XHR interceptor.
- CORS handling of SSR response.
- add all templates available in amp-form to viewer. Previously I was only sending the first template found.
- choumx@ outstanding comments in previous PR (#15643)

