### PR TITLE
Allow for extension version to specified in friendly iframe embeds

### DIFF
--- a/build-system/dep-check-config.js
+++ b/build-system/dep-check-config.js
@@ -302,8 +302,8 @@ exports.rules = [
           'src/service/xhr-impl.js',
       'extensions/amp-a4a/0.1/template-validator.js->' +
           'src/service/extensions-impl.js',
-       // Accessing extension-location.calculateExtensionScriptUrl().
-       'extensions/amp-script/0.1/amp-script.js->' +
+      // Accessing extension-location.calculateExtensionScriptUrl().
+      'extensions/amp-script/0.1/amp-script.js->' +
           'src/service/extension-location.js',
     ],
   },

--- a/build-system/dep-check-config.js
+++ b/build-system/dep-check-config.js
@@ -284,15 +284,27 @@ exports.rules = [
           'src/service/navigation.js',
 	  'extensions/amp-mowplayer/0.1/amp-mowplayer.js->' +
           'src/service/video-manager-impl.js',
+      'extensions/amp-a4a/0.1/amp-a4a.js->' +
+          'src/friendly-iframe-embed.js',
+      'extensions/amp-a4a/0.1/template-validator.js->' +
+          'src/friendly-iframe-embed.js',
+      'extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js->' +
+          'src/service/extensions-impl.js',
+      'extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js->' +
+          'src/service/extensions-impl.js',
+      'extensions/amp-ad-network-adsense-impl/0.1/template-validator.js->' +
+          'src/service/extensions-impl.js',
       'extensions/amp-analytics/0.1/linker-manager.js->' +
           'src/service/navigation.js',
       'extensions/amp-list/0.1/amp-list.js->' +
           'src/service/xhr-impl.js',
       'extensions/amp-form/0.1/amp-form.js->' +
           'src/service/xhr-impl.js',
-      // Accessing extension-location.calculateExtensionScriptUrl().
-      'extensions/amp-script/0.1/amp-script.js->' +
-            'src/service/extension-location.js',
+      'extensions/amp-a4a/0.1/template-validator.js->' +
+          'src/service/extensions-impl.js',
+       // Accessing extension-location.calculateExtensionScriptUrl().
+       'extensions/amp-script/0.1/amp-script.js->' +
+          'src/service/extension-location.js',
     ],
   },
   {

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -47,6 +47,7 @@ import {getMode} from '../../../src/mode';
 import {insertAnalyticsElement} from '../../../src/extension-analytics';
 import {
   installFriendlyIframeEmbed,
+  preloadExtensions,
   setFriendlyIframeEmbedVisible,
 } from '../../../src/friendly-iframe-embed';
 import {
@@ -55,7 +56,6 @@ import {
 import {isAdPositionAllowed} from '../../../src/ad-helper';
 import {isArray, isEnumValue, isObject} from '../../../src/types';
 import {parseJson} from '../../../src/json';
-import {preloadExtensions} from '../../../src/friendly-iframe-embed';
 import {setStyle} from '../../../src/style';
 import {signingServerURLs} from '../../../ads/_a4a-config';
 import {triggerAnalyticsEvent} from '../../../src/analytics';

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -1815,3 +1815,4 @@ export function signatureVerifierFor(win) {
   return win[propertyName] ||
       (win[propertyName] = new SignatureVerifier(win, signingServerURLs));
 }
+

--- a/extensions/amp-a4a/0.1/amp-ad-type-defs.js
+++ b/extensions/amp-a4a/0.1/amp-ad-type-defs.js
@@ -59,6 +59,8 @@ export let ValidatorOutput;
       minifiedCreative: string,
       customElementExtensions: !Array<string>,
       customStylesheets: !Array<{href: string}>,
+      extensions: !Array<
+          !../../../src/friendly-iframe-embed.CustomElementExtensionDef>,
       images: (Array<string>|undefined),
     }} */
 export let CreativeMetaDataDef;

--- a/extensions/amp-a4a/0.1/amp-ad-utils.js
+++ b/extensions/amp-a4a/0.1/amp-ad-utils.js
@@ -87,16 +87,17 @@ export function getAmpAdMetadata(creative) {
       throw new Error('Invalid runtime offsets');
     }
     const metaData = {};
-    if (metaDataObj['extensions']) {
+    if (metaDataObj['extensions'] && metaDataObj['extensions'].length) {
       metaData.extensions = metaDataObj['extensions'];
       if (!isArray(metaData.extensions)) {
         throw new Error(
             'Invalid extensions', metaData.extensions);
       }
     } else {
-      metaData.customElementExtensions = [];
+      metaData.extensions = [];
     }
-    if (metaDataObj['customElementExtensions']) {
+    if (metaDataObj['customElementExtensions']
+        && metaDataObj['customElementExtensions'].length) {
       metaData.customElementExtensions =
         metaDataObj['customElementExtensions'];
       if (!isArray(metaData.customElementExtensions)) {

--- a/extensions/amp-a4a/0.1/amp-ad-utils.js
+++ b/extensions/amp-a4a/0.1/amp-ad-utils.js
@@ -141,3 +141,18 @@ export function getAmpAdMetadata(creative) {
     return null;
   }
 }
+
+/**
+ * @param {?./amp-ad-type-defs.CreativeMetaDataDef} metadata
+ * @param {string} extensionId
+ */
+export function hasExtensionId(metadata, extensionId) {
+  const {extensions, customElementExtensions} = metadata;
+  if (extensions && extensions.length) {
+    return extensions.some(ext => {
+      return ext['custom-element'] === extensionId;
+    });
+  } else if (customElementExtensions && customElementExtensions.length) {
+    return customElementExtensions.indexOf(extensionId) !== -1;
+  }
+}

--- a/extensions/amp-a4a/0.1/amp-ad-utils.js
+++ b/extensions/amp-a4a/0.1/amp-ad-utils.js
@@ -87,6 +87,15 @@ export function getAmpAdMetadata(creative) {
       throw new Error('Invalid runtime offsets');
     }
     const metaData = {};
+    if (metaDataObj['extensions']) {
+      metaData.extensions = metaDataObj['extensions'];
+      if (!isArray(metaData.extensions)) {
+        throw new Error(
+            'Invalid extensions', metaData.extensions);
+      }
+    } else {
+      metaData.customElementExtensions = [];
+    }
     if (metaDataObj['customElementExtensions']) {
       metaData.customElementExtensions =
         metaDataObj['customElementExtensions'];

--- a/extensions/amp-a4a/0.1/friendly-frame-util.js
+++ b/extensions/amp-a4a/0.1/friendly-frame-util.js
@@ -72,7 +72,9 @@ export function renderCreativeIntoFriendlyFrame(
         host: element,
         url: /** @type {string} */ (adUrl),
         html: creativeMetadata.minifiedCreative,
-        extensionIds: creativeMetadata.customElementExtensions || [],
+        extensions: creativeMetadata.extensions || [],
+        customElementExtensions:
+            creativeMetadata.customElementExtensions || [],
         fonts: fontsArray,
       }, embedWin => {
         installUrlReplacementsForEmbed(element.getAmpDoc(), embedWin,

--- a/extensions/amp-a4a/0.1/template-validator.js
+++ b/extensions/amp-a4a/0.1/template-validator.js
@@ -21,7 +21,6 @@ import {
 } from './amp-ad-type-defs';
 import {AmpAdTemplateHelper} from '../../amp-a4a/0.1/amp-ad-template-helper';
 import {getAmpAdMetadata} from './amp-ad-utils';
-import {hasExtensionId} from '../../../src/service/extensions-impl';
 import {preloadExtensions} from '../../../src/friendly-iframe-embed';
 import {tryParseJson} from '../../../src/json';
 import {urls} from '../../../src/config';
@@ -123,8 +122,14 @@ export class TemplateValidator extends Validator {
    */
   addExtensionIfApplicable_(creativeMetadata, extensionId, extensionSrc) {
     if (creativeMetadata) {
-      const {customElementExtensions, extensions} = creativeMetadata;
-      if (!hasExtensionId(creativeMetadata, extensionId)) {
+      let ext = [];
+      const {extensions, customElementExtensions} = creativeMetadata;
+      if (extensions && extensions.length) {
+        ext = extensions;
+      } else if (customElementExtensions && customElementExtensions.length) {
+        ext = customElementExtensions;
+      }
+      if (ext.indexOf(extensionId) == -1) {
         if (extensions) {
           extensions.push({
             'custom-element': extensionId,

--- a/extensions/amp-a4a/0.1/template-validator.js
+++ b/extensions/amp-a4a/0.1/template-validator.js
@@ -20,7 +20,7 @@ import {
   ValidatorResult,
 } from './amp-ad-type-defs';
 import {AmpAdTemplateHelper} from '../../amp-a4a/0.1/amp-ad-template-helper';
-import {getAmpAdMetadata} from './amp-ad-utils';
+import {getAmpAdMetadata, hasExtensionId} from './amp-ad-utils';
 import {preloadExtensions} from '../../../src/friendly-iframe-embed';
 import {tryParseJson} from '../../../src/json';
 import {urls} from '../../../src/config';
@@ -116,29 +116,21 @@ export class TemplateValidator extends Validator {
   }
 
   /**
-   * @param {?../../../extensions/amp-a4a/0.1/amp-ad-type-defs.CreativeMetaDataDef} creativeMetadata
+   * @param {?../../../extensions/amp-a4a/0.1/amp-ad-type-defs.CreativeMetaDataDef} creativeMetaData
    * @param {string} extensionId
    * @param {string} extensionSrc
    */
-  addExtensionIfApplicable_(creativeMetadata, extensionId, extensionSrc) {
-    if (creativeMetadata) {
-      let ext = [];
-      const {extensions, customElementExtensions} = creativeMetadata;
-      if (extensions && extensions.length) {
-        ext = extensions;
-      } else if (customElementExtensions && customElementExtensions.length) {
-        ext = customElementExtensions;
+  addExtensionIfApplicable_(creativeMetaData, extensionId, extensionSrc) {
+    if (creativeMetaData && !hasExtensionId(creativeMetaData, extensionId)) {
+      const {extensions, customElementExtensions} = creativeMetaData;
+      if (extensions) {
+        extensions.push({
+          'custom-element': extensionId,
+          'src': extensionSrc,
+        });
       }
-      if (ext.indexOf(extensionId) == -1) {
-        if (extensions) {
-          extensions.push({
-            'custom-element': extensionId,
-            'src': extensionSrc,
-          });
-        }
-        if (customElementExtensions) {
-          customElementExtensions.push(extensionId);
-        }
+      if (customElementExtensions) {
+        customElementExtensions.push(extensionId);
       }
     }
   }

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -1708,6 +1708,7 @@ describe('amp-a4a', () => {
           {href: 'https://fonts.googleapis.com/css?foobar'},
           {href: 'https://fonts.com/css?helloworld'},
         ],
+        extensions: [],
         images: ['https://some.image.com/a=b', 'https://other.image.com'],
       };
       return createIframePromise().then(fixture => {

--- a/extensions/amp-a4a/0.1/test/test-amp-ad-utils.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-ad-utils.js
@@ -15,7 +15,7 @@
  */
 
 import {data} from './testdata/valid_css_at_rules_amp.reserialized';
-import {getAmpAdMetadata} from '../amp-ad-utils';
+import {getAmpAdMetadata, hasExtensionId} from '../amp-ad-utils';
 
 describe('getAmpAdMetadata', () => {
 
@@ -43,4 +43,26 @@ describe('getAmpAdMetadata', () => {
     expect(creativeMetadata).to.be.null;
   });
 
+});
+
+describe('hasExtensionId', () => {
+  it('should work with customElementExtensions legacy field', () => {
+    const creativeMetadata = getAmpAdMetadata(data.reserialized);
+    expect(creativeMetadata).to.be.ok;
+    // Ensure that new field isn't set.
+    creativeMetadata.extensions = [];
+    // Verify that old field is present.
+    expect(creativeMetadata.customElementExtensions.length).to.equal(1);
+    expect(hasExtensionId(creativeMetadata, 'amp-font')).to.be.true;
+  });
+
+  it('should work with now favored extension field', () => {
+    const creativeMetadata = getAmpAdMetadata(data.reserialized);
+    expect(creativeMetadata).to.be.ok;
+    // Ensure that old field isn't set.
+    creativeMetadata.customElementExtensions = [];
+    // Verify that old field is present.
+    expect(creativeMetadata.extensions.length).to.equal(1);
+    expect(hasExtensionId(creativeMetadata, 'amp-font')).to.be.true;
+  });
 });

--- a/extensions/amp-a4a/0.1/test/test-template-validator.js
+++ b/extensions/amp-a4a/0.1/test/test-template-validator.js
@@ -117,8 +117,21 @@ describes.realWin('TemplateValidator', realWinConfig, env => {
             expect(validatorOutput).to.be.ok;
             expect(validatorOutput.creativeData).to.be.ok;
             const {creativeMetadata} = validatorOutput.creativeData;
+            // should populate the deprecated customElementExtensions field.
             expect(creativeMetadata.customElementExtensions)
                 .to.deep.equal(['amp-analytics', 'amp-mustache']);
+            // Should populate the extensions metadata.
+            expect(creativeMetadata.extensions)
+                .to.deep.equal([
+                  {
+                    'custom-element': 'amp-analytics',
+                    'src': 'https://cdn.ampproject.org/v0/amp-analytics-0.1.js',
+                  },
+                  {
+                    'custom-element': 'amp-mustache',
+                    'src': 'https://cdn.ampproject.org/v0/amp-mustache-0.1.js',
+                  }]
+                );
           });
         });
   });

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -70,7 +70,6 @@ import {
   randomlySelectUnsetExperiments,
 } from '../../../src/experiments';
 import {getMode} from '../../../src/mode';
-import {hasExtensionId} from '../../../src/service/extensions-impl';
 import {insertAnalyticsElement} from '../../../src/extension-analytics';
 import {removeElement} from '../../../src/dom';
 import {stringHash32} from '../../../src/string';
@@ -464,12 +463,21 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
   onCreativeRender(creativeMetaData) {
     super.onCreativeRender(creativeMetaData);
     this.isAmpCreative_ = !!creativeMetaData;
-    if (creativeMetaData && !hasExtensionId(creativeMetaData, 'amp-ad-exit')) {
-      // Capture phase click handlers on the ad if amp-ad-exit not present
-      // (assume it will handle capture).
-      dev().assert(this.iframe);
-      Navigation.installAnchorClickInterceptor(
-          this.getAmpDoc(), this.iframe.contentWindow);
+    let ext = [];
+    if (creativeMetaData) {
+      const {extensions, customElementExtensions} = creativeMetaData;
+      if (extensions && extensions.length) {
+        ext = extensions;
+      } else if (customElementExtensions && customElementExtensions.length) {
+        ext = customElementExtensions;
+      }
+      if (ext.indexOf('amp-ad-exit') == -1) {
+        // Capture phase click handlers on the ad if amp-ad-exit not present
+        // (assume it will handle capture).
+        dev().assert(this.iframe);
+        Navigation.installAnchorClickInterceptor(
+            this.getAmpDoc(), this.iframe.contentWindow);
+      }
     }
     if (this.ampAnalyticsConfig_) {
       dev().assert(!this.ampAnalyticsElement_);

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -464,9 +464,7 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
   onCreativeRender(creativeMetaData) {
     super.onCreativeRender(creativeMetaData);
     this.isAmpCreative_ = !!creativeMetaData;
-    if (creativeMetaData &&
-        !hasExtensionId(
-            creativeMetaData.customElementExtensions, 'amp-ad-exit')) {
+    if (creativeMetaData && !hasExtensionId(creativeMetaData, 'amp-ad-exit')) {
       // Capture phase click handlers on the ad if amp-ad-exit not present
       // (assume it will handle capture).
       dev().assert(this.iframe);

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -70,6 +70,7 @@ import {
   randomlySelectUnsetExperiments,
 } from '../../../src/experiments';
 import {getMode} from '../../../src/mode';
+import {hasExtensionId} from '../../../src/service/extensions-impl';
 import {insertAnalyticsElement} from '../../../src/extension-analytics';
 import {removeElement} from '../../../src/dom';
 import {stringHash32} from '../../../src/string';
@@ -464,7 +465,8 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
     super.onCreativeRender(creativeMetaData);
     this.isAmpCreative_ = !!creativeMetaData;
     if (creativeMetaData &&
-        !creativeMetaData.customElementExtensions.includes('amp-ad-exit')) {
+        !hasExtensionId(
+            creativeMetaData.customElementExtensions, 'amp-ad-exit')) {
       // Capture phase click handlers on the ad if amp-ad-exit not present
       // (assume it will handle capture).
       dev().assert(this.iframe);

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -70,6 +70,7 @@ import {
   randomlySelectUnsetExperiments,
 } from '../../../src/experiments';
 import {getMode} from '../../../src/mode';
+import {hasExtensionId} from '../../../extensions/amp-a4a/0.1/amp-ad-utils.js';
 import {insertAnalyticsElement} from '../../../src/extension-analytics';
 import {removeElement} from '../../../src/dom';
 import {stringHash32} from '../../../src/string';
@@ -463,21 +464,12 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
   onCreativeRender(creativeMetaData) {
     super.onCreativeRender(creativeMetaData);
     this.isAmpCreative_ = !!creativeMetaData;
-    let ext = [];
-    if (creativeMetaData) {
-      const {extensions, customElementExtensions} = creativeMetaData;
-      if (extensions && extensions.length) {
-        ext = extensions;
-      } else if (customElementExtensions && customElementExtensions.length) {
-        ext = customElementExtensions;
-      }
-      if (ext.indexOf('amp-ad-exit') == -1) {
-        // Capture phase click handlers on the ad if amp-ad-exit not present
-        // (assume it will handle capture).
-        dev().assert(this.iframe);
-        Navigation.installAnchorClickInterceptor(
-            this.getAmpDoc(), this.iframe.contentWindow);
-      }
+    if (creativeMetaData && !hasExtensionId(creativeMetaData, 'amp-ad-exit')) {
+      // Capture phase click handlers on the ad if amp-ad-exit not present
+      // (assume it will handle capture).
+      dev().assert(this.iframe);
+      Navigation.installAnchorClickInterceptor(
+          this.getAmpDoc(), this.iframe.contentWindow);
     }
     if (this.ampAnalyticsConfig_) {
       dev().assert(!this.ampAnalyticsElement_);

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -913,20 +913,21 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
   onCreativeRender(creativeMetaData) {
     super.onCreativeRender(creativeMetaData);
     this.isAmpCreative_ = !!creativeMetaData;
-    let ext = [];
-    const {extensions, customElementExtensions} = creativeMetaData;
-    if (extensions && extensions.length) {
-      ext = extensions;
-    } else if (customElementExtensions && customElementExtensions.length) {
-      ext = customElementExtensions;
-    }
-    if (creativeMetaData &&
-        ext.indexOf('amp-ad-exit') == -1) {
-      // Capture phase click handlers on the ad if amp-ad-exit not present
-      // (assume it will handle capture).
-      dev().assert(this.iframe);
-      Navigation.installAnchorClickInterceptor(
-          this.getAmpDoc(), this.iframe.contentWindow);
+    if (creativeMetaData) {
+      let ext = [];
+      const {extensions, customElementExtensions} = creativeMetaData;
+      if (extensions && extensions.length) {
+        ext = extensions;
+      } else if (customElementExtensions && customElementExtensions.length) {
+        ext = customElementExtensions;
+      }
+      if (ext.indexOf('amp-ad-exit') == -1) {
+        // Capture phase click handlers on the ad if amp-ad-exit not present
+        // (assume it will handle capture).
+        dev().assert(this.iframe);
+        Navigation.installAnchorClickInterceptor(
+            this.getAmpDoc(), this.iframe.contentWindow);
+      }
     }
     if (this.ampAnalyticsConfig_) {
       dev().assert(!this.ampAnalyticsElement_);

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -78,6 +78,7 @@ import {
 } from '../../../ads/google/a4a/traffic-experiments';
 import {getMode} from '../../../src/mode';
 import {getOrCreateAdCid} from '../../../src/ad-cid';
+import {hasExtensionId} from '../../amp-a4a/0.1/amp-ad-utils';
 import {
   incrementLoadingAds,
   is3pThrottled,
@@ -913,21 +914,12 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
   onCreativeRender(creativeMetaData) {
     super.onCreativeRender(creativeMetaData);
     this.isAmpCreative_ = !!creativeMetaData;
-    if (creativeMetaData) {
-      let ext = [];
-      const {extensions, customElementExtensions} = creativeMetaData;
-      if (extensions && extensions.length) {
-        ext = extensions;
-      } else if (customElementExtensions && customElementExtensions.length) {
-        ext = customElementExtensions;
-      }
-      if (ext.indexOf('amp-ad-exit') == -1) {
-        // Capture phase click handlers on the ad if amp-ad-exit not present
-        // (assume it will handle capture).
-        dev().assert(this.iframe);
-        Navigation.installAnchorClickInterceptor(
-            this.getAmpDoc(), this.iframe.contentWindow);
-      }
+    if (creativeMetaData && !hasExtensionId(creativeMetaData, 'amp-ad-exit')) {
+      // Capture phase click handlers on the ad if amp-ad-exit not present
+      // (assume it will handle capture).
+      dev().assert(this.iframe);
+      Navigation.installAnchorClickInterceptor(
+          this.getAmpDoc(), this.iframe.contentWindow);
     }
     if (this.ampAnalyticsConfig_) {
       dev().assert(!this.ampAnalyticsElement_);

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -915,8 +915,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     super.onCreativeRender(creativeMetaData);
     this.isAmpCreative_ = !!creativeMetaData;
     if (creativeMetaData &&
-        !hasExtensionId(
-            creativeMetaData.customElementExtensions, 'amp-ad-exit')) {
+        !hasExtensionId(creativeMetaData, 'amp-ad-exit')) {
       // Capture phase click handlers on the ad if amp-ad-exit not present
       // (assume it will handle capture).
       dev().assert(this.iframe);

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -78,6 +78,7 @@ import {
 } from '../../../ads/google/a4a/traffic-experiments';
 import {getMode} from '../../../src/mode';
 import {getOrCreateAdCid} from '../../../src/ad-cid';
+import {hasExtensionId} from '../../../src/service/extensions-impl';
 import {
   incrementLoadingAds,
   is3pThrottled,
@@ -914,7 +915,8 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     super.onCreativeRender(creativeMetaData);
     this.isAmpCreative_ = !!creativeMetaData;
     if (creativeMetaData &&
-        !creativeMetaData.customElementExtensions.includes('amp-ad-exit')) {
+        !hasExtensionId(
+            creativeMetaData.customElementExtensions, 'amp-ad-exit')) {
       // Capture phase click handlers on the ad if amp-ad-exit not present
       // (assume it will handle capture).
       dev().assert(this.iframe);

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -78,7 +78,6 @@ import {
 } from '../../../ads/google/a4a/traffic-experiments';
 import {getMode} from '../../../src/mode';
 import {getOrCreateAdCid} from '../../../src/ad-cid';
-import {hasExtensionId} from '../../../src/service/extensions-impl';
 import {
   incrementLoadingAds,
   is3pThrottled,
@@ -914,8 +913,15 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
   onCreativeRender(creativeMetaData) {
     super.onCreativeRender(creativeMetaData);
     this.isAmpCreative_ = !!creativeMetaData;
+    let ext = [];
+    const {extensions, customElementExtensions} = creativeMetaData;
+    if (extensions && extensions.length) {
+      ext = extensions;
+    } else if (customElementExtensions && customElementExtensions.length) {
+      ext = customElementExtensions;
+    }
     if (creativeMetaData &&
-        !hasExtensionId(creativeMetaData, 'amp-ad-exit')) {
+        ext.indexOf('amp-ad-exit') == -1) {
       // Capture phase click handlers on the ad if amp-ad-exit not present
       // (assume it will handle capture).
       dev().assert(this.iframe);

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-safeframe.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-safeframe.js
@@ -381,6 +381,7 @@ describes.realWin('DoubleClick Fast Fetch - Safeframe', realWinConfig, env => {
 
 
     it('should handle cancellation', () => {
+      expectAsyncConsoleError('[AMP-DOUBLECLICK-SAFEFRAME] Error: CANCELLED');
       sandbox./*OK*/stub(safeframeHost.baseInstance_,
           'getPageLayoutBox').returns({
         top: 0,

--- a/extensions/amp-ad-network-fake-impl/0.1/data/fake_amp.html
+++ b/extensions/amp-ad-network-fake-impl/0.1/data/fake_amp.html
@@ -18,6 +18,9 @@
    </script>
 </amp-analytics>
 <script amp-ad-metadata type=application/json>
+// Note that there are two means of specifying extensions.
+// 'extensions' is the new and favored way, supporting versions. It will
+// override what's set in customElementExtensions, if both are provided.
 {
    "ampRuntimeUtf16CharOffsets" : [ 134, 1129 ],
    "customElementExtensions" : [

--- a/src/friendly-iframe-embed.js
+++ b/src/friendly-iframe-embed.js
@@ -216,12 +216,21 @@ export function installFriendlyIframeEmbed(iframe, container, spec,
   return readyPromise.then(() => {
     const embed = new FriendlyIframeEmbed(iframe, spec, loadedPromise);
     iframe[EMBED_PROP] = embed;
-
     const childWin = /** @type {!Window} */ (iframe.contentWindow);
     // Add extensions.
+    // TODO (alabiaga): remove customElementExtensions once extensions
+    // becomes preferred way.
+    let ext = [];
+    if (spec.customElementExtensions) {
+      ext = spec.customElementExtensions;
+    } else if (spec.extensions) {
+      spec.extensions.forEach(extension => {
+        ext.push(extension['custom-element']);
+      });
+    }
     extensions.installExtensionsInChildWindow(
         childWin,
-        spec.extensions || spec.customElementExtensions || [],
+        ext,
         opt_preinstallCallback);
     // Ready to be shown.
     embed.startRender_();

--- a/src/friendly-iframe-embed.js
+++ b/src/friendly-iframe-embed.js
@@ -654,6 +654,8 @@ export function isInFie(element) {
 /**
  * Preloads extensions. The extensions field is the preferred means as it
  * supports versions.
+ * TODO(alabiaga): clean up once verified that cloudfare is also using the
+ * extensions format.
  * @param {?../extensions/amp-a4a/0.1/amp-ad-type-defs.CreativeMetaDataDef|!FriendlyIframeSpec} metaData
  * @param {!Window} win
  */

--- a/src/friendly-iframe-embed.js
+++ b/src/friendly-iframe-embed.js
@@ -666,22 +666,21 @@ export function isInFie(element) {
  * @param {!Window} win
  */
 export function preloadExtensions(metaData, win) {
+  const extensions = Services.extensionsFor(win);
   if (isExperimentOn(win, 'fie-metadata-extension')
       && metaData.extensions && metaData.extensions.length) {
     metaData.extensions.forEach(
         extensionDef => {
           const extensionId = extensionDef['custom-element'];
           const version = extensionDef['src'];
-          Services.extensionsFor(win)
-              ./*OK*/preloadExtension(extensionId, version);
+          extensions./*OK*/preloadExtension(extensionId, version);
         });
   } else if (metaData.customElementExtensions
         && metaData.customElementExtensions.length) {
     user().warn(TAG, 'Legacy field customElementExtensions on '
         + 'amp-ad-metadata used.');
     metaData.customElementExtensions.forEach(extensionId => {
-      Services.extensionsFor(win)
-          ./*OK*/preloadExtension(extensionId);
+      extensions./*OK*/preloadExtension(extensionId);
     });
   }
 }

--- a/src/friendly-iframe-embed.js
+++ b/src/friendly-iframe-embed.js
@@ -46,7 +46,8 @@ const EXCLUDE_INI_LOAD =
  * - html: The complete content of an AMP embed, which is itself an AMP
  *   document. Can include whatever is normally allowed in an AMP document,
  *   except for AMP `<script>` declarations. Those should be passed as an
- *   array of `extensionIds`.
+ *   array of `extensionIds` via customElementExtensions field or an array of
+ *   extensionIds with their version via extensions field.
  * - customElementExtensions: An optional array of AMP extension IDs.
  *     used in this embed.
  * - extensions: An optional array of AMP extension IDs w/wo versions
@@ -148,8 +149,6 @@ export function installFriendlyIframeEmbed(iframe, container, spec,
   setStyle(iframe, 'visibility', 'hidden');
   iframe.setAttribute('referrerpolicy', 'unsafe-url');
 
-  // Pre-load extensions. The extensions field is the preferred
-  // means of settings extensions as it allows for versions.
   preloadExtensions(spec, win);
 
   const html = mergeHtml(spec);
@@ -644,15 +643,17 @@ export function isInFie(element) {
 }
 
 /**
- * @param {!../extensions/amp-a4a/0.1/amp-ad-type-defs.CreativeMetaDataDef|!FriendlyIframeSpec} metaData
+ * Preloads extensions. The extensions field is the preferred means as it
+ * supports versions.
+ * @param {?../extensions/amp-a4a/0.1/amp-ad-type-defs.CreativeMetaDataDef|!FriendlyIframeSpec} metaData
  * @param {!Window} win
  */
 export function preloadExtensions(metaData, win) {
   if (metaData.extensions && metaData.extensions.length) {
     metaData.extensions.forEach(
-        extensionDefOrId => {
-          const extensionId = extensionDefOrId['custom-element'];
-          const version = extensionDefOrId['src'];
+        extensionDef => {
+          const extensionId = extensionDef['custom-element'];
+          const version = extensionDef['src'];
           Services.extensionsFor(win)
               ./*OK*/preloadExtension(extensionId, version);
         });

--- a/src/service/extensions-impl.js
+++ b/src/service/extensions-impl.js
@@ -638,13 +638,20 @@ export class Extensions {
 }
 
 /**
- * @param {!Array<!../friendly-iframe-embed.CustomElementExtensionDef|string>} customElementExtensions
+ * @param {!../../extensions/amp-a4a/0.1/amp-ad-type-defs.CreativeMetaDataDef} metadata
  * @param {string} extensionId
  * @return {boolean}
  */
-export function hasExtensionId(customElementExtensions, extensionId) {
-  for (let i = 0; i < customElementExtensions.length; i++) {
-    const extensionDefOrId = customElementExtensions[i];
+export function hasExtensionId(metadata, extensionId) {
+  let ext = [];
+  const {extensions, customElementExtensions} = metadata;
+  if (extensions && extensions.length) {
+    ext = extensions;
+  } else if (customElementExtensions && customElementExtensions.length) {
+    ext = customElementExtensions;
+  }
+  for (let i = 0; i < ext.length; i++) {
+    const extensionDefOrId = ext[i];
     if ((extensionDefOrId && typeof extensionDefOrId == 'object'
         && extensionId === extensionDefOrId['custom-element'])
         || (extensionDefOrId === extensionId)) {

--- a/src/service/extensions-impl.js
+++ b/src/service/extensions-impl.js
@@ -415,12 +415,12 @@ export class Extensions {
    * callback, if specified, is executed after polyfills have been configured
    * but before the first extension is installed.
    * @param {!Window} childWin
-   * @param {!Array<string|!../../extensions/amp-a4a/0.1/amp-ad-type-defs.CreativeMetaDataDef>} extensionData
+   * @param {!Array<string>} extensionIds
    * @param {function(!Window)=} opt_preinstallCallback
    * @return {!Promise}
    * @restricted
    */
-  installExtensionsInChildWindow(childWin, extensionData,
+  installExtensionsInChildWindow(childWin, extensionIds,
     opt_preinstallCallback) {
     const topWin = this.win;
     const parentWin = toWin(childWin.frameElement.ownerDocument.defaultView);
@@ -446,13 +446,7 @@ export class Extensions {
     stubLegacyElements(childWin);
 
     const promises = [];
-    extensionData.forEach(extension => {
-      let extensionId;
-      if (extension && typeof extension == 'object') {
-        extensionId = extension['custom-element'];
-      } else {
-        extensionId = extension;
-      }
+    extensionIds.forEach(extensionId => {
       // This will extend automatic upgrade of custom elements from top
       // window to the child window.
       if (!LEGACY_ELEMENTS.includes(extensionId)) {
@@ -635,30 +629,6 @@ export class Extensions {
     scriptElement.src = scriptSrc;
     return scriptElement;
   }
-}
-
-/**
- * @param {!../../extensions/amp-a4a/0.1/amp-ad-type-defs.CreativeMetaDataDef} metadata
- * @param {string} extensionId
- * @return {boolean}
- */
-export function hasExtensionId(metadata, extensionId) {
-  let ext = [];
-  const {extensions, customElementExtensions} = metadata;
-  if (extensions && extensions.length) {
-    ext = extensions;
-  } else if (customElementExtensions && customElementExtensions.length) {
-    ext = customElementExtensions;
-  }
-  for (let i = 0; i < ext.length; i++) {
-    const extensionDefOrId = ext[i];
-    if ((extensionDefOrId && typeof extensionDefOrId == 'object'
-        && extensionId === extensionDefOrId['custom-element'])
-        || (extensionDefOrId === extensionId)) {
-      return true;
-    }
-  }
-  return false;
 }
 
 /**

--- a/test/functional/test-extensions.js
+++ b/test/functional/test-extensions.js
@@ -947,7 +947,7 @@ describes.sandboxed('Extensions', {}, () => {
       const extHolder = extensions.getExtensionHolder_('amp-test');
       extHolder.scriptPresent = true;
       const promise = extensions.installExtensionsInChildWindow(
-          iframeWin, ['amp-test']);
+          iframeWin, [{'custom-element': 'amp-test', 'src': null}]);
       // Must be stubbed already.
       expect(iframeWin.ampExtendedElements['amp-test']).to.equal(ElementStub);
       expect(iframeWin.document.createElement('amp-test').implementation_)
@@ -996,7 +996,8 @@ describes.sandboxed('Extensions', {}, () => {
       const extHolder = extensions.getExtensionHolder_('amp-test');
       extHolder.scriptPresent = true;
       const promise =
-          extensions.installExtensionsInChildWindow(iframeWin, ['amp-test']);
+          extensions.installExtensionsInChildWindow(
+              iframeWin, [{'custom-element': 'amp-test', 'src': null}]);
       // Resolve the promise.
       extensions.registerExtension('amp-test', AMP => {
         AMP.registerServiceForDoc('fake-service-foo', () => fakeServiceFoo);
@@ -1014,7 +1015,7 @@ describes.sandboxed('Extensions', {}, () => {
       extHolder.scriptPresent = true;
       const promise = extensions.installExtensionsInChildWindow(
           iframeWin,
-          ['amp-test'],
+          [{'custom-element': 'amp-test', 'src': null}],
           function() {
             // Built-ins not installed yet.
             expect(

--- a/test/functional/test-extensions.js
+++ b/test/functional/test-extensions.js
@@ -25,7 +25,6 @@ import {ElementStub} from '../../src/element-stub';
 import {
   Extensions,
   adoptStandardServicesForEmbed,
-  hasExtensionId,
   installExtensionsService,
 } from '../../src/service/extensions-impl';
 import {Services} from '../../src/services';
@@ -579,31 +578,6 @@ describes.sandboxed('Extensions', {}, () => {
         expect(elementClass).to.equal(ctor);
       });
     });
-
-    describe('hasExtensionId', () => {
-      it('should detect extension as string or with version', () => {
-        // Given a list of extension IDs.
-        let extensionIds = ['amp-list', 'amp-mustache'];
-        expect(hasExtensionId(
-            {customElementExtensions: extensionIds}, 'amp-mustache'))
-            .to.be.true;
-
-        // Given a list of extension IDs, along with versions.
-        extensionIds =
-            [{'custom-element': 'amp-mustache', 'src': '0.2'}];
-        expect(hasExtensionId({extensions: extensionIds}, 'amp-mustache'))
-            .to.be.true;
-
-        // Given the extension is not in the list.
-        extensionIds =
-          [{'custom-element': 'amp-mustache', 'src': '0.2'}];
-        expect(hasExtensionId({extensions: extensionIds}, 'amp-form'))
-            .to.be.false;
-        extensionIds = ['amp-mustache', 'amp-list'];
-        expect(hasExtensionId({extensions: extensionIds}, 'amp-form'))
-            .to.be.false;
-      });
-    });
   });
 
   describes.realWin('preloadExtension', {
@@ -1084,29 +1058,6 @@ describes.sandboxed('Extensions', {}, () => {
           expect(adoptServiceForEmbed.getCall([index]).args[1])
               .to.equal(expectedCallsInOrder[index]);
         });
-      });
-    });
-
-    describe('hasExtensionId', () => {
-      it('should detect extension as string or with version', () => {
-        // Given the extensions provided is just a list of extension IDs.
-        let extensionIds = ['amp-list', 'amp-mustache'];
-        expect(hasExtensionId(
-            {customElementExtensions: extensionIds}, 'amp-mustache'))
-            .to.be.true;
-
-        // Given the extensions is list with a version.
-        extensionIds =
-            ['amp-list', {'custom-element': 'amp-mustache', 'src': '0.2'}];
-        expect(hasExtensionId(
-            {customElementExtensions: extensionIds}, 'amp-mustache'))
-            .to.be.true;
-
-        // Given a non existent extension.
-        extensionIds =
-            [{'custom-element': 'amp-mustache', 'src': '0.2'}];
-        expect(hasExtensionId(
-            {extensions: extensionIds}, 'amp-non-existent')).to.be.false;
       });
     });
   });

--- a/test/functional/test-extensions.js
+++ b/test/functional/test-extensions.js
@@ -25,6 +25,7 @@ import {ElementStub} from '../../src/element-stub';
 import {
   Extensions,
   adoptStandardServicesForEmbed,
+  hasExtensionId,
   installExtensionsService,
 } from '../../src/service/extensions-impl';
 import {Services} from '../../src/services';
@@ -578,6 +579,26 @@ describes.sandboxed('Extensions', {}, () => {
         expect(elementClass).to.equal(ctor);
       });
     });
+
+    describe('hasExtensionId', () => {
+      it('should detect extension as string or with version', () => {
+        // Given a list of extension IDs.
+        let extensionIds = ['amp-list', 'amp-mustache'];
+        expect(hasExtensionId(extensionIds, 'amp-mustache')).to.be.true;
+
+        // Given a list of extension IDs, along with versions.
+        extensionIds =
+            [{'custom-element': 'amp-mustache', 'src': '0.2'}];
+        expect(hasExtensionId(extensionIds, 'amp-mustache')).to.be.true;
+
+        // Given the extension is not in the list.
+        extensionIds =
+          [{'custom-element': 'amp-mustache', 'src': '0.2'}];
+        expect(hasExtensionId(extensionIds, 'amp-form')).to.be.false;
+        extensionIds = ['amp-mustache', 'amp-list'];
+        expect(hasExtensionId(extensionIds, 'amp-form')).to.be.false;
+      });
+    });
   });
 
   describes.realWin('preloadExtension', {
@@ -1058,6 +1079,24 @@ describes.sandboxed('Extensions', {}, () => {
           expect(adoptServiceForEmbed.getCall([index]).args[1])
               .to.equal(expectedCallsInOrder[index]);
         });
+      });
+    });
+
+    describe('hasExtensionId', () => {
+      it('should detect extension as string or with version', () => {
+        // Given the extensions provided is just a list of extension IDs.
+        let extensionIds = ['amp-list', 'amp-mustache'];
+        expect(hasExtensionId(extensionIds, 'amp-mustache')).to.be.true;
+
+        // Given the extensions is list with a version.
+        extensionIds =
+            ['amp-list', {'custom-element': 'amp-mustache', 'src': '0.2'}];
+        expect(hasExtensionId(extensionIds, 'amp-mustache')).to.be.true;
+
+        // Given a non existent extension.
+        extensionIds =
+            ['amp-list', {'custom-element': 'amp-mustache', 'src': '0.2'}];
+        expect(hasExtensionId(extensionIds, 'amp-non-existent')).to.be.false;
       });
     });
   });

--- a/test/functional/test-extensions.js
+++ b/test/functional/test-extensions.js
@@ -584,19 +584,24 @@ describes.sandboxed('Extensions', {}, () => {
       it('should detect extension as string or with version', () => {
         // Given a list of extension IDs.
         let extensionIds = ['amp-list', 'amp-mustache'];
-        expect(hasExtensionId(extensionIds, 'amp-mustache')).to.be.true;
+        expect(hasExtensionId(
+            {customElementExtensions: extensionIds}, 'amp-mustache'))
+            .to.be.true;
 
         // Given a list of extension IDs, along with versions.
         extensionIds =
             [{'custom-element': 'amp-mustache', 'src': '0.2'}];
-        expect(hasExtensionId(extensionIds, 'amp-mustache')).to.be.true;
+        expect(hasExtensionId({extensions: extensionIds}, 'amp-mustache'))
+            .to.be.true;
 
         // Given the extension is not in the list.
         extensionIds =
           [{'custom-element': 'amp-mustache', 'src': '0.2'}];
-        expect(hasExtensionId(extensionIds, 'amp-form')).to.be.false;
+        expect(hasExtensionId({extensions: extensionIds}, 'amp-form'))
+            .to.be.false;
         extensionIds = ['amp-mustache', 'amp-list'];
-        expect(hasExtensionId(extensionIds, 'amp-form')).to.be.false;
+        expect(hasExtensionId({extensions: extensionIds}, 'amp-form'))
+            .to.be.false;
       });
     });
   });
@@ -1086,17 +1091,22 @@ describes.sandboxed('Extensions', {}, () => {
       it('should detect extension as string or with version', () => {
         // Given the extensions provided is just a list of extension IDs.
         let extensionIds = ['amp-list', 'amp-mustache'];
-        expect(hasExtensionId(extensionIds, 'amp-mustache')).to.be.true;
+        expect(hasExtensionId(
+            {customElementExtensions: extensionIds}, 'amp-mustache'))
+            .to.be.true;
 
         // Given the extensions is list with a version.
         extensionIds =
             ['amp-list', {'custom-element': 'amp-mustache', 'src': '0.2'}];
-        expect(hasExtensionId(extensionIds, 'amp-mustache')).to.be.true;
+        expect(hasExtensionId(
+            {customElementExtensions: extensionIds}, 'amp-mustache'))
+            .to.be.true;
 
         // Given a non existent extension.
         extensionIds =
-            ['amp-list', {'custom-element': 'amp-mustache', 'src': '0.2'}];
-        expect(hasExtensionId(extensionIds, 'amp-non-existent')).to.be.false;
+            [{'custom-element': 'amp-mustache', 'src': '0.2'}];
+        expect(hasExtensionId(
+            {extensions: extensionIds}, 'amp-non-existent')).to.be.false;
       });
     });
   });

--- a/test/functional/test-friendly-iframe-embed.js
+++ b/test/functional/test-friendly-iframe-embed.js
@@ -149,8 +149,9 @@ describe('friendly-iframe-embed', () => {
         .withExactArgs(sinon.match(arg => {
           installExtWin = arg;
           return true;
-        }), [{'custom-element': 'amp-test', 'src': null}],
-            /* preinstallCallback */ undefined)
+        }),
+        [{'custom-element': 'amp-test', 'src': null}],
+        /* preinstallCallback */ undefined)
         .once();
 
     const embedPromise = installFriendlyIframeEmbed(iframe, document.body, {
@@ -178,8 +179,9 @@ describe('friendly-iframe-embed', () => {
         .withExactArgs(sinon.match(arg => {
           installExtWin = arg;
           return true;
-        }), [{'custom-element': 'amp-mustache', 'src': '0.2'}],
-            /* preinstallCallback */ undefined)
+        }),
+        [{'custom-element': 'amp-mustache', 'src': '0.2'}],
+        /* preinstallCallback */ undefined)
         .once();
 
     const embedPromise = installFriendlyIframeEmbed(iframe, document.body, {

--- a/test/functional/test-friendly-iframe-embed.js
+++ b/test/functional/test-friendly-iframe-embed.js
@@ -176,7 +176,7 @@ describe('friendly-iframe-embed', () => {
         .withExactArgs(sinon.match(arg => {
           installExtWin = arg;
           return true;
-        }), [{'custom-element': 'amp-mustache', 'src': '0.2'}],
+        }), ['amp-mustache'],
             /* preinstallCallback */ undefined)
         .once();
 

--- a/test/functional/test-xhr.js
+++ b/test/functional/test-xhr.js
@@ -225,6 +225,9 @@ describe.configure().skipSafari().run('XHR', function() {
         });
 
         it('should deny AMP origin for different origin in response', () => {
+          const error = 'Returned AMP-Access-Control-Allow-Source-Origin is '
+              + 'not equal to the current: https://other.com vs https://acme.com';
+          expectAsyncConsoleError(error);
           const promise = xhr.fetchJson('/get');
           xhrCreated.then(
               xhr => xhr.respond(
@@ -244,6 +247,8 @@ describe.configure().skipSafari().run('XHR', function() {
         });
 
         it('should require AMP origin in response for when request', () => {
+          expectAsyncConsoleError('Response must contain the '
+              + 'AMP-Access-Control-Allow-Source-Origin header');
           const promise = xhr.fetchJson('/get');
           xhrCreated.then(
               xhr => xhr.respond(
@@ -826,6 +831,7 @@ describe.configure().skipSafari().run('XHR', function() {
     });
 
     it('should be rejected when response undefined', () => {
+      expectAsyncConsoleError(/Object expected/);
       sendMessageStub.returns(Promise.resolve());
       const xhr = xhrServiceForTesting(interceptionEnabledWin);
 
@@ -834,6 +840,7 @@ describe.configure().skipSafari().run('XHR', function() {
     });
 
     it('should be rejected when response null', () => {
+      expectAsyncConsoleError(/Object expected/);
       sendMessageStub.returns(Promise.resolve(null));
       const xhr = xhrServiceForTesting(interceptionEnabledWin);
 
@@ -842,6 +849,7 @@ describe.configure().skipSafari().run('XHR', function() {
     });
 
     it('should be rejected when response is string', () => {
+      expectAsyncConsoleError(/Object expected/);
       sendMessageStub.returns(Promise.resolve('response text'));
       const xhr = xhrServiceForTesting(interceptionEnabledWin);
 

--- a/testing/describes.js
+++ b/testing/describes.js
@@ -1,5 +1,5 @@
 /**
-* Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -672,11 +672,12 @@ class AmpFixture {
       // Thus, not changes needed here.
     }
     maybeTrackImpression(self);
-    const extensions = [];
-    if (spec.extensions && spec.extensions.length) {
+    const extensionIds = [];
+    if (spec.extensions) {
       spec.extensions.forEach(extensionIdWithVersion => {
         const tuple = extensionIdWithVersion.split(':');
         const extensionId = tuple[0];
+        extensionIds.push(extensionId);
         // Default to 0.1 if no version was provided.
         const version = tuple[1] || '0.1';
         const installer = extensionsBuffer[`${extensionId}:${version}`];
@@ -748,7 +749,7 @@ class AmpFixture {
           embedIframe, container, {
             url: 'http://ads.localhost:8000/example',
             html,
-            extensions,
+            extensionIds,
           }, embedWin => {
             interceptEventListeners(embedWin);
             interceptEventListeners(embedWin.document);
@@ -771,7 +772,7 @@ class AmpFixture {
       const {ampdoc} = ret;
       env.ampdoc = ampdoc;
       const promise = Promise.all([
-        env.extensions.installExtensionsInDoc(ampdoc, extensions),
+        env.extensions.installExtensionsInDoc(ampdoc, extensionIds),
         ampdoc.whenReady(),
       ]);
       completePromise = completePromise ?

--- a/testing/describes.js
+++ b/testing/describes.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+* Copyright 2016 The AMP HTML Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -671,13 +671,17 @@ class AmpFixture {
       // Notice that ampdoc's themselves install runtime styles in shadow roots.
       // Thus, not changes needed here.
     }
+<<<<<<< HEAD
     maybeTrackImpression(self);
     const extensionIds = [];
     if (spec.extensions) {
+=======
+    const extensions = [];
+    if (spec.extensions && spec.extensions.length) {
+>>>>>>> changes
       spec.extensions.forEach(extensionIdWithVersion => {
         const tuple = extensionIdWithVersion.split(':');
         const extensionId = tuple[0];
-        extensionIds.push(extensionId);
         // Default to 0.1 if no version was provided.
         const version = tuple[1] || '0.1';
         const installer = extensionsBuffer[`${extensionId}:${version}`];
@@ -749,7 +753,7 @@ class AmpFixture {
           embedIframe, container, {
             url: 'http://ads.localhost:8000/example',
             html,
-            extensionIds,
+            extensions,
           }, embedWin => {
             interceptEventListeners(embedWin);
             interceptEventListeners(embedWin.document);
@@ -772,7 +776,7 @@ class AmpFixture {
       const {ampdoc} = ret;
       env.ampdoc = ampdoc;
       const promise = Promise.all([
-        env.extensions.installExtensionsInDoc(ampdoc, extensionIds),
+        env.extensions.installExtensionsInDoc(ampdoc, extensions),
         ampdoc.whenReady(),
       ]);
       completePromise = completePromise ?

--- a/testing/describes.js
+++ b/testing/describes.js
@@ -671,14 +671,9 @@ class AmpFixture {
       // Notice that ampdoc's themselves install runtime styles in shadow roots.
       // Thus, not changes needed here.
     }
-<<<<<<< HEAD
     maybeTrackImpression(self);
-    const extensionIds = [];
-    if (spec.extensions) {
-=======
     const extensions = [];
     if (spec.extensions && spec.extensions.length) {
->>>>>>> changes
       spec.extensions.forEach(extensionIdWithVersion => {
         const tuple = extensionIdWithVersion.split(':');
         const extensionId = tuple[0];


### PR DESCRIPTION
fixes 1/2 tasks in #12429

support 'extensions' on client side for friendlyIframeSpec, allowing for extensions and their versions.

related: #7217