### PR TITLE
amp-mustache: Fix SVG image[xlink:href]

### DIFF
--- a/extensions/amp-mustache/0.2/amp-mustache.js
+++ b/extensions/amp-mustache/0.2/amp-mustache.js
@@ -97,8 +97,28 @@ export class AmpMustache extends AMP.BaseTemplate {
       html = mustacheRender(this.template_, mustacheData);
     }
     const body = purifyHtml(`<div>${html}</div>`);
+    this.fixSvgImages_(body);
     const div = body.firstElementChild;
     return this.unwrap(div);
+  }
+
+  /**
+   * <image xlink:href="..."> fetches the image but fails to render when
+   * using RETURN_DOM with DOMPurify. Setting the attribute manually appears
+   * to fix it. Doesn't happen with "href" attribute. See b/112204851.
+   * @param {!Element} element
+   */
+  fixSvgImages_(element) {
+    const namespace = 'http://www.w3.org/1999/xlink';
+    const attr = 'xlink:href';
+
+    const images = element.querySelectorAll('image');
+    for (let i = 0; i < images.length; i++) {
+      const img = images[i];
+      if (img.hasAttribute(attr)) {
+        img.setAttributeNS(namespace, attr, img.getAttribute(attr));
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Alternative is to revert the `RETURN_DOM` change and use `innerHTML` again, but I figured this hack is more performant than that. Tested on latest Chrome, Safari, Firefox on macOS.

Context: `b/112204851`

/to @jridgewell 