### PR TITLE
Better style protection for the story cta layer.

### DIFF
--- a/extensions/amp-story/0.1/amp-story.css
+++ b/extensions/amp-story/0.1/amp-story.css
@@ -213,24 +213,26 @@ amp-story amp-video::after {
   left: 0 !important;
 }
 
-amp-story-cta-layer, amp-story-grid-layer {
-  bottom: 0 !important;
-  left: 0 !important;
-  right: 0 !important;
-  position: absolute !important;
-}
-
-/** Call to action layer */
+/** Call to action layer, positioned at the bottom 20% of the screen. */
 amp-story-cta-layer {
   display: block !important;
-  height: 20% !important;
+  position: absolute !important;
+  top: 80% !important;
+  right: 0 !important;
+  bottom: 0 !important;
+  left: 0 !important;
+  margin: 0 !important;
   z-index: 3 !important;
 }
 
 /** Grid level */
 amp-story-grid-layer {
   display: grid !important;
+  position: absolute !important;
   top: 0 !important;
+  right: 0 !important;
+  bottom: 0 !important;
+  left: 0 !important;
   z-index: 2 !important;
 }
 

--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -257,24 +257,26 @@ amp-story amp-video::after {
   left: 0 !important;
 }
 
-amp-story-cta-layer, amp-story-grid-layer {
-  bottom: 0 !important;
-  left: 0 !important;
-  right: 0 !important;
-  position: absolute !important;
-}
-
-/** Call to action layer */
+/** Call to action layer, positioned at the bottom 20% of the screen. */
 amp-story-cta-layer {
   display: block !important;
-  height: 20% !important;
+  position: absolute !important;
+  top: 80% !important;
+  right: 0 !important;
+  bottom: 0 !important;
+  left: 0 !important;
+  margin: 0 !important;
   z-index: 3 !important;
 }
 
 /** Grid level */
 amp-story-grid-layer {
   display: grid !important;
+  position: absolute !important;
   top: 0 !important;
+  right: 0 !important;
+  bottom: 0 !important;
+  left: 0 !important;
   z-index: 2 !important;
 }
 


### PR DESCRIPTION
Goal is to limit links in the `amp-story-cta-layer` to the bottom 20% of the screen.
However, this rule is easy to override by using CSS rules like `min-height`, `padding`, or `margin`.

This PR tries to solve most cases:

- Forbids `margin`: publishers won't need margins since the area can't be moved around. Also, it would make it to easy for a publisher to move the `cta-layer` by applying a negative `margin-top`.
- Changes the `height: 20%` with a `top: 80%; bottom: 0;`. This way, `height` or `min-height` overrides don't matter anymore
- Allows `padding`: can be useful to set a horizontal border for their content. Vertical padding won't make the element taller with the new absolute positioning
- Does not break the existing publisher implementations: [before](https://user-images.githubusercontent.com/1492044/43108144-5f3bcee2-8eae-11e8-80b8-de0576924eb0.png) / [after](https://user-images.githubusercontent.com/1492044/43108167-76bfa7fa-8eae-11e8-8d9a-28de202de792.png)

Fixes #17030