### PR TITLE
Fix spelling of 'tomatoes'

### DIFF
--- a/examples/visual-tests/amp-by-example/visual_effects/basics_of_scrollbound_effects/embed/index.html
+++ b/examples/visual-tests/amp-by-example/visual_effects/basics_of_scrollbound_effects/embed/index.html
@@ -446,7 +446,7 @@ exits the viewport a bit (20%).</li>
 
     <amp-fit-text layout="fill">
       <div class="card-title">
-        Organic, fresh tomatos and pasta!
+        Organic, fresh tomatoes and pasta!
       </div>
     </amp-fit-text>
 
@@ -474,7 +474,7 @@ exits the viewport a bit (20%).</li>
 
   <span class="hljs-tag">&lt;<span class="hljs-name">amp-fit-text</span> <span class="hljs-attr">layout</span>=<span class="hljs-string">"fill"</span>&gt;</span>
     <span class="hljs-tag">&lt;<span class="hljs-name">div</span> <span class="hljs-attr">class</span>=<span class="hljs-string">"card-title"</span>&gt;</span>
-      Organic, fresh tomatos and pasta!
+      Organic, fresh tomatoes and pasta!
     <span class="hljs-tag">&lt;/<span class="hljs-name">div</span>&gt;</span>
   <span class="hljs-tag">&lt;/<span class="hljs-name">amp-fit-text</span>&gt;</span>
 

--- a/examples/visual-tests/amp-by-example/visual_effects/basics_of_scrollbound_effects/index.html
+++ b/examples/visual-tests/amp-by-example/visual_effects/basics_of_scrollbound_effects/index.html
@@ -1208,7 +1208,7 @@ exits the viewport a bit (20%).</li>
 
     <amp-fit-text layout="fill">
       <div class="card-title">
-        Organic, fresh tomatos and pasta!
+        Organic, fresh tomatoes and pasta!
       </div>
     </amp-fit-text>
 
@@ -1236,7 +1236,7 @@ exits the viewport a bit (20%).</li>
 
   <span class="hljs-tag">&lt;<span class="hljs-name">amp-fit-text</span> <span class="hljs-attr">layout</span>=<span class="hljs-string">"fill"</span>&gt;</span>
     <span class="hljs-tag">&lt;<span class="hljs-name">div</span> <span class="hljs-attr">class</span>=<span class="hljs-string">"card-title"</span>&gt;</span>
-      Organic, fresh tomatos and pasta!
+      Organic, fresh tomatoes and pasta!
     <span class="hljs-tag">&lt;/<span class="hljs-name">div</span>&gt;</span>
   <span class="hljs-tag">&lt;/<span class="hljs-name">amp-fit-text</span>&gt;</span>
 

--- a/examples/visual-tests/amp-by-example/visual_effects/basics_of_scrollbound_effects/preview/embed/index.html
+++ b/examples/visual-tests/amp-by-example/visual_effects/basics_of_scrollbound_effects/preview/embed/index.html
@@ -199,7 +199,7 @@
 
     <amp-fit-text layout="fill">
       <div class="card-title">
-        Organic, fresh tomatos and pasta!
+        Organic, fresh tomatoes and pasta!
       </div>
     </amp-fit-text>
 

--- a/examples/visual-tests/amp-by-example/visual_effects/basics_of_scrollbound_effects/preview/index.html
+++ b/examples/visual-tests/amp-by-example/visual_effects/basics_of_scrollbound_effects/preview/index.html
@@ -210,7 +210,7 @@
 
     <amp-fit-text layout="fill">
       <div class="card-title">
-        Organic, fresh tomatos and pasta!
+        Organic, fresh tomatoes and pasta!
       </div>
     </amp-fit-text>
 

--- a/examples/visual-tests/amp-by-example/visual_effects/basics_of_scrollbound_effects/source/index.html
+++ b/examples/visual-tests/amp-by-example/visual_effects/basics_of_scrollbound_effects/source/index.html
@@ -212,7 +212,7 @@
 
     <amp-fit-text layout="fill">
       <div class="card-title">
-        Organic, fresh tomatos and pasta!
+        Organic, fresh tomatoes and pasta!
       </div>
     </amp-fit-text>
 


### PR DESCRIPTION
Documentation has `tomatos` where the standard spelling is `tomatoes`.  Fix it.
