### PR TITLE
amp-mustache-0.2: Preserve HTML entities in triple-stache

### DIFF
--- a/extensions/amp-mustache/0.1/amp-mustache.js
+++ b/extensions/amp-mustache/0.1/amp-mustache.js
@@ -19,7 +19,7 @@ import {dict} from '../../../src/utils/object';
 import {getMode} from '../../../src/mode';
 import {iterateCursor, templateContentClone} from '../../../src/dom';
 import {parse as mustacheParse, render as mustacheRender,
-  setUnescapedSanitizier} from '../../../third_party/mustache/mustache';
+  setUnescapedSanitizer} from '../../../third_party/mustache/mustache';
 import {sanitizeHtml, sanitizeTagsForTripleMustache} from '../../../src/sanitizer';
 import {user} from '../../../src/log';
 
@@ -41,7 +41,7 @@ export class AmpMustache extends AMP.BaseTemplate {
     super(element, win);
 
     // Unescaped templating (triple mustache) has a special, strict sanitizer.
-    setUnescapedSanitizier(sanitizeTagsForTripleMustache);
+    setUnescapedSanitizer(sanitizeTagsForTripleMustache);
 
     user().warn(TAG, 'The extension "amp-mustache-0.1.js" is deprecated. ' +
         'Please use a more recent version of this extension.');

--- a/extensions/amp-mustache/0.2/amp-mustache.js
+++ b/extensions/amp-mustache/0.2/amp-mustache.js
@@ -19,7 +19,7 @@ import {dict} from '../../../src/utils/object';
 import {getMode} from '../../../src/mode';
 import {iterateCursor, templateContentClone} from '../../../src/dom';
 import {parse as mustacheParse, render as mustacheRender,
-  setUnescapedSanitizier} from '../../../third_party/mustache/mustache';
+  setUnescapedSanitizer} from '../../../third_party/mustache/mustache';
 import {purifyHtml, purifyTagsForTripleMustache} from '../../../src/purifier';
 
 /**
@@ -38,7 +38,8 @@ export class AmpMustache extends AMP.BaseTemplate {
     super(element, win);
 
     // Unescaped templating (triple mustache) has a special, strict sanitizer.
-    setUnescapedSanitizier(purifyTagsForTripleMustache);
+    setUnescapedSanitizer(value =>
+      purifyTagsForTripleMustache(value, this.win.document));
   }
 
   /** @override */

--- a/src/purifier.js
+++ b/src/purifier.js
@@ -412,9 +412,10 @@ export function purifyHtml(dirty) {
  * e.g. triple mustache.
  *
  * @param {string} html
+ * @param {!Document=} doc
  * @return {string}
  */
-export function purifyTagsForTripleMustache(html) {
+export function purifyTagsForTripleMustache(html, doc = self.document) {
   // Reference to DOMPurify's `allowedTags` whitelist.
   let allowedTags;
 
@@ -444,27 +445,11 @@ export function purifyTagsForTripleMustache(html) {
     'RETURN_DOM_FRAGMENT': true,
   });
   DOMPurify.removeAllHooks();
-  return fragmentToHtml(fragment);
-}
-
-/**
- * @param {!DocumentFragment} fragment
- * @return {string}
- */
-function fragmentToHtml(fragment) {
-  let html = '';
-  for (let i = 0; i < fragment.childNodes.length; i++) {
-    const child = fragment.childNodes[i];
-    switch (child.nodeType) {
-      case Node.TEXT_NODE:
-        html += child.textContent;
-        break;
-      case Node.ELEMENT_NODE:
-        html += child./*OK*/outerHTML;
-        break;
-    }
-  }
-  return html;
+  // Serialize DocumentFragment to HTML. XMLSerializer would also work, but adds
+  // namespaces for all elements and attributes.
+  const div = doc.createElement('div');
+  div.appendChild(fragment);
+  return div./*OK*/innerHTML;
 }
 
 /**

--- a/test/functional/test-mustache.js
+++ b/test/functional/test-mustache.js
@@ -23,13 +23,13 @@ describe('Mustache', () => {
 
   beforeEach(() => {
     savedSanitizer = mustache.sanitizeUnescaped;
-    mustache.setUnescapedSanitizier(function(value) {
+    mustache.setUnescapedSanitizer(function(value) {
       return value.toUpperCase();
     });
   });
 
   afterEach(() => {
-    mustache.setUnescapedSanitizier(savedSanitizer);
+    mustache.setUnescapedSanitizer(savedSanitizer);
   });
 
   it('should escape html', () => {

--- a/test/functional/test-purifier.js
+++ b/test/functional/test-purifier.js
@@ -412,6 +412,14 @@ function runSanitizerTests() {
       expect(purifyTagsForTripleMustache('abc')).to.be.equal('abc');
     });
 
+    it('should output HTML entities', () => {
+      const entity = '&lt;tag&gt;';
+      expect(purifyTagsForTripleMustache(entity)).to.be.equal(entity);
+      // DOMPurify short-circuits when there are no '<' characters.
+      expect(purifyTagsForTripleMustache(`<p>${entity}</p>`))
+          .to.be.equal(`<p>${entity}</p>`);
+    });
+
     it('should output valid markup', () => {
       expect(purifyTagsForTripleMustache('<b>abc</b>'))
           .to.be.equal('<b>abc</b>');

--- a/third_party/mustache/mustache.js
+++ b/third_party/mustache/mustache.js
@@ -640,7 +640,7 @@
 
   // Export the sanitizing function for unescaped values.
   mustache.sanitizeUnescaped = null;
-  mustache.setUnescapedSanitizier = function setUnescapedSanitizier (sanitizeUnescaped) {
+  mustache.setUnescapedSanitizer = function setUnescapedSanitizer(sanitizeUnescaped) {
     mustache.sanitizeUnescaped = sanitizeUnescaped;
   };
 


### PR DESCRIPTION
Previous use of `textContent` doesn't preserve HTML entities.

Internal: `b/113323347`