### PR TITLE
Simplifying amp-story-page CSS selectors to make them easy to override.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-desktop.css
+++ b/extensions/amp-story/1.0/amp-story-desktop.css
@@ -81,7 +81,7 @@ amp-story[standalone][desktop] {
   z-index: 1 !important;
 }
 
-[desktop] amp-story-page {
+[desktop] amp-story-page[distance] {
   transform: scale(1.0) translateX(50vw) translateY(0%) !important;
   opacity: .05 !important;
   transform-origin: left !important;

--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -182,37 +182,31 @@ amp-story-page[active] {
  * not be automatically laid out. Max distance is set to 2 (next 2 pages) since
  * we don't want to schedule any further pages. */
 
-amp-story:not([desktop]) >
-    amp-story-page.i-amphtml-layout-container:not([active]) {
+amp-story-page:not([active]) {
   transform: translateY(1000%) !important;
 }
 
 amp-story-page[active],
-amp-story:not([desktop]) >
-    amp-story-page.i-amphtml-layout-container[distance="0"],
-amp-story:not([desktop]) >
-    amp-story-page.i-amphtml-layout-container[distance="1"] {
+amp-story-page[distance="0"],
+amp-story-page[distance="1"] {
   transform: translateY(0) !important;
 }
 
-amp-story:not([desktop]) >
-    amp-story-page.i-amphtml-layout-container[distance="2"] {
+amp-story-page[distance="2"] {
   transform: translateY(100%) !important;
 }
 
-amp-story:not([desktop]) >
-    amp-story-page.i-amphtml-layout-container[active] {
+amp-story-page[active] {
   transition: filter 0.2s cubic-bezier(0.4, 0.0, 1, 1) !important;
 }
 
-.i-amphtml-story-bookend-active:not([desktop]) >
-    amp-story-page.i-amphtml-layout-container[active] {
+.i-amphtml-story-bookend-active amp-story-page[active] {
   filter: blur(3px) !important;
   transition: filter 0.3s cubic-bezier(0.0, 0.0, 0.2, 1) !important;
 }
 
 /* TODO(gmajoulet): move the overlay to the bookend styles. */
-.i-amphtml-story-bookend-active > amp-story-page[active]::after {
+.i-amphtml-story-bookend-active amp-story-page[active]::after {
   content: '' !important;
   display: block !important;
   left: 0 !important;


### PR DESCRIPTION
#17169 allows different ways to consume a story (mobile, desktop "three panels", and desktop scroll).

Simplifying the `amp-story-page` CSS selectors makes it easier to override these pages positions from other experience's specific spreadsheets. 

Related to #16465
Fixes #17170