### PR TITLE
Cleanup story navigation performance experiment configuration.

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -17,7 +17,6 @@
   "amp-apester-media": 1,
   "amp-ima-video": 1,
   "amp-playbuzz": 1,
-  "amp-story-navigation-performance": 1,
   "chunked-amp": 1,
   "pump-early-frame": 1,
   "amp-auto-ads": 1,

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -19,7 +19,6 @@
   "amp-apester-media": 1,
   "amp-ima-video": 1,
   "amp-playbuzz": 1,
-  "amp-story-navigation-performance": 1,
   "chunked-amp": 1,
   "amp-auto-ads": 1,
   "amp-auto-ads-adsense-holdout": 0.1,


### PR DESCRIPTION
Cleanup the launched `amp-story-navigation-performance` experiment configuration.

Part of #17018