### PR TITLE
Update Sauce Connect to 4.5.0

### DIFF
--- a/build-system/sauce_connect/start_sauce_connect.sh
+++ b/build-system/sauce_connect/start_sauce_connect.sh
@@ -20,7 +20,7 @@
 CYAN() { echo -e "\033[0;36m$1\033[0m"; }
 YELLOW() { echo -e "\033[1;33m$1\033[0m"; }
 
-SC_VERSION="sc-4.4.12-linux"
+SC_VERSION="sc-4.5.0-linux"
 DOWNLOAD_URL="https://saucelabs.com/downloads/$SC_VERSION.tar.gz"
 TAR_FILE="$SC_VERSION.tar.gz"
 BINARY_FILE="$SC_VERSION/bin/sc"

--- a/build-system/tasks/bundle-size.js
+++ b/build-system/tasks/bundle-size.js
@@ -22,7 +22,7 @@ const log = require('fancy-log');
 const {getStdout} = require('../exec');
 
 const runtimeFile = './dist/v0.js';
-const maxSize = '80.9KB';
+const maxSize = '80.91KB';
 
 const {green, red, cyan, yellow} = colors;
 


### PR DESCRIPTION
```sh
22 Aug 17:57:16 - A newer version of Sauce Connect (build 4165) is available!
22 Aug 17:57:16 - Download it here:
22 Aug 17:57:16 - https://saucelabs.com/downloads/sc-4.5.0-linux.tar.gz
```

/to @rsimha @danielrozenberg 