### PR TITLE
🐛 amp-brightcove: Restore redispatched events

### DIFF
--- a/extensions/amp-brightcove/0.1/amp-brightcove.js
+++ b/extensions/amp-brightcove/0.1/amp-brightcove.js
@@ -185,6 +185,8 @@ class AmpBrightcove extends AMP.BaseElement {
 
     if (redispatch(element, eventType, {
       'ready': VideoEvents.LOAD,
+      'playing': VideoEvents.PLAYING,
+      'pause': VideoEvents.PAUSE,
       'ended': VideoEvents.ENDED,
       'ads-ad-started': VideoEvents.AD_START,
       'ads-ad-ended': VideoEvents.AD_END,

--- a/extensions/amp-brightcove/0.1/test/test-amp-brightcove.js
+++ b/extensions/amp-brightcove/0.1/test/test-amp-brightcove.js
@@ -15,9 +15,9 @@
  */
 
 import '../amp-brightcove';
-import {parseUrlDeprecated} from '../../../../src/url';
 import {VideoEvents} from '../../../../src/video-interface';
 import {listenOncePromise} from '../../../../src/event-helper';
+import {parseUrlDeprecated} from '../../../../src/url';
 
 
 describes.realWin('amp-brightcove', {
@@ -45,7 +45,7 @@ describes.realWin('amp-brightcove', {
     doc.body.appendChild(bc);
     return bc.build().then(() => bc.layoutCallback()).then(() => bc);
   }
-  
+
   function fakePostMessage(bc, info) {
     bc.implementation_.handlePlayerMessage_({
       origin: 'https://players.brightcove.net',
@@ -63,8 +63,8 @@ describes.realWin('amp-brightcove', {
       expect(iframe).to.not.be.null;
       expect(iframe.tagName).to.equal('IFRAME');
       expect(iframe.src).to.equal(
-          'https://players.brightcove.net/1290862519001' +
-          '/default_default/index.html?videoId=ref:amp-test-video&playsinline=true');
+          'https://players.brightcove.net/1290862519001/default_default' +
+          '/index.html?videoId=ref:amp-test-video&playsinline=true');
     });
   });
 
@@ -82,7 +82,7 @@ describes.realWin('amp-brightcove', {
   it('requires data-account', () => {
     expectAsyncConsoleError(/The data-account attribute is required for/, 1);
     return getBrightcove({}).should.eventually.be.rejectedWith(
-      /The data-account attribute is required for/);
+        /The data-account attribute is required for/);
   });
 
   it('removes iframe after unlayoutCallback', () => {
@@ -118,8 +118,9 @@ describes.realWin('amp-brightcove', {
     }).then(bc => {
       const iframe = bc.querySelector('iframe');
 
-      expect(iframe.src).to.equal('https://players.brightcove.net/1290862519001' +
-          '/default_default/index.html?videoId=ref:amp-test-video&playsinline=true');
+      expect(iframe.src).to.equal(
+          'https://players.brightcove.net/1290862519001/default_default' +
+          '/index.html?videoId=ref:amp-test-video&playsinline=true');
 
       bc.setAttribute('data-account', '12345');
       bc.setAttribute('data-video-id', 'abcdef');
@@ -132,53 +133,58 @@ describes.realWin('amp-brightcove', {
           '12345/default_default/index.html?videoId=abcdef&playsinline=true');
     });
   });
-  
+
   it('should forward events', () => {
     return getBrightcove({
       'data-account': '1290862519001',
       'data-video-id': 'ref:amp-test-video',
     }).then(bc => {
       return Promise.resolve()
-        .then(() =>{
-          const p = listenOncePromise(bc, VideoEvents.LOAD);
-          fakePostMessage(bc, {event: 'ready', muted: false, playing: false});
-          return p;
-        })
-        .then(() =>{
-          const p = listenOncePromise(bc, VideoEvents.AD_START);
-          fakePostMessage(bc, {event: 'ads-ad-started', muted: false, playing: false});
-          return p;
-        })
-        .then(() =>{
-          const p = listenOncePromise(bc, VideoEvents.AD_END);
-          fakePostMessage(bc, {event: 'ads-ad-ended', muted: false, playing: false});
-          return p;
-        })
-        .then(() =>{
-          const p = listenOncePromise(bc, VideoEvents.PLAYING);
-          fakePostMessage(bc, {event: 'playing', muted: false, playing: true});
-          return p;
-        })
-        .then(() =>{
-          const p = listenOncePromise(bc, VideoEvents.MUTED);
-          fakePostMessage(bc, {event: 'volumechange', muted: true, playing: true});
-          return p;
-        })
-        .then(() =>{
-          const p = listenOncePromise(bc, VideoEvents.UNMUTED);
-          fakePostMessage(bc, {event: 'volumechange', muted: false, playing: true});
-          return p;
-        })
-        .then(() =>{
-          const p = listenOncePromise(bc, VideoEvents.PAUSE);
-          fakePostMessage(bc, {event: 'pause', muted: false, playing: false});
-          return p;
-        })
-        .then(() =>{
-          const p = listenOncePromise(bc, VideoEvents.ENDED);
-          fakePostMessage(bc, {event: 'ended', muted: false, playing: false});
-          return p;
-        });
+          .then(() => {
+            const p = listenOncePromise(bc, VideoEvents.LOAD);
+            fakePostMessage(bc, {event: 'ready', muted: false, playing: false});
+            return p;
+          })
+          .then(() => {
+            const p = listenOncePromise(bc, VideoEvents.AD_START);
+            fakePostMessage(bc,
+                {event: 'ads-ad-started', muted: false, playing: false});
+            return p;
+          })
+          .then(() => {
+            const p = listenOncePromise(bc, VideoEvents.AD_END);
+            fakePostMessage(bc,
+                {event: 'ads-ad-ended', muted: false, playing: false});
+            return p;
+          })
+          .then(() => {
+            const p = listenOncePromise(bc, VideoEvents.PLAYING);
+            fakePostMessage(bc,
+                {event: 'playing', muted: false, playing: true});
+            return p;
+          })
+          .then(() => {
+            const p = listenOncePromise(bc, VideoEvents.MUTED);
+            fakePostMessage(bc,
+                {event: 'volumechange', muted: true, playing: true});
+            return p;
+          })
+          .then(() => {
+            const p = listenOncePromise(bc, VideoEvents.UNMUTED);
+            fakePostMessage(bc,
+                {event: 'volumechange', muted: false, playing: true});
+            return p;
+          })
+          .then(() => {
+            const p = listenOncePromise(bc, VideoEvents.PAUSE);
+            fakePostMessage(bc, {event: 'pause', muted: false, playing: false});
+            return p;
+          })
+          .then(() => {
+            const p = listenOncePromise(bc, VideoEvents.ENDED);
+            fakePostMessage(bc, {event: 'ended', muted: false, playing: false});
+            return p;
+          });
     });
   });
 });

--- a/extensions/amp-brightcove/0.1/test/test-amp-brightcove.js
+++ b/extensions/amp-brightcove/0.1/test/test-amp-brightcove.js
@@ -16,6 +16,8 @@
 
 import '../amp-brightcove';
 import {parseUrlDeprecated} from '../../../../src/url';
+import {VideoEvents} from '../../../../src/video-interface';
+import {listenOncePromise} from '../../../../src/event-helper';
 
 
 describes.realWin('amp-brightcove', {
@@ -43,25 +45,33 @@ describes.realWin('amp-brightcove', {
     doc.body.appendChild(bc);
     return bc.build().then(() => bc.layoutCallback()).then(() => bc);
   }
+  
+  function fakePostMessage(bc, info) {
+    bc.implementation_.handlePlayerMessage_({
+      origin: 'https://players.brightcove.net',
+      source: bc.querySelector('iframe').contentWindow,
+      data: JSON.stringify(info),
+    });
+  }
 
   it('renders', () => {
     return getBrightcove({
       'data-account': '1290862519001',
-      'data-video-id': 'ref:ampdemo',
+      'data-video-id': 'ref:amp-test-video',
     }).then(bc => {
       const iframe = bc.querySelector('iframe');
       expect(iframe).to.not.be.null;
       expect(iframe.tagName).to.equal('IFRAME');
       expect(iframe.src).to.equal(
           'https://players.brightcove.net/1290862519001' +
-          '/default_default/index.html?videoId=ref:ampdemo&playsinline=true');
+          '/default_default/index.html?videoId=ref:amp-test-video&playsinline=true');
     });
   });
 
   it('renders responsively', () => {
     return getBrightcove({
       'data-account': '1290862519001',
-      'data-video-id': 'ref:ampdemo',
+      'data-video-id': 'ref:amp-test-video',
     }, true).then(bc => {
       const iframe = bc.querySelector('iframe');
       expect(iframe).to.not.be.null;
@@ -70,14 +80,15 @@ describes.realWin('amp-brightcove', {
   });
 
   it('requires data-account', () => {
+    expectAsyncConsoleError(/The data-account attribute is required for/, 1);
     return getBrightcove({}).should.eventually.be.rejectedWith(
-        /The data-account attribute is required for/);
+      /The data-account attribute is required for/);
   });
 
   it('removes iframe after unlayoutCallback', () => {
     return getBrightcove({
       'data-account': '1290862519001',
-      'data-video-id': 'ref:ampdemo',
+      'data-video-id': 'ref:amp-test-video',
     }, true).then(bc => {
       const iframe = bc.querySelector('iframe');
       expect(iframe).to.not.be.null;
@@ -91,7 +102,7 @@ describes.realWin('amp-brightcove', {
   it('should pass data-param-* attributes to the iframe src', () => {
     return getBrightcove({
       'data-account': '1290862519001',
-      'data-video-id': 'ref:ampdemo',
+      'data-video-id': 'ref:amp-test-video',
       'data-param-my-param': 'hello world',
     }).then(bc => {
       const iframe = bc.querySelector('iframe');
@@ -103,12 +114,12 @@ describes.realWin('amp-brightcove', {
   it('should propagate mutated attributes', () => {
     return getBrightcove({
       'data-account': '1290862519001',
-      'data-video-id': 'ref:ampdemo',
+      'data-video-id': 'ref:amp-test-video',
     }).then(bc => {
       const iframe = bc.querySelector('iframe');
 
       expect(iframe.src).to.equal('https://players.brightcove.net/1290862519001' +
-          '/default_default/index.html?videoId=ref:ampdemo&playsinline=true');
+          '/default_default/index.html?videoId=ref:amp-test-video&playsinline=true');
 
       bc.setAttribute('data-account', '12345');
       bc.setAttribute('data-video-id', 'abcdef');
@@ -119,6 +130,55 @@ describes.realWin('amp-brightcove', {
 
       expect(iframe.src).to.equal('https://players.brightcove.net/' +
           '12345/default_default/index.html?videoId=abcdef&playsinline=true');
+    });
+  });
+  
+  it('should forward events', () => {
+    return getBrightcove({
+      'data-account': '1290862519001',
+      'data-video-id': 'ref:amp-test-video',
+    }).then(bc => {
+      return Promise.resolve()
+        .then(() =>{
+          const p = listenOncePromise(bc, VideoEvents.LOAD);
+          fakePostMessage(bc, {event: 'ready', muted: false, playing: false});
+          return p;
+        })
+        .then(() =>{
+          const p = listenOncePromise(bc, VideoEvents.AD_START);
+          fakePostMessage(bc, {event: 'ads-ad-started', muted: false, playing: false});
+          return p;
+        })
+        .then(() =>{
+          const p = listenOncePromise(bc, VideoEvents.AD_END);
+          fakePostMessage(bc, {event: 'ads-ad-ended', muted: false, playing: false});
+          return p;
+        })
+        .then(() =>{
+          const p = listenOncePromise(bc, VideoEvents.PLAYING);
+          fakePostMessage(bc, {event: 'playing', muted: false, playing: true});
+          return p;
+        })
+        .then(() =>{
+          const p = listenOncePromise(bc, VideoEvents.MUTED);
+          fakePostMessage(bc, {event: 'volumechange', muted: true, playing: true});
+          return p;
+        })
+        .then(() =>{
+          const p = listenOncePromise(bc, VideoEvents.UNMUTED);
+          fakePostMessage(bc, {event: 'volumechange', muted: false, playing: true});
+          return p;
+        })
+        .then(() =>{
+          const p = listenOncePromise(bc, VideoEvents.PAUSE);
+          fakePostMessage(bc, {event: 'pause', muted: false, playing: false});
+          return p;
+        })
+        .then(() =>{
+          const p = listenOncePromise(bc, VideoEvents.ENDED);
+          fakePostMessage(bc, {event: 'ended', muted: false, playing: false});
+          return p;
+        });
     });
   });
 });


### PR DESCRIPTION
Redispatch of `VideoEvents.PLAYING` and `VideoEvents.PAUSE` were removed in #15527. This restores these.

Adds tests for event dispatch.
