### PR TITLE
Set viewer and ssrTemplateHelper when ampdoc is available

### DIFF
--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -90,13 +90,10 @@ export class AmpList extends AMP.BaseElement {
       }
     }, ActionTrust.HIGH);
 
-    /** @private @const {?../../../src/service/viewer-impl.Viewer} */
+    /** @private {?../../../src/service/viewer-impl.Viewer} */
     this.viewer_ = null;
 
-    /**
-     * @const {?../../../src/ssr-template-helper.SsrTemplateHelper}
-     * @private
-     */
+    /** @private {?../../../src/ssr-template-helper.SsrTemplateHelper} */
     this.ssrTemplateHelper_ = null;
   }
 

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -91,7 +91,7 @@ export class AmpList extends AMP.BaseElement {
     }, ActionTrust.HIGH);
 
     /** @private @const {!../../../src/service/viewer-impl.Viewer} */
-    this.viewer_ = Services.viewerForDoc(this.getAmpDoc());
+    this.viewer_ = Services.viewerForDoc(this.element);
 
     /**
      * @const {!../../../src/ssr-template-helper.SsrTemplateHelper}

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -90,15 +90,14 @@ export class AmpList extends AMP.BaseElement {
       }
     }, ActionTrust.HIGH);
 
-    /** @private @const {!../../../src/service/viewer-impl.Viewer} */
-    this.viewer_ = Services.viewerForDoc(this.element);
+    /** @private @const {?../../../src/service/viewer-impl.Viewer} */
+    this.viewer_ = null;
 
     /**
-     * @const {!../../../src/ssr-template-helper.SsrTemplateHelper}
+     * @const {?../../../src/ssr-template-helper.SsrTemplateHelper}
      * @private
      */
-    this.ssrTemplateHelper_ = new SsrTemplateHelper(
-        TAG, this.viewer_, this.templates_);
+    this.ssrTemplateHelper_ = null;
   }
 
   /** @override */
@@ -108,6 +107,11 @@ export class AmpList extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
+    this.viewer_ = Services.viewerForDoc(this.getAmpDoc());
+
+    this.ssrTemplateHelper_ = new SsrTemplateHelper(
+        TAG, this.viewer_, this.templates_);
+
     // Store this in buildCallback() because `this.element` sometimes
     // is missing attributes in the constructor.
     this.initialSrc_ = this.element.getAttribute('src');


### PR DESCRIPTION
Fixes: #17095 

I tried 

`this.viewer_ = Services.viewerForDoc(this.element)`

to fetch the amp doc and service but oddly enough it didn't work, as the element has yet to be connected to the document when fetching the ampdoc. amp-form on the other hand doesn't have this issue, which uses this method. 

