### PR TITLE
🐛 Fix docs for amp-position-observer s/target-id/target/

### DIFF
--- a/extensions/amp-position-observer/0.1/amp-position-observer.js
+++ b/extensions/amp-position-observer/0.1/amp-position-observer.js
@@ -314,7 +314,7 @@ export class AmpVisibilityObserver extends AMP.BaseElement {
 
   /**
    * Finds the container scene. Either parent of the component or specified by
-   * `target-id` attribute.
+   * `target` attribute.
    * @return {!Element} scene element.
    * @private
    */

--- a/extensions/amp-position-observer/amp-position-observer.md
+++ b/extensions/amp-position-observer/amp-position-observer.md
@@ -188,7 +188,7 @@ as clock becomes less than 50% visible.
 
 ## Attributes
 
-#### target-id (optional)
+#### target (optional)
 Specifies the ID of the element to observe. If **not specified**, the **parent** of `<amp-position-observer>` is used as the target.
 
 #### intersection-ratios (optional)


### PR DESCRIPTION
The [`amp-position-observer` docs](https://www.ampproject.org/docs/reference/components/amp-position-observer#attributes) incorrectly state that there is a `target-id` attribute:

> ![image](https://user-images.githubusercontent.com/134745/43627369-f258dd38-96aa-11e8-8509-9d937e0089d2.png)

It should actually be just `target`:

https://github.com/ampproject/amphtml/blob/1143ef048f4845ff0ae21a78c07053646508fc36/extensions/amp-position-observer/validator-amp-position-observer.protoascii#L45