### PR TITLE
Launch amp-story-navigation-performance in canary.

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -19,6 +19,7 @@
   "amp-apester-media": 1,
   "amp-ima-video": 1,
   "amp-playbuzz": 1,
+  "amp-story-navigation-performance": 1,
   "chunked-amp": 1,
   "pump-early-frame": 1,
   "amp-auto-ads": 1,

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -19,6 +19,7 @@
   "amp-apester-media": 1,
   "amp-ima-video": 1,
   "amp-playbuzz": 1,
+  "amp-story-navigation-performance": 0,
   "chunked-amp": 1,
   "amp-auto-ads": 1,
   "amp-auto-ads-adsense-holdout": 0.1,


### PR DESCRIPTION
Launches the `amp-story-navigation-performance` experiment (#16949) in canary.

Master feature #17017