### PR TITLE
AdSense/Doubleclick Fast Fetch - timeout on viewer get referrer

### DIFF
--- a/ads/google/a4a/test/test-utils.js
+++ b/ads/google/a4a/test/test-utils.js
@@ -497,7 +497,7 @@ describe('Google A4A utils', () => {
         const impl = new MockA4AImpl(elem);
         noopMethods(impl, doc, sandbox);
         sandbox.stub(Services.viewerForDoc(impl.getAmpDoc()), 'getReferrerUrl')
-            .returns(new Promise(unused_resolve => {}));
+            .returns(new Promise(() => {}));
         const createElementStub =
           sandbox.stub(impl.win.document, 'createElement');
         createElementStub.withArgs('iframe').returns({

--- a/ads/google/a4a/test/test-utils.js
+++ b/ads/google/a4a/test/test-utils.js
@@ -54,7 +54,7 @@ function setupForAdTesting(fixture) {
   installDocService(fixture.win, /* isSingleDoc */ true);
   installExtensionsService(fixture.win);
   const {doc} = fixture;
-  // TODO(a4a-cam@): This is necessary in the short term, until A4A isunused
+  // TODO(a4a-cam@): This is necessary in the short term, until A4A is
   // smarter about host document styling.  The issue is that it needs to
   // inherit the AMP runtime style element in order for shadow DOM-enclosed
   // elements to behave properly.  So we have to set up a minimal one here.


### PR DESCRIPTION
Ensure that retrieving referrer from Services.viewerForDoc(ampDoc).getReferrerUrl() returns in at most one second to mitigate possible viewer integration issues.  If timeout occurs, error is logged and referrer is not included in ad request.