### PR TITLE
<amp-carousel>: Don't update internal position in the scroll handler. 

### DIFF
--- a/extensions/amp-carousel/0.1/scrollable-carousel.js
+++ b/extensions/amp-carousel/0.1/scrollable-carousel.js
@@ -190,7 +190,6 @@ export class AmpScrollableCarousel extends BaseCarousel {
    */
   scrollHandler_() {
     const currentScrollLeft = this.container_./*OK*/scrollLeft;
-    this.pos_ = currentScrollLeft;
 
     if (this.scrollTimerId_ === null) {
       this.waitForScroll_(currentScrollLeft);


### PR DESCRIPTION
Fixes #17234.

We don't need to update `this.pos_` in the main `scrollHandler_()` function as it is updated in `waitForScroll_()` by calling `commitSwitch_()`. By calling it in both `scrollHandler_()` and `waitForScroll_()` we are scrolling too far ahead. 