### PR TITLE
[WIP] native form usage in non-standard AMP 

### DIFF
--- a/examples/forms.amp.html
+++ b/examples/forms.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html>
 <head>
     <meta charset="utf-8">
     <title>Forms Examples in AMP</title>

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -432,6 +432,17 @@ export class AmpForm {
       event.preventDefault();
     }
 
+    this.validateFormAttributes_();
+
+    // Submits caused by user input have high trust.
+    this.submit_(ActionTrust.HIGH);
+  }
+
+  /**
+   * Validates the form's attributes.
+   */
+  validateFormAttributes_() {
+    const {form_} = this;
     const action = form_.getAttribute('action');
     const actionXhr = form_.getAttribute('action-xhr');
     const method = (form_.getAttribute('method') || 'GET').toUpperCase();
@@ -477,11 +488,7 @@ export class AmpForm {
     } else {
       form_.setAttribute('target', '_top');
     }
-
-    // Submits caused by user input have high trust.
-    this.submit_(ActionTrust.HIGH);
   }
-
   /**
    * Helper method that actual handles the different cases (post, get, xhr...).
    * @param {ActionTrust} trust

--- a/src/document-submit.js
+++ b/src/document-submit.js
@@ -14,129 +14,31 @@
  * limitations under the License.
  */
 
-import {ActionTrust} from './action-constants';
-import {
-  SOURCE_ORIGIN_PARAM,
-  assertHttpsUrl,
-  checkCorsUrl,
-  isProxyOrigin,
-} from './url';
-import {Services} from './services';
-import {dev, user} from './log';
-import {isExperimentOn} from './experiments';
+import {dev} from './log';
 
 /**
  * @param {!./service/ampdoc-impl.AmpDoc} ampdoc
  */
 export function installGlobalSubmitListenerForDoc(ampdoc) {
-  if (!isExperimentOn(self, 'dirty-amp')) {
-    return;
-  }
-  ampdoc.getRootNode().addEventListener('submit', onDocumentFormSubmit_, true);
+  ampdoc.getRootNode().addEventListener(
+      'submit', onDocumentFormSubmit_.bind(this, ampdoc.isDirtyAmp()), true);
 }
 
-
 /**
- * Intercept any submit on the current document and prevent invalid submits from
- * going through.
+ * If a valid AMP page, we prohibit usage of the non amp form element, thus
+ * intercept any submit on the current document and prevent invalid submits
+ * from going through.
  *
+ * @param {boolean} isDirtyAmp
  * @param {!Event} e
  */
-export function onDocumentFormSubmit_(e) {
-  if (e.defaultPrevented) {
+export function onDocumentFormSubmit_(isDirtyAmp, e) {
+  if (e.defaultPrevented || isDirtyAmp) {
     return;
   }
 
   const form = dev().assertElement(e.target);
   if (!form || form.tagName != 'FORM') {
     return;
-  }
-
-  // amp-form extension will add novalidate to all forms to manually trigger
-  // validation. In that case `novalidate` doesn't have the same meaning.
-  const isAmpFormMarked = form.classList.contains('i-amphtml-form');
-  let shouldValidate;
-  if (isAmpFormMarked) {
-    shouldValidate = !form.hasAttribute('amp-novalidate');
-  } else {
-    shouldValidate = !form.hasAttribute('novalidate');
-  }
-
-  // Safari does not trigger validation check on submission, hence we
-  // trigger it manually. In other browsers this would never execute since
-  // the submit event wouldn't be fired if the form is invalid.
-  if (shouldValidate && form.checkValidity && !form.checkValidity()) {
-    e.preventDefault();
-  }
-
-  const inputs = form.elements;
-  for (let i = 0; i < inputs.length; i++) {
-    user().assert(!inputs[i].name ||
-        inputs[i].name != SOURCE_ORIGIN_PARAM,
-    'Illegal input name, %s found: %s', SOURCE_ORIGIN_PARAM, inputs[i]);
-  }
-
-  const action = form.getAttribute('action');
-  const actionXhr = form.getAttribute('action-xhr');
-  const method = (form.getAttribute('method') || 'GET').toUpperCase();
-
-  if (actionXhr) {
-    assertHttpsUrl(actionXhr, form, 'action-xhr');
-    user().assert(!isProxyOrigin(actionXhr),
-        'form action-xhr should not be on AMP CDN: %s', form);
-    checkCorsUrl(actionXhr);
-  }
-  if (action) {
-    assertHttpsUrl(action, form, 'action');
-    user().assert(!isProxyOrigin(action),
-        'form action should not be on AMP CDN: %s', form);
-    checkCorsUrl(action);
-  }
-
-  if (method == 'GET') {
-    user().assert(actionXhr || action,
-        'form action-xhr or action attribute is required for method=GET: %s',
-        form);
-  } else if (method == 'POST') {
-    if (action) {
-      const TAG = 'form';
-      user().error(TAG,
-          'action attribute is invalid for method=POST: %s', form);
-    }
-
-    if (!actionXhr) {
-      e.preventDefault();
-      user().assert(false,
-          'Only XHR based (via action-xhr attribute) submissions are support ' +
-          'for POST requests. %s',
-          form);
-    }
-  }
-
-  const target = form.getAttribute('target');
-  if (target) {
-    user().assert(target == '_blank' || target == '_top',
-        'form target=%s is invalid can only be _blank or _top: %s',
-        target, form);
-  } else {
-    form.setAttribute('target', '_top');
-  }
-
-  // For xhr submissions relay the submission event through action service to
-  // allow us to wait for amp-form (and possibly its dependencies) to execute
-  // the actual submission. For non-XHR GET we let the submission go through
-  // to allow _blank target to work.
-  if (actionXhr) {
-    e.preventDefault();
-
-    // It's important to stop propagation of the submission to avoid double
-    // handling of the event in cases were we are delegating to action service
-    // to deliver the submission event.
-    e.stopImmediatePropagation();
-
-    const actions = Services.actionServiceForDoc(form);
-    actions.execute(
-        form, 'submit', /*args*/ null, /*source*/ form, /*caller*/ form, e,
-        ActionTrust.HIGH);
   }
 }

--- a/src/document-submit.js
+++ b/src/document-submit.js
@@ -23,11 +23,15 @@ import {
 } from './url';
 import {Services} from './services';
 import {dev, user} from './log';
+import {isExperimentOn} from './experiments';
 
 /**
  * @param {!./service/ampdoc-impl.AmpDoc} ampdoc
  */
 export function installGlobalSubmitListenerForDoc(ampdoc) {
+  if (!isExperimentOn(self, 'dirty-amp')) {
+    return;
+  }
   ampdoc.getRootNode().addEventListener('submit', onDocumentFormSubmit_, true);
 }
 

--- a/src/service/ampdoc-impl.js
+++ b/src/service/ampdoc-impl.js
@@ -214,6 +214,13 @@ export class AmpDoc {
   }
 
   /**
+   * Whether the runtime should recognize this document as an intended invalid
+   * amp page.
+   * @return {boolean}
+   */
+  isDirtyAmp() {}
+
+  /**
    * Whether the runtime in the single-doc mode. Alternative is the shadow-doc
    * mode that supports multiple documents per a single window.
    * @return {boolean}
@@ -376,6 +383,12 @@ export class AmpDocSingle extends AmpDoc {
   }
 
   /** @override */
+  isDirtyAmp() {
+    const docElement = this.win.document.documentElement;
+    return !(docElement.hasAttribute('amp') || docElement.hasAttribute('⚡'));
+  }
+
+  /** @override */
   isSingleDoc() {
     return true;
   }
@@ -461,6 +474,11 @@ export class AmpDocShadow extends AmpDoc {
 
     /** @private {function()|undefined} */
     this.readyResolver_ = readyDeferred.resolve;
+  }
+
+  /** @override */
+  isDirtyAmp() {
+    return /** @type {?} */ (dev().assert(null, 'not implemented'));
   }
 
   /** @override */

--- a/src/service/ampdoc-impl.js
+++ b/src/service/ampdoc-impl.js
@@ -215,10 +215,10 @@ export class AmpDoc {
 
   /**
    * Whether the runtime should recognize this document as an intended invalid
-   * amp page.
+   * amp page. This is triggered by the absense of 'amp' or '⚡' in the html tag.
    * @return {boolean}
    */
-  isDirtyAmp() {}
+  isNonStandardAmp() {}
 
   /**
    * Whether the runtime in the single-doc mode. Alternative is the shadow-doc
@@ -383,7 +383,7 @@ export class AmpDocSingle extends AmpDoc {
   }
 
   /** @override */
-  isDirtyAmp() {
+  isNonStandardAmp() {
     const docElement = this.win.document.documentElement;
     return !(docElement.hasAttribute('amp') || docElement.hasAttribute('⚡'));
   }
@@ -477,7 +477,7 @@ export class AmpDocShadow extends AmpDoc {
   }
 
   /** @override */
-  isDirtyAmp() {
+  isNonStandardAmp() {
     return /** @type {?} */ (dev().assert(null, 'not implemented'));
   }
 

--- a/src/service/document-info-impl.js
+++ b/src/service/document-info-impl.js
@@ -88,6 +88,7 @@ export class DocInfo {
         ? parseUrlDeprecated(canonicalTag.href).href
         : sourceUrl;
     }
+
     const pageViewId = getPageViewId(ampdoc.win);
     const linkRels = getLinkRels(ampdoc.win.document);
     const metaTags = getMetaTags(ampdoc.win.document);


### PR DESCRIPTION
allow usage of native non-amp forms in non-standard AMP

- move logic specific to form submission from document-submit.js to amp-form.
- dont' hijack native form submission if ampdoc is non-standard. That is if 'amp' or '⚡' is missing in the html tag.

Fixes: #16761 
