### PR TITLE
Fixing the desktop state race condition.

### DIFF
--- a/extensions/amp-story/0.1/amp-story.js
+++ b/extensions/amp-story/0.1/amp-story.js
@@ -413,7 +413,7 @@ export class AmpStory extends AMP.BaseElement {
 
     this.storeService_.subscribe(StateProperty.DESKTOP_STATE, isDesktop => {
       this.onDesktopStateUpdate_(isDesktop);
-    });
+    }, true /** callToInitialize */);
 
     this.win.document.addEventListener('keydown', e => {
       this.onKeyDown_(e);

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -530,7 +530,7 @@ export class AmpStory extends AMP.BaseElement {
 
     this.storeService_.subscribe(StateProperty.DESKTOP_STATE, isDesktop => {
       this.onDesktopStateUpdate_(isDesktop);
-    });
+    }, true /** callToInitialize */);
 
     this.storeService_.subscribe(StateProperty.PAUSED_STATE, isPaused => {
       this.onPausedStateUpdate_(isPaused);


### PR DESCRIPTION
Starting from #16811 (v1.0) and soon #17054 (v0.1), `initializeStandaloneStory_` is called sooner than before. This method calls `onResize`, that might change the `DESKTOP_STATE` to `true` before `amp-story` starts listening for this state updates.
When we dispatch the event later in the code execution, `DESKTOP_STATE` is already true, so setting it to true again doesn't trigger the listeners.

Fixes #17093