### PR TITLE
Desktop scroll experience experiment.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-hint.js
+++ b/extensions/amp-story/1.0/amp-story-hint.js
@@ -17,7 +17,11 @@
 import {CSS} from '../../../build/amp-story-hint-1.0.css';
 import {LocalizedStringId} from './localization';
 import {Services} from '../../../src/services';
-import {StateProperty, getStoreService} from './amp-story-store-service';
+import {
+  StateProperty,
+  UIType,
+  getStoreService,
+} from './amp-story-store-service';
 import {createShadowRootWithStyle} from './utils';
 import {dict} from '../../../src/utils/object';
 import {renderAsElement} from './simple-template';
@@ -183,7 +187,7 @@ export class AmpStoryHint {
    * @private
    */
   showHint_(hintClass) {
-    if (this.storeService_.get(StateProperty.DESKTOP_STATE)) {
+    if (this.storeService_.get(StateProperty.UI_STATE) !== UIType.MOBILE) {
       return;
     }
 

--- a/extensions/amp-story/1.0/amp-story-scroll.css
+++ b/extensions/amp-story/1.0/amp-story-scroll.css
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+amp-story[scroll] {
+  contain: none !important;
+}
+
+[scroll] amp-story-page {
+  position: relative !important;
+  height: 100vh !important;
+}
+
+amp-story[scroll] > amp-story-page.i-amphtml-layout-container[distance] {
+  transform: none !important;
+}

--- a/extensions/amp-story/1.0/amp-story-store-service.js
+++ b/extensions/amp-story/1.0/amp-story-store-service.js
@@ -46,6 +46,17 @@ export const getStoreService = win => {
 
 
 /**
+ * Different UI experiences to display the story.
+ * @const @enum {number}
+ */
+export const UIType = {
+  MOBILE: 0,
+  DESKTOP: 1,
+  SCROLL: 2,
+};
+
+
+/**
  * @typedef {{
  *    caninsertautomaticad: boolean,
  *    canshowbookend: boolean,
@@ -65,6 +76,7 @@ export const getStoreService = win => {
  *    rtlstate: boolean,
  *    sharemenustate: boolean,
  *    supportedbrowserstate: boolean,
+ *    uistate: !UIType,
  *    consentid: ?string,
  *    currentpageid: string,
  * }}
@@ -95,6 +107,7 @@ export const StateProperty = {
   RTL_STATE: 'rtlstate',
   SHARE_MENU_STATE: 'sharemenustate',
   SUPPORTED_BROWSER_STATE: 'supportedbrowserstate',
+  UI_STATE: 'uistate',
 
   // App data.
   CONSENT_ID: 'consentid',
@@ -110,7 +123,6 @@ export const Action = {
   TOGGLE_ACCESS: 'toggleaccess',
   TOGGLE_AD: 'togglead',
   TOGGLE_BOOKEND: 'togglebookend',
-  TOGGLE_DESKTOP: 'toggledesktop',
   TOGGLE_INFO_DIALOG: 'toggleinfodialog',
   TOGGLE_HAS_AUDIO: 'togglehasaudio',
   TOGGLE_LANDSCAPE: 'togglelandscape',
@@ -119,6 +131,7 @@ export const Action = {
   TOGGLE_RTL: 'togglertl',
   TOGGLE_SHARE_MENU: 'togglesharemenu',
   TOGGLE_SUPPORTED_BROWSER: 'togglesupportedbrowser',
+  TOGGLE_UI: 'toggleui',
 };
 
 
@@ -149,10 +162,6 @@ const actions = (state, action, data) => {
       }
       return /** @type {!State} */ (Object.assign(
           {}, state, {[StateProperty.BOOKEND_STATE]: !!data}));
-    // Triggers the desktop UI.
-    case Action.TOGGLE_DESKTOP:
-      return /** @type {!State} */ (Object.assign(
-          {}, state, {[StateProperty.DESKTOP_STATE]: !!data}));
     // Shows or hides the info dialog.
     case Action.TOGGLE_INFO_DIALOG:
       return /** @type {!State} */ (Object.assign(
@@ -174,6 +183,9 @@ const actions = (state, action, data) => {
     case Action.TOGGLE_PAUSED:
       return /** @type {!State} */ (Object.assign(
           {}, state, {[StateProperty.PAUSED_STATE]: !!data}));
+    case Action.TOGGLE_RTL:
+      return /** @type {!State} */ (Object.assign(
+          {}, state, {[StateProperty.RTL_STATE]: !!data}));
     case Action.TOGGLE_SUPPORTED_BROWSER:
       return /** @type {!State} */ (Object.assign(
           {}, state, {[StateProperty.SUPPORTED_BROWSER_STATE]: !!data}));
@@ -183,10 +195,13 @@ const actions = (state, action, data) => {
             [StateProperty.PAUSED_STATE]: !!data,
             [StateProperty.SHARE_MENU_STATE]: !!data,
           }));
-    // Triggers right to left experience.
-    case Action.TOGGLE_RTL:
+    case Action.TOGGLE_UI:
       return /** @type {!State} */ (Object.assign(
-          {}, state, {[StateProperty.RTL_STATE]: !!data}));
+          {}, state, {
+            // Keep DESKTOP_STATE for compatiblity with v0.1.
+            [StateProperty.DESKTOP_STATE]: data === UIType.DESKTOP,
+            [StateProperty.UI_STATE]: data,
+          }));
     case Action.SET_CONSENT_ID:
       return /** @type {!State} */ (Object.assign(
           {}, state, {[StateProperty.CONSENT_ID]: data}));
@@ -301,6 +316,7 @@ export class AmpStoryStoreService {
       [StateProperty.RTL_STATE]: false,
       [StateProperty.SHARE_MENU_STATE]: false,
       [StateProperty.SUPPORTED_BROWSER_STATE]: true,
+      [StateProperty.UI_STATE]: UIType.MOBILE,
       [StateProperty.CONSENT_ID]: null,
       [StateProperty.CURRENT_PAGE_ID]: '',
       [StateProperty.CURRENT_PAGE_INDEX]: 0,

--- a/extensions/amp-story/1.0/amp-story-system-layer.js
+++ b/extensions/amp-story/1.0/amp-story-system-layer.js
@@ -16,6 +16,7 @@
 import {
   Action,
   StateProperty,
+  UIType,
   getStoreService,
 } from './amp-story-store-service';
 import {CSS} from '../../../build/amp-story-system-layer-1.0.css';
@@ -264,16 +265,16 @@ export class SystemLayer {
       this.onCanShowSharingUisUpdate_(show);
     }, true /** callToInitialize */);
 
-    this.storeService_.subscribe(StateProperty.DESKTOP_STATE, isDesktop => {
-      this.onDesktopStateUpdate_(isDesktop);
-    }, true /** callToInitialize */);
-
     this.storeService_.subscribe(StateProperty.HAS_AUDIO_STATE, hasAudio => {
       this.onHasAudioStateUpdate_(hasAudio);
     }, true /** callToInitialize */);
 
     this.storeService_.subscribe(StateProperty.MUTED_STATE, isMuted => {
       this.onMutedStateUpdate_(isMuted);
+    }, true /** callToInitialize */);
+
+    this.storeService_.subscribe(StateProperty.UI_STATE, isDesktop => {
+      this.onUIStateUpdate_(isDesktop);
     }, true /** callToInitialize */);
 
     this.storeService_.subscribe(StateProperty.CURRENT_PAGE_INDEX, index => {
@@ -336,23 +337,6 @@ export class SystemLayer {
   }
 
   /**
-   * Reacts to desktop state updates and triggers the desktop UI.
-   * @param {boolean} isDesktop
-   * @private
-   */
-  onDesktopStateUpdate_(isDesktop) {
-    if (isDesktop) {
-      this.buildSharePill_();
-    }
-
-    this.vsync_.mutate(() => {
-      isDesktop ?
-        this.getShadowRoot().setAttribute('desktop', '') :
-        this.getShadowRoot().removeAttribute('desktop');
-    });
-  }
-
-  /**
    * Reacts to has audio state updates, displays the audio controls if needed.
    * @param {boolean} hasAudio
    * @private
@@ -373,6 +357,23 @@ export class SystemLayer {
       isMuted ?
         this.getShadowRoot().setAttribute(AUDIO_MUTED_ATTRIBUTE, '') :
         this.getShadowRoot().removeAttribute(AUDIO_MUTED_ATTRIBUTE);
+    });
+  }
+
+  /**
+   * Reacts to desktop state updates and triggers the desktop UI.
+   * @param {!UIType} uiState
+   * @private
+   */
+  onUIStateUpdate_(uiState) {
+    if ([UIType.SCROLL, UIType.DESKTOP].includes(uiState)) {
+      this.buildSharePill_();
+    }
+
+    this.vsync_.mutate(() => {
+      uiState === UIType.DESKTOP ?
+        this.getShadowRoot().setAttribute('desktop', '') :
+        this.getShadowRoot().removeAttribute('desktop');
     });
   }
 

--- a/extensions/amp-story/1.0/amp-story-viewport-warning-layer.js
+++ b/extensions/amp-story/1.0/amp-story-viewport-warning-layer.js
@@ -150,7 +150,8 @@ export class ViewportWarningLayer {
     createShadowRootWithStyle(root, this.overlayEl_, CSS);
 
     // Initializes the UI state now that the component is built.
-    this.onUIStateUpdate_(this.storeService_.get(StateProperty.UI_STATE));
+    this.onUIStateUpdate_(/** @type {!UIType} */
+        (this.storeService_.get(StateProperty.UI_STATE)));
 
     this.vsync_.mutate(() => {
       this.storyElement_.insertBefore(root, this.storyElement_.firstChild);

--- a/extensions/amp-story/1.0/amp-story-viewport-warning-layer.js
+++ b/extensions/amp-story/1.0/amp-story-viewport-warning-layer.js
@@ -17,7 +17,11 @@
 import {CSS} from '../../../build/amp-story-viewport-warning-layer-1.0.css';
 import {LocalizedStringId} from './localization';
 import {Services} from '../../../src/services';
-import {StateProperty, getStoreService} from './amp-story-store-service';
+import {
+  StateProperty,
+  UIType,
+  getStoreService,
+} from './amp-story-store-service';
 import {createShadowRootWithStyle} from './utils';
 import {dict} from './../../../src/utils/object';
 import {isExperimentOn} from '../../../src/experiments';
@@ -145,9 +149,8 @@ export class ViewportWarningLayer {
 
     createShadowRootWithStyle(root, this.overlayEl_, CSS);
 
-    // Initializes the desktop state now that the component is built.
-    this.onDesktopStateUpdate_(
-        !!this.storeService_.get(StateProperty.DESKTOP_STATE));
+    // Initializes the UI state now that the component is built.
+    this.onUIStateUpdate_(this.storeService_.get(StateProperty.UI_STATE));
 
     this.vsync_.mutate(() => {
       this.storyElement_.insertBefore(root, this.storyElement_.firstChild);
@@ -166,8 +169,8 @@ export class ViewportWarningLayer {
    * @private
    */
   initializeListeners_() {
-    this.storeService_.subscribe(StateProperty.DESKTOP_STATE, isDesktop => {
-      this.onDesktopStateUpdate_(isDesktop);
+    this.storeService_.subscribe(StateProperty.UI_STATE, uiState => {
+      this.onUIStateUpdate_(uiState);
     }, true /** callToInitialize */);
 
     this.storeService_.subscribe(StateProperty.LANDSCAPE_STATE, isLandscape => {
@@ -181,10 +184,11 @@ export class ViewportWarningLayer {
    * @private
    */
   onLandscapeStateUpdate_(isLandscape) {
-    const isDesktop = this.storeService_.get(StateProperty.DESKTOP_STATE);
+    const isMobile =
+        this.storeService_.get(StateProperty.UI_STATE) === UIType.MOBILE;
 
     // Adds the landscape class if we are mobile landscape.
-    const shouldShowLandscapeOverlay = !isDesktop && isLandscape;
+    const shouldShowLandscapeOverlay = isMobile && isLandscape;
 
     // Don't build the layer until we need to display it.
     if (!shouldShowLandscapeOverlay && !this.isBuilt()) {
@@ -194,23 +198,23 @@ export class ViewportWarningLayer {
     this.build();
 
     this.vsync_.mutate(() => {
-      this.overlayEl_
-          .classList.toggle(LANDSCAPE_OVERLAY_CLASS, !isDesktop && isLandscape);
+      this.overlayEl_.classList.toggle(
+          LANDSCAPE_OVERLAY_CLASS, shouldShowLandscapeOverlay);
     });
   }
 
   /**
-   * Reacts to desktop state updates.
-   * @param {boolean} isDesktop
+   * Reacts to UI state updates.
+   * @param {!UIType} uiState
    * @private
    */
-  onDesktopStateUpdate_(isDesktop) {
+  onUIStateUpdate_(uiState) {
     if (!this.isBuilt()) {
       return;
     }
 
     this.vsync_.mutate(() => {
-      isDesktop ?
+      uiState === UIType.DESKTOP ?
         this.overlayEl_.setAttribute('desktop', '') :
         this.overlayEl_.removeAttribute('desktop');
     });

--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -15,6 +15,7 @@
  */
 
 @import './amp-story-access.css';
+@import './amp-story-scroll.css';
 @import './amp-story-desktop.css';
 @import './amp-story-user-overridable.css';
 

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -30,6 +30,7 @@ import './amp-story-page';
 import {
   Action,
   StateProperty,
+  UIType,
   getStoreService,
 } from './amp-story-store-service';
 import {ActionTrust} from '../../../src/action-constants';
@@ -329,7 +330,10 @@ export class AmpStory extends AMP.BaseElement {
     this.initializeListenersForDev_();
 
     if (this.isDesktop_()) {
-      this.storeService_.dispatch(Action.TOGGLE_DESKTOP, true);
+      const uiState =
+          isExperimentOn(this.win, 'amp-story-scroll') ?
+              UIType.SCROLL : UIType.DESKTOP;
+      this.storeService_.dispatch(Action.TOGGLE_UI, uiState);
     }
 
     this.navigationState_.observe(stateChangeEvent => {
@@ -531,13 +535,13 @@ export class AmpStory extends AMP.BaseElement {
       this.onCurrentPageIdUpdate_(pageId);
     });
 
-    this.storeService_.subscribe(StateProperty.DESKTOP_STATE, isDesktop => {
-      this.onDesktopStateUpdate_(isDesktop);
-    }, true /** callToInitialize */);
-
     this.storeService_.subscribe(StateProperty.PAUSED_STATE, isPaused => {
       this.onPausedStateUpdate_(isPaused);
     });
+
+    this.storeService_.subscribe(StateProperty.UI_STATE, uiState => {
+      this.onUIStateUpdate_(uiState);
+    }, true /** callToInitialize */);
 
     this.win.document.addEventListener('keydown', e => {
       this.onKeyDown_(e);
@@ -692,8 +696,8 @@ export class AmpStory extends AMP.BaseElement {
         .then(() => {
           // Preloads and prerenders the share menu if mobile, where the share
           // button is visible.
-
-          if (!this.storeService_.get(StateProperty.DESKTOP_STATE)) {
+          const uiState = this.storeService_.get(StateProperty.UI_STATE);
+          if (uiState === UIType.MOBILE) {
             this.shareMenu_.build();
           }
 
@@ -1215,10 +1219,16 @@ export class AmpStory extends AMP.BaseElement {
   onResize() {
     this.updateViewportSizeStyles_();
 
-    const isDesktop = this.isDesktop_();
-    this.storeService_.dispatch(Action.TOGGLE_DESKTOP, isDesktop);
+    let uiState = UIType.MOBILE;
 
-    if (isDesktop) {
+    if (this.isDesktop_()) {
+      uiState = isExperimentOn(this.win, 'amp-story-scroll') ?
+          UIType.SCROLL : UIType.DESKTOP;
+    }
+
+    this.storeService_.dispatch(Action.TOGGLE_UI, uiState);
+
+    if (uiState !== UIType.MOBILE) {
       this.storeService_.dispatch(Action.TOGGLE_LANDSCAPE, false);
       return;
     }
@@ -1260,30 +1270,39 @@ export class AmpStory extends AMP.BaseElement {
   }
 
   /**
-   * Reacts to desktop state updates.
-   * @param {boolean} isDesktop
+   * Reacts to UI state updates.
+   * @param {!UIType} uiState
    * @private
    */
-  onDesktopStateUpdate_(isDesktop) {
-    if (isDesktop) {
-      this.vsync_.mutate(() => {
-        this.element.setAttribute('desktop', '');
-      });
-      if (!this.background_) {
-        this.background_ = new AmpStoryBackground(this.win, this.element);
-        this.background_.attach();
-      }
-      if (this.activePage_) {
-        this.updateBackground_(this.activePage_.element, /* initial */ true);
-      }
-    } else {
-      // Preloads and prerenders the share menu as the share button gets visible
-      // on the mobile UI. No-op if already built.
-      this.shareMenu_.build();
+  onUIStateUpdate_(uiState) {
+    this.vsync_.mutate(() => {
+      this.element.removeAttribute('desktop');
+      this.element.removeAttribute('scroll');
+    });
 
-      this.vsync_.mutate(() => {
-        this.element.removeAttribute('desktop');
-      });
+    switch (uiState) {
+      case UIType.MOBILE:
+        // Preloads and prerenders the share menu as the share button gets
+        // visible on the mobile UI. No-op if already built.
+        this.shareMenu_.build();
+        break;
+      case UIType.DESKTOP:
+        this.vsync_.mutate(() => {
+          this.element.setAttribute('desktop', '');
+        });
+        if (!this.background_) {
+          this.background_ = new AmpStoryBackground(this.win, this.element);
+          this.background_.attach();
+        }
+        if (this.activePage_) {
+          this.updateBackground_(this.activePage_.element, /* initial */ true);
+        }
+        break;
+      case UIType.SCROLL:
+        this.vsync_.mutate(() => {
+          this.element.setAttribute('scroll', '');
+        });
+        break;
     }
   }
 

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -332,7 +332,7 @@ export class AmpStory extends AMP.BaseElement {
     if (this.isDesktop_()) {
       const uiState =
           isExperimentOn(this.win, 'amp-story-scroll') ?
-              UIType.SCROLL : UIType.DESKTOP;
+            UIType.SCROLL : UIType.DESKTOP;
       this.storeService_.dispatch(Action.TOGGLE_UI, uiState);
     }
 
@@ -1223,7 +1223,7 @@ export class AmpStory extends AMP.BaseElement {
 
     if (this.isDesktop_()) {
       uiState = isExperimentOn(this.win, 'amp-story-scroll') ?
-          UIType.SCROLL : UIType.DESKTOP;
+        UIType.SCROLL : UIType.DESKTOP;
     }
 
     this.storeService_.dispatch(Action.TOGGLE_UI, uiState);

--- a/extensions/amp-story/1.0/bookend/amp-story-bookend.js
+++ b/extensions/amp-story/1.0/bookend/amp-story-bookend.js
@@ -17,6 +17,7 @@
 import {
   Action,
   StateProperty,
+  UIType,
   getStoreService,
 } from '../amp-story-store-service';
 import {ActionTrust} from '../../../../src/action-constants';
@@ -282,8 +283,8 @@ export class AmpStoryBookend extends AMP.BaseElement {
       this.onCanShowSharingUisUpdate_(show);
     }, true /** callToInitialize */);
 
-    this.storeService_.subscribe(StateProperty.DESKTOP_STATE, isDesktop => {
-      this.onDesktopStateUpdate_(isDesktop);
+    this.storeService_.subscribe(StateProperty.UI_STATE, uiState => {
+      this.onUIStateUpdate_(uiState);
     }, true /** callToInitialize */);
   }
 
@@ -329,12 +330,16 @@ export class AmpStoryBookend extends AMP.BaseElement {
   }
 
   /**
-   * Reacts to desktop state updates.
-   * @param {boolean} isDesktop
+   * Reacts to UI state updates.
+   * @param {!UIType} uiState
    * @private
    */
-  onDesktopStateUpdate_(isDesktop) {
-    this.toggleDesktopAttribute_(isDesktop);
+  onUIStateUpdate_(uiState) {
+    this.mutateElement(() => {
+      uiState === UIType.DESKTOP ?
+        this.getShadowRoot().setAttribute('desktop', '') :
+        this.getShadowRoot().removeAttribute('desktop');
+    });
   }
 
   /**
@@ -476,19 +481,6 @@ export class AmpStoryBookend extends AMP.BaseElement {
   toggle_(show) {
     this.mutateElement(() => {
       this.getShadowRoot().classList.toggle(HIDDEN_CLASSNAME, !show);
-    });
-  }
-
-  /**
-   * Toggles the bookend desktop UI.
-   * @param {boolean} isDesktop
-   * @private
-   */
-  toggleDesktopAttribute_(isDesktop) {
-    this.mutateElement(() => {
-      isDesktop ?
-        this.getShadowRoot().setAttribute('desktop', '') :
-        this.getShadowRoot().removeAttribute('desktop');
     });
   }
 

--- a/extensions/amp-story/1.0/test/test-amp-story-store-service.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-store-service.js
@@ -18,6 +18,7 @@ import {
   Action,
   AmpStoryStoreService,
   StateProperty,
+  UIType,
 } from '../amp-story-store-service';
 import {EmbedMode, EmbedModeParam} from '../embed-mode';
 
@@ -109,10 +110,10 @@ describes.fakeWin('amp-story-store-service actions', {}, env => {
     expect(listenerSpy).to.have.been.calledWith(false);
   });
 
-  it('should toggle the desktop state', () => {
+  it('should toggle the desktop state when setting a UI State', () => {
     const listenerSpy = sandbox.spy();
     storeService.subscribe(StateProperty.DESKTOP_STATE, listenerSpy);
-    storeService.dispatch(Action.TOGGLE_DESKTOP, true);
+    storeService.dispatch(Action.TOGGLE_UI, UIType.DESKTOP);
     expect(listenerSpy).to.have.been.calledOnce;
     expect(listenerSpy).to.have.been.calledWith(true);
   });

--- a/extensions/amp-story/1.0/test/test-amp-story.js
+++ b/extensions/amp-story/1.0/test/test-amp-story.js
@@ -20,6 +20,7 @@ import {
   Action,
   AmpStoryStoreService,
   StateProperty,
+  UIType,
 } from '../amp-story-store-service';
 import {AmpStory} from '../amp-story';
 import {AmpStoryConsent} from '../amp-story-consent';
@@ -198,7 +199,7 @@ describes.realWin('amp-story', {
   it('should not prerender/load the share menu on desktop', () => {
     createPages(story.element, 2);
 
-    story.storeService_.dispatch(Action.TOGGLE_DESKTOP, true);
+    story.storeService_.dispatch(Action.TOGGLE_UI, UIType.DESKTOP);
 
     const buildShareMenuStub = sandbox.stub(story.shareMenu_, 'build');
 

--- a/tools/experiments/experiments.js
+++ b/tools/experiments/experiments.js
@@ -236,6 +236,12 @@ const EXPERIMENTS = [
     cleanupIssue: 'https://github.com/ampproject/amphtml/issues/17018',
   },
   {
+    id: 'amp-story-scroll',
+    name: 'Scrollable experience for amp-story',
+    spec: 'https://github.com/ampproject/amphtml/issues/16465',
+    cleanupIssue: 'https://github.com/ampproject/amphtml/issues/16466',
+  },
+  {
     id: 'inline-styles',
     name: 'Enables the usage of inline styles for non fixed elements',
     spec: 'https://github.com/ampproject/amphtml/issues/11881',


### PR DESCRIPTION
- Introduces a new scroll experiment
- Introduces an enum of different available experiences (mobile, desktop, scroll)
- Introduces a new `UI_STATE` that replaces the `DESKTOP_STATE`
- Keeps `DESKTOP_STATE` cause it's used by `amp-story-auto-ads`

Related to #16465

cc @sarrimaxime