### PR TITLE
🐛  amp-3d-gltf: Correct colorspace for glTF rendering

### DIFF
--- a/3p/3d-gltf/viewer.js
+++ b/3p/3d-gltf/viewer.js
@@ -145,6 +145,8 @@ export default class GltfViewer {
     setStyle(el, 'left', 0);
     document.body.appendChild(this.renderer_.domElement);
 
+    this.renderer_.gammaOutput = true;
+    this.renderer_.gammaFactor = 2.2;
     this.renderer_.setPixelRatio(
         Math.min(
             this.options_['rendererSettings']['maxPixelRatio'],

--- a/3p/3d-gltf/viewer.js
+++ b/3p/3d-gltf/viewer.js
@@ -121,13 +121,13 @@ export default class GltfViewer {
    *
    * @private */
   setupLight_() {
-    const amb = new THREE.AmbientLight();
+    const amb = new THREE.AmbientLight(0xEDECD5, .5);
 
-    const dir1 = new THREE.DirectionalLight();
-    dir1.position.set(1, 2, 3);
+    const dir1 = new THREE.DirectionalLight(0xFFFFFF, .5);
+    dir1.position.set(0, 5, 3);
 
-    const dir2 = new THREE.DirectionalLight();
-    dir2.position.set(1, -2, -2);
+    const dir2 = new THREE.DirectionalLight(0xAECDD6, .4);
+    dir2.position.set(-1, -2, 4);
 
     const light = new THREE.Group();
     light.add(amb, dir1, dir2);

--- a/ads/ads.extern.js
+++ b/ads/ads.extern.js
@@ -77,6 +77,10 @@ THREE.WebGLRenderer.prototype.setSize
 THREE.WebGLRenderer.prototype.setPixelRatio
 THREE.WebGLRenderer.prototype.setClearColor
 THREE.WebGLRenderer.prototype.render
+/** @type {boolean} */
+THREE.WebGLRenderer.prototype.gammaOutput
+/** @type {number} */
+THREE.WebGLRenderer.prototype.gammaFactor
 
 THREE.Light = class extends THREE.Object3D {};
 THREE.DirectionalLight = class extends THREE.Light {};


### PR DESCRIPTION
The three.js renderer calculations use linear colorspace, and so recent versions of GLTFLoader (r88+, including r91 used here) convert all textures from sRGB to linear according to the glTF specification. In order to have correct output, colors must be converted _back_ to sRGB in output to screen. Without this, textures will appear too dark.

This change will affect any existing use of `amp-3d-gltf`, and in particular models that do not use textures may be noticeably lighter. It is, however, correct and consistent with other glTF renderers. For a before/after preview, drag any glTF model into https://gltf-viewer.donmccurdy.com/ and toggle the `gammaOutput` setting under the *Lighting* panel.

| before | after | [original](https://sketchfab.com/models/b81008d513954189a063ff901f7abfe4)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; |
|---|---|---|
| ![before](https://user-images.githubusercontent.com/1848368/43666343-534534b6-9728-11e8-88cc-2550c6abefb2.png) |  ![after](https://user-images.githubusercontent.com/1848368/43666347-5a24290e-9728-11e8-8179-75b86e470b15.png) | ![original](https://user-images.githubusercontent.com/1848368/43666352-624fd51a-9728-11e8-945f-e076f18b48be.png) |

/cc @mixtur 

