### PR TITLE
🐛Use bytes in CRC32

### DIFF
--- a/extensions/amp-analytics/0.1/crc32.js
+++ b/extensions/amp-analytics/0.1/crc32.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {utf8Encode} from '../../../src/utils/bytes';
 
 /**
  * Standard key for CRC32
@@ -34,10 +35,13 @@ export function crc32(str) {
   if (!crcTable) {
     crcTable = makeCrcTable();
   }
+
+  const bytes = utf8Encode(str);
+
   // Shrink to 32 bits.
   let crc = -1 >>> 0;
-  for (let i = 0; i < str.length; i++) {
-    const lookupIndex = (crc ^ str.charCodeAt(i)) & 0xFF;
+  for (let i = 0; i < bytes.length; i++) {
+    const lookupIndex = (crc ^ bytes[i]) & 0xFF;
     crc = (crc >>> 8) ^ crcTable[lookupIndex];
   }
   return (crc ^ (-1)) >>> 0;

--- a/extensions/amp-analytics/0.1/test/test-crc32.js
+++ b/extensions/amp-analytics/0.1/test/test-crc32.js
@@ -47,7 +47,7 @@ const testVectors = [
   },
   {
     input: '漢字',
-    output: 325357704,
+    output: 2573319087,
   },
   {
     input: '    spaces',


### PR DESCRIPTION
This handles unicode characters to match implementations such as http://oss.sheetjs.com/js-crc32/