### PR TITLE
📖 Removing "optional" for creating new component example

### DIFF
--- a/contributing/building-an-amp-extension.md
+++ b/contributing/building-an-amp-extension.md
@@ -702,8 +702,8 @@ true/false)` to enable.
 
 ## Example of using your extension
 
-This is optional but it greatly helps users to understand and demo how
-your element works and provides an easy start-point for them to
+This greatly helps users to understand and demonstrate how
+your element works, and provides an easy start-point for them to
 experiment with it. This is basically where you actually build an AMP
 HTML document and use your element in it by creating a file in the
 `examples/` directory, usually with the `my-element.amp.html` file


### PR DESCRIPTION
As part of creating a new extension, creating a code example isn't optional.
(Identified in the initiative to improving contributor docs)

