### PR TITLE
🐛 Fixing store and request services race conditions.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-access.js
+++ b/extensions/amp-story/1.0/amp-story-access.js
@@ -16,7 +16,7 @@
 
 import {Layout} from '../../../src/layout';
 import {Services} from '../../../src/services';
-import {StateProperty} from './amp-story-store-service';
+import {StateProperty, getStoreService} from './amp-story-store-service';
 import {copyChildren, removeChildren} from '../../../src/dom';
 import {dev} from '../../../src/log';
 import {dict} from './../../../src/utils/object';
@@ -62,7 +62,7 @@ export class AmpStoryAccess extends AMP.BaseElement {
     this.scrollableEl_ = null;
 
     /** @private @const {!./amp-story-store-service.AmpStoryStoreService} */
-    this.storeService_ = Services.storyStoreService(this.win);
+    this.storeService_ = getStoreService(this.win);
   }
 
   /** @override */

--- a/extensions/amp-story/1.0/amp-story-consent.js
+++ b/extensions/amp-story/1.0/amp-story-consent.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {Action} from './amp-story-store-service';
+import {Action, getStoreService} from './amp-story-store-service';
 import {ActionTrust} from '../../../src/action-constants';
 import {CSS} from '../../../build/amp-story-consent-1.0.css';
 import {Layout} from '../../../src/layout';
@@ -184,7 +184,7 @@ export class AmpStoryConsent extends AMP.BaseElement {
     this.scrollableEl_ = null;
 
     /** @private @const {!./amp-story-store-service.AmpStoryStoreService} */
-    this.storeService_ = Services.storyStoreService(this.win);
+    this.storeService_ = getStoreService(this.win);
 
     /** @private {?Object} */
     this.storyConsentConfig_ = null;

--- a/extensions/amp-story/1.0/amp-story-hint.js
+++ b/extensions/amp-story/1.0/amp-story-hint.js
@@ -17,7 +17,7 @@
 import {CSS} from '../../../build/amp-story-hint-1.0.css';
 import {LocalizedStringId} from './localization';
 import {Services} from '../../../src/services';
-import {StateProperty} from './amp-story-store-service';
+import {StateProperty, getStoreService} from './amp-story-store-service';
 import {createShadowRootWithStyle} from './utils';
 import {dict} from '../../../src/utils/object';
 import {renderAsElement} from './simple-template';
@@ -144,7 +144,7 @@ export class AmpStoryHint {
     this.hintTimeout_ = null;
 
     /** @private @const {!./amp-story-store-service.AmpStoryStoreService} */
-    this.storeService_ = Services.storyStoreService(this.win_);
+    this.storeService_ = getStoreService(this.win_);
 
     /** @private @const {!Element} */
     this.parentEl_ = parentEl;

--- a/extensions/amp-story/1.0/amp-story-info-dialog.js
+++ b/extensions/amp-story/1.0/amp-story-info-dialog.js
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import {Action, StateProperty} from './amp-story-store-service';
+import {
+  Action,
+  StateProperty,
+  getStoreService,
+} from './amp-story-store-service';
 import {CSS} from '../../../build/amp-story-info-dialog-1.0.css';
 import {LocalizedStringId} from './localization';
 import {Services} from '../../../src/services';
@@ -58,7 +62,7 @@ export class InfoDialog {
     this.localizationService_ = Services.localizationService(this.win_);
 
     /** @private @const {!./amp-story-store-service.AmpStoryStoreService} */
-    this.storeService_ = Services.storyStoreService(this.win_);
+    this.storeService_ = getStoreService(this.win_);
 
     /** @private @const {!Element} */
     this.parentEl_ = parentEl;

--- a/extensions/amp-story/1.0/amp-story-request-service.js
+++ b/extensions/amp-story/1.0/amp-story-request-service.js
@@ -18,6 +18,7 @@ import {Services} from '../../../src/services';
 import {childElementByTag} from '../../../src/dom';
 import {getAmpdoc} from '../../../src/service';
 import {once} from '../../../src/utils/function';
+import {registerServiceBuilder} from '../../../src/service';
 import {user} from '../../../src/log';
 
 /** @private @const {string} */
@@ -79,3 +80,22 @@ export class AmpStoryRequestService {
         });
   }
 }
+
+/**
+ * Util function to retrieve the request service. Ensures we can retrieve the
+ * service synchronously from the amp-story codebase without running into race
+ * conditions.
+ * @param  {!Window} win
+ * @param  {!Element} storyEl
+ * @return {!AmpStoryRequestService}
+ */
+export const getRequestService = (win, storyEl) => {
+  let service = Services.storyRequestService(win);
+
+  if (!service) {
+    service = new AmpStoryRequestService(win, storyEl);
+    registerServiceBuilder(win, 'story-request', () => service);
+  }
+
+  return service;
+};

--- a/extensions/amp-story/1.0/amp-story-share-menu.js
+++ b/extensions/amp-story/1.0/amp-story-share-menu.js
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import {Action, StateProperty} from './amp-story-store-service';
+import {
+  Action,
+  StateProperty,
+  getStoreService,
+} from './amp-story-store-service';
 import {CSS} from '../../../build/amp-story-share-menu-1.0.css';
 import {Services} from '../../../src/services';
 import {ShareWidget} from './amp-story-share';
@@ -66,9 +70,9 @@ const AMP_SOCIAL_SYSTEM_SHARE_TEMPLATE = {
 export class ShareMenu {
   /**
    * @param {!Window} win
-   * @param {!Element} parentEl Element where to append the component
+   * @param {!Element} storyEl Element where to append the component
    */
-  constructor(win, parentEl) {
+  constructor(win, storyEl) {
     /** @private @const {!Window} */
     this.win_ = win;
 
@@ -85,13 +89,13 @@ export class ShareMenu {
     this.isSystemShareSupported_ = false;
 
     /** @private @const {!ShareWidget} */
-    this.shareWidget_ = ShareWidget.create(this.win_);
+    this.shareWidget_ = ShareWidget.create(this.win_, storyEl);
 
     /** @private @const {!./amp-story-store-service.AmpStoryStoreService} */
-    this.storeService_ = Services.storyStoreService(this.win_);
+    this.storeService_ = getStoreService(this.win_);
 
     /** @private @const {!Element} */
-    this.parentEl_ = parentEl;
+    this.parentEl_ = storyEl;
 
     /** @const @private {!../../../src/service/vsync-impl.Vsync} */
     this.vsync_ = Services.vsyncFor(this.win_);

--- a/extensions/amp-story/1.0/amp-story-share.js
+++ b/extensions/amp-story/1.0/amp-story-share.js
@@ -22,6 +22,7 @@ import {
 } from '../../../src/clipboard';
 import {dev, user} from '../../../src/log';
 import {dict, map} from './../../../src/utils/object';
+import {getRequestService} from './amp-story-request-service';
 import {isObject} from '../../../src/types';
 import {listen} from '../../../src/event-helper';
 import {px, setImportantStyles} from '../../../src/style';
@@ -188,8 +189,11 @@ function buildCopySuccessfulToast(doc, url) {
  * Social share widget for story bookend.
  */
 export class ShareWidget {
-  /** @param {!Window} win */
-  constructor(win) {
+  /**
+   * @param {!Window} win
+   * @param {!Element} storyEl
+   */
+  constructor(win, storyEl) {
     /** @private {?../../../src/service/ampdoc-impl.AmpDoc} */
     this.ampdoc_ = null;
 
@@ -203,12 +207,16 @@ export class ShareWidget {
     this.localizationServicePromise_ = null;
 
     /** @private @const {!./amp-story-request-service.AmpStoryRequestService} */
-    this.requestService_ = Services.storyRequestService(this.win);
+    this.requestService_ = getRequestService(this.win, storyEl);
   }
 
-  /** @param {!Window} win */
-  static create(win) {
-    return new ShareWidget(win);
+  /**
+   * @param {!Window} win
+   * @param {!Element} storyEl
+   * @return {!ShareWidget}
+   */
+  static create(win, storyEl) {
+    return new ShareWidget(win, storyEl);
   }
 
   /**
@@ -381,9 +389,12 @@ export class ShareWidget {
  * This class is coupled to the DOM structure for ShareWidget, but that's ok.
  */
 export class ScrollableShareWidget extends ShareWidget {
-  /** @param {!Window} win */
-  constructor(win) {
-    super(win);
+  /**
+   * @param {!Window} win
+   * @param {!Element} storyEl
+   */
+  constructor(win, storyEl) {
+    super(win, storyEl);
 
     /** @private @const {!../../../src/service/vsync-impl.Vsync} */
     this.vsync_ = Services.vsyncFor(win);
@@ -396,9 +407,13 @@ export class ScrollableShareWidget extends ShareWidget {
     this.containerWidth_ = null;
   }
 
-  /** @param {!Window} win */
-  static create(win) {
-    return new ScrollableShareWidget(win);
+  /**
+   * @param {!Window} win
+   * @param {!Element} storyEl
+   * @return {!ScrollableShareWidget}
+   */
+  static create(win, storyEl) {
+    return new ScrollableShareWidget(win, storyEl);
   }
 
   /**

--- a/extensions/amp-story/1.0/amp-story-store-service.js
+++ b/extensions/amp-story/1.0/amp-story-store-service.js
@@ -16,12 +16,33 @@
 
 import {EmbedMode, parseEmbedMode} from './embed-mode';
 import {Observable} from '../../../src/observable';
+import {Services} from '../../../src/services';
 import {dev} from '../../../src/log';
 import {hasOwn} from '../../../src/utils/object';
+import {registerServiceBuilder} from '../../../src/service';
 
 
 /** @type {string} */
 const TAG = 'amp-story';
+
+
+/**
+ * Util function to retrieve the store service. Ensures we can retrieve the
+ * service synchronously from the amp-story codebase without running into race
+ * conditions.
+ * @param  {!Window} win
+ * @return {!AmpStoryStoreService}
+ */
+export const getStoreService = win => {
+  let service = Services.storyStoreService(win);
+
+  if (!service) {
+    service = new AmpStoryStoreService(win);
+    registerServiceBuilder(win, 'story-store', () => service);
+  }
+
+  return service;
+};
 
 
 /**

--- a/extensions/amp-story/1.0/amp-story-system-layer.js
+++ b/extensions/amp-story/1.0/amp-story-system-layer.js
@@ -13,7 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {Action, StateProperty} from './amp-story-store-service';
+import {
+  Action,
+  StateProperty,
+  getStoreService,
+} from './amp-story-store-service';
 import {CSS} from '../../../build/amp-story-system-layer-1.0.css';
 import {DevelopmentModeLog, DevelopmentModeLogButtonSet} from './development-ui';
 import {LocalizedStringId} from './localization';
@@ -165,7 +169,7 @@ export class SystemLayer {
     this.sharePillContainerNode_ = null;
 
     /** @private @const {!./amp-story-store-service.AmpStoryStoreService} */
-    this.storeService_ = Services.storyStoreService(this.win_);
+    this.storeService_ = getStoreService(this.win_);
 
     /** @const @private {!../../../src/service/vsync-impl.Vsync} */
     this.vsync_ = Services.vsyncFor(this.win_);
@@ -445,7 +449,7 @@ export class SystemLayer {
     this.sharePillContainerNode_ =
         renderSimpleTemplate(this.win_.document, SHARE_WIDGET_PILL_CONTAINER);
 
-    const shareWidget = new ShareWidget(this.win_);
+    const shareWidget = new ShareWidget(this.win_, this.parentEl_);
 
     this.sharePillContainerNode_
         .querySelector('.i-amphtml-story-share-pill')

--- a/extensions/amp-story/1.0/amp-story-unsupported-browser-layer.js
+++ b/extensions/amp-story/1.0/amp-story-unsupported-browser-layer.js
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
-import {Action} from './amp-story-store-service';
+import {Action, getStoreService} from './amp-story-store-service';
 import {CSS} from '../../../build/amp-story-unsupported-browser-layer-1.0.css';
 import {LocalizedStringId} from './localization';
-import {Services} from '../../../src/services';
 import {createShadowRootWithStyle} from './utils';
 import {dict} from './../../../src/utils/object';
 import {removeElement} from '../../../src/dom';
@@ -83,7 +82,7 @@ export class UnsupportedBrowserLayer {
     this.continueButton_ = null;
 
     /** @private @const {!./amp-story-store-service.AmpStoryStoreService} */
-    this.storeService_ = Services.storyStoreService(this.win_);
+    this.storeService_ = getStoreService(this.win_);
   }
 
   /**

--- a/extensions/amp-story/1.0/amp-story-viewport-warning-layer.js
+++ b/extensions/amp-story/1.0/amp-story-viewport-warning-layer.js
@@ -17,7 +17,7 @@
 import {CSS} from '../../../build/amp-story-viewport-warning-layer-1.0.css';
 import {LocalizedStringId} from './localization';
 import {Services} from '../../../src/services';
-import {StateProperty} from './amp-story-store-service';
+import {StateProperty, getStoreService} from './amp-story-store-service';
 import {createShadowRootWithStyle} from './utils';
 import {dict} from './../../../src/utils/object';
 import {renderAsElement} from './simple-template';
@@ -114,7 +114,7 @@ export class ViewportWarningLayer {
     this.platform_ = Services.platformFor(this.win_);
 
     /** @private @const {!./amp-story-store-service.AmpStoryStoreService} */
-    this.storeService_ = Services.storyStoreService(this.win_);
+    this.storeService_ = getStoreService(this.win_);
 
     /** @private @const {!Element} */
     this.storyElement_ = storyElement;

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -29,8 +29,8 @@ import './amp-story-grid-layer';
 import './amp-story-page';
 import {
   Action,
-  AmpStoryStoreService,
   StateProperty,
+  getStoreService,
 } from './amp-story-store-service';
 import {ActionTrust} from '../../../src/action-constants';
 import {AmpStoryAccess} from './amp-story-access';
@@ -42,7 +42,6 @@ import {AmpStoryCtaLayer} from './amp-story-cta-layer';
 import {AmpStoryGridLayer} from './amp-story-grid-layer';
 import {AmpStoryHint} from './amp-story-hint';
 import {AmpStoryPage, PageState} from './amp-story-page';
-import {AmpStoryRequestService} from './amp-story-request-service';
 import {AmpStoryVariableService} from './variable-service';
 import {CSS} from '../../../build/amp-story-1.0.css';
 import {CommonSignals} from '../../../src/common-signals';
@@ -188,14 +187,8 @@ export class AmpStory extends AMP.BaseElement {
   constructor(element) {
     super(element);
 
-    /** @private @const {!AmpStoryStoreService} */
-    this.storeService_ = new AmpStoryStoreService(this.win);
-    registerServiceBuilder(this.win, 'story-store', () => this.storeService_);
-
-    /** @private @const {!AmpStoryRequestService} */
-    this.requestService_ = new AmpStoryRequestService(this.win, this.element);
-    registerServiceBuilder(
-        this.win, 'story-request', () => this.requestService_);
+    /** @private @const {!./amp-story-store-service.AmpStoryStoreService} */
+    this.storeService_ = getStoreService(this.win);
 
     /** @private {!NavigationState} */
     this.navigationState_ =
@@ -1654,7 +1647,6 @@ export class AmpStory extends AMP.BaseElement {
    */
   getPageIndexById(id) {
     const pageIndex = findIndex(this.pages_, page => page.element.id === id);
-
     if (pageIndex < 0) {
       user().error(TAG,
           `Story refers to page "${id}", but no such page exists.`);

--- a/extensions/amp-story/1.0/navigation-state.js
+++ b/extensions/amp-story/1.0/navigation-state.js
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 import {Observable} from '../../../src/observable';
-import {Services} from '../../../src/services';
-import {StateProperty} from './amp-story-store-service';
+import {StateProperty, getStoreService} from './amp-story-store-service';
 
 
 /**
@@ -53,7 +52,7 @@ export class NavigationState {
     this.win_ = win;
 
     /** @private @const {!./amp-story-store-service.AmpStoryStoreService} */
-    this.storeService_ = Services.storyStoreService(this.win_);
+    this.storeService_ = getStoreService(this.win_);
 
     this.initializeListeners_();
   }

--- a/extensions/amp-story/1.0/page-advancement.js
+++ b/extensions/amp-story/1.0/page-advancement.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import {Services} from '../../../src/services';
-import {StateProperty} from './amp-story-store-service';
+import {StateProperty, getStoreService} from './amp-story-store-service';
 import {TAPPABLE_ARIA_ROLES} from '../../../src/service/action-impl';
 import {VideoEvents} from '../../../src/video-interface';
 import {closest, escapeCssSelectorIdent} from '../../../src/dom';
@@ -269,7 +269,7 @@ class ManualAdvancement extends AdvancementConfig {
     if (element.ownerDocument.defaultView) {
       /** @private @const {!./amp-story-store-service.AmpStoryStoreService} */
       this.storeService_ =
-        Services.storyStoreService(element.ownerDocument.defaultView);
+        getStoreService(element.ownerDocument.defaultView);
     }
 
     const rtlState = this.storeService_.get(StateProperty.RTL_STATE);

--- a/extensions/amp-story/1.0/pagination-buttons.js
+++ b/extensions/amp-story/1.0/pagination-buttons.js
@@ -13,9 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {Action} from './amp-story-store-service';
+import {Action, getStoreService} from './amp-story-store-service';
 import {EventType, dispatch} from './events';
-import {Services} from '../../../src/services';
 import {StateChangeType} from './navigation-state';
 import {dev} from '../../../src/log';
 import {dict} from './../../../src/utils/object';
@@ -153,7 +152,7 @@ export class PaginationButtons {
   /** @param {!Window} win */
   constructor(win) {
     const doc = win.document;
-    const storeService = Services.storyStoreService(win);
+    const storeService = getStoreService(win);
 
     /** @private @const {!PaginationButton} */
     this.forwardButton_ =

--- a/extensions/amp-story/1.0/test/test-amp-story-bookend.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-bookend.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {Action, AmpStoryStoreService} from '../amp-story-store-service';
+import {Action} from '../amp-story-store-service';
 import {AmpStoryBookend} from '../bookend/amp-story-bookend';
 import {AmpStoryRequestService} from '../amp-story-request-service';
 import {ArticleComponent} from '../bookend/components/article';
@@ -22,6 +22,7 @@ import {CtaLinkComponent} from '../bookend/components/cta-link';
 import {LandscapeComponent} from '../bookend/components/landscape';
 import {LocalizationService} from '../localization';
 import {PortraitComponent} from '../bookend/components/portrait';
+import {Services} from '../../../../src/services';
 import {TextBoxComponent} from '../bookend/components/text-box';
 import {createElementWithAttributes} from '../../../../src/dom';
 import {registerServiceBuilder} from '../../../../src/service';
@@ -32,6 +33,7 @@ describes.realWin('amp-story-bookend', {amp: true}, env => {
   let storyElem;
   let bookend;
   let bookendElem;
+  let requestService;
 
   const expectedComponents = [
     {
@@ -124,11 +126,8 @@ describes.realWin('amp-story-bookend', {amp: true}, env => {
         'amp-story-bookend', {'layout': 'nodisplay'});
     storyElem.appendChild(bookendElem);
 
-    const requestService = new AmpStoryRequestService(win, storyElem);
-    registerServiceBuilder(win, 'story-request', () => requestService);
-
-    const storeService = new AmpStoryStoreService(win);
-    registerServiceBuilder(win, 'story-store', () => storeService);
+    requestService = new AmpStoryRequestService(win, storyElem);
+    sandbox.stub(Services, 'storyRequestService').returns(requestService);
 
     const localizationService = new LocalizationService(win);
     registerServiceBuilder(win, 'localization', () => localizationService);
@@ -202,8 +201,7 @@ describes.realWin('amp-story-bookend', {amp: true}, env => {
       ],
     };
 
-    sandbox.stub(bookend.requestService_, 'loadBookendConfig')
-        .resolves(userJson);
+    sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
 
     bookend.build();
     return bookend.loadConfigAndMaybeRenderBookend().then(config => {
@@ -277,8 +275,7 @@ describes.realWin('amp-story-bookend', {amp: true}, env => {
       ],
     };
 
-    sandbox.stub(bookend.requestService_, 'loadBookendConfig')
-        .resolves(userJson);
+    sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
 
     bookend.build();
     return bookend.loadConfigAndMaybeRenderBookend().then(config => {
@@ -312,8 +309,7 @@ describes.realWin('amp-story-bookend', {amp: true}, env => {
       ],
     };
 
-    sandbox.stub(bookend.requestService_, 'loadBookendConfig')
-        .resolves(userJson);
+    sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
 
     bookend.build();
     return bookend.loadConfigAndMaybeRenderBookend().then(() => {
@@ -353,8 +349,7 @@ describes.realWin('amp-story-bookend', {amp: true}, env => {
       ],
     };
 
-    sandbox.stub(bookend.requestService_, 'loadBookendConfig')
-        .resolves(userJson);
+    sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
 
     bookend.build();
     return bookend.loadConfigAndMaybeRenderBookend().then(() => {
@@ -386,8 +381,7 @@ describes.realWin('amp-story-bookend', {amp: true}, env => {
       ],
     };
 
-    sandbox.stub(bookend.requestService_, 'loadBookendConfig')
-        .resolves(userJson);
+    sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
 
     bookend.build();
     return bookend.loadConfigAndMaybeRenderBookend().then(() => {
@@ -425,8 +419,7 @@ describes.realWin('amp-story-bookend', {amp: true}, env => {
       ],
     };
 
-    sandbox.stub(bookend.requestService_, 'loadBookendConfig')
-        .resolves(userJson);
+    sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
 
     bookend.build();
     return bookend.loadConfigAndMaybeRenderBookend().then(() => {
@@ -458,8 +451,7 @@ describes.realWin('amp-story-bookend', {amp: true}, env => {
       ],
     };
 
-    sandbox.stub(bookend.requestService_, 'loadBookendConfig')
-        .resolves(userJson);
+    sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
 
     bookend.build();
     return bookend.loadConfigAndMaybeRenderBookend().then(() => {
@@ -498,8 +490,7 @@ describes.realWin('amp-story-bookend', {amp: true}, env => {
       ],
     };
 
-    sandbox.stub(bookend.requestService_, 'loadBookendConfig')
-        .resolves(userJson);
+    sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
 
     bookend.build();
     return bookend.loadConfigAndMaybeRenderBookend().then(() => {
@@ -531,8 +522,7 @@ describes.realWin('amp-story-bookend', {amp: true}, env => {
       ],
     };
 
-    sandbox.stub(bookend.requestService_, 'loadBookendConfig')
-        .resolves(userJson);
+    sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
 
     bookend.build();
     return bookend.loadConfigAndMaybeRenderBookend().then(() => {
@@ -571,8 +561,7 @@ describes.realWin('amp-story-bookend', {amp: true}, env => {
       ],
     };
 
-    sandbox.stub(bookend.requestService_, 'loadBookendConfig')
-        .resolves(userJson);
+    sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
 
     bookend.build();
     return bookend.loadConfigAndMaybeRenderBookend().then(() => {
@@ -615,8 +604,7 @@ describes.realWin('amp-story-bookend', {amp: true}, env => {
       'whatsapp',
     ];
 
-    sandbox.stub(bookend.requestService_, 'loadBookendConfig')
-        .resolves(userJson);
+    sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
 
     bookend.build();
     return bookend.loadConfigAndMaybeRenderBookend().then(config => {
@@ -645,8 +633,7 @@ describes.realWin('amp-story-bookend', {amp: true}, env => {
       ],
     };
 
-    sandbox.stub(bookend.requestService_, 'loadBookendConfig')
-        .resolves(userJson);
+    sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
 
     bookend.build();
     return bookend.loadConfigAndMaybeRenderBookend().then(config => {
@@ -674,8 +661,7 @@ describes.realWin('amp-story-bookend', {amp: true}, env => {
 
     const userWarnStub = sandbox.stub(user(), 'warn');
 
-    sandbox.stub(bookend.requestService_, 'loadBookendConfig')
-        .resolves(userJson);
+    sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
 
     bookend.build();
     return bookend.loadConfigAndMaybeRenderBookend().then(() => {
@@ -888,8 +874,7 @@ describes.realWin('amp-story-bookend', {amp: true}, env => {
       ],
     };
 
-    sandbox.stub(bookend.requestService_, 'loadBookendConfig')
-        .resolves(userJson);
+    sandbox.stub(requestService, 'loadBookendConfig').resolves(userJson);
 
     bookend.build();
     expectAsyncConsoleError(/[Component `invalid-type` is not supported. Skipping invalid]/);

--- a/extensions/amp-story/1.0/test/test-amp-story.js
+++ b/extensions/amp-story/1.0/test/test-amp-story.js
@@ -16,7 +16,11 @@
 
 import * as consent from '../../../../src/consent';
 import * as utils from '../utils';
-import {Action, StateProperty} from '../amp-story-store-service';
+import {
+  Action,
+  AmpStoryStoreService,
+  StateProperty,
+} from '../amp-story-store-service';
 import {AmpStory} from '../amp-story';
 import {EventType} from '../events';
 import {KeyCodes} from '../../../../src/utils/key-codes';
@@ -24,6 +28,7 @@ import {LocalizationService} from '../localization';
 import {MediaType} from '../media-pool';
 import {PageState} from '../amp-story-page';
 import {PaginationButtons} from '../pagination-buttons';
+import {Services} from '../../../../src/services';
 import {registerServiceBuilder} from '../../../../src/service';
 
 
@@ -87,6 +92,9 @@ describes.realWin('amp-story', {
   beforeEach(() => {
     win = env.win;
 
+    sandbox.stub(Services, 'storyStoreService')
+        .callsFake(() => new AmpStoryStoreService(win));
+
     element = win.document.createElement('amp-story');
     win.document.body.appendChild(element);
 
@@ -94,6 +102,7 @@ describes.realWin('amp-story', {
     registerServiceBuilder(win, 'localization', () => localizationService);
 
     AmpStory.isBrowserSupported = () => true;
+
     story = new AmpStory(element);
     // TODO(alanorozco): Test active page event triggers once the stubbable
     // `Services` module is part of the amphtml-story repo.

--- a/extensions/amp-story/1.0/test/test-full-bleed-animations.js
+++ b/extensions/amp-story/1.0/test/test-full-bleed-animations.js
@@ -20,8 +20,10 @@
 
 import {AmpStory} from '../amp-story';
 import {AmpStoryPage} from '../amp-story-page';
+import {AmpStoryStoreService} from '../amp-story-store-service';
 import {LocalizationService} from '../localization';
 import {PRESETS} from '../animation-presets';
+import {Services} from '../../../../src/services';
 import {calculateTargetScalingFactor, targetFitsWithinPage} from '../animation-presets-utils';
 import {registerServiceBuilder} from '../../../../src/service';
 
@@ -37,6 +39,10 @@ describes.realWin('amp-story-full-bleed-animations', {
 
   beforeEach(() => {
     win = env.win;
+
+    sandbox.stub(Services, 'storyStoreService')
+        .callsFake(() => new AmpStoryStoreService(win));
+
     storyElem = win.document.createElement('amp-story');
     win.document.body.appendChild(storyElem);
 

--- a/src/services.js
+++ b/src/services.js
@@ -323,18 +323,20 @@ export class Services {
 
   /**
    * @param {!Window} win
-   * @return {!../extensions/amp-story/1.0/amp-story-store-service.AmpStoryStoreService}
+   * @return {?../extensions/amp-story/1.0/amp-story-store-service.AmpStoryStoreService}
    */
   static storyStoreService(win) {
-    return getService(win, 'story-store');
+    return (/** @type {?../extensions/amp-story/1.0/amp-story-store-service.AmpStoryStoreService} */
+      (getExistingServiceOrNull(win, 'story-store')));
   }
 
   /**
    * @param {!Window} win
-   * @return {!../extensions/amp-story/1.0/amp-story-request-service.AmpStoryRequestService}
+   * @return {?../extensions/amp-story/1.0/amp-story-request-service.AmpStoryRequestService}
    */
   static storyRequestService(win) {
-    return getService(win, 'story-request');
+    return (/** @type {?../extensions/amp-story/1.0/amp-story-request-service.AmpStoryRequestService} */
+      (getExistingServiceOrNull(win, 'story-request')));
   }
 
   /**


### PR DESCRIPTION
Both the story store and the request service are instantiated from the `amp-story` file, but runtime might instantiate other custom elements before the story itself. Which could result in the services being not declared, and trigger errors completely breaking the story.

- New util methods to retrieve the service synchronously (we could use Promises to retrieve services but a synchronous approach allows easier implementations)
- First element to retrieve the service instantiates it
- Request service is only instantiated when needed to load the bookend config, and not on story construct
- Bookend's ScrollableShareWidget is built only when building the whole bookend

Fixes #17042