### PR TITLE
✅ [DO NOT MERGE] [WIP] Un-flake and Un-skip amp-image-slider hint reappear tests

### DIFF
--- a/extensions/amp-image-slider/0.1/amp-image-slider.js
+++ b/extensions/amp-image-slider/0.1/amp-image-slider.js
@@ -21,11 +21,11 @@ import {Gestures} from '../../../src/gesture';
 import {Services} from '../../../src/services';
 import {SwipeXRecognizer} from '../../../src/gesture-recognizers';
 import {clamp} from '../../../src/utils/math';
+import {createCustomEvent, listen} from '../../../src/event-helper';
 import {dev, user} from '../../../src/log';
 import {getMode} from '../../../src/mode';
 import {isExperimentOn} from '../../../src/experiments';
 import {isLayoutSizeDefined} from '../../../src/layout';
-import {listen} from '../../../src/event-helper';
 import {setStyles} from '../../../src/style';
 
 export class AmpImageSlider extends AMP.BaseElement {
@@ -717,10 +717,10 @@ export class AmpImageSlider extends AMP.BaseElement {
     // Show hint if back into viewport and user does not explicitly
     // disable this
     if (getMode().localDev) {
-      this.element.dispatchEvent(new CustomEvent(
-          'amp-image-slider-viewportCallback', {
-            detail: {'inViewport': inViewport},
-          }
+      this.element.dispatchEvent(createCustomEvent(
+          this.win,
+          'amp-image-slider-viewportCallback',
+          {'inViewport': inViewport}
       ));
     }
     if (inViewport && this.shouldHintReappear_) {

--- a/extensions/amp-image-slider/0.1/amp-image-slider.js
+++ b/extensions/amp-image-slider/0.1/amp-image-slider.js
@@ -22,6 +22,7 @@ import {Services} from '../../../src/services';
 import {SwipeXRecognizer} from '../../../src/gesture-recognizers';
 import {clamp} from '../../../src/utils/math';
 import {dev, user} from '../../../src/log';
+import {getMode} from '../../../src/mode';
 import {isExperimentOn} from '../../../src/experiments';
 import {isLayoutSizeDefined} from '../../../src/layout';
 import {listen} from '../../../src/event-helper';
@@ -715,6 +716,13 @@ export class AmpImageSlider extends AMP.BaseElement {
   viewportCallback(inViewport) {
     // Show hint if back into viewport and user does not explicitly
     // disable this
+    if (getMode().localDev) {
+      this.element.dispatchEvent(new CustomEvent(
+          'amp-image-slider-viewportCallback', {
+            detail: {'inViewport': inViewport},
+          }
+      ));
+    }
     if (inViewport && this.shouldHintReappear_) {
       this.animateShowHint_();
     }

--- a/extensions/amp-image-slider/0.1/amp-image-slider.js
+++ b/extensions/amp-image-slider/0.1/amp-image-slider.js
@@ -23,6 +23,7 @@ import {SwipeXRecognizer} from '../../../src/gesture-recognizers';
 import {clamp} from '../../../src/utils/math';
 import {createCustomEvent, listen} from '../../../src/event-helper';
 import {dev, user} from '../../../src/log';
+import {dict} from '../../../src/utils/object';
 import {getMode} from '../../../src/mode';
 import {isExperimentOn} from '../../../src/experiments';
 import {isLayoutSizeDefined} from '../../../src/layout';
@@ -720,7 +721,7 @@ export class AmpImageSlider extends AMP.BaseElement {
       this.element.dispatchEvent(createCustomEvent(
           this.win,
           'amp-image-slider-viewportCallback',
-          {'inViewport': inViewport}
+          dict({'inViewport': inViewport})
       ));
     }
     if (inViewport && this.shouldHintReappear_) {

--- a/extensions/amp-image-slider/0.1/test/integration/test-amp-image-slider.js
+++ b/extensions/amp-image-slider/0.1/test/integration/test-amp-image-slider.js
@@ -632,12 +632,14 @@ config.run('amp-image-slider', function() {
             /*cb*/isHintHiddenCallback,
             /*opt_errorMessage*/'Hint failed to be hidden'
         ).then(() => {
+          const promise = outOfViewportPromise(s1.slider);
           // scroll slider outside of viewport
           win.scrollTo(0, doc.body.scrollHeight);
           // Wait to ensure runtime notices the update.
           // Have to use timeout(...) here,
           // no indication of proper viewportCallback trigger
-          return timeout(500);
+          return promise;
+          // return timeout(500);
         }).then(() => {
           // scroll page to top
           const scrollToTopFunction =
@@ -955,6 +957,26 @@ config.run('amp-image-slider', function() {
     function verifyPositionAfterTimeout(sliderInfo, targetPos) {
       return timeout(DEFAULT_TIMEOUT).then(() => {
         expect(hasCorrectSliderPosition(sliderInfo, targetPos)).to.be.true;
+      });
+    }
+
+    function inViewportPromise(element) {
+      return new Promise(resolve => {
+        element.addEventListener('amp-image-slider-viewportCallback', e => {
+          if (e.detail.inViewport) {
+            resolve();
+          }
+        });
+      });
+    }
+
+    function outOfViewportPromise(element) {
+      return new Promise(resolve => {
+        element.addEventListener('amp-image-slider-viewportCallback', e => {
+          if (!e.detail.inViewport) {
+            resolve();
+          }
+        });
       });
     }
 

--- a/extensions/amp-image-slider/0.1/test/integration/test-amp-image-slider.js
+++ b/extensions/amp-image-slider/0.1/test/integration/test-amp-image-slider.js
@@ -615,7 +615,10 @@ config.run('amp-image-slider', function() {
 
       // TODO: (#17581)
       // This test flakes. May require events/signals to help solve the issue.
-      it.skip('should show hint again on slider scrolling back and ' +
+      it('should show hint again on slider scrolling back and ' +
+      // TODO:
+      // This test flakes. May require signals to help solve the issue.
+      it('should show hint again on slider scrolling back and ' +
         'into viewport, after hint hidden and slider scrolled out of viewport',
       () => {
         const dispatchMouseDownEventFunction =
@@ -635,11 +638,8 @@ config.run('amp-image-slider', function() {
           const promise = outOfViewportPromise(s1.slider);
           // scroll slider outside of viewport
           win.scrollTo(0, doc.body.scrollHeight);
-          // Wait to ensure runtime notices the update.
-          // Have to use timeout(...) here,
-          // no indication of proper viewportCallback trigger
+          // Wait for outOfViewportPromise
           return promise;
-          // return timeout(500);
         }).then(() => {
           // scroll page to top
           const scrollToTopFunction =
@@ -678,12 +678,11 @@ config.run('amp-image-slider', function() {
             /*cb*/isHintHiddenCallback,
             /*opt_errorMessage*/'Hint failed to be hidden'
         ).then(() => {
+          const promise = outOfViewportPromise(s2.slider);
           // scroll slider outside of viewport
           win.scrollTo(0, doc.body.scrollHeight);
-          // Wait to ensure runtime notices the update.
-          // Have to use timeout(...) here,
-          // no indication of proper viewportCallback trigger
-          return timeout(500);
+          // Wait for outOfViewportPromise
+          return promise;
         }).then(() => {
           // scroll page to top
           win.scrollTo(0, s2.slider.offsetTop);
@@ -960,15 +959,15 @@ config.run('amp-image-slider', function() {
       });
     }
 
-    function inViewportPromise(element) {
-      return new Promise(resolve => {
-        element.addEventListener('amp-image-slider-viewportCallback', e => {
-          if (e.detail.inViewport) {
-            resolve();
-          }
-        });
-      });
-    }
+    // function inViewportPromise(element) {
+    //   return new Promise(resolve => {
+    //     element.addEventListener('amp-image-slider-viewportCallback', e => {
+    //       if (e.detail.inViewport) {
+    //         resolve();
+    //       }
+    //     });
+    //   });
+    // }
 
     function outOfViewportPromise(element) {
       return new Promise(resolve => {

--- a/extensions/amp-image-slider/0.1/test/integration/test-amp-image-slider.js
+++ b/extensions/amp-image-slider/0.1/test/integration/test-amp-image-slider.js
@@ -616,9 +616,6 @@ config.run('amp-image-slider', function() {
       // TODO: (#17581)
       // This test flakes. May require events/signals to help solve the issue.
       it('should show hint again on slider scrolling back and ' +
-      // TODO:
-      // This test flakes. May require signals to help solve the issue.
-      it('should show hint again on slider scrolling back and ' +
         'into viewport, after hint hidden and slider scrolled out of viewport',
       () => {
         const dispatchMouseDownEventFunction =


### PR DESCRIPTION
__DO NOT MERGE__
__DO NOT REVIEW__
__WIP__

Currently the amp-image-slider hint reappearance tests flakes badly due to non-determinism of runtime scheduling. This is a PR that allows attempted changes to code immediately tested on Travis (since local machine shows different behavior from Travis).
