### PR TITLE
Avoid unnecessary DOM serialization in amp-mustache-0.2

### DIFF
--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -400,7 +400,6 @@ export class Bind {
             .then(results => this.applyElements_(results, addedElements));
       }).then(() => {
         // Remove bindings at the end to reduce evaluation/apply latency.
-        // Don't chain this promise since this is a non-blocking clean up task.
         cleanup(added);
       });
     } else {
@@ -749,10 +748,9 @@ export class Bind {
    */
   scanElement_(element, quota, outBindings) {
     let quotaExceeded = false;
-    let boundProperties = this.boundPropertiesInElement_(element);
-    // Stop scanning once |limit| bindings are reached.
+    const boundProperties = this.boundPropertiesInElement_(element);
     if (boundProperties.length > quota) {
-      boundProperties = boundProperties.slice(0, quota);
+      boundProperties.length = quota;
       quotaExceeded = true;
     }
     if (boundProperties.length > 0) {

--- a/extensions/amp-mustache/0.2/amp-mustache.js
+++ b/extensions/amp-mustache/0.2/amp-mustache.js
@@ -96,20 +96,9 @@ export class AmpMustache extends AMP.BaseTemplate {
       }
       html = mustacheRender(this.template_, mustacheData);
     }
-    return this.serializeHtml_(html);
-  }
-
-  /**
-   * Sanitizes the html and inserts it in the DOM.
-   * @param {string} html
-   * @return {!Element}
-   * @private
-   */
-  serializeHtml_(html) {
-    const sanitized = purifyHtml(html);
-    const root = this.win.document.createElement('div');
-    root./*OK*/innerHTML = sanitized;
-    return this.unwrap(root);
+    const body = purifyHtml(`<div>${html}</div>`);
+    const div = body.firstElementChild;
+    return this.unwrap(div);
   }
 }
 

--- a/src/purifier.js
+++ b/src/purifier.js
@@ -234,6 +234,8 @@ export function purifyHtml(dirty) {
     'FORBID_TAGS': Object.keys(BLACKLISTED_TAGS),
     // Avoid reparenting of some elements to document head e.g. <script>.
     'FORCE_BODY': true,
+    // Avoid need for serializing to/from string by returning Node directly.
+    'RETURN_DOM': true,
   });
 
   // Reference to DOMPurify's `allowedTags` whitelist.
@@ -383,9 +385,9 @@ export function purifyHtml(dirty) {
   DOMPurify.addHook('afterSanitizeElements', afterSanitizeElements);
   DOMPurify.addHook('uponSanitizeAttribute', uponSanitizeAttribute);
   DOMPurify.addHook('afterSanitizeAttributes', afterSanitizeAttributes);
-  const purified = DOMPurify.sanitize(dirty, config);
+  const body = DOMPurify.sanitize(dirty, config);
   DOMPurify.removeAllHooks();
-  return purified;
+  return body;
 }
 
 /**

--- a/src/purifier.js
+++ b/src/purifier.js
@@ -224,8 +224,9 @@ const PURIFY_CONFIG = {
 };
 
 /**
+ * Returns a <body> element containing the sanitized, serialized `dirty`.
  * @param {string} dirty
- * @return {string}
+ * @return {!Node}
  */
 export function purifyHtml(dirty) {
   const config = Object.assign({}, PURIFY_CONFIG, {

--- a/test/functional/test-purifier.js
+++ b/test/functional/test-purifier.js
@@ -23,57 +23,66 @@ import {
 } from '../../src/purifier';
 import {toggleExperiment} from '../../src/experiments';
 
+/**
+ * Helper that serializes output of purifyHtml() to string.
+ * @param {string} html
+ * @return {string}
+ */
+function purify(html) {
+  return purifyHtml(html).innerHTML;
+}
+
 describe('DOMPurify-based', () => {
   runSanitizerTests();
 
   describe('<script>', () => {
     it('should not allow plain <script> tags', () => {
-      expect(purifyHtml('<script>alert(1)</script>')).to.equal('');
+      expect(purify('<script>alert(1)</script>')).to.equal('');
     });
 
     it('should not allow script[type="text/javascript"]', () => {
-      expect(purifyHtml('<script type="text/javascript">alert(1)</script>'))
+      expect(purify('<script type="text/javascript">alert(1)</script>'))
           .to.equal('');
     });
 
     it('should not allow script[type="application/javascript"]', () => {
       const html = '<script type="application/javascript">alert(1)</script>';
-      expect(purifyHtml(html)).to.equal('');
+      expect(purify(html)).to.equal('');
     });
 
     it('should allow script[type="application/json"]', () => {
       const html = '<script type="application/json">{}</script>';
-      expect(purifyHtml(html)).to.equal(html);
+      expect(purify(html)).to.equal(html);
     });
 
     it('should allow script[type="application/ld+json"]', () => {
       const html = '<script type="application/ld+json">{}</script>';
-      expect(purifyHtml(html)).to.equal(html);
+      expect(purify(html)).to.equal(html);
     });
 
     it('should not allow insecure <script> tags around secure ones', () => {
       const html = '<script type="application/json">{}</script>';
       // Should not allow an insecure tag following a secure one.
-      expect(purifyHtml(html + '<script>alert(1)</script>')).to.equal(html);
+      expect(purify(html + '<script>alert(1)</script>')).to.equal(html);
       // Should not allow an insecure tag preceding a secure one.
-      expect(purifyHtml('<script>alert(1)</script>' + html)).to.equal(html);
+      expect(purify('<script>alert(1)</script>' + html)).to.equal(html);
       // Should not allow an insecure tag containing a secure one.
-      expect(purifyHtml('<script>alert(1)' +
+      expect(purify('<script>alert(1)' +
           '<script type="application/json">{}</script></script>')).to.equal('');
     });
   });
 
   describe('for <amp-bind>', () => {
     it('should rewrite [text] and [class] attributes', () => {
-      expect(purifyHtml('<p [text]="foo"></p>')).to.be
+      expect(purify('<p [text]="foo"></p>')).to.be
           .equal('<p data-amp-bind-text="foo" i-amphtml-binding=""></p>');
-      expect(purifyHtml('<p [class]="bar"></p>')).to.be
+      expect(purify('<p [class]="bar"></p>')).to.be
           .equal('<p data-amp-bind-class="bar" i-amphtml-binding=""></p>');
     });
 
     it('should NOT rewrite values of binding attributes', () => {
       // Should not change "foo.bar".
-      expect(purifyHtml('<a [href]="foo.bar">link</a>')).to.equal(
+      expect(purify('<a [href]="foo.bar">link</a>')).to.equal(
           '<a data-amp-bind-href="foo.bar" i-amphtml-binding="">link</a>');
     });
   });
@@ -83,14 +92,14 @@ describe('DOMPurify-based', () => {
     it('should prevent XSS via <G> tag and onload attribute', () => {
       const svg = '<svg xmlns="http://www.w3.org/2000/svg">'
           + '<g onload="javascript:alert(1)"></g></svg>';
-      expect(purifyHtml(svg)).to.equal(
+      expect(purify(svg)).to.equal(
           '<svg xmlns="http://www.w3.org/2000/svg"><g></g></svg>');
     });
 
     it('should prevent XSS via <SCRIPT> tag', () => {
       const svg = '<svg xmlns="http://www.w3.org/2000/svg">'
           + '<script>alert(1)</script></svg>';
-      expect(purifyHtml(svg)).to.equal(
+      expect(purify(svg)).to.equal(
           '<svg xmlns="http://www.w3.org/2000/svg"></svg>');
     });
 
@@ -98,7 +107,7 @@ describe('DOMPurify-based', () => {
         + 'SVG elements', () => {
       const svg = '<svg onload="javascript:alert(1)" '
           + 'xmlns="http://www.w3.org/2000/svg"></svg>';
-      expect(purifyHtml(svg)).to.equal(
+      expect(purify(svg)).to.equal(
           '<svg xmlns="http://www.w3.org/2000/svg"></svg>');
     });
 
@@ -107,7 +116,7 @@ describe('DOMPurify-based', () => {
           + '<a xmlns:xlink="http://www.w3.org/1999/xlink" '
           + 'xlink:href="javascript:alert(1)">'
           + '<rect width="1000" height="1000" fill="white"/></a></svg>';
-      expect(purifyHtml(svg)).to.equal(
+      expect(purify(svg)).to.equal(
           '<svg xmlns="http://www.w3.org/2000/svg">'
           + '<a xmlns:xlink="http://www.w3.org/1999/xlink">' +
           '<rect fill="white" height="1000" width="1000"></rect></a></svg>');
@@ -120,7 +129,7 @@ describe('DOMPurify-based', () => {
           + '<animate attributeName="xlink:href" begin="0" '
           + 'from="javascript:alert(1)" to="&" />'
           + '</a></svg>';
-      expect(purifyHtml(svg)).to.equal(
+      expect(purify(svg)).to.equal(
           '<svg><a xlink:href="?" xmlns:xlink="http://www.w3.org/1999/xlink">'
           + '<circle r="400"></circle></a></svg>');
     });
@@ -151,16 +160,16 @@ function runSanitizerTests() {
     }
 
     it('should output basic text', () => {
-      expect(purifyHtml('abc')).to.be.equal('abc');
+      expect(purify('abc')).to.be.equal('abc');
     });
 
     it('should output valid markup', () => {
-      expect(purifyHtml('<h1>abc</h1>')).to.be.equal('<h1>abc</h1>');
-      expect(purifyHtml('<h1>a<i>b</i>c</h1>')).to.be.equal(
+      expect(purify('<h1>abc</h1>')).to.be.equal('<h1>abc</h1>');
+      expect(purify('<h1>a<i>b</i>c</h1>')).to.be.equal(
           '<h1>a<i>b</i>c</h1>');
-      expect(purifyHtml('<h1>a<i>b</i><br>c</h1>')).to.be.equal(
+      expect(purify('<h1>a<i>b</i><br>c</h1>')).to.be.equal(
           '<h1>a<i>b</i><br>c</h1>');
-      expect(purifyHtml(
+      expect(purify(
           '<h1>a<i>b</i>c' +
           '<amp-img src="http://example.com/1.png"></amp-img></h1>'))
           .to.be.equal(
@@ -169,42 +178,42 @@ function runSanitizerTests() {
     });
 
     it('should NOT output security-sensitive markup', () => {
-      expect(purifyHtml('a<script>b</script>c')).to.be.equal('ac');
-      expect(purifyHtml('a<script>b<img>d</script>c')).to.be.equal('ac');
-      expect(purifyHtml('a<style>b</style>c')).to.be.equal('ac');
-      expect(purifyHtml('a<img>c')).to.be.equal('ac');
-      expect(purifyHtml('a<iframe></iframe>c')).to.be.equal('ac');
-      expect(purifyHtml('a<frame></frame>c')).to.be.equal('ac');
-      expect(purifyHtml('a<video></video>c')).to.be.equal('ac');
-      expect(purifyHtml('a<audio></audio>c')).to.be.equal('ac');
-      expect(purifyHtml('a<applet></applet>c')).to.be.equal('ac');
-      expect(purifyHtml('a<link>c')).to.be.equal('ac');
-      expect(purifyHtml('a<meta>c')).to.be.equal('ac');
+      expect(purify('a<script>b</script>c')).to.be.equal('ac');
+      expect(purify('a<script>b<img>d</script>c')).to.be.equal('ac');
+      expect(purify('a<style>b</style>c')).to.be.equal('ac');
+      expect(purify('a<img>c')).to.be.equal('ac');
+      expect(purify('a<iframe></iframe>c')).to.be.equal('ac');
+      expect(purify('a<frame></frame>c')).to.be.equal('ac');
+      expect(purify('a<video></video>c')).to.be.equal('ac');
+      expect(purify('a<audio></audio>c')).to.be.equal('ac');
+      expect(purify('a<applet></applet>c')).to.be.equal('ac');
+      expect(purify('a<link>c')).to.be.equal('ac');
+      expect(purify('a<meta>c')).to.be.equal('ac');
     });
 
     it('should NOT output security-sensitive markup when nested', () => {
-      expect(purifyHtml('a<script><style>b</style></script>c'))
+      expect(purify('a<script><style>b</style></script>c'))
           .to.be.equal('ac');
-      expect(purifyHtml('a<style><iframe>b</iframe></style>c'))
+      expect(purify('a<style><iframe>b</iframe></style>c'))
           .to.be.equal('ac');
-      expect(purifyHtml('a<script><img></script>c'))
+      expect(purify('a<script><img></script>c'))
           .to.be.equal('ac');
     });
 
     it('should NOT output security-sensitive markup when broken', () => {
-      expect(purifyHtml('a<script>bc')).to.be.equal('a');
-      expect(purifyHtml('a<SCRIPT>bc')).to.be.equal('a');
+      expect(purify('a<script>bc')).to.be.equal('a');
+      expect(purify('a<SCRIPT>bc')).to.be.equal('a');
     });
 
     it('should output "on" attribute', () => {
-      expect(purifyHtml('a<a on="tap:AMP.print">b</a>')).to.be.equal(
+      expect(purify('a<a on="tap:AMP.print">b</a>')).to.be.equal(
           'a<a on="tap:AMP.print">b</a>');
     });
 
     it('should output "data-, aria-, and role" attributes', () => {
       // Can't use string equality since DOMPurify will reorder attributes.
       const actual = serialize(
-          purifyHtml('<a aria-label="bar" data-foo="bar" role="button">b</a>')
+          purify('<a aria-label="bar" data-foo="bar" role="button">b</a>')
       );
       const expected = serialize(
           '<a aria-label="bar" data-foo="bar" role="button">b</a>');
@@ -214,7 +223,7 @@ function runSanitizerTests() {
     it('should output "href" attribute', () => {
       // Can't use string equality since DOMPurify will reorder attributes.
       const actual = serialize(
-          purifyHtml('a<a href="http://acme.com/">b</a>')
+          purify('a<a href="http://acme.com/">b</a>')
       );
       const expected = serialize(
           'a<a target="_top" href="http://acme.com/">b</a>');
@@ -224,7 +233,7 @@ function runSanitizerTests() {
     it('should output "rel" attribute', () => {
       // Can't use string equality since DOMPurify will reorder attributes.
       const actual = serialize(
-          purifyHtml('a<a href="http://acme.com/" rel="amphtml">b</a>')
+          purify('a<a href="http://acme.com/" rel="amphtml">b</a>')
       );
       const expected = serialize(
           'a<a href="http://acme.com/" rel="amphtml" target="_top">b</a>');
@@ -233,28 +242,28 @@ function runSanitizerTests() {
 
     it('should output "layout" attribute', () => {
       const img = '<amp-img layout="responsive"></amp-img>';
-      expect(purifyHtml(img)).to.equal(img);
+      expect(purify(img)).to.equal(img);
     });
 
     it('should output "media" attribute', () => {
       const img = '<amp-img media="(min-width: 650px)"></amp-img>';
-      expect(purifyHtml(img)).to.equal(img);
+      expect(purify(img)).to.equal(img);
     });
 
     it('should output "sizes" attribute', () => {
       const img = '<amp-img sizes="(min-width: 650px) 50vw, 100vw"></amp-img>';
-      expect(purifyHtml(img)).to.equal(img);
+      expect(purify(img)).to.equal(img);
     });
 
     it('should output "heights" attribute', () => {
       const img = '<amp-img heights="(min-width:500px) 200px, 80%"></amp-img>';
-      expect(purifyHtml(img)).to.equal(img);
+      expect(purify(img)).to.equal(img);
     });
 
     it('should default target to _top with href', () => {
       // Can't use string equality since DOMPurify will reorder attributes.
       const actual = serialize(
-          purifyHtml('<a href="">a</a><a href="" target="">c</a>')
+          purify('<a href="">a</a><a href="" target="">c</a>')
       );
       const expected = serialize(
           '<a href="" target="_top">a</a><a href="" target="_top">c</a>');
@@ -262,7 +271,7 @@ function runSanitizerTests() {
     });
 
     it('should NOT default target to _top w/o href', () => {
-      expect(purifyHtml(
+      expect(purify(
           '<a>b</a>'
           + '<a target="">d</a>'
       )).to.equal(
@@ -271,17 +280,17 @@ function runSanitizerTests() {
     });
 
     it('should output a valid target', () => {
-      expect(purifyHtml('<a target="_top">a</a><a target="_blank">b</a>'))
+      expect(purify('<a target="_top">a</a><a target="_blank">b</a>'))
           .to.equal('<a target="_top">a</a><a target="_blank">b</a>');
     });
 
     it('should output a valid target in different case', () => {
-      expect(purifyHtml('<a target="_TOP">a</a><a target="_BLANK">b</a>'))
+      expect(purify('<a target="_TOP">a</a><a target="_BLANK">b</a>'))
           .to.equal('<a target="_top">a</a><a target="_blank">b</a>');
     });
 
     it('should override a unallowed target', () => {
-      expect(purifyHtml(
+      expect(purify(
           '<a target="_self">_self</a>'
           + '<a target="_parent">_parent</a>'
           + '<a target="_other">_other</a>'
@@ -297,53 +306,53 @@ function runSanitizerTests() {
 
     it('should NOT output security-sensitive attributes', () => {
       allowConsoleError(() => {
-        expect(purifyHtml('a<a onclick="alert">b</a>')).to.be.equal(
+        expect(purify('a<a onclick="alert">b</a>')).to.be.equal(
             'a<a>b</a>');
-        expect(purifyHtml('a<a style="color: red;">b</a>')).to.be.equal(
+        expect(purify('a<a style="color: red;">b</a>')).to.be.equal(
             'a<a>b</a>');
-        expect(purifyHtml('a<a STYLE="color: red;">b</a>')).to.be.equal(
+        expect(purify('a<a STYLE="color: red;">b</a>')).to.be.equal(
             'a<a>b</a>');
-        expect(purifyHtml('a<a href="javascript:alert">b</a>')).to.be.equal(
+        expect(purify('a<a href="javascript:alert">b</a>')).to.be.equal(
             'a<a target="_top">b</a>');
-        expect(purifyHtml('a<a href="JAVASCRIPT:alert">b</a>')).to.be.equal(
+        expect(purify('a<a href="JAVASCRIPT:alert">b</a>')).to.be.equal(
             'a<a target="_top">b</a>');
-        expect(purifyHtml('a<a href="vbscript:alert">b</a>')).to.be.equal(
+        expect(purify('a<a href="vbscript:alert">b</a>')).to.be.equal(
             'a<a target="_top">b</a>');
-        expect(purifyHtml('a<a href="VBSCRIPT:alert">b</a>')).to.be.equal(
+        expect(purify('a<a href="VBSCRIPT:alert">b</a>')).to.be.equal(
             'a<a target="_top">b</a>');
-        expect(purifyHtml('a<a href="data:alert">b</a>')).to.be.equal(
+        expect(purify('a<a href="data:alert">b</a>')).to.be.equal(
             'a<a target="_top">b</a>');
-        expect(purifyHtml('a<a href="DATA:alert">b</a>')).to.be.equal(
+        expect(purify('a<a href="DATA:alert">b</a>')).to.be.equal(
             'a<a target="_top">b</a>');
       });
     });
 
     it('should NOT output blacklisted values for class attributes', () => {
       allowConsoleError(() => {
-        expect(purifyHtml('<p class="i-amphtml-">hello</p>')).to.be
+        expect(purify('<p class="i-amphtml-">hello</p>')).to.be
             .equal('<p>hello</p>');
-        expect(purifyHtml('<p class="i-amphtml-class">hello</p>')).to.be
+        expect(purify('<p class="i-amphtml-class">hello</p>')).to.be
             .equal('<p>hello</p>');
-        expect(purifyHtml('<p class="foo-i-amphtml-bar">hello</p>')).to.be
+        expect(purify('<p class="foo-i-amphtml-bar">hello</p>')).to.be
             .equal('<p>hello</p>');
       });
     });
 
     it('should allow amp-subscriptions attributes', () => {
-      expect(purifyHtml('<div subscriptions-action="login">link</div>'))
+      expect(purify('<div subscriptions-action="login">link</div>'))
           .to.equal('<div subscriptions-action="login">link</div>');
-      expect(purifyHtml('<div subscriptions-section="actions">link</div>'))
+      expect(purify('<div subscriptions-section="actions">link</div>'))
           .to.equal('<div subscriptions-section="actions">link</div>');
-      expect(purifyHtml('<div subscriptions-actions="">link</div>'))
+      expect(purify('<div subscriptions-actions="">link</div>'))
           .to.equal('<div subscriptions-actions="">link</div>');
-      expect(purifyHtml('<div subscriptions-display="">link</div>'))
+      expect(purify('<div subscriptions-display="">link</div>'))
           .to.equal('<div subscriptions-display="">link</div>');
-      expect(purifyHtml('<div subscriptions-dialog="">link</div>'))
+      expect(purify('<div subscriptions-dialog="">link</div>'))
           .to.equal('<div subscriptions-dialog="">link</div>');
     });
 
     it('should allow source::src with valid protocol', () => {
-      expect(purifyHtml('<source src="https://www.foo.com/">'))
+      expect(purify('<source src="https://www.foo.com/">'))
           .to.equal('<source src="https://www.foo.com/">');
     });
 
@@ -351,19 +360,19 @@ function runSanitizerTests() {
     // in the sanitizer yet. E.g. amp-video requires HTTPS, amp-img does not.
     // Unskip when this is fixed.
     it.skip('should not allow source::src with invalid protocol', () => {
-      expect(purifyHtml('<source src="http://www.foo.com">'))
+      expect(purify('<source src="http://www.foo.com">'))
           .to.equal('<source src="">');
-      expect(purifyHtml('<source src="<script>bad()</script>">'))
+      expect(purify('<source src="<script>bad()</script>">'))
           .to.equal('<source src="">');
     });
 
     it('should allow div::template', () => {
-      expect(purifyHtml('<div template="my-template-id"></div>'))
+      expect(purify('<div template="my-template-id"></div>'))
           .to.equal('<div template="my-template-id"></div>');
     });
 
     it('should allow form::action-xhr', () => {
-      expect(purifyHtml('<form action-xhr="https://foo.com"></form>'))
+      expect(purify('<form action-xhr="https://foo.com"></form>'))
           .to.equal('<form action-xhr="https://foo.com"></form>');
     });
 
@@ -372,22 +381,22 @@ function runSanitizerTests() {
     it('should not allow unsupported attributes after a valid one', () => {
       const html = '<form action-xhr="https://foo.com"></form>' +
             '<p action-xhr="https://foo.com"></p>';
-      expect(purifyHtml(html))
+      expect(purify(html))
           .to.equal('<form action-xhr="https://foo.com"></form><p></p>');
     });
 
     it('should allow <amp-form>-related attributes', () => {
-      expect(purifyHtml('<div submitting></div>'))
+      expect(purify('<div submitting></div>'))
           .to.equal('<div submitting=""></div>');
-      expect(purifyHtml('<div submit-success></div>'))
+      expect(purify('<div submit-success></div>'))
           .to.equal('<div submit-success=""></div>');
-      expect(purifyHtml('<div submit-error></div>'))
+      expect(purify('<div submit-error></div>'))
           .to.equal('<div submit-error=""></div>');
-      expect(purifyHtml('<div verify-error></div>'))
+      expect(purify('<div verify-error></div>'))
           .to.equal('<div verify-error=""></div>');
-      expect(purifyHtml('<span visible-when-invalid="valueMissing"></span>'))
+      expect(purify('<span visible-when-invalid="valueMissing"></span>'))
           .to.equal('<span visible-when-invalid="valueMissing"></span>');
-      expect(purifyHtml('<span validation-for="form1"></span>'))
+      expect(purify('<span validation-for="form1"></span>'))
           .to.equal('<span validation-for="form1"></span>');
     });
   });
@@ -448,27 +457,27 @@ function runSanitizerTests() {
       });
 
       it('should allow valid styles',() => {
-        expect(purifyHtml('<div style="color:blue">Test</div>'))
+        expect(purify('<div style="color:blue">Test</div>'))
             .to.equal('<div style="color:blue">Test</div>');
       });
 
       it('should ignore styles containing `!important`',() => {
         allowConsoleError(() => {
-          expect(purifyHtml('<div style="color:blue!important">Test</div>'))
+          expect(purify('<div style="color:blue!important">Test</div>'))
               .to.equal('<div>Test</div>');
         });
       });
 
       it('should ignore styles containing `position:fixed`', () => {
         allowConsoleError(() => {
-          expect(purifyHtml('<div style="position:fixed">Test</div>'))
+          expect(purify('<div style="position:fixed">Test</div>'))
               .to.equal('<div>Test</div>');
         });
       });
 
       it('should ignore styles containing `position:sticky`', () => {
         allowConsoleError(() => {
-          expect(purifyHtml('<div style="position:sticky">Test</div>'))
+          expect(purify('<div style="position:sticky">Test</div>'))
               .to.equal('<div>Test</div>');
         });
       });
@@ -539,9 +548,9 @@ describe('resolveUrlAttr', () => {
   });
 
   it('should be called by sanitizer', () => {
-    expect(purifyHtml('<a href="/path"></a>')).to.match(/http/);
-    expect(purifyHtml('<amp-img src="/path"></amp-img>')).to.match(/http/);
-    expect(purifyHtml('<amp-img srcset="/path"></amp-img>'))
+    expect(purify('<a href="/path"></a>')).to.match(/http/);
+    expect(purify('<amp-img src="/path"></amp-img>')).to.match(/http/);
+    expect(purify('<amp-img srcset="/path"></amp-img>'))
         .to.match(/http/);
   });
 

--- a/test/functional/test-purifier.js
+++ b/test/functional/test-purifier.js
@@ -29,7 +29,8 @@ import {toggleExperiment} from '../../src/experiments';
  * @return {string}
  */
 function purify(html) {
-  return purifyHtml(html).innerHTML;
+  const body = purifyHtml(html);
+  return body.innerHTML;
 }
 
 describe('DOMPurify-based', () => {


### PR DESCRIPTION
- Shaves off a few ms by not setting `innerHTML`.
- Fixes @jridgewell's comments in #17229.