### PR TITLE
Move code out of viewer constructor.

### DIFF
--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -259,24 +259,11 @@ export class Viewer {
         this.prerenderSize_;
     dev().fine(TAG_, '- prerenderSize:', this.prerenderSize_);
 
-    let isCctEmbedded = false;
-    if (!this.isIframed_) {
-      const queryParams = parseQueryString(this.win.location.search);
-      isCctEmbedded = queryParams['amp_gsa'] === '1' &&
-          startsWith(queryParams['amp_js_v'] || '', 'a');
-    }
     /**
      * Whether the AMP document is embedded in a Chrome Custom Tab.
-     * @private @const {boolean}
+     * @private {?boolean}
      */
-    this.isCctEmbedded_ = isCctEmbedded;
-
-    /**
-     * Whether the AMP document is embedded in a webview.
-     * @private @const {boolean}
-     */
-    this.isWebviewEmbedded_ = !this.isIframed_ &&
-        this.params_['webview'] == '1';
+    this.isCctEmbedded_ = null;
 
     /**
      * Whether the AMP document is embedded in a viewer, such as an iframe, or
@@ -297,8 +284,8 @@ export class Viewer {
             || this.params_['visibilityState']
             // Parent asked for viewer JS. We must be embedded.
             || (this.win.location.search.indexOf('amp_js_v') != -1)))
-        || this.isWebviewEmbedded_
-        || this.isCctEmbedded_
+        || this.isWebviewEmbedded()
+        || this.isCctEmbedded()
         || !ampdoc.isSingleDoc());
 
     const url = parseUrlDeprecated(this.ampdoc.win.location.href);
@@ -354,8 +341,8 @@ export class Viewer {
       // Not embedded in IFrame - can't trust the viewer.
       trustedViewerResolved = false;
       trustedViewerPromise = Promise.resolve(false);
-    } else if (this.win.location.ancestorOrigins && !this.isWebviewEmbedded_ &&
-        !this.isCctEmbedded_) {
+    } else if (this.win.location.ancestorOrigins && !this.isWebviewEmbedded() &&
+        !this.isCctEmbedded()) {
       // Ancestors when available take precedence. This is the main API used
       // for this determination. Fallback is only done when this API is not
       // supported by the browser.
@@ -557,7 +544,7 @@ export class Viewer {
    * @return {boolean}
    */
   isWebviewEmbedded() {
-    return this.isWebviewEmbedded_;
+    return !this.isIframed_ && this.params_['webview'] == '1';
   }
 
   /**
@@ -565,6 +552,15 @@ export class Viewer {
    * @return {boolean}
    */
   isCctEmbedded() {
+    if (this.isCctEmbedded_ != null) {
+      return this.isCctEmbedded_;
+    }
+    this.isCctEmbedded_ = false;
+    if (!this.isIframed_) {
+      const queryParams = parseQueryString(this.win.location.search);
+      this.isCctEmbedded_ = queryParams['amp_gsa'] === '1' &&
+          startsWith(queryParams['amp_js_v'] || '', 'a');
+    }
     return this.isCctEmbedded_;
   }
 
@@ -581,7 +577,7 @@ export class Viewer {
    * not clear query string parameters, but will clear the fragment.
    */
   maybeUpdateFragmentForCct() {
-    if (!this.isCctEmbedded_) {
+    if (!this.isCctEmbedded()) {
       return;
     }
     // CCT only works with versions of Chrome that support the history API.


### PR DESCRIPTION
constructor was super long with many member fields. hard to read.