### PR TITLE
🏗🐛 Print uncaught errors seen during tests (instead of rethrowing them)

### DIFF
--- a/build-system/tasks/karma.conf.js
+++ b/build-system/tasks/karma.conf.js
@@ -227,9 +227,6 @@ module.exports = {
       // Longer timeout on Travis; fail quickly at local.
       timeout: process.env.TRAVIS ? 10000 : 2000,
     },
-    // TODO(rsimha, #14406): Remove this after all tests are fixed.
-    failOnConsoleError: !process.env.TRAVIS && !process.env.LOCAL_PR_CHECK,
-    // TODO(rsimha, #14432): Set to false after all tests are fixed.
     captureConsole: true,
     verboseLogging: false,
   },

--- a/build-system/tasks/runtime-test.js
+++ b/build-system/tasks/runtime-test.js
@@ -40,7 +40,6 @@ const {green, yellow, cyan, red, bold} = colors;
 const preTestTasks = argv.nobuild ? [] : (
   (argv.unit || argv.a4a || argv['local-changes']) ? ['css'] : ['build']);
 const ampConfig = (argv.config === 'canary') ? 'canary' : 'prod';
-const tooManyTestsToFix = 15;
 const extensionsCssMapPath = 'EXTENSIONS_CSS_MAP';
 
 /**
@@ -458,9 +457,6 @@ function runTests() {
       });
     }
     c.files = c.files.concat(config.commonUnitTestPaths, testsToRun);
-    if (testsToRun.length < tooManyTestsToFix) {
-      c.client.failOnConsoleError = true;
-    }
   } else if (argv.integration) {
     c.files = c.files.concat(
         config.commonIntegrationTestPaths, config.integrationTestPaths);
@@ -476,10 +472,6 @@ function runTests() {
     c.files = c.files.concat(config.a4aTestPaths);
   } else {
     c.files = c.files.concat(config.testPaths);
-  }
-
-  if (argv.travis_like) {
-    c.client.failOnConsoleError = false;
   }
 
   // c.client is available in test browser via window.parent.karma.config

--- a/test/_init_tests.js
+++ b/test/_init_tests.js
@@ -315,14 +315,7 @@ function warnForConsoleError() {
       }
     }
 
-    // We're throwing an error. Clean up other expected errors since they will
-    // never appear.
-    expectedAsyncErrors = [];
-
     const errorMessage = message.split('\n', 1)[0]; // First line.
-    const {failOnConsoleError} = window.__karma__.config;
-    const terminator = failOnConsoleError ? '\'' : '';
-    const separator = failOnConsoleError ? '\n' : '\'\n';
     const helpMessage = '    The test "' + testName + '"' +
         ' resulted in a call to console.error. (See above line.)\n' +
         '    ⤷ If the error is not expected, fix the code that generated ' +
@@ -333,14 +326,9 @@ function warnForConsoleError() {
             'error> });\'\n' +
         '    ⤷ If the error is expected (and asynchronous), use the ' +
             'following pattern at the top of the test:\n' +
-        '        \'expectAsyncConsoleError(<string or regex>[, number of' +
-        ' times the error message repeats]);' + terminator;
-    // TODO(rsimha, #14406): Simply throw here after all tests are fixed.
-    if (failOnConsoleError) {
-      throw new Error(errorMessage + separator + helpMessage);
-    } else {
-      originalConsoleError(errorMessage + separator + helpMessage);
-    }
+        '        \'expectAsyncConsoleError(<string or regex>[, <number of' +
+        ' times the error message repeats>]);';
+    originalConsoleError(errorMessage + '\'\n' + helpMessage);
   });
   this.expectAsyncConsoleError = function(message, repeat = 1) {
     expectedAsyncErrors.push.apply(
@@ -355,7 +343,7 @@ function warnForConsoleError() {
       const helpMessage =
           'The test "' + testName + '" contains an "allowConsoleError" block ' +
           'that didn\'t result in a call to console.error.';
-      throw new Error(helpMessage);
+      originalConsoleError(helpMessage);
     }
     warnForConsoleError();
     return result;


### PR DESCRIPTION
We've fought a long battle against uncaught errors in tests (starting with #7381). The solution put in place a while ago (#14336) involved allowing tests to declare errors that are expected during execution, and surfacing ones that weren't declared. Until now, the way we did so was to rethrow the errors (synchronously) so that the test would fail.

However, due to the large number of asynchronous code paths in the AMP runtime, It's not guaranteed that uncaught errors are thrown during the test body. Sometimes, they appear in between tests, which works badly with mocha (#15658), and causes subsequent tests to be silently skipped. While this doesn't happen during full Travis runs, it does happen during local development, and has proven to be very annoying. For example, see https://github.com/ampproject/amphtml/pull/16916#pullrequestreview-140948171 and https://github.com/ampproject/amphtml/pull/17209#pullrequestreview-141795405.

Given this context, this PR does the following:
1. Removes all infrastructure code paths that cause tests to throw when uncaught errors are detected.
2. Instead of throwing, we print the same error message as before, but pass the test.
    - During local development, error messages are printed inline, so developers can address them even though the tests that generate them will now pass
    - During Travis runs, error messages are collected and printed at the end of the test run (in a collapsed section of the logs)

In effect, this PR is backing off from the original policy laid out by @cramforce in https://github.com/ampproject/amphtml/issues/7381#issue-205716701 (to fail tests that generate uncaught errors) due to the high cost of dealing with the resulting failures. However, the mechanism to detect these errors is still in place, and the hope is that printing them out during local development provides sufficient incentive to fix them.

**Here's an example of a test that generates an unexpected async error:**
```js
it('should not render fixed ad', function* () {
  const ampIframe = createAmpIframe(env, { src: iframeSrc, sandbox: 'allow-scripts allow-same-origin', width: 300, height: 250, position: 'fixed' }, 0);
  yield whenUpgradedToCustomElement(ampIframe);
  yield ampIframe.signals().whenSignal(CommonSignals.LOAD_START);
});
```

**Error message printed by the test:**
```
ERROR: 'amp-iframe is not used for displaying fixed ad. Please use amp-sticky-ad and amp-ad instead.'
    The test "amp-iframe   amp-iframe should not render fixed ad" resulted in a call to console.error. (See above line.)
    ⤷ If the error is not expected, fix the code that generated the error.
    ⤷ If the error is expected (and synchronous), use the following pattern to wrap the test code that generated the error:
        'allowConsoleError(() => { <code that generated the error> });'
    ⤷ If the error is expected (and asynchronous), use the following pattern at the top of the test:
        'expectAsyncConsoleError(<string or regex>[, <number of times the error message repeats>]);'
```

**The same test, but it now expects the error:**
```js
it('should not render fixed ad', function* () {
  expectAsyncConsoleError(/not used for displaying fixed ad/);
  const ampIframe = createAmpIframe(env, { src: iframeSrc, sandbox: 'allow-scripts allow-same-origin', width: 300, height: 250, position: 'fixed' }, 0);
  yield whenUpgradedToCustomElement(ampIframe);
  yield ampIframe.signals().whenSignal(CommonSignals.LOAD_START);
});

```
Fixes #15658
Addresses https://github.com/ampproject/amphtml/pull/16916#pullrequestreview-140948171 and https://github.com/ampproject/amphtml/pull/17209#pullrequestreview-141795405
Closes #14406
Partially fixes #14360