### PR TITLE
🏗Make codecov.io post a status on PRs instead of a comment

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -7,12 +7,26 @@ comment: off
 coverage:
   status:
     project:
-      default:
+      default: off
+      unit_tests:
+        flags: unit_tests
+        target: auto
+        threshold: 100 # Passing check no matter what the coverage is
+        base: auto
+      integration_tests:
+        flags: integration_tests
         target: auto
         threshold: 100 # Passing check no matter what the coverage is
         base: auto
     patch:
-      default:
+      default: off
+      unit_tests:
+        flags: unit_tests
+        target: 100 # Target 100% coverage for diffs
+        threshold: 100 # Passing check no matter what the coverage is
+        base: auto
+      integration_tests:
+        flags: integration_tests
         target: 100 # Target 100% coverage for diffs
         threshold: 100 # Passing check no matter what the coverage is
         base: auto

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,6 +1,18 @@
-# Settings for code coverage PR comments from https://codecov.io
-comment:
-  layout: "header, diff, flags, footer"
-  behavior: default
-  require_base: no
-  require_head: yes
+# Settings for https://codecov.io integration
+
+# See https://docs.codecov.io/docs/pull-request-comments
+comment: off
+
+# See https://docs.codecov.io/v4.3.0/docs/commit-status
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 100 # Passing check no matter what the coverage is
+        base: auto
+    patch:
+      default:
+        target: 100 # Target 100% coverage for diffs
+        threshold: 100 # Passing check no matter what the coverage is
+        base: auto

--- a/build-system/tasks/runtime-test.js
+++ b/build-system/tasks/runtime-test.js
@@ -570,8 +570,6 @@ function runTests() {
     }
     if (argv.coverage) {
       if (process.env.TRAVIS) {
-        log(green('INFO: ') + 'Uploading code coverage report to ' +
-            cyan('https://codecov.io/gh/ampproject/amphtml') + '...');
         const codecovCmd =
             './node_modules/.bin/codecov --file=test/coverage/lcov.info';
         let flags = '';
@@ -580,6 +578,9 @@ function runTests() {
         } else if (argv.integration) {
           flags = ' --flags=integration_tests';
         }
+        log(green('INFO: ') + 'Uploading code coverage report to ' +
+            cyan('https://codecov.io/gh/ampproject/amphtml') + ' by running ' +
+            cyan(codecovCmd + flags) + '...');
         const output = getStdout(codecovCmd + flags);
         const viewReportPrefix = 'View report at: ';
         const viewReport = output.match(viewReportPrefix + '.*');


### PR DESCRIPTION
PR comments from codecov.io are annoying and produce a lot of noise. 

This PR does the following:

- Instead of comments, posts a status on the PR
- ~~We use a threshold of 1% so that minor changes in coverage do not produce a red X mark~~
- We use a threshold of 100% so that changes in coverage do not produce a red X mark on PRs (for now)
- The codecov status isn't a required check, so a PR can be merged even if the status hasn't yet (or doesn't) appear