### PR TITLE
Friendly domain matching for linkers.

### DIFF
--- a/extensions/amp-analytics/0.1/linker-manager.js
+++ b/extensions/amp-analytics/0.1/linker-manager.js
@@ -27,12 +27,6 @@ import {user} from '../../../src/log';
 
 const TAG = 'amp-analytics/linker-manager';
 
-/**
- * The name of the Google CID API as it appears in the meta tag to opt-in.
- * @const @private {string}
- */
-const GOOGLE_CID_API_META_NAME = 'amp-google-client-id-api';
-
 export class LinkerManager {
 
   /**
@@ -186,7 +180,7 @@ export class LinkerManager {
     }
 
     const optInMeta = this.ampdoc_.win.document.head
-        ./*OK*/querySelector(`meta[name=${GOOGLE_CID_API_META_NAME}]`);
+        ./*OK*/querySelector('meta[name="amp-google-client-id-api"][content="googleanalytics"]');
     const isGaType = this.type_ === 'googleanalytics';
 
     return !!(optInMeta && isGaType);

--- a/extensions/amp-analytics/0.1/linker-manager.js
+++ b/extensions/amp-analytics/0.1/linker-manager.js
@@ -179,8 +179,8 @@ export class LinkerManager {
       return false;
     }
 
-    const optInMeta = this.ampdoc_.win.document.head
-        ./*OK*/querySelector('meta[name="amp-google-client-id-api"][content="googleanalytics"]');
+    const optInMeta = this.ampdoc_.win.document.head./*OK*/querySelector(
+        'meta[name="amp-google-client-id-api"][content="googleanalytics"]');
     const isGaType = this.type_ === 'googleanalytics';
 
     return !!(optInMeta && isGaType);

--- a/extensions/amp-analytics/0.1/linker-manager.js
+++ b/extensions/amp-analytics/0.1/linker-manager.js
@@ -244,9 +244,12 @@ export class LinkerManager {
 
     // If no domains given, default to friendly domain matching.
     if (!domains) {
-      const {sourceUrl} = Services.documentInfoForDoc(this.ampdoc_);
+      const {sourceUrl, canonicalUrl} =
+          Services.documentInfoForDoc(this.ampdoc_);
       const sourceOrigin = urlService.parse(sourceUrl).hostname;
-      if (!isFriendlyDomains(sourceOrigin, hostname)) {
+      const canonicalOrigin = urlService.parse(canonicalUrl).hostname;
+      if (!areFriendlyDomains(sourceOrigin, hostname)
+          && !areFriendlyDomains(canonicalOrigin, hostname)) {
         return;
       }
     }
@@ -270,7 +273,7 @@ export class LinkerManager {
  * @return {boolean}
  * @visibleForTesting
  */
-export function isFriendlyDomains(domain1, domain2) {
+export function areFriendlyDomains(domain1, domain2) {
   return getBaseDomain(domain1) === getBaseDomain(domain2);
 }
 

--- a/extensions/amp-analytics/0.1/test/test-linker-manager.js
+++ b/extensions/amp-analytics/0.1/test/test-linker-manager.js
@@ -18,117 +18,135 @@ import * as experiments from '../../../../src/experiments';
 import {LinkerManager, areFriendlyDomains} from '../linker-manager';
 import {Priority} from '../../../../src/service/navigation';
 import {Services} from '../../../../src/services';
-import {installPlatformService} from '../../../../src/service/platform-impl';
+import {installVariableService} from '../variables';
+import {mockWindowInterface} from '../../../../testing/test-helper';
 
-const DELIMITER = '*';
-const BASE64_REGEX = /^[a-zA-Z0-9\-_.]+$/;
-
-describe('Linker Manager', () => {
+describes.realWin('Linker Manager', {amp: true}, env => {
   let sandbox;
   let ampdoc;
-  let registerSpy;
-  let isProxyStub;
-  let findMetaTagStub;
+  let win;
+  let doc;
+  let windowInterface;
+  let handler;
 
   beforeEach(() => {
-    // Linker uses a timestamp value to generate checksum.
-    sandbox = sinon.sandbox;
-
-    findMetaTagStub = sandbox.stub();
-    ampdoc = {
-      win: {
-        document: {
-          head: {
-            querySelector: findMetaTagStub,
-          },
-        },
-      },
-    };
-
+    sandbox = env.sandbox;
+    ampdoc = env.ampdoc;
+    win = env.win;
+    doc = win.document;
+    windowInterface = mockWindowInterface(sandbox);
     sandbox.stub(Services, 'documentInfoForDoc')
         .returns({
           sourceUrl: 'https://amp.source.com/some/path?q=123',
           canonicalUrl: 'https://www.canonical.com/some/path?q=123',
         });
 
-    registerSpy = sandbox.spy();
+    handler = null;
     sandbox.stub(Services, 'navigationForDoc').returns({
-      registerAnchorMutator: registerSpy,
+      registerAnchorMutator: (callback, priority) => {
+        if (priority === Priority.ANALYTICS_LINKER) {
+          handler = callback;
+        }
+      },
     });
-
-    isProxyStub = sandbox.stub().returns(true);
-    sandbox.stub(Services, 'urlForDoc').returns({
-      isProxyOrigin: isProxyStub,
-      parse: url => new URL(url),
+    windowInterface.getLocation.returns({
+      origin: 'https://amp-source-com.cdn.ampproject.org',
     });
+    installVariableService(win);
   });
 
-  afterEach(() => {
-    sandbox.restore();
-  });
-
-
-  it('registers the callback if given valid linkers config', () => {
-
-    const config = {
+  it('registers anchor mutator if given valid linkers config', () => {
+    new LinkerManager(ampdoc, {
       linkers: {
         testLinker: {
           enabled: true,
           ids: {
-            gclid: '123',
+            foo: 'bar',
           },
         },
       },
-    };
+    }, null).init();
 
-    const manager = new LinkerManager(ampdoc, config);
-    sandbox.stub(manager, 'isLegacyOptIn_').returns(false);
-    sandbox.stub(manager, 'expandTemplateWithUrlParams_');
-    manager.init();
-
-    expect(registerSpy.calledOnce).to.be.true;
-    expect(registerSpy).calledWith(
-        sinon.match.func,
-        Priority.ANALYTICS_LINKER);
+    expect(handler).to.be.ok;
   });
 
   it('does not register anchor mutator if no linkers config', () => {
-    const config = {};
+    new LinkerManager(ampdoc, {}, null).init();
+    expect(handler).to.not.be.ok;
+  });
 
-    const manager = new LinkerManager(ampdoc, config);
-    manager.init();
-
-    expect(registerSpy).to.not.be.called;
+  it('does not register anchor mutator if empty linkers config', () => {
+    new LinkerManager(ampdoc, {linkers: {}}, null).init();
+    expect(handler).to.not.be.ok;
   });
 
   it('does not register anchor mutator if no linkers enabled', () => {
-    const config = {
-      testLinker1: {
-        ids: {
-          _key: 'CLIENT_ID(_ga)',
-          gclid: '234',
+    new LinkerManager(ampdoc, {
+      linkers: {
+        testLinker1: {
+          ids: {
+            bar: 'foo',
+          },
+        },
+        testLinker2: {
+          ids: {
+            foo: 'bar',
+          },
         },
       },
-      testLinker2: {
-        ids: {
-          foo: 'bar',
-        },
-      },
-    };
-
-    const manager = new LinkerManager(ampdoc, config);
-    manager.init();
-
-    expect(registerSpy).to.not.be.called;
+    }, null).init();
+    expect(handler).to.not.be.ok;
   });
 
-  it('starts resolving macros and adds them to matching anchor', () => {
+  it('does not register anchor mutator if not on proxy', () => {
+    windowInterface.getLocation.returns({
+      origin: 'https://amp.source.com',
+    });
+    new LinkerManager(ampdoc, {
+      linkers: {
+        testLinker: {
+          enabled: true,
+          ids: {
+            bar: 'foo',
+          },
+        },
+      },
+    }, null).init();
+    expect(handler).to.not.be.ok;
+  });
+
+  it('registers anchor mutator if not on proxy but proxyOnly=false', () => {
+    windowInterface.getLocation.returns({
+      origin: 'https://amp.source.com',
+    });
+    new LinkerManager(ampdoc, {
+      linkers: {
+        testLinker: {
+          enabled: true,
+          proxyOnly: false,
+          ids: {
+            bar: 'foo',
+          },
+        },
+      },
+    }, null).init();
+    expect(handler).to.be.ok;
+  });
+
+  it('should resolve vars and append to matching anchor', () => {
+    windowInterface.getUserAgent.returns('Mozilla/5.0 (X11; Linux x86_64) ' +
+        'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.99 ' +
+        'Safari/537.36');
+    windowInterface.getUserLanguage.returns('en-US');
+    sandbox.useFakeTimers(1533329483292);
+    sandbox.stub(Date.prototype, 'getTimezoneOffset').returns(420);
+    doc.title = 'TEST TITLE';
     const config = {
       linkers: {
         enabled: true,
         testLinker1: {
           ids: {
-            _key: 'CLIENT_ID(_ga)',
+            _key: '${title}',
             gclid: '234',
           },
         },
@@ -138,68 +156,18 @@ describe('Linker Manager', () => {
           },
         },
       },
-    };
-
-    const manager = new LinkerManager(ampdoc, config);
-    const expandStub = sandbox.stub(manager, 'expandTemplateWithUrlParams_');
-    expandStub.withArgs('CLIENT_ID(_ga)')
-        .returns('amp-12345');
-    expandStub.returnsArg(0);
-    manager.init();
-    expect(registerSpy).to.be.called;
-
-    const a = {
-      href: 'https://www.source.com',
-      hostname: 'www.source.com',
-    };
-
-    return Promise.all(manager.allLinkerPromises_).then(() => {
-      manager.handleAnchorMutation(a);
-      const parsedUrl = new URL(a.href);
-      const param1 = parsedUrl.searchParams.get('testLinker1').split(DELIMITER);
-      const param2 = parsedUrl.searchParams.get('testLinker2').split(DELIMITER);
-
-      expect(param1[2]).to.equal('_key');
-      expect(param1[3]).to.match(BASE64_REGEX);
-      expect(param1[4]).to.equal('gclid');
-      expect(param1[5]).to.equal('MjM0');
-
-      expect(param2[2]).to.equal('foo');
-      expect(param2[3]).to.equal('YmFy');
-    });
-  });
-
-  it('should add linker with valid config.', () => {
-    const config = {
-      linkers: {
-        testLinker1: {
-          enabled: true,
-          ids: {
-            _key: 'CLIENT_ID(_ga)',
-            gclid: '234',
-          },
-        },
+      vars: {
+        'title': 'TITLE',
       },
     };
 
-    const a = {
-      href: 'https://www.source.com',
-      hostname: 'www.source.com',
-    };
-
-    const manager = new LinkerManager(ampdoc, config);
-    sandbox.stub(manager, 'isLegacyOptIn_').returns(false);
-    const expandStub = sandbox.stub(manager, 'expandTemplateWithUrlParams_');
-    expandStub.withArgs('CLIENT_ID(_ga)')
-        .returns('amp-12345');
-    expandStub.returnsArg(0);
-    manager.init();
-    expect(registerSpy).to.be.called;
-
-    return Promise.all(manager.allLinkerPromises_).then(() => {
-      manager.handleAnchorMutation(a);
-      expect(a.href.indexOf(
-          'https:\/\/www\.source\.com\?testLinker1=1*')).to.equal(0);
+    return new LinkerManager(ampdoc, config, null).init().then(() => {
+      expect(handler).to.be.ok;
+      expect(clickAnchor('https://www.source.com/dest?a=1')).to.equal(
+          'https://www.source.com/dest' +
+          '?a=1' +
+          '&testLinker1=1*1pgvkob*_key*VEVTVCUyMFRJVExF*gclid*MjM0' +
+          '&testLinker2=1*1u4ugj3*foo*YmFy');
     });
   });
 
@@ -221,48 +189,26 @@ describe('Linker Manager', () => {
       },
     };
 
-    const manager = new LinkerManager(ampdoc, config);
-    const expandStub = sandbox.stub(manager,
-        'expandTemplateWithUrlParams_');
-    expandStub.returnsArg(0);
-
-    manager.init();
-
-    return Promise.all(manager.allLinkerPromises_).then(() => {
-      const canonicalDomainlUrl = {
-        href: 'https://www.canonical.com/path',
-        hostname: 'www.canonical.com',
-      };
-      const sourceDomainUrl = {
-        href: 'https://amp.source.com/path',
-        hostname: 'amp.source.com',
-      };
-      manager.handleAnchorMutation(canonicalDomainlUrl);
-      manager.handleAnchorMutation(sourceDomainUrl);
-
+    return new LinkerManager(ampdoc, config, null).init().then(() => {
       // testLinker1 should apply to both canonical and source
       // testLinker2 should not
-      expect(canonicalDomainlUrl.href).to.contain('testLinker1=');
-      expect(sourceDomainUrl.href).to.contain('testLinker1=');
-      expect(canonicalDomainlUrl.href).to.not.contain('testLinker2=');
-      expect(sourceDomainUrl.href).to.not.contain('testLinker2=');
+      const canonicalDomainUrl = clickAnchor('https://www.canonical.com/path');
+      expect(canonicalDomainUrl).to.contain('testLinker1=');
+      expect(canonicalDomainUrl).to.not.contain('testLinker2=');
 
-      const fooDomainUrl = {
-        href: 'https://foo.com/path',
-        hostname: 'foo.com',
-      };
-      const barDomainUrl = {
-        href: 'https://bar.com/path',
-        hostname: 'bar.com',
-      };
-      manager.handleAnchorMutation(fooDomainUrl);
-      manager.handleAnchorMutation(barDomainUrl);
+      const sourceDomainUrl = clickAnchor('https://amp.source.com/path');
+      expect(sourceDomainUrl).to.contain('testLinker1=');
+      expect(sourceDomainUrl).to.not.contain('testLinker2=');
+
       // testLinker2 should apply to both foo and bar
       // testLinker1 should not
-      expect(fooDomainUrl.href).to.not.contain('testLinker1=');
-      expect(barDomainUrl.href).to.not.contain('testLinker1=');
-      expect(fooDomainUrl.href).to.contain('testLinker2=');
-      expect(barDomainUrl.href).to.contain('testLinker2=');
+      const fooUrl = clickAnchor('https://foo.com/path');
+      expect(fooUrl).to.not.contain('testLinker1=');
+      expect(fooUrl).to.contain('testLinker2=');
+
+      const barDomainUrl = clickAnchor('https://bar.com/path');
+      expect(barDomainUrl).to.not.contain('testLinker1=');
+      expect(barDomainUrl).to.contain('testLinker2=');
     });
   });
 
@@ -285,26 +231,14 @@ describe('Linker Manager', () => {
       },
     };
 
-    const manager = new LinkerManager(ampdoc, config);
-    sandbox.stub(manager, 'expandTemplateWithUrlParams_').returnsArg(0);
-    manager.init();
+    return new LinkerManager(ampdoc, config, null).init().then(() => {
+      const fooDomainUrl = clickAnchor('https://foo.com/path');
+      const barDomainUrl = clickAnchor('https://bar.com/path');
 
-    return Promise.all(manager.allLinkerPromises_).then(() => {
-      const fooDomainUrl = {
-        href: 'https://foo.com/path',
-        hostname: 'foo.com',
-      };
-      const barDomainUrl = {
-        href: 'https://bar.com/path',
-        hostname: 'bar.com',
-      };
-      manager.handleAnchorMutation(fooDomainUrl);
-      manager.handleAnchorMutation(barDomainUrl);
-
-      expect(fooDomainUrl.href).to.contain('testLinker1=');
-      expect(fooDomainUrl.href).to.not.contain('testLinker2=');
-      expect(barDomainUrl.href).to.contain('testLinker2=');
-      expect(barDomainUrl.href).to.not.contain('testLinker1=');
+      expect(fooDomainUrl).to.contain('testLinker1=');
+      expect(fooDomainUrl).to.not.contain('testLinker2=');
+      expect(barDomainUrl).to.contain('testLinker2=');
+      expect(barDomainUrl).to.not.contain('testLinker1=');
     });
   });
 
@@ -320,81 +254,54 @@ describe('Linker Manager', () => {
       },
     };
 
-    const manager = new LinkerManager(ampdoc, config);
-    sandbox.stub(manager, 'expandTemplateWithUrlParams_').returnsArg(0);
-    manager.init();
+    return new LinkerManager(ampdoc, config, null).init().then(() => {
+      const url1 = clickAnchor('https://www.source.com/path');
+      const url2 = clickAnchor('https://amp.www.source.com/path');
+      const url3 = clickAnchor('https://canonical.com/path');
+      const url4 = clickAnchor('https://amp.www.canonical.com/path');
+      const url5 = clickAnchor('https://amp.google.com/path');
 
-    return Promise.all(manager.allLinkerPromises_).then(() => {
-      const url1 = {
-        href: 'https://www.source.com/path',
-        hostname: 'www.source.com',
-      };
-      const url2 = {
-        href: 'https://amp.www.source.com/path',
-        hostname: 'amp.www.source.com',
-      };
-      const url3 = {
-        href: 'https://canonical.com/path',
-        hostname: 'canonical.com',
-      };
-      const url4 = {
-        href: 'https://amp.www.canonical.com/path',
-        hostname: 'amp.www.canonical.com',
-      };
-      const url5 = {
-        href: 'https://amp.google.com/path',
-        hostname: 'amp.google.com',
-      };
-      manager.handleAnchorMutation(url1);
-      manager.handleAnchorMutation(url2);
-      manager.handleAnchorMutation(url3);
-      manager.handleAnchorMutation(url4);
-      manager.handleAnchorMutation(url5);
-
-      expect(url1.href).to.contain('testLinker1=');
-      expect(url2.href).to.contain('testLinker1=');
-      expect(url3.href).to.contain('testLinker1=');
-      expect(url4.href).to.contain('testLinker1=');
-      expect(url5.href).to.not.contain('testLinker1=');
+      expect(url1).to.contain('testLinker1=');
+      expect(url2).to.contain('testLinker1=');
+      expect(url3).to.contain('testLinker1=');
+      expect(url4).to.contain('testLinker1=');
+      expect(url5).to.not.contain('testLinker1=');
     });
   });
 
   it('should respect proxyOnly config', () => {
+    windowInterface.getLocation.returns({
+      origin: 'https://amp.source.com',
+    });
     const config = {
       linkers: {
         enabled: true,
-        proxyOnly: false,
         testLinker1: {
+          proxyOnly: false,
           ids: {
             id: '111',
           },
         },
         testLinker2: {
+          proxyOnly: true,
           ids: {
             id: '222',
           },
-          proxyOnly: true,
         },
       },
     };
 
-    const manager = new LinkerManager(ampdoc, config);
-    sandbox.stub(manager, 'expandTemplateWithUrlParams_').returnsArg(0);
-    isProxyStub.returns(false);
-    manager.init();
-
-    return Promise.all(manager.allLinkerPromises_).then(() => {
-      const a = {
-        href: 'https://www.source.com',
-        hostname: 'www.source.com',
-      };
-      manager.handleAnchorMutation(a);
-      expect(a.href).to.contain('testLinker1=');
-      expect(a.href).to.not.contain('testLinker2=');
+    return new LinkerManager(ampdoc, config, null).init().then(() => {
+      const a = clickAnchor('https://www.source.com/path');
+      expect(a).to.contain('testLinker1=');
+      expect(a).to.not.contain('testLinker2=');
     });
   });
 
   it('proxyOnly should default to true', () => {
+    windowInterface.getLocation.returns({
+      origin: 'https://amp.source.com',
+    });
     const config = {
       linkers: {
         enabled: true,
@@ -412,192 +319,130 @@ describe('Linker Manager', () => {
       },
     };
 
-    const manager = new LinkerManager(ampdoc, config);
-    sandbox.stub(manager, 'expandTemplateWithUrlParams_').returnsArg(0);
-    isProxyStub.returns(false);
-    manager.init();
-
-    return Promise.all(manager.allLinkerPromises_).then(() => {
-      const a = {
-        href: 'https://www.source.com',
-        hostname: 'www.source.com',
-      };
-      manager.handleAnchorMutation(a);
-      expect(a.href).to.not.contain('testLinker1=');
-      expect(a.href).to.contain('testLinker2=');
+    return new LinkerManager(ampdoc, config).init().then(() => {
+      const a = clickAnchor('https://www.source.com');
+      expect(a).to.not.contain('testLinker1=');
+      expect(a).to.contain('testLinker2=');
     });
   });
 
-  it('should not add linker destination domains do not match', () => {
-    const config = {
-      linkers: {
-        testLinker1: {
-          enabled: true,
-          ids: {
-            _key: 'CLIENT_ID(_ga)',
-          },
-          destinationDomains: ['www.foo.com'],
-        },
-      },
-    };
+  describe('when CID API enabled', () => {
 
-    const a = {
-      href: 'https://www.source.com',
-      hostname: 'www.source.com',
-    };
-
-    const manager = new LinkerManager(ampdoc, config);
-    sandbox.stub(manager, 'isLegacyOptIn_').returns(false);
-    sandbox.stub(manager, 'expandTemplateWithUrlParams_');
-    manager.init();
-
-    return Promise.all(manager.allLinkerPromises_).then(() => {
-      manager.handleAnchorMutation(a);
-      expect(a.href).to.equal('https://www.source.com');
+    beforeEach(() => {
+      addCidApiMeta();
     });
-  });
 
-  it('should not add linker if not explicitly enabled', () => {
-    const config = {
-      linkers: {
-        testLinker1: {
-          ids: {
-            _key: 'CLIENT_ID(_ga)',
-            gclid: '234',
-          },
-        },
-      },
-    };
-
-    const a = {
-      href: 'https://www.source.com',
-      hostname: 'www.source.com',
-    };
-
-    const manager = new LinkerManager(ampdoc, config);
-    sandbox.stub(manager, 'isLegacyOptIn_').returns(false);
-    sandbox.stub(manager, 'expandTemplateWithUrlParams_');
-    manager.init();
-
-    return Promise.all(manager.allLinkerPromises_).then(() => {
-      manager.handleAnchorMutation(a);
-      expect(a.href).to.equal('https://www.source.com');
-    });
-  });
-
-  it('should add linker for CID API users with Safari 12', () => {
-    ampdoc.win.navigator = {
-      userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) ' +
-        'AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 ' +
-        'Safari/605.1.15',
-    };
-    installPlatformService(ampdoc.win);
-    const config = {
-      linkers: {
-        testLinker1: {
-          ids: {
-            _key: 'CLIENT_ID(_ga)',
-            gclid: '234',
-          },
-        },
-      },
-    };
-
-    const a = {
-      href: 'https://www.source.com',
-      hostname: 'www.source.com',
-    };
-
-    const manager = new LinkerManager(ampdoc, config, 'googleanalytics');
-    sandbox.stub(experiments, 'isExperimentOn').returns(true);
-    findMetaTagStub.returns({});
-    const expandStub = sandbox.stub(manager, 'expandTemplateWithUrlParams_');
-    expandStub.withArgs('CLIENT_ID(_ga)')
-        .returns('amp-12345');
-    expandStub.returnsArg(0);
-
-    manager.init();
-
-    return Promise.all(manager.allLinkerPromises_).then(() => {
-      manager.handleAnchorMutation(a);
-      expect(a.href).to.contain('testLinker1=');
-    });
-  });
-
-  it('should not add linker for CID API users with Safari 11', () => {
-    ampdoc.win.navigator = {
-      userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) ' +
-        'AppleWebKit/605.1.15 (KHTML, like Gecko) ' +
-        'Version/11.1.2 Safari/605.1.15',
-    };
-    installPlatformService(ampdoc.win);
-    const config = {
-      linkers: {
-        testLinker1: {
-          ids: {
-            _key: 'CLIENT_ID(_ga)',
-            gclid: '234',
-          },
-        },
-      },
-    };
-
-    const a = {
-      href: 'https://www.source.com',
-      hostname: 'www.source.com',
-    };
-
-    const manager = new LinkerManager(ampdoc, config, 'googleanalytics');
-    sandbox.stub(experiments, 'isExperimentOn').returns(true);
-    findMetaTagStub.returns({});
-    const expandStub = sandbox.stub(manager, 'expandTemplateWithUrlParams_');
-    expandStub.withArgs('CLIENT_ID(_ga)')
-        .returns('amp-12345');
-    expandStub.returnsArg(0);
-
-    manager.init();
-
-    return Promise.all(manager.allLinkerPromises_).then(() => {
-      manager.handleAnchorMutation(a);
-      expect(a.href).to.equal('https://www.source.com');
-    });
-  });
-
-  it('should not add linker if meta tag is present but experiment is not on',
-      () => {
-        const config = {
-          linkers: {
-            testLinker1: {
-              ids: {
-                _key: 'CLIENT_ID(_ga)',
-                gclid: '234',
-              },
+    it('should add linker for Safari 12', () => {
+      stubPlatform(true, 12);
+      sandbox.stub(experiments, 'isExperimentOn').returns(true);
+      const config = {
+        linkers: {
+          testLinker1: {
+            ids: {
+              _key: 'CLIENT_ID(_ga)',
+              gclid: '234',
             },
           },
-        };
+        },
+      };
 
-        const a = {
-          href: 'https://www.source.com',
-          hostname: 'www.source.com',
-        };
+      return new LinkerManager(ampdoc, config, 'googleanalytics')
+          .init().then(() => {
+            const a = clickAnchor('https://www.source.com/path');
+            expect(a).to.contain('testLinker1=');
+          });
+    });
 
-        const manager = new LinkerManager(ampdoc, config);
-        sandbox.stub(experiments, 'isExperimentOn').returns(false);
-        manager.type_ = 'googleanalytics';
-        findMetaTagStub.returns({});
-        const expandStub = sandbox.stub(manager,
-            'expandTemplateWithUrlParams_');
-        expandStub.withArgs('CLIENT_ID(_ga)')
-            .returns('amp-12345');
-        expandStub.returnsArg(0);
+    it('should not add linker for not google analytics vendor', () => {
+      stubPlatform(true, 12);
+      sandbox.stub(experiments, 'isExperimentOn').returns(true);
+      const config = {
+        linkers: {
+          testLinker1: {
+            ids: {
+              _key: 'CLIENT_ID(_ga)',
+              gclid: '234',
+            },
+          },
+        },
+      };
 
-        manager.init();
+      new LinkerManager(ampdoc, config, 'somevendor');
+      expect(handler).to.be.null;
+    });
 
-        return Promise.all(manager.allLinkerPromises_).then(() => {
-          manager.handleAnchorMutation(a);
-          expect(a.href).to.equal('https://www.source.com');
-        });
-      });
+    it('should not add linker for Safari 11', () => {
+      stubPlatform(true, 11);
+      sandbox.stub(experiments, 'isExperimentOn').returns(true);
+      const config = {
+        linkers: {
+          testLinker1: {
+            ids: {
+              foo: 'bar',
+            },
+          },
+        },
+      };
+
+      new LinkerManager(ampdoc, config, 'googleanalytics');
+      expect(handler).to.be.null;
+    });
+
+    it('should not add linker for Chrome', () => {
+      stubPlatform(false, 66);
+      sandbox.stub(experiments, 'isExperimentOn').returns(true);
+      const config = {
+        linkers: {
+          testLinker1: {
+            ids: {
+              foo: 'bar',
+            },
+          },
+        },
+      };
+
+      new LinkerManager(ampdoc, config, 'googleanalytics');
+      expect(handler).to.be.null;
+    });
+
+    it('should not add linker if experiment is off', () => {
+      stubPlatform(true, 12);
+      sandbox.stub(experiments, 'isExperimentOn').returns(false);
+      const config = {
+        linkers: {
+          testLinker1: {
+            ids: {
+              foo: 'bar',
+            },
+          },
+        },
+      };
+
+      new LinkerManager(ampdoc, config, 'googleanalytics');
+      expect(handler).to.be.null;
+    });
+  });
+
+  function clickAnchor(url) {
+    const a = doc.createElement('a');
+    a.href = url;
+    doc.body.appendChild(a);
+    handler(a);
+    return a.href;
+  }
+
+  function addCidApiMeta() {
+    const meta = doc.createElement('meta');
+    meta.setAttribute('name', 'amp-google-client-id-api');
+    meta.setAttribute('content', 'googleanalytics');
+    doc.head.appendChild(meta);
+  }
+
+  function stubPlatform(isSafari, version) {
+    const platform = Services.platformFor(ampdoc.win);
+    sandbox.stub(platform, 'isSafari').returns(isSafari);
+    sandbox.stub(platform, 'getMajorVersion').returns(version);
+  }
 });
 
 describe('areFriendlyDomains', () => {

--- a/extensions/amp-analytics/0.1/test/test-linker-manager.js
+++ b/extensions/amp-analytics/0.1/test/test-linker-manager.js
@@ -15,7 +15,7 @@
  */
 
 import * as experiments from '../../../../src/experiments';
-import {LinkerManager, isFriendlyDomains} from '../linker-manager';
+import {LinkerManager, areFriendlyDomains} from '../linker-manager';
 import {Priority} from '../../../../src/service/navigation';
 import {Services} from '../../../../src/services';
 import {installPlatformService} from '../../../../src/service/platform-impl';
@@ -47,8 +47,8 @@ describe('Linker Manager', () => {
 
     sandbox.stub(Services, 'documentInfoForDoc')
         .returns({
-          sourceUrl: 'https://amp.example.com/some/path?q=123',
-          canonicalUrl: 'https://www.example.com/some/path?q=123',
+          sourceUrl: 'https://amp.source.com/some/path?q=123',
+          canonicalUrl: 'https://www.canonical.com/some/path?q=123',
         });
 
     registerSpy = sandbox.spy();
@@ -149,8 +149,8 @@ describe('Linker Manager', () => {
     expect(registerSpy).to.be.called;
 
     const a = {
-      href: 'https://www.example.com',
-      hostname: 'www.example.com',
+      href: 'https://www.source.com',
+      hostname: 'www.source.com',
     };
 
     return Promise.all(manager.allLinkerPromises_).then(() => {
@@ -183,8 +183,8 @@ describe('Linker Manager', () => {
     };
 
     const a = {
-      href: 'https://www.example.com',
-      hostname: 'www.example.com',
+      href: 'https://www.source.com',
+      hostname: 'www.source.com',
     };
 
     const manager = new LinkerManager(ampdoc, config);
@@ -199,7 +199,7 @@ describe('Linker Manager', () => {
     return Promise.all(manager.allLinkerPromises_).then(() => {
       manager.handleAnchorMutation(a);
       expect(a.href.indexOf(
-          'https:\/\/www\.example\.com\?testLinker1=1*')).to.equal(0);
+          'https:\/\/www\.source\.com\?testLinker1=1*')).to.equal(0);
     });
   });
 
@@ -230,12 +230,12 @@ describe('Linker Manager', () => {
 
     return Promise.all(manager.allLinkerPromises_).then(() => {
       const canonicalDomainlUrl = {
-        href: 'https://www.example.com/path',
-        hostname: 'www.example.com',
+        href: 'https://www.canonical.com/path',
+        hostname: 'www.canonical.com',
       };
       const sourceDomainUrl = {
-        href: 'https://amp.example.com/path',
-        hostname: 'amp.example.com',
+        href: 'https://amp.source.com/path',
+        hostname: 'amp.source.com',
       };
       manager.handleAnchorMutation(canonicalDomainlUrl);
       manager.handleAnchorMutation(sourceDomainUrl);
@@ -326,24 +326,36 @@ describe('Linker Manager', () => {
 
     return Promise.all(manager.allLinkerPromises_).then(() => {
       const url1 = {
-        href: 'https://www.example.com/path',
-        hostname: 'www.example.com',
+        href: 'https://www.source.com/path',
+        hostname: 'www.source.com',
       };
       const url2 = {
-        href: 'https://amp.www.example.com/path',
-        hostname: 'amp.www.example.com',
+        href: 'https://amp.www.source.com/path',
+        hostname: 'amp.www.source.com',
       };
       const url3 = {
+        href: 'https://canonical.com/path',
+        hostname: 'canonical.com',
+      };
+      const url4 = {
+        href: 'https://amp.www.canonical.com/path',
+        hostname: 'amp.www.canonical.com',
+      };
+      const url5 = {
         href: 'https://amp.google.com/path',
         hostname: 'amp.google.com',
       };
       manager.handleAnchorMutation(url1);
       manager.handleAnchorMutation(url2);
       manager.handleAnchorMutation(url3);
+      manager.handleAnchorMutation(url4);
+      manager.handleAnchorMutation(url5);
 
       expect(url1.href).to.contain('testLinker1=');
       expect(url2.href).to.contain('testLinker1=');
-      expect(url3.href).to.not.contain('testLinker1=');
+      expect(url3.href).to.contain('testLinker1=');
+      expect(url4.href).to.contain('testLinker1=');
+      expect(url5.href).to.not.contain('testLinker1=');
     });
   });
 
@@ -373,8 +385,8 @@ describe('Linker Manager', () => {
 
     return Promise.all(manager.allLinkerPromises_).then(() => {
       const a = {
-        href: 'https://www.example.com',
-        hostname: 'www.example.com',
+        href: 'https://www.source.com',
+        hostname: 'www.source.com',
       };
       manager.handleAnchorMutation(a);
       expect(a.href).to.contain('testLinker1=');
@@ -407,8 +419,8 @@ describe('Linker Manager', () => {
 
     return Promise.all(manager.allLinkerPromises_).then(() => {
       const a = {
-        href: 'https://www.example.com',
-        hostname: 'www.example.com',
+        href: 'https://www.source.com',
+        hostname: 'www.source.com',
       };
       manager.handleAnchorMutation(a);
       expect(a.href).to.not.contain('testLinker1=');
@@ -430,8 +442,8 @@ describe('Linker Manager', () => {
     };
 
     const a = {
-      href: 'https://www.example.com',
-      hostname: 'www.example.com',
+      href: 'https://www.source.com',
+      hostname: 'www.source.com',
     };
 
     const manager = new LinkerManager(ampdoc, config);
@@ -441,7 +453,7 @@ describe('Linker Manager', () => {
 
     return Promise.all(manager.allLinkerPromises_).then(() => {
       manager.handleAnchorMutation(a);
-      expect(a.href).to.equal('https://www.example.com');
+      expect(a.href).to.equal('https://www.source.com');
     });
   });
 
@@ -458,8 +470,8 @@ describe('Linker Manager', () => {
     };
 
     const a = {
-      href: 'https://www.example.com',
-      hostname: 'www.example.com',
+      href: 'https://www.source.com',
+      hostname: 'www.source.com',
     };
 
     const manager = new LinkerManager(ampdoc, config);
@@ -469,7 +481,7 @@ describe('Linker Manager', () => {
 
     return Promise.all(manager.allLinkerPromises_).then(() => {
       manager.handleAnchorMutation(a);
-      expect(a.href).to.equal('https://www.example.com');
+      expect(a.href).to.equal('https://www.source.com');
     });
   });
 
@@ -492,8 +504,8 @@ describe('Linker Manager', () => {
     };
 
     const a = {
-      href: 'https://www.example.com',
-      hostname: 'www.example.com',
+      href: 'https://www.source.com',
+      hostname: 'www.source.com',
     };
 
     const manager = new LinkerManager(ampdoc, config, 'googleanalytics');
@@ -531,8 +543,8 @@ describe('Linker Manager', () => {
     };
 
     const a = {
-      href: 'https://www.example.com',
-      hostname: 'www.example.com',
+      href: 'https://www.source.com',
+      hostname: 'www.source.com',
     };
 
     const manager = new LinkerManager(ampdoc, config, 'googleanalytics');
@@ -547,7 +559,7 @@ describe('Linker Manager', () => {
 
     return Promise.all(manager.allLinkerPromises_).then(() => {
       manager.handleAnchorMutation(a);
-      expect(a.href).to.equal('https://www.example.com');
+      expect(a.href).to.equal('https://www.source.com');
     });
   });
 
@@ -565,8 +577,8 @@ describe('Linker Manager', () => {
         };
 
         const a = {
-          href: 'https://www.example.com',
-          hostname: 'www.example.com',
+          href: 'https://www.source.com',
+          hostname: 'www.source.com',
         };
 
         const manager = new LinkerManager(ampdoc, config);
@@ -583,21 +595,21 @@ describe('Linker Manager', () => {
 
         return Promise.all(manager.allLinkerPromises_).then(() => {
           manager.handleAnchorMutation(a);
-          expect(a.href).to.equal('https://www.example.com');
+          expect(a.href).to.equal('https://www.source.com');
         });
       });
 });
 
-describe('isFriendlyDomains', () => {
+describe('areFriendlyDomains', () => {
   it('should work', () => {
-    expect(isFriendlyDomains('amp.example.com', 'www.example.com')).to.be.true;
-    expect(isFriendlyDomains('m.example.com', 'www.example.com')).to.be.true;
-    expect(isFriendlyDomains('amp.www.example.com', 'example.com')).to.be.true;
-    expect(isFriendlyDomains('amp.example.com', 'm.www.example.com'))
+    expect(areFriendlyDomains('amp.source.com', 'www.source.com')).to.be.true;
+    expect(areFriendlyDomains('m.source.com', 'www.source.com')).to.be.true;
+    expect(areFriendlyDomains('amp.www.source.com', 'source.com')).to.be.true;
+    expect(areFriendlyDomains('amp.source.com', 'm.www.source.com'))
         .to.be.true;
 
-    expect(isFriendlyDomains('amp.example.com', 'amp.google.com')).to.be.false;
-    expect(isFriendlyDomains('web.amp.example.com', 'web.m.example.com'))
+    expect(areFriendlyDomains('amp.source.com', 'amp.google.com')).to.be.false;
+    expect(areFriendlyDomains('web.amp.source.com', 'web.m.source.com'))
         .to.be.false;
   });
 });

--- a/src/window-interface.js
+++ b/src/window-interface.js
@@ -24,6 +24,15 @@ export class WindowInterface {
   /**
    * @static
    * @param {!Window} win
+   * @return {!Location}
+   */
+  static getLocation(win) {
+    return win.location;
+  }
+
+  /**
+   * @static
+   * @param {!Window} win
    * @return {string}
    */
   static getDocumentReferrer(win) {


### PR DESCRIPTION
Behavior changed when destinationDomains are not specified:

**Before**: only URLs under source domains or canonical domains are matched
**After**: URLs under friendly domains are matched

Domains are considered to be friends if they are identical after removing these prefixes: m. www. amp.