### PR TITLE
Viewer service refactoring

### DIFF
--- a/build-system/tasks/bundle-size.js
+++ b/build-system/tasks/bundle-size.js
@@ -22,7 +22,7 @@ const log = require('fancy-log');
 const {getStdout} = require('../exec');
 
 const runtimeFile = './dist/v0.js';
-const maxSize = '80.73KB';
+const maxSize = '80.9KB';
 
 const {green, red, cyan, yellow} = colors;
 

--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -337,6 +337,7 @@ const forbiddenTerms = {
     whitelist: [
       // viewer-impl.sendMessage
       'src/error.js',
+      'src/service/navigation.js',
       'src/service/viewer-impl.js',
       'src/service/viewport/viewport-impl.js',
       'src/service/performance-impl.js',

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -126,7 +126,8 @@ describes.realWin('amp-list component', {
   function expectViewerProxiedFetchAndRender(
     fetched, rendered, opts = DEFAULT_LIST_OPTS) {
     const fetch = Promise.resolve(fetched);
-    viewerMock.expects('canRenderTemplates').returns(true).twice();
+    viewerMock.expects('hasCapability')
+        .withExactArgs(Capability.VIEWER_RENDER_TEMPLATE).returns(true).twice();
     viewerMock.expects('sendMessageAwaitResponse').withExactArgs(
         Capability.VIEWER_RENDER_TEMPLATE,
         {
@@ -177,7 +178,8 @@ describes.realWin('amp-list component', {
       });
 
       it('should error if viewer does not define response data', () => {
-        viewerMock.expects('canRenderTemplates').returns(true);
+        viewerMock.expects('hasCapability')
+            .withExactArgs(Capability.VIEWER_RENDER_TEMPLATE).returns(true);
         viewerMock.expects('sendMessageAwaitResponse').withExactArgs(
             Capability.VIEWER_RENDER_TEMPLATE,
             {

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -16,7 +16,6 @@
 
 import {AmpEvents} from '../../../../src/amp-events';
 import {AmpList} from '../amp-list';
-import {Capability} from '../../../../src/service/viewer-impl';
 import {Deferred} from '../../../../src/utils/promise';
 import {Services} from '../../../../src/services';
 
@@ -127,9 +126,9 @@ describes.realWin('amp-list component', {
     fetched, rendered, opts = DEFAULT_LIST_OPTS) {
     const fetch = Promise.resolve(fetched);
     viewerMock.expects('hasCapability')
-        .withExactArgs(Capability.VIEWER_RENDER_TEMPLATE).returns(true).twice();
+        .withExactArgs('viewerRenderTemplate').returns(true).twice();
     viewerMock.expects('sendMessageAwaitResponse').withExactArgs(
-        Capability.VIEWER_RENDER_TEMPLATE,
+        'viewerCanRenderTemplate',
         {
           data: {inputData: { }, src: 'https://data.com/list.json'},
           mustacheTemplate: '<template xmlns="http://www.w3.org/1999/xhtml">' +
@@ -179,9 +178,9 @@ describes.realWin('amp-list component', {
 
       it('should error if viewer does not define response data', () => {
         viewerMock.expects('hasCapability')
-            .withExactArgs(Capability.VIEWER_RENDER_TEMPLATE).returns(true);
+            .withExactArgs('viewerRenderTemplate').returns(true);
         viewerMock.expects('sendMessageAwaitResponse').withExactArgs(
-            Capability.VIEWER_RENDER_TEMPLATE,
+            'viewerRenderTemplate',
             {
               data: {
                 inputData: { },

--- a/extensions/amp-mustache/0.1/test/test-amp-mustache.js
+++ b/extensions/amp-mustache/0.1/test/test-amp-mustache.js
@@ -17,7 +17,7 @@
 import * as mustache from '../../../../third_party/mustache/mustache';
 import * as sanitizer from '../../../../src/sanitizer';
 import * as service from '../../../../src/service';
-import {AmpMustache} from '../amp-mustache';
+import {AmpMustache} from '../amp-mustache'
 
 describe('amp-mustache 0.1', () => {
   let sandbox;
@@ -30,9 +30,7 @@ describe('amp-mustache 0.1', () => {
     templateElement = document.createElement('template');
     const getServiceForDocStub = sandbox.stub(service, 'getServiceForDoc');
     getServiceForDocStub.returns({
-      canRenderTemplates: () => viewerCanRenderTemplates,
-    });
-
+      hasCapability: unused => viewerCanRenderTemplates});
     template = new AmpMustache(templateElement);
   });
 

--- a/extensions/amp-mustache/0.1/test/test-amp-mustache.js
+++ b/extensions/amp-mustache/0.1/test/test-amp-mustache.js
@@ -17,7 +17,7 @@
 import * as mustache from '../../../../third_party/mustache/mustache';
 import * as sanitizer from '../../../../src/sanitizer';
 import * as service from '../../../../src/service';
-import {AmpMustache} from '../amp-mustache'
+import {AmpMustache} from '../amp-mustache';
 
 describe('amp-mustache 0.1', () => {
   let sandbox;

--- a/extensions/amp-mustache/0.2/test/test-amp-mustache.js
+++ b/extensions/amp-mustache/0.2/test/test-amp-mustache.js
@@ -30,7 +30,7 @@ describe('amp-mustache 0.2', () => {
     templateElement = document.createElement('template');
     const getServiceForDocStub = sandbox.stub(service, 'getServiceForDoc');
     getServiceForDocStub.returns({
-      canRenderTemplates: () => viewerCanRenderTemplates,
+      hasCapability: unused => viewerCanRenderTemplates,
     });
 
     template = new AmpMustache(templateElement);

--- a/extensions/amp-next-page/0.1/next-page-service.js
+++ b/extensions/amp-next-page/0.1/next-page-service.js
@@ -86,6 +86,9 @@ export class NextPageService {
     /** @private {boolean} */
     this.documentQueued_ = false;
 
+    /** @private {?../../../src/service/navigation.Navigation} */
+    this.navigation_ = null;
+
     /** @private {?../../../src/service/viewer-impl.Viewer} */
     this.viewer_ = null;
 
@@ -314,7 +317,7 @@ export class NextPageService {
         this.triggerAnalyticsEvent_(
             'amp-next-page-click', next.ampUrl, currentAmpUrl);
         const a2a =
-            this.viewer_.navigateToAmpUrl(next.ampUrl, 'content-discovery');
+            this.navigation_.navigateToAmpUrl(next.ampUrl, 'content-discovery');
         if (a2a) {
           // A2A is enabled, don't navigate the browser.
           e.preventDefault();

--- a/extensions/amp-next-page/0.1/next-page-service.js
+++ b/extensions/amp-next-page/0.1/next-page-service.js
@@ -136,7 +136,6 @@ export class NextPageService {
       this.hideSelector_ = this.config_.hideSelectors.join(',');
     }
 
-    this.viewer_ = Services.viewerForDoc(ampDoc);
     this.viewport_ = Services.viewportForDoc(ampDoc);
     this.resources_ = Services.resourcesForDoc(ampDoc);
     this.multidocManager_ =

--- a/extensions/amp-next-page/0.1/next-page-service.js
+++ b/extensions/amp-next-page/0.1/next-page-service.js
@@ -89,9 +89,6 @@ export class NextPageService {
     /** @private {?../../../src/service/navigation.Navigation} */
     this.navigation_ = null;
 
-    /** @private {?../../../src/service/viewer-impl.Viewer} */
-    this.viewer_ = null;
-
     /** @private {?../../../src/service/viewport/viewport-impl.Viewport} */
     this.viewport_ = null;
 

--- a/src/service/navigation.js
+++ b/src/service/navigation.js
@@ -22,6 +22,7 @@ import {
   openWindowDialog,
 } from '../dom';
 import {dev, user} from '../log';
+import {dict} from '../utils/object';
 import {
   getExtraParamsUrl,
   shouldAppendExtraParams,
@@ -178,7 +179,7 @@ export class Navigation {
         this.a2aFeatures_ = this.queryA2AFeatures_();
       }
       if (this.a2aFeatures_.includes(opt_requestedBy)) {
-        if (this.viewer_.navigateToAmpUrl(url, opt_requestedBy)) {
+        if (this.navigateToAmpUrl(url, opt_requestedBy)) {
           return;
         }
       }
@@ -186,6 +187,27 @@ export class Navigation {
 
     // Otherwise, perform normal behavior of navigating the top frame.
     win.top.location.href = url;
+  }
+
+  /**
+   * Requests A2A navigation to the given destination. If the viewer does
+   * not support this operation, does nothing.
+   * The URL is assumed to be in AMP Cache format already.
+   * @param {string} url An AMP article URL.
+   * @param {string} requestedBy Informational string about the entity that
+   *     requested the navigation.
+   * @return {boolean} Returns true if navigation message was sent to viewer.
+   *     Otherwise, returns false.
+   */
+  navigateToAmpUrl(url, requestedBy) {
+    if (this.viewer_.hasCapability('a2a')) {
+      this.viewer_.sendMessage('a2aNavigate', dict({
+        'url': url,
+        'requestedBy': requestedBy,
+      }));
+      return true;
+    }
+    return false;
   }
 
   /**
@@ -335,7 +357,7 @@ export class Navigation {
       return false;
     }
     // The viewer may not support the capability for navigating AMP links.
-    if (this.viewer_.navigateToAmpUrl(location.href, '<a rel=amphtml>')) {
+    if (this.navigateToAmpUrl(location.href, '<a rel=amphtml>')) {
       e.preventDefault();
       return true;
     }

--- a/src/service/template-impl.js
+++ b/src/service/template-impl.js
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
+import {Capability} from './viewer-impl';
 import {Deferred} from '../utils/promise';
 import {childElementByTag, rootNodeFor, scopedQuerySelector} from '../dom';
 import {dev, user} from '../log';
 import {getMode} from '../mode';
 import {getService, getServiceForDoc, registerServiceBuilder} from '../service';
-import { Capability } from './viewer-impl';
 
 /**
  * @fileoverview

--- a/src/service/template-impl.js
+++ b/src/service/template-impl.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import {Capability} from './viewer-impl';
 import {Deferred} from '../utils/promise';
 import {childElementByTag, rootNodeFor, scopedQuerySelector} from '../dom';
 import {dev, user} from '../log';
@@ -116,7 +115,7 @@ export class BaseTemplate {
    */
   viewerCanRenderTemplates() {
     return getServiceForDoc(this.element, 'viewer')
-        .hasCapability(Capability.VIEWER_RENDER_TEMPLATE);
+        .hasCapability('viewerRenderTemplate');
   }
 }
 

--- a/src/service/template-impl.js
+++ b/src/service/template-impl.js
@@ -19,6 +19,7 @@ import {childElementByTag, rootNodeFor, scopedQuerySelector} from '../dom';
 import {dev, user} from '../log';
 import {getMode} from '../mode';
 import {getService, getServiceForDoc, registerServiceBuilder} from '../service';
+import { Capability } from './viewer-impl';
 
 /**
  * @fileoverview
@@ -114,8 +115,8 @@ export class BaseTemplate {
    * @return {boolean}
    */
   viewerCanRenderTemplates() {
-    return getServiceForDoc(
-        this.element, 'viewer').canRenderTemplates();
+    return getServiceForDoc(this.element, 'viewer')
+        .hasCapability(Capability.VIEWER_RENDER_TEMPLATE);
   }
 }
 

--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -19,7 +19,6 @@ import {Observable} from '../observable';
 import {Services} from '../services';
 import {VisibilityState} from '../visibility-state';
 import {dev, duplicateErrorIfNecessary} from '../log';
-import {dict, map} from '../utils/object';
 import {findIndex} from '../utils/array';
 import {
   getSourceOrigin,
@@ -30,6 +29,7 @@ import {
   serializeQueryString,
 } from '../url';
 import {isIframed} from '../dom';
+import {map} from '../utils/object';
 import {registerServiceBuilderForDoc} from '../service';
 import {reportError} from '../error';
 import {startsWith} from '../string';
@@ -500,35 +500,6 @@ export class Viewer {
     }
     // TODO(@cramforce): Consider caching the split.
     return capabilities.split(',').indexOf(name) != -1;
-  }
-
-  /**
-   * Whether the viewer can render templates.
-   * @return {boolean}
-   */
-  canRenderTemplates() {
-    return this.hasCapability(Capability.VIEWER_RENDER_TEMPLATE);
-  }
-
-  /**
-   * Requests A2A navigation to the given destination. If the viewer does
-   * not support this operation, does nothing.
-   * The URL is assumed to be in AMP Cache format already.
-   * @param {string} url An AMP article URL.
-   * @param {string} requestedBy Informational string about the entity that
-   *     requested the navigation.
-   * @return {boolean} Returns true if navigation message was sent to viewer.
-   *     Otherwise, returns false.
-   */
-  navigateToAmpUrl(url, requestedBy) {
-    if (this.hasCapability('a2a')) {
-      this.sendMessage('a2aNavigate', dict({
-        'url': url,
-        'requestedBy': requestedBy,
-      }));
-      return true;
-    }
-    return false;
   }
 
   /**

--- a/src/ssr-template-helper.js
+++ b/src/ssr-template-helper.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import {Capability} from './service/viewer-impl';
 import {dict, map} from './utils/object';
 import {iterateCursor} from './dom';
 
@@ -54,7 +53,7 @@ export class SsrTemplateHelper {
    * @return {boolean}
    */
   isSupported() {
-    return this.viewer_.hasCapability(Capability.VIEWER_RENDER_TEMPLATE);
+    return this.viewer_.hasCapability('viewerRenderTemplate');
   }
 
   /**
@@ -82,7 +81,7 @@ export class SsrTemplateHelper {
       'sourceAmpComponent': this.sourceComponent_,
     });
     return this.viewer_.sendMessageAwaitResponse(
-        Capability.VIEWER_RENDER_TEMPLATE, data);
+        'viewerRenderTemplate', data);
   }
 
   /**

--- a/src/ssr-template-helper.js
+++ b/src/ssr-template-helper.js
@@ -54,7 +54,7 @@ export class SsrTemplateHelper {
    * @return {boolean}
    */
   isSupported() {
-    return this.viewer_.canRenderTemplates();
+    return this.viewer_.hasCapability(Capability.VIEWER_RENDER_TEMPLATE);
   }
 
   /**

--- a/test/functional/test-navigation.js
+++ b/test/functional/test-navigation.js
@@ -469,7 +469,7 @@ describes.sandboxed('Navigation', {}, () => {
 
       it('should delegate navigation if viewer supports A2A', () => {
         const stub =
-            sandbox.stub(handler.viewer_, 'navigateToAmpUrl').returns(true);
+            sandbox.stub(handler, 'navigateToAmpUrl').returns(true);
 
         handler.handle_(event);
 
@@ -485,7 +485,7 @@ describes.sandboxed('Navigation', {}, () => {
 
       it('should behave normally if viewer does not support A2A', () => {
         const stub =
-            sandbox.stub(handler.viewer_, 'navigateToAmpUrl').returns(false);
+            sandbox.stub(handler, 'navigateToAmpUrl').returns(false);
 
         handler.handle_(event);
 
@@ -526,7 +526,7 @@ describes.sandboxed('Navigation', {}, () => {
         ampdoc.getRootNode().head.appendChild(meta);
 
         const stub =
-            sandbox.stub(handler.viewer_, 'navigateToAmpUrl').returns(true);
+            sandbox.stub(handler, 'navigateToAmpUrl').returns(true);
         expect(win.location.href).to.equal('https://www.pub.com/');
 
         // Delegate to viewer if opt_requestedBy matches the <meta> tag content

--- a/test/functional/test-navigation.js
+++ b/test/functional/test-navigation.js
@@ -525,30 +525,31 @@ describes.sandboxed('Navigation', {}, () => {
         meta.setAttribute('content', 'feature-foo, action-bar');
         ampdoc.getRootNode().head.appendChild(meta);
 
-        const stub =
-            sandbox.stub(handler, 'navigateToAmpUrl').returns(true);
+        const send = sandbox.stub(handler.viewer_, 'sendMessage');
+        const hasCapability = sandbox.stub(handler.viewer_, 'hasCapability');
+        hasCapability.returns(true);
         expect(win.location.href).to.equal('https://www.pub.com/');
 
         // Delegate to viewer if opt_requestedBy matches the <meta> tag content
         // and the viewer supports A2A.
         handler.navigateTo(win, 'https://amp.pub.com/amp_page', 'feature-foo');
-        expect(stub).to.be.calledOnce;
-        expect(stub).to.be.calledWithExactly(
-            'https://amp.pub.com/amp_page', 'feature-foo');
+        expect(hasCapability).to.be.calledWithExactly('a2a');
+        expect(send).to.be.calledOnce;
+        expect(send).to.be.calledWithExactly('a2aNavigate',
+            {requestedBy: 'feature-foo', url: 'https://amp.pub.com/amp_page'});
         expect(win.location.href).to.equal('https://www.pub.com/');
 
         // If opt_requestedBy doesn't match, navigate top normally.
         handler.navigateTo(win, 'https://amp.pub.com/amp_page', 'no-match');
-        expect(stub).to.be.calledOnce;
+        expect(send).to.be.calledOnce;
         expect(win.location.href).to.equal('https://amp.pub.com/amp_page');
 
         // If opt_requestedBy matches but viewer doesn't support A2A, navigate
         // top normally.
-        stub.returns(false);
+        send.reset();
+        hasCapability.returns(false);
         handler.navigateTo(win, 'https://amp.pub.com/different', 'action-bar');
-        expect(stub).to.be.calledTwice;
-        expect(stub).to.be.calledWithExactly(
-            'https://amp.pub.com/different', 'action-bar');
+        expect(send).to.not.be.called;
         expect(win.location.href).to.equal('https://amp.pub.com/different');
       });
     });

--- a/test/functional/test-viewer.js
+++ b/test/functional/test-viewer.js
@@ -1669,28 +1669,4 @@ describe('Viewer', () => {
       return result;
     });
   });
-
-  describe('navigateTo', () => {
-    const ampUrl = 'https://cdn.ampproject.org/test/123';
-    it('should message viewer if a2a capability is supported', () => {
-      windowApi.location.hash = '#cap=a2a';
-      const viewer = new Viewer(ampdoc);
-      const send = sandbox.stub(viewer, 'sendMessage');
-      const result = viewer.navigateToAmpUrl(ampUrl, 'abc123');
-      expect(send.lastCall.args[0]).to.equal('a2aNavigate');
-      expect(send.lastCall.args[1]).to.jsonEqual({
-        url: ampUrl,
-        requestedBy: 'abc123',
-      });
-      expect(result).to.be.true;
-    });
-
-    it('should return false if a2a capability is not supported', () => {
-      const viewer = new Viewer(ampdoc);
-      const send = sandbox.stub(viewer, 'sendMessage');
-      const result = viewer.navigateToAmpUrl(ampUrl, 'abc123');
-      expect(send).to.have.not.been.called;
-      expect(result).to.be.false;
-    });
-  });
 });


### PR DESCRIPTION
extract canRenderTemplates and navigateToAmpUrl from viewer service.

fixes 2/3 tasks from #17590 