### PR TITLE
✅ amp-next-page: Call verify on fetchDocumentMock after each test

### DIFF
--- a/extensions/amp-next-page/0.1/test/test-amp-next-page.js
+++ b/extensions/amp-next-page/0.1/test/test-amp-next-page.js
@@ -73,6 +73,7 @@ env => {
 
   afterEach(() => {
     xhrMock.verify();
+    fetchDocumentMock.verify();
     toggleExperiment(win, 'amp-next-page', false);
   });
 


### PR DESCRIPTION
This was the behaviour before, but the fetchDocumentMock was added (replacing xhrMock) and the verification didn't get added back.