### PR TITLE
🐛 Consider descendants of protected targets to be protected

### DIFF
--- a/extensions/amp-story/0.1/page-advancement.js
+++ b/extensions/amp-story/0.1/page-advancement.js
@@ -312,7 +312,9 @@ class ManualAdvancement extends AdvancementConfig {
    * @return {boolean}
    */
   isProtectedTarget_(event) {
-    return !!PROTECTED_ELEMENTS[event.target.tagName];
+    return !closest(dev().assertElement(event.target), el => {
+      return !!PROTECTED_ELEMENTS[el.tagName];
+    }, /* opt_stopAt */ this.element_);
   }
 
 

--- a/extensions/amp-story/0.1/page-advancement.js
+++ b/extensions/amp-story/0.1/page-advancement.js
@@ -312,8 +312,8 @@ class ManualAdvancement extends AdvancementConfig {
    * @return {boolean}
    */
   isProtectedTarget_(event) {
-    return !closest(dev().assertElement(event.target), el => {
-      return !!PROTECTED_ELEMENTS[el.tagName];
+    return !!closest(dev().assertElement(event.target), el => {
+      return PROTECTED_ELEMENTS[el.tagName];
     }, /* opt_stopAt */ this.element_);
   }
 

--- a/extensions/amp-story/1.0/page-advancement.js
+++ b/extensions/amp-story/1.0/page-advancement.js
@@ -332,7 +332,7 @@ class ManualAdvancement extends AdvancementConfig {
    * @return {boolean}
    */
   isProtectedTarget_(event) {
-    return closest(dev().assertElement(event.target), el => {
+    return !!closest(dev().assertElement(event.target), el => {
       const elementRole = el.getAttribute('role');
 
       if (elementRole) {

--- a/extensions/amp-story/1.0/page-advancement.js
+++ b/extensions/amp-story/1.0/page-advancement.js
@@ -332,12 +332,14 @@ class ManualAdvancement extends AdvancementConfig {
    * @return {boolean}
    */
   isProtectedTarget_(event) {
-    const elementRole = event.target.getAttribute('role');
+    return closest(dev().assertElement(event.target), el => {
+      const elementRole = el.getAttribute('role');
 
-    if (elementRole) {
-      return !!TAPPABLE_ARIA_ROLES[elementRole.toLowerCase()];
-    }
-    return false;
+      if (elementRole) {
+        return !!TAPPABLE_ARIA_ROLES[elementRole.toLowerCase()];
+      }
+      return false;
+    }, /* opt_stopAt */ this.element_);
   }
 
 


### PR DESCRIPTION
Before this PR, clicks on elements nested within a link in a CTA layer would cause the CTA to open *and* the page to navigate simultaneously, since the nested element is not considered to be protected.  This fixes that scenario by considering all descendants of protected elements to be protected as well.