### PR TITLE
Support <amp-layout> as ad container during collapse

### DIFF
--- a/3p/3p.js
+++ b/3p/3p.js
@@ -277,6 +277,7 @@ function validateAllowedFields(data, allowedFields) {
     adHolderText: true,
     loadingStrategy: true,
     htmlAccessAllowed: true,
+    adContainerId: true,
   };
 
   for (const field in data) {

--- a/builtins/amp-layout.js
+++ b/builtins/amp-layout.js
@@ -15,18 +15,22 @@
  */
 
 import {BaseElement} from '../src/base-element';
-import {isLayoutSizeDefined} from '../src/layout';
+import {Layout, isLayoutSizeDefined} from '../src/layout';
 import {registerElement} from '../src/service/custom-element-registry';
 
 class AmpLayout extends BaseElement {
 
   /** @override */
   isLayoutSupported(layout) {
-    return isLayoutSizeDefined(layout);
+    return layout == Layout.CONTAINER ||
+        isLayoutSizeDefined(layout);
   }
 
   /** @override */
   buildCallback() {
+    if (this.getLayout() == Layout.CONTAINER) {
+      return;
+    }
     const container = this.win.document.createElement('div');
     this.applyFillContent(container);
     this.getRealChildNodes().forEach(child => {

--- a/builtins/amp-layout.md
+++ b/builtins/amp-layout.md
@@ -23,7 +23,7 @@ limitations under the License.
   </tr>
   <tr>
     <td class="col-fourty"><strong><a href="https://www.ampproject.org/docs/guides/responsive/control_layout.html">Supported Layouts</a></strong></td>
-    <td>fill, fixed, fixed-height, flex-item, intrinsic, responsive</td>
+    <td>container, fill, fixed, fixed-height, flex-item, intrinsic, responsive</td>
   </tr>
 </table>
 

--- a/extensions/amp-ad/0.1/test/test-amp-ad-ui.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-ui.js
@@ -17,6 +17,7 @@
 import * as adHelper from '../../../../src/ad-helper';
 import {AmpAdUIHandler} from '../amp-ad-ui';
 import {BaseElement} from '../../../../src/base-element';
+import {createElementWithAttributes} from '../../../../src/dom';
 import {setStyles} from '../../../../src/style';
 
 describes.realWin('amp-ad-ui handler', {
@@ -49,6 +50,21 @@ describes.realWin('amp-ad-ui handler', {
       uiHandler.applyNoContentUI();
       expect(collapseSpy).to.be.calledOnce;
       expect(attemptCollapseSpy).to.not.be.called;
+    });
+
+    it('should collapse ad amp-layout container if there is one', () => {
+      adElement = createElementWithAttributes(env.win.document, 'amp-ad', {
+        'data-ad-container-id': 'test',
+      });
+      const container = createElementWithAttributes(env.win.document,
+          'amp-layout', {'id': 'test'});
+      container.appendChild(adElement);
+      env.win.document.body.appendChild(container);
+      adImpl = new BaseElement(adElement);
+      uiHandler = new AmpAdUIHandler(adImpl);
+      const adAttemptCollapseSpy = sandbox.spy(adImpl, 'attemptCollapse');
+      uiHandler.applyNoContentUI();
+      expect(adAttemptCollapseSpy).to.not.be.called;
     });
 
     it('should try to collapse element first', () => {

--- a/extensions/amp-ad/amp-ad.md
+++ b/extensions/amp-ad/amp-ad.md
@@ -93,6 +93,9 @@ If provided, requires confirming the [amp-user-notification](https://www.ampproj
 
 Instructs the ad to start loading when the ad is within the given number of viewports away from the current viewport. You must specify a float value in the range of [0, 3]. By default, the value is 3. Use a smaller value to gain a higher degree of viewability (i.e., increase the chance that an ad, once loaded, will be seen) but with the risk of generating fewer impressions (i.e., fewer ads loaded). If the attribute is specified but the value is left blank, the system assigns a float value, which optimizes for viewability without drastically impacting the impressions.  Note, specifying `prefer-viewability-over-views` as the value also automatically optimizes viewability.
 
+##### data-ad-container-id (optional)
+Informs the ad of the container component id in the case of attempting to collapse. The container component must be an `<amp-layout>` component that's parent of the ad. When the `data-ad-container-id` is specified, and such a `<amp-layout>` container component is found, AMP runtime will try to collapse the container component instead of the ad component during no fill. This feature can be useful when an ad indicator is in presence.
+
 ##### common attributes
 
 This element includes [common attributes](https://www.ampproject.org/docs/reference/common_attributes) extended to AMP components.

--- a/test/manual/fakead3p.amp.html
+++ b/test/manual/fakead3p.amp.html
@@ -30,7 +30,7 @@
   <a href="https://google.com/fake">fake link</a>
 
   <h2>fake3pAd send no-content</h2>
-  <div>
+    <div>
     <amp-ad width=300 height=250
         type="_ping_"
         data-url='not-exist'
@@ -96,14 +96,16 @@
   </div>
 
   <h2>Below viewport fake3pAd send no-content</h2>
-  <div>
+  <amp-layout id='layout-container'>
+    <div>Advertisment</div>
     <amp-ad width=300 height=250
         type="_ping_"
         data-url='not-exist'
         data-valid='false'
+        data-ad-container-id='layout-container'
         data-enable-io='true'>
     </amp-ad>
-  </div>
+  </amp-layout>
 
   <div class="fixed">
     <amp-ad width=300 height=50

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -4817,6 +4817,7 @@ tags: {  # <amp-layout>
     supported_layouts: INTRINSIC
     supported_layouts: NODISPLAY
     supported_layouts: RESPONSIVE
+    supported_layouts: CONTAINER
   }
 }
 tags: {  # <amp-pixel>


### PR DESCRIPTION
Closes #8941 
As we agreed. Allow user to pass in an `<amp-layout>` id as ad container. So in the event of attempt to collapse, we will try to collapse the container instead of the ad. This can be useful when an ad indicator is required. 