### PR TITLE
✨ Lotame vendor - set disableKeyAppend to true

### DIFF
--- a/extensions/amp-a4a/0.1/callout-vendors.js
+++ b/extensions/amp-a4a/0.1/callout-vendors.js
@@ -62,6 +62,7 @@ export const RTC_VENDORS = {
   lotame: {
     url: 'https://ad.crwdcntrl.net/5/pe=y/c=CLIENT_ID/an=AD_NETWORK',
     macros: ['CLIENT_ID', 'AD_NETWORK'],
+    disableKeyAppend: true,
   },
   yieldbot: {
     url: 'https://i.yldbt.com/m/YB_PSN/v1/amp/init?curl=CANONICAL_URL&sn=YB_SLOT&w=ATTR(width)&h=ATTR(height)&ow=ATTR(data-override-width)&oh=ATTR(data-override-height)&ms=ATTR(data-multi-size)&aup=ATTR(data-slot)&pvi=PAGEVIEWID&tgt=TGT&adcid=ADCID&href=HREF',


### PR DESCRIPTION
This change is in response to complaints from our clients. When we changed from the old remote.html implementation to RTC, the suffix "_lotame" started to be added to variable names. This was causing confusion, and it was decided that everyone would be happier if we simply disabled that behavior.

