### PR TITLE
🐛amp-3d-gltf: add attribute clearColor

### DIFF
--- a/3p/3d-gltf/viewer.js
+++ b/3p/3d-gltf/viewer.js
@@ -147,8 +147,12 @@ export default class GltfViewer {
 
     this.renderer_.setPixelRatio(
         Math.min(
-            this.options_['maxPixelRatio'],
+            this.options_['rendererSettings']['maxPixelRatio'],
             devicePixelRatio));
+    this.renderer_.setClearColor(
+        this.options_['rendererSettings']['clearColor'],
+        this.options_['rendererSettings']['clearAlpha']
+    );
   }
 
   /**

--- a/ads/ads.extern.js
+++ b/ads/ads.extern.js
@@ -75,6 +75,7 @@ THREE.WebGLRenderer = class {
     /** @type {?Element} */ this.domElement = null;}};
 THREE.WebGLRenderer.prototype.setSize
 THREE.WebGLRenderer.prototype.setPixelRatio
+THREE.WebGLRenderer.prototype.setClearColor
 THREE.WebGLRenderer.prototype.render
 
 THREE.Light = class extends THREE.Object3D {};

--- a/examples/amp-3d-gltf.amp.html
+++ b/examples/amp-3d-gltf.amp.html
@@ -14,7 +14,7 @@
     amp-3d-gltf [placeholder] {
       background: green;
     }
-    
+
     section amp-3d-gltf {
       max-width: 600px;
       border: 1px solid black;
@@ -29,7 +29,7 @@
   <h2>Layout: fixed</h2>
   <section>
     <amp-3d-gltf layout="fixed"
-                 alpha="true"
+                 clearColor="cyan"
                  antialiasing="true"
                  width="320"
                  height="240"
@@ -39,7 +39,6 @@
   <h2>Layout: responsive</h2>
   <section>
     <amp-3d-gltf layout="responsive"
-                 alpha="true"
                  antialiasing="true"
                  maxPixelRatio="1.5"
                  width="240"

--- a/extensions/amp-3d-gltf/0.1/amp-3d-gltf.js
+++ b/extensions/amp-3d-gltf/0.1/amp-3d-gltf.js
@@ -95,14 +95,21 @@ export class Amp3dGltf extends AMP.BaseElement {
         getOption('src', string, ''),
         this.element);
 
+    const useAlpha = getOption('alpha', bool, false);
+
     this.context_ = dict({
       'src': resolveRelativeUrl(src, this.getAmpDoc().getUrl()),
       'renderer': {
-        'alpha': getOption('alpha', bool, false),
+        'alpha': useAlpha,
         'antialias': getOption('antialiasing', bool, true),
       },
-      'maxPixelRatio':
-          getOption('maxPixelRatio', number, devicePixelRatio || 1),
+      'rendererSettings': {
+        'clearAlpha': useAlpha ? 0 : 1,
+        'clearColor':
+            getOption('clearColor', string, '#fff'),
+        'maxPixelRatio':
+            getOption('maxPixelRatio', number, devicePixelRatio || 1),
+      },
       'controls': {
         'enableZoom': getOption('enableZoom', bool, true),
         'autoRotate': getOption('autoRotate', bool, false),

--- a/extensions/amp-3d-gltf/amp-3d-gltf.md
+++ b/extensions/amp-3d-gltf/amp-3d-gltf.md
@@ -71,6 +71,10 @@ Default value is `false`.
 
 A Boolean attribute that specifies whether to turn on antialiasing. Default value is `false`.
 
+##### clearColor [optional]
+
+A string that must contain valid CSS color, that will be used to fill free space on canvas. 
+
 ##### maxPixelRatio [optional]
 
 A numeric value that specifies the upper limit for the pixelRatio render option. The default is `window.devicePixelRatio`.

--- a/extensions/amp-3d-gltf/validator-amp-3d-gltf.protoascii
+++ b/extensions/amp-3d-gltf/validator-amp-3d-gltf.protoascii
@@ -44,6 +44,9 @@ tags: {  # <amp-3d-gltf>
     value: "true"
   }
   attrs: {
+    name: "clearcolor"
+  }
+  attrs: {
     name: "enablezoom"
     value: "false"
     value: "true"


### PR DESCRIPTION
We reliazed that if you don't specify `alpha=true` you would result in visually black "background" and have no way to change it except setting `alpha=true` and adding background to container.

So we decided to add attribute `clearColor` to allow changing canvas color. Also we set it to white by default.