### PR TITLE
Bypass isConnected checks when destroying FIE

### DIFF
--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -867,18 +867,10 @@ function createBaseCustomElementClass(win) {
     /**
      * Called when the element is disconnected from the DOM.
      *
-     * This callback is guarded by checks to see if the element is still
-     * connected. See #12849, https://crbug.com/821195, and
-     * https://bugs.webkit.org/show_bug.cgi?id=180940.
-     *
      * @final @this {!Element}
      */
     disconnectedCallback() {
-      // Short circut: Only call DOM methods if we think we're connected.
-      if (this.isConnected_ && dom.isConnectedNode(this)) {
-        return;
-      }
-      this.disconnect();
+      this.disconnect(/* pretendDisconnected */ false);
     }
 
     /** The Custom Elements V0 sibling to `disconnectedCallback`. */
@@ -890,10 +882,20 @@ function createBaseCustomElementClass(win) {
      * Called when an element is disconnected from DOM, or when an ampDoc is
      * being disconnected (the element itself may still be connected to ampDoc).
      *
-     * This does not guard against connected elements.
+     * This callback is guarded by checks to see if the element is still
+     * connected. See #12849, https://crbug.com/821195, and
+     * https://bugs.webkit.org/show_bug.cgi?id=180940.
+     * If the element is still connected to the document, you'll need to pass
+     * opt_pretendDisconnected.
+     *
+     * @param {boolean} pretendDisconnected Forces disconnection regardless
+     *     of DOM isConnected.
      */
-    disconnect() {
+    disconnect(pretendDisconnected) {
       if (this.isInTemplate_ || !this.isConnected_) {
+        return;
+      }
+      if (!pretendDisconnected && dom.isConnectedNode(this)) {
         return;
       }
       this.isConnected_ = false;

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -1021,6 +1021,6 @@ export class Resource {
    */
   disconnect() {
     delete this.element[RESOURCE_PROP_];
-    this.element.disconnect();
+    this.element.disconnect(/* opt_pretendDisconnected */ true);
   }
 }

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -1021,6 +1021,6 @@ export class Resource {
    */
   disconnect() {
     delete this.element[RESOURCE_PROP_];
-    this.element.disconnectedCallback();
+    this.element.disconnect();
   }
 }

--- a/test/functional/test-resource.js
+++ b/test/functional/test-resource.js
@@ -864,12 +864,29 @@ describes.realWin('Resource', {amp: true}, env => {
         elementMock.expects('pauseCallback').once();
         resource.pauseOnRemove();
       });
+    });
 
-      it('should call disconnectedCallback on remove for built ele', () => {
-        expect(Resource.forElementOptional(resource.element))
-            .to.equal(resource);
-        elementMock.expects('disconnectedCallback').once();
+    describe('manual disconnect', () => {
+      beforeEach(() => {
+        element.setAttribute('layout', 'nodisplay');
+        doc.body.appendChild(element);
+        resource = Resource.forElementOptional(element);
+        resources = element.getResources();
+      });
+
+      it('should call disconnect on remove for built ele', () => {
+        sandbox.stub(element, 'isConnected').value(false);
+        const remove = sandbox.spy(resources, 'remove');
         resource.disconnect();
+        expect(remove).to.have.been.called;
+        expect(Resource.forElementOptional(resource.element)).to.not.exist;
+      });
+
+      it('should call disconnected regardless of isConnected', () => {
+        // element is already connected to DOM
+        const spy = sandbox.spy(resources, 'remove');
+        resource.disconnect();
+        expect(spy).to.have.been.called;
         expect(Resource.forElementOptional(resource.element)).to.not.exist;
       });
     });


### PR DESCRIPTION
This may be the cause of all the "window is null" bugs...

Introduced in #13945, we started to ignore `disconnectedCallback`s when the node itself was still connected to a document. But, FIE's destroy themselves and try to clean up `Resource`s even though those resources are still connected to the FIE's document. So, we would end up ignoring the disconnect, leaving all of them in memory and active.

Fixes #17839.
Fixes #15883.
Fixes #17604.
Probably more... Anything that touches FIE.

Fixes (maybe) #9177?
Fixes (maybe) #17840?

Working on tests now.