### PR TITLE
Adding a header + logo to the access component UI.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-access.css
+++ b/extensions/amp-story/1.0/amp-story-access.css
@@ -82,8 +82,6 @@ amp-story-access.i-amphtml-story-access-visible::before {
   border-radius: initial !important;
 }
 
-/** Access header. */
-
 .i-amphtml-story-access-header {
   position: relative !important;
   height: 80px !important;
@@ -121,8 +119,6 @@ amp-story-access.i-amphtml-story-access-visible::before {
   box-shadow: 0 2px 3px rgba(0, 0, 0, 0.12) !important;
   z-index: -1 !important;
 }
-
-/** Access content. */
 
 .i-amphtml-story-access-content {
   padding: 60px 16px 16px !important;

--- a/extensions/amp-story/1.0/amp-story-access.css
+++ b/extensions/amp-story/1.0/amp-story-access.css
@@ -82,10 +82,50 @@ amp-story-access.i-amphtml-story-access-visible::before {
   border-radius: initial !important;
 }
 
-/** access content. */
+/** Access header. */
+
+.i-amphtml-story-access-header {
+  position: relative !important;
+  height: 80px !important;
+  min-height: 80px !important;
+  background: var(--primary-color, #F0F0F0) !important;
+  z-index: 2 !important;
+
+  /* Making sure the background color fills the container in full bleed mode. */
+  margin: 0 -8px !important;
+}
+
+.i-amphtml-story-access-logo {
+  position: absolute !important;
+  bottom: -32px !important;
+  margin-left: -32px !important;
+  left: 50% !important;
+  height: 64px !important;
+  width: 64px !important;
+  background: #F0F0F0 !important;
+  background-position: center !important;
+  background-repeat: no-repeat !important;
+  background-size: contain !important;
+  border-radius: 5px !important;
+}
+
+.i-amphtml-story-access-logo::before {
+  content: "" !important;
+  position: absolute !important;
+  top: -6px !important;
+  bottom: -6px !important;
+  left: -6px !important;
+  right: -6px !important;
+  background: #FFFFFF !important;
+  border-radius: 6px !important;
+  box-shadow: 0 2px 3px rgba(0, 0, 0, 0.12) !important;
+  z-index: -1 !important;
+}
+
+/** Access content. */
 
 .i-amphtml-story-access-content {
-  padding: 16px !important;
+  padding: 60px 16px 16px !important;
   font-size: 14px !important;
   z-index: 0 !important;
 }

--- a/extensions/amp-story/1.0/amp-story-access.js
+++ b/extensions/amp-story/1.0/amp-story-access.js
@@ -21,7 +21,13 @@ import {
 } from './amp-story-store-service';
 import {Layout} from '../../../src/layout';
 import {Services} from '../../../src/services';
-import {closest, closestByTag, copyChildren, removeChildren} from '../../../src/dom';
+import {assertHttpsUrl} from '../../../src/url';
+import {
+  closest,
+  closestByTag,
+  copyChildren,
+  removeChildren,
+} from '../../../src/dom';
 import {dev} from '../../../src/log';
 import {dict} from './../../../src/utils/object';
 import {isArray, isObject} from '../../../src/types';
@@ -36,7 +42,8 @@ const TAG = 'amp-story-access';
 
 /**
  * Story access template.
- * @const {!./simple-template.ElementDef}
+ * @param {?string} logoSrc
+ * @return {!./simple-template.ElementDef}
  */
 const getTemplate = logoSrc => ({
   tag: 'div',
@@ -93,13 +100,14 @@ export class AmpStoryAccess extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
-    const storyEl = closestByTag(this.element, 'AMP-STORY');
+    const storyEl =
+        dev().assertElement(closestByTag(this.element, 'AMP-STORY'));
     const logoSrc = storyEl && storyEl.getAttribute('publisher-logo-src');
 
-    if (!logoSrc) {
+    logoSrc ?
+      assertHttpsUrl(logoSrc, storyEl, 'publisher-logo-src') :
       user().warn(
           TAG, 'Expected "publisher-logo-src" attribute on <amp-story>');
-    }
 
     const drawerEl = renderAsElement(this.win.document, getTemplate(logoSrc));
     this.contentEl_ = dev().assertElement(

--- a/extensions/amp-story/1.0/amp-story-access.js
+++ b/extensions/amp-story/1.0/amp-story-access.js
@@ -21,20 +21,24 @@ import {
 } from './amp-story-store-service';
 import {Layout} from '../../../src/layout';
 import {Services} from '../../../src/services';
-import {closest, copyChildren, removeChildren} from '../../../src/dom';
+import {closest, closestByTag, copyChildren, removeChildren} from '../../../src/dom';
 import {dev} from '../../../src/log';
 import {dict} from './../../../src/utils/object';
 import {isArray, isObject} from '../../../src/types';
 import {parseJson} from '../../../src/json';
 import {renderAsElement} from './simple-template';
 import {throttle} from '../../../src/utils/rate-limit';
+import {user} from '../../../src/log';
 
+
+/** @const {string} */
+const TAG = 'amp-story-access';
 
 /**
  * Story access template.
  * @const {!./simple-template.ElementDef}
  */
-const TEMPLATE = {
+const getTemplate = logoSrc => ({
   tag: 'div',
   attrs: dict({'class': 'i-amphtml-story-access-overflow'}),
   children: [
@@ -44,12 +48,27 @@ const TEMPLATE = {
       children: [
         {
           tag: 'div',
+          attrs: dict({'class': 'i-amphtml-story-access-header'}),
+          children: [
+            {
+              tag: 'div',
+              attrs: dict({
+                'class': 'i-amphtml-story-access-logo',
+                'style': logoSrc ?
+                  `background-image: url('${logoSrc}') !important;` : '',
+              }),
+              children: [],
+            },
+          ],
+        },
+        {
+          tag: 'div',
           attrs: dict({'class': 'i-amphtml-story-access-content'}),
         },
       ],
     },
   ],
-};
+});
 
 /**
  * The <amp-story-access> custom element.
@@ -74,7 +93,15 @@ export class AmpStoryAccess extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
-    const drawerEl = renderAsElement(this.win.document, TEMPLATE);
+    const storyEl = closestByTag(this.element, 'AMP-STORY');
+    const logoSrc = storyEl && storyEl.getAttribute('publisher-logo-src');
+
+    if (!logoSrc) {
+      user().warn(
+          TAG, 'Expected "publisher-logo-src" attribute on <amp-story>');
+    }
+
+    const drawerEl = renderAsElement(this.win.document, getTemplate(logoSrc));
     this.contentEl_ = dev().assertElement(
         drawerEl.querySelector('.i-amphtml-story-access-content'));
 

--- a/extensions/amp-story/1.0/test/test-amp-story-access.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-access.js
@@ -24,6 +24,7 @@ describes.realWin('amp-story-access', {amp: true}, env => {
   let defaultConfig;
   let storeService;
   let storyAccess;
+  let storyEl;
 
   const setConfig = config => {
     accessConfigurationEl.textContent = JSON.stringify(config);
@@ -40,11 +41,14 @@ describes.realWin('amp-story-access', {amp: true}, env => {
     defaultConfig = {login: 'https://example.com'};
     setConfig(defaultConfig);
 
+    storyEl = win.document.createElement('amp-story');
     const storyAccessEl = win.document.createElement('amp-story-access');
     storyAccessEl.getResources = () => win.services.resources.obj;
 
+    storyEl.appendChild(storyAccessEl);
+
     win.document.body.appendChild(accessConfigurationEl);
-    win.document.body.appendChild(storyAccessEl);
+    win.document.body.appendChild(storyEl);
 
     storyAccess = new AmpStoryAccess(storyAccessEl);
   });
@@ -147,5 +151,16 @@ describes.realWin('amp-story-access', {amp: true}, env => {
         .to.have.been.calledWith('SCRIPT.login-namespace1-type2');
     expect(addToWhitelistStub)
         .to.have.been.calledWith('SCRIPT.login-namespace2');
+  });
+
+  it('should require publisher-logo-src to be a URL', () => {
+    storyEl.setAttribute('publisher-logo-src', 'foo:bar');
+
+    allowConsoleError(() => {
+      expect(() => {
+        storyAccess.buildCallback();
+      }).to.throw('amp-story publisher-logo-src must start with ' +
+          '"https://" or "//"');
+    });
   });
 });


### PR DESCRIPTION
Adding a header + logo to the access component UI.

![image](https://user-images.githubusercontent.com/1492044/44235347-2d6b7f80-a177-11e8-84bd-edf95f45a89b.png)

Related to #12180