### PR TITLE
Revert #12211

### DIFF
--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -345,8 +345,7 @@ export class AmpAnalytics extends AMP.BaseElement {
     const ampAdResourceId = this.assertAmpAdResourceId();
 
     this.iframeTransport_ = new IframeTransport(
-        // Create  3p transport frame within creative frame if inabox.
-        this.isInabox_ ? this.win : this.getAmpDoc().win,
+        this.getAmpDoc().win,
         this.element.getAttribute('type'),
         this.config_['transport'], ampAdResourceId);
   }

--- a/extensions/amp-analytics/0.1/test/test-amp-analytics.js
+++ b/extensions/amp-analytics/0.1/test/test-amp-analytics.js
@@ -1740,30 +1740,6 @@ describes.realWin('amp-analytics', {
     });
   });
 
-  describe('inabox nested transport iframe', () => {
-    let origAmpMode;
-    beforeEach(() => {
-      origAmpMode = env.win.AMP_MODE;
-      env.win.AMP_MODE = 'inabox';
-      // Unfortunately need to fake sandbox analytics element's parent
-      // to an AMP element
-      doc.body.classList.add('i-amphtml-element');
-    });
-
-    afterEach(() => {
-      doc.body.classList.remove('i-amphtml-element');
-      env.win.AMP_MODE = origAmpMode;
-    });
-
-    it('sends a basic hit', function() {
-      const analytics = getAnalyticsTag(trivialConfig);
-      return waitForSendRequest(analytics).then(() => {
-        expect(sendRequestSpy.withArgs('https://example.com/bar'))
-            .to.be.calledOnce;
-      });
-    });
-  });
-
   describe('resourceTiming', () => {
     // NOTE: The following tests verify plumbing for resource timing variables.
     // More tests for resource timing can be found in test-resource-timing.js.


### PR DESCRIPTION
Reverts #12211
It's unclear why the logic is needed.

```js
this.isInabox_ ? this.win : this.getAmpDoc().win
```
In the case of inabox, `this.win` should be identical to `this.getAmpDoc().win`.


