### PR TITLE
🏗🚀Allow building extensions from an example document

### DIFF
--- a/contributing/DEVELOPING.md
+++ b/contributing/DEVELOPING.md
@@ -35,12 +35,14 @@ The Quick Start Guide's  [One-time setup](getting-started-quick.md#one-time-setu
 | Command                                                                 | Description                                                           |
 | ----------------------------------------------------------------------- | --------------------------------------------------------------------- |
 | **`gulp`**                                                              | Runs "watch" and "serve". Use this for standard local dev.            |
-| `gulp --extensions=<amp-foo,amp-bar>`                                   | Runs "watch" and "serve", after building only the listed extensions.
+| `gulp --extensions=amp-foo,amp-bar`                                     | Runs "watch" and "serve", after building only the listed extensions.
 | `gulp --extensions=minimal_set`                                         | Runs "watch" and "serve", after building the extensions needed to load `article.amp.html`.
+| `gulp --extensions_from=examples/foo.amp.html`                          | Runs "watch" and "serve", after building only extensions from the listed examples.
 | `gulp --noextensions`                                                   | Runs "watch" and "serve" without building any extensions.
 | `gulp dist`                                                             | Builds production binaries.                                           |
-| `gulp dist --extensions=<amp-foo,amp-bar>`                              | Builds production binaries, with only the listed extensions.
+| `gulp dist --extensions=amp-foo,amp-bar`                                | Builds production binaries, with only the listed extensions.
 | `gulp dist --extensions=minimal_set`                                    | Builds production binaries, with only the extensions needed to load `article.amp.html`.
+| `gulp dist --extensions_from=examples/foo.amp.html`                     | Builds production binaries, with only extensions from  the listed examples.
 | `gulp dist --noextensions`                                              | Builds production binaries without building any extensions.
 | `gulp dist --fortesting`                                                | Builds production binaries for local testing. (Allows use cases like ads, tweets, etc. to work with minified sources. Overrides `TESTING_HOST` if specified. Uses the production `AMP_CONFIG` by default.) |
 | `gulp dist --fortesting --config=<config>`                              | Builds production binaries for local testing, with the specified `AMP_CONFIG`. `config` can be `prod` or `canary`. (Defaults to `prod`.) |
@@ -50,15 +52,17 @@ The Quick Start Guide's  [One-time setup](getting-started-quick.md#one-time-setu
 | `gulp lint --files=<files-path-glob>`                                   | Lints just the files provided. Can be used with `--fix`.              |
 | `gulp lint --local-changes`                                             | Lints just the files changed in the local branch. Can be used with `--fix`.   |
 | `gulp build`                                                            | Builds the AMP library.                                               |
-| `gulp build --extensions=<amp-foo,amp-bar>`                             | Builds the AMP library, with only the listed extensions.
+| `gulp build --extensions=amp-foo,amp-bar`                               | Builds the AMP library, with only the listed extensions.
 | `gulp build --extensions=minimal_set`                                   | Builds the AMP library, with only the extensions needed to load `article.amp.html`.
+| `gulp build --extensions_from=examples/foo.amp.html`                    | Builds the AMP library, with only the extensions needed to load the listed examples.
 | `gulp build --noextensions`                                             | Builds the AMP library with no extensions.
 | `gulp check-links --files foo.md,bar.md`                                | Reports dead links in `.md` files.                                                 |
 | `gulp clean`                                                            | Removes build output.                                                 |
 | `gulp css`                                                              | Recompiles css to build directory and builds the embedded css into js files for the AMP library. |
 | `gulp watch`                                                            | Watches for changes in files, re-builds.                               |
-| `gulp watch --extensions=<amp-foo,amp-bar>`                             | Watches for changes in files, re-builds only the listed extensions.
+| `gulp watch --extensions=amp-foo,amp-bar`                               | Watches for changes in files, re-builds only the listed extensions.
 | `gulp watch --extensions=minimal_set`                                   | Watches for changes in files, re-builds only the extensions needed to load `article.amp.html`.
+| `gulp watch --extensions_from=examples/foo.amp.html`                    | Watches for changes in files, re-builds only the extensions needed to load the listed examples.
 | `gulp watch --noextensions`                                             | Watches for changes in files, re-builds with no extensions.
 | `gulp pr-check`                                                         | Runs all the Travis CI checks locally.         |
 | `gulp pr-check --nobuild`                                               | Runs all the Travis CI checks locally, but skips the `gulp build` step.         |

--- a/contributing/DEVELOPING.md
+++ b/contributing/DEVELOPING.md
@@ -32,72 +32,72 @@ For most developers the instructions in the [Getting Started Quick Start Guide](
 
 The Quick Start Guide's  [One-time setup](getting-started-quick.md#one-time-setup) has instructions for installing Node.js, yarn, and Gulp which you'll need before running these commands.
 
-| Command                                                                 | Description                                                           |
-| ----------------------------------------------------------------------- | --------------------------------------------------------------------- |
-| **`gulp`**                                                              | Runs "watch" and "serve". Use this for standard local dev.            |
-| `gulp --extensions=amp-foo,amp-bar`                                     | Runs "watch" and "serve", after building only the listed extensions.
-| `gulp --extensions=minimal_set`                                         | Runs "watch" and "serve", after building the extensions needed to load `article.amp.html`.
-| `gulp --extensions_from=examples/foo.amp.html`                          | Runs "watch" and "serve", after building only extensions from the listed examples.
-| `gulp --noextensions`                                                   | Runs "watch" and "serve" without building any extensions.
-| `gulp dist`                                                             | Builds production binaries.                                           |
-| `gulp dist --extensions=amp-foo,amp-bar`                                | Builds production binaries, with only the listed extensions.
-| `gulp dist --extensions=minimal_set`                                    | Builds production binaries, with only the extensions needed to load `article.amp.html`.
-| `gulp dist --extensions_from=examples/foo.amp.html`                     | Builds production binaries, with only extensions from  the listed examples.
-| `gulp dist --noextensions`                                              | Builds production binaries without building any extensions.
-| `gulp dist --fortesting`                                                | Builds production binaries for local testing. (Allows use cases like ads, tweets, etc. to work with minified sources. Overrides `TESTING_HOST` if specified. Uses the production `AMP_CONFIG` by default.) |
-| `gulp dist --fortesting --config=<config>`                              | Builds production binaries for local testing, with the specified `AMP_CONFIG`. `config` can be `prod` or `canary`. (Defaults to `prod`.) |
-| `gulp lint`                                                             | Validates against the ESLint linter.                              |
-| `gulp lint --watch`                                                     | Watches for changes in files, and validates against the ESLint linter. |
-| `gulp lint --fix`                                                       | Fixes simple lint warnings/errors automatically.                      |
-| `gulp lint --files=<files-path-glob>`                                   | Lints just the files provided. Can be used with `--fix`.              |
-| `gulp lint --local-changes`                                             | Lints just the files changed in the local branch. Can be used with `--fix`.   |
-| `gulp build`                                                            | Builds the AMP library.                                               |
-| `gulp build --extensions=amp-foo,amp-bar`                               | Builds the AMP library, with only the listed extensions.
-| `gulp build --extensions=minimal_set`                                   | Builds the AMP library, with only the extensions needed to load `article.amp.html`.
-| `gulp build --extensions_from=examples/foo.amp.html`                    | Builds the AMP library, with only the extensions needed to load the listed examples.
-| `gulp build --noextensions`                                             | Builds the AMP library with no extensions.
-| `gulp check-links --files foo.md,bar.md`                                | Reports dead links in `.md` files.                                                 |
-| `gulp clean`                                                            | Removes build output.                                                 |
-| `gulp css`                                                              | Recompiles css to build directory and builds the embedded css into js files for the AMP library. |
-| `gulp watch`                                                            | Watches for changes in files, re-builds.                               |
-| `gulp watch --extensions=amp-foo,amp-bar`                               | Watches for changes in files, re-builds only the listed extensions.
-| `gulp watch --extensions=minimal_set`                                   | Watches for changes in files, re-builds only the extensions needed to load `article.amp.html`.
-| `gulp watch --extensions_from=examples/foo.amp.html`                    | Watches for changes in files, re-builds only the extensions needed to load the listed examples.
-| `gulp watch --noextensions`                                             | Watches for changes in files, re-builds with no extensions.
-| `gulp pr-check`                                                         | Runs all the Travis CI checks locally.         |
-| `gulp pr-check --nobuild`                                               | Runs all the Travis CI checks locally, but skips the `gulp build` step.         |
-| `gulp pr-check --files=<test-files-path-glob>`                          | Runs all the Travis CI checks locally, and restricts tests to the files provided.  |
-| `gulp test --unit`                                                      | Runs the unit tests in Chrome (doesn't require the AMP library to be built).                                                 |
-| `gulp test --unit --files=<test-files-path-glob>`                       | Runs the unit tests from the specified files in Chrome.                                                 |
-| `gulp test --local-changes`                                             | Runs the unit tests directly affected by the files changed in the local branch in Chrome.   |
-| `gulp test --integration`                                               | Runs the integration tests in Chrome (requires the AMP library to be built).                                                 |
-| `gulp test --integration --files=<test-files-path-glob>`                | Runs the integration tests from the specified files in Chrome.                                                 |
-| `gulp test [--unit\|--integration] --verbose`                           | Runs tests in Chrome with logging enabled.                            |
-| `gulp test [--unit\|--integration] --nobuild`                           | Runs tests without re-build.                                          |
-| `gulp test [--unit\|--integration] --coverage`                          | Runs code coverage tests. After running, the report will be available at test/coverage/index.html |
-| `gulp test [--unit\|--integration] --watch`                             | Watches for changes in files, runs corresponding test(s) in Chrome.   |
-| `gulp test [--unit\|--integration] --watch --verbose`                   | Same as `watch`, with logging enabled.                                 |
-| `gulp test [--integration] --saucelabs`                                 | Runs integration tests on saucelabs (requires [setup](#testing-on-sauce-labs)).                |
-| `gulp test [--unit] --saucelabs_lite`                                   | Runs unit tests on a subset of saucelabs browsers (requires [setup](#testing-on-sauce-labs)).                |
-| `gulp test [--unit\|--integration] --safari`                            | Runs tests in Safari.                                                 |
-| `gulp test [--unit\|--integration] --firefox`                           | Runs tests in Firefox.                                                |
-| `gulp test [--unit\|--integration] --files=<test-files-path-glob>`      | Runs specific test files.                                             |
-| `gulp test [--unit\|--integration] --testnames`                         | Lists the name of each test being run, and prints a summary at the end.  |
-| `gulp serve`                                                            | Serves content in repo root dir over http://localhost:8000/. Examples live in http://localhost:8000/examples/. Serve unminified AMP by default. |
-| `gulp serve --quiet`                                                    | Same as `serve`, with logging silenced. |
-| `gulp serve --port 9000`                                                | Same as `serve`, but uses a port number other than the default of 8000. |
-| `gulp check-types`                                                      | Verifies that there are no errors associated with Closure typing. Run automatically upon push.  |
-| `gulp dep-check`                                                        | Runs a dependency check on each module. Run automatically upon push.  |
-| `gulp presubmit`                                                        | Run validation against files to check for forbidden and required terms. Run automatically upon push.  |
-| `gulp validator`                                                        | Builds and tests the AMP validator. Run automatically upon push.  |
-| `node build-system/pr-check.js`                                         | Runs all tests that will be run upon pushing a CL.                     |
-| `gulp ava`                                                              | Run node tests for tasks and offline/node code using [ava](https://github.com/avajs/ava). |
-| `gulp todos:find-closed`                                                | Find `TODO`s in code for issues that have been closed. |
-| `gulp visual-diff`                                                      | Runs all visual diff tests on local Chrome. Requires `PERCY_PROJECT` and `PERCY_TOKEN` to be set as environment variables or passed to the task with `--percy_project` and `--percy_token`. |
-| `gulp visual-diff --nobuild`                                            | Same as above, but without re-build. |
-| `gulp visual-diff --headless`                                           | Same as above, but launches local Chrome in headless mode. |
-| `gulp visual-diff --chrome_debug --webserver_debug`                     | Same as above, with additional logging. Debug flags can be used independently.  |
-| `gulp visual-diff --grep=<regular-expression-pattern>`                  | Same as above, but executes only those tests whose name matches the regular expression pattern. |
+Command                                                                 | Description
+------------------------------------------------------------------------|----------------------------------------------------------------------
+**`gulp`**                                                              | Runs "watch" and "serve". Use this for standard local dev.
+`gulp --extensions=amp-foo,amp-bar`                                     | Runs "watch" and "serve", after building only the listed extensions.
+`gulp --extensions=minimal_set`                                         | Runs "watch" and "serve", after building the extensions needed to load `article.amp.html`.
+`gulp --extensions_from=examples/foo.amp.html`                          | Runs "watch" and "serve", after building only extensions from the listed examples.
+`gulp --noextensions`                                                   | Runs "watch" and "serve" without building any extensions.
+`gulp dist`                                                             | Builds production binaries.
+`gulp dist --extensions=amp-foo,amp-bar`                                | Builds production binaries, with only the listed extensions.
+`gulp dist --extensions=minimal_set`                                    | Builds production binaries, with only the extensions needed to load `article.amp.html`.
+`gulp dist --extensions_from=examples/foo.amp.html`                     | Builds production binaries, with only extensions from  the listed examples.
+`gulp dist --noextensions`                                              | Builds production binaries without building any extensions.
+`gulp dist --fortesting`                                                | Builds production binaries for local testing. (Allows use cases like ads, tweets, etc. to work with minified sources. Overrides `TESTING_HOST` if specified. Uses the production `AMP_CONFIG` by default.)
+`gulp dist --fortesting --config=<config>`                              | Builds production binaries for local testing, with the specified `AMP_CONFIG`. `config` can be `prod` or `canary`. (Defaults to `prod`.)
+`gulp lint`                                                             | Validates against the ESLint linter.
+`gulp lint --watch`                                                     | Watches for changes in files, and validates against the ESLint linter.
+`gulp lint --fix`                                                       | Fixes simple lint warnings/errors automatically.
+`gulp lint --files=<files-path-glob>`                                   | Lints just the files provided. Can be used with `--fix`.
+`gulp lint --local-changes`                                             | Lints just the files changed in the local branch. Can be used with `--fix`.
+`gulp build`                                                            | Builds the AMP library.
+`gulp build --extensions=amp-foo,amp-bar`                               | Builds the AMP library, with only the listed extensions.
+`gulp build --extensions=minimal_set`                                   | Builds the AMP library, with only the extensions needed to load `article.amp.html`.
+`gulp build --extensions_from=examples/foo.amp.html`                    | Builds the AMP library, with only the extensions needed to load the listed examples.
+`gulp build --noextensions`                                             | Builds the AMP library with no extensions.
+`gulp check-links --files foo.md,bar.md`                                | Reports dead links in `.md` files.
+`gulp clean`                                                            | Removes build output.
+`gulp css`                                                              | Recompiles css to build directory and builds the embedded css into js files for the AMP library.
+`gulp watch`                                                            | Watches for changes in files, re-builds.
+`gulp watch --extensions=amp-foo,amp-bar`                               | Watches for changes in files, re-builds only the listed extensions.
+`gulp watch --extensions=minimal_set`                                   | Watches for changes in files, re-builds only the extensions needed to load `article.amp.html`.
+`gulp watch --extensions_from=examples/foo.amp.html`                    | Watches for changes in files, re-builds only the extensions needed to load the listed examples.
+`gulp watch --noextensions`                                             | Watches for changes in files, re-builds with no extensions.
+`gulp pr-check`                                                         | Runs all the Travis CI checks locally.
+`gulp pr-check --nobuild`                                               | Runs all the Travis CI checks locally, but skips the `gulp build` step.
+`gulp pr-check --files=<test-files-path-glob>`                          | Runs all the Travis CI checks locally, and restricts tests to the files provided.
+`gulp test --unit`                                                      | Runs the unit tests in Chrome (doesn't require the AMP library to be built).
+`gulp test --unit --files=<test-files-path-glob>`                       | Runs the unit tests from the specified files in Chrome.
+`gulp test --local-changes`                                             | Runs the unit tests directly affected by the files changed in the local branch in Chrome.
+`gulp test --integration`                                               | Runs the integration tests in Chrome (requires the AMP library to be built).
+`gulp test --integration --files=<test-files-path-glob>`                | Runs the integration tests from the specified files in Chrome.
+`gulp test [--unit\|--integration] --verbose`                           | Runs tests in Chrome with logging enabled.
+`gulp test [--unit\|--integration] --nobuild`                           | Runs tests without re-build.
+`gulp test [--unit\|--integration] --coverage`                          | Runs code coverage tests. After running, the report will be available at test/coverage/index.html
+`gulp test [--unit\|--integration] --watch`                             | Watches for changes in files, runs corresponding test(s) in Chrome.
+`gulp test [--unit\|--integration] --watch --verbose`                   | Same as `watch`, with logging enabled.
+`gulp test [--integration] --saucelabs`                                 | Runs integration tests on saucelabs (requires [setup](#testing-on-sauce-labs)).
+`gulp test [--unit] --saucelabs_lite`                                   | Runs unit tests on a subset of saucelabs browsers (requires [setup](#testing-on-sauce-labs)).
+`gulp test [--unit\|--integration] --safari`                            | Runs tests in Safari.
+`gulp test [--unit\|--integration] --firefox`                           | Runs tests in Firefox.
+`gulp test [--unit\|--integration] --files=<test-files-path-glob>`      | Runs specific test files.
+`gulp test [--unit\|--integration] --testnames`                         | Lists the name of each test being run, and prints a summary at the end.
+`gulp serve`                                                            | Serves content in repo root dir over http://localhost:8000/. Examples live in http://localhost:8000/examples/. Serve unminified AMP by default.
+`gulp serve --quiet`                                                    | Same as `serve`, with logging silenced.
+`gulp serve --port 9000`                                                | Same as `serve`, but uses a port number other than the default of 8000.
+`gulp check-types`                                                      | Verifies that there are no errors associated with Closure typing. Run automatically upon push.
+`gulp dep-check`                                                        | Runs a dependency check on each module. Run automatically upon push.
+`gulp presubmit`                                                        | Run validation against files to check for forbidden and required terms. Run automatically upon push.
+`gulp validator`                                                        | Builds and tests the AMP validator. Run automatically upon push.
+`node build-system/pr-check.js`                                         | Runs all tests that will be run upon pushing a CL.
+`gulp ava`                                                              | Run node tests for tasks and offline/node code using [ava](https://github.com/avajs/ava).
+`gulp todos:find-closed`                                                | Find `TODO`s in code for issues that have been closed.
+`gulp visual-diff`                                                      | Runs all visual diff tests on local Chrome. Requires `PERCY_PROJECT` and `PERCY_TOKEN` to be set as environment variables or passed to the task with `--percy_project` and `--percy_token`.
+`gulp visual-diff --nobuild`                                            | Same as above, but without re-build.
+`gulp visual-diff --headless`                                           | Same as above, but launches local Chrome in headless mode.
+`gulp visual-diff --chrome_debug --webserver_debug`                     | Same as above, with additional logging. Debug flags can be used independently.
+`gulp visual-diff --grep=<regular-expression-pattern>`                  | Same as above, but executes only those tests whose name matches the regular expression pattern.
 
 ## Manual testing
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -212,8 +212,8 @@ function buildExtensions(options) {
   }
 
   if (!!argv.extensions_from && !options.compileAll) {
-    extensionsToBuild =
-        extensionsToBuild.concat(getExtensionsFromArg(argv.extensions_from));
+    const extensionsFrom = getExtensionsFromArg(argv.extensions_from);
+    extensionsToBuild = dedupe(extensionsToBuild.concat(extensionsFrom));
   }
 
   const results = [];
@@ -231,9 +231,9 @@ function buildExtensions(options) {
 }
 
 /**
- * Process the command line argument --extensions from a list of extensions
- * and example AMP documents into a single list of extensions.
- * @param {string} examples A comma separated list of AMPHTML documents
+ * Process the command line argument --extensions_from of example AMP documents
+ * into a single list of AMP extensions consumed by those documents.
+ * @param {string} examples A comma separated list of AMP documents
  * @return {!Array<string>}
  */
 function getExtensionsFromArg(examples) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -905,6 +905,11 @@ function copyAliasExtensions() {
     extensionsToBuild = argv.extensions.split(',');
   }
 
+  if (!!argv.extensions_from) {
+    const extensionsFrom = getExtensionsFromArg(argv.extensions_from);
+    extensionsToBuild = dedupe(extensionsToBuild.concat(extensionsFrom));
+  }
+
   for (const key in extensionAliasFilePath) {
     if (extensionsToBuild.length > 0 &&
         extensionsToBuild.indexOf(extensionAliasFilePath[key]['name']) == -1) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -237,6 +237,10 @@ function buildExtensions(options) {
  * @return {!Array<string>}
  */
 function getExtensionsFromArg(examples) {
+  if (!examples) {
+    return;
+  }
+
   const extensions = [];
 
   examples.split(',').forEach(example => {
@@ -1588,6 +1592,7 @@ gulp.task('build', 'Builds the AMP library', maybeUpdatePackages, build, {
   options: {
     config: '  Sets the runtime\'s AMP_CONFIG to one of "prod" or "canary"',
     extensions: '  Builds only the listed extensions.',
+    extensions_from: '  Builds only the extensions from the listed AMP(s).',
     noextensions: '  Builds with no extensions.',
   },
 });
@@ -1599,6 +1604,8 @@ gulp.task('default', 'Runs "watch" and then "serve"',
     maybeUpdatePackages.concat(['watch']), serve, {
       options: {
         extensions: '  Watches and builds only the listed extensions.',
+        extensions_from: '  Watches and builds only the extensions from the ' +
+            'listed AMP(s).',
         noextensions: '  Watches and builds with no extensions.',
       },
     });
@@ -1608,7 +1615,10 @@ gulp.task('dist', 'Build production binaries', maybeUpdatePackages, dist, {
             'Great for profiling and debugging production code.',
     fortesting: '  Compiles production binaries for local testing',
     config: '  Sets the runtime\'s AMP_CONFIG to one of "prod" or "canary"',
-    single_pass: 'Compile AMP\'s primary JS bundles in a single invocatoion',
+    single_pass: 'Compile AMP\'s primary JS bundles in a single invocation',
+    extensions: '  Builds only the listed extensions.',
+    extensions_from: '  Builds only the extensions from the listed AMP(s).',
+    noextensions: '  Builds with no extensions.',
   },
 });
 gulp.task('watch', 'Watches for changes in files, re-builds when detected',
@@ -1617,6 +1627,8 @@ gulp.task('watch', 'Watches for changes in files, re-builds when detected',
         with_inabox: '  Also watch and build the amp-inabox.js binary.',
         with_shadow: '  Also watch and build the amp-shadow.js binary.',
         extensions: '  Watches and builds only the listed extensions.',
+        extensions_from: '  Watches and builds only the extensions from the ' +
+            'listed AMP(s).',
         noextensions: '  Watches and builds with no extensions.',
       },
     });


### PR DESCRIPTION
This PR allows paths to AMPHTML documents to be added to the `--extensions` gulp argument. Any valid AMP extensions scripts will be picked up from their `custom-element` or `custom-template` attributes and they will be built. These can be combined with names of AMP extensions as well e.g.

```sh
gulp --extensions=examples/forms.amp.html,amp-sidebar
```

I think this will help speed up the development workflow when trying to fix a bug in a particular repro doc or when adding a new use-case to an existing component or pattern.