### PR TITLE
🐛 Fix doc.fonts.values presence check in font-display-swap experiment

### DIFF
--- a/src/font-stylesheet-timeout.js
+++ b/src/font-stylesheet-timeout.js
@@ -123,7 +123,7 @@ function timeoutFontFaces(win) {
   }
   const doc = win.document;
   // TODO(@cramforce) Switch to .values when FontFaceSet extern supports it.
-  if (!doc.fonts && !doc.fonts['values']) {
+  if (!doc.fonts || !doc.fonts['values']) {
     return;
   }
   const it = doc.fonts['values']();


### PR DESCRIPTION
The current check verifies that neither `doc.fonts` nor `doc.fonts.values` is defined:

https://github.com/ampproject/amphtml/blob/e6d52ecd4fe95e367652e0caf1a6897153076cec/src/font-stylesheet-timeout.js#L126-L128

However, if `doc.fonts` is not defined, trying to check for `doc.fonts.values` will result in an error.
I noticed this on IE 11 (where `document.fonts` is undefined), getting the following error:

> SCRIPT5007: Unable to get property 'values' of undefined or null reference
> File: v0.js, line: 505, column: 218

Changing the logical AND by a logical OR fixes the issue and properly early returns when either of them is undefined.

Fixes #17407