### PR TITLE
✨Allow static initial date attributes. Enable date offsets.

### DIFF
--- a/examples/date-picker.amp.html
+++ b/examples/date-picker.amp.html
@@ -228,7 +228,29 @@
   ></amp-date-picker>
 </amp-lightbox>
 
+<h2>Initial dates</h2>
+<h3>Today default</h3>
+<amp-date-picker date="P0D" layout="fixed-height" height="300"></amp-date-picker>
+
+<h3>Next week default</h3>
+<amp-date-picker type="range" start-date="P4W" end-date="P5W" layout="fixed-height" height="300" number-of-months=3></amp-date-picker>
+
 <h2>Actions</h2>
+<h3>setDate</h3>
+<button on="tap: sdsp.setDate(date='P0D')">Today</button>
+<button on="tap: sdsp.setDate(date='P1D')">Tomorrow</button>
+<button on="tap: sdsp.setDate(date='2018-08-09')">2018-08-09</button>
+<amp-date-picker id="sdsp" layout="fixed-height" height="360"></amp-date-picker>
+
+<h3>setDates</h3>
+<button on="tap: sdrp.setDates(startDate='P0D',endDate='P0D')">Today</button>
+<button on="tap: sdrp.setDates(startDate='P0D',endDate='P1D')">Tonight</button>
+<button on="tap: sdrp.setDates(startDate='P0D',endDate='P1W')">This week</button>
+<button on="tap: sdrp.setDates(startDate='2018-08-09')">Start 2018-08-09</button>
+<button on="tap: sdrp.setDates(endDate='2018-08-10')">End 2018-08-10</button>
+<button on="tap: sdrp.setDates(startDate='2018-08-10',endDate='2018-08-12')">Range 2018-08-10 to 2018-08-12</button>
+<amp-date-picker id="sdrp" type="range" layout="fixed-height" height="360"></amp-date-picker>
+
 <h3>Today</h3>
 <button on="tap: tsp.today">Today</button>
 <button on="tap: tsp.today(offset=1)">Tomorrow</button>

--- a/extensions/amp-date-picker/0.1/amp-date-picker.js
+++ b/extensions/amp-date-picker/0.1/amp-date-picker.js
@@ -547,7 +547,7 @@ export class AmpDatePicker extends AMP.BaseElement {
    * @param {string} date
    */
   handleSetDateFromString_(date) {
-    const momentDate = this.createMoment_(date);
+    const momentDate = this.createOffsetMoment_(date);
     return this.handleSetDate_(momentDate);
   }
 
@@ -568,8 +568,8 @@ export class AmpDatePicker extends AMP.BaseElement {
    * @param {?string} endDate
    */
   handleSetDatesFromString_(startDate, endDate) {
-    const momentStart = startDate ? this.createMoment_(startDate) : null;
-    const momentEnd = endDate ? this.createMoment_(endDate) : null;
+    const momentStart = startDate ? this.createOffsetMoment_(startDate) : null;
+    const momentEnd = endDate ? this.createOffsetMoment_(endDate) : null;
     this.handleSetDates_(momentStart, momentEnd);
   }
 
@@ -602,10 +602,11 @@ export class AmpDatePicker extends AMP.BaseElement {
   }
 
   /**
-   * Forgivingly parse an input string into a moment object, preferring the
-   * date picker's configured format.
+   * Forgivingly parse an ISO8601 input string into a moment object,
+   * preferring the date picker's configured format.
    * @param {string} input The input date string to parse
    * @return {?moment}
+   * @private
    */
   createMoment_(input) {
     if (!input) {
@@ -613,6 +614,26 @@ export class AmpDatePicker extends AMP.BaseElement {
     }
     const moment = this.moment_(input, this.format_);
     return moment.isValid() ? moment : this.moment_(input);
+  }
+
+  /**
+   * Parse an ISO8601 date or duration.
+   * @param {string} input The input date string to parse
+   * @return {?moment}
+   * @private
+   */
+  createOffsetMoment_(input) {
+    if (!input) {
+      return null;
+    }
+    const isISO8601Duration = (input[0] == 'P');
+
+    if (isISO8601Duration) {
+      const duration = this.moment_.duration(input);
+      return this.moment_().add(duration);
+    } else {
+      return this.createMoment_(input);
+    }
   }
 
   /**
@@ -648,15 +669,25 @@ export class AmpDatePicker extends AMP.BaseElement {
    * the AMP element.
    */
   getInitialState_() {
-    const date = this.dateField_ && this.dateField_.value ?
-      this.createMoment_(this.dateField_.value) :
-      null;
-    const startDate = this.startDateField_ && this.startDateField_.value ?
-      this.createMoment_(this.startDateField_.value) :
-      null;
-    const endDate = this.endDateField_ && this.endDateField_.value ?
-      this.createMoment_(this.endDateField_.value) :
-      null;
+    const {element} = this;
+    const date = this.createOffsetMoment_(element.getAttribute('date') ||
+        (this.dateField_ && this.dateField_.value));
+    const startDate = this.createOffsetMoment_(
+        element.getAttribute('start-date') ||
+        (this.startDateField_ && this.startDateField_.value));
+    const endDate = this.createOffsetMoment_(
+        element.getAttribute('end-date') ||
+        (this.endDateField_ && this.endDateField_.value));
+
+    if (date && this.dateField_) {
+      this.dateField_.value = this.getFormattedDate_(date);
+    }
+    if (startDate && this.startDateField_) {
+      this.startDateField_.value = this.getFormattedDate_(startDate);
+    }
+    if (endDate && this.endDateField_) {
+      this.endDateField_.value = this.getFormattedDate_(endDate);
+    }
 
     return map({
       date,

--- a/extensions/amp-date-picker/0.1/test/integration/test-integration-dates-attributes.js
+++ b/extensions/amp-date-picker/0.1/test/integration/test-integration-dates-attributes.js
@@ -1,0 +1,97 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as lolex from 'lolex';
+import {htmlFor} from '../../../../../src/static-template';
+import {poll} from '../../../../../testing/iframe';
+
+const config = describe.configure().ifNewChrome().skipSinglePass();
+config.run('amp-date-picker', function() {
+  this.timeout(10000);
+
+  const extensions = ['amp-date-picker'];
+
+  describes.integration('single date attribute', {
+    // TODO(cvializ): The beforeEach timers are not installed soon enough
+    // so the date picker uses the non-fake time when the element is built.
+    // Adding the elements to the body after the fake timer is installed
+    // solves the problem. I believe this could be resolved if the `body`
+    // property here was added after the beforeEach runs.
+    body: '',
+    extensions,
+  }, env => {
+    let win;
+    let document;
+    let clock;
+
+    beforeEach(() => {
+      win = env.win;
+      document = env.win.document;
+      clock = lolex.install({
+        target: win,
+        now: new Date('2018-01-01T08:00:00Z'),
+      });
+
+      document.body.appendChild(htmlFor(document)`
+      <div>
+        <input id="today-explicit-date">
+        <amp-date-picker
+          layout="fixed-height"
+          height="360"
+          id="today-explicit"
+          date="2018-01-01"
+          input-selector="#today-explicit-date"
+        ></amp-date-picker>
+
+        <input id="today-duration-date">
+        <amp-date-picker
+          layout="fixed-height"
+          height="360"
+          id="today-duration"
+          date="P0D"
+          input-selector="#today-duration-date"
+        ></amp-date-picker>
+      </div>`);
+    });
+
+    after(() => {
+      clock.uninstall();
+    });
+
+    it('sets the date to today explicitly', () => {
+      const date = document.getElementById('today-explicit-date');
+
+      return waitForProperty(date, 'value').then(() => {
+        expect(date.value).to.equal('2018-01-01');
+      });
+    });
+
+    it('sets the date to today with a duration', () => {
+      const date = document.getElementById('today-duration-date');
+
+      return waitForProperty(date, 'value').then(() => {
+        expect(date.value).to.equal('2018-01-01');
+      });
+    });
+  });
+});
+
+function waitForProperty(element, property) {
+  return poll(`wait for property ${property} on ${element.id}`, () => {
+    return element[property];
+  }, undefined, 8000);
+}
+

--- a/third_party/moment/moment.extern.js
+++ b/third_party/moment/moment.extern.js
@@ -91,3 +91,6 @@ moment.Locale.longDateFormat = function (format) {};
 
 /** @return {moment.Locale} */
 moment.prototype.localeData = function () {};
+
+/** @return {!moment} */
+moment.prototype.duration = function () {};


### PR DESCRIPTION
Authors can now specify `date`, `start-date` and `end-date` attributes and they can be assigned ISO 8601 durations to specify a distance from today's date, e.g.

```html
<!-- Select tomorrow by default -->
<amp-date-picker layout="fixed-height" height="360" date="P1D">
<!-- Select next week -->
<amp-date-picker layout="fixed-height" height="360" start-date="P1W" end-date="P2W">
``` 

Next up will be binding to these attributes.

This does not enable selecting offsets from weekdays, e.g. "select a week from the next monday," but this implementation should cover most use-cases.