### PR TITLE
Build all ad extensions with amp-ad

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -143,7 +143,8 @@ function declareExtension(name, version, options) {
         Object.assign({name, version: v}, defaultOptions, options);
   });
   if (name.startsWith('amp-ad-network-')) {
-    // Get the ad network name
+    // Get the ad network name. All ad network extensions are named
+    // in the format `amp-ad-network-${name}-impl`
     name = name.slice(15, -5);
     adVendors.push(name);
   }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -57,6 +57,9 @@ const hostname3p = argv.hostname3p || '3p.ampproject.net';
 const extensions = {};
 const extensionAliasFilePath = {};
 
+// All a4a extensions.
+const adExtensions = ['amp-a4a'];
+
 const {green, red, cyan} = colors;
 
 const minifiedRuntimeTarget = 'dist/v0.js';
@@ -139,6 +142,9 @@ function declareExtension(name, version, options) {
     extensions[`${name}-${v}`] =
         Object.assign({name, version: v}, defaultOptions, options);
   });
+  if (name.startsWith('amp-ad-network-')) {
+    adExtensions.push(name);
+  }
 }
 
 /**
@@ -238,6 +244,12 @@ function getExtensionsToBuild() {
   if (!!argv.extensions_from) {
     const extensionsFrom = getExtensionsFromArg(argv.extensions_from);
     extensionsToBuild = dedupe(extensionsToBuild.concat(extensionsFrom));
+  }
+
+  if (extensionsToBuild.indexOf('amp-ad') > -1) {
+    // Build every amp a4a extension now. Need to expand feature once vendor
+    // number exceeds 10.
+    extensionsToBuild = dedupe(extensionsToBuild.concat(adExtensions));
   }
 
   return extensionsToBuild;


### PR DESCRIPTION
It's difficult to remember all ad extensions. 
I tried to add the feature to `--extensions_from` but regex to check for the correct ad type seems to be expensive.

As @lannka and I agreed we can simply build all ad extensions along with amp-ad currently. 