### PR TITLE
🐛Build scrollbar URL with access source in amp-access-scroll

### DIFF
--- a/extensions/amp-access-scroll/0.1/amp-access-scroll.js
+++ b/extensions/amp-access-scroll/0.1/amp-access-scroll.js
@@ -23,7 +23,7 @@ AMP.extension('amp-access-scroll', '0.1', function(AMP) {
       function(ampdoc) {
         return Services.accessServiceForDoc(ampdoc).then(accessService => {
           const source = accessService.getVendorSource('scroll');
-          const vendor = new ScrollAccessVendor(ampdoc, accessService, source);
+          const vendor = new ScrollAccessVendor(ampdoc, source);
           const adapter = /** @type {
             !../../amp-access/0.1/amp-access-vendor.AccessVendorAdapter
           } */ (source.getAdapter());


### PR DESCRIPTION
Uses the `buildUrl()` method on access source to construct the scrollbar URL instead of building it manually.