### PR TITLE
🏗 Parallelize visual diff tests in multiple browser tabs

### DIFF
--- a/build-system/tasks/visual-diff.js
+++ b/build-system/tasks/visual-diff.js
@@ -439,8 +439,6 @@ async function snapshotWebpages(percy, page, webpages) {
     const {name, url, viewport} = webpage;
     log('verbose', 'Visual diff test', colors.yellow(name));
 
-    await enableExperiments(page, webpage['experiments']);
-
     if (viewport) {
       log('verbose', 'Setting explicit viewport size of',
           colors.yellow(`${viewport.width}×${viewport.height}`));
@@ -513,7 +511,6 @@ async function snapshotWebpages(percy, page, webpages) {
     }
 
     await percy.snapshot(name, page, snapshotOptions);
-    await clearExperiments(page);
     log('travis', colors.cyan('●'));
   }
   log('travis', '\n');
@@ -660,33 +657,6 @@ async function waitForSelectorExistence(page, selector) {
     attempt++;
   } while (attempt < CSS_SELECTOR_RETRY_ATTEMPTS);
   return false;
-}
-
-/**
- * Enables the given AMP experiments.
- *
- * @param {!puppeteer.Page} page a Puppeteer control browser tab/page.
- * @param {!Array<string>} experiments List of experiments to enable.
- */
-async function enableExperiments(page, experiments) {
-  if (experiments) {
-    log('verbose', 'Setting AMP experiments',
-        colors.cyan(experiments.join(', ')));
-    await page.setCookie({
-      name: 'AMP_EXP',
-      value: experiments.join('%2C'),
-      domain: HOST,
-    });
-  }
-}
-
-/**
- * Clears all AMP experiment cookies.
- *
- * @param {!puppeteer.Page} page a Puppeteer control browser tab/page.
- */
-async function clearExperiments(page) {
-  await page.deleteCookie({name: 'AMP_EXP', domain: HOST});
 }
 
 /**

--- a/build-system/tasks/visual-diff.js
+++ b/build-system/tasks/visual-diff.js
@@ -256,7 +256,7 @@ function verifyBuildStatus(status, buildId) {
  * Waits until the browsers are up and reachable, and ties their lifecycle to
  * this process's lifecycle.
  *
- * @param {int} numPages how many pages to open.
+ * @param {number} numPages how many pages to open.
  * @return {!Array<!puppeteer.Page>} a Puppeteer controlled page.
  */
 async function launchBrowsers(numPages) {

--- a/build-system/tasks/visual-diff.js
+++ b/build-system/tasks/visual-diff.js
@@ -425,7 +425,7 @@ async function snapshotWebpages(percy, page, webpages) {
 
     // Navigate to an empty page first to support different webpages that only
     // modify the #anchor name.
-    await page.goto('about:blank');
+    await page.goto('about:blank').then(() => {}, () => {});
 
     // Puppeteer is flaky when it comes to catching navigation requests, so
     // ignore timeouts. If this was a real non-loading page, this will be caught

--- a/build-system/tasks/visual-diff.js
+++ b/build-system/tasks/visual-diff.js
@@ -433,9 +433,9 @@ async function snapshotWebpages(percy, page, webpages) {
     // more network requests. This method is flaky since Puppeteer doesn't
     // always understand Chrome's network activity, so ignore timeouts again.
     navigationPromises[pageId] = Promise.all([
-      page.goto(`${BASE_URL}/${url}`),
-      page.waitForNavigation({waitUntil: 'networkidle2'}),
-    ]).then(() => pageId).catch(() => pageId);
+      page.goto(`${BASE_URL}/${url}`).catch(() => {}),
+      page.waitForNavigation({waitUntil: 'networkidle0'}).catch(() => {}),
+    ]).then(() => pageId);
   }
 
   while (Object.keys(navigationPromises).length > 0) {

--- a/build-system/tasks/visual-diff.js
+++ b/build-system/tasks/visual-diff.js
@@ -432,10 +432,9 @@ async function snapshotWebpages(percy, page, webpages) {
     // in the resulting Percy build. Also attempt to wait until there are no
     // more network requests. This method is flaky since Puppeteer doesn't
     // always understand Chrome's network activity, so ignore timeouts again.
-    navigationPromises[pageId] = Promise.all([
-      page.goto(`${BASE_URL}/${url}`).catch(() => {}),
-      page.waitForNavigation({waitUntil: 'networkidle0'}).catch(() => {}),
-    ]).then(() => pageId);
+    navigationPromises[pageId] = page.goto(
+        `${BASE_URL}/${url}`, {waitUntil: 'networkidle0'})
+        .then(() => pageId, () => pageId);
   }
 
   while (Object.keys(navigationPromises).length > 0) {

--- a/build-system/tasks/visual-diff.js
+++ b/build-system/tasks/visual-diff.js
@@ -272,7 +272,7 @@ async function launchBrowsers(numPages) {
   const pages = [];
   for (let i = 0; i < numPages; i++) {
     const browser = await puppeteer.launch(browserOptions)
-        .catch(err => log.fatal(err));
+        .catch(err => log('fatal', err));
     browsers_.push(browser);
 
     const page = (await browser.pages())[0];
@@ -382,8 +382,8 @@ async function generateSnapshots(percy, webpages) {
 
   log('verbose', 'Generating snapshots...');
   for (let i = 0; i < webpages.length; i += NUM_PARALLEL_PAGES) {
-    await snapshotWebpages(percy, pages,
-        webpages.slice(i, i + NUM_PARALLEL_PAGES), config);
+    await snapshotWebpages(
+        percy, pages, webpages.slice(i, i + NUM_PARALLEL_PAGES));
   }
 }
 
@@ -398,7 +398,7 @@ async function generateSnapshots(percy, webpages) {
  * @param {!Array<!JsonObject>} webpages an array of JSON objects containing
  *     details about the pages to snapshot.
  */
-async function snapshotWebpages(percy, page, webpages) {
+async function snapshotWebpages(percy, pages, webpages) {
   if (pages.length < webpages.length) {
     log('fatal', 'snapshotWebpages() called with `pages` and `webpages` with',
         'different lengths');
@@ -444,8 +444,7 @@ async function snapshotWebpages(percy, page, webpages) {
     const webpage = webpages[pageId];
     const page = pages[pageId];
 
-    const {url, viewport} = webpage;
-    const name = `${webpage.name} (${config})`;
+    const {name, url, viewport} = webpage;
 
     log('verbose', 'Navigation to page', colors.yellow(`${BASE_URL}/${url}`),
         'on tab', colors.cyan(`#${pageId + 1}`), 'is done, verifying page');

--- a/build-system/tasks/visual-diff.js
+++ b/build-system/tasks/visual-diff.js
@@ -385,6 +385,7 @@ async function generateSnapshots(percy, webpages) {
     await snapshotWebpages(
         percy, pages, webpages.slice(i, i + NUM_PARALLEL_PAGES));
   }
+  log('travis', '\n');
 }
 
 /**
@@ -485,7 +486,6 @@ async function snapshotWebpages(percy, pages, webpages) {
     await percy.snapshot(name, page, snapshotOptions);
     log('travis', colors.cyan('●'));
   }
-  log('travis', '\n');
 }
 
 /**

--- a/build-system/tasks/visual-diff.js
+++ b/build-system/tasks/visual-diff.js
@@ -41,8 +41,8 @@ const PORT = 8000;
 const BASE_URL = `http://${HOST}:${PORT}`;
 const WEBSERVER_TIMEOUT_RETRIES = 10;
 const NAVIGATE_TIMEOUT_MS = 3000;
-const MAX_PARALLEL_PAGES = 10;
-const WAIT_FOR_PRODUCER_OR_CONSUMER_MS = 1000;
+const MAX_PARALLEL_TABS = 10;
+const WAIT_FOR_TABS_MS = 1000;
 const CSS_SELECTOR_RETRY_MS = 100;
 const CSS_SELECTOR_RETRY_ATTEMPTS = 50;
 const CSS_SELECTOR_TIMEOUT_MS =
@@ -400,8 +400,8 @@ async function generateSnapshots(percy, webpages) {
 async function snapshotWebpages(percy, browser, webpages) {
   const pagePromises = {};
   for (const webpage of webpages) {
-    while (Object.keys(pagePromises).length >= MAX_PARALLEL_PAGES) {
-      await sleep(WAIT_FOR_PRODUCER_OR_CONSUMER_MS);
+    while (Object.keys(pagePromises).length >= MAX_PARALLEL_TABS) {
+      await sleep(WAIT_FOR_TABS_MS);
     }
 
     const page = await newPage(browser);
@@ -478,7 +478,7 @@ async function snapshotWebpages(percy, browser, webpages) {
   }
 
   while (Object.keys(pagePromises).length > 0) {
-    await sleep(WAIT_FOR_PRODUCER_OR_CONSUMER_MS);
+    await sleep(WAIT_FOR_TABS_MS);
   }
   log('travis', '\n');
 }

--- a/examples/visual-tests/amp-sticky-ad/amp-sticky-ad.amp.html
+++ b/examples/visual-tests/amp-sticky-ad/amp-sticky-ad.amp.html
@@ -11,9 +11,10 @@
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <script>
-window.setTimeout(function() {
+window.setInterval(function() {
+  window.scrollTo(0, 100);
   window.scrollTo(0, 200);
-}, 300);
+}, 100);
   </script>
 </head>
 <body>

--- a/test/visual-diff/visual-tests
+++ b/test/visual-diff/visual-tests
@@ -185,7 +185,7 @@
         "width": 400,
         "height": 600
       },
-      "loading_complete_css": ["amp-sticky-ad[visible]"],
+      "loading_complete_delay_ms": 500,
       "enable_percy_javascript": true
     },
     {

--- a/test/visual-diff/visual-tests
+++ b/test/visual-diff/visual-tests
@@ -80,13 +80,6 @@
    *   // allow CSS transitions or other effects to complete.
    *   "loading_complete_delay_ms": 1000,
    *
-   *   // [optional] Experiments that must be enabled via cookies.
-   *   "experiments": [
-   *     "amp-feature-one",
-   *     "amp-feature-two"
-   *   ],
-   *
-   *
    *   // [optional, EXPERIMENTAL] Allow running "dirty" JavaScript code on
    *   // on Percy in this AMP page. The code being executed *must* be inlined
    *   // inside a <script> tag, not be an externally loaded script via a
@@ -178,8 +171,7 @@
     },
     {
       "url": "examples/visual-tests/amp-lightbox-gallery.html",
-      "name": "amp-lightbox-gallery - article",
-      "experiments": ["amp-lightbox-gallery"]
+      "name": "amp-lightbox-gallery - article"
     },
     {
       "url": "examples/visual-tests/video/rotate-to-fullscreen.html",

--- a/test/visual-diff/visual-tests
+++ b/test/visual-diff/visual-tests
@@ -157,8 +157,8 @@
       "name": "AMP Article",
       "loading_complete_css": [
         ".article-body",
-        ".ad-one",
-        ".ad-two"
+        ".ad-one div[placeholder].amp-hidden",
+        ".ad-two div[placeholder].amp-hidden"
       ]
     },
     {


### PR DESCRIPTION
This should speed up processing time without increasing computation by much, since most of the time is wasted on waiting for navigation to finish.

Unfortunately when I run these locally I'm getting flakes, e.g. see these two builds:
* https://percy.io/ampproject/danielrozenberg/builds/892614
* https://percy.io/ampproject/danielrozenberg/builds/892649

I'm not sure why these flakes appear now but didn't appear before. e.g., the video loading progress bar in `amp-video`. Any guesses as to why those happen now but didn't happen before?

I'll let this run on Travis as well, maybe Travis will be better :)