### PR TITLE
🐛Fix transparent edges on blurred image placeholders on mobile

### DIFF
--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -143,7 +143,7 @@ export class AmpImg extends BaseElement {
     const placeholder = this.getPlaceholder();
     if (placeholder &&
     placeholder.classList.contains('i-amphtml-blur') &&
-    true ) {//isExperimentOn(this.win, 'blurry-placeholder')) {
+    isExperimentOn(this.win, 'blurry-placeholder')) {
       this.blurredPlaceholder_ = placeholder;
     }
     if (this.blurredPlaceholder_ && this.fillContent_) {

--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -52,10 +52,7 @@ export class AmpImg extends BaseElement {
     this.unlistenError_ = null;
 
     /** @private {?Element} */
-    this.blurredPlaceholder_ = null;
-
-    /** @private {?Element} */
-    this.fillContent_ = null;
+    this.blurryPlaceholder_ = null;
   }
 
   /** @override */
@@ -141,15 +138,17 @@ export class AmpImg extends BaseElement {
     this.applyFillContent(this.img_, true);
     this.element.appendChild(this.img_);
 
-    this.fillContent_ = this.element.querySelector('.i-amphtml-fill-content');
     const placeholder = this.getPlaceholder();
     if (placeholder &&
       placeholder.classList.contains('i-amphtml-blur') &&
       isExperimentOn(this.win, 'blurry-placeholder')) {
-      this.blurredPlaceholder_ = placeholder;
+      this.blurryPlaceholder_ = placeholder;
     }
-    if (this.blurredPlaceholder_ && this.fillContent_) {
-      setImportantStyles(this.fillContent_, {'visibility': 'hidden'});
+
+    // The image must be hidden until it is fully loaded so it does not show up
+    // behind the transparent edges of the blurred placeholder. See #18113.
+    if (this.blurryPlaceholder_) {
+      setImportantStyles(this.img_, {'visibility': 'hidden'});
     }
   }
 
@@ -190,9 +189,9 @@ export class AmpImg extends BaseElement {
 
   /** @override **/
   firstLayoutCompleted() {
-    if (this.blurredPlaceholder_ && this.fillContent_) {
-      setImportantStyles(this.blurredPlaceholder_, {'opacity': 0});
-      setImportantStyles(this.fillContent_, {'visibility': 'visible'});
+    if (this.blurryPlaceholder_) {
+      setImportantStyles(this.blurryPlaceholder_, {'opacity': 0});
+      setImportantStyles(this.img_, {'visibility': 'visible'});
     } else {
       this.togglePlaceholder(false);
     }

--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -120,7 +120,6 @@ export class AmpImg extends BaseElement {
     if (this.element.hasAttribute('i-amphtml-ssr')) {
       this.img_ = this.element.querySelector('img');
     }
-    
     this.img_ = this.img_ || new Image();
     this.img_.setAttribute('decoding', 'async');
     if (this.element.id) {
@@ -145,8 +144,8 @@ export class AmpImg extends BaseElement {
     this.fillContent_ = this.element.querySelector('.i-amphtml-fill-content');
     const placeholder = this.getPlaceholder();
     if (placeholder &&
-    placeholder.classList.contains('i-amphtml-blur') &&
-    isExperimentOn(this.win, 'blurry-placeholder')) {
+      placeholder.classList.contains('i-amphtml-blur') &&
+      isExperimentOn(this.win, 'blurry-placeholder')) {
       this.blurredPlaceholder_ = placeholder;
     }
     if (this.blurredPlaceholder_ && this.fillContent_) {

--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -117,7 +117,10 @@ export class AmpImg extends BaseElement {
 
     // For inabox SSR, image will have been written directly to DOM so no need
     // to recreate.  Calling appendChild again will have no effect.
-
+    if (this.element.hasAttribute('i-amphtml-ssr')) {
+      this.img_ = this.element.querySelector('img');
+    }
+    
     this.img_ = this.img_ || new Image();
     this.img_.setAttribute('decoding', 'async');
     if (this.element.id) {
@@ -169,9 +172,6 @@ export class AmpImg extends BaseElement {
     this.unlistenError_ = listen(img, 'error', () => this.onImgLoadingError_());
     if (this.getLayoutWidth() <= 0) {
       return Promise.resolve();
-    }
-    if (this.element.hasAttribute('i-amphtml-ssr')) {
-      this.img_ = this.element.querySelector('img');
     }
     return this.loadPromise(img);
   }

--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -51,8 +51,11 @@ export class AmpImg extends BaseElement {
     /** @private {?UnlistenDef} */
     this.unlistenError_ = null;
 
-    /** @private {boolean} */
-    this.hasBlurredPlaceholder_ = false;
+    /** @private {?Element} */
+    this.blurredPlaceholder_ = null;
+
+    /** @private {?Element} */
+    this.fillContent_ = null;
   }
 
   /** @override */
@@ -136,13 +139,15 @@ export class AmpImg extends BaseElement {
     this.applyFillContent(this.img_, true);
     this.element.appendChild(this.img_);
 
+    this.fillContent_ = this.element.querySelector('.i-amphtml-fill-content');
     const placeholder = this.getPlaceholder();
-    this.hasBlurredPlaceholder_ = placeholder &&
+    if (placeholder &&
     placeholder.classList.contains('i-amphtml-blur') &&
-    isExperimentOn(this.win, 'blurry-placeholder');
-    if (this.hasBlurredPlaceholder_) {
-      setImportantStyles(this.element.querySelector('.i-amphtml-fill-content'),
-          {'visibility': 'hidden'});
+    true ) {//isExperimentOn(this.win, 'blurry-placeholder')) {
+      this.blurredPlaceholder_ = placeholder;
+    }
+    if (this.blurredPlaceholder_ && this.fillContent_) {
+      setImportantStyles(this.fillContent_, {'visibility': 'hidden'});
     }
   }
 
@@ -186,10 +191,9 @@ export class AmpImg extends BaseElement {
 
   /** @override **/
   firstLayoutCompleted() {
-    if (this.hasBlurredPlaceholder_) {
-      setImportantStyles(this.getPlaceholder(), {'opacity': 0});
-      setImportantStyles(this.element.querySelector('.i-amphtml-fill-content'),
-          {'visibility': 'visible'});
+    if (this.blurredPlaceholder_ && this.fillContent_) {
+      setImportantStyles(this.blurredPlaceholder_, {'opacity': 0});
+      setImportantStyles(this.fillContent_, {'visibility': 'visible'});
     } else {
       this.togglePlaceholder(false);
     }


### PR DESCRIPTION
- Fixes issue #18113 for amp-img (separate PR for amp-video)

For this image:
<img width="542" alt="screen shot 2018-09-20 at 4 38 59 pm" src="https://user-images.githubusercontent.com/39060570/45845727-e4699680-bcf3-11e8-82a4-79942dd0822c.png">

Old blur:
<img width="542" alt="screen shot 2018-09-20 at 4 38 43 pm" src="https://user-images.githubusercontent.com/39060570/45845759-fc411a80-bcf3-11e8-9f72-48aefbd51fd7.png">

New blur:
<img width="540" alt="screen shot 2018-09-20 at 4 38 16 pm" src="https://user-images.githubusercontent.com/39060570/45845777-0bc06380-bcf4-11e8-83b9-903214531c0c.png">

