### PR TITLE
🐛 Fix `scrollTo` with layers

### DIFF
--- a/src/service/viewport/viewport-impl.js
+++ b/src/service/viewport/viewport-impl.js
@@ -554,19 +554,15 @@ export class Viewport {
         offset = 0;
         break;
     }
-    let newScrollTop;
-    let curScrollTopPromise;
 
-    if (this.useLayers_) {
-      newScrollTop = elementRect.top + offset;
-      curScrollTopPromise = Promise.resolve(0);
-    } else {
-      const calculatedScrollTop = elementRect.top - this.paddingTop_ + offset;
-      newScrollTop = Math.max(0, calculatedScrollTop);
-      curScrollTopPromise = this.getElementScrollTop_(parent);
-    }
-
-    return curScrollTopPromise.then(curScrollTop => {
+    return this.getElementScrollTop_(parent).then(curScrollTop => {
+      let newScrollTop;
+      if (this.useLayers_) {
+        newScrollTop = elementRect.top + offset + curScrollTop;
+      } else {
+        const calculatedScrollTop = elementRect.top - this.paddingTop_ + offset;
+        newScrollTop = Math.max(0, calculatedScrollTop);
+      }
       if (newScrollTop == curScrollTop) {
         return;
       }


### PR DESCRIPTION
With layers, both `newScrollTop` and `curScrollTop` should be relative to parent's `scrollTop`.

Thanks @jridgewell !