### PR TITLE
Revert "Update dependency topological-sort to v0.2.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -169,7 +169,7 @@
     "sleep-promise": "8.0.1",
     "text-table": "0.2.0",
     "through2": "2.0.3",
-    "topological-sort": "0.2.0",
+    "topological-sort": "0.1.5",
     "touch": "3.1.0",
     "traverse": "0.6.6",
     "try-net-connect": "3.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12942,9 +12942,9 @@ to-regex@^3.0.2:
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
 
-topological-sort@0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/topological-sort/-/topological-sort-0.2.0.tgz#4e2cf8c37b7ca5283406c48edb86d6407ebc5f3c"
+topological-sort@0.1.5:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/topological-sort/-/topological-sort-0.1.5.tgz#5c38d264b98b6e296b2ab2e25e54c40eb6e10e1d"
 
 touch@3.1.0, touch@^3.1.0:
   version "3.1.0"


### PR DESCRIPTION
Reverts ampproject/amphtml#16897

breaking master with `[20:28:30] TypeError: TopologicalSort is not a constructor`
not sure why PR passed CI though. /cc @rsimha 
