### PR TITLE
Don't send progress events to the progress bar for ad pages.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -603,6 +603,11 @@ export class AmpStoryPage extends AMP.BaseElement {
    * @param {number} progress The progress from 0.0 to 1.0.
    */
   emitProgress_(progress) {
+    // Don't emit progress for ads, since the progress bar is hidden.
+    if (this.isAd()) {
+      return;
+    }
+
     const payload = dict({
       'pageId': this.element.id,
       'progress': progress,


### PR DESCRIPTION
Don't send progress events to the progress bar for ad pages since the progress bar is hidden.