### PR TITLE
✨[standard-actions]Add AMP.scrollTo(id) alias for id.scrollTo

### DIFF
--- a/examples/standard-actions.amp.html
+++ b/examples/standard-actions.amp.html
@@ -67,6 +67,13 @@
 </div>
 
 <div class="button-set">
+  <h3>AMP.scrollTo()</h3>
+  <button on="tap:AMP.scrollTo('id' = 'normal-element3', 'position' = 'bottom')">ScrollTo Bottom</button>
+  <button on="tap:AMP.scrollTo('id' = 'normal-element3', 'position' = 'center')">ScrollTo Center</button>
+  <button on="tap:AMP.scrollTo('id' = 'normal-element3', 'duration' = 5000)">ScrollTo Slowly</button>
+</div>
+
+<div class="button-set">
   <h3>amp-img:</h3>
   <button on="tap:img-on-viewport.show">Show</button>
   <button on="tap:img-on-viewport.hide">Hide</button>

--- a/test/functional/test-standard-actions.js
+++ b/test/functional/test-standard-actions.js
@@ -30,15 +30,22 @@ describes.sandboxed('StandardActions', {}, () => {
   let scrollStub;
   let ampdoc;
 
-  function createElement() {
-    return document.createElement('div');
+  function createElement(id = null) {
+    const element = document.createElement('div');
+    if (id !== null) {
+      element.id = id;
+    }
+    return element;
   }
 
-  function createAmpElement() {
+  function createAmpElement(id = null) {
     const element = createElement();
     element.classList.add('i-amphtml-element');
     element.collapse = sandbox.stub();
     element.expand = sandbox.stub();
+    if (id !== null) {
+      element.id = id;
+    }
     return element;
   }
 
@@ -407,6 +414,15 @@ describes.sandboxed('StandardActions', {}, () => {
       expect(optoutStub).to.be.calledOnce;
     });
 
+    it('should implement scrollTo', () => {
+      const id = 'AMP-scrollTo';
+      const element = createElement(id);
+      document.body.appendChild(element);
+      invocation.args = {id};
+      invocation.method = 'scrollTo';
+      standardActions.handleAmpTarget(invocation);
+      expectAmpElementToHaveBeenScrolledIntoView(element);
+    });
 
     it('should implement setState()', () => {
       const invokeSpy = sandbox.stub();


### PR DESCRIPTION
Closes #17426

- [x] Add `AMP.scrollTo`
- [x] Add `forwardGlobalTargetAliasForMethod` for future aliasing purposes