### PR TITLE
Allow promptIfUnknownForGeoGroup override promptIfUnknown

### DIFF
--- a/extensions/amp-consent/0.1/amp-consent.js
+++ b/extensions/amp-consent/0.1/amp-consent.js
@@ -107,6 +107,9 @@ export class AmpConsent extends AMP.BaseElement {
 
     /** @private {boolean} */
     this.isPostPromptUIRequired_ = false;
+
+    /** @private {!Object<string, Promise<?JsonObject>>} */
+    this.remoteConfigPromises_ = map();
   }
 
   /** @override */
@@ -367,8 +370,11 @@ export class AmpConsent extends AMP.BaseElement {
       this.consentStateManager_.registerConsentInstance(
           instanceId, this.consentConfig_[instanceId]);
 
+      this.passSharedData_(instanceId);
+
       const isConsentRequiredPromise = this.getConsentRequiredPromise_(
           instanceId, this.consentConfig_[instanceId]);
+
 
       const handlePromptPromise = isConsentRequiredPromise.then(() => {
         return this.initPromptUI_(instanceId);
@@ -399,20 +405,19 @@ export class AmpConsent extends AMP.BaseElement {
         config['promptIfUnknownForGeoGroup'],
     'neither checkConsentHref nor ' +
     'promptIfUnknownForGeoGroup is defined');
+    let geoPromise = Promise.resolve(null);
     let remoteConfigPromise = Promise.resolve(null);
-    if (config['checkConsentHref']) {
-      remoteConfigPromise = this.getConsentRemote_(instanceId);
-      this.passSharedData_(instanceId, remoteConfigPromise);
-    }
-    let geoPromise = Promise.resolve();
     if (config['promptIfUnknownForGeoGroup']) {
       const geoGroup = config['promptIfUnknownForGeoGroup'];
       geoPromise = this.isConsentRequiredGeo_(geoGroup);
+    } else {
+      remoteConfigPromise = this.getConsentRemote_(instanceId);
     }
+
     return geoPromise.then(promptIfUnknown => {
       return remoteConfigPromise.then(response => {
         this.consentRequired_[instanceId] =
-            this.isPromptRequired_(instanceId, response, promptIfUnknown);
+            this.isPromptRequired_(instanceId, promptIfUnknown, response);
       });
     });
   }
@@ -420,9 +425,9 @@ export class AmpConsent extends AMP.BaseElement {
   /**
    * Blindly pass sharedData
    * @param {string} instanceId
-   * @param {!Promise<!JsonObject>} responsePromise
    */
-  passSharedData_(instanceId, responsePromise) {
+  passSharedData_(instanceId) {
+    const responsePromise = this.getConsentRemote_(instanceId);
     const sharedDataPromise = responsePromise.then(response => {
       if (!response || response['sharedData'] === undefined) {
         return null;
@@ -500,32 +505,42 @@ export class AmpConsent extends AMP.BaseElement {
 
   /**
    * Get localStored consent info, and send request to get consent from endpoint
+   * if there is checkConsentHref specified.
    * @param {string} instanceId
-   * @return {!Promise<!JsonObject>}
+   * @return {!Promise<?JsonObject>}
    */
   getConsentRemote_(instanceId) {
-    // Note: Expect the request to look different in following versions.
-    const request = /** @type {!JsonObject} */ ({
-      'consentInstanceId': instanceId,
-    });
-    const init = {
-      credentials: 'include',
-      method: 'POST',
-      body: request,
-      requireAmpResponseSourceOrigin: false,
-    };
-    const href =
-        this.consentConfig_[instanceId]['checkConsentHref'];
-    assertHttpsUrl(href, this.element);
-    const ampdoc = this.getAmpDoc();
-    const sourceBase = getSourceUrl(ampdoc.getUrl());
-    const resolvedHref = resolveRelativeUrl(href, sourceBase);
-    const viewer = Services.viewerForDoc(ampdoc);
-    return viewer.whenFirstVisible().then(() => {
-      return Services.xhrFor(this.win)
-          .fetchJson(resolvedHref, init)
-          .then(res => res.json());
-    });
+    if (this.remoteConfigPromises_[instanceId]) {
+      return this.remoteConfigPromises_[instanceId];
+    }
+    if (!this.consentConfig_[instanceId]['checkConsentHref']) {
+      this.remoteConfigPromises_[instanceId] = Promise.resolve(null);
+    } else {
+      // Note: Expect the request to look different in following versions.
+      const request = /** @type {!JsonObject} */ ({
+        'consentInstanceId': instanceId,
+      });
+      const init = {
+        credentials: 'include',
+        method: 'POST',
+        body: request,
+        requireAmpResponseSourceOrigin: false,
+      };
+      const href =
+          this.consentConfig_[instanceId]['checkConsentHref'];
+      assertHttpsUrl(href, this.element);
+      const ampdoc = this.getAmpDoc();
+      const sourceBase = getSourceUrl(ampdoc.getUrl());
+      const resolvedHref = resolveRelativeUrl(href, sourceBase);
+      const viewer = Services.viewerForDoc(ampdoc);
+      this.remoteConfigPromises_[instanceId] =
+          viewer.whenFirstVisible().then(() => {
+            return Services.xhrFor(this.win)
+                .fetchJson(resolvedHref, init)
+                .then(res => res.json());
+          });
+    }
+    return this.remoteConfigPromises_[instanceId];
   }
 
   /**
@@ -653,28 +668,25 @@ export class AmpConsent extends AMP.BaseElement {
   }
 
   /**
-   * Parse response from server endpoint
-   * The response format example:
-   * {
-   *   "promptIfUnknown": true/false
-   * }
-   * TODO: Support vendor lists
+   * Determine to prompt or not based on
+   * geo location and checkConsentHref response
    * @param {string} instanceId
-   * @param {?JsonObject} response
-   * @param {boolean=} opt_initValue
+   * @param {?boolean} prompt
+   * @param {?JsonObject} remoteConfig
    * @return {boolean}
    */
-  isPromptRequired_(instanceId, response, opt_initValue) {
-    let promptIfUnknown = opt_initValue;
-    if (response && response['promptIfUnknown'] == true) {
-      promptIfUnknown = true;
-    } else if (response && response['promptIfUnknown'] == false) {
-      promptIfUnknown = false;
-    } else if (promptIfUnknown == undefined) {
-      // Set to false if not defined
-      promptIfUnknown = false;
+  isPromptRequired_(instanceId, prompt, remoteConfig) {
+    console.log(instanceId, prompt, remoteConfig);
+    if (prompt != null) {
+      return prompt;
     }
-    return promptIfUnknown;
+    if (!remoteConfig || !remoteConfig['promptIfUnknown']) {
+      this.user().error(TAG, 'Expecting promptIfUnknown from checkConsentHref' +
+        ' when promptIfUnknownForGeoGroup is not specified');
+      // Set to false if not defined
+      return false;
+    }
+    return !!remoteConfig['promptIfUnknown'];
   }
 
   /**

--- a/extensions/amp-consent/0.1/test/test-amp-consent.js
+++ b/extensions/amp-consent/0.1/test/test-amp-consent.js
@@ -266,7 +266,7 @@ describes.realWin('amp-consent', {
       const parseSpy = sandbox.spy(ampConsent, 'isPromptRequired_');
       ampConsent.buildCallback();
       yield macroTask();
-      expect(parseSpy).to.be.calledWith('ABC', {
+      expect(parseSpy).to.be.calledWith('ABC', null, {
         'promptIfUnknown': true,
       });
     });
@@ -305,7 +305,7 @@ describes.realWin('amp-consent', {
       expect(ampConsent.consentRequired_['ABC']).to.equal(false);
     });
 
-    it('promptIfUnknow override geo', function* () {
+    it('geo override promptIfUnknown', function* () {
       ISOCountryGroups = ['unknown'];
       consentElement = createConsentElement(doc, dict({
         'consents': {
@@ -319,41 +319,7 @@ describes.realWin('amp-consent', {
       ampConsent = new AmpConsent(consentElement);
       ampConsent.buildCallback();
       yield macroTask();
-      expect(ampConsent.consentRequired_['ABC']).to.equal(true);
-    });
-
-    it('promptIfUnknow override geo with false value', function* () {
-      ISOCountryGroups = ['unknown'];
-      consentElement = createConsentElement(doc, dict({
-        'consents': {
-          'ABC': {
-            'checkConsentHref': 'https://response3',
-            'promptIfUnknownForGeoGroup': 'unknown',
-          },
-        },
-      }));
-      doc.body.appendChild(consentElement);
-      ampConsent = new AmpConsent(consentElement);
-      ampConsent.buildCallback();
-      yield macroTask();
       expect(ampConsent.consentRequired_['ABC']).to.equal(false);
-    });
-
-    it('checkConsentHref w/o promptIfUnknow not override geo', function* () {
-      ISOCountryGroups = ['testGroup'];
-      consentElement = createConsentElement(doc, dict({
-        'consents': {
-          'ABC': {
-            'checkConsentHref': 'https://response2',
-            'promptIfUnknownForGeoGroup': 'testGroup',
-          },
-        },
-      }));
-      doc.body.appendChild(consentElement);
-      ampConsent = new AmpConsent(consentElement);
-      ampConsent.buildCallback();
-      yield macroTask();
-      expect(ampConsent.consentRequired_['ABC']).to.equal(true);
     });
   });
 

--- a/extensions/amp-consent/amp-consent.md
+++ b/extensions/amp-consent/amp-consent.md
@@ -162,7 +162,7 @@ AMP sends the consent instance ID, a generated user id only for this usage and t
 
 To use `promptIfUnknownForGeoGroup`, a `<amp-geo>` component must be included and properly configured. The `promptIfUnknownForGeoGroup` then accepts a key of a geo group of country codes. More details on how `<amp-geo>` works can be found [here](https://github.com/ampproject/amphtml/blob/master/extensions/amp-geo/amp-geo.md).
 
-In the case that `checkConsentHref` and `promptIfUnknownForGeoGroup` are both defined. `promptIfUnknown`'s value from response will be respected.
+In the case that `checkConsentHref` and `promptIfUnknownForGeoGroup` are both defined. The value from `<amp-geo>` will be respected.
 
 #### promptUI
 


### PR DESCRIPTION
I introduce a behavior change here. Which I believe shouldn't affect any publishers. 

But we need to make the change anyway in order to support `promptIfUnknownForGeoGroup` with CMPs. As `checkConsentHref` is always required from CMP. `promptIfUnknownForGeoGroup` won't work if we don't reverse the order. 
cc @jpettitt 