### PR TITLE
Update Sauce Connect to 4.5.1

### DIFF
--- a/build-system/sauce_connect/start_sauce_connect.sh
+++ b/build-system/sauce_connect/start_sauce_connect.sh
@@ -20,7 +20,7 @@
 CYAN() { echo -e "\033[0;36m$1\033[0m"; }
 YELLOW() { echo -e "\033[1;33m$1\033[0m"; }
 
-SC_VERSION="sc-4.5.0-linux"
+SC_VERSION="sc-4.5.1-linux"
 DOWNLOAD_URL="https://saucelabs.com/downloads/$SC_VERSION.tar.gz"
 TAR_FILE="$SC_VERSION.tar.gz"
 BINARY_FILE="$SC_VERSION/bin/sc"


### PR DESCRIPTION
```
31 Aug 00:10:07 - ***********************************************************
31 Aug 00:10:07 - A newer version of Sauce Connect (build 4191) is available!
31 Aug 00:10:07 - Download it here:
31 Aug 00:10:07 - https://saucelabs.com/downloads/sc-4.5.1-linux.tar.gz
31 Aug 00:10:07 - ***********************************************************
```