### PR TITLE
Create auto-started video player by Viqeo

### DIFF
--- a/3p/integration.js
+++ b/3p/integration.js
@@ -66,6 +66,7 @@ import {gltfViewer} from './3d-gltf/index';
 import {mathml} from './mathml';
 import {reddit} from './reddit';
 import {twitter} from './twitter';
+import {viqeoplayer} from './viqeoplayer';
 import {yotpo} from './yotpo';
 
 import {_ping_} from '../ads/_ping_';
@@ -441,6 +442,7 @@ register('uzou', uzou);
 register('valuecommerce', valuecommerce);
 register('videointelligence', videointelligence);
 register('videonow', videonow);
+register('viqeoplayer', viqeoplayer);
 register('viralize', viralize);
 register('vmfive', vmfive);
 register('webediads', webediads);

--- a/3p/viqeoplayer.js
+++ b/3p/viqeoplayer.js
@@ -1,0 +1,196 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {assertAbsoluteHttpOrHttpsUrl, tryDecodeUriComponent} from '../src/url';
+import {getData} from '../src/event-helper';
+import {loadScript} from './3p';
+import {parseJson} from '../src/json';
+import {setStyles} from '../src/style';
+
+/**
+ * @param {Window} global
+ * @param {boolean} autoplay
+ * @param {Object} VIQEO
+ * @param  {function(Object)} VIQEO.getPlayers - returns viqeo player
+ * @param {function(function(Object), Object)} VIQEO.subscribeTracking - subscriber
+ * @private
+ */
+function viqeoPlayerInitLoaded(global, autoplay, VIQEO) {
+  let viqeoPlayerInstance;
+  global.addEventListener('message', parseMessage, false);
+
+  subscribe('added', 'ready', () => {
+    const players = VIQEO['getPlayers']({container: 'stdPlayer'});
+    viqeoPlayerInstance = players && players[0];
+  });
+  subscribe('started', 'started', () => {
+    // if autoplay is off then player will be paused as it just has been started
+    !autoplay && viqeoPlayerInstance && viqeoPlayerInstance.pause();
+  });
+  subscribe('paused', 'pause');
+  subscribe('played', 'play');
+  subscribe('replayed', 'play');
+  subscribeTracking({
+    Mute: 'mute',
+    Unmute: 'unmute',
+  });
+
+  /**
+   * Subscribe on viqeo's events
+   * @param {string} playerEventName
+   * @param {string} targetEventName
+   * @param {function()|undefined|null} extraHandler
+   * @private
+   */
+  function subscribe(playerEventName, targetEventName, extraHandler = null) {
+    VIQEO['subscribeTracking'](
+        () => {
+          sendMessage(targetEventName);
+          if (extraHandler) {
+            extraHandler();
+          }
+        },
+        {eventName: `Player:${playerEventName}`, container: 'stdPlayer'}
+    );
+  }
+
+  /**
+   * Subscribe viqeo's tracking
+   * @param {Object.<string, string>} eventsDescription
+   * @private
+   */
+  function subscribeTracking(eventsDescription) {
+    VIQEO['subscribeTracking'](params => {
+      const name = params && params['trackingParams'] &&
+          params['trackingParams'].name;
+      const targetEventName = eventsDescription[name];
+      sendMessage(targetEventName);
+    }, 'Player:userAction');
+  }
+
+  const sendMessage = (eventName, value = null) => {
+    const {parent} = global;
+    const message = /** @type {JsonObject} */({
+      source: 'ViqeoPlayer',
+      action: eventName,
+      value,
+    });
+    parent./*OK*/postMessage(message, '*');
+  };
+
+  /**
+   * Parse events data for viqeo
+   * @param {!Event|{data: !JsonObject}} event
+   */
+  function parseMessage(event) {
+    const eventData = getData(event);
+    const action = eventData['action'];
+    if (!action) {
+      return;
+    }
+    if (action === 'play') {
+      viqeoPlayerInstance.play();
+    } else if (action === 'pause') {
+      viqeoPlayerInstance.pause();
+    } else if (action === 'stop') {
+      viqeoPlayerInstance.stop();
+    } else if (action === 'mute') {
+      viqeoPlayerInstance.setVolume(0);
+    } else if (action === 'unmute') {
+      viqeoPlayerInstance.setVolume(1);
+    }
+  }
+}
+
+/**
+ * Prepare and return viqeo instance
+ * @param {!Window} global
+ */
+export function viqeoplayer(global) {
+  const data = getData(global.context);
+  let autoplay = false;
+  try {
+    autoplay = parseJson(global.name)['attributes']._context['autoplay'];
+  } catch (e) {
+    // do nothing
+  }
+  const videoId = data['videoid'];
+  const profileId = data['profileid'];
+
+  const markTagsAdvancedParams = data['tag-settings'];
+
+  const kindIsProd = data['data-kind'] !== 'stage';
+
+  let scriptPlayerInit = data['script-url'];
+  scriptPlayerInit =
+      (scriptPlayerInit
+          && tryDecodeUriComponent(scriptPlayerInit)
+      )
+      ||
+      (kindIsProd
+        ? 'https://cdn.viqeo.tv/js/vq_player_init.js?amp=true'
+        : 'https://static.viqeo.tv/js/vq_player_init.js?branch=dev1&amp=true'
+      );
+  // embed preview url
+  let previewUrl = data['player-url'];
+  previewUrl =
+      (previewUrl
+          && previewUrl.length && decodeURI(previewUrl)
+      )
+      || (kindIsProd ? 'https://cdn.viqeo.tv/embed' : 'https://stage.embed.viqeo.tv');
+
+  // Create preview iframe source path
+  previewUrl = assertAbsoluteHttpOrHttpsUrl(
+      `${previewUrl}/?vid=${videoId}&amp=true`);
+
+  const doc = global.document;
+  const mark = doc.createElement('div');
+
+  const markTagsStyle = Object.assign({
+    position: 'relative',
+    width: '100%',
+    height: '0',
+    paddingBottom: '100%',
+  }, markTagsAdvancedParams);
+
+  setStyles(mark, markTagsStyle);
+
+  mark.setAttribute('data-vnd', videoId);
+  mark.setAttribute('data-profile', profileId);
+  mark.classList.add('viqeo-embed');
+
+  const iframe = doc.createElement('iframe');
+
+  iframe.setAttribute('width', '100%');
+  iframe.setAttribute('height', '100%');
+  iframe.setAttribute('style', 'position: absolute');
+  iframe.setAttribute('frameBorder', '0');
+  iframe.setAttribute('allowFullScreen', '');
+  iframe.src = previewUrl;
+
+  mark.appendChild(iframe);
+
+  doc.getElementById('c').appendChild(mark);
+
+  loadScript(global, scriptPlayerInit, () => {
+    if (!global['VIQEO']) {
+      global['onViqeoLoad'] =
+        viqeoPlayerInitLoaded.bind(null, global, autoplay);
+    } else {
+      viqeoPlayerInitLoaded(global, autoplay, global['VIQEO']);
+    }
+  });
+}

--- a/build-system/dep-check-config.js
+++ b/build-system/dep-check-config.js
@@ -128,6 +128,7 @@ exports.rules = [
       '3p/messaging.js->src/event-helper.js',
       '3p/bodymovinanimation.js->src/event-helper.js',
       '3p/iframe-messaging-client.js->src/event-helper.js',
+      '3p/viqeoplayer.js->src/event-helper.js',
     ],
   },
   {
@@ -209,6 +210,8 @@ exports.rules = [
       'extensions/amp-ooyala-player/0.1/amp-ooyala-player.js->' +
           'src/service/video-manager-impl.js',
       'extensions/amp-youtube/0.1/amp-youtube.js->' +
+          'src/service/video-manager-impl.js',
+      'extensions/amp-viqeo-player/0.1/amp-viqeo-player.js->' +
           'src/service/video-manager-impl.js',
       'extensions/amp-brightcove/0.1/amp-brightcove.js->' +
           'src/service/video-manager-impl.js',

--- a/bundles.config.js
+++ b/bundles.config.js
@@ -366,6 +366,7 @@ exports.extensionBundles = [
     },
     type: TYPES.MISC,
   },
+  {name: 'amp-viqeo-player', version: '0.1', type: TYPES.MEDIA},
   {name: 'amp-vk', version: '0.1', type: TYPES.MISC},
   {name: 'amp-yotpo', version: '0.1', type: TYPES.MISC},
   {name: 'amp-youtube', version: '0.1', type: TYPES.MEDIA},

--- a/examples/viqeo.amp.html
+++ b/examples/viqeo.amp.html
@@ -1,0 +1,96 @@
+<!--
+  Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS-IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the license.
+-->
+<!doctype html>
+<html ⚡>
+<head>
+    <meta charset="utf-8">
+    <title>Viqeo examples</title>
+    <link rel="canonical" href="amps.html">
+    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+    <link href="https://fonts.googleapis.com/css?family=Questrial" rel="stylesheet" type="text/css">
+    <script async custom-element="amp-viqeo-player" data-amp-report-test="amp-viqeo-player" src="https://cdn.ampproject.org/v0/amp-viqeo-player-0.1.js"></script>
+    <style amp-custom>
+        body {
+            max-width: 527px;
+            font-family: 'Questrial', Arial;
+        }
+        [fallback] {
+            display: block;
+            /* @alternative */ display: flex;
+            flex-direction: column;
+            flex-wrap: nowrap;
+            justify-content: center;
+            align-items: center;
+            background: rgba(0, 0, 0, 0.5);
+            color: #fff;
+        }
+        .spacer {
+            height: 100vh;
+        }
+        p, h1, h2, h3 {
+            padding: 10px;
+        }
+    </style>
+    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+    <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+
+<h1>amp-viqeo-player</h1>
+<amp-viqeo-player
+        id="myVideo"
+        width="640"
+        height="400"
+        data-profileid="184"
+        data-tag-settings="paddingBottom:57%"
+        data-videoid="922d04f30b66f1a32eb2"
+        layout="responsive"
+        autoplay>
+</amp-viqeo-player>
+
+<h3>Actions</h3>
+<button on="tap:myVideo.play">Play</button>
+<button on="tap:myVideo.pause">Pause</button>
+<button on="tap:myVideo.mute">Mute</button>
+<button on="tap:myVideo.unmute">Unmute</button>
+<button on="tap:myVideo.fullscreen">Fullscreen</button>
+
+<h2>Autoplay</h2>
+<amp-viqeo-player
+        width="640"
+        height="400"
+        data-profileid="184"
+        data-tag-settings="paddingBottom:57%"
+        data-videoid="922d04f30b66f1a32eb2"
+        layout="responsive"
+        autoplay>
+</amp-viqeo-player>
+
+<h2>Without autoplay</h2>
+<amp-viqeo-player
+        width="640"
+        height="400"
+        data-profileid="184"
+        data-tag-settings="paddingBottom:57%"
+        data-videoid="922d04f30b66f1a32eb2"
+        layout="responsive"
+        rotate-to-fullscreen>
+</amp-viqeo-player>
+
+<div class="spacer"></div>
+
+</body>
+</html>

--- a/extensions/amp-viqeo-player/0.1/amp-viqeo-player.js
+++ b/extensions/amp-viqeo-player/0.1/amp-viqeo-player.js
@@ -1,0 +1,316 @@
+/* eslint-disable no-unused-vars */
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Deferred} from '../../../src/utils/promise';
+import {Layout, isLayoutSizeDefined} from '../../../src/layout';
+import {Services} from '../../../src/services';
+import {VideoAttributes, VideoEvents} from '../../../src/video-interface';
+
+import {dev, user} from '../../../src/log';
+import {fullscreenEnter, fullscreenExit, isFullscreenElement, removeElement} from '../../../src/dom';
+import {getData, listen} from '../../../src/event-helper';
+import {getIframe} from '../../../src/3p-frame';
+import {installVideoManagerForDoc} from '../../../src/service/video-manager-impl';
+
+/**
+ * @implements {../../../src/video-interface.VideoInterface}
+ */
+class AmpViqeoPlayer extends AMP.BaseElement {
+
+  /** @param {!AmpElement} element */
+  constructor(element) {
+    super(element);
+
+    /** @private {?HTMLIFrameElement} */
+    this.iframe_ = null;
+
+    /** @private {?Promise} */
+    this.playerReadyPromise_ = null;
+
+    /** @private {?Function} */
+    this.playerReadyResolver_ = null;
+
+    /** @private {?number} */
+    this.volume_ = null;
+
+    /** @private {?Function} */
+    this.unlistenMessage_ = null;
+
+    /** @private {?Object} */
+    this.viqeoPlayer_ = null;
+
+    /** @private {boolean} */
+    this.hasAutoplay_ = false;
+  }
+
+  /**
+   * @param {boolean=} opt_onLayout
+   * @override
+   */
+  preconnectCallback(opt_onLayout) {
+    this.preconnect.url('https://static.viqeo.tv', opt_onLayout);
+    this.preconnect.url('https://stage.embed.viqeo.tv', opt_onLayout);
+  }
+
+  /**
+   * @param {!Layout} layout
+   * @return {boolean}
+   * @override
+   */
+  isLayoutSupported(layout) {
+    return isLayoutSizeDefined(layout);
+  }
+
+  /** @override */
+  buildCallback() {
+
+    user().assert(
+        this.element.getAttribute('data-videoid'),
+        'The data-videoid attribute is required for <amp-viqeo-player> %s',
+        this.element);
+
+    user().assert(
+        this.element.getAttribute('data-profileid'),
+        'The data-profileid attribute is required for <amp-viqeo-player> %s',
+        this.element);
+
+    this.hasAutoplay_ = this.element.hasAttribute(VideoAttributes.AUTOPLAY);
+
+    const deferred = new Deferred();
+    this.playerReadyPromise_ = deferred.promise;
+    this.playerReadyResolver_ = deferred.resolve;
+
+    installVideoManagerForDoc(this.element);
+    Services.videoManagerForDoc(this.element).register(this);
+  }
+
+  /** @override */
+  layoutCallback() {
+
+    const iframe = getIframe(
+        this.win,
+        this.element,
+        'viqeoplayer',
+        {
+          'autoplay': this.hasAutoplay_,
+        },
+        {
+          allowFullscreen: true,
+        });
+
+    // required to display the user gesture in the iframe
+    iframe.setAttribute('allow', 'autoplay');
+
+    this.unlistenMessage_ = listen(
+        this.win,
+        'message',
+        this.handleViqeoMessages_.bind(this)
+    );
+
+    return this.mutateElement(() => {
+      this.element.appendChild(iframe);
+      this.iframe_ = iframe;
+      this.applyFillContent(iframe);
+    }).then(() => {
+      return this.playerReadyPromise_;
+    });
+  }
+
+  /**
+   * @param {!Event|{data: !JsonObject}} event
+   * @return {?JsonObject|string|undefined}
+   * @private
+   * */
+  handleViqeoMessages_(event) {
+    const eventData = getData(event);
+    if (!eventData ||
+        event.source !== (this.iframe_ && this.iframe_.contentWindow) ||
+        eventData['source'] !== 'ViqeoPlayer') {
+      return;
+    }
+
+    const action = eventData['action'];
+    if (action === 'ready') {
+      this.element.dispatchCustomEvent(VideoEvents.LOAD);
+      this.playerReadyResolver_(this.iframe_);
+    } else if (action === 'play') {
+      this.element.dispatchCustomEvent(VideoEvents.PLAYING);
+    } else if (action === 'pause') {
+      this.element.dispatchCustomEvent(VideoEvents.PAUSE);
+    } else if (action === 'mute') {
+      this.element.dispatchCustomEvent(VideoEvents.MUTED);
+    } else if (action === 'unmute') {
+      this.element.dispatchCustomEvent(VideoEvents.UNMUTED);
+    } else if (action === 'volume') {
+      this.volume_ = parseFloat(eventData['value']);
+      if (this.volume_ === 0) {
+        this.element.dispatchCustomEvent(VideoEvents.MUTED);
+      } else {
+        this.element.dispatchCustomEvent(VideoEvents.UNMUTED);
+      }
+    }
+  }
+
+  /** @override */
+  unlayoutCallback() {
+    if (this.iframe_) {
+      removeElement(this.iframe_);
+      this.iframe_ = null;
+    }
+    if (this.unlistenMessage_) {
+      this.unlistenMessage_();
+    }
+
+    const deferred = new Deferred();
+    this.playerReadyPromise_ = deferred.promise;
+    this.playerReadyResolver_ = deferred.resolve;
+    return true; // Call layoutCallback again.
+  }
+
+  /** @override */
+  supportsPlatform() {
+    return true;
+  }
+
+  /** @override */
+  isInteractive() {
+    return true;
+  }
+
+  /** @override */
+  play() {
+    this.sendCommand_('play');
+  }
+
+  /** @override */
+  pause() {
+    this.sendCommand_('pause');
+  }
+
+  /** @override */
+  mute() {
+    this.sendCommand_('mute');
+  }
+
+  /** @override */
+  unmute() {
+    this.sendCommand_('unmute');
+  }
+
+  /** @override */
+  showControls() {
+    // Not supported.
+  }
+
+  /** @override */
+  hideControls() {
+    // Not supported.
+  }
+
+  /**
+   * @override
+   */
+  fullscreenEnter() {
+    if (!this.iframe_) {
+      return;
+    }
+    fullscreenEnter(dev().assertElement(this.iframe_));
+  }
+
+  /**
+   * @override
+   */
+  fullscreenExit() {
+    if (!this.iframe_) {
+      return;
+    }
+    fullscreenExit(dev().assertElement(this.iframe_));
+  }
+
+  /** @override */
+  isFullscreen() {
+    if (!this.iframe_) {
+      return false;
+    }
+    return isFullscreenElement(dev().assertElement(this.iframe_));
+  }
+
+  /** @override */
+  getMetadata() {
+    // Not implemented
+  }
+
+  /** @override */
+  preimplementsMediaSessionAPI() {
+    return false;
+  }
+
+  /** @override */
+  preimplementsAutoFullscreen() {
+    return false;
+  }
+
+  /** @override */
+  getCurrentTime() {
+    if (!this.viqeoPlayer_) {
+      return 0;
+    }
+    return this.viqeoPlayer_.getCurrentTime();
+  }
+
+  /** @override */
+  getDuration() {
+    if (!this.viqeoPlayer_) {
+      return 1;
+    }
+    return this.viqeoPlayer_.getDuration();
+  }
+
+  /** @override */
+  getPlayedRanges() {
+    // Not supported.
+    return [];
+  }
+
+  /**
+   * Sends a command to the player
+   * @param {string|JsonObject} command
+   * @private
+   */
+  sendCommand_(command) {
+    if (!this.iframe_) {
+      return;
+    }
+    const {contentWindow} = this.iframe_;
+    if (!contentWindow) {
+      return;
+    }
+
+    if (typeof command === 'string') {
+      command = /** @type {JsonObject} */ ({
+        action: command,
+      });
+    }
+    contentWindow./*OK*/postMessage(command, '*');
+  }
+}
+
+AMP.extension('amp-viqeo-player', '0.1', AMP => {
+  AMP.registerElement('amp-viqeo-player', AmpViqeoPlayer);
+});
+
+export default AmpViqeoPlayer;

--- a/extensions/amp-viqeo-player/0.1/test/test-amp-viqeo-player.js
+++ b/extensions/amp-viqeo-player/0.1/test/test-amp-viqeo-player.js
@@ -1,0 +1,137 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {PlayingStates} from '../../../../src/video-interface';
+import {Services} from '../../../../src/services';
+import AmpViqeoPlayer from '../amp-viqeo-player';
+
+describes.realWin('amp-viqeo-player', {
+  amp: {
+    extensions: ['amp-viqeo-player'],
+  },
+  allowExternalResources: true,
+}, function(env) {
+  this.timeout(4000);
+  let win, doc;
+
+  beforeEach(() => {
+    win = env.win;
+    doc = win.document;
+  });
+
+  it.skip('test-get-data', () => {
+    return getViqeo().then(p => {
+      const {viqeoElement, entry, viqeo} = p;
+      expect(entry.video.element).to.equal(viqeoElement);
+      expect(entry.video instanceof AmpViqeoPlayer).to.equal(true);
+      expect(entry.video).to.equal(viqeo);
+      expect(viqeo instanceof AmpViqeoPlayer).to.equal(true);
+    });
+  });
+
+  describe('test-requires-attributes', () => {
+    it('requires data-videoid', () => {
+      const error = /The data-videoid attribute is required for/;
+      expectAsyncConsoleError(error);
+      return getViqeo({viqeoId: null}).should.eventually.be.rejectedWith(error);
+    });
+
+    it('requires data-profileid', () => {
+      const error = /The data-profileid attribute is required for/;
+      expectAsyncConsoleError(error);
+      return getViqeo({viqeoProfileId: null}).should.eventually.be
+          .rejectedWith(error);
+    });
+  });
+
+  describe.skip('test-playing-actions', () => {
+    it('renders responsively', () => {
+      return getViqeo().then(p => {
+        const iframe = p.viqeoElement.querySelector('iframe');
+        expect(iframe).to.not.be.null;
+        expect(iframe.className).to.match(/i-amphtml-fill-content/);
+      });
+    });
+
+    it('should propagate autoplay to ad iframe', () => {
+      return getViqeo({opt_params: {autoplay: ''}}).then(p => {
+        const iframe = p.viqeoElement.querySelector('iframe');
+        const data = JSON.parse(iframe.name).attributes;
+        expect(data).to.be.ok;
+        expect(data._context).to.be.ok;
+        expect(data._context.autoplay).to.equal(true);
+      });
+    });
+
+    it('should propagate autoplay=false ' +
+      'if element has not autoplay attribute to ad iframe', () => {
+      return getViqeo().then(p => {
+        const iframe = p.viqeoElement.querySelector('iframe');
+        const data = JSON.parse(iframe.name).attributes;
+        expect(data).to.be.ok;
+        expect(data._context).to.be.ok;
+        return expect(data._context.autoplay).to.equal(false);
+      });
+    });
+
+    it('should paused without autoplay', () => {
+      return getViqeo().then(p => {
+        const curState = p.videoManager.getPlayingState(p.viqeo);
+        return expect(curState).to.equal(PlayingStates.PAUSED);
+      });
+    });
+
+  });
+
+  function getViqeo(params) {
+    const {id, viqeoProfileId, viqeoId, width, height, opt_params} =
+      Object.assign({
+        id: 'myVideo',
+        viqeoProfileId: 184,
+        viqeoId: '922d04f30b66f1a32eb2',
+        width: 320,
+        height: 180,
+        opt_params: {},
+      }, params);
+
+    const viqeoElement = doc.createElement('amp-viqeo-player');
+
+    id && viqeoElement.setAttribute('id', id);
+    viqeoProfileId
+      && viqeoElement.setAttribute('data-profileid', viqeoProfileId);
+
+    viqeoId && viqeoElement.setAttribute('data-videoid', viqeoId);
+
+    width && viqeoElement.setAttribute('width', width);
+    height && viqeoElement.setAttribute('height', height);
+
+    opt_params && Object.keys(opt_params).forEach(key => {
+      viqeoElement.setAttribute(key, opt_params[key]);
+    });
+
+    doc.body.appendChild(viqeoElement);
+    return viqeoElement.build()
+        .then(viqeoElement.layoutCallback.bind(viqeoElement))
+        .then(() => {
+          const videoManager =
+            Services.videoManagerForDoc(doc);
+          const entry = videoManager.getEntryForElement_(viqeoElement);
+          return Promise.resolve(
+              {viqeoElement, videoManager, entry, viqeo: entry.video}
+          );
+        });
+  }
+});

--- a/extensions/amp-viqeo-player/0.1/test/validator-amp-viqeo-player.html
+++ b/extensions/amp-viqeo-player/0.1/test/validator-amp-viqeo-player.html
@@ -13,6 +13,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
+<!--
+  Test Description:
+  This tests validation for the amp-viqeo-player tag.
+-->
 <!doctype html>
 <html ⚡>
 <head>
@@ -28,6 +32,22 @@ limitations under the License.
 <amp-viqeo-player
         data-profileid="184"
         data-videoid="b51b70cdbb06248f4438"
+        width="640"
+        height="400"
+        layout="responsive"
+        autoplay>
+</amp-viqeo-player>
+<!-- not valid: the mandatory attribute 'data-profileid' is missing in tag -->
+<amp-viqeo-player
+        data-videoid="b51b70cdbb06248f4438"
+        width="640"
+        height="400"
+        layout="responsive"
+        autoplay>
+</amp-viqeo-player>
+<!-- not valid: the mandatory attribute 'data-videoid' is missing in tag -->
+<amp-viqeo-player
+        data-profileid="184"
         width="640"
         height="400"
         layout="responsive"

--- a/extensions/amp-viqeo-player/0.1/test/validator-amp-viqeo-player.html
+++ b/extensions/amp-viqeo-player/0.1/test/validator-amp-viqeo-player.html
@@ -1,0 +1,37 @@
+<!---
+Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS-IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<!doctype html>
+<html ⚡>
+<head>
+    <meta charset="utf-8">
+    <link rel="canonical" href="amps.html">
+    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+    <script async custom-element="amp-viqeo-player" src="https://cdn.ampproject.org/v0/amp-viqeo-player-0.1.js"></script>
+    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+    <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+<!-- valid -->
+<amp-viqeo-player
+        data-profileid="184"
+        data-videoid="b51b70cdbb06248f4438"
+        width="640"
+        height="400"
+        layout="responsive"
+        autoplay>
+</amp-viqeo-player>
+</body>
+</html>

--- a/extensions/amp-viqeo-player/0.1/test/validator-amp-viqeo-player.out
+++ b/extensions/amp-viqeo-player/0.1/test/validator-amp-viqeo-player.out
@@ -1,0 +1,38 @@
+PASS
+|  <!---
+|  Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+|  
+|  Licensed under the Apache License, Version 2.0 (the "License");
+|  you may not use this file except in compliance with the License.
+|  You may obtain a copy of the License at
+|  
+|        http://www.apache.org/licenses/LICENSE-2.0
+|  
+|  Unless required by applicable law or agreed to in writing, software
+|  distributed under the License is distributed on an "AS-IS" BASIS,
+|  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|  See the License for the specific language governing permissions and
+|  limitations under the License.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|      <meta charset="utf-8">
+|      <link rel="canonical" href="amps.html">
+|      <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+|      <script async custom-element="amp-viqeo-player" src="https://cdn.ampproject.org/v0/amp-viqeo-player-0.1.js"></script>
+|      <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|      <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|  <body>
+|  <!-- valid -->
+|  <amp-viqeo-player
+|          data-profileid="184"
+|          data-videoid="b51b70cdbb06248f4438"
+|          width="640"
+|          height="400"
+|          layout="responsive"
+|          autoplay>
+|  </amp-viqeo-player>
+|  </body>
+|  </html>

--- a/extensions/amp-viqeo-player/0.1/test/validator-amp-viqeo-player.out
+++ b/extensions/amp-viqeo-player/0.1/test/validator-amp-viqeo-player.out
@@ -1,18 +1,22 @@
-PASS
+FAIL
 |  <!---
 |  Copyright 2018 The AMP HTML Authors. All Rights Reserved.
-|  
+|
 |  Licensed under the Apache License, Version 2.0 (the "License");
 |  you may not use this file except in compliance with the License.
 |  You may obtain a copy of the License at
-|  
+|
 |        http://www.apache.org/licenses/LICENSE-2.0
-|  
+|
 |  Unless required by applicable law or agreed to in writing, software
 |  distributed under the License is distributed on an "AS-IS" BASIS,
 |  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 |  See the License for the specific language governing permissions and
 |  limitations under the License.
+|  -->
+|  <!--
+|    Test Description:
+|    This tests validation for the amp-viqeo-player tag.
 |  -->
 |  <!doctype html>
 |  <html ⚡>
@@ -29,6 +33,26 @@ PASS
 |  <amp-viqeo-player
 |          data-profileid="184"
 |          data-videoid="b51b70cdbb06248f4438"
+|          width="640"
+|          height="400"
+|          layout="responsive"
+|          autoplay>
+|  </amp-viqeo-player>
+|  <!-- not valid: the mandatory attribute 'data-profileid' is missing in tag -->
+|  <amp-viqeo-player
+>> ^~~~~~~~~
+amp-viqeo-player/0.1/test/validator-amp-viqeo-player.html:41:0 The mandatory attribute 'data-profileid' is missing in tag 'amp-viqeo-player'. (see https://www.ampproject.org/docs/reference/components/amp-viqeo-player) [AMP_TAG_PROBLEM]
+|          data-videoid="b51b70cdbb06248f4438"
+|          width="640"
+|          height="400"
+|          layout="responsive"
+|          autoplay>
+|  </amp-viqeo-player>
+|  <!-- not valid: the mandatory attribute 'data-videoid' is missing in tag -->
+|  <amp-viqeo-player
+>> ^~~~~~~~~
+amp-viqeo-player/0.1/test/validator-amp-viqeo-player.html:49:0 The mandatory attribute 'data-videoid' is missing in tag 'amp-viqeo-player'. (see https://www.ampproject.org/docs/reference/components/amp-viqeo-player) [AMP_TAG_PROBLEM]
+|          data-profileid="184"
 |          width="640"
 |          height="400"
 |          layout="responsive"

--- a/extensions/amp-viqeo-player/OWNERS.yaml
+++ b/extensions/amp-viqeo-player/OWNERS.yaml
@@ -1,0 +1,1 @@
+- viqeo.tv

--- a/extensions/amp-viqeo-player/amp-viqeo-player.md
+++ b/extensions/amp-viqeo-player/amp-viqeo-player.md
@@ -1,0 +1,85 @@
+<!---
+Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS-IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# <a name="amp-viqeo-player"></a> `amp-viqeo-player`
+
+<table>
+  <tr>
+    <td width="40%"><strong>Description</strong></td>
+    <td>Displays a <a href="https://viqeo.tv/">Viqeo</a> video player.</td>
+  </tr>
+  <tr>
+    <td width="40%"><strong>Required Script</strong></td>
+    <td><code>&lt;script async custom-element="amp-viqeo-player" src="https://cdn.ampproject.org/v0/amp-viqeo-player-0.1.js">&lt;/script></code></td>
+  </tr>
+  <tr>
+    <td class="col-fourty"><strong><a href="https://www.ampproject.org/docs/guides/responsive/control_layout.html">Supported Layouts</a></strong></td>
+    <td>fill, fixed, fixed-height, flex-item, responsive</td>
+  </tr>
+  <tr>
+    <td class="col-fourty"><strong>Examples</strong></td>
+    <td>
+    <ul>
+    <li>Viqeo WordPress embedding demo: <a href="http://demo.viqeo.tv/2018/04/04/%D0%BF%D0%BE%D0%B4%D0%B2%D0%BE%D0%B4%D0%BD%D1%8B%D0%B9-%D1%81%D0%BA%D1%83%D1%82%D0%B5%D1%80-%D0%B4%D0%BB%D1%8F-%D0%B4%D0%B0%D0%B9%D0%B2%D0%B8%D0%BD%D0%B3%D0%B0-%D0%BA%D0%BE%D1%82%D0%BE%D1%80%D1%8B-2/">Aqua Scooter</a></li>
+    <li>The-Village: <a href="https://www.the-village.ru/village/food/place/316257-mesto">Pizza Resto Review</a></li>
+    <li>Kanobu.ru: <a href="https://kanobu.ru/reviews/retsenziya-na-deadpool-372034/">Deadpool game review</a></li>
+    </ul>
+    </td>
+  </tr>
+</table>
+
+[TOC]
+
+## Example
+
+The `width` and `height` attributes determine the aspect ratio of the Viqeo embedded in responsive layouts.
+
+```html
+<amp-viqeo-player
+    data-profileid="184"
+    data-videoid="b51b70cdbb06248f4438"
+    width="640"
+    height="360"
+    layout="responsive">
+</amp-viqeo-player>
+```
+
+## Attributes
+
+##### autoplay
+
+If this attribute is present, and the browser supports autoplay:
+
+* the video is automatically muted before autoplay starts
+* when the video is scrolled out of view, the video is paused
+* when the video is scrolled into view, the video resumes playback
+* when the user taps the video, the video is unmuted
+* if the user has interacted with the video (e.g., mutes/unmutes, pauses/resumes, etc.), and the video is scrolled in or out of view, the state of the video remains as how the user left it.  For example, if the user pauses the video, then scrolls the video out of view and returns to the video, the video is still paused.
+
+##### data-profileid
+
+Viqeo is a registration only video platform for Publishers to add videos as illustrations. All videos are played automaticaly without sound and only when fully visible (minimum visible area possible is 50%).
+Detailed description of Viqeo is in presentation: https://docs.google.com/presentation/d/1P6DJTPJtfeMmPozv1pPz7Wner7NCcJ_DmlPOcVclgLE/present?slide=id.p
+
+To get data-profileid you need to login to Viqeo account (https://viqeo.tv) and press 'Get code' near the video you want to paste to website. You will get a code with data-profileid, data-videoid & width and height.
+
+##### data-videoid
+
+The identifier of the video. All videos have unique id, and can be found in Viqeo account after authorisation. Viqeo do not let embed videos by 3rd party websites so only one way to get a data-videoid and other attributes to sign in to Viqeo account.
+
+##### width and height
+
+The width and height attributes are special for the Viqeo embed. Viqeo supports any proportions of videos. Basically Viqeo generates an unique code for each video depending on video size and proportions, but Viqeo user may change proportions in interface. Anyway after pressing 'Get code' button an unique code will be generated.

--- a/extensions/amp-viqeo-player/validator-amp-viqeo-player.protoascii
+++ b/extensions/amp-viqeo-player/validator-amp-viqeo-player.protoascii
@@ -19,8 +19,8 @@ tags: {  # amp-viqeo-player
   tag_name: "SCRIPT"
   extension_spec: {
     name: "amp-viqeo-player"
-    allowed_versions: "0.1"
-    allowed_versions: "latest"
+    version: "0.1"
+    version: "latest"
   }
   attr_lists: "common-extension-attrs"
 }

--- a/extensions/amp-viqeo-player/validator-amp-viqeo-player.protoascii
+++ b/extensions/amp-viqeo-player/validator-amp-viqeo-player.protoascii
@@ -1,0 +1,50 @@
+#
+# Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the license.
+#
+
+tags: {  # amp-viqeo-player
+  html_format: AMP
+  tag_name: "SCRIPT"
+  extension_spec: {
+    name: "amp-viqeo-player"
+    allowed_versions: "0.1"
+    allowed_versions: "latest"
+  }
+  attr_lists: "common-extension-attrs"
+}
+
+tags: {  # <amp-viqeo-player>
+  html_format: AMP
+  tag_name: "AMP-VIQEO-PLAYER"
+  requires_extension: "amp-viqeo-player"
+  attrs: { name: "autoplay" }
+  attrs: {
+    name: "data-profileid"
+    value_regex: "[0-9a-f]*"
+    mandatory: true
+  }
+  attrs: {
+    name: "data-videoid"
+    mandatory: true
+  }
+  attr_lists: "extended-amp-global"
+  amp_layout: {
+    supported_layouts: FILL
+    supported_layouts: FIXED
+    supported_layouts: FIXED_HEIGHT
+    supported_layouts: FLEX_ITEM
+    supported_layouts: RESPONSIVE
+  }
+}


### PR DESCRIPTION
A Viqeo tag is a autoplayed video without sound with specified width and height and may be done in a fixed size or as responsive iframe.

Viqeo is registration only video platform for Publishers, that's why it has no Public Access and iframe-sharing options. 

To get amp-tag with attributes such as data-profileid, data-videoid, width and height Publisher has to sign in to https://viqeo.tv and get a code in interface or via API.

The good examples of Viqeo implementation can be found here:
 - https://www.the-village.ru/village/food/place/316257-mesto
 - https://kanobu.ru/reviews/retsenziya-na-deadpool-372034/

from https://github.com/ampproject/amphtml/pull/15348