### PR TITLE
🐛Fixes for <amp-lightbox-gallery> and shadow docs

### DIFF
--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -185,7 +185,7 @@ export class AmpLightboxGallery extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
-    return lightboxManagerFor(this.getAmpDoc()).then(manager => {
+    return lightboxManagerForDoc(this.getAmpDoc()).then(manager => {
       this.manager_ = manager;
       this.history_ = Services.historyForDoc(this.getAmpDoc());
       this.action_ = Services.actionServiceForDoc(this.getAmpDoc());
@@ -1537,7 +1537,7 @@ export function installLightboxGallery(ampdoc) {
  * @param {!Element|!../../../src/service/ampdoc-impl.AmpDoc} elementOrAmpDoc
  * @return {!Promise<?LightboxManager>}
  */
-function lightboxManagerFor(elementOrAmpDoc) {
+function lightboxManagerForDoc(elementOrAmpDoc) {
   return /** @type {!Promise<?LightboxManager>} */ (
     getElementServiceForDoc(
         elementOrAmpDoc, 'amp-lightbox-manager', 'amp-lightbox-gallery'));

--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -47,6 +47,9 @@ import {
 } from '../../../src/transition';
 import {dev, user} from '../../../src/log';
 import {getData, listen} from '../../../src/event-helper';
+import {
+  getElementServiceForDoc,
+} from '../../../src/element-service';
 import {isLoaded} from '../../../src/event-helper';
 import {layoutRectFromDomRect} from '../../../src/layout-rect';
 import {px, setStyles} from '../../../src/style';
@@ -81,11 +84,6 @@ const MAX_DISTANCE_APPROXIMATION = 250; // px
 const MOTION_DURATION_RATIO = 0.8; // fraction of animation
 const EPSILON = 0.01; // precision for approx equals
 
-/**
- * TODO(aghassemi): Make lightbox-manager into a doc-level service.
- * @private  {!./service/lightbox-manager-impl.LightboxManager}
- * */
-let manager_;
 
 /**
  * The structure that represents the metadata of a lightbox element
@@ -187,11 +185,13 @@ export class AmpLightboxGallery extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
-    this.manager_ = dev().assert(manager_);
-    this.history_ = Services.historyForDoc(this.getAmpDoc());
-    this.action_ = Services.actionServiceForDoc(this.element);
-    const viewer = Services.viewerForDoc(this.getAmpDoc());
-    viewer.whenFirstVisible().then(() => {
+    return lightboxManagerFor(this.getAmpDoc()).then(manager => {
+      this.manager_ = manager;
+      this.history_ = Services.historyForDoc(this.getAmpDoc());
+      this.action_ = Services.actionServiceForDoc(this.getAmpDoc());
+      const viewer = Services.viewerForDoc(this.getAmpDoc());
+      return viewer.whenFirstVisible();
+    }).then(() => {
       this.container_ = this.win.document.createElement('div');
       this.container_.classList.add('i-amphtml-lbg');
       this.element.appendChild(this.container_);
@@ -1515,29 +1515,16 @@ export class AmpLightboxGallery extends AMP.BaseElement {
 }
 
 /**
- * @param {!Window} win
- * @private visible for testing.
- */
-export function installLightboxManager(win) {
-  // TODO (#12859): This only works for singleDoc mode. We will move
-  // installation of LightboxManager to core after the experiment, okay for now.
-  const ampdoc = Services.ampdocServiceFor(win).getAmpDoc();
-  manager_ = new LightboxManager(ampdoc);
-}
-
-/**
  * Tries to find an existing amp-lightbox-gallery, if there is none, it adds a
  * default one.
- * @param {!Window} win
- * @return {!Promise}
+ * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
+ * @return {!Promise<undefined>}
  */
-export function installLightboxGallery(win) {
-  const ampdoc = Services.ampdocServiceFor(win).getAmpDoc();
-  // TODO (#12859): make this work for more than singleDoc mode
+export function installLightboxGallery(ampdoc) {
   return ampdoc.whenBodyAvailable().then(body => {
     const existingGallery = elementByTag(ampdoc.getRootNode(), TAG);
     if (!existingGallery) {
-      const gallery = ampdoc.getRootNode().createElement(TAG);
+      const gallery = ampdoc.win.document.createElement(TAG);
       gallery.setAttribute('layout', 'nodisplay');
       gallery.setAttribute('id', DEFAULT_GALLERY_ID);
       body.appendChild(gallery);
@@ -1545,8 +1532,19 @@ export function installLightboxGallery(win) {
   });
 }
 
+/**
+ * Returns a promise for the LightboxManager.
+ * @param {!Element|!../../../src/service/ampdoc-impl.AmpDoc} elementOrAmpDoc
+ * @return {!Promise<?LightboxManager>}
+ */
+function lightboxManagerFor(elementOrAmpDoc) {
+  return /** @type {!Promise<?LightboxManager>} */ (
+    getElementServiceForDoc(
+        elementOrAmpDoc, 'amp-lightbox-manager', 'amp-lightbox-gallery'));
+}
+
 AMP.extension(TAG, '0.1', AMP => {
   AMP.registerElement(TAG, AmpLightboxGallery, CSS);
-  installLightboxManager(AMP.win);
-  installLightboxGallery(AMP.win);
+  AMP.registerServiceForDoc('amp-lightbox-manager', LightboxManager);
+  Services.extensionsFor(global).addDocFactory(installLightboxGallery);
 });

--- a/extensions/amp-lightbox-gallery/0.1/service/lightbox-manager-impl.js
+++ b/extensions/amp-lightbox-gallery/0.1/service/lightbox-manager-impl.js
@@ -295,8 +295,7 @@ export class LightboxManager {
     }
     const ariaDescribedBy = element.getAttribute('aria-describedby');
     if (ariaDescribedBy) {
-      const descriptionElement = element.ownerDocument
-          .getElementById(ariaDescribedBy);
+      const descriptionElement = this.ampdoc_.getElementById(ariaDescribedBy);
       if (descriptionElement) {
         return descriptionElement./*OK*/innerText;
       }
@@ -361,7 +360,7 @@ export class LightboxManager {
   getThumbnailSrcset_(element) {
     if (element.hasAttribute('lightbox-thumbnail-id')) {
       const thumbnailId = element.getAttribute('lightbox-thumbnail-id');
-      const thumbnailImage = element.ownerDocument.getElementById(thumbnailId);
+      const thumbnailImage = this.ampdoc_.getElementById(thumbnailId);
       if (thumbnailImage && thumbnailImage.tagName == 'AMP-IMG') {
         return srcsetFromElement(thumbnailImage);
       }

--- a/extensions/amp-lightbox-gallery/0.1/test/test-amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/test/test-amp-lightbox-gallery.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {installLightboxGallery, installLightboxManager} from '../amp-lightbox-gallery';
+import {installLightboxGallery} from '../amp-lightbox-gallery';
 
 const TAG = 'amp-lightbox-gallery';
 
@@ -31,9 +31,9 @@ describes.realWin('amp-lightbox-gallery', {
   beforeEach(() => {
     win = env.win;
     doc = win.document;
-    installLightboxManager(win);
-    installLightboxGallery(win);
-    gallery = doc.getElementById(TAG);
+    return installLightboxGallery(env.ampdoc).then(() => {
+      gallery = doc.getElementById(TAG);
+    });
   });
 
   describe('basic functionality', function() {


### PR DESCRIPTION

- Make the `LightboxManager` a service to be a bit cleaner.
- Use `getAmpDoc().getElementById(...)` instead of `element.ownerDocument.getElementById(...)` so that it works with shadow DOM.

Partially addresses #12859, more work needed when used in shadow docs in single doc mode. There is still a problem with opening an element with an id (e.g. `on="tap:myLightboxGallery.open(id='<elementId>')`) when used in `<amp-next-page>` due to #17614.
