### PR TITLE
Add x-thread as trusted viewer origin protocol (AMP4Email)

### DIFF
--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -891,7 +891,7 @@ export class Viewer {
     /** @const {!Location} */
     const url = parseUrlDeprecated(urlString);
     const {protocol} = url;
-    if (protocol != 'https:' || protocol != 'x-thread:') {
+    if (protocol != 'https:' && protocol != 'x-thread:') {
       // Non-https origins are never trusted. Android x-thread is allowed.
       return false;
     }

--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -890,8 +890,9 @@ export class Viewer {
   isTrustedViewerOrigin_(urlString) {
     /** @const {!Location} */
     const url = parseUrlDeprecated(urlString);
-    if (url.protocol != 'https:') {
-      // Non-https origins are never trusted.
+    const {protocol} = url;
+    if (protocol != 'https:' || protocol != 'x-thread:') {
+      // Non-https origins are never trusted. Android x-thread is allowed.
       return false;
     }
     return TRUSTED_VIEWER_HOSTS.some(th => th.test(url.hostname));

--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -891,8 +891,12 @@ export class Viewer {
     /** @const {!Location} */
     const url = parseUrlDeprecated(urlString);
     const {protocol} = url;
-    if (protocol != 'https:' && protocol != 'x-thread:') {
-      // Non-https origins are never trusted. Android x-thread is allowed.
+    // Android x-thread is allowed.
+    if (protocol == 'x-thread:') {
+      return true;
+    }
+    if (protocol != 'https:') {
+      // Non-https origins are never trusted.
       return false;
     }
     return TRUSTED_VIEWER_HOSTS.some(th => th.test(url.hostname));

--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -891,7 +891,7 @@ export class Viewer {
     /** @const {!Location} */
     const url = parseUrlDeprecated(urlString);
     const {protocol} = url;
-    // Android x-thread is allowed.
+    // Mobile WebView x-thread is allowed.
     if (protocol == 'x-thread:') {
       return true;
     }

--- a/test/functional/test-viewer.js
+++ b/test/functional/test-viewer.js
@@ -1291,7 +1291,7 @@ describe('Viewer', () => {
       });
     }
 
-    describe('should trust domain variations', () => {
+    describe('should trust trusted viewer origins', () => {
       test('https://google.com', true);
       test('https://www.google.com', true);
       test('https://news.google.com', true);
@@ -1308,6 +1308,7 @@ describe('Viewer', () => {
       test('https://abc.www.google.com', true);
       test('https://google.cat', true);
       test('https://www.google.cat', true);
+      test('x-thread://', true);
     });
 
     describe('should not trust host as referrer with http', () => {

--- a/test/functional/test-viewer.js
+++ b/test/functional/test-viewer.js
@@ -1308,7 +1308,7 @@ describe('Viewer', () => {
       test('https://abc.www.google.com', true);
       test('https://google.cat', true);
       test('https://www.google.cat', true);
-      test('x-thread://', true);
+      test('x-thread://www.google.com', true);
     });
 
     describe('should not trust host as referrer with http', () => {

--- a/test/functional/test-viewer.js
+++ b/test/functional/test-viewer.js
@@ -1308,7 +1308,7 @@ describe('Viewer', () => {
       test('https://abc.www.google.com', true);
       test('https://google.cat', true);
       test('https://www.google.cat', true);
-      test('x-thread://www.google.com', true);
+      test('x-thread://', true);
     });
 
     describe('should not trust host as referrer with http', () => {


### PR DESCRIPTION
add x-thread as a trusted origin.