### PR TITLE
Setting AMP = 1 in UAS amp-ad tag

### DIFF
--- a/ads/uas.js
+++ b/ads/uas.js
@@ -67,6 +67,7 @@ export function uas(global, data) {
   loadScript(global, 'https://ads.pubmatic.com/AdServer/js/phoenix.js', () => {
     global.Phoenix.EQ.push(function() {
       global.Phoenix.enableSingleRequestCallMode();
+      global.Phoenix.setInfo('AMP', 1);
       global.Phoenix.setInfo('ACCID', data.accId);
       global.Phoenix.setInfo('PAGEURL', global.context.location.href);
       data.pageURL && global.Phoenix.setInfo('PAGEURL', data.pageURL);

--- a/ads/uas.js
+++ b/ads/uas.js
@@ -67,7 +67,7 @@ export function uas(global, data) {
   loadScript(global, 'https://ads.pubmatic.com/AdServer/js/phoenix.js', () => {
     global.Phoenix.EQ.push(function() {
       global.Phoenix.enableSingleRequestCallMode();
-      global.Phoenix.setInfo('AMP', 1);//Need to set the AMP flag
+      global.Phoenix.setInfo('AMP', 1);// Need to set the AMP flag
       global.Phoenix.setInfo('ACCID', data.accId);
       global.Phoenix.setInfo('PAGEURL', global.context.location.href);
       data.pageURL && global.Phoenix.setInfo('PAGEURL', data.pageURL);

--- a/ads/uas.js
+++ b/ads/uas.js
@@ -67,7 +67,7 @@ export function uas(global, data) {
   loadScript(global, 'https://ads.pubmatic.com/AdServer/js/phoenix.js', () => {
     global.Phoenix.EQ.push(function() {
       global.Phoenix.enableSingleRequestCallMode();
-      global.Phoenix.setInfo('AMP', 1);
+      global.Phoenix.setInfo('AMP', 1);//Need to set the AMP flag
       global.Phoenix.setInfo('ACCID', data.accId);
       global.Phoenix.setInfo('PAGEURL', global.context.location.href);
       data.pageURL && global.Phoenix.setInfo('PAGEURL', data.pageURL);


### PR DESCRIPTION
UAS tag needs to call Phoenix.setInfo method internally. This is the only change made.
