### PR TITLE
Instantiate the amp-story element only once per test.

### DIFF
--- a/extensions/amp-story/1.0/test/test-amp-story.js
+++ b/extensions/amp-story/1.0/test/test-amp-story.js
@@ -108,11 +108,9 @@ describes.realWin('amp-story', {
 
     AmpStory.isBrowserSupported = () => true;
 
-    story = new AmpStory(element);
-    // TODO(alanorozco): Test active page event triggers once the stubbable
-    // `Services` module is part of the amphtml-story repo.
-    // sandbox.stub(element.implementation_,
-    // 'triggerActiveEventForPage_').callsFake(NOOP);
+    return element.getImpl().then(impl => {
+      story = impl;
+    });
   });
 
   afterEach(() => {
@@ -293,7 +291,6 @@ describes.realWin('amp-story', {
 
   it('lock body when amp-story is initialized', () => {
     createPages(story.element, 2, ['cover', 'page-1']);
-    story.buildCallback();
 
     return story.layoutCallback()
         .then(() => {
@@ -308,7 +305,6 @@ describes.realWin('amp-story', {
 
   it('builds and attaches pagination buttons ', () => {
     createPages(story.element, 2, ['cover', 'page-1']);
-    story.buildCallback();
 
     return story.layoutCallback()
         .then(() => {
@@ -372,7 +368,6 @@ describes.realWin('amp-story', {
     const pageCount = 2;
     createPages(story.element, pageCount, [firstPageId, 'page-1']);
 
-    story.buildCallback();
     return story.layoutCallback()
         .then(() => {
           return expect(replaceStateStub).to.have.been.calledWith(
@@ -390,7 +385,6 @@ describes.realWin('amp-story', {
     const firstPage = pages[0];
     firstPage.setAttribute('ad', '');
 
-    story.buildCallback();
     return story.layoutCallback()
         .then(() => {
           return expect(replaceStateStub).to.not.have.been.called;
@@ -401,7 +395,6 @@ describes.realWin('amp-story', {
     createPages(story.element, 2, ['cover', 'page-1']);
 
     story.storeService_.dispatch(Action.TOGGLE_PAUSED, true);
-    story.buildCallback();
 
     return story.layoutCallback()
         .then(() => {
@@ -430,8 +423,6 @@ describes.realWin('amp-story', {
       // consent prompt.
       const promise = new Promise(() => {});
       sandbox.stub(consent, 'getConsentPolicyState').returns(promise);
-
-      story.buildCallback();
 
       const coverEl = element.querySelector('amp-story-page');
       let setStateStub;
@@ -475,8 +466,6 @@ describes.realWin('amp-story', {
 
       sandbox.stub(consent, 'getConsentPolicyState').returns(promise);
 
-      story.buildCallback();
-
       const coverEl = element.querySelector('amp-story-page');
       let setStateStub;
 
@@ -517,8 +506,6 @@ describes.realWin('amp-story', {
       // Returns an already resolved promised: the user already accepted or
       // rejected the consent in a previous session.
       sandbox.stub(consent, 'getConsentPolicyState').resolves();
-
-      story.buildCallback();
 
       const coverEl = element.querySelector('amp-story-page');
       let setStateStub;
@@ -590,8 +577,6 @@ describes.realWin('amp-story', {
     it('should pause the story when viewer becomes inactive', () => {
       createPages(story.element, 2, ['cover', 'page-1']);
 
-      story.buildCallback();
-
       return story.layoutCallback()
           .then(() => {
             story.pauseCallback();
@@ -605,8 +590,6 @@ describes.realWin('amp-story', {
 
       story.storeService_.dispatch(Action.TOGGLE_PAUSED, true);
 
-      story.buildCallback();
-
       return story.layoutCallback()
           .then(() => {
             story.resumeCallback();
@@ -619,8 +602,6 @@ describes.realWin('amp-story', {
       createPages(story.element, 2, ['cover', 'page-1']);
 
       story.storeService_.dispatch(Action.TOGGLE_PAUSED, true);
-
-      story.buildCallback();
 
       return story.layoutCallback()
           .then(() => {
@@ -638,7 +619,6 @@ describes.realWin('amp-story', {
       story = new AmpStory(element);
       const dispatchStub = sandbox.stub(story.storeService_, 'dispatch');
       createPages(story.element, 2, ['cover', 'page-4']);
-      story.buildCallback();
       return story.layoutCallback()
           .then(() => {
             expect(dispatchStub).to.have.been.calledWith(
@@ -648,7 +628,6 @@ describes.realWin('amp-story', {
     });
 
     it('should display the story after clicking "continue" button', () => {
-
       AmpStory.isBrowserSupported = () => false;
       story = new AmpStory(element);
       const dispatchStub = sandbox.stub(
@@ -656,9 +635,6 @@ describes.realWin('amp-story', {
       createPages(story.element, 2, ['cover', 'page-1']);
 
       story.buildCallback();
-      //story.layoutCallback();
-
-      //story.unsupportedBrowserLayer_.continueButton_.click();
 
       return story.layoutCallback()
           .then(() => {
@@ -680,7 +656,6 @@ describes.realWin('amp-story', {
 
       const pages = createPages(story.element, 2, ['page-0', 'page-1']);
       const page1 = pages[1];
-      story.buildCallback();
       return story.layoutCallback()
           .then(() => {
             expect(page1.hasAttribute('i-amphtml-next-page')).to.be.true;
@@ -694,7 +669,6 @@ describes.realWin('amp-story', {
 
       const pages = createPages(story.element, 2, ['page-0', 'page-1']);
       const page0 = pages[0];
-      story.buildCallback();
       return story.layoutCallback()
           .then(() => story.switchTo_('page-1'))
           .then(() => {
@@ -709,7 +683,6 @@ describes.realWin('amp-story', {
 
       const pages = createPages(story.element, 2, ['page-0', 'page-1']);
       const page0 = pages[0];
-      story.buildCallback();
       return story.layoutCallback()
           .then(() => story.switchTo_('page-1'))
           .then(() => {
@@ -727,8 +700,6 @@ describes.realWin('amp-story', {
 
       createPages(story.element, 2, ['cover', 'page-1']);
 
-      story.buildCallback();
-
       return story.layoutCallback()
           .then(() => {
             expect(story.backgroundAudioEl_).to.exist;
@@ -743,7 +714,6 @@ describes.realWin('amp-story', {
           sandbox.stub(story.mediaPool_, 'blessAll').resolves();
 
       createPages(story.element, 2, ['cover', 'page-1']);
-      story.buildCallback();
 
       return story.layoutCallback()
           .then(() => {
@@ -758,7 +728,6 @@ describes.realWin('amp-story', {
       story.backgroundAudioEl_ = backgroundAudioEl;
 
       createPages(story.element, 2, ['cover', 'page-1']);
-      story.buildCallback();
       return story.layoutCallback()
           .then(() => {
             const pauseStub = sandbox.stub(story.mediaPool_, 'pause');
@@ -777,7 +746,6 @@ describes.realWin('amp-story', {
       story.backgroundAudioEl_ = backgroundAudioEl;
 
       createPages(story.element, 2, ['cover', 'page-1']);
-      story.buildCallback();
 
       return story.layoutCallback()
           .then(() => {
@@ -803,7 +771,6 @@ describes.realWin('amp-story', {
       story.backgroundAudioEl_ = backgroundAudioEl;
 
       createPages(story.element, 2, ['cover', 'page-1']);
-      story.buildCallback();
 
       return story.layoutCallback()
           .then(() => {
@@ -823,7 +790,6 @@ describes.realWin('amp-story', {
       createPages(story.element, 4, ['cover', 'page-1', 'page-2', 'page-3']);
 
       story.storeService_.dispatch(Action.TOGGLE_MUTED, false);
-      story.buildCallback();
 
       let coverMuteStub;
       let firstPageUnmuteStub;
@@ -846,7 +812,6 @@ describes.realWin('amp-story', {
   describe('#getMaxMediaElementCounts', () => {
     it('should create 2 audio & video elements when no elements found', () => {
       createPages(story.element, 2, ['cover', 'page-1']);
-      story.buildCallback();
 
       return story.layoutCallback()
           .then(() => {
@@ -862,7 +827,6 @@ describes.realWin('amp-story', {
 
     it('should create 2 extra audio & video elements for ads', () => {
       createPages(story.element, 2, ['cover', 'page-1']);
-      story.buildCallback();
 
       return story.layoutCallback()
           .then(() => {
@@ -880,7 +844,6 @@ describes.realWin('amp-story', {
 
     it('never have more than the defined maximums', () => {
       createPages(story.element, 2, ['cover', 'page-1']);
-      story.buildCallback();
 
       return story.layoutCallback()
           .then(() => {
@@ -903,8 +866,6 @@ describes.realWin('amp-story', {
     it('should set the access state to true if next page blocked', () => {
       createPages(story.element, 4, ['cover', 'page-1', 'page-2', 'page-3']);
 
-      story.buildCallback();
-
       return story.layoutCallback()
           .then(() => {
             story.getPageById('page-1')
@@ -919,8 +880,6 @@ describes.realWin('amp-story', {
 
     it('should not navigate if next page is blocked by paywall', () => {
       createPages(story.element, 4, ['cover', 'page-1', 'page-2', 'page-3']);
-
-      story.buildCallback();
 
       return story.layoutCallback()
           .then(() => {
@@ -943,8 +902,6 @@ describes.realWin('amp-story', {
       };
       sandbox.stub(Services, 'accessServiceForDocOrNull')
           .resolves(fakeAccessService);
-
-      story.buildCallback();
 
       // Navigates to a paywall protected page, and waits until the document
       // is successfuly reauthorized to navigate.
@@ -973,8 +930,6 @@ describes.realWin('amp-story', {
       };
       sandbox.stub(Services, 'accessServiceForDocOrNull')
           .resolves(fakeAccessService);
-
-      story.buildCallback();
 
       // Navigates to a paywall protected page, and waits until the document
       // is successfuly reauthorized to hide the access UI.
@@ -1006,8 +961,6 @@ describes.realWin('amp-story', {
       sandbox.stub(Services, 'accessServiceForDocOrNull')
           .resolves(fakeAccessService);
 
-      story.buildCallback();
-
       // Navigates to a paywall protected page, and does not navigate to that
       // page if the document has been reauthorized with insuficient rights.
       return story.layoutCallback()
@@ -1033,8 +986,6 @@ describes.realWin('amp-story', {
       };
       sandbox.stub(Services, 'accessServiceForDocOrNull')
           .resolves(fakeAccessService);
-
-      story.buildCallback();
 
       // Navigates to a paywall protected page, and does not hide the access UI
       // if the document has been reauthorized with insuficient rights.
@@ -1062,8 +1013,6 @@ describes.realWin('amp-story', {
       sandbox.stub(Services, 'accessServiceForDocOrNull')
           .resolves(fakeAccessService);
 
-      story.buildCallback();
-
       // Navigates to a maybe protected page (has amp-access="" rule), but the
       // document authorizations are still pending. Asserts that it blocks the
       // navigation.
@@ -1088,8 +1037,6 @@ describes.realWin('amp-story', {
       };
       sandbox.stub(Services, 'accessServiceForDocOrNull')
           .resolves(fakeAccessService);
-
-      story.buildCallback();
 
       // Navigation to a maybe protected page (has amp-access="" rule) is
       // blocked until the authorizations are completed.


### PR DESCRIPTION
In the `beforeEach` statement of `test-amp-story`, we were doing:
````
element = win.document.createElement('amp-story'); // Creates an AmpStory instance
story = new AmpStory(element); // Also creates an AmpStory instance
````

Having two instances of AmpStory was bringing different side effects:
- the second AmpStory `buildCallback` wasn't called by the runtime, which is why this PR is removing the `buildCallback` that were manually added
- listeners would get triggered twice

This PR ensures we only instantiate AmpStory once.