### PR TITLE
🏗🐛 Increase `bundleDelay` for `karma-browserify` on Travis

### DIFF
--- a/build-system/tasks/karma.conf.js
+++ b/build-system/tasks/karma.conf.js
@@ -65,7 +65,8 @@ module.exports = {
     transform: [
       ['babelify', {compact: false, sourceMapsAbsolute: true}],
     ],
-    bundleDelay: 1200,
+    // Prevent "cannot find module" errors on Travis. See #14166.
+    bundleDelay: process.env.TRAVIS ? 5000 : 1200,
   },
 
   reporters: ['super-dots', 'karmaSimpleReporter'],


### PR DESCRIPTION
We're still seeing transient `cannot find module` errors on Travis while running Karma tests. From https://github.com/nikku/karma-browserify/issues/114#issuecomment-78289776, it's likely that these errors are due to slow disk speed on Travis, where `karma-browserify` isn't waiting long enough for the Karma server to load all the test files.

> What the bundleDelay does: karma-browserify needs to wait for all files to be loaded by karma before it can actually start bundling. The bundleDelay is the timeout we accept until we assume karma handed over all files to us. If you have a slow disk (that needs more than the default delay to serve subsequent files the plug-in starts bundling without some files (the ones it later prints Cannot find module for).

This PR increases `bundleDelay` to 5 seconds on Travis to give the Karma server enough time to load the entire set of files needed to run tests.

Fixes #14166
