### PR TITLE
📖 Update docs for amp-gist to indicate height does not have to be obtained up front

### DIFF
--- a/extensions/amp-gist/amp-gist.md
+++ b/extensions/amp-gist/amp-gist.md
@@ -74,9 +74,9 @@ Currently only supports `fixed-height`.
 
 ##### height (required)
 
-The height of the gist or gist file in pixels.
+The initial height of the gist or gist file in pixels.
 
-**Note**: You must find the height of the gist by inspecting it with your browser (e.g., Chrome Developer Tools).
+**Note**: You should obtain the height of the gist by inspecting it with your browser (e.g., Chrome Developer Tools). Once the Gist loads the contained iframe will resize to fit so that its contents will fit.
 
 ##### data-file (optional)
 


### PR DESCRIPTION
In the docs for `amp-gist` for its `height` attribute, there is [a note](https://www.ampproject.org/docs/reference/components/amp-gist#height-(required)):

> Note: You must find the height of the gist by inspecting it with your browser (e.g., Chrome Developer Tools).

This turns out not to be true. If the exact height is not specified, the gist will get resized to be the proper dimensions once the gist loads:

https://github.com/ampproject/amphtml/blob/2f5187311d9457b401f300d158ea0c15ba3cc1f0/extensions/amp-gist/0.1/amp-gist.js#L63-L66

So I believe the `height` should be marked as _recommended_, or that it is the _initial_ height of the gist.