### PR TITLE
✅ Update amp-story extension with hooks for testing

### DIFF
--- a/extensions/amp-story/1.0/amp-story-consent.css
+++ b/extensions/amp-story/1.0/amp-story-consent.css
@@ -190,6 +190,7 @@
   font-size: 13px !important;
   font-weight: bold !important;
   line-height: 40px !important;
+  text-align: center !important;
   text-transform: uppercase !important;
 }
 

--- a/extensions/amp-story/1.0/amp-story-desktop.css
+++ b/extensions/amp-story/1.0/amp-story-desktop.css
@@ -142,6 +142,7 @@ amp-story[standalone][desktop] {
 }
 
 [desktop] > .next-container > .i-amphtml-story-button-move {
+  left: auto !important;
   right: 0 !important;
 }
 

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -234,16 +234,12 @@ export class AmpStoryPage extends AMP.BaseElement {
       case PageState.NOT_ACTIVE:
         this.element.removeAttribute('active');
         this.pauseCallback();
-        dispatch(this.win, this.element, EventType.PAGE_INACTIVE,
-            dict({'pageId': this.element.id}), {bubbles: true});
         this.state_ = state;
         break;
       case PageState.ACTIVE:
         if (this.state_ === PageState.NOT_ACTIVE) {
           this.element.setAttribute('active', '');
           this.resumeCallback();
-          dispatch(this.win, this.element, EventType.PAGE_ACTIVE,
-              dict({'pageId': this.element.id}), {bubbles: true});
         }
 
         if (this.state_ === PageState.PAUSED) {

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -234,12 +234,16 @@ export class AmpStoryPage extends AMP.BaseElement {
       case PageState.NOT_ACTIVE:
         this.element.removeAttribute('active');
         this.pauseCallback();
+        dispatch(this.win, this.element, EventType.PAGE_INACTIVE,
+            dict({'pageId': this.element.id}), {bubbles: true});
         this.state_ = state;
         break;
       case PageState.ACTIVE:
         if (this.state_ === PageState.NOT_ACTIVE) {
           this.element.setAttribute('active', '');
           this.resumeCallback();
+          dispatch(this.win, this.element, EventType.PAGE_ACTIVE,
+              dict({'pageId': this.element.id}), {bubbles: true});
         }
 
         if (this.state_ === PageState.PAUSED) {

--- a/extensions/amp-story/1.0/amp-story-unsupported-browser-layer.css
+++ b/extensions/amp-story/1.0/amp-story-unsupported-browser-layer.css
@@ -33,6 +33,10 @@
   display: none !important;
 }
 
+.i-amphtml-story-unsupported-browser-overlay .i-amphtml-story-overlay-text {
+  color: #fff !important;
+}
+
 .i-amphtml-story-unsupported-browser-overlay {
   display: flex !important;
 }

--- a/extensions/amp-story/1.0/amp-story-viewport-warning-layer.css
+++ b/extensions/amp-story/1.0/amp-story-viewport-warning-layer.css
@@ -33,6 +33,10 @@
   display: none !important;
 }
 
+.i-amphtml-story-no-rotation-overlay .i-amphtml-story-overlay-text {
+  color: #fff !important;
+}
+
 .i-amphtml-story-landscape.i-amphtml-story-no-rotation-overlay {
   display: flex !important;
 }

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -516,6 +516,16 @@ export class AmpStory extends AMP.BaseElement {
       this.performTapNavigation_(direction);
     });
 
+    this.element.addEventListener(EventType.DISPATCH_ACTION, e => {
+      if (!getMode().test) {
+        return;
+      }
+
+      const action = getDetail(e)['action'];
+      const data = getDetail(e)['data'];
+      this.storeService_.dispatch(action, data);
+    });
+
     this.storeService_.subscribe(StateProperty.AD_STATE, isAd => {
       this.onAdStateUpdate_(isAd);
     });

--- a/extensions/amp-story/1.0/events.js
+++ b/extensions/amp-story/1.0/events.js
@@ -55,6 +55,15 @@ export const EventType = {
 
   // Triggered when a page has loaded at least one frame of all of its media.
   PAGE_LOADED: 'ampstory:pageload',
+
+  // Triggered when a page becomes active.
+  PAGE_ACTIVE: 'ampstory:pageactive',
+
+  // Triggered when a page becomes inactive.
+  PAGE_INACTIVE: 'ampstory:pageinactive',
+
+  // Dispatches an action to the amp-story store service. Only works under test.
+  DISPATCH_ACTION: 'ampstory:dispatchaction',
 };
 
 /**

--- a/extensions/amp-story/1.0/events.js
+++ b/extensions/amp-story/1.0/events.js
@@ -56,12 +56,6 @@ export const EventType = {
   // Triggered when a page has loaded at least one frame of all of its media.
   PAGE_LOADED: 'ampstory:pageload',
 
-  // Triggered when a page becomes active.
-  PAGE_ACTIVE: 'ampstory:pageactive',
-
-  // Triggered when a page becomes inactive.
-  PAGE_INACTIVE: 'ampstory:pageinactive',
-
   // Dispatches an action to the amp-story store service. Only works under test.
   DISPATCH_ACTION: 'ampstory:dispatchaction',
 };

--- a/extensions/amp-story/1.0/test/test-amp-story-hint.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-hint.js
@@ -93,10 +93,10 @@ describes.fakeWin('amp-story hint layer', {}, env => {
  * @return {?Element}
  */
 function getHintContainerFromHost(host) {
-  if (!host.lastElementChild || !host.lastElementChild.shadowRoot) {
+  if (!host.lastElementChild) {
     return null;
   }
 
-  return host.lastElementChild.shadowRoot.querySelector(
-      '.i-amphtml-story-hint-container');
+  const hintRoot = host.lastElementChild.shadowRoot || host.lastElementChild;
+  return hintRoot.querySelector('.i-amphtml-story-hint-container');
 }

--- a/extensions/amp-story/1.0/utils.js
+++ b/extensions/amp-story/1.0/utils.js
@@ -16,6 +16,7 @@
 import {Services} from '../../../src/services';
 import {closestBySelector} from '../../../src/dom';
 import {createShadowRoot} from '../../../src/shadow-embed';
+import {getMode} from '../../../src/mode';
 import {user} from '../../../src/log';
 
 /**
@@ -93,18 +94,16 @@ export function ampMediaElementFor(el) {
  * @param  {!Element} container
  * @param  {!Element} element
  * @param  {string} css
- * @return {!ShadowRoot}
  */
 export function createShadowRootWithStyle(container, element, css) {
-  const shadowRoot = createShadowRoot(container);
-
   const style = self.document.createElement('style');
   style./*OK*/textContent = css;
 
-  shadowRoot.appendChild(style);
-  shadowRoot.appendChild(element);
+  const containerToUse = getMode().test ?
+    container : createShadowRoot(container);
 
-  return shadowRoot;
+  containerToUse.appendChild(style);
+  containerToUse.appendChild(element);
 }
 
 


### PR DESCRIPTION
This PR contains changes to the `amp-story` extension necessary to enable visual diff testing in #17110, only in `test` mode.  Namely:

- Allow dispatching an action to the store service by triggering an event on the `<amp-story>` element
- Do not use shadow DOM in `test`
- Update styles that get accidentally overridden when shadow DOM is not used
- Update tests that explicitly expect shadow DOM

Partial for #16460.