### PR TITLE
✨ Version lock CSS

### DIFF
--- a/src/style-installer.js
+++ b/src/style-installer.js
@@ -131,7 +131,6 @@ export function installStylesLegacy(
  * @return {!Element}
  */
 function insertStyleElement(cssRoot, cssText, isRuntimeCss, ext) {
-  cssText = cssText.trim();
   let styleMap = cssRoot[STYLE_MAP_PROP];
   if (!styleMap) {
     styleMap = cssRoot[STYLE_MAP_PROP] = map();
@@ -147,7 +146,7 @@ function insertStyleElement(cssRoot, cssText, isRuntimeCss, ext) {
   if (key) {
     const existing = getExistingStyleElement(cssRoot, styleMap, key);
     if (existing) {
-      if (existing.textContent.trim() !== cssText) {
+      if (existing.textContent !== cssText) {
         existing.textContent = cssText;
       }
       return existing;

--- a/src/style-installer.js
+++ b/src/style-installer.js
@@ -131,6 +131,7 @@ export function installStylesLegacy(
  * @return {!Element}
  */
 function insertStyleElement(cssRoot, cssText, isRuntimeCss, ext) {
+  cssText = cssText.trim();
   let styleMap = cssRoot[STYLE_MAP_PROP];
   if (!styleMap) {
     styleMap = cssRoot[STYLE_MAP_PROP] = map();
@@ -146,6 +147,9 @@ function insertStyleElement(cssRoot, cssText, isRuntimeCss, ext) {
   if (key) {
     const existing = getExistingStyleElement(cssRoot, styleMap, key);
     if (existing) {
+      if (existing.textContent.trim() !== cssText) {
+        existing.textContent = cssText;
+      }
       return existing;
     }
   }

--- a/test/functional/test-style-installer.js
+++ b/test/functional/test-style-installer.js
@@ -225,29 +225,6 @@ describe('Styles', () => {
         });
       });
 
-      it('should not override ws-only difference extension styles', () => {
-        const serverEl = doc.createElement('style');
-        serverEl.setAttribute('amp-runtime', '');
-        serverEl.textContent = '  CSS  ';
-        head.appendChild(serverEl);
-        const promise = installStylesAsPromise('CSS', true);
-        return promise.then(styleEl => {
-          expect(head.__AMP_CSS_SM['amp-runtime']).to.equal(serverEl);
-          expect(styleEl).to.equal(serverEl);
-          expect(styleEl.textContent).to.equal('  CSS  ');
-          expect(head.querySelectorAll('style[amp-runtime]'))
-              .to.have.length(1);
-
-          return installStylesAsPromise('   CSS   ', true);
-        }).then(styleEl => {
-          expect(head.__AMP_CSS_SM['amp-runtime']).to.equal(serverEl);
-          expect(styleEl).to.equal(serverEl);
-          expect(styleEl.textContent).to.equal('  CSS  ');
-          expect(head.querySelectorAll('style[amp-runtime]'))
-              .to.have.length(1);
-        });
-      });
-
       it('should re-create runtime style if absent', () => {
         return installStylesAsPromise('other{}', true).then(styleEl => {
           expect(head.__AMP_CSS_SM['amp-runtime']).to.equal(styleEl);
@@ -266,29 +243,6 @@ describe('Styles', () => {
           expect(head.__AMP_CSS_SM['amp-runtime']).to.not.exist;
           expect(styleEl).to.equal(serverEl);
           expect(styleEl.textContent).to.equal('other{}');
-          expect(head.querySelectorAll('style[amp-extension=amp-ext1]'))
-              .to.have.length(1);
-        });
-      });
-
-      it('should not override ws-only difference extension styles', () => {
-        const serverEl = doc.createElement('style');
-        serverEl.setAttribute('amp-extension', 'amp-ext1');
-        serverEl.textContent = '  CSS  ';
-        head.appendChild(serverEl);
-        const promise = installStylesAsPromise('CSS', false, 'amp-ext1');
-        return promise.then(styleEl => {
-          expect(head.__AMP_CSS_SM['amp-runtime']).to.not.exist;
-          expect(styleEl).to.equal(serverEl);
-          expect(styleEl.textContent).to.equal('  CSS  ');
-          expect(head.querySelectorAll('style[amp-extension=amp-ext1]'))
-              .to.have.length(1);
-
-          return installStylesAsPromise('   CSS   ', false, 'amp-ext1');
-        }).then(styleEl => {
-          expect(head.__AMP_CSS_SM['amp-runtime']).to.not.exist;
-          expect(styleEl).to.equal(serverEl);
-          expect(styleEl.textContent).to.equal('  CSS  ');
           expect(head.querySelectorAll('style[amp-extension=amp-ext1]'))
               .to.have.length(1);
         });

--- a/test/functional/test-style-installer.js
+++ b/test/functional/test-style-installer.js
@@ -206,7 +206,7 @@ describe('Styles', () => {
           return installStylesAsPromise('other{}', true);
         }).then(styleEl => {
           expect(styleEl).to.equal(firstStyleEl);
-          expect(styleEl.textContent).to.equal('');
+          expect(styleEl.textContent).to.equal('other{}');
           expect(head.querySelectorAll('style[amp-runtime]'))
               .to.have.length(1);
         });
@@ -219,7 +219,30 @@ describe('Styles', () => {
         return installStylesAsPromise('other{}', true).then(styleEl => {
           expect(head.__AMP_CSS_SM['amp-runtime']).to.equal(serverEl);
           expect(styleEl).to.equal(serverEl);
-          expect(styleEl.textContent).to.equal('');
+          expect(styleEl.textContent).to.equal('other{}');
+          expect(head.querySelectorAll('style[amp-runtime]'))
+              .to.have.length(1);
+        });
+      });
+
+      it('should not override ws-only difference extension styles', () => {
+        const serverEl = doc.createElement('style');
+        serverEl.setAttribute('amp-runtime', '');
+        serverEl.textContent = '  CSS  ';
+        head.appendChild(serverEl);
+        const promise = installStylesAsPromise('CSS', true);
+        return promise.then(styleEl => {
+          expect(head.__AMP_CSS_SM['amp-runtime']).to.equal(serverEl);
+          expect(styleEl).to.equal(serverEl);
+          expect(styleEl.textContent).to.equal('  CSS  ');
+          expect(head.querySelectorAll('style[amp-runtime]'))
+              .to.have.length(1);
+
+          return installStylesAsPromise('   CSS   ', true);
+        }).then(styleEl => {
+          expect(head.__AMP_CSS_SM['amp-runtime']).to.equal(serverEl);
+          expect(styleEl).to.equal(serverEl);
+          expect(styleEl.textContent).to.equal('  CSS  ');
           expect(head.querySelectorAll('style[amp-runtime]'))
               .to.have.length(1);
         });
@@ -242,7 +265,30 @@ describe('Styles', () => {
         return promise.then(styleEl => {
           expect(head.__AMP_CSS_SM['amp-runtime']).to.not.exist;
           expect(styleEl).to.equal(serverEl);
-          expect(styleEl.textContent).to.equal('');
+          expect(styleEl.textContent).to.equal('other{}');
+          expect(head.querySelectorAll('style[amp-extension=amp-ext1]'))
+              .to.have.length(1);
+        });
+      });
+
+      it('should not override ws-only difference extension styles', () => {
+        const serverEl = doc.createElement('style');
+        serverEl.setAttribute('amp-extension', 'amp-ext1');
+        serverEl.textContent = '  CSS  ';
+        head.appendChild(serverEl);
+        const promise = installStylesAsPromise('CSS', false, 'amp-ext1');
+        return promise.then(styleEl => {
+          expect(head.__AMP_CSS_SM['amp-runtime']).to.not.exist;
+          expect(styleEl).to.equal(serverEl);
+          expect(styleEl.textContent).to.equal('  CSS  ');
+          expect(head.querySelectorAll('style[amp-extension=amp-ext1]'))
+              .to.have.length(1);
+
+          return installStylesAsPromise('   CSS   ', false, 'amp-ext1');
+        }).then(styleEl => {
+          expect(head.__AMP_CSS_SM['amp-runtime']).to.not.exist;
+          expect(styleEl).to.equal(serverEl);
+          expect(styleEl.textContent).to.equal('  CSS  ');
           expect(head.querySelectorAll('style[amp-extension=amp-ext1]'))
               .to.have.length(1);
         });


### PR DESCRIPTION
This ensures that when an AMP doc is Server Side Rendered (by inlining
the v0.css or any extension's CSS into the doc), the inlined styles are
exactly what the JS expects. This eliminates the possibility of version
skew for pages that use cached v0.js but inlined CSS.