### PR TITLE
🐛 Update the URL to Moat's iframe transport

### DIFF
--- a/extensions/amp-analytics/0.1/iframe-transport-vendors.js
+++ b/extensions/amp-analytics/0.1/iframe-transport-vendors.js
@@ -26,5 +26,5 @@
  */
 export const IFRAME_TRANSPORTS = /** @type {!JsonObject} */ ({
   'bg': 'https://tpc.googlesyndication.com/b4a/b4a-runner.html',
-  'moat': 'https://js.moatads.com/ampanalytics093284/iframe.html',
+  'moat': 'https://z.moatads.com/ampanalytics093284/iframe.html',
 });


### PR DESCRIPTION
Updates the URL to Moat's iframe transport to point to the secure version of the file.
