### PR TITLE
Don't call preloadPagesByDistance twice on story load.

### DIFF
--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -686,7 +686,6 @@ export class AmpStory extends AMP.BaseElement {
         })
         .then(() => this.switchTo_(initialPageId))
         .then(() => this.updateViewportSizeStyles_())
-        .then(() => this.preloadPagesByDistance_())
         .then(() => {
           // Preloads and prerenders the share menu if mobile, where the share
           // button is visible.


### PR DESCRIPTION
The `preloadPagesByDistance` method does not need to be called a second time from `layoutCallback`, since it is already done by the `switchTo` method.