### PR TITLE
Move out isTrustedReferrer from viewer

### DIFF
--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -88,23 +88,6 @@ const TRUSTED_VIEWER_HOSTS = [
 ];
 
 /**
- * These domains are trusted with more sensitive viewer operations such as
- * sending impression requests. If you believe your domain should be here,
- * file the issue on GitHub to discuss. The process will be similar
- * (but somewhat more stringent) to the one described in the [3p/README.md](
- * https://github.com/ampproject/amphtml/blob/master/3p/README.md)
- *
- * @export {!Array<!RegExp>}
- */
-const TRUSTED_REFERRER_HOSTS = [
-  /**
-   * Twitter's link wrapper domains:
-   * - t.co
-   */
-  /^t.co$/,
-];
-
-/**
  * @typedef {function(*):(!Promise<*>|undefined)}
  */
 export let RequestResponder;
@@ -776,19 +759,6 @@ export class Viewer {
   }
 
   /**
-   * @param {string} referrer
-   * @return {boolean}
-   * @private
-   */
-  isTrustedReferrer_(referrer) {
-    const url = parseUrlDeprecated(referrer);
-    if (url.protocol != 'https:') {
-      return false;
-    }
-    return TRUSTED_REFERRER_HOSTS.some(th => th.test(url.hostname));
-  }
-
-  /**
    * Returns an unconfirmed "referrer" URL that can be optionally customized by
    * the viewer. Consider using `getReferrerUrl()` instead, which returns the
    * promise that will yield the confirmed "referrer" URL.
@@ -815,16 +785,6 @@ export class Viewer {
    */
   isTrustedViewer() {
     return this.isTrustedViewer_;
-  }
-
-  /**
-   * Whether the referrer has been whitelisted for CORS impression
-   * @return {!Promise<boolean>}
-   */
-  isTrustedReferrer() {
-    return this.referrerUrl_.then(referrer => {
-      return this.isTrustedReferrer_(referrer);
-    });
   }
 
   /**

--- a/test/functional/test-impression.js
+++ b/test/functional/test-impression.js
@@ -18,6 +18,7 @@ import {Services} from '../../src/services';
 import {
   getExtraParamsUrl,
   getTrackImpressionPromise,
+  isTrustedReferrer,
   maybeTrackImpression,
   resetTrackImpressionPromiseForTesting,
   shouldAppendExtraParams,
@@ -32,7 +33,7 @@ describe('impression', () => {
   let viewer;
   let xhr;
   let isTrustedViewer;
-  let isTrustedReferrer;
+  let referrer = 'http://do-not-trust-me.com';
   let warnStub;
 
   beforeEach(() => {
@@ -54,8 +55,8 @@ describe('impression', () => {
     sandbox.stub(viewer, 'isTrustedViewer').callsFake(() => {
       return Promise.resolve(isTrustedViewer);
     });
-    sandbox.stub(viewer, 'isTrustedReferrer').callsFake(() => {
-      return Promise.resolve(isTrustedReferrer);
+    sandbox.stub(viewer, 'getReferrerUrl').callsFake(() => {
+      return Promise.resolve(referrer);
     });
     resetTrackImpressionPromiseForTesting();
   });
@@ -166,7 +167,7 @@ describe('impression', () => {
     it('should invoke click URL for trusted referrer', function* () {
       toggleExperiment(window, 'alp', false);
       isTrustedViewer = false;
-      isTrustedReferrer = true;
+      referrer = 'https://t.co/docref';
       viewer.getParam.withArgs('click').returns('https://www.example.com');
       maybeTrackImpression(window);
       expect(xhr.fetchJson).to.have.not.been.called;
@@ -412,4 +413,32 @@ describe('impression', () => {
           'gclsrc=QUERY_PARAM(gclsrc)');
     });
   });
+
+  describe('isTrustedReferrer', () => {
+    /**
+     * Tests trust determination by referrer.
+     * @param {string} referrer URL under test.
+     * @param {boolean} toBeTrusted The expected outcome.
+     */
+    function test(referrer, toBeTrusted) {
+      it('testing ' + referrer, () => {
+        expect(isTrustedReferrer(referrer)).to.equal(toBeTrusted);
+      });
+    }
+
+    it('should return true for whitelisted hosts', () => {
+      test('https://t.co/docref', true);
+    });
+
+    it('should not trust host as referrer with http', () => {
+      test('http://t.co/asdf', false);
+    });
+
+    it('should not trust non-whitelisted hosts', () => {
+      test('https://www.t.co/asdf', false);
+      test('https://t.com/asdf', false);
+      test('https://t.cn/asdf', false);
+    });
+  });
+
 });

--- a/test/functional/test-viewer.js
+++ b/test/functional/test-viewer.js
@@ -1321,42 +1321,6 @@ describe('Viewer', () => {
   });
 
   describe('referrer', () => {
-    /**
-     * Tests trust determination by referrer.
-     * @param {string} referrer URL under test.
-     * @param {boolean} toBeTrusted The expected outcome.
-     */
-    function test(referrer, toBeTrusted) {
-      it('testing ' + referrer, () => {
-        const viewer = new Viewer(ampdoc);
-        expect(viewer.isTrustedReferrer_(referrer)).to.equal(toBeTrusted);
-      });
-    }
-
-    describe('should not trust host as referrer with http', () => {
-      test('http://t.co/asdf', false);
-    });
-
-    describe('should trust whitelisted hosts', () => {
-      test('https://t.co/asdf', true);
-    });
-
-    describe('should not trust non-whitelisted hosts', () => {
-      test('https://www.t.co/asdf', false);
-      test('https://t.com/asdf', false);
-      test('https://t.cn/asdf', false);
-    });
-
-    describe('isTrustedReferrer', () => {
-      it('should return true for whitelisted hosts', () => {
-        windowApi.document.referrer = 'https://t.co/docref';
-        const viewer = new Viewer(ampdoc);
-        return viewer.isTrustedReferrer().then(isTrusted => {
-          expect(isTrusted).to.equal(true);
-        });
-      });
-    });
-
     it('should return document referrer if not overriden', () => {
       windowApi.parent = {};
       windowApi.location.hash = '#';


### PR DESCRIPTION
fix last task from #17590: 
Move business logic out of viewer-impl.js