### PR TITLE
Restore deprecated_allow_duplicates in amp-mustache

### DIFF
--- a/extensions/amp-mustache/0.1/test/validator-amp-mustache-version.out
+++ b/extensions/amp-mustache/0.1/test/validator-amp-mustache-version.out
@@ -1,4 +1,4 @@
-FAIL
+PASS
 |  <!--
 |    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
 |
@@ -31,7 +31,7 @@ FAIL
 amp-mustache/0.1/test/validator-amp-mustache-version.html:28:2 The extension 'amp-mustache' is referenced at version '0.1' which is a deprecated version. Please use a more recent version of this extension. This may become an error in the future. (see https://www.ampproject.org/docs/reference/components/amp-mustache) [DEPRECATION]
 |    <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-latest.js"></script>
 >>   ^~~~~~~~~
-amp-mustache/0.1/test/validator-amp-mustache-version.html:29:2 The tag 'amp-mustache extension .js script' appears more than once in the document. (see https://www.ampproject.org/docs/reference/components/amp-mustache) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
+amp-mustache/0.1/test/validator-amp-mustache-version.html:29:2 The tag 'amp-mustache extension .js script' appears more than once in the document. This will soon be an error. (see https://www.ampproject.org/docs/reference/components/amp-mustache) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
 |  </head>
 |  <body>
 |  </body>

--- a/extensions/amp-mustache/0.2/test/validator-amp-mustache-version.out
+++ b/extensions/amp-mustache/0.2/test/validator-amp-mustache-version.out
@@ -1,4 +1,4 @@
-FAIL
+PASS
 |  <!--
 |    Copyright 2015 The AMP HTML Authors. All Rights Reserved.
 |
@@ -29,7 +29,7 @@ FAIL
 |    <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.2.js"></script>
 |    <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-latest.js"></script>
 >>   ^~~~~~~~~
-amp-mustache/0.2/test/validator-amp-mustache-version.html:29:2 The tag 'amp-mustache extension .js script' appears more than once in the document. (see https://www.ampproject.org/docs/reference/components/amp-mustache) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
+amp-mustache/0.2/test/validator-amp-mustache-version.html:29:2 The tag 'amp-mustache extension .js script' appears more than once in the document. This will soon be an error. (see https://www.ampproject.org/docs/reference/components/amp-mustache) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
 |  </head>
 |  <body>
 |  </body>

--- a/extensions/amp-mustache/validator-amp-mustache.protoascii
+++ b/extensions/amp-mustache/validator-amp-mustache.protoascii
@@ -30,6 +30,7 @@ tags: {  # amp-mustache
     version: "latest"
     deprecated_version: "0.1"
     requires_usage: GRANDFATHERED
+    deprecated_allow_duplicates: true
   }
   attr_lists: "common-extension-attrs"
 }


### PR DESCRIPTION
Accidentally removed during master merge in #16201.

/to @honeybadgerdontcare 