### PR TITLE
Add firebase folder generation to gulp tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ EXTENSIONS_CSS_MAP
 deps.txt
 flags-array.txt
 out/
+firebase
+.firebaserc
+firebase.json

--- a/build-system/tasks/firebase.js
+++ b/build-system/tasks/firebase.js
@@ -17,14 +17,14 @@ const argv = require('minimist')(process.argv.slice(2));
 const colors = require('ansi-colors');
 const fs = require('fs-extra');
 const gulp = require('gulp-help')(require('gulp'));
+const log = require('fancy-log');
 const path = require('path');
-
 
 function generateFirebaseFolder() {
   fs.mkdirpSync('firebase');
   if (argv.file) {
-    console.log(colors.green(`Processing file: ${argv.file}.`));
-    console.log(colors.green('Writing file to firebase.index.html.'));
+    log(colors.green(`Processing file: ${argv.file}.`));
+    log(colors.green('Writing file to firebase.index.html.'));
     fs.copyFileSync(/*src*/ argv.file, 'firebase/index.html',
         {overwrite: true});
     replaceUrls('firebase/index.html');
@@ -39,7 +39,7 @@ function generateFirebaseFolder() {
     manualTests.filter(fileName => path.extname(fileName) == '.html')
         .forEach(file => replaceUrls('firebase/manual/' + file));
   }
-  console.log(colors.green('Copying local amp files from dist folder.'));
+  log(colors.green('Copying local amp files from dist folder.'));
   fs.copySync('dist', 'firebase/dist', {overwrite: true});
   fs.copyFileSync('firebase/dist/ww.max.js',
       'firebase/dist/ww.js', {overwrite: true});
@@ -48,7 +48,7 @@ function generateFirebaseFolder() {
 function replaceUrls(filePath) {
   fs.readFile(filePath, 'utf8', (err, data) => {
     if (err) {
-      console.error(colors.red(err));
+      log(colors.red(err));
     }
     let result = data.replace(/https:\/\/cdn\.ampproject\.org\/v0\.js/g, '/dist/amp.js');
     if (argv.min) {
@@ -58,7 +58,7 @@ function replaceUrls(filePath) {
     }
     fs.writeFile(filePath, result, 'utf8', err => {
       if (err) {
-        console.error(colors.red(err));
+        log(colors.red(err));
       }
     });
   });

--- a/build-system/tasks/firebase.js
+++ b/build-system/tasks/firebase.js
@@ -1,0 +1,70 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+const argv = require('minimist')(process.argv.slice(2));
+const fs = require('fs-extra');
+const gulp = require('gulp-help')(require('gulp'));
+const path = require('path');
+
+
+function generateFirebaseFolder() {
+  fs.mkdirpSync('firebase');
+  if (argv.file) {
+    process.stdout.write(`Processing file: ${argv.file}\n`);
+    process.stdout.write('Writing file to firebase.index.html\n');
+    fs.copyFileSync(/*src*/ argv.file, 'firebase/index.html',
+        {overwrite: true});
+    replaceUrls('firebase/index.html');
+
+  } else {
+    fs.copySync('test/manual', 'firebase/manual', {overwrite: true});
+    fs.copySync('examples', 'firebase/examples', {overwrite: true});
+    const examples = fs.readdirSync('firebase/examples');
+    const manualTests = fs.readdirSync('firebase/manual');
+    examples.filter(fileName => path.extname(fileName) == '.html')
+        .forEach(file => replaceUrls('firebase/examples/' + file));
+    manualTests.filter(fileName => path.extname(fileName) == '.html')
+        .forEach(file => replaceUrls('firebase/manual/' + file));
+  }
+  process.stdout.write('Copying local amp files from dist folder\n');
+  fs.copySync('dist', 'firebase/dist', {overwrite: true});
+}
+
+function replaceUrls(filePath) {
+  fs.readFile(filePath, 'utf8', (err, data) => {
+    if (err) {
+      process.stdout.write(err);
+    }
+    let result = data.replace(/https:\/\/cdn\.ampproject\.org\/v0\.js/g, '/dist/amp.js');
+    result = result.replace(/https:\/\/cdn\.ampproject\.org\/v0\/(.+?).js/g, '/dist/v0/$1.max.js');
+
+    fs.writeFileSync(filePath, result, 'utf8', err => {
+      if (err) {
+        process.stdout.write(err);
+      }
+    });
+  });
+
+}
+
+gulp.task(
+    'firebase',
+    'Generates firebase folder for deployment',
+    generateFirebaseFolder,
+    {
+      options: {
+        'file': 'File to deploy to firebase as index.html',
+      },
+    });

--- a/build-system/tasks/index.js
+++ b/build-system/tasks/index.js
@@ -27,6 +27,7 @@ require('./compile-css-expr');
 require('./create-golden-css');
 require('./csvify-size');
 require('./dep-check');
+require('./firebase');
 require('./get-zindex');
 require('./gen-codeowners');
 require('./extension-generator');

--- a/contributing/DEVELOPING.md
+++ b/contributing/DEVELOPING.md
@@ -99,6 +99,8 @@ Command                                                                 | Descri
 `gulp visual-diff --headless`                                           | Same as above, but launches local Chrome in headless mode.
 `gulp visual-diff --chrome_debug --webserver_debug`                     | Same as above, with additional logging. Debug flags can be used independently.
 `gulp visual-diff --grep=<regular-expression-pattern>`                  | Same as above, but executes only those tests whose name matches the regular expression pattern.
+`gulp firebase`                                                         | Generates a folder `firebase` and copies over all files from `examples` and `test/manual` for firebase deployment.
+`gulp firebase --file path/to/file`                                     | Same as above, but copies over the file specified as `firebase/index.html`.
 
 ## Manual testing
 
@@ -284,6 +286,17 @@ you will need set the `AMP_TESTING_HOST` environment variable. (On heroku this
 is done through
 `heroku config:set AMP_TESTING_HOST=my-heroku-subdomain.herokuapp.com`)
 
+### Testing with Firebase
+For deploying and testing local AMP builds on [Firebase](https://firebase.google.com/), install firebase and initialize firebase within this directory, setting the `public` folder to `firebase` (a `firebase` folder can be generated with the command, `gulp firebase`).
+```
+npm install -g firebase-tools
+firebase login
+firebase init
+gulp firebase
+firebase deploy
+```
+
+`gulp firebase` will generate a `firebase` folder and copy over all files from `examples` and `test/manual`. It will rewrite all urls in the copied files to point to the local versions of AMP.
 
 ## Repository Layout
 <pre>


### PR DESCRIPTION
Adds a gulp task to generate a firebase folder, rewrite all the urls, and copy all necessary files over. 

```
npm install -g firebase-tools
firebase login
firebase init
# gulp dist #if necessary
gulp firebase
firebase deploy
```
Just set the public folder to `firebase`. 

Run `gulp firebase --file path/to/my/file` if you want to just do one file and make it the index.html file. Firebase has this weird quirk of requiring an index.html file or otherwise it autogenerates one. 

Takes a total of 5 seconds to run, and 3 minutes to deploy. 

~~Need to find a place in the documentation to move over what I currently have in a google doc.~~