### PR TITLE
Enable new arrows for <amp-carousel> experiment

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -38,6 +38,7 @@
   "font-display-swap": 1,
   "amp-date-picker": 1,
   "amp-carousel-scroll-snap": 1,
+  "amp-carousel-new-arrows": 1,
   "user-error-reporting": 1,
   "doubleclickSraExp": 0.01,
   "doubleclickSraReportExcludedBlock": 0.1


### PR DESCRIPTION
This propagates the arrows experiment to 1% canary. 