### PR TITLE
🐛 amp-next-page: Fix initial documentRef ampUrl assignment

### DIFF
--- a/extensions/amp-next-page/0.1/next-page-service.js
+++ b/extensions/amp-next-page/0.1/next-page-service.js
@@ -147,7 +147,7 @@ export class NextPageService {
     this.positionObserver_ = getServiceForDoc(ampDoc, 'position-observer');
 
     const documentRef =
-        createDocumentRef(win.document.location.url, win.document.title);
+        createDocumentRef(win.document.location.href, win.document.title);
     this.documentRefs_.push(documentRef);
     this.activeDocumentRef_ = this.documentRefs_[0];
 


### PR DESCRIPTION
document.location.url doesn't exist, should be document.location. Introduced in #16624

Fixes an issue where the URL gets set to "undefined" when scrolling back up to the original document.

@aghassemi