### PR TITLE
Allow 'fluid' as a multi-size option

### DIFF
--- a/ads/google/test/test-utils.js
+++ b/ads/google/test/test-utils.js
@@ -77,4 +77,15 @@ describe('#getMultiSizeDimensions', () => {
         /* Ignore lowerbound */ false);
     verifyArray(actual, 0, multiSizes.length);
   });
+
+  it('should add dummy size for fluid', () => {
+    expect(getMultiSizeDimensions('fluid')).to.deep.equal([[320, 50]]);
+  });
+
+  it('should allow fluid with fixed sizes', () => {
+    expect(getMultiSizeDimensions('fluid,300x300'))
+        .to.deep.equal([[320, 50], [300, 300]]);
+    expect(getMultiSizeDimensions('300x300,fluid'))
+        .to.deep.equal([[300, 300], [320, 50]]);
+  });
 });

--- a/ads/google/test/test-utils.js
+++ b/ads/google/test/test-utils.js
@@ -79,13 +79,24 @@ describe('#getMultiSizeDimensions', () => {
   });
 
   it('should add dummy size for fluid', () => {
-    expect(getMultiSizeDimensions('fluid')).to.deep.equal([[320, 50]]);
+    expect(
+        getMultiSizeDimensions('fluid', 300, 300, /* useLowerBound */ false))
+        .to.deep.equal([[320, 50]]);
+  });
+
+  it('should not add dummy size for fluid if fluid is primary size', () => {
+    expect(getMultiSizeDimensions('fluid', 300, 300,
+        /* useLowerBound */ false,
+        /* isFluidPrimary */ true))
+        .to.deep.equal([]);
   });
 
   it('should allow fluid with fixed sizes', () => {
-    expect(getMultiSizeDimensions('fluid,300x300'))
+    expect(getMultiSizeDimensions(
+        'fluid,300x300', 300, 300, /* useLowerBound */ false))
         .to.deep.equal([[320, 50], [300, 300]]);
-    expect(getMultiSizeDimensions('300x300,fluid'))
+    expect(getMultiSizeDimensions(
+        '300x300,fluid', 300, 300, /* useLowerBound */ false))
         .to.deep.equal([[300, 300], [320, 50]]);
   });
 });

--- a/ads/google/utils.js
+++ b/ads/google/utils.js
@@ -41,7 +41,8 @@ export const DUMMY_FLUID_SIZE = '320x50';
  * Required size to be sent with fluid requests in array format.
  * @const {!Array<number>}
  */
-export const DUMMY_FLUID_SIZE_ARR = [320, 50];
+const DUMMY_FLUID_SIZE_ARR =
+    DUMMY_FLUID_SIZE.split('x').map(dim => Number(dim));
 
 /**
  * Given the amp-ad data attribute containing the multi-size dimensions, and a
@@ -75,7 +76,7 @@ export function getMultiSizeDimensions(
     if (sizeStr.toLowerCase() == 'fluid') {
       if (!isFluidPrimary) {
         // If the primary size is fluid, then the dummy size will already be
-        // included.
+        // be included.
         dimensions.push(DUMMY_FLUID_SIZE_ARR);
       }
       continue;

--- a/ads/google/utils.js
+++ b/ads/google/utils.js
@@ -60,10 +60,12 @@ export function getMultiSizeDimensions(
   for (let i = 0; i < arrayOfSizeStrs.length; i++) {
 
     const sizeStr = arrayOfSizeStrs[i];
-    if (!isFluidPrimary && sizeStr.toLowerCase() == 'fluid') {
-      // If the primary size is fluid, then the dummy 320x50 size will
-      // automatically be included.
-      dimensions.push([320, 50]);
+    if (sizeStr.toLowerCase() == 'fluid') {
+      if (!isFluidPrimary) {
+        // If the primary size is fluid, then the dummy 320x50 size will
+        // automatically be included.
+        dimensions.push([320, 50]);
+      }
       continue;
     }
     const size = sizeStr.split('x');

--- a/ads/google/utils.js
+++ b/ads/google/utils.js
@@ -43,7 +43,8 @@ export const ADSENSE_MCRSPV_TAG = 'mcrspv';
  * @param {boolean} multiSizeValidation A flag that if set to true will enforce
  *   the rule that ensures multi-size dimensions are no less than 2/3rds of
  *   their primary dimension's counterpart.
- * @param {boolean=} isFluid Indicates whether this ad slot is Fluid-enabled.
+ * @param {boolean=} isFluidPrimary Indicates whether the ad slot's primary
+ *   size is fluid.
  * @return {?Array<!Array<number>>} An array of dimensions.
  */
 export function getMultiSizeDimensions(
@@ -51,7 +52,7 @@ export function getMultiSizeDimensions(
   primaryWidth,
   primaryHeight,
   multiSizeValidation,
-  isFluid = false) {
+  isFluidPrimary = false) {
 
   const dimensions = [];
   const arrayOfSizeStrs = multiSizeDataStr.split(',');
@@ -59,6 +60,12 @@ export function getMultiSizeDimensions(
   for (let i = 0; i < arrayOfSizeStrs.length; i++) {
 
     const sizeStr = arrayOfSizeStrs[i];
+    if (!isFluidPrimary && sizeStr.toLowerCase() == 'fluid') {
+      // If the primary size is fluid, then the dummy 320x50 size will
+      // automatically be included.
+      dimensions.push([320, 50]);
+      continue;
+    }
     const size = sizeStr.split('x');
 
     // Make sure that each size is specified in the form WxH.
@@ -81,7 +88,7 @@ export function getMultiSizeDimensions(
     }
 
     // Check that secondary size is not larger than primary size.
-    if (!isFluid && !validateDimensions(width, height,
+    if (!isFluidPrimary && !validateDimensions(width, height,
         w => w > primaryWidth,
         h => h > primaryHeight,
         badParams => badParams.map(badParam =>

--- a/ads/google/utils.js
+++ b/ads/google/utils.js
@@ -74,8 +74,8 @@ export function getMultiSizeDimensions(
     const sizeStr = arrayOfSizeStrs[i];
     if (sizeStr.toLowerCase() == 'fluid') {
       if (!isFluidPrimary) {
-        // If the primary size is fluid, then the dummy 320x50 size will
-        // automatically be included.
+        // If the primary size is fluid, then the dummy size will already be
+        // included.
         dimensions.push(DUMMY_FLUID_SIZE_ARR);
       }
       continue;

--- a/ads/google/utils.js
+++ b/ads/google/utils.js
@@ -32,6 +32,18 @@ export const ADSENSE_RSPV_TAG = 'rspv';
 export const ADSENSE_MCRSPV_TAG = 'mcrspv';
 
 /**
+ * Required size to be sent with fluid requests.
+ * @const {string}
+ */
+export const DUMMY_FLUID_SIZE = '320x50';
+
+/**
+ * Required size to be sent with fluid requests in array format.
+ * @const {!Array<number>}
+ */
+export const DUMMY_FLUID_SIZE_ARR = [320, 50];
+
+/**
  * Given the amp-ad data attribute containing the multi-size dimensions, and a
  * set of primary dimensions, this function will return all valid multi-size
  * [width, height] pairs in an array.
@@ -64,7 +76,7 @@ export function getMultiSizeDimensions(
       if (!isFluidPrimary) {
         // If the primary size is fluid, then the dummy 320x50 size will
         // automatically be included.
-        dimensions.push([320, 50]);
+        dimensions.push(DUMMY_FLUID_SIZE_ARR);
       }
       continue;
     }

--- a/examples/fluid.amp.html
+++ b/examples/fluid.amp.html
@@ -21,9 +21,6 @@
     <h1>AMP Static Image DFP Reservation.</h1>
     <p>Tests a static image ad in an AMP page.</p>
     <div class="artificialfold"></div>
-    <div style="margin-left: 35%; margin-right: 15%; border: 1px red solid">
-      <amp-ad type=doubleclick data-slot="/30497360/native_v2/iu0/iu1/iu2" height="fluid"></amp-ad>
-    </div>
-    <amp-ad type=doubleclick data-slot="/30497360/native_v2/iu7" height="fluid"></amp-ad>
+    <amp-ad type=doubleclick data-slot="/30497360/native_v2/iu7" width=300 height=300 data-multi-size="fluid"></amp-ad>
   </body>
 </html>

--- a/examples/fluid.amp.html
+++ b/examples/fluid.amp.html
@@ -21,6 +21,9 @@
     <h1>AMP Static Image DFP Reservation.</h1>
     <p>Tests a static image ad in an AMP page.</p>
     <div class="artificialfold"></div>
-    <amp-ad type=doubleclick data-slot="/30497360/native_v2/iu7" width=300 height=300 data-multi-size="fluid"></amp-ad>
+    <div style="margin-left: 35%; margin-right: 15%; border: 1px red solid">
+      <amp-ad type=doubleclick data-slot="/30497360/native_v2/iu0/iu1/iu2" height="fluid"></amp-ad>
+    </div>
+    <amp-ad type=doubleclick data-slot="/30497360/native_v2/iu7" height="fluid"></amp-ad>
   </body>
 </html>

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -299,7 +299,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
   /** @override */
   isLayoutSupported(layout) {
     this.isFluidPrimaryRequest_ = layout == Layout.FLUID;
-    this.isFluidRequest_ = this.isFluidRequest || this.isFluidPrimaryRequest_;
+    this.isFluidRequest_ = this.isFluidRequest_ || this.isFluidPrimaryRequest_;
     return this.isFluidPrimaryRequest_ || isLayoutSizeDefined(layout);
   }
 

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -299,9 +299,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
   /** @override */
   isLayoutSupported(layout) {
     this.isFluidPrimaryRequest_ = layout == Layout.FLUID;
-    if (!this.isFluidRequest_) {
-      this.isFluidRequest_ = this.isFluidPrimaryRequest_;
-    }
+    this.isFluidRequest_ = this.isFluidRequest || this.isFluidPrimaryRequest_;
     return this.isFluidPrimaryRequest_ || isLayoutSizeDefined(layout);
   }
 

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -386,7 +386,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
         this.element.getAttribute('data-amp-slot-index');
     if (!this.isFluidRequest_) {
       const multiSizeStr = this.element.getAttribute('data-multi-size');
-      this.isFluidRequest_ = multiSizeStr &&
+      this.isFluidRequest_ = !!multiSizeStr &&
           multiSizeStr.indexOf('fluid') != -1;
     }
   }

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -385,8 +385,9 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     this.troubleshootData_.slotIndex =
         this.element.getAttribute('data-amp-slot-index');
     if (!this.isFluidRequest_) {
-      this.isFluidRequest_ =
-          this.element.getAttribute('data-multi-size').indexOf('fluid') != -1;
+      const multiSizeStr = this.element.getAttribute('data-multi-size');
+      this.isFluidRequest_ = multiSizeStr &&
+          multiSizeStr.indexOf('fluid') != -1;
     }
   }
 

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -47,6 +47,10 @@ import {
   truncAndTimeUrl,
 } from '../../../ads/google/a4a/utils';
 import {CONSENT_POLICY_STATE} from '../../../src/consent-state';
+import {
+  DUMMY_FLUID_SIZE,
+  getMultiSizeDimensions,
+} from '../../../ads/google/utils';
 import {Deferred} from '../../../src/utils/promise';
 import {Layout, isLayoutSizeDefined} from '../../../src/layout';
 import {Navigation} from '../../../src/service/navigation';
@@ -68,7 +72,6 @@ import {deepMerge, dict} from '../../../src/utils/object';
 import {dev, user} from '../../../src/log';
 import {domFingerprintPlain} from '../../../src/utils/dom-fingerprint';
 import {getMode} from '../../../src/mode';
-import {getMultiSizeDimensions} from '../../../ads/google/utils';
 import {getOrCreateAdCid} from '../../../src/ad-cid';
 import {
   incrementLoadingAds,
@@ -474,8 +477,9 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
       tryParseJson(this.element.getAttribute('json')) || {};
     this.adKey = this.generateAdKey_(
         `${this.initialSize_.width}x${this.initialSize_.height}`);
-    this.parameterSize = this.isFluidPrimaryRequest_ ?
-      '320x50' : `${this.initialSize_.width}x${this.initialSize_.height}`;
+    this.parameterSize = this.isFluidPrimaryRequest_
+      ? DUMMY_FLUID_SIZE
+      : `${this.initialSize_.width}x${this.initialSize_.height}`;
     const multiSizeDataStr = this.element.getAttribute('data-multi-size');
     if (multiSizeDataStr) {
       if (this.element.getAttribute('layout') == 'responsive') {

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -652,7 +652,7 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
       impl.buildCallback();
       impl.onLayoutMeasure();
       return impl.getAdUrl().then(url =>
-          expect(url).to.match(/sz=300x300%7C320x50&/));
+        expect(url).to.match(/sz=300x300%7C320x50&/));
     });
     it('should have the correct ifi numbers - no refresh', function() {
       // When ran locally, this test tends to exceed 2000ms timeout.

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -644,6 +644,16 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
             // Ensure that "auto" doesn't appear anywhere here:
             expect(url).to.match(/sz=[0-9]+x[0-9]+%7C1x2%7C3x4&/));
         });
+    it('has correct sz with fluid as multi-size', () => {
+      element.setAttribute('width', '300');
+      element.setAttribute('height', '300');
+      element.setAttribute('data-multi-size', 'fluid');
+      new AmpAd(element).upgradeCallback();
+      impl.buildCallback();
+      impl.onLayoutMeasure();
+      return impl.getAdUrl().then(url =>
+          expect(url).to.match(/sz=300x300%7C320x50&/));
+    });
     it('should have the correct ifi numbers - no refresh', function() {
       // When ran locally, this test tends to exceed 2000ms timeout.
       this.timeout(5000);

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -646,13 +646,13 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
         });
     it('has correct sz with fluid as multi-size', () => {
       element.setAttribute('width', '300');
-      element.setAttribute('height', '300');
+      element.setAttribute('height', '250');
       element.setAttribute('data-multi-size', 'fluid');
       new AmpAd(element).upgradeCallback();
       impl.buildCallback();
       impl.onLayoutMeasure();
       return impl.getAdUrl().then(url =>
-        expect(url).to.match(/sz=300x300%7C320x50&/));
+        expect(url).to.match(/sz=300x250%7C320x50&/));
     });
     it('should have the correct ifi numbers - no refresh', function() {
       // When ran locally, this test tends to exceed 2000ms timeout.


### PR DESCRIPTION
Allows 'fluid' to be specified as an additional size on the `data-multi-size` attribute.

Implements #17764.