### PR TITLE
Remove CSS Scroll Snap experiment from 1% Canary

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -32,7 +32,6 @@
   "amp-live-list-sorting": 1,
   "amp-sidebar toolbar": 1,
   "svg-in-mustache": 1,
-  "amp-carousel-scroll-snap": 1,
   "amp-consent": 1,
   "amp-img-native-srcset": 1,
   "amp-story-v1": 1,


### PR DESCRIPTION
This fixes #17363 which is happening in 1% canary. Want to remove the flag before it hits 1% prod. 