### PR TITLE
Amp-ad Fast Fetch xdomain iframe sandboxing

### DIFF
--- a/ads/google/a4a/utils.js
+++ b/ads/google/a4a/utils.js
@@ -67,6 +67,9 @@ const visibilityStateCodes = {
 /** @const {string} */
 export const QQID_HEADER = 'X-QQID';
 
+/** @type {string} */
+export const SANDBOX_HEADER = 'amp-ff-sandbox';
+
 /**
  * Element attribute that stores experiment IDs.
  *

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -23,6 +23,11 @@ import {LayoutPriority} from '../../../src/layout';
 import {Services} from '../../../src/services';
 import {SignatureVerifier, VerificationStatus} from './signature-verifier';
 import {
+  applySandbox,
+  generateSentinel,
+  getDefaultBootstrapBaseUrl,
+} from '../../../src/3p-frame';
+import {
   assertHttpsUrl,
   tryDecodeUriComponent,
 } from '../../../src/url';
@@ -30,10 +35,6 @@ import {cancellation, isCancellation} from '../../../src/error';
 import {createElementWithAttributes} from '../../../src/dom';
 import {dev, duplicateErrorIfNecessary, user} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
-import {
-  generateSentinel,
-  getDefaultBootstrapBaseUrl,
-} from '../../../src/3p-frame';
 import {
   getAmpAdRenderOutsideViewport,
   incrementLoadingAds,
@@ -85,9 +86,6 @@ export const SAFEFRAME_VERSION_HEADER = 'X-AmpSafeFrameVersion';
 
 /** @type {string} @visibleForTesting */
 export const EXPERIMENT_FEATURE_HEADER_NAME = 'amp-ff-exps';
-
-/** @type {string} @visibileForTesting */
-export const SANDBOX_HEADER = 'amp-ff-sandbox';
 
 /** @type {string} */
 const TAG = 'amp-a4a';
@@ -165,15 +163,6 @@ const LIFECYCLE_STAGE_TO_ANALYTICS_TRIGGER = {
   'friendlyIframeIniLoad': AnalyticsTrigger.AD_IFRAME_LOADED,
   'crossDomainIframeLoaded': AnalyticsTrigger.AD_IFRAME_LOADED,
 };
-
-/**
- * The sandboxing flags to use when applying the "sandbox" attribute to ad
- * iframes. See http://go/mdn/HTML/Element/iframe#attr-sandbox.
- * @const {string} @visibleForTesting
- */
-export const IFRAME_SANDBOXING_FLAGS = 'allow-forms allow-pointer-lock ' +
-    'allow-popups allow-popups-to-escape-sandbox allow-same-origin ' +
-    'allow-scripts allow-top-navigation-by-user-activation';
 
 /**
  * Utility function that ensures any error thrown is handled by optional
@@ -274,13 +263,6 @@ export class AmpA4A extends AMP.BaseElement {
      */
     this.experimentalNonAmpCreativeRenderMethod_ =
         this.getNonAmpCreativeRenderingMethod();
-
-    /**
-     * Whether or not the iframe containing the ad should be sandboxed via the
-     * "sandbox" attribute.
-     * @private {boolean}
-     */
-    this.shouldSandbox_ = false;
 
     /**
      * Gets a notion of current time, in ms.  The value is not necessarily
@@ -717,10 +699,6 @@ export class AmpA4A extends AMP.BaseElement {
             this.preconnect.preload(
                 getDefaultBootstrapBaseUrl(this.win, 'nameframe'));
           }
-          const browserSupportsSandbox = this.win.HTMLIFrameElement &&
-              'sandbox' in this.win.HTMLIFrameElement.prototype;
-          this.shouldSandbox_ = browserSupportsSandbox &&
-              fetchResponse.headers.get(SANDBOX_HEADER) == 'true';
           const safeframeVersionHeader =
             fetchResponse.headers.get(SAFEFRAME_VERSION_HEADER);
           if (/^[0-9-]+$/.test(safeframeVersionHeader) &&
@@ -1246,6 +1224,11 @@ export class AmpA4A extends AMP.BaseElement {
         `onCrossDomainIframeCreated ${iframe}`);
   }
 
+  /** @return {boolean} whether html creatives should be sandboxed. */
+  sandboxHTMLCreativeFrame() {
+    return isExperimentOn(this.win, 'sandbox-ads');
+  }
+
   /**
    * Send ad request, extract the creative and signature from the response.
    * @param {string} adUrl Request URL to send XHR to.
@@ -1441,9 +1424,6 @@ export class AmpA4A extends AMP.BaseElement {
     if (this.sentinel) {
       mergedAttributes['data-amp-3p-sentinel'] = this.sentinel;
     }
-    if (this.shouldSandbox_) {
-      mergedAttributes['sandbox'] = IFRAME_SANDBOXING_FLAGS;
-    }
     if (isExperimentOn(this.win, 'no-sync-xhr-in-ads')) {
       // Block synchronous XHR in ad. These are very rare, but super bad for UX
       // as they block the UI thread for the arbitrary amount of time until the
@@ -1454,6 +1434,9 @@ export class AmpA4A extends AMP.BaseElement {
         /** @type {!Document} */ (this.element.ownerDocument),
         'iframe', /** @type {!JsonObject} */ (
           Object.assign(mergedAttributes, SHARED_IFRAME_PROPERTIES)));
+    if (this.sandboxHTMLCreativeFrame()) {
+      applySandbox(this.iframe);
+    }
     // TODO(keithwrightbos): noContentCallback?
     this.xOriginIframeHandler_ = new AMP.AmpAdXOriginIframeHandler(this);
     // Iframe is appended to element as part of xorigin frame handler init.

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -30,11 +30,9 @@ import {
   CREATIVE_SIZE_HEADER,
   DEFAULT_SAFEFRAME_VERSION,
   EXPERIMENT_FEATURE_HEADER_NAME,
-  IFRAME_SANDBOXING_FLAGS,
   INVALID_SPSA_RESPONSE,
   RENDERING_TYPE_HEADER,
   SAFEFRAME_VERSION_HEADER,
-  SANDBOX_HEADER,
   assignAdUrlToError,
   protectFunctionWrapper,
 } from '../amp-a4a';
@@ -68,6 +66,11 @@ import {
 } from './testdata/valid_css_at_rules_amp.reserialized';
 
 describe('amp-a4a', () => {
+  const IFRAME_SANDBOXING_FLAGS = ['allow-forms', 'allow-modals',
+    'allow-pointer-lock', 'allow-popups', 'allow-popups-to-escape-sandbox',
+    'allow-same-origin', 'allow-scripts',
+    'allow-top-navigation-by-user-activation'];
+
   let sandbox;
   let fetchMock;
   let getSigningServiceNamesMock;
@@ -201,10 +204,24 @@ describe('amp-a4a', () => {
   }
 
   /**
+   * Checks that element has expected sandbox attribute.
+   * @param {!Element} element
+   * @param {boolean} shouldSandbox
+   */
+  function verifySandbox(element, shouldSandbox) {
+    const sandboxAttribute = element.getAttribute('sandbox');
+    expect(!!sandboxAttribute).to.equal(shouldSandbox);
+    if (shouldSandbox) {
+      expect(sandboxAttribute.split(' ').sort()).to.jsonEqual(
+          IFRAME_SANDBOXING_FLAGS);
+    }
+  }
+
+  /**
    * Checks that element is an amp-ad that is rendered via SafeFrame.
    * @param {!Element} element
    * @param {string} sfVersion
-   * @param {boolean} shouldSandbox
+   * @param {boolean=} shouldSandbox
    */
   function verifySafeFrameRender(element, sfVersion, shouldSandbox = false) {
     expect(element.tagName.toLowerCase()).to.equal('amp-a4a');
@@ -219,12 +236,7 @@ describe('amp-a4a', () => {
     const re = /^([^;]+);(\d+);([\s\S]*)$/;
     const match = re.exec(name);
     expect(match).to.be.ok;
-    const sandboxAttribute = child.getAttribute('sandbox');
-    if (shouldSandbox) {
-      expect(sandboxAttribute).to.equal(IFRAME_SANDBOXING_FLAGS);
-    } else {
-      expect(sandboxAttribute).to.be.null;
-    }
+    verifySandbox(child, shouldSandbox);
     const contentLength = Number(match[2]);
     const rest = match[3];
     expect(rest.length).to.be.above(contentLength);
@@ -256,18 +268,13 @@ describe('amp-a4a', () => {
     expect(nameData).to.be.ok;
     verifyNameData(nameData);
     expect(child).to.be.visible;
-    const sandboxAttribute = child.getAttribute('sandbox');
-    if (shouldSandbox) {
-      expect(sandboxAttribute).to.equal(IFRAME_SANDBOXING_FLAGS);
-    } else {
-      expect(sandboxAttribute).to.be.null;
-    }
+    verifySandbox(child, shouldSandbox);
   }
 
   /**
    * @param {!Element} element
    * @param {string} srcUrl
-   * @param {boolean} shouldSandbox
+   * @param {boolean=} shouldSandbox
    */
   function verifyCachedContentIframeRender(element, srcUrl,
     shouldSandbox = false) {
@@ -281,12 +288,7 @@ describe('amp-a4a', () => {
     expect(nameData).to.be.ok;
     verifyNameData(nameData);
     expect(child).to.be.visible;
-    const sandboxAttribute = child.getAttribute('sandbox');
-    if (shouldSandbox) {
-      expect(sandboxAttribute).to.equal(IFRAME_SANDBOXING_FLAGS);
-    } else {
-      expect(sandboxAttribute).to.be.null;
-    }
+    verifySandbox(child, shouldSandbox);
   }
 
   /** @param {string} nameData */
@@ -627,8 +629,8 @@ describe('amp-a4a', () => {
         });
       });
 
-      it('should apply sandbox attribute when header is true', () => {
-        adResponse.headers[SANDBOX_HEADER] = 'true';
+      it('should apply sandbox when sandboxHTMLCreativeFrame is true', () => {
+        a4a.sandboxHTMLCreativeFrame = () => true;
         a4a.onLayoutMeasure();
         return a4a.layoutCallback().then(() => {
           verifyCachedContentIframeRender(a4aElement, TEST_URL,
@@ -637,8 +639,8 @@ describe('amp-a4a', () => {
         });
       });
 
-      it('should not apply sandbox attribute when header is false', () => {
-        adResponse.headers[SANDBOX_HEADER] = 'false';
+      it('should not apply sandbox when sandboxHTMLCreativeFrame false', () => {
+        a4a.sandboxHTMLCreativeFrame = () => false;
         a4a.onLayoutMeasure();
         return a4a.layoutCallback().then(() => {
           verifyCachedContentIframeRender(a4aElement, TEST_URL,
@@ -648,7 +650,7 @@ describe('amp-a4a', () => {
       });
 
       it('shouldn\'t set feature policy for sync-xhr with exp off-a4a', () => {
-        adResponse.headers[SANDBOX_HEADER] = 'true';
+        a4a.sandboxHTMLCreativeFrame = () => true;
         a4a.onLayoutMeasure();
         return a4a.layoutCallback().then(() => {
           verifyCachedContentIframeRender(a4aElement, TEST_URL, true);
@@ -657,7 +659,7 @@ describe('amp-a4a', () => {
       });
 
       it('should set feature policy for sync-xhr with exp on-a4a', () => {
-        adResponse.headers[SANDBOX_HEADER] = 'true';
+        a4a.sandboxHTMLCreativeFrame = () => true;
         toggleExperiment(a4a.win, 'no-sync-xhr-in-ads', true);
         a4a.onLayoutMeasure();
         return a4a.layoutCallback().then(() => {
@@ -728,8 +730,8 @@ describe('amp-a4a', () => {
         });
       });
 
-      it('should apply sandbox attribute when header is true', () => {
-        adResponse.headers[SANDBOX_HEADER] = 'true';
+      it('should apply sandbox when sandboxHTMLCreativeFrame is true', () => {
+        a4a.sandboxHTMLCreativeFrame = () => true;
         a4a.onLayoutMeasure();
         return a4a.layoutCallback().then(() => {
           verifyNameFrameRender(a4aElement, true /* shouldSandbox */);
@@ -737,8 +739,8 @@ describe('amp-a4a', () => {
         });
       });
 
-      it('should not apply sandbox attribute when header is false', () => {
-        adResponse.headers[SANDBOX_HEADER] = 'false';
+      it('should not apply sandbox when sandboxHTMLCreativeFrame false', () => {
+        a4a.sandboxHTMLCreativeFrame = () => false;
         a4a.onLayoutMeasure();
         return a4a.layoutCallback().then(() => {
           verifyNameFrameRender(a4aElement, false /* shouldSandbox */);
@@ -824,8 +826,8 @@ describe('amp-a4a', () => {
         });
       });
 
-      it('should apply sandbox attribute when header is true', () => {
-        adResponse.headers[SANDBOX_HEADER] = 'true';
+      it('should apply sandbox when sandboxHTMLCreativeFrame is true', () => {
+        a4a.sandboxHTMLCreativeFrame = () => true;
         a4a.onLayoutMeasure();
         return a4a.layoutCallback().then(() => {
           verifySafeFrameRender(a4aElement, DEFAULT_SAFEFRAME_VERSION,
@@ -834,8 +836,8 @@ describe('amp-a4a', () => {
         });
       });
 
-      it('should not apply sandbox attribute when header is false', () => {
-        adResponse.headers[SANDBOX_HEADER] = 'false';
+      it('should not apply sandbox when sandboxHTMLCreativeFrame false', () => {
+        a4a.sandboxHTMLCreativeFrame = () => false;
         a4a.onLayoutMeasure();
         return a4a.layoutCallback().then(() => {
           verifySafeFrameRender(a4aElement, DEFAULT_SAFEFRAME_VERSION,
@@ -2526,5 +2528,17 @@ describes.realWin('AmpA4a-RTC', {amp: true}, env => {
         a4a.postAdResponseExperimentFeatures['pref_neutral_enabled'] = prefVal;
         expect(a4a.inNonAmpPreferenceExp()).to.equal(!!expected);
       }));
+  });
+
+  describe('#sandboxHTMLCreativeFrame', () => {
+    it('should return true if experiment enabled', () => {
+      toggleExperiment(a4a.win, 'sandbox-ads', true);
+      expect(a4a.sandboxHTMLCreativeFrame()).to.be.true;
+    });
+
+    it('should return true if experiment disabled', () => {
+      toggleExperiment(a4a.win, 'sandbox-ads', false);
+      expect(a4a.sandboxHTMLCreativeFrame()).to.be.false;
+    });
   });
 });

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -31,6 +31,7 @@ import {CONSENT_POLICY_STATE} from '../../../src/consent-state';
 import {Navigation} from '../../../src/service/navigation';
 import {
   QQID_HEADER,
+  SANDBOX_HEADER,
   ValidAdContainerTypes,
   addCsiSignalsToAmpAnalyticsConfig,
   additionalDimensions,
@@ -158,6 +159,13 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
 
     /** @private {number} slot index specific to google inventory */
     this.ifi_ = 0;
+
+    /**
+     * Whether or not the iframe containing the ad should be sandboxed via the
+     * "sandbox" attribute.
+     * @private {boolean}
+     */
+    this.shouldSandbox_ = false;
   }
 
   /**
@@ -402,6 +410,7 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
   extractSize(responseHeaders) {
     this.ampAnalyticsConfig_ = extractAmpAnalyticsConfig(this, responseHeaders);
     this.qqid_ = responseHeaders.get(QQID_HEADER);
+    this.shouldSandbox_ = responseHeaders.get(SANDBOX_HEADER) == 'true';
     if (this.ampAnalyticsConfig_) {
       // Load amp-analytics extensions
       this.extensions_./*OK*/installExtensionForDoc(
@@ -443,6 +452,11 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
   isXhrAllowed() {
     return isCdnProxy(this.win) || getMode(this.win).localDev ||
         getMode(this.win).test;
+  }
+
+  /** @override */
+  sandboxHTMLCreativeFrame() {
+    return this.shouldSandbox_;
   }
 
   /** @override */
@@ -501,6 +515,7 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
     this.ampAnalyticsConfig_ = null;
     this.qqid_ = null;
     this.isAmpCreative_ = null;
+    this.shouldSandbox_ = false;
     return superResult;
   }
 

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
@@ -207,6 +207,23 @@ describes.realWin('amp-ad-network-adsense-impl', {
       // exact value of ampAnalyticsConfig_ covered in
       // ads/google/test/test-utils.js
     });
+
+    it('should consume sandbox header', () => {
+      impl.extractSize({
+        get(name) {
+          switch (name) {
+            case 'amp-ff-sandbox':
+              return 'true';
+            default:
+              return undefined;
+          }
+        },
+        has(name) {
+          return !!this.get(name);
+        },
+      });
+      expect(impl.sandboxHTMLCreativeFrame()).to.be.true;
+    });
   });
 
   describe('#onNetworkFailure', () => {

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -30,6 +30,7 @@ import {
 import {
   AmpAnalyticsConfigDef,
   QQID_HEADER,
+  SANDBOX_HEADER,
   ValidAdContainerTypes,
   addCsiSignalsToAmpAnalyticsConfig,
   extractAmpAnalyticsConfig,
@@ -255,6 +256,13 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
      * attempt to expand again when outside of the viewport.
      */
     this.reattemptToExpandFluidCreative_ = false;
+
+    /**
+     * Whether or not the iframe containing the ad should be sandboxed via the
+     * "sandbox" attribute.
+     * @private {boolean}
+     */
+    this.shouldSandbox_ = false;
   }
 
   /**
@@ -711,6 +719,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
   extractSize(responseHeaders) {
     this.ampAnalyticsConfig_ = extractAmpAnalyticsConfig(this, responseHeaders);
     this.qqid_ = responseHeaders.get(QQID_HEADER);
+    this.shouldSandbox_ = responseHeaders.get(SANDBOX_HEADER) == 'true';
     this.troubleshootData_.creativeId =
         responseHeaders.get('google-creative-id');
     this.troubleshootData_.lineItemId =
@@ -744,6 +753,11 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     }
 
     return size;
+  }
+
+  /** @override */
+  sandboxHTMLCreativeFrame() {
+    return this.shouldSandbox_;
   }
 
   /**
@@ -783,6 +797,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     sraRequests = null;
     this.sraDeferred = null;
     this.qqid_ = null;
+    this.shouldSandbox_ = false;
     this.consentState = null;
     this.getAdUrlDeferred = new Deferred();
     this.removePageviewStateToken();

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -276,6 +276,23 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, env => {
           expect(setPageviewStateTokenSpy.withArgs('DUMMY_TOKEN')).to.be
               .calledOnce;
         });
+
+    it('should consume sandbox header', () => {
+      impl.extractSize({
+        get(name) {
+          switch (name) {
+            case 'amp-ff-sandbox':
+              return 'true';
+            default:
+              return undefined;
+          }
+        },
+        has(name) {
+          return !!this.get(name);
+        },
+      });
+      expect(impl.sandboxHTMLCreativeFrame()).to.be.true;
+    });
   });
 
   describe('#onCreativeRender', () => {

--- a/src/3p-frame.js
+++ b/src/3p-frame.js
@@ -360,6 +360,8 @@ export function applySandbox(iframe) {
     // We should consider turning this off! But since the top navigation
     // issue is the big one, we'll leave this allowed for now.
     'allow-modals',
+    // Give access to raw mouse movements.
+    'allow-pointer-lock',
     // This remains subject to popup blocking, it just makes it supported
     // at all.
     'allow-popups',


### PR DESCRIPTION
For amp-ad networks extending amp-a4a:
- Port sandboxing logic already in place to use #18003
- Sandboxing for cross domain frame enablement based on sandbox-ads experiment by default
- Overridden for AdSense/Doubleclick to be based on pre-existing header detection with goal to launch for all non-AMPHML creatives in near future