### PR TITLE
🐛 amp-next-page: Restore functionality to drop amp-analytics configs from child pages

### DIFF
--- a/extensions/amp-next-page/0.1/next-page-service.js
+++ b/extensions/amp-next-page/0.1/next-page-service.js
@@ -28,6 +28,7 @@ import {installStylesForDoc} from '../../../src/style-installer';
 import {layoutRectLtwh} from '../../../src/layout-rect';
 import {setStyle, toggle} from '../../../src/style';
 import {triggerAnalyticsEvent} from '../../../src/analytics';
+import {removeElement} from '../../../src/dom';
 
 // TODO(emarchiori): Make this a configurable parameter.
 const SEPARATOR_RECOS = 3;
@@ -179,6 +180,14 @@ export class NextPageService {
       for (let i = 0; i < elements.length; i++) {
         elements[i].classList.add('i-amphtml-next-page-hidden');
       }
+    }
+
+    // Drop any amp-analytics tags from the child doc. We want to reuse the
+    // parent config instead.
+    const analytics = doc.querySelectorAll('amp-analytics');
+    for (let i = 0; i < analytics.length; i++) {
+      const item = analytics[i];
+      removeElement(item);
     }
 
     const amp =

--- a/extensions/amp-next-page/0.1/next-page-service.js
+++ b/extensions/amp-next-page/0.1/next-page-service.js
@@ -26,9 +26,9 @@ import {
 } from '../../../src/service/position-observer/position-observer-impl';
 import {installStylesForDoc} from '../../../src/style-installer';
 import {layoutRectLtwh} from '../../../src/layout-rect';
+import {removeElement} from '../../../src/dom';
 import {setStyle, toggle} from '../../../src/style';
 import {triggerAnalyticsEvent} from '../../../src/analytics';
-import {removeElement} from '../../../src/dom';
 
 // TODO(emarchiori): Make this a configurable parameter.
 const SEPARATOR_RECOS = 3;

--- a/extensions/amp-next-page/0.1/test/test-amp-next-page.js
+++ b/extensions/amp-next-page/0.1/test/test-amp-next-page.js
@@ -178,6 +178,34 @@ env => {
       expect(shadowRoot.querySelector('footer'))
           .to.have.class('i-amphtml-next-page-hidden');
     });
+
+    it('removes amp-analytics tags from child documents', function* () {
+      const exampleDoc = createExampleDocument(doc);
+      exampleDoc.body.innerHTML +=
+          '<amp-analytics id="analytics1"></amp-analytics>';
+      exampleDoc.body.innerHTML +=
+          '<amp-analytics id="analytics2"></amp-analytics>';
+      fetchDocumentMock.expects('fetchDocument')
+          .returns(Promise.resolve(exampleDoc))
+          .once();
+      const nextPageService =
+          yield getServicePromiseForDoc(ampdoc, 'next-page');
+      const attachShadowDocSpy =
+          sandbox.spy(nextPageService.multidocManager_, 'attachShadowDoc');
+      sandbox.stub(viewport, 'getClientRectAsync')
+          .onFirstCall().callsFake(() => {
+            // 1x viewport away
+            return Promise.resolve(
+                layoutRectLtwh(0, 0, sizes.width, sizes.height * 2));
+          });
+      win.dispatchEvent(new Event('scroll'));
+      yield macroTask();
+      const shadowDoc = attachShadowDocSpy.firstCall.returnValue.ampdoc;
+      yield shadowDoc.whenReady();
+      const shadowRoot = shadowDoc.getRootNode();
+      expect(shadowRoot.getElementById('analytics1')).to.be.null;
+      expect(shadowRoot.getElementById('analytics2')).to.be.null;
+    });
   });
 
   describe('remote config', () => {


### PR DESCRIPTION
Was removed in https://github.com/ampproject/amphtml/pull/17645, but analytics functionality within child pages isn't fully functional right now.

Child pages could result in e.g. scroll triggers being fired from both the parent and child pages at once.  We should keep this disabled for now and re-enable it when we have things implemented properly.

@aghassemi 