### PR TITLE
Reporting errors to viewer with exponential back off.

### DIFF
--- a/src/error.js
+++ b/src/error.js
@@ -315,11 +315,11 @@ function reportErrorToServer(message, filename, line, col, error) {
   const data = getErrorReportData(message, filename, line, col, error,
       hasNonAmpJs);
   if (data) {
-    // Report the error to viewer if it has the capability. The data passed
-    // to the viewer is exactly the same as the data passed to the server
-    // below.
-    maybeReportErrorToViewer(this, data);
     reportingBackoff(() => {
+      // Report the error to viewer if it has the capability. The data passed
+      // to the viewer is exactly the same as the data passed to the server
+      // below.
+      maybeReportErrorToViewer(this, data);
       const xhr = new XMLHttpRequest();
       xhr.open('POST', urls.errorReporting, true);
       xhr.send(JSON.stringify(data));


### PR DESCRIPTION
Only reports errors to view with exponential back off.

In AMP4EMAIL, all errors sending to viewer will be recorded by our server. We would like to only record some of the same errors by exponential back off.