### PR TITLE
🐛 Ensure actions wait for `scrollTo` to finish

### DIFF
--- a/src/service/standard-actions-impl.js
+++ b/src/service/standard-actions-impl.js
@@ -173,9 +173,8 @@ export class StandardActions {
       invocation.args['position'] : 'top';
 
     // Animate the scroll
-    this.viewport_.animateScrollIntoView(node, duration, 'ease-in', pos);
-
-    return null;
+    // Should return a promise instead of null
+    return this.viewport_.animateScrollIntoView(node, duration, 'ease-in', pos);
   }
 
   /**


### PR DESCRIPTION
- [x] Make `scrollTo` returns a Promise instead of null such that subsequent actions could wait for it

Closes #17526