### PR TITLE
Change AdSense Auto Ads Responsive experiment into an A/B experiment.

### DIFF
--- a/ads/google/adsense-amp-auto-ads-responsive.js
+++ b/ads/google/adsense-amp-auto-ads-responsive.js
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+import {
+  ExperimentInfo, // eslint-disable-line no-unused-vars
+  getExperimentBranch,
+  randomlySelectUnsetExperiments,
+} from '../../src/experiments';
+
+
+/** @const {string} */
+export const ADSENSE_AMP_AUTO_ADS_RESPONSIVE_EXPERIMENT_NAME =
+    'amp-auto-ads-adsense-responsive';
+
+
+/**
+ * @enum {string}
+ */
+export const AdSenseAmpAutoAdsResponsiveBranches = {
+  CONTROL: '19861210', // don't attempt to expand auto ads to responsive format
+  EXPERIMENT: '19861211', // do attempt to expand auto ads to responsive format
+};
+
+
+/** @const {!ExperimentInfo} */
+const ADSENSE_AMP_AUTO_ADS_RESPONSIVE_EXPERIMENT_INFO = {
+  isTrafficEligible: win => !!win.document.querySelector('AMP-AUTO-ADS'),
+  branches: [
+    AdSenseAmpAutoAdsResponsiveBranches.CONTROL,
+    AdSenseAmpAutoAdsResponsiveBranches.EXPERIMENT,
+  ],
+};
+
+
+/**
+ * This has the side-effect of selecting the page into a branch of the
+ * experiment, which becomes sticky for the entire pageview.
+ *
+ * @param {!Window} win
+ * @return {?string}
+ */
+export function getAdSenseAmpAutoAdsResponsiveExperimentBranch(win) {
+  const experiments = /** @type {!Object<string, !ExperimentInfo>} */ ({});
+  experiments[ADSENSE_AMP_AUTO_ADS_RESPONSIVE_EXPERIMENT_NAME] =
+      ADSENSE_AMP_AUTO_ADS_RESPONSIVE_EXPERIMENT_INFO;
+  randomlySelectUnsetExperiments(win, experiments);
+  return getExperimentBranch(win,
+      ADSENSE_AMP_AUTO_ADS_RESPONSIVE_EXPERIMENT_NAME) || null;
+}

--- a/ads/google/test/test-adsense-amp-auto-ads-responsive.js
+++ b/ads/google/test/test-adsense-amp-auto-ads-responsive.js
@@ -1,0 +1,85 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  ADSENSE_AMP_AUTO_ADS_RESPONSIVE_EXPERIMENT_NAME,
+  AdSenseAmpAutoAdsResponsiveBranches,
+  getAdSenseAmpAutoAdsResponsiveExperimentBranch,
+} from '../adsense-amp-auto-ads-responsive';
+import {
+  RANDOM_NUMBER_GENERATORS,
+  toggleExperiment,
+} from '../../../src/experiments';
+
+describes.realWin('adsense-amp-auto-ads-responsive', {}, env => {
+  let win;
+  let sandbox;
+  let accurateRandomStub;
+  let cachedAccuratePrng;
+
+  beforeEach(() => {
+    win = env.win;
+    sandbox = env.sandbox;
+
+    accurateRandomStub = sandbox.stub().returns(-1);
+    cachedAccuratePrng = RANDOM_NUMBER_GENERATORS.accuratePrng;
+    RANDOM_NUMBER_GENERATORS.accuratePrng = accurateRandomStub;
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+    RANDOM_NUMBER_GENERATORS.accuratePrng = cachedAccuratePrng;
+  });
+
+  it('should pick the control branch when experiment on and amp-auto-ads ' +
+      'tag present.', () => {
+    const ampAutoAdsEl = win.document.createElement('amp-auto-ads');
+    win.document.body.appendChild(ampAutoAdsEl);
+    toggleExperiment(
+        win, ADSENSE_AMP_AUTO_ADS_RESPONSIVE_EXPERIMENT_NAME, true);
+    RANDOM_NUMBER_GENERATORS.accuratePrng.onFirstCall().returns(0.4);
+    expect(getAdSenseAmpAutoAdsResponsiveExperimentBranch(win))
+        .to.equal(AdSenseAmpAutoAdsResponsiveBranches.CONTROL);
+  });
+
+  it('should pick the experiment branch when experiment on and amp-auto-ads ' +
+      'tag present.', () => {
+    const ampAutoAdsEl = win.document.createElement('amp-auto-ads');
+    win.document.body.appendChild(ampAutoAdsEl);
+    toggleExperiment(
+        win, ADSENSE_AMP_AUTO_ADS_RESPONSIVE_EXPERIMENT_NAME, true);
+    RANDOM_NUMBER_GENERATORS.accuratePrng.onFirstCall().returns(0.6);
+    expect(getAdSenseAmpAutoAdsResponsiveExperimentBranch(win))
+        .to.equal(AdSenseAmpAutoAdsResponsiveBranches.EXPERIMENT);
+  });
+
+  it('should not pick a branch when experiment off.', () => {
+    const ampAutoAdsEl = win.document.createElement('amp-auto-ads');
+    win.document.body.appendChild(ampAutoAdsEl);
+    toggleExperiment(
+        win, ADSENSE_AMP_AUTO_ADS_RESPONSIVE_EXPERIMENT_NAME, false);
+    RANDOM_NUMBER_GENERATORS.accuratePrng.onFirstCall().returns(0.4);
+    expect(getAdSenseAmpAutoAdsResponsiveExperimentBranch(win)).to.be.null;
+  });
+
+  it('should not pick a branch when experiment on but no and amp-auto-ads ' +
+      'tag present.', () => {
+    toggleExperiment(
+        win, ADSENSE_AMP_AUTO_ADS_RESPONSIVE_EXPERIMENT_NAME, true);
+    RANDOM_NUMBER_GENERATORS.accuratePrng.onFirstCall().returns(0.4);
+    expect(getAdSenseAmpAutoAdsResponsiveExperimentBranch(win)).to.be.null;
+  });
+});

--- a/build-system/dep-check-config.js
+++ b/build-system/dep-check-config.js
@@ -151,6 +151,7 @@ exports.rules = [
       'ads/**->src/style.js',
       'ads/**->src/consent-state.js',
       'ads/google/adsense-amp-auto-ads.js->src/experiments.js',
+      'ads/google/adsense-amp-auto-ads-responsive.js->src/experiments.js',
       'ads/google/doubleclick.js->src/experiments.js',
       // ads/google/a4a doesn't contain 3P ad code and should probably move
       // somewhere else at some point

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -56,6 +56,9 @@ import {domFingerprintPlain} from '../../../src/utils/dom-fingerprint';
 import {
   getAdSenseAmpAutoAdsExpBranch,
 } from '../../../ads/google/adsense-amp-auto-ads';
+import {
+  getAdSenseAmpAutoAdsResponsiveExperimentBranch,
+} from '../../../ads/google/adsense-amp-auto-ads-responsive';
 import {getDefaultBootstrapBaseUrl} from '../../../src/3p-frame';
 import {
   getExperimentBranch,
@@ -332,8 +335,13 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
 
     const experimentIds = [];
     const ampAutoAdsBranch = getAdSenseAmpAutoAdsExpBranch(this.win);
+    const ampAutoAdsResponsiveBranch =
+      getAdSenseAmpAutoAdsResponsiveExperimentBranch(this.win);
     if (ampAutoAdsBranch) {
       experimentIds.push(ampAutoAdsBranch);
+    }
+    if (ampAutoAdsResponsiveBranch) {
+      experimentIds.push(ampAutoAdsResponsiveBranch);
     }
     const identityPromise = Services.timerFor(this.win)
         .timeoutPromise(1000, this.identityTokenPromise_)

--- a/extensions/amp-auto-ads/0.1/ad-network-config.js
+++ b/extensions/amp-auto-ads/0.1/ad-network-config.js
@@ -18,10 +18,13 @@ import {
   AdSenseAmpAutoAdsHoldoutBranches,
   getAdSenseAmpAutoAdsExpBranch,
 } from '../../../ads/google/adsense-amp-auto-ads';
+import {
+  AdSenseAmpAutoAdsResponsiveBranches,
+  getAdSenseAmpAutoAdsResponsiveExperimentBranch,
+} from '../../../ads/google/adsense-amp-auto-ads-responsive';
 import {Services} from '../../../src/services';
 import {buildUrl} from '../../../ads/google/a4a/url-builder';
 import {dict} from '../../../src/utils/object';
-import {isExperimentOn} from '../../../src/experiments';
 import {parseUrlDeprecated} from '../../../src/url';
 import {tryParseJson} from '../../../src/json';
 
@@ -114,7 +117,8 @@ class AdSenseNetworkConfig {
    * @param {!Window} win
    */
   isResponsiveEnabled(win) {
-    return (isExperimentOn(win, 'amp-auto-ads-adsense-responsive'));
+    const branch = getAdSenseAmpAutoAdsResponsiveExperimentBranch(win);
+    return branch != AdSenseAmpAutoAdsResponsiveBranches.CONTROL;
   }
 
   /** @override */

--- a/extensions/amp-auto-ads/0.1/test/test-ad-network-config.js
+++ b/extensions/amp-auto-ads/0.1/test/test-ad-network-config.js
@@ -18,6 +18,10 @@ import {
   ADSENSE_AMP_AUTO_ADS_HOLDOUT_EXPERIMENT_NAME,
   AdSenseAmpAutoAdsHoldoutBranches,
 } from '../../../../ads/google/adsense-amp-auto-ads';
+import {
+  ADSENSE_AMP_AUTO_ADS_RESPONSIVE_EXPERIMENT_NAME,
+  AdSenseAmpAutoAdsResponsiveBranches,
+} from '../../../../ads/google/adsense-amp-auto-ads-responsive';
 import {Services} from '../../../../src/services';
 import {
   forceExperimentBranch,
@@ -87,16 +91,30 @@ describes.realWin('ad-network-config', {
           'url=https%3A%2F%2Ffoo.bar%2Fbaz');
     });
 
-    it('should not be responsive-enabled if experiment is off', () => {
-      toggleExperiment(env.win, 'amp-auto-ads-adsense-responsive', false);
+    it('should report responsive-enabled when responsive experiment not on',
+        () => {
+          toggleExperiment(
+              env.win, ADSENSE_AMP_AUTO_ADS_RESPONSIVE_EXPERIMENT_NAME, false);
+          const adNetwork = getAdNetworkConfig('adsense', ampAutoAdsElem);
+          expect(adNetwork.isResponsiveEnabled(env.win)).to.equal(true);
+        });
+
+    it('should report responsive-enabled when responsive experiment on and ' +
+       'experiment branch picked', () => {
+      forceExperimentBranch(env.win,
+          ADSENSE_AMP_AUTO_ADS_RESPONSIVE_EXPERIMENT_NAME,
+          AdSenseAmpAutoAdsResponsiveBranches.EXPERIMENT);
       const adNetwork = getAdNetworkConfig('adsense', ampAutoAdsElem);
-      expect(adNetwork.isResponsiveEnabled(env.win)).to.be.false;
+      expect(adNetwork.isResponsiveEnabled(env.win)).to.equal(true);
     });
 
-    it('should be responsive-enabled if experiment is on', () => {
-      toggleExperiment(env.win, 'amp-auto-ads-adsense-responsive', true);
+    it('should report responsive-disabled when responsive experiment on ' +
+       'and control branch picked', () => {
+      forceExperimentBranch(env.win,
+          ADSENSE_AMP_AUTO_ADS_RESPONSIVE_EXPERIMENT_NAME,
+          AdSenseAmpAutoAdsResponsiveBranches.CONTROL);
       const adNetwork = getAdNetworkConfig('adsense', ampAutoAdsElem);
-      expect(adNetwork.isResponsiveEnabled(env.win)).to.be.true;
+      expect(adNetwork.isResponsiveEnabled(env.win)).to.equal(false);
     });
 
     // TODO(bradfrizzell, #12476): Make this test work with sinon 4.0.


### PR DESCRIPTION
The experiment is still off everywhere. This PR binds the experiment branches to A/B ids.