### PR TITLE
🏗🐛 Add a more robust mechanism for dynamically skipping tests

### DIFF
--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -612,6 +612,14 @@ const forbiddenTerms = {
       'extensions/amp-access/0.1/iframe-api/access-controller.js',
     ],
   },
+  'this\\.skip\\(\\)': {
+    message: 'Use of `this.skip()` is forbidden. Use `this.skipTest()` ' +
+        'from within a `before()` block instead. See #17245.',
+    checkInTestFolder: true,
+    whitelist: [
+      'test/_init_tests.js',
+    ],
+  },
 };
 
 const ThreePTermsMessage = 'The 3p bootstrap iframe has no polyfills loaded' +

--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -613,8 +613,8 @@ const forbiddenTerms = {
     ],
   },
   'this\\.skip\\(\\)': {
-    message: 'Use of `this.skip()` is forbidden. Use `this.skipTest()` ' +
-        'from within a `before()` block instead. See #17245.',
+    message: 'Use of `this.skip()` is forbidden in test files. Use ' +
+        '`this.skipTest()` from within a `before()` block instead. See #17245.',
     checkInTestFolder: true,
     whitelist: [
       'test/_init_tests.js',

--- a/test/_init_tests.js
+++ b/test/_init_tests.js
@@ -392,7 +392,7 @@ before(function() {
     if (this._runnable.title != '"before all" hook') {
       throw new Error('skipTest() can only be called from within before()');
     }
-    this.test.parent.pending = true;
+    this.test.parent.pending = true; // Workaround for mochajs/mocha#2683.
     this.skip();
   };
 });

--- a/test/_init_tests.js
+++ b/test/_init_tests.js
@@ -52,10 +52,6 @@ const originalConsoleError = console/*OK*/.error;
 let initialGlobalState;
 let initialWindowState;
 
-// TODO(rsimha, #17245): Temporary. Remove this. Needed due to
-// https://github.com/mochajs/mocha/issues/2148.
-let sandboxCreated;
-
 // All exposed describes.
 global.describes = describes;
 
@@ -390,17 +386,22 @@ function preventAsyncErrorThrows() {
   stubAsyncErrorThrows();
 }
 
+before(function() {
+  // This is a more robust version of `this.skip()`. See #17245.
+  this.skipTest = function() {
+    if (this._runnable.title != '"before all" hook') {
+      throw new Error('skipTest() can only be called from within before()');
+    }
+    this.test.parent.pending = true;
+    this.skip();
+  };
+});
+
 beforeEach(function() {
   this.timeout(BEFORE_AFTER_TIMEOUT);
   beforeTest();
   testName = this.currentTest.fullTitle();
-  if (sandboxCreated) {
-    sinon.sandbox.restore();
-    consoleErrorSandbox.restore();
-    rethrowAsyncSandbox.restore();
-  }
   sinon.sandbox = sinon.createSandbox();
-  sandboxCreated = true;
   maybeStubConsoleInfoLogWarn();
   preventAsyncErrorThrows();
   warnForConsoleError();
@@ -430,7 +431,6 @@ afterEach(function() {
   const globalState = Object.keys(global);
   const windowState = Object.keys(window);
   sinon.sandbox.restore();
-  sandboxCreated = false;
   restoreConsoleError();
   restoreAsyncErrorThrows();
   this.timeout(BEFORE_AFTER_TIMEOUT);

--- a/test/functional/test-fixed-layer.js
+++ b/test/functional/test-fixed-layer.js
@@ -1333,7 +1333,8 @@ describes.realWin('FixedLayer', {}, env => {
   let container;
 
   // Can only test when SD is supported.
-  describe.configure().ifChrome('shadow transfer', function() {
+  describe.configure().if(() => Element.prototype.attachShadow).run('shadow ' +
+      'transfer', function() {
     beforeEach(function() {
       win = env.win;
       doc = win.document;

--- a/test/functional/test-fixed-layer.js
+++ b/test/functional/test-fixed-layer.js
@@ -1321,7 +1321,7 @@ describes.sandboxed('FixedLayer', {}, () => {
 });
 
 
-describes.realWin('FixedLayer: shadow transfer', {}, env => {
+describes.realWin('FixedLayer', {}, env => {
   let win, doc;
   let ampdoc;
   let fixedLayer;
@@ -1332,83 +1332,82 @@ describes.realWin('FixedLayer: shadow transfer', {}, env => {
   let shadowRoot;
   let container;
 
-  beforeEach(function() {
-    if (!env.win.Element.prototype.attachShadow) {
-      // Can only test when SD is supported.
-      this.skip();
-    }
-    win = env.win;
-    doc = win.document;
-    vsyncTasks = [];
-    vsyncApi = {
-      runPromise: task => {
-        vsyncTasks.push(task);
-        return Promise.resolve();
-      },
-      mutate: mutator => {
-        vsyncTasks.push({mutate: mutator});
-      },
-    };
-    installPlatformService(win);
-    ampdoc = new AmpDocSingle(win);
-    shadowRoot = win.document.body.attachShadow({mode: 'open'});
-    fixedLayer = new FixedLayer(ampdoc, vsyncApi,
-        /* borderTop */ 0, /* paddingTop */ 11, /* transfer */ true);
-    fixedLayer.setup();
-    transferLayer = fixedLayer.getTransferLayer_();
-    root = transferLayer.getRoot();
-    container = doc.createElement('div');
-    doc.body.appendChild(container);
-  });
+  // Can only test when SD is supported.
+  describe.configure().ifChrome('shadow transfer', function() {
+    beforeEach(function() {
+      win = env.win;
+      doc = win.document;
+      vsyncTasks = [];
+      vsyncApi = {
+        runPromise: task => {
+          vsyncTasks.push(task);
+          return Promise.resolve();
+        },
+        mutate: mutator => {
+          vsyncTasks.push({mutate: mutator});
+        },
+      };
+      installPlatformService(win);
+      ampdoc = new AmpDocSingle(win);
+      shadowRoot = win.document.body.attachShadow({mode: 'open'});
+      fixedLayer = new FixedLayer(ampdoc, vsyncApi,
+          /* borderTop */ 0, /* paddingTop */ 11, /* transfer */ true);
+      fixedLayer.setup();
+      transferLayer = fixedLayer.getTransferLayer_();
+      root = transferLayer.getRoot();
+      container = doc.createElement('div');
+      doc.body.appendChild(container);
+    });
 
-  it('should create layer correctly', () => {
-    expect(root.parentNode).to.equal(shadowRoot);
-    expect(root.id).to.equal('i-amphtml-fixed-layer');
-    expect(root.style.position).to.equal('absolute');
-    expect(root.style.top).to.equal('0px');
-    expect(root.style.left).to.equal('0px');
-    expect(root.style.width).to.equal('0px');
-    expect(root.style.height).to.equal('0px');
-    expect(root.style.overflow).to.equal('hidden');
-    expect(root.style.visibility).to.equal('');
-    expect(root.children).to.have.length(1);
-    expect(root.children[0].tagName).to.equal('SLOT');
-    expect(root.children[0].name).to.equal('i-amphtml-fixed');
-  });
+    it('should create layer correctly', () => {
+      expect(root.parentNode).to.equal(shadowRoot);
+      expect(root.id).to.equal('i-amphtml-fixed-layer');
+      expect(root.style.position).to.equal('absolute');
+      expect(root.style.top).to.equal('0px');
+      expect(root.style.left).to.equal('0px');
+      expect(root.style.width).to.equal('0px');
+      expect(root.style.height).to.equal('0px');
+      expect(root.style.overflow).to.equal('hidden');
+      expect(root.style.visibility).to.equal('');
+      expect(root.children).to.have.length(1);
+      expect(root.children[0].tagName).to.equal('SLOT');
+      expect(root.children[0].name).to.equal('i-amphtml-fixed');
+    });
 
-  it('should transfer element', () => {
-    const element = doc.createElement('div');
-    container.appendChild(element);
-    const fe = {element, id: 'F0'};
-    transferLayer.transferTo(fe);
+    it('should transfer element', () => {
+      const element = doc.createElement('div');
+      container.appendChild(element);
+      const fe = {element, id: 'F0'};
+      transferLayer.transferTo(fe);
 
-    // Element stays where it was.
-    expect(element.parentElement).to.equal(container);
-    expect(element.getAttribute('slot')).to.equal('i-amphtml-fixed');
-    expect(root.children).to.have.length(1);
+      // Element stays where it was.
+      expect(element.parentElement).to.equal(container);
+      expect(element.getAttribute('slot')).to.equal('i-amphtml-fixed');
+      expect(root.children).to.have.length(1);
 
-    // Ensure that repeat slotting doesn't change anything.
-    transferLayer.transferTo(fe);
-    expect(element.getAttribute('slot')).to.equal('i-amphtml-fixed');
-    expect(root.children).to.have.length(1);
-  });
+      // Ensure that repeat slotting doesn't change anything.
+      transferLayer.transferTo(fe);
+      expect(element.getAttribute('slot')).to.equal('i-amphtml-fixed');
+      expect(root.children).to.have.length(1);
+    });
 
-  it('should return element', () => {
-    const element = doc.createElement('div');
-    container.appendChild(element);
-    const fe = {element, id: 'F0'};
-    transferLayer.transferTo(fe);
-    expect(element.getAttribute('slot')).to.equal('i-amphtml-fixed');
-    expect(root.children).to.have.length(1);
+    it('should return element', () => {
+      const element = doc.createElement('div');
+      container.appendChild(element);
+      const fe = {element, id: 'F0'};
+      transferLayer.transferTo(fe);
+      expect(element.getAttribute('slot')).to.equal('i-amphtml-fixed');
+      expect(root.children).to.have.length(1);
 
-    // The slot distribution is canceled, but the slot itself is kept.
-    transferLayer.returnFrom(fe);
-    expect(element.getAttribute('slot')).to.be.null;
-    expect(root.children).to.have.length(1);
+      // The slot distribution is canceled, but the slot itself is kept.
+      transferLayer.returnFrom(fe);
+      expect(element.getAttribute('slot')).to.be.null;
+      expect(root.children).to.have.length(1);
 
-    // Ensure that repeat slotting doesn't change anything.
-    transferLayer.transferTo(fe);
-    expect(element.getAttribute('slot')).to.equal('i-amphtml-fixed');
-    expect(root.children).to.have.length(1);
+      // Ensure that repeat slotting doesn't change anything.
+      transferLayer.transferTo(fe);
+      expect(element.getAttribute('slot')).to.equal('i-amphtml-fixed');
+      expect(root.children).to.have.length(1);
+    });
   });
 });

--- a/test/functional/test-fixed-layer.js
+++ b/test/functional/test-fixed-layer.js
@@ -1332,7 +1332,7 @@ describes.realWin('FixedLayer', {}, env => {
   let shadowRoot;
   let container;
 
-  // Can only test when SD is supported.
+  // Can only test when Shadow DOM is available.
   describe.configure().if(() => Element.prototype.attachShadow).run('shadow ' +
       'transfer', function() {
     beforeEach(function() {

--- a/test/functional/test-shadow-embed.js
+++ b/test/functional/test-shadow-embed.js
@@ -41,194 +41,200 @@ describes.sandboxed('shadow-embed', {}, () => {
 
   [ShadowDomVersion.NONE, ShadowDomVersion.V0, ShadowDomVersion.V1]
       .forEach(scenario => {
-        describe('shadow APIs ' + scenario, () => {
+        describe('shadow APIs', () => {
           let hostElement;
 
           beforeEach(function() {
             hostElement = document.createElement('div');
             setShadowDomSupportedVersionForTesting(scenario);
             setShadowCssSupportedForTesting(undefined);
-
-            if (scenario == ShadowDomVersion.V0 &&
-                !Element.prototype.createShadowRoot) {
-              this.skip();
-            }
-
-            if (scenario == ShadowDomVersion.V1 &&
-                !Element.prototype.attachShadow) {
-              this.skip();
-            }
           });
 
-          it('should transform CSS installStylesForDoc for shadow root', () => {
-            const shadowRoot = createShadowRoot(hostElement);
-            const ampdoc = new AmpDocShadow(
-                window, 'https://a.org/', shadowRoot);
-            const style = installStylesForDoc(ampdoc, 'body {}', null, true);
-            expect(shadowRoot.contains(style)).to.be.true;
-            const css = style.textContent.replace(/\s/g, '');
-            if (scenario == ShadowDomVersion.NONE) {
-              expect(css).to.match(/amp-body/);
-            } else {
-              expect(css).to.equal('body{}');
-            }
-          });
-
-          describe('createShadowRoot', () => {
-            it('should clear duplicate root', () => {
-              const shadowRoot1 = createShadowRoot(hostElement);
-              const span = document.createElement('span');
-              shadowRoot1.appendChild(span);
-              expect(shadowRoot1.contains(span)).to.be.true;
-
-              const shadowRoot2 = createShadowRoot(hostElement);
-              expect(shadowRoot2).to.equal(shadowRoot1);
-              expect(shadowRoot2.contains(span)).to.be.false;
-            });
-
-            it('should have host', () => {
-              const shadowRoot = createShadowRoot(hostElement);
-              expect(shadowRoot.host).to.equal(hostElement);
-            });
-
-            it('should have getElementById', () => {
-              const shadowRoot = createShadowRoot(hostElement);
-              expect(shadowRoot.getElementById).to.be.ok;
-
-              const spanId = 'test' + Math.floor(Math.random() * 10000);
-              const span = document.createElement('span');
-              span.id = spanId;
-              shadowRoot.appendChild(span);
-              expect(shadowRoot.getElementById(spanId)).to.equal(span);
-            });
-
-            if (scenario == ShadowDomVersion.NONE) {
-              it('should add id for polyfill', () => {
-                const shadowRoot = createShadowRoot(hostElement);
-                expect(shadowRoot.tagName).to.equal('I-AMPHTML-SHADOW-ROOT');
-                expect(shadowRoot.id).to.match(/i-amphtml-sd-\d+/);
-              });
-
-              it('should add host style for polyfill', () => {
-                const doc = hostElement.ownerDocument;
-                const win = doc.defaultView;
-                doc.body.appendChild(hostElement);
-                const slot = doc.createElement('div');
-                hostElement.appendChild(slot);
-                expect(win.getComputedStyle(slot).display).to.equal('block');
-                const shadowRoot = createShadowRoot(hostElement);
-                expect(hostElement).to.have.class(
-                    'i-amphtml-shadow-host-polyfill');
-                expect(win.getComputedStyle(slot).display).to.equal('none');
-                expect(win.getComputedStyle(shadowRoot).display)
-                    .to.not.equal('none');
-                doc.body.removeChild(hostElement);
-              });
-            }
-
-            // Test scenarios where Shadow Css is not supported
-            it('Should add an id and class for CSS \
-              encapsulation to the shadow root', () => {
-              setShadowCssSupportedForTesting(false);
-              const shadowRoot = createShadowRoot(hostElement);
-              expect(shadowRoot.id).to.match(/i-amphtml-sd-\d+/);
-              // Browserify does not support arrow functions with params.
-              // Using Old School for
-              const shadowRootClassListArray =
-                toArray(shadowRoot.host.classList);
-              let foundShadowCssClass = false;
-              for (let i = 0; i < shadowRootClassListArray.length; i++) {
-                if (shadowRootClassListArray[i].match(/i-amphtml-sd-\d+/)) {
-                  foundShadowCssClass = true;
-                  break;
-                }
+          describe(scenario, function() {
+            before(function() {
+              if (scenario == ShadowDomVersion.V0 &&
+                  !Element.prototype.createShadowRoot) {
+                this.skipTest();
               }
-              expect(foundShadowCssClass).to.be.ok;
+
+              if (scenario == ShadowDomVersion.V1 &&
+                  !Element.prototype.attachShadow) {
+                this.skipTest();
+              }
             });
 
-            it('Should transform CSS for the shadow root', () => {
-              setShadowCssSupportedForTesting(false);
+            it('should transform CSS installStylesForDoc ' +
+                'for shadow root', () => {
               const shadowRoot = createShadowRoot(hostElement);
               const ampdoc = new AmpDocShadow(
                   window, 'https://a.org/', shadowRoot);
               const style = installStylesForDoc(ampdoc, 'body {}', null, true);
               expect(shadowRoot.contains(style)).to.be.true;
               const css = style.textContent.replace(/\s/g, '');
-              expect(css).to.match(/amp-body/);
-            });
-          });
-
-          describe('stylesheets', () => {
-            let parentStylesheet;
-
-            beforeEach(() => {
-              parentStylesheet = document.createElement('style');
-              parentStylesheet.textContent = '.x {background: red}';
-              document.body.appendChild(parentStylesheet);
-              document.body.appendChild(hostElement);
-            });
-
-            afterEach(() => {
-              document.body.removeChild(parentStylesheet);
-              document.body.removeChild(hostElement);
-            });
-
-            it('should have shadow stylesheets and not global', () => {
-              const shadowRoot = createShadowRoot(hostElement);
-              const shadowStyle = document.createElement('style');
-              shadowStyle.textContent = '.x {background: green}';
-              shadowRoot.appendChild(shadowStyle);
-
-              const {styleSheets} = shadowRoot;
-              expect(styleSheets).to.exist;
-              expect(styleSheets).to.have.length(1);
-              expect(styleSheets[0].ownerNode).to.equal(shadowStyle);
-            });
-          });
-
-          // TODO(aghassemi, #12499): Make this work with latest mocha / karma.
-          describe.skip('importShadowBody', () => {
-            let shadowRoot, source, child1, child2;
-
-            beforeEach(() => {
-              shadowRoot = createShadowRoot(hostElement);
-              source = document.createElement('body');
-              child1 = document.createElement('div');
-              child1.id = 'child1';
-              child2 = document.createElement('div');
-              child2.id = 'child2';
-              source.appendChild(child1);
-              source.appendChild(child2);
-            });
-
-            it('should import body with all children', () => {
-              expect(shadowRoot.body).to.be.undefined;
-              const body = importShadowBody(shadowRoot, source, true);
-              expect(shadowRoot.body).to.equal(body);
-              expect(body.tagName).to.equal(
-                  scenario == ShadowDomVersion.NONE ? 'AMP-BODY' : 'BODY');
-              expect(body.style.position).to.equal('relative');
               if (scenario == ShadowDomVersion.NONE) {
-                expect(body.style.display).to.equal('block');
+                expect(css).to.match(/amp-body/);
+              } else {
+                expect(css).to.equal('body{}');
               }
-              expect(shadowRoot.contains(body)).to.be.true;
-              expect(body.children).to.have.length(2);
-              expect(body.children[0].id).to.equal('child1');
-              expect(body.children[1].id).to.equal('child2');
             });
 
-            it('should import shallow body', () => {
-              expect(shadowRoot.body).to.be.undefined;
-              const body = importShadowBody(shadowRoot, source, false);
-              expect(shadowRoot.body).to.equal(body);
-              expect(body.tagName).to.equal(
-                  scenario == ShadowDomVersion.NONE ? 'AMP-BODY' : 'BODY');
-              expect(body.style.position).to.equal('relative');
+            describe('createShadowRoot', () => {
+              it('should clear duplicate root', () => {
+                const shadowRoot1 = createShadowRoot(hostElement);
+                const span = document.createElement('span');
+                shadowRoot1.appendChild(span);
+                expect(shadowRoot1.contains(span)).to.be.true;
+
+                const shadowRoot2 = createShadowRoot(hostElement);
+                expect(shadowRoot2).to.equal(shadowRoot1);
+                expect(shadowRoot2.contains(span)).to.be.false;
+              });
+
+              it('should have host', () => {
+                const shadowRoot = createShadowRoot(hostElement);
+                expect(shadowRoot.host).to.equal(hostElement);
+              });
+
+              it('should have getElementById', () => {
+                const shadowRoot = createShadowRoot(hostElement);
+                expect(shadowRoot.getElementById).to.be.ok;
+
+                const spanId = 'test' + Math.floor(Math.random() * 10000);
+                const span = document.createElement('span');
+                span.id = spanId;
+                shadowRoot.appendChild(span);
+                expect(shadowRoot.getElementById(spanId)).to.equal(span);
+              });
+
               if (scenario == ShadowDomVersion.NONE) {
-                expect(body.style.display).to.equal('block');
+                it('should add id for polyfill', () => {
+                  const shadowRoot = createShadowRoot(hostElement);
+                  expect(shadowRoot.tagName).to.equal('I-AMPHTML-SHADOW-ROOT');
+                  expect(shadowRoot.id).to.match(/i-amphtml-sd-\d+/);
+                });
+
+                it('should add host style for polyfill', () => {
+                  const doc = hostElement.ownerDocument;
+                  const win = doc.defaultView;
+                  doc.body.appendChild(hostElement);
+                  const slot = doc.createElement('div');
+                  hostElement.appendChild(slot);
+                  expect(win.getComputedStyle(slot).display).to.equal('block');
+                  const shadowRoot = createShadowRoot(hostElement);
+                  expect(hostElement).to.have.class(
+                      'i-amphtml-shadow-host-polyfill');
+                  expect(win.getComputedStyle(slot).display).to.equal('none');
+                  expect(win.getComputedStyle(shadowRoot).display)
+                      .to.not.equal('none');
+                  doc.body.removeChild(hostElement);
+                });
               }
-              expect(shadowRoot.contains(body)).to.be.true;
-              expect(body.children).to.have.length(0);
+
+              // Test scenarios where Shadow Css is not supported
+              it('Should add an id and class for CSS \
+                encapsulation to the shadow root', () => {
+                setShadowCssSupportedForTesting(false);
+                const shadowRoot = createShadowRoot(hostElement);
+                expect(shadowRoot.id).to.match(/i-amphtml-sd-\d+/);
+                // Browserify does not support arrow functions with params.
+                // Using Old School for
+                const shadowRootClassListArray =
+                  toArray(shadowRoot.host.classList);
+                let foundShadowCssClass = false;
+                for (let i = 0; i < shadowRootClassListArray.length; i++) {
+                  if (shadowRootClassListArray[i].match(/i-amphtml-sd-\d+/)) {
+                    foundShadowCssClass = true;
+                    break;
+                  }
+                }
+                expect(foundShadowCssClass).to.be.ok;
+              });
+
+              it('Should transform CSS for the shadow root', () => {
+                setShadowCssSupportedForTesting(false);
+                const shadowRoot = createShadowRoot(hostElement);
+                const ampdoc = new AmpDocShadow(
+                    window, 'https://a.org/', shadowRoot);
+                const style =
+                    installStylesForDoc(ampdoc, 'body {}', null, true);
+                expect(shadowRoot.contains(style)).to.be.true;
+                const css = style.textContent.replace(/\s/g, '');
+                expect(css).to.match(/amp-body/);
+              });
+            });
+
+            describe('stylesheets', () => {
+              let parentStylesheet;
+
+              beforeEach(() => {
+                parentStylesheet = document.createElement('style');
+                parentStylesheet.textContent = '.x {background: red}';
+                document.body.appendChild(parentStylesheet);
+                document.body.appendChild(hostElement);
+              });
+
+              afterEach(() => {
+                document.body.removeChild(parentStylesheet);
+                document.body.removeChild(hostElement);
+              });
+
+              it('should have shadow stylesheets and not global', () => {
+                const shadowRoot = createShadowRoot(hostElement);
+                const shadowStyle = document.createElement('style');
+                shadowStyle.textContent = '.x {background: green}';
+                shadowRoot.appendChild(shadowStyle);
+
+                const {styleSheets} = shadowRoot;
+                expect(styleSheets).to.exist;
+                expect(styleSheets).to.have.length(1);
+                expect(styleSheets[0].ownerNode).to.equal(shadowStyle);
+              });
+            });
+
+            // TODO(aghassemi, #12499): Make this work with latest mocha / karma
+            describe.skip('importShadowBody', () => {
+              let shadowRoot, source, child1, child2;
+
+              beforeEach(() => {
+                shadowRoot = createShadowRoot(hostElement);
+                source = document.createElement('body');
+                child1 = document.createElement('div');
+                child1.id = 'child1';
+                child2 = document.createElement('div');
+                child2.id = 'child2';
+                source.appendChild(child1);
+                source.appendChild(child2);
+              });
+
+              it('should import body with all children', () => {
+                expect(shadowRoot.body).to.be.undefined;
+                const body = importShadowBody(shadowRoot, source, true);
+                expect(shadowRoot.body).to.equal(body);
+                expect(body.tagName).to.equal(
+                    scenario == ShadowDomVersion.NONE ? 'AMP-BODY' : 'BODY');
+                expect(body.style.position).to.equal('relative');
+                if (scenario == ShadowDomVersion.NONE) {
+                  expect(body.style.display).to.equal('block');
+                }
+                expect(shadowRoot.contains(body)).to.be.true;
+                expect(body.children).to.have.length(2);
+                expect(body.children[0].id).to.equal('child1');
+                expect(body.children[1].id).to.equal('child2');
+              });
+
+              it('should import shallow body', () => {
+                expect(shadowRoot.body).to.be.undefined;
+                const body = importShadowBody(shadowRoot, source, false);
+                expect(shadowRoot.body).to.equal(body);
+                expect(body.tagName).to.equal(
+                    scenario == ShadowDomVersion.NONE ? 'AMP-BODY' : 'BODY');
+                expect(body.style.position).to.equal('relative');
+                if (scenario == ShadowDomVersion.NONE) {
+                  expect(body.style.display).to.equal('block');
+                }
+                expect(shadowRoot.contains(body)).to.be.true;
+                expect(body.children).to.have.length(0);
+              });
             });
           });
         });

--- a/test/functional/test-viewport-binding.js
+++ b/test/functional/test-viewport-binding.js
@@ -438,7 +438,7 @@ describes.realWin('ViewportBindingIosEmbedWrapper', {ampCss: true}, env => {
   });
 });
 
-describes.realWin('ViewportBindingIos', {ampCss: true}, env => {
+describes.realWin('ViewportBindingIosEmbedShadowRoot_', {ampCss: true}, env => {
   let iframe;
   let win;
   let binding;
@@ -446,7 +446,8 @@ describes.realWin('ViewportBindingIos', {ampCss: true}, env => {
   let child;
 
   // Can only test when SD is supported.
-  describe.configure().ifChrome('EmbedShadowRoot_', function() {
+  describe.configure().if(() => Element.prototype.attachShadow).run('Viewport' +
+      'BindingIosEmbedShadowRoot_', function() {
     beforeEach(function() {
       iframe = env.iframe;
       iframe.style.width = '100px';

--- a/test/functional/test-viewport-binding.js
+++ b/test/functional/test-viewport-binding.js
@@ -445,7 +445,7 @@ describes.realWin('ViewportBindingIosEmbedShadowRoot_', {ampCss: true}, env => {
   let vsync;
   let child;
 
-  // Can only test when SD is supported.
+  // Can only test when Shadow DOM is available.
   describe.configure().if(() => Element.prototype.attachShadow).run('Viewport' +
       'BindingIosEmbedShadowRoot_', function() {
     beforeEach(function() {

--- a/test/functional/test-viewport-binding.js
+++ b/test/functional/test-viewport-binding.js
@@ -438,293 +438,292 @@ describes.realWin('ViewportBindingIosEmbedWrapper', {ampCss: true}, env => {
   });
 });
 
-describes.realWin('ViewportBindingIosEmbedShadowRoot_', {ampCss: true}, env => {
+describes.realWin('ViewportBindingIos', {ampCss: true}, env => {
   let iframe;
   let win;
   let binding;
   let vsync;
   let child;
 
-  beforeEach(function() {
-    if (!env.win.Element.prototype.attachShadow) {
-      // Can only test when SD is supported.
-      this.skip();
-    }
-    iframe = env.iframe;
-    iframe.style.width = '100px';
-    iframe.style.height = '100px';
-    win = env.win;
-    win.document.documentElement.className = 'top i-amphtml-singledoc';
-    child = win.document.createElement('div');
-    child.style.width = '200px';
-    child.style.height = '300px';
-    child.textContent = 'test';
-    win.document.body.appendChild(child);
+  // Can only test when SD is supported.
+  describe.configure().ifChrome('EmbedShadowRoot_', function() {
+    beforeEach(function() {
+      iframe = env.iframe;
+      iframe.style.width = '100px';
+      iframe.style.height = '100px';
+      win = env.win;
+      win.document.documentElement.className = 'top i-amphtml-singledoc';
+      child = win.document.createElement('div');
+      child.style.width = '200px';
+      child.style.height = '300px';
+      child.textContent = 'test';
+      win.document.body.appendChild(child);
 
-    const styleEl = win.document.createElement('style');
-    styleEl.textContent = `
-        .flexed {display: flex}
-        @media (min-width: 150px) {
-          body {display: table}
-        }
-      `;
-    win.document.head.appendChild(styleEl);
+      const styleEl = win.document.createElement('style');
+      styleEl.textContent = `
+          .flexed {display: flex}
+          @media (min-width: 150px) {
+            body {display: table}
+          }
+        `;
+      win.document.head.appendChild(styleEl);
 
-    installDocService(win, /* isSingleDoc */ true);
-    installDocumentStateService(win);
-    installVsyncService(win);
-    vsync = Services.vsyncFor(win);
-    binding = new ViewportBindingIosEmbedShadowRoot_(win);
-    binding.connect();
-  });
-
-  it('should NOT require fixed layer transferring', () => {
-    expect(binding.requiresFixedLayerTransfer()).to.be.true;
-  });
-
-  it('should start w/o overscroll and set it on doc ready', () => {
-    const root = binding.getScrollingElement();
-    expect(root).to.not.have.class('i-amphtml-ios-overscroll');
-    return whenDocumentReady(win.document).then(() => {
-      expect(root).to.have.class('i-amphtml-ios-overscroll');
+      installDocService(win, /* isSingleDoc */ true);
+      installDocumentStateService(win);
+      installVsyncService(win);
+      vsync = Services.vsyncFor(win);
+      binding = new ViewportBindingIosEmbedShadowRoot_(win);
+      binding.connect();
     });
-  });
 
-  it('should have UI setup', () => {
-    expect(binding.setupDone_).to.be.true;
-    expect(win.document.documentElement)
-        .to.have.class('i-amphtml-ios-embed-sd');
-    // Should preserve existing classes.
-    expect(win.document.documentElement).to.have.class('top');
-    expect(win.document.body).to.exist;
-    expect(win.document.body.parentNode)
-        .to.equal(win.document.documentElement);
-    expect(win.document.body.shadowRoot).to.exist;
-    expect(win.document.body.shadowRoot.firstElementChild)
-        .to.equal(binding.scroller_);
-    expect(binding.wrapper_.parentNode)
-        .to.equal(binding.scroller_);
-    expect(binding.wrapper_.firstElementChild.tagName)
-        .to.equal('SLOT');
-    expect(binding.wrapper_.tagName).to.equal('DIV');
-    expect(binding.wrapper_.id).to.equal('i-amphtml-body-wrapper');
-    expect(win.document.body.contains(child)).to.be.true;
-    expect(binding.wrapper_.contains(child)).to.be.false;
-    expect(win.document.contains(child)).to.be.true;
-    expect(child.textContent).to.equal('test');
-  });
-
-  it('should have CSS setup', () => {
-    const htmlCss = win.getComputedStyle(win.document.documentElement);
-    const scrollerCss = win.getComputedStyle(binding.scroller_);
-    const wrapperCss = win.getComputedStyle(binding.wrapper_);
-    const bodyCss = win.getComputedStyle(win.document.body);
-
-    // `<html>` must have `position: static` or layout is broken. It must
-    // not be scrollable.
-    expect(htmlCss.position).to.equal('static');
-    expect(htmlCss.overflowY).to.equal('hidden');
-    expect(htmlCss.overflowX).to.equal('hidden');
-
-    // Body takes full viewport and not scrollable.
-    expect(bodyCss.overflowY).to.equal('hidden');
-    expect(bodyCss.overflowX).to.equal('hidden');
-    expect(bodyCss.margin).to.equal('0px');
-    expect(bodyCss.position).to.equal('absolute');
-    expect(bodyCss.top).to.equal('0px');
-    expect(bodyCss.left).to.equal('0px');
-    expect(bodyCss.right).to.equal('0px');
-    expect(bodyCss.bottom).to.equal('0px');
-
-    // Scroller is full-viewport size and scrollable.
-    // Unfortunately, we can't test here `-webkit-overflow-scrolling`.
-    expect(scrollerCss.overflowY).to.equal('auto');
-    expect(scrollerCss.overflowX).to.equal('hidden');
-    expect(wrapperCss.overflowY).to.equal('visible');
-    expect(wrapperCss.overflowX).to.equal('visible');
-
-    // Scroller must be a block and positioned absolute at 0/0/0/0.
-    expect(scrollerCss.display).to.equal('block');
-    expect(scrollerCss.boxSizing).to.equal('border-box');
-    expect(scrollerCss.position).to.equal('absolute');
-    expect(scrollerCss.top).to.equal('0px');
-    expect(scrollerCss.left).to.equal('0px');
-    expect(scrollerCss.right).to.equal('0px');
-    expect(scrollerCss.bottom).to.equal('0px');
-    expect(scrollerCss.margin).to.equal('0px');
-    // Scroler must have a 1px transparent border for two purposes:
-    // (1) to cancel out margin collapse in body's children;
-    // (2) to offset scroll adjustment to 1 to avoid scroll freeze problem.
-    expect(scrollerCss.borderTop.replace('rgba(0, 0, 0, 0)', 'transparent'))
-        .to.equal('1px solid transparent');
-
-    // Preserve and inherit the customized body styles.
-    win.document.body.style.display = 'flex';
-    win.document.body.style.flexDirection = 'row';
-    win.document.body.style.alignItems = 'center';
-    return vsync.mutatePromise().then(() => {
-      expect(binding.wrapper_.style.display).to.equal('flex');
-      expect(binding.wrapper_.style.flexDirection).to.equal('row');
-      expect(binding.wrapper_.style.alignItems).to.equal('center');
+    it('should NOT require fixed layer transferring', () => {
+      expect(binding.requiresFixedLayerTransfer()).to.be.true;
     });
-  });
 
-  it('should update body styles on class changes', () => {
-    // Body styles are moved to the wrapper.
-    return vsync.mutatePromise().then(() => {
-      expect(binding.wrapper_.style.display).to.equal('block');
-      win.document.body.classList.add('flexed');
-      return vsync.mutatePromise();
-    }).then(() => {
-      expect(binding.wrapper_.style.display).to.equal('flex');
-    });
-  });
-
-  it('should update body styles on style changes', () => {
-    // Body styles are moved to the wrapper.
-    return vsync.mutatePromise().then(() => {
-      expect(binding.wrapper_.style.display).to.equal('block');
-      win.document.body.style.display = 'table';
-      return vsync.mutatePromise();
-    }).then(() => {
-      expect(binding.wrapper_.style.display).to.equal('table');
-    });
-  });
-
-  it('should update body styles on resize', () => {
-    // Body styles are moved to the wrapper.
-    return vsync.mutatePromise().then(() => {
-      expect(binding.wrapper_.style.display).to.equal('block');
-      return new Promise(resolve => {
-        binding.onResize(resolve);
-        iframe.style.width = '200px';
+    it('should start w/o overscroll and set it on doc ready', () => {
+      const root = binding.getScrollingElement();
+      expect(root).to.not.have.class('i-amphtml-ios-overscroll');
+      return whenDocumentReady(win.document).then(() => {
+        expect(root).to.have.class('i-amphtml-ios-overscroll');
       });
-    }).then(() => {
-      return vsync.mutatePromise();
-    }).then(() => {
-      expect(binding.wrapper_.style.display).to.equal('table');
     });
-  });
 
-  it('should be immediately scrolled to 1 to avoid freeze', () => {
-    expect(binding.scroller_.scrollTop).to.equal(1);
-  });
-
-  it('should connect events: subscribe to scroll and resize events', () => {
-    expect(win.eventListeners.count('resize')).to.equal(1);
-    // Note that scroll event is on the wrapper, and NOT on root or body.
-    expect(win.eventListeners.count('scroll')).to.equal(0);
-    expect(win.document.eventListeners.count('scroll')).to.equal(0);
-    expect(win.document.documentElement.eventListeners.count('scroll'))
-        .to.equal(0);
-    expect(win.document.body.eventListeners.count('scroll'))
-        .to.equal(0);
-  });
-
-  it('should disconnect events', () => {
-    // After disconnect, there are no more listeners on window.
-    binding.disconnect();
-    expect(win.eventListeners.count('resize')).to.equal(0);
-  });
-
-  it('should update padding', () => {
-    binding.updatePaddingTop(31);
-    expect(binding.scroller_.style.paddingTop).to.equal('31px');
-    // Notice, root is not touched.
-    expect(win.document.documentElement.style.paddingTop).to.equal('');
-  });
-
-  it('should calculate scrollTop from scroller', () => {
-    binding.scroller_.scrollTop = 17;
-    expect(binding.getScrollTop()).to.equal(17);
-  });
-
-  it('should calculate scrollWidth from scroller', () => {
-    expect(binding.getScrollWidth()).to.equal(200);
-  });
-
-  it('should calculate scrollHeight from scroller', () => {
-    expect(binding.getScrollHeight()).to.equal(300);
-  });
-
-  it('should calculate contentHeight from body height', () => {
-    // Set content to be smaller than viewport.
-    child.style.height = '50px';
-    expect(binding.getContentHeight()).to.equal(51);
-  });
-
-  it('should include padding top in contentHeight', () => {
-    binding.updatePaddingTop(10);
-    binding.setScrollTop(20); // should have no effect on height
-    expect(binding.getContentHeight()).to.equal(311); // +1px for border-top.
-  });
-
-  it('should update scrollTop on scroller', () => {
-    binding.setScrollTop(21);
-    expect(binding.scroller_.scrollTop).to.equal(21);
-  });
-
-  it('should adjust scrollTop to avoid scroll freeze', () => {
-    binding.setScrollTop(21);
-    expect(binding.scroller_.scrollTop).to.equal(21);
-
-    // `scrollTop=0` is normally not allowed.
-    binding.setScrollTop(0);
-    expect(binding.scroller_.scrollTop).to.equal(1);
-  });
-
-  it('should offset client rect for layout', () => {
-    binding.scroller_.scrollTop = 200;
-    const el = {
-      getBoundingClientRect: () => {
-        return {left: 11.5, top: 12.5, width: 13.5, height: 14.5};
-      },
-    };
-    const rect = binding.getLayoutRect(el);
-    expect(rect.top).to.equal(213); // round(200 + 12.5)
-    expect(rect.width).to.equal(14); // round(13.5)
-    expect(rect.height).to.equal(15); // round(14.5)
-  });
-
-  it('should offset client rect for layout and position passed in', () => {
-    binding.scroller_.scrollTop = 10;
-    const el = {
-      getBoundingClientRect: () => {
-        return {left: 11.5, top: 12.5, width: 13.5, height: 14.5};
-      },
-    };
-    const rect = binding.getLayoutRect(el, 100, 200);
-    expect(rect.left).to.equal(112); // round(100 + 11.5)
-    expect(rect.top).to.equal(213); // round(200 + 12.5)
-    expect(rect.width).to.equal(14); // round(13.5)
-    expect(rect.height).to.equal(15); // round(14.5)
-  });
-
-  it('should call scroll event', () => {
-    binding.scroller_.scrollTop = 1;
-    return new Promise(resolve => {
-      binding.onScroll(resolve);
-      binding.scroller_.scrollTop = 11;
-    }).then(() => {
-      expect(binding.getScrollTop()).to.equal(11);
+    it('should have UI setup', () => {
+      expect(binding.setupDone_).to.be.true;
+      expect(win.document.documentElement)
+          .to.have.class('i-amphtml-ios-embed-sd');
+      // Should preserve existing classes.
+      expect(win.document.documentElement).to.have.class('top');
+      expect(win.document.body).to.exist;
+      expect(win.document.body.parentNode)
+          .to.equal(win.document.documentElement);
+      expect(win.document.body.shadowRoot).to.exist;
+      expect(win.document.body.shadowRoot.firstElementChild)
+          .to.equal(binding.scroller_);
+      expect(binding.wrapper_.parentNode)
+          .to.equal(binding.scroller_);
+      expect(binding.wrapper_.firstElementChild.tagName)
+          .to.equal('SLOT');
+      expect(binding.wrapper_.tagName).to.equal('DIV');
+      expect(binding.wrapper_.id).to.equal('i-amphtml-body-wrapper');
+      expect(win.document.body.contains(child)).to.be.true;
+      expect(binding.wrapper_.contains(child)).to.be.false;
+      expect(win.document.contains(child)).to.be.true;
+      expect(child.textContent).to.equal('test');
     });
-  });
 
-  it('should disable scroll temporarily and reset scroll', () => {
-    let scrollerCss = win.getComputedStyle(binding.scroller_);
-    expect(scrollerCss.overflowX).to.equal('hidden');
-    expect(scrollerCss.overflowY).to.equal('auto');
+    it('should have CSS setup', () => {
+      const htmlCss = win.getComputedStyle(win.document.documentElement);
+      const scrollerCss = win.getComputedStyle(binding.scroller_);
+      const wrapperCss = win.getComputedStyle(binding.wrapper_);
+      const bodyCss = win.getComputedStyle(win.document.body);
 
-    binding.disableScroll();
+      // `<html>` must have `position: static` or layout is broken. It must
+      // not be scrollable.
+      expect(htmlCss.position).to.equal('static');
+      expect(htmlCss.overflowY).to.equal('hidden');
+      expect(htmlCss.overflowX).to.equal('hidden');
 
-    scrollerCss = win.getComputedStyle(binding.scroller_);
-    expect(scrollerCss.overflowX).to.equal('hidden');
-    expect(scrollerCss.overflowY).to.equal('hidden');
+      // Body takes full viewport and not scrollable.
+      expect(bodyCss.overflowY).to.equal('hidden');
+      expect(bodyCss.overflowX).to.equal('hidden');
+      expect(bodyCss.margin).to.equal('0px');
+      expect(bodyCss.position).to.equal('absolute');
+      expect(bodyCss.top).to.equal('0px');
+      expect(bodyCss.left).to.equal('0px');
+      expect(bodyCss.right).to.equal('0px');
+      expect(bodyCss.bottom).to.equal('0px');
 
-    binding.resetScroll();
+      // Scroller is full-viewport size and scrollable.
+      // Unfortunately, we can't test here `-webkit-overflow-scrolling`.
+      expect(scrollerCss.overflowY).to.equal('auto');
+      expect(scrollerCss.overflowX).to.equal('hidden');
+      expect(wrapperCss.overflowY).to.equal('visible');
+      expect(wrapperCss.overflowX).to.equal('visible');
 
-    scrollerCss = win.getComputedStyle(binding.scroller_);
-    expect(scrollerCss.overflowX).to.equal('hidden');
-    expect(scrollerCss.overflowY).to.equal('auto');
+      // Scroller must be a block and positioned absolute at 0/0/0/0.
+      expect(scrollerCss.display).to.equal('block');
+      expect(scrollerCss.boxSizing).to.equal('border-box');
+      expect(scrollerCss.position).to.equal('absolute');
+      expect(scrollerCss.top).to.equal('0px');
+      expect(scrollerCss.left).to.equal('0px');
+      expect(scrollerCss.right).to.equal('0px');
+      expect(scrollerCss.bottom).to.equal('0px');
+      expect(scrollerCss.margin).to.equal('0px');
+      // Scroler must have a 1px transparent border for two purposes:
+      // (1) to cancel out margin collapse in body's children;
+      // (2) to offset scroll adjustment to 1 to avoid scroll freeze problem.
+      expect(scrollerCss.borderTop.replace('rgba(0, 0, 0, 0)', 'transparent'))
+          .to.equal('1px solid transparent');
+
+      // Preserve and inherit the customized body styles.
+      win.document.body.style.display = 'flex';
+      win.document.body.style.flexDirection = 'row';
+      win.document.body.style.alignItems = 'center';
+      return vsync.mutatePromise().then(() => {
+        expect(binding.wrapper_.style.display).to.equal('flex');
+        expect(binding.wrapper_.style.flexDirection).to.equal('row');
+        expect(binding.wrapper_.style.alignItems).to.equal('center');
+      });
+    });
+
+    it('should update body styles on class changes', () => {
+      // Body styles are moved to the wrapper.
+      return vsync.mutatePromise().then(() => {
+        expect(binding.wrapper_.style.display).to.equal('block');
+        win.document.body.classList.add('flexed');
+        return vsync.mutatePromise();
+      }).then(() => {
+        expect(binding.wrapper_.style.display).to.equal('flex');
+      });
+    });
+
+    it('should update body styles on style changes', () => {
+      // Body styles are moved to the wrapper.
+      return vsync.mutatePromise().then(() => {
+        expect(binding.wrapper_.style.display).to.equal('block');
+        win.document.body.style.display = 'table';
+        return vsync.mutatePromise();
+      }).then(() => {
+        expect(binding.wrapper_.style.display).to.equal('table');
+      });
+    });
+
+    it('should update body styles on resize', () => {
+      // Body styles are moved to the wrapper.
+      return vsync.mutatePromise().then(() => {
+        expect(binding.wrapper_.style.display).to.equal('block');
+        return new Promise(resolve => {
+          binding.onResize(resolve);
+          iframe.style.width = '200px';
+        });
+      }).then(() => {
+        return vsync.mutatePromise();
+      }).then(() => {
+        expect(binding.wrapper_.style.display).to.equal('table');
+      });
+    });
+
+    it('should be immediately scrolled to 1 to avoid freeze', () => {
+      expect(binding.scroller_.scrollTop).to.equal(1);
+    });
+
+    it('should connect events: subscribe to scroll and resize events', () => {
+      expect(win.eventListeners.count('resize')).to.equal(1);
+      // Note that scroll event is on the wrapper, and NOT on root or body.
+      expect(win.eventListeners.count('scroll')).to.equal(0);
+      expect(win.document.eventListeners.count('scroll')).to.equal(0);
+      expect(win.document.documentElement.eventListeners.count('scroll'))
+          .to.equal(0);
+      expect(win.document.body.eventListeners.count('scroll'))
+          .to.equal(0);
+    });
+
+    it('should disconnect events', () => {
+      // After disconnect, there are no more listeners on window.
+      binding.disconnect();
+      expect(win.eventListeners.count('resize')).to.equal(0);
+    });
+
+    it('should update padding', () => {
+      binding.updatePaddingTop(31);
+      expect(binding.scroller_.style.paddingTop).to.equal('31px');
+      // Notice, root is not touched.
+      expect(win.document.documentElement.style.paddingTop).to.equal('');
+    });
+
+    it('should calculate scrollTop from scroller', () => {
+      binding.scroller_.scrollTop = 17;
+      expect(binding.getScrollTop()).to.equal(17);
+    });
+
+    it('should calculate scrollWidth from scroller', () => {
+      expect(binding.getScrollWidth()).to.equal(200);
+    });
+
+    it('should calculate scrollHeight from scroller', () => {
+      expect(binding.getScrollHeight()).to.equal(300);
+    });
+
+    it('should calculate contentHeight from body height', () => {
+      // Set content to be smaller than viewport.
+      child.style.height = '50px';
+      expect(binding.getContentHeight()).to.equal(51);
+    });
+
+    it('should include padding top in contentHeight', () => {
+      binding.updatePaddingTop(10);
+      binding.setScrollTop(20); // should have no effect on height
+      expect(binding.getContentHeight()).to.equal(311); // +1px for border-top.
+    });
+
+    it('should update scrollTop on scroller', () => {
+      binding.setScrollTop(21);
+      expect(binding.scroller_.scrollTop).to.equal(21);
+    });
+
+    it('should adjust scrollTop to avoid scroll freeze', () => {
+      binding.setScrollTop(21);
+      expect(binding.scroller_.scrollTop).to.equal(21);
+
+      // `scrollTop=0` is normally not allowed.
+      binding.setScrollTop(0);
+      expect(binding.scroller_.scrollTop).to.equal(1);
+    });
+
+    it('should offset client rect for layout', () => {
+      binding.scroller_.scrollTop = 200;
+      const el = {
+        getBoundingClientRect: () => {
+          return {left: 11.5, top: 12.5, width: 13.5, height: 14.5};
+        },
+      };
+      const rect = binding.getLayoutRect(el);
+      expect(rect.top).to.equal(213); // round(200 + 12.5)
+      expect(rect.width).to.equal(14); // round(13.5)
+      expect(rect.height).to.equal(15); // round(14.5)
+    });
+
+    it('should offset client rect for layout and position passed in', () => {
+      binding.scroller_.scrollTop = 10;
+      const el = {
+        getBoundingClientRect: () => {
+          return {left: 11.5, top: 12.5, width: 13.5, height: 14.5};
+        },
+      };
+      const rect = binding.getLayoutRect(el, 100, 200);
+      expect(rect.left).to.equal(112); // round(100 + 11.5)
+      expect(rect.top).to.equal(213); // round(200 + 12.5)
+      expect(rect.width).to.equal(14); // round(13.5)
+      expect(rect.height).to.equal(15); // round(14.5)
+    });
+
+    it('should call scroll event', () => {
+      binding.scroller_.scrollTop = 1;
+      return new Promise(resolve => {
+        binding.onScroll(resolve);
+        binding.scroller_.scrollTop = 11;
+      }).then(() => {
+        expect(binding.getScrollTop()).to.equal(11);
+      });
+    });
+
+    it('should disable scroll temporarily and reset scroll', () => {
+      let scrollerCss = win.getComputedStyle(binding.scroller_);
+      expect(scrollerCss.overflowX).to.equal('hidden');
+      expect(scrollerCss.overflowY).to.equal('auto');
+
+      binding.disableScroll();
+
+      scrollerCss = win.getComputedStyle(binding.scroller_);
+      expect(scrollerCss.overflowX).to.equal('hidden');
+      expect(scrollerCss.overflowY).to.equal('hidden');
+
+      binding.resetScroll();
+
+      scrollerCss = win.getComputedStyle(binding.scroller_);
+      expect(scrollerCss.overflowX).to.equal('hidden');
+      expect(scrollerCss.overflowY).to.equal('auto');
+    });
   });
 });

--- a/test/integration/test-video-players-helper.js
+++ b/test/integration/test-video-players-helper.js
@@ -38,7 +38,7 @@ function skipIfAutoplayUnsupported(win) {
     if (isSupported) {
       return;
     }
-    this.skip();
+    this.skipTest();
   });
 }
 
@@ -229,23 +229,29 @@ export function runVideoPlayerIntegrationTests(
           });
         });
 
-        it('should trigger ended analytics when the video ends', function() {
-          return getVideoPlayer(
-              {
-                outsideView: false,
-                autoplay: true,
-              }
-          ).then(r => {
-            // TODO(cvializ): Better way to detect which classes implement
-            // methods needed for tracking?
-            const {tagName} = r.video;
-            if (tagName !== 'AMP-VIDEO' &&
-            tagName !== 'AMP-TEST-FAKE-VIDEOPLAYER') {
-              this.skip();
-              return;
-            }
 
-            video = r.video;
+        describe('should trigger ended analytics', () => {
+          let player;
+          before(function() {
+            return getVideoPlayer(
+                {
+                  outsideView: false,
+                  autoplay: true,
+                }
+            ).then(r => {
+              // TODO(cvializ): Better way to detect which classes implement
+              // methods needed for tracking?
+              const {tagName} = r.video;
+              if (tagName !== 'AMP-VIDEO' &&
+              tagName !== 'AMP-TEST-FAKE-VIDEOPLAYER') {
+                this.skipTest();
+                return;
+              }
+              player = r;
+            });
+          });
+          it('when the video ends', function() {
+            video = player.video;
             return listenOncePromise(video, VideoAnalyticsEvents.ENDED);
           });
         });


### PR DESCRIPTION
There are two issues with mocha's `this.skip()`:
1. Using it within the body of a `beforeEach()` block or `it()` block will cause `afterEach()` to be skipped (https://github.com/mochajs/mocha/issues/2148)
2. It doesn't work when used within a nested `describe` block (https://github.com/mochajs/mocha/issues/2683)

According to https://mochajs.org/#inclusive-tests, the recommended place in which to dynamically skip tests is within a `before()` block.

This PR does the following:
- Introduces `this.skipTest()`, a more robust version of `this.skip()` that...
    - makes sure it is being used within a `before()` block
    - works within nested `describe` blocks
- Forbids the use of `this.skip()` within tests, and recommends the use of `this.skipTest()` instead

With this, dirty global state due to inadvertent skipping of `afterEach()` should no longer be a problem.

Fixes #17245
Partial fix for #14360
