### PR TITLE
🐛Allow looking up AmpDoc when it might not be available.

### DIFF
--- a/src/service/ampdoc-impl.js
+++ b/src/service/ampdoc-impl.js
@@ -95,19 +95,9 @@ export class AmpDocService {
    * @param {{
    *  closestAmpDoc: boolean
    * }=} opt_options
-   * @return {!AmpDoc}
+   * @return {?AmpDoc}
    */
-  getAmpDoc(opt_node = undefined, {closestAmpDoc = false} = {}) {
-    // Ensure that node is attached if specified. This check uses a new and
-    // fast `isConnected` API and thus only checked on platforms that have it.
-    // See https://www.chromestatus.com/feature/5676110549352448.
-    if (opt_node) {
-      dev().assert(
-          opt_node['isConnected'] === undefined ||
-          opt_node['isConnected'] === true,
-          'The node must be attached to request ampdoc.');
-    }
-
+  getAmpDocIfAvailable(opt_node = undefined, {closestAmpDoc = false} = {}) {
     // Single document: return it immediately.
     if (this.singleDoc_ && !closestAmpDoc && !this.alwaysClosestAmpDoc_) {
       return this.singleDoc_;
@@ -170,7 +160,40 @@ export class AmpDocService {
       return this.singleDoc_;
     }
 
-    throw dev().createError('No ampdoc found for', opt_node);
+    return null;
+  }
+
+  /**
+   * Returns the instance of the ampdoc (`AmpDoc`) that contains the specified
+   * node. If the runtime is in the single-doc mode, the one global `AmpDoc`
+   * instance is returned, unless specfically looking for a closer `AmpDoc`.
+   * Otherwise, this method locates the `AmpDoc` that contains the specified
+   * node and, if necessary, initializes it.
+   * 
+   * An Error is thrown in development if no `AmpDoc` is found.
+   * @param {!Node=} opt_node
+   * @param {{
+   *  closestAmpDoc: boolean
+   * }=} opt_options
+   * @return {!AmpDoc}
+   */
+  getAmpDoc(opt_node, opt_options) {
+    // Ensure that node is attached if specified. This check uses a new and
+    // fast `isConnected` API and thus only checked on platforms that have it.
+    // See https://www.chromestatus.com/feature/5676110549352448.
+    if (opt_node) {
+      dev().assert(
+          opt_node['isConnected'] === undefined ||
+          opt_node['isConnected'] === true,
+          'The node must be attached to request ampdoc.');
+    }
+
+    const ampdoc = this.getAmpDocIfAvailable(opt_node, opt_options);
+    if (!ampdoc) {
+      throw dev().createError('No ampdoc found for', opt_node);
+    }
+
+    return ampdoc;
   }
 
   /**

--- a/src/service/ampdoc-impl.js
+++ b/src/service/ampdoc-impl.js
@@ -169,7 +169,7 @@ export class AmpDocService {
    * instance is returned, unless specfically looking for a closer `AmpDoc`.
    * Otherwise, this method locates the `AmpDoc` that contains the specified
    * node and, if necessary, initializes it.
-   * 
+   *
    * An Error is thrown in development if no `AmpDoc` is found.
    * @param {!Node=} opt_node
    * @param {{

--- a/src/service/vsync-impl.js
+++ b/src/service/vsync-impl.js
@@ -281,8 +281,8 @@ export class Vsync {
 
     // Multi-doc: animations depend on the state of the relevant doc.
     if (opt_contextNode) {
-      const ampdoc = this.ampdocService_.getAmpDoc(opt_contextNode);
-      return Services.viewerForDoc(ampdoc).isVisible();
+      const ampdoc = this.ampdocService_.getAmpDocIfAvailable(opt_contextNode);
+      return !ampdoc || Services.viewerForDoc(ampdoc).isVisible();
     }
 
     return true;

--- a/test/functional/test-ampdoc.js
+++ b/test/functional/test-ampdoc.js
@@ -222,6 +222,14 @@ describe('AmpDocService', () => {
       }).to.throw(/No ampdoc found/);
     });
 
+    it('should allow checking for an AmpDoc for an external node', () => {
+      if (!shadowRoot) {
+        return;
+      }
+      const ampDoc = service.getAmpDocIfAvailable(host);
+      expect(ampDoc).to.be.null;
+    });
+
     it('should fail to install shadow doc twice', () => {
       if (!shadowRoot) {
         return;


### PR DESCRIPTION
- When using shadow docs, you might want to look up the AmpDoc for an Element that does not have an associated AmpDoc. Since there is no easy way to tell if the lookup will fail, add a method to allow the lookup to be done and return `null` if no AmpDoc was found.
- When trying to animate an Element, allow the animation if we do not have an associated `AmpDoc`. One situation this occurs is when trying to animate the scroll on the `<html>` element, when trying to scroll to an Element in a shadow doc.

Fixes #17792
