### PR TITLE
✅ amp-image-slider test speedup

### DIFF
--- a/extensions/amp-image-slider/0.1/test/integration/test-amp-image-slider.js
+++ b/extensions/amp-image-slider/0.1/test/integration/test-amp-image-slider.js
@@ -89,7 +89,7 @@ config.run('amp-image-slider', function() {
         // layoutCallback is called
         // this is the same as CommonSignal.LOAD_END
         return !!slider.signals().get('load-end');
-      }, 1000);
+      });
     }
 
     function createFakeEvent(type, x, y) {
@@ -167,7 +167,7 @@ config.run('amp-image-slider', function() {
           return true;
         }
         return false;
-      }, 500);
+      }, () => { return `${leftPos} is not reached.`; });
     }
 
     it('should construct', () => {

--- a/extensions/amp-image-slider/0.1/test/integration/test-amp-image-slider.js
+++ b/extensions/amp-image-slider/0.1/test/integration/test-amp-image-slider.js
@@ -89,7 +89,7 @@ config.run('amp-image-slider', function() {
         // layoutCallback is called
         // this is the same as CommonSignal.LOAD_END
         return !!slider.signals().get('load-end');
-      });
+      }, 1000);
     }
 
     function createFakeEvent(type, x, y) {
@@ -107,10 +107,6 @@ config.run('amp-image-slider', function() {
       return event;
     }
 
-    function timeout(win, ms) {
-      return new Promise(resolve => win.setTimeout(resolve, ms));
-    }
-
     function createKeyDownEvent(key) {
       return new KeyboardEvent('keydown', {
         key,
@@ -124,13 +120,13 @@ config.run('amp-image-slider', function() {
 
     function prep() {
       return waitForImageSlider()
-          .then(() => timeout(env.win, 1000))
           .then(prepareSlider);
     }
 
     // A bunch of expects to check if the slider has slided to
     // where we intended
-    function expectByBarLeftPos(leftPos) {
+    // Returns true/false for position checks
+    function isOkByBarLeftPos(leftPos) {
       slider = doc.querySelector('#slider');
       bar_ = slider.querySelector('.i-amphtml-image-slider-bar');
       container_ =
@@ -148,19 +144,30 @@ config.run('amp-image-slider', function() {
       const roundedLeftPos = Math.round(leftPos);
       const roundedRectLeft = Math.round(rect.left);
 
-      expect(Math.round(bar_.getBoundingClientRect().left))
-          .to.equal(roundedLeftPos);
-      expect(Math.round(rightMask_.getBoundingClientRect().left))
-          .to.equal(roundedLeftPos);
-      // amp-imgs should stay where they are
-      expect(Math.round(leftAmpImage_.getBoundingClientRect().left))
-          .to.equal(roundedRectLeft);
-      expect(Math.round(rightAmpImage_.getBoundingClientRect().left))
-          .to.equal(roundedRectLeft);
-      expect(Math.round(leftLabel_.getBoundingClientRect().left))
-          .to.equal(roundedRectLeft);
-      expect(Math.round(rightLabel_.getBoundingClientRect().left))
-          .to.equal(roundedRectLeft);
+      return Math.round(bar_.getBoundingClientRect().left)
+          === roundedLeftPos &&
+        Math.round(rightMask_.getBoundingClientRect().left)
+          === roundedLeftPos &&
+        Math.round(leftAmpImage_.getBoundingClientRect().left)
+          === roundedRectLeft &&
+        Math.round(rightAmpImage_.getBoundingClientRect().left)
+          === roundedRectLeft &&
+        Math.round(leftLabel_.getBoundingClientRect().left)
+          === roundedRectLeft &&
+        Math.round(rightLabel_.getBoundingClientRect().left)
+          === roundedRectLeft;
+    }
+
+    // Poll for 500ms.
+    // If all elements are at correct position in 500ms, resolve
+    // Otherwise, pass expected value to reject.
+    function pollByBarLeftPos(leftPos) {
+      return poll('examine position correctness', () => {
+        if (isOkByBarLeftPos(leftPos)) {
+          return true;
+        }
+        return false;
+      }, 500);
     }
 
     it('should construct', () => {
@@ -203,10 +210,7 @@ config.run('amp-image-slider', function() {
                 );
 
             container_.dispatchEvent(mouseDownEvent);
-            return timeout(env.win, 500);
-          })
-          .then(() => {
-            expectByBarLeftPos(leftQuarterPos);
+            return pollByBarLeftPos(leftQuarterPos);
           })
           .then(() => {
             centerPos = rect.left + 0.5 * rect.width;
@@ -217,10 +221,7 @@ config.run('amp-image-slider', function() {
                     0
                 );
             container_.dispatchEvent(mouseDownEvent);
-            return timeout(env.win, 500);
-          })
-          .then(() => {
-            expectByBarLeftPos(centerPos);
+            return pollByBarLeftPos(centerPos);
           });
     });
 
@@ -239,10 +240,7 @@ config.run('amp-image-slider', function() {
                     0
                 );
             slider.dispatchEvent(touchStartEvent);
-            return timeout(env.win, 500);
-          })
-          .then(() => {
-            expectByBarLeftPos(leftQuarterPos);
+            return pollByBarLeftPos(leftQuarterPos);
           })
           .then(() => {
             centerPos = rect.left + 0.5 * rect.width;
@@ -253,10 +251,7 @@ config.run('amp-image-slider', function() {
                     0
                 );
             slider.dispatchEvent(touchStartEvent);
-            return timeout(env.win, 500);
-          })
-          .then(() => {
-            expectByBarLeftPos(centerPos);
+            return pollByBarLeftPos(centerPos);
           });
     });
 
@@ -284,11 +279,9 @@ config.run('amp-image-slider', function() {
                 0
             );
             container_.dispatchEvent(mouseDownEvent);
-            return timeout(env.win, 500);
+            return pollByBarLeftPos(centerPos);
           })
           .then(() => {
-            expectByBarLeftPos(centerPos);
-
             // Mouse button is still down, move to somewhere on slider
             mouseMoveEvent = createFakeEvent(
                 'mousemove',
@@ -296,11 +289,9 @@ config.run('amp-image-slider', function() {
                 0
             );
             win.dispatchEvent(mouseMoveEvent);
-            return timeout(env.win, 500);
+            return pollByBarLeftPos(leftQuarterPos);
           })
           .then(() => {
-            expectByBarLeftPos(leftQuarterPos);
-
             // Mouse button is still down, move to somewhere outside of slider
             // The bar position should be capped at right border
             mouseMoveEvent = createFakeEvent(
@@ -309,11 +300,9 @@ config.run('amp-image-slider', function() {
                 0
             );
             win.dispatchEvent(mouseMoveEvent);
-            return timeout(env.win, 500);
+            return pollByBarLeftPos(rect.right);
           })
           .then(() => {
-            expectByBarLeftPos(rect.right);
-
             // Mouse button is still down, move back to inside the slider
             // The bar position should still be updated
             mouseMoveEvent = createFakeEvent(
@@ -322,11 +311,9 @@ config.run('amp-image-slider', function() {
                 0
             );
             win.dispatchEvent(mouseMoveEvent);
-            return timeout(env.win, 500);
+            return pollByBarLeftPos(rightQuarterPos);
           })
           .then(() => {
-            expectByBarLeftPos(rightQuarterPos);
-
             // Release mouse button
             mouseUpEvent = createFakeEvent(
                 'mouseup',
@@ -334,11 +321,9 @@ config.run('amp-image-slider', function() {
                 0
             );
             win.dispatchEvent(mouseUpEvent);
-            return timeout(env.win, 500);
+            return pollByBarLeftPos(rightQuarterPos);
           })
           .then(() => {
-            expectByBarLeftPos(rightQuarterPos);
-
             // Mouse button is now up, should no longer follow mouse move
             mouseMoveEvent = createFakeEvent(
                 'mousemove',
@@ -346,10 +331,7 @@ config.run('amp-image-slider', function() {
                 0
             );
             win.dispatchEvent(mouseMoveEvent);
-            return timeout(env.win, 500);
-          })
-          .then(() => {
-            expectByBarLeftPos(rightQuarterPos);
+            return pollByBarLeftPos(rightQuarterPos);
           });
     });
 
@@ -372,11 +354,9 @@ config.run('amp-image-slider', function() {
                 0
             );
             slider.dispatchEvent(touchStartEvent);
-            return timeout(env.win, 500);
+            return pollByBarLeftPos(centerPos);
           })
           .then(() => {
-            expectByBarLeftPos(centerPos);
-
             // Touch is still down, move to somewhere on slider
             touchMoveEvent = createFakeEvent(
                 'touchmove',
@@ -384,11 +364,9 @@ config.run('amp-image-slider', function() {
                 0
             );
             slider.dispatchEvent(touchMoveEvent);
-            return timeout(env.win, 500);
+            return pollByBarLeftPos(leftQuarterPos);
           })
           .then(() => {
-            expectByBarLeftPos(leftQuarterPos);
-
             // Touch is still down, move to somewhere outside of slider
             // The bar position should be capped at right border
             touchMoveEvent = createFakeEvent(
@@ -397,11 +375,9 @@ config.run('amp-image-slider', function() {
                 0
             );
             slider.dispatchEvent(touchMoveEvent);
-            return timeout(env.win, 500);
+            return pollByBarLeftPos(rect.right);
           })
           .then(() => {
-            expectByBarLeftPos(rect.right);
-
             // Touch is still down, move back to inside the slider
             // The bar position should still be updated
             touchMoveEvent = createFakeEvent(
@@ -410,11 +386,9 @@ config.run('amp-image-slider', function() {
                 0
             );
             slider.dispatchEvent(touchMoveEvent);
-            return timeout(env.win, 500);
+            return pollByBarLeftPos(rightQuarterPos);
           })
           .then(() => {
-            expectByBarLeftPos(rightQuarterPos);
-
             // Release touch
             touchEndEvent = createFakeEvent(
                 'touchend',
@@ -422,11 +396,9 @@ config.run('amp-image-slider', function() {
                 0
             );
             slider.dispatchEvent(touchEndEvent);
-            return timeout(env.win, 500);
+            return pollByBarLeftPos(rightQuarterPos);
           })
           .then(() => {
-            expectByBarLeftPos(rightQuarterPos);
-
             // Mouse button is now up, should no longer follow mouse move
             touchMoveEvent = createFakeEvent(
                 'touchmove',
@@ -434,10 +406,7 @@ config.run('amp-image-slider', function() {
                 0
             );
             slider.dispatchEvent(touchMoveEvent);
-            return timeout(env.win, 500);
-          })
-          .then(() => {
-            expectByBarLeftPos(rightQuarterPos);
+            return pollByBarLeftPos(rightQuarterPos);
           });
     });
 
@@ -454,38 +423,27 @@ config.run('amp-image-slider', function() {
 
             keyDownEvent = createKeyDownEvent('ArrowLeft');
             slider.dispatchEvent(keyDownEvent);
-            return timeout(env.win, 500);
+            return pollByBarLeftPos(pos40Percent);
           })
           .then(() => {
-            expectByBarLeftPos(pos40Percent);
-
             keyDownEvent = createKeyDownEvent('ArrowRight');
             slider.dispatchEvent(keyDownEvent);
-            return timeout(env.win, 500);
+            return pollByBarLeftPos(centerPos);
           })
           .then(() => {
-            expectByBarLeftPos(centerPos);
-
             keyDownEvent = createKeyDownEvent('PageUp');
             slider.dispatchEvent(keyDownEvent);
-            return timeout(env.win, 500);
+            return pollByBarLeftPos(rect.left);
           })
           .then(() => {
-            expectByBarLeftPos(rect.left);
-
             keyDownEvent = createKeyDownEvent('Home');
             slider.dispatchEvent(keyDownEvent);
-            return timeout(env.win, 500);
+            return pollByBarLeftPos(centerPos);
           })
           .then(() => {
-            expectByBarLeftPos(centerPos);
-
             keyDownEvent = createKeyDownEvent('PageDown');
             slider.dispatchEvent(keyDownEvent);
-            return timeout(env.win, 500);
-          })
-          .then(() => {
-            expectByBarLeftPos(rect.right);
+            return pollByBarLeftPos(rect.right);
           });
     });
   });


### PR DESCRIPTION
- [x] Use `poll` with timeout to replace `timeout`, ensures faster `resolve` on action complete