### PR TITLE
🐛 amp-image-slider remove webkit tap grayish color

### DIFF
--- a/extensions/amp-image-slider/0.1/amp-image-slider.css
+++ b/extensions/amp-image-slider/0.1/amp-image-slider.css
@@ -22,6 +22,8 @@
   left: 0;
   /* Fix iOS translate + overflow: hidden bug */
   transform: translateZ(0);
+  /* Remove webkit tap highlight grayish color */
+  -webkit-tap-highlight-color: rgba(0,0,0,0);
 }
 
 .i-amphtml-image-slider-left-mask {


### PR DESCRIPTION
- [x] Set webkit highlight color to transparent

Solution described here:
https://css-tricks.com/snippets/css/remove-gray-highlight-when-tapping-links-in-mobile-safari/