### PR TITLE
✨Created the initial <amp-recaptcha-input> 3p Bootstrap Iframe

### DIFF
--- a/3p/integration.js
+++ b/3p/integration.js
@@ -414,7 +414,7 @@ register('pulsepoint', pulsepoint);
 register('purch', purch);
 register('quoraad', quoraad);
 register('realclick', realclick);
-register('recaptcha', recaptcha)
+register('recaptcha', recaptcha);
 register('reddit', reddit);
 register('relap', relap);
 register('revcontent', revcontent);

--- a/3p/integration.js
+++ b/3p/integration.js
@@ -64,6 +64,7 @@ import {facebook} from './facebook';
 import {github} from './github';
 import {gltfViewer} from './3d-gltf/index';
 import {mathml} from './mathml';
+import {recaptcha} from './recaptcha';
 import {reddit} from './reddit';
 import {twitter} from './twitter';
 import {viqeoplayer} from './viqeoplayer';
@@ -413,6 +414,7 @@ register('pulsepoint', pulsepoint);
 register('purch', purch);
 register('quoraad', quoraad);
 register('realclick', realclick);
+register('recaptcha', recaptcha)
 register('reddit', reddit);
 register('relap', relap);
 register('revcontent', revcontent);

--- a/3p/recaptcha.js
+++ b/3p/recaptcha.js
@@ -14,10 +14,39 @@
  * limitations under the License.
  */
 
+import {user} from '../src/log';
+import {writeScript} from './3p';
+
+/**
+ * Get the recaptcha script.
+ *
+ * Use writeScript: Failed to execute 'write' on 'Document': It isn't possible
+ * to write into a document from an asynchronously-loaded external script unless
+ * it is explicitly opened.
+ *
+ * @param {!Window} global
+ * @param {string} scriptSource The source of the script, different for post and comment embeds.
+ * @param {function(*)} cb
+ */
+function getRecaptchaApiJs(global, scriptSource, cb) {
+  writeScript(global, scriptSource, function() {
+    cb(global.gist);
+  });
+}
+
+
 /**
  * @param {!Window} global
  * @param {!Object} data
  */
 export function recaptcha(global, data) {
   console.log('recaptcha is called!');
+  
+  let recaptchaApiUrl = 'https://www.google.com/recaptcha/api.js?render=';
+  recaptchaApiUrl += '6LebBGoUAAAAAHbj1oeZMBU_rze_CutlbyzpH8VE' // TODO: Get sitekey from data
+
+  getRecaptchaApiJs(global, recaptchaApiUrl, function() {
+    console.log('got recaptcha!');
+    console.log('recaptcha object', grecaptcha);
+  });
 }

--- a/3p/recaptcha.js
+++ b/3p/recaptcha.js
@@ -19,7 +19,7 @@ import {dict} from '../src/utils/object';
 import {user} from '../src/log';
 import {writeScript} from './3p';
 
-/** @const {!String} */
+/** @const {string} */
 const TAG = 'RECAPTCHA';
 
 /** {!IframeMessaginClient|null} **/
@@ -59,12 +59,12 @@ function actionTypeHandler(grecaptcha, siteKey, data) {
   grecaptcha.execute(siteKey, {
     action: data.action,
   })./*OK*/then(function(token) {
-    iframeMessagingClient.sendMessage('token', {
+    iframeMessagingClient./*OK*/sendMessage('token', {
       token,
     });
   }).catch(function(err) {
     user().error(TAG, err);
-    iframeMessagingClient.sendMessage('error', dict({
+    iframeMessagingClient./*OK*/sendMessage('error', dict({
       'error': (err || '').toString(),
     }));
   });
@@ -76,9 +76,10 @@ function actionTypeHandler(grecaptcha, siteKey, data) {
  */
 export function recaptcha(global, data) {
   user().assert(
-    data.sitekey,
-    TAG + ' The data-sitekey attribute is required for <amp-recaptcha-input> %s',
-    data.element
+      data.sitekey,
+      TAG +
+      ' The data-sitekey attribute is required for <amp-recaptcha-input> %s',
+      data.element
   );
 
   let recaptchaApiUrl = 'https://www.google.com/recaptcha/api.js?render=';
@@ -93,7 +94,7 @@ export function recaptcha(global, data) {
           'action',
           actionTypeHandler.bind(this, grecaptcha, siteKey)
       );
-      iframeMessagingClient.sendMessage('ready');
+      iframeMessagingClient./*OK*/sendMessage('ready');
     });
   });
 }

--- a/3p/recaptcha.js
+++ b/3p/recaptcha.js
@@ -78,13 +78,14 @@ function actionTypeHandler(grecaptcha, siteKey, data) {
   grecaptcha.execute(siteKey, {
     action: data.action,
   })./*OK*/then(function(token) {
+    // .then() promise pollyfilled by recaptcha api script
     iframeMessagingClient./*OK*/sendMessage(MESSAGE_TAG + 'token', {
       token,
     });
   }).catch(function(err) {
     user().error(TAG, err);
     iframeMessagingClient./*OK*/sendMessage(MESSAGE_TAG + 'error', dict({
-      'error': (err || '').toString(),
+      'error': err.message,
     }));
   });
 }

--- a/3p/recaptcha.js
+++ b/3p/recaptcha.js
@@ -13,3 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+/**
+ * @param {!Window} global
+ * @param {!Object} data
+ */
+export function recaptcha(global, data) {
+  console.log('recaptcha is called!');
+}

--- a/build-system/amp.extern.js
+++ b/build-system/amp.extern.js
@@ -355,6 +355,9 @@ animationHandler.stop;
 animationHandler.goToAndStop;
 animationHandler.totalFrames;
 
+var grecaptcha;
+grecaptcha.execute;
+
 // Validator
 var amp;
 amp.validator;

--- a/build-system/amp.extern.js
+++ b/build-system/amp.extern.js
@@ -330,6 +330,7 @@ data.headerBackgroundColor;
 data.bodyBackgroundColor;
 data.data.fontColor;
 data.width;
+data.sitekey;
 
 // 3p code
 var twttr;


### PR DESCRIPTION
relates to #2273 

This creates the initial 3p Bootstrap Iframe for `<amp-recaptcha-input>`. Here are some things to note:

* renamed `recaptcha-bootstrap.js` to just `recaptcha.js` to be consistent, and work with `integration.js` easier.
* Used `IframeMessagingClient` for messaging, instead of `messaging.js`

I tested this using a gitignored modified `amp-gist` component. Also, it is worth noting, this has no tests, as it seems all the 3p API type services don't have tests, only the iframe messaging systems do.

# Example

This example was made with a modified version of this PR, and I modified `<amp-gist>` just to show the recaptcha 3p bootstrap iframe and it works! 😄 

<img width="1440" alt="screen shot 2018-08-27 at 5 25 58 pm" src="https://user-images.githubusercontent.com/1448289/44694349-c759e480-aa21-11e8-9d9c-34c3d47925bd.png">


