### PR TITLE
Removes story navigation flashes.

### DIFF
--- a/extensions/amp-story/0.1/amp-story.css
+++ b/extensions/amp-story/0.1/amp-story.css
@@ -137,6 +137,7 @@ amp-story-page {
   position: absolute !important;
   right: 0 !important;
   top: 0 !important;
+  opacity: 1 !important;
   transition: none !important;
   z-index: 0 !important;
 }
@@ -161,23 +162,15 @@ amp-story:not([desktop]) >
 
 amp-story-page[active],
 amp-story:not([desktop]) >
-    amp-story-page.i-amphtml-layout-container[distance="0"] {
+    amp-story-page.i-amphtml-layout-container[distance="0"],
+amp-story:not([desktop]) >
+    amp-story-page.i-amphtml-layout-container[distance="1"] {
   transform: translateY(0) !important;
 }
 
 amp-story:not([desktop]) >
-    amp-story-page.i-amphtml-layout-container[distance="1"] {
-  transform: translateY(100%) !important;
-}
-
-amp-story:not([desktop]) >
     amp-story-page.i-amphtml-layout-container[distance="2"] {
-  transform: translateY(200%) !important;
-}
-
-amp-story:not([desktop]) >
-    amp-story-page.i-amphtml-layout-container[distance="3"] {
-  transform: translateY(300%) !important;
+  transform: translateY(100%) !important;
 }
 
 .i-amphtml-story-bookend-active:not([desktop]) >

--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -164,6 +164,7 @@ amp-story-page {
   position: absolute !important;
   right: 0 !important;
   top: 0 !important;
+  opacity: 1 !important;
   transition: none !important;
   z-index: 0 !important;
 }
@@ -178,8 +179,8 @@ amp-story-page[active] {
 
 /* Setting `translateY` distances as a trick so that the runtime schedules
  * layout for the next N pages. The default value (1000%) means that pages are
- * not be automatically laid out. Max distance is set to 3 since we don't want
- * to schedule any further pages. */
+ * not be automatically laid out. Max distance is set to 2 (next 2 pages) since
+ * we don't want to schedule any further pages. */
 
 amp-story:not([desktop]) >
     amp-story-page.i-amphtml-layout-container:not([active]) {
@@ -188,25 +189,15 @@ amp-story:not([desktop]) >
 
 amp-story-page[active],
 amp-story:not([desktop]) >
-    amp-story-page[active].i-amphtml-layout-container[distance],
+    amp-story-page.i-amphtml-layout-container[distance="0"],
 amp-story:not([desktop]) >
-    amp-story-page.i-amphtml-layout-container[distance="0"] {
+    amp-story-page.i-amphtml-layout-container[distance="1"] {
   transform: translateY(0) !important;
 }
 
 amp-story:not([desktop]) >
-    amp-story-page.i-amphtml-layout-container[distance="1"] {
-  transform: translateY(100%) !important;
-}
-
-amp-story:not([desktop]) >
     amp-story-page.i-amphtml-layout-container[distance="2"] {
-  transform: translateY(200%) !important;
-}
-
-amp-story:not([desktop]) >
-    amp-story-page.i-amphtml-layout-container[distance="3"] {
-  transform: translateY(300%) !important;
+  transform: translateY(100%) !important;
 }
 
 amp-story:not([desktop]) >


### PR DESCRIPTION
- Removes background flashes when navigating between two pages that have images
- Removes CSS for the `[distance=3]` attribute, that was not preloaded by the runtime, so we don't really need to change its position
