### PR TITLE
🐛Add flag to always use the closest AmpDoc

### DIFF
--- a/src/service/ampdoc-impl.js
+++ b/src/service/ampdoc-impl.js
@@ -55,6 +55,9 @@ export class AmpDocService {
       this.singleDoc_ = new AmpDocSingle(win);
     }
 
+    /** @private @const */
+    this.alwaysClosestAmpDoc_ = isExperimentOn(win, 'ampdoc-closest');
+
     /** Guarded by 'ampdoc-shell' experiment
      * @private {?AmpDocShell}
      */
@@ -106,7 +109,7 @@ export class AmpDocService {
     }
 
     // Single document: return it immediately.
-    if (this.singleDoc_ && !closestAmpDoc) {
+    if (this.singleDoc_ && !closestAmpDoc && !this.alwaysClosestAmpDoc_) {
       return this.singleDoc_;
     }
 
@@ -120,7 +123,12 @@ export class AmpDocService {
       }
     }
 
-    dev().assert(opt_node);
+    // TODO(sparhami) Should we always require a node to be passed? This will
+    // make sure any functionality that works for a standalone AmpDoc works if
+    // the AmpDoc is loaded in a shadow doc.
+    if (!this.singleDoc_) {
+      dev().assert(opt_node);
+    }
     // Otherwise discover and possibly create the ampdoc.
     let n = opt_node;
     while (n) {
@@ -128,7 +136,7 @@ export class AmpDocService {
       // for the closest AmpDoc, the element might have a reference to the
       // global AmpDoc, which we do not want. This occurs when using
       // <amp-next-page>.
-      if (n.ampdoc_ && !closestAmpDoc) {
+      if (n.ampdoc_ && (this.alwaysClosestAmpDoc_ || !closestAmpDoc)) {
         return n.ampdoc_;
       }
 

--- a/test/functional/test-ampdoc.js
+++ b/test/functional/test-ampdoc.js
@@ -29,6 +29,7 @@ import {
   setShadowDomSupportedVersionForTesting,
 } from '../../src/web-components';
 import {createShadowRoot} from '../../src/shadow-embed';
+import {toggleExperiment} from '../../src/experiments';
 
 
 describe('AmpDocService', () => {
@@ -65,6 +66,16 @@ describe('AmpDocService', () => {
       expect(service.getAmpDoc(div)).to.equal(service.singleDoc_);
     });
 
+    it('should yield the single doc when ampdoc-closest is enabled', () => {
+      toggleExperiment(window, 'ampdoc-closest', true);
+      service = new AmpDocService(window, /* isSingleDoc */ true);
+      expect(service.getAmpDoc(null)).to.equal(service.singleDoc_);
+      expect(service.getAmpDoc(document)).to.equal(service.singleDoc_);
+      const div = document.createElement('div');
+      document.body.appendChild(div);
+      expect(service.getAmpDoc(div)).to.equal(service.singleDoc_);
+    });
+
     // For example, <amp-next-page> creates shadow documents in single-doc
     // mode.
     describe('shadow documents', () => {
@@ -90,6 +101,7 @@ describe('AmpDocService', () => {
         if (host.parentNode) {
           host.parentNode.removeChild(host);
         }
+        toggleExperiment(window, 'ampdoc-closest', false);
       });
 
       it('should yield the single doc', () => {
@@ -109,6 +121,18 @@ describe('AmpDocService', () => {
 
         const newAmpDoc = service.installShadowDoc('https://a.org/', shadowRoot);
         const ampDoc = service.getAmpDoc(content, {closestAmpDoc: true});
+        expect(ampDoc).to.equal(newAmpDoc);
+      });
+
+      it('should yield the shadow doc when ampdoc-closest is enabled', () => {
+        if (!shadowRoot) {
+          return;
+        }
+
+        toggleExperiment(window, 'ampdoc-closest', true);
+        service = new AmpDocService(window, /* isSingleDoc */ true);
+        const newAmpDoc = service.installShadowDoc('https://a.org/', shadowRoot);
+        const ampDoc = service.getAmpDoc(content);
         expect(ampDoc).to.equal(newAmpDoc);
       });
     });


### PR DESCRIPTION
Create a flag for #17614, so that we can try this out in a controlled way. This change will return the the `AmpDocShadow` when in single doc mode when using `<amp-next-page>` instead of the `AmpDocSingle`.

- Change the assert for opt_node to only apply when not in single doc, since the assert never applied to the single doc case before. Long term, we should probably force a node to be passed, otherwise there might be code written that would work in a canonical AMP page, that would not work when embedded in a shadow doc.