### PR TITLE
Don't instantiate amp-story-consent in amp-story tests.

### DIFF
--- a/extensions/amp-story/1.0/test/test-amp-story.js
+++ b/extensions/amp-story/1.0/test/test-amp-story.js
@@ -22,6 +22,7 @@ import {
   StateProperty,
 } from '../amp-story-store-service';
 import {AmpStory} from '../amp-story';
+import {AmpStoryConsent} from '../amp-story-consent';
 import {EventType} from '../events';
 import {KeyCodes} from '../../../../src/utils/key-codes';
 import {LocalizationService} from '../localization';
@@ -395,6 +396,13 @@ describes.realWin('amp-story', {
 
   describe('amp-story consent', () => {
     it('should pause the story if there is a consent', () => {
+      sandbox.stub(Services, 'actionServiceForDoc')
+          .returns({setWhitelist: () => {}, trigger: () => {}});
+
+      // Prevents amp-story-consent element from running code that is irrelevant
+      // to this test.
+      sandbox.stub(AmpStoryConsent.prototype, 'buildCallback');
+
       const consentEl = win.document.createElement('amp-consent');
       const storyConsentEl = win.document.createElement('amp-story-consent');
       consentEl.appendChild(storyConsentEl);
@@ -428,6 +436,13 @@ describes.realWin('amp-story', {
     });
 
     it('should play the story after the consent is resolved', () => {
+      sandbox.stub(Services, 'actionServiceForDoc')
+          .returns({setWhitelist: () => {}, trigger: () => {}});
+
+      // Prevents amp-story-consent element from running code that is irrelevant
+      // to this test.
+      sandbox.stub(AmpStoryConsent.prototype, 'buildCallback');
+
       const consentEl = win.document.createElement('amp-consent');
       const storyConsentEl = win.document.createElement('amp-story-consent');
       consentEl.appendChild(storyConsentEl);
@@ -469,6 +484,13 @@ describes.realWin('amp-story', {
     });
 
     it('should play the story if the consent was already resolved', () => {
+      sandbox.stub(Services, 'actionServiceForDoc')
+          .returns({setWhitelist: () => {}, trigger: () => {}});
+
+      // Prevents amp-story-consent element from running code that is irrelevant
+      // to this test.
+      sandbox.stub(AmpStoryConsent.prototype, 'buildCallback');
+
       const consentEl = win.document.createElement('amp-consent');
       const storyConsentEl = win.document.createElement('amp-story-consent');
       consentEl.appendChild(storyConsentEl);


### PR DESCRIPTION
Don't instantiate `amp-story-consent` in `amp-story` tests. It leads to various issues caused by `amp-story-consent` not being connected when it's instantiated, that silently skips all the following tests (or at least their reporting).

Context: https://github.com/ampproject/amphtml/issues/15658#issuecomment-408226428