### PR TITLE
amp-video: when cached, remove `src` from `amp-video` node since it gets copied back by stories `media-pool`

### DIFF
--- a/extensions/amp-video/0.1/amp-video.js
+++ b/extensions/amp-video/0.1/amp-video.js
@@ -317,6 +317,10 @@ class AmpVideo extends AMP.BaseElement {
       const srcSource = this.createSourceElement_(src, type);
       const ampOrigSrc = this.element.getAttribute('amp-orig-src');
       srcSource.setAttribute('amp-orig-src', ampOrigSrc);
+      // Also make sure src is removed from amp-video since Stories media-pool
+      // may copy it back from amp-video.
+      this.element.removeAttribute('src');
+      this.element.removeAttribute('type');
       sources.unshift(srcSource);
     }
 

--- a/extensions/amp-video/0.1/test/test-amp-video.js
+++ b/extensions/amp-video/0.1/test/test-amp-video.js
@@ -681,15 +681,21 @@ describes.realWin('amp-video', {
 
     describe('after visible', () => {
       it('should add original source after cache one - single src', () => {
+        let ampVideoElement;
         return getVideo({
           'src': 'https://example-com.cdn.ampproject.org/m/s/video.mp4',
           'amp-orig-src': 'https://example.com/video.mp4',
         }).then(v => {
+          ampVideoElement = v;
           video = v.querySelector('video');
           makeVisible();
           return visiblePromise;
         }).then(() => {
           expect(video.hasAttribute('src')).to.be.false;
+          // also make sure removed from amp-video since Stories media-pool
+          // may copy it back from amp-video.
+          expect(ampVideoElement.hasAttribute('src')).to.be.false;
+          expect(ampVideoElement.hasAttribute('type')).to.be.false;
           const sources = video.querySelectorAll('source');
           expect(sources.length).to.equal(2);
           expect(sources[0].getAttribute('src')).to.equal('https://example-com.cdn.ampproject.org/m/s/video.mp4');

--- a/extensions/amp-video/0.1/test/test-amp-video.js
+++ b/extensions/amp-video/0.1/test/test-amp-video.js
@@ -601,6 +601,10 @@ describes.realWin('amp-video', {
         }).then(v => {
           video = v.querySelector('video');
           expect(video.hasAttribute('src')).to.be.false;
+          // also make sure removed from amp-video since Stories media-pool
+          // may copy it back from amp-video.
+          expect(video.parentNode.hasAttribute('src')).to.be.false;
+          expect(video.parentNode.hasAttribute('type')).to.be.false;
           const sources = video.querySelectorAll('source');
           expect(sources.length).to.equal(1);
           const cachedSource = sources[0];

--- a/extensions/amp-video/0.1/test/test-amp-video.js
+++ b/extensions/amp-video/0.1/test/test-amp-video.js
@@ -603,8 +603,8 @@ describes.realWin('amp-video', {
           expect(video.hasAttribute('src')).to.be.false;
           // also make sure removed from amp-video since Stories media-pool
           // may copy it back from amp-video.
-          expect(video.parentNode.hasAttribute('src')).to.be.false;
-          expect(video.parentNode.hasAttribute('type')).to.be.false;
+          expect(v.hasAttribute('src')).to.be.false;
+          expect(v.hasAttribute('type')).to.be.false;
           const sources = video.querySelectorAll('source');
           expect(sources.length).to.equal(1);
           const cachedSource = sources[0];


### PR DESCRIPTION
When a `src` of `video` is cached, we normally leave the `src` on `amp-video` untouched but instead do not propagate `src` on the `video` (since an additional `source` is added).

This was assumed to be a no-op since `src` on `amp-video` won't impact browser rendering however Stories `media-pool` copies attributes from `amp-video` to `video`. 

There is no real need to keep `src` and `type` on `amp-video` beyond readability of DOM so removing it to reduce chances of bugs like this.