### PR TITLE
🏗🐛  Make the installation of custom lint rules more robust

### DIFF
--- a/build-system/tasks/update-packages.js
+++ b/build-system/tasks/update-packages.js
@@ -99,12 +99,14 @@ function patchRegisterElement() {
 }
 
 /**
- * Installs custom lint rules in build-system/eslint-rules to node_modules.
+ * Installs custom lint rules from build-system/eslint-rules to node_modules.
  */
 function installCustomEslintRules() {
   const customRuleDir = 'build-system/eslint-rules';
   const customRuleName = 'eslint-plugin-amphtml-internal';
+  exec(yarnExecutable + ' unlink', {'stdio': 'ignore', 'cwd': customRuleDir});
   exec(yarnExecutable + ' link', {'stdio': 'ignore', 'cwd': customRuleDir});
+  exec(yarnExecutable + ' unlink ' + customRuleName, {'stdio': 'ignore'});
   exec(yarnExecutable + ' link ' + customRuleName, {'stdio': 'ignore'});
   if (!process.env.TRAVIS) {
     log(colors.green('Installed lint rules from'), colors.cyan(customRuleDir));


### PR DESCRIPTION
When new custom lint rules are added to `build-system/eslint-rules`, we run `yarn link` to make sure they are installed to `node_modules/eslint-plugin-amphtml-internal`. However, this isn't fully reliable if the directory is already linked, and new files are synced in.

In this PR, we run `yarn unlink` followed by `yarn link` so that all new rules are explicitly re-installed during `gulp update-packages`.

Discovered via https://github.com/ampproject/amphtml/pull/17132#issuecomment-408199205
Fixes #17133