### PR TITLE
🐛Fix flash while expanding accordion with animation.

### DIFF
--- a/bundles.config.js
+++ b/bundles.config.js
@@ -47,7 +47,12 @@ exports.extensionBundles = [
     version: '0.1', options: {hasCss: true},
     type: TYPES.MISC,
   },
-  {name: 'amp-accordion', version: '0.1', type: TYPES.MISC},
+  {
+    name: 'amp-accordion',
+    version: '0.1',
+    options: {hasCss: true},
+    type: TYPES.MISC,
+  },
   {name: 'amp-ad', version: '0.1', options: {hasCss: true}, type: TYPES.AD},
   {name: 'amp-ad-network-adsense-impl', version: '0.1', type: TYPES.AD},
   {name: 'amp-ad-network-adzerk-impl', version: '0.1', type: TYPES.AD},

--- a/extensions/amp-accordion/0.1/amp-accordion.css
+++ b/extensions/amp-accordion/0.1/amp-accordion.css
@@ -2,5 +2,5 @@ amp-accordion [i-amphtml-measure] {
   /* Need to use CSS (not inline style) to use !important. Overrides a rule
    * in amp.css */
   position: fixed !important;
-  opacity: 0;
+  opacity: 0 !important;
 }

--- a/extensions/amp-accordion/0.1/amp-accordion.css
+++ b/extensions/amp-accordion/0.1/amp-accordion.css
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 amp-accordion [i-amphtml-measure] {
   /* Need to use CSS (not inline style) to use !important. Overrides a rule
    * in amp.css */

--- a/extensions/amp-accordion/0.1/amp-accordion.css
+++ b/extensions/amp-accordion/0.1/amp-accordion.css
@@ -1,0 +1,6 @@
+amp-accordion [i-amphtml-measure] {
+  /* Need to use CSS (not inline style) to use !important. Overrides a rule
+   * in amp.css */
+  position: fixed !important;
+  opacity: 0;
+}

--- a/extensions/amp-accordion/0.1/amp-accordion.js
+++ b/extensions/amp-accordion/0.1/amp-accordion.js
@@ -16,6 +16,7 @@
 
 import {ActionTrust} from '../../../src/action-constants';
 import {Animation} from '../../../src/animation';
+import {CSS} from '../../../build/amp-accordion-0.1.css';
 import {KeyCodes} from '../../../src/utils/key-codes';
 import {Layout} from '../../../src/layout';
 import {Services} from '../../../src/services';
@@ -316,10 +317,7 @@ class AmpAccordion extends AMP.BaseElement {
 
     return this.mutateElement(() => {
       // We set position and opacity to avoid a FOUC while measuring height
-      setStyles(sectionChild, {
-        opacity: 0,
-        position: 'fixed',
-      });
+      sectionChild.setAttribute('i-amphtml-measure', '');
       if (!section.hasAttribute('expanded')) {
         this.triggerEvent_('expand', section);
         section.setAttribute('expanded', '');
@@ -333,10 +331,9 @@ class AmpAccordion extends AMP.BaseElement {
                 viewportHeight);
           },
           () => {
+            sectionChild.removeAttribute('i-amphtml-measure');
             setStyles(sectionChild, {
-              'opacity': '',
               'height': 0,
-              'position': '',
             });
           });
     }).then(() => {
@@ -518,5 +515,5 @@ class AmpAccordion extends AMP.BaseElement {
 
 
 AMP.extension(TAG, '0.1', AMP => {
-  AMP.registerElement(TAG, AmpAccordion);
+  AMP.registerElement(TAG, AmpAccordion, CSS);
 });


### PR DESCRIPTION
- Use CSS when measuring the content so that a positioning rule from
amp.css can be overridden.

Fixes #17117