### PR TITLE
Remove isTrustedViewer hack to support missing schema

### DIFF
--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -886,12 +886,6 @@ export class Viewer {
    * @private
    */
   isTrustedViewerOrigin_(urlString) {
-    // TEMPORARY HACK due to a misbehaving native app. See b/32626673
-    // In native apps all security bets are off anyway, and in browser
-    // origins never take the form that is matched here.
-    if (this.isWebviewEmbedded_ && /^www\.[.a-z]+$/.test(urlString)) {
-      return TRUSTED_VIEWER_HOSTS.some(th => th.test(urlString));
-    }
     /** @const {!Location} */
     const url = parseUrlDeprecated(urlString);
     if (url.protocol != 'https:') {

--- a/test/functional/test-viewer.js
+++ b/test/functional/test-viewer.js
@@ -1317,17 +1317,6 @@ describe('Viewer', () => {
           test('https://google', false);
           test('https://www.google', false);
         });
-
-    describe('tests for b/32626673', () => {
-      test('www.google.com', true, true);
-      test('www.google.com', false, /* not in webview */ false);
-      test('www.google.de', true, true);
-      test('www.google.co.uk', true, true);
-      test(':www.google.de', false, true);
-      test('news.google.de', false, true);
-      test('www.google.de/', false, true);
-      test('www.acme.com', false, true);
-    });
   });
 
   describe('referrer', () => {

--- a/test/functional/test-viewport.js
+++ b/test/functional/test-viewport.js
@@ -1398,6 +1398,7 @@ describe('createViewport', () => {
       ampDoc = Services.ampdocServiceFor(win).getAmpDoc();
       installViewerServiceForDoc(ampDoc);
       viewer = Services.viewerForDoc(ampDoc);
+      win.getComputedStyle = () => ({});
     });
 
     it('should bind to "natural" when not iframed', () => {
@@ -1471,7 +1472,6 @@ describe('createViewport', () => {
           .callsFake(() => 12);
       toggleExperiment(win, 'ios-embed-sd', true);
       win.parent = {};
-      win.getComputedStyle = () => ({});
       sandbox.stub(viewer, 'isEmbedded').callsFake(() => true);
       installViewportServiceForDoc(ampDoc);
       const viewport = Services.viewportForDoc(ampDoc);
@@ -1485,7 +1485,6 @@ describe('createViewport', () => {
           .callsFake(() => 10);
       toggleExperiment(win, 'ios-embed-sd', true);
       win.parent = {};
-      win.getComputedStyle = () => ({});
       sandbox.stub(viewer, 'isEmbedded').callsFake(() => true);
       installViewportServiceForDoc(ampDoc);
       const viewport = Services.viewportForDoc(ampDoc);


### PR DESCRIPTION
Revert #6001 now that the native client is behaving properly.

Context: `b/32626673`

/to @cramforce 