### PR TITLE
🚀 Add an experiment to remove default media

### DIFF
--- a/extensions/amp-story/1.0/media-pool.js
+++ b/extensions/amp-story/1.0/media-pool.js
@@ -268,7 +268,7 @@ export class MediaPool {
    */
   getDefaultSource_(mediaType) {
     const sourceStr = this.defaultSources_[mediaType];
-    if (!sourceStr) {
+    if (sourceStr === undefined) {
       dev().error('AMP-STORY', `No default media for type ${mediaType}.`);
       return new Sources();
     }

--- a/extensions/amp-story/1.0/media-pool.js
+++ b/extensions/amp-story/1.0/media-pool.js
@@ -37,6 +37,7 @@ import {ampMediaElementFor} from './utils';
 import {dev} from '../../../src/log';
 import {findIndex} from '../../../src/utils/array';
 import {isConnectedNode} from '../../../src/dom';
+import {isExperimentOn} from '../../../src/experiments';
 import {toWin} from '../../../src/types';
 
 
@@ -171,6 +172,19 @@ export class MediaPool {
      */
     this.blessed_ = false;
 
+    /**
+     * The default source to use for pool-created audio sources,
+     * @private @const {!Object<!MediaType, string>}
+     */
+    this.defaultSources_ = {
+      [MediaType.AUDIO]:
+          isExperimentOn(win, 'disable-amp-story-default-media') ? '' :
+            BLANK_AUDIO_SRC,
+      [MediaType.AUDIO]:
+          isExperimentOn(win, 'disable-amp-story-default-media') ? '' :
+            BLANK_VIDEO_SRC,
+    };
+
     /** @private {?Array<!AmpElement>} */
     this.ampElementsToBless_ = null;
 
@@ -253,15 +267,13 @@ export class MediaPool {
    * @return {!Sources} The default source for the specified type of media.
    */
   getDefaultSource_(mediaType) {
-    switch (mediaType) {
-      case MediaType.AUDIO:
-        return new Sources(BLANK_AUDIO_SRC);
-      case MediaType.VIDEO:
-        return new Sources(BLANK_VIDEO_SRC);
-      default:
-        dev().error('AMP-STORY', `No default media for type ${mediaType}.`);
-        return new Sources();
+    const sourceStr = this.defaultSources_[mediaType];
+    if (!sourceStr) {
+      dev().error('AMP-STORY', `No default media for type ${mediaType}.`);
+      return new Sources();
     }
+
+    return new Sources(sourceStr);
   }
 
 

--- a/extensions/amp-story/1.0/media-pool.js
+++ b/extensions/amp-story/1.0/media-pool.js
@@ -180,7 +180,7 @@ export class MediaPool {
       [MediaType.AUDIO]:
           isExperimentOn(win, 'disable-amp-story-default-media') ? '' :
             BLANK_AUDIO_SRC,
-      [MediaType.AUDIO]:
+      [MediaType.VIDEO]:
           isExperimentOn(win, 'disable-amp-story-default-media') ? '' :
             BLANK_VIDEO_SRC,
     };

--- a/extensions/amp-story/1.0/sources.js
+++ b/extensions/amp-story/1.0/sources.js
@@ -32,7 +32,7 @@ export class Sources {
    */
   constructor(opt_srcAttr, opt_srcEls, opt_trackEls) {
     /** @private @const {?string} */
-    this.srcAttr_ = opt_srcAttr && opt_srcAttr.length ? opt_srcAttr : null;
+    this.srcAttr_ = opt_srcAttr !== undefined ? opt_srcAttr : null;
 
     /** @private @const {!IArrayLike<!Element>} */
     this.srcEls_ = opt_srcEls || [];

--- a/tools/experiments/experiments.js
+++ b/tools/experiments/experiments.js
@@ -230,6 +230,12 @@ const EXPERIMENTS = [
     cleanupIssue: 'https://github.com/ampproject/amphtml/issues/11715',
   },
   {
+    id: 'disable-amp-story-default-media',
+    name: 'Removes default media for amp-story',
+    spec: 'https://github.com/ampproject/amphtml/issues/14535',
+    cleanupIssue: 'https://github.com/ampproject/amphtml/issues/14535',
+  },
+  {
     id: 'amp-story-responsive-units',
     name: 'Scale pages in amp-story by rewriting responsive units',
     spec: 'https://github.com/ampproject/amphtml/issues/15955',


### PR DESCRIPTION
With the `disable-amp-story-default-media` experiment enabled, we instead initialize media sources to empty string, rather than a data URI.

#14535 claims this was tested and did not work, but I am unable to reproduce, so I wonder if other fixes we have made in the meantime have allowed this to now work.