### PR TITLE
✨Add disable-double-tap attribute for amp-pan-zoom

### DIFF
--- a/extensions/amp-pan-zoom/0.1/amp-pan-zoom.js
+++ b/extensions/amp-pan-zoom/0.1/amp-pan-zoom.js
@@ -144,6 +144,9 @@ export class AmpPanZoom extends AMP.BaseElement {
 
     /** @private {?Element} */
     this.zoomButton_ = null;
+
+    /** @private */
+    this.disableDoubleTap = false;
   }
 
   /** @override */
@@ -164,7 +167,7 @@ export class AmpPanZoom extends AMP.BaseElement {
     this.initialX_ = this.getNumberAttributeOr_('initial-x', 0);
     this.initialY_ = this.getNumberAttributeOr_('initial-y', 0);
     this.resetOnResize_ = this.element.hasAttribute('reset-on-resize');
-
+    this.disableDoubleTap = this.element.hasAttribute('disable-double-tap');
     this.registerAction('transform', invocation => {
       const {args} = invocation;
       if (!args) {
@@ -390,17 +393,6 @@ export class AmpPanZoom extends AMP.BaseElement {
       }
     });
 
-    // Zoomable.
-    this.gestures_.onGesture(DoubletapRecognizer, e => {
-      const {clientX, clientY} = e.data;
-      const newScale = this.scale_ == 1 ? this.maxScale_ : this.minScale_;
-      const deltaX = (this.elementBox_.width / 2) + this.getOffsetX_(clientX);
-      const deltaY = (this.elementBox_.height / 2) + this.getOffsetY_(clientY);
-
-      this.onZoom_(newScale, deltaX, deltaY, /*animate*/ true)
-          .then(() => this.onZoomRelease_());
-    });
-
     this.gestures_.onGesture(PinchRecognizer, e => {
       const {
         centerClientX,
@@ -422,6 +414,20 @@ export class AmpPanZoom extends AMP.BaseElement {
       const event = createCustomEvent(this.win, 'click', null, {bubbles: true});
       e.data.target.dispatchEvent(event);
     });
+
+    if (this.disableDoubleTap) {
+      return;
+    }
+    this.gestures_.onGesture(DoubletapRecognizer, e => {
+      const {clientX, clientY} = e.data;
+      const newScale = this.scale_ == 1 ? this.maxScale_ : this.minScale_;
+      const deltaX = (this.elementBox_.width / 2) + this.getOffsetX_(clientX);
+      const deltaY = (this.elementBox_.height / 2) + this.getOffsetY_(clientY);
+
+      this.onZoom_(newScale, deltaX, deltaY, /*animate*/ true)
+          .then(() => this.onZoomRelease_());
+    });
+
   }
 
   /**

--- a/extensions/amp-pan-zoom/0.1/amp-pan-zoom.js
+++ b/extensions/amp-pan-zoom/0.1/amp-pan-zoom.js
@@ -415,18 +415,16 @@ export class AmpPanZoom extends AMP.BaseElement {
       e.data.target.dispatchEvent(event);
     });
 
-    if (this.disableDoubleTap_) {
-      return;
+    if (!this.disableDoubleTap_) {
+      this.gestures_.onGesture(DoubletapRecognizer, e => {
+        const {clientX, clientY} = e.data;
+        const newScale = this.scale_ == 1 ? this.maxScale_ : this.minScale_;
+        const dx = (this.elementBox_.width / 2) + this.getOffsetX_(clientX);
+        const dy = (this.elementBox_.height / 2) + this.getOffsetY_(clientY);
+        this.onZoom_(newScale, dx, dy, /*animate*/ true)
+            .then(() => this.onZoomRelease_());
+      });
     }
-    this.gestures_.onGesture(DoubletapRecognizer, e => {
-      const {clientX, clientY} = e.data;
-      const newScale = this.scale_ == 1 ? this.maxScale_ : this.minScale_;
-      const deltaX = (this.elementBox_.width / 2) + this.getOffsetX_(clientX);
-      const deltaY = (this.elementBox_.height / 2) + this.getOffsetY_(clientY);
-
-      this.onZoom_(newScale, deltaX, deltaY, /*animate*/ true)
-          .then(() => this.onZoomRelease_());
-    });
 
   }
 

--- a/extensions/amp-pan-zoom/0.1/amp-pan-zoom.js
+++ b/extensions/amp-pan-zoom/0.1/amp-pan-zoom.js
@@ -146,7 +146,7 @@ export class AmpPanZoom extends AMP.BaseElement {
     this.zoomButton_ = null;
 
     /** @private */
-    this.disableDoubleTap = false;
+    this.disableDoubleTap_ = false;
   }
 
   /** @override */
@@ -415,7 +415,7 @@ export class AmpPanZoom extends AMP.BaseElement {
       e.data.target.dispatchEvent(event);
     });
 
-    if (this.disableDoubleTap) {
+    if (this.disableDoubleTap_) {
       return;
     }
     this.gestures_.onGesture(DoubletapRecognizer, e => {

--- a/extensions/amp-pan-zoom/0.1/amp-pan-zoom.js
+++ b/extensions/amp-pan-zoom/0.1/amp-pan-zoom.js
@@ -167,7 +167,7 @@ export class AmpPanZoom extends AMP.BaseElement {
     this.initialX_ = this.getNumberAttributeOr_('initial-x', 0);
     this.initialY_ = this.getNumberAttributeOr_('initial-y', 0);
     this.resetOnResize_ = this.element.hasAttribute('reset-on-resize');
-    this.disableDoubleTap = this.element.hasAttribute('disable-double-tap');
+    this.disableDoubleTap_ = this.element.hasAttribute('disable-double-tap');
     this.registerAction('transform', invocation => {
       const {args} = invocation;
       if (!args) {

--- a/extensions/amp-pan-zoom/0.1/test/validator-amp-pan-zoom.html
+++ b/extensions/amp-pan-zoom/0.1/test/validator-amp-pan-zoom.html
@@ -43,7 +43,7 @@
     <svg></svg>
   </amp-pan-zoom>
 
-  <amp-pan-zoom layout="fill" controls>
+  <amp-pan-zoom layout="fill" controls disable-double-tap>
     <div></div>
   </amp-pan-zoom>
 

--- a/extensions/amp-pan-zoom/0.1/test/validator-amp-pan-zoom.out
+++ b/extensions/amp-pan-zoom/0.1/test/validator-amp-pan-zoom.out
@@ -44,7 +44,7 @@ FAIL
 |      <svg></svg>
 |    </amp-pan-zoom>
 |
-|    <amp-pan-zoom layout="fill" controls>
+|    <amp-pan-zoom layout="fill" controls disable-double-tap>
 |      <div></div>
 |    </amp-pan-zoom>
 |

--- a/extensions/amp-pan-zoom/validator-amp-pan-zoom.protoascii
+++ b/extensions/amp-pan-zoom/validator-amp-pan-zoom.protoascii
@@ -30,11 +30,11 @@ tags: {  # <amp-pan-zoom>
   tag_name: "AMP-PAN-ZOOM"
   requires_extension: "amp-pan-zoom"
   attrs: {
-    name: "disable-double-tap"
+    name: "controls"
     value: ""
   }
   attrs: {
-    name: "controls"
+    name: "disable-double-tap"
     value: ""
   }
   attrs: {

--- a/extensions/amp-pan-zoom/validator-amp-pan-zoom.protoascii
+++ b/extensions/amp-pan-zoom/validator-amp-pan-zoom.protoascii
@@ -30,6 +30,10 @@ tags: {  # <amp-pan-zoom>
   tag_name: "AMP-PAN-ZOOM"
   requires_extension: "amp-pan-zoom"
   attrs: {
+    name: "disable-double-tap"
+    value: ""
+  }
+  attrs: {
     name: "controls"
     value: ""
   }

--- a/test/manual/amp-pan-zoom.amp.html
+++ b/test/manual/amp-pan-zoom.amp.html
@@ -110,7 +110,7 @@
 <article>
   <h1>AMP Pan Zoom</h1>
   <h2>AMP Pan Zoom Basic Example</h2>
-  <amp-pan-zoom layout="responsive" width="300" height="400" controls>
+  <amp-pan-zoom layout="responsive" width="300" height="400" controls disable-double-tap>
       <amp-img id="img0"
         src="/examples/img/sample.jpg"
         width="641" height="481" layout="fixed"></amp-img>
@@ -168,7 +168,11 @@
   <p>This just tests basic features under layout fill</p>
   <p [text]="'Current scale: ' + scale">Current scale: 1</p>
     <amp-layout layout="responsive" height="1" width="1">
-      <amp-pan-zoom layout="fill" on="transformEnd:AMP.setState({scale: event.scale})">
+      <amp-pan-zoom
+        controls
+        disable-double-tap
+        layout="fill"
+        on="transformEnd:AMP.setState({scale: event.scale})">
       <svg viewBox="0 0 190 110" preserveAspectRatio="xMidYMin slice">
           <rect class="area-half" x="5" y="5" />
           <g class="hide" [class]="scale < 2 ? 'hide' : ''" >


### PR DESCRIPTION
Partially addresses https://github.com/ampproject/amphtml/issues/17416. This adds an attribute `disable-double-tap` to allow users of this component to disable double tap zoom to remove the 200ms latency necessary to preserve doubletap detection. This does not disable double-tap zoom by default. Open to feedback on naming. 