### PR TITLE
🐛Make sure template rendering works when detached.

### DIFF
--- a/src/service/template-impl.js
+++ b/src/service/template-impl.js
@@ -55,6 +55,9 @@ export class BaseTemplate {
     /** @public @const {!Window} */
     this.win = element.ownerDocument.defaultView || win;
 
+    /** @private @const */
+    this.viewer_ = getServiceForDoc(this.element, 'viewer');
+
     this.compileCallback();
   }
 
@@ -114,8 +117,7 @@ export class BaseTemplate {
    * @return {boolean}
    */
   viewerCanRenderTemplates() {
-    return getServiceForDoc(this.element, 'viewer')
-        .hasCapability('viewerRenderTemplate');
+    return this.viewer_.hasCapability('viewerRenderTemplate');
   }
 }
 

--- a/test/functional/test-template.js
+++ b/test/functional/test-template.js
@@ -20,22 +20,26 @@ import {
   registerExtendedTemplate,
 } from '../../src/service/template-impl';
 import {Services} from '../../src/services';
-import {resetServiceForTesting} from '../../src/service';
+import {getServiceForDoc, resetServiceForTesting} from '../../src/service';
 
-describes.fakeWin('Template', {}, env => {
+describes.fakeWin('Template', {amp: true}, env => {
   let templates;
   let doc;
   let win;
+  let container;
 
   beforeEach(() => {
     win = env.win;
     installTemplatesService(win);
     templates = Services.templatesFor(win);
     doc = win.document;
+    container = document.createElement('div');
+    document.body.appendChild(container);
   });
 
   afterEach(() => {
     resetServiceForTesting(win, 'templates');
+    document.body.removeChild(container);
   });
 
   class TemplateImpl extends BaseTemplate {
@@ -46,6 +50,16 @@ describes.fakeWin('Template', {}, env => {
     }
   }
 
+  class TemplateImplCheckingViewer extends TemplateImpl {
+    render(data) {
+      if (!this.viewerCanRenderTemplates()) {
+        throw new Error();
+      }
+
+      return super.render(data);
+    }
+  }
+
   let count = 0;
 
   function createTemplateElement() {
@@ -53,6 +67,7 @@ describes.fakeWin('Template', {}, env => {
     const type = `amp-template-${id}`;
     const element = doc.createElement('template');
     element.setAttribute('type', type);
+    container.appendChild(element);
     return element;
   }
 
@@ -62,6 +77,22 @@ describes.fakeWin('Template', {}, env => {
         TemplateImpl);
     return templates.renderTemplate(templateElement, {value: 1}).then(res => {
       expect(res.textContent).to.equal('abc1');
+    });
+  });
+
+  it('should render when detached', () => {
+    const templateElement = createTemplateElement();
+    // Use TemplateImplCheckingViewer to make sure viewerCanRenderTemplates
+    // works correctly when the template is later detached.
+    registerExtendedTemplate(win, templateElement.getAttribute('type'),
+        TemplateImplCheckingViewer);
+    const viewerService = getServiceForDoc(templateElement, 'viewer');
+    env.sandbox.stub(viewerService, 'hasCapability').returns(true);
+    return templates.renderTemplate(templateElement, {value: 1}).then(() => {
+      templateElement.parentElement.removeChild(templateElement);
+      return templates.renderTemplate(templateElement, {value: 2});
+    }).then(res => {
+      expect(res.textContent).to.equal('abc2');
     });
   });
 
@@ -177,6 +208,7 @@ describes.fakeWin('Template', {}, env => {
 
     const parentElement = doc.createElement('div');
     parentElement.appendChild(templateElement);
+    container.appendChild(parentElement);
     return templates.findAndRenderTemplate(parentElement, {value: 1}).then(
         res => {
           expect(res.textContent).to.equal('abc1');
@@ -240,14 +272,19 @@ describes.fakeWin('Template', {}, env => {
 
 describes.fakeWin('BaseTemplate', {}, env => {
 
-  let templateElement;
   let win;
   let doc;
+  let templateElement;
 
   beforeEach(() => {
     win = env.win;
     doc = win.document;
     templateElement = doc.createElement('div');
+    document.body.appendChild(templateElement);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(templateElement);
   });
 
   it('should require render override', () => {


### PR DESCRIPTION
Change `viewerCanRenderTemplates` to use a cached reference to the
viewer. Since the template element can later be detached, we need to
make sure we already have the service reference. We cannot look up the
service when the template is detached.

We cannot have `<amp-access>` keep the template in the DOM since that
will impact CSS selectors (e.g. :first-child or .foo + .bar) as we
will be altering the DOM structure from the current state.

Context: https://github.com/ampproject/amphtml/issues/17328#issuecomment-418892904
For #17328 (not sure it fixes all of the problems though)