### PR TITLE
Make sure that amp-fx works above fold as well

### DIFF
--- a/examples/article-fade-in.amp.html
+++ b/examples/article-fade-in.amp.html
@@ -80,9 +80,9 @@
   <main>
     <header>
       <h1>
-          <span class="title">Lorem Ipsum Dolor Sit Lorem Ipsum<span>
+          <span amp-fx="fade-in" class="title">Lorem Ipsum Dolor Sit Lorem Ipsum<span>
       </h1>
-      <amp-img height="50vh" layout="fixed-height" src="https://picsum.photos/1600/900?image=1069"></amp-img>
+      <amp-img amp-fx="fade-in" height="50vh" layout="fixed-height" src="https://picsum.photos/1600/900?image=1069"></amp-img>
     </header>
 
     <article>

--- a/extensions/amp-fx-collection/0.1/providers/fx-provider.js
+++ b/extensions/amp-fx-collection/0.1/providers/fx-provider.js
@@ -174,24 +174,12 @@ export class FxElement {
   /**
    * Preset effect behaves differently for elements that are initially above
    * the fold.
-   *
-   * Normally, preset factor is spread across a whole viewport height however
-   * for elements above the fold, we should only apply the animation after
-   * between the element and top of the page.
    * @return {!Promise<number>}
    * @private
    */
   getAdjustedViewportHeight_() {
     return this.resources_.measureElement(() => {
-      const viewportHeight = this.viewport_.getHeight();
-
-      let offsetTop = 0;
-      for (let node = this.element_; node; node = node./*OK*/offsetParent) {
-        offsetTop += node./*OK*/offsetTop;
-      }
-      const aboveTheFold = (offsetTop < viewportHeight);
-
-      return aboveTheFold ? offsetTop : viewportHeight;
+      return this.viewport_.getHeight();
     });
   }
 


### PR DESCRIPTION
Fix #17457

Currently if an element is above the fold we don't trigger `amp-fx` animations. Fix this by reporting the viewport height always correctly. 