### PR TITLE
📖 Clean up docs for "observer" components

### DIFF
--- a/extensions/amp-orientation-observer/amp-orientation-observer.md
+++ b/extensions/amp-orientation-observer/amp-orientation-observer.md
@@ -19,8 +19,8 @@ limitations under the License.
 <table>
   <tr>
     <td width="40%"><strong>Description</strong></td>
-    <td>Monitors the orientation of an element within the viewport as a user scrolls, and dispatches <code>enter</code>, <code>exit</code> and <code>scroll</code> events that can be used with
-    other components, such as <code>&lt;amp-animation>.</code>
+    <td>Monitors the orientation of an element within the viewport as a user scrolls, and dispatches events that can be used with
+    other AMP components.</code>
     </td>
   </tr>
   <tr>
@@ -28,34 +28,42 @@ limitations under the License.
     <td><code>&lt;script async custom-element="amp-orientation-observer" src="https://cdn.ampproject.org/v0/amp-orientation-observer-0.1.js">&lt;/script></code></td>
   </tr>
   <tr>
-    <td class="col-fourty"><strong><a href="https://www.ampproject.org/docs/guides/responsive/control_layout.html">Supported Layouts</a></strong></td>
+    <td class="col-fourty"><strong><a href="https://www.ampproject.org/docs/design/responsive/control_layout#the-layout-attribute">Supported Layouts</a></strong></td>
     <td>nodisplay</td>
   </tr>
   <tr>
     <td width="40%"><strong>Examples</strong></td>
-    <td>
-      <ul>
-        <li><a href="https://codepen.io/nainar92/project/full/XwzYOd/">CodePen project with samples</a></li>
-      </ul>
+    <td><a href="https://codepen.io/nainar92/project/full/XwzYOd/">CodePen project with samples</a>
     </td>
   </tr>
 </table>
 
 [TOC]
 
-## What is amp-orientation-observer?
+## Overview
 
-`amp-orientation-observer` is a functional component that monitors the orientation of an the device, and dispatches `alpha`, `beta` and `gamma` events (Low Trust Level) which report changes in the device orientation along the `alpha`, `beta` and `gamma` axises in terms of `angle` and `percent`. These can be used to trigger actions (Only Low Trust Actions) on other components.
+The `amp-orientation-observer` component monitors the orientation of a device, and dispatches low-trust level events (`alpha`, `beta`, `gamma`) that report changes in the device's orientation along the `alpha`, `beta` and `gamma` axises in terms of `angle` and `percent`. These can be used to trigger actions (*Only Low Trust Actions*) on other components (e.g., [amp-animation](https://www.ampproject.org/docs/reference/components/amp-animation)).
 
-- The `alpha` event represents the motion of the device around the z axis.
-- The `beta` event represents the motion of the device around the x axis.
-- The `gamma` event represents the motion of the device around the y axis. This represents a left to right motion of the device.
-
+{% call callout('Note', type='note') %}
 The `amp-orientation-observer` component is only useful when used with other components and does not do anything on its own.
+{% endcall %}
+
+
+#### Events
+
+These are the low-trust level events that the `amp-orientation-observer` component dispatches:
+
+
+| Event    | Description                                            |
+| ---------| -------------------------------------------------------|
+| `alpha`  | Represents the motion of the device around the z axis. |
+| `beta`   | Represents the motion of the device around the x axis. |
+| `gamma`  | Represents the motion of the device around the y axis. This represents a left to right motion of the device. |
+
 
 ## What can I do with amp-orientation-observer?
 
-Currently `amp-animation` and several video players in AMP are the only components that allow low-trust events to trigger their actions such as starting an animation, seeking to a position within the animation, pausing a video, etc.
+Currently, [amp-animation](https://www.ampproject.org/docs/reference/components/amp-animation) and several video players in AMP are the only components that allow low-trust events to trigger their actions (e.g., starting an animation, seeking to a position within the animation, pausing a video, etc.).
 
 ### Scroll-bound animations
 
@@ -105,15 +113,15 @@ Imagine an animation where the hour hand of a clock rotates as the user scrolls 
 
 ## Attributes
 
-### alpha-range (optional)
+##### alpha-range (optional)
 
-Specifies that the associated action should only take place for changes between the specified range along the z axis. Specified as a space separated list of 2 values e.g. `alpha-range="0 180"`. By default the related action is triggered for all changes between `0` and `360 degrees`.
+Specifies that the associated action should only take place for changes between the specified range along the z axis. Specified as a space separated list of 2 values (e.g., `alpha-range="0 180"`). By default, the related action is triggered for all changes between `0` and `360 degrees`.
 
-### beta-range (optional)
+##### beta-range (optional)
 
-Specifies that the associated action should only take place for changes between the specified range along the x axis. Specified as a space separated list of 2 values e.g. `beta-range="0 180"`. By default the related action is triggered for all changes between `0` and `360 degrees`.
+Specifies that the associated action should only take place for changes between the specified range along the x axis. Specified as a space separated list of 2 values (e.g., `beta-range="0 180"`). By default, the related action is triggered for all changes between `0` and `360 degrees`.
 
-#### Example: Limit the range of degrees to watch along the x axis.
+*Example: Using beta-range to limit the range of degrees to watch along the x axis*
 
 Imagine an animation where the hour hand of a clock rotates as the user scrolls the page.
 
@@ -125,9 +133,9 @@ Imagine an animation where the hour hand of a clock rotates as the user scrolls 
 </amp-orientation-observer>
 ```
 
-### gamma-range (optional)
+##### gamma-range (optional)
 
-Specifies that the associated action should only take place for changes between the specified range along the y axis. Specified as a space separated list of 2 values e.g. `gamma-range="0 90"`. By default the related action is triggered for all changes between `0` and `360 degrees`.
+Specifies that the associated action should only take place for changes between the specified range along the y axis. Specified as a space separated list of 2 values (e.g., `gamma-range="0 90"`. By default the related action is triggered for all changes between `0` and `360 degrees`.
 
 ## Validation
 

--- a/extensions/amp-position-observer/amp-position-observer.md
+++ b/extensions/amp-position-observer/amp-position-observer.md
@@ -19,8 +19,8 @@ limitations under the License.
 <table>
   <tr>
     <td width="40%"><strong>Description</strong></td>
-    <td>Monitors the position of an element within the viewport as a user scrolls, and dispatches <code>enter</code>, <code>exit</code> and <code>scroll</code> events that can be used with
-    other components, such as <code>&lt;amp-animation>.</code>
+    <td>Monitors the position of an element within the viewport as a user scrolls, and dispatches events that can be used with
+    other AMP components.</code>
     </td>
   </tr>
   <tr>
@@ -44,20 +44,22 @@ limitations under the License.
 
 [TOC]
 
-## What is amp-position-observer?
-`amp-position-observer` is a functional component that monitors the position of an
-element within the viewport as a user scrolls, and dispatches
-`enter`, `exit` and `scroll:<Position In Viewport As a Percentage>` events (**Low Trust Level**)
-which can be used to trigger actions (**Only Low Trust Actions**) on other components.
+## Overview
 
+The `amp-position-observer` component monitors the position of an
+element within the viewport as a user scrolls, and dispatches
+`enter`, `exit` and `scroll:<Position In Viewport As a Percentage>` events (**Low Trust Level**), which can be used to trigger actions (**Only Low Trust Actions**) on other components (e.g., [amp-animation](https://www.ampproject.org/docs/reference/components/amp-animation).
+
+{% call callout('Note', type='note') %}
 The `amp-position-observer` component is only useful when used with other components and does not do anything on its own.
+{% endcall %}
 
 ## What can I do with amp-position-observer?
 
-Currently [amp-animation](https://www.ampproject.org/docs/reference/components/amp-animation)
+Currently, [amp-animation](https://www.ampproject.org/docs/reference/components/amp-animation)
 and several video players in AMP are the only components that allow low-trust events
-to trigger their actions such as starting an animation, seeking to a position
-within the animation, pausing a video, etc.
+to trigger their actions (e.g., starting an animation, seeking to a position
+within the animation, pausing a video, etc.).
 
 ### Scroll-bound animations
 The `amp-animation` component exposes a `seekTo` action that can be tied to the `scroll` event
@@ -188,10 +190,10 @@ as clock becomes less than 50% visible.
 
 ## Attributes
 
-#### target (optional)
+##### target (optional)
 Specifies the ID of the element to observe. If **not specified**, the **parent** of `<amp-position-observer>` is used as the target.
 
-#### intersection-ratios (optional)
+##### intersection-ratios (optional)
 
 Defines how much of the target should be visible in the viewport before `<amp-position-observer>` triggers any of its events. The value is a number between 0 and 1 (default is 0).
 
@@ -203,7 +205,7 @@ You can specify different ratios for top vs. bottom by providing two values (`<t
 - `intersection-ratios="0 1"` makes the conditions different depending on whether the target is entering/exiting from top (0 will be used) or bottom (1 will be used).
 
 
-#### viewport-margins (optional)
+##### viewport-margins (optional)
 
 A `px` or `vh` value which can be used to shrink the area of the viewport used for visibility calculations. A number without a unit will be assumed `px`. Defaults to 0.
 
@@ -213,9 +215,9 @@ You can specify different values for top vs. bottom by providing two values (`<t
 - `viewport-margins="25vh"` means shrink the viewport by 25% from the top and 25% from the bottom. Effectively only considering the middle 50% of the viewport.
 - `viewport-margins="100px 10vh"` means shrink the viewport by 100px from the top and 10% from the bottom.
 
-#### once (optional)
+##### once (optional)
 
-Only triggers `enter` and `exit` events once. `scroll` event will also only do one iteration.
+Only triggers the `enter` and `exit` events once. The `scroll` event will also only perform one iteration.
 
 ## Validation
 


### PR DESCRIPTION
Cleaned up the docs for `amp-position-observer` and `amp-orientation-observer` so they are consistent in appearance and wording, and are clear.

As `amp-orientation-observer` is new, I'll make sure it's pulled into ampproject.org's docs.

Note: These two components are confusing upon first glance because of their naming, and they are worded practically identically.

cc: @nainar 