### PR TITLE
Update firebase documentation

### DIFF
--- a/contributing/TESTING.md
+++ b/contributing/TESTING.md
@@ -305,7 +305,7 @@ gulp firebase
 firebase deploy
 ```
 
-`gulp firebase` will generate a `firebase` folder and copy over all files from `dist`, `examples` and `test/manual`. It will rewrite all urls in the copied files to point to the local versions of AMP (i.e. the ones copied from `dist` to `firebase/dist`). It assumes that you have already run `gulp build` or `gulp dist` prior to running `gulp firebase`.  When you initialize firebase, you should set the `firebase` `public` directory to `firebase`. This way `firebase deploy` will just directly copy and deploy the contents of the generated `firebase` folder. As an example, your `firebase.json` file can look something like this:
+`gulp firebase` will generate a `firebase` folder and copy over all files from `dist`, `examples` and `test/manual`. It will rewrite all urls in the copied files to point to the local versions of AMP (i.e. the ones copied from `dist` to `firebase/dist`). It assumes that you have already run `gulp build` or `gulp dist` prior to running `gulp firebase` (use `gulp build` with `gulp firebase` and `gulp dist` with `gulp firebase --min`.  When you initialize firebase, you should set the `firebase` `public` directory to `firebase`. This way `firebase deploy` will just directly copy and deploy the contents of the generated `firebase` folder. As an example, your `firebase.json` file can look something like this:
 
 ```
 {

--- a/contributing/TESTING.md
+++ b/contributing/TESTING.md
@@ -111,7 +111,7 @@ Command                                                                 | Descri
 `gulp visual-diff --grep=<regular-expression-pattern>`                  | Same as above, but executes only those tests whose name matches the regular expression pattern.
 `gulp firebase`                                                         | Generates a folder `firebase` and copies over all files from `examples` and `test/manual` for firebase deployment.
 `gulp firebase --file path/to/file`                                     | Same as above, but copies over the file specified as `firebase/index.html`.
-
+`gulp firebase --min`                                                   | Same as `gulp firebase`, but uses minified files of the form `/dist/v0/amp-component-name.js` instead of unminified files of the form `/dist/v0/amp-component-name.max.js`.
 ## Manual testing
 
 For manual testing build AMP and start the Node.js server by running `gulp`.
@@ -300,8 +300,24 @@ For deploying and testing local AMP builds on [Firebase](https://firebase.google
 npm install -g firebase-tools
 firebase login
 firebase init
+gulp build # or gulp dist
 gulp firebase
 firebase deploy
 ```
 
-`gulp firebase` will generate a `firebase` folder and copy over all files from `examples` and `test/manual`. It will rewrite all urls in the copied files to point to the local versions of AMP.
+`gulp firebase` will generate a `firebase` folder and copy over all files from `dist`, `examples` and `test/manual`. It will rewrite all urls in the copied files to point to the local versions of AMP (i.e. the ones copied from `dist` to `firebase/dist`). It assumes that you have already run `gulp build` or `gulp dist` prior to running `gulp firebase`.  When you initialize firebase, you should set the `firebase` `public` directory to `firebase`. This way `firebase deploy` will just directly copy and deploy the contents of the generated `firebase` folder. As an example, your `firebase.json` file can look something like this:
+
+```
+{
+  "hosting": {
+    "public": "firebase",
+    "ignore": [
+      "firebase.json",
+      "**/.*",
+      "**/node_modules/**"
+    ]
+  }
+}
+```
+
+If you are only testing a single file, you can use `gulp firebase --file=path/to/my/file.amp.html` to avoid copying over all of `test/manual` and `examples`. It will copy over the specified file to `firebase/index.html`, which simplifies debugging.

--- a/contributing/TESTING.md
+++ b/contributing/TESTING.md
@@ -305,7 +305,7 @@ gulp firebase
 firebase deploy
 ```
 
-`gulp firebase` will generate a `firebase` folder and copy over all files from `dist`, `examples` and `test/manual`. It will rewrite all urls in the copied files to point to the local versions of AMP (i.e. the ones copied from `dist` to `firebase/dist`). It assumes that you have already run `gulp build` or `gulp dist` prior to running `gulp firebase` (use `gulp build` with `gulp firebase` and `gulp dist` with `gulp firebase --min`.  When you initialize firebase, you should set the `firebase` `public` directory to `firebase`. This way `firebase deploy` will just directly copy and deploy the contents of the generated `firebase` folder. As an example, your `firebase.json` file can look something like this:
+`gulp firebase` will generate a `firebase` folder and copy over all files from `dist`, `examples` and `test/manual`. It will rewrite all urls in the copied files to point to the local versions of AMP (i.e. the ones copied from `dist` to `firebase/dist`). It assumes that you have already run `gulp build` or `gulp dist` prior to running `gulp firebase` (use `gulp build` with `gulp firebase` and `gulp dist` with `gulp firebase --min`).  When you initialize firebase, you should set the `firebase` `public` directory to `firebase`. This way `firebase deploy` will just directly copy and deploy the contents of the generated `firebase` folder. As an example, your `firebase.json` file can look something like this:
 
 ```
 {


### PR DESCRIPTION
Add a line for `--min` as well as explicit instructions for setting the `firebase` public folder to `firebase` and provide a sample `firebase.json`. 