### PR TITLE
♻️Moved Analytics Scroll Events to the Event Tracker Design.

### DIFF
--- a/extensions/amp-analytics/0.1/analytics-root.js
+++ b/extensions/amp-analytics/0.1/analytics-root.js
@@ -61,6 +61,9 @@ export class AnalyticsRoot {
 
     /** @private {?./visibility-manager.VisibilityManager} */
     this.visibilityManager_ = null;
+    
+    /** @private {boolean} */
+    this.scrollEventTracker_ = false;
   }
 
   /** @override */

--- a/extensions/amp-analytics/0.1/analytics-root.js
+++ b/extensions/amp-analytics/0.1/analytics-root.js
@@ -355,18 +355,9 @@ export class AnalyticsRoot {
    */
   getScrollManager() {
     if (!this.scrollManager_) {
-      this.scrollManager_ = this.createScrollManager();
+      this.scrollManager_ = new ScrollManager(this.ampdoc);
     }
 
-    return this.scrollManager_;
-  }
-
-  /**
-   * @return {!./scroll-manager.ScrollManager}
-   * @protected
-   */
-  createScrollManager() {
-    this.scrollManager_ = new ScrollManager(this.ampdoc);
     return this.scrollManager_;
   }
 }

--- a/extensions/amp-analytics/0.1/analytics-root.js
+++ b/extensions/amp-analytics/0.1/analytics-root.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {ScrollManager} from './scroll-manager';
 import {Services} from '../../../src/services';
 import {
   VisibilityManagerForDoc,
@@ -61,9 +62,9 @@ export class AnalyticsRoot {
 
     /** @private {?./visibility-manager.VisibilityManager} */
     this.visibilityManager_ = null;
-    
-    /** @private {boolean} */
-    this.scrollEventTracker_ = false;
+
+    /** @private {?./scroll-manager.ScrollManager} */
+    this.scrollManager_ = false;
   }
 
   /** @override */
@@ -74,6 +75,9 @@ export class AnalyticsRoot {
     }
     if (this.visibilityManager_) {
       this.visibilityManager_.dispose();
+    }
+    if (this.scrollManager_) {
+      this.scrollManager_.dispose();
     }
   }
 
@@ -165,7 +169,7 @@ export class AnalyticsRoot {
    * has not been requested before, it will be created.
    *
    * @param {string} name
-   * @param {function(new:./events.CustomEventTracker, !AnalyticsRoot)|function(new:./events.ClickEventTracker, !AnalyticsRoot)|function(new:./events.SignalTracker, !AnalyticsRoot)|function(new:./events.IniLoadTracker, !AnalyticsRoot)|function(new:./events.VideoEventTracker, !AnalyticsRoot)|function(new:./events.VideoEventTracker, !AnalyticsRoot)|function(new:./events.VisibilityTracker, !AnalyticsRoot)} klass
+   * @param {function(new:./events.CustomEventTracker, !AnalyticsRoot)|function(new:./events.ClickEventTracker, !AnalyticsRoot)|function(new:./events.ScrollEventTracker, !AnalyticsRoot)|function(new:./events.SignalTracker, !AnalyticsRoot)|function(new:./events.IniLoadTracker, !AnalyticsRoot)|function(new:./events.VideoEventTracker, !AnalyticsRoot)|function(new:./events.VideoEventTracker, !AnalyticsRoot)|function(new:./events.VisibilityTracker, !AnalyticsRoot)} klass
    * @return {!./events.EventTracker}
    */
   getTracker(name, klass) {
@@ -342,6 +346,29 @@ export class AnalyticsRoot {
    * @abstract
    */
   createVisibilityManager() {}
+
+  /**
+   *  Returns the Scroll Managet corresponding to this analytics root.
+   * The Scroll Manager is created lazily as needed, and will handle
+   * calling all handlers for a scroll event.
+   * @return {!./scroll-manager.ScrollManager}
+   */
+  getScrollManager() {
+    if (!this.scrollManager_) {
+      this.scrollManager_ = this.createScrollManager();
+    }
+
+    return this.scrollManager_;
+  }
+
+  /**
+   * @return {!./scroll-manager.ScrollManager}
+   * @protected
+   */
+  createScrollManager() {
+    this.scrollManager_ = new ScrollManager(this.ampdoc);
+    return this.scrollManager_;
+  }
 }
 
 

--- a/extensions/amp-analytics/0.1/analytics-root.js
+++ b/extensions/amp-analytics/0.1/analytics-root.js
@@ -64,7 +64,7 @@ export class AnalyticsRoot {
     this.visibilityManager_ = null;
 
     /** @private {?./scroll-manager.ScrollManager} */
-    this.scrollManager_ = false;
+    this.scrollManager_ = null;
   }
 
   /** @override */

--- a/extensions/amp-analytics/0.1/events.js
+++ b/extensions/amp-analytics/0.1/events.js
@@ -422,9 +422,9 @@ export class ScrollEventTracker extends EventTracker {
 
     /** @private {!./analytics-root.AnalyticsRoot} root */
     this.root_ = root;
-    
+
     /** @private {function(!Object)|null} */
-    this.scrollHandler_ = null
+    this.scrollHandler_ = null;
   }
 
   /** @override */
@@ -460,35 +460,34 @@ export class ScrollEventTracker extends EventTracker {
    * Function to return a Scroll Handler Function instance
    * @param {!JsonObject} config
    * @param {function(!AnalyticsEvent)} listener
-   * @return {function(!Object)} 
+   * @return {function(!Object)}
    * @private
    */
   getScrollHandler_(config, listener) {
 
     const boundsV = this.normalizeBoundaries_(
-      config['scrollSpec']['verticalBoundaries']
+        config['scrollSpec']['verticalBoundaries']
     );
     const boundsH = this.normalizeBoundaries_(
-      config['scrollSpec']['horizontalBoundaries']
+        config['scrollSpec']['horizontalBoundaries']
     );
 
 
-    return (e) => {
+    return e => {
       // Calculates percentage scrolled by adding screen height/width to
       // top/left and dividing by the total scroll height/width.
       this.triggerScrollEvents_(boundsV,
-        (e.top + e.screenHeight) * 100 / e.height,
-        VAR_V_SCROLL_BOUNDARY, 
-        listener
+          (e.top + e.screenHeight) * 100 / e.height,
+          VAR_V_SCROLL_BOUNDARY,
+          listener
       );
       this.triggerScrollEvents_(boundsH,
-        (e.left + e.screenWidth) * 100 / e.width,
-        VAR_H_SCROLL_BOUNDARY, 
-        listener
+          (e.left + e.screenWidth) * 100 / e.width,
+          VAR_H_SCROLL_BOUNDARY,
+          listener
       );
-    }
+    };
   }
-
 
   /**
    * Rounds the boundaries for scroll trigger to nearest
@@ -519,7 +518,7 @@ export class ScrollEventTracker extends EventTracker {
     }
     return result;
   }
-  
+
   /**
    * @param {!Object<number, boolean>} bounds
    * @param {number} scrollPos Number representing the current scroll
@@ -546,11 +545,11 @@ export class ScrollEventTracker extends EventTracker {
       const vars = Object.create(null);
       vars[varName] = b;
       listener(
-        new AnalyticsEvent(
-          this.root_.getRootElement(),
-          AnalyticsEventType.SCROLL,
-          vars
-        )
+          new AnalyticsEvent(
+              this.root_.getRootElement(),
+              AnalyticsEventType.SCROLL,
+              vars
+          )
       );
     }
   }

--- a/extensions/amp-analytics/0.1/events.js
+++ b/extensions/amp-analytics/0.1/events.js
@@ -21,13 +21,13 @@ import {
   VideoAnalyticsDetailsDef,
   VideoAnalyticsEvents,
 } from '../../../src/video-interface';
+import {Services} from '../../../src/services';
 import {dev, user} from '../../../src/log';
 import {getData} from '../../../src/event-helper';
 import {getDataParamsFromAttributes} from '../../../src/dom';
 import {hasOwn} from '../../../src/utils/object';
 import {isEnumValue} from '../../../src/types';
 import {startsWith} from '../../../src/string';
-import {Services} from '../../../src/services';
 
 
 const SCROLL_PRECISION_PERCENT = 5;
@@ -414,7 +414,7 @@ export class ClickEventTracker extends EventTracker {
  * Tracks scroll events.
  */
 export class ScrollEventTracker extends EventTracker {
-  
+
   /**
    * @param {!./analytics-root.AnalyticsRoot} root
    */
@@ -426,7 +426,7 @@ export class ScrollEventTracker extends EventTracker {
 
     /** @const @private {!../../../src/service/viewport/viewport-impl.Viewport} */
     this.viewport_ = Services.viewportForDoc(root.ampdoc);
-    
+
     /** @private {!./analytics-root.AnalyticsRoot} root */
     this.root_ = root;
   }
@@ -500,7 +500,13 @@ export class ScrollEventTracker extends EventTracker {
         bounds[bound] = true;
         const vars = Object.create(null);
         vars[varName] = b;
-        listener(new AnalyticsEvent(this.root_, AnalyticsEventType.SCROLL, vars));
+        listener(
+            new AnalyticsEvent(
+                this.root_,
+                AnalyticsEventType.SCROLL,
+                vars
+            )
+        );
       }
     };
 
@@ -510,11 +516,11 @@ export class ScrollEventTracker extends EventTracker {
       // Calculates percentage scrolled by adding screen height/width to
       // top/left and dividing by the total scroll height/width.
       triggerScrollEvents(boundsV,
-        (e.top + e.height) * 100 / this.viewport_.getScrollHeight(),
-        VAR_V_SCROLL_BOUNDARY);
+          (e.top + e.height) * 100 / this.viewport_.getScrollHeight(),
+          VAR_V_SCROLL_BOUNDARY);
       triggerScrollEvents(boundsH,
-        (e.left + e.width) * 100 / this.viewport_.getScrollWidth(),
-        VAR_H_SCROLL_BOUNDARY);
+          (e.left + e.width) * 100 / this.viewport_.getScrollWidth(),
+          VAR_H_SCROLL_BOUNDARY);
     });
   }
 

--- a/extensions/amp-analytics/0.1/events.js
+++ b/extensions/amp-analytics/0.1/events.js
@@ -427,6 +427,9 @@ export class ScrollEventTracker extends EventTracker {
     /** @const @private {!../../../src/service/viewport/viewport-impl.Viewport} */
     this.viewport_ = Services.viewportForDoc(root.ampdoc);
 
+    /** @private {boolean} */
+    this.scrollHandlerRegistered_ = false;
+
     /** @private {!./analytics-root.AnalyticsRoot} root */
     this.root_ = root;
   }
@@ -473,6 +476,7 @@ export class ScrollEventTracker extends EventTracker {
 
     // Ensure that the scroll events are being listened to.
     if (!this.scrollHandlerRegistered_) {
+      this.scrollHandlerRegistered_ = true;
       this.viewport_.onChanged(this.onScroll_.bind(this));
     }
 

--- a/extensions/amp-analytics/0.1/events.js
+++ b/extensions/amp-analytics/0.1/events.js
@@ -430,7 +430,7 @@ export class ScrollEventTracker extends EventTracker {
   /** @override */
   dispose() {
     this.root_.getScrollManager()
-      .removeScrollHandler(this.scrollHandler_);
+        .removeScrollHandler(this.scrollHandler_);
     this.scrollHandler_ = undefined;
   }
 
@@ -493,10 +493,10 @@ export class ScrollEventTracker extends EventTracker {
       // Calculates percentage scrolled by adding screen height/width to
       // top/left and dividing by the total scroll height/width.
       triggerScrollEvents(boundsV,
-          (e.top + e.height) * 100 / this.viewport_.getScrollHeight(),
+          (e.scrollTop + e.screenHeight) * 100 / e.scrollHeight,
           VAR_V_SCROLL_BOUNDARY);
       triggerScrollEvents(boundsH,
-          (e.left + e.width) * 100 / this.viewport_.getScrollWidth(),
+          (e.scrollLeft + e.screenWidth) * 100 / e.scrollWidth,
           VAR_H_SCROLL_BOUNDARY);
     };
 

--- a/extensions/amp-analytics/0.1/events.js
+++ b/extensions/amp-analytics/0.1/events.js
@@ -64,6 +64,11 @@ const TRACKER_TYPE = Object.freeze({
     // Escape the temporal dead zone by not referencing a class directly.
     klass: function(root) { return new ClickEventTracker(root); },
   },
+  'scroll': {
+    name: 'scroll',
+    allowedFor: ALLOWED_FOR_ALL_ROOT_TYPES.concat(['timer']),
+    klass: function(root) { return new ScrollCustomEventTracker(root); },
+  }
   'custom': {
     name: 'custom',
     allowedFor: ALLOWED_FOR_ALL_ROOT_TYPES.concat(['timer']),
@@ -400,6 +405,29 @@ export class ClickEventTracker extends EventTracker {
   }
 }
 
+/**
+ * Tracks scroll events.
+ */
+export class ScrollEventTracker extends EventTracker {
+  
+  /**
+   * @param {!./analytics-root.AnalyticsRoot} root
+   */
+  constructor(root) {
+    super(root);
+   
+  }
+
+  /** @override */
+  dispose() {
+    
+  }
+
+  /** @override */
+  add(context, eventType, config, listener) {
+    
+  }
+}
 
 /**
  * Tracks events based on signals.

--- a/extensions/amp-analytics/0.1/events.js
+++ b/extensions/amp-analytics/0.1/events.js
@@ -477,12 +477,12 @@ export class ScrollEventTracker extends EventTracker {
       // Calculates percentage scrolled by adding screen height/width to
       // top/left and dividing by the total scroll height/width.
       this.triggerScrollEvents_(boundsV,
-          (e.top + e.screenHeight) * 100 / e.height,
+        (e.top + e.height) * 100 / e./*OK*/scrollHeight,
           VAR_V_SCROLL_BOUNDARY,
           listener
       );
       this.triggerScrollEvents_(boundsH,
-          (e.left + e.screenWidth) * 100 / e.width,
+        (e.left + e.width) * 100 / e./*OK*/scrollWidth,
           VAR_H_SCROLL_BOUNDARY,
           listener
       );

--- a/extensions/amp-analytics/0.1/instrumentation.js
+++ b/extensions/amp-analytics/0.1/instrumentation.js
@@ -39,16 +39,10 @@ import {
 } from '../../../src/service';
 import {hasOwn} from '../../../src/utils/object';
 
-const SCROLL_PRECISION_PERCENT = 5;
-const VAR_H_SCROLL_BOUNDARY = 'horizontalScrollBoundary';
-const VAR_V_SCROLL_BOUNDARY = 'verticalScrollBoundary';
 const PROP = '__AMP_AN_ROOT';
-
-
 
 /** @const {string} */
 const TAG = 'Analytics.Instrumentation';
-
 
 /**
  * Events that can result in analytics data to be sent.
@@ -58,6 +52,7 @@ const ALLOWED_IN_EMBED = [
   AnalyticsEventType.VISIBLE,
   AnalyticsEventType.CLICK,
   AnalyticsEventType.TIMER,
+  AnalyticsEventType.SCROLL,
   AnalyticsEventType.HIDDEN,
 ];
 
@@ -77,16 +72,6 @@ export class InstrumentationService {
 
     /** @const */
     this.ampdocRoot_ = new AmpdocAnalyticsRoot(this.ampdoc);
-
-    /** @const {!../../../src/service/viewport/viewport-impl.Viewport} */
-    this.viewport_ = Services.viewportForDoc(this.ampdoc);
-
-    /** @private {boolean} */
-    this.scrollHandlerRegistered_ = false;
-
-    /** @private {!Observable<
-      !../../../src/service/viewport/viewport-impl.ViewportChangedEventDef>} */
-    this.scrollObservable_ = new Observable();
   }
 
   /** @override */
@@ -108,7 +93,7 @@ export class InstrumentationService {
    */
   createAnalyticsGroup(analyticsElement) {
     const root = this.findRoot_(analyticsElement);
-    return new AnalyticsGroup(root, analyticsElement, this);
+    return new AnalyticsGroup(root, analyticsElement);
   }
 
   /**
@@ -164,155 +149,6 @@ export class InstrumentationService {
   }
 
   /**
-   * @param {!JsonObject} config Configuration for instrumentation.
-   * @param {function(!AnalyticsEvent)} listener The callback to call when the event
-   *  occurs.
-   * @param {!Element} analyticsElement The element associated with the
-   *  config.
-   * @private
-   * @restricted
-   */
-  addListenerDepr_(config, listener, analyticsElement) {
-    const eventType = config['on'];
-    if (!this.isTriggerAllowed_(eventType, analyticsElement)) {
-      user().error(TAG, 'Trigger type "' + eventType + '" is not ' +
-        'allowed in the embed.');
-      return;
-    }
-    if (eventType === AnalyticsEventType.SCROLL) {
-      if (!config['scrollSpec']) {
-        user().error(TAG, 'Missing scrollSpec on scroll trigger.');
-        return;
-      }
-      this.registerScrollTrigger_(config['scrollSpec'], listener);
-
-      // Trigger an event to fire events that might have already happened.
-      const size = this.viewport_.getSize();
-      this.onScroll_({
-        top: this.viewport_.getScrollTop(),
-        left: this.viewport_.getScrollLeft(),
-        width: size.width,
-        height: size.height,
-        relayoutAll: false,
-        velocity: 0, // Hack for typing.
-      });
-    }
-  }
-
-  /**
-   * @param {string} type
-   * @param {!Object<string, string>=} opt_vars
-   * @return {!AnalyticsEvent}
-   * @private
-   */
-  createEventDepr_(type, opt_vars) {
-    // TODO(dvoytenko): Remove when Tracker migration is complete.
-    return new AnalyticsEvent(
-        this.ampdocRoot_.getRootElement(), type, opt_vars);
-  }
-
-  /**
-   * @param {!../../../src/service/viewport/viewport-impl.ViewportChangedEventDef} e
-   * @private
-   */
-  onScroll_(e) {
-    this.scrollObservable_.fire(e);
-  }
-
-  /**
-   * Register for a listener to be called when the boundaries specified in
-   * config are reached.
-   * @param {!JsonObject} config the config that specifies the boundaries.
-   * @param {function(!AnalyticsEvent)} listener
-   * @private
-   */
-  registerScrollTrigger_(config, listener) {
-    if (!Array.isArray(config['verticalBoundaries']) &&
-        !Array.isArray(config['horizontalBoundaries'])) {
-      user().error(TAG, 'Boundaries are required for the scroll ' +
-          'trigger to work.');
-      return;
-    }
-
-    // Ensure that the scroll events are being listened to.
-    if (!this.scrollHandlerRegistered_) {
-      this.scrollHandlerRegistered_ = true;
-      this.viewport_.onChanged(this.onScroll_.bind(this));
-    }
-
-    /**
-     * @param {!Object<number, boolean>} bounds
-     * @param {number} scrollPos Number representing the current scroll
-     * @param {string} varName variable name to assign to the bound that
-     * triggers the event
-     * position.
-     */
-    const triggerScrollEvents = (bounds, scrollPos, varName) => {
-      if (!scrollPos) {
-        return;
-      }
-      // Goes through each of the boundaries and fires an event if it has not
-      // been fired so far and it should be.
-      for (const b in bounds) {
-        if (!hasOwn(bounds, b)) {
-          continue;
-        }
-        const bound = parseInt(b, 10);
-        if (bound > scrollPos || bounds[bound]) {
-          continue;
-        }
-        bounds[bound] = true;
-        const vars = Object.create(null);
-        vars[varName] = b;
-        listener(this.createEventDepr_(AnalyticsEventType.SCROLL, vars));
-      }
-    };
-
-    const boundsV = this.normalizeBoundaries_(config['verticalBoundaries']);
-    const boundsH = this.normalizeBoundaries_(config['horizontalBoundaries']);
-    this.scrollObservable_.add(e => {
-      // Calculates percentage scrolled by adding screen height/width to
-      // top/left and dividing by the total scroll height/width.
-      triggerScrollEvents(boundsV,
-          (e.top + e.height) * 100 / this.viewport_.getScrollHeight(),
-          VAR_V_SCROLL_BOUNDARY);
-      triggerScrollEvents(boundsH,
-          (e.left + e.width) * 100 / this.viewport_.getScrollWidth(),
-          VAR_H_SCROLL_BOUNDARY);
-    });
-  }
-
-  /**
-   * Rounds the boundaries for scroll trigger to nearest
-   * SCROLL_PRECISION_PERCENT and returns an object with normalized boundaries
-   * as keys and false as values.
-   *
-   * @param {!Array<number>} bounds array of bounds.
-   * @return {!Object<number,boolean>} Object with normalized bounds as keys
-   * and false as value.
-   * @private
-   */
-  normalizeBoundaries_(bounds) {
-    const result = {};
-    if (!bounds || !Array.isArray(bounds)) {
-      return result;
-    }
-
-    for (let b = 0; b < bounds.length; b++) {
-      let bound = bounds[b];
-      if (typeof bound !== 'number' || !isFinite(bound)) {
-        user().error(TAG, 'Scroll trigger boundaries must be finite.');
-        return result;
-      }
-
-      bound = Math.min(Math.round(bound / SCROLL_PRECISION_PERCENT) *
-          SCROLL_PRECISION_PERCENT, 100);
-      result[bound] = false;
-    }
-    return result;
-  }
-
-  /**
    * Checks to confirm that a given trigger type is allowed for the element.
    * Specifically, it confirms that if the element is in the embed, only a
    * subset of the trigger types are allowed.
@@ -339,17 +175,13 @@ export class AnalyticsGroup {
   /**
    * @param {!./analytics-root.AnalyticsRoot} root
    * @param {!Element} analyticsElement
-   * @param {!InstrumentationService} service
    */
-  constructor(root, analyticsElement, service) {
-    // TODO(dvoytenko): remove `service` as soon as migration is complete.
+  constructor(root, analyticsElement) {
 
     /** @const */
     this.root_ = root;
     /** @const */
     this.analyticsElement_ = analyticsElement;
-    /** @const */
-    this.service_ = service;
 
     /** @private @const {!Array<!UnlistenDef>} */
     this.listeners_ = [];
@@ -377,13 +209,6 @@ export class AnalyticsGroup {
     const trackerKey = getTrackerKeyName(eventType);
     const trackerWhitelist = getTrackerTypesForParentType(this.root_.getType());
 
-    if (this.isDeprecatedListenerEvent(trackerKey)) {
-      // TODO(dvoytenko): remove this use and `addListenerDepr_` once all
-      // triggers have been migrated..
-      this.service_.addListenerDepr_(config, handler, this.analyticsElement_);
-      return;
-    }
-
     const tracker = this.root_.getTrackerForWhitelist(
         trackerKey, trackerWhitelist);
     user().assert(!!tracker,
@@ -392,14 +217,6 @@ export class AnalyticsGroup {
     const unlisten = tracker.add(this.analyticsElement_, eventType, config,
         handler);
     this.listeners_.push(unlisten);
-  }
-
-  /**
-   * @param {string} triggerType
-   * @return {boolean}
-   */
-  isDeprecatedListenerEvent(triggerType) {
-    return triggerType == 'scroll';
   }
 }
 

--- a/extensions/amp-analytics/0.1/instrumentation.js
+++ b/extensions/amp-analytics/0.1/instrumentation.js
@@ -25,8 +25,6 @@ import {
   getTrackerKeyName,
   getTrackerTypesForParentType,
 } from './events';
-import {Observable} from '../../../src/observable';
-import {Services} from '../../../src/services';
 import {dev, user} from '../../../src/log';
 import {
   getFriendlyIframeEmbedOptional,
@@ -146,21 +144,6 @@ export class InstrumentationService {
       holder[PROP] = root;
     }
     return root;
-  }
-
-  /**
-   * Checks to confirm that a given trigger type is allowed for the element.
-   * Specifically, it confirms that if the element is in the embed, only a
-   * subset of the trigger types are allowed.
-   * @param  {!AnalyticsEventType} triggerType
-   * @param  {!Element} element
-   * @return {boolean} True if the trigger is allowed. False otherwise.
-   */
-  isTriggerAllowed_(triggerType, element) {
-    if (element.ownerDocument.defaultView != this.ampdoc.win) {
-      return ALLOWED_IN_EMBED.includes(triggerType);
-    }
-    return true;
   }
 }
 

--- a/extensions/amp-analytics/0.1/instrumentation.js
+++ b/extensions/amp-analytics/0.1/instrumentation.js
@@ -20,7 +20,6 @@ import {
 } from './analytics-root';
 import {
   AnalyticsEvent,
-  AnalyticsEventType,
   CustomEventTracker,
   getTrackerKeyName,
   getTrackerTypesForParentType,
@@ -35,25 +34,8 @@ import {
   getServicePromiseForDoc,
   registerServiceBuilderForDoc,
 } from '../../../src/service';
-import {hasOwn} from '../../../src/utils/object';
 
 const PROP = '__AMP_AN_ROOT';
-
-/** @const {string} */
-const TAG = 'Analytics.Instrumentation';
-
-/**
- * Events that can result in analytics data to be sent.
- * @const {Array<AnalyticsEventType>}
- */
-const ALLOWED_IN_EMBED = [
-  AnalyticsEventType.VISIBLE,
-  AnalyticsEventType.CLICK,
-  AnalyticsEventType.TIMER,
-  AnalyticsEventType.SCROLL,
-  AnalyticsEventType.HIDDEN,
-];
-
 
 /**
  * @implements {../../../src/service.Disposable}

--- a/extensions/amp-analytics/0.1/scroll-manager.js
+++ b/extensions/amp-analytics/0.1/scroll-manager.js
@@ -1,0 +1,83 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Services} from '../../../src/services';
+import {Observable} from '../../../src/observable';
+
+/**
+ * A manager for handling multiple Scroll Event Trackers.
+ * The instance of this class corresponds 1:1 to `AnalyticsRoot`. It represents
+ * a collection of all scroll triggers declared within the `AnalyticsRoot`.
+ * @implements {../../../src/service.Disposable}
+ * @abstract
+ */
+export class ScrollManager {
+  /**
+   * @param {?VisibilityManager} parent
+   * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
+   */
+  constructor(ampdoc) {
+
+    /** @const @protected */
+    this.ampdoc = ampdoc;
+
+    /** @private {!Observable<!../../../src/service/viewport/viewport-impl.ViewportChangedEventDef>} */
+    this.scrollObservable_ = new Observable();
+
+    /** @const @private {!../../../src/service/viewport/viewport-impl.Viewport} */
+    this.viewport_ = Services.viewportForDoc(this.ampdoc);
+    this.viewport_.onChanged(this.onScroll_.bind(this));
+  }
+
+  dispose() {
+    this.scrollObservable_.removeAll();
+  }
+  
+  /**
+   * @param {function(!Event)} 
+   */
+  removeScrollHandler(handler) {
+    this.scrollObservable_.remove(handler);
+  }
+  
+  /**
+   * @param {function(!Event)} 
+   */
+  addScrollHandler(handler) {
+    this.scrollObservable_.add(handler); 
+
+    // Trigger an event to fire events that might have already happened.
+    const size = this.viewport_.getSize();
+    handler({
+      top: this.viewport_.getScrollTop(),
+      left: this.viewport_.getScrollLeft(),
+      width: size.width,
+      height: size.height,
+      relayoutAll: false,
+      velocity: 0, // Hack for typing.
+    });
+  }
+
+  /**
+   * @param {!../../../src/service/viewport/viewport-impl.ViewportChangedEventDef} e
+   * @private
+   */
+  onScroll_(e) {
+    // Fire all of our children scroll observables
+    this.scrollObservable_.fire(e);
+  }
+}
+

--- a/extensions/amp-analytics/0.1/scroll-manager.js
+++ b/extensions/amp-analytics/0.1/scroll-manager.js
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import {Services} from '../../../src/services';
 import {Observable} from '../../../src/observable';
+import {Services} from '../../../src/services';
 
 /**
  * A manager for handling multiple Scroll Event Trackers.
@@ -26,12 +26,11 @@ import {Observable} from '../../../src/observable';
  */
 export class ScrollManager {
   /**
-   * @param {?VisibilityManager} parent
    * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
    */
   constructor(ampdoc) {
 
-    /** @const @protected */
+    /** @const @protected {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc*/
     this.ampdoc = ampdoc;
 
     /** @private {!Observable<!../../../src/service/viewport/viewport-impl.ViewportChangedEventDef>} */
@@ -42,30 +41,35 @@ export class ScrollManager {
     this.viewport_.onChanged(this.onScroll_.bind(this));
   }
 
+  /**
+   * Function to dispose of all handlers on the scroll observable
+   */
   dispose() {
     this.scrollObservable_.removeAll();
   }
-  
+
   /**
-   * @param {function(!Event)} 
+   * @param {function(!Event)} handler
    */
   removeScrollHandler(handler) {
     this.scrollObservable_.remove(handler);
   }
-  
+
   /**
-   * @param {function(!Event)} 
+   * @param {function(!Event)} handler
    */
   addScrollHandler(handler) {
-    this.scrollObservable_.add(handler); 
+    this.scrollObservable_.add(handler);
 
     // Trigger an event to fire events that might have already happened.
     const size = this.viewport_.getSize();
     handler({
-      top: this.viewport_.getScrollTop(),
-      left: this.viewport_.getScrollLeft(),
-      width: size.width,
-      height: size.height,
+      scrollTop: this.viewport_.getScrollTop(),
+      scrollLeft: this.viewport_.getScrollLeft(),
+      scrollWidth: this.viewport_.getScrollWidth(),
+      scrollHeight: this.viewport_.getScrollHeight(),
+      screenWidth: size.width,
+      screenHeight: size.height,
       relayoutAll: false,
       velocity: 0, // Hack for typing.
     });

--- a/extensions/amp-analytics/0.1/scroll-manager.js
+++ b/extensions/amp-analytics/0.1/scroll-manager.js
@@ -82,12 +82,10 @@ export class ScrollManager {
     const scrollEvent = {
       top: this.viewport_.getScrollTop(),
       left: this.viewport_.getScrollLeft(),
-      width: this.viewport_.getScrollWidth(),
-      height: this.viewport_.getScrollHeight(),
-      screenWidth: size.width,
-      screenHeight: size.height,
-      relayoutAll: false,
-      velocity: 0, // Hack for typing.
+      width: size.width,
+      height: size.height,
+      scrollWidth: this.viewport_.getScrollWidth(),
+      scrollHeight: this.viewport_.getScrollHeight(),
     };
     handler(scrollEvent);
 

--- a/extensions/amp-analytics/0.1/scroll-manager.js
+++ b/extensions/amp-analytics/0.1/scroll-manager.js
@@ -19,14 +19,12 @@ import {Services} from '../../../src/services';
 
 /**
  * @typedef {{
- *   relayoutAll: boolean,
  *   top: number,
  *   left: number,
  *   width: number,
  *   height: number,
- *   screenHeight: number,
- *   screenWidth: number,
- *   velocity: number
+ *   scrollHeight: number,
+ *   scrollWidth: number,
  * }}
  */
 export let ScrollEventDef;
@@ -43,17 +41,14 @@ export class ScrollManager {
    */
   constructor(ampdoc) {
 
-    /** @const @protected {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc*/
-    this.ampdoc = ampdoc;
+    /** @const @private {!../../../src/service/viewport/viewport-impl.Viewport} */
+    this.viewport_ = Services.viewportForDoc(ampdoc);
+
+    /** @private {!UnlistenDef|null} */
+    this.viewportOnChangedUnlistener_ = null;
 
     /** @private {!Observable<!./scroll-manager.ScrollEventDef>} */
     this.scrollObservable_ = new Observable();
-
-    /** @const @private {!../../../src/service/viewport/viewport-impl.Viewport} */
-    this.viewport_ = Services.viewportForDoc(this.ampdoc);
-
-    /** @private {!UnlistenDef|null} */
-    this.viewportOnChangedUnlistenDef_ = null;
   }
 
   /**
@@ -112,12 +107,11 @@ export class ScrollManager {
     const scrollEvent = {
       top: e.top,
       left: e.left,
-      width: this.viewport_.getScrollWidth(),
-      height: this.viewport_.getScrollHeight(),
-      screenWidth: e.width,
-      screenHeight: e.height,
-      relayoutAll: e.relayoutAll,
-      velocity: e.velocity, // Hack for typing.
+      width: e.width,
+      height: e.height,
+      scrollWidth: this.viewport_.getScrollWidth(),
+      scrollHeight: this.viewport_.getScrollHeight(),
+
     };
     // Fire all of our children scroll observables
     this.scrollObservable_.fire(scrollEvent);
@@ -128,9 +122,9 @@ export class ScrollManager {
    * @private
    */
   removeViewportOnChangedListener_() {
-    if (this.viewportOnChangedUnlistenDef_) {
-      this.viewportOnChangedUnlistenDef_();
-      this.viewportOnChangedUnlistenDef_ = null;
+    if (this.viewportOnChangedUnlistener_) {
+      this.viewportOnChangedUnlistener_();
+      this.viewportOnChangedUnlistener_ = null;
     }
   }
 
@@ -139,7 +133,7 @@ export class ScrollManager {
    * @private
    */
   addViewportOnChangedListener_() {
-    this.viewportOnChangedUnlistenDef_ =
+    this.viewportOnChangedUnlistener_ =
       this.viewport_.onChanged(this.onScroll_.bind(this));
   }
 

--- a/extensions/amp-analytics/0.1/scroll-manager.js
+++ b/extensions/amp-analytics/0.1/scroll-manager.js
@@ -51,8 +51,8 @@ export class ScrollManager {
 
     /** @const @private {!../../../src/service/viewport/viewport-impl.Viewport} */
     this.viewport_ = Services.viewportForDoc(this.ampdoc);
-    
-    /** @const @private {!UnlistenDef|null} */
+
+    /** @private {!UnlistenDef|null} */
     this.viewportOnChangedUnlistenDef_ = null;
   }
 
@@ -63,13 +63,13 @@ export class ScrollManager {
     this.scrollObservable_.removeAll();
     this.removeViewportOnChangedListener_();
   }
-  
+
   /**
    * @param {function(!Object)} handler
    */
   removeScrollHandler(handler) {
     this.scrollObservable_.remove(handler);
-    
+
     if (this.scrollObservable_.getHandlerCount() <= 0) {
       this.removeViewportOnChangedListener_();
     }
@@ -139,7 +139,8 @@ export class ScrollManager {
    * @private
    */
   addViewportOnChangedListener_() {
-    this.viewportOnChangedUnlistenDef_ = this.viewport_.onChanged(this.onScroll_.bind(this));
+    this.viewportOnChangedUnlistenDef_ =
+      this.viewport_.onChanged(this.onScroll_.bind(this));
   }
 
 }

--- a/extensions/amp-analytics/0.1/test/test-analytics-root.js
+++ b/extensions/amp-analytics/0.1/test/test-analytics-root.js
@@ -143,7 +143,6 @@ describes.realWin('AmpdocAnalyticsRoot', {amp: 1}, env => {
   it('should create scroll manager', () => {
     const scrollManager = root.getScrollManager();
     expect(scrollManager).to.be.instanceOf(ScrollManager);
-    expect(scrollManager.ampdoc).to.equal(ampdoc);
     // Ensure the instance is reused.
     expect(root.getScrollManager()).to.equal(scrollManager);
   });

--- a/extensions/amp-analytics/0.1/test/test-analytics-root.js
+++ b/extensions/amp-analytics/0.1/test/test-analytics-root.js
@@ -24,6 +24,7 @@ import {
 import {
   CustomEventTracker,
 } from '../events';
+import {ScrollManager} from '../scroll-manager';
 import {
   VisibilityManagerForDoc,
   VisibilityManagerForEmbed,
@@ -137,6 +138,14 @@ describes.realWin('AmpdocAnalyticsRoot', {amp: 1}, env => {
     expect(visibilityManager.parent).to.be.null;
     // Ensure the instance is reused.
     expect(root.getVisibilityManager()).to.equal(visibilityManager);
+  });
+
+  it('should create scroll manager', () => {
+    const scrollManager = root.getScrollManager();
+    expect(scrollManager).to.be.instanceOf(ScrollManager);
+    expect(scrollManager.ampdoc).to.equal(ampdoc);
+    // Ensure the instance is reused.
+    expect(root.getScrollManager()).to.equal(scrollManager);
   });
 
 

--- a/extensions/amp-analytics/0.1/test/test-events.js
+++ b/extensions/amp-analytics/0.1/test/test-events.js
@@ -170,6 +170,7 @@ describes.realWin('Events', {amp: 1}, env => {
         'horizontalBoundaries': [0, 100],
       },
     };
+    let scrollManager;
 
     beforeEach(() => {
       tracker = root.getTracker('scroll', ScrollEventTracker);
@@ -182,7 +183,8 @@ describes.realWin('Events', {amp: 1}, env => {
         'getScrollWidth': sandbox.stub().returns(500),
         'onChanged': sandbox.stub(),
       };
-      tracker.root_.getScrollManager().viewport_ = fakeViewport;
+      scrollManager = tracker.root_.getScrollManager();
+      scrollManager.viewport_ = fakeViewport;
 
       getFakeViewportChangedEvent = () => {
         const size = fakeViewport.getSize();
@@ -199,14 +201,15 @@ describes.realWin('Events', {amp: 1}, env => {
 
     it('should initalize, add listeners and dispose', () => {
       expect(tracker.root).to.equal(root);
-      expect(tracker.scrollHandler_).to.be.not.ok;
+      expect(scrollManager.scrollObservable_.getHandlerCount()).to.equal(0);
 
       tracker.add(undefined, 'scroll', defaultScrollConfig, sandbox.stub());
-      expect(tracker.scrollHandler_).to.be.ok;
+      expect(scrollManager.scrollObservable_.getHandlerCount()).to.equal(1);
+
 
 
       tracker.dispose();
-      expect(tracker.scrollHandler_).to.be.not.ok;
+      expect(scrollManager.scrollObservable_.getHandlerCount()).to.equal(0);
     });
 
 

--- a/extensions/amp-analytics/0.1/test/test-events.js
+++ b/extensions/amp-analytics/0.1/test/test-events.js
@@ -162,6 +162,7 @@ describes.realWin('Events', {amp: 1}, env => {
 
     let tracker;
     let fakeViewport;
+    let getFakeViewportEvent;
     const defaultScrollConfig = {
       'on': 'scroll',
       'scrollSpec': {
@@ -181,7 +182,21 @@ describes.realWin('Events', {amp: 1}, env => {
         'getScrollWidth': sandbox.stub().returns(500),
         'onChanged': sandbox.stub(),
       };
-      root.getScrollManager().viewport_ = fakeViewport;
+      tracker.root_.getScrollManager().viewport_ = fakeViewport;
+
+      getFakeViewportEvent = () => {
+        const size = fakeViewport.getSize();
+        return {
+          scrollTop: fakeViewport.getScrollTop(),
+          scrollLeft: fakeViewport.getScrollLeft(),
+          scrollWidth: fakeViewport.getScrollWidth(),
+          scrollHeight: fakeViewport.getScrollHeight(),
+          screenWidth: size.width,
+          screenHeight: size.height,
+          relayoutAll: false,
+          velocity: 0, // Hack for typing.
+        };
+      };
     });
 
     it('should initalize, add listeners and dispose', () => {
@@ -229,7 +244,7 @@ describes.realWin('Events', {amp: 1}, env => {
       // Scroll Down
       fakeViewport.getScrollTop.returns(500);
       fakeViewport.getScrollLeft.returns(500);
-      .onScroll_({top: 500, left: 500, height: 250, width: 250});
+      tracker.root_.getScrollManager().onScroll_(getFakeViewportEvent());
 
       expect(fn1).to.have.callCount(4);
       expect(fn1.getCall(2).calledWithMatch(sinon.match(matcher(100)))).to.be
@@ -254,7 +269,7 @@ describes.realWin('Events', {amp: 1}, env => {
       // Scroll Down
       fakeViewport.getScrollTop.returns(10);
       fakeViewport.getScrollLeft.returns(10);
-      tracker.onScroll_({top: 10, left: 10, height: 250, width: 250});
+      tracker.root_.getScrollManager().onScroll_(getFakeViewportEvent());
 
       expect(fn1).to.have.callCount(2);
     });

--- a/extensions/amp-analytics/0.1/test/test-events.js
+++ b/extensions/amp-analytics/0.1/test/test-events.js
@@ -162,7 +162,7 @@ describes.realWin('Events', {amp: 1}, env => {
 
     let tracker;
     let fakeViewport;
-    let getFakeViewportEvent;
+    let getFakeViewportChangedEvent;
     const defaultScrollConfig = {
       'on': 'scroll',
       'scrollSpec': {
@@ -184,15 +184,13 @@ describes.realWin('Events', {amp: 1}, env => {
       };
       tracker.root_.getScrollManager().viewport_ = fakeViewport;
 
-      getFakeViewportEvent = () => {
+      getFakeViewportChangedEvent = () => {
         const size = fakeViewport.getSize();
         return {
-          scrollTop: fakeViewport.getScrollTop(),
-          scrollLeft: fakeViewport.getScrollLeft(),
-          scrollWidth: fakeViewport.getScrollWidth(),
-          scrollHeight: fakeViewport.getScrollHeight(),
-          screenWidth: size.width,
-          screenHeight: size.height,
+          top: fakeViewport.getScrollTop(),
+          left: fakeViewport.getScrollLeft(),
+          width: size.width,
+          height: size.height,
           relayoutAll: false,
           velocity: 0, // Hack for typing.
         };
@@ -244,7 +242,7 @@ describes.realWin('Events', {amp: 1}, env => {
       // Scroll Down
       fakeViewport.getScrollTop.returns(500);
       fakeViewport.getScrollLeft.returns(500);
-      tracker.root_.getScrollManager().onScroll_(getFakeViewportEvent());
+      tracker.root_.getScrollManager().onScroll_(getFakeViewportChangedEvent());
 
       expect(fn1).to.have.callCount(4);
       expect(fn1.getCall(2).calledWithMatch(sinon.match(matcher(100)))).to.be
@@ -269,7 +267,7 @@ describes.realWin('Events', {amp: 1}, env => {
       // Scroll Down
       fakeViewport.getScrollTop.returns(10);
       fakeViewport.getScrollLeft.returns(10);
-      tracker.root_.getScrollManager().onScroll_(getFakeViewportEvent());
+      tracker.root_.getScrollManager().onScroll_(getFakeViewportChangedEvent());
 
       expect(fn1).to.have.callCount(2);
     });

--- a/extensions/amp-analytics/0.1/test/test-events.js
+++ b/extensions/amp-analytics/0.1/test/test-events.js
@@ -206,8 +206,6 @@ describes.realWin('Events', {amp: 1}, env => {
       tracker.add(undefined, 'scroll', defaultScrollConfig, sandbox.stub());
       expect(scrollManager.scrollObservable_.getHandlerCount()).to.equal(1);
 
-
-
       tracker.dispose();
       expect(scrollManager.scrollObservable_.getHandlerCount()).to.equal(0);
     });

--- a/extensions/amp-analytics/0.1/test/test-events.js
+++ b/extensions/amp-analytics/0.1/test/test-events.js
@@ -21,9 +21,10 @@ import {
   ClickEventTracker,
   CustomEventTracker,
   IniLoadTracker,
+  ScrollEventTracker,
   SignalTracker,
   TimerEventTracker,
-  VisibilityTracker,
+  VisibilityTracker
 } from '../events';
 import {Signals} from '../../../../src/utils/signals';
 
@@ -154,6 +155,164 @@ describes.realWin('Events', {amp: 1}, env => {
       target.click();
       const event = handler.args[0][0];
       expect(event.vars).to.deep.equal({'foo': 'bar'});
+    });
+  });
+
+  describe('ScrollEventTracker', () => {
+
+    let tracker;
+    let fakeViewport;
+    const defaultScrollConfig = {
+      'on': 'scroll',
+      'scrollSpec': {
+        'verticalBoundaries': [0, 100],
+        'horizontalBoundaries': [0, 100],
+      }
+    };
+
+    beforeEach(() => {
+      tracker = root.getTracker('scroll', ScrollEventTracker);
+      fakeViewport = {
+        'getSize': sandbox.stub().returns(
+          {top: 0, left: 0, height: 200, width: 200}),
+        'getScrollTop': sandbox.stub().returns(0),
+        'getScrollLeft': sandbox.stub().returns(0),
+        'getScrollHeight': sandbox.stub().returns(500),
+        'getScrollWidth': sandbox.stub().returns(500),
+        'onChanged': sandbox.stub(),
+      };
+      tracker.viewport_ = fakeViewport;
+    });
+
+    it('should initalize, add listeners and dispose', () => {
+      expect(tracker.root).to.equal(root);
+      expect(tracker.scrollObservable_.getHandlerCount()).to.equal(0);
+
+      const sandboxStub = sandbox.stub();
+
+      tracker.add(undefined, 'scroll', defaultScrollConfig, sandbox.stub());
+      expect(tracker.scrollObservable_.getHandlerCount()).to.equal(1);
+
+      tracker.dispose();
+      expect(tracker.scrollObservable_.getHandlerCount()).to.equal(0);
+    });
+
+
+    it('fires on scroll', () => {
+      const fn1 = sandbox.stub();
+      const fn2 = sandbox.stub();
+      tracker.add(undefined, 'scroll', defaultScrollConfig, fn1);
+      tracker.add(undefined, 'scroll', {
+        'on': 'scroll', 
+        'scrollSpec': {
+          'verticalBoundaries': [92], 
+          'horizontalBoundaries': [92]
+        }
+      }, fn2);
+
+      function matcher(expected) {
+        return actual => {
+          return actual.vars.horizontalScrollBoundary === String(expected) ||
+            actual.vars.verticalScrollBoundary === String(expected);
+        };
+      }
+      expect(fn1).to.have.callCount(2);
+      expect(fn1.getCall(0).calledWithMatch(sinon.match(matcher(0)))).to.be.true;
+      expect(fn1.getCall(1).calledWithMatch(sinon.match(matcher(0)))).to.be.true;
+      expect(fn2).to.have.not.been.called;
+
+      // Scroll Down
+      fakeViewport.getScrollTop.returns(500);
+      fakeViewport.getScrollLeft.returns(500);
+      tracker.onScroll_({top: 500, left: 500, height: 250, width: 250});
+
+      expect(fn1).to.have.callCount(4);
+      expect(fn1.getCall(2).calledWithMatch(sinon.match(matcher(100)))).to.be
+        .true;
+      expect(fn1.getCall(3).calledWithMatch(sinon.match(matcher(100)))).to.be
+        .true;
+      expect(fn2).to.have.callCount(2);
+      expect(fn2.getCall(0).calledWithMatch(sinon.match(matcher(90)))).to.be.true;
+      expect(fn2.getCall(1).calledWithMatch(sinon.match(matcher(90)))).to.be.true;
+    });
+
+    it('does not fire duplicates on scroll', () => {
+      const fn1 = sandbox.stub();
+      tracker.add(undefined, 'scroll', defaultScrollConfig, fn1);
+
+      // Scroll Down
+      fakeViewport.getScrollTop.returns(10);
+      fakeViewport.getScrollLeft.returns(10);
+      tracker.onScroll_({top: 10, left: 10, height: 250, width: 250});
+
+      expect(fn1).to.have.callCount(2);
+    });
+
+    it('fails gracefully on bad scroll config', () => {
+      const fn1 = sandbox.stub();
+
+      allowConsoleError(() => {
+        tracker.add(undefined, 'scroll', {'on': 'scroll'}, fn1);
+        expect(fn1).to.have.not.been.called;
+
+        tracker.add(undefined, 'scroll', {'on': 'scroll', 'scrollSpec': {}}, fn1);
+        expect(fn1).to.have.not.been.called;
+
+        tracker.add(undefined, 'scroll', {
+          'on': 'scroll',
+          'scrollSpec': {
+            'verticalBoundaries': undefined, 'horizontalBoundaries': undefined,
+          }
+        }, fn1);
+        expect(fn1).to.have.not.been.called;
+
+        tracker.add(undefined, 'scroll', {
+          'on': 'scroll',
+          'scrollSpec': {'verticalBoundaries': [], 'horizontalBoundaries': []}
+        }, fn1);
+        expect(fn1).to.have.not.been.called;
+
+        tracker.add(undefined, 'scroll', {
+          'on': 'scroll',
+          'scrollSpec': {
+            'verticalBoundaries': ['foo'], 'horizontalBoundaries': ['foo'],
+          }
+        }, fn1);
+        expect(fn1).to.have.not.been.called;
+      });
+    });
+
+    it('normalizes boundaries correctly.', () => {
+      allowConsoleError(() => {
+        expect(tracker.normalizeBoundaries_([])).to.be.empty;
+        expect(tracker.normalizeBoundaries_(undefined)).to.be.empty;
+        expect(tracker.normalizeBoundaries_(['foo'])).to.be.empty;
+        expect(tracker.normalizeBoundaries_(['0', '1'])).to.be.empty;
+      });
+      expect(tracker.normalizeBoundaries_([1])).to.deep.equal({0: false});
+      expect(tracker.normalizeBoundaries_([1, 4, 99, 1001])).to.deep.equal({
+        0: false,
+        5: false,
+        100: false,
+      });
+    });
+
+    it('fires events on normalized boundaries.', () => {
+      const fn1 = sandbox.stub();
+      const fn2 = sandbox.stub();
+      tracker.add(undefined, 'scroll', {
+        'on': 'scroll', 
+        'scrollSpec': {
+          'verticalBoundaries': [1]
+        }
+      }, fn1);
+      tracker.add(undefined, 'scroll', {
+        'on': 'scroll', 
+        'scrollSpec': {
+          'verticalBoundaries': [4]
+        }
+      }, fn2);
+      expect(fn2).to.be.calledOnce;
     });
   });
 

--- a/extensions/amp-analytics/0.1/test/test-events.js
+++ b/extensions/amp-analytics/0.1/test/test-events.js
@@ -181,18 +181,19 @@ describes.realWin('Events', {amp: 1}, env => {
         'getScrollWidth': sandbox.stub().returns(500),
         'onChanged': sandbox.stub(),
       };
-      tracker.viewport_ = fakeViewport;
+      root.getScrollManager().viewport_ = fakeViewport;
     });
 
     it('should initalize, add listeners and dispose', () => {
       expect(tracker.root).to.equal(root);
-      expect(tracker.scrollObservable_.getHandlerCount()).to.equal(0);
+      expect(tracker.scrollHandler_).to.be.not.ok;
 
       tracker.add(undefined, 'scroll', defaultScrollConfig, sandbox.stub());
-      expect(tracker.scrollObservable_.getHandlerCount()).to.equal(1);
+      expect(tracker.scrollHandler_).to.be.ok;
+
 
       tracker.dispose();
-      expect(tracker.scrollObservable_.getHandlerCount()).to.equal(0);
+      expect(tracker.scrollHandler_).to.be.not.ok;
     });
 
 
@@ -228,7 +229,7 @@ describes.realWin('Events', {amp: 1}, env => {
       // Scroll Down
       fakeViewport.getScrollTop.returns(500);
       fakeViewport.getScrollLeft.returns(500);
-      tracker.onScroll_({top: 500, left: 500, height: 250, width: 250});
+      .onScroll_({top: 500, left: 500, height: 250, width: 250});
 
       expect(fn1).to.have.callCount(4);
       expect(fn1.getCall(2).calledWithMatch(sinon.match(matcher(100)))).to.be

--- a/extensions/amp-analytics/0.1/test/test-events.js
+++ b/extensions/amp-analytics/0.1/test/test-events.js
@@ -24,7 +24,7 @@ import {
   ScrollEventTracker,
   SignalTracker,
   TimerEventTracker,
-  VisibilityTracker
+  VisibilityTracker,
 } from '../events';
 import {Signals} from '../../../../src/utils/signals';
 
@@ -167,14 +167,14 @@ describes.realWin('Events', {amp: 1}, env => {
       'scrollSpec': {
         'verticalBoundaries': [0, 100],
         'horizontalBoundaries': [0, 100],
-      }
+      },
     };
 
     beforeEach(() => {
       tracker = root.getTracker('scroll', ScrollEventTracker);
       fakeViewport = {
         'getSize': sandbox.stub().returns(
-          {top: 0, left: 0, height: 200, width: 200}),
+            {top: 0, left: 0, height: 200, width: 200}),
         'getScrollTop': sandbox.stub().returns(0),
         'getScrollLeft': sandbox.stub().returns(0),
         'getScrollHeight': sandbox.stub().returns(500),
@@ -187,8 +187,6 @@ describes.realWin('Events', {amp: 1}, env => {
     it('should initalize, add listeners and dispose', () => {
       expect(tracker.root).to.equal(root);
       expect(tracker.scrollObservable_.getHandlerCount()).to.equal(0);
-
-      const sandboxStub = sandbox.stub();
 
       tracker.add(undefined, 'scroll', defaultScrollConfig, sandbox.stub());
       expect(tracker.scrollObservable_.getHandlerCount()).to.equal(1);
@@ -203,11 +201,11 @@ describes.realWin('Events', {amp: 1}, env => {
       const fn2 = sandbox.stub();
       tracker.add(undefined, 'scroll', defaultScrollConfig, fn1);
       tracker.add(undefined, 'scroll', {
-        'on': 'scroll', 
+        'on': 'scroll',
         'scrollSpec': {
-          'verticalBoundaries': [92], 
-          'horizontalBoundaries': [92]
-        }
+          'verticalBoundaries': [92],
+          'horizontalBoundaries': [92],
+        },
       }, fn2);
 
       function matcher(expected) {
@@ -217,8 +215,14 @@ describes.realWin('Events', {amp: 1}, env => {
         };
       }
       expect(fn1).to.have.callCount(2);
-      expect(fn1.getCall(0).calledWithMatch(sinon.match(matcher(0)))).to.be.true;
-      expect(fn1.getCall(1).calledWithMatch(sinon.match(matcher(0)))).to.be.true;
+      expect(
+          fn1.getCall(0)
+              .calledWithMatch(sinon.match(matcher(0)))
+      ).to.be.true;
+      expect(
+          fn1.getCall(1)
+              .calledWithMatch(sinon.match(matcher(0)))
+      ).to.be.true;
       expect(fn2).to.have.not.been.called;
 
       // Scroll Down
@@ -228,12 +232,18 @@ describes.realWin('Events', {amp: 1}, env => {
 
       expect(fn1).to.have.callCount(4);
       expect(fn1.getCall(2).calledWithMatch(sinon.match(matcher(100)))).to.be
-        .true;
+          .true;
       expect(fn1.getCall(3).calledWithMatch(sinon.match(matcher(100)))).to.be
-        .true;
+          .true;
       expect(fn2).to.have.callCount(2);
-      expect(fn2.getCall(0).calledWithMatch(sinon.match(matcher(90)))).to.be.true;
-      expect(fn2.getCall(1).calledWithMatch(sinon.match(matcher(90)))).to.be.true;
+      expect(
+          fn2.getCall(0)
+              .calledWithMatch(sinon.match(matcher(90)))
+      ).to.be.true;
+      expect(
+          fn2.getCall(1)
+              .calledWithMatch(sinon.match(matcher(90)))
+      ).to.be.true;
     });
 
     it('does not fire duplicates on scroll', () => {
@@ -255,20 +265,23 @@ describes.realWin('Events', {amp: 1}, env => {
         tracker.add(undefined, 'scroll', {'on': 'scroll'}, fn1);
         expect(fn1).to.have.not.been.called;
 
-        tracker.add(undefined, 'scroll', {'on': 'scroll', 'scrollSpec': {}}, fn1);
+        tracker.add(undefined, 'scroll', {
+          'on': 'scroll',
+          'scrollSpec': {},
+        }, fn1);
         expect(fn1).to.have.not.been.called;
 
         tracker.add(undefined, 'scroll', {
           'on': 'scroll',
           'scrollSpec': {
             'verticalBoundaries': undefined, 'horizontalBoundaries': undefined,
-          }
+          },
         }, fn1);
         expect(fn1).to.have.not.been.called;
 
         tracker.add(undefined, 'scroll', {
           'on': 'scroll',
-          'scrollSpec': {'verticalBoundaries': [], 'horizontalBoundaries': []}
+          'scrollSpec': {'verticalBoundaries': [], 'horizontalBoundaries': []},
         }, fn1);
         expect(fn1).to.have.not.been.called;
 
@@ -276,7 +289,7 @@ describes.realWin('Events', {amp: 1}, env => {
           'on': 'scroll',
           'scrollSpec': {
             'verticalBoundaries': ['foo'], 'horizontalBoundaries': ['foo'],
-          }
+          },
         }, fn1);
         expect(fn1).to.have.not.been.called;
       });
@@ -301,16 +314,16 @@ describes.realWin('Events', {amp: 1}, env => {
       const fn1 = sandbox.stub();
       const fn2 = sandbox.stub();
       tracker.add(undefined, 'scroll', {
-        'on': 'scroll', 
+        'on': 'scroll',
         'scrollSpec': {
-          'verticalBoundaries': [1]
-        }
+          'verticalBoundaries': [1],
+        },
       }, fn1);
       tracker.add(undefined, 'scroll', {
-        'on': 'scroll', 
+        'on': 'scroll',
         'scrollSpec': {
-          'verticalBoundaries': [4]
-        }
+          'verticalBoundaries': [4],
+        },
       }, fn2);
       expect(fn2).to.be.calledOnce;
     });

--- a/extensions/amp-analytics/0.1/test/test-instrumentation.js
+++ b/extensions/amp-analytics/0.1/test/test-instrumentation.js
@@ -14,27 +14,19 @@
  * limitations under the License.
  */
 
-import {AmpDocSingle} from '../../../../src/service/ampdoc-impl';
 import {
-  AnalyticsEventType,
   ClickEventTracker,
   CustomEventTracker,
   IniLoadTracker,
+  ScrollEventTracker,
   SignalTracker,
   TimerEventTracker,
   VisibilityTracker,
-  ScrollEventTracker
 } from '../events';
 
 import {
   InstrumentationService,
 } from '../instrumentation.js';
-import {Services} from '../../../../src/services';
-import {installPlatformService} from '../../../../src/service/platform-impl';
-import {
-  installResourcesServiceForDoc,
-} from '../../../../src/service/resources-impl';
-import {installTimerService} from '../../../../src/service/timer-impl';
 
 describes.realWin('InstrumentationService', {amp: 1}, env => {
   let win;
@@ -94,7 +86,6 @@ describes.realWin('InstrumentationService', {amp: 1}, env => {
 
   describe('AnalyticsGroup', () => {
     let group;
-    let insStub;
 
     beforeEach(() => {
       group = service.createAnalyticsGroup(analyticsElement);
@@ -145,7 +136,7 @@ describes.realWin('InstrumentationService', {amp: 1}, env => {
       group.addTrigger(config, handler);
       expect(stub).to.be.calledOnce;
       expect(stub).to.be.calledWith(
-        analyticsElement, 'scroll', config, handler);
+          analyticsElement, 'scroll', config, handler);
       expect(group.listeners_).to.have.length(1);
       expect(group.listeners_[0]).to.equal(unlisten);
     });

--- a/extensions/amp-analytics/0.1/test/test-instrumentation.js
+++ b/extensions/amp-analytics/0.1/test/test-instrumentation.js
@@ -23,6 +23,7 @@ import {
   SignalTracker,
   TimerEventTracker,
   VisibilityTracker,
+  ScrollEventTracker
 } from '../events';
 
 import {
@@ -97,7 +98,6 @@ describes.realWin('InstrumentationService', {amp: 1}, env => {
 
     beforeEach(() => {
       group = service.createAnalyticsGroup(analyticsElement);
-      insStub = sandbox.stub(service, 'addListenerDepr_');
     });
 
     it('should create group for the ampdoc root', () => {
@@ -120,22 +120,6 @@ describes.realWin('InstrumentationService', {amp: 1}, env => {
       }).to.throw(/intentional/);
     });
 
-    it('should delegate to deprecated addListener', () => {
-      const trackerStub = sandbox.stub(root, 'getTracker');
-      const handler = function() {};
-      group.addTrigger({on: 'scroll'}, handler);
-
-      expect(trackerStub).to.not.be.called;
-      expect(group.listeners_).to.be.empty;
-
-      expect(insStub).to.have.callCount(1);
-
-      expect(insStub.args[0][0].on).to.equal('scroll');
-      expect(insStub.args[0][1]).to.equal(handler);
-      expect(insStub.args[0][2]).to.equal(analyticsElement);
-
-    });
-
     it('should add "click" trigger', () => {
       const tracker = root.getTracker('click', ClickEventTracker);
       const unlisten = function() {};
@@ -149,7 +133,21 @@ describes.realWin('InstrumentationService', {amp: 1}, env => {
           analyticsElement, 'click', config, handler);
       expect(group.listeners_).to.have.length(1);
       expect(group.listeners_[0]).to.equal(unlisten);
-      expect(insStub).to.not.be.called;
+    });
+
+    it('should add "scroll" trigger', () => {
+      const tracker = root.getTracker('scroll', ScrollEventTracker);
+      const unlisten = function() {};
+      const stub = sandbox.stub(tracker, 'add').callsFake(() => unlisten);
+      const config = {on: 'scroll', selector: '*'};
+      const handler = function() {};
+      expect(group.listeners_).to.be.empty;
+      group.addTrigger(config, handler);
+      expect(stub).to.be.calledOnce;
+      expect(stub).to.be.calledWith(
+        analyticsElement, 'scroll', config, handler);
+      expect(group.listeners_).to.have.length(1);
+      expect(group.listeners_[0]).to.equal(unlisten);
     });
 
     it('should add "custom" trigger', () => {
@@ -165,7 +163,6 @@ describes.realWin('InstrumentationService', {amp: 1}, env => {
           analyticsElement, 'custom-event-1', config, handler);
       expect(group.listeners_).to.have.length(1);
       expect(group.listeners_[0]).to.equal(unlisten);
-      expect(insStub).to.not.be.called;
     });
 
     it('should add "render-start" trigger', () => {
@@ -288,197 +285,3 @@ describes.realWin('InstrumentationService in FIE', {
   });
 });
 
-
-// TODO(dvoytenko): remove after migration to trackers.
-describe('amp-analytics.instrumentation OLD', function() {
-
-  let ins;
-  let fakeViewport;
-  let sandbox;
-  let ampdoc;
-
-  beforeEach(() => {
-    sandbox = sinon.sandbox;
-    const docState = Services.documentStateFor(window);
-    sandbox.stub(docState, 'isHidden').callsFake(() => false);
-    ampdoc = new AmpDocSingle(window);
-    installResourcesServiceForDoc(ampdoc);
-    installPlatformService(window);
-    installTimerService(window);
-    ins = new InstrumentationService(ampdoc);
-    fakeViewport = {
-      'getSize': sandbox.stub().returns(
-          {top: 0, left: 0, height: 200, width: 200}),
-      'getScrollTop': sandbox.stub().returns(0),
-      'getScrollLeft': sandbox.stub().returns(0),
-      'getScrollHeight': sandbox.stub().returns(500),
-      'getScrollWidth': sandbox.stub().returns(500),
-      'onChanged': sandbox.stub(),
-    };
-    ins.viewport_ = fakeViewport;
-    sandbox.stub(ins, 'isTriggerAllowed_').returns(true);
-  });
-
-  afterEach(() => {
-    sandbox.restore();
-  });
-
-  it('fires on scroll', () => {
-    const fn1 = sandbox.stub();
-    const fn2 = sandbox.stub();
-    ins.addListenerDepr_({
-      'on': 'scroll',
-      'scrollSpec': {
-        'verticalBoundaries': [0, 100],
-        'horizontalBoundaries': [0, 100],
-      }},
-    fn1);
-    ins.addListenerDepr_({'on': 'scroll', 'scrollSpec': {
-      'verticalBoundaries': [92], 'horizontalBoundaries': [92]}}, fn2);
-
-    function matcher(expected) {
-      return actual => {
-        return actual.vars.horizontalScrollBoundary === String(expected) ||
-          actual.vars.verticalScrollBoundary === String(expected);
-      };
-    }
-    expect(fn1).to.have.callCount(2);
-    expect(fn1.getCall(0).calledWithMatch(sinon.match(matcher(0)))).to.be.true;
-    expect(fn1.getCall(1).calledWithMatch(sinon.match(matcher(0)))).to.be.true;
-    expect(fn2).to.have.not.been.called;
-
-    // Scroll Down
-    fakeViewport.getScrollTop.returns(500);
-    fakeViewport.getScrollLeft.returns(500);
-    ins.onScroll_({top: 500, left: 500, height: 250, width: 250});
-
-    expect(fn1).to.have.callCount(4);
-    expect(fn1.getCall(2).calledWithMatch(sinon.match(matcher(100)))).to.be
-        .true;
-    expect(fn1.getCall(3).calledWithMatch(sinon.match(matcher(100)))).to.be
-        .true;
-    expect(fn2).to.have.callCount(2);
-    expect(fn2.getCall(0).calledWithMatch(sinon.match(matcher(90)))).to.be.true;
-    expect(fn2.getCall(1).calledWithMatch(sinon.match(matcher(90)))).to.be.true;
-  });
-
-  it('does not fire duplicates on scroll', () => {
-    const fn1 = sandbox.stub();
-    ins.addListenerDepr_({
-      'on': 'scroll',
-      'scrollSpec': {
-        'verticalBoundaries': [0, 100],
-        'horizontalBoundaries': [0, 100],
-      }},
-    fn1);
-
-    // Scroll Down
-    fakeViewport.getScrollTop.returns(10);
-    fakeViewport.getScrollLeft.returns(10);
-    ins.onScroll_({top: 10, left: 10, height: 250, width: 250});
-
-    expect(fn1).to.have.callCount(2);
-  });
-
-  it('fails gracefully on bad scroll config', () => {
-    const fn1 = sandbox.stub();
-
-    allowConsoleError(() => {
-      ins.addListenerDepr_({'on': 'scroll'}, fn1);
-      expect(fn1).to.have.not.been.called;
-
-      ins.addListenerDepr_({'on': 'scroll', 'scrollSpec': {}}, fn1);
-      expect(fn1).to.have.not.been.called;
-
-      ins.addListenerDepr_({
-        'on': 'scroll',
-        'scrollSpec': {
-          'verticalBoundaries': undefined, 'horizontalBoundaries': undefined,
-        }},
-      fn1);
-      expect(fn1).to.have.not.been.called;
-
-      ins.addListenerDepr_({
-        'on': 'scroll',
-        'scrollSpec': {'verticalBoundaries': [], 'horizontalBoundaries': []}},
-      fn1);
-      expect(fn1).to.have.not.been.called;
-
-      ins.addListenerDepr_({
-        'on': 'scroll',
-        'scrollSpec': {
-          'verticalBoundaries': ['foo'], 'horizontalBoundaries': ['foo'],
-        }},
-      fn1);
-      expect(fn1).to.have.not.been.called;
-    });
-  });
-
-  it('normalizes boundaries correctly.', () => {
-    allowConsoleError(() => {
-      expect(ins.normalizeBoundaries_([])).to.be.empty;
-      expect(ins.normalizeBoundaries_(undefined)).to.be.empty;
-      expect(ins.normalizeBoundaries_(['foo'])).to.be.empty;
-      expect(ins.normalizeBoundaries_(['0', '1'])).to.be.empty;
-    });
-    expect(ins.normalizeBoundaries_([1])).to.deep.equal({0: false});
-    expect(ins.normalizeBoundaries_([1, 4, 99, 1001])).to.deep.equal({
-      0: false,
-      5: false,
-      100: false,
-    });
-  });
-
-  it('fires events on normalized boundaries.', () => {
-    const fn1 = sandbox.stub();
-    const fn2 = sandbox.stub();
-    ins.addListenerDepr_(
-        {'on': 'scroll', 'scrollSpec': {'verticalBoundaries': [1]}},
-        fn1);
-    ins.addListenerDepr_(
-        {'on': 'scroll', 'scrollSpec': {'verticalBoundaries': [4]}},
-        fn2);
-    expect(fn2).to.be.calledOnce;
-  });
-
-
-  describe('isTriggerAllowed_', () => {
-    let el;
-    beforeEach(() => {
-      ins.isTriggerAllowed_.restore();
-    });
-
-    it('allows all triggers for top level window', () => {
-      el = document.createElement('amp-analytics');
-      document.body.appendChild(el);
-
-      expect(ins.isTriggerAllowed_(AnalyticsEventType.VISIBLE, el)).to.be.true;
-      expect(ins.isTriggerAllowed_(AnalyticsEventType.CLICK, el)).to.be.true;
-      expect(ins.isTriggerAllowed_(AnalyticsEventType.TIMER, el)).to.be.true;
-      expect(ins.isTriggerAllowed_(AnalyticsEventType.SCROLL, el)).to.be.true;
-      expect(ins.isTriggerAllowed_(AnalyticsEventType.HIDDEN, el)).to.be.true;
-    });
-
-    it('allows some trigger', () => {
-      const iframe = document.createElement('iframe');
-      document.body.appendChild(iframe);
-      el = document.createElement('foo'); // dummy element as amp-analytics can't be used in iframe.
-      iframe.contentWindow.document.body.appendChild(el);
-      expect(ins.isTriggerAllowed_(AnalyticsEventType.VISIBLE, el)).to.be.true;
-      expect(ins.isTriggerAllowed_(AnalyticsEventType.CLICK, el)).to.be.true;
-      expect(ins.isTriggerAllowed_(AnalyticsEventType.TIMER, el)).to.be.true;
-      expect(ins.isTriggerAllowed_(AnalyticsEventType.HIDDEN, el)).to.be.true;
-    });
-
-
-    it('disallows scroll trigger', () => {
-      const iframe = document.createElement('iframe');
-      document.body.appendChild(iframe);
-      el = document.createElement('foo'); // dummy element as amp-analytics can't be used in iframe.
-      iframe.contentWindow.document.body.appendChild(el);
-
-      expect(ins.isTriggerAllowed_(AnalyticsEventType.SCROLL, el)).to.be.false;
-      expect(ins.isTriggerAllowed_('custom-trigger', el)).to.be.false;
-    });
-  });
-});

--- a/extensions/amp-analytics/0.1/test/test-scroll-manager.js
+++ b/extensions/amp-analytics/0.1/test/test-scroll-manager.js
@@ -77,18 +77,18 @@ describes.realWin('ScrollManager', {amp: 1}, env => {
 
   it('should add a viewport onChanged listener with scroll handlers, '
     + 'and dispose when there are none', () => {
-      expect(scrollManager.viewportOnChangedUnlistenDef_).to.not.be.ok;
-      
-      const fn1 = sandbox.stub()
-      scrollManager.addScrollHandler(fn1);
+    expect(scrollManager.viewportOnChangedUnlistenDef_).to.not.be.ok;
 
-      expect(scrollManager.viewportOnChangedUnlistenDef_).to.be.ok;
-      const unlistenStub = scrollManager.viewportOnChangedUnlistenDef_;
+    const fn1 = sandbox.stub();
+    scrollManager.addScrollHandler(fn1);
 
-      scrollManager.removeScrollHandler(fn1);
+    expect(scrollManager.viewportOnChangedUnlistenDef_).to.be.ok;
+    const unlistenStub = scrollManager.viewportOnChangedUnlistenDef_;
 
-      expect(scrollManager.viewportOnChangedUnlistenDef_).to.not.be.ok;
-      expect(unlistenStub).to.have.callCount(1);
+    scrollManager.removeScrollHandler(fn1);
+
+    expect(scrollManager.viewportOnChangedUnlistenDef_).to.not.be.ok;
+    expect(unlistenStub).to.have.callCount(1);
   });
 
   it('fires on scroll', () => {

--- a/extensions/amp-analytics/0.1/test/test-scroll-manager.js
+++ b/extensions/amp-analytics/0.1/test/test-scroll-manager.js
@@ -21,25 +21,15 @@ import {ScrollManager} from '../scroll-manager';
 describes.realWin('ScrollManager', {amp: 1}, env => {
   let win;
   let ampdoc;
-  let resources, viewport;
   let root;
   let body, target, child, other;
 
   let scrollManager;
   let fakeViewport;
-  const defaultScrollConfig = {
-    'on': 'scroll',
-    'scrollSpec': {
-      'verticalBoundaries': [0, 100],
-      'horizontalBoundaries': [0, 100],
-    },
-  };
 
   beforeEach(() => {
     win = env.win;
     ampdoc = env.ampdoc;
-    resources = win.services.resources.obj;
-    viewport = win.services.viewport.obj;
     root = new AmpdocAnalyticsRoot(ampdoc);
     body = win.document.body;
 
@@ -58,10 +48,11 @@ describes.realWin('ScrollManager', {amp: 1}, env => {
     other.className = 'other';
     body.appendChild(other);
 
-    scrollManager = root.getScrollManager();
+    scrollManager = new ScrollManager(ampdoc);
+    root.scrollManager_ = scrollManager;
     fakeViewport = {
       'getSize': sandbox.stub().returns(
-        {top: 0, left: 0, height: 200, width: 200}),
+          {top: 0, left: 0, height: 200, width: 200}),
       'getScrollTop': sandbox.stub().returns(0),
       'getScrollLeft': sandbox.stub().returns(0),
       'getScrollHeight': sandbox.stub().returns(500),
@@ -100,5 +91,24 @@ describes.realWin('ScrollManager', {amp: 1}, env => {
     expect(fn2).to.have.callCount(2);
   });
 
-  
+  it('can remove specifc handlers', () => {
+    const fn1 = sandbox.stub();
+    const fn2 = sandbox.stub();
+    scrollManager.addScrollHandler(fn1);
+    scrollManager.addScrollHandler(fn2);
+
+    expect(fn1).to.have.callCount(1);
+    expect(fn2).to.have.callCount(1);
+
+    scrollManager.removeScrollHandler(fn2);
+
+    // Scroll Down
+    fakeViewport.getScrollTop.returns(500);
+    fakeViewport.getScrollLeft.returns(500);
+    scrollManager.onScroll_({top: 500, left: 500, height: 250, width: 250});
+
+
+    expect(fn1).to.have.callCount(2);
+    expect(fn2).to.have.callCount(1);
+  });
 });

--- a/extensions/amp-analytics/0.1/test/test-scroll-manager.js
+++ b/extensions/amp-analytics/0.1/test/test-scroll-manager.js
@@ -104,8 +104,36 @@ describes.realWin('ScrollManager', {amp: 1}, env => {
     fakeViewport.getScrollLeft.returns(500);
     scrollManager.onScroll_({top: 500, left: 500, height: 250, width: 250});
 
+    const expectedScrollEvent = {
+      top: 500,
+      left: 500,
+      height: 250,
+      width: 250,
+      scrollWidth: 500,
+      scrollHeight: 500,
+    };
+
+    function matcher(expected) {
+      return actual => {
+        // Returns true if all of the object keys have the same value
+        return !Object.keys(actual).some(key => {
+          return actual[key] !== expected[key];
+        });
+      };
+    }
+
     expect(fn1).to.have.callCount(2);
+    expect(
+        fn1.getCall(1)
+            .calledWithMatch(sinon.match(matcher(expectedScrollEvent)))
+    ).to.be.true;
+
     expect(fn2).to.have.callCount(2);
+    expect(
+        fn2.getCall(1)
+            .calledWithMatch(sinon.match(matcher(expectedScrollEvent)))
+    ).to.be.true;
+
   });
 
   it('can remove specifc handlers', () => {

--- a/extensions/amp-analytics/0.1/test/test-scroll-manager.js
+++ b/extensions/amp-analytics/0.1/test/test-scroll-manager.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,7 +57,9 @@ describes.realWin('ScrollManager', {amp: 1}, env => {
       'getScrollLeft': sandbox.stub().returns(0),
       'getScrollHeight': sandbox.stub().returns(500),
       'getScrollWidth': sandbox.stub().returns(500),
-      'onChanged': sandbox.stub(),
+      'onChanged': () => {
+        return sandbox.stub();
+      },
     };
     scrollManager.viewport_ = fakeViewport;
 
@@ -71,6 +73,22 @@ describes.realWin('ScrollManager', {amp: 1}, env => {
 
     scrollManager.dispose();
     expect(scrollManager.scrollObservable_.getHandlerCount()).to.equal(0);
+  });
+
+  it('should add a viewport onChanged listener with scroll handlers, '
+    + 'and dispose when there are none', () => {
+      expect(scrollManager.viewportOnChangedUnlistenDef_).to.not.be.ok;
+      
+      const fn1 = sandbox.stub()
+      scrollManager.addScrollHandler(fn1);
+
+      expect(scrollManager.viewportOnChangedUnlistenDef_).to.be.ok;
+      const unlistenStub = scrollManager.viewportOnChangedUnlistenDef_;
+
+      scrollManager.removeScrollHandler(fn1);
+
+      expect(scrollManager.viewportOnChangedUnlistenDef_).to.not.be.ok;
+      expect(unlistenStub).to.have.callCount(1);
   });
 
   it('fires on scroll', () => {

--- a/extensions/amp-analytics/0.1/test/test-scroll-manager.js
+++ b/extensions/amp-analytics/0.1/test/test-scroll-manager.js
@@ -23,7 +23,6 @@ describes.realWin('ScrollManager', {amp: 1}, env => {
   let ampdoc;
   let root;
   let body, target, child, other;
-
   let scrollManager;
   let fakeViewport;
 

--- a/extensions/amp-analytics/0.1/test/test-scroll-manager.js
+++ b/extensions/amp-analytics/0.1/test/test-scroll-manager.js
@@ -77,17 +77,17 @@ describes.realWin('ScrollManager', {amp: 1}, env => {
 
   it('should add a viewport onChanged listener with scroll handlers, '
     + 'and dispose when there are none', () => {
-    expect(scrollManager.viewportOnChangedUnlistenDef_).to.not.be.ok;
+    expect(scrollManager.viewportOnChangedUnlistener_).to.not.be.ok;
 
     const fn1 = sandbox.stub();
     scrollManager.addScrollHandler(fn1);
 
-    expect(scrollManager.viewportOnChangedUnlistenDef_).to.be.ok;
-    const unlistenStub = scrollManager.viewportOnChangedUnlistenDef_;
+    expect(scrollManager.viewportOnChangedUnlistener_).to.be.ok;
+    const unlistenStub = scrollManager.viewportOnChangedUnlistener_;
 
     scrollManager.removeScrollHandler(fn1);
 
-    expect(scrollManager.viewportOnChangedUnlistenDef_).to.not.be.ok;
+    expect(scrollManager.viewportOnChangedUnlistener_).to.not.be.ok;
     expect(unlistenStub).to.have.callCount(1);
   });
 


### PR DESCRIPTION
closes #12215 

This removes the old scroll listener implementation for analytics, and moved it over to the `EventTracker` design. Also, moves over the tests to match the this new design as well. And cleans up plenty of TODOs.

Asked for review from @dvoytenko since there was a lot of their TODOs I cleared out, and @zhouyx since they opened the issue and helped me with it 😄 .

# Key things to look out for

Since I don't have too much domain knowledge of the analytics extension, please be wary of these things:

1. Did I assumed the correct permissions for scroll embed ability / root type?
2. Any TODOs I missed, or code I moved into the wrong place?
3. Am I properly disposing of the listeners?
4. Should the code be restructured, as opposed as to following the old format?

Thanks!

# Screenshots

Screenshots are of tests passing, The mock server receiving scroll events at proper times from the `analytics.amp.html` example, and a screenshot of a clean console from the `analytics.amp.html` example.

![screen shot 2018-08-21 at 4 55 20 pm](https://user-images.githubusercontent.com/1448289/44435534-47390800-a565-11e8-97b9-a047f8829b27.png)
![screen shot 2018-08-21 at 4 56 00 pm](https://user-images.githubusercontent.com/1448289/44435535-47390800-a565-11e8-8070-be8606287ae0.png)
![screen shot 2018-08-21 at 5 03 32 pm](https://user-images.githubusercontent.com/1448289/44435536-47390800-a565-11e8-9d29-e251bd3b0063.png)
![screen shot 2018-08-21 at 5 04 12 pm](https://user-images.githubusercontent.com/1448289/44435537-47390800-a565-11e8-9004-e04a74e5ec21.png)
<img width="1439" alt="screen shot 2018-08-21 at 5 10 42 pm" src="https://user-images.githubusercontent.com/1448289/44435539-47d19e80-a565-11e8-9616-078055e4c758.png">
