### PR TITLE
📉Set url macro experiment to zero.

### DIFF
--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -40,6 +40,6 @@
   "expAdsenseCanonical": 0,
   "font-display-swap": 1,
   "amp-date-picker": 1,
-  "url-replacement-v2": 0.5,
+  "url-replacement-v2": 0,
   "inline-styles": 1
 }


### PR DESCRIPTION
Due to regressions in short macro names as outlined in #16917 we are disabling this experiment until the fix hits prod.