### PR TITLE
Doubleclick SRA - move to client-side exp selection

### DIFF
--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -323,6 +323,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
   /**
    * For easier unit testing.
    * @param {!Object<string, !../../../src/experiments.ExperimentInfo>} experimentInfoMap
+   * @return {!Object<string, string>}
    */
   randomlySelectUnsetExperiments_(experimentInfoMap) {
     return randomlySelectUnsetExperiments(this.win, experimentInfoMap);

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -302,22 +302,30 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
       this.experimentIds.push('21060933');
     }
     const experimentInfoMap =
-        /** @type {!Object<string,
+    /** @type {!Object<string,
         !../../../src/experiments.ExperimentInfo>} */ ({
-        // If SRA and refresh are not enabled, select into experiments that
-        // enable by default.
+        // Only select into SRA experiments if SRA not already explicitly
+        // enabled and refresh is not being used by any slot.
         [DOUBLECLICK_SRA_EXP]: {
           isTrafficEligible: () => !this.win.document./*OK*/querySelector(
               'meta[name=amp-ad-enable-refresh], ' +
               'amp-ad[type=doubleclick][data-enable-refresh], ' +
               'meta[name=amp-ad-doubleclick-sra]'),
           branches: Object.keys(DOUBLECLICK_SRA_EXP_BRANCHES).map(
-              key => RDOUBLECLICK_SRA_EXP_BRANCHES[key]),
+              key => DOUBLECLICK_SRA_EXP_BRANCHES[key]),
         },
       });
-    const setExps = randomlySelectUnsetExperiments(this.win, experimentInfoMap);
+    const setExps = this.randomlySelectUnsetExperiments_(experimentInfoMap);
     Object.keys(setExps).forEach(expName =>
       setExps[expName] && this.experimentIds.push(setExps[expName]));
+  }
+
+  /**
+   * For easier unit testing.
+   * @param {!Object<string, !../../../src/experiments.ExperimentInfo>} experimentInfoMap
+   */
+  randomlySelectUnsetExperiments_(experimentInfoMap) {
+    return randomlySelectUnsetExperiments(this.win, experimentInfoMap);
   }
 
   /** @private */
@@ -1058,7 +1066,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
                     } else if (!!this.win.document.querySelector(
                         'meta[name=amp-ad-doubleclick-sra]') ||
                         this.experimentIds.includes(
-                            DOUBLECLICK_EXPERIMENT_FEATURE.SRA_NO_RECOVER)) {
+                            DOUBLECLICK_SRA_EXP_BRANCHES.SRA_NO_RECOVER)) {
                       // If publisher has explicitly enabled SRA mode (not
                       // experiment), then assume error is network failure,
                       // collapse slot, reset url to empty string to ensure

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -67,9 +67,6 @@ import {createElementWithAttributes, removeElement} from '../../../src/dom';
 import {deepMerge, dict} from '../../../src/utils/object';
 import {dev, user} from '../../../src/log';
 import {domFingerprintPlain} from '../../../src/utils/dom-fingerprint';
-import {
-  extractUrlExperimentId,
-} from '../../../ads/google/a4a/traffic-experiments';
 import {getMode} from '../../../src/mode';
 import {getMultiSizeDimensions} from '../../../ads/google/utils';
 import {getOrCreateAdCid} from '../../../src/ad-cid';
@@ -89,6 +86,7 @@ import {
   lineDelimitedStreamer,
   metaJsonCreativeGrouper,
 } from '../../../ads/google/a4a/line-delimited-response-handler';
+import {randomlySelectUnsetExperiments} from '../../../src/experiments';
 import {setStyles} from '../../../src/style';
 import {stringHash32} from '../../../src/string';
 import {tryParseJson} from '../../../src/json';
@@ -103,8 +101,11 @@ const DOUBLECLICK_BASE_URL =
 /** @const {string} */
 const RTC_SUCCESS = '2';
 
+/** @const {string} */
+const DOUBLECLICK_SRA_EXP = 'doubleclickSraExp';
+
 /** @const @enum{string} */
-const DOUBLECLICK_EXPERIMENT_FEATURE = {
+const DOUBLECLICK_SRA_EXP_BRANCHES = {
   SRA_CONTROL: '117152666',
   SRA: '117152667',
   SRA_NO_RECOVER: '21062235',
@@ -291,38 +292,32 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
   }
 
   /**
-   * @param {?string} urlExperimentId
+   * Executes page level experiment diversion and pushes any experiment IDs
+   * onto this.experimentIds.
    * @visibleForTesting
    */
-  setPageLevelExperiments(urlExperimentId) {
+  setPageLevelExperiments() {
     if (!isCdnProxy(this.win) && !isExperimentOn(
         this.win, 'expDfpInvOrigDeprecated')) {
       this.experimentIds.push('21060933');
     }
-    const experimentId = {
-      // SRA
-      '7': DOUBLECLICK_EXPERIMENT_FEATURE.SRA_CONTROL,
-      '8': DOUBLECLICK_EXPERIMENT_FEATURE.SRA,
-      '9': DOUBLECLICK_EXPERIMENT_FEATURE.SRA_NO_RECOVER,
-    }[urlExperimentId];
-    switch (experimentId) {
-      case undefined:
-        break;
-      case DOUBLECLICK_EXPERIMENT_FEATURE.SRA_CONTROL:
-      case DOUBLECLICK_EXPERIMENT_FEATURE.SRA:
-      case DOUBLECLICK_EXPERIMENT_FEATURE.SRA_NO_RECOVER:
-        // For SRA experiments, do not include pages that are using refresh.
-        if (this.win.document./*OK*/querySelector(
-            'meta[name=amp-ad-enable-refresh], ' +
-            'amp-ad[type=doubleclick][data-enable-refresh]')) {
-          break;
-        }
-      default:
-        dev().info(
-            TAG,
-            `url experiment selection ${urlExperimentId}: ${experimentId}.`);
-        this.experimentIds.push(experimentId);
-    }
+    const experimentInfoMap =
+        /** @type {!Object<string,
+        !../../../src/experiments.ExperimentInfo>} */ ({
+        // If SRA and refresh are not enabled, select into experiments that
+        // enable by default.
+        [DOUBLECLICK_SRA_EXP]: {
+          isTrafficEligible: () => !this.win.document./*OK*/querySelector(
+              'meta[name=amp-ad-enable-refresh], ' +
+              'amp-ad[type=doubleclick][data-enable-refresh], ' +
+              'meta[name=amp-ad-doubleclick-sra]'),
+          branches: Object.keys(DOUBLECLICK_SRA_EXP_BRANCHES).map(
+              key => RDOUBLECLICK_SRA_EXP_BRANCHES[key]),
+        },
+      });
+    const setExps = randomlySelectUnsetExperiments(this.win, experimentInfoMap);
+    Object.keys(setExps).forEach(expName =>
+      setExps[expName] && this.experimentIds.push(setExps[expName]));
   }
 
   /** @private */
@@ -349,15 +344,14 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
   buildCallback() {
     super.buildCallback();
     this.maybeDeprecationWarn_();
-    this.setPageLevelExperiments(
-        extractUrlExperimentId(this.win, this.element));
+    this.setPageLevelExperiments();
     this.useSra = (getMode().localDev && /(\?|&)force_sra=true(&|$)/.test(
         this.win.location.search)) ||
         !!this.win.document.querySelector(
             'meta[name=amp-ad-doubleclick-sra]') ||
         !!this.experimentIds.filter(exp =>
-          exp == DOUBLECLICK_EXPERIMENT_FEATURE.SRA ||
-          exp == DOUBLECLICK_EXPERIMENT_FEATURE.SRA_NO_RECOVER).length;
+          exp == DOUBLECLICK_SRA_EXP_BRANCHES.SRA ||
+          exp == DOUBLECLICK_SRA_EXP_BRANCHES.SRA_NO_RECOVER).length;
     this.identityTokenPromise_ = Services.viewerForDoc(this.getAmpDoc())
         .whenFirstVisible()
         .then(() => getIdentityToken(this.win, this.getAmpDoc()));

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -1431,21 +1431,21 @@ describes.realWin('additional amp-ad-network-doubleclick-impl',
         });
 
         it('should set invalid origin fix experiment if on canonical', () => {
-          randomlySelectUnsetExperimentsStub.returns([]);
+          randomlySelectUnsetExperimentsStub.returns({});
           impl.setPageLevelExperiments();
           expect(impl.experimentIds.includes('21060933')).to.be.true;
         });
 
         it('should not set invalid origin fix if exp on', () => {
           toggleExperiment(env.win, 'envDfpInvOrigDeprecated', true);
-          randomlySelectUnsetExperimentsStub.returns([]);
+          randomlySelectUnsetExperimentsStub.returns({});
           impl.setPageLevelExperiments();
           expect(impl.experimentIds.includes('21060933')).to.be.true;
         });
 
         it('should select SRA experiments', () => {
           randomlySelectUnsetExperimentsStub.returns(
-              {doubleclickSraExp: ['117152667']});
+              {doubleclickSraExp: '117152667'});
           impl.buildCallback();
           expect(impl.experimentIds.includes('117152667')).to.be.true;
           expect(impl.useSra).to.be.true;
@@ -1454,7 +1454,7 @@ describes.realWin('additional amp-ad-network-doubleclick-impl',
         describe('should properly limit SRA traffic', () => {
           let experimentInfoMap;
           beforeEach(() => {
-            randomlySelectUnsetExperimentsStub.returns([]);
+            randomlySelectUnsetExperimentsStub.returns({});
             impl.setPageLevelExperiments();
             // args format is call array followed by parameter array so expect
             // first call, first param.

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -39,6 +39,7 @@ import {
   resetTokensToInstancesMap,
 } from '../amp-ad-network-doubleclick-impl';
 import {CONSENT_POLICY_STATE} from '../../../../src/consent-state';
+import {Deferred} from '../../../../src/utils/promise';
 import {FriendlyIframeEmbed} from '../../../../src/friendly-iframe-embed';
 import {Layout} from '../../../../src/layout';
 import {
@@ -1416,20 +1417,72 @@ describes.realWin('additional amp-ad-network-doubleclick-impl',
       });
 
       describe('#setPageLevelExperiments', () => {
-
+        let randomlySelectUnsetExperimentsStub;
+        beforeEach(() => {
+          randomlySelectUnsetExperimentsStub =
+            sandbox.stub(impl, 'randomlySelectUnsetExperiments_');
+          sandbox.stub(AmpA4A.prototype, 'buildCallback').callsFake(() => {});
+          sandbox.stub(impl, 'getAmpDoc').returns({});
+          sandbox.stub(Services, 'viewerForDoc').returns(
+              {whenFirstVisible: () => new Deferred().promise});
+        });
         afterEach(() => {
           toggleExperiment(env.win, 'envDfpInvOrigDeprecated', false);
         });
 
         it('should set invalid origin fix experiment if on canonical', () => {
-          impl.setPageLevelExperiments('');
+          randomlySelectUnsetExperimentsStub.returns([]);
+          impl.setPageLevelExperiments();
           expect(impl.experimentIds.includes('21060933')).to.be.true;
         });
 
         it('should not set invalid origin fix if exp on', () => {
           toggleExperiment(env.win, 'envDfpInvOrigDeprecated', true);
-          impl.setPageLevelExperiments('');
+          randomlySelectUnsetExperimentsStub.returns([]);
+          impl.setPageLevelExperiments();
           expect(impl.experimentIds.includes('21060933')).to.be.true;
+        });
+
+        it('should select SRA experiments', () => {
+          randomlySelectUnsetExperimentsStub.returns(
+              {doubleclickSraExp: ['117152667']});
+          impl.buildCallback();
+          expect(impl.experimentIds.includes('117152667')).to.be.true;
+          expect(impl.useSra).to.be.true;
+        });
+
+        describe('should properly limit SRA traffic', () => {
+          let experimentInfoMap;
+          beforeEach(() => {
+            randomlySelectUnsetExperimentsStub.returns([]);
+            impl.setPageLevelExperiments();
+            // args format is call array followed by parameter array so expect
+            // first call, first param.
+            experimentInfoMap = randomlySelectUnsetExperimentsStub
+                .args[0][0]['doubleclickSraExp'];
+            expect(experimentInfoMap).to.be.ok;
+            expect(impl.useSra).to.be.false;
+          });
+
+          it('should allow by default', () =>
+            expect(experimentInfoMap.isTrafficEligible()).to.be.true);
+
+          it('should not allow if refresh meta', () => {
+            doc.head.appendChild(createElementWithAttributes(
+                doc, 'meta', {name: 'amp-ad-enable-refresh'}));
+            expect(experimentInfoMap.isTrafficEligible()).to.be.false;
+          });
+
+          it('should not allow if sra meta', () => {
+            doc.head.appendChild(createElementWithAttributes(
+                doc, 'meta', {name: 'amp-ad-doubleclick-sra'}));
+            expect(experimentInfoMap.isTrafficEligible()).to.be.false;
+          });
+
+          it('should not allow if block level refresh', () => {
+            impl.element.setAttribute('data-enable-refresh', '');
+            expect(experimentInfoMap.isTrafficEligible()).to.be.false;
+          });
         });
       });
 


### PR DESCRIPTION
Move from SERP diversion to client-side, page level for simplicity and to get results across all AMP environments.  Given there are now no SERP diverted experiments within Doubleclick impl, code has been removed.