### PR TITLE
🏗✅ Add an explicit `test` value to `AMP_CONFIG`

### DIFF
--- a/build-system/amp.extern.js
+++ b/build-system/amp.extern.js
@@ -180,6 +180,8 @@ AmpConfigType.prototype.v;
 AmpConfigType.prototype.canary;
 /* @public {string} */
 AmpConfigType.prototype.runtime;
+/* @public {boolean} */
+AmpConfigType.prototype.test;
 
 /** @type {!AmpConfigType}  */
 window.AMP_CONFIG;

--- a/build-system/tasks/prepend-global/index.js
+++ b/build-system/tasks/prepend-global/index.js
@@ -118,10 +118,12 @@ function valueOrDefault(value, defaultValue) {
  * @param {boolean=} opt_localDev Whether to enable local development
  * @param {boolean=} opt_localBranch Whether to use the local branch version
  * @param {string=} opt_branch If not the local branch, which branch to use
+ * @param {boolean=} opt_fortesting Whether to force getMode().test to be true
  * @return {!Promise}
  */
 function applyConfig(
-  config, target, filename, opt_localDev, opt_localBranch, opt_branch) {
+  config, target, filename, opt_localDev, opt_localBranch, opt_branch,
+  opt_fortesting) {
   return checkoutBranchConfigs(filename, opt_localBranch, opt_branch)
       .then(() => {
         return Promise.all([
@@ -140,6 +142,7 @@ function applyConfig(
         if (opt_localDev) {
           configJson = enableLocalDev(config, target, configJson);
         }
+        configJson.test = !!opt_fortesting;
         const targetString = files[1].toString();
         const configString = JSON.stringify(configJson);
         return prependConfig(configString, targetString);
@@ -244,7 +247,7 @@ function main() {
   return removeConfig(target).then(() => {
     return applyConfig(
         config, target, filename,
-        argv.local_dev, argv.local_branch, argv.branch);
+        argv.local_dev, argv.local_branch, argv.branch, argv.fortesting);
   });
 }
 
@@ -260,6 +263,7 @@ gulp.task('prepend-global', 'Prepends a json config to a target file', main, {
         'Uses master by default.',
     'local_branch': '  Don\'t switch branches and use the config from the ' +
         'local branch.',
+    'fortesting': '  Force the config to return true for getMode().test',
     'remove': '  Removes previously prepended json config from the target ' +
         'file (if present).',
   },

--- a/build-system/tasks/prepend-global/index.js
+++ b/build-system/tasks/prepend-global/index.js
@@ -142,7 +142,9 @@ function applyConfig(
         if (opt_localDev) {
           configJson = enableLocalDev(config, target, configJson);
         }
-        configJson.test = !!opt_fortesting;
+        if (opt_fortesting) {
+          configJson = Object.assign({test: true}, configJson);
+        }
         const targetString = files[1].toString();
         const configString = JSON.stringify(configJson);
         return prependConfig(configString, targetString);

--- a/build-system/tasks/visual-diff.js
+++ b/build-system/tasks/visual-diff.js
@@ -48,7 +48,7 @@ const CSS_SELECTOR_RETRY_ATTEMPTS = 50;
 const CSS_SELECTOR_TIMEOUT_MS =
     CSS_SELECTOR_RETRY_MS * CSS_SELECTOR_RETRY_ATTEMPTS;
 const AMP_RUNTIME_TARGET_FILES = [
-  'dist/amp.js', 'dist.3p/current/integration.js'];
+  'dist/amp.js', 'dist/amp-esm.js', 'dist.3p/current/integration.js'];
 const BUILD_STATUS_URL = 'https://amphtml-percy-status-checker.appspot.com/status';
 const BUILD_PROCESSING_POLLING_INTERVAL_MS = 5 * 1000; // Poll every 5 seconds
 const BUILD_PROCESSING_TIMEOUT_MS = 15 * 1000; // Wait for up to 10 minutes

--- a/build-system/tasks/visual-diff.js
+++ b/build-system/tasks/visual-diff.js
@@ -529,7 +529,7 @@ async function verifyCssElements(page, url, forbiddenCss, loadingIncompleteCss,
       if (!(await waitForElementVisibility(page, css, {hidden: true}))) {
         log('fatal', colors.cyan(url), '| An element with the CSS selector',
             colors.cyan(css),
-            `is still visible after ${CSS_SELECTOR_RETRY_MS} ms`);
+            `is still visible after ${CSS_SELECTOR_TIMEOUT_MS} ms`);
       }
     }
   }
@@ -550,7 +550,7 @@ async function verifyCssElements(page, url, forbiddenCss, loadingIncompleteCss,
       if (!(await waitForElementVisibility(page, css, {visible: true}))) {
         log('fatal', colors.cyan(url), '| An element with the CSS selector',
             colors.cyan(css),
-            `is still invisible after ${CSS_SELECTOR_RETRY_MS} ms`);
+            `is still invisible after ${CSS_SELECTOR_TIMEOUT_MS} ms`);
       }
     }
   }

--- a/src/mode.js
+++ b/src/mode.js
@@ -60,6 +60,8 @@ export function getMode(opt_win) {
  * @return {!ModeDef}
  */
 function getMode_(win) {
+  const AMP_CONFIG = self.AMP_CONFIG || {};
+
   // Magic constants that are replaced by closure compiler.
   // IS_MINIFIED is always replaced with true when closure compiler is used
   // while IS_DEV is only replaced when `gulp dist` is called without the
@@ -67,8 +69,9 @@ function getMode_(win) {
   const IS_DEV = true;
   const IS_MINIFIED = false;
 
-  const localDevEnabled = !!(self.AMP_CONFIG && self.AMP_CONFIG.localDev);
-  const runningTests = IS_DEV && !!(win.AMP_TEST || win.__karma__);
+  const localDevEnabled = !!self.AMP_CONFIG.localDev;
+  const runningTests = (!!AMP_CONFIG.test) || (
+    IS_DEV && !!(win.AMP_TEST || win.__karma__));
   const isLocalDev = IS_DEV && (localDevEnabled || runningTests);
   const hashQuery = parseQueryString_(
       // location.originalHash is set by the viewer when it removes the fragment

--- a/src/mode.js
+++ b/src/mode.js
@@ -69,7 +69,7 @@ function getMode_(win) {
   const IS_DEV = true;
   const IS_MINIFIED = false;
 
-  const localDevEnabled = !!self.AMP_CONFIG.localDev;
+  const localDevEnabled = !!AMP_CONFIG.localDev;
   const runningTests = (!!AMP_CONFIG.test) || (
     IS_DEV && !!(win.AMP_TEST || win.__karma__));
   const isLocalDev = IS_DEV && (localDevEnabled || runningTests);

--- a/src/mode.js
+++ b/src/mode.js
@@ -60,6 +60,7 @@ export function getMode(opt_win) {
  * @return {!ModeDef}
  */
 function getMode_(win) {
+  // TODO(erwinmombay): simplify the logic here
   const AMP_CONFIG = self.AMP_CONFIG || {};
 
   // Magic constants that are replaced by closure compiler.


### PR DESCRIPTION
* Defaults to `false`
* Set this value to true by adding `--fortesting` to `gulp prepend-global`
* `gulp visual-diff` will set this to true explicitly
* When `AMP_CONFIG.test == true` it will explicitly make `src/mode.js#getMode().test` evaluate to `true` (without changing the other existing logic that causes `getMode().test` to be `true`)

Fixes #17108