### PR TITLE
🏗🐛 Don't stop `check-package-manager` when an error is detected, merely pause execution for 5 sec

### DIFF
--- a/build-system/check-package-manager.js
+++ b/build-system/check-package-manager.js
@@ -16,7 +16,6 @@
 'use strict';
 
 const https = require('https');
-const readline = require('readline');
 const {getStdout} = require('./exec');
 
 const setupInstructionsUrl = 'https://github.com/ampproject/amphtml/blob/master/contributing/getting-started-quick.md#one-time-setup';
@@ -198,19 +197,17 @@ function main() {
     if (!process.env.TRAVIS && updatesNeeded.length > 0) {
       console.log(yellow('\nWARNING: Detected missing updates for'),
           cyan(updatesNeeded.join(', ')));
-      console.log(yellow('⤷ Press any key to continue install...'));
+      console.log(yellow('⤷ Continuing install in'), cyan('5'),
+          yellow('seconds...'));
       console.log(yellow('⤷ Press'), cyan('Ctrl + C'),
           yellow('to abort and fix...'));
-      readline.emitKeypressEvents(process.stdin);
-      process.stdin.setRawMode(true);
-      process.stdin.on('keypress', (unusedStr, key) => {
-        if (key.ctrl && key.name === 'c') {
-          process.exit(1);
-        } else {
-          console.log(yellow('\nAttempting to install packages...'));
-          process.exit(0);
-        }
-      });
+      let resolver;
+      const deferred = new Promise(resolverIn => {resolver = resolverIn;});
+      setTimeout(() => {
+        console.log(yellow('\nAttempting to install packages...'));
+        resolver();
+      }, 5000);
+      return deferred;
     }
   });
 }

--- a/build-system/tasks/update-packages.js
+++ b/build-system/tasks/update-packages.js
@@ -19,7 +19,7 @@ const colors = require('ansi-colors');
 const fs = require('fs-extra');
 const gulp = require('gulp-help')(require('gulp'));
 const log = require('fancy-log');
-const {exec, getStderr} = require('../exec');
+const {exec, execOrDie, getStderr} = require('../exec');
 
 const yarnExecutable = 'npx yarn';
 
@@ -125,7 +125,7 @@ function runYarnCheck() {
     const verifyTreeCmd = yarnExecutable + ' check --verify-tree';
     exec(verifyTreeCmd);
     log('Running', colors.cyan('yarn'), 'to update packages...');
-    exec(yarnExecutable);
+    execOrDie(yarnExecutable); // Stop execution when Ctrl + C is detected.
   } else {
     log(colors.green('All packages in'),
         colors.cyan('node_modules'), colors.green('are up to date.'));


### PR DESCRIPTION
The file `build-system/check-package-manager.js` makes sure the development toolchain is up to date. When an error is detected, the script pauses for input to give the user a chance to abort and fix the toolchain. This breaks automated scripts that aren't interactive.

In this PR, we remove the code that waits on user input, and replace it with a 5 second wait. This is enough time for a user to respond with `Ctrl + C`, and no longer breaks automated scripts.

Fixes #17984
