### PR TITLE
🏗 Insert a line break before the code wrappers.

### DIFF
--- a/build-system/compile-wrappers.js
+++ b/build-system/compile-wrappers.js
@@ -19,7 +19,7 @@ const {VERSION} = require('./internal-version');
 // If there is a sync JS error during initial load,
 // at least try to unhide the body.
 exports.mainBinary = 'var global=self;self.AMP=self.AMP||[];' +
-    'try{(function(_){<%= contents %>})(AMP._={})}catch(e){' +
+    'try{(function(_){\n<%= contents %>})(AMP._={})}catch(e){' +
     'setTimeout(function(){' +
     'var s=document.body.style;' +
     's.opacity=1;' +
@@ -49,7 +49,7 @@ exports.extension = function(name, loadPriority, intermediateDeps) {
     priority = 'p:"high",';
   }
   return `(self.AMP=self.AMP||[]).push({n:"${name}",${priority}${deps}` +
-      `v:"${VERSION}",f:(function(AMP,_){<%= contents %>\n})});`;
+      `v:"${VERSION}",f:(function(AMP,_){\n<%= contents %>\n})});`;
 };
 
 exports.none = '<%= contents %>';


### PR DESCRIPTION
This will make adding stuff to the first line in postprocessing invariant to sourcemaps.

Part of #17061