### PR TITLE
Fix lightbox-gallery starts showing blank 0x0 images after one full loop bug

### DIFF
--- a/extensions/amp-image-viewer/0.1/amp-image-viewer.js
+++ b/extensions/amp-image-viewer/0.1/amp-image-viewer.js
@@ -149,10 +149,16 @@ export class AmpImageViewer extends AMP.BaseElement {
       return this.loadPromise_;
     }
     const ampImg = dev().assertElement(this.sourceAmpImage_);
-    const laidOutPromise = ampImg.hasAttribute('i-amphtml-layout')
+    const isLaidOut = ampImg.hasAttribute('i-amphtml-layout') ||
+      ampImg.classList.contains('i-amphtml-layout');
+    const laidOutPromise = isLaidOut
       ? Promise.resolve()
       : ampImg.signals().whenSignal(CommonSignals.LOAD_END);
-    this.scheduleLayout(ampImg);
+
+    if (!isLaidOut) {
+      this.scheduleLayout(ampImg);
+    }
+
     this.loadPromise_ = laidOutPromise
         .then(() => this.init_())
         .then(() => this.resetImageDimensions_())
@@ -173,9 +179,6 @@ export class AmpImageViewer extends AMP.BaseElement {
 
   /** @override */
   resumeCallback() {
-    if (this.sourceAmpImage_) {
-      this.scheduleLayout(this.sourceAmpImage_);
-    }
     if (!this.loadPromise_) {
       return;
     }


### PR DESCRIPTION
It turns out that `i-amphtml-layout` is an SSR-only thing. For non-SSR laid out components, it's a CSS class. The reason why we need this is because carousel started calling layoutCallback and unlayoutCallback on slides when we swipe, thus the slides will unlayout after being swiped away and fail to correctly display when we next navigate / swipe to them. 

Closes https://github.com/ampproject/amphtml/issues/17258. 