### PR TITLE
Getting videos to play reliably in the first story page.

### DIFF
--- a/extensions/amp-story/0.1/media-pool.js
+++ b/extensions/amp-story/0.1/media-pool.js
@@ -121,9 +121,6 @@ export class MediaPool {
     /** @private @const {!../../../src/service/timer-impl.Timer} */
     this.timer_ = Services.timerFor(win);
 
-    /** @private @const {!../../../src/service/vsync-impl.Vsync} */
-    this.vsync_ = Services.vsyncFor(win);
-
     /**
      * The function used to retrieve the distance between an element and the
      * current position in the document.
@@ -224,24 +221,22 @@ export class MediaPool {
       this.allocated[type] = [];
       this.unallocated[type] = [];
 
-      this.vsync_.mutate(() => {
-        // Reverse-looping is generally faster and Closure would usually make
-        // this optimization automatically. However, it skips it due to a
-        // comparison with the itervar below, so we have to roll it by hand.
-        for (let i = count; i > 0; i--) {
-          const mediaEl = /** @type {!HTMLMediaElement} */
-              // Use seed element at end of set to prevent wasting it.
-              (i == 1 ? mediaElSeed : mediaElSeed.cloneNode(/* deep */ true));
-          const sources = this.getDefaultSource_(type);
-          mediaEl.setAttribute('pool-element', elId++);
-          this.enqueueMediaElementTask_(mediaEl,
-              new UpdateSourcesTask(sources));
-          // TODO(newmuis): Check the 'error' field to see if MEDIA_ERR_DECODE
-          // is returned.  If so, we should adjust the pool size/distribution
-          // between media types.
-          this.unallocated[type].push(mediaEl);
-        }
-      });
+      // Reverse-looping is generally faster and Closure would usually make
+      // this optimization automatically. However, it skips it due to a
+      // comparison with the itervar below, so we have to roll it by hand.
+      for (let i = count; i > 0; i--) {
+        const mediaEl = /** @type {!HTMLMediaElement} */
+            // Use seed element at end of set to prevent wasting it.
+            (i == 1 ? mediaElSeed : mediaElSeed.cloneNode(/* deep */ true));
+        const sources = this.getDefaultSource_(type);
+        mediaEl.setAttribute('pool-element', elId++);
+        this.enqueueMediaElementTask_(mediaEl,
+            new UpdateSourcesTask(sources));
+        // TODO(newmuis): Check the 'error' field to see if MEDIA_ERR_DECODE
+        // is returned.  If so, we should adjust the pool size/distribution
+        // between media types.
+        this.unallocated[type].push(mediaEl);
+      }
     });
   }
 

--- a/extensions/amp-story/1.0/media-pool.js
+++ b/extensions/amp-story/1.0/media-pool.js
@@ -124,9 +124,6 @@ export class MediaPool {
     /** @private @const {!../../../src/service/timer-impl.Timer} */
     this.timer_ = Services.timerFor(win);
 
-    /** @private @const {!../../../src/service/vsync-impl.Vsync} */
-    this.vsync_ = Services./*OK*/vsyncFor(win);
-
     /**
      * The function used to retrieve the distance between an element and the
      * current position in the document.
@@ -230,24 +227,22 @@ export class MediaPool {
       this.allocated[type] = [];
       this.unallocated[type] = [];
 
-      this.vsync_.mutate(() => {
-        // Reverse-looping is generally faster and Closure would usually make
-        // this optimization automatically. However, it skips it due to a
-        // comparison with the itervar below, so we have to roll it by hand.
-        for (let i = count; i > 0; i--) {
-          const mediaEl = /** @type {!HTMLMediaElement} */
-              // Use seed element at end of set to prevent wasting it.
-              (i == 1 ? mediaElSeed : mediaElSeed.cloneNode(/* deep */ true));
-          const sources = this.getDefaultSource_(type);
-          mediaEl.setAttribute('pool-element', elId++);
-          this.enqueueMediaElementTask_(mediaEl,
-              new UpdateSourcesTask(sources));
-          // TODO(newmuis): Check the 'error' field to see if MEDIA_ERR_DECODE
-          // is returned.  If so, we should adjust the pool size/distribution
-          // between media types.
-          this.unallocated[type].push(mediaEl);
-        }
-      });
+      // Reverse-looping is generally faster and Closure would usually make
+      // this optimization automatically. However, it skips it due to a
+      // comparison with the itervar below, so we have to roll it by hand.
+      for (let i = count; i > 0; i--) {
+        const mediaEl = /** @type {!HTMLMediaElement} */
+            // Use seed element at end of set to prevent wasting it.
+            (i == 1 ? mediaElSeed : mediaElSeed.cloneNode(/* deep */ true));
+        const sources = this.getDefaultSource_(type);
+        mediaEl.setAttribute('pool-element', elId++);
+        this.enqueueMediaElementTask_(mediaEl,
+            new UpdateSourcesTask(sources));
+        // TODO(newmuis): Check the 'error' field to see if MEDIA_ERR_DECODE
+        // is returned.  If so, we should adjust the pool size/distribution
+        // between media types.
+        this.unallocated[type].push(mediaEl);
+      }
     });
   }
 


### PR DESCRIPTION
A race condition in the way the `media-pool` is instantiated was leading to videos not playing in the first page of a story.

The `media-pool` creates `HTMLMediaElements` to replace the `amp-video` and `amp-audio`.
Because of that race condition, we were trying to play the video before the `HTMLMediaElement`s are created. So the `media-pool` had no element to allocate, and wasn't performing the replace/preload/play operations.

This PR ensures the `media-pool` is instantiated synchronously, so there are always elements to allocate when we try to register/preload/play media elements.
The `mutateElement` statement was not needed since the operations performed don't write in the DOM.

For some reason, videos used to play if you had an `amp-img` in the very first page. I imagine something in the runtime was leading the `mutateElement` to be called sooner when another AMP element had to be built.

Fixes #17277