### PR TITLE
Turn on no-sync-xhr-in-ads in prod config.

### DIFF
--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -47,6 +47,7 @@
   "url-replacement-v2": 1,
   "user-error-reporting": 1,
   "no-initial-intersection": 1,
+  "no-sync-xhr-in-ads": 1,
   "doubleclickSraExp": 0,
   "doubleclickSraReportExcludedBlock": 0.1,
   "inabox-rov": 1


### PR DESCRIPTION
The flag has been turned on in canary for 4 weeks with no known issues.

Last part of #13766