### PR TITLE
🐛All macro resolution should allow falsey values.

### DIFF
--- a/src/service/url-expander/expander.js
+++ b/src/service/url-expander/expander.js
@@ -241,11 +241,11 @@ export class Expander {
   evaluateBinding_(bindingInfo, opt_args, opt_collectVars, opt_sync) {
     const {name} = bindingInfo;
     let binding;
-    if (bindingInfo.prioritized) {
+    if (hasOwn(bindingInfo, 'prioritized')) {
       // If a binding is passed in through opt_bindings it always takes
       // precedence.
       binding = bindingInfo.prioritized;
-    } else if (opt_sync && bindingInfo.sync) {
+    } else if (opt_sync && hasOwn(bindingInfo, 'sync')) {
       // Use the sync resolution if avaliable when called synchronously.
       binding = bindingInfo.sync;
     } else if (opt_sync) {


### PR DESCRIPTION
In the new expander, if a macro returned a falsey value it could be ignored in certain edge cases. Protect against that.