### PR TITLE
🏗 Clean up output of `gulp dist --single_pass`

### DIFF
--- a/build-system/get-dep-graph.js
+++ b/build-system/get-dep-graph.js
@@ -247,6 +247,7 @@ exports.getGraph = function(entryModules, config) {
   // directly and which we don't want to apply during deps finding.
       .transform(babel, {
         babelrc: false,
+        compact: false,
         plugins: [
           require.resolve('babel-plugin-transform-es2015-modules-commonjs'),
         ],


### PR DESCRIPTION
The output of `gulp dist --single_pass` is quite verbose on Travis and during local development. See https://travis-ci.org/ampproject/amphtml/jobs/409174647#L2345-L2466

This PR does the following:
1. Cleans up the logs by following the convention used by other build types
2. Adds the `compact: false` option to the `babelify` transform to be consistent about how modules of different sizes are transformed. See #14831 and https://github.com/ampproject/amphtml/pull/15076#issue-185863176
3. Fixes a bug where `buildExtension` was swallowing the promise returned by `buildExtensionJs`
