### PR TITLE
🐛 Fix path in custom eslint rule import

### DIFF
--- a/build-system/eslint-rules/no-global.js
+++ b/build-system/eslint-rules/no-global.js
@@ -15,7 +15,7 @@
  */
 'use strict';
 
-const astUtils = require('eslint/lib/ast-utils');
+const astUtils = require('eslint/lib/util/ast-utils');
 
 const GLOBALS = Object.create(null);
 GLOBALS.window = 'Use `self` instead.';


### PR DESCRIPTION
Follow up to #18144

Likely happened because a conflicting change was checked in after the PR was tested, but before it was merged
