### PR TITLE
🐛 amp-next-page: Fix cache URL rewriting

### DIFF
--- a/extensions/amp-next-page/0.1/amp-next-page.js
+++ b/extensions/amp-next-page/0.1/amp-next-page.js
@@ -30,6 +30,7 @@ import {
   removeElement,
 } from '../../../src/dom';
 import {getServicePromiseForDoc} from '../../../src/service';
+import {getSourceOrigin} from '../../../src/url';
 import {isExperimentOn} from '../../../src/experiments';
 import {tryParseJson} from '../../../src/json';
 import {user} from '../../../src/log';
@@ -100,11 +101,10 @@ export class AmpNextPage extends AMP.BaseElement {
    */
   register_(service, configJson, separator) {
     const {element} = this;
-    const docInfo = Services.documentInfoForDoc(element);
     const urlService = Services.urlForDoc(element);
 
-    const url = urlService.parse(docInfo.url);
-    const sourceOrigin = urlService.getSourceOrigin(url);
+    const url = urlService.parse(this.getAmpDoc().getUrl());
+    const sourceOrigin = getSourceOrigin(url);
 
     const config = assertConfig(element, configJson, url.origin, sourceOrigin);
 

--- a/extensions/amp-next-page/0.1/config.js
+++ b/extensions/amp-next-page/0.1/config.js
@@ -107,7 +107,8 @@ function assertReco(context, reco, origin, sourceOrigin) {
   user().assertString(reco.image, 'image must be a string');
   user().assertString(reco.title, 'title must be a string');
 
-  if (sourceOrigin !== origin) {
+  // Rewrite canonical URLs to cache URLs, when served from the cache.
+  if (sourceOrigin !== origin && url.origin === sourceOrigin) {
     reco.ampUrl = `${origin}/c/` +
         (url.protocol === 'https:' ? 's/' : '') +
         encodeURIComponent(url.host) +

--- a/extensions/amp-next-page/0.1/test/test-amp-next-page.js
+++ b/extensions/amp-next-page/0.1/test/test-amp-next-page.js
@@ -55,8 +55,7 @@ env => {
     doc.body.appendChild(element);
     nextPage = new AmpNextPage(element);
 
-    // sourceUrl is set to about:srcdoc, which has no host.
-    sandbox.stub(Services.documentInfoForDoc(element), 'sourceUrl').value('/');
+    ampdoc.getUrl = () => 'https://example.com/example';
 
     xhrMock = sandbox.mock(Services.xhrFor(win));
     fetchDocumentMock = sandbox.mock(DocFetcher);

--- a/extensions/amp-next-page/0.1/test/test-amp-next-page.js
+++ b/extensions/amp-next-page/0.1/test/test-amp-next-page.js
@@ -55,7 +55,7 @@ env => {
     doc.body.appendChild(element);
     nextPage = new AmpNextPage(element);
 
-    ampdoc.getUrl = () => 'https://example.com/example';
+    ampdoc.getUrl = () => document.location.href;
 
     xhrMock = sandbox.mock(Services.xhrFor(win));
     fetchDocumentMock = sandbox.mock(DocFetcher);

--- a/extensions/amp-next-page/0.1/test/test-config.js
+++ b/extensions/amp-next-page/0.1/test/test-config.js
@@ -68,7 +68,7 @@ describe('amp-next-page config', () => {
       const config = {
         pages: [
           {
-            ampUrl: 'https://example-com.cdn.ampproject.org/example.com/art1',
+            ampUrl: 'https://example-com.cdn.ampproject.org/c/s/example.com/art1',
             image: 'https://example.com/image.png',
             title: 'Article 1',
           },
@@ -81,6 +81,8 @@ describe('amp-next-page config', () => {
       };
       expect(() => assertConfig(/*ctx*/ null, config, cdnOrigin, origin))
           .to.not.throw();
+      expect(config.pages[0].ampUrl).to.equal(
+          'https://example-com.cdn.ampproject.org/c/s/example.com/art1');
       expect(config.pages[1].ampUrl).to.equal(
           'https://example-com.cdn.ampproject.org/c/s/example.com/art2?x=1');
     });


### PR DESCRIPTION
Don't attempt to rewrite URLs to cache URLs if they're already cache.

Fixes a bug where if cache URLs were provided in the config, they would get rewritten to try and transform it again into the cache format, giving a broken URL.

URLs should only be rewritten if they are from the source origin.