### PR TITLE
🐛 Temporarily turn down fast fetch SRA experiments.

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -41,7 +41,7 @@
   "amp-carousel-new-arrows": 1,
   "user-error-reporting": 1,
   "no-initial-intersection": 1,
-  "doubleclickSraExp": 0.01,
+  "doubleclickSraExp": 0,
   "doubleclickSraReportExcludedBlock": 0.1,
   "inabox-rov": 1
 }

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -42,7 +42,7 @@
   "url-replacement-v2": 1,
   "user-error-reporting": 1,
   "inline-styles": 1,
-  "doubleclickSraExp": 0.01,
+  "doubleclickSraExp": 0,
   "doubleclickSraReportExcludedBlock": 0.1,
   "inabox-rov": 1
 }


### PR DESCRIPTION
These experiments have been misbehaving since the 1533924452420 release, although it's not known for certain whether that release is directly responsible for the problem.