### PR TITLE
Server side rendering for AMP4Email. Part 2.

### DIFF
--- a/build-system/amp.extern.js
+++ b/build-system/amp.extern.js
@@ -17,6 +17,27 @@
 /** @externs */
 
 /**
+ * Special case for fetchJson
+ * @typedef {{
+ *   body: (!JsonObject|!FormData|undefined),
+ *   credentials: (string|undefined),
+ *   headers: (!JsonObject|undefined),
+ *   method: (string|undefined),
+ *   requireAmpResponseSourceOrigin: (boolean|undefined),
+ *   ampCors: (boolean|undefined)
+ * }}
+ */
+var FetchInitJsonDef;
+
+/**
+ * @typedef {{
+ *  xhrUrl: string,
+ *  fetchOpt: !FetchInitJsonDef
+ * }}
+ */
+var FetchRequestDef;
+
+/**
  * A type for Objects that can be JSON serialized or that come from
  * JSON serialization. Requires the objects fields to be accessed with
  * bracket notation object['name'] to make sure the fields do not get

--- a/build-system/amp.extern.js
+++ b/build-system/amp.extern.js
@@ -17,7 +17,9 @@
 /** @externs */
 
 /**
- * Special case for fetchJson
+ * Special case for fetchJson.
+ * Externed for use in the amp-form component when reconstructing
+ * the request for SSR and then passed to runtime.
  * @typedef {{
  *   body: (!JsonObject|!FormData|undefined),
  *   credentials: (string|undefined),
@@ -30,6 +32,8 @@
 var FetchInitJsonDef;
 
 /**
+ * Externed as this is constructed in the amp-form component and
+ * then passed to runtime.
  * @typedef {{
  *  xhrUrl: string,
  *  fetchOpt: !FetchInitJsonDef

--- a/build-system/dep-check-config.js
+++ b/build-system/dep-check-config.js
@@ -278,6 +278,10 @@ exports.rules = [
           'src/service/navigation.js',
       'extensions/amp-analytics/0.1/linker-manager.js->' +
           'src/service/navigation.js',
+      'extensions/amp-list/0.1/amp-list.js->' +
+          'src/service/xhr-impl.js',
+      'extensions/amp-form/0.1/amp-form.js->' +
+          'src/service/xhr-impl.js',
     ],
   },
   {

--- a/examples/viewer.html
+++ b/examples/viewer.html
@@ -435,9 +435,10 @@
           log('touch event!', name);
           return Promise.resolve();
         case 'viewerRenderTemplate':
-        if (data.sourceAmpComponent === 'amp-list') {
+        const ampComponent = data.ampComponent.type
+        if (ampComponent === 'amp-list') {
           return this.ssrRenderAmpListTemplate_(data);
-        } else if (data.sourceAmpComponent == 'amp-form') {
+        } else if (ampComponent == 'amp-form') {
           return this.ssrRenderAmpFormTemplate_(data);
         } else {
           return Promise.reject({error: 'source amp component is not valid'})
@@ -456,6 +457,7 @@
 
     Viewer.prototype.ssrRenderAmpListTemplate_ = function(data) {
       // Mocked response.
+      new Response
       return Promise.resolve({
         data : "<ul><li>Some list item</li><li>Some list item</li><li>Some list item</li></ul>"
       });

--- a/examples/viewer.html
+++ b/examples/viewer.html
@@ -435,10 +435,10 @@
           log('touch event!', name);
           return Promise.resolve();
         case 'viewerRenderTemplate':
-        const ampComponent = data.ampComponent.type
-        if (ampComponent === 'amp-list') {
+        const ampComponentType = data.ampComponent.type
+        if (ampComponentType === 'amp-list') {
           return this.ssrRenderAmpListTemplate_(data);
-        } else if (ampComponent == 'amp-form') {
+        } else if (ampComponentType == 'amp-form') {
           return this.ssrRenderAmpFormTemplate_(data);
         } else {
           return Promise.reject({error: 'source amp component is not valid'})
@@ -459,13 +459,28 @@
       // Mocked response.
       new Response
       return Promise.resolve({
-        data : "<ul><li>Some list item</li><li>Some list item</li><li>Some list item</li></ul>"
+        "html": "<ul><li>Some list item</li><li>Some list item</li><li>Some list item</li></ul>",
+        "body" : "",
+        "init" : {
+          "headers": {
+            "Content-Type": "application/json",
+          }
+        }
       });
     };
 
     Viewer.prototype.ssrRenderAmpFormTemplate_ = function(data) {
       // Mocked response.
-      return Promise.resolve({data: "<div>Server side rendered search result</div>"});
+      return Promise.resolve({
+        "html": "<div>Server side rendered search result</div>",
+        "body": "",
+        "init" : {
+          "headers": {
+            "Content-Type": "application/json",
+            "AMP-Access-Control-Allow-Source-Origin": "http://localhost:8000"
+          }
+        }
+      });
     };
 
     Viewer.prototype.handleUnload_ = function(type, data, awaitResponse) {

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -250,8 +250,8 @@ export class AmpForm {
       }
     }
     return {
-      'xhrUrl': xhrUrl,
-      'fetchOpt': dict({
+      xhrUrl,
+      fetchOpt: dict({
         'body': body,
         'method': method,
         'credentials': 'include',

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -503,18 +503,11 @@ export class AmpForm {
             this.submittingWithTrust_(trust);
             return this.doActionXhr_();
           })
-<<<<<<< HEAD
           .then(response => this.handleXhrSubmitSuccess_(
               /* {!../../../src/utils/xhr-utils.FetchResponse} */ response),
           error => {
             return this.handleXhrSubmitFailure_(/** @type {!Error} */(error));
           });
-=======
-          .then(response => this.handleXhrSubmitSuccess_(response),
-              error => {
-                return this.handleXhrSubmitFailure_(/** @type {!Error} */(error));
-              });
->>>>>>> .
     }
     if (getMode().test) {
       this.xhrSubmitPromise_ = p;

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -43,7 +43,7 @@ import {
 } from '../../../src/form';
 import {
   fromStructuredCloneable,
-  setupAmpCors,
+  setupAMPCors,
   setupInit,
   verifyAmpCORSHeaders,
 } from '../../../src/utils/xhr-utils';
@@ -504,8 +504,8 @@ export class AmpForm {
         // and only deal with submit-success or submit-error.
         fetchData = this.buildFetchData(
             dev().assertString(this.xhrAction_), this.method_);
-        setupInit(this.win_, fetchData.xhrUrl, fetchData.fetchOpt);
-        setupAmpCors(this.win_, fetchData.xhrUrl, fetchData.fetchOpt);
+        setupInit(fetchData.fetchOpt);
+        setupAMPCors(this.win_, fetchData.xhrUrl, fetchData.fetchOpt);
         return this.ssrTemplateHelper_.fetchAndRenderTemplate(
             this.form_,
             fetchData,
@@ -641,7 +641,7 @@ export class AmpForm {
 
   /**
    * Transition the form to the submit success state.
-   * @param {!JsonObject} response
+   * @param {!JsonObject|string|undefined} response
    * @param {!../../../src/service/xhr-impl.FetchData} fetchData
    * @return {!Promise}
    * @private visible for testing

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -43,10 +43,10 @@ import {
 } from '../../../src/form';
 import {
   fromStructuredCloneable,
-  setAmpCors,
+  setupAmpCors,
   setupInit,
-  validateFetchResponse,
-} from '../../../src/service/xhr-impl';
+  verifyAmpCORSHeaders,
+} from '../../../src/utils/xhr-utils';
 import {
   getFormValidator,
   isCheckValiditySupported,
@@ -504,8 +504,8 @@ export class AmpForm {
         // and only deal with submit-success or submit-error.
         fetchData = this.buildFetchData(
             dev().assertString(this.xhrAction_), this.method_);
-        setupInit(fetchData.fetchOpt);
-        setAmpCors(this.win_, fetchData.xhrUrl, fetchData.fetchOpt);
+        setupInit(this.win_, fetchData.xhrUrl, fetchData.fetchOpt);
+        setupAmpCors(this.win_, fetchData.xhrUrl, fetchData.fetchOpt);
         return this.ssrTemplateHelper_.fetchAndRenderTemplate(
             this.form_,
             fetchData,
@@ -649,8 +649,8 @@ export class AmpForm {
   handleSsrTemplateSuccess_(response, fetchData) {
     // Construct the fetch response and validate.
     const fetchResponse =
-        fromStructuredCloneable(this.win_, response, fetchData.responseType);
-    validateFetchResponse(this.win_, fetchResponse, fetchData.fetchOpt);
+        fromStructuredCloneable(response, fetchData.responseType);
+    verifyAmpCORSHeaders(this.win_, fetchResponse, fetchData.fetchOpt);
     return this.handleSubmitSuccess_(Promise.resolve(response['data']));
   }
 

--- a/extensions/amp-form/0.1/test/test-amp-form.js
+++ b/extensions/amp-form/0.1/test/test-amp-form.js
@@ -165,12 +165,12 @@ describes.repeated('', {
       });
 
       it('should server side render templates if enabled', () => {
+        const setupAMPCors = sandbox.spy(xhrUtils, 'setupAMPCors');
+        const fromStructuredCloneable =
+            sandbox.spy(xhrUtils, 'fromStructuredCloneable');
+        const verifyAmpCORSHeaders =
+            sandbox.spy(xhrUtils, 'verifyAmpCORSHeaders');
         ampForm.then(ampForm => {
-          const setupAMPCors = sandbox.spy(xhrUtils, 'setupAMPCors');
-          const fromStructuredCloneable =
-              sandbox.spy(xhrUtils, 'fromStructuredCloneable');
-          const verifyAmpCORSHeaders =
-              sandbox.spy(xhrUtils, 'verifyAmpCORSHeaders');
           const form = ampForm.form_;
           const template = createElement('template');
           template.setAttribute('type', 'amp-mustache');

--- a/extensions/amp-form/0.1/test/test-amp-form.js
+++ b/extensions/amp-form/0.1/test/test-amp-form.js
@@ -1239,7 +1239,7 @@ describes.repeated('', {
 
     describe('User Validity', () => {
       it('should manage valid/invalid on input/fieldset/form on submit', () => {
-        expectAsyncConsoleError(/Form submission failed.*/);
+        expectAsyncConsoleError(/Form submission failed/);
         setReportValiditySupportedForTesting(false);
         return getAmpForm(getForm(/*button1*/ true)).then(ampForm => {
           const form = ampForm.form_;
@@ -1478,7 +1478,7 @@ describes.repeated('', {
     });
 
     it('should submit after timeout of waiting for amp-selector', function() {
-      expectAsyncConsoleError(/Form submission failed.*/);
+      expectAsyncConsoleError(/Form submission failed/);
       this.timeout(3000);
       return getAmpForm(getForm()).then(ampForm => {
         const form = ampForm.form_;

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -29,11 +29,11 @@ import {createCustomEvent} from '../../../src/event-helper';
 import {dev, user} from '../../../src/log';
 import {
   fromStructuredCloneable,
-  setAmpCors,
+  setupAMPCors,
   setupInit,
   setupJsonFetchInit,
-  validateFetchResponse,
-} from '../../../src/service/xhr-impl';
+  verifyAmpCORSHeaders,
+} from '../../../src/utils/xhr-utils';
 import {getSourceOrigin} from '../../../src/url';
 import {isArray} from '../../../src/types';
 import {isLayoutSizeDefined} from '../../../src/layout';
@@ -274,7 +274,7 @@ export class AmpList extends AMP.BaseElement {
         this.element,
         this.getPolicy_()).then(batchFetchData => {
       fetchData =
-          setAmpCors(win, batchFetchData.xhrUrl, batchFetchData.fetchOpt);
+          setupAMPCors(win, batchFetchData.xhrUrl, batchFetchData.fetchOpt);
       setupJsonFetchInit(fetchData.fetchOpt);
       setupInit(fetchData.fetchOpt);
       return this.ssrTemplateHelper_.fetchAndRenderTemplate(
@@ -283,7 +283,7 @@ export class AmpList extends AMP.BaseElement {
       // Construct the fetch response and validate.
       const fetchResponse =
           fromStructuredCloneable(win, response, fetchData.responseType);
-      validateFetchResponse(win, fetchResponse, fetchData.fetchOpt);
+      verifyAmpCORSHeaders(win, fetchResponse, fetchData.fetchOpt);
       return fetchResponse;
     }, error => {
       throw user().createError('Error proxying amp-list templates', error);

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -23,7 +23,7 @@ import {SsrTemplateHelper} from '../../../src/ssr-template-helper';
 import {
   UrlReplacementPolicy,
   batchFetchJsonFor,
-  constructBatchFetchDef,
+  requestForBatchFetch,
 } from '../../../src/batched-json';
 import {createCustomEvent} from '../../../src/event-helper';
 import {dev, user} from '../../../src/log';
@@ -266,7 +266,7 @@ export class AmpList extends AMP.BaseElement {
     let fetchDef;
     // Construct the fetch init data that would be called by the viewer
     // passed in as the 'originalRequest'.
-    return constructBatchFetchDef(
+    return requestForBatchFetch(
         this.getAmpDoc(),
         this.element,
         this.getPolicy_()).then(batchFetchDef => {
@@ -284,7 +284,7 @@ export class AmpList extends AMP.BaseElement {
       return this.ssrTemplateHelper_.fetchAndRenderTemplate(
           this.element, batchFetchDef, null, ampListAttributes);
     }).then(response => {
-      fetchDef.responseType = 'application/json';
+      fetchDef.fetchOpt.responseType = 'application/json';
       this.ssrTemplateHelper_.verifySsrResponse(
           this.win, response, fetchDef);
       return response['html'];

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -263,14 +263,14 @@ export class AmpList extends AMP.BaseElement {
    * @return {!Promise}
    */
   ssrTemplate_() {
-    let fetchDef;
+    let request;
     // Construct the fetch init data that would be called by the viewer
     // passed in as the 'originalRequest'.
     return requestForBatchFetch(
         this.getAmpDoc(),
         this.element,
         this.getPolicy_()).then(batchFetchDef => {
-      fetchDef = batchFetchDef;
+      request = batchFetchDef;
       batchFetchDef.fetchOpt = setupAMPCors(
           this.win, batchFetchDef.xhrUrl, batchFetchDef.fetchOpt);
       setupJsonFetchInit(batchFetchDef.fetchOpt);
@@ -284,9 +284,9 @@ export class AmpList extends AMP.BaseElement {
       return this.ssrTemplateHelper_.fetchAndRenderTemplate(
           this.element, batchFetchDef, null, ampListAttributes);
     }).then(response => {
-      fetchDef.fetchOpt.responseType = 'application/json';
+      request.fetchOpt.responseType = 'application/json';
       this.ssrTemplateHelper_.verifySsrResponse(
-          this.win, response, fetchDef);
+          this.win, response, request);
       return response['html'];
     }, error => {
       throw user().createError('Error proxying amp-list templates', error);

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -278,7 +278,6 @@ export class AmpList extends AMP.BaseElement {
           setupAMPCors(win, batchFetchData.xhrUrl, batchFetchData.fetchOpt);
       setupJsonFetchInit(batchFetchData.fetchOpt);
       setupInit(batchFetchData.fetchOpt);
-      this.element.getAttribute('items') || 'items';
       const ampListAttributes = dict({
         'ampListAttributes': {
           'items': this.element.getAttribute('items') || 'items',

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -27,6 +27,7 @@ import {
 } from '../../../src/batched-json';
 import {createCustomEvent} from '../../../src/event-helper';
 import {dev, user} from '../../../src/log';
+import {dict} from '../../../src/utils/object';
 import {
   fromStructuredCloneable,
   setupAMPCors,
@@ -277,8 +278,16 @@ export class AmpList extends AMP.BaseElement {
           setupAMPCors(win, batchFetchData.xhrUrl, batchFetchData.fetchOpt);
       setupJsonFetchInit(batchFetchData.fetchOpt);
       setupInit(batchFetchData.fetchOpt);
+      this.element.getAttribute('items') || 'items';
+      const ampListAttributes = dict({
+        'ampListAttributes': {
+          'items': this.element.getAttribute('items') || 'items',
+          'singleItem': this.element.getAttribute('single-item'),
+          'maxItems': this.element.getAttribute('max-items'),
+        },
+      });
       return this.ssrTemplateHelper_.fetchAndRenderTemplate(
-          this.element, batchFetchData);
+          this.element, batchFetchData, null, ampListAttributes);
     }).then(response => {
       // Construct the fetch response and validate.
       const fetchResponse =

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -34,11 +34,13 @@ describes.realWin('amp-list component', {
   let viewerMock;
   let setBindService;
   let template;
+  let sandbox;
 
   beforeEach(() => {
     win = env.win;
     doc = win.document;
     ampdoc = env.ampdoc;
+    sandbox = env.sandbox;
 
     const templates = Services.templatesFor(win);
     templatesMock = sandbox.mock(templates);
@@ -168,10 +170,6 @@ describes.realWin('amp-list component', {
   describe('without amp-bind', () => {
     beforeEach(() => {
       setBindService(null);
-    });
-
-    afterEach(() => {
-      sandbox.restore();
     });
 
     it('should fetch and render', () => {

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import * as xhrUtils from '../../../../src/utils/xhr-utils';
 import {AmpEvents} from '../../../../src/amp-events';
 import {AmpList} from '../amp-list';
 import {Deferred} from '../../../../src/utils/promise';
@@ -85,6 +86,7 @@ describes.realWin('amp-list component', {
    * @return {!Promise}
    */
   function expectFetchAndRender(fetched, rendered, opts = DEFAULT_LIST_OPTS) {
+    viewerMock.expects('canRenderTemplates').returns(false).twice();
     listMock.expects('fetch_')
         .withExactArgs(opts.expr || DEFAULT_LIST_OPTS.expr)
         .returns(Promise.resolve(fetched))
@@ -130,10 +132,24 @@ describes.realWin('amp-list component', {
     viewerMock.expects('sendMessageAwaitResponse').withExactArgs(
         'viewerCanRenderTemplate',
         {
-          data: {inputData: { }, src: 'https://data.com/list.json'},
-          mustacheTemplate: '<template xmlns="http://www.w3.org/1999/xhtml">' +
-              '{{template}}</template>',
-          'sourceAmpComponent': 'amp-list',
+          'ampComponent': {
+            'errorTemplate': {'payload': null, 'type': 'amp-mustache'},
+            'successTemplate': {
+              'payload': '<template xmlns="http://www.w3.org/1999/xhtml">{{template}}</template>',
+              'type': 'amp-mustache',
+            },
+            'type': 'amp-list',
+          },
+          'ampListAttributes': {
+            'items': 'items', 'maxItems': null, 'singleItem': null},
+          'originalRequest': {
+            'init': {
+              'headers': {'Accept': 'application/json'},
+              'method': 'GET',
+              'requireAmpResponseSourceOrigin': false,
+            },
+            'input': 'https://data.com/list.json',
+          },
         }).returns(fetch).once();
     if (opts.resetOnRefresh) {
       listMock.expects('togglePlaceholder').withExactArgs(true).once();
@@ -143,7 +159,7 @@ describes.realWin('amp-list component', {
     listMock.expects('togglePlaceholder').withExactArgs(false).once();
     const render = Promise.resolve(rendered);
     templatesMock.expects('findAndRenderTemplate')
-        .withExactArgs(element, fetched.data)
+        .withExactArgs(element, fetched.html)
         .returns(render).once(1);
 
     return Promise.all([fetch, render]);
@@ -152,6 +168,10 @@ describes.realWin('amp-list component', {
   describe('without amp-bind', () => {
     beforeEach(() => {
       setBindService(null);
+    });
+
+    afterEach(() => {
+      sandbox.restore();
     });
 
     it('should fetch and render', () => {
@@ -165,14 +185,20 @@ describes.realWin('amp-list component', {
       });
     });
 
-    // TODO(alabiaga): Fix failing tests.
-    describe.skip('Viewer render template', () => {
+    describe('Viewer render template', () => {
       it('should proxy rendering to viewer', () => {
-        const resp = {data: '<div>Rendered template</div>'};
+        const setupAMPCors = sandbox.spy(xhrUtils, 'setupAMPCors');
+        const fromStructuredCloneable =
+            sandbox.spy(xhrUtils, 'fromStructuredCloneable');
+        const verifyAmpCORSHeaders =
+            sandbox.spy(xhrUtils, 'verifyAmpCORSHeaders');
+        const resp = {'html': '<div>Rendered template</div>'};
         const itemElement = doc.createElement('div');
         const rendered = expectViewerProxiedFetchAndRender(resp, itemElement);
         return list.layoutCallback().then(() => rendered).then(() => {
           expect(list.container_.contains(itemElement)).to.be.true;
+          sinon.assert.callOrder(
+              setupAMPCors, fromStructuredCloneable, verifyAmpCORSHeaders);
         });
       });
 
@@ -182,18 +208,28 @@ describes.realWin('amp-list component', {
         viewerMock.expects('sendMessageAwaitResponse').withExactArgs(
             'viewerRenderTemplate',
             {
-              data: {
-                inputData: { },
-                src: 'https://data.com/list.json',
+              'ampComponent': {
+                'errorTemplate': {'payload': null, 'type': 'amp-mustache'},
+                'src': 'https://data.com/list.json',
               },
-              mustacheTemplate: '<template xmlns="http://www.w3.org/1999/xhtml">' +
-                  '{{template}}</template>',
-              'sourceAmpComponent': 'amp-list',
+              'successTemplate': {
+                'payload': '<template xmlns="http://www.w3.org/1999/xhtml">{{template}}</template>',
+                'type': 'amp-mustache',
+              },
+              'type': 'amp-list',
+              'originalRequest': {
+                'init': {
+                  'headers': {'Accept': 'application/json'},
+                  'method': 'GET',
+                  'requireAmpResponseSourceOrigin': false,
+                },
+                'input': 'https://data.com/list.json',
+              },
             }).returns(Promise.resolve({})).once();
         templatesMock.expects('findAndRenderTemplate').never();
         listMock.expects('toggleLoading').withExactArgs(false).once();
         return expect(list.layoutCallback()).to.eventually.be
-            .rejectedWith(/Response missing the \'data\' field/);
+            .rejectedWith(/Error proxying amp-list templates/);
       });
     });
 
@@ -420,6 +456,7 @@ describes.realWin('amp-list component', {
 
     it('should show placeholder on fetch failure (w/o fallback)', () => {
       // Stub fetch_() to fail.
+      viewerMock.expects('canRenderTemplates').returns(false).twice();
       listMock.expects('fetch_').returns(Promise.reject()).once();
       listMock.expects('toggleLoading').withExactArgs(false).once();
       listMock.expects('togglePlaceholder').never();
@@ -473,6 +510,7 @@ describes.realWin('amp-list component', {
         },
       };
       setBindService(bind);
+      viewerMock.expects('canRenderTemplates').returns(false).twice();
     });
 
     it('should _not_ refetch if [src] attr changes (before layout)', () => {

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -88,7 +88,8 @@ describes.realWin('amp-list component', {
    * @return {!Promise}
    */
   function expectFetchAndRender(fetched, rendered, opts = DEFAULT_LIST_OPTS) {
-    viewerMock.expects('canRenderTemplates').returns(false).twice();
+    viewerMock.expects('hasCapability').withExactArgs('viewerRenderTemplate')
+        .returns(false).twice();
     listMock.expects('fetch_')
         .withExactArgs(opts.expr || DEFAULT_LIST_OPTS.expr)
         .returns(Promise.resolve(fetched))
@@ -132,7 +133,7 @@ describes.realWin('amp-list component', {
     viewerMock.expects('hasCapability')
         .withExactArgs('viewerRenderTemplate').returns(true).twice();
     viewerMock.expects('sendMessageAwaitResponse').withExactArgs(
-        'viewerCanRenderTemplate',
+        'viewerRenderTemplate',
         {
           'ampComponent': {
             'errorTemplate': {'payload': null, 'type': 'amp-mustache'},
@@ -454,7 +455,8 @@ describes.realWin('amp-list component', {
 
     it('should show placeholder on fetch failure (w/o fallback)', () => {
       // Stub fetch_() to fail.
-      viewerMock.expects('canRenderTemplates').returns(false).twice();
+      viewerMock.expects('hasCapability').withExactArgs('viewerRenderTemplate')
+          .returns(false).twice();
       listMock.expects('fetch_').returns(Promise.reject()).once();
       listMock.expects('toggleLoading').withExactArgs(false).once();
       listMock.expects('togglePlaceholder').never();
@@ -508,7 +510,8 @@ describes.realWin('amp-list component', {
         },
       };
       setBindService(bind);
-      viewerMock.expects('canRenderTemplates').returns(false).twice();
+      viewerMock.expects('hasCapability').withExactArgs('viewerRenderTemplate')
+          .returns(false).twice();
     });
 
     it('should _not_ refetch if [src] attr changes (before layout)', () => {

--- a/src/batched-json.js
+++ b/src/batched-json.js
@@ -38,7 +38,7 @@ export const UrlReplacementPolicy = {
  * @param {string=} opt_expr Dot-syntax reference to subdata of JSON result
  *     to return. If not specified, entire JSON result is returned.
  * @param {UrlReplacementPolicy=} opt_urlReplacement If ALL, replaces all URL
- *     vars. If OPT_IN, replaces whitelisted URL vars. Otherwise, don't expand.
+ *     vars. If OPT_IN, replaces whitelisted URL vars. Otherwise, don't expand..
  * @return {!Promise<!JsonObject|!Array<JsonObject>>} Resolved with JSON
  *     result or rejected if response is invalid.
  */
@@ -48,15 +48,36 @@ export function batchFetchJsonFor(
   opt_expr = '.',
   opt_urlReplacement = UrlReplacementPolicy.NONE)
 {
-  const url = assertHttpsUrl(element.getAttribute('src'), element);
+  assertHttpsUrl(element.getAttribute('src'), element);
+  return constructBatchFetchData(ampdoc, element, opt_urlReplacement)
+      .then(data => {
+        return Services.batchedXhrFor(ampdoc.win)
+            .fetchJson(data['src'], data['fetchOpts']);
+      }).then(res => res.json()).then(data => {
+        if (data == null) {
+          throw new Error('Response is undefined.');
+        }
+        return getValueForExpr(data, opt_expr || '.');
+      });
+}
 
+/**
+ * Handles url replacement and constructs the FetchInitJsonDef required for a
+ * fetch.
+ * @param {!./service/ampdoc-impl.AmpDoc} ampdoc
+ * @param {!Element} element
+ * @param {!UrlReplacementPolicy} opt_urlReplacement If ALL, replaces all URL
+ *     vars. If OPT_IN, replaces whitelisted URL vars. Otherwise, don't expand.
+ * @return {!Promise<!./service/xhr-impl.FetchData>}
+ */
+export function constructBatchFetchData(
+  ampdoc, element, opt_urlReplacement) {
+  const url = element.getAttribute('src');
   // Replace vars in URL if desired.
   const urlReplacements = Services.urlReplacementsForDoc(ampdoc);
   const srcPromise = (opt_urlReplacement >= UrlReplacementPolicy.OPT_IN)
-    ? urlReplacements.expandUrlAsync(url)
-    : Promise.resolve(url);
-
-  return srcPromise.then(src => {
+    ? urlReplacements.expandUrlAsync(url) : Promise.resolve(url);
+  return srcPromise.then(xhrUrl => {
     // Throw user error if this element is performing URL substitutions
     // without the soon-to-be-required opt-in (#12498).
     if (opt_urlReplacement == UrlReplacementPolicy.OPT_IN) {
@@ -65,20 +86,15 @@ export function batchFetchJsonFor(
         throw user().createError('URL variable substitutions in CORS ' +
             'fetches from dynamic URLs (e.g. via amp-bind) require opt-in. ' +
             `Please add data-amp-replace="${invalid.join(' ')}" to the ` +
-            `<${element.tagName}> element. See https://bit.ly/amp-var-subs.`);
+           `<${element.tagName}> element. See https://bit.ly/amp-var-subs.`);
       }
     }
-    const opts = {};
+    const fetchOpt = {};
     if (element.hasAttribute('credentials')) {
-      opts.credentials = element.getAttribute('credentials');
+      fetchOpt.credentials = element.getAttribute('credentials');
     } else {
-      opts.requireAmpResponseSourceOrigin = false;
+      fetchOpt.requireAmpResponseSourceOrigin = false;
     }
-    return Services.batchedXhrFor(ampdoc.win).fetchJson(src, opts);
-  }).then(res => res.json()).then(data => {
-    if (data == null) {
-      throw new Error('Response is undefined.');
-    }
-    return getValueForExpr(data, opt_expr || '.');
+    return {xhrUrl, fetchOpt};
   });
 }

--- a/src/batched-json.js
+++ b/src/batched-json.js
@@ -49,10 +49,10 @@ export function batchFetchJsonFor(
   opt_urlReplacement = UrlReplacementPolicy.NONE)
 {
   assertHttpsUrl(element.getAttribute('src'), element);
-  return constructBatchFetchData(ampdoc, element, opt_urlReplacement)
+  return constructBatchFetchDef(ampdoc, element, opt_urlReplacement)
       .then(data => {
         return Services.batchedXhrFor(ampdoc.win)
-            .fetchJson(data['src'], data['fetchOpts']);
+            .fetchJson(data['xhrUrl'], data['fetchOpt']);
       }).then(res => res.json()).then(data => {
         if (data == null) {
           throw new Error('Response is undefined.');
@@ -68,10 +68,12 @@ export function batchFetchJsonFor(
  * @param {!Element} element
  * @param {!UrlReplacementPolicy} opt_urlReplacement If ALL, replaces all URL
  *     vars. If OPT_IN, replaces whitelisted URL vars. Otherwise, don't expand.
- * @return {!Promise<!./service/xhr-impl.FetchData>}
+ * @return {!Promise<!./service/xhr-impl.FetchDef>}
  */
-export function constructBatchFetchData(
-  ampdoc, element, opt_urlReplacement) {
+export function constructBatchFetchDef(
+  ampdoc,
+  element,
+  opt_urlReplacement) {
   const url = element.getAttribute('src');
   // Replace vars in URL if desired.
   const urlReplacements = Services.urlReplacementsForDoc(ampdoc);

--- a/src/batched-json.js
+++ b/src/batched-json.js
@@ -49,7 +49,7 @@ export function batchFetchJsonFor(
   opt_urlReplacement = UrlReplacementPolicy.NONE)
 {
   assertHttpsUrl(element.getAttribute('src'), element);
-  return constructBatchFetchDef(ampdoc, element, opt_urlReplacement)
+  return requestForBatchFetch(ampdoc, element, opt_urlReplacement)
       .then(data => {
         return Services.batchedXhrFor(ampdoc.win)
             .fetchJson(data['xhrUrl'], data['fetchOpt']);

--- a/src/batched-json.js
+++ b/src/batched-json.js
@@ -68,7 +68,7 @@ export function batchFetchJsonFor(
  * @param {!Element} element
  * @param {!UrlReplacementPolicy} opt_urlReplacement If ALL, replaces all URL
  *     vars. If OPT_IN, replaces whitelisted URL vars. Otherwise, don't expand.
- * @return {!Promise<!./service/xhr-impl.FetchDef>}
+ * @return {!Promise<!./service/xhr-impl.FetchRequestDef>}
  */
 export function requestForBatchFetch(
   ampdoc,

--- a/src/batched-json.js
+++ b/src/batched-json.js
@@ -70,7 +70,7 @@ export function batchFetchJsonFor(
  *     vars. If OPT_IN, replaces whitelisted URL vars. Otherwise, don't expand.
  * @return {!Promise<!./service/xhr-impl.FetchDef>}
  */
-export function constructBatchFetchDef(
+export function requestForBatchFetch(
   ampdoc,
   element,
   opt_urlReplacement) {

--- a/src/service/xhr-impl.js
+++ b/src/service/xhr-impl.js
@@ -22,17 +22,16 @@ import {
   setupAMPCors,
   setupInit,
   setupInput,
+  setupJsonFetchInit,
   verifyAmpCORSHeaders,
 } from '../utils/xhr-utils';
-import {dev, user} from '../log';
 import {
   getCorsUrl,
   parseUrlDeprecated,
-  serializeQueryString,
 } from '../url';
 import {getService, registerServiceBuilder} from '../service';
-import {isArray, isObject} from '../types';
 import {isFormDataWrapper} from '../form-data-wrapper';
+import {user} from '../log';
 
 /**
  * Special case for fetchJson
@@ -54,10 +53,6 @@ export let FetchInitJsonDef;
  * }}
  */
 export let FetchData;
-
-
-/** @private @const {!Array<function(*):boolean>} */
-const allowedJsonBodyTypes_ = [isArray, isObject];
 
 /**
  * A service that polyfills Fetch API for use within AMP.
@@ -161,29 +156,7 @@ export class Xhr {
    * @return {!Promise<!../utils/xhr-utils.FetchResponse>}
    */
   fetchJson(input, opt_init, opt_allowFailure) {
-    const init = setupInit(opt_init, 'application/json');
-    if (init.method == 'POST' && !isFormDataWrapper(init.body)) {
-      // Assume JSON strict mode where only objects or arrays are allowed
-      // as body.
-      dev().assert(
-          allowedJsonBodyTypes_.some(test => test(init.body)),
-          'body must be of type object or array. %s',
-          init.body
-      );
-
-      // Content should be 'text/plain' to avoid CORS preflight.
-      init.headers['Content-Type'] = init.headers['Content-Type'] ||
-          'text/plain;charset=utf-8';
-      const headerContentType = init.headers['Content-Type'];
-      // Cast is valid, because we checked that it is not form data above.
-      if (headerContentType === 'application/x-www-form-urlencoded') {
-        init.body =
-          serializeQueryString(/** @type {!JsonObject} */ (init.body));
-      } else {
-        init.body = JSON.stringify(/** @type {!JsonObject} */ (init.body));
-      }
-    }
-    return this.fetch(input, init);
+    return this.fetch(input, setupJsonFetchInit(opt_init));
   }
 
   /**

--- a/src/service/xhr-impl.js
+++ b/src/service/xhr-impl.js
@@ -52,7 +52,7 @@ export let FetchInitJsonDef;
  *  fetchOpt: !FetchInitJsonDef
  * }}
  */
-export let FetchDef;
+export let FetchRequestDef;
 
 /**
  * A service that polyfills Fetch API for use within AMP.

--- a/src/service/xhr-impl.js
+++ b/src/service/xhr-impl.js
@@ -215,7 +215,6 @@ export class Xhr {
   }
 }
 
-
 /**
  * @param {!Window} window
  * @return {!Xhr}

--- a/src/service/xhr-impl.js
+++ b/src/service/xhr-impl.js
@@ -47,6 +47,15 @@ import {isFormDataWrapper} from '../form-data-wrapper';
  */
 export let FetchInitJsonDef;
 
+/**
+ * @typedef {{
+ *  xhrUrl: string,
+ *  fetchOpt: !FetchInitJsonDef
+ * }}
+ */
+export let FetchData;
+
+
 /** @private @const {!Array<function(*):boolean>} */
 const allowedJsonBodyTypes_ = [isArray, isObject];
 

--- a/src/service/xhr-impl.js
+++ b/src/service/xhr-impl.js
@@ -52,7 +52,7 @@ export let FetchInitJsonDef;
  *  fetchOpt: !FetchInitJsonDef
  * }}
  */
-export let FetchData;
+export let FetchDef;
 
 /**
  * A service that polyfills Fetch API for use within AMP.

--- a/src/ssr-template-helper.js
+++ b/src/ssr-template-helper.js
@@ -86,15 +86,15 @@ export class SsrTemplateHelper {
             fetchData,
             mustacheTemplate,
             opt_templates,
-            opt_attributes,
+            opt_attributes
         ));
   }
 
   /**
    * @param {!./service/xhr-impl.FetchData} fetchData
-   * @param {string} mustacheTemplate
+   * @param {string|undefined} mustacheTemplate
    * @param {?SsrTemplateDef=} opt_templates
-   * @param {!JsonObject=} opt_attributes
+   * @param {?JsonObject=} opt_attributes
    */
   buildPayload_(fetchData, mustacheTemplate, opt_templates, opt_attributes) {
     const ampComponent = dict({

--- a/src/ssr-template-helper.js
+++ b/src/ssr-template-helper.js
@@ -15,7 +15,7 @@
  */
 
 import {dict} from './utils/object';
-import {toStructuredCloneable} from './service/xhr-utils';
+import {toStructuredCloneable} from './utils/xhr-utils';
 
 /**
  * @typedef {{

--- a/src/ssr-template-helper.js
+++ b/src/ssr-template-helper.js
@@ -99,6 +99,8 @@ export class SsrTemplateHelper {
    * @param {string|undefined} mustacheTemplate
    * @param {?SsrTemplateDef=} opt_templates
    * @param {!Object=} opt_attributes
+   * @return {!JsonObject}
+   * @private
    */
   buildPayload_(
     fetchDef, mustacheTemplate, opt_templates, opt_attributes = {}) {
@@ -154,7 +156,7 @@ export class SsrTemplateHelper {
         win,
         fromStructuredCloneable(
             response,
-            fetchDef.responseType),
+            fetchDef.fetchOpt.responseType),
         fetchDef.fetchOpt);
   }
 }

--- a/src/ssr-template-helper.js
+++ b/src/ssr-template-helper.js
@@ -15,7 +15,7 @@
  */
 
 import {dict} from './utils/object';
-import {toStructuredCloneable} from './service/xhr-impl';
+import {toStructuredCloneable} from './service/xhr-utils';
 
 /**
  * @typedef {{

--- a/src/ssr-template-helper.js
+++ b/src/ssr-template-helper.js
@@ -124,7 +124,6 @@ export class SsrTemplateHelper {
           toStructuredCloneable(fetchDef.xhrUrl, fetchDef.fetchOpt),
       'ampComponent': ampComponent,
     });
-<<<<<<< HEAD
     data['successTemplate'] = opt_templates
       ? this.xmls_.serializeToString(opt_templates['successTemplate'])
       : mustacheTemplate;
@@ -134,15 +133,6 @@ export class SsrTemplateHelper {
 
     return this.viewer_.sendMessageAwaitResponse(
         'viewerRenderTemplate', data);
-=======
-    const additionalAttr = opt_attributes && Object.keys(opt_attributes);
-    if (additionalAttr) {
-      Object.keys(opt_attributes).forEach(key => {
-        data[key] = opt_attributes[key];
-      });
-    }
-    return data;
->>>>>>> fix tests
   }
 
   /**

--- a/src/ssr-template-helper.js
+++ b/src/ssr-template-helper.js
@@ -139,14 +139,14 @@ export class SsrTemplateHelper {
    * Constructs the fetch response and verifies AMP CORS headers.
    * @param {!Window} win
    * @param {!JsonObject|string|undefined} response
-   * @param {!./service/xhr-impl.FetchDef|string} fetchDef
+   * @param {!./service/xhr-impl.FetchRequestDef|string} request
    */
-  verifySsrResponse(win, response, fetchDef) {
+  verifySsrResponse(win, response, request) {
     verifyAmpCORSHeaders(
         win,
         fromStructuredCloneable(
             response,
-            fetchDef.fetchOpt.responseType),
-        fetchDef.fetchOpt);
+            request.fetchOpt.responseType),
+        request.fetchOpt);
   }
 }

--- a/src/ssr-template-helper.js
+++ b/src/ssr-template-helper.js
@@ -65,7 +65,7 @@ export class SsrTemplateHelper {
   /**
    * Proxies xhr and template rendering to the viewer and renders the response.
    * @param {!Element} element
-   * @param {!./service/xhr-impl.FetchRequestDef} request The fetch/XHR related data.
+   * @param {!FetchRequestDef} request The fetch/XHR related data.
    * @param {?SsrTemplateDef=} opt_templates Response templates to pass into
    *     the payload. If provided, finding the template in the passed in
    *     element is not attempted.
@@ -95,7 +95,7 @@ export class SsrTemplateHelper {
   }
 
   /**
-   * @param {!./service/xhr-impl.FetchRequestDef} request
+   * @param {!FetchRequestDef} request
    * @param {string|undefined} mustacheTemplate
    * @param {?SsrTemplateDef=} opt_templates
    * @param {!Object=} opt_attributes
@@ -139,7 +139,7 @@ export class SsrTemplateHelper {
    * Constructs the fetch response and verifies AMP CORS headers.
    * @param {!Window} win
    * @param {!JsonObject|string|undefined} response
-   * @param {!./service/xhr-impl.FetchRequestDef|string} request
+   * @param {!FetchRequestDef|string} request
    */
   verifySsrResponse(win, response, request) {
     verifyAmpCORSHeaders(

--- a/src/utils/xhr-utils.js
+++ b/src/utils/xhr-utils.js
@@ -23,6 +23,7 @@ import {getMode} from '../mode';
 import {isArray, isObject} from '../types';
 import {isFormDataWrapper} from '../form-data-wrapper';
 import {parseJson} from '../json';
+import {serializeQueryString} from '../url';
 import {utf8Encode} from './bytes';
 
 /** @private @const {!Array<string>} */
@@ -30,6 +31,9 @@ const allowedMethods_ = ['GET', 'POST'];
 
 /** @private @const {string} */
 const ALLOW_SOURCE_ORIGIN_HEADER = 'AMP-Access-Control-Allow-Source-Origin';
+
+/** @private @const {!Array<function(*):boolean>} */
+const allowedJsonBodyTypes_ = [isArray, isObject];
 
 /**
  * The "init" argument of the Fetch API. Currently, only "credentials: include"
@@ -319,6 +323,36 @@ export function setupAMPCors(win, input, init) {
   }
 
   return init;
+}
+
+/**
+ * @param {?FetchInitJsonDef=} init
+ * @return {!FetchInitJsonDef}
+ */
+export function setupJsonFetchInit(init) {
+  const fetchInit = setupInit(init, 'application/json');
+  if (fetchInit.method == 'POST' && !isFormDataWrapper(fetchInit.body)) {
+    // Assume JSON strict mode where only objects or arrays are allowed
+    // as body.
+    dev().assert(
+        allowedJsonBodyTypes_.some(test => test(fetchInit.body)),
+        'body must be of type object or array. %s',
+        fetchInit.body
+    );
+
+    // Content should be 'text/plain' to avoid CORS preflight.
+    fetchInit.headers['Content-Type'] = fetchInit.headers['Content-Type'] ||
+        'text/plain;charset=utf-8';
+    const headerContentType = fetchInit.headers['Content-Type'];
+    // Cast is valid, because we checked that it is not form data above.
+    if (headerContentType === 'application/x-www-form-urlencoded') {
+      fetchInit.body =
+        serializeQueryString(/** @type {!JsonObject} */ (fetchInit.body));
+    } else {
+      fetchInit.body = JSON.stringify(/** @type {!JsonObject} */ (fetchInit.body));
+    }
+  }
+  return fetchInit;
 }
 
 /**

--- a/src/utils/xhr-utils.js
+++ b/src/utils/xhr-utils.js
@@ -326,8 +326,8 @@ export function setupAMPCors(win, input, init) {
 }
 
 /**
- * @param {?FetchInitJsonDef=} init
- * @return {!FetchInitJsonDef}
+ * @param {?../service/xhr-impl.FetchInitJsonDef=} init
+ * @return {!../service/xhr-impl.FetchInitJsonDef}
  */
 export function setupJsonFetchInit(init) {
   const fetchInit = setupInit(init, 'application/json');

--- a/src/utils/xhr-utils.js
+++ b/src/utils/xhr-utils.js
@@ -378,9 +378,9 @@ function normalizeMethod_(method) {
 /**
  * Verifies if response has the correct headers
  * @param {!Window} win
- * @param {!FetchResponse} response
+ * @param {!FetchResponse|!Response} response
  * @param {!FetchInitDef=} init
- * @return {!FetchResponse}
+ * @return {!FetchResponse|!Response}
  */
 export function verifyAmpCORSHeaders(win, response, init) {
   const allowSourceOriginHeader = response.headers.get(

--- a/src/utils/xhr-utils.js
+++ b/src/utils/xhr-utils.js
@@ -326,8 +326,8 @@ export function setupAMPCors(win, input, init) {
 }
 
 /**
- * @param {?../service/xhr-impl.FetchInitJsonDef=} init
- * @return {!../service/xhr-impl.FetchInitJsonDef}
+ * @param {?FetchInitJsonDef=} init
+ * @return {!FetchInitJsonDef}
  */
 export function setupJsonFetchInit(init) {
   const fetchInit = setupInit(init, 'application/json');


### PR DESCRIPTION
Address outstanding items from #15643

- add "originalRequest" in message/payload to viewer as does the XHR interceptor.
- CORS handling of SSR response.
- add all templates available in amp-form to viewer. Previously I was only sending the first template found.
- add back support for the 'submitting' form state for rendering templates as there have been validation changes ensuring that there are no mustache templates present for possible security implications.
- choumx@ outstanding comments in previous PR (#15643)