### PR TITLE
Allow image viewer to correctly relayout after unlayoutCallback

### DIFF
--- a/extensions/amp-image-viewer/0.1/amp-image-viewer.js
+++ b/extensions/amp-image-viewer/0.1/amp-image-viewer.js
@@ -148,9 +148,12 @@ export class AmpImageViewer extends AMP.BaseElement {
     if (this.loadPromise_) {
       return this.loadPromise_;
     }
+    const laidOutPromise =
+      elementByTag(this.sourceAmpImage_, 'i-amphtml-sizer') !== null
+        ? Promise.resolve()
+        : this.sourceAmpImage_.signals().whenSignal(CommonSignals.LOAD_END);
     this.scheduleLayout(dev().assertElement(this.sourceAmpImage_));
-    this.loadPromise_ = this.sourceAmpImage_.signals()
-        .whenSignal(CommonSignals.LOAD_END)
+    this.loadPromise_ = laidOutPromise
         .then(() => this.init_())
         .then(() => this.resetImageDimensions_())
         .then(() => this.setupGestures_());


### PR DESCRIPTION
Closes https://github.com/ampproject/amphtml/issues/17044. 
`<amp-image-viewer>`'s `layoutCallback` doesn't work after `unlayoutCallback`. Surprisingly it seems that closing `<amp-lightbox-gallery>` never resulted in `<amp-image-viewer>`'s `unlayoutCallback` being called until recently, which exposed this bug. 