### PR TITLE
amp-bind: scanAndApply() without DOM walking

### DIFF
--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -68,11 +68,6 @@ let BoundPropertyDef;
 let BoundElementDef;
 
 /**
- * @typedef {{bindings: !Array<!BindBindingDef>, limitExceeded: boolean}}
- */
-let NodeScanDef;
-
-/**
  * A map of tag names to arrays of attributes that do not have non-bind
  * counterparts. For instance, amp-carousel allows a `[slide]` attribute,
  * but does not support a `slide` attribute.
@@ -367,7 +362,11 @@ export class Bind {
    */
   scanAndApply(addedElements, removedElements, timeout = 2000) {
     dev().info(TAG, 'rescan:', addedElements, removedElements);
-    // Helper function for cleaning up bindings in removed elements.
+    /**
+     * Helper function for cleaning up bindings in removed elements.
+     * @param {number} added
+     * @return {!Promise}
+     */
     const cleanup = added => {
       this.removeBindingsForNodes_(removedElements).then(removed => {
         dev().info(TAG,
@@ -674,7 +673,7 @@ export class Bind {
    * a tuple containing bound elements and binding data for the evaluator.
    * @param {!Node} node
    * @param {number} limit
-   * @return {!Promise<NodeScanDef>}
+   * @return {!Promise<{bindings: !Array<!BindBindingDef>, limitExceeded: boolean}>}
    * @private
    */
   scanNode_(node, limit) {

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -364,7 +364,7 @@ export class Bind {
   scanAndApply(addedElements, removedElements, timeout = 2000) {
     dev().info(TAG, 'rescan:', addedElements, removedElements);
     let promise;
-    if (isExperimentOn(this.win, 'faster-bind-scan')) {
+    if (isExperimentOn(this.win_, 'faster-bind-scan')) {
       /**
        * Helper function for cleaning up bindings in removed elements.
        * @param {number} added

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -589,9 +589,7 @@ export class Bind {
     });
   }
 
-  /**
-   * TODO(choumx)
-   */
+  /** Emits console error stating that the binding limit was exceeded. */
   emitMaxBindingsExceededError_() {
     dev().expectedError(TAG, 'Maximum number of bindings reached ' +
         `(${this.maxNumberOfBindings_}). Additional elements with ` +
@@ -599,7 +597,7 @@ export class Bind {
   }
 
   /**
-   * TODO(choumx)
+   * Sends new bindings to the web worker for parsing.
    * @param {!Array<!BindBindingDef>} bindings
    * @return {!Promise<number>}
    */
@@ -735,7 +733,7 @@ export class Bind {
   }
 
   /**
-   * TODO(choumx)
+   * Scans the element for bindings and stores them in ivars.
    * @param {!Element} element
    * @param {number} quota
    * @param {!Array<!BindBindingDef>} outBindings

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -739,11 +739,13 @@ export class Bind {
   }
 
   /**
-   * Scans the element for bindings and stores them in ivars.
+   * Scans the element for bindings and adds up to |quota| to `outBindings`.
+   * Also updates ivars `boundElements_` and `expressionToElements_`.
    * @param {!Element} element
    * @param {number} quota
    * @param {!Array<!BindBindingDef>} outBindings
-   * @return {boolean}
+   * @return {boolean} Returns true if `element` contains more than `quota`
+   *     bindings. Otherwise, returns false.
    */
   scanElement_(element, quota, outBindings) {
     let quotaExceeded = false;

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -386,7 +386,7 @@ export class Bind {
     addedElements.forEach(ae => {
       const elements = ae.querySelectorAll('[i-amphtml-binding]');
       for (let i = 0; i < elements.length; i++) {
-        this.scanElement_(elements[i], Math.POSITIVE_INFINITY, bindings);
+        this.scanElement_(elements[i], Number.POSITIVE_INFINITY, bindings);
       }
     });
     const added = bindings.length;

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -316,7 +316,7 @@ export class AmpList extends AMP.BaseElement {
     if (this.ssrTemplateHelper_.isSupported()) {
       const json = /** @type {!JsonObject} */ (current.data);
       this.templates_.findAndRenderTemplate(this.element, json)
-          .then(result => this.container_.appendChild(result.element))
+          .then(element => this.container_.appendChild(element))
           .then(onFulfilledCallback, onRejectedCallback);
     } else {
       const array = /** @type {!Array} */ (current.data);
@@ -350,7 +350,7 @@ export class AmpList extends AMP.BaseElement {
     // first mutation (AMP.setState).
     if (binding === 'refresh') {
       if (this.bind_ && this.bind_.signals().get('FIRST_MUTATE')) {
-        return updateWith(this.bind_, elements);
+        return updateWith(this.bind_);
       } else {
         return Promise.resolve(elements);
       }
@@ -359,7 +359,7 @@ export class AmpList extends AMP.BaseElement {
     // in the newly rendered `elements`.
     return Services.bindForDocOrNull(this.element).then(bind => {
       if (bind) {
-        return updateWith(bind, elements);
+        return updateWith(bind);
       } else {
         return Promise.resolve(elements);
       }

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -314,18 +314,16 @@ export class AmpList extends AMP.BaseElement {
       current.rejecter();
     };
     if (this.ssrTemplateHelper_.isSupported()) {
-      this.templates_.findAndRenderTemplate(
-          this.element, /** @type {!JsonObject} */ (current.data))
-          .then(element => {
-            this.container_.appendChild(element);
-          })
-          .then(onFulfilledCallback.bind(this), onRejectedCallback.bind(this));
+      const json = /** @type {!JsonObject} */ (current.data);
+      this.templates_.findAndRenderTemplate(this.element, json)
+          .then(result => this.container_.appendChild(result.element))
+          .then(onFulfilledCallback, onRejectedCallback);
     } else {
-      this.templates_.findAndRenderTemplateArray(
-          this.element, /** @type {!Array} */ (current.data))
-          .then(elements => this.updateBindingsForElements_(elements))
+      const array = /** @type {!Array} */ (current.data);
+      this.templates_.findAndRenderTemplateArray(this.element, array)
+          .then(results => this.updateBindings_(results))
           .then(elements => this.render_(elements))
-          .then(onFulfilledCallback.bind(this), onRejectedCallback.bind(this));
+          .then(onFulfilledCallback, onRejectedCallback);
     }
   }
 
@@ -337,17 +335,22 @@ export class AmpList extends AMP.BaseElement {
    * @return {!Promise<!Array<!Element>>}
    * @private
    */
-  updateBindingsForElements_(elements) {
+  updateBindings_(elements) {
     const binding = this.element.getAttribute('binding');
     // "no": Always skip binding update.
     if (binding === 'no') {
       return Promise.resolve(elements);
     }
+    const updateWith = bind => {
+      // Forward elements to chained promise on success or failure.
+      return bind.scanAndApply(elements, [this.container_])
+          .then(() => elements, () => elements);
+    };
     // "refresh": Do _not_ block on retrieval of the Bind service before the
     // first mutation (AMP.setState).
     if (binding === 'refresh') {
       if (this.bind_ && this.bind_.signals().get('FIRST_MUTATE')) {
-        return this.updateBindingsWith_(this.bind_, elements);
+        return updateWith(this.bind_, elements);
       } else {
         return Promise.resolve(elements);
       }
@@ -356,23 +359,11 @@ export class AmpList extends AMP.BaseElement {
     // in the newly rendered `elements`.
     return Services.bindForDocOrNull(this.element).then(bind => {
       if (bind) {
-        return this.updateBindingsWith_(bind, elements);
+        return updateWith(bind, elements);
       } else {
         return Promise.resolve(elements);
       }
     });
-  }
-
-  /**
-   * @param {!../../../extensions/amp-bind/0.1/bind-impl.Bind} bind
-   * @param {!Array<!Element>} elements
-   * @return {!Promise<!Array<!Element>>}
-   */
-  updateBindingsWith_(bind, elements) {
-    // Forward elements to chained promise on success or failure.
-    const forwardElements = () => elements;
-    return bind.scanAndApply(elements, [this.container_])
-        .then(forwardElements, forwardElements);
   }
 
   /**

--- a/src/purifier.js
+++ b/src/purifier.js
@@ -333,6 +333,9 @@ export function purifyHtml(dirty) {
     if (isBinding) {
       const property = attrName.substring(1, attrName.length - 1);
       node.setAttribute(`data-amp-bind-${property}`, attrValue);
+      // Set a custom attribute to mark this element as containing a binding.
+      // This is an optimization that obviates the need for DOM scan later.
+      node.setAttribute('i-amphtml-binding', '');
     }
 
     if (isValidAttr(tagName, attrName, attrValue, /* opt_purify */ true)) {

--- a/src/sanitizer.js
+++ b/src/sanitizer.js
@@ -175,6 +175,7 @@ function sanitizeWithCaja(html) {
         }
         return;
       }
+      let emittedBindingMarker = false;
       emit('<');
       emit(tagName);
       for (let i = 0; i < attribs.length; i += 2) {
@@ -201,6 +202,12 @@ function sanitizeWithCaja(html) {
           emit(htmlSanitizer.escapeAttrib(rewrite));
         }
         emit('"');
+        // Set a custom attribute to mark this element as containing a binding.
+        // This is an optimization that obviates the need for DOM scan later.
+        if (isBinding[i] && !emittedBindingMarker) {
+          emit(' i-amphtml-binding');
+          emittedBindingMarker = true;
+        }
       }
       emit('>');
     },

--- a/test/functional/test-purifier.js
+++ b/test/functional/test-purifier.js
@@ -66,15 +66,15 @@ describe('DOMPurify-based', () => {
   describe('for <amp-bind>', () => {
     it('should rewrite [text] and [class] attributes', () => {
       expect(purifyHtml('<p [text]="foo"></p>')).to.be
-          .equal('<p data-amp-bind-text="foo"></p>');
+          .equal('<p data-amp-bind-text="foo" i-amphtml-binding=""></p>');
       expect(purifyHtml('<p [class]="bar"></p>')).to.be
-          .equal('<p data-amp-bind-class="bar"></p>');
+          .equal('<p data-amp-bind-class="bar" i-amphtml-binding=""></p>');
     });
 
     it('should NOT rewrite values of binding attributes', () => {
       // Should not change "foo.bar".
-      expect(purifyHtml('<a [href]="foo.bar">link</a>'))
-          .to.equal('<a data-amp-bind-href="foo.bar">link</a>');
+      expect(purifyHtml('<a [href]="foo.bar">link</a>')).to.equal(
+          '<a data-amp-bind-href="foo.bar" i-amphtml-binding="">link</a>');
     });
   });
 

--- a/test/functional/test-sanitizer.js
+++ b/test/functional/test-sanitizer.js
@@ -56,14 +56,14 @@ describe('Caja-based', () => {
   describe('for <amp-bind>', () => {
     it('should output [text] and [class] attributes', () => {
       expect(sanitizeHtml('<p [text]="foo" [class]="bar"></p>')).to.be
-          .equal('<p [text]="foo" [class]="bar"></p>');
+          .equal('<p [text]="foo" i-amphtml-binding [class]="bar"></p>');
     });
 
     it('should NOT rewrite values of binding attributes', () => {
       // Should not change "foo.bar". Adding `target` attribute is not necessary
       // (but harmless) since <amp-bind> will use rewriteAttributesForElement().
-      expect(sanitizeHtml('<a [href]="foo.bar">link</a>'))
-          .to.equal('<a [href]="foo.bar" target="_top">link</a>');
+      expect(sanitizeHtml('<a [href]="foo.bar">link</a>')).to.equal(
+          '<a [href]="foo.bar" i-amphtml-binding target="_top">link</a>');
     });
   });
 });

--- a/tools/experiments/experiments.js
+++ b/tools/experiments/experiments.js
@@ -321,6 +321,12 @@ const EXPERIMENTS = [
     spec: 'https://github.com/ampproject/amphtml/issues/15146',
     cleanupIssue: 'https://github.com/ampproject/amphtml/issues/17107',
   },
+  {
+    id: 'faster-bind-scan',
+    name: 'Enables faster scanning of dynamic markup for bindings',
+    spec: 'https://github.com/ampproject/amphtml/pull/17229',
+    cleanupIssue: 'https://github.com/ampproject/amphtml/issues/17230',
+  },
 ];
 
 if (getMode().localDev) {


### PR DESCRIPTION
Alternative to #17203.

Under a new experiment 'faster-bind-scan':
- Add `i-amphtml-binding` attribute to elements with bindings i.e. `[foo]` or `data-amp-bind-foo`
- Use `querySelectorAll('[i-amphtml-binding]')` instead of TreeWalker
- Move removal of old bindings out of critical path of `scanAndApply` as another optimization

Also simplifies some of the logic for DOM scanning in bind-impl.js.