### PR TITLE
Fix and improvement to --extensions_from flag

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -819,7 +819,7 @@ function parseExtensionFlags() {
 
 /**
  * Adds `amp-video-service` to the extension set if a component requires it.
- * @param {!Array<string>}
+ * @param {!Array<string>} extensionsToBuild
  * @return {boolean}
  */
 function maybeAddVideoService(extensionsToBuild) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -761,7 +761,7 @@ function printConfigHelp(command) {
 }
 
 /**
- * Parse the --extensions or the --noextensions flag and
+ * Parse the --extensions --extensions_from or the --noextensions flag and
  * prints a helpful message that lets the developer know how to build
  * a list of extensions or without any extensions.
  */
@@ -794,11 +794,14 @@ function parseExtensionFlags() {
       if (argv.extensions === 'minimal_set') {
         argv.extensions = MINIMAL_EXTENSION_SET.join(',');
       }
+    }
 
+    if (argv.extensions || argv.extensions_from) {
+      const extensionsToBuild = getExtensionsToBuild();
       log(green('Building extension(s):'),
-          cyan(getExtensionsToBuild().join(', ')));
+          cyan(extensionsToBuild.join(', ')));
 
-      if (maybeAddVideoService()) {
+      if (maybeAddVideoService(extensionsToBuild)) {
         log(green('⤷ Video component(s) being built, added'),
             cyan('amp-video-service'), green('to extension set.'));
       }
@@ -816,10 +819,11 @@ function parseExtensionFlags() {
 
 /**
  * Adds `amp-video-service` to the extension set if a component requires it.
+ * @param {!Array<string>}
  * @return {boolean}
  */
-function maybeAddVideoService() {
-  if (!argv.extensions.split(',').find(ext => VIDEO_EXTENSIONS.has(ext))) {
+function maybeAddVideoService(extensionsToBuild) {
+  if (!extensionsToBuild.find(ext => VIDEO_EXTENSIONS.has(ext))) {
     return false;
   }
   argv.extensions += ',amp-video-service';

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -218,11 +218,12 @@ function buildExtensions(options) {
     return Promise.resolve();
   }
 
-  const extensionsToBuild = getExtensionsToBuild();
+  const extensionsToBuild = options.compileAll ?
+    [] : getExtensionsToBuild();
 
   const results = [];
   for (const key in extensions) {
-    if (!options.compileAll &&
+    if (extensionsToBuild.length > 0 &&
         extensionsToBuild.indexOf(extensions[key].name) == -1) {
       continue;
     }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -247,6 +247,9 @@ function getExtensionsToBuild() {
   extensionsToBuild = [];
 
   if (!!argv.extensions) {
+    if (argv.extensions === 'minimal_set') {
+      argv.extensions = MINIMAL_EXTENSION_SET.join(',');
+    }
     extensionsToBuild = argv.extensions.split(',');
   }
 
@@ -768,9 +771,8 @@ function printConfigHelp(command) {
 
 /**
  * Parses the --extensions, --extensions_from, and the --noextensions flags,
- * and prints a helpful message that lets the developer know how to build
- * the runtime with a list of extensions,
- * all the extensions used by a test file,
+ * and prints a helpful message that lets the developer know how to build the
+ * runtime with a list of extensions, all the extensions used by a test file,
  * or no extensions at all.
  */
 function parseExtensionFlags() {
@@ -798,10 +800,6 @@ function parseExtensionFlags() {
         process.exit(1);
       }
       argv.extensions = argv.extensions.replace(/\s/g, '');
-
-      if (argv.extensions === 'minimal_set') {
-        argv.extensions = MINIMAL_EXTENSION_SET.join(',');
-      }
     }
 
     if (argv.extensions || argv.extensions_from) {


### PR DESCRIPTION
We always print `Build all extensions` even with `--extensions_from` flag. It's super confusing. 
Also fix the bug that add video service doesn't work well with `--extensions_from` flag.