### PR TITLE
amp-auto-ads - use documentElement for root query selector

### DIFF
--- a/extensions/amp-auto-ads/0.1/placement.js
+++ b/extensions/amp-auto-ads/0.1/placement.js
@@ -329,7 +329,7 @@ function getPlacementsFromObject(ampdoc, placementObj, placements) {
     user().warn(TAG, 'No anchor in placement');
     return;
   }
-  const anchorElements = getAnchorElements(ampdoc.getBody(), anchor);
+  const anchorElements = getAnchorElements(ampdoc.getRootNode(), anchor);
   if (!anchorElements.length) {
     user().warn(TAG, 'No anchor element found');
     return;
@@ -365,7 +365,7 @@ function getPlacementsFromObject(ampdoc, placementObj, placements) {
 /**
  * Looks up the element(s) addresses by the anchorObj.
  *
- * @param {!Element} rootElement
+ * @param {(Document|ShadowRoot|Element)} rootElement
  * @param {!Object} anchorObj
  * @return {!Array<!Element>}
  */
@@ -375,7 +375,8 @@ function getAnchorElements(rootElement, anchorObj) {
     user().warn(TAG, 'No selector in anchor');
     return [];
   }
-  let elements = [].slice.call(scopedQuerySelectorAll(rootElement, selector));
+  let elements = [].slice.call(scopedQuerySelectorAll(
+      rootElement.documentElement || rootElement, selector));
 
   const minChars = anchorObj['min_c'] || 0;
   if (minChars > 0) {

--- a/extensions/amp-auto-ads/0.1/test/test-placement.js
+++ b/extensions/amp-auto-ads/0.1/test/test-placement.js
@@ -1544,7 +1544,7 @@ describes.realWin('placement', {
         placements: [
           {
             anchor: {
-              selector: 'DIV.class2',
+              selector: 'body DIV.class2',
               sub: {
                 selector: 'DIV.class1 DIV.class3',
                 all: true,


### PR DESCRIPTION
Allows for configuration query selectors to include body as the first element.