### PR TITLE
🏗 Allow renovate to update AMP runtime dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,14 +3,6 @@
     "config:base"
   ],
   "statusCheckVerify": true,
-  "ignoreDeps": [
-    "babel-polyfill",
-    "document-register-element",
-    "dompurify",
-    "promise-pjs",
-    "web-activities",
-    "web-animations-js"
-  ],
   "includePaths": [
     "package.json"
   ]


### PR DESCRIPTION
We've been using tools like Greenkeeper, and now Renovate, to keep the `devDependencies` section of `package.json` up to date. However, we've preferred to manually upgrade the `dependencies` section due to the risk of a breaking change.

As it turns out, there's just as much risk in having dependency versions go stale because no one has touched them in years. For example, #15728

This PR enables semi-automatic updates to the `dependencies` section of `package.json`. A new PR will be generated for each item on the list that gets an updated. It still falls on the AMP build cop to review the updates, make sure they are safe, and merge them manually.