### PR TITLE
Revert "Don't update position as we scroll (#17507)"

### DIFF
--- a/extensions/amp-carousel/0.1/scrollable-carousel.js
+++ b/extensions/amp-carousel/0.1/scrollable-carousel.js
@@ -190,6 +190,7 @@ export class AmpScrollableCarousel extends BaseCarousel {
    */
   scrollHandler_() {
     const currentScrollLeft = this.container_./*OK*/scrollLeft;
+    this.pos_ = currentScrollLeft;
 
     if (this.scrollTimerId_ === null) {
       this.waitForScroll_(currentScrollLeft);

--- a/test/manual/amp-carousel-scroll-regression.amp.html
+++ b/test/manual/amp-carousel-scroll-regression.amp.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>AMP #0</title>
+  <link rel="canonical" href="amps.html" >
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
+<script async src="https://cdn.ampproject.org/v0.js"></script>
+<script async custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.1.js"></script>
+</head>
+<body>
+  <amp-carousel height="300"
+    layout="fixed-height"
+    type="carousel">
+    <amp-img src="https://ampbyexample.com/img/image1.jpg"
+      width="400"
+      height="300"
+      alt="a sample image"></amp-img>
+    <amp-img src="https://ampbyexample.com/img/image2.jpg"
+      width="400"
+      height="300"
+      alt="another sample image"></amp-img>
+    <amp-img src="https://ampbyexample.com/img/image3.jpg"
+      width="400"
+      height="300"
+      alt="and another sample image"></amp-img>
+  </amp-carousel>
+</body>
+</html>


### PR DESCRIPTION
For some reason I cannot cleanly revert the PR from github, so I opened this branch and added a manual regression test. Fixes regression https://github.com/ampproject/amphtml/issues/17761. 

The reason that #17507 caused this bug was that we needed to update `this.pos_` because scheduling layout and preload depended on it. 