### PR TITLE
✨ Collapse ad unit (amp-brid-player) on ad end

### DIFF
--- a/extensions/amp-brid-player/0.1/amp-brid-player.js
+++ b/extensions/amp-brid-player/0.1/amp-brid-player.js
@@ -37,6 +37,7 @@ import {
   installVideoManagerForDoc,
 } from '../../../src/service/video-manager-impl';
 import {isLayoutSizeDefined} from '../../../src/layout';
+import {setStyles} from '../../../src/style';
 
 /**
  * @implements {../../../src/video-interface.VideoInterface}
@@ -114,7 +115,7 @@ class AmpBridPlayer extends AMP.BaseElement {
         encodeURIComponent(feedType) +
         '/' + encodeURIComponent(this.feedID_) +
         '/' + encodeURIComponent(this.partnerID_) +
-        '/' + encodeURIComponent(this.playerID_) + '/0/1';
+        '/' + encodeURIComponent(this.playerID_) + '/0/1/?amp=1';
 
     this.videoIframeSrc_ = assertAbsoluteHttpOrHttpsUrl(src);
 
@@ -161,8 +162,6 @@ class AmpBridPlayer extends AMP.BaseElement {
         'message',
         this.handleBridMessage_.bind(this)
     );
-
-    this.element.appendChild(iframe);
 
     return this.loadPromise(iframe)
         .then(() => this.playerReadyPromise_);
@@ -260,6 +259,15 @@ class AmpBridPlayer extends AMP.BaseElement {
     if (params[2] == 'trigger') {
       if (params[3] == 'ready') {
         this.playerReadyResolver_(this.iframe_);
+      } else if (params[3] == 'play') {
+    	if (this.element.hasAttribute('data-outstream')) {
+          setStyles(this.element, {transition: 'height 2s',
+        	  height: '100%'});
+        }
+      } else if (params[3] == 'adEnd') {
+        if (this.element.hasAttribute('data-outstream')) {
+          setStyles(this.element, {height: '0px'});
+        }
       }
       redispatch(element, params[3], {
         'ready': VideoEvents.LOAD,

--- a/extensions/amp-brid-player/0.1/amp-brid-player.js
+++ b/extensions/amp-brid-player/0.1/amp-brid-player.js
@@ -37,7 +37,6 @@ import {
   installVideoManagerForDoc,
 } from '../../../src/service/video-manager-impl';
 import {isLayoutSizeDefined} from '../../../src/layout';
-import {setStyles} from '../../../src/style';
 
 /**
  * @implements {../../../src/video-interface.VideoInterface}
@@ -259,15 +258,6 @@ class AmpBridPlayer extends AMP.BaseElement {
     if (params[2] == 'trigger') {
       if (params[3] == 'ready') {
         this.playerReadyResolver_(this.iframe_);
-      } else if (params[3] == 'play') {
-    	if (this.element.hasAttribute('data-outstream')) {
-          setStyles(this.element, {transition: 'height 2s',
-        	  height: '100%'});
-        }
-      } else if (params[3] == 'adEnd') {
-        if (this.element.hasAttribute('data-outstream')) {
-          setStyles(this.element, {height: '0px'});
-        }
       }
       redispatch(element, params[3], {
         'ready': VideoEvents.LOAD,

--- a/extensions/amp-brid-player/0.1/test/test-amp-brid-player.js
+++ b/extensions/amp-brid-player/0.1/test/test-amp-brid-player.js
@@ -70,7 +70,7 @@ describes.realWin('amp-brid-player', {
       expect(iframe).to.not.be.null;
       expect(iframe.tagName).to.equal('IFRAME');
       expect(iframe.src).to.equal(
-          'https://services.brid.tv/services/iframe/video/13663/264/4144/0/1');
+          'https://services.brid.tv/services/iframe/video/13663/264/4144/0/1/?amp=1');
     });
   });
 


### PR DESCRIPTION
- Adding collapse behavior to ad unit to improve user experience.
- Unit should collapse when ad is finished or when there is no ad.