### PR TITLE
Fix width on fluid creatives with size headers

### DIFF
--- a/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
@@ -20,7 +20,7 @@ import {dict, hasOwn} from '../../../src/utils/object';
 import {getData} from '../../../src/event-helper';
 import {getStyle} from '../../../src/style';
 import {parseUrlDeprecated} from '../../../src/url';
-import {setStyles} from '../../../src/style';
+import {setStyle, setStyles} from '../../../src/style';
 import {throttle} from '../../../src/utils/rate-limit';
 import {tryParseJson} from '../../../src/json';
 
@@ -712,7 +712,11 @@ export class SafeframeHostApi {
     const iframe = dev().assertElement(this.baseInstance_.iframe);
     const iframeHeight = parseInt(getStyle(iframe, 'height'), 10) || 0;
     if (iframeHeight != newHeight) {
-      setStyles(iframe, {height: `${newHeight}px`});
+      setStyles(iframe, {
+        height: `${newHeight}px`,
+        width: '100%',
+      });
+      setStyle(this.baseInstance_.element, 'width', '100%');
     }
     if (this.fluidImpressionUrl_) {
       this.baseInstance_.fireDelayedImpressions(

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-fluid.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-fluid.js
@@ -235,6 +235,8 @@ describes.realWin('DoubleClick Fast Fetch Fluid', realWinConfig, env => {
     return impl.adPromise_.then(() => {
       return impl.layoutCallback().then(() => {
         expect(impl.iframe.style.height).to.equal('250px');
+        expect(impl.iframe.style.width).to.equal('100%');
+        expect(impl.element.style.width).to.equal('100%');
       });
     });
   });

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-fluid.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-fluid.js
@@ -230,7 +230,7 @@ describes.realWin('DoubleClick Fast Fetch Fluid', realWinConfig, env => {
     });
   });
 
-  it('should set height on iframe', () => {
+  it('should style iframe and element correctly', () => {
     createScaffoldingForFluidRendering(impl, sandbox);
     return impl.adPromise_.then(() => {
       return impl.layoutCallback().then(() => {

--- a/extensions/amp-ad/0.1/amp-ad.css
+++ b/extensions/amp-ad/0.1/amp-ad.css
@@ -68,11 +68,5 @@ amp-ad[data-a4a-upgrade-type="amp-ad-network-adsense-impl"] > iframe {
 }
 
 amp-ad[data-a4a-upgrade-type="amp-ad-network-doubleclick-impl"][height="fluid"] > iframe {
-  height: 100% !important;
-  width: 100% !important;
   position: relative;
-}
-
-amp-ad[data-a4a-upgrade-type="amp-ad-network-doubleclick-impl"][height="fluid"] {
-  width: 100% !important;
 }


### PR DESCRIPTION
In PR #16393 we fixed an issue wherein fluid creatives were being incorrectly resized due to having size headers attached. That PR only fixed the issue for height, but did not address the width being cropped. While the full creative is still visible, it's not taking up the full width as a fluid creative should.

This PR fixes the issue by setting the width of the amp-ad and iframe elements to 100% after resizing.