### PR TITLE
Validator Rollup

### DIFF
--- a/extensions/amp-access-laterpay/0.1/test/validator-amp-access-laterpay.html
+++ b/extensions/amp-access-laterpay/0.1/test/validator-amp-access-laterpay.html
@@ -32,7 +32,7 @@
   <script id="amp-access" type="application/json">
     {
       "contents": "currently untested",
-      "laterpay": {},
+      "laterpay": {}
     }
   </script>
 </head>

--- a/extensions/amp-access-laterpay/0.1/test/validator-amp-access-laterpay.out
+++ b/extensions/amp-access-laterpay/0.1/test/validator-amp-access-laterpay.out
@@ -33,7 +33,7 @@ PASS
 |    <script id="amp-access" type="application/json">
 |      {
 |        "contents": "currently untested",
-|        "laterpay": {},
+|        "laterpay": {}
 |      }
 |    </script>
 |  </head>

--- a/extensions/amp-access-laterpay/0.2/test/validator-amp-access-laterpay.html
+++ b/extensions/amp-access-laterpay/0.2/test/validator-amp-access-laterpay.html
@@ -32,7 +32,7 @@
   <script id="amp-access" type="application/json">
     {
       "contents": "currently untested",
-      "laterpay": {},
+      "laterpay": {}
     }
   </script>
 </head>

--- a/extensions/amp-access-laterpay/0.2/test/validator-amp-access-laterpay.out
+++ b/extensions/amp-access-laterpay/0.2/test/validator-amp-access-laterpay.out
@@ -33,7 +33,7 @@ PASS
 |    <script id="amp-access" type="application/json">
 |      {
 |        "contents": "currently untested",
-|        "laterpay": {},
+|        "laterpay": {}
 |      }
 |    </script>
 |  </head>

--- a/extensions/amp-geo/0.1/test/validator-amp-geo.html
+++ b/extensions/amp-geo/0.1/test/validator-amp-geo.html
@@ -39,6 +39,12 @@
       }
     }
     </script>
+    <!-- Invalid: AMP Runtime can't parse json with comments. -->
+    <script type="application/json">
+    {
+      // Comment, should break parsing and result in a warning.
+    }
+    </script>
   </amp-geo>
 </body>
 </html>

--- a/extensions/amp-geo/0.1/test/validator-amp-geo.out
+++ b/extensions/amp-geo/0.1/test/validator-amp-geo.out
@@ -40,6 +40,14 @@ PASS
 |        }
 |      }
 |      </script>
+|      <!-- Invalid: AMP Runtime can't parse json with comments. -->
+|      <script type="application/json">
+>>     ^~~~~~~~~
+amp-geo/0.1/test/validator-amp-geo.html:43:4 JSON contents are invalid data that can not be parsed. [DISALLOWED_HTML]
+|      {
+|        // Comment, should break parsing and result in a warning.
+|      }
+|      </script>
 |    </amp-geo>
 |  </body>
 |  </html>

--- a/extensions/amp-list/0.1/test/validator-amp-list.out
+++ b/extensions/amp-list/0.1/test/validator-amp-list.out
@@ -66,18 +66,6 @@ amp-list/0.1/test/validator-amp-list.html:43:2 The attribute '[state]' in tag 'a
 |              reset-on-refresh="always">
 |      <div></div>
 |    </amp-list>
-|    <!-- Valid: amp-list with src and reset-on-refresh="fetch" attributes -->
-|    <amp-list width=10 height=10
-|              src="https://data.com/articles.json?ref=CANONICAL_URL"
-|              reset-on-refresh="fetch">
-|      <div></div>
-|    </amp-list>
-|    <!-- Valid: amp-list with src and reset-on-refresh="always" attributes -->
-|    <amp-list width=10 height=10
-|              src="https://data.com/articles.json?ref=CANONICAL_URL"
-|              reset-on-refresh="always">
-|      <div></div>
-|    </amp-list>
 |    <!-- Valid: amp-list with [src] and reset-on-refresh attributes -->
 |    <amp-list width=10 height=10
 |              [src]="foo.bar"

--- a/extensions/amp-list/0.1/test/validator-amp-list.out
+++ b/extensions/amp-list/0.1/test/validator-amp-list.out
@@ -66,6 +66,18 @@ amp-list/0.1/test/validator-amp-list.html:43:2 The attribute '[state]' in tag 'a
 |              reset-on-refresh="always">
 |      <div></div>
 |    </amp-list>
+|    <!-- Valid: amp-list with src and reset-on-refresh="fetch" attributes -->
+|    <amp-list width=10 height=10
+|              src="https://data.com/articles.json?ref=CANONICAL_URL"
+|              reset-on-refresh="fetch">
+|      <div></div>
+|    </amp-list>
+|    <!-- Valid: amp-list with src and reset-on-refresh="always" attributes -->
+|    <amp-list width=10 height=10
+|              src="https://data.com/articles.json?ref=CANONICAL_URL"
+|              reset-on-refresh="always">
+|      <div></div>
+|    </amp-list>
 |    <!-- Valid: amp-list with [src] and reset-on-refresh attributes -->
 |    <amp-list width=10 height=10
 |              [src]="foo.bar"

--- a/extensions/amp-story-auto-ads/0.1/test/validator-amp-story-auto-ads.html
+++ b/extensions/amp-story-auto-ads/0.1/test/validator-amp-story-auto-ads.html
@@ -39,10 +39,10 @@
     <amp-story-auto-ads>
       <script type="application/json">
       {
-         "ad-attributes": {
-           type: "custom"
-           data-src: "https://adserver.com/getad?slot=abcd1234"
-         }
+        "ad-attributes": {
+          "type": "custom",
+          "data-src": "https://adserver.com/getad?slot=abcd1234"
+        }
       }
       </script>
 

--- a/extensions/amp-story-auto-ads/0.1/test/validator-amp-story-auto-ads.out
+++ b/extensions/amp-story-auto-ads/0.1/test/validator-amp-story-auto-ads.out
@@ -42,10 +42,10 @@ amp-story-auto-ads/0.1/test/validator-amp-story-auto-ads.html:34:2 The tag 'AMP-
 |      <amp-story-auto-ads>
 |        <script type="application/json">
 |        {
-|           "ad-attributes": {
-|             type: "custom"
-|             data-src: "https://adserver.com/getad?slot=abcd1234"
-|           }
+|          "ad-attributes": {
+|            "type": "custom",
+|            "data-src": "https://adserver.com/getad?slot=abcd1234"
+|          }
 |        }
 |        </script>
 |

--- a/extensions/amp-subscriptions/0.1/test/validator-amp-subscriptions-errors.html
+++ b/extensions/amp-subscriptions/0.1/test/validator-amp-subscriptions-errors.html
@@ -30,7 +30,7 @@
   <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.2.js"></script>
   <script async custom-element="amp-access" src="https://cdn.ampproject.org/v0/amp-access-0.1.js"></script>
   <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
-  <script type="application/json" id="amp-access">{"property": value}</script>
+  <script type="application/json" id="amp-access">{"property": "value"}</script>
   <script type="application/json" id="amp-subscriptions">
     {
       "services": [

--- a/extensions/amp-subscriptions/0.1/test/validator-amp-subscriptions-errors.out
+++ b/extensions/amp-subscriptions/0.1/test/validator-amp-subscriptions-errors.out
@@ -31,7 +31,7 @@ FAIL
 |    <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.2.js"></script>
 |    <script async custom-element="amp-access" src="https://cdn.ampproject.org/v0/amp-access-0.1.js"></script>
 |    <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
-|    <script type="application/json" id="amp-access">{"property": value}</script>
+|    <script type="application/json" id="amp-access">{"property": "value"}</script>
 |    <script type="application/json" id="amp-subscriptions">
 |      {
 |        "services": [

--- a/validator/engine/parse-srcset.js
+++ b/validator/engine/parse-srcset.js
@@ -95,7 +95,6 @@ parse_srcset.parseSrcset = function(srcset) {
   const seenWidthOrPixelDensity = new goog.structs.Set();
   /** @type {!parse_srcset.SrcsetParsingResult} */
   const result = new parse_srcset.SrcsetParsingResult();
-  /** @type {!Array<parse_srcset.SrcsetSourceDef>} */
   const {srcsetImages} = result;
   let source;
   while (source = imageCandidateRegex.exec(srcset)) {

--- a/validator/testdata/feature_tests/extensions.html
+++ b/validator/testdata/feature_tests/extensions.html
@@ -40,7 +40,7 @@
 
   <!-- Extension missing. Produces error. -->
   <amp-analytics type="googleanalytics">
-    <script type="application/json"></script>
+    <script type="application/json">{}</script>
   </amp-analytics>
 
 Hello, world.

--- a/validator/testdata/feature_tests/extensions.out
+++ b/validator/testdata/feature_tests/extensions.out
@@ -43,7 +43,7 @@ FAIL
 |    <amp-analytics type="googleanalytics">
 >>   ^~~~~~~~~
 feature_tests/extensions.html:42:2 The tag 'amp-analytics' requires including the 'amp-analytics' extension JavaScript. (see https://www.ampproject.org/docs/reference/components/amp-analytics) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
-|      <script type="application/json"></script>
+|      <script type="application/json">{}</script>
 >>     ^~~~~~~~~
 feature_tests/extensions.html:43:4 The tag 'amp-analytics extension .json script' requires including the 'amp-analytics' extension JavaScript. (see https://www.ampproject.org/docs/reference/components/amp-analytics) [MANDATORY_AMP_TAG_MISSING_OR_INCORRECT]
 |    </amp-analytics>

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -26,7 +26,7 @@ min_validator_revision_required: 348
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 711
+spec_file_revision: 712
 
 styles_spec_url: "https://www.ampproject.org/docs/guides/author-develop/responsive/style_pages"
 script_spec_url: "https://www.ampproject.org/docs/reference/spec#html-tags"

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -26,7 +26,7 @@ min_validator_revision_required: 348
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 709
+spec_file_revision: 710
 
 styles_spec_url: "https://www.ampproject.org/docs/guides/author-develop/responsive/style_pages"
 script_spec_url: "https://www.ampproject.org/docs/reference/spec#html-tags"

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -20,13 +20,13 @@
 # in production from crashing. This id is not relevant to validator.js
 # because thus far, engine (validator.js) and spec file
 # (validator-main.protoascii) are always released together.
-min_validator_revision_required: 346
+min_validator_revision_required: 348
 
 # The spec file revision allows the validator engine to distinguish
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 706
+spec_file_revision: 707
 
 styles_spec_url: "https://www.ampproject.org/docs/guides/author-develop/responsive/style_pages"
 script_spec_url: "https://www.ampproject.org/docs/reference/spec#html-tags"
@@ -5493,112 +5493,113 @@ error_specificity { code: UNKNOWN_CODE specificity: 0 }
 error_specificity { code: MANDATORY_CDATA_MISSING_OR_INCORRECT specificity: 1 }
 error_specificity { code: CDATA_VIOLATES_BLACKLIST specificity: 2 }
 error_specificity { code: NON_WHITESPACE_CDATA_ENCOUNTERED specificity: 3 }
-error_specificity { code: DISALLOWED_TAG_ANCESTOR specificity: 4 }
-error_specificity { code: MANDATORY_TAG_ANCESTOR specificity: 5 }
-error_specificity { code: MANDATORY_TAG_ANCESTOR_WITH_HINT specificity: 6 }
-error_specificity { code: MANDATORY_TAG_MISSING specificity: 7 }
-error_specificity { code: WRONG_PARENT_TAG specificity: 8 }
-error_specificity { code: TAG_REQUIRED_BY_MISSING specificity: 9 }
-error_specificity { code: TAG_EXCLUDED_BY_TAG specificity: 10 }
-error_specificity { code: MISSING_REQUIRED_EXTENSION specificity: 11 }
-error_specificity { code: ATTR_MISSING_REQUIRED_EXTENSION specificity: 12 }
-error_specificity { code: WARNING_TAG_REQUIRED_BY_MISSING specificity: 13 }
-error_specificity { code: EXTENSION_UNUSED specificity: 14 }
-error_specificity { code: WARNING_EXTENSION_UNUSED specificity: 15 }
-error_specificity { code: WARNING_EXTENSION_DEPRECATED_VERSION specificity: 16 }
-error_specificity { code: DISALLOWED_TAG specificity: 17 }
-error_specificity { code: DISALLOWED_ATTR specificity: 18 }
-error_specificity { code: INVALID_ATTR_VALUE specificity: 19 }
-error_specificity { code: DUPLICATE_ATTRIBUTE specificity: 20 }
-error_specificity { code: ATTR_VALUE_REQUIRED_BY_LAYOUT specificity: 21 }
-error_specificity { code: MANDATORY_ATTR_MISSING specificity: 22 }
-error_specificity { code: MANDATORY_ONEOF_ATTR_MISSING specificity: 23 }
-error_specificity { code: MANDATORY_ANYOF_ATTR_MISSING specificity: 24 }
-error_specificity { code: ATTR_REQUIRED_BUT_MISSING specificity: 25 }
-error_specificity { code: DUPLICATE_UNIQUE_TAG specificity: 26 }
-error_specificity { code: DUPLICATE_UNIQUE_TAG_WARNING specificity: 27 }
-error_specificity { code: STYLESHEET_TOO_LONG specificity: 28 }
-error_specificity { code: STYLESHEET_AND_INLINE_STYLE_TOO_LONG specificity: 29 }
-error_specificity { code: INLINE_STYLE_TOO_LONG specificity: 30 }
-error_specificity { code: CSS_SYNTAX_INVALID_AT_RULE specificity: 31 }
+error_specificity { code: INVALID_JSON_CDATA specificity: 4 }
+error_specificity { code: DISALLOWED_TAG_ANCESTOR specificity: 5 }
+error_specificity { code: MANDATORY_TAG_ANCESTOR specificity: 6 }
+error_specificity { code: MANDATORY_TAG_ANCESTOR_WITH_HINT specificity: 7 }
+error_specificity { code: MANDATORY_TAG_MISSING specificity: 8 }
+error_specificity { code: WRONG_PARENT_TAG specificity: 9 }
+error_specificity { code: TAG_REQUIRED_BY_MISSING specificity: 10 }
+error_specificity { code: TAG_EXCLUDED_BY_TAG specificity: 11 }
+error_specificity { code: MISSING_REQUIRED_EXTENSION specificity: 12 }
+error_specificity { code: ATTR_MISSING_REQUIRED_EXTENSION specificity: 13 }
+error_specificity { code: WARNING_TAG_REQUIRED_BY_MISSING specificity: 14 }
+error_specificity { code: EXTENSION_UNUSED specificity: 15 }
+error_specificity { code: WARNING_EXTENSION_UNUSED specificity: 16 }
+error_specificity { code: WARNING_EXTENSION_DEPRECATED_VERSION specificity: 17 }
+error_specificity { code: DISALLOWED_TAG specificity: 18 }
+error_specificity { code: DISALLOWED_ATTR specificity: 19 }
+error_specificity { code: INVALID_ATTR_VALUE specificity: 20 }
+error_specificity { code: DUPLICATE_ATTRIBUTE specificity: 21 }
+error_specificity { code: ATTR_VALUE_REQUIRED_BY_LAYOUT specificity: 22 }
+error_specificity { code: MANDATORY_ATTR_MISSING specificity: 23 }
+error_specificity { code: MANDATORY_ONEOF_ATTR_MISSING specificity: 24 }
+error_specificity { code: MANDATORY_ANYOF_ATTR_MISSING specificity: 25 }
+error_specificity { code: ATTR_REQUIRED_BUT_MISSING specificity: 26 }
+error_specificity { code: DUPLICATE_UNIQUE_TAG specificity: 27 }
+error_specificity { code: DUPLICATE_UNIQUE_TAG_WARNING specificity: 28 }
+error_specificity { code: STYLESHEET_TOO_LONG specificity: 29 }
+error_specificity { code: STYLESHEET_AND_INLINE_STYLE_TOO_LONG specificity: 30 }
+error_specificity { code: INLINE_STYLE_TOO_LONG specificity: 31 }
+error_specificity { code: CSS_SYNTAX_INVALID_AT_RULE specificity: 32 }
 error_specificity {
-  code: MANDATORY_PROPERTY_MISSING_FROM_ATTR_VALUE specificity: 32
+  code: MANDATORY_PROPERTY_MISSING_FROM_ATTR_VALUE specificity: 33
 }
-error_specificity { code: INVALID_PROPERTY_VALUE_IN_ATTR_VALUE specificity: 33 }
-error_specificity { code: DISALLOWED_PROPERTY_IN_ATTR_VALUE specificity: 34 }
-error_specificity { code: MUTUALLY_EXCLUSIVE_ATTRS specificity: 35 }
-error_specificity { code: UNESCAPED_TEMPLATE_IN_ATTR_VALUE specificity: 36 }
-error_specificity { code: TEMPLATE_PARTIAL_IN_ATTR_VALUE specificity: 37 }
-error_specificity { code: TEMPLATE_IN_ATTR_NAME specificity: 38 }
+error_specificity { code: INVALID_PROPERTY_VALUE_IN_ATTR_VALUE specificity: 34 }
+error_specificity { code: DISALLOWED_PROPERTY_IN_ATTR_VALUE specificity: 35 }
+error_specificity { code: MUTUALLY_EXCLUSIVE_ATTRS specificity: 36 }
+error_specificity { code: UNESCAPED_TEMPLATE_IN_ATTR_VALUE specificity: 37 }
+error_specificity { code: TEMPLATE_PARTIAL_IN_ATTR_VALUE specificity: 38 }
+error_specificity { code: TEMPLATE_IN_ATTR_NAME specificity: 39 }
 error_specificity {
-  code: INCONSISTENT_UNITS_FOR_WIDTH_AND_HEIGHT specificity: 39
+  code: INCONSISTENT_UNITS_FOR_WIDTH_AND_HEIGHT specificity: 40
 }
-error_specificity { code: MISSING_LAYOUT_ATTRIBUTES specificity: 40 }
-error_specificity { code: IMPLIED_LAYOUT_INVALID specificity: 41 }
-error_specificity { code: SPECIFIED_LAYOUT_INVALID specificity: 42 }
-error_specificity { code: ATTR_DISALLOWED_BY_IMPLIED_LAYOUT specificity: 43 }
-error_specificity { code: ATTR_DISALLOWED_BY_SPECIFIED_LAYOUT specificity: 44 }
-error_specificity { code: DUPLICATE_DIMENSION specificity: 45 }
-error_specificity { code: DISALLOWED_RELATIVE_URL specificity: 46 }
-error_specificity { code: MISSING_URL specificity: 47 }
-error_specificity { code: DISALLOWED_DOMAIN specificity: 48 }
-error_specificity { code: INVALID_URL_PROTOCOL specificity: 49 }
-error_specificity { code: INVALID_URL specificity: 50 }
-error_specificity { code: DISALLOWED_STYLE_ATTR specificity: 51 }
-error_specificity { code: CSS_SYNTAX_STRAY_TRAILING_BACKSLASH specificity: 52 }
-error_specificity { code: CSS_SYNTAX_UNTERMINATED_COMMENT specificity: 53 }
-error_specificity { code: CSS_SYNTAX_UNTERMINATED_STRING specificity: 54 }
-error_specificity { code: CSS_SYNTAX_BAD_URL specificity: 55 }
+error_specificity { code: MISSING_LAYOUT_ATTRIBUTES specificity: 41 }
+error_specificity { code: IMPLIED_LAYOUT_INVALID specificity: 42 }
+error_specificity { code: SPECIFIED_LAYOUT_INVALID specificity: 43 }
+error_specificity { code: ATTR_DISALLOWED_BY_IMPLIED_LAYOUT specificity: 44 }
+error_specificity { code: ATTR_DISALLOWED_BY_SPECIFIED_LAYOUT specificity: 45 }
+error_specificity { code: DUPLICATE_DIMENSION specificity: 46 }
+error_specificity { code: DISALLOWED_RELATIVE_URL specificity: 47 }
+error_specificity { code: MISSING_URL specificity: 48 }
+error_specificity { code: DISALLOWED_DOMAIN specificity: 49 }
+error_specificity { code: INVALID_URL_PROTOCOL specificity: 50 }
+error_specificity { code: INVALID_URL specificity: 51 }
+error_specificity { code: DISALLOWED_STYLE_ATTR specificity: 52 }
+error_specificity { code: CSS_SYNTAX_STRAY_TRAILING_BACKSLASH specificity: 53 }
+error_specificity { code: CSS_SYNTAX_UNTERMINATED_COMMENT specificity: 54 }
+error_specificity { code: CSS_SYNTAX_UNTERMINATED_STRING specificity: 55 }
+error_specificity { code: CSS_SYNTAX_BAD_URL specificity: 56 }
 error_specificity {
-  code: CSS_SYNTAX_EOF_IN_PRELUDE_OF_QUALIFIED_RULE specificity: 56
+  code: CSS_SYNTAX_EOF_IN_PRELUDE_OF_QUALIFIED_RULE specificity: 57
 }
-error_specificity { code: CSS_SYNTAX_INVALID_DECLARATION specificity: 57 }
-error_specificity { code: CSS_SYNTAX_INCOMPLETE_DECLARATION specificity: 58 }
-error_specificity { code: CSS_SYNTAX_ERROR_IN_PSEUDO_SELECTOR specificity: 59 }
-error_specificity { code: CSS_SYNTAX_MISSING_SELECTOR specificity: 60 }
-error_specificity { code: CSS_SYNTAX_NOT_A_SELECTOR_START specificity: 61 }
+error_specificity { code: CSS_SYNTAX_INVALID_DECLARATION specificity: 58 }
+error_specificity { code: CSS_SYNTAX_INCOMPLETE_DECLARATION specificity: 59 }
+error_specificity { code: CSS_SYNTAX_ERROR_IN_PSEUDO_SELECTOR specificity: 60 }
+error_specificity { code: CSS_SYNTAX_MISSING_SELECTOR specificity: 61 }
+error_specificity { code: CSS_SYNTAX_NOT_A_SELECTOR_START specificity: 62 }
 error_specificity {
-  code: CSS_SYNTAX_UNPARSED_INPUT_REMAINS_IN_SELECTOR specificity: 62
+  code: CSS_SYNTAX_UNPARSED_INPUT_REMAINS_IN_SELECTOR specificity: 63
 }
-error_specificity { code: CSS_SYNTAX_MISSING_URL specificity: 63 }
-error_specificity { code: CSS_SYNTAX_DISALLOWED_DOMAIN specificity: 64 }
-error_specificity { code: CSS_SYNTAX_INVALID_URL specificity: 65 }
-error_specificity { code: CSS_SYNTAX_INVALID_URL_PROTOCOL specificity: 66 }
-error_specificity { code: CSS_SYNTAX_DISALLOWED_RELATIVE_URL specificity: 67 }
-error_specificity { code: INCORRECT_NUM_CHILD_TAGS specificity: 68 }
-error_specificity { code: DISALLOWED_CHILD_TAG_NAME specificity: 69 }
-error_specificity { code: DISALLOWED_FIRST_CHILD_TAG_NAME specificity: 70 }
-error_specificity { code: CSS_SYNTAX_INVALID_ATTR_SELECTOR specificity: 71 }
+error_specificity { code: CSS_SYNTAX_MISSING_URL specificity: 64 }
+error_specificity { code: CSS_SYNTAX_DISALLOWED_DOMAIN specificity: 65 }
+error_specificity { code: CSS_SYNTAX_INVALID_URL specificity: 66 }
+error_specificity { code: CSS_SYNTAX_INVALID_URL_PROTOCOL specificity: 67 }
+error_specificity { code: CSS_SYNTAX_DISALLOWED_RELATIVE_URL specificity: 68 }
+error_specificity { code: INCORRECT_NUM_CHILD_TAGS specificity: 69 }
+error_specificity { code: DISALLOWED_CHILD_TAG_NAME specificity: 70 }
+error_specificity { code: DISALLOWED_FIRST_CHILD_TAG_NAME specificity: 71 }
+error_specificity { code: CSS_SYNTAX_INVALID_ATTR_SELECTOR specificity: 72 }
 error_specificity {
-  code: CHILD_TAG_DOES_NOT_SATISFY_REFERENCE_POINT specificity: 72
+  code: CHILD_TAG_DOES_NOT_SATISFY_REFERENCE_POINT specificity: 73
 }
-error_specificity { code: MANDATORY_REFERENCE_POINT_MISSING specificity: 73 }
-error_specificity { code: DUPLICATE_REFERENCE_POINT specificity: 74 }
-error_specificity { code: TAG_REFERENCE_POINT_CONFLICT specificity: 75 }
+error_specificity { code: MANDATORY_REFERENCE_POINT_MISSING specificity: 74 }
+error_specificity { code: DUPLICATE_REFERENCE_POINT specificity: 75 }
+error_specificity { code: TAG_REFERENCE_POINT_CONFLICT specificity: 76 }
 error_specificity {
   code: CHILD_TAG_DOES_NOT_SATISFY_REFERENCE_POINT_SINGULAR
-  specificity: 76
+  specificity: 77
 }
-error_specificity { code: CSS_SYNTAX_DISALLOWED_PROPERTY_VALUE specificity: 77 }
+error_specificity { code: CSS_SYNTAX_DISALLOWED_PROPERTY_VALUE specificity: 78 }
 error_specificity {
   code: CSS_SYNTAX_DISALLOWED_PROPERTY_VALUE_WITH_HINT
-  specificity: 78
-}
-error_specificity {
-  code: CSS_SYNTAX_PROPERTY_DISALLOWED_WITHIN_AT_RULE
   specificity: 79
 }
 error_specificity {
-  code: CSS_SYNTAX_PROPERTY_DISALLOWED_TOGETHER_WITH
+  code: CSS_SYNTAX_PROPERTY_DISALLOWED_WITHIN_AT_RULE
   specificity: 80
 }
 error_specificity {
-  code: CSS_SYNTAX_PROPERTY_REQUIRES_QUALIFICATION
+  code: CSS_SYNTAX_PROPERTY_DISALLOWED_TOGETHER_WITH
   specificity: 81
 }
 error_specificity {
-  code: BASE_TAG_MUST_PRECEED_ALL_URLS
+  code: CSS_SYNTAX_PROPERTY_REQUIRES_QUALIFICATION
   specificity: 82
+}
+error_specificity {
+  code: BASE_TAG_MUST_PRECEED_ALL_URLS
+  specificity: 83
 }
 error_specificity { code: DISALLOWED_SCRIPT_TAG specificity: 100 }
 error_specificity { code: GENERAL_DISALLOWED_TAG specificity: 101 }
@@ -5773,6 +5774,10 @@ error_formats {
 error_formats {
   code: NON_WHITESPACE_CDATA_ENCOUNTERED
   format: "The tag '%1' contains text, which is disallowed."
+}
+error_formats {
+  code: INVALID_JSON_CDATA
+  format: "JSON contents are invalid data that can not be parsed."
 }
 error_formats {
   code: DISALLOWED_PROPERTY_IN_ATTR_VALUE

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -26,7 +26,7 @@ min_validator_revision_required: 348
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 707
+spec_file_revision: 708
 
 styles_spec_url: "https://www.ampproject.org/docs/guides/author-develop/responsive/style_pages"
 script_spec_url: "https://www.ampproject.org/docs/reference/spec#html-tags"

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -26,7 +26,7 @@ min_validator_revision_required: 348
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 708
+spec_file_revision: 709
 
 styles_spec_url: "https://www.ampproject.org/docs/guides/author-develop/responsive/style_pages"
 script_spec_url: "https://www.ampproject.org/docs/reference/spec#html-tags"
@@ -5760,7 +5760,7 @@ error_formats {
 }
 error_formats {
   code: INLINE_STYLE_TOO_LONG
-  format: "The inline style specified in tag '%1' is too long - document "
+  format: "The inline style specified in tag '%1' is too long - it "
           "contains %2 bytes whereas the limit is %3 bytes."
 }
 error_formats {

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -26,7 +26,7 @@ min_validator_revision_required: 348
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 710
+spec_file_revision: 711
 
 styles_spec_url: "https://www.ampproject.org/docs/guides/author-develop/responsive/style_pages"
 script_spec_url: "https://www.ampproject.org/docs/reference/spec#html-tags"

--- a/validator/validator.proto
+++ b/validator/validator.proto
@@ -635,7 +635,7 @@ message ValidationError {
     // DO NOT REASSIGN the previously used values 2, 3.
   }
   optional Severity severity = 6 [ default = ERROR ];
-  // NEXT AVAILABLE TAG: 106
+  // NEXT AVAILABLE TAG: 107
   enum Code {
     UNKNOWN_CODE = 0;
     MANDATORY_TAG_MISSING = 1;
@@ -670,6 +670,7 @@ message ValidationError {
     MANDATORY_CDATA_MISSING_OR_INCORRECT = 9;
     CDATA_VIOLATES_BLACKLIST = 30;
     NON_WHITESPACE_CDATA_ENCOUNTERED = 82;
+    INVALID_JSON_CDATA = 106;
     DEPRECATED_ATTR = 11;
     DEPRECATED_TAG = 12;
     MANDATORY_PROPERTY_MISSING_FROM_ATTR_VALUE = 14;


### PR DESCRIPTION
- Emits a warning if JSON cannot be parsed #15888 
- Add `amp-pan-zoom` to experimental format #17150 
- Clarify `INLINE_STYLE_TOO_LONG` error message.
- Enable the `amp-date-picker` `minimum-nights` attribute #17201, #17220
- `amp-list`: Require `reset-on-refresh="always"` for local data #17221 
- `amp-3d-glt`: add attribute `clearColor` #17085