### PR TITLE
✨Add many more choices for STAMP ads enum

### DIFF
--- a/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
+++ b/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
@@ -57,12 +57,28 @@ const DATA_ATTR = {
 
 /** @const */
 const CTA_TYPES = {
+  APPLY_NOW: 'Apply Now',
+  BOOK_NOW: 'Book',
+  BUY_TICKETS: 'Buy Tickets',
+  DOWNLOAD: 'Download',
   EXPLORE: 'Explore Now',
-  SHOP: 'Shop Now',
-  READ: 'Read Now',
+  GET_NOW: 'Get Now',
   INSTALL: 'Install Now',
   LISTEN: 'Listen Now',
+  MORE: 'More',
+  OPEN_APP: 'Open App',
+  ORDER_NOW: 'Order Now',
+  PLAY: 'Play',
+  READ: 'Read Now',
+  SHOP: 'Shop Now',
+  SHOW: 'Show',
+  SHOWTIMES: 'Showtimes',
+  SIGN_UP: 'Sign Up',
   SUBSCRIBE: 'Subscribe Now',
+  USE_APP: 'Use App',
+  VIEW: 'View',
+  WATCH: 'Watch',
+  WATCH_EPISODE: 'Watch Episode',
 };
 
 /** @const */

--- a/extensions/amp-story/amp-story-ads.md
+++ b/extensions/amp-story/amp-story-ads.md
@@ -47,10 +47,28 @@ the button of a CTA ad.
 
 ### CTA Text Enum
 The CTA button must be configured from a pre-defined set of choices.
+  * APPLY_NOW: "Apply Now"
+  * BOOK_NOW: "Book"
+  * BUY_TICKETS: "Buy Tickets"
+  * DOWNLOAD: "Download"
   * EXPLORE: "Explore Now"
-  * SHOP: "Shop Now"
-  * READ: "Read Now"
+  * GET_NOW: "Get Now"
   * INSTALL: "Install Now" (Note that deep links to apps (e.g. whatsapp://chat) are not supported but publishers can link to the App Store page or the Google Play Store page using http/https).
+  * LISTEN: "Listen Now"
+  * MORE: "More"
+  * OPEN_APP: "Open App"
+  * ORDER_NOW: "Order Now"
+  * PLAY: "Play"
+  * READ: "Read Now"
+  * SHOP: "Shop Now"
+  * SHOW: "Show"
+  * SHOWTIMES: "Showtimes"
+  * SIGN_UP: "Sign Up"
+  * SUBSCRIBE: "Subscribe Now"
+  * USE_APP: "Use App"
+  * VIEW: "View"
+  * WATCH: "Watch"
+  * WATCH_EPISODE: "Watch Episode"
 
 If you need support for a new CTA button, please open a [GitHub issue](https://github.com/ampproject/amphtml/issues/new).
 


### PR DESCRIPTION
Looks like even the longest string `Watch Episode` will fit.

![localhost_8000_examples_amp-story-auto-ads amp html iphone x](https://user-images.githubusercontent.com/16087874/44282399-c51cac80-a20f-11e8-983c-346cb90c68ea.png)
