### PR TITLE
🌐 Use 'start' instead of 'left' for text-align

### DIFF
--- a/extensions/amp-story/0.1/amp-story.css
+++ b/extensions/amp-story/0.1/amp-story.css
@@ -45,7 +45,7 @@ amp-consent {
   height: auto !important;
   margin: 0 !important;
   padding: 0 !important;
-  text-align: left !important;
+  text-align: start !important;
   width: auto !important;
 }
 

--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -46,7 +46,7 @@ amp-consent {
   height: auto !important;
   margin: 0 !important;
   padding: 0 !important;
-  text-align: left !important;
+  text-align: start !important;
   width: auto !important;
 }
 


### PR DESCRIPTION
`text-align: start` aligns text to the left in LTR, and to the right in RTL.