### PR TITLE
amp-fx: Use correct adjusted viewport for scroll based/triggered animations

### DIFF
--- a/examples/article-fade-in.amp.html
+++ b/examples/article-fade-in.amp.html
@@ -80,7 +80,7 @@
   <main>
     <header>
       <h1>
-          <span class="title">Lorem Ipsum Dolor Sit Lorem Ipsum<span>
+          <span amp-fx="fade-in" class="title">Lorem Ipsum Dolor Sit Lorem Ipsum<span>
       </h1>
       <amp-img height="50vh" layout="fixed-height" src="https://picsum.photos/1600/900?image=1069"></amp-img>
     </header>

--- a/examples/article-fly-in.amp.html
+++ b/examples/article-fly-in.amp.html
@@ -2,7 +2,7 @@
 <html ⚡>
 <head>
   <meta charset="utf-8">
-  <title>AMP Article with fade-in animations</title>
+  <title>AMP Article with fly-in animations</title>
   <link rel="canonical" href="amps.html">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>

--- a/extensions/amp-fx-collection/0.1/providers/amp-fx-presets.js
+++ b/extensions/amp-fx-collection/0.1/providers/amp-fx-presets.js
@@ -75,13 +75,13 @@ export const Presets = {
     },
     update(entry) {
       const fxElement = this;
-      dev().assert(fxElement.adjustedViewportHeight);
+      dev().assert(fxElement.viewportHeight);
       const top = entry.positionRect ? entry.positionRect.top : null;
       // Outside viewport
-      if (!top || top - (fxElement.adjustedViewportHeight *
+      if (!top || top - (fxElement.viewportHeight *
         fxElement.getFlyInDistance() / 100) >
           (1 - fxElement.getMarginStart()) *
-            fxElement.adjustedViewportHeight) {
+            fxElement.viewportHeight) {
         return;
       }
 
@@ -129,11 +129,11 @@ export const Presets = {
     },
     update(entry) {
       const fxElement = this;
-      dev().assert(fxElement.adjustedViewportHeight);
+      dev().assert(fxElement.viewportHeight);
       const top = entry.positionRect ? entry.positionRect.top : null;
       // Outside viewport
       if (!top || top > (1 - fxElement.getMarginStart()) *
-        fxElement.adjustedViewportHeight) {
+        fxElement.viewportHeight) {
         return;
       }
 
@@ -182,11 +182,11 @@ export const Presets = {
     },
     update(entry) {
       const fxElement = this;
-      dev().assert(fxElement.adjustedViewportHeight);
+      dev().assert(fxElement.viewportHeight);
       const top = entry.positionRect ? entry.positionRect.top : null;
       // Outside viewport
       if (!top || top > (1 - fxElement.getMarginStart()) *
-        fxElement.adjustedViewportHeight) {
+        fxElement.viewportHeight) {
         return;
       }
 
@@ -235,13 +235,13 @@ export const Presets = {
     },
     update(entry) {
       const fxElement = this;
-      dev().assert(fxElement.adjustedViewportHeight);
+      dev().assert(fxElement.viewportHeight);
       const top = entry.positionRect ? entry.positionRect.top : null;
       // Outside viewport
-      if (!top || top + (fxElement.adjustedViewportHeight *
+      if (!top || top + (fxElement.viewportHeight *
         fxElement.getFlyInDistance() / 100) >
           (1 - fxElement.getMarginStart()) *
-            fxElement.adjustedViewportHeight) {
+            fxElement.viewportHeight) {
         return;
       }
 
@@ -289,11 +289,11 @@ export const Presets = {
     },
     update(entry) {
       const fxElement = this;
-      dev().assert(fxElement.adjustedViewportHeight);
+      dev().assert(fxElement.viewportHeight);
       const top = entry.positionRect ? entry.positionRect.top : null;
       // Outside viewport
       if (!top || top > (1 - fxElement.getMarginStart()) *
-        fxElement.adjustedViewportHeight) {
+        fxElement.viewportHeight) {
         return;
       }
 
@@ -357,9 +357,9 @@ export const Presets = {
       const marginDelta = fxElement.getMarginEnd() - fxElement.getMarginStart();
       // Offset is how much extra to move the element which is position within
       // viewport times adjusted factor.
-      const offset = 1 * (fxElement.adjustedViewportHeight - top -
-        (fxElement.getMarginStart() * fxElement.adjustedViewportHeight)) /
-        (marginDelta * fxElement.adjustedViewportHeight);
+      const offset = 1 * (fxElement.viewportHeight - top -
+        (fxElement.getMarginStart() * fxElement.viewportHeight)) /
+        (marginDelta * fxElement.viewportHeight);
       fxElement.setOffset(offset);
 
       if (fxElement.isMutateScheduled()) {

--- a/extensions/amp-fx-collection/0.1/providers/fx-provider.js
+++ b/extensions/amp-fx-collection/0.1/providers/fx-provider.js
@@ -94,6 +94,9 @@ export class FxElement {
     this.resources_ = resources;
 
     /** @type {?number} */
+    this.viewportHeight = null;
+
+    /** @type {?number} */
     this.adjustedViewportHeight = null;
 
     /** @private @const {!Element} */
@@ -154,6 +157,11 @@ export class FxElement {
       // start observing position of the element.
       this.observePositionChanges_();
     });
+
+    this.getViewportHeight_().then(viewportHeight => {
+      this.viewportHeight = viewportHeight;
+    });
+
   }
 
   /**
@@ -168,6 +176,20 @@ export class FxElement {
       this.getAdjustedViewportHeight_().then(adjustedViewportHeight => {
         this.adjustedViewportHeight = adjustedViewportHeight;
       });
+      this.getViewportHeight_().then(viewportHeight => {
+        this.viewportHeight = viewportHeight;
+      });
+    });
+  }
+
+  /**
+   * Returns the current viewport height.
+   * @return {!Promise<number>}
+   * @private
+   */
+  getViewportHeight_() {
+    return this.resources_.measureElement(() => {
+      return this.viewport_.getHeight();
     });
   }
 


### PR DESCRIPTION
Fix #17457

Currently if an element is above the fold we don't trigger amp-fx animations. Fix this by reporting the viewport height always correctly.