### PR TITLE
🖍 Update nodisplay to take advantage of [hidden]

### DIFF
--- a/css/amp.css
+++ b/css/amp.css
@@ -174,10 +174,21 @@ html.i-amphtml-singledoc.i-amphtml-ios-embed-sd > body {
   transition: opacity 0.3s cubic-bezier(0.0, 0.0, 0.2, 1) !important;
 }
 
-.i-amphtml-layout-nodisplay,
-[layout=nodisplay]:not(.i-amphtml-layout-nodisplay)
+/* layout=nodisplay are automatically until JS initializes. */
+[layout=nodisplay]:not(.i-amphtml-element) {
+  display: none !important;
+}
+
+/* Initialized layout=nodisplay contain [hidden] */
+.i-amphtml-layout-nodisplay[hidden],
+[layout=nodisplay][hidden]:not(.i-amphtml-layout-nodisplay)
 {
-  /* Display is set/reset in JS */
+  /* Display is set/reset via the hidden attribute */
+}
+.i-amphtml-layout-nodisplay:not([hidden]),
+[layout=nodisplay]:not(.i-amphtml-layout-nodisplay[hidden])
+{
+  /* Display is set/reset via the hidden attribute */
 }
 
 .i-amphtml-layout-fixed,
@@ -388,11 +399,6 @@ i-amphtml-sizer {
 
 .i-amphtml-error {
   /* Just state. */
-}
-
-/* layout=nodisplay are automatically hidden until displayed directly. */
-[layout=nodisplay]:not(.i-amphtml-display) {
-  display: none !important;
 }
 
 .i-amphtml-element > [placeholder],

--- a/css/amp.css
+++ b/css/amp.css
@@ -174,7 +174,7 @@ html.i-amphtml-singledoc.i-amphtml-ios-embed-sd > body {
   transition: opacity 0.3s cubic-bezier(0.0, 0.0, 0.2, 1) !important;
 }
 
-/* layout=nodisplay are automatically until JS initializes. */
+/* layout=nodisplay are automatically hidden until JS initializes. */
 [layout=nodisplay]:not(.i-amphtml-element) {
   display: none !important;
 }

--- a/extensions/amp-user-notification/0.1/amp-user-notification.js
+++ b/extensions/amp-user-notification/0.1/amp-user-notification.js
@@ -28,7 +28,7 @@ import {
   getServicePromiseForDoc,
   registerServiceBuilderForDoc,
 } from '../../../src/service';
-import {setStyle} from '../../../src/style';
+import {toggle} from '../../../src/style';
 
 const TAG = 'amp-user-notification';
 const SERVICE_ID = 'userNotificationManager';
@@ -396,7 +396,7 @@ export class AmpUserNotification extends AMP.BaseElement {
 
   /** @override */
   show() {
-    setStyle(this.element, 'display', '');
+    toggle(this.element, true);
     this.element.classList.add('amp-active');
     this.getViewport().addToFixedLayer(this.element);
     return this.dialogPromise_;

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -1408,7 +1408,11 @@ function createBaseCustomElementClass(win) {
      * @param {boolean} displayOn
      */
     toggleLayoutDisplay(displayOn) {
-      this.classList.toggle('i-amphtml-display', displayOn);
+      if (displayOn) {
+        this.removeAttribute('hidden');
+      } else {
+        this.setAttribute('hidden', '');
+      }
     }
 
     /**

--- a/src/layout.js
+++ b/src/layout.js
@@ -492,9 +492,6 @@ export function applyStaticLayout(element) {
  * @param {!Element} element
  */
 function applyNoDisplayLayout(element) {
-  // TODO(dvoytenko, #9353): once `toggleLayoutDisplay` API has been deployed
-  // everywhere, switch all relevant elements to this API. In the meantime,
-  // simply unblock display toggling via `style="display: ..."`.
+  // TODO(jridgewell, #17475): This should be using the [hidden] attribute.
   setStyle(element, 'display', 'none');
-  element.classList.add('i-amphtml-display');
 }

--- a/test/functional/test-custom-element.js
+++ b/test/functional/test-custom-element.js
@@ -1098,10 +1098,7 @@ describes.realWin('CustomElement', {amp: true}, env => {
       element1.setAttribute('i-amphtml-layout', 'nodisplay');
       element1.setAttribute('layout', 'nodisplay');
       container.appendChild(element1);
-      // TODO(dvoytenko, #9353): cleanup once `toggleLayoutDisplay` API has been
-      // fully migrated.
       expect(element1.style.display).to.equal('none');
-      expect(element1).to.have.class('i-amphtml-display');
     });
 
     it('should change size without sizer', () => {
@@ -1510,21 +1507,19 @@ describes.realWin('CustomElement Service Elements', {amp: true}, env => {
     return poll('wait for static layout',
         () => element.classList.contains('i-amphtml-layout-nodisplay'))
         .then(() => {
-          // TODO(dvoytenko, #9353): once `toggleLayoutDisplay` API has been
-          // deployed this will start `false`.
-          expect(element.classList.contains('i-amphtml-display')).to.be.true;
+          expect(element.style.display).to.be.equal('none');
 
           element.style.display = 'block';
           element.toggleLayoutDisplay(true);
-          expect(element.classList.contains('i-amphtml-display')).to.be.true;
+          expect(element).not.to.have.attribute('hidden');
           expect(win.getComputedStyle(element).display).to.equal('block');
 
           element.toggleLayoutDisplay(false);
-          expect(element.classList.contains('i-amphtml-display')).to.be.false;
+          expect(element).to.have.attribute('hidden');
           expect(win.getComputedStyle(element).display).to.equal('none');
 
           element.toggleLayoutDisplay(true);
-          expect(element.classList.contains('i-amphtml-display')).to.be.true;
+          expect(element).not.to.have.attribute('hidden');
           expect(win.getComputedStyle(element).display).to.equal('block');
         });
   });


### PR DESCRIPTION
This updates layout=nodisplay elements to take advantage of the `hidden`
attribute for display purposes. Hidden will soon be the one true way to
toggle `display: none` of an element.

Part of #17475

/to @choumx, and @dvoytenko