### PR TITLE
[DO NOT MERGE] WIP - Add new arrows for amp-carousel

### DIFF
--- a/examples/carousel-override.amp.html
+++ b/examples/carousel-override.amp.html
@@ -1,0 +1,210 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>AMP #0</title>
+  <link rel="canonical" href="amps.html" >
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
+  <style amp-custom>
+    body {
+      font-family: 'Questrial', Arial;
+    }
+    .amp-carousel-button-prev {
+        left: 5%;
+        background-image: url('https://lh3.googleusercontent.com/5rcQ32ml8E5ONp9f9-Rf78IofLb9QjS5_0mqsY1zEFc=w400-h300-no-n');
+    }
+    .amp-carousel-button-next {
+        left: 5%;
+        background-image: url('https://lh3.googleusercontent.com/5rcQ32ml8E5ONp9f9-Rf78IofLb9QjS5_0mqsY1zEFc=w400-h300-no-n');
+    }
+  </style>
+
+
+  <script async custom-element="amp-vine" src="https://cdn.ampproject.org/v0/amp-vine-0.1.js"></script>
+  <script async custom-element="amp-vimeo" src="https://cdn.ampproject.org/v0/amp-vimeo-0.1.js"></script>
+  <script async custom-element="amp-dailymotion" src="https://cdn.ampproject.org/v0/amp-dailymotion-0.1.js"></script>
+  <script async custom-element="amp-brightcove" src="https://cdn.ampproject.org/v0/amp-brightcove-0.1.js"></script>
+  <script async custom-element="amp-audio" src="https://cdn.ampproject.org/v0/amp-audio-0.1.js"></script>
+  <script async custom-element="amp-soundcloud" src="https://cdn.ampproject.org/v0/amp-soundcloud-0.1.js"></script>
+  <script async custom-element="amp-anim" src="https://cdn.ampproject.org/v0/amp-anim-0.1.js"></script>
+  <script async custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.1.js"></script>
+  <script async custom-element="amp-youtube" src="https://cdn.ampproject.org/v0/amp-youtube-0.1.js"></script>
+  <script async custom-element="amp-video" src="https://cdn.ampproject.org/v0/amp-video-0.1.js"></script>
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+
+    <amp-carousel
+        id="scrollable-carousel"
+        width="800"
+        height="300"
+        layout="fixed"
+        type="carousel">
+        <amp-img src="https://picsum.photos/1600/900?image=110"
+            width="400"
+            height="225"
+            aria-label="Aria labels are cool."></amp-img>
+        <amp-img src="https://picsum.photos/1600/900?image=112"
+            width="400"
+            height="225"></amp-img>
+        <amp-img src="https://picsum.photos/1600/900?image=113"
+            width="400"
+            height="225"></amp-img>
+        <amp-img src="https://picsum.photos/1600/900?image=110"
+            width="400"
+            height="225"
+            alt="a beautiful cat"></amp-img>
+        <amp-img src="https://picsum.photos/1600/900?image=112"
+            width="400"
+            height="225"></amp-img>
+        <amp-img src="https://picsum.photos/1600/900?image=113"
+            width="400"
+            height="225"></amp-img>
+    </amp-carousel>
+    <button on="tap:scrollable-carousel.goToSlide(index=0)">Go to slide 0</button>
+    <button on="tap:scrollable-carousel.goToSlide(index=3)">Go to slide 3</button>
+    <button on="tap:scrollable-carousel.goToSlide(index=5)">Go to slide 5</button>
+
+  <amp-carousel width=400 height=300 layout=responsive type=slides>
+
+    <div>hello world</div>
+
+    <amp-img src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w400-h300-no-n" layout=fill>
+    </amp-img>
+
+    <amp-img src="https://lh3.googleusercontent.com/5rcQ32ml8E5ONp9f9-Rf78IofLb9QjS5_0mqsY1zEFc=w400-h300-no-n" width=400 height=300 layout=responsive>
+    </amp-img>
+
+    <amp-img src="https://lh3.googleusercontent.com/Z4gtm5Bkxyv21Z2PtbTf95Clb9AE4VTR6olbBKYrenM=w400-h300-no-n" width=400 height=300 layout=responsive>
+    </amp-img>
+
+    <amp-soundcloud height=300
+        layout="fixed-height"
+        data-trackid="243169232">
+    </amp-soundcloud>
+
+    <amp-youtube
+        data-videoid="mGENRKrdoGY"
+        width="400" height="300">
+    </amp-youtube>
+
+    <amp-anim
+        src="https://lh3.googleusercontent.com/qNn8GDz8Jfd-s9lt3Nc4lJeLjVyEaqGJTk1vuCUWazCmAeOBVjSWDD0SMTU7x0zhVe5UzOTKR0n-kN4SXx7yElvpKYvCMaRyS_g-jydhJ_cEVYmYPiZ_j1Y9de43mlKxU6s06uK1NAlpbSkL_046amEKOdgIACICkuWfOBwlw2hUDfjPOWskeyMrcTu8XOEerCLuVqXugG31QC345hz3lUyOlkdT9fMYVUynSERGNzHba7bXMOxKRe3izS5DIWUgJs3oeKYqA-V8iqgCvneD1jj0Ff68V_ajm4BDchQubBJU0ytXVkoWh27ngeEHubpnApOS6fcGsjPxeuMjnzAUtoTsiXz2FZi1mMrxrblJ-kZoAq1DJ95cnoqoa2CYq3BTgq2E8BRe2paNxLJ5GXBCTpNdXMpVJc6eD7ceijQyn-2qanilX-iK3ChbOq0uBHMvsdoC_LsFOu5KzbbNH71vM3DPkvDGmHJmF67Vj8sQ6uBrLnzpYlCyN4-Y9frR8zugDcqX5Q=w400-h300-no"
+        width="400" height="300">
+      <amp-img placeholder
+          src="https://lh3.googleusercontent.com/qNn8GDz8Jfd-s9lt3Nc4lJeLjVyEaqGJTk1vuCUWazCmAeOBVjSWDD0SMTU7x0zhVe5UzOTKR0n-kN4SXx7yElvpKYvCMaRyS_g-jydhJ_cEVYmYPiZ_j1Y9de43mlKxU6s06uK1NAlpbSkL_046amEKOdgIACICkuWfOBwlw2hUDfjPOWskeyMrcTu8XOEerCLuVqXugG31QC345hz3lUyOlkdT9fMYVUynSERGNzHba7bXMOxKRe3izS5DIWUgJs3oeKYqA-V8iqgCvneD1jj0Ff68V_ajm4BDchQubBJU0ytXVkoWh27ngeEHubpnApOS6fcGsjPxeuMjnzAUtoTsiXz2FZi1mMrxrblJ-kZoAq1DJ95cnoqoa2CYq3BTgq2E8BRe2paNxLJ5GXBCTpNdXMpVJc6eD7ceijQyn-2qanilX-iK3ChbOq0uBHMvsdoC_LsFOu5KzbbNH71vM3DPkvDGmHJmF67Vj8sQ6uBrLnzpYlCyN4-Y9frR8zugDcqX5Q=w400-h300-no-k"
+          width="400" height="300">
+        </amp-img>
+    </amp-anim>
+
+    <amp-audio src="/examples/av/audio.mp3">
+    </amp-audio>
+
+    <amp-brightcove
+        data-account="1290862519001"
+        data-video-id="ref:amp-docs-sample"
+        data-player="SyIOV8yWM"
+        layout="responsive" width="480" height="270">
+    </amp-brightcove>
+
+    <amp-vimeo
+        data-videoid="27246366"
+        width="500"
+        height="281">
+    </amp-vimeo>
+
+    <amp-dailymotion
+        data-videoid="x3rdtfy"
+        width="500"
+        height="281">
+    </amp-dailymotion>
+
+    <amp-vine
+        data-vineid="MdKjXez002d"
+        width="381"
+        height="381"
+        layout="responsive">
+    </amp-vine>
+
+    <amp-video
+        src="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4"
+        width="358"
+        height="204"
+        layout="responsive"
+        controls>
+    </amp-video>
+
+  </amp-carousel>
+
+  <amp-carousel width=auto height=300 data-next-button-aria-label="Go to next slide" data-previous-button-aria-label="Go to previous slide" controls>
+
+    <div>hello world</div>
+
+    <amp-img src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w400-h300-no-n" width=400 height=300>
+    </amp-img>
+
+    <amp-img src="https://lh3.googleusercontent.com/5rcQ32ml8E5ONp9f9-Rf78IofLb9QjS5_0mqsY1zEFc=w400-h300-no-n" width=400 height=300>
+    </amp-img>
+
+    <amp-img src="https://lh3.googleusercontent.com/Z4gtm5Bkxyv21Z2PtbTf95Clb9AE4VTR6olbBKYrenM=w400-h300-no-n" width=400 height=300>
+    </amp-img>
+
+    <amp-soundcloud height=300
+        layout="fixed-height"
+        data-trackid="243169232">
+    </amp-soundcloud>
+
+    <amp-youtube
+        data-videoid="mGENRKrdoGY"
+        width="400" height="300">
+    </amp-youtube>
+
+    <amp-anim
+        src="https://lh3.googleusercontent.com/qNn8GDz8Jfd-s9lt3Nc4lJeLjVyEaqGJTk1vuCUWazCmAeOBVjSWDD0SMTU7x0zhVe5UzOTKR0n-kN4SXx7yElvpKYvCMaRyS_g-jydhJ_cEVYmYPiZ_j1Y9de43mlKxU6s06uK1NAlpbSkL_046amEKOdgIACICkuWfOBwlw2hUDfjPOWskeyMrcTu8XOEerCLuVqXugG31QC345hz3lUyOlkdT9fMYVUynSERGNzHba7bXMOxKRe3izS5DIWUgJs3oeKYqA-V8iqgCvneD1jj0Ff68V_ajm4BDchQubBJU0ytXVkoWh27ngeEHubpnApOS6fcGsjPxeuMjnzAUtoTsiXz2FZi1mMrxrblJ-kZoAq1DJ95cnoqoa2CYq3BTgq2E8BRe2paNxLJ5GXBCTpNdXMpVJc6eD7ceijQyn-2qanilX-iK3ChbOq0uBHMvsdoC_LsFOu5KzbbNH71vM3DPkvDGmHJmF67Vj8sQ6uBrLnzpYlCyN4-Y9frR8zugDcqX5Q=w400-h300-no"
+        width="400" height="300">
+      <amp-img placeholder
+          src="https://lh3.googleusercontent.com/qNn8GDz8Jfd-s9lt3Nc4lJeLjVyEaqGJTk1vuCUWazCmAeOBVjSWDD0SMTU7x0zhVe5UzOTKR0n-kN4SXx7yElvpKYvCMaRyS_g-jydhJ_cEVYmYPiZ_j1Y9de43mlKxU6s06uK1NAlpbSkL_046amEKOdgIACICkuWfOBwlw2hUDfjPOWskeyMrcTu8XOEerCLuVqXugG31QC345hz3lUyOlkdT9fMYVUynSERGNzHba7bXMOxKRe3izS5DIWUgJs3oeKYqA-V8iqgCvneD1jj0Ff68V_ajm4BDchQubBJU0ytXVkoWh27ngeEHubpnApOS6fcGsjPxeuMjnzAUtoTsiXz2FZi1mMrxrblJ-kZoAq1DJ95cnoqoa2CYq3BTgq2E8BRe2paNxLJ5GXBCTpNdXMpVJc6eD7ceijQyn-2qanilX-iK3ChbOq0uBHMvsdoC_LsFOu5KzbbNH71vM3DPkvDGmHJmF67Vj8sQ6uBrLnzpYlCyN4-Y9frR8zugDcqX5Q=w400-h300-no-k"
+          width="400" height="300">
+        </amp-img>
+    </amp-anim>
+
+    <amp-audio src="/examples/av/audio.mp3">
+    </amp-audio>
+
+    <amp-brightcove
+        data-account="1290862519001"
+        data-video-id="ref:amp-docs-sample"
+        data-player="SyIOV8yWM"
+        layout="responsive" width="300" height="300">
+    </amp-brightcove>
+
+    <amp-vimeo
+        data-videoid="27246366"
+        width="300"
+        height="300">
+    </amp-vimeo>
+
+    <amp-dailymotion
+        data-videoid="x3rdtfy"
+        width="300"
+        height="300">
+    </amp-dailymotion>
+
+    <amp-vine
+        data-vineid="MdKjXez002d"
+        width="300"
+        height="300">
+    </amp-vine>
+
+    <amp-video
+        src="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4"
+        width="300"
+        height="300"
+        controls>
+    </amp-video>
+
+  </amp-carousel>
+
+</html>

--- a/extensions/amp-carousel/0.1/amp-carousel.css
+++ b/extensions/amp-carousel/0.1/amp-carousel.css
@@ -53,16 +53,12 @@ amp-carousel[controls] .amp-carousel-button,
   visibility: visible;
 }
 
-.amp-carousel-button-prev {
+.amp-carousel-button.amp-carousel-button-prev {
   left: 16px;
-  background-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="#fff" viewBox="0 0 18 18"><path d="M15 8.25H5.87l4.19-4.19L9 3 3 9l6 6 1.06-1.06-4.19-4.19H15v-1.5z"/></svg>');
-  background-size: 18px 18px;
 }
 
-.amp-carousel-button-next {
+.amp-carousel-button.amp-carousel-button-next {
   right: 16px;
-  background-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="#fff" viewBox="0 0 18 18"><path d="M9 3L7.94 4.06l4.19 4.19H3v1.5h9.13l-4.19 4.19L9 15l6-6z"/></svg>');
-  background-size: 18px 18px;
 }
 
 .i-amphtml-carousel-button-start-hint .amp-carousel-button:not(.amp-disabled) {

--- a/tools/experiments/experiments.js
+++ b/tools/experiments/experiments.js
@@ -338,6 +338,11 @@ const EXPERIMENTS = [
     name: 'Enables scroll snap on carousel across all browsers/OSes',
     cleanupIssue: 'https://github.com/ampproject/amphtml/issues/16508',
   },
+  {
+    id: 'amp-carousel-new-arrows',
+    name: 'Enables new AMP carousel navigation arrows',
+    cleanupIssue: 'https://github.com/ampproject/amphtml/issues/17510',
+  },
 ];
 
 if (getMode().localDev) {


### PR DESCRIPTION
This PR uses internal classes for the internal styling of elements.

If no override is provided:
<img width="703" alt="screen shot 2018-08-22 at 3 30 19 pm" src="https://user-images.githubusercontent.com/7919520/44483300-17e7d100-a621-11e8-807a-ddb4687318f8.png">
<img width="703" alt="screen shot 2018-08-22 at 3 30 24 pm" src="https://user-images.githubusercontent.com/7919520/44483301-17e7d100-a621-11e8-9f81-dddf85509530.png">

If override is provided:
<img width="384" alt="screen shot 2018-08-23 at 4 02 32 pm" src="https://user-images.githubusercontent.com/7919520/44546360-0ddfd400-a6ee-11e8-8e20-e6075e7f0271.png">
Please note that the default for ABE in this case used to use the default background provided by the internal styling which is not available now. Is this a regression we want? I am assuming some other sites use this as well?