### PR TITLE
Doubleclick Render on Idle Interaction with 3p throttle

### DIFF
--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -364,7 +364,6 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
         },
       });
     const setExps = this.randomlySelectUnsetExperiments_(experimentInfoMap);
-    console.log('setExps', setExps);
     Object.keys(setExps).forEach(expName =>
       setExps[expName] && this.experimentIds.push(setExps[expName]));
   }

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -306,8 +306,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     }
     const renderOutsideViewport = this.renderOutsideViewport();
     // False will occur when throttle in effect.
-    if (!!this.experimentIds.filter(exp =>
-      exp == DOUBLECLICK_IDLE_BOOL_EXP_BRANCHES.EXP).length &&
+    if (this.experimentIds.includes(DOUBLECLICK_IDLE_BOOL_EXP_BRANCHES.EXP) &&
       typeof renderOutsideViewport === 'boolean') {
       return renderOutsideViewport;
     }

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -117,6 +117,15 @@ const DOUBLECLICK_SRA_EXP_BRANCHES = {
   SRA_NO_RECOVER: '21062235',
 };
 
+/** @const {string} */
+const DOUBLECLICK_IDLE_BOOL_EXP = 'doubleclickIdleExp';
+
+/** @const @enum{string} */
+const DOUBLECLICK_IDLE_BOOL_EXP_BRANCHES = {
+  CONTROL: '21062567',
+  EXP: '21062568',
+};
+
 /**
  * Map of pageview tokens to the instances they belong to.
  * @private {!Object<string, !AmpAdNetworkDoubleclickImpl>}
@@ -295,13 +304,20 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     if (vpRange === false) {
       return vpRange;
     }
+    const renderOutsideViewport = this.renderOutsideViewport();
+    // False will occur when throttle in effect.
+    if (!!this.experimentIds.filter(exp =>
+      exp == DOUBLECLICK_IDLE_BOOL_EXP_BRANCHES.EXP).length &&
+      typeof renderOutsideViewport === 'boolean') {
+      return renderOutsideViewport;
+    }
     this.isIdleRender_ = true;
     // NOTE(keithwrightbos): handle race condition where previous
     // idleRenderOutsideViewport marked slot as idle render despite never
     // being schedule due to being beyond viewport max offset.  If slot
     // comes within standard outside viewport range, then ensure throttling
     // will not be applied.
-    this.getResource().whenWithinViewport(this.renderOutsideViewport()).then(
+    this.getResource().whenWithinViewport(renderOutsideViewport).then(
         () => this.isIdleRender_ = false);
     return vpRange;
   }
@@ -341,8 +357,14 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
           branches: Object.keys(DOUBLECLICK_SRA_EXP_BRANCHES).map(
               key => DOUBLECLICK_SRA_EXP_BRANCHES[key]),
         },
+        [DOUBLECLICK_IDLE_BOOL_EXP]: {
+          isTrafficEligible: () => true,
+          branches: Object.keys(DOUBLECLICK_IDLE_BOOL_EXP_BRANCHES).map(
+              key => DOUBLECLICK_IDLE_BOOL_EXP_BRANCHES[key]),
+        },
       });
     const setExps = this.randomlySelectUnsetExperiments_(experimentInfoMap);
+    console.log('setExps', setExps);
     Object.keys(setExps).forEach(expName =>
       setExps[expName] && this.experimentIds.push(setExps[expName]));
   }

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -1383,6 +1383,23 @@ describes.realWin('additional amp-ad-network-doubleclick-impl',
         it('should return 12 if no experiment header', () => {
           expect(impl.idleRenderOutsideViewport()).to.equal(12);
         });
+
+        it('should not return renderOutsideViewport boolean not set', () => {
+          sandbox.stub(impl, 'renderOutsideViewport').returns(false);
+          expect(impl.idleRenderOutsideViewport()).to.equal(12);
+        });
+
+        it('should not return renderOutsideViewport boolean ctrl', () => {
+          impl.experimentIds.push('21062567');
+          sandbox.stub(impl, 'renderOutsideViewport').returns(false);
+          expect(impl.idleRenderOutsideViewport()).to.equal(12);
+        });
+
+        it('should return renderOutsideViewport boolean, exp', () => {
+          impl.experimentIds.push('21062568');
+          sandbox.stub(impl, 'renderOutsideViewport').returns(false);
+          expect(impl.idleRenderOutsideViewport()).to.be.false;
+        });
       });
 
       describe('idle renderNonAmpCreative', () => {


### PR DESCRIPTION
dev().assert being violated due to call to whenWithinViewport(false) caused by interaction with render on idle and non-AMP creative throttle.  Fix in place guarded by experiment to verify effect.