### PR TITLE
🐛 Validator: allow div[submitting] in AMP4EMAIL

### DIFF
--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -3835,6 +3835,7 @@ tags {  # <form method=POST ...>
 tags {
   html_format: AMP
   html_format: AMP4ADS
+  html_format: AMP4EMAIL
   html_format: EXPERIMENTAL
   tag_name: "DIV"
   spec_name: "FORM DIV [submitting]"


### PR DESCRIPTION
It seems that, unlike `div[submit-success]` and `div[submit-error]`, `div[submitting]` is currently marked as not supported by AMP4EMAIL.