### PR TITLE
Add controls option to <amp-pan-zoom>

### DIFF
--- a/extensions/amp-pan-zoom/0.1/amp-pan-zoom.css
+++ b/extensions/amp-pan-zoom/0.1/amp-pan-zoom.css
@@ -23,3 +23,23 @@
 .i-amphtml-pan-zoom-child {
   position: absolute;
 }
+
+.i-amphtml-pan-zoom-button {
+  position: absolute;
+  width: 24px;
+  height: 24px;
+  bottom: 12px;
+  background-repeat: no-repeat;
+  background-position: center center;
+}
+
+.i-amphtml-pan-zoom-in-button {
+  right: 12px;
+  background-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"><path d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path fill="none" d="M0 0h24v24H0V0z"/><path d="M12 10h-2v2H9v-2H7V9h2V7h1v2h2v1z"/></svg>');
+}
+
+.i-amphtml-pan-zoom-out-button {
+  position: absolute;
+  right: 36px;
+  background-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"><path fill="none" d="M0 0h24v24H0V0z"/><path d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14zM7 9h5v1H7z"/></svg>');
+}

--- a/extensions/amp-pan-zoom/0.1/amp-pan-zoom.css
+++ b/extensions/amp-pan-zoom/0.1/amp-pan-zoom.css
@@ -26,20 +26,21 @@
 
 .i-amphtml-pan-zoom-button {
   position: absolute;
-  width: 24px;
-  height: 24px;
+  right: 12px;
+  width: 36px;
+  height: 36px;
   bottom: 12px;
   background-repeat: no-repeat;
   background-position: center center;
+  box-shadow: 1px 1px 2px;
+  background-color: white;
+  border-radius: 3px;
 }
 
 .i-amphtml-pan-zoom-in-button {
-  right: 12px;
-  background-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"><path d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path fill="none" d="M0 0h24v24H0V0z"/><path d="M12 10h-2v2H9v-2H7V9h2V7h1v2h2v1z"/></svg>');
+  background-image: url('data:image/svg+xml;charset=utf-8,<svg height="24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6z"/><path d="M0 0h24v24H0z" fill="none"/></svg>');
 }
 
 .i-amphtml-pan-zoom-out-button {
-  position: absolute;
-  right: 36px;
-  background-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"><path fill="none" d="M0 0h24v24H0V0z"/><path d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14zM7 9h5v1H7z"/></svg>');
+  background-image: url('data:image/svg+xml;charset=utf-8,<svg height="24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M19 13H5v-2h14z"/><path d="M0 0h24v24H0z" fill="none"/></svg>');
 }

--- a/extensions/amp-pan-zoom/0.1/amp-pan-zoom.css
+++ b/extensions/amp-pan-zoom/0.1/amp-pan-zoom.css
@@ -24,7 +24,7 @@
   position: absolute;
 }
 
-.i-amphtml-pan-zoom-button {
+.amp-pan-zoom-button {
   position: absolute;
   right: 12px;
   width: 36px;
@@ -37,10 +37,10 @@
   border-radius: 3px;
 }
 
-.i-amphtml-pan-zoom-in-button {
+.amp-pan-zoom-in-icon {
   background-image: url('data:image/svg+xml;charset=utf-8,<svg height="24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6z"/><path d="M0 0h24v24H0z" fill="none"/></svg>');
 }
 
-.i-amphtml-pan-zoom-out-button {
+.amp-pan-zoom-out-icon {
   background-image: url('data:image/svg+xml;charset=utf-8,<svg height="24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M19 13H5v-2h14z"/><path d="M0 0h24v24H0z" fill="none"/></svg>');
 }

--- a/extensions/amp-pan-zoom/0.1/amp-pan-zoom.js
+++ b/extensions/amp-pan-zoom/0.1/amp-pan-zoom.js
@@ -262,9 +262,7 @@ export class AmpPanZoom extends AMP.BaseElement {
         this.zoomButton_.classList.remove('i-amphtml-pan-zoom-out-button');
       }
     });
-    this.mutateElement(() => {
-      this.element.appendChild(this.zoomButton_);
-    });
+    this.element.appendChild(this.zoomButton_);
   }
 
   /**

--- a/extensions/amp-pan-zoom/0.1/amp-pan-zoom.js
+++ b/extensions/amp-pan-zoom/0.1/amp-pan-zoom.js
@@ -168,12 +168,24 @@ export class AmpPanZoom extends AMP.BaseElement {
         return;
       }
       const scale = args['scale'] || 1;
-      this.updatePanZoomBounds_(scale);
-      const x = this.boundX_(args['x'] || 0, /*allowExtent*/ false);
-      const y = this.boundY_(args['y'] || 0, /*allowExtent*/ false);
-      return this.set_(scale, x, y, /*animate*/ true)
-          .then(() => this.onZoomRelease_());
+      const x = args['x'] || 0;
+      const y = args['y'] || 0;
+      return this.transform(x, y, scale);
     });
+  }
+
+  /**
+   *
+   * @param {number} x
+   * @param {number} y
+   * @param {number} scale
+   */
+  transform(x, y, scale) {
+    this.updatePanZoomBounds_(scale);
+    const boundX = this.boundX_(x, /*allowExtent*/ false);
+    const boundY = this.boundY_(y, /*allowExtent*/ false);
+    return this.set_(scale, boundX, boundY, /*animate*/ true)
+        .then(() => this.onZoomRelease_());
   }
 
   /** @override */
@@ -185,6 +197,9 @@ export class AmpPanZoom extends AMP.BaseElement {
 
   /** @override */
   layoutCallback() {
+    if (this.element.hasAttribute('controls')) {
+      this.createZoomButtons_();
+    }
     return this.resetContentDimensions_().then(this.setupGestures_());
   }
 
@@ -224,6 +239,30 @@ export class AmpPanZoom extends AMP.BaseElement {
    */
   elementIsSupported_(element) {
     return ELIGIBLE_TAGS[element.tagName];
+  }
+
+  /**
+   * Creates zoom buttoms
+   */
+  createZoomButtons_() {
+    const zoomInButton = this.element.ownerDocument.createElement('div');
+    zoomInButton.classList.add('i-amphtml-pan-zoom-in-button');
+    zoomInButton.classList.add('i-amphtml-pan-zoom-button');
+    zoomInButton.addEventListener('click', () => {
+      this.transform(0, 0, this.maxScale_);
+    });
+
+    const zoomOutButton = this.element.ownerDocument.createElement('div');
+    zoomOutButton.classList.add('i-amphtml-pan-zoom-out-button');
+    zoomOutButton.classList.add('i-amphtml-pan-zoom-button');
+    zoomOutButton.addEventListener('click', () => {
+      this.transform(0, 0, this.minScale_);
+    });
+
+    this.mutateElement(() => {
+      this.element.appendChild(zoomInButton);
+      this.element.appendChild(zoomOutButton);
+    });
   }
 
   /**

--- a/extensions/amp-pan-zoom/0.1/amp-pan-zoom.js
+++ b/extensions/amp-pan-zoom/0.1/amp-pan-zoom.js
@@ -141,6 +141,9 @@ export class AmpPanZoom extends AMP.BaseElement {
 
     /** @private */
     this.resetOnResize_ = false;
+
+    /** @private {?Element} */
+    this.zoomButton_ = null;
   }
 
   /** @override */
@@ -198,7 +201,7 @@ export class AmpPanZoom extends AMP.BaseElement {
   /** @override */
   layoutCallback() {
     if (this.element.hasAttribute('controls')) {
-      this.createZoomButtons_();
+      this.createZoomButton_();
     }
     return this.resetContentDimensions_().then(this.setupGestures_());
   }
@@ -244,24 +247,23 @@ export class AmpPanZoom extends AMP.BaseElement {
   /**
    * Creates zoom buttoms
    */
-  createZoomButtons_() {
-    const zoomInButton = this.element.ownerDocument.createElement('div');
-    zoomInButton.classList.add('i-amphtml-pan-zoom-in-button');
-    zoomInButton.classList.add('i-amphtml-pan-zoom-button');
-    zoomInButton.addEventListener('click', () => {
-      this.transform(0, 0, this.maxScale_);
+  createZoomButton_() {
+    this.zoomButton_ = this.element.ownerDocument.createElement('div');
+    this.zoomButton_.classList.add('i-amphtml-pan-zoom-in-button');
+    this.zoomButton_.classList.add('i-amphtml-pan-zoom-button');
+    this.zoomButton_.addEventListener('click', () => {
+      if (this.zoomButton_.classList.contains('i-amphtml-pan-zoom-in-button')) {
+        this.transform(0, 0, this.maxScale_);
+        this.zoomButton_.classList.remove('i-amphtml-pan-zoom-in-button');
+        this.zoomButton_.classList.add('i-amphtml-pan-zoom-out-button');
+      } else {
+        this.transform(0, 0, this.minScale_);
+        this.zoomButton_.classList.add('i-amphtml-pan-zoom-in-button');
+        this.zoomButton_.classList.remove('i-amphtml-pan-zoom-out-button');
+      }
     });
-
-    const zoomOutButton = this.element.ownerDocument.createElement('div');
-    zoomOutButton.classList.add('i-amphtml-pan-zoom-out-button');
-    zoomOutButton.classList.add('i-amphtml-pan-zoom-button');
-    zoomOutButton.addEventListener('click', () => {
-      this.transform(0, 0, this.minScale_);
-    });
-
     this.mutateElement(() => {
-      this.element.appendChild(zoomInButton);
-      this.element.appendChild(zoomOutButton);
+      this.element.appendChild(this.zoomButton_);
     });
   }
 
@@ -679,8 +681,12 @@ export class AmpPanZoom extends AMP.BaseElement {
       // After the scale is updated, also register or unregister panning
       if (this.scale_ <= 1) {
         this.unregisterPanningGesture_();
+        this.zoomButton_.classList.add('i-amphtml-pan-zoom-in-button');
+        this.zoomButton_.classList.remove('i-amphtml-pan-zoom-out-button');
       } else {
         this.registerPanningGesture_();
+        this.zoomButton_.classList.remove('i-amphtml-pan-zoom-in-button');
+        this.zoomButton_.classList.add('i-amphtml-pan-zoom-out-button');
       }
     });
   }

--- a/extensions/amp-pan-zoom/0.1/amp-pan-zoom.js
+++ b/extensions/amp-pan-zoom/0.1/amp-pan-zoom.js
@@ -249,17 +249,17 @@ export class AmpPanZoom extends AMP.BaseElement {
    */
   createZoomButton_() {
     this.zoomButton_ = this.element.ownerDocument.createElement('div');
-    this.zoomButton_.classList.add('i-amphtml-pan-zoom-in-button');
-    this.zoomButton_.classList.add('i-amphtml-pan-zoom-button');
+    this.zoomButton_.classList.add('amp-pan-zoom-in-icon');
+    this.zoomButton_.classList.add('amp-pan-zoom-button');
     this.zoomButton_.addEventListener('click', () => {
-      if (this.zoomButton_.classList.contains('i-amphtml-pan-zoom-in-button')) {
+      if (this.zoomButton_.classList.contains('amp-pan-zoom-in-icon')) {
         this.transform(0, 0, this.maxScale_);
-        this.zoomButton_.classList.remove('i-amphtml-pan-zoom-in-button');
-        this.zoomButton_.classList.add('i-amphtml-pan-zoom-out-button');
+        this.zoomButton_.classList.remove('amp-pan-zoom-in-icon');
+        this.zoomButton_.classList.add('amp-pan-zoom-out-icon');
       } else {
         this.transform(0, 0, this.minScale_);
-        this.zoomButton_.classList.add('i-amphtml-pan-zoom-in-button');
-        this.zoomButton_.classList.remove('i-amphtml-pan-zoom-out-button');
+        this.zoomButton_.classList.add('amp-pan-zoom-in-icon');
+        this.zoomButton_.classList.remove('amp-pan-zoom-out-icon');
       }
     });
     this.element.appendChild(this.zoomButton_);
@@ -679,12 +679,12 @@ export class AmpPanZoom extends AMP.BaseElement {
       // After the scale is updated, also register or unregister panning
       if (this.scale_ <= 1) {
         this.unregisterPanningGesture_();
-        this.zoomButton_.classList.add('i-amphtml-pan-zoom-in-button');
-        this.zoomButton_.classList.remove('i-amphtml-pan-zoom-out-button');
+        this.zoomButton_.classList.add('amp-pan-zoom-in-icon');
+        this.zoomButton_.classList.remove('amp-pan-zoom-out-icon');
       } else {
         this.registerPanningGesture_();
-        this.zoomButton_.classList.remove('i-amphtml-pan-zoom-in-button');
-        this.zoomButton_.classList.add('i-amphtml-pan-zoom-out-button');
+        this.zoomButton_.classList.remove('amp-pan-zoom-in-icon');
+        this.zoomButton_.classList.add('amp-pan-zoom-out-icon');
       }
     });
   }

--- a/extensions/amp-pan-zoom/0.1/test/validator-amp-pan-zoom.html
+++ b/extensions/amp-pan-zoom/0.1/test/validator-amp-pan-zoom.html
@@ -43,7 +43,7 @@
     <svg></svg>
   </amp-pan-zoom>
 
-  <amp-pan-zoom layout="fill">
+  <amp-pan-zoom layout="fill" controls>
     <div></div>
   </amp-pan-zoom>
 

--- a/extensions/amp-pan-zoom/0.1/test/validator-amp-pan-zoom.out
+++ b/extensions/amp-pan-zoom/0.1/test/validator-amp-pan-zoom.out
@@ -44,7 +44,7 @@ FAIL
 |      <svg></svg>
 |    </amp-pan-zoom>
 |
-|    <amp-pan-zoom layout="fill">
+|    <amp-pan-zoom layout="fill" controls>
 |      <div></div>
 |    </amp-pan-zoom>
 |

--- a/extensions/amp-pan-zoom/amp-pan-zoom.md
+++ b/extensions/amp-pan-zoom/amp-pan-zoom.md
@@ -70,6 +70,9 @@ Specifies default translation coordinates, otherwise both are set to 0. The valu
 
 Refers to the ability to center  the image and set the image's scale back to 1. Setting this attribute causes the component to reset the zoomable content on resize of the image itself.
 
+##### controls (optional)
+
+Shows default controls (zoom in / zoom out button) which can be customized via public CSS classes.
 ##### common attributes
 
 This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.
@@ -107,6 +110,18 @@ The `transform` action takes `scale`, `x`, `y` as parameters and sets the CSS tr
 ##### Example
 
 Assuming that there is an `<amp-pan-zoom>` component with the id `pan-zoom` on the page, a button with `on="tap:pan-zoom.transform(scale=3)"` will zoom to scale 3x at the center of the content, a button with `on="tap:pan-zoom.transform(scale=3, x=50, y=10)"` will first scale the content to 3x scale, and then shift the content 50 pixels towards the left, and 10 pixels upwards. Consider the `scale`, `x`, and `y` attributes directly applied to the content's CSS transform attribute after animation.
+
+## Customizing Buttons
+
+The following public CSS classes are exposed to allow customization for the zoom buttons:
+```
+.amp-pan-zoom-button
+.amp-pan-zoom-in-icon
+.amp-pan-zoom-out-icon
+```
+Use `.amp-pan-zoom-button` to customize the dimensions, positioning, background-color, border-radius of all buttons.
+Use `.amp-pan-zoom-in-icon` to customize the icon for the zoom in button.
+Use `.amp-pan-zoom-out-icon` to customize the icon for the zoom out button.
 
 ## Validation
 See [amp-pan-zoom rules](https://github.com/ampproject/amphtml/blob/master/extensions/amp-pan-zoom/validator-amp-pan-zoom.protoascii) in the AMP validator specification.

--- a/extensions/amp-pan-zoom/validator-amp-pan-zoom.protoascii
+++ b/extensions/amp-pan-zoom/validator-amp-pan-zoom.protoascii
@@ -29,7 +29,10 @@ tags: {  # <amp-pan-zoom>
   html_format: EXPERIMENTAL
   tag_name: "AMP-PAN-ZOOM"
   requires_extension: "amp-pan-zoom"
-
+  attrs: {
+    name: "controls"
+    value: ""
+  }
   attrs: {
     name: "initial-scale"
     value_regex: "[0-9]+(\\.[0-9]+)?"

--- a/test/manual/amp-pan-zoom.amp.html
+++ b/test/manual/amp-pan-zoom.amp.html
@@ -105,7 +105,7 @@
 <article>
   <h1>AMP Pan Zoom</h1>
   <h2>AMP Pan Zoom Basic Example</h2>
-  <amp-pan-zoom layout="responsive" width="300" height="400">
+  <amp-pan-zoom layout="responsive" width="300" height="400" controls>
       <amp-img id="img0"
         src="/examples/img/sample.jpg"
         width="641" height="481" layout="fixed"></amp-img>


### PR DESCRIPTION
Adds an optional attribute to `<amp-pan-zoom>` that enables a default zoom button anchored to the bottom right. For custom buttons, the transform function is already exposed. 

<img width="412" alt="screen shot 2018-08-07 at 3 58 56 pm" src="https://user-images.githubusercontent.com/1528181/43806934-03126122-9a5b-11e8-93df-7a31abf9fab2.png">
<img width="422" alt="screen shot 2018-08-07 at 3 59 04 pm" src="https://user-images.githubusercontent.com/1528181/43806935-0325efc6-9a5b-11e8-8a2e-e1a09f56ab7e.png">
