### PR TITLE
🏗  Run pre-push tests in headless mode

### DIFF
--- a/build-system/default-pre-push
+++ b/build-system/default-pre-push
@@ -27,7 +27,7 @@ CYAN() { echo -e "\033[0;36m$1\033[0m"; }
 
 GULP_BUNDLE_SIZE="gulp bundle-size"
 GULP_LINT_LOCAL="gulp lint --local-changes"
-GULP_TEST_LOCAL="gulp test --local-changes"
+GULP_TEST_LOCAL="gulp test --local-changes --headless"
 
 echo $(GREEN "Running") $(CYAN "pre-push") $(GREEN "hooks. (Run") $(CYAN "git push --no-verify") $(GREEN "to skip them.)")
 echo -e "\n"


### PR DESCRIPTION
This makes the pre-push tests less annoying, and more likely to pass (inadvertent clicks on the test window can fail them).