### PR TITLE
Remove remnants of validator LIGHT mode. 

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -50,5 +50,5 @@
   "doubleclickSraExp": 0,
   "doubleclickSraReportExcludedBlock": 0.1,
   "inabox-rov": 1,
-  "layers": 1
+  "layers": 0
 }

--- a/validator/OWNERS.yaml
+++ b/validator/OWNERS.yaml
@@ -1,2 +1,4 @@
-- Gregable
+- gregable
 - honeybadgerdontcare
+- alin04
+- twifkak

--- a/validator/engine/amp4ads-parse-css.js
+++ b/validator/engine/amp4ads-parse-css.js
@@ -17,7 +17,6 @@
 
 goog.provide('parse_css.validateAmp4AdsCss');
 
-goog.require('amp.validator.LIGHT');
 goog.require('amp.validator.ValidationError');
 goog.require('parse_css.ErrorToken');
 goog.require('parse_css.RuleVisitor');
@@ -83,10 +82,6 @@ class Amp4AdsVisitor extends parse_css.RuleVisitor {
     }
     const ident = firstIdent(declaration.value);
     if (ident === 'fixed' || ident === 'sticky') {
-      if (amp.validator.LIGHT) {
-        this.errors.push(parse_css.TRIVIAL_ERROR_TOKEN);
-        return;
-      }
       this.errors.push(createParseErrorTokenAt(
           declaration, amp.validator.ValidationError.Code
               .CSS_SYNTAX_DISALLOWED_PROPERTY_VALUE,
@@ -106,10 +101,6 @@ class Amp4AdsVisitor extends parse_css.RuleVisitor {
             parse_css.stripVendorPrefix(transitionedProperty);
         if (transitionedPropertyStripped !== 'opacity' &&
             transitionedPropertyStripped !== 'transform') {
-          if (amp.validator.LIGHT) {
-            this.errors.push(parse_css.TRIVIAL_ERROR_TOKEN);
-            return;
-          }
           this.errors.push(createParseErrorTokenAt(
               decl, amp.validator.ValidationError.Code
                   .CSS_SYNTAX_DISALLOWED_PROPERTY_VALUE_WITH_HINT,
@@ -124,10 +115,6 @@ class Amp4AdsVisitor extends parse_css.RuleVisitor {
       // are opacity, transform, and animation-timing-function.
       if (this.inKeyframes !== null && name !== 'transform' &&
           name !== 'opacity' && name !== 'animation-timing-function') {
-        if (amp.validator.LIGHT) {
-          this.errors.push(parse_css.TRIVIAL_ERROR_TOKEN);
-          return;
-        }
         this.errors.push(createParseErrorTokenAt(
             decl, amp.validator.ValidationError.Code
                 .CSS_SYNTAX_PROPERTY_DISALLOWED_WITHIN_AT_RULE,

--- a/validator/engine/css-selectors.js
+++ b/validator/engine/css-selectors.js
@@ -33,7 +33,6 @@ goog.provide('parse_css.parseAnAttrSelector');
 goog.provide('parse_css.parseAnIdSelector');
 goog.provide('parse_css.parseSelectors');
 goog.provide('parse_css.traverseSelectors');
-goog.require('amp.validator.LIGHT');
 goog.require('amp.validator.ValidationError');
 goog.require('goog.asserts');
 goog.require('parse_css.ErrorToken');
@@ -151,15 +150,13 @@ parse_css.TypeSelector = class extends parse_css.Selector {
     visitor.visitTypeSelector(this);
   }
 };
-if (!amp.validator.LIGHT) {
-  /** @inheritDoc */
-  parse_css.TypeSelector.prototype.toJSON = function() {
-    const json = parse_css.Selector.prototype.toJSON.call(this);
-    json['namespacePrefix'] = this.namespacePrefix;
-    json['elementName'] = this.elementName;
-    return json;
-  };
-}
+/** @inheritDoc */
+parse_css.TypeSelector.prototype.toJSON = function() {
+  const json = parse_css.Selector.prototype.toJSON.call(this);
+  json['namespacePrefix'] = this.namespacePrefix;
+  json['elementName'] = this.elementName;
+  return json;
+};
 
 /**
  * Helper function for determining whether the provided token is a specific
@@ -240,14 +237,12 @@ parse_css.IdSelector = class extends parse_css.Selector {
     visitor.visitIdSelector(this);
   }
 };
-if (!amp.validator.LIGHT) {
-  /** @inheritDoc */
-  parse_css.IdSelector.prototype.toJSON = function() {
-    const json = parse_css.Selector.prototype.toJSON.call(this);
-    json['value'] = this.value;
-    return json;
-  };
-}
+/** @inheritDoc */
+parse_css.IdSelector.prototype.toJSON = function() {
+  const json = parse_css.Selector.prototype.toJSON.call(this);
+  json['value'] = this.value;
+  return json;
+};
 
 /**
  * tokenStream.current() must be the hash token.
@@ -300,17 +295,15 @@ parse_css.AttrSelector = class extends parse_css.Selector {
     visitor.visitAttrSelector(this);
   }
 };
-if (!amp.validator.LIGHT) {
-  /** @inheritDoc */
-  parse_css.AttrSelector.prototype.toJSON = function() {
-    const json = parse_css.Selector.prototype.toJSON.call(this);
-    json['namespacePrefix'] = this.namespacePrefix;
-    json['attrName'] = this.attrName;
-    json['matchOperator'] = this.matchOperator;
-    json['value'] = this.value;
-    return json;
-  };
-}
+/** @inheritDoc */
+parse_css.AttrSelector.prototype.toJSON = function() {
+  const json = parse_css.Selector.prototype.toJSON.call(this);
+  json['namespacePrefix'] = this.namespacePrefix;
+  json['attrName'] = this.attrName;
+  json['matchOperator'] = this.matchOperator;
+  json['value'] = this.value;
+  return json;
+};
 
 /**
  * Helper for parseAnAttrSelector.
@@ -359,9 +352,6 @@ parse_css.parseAnAttrSelector = function(tokenStream) {
   }
   // Now parse the attribute name. This part is mandatory.
   if (!(tokenStream.current().tokenType === parse_css.TokenType.IDENT)) {
-    if (amp.validator.LIGHT) {
-      return parse_css.TRIVIAL_ERROR_TOKEN;
-    }
     return newInvalidAttrSelectorError(start);
   }
   const ident = /** @type {!parse_css.IdentToken} */ (tokenStream.current());
@@ -416,10 +406,6 @@ parse_css.parseAnAttrSelector = function(tokenStream) {
       const str = /** @type {!parse_css.StringToken} */ (tokenStream.current());
       value = str.value;
       tokenStream.consume();
-    } else {
-      if (amp.validator.LIGHT) {
-        return parse_css.TRIVIAL_ERROR_TOKEN;
-      }
     }
   }
   if (tokenStream.current().tokenType === parse_css.TokenType.WHITESPACE) {
@@ -428,9 +414,6 @@ parse_css.parseAnAttrSelector = function(tokenStream) {
   // The attribute selector must in any case terminate with a close square
   // token.
   if (tokenStream.current().tokenType !== parse_css.TokenType.CLOSE_SQUARE) {
-    if (amp.validator.LIGHT) {
-      return parse_css.TRIVIAL_ERROR_TOKEN;
-    }
     return newInvalidAttrSelectorError(start);
   }
   tokenStream.consume();
@@ -476,18 +459,16 @@ parse_css.PseudoSelector = class extends parse_css.Selector {
     visitor.visitPseudoSelector(this);
   }
 };
-if (!amp.validator.LIGHT) {
-  /** @inheritDoc */
-  parse_css.PseudoSelector.prototype.toJSON = function() {
-    const json = parse_css.Selector.prototype.toJSON.call(this);
-    json['isClass'] = this.isClass;
-    json['name'] = this.name;
-    if (this.func.length !== 0) {
-      json['func'] = recursiveArrayToJSON(this.func);
-    }
-    return json;
-  };
-}
+/** @inheritDoc */
+parse_css.PseudoSelector.prototype.toJSON = function() {
+  const json = parse_css.Selector.prototype.toJSON.call(this);
+  json['isClass'] = this.isClass;
+  json['name'] = this.name;
+  if (this.func.length !== 0) {
+    json['func'] = recursiveArrayToJSON(this.func);
+  }
+  return json;
+};
 
 /**
  * tokenStream.current() must be the ColonToken. Returns an error if
@@ -521,7 +502,7 @@ parse_css.parseAPseudoSelector = function(tokenStream) {
     tokenStream.consume();
     return firstColon.copyPosTo(
         new parse_css.PseudoSelector(isClass, funcToken.value, func));
-  } else if (!amp.validator.LIGHT) {
+  } else {
     return firstColon.copyPosTo(new parse_css.ErrorToken(
         amp.validator.ValidationError.Code.CSS_SYNTAX_ERROR_IN_PSEUDO_SELECTOR,
         ['style']));
@@ -555,14 +536,12 @@ parse_css.ClassSelector = class extends parse_css.Selector {
     visitor.visitClassSelector(this);
   }
 };
-if (!amp.validator.LIGHT) {
-  /** @inheritDoc */
-  parse_css.ClassSelector.prototype.toJSON = function() {
-    const json = parse_css.Selector.prototype.toJSON.call(this);
-    json['value'] = this.value;
-    return json;
-  };
-}
+/** @inheritDoc */
+parse_css.ClassSelector.prototype.toJSON = function() {
+  const json = parse_css.Selector.prototype.toJSON.call(this);
+  json['value'] = this.value;
+  return json;
+};
 
 /**
  * tokenStream.current() must be the '.' delimiter token.
@@ -625,15 +604,13 @@ parse_css.SimpleSelectorSequence = class extends parse_css.Selector {
     visitor.visitSimpleSelectorSequence(this);
   }
 };
-if (!amp.validator.LIGHT) {
-  /** @inheritDoc */
-  parse_css.SimpleSelectorSequence.prototype.toJSON = function() {
-    const json = parse_css.Selector.prototype.toJSON.call(this);
-    json['typeSelector'] = this.typeSelector.toJSON();
-    json['otherSelectors'] = recursiveArrayToJSON(this.otherSelectors);
-    return json;
-  };
-}
+/** @inheritDoc */
+parse_css.SimpleSelectorSequence.prototype.toJSON = function() {
+  const json = parse_css.Selector.prototype.toJSON.call(this);
+  json['typeSelector'] = this.typeSelector.toJSON();
+  json['otherSelectors'] = recursiveArrayToJSON(this.otherSelectors);
+  return json;
+};
 
 /**
  * tokenStream.current must be the first token of the sequence.
@@ -677,9 +654,6 @@ parse_css.parseASimpleSelectorSequence = function(tokenStream) {
     } else {
       if (typeSelector === null) {
         if (otherSelectors.length == 0) {
-          if (amp.validator.LIGHT) {
-            return parse_css.TRIVIAL_ERROR_TOKEN;
-          }
           return tokenStream.current().copyPosTo(new parse_css.ErrorToken(
               amp.validator.ValidationError.Code.CSS_SYNTAX_MISSING_SELECTOR,
               ['style']));
@@ -737,16 +711,14 @@ parse_css.Combinator = class extends parse_css.Selector {
     visitor.visitCombinator(this);
   }
 };
-if (!amp.validator.LIGHT) {
-  /** @inheritDoc */
-  parse_css.Combinator.prototype.toJSON = function() {
-    const json = parse_css.Selector.prototype.toJSON.call(this);
-    json['combinatorType'] = this.combinatorType;
-    json['left'] = this.left.toJSON();
-    json['right'] = this.right.toJSON();
-    return json;
-  };
-}
+/** @inheritDoc */
+parse_css.Combinator.prototype.toJSON = function() {
+  const json = parse_css.Selector.prototype.toJSON.call(this);
+  json['combinatorType'] = this.combinatorType;
+  json['left'] = this.left.toJSON();
+  json['right'] = this.right.toJSON();
+  return json;
+};
 
 /**
  * The CombinatorType for a given token; helper function used when
@@ -810,9 +782,6 @@ function isSimpleSelectorSequenceStart(token) {
  */
 parse_css.parseASelector = function(tokenStream) {
   if (!isSimpleSelectorSequenceStart(tokenStream.current())) {
-    if (amp.validator.LIGHT) {
-      return parse_css.TRIVIAL_ERROR_TOKEN;
-    }
     return tokenStream.current().copyPosTo(new parse_css.ErrorToken(
         amp.validator.ValidationError.Code.CSS_SYNTAX_NOT_A_SELECTOR_START,
         ['style']));
@@ -884,14 +853,12 @@ parse_css.SelectorsGroup = class extends parse_css.Selector {
     visitor.visitSelectorsGroup(this);
   }
 };
-if (!amp.validator.LIGHT) {
-  /** @inheritDoc */
-  parse_css.SelectorsGroup.prototype.toJSON = function() {
-    const json = parse_css.Selector.prototype.toJSON.call(this);
-    json['elements'] = recursiveArrayToJSON(this.elements);
-    return json;
-  };
-}
+/** @inheritDoc */
+parse_css.SelectorsGroup.prototype.toJSON = function() {
+  const json = parse_css.Selector.prototype.toJSON.call(this);
+  json['elements'] = recursiveArrayToJSON(this.elements);
+  return json;
+};
 
 /**
  * The selectors_group production from
@@ -905,9 +872,6 @@ if (!amp.validator.LIGHT) {
  */
 parse_css.parseASelectorsGroup = function(tokenStream) {
   if (!isSimpleSelectorSequenceStart(tokenStream.current())) {
-    if (amp.validator.LIGHT) {
-      return parse_css.TRIVIAL_ERROR_TOKEN;
-    }
     return tokenStream.current().copyPosTo(new parse_css.ErrorToken(
         amp.validator.ValidationError.Code.CSS_SYNTAX_NOT_A_SELECTOR_START,
         ['style']));
@@ -936,9 +900,6 @@ parse_css.parseASelectorsGroup = function(tokenStream) {
     // We're about to claim success and return a selector,
     // but before we do, we check that no unparsed input remains.
     if (!(tokenStream.current().tokenType === parse_css.TokenType.EOF_TOKEN)) {
-      if (amp.validator.LIGHT) {
-        return parse_css.TRIVIAL_ERROR_TOKEN;
-      }
       return tokenStream.current().copyPosTo(new parse_css.ErrorToken(
           amp.validator.ValidationError.Code
               .CSS_SYNTAX_UNPARSED_INPUT_REMAINS_IN_SELECTOR,

--- a/validator/engine/definitions.js
+++ b/validator/engine/definitions.js
@@ -14,11 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the license.
  */
-goog.provide('amp.validator.LIGHT');
 goog.provide('amp.validator.VALIDATE_CSS');
-
-/** @define {boolean} */
-amp.validator.LIGHT = false;
 
 /** @define {boolean} */
 amp.validator.VALIDATE_CSS = true;

--- a/validator/engine/keyframes-parse-css.js
+++ b/validator/engine/keyframes-parse-css.js
@@ -16,7 +16,6 @@
  */
 
 goog.provide('parse_css.validateKeyframesCss');
-goog.require('amp.validator.LIGHT');
 goog.require('amp.validator.ValidationError');
 goog.require('parse_css.ErrorToken');
 goog.require('parse_css.RuleVisitor');
@@ -54,27 +53,19 @@ class KeyframesVisitor extends parse_css.RuleVisitor {
   /** @inheritDoc */
   visitQualifiedRule(qualifiedRule) {
     if (!this.parentIsKeyframesAtRule) {
-      if (amp.validator.LIGHT) {
-        this.errors.push(parse_css.TRIVIAL_ERROR_TOKEN);
-      } else {
-        this.errors.push(createErrorTokenAt(
-            qualifiedRule,
-            amp.validator.ValidationError.Code
-                .CSS_SYNTAX_DISALLOWED_QUALIFIED_RULE_MUST_BE_INSIDE_KEYFRAME,
-            ['style', qualifiedRule.ruleName()]));
-      }
-      return;
-    }
-    if (qualifiedRule.declarations.length > 0) {return;}
-    if (amp.validator.LIGHT) {
-      this.errors.push(parse_css.TRIVIAL_ERROR_TOKEN);
-    } else {
       this.errors.push(createErrorTokenAt(
           qualifiedRule,
           amp.validator.ValidationError.Code
-              .CSS_SYNTAX_QUALIFIED_RULE_HAS_NO_DECLARATIONS,
+              .CSS_SYNTAX_DISALLOWED_QUALIFIED_RULE_MUST_BE_INSIDE_KEYFRAME,
           ['style', qualifiedRule.ruleName()]));
+      return;
     }
+    if (qualifiedRule.declarations.length > 0) {return;}
+    this.errors.push(createErrorTokenAt(
+        qualifiedRule,
+        amp.validator.ValidationError.Code
+            .CSS_SYNTAX_QUALIFIED_RULE_HAS_NO_DECLARATIONS,
+        ['style', qualifiedRule.ruleName()]));
   }
 
   /** @inheritDoc */
@@ -85,15 +76,11 @@ class KeyframesVisitor extends parse_css.RuleVisitor {
       case '-o-keyframes':
       case '-webkit-keyframes':
         if (this.parentIsKeyframesAtRule) {
-          if (amp.validator.LIGHT) {
-            this.errors.push(parse_css.TRIVIAL_ERROR_TOKEN);
-          } else {
-            this.errors.push(createErrorTokenAt(
-                atRule,
-                amp.validator.ValidationError.Code
-                    .CSS_SYNTAX_DISALLOWED_KEYFRAME_INSIDE_KEYFRAME,
-                ['style']));
-          }
+          this.errors.push(createErrorTokenAt(
+              atRule,
+              amp.validator.ValidationError.Code
+                  .CSS_SYNTAX_DISALLOWED_KEYFRAME_INSIDE_KEYFRAME,
+              ['style']));
         }
         this.parentIsKeyframesAtRule = true;
         return;

--- a/validator/engine/parse-css.js
+++ b/validator/engine/parse-css.js
@@ -36,7 +36,6 @@ goog.provide('parse_css.parseAStylesheet');
 goog.provide('parse_css.parseInlineStyle');
 goog.provide('parse_css.parseMediaQueries');
 goog.provide('parse_css.stripVendorPrefix');
-goog.require('amp.validator.LIGHT');
 goog.require('amp.validator.ValidationError.Code');
 goog.require('goog.asserts');
 goog.require('goog.string');
@@ -231,15 +230,13 @@ parse_css.Stylesheet = class extends parse_css.Rule {
     visitor.leaveStylesheet(this);
   }
 };
-if (!amp.validator.LIGHT) {
-  /** @inheritDoc */
-  parse_css.Stylesheet.prototype.toJSON = function() {
-    const json = parse_css.Rule.prototype.toJSON.call(this);
-    json['rules'] = arrayToJSON(this.rules);
-    json['eof'] = this.eof.toJSON();
-    return json;
-  };
-}
+/** @inheritDoc */
+parse_css.Stylesheet.prototype.toJSON = function() {
+  const json = parse_css.Rule.prototype.toJSON.call(this);
+  json['rules'] = arrayToJSON(this.rules);
+  json['eof'] = this.eof.toJSON();
+  return json;
+};
 
 parse_css.AtRule = class extends parse_css.Rule {
   /**
@@ -271,17 +268,15 @@ parse_css.AtRule = class extends parse_css.Rule {
     visitor.leaveAtRule(this);
   }
 };
-if (!amp.validator.LIGHT) {
-  /** @inheritDoc */
-  parse_css.AtRule.prototype.toJSON = function() {
-    const json = parse_css.Rule.prototype.toJSON.call(this);
-    json['name'] = this.name;
-    json['prelude'] = arrayToJSON(this.prelude);
-    json['rules'] = arrayToJSON(this.rules);
-    json['declarations'] = arrayToJSON(this.declarations);
-    return json;
-  };
-}
+/** @inheritDoc */
+parse_css.AtRule.prototype.toJSON = function() {
+  const json = parse_css.Rule.prototype.toJSON.call(this);
+  json['name'] = this.name;
+  json['prelude'] = arrayToJSON(this.prelude);
+  json['rules'] = arrayToJSON(this.rules);
+  json['declarations'] = arrayToJSON(this.declarations);
+  return json;
+};
 
 parse_css.QualifiedRule = class extends parse_css.Rule {
   constructor() {
@@ -303,26 +298,24 @@ parse_css.QualifiedRule = class extends parse_css.Rule {
     visitor.leaveQualifiedRule(this);
   }
 };
-if (!amp.validator.LIGHT) {
-  /** @inheritDoc */
-  parse_css.QualifiedRule.prototype.toJSON = function() {
-    const json = parse_css.Rule.prototype.toJSON.call(this);
-    json['prelude'] = arrayToJSON(this.prelude);
-    json['declarations'] = arrayToJSON(this.declarations);
-    return json;
-  };
+/** @inheritDoc */
+parse_css.QualifiedRule.prototype.toJSON = function() {
+  const json = parse_css.Rule.prototype.toJSON.call(this);
+  json['prelude'] = arrayToJSON(this.prelude);
+  json['declarations'] = arrayToJSON(this.declarations);
+  return json;
+};
 
-  /** @return {string} The concatenation of the qualified rule name. */
-  parse_css.QualifiedRule.prototype.ruleName = function() {
-    let ruleName = '';
-    for (let i = 0; i < this.prelude.length; ++i) {
-      const prelude =
-      /** @type {!parse_css.IdentToken} */ (this.prelude[i]);
-      if (prelude.value) {ruleName += prelude.value;}
-    }
-    return ruleName;
-  };
-}
+/** @return {string} The concatenation of the qualified rule name. */
+parse_css.QualifiedRule.prototype.ruleName = function() {
+  let ruleName = '';
+  for (let i = 0; i < this.prelude.length; ++i) {
+    const prelude =
+    /** @type {!parse_css.IdentToken} */ (this.prelude[i]);
+    if (prelude.value) {ruleName += prelude.value;}
+  }
+  return ruleName;
+};
 
 parse_css.Declaration = class extends parse_css.Rule {
   /**
@@ -366,16 +359,14 @@ parse_css.Declaration = class extends parse_css.Rule {
     visitor.leaveDeclaration(this);
   }
 };
-if (!amp.validator.LIGHT) {
-  /** @inheritDoc */
-  parse_css.Declaration.prototype.toJSON = function() {
-    const json = parse_css.Rule.prototype.toJSON.call(this);
-    json['name'] = this.name;
-    json['important'] = this.important;
-    json['value'] = arrayToJSON(this.value);
-    return json;
-  };
-}
+/** @inheritDoc */
+parse_css.Declaration.prototype.toJSON = function() {
+  const json = parse_css.Rule.prototype.toJSON.call(this);
+  json['name'] = this.name;
+  json['important'] = this.important;
+  json['value'] = arrayToJSON(this.value);
+  return json;
+};
 
 /**
  * A visitor for Rule subclasses (StyleSheet, AtRule, QualifiedRule,
@@ -514,9 +505,7 @@ class Canonicalizer {
     const startToken =
     /** @type {!parse_css.AtKeywordToken} */ (tokenStream.current());
     const rule = new parse_css.AtRule(startToken.value);
-    if (!amp.validator.LIGHT) {
-      startToken.copyPosTo(rule);
-    }
+    startToken.copyPosTo(rule);
 
     while (true) {
       tokenStream.consume();
@@ -573,25 +562,16 @@ class Canonicalizer {
             tokenStream.current().tokenType !== parse_css.TokenType.AT_KEYWORD,
         'Internal Error: parseAQualifiedRule precondition not met');
 
-    if (amp.validator.LIGHT && errors.length > 0) {
-      return;
-    }
-
     const rule = tokenStream.current().copyPosTo(new parse_css.QualifiedRule());
     tokenStream.reconsume();
     while (true) {
       tokenStream.consume();
       const current = tokenStream.current().tokenType;
       if (current === parse_css.TokenType.EOF_TOKEN) {
-        if (amp.validator.LIGHT) {
-          errors.push(parse_css.TRIVIAL_ERROR_TOKEN);
-        } else {
-          errors.push(rule.copyPosTo(new parse_css.ErrorToken(
-              amp.validator.ValidationError.Code
-                  .CSS_SYNTAX_EOF_IN_PRELUDE_OF_QUALIFIED_RULE,
-              ['style'])));
-
-        }
+        errors.push(rule.copyPosTo(new parse_css.ErrorToken(
+            amp.validator.ValidationError.Code
+                .CSS_SYNTAX_EOF_IN_PRELUDE_OF_QUALIFIED_RULE,
+            ['style'])));
         return;
       }
       if (current === parse_css.TokenType.OPEN_CURLY) {
@@ -617,10 +597,6 @@ class Canonicalizer {
    * @return {!Array<!parse_css.Declaration>}
    */
   parseAListOfDeclarations(tokenList, errors) {
-    if (amp.validator.LIGHT && errors.length > 0) {
-      return [];
-    }
-
     /** @type {!Array<!parse_css.Declaration>} */
     const decls = [];
     const tokenStream = new parse_css.TokenStream(tokenList);
@@ -636,10 +612,6 @@ class Canonicalizer {
         // The CSS3 Parsing spec allows for AT rules inside lists of
         // declarations, but our grammar does not so we deviate a tiny bit here.
         // We consume an AT rule, but drop it and instead push an error token.
-        if (amp.validator.LIGHT) {
-          errors.push(parse_css.TRIVIAL_ERROR_TOKEN);
-          return [];
-        }
         const atRule = this.parseAnAtRule(tokenStream, errors);
         errors.push(atRule.copyPosTo(new parse_css.ErrorToken(
             amp.validator.ValidationError.Code.CSS_SYNTAX_INVALID_AT_RULE,
@@ -647,10 +619,6 @@ class Canonicalizer {
       } else if (current === parse_css.TokenType.IDENT) {
         this.parseADeclaration(tokenStream, decls, errors);
       } else {
-        if (amp.validator.LIGHT) {
-          errors.push(parse_css.TRIVIAL_ERROR_TOKEN);
-          return [];
-        }
         errors.push(tokenStream.current().copyPosTo(new parse_css.ErrorToken(
             amp.validator.ValidationError.Code.CSS_SYNTAX_INVALID_DECLARATION,
             ['style'])));
@@ -678,10 +646,6 @@ class Canonicalizer {
         tokenStream.current().tokenType === parse_css.TokenType.IDENT,
         'Internal Error: parseADeclaration precondition not met');
 
-    if (amp.validator.LIGHT && errors.length > 0) {
-      return;
-    }
-
     const startToken =
     /** @type {!parse_css.IdentToken} */ (tokenStream.current());
     const decl =
@@ -693,10 +657,6 @@ class Canonicalizer {
 
     tokenStream.consume();
     if (!(tokenStream.current().tokenType === parse_css.TokenType.COLON)) {
-      if (amp.validator.LIGHT) {
-        errors.push(parse_css.TRIVIAL_ERROR_TOKEN);
-        return;
-      }
       errors.push(startToken.copyPosTo(new parse_css.ErrorToken(
           amp.validator.ValidationError.Code.CSS_SYNTAX_INCOMPLETE_DECLARATION,
           ['style'])));
@@ -817,9 +777,7 @@ parse_css.extractASimpleBlock = function(tokenStream) {
 
   // Exclude the start token. Convert end token to EOF.
   const end = consumedTokens.length - 1;
-  consumedTokens[end] = amp.validator.LIGHT ?
-    parse_css.TRIVIAL_EOF_TOKEN :
-    consumedTokens[end].copyPosTo(new parse_css.EOFToken());
+  consumedTokens[end] = consumedTokens[end].copyPosTo(new parse_css.EOFToken());
   return consumedTokens.slice(1);
 };
 
@@ -865,9 +823,7 @@ parse_css.extractAFunction = function(tokenStream) {
 
   // Convert end token to EOF.
   const end = consumedTokens.length - 1;
-  consumedTokens[end] = amp.validator.LIGHT ?
-    parse_css.TRIVIAL_EOF_TOKEN :
-    consumedTokens[end].copyPosTo(new parse_css.EOFToken());
+  consumedTokens[end] = consumedTokens[end].copyPosTo(new parse_css.EOFToken());
   return consumedTokens;
 };
 
@@ -897,15 +853,13 @@ parse_css.ParsedCssUrl = class extends parse_css.Token {
     this.atRuleScope = '';
   }
 };
-if (!amp.validator.LIGHT) {
-  /** @inheritDoc */
-  parse_css.ParsedCssUrl.prototype.toJSON = function() {
-    const json = parse_css.Token.prototype.toJSON.call(this);
-    json['utf8Url'] = this.utf8Url;
-    json['atRuleScope'] = this.atRuleScope;
-    return json;
-  };
-}
+/** @inheritDoc */
+parse_css.ParsedCssUrl.prototype.toJSON = function() {
+  const json = parse_css.Token.prototype.toJSON.call(this);
+  json['utf8Url'] = this.utf8Url;
+  json['atRuleScope'] = this.atRuleScope;
+  return json;
+};
 
 /**
  * Parses a CSS URL token; typically takes the form "url(http://foo)".
@@ -1019,9 +973,6 @@ class UrlFunctionVisitor extends parse_css.RuleVisitor {
     goog.asserts.assert(
         declaration.value[declaration.value.length - 1].tokenType ===
         parse_css.TokenType.EOF_TOKEN);
-    if (amp.validator.LIGHT && this.errors.length > 0) {
-      return;
-    }
     for (let ii = 0; ii < declaration.value.length - 1;) {
       const token = declaration.value[ii];
       if (token.tokenType === parse_css.TokenType.URL) {
@@ -1037,13 +988,9 @@ class UrlFunctionVisitor extends parse_css.RuleVisitor {
         const parsedUrl = new parse_css.ParsedCssUrl();
         ii = parseUrlFunction(declaration.value, ii, parsedUrl);
         if (ii === -1) {
-          if (amp.validator.LIGHT) {
-            this.errors.push(parse_css.TRIVIAL_ERROR_TOKEN);
-          } else {
-            this.errors.push(token.copyPosTo(new parse_css.ErrorToken(
-                amp.validator.ValidationError.Code.CSS_SYNTAX_BAD_URL,
-                ['style'])));
-          }
+          this.errors.push(token.copyPosTo(new parse_css.ErrorToken(
+              amp.validator.ValidationError.Code.CSS_SYNTAX_BAD_URL,
+              ['style'])));
           return;
         }
         parsedUrl.atRuleScope = this.atRuleScope;
@@ -1102,13 +1049,9 @@ class MediaQueryVisitor extends parse_css.RuleVisitor {
     const tokenStream = new parse_css.TokenStream(atRule.prelude);
     tokenStream.consume(); // Advance to first token.
     if (!this.parseAMediaQueryList_(tokenStream)) {
-      if (amp.validator.LIGHT) {
-        this.errors.push(parse_css.TRIVIAL_ERROR_TOKEN);
-      } else {
-        this.errors.push(atRule.copyPosTo(new parse_css.ErrorToken(
-            amp.validator.ValidationError.Code.CSS_SYNTAX_MALFORMED_MEDIA_QUERY,
-            ['style'])));
-      }
+      this.errors.push(atRule.copyPosTo(new parse_css.ErrorToken(
+          amp.validator.ValidationError.Code.CSS_SYNTAX_MALFORMED_MEDIA_QUERY,
+          ['style'])));
     }
   }
 

--- a/validator/engine/parse-srcset.js
+++ b/validator/engine/parse-srcset.js
@@ -16,7 +16,6 @@
  */
 goog.provide('parse_srcset.SrcsetParsingResult');
 goog.provide('parse_srcset.parseSrcset');
-goog.require('amp.validator.LIGHT');
 goog.require('amp.validator.ValidationError');
 goog.require('goog.structs.Set');
 
@@ -36,10 +35,8 @@ parse_srcset.SrcsetSourceDef;
 parse_srcset.SrcsetParsingResult = function() {
   /** @type {boolean} */
   this.success = false;
-  if (!amp.validator.LIGHT) {
-    /** @type {!amp.validator.ValidationError.Code} */
-    this.errorCode = amp.validator.ValidationError.Code.UNKNOWN_CODE;
-  }
+  /** @type {!amp.validator.ValidationError.Code} */
+  this.errorCode = amp.validator.ValidationError.Code.UNKNOWN_CODE;
   /** @type {!Array<!parse_srcset.SrcsetSourceDef>} */
   this.srcsetImages = [];
 };
@@ -106,9 +103,7 @@ parse_srcset.parseSrcset = function(srcset) {
     }
     // Duplicate width or pixel density in srcset.
     if (seenWidthOrPixelDensity.contains(widthOrPixelDensity)) {
-      if (!amp.validator.LIGHT) {
-        result.errorCode = amp.validator.ValidationError.Code.DUPLICATE_DIMENSION;
-      }
+      result.errorCode = amp.validator.ValidationError.Code.DUPLICATE_DIMENSION;
       return result;
     }
     seenWidthOrPixelDensity.add(widthOrPixelDensity);
@@ -120,24 +115,18 @@ parse_srcset.parseSrcset = function(srcset) {
     }
     // More srcset, comma expected as separator for image candidates.
     if (comma === undefined) {
-      if (!amp.validator.LIGHT) {
-        result.errorCode = amp.validator.ValidationError.Code.INVALID_ATTR_VALUE;
-      }
+      result.errorCode = amp.validator.ValidationError.Code.INVALID_ATTR_VALUE;
       return result;
     }
   }
   // Regex didn't consume all of the srcset string
   if (remainingSrcset !== '') {
-    if (!amp.validator.LIGHT) {
-      result.errorCode = amp.validator.ValidationError.Code.INVALID_ATTR_VALUE;
-    }
+    result.errorCode = amp.validator.ValidationError.Code.INVALID_ATTR_VALUE;
     return result;
   }
   // Must have at least one image candidate.
   if (srcsetImages.length === 0) {
-    if (!amp.validator.LIGHT) {
-      result.errorCode = amp.validator.ValidationError.Code.INVALID_ATTR_VALUE;
-    }
+    result.errorCode = amp.validator.ValidationError.Code.INVALID_ATTR_VALUE;
     return result;
   }
   result.success = true;

--- a/validator/engine/tokenize-css.js
+++ b/validator/engine/tokenize-css.js
@@ -58,7 +58,6 @@ goog.provide('parse_css.TokenType');
 goog.provide('parse_css.URLToken');
 goog.provide('parse_css.WhitespaceToken');
 goog.provide('parse_css.tokenize');
-goog.require('amp.validator.LIGHT');
 goog.require('amp.validator.ValidationError');
 goog.require('goog.asserts');
 
@@ -296,39 +295,30 @@ class Tokenizer {
 
     // Line number information.
     let eofToken;
-    if (amp.validator.LIGHT) {
-      eofToken = parse_css.TRIVIAL_EOF_TOKEN;
-    } else {
-      /** @private @type {!Array<number>} */
-      this.lineByPos_ = [];
-      /** @private @type {!Array<number>} */
-      this.colByPos_ = [];
-      let currentLine = line || 1;
-      let currentCol = col || 0;
-      for (let i = 0; i < this.codepoints_.length; ++i) {
-        this.lineByPos_[i] = currentLine;
-        this.colByPos_[i] = currentCol;
-        if (newline(this.codepoints_[i])) {
-          ++currentLine;
-          currentCol = 0;
-        } else {
-          ++currentCol;
-        }
+    /** @private @type {!Array<number>} */
+    this.lineByPos_ = [];
+    /** @private @type {!Array<number>} */
+    this.colByPos_ = [];
+    let currentLine = line || 1;
+    let currentCol = col || 0;
+    for (let i = 0; i < this.codepoints_.length; ++i) {
+      this.lineByPos_[i] = currentLine;
+      this.colByPos_[i] = currentCol;
+      if (newline(this.codepoints_[i])) {
+        ++currentLine;
+        currentCol = 0;
+      } else {
+        ++currentCol;
       }
-      eofToken = new parse_css.EOFToken();
-      eofToken.line = currentLine;
-      eofToken.col = currentCol;
     }
+    eofToken = new parse_css.EOFToken();
+    eofToken.line = currentLine;
+    eofToken.col = currentCol;
 
     let iterationCount = 0;
     while (!this.eof(this.next())) {
       const token = this.consumeAToken();
       if (token.tokenType === parse_css.TokenType.ERROR) {
-        if (amp.validator.LIGHT) {
-          this.errors_.push(parse_css.TRIVIAL_ERROR_TOKEN);
-          this.tokens_ = [];
-          return;
-        }
         this.errors_.push(/** @type {!parse_css.ErrorToken} */ (token));
       } else {
         this.tokens_.push(token);
@@ -423,17 +413,10 @@ class Tokenizer {
     this.consumeComments();
     this.consume();
     const mark = new parse_css.Token();
-    if (!amp.validator.LIGHT) {
-      mark.line = this.getLine();
-      mark.col = this.getCol();
-    }
     if (whitespace(this.code_)) {
       // Merge consecutive whitespace into one token.
       while (whitespace(this.next())) {
         this.consume();
-      }
-      if (amp.validator.LIGHT) {
-        return TRIVIAL_WHITESPACE_TOKEN;
       }
       return mark.copyPosTo(new parse_css.WhitespaceToken());
     } else if (this.code_ === /* '"' */ 0x22) {
@@ -453,47 +436,26 @@ class Tokenizer {
         }
         return mark.copyPosTo(token);
       } else {
-        if (amp.validator.LIGHT) {
-          return TRIVIAL_DELIM_TOKEN_23;
-        }
         return mark.copyPosTo(new parse_css.DelimToken(this.code_));
       }
     } else if (this.code_ === /* '$' */ 0x24) {
       if (this.next() === /* '=' */ 0x3d) {
         this.consume();
-        if (amp.validator.LIGHT) {
-          return TRIVIAL_SUFFIX_MATCH_TOKEN;
-        }
         return mark.copyPosTo(new parse_css.SuffixMatchToken());
       } else {
-        if (amp.validator.LIGHT) {
-          return TRIVIAL_DELIM_TOKEN_24;
-        }
         return mark.copyPosTo(new parse_css.DelimToken(this.code_));
       }
     } else if (this.code_ === /* ''' */ 0x27) {
       return mark.copyPosTo(this.consumeAStringToken());
     } else if (this.code_ === /* '(' */ 0x28) {
-      if (amp.validator.LIGHT) {
-        return TRIVIAL_OPEN_PAREN_TOKEN;
-      }
       return mark.copyPosTo(new parse_css.OpenParenToken());
     } else if (this.code_ === /* ')' */ 0x29) {
-      if (amp.validator.LIGHT) {
-        return TRIVIAL_CLOSE_PAREN_TOKEN;
-      }
       return mark.copyPosTo(new parse_css.CloseParenToken());
     } else if (this.code_ === /* '*' */ 0x2a) {
       if (this.next() === /* '=' */ 0x3d) {
         this.consume();
-        if (amp.validator.LIGHT) {
-          return TRIVIAL_SUBSTRING_MATCH_TOKEN;
-        }
         return mark.copyPosTo(new parse_css.SubstringMatchToken());
       } else {
-        if (amp.validator.LIGHT) {
-          return TRIVIAL_DELIM_TOKEN_2A;
-        }
         return mark.copyPosTo(new parse_css.DelimToken(this.code_));
       }
     } else if (this.code_ === /* '+' */ 0x2b) {
@@ -501,15 +463,9 @@ class Tokenizer {
         this.reconsume();
         return mark.copyPosTo(this.consumeANumericToken());
       } else {
-        if (amp.validator.LIGHT) {
-          return TRIVIAL_DELIM_TOKEN_2B;
-        }
         return mark.copyPosTo(new parse_css.DelimToken(this.code_));
       }
     } else if (this.code_ === /* ',' */ 0x2c) {
-      if (amp.validator.LIGHT) {
-        return TRIVIAL_COMMA_TOKEN;
-      }
       return mark.copyPosTo(new parse_css.CommaToken());
     } else if (this.code_ === /* '-' */ 0x2d) {
       if (this./*OK*/ startsWithANumber()) {
@@ -518,17 +474,11 @@ class Tokenizer {
       } else if (
         this.next(1) === /* '-' */ 0x2d && this.next(2) === /* '>' */ 0x3e) {
         this.consume(2);
-        if (amp.validator.LIGHT) {
-          return TRIVIAL_CDC_TOKEN;
-        }
         return mark.copyPosTo(new parse_css.CDCToken());
       } else if (this./*OK*/ startsWithAnIdentifier()) {
         this.reconsume();
         return mark.copyPosTo(this.consumeAnIdentlikeToken());
       } else {
-        if (amp.validator.LIGHT) {
-          return TRIVIAL_DELIM_TOKEN_2D;
-        }
         return mark.copyPosTo(new parse_css.DelimToken(this.code_));
       }
     } else if (this.code_ === /* '.' */ 0x2e) {
@@ -536,33 +486,18 @@ class Tokenizer {
         this.reconsume();
         return mark.copyPosTo(this.consumeANumericToken());
       } else {
-        if (amp.validator.LIGHT) {
-          return TRIVIAL_DELIM_TOKEN_2E;
-        }
         return mark.copyPosTo(new parse_css.DelimToken(this.code_));
       }
     } else if (this.code_ === /* ':' */ 0x3a) {
-      if (amp.validator.LIGHT) {
-        return TRIVIAL_COLON_TOKEN;
-      }
       return mark.copyPosTo(new parse_css.ColonToken());
     } else if (this.code_ === /* ';' */ 0x3b) {
-      if (amp.validator.LIGHT) {
-        return TRIVIAL_SEMICOLON_TOKEN;
-      }
       return mark.copyPosTo(new parse_css.SemicolonToken());
     } else if (this.code_ === /* '<' */ 0x3c) {
       if (this.next(1) === /* '!' */ 0x21 && this.next(2) === /* '-' */ 0x2d &&
           this.next(3) === /* '-' */ 0x2d) {
         this.consume(3);
-        if (amp.validator.LIGHT) {
-          return TRIVIAL_CDO_TOKEN;
-        }
         return mark.copyPosTo(new parse_css.CDOToken());
       } else {
-        if (amp.validator.LIGHT) {
-          return TRIVIAL_DELIM_TOKEN_3C;
-        }
         return mark.copyPosTo(new parse_css.DelimToken(this.code_));
       }
     } else if (this.code_ === /* '@' */ 0x40) {
@@ -572,24 +507,15 @@ class Tokenizer {
         token.value = this.consumeAName();
         return mark.copyPosTo(token);
       } else {
-        if (amp.validator.LIGHT) {
-          return TRIVIAL_DELIM_TOKEN_40;
-        }
         return mark.copyPosTo(new parse_css.DelimToken(this.code_));
       }
     } else if (this.code_ === /* '[' */ 0x5b) {
-      if (amp.validator.LIGHT) {
-        return TRIVIAL_OPEN_SQUARE_TOKEN;
-      }
       return mark.copyPosTo(new parse_css.OpenSquareToken());
     } else if (this.code_ === /* '\' */ 0x5c) {
       if (this./*OK*/ startsWithAValidEscape()) {
         this.reconsume();
         return mark.copyPosTo(this.consumeAnIdentlikeToken());
       } else {
-        if (amp.validator.LIGHT) {
-          return parse_css.TRIVIAL_ERROR_TOKEN;
-        }
         // This condition happens if we are in consumeAToken (this method),
         // the current codepoint is 0x5c (\) and the next codepoint is a
         // newline (\n).
@@ -599,63 +525,33 @@ class Tokenizer {
             ['style']));
       }
     } else if (this.code_ === /* ']' */ 0x5d) {
-      if (amp.validator.LIGHT) {
-        return TRIVIAL_CLOSE_SQUARE_TOKEN;
-      }
       return mark.copyPosTo(new parse_css.CloseSquareToken());
     } else if (this.code_ === /* '^' */ 0x5e) {
       if (this.next() === /* '=' */ 0x3d) {
         this.consume();
-        if (amp.validator.LIGHT) {
-          return TRIVIAL_PREFIX_MATCH_TOKEN;
-        }
         return mark.copyPosTo(new parse_css.PrefixMatchToken());
       } else {
-        if (amp.validator.LIGHT) {
-          return TRIVIAL_DELIM_TOKEN_5E;
-        }
         return mark.copyPosTo(new parse_css.DelimToken(this.code_));
       }
     } else if (this.code_ === /* '{' */ 0x7b) {
-      if (amp.validator.LIGHT) {
-        return TRIVIAL_OPEN_CURLY_TOKEN;
-      }
       return mark.copyPosTo(new parse_css.OpenCurlyToken());
     } else if (this.code_ === /* '|' */ 0x7c) {
       if (this.next() === /* '=' */ 0x3d) {
         this.consume();
-        if (amp.validator.LIGHT) {
-          return TRIVIAL_DASH_MATCH_TOKEN;
-        }
         return mark.copyPosTo(new parse_css.DashMatchToken());
       } else if (this.next() === /* '|' */ 0x7c) {
         this.consume();
-        if (amp.validator.LIGHT) {
-          return TRIVIAL_COLUMN_TOKEN;
-        }
         return mark.copyPosTo(new parse_css.ColumnToken());
       } else {
-        if (amp.validator.LIGHT) {
-          return TRIVIAL_DELIM_TOKEN_7C;
-        }
         return mark.copyPosTo(new parse_css.DelimToken(this.code_));
       }
     } else if (this.code_ === /* '}' */ 0x7d) {
-      if (amp.validator.LIGHT) {
-        return TRIVIAL_CLOSE_CURLY_TOKEN;
-      }
       return mark.copyPosTo(new parse_css.CloseCurlyToken());
     } else if (this.code_ === /* '~' */ 0x7e) {
       if (this.next() === /* '=' */ 0x3d) {
         this.consume();
-        if (amp.validator.LIGHT) {
-          return TRIVIAL_CLOSE_CURLY_TOKEN;
-        }
         return mark.copyPosTo(new parse_css.IncludeMatchToken());
       } else {
-        if (amp.validator.LIGHT) {
-          return TRIVIAL_DELIM_TOKEN_7E;
-        }
         return mark.copyPosTo(new parse_css.DelimToken(this.code_));
       }
     } else if (digit(this.code_)) {
@@ -665,9 +561,6 @@ class Tokenizer {
       this.reconsume();
       return mark.copyPosTo(this.consumeAnIdentlikeToken());
     } else if (this.eof()) {
-      if (amp.validator.LIGHT) {
-        return parse_css.TRIVIAL_EOF_TOKEN;
-      }
       return mark.copyPosTo(new parse_css.EOFToken());
     } else {
       const token = new parse_css.DelimToken(this.code_);
@@ -681,10 +574,8 @@ class Tokenizer {
    */
   consumeComments() {
     const mark = new parse_css.Token();
-    if (!amp.validator.LIGHT) {
-      mark.line = this.getLine();
-      mark.col = this.getCol();
-    }
+    mark.line = this.getLine();
+    mark.col = this.getCol();
     while (this.next(1) === /* '/' */ 0x2f && this.next(2) === /* '*' */ 0x2a) {
       this.consume(2);
       while (true) {
@@ -693,16 +584,12 @@ class Tokenizer {
           this.consume();
           break;
         } else if (this.eof()) {
-          if (amp.validator.LIGHT) {
-            this.errors_.push(parse_css.TRIVIAL_ERROR_TOKEN);
-          } else {
-            // For example "h1 { color: red; } \* " would emit this parse error
-            // at the end of the string.
-            this.errors_.push(mark.copyPosTo(new parse_css.ErrorToken(
-                amp.validator.ValidationError.Code
-                    .CSS_SYNTAX_UNTERMINATED_COMMENT,
-                ['style'])));
-          }
+          // For example "h1 { color: red; } \* " would emit this parse error
+          // at the end of the string.
+          this.errors_.push(mark.copyPosTo(new parse_css.ErrorToken(
+              amp.validator.ValidationError.Code
+                  .CSS_SYNTAX_UNTERMINATED_COMMENT,
+              ['style'])));
           return;
         }
       }
@@ -796,9 +683,6 @@ class Tokenizer {
         return token;
       } else if (newline(this.code_)) {
         this.reconsume();
-        if (amp.validator.LIGHT) {
-          return parse_css.TRIVIAL_ERROR_TOKEN;
-        }
         return new parse_css.ErrorToken(
             amp.validator.ValidationError.Code.CSS_SYNTAX_UNTERMINATED_STRING,
             ['style']);
@@ -843,9 +727,6 @@ class Tokenizer {
           return token;
         } else {
           this.consumeTheRemnantsOfABadURL();
-          if (amp.validator.LIGHT) {
-            return parse_css.TRIVIAL_ERROR_TOKEN;
-          }
           return new parse_css.ErrorToken(
               amp.validator.ValidationError.Code.CSS_SYNTAX_BAD_URL, ['style']);
         }
@@ -853,9 +734,6 @@ class Tokenizer {
         this.code_ === /* '"' */ 0x22 || this.code_ === /* ''' */ 0x27 ||
           this.code_ === /* '(' */ 0x28 || nonPrintable(this.code_)) {
         this.consumeTheRemnantsOfABadURL();
-        if (amp.validator.LIGHT) {
-          return parse_css.TRIVIAL_ERROR_TOKEN;
-        }
         return new parse_css.ErrorToken(
             amp.validator.ValidationError.Code.CSS_SYNTAX_BAD_URL, ['style']);
       } else if (this.code_ === /* '\' */ 0x5c) {
@@ -863,9 +741,6 @@ class Tokenizer {
           token.value += stringFromCode(this.consumeEscape());
         } else {
           this.consumeTheRemnantsOfABadURL();
-          if (amp.validator.LIGHT) {
-            return parse_css.TRIVIAL_ERROR_TOKEN;
-          }
           return new parse_css.ErrorToken(
               amp.validator.ValidationError.Code.CSS_SYNTAX_BAD_URL, ['style']);
         }
@@ -1225,12 +1100,10 @@ const TokenType_NamesById = [
  */
 parse_css.Token = class {
   constructor() {
-    if (!amp.validator.LIGHT) {
-      /** @type {number} */
-      this.line = 1;
-      /** @type {number} */
-      this.col = 0;
-    }
+    /** @type {number} */
+    this.line = 1;
+    /** @type {number} */
+    this.col = 0;
   }
 
   /**
@@ -1240,26 +1113,22 @@ parse_css.Token = class {
    * @template T
    */
   copyPosTo(other) {
-    if (!amp.validator.LIGHT) {
-      other.line = this.line;
-      other.col = this.col;
-    }
+    other.line = this.line;
+    other.col = this.col;
     return other;
   }
 };
 /** @type {!parse_css.TokenType} */
 parse_css.Token.prototype.tokenType = parse_css.TokenType.UNKNOWN;
 
-if (!amp.validator.LIGHT) {
-  /** @return {!Object} */
-  parse_css.Token.prototype.toJSON = function() {
-    return {
-      'tokenType': TokenType_NamesById[this.tokenType],
-      'line': this.line,
-      'col': this.col,
-    };
+/** @return {!Object} */
+parse_css.Token.prototype.toJSON = function() {
+  return {
+    'tokenType': TokenType_NamesById[this.tokenType],
+    'line': this.line,
+    'col': this.col,
   };
-}
+};
 
 /**
  * Error tokens carry an error code and parameters, which can be
@@ -1273,35 +1142,24 @@ parse_css.ErrorToken = class extends parse_css.Token {
    */
   constructor(opt_code, opt_params) {
     super();
-    if (!amp.validator.LIGHT) {
-      goog.asserts.assert(opt_code !== undefined);
-      goog.asserts.assert(opt_params !== undefined);
-      /** @type {!amp.validator.ValidationError.Code} */
-      this.code = opt_code;
-      /** @type {!Array<string>} */
-      this.params = opt_params;
-    }
+    goog.asserts.assert(opt_code !== undefined);
+    goog.asserts.assert(opt_params !== undefined);
+    /** @type {!amp.validator.ValidationError.Code} */
+    this.code = opt_code;
+    /** @type {!Array<string>} */
+    this.params = opt_params;
   }
 };
 /** @type {!parse_css.TokenType} */
 parse_css.ErrorToken.prototype.tokenType = parse_css.TokenType.ERROR;
 
-if (!amp.validator.LIGHT) {
-  /** @inheritDoc */
-  parse_css.ErrorToken.prototype.toJSON = function() {
-    const json = parse_css.Token.prototype.toJSON.call(this);
-    json['code'] = this.code;
-    json['params'] = this.params;
-    return json;
-  };
-}
-
-if (amp.validator.LIGHT) {
-  /**
-   * @type {!parse_css.ErrorToken}
-   */
-  parse_css.TRIVIAL_ERROR_TOKEN = new parse_css.ErrorToken();
-}
+/** @inheritDoc */
+parse_css.ErrorToken.prototype.toJSON = function() {
+  const json = parse_css.Token.prototype.toJSON.call(this);
+  json['code'] = this.code;
+  json['params'] = this.params;
+  return json;
+};
 
 parse_css.WhitespaceToken = class extends parse_css.Token {};
 /** @type {!parse_css.TokenType} */
@@ -1460,14 +1318,12 @@ const TRIVIAL_DELIM_TOKEN_5E = new parse_css.DelimToken(0x5E);
 const TRIVIAL_DELIM_TOKEN_7C = new parse_css.DelimToken(0x7C);
 const TRIVIAL_DELIM_TOKEN_7E = new parse_css.DelimToken(0x7E);
 
-if (!amp.validator.LIGHT) {
-  /** @inheritDoc */
-  parse_css.DelimToken.prototype.toJSON = function() {
-    const json = parse_css.Token.prototype.toJSON.call(this);
-    json['value'] = this.value;
-    return json;
-  };
-}
+/** @inheritDoc */
+parse_css.DelimToken.prototype.toJSON = function() {
+  const json = parse_css.Token.prototype.toJSON.call(this);
+  json['value'] = this.value;
+  return json;
+};
 
 parse_css.StringValuedToken = class extends parse_css.Token {
   constructor() {
@@ -1484,14 +1340,12 @@ parse_css.StringValuedToken = class extends parse_css.Token {
     return this.value.toLowerCase() === str.toLowerCase();
   }
 };
-if (!amp.validator.LIGHT) {
-  /** @inheritDoc */
-  parse_css.StringValuedToken.prototype.toJSON = function() {
-    const json = parse_css.Token.prototype.toJSON.call(this);
-    json['value'] = this.value;
-    return json;
-  };
-}
+/** @inheritDoc */
+parse_css.StringValuedToken.prototype.toJSON = function() {
+  const json = parse_css.Token.prototype.toJSON.call(this);
+  json['value'] = this.value;
+  return json;
+};
 
 parse_css.IdentToken = class extends parse_css.StringValuedToken {};
 /** @type {!parse_css.TokenType} */
@@ -1518,14 +1372,12 @@ parse_css.HashToken = class extends parse_css.StringValuedToken {
 /** @type {!parse_css.TokenType} */
 parse_css.HashToken.prototype.tokenType = parse_css.TokenType.HASH;
 
-if (!amp.validator.LIGHT) {
-  /** @inheritDoc */
-  parse_css.HashToken.prototype.toJSON = function() {
-    const json = parse_css.StringValuedToken.prototype.toJSON.call(this);
-    json['type'] = this.type;
-    return json;
-  };
-}
+/** @inheritDoc */
+parse_css.HashToken.prototype.toJSON = function() {
+  const json = parse_css.StringValuedToken.prototype.toJSON.call(this);
+  json['type'] = this.type;
+  return json;
+};
 
 parse_css.StringToken = class extends parse_css.StringValuedToken {};
 /** @type {!parse_css.TokenType} */
@@ -1549,16 +1401,14 @@ parse_css.NumberToken = class extends parse_css.Token {
 /** @type {!parse_css.TokenType} */
 parse_css.NumberToken.prototype.tokenType = parse_css.TokenType.NUMBER;
 
-if (!amp.validator.LIGHT) {
-  /** @inheritDoc */
-  parse_css.NumberToken.prototype.toJSON = function() {
-    const json = parse_css.Token.prototype.toJSON.call(this);
-    json['value'] = this.value;
-    json['type'] = this.type;
-    json['repr'] = this.repr;
-    return json;
-  };
-}
+/** @inheritDoc */
+parse_css.NumberToken.prototype.toJSON = function() {
+  const json = parse_css.Token.prototype.toJSON.call(this);
+  json['value'] = this.value;
+  json['type'] = this.type;
+  json['repr'] = this.repr;
+  return json;
+};
 
 parse_css.PercentageToken = class extends parse_css.Token {
   constructor() {
@@ -1572,15 +1422,13 @@ parse_css.PercentageToken = class extends parse_css.Token {
 /** @type {!parse_css.TokenType} */
 parse_css.PercentageToken.prototype.tokenType = parse_css.TokenType.PERCENTAGE;
 
-if (!amp.validator.LIGHT) {
-  /** @inheritDoc */
-  parse_css.PercentageToken.prototype.toJSON = function() {
-    const json = parse_css.Token.prototype.toJSON.call(this);
-    json['value'] = this.value;
-    json['repr'] = this.repr;
-    return json;
-  };
-}
+/** @inheritDoc */
+parse_css.PercentageToken.prototype.toJSON = function() {
+  const json = parse_css.Token.prototype.toJSON.call(this);
+  json['value'] = this.value;
+  json['repr'] = this.repr;
+  return json;
+};
 
 parse_css.DimensionToken = class extends parse_css.Token {
   constructor() {
@@ -1598,14 +1446,12 @@ parse_css.DimensionToken = class extends parse_css.Token {
 /** @type {!parse_css.TokenType} */
 parse_css.DimensionToken.prototype.tokenType = parse_css.TokenType.DIMENSION;
 
-if (!amp.validator.LIGHT) {
-  /** @inheritDoc */
-  parse_css.DimensionToken.prototype.toJSON = function() {
-    const json = parse_css.Token.prototype.toJSON.call(this);
-    json['value'] = this.value;
-    json['type'] = this.type;
-    json['repr'] = this.repr;
-    json['unit'] = this.unit;
-    return json;
-  };
-}
+/** @inheritDoc */
+parse_css.DimensionToken.prototype.toJSON = function() {
+  const json = parse_css.Token.prototype.toJSON.call(this);
+  json['value'] = this.value;
+  json['type'] = this.type;
+  json['repr'] = this.repr;
+  json['unit'] = this.unit;
+  return json;
+};


### PR DESCRIPTION
Previously these were only removed from the main validator.js file, not these supporting libraries.