### PR TITLE
🖍 Style tweaks for amp-story

### DIFF
--- a/extensions/amp-story/1.0/amp-story-user-overridable.css
+++ b/extensions/amp-story/1.0/amp-story-user-overridable.css
@@ -18,6 +18,12 @@ amp-story {
   font-display: optional;
 }
 
+.i-amphtml-story-grid-template-fill > amp-anim img,
+.i-amphtml-story-grid-template-fill > amp-img img,
+.i-amphtml-story-grid-template-fill > amp-video video {
+  object-fit: cover;
+}
+
 .i-amphtml-story-grid-template-vertical {
   align-content: start;
   grid-gap: 16px;

--- a/extensions/amp-story/1.0/amp-story-user-overridable.css
+++ b/extensions/amp-story/1.0/amp-story-user-overridable.css
@@ -18,6 +18,11 @@ amp-story {
   font-display: optional;
 }
 
+amp-story-grid-layer * {
+  box-sizing: border-box;
+  margin: 0;
+}
+
 .i-amphtml-story-grid-template-fill > amp-anim img,
 .i-amphtml-story-grid-template-fill > amp-img img,
 .i-amphtml-story-grid-template-fill > amp-video video {

--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -304,12 +304,6 @@ amp-story-grid-layer * {
   width: auto !important;
 }
 
-.i-amphtml-story-grid-template-fill > amp-anim img,
-.i-amphtml-story-grid-template-fill > amp-img img,
-.i-amphtml-story-grid-template-fill > amp-video video {
-  object-fit: cover !important;
-}
-
 .i-amphtml-story-grid-template-vertical {
   grid-auto-flow: row !important;
   grid-template-columns: 100% !important;

--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -273,11 +273,6 @@ amp-story-grid-layer {
   z-index: 2 !important;
 }
 
-amp-story-grid-layer * {
-  box-sizing: border-box !important;
-  margin: 0 !important;
-}
-
 .i-amphtml-story-grid-template-with-full-bleed-animation {
   position: absolute !important;
   display: block !important;

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -212,10 +212,8 @@ export class AmpStory extends AMP.BaseElement {
     /** @private @const {!UnsupportedBrowserLayer} */
     this.unsupportedBrowserLayer_ = new UnsupportedBrowserLayer(this.win);
 
-    if (!isExperimentOn(this.win, 'disable-amp-story-desktop')) {
-      /** Instantiates the viewport warning layer. */
-      new ViewportWarningLayer(this.win, this.element);
-    }
+    /** Instantiates the viewport warning layer. */
+    new ViewportWarningLayer(this.win, this.element);
 
     /** @private @const {!Array<!./amp-story-page.AmpStoryPage>} */
     this.pages_ = [];

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -212,8 +212,10 @@ export class AmpStory extends AMP.BaseElement {
     /** @private @const {!UnsupportedBrowserLayer} */
     this.unsupportedBrowserLayer_ = new UnsupportedBrowserLayer(this.win);
 
-    /** Instantiates the viewport warning layer. */
-    new ViewportWarningLayer(this.win, this.element);
+    if (!isExperimentOn(this.win, 'disable-amp-story-desktop')) {
+      /** Instantiates the viewport warning layer. */
+      new ViewportWarningLayer(this.win, this.element);
+    }
 
     /** @private @const {!Array<!./amp-story-page.AmpStoryPage>} */
     this.pages_ = [];


### PR DESCRIPTION
- Do not show the viewport warning overlay if the `disable-amp-story-desktop` experiment is enabled
- Allow overriding the `object-fit` property for images/videos that are children of `amp-story-grid-layer[template="fill"]`