### PR TITLE
Add innerHTML to workaround DOMPurify bug

### DIFF
--- a/build-system/tasks/bundle-size.js
+++ b/build-system/tasks/bundle-size.js
@@ -22,7 +22,7 @@ const log = require('fancy-log');
 const {getStdout} = require('../exec');
 
 const runtimeFile = './dist/v0.js';
-const maxSize = '80.60KB';
+const maxSize = '80.63KB';
 
 const {green, red, cyan, yellow} = colors;
 

--- a/extensions/amp-mustache/0.2/amp-mustache.js
+++ b/extensions/amp-mustache/0.2/amp-mustache.js
@@ -96,9 +96,12 @@ export class AmpMustache extends AMP.BaseTemplate {
       }
       html = mustacheRender(this.template_, mustacheData);
     }
-    const body = purifyHtml(`<div>${html}</div>`);
-    const div = body.firstElementChild;
-    return this.unwrap(div);
+    const body = purifyHtml(html);
+    // TODO(choumx): Remove innerHTML usage once DOMPurify bug is fixed.
+    // https://github.com/cure53/DOMPurify/pull/295
+    const root = this.win.document.createElement('div');
+    root./*OK*/innerHTML = body.innerHTML;
+    return this.unwrap(root);
   }
 }
 

--- a/extensions/amp-mustache/0.2/amp-mustache.js
+++ b/extensions/amp-mustache/0.2/amp-mustache.js
@@ -100,7 +100,7 @@ export class AmpMustache extends AMP.BaseTemplate {
     // TODO(choumx): Remove innerHTML usage once DOMPurify bug is fixed.
     // https://github.com/cure53/DOMPurify/pull/295
     const root = this.win.document.createElement('div');
-    root./*OK*/innerHTML = body.innerHTML;
+    root./*OK*/innerHTML = body./*OK*/innerHTML;
     return this.unwrap(root);
   }
 }


### PR DESCRIPTION
Temporary workaround while we wait for: https://github.com/cure53/DOMPurify/pull/295

Context: `b/112204851`

/to @jridgewell 