### PR TITLE
Don't accidentally unpause the story when amp-access resolves.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-store-service.js
+++ b/extensions/amp-story/1.0/amp-story-store-service.js
@@ -147,6 +147,11 @@ const actions = (state, action, data) => {
   switch (action) {
     // Triggers the amp-acess paywall.
     case Action.TOGGLE_ACCESS:
+      // Don't change the PAUSED_STATE if ACCESS_STATE is not changed.
+      if (state[StateProperty.ACCESS_STATE] === data) {
+        return state;
+      }
+
       return /** @type {!State} */ (Object.assign(
           {}, state, {
             [StateProperty.ACCESS_STATE]: !!data,

--- a/extensions/amp-story/1.0/test/test-amp-story-store-service.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-store-service.js
@@ -199,4 +199,16 @@ describes.fakeWin('amp-story-store-service actions', {}, env => {
     expect(pausedListenerSpy).to.have.been.calledOnce;
     expect(pausedListenerSpy).to.have.been.calledWith(false);
   });
+
+  it('should not update PAUSED_STATE if ACCESS_STATE is unchanged', () => {
+    // Story is paused.
+    storeService.dispatch(Action.TOGGLE_PAUSED, true);
+
+    // ACCESS_STATE was already false but is set to false again.
+    expect(storeService.get(StateProperty.ACCESS_STATE)).to.be.false;
+    storeService.dispatch(Action.TOGGLE_ACCESS, false);
+
+    // PAUSED_STATE did not get affected.
+    expect(storeService.get(StateProperty.PAUSED_STATE)).to.be.true;
+  });
 });


### PR DESCRIPTION
It's hard to reproduce but the issue was:

- Story is paused on render because `amp-story-consent` is displayed
- `amp-access` resolves, and if the user is authorized, calls `dispatch(Action.TOGGLE_ACCESS, false)`
- this action would set `PAUSED_STATE` to `false` and accidentally unpause the story

(See test case)