### PR TITLE
📖 Fix issue for cors + cleanup

### DIFF
--- a/extensions/amp-form/amp-form.md
+++ b/extensions/amp-form/amp-form.md
@@ -19,19 +19,19 @@ limitations under the License.
 <table>
   <tr>
     <td width="40%"><strong>Description</strong></td>
-    <td>Allow usage of <code>form</code> and <code>input</code> tags.</td>
+    <td>Allows you to create <code>form</code> and <code>input</code> tags.</td>
   </tr>
   <tr>
-    <td width="40%"><strong>Required Script</strong></td>
+    <td><strong>Required Script</strong></td>
     <td><code>&lt;script async custom-element="amp-form" src="https://cdn.ampproject.org/v0/amp-form-0.1.js">&lt;/script></code></td>
   </tr>
   <tr>
-    <td class="col-fourty"><strong><a href="https://www.ampproject.org/docs/guides/responsive/control_layout.html">Supported Layouts</a></strong></td>
+    <td><strong><a href="https://www.ampproject.org/docs/design/responsive/control_layout.html#the-layout-attribute">Supported Layouts</a></strong></td>
     <td>N/A</td>
   </tr>
   <tr>
-    <td width="40%"><strong>Examples</strong></td>
-    <td>See AMP By Example's <a href="https://ampbyexample.com/components/amp-form/">annotated amp-form</a> example.</td>
+    <td><strong>Examples</strong></td>
+    <td>See AMP By Example's <a href="https://ampbyexample.com/components/amp-form/">amp-form</a> examples.</td>
   </tr>
 </table>
 
@@ -39,10 +39,18 @@ limitations under the License.
 
 ## Behavior
 
-The `amp-form` extension allows the usage of forms to submit input fields in an AMP document. The extension allows polyfilling some of the missing behaviors in browsers.
+The `amp-form` extension allows you to create forms (`<form>`) to submit input fields in an AMP document. The  `amp-form` extension also provides [polyfills](#polyfills) for some missing behaviors in browsers.
 
-The `amp-form` extension **MUST** be loaded if you're using `<form>`, otherwise your document will be invalid! Use of `input` tags for purposes other than submitting their values (e.g. inputs not inside a `<form>`) is valid without loading `amp-form` extension.
+{% call callout('Important', type='caution') %}
+If you're submitting data in your form, your server endpoint must implement the requirements for [CORS security](https://www.ampproject.org/docs/fundamentals/amp-cors-requests#cors-security-in-amp).
+{% endcall %}
 
+
+Before creating a `<form>`, you must include the required script for the `<amp-form>` extension, otherwise your document will be invalid. If you're using `input` tags for purposes other than submitting their values (e.g., inputs not inside a `<form>`), you do not need to load the `amp-form` extension.
+
+Here's an example of a basic form:
+
+<!-- embedded sample that is rendered on ampproject.org -->
 <div>
   <amp-iframe height="671"
             layout="fixed-height"
@@ -64,9 +72,8 @@ Indicates where to display the form response after submitting the form. The valu
 
 Specifies a server endpoint to handle the form input. The value must be an `https` URL (absolute or relative) and must not be a link to a CDN.
 
-This attribute is required for `method=GET`. For `method=POST`, the `action` attribute is invalid, use `action-xhr` instead.
-
-For GET submissions, provide at least one of `action` or `action-xhr`.
+* For `method=GET`: use this attribute or [`action-xhr`](#action-xhr).
+* For `method=POST`: use the [`action-xhr`](#action-xhr) attribute.
 
 
 {% call callout('Note', type='note') %}
@@ -75,9 +82,12 @@ The `target` and `action` attributes are only used for non-xhr GET requests. The
 
 ##### action-xhr
 
-Specifies a server endpoint to handle the form input and submit the form via XMLHttpRequest (XHR).
+Specifies a server endpoint to handle the form input and submit the form via XMLHttpRequest (XHR). An XHR request (sometimes called an AJAX request) is where the browser would make the request without a full load of the page or opening a new page. Browsers will send the request in the background using the [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) when available and fallback to [XMLHttpRequest API](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest) for older browsers.
 
-An XHR request (sometimes called an AJAX request) is where the browser would make the request without a full load of the page or opening a new page. Browsers will send the request in the background using the [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) when available and fallback to [XMLHttpRequest API](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest) for older browsers.
+{% call callout('Important', type='caution') %}
+Your XHR endpoint must implement the requirements for [CORS security](https://www.ampproject.org/docs/fundamentals/amp-cors-requests#cors-security-in-amp).
+{% endcall %}
+
 
 This attribute is required for `method=POST`, and is optional for `method=GET`.
 
@@ -85,9 +95,6 @@ The value for `action-xhr` can be the same or a different endpoint than `action`
 
 To learn about redirecting the user after successfully submitting the form, see the [Redirecting after a submission](#redirecting-after-a-submission) section below.
 
-{% call callout('Important', type='caution') %}
-See the [Security Considerations](#security-considerations) section below for notes on how to secure your forms endpoints.
-{% endcall %}
 
 ##### other form attributes
 
@@ -99,7 +106,7 @@ This is an optional attribute that enables and selects a custom validation repor
 
 See the [Custom Validation](#custom-validations) section for more details.
 
-## Inputs and Fields
+## Inputs and fields
 
 **Allowed**:
 
@@ -112,32 +119,40 @@ See the [Custom Validation](#custom-validations) section for more details.
 * `<input type=button>`, `<input type=image>`
 * Most of the form-related attributes on inputs including: `form`, `formaction`, `formtarget`, `formmethod` and others.
 
-(Relaxing some of these rules might be reconsidered in the future - [please let us know](https://www.ampproject.org/support/developer/) if you require these and provide use cases).
+(Relaxing some of these rules might be reconsidered in the future - [please let us know](https://github.com/ampproject/amphtml/blob/master/CONTRIBUTING.md#suggestions-and-feature-requests) if you require these and provide use cases).
 
 For details on valid inputs and fields, see [amp-form rules](https://github.com/ampproject/amphtml/blob/master/validator/validator-main.protoascii) in the AMP validator specification.
 
 ## Actions
-`amp-form` exposes two actions: `submit`, and `clear`.
 
-`submit` allows you to trigger the form submission on a specific action, for example, tapping a link, or [submitting a form on input change](#input-events).
+The `amp-form` element exposes the following actions: 
 
-`clear` empties the values from each input in the form. This can allow users to quickly fill out forms a second time.
+| Action | Description |
+|--------|-------------| 
+| `submit` | Allows you to trigger the form submission on a specific action, for example, tapping a link, or [submitting a form on input change](#input-events). |
+| `clear` | Empties the values from each input in the form. This can allow users to quickly fill out forms a second time. |
 
-You can [read more about Actions and Events in AMP in the spec](https://www.ampproject.org/docs/interaction_dynamic/amp-actions-and-events).
+{% call callout('Read on', type='read') %}
+Learn more about [Actions and Events in AMP](https://www.ampproject.org/docs/interaction_dynamic/amp-actions-and-events.html).
+{% endcall %}
 
 ## Events
-`amp-form` exposes the following events:
 
-* **submit**: Emitted whenever the form is submitted and before the submission is complete.
-* **submit-success**: Emitted whenever the form submission is done and the response is a success.
-* **submit-error**: Emitted whenever the form submission is done and the response is an error.
-* **verify**: Emitted whenever asynchronous verification is initiated.
-* **verify-error**: Emitted whenever asynchronous verification is done and the response is an error.
-* **valid**: Emitted whenever the form's validation state changes to "valid" (in accordance with its [reporting strategy](#reporting-strategies)).
-* **invalid**: Emitted whenever the form's validation state to "invalid" (in accordance with its [reporting strategy](#reporting-strategies)).
+The `amp-form` exposes the following events:
 
-These events can be used through the [`on` attribute](https://www.ampproject.org/docs/fundamentals/spec#on).
-For example, the following listens to both `submit-success` and `submit-error` and shows different lightboxes depending on the event.
+| Event | Fired when |
+|-------|-------------| 
+| `submit` | The form is submitted and before the submission is complete. |
+| `submit-success` | The form submission is done and the response is a success. |
+| `submit-error` | The form submission is done and the response is an error. |
+| `verify` | Asynchronous verification is initiated. |
+| `verify-error` | Asynchronous verification is done and the response is an error. |
+| `valid` | The form's validation state changes to "valid" (in accordance with its [reporting strategy](#reporting-strategies)). |
+| `invalid` | The form's validation state to "invalid" (in accordance with its [reporting strategy](#reporting-strategies)). |
+
+These events can be used via the [`on` attribute](https://www.ampproject.org/docs/fundamentals/spec#on).
+
+For example, the following listens to both the `submit-success` and `submit-error` events and shows different lightboxes depending on the event:
 
 ```html
 <form ... on="submit-success:success-lightbox;submit-error:error-lightbox" ...>
@@ -146,11 +161,13 @@ For example, the following listens to both `submit-success` and `submit-error` a
 
 See the [full example here](../../examples/forms.amp.html).
 
-#### Input Events
+#### Input events
+
 AMP exposes `change` and `input-debounced` events on child `<input>` elements. This allows you to use the [`on` attribute](https://www.ampproject.org/docs/fundamentals/spec#on) to execute an action on any element when an input value changes.
 
 For example, a common use case is to submit a form on input change (selecting a radio button to answer a poll, choosing a language from a `select` input to translate a page, etc.).
 
+<!-- embedded sample that is rendered on ampproject.org -->
 <div>
 <amp-iframe height="450"
             layout="fixed-height"
@@ -164,10 +181,17 @@ For example, a common use case is to submit a form on input change (selecting a 
 
 See the [full example here](../../examples/forms.amp.html).
 
-### Analytics Triggers
-`amp-form` triggers three events you can track in your `amp-analytics` config: `amp-form-submit`, `amp-form-submit-success`, and `amp-form-submit-error`.
+### Analytics triggers
 
-You can configure your analytics to send these events as in the example below.
+The `amp-form` extension triggers the following events that you can track in your [amp-analytics](https://www.ampproject.org/docs/reference/components/amp-analytics) config:
+
+| Event                     | Fired when                        |
+|---------------------------|-----------------------------------| 
+| `amp-form-submit`         | A form request is initiated.      |
+| `amp-form-submit-success` | A successful response is received (i.e, when the response has a status of `2XX`). |
+| `amp-form-submit-error`   | An unsuccessful response is received (i.e, when the response doesn't have a status of `2XX`). |
+
+You can configure your analytics to send these events as in the following example:
 
 ```html
 <amp-analytics>
@@ -202,9 +226,6 @@ You can configure your analytics to send these events as in the example below.
 </amp-analytics>
 ```
 
-The `amp-form-submit` event fires when a form request is initiated.
-The `amp-form-submit-success` event fires when a successful response is received, that is when the response has a status of `2XX`. Any other status triggers the `amp-form-submit-error` event.
-
 All three events generate a set of variables that correspond to the specific form and the fields in the form. These variables can be used for analytics.
 
 For example, the following form has one field:
@@ -215,42 +236,35 @@ For example, the following form has one field:
   <input type="submit" value="Comment" />
 </form>
 ```
+
 When the `amp-form-submit`, `amp-form-submit-success`, or `amp-form-submit-error` event fires, it generates the following variables containing the values that were specified in the form:
 
 * `formId`
 * `formFields[comment]`
 
-## Success/Error Response Rendering
-`amp-form` allows publishers to render the responses using [Extended Templates](https://www.ampproject.org/docs/fundamentals/spec#extended-templates).
+## Success/error response rendering
 
-Using `submit-success` and `submit-error` special marker attributes, publishers can mark any **direct child element of form** and include a `<template></template>` tag inside it, or a `template="id_of_other_template"` attribute, to render the response in it.
+You can render success or error responses in your form by using [extended templates (e.g., Mustache)](https://www.ampproject.org/docs/fundamentals/spec#extended-templates) and the following response attributes:
 
-Using the `submitting` special marker attribute, publishers can also include a template to display a message when the form is submitting. The template for this attribute will have access to the form's input fields for any display purposes. Please see the full form example below for how to use the `submitting` attribute.
+| Response attribute | Description |
+|-----------|---------------------|
+| `submit-success` | Can be used to display a success message if the response is successful (i.e., has a status of `2XX`). |
+| `submit-error` | an be used to display a submission error if the response is unsuccessful (i.e., does not have a status of `2XX`).  |
+| `submitting` | Can be used to display a message when the form is submitting. The template for this attribute has access to the form's input fields for any display purposes. Please see the [full form example below](#example-submitting) for how to use the `submitting` attribute. |
 
-For submit-success and submit-error, the response is expected to be a valid JSON Object. For example, if the publisher's `action-xhr` endpoint returns the following responses:
+To render responses:
 
-**Success Response**
-```json
-{
-  "name": "Jane Miller",
-  "interests": [{"name": "Basketball"}, {"name": "Swimming"}, {"name": "Reading"}],
-  "email": "email@example.com"
-}
-```
+* Apply a response attribute to *any direct child* of the `<form>` element.
+* Render the response in the child element by including a `<template></template>` tag inside it or by referencing a template with a `template="id_of_other_template"` attribute.
+* Provide a valid JSON object for responses to `submit-success` and `submit-error`. Both success and error responses should have a `Content-Type: application/json` header.
 
-**Error Response**
-```json
-{
-  "name": "Jane Miller",
-  "message": "The email (email@example.com) you used is already subscribed."
-}
-```
 
-Both success and error responses should have a `Content-Type: application/json` header. `submit-success` will render for all responses that has a status of `2XX`, all other statuses will render `submit-error`.
 
-Publishers can render these responses in a inlined template inside their forms as follows:
 
-*Note*: This form uses the `submitting` attribute to display a message to the user when the form is submitting.
+<a id="example-submitting"></a>
+##### Example: Form displays success, error, and submitting messages
+
+In the following example, the responses are rendered in an inline template inside the form. 
 
 ```html
 <form ...>
@@ -266,7 +280,7 @@ Publishers can render these responses in a inlined template inside their forms a
   </div>
   <div submitting>
     <template type="amp-mustache">
-      Form submitting... Thank you for waiting {{firstName}}.
+      Form submitting... Thank you for waiting {{name}}.
     </template>
   </div>
   <div submit-success>
@@ -283,7 +297,27 @@ Publishers can render these responses in a inlined template inside their forms a
 </form>
 ```
 
-Publishers can render the responses in a referenced template defined earlier in the document by using the template's id as the value of the `template` attribute, set on the elements with the `submit-success` and `submit-error` attributes.
+The publisher's `action-xhr` endpoint returns the following JSON responses:
+
+On success: 
+
+```json
+{
+  "name": "Jane Miller",
+  "interests": [{"name": "Basketball"}, {"name": "Swimming"}, {"name": "Reading"}],
+  "email": "email@example.com"
+}
+```
+
+On error: 
+```json
+{
+  "name": "Jane Miller",
+  "message": "The email (email@example.com) you used is already subscribed."
+}
+```
+
+You can render the responses in a referenced template defined earlier in the document by using the template's id as the value of the `template` attribute, set on the elements with the `submit-success` and `submit-error` attributes.
 
 ```html
 <template type="amp-mustache" id="submit_success_template">
@@ -307,7 +341,7 @@ See the [full example here](../../examples/forms.amp.html).
 
 ### Redirecting after a submission
 
-You can redirect users to a new page after a successful `amp-form` submission by setting the `AMP-Redirect-To` response header and specifying a redirect URL. The redirect URL must be a HTTPS URL, otherwise AMP will throw an error and redirection won't occur.  HTTP response headers are configured via your server.
+You can redirect users to a new page after a successful form submission by setting the `AMP-Redirect-To` response header and specifying a redirect URL. The redirect URL must be a HTTPS URL, otherwise AMP will throw an error and redirection won't occur.  HTTP response headers are configured via your server.
 
 Make sure to update your `Access-Control-Expose-Headers` response header to include `AMP-Redirect-To` to the list of allowed headers.  Learn more about these headers in [CORS Security in AMP](https://www.ampproject.org/docs/fundamentals/amp-cors-requests#cors-security-in-amp).
 
@@ -319,35 +353,12 @@ Access-Control-Expose-Headers: AMP-Redirect-To, Another-Header, And-Some-More
 ```
 
 
+{% call callout('Tip', type='success') %}
 Check out AMP By Example's [Form Submission with Update](https://ampbyexample.com/components/amp-form/#form-submission-with-page-update) and [Product Page](https://ampbyexample.com/samples_templates/product_page/#product-page) that demonstrate using redirection after a form submission.
+{% endcall %}
 
 
-## Polyfills
-`amp-form` provide polyfills for behaviors and functionality missing from some browsers or being implemented in the next version of CSS.
-
-#### Invalid Submit Blocking and Validation Message Bubble
-Browsers that uses webkit-based engines currently (as of August 2016) do not support invalid form submissions. These include Safari on all platforms, and all iOS browsers. `amp-form` polyfills this behavior to block any invalid submissions and show validation message bubbles on invalid inputs.
-
-**Note**: Messages are sometimes limited to a few words like "required field", these messages are provided by the browser implementation. We'll be working on allowing publisher-provided custom validation messages as well as custom validation UIs (instead of the builtin/polyfill'd bubbles).
-
-#### :user-invalid/:user-valid
-These pseudo classes are part of the [future CSS Selectors 4 spec](https://drafts.csswg.org/selectors-4/#user-pseudos) and are introduced to allow better hooks for styling invalid/valid fields based on a few criteria.
-
-One of the main differences between `:invalid` and `:user-invalid` is when are they applied to the element. :user-invalid is applied after a significant interaction from the user with the field (e.g. user types in a field, or blur from the field).
-
-`amp-form` provides classes (see below) to polyfill these pseudo-classes. `amp-form` also propagates these to ancestors `fieldset`s and `form`.
-
-
-## Classes and CSS Hooks
-`amp-form` provides classes and CSS hooks for publishers to style their forms and inputs.
-
-`.amp-form-initial`, `.amp-form-verify`, `.amp-form-verify-error`, `.amp-form-submitting`, `.amp-form-submit-success` and `.amp-form-submit-error` are added to indicate the state of the form submission.
-
-`.user-valid` and `.user-invalid` classes are a polyfill for the pseudo classes as described above. Publishers can use these to style their inputs and fieldsets to be responsive to user actions (e.g., highlighting an invalid input with a red border after user blurs from it).
-
-See the [full example here](../../examples/forms.amp.html) on using these.
-
-## Custom Validations
+## Custom validations
 
 The `amp-form` extension allows you to build your own custom validation UI by using the `custom-validation-reporting` attribute along with one the following reporting strategies: `show-first-on-submit`, `show-all-on-submit` or `as-you-go`.
 
@@ -358,6 +369,7 @@ To specify custom validation on your form:
 
 Here's an example:
 
+<!-- embedded sample that is rendered on ampproject.org -->
 <div>
 <amp-iframe height="748"
             layout="fixed-height"
@@ -373,7 +385,7 @@ For more examples, see [examples/forms.amp.html](../../examples/forms.amp.html).
 
 For validation messages, if your element contains no text content inside, AMP will fill it out with the browser's default validation message. In the example above, when the `name5` input is empty and validation is kicked off (i.e., user tried to submit the form) AMP will fill `<span visible-when-invalid="valueMissing" validation-for="name5"></span>` with the browser's validation message and show that `span` to the user.
 
-### Reporting Strategies
+### Reporting strategies
 
 Specify one of the following reporting options for the `custom-validation-reporting` attribute:
 
@@ -441,8 +453,6 @@ the server that the request is a verify request and not a formal submit.
 This is helpful so the server knows not to store the verify request if the same
 endpoint is used for verification and for submit.
 
-```
-
 Here is how an error response should look for verification:
 ```json
 {
@@ -456,8 +466,9 @@ Here is how an error response should look for verification:
 For more examples, see [examples/forms.amp.html](../../examples/forms.amp.html).
 
 
-## Variable Substitutions
-`amp-form` allows [platform variable substitutions](../../spec/amp-var-substitutions.md) for inputs that are hidden and that have the `data-amp-replace` attribute. On each form submission, `amp-form` finds all `input[type=hidden][data-amp-replace]` inside the form and applies variable substitutions to its `value` attribute and replaces it with the result of the substitution.
+## Variable substitutions
+
+The `amp-form` extension allows [platform variable substitutions](../../spec/amp-var-substitutions.md) for inputs that are hidden and that have the `data-amp-replace` attribute. On each form submission, `amp-form` finds all `input[type=hidden][data-amp-replace]` inside the form and applies variable substitutions to its `value` attribute and replaces it with the result of the substitution.
 
 You must provide the variables you are using for each substitution on each input by specifying a space-separated string of the variables used in `data-amp-replace` (see example below). AMP will not replace variables that are not explicitly specified.
 
@@ -494,25 +505,61 @@ Note how `CANONICAL_HOSTNAME` above did not get replaced because it was not in t
 
 Substitutions will happen on every subsequent submission. Read more about [variable substitutions in AMP](../../spec/amp-var-substitutions.md).
 
-## Security Considerations
+## Polyfills
 
-{% call callout('Important', type='caution') %}
-Your XHR endpoint must implement the requirements specified in the [CORS Requests in AMP](https://www.ampproject.org/docs/fundamentals/amp-cors-requests) spec.
-{% endcall %}
+The `amp-form` extension provide polyfills for behaviors and functionality missing from some browsers or being implemented in the next version of CSS.
 
-### Protecting against XSRF
-In addition to following the details in the AMP CORS spec, please pay extra attention to the section on ["Processing state changing requests" ](https://www.ampproject.org/docs/fundamentals/amp-cors-requests#processing-state-changing-requests) to protect against [XSRF attacks](https://en.wikipedia.org/wiki/Cross-site_request_forgery) where an attacker can execute unauthorized commands using the current user session without the user knowledge.
+#### Invalid submit blocking and validation message bubble
 
-In general, keep in mind the following points when accepting input from the user:
+Browsers that use webkit-based engines currently (as of August 2016) do not support invalid form submissions. These include Safari on all platforms, and all iOS browsers. The `amp-form` extension polyfills this behavior to block any invalid submissions and shows validation message bubbles on invalid inputs.
 
-* Only use POST for state changing requests.
-* Use non-XHR GET for navigational purposes only, e.g. Search.
-    * non-XHR GET requests are not going to receive accurate origin/headers and backends won't be able to protect against XSRF with the above mechanism.
-    * In general use XHR/non-XHR GET requests for navigational or information retrieval only.
-* non-XHR POST requests are not allowed in AMP documents. This is due to inconsistencies of setting `Origin` header on these requests across browsers. And the complications supporting it would introduce in protecting against XSRF. This might be reconsidered and introduced later, please file an issue if you think this is needed.
+
+#### User-interaction pseudo-classes
+
+The `:user-invalid` and `:user-valid` pseudo classes are part of the [future CSS Selectors 4 spec](https://drafts.csswg.org/selectors-4/#user-pseudos) and are introduced to allow better hooks for styling invalid/valid fields based on a few criteria.
+
+One of the main differences between `:invalid` and `:user-invalid` is when are they applied to the element. The `:user-invalid` class is applied after a significant interaction from the user with the field (e.g., the user types in a field, or blurs from the field).
+
+The `amp-form` extension provides [classes](#classes-and-css-hooks) to polyfill these pseudo-classes. The `amp-form` extension also propagates these to ancestors `fieldset`elements and `form`.
 
 ## Styling
+
+### Classes and CSS hooks
+
+The `amp-form` extension provides classes and CSS hooks for publishers to style their forms and inputs.
+
+The following classes can be used to indicate the state of the form submission:
+
+* `.amp-form-initial`
+* `.amp-form-verify`
+* `.amp-form-verify-error`
+* `.amp-form-submitting`
+* `.amp-form-submit-success`
+* `.amp-form-submit-error`
+
+
+The following classes are a [polyfill for the user interaction pseudo classes](#user-interaction-pseudo-classes):
+
+* `.user-valid`
+* `.user-invalid`
+
+Publishers can use these classes to style their inputs and fieldsets to be responsive to user actions (e.g., highlighting an invalid input with a red border after user blurs from it).
+
+See the [full example here](../../examples/forms.amp.html) on using these.
 
 {% call callout('Tip', type='success') %}
 Visit [AMP Start](https://ampstart.com/components#form-elements) for responsive, pre-styled AMP form elements that you can use in your AMP pages.
 {% endcall %}
+
+## Security considerations
+
+### Protecting against XSRF
+In addition to following the details in the [AMP CORS spec](https://www.ampproject.org/docs/fundamentals/amp-cors-requests.html), please pay extra attention to the section on ["Processing state changing requests" ](https://www.ampproject.org/docs/fundamentals/amp-cors-requests.html#processing-state-changing-requests) to protect against [XSRF attacks](https://en.wikipedia.org/wiki/Cross-site_request_forgery) where an attacker can execute unauthorized commands using the current user session without the user knowledge.
+
+In general, keep in mind the following points when accepting input from the user:
+
+* Only use POST for state changing requests.
+* Use non-XHR GET for navigational purposes only (e.g., Search).
+    * non-XHR GET requests are not going to receive accurate origin/headers and backends won't be able to protect against XSRF with the above mechanism.
+    * In general, use XHR/non-XHR GET requests for navigational or information retrieval only.
+* non-XHR POST requests are not allowed in AMP documents. This is due to inconsistencies of setting `Origin` header on these requests across browsers. And the complications supporting it would introduce in protecting against XSRF. This might be reconsidered and introduced later, please file an issue if you think this is needed.


### PR DESCRIPTION
Fixes #12513 (Part 3) - Make CORS obvious for amp-form doc.

Also, while I was in the doc, I performed a bunch of clean up for: formatting, wording, organization.
