### PR TITLE
🐛 Sets page ID and index on CTA links to allow usage with click tracking

### DIFF
--- a/examples/amp-story/analytics.html
+++ b/examples/amp-story/analytics.html
@@ -42,9 +42,18 @@
             "requests": {
               "endpoint": "https://raw.githubusercontent.com/ampproject/amphtml/master/examples/img/ampicon.png",
               "base": "${endpoint}?${type|default:foo}&path=${canonicalPath}",
-              "pageView": "${base}?&index=${storyPageIndex}&count=${storyPageCount}&id=${storyPageId}&muted=${storyIsMuted}&progress=${storyProgress}"
+              "pageView": "${base}?&index=${storyPageIndex}&count=${storyPageCount}&id=${storyPageId}&muted=${storyIsMuted}&progress=${storyProgress}",
+              "click": "${base}?index=${storyPageIndex}&id=${storyPageId}"
             },
             "triggers": {
+              "trackAnchorClicks": {
+                "on": "click",
+                "selector": "amp-story-cta-layer a",
+                "request": "click",
+                "vars": {
+                  "eventId": "clickOnAnyAnchor"
+                }
+              },
               "trackPageview": {
                 "on": "story-page-visible",
                 "request": "pageView"
@@ -85,6 +94,9 @@
       <amp-story-page id="p3">
         <amp-story-grid-layer template="vertical">
           <h1>Page Three</h1>
+        </amp-story-grid-layer>
+        <amp-story-cta-layer>
+          <a>click me</a>
         </amp-story-grid-layer>
       </amp-story-page>
 

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -148,6 +148,9 @@ export class AmpStoryPage extends AMP.BaseElement {
      * @private @const {boolean}
      */
     this.isBotUserAgent_ = Services.platformFor(this.win).isBot();
+
+    /** @private {?number} */
+    this.index_ = null;
   }
 
 

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -148,9 +148,6 @@ export class AmpStoryPage extends AMP.BaseElement {
      * @private @const {boolean}
      */
     this.isBotUserAgent_ = Services.platformFor(this.win).isBot();
-
-    /** @private {?number} */
-    this.index_ = null;
   }
 
 

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -693,8 +693,9 @@ export class AmpStory extends AMP.BaseElement {
     const storyLayoutPromise = this.initializePages_()
         .then(() => this.buildSystemLayer_())
         .then(() => {
-          this.pages_.forEach(page => {
+          this.pages_.forEach((page, index) => {
             page.setState(PageState.NOT_ACTIVE);
+            this.upgradeCtaAnchorTagsForTracking_(page, index);
           });
         })
         .then(() => this.switchTo_(initialPageId))
@@ -1850,6 +1851,25 @@ export class AmpStory extends AMP.BaseElement {
         removeAttributeInMutate(page, Attributes.VISITED));
     }));
   }
+
+
+  /**
+   * @param {!AmpStoryPage} page The page whose CTA anchor tags should be
+   *     upgraded.
+   * @param {number} pageIndex The index of the page.
+   * @private
+   */
+  upgradeCtaAnchorTagsForTracking_(page, pageIndex) {
+    const pageId = page.element.id;
+    const ctaAnchorEls =
+        scopedQuerySelectorAll(page.element, 'amp-story-cta-layer a');
+
+    Array.prototype.forEach.call(ctaAnchorEls, ctaAnchorEl => {
+      ctaAnchorEl.setAttribute('data-vars-story-page-id', pageId);
+      ctaAnchorEl.setAttribute('data-vars-story-page-index', pageIndex);
+    });
+  }
+
 
   /** @return {!NavigationState} */
   getNavigationState() {

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -1860,13 +1860,15 @@ export class AmpStory extends AMP.BaseElement {
    * @private
    */
   upgradeCtaAnchorTagsForTracking_(page, pageIndex) {
-    const pageId = page.element.id;
-    const ctaAnchorEls =
-        scopedQuerySelectorAll(page.element, 'amp-story-cta-layer a');
+    this.mutateElement(() => {
+      const pageId = page.element.id;
+      const ctaAnchorEls =
+          scopedQuerySelectorAll(page.element, 'amp-story-cta-layer a');
 
-    Array.prototype.forEach.call(ctaAnchorEls, ctaAnchorEl => {
-      ctaAnchorEl.setAttribute('data-vars-story-page-id', pageId);
-      ctaAnchorEl.setAttribute('data-vars-story-page-index', pageIndex);
+      Array.prototype.forEach.call(ctaAnchorEls, ctaAnchorEl => {
+        ctaAnchorEl.setAttribute('data-vars-story-page-id', pageId);
+        ctaAnchorEl.setAttribute('data-vars-story-page-index', pageIndex);
+      });
     });
   }
 


### PR DESCRIPTION
This allows CTA links to be logged by following the instructions [here](https://ampbyexample.com/components/amp-analytics/#anchor-clicks)

It works by using [variables as data attributes](https://github.com/ampproject/amphtml/blob/master/extensions/amp-analytics/analytics-vars.md#variables-as-data-attribute) specified on the element, that are specifically named to match the `storyPageIndex` and `storyPageId` variables that we already publish.

Ideally, I think we would do this at the page level, but pages do not know their own index within the story.  We should take on a larger refactor to simplify this, but I think this would include some more dangerous changes, like initializing the pages array at build time.