### PR TITLE
🐛 Use promise-based service getters for cross-component services

### DIFF
--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -1178,8 +1178,6 @@ export class AmpStory extends AMP.BaseElement {
    * @private
    */
   setHistoryStatePageId_(pageId) {
-    return;
-
     // Never save ad pages to history as they are unique to each visit.
     const page = this.getPageById(pageId);
     if (page.isAd()) {

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -1178,6 +1178,8 @@ export class AmpStory extends AMP.BaseElement {
    * @private
    */
   setHistoryStatePageId_(pageId) {
+    return;
+
     // Never save ad pages to history as they are unique to each visit.
     const page = this.getPageById(pageId);
     if (page.isAd()) {
@@ -1620,8 +1622,8 @@ export class AmpStory extends AMP.BaseElement {
    * @private
    */
   buildAndPreloadBookend_() {
-    this.bookend_.build();
-    return this.bookend_.loadConfigAndMaybeRenderBookend();
+    return this.bookend_.build()
+        .then(() => this.bookend_.loadConfigAndMaybeRenderBookend());
   }
 
 

--- a/src/services.js
+++ b/src/services.js
@@ -330,6 +330,18 @@ export class Services {
   }
 
   /**
+   * Version of the story store service depends on which version of amp-story
+   * the publisher is loading. They all have the same implementation.
+   * @param {!Window} win
+   * @return {?Promise<?../extensions/amp-story/1.0/amp-story-store-service.AmpStoryRequestService|?../extensions/amp-story/0.1/amp-story-store-service.AmpStoryRequestService>}
+   */
+  static storyRequestServiceForOrNull(win) {
+    return (
+    /** @type {!Promise<?../extensions/amp-story/1.0/amp-story-store-service.AmpStoryRequestService|?../extensions/amp-story/0.1/amp-story-store-service.AmpStoryRequestService>} */
+      (getElementServiceIfAvailable(win, 'story-request', 'amp-story')));
+  }
+
+  /**
    * @param {!Window} win
    * @return {!../extensions/amp-story/1.0/amp-story-request-service.AmpStoryRequestService}
    */


### PR DESCRIPTION
The `story-store` and `story-request` services are registered in `AmpStory`, but the execution order for the constructors of other components extending `BaseElement` (e.g. `AmpStoryPage`, `AmpStoryBookend`, `AmpStoryGridLayer`, `AmpStoryCtaLayer`) is undefined.

As such, these other components should use the promised-based getters for the services, as it is unclear whether or not the services will have been registered by the time that these components attempt to consume them.

Fixes #17042 (tested locally)
