### PR TITLE
add .firebase to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ out/
 firebase
 .firebaserc
 firebase.json
+.firebase/


### PR DESCRIPTION
The newest version of firebase tools adds a `.firebase` folder. Adding it to gitignore. 