### PR TITLE
:bug: AppNexus: fix scope in ad available function

### DIFF
--- a/ads/appnexus.js
+++ b/ads/appnexus.js
@@ -126,14 +126,14 @@ function appnexusAst(global, data) {
     apntag.onEvent('adAvailable', data.target, isAdAvailable);
     apntag.onEvent('adNoBid', data.target, context.noContentAvailable);
   });
-}
 
-/**
- * resolve getAd with an available ad object
- *
- * @param {{targetId: string}} adObj
- */
-function isAdAvailable(adObj) {
-  global.context.renderStart({width: adObj.width, height: adObj.height});
-  global.apntag.showTag(adObj.targetId, global.window);
+  /**
+   * resolve getAd with an available ad object
+   *
+   * @param {{targetId: string}} adObj
+   */
+  function isAdAvailable(adObj) {
+    global.context.renderStart({width: adObj.width, height: adObj.height});
+    global.apntag.showTag(adObj.targetId, global.window);
+  }
 }


### PR DESCRIPTION
[This test page](http://cdn.adnxs.com/ast/monitor/amp.html) produces the error `Uncaught ReferenceError: global is not defined`, pointing to [this line](https://github.com/ampproject/amphtml/blob/b4bcf6cfbb7ebd47be82044114401076e463ddd0/ads/appnexus.js#L137) in appnexus.js. This PR moves the ad available function so that `global` is within scope