### PR TITLE
🐛 [amp-image-slider] Conservative loading with tweak over hints

### DIFF
--- a/examples/image-slider.amp.html
+++ b/examples/image-slider.amp.html
@@ -108,6 +108,16 @@
       <amp-img src="https://unsplash.it/1080/720?image=1038" layout="fill"></amp-img>
     </amp-image-slider>
 
+    <p>Images toggle their own fallback</p>
+    <amp-image-slider tabindex="0" layout="responsive" width="1024" height="600">
+      <amp-img src="boom" layout="fill">
+        <amp-img fallback src="https://unsplash.it/1080/720?image=1038" layout="fill"></amp-img>
+      </amp-img>
+      <amp-img src="boom" layout="fill">
+        <amp-img fallback src="https://unsplash.it/1080/720?image=1037" layout="fill"></amp-img>
+      </amp-img>
+    </amp-image-slider>
+
     <p>Labels with NO positioning rules specified (default to both top left)</p>
     <amp-image-slider tabindex="0" layout="responsive" width="1024" height="600">
       <amp-img src="https://unsplash.it/1080/720?image=1037" layout="fill"></amp-img>

--- a/extensions/amp-image-slider/0.1/amp-image-slider.js
+++ b/extensions/amp-image-slider/0.1/amp-image-slider.js
@@ -149,6 +149,7 @@ export class AmpImageSlider extends AMP.BaseElement {
 
     this.buildImageWrappers_();
     this.buildBar_();
+    // Notice: hints are attached after amp-img finished loading
     this.buildHint_();
     this.checkARIA_();
 
@@ -298,8 +299,7 @@ export class AmpImageSlider extends AMP.BaseElement {
     rightHintWrapper.appendChild(this.hintRightArrow_);
     this.hintLeftBody_.appendChild(leftHintWrapper);
     this.hintRightBody_.appendChild(rightHintWrapper);
-    this.container_.appendChild(this.hintLeftBody_);
-    this.container_.appendChild(this.hintRightBody_);
+    // Notice: hints are attached after amp-img finished loading
   }
 
   /**
@@ -717,8 +717,13 @@ export class AmpImageSlider extends AMP.BaseElement {
       dev().assertElement(this.rightAmpImage_)
           .signals().whenSignal(CommonSignals.LOAD_END),
     ]).then(() => {
-      // Turn on main container visibility
-      this.container_.classList.add('i-amphtml-image-slider-images-ready');
+      // Notice: hints are attached after amp-img finished loading
+      this.container_.appendChild(this.hintLeftBody_);
+      this.container_.appendChild(this.hintRightBody_);
+    }, () => {
+      // Do the same thing when signal rejects
+      this.container_.appendChild(this.hintLeftBody_);
+      this.container_.appendChild(this.hintRightBody_);
     });
   }
 

--- a/extensions/amp-image-slider/0.1/amp-image-slider.js
+++ b/extensions/amp-image-slider/0.1/amp-image-slider.js
@@ -312,7 +312,7 @@ export class AmpImageSlider extends AMP.BaseElement {
     const rightAmpImage = dev().assertElement(this.rightAmpImage_);
     leftAmpImage.signals().whenSignal(CommonSignals.LOAD_END).then(() => {
       if (leftAmpImage.childElementCount > 0) {
-        const img = leftAmpImage.firstChild;
+        const img = leftAmpImage.querySelector('img');
         let newAltText;
         this.measureMutateElement(() => {
           const ariaSuffix =
@@ -330,7 +330,7 @@ export class AmpImageSlider extends AMP.BaseElement {
     });
     rightAmpImage.signals().whenSignal(CommonSignals.LOAD_END).then(() => {
       if (rightAmpImage.childElementCount > 0) {
-        const img = rightAmpImage.firstChild;
+        const img = rightAmpImage.querySelector('img');
         let newAltText;
         this.measureMutateElement(() => {
           const ariaSuffix =

--- a/extensions/amp-image-slider/0.1/amp-image-slider.js
+++ b/extensions/amp-image-slider/0.1/amp-image-slider.js
@@ -711,7 +711,15 @@ export class AmpImageSlider extends AMP.BaseElement {
       this.disableGesture_();
     }
 
-    return Promise.resolve();
+    return Promise.all([
+      dev().assertElement(this.leftAmpImage_)
+          .signals().whenSignal(CommonSignals.LOAD_END),
+      dev().assertElement(this.rightAmpImage_)
+          .signals().whenSignal(CommonSignals.LOAD_END),
+    ]).then(() => {
+      // Turn on main container visibility
+      this.container_.classList.add('i-amphtml-image-slider-images-ready');
+    });
   }
 
   /** @override */

--- a/src/layout.js
+++ b/src/layout.js
@@ -106,6 +106,7 @@ export const LOADING_ELEMENTS_ = {
   'AMP-FACEBOOK-PAGE': true,
   'AMP-IFRAME': true,
   'AMP-IMG': true,
+  'AMP-IMAGE-SLIDER': true,
   'AMP-INSTAGRAM': true,
   'AMP-LIST': true,
   'AMP-OOYALA-PLAYER': true,

--- a/src/layout.js
+++ b/src/layout.js
@@ -106,7 +106,6 @@ export const LOADING_ELEMENTS_ = {
   'AMP-FACEBOOK-PAGE': true,
   'AMP-IFRAME': true,
   'AMP-IMG': true,
-  'AMP-IMAGE-SLIDER': true,
   'AMP-INSTAGRAM': true,
   'AMP-LIST': true,
   'AMP-OOYALA-PLAYER': true,


### PR DESCRIPTION
Per #17446

- [x] Hide hints until the images finished loading, or failed to load.

1st slider below loads correctly.
2nd fails and toggles `amp-img`s' own fallbacks.
![loading-improve](https://user-images.githubusercontent.com/15007517/44060240-e3d186aa-9f08-11e8-8a00-98beff0c5d52.gif)

Caveat:
1. If `layer` is not enabled, three dots would not show
2. If `layer` is not enabled, if amp-imgs' fallback are also amp-imgs or other amp components, they would not show (due to slider taking the ownership)