### PR TITLE
🐛 amp-ima-video: seek should consume touch events

### DIFF
--- a/ads/google/imaVideo.js
+++ b/ads/google/imaVideo.js
@@ -848,6 +848,8 @@ function onProgressClick(event) {
   // instead of clicking and dragging.
   clearInterval(hideControlsTimeout);
   onProgressMove(event);
+  event.preventDefault();
+  event.stopPropagation();
   clearInterval(uiTicker);
   document.addEventListener(mouseMoveEvent, onProgressMove);
   document.addEventListener(mouseUpEvent, onProgressClickEnd);
@@ -1122,6 +1124,16 @@ function onMessage(global, event) {
         muteAdsManagerOnLoaded = false;
       }
       postMessage({event: VideoEvents.UNMUTED});
+      break;
+    case 'hideControls':
+      if (!adsActive) {
+        hideControls();
+      }
+      break;
+    case 'showControls':
+      if (!adsActive) {
+        showControls();
+      }
       break;
     case 'resize':
       if (msg.args && msg.args.width && msg.args.height) {

--- a/extensions/amp-ima-video/0.1/amp-ima-video.js
+++ b/extensions/amp-ima-video/0.1/amp-ima-video.js
@@ -313,12 +313,12 @@ class AmpImaVideo extends AMP.BaseElement {
 
   /** @override */
   showControls() {
-    // Not supported.
+    this.sendCommand_('showControls');
   }
 
   /** @override */
   hideControls() {
-    // Not supported.
+    this.sendCommand_('hideControls');
   }
 
   /** @override */

--- a/test/manual/amp-ima-video.html
+++ b/test/manual/amp-ima-video.html
@@ -7,6 +7,7 @@
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
     <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
     <script async custom-element="amp-ima-video" src="https://cdn.ampproject.org/v0/amp-ima-video-0.1.js"></script>
+    <script async custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.1.js"></script>
     <style amp-custom>
     .spacer {
         height: 100vh;
@@ -166,5 +167,22 @@
     <button on="tap:adsenseskippable.mute">Mute</button>
     <button on="tap:adsenseskippable.unmute">Unmute</button>
     <button on="tap:adsenseskippable.fullscreen">Fullscreen</button>
+
+    <h2>In Carousel</h2>
+    <amp-carousel layout="responsive" width="640" height="360" type="slides">
+        <amp-ima-video id="adsense"
+            width="640" height="360" layout="responsive"
+            data-tag="https://afimplex.appspot.com/nonskippable"
+            data-poster="/examples/img/ima-poster.png">
+            <source src="https://s0.2mdn.net/4253510/google_ddm_animation_480P.mp4" type="video/mp4">
+        </amp-ima-video>
+        <div>Slide 2</div>
+        <amp-ima-video id="adsense"
+            width="640" height="360" layout="responsive"
+            data-tag="https://afimplex.appspot.com/nonskippable"
+            data-poster="/examples/img/ima-poster.png">
+            <source src="https://s0.2mdn.net/4253510/google_ddm_animation_480P.mp4" type="video/mp4">
+        </amp-ima-video>
+    </amp-carousel>
 </body>
 </html>


### PR DESCRIPTION
Fixes https://github.com/ampproject/amphtml/issues/17065 from [UI - Bugs - Low Effort](https://github.com/ampproject/amphtml/projects/54)

Drive-by `show/hideControls` implementation. Makes tasty.co work much nice now that clicking on the autoplaying video will also show the controls.