### PR TITLE
apm-video-*: Making more tests less flaky

### DIFF
--- a/extensions/amp-hulu/0.1/test/test-amp-hulu.js
+++ b/extensions/amp-hulu/0.1/test/test-amp-hulu.js
@@ -38,7 +38,7 @@ describes.realWin('amp-hulu', {
       hulu.setAttribute('layout', 'responsive');
     }
     doc.body.appendChild(hulu);
-    return hulu.build().then(() => hulu.layoutCallback()).then(() => hulu);
+    return hulu.build().then(() => { hulu.layoutCallback(); return hulu; });
   }
 
   it('renders', () => {

--- a/extensions/amp-jwplayer/0.1/test/test-amp-jwplayer.js
+++ b/extensions/amp-jwplayer/0.1/test/test-amp-jwplayer.js
@@ -38,7 +38,7 @@ describes.realWin('amp-jwplayer', {
     jw.setAttribute('height', '180');
     jw.setAttribute('layout', 'responsive');
     doc.body.appendChild(jw);
-    return jw.build().then(() => jw.layoutCallback()).then(() => jw);
+    return jw.build().then(() => { jw.layoutCallback(); return jw; });
   }
 
   it('renders', () => {

--- a/extensions/amp-ooyala-player/0.1/amp-ooyala-player.js
+++ b/extensions/amp-ooyala-player/0.1/amp-ooyala-player.js
@@ -46,14 +46,14 @@ class AmpOoyalaPlayer extends AMP.BaseElement {
     /** @private {?Element} */
     this.iframe_ = null;
 
-    /**@private {?string} */
-    this.embedCode_ = null;
+    /**@private {string} */
+    this.embedCode_ = '';
 
-    /**@private {?string} */
-    this.pCode_ = null;
+    /**@private {string} */
+    this.pCode_ = '';
 
-    /**@private {?string} */
-    this.playerId_ = null;
+    /**@private {string} */
+    this.playerId_ = '';
 
     /** @private {?Promise} */
     this.playerReadyPromise_ = null;

--- a/extensions/amp-ooyala-player/0.1/amp-ooyala-player.js
+++ b/extensions/amp-ooyala-player/0.1/amp-ooyala-player.js
@@ -46,6 +46,15 @@ class AmpOoyalaPlayer extends AMP.BaseElement {
     /** @private {?Element} */
     this.iframe_ = null;
 
+    /**@private {?string} */
+    this.embedCode_ = null;
+
+    /**@private {?string} */
+    this.pCode_ = null;
+
+    /**@private {?string} */
+    this.playerId_ = null;
+
     /** @private {?Promise} */
     this.playerReadyPromise_ = null;
 
@@ -54,6 +63,7 @@ class AmpOoyalaPlayer extends AMP.BaseElement {
 
     /** @private {?Function} */
     this.unlistenMessage_ = null;
+
   }
 
   /**
@@ -66,43 +76,45 @@ class AmpOoyalaPlayer extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
+    const {element: el} = this;
+
+    this.embedCode_ = user().assert(
+        el.getAttribute('data-embedcode'),
+        'The data-embedcode attribute is required for %s', el);
+
+    this.pCode_ = user().assert(
+        el.getAttribute('data-pcode'),
+        'The data-pcode attribute is required for %s', el);
+
+    this.playerId_ = user().assert(
+        el.getAttribute('data-playerid'),
+        'The data-playerid attribute is required for %s', el);
+
     const deferred = new Deferred();
     this.playerReadyPromise_ = deferred.promise;
     this.playerReadyResolver_ = deferred.resolve;
 
-    installVideoManagerForDoc(this.element);
-    Services.videoManagerForDoc(this.element).register(this);
+    installVideoManagerForDoc(el);
+    Services.videoManagerForDoc(el).register(this);
   }
 
   /** @override */
   layoutCallback() {
     const {element: el} = this;
 
-    const embedCode = user().assert(
-        el.getAttribute('data-embedcode'),
-        'The data-embedcode attribute is required for %s', el);
-
-    const pCode = user().assert(
-        el.getAttribute('data-pcode'),
-        'The data-pcode attribute is required for %s', el);
-
-    const playerId = user().assert(
-        el.getAttribute('data-playerid'),
-        'The data-playerid attribute is required for %s', el);
-
     let src = 'https://player.ooyala.com/iframe.html?platform=html5-priority';
     const playerVersion = el.getAttribute('data-playerversion') || '';
     if (playerVersion.toLowerCase() == 'v4') {
       src = 'https://player.ooyala.com/static/v4/sandbox/amp_iframe/' +
-        'skin-plugin/amp_iframe.html?pcode=' + encodeURIComponent(pCode);
+        'skin-plugin/amp_iframe.html?pcode=' + encodeURIComponent(this.pCode_);
       const configUrl = el.getAttribute('data-config');
       if (configUrl) {
         src += '&options[skin.config]=' + encodeURIComponent(configUrl);
       }
     }
 
-    src += '&ec=' + encodeURIComponent(embedCode) +
-      '&pbid=' + encodeURIComponent(playerId);
+    src += '&ec=' + encodeURIComponent(this.embedCode_) +
+      '&pbid=' + encodeURIComponent(this.playerId_);
 
     const iframe = createFrameFor(this, src);
 

--- a/extensions/amp-ooyala-player/0.1/test/test-amp-ooyala.js
+++ b/extensions/amp-ooyala-player/0.1/test/test-amp-ooyala.js
@@ -56,8 +56,7 @@ describes.realWin('amp-ooyala-player', {
 
     doc.body.appendChild(player);
     return player.build()
-        .then(() => player.layoutCallback())
-        .then(() => player);
+        .then(() => { player.layoutCallback(); return player; });
   }
 
   it('renders a V3 player', () => {

--- a/extensions/amp-viqeo-player/0.1/test/test-amp-viqeo-player.js
+++ b/extensions/amp-viqeo-player/0.1/test/test-amp-viqeo-player.js
@@ -124,7 +124,7 @@ describes.realWin('amp-viqeo-player', {
 
     doc.body.appendChild(viqeoElement);
     return viqeoElement.build()
-        .then(viqeoElement.layoutCallback.bind(viqeoElement))
+        .then(() => { viqeoElement.layoutCallback.bind(viqeoElement); })
         .then(() => {
           const videoManager =
             Services.videoManagerForDoc(doc);


### PR DESCRIPTION
Further fixes https://github.com/ampproject/amphtml/issues/17309

Remaining video player tests not to wait for layout callback in unit tests.