### PR TITLE
🏗 Remove reference to chromedriver.log

### DIFF
--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -370,10 +370,7 @@ const command = {
     const {status} = timedExec(cmd);
     if (status != 0) {
       console.error(fileLogPrefix, colors.red('ERROR:'),
-          'Found errors while running', colors.cyan(cmd) +
-          '. Here are the last 100 lines from',
-          colors.cyan('chromedriver.log') + ':\n');
-      exec('tail -n 100 chromedriver.log');
+          'Found errors while running', colors.cyan(cmd));
     }
   },
   verifyVisualDiffTests: function() {


### PR DESCRIPTION
Since switching from Selenium to Puppeteer for visual diff testing, our PR checks no longer generate `chromedriver.log` files

Sidenote: should I also remove the `chromedriver.log` line from `.gitignore`? I wonder if other people just have that file in their `amphtml` directory and might accidentally create PRs that include this file by accident