### PR TITLE
amp-list: Require reset-on-refresh="always" for local data

### DIFF
--- a/examples/bind/list.amp.html
+++ b/examples/bind/list.amp.html
@@ -52,22 +52,22 @@
   </template>
 
   <h3>Default</h3>
-  <amp-list layout="responsive" src="/list/fruit-data/get" [src]="src" width="600" height="100" template="my-template" reset-on-refresh>
+  <amp-list layout="responsive" src="/list/fruit-data/get" [src]="src" width="600" height="100" template="my-template" reset-on-refresh="always">
     <div placeholder>(Placeholder)</div>
   </amp-list>
 
   <h3>binding="always"</h3>
-  <amp-list binding="always" layout="responsive" src="/list/fruit-data/get" [src]="src" width="600" height="100" template="my-template" reset-on-refresh>
+  <amp-list binding="always" layout="responsive" src="/list/fruit-data/get" [src]="src" width="600" height="100" template="my-template" reset-on-refresh="always">
     <div placeholder>(Placeholder)</div>
   </amp-list>
 
   <h3>binding="refresh"</h3>
-  <amp-list binding="refresh" layout="responsive" src="/list/fruit-data/get" [src]="src" width="600" height="100" template="my-template" reset-on-refresh>
+  <amp-list binding="refresh" layout="responsive" src="/list/fruit-data/get" [src]="src" width="600" height="100" template="my-template" reset-on-refresh="always">
     <div placeholder>(Placeholder)</div>
   </amp-list>
 
   <h3>binding="no"</h3>
-  <amp-list binding="no" layout="responsive" src="/list/fruit-data/get" [src]="src" width="600" height="100" template="my-template" reset-on-refresh>
+  <amp-list binding="no" layout="responsive" src="/list/fruit-data/get" [src]="src" width="600" height="100" template="my-template" reset-on-refresh="always">
     <div placeholder>(Placeholder)</div>
   </amp-list>
 </body>

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -153,14 +153,14 @@ export class AmpList extends AMP.BaseElement {
       } else if (typeof src === 'object') {
         // Remove the 'src' now that local data is used to render the list.
         this.element.setAttribute('src', '');
-        this.resetIfNecessary_();
+        this.resetIfNecessary_(/* isFetch */ false);
         this.scheduleRender_(isArray(src) ? src : [src]);
       } else {
         this.user().error(TAG, 'Unexpected "src" type: ' + src);
       }
     } else if (state !== undefined) {
       user().error(TAG, '[state] is deprecated, please use [src] instead.');
-      this.resetIfNecessary_();
+      this.resetIfNecessary_(/* isFetch */ false);
       this.scheduleRender_(isArray(state) ? state : [state]);
     }
   }
@@ -189,11 +189,21 @@ export class AmpList extends AMP.BaseElement {
   }
 
   /**
-   * If `reset-on-refresh` attribute exists, then removes any previously
-   * rendered children and displays placeholder, loading indicator, etc.
+   * Removes any previously rendered children and displays placeholder, loading
+   * indicator, etc. depending on the value of `reset-on-refresh` attribute.
+   *
+   *     <amp-list reset-on-refresh="fetch|always">
+   *
+   * - "fetch": Reset only on network requests.
+   * - "always": Reset on network request OR rendering with local data.
+   *
+   * Default is "fetch" if no value is specified (boolean attribute).
+   *
+   * @param {boolean=} isFetch
    */
-  resetIfNecessary_() {
-    if (this.element.hasAttribute('reset-on-refresh')) {
+  resetIfNecessary_(isFetch = true) {
+    if ((isFetch && this.element.hasAttribute('reset-on-refresh'))
+      || this.element.getAttribute('reset-on-refresh') === 'always') {
       // Placeholder and loading don't need a mutate context.
       this.togglePlaceholder(true);
       this.toggleLoading(true, /* opt_force */ true);

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -517,8 +517,27 @@ describes.realWin('amp-list component', {
       });
     });
 
-    it('should reset if `reset-on-refresh` is set (new data)', () => {
+    it('should not reset if `reset-on-refresh=""` (new data)', () => {
       element.setAttribute('reset-on-refresh', '');
+      const items = [{title: 'foo'}];
+      const foo = doc.createElement('div');
+      expectFetchAndRender(items, [foo]);
+
+      return list.layoutCallback().then(() => {
+        expect(list.container_.contains(foo)).to.be.true;
+
+        listMock.expects('fetchList_').never();
+        // Expect hiding of placeholder/loading after render.
+        listMock.expects('togglePlaceholder').withExactArgs(false).once();
+        listMock.expects('toggleLoading').withExactArgs(false).once();
+
+        element.setAttribute('src', 'https://new.com/list.json');
+        list.mutatedAttributesCallback({'src': items});
+      });
+    });
+
+    it('should reset if `reset-on-refresh="always"` (new data)', () => {
+      element.setAttribute('reset-on-refresh', 'always');
       const items = [{title: 'foo'}];
       const foo = doc.createElement('div');
       expectFetchAndRender(items, [foo]);

--- a/extensions/amp-list/0.1/test/validator-amp-list.html
+++ b/extensions/amp-list/0.1/test/validator-amp-list.html
@@ -51,6 +51,18 @@
             reset-on-refresh>
     <div></div>
   </amp-list>
+  <!-- Valid: amp-list with src and reset-on-refresh="fetch" attributes -->
+  <amp-list width=10 height=10
+            src="https://data.com/articles.json?ref=CANONICAL_URL"
+            reset-on-refresh="fetch">
+    <div></div>
+  </amp-list>
+  <!-- Valid: amp-list with src and reset-on-refresh="always" attributes -->
+  <amp-list width=10 height=10
+            src="https://data.com/articles.json?ref=CANONICAL_URL"
+            reset-on-refresh="always">
+    <div></div>
+  </amp-list>
   <!-- Valid: amp-list with [src] and reset-on-refresh attributes -->
   <amp-list width=10 height=10
             [src]="foo.bar"

--- a/extensions/amp-list/0.1/test/validator-amp-list.out
+++ b/extensions/amp-list/0.1/test/validator-amp-list.out
@@ -54,6 +54,18 @@ amp-list/0.1/test/validator-amp-list.html:43:2 The attribute '[state]' in tag 'a
 |              reset-on-refresh>
 |      <div></div>
 |    </amp-list>
+|    <!-- Valid: amp-list with src and reset-on-refresh="fetch" attributes -->
+|    <amp-list width=10 height=10
+|              src="https://data.com/articles.json?ref=CANONICAL_URL"
+|              reset-on-refresh="fetch">
+|      <div></div>
+|    </amp-list>
+|    <!-- Valid: amp-list with src and reset-on-refresh="always" attributes -->
+|    <amp-list width=10 height=10
+|              src="https://data.com/articles.json?ref=CANONICAL_URL"
+|              reset-on-refresh="always">
+|      <div></div>
+|    </amp-list>
 |    <!-- Valid: amp-list with [src] and reset-on-refresh attributes -->
 |    <amp-list width=10 height=10
 |              [src]="foo.bar"
@@ -75,7 +87,7 @@ amp-list/0.1/test/validator-amp-list.html:43:2 The attribute '[state]' in tag 'a
 |    <!-- Invalid: unsupported "binding" attribute value -->
 |    <amp-list width=10 height=10
 >>   ^~~~~~~~~
-amp-list/0.1/test/validator-amp-list.html:73:2 The attribute 'binding' in tag 'amp-list' is set to the invalid value 'this-is-an-error'. (see https://www.ampproject.org/docs/reference/components/amp-list) [DISALLOWED_HTML]
+amp-list/0.1/test/validator-amp-list.html:85:2 The attribute 'binding' in tag 'amp-list' is set to the invalid value 'this-is-an-error'. (see https://www.ampproject.org/docs/reference/components/amp-list) [DISALLOWED_HTML]
 |              src="https://data.com/articles.json?ref=CANONICAL_URL"
 |              binding="this-is-an-error">
 |      <div></div>
@@ -83,21 +95,21 @@ amp-list/0.1/test/validator-amp-list.html:73:2 The attribute 'binding' in tag 'a
 |    <!-- Invalid: width is mistyped. -->
 |    <amp-list src="https://data.com/articles.json?ref=CANONICAL_URL"
 >>   ^~~~~~~~~
-amp-list/0.1/test/validator-amp-list.html:79:2 The attribute 'wdith' may not appear in tag 'amp-list'. (see https://www.ampproject.org/docs/reference/components/amp-list) [DISALLOWED_HTML]
+amp-list/0.1/test/validator-amp-list.html:91:2 The attribute 'wdith' may not appear in tag 'amp-list'. (see https://www.ampproject.org/docs/reference/components/amp-list) [DISALLOWED_HTML]
 |              wdith=10 height=10>
 |      <div></div>
 |    </amp-list>
 |    <!-- Invalid: missing at least src or [src]. -->
 |    <amp-list width=10 height=10>
 >>   ^~~~~~~~~
-amp-list/0.1/test/validator-amp-list.html:84:2 The tag 'amp-list' is missing a mandatory attribute - pick at least one of ['src','[src]']. (see https://www.ampproject.org/docs/reference/components/amp-list) [AMP_TAG_PROBLEM]
+amp-list/0.1/test/validator-amp-list.html:96:2 The tag 'amp-list' is missing a mandatory attribute - pick at least one of ['src','[src]']. (see https://www.ampproject.org/docs/reference/components/amp-list) [AMP_TAG_PROBLEM]
 |      <div></div>
 |    </amp-list>
 |    <!-- Invalid: width/height missing, so it's container layout
 |         which isn't supported. -->
 |    <amp-list src="https://data.com/articles.json?ref=CANONICAL_URL">
 >>   ^~~~~~~~~
-amp-list/0.1/test/validator-amp-list.html:89:2 Incomplete layout attributes specified for tag 'amp-list'. For example, provide attributes 'width' and 'height'. (see https://www.ampproject.org/docs/reference/components/amp-list) [AMP_LAYOUT_PROBLEM]
+amp-list/0.1/test/validator-amp-list.html:101:2 Incomplete layout attributes specified for tag 'amp-list'. For example, provide attributes 'width' and 'height'. (see https://www.ampproject.org/docs/reference/components/amp-list) [AMP_LAYOUT_PROBLEM]
 |      <div></div>
 |    </amp-list>
 |  </body>

--- a/extensions/amp-list/validator-amp-list.protoascii
+++ b/extensions/amp-list/validator-amp-list.protoascii
@@ -54,6 +54,8 @@ tags: {  # <amp-list> with mandatory src and/or [src] attr
   attrs: {
     name: "reset-on-refresh"
     value: ""
+    value: "always"
+    value: "fetch"
   }
   attrs: { name: "single-item" }
   attrs: {


### PR DESCRIPTION
Related to #17202. Tested locally.

Turns out that changing `reset-on-refresh` behavior to also apply to local data (#16840) is a breaking change due to content height change when removing old children. Make this behavior opt-in by requiring `reset-on-refresh="always"`.

/to @aghassemi 