### PR TITLE
Allow all attrs of AMP elements in mustache-0.2

### DIFF
--- a/test/functional/test-purifier.js
+++ b/test/functional/test-purifier.js
@@ -392,6 +392,11 @@ function runSanitizerTests() {
       expect(purify('<span validation-for="form1"></span>'))
           .to.equal('<span validation-for="form1"></span>');
     });
+
+    it('should allow <amp-lightbox> attributes', () => {
+      expect(purify('<amp-lightbox scrollable></amp-lightbox>'))
+          .to.equal('<amp-lightbox scrollable=""></amp-lightbox>');
+    });
   });
 
   describe('purifyTagsForTripleMustache', () => {

--- a/test/functional/test-sanitizer.js
+++ b/test/functional/test-sanitizer.js
@@ -316,6 +316,11 @@ function runSanitizerTests() {
       expect(sanitizeHtml('<span validation-for="form1"></span>'))
           .to.equal('<span validation-for="form1"></span>');
     });
+
+    it('should allow <amp-lightbox> attributes', () => {
+      expect(sanitizeHtml('<amp-lightbox scrollable></amp-lightbox>'))
+          .to.equal('<amp-lightbox scrollable=""></amp-lightbox>');
+    });
   });
 
   describe('sanitizeTagsForTripleMustache', () => {


### PR DESCRIPTION
Fixes #17335.

Turns out 0.1's sanitizer.js already does this, just missed it in the translation to purifier.js. 😓 

https://github.com/ampproject/amphtml/blob/c47e908b78f194d06b552873c4b3ae700cd1ff15/src/sanitizer.js#L120

/to @jridgewell 