### PR TITLE
🐛Protect macros better.

### DIFF
--- a/build-system/tasks/bundle-size.js
+++ b/build-system/tasks/bundle-size.js
@@ -22,7 +22,7 @@ const log = require('fancy-log');
 const {getStdout} = require('../exec');
 
 const runtimeFile = './dist/v0.js';
-const maxSize = '79.26KB';
+const maxSize = '79.28KB';
 
 const {green, red, cyan, yellow} = colors;
 

--- a/extensions/amp-analytics/0.1/test/test-requests.js
+++ b/extensions/amp-analytics/0.1/test/test-requests.js
@@ -466,8 +466,9 @@ describes.realWin('Requests', {amp: 1}, env => {
       'param1': 'PARAM_1',
       'param2': 'PARAM_2',
       'param3': 'PARAM_3',
-      'foo': 'TOUPPERCASE(BASE64(foo))',
-    });
+      'foo': '$TOUPPERCASE($BASE64(foo))',
+    }, /* opt_iterations */ 2, /* opt_noencode */ true);
+
     const bindings = {
       'PARAM_1': 'val1',
       'PARAM_2': () => 'val2',

--- a/extensions/amp-analytics/0.1/test/test-variables.js
+++ b/extensions/amp-analytics/0.1/test/test-variables.js
@@ -163,7 +163,7 @@ describe('amp-analytics.VariableService', function() {
     it('default works without first arg', () => check('$DEFAULT(,two)', 'two'));
 
     it('default works without first arg length',
-        () => check('$DEFAULT(TRIM(), two)', 'two'));
+        () => check('$DEFAULT($TRIM(), two)', 'two'));
 
     it('hash works', () => check('$HASH(test)',
         'doQSMg97CqWBL85CjcRwazyuUOAqZMqhangiSb_o78S37xzLEmJV0ZYEff7fF6Cp'));
@@ -194,7 +194,7 @@ describe('amp-analytics.VariableService', function() {
 
     it('chaining works', () => {
       return check('$SUBSTR(Hello world!, 6)', 'world!').then(() =>
-        check('$TOUPPERCASE(SUBSTR(Hello world!, 6))', 'WORLD!')).then(() =>
+        check('$TOUPPERCASE($SUBSTR(Hello world!, 6))', 'WORLD!')).then(() =>
         check('$BASE64($TOUPPERCASE($SUBSTR(Hello world!, 6)))', 'V09STEQh'))
           .then(() =>
             check('$HASH($BASE64($TOUPPERCASE($SUBSTR(Hello world!, 6))))',

--- a/extensions/amp-analytics/0.1/test/test-variables.js
+++ b/extensions/amp-analytics/0.1/test/test-variables.js
@@ -158,77 +158,77 @@ describe('amp-analytics.VariableService', function() {
       return expect(expanded).to.eventually.equal(output);
     }
 
-    it('default works', () => check('DEFAULT(one,two)', 'one'));
+    it('default works', () => check('$DEFAULT(one,two)', 'one'));
 
-    it('default works without first arg', () => check('DEFAULT(,two)', 'two'));
+    it('default works without first arg', () => check('$DEFAULT(,two)', 'two'));
 
     it('default works without first arg length',
-        () => check('DEFAULT(TRIM(), two)', 'two'));
+        () => check('$DEFAULT(TRIM(), two)', 'two'));
 
-    it('hash works', () => check('HASH(test)',
+    it('hash works', () => check('$HASH(test)',
         'doQSMg97CqWBL85CjcRwazyuUOAqZMqhangiSb_o78S37xzLEmJV0ZYEff7fF6Cp'));
 
-    it('substr works', () => check('SUBSTR(Hello world!, 1, 4)', 'ello'));
+    it('substr works', () => check('$SUBSTR(Hello world!, 1, 4)', 'ello'));
 
-    it('trim works', () => check('TRIM(hello      )', 'hello'));
+    it('trim works', () => check('$TRIM(hello      )', 'hello'));
 
     it('json works', () =>
-      check('JSON(Hello world!)', '%22Hello%20world!%22'));
+      check('$JSON(Hello world!)', '%22Hello%20world!%22'));
 
     it('toLowerCase works', () =>
-      check('TOLOWERCASE(HeLLO WOrld!)', 'hello%20world!'));
+      check('$TOLOWERCASE(HeLLO WOrld!)', 'hello%20world!'));
 
     it('toUpperCase works', () => {
-      return check('TOUPPERCASE(HeLLO WOrld!)', 'HELLO%20WORLD!');
+      return check('$TOUPPERCASE(HeLLO WOrld!)', 'HELLO%20WORLD!');
     });
 
-    it('not works (truth-y value)', () => check('NOT(hello)', 'false'));
+    it('not works (truth-y value)', () => check('$NOT(hello)', 'false'));
 
-    it('not works (false-y value)', () => check('NOT()', 'true'));
+    it('not works (false-y value)', () => check('$NOT()', 'true'));
 
     it('base64 works', () => {
-      return check('BASE64(Hello World!)', 'SGVsbG8gV29ybGQh');
+      return check('$BASE64(Hello World!)', 'SGVsbG8gV29ybGQh');
     });
 
-    it('if works', () => check('IF(hey, truthy, falsey)', 'truthy'));
+    it('if works', () => check('$IF(hey, truthy, falsey)', 'truthy'));
 
     it('chaining works', () => {
-      return check('SUBSTR(Hello world!, 6)', 'world!').then(() =>
-        check('TOUPPERCASE(SUBSTR(Hello world!, 6))', 'WORLD!')).then(() =>
-        check('BASE64(TOUPPERCASE(SUBSTR(Hello world!, 6)))', 'V09STEQh'))
+      return check('$SUBSTR(Hello world!, 6)', 'world!').then(() =>
+        check('$TOUPPERCASE(SUBSTR(Hello world!, 6))', 'WORLD!')).then(() =>
+        check('$BASE64($TOUPPERCASE($SUBSTR(Hello world!, 6)))', 'V09STEQh'))
           .then(() =>
-            check('HASH(BASE64(TOUPPERCASE(SUBSTR(Hello world!, 6))))',
+            check('$HASH($BASE64($TOUPPERCASE($SUBSTR(Hello world!, 6))))',
                 'OPTTt2IGW8-R31MrIF_cRUwLTZ9jLDOXEuhNz_Q' +
                 'S7Uc5ZmODduHWdplzrZ7Jsnqx')
           );
     });
 
     it('replaces common use case', () => {
-      return check('REPLACE(this-is-a-test, `-`)', 'thisisatest');
+      return check('$REPLACE(this-is-a-test, `-`)', 'thisisatest');
     });
 
     it('replaces three args', () => {
-      return check('REPLACE(this-is-a-test, `-`, *)', 'this*is*a*test');
+      return check('$REPLACE(this-is-a-test, `-`, *)', 'this*is*a*test');
     });
 
     it('replaces backticks optional', () => {
-      return check('REPLACE(this-is-a-test, -, **)', 'this**is**a**test');
+      return check('$REPLACE(this-is-a-test, -, **)', 'this**is**a**test');
     });
 
     it('replaces not trimming spaces in backticks', () => {
-      return check('REPLACE(this-is-a-test, ` -`)', 'this-is-a-test');
+      return check('$REPLACE(this-is-a-test, ` -`)', 'this-is-a-test');
     });
 
     it('replaces respecting space as arg', () => {
-      return check('REPLACE(this-is-a-test, `-`, ` `)', 'this%20is%20a%20test');
+      return check('$REPLACE(this-is-a-test, `-`, ` `)', 'this%20is%20a%20test');
     });
 
     it('replaces respecting backticks', () => {
-      return check('REPLACE(`this-,is-,a-,test`, `-,`)', 'thisisatest');
+      return check('$REPLACE(`this-,is-,a-,test`, `-,`)', 'thisisatest');
     });
 
     it('replace with no third arg', () => {
-      return check('REPLACE(thi@s-is-a-te@st, `-|@`)', 'thisisatest');
+      return check('$REPLACE(thi@s-is-a-te@st, `-|@`)', 'thisisatest');
     });
   });
 

--- a/extensions/amp-analytics/0.1/test/test-variables.js
+++ b/extensions/amp-analytics/0.1/test/test-variables.js
@@ -220,7 +220,8 @@ describe('amp-analytics.VariableService', function() {
     });
 
     it('replaces respecting space as arg', () => {
-      return check('$REPLACE(this-is-a-test, `-`, ` `)', 'this%20is%20a%20test');
+      return check('$REPLACE(this-is-a-test, `-`, ` `)',
+          'this%20is%20a%20test');
     });
 
     it('replaces respecting backticks', () => {

--- a/extensions/amp-analytics/0.1/variables.js
+++ b/extensions/amp-analytics/0.1/variables.js
@@ -131,18 +131,18 @@ export class VariableService {
     /** @private {!Object<string, *>} */
     this.macros_ = {};
 
-    this.register_('DEFAULT', defaultMacro);
-    this.register_('SUBSTR', substrMacro);
-    this.register_('TRIM', value => value.trim());
-    this.register_('JSON', value => JSON.stringify(value));
-    this.register_('TOLOWERCASE', value => value.toLowerCase());
-    this.register_('TOUPPERCASE', value => value.toUpperCase());
-    this.register_('NOT', value => String(!value));
-    this.register_('BASE64', value => btoa(value));
-    this.register_('HASH', this.hashMacro_.bind(this));
-    this.register_('IF',
+    this.register_('$DEFAULT', defaultMacro);
+    this.register_('$SUBSTR', substrMacro);
+    this.register_('$TRIM', value => value.trim());
+    this.register_('$JSON', value => JSON.stringify(value));
+    this.register_('$TOLOWERCASE', value => value.toLowerCase());
+    this.register_('$TOUPPERCASE', value => value.toUpperCase());
+    this.register_('$NOT', value => String(!value));
+    this.register_('$BASE64', value => btoa(value));
+    this.register_('$HASH', this.hashMacro_.bind(this));
+    this.register_('$IF',
         (value, thenValue, elseValue) => value ? thenValue : elseValue);
-    this.register_('REPLACE', replaceMacro);
+    this.register_('$REPLACE', replaceMacro);
   }
 
   /**

--- a/src/service/variable-source.js
+++ b/src/service/variable-source.js
@@ -265,7 +265,16 @@ export class VariableSource {
     // The keys must be sorted to ensure that the longest keys are considered
     // first. This avoids a problem where a RANDOM conflicts with RANDOM_ONE.
     keys.sort((s1, s2) => s2.length - s1.length);
-    const all = keys.join('|');
+    // Keys that start with a `$` need to be escaped so that they do not
+    // interfere with the regex that is constructed.
+    const escaped = keys.map(key => {
+      if (key[0] === '$') {
+        return '\\' + key;
+      }
+      return key;
+    });
+
+    const all = escaped.join('|');
     // Match the given replacement patterns, as well as optionally
     // arguments to the replacement behind it in parentheses.
     // Example string that match


### PR DESCRIPTION
With the introduction of the new URL macros there was a regression when certain users were using `base64` strings. In this long string of random characters it is very likely that there will be a collision with names like`IF`.

We now prefix all of our new macros with the character that cannot be generated from `base64` encoding.

Closes #16917