### PR TITLE
Avoid calling Object.assign before polyfill is installed

### DIFF
--- a/src/polyfills.js
+++ b/src/polyfills.js
@@ -28,14 +28,15 @@ import {installCustomElements as installRegisterElement} from
   'document-register-element/build/document-register-element.patched';
 import {isExperimentOn} from './experiments';
 
-if (isExperimentOn(self, 'custom-elements-v1') || getMode().test) {
-  installCustomElements(self, class {});
-} else {
-  installRegisterElement(self, 'auto');
-}
 installDOMTokenListToggle(self);
 installMathSign(self);
 installObjectAssign(self);
 installPromise(self);
 installDocContains(self);
 installArrayIncludes(self);
+// isExperimentOn() must be called after Object.assign polyfill is installed.
+if (isExperimentOn(self, 'custom-elements-v1') || getMode().test) {
+  installCustomElements(self, class {});
+} else {
+  installRegisterElement(self, 'auto');
+}


### PR DESCRIPTION
Breaks AMP on browsers that don't have `Object.assign` which appears to be Chrome 44 and earlier among others. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign#Browser_compatibility

Verified locally that this fixes the bug in Chrome 41.

Context: `b/112598137`

/to @jridgewell @rsimha 

Fixes #17505
Fixes #17533
Fixes #17528