### PR TITLE
Enable [title] binding for amp-iframe

### DIFF
--- a/extensions/amp-iframe/0.1/amp-iframe.js
+++ b/extensions/amp-iframe/0.1/amp-iframe.js
@@ -53,6 +53,7 @@ const ATTRIBUTES_TO_PROPAGATE = [
   'frameborder',
   'referrerpolicy',
   'scrolling',
+  'title',
 ];
 
 /** @type {number}  */


### PR DESCRIPTION
Fix for issue https://github.com/ampproject/amphtml/issues/17308

Enable amp-bind [title] attribute for amp-iframe to improve accessibility. Since the [src] attribute is enabled, we need to allow document authors to change the title attribute to better annotate the changing iframed documents for screen readers.

https://www.w3.org/TR/WCAG20-TECHS/H64.html

