### PR TITLE
🗑Remove Deprecated URL replacements 

### DIFF
--- a/build-system/dep-check-config.js
+++ b/build-system/dep-check-config.js
@@ -257,9 +257,6 @@ exports.rules = [
           'src/service/position-observer/position-observer-impl.js',
       'extensions/amp-next-page/0.1/next-page-service.js->' +
           'src/service/position-observer/position-observer-worker.js',
-      // TODO(calebcordry) remove this once experiment is launched
-      'extensions/amp-analytics/0.1/variables.js->' +
-          'src/service/url-replacements-impl.js',
       'extensions/amp-user-notification/0.1/amp-user-notification.js->' +
           'src/service/notification-ui-manager.js',
       'extensions/amp-consent/0.1/amp-consent.js->' +

--- a/extensions/amp-analytics/0.1/test/test-amp-analytics.js
+++ b/extensions/amp-analytics/0.1/test/test-amp-analytics.js
@@ -1145,7 +1145,8 @@ describes.realWin('amp-analytics', {
       const analytics = getAnalyticsTag(config);
 
       const urlReplacements = Services.urlReplacementsForDoc(analytics.element);
-      sandbox.stub(urlReplacements.getVariableSource(), 'get').returns(0);
+      sandbox.stub(urlReplacements.getVariableSource(), 'get')
+          .returns({async: 0});
       sandbox.stub(crypto, 'uniform')
           .withArgs('0').returns(Promise.resolve(0.005));
       return waitForSendRequest(analytics).then(() => {
@@ -1701,7 +1702,8 @@ describes.realWin('amp-analytics', {
       }, true);
 
       const urlReplacements = Services.urlReplacementsForDoc(analytics.element);
-      sandbox.stub(urlReplacements.getVariableSource(), 'get').returns(0);
+      sandbox.stub(urlReplacements.getVariableSource(), 'get')
+          .returns({async: 0});
       sandbox.stub(crypto, 'uniform')
           .withArgs('0').returns(Promise.resolve(0.005))
           .withArgs('CLIENT_ID').returns(Promise.resolve(0.5));

--- a/extensions/amp-analytics/0.1/test/test-requests.js
+++ b/extensions/amp-analytics/0.1/test/test-requests.js
@@ -19,7 +19,6 @@ import {ExpansionOptions, installVariableService} from '../variables';
 import {RequestHandler, expandPostMessage} from '../requests';
 import {dict} from '../../../../src/utils/object';
 import {macroTask} from '../../../../testing/yield';
-import {toggleExperiment} from '../../../../src/experiments';
 
 describes.realWin('Requests', {amp: 1}, env => {
   let ampdoc;

--- a/extensions/amp-analytics/0.1/test/test-requests.js
+++ b/extensions/amp-analytics/0.1/test/test-requests.js
@@ -455,7 +455,6 @@ describes.realWin('Requests', {amp: 1}, env => {
 
 
   it('should replace bindings with v2 flag', function* () {
-    toggleExperiment(env.win, 'url-replacement-v2', true);
     const spy = sandbox.spy();
     const r = {
       'baseUrl': 'r1&${extraUrlParams}&BASE_VALUE&foo=${foo}',
@@ -487,7 +486,6 @@ describes.realWin('Requests', {amp: 1}, env => {
     expect(spy).to.be.calledOnce;
     expect(spy.args[0][0]).to.equal(
         'r1&key1=val1&key2=val2&key3=val3&val_base&foo=ZM9V');
-    toggleExperiment(env.win, 'url-replacement-v2');
   });
 
   describe('expandPostMessage', () => {

--- a/extensions/amp-analytics/0.1/test/test-variables.js
+++ b/extensions/amp-analytics/0.1/test/test-variables.js
@@ -23,7 +23,6 @@ import {
   variableServiceFor,
 } from '../variables';
 import {Services} from '../../../../src/services';
-import {toggleExperiment} from '../../../../src/experiments';
 
 describe('amp-analytics.VariableService', function() {
   let variables;

--- a/extensions/amp-analytics/0.1/test/test-variables.js
+++ b/extensions/amp-analytics/0.1/test/test-variables.js
@@ -168,14 +168,9 @@ describe('amp-analytics.VariableService', function() {
     beforeEach(() => {
       ampdoc = env.ampdoc;
       win = env.win;
-      toggleExperiment(env.win, 'url-replacement-v2', true);
       installVariableService(win);
       variables = variableServiceFor(win);
       urlReplacementService = Services.urlReplacementsForDoc(ampdoc);
-    });
-
-    afterEach(() => {
-      toggleExperiment(env.win, 'url-replacement-v2');
     });
 
     function check(input, output) {

--- a/extensions/amp-analytics/0.1/variables.js
+++ b/extensions/amp-analytics/0.1/variables.js
@@ -19,9 +19,6 @@ import {base64UrlEncodeFromString} from '../../../src/utils/base64';
 import {dev, user} from '../../../src/log';
 import {getService, registerServiceBuilder} from '../../../src/service';
 import {isArray, isFiniteNumber} from '../../../src/types';
-// TODO(calebcordry) remove this once experiment is launched
-// also remove from dep-check-config whitelist;
-import {isExperimentOn} from '../../../src/experiments';
 import {tryResolve} from '../../../src/utils/promise';
 
 /** @const {string} */
@@ -150,9 +147,7 @@ export class VariableService {
    * @return {!Object} contains all registered macros
    */
   getMacros() {
-    const isV2ExpansionOn = this.win_ && isExperimentOn(this.win_,
-        'url-replacement-v2');
-    return isV2ExpansionOn ? this.macros_ : {};
+    return this.macros_;
   }
 
   /**

--- a/src/service/url-expander/expander.js
+++ b/src/service/url-expander/expander.js
@@ -57,9 +57,9 @@ export class Expander {
     }
 
     const expr = this.variableSource_
-        .getExpr(opt_bindings, /*opt_ignoreArgs */ true, opt_whiteList);
+        .getExpr(opt_bindings, /*opt_ignoreArgs */ true);
 
-    const matches = this.findMatches_(url, expr);
+    const matches = this.findMatches_(url, expr, opt_whiteList);
     // if no keywords move on
     if (!matches.length) {
       return opt_sync ? url : Promise.resolve(url);
@@ -73,10 +73,12 @@ export class Expander {
    * Structures the regex matching into the desired format
    * @param {string} url url to be substituted
    * @param {RegExp} expression regex containing all keywords
+   * @param {!Object<string, boolean>=} opt_whiteList Optional white list of names
+   *   that can be substituted.
    * @return {Array<Object<string, string|number>>} array of objects representing
    *  matching keywords
    */
-  findMatches_(url, expression) {
+  findMatches_(url, expression, opt_whiteList) {
     const matches = [];
     url.replace(expression, (match, name, startPosition) => {
       const {length} = match;
@@ -87,7 +89,9 @@ export class Expander {
         name,
         length,
       };
-      matches.push(info);
+      if (!opt_whiteList || opt_whiteList[name]) {
+        matches.push(info);
+      }
     });
     return matches;
   }

--- a/src/service/url-expander/expander.js
+++ b/src/service/url-expander/expander.js
@@ -56,8 +56,7 @@ export class Expander {
       return opt_sync ? url : Promise.resolve(url);
     }
 
-    const expr = this.variableSource_
-        .getExpr(opt_bindings, /*opt_ignoreArgs */ true);
+    const expr = this.variableSource_.getExpr(opt_bindings);
 
     const matches = this.findMatches_(url, expr, opt_whiteList);
     // if no keywords move on

--- a/src/service/url-expander/expander.js
+++ b/src/service/url-expander/expander.js
@@ -257,10 +257,14 @@ export class Expander {
       // If there is no sync resolution we can not wait.
       user().error(TAG, 'ignoring async replacement key: ', bindingInfo.name);
       binding = '';
-    } else {
+    } else if (bindingInfo.async !== undefined && bindingInfo.async !== null) {
       // Prefer the async over the sync but it may not exist.
-      binding = bindingInfo.async || bindingInfo.sync;
+      binding = bindingInfo.async;
+    } else {
+      // Use sync if it is the last option.
+      binding = bindingInfo.sync;
     }
+
     return opt_sync ?
       this.evaluateBindingSync_(binding, name, opt_args, opt_collectVars) :
       this.evaluateBindingAsync_(binding, name, opt_args, opt_collectVars);

--- a/src/service/url-expander/expander.js
+++ b/src/service/url-expander/expander.js
@@ -338,7 +338,8 @@ export class Expander {
         // may return a promise.
         user().error(TAG, 'ignoring async macro resolution');
         result = '';
-      } else if (typeof value === 'string' || typeof value === 'number') {
+      } else if (typeof value === 'string' || typeof value === 'number' ||
+          typeof value === 'boolean') {
         // Normal case.
         result = NOENCODE_WHITELIST[name] ? value.toString() :
           encodeURIComponent(/** @type {string} */ (value));

--- a/src/service/url-expander/expander.js
+++ b/src/service/url-expander/expander.js
@@ -89,6 +89,7 @@ export class Expander {
         name,
         length,
       };
+
       if (!opt_whiteList || opt_whiteList[name]) {
         matches.push(info);
       }

--- a/src/service/url-expander/expander.js
+++ b/src/service/url-expander/expander.js
@@ -291,7 +291,7 @@ export class Expander {
         value = Promise.resolve(binding);
       }
       return value.then(val => {
-        this.maybeCollectVars_(opt_collectVars, name, val, opt_args);
+        this.maybeCollectVars_(name, val, opt_collectVars, opt_args);
 
         let result;
 
@@ -304,7 +304,7 @@ export class Expander {
         return result;
       }).catch(e => {
         rethrowAsync(e);
-        this.maybeCollectVars_(opt_collectVars, name, '', opt_args);
+        this.maybeCollectVars_(name, '', opt_collectVars, opt_args);
         return Promise.resolve('');
       });
 
@@ -312,7 +312,7 @@ export class Expander {
       // Report error, but do not disrupt URL replacement. This will
       // interpolate as the empty string.
       rethrowAsync(e);
-      this.maybeCollectVars_(opt_collectVars, name, '', opt_args);
+      this.maybeCollectVars_(name, '', opt_collectVars, opt_args);
       return Promise.resolve('');
     }
   }
@@ -343,11 +343,11 @@ export class Expander {
         // Normal case.
         result = NOENCODE_WHITELIST[name] ? value.toString() :
           encodeURIComponent(/** @type {string} */ (value));
-        this.maybeCollectVars_(opt_collectVars, name, value, opt_args);
+        this.maybeCollectVars_(name, value, opt_collectVars, opt_args);
       } else {
         // Most likely a broken binding gets us here.
         result = '';
-        this.maybeCollectVars_(opt_collectVars, name, '', opt_args);
+        this.maybeCollectVars_(name, '', opt_collectVars, opt_args);
       }
 
       return result;
@@ -355,20 +355,20 @@ export class Expander {
       // Report error, but do not disrupt URL replacement. This will
       // interpolate as the empty string.
       rethrowAsync(e);
-      this.maybeCollectVars_(opt_collectVars, name, '', opt_args);
+      this.maybeCollectVars_(name, '', opt_collectVars, opt_args);
       return '';
     }
   }
 
   /**
    * Collect vars if given the optional object. Handles formatting of kv pairs.
-   * @param {!Object<string, *>=} opt_collectVars Object passed in to collect
-   *   variable resolutions.
    * @param {string} name Name of the macro.
    * @param {*} value Raw macro resolution value.
+   * @param {!Object<string, *>=} opt_collectVars Object passed in to collect
+   *   variable resolutions.
    * @param {?Array=} opt_args Arguments to be passed if binding is function.
    */
-  maybeCollectVars_(opt_collectVars, name, value, opt_args) {
+  maybeCollectVars_(name, value, opt_collectVars, opt_args) {
     if (!opt_collectVars) {
       return;
     }

--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -1019,7 +1019,6 @@ export class UrlReplacements {
    * @private
    */
   expand_(url, opt_bindings, opt_collectVars, opt_sync, opt_whiteList) {
-    debugger;
     return this.expander_./*OK*/expand(url, opt_bindings, opt_collectVars,
         opt_sync, opt_whiteList);
   }

--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -23,7 +23,7 @@ import {
   getTimingDataAsync,
   getTimingDataSync,
 } from './variable-source';
-import {Expander, NOENCODE_WHITELIST} from './url-expander/expander';
+import {Expander} from './url-expander/expander';
 import {Services} from '../services';
 import {WindowInterface} from '../window-interface';
 import {addMissingParamsToUrl, isProtocolValid} from '../url';
@@ -35,14 +35,13 @@ import {
   removeAmpJsParamsFromUrl,
   removeFragment,
 } from '../url';
-import {dev, rethrowAsync, user} from '../log';
+import {dev, user} from '../log';
 import {getTrackImpressionPromise} from '../impression.js';
 import {hasOwn} from '../utils/object';
 import {
   installServiceInEmbedScope,
   registerServiceBuilderForDoc,
 } from '../service';
-import {isExperimentOn} from '../experiments';
 import {tryResolve} from '../utils/promise';
 
 /** @private @const {string} */
@@ -53,17 +52,6 @@ const GEO_DELIM = ',';
 const ORIGINAL_HREF_PROPERTY = 'amp-original-href';
 const ORIGINAL_VALUE_PROPERTY = 'amp-original-value';
 
-/**
- * Returns a encoded URI Component, or an empty string if the value is nullish.
- * @param {*} val
- * @return {string}
- */
-function encodeValue(val) {
-  if (val == null) {
-    return '';
-  }
-  return encodeURIComponent(/** @type {string} */(val));
-}
 
 /**
  * Returns a function that executes method on a new Date instance. This is a
@@ -1031,93 +1019,9 @@ export class UrlReplacements {
    * @private
    */
   expand_(url, opt_bindings, opt_collectVars, opt_sync, opt_whiteList) {
-    const isV2ExperimentOn = isExperimentOn(this.ampdoc.win,
-        'url-replacement-v2');
-    if (isV2ExperimentOn) {
-      // TODO(ccordy) support opt_collectVars && opt_whitelist
-      return this.expander_./*OK*/expand(url, opt_bindings, opt_collectVars,
-          opt_sync, opt_whiteList);
-    }
-
-    // existing parsing method
-    const expr = this.variableSource_.getExpr(opt_bindings);
-    let replacementPromise;
-    let replacement = url.replace(expr, (match, name, opt_strargs) => {
-      let args = [];
-      if (typeof opt_strargs == 'string') {
-        args = opt_strargs.split(/,\s*/);
-      }
-      if (opt_whiteList && !opt_whiteList[name]) {
-        // Do not perform substitution and just return back the original
-        // match, so that the string doesn't change.
-        return match;
-      }
-      let binding;
-      if (opt_bindings && (name in opt_bindings)) {
-        binding = opt_bindings[name];
-      } else if ((binding = this.variableSource_.get(name))) {
-        if (opt_sync) {
-          binding = binding.sync;
-          if (!binding) {
-            user().error(TAG, 'ignoring async replacement key: ', name);
-            return '';
-          }
-        } else {
-          binding = binding.async || binding.sync;
-        }
-      }
-      let val;
-      try {
-        val = (typeof binding == 'function') ?
-          binding.apply(null, args) : binding;
-      } catch (e) {
-        // Report error, but do not disrupt URL replacement. This will
-        // interpolate as the empty string.
-        if (opt_sync) {
-          val = '';
-        }
-        rethrowAsync(e);
-      }
-      // In case the produced value is a promise, we don't actually
-      // replace anything here, but do it again when the promise resolves.
-      if (val && val.then) {
-        if (opt_sync) {
-          user().error(TAG, 'ignoring promise value for key: ', name);
-          return '';
-        }
-        /** @const {Promise<string>} */
-        const p = val.catch(err => {
-          // Report error, but do not disrupt URL replacement. This will
-          // interpolate as the empty string.
-          rethrowAsync(err);
-        }).then(v => {
-          replacement = replacement.replace(match,
-              NOENCODE_WHITELIST[match] ? v : encodeValue(v));
-          if (opt_collectVars) {
-            opt_collectVars[match] = v;
-          }
-        });
-        if (replacementPromise) {
-          replacementPromise = replacementPromise.then(() => p);
-        } else {
-          replacementPromise = p;
-        }
-        return match;
-      }
-      if (opt_collectVars) {
-        opt_collectVars[match] = val;
-      }
-      return NOENCODE_WHITELIST[match] ? val : encodeValue(val);
-    });
-
-    if (replacementPromise) {
-      replacementPromise = replacementPromise.then(() => replacement);
-    }
-
-    if (opt_sync) {
-      return replacement;
-    }
-    return replacementPromise || Promise.resolve(replacement);
+    debugger;
+    return this.expander_./*OK*/expand(url, opt_bindings, opt_collectVars,
+        opt_sync, opt_whiteList);
   }
 
   /**

--- a/src/service/variable-source.js
+++ b/src/service/variable-source.js
@@ -227,10 +227,11 @@ export class VariableSource {
       });
       return this.buildExpr_(allKeys, isV2, opt_whiteList);
     }
+
     if (!this.replacementExpr_ && !isV2) {
-      this.replacementExpr_ = this.buildExpr_(
-          Object.keys(this.replacements_));
+      this.replacementExpr_ = this.buildExpr_(Object.keys(this.replacements_));
     }
+
     // sometimes the v1 expand will be called before the v2
     // so we need to cache both versions
     if (!this.replacementExprV2_ && isV2) {

--- a/src/service/variable-source.js
+++ b/src/service/variable-source.js
@@ -109,8 +109,8 @@ export class VariableSource {
     /** @protected @const {!./ampdoc-impl.AmpDoc} */
     this.ampdoc = ampdoc;
 
-    /** @private {!RegExp|undefined} */
-    this.replacementExpr_ = undefined;
+    /** @private {?RegExp} */
+    this.replacementExpr_ = null;
 
     /** @private @const {!Object<string, !ReplacementDef>} */
     this.replacements_ = Object.create(null);

--- a/test/functional/test-url-replacements.js
+++ b/test/functional/test-url-replacements.js
@@ -1663,7 +1663,7 @@ describes.sandboxed('UrlReplacements', {}, () => {
       expect(a.href).to.equal('http://whitelisted.com/link?out=QUERY_PARAM(foo)&guid=123');
     });
 
-    it('should add URL parameters and repalce whitelisted'
+    it('should add URL parameters and replace whitelisted'
       + ' values for http whitelisted URL\'s(non-secure)', () => {
       a.href = 'http://example.com/link?out=QUERY_PARAM(foo)';
       a.setAttribute('data-amp-replace', 'CLIENT_ID');
@@ -1676,7 +1676,7 @@ describes.sandboxed('UrlReplacements', {}, () => {
       });
     });
 
-    it('should add URL parameters and not repalce whitelisted'
+    it('should add URL parameters and not replace whitelisted'
       + ' values for non whitelisted http URL\'s(non-secure)', () => {
       a.href = 'http://example2.com/link?out=QUERY_PARAM(foo)';
       a.setAttribute('data-amp-replace', 'CLIENT_ID');
@@ -1758,7 +1758,7 @@ describes.sandboxed('UrlReplacements', {}, () => {
       expect(input.value).to.equal('RANDOM');
     });
 
-    it.only('should not replace not whitelisted vars', () => {
+    it('should not replace not whitelisted vars', () => {
       const win = getFakeWindow();
       const urlReplacements = Services.urlReplacementsForDoc(win.ampdoc);
       const input = document.createElement('input');
@@ -1767,7 +1767,6 @@ describes.sandboxed('UrlReplacements', {}, () => {
       input.setAttribute('data-amp-replace', 'CANONICAL_URL');
       let expandedValue = urlReplacements.expandInputValueSync(input);
       expect(expandedValue).to.equal('RANDOM');
-      debugger;
       input.setAttribute('data-amp-replace', 'CANONICAL_URL RANDOM');
       expandedValue = urlReplacements.expandInputValueSync(input);
       expect(expandedValue).to.match(/(\d+(\.\d+)?)/);

--- a/test/functional/test-url-replacements.js
+++ b/test/functional/test-url-replacements.js
@@ -1758,7 +1758,7 @@ describes.sandboxed('UrlReplacements', {}, () => {
       expect(input.value).to.equal('RANDOM');
     });
 
-    it('should not replace not whitelisted vars', () => {
+    it.only('should not replace not whitelisted vars', () => {
       const win = getFakeWindow();
       const urlReplacements = Services.urlReplacementsForDoc(win.ampdoc);
       const input = document.createElement('input');
@@ -1767,6 +1767,7 @@ describes.sandboxed('UrlReplacements', {}, () => {
       input.setAttribute('data-amp-replace', 'CANONICAL_URL');
       let expandedValue = urlReplacements.expandInputValueSync(input);
       expect(expandedValue).to.equal('RANDOM');
+      debugger;
       input.setAttribute('data-amp-replace', 'CANONICAL_URL RANDOM');
       expandedValue = urlReplacements.expandInputValueSync(input);
       expect(expandedValue).to.match(/(\d+(\.\d+)?)/);

--- a/tools/experiments/experiments.js
+++ b/tools/experiments/experiments.js
@@ -248,12 +248,6 @@ const EXPERIMENTS = [
     cleanupIssue: 'https://github.com/ampproject/amphtml/issues/16466',
   },
   {
-    id: 'url-replacement-v2',
-    name: 'new parsing engine for url variables',
-    spec: 'https://github.com/ampproject/amphtml/issues/12119',
-    cleanupIssue: 'https://github.com/ampproject/amphtml/issues/2198',
-  },
-  {
     id: 'amp-next-page',
     name: 'Document level next page recommendations and infinite scroll',
     spec: 'https://github.com/ampproject/amphtml/issues/12945',


### PR DESCRIPTION
This removes the legacy URL replacement code, and migrates everything to use the new expander.

`opt_collectVars` needed some alterations to reach parity with the legacy code. Specifically the arguments that the macro was called with were added to the keys of the returned object.

Also fixed a couple of bugs.
- New expander was not always handling falsey values correctly.
- Moved the `opt_whiteList` logic to the `findMatches_` method. Previously it was trying to manipulate the regex, but was causing problems because the regex can be cached.