### PR TITLE
Fixing the progress bar "double segment" animations.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-system-layer.js
+++ b/extensions/amp-story/1.0/amp-story-system-layer.js
@@ -435,15 +435,6 @@ export class SystemLayer {
   }
 
   /**
-   * @param {string} pageId The page id of the new active page.
-   * @public
-   */
-  setActivePageId(pageId) {
-    // TODO(newmuis) avoid passing progress logic through system-layer
-    this.progressBar_.setActiveSegmentId(pageId);
-  }
-
-  /**
    * @param {string} pageId The id of the page whose progress should be
    *     changed.
    * @param {number} progress A number from 0.0 to 1.0, representing the

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -910,8 +910,6 @@ export class AmpStory extends AMP.BaseElement {
     } else {
       this.storeService_.dispatch(Action.TOGGLE_AD, false);
       removeAttributeInMutate(this, Attributes.AD_SHOWING);
-      // TODO(alanorozco): decouple this using NavigationState
-      this.systemLayer_.setActivePageId(targetPageId);
     }
 
     // TODO(alanorozco): check if autoplay
@@ -983,8 +981,6 @@ export class AmpStory extends AMP.BaseElement {
       // target page as fast as possible.
       () => {
         oldPage && oldPage.element.removeAttribute('active');
-
-        this.systemLayer_.setActivePageId(targetPageId);
 
         // Starts playing the page, if the story is not paused.
         // Note: navigation is prevented when the story is paused, this test

--- a/extensions/amp-story/1.0/page-advancement.js
+++ b/extensions/amp-story/1.0/page-advancement.js
@@ -430,6 +430,8 @@ class TimeBasedAdvancement extends AdvancementConfig {
 
     this.timeoutId_ = this.timer_.delay(() => this.onAdvance(), this.delayMs_);
 
+    this.onProgressUpdate();
+
     this.timer_.poll(POLL_INTERVAL_MS, () => {
       this.onProgressUpdate();
       return !this.isRunning();
@@ -591,6 +593,8 @@ class MediaBasedAdvancement extends AdvancementConfig {
 
     listenOnce(this.element_, VideoEvents.ENDED, () => this.onAdvance(),
         {capture: true});
+
+    this.onProgressUpdate();
 
     this.timer_.poll(POLL_INTERVAL_MS, () => {
       this.onProgressUpdate();

--- a/extensions/amp-story/1.0/test/test-amp-story-system-layer.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-system-layer.js
@@ -41,7 +41,6 @@ describes.fakeWin('amp-story system layer', {amp: true}, env => {
     progressBarStub = {
       build: sandbox.stub().returns(progressBarRoot),
       getRoot: sandbox.stub().returns(progressBarRoot),
-      setActiveSegmentId: sandbox.spy(),
       updateProgress: sandbox.spy(),
     };
 
@@ -75,13 +74,6 @@ describes.fakeWin('amp-story system layer', {amp: true}, env => {
     systemLayer.initializeListeners_();
 
     expect(rootMock.addEventListener).to.have.been.calledWith('click');
-  });
-
-  it('should set the active page index', () => {
-    [0, 1, 2, 3, 4].forEach(index => {
-      systemLayer.setActivePageId(index);
-      progressBarStub.setActiveSegmentId.should.have.been.calledWith(index);
-    });
   });
 
   it('should set an attribute to toggle the UI when an ad is shown', () => {


### PR DESCRIPTION
A few updates for the `progress-bar`:
- Ensures we never get two progress bar segments animating at the same time
- Uses `updateProgress` to update all the progress bar statements
- Removes `setActiveSegmentId` as we already get the information from `updateProgress`
- Ensures `page-advancement` fires progress events for time and media advancement before it starts polling

Fixes #14635