### PR TITLE
CSS RTL improvements to amp-story 🖍

### DIFF
--- a/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.css
+++ b/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.css
@@ -70,11 +70,22 @@ amp-story-page[active] .i-amphtml-story-ad-link {
   z-index: 100001 !important;
 }
 
+[dir=rtl] .i-amphtml-ad-overlay-container {
+  left: auto !important;
+  right: 0 !important;
+}
+
 [desktop] .i-amphtml-ad-overlay-container {
   /* On desktop a story page has a with of 45vh. */
   left: calc(50vw - 22.5vh) !important;
   /* And a height of 75 vh. */
   top: 12.5vh !important;
+}
+
+[dir=rtl] [desktop] .i-amphtml-ad-overlay-container {
+  left: auto !important;
+  /* On desktop a story page has a with of 45vh. */
+  right: calc(50vw - 22.5vh) !important;
 }
 
 .i-amphtml-story-ad-attribution {
@@ -87,6 +98,11 @@ amp-story-page[active] .i-amphtml-story-ad-link {
   opacity: 0 !important;
   padding: 0 !important;
   visibility: hidden !important;
+}
+
+[dir=rtl] .i-amphtml-story-ad-attribution {
+  margin-left:0px !important;
+  margin-right:16px !important;
 }
 
 amp-story[ad-showing][desktop] .i-amphtml-story-ad-attribution {

--- a/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.css
+++ b/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.css
@@ -101,8 +101,8 @@ amp-story-page[active] .i-amphtml-story-ad-link {
 }
 
 [dir=rtl] .i-amphtml-story-ad-attribution {
-  margin-left:0px !important;
-  margin-right:16px !important;
+  margin-left: 0px !important;
+  margin-right: 16px !important;
 }
 
 amp-story[ad-showing][desktop] .i-amphtml-story-ad-attribution {

--- a/extensions/amp-story/1.0/amp-story-bookend.css
+++ b/extensions/amp-story/1.0/amp-story-bookend.css
@@ -169,9 +169,7 @@
   }
 
   .i-amphtml-story-bookend-component:not(.i-amphtml-story-bookend-heading) {
-    /**
-    * 12px to match 24px margin-bottom with margin between 2 elements.
-    */
+    /* 12px to match 24px margin-bottom with margin between 2 elements. */
     width: calc(50% - 12px) !important;
   }
 }
@@ -179,9 +177,9 @@
 @media (min-width: 960px) {
   .i-amphtml-story-bookend-component:not(.i-amphtml-story-bookend-heading) {
     /**
-    * 16px to get 24 in the two margins between the 3 elements and match the margin-bottom.
-    * 16px = (24px * 2) / 3
-    */
+     * 16px to get 24 in the two margins between the 3 elements and match the margin-bottom.
+     * 16px = (24px * 2) / 3
+     */
     width: calc(33% - 16px) !important;
   }
 }
@@ -403,9 +401,7 @@
 
 @media (min-width: 952px) {
   [desktop] .i-amphtml-story-bookend-component:not(.i-amphtml-story-bookend-heading) {
-    /**
-    * 12px to match 24px margin-bottom with margin between 2 elements.
-    */
+    /* 12px to match 24px margin-bottom with margin between 2 elements. */
     width: calc(50% - 12px) !important;
   }
 }
@@ -413,9 +409,9 @@
 @media (min-width: 1272px) {
   [desktop] .i-amphtml-story-bookend-component:not(.i-amphtml-story-bookend-heading) {
     /**
-    * 16px to get 24 in the two margins between the 3 elements and match the margin-bottom.
-    * 16px = (24px * 2) / 3
-    */
+     * 16px to get 24 in the two margins between the 3 elements and match the margin-bottom.
+     * 16px = (24px * 2) / 3
+     */
     width: calc(33% - 16px) !important;
   }
 }

--- a/extensions/amp-story/1.0/amp-story-bookend.css
+++ b/extensions/amp-story/1.0/amp-story-bookend.css
@@ -30,7 +30,7 @@
   transition: transform 0.3s cubic-bezier(0.0, 0.0, 0.2, 1) !important;
 }
 
-[dir=rtl] {
+[dir=rtl].i-amphtml-story-bookend {
   text-align: right !important;
 }
 
@@ -128,6 +128,11 @@
   padding-right: 10px !important;
 }
 
+[dir=rtl] .i-amphtml-story-bookend-article-text-content {
+  padding-right: 0px !important;
+  padding-left: 10px !important;
+}
+
 .i-amphtml-story-bookend-article-heading,
 .i-amphtml-story-bookend-text,
 .i-amphtml-story-bookend-consent-button {
@@ -154,8 +159,6 @@
   text-decoration: none !important;
   color: inherit !important;
   overflow: hidden !important;
-  flex: 1 0 320px !important;
-  min-width: 33% !important;
 }
 
 @media (min-width: 640px) {
@@ -166,14 +169,20 @@
   }
 
   .i-amphtml-story-bookend-component:not(.i-amphtml-story-bookend-heading) {
-    /** Leave some horizontal space between cards. */
-    max-width: calc(50%-12px) !important;
+    /**
+    * 12px to match 24px margin-bottom with margin between 2 elements.
+    */
+    width: calc(50% - 12px) !important;
   }
 }
 
 @media (min-width: 960px) {
   .i-amphtml-story-bookend-component:not(.i-amphtml-story-bookend-heading) {
-    max-width: 33% !important;
+    /**
+    * 16px to get 24 in the two margins between the 3 elements and match the margin-bottom.
+    * 16px = (24px * 2) / 3
+    */
+    width: calc(33% - 16px) !important;
   }
 }
 
@@ -254,7 +263,7 @@
 }
 
 .i-amphtml-story-bookend-replay {
-  margin: 0 32px !important;
+  margin: 0 24px !important;
   overflow: hidden !important;
   display: flex !important;
   max-height: 120px !important;
@@ -285,8 +294,8 @@
 }
 
 .i-amphtml-story-bookend-component-set {
-  margin: 0 32px !important;
-  margin-bottom: 32px !important;
+  margin: 0 24px !important;
+  margin-bottom: 24px !important;
 }
 
 .i-amphtml-story-bookend-cta-link-wrapper,
@@ -296,7 +305,6 @@
   box-sizing: border-box !important;
   color: inherit !important;
   overflow: hidden !important;
-  flex: 1 0 320px !important;
   justify-content: space-between !important;
 }
 
@@ -395,14 +403,19 @@
 
 @media (min-width: 952px) {
   [desktop] .i-amphtml-story-bookend-component:not(.i-amphtml-story-bookend-heading) {
-    /** Leave some horizontal space between cards. */
-    max-width: calc(50%-12px) !important;
+    /**
+    * 12px to match 24px margin-bottom with margin between 2 elements.
+    */
+    width: calc(50% - 12px) !important;
   }
 }
 
 @media (min-width: 1272px) {
   [desktop] .i-amphtml-story-bookend-component:not(.i-amphtml-story-bookend-heading) {
-    /** Leave some horizontal space between cards. */
-    max-width: calc(33%-12px) !important;
+    /**
+    * 16px to get 24 in the two margins between the 3 elements and match the margin-bottom.
+    * 16px = (24px * 2) / 3
+    */
+    width: calc(33% - 16px) !important;
   }
 }

--- a/extensions/amp-story/1.0/amp-story-bookend.css
+++ b/extensions/amp-story/1.0/amp-story-bookend.css
@@ -125,9 +125,22 @@
 
 .i-amphtml-story-bookend-article-text-content {
   width: 100% !important;
-  flex: 1;
-  overflow: hidden;
+  flex: 1 !important;
+  overflow: hidden !important;
   padding-right: 10px !important;
+}
+
+.i-amphtml-story-bookend-article-heading,
+.i-amphtml-story-bookend-text,
+.i-amphtml-story-bookend-consent-button {
+  font-weight: 400 !important;
+  font-size: 16px !important;
+  overflow: hidden !important;
+  text-overflow: ellipsis !important;
+  color: #fff !important;
+  line-height: 1.45em !important;
+  max-height: 4.35em !important;
+  margin: 0 0 8px !important;
 }
 
 .i-amphtml-story-bookend-component {
@@ -149,28 +162,22 @@
 }
 
 @media (min-width: 640px) {
-  .i-amphtml-story-bookend-component {
-    max-width: 50% !important;
+  .i-amphtml-story-bookend-component-set {
+    display: flex !important;
+    flex-wrap: wrap !important;
+    justify-content: space-between !important;
+  }
+
+  .i-amphtml-story-bookend-component:not(.i-amphtml-story-bookend-heading) {
+    /** Leave some horizontal space between cards. */
+    max-width: calc(50%-12px) !important;
   }
 }
 
 @media (min-width: 960px) {
-  .i-amphtml-story-bookend-component {
+  .i-amphtml-story-bookend-component:not(.i-amphtml-story-bookend-heading) {
     max-width: 33% !important;
   }
-}
-
-.i-amphtml-story-bookend-article-heading,
-.i-amphtml-story-bookend-text,
-.i-amphtml-story-bookend-consent-button {
-  font-weight: 400 !important;
-  font-size: 16px !important;
-  overflow: hidden !important;
-  text-overflow: ellipsis !important;
-  color: #fff !important;
-  line-height: 1.45em !important;
-  max-height: 4.35em !important;
-  margin: 0 0 8px !important;
 }
 
 .i-amphtml-story-bookend-text {
@@ -258,7 +265,7 @@
   overflow: hidden !important;
   display: flex !important;
   box-sizing: border-box !important;
-  max-height: 110px !important;
+  max-height: 120px !important;
   justify-content: space-between !important;
 }
 
@@ -290,11 +297,11 @@
   margin: 0 32px !important;
 }
 
-[desktop] .i-amphtml-story-bookend-component-set {
+/* [desktop] .i-amphtml-story-bookend-component-set {
   display: flex !important;
   flex-wrap: wrap !important;
   justify-content: space-between !important;
-}
+} */
 
 .i-amphtml-story-bookend-cta-link-wrapper,
 .i-amphtml-story-bookend-textbox {
@@ -400,15 +407,15 @@
 }
 
 @media (min-width: 952px) {
-  [desktop] .i-amphtml-story-bookend-component {
+  [desktop] .i-amphtml-story-bookend-component:not(.i-amphtml-story-bookend-heading) {
     /** Leave some horizontal space between cards. */
     max-width: calc(50%-12px) !important;
   }
 }
 
 @media (min-width: 1272px) {
-  [desktop] .i-amphtml-story-bookend-component {
+  [desktop] .i-amphtml-story-bookend-component:not(.i-amphtml-story-bookend-heading) {
     /** Leave some horizontal space between cards. */
-    max-width: calc(50%-12px) !important;
+    max-width: calc(33%-12px) !important;
   }
 }

--- a/extensions/amp-story/1.0/amp-story-bookend.css
+++ b/extensions/amp-story/1.0/amp-story-bookend.css
@@ -124,7 +124,6 @@
 
 .i-amphtml-story-bookend-article-text-content {
   width: 100% !important;
-  /* flex: 1 !important; */
   overflow: hidden !important;
   padding-right: 10px !important;
 }
@@ -203,7 +202,6 @@
   height: 100px !important;
   border-radius: 8px !important;
   overflow: hidden !important;
-  /* flex-shrink: 0 !important; */
 }
 
 
@@ -259,7 +257,6 @@
   margin: 0 32px !important;
   overflow: hidden !important;
   display: flex !important;
-  box-sizing: border-box !important;
   max-height: 120px !important;
   justify-content: space-between !important;
 }

--- a/extensions/amp-story/1.0/amp-story-bookend.css
+++ b/extensions/amp-story/1.0/amp-story-bookend.css
@@ -30,6 +30,10 @@
   transition: transform 0.3s cubic-bezier(0.0, 0.0, 0.2, 1) !important;
 }
 
+[dir=rtl] {
+  text-align: right !important;
+}
+
 .i-amphtml-story-bookend.i-amphtml-hidden {
   transition: transform 0.2s cubic-bezier(0.4, 0.0, 1, 1) !important;
   transform: translateY(100vh) !important;
@@ -43,6 +47,7 @@
 }
 
 .i-amphtml-story-bookend-inner {
+  box-sizing: border-box !important;
   margin: 88px 0 0 !important;
   font-family: 'Roboto', sans-serif !important;
   position: relative !important;
@@ -106,21 +111,28 @@
   overflow: hidden !important;
   white-space: nowrap !important;
   line-height: 16px !important;
-  width: 50% !important;
   color: rgba(255, 255, 255, 0.6) !important;
   margin-top: 8px !important;
 }
 
 .i-amphtml-story-bookend-article {
-  box-sizing: border-box !important;
-  display: block !important;
   text-decoration: none !important;
   color: inherit !important;
-  overflow: hidden !important;
-  flex: 1 0 320px !important;
-  min-width: 33% !important;
   margin: 24px 0 !important;
-  padding: 0 32px !important;
+  display: flex !important;
+  justify-content: space-between !important;
+  max-height: 104px !important;
+}
+
+.i-amphtml-story-bookend-article-text-content {
+  width: 100% !important;
+  flex: 1;
+  overflow: hidden;
+  padding-right: 10px !important;
+}
+
+.i-amphtml-story-bookend-component {
+  width: 100% !important;
 }
 
 .i-amphtml-story-bookend-landscape,
@@ -134,7 +146,7 @@
   flex: 1 0 320px !important;
   min-width: 33% !important;
   margin: 24px 0 !important;
-  padding: 0 32px !important;
+  /* padding: 0 32px !important; */
 }
 
 @media (min-width: 640px) {
@@ -155,6 +167,7 @@
   font-weight: 400 !important;
   font-size: 16px !important;
   overflow: hidden !important;
+  text-overflow: ellipsis !important;
   color: #fff !important;
   line-height: 1.45em !important;
   max-height: 4.35em !important;
@@ -186,6 +199,7 @@
   height: 100px !important;
   border-radius: 8px !important;
   overflow: hidden !important;
+  flex-shrink: 0;
 }
 
 
@@ -233,15 +247,20 @@
 .i-amphtml-story-bookend-article-image,
 .i-amphtml-story-bookend-replay-image,
 .i-amphtml-story-bookend-replay-icon {
-  float: right !important;
   margin-left: 24px !important;
   position: relative !important;
+  flex: none !important;
 }
 
+/** TOOD(enriqe) this is very similar to .i-amphtml-story-bookend-article */
 .i-amphtml-story-bookend-replay {
   padding: 16px 0 !important;
-  margin: 0 0 24px !important;
+  margin: 0 32px !important;
   overflow: hidden !important;
+  display: flex !important;
+  box-sizing: border-box !important;
+  max-height: 110px !important;
+  justify-content: space-between !important;
 }
 
 .i-amphtml-story-bookend-replay-icon {
@@ -269,16 +288,13 @@
 
 .i-amphtml-story-bookend-component-set {
   margin-bottom: 32px !important;
+  margin: 0 32px !important;
+}
+
+[desktop] .i-amphtml-story-bookend-component-set {
   display: flex !important;
   flex-wrap: wrap !important;
   justify-content: space-between !important;
-}
-
-/* All top-level bookend elements need to set their own left/right margins */
-.i-amphtml-story-bookend-heading,
-.i-amphtml-story-bookend-replay {
-  margin-left: 32px !important;
-  margin-right: 32px !important;
 }
 
 .i-amphtml-story-bookend-cta-link-wrapper,
@@ -291,7 +307,6 @@
   flex: 1 0 320px !important;
   justify-content: space-between !important;
   margin: 24px 0 !important;
-  padding: 0 32px !important;
 }
 
 .i-amphtml-story-bookend-textbox {
@@ -367,7 +382,6 @@
 }
 
 [desktop] .i-amphtml-story-bookend-inner {
-  box-sizing: border-box !important;
   min-height: 100vh !important;
   padding: 104px 156px 64px !important;
   margin: 0 !important;
@@ -389,12 +403,14 @@
 
 @media (min-width: 952px) {
   [desktop] .i-amphtml-story-bookend-component {
-    max-width: 50% !important;
+    /** Leave some horizontal space between cards. */
+    max-width: calc(50%-12px) !important;
   }
 }
 
 @media (min-width: 1272px) {
   [desktop] .i-amphtml-story-bookend-component {
-    max-width: 33% !important;
+    /** Leave some horizontal space between cards. */
+    max-width: calc(50%-12px) !important;
   }
 }

--- a/extensions/amp-story/1.0/amp-story-bookend.css
+++ b/extensions/amp-story/1.0/amp-story-bookend.css
@@ -82,7 +82,7 @@
   text-transform: uppercase !important;
   font-size: 12px !important;
   padding-bottom: 8px !important;
-  margin: 48px 0 8px !important;
+  margin: 0 !important;
   border-bottom: 1px solid rgba(255, 255, 255, 0.25) !important;
   color: rgba(255, 255, 255, 0.54) !important;
   font-weight: 700 !important;
@@ -118,7 +118,6 @@
 .i-amphtml-story-bookend-article {
   text-decoration: none !important;
   color: inherit !important;
-  margin: 24px 0 !important;
   display: flex !important;
   justify-content: space-between !important;
   max-height: 104px !important;
@@ -133,6 +132,7 @@
 
 .i-amphtml-story-bookend-component {
   width: 100% !important;
+  margin-bottom: 24px !important;
 }
 
 .i-amphtml-story-bookend-landscape,
@@ -145,7 +145,6 @@
   overflow: hidden !important;
   flex: 1 0 320px !important;
   min-width: 33% !important;
-  margin: 24px 0 !important;
   /* padding: 0 32px !important; */
 }
 
@@ -247,7 +246,7 @@
 .i-amphtml-story-bookend-article-image,
 .i-amphtml-story-bookend-replay-image,
 .i-amphtml-story-bookend-replay-icon {
-  margin-left: 24px !important;
+  /* margin-left: 24px !important; */
   position: relative !important;
   flex: none !important;
 }
@@ -306,7 +305,6 @@
   overflow: hidden !important;
   flex: 1 0 320px !important;
   justify-content: space-between !important;
-  margin: 24px 0 !important;
 }
 
 .i-amphtml-story-bookend-textbox {

--- a/extensions/amp-story/1.0/amp-story-bookend.css
+++ b/extensions/amp-story/1.0/amp-story-bookend.css
@@ -47,7 +47,6 @@
 }
 
 .i-amphtml-story-bookend-inner {
-  box-sizing: border-box !important;
   margin: 88px 0 0 !important;
   font-family: 'Roboto', sans-serif !important;
   position: relative !important;
@@ -120,12 +119,12 @@
   color: inherit !important;
   display: flex !important;
   justify-content: space-between !important;
-  max-height: 104px !important;
+  max-height: 100px !important;
 }
 
 .i-amphtml-story-bookend-article-text-content {
   width: 100% !important;
-  flex: 1 !important;
+  /* flex: 1 !important; */
   overflow: hidden !important;
   padding-right: 10px !important;
 }
@@ -158,7 +157,6 @@
   overflow: hidden !important;
   flex: 1 0 320px !important;
   min-width: 33% !important;
-  /* padding: 0 32px !important; */
 }
 
 @media (min-width: 640px) {
@@ -205,7 +203,7 @@
   height: 100px !important;
   border-radius: 8px !important;
   overflow: hidden !important;
-  flex-shrink: 0;
+  /* flex-shrink: 0 !important; */
 }
 
 
@@ -253,14 +251,11 @@
 .i-amphtml-story-bookend-article-image,
 .i-amphtml-story-bookend-replay-image,
 .i-amphtml-story-bookend-replay-icon {
-  /* margin-left: 24px !important; */
   position: relative !important;
   flex: none !important;
 }
 
-/** TOOD(enriqe) this is very similar to .i-amphtml-story-bookend-article */
 .i-amphtml-story-bookend-replay {
-  padding: 16px 0 !important;
   margin: 0 32px !important;
   overflow: hidden !important;
   display: flex !important;
@@ -293,15 +288,9 @@
 }
 
 .i-amphtml-story-bookend-component-set {
-  margin-bottom: 32px !important;
   margin: 0 32px !important;
+  margin-bottom: 32px !important;
 }
-
-/* [desktop] .i-amphtml-story-bookend-component-set {
-  display: flex !important;
-  flex-wrap: wrap !important;
-  justify-content: space-between !important;
-} */
 
 .i-amphtml-story-bookend-cta-link-wrapper,
 .i-amphtml-story-bookend-textbox {
@@ -387,6 +376,7 @@
 }
 
 [desktop] .i-amphtml-story-bookend-inner {
+  box-sizing: border-box !important;
   min-height: 100vh !important;
   padding: 104px 156px 64px !important;
   margin: 0 !important;

--- a/extensions/amp-story/1.0/amp-story-consent.css
+++ b/extensions/amp-story/1.0/amp-story-consent.css
@@ -56,6 +56,10 @@
   overflow: hidden !important;
 }
 
+[dir=rtl] .i-amphtml-story-consent-container {
+  text-align: right !important;
+}
+
 .i-amphtml-story-consent-fullbleed .i-amphtml-story-consent-container {
   margin: 88px 0px 72px !important;
   padding: 0 8px !important;

--- a/extensions/amp-story/1.0/amp-story-consent.js
+++ b/extensions/amp-story/1.0/amp-story-consent.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {Action, getStoreService} from './amp-story-store-service';
+import {Action, StateProperty, getStoreService} from './amp-story-store-service';
 import {ActionTrust} from '../../../src/action-constants';
 import {CSS} from '../../../build/amp-story-consent-1.0.css';
 import {Layout} from '../../../src/layout';
@@ -249,6 +249,10 @@ export class AmpStoryConsent extends AMP.BaseElement {
         this.storyConsentEl_.querySelector('.i-amphtml-story-consent-overflow');
     this.scrollableEl_.addEventListener(
         'scroll', throttle(this.win, () => this.onScroll_(), 100));
+
+    this.storeService_.subscribe(StateProperty.RTL_STATE, rtlState => {
+      this.onRtlStateUpdate_(rtlState);
+    }, true /** callToInitialize */);
   }
 
   /**
@@ -282,6 +286,19 @@ export class AmpStoryConsent extends AMP.BaseElement {
 
     this.element.getResources()
         .measureMutateElement(this.storyConsentEl_, measurer, mutator);
+  }
+
+  /**
+   * Reacts to RTL state updates and triggers the UI for RTL.
+   * @param {boolean} rtlState
+   * @private
+   */
+  onRtlStateUpdate_(rtlState) {
+    this.mutateElement(() => {
+      rtlState ?
+        this.storyConsentEl_.setAttribute('dir', 'rtl') :
+        this.storyConsentEl_.removeAttribute('dir');
+    });
   }
 
   /**

--- a/extensions/amp-story/1.0/amp-story-consent.js
+++ b/extensions/amp-story/1.0/amp-story-consent.js
@@ -294,11 +294,13 @@ export class AmpStoryConsent extends AMP.BaseElement {
    * @private
    */
   onRtlStateUpdate_(rtlState) {
-    this.mutateElement(() => {
+    const mutator = () => {
       rtlState ?
         this.storyConsentEl_.setAttribute('dir', 'rtl') :
         this.storyConsentEl_.removeAttribute('dir');
-    });
+    };
+
+    this.element.getResources().mutateElement(this.storyConsentEl_, mutator);
   }
 
   /**

--- a/extensions/amp-story/1.0/amp-story-consent.js
+++ b/extensions/amp-story/1.0/amp-story-consent.js
@@ -284,8 +284,7 @@ export class AmpStoryConsent extends AMP.BaseElement {
           .classList.toggle('i-amphtml-story-consent-fullbleed', isFullBleed);
     };
 
-    this.element.getResources()
-        .measureMutateElement(this.storyConsentEl_, measurer, mutator);
+    this.measureMutateElement(this.storyConsentEl_, measurer, mutator);
   }
 
   /**
@@ -300,7 +299,7 @@ export class AmpStoryConsent extends AMP.BaseElement {
         this.storyConsentEl_.removeAttribute('dir');
     };
 
-    this.element.getResources().mutateElement(this.storyConsentEl_, mutator);
+    this.mutateElement(this.storyConsentEl_, mutator);
   }
 
   /**

--- a/extensions/amp-story/1.0/amp-story-consent.js
+++ b/extensions/amp-story/1.0/amp-story-consent.js
@@ -284,7 +284,7 @@ export class AmpStoryConsent extends AMP.BaseElement {
           .classList.toggle('i-amphtml-story-consent-fullbleed', isFullBleed);
     };
 
-    this.measureMutateElement(this.storyConsentEl_, measurer, mutator);
+    this.measureMutateElement(measurer, mutator, this.storyConsentEl_);
   }
 
   /**
@@ -299,7 +299,7 @@ export class AmpStoryConsent extends AMP.BaseElement {
         this.storyConsentEl_.removeAttribute('dir');
     };
 
-    this.mutateElement(this.storyConsentEl_, mutator);
+    this.mutateElement(mutator, this.storyConsentEl_);
   }
 
   /**

--- a/extensions/amp-story/1.0/amp-story-hint.css
+++ b/extensions/amp-story/1.0/amp-story-hint.css
@@ -54,6 +54,15 @@
   flex: 1 !important;
 }
 
+[dir=rtl] .prev-page {
+  flex: 1 !important;
+  border-left: 1px dashed transparent !important;
+  border-image-source: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="30" height="30" version="1.1"><line x1="0" y1="0" x2="0" y2="30" fill-rule="evenodd" stroke-width="1" fill="none" stroke-linecap="square" stroke-dasharray="6,6" stroke="white"></line></svg>')  !important;
+  border-image-slice: 33% 33%  !important;
+  border-image-repeat: repeat  !important;
+  border-image-width: 14px !important;
+}
+
 .show-first-page-overlay .i-amphtml-story-navigation-help-overlay {
   background: rgba(0,0,0,0) !important;
 }
@@ -83,6 +92,10 @@
   border-image-width: 14px !important;
 }
 
+[dir=rtl].i-amphtml-story-hint-container .next-page {
+  border-left: none !important;
+}
+
 .show-navigation-overlay .i-amphtml-story-navigation-help-overlay,
 .show-first-page-overlay .i-amphtml-story-navigation-help-overlay {
   display: flex !important;
@@ -98,6 +111,10 @@
   width: 30px !important;
   height: 30px !important;
   display: inline-block !important;
+}
+
+[dir=rtl].show-navigation-overlay .prev-page .i-amphtml-story-hint-tap-button-icon:before {
+  background-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="30px" height="30px" viewBox="0 0 24 24" fill="#000000"><path d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"/><path d="M0 0h24v24H0z" fill="none"/></svg>') !important;
 }
 
 .i-amphtml-story-hint-container .i-amphtml-story-hint-tap-button {
@@ -147,6 +164,10 @@
   width: 24px !important;
   height: 24px !important;
   display: inline-block !important;
+}
+
+[dir=rtl] .next-page .i-amphtml-story-hint-tap-button-icon:after {
+  background-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="30px" height="30px" viewBox="0 0 24 24" fill="#000000"><path d="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"/><path d="M0 0h24v24H0z" fill="none"/></svg>') !important;
 }
 
 .i-amphtml-story-hint-placeholder {

--- a/extensions/amp-story/1.0/amp-story-hint.js
+++ b/extensions/amp-story/1.0/amp-story-hint.js
@@ -168,6 +168,10 @@ export class AmpStoryHint {
     this.hintContainer_ = renderAsElement(this.document_, TEMPLATE);
     createShadowRootWithStyle(root, this.hintContainer_, CSS);
 
+    this.storeService_.subscribe(StateProperty.RTL_STATE, rtlState => {
+      this.onRtlStateUpdate_(rtlState);
+    }, true /** callToInitialize */);
+
     this.vsync_.mutate(() => {
       this.parentEl_.appendChild(root);
     });
@@ -255,6 +259,19 @@ export class AmpStoryHint {
 
     this.vsync_.mutate(() => {
       this.hintContainer_.classList.add('i-amphtml-hidden');
+    });
+  }
+
+  /**
+   * Reacts to RTL state updates and triggers the UI for RTL.
+   * @param {boolean} rtlState
+   * @private
+   */
+  onRtlStateUpdate_(rtlState) {
+    this.vsync_.mutate(() => {
+      rtlState ?
+        this.hintContainer_.setAttribute('dir', 'rtl') :
+        this.hintContainer_.removeAttribute('dir');
     });
   }
 }

--- a/extensions/amp-story/1.0/amp-story-system-layer.css
+++ b/extensions/amp-story/1.0/amp-story-system-layer.css
@@ -114,8 +114,8 @@
   will-change: transform, transition !important;
 }
 
-[dir=rtl] .i-amphtml-story-progress-value {
-  transform-origin: right !important;
+[dir=rtl] .i-amphtml-story-page-progress-value {
+   transform-origin: right !important;
 }
 
 .i-amphtml-story-mute-audio-control,

--- a/extensions/amp-story/1.0/amp-story-system-layer.css
+++ b/extensions/amp-story/1.0/amp-story-system-layer.css
@@ -115,7 +115,7 @@
 }
 
 [dir=rtl] .i-amphtml-story-page-progress-value {
-   transform-origin: right !important;
+  transform-origin: right !important;
 }
 
 .i-amphtml-story-mute-audio-control,

--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -25,10 +25,6 @@ amp-story, amp-story-page, amp-story-grid-layer, amp-story-cta-layer {
   overflow: hidden !important;
 }
 
-[dir=rtl] {
-  text-align: right !important;
-}
-
 amp-consent {
   position: absolute !important;
   top: 0 !important;

--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -25,6 +25,10 @@ amp-story, amp-story-page, amp-story-grid-layer, amp-story-cta-layer {
   overflow: hidden !important;
 }
 
+[dir=rtl] {
+  text-align: right !important;
+}
+
 amp-consent {
   position: absolute !important;
   top: 0 !important;

--- a/extensions/amp-story/1.0/bookend/amp-story-bookend.js
+++ b/extensions/amp-story/1.0/bookend/amp-story-bookend.js
@@ -149,14 +149,16 @@ const buildPromptConsentTemplate = consentId => {
     children: [
       {
         tag: 'h3',
-        attrs: dict({'class': 'i-amphtml-story-bookend-heading'}),
+        attrs: dict({'class': 'i-amphtml-story-bookend-heading ' +
+          ' i-amphtml-story-bookend-component'}),
         localizedStringId:
             LocalizedStringId.AMP_STORY_BOOKEND_PRIVACY_SETTINGS_TITLE,
       },
       {
         tag: 'h2',
         attrs: dict({
-          'class': 'i-amphtml-story-bookend-consent-button',
+          'class': 'i-amphtml-story-bookend-consent-button ' +
+            'i-amphtml-story-bookend-component',
           'on': `tap:${consentId}.prompt`,
           'role': 'button',
           'aria-label': 'Change data privacy settings',

--- a/extensions/amp-story/1.0/bookend/amp-story-bookend.js
+++ b/extensions/amp-story/1.0/bookend/amp-story-bookend.js
@@ -110,6 +110,22 @@ const buildReplayButtonTemplate = (title, domainName, imageUrl = undefined) => {
     tag: 'div',
     attrs: dict({'class': 'i-amphtml-story-bookend-replay'}),
     children: [
+      {
+        tag: 'div',
+        attrs: dict({'class': 'i-amphtml-story-bookend-article-text-content'}),
+        children: [
+          {
+            tag: 'h2',
+            attrs: dict({'class': 'i-amphtml-story-bookend-article-heading'}),
+            unlocalizedString: title,
+          },
+          {
+            tag: 'div',
+            attrs: dict({'class': 'i-amphtml-story-bookend-component-meta'}),
+            unlocalizedString: domainName,
+          },
+        ],
+      },
       !imageUrl ? REPLAY_ICON_TEMPLATE : {
         tag: 'div',
         attrs: dict({
@@ -117,16 +133,6 @@ const buildReplayButtonTemplate = (title, domainName, imageUrl = undefined) => {
           'style': `background-image: url(${imageUrl}) !important`,
         }),
         children: [REPLAY_ICON_TEMPLATE],
-      },
-      {
-        tag: 'h2',
-        attrs: dict({'class': 'i-amphtml-story-bookend-article-heading'}),
-        unlocalizedString: title,
-      },
-      {
-        tag: 'div',
-        attrs: dict({'class': 'i-amphtml-story-bookend-component-meta'}),
-        unlocalizedString: domainName,
       },
     ],
   });
@@ -286,6 +292,10 @@ export class AmpStoryBookend extends AMP.BaseElement {
     this.storeService_.subscribe(StateProperty.UI_STATE, uiState => {
       this.onUIStateUpdate_(uiState);
     }, true /** callToInitialize */);
+
+    this.storeService_.subscribe(StateProperty.RTL_STATE, rtlState => {
+      this.onRtlStateUpdate_(rtlState);
+    }, true /** callToInitialize */);
   }
 
   /**
@@ -339,6 +349,19 @@ export class AmpStoryBookend extends AMP.BaseElement {
       uiState === UIType.DESKTOP ?
         this.getShadowRoot().setAttribute('desktop', '') :
         this.getShadowRoot().removeAttribute('desktop');
+    });
+  }
+
+  /**
+   * Reacts to RTL state updates and triggers the UI for RTL.
+   * @param {boolean} rtlState
+   * @private
+   */
+  onRtlStateUpdate_(rtlState) {
+    this.mutateElement(() => {
+      rtlState ?
+        this.getShadowRoot().setAttribute('dir', 'rtl') :
+        this.getShadowRoot().removeAttribute('dir');
     });
   }
 

--- a/extensions/amp-story/1.0/bookend/components/article.js
+++ b/extensions/amp-story/1.0/bookend/components/article.js
@@ -91,9 +91,14 @@ export class ArticleComponent {
         <a class="i-amphtml-story-bookend-article
           i-amphtml-story-bookend-component"
           target="_top">
-          <h2 class="i-amphtml-story-bookend-article-heading" ref="heading">
-          </h2>
-          <div class="i-amphtml-story-bookend-component-meta" ref="meta"></div>
+          <div class="i-amphtml-story-bookend-article-text-content">
+            <h2
+              class="i-amphtml-story-bookend-article-heading" ref="heading">
+            </h2>
+            <div
+              class="i-amphtml-story-bookend-component-meta" ref="meta">
+            </div>
+          </div>
         </a>`;
     addAttributesToElement(el, dict({'href': articleData.url}));
 
@@ -111,7 +116,7 @@ export class ArticleComponent {
 
       const {image} = htmlRefs(imgEl);
       addAttributesToElement(image, dict({'src': articleData.image}));
-      el.insertBefore(imgEl, el.firstChild);
+      el.appendChild(imgEl);
     }
 
     const articleElements = htmlRefs(el);

--- a/extensions/amp-story/1.0/bookend/components/heading.js
+++ b/extensions/amp-story/1.0/bookend/components/heading.js
@@ -61,7 +61,9 @@ export class HeadingComponent {
    * */
   buildElement(headingData, doc) {
     const html = htmlFor(doc);
-    const template = html`<h3 class="i-amphtml-story-bookend-heading"></h3>`;
+    const template =
+      html`<h3 class="i-amphtml-story-bookend-component
+        i-amphtml-story-bookend-heading"></h3>`;
 
     template.textContent = headingData.text;
 

--- a/extensions/amp-story/1.0/test/test-amp-story-consent.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-consent.js
@@ -78,6 +78,7 @@ describes.realWin('amp-story-consent', {amp: true}, env => {
     setConfig(defaultConfig);
 
     storyConsentEl = win.document.createElement('amp-story-consent');
+    storyConsentEl.getResources = () => win.services.resources.obj;
     storyConsentEl.appendChild(storyConsentConfigEl);
 
     consentEl.appendChild(consentConfigEl);


### PR DESCRIPTION
Closes #11647
Fixes #15931 #17103 

Adds a number of CSS improvements in amp-story focused in RTL:

* Adds RTL state attribute to bookend.
* Bookend now uses flexbox for the components.
* The container holding the bookend components is now in charge of the padding around the components, instead of each individual component having the padding.
* Removes unnecessary margins on top of components.
* RTL support for hint overlay.
* RTL support for story ads in desktop. 
* Treats style of consent button in bookend as a component too.

