### PR TITLE
Fix error when URL macro whitelist is empty

### DIFF
--- a/build-system/tasks/bundle-size.js
+++ b/build-system/tasks/bundle-size.js
@@ -22,7 +22,7 @@ const log = require('fancy-log');
 const {getStdout} = require('../exec');
 
 const runtimeFile = './dist/v0.js';
-const maxSize = '81.01KB';
+const maxSize = '81.03KB';
 
 const {green, red, cyan, yellow} = colors;
 

--- a/src/service/variable-source.js
+++ b/src/service/variable-source.js
@@ -263,7 +263,7 @@ export class VariableSource {
       keys = keys.filter(key => opt_whiteList[key]);
     }
     if (keys.length === 0) {
-      const regexThatMatchesNothing = /_^/g;
+      const regexThatMatchesNothing = /_^/g; // lgtm [js/regex/unmatchable-caret]
       return regexThatMatchesNothing;
     }
     // The keys must be sorted to ensure that the longest keys are considered

--- a/src/service/variable-source.js
+++ b/src/service/variable-source.js
@@ -262,6 +262,10 @@ export class VariableSource {
     if (opt_whiteList) {
       keys = keys.filter(key => opt_whiteList[key]);
     }
+    if (keys.length === 0) {
+      const regexThatMatchesNothing = /_^/g;
+      return regexThatMatchesNothing;
+    }
     // The keys must be sorted to ensure that the longest keys are considered
     // first. This avoids a problem where a RANDOM conflicts with RANDOM_ONE.
     keys.sort((s1, s2) => s2.length - s1.length);

--- a/test/functional/test-variable-source.js
+++ b/test/functional/test-variable-source.js
@@ -127,6 +127,23 @@ describes.fakeWin('VariableSource', {
 
   });
 
+  it('Should not work with empty variable whitelist', () => {
+    env.win.document.head.appendChild(
+        createElementWithAttributes(env.win.document, 'meta', {
+          name: 'amp-allowed-url-macros',
+          content: '',
+        }));
+    const variableSource = new VariableSource(env.ampdoc);
+
+    variableSource.setAsync('RANDOM', () => Promise.resolve('0.1234'));
+    expect(variableSource.getExpr()).to.be.ok;
+    expect(variableSource.getExpr().toString()).not.to.contain('RANDOM');
+
+    return variableSource.get('RANDOM')['async']().then(value => {
+      expect(value).to.equal('0.1234');
+    });
+  });
+
   describes.fakeWin('getTimingData', {}, env => {
     let win;
 

--- a/test/functional/url-expander/test-expander.js
+++ b/test/functional/url-expander/test-expander.js
@@ -97,29 +97,53 @@ describes.realWin('Expander', {
       ABC: () => 'three',
       ABCD: () => 'four',
     };
-    beforeEach(() => {
-      env.win.document.head.appendChild(
-          createElementWithAttributes(env.win.document, 'meta', {
-            name: 'amp-allowed-url-macros',
-            content: 'ABC,ABCD,CANONICAL',
-          }));
 
-      variableSource = new GlobalVariableSource(env.ampdoc);
-      expander = new Expander(variableSource);
+    describe('Non-empty whitelist', () => {
+      beforeEach(() => {
+        env.win.document.head.appendChild(
+            createElementWithAttributes(env.win.document, 'meta', {
+              name: 'amp-allowed-url-macros',
+              content: 'ABC,ABCD,CANONICAL',
+            }));
+
+        variableSource = new GlobalVariableSource(env.ampdoc);
+        expander = new Expander(variableSource);
+      });
+
+      it('should not replace unwhitelisted RANDOM', () => {
+        const url = 'http://www.google.com/?test=RANDOM';
+        const expected = 'http://www.google.com/?test=RANDOM';
+        return expect(expander.expand(url, mockBindings))
+            .to.eventually.equal(expected);
+      });
+
+      it('should replace whitelisted ABCD', () => {
+        const url = 'http://www.google.com/?test=ABCD';
+        const expected = 'http://www.google.com/?test=four';
+        return expect(expander.expand(url, mockBindings))
+            .to.eventually.equal(expected);
+      });
     });
 
-    it('should not replace unwhitelisted RANDOM', () => {
-      const url = 'http://www.google.com/?test=RANDOM';
-      const expected = 'http://www.google.com/?test=RANDOM';
-      return expect(expander.expand(url, mockBindings))
-          .to.eventually.equal(expected);
-    });
+    describe('Empty whitelist', () => {
+      beforeEach(() => {
+        env.win.document.head.appendChild(
+            createElementWithAttributes(env.win.document, 'meta', {
+              name: 'amp-allowed-url-macros',
+              content: '',
+            }));
 
-    it('should replace whitelisted ABCD', () => {
-      const url = 'http://www.google.com/?test=ABCD';
-      const expected = 'http://www.google.com/?test=four';
-      return expect(expander.expand(url, mockBindings))
-          .to.eventually.equal(expected);
+        variableSource = new GlobalVariableSource(env.ampdoc);
+        expander = new Expander(variableSource);
+      });
+
+      it('should not replace anything', () => {
+        const url = 'http://www.google.com/?test=ABCD';
+        const expected = 'http://www.google.com/?test=ABCD';
+        return expect(expander.expand(url, mockBindings))
+            .to.eventually.equal(expected);
+      });
+
     });
   });
 

--- a/test/functional/url-expander/test-expander.js
+++ b/test/functional/url-expander/test-expander.js
@@ -89,62 +89,47 @@ describes.realWin('Expander', {
   });
 
   describe('Whitelist of variables', () => {
-    let variableSource;
-    let expander;
-
     const mockBindings = {
       RANDOM: () => 0.1234,
       ABC: () => 'three',
       ABCD: () => 'four',
     };
 
-    describe('Non-empty whitelist', () => {
-      beforeEach(() => {
-        env.win.document.head.appendChild(
-            createElementWithAttributes(env.win.document, 'meta', {
-              name: 'amp-allowed-url-macros',
-              content: 'ABC,ABCD,CANONICAL',
-            }));
+    function createExpanderWithWhitelist(whitelist) {
+      env.win.document.head.appendChild(
+          createElementWithAttributes(env.win.document, 'meta', {
+            name: 'amp-allowed-url-macros',
+            content: whitelist,
+          }));
 
-        variableSource = new GlobalVariableSource(env.ampdoc);
-        expander = new Expander(variableSource);
-      });
+      variableSource = new GlobalVariableSource(env.ampdoc);
+      return new Expander(variableSource);
+    }
 
-      it('should not replace unwhitelisted RANDOM', () => {
-        const url = 'http://www.google.com/?test=RANDOM';
-        const expected = 'http://www.google.com/?test=RANDOM';
-        return expect(expander.expand(url, mockBindings))
-            .to.eventually.equal(expected);
-      });
-
-      it('should replace whitelisted ABCD', () => {
-        const url = 'http://www.google.com/?test=ABCD';
-        const expected = 'http://www.google.com/?test=four';
-        return expect(expander.expand(url, mockBindings))
-            .to.eventually.equal(expected);
-      });
+    it('should not replace unwhitelisted RANDOM', () => {
+      const expander = createExpanderWithWhitelist('ABC,ABCD,CANONICAL');
+      const url = 'http://www.google.com/?test=RANDOM';
+      const expected = 'http://www.google.com/?test=RANDOM';
+      return expect(expander.expand(url, mockBindings))
+          .to.eventually.equal(expected);
     });
 
-    describe('Empty whitelist', () => {
-      beforeEach(() => {
-        env.win.document.head.appendChild(
-            createElementWithAttributes(env.win.document, 'meta', {
-              name: 'amp-allowed-url-macros',
-              content: '',
-            }));
-
-        variableSource = new GlobalVariableSource(env.ampdoc);
-        expander = new Expander(variableSource);
-      });
-
-      it('should not replace anything', () => {
-        const url = 'http://www.google.com/?test=ABCD';
-        const expected = 'http://www.google.com/?test=ABCD';
-        return expect(expander.expand(url, mockBindings))
-            .to.eventually.equal(expected);
-      });
-
+    it('should replace whitelisted ABCD', () => {
+      const expander = createExpanderWithWhitelist('ABC,ABCD,CANONICAL');
+      const url = 'http://www.google.com/?test=ABCD';
+      const expected = 'http://www.google.com/?test=four';
+      return expect(expander.expand(url, mockBindings))
+          .to.eventually.equal(expected);
     });
+
+    it('should not replace anything with empty whitelist', () => {
+      const expander = createExpanderWithWhitelist('');
+      const url = 'http://www.google.com/?test=ABCD';
+      const expected = 'http://www.google.com/?test=ABCD';
+      return expect(expander.expand(url, mockBindings))
+          .to.eventually.equal(expected);
+    });
+
   });
 
   describe('#expand', () => {


### PR DESCRIPTION
Currently, if

```html
<meta name="amp-allowed-url-macros" content="">
```

is present in the doc and the doc has, for example, an amp-list, then
the runtime will throw this error:

```
Cannot set property 'name' of undefined
```

This occurs here:

https://github.com/ampproject/amphtml/blob/8e799b53c96e84840e73b7d1b5c9935536c3d1a5/src/service/url-expander/expander.js#L133

This is because currently `VariableSource.prototype.getExpr` returns the
following regex when the URL macro whitelist is empty:

```
\$?()
```

Note the empty parentheses. This regex actually matches the empty
string, so when tested against any string, the match result will be an
array of size `n+1` of empty strings, where `n` is the length of the tested
string.

To fix that, we need to return a regex that matches nothing when the
whitelist is empty.

\cc @choumx @raywainman 