### PR TITLE
Disable menu for <amp-mathml>.

### DIFF
--- a/3p/mathml.js
+++ b/3p/mathml.js
@@ -56,6 +56,9 @@ export function mathml(global, data) {
         div.textContent = data.formula;
         setStyle(div, 'visibility', 'hidden');
         global.document.body.appendChild(div);
+        mathjax.Hub.Config({
+          showMathMenu: false,
+        });
         mathjax.Hub.Queue(function() {
           const rendered = document.getElementById('MathJax-Element-1-Frame');
           // Remove built in mathjax margins.

--- a/ads/ads.extern.js
+++ b/ads/ads.extern.js
@@ -60,6 +60,7 @@ data.tweetid
 data.formula
 var mathjax
 mathjax.Hub
+mathjax.Hub.Config
 mathjax.Hub.Queue
 window.MathJax
 


### PR DESCRIPTION
Disable mathml menu since it does not play well with the fact that it is in an iframe, which can be too small to contain the menu.

If the functionality provided by the menu is useful, we may be able to implement our own version outside of the iframe by sending messages back and forth (e.g. to obtain the mathml formula).

Fixes #17039