### PR TITLE
Imperative case, matching the example

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,10 +10,10 @@
 
 # Example of a good description:
 
-- Implements aspect X
-- Leaves out feature Y because of A
-- Improves performance by B
-- Improves accessibility by C
+- Implement aspect X
+- Leave out feature Y because of A
+- Improve performance by B
+- Improve accessibility by C
 
 # Emojis for categorizing pull requests:
 


### PR DESCRIPTION
The example `ProjectX: Implement some feature` (and other [commit message style guides](https://chris.beams.io/posts/git-commit/)) use the imperative mood.

Also, question: should we instruct contributors to paste the emoji itself, or its `GitHub` code (e.g. `📖` vs. `:book:`)?