### PR TITLE
fix parenthesis removal when preprocessing with babel

### DIFF
--- a/build-system/babel-plugins/babel-plugin-transform-amp-asserts/index.js
+++ b/build-system/babel-plugins/babel-plugin-transform-amp-asserts/index.js
@@ -40,7 +40,9 @@ module.exports = function(babel) {
   return {
     visitor: {
       CallExpression(path) {
-        const {callee} = path.node;
+        const {node} = path;
+        const {callee} = node;
+        const {parenthesized} = node.extra || {};
         const isMemberAndCallExpression = t.isMemberExpression(callee)
             && t.isCallExpression(callee.object);
 
@@ -65,7 +67,12 @@ module.exports = function(babel) {
         // don't remove.
         const args = path.node.arguments[0];
         if (args) {
-          path.replaceWith(args);
+          if (parenthesized) {
+            path.replaceWith(t.parenthesizedExpression(args));
+            path.skip();
+          } else {
+            path.replaceWith(args);
+          }
         } else {
           // This is to resolve right hand side usage of expression where
           // no argument is passed in.

--- a/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/preserve-parens/input.js
+++ b/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/preserve-parens/input.js
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/** @type {x} */ (dev().assertElement(dev()));
+
+function hello() {
+    return /** @type {x} */ (
+        dev().assertElement(dev()));
+}

--- a/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/preserve-parens/options.json
+++ b/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/preserve-parens/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["../../../../../babel-plugin-transform-amp-asserts"]
+}

--- a/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/preserve-parens/output.js
+++ b/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/preserve-parens/output.js
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** @type {x} */
+(dev());
+
+function hello() {
+  return (
+    /** @type {x} */
+    (dev())
+  );
+}

--- a/build-system/babel-plugins/babel-plugin-transform-parenthesize-expression/index.js
+++ b/build-system/babel-plugins/babel-plugin-transform-parenthesize-expression/index.js
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module.exports = function(babel) {
+  const {types: t} = babel;
+  return {
+    visitor: {
+      Expression: {
+        exit(path) {
+          const {node} = path;
+          const {parenthesized} = node.extra || {};
+          if (!parenthesized) {
+            return;
+          }
+
+          path.replaceWith(t.parenthesizedExpression(node));
+          path.skip();
+        },
+      },
+    },
+  };
+};

--- a/package.json
+++ b/package.json
@@ -206,6 +206,8 @@
       "/test/fixtures/",
       "<rootDir>/build/"
     ],
-    "reporters": ["jest-dot-reporter"]
+    "reporters": [
+      "jest-dot-reporter"
+    ]
   }
 }


### PR DESCRIPTION
we need to preserve the parenthesis so that type casting through closure annotations don't break.