### PR TITLE
Fix media layout race condition delaying story ads.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -32,6 +32,7 @@ import {
   AnimationManager,
   hasAnimations,
 } from './animation';
+import {CommonSignals} from '../../../src/common-signals';
 import {Deferred} from '../../../src/utils/promise';
 import {EventType, dispatch} from './events';
 import {Layout} from '../../../src/layout';
@@ -333,7 +334,8 @@ export class AmpStoryPage extends AMP.BaseElement {
         switch (mediaEl.tagName.toLowerCase()) {
           case 'amp-img':
           case 'amp-anim':
-            mediaEl.addEventListener('load', resolve, true /* useCapture */);
+            mediaEl.signals().whenSignal(CommonSignals.LOAD_END)
+                .then(resolve, resolve);
             break;
           case 'amp-audio':
           case 'amp-video':


### PR DESCRIPTION
I've been able to reproduce the issue thanks to @lannka's instructions in #17757.
`amp-story`'s code running after an `amp-img` is loaded doesn't detect that the story is actually already loaded, causing the load events broadcasted by the story to be triggered after a 5s timeout.

I've been testing by replacing the amp-story script tag with the following snippets, that ensures amp-story only runs after the amp-img is loaded.

````
  <script type="text/javascript">
    setTimeout(() => {
      const script = document.createElement('script');
      script.src = "https://cdn.ampproject.org/v0/amp-story-1.0.js";
      script.setAttribute('custom-element', 'amp-story');
      document.getElementsByTagName('head')[0].appendChild(script);
    }, 1000);
  </script>
````

I haven't been able to write a unit test that reproduces the error though. I tried specifically loading the `amp-img` from the test config, and setting an empty `src`, or a `base64` `src`, that should resolve right away, but none of this did it...