### PR TITLE
Fix width on fluid creatives with size headers

### DIFF
--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -249,8 +249,8 @@ export class AmpA4A extends AMP.BaseElement {
     /** @private {?AMP.AmpAdXOriginIframeHandler} */
     this.xOriginIframeHandler_ = null;
 
-    /** @private {boolean} whether creative has been verified as AMP */
-    this.isVerifiedAmpCreative_ = false;
+    /** @type {boolean} whether creative has been verified as AMP */
+    this.isVerifiedAmpCreative = false;
 
     /** @private {?ArrayBuffer} */
     this.creativeBody_ = null;
@@ -423,7 +423,7 @@ export class AmpA4A extends AMP.BaseElement {
   /** @override */
   renderOutsideViewport() {
     // Ensure non-verified AMP creatives are throttled.
-    if (!this.isVerifiedAmpCreative_ && is3pThrottled(this.win) &&
+    if (!this.isVerifiedAmpCreative && is3pThrottled(this.win) &&
         !this.inNonAmpPreferenceExp()) {
       return false;
     }
@@ -775,7 +775,7 @@ export class AmpA4A extends AMP.BaseElement {
           // Need to know if creative was verified as part of render outside
           // viewport but cannot wait on promise.  Sadly, need a state a
           // variable.
-          this.isVerifiedAmpCreative_ = !!creative;
+          this.isVerifiedAmpCreative = !!creative;
           return creative && utf8Decode(creative);
         })
         // This block returns CreativeMetaDataDef iff the creative was verified
@@ -1097,7 +1097,7 @@ export class AmpA4A extends AMP.BaseElement {
     this.adPromise_ = null;
     this.adUrl_ = null;
     this.creativeBody_ = null;
-    this.isVerifiedAmpCreative_ = false;
+    this.isVerifiedAmpCreative = false;
     this.fromResumeCallback = false;
     this.experimentalNonAmpCreativeRenderMethod_ =
         this.getNonAmpCreativeRenderingMethod();
@@ -1186,7 +1186,7 @@ export class AmpA4A extends AMP.BaseElement {
    * headers. Must be less than or equal to the original size of the ad slot
    * along each dimension. May be overridden by network.
    *
-   * @param {!../../../src/utils/xhr-utils.FetchResponseHeaders} responseHeaders
+   * @param {!../../../src/service/xhr-impl.FetchResponseHeaders} responseHeaders
    * @return {?SizeInfoDef}
    */
   extractSize(responseHeaders) {
@@ -1249,7 +1249,7 @@ export class AmpA4A extends AMP.BaseElement {
   /**
    * Send ad request, extract the creative and signature from the response.
    * @param {string} adUrl Request URL to send XHR to.
-   * @return {!Promise<?../../../src/utils/xhr-utils.FetchResponse>}
+   * @return {!Promise<?../../../src/service/xhr-impl.FetchResponse>}
    * @protected
    */
   sendXhrRequest(adUrl) {
@@ -1803,3 +1803,7 @@ export function signatureVerifierFor(win) {
   return win[propertyName] ||
       (win[propertyName] = new SignatureVerifier(win, signingServerURLs));
 }
+
+
+
+

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
@@ -123,9 +123,8 @@ export class SafeframeHostApi {
    * @param {!./amp-ad-network-doubleclick-impl.AmpAdNetworkDoubleclickImpl} baseInstance
    * @param {boolean} isFluid
    * @param {{width:number, height:number}} creativeSize
-   * @param {?string} fluidImpressionUrl
    */
-  constructor(baseInstance, isFluid, creativeSize, fluidImpressionUrl) {
+  constructor(baseInstance, isFluid, creativeSize) {
     /** @private {!./amp-ad-network-doubleclick-impl.AmpAdNetworkDoubleclickImpl} */
     this.baseInstance_ = baseInstance;
 
@@ -164,9 +163,6 @@ export class SafeframeHostApi {
     this.initialCreativeSize_ =
       /** @private {{width:number, height:number}} */
       (Object.assign({}, creativeSize));
-
-    /** @private {?string} */
-    this.fluidImpressionUrl_ = fluidImpressionUrl;
 
     /** @private {?Promise} */
     this.delay_ = null;
@@ -712,13 +708,13 @@ export class SafeframeHostApi {
     const iframe = dev().assertElement(this.baseInstance_.iframe);
     const iframeHeight = parseInt(getStyle(iframe, 'height'), 10) || 0;
     if (iframeHeight != newHeight) {
-      setStyles(iframe, {height: `${newHeight}px`});
+      setStyles(iframe, {
+        height: `${newHeight}px`,
+        width: '100%'
+      });
+      setStyles(this.baseInstance_.element, {width: '100%'});
     }
-    if (this.fluidImpressionUrl_) {
-      this.baseInstance_.fireDelayedImpressions(
-          this.fluidImpressionUrl_);
-      this.fluidImpressionUrl_ = null;
-    }
+    this.baseInstance_.fireFluidDelayedImpression();
     this.iframe_.contentWindow./*OK*/postMessage(
         JSON.stringify(dict({'message': 'resize-complete', 'c': this.channel})),
         SAFEFRAME_ORIGIN);
@@ -746,3 +742,5 @@ export function removeSafeframeListener() {
   window.removeEventListener('message', safeframeListener, false);
   safeframeListenerCreated_ = false;
 }
+
+


### PR DESCRIPTION
In PR #16393 we fixed an issue wherein fluid creatives were being incorrectly resized due to having size headers attached. That PR only fixed the issue for height, but did not address the width being cropped. While the full creative is still visible, it's not taking up the full width as a fluid creative should.

This PR fixes the issue by setting the width of the amp-ad and iframe elements to 100%.