### PR TITLE
Remove controls attribute and always display zoom buttons by default

### DIFF
--- a/extensions/amp-pan-zoom/0.1/amp-pan-zoom.js
+++ b/extensions/amp-pan-zoom/0.1/amp-pan-zoom.js
@@ -203,9 +203,7 @@ export class AmpPanZoom extends AMP.BaseElement {
 
   /** @override */
   layoutCallback() {
-    if (this.element.hasAttribute('controls')) {
-      this.createZoomButton_();
-    }
+    this.createZoomButton_();
     return this.resetContentDimensions_().then(this.setupGestures_());
   }
 

--- a/extensions/amp-pan-zoom/0.1/test/validator-amp-pan-zoom.html
+++ b/extensions/amp-pan-zoom/0.1/test/validator-amp-pan-zoom.html
@@ -43,7 +43,7 @@
     <svg></svg>
   </amp-pan-zoom>
 
-  <amp-pan-zoom layout="fill" controls disable-double-tap>
+  <amp-pan-zoom layout="fill" disable-double-tap>
     <div></div>
   </amp-pan-zoom>
 

--- a/extensions/amp-pan-zoom/0.1/test/validator-amp-pan-zoom.out
+++ b/extensions/amp-pan-zoom/0.1/test/validator-amp-pan-zoom.out
@@ -44,7 +44,7 @@ FAIL
 |      <svg></svg>
 |    </amp-pan-zoom>
 |
-|    <amp-pan-zoom layout="fill" controls disable-double-tap>
+|    <amp-pan-zoom layout="fill" disable-double-tap>
 |      <div></div>
 |    </amp-pan-zoom>
 |

--- a/extensions/amp-pan-zoom/amp-pan-zoom.md
+++ b/extensions/amp-pan-zoom/amp-pan-zoom.md
@@ -122,6 +122,14 @@ The following public CSS classes are exposed to allow customization for the zoom
 Use `.amp-pan-zoom-button` to customize the dimensions, positioning, background-color, border-radius of all buttons.
 Use `.amp-pan-zoom-in-icon` to customize the icon for the zoom in button.
 Use `.amp-pan-zoom-out-icon` to customize the icon for the zoom out button.
+You can also hide these buttons entirely and create your own using the `transform` action. To hide them, just apply
+
+```
+.amp-pan-zoom-button {
+  display: none;
+}
+```
+
 
 ## Validation
 See [amp-pan-zoom rules](https://github.com/ampproject/amphtml/blob/master/extensions/amp-pan-zoom/validator-amp-pan-zoom.protoascii) in the AMP validator specification.

--- a/extensions/amp-pan-zoom/validator-amp-pan-zoom.protoascii
+++ b/extensions/amp-pan-zoom/validator-amp-pan-zoom.protoascii
@@ -30,10 +30,6 @@ tags: {  # <amp-pan-zoom>
   tag_name: "AMP-PAN-ZOOM"
   requires_extension: "amp-pan-zoom"
   attrs: {
-    name: "controls"
-    value: ""
-  }
-  attrs: {
     name: "disable-double-tap"
     value: ""
   }

--- a/test/manual/amp-pan-zoom.amp.html
+++ b/test/manual/amp-pan-zoom.amp.html
@@ -109,7 +109,7 @@
 <article>
   <h1>AMP Pan Zoom</h1>
   <h2>AMP Pan Zoom Basic Example</h2>
-  <amp-pan-zoom layout="responsive" width="300" height="400" controls disable-double-tap>
+  <amp-pan-zoom layout="responsive" width="300" height="400" disable-double-tap>
       <amp-img id="img0"
         src="/examples/img/sample.jpg"
         width="641" height="481" layout="fixed"></amp-img>

--- a/test/manual/amp-pan-zoom.amp.html
+++ b/test/manual/amp-pan-zoom.amp.html
@@ -75,6 +75,10 @@
     amp-pan-zoom {
       border: #000 2px solid;
     }
+
+    #hide-controls .amp-pan-zoom-button {
+      display: none;
+    }
   </style>
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
@@ -114,6 +118,13 @@
         src="/examples/img/sample.jpg"
         width="641" height="481" layout="fixed"></amp-img>
   </amp-pan-zoom>
+
+  <h2>AMP Pan-Zoom Hide Controls Example</h2>
+  <amp-pan-zoom id="hide-controls" layout="responsive" width="300" height="400">
+    <amp-img id="img0"
+      src="/examples/img/sample.jpg"
+      width="641" height="481" layout="fixed"></amp-img>
+</amp-pan-zoom>
 
   <h2>AMP Pan-Zoom Advanced Example</h2>
   <p>Double tap or pinch to zoom in and out. This tests all initial configurations. </p>
@@ -340,6 +351,7 @@
             </g>
           </svg>
       </amp-pan-zoom>
+
 </article>
 </body>
 </html>


### PR DESCRIPTION
Per latest UX meeting, we decided to always show buttons on `<amp-pan-zoom>` by default and remove the 'controls' attribute. If users do not want this button, they should remove it by applying the `display: none` css attribute on id of the `<amp-pan-zoom>` component + class `amp-pan-zoom-button`. 

- [x] Add examples / manual tests
- [x] Add documentation showing example to disable hint buttons