### PR TITLE
✅ Restore amp-story visual diff tests, with fixes for flakiness

### DIFF
--- a/build-system/tasks/visual-diff.js
+++ b/build-system/tasks/visual-diff.js
@@ -455,6 +455,19 @@ async function snapshotWebpages(percy, page, webpages, config) {
     await verifyCssElements(page, url, webpage.forbidden_css,
         webpage.loading_incomplete_css, webpage.loading_complete_css);
 
+    if (webpage.loading_complete_delay_ms) {
+      if (typeof webpage.loading_complete_delay_ms !== 'number' &&
+          webpage.loading_complete_delay_ms > 0) {
+        log('verbose', 'Waiting',
+            colors.cyan(webpage.loading_complete_delay_ms + 'ms'),
+            'for loading to complete');
+        await sleep(webpage.loading_complete_delay_ms || 0);
+      } else {
+        log('warning', 'Skipping unknown delay',
+            webpage.loading_complete_delay_ms);
+      }
+    }
+
     if (webpage.enable_percy_javascript) {
       snapshotOptions.enableJavaScript = true;
       // Remove all scripts that have an external source, leaving only those

--- a/examples/visual-tests/amp-story/amp-story-bookend.html
+++ b/examples/visual-tests/amp-story/amp-story-bookend.html
@@ -18,6 +18,11 @@
         font-family: sans-serif;
       }
 
+      .i-amphtml-story-spinner-container {
+        /* Hide the spinner for loading pages, since this causes flakes */
+        display: none;
+      }
+
       h1.hello-world {
         color: white;
         text-align: center;

--- a/examples/visual-tests/amp-story/amp-story-bookend.rtl.html
+++ b/examples/visual-tests/amp-story/amp-story-bookend.rtl.html
@@ -18,6 +18,11 @@
         font-family: sans-serif;
       }
 
+      .i-amphtml-story-spinner-container {
+        /* Hide the spinner for loading pages, since this causes flakes */
+        display: none;
+      }
+
       h1.hello-world {
         color: white;
         text-align: center;

--- a/examples/visual-tests/amp-story/amp-story-consent.html
+++ b/examples/visual-tests/amp-story/amp-story-consent.html
@@ -20,6 +20,11 @@
         font-family: sans-serif;
       }
 
+      .i-amphtml-story-spinner-container {
+        /* Hide the spinner for loading pages, since this causes flakes */
+        display: none;
+      }
+
       h1#hello-world {
         color: white;
         text-align: center;

--- a/examples/visual-tests/amp-story/amp-story-consent.rtl.html
+++ b/examples/visual-tests/amp-story/amp-story-consent.rtl.html
@@ -20,6 +20,11 @@
         font-family: sans-serif;
       }
 
+      .i-amphtml-story-spinner-container {
+        /* Hide the spinner for loading pages, since this causes flakes */
+        display: none;
+      }
+
       h1#hello-world {
         color: white;
         text-align: center;

--- a/examples/visual-tests/amp-story/amp-story-cta-layer.html
+++ b/examples/visual-tests/amp-story/amp-story-cta-layer.html
@@ -17,7 +17,7 @@
       }
 
       button {
-        background-color: red;
+        background-color: blue;
         color: white;
         position: absolute;
         top: 50%;

--- a/examples/visual-tests/amp-story/basic.html
+++ b/examples/visual-tests/amp-story/basic.html
@@ -19,6 +19,11 @@
         font-family: sans-serif;
       }
 
+      .i-amphtml-story-spinner-container {
+        /* Hide the spinner for loading pages, since this causes flakes */
+        display: none;
+      }
+
       h1.hello-world {
         color: white;
         text-shadow: 3px 3px rgba(0, 0, 0, 0.5);

--- a/examples/visual-tests/amp-story/basic.rtl.html
+++ b/examples/visual-tests/amp-story/basic.rtl.html
@@ -19,6 +19,11 @@
         font-family: sans-serif;
       }
 
+      .i-amphtml-story-spinner-container {
+        /* Hide the spinner for loading pages, since this causes flakes */
+        display: none;
+      }
+
       h1.hello-world {
         color: white;
         text-shadow: 3px 3px rgba(0, 0, 0, 0.5);

--- a/examples/visual-tests/amp-story/embed-mode-1.html
+++ b/examples/visual-tests/amp-story/embed-mode-1.html
@@ -18,6 +18,11 @@
         font-family: sans-serif;
       }
 
+      .i-amphtml-story-spinner-container {
+        /* Hide the spinner for loading pages, since this causes flakes */
+        display: none;
+      }
+
       h1#hello-world {
         color: white;
         text-align: center;

--- a/examples/visual-tests/amp-story/embed-mode-2.html
+++ b/examples/visual-tests/amp-story/embed-mode-2.html
@@ -18,6 +18,11 @@
         font-family: sans-serif;
       }
 
+      .i-amphtml-story-spinner-container {
+        /* Hide the spinner for loading pages, since this causes flakes */
+        display: none;
+      }
+
       h1#hello-world {
         color: white;
         text-align: center;

--- a/examples/visual-tests/amp-story/info-dialog.html
+++ b/examples/visual-tests/amp-story/info-dialog.html
@@ -18,6 +18,11 @@
         font-family: sans-serif;
       }
 
+      .i-amphtml-story-spinner-container {
+        /* Hide the spinner for loading pages, since this causes flakes */
+        display: none;
+      }
+
       h1#hello-world {
         color: white;
         text-align: center;

--- a/examples/visual-tests/amp-story/info-dialog.rtl.html
+++ b/examples/visual-tests/amp-story/info-dialog.rtl.html
@@ -18,6 +18,11 @@
         font-family: sans-serif;
       }
 
+      .i-amphtml-story-spinner-container {
+        /* Hide the spinner for loading pages, since this causes flakes */
+        display: none;
+      }
+
       h1#hello-world {
         color: white;
         text-align: center;

--- a/examples/visual-tests/amp-story/share-menu.html
+++ b/examples/visual-tests/amp-story/share-menu.html
@@ -18,6 +18,11 @@
         font-family: sans-serif;
       }
 
+      .i-amphtml-story-spinner-container {
+        /* Hide the spinner for loading pages, since this causes flakes */
+        display: none;
+      }
+
       h1#hello-world {
         color: white;
         text-align: center;

--- a/examples/visual-tests/amp-story/share-menu.rtl.html
+++ b/examples/visual-tests/amp-story/share-menu.rtl.html
@@ -18,6 +18,11 @@
         font-family: sans-serif;
       }
 
+      .i-amphtml-story-spinner-container {
+        /* Hide the spinner for loading pages, since this causes flakes */
+        display: none;
+      }
+
       h1#hello-world {
         color: white;
         text-align: center;

--- a/test/visual-diff/visual-tests
+++ b/test/visual-diff/visual-tests
@@ -315,7 +315,7 @@
       "viewport": {"width": 1440, "height": 900},
       "loading_complete_css": [
         ".i-amphtml-story-loaded",
-        ".i-amphtml-story-share-pill",
+        ".i-amphtml-story-share-pill-label",
         "amp-story-page#page-2[active]"
       ]
     },
@@ -325,7 +325,7 @@
       "viewport": {"width": 1440, "height": 900},
       "loading_complete_css": [
         ".i-amphtml-story-loaded",
-        ".i-amphtml-story-share-pill",
+        ".i-amphtml-story-share-pill-label",
         ".i-amphtml-story-grid-template-fill"
       ]
     },
@@ -335,7 +335,7 @@
       "viewport": {"width": 1440, "height": 900},
       "loading_complete_css": [
         ".i-amphtml-story-loaded",
-        ".i-amphtml-story-share-pill",
+        ".i-amphtml-story-share-pill-label",
         ".i-amphtml-story-grid-template-vertical"
       ]
     },
@@ -345,7 +345,7 @@
       "viewport": {"width": 1440, "height": 900},
       "loading_complete_css": [
         ".i-amphtml-story-loaded",
-        ".i-amphtml-story-share-pill",
+        ".i-amphtml-story-share-pill-label",
         ".i-amphtml-story-grid-template-horizontal"
       ]
     },
@@ -358,7 +358,7 @@
       ],
       "loading_complete_css": [
         ".i-amphtml-story-loaded",
-        ".i-amphtml-story-share-pill",
+        ".i-amphtml-story-share-pill-label",
         ".i-amphtml-story-grid-template-thirds"
       ]
     },
@@ -368,7 +368,7 @@
       "viewport": {"width": 1440, "height": 900},
       "loading_complete_css": [
         ".i-amphtml-story-loaded",
-        ".i-amphtml-story-share-pill",
+        ".i-amphtml-story-share-pill-label",
         "amp-story-page#the-one-with-the-cta-layer[active]"
       ]
     },
@@ -386,7 +386,7 @@
       "viewport": {"width": 1440, "height": 900},
       "loading_complete_css": [
         ".i-amphtml-story-loaded",
-        ".i-amphtml-story-share-pill"
+        ".i-amphtml-story-share-pill-label"
       ]
     },
     {
@@ -395,7 +395,7 @@
       "viewport": {"width": 1440, "height": 900},
       "loading_complete_css": [
         ".i-amphtml-story-loaded",
-        ".i-amphtml-story-share-pill",
+        ".i-amphtml-story-share-pill-label",
         ".i-amphtml-story-bookend"
       ]
     },
@@ -405,7 +405,7 @@
       "viewport": {"width": 1440, "height": 900},
       "loading_complete_css": [
         ".i-amphtml-story-loaded",
-        ".i-amphtml-story-share-pill",
+        ".i-amphtml-story-share-pill-label",
         ".i-amphtml-story-consent"
       ]
     },
@@ -415,7 +415,6 @@
       "viewport": {"width": 1440, "height": 900},
       "loading_complete_css": [
         ".i-amphtml-story-fallback",
-        ".i-amphtml-story-share-pill",
         ".i-amphtml-story-unsupported-browser-overlay"
       ]
     },
@@ -470,7 +469,7 @@
       "viewport": {"width": 1440, "height": 900},
       "loading_complete_css": [
         ".i-amphtml-story-loaded",
-        ".i-amphtml-story-share-pill",
+        ".i-amphtml-story-share-pill-label",
         "amp-story-page#page-2[active]"
       ]
     },
@@ -480,7 +479,7 @@
       "viewport": {"width": 1440, "height": 900},
       "loading_complete_css": [
         ".i-amphtml-story-loaded",
-        ".i-amphtml-story-share-pill",
+        ".i-amphtml-story-share-pill-label",
         ".i-amphtml-story-bookend"
       ]
     },
@@ -490,7 +489,7 @@
       "viewport": {"width": 1440, "height": 900},
       "loading_complete_css": [
         ".i-amphtml-story-loaded",
-        ".i-amphtml-story-share-pill",
+        ".i-amphtml-story-share-pill-label",
         ".i-amphtml-story-consent"
       ]
     },

--- a/test/visual-diff/visual-tests
+++ b/test/visual-diff/visual-tests
@@ -315,6 +315,7 @@
       "viewport": {"width": 1440, "height": 900},
       "loading_complete_css": [
         ".i-amphtml-story-loaded",
+        ".i-amphtml-story-share-pill",
         "amp-story-page#page-2[active]"
       ]
     },
@@ -324,6 +325,7 @@
       "viewport": {"width": 1440, "height": 900},
       "loading_complete_css": [
         ".i-amphtml-story-loaded",
+        ".i-amphtml-story-share-pill",
         ".i-amphtml-story-grid-template-fill"
       ]
     },
@@ -333,6 +335,7 @@
       "viewport": {"width": 1440, "height": 900},
       "loading_complete_css": [
         ".i-amphtml-story-loaded",
+        ".i-amphtml-story-share-pill",
         ".i-amphtml-story-grid-template-vertical"
       ]
     },
@@ -342,6 +345,7 @@
       "viewport": {"width": 1440, "height": 900},
       "loading_complete_css": [
         ".i-amphtml-story-loaded",
+        ".i-amphtml-story-share-pill",
         ".i-amphtml-story-grid-template-horizontal"
       ]
     },
@@ -354,6 +358,7 @@
       ],
       "loading_complete_css": [
         ".i-amphtml-story-loaded",
+        ".i-amphtml-story-share-pill",
         ".i-amphtml-story-grid-template-thirds"
       ]
     },
@@ -363,6 +368,7 @@
       "viewport": {"width": 1440, "height": 900},
       "loading_complete_css": [
         ".i-amphtml-story-loaded",
+        ".i-amphtml-story-share-pill",
         "amp-story-page#the-one-with-the-cta-layer[active]"
       ]
     },
@@ -371,7 +377,8 @@
       "name": "amp-story: embed mode 1 (desktop)",
       "viewport": {"width": 1440, "height": 900},
       "loading_complete_css": [
-        ".i-amphtml-story-loaded"
+        ".i-amphtml-story-loaded",
+        ".i-amphtml-story-share-pill"
       ]
     },
     {
@@ -379,7 +386,8 @@
       "name": "amp-story: embed mode 2 (desktop)",
       "viewport": {"width": 1440, "height": 900},
       "loading_complete_css": [
-        ".i-amphtml-story-loaded"
+        ".i-amphtml-story-loaded",
+        ".i-amphtml-story-share-pill"
       ]
     },
     {
@@ -388,6 +396,7 @@
       "viewport": {"width": 1440, "height": 900},
       "loading_complete_css": [
         ".i-amphtml-story-loaded",
+        ".i-amphtml-story-share-pill",
         ".i-amphtml-story-bookend"
       ]
     },
@@ -397,6 +406,7 @@
       "viewport": {"width": 1440, "height": 900},
       "loading_complete_css": [
         ".i-amphtml-story-loaded",
+        ".i-amphtml-story-share-pill",
         ".i-amphtml-story-consent"
       ]
     },
@@ -406,6 +416,7 @@
       "viewport": {"width": 1440, "height": 900},
       "loading_complete_css": [
         ".i-amphtml-story-fallback",
+        ".i-amphtml-story-share-pill",
         ".i-amphtml-story-unsupported-browser-overlay"
       ]
     },
@@ -460,6 +471,7 @@
       "viewport": {"width": 1440, "height": 900},
       "loading_complete_css": [
         ".i-amphtml-story-loaded",
+        ".i-amphtml-story-share-pill",
         "amp-story-page#page-2[active]"
       ]
     },
@@ -469,6 +481,7 @@
       "viewport": {"width": 1440, "height": 900},
       "loading_complete_css": [
         ".i-amphtml-story-loaded",
+        ".i-amphtml-story-share-pill",
         ".i-amphtml-story-bookend"
       ]
     },
@@ -478,6 +491,7 @@
       "viewport": {"width": 1440, "height": 900},
       "loading_complete_css": [
         ".i-amphtml-story-loaded",
+        ".i-amphtml-story-share-pill",
         ".i-amphtml-story-consent"
       ]
     },

--- a/test/visual-diff/visual-tests
+++ b/test/visual-diff/visual-tests
@@ -377,8 +377,7 @@
       "name": "amp-story: embed mode 1 (desktop)",
       "viewport": {"width": 1440, "height": 900},
       "loading_complete_css": [
-        ".i-amphtml-story-loaded",
-        ".i-amphtml-story-share-pill"
+        ".i-amphtml-story-loaded"
       ]
     },
     {

--- a/test/visual-diff/visual-tests
+++ b/test/visual-diff/visual-tests
@@ -192,9 +192,6 @@
       "enable_percy_javascript": true
     },
     {
-      "flaky": true,
-      // amp-story tests are very flaky.
-      // e.g., https://percy.io/ampproject/amphtml/builds/894594
       "url": "examples/visual-tests/amp-story/basic.html",
       "name": "amp-story: basic",
       "viewport": {"width": 320, "height": 480},
@@ -204,8 +201,6 @@
       ]
     },
     {
-      "flaky": true,
-      // amp-story tests are very flaky.  see above.
       "url": "examples/visual-tests/amp-story/amp-story-grid-layer-template-fill.html",
       "name": "amp-story: Grid layer (fill)",
       "viewport": {"width": 320, "height": 480},
@@ -215,8 +210,6 @@
       ]
     },
     {
-      "flaky": true,
-      // amp-story tests are very flaky.  see above.
       "url": "examples/visual-tests/amp-story/amp-story-grid-layer-template-vertical.html",
       "name": "amp-story: Grid layer (vertical)",
       "viewport": {"width": 320, "height": 480},
@@ -226,8 +219,6 @@
       ]
     },
     {
-      "flaky": true,
-      // amp-story tests are very flaky.  see above.
       "url": "examples/visual-tests/amp-story/amp-story-grid-layer-template-horizontal.html",
       "name": "amp-story: Grid layer (horizontal)",
       "viewport": {"width": 320, "height": 480},
@@ -237,8 +228,6 @@
       ]
     },
     {
-      "flaky": true,
-      // amp-story tests are very flaky.  see above.
       "url": "examples/visual-tests/amp-story/amp-story-grid-layer-template-thirds.html",
       "name": "amp-story: Grid layer (thirds)",
       "viewport": {"width": 320, "height": 480},
@@ -251,8 +240,6 @@
       ]
     },
     {
-      "flaky": true,
-      // amp-story tests are very flaky.  see above.
       "url": "examples/visual-tests/amp-story/amp-story-cta-layer.html",
       "name": "amp-story: CTA layer",
       "viewport": {"width": 320, "height": 480},
@@ -262,8 +249,6 @@
       ]
     },
     {
-      "flaky": true,
-      // amp-story tests are very flaky.  see above.
       "url": "examples/visual-tests/amp-story/embed-mode-1.html",
       "name": "amp-story: embed mode 1",
       "viewport": {"width": 320, "height": 480},
@@ -272,8 +257,6 @@
       ]
     },
     {
-      "flaky": true,
-      // amp-story tests are very flaky.  see above.
       "url": "examples/visual-tests/amp-story/embed-mode-2.html",
       "name": "amp-story: embed mode 2",
       "viewport": {"width": 320, "height": 480},
@@ -282,8 +265,6 @@
       ]
     },
     {
-      "flaky": true,
-      // amp-story tests are very flaky.  see above.
       "url": "examples/visual-tests/amp-story/share-menu.html",
       "name": "amp-story: share menu",
       "viewport": {"width": 320, "height": 480},
@@ -293,8 +274,6 @@
       ]
     },
     {
-      "flaky": true,
-      // amp-story tests are very flaky.  see above.
       "url": "examples/visual-tests/amp-story/info-dialog.html",
       "name": "amp-story: info dialog",
       "viewport": {"width": 320, "height": 480},
@@ -304,8 +283,6 @@
       ]
     },
     {
-      "flaky": true,
-      // amp-story tests are very flaky.  see above.
       "url": "examples/visual-tests/amp-story/amp-story-bookend.html",
       "name": "amp-story: bookend",
       "viewport": {"width": 320, "height": 480},
@@ -315,8 +292,6 @@
       ]
     },
     {
-      "flaky": true,
-      // amp-story tests are very flaky.  see above.
       "url": "examples/visual-tests/amp-story/amp-story-consent.html",
       "name": "amp-story: consent",
       "viewport": {"width": 320, "height": 480},
@@ -326,8 +301,6 @@
       ]
     },
     {
-      "flaky": true,
-      // amp-story tests are very flaky.  see above.
       "url": "examples/visual-tests/amp-story/amp-story-unsupported-browser-layer.html",
       "name": "amp-story: unsupported browser",
       "viewport": {"width": 320, "height": 480},
@@ -337,8 +310,6 @@
       ]
     },
     {
-      "flaky": true,
-      // amp-story tests are very flaky.  see above.
       "url": "examples/visual-tests/amp-story/basic.html",
       "name": "amp-story: basic (desktop)",
       "viewport": {"width": 1440, "height": 900},
@@ -348,8 +319,6 @@
       ]
     },
     {
-      "flaky": true,
-      // amp-story tests are very flaky.  see above.
       "url": "examples/visual-tests/amp-story/amp-story-grid-layer-template-fill.html",
       "name": "amp-story: Grid layer (fill) (desktop)",
       "viewport": {"width": 1440, "height": 900},
@@ -359,8 +328,6 @@
       ]
     },
     {
-      "flaky": true,
-      // amp-story tests are very flaky.  see above.
       "url": "examples/visual-tests/amp-story/amp-story-grid-layer-template-vertical.html",
       "name": "amp-story: Grid layer (vertical) (desktop)",
       "viewport": {"width": 1440, "height": 900},
@@ -370,8 +337,6 @@
       ]
     },
     {
-      "flaky": true,
-      // amp-story tests are very flaky.  see above.
       "url": "examples/visual-tests/amp-story/amp-story-grid-layer-template-horizontal.html",
       "name": "amp-story: Grid layer (horizontal) (desktop)",
       "viewport": {"width": 1440, "height": 900},
@@ -381,8 +346,6 @@
       ]
     },
     {
-      "flaky": true,
-      // amp-story tests are very flaky.  see above.
       "url": "examples/visual-tests/amp-story/amp-story-grid-layer-template-thirds.html",
       "name": "amp-story: Grid layer (thirds) (desktop)",
       "viewport": {"width": 1440, "height": 900},
@@ -395,8 +358,6 @@
       ]
     },
     {
-      "flaky": true,
-      // amp-story tests are very flaky.  see above.
       "url": "examples/visual-tests/amp-story/amp-story-cta-layer.html",
       "name": "amp-story: CTA layer (desktop)",
       "viewport": {"width": 1440, "height": 900},
@@ -406,8 +367,6 @@
       ]
     },
     {
-      "flaky": true,
-      // amp-story tests are very flaky.  see above.
       "url": "examples/visual-tests/amp-story/embed-mode-1.html",
       "name": "amp-story: embed mode 1 (desktop)",
       "viewport": {"width": 1440, "height": 900},
@@ -416,8 +375,6 @@
       ]
     },
     {
-      "flaky": true,
-      // amp-story tests are very flaky.  see above.
       "url": "examples/visual-tests/amp-story/embed-mode-2.html",
       "name": "amp-story: embed mode 2 (desktop)",
       "viewport": {"width": 1440, "height": 900},
@@ -426,8 +383,6 @@
       ]
     },
     {
-      "flaky": true,
-      // amp-story tests are very flaky.  see above.
       "url": "examples/visual-tests/amp-story/amp-story-bookend.html",
       "name": "amp-story: bookend (desktop)",
       "viewport": {"width": 1440, "height": 900},
@@ -437,8 +392,6 @@
       ]
     },
     {
-      "flaky": true,
-      // amp-story tests are very flaky.  see above.
       "url": "examples/visual-tests/amp-story/amp-story-consent.html",
       "name": "amp-story: consent (desktop)",
       "viewport": {"width": 1440, "height": 900},
@@ -448,8 +401,6 @@
       ]
     },
     {
-      "flaky": true,
-      // amp-story tests are very flaky.  see above.
       "url": "examples/visual-tests/amp-story/amp-story-unsupported-browser-layer.html",
       "name": "amp-story: unsupported browser (desktop)",
       "viewport": {"width": 1440, "height": 900},
@@ -459,8 +410,6 @@
       ]
     },
     {
-      "flaky": true,
-      // amp-story tests are very flaky.  see above.
       "url": "examples/visual-tests/amp-story/basic.rtl.html",
       "name": "amp-story: basic (rtl)",
       "viewport": {"width": 320, "height": 480},
@@ -470,8 +419,6 @@
       ]
     },
     {
-      "flaky": true,
-      // amp-story tests are very flaky.  see above.
       "url": "examples/visual-tests/amp-story/share-menu.rtl.html",
       "name": "amp-story: share menu (rtl)",
       "viewport": {"width": 320, "height": 480},
@@ -481,8 +428,6 @@
       ]
     },
     {
-      "flaky": true,
-      // amp-story tests are very flaky.  see above.
       "url": "examples/visual-tests/amp-story/info-dialog.rtl.html",
       "name": "amp-story: info dialog (rtl)",
       "viewport": {"width": 320, "height": 480},
@@ -492,8 +437,6 @@
       ]
     },
     {
-      "flaky": true,
-      // amp-story tests are very flaky.  see above.
       "url": "examples/visual-tests/amp-story/amp-story-bookend.rtl.html",
       "name": "amp-story: bookend (rtl)",
       "viewport": {"width": 320, "height": 480},
@@ -503,8 +446,6 @@
       ]
     },
     {
-      "flaky": true,
-      // amp-story tests are very flaky.  see above.
       "url": "examples/visual-tests/amp-story/amp-story-consent.rtl.html",
       "name": "amp-story: consent (rtl)",
       "viewport": {"width": 320, "height": 480},
@@ -514,8 +455,6 @@
       ]
     },
     {
-      "flaky": true,
-      // amp-story tests are very flaky.  see above.
       "url": "examples/visual-tests/amp-story/basic.rtl.html",
       "name": "amp-story: basic (desktop) (rtl)",
       "viewport": {"width": 1440, "height": 900},
@@ -525,8 +464,6 @@
       ]
     },
     {
-      "flaky": true,
-      // amp-story tests are very flaky.  see above.
       "url": "examples/visual-tests/amp-story/amp-story-bookend.rtl.html",
       "name": "amp-story: bookend (desktop) (rtl)",
       "viewport": {"width": 1440, "height": 900},
@@ -536,8 +473,6 @@
       ]
     },
     {
-      "flaky": true,
-      // amp-story tests are very flaky.  see above.
       "url": "examples/visual-tests/amp-story/amp-story-consent.rtl.html",
       "name": "amp-story: consent (desktop) (rtl)",
       "viewport": {"width": 1440, "height": 900},
@@ -547,8 +482,6 @@
       ]
     },
     {
-      "flaky": true,
-      // amp-story tests are very flaky.  see above.
       // The url here should not matter; this UI should be triggered for all
       // story documents, based on the viewport dimensions.
       "url": "examples/visual-tests/amp-story/basic.html",

--- a/test/visual-diff/visual-tests
+++ b/test/visual-diff/visual-tests
@@ -75,6 +75,11 @@
    *     ".another-loading-complete-css-class"
    *   ],
    *
+   *   // [optional] A duration of time (in milliseconds) to wait after all
+   *   // other loading is complete, before taking a snapshot. Can be used to
+   *   // allow CSS transitions or other effects to complete.
+   *   "loading_complete_delay_ms": 1000,
+   *
    *   // [optional] Experiments that must be enabled via cookies.
    *   "experiments": [
    *     "amp-feature-one",
@@ -198,7 +203,8 @@
       "loading_complete_css": [
         ".i-amphtml-story-loaded",
         "amp-story-page#page-2[active]"
-      ]
+      ],
+      "loading_complete_delay_ms": 500, /* for page navigation */
     },
     {
       "url": "examples/visual-tests/amp-story/amp-story-grid-layer-template-fill.html",
@@ -246,7 +252,8 @@
       "loading_complete_css": [
         ".i-amphtml-story-loaded",
         "amp-story-page#the-one-with-the-cta-layer[active]"
-      ]
+      ],
+      "loading_complete_delay_ms": 500, /* for page navigation */
     },
     {
       "url": "examples/visual-tests/amp-story/embed-mode-1.html",
@@ -317,7 +324,8 @@
         ".i-amphtml-story-loaded",
         ".i-amphtml-story-share-pill-label",
         "amp-story-page#page-2[active]"
-      ]
+      ],
+      "loading_complete_delay_ms": 500, /* for page navigation */
     },
     {
       "url": "examples/visual-tests/amp-story/amp-story-grid-layer-template-fill.html",
@@ -370,7 +378,8 @@
         ".i-amphtml-story-loaded",
         ".i-amphtml-story-share-pill-label",
         "amp-story-page#the-one-with-the-cta-layer[active]"
-      ]
+      ],
+      "loading_complete_delay_ms": 500, /* for page navigation */
     },
     {
       "url": "examples/visual-tests/amp-story/embed-mode-1.html",
@@ -425,7 +434,8 @@
       "loading_complete_css": [
         ".i-amphtml-story-loaded",
         "amp-story-page#page-2[active]"
-      ]
+      ],
+      "loading_complete_delay_ms": 500, /* for page navigation */
     },
     {
       "url": "examples/visual-tests/amp-story/share-menu.rtl.html",
@@ -471,7 +481,8 @@
         ".i-amphtml-story-loaded",
         ".i-amphtml-story-share-pill-label",
         "amp-story-page#page-2[active]"
-      ]
+      ],
+      "loading_complete_delay_ms": 500, /* for page navigation */
     },
     {
       "url": "examples/visual-tests/amp-story/amp-story-bookend.rtl.html",


### PR DESCRIPTION
There were two causes of flakiness that I could identify.

1. The spinner for videos ([example](https://percy.io/ampproject/amphtml/builds/894594/view/52499659/320?browser=firefox&mode=diff)).  I remedied this by hiding the spinner in the CSS of every visual diff test with a video.
2. The share pill was rendering differently ([example](https://percy.io/ampproject/amphtml/builds/894594/view/52499859/1440?browser=firefox&mode=diff)).  I remedied this by waiting for the `.i-amphtml-story-share-pill-label` selector to be visible in all tests that show the share pill.

After this is merged, I will run numerous runs of the visual diff tests in a clean branch synced to HEAD on master, to ensure they are not flaky.