### PR TITLE
Fix bugs in Layers

### DIFF
--- a/src/service/layers-impl.js
+++ b/src/service/layers-impl.js
@@ -227,7 +227,8 @@ export class LayoutLayers {
    */
   getScrolledPosition(element, opt_ancestor) {
     const layout = this.add(element);
-    return layout.getScrolledPosition(opt_ancestor);
+    const pos = layout.getScrolledPosition(opt_ancestor);
+    return positionLt(Math.round(pos.left), Math.round(pos.top));
   }
 
   /**
@@ -242,7 +243,8 @@ export class LayoutLayers {
    */
   getOffsetPosition(element, opt_ancestor) {
     const layout = this.add(element);
-    return layout.getOffsetPosition(opt_ancestor);
+    const pos = layout.getOffsetPosition(opt_ancestor);
+    return positionLt(Math.round(pos.left), Math.round(pos.top));
   }
 
   /**
@@ -253,7 +255,8 @@ export class LayoutLayers {
    */
   getSize(element) {
     const layout = this.add(element);
-    return layout.getSize();
+    const size = layout.getSize();
+    return sizeWh(Math.round(size.width), Math.round(size.height));
   }
 
   /**

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -780,7 +780,7 @@ export class Resource {
    * calculation based on tree depth and number of layer scrolls it would take
    * to view the element.
    *
-   * @param {number} currentScore
+   * @param {number|undefined} currentScore
    * @param {!./layers-impl.LayoutElement} layout
    * @param {number} depth
    * @return {number}

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -786,6 +786,7 @@ export class Resource {
    * @return {number}
    */
   layersDistanceRatio_(currentScore, layout, depth) {
+    currentScore = currentScore || 0;
     const depthPenalty = 1 + (depth / 10);
     const nonActivePenalty = layout.isActiveUnsafe() ? 1 : 2;
     const distance = layout.getHorizontalViewportsFromParent() +

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -242,7 +242,7 @@ export class Resources {
         this.schedulePass();
       });
 
-      /** @private @const {function(number|undefined, !./layers-impl.LayoutElement, number, !Object<string, *>):number} */
+      /** @private @const {function((number|undefined), !./layers-impl.LayoutElement, number, !Object<string, *>):number} */
       this.boundCalcLayoutScore_ = this.calcLayoutScore_.bind(this);
     }
 

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -242,7 +242,7 @@ export class Resources {
         this.schedulePass();
       });
 
-      /** @private @const {function(number, !./layers-impl.LayoutElement, number, !Object<string, *>):number} */
+      /** @private @const {function(number|undefined, !./layers-impl.LayoutElement, number, !Object<string, *>):number} */
       this.boundCalcLayoutScore_ = this.calcLayoutScore_.bind(this);
     }
 
@@ -1783,7 +1783,7 @@ export class Resources {
    * Calculates the layout's distance from viewport score, using an iterative
    * (and cacheable) calculation based on tree depth and distance.
    *
-   * @param {number} currentScore
+   * @param {number|undefined} currentScore
    * @param {!./layers-impl.LayoutElement} layout
    * @param {number} depth
    * @param {!Object<string, *>} cache


### PR DESCRIPTION
Two bugs spotted in Layers during the transition verifications:

- `iterateAncestry` passes `undefined` as the initial value
  - This was causing the math operations to return `NaN`
- The size/position APIs returned fractional pixel values.
  - Resources returns whole numbers.