### PR TITLE
🐛 Fix issue with bad side effect of IE's innerHTML

### DIFF
--- a/src/static-template.js
+++ b/src/static-template.js
@@ -57,7 +57,7 @@ function html(strings) {
   dev().assert(!el.nextElementSibling, 'Too many root elements in template');
 
   // Clear to free memory.
-  container./*OK*/innerHTML = '';
+  container.removeChild(el);
 
   return el;
 }


### PR DESCRIPTION
Fixes #17652

[IE's innerHTML implementation](https://stackoverflow.com/questions/25167593/why-does-ie-discard-the-innerhtml-children-of-a-dom-element-after-dom-changes/25559902#25559902) trashes the child node tree if you set it to "" without preserving references.  use `removeChild()` instead.