### PR TITLE
🐛 Layers: Scrolling element scrolls like a viewport

### DIFF
--- a/build-system/tasks/bundle-size.js
+++ b/build-system/tasks/bundle-size.js
@@ -22,7 +22,7 @@ const log = require('fancy-log');
 const {getStdout} = require('../exec');
 
 const runtimeFile = './dist/v0.js';
-const maxSize = '80.9KB';
+const maxSize = '80.94KB';
 
 const {green, red, cyan, yellow} = colors;
 

--- a/src/inabox/inabox-viewport.js
+++ b/src/inabox/inabox-viewport.js
@@ -218,6 +218,11 @@ export class ViewportBindingInabox {
   }
 
   /** @override */
+  getScrollingElementScrollsLikeViewport() {
+    return true;
+  }
+
+  /** @override */
   supportsPositionFixed() {
     return false;
   }

--- a/src/service/layers-impl.js
+++ b/src/service/layers-impl.js
@@ -144,7 +144,6 @@ export class LayoutLayers {
     }));
 
     // Declare scrollingElement as the one true scrolling layer.
-    // We o
     const root = this.declareLayer_(scrollingElement, true,
         scrollingElementScrollsLikeViewport);
 

--- a/src/service/layers-impl.js
+++ b/src/service/layers-impl.js
@@ -102,8 +102,9 @@ export class LayoutLayers {
   /**
    * @param {!./ampdoc-impl.AmpDoc} ampdoc
    * @param {!Element} scrollingElement
+   * @param {boolean} scrollingElementScrollsLikeViewport
    */
-  constructor(ampdoc, scrollingElement) {
+  constructor(ampdoc, scrollingElement, scrollingElementScrollsLikeViewport) {
     const {win} = ampdoc;
 
     /** @const @private {!Element} */
@@ -143,7 +144,9 @@ export class LayoutLayers {
     }));
 
     // Declare scrollingElement as the one true scrolling layer.
-    const root = this.declareLayer_(scrollingElement, true);
+    // We o
+    const root = this.declareLayer_(scrollingElement, true,
+        scrollingElementScrollsLikeViewport);
 
     /**
      * Stores the most recently scrolled layer.
@@ -287,7 +290,7 @@ export class LayoutLayers {
    * @param {!Element} element
    */
   declareLayer(element) {
-    this.declareLayer_(element, false);
+    this.declareLayer_(element, false, false);
   }
 
   /**
@@ -308,11 +311,12 @@ export class LayoutLayers {
    *
    * @param {!Element} element
    * @param {boolean} isRootLayer
+   * @param {boolean} scrollsLikeViewport
    * @return {!LayoutElement}
    */
-  declareLayer_(element, isRootLayer) {
+  declareLayer_(element, isRootLayer, scrollsLikeViewport) {
     const layout = this.add(element);
-    layout.declareLayer(isRootLayer);
+    layout.declareLayer(isRootLayer, scrollsLikeViewport);
     return layout;
   }
 
@@ -468,15 +472,22 @@ export class LayoutElement {
     this.isLayer_ = false;
 
     /**
-     * Whether the layer is a "root" scrolling layer. Root scrollers have
-     * special properties, mainly that they can never be un-declared (they will
-     * always exist) and that their offset positions are not defined by
-     * scrollTop (DOM APIs are inconsistent between a root scroller and an
-     * overflow scroller).
+     * Whether the layer is a "root" scrolling layer. Root scrollers can never
+     * be un-declared (they will always exist).
      *
      * @private {boolean}
      */
     this.isRootLayer_ = false;
+
+    /**
+     * Whether the layer scrolls like a viewport. Native scrolling elements
+     * have special scrolling inconsistencies. When you scroll one of these
+     * special scrollers, its relative top (returned by getBoundingClientRect)
+     * changes. This is different than regular overflow scrollers.
+     *
+     * @private {boolean}
+     */
+    this.scrollsLikeViewport_ = false;
 
     /**
      * Whether this layer needs to remeasure its scrollTop/Left position during
@@ -650,13 +661,19 @@ export class LayoutElement {
    * for child elements.
    *
    * @param {boolean} isRootLayer
+   * @param {boolean} scrollsLikeViewport
    */
-  declareLayer(isRootLayer) {
+  declareLayer(isRootLayer, scrollsLikeViewport) {
+    dev().assert(!scrollsLikeViewport || isRootLayer, 'Only root layers may' +
+      ' scroll like a viewport.');
+
     if (this.isLayer_) {
       return;
     }
     this.isLayer_ = true;
     this.isRootLayer_ = isRootLayer;
+    this.scrollsLikeViewport_ = scrollsLikeViewport;
+
 
     // Ensure the coordinate system is remeasured
     this.needsRemeasure_ = true;
@@ -1077,10 +1094,10 @@ export class LayoutElement {
     this.size_ = sizeWh(element./*OK*/clientWidth, element./*OK*/clientHeight);
 
     let {left, top} = element./*OK*/getBoundingClientRect();
-    // Root layers are really screwed up. Their positions will **double** count
-    // their scroll position (left === -scrollLeft, top === -scrollTop), which
-    // breaks with every other scroll box on the page.
-    if (this.isRootLayer_) {
+    // Viewport scroller layers are really screwed up. Their positions will
+    // **double** count their scroll position (left === -scrollLeft, top ===
+    // -scrollTop), which breaks with every other scroll box on the page.
+    if (this.scrollsLikeViewport_) {
       left += this.getScrollLeft();
       top += this.getScrollTop();
     }
@@ -1141,9 +1158,12 @@ function relativeScrolledPositionForChildren(layer) {
 /**
  * @param {!./ampdoc-impl.AmpDoc} ampdoc
  * @param {!Element} scrollingElement
+ * @param {boolean} scrollingElementScrollsLikeViewport
  */
-export function installLayersServiceForDoc(ampdoc, scrollingElement) {
+export function installLayersServiceForDoc(ampdoc, scrollingElement,
+  scrollingElementScrollsLikeViewport) {
   registerServiceBuilderForDoc(ampdoc, 'layers', function(ampdoc) {
-    return new LayoutLayers(ampdoc, scrollingElement);
+    return new LayoutLayers(ampdoc, scrollingElement,
+        scrollingElementScrollsLikeViewport);
   }, /* opt_instantiate */ true);
 }

--- a/src/service/layers-impl.js
+++ b/src/service/layers-impl.js
@@ -349,7 +349,7 @@ export class LayoutLayers {
     if (layer && layer.isLayer()) {
       layer.dirtyScrollMeasurements();
     } else {
-      layer = this.declareLayer_(element, false);
+      layer = this.declareLayer_(element, false, false);
     }
 
     this.activeLayer_ = layer;

--- a/src/service/viewport/viewport-binding-def.js
+++ b/src/service/viewport/viewport-binding-def.js
@@ -178,4 +178,11 @@ export class ViewportBindingDef {
    * @return {!Element}
    */
   getScrollingElement() {}
+
+  /**
+   * Whether the root scroller is a native root scroller (behaves like a
+   * viewport), or an overflow scroller (scrolls like an element).
+   * @return {!boolean}
+   */
+  getScrollingElementScrollsLikeViewport() {}
 }

--- a/src/service/viewport/viewport-binding-def.js
+++ b/src/service/viewport/viewport-binding-def.js
@@ -182,7 +182,7 @@ export class ViewportBindingDef {
   /**
    * Whether the root scroller is a native root scroller (behaves like a
    * viewport), or an overflow scroller (scrolls like an element).
-   * @return {!boolean}
+   * @return {boolean}
    */
   getScrollingElementScrollsLikeViewport() {}
 }

--- a/src/service/viewport/viewport-binding-ios-embed-sd.js
+++ b/src/service/viewport/viewport-binding-ios-embed-sd.js
@@ -447,4 +447,9 @@ export class ViewportBindingIosEmbedShadowRoot_ {
   getScrollingElement() {
     return this.scroller_;
   }
+
+  /** @override */
+  getScrollingElementScrollsLikeViewport() {
+    return false;
+  }
 }

--- a/src/service/viewport/viewport-binding-ios-embed-wrapper.js
+++ b/src/service/viewport/viewport-binding-ios-embed-wrapper.js
@@ -293,4 +293,9 @@ export class ViewportBindingIosEmbedWrapper_ {
   getScrollingElement() {
     return this.wrapper_;
   }
+
+  /** @override */
+  getScrollingElementScrollsLikeViewport() {
+    return false;
+  }
 }

--- a/src/service/viewport/viewport-binding-natural.js
+++ b/src/service/viewport/viewport-binding-natural.js
@@ -251,4 +251,9 @@ export class ViewportBindingNatural_ {
     }
     return doc.documentElement;
   }
+
+  /** @override */
+  getScrollingElementScrollsLikeViewport() {
+    return true;
+  }
 }

--- a/src/service/viewport/viewport-impl.js
+++ b/src/service/viewport/viewport-impl.js
@@ -161,7 +161,8 @@ export class Viewport {
     this.useLayers_ = isExperimentOn(this.ampdoc.win, 'layers');
     if (this.useLayers_) {
       installLayersServiceForDoc(this.ampdoc,
-          this.binding_.getScrollingElement());
+          this.binding_.getScrollingElement(),
+          this.binding_.getScrollingElementScrollsLikeViewport());
     }
 
     /** @private @const {!FixedLayer} */

--- a/test/functional/test-layers.js
+++ b/test/functional/test-layers.js
@@ -21,366 +21,376 @@ import {
 import {Services} from '../../src/services';
 import {installDocService} from '../../src/service/ampdoc-impl';
 
-describes.realWin('Layers', {amp: false}, env => {
-  let win;
-  let root;
+describes.repeated('messaging', {
+  'Real document scroller': true,
+  'Overflow scroller': false,
+}, (name, useDocumentScroller) => {
+  describes.realWin(`Layers (${name})`, {amp: false}, env => {
+    let win;
+    let root;
 
-  function createElement() {
-    const div = win.document.createElement('div');
-    Object.defineProperty(div, 'isConnected', {
-      value: true,
-    });
-    return div;
-  }
-
-  beforeEach(() => {
-    win = env.win;
-    root = win.document.scrollingElement;
-    installDocService(win, true);
-    const ampdoc = Services.ampdocServiceFor(win).getAmpDoc();
-    installLayersServiceForDoc(ampdoc, root);
-  });
-
-  function scroll(element, top, left) {
-    element.scrollTop = top;
-    element.scrollLeft = left;
-    const layout = LayoutElement.for(element);
-    layout.dirtyScrollMeasurements();
-  }
-
-  describe('LayoutElement', () => {
-
-    describe('.getParentLayer', () => {
-      it('returns null for root layer', () => {
-        expect(LayoutElement.getParentLayer(root)).to.be.null;
+    function createElement() {
+      const div = win.document.createElement('div');
+      Object.defineProperty(div, 'isConnected', {
+        value: true,
       });
+      return div;
+    }
 
-      it('returns parent layer', () => {
-        const div = createElement();
-        root.appendChild(div);
-
-        expect(LayoutElement.getParentLayer(div)).to.equal(
-            LayoutElement.for(root));
-      });
-
-      it('returns null if element is fixed', () => {
-        const div = createElement();
-        root.appendChild(div);
-
-        div.style.position = 'fixed';
-        expect(LayoutElement.getParentLayer(div)).to.be.null;
-      });
-
-      it('returns parent if parent element is fixed', () => {
-        const parent = createElement();
-        const div = createElement();
-        parent.appendChild(div);
-        root.appendChild(parent);
-
-        parent.style.position = 'fixed';
-        const layer = LayoutElement.getParentLayer(div);
-        expect(layer).to.equal(LayoutElement.for(parent));
-      });
+    beforeEach(() => {
+      win = env.win;
+      if (useDocumentScroller) {
+        root = win.document.scrollingElement;
+      } else {
+        root = createElement();
+        win.document.body.appendChild(root);
+      }
+      installDocService(win, true);
+      const ampdoc = Services.ampdocServiceFor(win).getAmpDoc();
+      installLayersServiceForDoc(ampdoc, root, useDocumentScroller);
     });
 
-    describe('#getScrolledPosition', () => {
-      let parent;
-      let div;
-      let layout;
-      let parentLayout;
-      let rootLayout;
-      beforeEach(() => {
-        parent = createElement();
-        div = createElement();
-        parent.appendChild(div);
-        root.appendChild(parent);
+    function scroll(element, top, left) {
+      element.scrollTop = top;
+      element.scrollLeft = left;
+      const layout = LayoutElement.for(element);
+      layout.dirtyScrollMeasurements();
+    }
 
-        root.style.width = '100vw';
-        root.style.height = '100vh';
-        root.style.position = 'absolute';
-        root.style.overflow = 'scroll';
-        parent.style.width = '110vw';
-        parent.style.height = '110vh';
-        parent.style.position = 'absolute';
-        parent.style.overflow = 'scroll';
-        div.style.width = '120vw';
-        div.style.height = '120vh';
-        div.style.position = 'absolute';
-        div.style.overflow = 'scroll';
+    describe('LayoutElement', () => {
 
-        const layers = Services.layersForDoc(parent);
-        layers.declareLayer(parent);
-        layers.add(div);
-        layout = LayoutElement.for(div);
-        parentLayout = LayoutElement.for(parent);
-        rootLayout = LayoutElement.for(root);
-      });
-
-      it('calculates layout offsets without scrolls', () => {
-        expect(layout.getScrolledPosition()).to.deep.equal({
-          left: 0,
-          top: 0,
+      describe('.getParentLayer', () => {
+        it('returns null for root layer', () => {
+          expect(LayoutElement.getParentLayer(root)).to.be.null;
         });
 
-        div.style.top = '10px';
-        rootLayout.dirtyMeasurements();
-        expect(layout.getScrolledPosition()).to.deep.equal({
-          left: 0,
-          top: 10,
+        it('returns parent layer', () => {
+          const div = createElement();
+          root.appendChild(div);
+
+          expect(LayoutElement.getParentLayer(div)).to.equal(
+              LayoutElement.for(root));
         });
 
-        div.style.left = '10px';
-        rootLayout.dirtyMeasurements();
-        expect(layout.getScrolledPosition()).to.deep.equal({
-          left: 10,
-          top: 10,
+        it('returns null if element is fixed', () => {
+          const div = createElement();
+          root.appendChild(div);
+
+          div.style.position = 'fixed';
+          expect(LayoutElement.getParentLayer(div)).to.be.null;
+        });
+
+        it('returns parent if parent element is fixed', () => {
+          const parent = createElement();
+          const div = createElement();
+          parent.appendChild(div);
+          root.appendChild(parent);
+
+          parent.style.position = 'fixed';
+          const layer = LayoutElement.getParentLayer(div);
+          expect(layer).to.equal(LayoutElement.for(parent));
         });
       });
 
-      it('calculates parent offsets without scrolls', () => {
-        expect(layout.getScrolledPosition()).to.deep.equal({
-          left: 0,
-          top: 0,
+      describe('#getScrolledPosition', () => {
+        let parent;
+        let div;
+        let layout;
+        let parentLayout;
+        let rootLayout;
+        beforeEach(() => {
+          parent = createElement();
+          div = createElement();
+          parent.appendChild(div);
+          root.appendChild(parent);
+
+          root.style.width = '100vw';
+          root.style.height = '100vh';
+          root.style.position = 'absolute';
+          root.style.overflow = 'scroll';
+          parent.style.width = '110vw';
+          parent.style.height = '110vh';
+          parent.style.position = 'absolute';
+          parent.style.overflow = 'scroll';
+          div.style.width = '120vw';
+          div.style.height = '120vh';
+          div.style.position = 'absolute';
+          div.style.overflow = 'scroll';
+
+          const layers = Services.layersForDoc(parent);
+          layers.declareLayer(parent);
+          layers.add(div);
+          layout = LayoutElement.for(div);
+          parentLayout = LayoutElement.for(parent);
+          rootLayout = LayoutElement.for(root);
         });
 
-        parent.style.top = '10px';
-        rootLayout.dirtyMeasurements();
-        expect(layout.getScrolledPosition()).to.deep.equal({
-          left: 0,
-          top: 10,
+        it('calculates layout offsets without scrolls', () => {
+          expect(layout.getScrolledPosition()).to.deep.equal({
+            left: 0,
+            top: 0,
+          });
+
+          div.style.top = '10px';
+          rootLayout.dirtyMeasurements();
+          expect(layout.getScrolledPosition()).to.deep.equal({
+            left: 0,
+            top: 10,
+          });
+
+          div.style.left = '10px';
+          rootLayout.dirtyMeasurements();
+          expect(layout.getScrolledPosition()).to.deep.equal({
+            left: 10,
+            top: 10,
+          });
         });
 
-        parent.style.left = '10px';
-        rootLayout.dirtyMeasurements();
-        expect(layout.getScrolledPosition()).to.deep.equal({
-          left: 10,
-          top: 10,
+        it('calculates parent offsets without scrolls', () => {
+          expect(layout.getScrolledPosition()).to.deep.equal({
+            left: 0,
+            top: 0,
+          });
+
+          parent.style.top = '10px';
+          rootLayout.dirtyMeasurements();
+          expect(layout.getScrolledPosition()).to.deep.equal({
+            left: 0,
+            top: 10,
+          });
+
+          parent.style.left = '10px';
+          rootLayout.dirtyMeasurements();
+          expect(layout.getScrolledPosition()).to.deep.equal({
+            left: 10,
+            top: 10,
+          });
+        });
+
+        it('calculates parent and offsets without scrolls', () => {
+          expect(layout.getScrolledPosition()).to.deep.equal({
+            left: 0,
+            top: 0,
+          });
+
+          parent.style.top = '10px';
+          div.style.left = '10px';
+          rootLayout.dirtyMeasurements();
+          expect(layout.getScrolledPosition()).to.deep.equal({
+            left: 10,
+            top: 10,
+          });
+
+          parent.style.left = '10px';
+          div.style.top = '10px';
+          rootLayout.dirtyMeasurements();
+          expect(layout.getScrolledPosition()).to.deep.equal({
+            left: 20,
+            top: 20,
+          });
+        });
+
+        it('does not change when layout itself scrolls', function*() {
+          scroll(parent, 10, 0);
+          expect(parentLayout.getScrollTop()).to.equal(10);
+          expect(parentLayout.getScrolledPosition()).to.deep.equal({
+            left: 0,
+            top: 0,
+          });
+          rootLayout.dirtyMeasurements();
+          expect(parentLayout.getScrolledPosition()).to.deep.equal({
+            left: 0,
+            top: 0,
+          });
+
+          scroll(root, 10, 0);
+          expect(rootLayout.getScrollTop()).to.equal(10);
+          expect(rootLayout.getScrolledPosition()).to.deep.equal({
+            left: 0,
+            top: 0,
+          });
+          rootLayout.dirtyMeasurements();
+          expect(rootLayout.getScrolledPosition()).to.deep.equal({
+            left: 0,
+            top: 0,
+          });
+        });
+
+        it('updates as parent layers scroll', () => {
+          scroll(parent, 10, 5);
+          expect(parentLayout.getScrollTop()).to.equal(10);
+          expect(layout.getScrolledPosition()).to.deep.equal({
+            left: -5,
+            top: -10,
+          });
+          rootLayout.dirtyMeasurements();
+          expect(layout.getScrolledPosition()).to.deep.equal({
+            left: -5,
+            top: -10,
+          });
+
+          scroll(root, 10, 5);
+          expect(rootLayout.getScrollTop()).to.equal(10);
+          expect(layout.getScrolledPosition()).to.deep.equal({
+            left: -10,
+            top: -20,
+          });
+          rootLayout.dirtyMeasurements();
+          expect(layout.getScrolledPosition()).to.deep.equal({
+            left: -10,
+            top: -20,
+          });
         });
       });
 
-      it('calculates parent and offsets without scrolls', () => {
-        expect(layout.getScrolledPosition()).to.deep.equal({
-          left: 0,
-          top: 0,
+      describe('#getOffsetPosition', () => {
+        let parent;
+        let div;
+        let layout;
+        let parentLayout;
+        let rootLayout;
+        beforeEach(() => {
+          parent = createElement();
+          div = createElement();
+          parent.appendChild(div);
+          root.appendChild(parent);
+
+          root.style.width = '100vw';
+          root.style.height = '100vh';
+          root.style.position = 'absolute';
+          root.style.overflow = 'scroll';
+          parent.style.width = '110vw';
+          parent.style.height = '110vh';
+          parent.style.position = 'absolute';
+          parent.style.overflow = 'scroll';
+          div.style.width = '120vw';
+          div.style.height = '120vh';
+          div.style.position = 'absolute';
+          div.style.overflow = 'scroll';
+
+          const layers = Services.layersForDoc(parent);
+          layers.declareLayer(parent);
+          layers.add(div);
+          layout = LayoutElement.for(div);
+          parentLayout = LayoutElement.for(parent);
+          rootLayout = LayoutElement.for(root);
         });
 
-        parent.style.top = '10px';
-        div.style.left = '10px';
-        rootLayout.dirtyMeasurements();
-        expect(layout.getScrolledPosition()).to.deep.equal({
-          left: 10,
-          top: 10,
+        it('calculates layout offsets without scrolls', () => {
+          expect(layout.getOffsetPosition()).to.deep.equal({
+            left: 0,
+            top: 0,
+          });
+
+          div.style.top = '10px';
+          rootLayout.dirtyMeasurements();
+          expect(layout.getOffsetPosition()).to.deep.equal({
+            left: 0,
+            top: 10,
+          });
+
+          div.style.left = '10px';
+          rootLayout.dirtyMeasurements();
+          expect(layout.getOffsetPosition()).to.deep.equal({
+            left: 10,
+            top: 10,
+          });
         });
 
-        parent.style.left = '10px';
-        div.style.top = '10px';
-        rootLayout.dirtyMeasurements();
-        expect(layout.getScrolledPosition()).to.deep.equal({
-          left: 20,
-          top: 20,
-        });
-      });
+        it('calculates parent offsets without scrolls', () => {
+          expect(layout.getOffsetPosition()).to.deep.equal({
+            left: 0,
+            top: 0,
+          });
 
-      it('does not change when layout itself scrolls', function*() {
-        scroll(parent, 10, 0);
-        expect(parentLayout.getScrollTop()).to.equal(10);
-        expect(parentLayout.getScrolledPosition()).to.deep.equal({
-          left: 0,
-          top: 0,
-        });
-        rootLayout.dirtyMeasurements();
-        expect(parentLayout.getScrolledPosition()).to.deep.equal({
-          left: 0,
-          top: 0,
-        });
+          parent.style.top = '10px';
+          rootLayout.dirtyMeasurements();
+          expect(layout.getOffsetPosition()).to.deep.equal({
+            left: 0,
+            top: 10,
+          });
 
-        scroll(root, 10, 0);
-        expect(rootLayout.getScrollTop()).to.equal(10);
-        expect(rootLayout.getScrolledPosition()).to.deep.equal({
-          left: 0,
-          top: 0,
-        });
-        rootLayout.dirtyMeasurements();
-        expect(rootLayout.getScrolledPosition()).to.deep.equal({
-          left: 0,
-          top: 0,
-        });
-      });
-
-      it('updates as parent layers scroll', () => {
-        scroll(parent, 10, 5);
-        expect(parentLayout.getScrollTop()).to.equal(10);
-        expect(layout.getScrolledPosition()).to.deep.equal({
-          left: -5,
-          top: -10,
-        });
-        rootLayout.dirtyMeasurements();
-        expect(layout.getScrolledPosition()).to.deep.equal({
-          left: -5,
-          top: -10,
+          parent.style.left = '10px';
+          rootLayout.dirtyMeasurements();
+          expect(layout.getOffsetPosition()).to.deep.equal({
+            left: 10,
+            top: 10,
+          });
         });
 
-        scroll(root, 10, 5);
-        expect(rootLayout.getScrollTop()).to.equal(10);
-        expect(layout.getScrolledPosition()).to.deep.equal({
-          left: -10,
-          top: -20,
-        });
-        rootLayout.dirtyMeasurements();
-        expect(layout.getScrolledPosition()).to.deep.equal({
-          left: -10,
-          top: -20,
-        });
-      });
-    });
+        it('calculates parent and offsets without scrolls', () => {
+          expect(layout.getOffsetPosition()).to.deep.equal({
+            left: 0,
+            top: 0,
+          });
 
-    describe('#getOffsetPosition', () => {
-      let parent;
-      let div;
-      let layout;
-      let parentLayout;
-      let rootLayout;
-      beforeEach(() => {
-        parent = createElement();
-        div = createElement();
-        parent.appendChild(div);
-        root.appendChild(parent);
+          parent.style.top = '10px';
+          div.style.left = '10px';
+          rootLayout.dirtyMeasurements();
+          expect(layout.getOffsetPosition()).to.deep.equal({
+            left: 10,
+            top: 10,
+          });
 
-        root.style.width = '100vw';
-        root.style.height = '100vh';
-        root.style.position = 'absolute';
-        root.style.overflow = 'scroll';
-        parent.style.width = '110vw';
-        parent.style.height = '110vh';
-        parent.style.position = 'absolute';
-        parent.style.overflow = 'scroll';
-        div.style.width = '120vw';
-        div.style.height = '120vh';
-        div.style.position = 'absolute';
-        div.style.overflow = 'scroll';
-
-        const layers = Services.layersForDoc(parent);
-        layers.declareLayer(parent);
-        layers.add(div);
-        layout = LayoutElement.for(div);
-        parentLayout = LayoutElement.for(parent);
-        rootLayout = LayoutElement.for(root);
-      });
-
-      it('calculates layout offsets without scrolls', () => {
-        expect(layout.getOffsetPosition()).to.deep.equal({
-          left: 0,
-          top: 0,
+          parent.style.left = '10px';
+          div.style.top = '10px';
+          rootLayout.dirtyMeasurements();
+          expect(layout.getOffsetPosition()).to.deep.equal({
+            left: 20,
+            top: 20,
+          });
         });
 
-        div.style.top = '10px';
-        rootLayout.dirtyMeasurements();
-        expect(layout.getOffsetPosition()).to.deep.equal({
-          left: 0,
-          top: 10,
+        it('does not change when layout itself scrolls', function*() {
+          scroll(parent, 10, 0);
+          expect(parentLayout.getScrollTop()).to.equal(10);
+          expect(parentLayout.getOffsetPosition()).to.deep.equal({
+            left: 0,
+            top: 0,
+          });
+          rootLayout.dirtyMeasurements();
+          expect(parentLayout.getOffsetPosition()).to.deep.equal({
+            left: 0,
+            top: 0,
+          });
+
+          scroll(root, 10, 0);
+          expect(rootLayout.getScrollTop()).to.equal(10);
+          expect(rootLayout.getOffsetPosition()).to.deep.equal({
+            left: 0,
+            top: 0,
+          });
+          rootLayout.dirtyMeasurements();
+          expect(rootLayout.getOffsetPosition()).to.deep.equal({
+            left: 0,
+            top: 0,
+          });
         });
 
-        div.style.left = '10px';
-        rootLayout.dirtyMeasurements();
-        expect(layout.getOffsetPosition()).to.deep.equal({
-          left: 10,
-          top: 10,
-        });
-      });
+        it('doe snot change when parent layers scroll', () => {
+          scroll(parent, 10, 5);
+          expect(parentLayout.getScrollTop()).to.equal(10);
+          expect(layout.getOffsetPosition()).to.deep.equal({
+            left: 0,
+            top: 0,
+          });
+          rootLayout.dirtyMeasurements();
+          expect(layout.getOffsetPosition()).to.deep.equal({
+            left: 0,
+            top: 0,
+          });
 
-      it('calculates parent offsets without scrolls', () => {
-        expect(layout.getOffsetPosition()).to.deep.equal({
-          left: 0,
-          top: 0,
-        });
-
-        parent.style.top = '10px';
-        rootLayout.dirtyMeasurements();
-        expect(layout.getOffsetPosition()).to.deep.equal({
-          left: 0,
-          top: 10,
-        });
-
-        parent.style.left = '10px';
-        rootLayout.dirtyMeasurements();
-        expect(layout.getOffsetPosition()).to.deep.equal({
-          left: 10,
-          top: 10,
-        });
-      });
-
-      it('calculates parent and offsets without scrolls', () => {
-        expect(layout.getOffsetPosition()).to.deep.equal({
-          left: 0,
-          top: 0,
-        });
-
-        parent.style.top = '10px';
-        div.style.left = '10px';
-        rootLayout.dirtyMeasurements();
-        expect(layout.getOffsetPosition()).to.deep.equal({
-          left: 10,
-          top: 10,
-        });
-
-        parent.style.left = '10px';
-        div.style.top = '10px';
-        rootLayout.dirtyMeasurements();
-        expect(layout.getOffsetPosition()).to.deep.equal({
-          left: 20,
-          top: 20,
-        });
-      });
-
-      it('does not change when layout itself scrolls', function*() {
-        scroll(parent, 10, 0);
-        expect(parentLayout.getScrollTop()).to.equal(10);
-        expect(parentLayout.getOffsetPosition()).to.deep.equal({
-          left: 0,
-          top: 0,
-        });
-        rootLayout.dirtyMeasurements();
-        expect(parentLayout.getOffsetPosition()).to.deep.equal({
-          left: 0,
-          top: 0,
-        });
-
-        scroll(root, 10, 0);
-        expect(rootLayout.getScrollTop()).to.equal(10);
-        expect(rootLayout.getOffsetPosition()).to.deep.equal({
-          left: 0,
-          top: 0,
-        });
-        rootLayout.dirtyMeasurements();
-        expect(rootLayout.getOffsetPosition()).to.deep.equal({
-          left: 0,
-          top: 0,
-        });
-      });
-
-      it('doe snot change when parent layers scroll', () => {
-        scroll(parent, 10, 5);
-        expect(parentLayout.getScrollTop()).to.equal(10);
-        expect(layout.getOffsetPosition()).to.deep.equal({
-          left: 0,
-          top: 0,
-        });
-        rootLayout.dirtyMeasurements();
-        expect(layout.getOffsetPosition()).to.deep.equal({
-          left: 0,
-          top: 0,
-        });
-
-        scroll(root, 10, 5);
-        expect(rootLayout.getScrollTop()).to.equal(10);
-        expect(layout.getOffsetPosition()).to.deep.equal({
-          left: 0,
-          top: 0,
-        });
-        rootLayout.dirtyMeasurements();
-        expect(layout.getOffsetPosition()).to.deep.equal({
-          left: 0,
-          top: 0,
+          scroll(root, 10, 5);
+          expect(rootLayout.getScrollTop()).to.equal(10);
+          expect(layout.getOffsetPosition()).to.deep.equal({
+            left: 0,
+            top: 0,
+          });
+          rootLayout.dirtyMeasurements();
+          expect(layout.getOffsetPosition()).to.deep.equal({
+            left: 0,
+            top: 0,
+          });
         });
       });
     });


### PR DESCRIPTION
I thought I had solved this with `isRootLayer`, but iOS embed viewport screws things up pretty badly. Essentially, only the native root scrollers "scroll like a viewport" (as they scroll, their relative top changes). This is inconsistent with the way overflow elements scroll, whose relative top position don't change as they scroll.

iOS Embed uses a cloned `<html>` element to do scrolling, it it doesn't scroll like a viewport. So we can't apply the double-count correction to it.