### PR TITLE
♻️Refactored & Fixed Amp Auto Ads Test

### DIFF
--- a/extensions/amp-auto-ads/0.1/ad-network-config.js
+++ b/extensions/amp-auto-ads/0.1/ad-network-config.js
@@ -25,6 +25,7 @@ import {
 import {Services} from '../../../src/services';
 import {buildUrl} from '../../../ads/google/a4a/url-builder';
 import {dict} from '../../../src/utils/object';
+import {getMode} from '../../../src/mode';
 import {parseUrlDeprecated} from '../../../src/url';
 import {tryParseJson} from '../../../src/json';
 
@@ -85,7 +86,7 @@ class AdNetworkConfigDef {
  * @return {?AdNetworkConfigDef}
  */
 export function getAdNetworkConfig(type, autoAmpAdsElement) {
-  if (type == '_ping_') {
+  if ((getMode().test || getMode().localDev) && type == '_ping_') {
     return new PingNetworkConfig(autoAmpAdsElement);
   }
   if (type == 'adsense') {

--- a/extensions/amp-auto-ads/0.1/ad-network-config.js
+++ b/extensions/amp-auto-ads/0.1/ad-network-config.js
@@ -104,7 +104,7 @@ export function getAdNetworkConfig(type, autoAmpAdsElement) {
  * @implements {AdNetworkCOnfigDef}
  * @visibleForTesting
  */
-class PingNetworkConfig {;
+class PingNetworkConfig {
   /**
    * @param {!Element} autoAmpAdsElement
    */
@@ -112,25 +112,26 @@ class PingNetworkConfig {;
     this.autoAmpAdsElement_ = autoAmpAdsElement;
   }
 
+  /** @override */
   isEnabled() {
     return true;
   }
 
+  /** @override */
   isResponsiveEnabled() {
     return true;
   }
 
   /** @override */
   getConfigUrl() {
-    const docInfo = Services.documentInfoForDoc(this.autoAmpAdsElement_);
-    const canonicalHostname = parseUrlDeprecated(docInfo.canonicalUrl).hostname;
-    return buildUrl('//lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w400-h300-no-n', {}, 4096);
+    return buildUrl('//lh3.googleusercontent.com/' +
+      'pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w400-h300-no-n', {}, 4096);
   }
 
   /** @override */
   getAttributes() {
     return dict({
-      'type': '_ping_'
+      'type': '_ping_',
     });
   }
 

--- a/extensions/amp-auto-ads/0.1/ad-network-config.js
+++ b/extensions/amp-auto-ads/0.1/ad-network-config.js
@@ -101,7 +101,7 @@ export function getAdNetworkConfig(type, autoAmpAdsElement) {
  * A fake ad network integration that is mainly used for testing
  * and demo purposes. This implementation gets stripped out in compiled
  * production code.
- * @implements {AdNetworkCOnfigDef}
+ * @implements {AdNetworkConfigDef}
  * @visibleForTesting
  */
 class PingNetworkConfig {

--- a/extensions/amp-auto-ads/0.1/ad-network-config.js
+++ b/extensions/amp-auto-ads/0.1/ad-network-config.js
@@ -85,6 +85,9 @@ class AdNetworkConfigDef {
  * @return {?AdNetworkConfigDef}
  */
 export function getAdNetworkConfig(type, autoAmpAdsElement) {
+  if (type == '_ping_') {
+    return new PingNetworkConfig(autoAmpAdsElement);
+  }
   if (type == 'adsense') {
     return new AdSenseNetworkConfig(autoAmpAdsElement);
   }
@@ -93,6 +96,65 @@ export function getAdNetworkConfig(type, autoAmpAdsElement) {
   }
   return null;
 }
+
+/**
+ * A fake ad network integration that is mainly used for testing
+ * and demo purposes. This implementation gets stripped out in compiled
+ * production code.
+ * @implements {AdNetworkCOnfigDef}
+ * @visibleForTesting
+ */
+class PingNetworkConfig {;
+  /**
+   * @param {!Element} autoAmpAdsElement
+   */
+  constructor(autoAmpAdsElement) {
+    this.autoAmpAdsElement_ = autoAmpAdsElement;
+  }
+
+  isEnabled() {
+    return true;
+  }
+
+  isResponsiveEnabled() {
+    return true;
+  }
+
+  /** @override */
+  getConfigUrl() {
+    const docInfo = Services.documentInfoForDoc(this.autoAmpAdsElement_);
+    const canonicalHostname = parseUrlDeprecated(docInfo.canonicalUrl).hostname;
+    return buildUrl('//lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w400-h300-no-n', {}, 4096);
+  }
+
+  /** @override */
+  getAttributes() {
+    return dict({
+      'type': '_ping_'
+    });
+  }
+
+  /** @override */
+  getDefaultAdConstraints() {
+    const viewportHeight =
+      Services.viewportForDoc(this.autoAmpAdsElement_).getSize().height;
+    return {
+      initialMinSpacing: viewportHeight,
+      subsequentMinSpacing: [
+        {adCount: 3, spacing: viewportHeight * 2},
+        {adCount: 6, spacing: viewportHeight * 3},
+      ],
+      maxAdCount: 8,
+    };
+  }
+
+  /** @override */
+  getSizing() {
+    return {};
+  }
+
+}
+
 
 /**
  * @implements {AdNetworkConfigDef}

--- a/extensions/amp-auto-ads/0.1/test/test-amp-auto-ads.js
+++ b/extensions/amp-auto-ads/0.1/test/test-amp-auto-ads.js
@@ -16,13 +16,8 @@
 
 import '../../../amp-ad/0.1/amp-ad';
 import '../amp-auto-ads';
-import {
-  ADSENSE_AMP_AUTO_ADS_HOLDOUT_EXPERIMENT_NAME,
-  AdSenseAmpAutoAdsHoldoutBranches,
-} from '../../../../ads/google/adsense-amp-auto-ads';
 import {Services} from '../../../../src/services';
 import {
-  forceExperimentBranch,
   toggleExperiment,
 } from '../../../../src/experiments';
 import {waitForChild} from '../../../../src/dom';
@@ -34,7 +29,6 @@ describes.realWin('amp-auto-ads', {
   },
 }, env => {
 
-  const AD_CLIENT = 'ca-pub-1234';
   const OPT_IN_STATUS_ANCHOR_ADS = 2;
 
   let win;
@@ -217,7 +211,7 @@ describes.realWin('amp-auto-ads', {
       'data-custom-att-1': 'val-1',
       'data-custom-att-2': 'val-2',
     };
-    
+
     return getAmpAutoAds().then(() => {
       return new Promise(resolve => {
         waitForChild(anchor4, parent => {
@@ -225,21 +219,21 @@ describes.realWin('amp-auto-ads', {
         }, () => {
           expect(anchor1.childNodes).to.have.lengthOf(1);
           expect(anchor1.childNodes[0].getAttribute('data-custom-att-1'))
-            .to.equal('val-1');
+              .to.equal('val-1');
           expect(anchor1.childNodes[0].getAttribute('data-custom-att-2'))
-            .to.equal('val-2');
+              .to.equal('val-2');
 
           expect(anchor2.childNodes).to.have.lengthOf(1);
           expect(anchor2.childNodes[0].getAttribute('data-custom-att-1'))
-            .to.equal('val-1');
+              .to.equal('val-1');
           expect(anchor2.childNodes[0].getAttribute('data-custom-att-2'))
-            .to.equal('val-2');
+              .to.equal('val-2');
 
           expect(anchor4.childNodes).to.have.lengthOf(1);
           expect(anchor4.childNodes[0].getAttribute('data-custom-att-1'))
-            .to.equal('val-1');
+              .to.equal('val-1');
           expect(anchor4.childNodes[0].getAttribute('data-custom-att-2'))
-            .to.equal('val-2');
+              .to.equal('val-2');
           resolve();
         });
       });
@@ -259,15 +253,15 @@ describes.realWin('amp-auto-ads', {
             }, () => {
               expect(anchor1.childNodes).to.have.lengthOf(1);
               expect(anchor1.childNodes[0].getAttribute('type'))
-                .to.equal('_ping_');
+                  .to.equal('_ping_');
 
               expect(anchor2.childNodes).to.have.lengthOf(1);
               expect(anchor2.childNodes[0].getAttribute('type'))
-                .to.equal('_ping_');
+                  .to.equal('_ping_');
 
               expect(anchor4.childNodes).to.have.lengthOf(1);
               expect(anchor4.childNodes[0].getAttribute('type'))
-                .to.equal('_ping_');
+                  .to.equal('_ping_');
               resolve();
             });
           });
@@ -277,21 +271,20 @@ describes.realWin('amp-auto-ads', {
   it('should fetch a config from the correct URL', () => {
     return getAmpAutoAds().then(() => {
       expect(xhr.fetchJson).to.have.been.calledWith(
-        '//lh3.googleusercontent.com/' +
+          '//lh3.googleusercontent.com/' +
         'pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w400-h300-no-n', {
-          mode: 'cors',
-          method: 'GET',
-          credentials: 'omit',
-          requireAmpResponseSourceOrigin: false,
-        });
+            mode: 'cors',
+            method: 'GET',
+            credentials: 'omit',
+            requireAmpResponseSourceOrigin: false,
+          });
       expect(xhr.fetchJson).to.be.calledOnce;
     });
   });
 
   it('should throw an error if no type', () => {
     return allowConsoleError(() => {
-      return getAmpAutoAds('NONE').catch((err) => {
-        console.error(err.message);
+      return getAmpAutoAds('NONE').catch(err => {
         expect(err.message).to.include('Missing type attribute');
         expect(xhr.fetchJson).not.to.have.been.called;
       });
@@ -300,8 +293,7 @@ describes.realWin('amp-auto-ads', {
 
   it('should not try and fetch config if unknown type', () => {
     return allowConsoleError(() => {
-      return getAmpAutoAds('unknowntype').catch((err) => {
-        console.error(err.message);
+      return getAmpAutoAds('unknowntype').catch(err => {
         expect(err.message).to.include('No AdNetworkConfig for type');
         expect(xhr.fetchJson).not.to.have.been.called;
       });
@@ -311,8 +303,7 @@ describes.realWin('amp-auto-ads', {
   it('should not try and fetch config if experiment off', () => {
     return allowConsoleError(() => {
       toggleExperiment(env.win, 'amp-auto-ads', false);
-      return getAmpAutoAds().catch((err) => {
-        console.error(err.message);
+      return getAmpAutoAds().catch(err => {
         expect(err.message).to.include('Experiment is off');
         expect(xhr.fetchJson).not.to.have.been.called;
       });
@@ -321,50 +312,46 @@ describes.realWin('amp-auto-ads', {
 
   describe('Anchor Ad', () => {
     it('should not insert anchor ad if not opted in', () => {
-      ampAutoAdsElem.setAttribute('data-ad-client', AD_CLIENT);
-      ampAutoAdsElem.setAttribute('type', 'adsense');
-      ampAutoAds.buildCallback();
-
-      return new Promise(resolve => {
-        setTimeout(() => {
-          expect(env.win.document.getElementsByTagName('AMP-STICKY-AD'))
-              .to.have.lengthOf(0);
-          resolve();
-        }, 500);
+      return getAmpAutoAds().then(() => {
+        return new Promise(resolve => {
+          setTimeout(() => {
+            expect(env.win.document.getElementsByTagName('AMP-STICKY-AD'))
+                .to.have.lengthOf(0);
+            resolve();
+          }, 500);
+        });
       });
     });
 
     it('should insert three ads plus anchor ad', () => {
       configObj['optInStatus'].push(OPT_IN_STATUS_ANCHOR_ADS);
 
-      ampAutoAdsElem.setAttribute('data-ad-client', AD_CLIENT);
-      ampAutoAdsElem.setAttribute('type', 'adsense');
-      ampAutoAds.buildCallback();
-
-      const bannerAdsPromise = new Promise(resolve => {
-        waitForChild(anchor4, parent => {
-          return parent.childNodes.length > 0;
-        }, () => {
-          expect(anchor1.childNodes).to.have.lengthOf(1);
-          expect(anchor2.childNodes).to.have.lengthOf(1);
-          expect(anchor3.childNodes).to.have.lengthOf(0);
-          expect(anchor4.childNodes).to.have.lengthOf(1);
-          verifyAdElement(anchor1.childNodes[0]);
-          verifyAdElement(anchor2.childNodes[0]);
-          verifyAdElement(anchor4.childNodes[0]);
-          resolve();
+      return getAmpAutoAds().then(() => {
+        const bannerAdsPromise = new Promise(resolve => {
+          waitForChild(anchor4, parent => {
+            return parent.childNodes.length > 0;
+          }, () => {
+            expect(anchor1.childNodes).to.have.lengthOf(1);
+            expect(anchor2.childNodes).to.have.lengthOf(1);
+            expect(anchor3.childNodes).to.have.lengthOf(0);
+            expect(anchor4.childNodes).to.have.lengthOf(1);
+            verifyAdElement(anchor1.childNodes[0]);
+            verifyAdElement(anchor2.childNodes[0]);
+            verifyAdElement(anchor4.childNodes[0]);
+            resolve();
+          });
         });
-      });
 
-      const anchorAdPromise = new Promise(resolve => {
-        waitForChild(env.win.document.body, parent => {
-          return parent.firstChild.tagName == 'AMP-STICKY-AD';
-        }, () => {
-          resolve();
+        const anchorAdPromise = new Promise(resolve => {
+          waitForChild(env.win.document.body, parent => {
+            return parent.firstChild.tagName == 'AMP-STICKY-AD';
+          }, () => {
+            resolve();
+          });
         });
-      });
 
-      return Promise.all([bannerAdsPromise, anchorAdPromise]);
+        return Promise.all([bannerAdsPromise, anchorAdPromise]);
+      });
     });
 
     it('should insert anchor anchor ad only', () => {
@@ -372,15 +359,13 @@ describes.realWin('amp-auto-ads', {
         optInStatus: [2],
       };
 
-      ampAutoAdsElem.setAttribute('data-ad-client', AD_CLIENT);
-      ampAutoAdsElem.setAttribute('type', 'adsense');
-      ampAutoAds.buildCallback();
-
-      return new Promise(resolve => {
-        waitForChild(env.win.document.body, parent => {
-          return parent.firstChild.tagName == 'AMP-STICKY-AD';
-        }, () => {
-          resolve();
+      return getAmpAutoAds().then(() => {
+        return new Promise(resolve => {
+          waitForChild(env.win.document.body, parent => {
+            return parent.firstChild.tagName == 'AMP-STICKY-AD';
+          }, () => {
+            resolve();
+          });
         });
       });
     });
@@ -388,22 +373,20 @@ describes.realWin('amp-auto-ads', {
 
   describe('ad constraints', () => {
     it('should insert 3 ads when using the default ad contraints', () => {
-      ampAutoAdsElem.setAttribute('data-ad-client', AD_CLIENT);
-      ampAutoAdsElem.setAttribute('type', 'adsense');
-      ampAutoAds.buildCallback();
-
-      return new Promise(resolve => {
-        waitForChild(anchor4, parent => {
-          return parent.childNodes.length > 0;
-        }, () => {
-          expect(anchor1.childNodes).to.have.lengthOf(1);
-          expect(anchor2.childNodes).to.have.lengthOf(1);
-          expect(anchor3.childNodes).to.have.lengthOf(0);
-          expect(anchor4.childNodes).to.have.lengthOf(1);
-          verifyAdElement(anchor1.childNodes[0]);
-          verifyAdElement(anchor2.childNodes[0]);
-          verifyAdElement(anchor4.childNodes[0]);
-          resolve();
+      return getAmpAutoAds().then(() => {
+        return new Promise(resolve => {
+          waitForChild(anchor4, parent => {
+            return parent.childNodes.length > 0;
+          }, () => {
+            expect(anchor1.childNodes).to.have.lengthOf(1);
+            expect(anchor2.childNodes).to.have.lengthOf(1);
+            expect(anchor3.childNodes).to.have.lengthOf(0);
+            expect(anchor4.childNodes).to.have.lengthOf(1);
+            verifyAdElement(anchor1.childNodes[0]);
+            verifyAdElement(anchor2.childNodes[0]);
+            verifyAdElement(anchor4.childNodes[0]);
+            resolve();
+          });
         });
       });
     });
@@ -414,23 +397,21 @@ describes.realWin('amp-auto-ads', {
         maxAdCount: 8,
       };
 
-      ampAutoAdsElem.setAttribute('data-ad-client', AD_CLIENT);
-      ampAutoAdsElem.setAttribute('type', 'adsense');
-      ampAutoAds.buildCallback();
-
-      return new Promise(resolve => {
-        waitForChild(anchor4, parent => {
-          return parent.childNodes.length > 0;
-        }, () => {
-          expect(anchor1.childNodes).to.have.lengthOf(1);
-          expect(anchor2.childNodes).to.have.lengthOf(1);
-          expect(anchor3.childNodes).to.have.lengthOf(1);
-          expect(anchor4.childNodes).to.have.lengthOf(1);
-          verifyAdElement(anchor1.childNodes[0]);
-          verifyAdElement(anchor2.childNodes[0]);
-          verifyAdElement(anchor3.childNodes[0]);
-          verifyAdElement(anchor4.childNodes[0]);
-          resolve();
+      return getAmpAutoAds().then(() => {
+        return new Promise(resolve => {
+          waitForChild(anchor4, parent => {
+            return parent.childNodes.length > 0;
+          }, () => {
+            expect(anchor1.childNodes).to.have.lengthOf(1);
+            expect(anchor2.childNodes).to.have.lengthOf(1);
+            expect(anchor3.childNodes).to.have.lengthOf(1);
+            expect(anchor4.childNodes).to.have.lengthOf(1);
+            verifyAdElement(anchor1.childNodes[0]);
+            verifyAdElement(anchor2.childNodes[0]);
+            verifyAdElement(anchor3.childNodes[0]);
+            verifyAdElement(anchor4.childNodes[0]);
+            resolve();
+          });
         });
       });
     });

--- a/extensions/amp-auto-ads/0.1/test/test-amp-auto-ads.js
+++ b/extensions/amp-auto-ads/0.1/test/test-amp-auto-ads.js
@@ -36,7 +36,7 @@ describes.realWin('amp-auto-ads', {
 
   const AD_CLIENT = 'ca-pub-1234';
   const OPT_IN_STATUS_ANCHOR_ADS = 2;
-  
+
   let win;
   let doc;
   let sandbox;
@@ -156,7 +156,7 @@ describes.realWin('amp-auto-ads', {
     whenVisible.returns(Promise.resolve());
   });
 
-  function getAmpAutoAds(type, adClient) {
+  function getAmpAutoAds(type) {
     ampAutoAds = doc.createElement('amp-auto-ads');
     ampAutoAds.setAttribute('type', type || '_ping_');
     doc.body.appendChild(ampAutoAds);
@@ -177,7 +177,7 @@ describes.realWin('amp-auto-ads', {
       resolve = res;
     });
     whenVisible.returns(visible);
-    
+
     return getAmpAutoAds().then(ampAutoAds => {
       return Promise.resolve().then(() => {
         expect(xhr.fetchJson).to.not.have.been.called;
@@ -209,50 +209,46 @@ describes.realWin('amp-auto-ads', {
     });
   });
 
-  it.skip('should insert ads on the page when in holdout experiment branch',
+  it('should insert ads on the page when in holdout experiment branch',
       () => {
         forceExperimentBranch(env.win,
             ADSENSE_AMP_AUTO_ADS_HOLDOUT_EXPERIMENT_NAME,
             AdSenseAmpAutoAdsHoldoutBranches.EXPERIMENT);
 
-        ampAutoAdsElem.setAttribute('data-ad-client', AD_CLIENT);
-        ampAutoAdsElem.setAttribute('type', 'adsense');
-        ampAutoAds.buildCallback();
-
-        return new Promise(resolve => {
-          waitForChild(anchor4, parent => {
-            return parent.childNodes.length > 0;
-          }, () => {
-            expect(anchor1.childNodes).to.have.lengthOf(1);
-            expect(anchor2.childNodes).to.have.lengthOf(1);
-            expect(anchor3.childNodes).to.have.lengthOf(0);
-            expect(anchor4.childNodes).to.have.lengthOf(1);
-            verifyAdElement(anchor1.childNodes[0]);
-            verifyAdElement(anchor2.childNodes[0]);
-            verifyAdElement(anchor4.childNodes[0]);
-            resolve();
+        return getAmpAutoAds().then(ampAutoAds => {
+          return new Promise(resolve => {
+            waitForChild(anchor4, parent => {
+              return parent.childNodes.length > 0;
+            }, () => {
+              expect(anchor1.childNodes).to.have.lengthOf(1);
+              expect(anchor2.childNodes).to.have.lengthOf(1);
+              expect(anchor3.childNodes).to.have.lengthOf(0);
+              expect(anchor4.childNodes).to.have.lengthOf(1);
+              verifyAdElement(anchor1.childNodes[0]);
+              verifyAdElement(anchor2.childNodes[0]);
+              verifyAdElement(anchor4.childNodes[0]);
+              resolve();
+            });
           });
         });
       });
 
-  it.skip('should not insert ads on the page when in holdout control branch',
+  it('should not insert ads on the page when in holdout control branch',
       () => {
         forceExperimentBranch(env.win,
             ADSENSE_AMP_AUTO_ADS_HOLDOUT_EXPERIMENT_NAME,
             AdSenseAmpAutoAdsHoldoutBranches.CONTROL);
 
-        ampAutoAdsElem.setAttribute('data-ad-client', AD_CLIENT);
-        ampAutoAdsElem.setAttribute('type', 'adsense');
-        ampAutoAds.buildCallback();
-
-        return new Promise(resolve => {
-          setTimeout(() => {
-            expect(anchor1.childNodes).to.have.lengthOf(0);
-            expect(anchor2.childNodes).to.have.lengthOf(0);
-            expect(anchor3.childNodes).to.have.lengthOf(0);
-            expect(anchor4.childNodes).to.have.lengthOf(0);
-            resolve();
-          }, 500);
+        return getAmpAutoAds().then(ampAutoAds => {
+          return new Promise(resolve => {
+            setTimeout(() => {
+              expect(anchor1.childNodes).to.have.lengthOf(0);
+              expect(anchor2.childNodes).to.have.lengthOf(0);
+              expect(anchor3.childNodes).to.have.lengthOf(0);
+              expect(anchor4.childNodes).to.have.lengthOf(0);
+              resolve();
+            }, 500);
+          });
         });
       });
 

--- a/extensions/amp-auto-ads/0.1/test/test-amp-auto-ads.js
+++ b/extensions/amp-auto-ads/0.1/test/test-amp-auto-ads.js
@@ -29,6 +29,7 @@ import {waitForChild} from '../../../../src/dom';
 
 describes.realWin('amp-auto-ads', {
   amp: {
+    runtimeOn: true,
     extensions: ['amp-ad', 'amp-auto-ads'],
   },
 }, env => {

--- a/extensions/amp-auto-ads/0.1/test/test-amp-auto-ads.js
+++ b/extensions/amp-auto-ads/0.1/test/test-amp-auto-ads.js
@@ -159,9 +159,6 @@ describes.realWin('amp-auto-ads', {
     ampAutoAds = doc.createElement('amp-auto-ads');
     ampAutoAds.setAttribute('type', type || '_ping_');
     doc.body.appendChild(ampAutoAds);
-    ampAutoAds.implementation_.testing = () => {
-      console.error('overirdden')
-    }
     return ampAutoAds.build().then(() => {
       return ampAutoAds.layoutCallback();
     });


### PR DESCRIPTION
closes #16545 

This refactors the `amp-auto-ads` tests, and implements the testing `_ping_` ad network for testing. This also, unskips all of the 2 year old tests, and gets them working again 😄 . The holdout experiment tests were removed, as I noticed there is no code in the actual `amp-auto-ads` for the experiment branch, and the testing should be done on the adsense network level.

# Example

ran `gulp test --local-changes`

![screen shot 2018-09-04 at 1 25 09 pm](https://user-images.githubusercontent.com/1448289/45056037-904d8980-b046-11e8-8b4f-0feec2e40ef7.png)


