### PR TITLE
🔥 Fixing the story navigation hint z-index.

### DIFF
--- a/extensions/amp-story/0.1/amp-story-hint.css
+++ b/extensions/amp-story/0.1/amp-story-hint.css
@@ -24,6 +24,7 @@
   top: 0 !important;
   right: 0 !important;
   bottom: 0 !important;
+  z-index: 2 !important;
 }
 
 .i-amphtml-story-hint-container.i-amphtml-hidden {

--- a/extensions/amp-story/1.0/amp-story-hint.css
+++ b/extensions/amp-story/1.0/amp-story-hint.css
@@ -24,6 +24,7 @@
   top: 0 !important;
   right: 0 !important;
   bottom: 0 !important;
+  z-index: 2 !important;
 }
 
 .i-amphtml-story-hint-container.i-amphtml-hidden {


### PR DESCRIPTION
#16827 introduced a `z-index` on `amp-story-page`, that places it on top of the `amp-story-hint`.

Fixes #17207 