### PR TITLE
✨ amp-analytics: allow use of iframe with inabox

### DIFF
--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -320,7 +320,7 @@ export class AmpAnalytics extends AMP.BaseElement {
       return;
     }
     this.preload(getIframeTransportScriptUrl(this.getAmpDoc().win), 'script');
-    const ampAdResourceId = this.isInabox_ ? 1 : this.assertAmpAdResourceId();
+    const ampAdResourceId = this.isInabox_ ? '1' : this.assertAmpAdResourceId();
 
     this.iframeTransport_ = new IframeTransport(
         // Create  3p transport frame within creative frame if inabox.

--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -320,7 +320,7 @@ export class AmpAnalytics extends AMP.BaseElement {
       return;
     }
     this.preload(getIframeTransportScriptUrl(this.getAmpDoc().win), 'script');
-    const ampAdResourceId = this.assertAmpAdResourceId();
+    const ampAdResourceId = this.isInabox_? 1 : this.assertAmpAdResourceId();
 
     this.iframeTransport_ = new IframeTransport(
         // Create  3p transport frame within creative frame if inabox.

--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -320,7 +320,7 @@ export class AmpAnalytics extends AMP.BaseElement {
       return;
     }
     this.preload(getIframeTransportScriptUrl(this.getAmpDoc().win), 'script');
-    const ampAdResourceId = this.isInabox_? 1 : this.assertAmpAdResourceId();
+    const ampAdResourceId = this.isInabox_ ? 1 : this.assertAmpAdResourceId();
 
     this.iframeTransport_ = new IframeTransport(
         // Create  3p transport frame within creative frame if inabox.

--- a/extensions/amp-analytics/0.1/test/test-amp-analytics.js
+++ b/extensions/amp-analytics/0.1/test/test-amp-analytics.js
@@ -371,7 +371,7 @@ describes.realWin('amp-analytics', {
         expect(preloadSpy.withArgs(
             'http://localhost:9876/dist/iframe-transport-client-lib.js',
             'script')).to.be.calledOnce;
-        expect(assertAmpAdResourceIdSpy.notCalled);
+        assert(assertAmpAdResourceIdSpy.notCalled);
       });
     });
   });

--- a/extensions/amp-analytics/0.1/test/test-amp-analytics.js
+++ b/extensions/amp-analytics/0.1/test/test-amp-analytics.js
@@ -349,6 +349,31 @@ describes.realWin('amp-analytics', {
             'script')).to.be.calledOnce;
       });
     });
+
+    it('preloads iframe transport script with inabox', function() {
+      env.win.AMP_MODE.runtime = 'inabox';
+      const el = doc.createElement('amp-analytics');
+      el.setAttribute('type', 'foo');
+      doc.body.appendChild(el);
+      const analytics = new AmpAnalytics(el);
+      const assertAmpAdResourceIdSpy = sandbox.spy(
+          analytics, 'assertAmpAdResourceId');
+      const preloadSpy = sandbox.spy(analytics, 'preload');
+      sandbox.stub(AnalyticsConfig.prototype, 'loadConfig')
+          .returns(Promise.resolve(Object.assign({}, sampleconfig, {
+            'transport': {
+              'iframe': 'http://example.com',
+            },
+          })));
+      analytics.buildCallback();
+      analytics.preconnectCallback();
+      return analytics.layoutCallback().then(() => {
+        expect(preloadSpy.withArgs(
+            'http://localhost:9876/dist/iframe-transport-client-lib.js',
+            'script')).to.be.calledOnce;
+        expect(assertAmpAdResourceIdSpy.notCalled);
+      });
+    });
   });
 
   it('sends a basic hit', function() {


### PR DESCRIPTION
Transport iframe nearly works with Inabox; the only difference is that in Inabox the frame always goes within the ad instead of having one frame at the top level shared between all the ads.