### PR TITLE
🐛Don't fire STAMP ads analytics if no ads  

### DIFF
--- a/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
+++ b/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
@@ -546,6 +546,13 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
       this.uniquePageIds_[pageId] = true;
     }
 
+    if (this.adPagesCreated_ === 0) {
+      // This is protection against us running our placement algorithm in a
+      // story where no ads have been created. Most likely because INI_LOAD on
+      // the story was fired very late, or not at all.
+      return;
+    }
+
     if (this.uniquePagesCount_ > MIN_INTERVAL) {
       const adState = this.tryToPlaceAdAfterPage_(pageId);
 


### PR DESCRIPTION
Some analytics that were triggered by listening to page changes would break if no ad pages existed. This appears to be caused by `INI_LOAD` on the story firing very late or not at all (will file separate issue to investigate)

Closes #17593 