### PR TITLE
Remove unneeded check on resize validation

### DIFF
--- a/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
@@ -591,9 +591,7 @@ export class SafeframeHostApi {
           (payload['resize_r'] + payload['resize_l']);
 
     // Make sure we are actually resizing here.
-    if (isNaN(resizeWidth) || isNaN(resizeHeight) ||
-        resizeWidth > this.creativeSize_.width ||
-        resizeHeight > this.creativeSize_.height) {
+    if (isNaN(resizeWidth) || isNaN(resizeHeight)) {
       dev().error(TAG, 'Invalid resize values.');
       return;
     }


### PR DESCRIPTION
Doubleclick resize attempts were checking to make sure that you could not expand outside the bounds of the current slot size. This check is no longer needed. Reflow is still prevented downstream, this check was just causing errors to fire like crazy 