### PR TITLE
Change doubletap delay to 200 ms in gestures

### DIFF
--- a/src/gesture-recognizers.js
+++ b/src/gesture-recognizers.js
@@ -17,6 +17,7 @@
 import {GestureRecognizer} from './gesture';
 import {calcVelocity} from './motion';
 
+const DOUBLETAP_DELAY = 200;
 
 /**
  * A "tap" gesture.
@@ -113,7 +114,7 @@ let DoubletapDef;
 
 /**
  * Recognizes a "doubletap" gesture. This gesture will block a single "tap"
- * for about 300ms while it's expecting the second "tap".
+ * for about 200ms while it's expecting the second "tap".
  * @extends {GestureRecognizer<DoubletapDef>}
  */
 export class DoubletapRecognizer extends GestureRecognizer {
@@ -181,7 +182,7 @@ export class DoubletapRecognizer extends GestureRecognizer {
   onTouchEnd(e) {
     this.tapCount_++;
     if (this.tapCount_ < 2) {
-      this.signalPending(300);
+      this.signalPending(DOUBLETAP_DELAY);
     } else {
       this.event_ = e;
       this.signalReady(0);

--- a/test/functional/test-gesture-recognizers.js
+++ b/test/functional/test-gesture-recognizers.js
@@ -189,7 +189,7 @@ describe('DoubletapRecognizer', () => {
 
   it('should ask pending for first touchend', () => {
     gesturesMock.expects('signalPending_').withExactArgs(
-        recognizer, 300).once();
+        recognizer, 200).once();
     gesturesMock.expects('signalReady_').never();
     recognizer.onTouchEnd({});
     expect(recognizer.tapCount_).to.equal(1);

--- a/test/manual/amp-pan-zoom.amp.html
+++ b/test/manual/amp-pan-zoom.amp.html
@@ -24,7 +24,6 @@
     .seat-selected {
       width: 10px;
       height: 10px;
-      transition: fill .4s ease;
     }
 
     .area-free,


### PR DESCRIPTION
Partially addresses https://github.com/ampproject/amphtml/issues/17416. 

Follow up: investigate optimizing the timer-impl library. 