### PR TITLE
🖍 Allow @page CSS at-rule

### DIFF
--- a/spec/amp-html-format.md
+++ b/spec/amp-html-format.md
@@ -250,7 +250,7 @@ Major semantic tags and the AMP custom elements come with default styles to make
 
 The following @-rules are allowed in stylesheets:
 
-`@font-face`, `@keyframes`, `@media`, `@supports`.
+`@font-face`, `@keyframes`, `@media`, `@page`, `@supports`.
 
 `@import` will not be allowed. Others may be added in the future.
 

--- a/validator/testdata/feature_tests/valid_css_at_rules_amp.html
+++ b/validator/testdata/feature_tests/valid_css_at_rules_amp.html
@@ -50,6 +50,14 @@
       to { opacity: 1; }
     }
 
+    @page {
+      margin: 1cm;
+    }
+
+    @page :first {
+      margin: 2cm;
+    }
+
     amp-user-notification.amp-active {
       opacity: 0;
       -webkit-animation: fadeIn ease-in 1s 1 forwards;

--- a/validator/testdata/feature_tests/valid_css_at_rules_amp.out
+++ b/validator/testdata/feature_tests/valid_css_at_rules_amp.out
@@ -51,6 +51,14 @@ PASS
 |        to { opacity: 1; }
 |      }
 |
+|      @page {
+|        margin: 1cm;
+|      }
+|
+|      @page :first {
+|        margin: 2cm;
+|      }
+|
 |      amp-user-notification.amp-active {
 |        opacity: 0;
 |        -webkit-animation: fadeIn ease-in 1s 1 forwards;

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -940,6 +940,10 @@ tags: {  # Special custom 'author' spreadsheet for AMP
         type: PARSE_AS_RULES
       }
       at_rule_spec: {
+        name: 'page'
+        type: PARSE_AS_DECLARATIONS
+      }
+      at_rule_spec: {
         name: 'supports'
         type: PARSE_AS_RULES
       }
@@ -1084,6 +1088,10 @@ tags: {  # Special custom 'author' spreadsheet for AMP
       at_rule_spec: {
         name: 'media'
         type: PARSE_AS_RULES
+      }
+      at_rule_spec: {
+        name: 'page'
+        type: PARSE_AS_DECLARATIONS
       }
       at_rule_spec: {
         name: '$DEFAULT'  # matches if none of the above match


### PR DESCRIPTION
When testing the WordPress AMP plugin with the [Genesis Sample Theme](https://github.com/copyblogger/genesis-sample/), the validator was raising an error regrading an [`@page` at-rule appearing in the CSS](https://github.com/copyblogger/genesis-sample/blob/5a51a24c45d16a82b44d5f71c86be7b350d7cc7a/style.css#L1722-L1724):

```css
@media print {
	/* ... */
	@page {
		margin: 2cm 0.5cm;
	}
	/* ... */
}
```

See MDN docs on `@page` rule: https://developer.mozilla.org/en-US/docs/Web/CSS/@page

There doesn't seem to be any reason for why `@page` should be excluded in AMP, other than it was perhaps not included since it is not a commonly-used rule. So this PR allows the rule in the AMP and AMP4EMAIL formats; I didn't include AMP4ADS as it didn't seem to make sense, but maybe it does.