### PR TITLE
🐛 Pass extension version when reloading extension

### DIFF
--- a/src/service/extension-location.js
+++ b/src/service/extension-location.js
@@ -72,3 +72,18 @@ export function calculateEntryPointScriptUrl(
   }
   return `${base}/${entryPoint}.js`;
 }
+
+/**
+ * Parse the extension version from a given script URL.
+ * @param {string} scriptUrl
+ * @return {!Object<string, string>}
+ */
+export function parseExtensionUrl(scriptUrl) {
+  const regex = /^(.*)\/(.*)-([0-9.]+)\.js$/i;
+  const matches = scriptUrl.match(regex);
+
+  return {
+    extensionId: matches[2],
+    extensionVersion: matches[3],
+  };
+}

--- a/src/service/extensions-impl.js
+++ b/src/service/extensions-impl.js
@@ -23,7 +23,10 @@ import {
   registerServiceBuilderForDoc,
   setParentWindow,
 } from '../service';
-import {calculateExtensionScriptUrl} from './extension-location';
+import {
+  calculateExtensionScriptUrl,
+  parseExtensionUrl,
+} from './extension-location';
 import {
   copyElementToChildWindow,
   stubElementIfNotKnown,
@@ -259,7 +262,8 @@ export class Extensions {
     }
     oldScriptElement.removeAttribute('custom-element');
     oldScriptElement.setAttribute('i-amphtml-loaded-new-version', extensionId);
-    return this.preloadExtension(extensionId);
+    const urlParts = parseExtensionUrl(oldScriptElement.src);
+    return this.preloadExtension(extensionId, urlParts.extensionVersion);
   }
 
   /**

--- a/test/functional/test-extension-location.js
+++ b/test/functional/test-extension-location.js
@@ -17,6 +17,7 @@
 import {
   calculateEntryPointScriptUrl,
   calculateExtensionScriptUrl,
+  parseExtensionUrl,
 } from '../../src/service/extension-location';
 import {
   initLogConstructor,
@@ -107,6 +108,22 @@ describes.sandboxed('Extension Location', {}, () => {
       }, 'ww', /* isLocalDev */ false, /* opt_rtv */ true);
       expect(script).to.equal(
           'https://cdn.ampproject.org/rtv/123/ww.js');
+    });
+  });
+
+  describe('get correct URL parts', () => {
+    it('unversioned urls', () => {
+      const urlParts =
+          parseExtensionUrl('https://cdn.ampproject.org/v0/amp-ad-1.0.js');
+      expect(urlParts.extensionId).to.equal('amp-ad');
+      expect(urlParts.extensionVersion).to.equal('1.0');
+    });
+
+    it('versioned urls', () => {
+      const urlParts = parseExtensionUrl('https://cdn.ampproject.org/rtv/123' +
+          '/v0/amp-ad-0.1.js');
+      expect(urlParts.extensionId).to.equal('amp-ad');
+      expect(urlParts.extensionVersion).to.equal('0.1');
     });
   });
 });


### PR DESCRIPTION
Currently, when extensions are reloaded, version 0.1 is always used.  This breaks any extension that is not version 0.1.

This PR parses the version from the extension URL and passes it through to `preloadExtension`, so that the proper version gets loaded.

/cc @vinaymahag @gmajoulet @Enriqe 