### PR TITLE
🐛✨amp-image-slider UX updates [compressed and corrected]

### DIFF
--- a/examples/image-slider.amp.html
+++ b/examples/image-slider.amp.html
@@ -116,20 +116,20 @@
       <amp-img src="https://unsplash.it/1080/720?image=1038" layout="fill"></amp-img>
     </amp-image-slider>
 
-    <p>Labels with NO positioning rules specified (default to both top, left label to left, right label to right)</p>
+    <p>Labels with NO positioning rules specified (default to both top left)</p>
     <amp-image-slider tabindex="0" layout="responsive" width="1024" height="600">
       <amp-img src="https://unsplash.it/1080/720?image=1037" layout="fill"></amp-img>
       <amp-img src="https://unsplash.it/1080/720?image=1038" layout="fill"></amp-img>
-      <div before class="label">BEFORE</div>
-      <div after class="label">AFTER</div>
+      <div first class="label">BEFORE</div>
+      <div second class="label">AFTER</div>
     </amp-image-slider>
 
     <p>Labels with positioning rules specified</p>
     <amp-image-slider tabindex="0" layout="responsive" width="1024" height="600">
       <amp-img src="https://unsplash.it/1080/720?image=1037" layout="fill"></amp-img>
       <amp-img src="https://unsplash.it/1080/720?image=1038" layout="fill"></amp-img>
-      <div before class="label left-label-center-xy">BEFORE</div>
-      <div after class="label right-label-center-xy">AFTER</div>
+      <div first class="label left-label-center-xy">BEFORE</div>
+      <div second class="label right-label-center-xy">AFTER</div>
     </amp-image-slider>
 
     <h1>Customizable Hints</h1>
@@ -138,8 +138,8 @@
     <amp-image-slider tabindex="0" layout="responsive" width="1024" height="600" disable-hint>
       <amp-img src="https://unsplash.it/1080/720?image=1037" layout="fill"></amp-img>
       <amp-img src="https://unsplash.it/1080/720?image=1038" layout="fill"></amp-img>
-      <div before class="label">BEFORE</div>
-      <div after class="label">AFTER</div>
+      <div first class="label">BEFORE</div>
+      <div second class="label">AFTER</div>
     </amp-image-slider>
 
     <p>Reemerging hint (default to no interaction for 10s)</p>
@@ -147,8 +147,8 @@
         hint-reappear>
       <amp-img src="https://unsplash.it/1080/720?image=1037" layout="fill"></amp-img>
       <amp-img src="https://unsplash.it/1080/720?image=1038" layout="fill"></amp-img>
-      <div before class="label">BEFORE</div>
-      <div after class="label">AFTER</div>
+      <div first class="label">BEFORE</div>
+      <div second class="label">AFTER</div>
     </amp-image-slider>
 
     <p>Reemerging hint (customized to no interaction for 2s)</p>
@@ -156,8 +156,8 @@
         hint-reappear hint-reappear-interval="2000">
       <amp-img src="https://unsplash.it/1080/720?image=1037" layout="fill"></amp-img>
       <amp-img src="https://unsplash.it/1080/720?image=1038" layout="fill"></amp-img>
-      <div before class="label">BEFORE</div>
-      <div after class="label">AFTER</div>
+      <div first class="label">BEFORE</div>
+      <div second class="label">AFTER</div>
     </amp-image-slider>
 
     <p>Instantly reemerging hint (customized to no interaction for 0.001s)</p>
@@ -165,8 +165,8 @@
         hint-reappear hint-reappear-interval="1">
       <amp-img src="https://unsplash.it/1080/720?image=1037" layout="fill"></amp-img>
       <amp-img src="https://unsplash.it/1080/720?image=1038" layout="fill"></amp-img>
-      <div before class="label">BEFORE</div>
-      <div after class="label">AFTER</div>
+      <div first class="label">BEFORE</div>
+      <div second class="label">AFTER</div>
     </amp-image-slider>
 
     <h1>Initial Percent</h1>
@@ -188,8 +188,8 @@
       <amp-image-slider id="observed" tabindex="0" layout="responsive" width="1024" height="600" disable-gesture>
         <amp-img src="https://unsplash.it/1080/720?image=1037" layout="fill"></amp-img>
         <amp-img src="https://unsplash.it/1080/720?image=1038" layout="fill"></amp-img>
-        <div before class="label">BEFORE</div>
-        <div after class="label">AFTER</div>
+        <div first class="label">BEFORE</div>
+        <div second class="label">AFTER</div>
       </amp-image-slider>
     </div>
 
@@ -197,8 +197,8 @@
     <amp-image-slider id="seekable" tabindex="0" layout="responsive" width="1024" height="600">
       <amp-img src="https://unsplash.it/1080/720?image=1037" layout="fill"></amp-img>
       <amp-img src="https://unsplash.it/1080/720?image=1038" layout="fill"></amp-img>
-      <div before class="label">BEFORE</div>
-      <div after class="label">AFTER</div>
+      <div first class="label">BEFORE</div>
+      <div second class="label">AFTER</div>
     </amp-image-slider>
     <div class="flex">
       <button on="tap:seekable.seekTo(percent=0)">Click me to Seek to Left</button>
@@ -211,8 +211,8 @@
     <amp-image-slider tabindex="0" step-size="0.2" layout="responsive" width="1024" height="600">
       <amp-img src="https://unsplash.it/1080/720?image=1037" layout="fill"></amp-img>
       <amp-img src="https://unsplash.it/1080/720?image=1038" layout="fill"></amp-img>
-      <div before class="label">BEFORE</div>
-      <div after class="label">AFTER</div>
+      <div first class="label">BEFORE</div>
+      <div second class="label">AFTER</div>
     </amp-image-slider>
 
     <!--
@@ -221,8 +221,8 @@
     <amp-image-slider id="disableDemo" tabindex="11" layout="responsive" width="1024" height="600" [disable-gesture]="disableDemo.disabled">
       <amp-img src="https://unsplash.it/1080/720?image=1037" layout="fill"></amp-img>
       <amp-img src="https://unsplash.it/1080/720?image=1038" layout="fill"></amp-img>
-      <div before class="label">BEFORE</div>
-      <div after class="label">AFTER</div>
+      <div first class="label">BEFORE</div>
+      <div second class="label">AFTER</div>
     </amp-image-slider>
     <div class="flex">
       <button on="tap:AMP.setState({disableDemo: {disabled: false}})">Enable</button>
@@ -231,12 +231,12 @@
     </div>
 
     <p>Toggling disable-gesture with Hint Reappearing</p>
-    <amp-image-slider id="disableDemo1" tabindex="12" layout="responsive" width="1024" height="600" [disable-gesture]="disableDemo1.disabled">
+    <amp-image-slider id="disableDemo1" tabindex="12" layout="responsive" width="1024" height="600" [disable-gesture]="disableDemo1.disabled"
+        hint-reappear hint-reappear-interval="1000">
       <amp-img src="https://unsplash.it/1080/720?image=1037" layout="fill"></amp-img>
       <amp-img src="https://unsplash.it/1080/720?image=1038" layout="fill"></amp-img>
-      <div before class="label">BEFORE</div>
-      <div after class="label">AFTER</div>
-      <div hint hint-reappear hint-reappear-interval="1000"></div>
+      <div first class="label">BEFORE</div>
+      <div second class="label">AFTER</div>
     </amp-image-slider>
     <div class="flex">
       <button on="tap:AMP.setState({disableDemo1: {disabled: false}})">Enable</button>
@@ -248,8 +248,8 @@
     <amp-image-slider id="disableDemo2" tabindex="13" layout="responsive" width="1024" height="600" disable-hint [disable-gesture]="disableDemo2.disabled">
       <amp-img src="https://unsplash.it/1080/720?image=1037" layout="fill"></amp-img>
       <amp-img src="https://unsplash.it/1080/720?image=1038" layout="fill"></amp-img>
-      <div before class="label">BEFORE</div>
-      <div after class="label">AFTER</div>
+      <div first class="label">BEFORE</div>
+      <div second class="label">AFTER</div>
     </amp-image-slider>
     <div class="flex">
       <button on="tap:AMP.setState({disableDemo2: {disabled: false}})">Enable</button>
@@ -294,28 +294,28 @@
       <amp-img src="https://unsplash.it/1080/720?image=1038" layout="fill"></amp-img>
     </amp-image-slider>
 
-    <p>Labels with NO positioning rules specified (default to both top, left label to left, right label to right)</p>
+    <p>Labels with NO positioning rules specified (default to both top left)</p>
     <amp-image-slider tabindex="0" layout="responsive" width="1024" height="600">
       <amp-img src="https://unsplash.it/1080/720?image=1037" layout="fill"></amp-img>
       <amp-img src="https://unsplash.it/1080/720?image=1038" layout="fill"></amp-img>
-      <div before class="label">BEFORE</div>
-      <div after class="label">AFTER</div>
+      <div first class="label">BEFORE</div>
+      <div second class="label">AFTER</div>
     </amp-image-slider>
 
     <p>Labels with positioning rules specified</p>
     <amp-image-slider tabindex="0" layout="responsive" width="1024" height="600">
       <amp-img src="https://unsplash.it/1080/720?image=1037" layout="fill"></amp-img>
       <amp-img src="https://unsplash.it/1080/720?image=1038" layout="fill"></amp-img>
-      <div before class="label left-label-center-xy">BEFORE</div>
-      <div after class="label right-label-center-xy">AFTER</div>
+      <div first class="label left-label-center-xy">BEFORE</div>
+      <div second class="label right-label-center-xy">AFTER</div>
     </amp-image-slider>
 
     <p>Has ARIA labels</p>
     <amp-image-slider tabindex="0" layout="responsive" width="1024" height="600" aria-label="check out the following images">
       <amp-img src="https://unsplash.it/1080/720?image=1037" layout="fill" alt="Mountain"></amp-img>
       <amp-img src="https://unsplash.it/1080/720?image=1038" layout="fill" alt="Ocean"></amp-img>
-      <div before class="label">BEFORE</div>
-      <div after class="label">AFTER</div>
+      <div first class="label">BEFORE</div>
+      <div second class="label">AFTER</div>
     </amp-image-slider>
 
     <h1>Test lightbox overlay</h1>

--- a/extensions/amp-image-slider/0.1/amp-image-slider.css
+++ b/extensions/amp-image-slider/0.1/amp-image-slider.css
@@ -14,33 +14,31 @@
  * limitations under the License.
  */
 
-amp-image-slider {
-}
-
-.i-amphtml-image-slider-container {
+ .i-amphtml-image-slider-container {
   position: absolute;
-  left: 0;
-  right: 0;
   top: 0;
+  right: 0;
   bottom: 0;
-  width: 100%;
-  height: 100%;
+  left: 0;
   /* Fix iOS translate + overflow: hidden bug */
   transform: translateZ(0);
 }
 
 .i-amphtml-image-slider-left-mask {
   position: absolute;
-  width: 100%;
-  height: 100%;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
   overflow: hidden;
 }
 
 .i-amphtml-image-slider-right-mask {
-  position: relative;
-  width: 100%;
-  transform: translateX(50%);
-  height: 100%;
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
   overflow: hidden;
   z-index: 1;
 }
@@ -50,96 +48,80 @@ amp-image-slider amp-img > img {
   object-fit: cover;
 }
 
-.i-amphtml-image-slider-image-on-top {
+.i-amphtml-image-slider-push-left {
   transform: translateX(-50%);
 }
 
+.i-amphtml-image-slider-push-right {
+  transform: translateX(50%);
+}
+
 .i-amphtml-image-slider-bar {
-  direction: ltr; /* fix RTL */
+  /* make sure arrow directions not change in RTL */
+  direction: ltr;
   position: absolute;
   top: 0;
+  right: 0;
   bottom: 0;
   left: 0;
-  right: 0;
-  transform: translateX(50%);
   z-index: 2;
-  width: 100%;
-  height: 100%;
 }
 
 .i-amphtml-image-slider-bar-stick {
-  float: left; /* fix RTL */
   width: 0;
   height: 100%;
   border: 0.5px solid white;
   box-sizing: border-box;
-  transform: translateX(-50%);
   opacity: 0.5;
 }
 
-.i-amphtml-image-slider-left-label-wrapper {
+.i-amphtml-image-slider-label-wrapper {
   position: absolute;
-  width: 100%;
-  height: 100%;
-  z-index: 1;
-}
-
-.i-amphtml-image-slider-left-label {
-  position: absolute;
-  left: 0;
-}
-
-.i-amphtml-image-slider-right-label-wrapper {
-  position: absolute;
-  height: 100%;
-  width: 100%;
-  transform: translateX(-50%);
-  z-index: 1;
-}
-
-.i-amphtml-image-slider-right-label {
-  position: absolute;
+  top: 0;
   right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 1;
+}
+
+.i-amphtml-image-slider-label-wrapper > [first],
+.i-amphtml-image-slider-label-wrapper > [second] {
+  position: absolute;
 }
 
 .i-amphtml-image-slider-hint {
   position: absolute;
-  margin: auto;
-  width: 9em;
-  height: 9em;
-  border-radius: 50%;
-  color: white;
   top: 0;
   bottom: 0;
-  transform: translate(-50%);
-  z-index: 3;
+  z-index: 2;
   display: flex;
   align-items: center;
-  justify-content: center;
-  transition: all 0.3s;
+  transition: opacity 0.3s;
 }
 
-.i-amphtml-image-slider-hint.i-amphtml-image-slider-hint-hidden {
+.i-amphtml-image-slider-hint-hidden {
   opacity: 0;
-  transition: all 0.3s;
 }
 
 .amp-image-slider-hint-left-arrow {
-  display: inline-block !important;
   background-size: 32px 16px;
-  margin-right: 15px !important;
   width: 32px;
   height: 16px;
+  margin-right: 15px !important;
   background-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 8"><g data-name="Layer 2"><path d="M4 5h12V3H4V0L0 4l4 4z" fill="#fff" data-name="Layer 1"/></g></svg>');
   filter: drop-shadow(3px 3px 4px black);
 }
 
 .amp-image-slider-hint-right-arrow {
-  display: inline-block !important;
   background-size: 32px 16px;
-  margin-left: 15px !important;
   width: 32px;
   height: 16px;
+  margin-left: 15px !important;
   background-image: url('data:image/svg+xml;charset=utf-8,<svg width="32" height="16" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><defs><path id="a" d="M32.02 22H8v4h24.02v6L40 24l-7.98-8z"/></defs><g transform="translate(-8 -16)" fill="none" fill-rule="evenodd"><mask id="b" fill="#fff"><use xlink:href="#a"/></mask><g mask="url(#b)" fill="#F1F3F4"><path d="M0 0h48v48H0z"/></g></g></svg>');
   filter: drop-shadow(3px 3px 4px black);
+}
+
+.amp-image-slider-hint-arrow-background {
+  background-color: rgba(0, 0, 0, 0.4);
+  border-radius: 50%;
 }

--- a/extensions/amp-image-slider/0.1/amp-image-slider.js
+++ b/extensions/amp-image-slider/0.1/amp-image-slider.js
@@ -127,9 +127,9 @@ export class AmpImageSlider extends AMP.BaseElement {
       }
 
       if (child.tagName.toLowerCase() === 'div') {
-        if (child.hasAttribute('before')) {
+        if (child.hasAttribute('first')) {
           this.leftLabel_ = child;
-        } else if (child.hasAttribute('after')) {
+        } else if (child.hasAttribute('second')) {
           this.rightLabel_ = child;
         }
       }
@@ -241,19 +241,20 @@ export class AmpImageSlider extends AMP.BaseElement {
     if (this.leftLabel_) {
       this.leftLabelWrapper_ = this.doc_.createElement('div');
       this.leftLabelWrapper_.classList
-          .add('i-amphtml-image-slider-left-label-wrapper');
-      this.leftLabel_.classList.add('i-amphtml-image-slider-left-label');
+          .add('i-amphtml-image-slider-label-wrapper');
       this.leftLabelWrapper_.appendChild(this.leftLabel_);
       this.leftMask_.appendChild(this.leftLabelWrapper_);
     }
 
     this.rightMask_.classList.add('i-amphtml-image-slider-right-mask');
-    this.rightAmpImage_.classList.add('i-amphtml-image-slider-image-on-top');
+    this.rightMask_.classList.add('i-amphtml-image-slider-push-right');
+    this.rightAmpImage_.classList.add('i-amphtml-image-slider-push-left');
     if (this.rightLabel_) {
       this.rightLabelWrapper_ = this.doc_.createElement('div');
       this.rightLabelWrapper_.classList
-          .add('i-amphtml-image-slider-right-label-wrapper');
-      this.rightLabel_.classList.add('i-amphtml-image-slider-right-label');
+          .add('i-amphtml-image-slider-label-wrapper');
+      this.rightLabelWrapper_.classList
+          .add('i-amphtml-image-slider-push-left');
       this.rightLabelWrapper_.appendChild(this.rightLabel_);
       this.rightMask_.appendChild(this.rightLabelWrapper_);
     }
@@ -269,7 +270,9 @@ export class AmpImageSlider extends AMP.BaseElement {
     this.bar_.appendChild(this.barStick_);
 
     this.bar_.classList.add('i-amphtml-image-slider-bar');
+    this.bar_.classList.add('i-amphtml-image-slider-push-right');
     this.barStick_.classList.add('i-amphtml-image-slider-bar-stick');
+    this.barStick_.classList.add('i-amphtml-image-slider-push-left');
 
     this.container_.appendChild(this.bar_);
   }
@@ -303,6 +306,7 @@ export class AmpImageSlider extends AMP.BaseElement {
     this.hint_.appendChild(leftHintIcon);
     this.hint_.appendChild(rightHintIcon);
     this.hint_.classList.add('i-amphtml-image-slider-hint');
+    this.hint_.classList.add('i-amphtml-image-slider-push-left');
     this.bar_.appendChild(this.hint_);
   }
 

--- a/extensions/amp-image-slider/0.1/test/integration/test-amp-image-slider.js
+++ b/extensions/amp-image-slider/0.1/test/integration/test-amp-image-slider.js
@@ -21,11 +21,12 @@ config.run('amp-image-slider', function() {
   this.timeout(20000);
 
   const sliderBody = `
-    <amp-image-slider id="slider" layout="responsive" width="1000" height="500">
+    <amp-image-slider tabindex="0" id="slider"
+        layout="responsive" width="1000" height="500">
       <amp-img src="https://unsplash.it/1080/720?image=1037" layout="fill"></amp-img>
       <amp-img src="https://unsplash.it/1080/720?image=1038" layout="fill"></amp-img>
-      <div before class="label">BEFORE</div>
-      <div after class="label">AFTER</div>
+      <div first class="label">BEFORE</div>
+      <div second class="label">AFTER</div>
     </amp-image-slider>
   `;
 
@@ -54,6 +55,7 @@ config.run('amp-image-slider', function() {
     let sliderImpl;
     let rect;
     let bar_, container_, rightMask_, leftAmpImage_, rightAmpImage_;
+    let leftLabel_, rightLabel_;
 
     beforeEach(() => {
       win = env.win;
@@ -94,6 +96,12 @@ config.run('amp-image-slider', function() {
       return event;
     }
 
+    function createKeyDownEvent(key) {
+      return new KeyboardEvent('keydown', {
+        key,
+      });
+    }
+
     function prepareSlider() {
       sliderImpl = slider.implementation_;
       rect = slider.getBoundingClientRect();
@@ -117,6 +125,8 @@ config.run('amp-image-slider', function() {
       const ampImgs = slider.getElementsByTagName('amp-img');
       leftAmpImage_ = ampImgs[0];
       rightAmpImage_ = ampImgs[1];
+      leftLabel_ = slider.querySelector('.i-amphtml-image-slider-left-label');
+      rightLabel_ = slider.querySelector('.i-amphtml-image-slider-right-label');
 
       expect(bar_.getBoundingClientRect().left)
           .to.equal(leftPos);
@@ -126,6 +136,10 @@ config.run('amp-image-slider', function() {
       expect(leftAmpImage_.getBoundingClientRect().left)
           .to.equal(rect.left);
       expect(rightAmpImage_.getBoundingClientRect().left)
+          .to.equal(rect.left);
+      expect(leftLabel_.getBoundingClientRect().left)
+          .to.equal(rect.left);
+      expect(rightLabel_.getBoundingClientRect().left)
           .to.equal(rect.left);
     }
 
@@ -408,6 +422,54 @@ config.run('amp-image-slider', function() {
           })
           .then(() => {
             expectByBarLeftPos(rightQuarterPos);
+          });
+    });
+
+    it('should follow keyboard buttons', () => {
+      let slider;
+      let keyDownEvent;
+      let centerPos, Pos40Percent;
+      return prep()
+          .then(() => {
+            slider = doc.querySelector('amp-image-slider');
+            slider.focus();
+            centerPos = rect.left + 0.5 * rect.width;
+            Pos40Percent = rect.left + 0.4 * rect.width;
+
+            keyDownEvent = createKeyDownEvent('ArrowLeft');
+            slider.dispatchEvent(keyDownEvent);
+            return timeout(env.win, 500);
+          })
+          .then(() => {
+            expectByBarLeftPos(Pos40Percent);
+
+            keyDownEvent = createKeyDownEvent('ArrowRight');
+            slider.dispatchEvent(keyDownEvent);
+            return timeout(env.win, 500);
+          })
+          .then(() => {
+            expectByBarLeftPos(centerPos);
+
+            keyDownEvent = createKeyDownEvent('PageUp');
+            slider.dispatchEvent(keyDownEvent);
+            return timeout(env.win, 500);
+          })
+          .then(() => {
+            expectByBarLeftPos(rect.left);
+
+            keyDownEvent = createKeyDownEvent('Home');
+            slider.dispatchEvent(keyDownEvent);
+            return timeout(env.win, 500);
+          })
+          .then(() => {
+            expectByBarLeftPos(centerPos);
+
+            keyDownEvent = createKeyDownEvent('PageDown');
+            slider.dispatchEvent(keyDownEvent);
+            return timeout(env.win, 500);
+          })
+          .then(() => {
+            expectByBarLeftPos(rect.right);
           });
     });
   });

--- a/extensions/amp-image-slider/0.1/test/integration/test-amp-image-slider.js
+++ b/extensions/amp-image-slider/0.1/test/integration/test-amp-image-slider.js
@@ -125,8 +125,10 @@ config.run('amp-image-slider', function() {
       const ampImgs = slider.getElementsByTagName('amp-img');
       leftAmpImage_ = ampImgs[0];
       rightAmpImage_ = ampImgs[1];
-      leftLabel_ = slider.querySelector('.i-amphtml-image-slider-left-label');
-      rightLabel_ = slider.querySelector('.i-amphtml-image-slider-right-label');
+      leftLabel_ = slider.querySelectorAll(
+          '.i-amphtml-image-slider-label-wrapper')[0];
+      rightLabel_ = slider.querySelectorAll(
+          '.i-amphtml-image-slider-label-wrapper')[1];
 
       expect(bar_.getBoundingClientRect().left)
           .to.equal(leftPos);

--- a/extensions/amp-image-slider/amp-image-slider.md
+++ b/extensions/amp-image-slider/amp-image-slider.md
@@ -45,14 +45,14 @@ This is an __EXPERIMENTAL__ component.
 
 `amp-image-slider` is required to have exactly 2 `amp-img`s as its children, with the first one becoming the image displaying on the left, and the second on the right.
 
-The slider could also take 2 optional `div`s for labels, which are used to add extra information that overlay on top of the images. The label on the left image requires the `before` attribute to be present, while the right labels requires the `after` attribute.
+The slider could also take 2 optional `div`s for labels, which are used to add extra information that overlay on top of the images. The label on the left image requires the `first` attribute to be present, while the right labels requires the `second` attribute. Custom classes could be added to adjust styling and position (using `top`, `right`, `bottom`, `left` properties). Notice that by default, both labels would show at the top left corner of images.
 
 ```html
 <amp-image-slider layout="responsive" width="100" height="200">
   <amp-img src="/green-apple.jpg" alt="A green apple"></amp-img>
   <amp-img src="/red-apple.jpg" alt="A red apple"></amp-img>
-  <div before>This apple is green</div>
-  <div after>This apple is red</div>
+  <div first>This apple is green</div>
+  <div second>This apple is red</div>
 </amp-image-slider>
 ```
 

--- a/test/manual/amp-image-slider.amp.html
+++ b/test/manual/amp-image-slider.amp.html
@@ -92,28 +92,28 @@
       <amp-img src="https://unsplash.it/1080/720?image=1038" layout="fill"></amp-img>
     </amp-image-slider>
 
-    <p>Labels with NO positioning rules specified (default to both top, left label to left, right label to right)</p>
+    <p>Labels with NO positioning rules specified (default to both top left)</p>
     <amp-image-slider tabindex="0" layout="responsive" width="1024" height="600">
       <amp-img src="https://unsplash.it/1080/720?image=1037" layout="fill"></amp-img>
       <amp-img src="https://unsplash.it/1080/720?image=1038" layout="fill"></amp-img>
-      <div before class="label">BEFORE</div>
-      <div after class="label">AFTER</div>
+      <div first class="label">BEFORE</div>
+      <div second class="label">AFTER</div>
     </amp-image-slider>
 
     <p>Labels with positioning rules specified</p>
     <amp-image-slider tabindex="0" layout="responsive" width="1024" height="600">
       <amp-img src="https://unsplash.it/1080/720?image=1037" layout="fill"></amp-img>
       <amp-img src="https://unsplash.it/1080/720?image=1038" layout="fill"></amp-img>
-      <div before class="label left-label-center-xy">BEFORE</div>
-      <div after class="label right-label-center-xy">AFTER</div>
+      <div first class="label left-label-center-xy">BEFORE</div>
+      <div second class="label right-label-center-xy">AFTER</div>
     </amp-image-slider>
 
     <p>Has Alt</p>
     <amp-image-slider tabindex="0" layout="responsive" width="1024" height="600">
       <amp-img src="https://unsplash.it/1080/720?image=1037" layout="fill" alt="Mountain"></amp-img>
       <amp-img src="https://unsplash.it/1080/720?image=1038" layout="fill" alt="Ocean"></amp-img>
-      <div before class="label">BEFORE</div>
-      <div after class="label">AFTER</div>
+      <div first class="label">BEFORE</div>
+      <div second class="label">AFTER</div>
     </amp-image-slider>
   </main>
 </body>


### PR DESCRIPTION
- [x] Rename `before/after` to `first/second`
- [x] Spill hint settings to slider body and remove hint div
- [x] Simplify CSS
- [x] Change default CSS for both labels to top left (less CSS assumptions)
- [x] Add tests with keyboard movements
