### PR TITLE
Do not duplicate the listeners when using media based advancement start/stop methods.

### DIFF
--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -971,6 +971,11 @@ export class AmpStory extends AMP.BaseElement {
     const targetPage = this.getPageById(targetPageId);
     const pageIndex = this.getPageIndex(targetPage);
 
+    // Step out if trying to navigate to the currently active page.
+    if (this.activePage_ && (this.activePage_.element.id === targetPageId)) {
+      return Promise.resolve();
+    }
+
     const oldPage = this.activePage_;
     this.activePage_ = targetPage;
 


### PR DESCRIPTION
Do not duplicate the listeners when using media based advancement start/stop methods.

Because the `PAUSED_STATE` calls the `MediaBasedAdvancement.start` and `MediaBasedAdvancement.stop` methods, it can happen that we duplicate the media advancement listeners (timeupdate and ended).
That's bad for performance, but led to a bug where it'd call the `switchTo` method multiple times when the video ends, breaking the story navigation.

- Ensure we don't duplicate the media based advancement event listeners
- Ensure navigation doesn't break if we try to navigate to the already active page