### PR TITLE
Fix width / height typo on <amp-pan-zoom>

### DIFF
--- a/extensions/amp-pan-zoom/0.1/amp-pan-zoom.js
+++ b/extensions/amp-pan-zoom/0.1/amp-pan-zoom.js
@@ -377,9 +377,7 @@ export class AmpPanZoom extends AMP.BaseElement {
         last,
       } = e.data;
 
-      const centerX = this.getOffsetX_(centerClientX);
-      const centerY = this.getOffsetY_(centerClientY);
-      this.onPinchZoom_(centerX, centerY, deltaX, deltaY, dir);
+      this.onPinchZoom_(centerClientX, centerClientY, deltaX, deltaY, dir);
       if (last) {
         this.onZoomRelease_();
       }


### PR DESCRIPTION
Fix a typo bug where we try to associate height with width instead. 