### PR TITLE
📖  Document use of text/plain in pingback.

### DIFF
--- a/extensions/amp-subscriptions/0.1/local-subscription-platform.js
+++ b/extensions/amp-subscriptions/0.1/local-subscription-platform.js
@@ -199,6 +199,7 @@ export class LocalSubscriptionPlatform {
     const promise = this.urlBuilder_.buildUrl(pingbackUrl,
         /* useAuthData */ true);
     return promise.then(url => {
+      // Content should be 'text/plain' to avoid CORS preflight.
       return this.xhr_.sendSignal(url, {
         method: 'POST',
         credentials: 'include',

--- a/extensions/amp-subscriptions/amp-subscriptions.md
+++ b/extensions/amp-subscriptions/amp-subscriptions.md
@@ -244,8 +244,7 @@ Pingback is optional. It's only enabled when the "pingbackUrl" property is speci
 
 As the body, pingback POST request recieves the entitlement object returned by the "winning" authorization endpoint.
 
-**Important:** Due to issue #[17393](https://github.com/ampproject/amphtml/issues/17393), the pingback data JSON object is being sent with `Content-type: text/plain` instead of the correct `application/json`. Developers should accept both content types to prevent a breaking change when this is resolved.
-
+**Important:** The pingback JSON object is sent with `Content-type: text/plain`.  This is intentional as it removes the need for CORS preflight check.
 
 ## Actions
 

--- a/extensions/amp-subscriptions/amp-subscriptions.md
+++ b/extensions/amp-subscriptions/amp-subscriptions.md
@@ -244,7 +244,7 @@ Pingback is optional. It's only enabled when the "pingbackUrl" property is speci
 
 As the body, pingback POST request recieves the entitlement object returned by the "winning" authorization endpoint.
 
-**Important:** The pingback JSON object is sent with `Content-type: text/plain`.  This is intentional as it removes the need for CORS preflight check.
+**Important:** The pingback JSON object is sent with `Content-type: text/plain`.  This is intentional as it removes the need for a CORS preflight check.
 
 ## Actions
 


### PR DESCRIPTION
Add documentation for use of `text/plain` over `application/json` in preflight