### PR TITLE
Story notification paywall.

### DIFF
--- a/examples/amp-story/access.html
+++ b/examples/amp-story/access.html
@@ -66,9 +66,8 @@
         <button on="tap:amp-access.login">Login to read more!</button>
       </amp-story-access>
 
-      <amp-story-access id="meter-notif" amp-access="NOT access" type="notification">
+      <amp-story-access amp-access="NOT access" type="notification">
         <button on="tap:amp-access.login">Please subscribe or log in!</button>
-        <button on="tap:meter-notif.hide">Dismiss</button>
       </amp-story-access>
 
       <amp-story-page id="cover">

--- a/examples/amp-story/access.html
+++ b/examples/amp-story/access.html
@@ -66,6 +66,11 @@
         <button on="tap:amp-access.login">Login to read more!</button>
       </amp-story-access>
 
+      <amp-story-access id="meter-notif" amp-access="NOT access" type="notification">
+        <button on="tap:amp-access.login">Please subscribe or log in!</button>
+        <button on="tap:meter-notif.hide">Dismiss</button>
+      </amp-story-access>
+
       <amp-story-page id="cover">
         <amp-story-grid-layer template="vertical">
           <h1>Free page!</h1>

--- a/extensions/amp-story/1.0/amp-story-access.css
+++ b/extensions/amp-story/1.0/amp-story-access.css
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-amp-story-access {
+amp-story-access.i-amphtml-element {
   position: absolute !important;
-  display: flex !important;
+  display: flex; /** No !important to allow the runtime to hide/show it. */
   flex-direction: column !important;
   top: 0 !important;
   left: 0 !important;
@@ -25,6 +25,11 @@ amp-story-access {
   z-index: 100003 !important; /** Above the bookend and desktop navigation UI. */
   transform: translate3d(0, 100vh, 0) !important;
   transition-delay: 0.15s !important;
+  pointer-events: none !important;
+}
+
+amp-story-access[type=blocking] {
+  z-index: 100004 !important; /** Above the [type=notification]. */
 }
 
 amp-story-access.i-amphtml-story-access-visible {
@@ -32,8 +37,8 @@ amp-story-access.i-amphtml-story-access-visible {
   transition-delay: 0s !important;
 }
 
-/** Black opacity overlay. */
-amp-story-access::before {
+/** Black opacity overlay. Only on blocking story-access. */
+amp-story-access[type=blocking]::before {
   content: "" !important;
   position: absolute !important;
   top: 0 !important;
@@ -42,10 +47,11 @@ amp-story-access::before {
   width: 100% !important;
   background: #000000 !important;
   opacity: 0 !important;
+  pointer-events: auto !important;
   transition: opacity 0.15s cubic-bezier(0.4, 0.0, 1, 1) !important;
 }
 
-amp-story-access.i-amphtml-story-access-visible::before {
+amp-story-access[type=blocking].i-amphtml-story-access-visible::before {
   opacity: 0.4 !important;
   transition: opacity 0.2s cubic-bezier(0.0, 0.0, 0.2, 1) !important;
 }
@@ -65,8 +71,9 @@ amp-story-access.i-amphtml-story-access-visible::before {
   border-radius: 8px 8px 0 0 !important;
   color: rgba(0, 0, 0, 0.87) !important;
   font-family: 'Roboto', sans-serif !important;
-  text-align: start !important;
   overflow: hidden !important;
+  pointer-events: auto !important;
+  text-align: start !important;
   transform: translate3d(0, 100%, 0) !important;
   transition: transform 0.15s cubic-bezier(0.4, 0.0, 1, 1) !important;
 }
@@ -82,6 +89,10 @@ amp-story-access.i-amphtml-story-access-visible::before {
   border-radius: initial !important;
 }
 
+[type="notification"] .i-amphtml-story-access-container {
+  box-shadow: 0 -1px 2px 1px rgba(0, 0, 0, 0.12) !important;
+}
+
 .i-amphtml-story-access-header {
   position: relative !important;
   height: 80px !important;
@@ -90,7 +101,7 @@ amp-story-access.i-amphtml-story-access-visible::before {
   z-index: 2 !important;
 
   /* Making sure the background color fills the container in full bleed mode. */
-  margin: 0 -8px !important;
+  margin: 0 -8px 48px !important;
 }
 
 .i-amphtml-story-access-logo {
@@ -120,8 +131,21 @@ amp-story-access.i-amphtml-story-access-visible::before {
   z-index: -1 !important;
 }
 
+.i-amphtml-story-access-close-button {
+  position: absolute !important;
+  top: 0 !important;
+  right: 0 !important;
+  height: 36px !important;
+  width: 36px !important;
+  color: #757575 !important;
+  cursor: pointer !important;
+  font-size: 24px !important;
+  line-height: 36px !important;
+  text-align: center !important;
+}
+
 .i-amphtml-story-access-content {
-  padding: 60px 16px 16px !important;
+  padding: 16px !important;
   font-size: 14px !important;
   z-index: 0 !important;
 }
@@ -138,6 +162,8 @@ amp-story-access.i-amphtml-story-access-visible::before {
 
   .i-amphtml-story-access-overflow {
     margin-top: 0 !important;
+    border-radius: 6px !important;
+    box-shadow: 0 1px 3px 1px rgba(0, 0, 0, 0.2) !important;
   }
 
   .i-amphtml-story-access-container {
@@ -148,9 +174,14 @@ amp-story-access.i-amphtml-story-access-visible::before {
     min-height: 20vh !important;
     width: calc(100vw - 80px) !important;
     max-width: 800px !important;
+    border-radius: 0px !important;
     opacity: 0 !important;
     transform: translate3d(0, 0, 0) !important;
     transition: opacity 0.15s cubic-bezier(0.4, 0.0, 1, 1) !important;
+  }
+
+  [type=notification] .i-amphtml-story-access-container {
+    min-height: 0 !important;
   }
 
   .i-amphtml-story-access-visible .i-amphtml-story-access-container {

--- a/extensions/amp-story/1.0/amp-story-access.css
+++ b/extensions/amp-story/1.0/amp-story-access.css
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-amp-story-access.i-amphtml-element {
+amp-story-access {
   position: absolute !important;
-  display: flex; /** No !important to allow the runtime to hide/show it. */
+  display: flex !important;
   flex-direction: column !important;
   top: 0 !important;
   left: 0 !important;
@@ -26,6 +26,11 @@ amp-story-access.i-amphtml-element {
   transform: translate3d(0, 100vh, 0) !important;
   transition-delay: 0.15s !important;
   pointer-events: none !important;
+}
+
+/** Allows [amp-access="CONDITION"] rules. */
+amp-story-access[amp-access-hide] {
+  display: none !important;
 }
 
 amp-story-access[type=blocking] {

--- a/extensions/amp-story/1.0/amp-story-access.js
+++ b/extensions/amp-story/1.0/amp-story-access.js
@@ -29,10 +29,10 @@ import {
   removeChildren,
 } from '../../../src/dom';
 import {dev} from '../../../src/log';
-import {dict} from './../../../src/utils/object';
+import {htmlFor} from '../../../src/static-template';
 import {isArray, isObject} from '../../../src/types';
 import {parseJson} from '../../../src/json';
-import {renderAsElement} from './simple-template';
+import {setImportantStyles} from '../../../src/style';
 import {throttle} from '../../../src/utils/rate-limit';
 import {user} from '../../../src/log';
 
@@ -41,41 +41,47 @@ import {user} from '../../../src/log';
 const TAG = 'amp-story-access';
 
 /**
- * Story access template.
- * @param {?string} logoSrc
- * @return {!./simple-template.ElementDef}
+ * @enum {string}
  */
-const getTemplate = logoSrc => ({
-  tag: 'div',
-  attrs: dict({'class': 'i-amphtml-story-access-overflow'}),
-  children: [
-    {
-      tag: 'div',
-      attrs: dict({'class': 'i-amphtml-story-access-container'}),
-      children: [
-        {
-          tag: 'div',
-          attrs: dict({'class': 'i-amphtml-story-access-header'}),
-          children: [
-            {
-              tag: 'div',
-              attrs: dict({
-                'class': 'i-amphtml-story-access-logo',
-                'style': logoSrc ?
-                  `background-image: url('${logoSrc}') !important;` : '',
-              }),
-              children: [],
-            },
-          ],
-        },
-        {
-          tag: 'div',
-          attrs: dict({'class': 'i-amphtml-story-access-content'}),
-        },
-      ],
-    },
-  ],
-});
+export const Type = {
+  BLOCKING: 'blocking',
+  NOTIFICATION: 'notification',
+};
+
+/**
+ * Story access blocking type template.
+ * @param {!Element} element
+ * @return {!Element}
+ */
+const getBlockingTemplate = element => {
+  return htmlFor(element)`
+      <div class="i-amphtml-story-access-overflow">
+        <div class="i-amphtml-story-access-container">
+          <div class="i-amphtml-story-access-header">
+            <div class="i-amphtml-story-access-logo"></div>
+          </div>
+          <div class="i-amphtml-story-access-content"></div>
+        </div>
+      </div>`;
+};
+
+/**
+ * Story access notification type template.
+ * @param {!Element} element
+ * @return {!Element}
+ */
+const getNotificationTemplate = element => {
+  return htmlFor(element)`
+      <div class="i-amphtml-story-access-overflow">
+        <div class="i-amphtml-story-access-container">
+          <div class="i-amphtml-story-access-content">
+            <span class="i-amphtml-story-access-close-button" role="button">
+              &times;
+            </span>
+          </div>
+        </div>
+      </div>`;
+};
 
 /**
  * The <amp-story-access> custom element.
@@ -89,7 +95,7 @@ export class AmpStoryAccess extends AMP.BaseElement {
     this.actions_ = Services.actionServiceForDoc(this.element);
 
     /** @private {?Element} */
-    this.contentEl_ = null;
+    this.containerEl_ = null;
 
     /** @private {?Element} */
     this.scrollableEl_ = null;
@@ -100,20 +106,19 @@ export class AmpStoryAccess extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
-    const storyEl =
-        dev().assertElement(closestByTag(this.element, 'AMP-STORY'));
-    const logoSrc = storyEl && storyEl.getAttribute('publisher-logo-src');
+    // Defaults to blocking paywall.
+    if (!this.element.hasAttribute('type')) {
+      this.element.setAttribute('type', Type.BLOCKING);
+    }
 
-    logoSrc ?
-      assertHttpsUrl(logoSrc, storyEl, 'publisher-logo-src') :
-      user().warn(
-          TAG, 'Expected "publisher-logo-src" attribute on <amp-story>');
+    const drawerEl = this.renderDrawerEl_();
 
-    const drawerEl = renderAsElement(this.win.document, getTemplate(logoSrc));
-    this.contentEl_ = dev().assertElement(
+    this.containerEl_ = dev().assertElement(
+        drawerEl.querySelector('.i-amphtml-story-access-container'));
+    const contentEl = dev().assertElement(
         drawerEl.querySelector('.i-amphtml-story-access-content'));
 
-    copyChildren(this.element, this.contentEl_);
+    copyChildren(this.element, contentEl);
     removeChildren(this.element);
 
     this.element.appendChild(drawerEl);
@@ -136,6 +141,11 @@ export class AmpStoryAccess extends AMP.BaseElement {
       this.onAccessStateChange_(isAccess);
     });
 
+    this.storeService_
+        .subscribe(StateProperty.CURRENT_PAGE_INDEX, currentPageIndex => {
+          this.onCurrentPageIndexChange_(currentPageIndex);
+        }, true /** callToInitialize */);
+
     this.scrollableEl_ =
         this.element.querySelector('.i-amphtml-story-access-overflow');
     this.scrollableEl_.addEventListener(
@@ -150,9 +160,23 @@ export class AmpStoryAccess extends AMP.BaseElement {
    * @private
    */
   onAccessStateChange_(isAccess) {
-    this.mutateElement(() => {
-      this.element.classList.toggle('i-amphtml-story-access-visible', isAccess);
-    });
+    if (this.getType_() === Type.BLOCKING) {
+      this.toggle_(isAccess);
+    }
+  }
+
+  /**
+   * Reacts to story active page index update, and maybe display the
+   * "notification" story-access.
+   * @param {number} currentPageIndex
+   */
+  onCurrentPageIndexChange_(currentPageIndex) {
+    if (this.getType_() === Type.NOTIFICATION) {
+      // Only show the notification if on the first page of the story.
+      // Note: this can be overriden by an amp-access attribute that might
+      // show/hide the notification based on the user's authorizations.
+      this.toggle_(currentPageIndex === 0);
+    }
   }
 
   /**
@@ -183,10 +207,85 @@ export class AmpStoryAccess extends AMP.BaseElement {
   onClick_(event) {
     const el = dev().assertElement(event.target);
 
+    if (el.classList.contains('i-amphtml-story-access-close-button')) {
+      return this.toggle_(false);
+    }
+
     // Closes the menu if click happened outside of the main container.
-    if (!closest(el, el => el === this.contentEl_, this.element)) {
+    if (!closest(el, el => el === this.containerEl_, this.element)) {
       this.storeService_.dispatch(Action.TOGGLE_ACCESS, false);
     }
+  }
+
+  /**
+   * @param {boolean} show
+   * @private
+   */
+  toggle_(show) {
+    this.mutateElement(() => {
+      this.element.classList.toggle('i-amphtml-story-access-visible', show);
+    });
+  }
+
+  /**
+   * Returns the element's type.
+   * @return {string}
+   * @private
+   */
+  getType_() {
+    return this.element.getAttribute('type').toLowerCase();
+  }
+
+  /**
+   * Renders and returns an empty drawer element element that will contain the
+   * publisher provided DOM, depending on the type of <amp-story-access>.
+   * Blocking template gets a header containing the publisher's logo, and
+   * notification template gets a "dismiss" button.
+   * @return {!Element|undefined}
+   * @private
+   */
+  renderDrawerEl_() {
+    switch (this.getType_()) {
+      case Type.BLOCKING:
+        const drawerEl = getBlockingTemplate(this.element);
+
+        const logoSrc = this.getLogoSrc_();
+
+        if (logoSrc) {
+          const logoEl =
+              dev().assertElement(
+                  drawerEl.querySelector('.i-amphtml-story-access-logo'));
+          setImportantStyles(logoEl, {'background-image': `url(${logoSrc})`});
+        }
+
+        return drawerEl;
+        break;
+      case Type.NOTIFICATION:
+        return getNotificationTemplate(this.element);
+        break;
+      default:
+        user().error(TAG, 'Unknown "type" attribute, expected one of: ' +
+            'blocking, notification.');
+    }
+  }
+
+  /**
+   * Retrieves the publisher-logo-src set on the <amp-story> element, and
+   * validates it's a valid https or relative URL.
+   * @return {?string}
+   * @private
+   */
+  getLogoSrc_() {
+    const storyEl =
+            dev().assertElement(closestByTag(this.element, 'AMP-STORY'));
+    const logoSrc = storyEl && storyEl.getAttribute('publisher-logo-src');
+
+    logoSrc ?
+      assertHttpsUrl(logoSrc, storyEl, 'publisher-logo-src') :
+      user().warn(
+          TAG, 'Expected "publisher-logo-src" attribute on <amp-story>');
+
+    return logoSrc;
   }
 
   /**
@@ -203,6 +302,13 @@ export class AmpStoryAccess extends AMP.BaseElement {
    * @private
    */
   whitelistActions_() {
+    // Allows a button that could hide the amp-story-access element, like
+    // regular AMP allows.
+    // eg: <button on="tap:notification.hide">Dismiss</button>
+    if (this.getType_() === Type.NOTIFICATION) {
+      this.actions_.addToWhitelist('AMP-STORY-ACCESS.hide');
+    }
+
     const accessEl =
         dev().assertElement(
             this.win.document.getElementById('amp-access'),

--- a/extensions/amp-story/1.0/amp-story-access.js
+++ b/extensions/amp-story/1.0/amp-story-access.js
@@ -302,13 +302,6 @@ export class AmpStoryAccess extends AMP.BaseElement {
    * @private
    */
   whitelistActions_() {
-    // Allows a button that could hide the amp-story-access element, like
-    // regular AMP allows.
-    // eg: <button on="tap:notification.hide">Dismiss</button>
-    if (this.getType_() === Type.NOTIFICATION) {
-      this.actions_.addToWhitelist('AMP-STORY-ACCESS.hide');
-    }
-
     const accessEl =
         dev().assertElement(
             this.win.document.getElementById('amp-access'),

--- a/extensions/amp-story/1.0/amp-story-consent.css
+++ b/extensions/amp-story/1.0/amp-story-consent.css
@@ -22,7 +22,7 @@
   left: 0 !important;
   height: 100% !important;
   width: 100% !important;
-  z-index: 100003 !important;
+  z-index: 100005 !important; /** Above amp-story-access. */
 }
 
 /** Black opacity overlay. */

--- a/extensions/amp-story/1.0/test/test-amp-story-access.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-access.js
@@ -15,7 +15,7 @@
  */
 
 import {Action, AmpStoryStoreService} from '../amp-story-store-service';
-import {AmpStoryAccess} from '../amp-story-access';
+import {AmpStoryAccess, Type} from '../amp-story-access';
 import {registerServiceBuilder} from '../../../../src/service';
 
 describes.realWin('amp-story-access', {amp: true}, env => {
@@ -72,10 +72,26 @@ describes.realWin('amp-story-access', {amp: true}, env => {
     expect(buttonInDrawerEl).to.exist;
   });
 
-  it('should display the <amp-story-access> tag on state update', done => {
+  it('should display the access blocking paywall on state update', done => {
     storyAccess.buildCallback();
 
     storeService.dispatch(Action.TOGGLE_ACCESS, true);
+
+    win.requestAnimationFrame(() => {
+      expect(storyAccess.element)
+          .to.have.class('i-amphtml-story-access-visible');
+      done();
+    });
+  });
+
+  it('should show the access notification on state update', done => {
+    storyAccess.element.setAttribute('type', Type.NOTIFICATION);
+    storyAccess.buildCallback();
+
+    storeService.dispatch(Action.CHANGE_PAGE, {
+      id: 'foo',
+      index: 0,
+    });
 
     win.requestAnimationFrame(() => {
       expect(storyAccess.element)


### PR DESCRIPTION
- Introducing a new `type` attribute on `amp-story-access` that might be either `blocking` or `notification`
- Defaults to `blocking` and throws an error if another type is provided
- Moves from `renderTemplate` to the new `html` template renderer
- New `notification` template with a dismiss button, that has no opacity background overlay and is only displayed on the first page of the story
- That `notification` can be shown or hidden using an `amp-access` attribute, eg: `<amp-story-access type="notification" amp-access="viewsCount > freeViews">`

Related to #12180