### PR TITLE
SSR (AMP4Email) doc level opt-in

### DIFF
--- a/examples/viewer.html
+++ b/examples/viewer.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html allow-viewer-render-template>
 <head>
   <meta charset="utf-8">
   <title>Viewer</title>

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -188,12 +188,12 @@ describes.realWin('amp-list component', {
       const allowViewerRenderTemplate = 'allow-viewer-render-template';
       beforeEach(() => {
         win.document.documentElement.setAttribute(
-          allowViewerRenderTemplate, true);
+            allowViewerRenderTemplate, true);
       });
 
       afterEach(() => {
         win.document.documentElement.removeAttribute(
-          allowViewerRenderTemplate);
+            allowViewerRenderTemplate);
       });
 
       it('should proxy rendering to viewer', () => {
@@ -213,7 +213,8 @@ describes.realWin('amp-list component', {
       });
 
       it('should error if viewer does not define response data', () => {
-        win.document.documentElement.setAttribute('allow-viewer-render-template', true);
+        win.document.documentElement.setAttribute(
+            'allow-viewer-render-template', true);
         viewerMock.expects('hasCapability')
             .withExactArgs('viewerRenderTemplate').returns(true);
         viewerMock.expects('sendMessageAwaitResponse').withExactArgs(

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -185,6 +185,17 @@ describes.realWin('amp-list component', {
     });
 
     describe('Viewer render template', () => {
+      const allowViewerRenderTemplate = 'allow-viewer-render-template';
+      beforeEach(() => {
+        win.document.documentElement.setAttribute(
+          allowViewerRenderTemplate, true);
+      });
+
+      afterEach(() => {
+        win.document.documentElement.removeAttribute(
+          allowViewerRenderTemplate);
+      });
+
       it('should proxy rendering to viewer', () => {
         const setupAMPCors = sandbox.spy(xhrUtils, 'setupAMPCors');
         const fromStructuredCloneable =
@@ -202,6 +213,7 @@ describes.realWin('amp-list component', {
       });
 
       it('should error if viewer does not define response data', () => {
+        win.document.documentElement.setAttribute('allow-viewer-render-template', true);
         viewerMock.expects('hasCapability')
             .withExactArgs('viewerRenderTemplate').returns(true);
         viewerMock.expects('sendMessageAwaitResponse').withExactArgs(

--- a/src/ssr-template-helper.js
+++ b/src/ssr-template-helper.js
@@ -62,7 +62,7 @@ export class SsrTemplateHelper {
    */
   isSupported() {
     let isOptIn = false;
-    const ampdoc = this.viewer_.ampdoc;
+    const {ampdoc} = this.viewer_;
     /** @type {boolean|!Element} */
     const htmlElement =
         ampdoc.isSingleDoc() && ampdoc.getRootNode().documentElement;

--- a/src/ssr-template-helper.js
+++ b/src/ssr-template-helper.js
@@ -63,9 +63,9 @@ export class SsrTemplateHelper {
   isSupported() {
     const {ampdoc} = this.viewer_;
     if (ampdoc.isSingleDoc()) {
-      const htmlElement = ampdoc.getRootNode().documentElement
+      const htmlElement = ampdoc.getRootNode().documentElement;
       if (htmlElement.hasAttribute('allow-viewer-render-template')) {
-        return this.viewer_.hasCapability('viewerRenderTemplate')
+        return this.viewer_.hasCapability('viewerRenderTemplate');
       }
     }
   }

--- a/src/ssr-template-helper.js
+++ b/src/ssr-template-helper.js
@@ -61,15 +61,13 @@ export class SsrTemplateHelper {
    * @return {boolean}
    */
   isSupported() {
-    let isOptIn = false;
     const {ampdoc} = this.viewer_;
-    /** @type {boolean|!Element} */
-    const htmlElement =
-        ampdoc.isSingleDoc() && ampdoc.getRootNode().documentElement;
-    if (htmlElement) {
-      isOptIn = htmlElement.hasAttribute('allow-viewer-render-template');
+    if (ampdoc.isSingleDoc()) {
+      const htmlElement = ampdoc.getRootNode().documentElement
+      if (htmlElement.hasAttribute('allow-viewer-render-template')) {
+        return this.viewer_.hasCapability('viewerRenderTemplate')
+      }
     }
-    return isOptIn && this.viewer_.hasCapability('viewerRenderTemplate');
   }
 
   /**

--- a/src/ssr-template-helper.js
+++ b/src/ssr-template-helper.js
@@ -55,11 +55,21 @@ export class SsrTemplateHelper {
   }
 
   /**
-   * Whether the viewer can render templates.
+   * Whether the viewer can render templates. A doc-level opt in as
+   * trusted viewers must set this capability explicitly, as a security
+   * measure for potential abuse of feature.
    * @return {boolean}
    */
   isSupported() {
-    return this.viewer_.hasCapability('viewerRenderTemplate');
+    let isOptIn = false;
+    const ampdoc = this.viewer_.ampdoc;
+    /** @type {boolean|!Element} */
+    const htmlElement =
+        ampdoc.isSingleDoc() && ampdoc.getRootNode().documentElement;
+    if (htmlElement) {
+      isOptIn = htmlElement.hasAttribute('allow-viewer-render-template');
+    }
+    return isOptIn && this.viewer_.hasCapability('viewerRenderTemplate');
   }
 
   /**

--- a/src/ssr-template-helper.js
+++ b/src/ssr-template-helper.js
@@ -68,6 +68,7 @@ export class SsrTemplateHelper {
         return this.viewer_.hasCapability('viewerRenderTemplate');
       }
     }
+    return false;
   }
 
   /**

--- a/validator/testdata/feature_tests/root_element_attributes.html
+++ b/validator/testdata/feature_tests/root_element_attributes.html
@@ -15,7 +15,7 @@
   This demonstrates that certain attributes are not allowed on the root <html> element.
 -->
 <!doctype html>
-<html ⚡ allow-xhr-interception report-errors-to-viewer>
+<html ⚡ allow-xhr-interception allow-viewer-render-template report-errors-to-viewer>
 <head>
   <meta charset="utf-8">
   <link rel="canonical" href="./regular-html-version.html">

--- a/validator/testdata/feature_tests/root_element_attributes.out
+++ b/validator/testdata/feature_tests/root_element_attributes.out
@@ -16,7 +16,9 @@ FAIL
 |    This demonstrates that certain attributes are not allowed on the root <html> element.
 |  -->
 |  <!doctype html>
-|  <html ⚡ allow-xhr-interception report-errors-to-viewer>
+|  <html ⚡ allow-xhr-interception allow-viewer-render-template report-errors-to-viewer>
+>> ^~~~~~~~~
+feature_tests/root_element_attributes.html:18:0 The attribute 'allow-viewer-render-template' may not appear in tag 'html ⚡ for top-level html'. (see https://www.ampproject.org/docs/reference/spec#required-markup) [DISALLOWED_HTML]
 >> ^~~~~~~~~
 feature_tests/root_element_attributes.html:18:0 The attribute 'allow-xhr-interception' may not appear in tag 'html ⚡ for top-level html'. (see https://www.ampproject.org/docs/reference/spec#required-markup) [DISALLOWED_HTML]
 >> ^~~~~~~~~


### PR DESCRIPTION
- require trusted viewer(s) to set doc level opt-in 'allow-viewer-render-template' to enable 'viewerRenderTemplate' capability for security purposes. This intentionally fails the AMP validator so that publishers cannot add it themselves to maliciously enable this feature. Similar to the 'xhr-interceptor' viewer capability.

