### PR TITLE
Inabox host script - Cannot read property \'top\' of undefined

### DIFF
--- a/ads/inabox/inabox-host.js
+++ b/ads/inabox/inabox-host.js
@@ -70,6 +70,13 @@ export class InaboxHost {
       win.AMP[INABOX_UNREGISTER_IFRAME] = host.unregisterIframe.bind(host);
     }
     const queuedMsgs = win[PENDING_MESSAGES];
+    const processMessageFn = /** @type function(Event)*/((evt) => {
+      try {
+        host.processMessage(evt);
+      } catch (err) {
+        dev().error(TAG, 'Error processing inabox message', message, err);
+      }
+    });
     if (queuedMsgs) {
       if (Array.isArray(queuedMsgs)) {
         queuedMsgs.forEach(message => {
@@ -78,11 +85,7 @@ export class InaboxHost {
           if (!validateMessage(message)) {
             return;
           }
-          try {
-            host.processMessage(message);
-          } catch (err) {
-            dev().error(TAG, 'Error processing inabox message', message, err);
-          }
+          processMessageFn(message);
         });
       } else {
         dev().info(TAG, `Invalid ${PENDING_MESSAGES}`, queuedMsgs);
@@ -91,7 +94,7 @@ export class InaboxHost {
     // Empty and ensure that future messages are no longer stored in the array.
     win[PENDING_MESSAGES] = [];
     win[PENDING_MESSAGES]['push'] = () => {};
-    win.addEventListener('message', /** @type function(Event)*/ (host.processMessage.bind(host)));
+    win.addEventListener('message', processMessageFn.bind(host));
   }
 }
 

--- a/ads/inabox/inabox-host.js
+++ b/ads/inabox/inabox-host.js
@@ -70,11 +70,11 @@ export class InaboxHost {
       win.AMP[INABOX_UNREGISTER_IFRAME] = host.unregisterIframe.bind(host);
     }
     const queuedMsgs = win[PENDING_MESSAGES];
-    const processMessageFn = /** @type function(Event)*/((evt) => {
+    const processMessageFn = /** @type function(Event)*/(evt => {
       try {
         host.processMessage(evt);
       } catch (err) {
-        dev().error(TAG, 'Error processing inabox message', message, err);
+        dev().error(TAG, 'Error processing inabox message', evt, err);
       }
     });
     if (queuedMsgs) {

--- a/ads/inabox/inabox-messaging-host.js
+++ b/ads/inabox/inabox-messaging-host.js
@@ -253,8 +253,10 @@ export class InaboxMessagingHost {
     if (this.iframeMap_[sentinel]) {
       return this.iframeMap_[sentinel].measurableFrame;
     }
-    const measurableFrame =
-      /** @type {HTMLIFrameElement} */(this.getMeasureableFrame(source));
+    const measurableFrame = this.getMeasureableFrame(source);
+    if (!measurableFrame) {
+      return null;
+    }
     const measurableWin = measurableFrame.contentWindow;
     for (let i = 0; i < this.iframes_.length; i++) {
       const iframe = this.iframes_[i];
@@ -284,6 +286,9 @@ export class InaboxMessagingHost {
    * @visibleForTesting
    */
   getMeasureableFrame(win) {
+    if (!win) {
+      return null;
+    }
     // First, we try to find the top-most x-domain window in win's parent
     // hierarchy. If win is not nested within x-domain framing, then
     // this loop breaks immediately.

--- a/test/functional/inabox/test-inabox-messaging-host.js
+++ b/test/functional/inabox/test-inabox-messaging-host.js
@@ -92,6 +92,17 @@ describes.realWin('inabox-host:messaging', {}, env => {
         }),
       })).to.be.false;
     });
+
+    it('should tolerate message with null source', () => {
+      host.processMessage({
+        source: null,
+        origin: 'www.example.com',
+        data: 'amp-' + JSON.stringify({
+          sentinel: '0-123',
+          type: 'send-positions',
+        }),
+      });
+    });
   });
 
   describe('send-positions', () => {


### PR DESCRIPTION
Inabox host script throwing "Uncaught TypeError: Cannot read property \'top\' of undefined" likely due to event source being undefined due to underlying frame being destroyed between when message was sent and when it was processed.  Ensure that underlying code tolerates undefined/null window and that any postmessage processing is wrapped in try/catch (previously only queued events were wrapped).