### PR TITLE
Ramping up AdSense Auto Ads responsive to 0.1%

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -22,6 +22,7 @@
   "pump-early-frame": 1,
   "amp-auto-ads": 1,
   "amp-auto-ads-adsense-holdout": 0.1,
+  "amp-auto-ads-adsense-responsive": 0.01,
   "version-locking": 1,
   "as-use-attr-for-format": 0.01,
   "a4aFastFetchDoubleclickLaunched": 0,

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -23,6 +23,7 @@
   "chunked-amp": 1,
   "amp-auto-ads": 1,
   "amp-auto-ads-adsense-holdout": 0.1,
+  "amp-auto-ads-adsense-responsive": 0.01,
   "version-locking": 1,
   "as-use-attr-for-format": 0.01,
   "a4aFastFetchDoubleclickLaunched": 0,


### PR DESCRIPTION
When the experiment is on, auto ads will be resized to full viewport width.