### PR TITLE
🏗 Assume the loading_complete_delay_ms in visual-diffs is correct

### DIFF
--- a/build-system/tasks/visual-diff.js
+++ b/build-system/tasks/visual-diff.js
@@ -456,16 +456,10 @@ async function snapshotWebpages(percy, page, webpages, config) {
         webpage.loading_incomplete_css, webpage.loading_complete_css);
 
     if (webpage.loading_complete_delay_ms) {
-      if (typeof webpage.loading_complete_delay_ms !== 'number' &&
-          webpage.loading_complete_delay_ms > 0) {
-        log('verbose', 'Waiting',
-            colors.cyan(webpage.loading_complete_delay_ms + 'ms'),
-            'for loading to complete');
-        await sleep(webpage.loading_complete_delay_ms || 0);
-      } else {
-        log('warning', 'Skipping unknown delay',
-            webpage.loading_complete_delay_ms);
-      }
+      log('verbose', 'Waiting',
+          colors.cyan(`${webpage.loading_complete_delay_ms}ms`),
+          'for loading to complete');
+      await sleep(webpage.loading_complete_delay_ms);
     }
 
     if (webpage.enable_percy_javascript) {


### PR DESCRIPTION
For some reason it keeps showing errors for fields that are 100% certainly correct, removing the error checking, surprisingly, makes it work better :laughing: 

This is a safe change, since a wrong value would cause the build to fail with a crash, and the Travis checks would show red