### PR TITLE
AdSense/Doubleclick FF - set creative frame id and data-google-query-id attribute

### DIFF
--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -296,7 +296,7 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
     const viewportSize = this.getViewport().getSize();
     if (!this.ifi_) {
       this.win['ampAdGoogleIfiCounter'] =
-          this.win['ampAdGoogleIfiCounter'] || 0;
+          this.win['ampAdGoogleIfiCounter'] || 1;
       this.ifi_ = this.win['ampAdGoogleIfiCounter']++;
     }
     const enclosingContainers = getEnclosingContainerTypes(this.element);

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -151,6 +151,9 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
      * indicates no creative render.
      */
     this.isAmpCreative_ = null;
+
+    /** @private {number} slot index specific to google inventory */
+    this.ifi_ = 0;
   }
 
   /**
@@ -291,7 +294,11 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
     const sharedStateParams = sharedState.addNewSlot(
         format, this.uniqueSlotId_, adClientId, slotname);
     const viewportSize = this.getViewport().getSize();
-    this.win['ampAdGoogleIfiCounter'] = this.win['ampAdGoogleIfiCounter'] || 1;
+    if (!this.ifi_) {
+      this.win['ampAdGoogleIfiCounter'] =
+          this.win['ampAdGoogleIfiCounter'] || 0;
+      this.ifi_ = this.win['ampAdGoogleIfiCounter']++;
+    }
     const enclosingContainers = getEnclosingContainerTypes(this.element);
     const pfx = enclosingContainers.includes(
         ValidAdContainerTypes['AMP-FX-FLYING-CARPET']) ||
@@ -320,7 +327,7 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
       'prev_fmts': sharedStateParams.prevFmts || null,
       'prev_slotnames': sharedStateParams.prevSlotnames || null,
       'brdim': additionalDimensions(this.win, viewportSize),
-      'ifi': this.win['ampAdGoogleIfiCounter']++,
+      'ifi': this.ifi_,
       'rc': this.fromResumeCallback ? 1 : null,
       'rafmt': this.isResponsive_() ? 13 : null,
       'pfx': pfx ? '1' : '0',
@@ -446,6 +453,10 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
       width: `${this.size_.width}px`,
       height: `${this.size_.height}px`,
     });
+    if (this.qqid_) {
+      this.element.setAttribute('data-google-query-id', this.qqid_);
+    }
+    dev().assertElement(this.iframe).id = `google_ads_iframe_${this.ifi_}`;
   }
 
   /** @override */

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
@@ -360,6 +360,17 @@ describes.realWin('amp-ad-network-adsense-impl', {
       expect(a.href).to.equal('https://f.co/?CLICK_X,CLICK_Y,RANDOM');
       expect(clickHandlerCalled).to.equal(1);
     });
+
+    it('should set iframe id and data-google-query-id attribute', () => {
+      impl.buildCallback();
+      impl.ifi_ = 3;
+      impl.qqid_ = 'abc';
+      impl.iframe = impl.win.document.createElement('iframe');
+      impl.size_ = {width: 123, height: 456};
+      impl.onCreativeRender(null);
+      expect(impl.element.getAttribute('data-google-query-id')).to.equal('abc');
+      expect(impl.iframe.id).to.equal('google_ads_iframe_3');
+    });
   });
 
   describe('centering', () => {

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -862,6 +862,10 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
       height: `${size.height}px`,
       position: isMultiSizeFluid ? 'relative' : null,
     });
+    if (this.qqid_) {
+      this.element.setAttribute('data-google-query-id', this.qqid_);
+    }
+    dev().assertElement(this.iframe).id = `google_ads_iframe_${this.ifi_}`;
     if (isMultiSizeFluid) {
       // This is a fluid + multi-size request, where the returned creative is
       // multi-size. The slot needs to not be styled with width: 100%, or the

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -432,6 +432,17 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
       expect(a.href).to.equal('https://f.co/?CLICK_X,CLICK_Y,RANDOM');
       expect(clickHandlerCalled).to.equal(1);
     });
+
+    it('should set iframe id and data-google-query-id attribute', () => {
+      impl.buildCallback();
+      impl.ifi_ = 3;
+      impl.qqid_ = 'abc';
+      impl.iframe = impl.win.document.createElement('iframe');
+      impl.size_ = {width: 123, height: 456};
+      impl.onCreativeRender(null);
+      expect(impl.element.getAttribute('data-google-query-id')).to.equal('abc');
+      expect(impl.iframe.id).to.equal('google_ads_iframe_3');
+    });
   });
 
   describe('#getAdUrl', () => {


### PR DESCRIPTION
AdSense/Doubleclick via amp-ad, set creative frame id and data-google-query-id on amp-ad element.