### PR TITLE
🐛 [amp-ima-video] Fix ima controls not displayed bug on ads request failed

### DIFF
--- a/ads/google/imaVideo.js
+++ b/ads/google/imaVideo.js
@@ -638,16 +638,14 @@ export function playAds(global) {
       postMessage({event: VideoEvents.PLAYING});
       adsManager.start();
     } catch (adError) {
-      postMessage({event: VideoEvents.PLAYING});
-      playVideo();
+      onAdError();
     }
   } else if (!adRequestFailed) {
     // Ad request did not yet resolve but also did not yet fail.
     setTimeout(playAds.bind(null, global), 250);
   } else {
     // Ad request failed.
-    postMessage({event: VideoEvents.PLAYING});
-    playVideo();
+    onAdError();
   }
 }
 
@@ -721,6 +719,7 @@ export function onAdError() {
     adsManager.destroy();
   }
   videoPlayer.addEventListener(interactEvent, showControls);
+  // playVideo already contains postMessage({event: VideoEvents.PLAYING});
   playVideo();
 }
 


### PR DESCRIPTION
Fixes #17961 .

On other add failure conditions other than `ima.AdErrorEvent.Type.AD_ERROR`, we failed to call `onAdError`. This resulted in us failing to register `showControls` handler.

Using uniform `onAdError` for the failing cases.

__TO REVIEWER__:
Please double check if `postMessage({event: VideoEvents.AD_END});` from `onAdError` should be triggered without any problems. This is one major difference between reusing `onAdError` versus explicitly add `showControls` event listeners

/to @aghassemi 
