### PR TITLE
✨ Support (open) shadow roots in layers

### DIFF
--- a/build-system/tasks/bundle-size.js
+++ b/build-system/tasks/bundle-size.js
@@ -22,7 +22,7 @@ const log = require('fancy-log');
 const {getStdout} = require('../exec');
 
 const runtimeFile = './dist/v0.js';
-const maxSize = '81.15KB';
+const maxSize = '81.19KB';
 
 const {green, red, cyan, yellow} = colors;
 

--- a/build-system/tasks/bundle-size.js
+++ b/build-system/tasks/bundle-size.js
@@ -22,7 +22,7 @@ const log = require('fancy-log');
 const {getStdout} = require('../exec');
 
 const runtimeFile = './dist/v0.js';
-const maxSize = '81.19KB';
+const maxSize = '81.22KB';
 
 const {green, red, cyan, yellow} = colors;
 

--- a/src/service/layers-impl.js
+++ b/src/service/layers-impl.js
@@ -116,6 +116,7 @@ export class LayoutLayers {
      * TODO(jridgewell, #12556): send an array of elements who have changed
      * position due to the scroll.
      * @type {function()|null}
+     * @private
      */
     this.onScroll_ = null;
 
@@ -314,6 +315,7 @@ export class LayoutLayers {
    * @param {boolean} isRootLayer
    * @param {boolean} scrollsLikeViewport
    * @return {!LayoutElement}
+   * @private
    */
   declareLayer_(element, isRootLayer, scrollsLikeViewport) {
     const layout = this.add(element);
@@ -324,6 +326,7 @@ export class LayoutLayers {
   /**
    * Destroys the layer tree, since new CSS may apply to the document after a
    * resize.
+   * @private
    */
   onResize_() {
     const layouts = this.layouts_;
@@ -338,6 +341,7 @@ export class LayoutLayers {
    * Listens for scroll events on root.
    *
    * @param {!Node} root
+   * @private
    */
   listenForScroll_(root) {
     this.unlisteners_.push(listen(root, 'scroll', event => {
@@ -355,6 +359,7 @@ export class LayoutLayers {
    * position (instead of having to check all elements in the listener).
    *
    * @param {!Event} event
+   * @private
    */
   scrolled_(event) {
     const {target} = event;
@@ -759,6 +764,7 @@ export class LayoutElement {
    * the this layer.
    *
    * @param {!LayoutElement} layer
+   * @private
    */
   transfer_(layer) {
     // An optimization if we know that the new layer definitely contains
@@ -1115,6 +1121,7 @@ export class LayoutElement {
    *
    * @param {!PositionDef=} opt_relativeTo A performance optimization used when
    *     recursively measuring the child nodes of the layer.
+   * @private
    */
   remeasure_(opt_relativeTo) {
     this.updateScrollPosition_();
@@ -1169,6 +1176,7 @@ export class LayoutElement {
 
   /**
    * Updates the cached scroll positions of the layer, if the layer is dirty.
+   * @private
    */
   updateScrollPosition_() {
     if (this.isLayer_ && this.needsScrollRemeasure_) {

--- a/src/service/layers-impl.js
+++ b/src/service/layers-impl.js
@@ -133,7 +133,7 @@ export class LayoutLayers {
 
     // Scroll events do not bubble out of shadow trees.
     // Strangely, iOS 11 reports that document contains things in a shadow tree.
-    // Any node element, however, doesn't.
+    // Any Element, however, doesn't.
     if (!win.document.documentElement.contains(scrollingElement)) {
       this.listenForScroll_(scrollingElement);
     }
@@ -358,6 +358,12 @@ export class LayoutLayers {
    */
   scrolled_(event) {
     const {target} = event;
+    // If the target of the scroll event is an element, that means that element
+    // is an overflow scroller.
+    // However, if the target is the document itself, that means the native
+    // root scroller (`document.scrollingElement`) did the scrolling. But, we
+    // can't assign a layer to a Document (only Elements), so just pretend it
+    // was the scrolling element that scrolled.
     const scrolled = target.nodeType == Node.ELEMENT_NODE
       ? dev().assertElement(target)
       : this.scrollingElement_;

--- a/src/service/layers-impl.js
+++ b/src/service/layers-impl.js
@@ -129,17 +129,13 @@ export class LayoutLayers {
     // the document (the scrolling element) or an element scrolls.
     // This forwards to our scroll-dirty system, and eventually to the scroll
     // listener.
-    this.unlisteners_.push(listen(win.document, 'scroll', event => {
-      this.scrolled_(event);
-    }, {capture: true, passive: true}));
+    this.listenForScroll_(win.document);
 
     // Scroll events do not bubble out of shadow trees.
     // Strangely, iOS 11 reports that document contains things in a shadow tree.
     // Any node element, however, doesn't.
     if (!win.document.documentElement.contains(scrollingElement)) {
-      this.unlisteners_.push(listen(scrollingElement, 'scroll', event => {
-        this.scrolled_(event);
-      }, {capture: true, passive: true}));
+      this.listenForScroll_(scrollingElement);
     }
 
     // Destroys the layer tree on document resize, since entirely new CSS may
@@ -336,6 +332,17 @@ export class LayoutLayers {
       layout.undeclareLayer();
       layout.forgetParentLayer();
     }
+  }
+
+  /**
+   * Listens for scroll events on root.
+   *
+   * @param {!Node} root
+   */
+  listenForScroll_(root) {
+    this.unlisteners_.push(listen(scrollingElement, 'scroll', event => {
+      this.scrolled_(event);
+    }, {capture: true, passive: true}));
   }
 
   /**

--- a/src/service/layers-impl.js
+++ b/src/service/layers-impl.js
@@ -340,7 +340,7 @@ export class LayoutLayers {
    * @param {!Node} root
    */
   listenForScroll_(root) {
-    this.unlisteners_.push(listen(scrollingElement, 'scroll', event => {
+    this.unlisteners_.push(listen(root, 'scroll', event => {
       this.scrolled_(event);
     }, {capture: true, passive: true}));
   }

--- a/src/service/layers-impl.js
+++ b/src/service/layers-impl.js
@@ -547,7 +547,7 @@ export class LayoutElement {
    * If the element is itself a layer, it still looks in the element's ancestry
    * for a parent layer.
    *
-   * TODO(jridgewell, #12554): Needs to traverse FIE/Shadow boundary.
+   * TODO(jridgewell, #12554): Needs to traverse FIE boundary.
    *
    * @param {!Element} node
    * @param {boolean=} opt_force Whether to force a re-lookup
@@ -610,7 +610,7 @@ export class LayoutElement {
           // node is the op, we can't return the node as its own parent layer.
           // In that case, it doesn't have a parent layer.
           // TODO(jridgewell, #12554): Fixed position's parent is the FIE
-          // element, what about Shadows?
+          // element.
           return op === node ? null : LayoutElement.for(op);
         }
         op = op./*OK*/offsetParent;
@@ -639,8 +639,8 @@ export class LayoutElement {
    * A check that the LayoutElement is contained by this layer, and the element
    * is not the layer's element.
    *
-   * TODO(jridgewell, #12554): This needs to account for FIE/Shadow's root,
-   * since it will be a child layout of the host element.
+   * TODO(jridgewell, #12554): This needs to account for FIE root, since it
+   * will be a child layout of the host element.
    *
    * @param {!LayoutElement} layout
    * @return {boolean}

--- a/src/service/layers-impl.js
+++ b/src/service/layers-impl.js
@@ -17,11 +17,11 @@
 import {Services} from '../services';
 import {computedStyle} from '../style';
 import {dev} from '../log';
-import {escapeCssSelectorIdent, rootNodeFor} from '../dom';
 import {filterSplice} from '../utils/array';
 import {getMode} from '../mode';
 import {listen} from '../event-helper';
 import {registerServiceBuilderForDoc} from '../service';
+import {rootNodeFor} from '../dom';
 
 const LAYOUT_PROP = '__AMP_LAYOUT';
 

--- a/src/service/layers-impl.js
+++ b/src/service/layers-impl.js
@@ -17,6 +17,7 @@
 import {Services} from '../services';
 import {computedStyle} from '../style';
 import {dev} from '../log';
+import {escapeCssSelectorIdent, rootNodeFor} from '../dom';
 import {filterSplice} from '../utils/array';
 import {getMode} from '../mode';
 import {listen} from '../event-helper';
@@ -562,8 +563,34 @@ export class LayoutElement {
 
     const win = /** @type {!Window } */ (dev().assert(
         node.ownerDocument.defaultView));
+    let el = node;
     let op = node;
-    for (let el = node; el; el = el.parentNode) {
+    let last = node.shadowRoot;
+    while (el) {
+      const {shadowRoot} = el;
+      // There are two ways to get to this el.
+      // 1. We traversed up the normal DOM tree, in which case last will be
+      //   a child node.
+      // 2. We traversed up from the shadow root itself, in which case last
+      //   will be the shadow root.
+      // We don't want to go into the shadow root infinitely, so make sure last
+      // isn't the shadow root.
+      if (shadowRoot && last !== shadowRoot) {
+        const name = last.nodeType === Node.ELEMENT_NODE
+          ? last.getAttribute('slot')
+          : null;
+        const selector = name
+          ? `slot[name="${escapeCssSelectorIdent(name)}"]`
+          : 'slot:not([name]),slot[name=""]';
+        const slot = shadowRoot.querySelector(selector);
+
+        if (slot) {
+          last = el;
+          el = slot;
+          continue;
+        }
+      }
+
       // Ensure the node (if it a layer itself) is not return as the parent
       // layer.
       const layout = el === node ? null : LayoutElement.forOptional(el);
@@ -588,6 +615,10 @@ export class LayoutElement {
         }
         op = op./*OK*/offsetParent;
       }
+
+      last = el;
+      // Shadow roots have a host, not a parentNode.
+      el = el.parentNode || el.host;
     }
 
     // Use isConnected if available, but always pass if it's not.
@@ -615,7 +646,19 @@ export class LayoutElement {
    * @return {boolean}
    */
   contains(layout) {
-    return layout !== this && this.element_.contains(layout.element_);
+    if (layout === this) {
+      return false;
+    }
+    const element = this.element_;
+    const other = layout.element_;
+    if (element.contains(other)) {
+      return true;
+    }
+
+    // Layers inside a shadow tree may contain children from the light tree.
+    const rootNode = rootNodeFor(element);
+    const host = rootNode && rootNode.host;
+    return !!host && host.contains(other);
   }
 
   /**

--- a/test/functional/test-layers.js
+++ b/test/functional/test-layers.js
@@ -22,32 +22,50 @@ import {Services} from '../../src/services';
 import {installDocService} from '../../src/service/ampdoc-impl';
 
 describes.repeated('messaging', {
-  'Real document scroller': true,
-  'Overflow scroller': false,
-}, (name, useDocumentScroller) => {
+  'Real document scroller': 'native',
+  'Overflow scroller': 'overflow',
+  'Shadow DOM scroller': 'shadow',
+}, (name, impl) => {
   describes.realWin(`Layers (${name})`, {amp: false}, env => {
     let win;
     let root;
+    let scrollingElement;
 
-    function createElement() {
-      const div = win.document.createElement('div');
-      Object.defineProperty(div, 'isConnected', {
-        value: true,
-      });
-      return div;
+    function createElement(tag = 'div') {
+      return win.document.createElement(tag);
     }
+
+    before(function() {
+      if (impl === 'shadow' && !Element.prototype.attachShadow) {
+        this.skip();
+      }
+    });
 
     beforeEach(() => {
       win = env.win;
-      if (useDocumentScroller) {
-        root = win.document.scrollingElement;
-      } else {
-        root = createElement();
-        win.document.body.appendChild(root);
+      switch (impl) {
+        case 'native':
+          root = scrollingElement = win.document.scrollingElement;
+          break;
+
+        case 'overflow':
+          root = scrollingElement = createElement();
+          win.document.body.appendChild(root);
+          break;
+
+        case 'shadow': {
+          root = win.document.body;
+          scrollingElement = createElement('div');
+          const sd = root.attachShadow({mode: 'open'});
+          const slot = createElement('slot');
+          scrollingElement.appendChild(slot);
+          sd.appendChild(scrollingElement);
+        }
       }
+
       installDocService(win, true);
       const ampdoc = Services.ampdocServiceFor(win).getAmpDoc();
-      installLayersServiceForDoc(ampdoc, root, useDocumentScroller);
+      installLayersServiceForDoc(ampdoc, scrollingElement, impl === 'native');
     });
 
     function scroll(element, top, left) {
@@ -60,8 +78,8 @@ describes.repeated('messaging', {
     describe('LayoutElement', () => {
 
       describe('.getParentLayer', () => {
-        it('returns null for root layer', () => {
-          expect(LayoutElement.getParentLayer(root)).to.be.null;
+        it('returns null for scrolling layer', () => {
+          expect(LayoutElement.getParentLayer(scrollingElement)).to.be.null;
         });
 
         it('returns parent layer', () => {
@@ -69,7 +87,7 @@ describes.repeated('messaging', {
           root.appendChild(div);
 
           expect(LayoutElement.getParentLayer(div)).to.equal(
-              LayoutElement.for(root));
+              LayoutElement.for(scrollingElement));
         });
 
         it('returns null if element is fixed', () => {
@@ -104,10 +122,10 @@ describes.repeated('messaging', {
           parent.appendChild(div);
           root.appendChild(parent);
 
-          root.style.width = '100vw';
-          root.style.height = '100vh';
-          root.style.position = 'absolute';
-          root.style.overflow = 'scroll';
+          scrollingElement.style.width = '100vw';
+          scrollingElement.style.height = '100vh';
+          scrollingElement.style.position = 'absolute';
+          scrollingElement.style.overflow = 'scroll';
           parent.style.width = '110vw';
           parent.style.height = '110vh';
           parent.style.position = 'absolute';
@@ -122,7 +140,7 @@ describes.repeated('messaging', {
           layers.add(div);
           layout = LayoutElement.for(div);
           parentLayout = LayoutElement.for(parent);
-          rootLayout = LayoutElement.for(root);
+          rootLayout = LayoutElement.for(scrollingElement);
         });
 
         it('calculates layout offsets without scrolls', () => {
@@ -203,7 +221,7 @@ describes.repeated('messaging', {
             top: 0,
           });
 
-          scroll(root, 10, 0);
+          scroll(scrollingElement, 10, 0);
           expect(rootLayout.getScrollTop()).to.equal(10);
           expect(rootLayout.getScrolledPosition()).to.deep.equal({
             left: 0,
@@ -229,7 +247,7 @@ describes.repeated('messaging', {
             top: -10,
           });
 
-          scroll(root, 10, 5);
+          scroll(scrollingElement, 10, 5);
           expect(rootLayout.getScrollTop()).to.equal(10);
           expect(layout.getScrolledPosition()).to.deep.equal({
             left: -10,
@@ -255,10 +273,10 @@ describes.repeated('messaging', {
           parent.appendChild(div);
           root.appendChild(parent);
 
-          root.style.width = '100vw';
-          root.style.height = '100vh';
-          root.style.position = 'absolute';
-          root.style.overflow = 'scroll';
+          scrollingElement.style.width = '100vw';
+          scrollingElement.style.height = '100vh';
+          scrollingElement.style.position = 'absolute';
+          scrollingElement.style.overflow = 'scroll';
           parent.style.width = '110vw';
           parent.style.height = '110vh';
           parent.style.position = 'absolute';
@@ -273,7 +291,7 @@ describes.repeated('messaging', {
           layers.add(div);
           layout = LayoutElement.for(div);
           parentLayout = LayoutElement.for(parent);
-          rootLayout = LayoutElement.for(root);
+          rootLayout = LayoutElement.for(scrollingElement);
         });
 
         it('calculates layout offsets without scrolls', () => {
@@ -354,7 +372,7 @@ describes.repeated('messaging', {
             top: 0,
           });
 
-          scroll(root, 10, 0);
+          scroll(scrollingElement, 10, 0);
           expect(rootLayout.getScrollTop()).to.equal(10);
           expect(rootLayout.getOffsetPosition()).to.deep.equal({
             left: 0,
@@ -380,7 +398,7 @@ describes.repeated('messaging', {
             top: 0,
           });
 
-          scroll(root, 10, 5);
+          scroll(scrollingElement, 10, 5);
           expect(rootLayout.getScrollTop()).to.equal(10);
           expect(layout.getOffsetPosition()).to.deep.equal({
             left: 0,

--- a/test/functional/test-layers.js
+++ b/test/functional/test-layers.js
@@ -37,7 +37,7 @@ describes.repeated('messaging', {
 
     before(function() {
       if (impl === 'shadow' && !Element.prototype.attachShadow) {
-        this.skip();
+        this.skipTest();
       }
     });
 


### PR DESCRIPTION
This traverses open shadow trees when looking for parent layers.

It also listens for events on the scrolling element directly, when Layers detects that it is inside of a shadow tree. Scroll events don't bubble out of the shadow tree, sadly. Nor do they bubble to the shadow root, ugh. So for this to be truly generic I would have to install a MutaitonObserver on the shadow root, then listen for scroll events on any child of the shadow root.

But that's too much work for now.