### PR TITLE
fix #17596 migrated getAttributes from constructor to buildCallback

### DIFF
--- a/extensions/amp-date-countdown/0.1/amp-date-countdown.js
+++ b/extensions/amp-date-countdown/0.1/amp-date-countdown.js
@@ -75,52 +75,56 @@ export class AmpDateCountdown extends AMP.BaseElement {
   constructor(element) {
     super(element);
 
-    /** @const {function(!Element)} */
-    this.boundRendered_ = this.rendered_.bind(this);
-
-    //Note: One of end-date, timestamp-ms, timestamp-seconds is required.
-    /** @private {string} */
-    this.endDate_ = this.element.getAttribute('end-date');
-
-    /** @private {number} */
-    this.timestampMs_ = Number(this.element.getAttribute('timestamp-ms'));
-
-    /** @private {number} */
-    this.timestampSeconds_
-      = Number(this.element.getAttribute('timestamp-seconds'));
-
-    /** @private {number} */
-    this.offsetSeconds_
-      = Number(this.element.getAttribute('offset-seconds'))
-      || DEFAULT_OFFSET_SECONDS;
-
-    /** @private {string} */
-    this.locale_
-      = (this.element.getAttribute('locale')
-      || DEFAULT_LOCALE).toLowerCase();
-
-    /** @private {string} */
-    this.whenEnded_
-      = (this.element.getAttribute('when-ended')
-      || DEFAULT_WHEN_ENDED).toLowerCase();
-
-    /** @private {string} */
-    this.biggestUnit_
-      = (this.element.getAttribute('biggest-unit')
-      || DEFAULT_BIGGEST_UNIT).toUpperCase();
-
-    /** @private {!Object|null} */
-    this.localeWordList_ = this.getLocaleWord_(this.locale_);
-
-    /** @private {!Object|null} */
-    this.countDownTimer_ = null;
-
     /** @const {!../../../src/service/template-impl.Templates} */
     this.templates_ = Services.templatesFor(this.win);
   }
 
   /** @override */
   buildCallback() {
+
+    // Store this in buildCallback() because `this.element` sometimes
+    // is missing attributes in the constructor.
+
+     /** @const {function(!Element)} */
+     this.boundRendered_ = this.rendered_.bind(this);
+
+     //Note: One of end-date, timestamp-ms, timestamp-seconds is required.
+     /** @private {string} */
+     this.endDate_ = this.element.getAttribute('end-date');
+
+     /** @private {number} */
+     this.timestampMs_ = Number(this.element.getAttribute('timestamp-ms'));
+
+     /** @private {number} */
+     this.timestampSeconds_
+       = Number(this.element.getAttribute('timestamp-seconds'));
+
+     /** @private {number} */
+     this.offsetSeconds_
+       = Number(this.element.getAttribute('offset-seconds'))
+       || DEFAULT_OFFSET_SECONDS;
+
+     /** @private {string} */
+     this.locale_
+       = (this.element.getAttribute('locale')
+       || DEFAULT_LOCALE).toLowerCase();
+
+     /** @private {string} */
+     this.whenEnded_
+       = (this.element.getAttribute('when-ended')
+       || DEFAULT_WHEN_ENDED).toLowerCase();
+
+     /** @private {string} */
+     this.biggestUnit_
+       = (this.element.getAttribute('biggest-unit')
+       || DEFAULT_BIGGEST_UNIT).toUpperCase();
+
+     /** @private {!Object|null} */
+     this.localeWordList_ = this.getLocaleWord_(this.locale_);
+
+     /** @private {!Object|null} */
+     this.countDownTimer_ = null;
+
     Services.viewerForDoc(this.getAmpDoc()).whenFirstVisible().then(() => {
       const EPOCH = this.getEpoch_() + (this.offsetSeconds_ * 1000);
       this.tickCountDown_(new Date(EPOCH) - new Date());


### PR DESCRIPTION
`amp-date-countdown` will have issue of getting the attributes from DOM. We should have written 
list of elements which are responsible of getting attributes from DOM, such as `this.element.getAttribute('end-date')` in `buildCallback()` instead of `constructor()`


![image](https://user-images.githubusercontent.com/4065175/44334191-6ff8c900-a4a3-11e8-8bf6-0ad37aeebe2d.png)
