### PR TITLE
✅ Disable amp-story desktop visual tests, due to flakiness

### DIFF
--- a/test/visual-diff/visual-tests
+++ b/test/visual-diff/visual-tests
@@ -317,6 +317,8 @@
       ]
     },
     {
+      "flaky": true,
+      // See https://percy.io/ampproject/amphtml/builds/946709
       "url": "examples/visual-tests/amp-story/basic.html",
       "name": "amp-story: basic (desktop)",
       "viewport": {"width": 1440, "height": 900},
@@ -328,6 +330,8 @@
       "loading_complete_delay_ms": 500, /* for page navigation */
     },
     {
+      "flaky": true,
+      // See https://percy.io/ampproject/amphtml/builds/946709
       "url": "examples/visual-tests/amp-story/amp-story-grid-layer-template-fill.html",
       "name": "amp-story: Grid layer (fill) (desktop)",
       "viewport": {"width": 1440, "height": 900},
@@ -338,6 +342,8 @@
       ]
     },
     {
+      "flaky": true,
+      // See https://percy.io/ampproject/amphtml/builds/946709
       "url": "examples/visual-tests/amp-story/amp-story-grid-layer-template-vertical.html",
       "name": "amp-story: Grid layer (vertical) (desktop)",
       "viewport": {"width": 1440, "height": 900},
@@ -348,6 +354,8 @@
       ]
     },
     {
+      "flaky": true,
+      // See https://percy.io/ampproject/amphtml/builds/946709
       "url": "examples/visual-tests/amp-story/amp-story-grid-layer-template-horizontal.html",
       "name": "amp-story: Grid layer (horizontal) (desktop)",
       "viewport": {"width": 1440, "height": 900},
@@ -358,6 +366,8 @@
       ]
     },
     {
+      "flaky": true,
+      // See https://percy.io/ampproject/amphtml/builds/946709
       "url": "examples/visual-tests/amp-story/amp-story-grid-layer-template-thirds.html",
       "name": "amp-story: Grid layer (thirds) (desktop)",
       "viewport": {"width": 1440, "height": 900},
@@ -371,6 +381,8 @@
       ]
     },
     {
+      "flaky": true,
+      // See https://percy.io/ampproject/amphtml/builds/946709
       "url": "examples/visual-tests/amp-story/amp-story-cta-layer.html",
       "name": "amp-story: CTA layer (desktop)",
       "viewport": {"width": 1440, "height": 900},
@@ -382,6 +394,8 @@
       "loading_complete_delay_ms": 500, /* for page navigation */
     },
     {
+      "flaky": true,
+      // See https://percy.io/ampproject/amphtml/builds/946709
       "url": "examples/visual-tests/amp-story/embed-mode-1.html",
       "name": "amp-story: embed mode 1 (desktop)",
       "viewport": {"width": 1440, "height": 900},
@@ -390,6 +404,8 @@
       ]
     },
     {
+      "flaky": true,
+      // See https://percy.io/ampproject/amphtml/builds/946709
       "url": "examples/visual-tests/amp-story/embed-mode-2.html",
       "name": "amp-story: embed mode 2 (desktop)",
       "viewport": {"width": 1440, "height": 900},
@@ -399,6 +415,8 @@
       ]
     },
     {
+      "flaky": true,
+      // See https://percy.io/ampproject/amphtml/builds/946709
       "url": "examples/visual-tests/amp-story/amp-story-bookend.html",
       "name": "amp-story: bookend (desktop)",
       "viewport": {"width": 1440, "height": 900},
@@ -409,6 +427,8 @@
       ]
     },
     {
+      "flaky": true,
+      // See https://percy.io/ampproject/amphtml/builds/946709
       "url": "examples/visual-tests/amp-story/amp-story-consent.html",
       "name": "amp-story: consent (desktop)",
       "viewport": {"width": 1440, "height": 900},
@@ -474,6 +494,8 @@
       ]
     },
     {
+      "flaky": true,
+      // See https://percy.io/ampproject/amphtml/builds/946709
       "url": "examples/visual-tests/amp-story/basic.rtl.html",
       "name": "amp-story: basic (desktop) (rtl)",
       "viewport": {"width": 1440, "height": 900},
@@ -485,6 +507,8 @@
       "loading_complete_delay_ms": 500, /* for page navigation */
     },
     {
+      "flaky": true,
+      // See https://percy.io/ampproject/amphtml/builds/946709
       "url": "examples/visual-tests/amp-story/amp-story-bookend.rtl.html",
       "name": "amp-story: bookend (desktop) (rtl)",
       "viewport": {"width": 1440, "height": 900},
@@ -495,6 +519,8 @@
       ]
     },
     {
+      "flaky": true,
+      // See https://percy.io/ampproject/amphtml/builds/946709
       "url": "examples/visual-tests/amp-story/amp-story-consent.rtl.html",
       "name": "amp-story: consent (desktop) (rtl)",
       "viewport": {"width": 1440, "height": 900},


### PR DESCRIPTION
In the ongoing saga of #16460, looks like the desktop tests are still flaky.  Disabling them so as not to cause more problems.  😦 