### PR TITLE
:book: instruct users to copy paste the emoji itself

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 # Instructions:
 
 - Pick a meaningful title for your pull request. (Use sentence case.)
-  - Prefix the title with an emoji to identify what is being done. (Copy-paste from the list below.)
+  - Prefix the title with an emoji to identify what is being done. (Copy-paste the emoji itself (not the :code:) from the list below.)
   - Do not overuse punctuation in the title (like `(chore):`).
   - If it is helpful, use a simple prefix (like `ProjectX: Implement some feature`).
 - Enter a succinct description that says why the PR is necessary, and what it does.


### PR DESCRIPTION
Per https://github.com/ampproject/amphtml/pull/17433#pullrequestreview-146273922

The commit message is also a test of how the :code:s get rendered. Turns out the commit message did render `:book:` emoji code but the PR title did not. So we should definitely instruct the users to copy/paste the emoji itself.