### PR TITLE
amp-list: Faster bindings by avoiding DOM scan

### DIFF
--- a/build-system/amp.extern.js
+++ b/build-system/amp.extern.js
@@ -513,6 +513,15 @@ AMP.require;
 var TransitionDef;
 
 ///////////////////
+// Template externs
+///////////////////
+
+/**
+ * @typedef {{element: !Element, metadata: ?JsonObject}}
+ */
+let RenderedTemplateDef;
+
+///////////////////
 // amp-bind externs
 ///////////////////
 
@@ -562,9 +571,9 @@ let BindEvaluateBindingsResultDef;
  */
 let BindEvaluateExpressionResultDef;
 
-/////////////////////////////
-////// Web Anmomation externs
-/////////////////////////////
+////////////////////////
+// Web Animation externs
+/////////////////////////
 /**
  * @typedef {
  *   !WebMultiAnimationDef|

--- a/examples/bind/list.amp.html
+++ b/examples/bind/list.amp.html
@@ -40,7 +40,7 @@
   </template>
 
   <h3>Default</h3>
-  <amp-list layout="responsive" src="/list/fruit-data/get" [src]="src" width="600" height="100" template="my-template" max-items=1>
+  <amp-list layout="responsive" src="/list/fruit-data/get" [src]="src" width="600" height="100" template="my-template">
   </amp-list>
 
   <h3>binding="always"</h3>

--- a/examples/bind/list.amp.html
+++ b/examples/bind/list.amp.html
@@ -43,7 +43,7 @@
   <amp-list layout="responsive" src="/list/fruit-data/get" [src]="src" width="600" height="100" template="my-template" max-items=1>
   </amp-list>
 
-  <!-- <h3>binding="always"</h3>
+  <h3>binding="always"</h3>
   <amp-list binding="always" layout="responsive" src="/list/fruit-data/get" [src]="src" width="600" height="100" template="my-template">
   </amp-list>
 
@@ -53,5 +53,5 @@
 
   <h3>binding="no"</h3>
   <amp-list binding="no" layout="responsive" src="/list/fruit-data/get" [src]="src" width="600" height="100" template="my-template">
-  </amp-list> -->
+  </amp-list>
 </body>

--- a/examples/bind/list.amp.html
+++ b/examples/bind/list.amp.html
@@ -10,7 +10,7 @@
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script>
   <script async custom-element="amp-list" src="https://cdn.ampproject.org/v0/amp-list-0.1.js"></script>
-  <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-latest.js"></script>
+  <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.2.js"></script>
 </head>
 <body>
 
@@ -40,7 +40,7 @@
   </template>
 
   <h3>Default</h3>
-  <amp-list layout="responsive" src="/list/fruit-data/get" [src]="src" width="600" height="100" template="my-template">
+  <amp-list layout="responsive" src="/list/fruit-data/get" [src]="src" width="600" height="100" template="my-template" max-items=1>
   </amp-list>
 
   <!-- <h3>binding="always"</h3>

--- a/examples/bind/list.amp.html
+++ b/examples/bind/list.amp.html
@@ -43,7 +43,7 @@
   <amp-list layout="responsive" src="/list/fruit-data/get" [src]="src" width="600" height="100" template="my-template">
   </amp-list>
 
-  <h3>binding="always"</h3>
+  <!-- <h3>binding="always"</h3>
   <amp-list binding="always" layout="responsive" src="/list/fruit-data/get" [src]="src" width="600" height="100" template="my-template">
   </amp-list>
 
@@ -53,5 +53,5 @@
 
   <h3>binding="no"</h3>
   <amp-list binding="no" layout="responsive" src="/list/fruit-data/get" [src]="src" width="600" height="100" template="my-template">
-  </amp-list>
+  </amp-list> -->
 </body>

--- a/extensions/amp-a4a/0.1/amp-ad-template-helper.js
+++ b/extensions/amp-a4a/0.1/amp-ad-template-helper.js
@@ -75,8 +75,9 @@ export class AmpAdTemplateHelper {
    * @return {!Promise<!Element>} Promise which resolves after rendering completes.
    */
   render(templateValues, element) {
-    return Services.templatesFor(this.win_)
-        .findAndRenderTemplate(element, templateValues);
+    const templates = Services.templatesFor(this.win_);
+    return templates.findAndRenderTemplate(element, templateValues)
+        .then(rendered => rendered.element);
   }
 
   /**

--- a/extensions/amp-access/0.1/amp-access.js
+++ b/extensions/amp-access/0.1/amp-access.js
@@ -483,9 +483,8 @@ export class AccessService {
     if (!template) {
       return Promise.reject(new Error('template not found'));
     }
-
-    const rendered = this.templates_.renderTemplate(template, response);
-    return rendered.then(element => {
+    return this.templates_.renderTemplate(template, response).then(result => {
+      const {element} = result;
       return this.vsync_.mutatePromise(() => {
         element.setAttribute('amp-access-template', '');
         element[TEMPLATE_PROP] = template;

--- a/extensions/amp-ad/0.1/amp-ad-custom.js
+++ b/extensions/amp-ad/0.1/amp-ad-custom.js
@@ -115,13 +115,13 @@ export class AmpAdCustom extends AMP.BaseElement {
       try {
         Services.templatesFor(this.win)
             .findAndRenderTemplate(this.element, templateData)
-            .then(renderedElement => {
+            .then(rendered => {
               // Get here when the template has been rendered Clear out the
               // child template and replace it by the rendered version Note that
               // we can't clear templates that's not ad's child because they
               // maybe used by other ad component.
               removeChildren(this.element);
-              this.element.appendChild(renderedElement);
+              this.element.appendChild(rendered.element);
               this.signals().signal(CommonSignals.INI_LOAD);
             });
       } catch (e) {

--- a/extensions/amp-bind/0.1/amp-bind-macro.js
+++ b/extensions/amp-bind/0.1/amp-bind-macro.js
@@ -42,14 +42,4 @@ export class AmpBindMacro extends AMP.BaseElement {
     // We want the macro to be available wherever it is in the document.
     return true;
   }
-
-  /**
-   * @return {string} Returns a string to identify this tag. May not be unique
-   *     if the element name is not unique.
-   * @private
-   */
-  getName_() {
-    return '<amp-bind-macro> ' +
-        (this.element.getAttribute('id') || '<unknown id>');
-  }
 }

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -379,15 +379,23 @@ export class Bind {
         'Timed out waiting for amp-bind to process rendered template.');
   }
 
-  /** TODO */
-  ingestAndApply(ingestable) {
+  /**
+   * @param {!Array<!JsonObject>} ingestible
+   * @return {!Promise}
+   */
+  ingestAndApply(ingestible) {
+    // TODO: Still need to remove old bindings.
+    // TODO: Polish the implementation of this function.
+
     return this.initializePromise_.then(() => {
       const bindings = /** @type {!Array<!BindBindingDef>} */ ([]);
       const boundElements = /** @type {!Array<!BoundElementDef>} */ ([]);
       const expressionToElements = /** @type {!Object<string, !Array<!Element>>} */ (map());
 
-      ingestable.forEach(i => {
-        const {element, property, expression} = i;
+      ingestible.forEach(i => {
+        const element = i['element'];
+        const property = i['property'];
+        const expression = i['expression'];
 
         const boundProperty = {property, expressionString: expression, previousResult: undefined};
         const index = findIndex(boundElements, be => be.element === element);
@@ -419,7 +427,7 @@ export class Bind {
           }
         });
 
-        const elements = ingestable.map(i => i.element);
+        const elements = ingestible.map(i => i.element);
         return this.evaluate_().then(results =>
           this.applyElements_(results, elements));
       });

--- a/extensions/amp-date-countdown/0.1/amp-date-countdown.js
+++ b/extensions/amp-date-countdown/0.1/amp-date-countdown.js
@@ -75,9 +75,6 @@ export class AmpDateCountdown extends AMP.BaseElement {
   constructor(element) {
     super(element);
 
-    /** @const {function(!Element)} */
-    this.boundRendered_ = this.rendered_.bind(this);
-
     //Note: One of end-date, timestamp-ms, timestamp-seconds is required.
     /** @private {string} */
     this.endDate_ = this.element.getAttribute('end-date');
@@ -169,7 +166,7 @@ export class AmpDateCountdown extends AMP.BaseElement {
     items['data'] = Object.assign(DIFF, this.localeWordList_);
     this.templates_
         .findAndRenderTemplate(this.element, items['data'])
-        .then(this.boundRendered_);
+        .then(rendered => this.rendered_(rendered.element));
   }
 
   /**

--- a/extensions/amp-date-picker/0.1/amp-date-picker.js
+++ b/extensions/amp-date-picker/0.1/amp-date-picker.js
@@ -1428,7 +1428,8 @@ export class AmpDatePicker extends AMP.BaseElement {
    * @private
    */
   renderTemplateElement_(template, opt_data = /** @type {!JsonObject} */ ({})) {
-    return this.templates_.renderTemplate(template, opt_data);
+    return this.templates_.renderTemplate(template, opt_data)
+        .then(rendered => rendered.element);
   }
 
   /**
@@ -1446,7 +1447,7 @@ export class AmpDatePicker extends AMP.BaseElement {
   renderTemplate_(template, opt_data, opt_fallback = '') {
     if (template) {
       return this.renderTemplateElement_(template, opt_data)
-          .then(rendered => this.getRenderedTemplateString_(rendered));
+          .then(element => this.getRenderedTemplateString_(element));
     } else {
       return Promise.resolve(opt_fallback);
     }

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -825,18 +825,16 @@ export class AmpForm {
       container.setAttribute('aria-labeledby', messageId);
       container.setAttribute('aria-live', 'assertive');
       if (this.templates_.hasTemplate(container)) {
-        p = this.templates_.findAndRenderTemplate(container, data)
-            .then(rendered => {
-              rendered.id = messageId;
-              rendered.setAttribute('i-amphtml-rendered', '');
-              container.appendChild(rendered);
-              const renderedEvent = createCustomEvent(
-                  this.win_,
-                  AmpEvents.DOM_UPDATE,
-                  /* detail */ null,
-                  {bubbles: true});
-              container.dispatchEvent(renderedEvent);
-            });
+        p = this.templates_.findAndRenderTemplate(container, data).then(r => {
+          const {element} = r;
+          element.id = messageId;
+          element.setAttribute('i-amphtml-rendered', '');
+          container.appendChild(element);
+
+          const event = createCustomEvent(this.win_,
+              AmpEvents.DOM_UPDATE, /* detail */ null, {bubbles: true});
+          container.dispatchEvent(event);
+        });
       } else {
         // TODO(vializ): This is to let AMP know that the AMP elements inside
         // this container are now visible so they get scheduled for layout.
@@ -847,11 +845,9 @@ export class AmpForm {
         this.resources_.mutateElement(container, () => {});
       }
     }
-
     if (getMode().test) {
       this.renderTemplatePromise_ = p;
     }
-
     return p;
   }
 

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -379,13 +379,14 @@ export class AmpList extends AMP.BaseElement {
     // Forward elements to chained promise on success or failure.
     const forwardElements = () => elements;
     return this.templates_.findTemplateImplementation(this.element).then(template => {
+      let promise;
       if (this.element.hasAttribute('fast')) {
-        return bind.ingestAndApply(template.bindings)
-            .then(forwardElements, forwardElements);
+        const {bindings} = template; // HACK(choumx)
+        promise = bind.ingestAndApply(bindings);
       } else {
-        return bind.scanAndApply(elements, [this.container_])
-            .then(forwardElements, forwardElements);
+        promise = bind.scanAndApply(elements, [this.container_]);
       }
+      return promise.then(forwardElements, forwardElements);
     });
   }
 

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -360,11 +360,12 @@ export class AmpList extends AMP.BaseElement {
       return Promise.resolve(elements);
     }
     const updateWith = bind => {
+      const removedElements = [this.container_];
       // Instead of another experiment, use the new `binding` attribute as an
       // opt-in for the faster `ingestAndApply()` API.
       const promise = supportsIngestion && this.element.hasAttribute('binding')
-        ? bind.ingestAndApply(bindings)
-        : bind.scanAndApply(elements, [this.container_]);
+        ? bind.ingestAndApply(bindings, removedElements)
+        : bind.scanAndApply(/* added */ elements, removedElements);
       return promise.then(() => elements, () => elements);
     };
 

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -319,18 +319,16 @@ export class AmpList extends AMP.BaseElement {
       current.rejecter();
     };
     if (this.ssrTemplateHelper_.isSupported()) {
-      this.templates_.findAndRenderTemplate(
-          this.element, /** @type {!JsonObject} */ (current.data))
-          .then(element => {
-            this.container_.appendChild(element);
-          })
-          .then(onFulfilledCallback.bind(this), onRejectedCallback.bind(this));
+      const json = /** @type {!JsonObject} */ (current.data);
+      this.templates_.findAndRenderTemplate(this.element, json)
+          .then(element => this.container_.appendChild(element))
+          .then(onFulfilledCallback, onRejectedCallback);
     } else {
-      this.templates_.findAndRenderTemplateArray(
-          this.element, /** @type {!Array} */ (current.data))
+      const array = /** @type {!Array} */ (current.data);
+      this.templates_.findAndRenderTemplateArray(this.element, array)
           .then(elements => this.updateBindingsForElements_(elements))
           .then(elements => this.render_(elements))
-          .then(onFulfilledCallback.bind(this), onRejectedCallback.bind(this));
+          .then(onFulfilledCallback, onRejectedCallback);
     }
   }
 

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -374,8 +374,15 @@ export class AmpList extends AMP.BaseElement {
   updateBindingsWith_(bind, elements) {
     // Forward elements to chained promise on success or failure.
     const forwardElements = () => elements;
-    return bind.scanAndApply(elements, [this.container_])
-        .then(forwardElements, forwardElements);
+    return this.templates_.findTemplateImplementation(this.element).then(template => {
+      if (template.bindings) {
+        return bind.ingestAndApply(template.bindings)
+            .then(forwardElements, forwardElements);
+      } else {
+        return bind.scanAndApply(elements, [this.container_])
+            .then(forwardElements, forwardElements);
+      }
+    });
   }
 
   /**

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -372,10 +372,14 @@ export class AmpList extends AMP.BaseElement {
    * @return {!Promise<!Array<!Element>>}
    */
   updateBindingsWith_(bind, elements) {
+    dev().info(TAG, 'binding');
+
+    this.start_ = this.win.performance.now();
+
     // Forward elements to chained promise on success or failure.
     const forwardElements = () => elements;
     return this.templates_.findTemplateImplementation(this.element).then(template => {
-      if (template.bindings) {
+      if (this.element.hasAttribute('fast')) {
         return bind.ingestAndApply(template.bindings)
             .then(forwardElements, forwardElements);
       } else {
@@ -391,6 +395,8 @@ export class AmpList extends AMP.BaseElement {
    */
   render_(elements) {
     dev().info(TAG, 'render:', elements);
+
+    console.log(this.win.performance.now() - this.start_);
 
     this.mutateElement(() => {
       removeChildren(dev().assertElement(this.container_));

--- a/extensions/amp-mustache/0.1/amp-mustache.js
+++ b/extensions/amp-mustache/0.1/amp-mustache.js
@@ -86,7 +86,8 @@ export class AmpMustache extends AMP.BaseTemplate {
       }
       html = mustacheRender(this.template_, mustacheData);
     }
-    return this.serializeHtml_(html);
+    const element = this.serializeHtml_(html);
+    return {element, metadata: null};
   }
 
   /**

--- a/extensions/amp-mustache/0.2/amp-mustache.js
+++ b/extensions/amp-mustache/0.2/amp-mustache.js
@@ -96,21 +96,9 @@ export class AmpMustache extends AMP.BaseTemplate {
       }
       html = mustacheRender(this.template_, mustacheData);
     }
-    return this.serializeHtml_(html);
-  }
-
-  /**
-   * Sanitizes the html and inserts it in the DOM.
-   * @param {string} html
-   * @return {!Element}
-   * @private
-   */
-  serializeHtml_(html) {
     const {clean, bindings} = purifyHtml(html);
     this.bindings = bindings; // HACK(choumx)
-    const root = this.win.document.createElement('div');
-    root./*OK*/innerHTML = clean;
-    return this.unwrap(root);
+    return clean;
   }
 }
 

--- a/extensions/amp-mustache/0.2/amp-mustache.js
+++ b/extensions/amp-mustache/0.2/amp-mustache.js
@@ -107,6 +107,7 @@ export class AmpMustache extends AMP.BaseTemplate {
    */
   serializeHtml_(html) {
     const {clean, bindings} = purifyHtml(html);
+    this.bindings = bindings; // HACK(choumx)
     const root = this.win.document.createElement('div');
     root./*OK*/innerHTML = clean;
     return this.unwrap(root);

--- a/extensions/amp-mustache/0.2/amp-mustache.js
+++ b/extensions/amp-mustache/0.2/amp-mustache.js
@@ -97,8 +97,7 @@ export class AmpMustache extends AMP.BaseTemplate {
       html = mustacheRender(this.template_, mustacheData);
     }
     const {clean, bindings} = purifyHtml(html);
-    this.bindings = bindings; // HACK(choumx)
-    return clean;
+    return {element: clean, metadata: dict({'bindings': bindings})};
   }
 }
 

--- a/extensions/amp-mustache/0.2/amp-mustache.js
+++ b/extensions/amp-mustache/0.2/amp-mustache.js
@@ -106,9 +106,9 @@ export class AmpMustache extends AMP.BaseTemplate {
    * @private
    */
   serializeHtml_(html) {
-    const sanitized = purifyHtml(html);
+    const {clean, bindings} = purifyHtml(html);
     const root = this.win.document.createElement('div');
-    root./*OK*/innerHTML = sanitized;
+    root./*OK*/innerHTML = clean;
     return this.unwrap(root);
   }
 }

--- a/extensions/amp-subscriptions/0.1/local-subscription-platform-renderer.js
+++ b/extensions/amp-subscriptions/0.1/local-subscription-platform-renderer.js
@@ -87,12 +87,10 @@ export class LocalSubscriptionPlatformRenderer {
       }
       if (candidate.tagName == 'TEMPLATE') {
         return this.templates_.renderTemplate(candidate, authResponse)
-            .then(element => {
-              const renderState =
-                /** @type {!JsonObject} */(authResponse);
-              return this.renderActionsInNode_(
-                  renderState,
-                  element);
+            .then(rendered => {
+              const {element} = rendered;
+              const renderState = /** @type {!JsonObject} */(authResponse);
+              return this.renderActionsInNode_(renderState, element);
             });
       }
       const clone = candidate.cloneNode(true);

--- a/src/purifier.js
+++ b/src/purifier.js
@@ -221,7 +221,7 @@ const PURIFY_CONFIG = {
 
 /**
  * @param {string} dirty
- * @return {{clean: string, bindings: Array<{element: !Element, property: string, expression: string}>}}
+ * @return {{clean: !Node, bindings: Array<{element: !Element, property: string, expression: string}>}}
  */
 export function purifyHtml(dirty) {
   const config = Object.assign({}, PURIFY_CONFIG, {
@@ -230,6 +230,8 @@ export function purifyHtml(dirty) {
     'FORBID_TAGS': Object.keys(BLACKLISTED_TAGS),
     // Avoid reparenting of some elements to document head e.g. <script>.
     'FORCE_BODY': true,
+    // Avoid need for serializing to/from string by returning Node directly.
+    'RETURN_DOM': true,
   });
 
   // Reference to DOMPurify's `allowedTags` whitelist.
@@ -380,9 +382,9 @@ export function purifyHtml(dirty) {
   DOMPurify.addHook('afterSanitizeElements', afterSanitizeElements);
   DOMPurify.addHook('uponSanitizeAttribute', uponSanitizeAttribute);
   DOMPurify.addHook('afterSanitizeAttributes', afterSanitizeAttributes);
-  const clean = DOMPurify.sanitize(dirty, config);
+  const body = DOMPurify.sanitize(`<div>${dirty}</div>`, config);
   DOMPurify.removeAllHooks();
-  return {clean, bindings};
+  return {clean: body.firstElementChild, bindings};
 }
 
 /**

--- a/src/purifier.js
+++ b/src/purifier.js
@@ -221,7 +221,7 @@ const PURIFY_CONFIG = {
 
 /**
  * @param {string} dirty
- * @return {{clean: string, bindings: Array<!BindBindingDef>|undefined}}
+ * @return {{clean: string, bindings: Array<{element: !Element, property: string, expression: string}>}}
  */
 export function purifyHtml(dirty) {
   const config = Object.assign({}, PURIFY_CONFIG, {
@@ -242,7 +242,7 @@ export function purifyHtml(dirty) {
 
   // List of <amp-bind> bindings (tuple of tag, property, expression).
   // Collecting them here is an optimization to obviate DOM scanning later.
-  const bindings = /** @type {!Array<!BindBindingDef>} */ ([]);
+  const bindings = /** @type {!Array<{element: !Element, property: string, expression: string}>} */ ([]);
 
   /**
    * @param {!Node} node
@@ -332,7 +332,7 @@ export function purifyHtml(dirty) {
     if (binding) {
       const property = attrName.substring(1, attrName.length - 1);
       node.setAttribute(`data-amp-bind-${property}`, attrValue);
-      bindings.push({tagName, property, expressionString: attrValue});
+      bindings.push({element: node, property, expression: attrValue});
     }
 
     if (isValidAttr(tagName, attrName, attrValue, /* opt_purify */ true)) {

--- a/src/service/template-impl.js
+++ b/src/service/template-impl.js
@@ -26,7 +26,6 @@ import {getService, getServiceForDoc, registerServiceBuilder} from '../service';
  * {@link https://docs.google.com/document/d/1q-5MPQHnOHLF_uL7lQsGZdzuBgrPTkCy2PdRP-YCbOw/edit#}
  */
 
-
 /**
  * @typedef {function(new:BaseTemplate, !Element, !Window)}
  */
@@ -69,7 +68,7 @@ export class BaseTemplate {
   /**
    * To be implemented by subclasses.
    * @param {!JsonObject|string} unusedData
-   * @return {!Element}
+   * @return {!RenderedTemplateDef}
    */
   render(unusedData) {
     throw new Error('Not implemented');
@@ -146,7 +145,7 @@ export class Templates {
    * Renders the specified template element using the supplied data.
    * @param {!Element} templateElement
    * @param {!JsonObject} data
-   * @return {!Promise<!Element>}
+   * @return {!Promise<!RenderedTemplateDef>}
    */
   renderTemplate(templateElement, data) {
     return this.getImplementation_(templateElement).then(impl => {
@@ -159,7 +158,7 @@ export class Templates {
    * and returns an array of resulting elements.
    * @param {!Element} templateElement
    * @param {!Array<!JsonObject>} array
-   * @return {!Promise<!Array<!Element>>}
+   * @return {!Promise<!Array<!RenderedTemplateDef>>}
    */
   renderTemplateArray(templateElement, array) {
     if (array.length == 0) {
@@ -178,7 +177,7 @@ export class Templates {
    * @param {!Element} parent
    * @param {!JsonObject} data
    * @param {string=} opt_querySelector
-   * @return {!Promise<!Element>}
+   * @return {!Promise<!RenderedTemplateDef>}
    */
   findAndRenderTemplate(parent, data, opt_querySelector) {
     return this.renderTemplate(
@@ -194,7 +193,7 @@ export class Templates {
    * @param {!Element} parent
    * @param {!Array<!JsonObject>} array
    * @param {string=} opt_querySelector
-   * @return {!Promise<!Array<!Element>>}
+   * @return {!Promise<!Array<!RenderedTemplateDef>>}
    */
   findAndRenderTemplateArray(parent, array, opt_querySelector) {
     return this.renderTemplateArray(
@@ -224,12 +223,6 @@ export class Templates {
     user().assert(templateElement.tagName == 'TEMPLATE',
         'Template element must be a "template" tag %s', templateElement);
     return templateElement;
-  }
-
-  /** TODO */
-  findTemplateImplementation(parent, opt_querySelector) {
-    const template = this.findTemplate(parent, opt_querySelector);
-    return this.getImplementation_(template);
   }
 
   /**
@@ -337,7 +330,7 @@ export class Templates {
   /**
    * @param {!BaseTemplate} impl
    * @param {!JsonObject} data
-   * @return {!Element}
+   * @return {!RenderedTemplateDef}
    * @private
    */
   render_(impl, data) {

--- a/src/service/template-impl.js
+++ b/src/service/template-impl.js
@@ -230,6 +230,12 @@ export class Templates {
     return templateElement;
   }
 
+  /** TODO */
+  findTemplateImplementation(parent, opt_querySelector) {
+    const template = this.findTemplate(parent, opt_querySelector);
+    return this.getImplementation_(template);
+  }
+
   /**
    * Find a specified template inside the parent. Returns null if not present.
    * The template can be specified either via "template" attribute or as a

--- a/src/service/template-impl.js
+++ b/src/service/template-impl.js
@@ -166,9 +166,7 @@ export class Templates {
       return Promise.resolve([]);
     }
     return this.getImplementation_(templateElement).then(impl => {
-      return array.map(item => {
-        return this.render_(impl, item);
-      });
+      return array.map(item => this.render_(impl, item));
     });
   }
 
@@ -184,8 +182,7 @@ export class Templates {
    */
   findAndRenderTemplate(parent, data, opt_querySelector) {
     return this.renderTemplate(
-        this.findTemplate(parent, opt_querySelector),
-        data);
+        this.findTemplate(parent, opt_querySelector), data);
   }
 
   /**
@@ -201,8 +198,7 @@ export class Templates {
    */
   findAndRenderTemplateArray(parent, array, opt_querySelector) {
     return this.renderTemplateArray(
-        this.findTemplate(parent, opt_querySelector),
-        array);
+        this.findTemplate(parent, opt_querySelector), array);
   }
 
   /**


### PR DESCRIPTION
Partial for #15272.

- For `amp-bind` + `amp-list`, speeds up evaluation of bindings by avoiding DOM scan. Instead, piggyback on DOMPurify callbacks to collect bindings.
- Change DOMPurify to return `Node` directly instead of `string` to avoid unnecessary serialization.

TODO:
- Try Justin's suggestion for using a special attribute + `querySelector`.
- Fix a lot of tests due to API change.