### PR TITLE
🔥 Call onMeasureChanged after firstAttachedCallback

### DIFF
--- a/extensions/amp-fx-flying-carpet/0.1/amp-fx-flying-carpet.js
+++ b/extensions/amp-fx-flying-carpet/0.1/amp-fx-flying-carpet.js
@@ -92,6 +92,13 @@ export class AmpFlyingCarpet extends AMP.BaseElement {
   }
 
   /** @override */
+  firstAttachedCallback() {
+    // Fire onMeasureChanged in case we upgraded _after_ the element's
+    // measurements were really last changed.
+    this.onMeasureChanged();
+  }
+
+  /** @override */
   onMeasureChanged() {
     const width = this.getLayoutWidth();
     this.mutateElement(() => {


### PR DESCRIPTION
`onMeasureChanged` is only called when the size of the custom element is
changed. However, we may not have been upgraded when the size last
changed, meaning the noop version was called.

When the element is upgraded, assume it's measurements have been
changed.

Fixes https://github.com/ampproject/amphtml/issues/17223.