### PR TITLE
✨ Add a default placeholder for <amp-twitter>

### DIFF
--- a/bundles.config.js
+++ b/bundles.config.js
@@ -311,7 +311,12 @@ exports.extensionBundles = [
     type: TYPES.MISC,
   },
   {name: 'amp-timeago', version: '0.1', type: TYPES.MISC},
-  {name: 'amp-twitter', version: '0.1', type: TYPES.MISC},
+  {
+    name: 'amp-twitter',
+    version: '0.1',
+    options: {hasCss: true},
+    type: TYPES.MISC,
+  },
   {
     name: 'amp-user-notification',
     version: '0.1',

--- a/extensions/amp-twitter/0.1/amp-twitter.css
+++ b/extensions/amp-twitter/0.1/amp-twitter.css
@@ -68,24 +68,24 @@ amp-twitter {
   opacity: 0;
 }
 
-amp-twitter[loading="start"] .i-amphtml-twitter-placeholder-svg {
+amp-twitter[i-amphtml-loading="start"] .i-amphtml-twitter-placeholder-svg {
   transition-duration: 250ms;
   transform: scale(1);
   opacity: 1;
 }
 
-amp-twitter[loading="done"] .i-amphtml-twitter-placeholder {
+amp-twitter[i-amphtml-loading="done"] .i-amphtml-twitter-placeholder {
   border: none;
 }
 
-amp-twitter[loading="done"] .i-amphtml-twitter-placeholder-svg  {
+amp-twitter[i-amphtml-loading="done"] .i-amphtml-twitter-placeholder-svg  {
   transition-duration: 250ms;
   transition-timing-function: ease-out;
   transform: scale(12);
   opacity: 0;
 }
 
-amp-twitter[loading="done"]  .i-amphtml-twitter-iframe {
+amp-twitter[i-amphtml-loading="done"]  .i-amphtml-twitter-iframe {
   opacity: 1;
 }
 

--- a/extensions/amp-twitter/0.1/amp-twitter.css
+++ b/extensions/amp-twitter/0.1/amp-twitter.css
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 amp-twitter {
   transition-property: height;
   transition-duration: 250ms;
@@ -45,7 +61,7 @@ amp-twitter {
   opacity: 0.6;
 }
 
-.i-amp-html-twitter-iframe {
+.i-amphtml-twitter-iframe {
   transition-property: opacity;
   transition-duration: 200ms;
   transition-timing-function: ease-in;
@@ -69,7 +85,7 @@ amp-twitter[loading="done"] .i-amphtml-twitter-placeholder-svg  {
   opacity: 0;
 }
 
-amp-twitter[loading="done"]  .i-amp-html-twitter-iframe {
+amp-twitter[loading="done"]  .i-amphtml-twitter-iframe {
   opacity: 1;
 }
 

--- a/extensions/amp-twitter/0.1/amp-twitter.css
+++ b/extensions/amp-twitter/0.1/amp-twitter.css
@@ -1,0 +1,85 @@
+amp-twitter {
+  transition-property: height;
+  transition-duration: 250ms;
+}
+
+/**
+ * [placeholder] is need for specificity over the base placeholder rules
+ */
+.i-amphtml-twitter-placeholder[placeholder] {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  max-width: 500px;
+  min-width: 220px;
+  margin: auto;
+  border-radius: 5px;
+  border: 1px solid #e1e8ed;
+  overflow: hidden;
+  pointer-events: none;
+}
+
+/**
+ * Need a separate element for this so that we can have the pulse animation
+ * as well as the start/end transitions.
+ */
+.i-amphtml-twitter-placeholder-logo {
+  width: 100%;
+  height: 100%;
+  max-width: 200px;
+  max-height: 200px;
+  animation: amp-twitter-pulse 750ms infinite alternate-reverse ease-in-out;
+}
+
+.i-amphtml-twitter-placeholder-svg {
+  width: 100%;
+  height: 100%;
+  transition-property: transform, opacity;
+  transition-duration: 100ms;
+  transition-timing-function: ease-in;
+  /*
+   * The initial state. Rather than start straight from the fullsize pulsing
+   * state, we start off a bit smaller so there is some sense of progress.
+   */
+  transform: scale(0.4);
+  opacity: 0.6;
+}
+
+.i-amp-html-twitter-iframe {
+  transition-property: opacity;
+  transition-duration: 200ms;
+  transition-timing-function: ease-in;
+  opacity: 0;
+}
+
+amp-twitter[loading="start"] .i-amphtml-twitter-placeholder-svg {
+  transition-duration: 250ms;
+  transform: scale(1);
+  opacity: 1;
+}
+
+amp-twitter[loading="done"] .i-amphtml-twitter-placeholder {
+  border: none;
+}
+
+amp-twitter[loading="done"] .i-amphtml-twitter-placeholder-svg  {
+  transition-duration: 250ms;
+  transition-timing-function: ease-out;
+  transform: scale(12);
+  opacity: 0;
+}
+
+amp-twitter[loading="done"]  .i-amp-html-twitter-iframe {
+  opacity: 1;
+}
+
+@keyframes amp-twitter-pulse {
+  0% {
+    transform: scale(0.85);
+    opacity: 0.9;
+  }
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+}

--- a/extensions/amp-twitter/0.1/amp-twitter.js
+++ b/extensions/amp-twitter/0.1/amp-twitter.js
@@ -114,7 +114,7 @@ class AmpTwitter extends AMP.BaseElement {
   updateForLoadingState_() {
     this.element.setAttribute('loading', 'start');
     // Set an explicit height so we can animate it.
-    this./*OK*/changeHeight(this.element.getBoundingClientRect().height);
+    this./*OK*/changeHeight(this.element./*REVIEW*/getBoundingClientRect().height);
   }
 
   /**

--- a/extensions/amp-twitter/0.1/amp-twitter.js
+++ b/extensions/amp-twitter/0.1/amp-twitter.js
@@ -15,7 +15,11 @@
  */
 
 
+import {CSS} from '../../../build/amp-twitter-0.1.css';
+import {MessageType} from '../../../src/3p-frame-messaging';
 import {getIframe, preloadBootstrap} from '../../../src/3p-frame';
+import {htmlFor} from '../../../src/static-template';
+import {isExperimentOn} from '../../../src/experiments';
 import {isLayoutSizeDefined} from '../../../src/layout';
 import {listenFor} from '../../../src/iframe-helper';
 import {removeElement} from '../../../src/dom';
@@ -29,6 +33,33 @@ class AmpTwitter extends AMP.BaseElement {
 
     /** @private {?HTMLIFrameElement} */
     this.iframe_ = null;
+
+    /** @param {?Element} */
+    this.userPlaceholder_ = null;
+  }
+
+  /**
+   * @override
+   */
+  buildCallback() {
+    this.userPlaceholder_ = this.getPlaceholder();
+  }
+
+  /**
+   * @override
+   */
+  createPlaceholderCallback() {
+    if (!isExperimentOn(this.win, 'twitter-default-placeholder')) {
+      return;
+    }
+
+    // Svg from https://about.twitter.com/en_us/company/brand-resources.html
+    return htmlFor(this.element)`
+        <div class="i-amphtml-twitter-placeholder" placeholder>
+          <div class="i-amphtml-twitter-placeholder-logo">
+            <svg class="i-amphtml-twitter-placeholder-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400"><defs><style>.cls-1{fill:none;}.cls-2{fill:#1da1f2;}</style></defs><rect class="cls-1" width="400" height="400"></rect><path class="cls-2" d="M153.62,301.59c94.34,0,145.94-78.16,145.94-145.94,0-2.22,0-4.43-.15-6.63A104.36,104.36,0,0,0,325,122.47a102.38,102.38,0,0,1-29.46,8.07,51.47,51.47,0,0,0,22.55-28.37,102.79,102.79,0,0,1-32.57,12.45,51.34,51.34,0,0,0-87.41,46.78A145.62,145.62,0,0,1,92.4,107.81a51.33,51.33,0,0,0,15.88,68.47A50.91,50.91,0,0,1,85,169.86c0,.21,0,.43,0,.65a51.31,51.31,0,0,0,41.15,50.28,51.21,51.21,0,0,1-23.16.88,51.35,51.35,0,0,0,47.92,35.62,102.92,102.92,0,0,1-63.7,22A104.41,104.41,0,0,1,75,278.55a145.21,145.21,0,0,0,78.62,23"></path></svg>
+          </div>
+        </div>`;
   }
 
   /**
@@ -62,32 +93,65 @@ class AmpTwitter extends AMP.BaseElement {
     const iframe = getIframe(this.win, this.element, 'twitter', null,
         {allowFullscreen: true});
     this.applyFillContent(iframe);
-    listenFor(iframe, 'embed-size', data => {
-      // We only get the message if and when there is a tweet to display,
-      // so hide the placeholder
-      this.togglePlaceholder(false);
-      this./*OK*/changeHeight(data['height']);
+    iframe.classList.add('i-amp-html-twitter-iframe');
+
+    this.updateForLoadingState_();
+    listenFor(iframe, MessageType.EMBED_SIZE, data => {
+      this.updateForSuccessState_(data['height']);
     }, /* opt_is3P */true);
-    listenFor(iframe, 'no-content', () => {
-      const fallback = this.getFallback();
-      if (fallback) {
-        // If there is no content, but a fallback is provided.
-        this.togglePlaceholder(false);
-        this.toggleFallback(true);
-        this./*OK*/changeHeight(fallback./*OK*/offsetHeight);
-      } else {
-        // Else keep placeholder displayed since there's no fallback.
-        const placeholder = this.getPlaceholder();
-        if (placeholder) {
-          // Only happens if there is no content to render
-          // (e.g. tweet was deleted) and there is no fallback.
-          this./*OK*/changeHeight(placeholder./*OK*/offsetHeight);
-        }
-      }
+    listenFor(iframe, MessageType.NO_CONTENT, () => {
+      this.updateForFailureState_();
     }, /* opt_is3P */true);
     this.element.appendChild(iframe);
     this.iframe_ = iframe;
     return this.loadPromise(iframe);
+  }
+
+  /**
+   * Updates when starting to load a tweet.
+   * @private
+   */
+  updateForLoadingState_() {
+    this.element.setAttribute('loading', 'start');
+    // Set an explicit height so we can animate it.
+    this./*OK*/changeHeight(this.element.getBoundingClientRect().height);
+  }
+
+  /**
+   * Updates when the tweet has successfully rendered.
+   * @param {number} height The height of the rendered tweet.
+   * @private
+   */
+  updateForSuccessState_(height) {
+    if (this.userPlaceholder_) {
+      this.togglePlaceholder(false);
+    }
+
+    this.mutateElement(() => {
+      this.element.setAttribute('loading', 'done');
+      this./*OK*/changeHeight(height);
+    });
+  }
+
+  /**
+   * Updates wheen the tweet that failed to load. This uses the fallback
+   * provided if available. If not, it uses the user specified placeholder.
+   * @private
+   */
+  updateForFailureState_() {
+    const fallback = this.getFallback();
+    const content = fallback || this.userPlaceholder_;
+
+    this.mutateElement(() => {
+      if (fallback) {
+        this.togglePlaceholder(false);
+        this.toggleFallback(true);
+      }
+
+      if (content) {
+        this./*OK*/changeHeight(content./*OK*/offsetHeight);
+      }
+    });
   }
 
   /** @override */
@@ -107,5 +171,7 @@ class AmpTwitter extends AMP.BaseElement {
 
 
 AMP.extension('amp-twitter', '0.1', AMP => {
-  AMP.registerElement('amp-twitter', AmpTwitter);
+  const styles = isExperimentOn(AMP.win, 'twitter-default-placeholder') ? CSS :
+    undefined;
+  AMP.registerElement('amp-twitter', AmpTwitter, styles);
 });

--- a/extensions/amp-twitter/0.1/amp-twitter.js
+++ b/extensions/amp-twitter/0.1/amp-twitter.js
@@ -34,7 +34,7 @@ class AmpTwitter extends AMP.BaseElement {
     /** @private {?HTMLIFrameElement} */
     this.iframe_ = null;
 
-    /** @param {?Element} */
+    /** @private {?Element} */
     this.userPlaceholder_ = null;
   }
 
@@ -93,7 +93,7 @@ class AmpTwitter extends AMP.BaseElement {
     const iframe = getIframe(this.win, this.element, 'twitter', null,
         {allowFullscreen: true});
     this.applyFillContent(iframe);
-    iframe.classList.add('i-amp-html-twitter-iframe');
+    iframe.classList.add('i-amphtml-twitter-iframe');
 
     this.updateForLoadingState_();
     listenFor(iframe, MessageType.EMBED_SIZE, data => {
@@ -112,9 +112,10 @@ class AmpTwitter extends AMP.BaseElement {
    * @private
    */
   updateForLoadingState_() {
-    this.element.setAttribute('loading', 'start');
+    this.element.setAttribute('i-amphtml-loading', 'start');
     // Set an explicit height so we can animate it.
-    this./*OK*/changeHeight(this.element./*REVIEW*/getBoundingClientRect().height);
+    this./*OK*/changeHeight(
+        this.element./*REVIEW*/getBoundingClientRect().height);
   }
 
   /**
@@ -128,7 +129,7 @@ class AmpTwitter extends AMP.BaseElement {
     }
 
     this.mutateElement(() => {
-      this.element.setAttribute('loading', 'done');
+      this.element.setAttribute('i-amphtml-loading', 'done');
       this./*OK*/changeHeight(height);
     });
   }

--- a/test/manual/amp-twitter-resize.amp.html
+++ b/test/manual/amp-twitter-resize.amp.html
@@ -44,7 +44,7 @@
   </p>
   <p>
     Ullamcorper eget nulla facilisi etiam dignissim diam quis enim. Aliquam etiam erat velit scelerisque in dictum. Ornare quam viverra orci sagittis eu volutpat odio facilisis mauris. Dui accumsan sit amet nulla facilisi morbi. Orci a scelerisque purus semper eget duis at. Dui ut ornare lectus sit amet est placerat. Ipsum faucibus vitae aliquet nec ullamcorper sit. Integer eget aliquet nibh praesent tristique magna sit amet. Nec dui nunc mattis enim ut tellus. Interdum consectetur libero id faucibus nisl tincidunt. Fringilla ut morbi tincidunt augue interdum velit euismod. Eros in cursus turpis massa. Phasellus vestibulum lorem sed risus ultricies tristique nulla. Rhoncus mattis rhoncus urna neque viverra justo. Donec massa sapien faucibus et. Suscipit adipiscing bibendum est ultricies integer quis. Eget est lorem ipsum dolor. Mi ipsum faucibus vitae aliquet nec ullamcorper sit amet risus. Tristique nulla aliquet enim tortor. Amet venenatis urna cursus eget nunc scelerisque.
-  </p
+  </p>
   <p>
     Purus in mollis nunc sed id semper risus in hendrerit. Feugiat nisl pretium fusce id velit ut. Nisi vitae suscipit tellus mauris a diam maecenas sed. Pellentesque eu tincidunt tortor aliquam nulla facilisi. Eget egestas purus viverra accumsan in. Tortor consequat id porta nibh venenatis cras sed. Pretium aenean pharetra magna ac placerat vestibulum. Volutpat maecenas volutpat blandit aliquam etiam erat velit scelerisque in. Mauris commodo quis imperdiet massa tincidunt nunc pulvinar sapien. Tempor orci dapibus ultrices in. Urna neque viverra justo nec. Facilisis mauris sit amet massa vitae. Lectus magna fringilla urna porttitor rhoncus dolor.
   </p>

--- a/test/manual/amp-twitter-resize.amp.html
+++ b/test/manual/amp-twitter-resize.amp.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>Twitter examples</title>
+  <link rel="canonical" href="amps.html" >
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
+  <script async custom-element="amp-twitter" src="https://cdn.ampproject.org/v0/amp-twitter-0.1.js"></script>
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <style>
+    body {
+      padding: 0 16px;
+    }
+  </style>
+</head>
+<body>
+
+  <p>
+    Some text above the tweet. Just to give an idea what the tweet will look
+    like when surrounded by content. This also gives a better idea of how
+    placeholder / loading state looks.
+  </p>
+
+  <amp-twitter width=390 height=120
+      layout="responsive"
+      data-tweetid="585110598171631616"
+      data-cards="hidden">
+  </amp-twitter>
+
+  <p>
+    Some text under the tweet. Depending on the viewport size, this will get
+    pushed down when the tweet resizes due to rendering.
+  </p>
+  <p>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Vulputate dignissim suspendisse in est ante in. Cum sociis natoque penatibus et magnis dis. Consequat ac felis donec et. Amet risus nullam eget felis eget nunc. Neque convallis a cras semper auctor. Risus quis varius quam quisque. Etiam sit amet nisl purus in mollis nunc. Non enim praesent elementum facilisis leo vel. Congue nisi vitae suscipit tellus. Sem viverra aliquet eget sit amet tellus cras adipiscing. Pulvinar etiam non quam lacus suspendisse faucibus interdum posuere lorem. Dapibus ultrices in iaculis nunc sed augue lacus viverra vitae. Curabitur vitae nunc sed velit dignissim sodales ut eu sem. Penatibus et magnis dis parturient montes nascetur. Parturient montes nascetur ridiculus mus mauris.
+  </p>
+  <p>
+    Viverra suspendisse potenti nullam ac tortor vitae purus faucibus ornare. Rutrum quisque non tellus orci ac auctor augue mauris augue. Nulla pellentesque dignissim enim sit. Aliquet nec ullamcorper sit amet risus nullam eget felis eget. Praesent tristique magna sit amet purus gravida quis blandit turpis. Tristique risus nec feugiat in fermentum posuere urna. Facilisis volutpat est velit egestas dui id ornare arcu odio. Egestas congue quisque egestas diam in. Arcu odio ut sem nulla pharetra. Lacinia at quis risus sed vulputate odio ut enim blandit. Adipiscing tristique risus nec feugiat in fermentum. Faucibus et molestie ac feugiat sed lectus. Suscipit adipiscing bibendum est ultricies integer quis auctor. Ullamcorper a lacus vestibulum sed. Enim praesent elementum facilisis leo vel fringilla est ullamcorper eget.
+  </p>
+  <p>
+    Vitae sapien pellentesque habitant morbi. Vitae elementum curabitur vitae nunc sed. Sagittis orci a scelerisque purus semper eget duis at. Egestas integer eget aliquet nibh praesent tristique magna. Turpis egestas maecenas pharetra convallis posuere morbi leo urna. Id aliquet risus feugiat in ante metus. In egestas erat imperdiet sed euismod nisi porta lorem mollis. Interdum velit euismod in pellentesque massa placerat duis ultricies. Arcu non odio euismod lacinia at quis. Nunc eget lorem dolor sed viverra ipsum. Tortor dignissim convallis aenean et tortor at risus. Velit euismod in pellentesque massa placerat duis. Vel orci porta non pulvinar neque. Mauris ultrices eros in cursus turpis massa. Pulvinar elementum integer enim neque volutpat. Placerat orci nulla pellentesque dignissim enim. Mollis aliquam ut porttitor leo a diam. Donec massa sapien faucibus et molestie ac.
+  </p>
+  <p>
+    Ullamcorper eget nulla facilisi etiam dignissim diam quis enim. Aliquam etiam erat velit scelerisque in dictum. Ornare quam viverra orci sagittis eu volutpat odio facilisis mauris. Dui accumsan sit amet nulla facilisi morbi. Orci a scelerisque purus semper eget duis at. Dui ut ornare lectus sit amet est placerat. Ipsum faucibus vitae aliquet nec ullamcorper sit. Integer eget aliquet nibh praesent tristique magna sit amet. Nec dui nunc mattis enim ut tellus. Interdum consectetur libero id faucibus nisl tincidunt. Fringilla ut morbi tincidunt augue interdum velit euismod. Eros in cursus turpis massa. Phasellus vestibulum lorem sed risus ultricies tristique nulla. Rhoncus mattis rhoncus urna neque viverra justo. Donec massa sapien faucibus et. Suscipit adipiscing bibendum est ultricies integer quis. Eget est lorem ipsum dolor. Mi ipsum faucibus vitae aliquet nec ullamcorper sit amet risus. Tristique nulla aliquet enim tortor. Amet venenatis urna cursus eget nunc scelerisque.
+  </p
+  <p>
+    Purus in mollis nunc sed id semper risus in hendrerit. Feugiat nisl pretium fusce id velit ut. Nisi vitae suscipit tellus mauris a diam maecenas sed. Pellentesque eu tincidunt tortor aliquam nulla facilisi. Eget egestas purus viverra accumsan in. Tortor consequat id porta nibh venenatis cras sed. Pretium aenean pharetra magna ac placerat vestibulum. Volutpat maecenas volutpat blandit aliquam etiam erat velit scelerisque in. Mauris commodo quis imperdiet massa tincidunt nunc pulvinar sapien. Tempor orci dapibus ultrices in. Urna neque viverra justo nec. Facilisis mauris sit amet massa vitae. Lectus magna fringilla urna porttitor rhoncus dolor.
+  </p>
+
+</body>
+</html>


### PR DESCRIPTION
This adds a placeholder which shows a pulsing Twitter logo if one is not specified behind an experiment flag. If the results look good, the code can be generalized to apply to more extensions than just `<amp-twitter>`.

This looks like: https://drive.google.com/open?id=1R0uqLpxtQXmY_ct12vtyGPob_EsYSENe (video quality isn't great, looks a lot better in person).