### PR TITLE
Unlock scroll on <amp-story> when experiment is enabled.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-scroll.css
+++ b/extensions/amp-story/1.0/amp-story-scroll.css
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-
 amp-story[scroll] {
-  contain: none !important;
+  overflow-y: auto !important;
 }
 
 [scroll] amp-story-page {
@@ -24,6 +23,6 @@ amp-story[scroll] {
   height: 100vh !important;
 }
 
-amp-story[scroll] > amp-story-page.i-amphtml-layout-container[distance] {
+[scroll] amp-story-page[distance] {
   transform: none !important;
 }


### PR DESCRIPTION
Allows the `<amp-story>` element to scroll when the `amp-story-scroll` experience is enabled.

It does not break the runtime rendering/preloading and resources are loaded as you scroll. But it is not ideal as the scroll is not preserved if you reload the page.
We should switch to enabling scroll on the `html` tag later, if/when we want to launch this experiment.

Related to #16465