### PR TITLE
Add <amp-orientation-observer> panorama demo

### DIFF
--- a/examples/amp-orientation-observer-panorama.amp.html
+++ b/examples/amp-orientation-observer-panorama.amp.html
@@ -1,0 +1,58 @@
+<html ⚡>
+
+<head>
+  <meta charset="utf-8">
+  <title>amp-orientation-observer</title>
+  <link rel="canonical" href="amps.html">
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <script async custom-element="amp-animation" src="https://cdn.ampproject.org/v0/amp-animation-0.1.js"></script>
+  <script async custom-element="amp-orientation-observer" src="https://cdn.ampproject.org/v0/amp-orientation-observer-0.1.js"></script>
+  <style amp-custom>
+    .panorama {
+        height: 100vh;
+        width: 100vw;
+        overflow-x: hidden;
+        overflow-y: hidden;
+    }
+    .panorama amp-img {
+            transform: translate(-50%, -50%);
+    }
+  </style>
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+
+<body>
+    <amp-animation id="gammaAnim" layout="nodisplay">
+        <script type="application/json">
+            {
+            "duration": "3s",
+            "fill": "both",
+            "direction": "alternate",
+            "animations": [
+            {
+                "selector": ".panorama amp-img",
+                "keyframes": [
+                { "transform": "translateX(-100%)" },
+                { "transform": "translateX(0%)" }
+                ]
+            }
+            ]
+        }
+        </script>
+    </amp-animation>
+    <amp-orientation-observer
+        gamma-range="-90 90"
+        on="gamma:gammaAnim.seekTo(percent=event.percent)" 
+        layout="nodisplay">
+  </amp-orientation-observer>
+    <div class="panorama">
+        <amp-img alt="A view of the mountains"
+            src="img/panorama1.jpg"
+            width="2920"
+            height="728"
+            layout="fixed">
+        </amp-img>
+    </div>
+</body>
+</html>

--- a/extensions/amp-orientation-observer/0.1/amp-orientation-observer.js
+++ b/extensions/amp-orientation-observer/0.1/amp-orientation-observer.js
@@ -127,7 +127,7 @@ export class AmpOrientationObserver extends AMP.BaseElement {
    * @private
    */
   triggerEvent_(eventName, eventValue, eventRange) {
-    eventValue = eventValue.toFixed(2);
+    eventValue = eventValue.toFixed();
     const percentValue = eventRange[0] < 0 ?
       (eventValue - eventRange[0]) :
       eventValue;

--- a/extensions/amp-orientation-observer/0.1/amp-orientation-observer.js
+++ b/extensions/amp-orientation-observer/0.1/amp-orientation-observer.js
@@ -127,12 +127,11 @@ export class AmpOrientationObserver extends AMP.BaseElement {
    * @private
    */
   triggerEvent_(eventName, eventValue, eventRange) {
-    eventValue = eventValue.toFixed();
     const percentValue = eventRange[0] < 0 ?
-      (eventValue - eventRange[0]) :
-      eventValue;
+      (eventValue.toFixed() - eventRange[0]) :
+      eventValue.toFixed();
     const event = createCustomEvent(this.win, `${TAG}.${eventName}`, dict({
-      'angle': eventValue,
+      'angle': eventValue.toFixed(),
       'percent': percentValue /
         (eventRange[1] - eventRange[0]),
     }));

--- a/extensions/amp-orientation-observer/0.1/amp-orientation-observer.js
+++ b/extensions/amp-orientation-observer/0.1/amp-orientation-observer.js
@@ -127,6 +127,7 @@ export class AmpOrientationObserver extends AMP.BaseElement {
    * @private
    */
   triggerEvent_(eventName, eventValue, eventRange) {
+    eventValue = eventValue.toFixed(2);
     const percentValue = eventRange[0] < 0 ?
       (eventValue - eventRange[0]) :
       eventValue;


### PR DESCRIPTION
Also reduces the granularity at which we track changes in device orientation from 4 decimal places to units only.

This is done to allow the demos to be smoother. 

Issue: #14740 